### PR TITLE
ci: add GitHub Actions pipelines and Railway deploy workflows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,163 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+concurrency:
+  group: ci-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  lint:
+    name: Lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+          cache-dependency-path: |
+            core/go.mod
+            sdk/go/go.mod
+            test/integration/go.mod
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: latest
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
+
+      - name: Install UI dependencies
+        working-directory: ui
+        run: pnpm install --frozen-lockfile
+
+      - name: Go vet
+        run: go vet ./core/... ./sdk/go/...
+
+      - name: Svelte check
+        working-directory: ui
+        run: pnpm check
+
+  test:
+    name: Unit Tests
+    needs: lint
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+          cache-dependency-path: |
+            core/go.mod
+            sdk/go/go.mod
+            test/integration/go.mod
+
+      - name: Run Go tests
+        run: go test -race -coverprofile=coverage.out ./core/... ./sdk/go/...
+
+      - name: Upload coverage
+        if: always()
+        uses: actions/upload-artifact@v6
+        with:
+          name: coverage
+          path: coverage.out
+
+  build:
+    name: Build Docker Images
+    needs: test
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Build server image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: core/server/Dockerfile
+          push: false
+          load: true
+          tags: aileron-server:${{ github.sha }}
+          cache-from: type=gha,scope=server
+          cache-to: type=gha,mode=max,scope=server
+
+      - name: Build UI image
+        uses: docker/build-push-action@v7
+        with:
+          context: ./ui
+          file: ui/Dockerfile
+          push: false
+          load: true
+          tags: aileron-ui:${{ github.sha }}
+          cache-from: type=gha,scope=ui
+          cache-to: type=gha,mode=max,scope=ui
+
+  integration:
+    name: Integration Tests
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Start full stack
+        run: docker compose -f deploy/docker-compose.yml up -d --build --wait
+        timeout-minutes: 5
+
+      - name: Wait for healthy server
+        run: |
+          for i in $(seq 1 30); do
+            if curl -sf http://localhost:8080/v1/health; then
+              echo ""
+              echo "Server healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Server did not become healthy"
+          docker compose -f deploy/docker-compose.yml logs
+          exit 1
+
+      - name: Wait for healthy UI
+        run: |
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:3000; then
+              echo "UI healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "UI did not become healthy"
+          exit 1
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.24"
+          cache-dependency-path: |
+            core/go.mod
+            sdk/go/go.mod
+            test/integration/go.mod
+
+      - name: Run integration tests
+        run: go test -tags=integration -race ./test/integration/...
+        env:
+          AILERON_API_URL: http://localhost:8080
+          AILERON_UI_URL: http://localhost:3000
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose -f deploy/docker-compose.yml logs
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f deploy/docker-compose.yml down -v

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -86,6 +86,24 @@ tasks:
     cmds:
       - go test ./core/... ./sdk/go/...
 
+  test:integration:
+    desc: Run integration tests against running services
+    cmds:
+      - go test -tags=integration -race ./test/integration/...
+    env:
+      AILERON_API_URL: http://localhost:8080
+      AILERON_UI_URL: http://localhost:3000
+
+  ci:
+    desc: Run the full CI pipeline locally
+    cmds:
+      - task: lint
+      - task: test
+      - task: build
+      - task: up -- -d --build --wait
+      - task: test:integration
+      - task: down
+
   health:
     desc: Check the server health endpoint
     cmds:

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -6,6 +6,7 @@ WORKDIR /src
 COPY go.work go.work.sum* ./
 COPY core/go.mod core/go.sum* ./core/
 COPY sdk/go/go.mod sdk/go/go.sum* ./sdk/go/
+COPY test/integration/go.mod ./test/integration/
 
 RUN go work sync
 

--- a/go.work
+++ b/go.work
@@ -3,4 +3,5 @@ go 1.24
 use (
 	./core
 	./sdk/go
+	./test/integration
 )

--- a/test/integration/go.mod
+++ b/test/integration/go.mod
@@ -1,0 +1,3 @@
+module github.com/ALRubinger/aileron/test/integration
+
+go 1.24

--- a/test/integration/health_test.go
+++ b/test/integration/health_test.go
@@ -1,0 +1,27 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"os"
+	"testing"
+)
+
+func apiURL() string {
+	if u := os.Getenv("AILERON_API_URL"); u != "" {
+		return u
+	}
+	return "http://localhost:8080"
+}
+
+func TestHealthEndpoint(t *testing.T) {
+	resp, err := http.Get(apiURL() + "/v1/health")
+	if err != nil {
+		t.Fatalf("health request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

- Add CI pipeline (`.github/workflows/ci.yml`) with lint, unit test, Docker build, and integration test stages
- Add integration test scaffold (`test/integration/`) with health endpoint test
- Add `test:integration` and `ci` tasks to Taskfile
- Railway native GitHub integration handles production deploys and PR preview environments (no deploy workflows needed)

## Test plan

- [x] CI workflow triggers on PR and all 4 jobs pass (lint, test, build, integration)
- [x] Railway production environment deploys from `main`
- [x] Server and UI accessible on Railway
- [ ] PR preview environments created for future PRs after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)