### PR TITLE
build(ui): pin Svelte 5 version floors and enable runes explicitly

### DIFF
--- a/ui/package.json
+++ b/ui/package.json
@@ -12,10 +12,10 @@
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch"
   },
   "dependencies": {
-    "@sveltejs/adapter-node": "^5.2.0",
-    "@sveltejs/kit": "^2.21.0",
-    "@sveltejs/vite-plugin-svelte": "^5.0.0",
-    "svelte": "^5.0.0",
+    "@sveltejs/adapter-node": "^5.5.0",
+    "@sveltejs/kit": "^2.55.0",
+    "@sveltejs/vite-plugin-svelte": "^5.1.0",
+    "svelte": "^5.55.0",
     "vite": "^6.0.0"
   },
   "devDependencies": {

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -9,16 +9,16 @@ importers:
   .:
     dependencies:
       '@sveltejs/adapter-node':
-        specifier: ^5.2.0
+        specifier: ^5.5.0
         version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1))
       '@sveltejs/kit':
-        specifier: ^2.21.0
+        specifier: ^2.55.0
         version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1)
       '@sveltejs/vite-plugin-svelte':
-        specifier: ^5.0.0
+        specifier: ^5.1.0
         version: 5.1.1(svelte@5.55.1)(vite@6.4.1)
       svelte:
-        specifier: ^5.0.0
+        specifier: ^5.55.0
         version: 5.55.1
       vite:
         specifier: ^6.0.0

--- a/ui/svelte.config.js
+++ b/ui/svelte.config.js
@@ -3,6 +3,9 @@ import { vitePreprocess } from '@sveltejs/vite-plugin-svelte';
 
 /** @type {import('@sveltejs/kit').Config} */
 const config = {
+	compilerOptions: {
+		runes: true
+	},
 	preprocess: vitePreprocess(),
 	kit: {
 		adapter: adapter()


### PR DESCRIPTION
## Summary
- Tighten Svelte/SvelteKit dependency ranges in `ui/package.json` to match actually-resolved lockfile versions (`svelte ^5.55.0`, `@sveltejs/kit ^2.55.0`, etc.)
- Add `compilerOptions: { runes: true }` to `ui/svelte.config.js` to make Svelte 5 runes-mode self-documenting

## Test plan
- [x] `pnpm install` — lockfile unchanged (all current versions satisfy new ranges)
- [x] `pnpm run check` — 0 errors, 0 warnings
- [x] `pnpm run build` — succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)