### PR TITLE
ci: parallelize lint and test jobs in CI pipeline

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -70,7 +70,7 @@ jobs:
 
   test:
     name: Unit Tests
-    needs: lint
+    needs: generate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -95,7 +95,7 @@ jobs:
 
   build:
     name: Build Docker Images
-    needs: test
+    needs: [generate, lint, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary
- Run **Lint** and **Unit Tests** in parallel after **Verify Generated Code** passes, instead of sequentially
- **Build Docker Images** now waits for all three prerequisite jobs before starting

```
              ┌→ lint ──┐
generate ─────┤         ├→ build → integration
              └→ test ──┘
```

## Test plan
- [x] Verify CI pipeline runs lint and test in parallel (check Actions graph)
- [x] Verify build job waits for all three prerequisites
- [x] Confirm pipeline still fails fast if codegen is stale

🤖 Generated with [Claude Code](https://claude.com/claude-code)