### PR TITLE
refactor(ui): migrate to Tailwind CSS + shadcn-svelte

### DIFF
--- a/ui/components.json
+++ b/ui/components.json
@@ -1,0 +1,16 @@
+{
+	"$schema": "https://shadcn-svelte.com/schema.json",
+	"tailwind": {
+		"css": "src/app.css",
+		"baseColor": "neutral"
+	},
+	"aliases": {
+		"components": "$lib/components",
+		"utils": "$lib/utils",
+		"ui": "$lib/components/ui",
+		"hooks": "$lib/hooks",
+		"lib": "$lib"
+	},
+	"typescript": true,
+	"registry": "https://shadcn-svelte.com/registry"
+}

--- a/ui/package.json
+++ b/ui/package.json
@@ -15,11 +15,20 @@
     "@sveltejs/adapter-node": "^5.5.0",
     "@sveltejs/kit": "^2.55.0",
     "@sveltejs/vite-plugin-svelte": "^5.1.0",
+    "bits-ui": "^2.16.5",
+    "clsx": "^2.1.1",
     "svelte": "^5.55.0",
+    "tailwind-merge": "^3.5.0",
+    "tailwind-variants": "^3.2.2",
+    "tw-animate-css": "^1.4.0",
     "vite": "^6.0.0"
   },
   "devDependencies": {
+    "@internationalized/date": "^3.12.0",
+    "@lucide/svelte": "^1.7.0",
+    "@tailwindcss/vite": "^4.2.2",
     "svelte-check": "^4.0.0",
+    "tailwindcss": "^4.2.2",
     "typescript": "^5.0.0"
   }
 }

--- a/ui/pnpm-lock.yaml
+++ b/ui/pnpm-lock.yaml
@@ -10,23 +10,50 @@ importers:
     dependencies:
       '@sveltejs/adapter-node':
         specifier: ^5.5.0
-        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1))
+        version: 5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))
       '@sveltejs/kit':
         specifier: ^2.55.0
-        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1)
+        version: 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
       '@sveltejs/vite-plugin-svelte':
         specifier: ^5.1.0
-        version: 5.1.1(svelte@5.55.1)(vite@6.4.1)
+        version: 5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
+      bits-ui:
+        specifier: ^2.16.5
+        version: 2.16.5(@internationalized/date@3.12.0)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)
+      clsx:
+        specifier: ^2.1.1
+        version: 2.1.1
       svelte:
         specifier: ^5.55.0
         version: 5.55.1
+      tailwind-merge:
+        specifier: ^3.5.0
+        version: 3.5.0
+      tailwind-variants:
+        specifier: ^3.2.2
+        version: 3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.2)
+      tw-animate-css:
+        specifier: ^1.4.0
+        version: 1.4.0
       vite:
         specifier: ^6.0.0
-        version: 6.4.1
+        version: 6.4.1(jiti@2.6.1)(lightningcss@1.32.0)
     devDependencies:
+      '@internationalized/date':
+        specifier: ^3.12.0
+        version: 3.12.0
+      '@lucide/svelte':
+        specifier: ^1.7.0
+        version: 1.7.0(svelte@5.55.1)
+      '@tailwindcss/vite':
+        specifier: ^4.2.2
+        version: 4.2.2(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
       svelte-check:
         specifier: ^4.0.0
         version: 4.4.5(picomatch@4.0.4)(svelte@5.55.1)(typescript@5.9.3)
+      tailwindcss:
+        specifier: ^4.2.2
+        version: 4.2.2
       typescript:
         specifier: ^5.0.0
         version: 5.9.3
@@ -189,6 +216,18 @@ packages:
     cpu: [x64]
     os: [win32]
 
+  '@floating-ui/core@1.7.5':
+    resolution: {integrity: sha512-1Ih4WTWyw0+lKyFMcBHGbb5U5FtuHJuujoyyr5zTaWS5EYMeT6Jb2AuDeftsCsEuchO+mM2ij5+q9crhydzLhQ==}
+
+  '@floating-ui/dom@1.7.6':
+    resolution: {integrity: sha512-9gZSAI5XM36880PPMm//9dfiEngYoC6Am2izES1FF406YFsjvyBMmeJ2g4SAju3xWwtuynNRFL2s9hgxpLI5SQ==}
+
+  '@floating-ui/utils@0.2.11':
+    resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
+
+  '@internationalized/date@3.12.0':
+    resolution: {integrity: sha512-/PyIMzK29jtXaGU23qTvNZxvBXRtKbNnGDFD+PY6CZw/Y8Ex8pFUzkuCJCG9aOqmShjqhS9mPqP6Dk5onQY8rQ==}
+
   '@jridgewell/gen-mapping@0.3.13':
     resolution: {integrity: sha512-2kkt/7niJ6MgEPxF0bYdQ6etZaA+fQvDcLKckhy1yIQOzaoKjBBjSj63/aLVjYE3qhRt5dvM+uUyfCg6UKCBbA==}
 
@@ -204,6 +243,11 @@ packages:
 
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
+
+  '@lucide/svelte@1.7.0':
+    resolution: {integrity: sha512-YytBKOUBGox7yWcykZnYxOkn5WpR5G1qYXLYXV/j1B79SOTTEKzB+s5yF5Rq9l9OkweDStNH2b4yTqfvhEhV8g==}
+    peerDependencies:
+      svelte: ^5
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -426,6 +470,103 @@ packages:
       svelte: ^5.0.0
       vite: ^6.0.0
 
+  '@swc/helpers@0.5.20':
+    resolution: {integrity: sha512-2egEBHUMasdypIzrprsu8g+OEVd7Vp2MM3a2eVlM/cyFYto0nGz5BX5BTgh/ShZZI9ed+ozEq+Ngt+rgmUs8tw==}
+
+  '@tailwindcss/node@4.2.2':
+    resolution: {integrity: sha512-pXS+wJ2gZpVXqFaUEjojq7jzMpTGf8rU6ipJz5ovJV6PUGmlJ+jvIwGrzdHdQ80Sg+wmQxUFuoW1UAAwHNEdFA==}
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    resolution: {integrity: sha512-dXGR1n+P3B6748jZO/SvHZq7qBOqqzQ+yFrXpoOWWALWndF9MoSKAT3Q0fYgAzYzGhxNYOoysRvYlpixRBBoDg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [android]
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    resolution: {integrity: sha512-iq9Qjr6knfMpZHj55/37ouZeykwbDqF21gPFtfnhCCKGDcPI/21FKC9XdMO/XyBM7qKORx6UIhGgg6jLl7BZlg==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    resolution: {integrity: sha512-BlR+2c3nzc8f2G639LpL89YY4bdcIdUmiOOkv2GQv4/4M0vJlpXEa0JXNHhCHU7VWOKWT/CjqHdTP8aUuDJkuw==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [darwin]
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    resolution: {integrity: sha512-YUqUgrGMSu2CDO82hzlQ5qSb5xmx3RUrke/QgnoEx7KvmRJHQuZHZmZTLSuuHwFf0DJPybFMXMYf+WJdxHy/nQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    resolution: {integrity: sha512-FPdhvsW6g06T9BWT0qTwiVZYE2WIFo2dY5aCSpjG/S/u1tby+wXoslXS0kl3/KXnULlLr1E3NPRRw0g7t2kgaQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm]
+    os: [linux]
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    resolution: {integrity: sha512-4og1V+ftEPXGttOO7eCmW7VICmzzJWgMx+QXAJRAhjrSjumCwWqMfkDrNu1LXEQzNAwz28NCUpucgQPrR4S2yw==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    resolution: {integrity: sha512-oCfG/mS+/+XRlwNjnsNLVwnMWYH7tn/kYPsNPh+JSOMlnt93mYNCKHYzylRhI51X+TbR+ufNhhKKzm6QkqX8ag==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    resolution: {integrity: sha512-rTAGAkDgqbXHNp/xW0iugLVmX62wOp2PoE39BTCGKjv3Iocf6AFbRP/wZT/kuCxC9QBh9Pu8XPkv/zCZB2mcMg==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    resolution: {integrity: sha512-XW3t3qwbIwiSyRCggeO2zxe3KWaEbM0/kW9e8+0XpBgyKU4ATYzcVSMKteZJ1iukJ3HgHBjbg9P5YPRCVUxlnQ==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    resolution: {integrity: sha512-eKSztKsmEsn1O5lJ4ZAfyn41NfG7vzCg496YiGtMDV86jz1q/irhms5O0VrY6ZwTUkFy/EKG3RfWgxSI3VbZ8Q==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+    bundledDependencies:
+      - '@napi-rs/wasm-runtime'
+      - '@emnapi/core'
+      - '@emnapi/runtime'
+      - '@tybys/wasm-util'
+      - '@emnapi/wasi-threads'
+      - tslib
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    resolution: {integrity: sha512-qPmaQM4iKu5mxpsrWZMOZRgZv1tOZpUm+zdhhQP0VhJfyGGO3aUKdbh3gDZc/dPLQwW4eSqWGrrcWNBZWUWaXQ==}
+    engines: {node: '>= 20'}
+    cpu: [arm64]
+    os: [win32]
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    resolution: {integrity: sha512-1T/37VvI7WyH66b+vqHj/cLwnCxt7Qt3WFu5Q8hk65aOvlwAhs7rAp1VkulBJw/N4tMirXjVnylTR72uI0HGcA==}
+    engines: {node: '>= 20'}
+    cpu: [x64]
+    os: [win32]
+
+  '@tailwindcss/oxide@4.2.2':
+    resolution: {integrity: sha512-qEUA07+E5kehxYp9BVMpq9E8vnJuBHfJEC0vPC5e7iL/hw7HR61aDKoVoKzrG+QKp56vhNZe4qwkRmMC0zDLvg==}
+    engines: {node: '>= 20'}
+
+  '@tailwindcss/vite@4.2.2':
+    resolution: {integrity: sha512-mEiF5HO1QqCLXoNEfXVA1Tzo+cYsrqV7w9Juj2wdUFyW07JRenqMG225MvPwr3ZD9N1bFQj46X7r33iHxLUW0w==}
+    peerDependencies:
+      vite: ^5.2.0 || ^6 || ^7 || ^8
+
   '@types/cookie@0.6.0':
     resolution: {integrity: sha512-4Kh9a6B2bQciAhf7FSuMRRkUWecJgJu9nPnx3yzpsfXX/c50REIqpHY4C82bXP90qrLtXtkDxTZosYO3UpOwlA==}
 
@@ -455,6 +596,13 @@ packages:
     resolution: {integrity: sha512-qIj0G9wZbMGNLjLmg1PT6v2mE9AH2zlnADJD/2tC6E00hgmhUOfEB6greHPAfLRSufHqROIUTkw6E+M3lH0PTQ==}
     engines: {node: '>= 0.4'}
 
+  bits-ui@2.16.5:
+    resolution: {integrity: sha512-Dx+Sc1DGzRaRfzpxrBI40d+O7vykIZ8E2G6tCaOzqYLzg+mN3YYK+8f8ysAFLfkHzey1MACGrYO3IcO6ROKlSA==}
+    engines: {node: '>=20'}
+    peerDependencies:
+      '@internationalized/date': ^3.8.1
+      svelte: ^5.33.0
+
   chokidar@4.0.3:
     resolution: {integrity: sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==}
     engines: {node: '>= 14.16.0'}
@@ -483,8 +631,20 @@ packages:
     resolution: {integrity: sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A==}
     engines: {node: '>=0.10.0'}
 
+  dequal@2.0.3:
+    resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
+    engines: {node: '>=6'}
+
+  detect-libc@2.1.2:
+    resolution: {integrity: sha512-Btj2BOOO83o3WyH59e8MgXsxEQVcarkUOpEYrubB0urwnN10yQ364rsiByU11nZlqWYZm05i/of7io4mzihBtQ==}
+    engines: {node: '>=8'}
+
   devalue@5.6.4:
     resolution: {integrity: sha512-Gp6rDldRsFh/7XuouDbxMH3Mx8GMCcgzIb1pDTvNyn8pZGQ22u+Wa+lGV9dQCltFQ7uVw0MhRyb8XDskNFOReA==}
+
+  enhanced-resolve@5.20.1:
+    resolution: {integrity: sha512-Qohcme7V1inbAfvjItgw0EaxVX5q2rdVEZHRBrEQdRZTssLDGsL8Lwrznl8oQ/6kuTJONLaDcGjkNP247XEhcA==}
+    engines: {node: '>=10.13.0'}
 
   esbuild@0.25.12:
     resolution: {integrity: sha512-bbPBYYrtZbkt6Os6FiTLCTFxvq4tt3JKall1vRwshA3fdVztsLAatFaZobhkBC8/BrPetoa0oksYoKXoG4ryJg==}
@@ -517,9 +677,15 @@ packages:
   function-bind@1.1.2:
     resolution: {integrity: sha512-7XHNxH7qX9xG5mIwxkhumTox/MIRNcOgDrxWsMt2pAr23WHp6MrRlN7FBSFpCpr+oVO0F744iUgR82nJMfG2SA==}
 
+  graceful-fs@4.2.11:
+    resolution: {integrity: sha512-RbJ5/jmFcNNCcDV5o9eTnBLJ/HszWV0P73bc+Ff4nS/rJj+YaS6IGyiOL0VoBYX+l1Wrl3k63h/KrH+nhJ0XvQ==}
+
   hasown@2.0.2:
     resolution: {integrity: sha512-0hJU9SCPvmMzIBdZFqNPXWa6dqh7WdH0cII9y+CyS8rG3nL48Bclra9HmKhVVUHyPWNH5Y7xDwAB7bfgSjkUMQ==}
     engines: {node: '>= 0.4'}
+
+  inline-style-parser@0.2.7:
+    resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
 
   is-core-module@2.16.1:
     resolution: {integrity: sha512-UfoeMA6fIJ8wTYFEUjelnaGI67v6+N7qXJEvQuIGa99l4xsCruSYOVSQ0uPANn4dAzm8lkYPaKLrrijLq7x23w==}
@@ -534,12 +700,94 @@ packages:
   is-reference@3.0.3:
     resolution: {integrity: sha512-ixkJoqQvAP88E6wLydLGGqCJsrFUnqoH6HnaczB8XmDH1oaWU+xxdptvikTgaEhtZ53Ky6YXiBuUI2WXLMCwjw==}
 
+  jiti@2.6.1:
+    resolution: {integrity: sha512-ekilCSN1jwRvIbgeg/57YFh8qQDNbwDb9xT/qu2DAHbFFZUicIl4ygVaAvzveMhMVr3LnpSKTNnwt8PoOfmKhQ==}
+    hasBin: true
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
 
+  lightningcss-android-arm64@1.32.0:
+    resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [android]
+
+  lightningcss-darwin-arm64@1.32.0:
+    resolution: {integrity: sha512-RzeG9Ju5bag2Bv1/lwlVJvBE3q6TtXskdZLLCyfg5pt+HLz9BqlICO7LZM7VHNTTn/5PRhHFBSjk5lc4cmscPQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [darwin]
+
+  lightningcss-darwin-x64@1.32.0:
+    resolution: {integrity: sha512-U+QsBp2m/s2wqpUYT/6wnlagdZbtZdndSmut/NJqlCcMLTWp5muCrID+K5UJ6jqD2BFshejCYXniPDbNh73V8w==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [darwin]
+
+  lightningcss-freebsd-x64@1.32.0:
+    resolution: {integrity: sha512-JCTigedEksZk3tHTTthnMdVfGf61Fky8Ji2E4YjUTEQX14xiy/lTzXnu1vwiZe3bYe0q+SpsSH/CTeDXK6WHig==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [freebsd]
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    resolution: {integrity: sha512-x6rnnpRa2GL0zQOkt6rts3YDPzduLpWvwAF6EMhXFVZXD4tPrBkEFqzGowzCsIWsPjqSK+tyNEODUBXeeVHSkw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm]
+    os: [linux]
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    resolution: {integrity: sha512-0nnMyoyOLRJXfbMOilaSRcLH3Jw5z9HDNGfT/gwCPgaDjnx0i8w7vBzFLFR1f6CMLKF8gVbebmkUN3fa/kQJpQ==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    resolution: {integrity: sha512-UpQkoenr4UJEzgVIYpI80lDFvRmPVg6oqboNHfoH4CQIfNA+HOrZ7Mo7KZP02dC6LjghPQJeBsvXhJod/wnIBg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    resolution: {integrity: sha512-V7Qr52IhZmdKPVr+Vtw8o+WLsQJYCTd8loIfpDaMRWGUZfBOYEJeyJIkqGIDMZPwPx24pUMfwSxxI8phr/MbOA==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [glibc]
+
+  lightningcss-linux-x64-musl@1.32.0:
+    resolution: {integrity: sha512-bYcLp+Vb0awsiXg/80uCRezCYHNg1/l3mt0gzHnWV9XP1W5sKa5/TCdGWaR/zBM2PeF/HbsQv/j2URNOiVuxWg==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [linux]
+    libc: [musl]
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    resolution: {integrity: sha512-8SbC8BR40pS6baCM8sbtYDSwEVQd4JlFTOlaD3gWGHfThTcABnNDBda6eTZeqbofalIJhFx0qKzgHJmcPTnGdw==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [arm64]
+    os: [win32]
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    resolution: {integrity: sha512-Amq9B/SoZYdDi1kFrojnoqPLxYhQ4Wo5XiL8EVJrVsB8ARoC1PWW6VGtT0WKCemjy8aC+louJnjS7U18x3b06Q==}
+    engines: {node: '>= 12.0.0'}
+    cpu: [x64]
+    os: [win32]
+
+  lightningcss@1.32.0:
+    resolution: {integrity: sha512-NXYBzinNrblfraPGyrbPoD19C1h9lfI/1mzgWYvXUTe414Gz/X1FD2XBZSZM7rRTrMA8JL3OtAaGifrIKhQ5yQ==}
+    engines: {node: '>= 12.0.0'}
+
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
+
+  lz-string@1.5.0:
+    resolution: {integrity: sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==}
+    hasBin: true
 
   magic-string@0.30.21:
     resolution: {integrity: sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ==}
@@ -588,6 +836,15 @@ packages:
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
 
+  runed@0.35.1:
+    resolution: {integrity: sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==}
+    peerDependencies:
+      '@sveltejs/kit': ^2.21.0
+      svelte: ^5.7.0
+    peerDependenciesMeta:
+      '@sveltejs/kit':
+        optional: true
+
   sade@1.8.1:
     resolution: {integrity: sha512-xal3CZX1Xlo/k4ApwCFrHVACi9fBqJ7V+mwhBsuf/1IOKbBy098Fex+Wa/5QMubw09pSZ/u8EY8PWgevJsXp1A==}
     engines: {node: '>=6'}
@@ -603,6 +860,9 @@ packages:
     resolution: {integrity: sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA==}
     engines: {node: '>=0.10.0'}
 
+  style-to-object@1.0.14:
+    resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
   supports-preserve-symlinks-flag@1.0.0:
     resolution: {integrity: sha512-ot0WnXS9fgdkgIcePe6RHNk1WA8+muPa6cSjeR3V8K27q9BB1rTE3R1p7Hv0z1ZyAc8s6Vvv8DIyWf681MAt0w==}
     engines: {node: '>= 0.4'}
@@ -615,9 +875,38 @@ packages:
       svelte: ^4.0.0 || ^5.0.0-next.0
       typescript: '>=5.0.0'
 
+  svelte-toolbelt@0.10.6:
+    resolution: {integrity: sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==}
+    engines: {node: '>=18', pnpm: '>=8.7.0'}
+    peerDependencies:
+      svelte: ^5.30.2
+
   svelte@5.55.1:
     resolution: {integrity: sha512-QjvU7EFemf6mRzdMGlAFttMWtAAVXrax61SZYHdkD6yoVGQ89VeyKfZD4H1JrV1WLmJBxWhFch9H6ig/87VGjw==}
     engines: {node: '>=18'}
+
+  tabbable@6.4.0:
+    resolution: {integrity: sha512-05PUHKSNE8ou2dwIxTngl4EzcnsCDZGJ/iCLtDflR/SHB/ny14rXc+qU5P4mG9JkusiV7EivzY9Mhm55AzAvCg==}
+
+  tailwind-merge@3.5.0:
+    resolution: {integrity: sha512-I8K9wewnVDkL1NTGoqWmVEIlUcB9gFriAEkXkfCjX5ib8ezGxtR3xD7iZIxrfArjEsH7F1CHD4RFUtxefdqV/A==}
+
+  tailwind-variants@3.2.2:
+    resolution: {integrity: sha512-Mi4kHeMTLvKlM98XPnK+7HoBPmf4gygdFmqQPaDivc3DpYS6aIY6KiG/PgThrGvii5YZJqRsPz0aPyhoFzmZgg==}
+    engines: {node: '>=16.x', pnpm: '>=7.x'}
+    peerDependencies:
+      tailwind-merge: '>=3.0.0'
+      tailwindcss: '*'
+    peerDependenciesMeta:
+      tailwind-merge:
+        optional: true
+
+  tailwindcss@4.2.2:
+    resolution: {integrity: sha512-KWBIxs1Xb6NoLdMVqhbhgwZf2PGBpPEiwOqgI4pFIYbNTfBXiKYyWoTsXgBQ9WFg/OlhnvHaY+AEpW7wSmFo2Q==}
+
+  tapable@2.3.2:
+    resolution: {integrity: sha512-1MOpMXuhGzGL5TTCZFItxCc0AARf1EZFQkGqMm7ERKj8+Hgr5oLvJOVFcC+lRmR8hCe2S3jC4T5D7Vg/d7/fhA==}
+    engines: {node: '>=6'}
 
   tinyglobby@0.2.15:
     resolution: {integrity: sha512-j2Zq4NyQYG5XMST4cbs02Ak8iJUdxRM0XI5QyxXuZOzKOINmWurp3smXu3y5wDcJrptwpSjgXHzIQxR0omXljQ==}
@@ -626,6 +915,12 @@ packages:
   totalist@3.0.1:
     resolution: {integrity: sha512-sf4i37nQ2LBx4m3wB74y+ubopq6W/dIzXg0FDGjsYnZHVa1Da8FH853wlL2gtUhg+xJXjfk3kUZS3BRoQeoQBQ==}
     engines: {node: '>=6'}
+
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
+  tw-animate-css@1.4.0:
+    resolution: {integrity: sha512-7bziOlRqH0hJx80h/3mbicLW7o8qLsH5+RaLR2t+OHM3D0JlWGODQKQ4cxbK7WlvmUxpcj6Kgu6EKqjrGFe3QQ==}
 
   typescript@5.9.3:
     resolution: {integrity: sha512-jl1vZzPDinLr9eUt3J/t7V6FgNEw9QjvBPdysz9KfQDD41fQrC2Y4vKQdiaUpFT4bXlb1RHhLpp8wtm6M5TgSw==}
@@ -763,6 +1058,21 @@ snapshots:
   '@esbuild/win32-x64@0.25.12':
     optional: true
 
+  '@floating-ui/core@1.7.5':
+    dependencies:
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/dom@1.7.6':
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/utils': 0.2.11
+
+  '@floating-ui/utils@0.2.11': {}
+
+  '@internationalized/date@3.12.0':
+    dependencies:
+      '@swc/helpers': 0.5.20
+
   '@jridgewell/gen-mapping@0.3.13':
     dependencies:
       '@jridgewell/sourcemap-codec': 1.5.5
@@ -781,6 +1091,10 @@ snapshots:
     dependencies:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
+
+  '@lucide/svelte@1.7.0(svelte@5.55.1)':
+    dependencies:
+      svelte: 5.55.1
 
   '@polka/url@1.0.0-next.29': {}
 
@@ -901,19 +1215,19 @@ snapshots:
     dependencies:
       acorn: 8.16.0
 
-  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1))':
+  '@sveltejs/adapter-node@5.5.4(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))':
     dependencies:
       '@rollup/plugin-commonjs': 29.0.2(rollup@4.60.1)
       '@rollup/plugin-json': 6.1.0(rollup@4.60.1)
       '@rollup/plugin-node-resolve': 16.0.3(rollup@4.60.1)
-      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1)
+      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
       rollup: 4.60.1
 
-  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1)':
+  '@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
       '@standard-schema/spec': 1.1.0
       '@sveltejs/acorn-typescript': 1.0.9(acorn@8.16.0)
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.1)(vite@6.4.1)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
       '@types/cookie': 0.6.0
       acorn: 8.16.0
       cookie: 0.6.0
@@ -925,31 +1239,103 @@ snapshots:
       set-cookie-parser: 3.1.0
       sirv: 3.0.2
       svelte: 5.55.1
-      vite: 6.4.1
+      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.32.0)
     optionalDependencies:
       typescript: 5.9.3
 
-  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(vite@6.4.1)':
+  '@sveltejs/vite-plugin-svelte-inspector@4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.1)(vite@6.4.1)
+      '@sveltejs/vite-plugin-svelte': 5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
       debug: 4.4.3
       svelte: 5.55.1
-      vite: 6.4.1
+      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.32.0)
     transitivePeerDependencies:
       - supports-color
 
-  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1)':
+  '@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))':
     dependencies:
-      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1))(svelte@5.55.1)(vite@6.4.1)
+      '@sveltejs/vite-plugin-svelte-inspector': 4.0.1(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
       debug: 4.4.3
       deepmerge: 4.3.1
       kleur: 4.1.5
       magic-string: 0.30.21
       svelte: 5.55.1
-      vite: 6.4.1
-      vitefu: 1.1.2(vite@6.4.1)
+      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.32.0)
+      vitefu: 1.1.2(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
     transitivePeerDependencies:
       - supports-color
+
+  '@swc/helpers@0.5.20':
+    dependencies:
+      tslib: 2.8.1
+
+  '@tailwindcss/node@4.2.2':
+    dependencies:
+      '@jridgewell/remapping': 2.3.5
+      enhanced-resolve: 5.20.1
+      jiti: 2.6.1
+      lightningcss: 1.32.0
+      magic-string: 0.30.21
+      source-map-js: 1.2.1
+      tailwindcss: 4.2.2
+
+  '@tailwindcss/oxide-android-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-arm64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-darwin-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-freebsd-x64@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm-gnueabihf@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-arm64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-gnu@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-linux-x64-musl@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-wasm32-wasi@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-arm64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide-win32-x64-msvc@4.2.2':
+    optional: true
+
+  '@tailwindcss/oxide@4.2.2':
+    optionalDependencies:
+      '@tailwindcss/oxide-android-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-arm64': 4.2.2
+      '@tailwindcss/oxide-darwin-x64': 4.2.2
+      '@tailwindcss/oxide-freebsd-x64': 4.2.2
+      '@tailwindcss/oxide-linux-arm-gnueabihf': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-arm64-musl': 4.2.2
+      '@tailwindcss/oxide-linux-x64-gnu': 4.2.2
+      '@tailwindcss/oxide-linux-x64-musl': 4.2.2
+      '@tailwindcss/oxide-wasm32-wasi': 4.2.2
+      '@tailwindcss/oxide-win32-arm64-msvc': 4.2.2
+      '@tailwindcss/oxide-win32-x64-msvc': 4.2.2
+
+  '@tailwindcss/vite@4.2.2(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))':
+    dependencies:
+      '@tailwindcss/node': 4.2.2
+      '@tailwindcss/oxide': 4.2.2
+      tailwindcss: 4.2.2
+      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.32.0)
 
   '@types/cookie@0.6.0': {}
 
@@ -967,6 +1353,19 @@ snapshots:
 
   axobject-query@4.1.0: {}
 
+  bits-ui@2.16.5(@internationalized/date@3.12.0)(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1):
+    dependencies:
+      '@floating-ui/core': 1.7.5
+      '@floating-ui/dom': 1.7.6
+      '@internationalized/date': 3.12.0
+      esm-env: 1.2.2
+      runed: 0.35.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)
+      svelte: 5.55.1
+      svelte-toolbelt: 0.10.6(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)
+      tabbable: 6.4.0
+    transitivePeerDependencies:
+      - '@sveltejs/kit'
+
   chokidar@4.0.3:
     dependencies:
       readdirp: 4.1.2
@@ -983,7 +1382,16 @@ snapshots:
 
   deepmerge@4.3.1: {}
 
+  dequal@2.0.3: {}
+
+  detect-libc@2.1.2: {}
+
   devalue@5.6.4: {}
+
+  enhanced-resolve@5.20.1:
+    dependencies:
+      graceful-fs: 4.2.11
+      tapable: 2.3.2
 
   esbuild@0.25.12:
     optionalDependencies:
@@ -1032,9 +1440,13 @@ snapshots:
 
   function-bind@1.1.2: {}
 
+  graceful-fs@4.2.11: {}
+
   hasown@2.0.2:
     dependencies:
       function-bind: 1.1.2
+
+  inline-style-parser@0.2.7: {}
 
   is-core-module@2.16.1:
     dependencies:
@@ -1050,9 +1462,62 @@ snapshots:
     dependencies:
       '@types/estree': 1.0.8
 
+  jiti@2.6.1: {}
+
   kleur@4.1.5: {}
 
+  lightningcss-android-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-arm64@1.32.0:
+    optional: true
+
+  lightningcss-darwin-x64@1.32.0:
+    optional: true
+
+  lightningcss-freebsd-x64@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm-gnueabihf@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-arm64-musl@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-gnu@1.32.0:
+    optional: true
+
+  lightningcss-linux-x64-musl@1.32.0:
+    optional: true
+
+  lightningcss-win32-arm64-msvc@1.32.0:
+    optional: true
+
+  lightningcss-win32-x64-msvc@1.32.0:
+    optional: true
+
+  lightningcss@1.32.0:
+    dependencies:
+      detect-libc: 2.1.2
+    optionalDependencies:
+      lightningcss-android-arm64: 1.32.0
+      lightningcss-darwin-arm64: 1.32.0
+      lightningcss-darwin-x64: 1.32.0
+      lightningcss-freebsd-x64: 1.32.0
+      lightningcss-linux-arm-gnueabihf: 1.32.0
+      lightningcss-linux-arm64-gnu: 1.32.0
+      lightningcss-linux-arm64-musl: 1.32.0
+      lightningcss-linux-x64-gnu: 1.32.0
+      lightningcss-linux-x64-musl: 1.32.0
+      lightningcss-win32-arm64-msvc: 1.32.0
+      lightningcss-win32-x64-msvc: 1.32.0
+
   locate-character@3.0.0: {}
+
+  lz-string@1.5.0: {}
 
   magic-string@0.30.21:
     dependencies:
@@ -1117,6 +1582,15 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.1
       fsevents: 2.3.3
 
+  runed@0.35.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1):
+    dependencies:
+      dequal: 2.0.3
+      esm-env: 1.2.2
+      lz-string: 1.5.0
+      svelte: 5.55.1
+    optionalDependencies:
+      '@sveltejs/kit': 2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0))
+
   sade@1.8.1:
     dependencies:
       mri: 1.2.0
@@ -1131,6 +1605,10 @@ snapshots:
 
   source-map-js@1.2.1: {}
 
+  style-to-object@1.0.14:
+    dependencies:
+      inline-style-parser: 0.2.7
+
   supports-preserve-symlinks-flag@1.0.0: {}
 
   svelte-check@4.4.5(picomatch@4.0.4)(svelte@5.55.1)(typescript@5.9.3):
@@ -1144,6 +1622,15 @@ snapshots:
       typescript: 5.9.3
     transitivePeerDependencies:
       - picomatch
+
+  svelte-toolbelt@0.10.6(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1):
+    dependencies:
+      clsx: 2.1.1
+      runed: 0.35.1(@sveltejs/kit@2.55.0(@sveltejs/vite-plugin-svelte@5.1.1(svelte@5.55.1)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)(typescript@5.9.3)(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)))(svelte@5.55.1)
+      style-to-object: 1.0.14
+      svelte: 5.55.1
+    transitivePeerDependencies:
+      - '@sveltejs/kit'
 
   svelte@5.55.1:
     dependencies:
@@ -1164,6 +1651,20 @@ snapshots:
       magic-string: 0.30.21
       zimmerframe: 1.1.4
 
+  tabbable@6.4.0: {}
+
+  tailwind-merge@3.5.0: {}
+
+  tailwind-variants@3.2.2(tailwind-merge@3.5.0)(tailwindcss@4.2.2):
+    dependencies:
+      tailwindcss: 4.2.2
+    optionalDependencies:
+      tailwind-merge: 3.5.0
+
+  tailwindcss@4.2.2: {}
+
+  tapable@2.3.2: {}
+
   tinyglobby@0.2.15:
     dependencies:
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1171,9 +1672,13 @@ snapshots:
 
   totalist@3.0.1: {}
 
+  tslib@2.8.1: {}
+
+  tw-animate-css@1.4.0: {}
+
   typescript@5.9.3: {}
 
-  vite@6.4.1:
+  vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0):
     dependencies:
       esbuild: 0.25.12
       fdir: 6.5.0(picomatch@4.0.4)
@@ -1183,9 +1688,11 @@ snapshots:
       tinyglobby: 0.2.15
     optionalDependencies:
       fsevents: 2.3.3
+      jiti: 2.6.1
+      lightningcss: 1.32.0
 
-  vitefu@1.1.2(vite@6.4.1):
+  vitefu@1.1.2(vite@6.4.1(jiti@2.6.1)(lightningcss@1.32.0)):
     optionalDependencies:
-      vite: 6.4.1
+      vite: 6.4.1(jiti@2.6.1)(lightningcss@1.32.0)
 
   zimmerframe@1.1.4: {}

--- a/ui/src/app.css
+++ b/ui/src/app.css
@@ -1,0 +1,114 @@
+@import "tailwindcss";
+@import "tw-animate-css";
+
+@custom-variant dark (&:is(.dark *));
+
+:root {
+	--radius: 0.625rem;
+	--background: oklch(1 0 0);
+	--foreground: oklch(0.145 0 0);
+	--card: oklch(1 0 0);
+	--card-foreground: oklch(0.145 0 0);
+	--popover: oklch(1 0 0);
+	--popover-foreground: oklch(0.145 0 0);
+	--primary: oklch(0.205 0 0);
+	--primary-foreground: oklch(0.985 0 0);
+	--secondary: oklch(0.97 0 0);
+	--secondary-foreground: oklch(0.205 0 0);
+	--muted: oklch(0.97 0 0);
+	--muted-foreground: oklch(0.556 0 0);
+	--accent: oklch(0.97 0 0);
+	--accent-foreground: oklch(0.205 0 0);
+	--destructive: oklch(0.577 0.245 27.325);
+	--border: oklch(0.922 0 0);
+	--input: oklch(0.922 0 0);
+	--ring: oklch(0.708 0 0);
+	--sidebar: oklch(0.985 0 0);
+	--sidebar-foreground: oklch(0.145 0 0);
+	--sidebar-primary: oklch(0.205 0 0);
+	--sidebar-primary-foreground: oklch(0.985 0 0);
+	--sidebar-accent: oklch(0.97 0 0);
+	--sidebar-accent-foreground: oklch(0.205 0 0);
+	--sidebar-border: oklch(0.922 0 0);
+	--sidebar-ring: oklch(0.708 0 0);
+}
+
+.dark {
+	--background: oklch(0.145 0 0);
+	--foreground: oklch(0.985 0 0);
+	--card: oklch(0.205 0 0);
+	--card-foreground: oklch(0.985 0 0);
+	--popover: oklch(0.269 0 0);
+	--popover-foreground: oklch(0.985 0 0);
+	--primary: oklch(0.922 0 0);
+	--primary-foreground: oklch(0.205 0 0);
+	--secondary: oklch(0.269 0 0);
+	--secondary-foreground: oklch(0.985 0 0);
+	--muted: oklch(0.269 0 0);
+	--muted-foreground: oklch(0.708 0 0);
+	--accent: oklch(0.371 0 0);
+	--accent-foreground: oklch(0.985 0 0);
+	--destructive: oklch(0.704 0.191 22.216);
+	--border: oklch(1 0 0 / 10%);
+	--input: oklch(1 0 0 / 15%);
+	--ring: oklch(0.556 0 0);
+	--sidebar: oklch(0.205 0 0);
+	--sidebar-foreground: oklch(0.985 0 0);
+	--sidebar-primary: oklch(0.488 0.243 264.376);
+	--sidebar-primary-foreground: oklch(0.985 0 0);
+	--sidebar-accent: oklch(0.269 0 0);
+	--sidebar-accent-foreground: oklch(0.985 0 0);
+	--sidebar-border: oklch(1 0 0 / 10%);
+	--sidebar-ring: oklch(0.439 0 0);
+}
+
+@theme inline {
+	--radius-sm: calc(var(--radius) - 4px);
+	--radius-md: calc(var(--radius) - 2px);
+	--radius-lg: var(--radius);
+	--radius-xl: calc(var(--radius) + 4px);
+	--color-background: var(--background);
+	--color-foreground: var(--foreground);
+	--color-card: var(--card);
+	--color-card-foreground: var(--card-foreground);
+	--color-popover: var(--popover);
+	--color-popover-foreground: var(--popover-foreground);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-secondary: var(--secondary);
+	--color-secondary-foreground: var(--secondary-foreground);
+	--color-muted: var(--muted);
+	--color-muted-foreground: var(--muted-foreground);
+	--color-accent: var(--accent);
+	--color-accent-foreground: var(--accent-foreground);
+	--color-destructive: var(--destructive);
+	--color-border: var(--border);
+	--color-input: var(--input);
+	--color-ring: var(--ring);
+	--color-sidebar: var(--sidebar);
+	--color-sidebar-foreground: var(--sidebar-foreground);
+	--color-sidebar-primary: var(--sidebar-primary);
+	--color-sidebar-primary-foreground: var(--sidebar-primary-foreground);
+	--color-sidebar-accent: var(--sidebar-accent);
+	--color-sidebar-accent-foreground: var(--sidebar-accent-foreground);
+	--color-sidebar-border: var(--sidebar-border);
+	--color-sidebar-ring: var(--sidebar-ring);
+
+	/* Custom Aileron status colors */
+	--color-status-green: #22c55e;
+	--color-status-red: #ef4444;
+	--color-status-yellow: #eab308;
+	--color-status-orange: #f97316;
+	--color-status-blue: #3b82f6;
+}
+
+@layer base {
+	* {
+		@apply border-border;
+	}
+	body {
+		@apply bg-background text-foreground;
+		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+		margin: 0;
+	}
+}

--- a/ui/src/app.html
+++ b/ui/src/app.html
@@ -1,5 +1,5 @@
 <!doctype html>
-<html lang="en">
+<html lang="en" class="dark">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width, initial-scale=1" />

--- a/ui/src/lib/colors.ts
+++ b/ui/src/lib/colors.ts
@@ -1,0 +1,57 @@
+/** Approval status colors */
+export function approvalStatusColor(status: string): string {
+	switch (status) {
+		case 'pending': return 'var(--color-status-yellow)';
+		case 'approved': return 'var(--color-status-green)';
+		case 'denied': return 'var(--color-status-red)';
+		case 'modified': return 'var(--color-status-orange)';
+		default: return 'var(--color-muted-foreground)';
+	}
+}
+
+/** Server status colors */
+export function serverStatusColor(status: string): string {
+	switch (status) {
+		case 'running': return 'var(--color-status-green)';
+		case 'error': return 'var(--color-status-red)';
+		default: return 'var(--color-muted-foreground)';
+	}
+}
+
+/** Server mode colors */
+export function modeColor(mode: string): string {
+	return mode === 'remote' ? 'var(--color-status-orange)' : 'var(--color-status-blue)';
+}
+
+/** Risk level colors */
+export function riskColor(level: string): string {
+	switch (level) {
+		case 'low': return 'var(--color-status-green)';
+		case 'medium': return 'var(--color-status-yellow)';
+		case 'high': return 'var(--color-status-orange)';
+		case 'critical': return 'var(--color-status-red)';
+		default: return 'var(--color-muted-foreground)';
+	}
+}
+
+/** Policy effect colors */
+export function effectColor(effect: string): string {
+	switch (effect) {
+		case 'allow': return 'var(--color-status-green)';
+		case 'deny': return 'var(--color-status-red)';
+		case 'require_approval': return 'var(--color-status-yellow)';
+		case 'allow_with_modification': return 'var(--color-status-orange)';
+		default: return 'var(--color-muted-foreground)';
+	}
+}
+
+/** Trace event type colors */
+export function eventColor(eventType: string): string {
+	if (eventType.includes('submitted')) return 'var(--color-status-blue)';
+	if (eventType.includes('approved')) return 'var(--color-status-green)';
+	if (eventType.includes('denied')) return 'var(--color-status-red)';
+	if (eventType.includes('succeeded')) return 'var(--color-status-green)';
+	if (eventType.includes('failed')) return 'var(--color-status-red)';
+	if (eventType.includes('granted') || eventType.includes('issued')) return 'var(--color-status-green)';
+	return 'var(--color-muted-foreground)';
+}

--- a/ui/src/lib/components/ui/badge/badge.svelte
+++ b/ui/src/lib/components/ui/badge/badge.svelte
@@ -1,0 +1,49 @@
+<script lang="ts" module>
+	import { type VariantProps, tv } from "tailwind-variants";
+
+	export const badgeVariants = tv({
+		base: "h-5 gap-1 rounded-4xl border border-transparent px-2 py-0.5 text-xs font-medium transition-all has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&>svg]:size-3! focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive group/badge inline-flex w-fit shrink-0 items-center justify-center overflow-hidden whitespace-nowrap transition-colors focus-visible:ring-[3px] [&>svg]:pointer-events-none",
+		variants: {
+			variant: {
+				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+				secondary: "bg-secondary text-secondary-foreground [a]:hover:bg-secondary/80",
+				destructive: "bg-destructive/10 [a]:hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 text-destructive dark:bg-destructive/20",
+				outline: "border-border text-foreground [a]:hover:bg-muted [a]:hover:text-muted-foreground",
+				ghost: "hover:bg-muted hover:text-muted-foreground dark:hover:bg-muted/50",
+				link: "text-primary underline-offset-4 hover:underline",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+		},
+	});
+
+	export type BadgeVariant = VariantProps<typeof badgeVariants>["variant"];
+</script>
+
+<script lang="ts">
+	import type { HTMLAnchorAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		href,
+		class: className,
+		variant = "default",
+		children,
+		...restProps
+	}: WithElementRef<HTMLAnchorAttributes> & {
+		variant?: BadgeVariant;
+	} = $props();
+</script>
+
+<svelte:element
+	this={href ? "a" : "span"}
+	bind:this={ref}
+	data-slot="badge"
+	{href}
+	class={cn(badgeVariants({ variant }), className)}
+	{...restProps}
+>
+	{@render children?.()}
+</svelte:element>

--- a/ui/src/lib/components/ui/badge/index.ts
+++ b/ui/src/lib/components/ui/badge/index.ts
@@ -1,0 +1,2 @@
+export { default as Badge } from "./badge.svelte";
+export { badgeVariants, type BadgeVariant } from "./badge.svelte";

--- a/ui/src/lib/components/ui/button/button.svelte
+++ b/ui/src/lib/components/ui/button/button.svelte
@@ -1,0 +1,82 @@
+<script lang="ts" module>
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAnchorAttributes, HTMLButtonAttributes } from "svelte/elements";
+	import { type VariantProps, tv } from "tailwind-variants";
+
+	export const buttonVariants = tv({
+		base: "focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 rounded-lg border border-transparent bg-clip-padding text-sm font-medium focus-visible:ring-3 active:not-aria-[haspopup]:translate-y-px aria-invalid:ring-3 [&_svg:not([class*='size-'])]:size-4 group/button inline-flex shrink-0 items-center justify-center whitespace-nowrap transition-all outline-none select-none disabled:pointer-events-none disabled:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		variants: {
+			variant: {
+				default: "bg-primary text-primary-foreground [a]:hover:bg-primary/80",
+				outline: "border-border bg-background hover:bg-muted hover:text-foreground dark:bg-input/30 dark:border-input dark:hover:bg-input/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+				secondary: "bg-secondary text-secondary-foreground hover:bg-secondary/80 aria-expanded:bg-secondary aria-expanded:text-secondary-foreground",
+				ghost: "hover:bg-muted hover:text-foreground dark:hover:bg-muted/50 aria-expanded:bg-muted aria-expanded:text-foreground",
+				destructive: "bg-destructive/10 hover:bg-destructive/20 focus-visible:ring-destructive/20 dark:focus-visible:ring-destructive/40 dark:bg-destructive/20 text-destructive focus-visible:border-destructive/40 dark:hover:bg-destructive/30",
+				link: "text-primary underline-offset-4 hover:underline",
+			},
+			size: {
+				default: "h-8 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+				xs: "h-6 gap-1 rounded-[min(var(--radius-md),10px)] px-2 text-xs in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3",
+				sm: "h-7 gap-1 rounded-[min(var(--radius-md),12px)] px-2.5 text-[0.8rem] in-data-[slot=button-group]:rounded-lg has-data-[icon=inline-end]:pr-1.5 has-data-[icon=inline-start]:pl-1.5 [&_svg:not([class*='size-'])]:size-3.5",
+				lg: "h-9 gap-1.5 px-2.5 has-data-[icon=inline-end]:pr-2 has-data-[icon=inline-start]:pl-2",
+				icon: "size-8",
+				"icon-xs": "size-6 rounded-[min(var(--radius-md),10px)] in-data-[slot=button-group]:rounded-lg [&_svg:not([class*='size-'])]:size-3",
+				"icon-sm": "size-7 rounded-[min(var(--radius-md),12px)] in-data-[slot=button-group]:rounded-lg",
+				"icon-lg": "size-9",
+			},
+		},
+		defaultVariants: {
+			variant: "default",
+			size: "default",
+		},
+	});
+
+	export type ButtonVariant = VariantProps<typeof buttonVariants>["variant"];
+	export type ButtonSize = VariantProps<typeof buttonVariants>["size"];
+
+	export type ButtonProps = WithElementRef<HTMLButtonAttributes> &
+		WithElementRef<HTMLAnchorAttributes> & {
+			variant?: ButtonVariant;
+			size?: ButtonSize;
+		};
+</script>
+
+<script lang="ts">
+	let {
+		class: className,
+		variant = "default",
+		size = "default",
+		ref = $bindable(null),
+		href = undefined,
+		type = "button",
+		disabled,
+		children,
+		...restProps
+	}: ButtonProps = $props();
+</script>
+
+{#if href}
+	<a
+		bind:this={ref}
+		data-slot="button"
+		class={cn(buttonVariants({ variant, size }), className)}
+		href={disabled ? undefined : href}
+		aria-disabled={disabled}
+		role={disabled ? "link" : undefined}
+		tabindex={disabled ? -1 : undefined}
+		{...restProps}
+	>
+		{@render children?.()}
+	</a>
+{:else}
+	<button
+		bind:this={ref}
+		data-slot="button"
+		class={cn(buttonVariants({ variant, size }), className)}
+		{type}
+		{disabled}
+		{...restProps}
+	>
+		{@render children?.()}
+	</button>
+{/if}

--- a/ui/src/lib/components/ui/button/index.ts
+++ b/ui/src/lib/components/ui/button/index.ts
@@ -1,0 +1,17 @@
+import Root, {
+	type ButtonProps,
+	type ButtonSize,
+	type ButtonVariant,
+	buttonVariants,
+} from "./button.svelte";
+
+export {
+	Root,
+	type ButtonProps as Props,
+	//
+	Root as Button,
+	buttonVariants,
+	type ButtonProps,
+	type ButtonSize,
+	type ButtonVariant,
+};

--- a/ui/src/lib/components/ui/card/card-action.svelte
+++ b/ui/src/lib/components/ui/card/card-action.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-action"
+	class={cn(
+		"cn-card-action col-start-2 row-span-2 row-start-1 self-start justify-self-end",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/ui/src/lib/components/ui/card/card-content.svelte
+++ b/ui/src/lib/components/ui/card/card-content.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-content"
+	class={cn("px-4 group-data-[size=sm]/card:px-3", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/ui/src/lib/components/ui/card/card-description.svelte
+++ b/ui/src/lib/components/ui/card/card-description.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLParagraphElement>> = $props();
+</script>
+
+<p
+	bind:this={ref}
+	data-slot="card-description"
+	class={cn("text-muted-foreground text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</p>

--- a/ui/src/lib/components/ui/card/card-footer.svelte
+++ b/ui/src/lib/components/ui/card/card-footer.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-footer"
+	class={cn("bg-muted/50 rounded-b-xl border-t p-4 group-data-[size=sm]/card:p-3 flex items-center", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/ui/src/lib/components/ui/card/card-header.svelte
+++ b/ui/src/lib/components/ui/card/card-header.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-header"
+	class={cn(
+		"gap-1 rounded-t-xl px-4 group-data-[size=sm]/card:px-3 [.border-b]:pb-4 group-data-[size=sm]/card:[.border-b]:pb-3 group/card-header @container/card-header grid auto-rows-min items-start has-data-[slot=card-action]:grid-cols-[1fr_auto] has-data-[slot=card-description]:grid-rows-[auto_auto]",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/ui/src/lib/components/ui/card/card-title.svelte
+++ b/ui/src/lib/components/ui/card/card-title.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card-title"
+	class={cn("text-base leading-snug font-medium group-data-[size=sm]/card:text-sm", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/ui/src/lib/components/ui/card/card.svelte
+++ b/ui/src/lib/components/ui/card/card.svelte
@@ -1,0 +1,22 @@
+<script lang="ts">
+	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		size = "default",
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & { size?: "default" | "sm" } = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="card"
+	data-size={size}
+	class={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/ui/src/lib/components/ui/card/index.ts
+++ b/ui/src/lib/components/ui/card/index.ts
@@ -1,0 +1,25 @@
+import Root from "./card.svelte";
+import Content from "./card-content.svelte";
+import Description from "./card-description.svelte";
+import Footer from "./card-footer.svelte";
+import Header from "./card-header.svelte";
+import Title from "./card-title.svelte";
+import Action from "./card-action.svelte";
+
+export {
+	Root,
+	Content,
+	Description,
+	Footer,
+	Header,
+	Title,
+	Action,
+	//
+	Root as Card,
+	Content as CardContent,
+	Description as CardDescription,
+	Footer as CardFooter,
+	Header as CardHeader,
+	Title as CardTitle,
+	Action as CardAction,
+};

--- a/ui/src/lib/components/ui/collapsible/collapsible-content.svelte
+++ b/ui/src/lib/components/ui/collapsible/collapsible-content.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: CollapsiblePrimitive.ContentProps = $props();
+</script>
+
+<CollapsiblePrimitive.Content bind:ref data-slot="collapsible-content" {...restProps} />

--- a/ui/src/lib/components/ui/collapsible/collapsible-trigger.svelte
+++ b/ui/src/lib/components/ui/collapsible/collapsible-trigger.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from "bits-ui";
+
+	let { ref = $bindable(null), ...restProps }: CollapsiblePrimitive.TriggerProps = $props();
+</script>
+
+<CollapsiblePrimitive.Trigger bind:ref data-slot="collapsible-trigger" {...restProps} />

--- a/ui/src/lib/components/ui/collapsible/collapsible.svelte
+++ b/ui/src/lib/components/ui/collapsible/collapsible.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Collapsible as CollapsiblePrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		open = $bindable(false),
+		...restProps
+	}: CollapsiblePrimitive.RootProps = $props();
+</script>
+
+<CollapsiblePrimitive.Root bind:ref bind:open data-slot="collapsible" {...restProps} />

--- a/ui/src/lib/components/ui/collapsible/index.ts
+++ b/ui/src/lib/components/ui/collapsible/index.ts
@@ -1,0 +1,13 @@
+import Root from "./collapsible.svelte";
+import Trigger from "./collapsible-trigger.svelte";
+import Content from "./collapsible-content.svelte";
+
+export {
+	Root,
+	Content,
+	Trigger,
+	//
+	Root as Collapsible,
+	Content as CollapsibleContent,
+	Trigger as CollapsibleTrigger,
+};

--- a/ui/src/lib/components/ui/input/index.ts
+++ b/ui/src/lib/components/ui/input/index.ts
@@ -1,0 +1,7 @@
+import Root from "./input.svelte";
+
+export {
+	Root,
+	//
+	Root as Input,
+};

--- a/ui/src/lib/components/ui/input/input.svelte
+++ b/ui/src/lib/components/ui/input/input.svelte
@@ -1,0 +1,48 @@
+<script lang="ts">
+	import type { HTMLInputAttributes, HTMLInputTypeAttribute } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
+
+	type InputType = Exclude<HTMLInputTypeAttribute, "file">;
+
+	type Props = WithElementRef<
+		Omit<HTMLInputAttributes, "type"> &
+			({ type: "file"; files?: FileList } | { type?: InputType; files?: undefined })
+	>;
+
+	let {
+		ref = $bindable(null),
+		value = $bindable(),
+		type,
+		files = $bindable(),
+		class: className,
+		"data-slot": dataSlot = "input",
+		...restProps
+	}: Props = $props();
+</script>
+
+{#if type === "file"}
+	<input
+		bind:this={ref}
+		data-slot={dataSlot}
+		class={cn(
+			"dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+			className
+		)}
+		type="file"
+		bind:files
+		bind:value
+		{...restProps}
+	/>
+{:else}
+	<input
+		bind:this={ref}
+		data-slot={dataSlot}
+		class={cn(
+			"dark:bg-input/30 border-input focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 disabled:bg-input/50 dark:disabled:bg-input/80 h-8 rounded-lg border bg-transparent px-2.5 py-1 text-base transition-colors file:h-6 file:text-sm file:font-medium focus-visible:ring-3 aria-invalid:ring-3 md:text-sm file:text-foreground placeholder:text-muted-foreground w-full min-w-0 outline-none file:inline-flex file:border-0 file:bg-transparent disabled:pointer-events-none disabled:cursor-not-allowed disabled:opacity-50",
+			className
+		)}
+		{type}
+		bind:value
+		{...restProps}
+	/>
+{/if}

--- a/ui/src/lib/components/ui/select/index.ts
+++ b/ui/src/lib/components/ui/select/index.ts
@@ -1,0 +1,37 @@
+import Root from "./select.svelte";
+import Group from "./select-group.svelte";
+import Label from "./select-label.svelte";
+import Item from "./select-item.svelte";
+import Content from "./select-content.svelte";
+import Trigger from "./select-trigger.svelte";
+import Separator from "./select-separator.svelte";
+import ScrollDownButton from "./select-scroll-down-button.svelte";
+import ScrollUpButton from "./select-scroll-up-button.svelte";
+import GroupHeading from "./select-group-heading.svelte";
+import Portal from "./select-portal.svelte";
+
+export {
+	Root,
+	Group,
+	Label,
+	Item,
+	Content,
+	Trigger,
+	Separator,
+	ScrollDownButton,
+	ScrollUpButton,
+	GroupHeading,
+	Portal,
+	//
+	Root as Select,
+	Group as SelectGroup,
+	Label as SelectLabel,
+	Item as SelectItem,
+	Content as SelectContent,
+	Trigger as SelectTrigger,
+	Separator as SelectSeparator,
+	ScrollDownButton as SelectScrollDownButton,
+	ScrollUpButton as SelectScrollUpButton,
+	GroupHeading as SelectGroupHeading,
+	Portal as SelectPortal,
+};

--- a/ui/src/lib/components/ui/select/select-content.svelte
+++ b/ui/src/lib/components/ui/select/select-content.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import SelectPortal from "./select-portal.svelte";
+	import SelectScrollUpButton from "./select-scroll-up-button.svelte";
+	import SelectScrollDownButton from "./select-scroll-down-button.svelte";
+	import { cn, type WithoutChild } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+	import type { WithoutChildrenOrChild } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		sideOffset = 4,
+		portalProps,
+		children,
+		preventScroll = true,
+		...restProps
+	}: WithoutChild<SelectPrimitive.ContentProps> & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof SelectPortal>>;
+	} = $props();
+</script>
+
+<SelectPortal {...portalProps}>
+	<SelectPrimitive.Content
+		bind:ref
+		{sideOffset}
+		{preventScroll}
+		data-slot="select-content"
+		class={cn(
+			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 ring-foreground/10 min-w-36 rounded-lg shadow-md ring-1 duration-100 data-[side=inline-start]:slide-in-from-right-2 data-[side=inline-end]:slide-in-from-left-2 relative isolate z-50 overflow-x-hidden overflow-y-auto",
+			className
+		)}
+		{...restProps}
+	>
+		<SelectScrollUpButton />
+		<SelectPrimitive.Viewport
+			class={cn(
+				"h-(--bits-select-anchor-height) w-full min-w-(--bits-select-anchor-width) scroll-my-1"
+			)}
+		>
+			{@render children?.()}
+		</SelectPrimitive.Viewport>
+		<SelectScrollDownButton />
+	</SelectPrimitive.Content>
+</SelectPortal>

--- a/ui/src/lib/components/ui/select/select-group-heading.svelte
+++ b/ui/src/lib/components/ui/select/select-group-heading.svelte
@@ -1,0 +1,21 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: ComponentProps<typeof SelectPrimitive.GroupHeading> = $props();
+</script>
+
+<SelectPrimitive.GroupHeading
+	bind:ref
+	data-slot="select-group-heading"
+	class={cn("text-muted-foreground px-2 py-1.5 text-xs", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</SelectPrimitive.GroupHeading>

--- a/ui/src/lib/components/ui/select/select-group.svelte
+++ b/ui/src/lib/components/ui/select/select-group.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SelectPrimitive.GroupProps = $props();
+</script>
+
+<SelectPrimitive.Group
+	bind:ref
+	data-slot="select-group"
+	class={cn("scroll-my-1 p-1", className)}
+	{...restProps}
+/>

--- a/ui/src/lib/components/ui/select/select-item.svelte
+++ b/ui/src/lib/components/ui/select/select-item.svelte
@@ -1,0 +1,38 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn, type WithoutChild } from "$lib/utils.js";
+	import CheckIcon from '@lucide/svelte/icons/check';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		value,
+		label,
+		children: childrenProp,
+		...restProps
+	}: WithoutChild<SelectPrimitive.ItemProps> = $props();
+</script>
+
+<SelectPrimitive.Item
+	bind:ref
+	{value}
+	data-slot="select-item"
+	class={cn(
+		"focus:bg-accent focus:text-accent-foreground not-data-[variant=destructive]:focus:**:text-accent-foreground gap-1.5 rounded-md py-1 pr-8 pl-1.5 text-sm [&_svg:not([class*='size-'])]:size-4 *:[span]:last:flex *:[span]:last:items-center *:[span]:last:gap-2 focus:bg-accent data-highlighted:bg-accent data-highlighted:text-accent-foreground focus:text-accent-foreground relative flex w-full cursor-default items-center outline-hidden select-none data-[disabled]:pointer-events-none data-[disabled]:opacity-50 [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{#snippet children({ selected, highlighted })}
+		<span class="absolute end-2 flex size-3.5 items-center justify-center">
+			{#if selected}
+				<CheckIcon class="cn-select-item-indicator-icon" />
+			{/if}
+		</span>
+		{#if childrenProp}
+			{@render childrenProp({ selected, highlighted })}
+		{:else}
+			{label || value}
+		{/if}
+	{/snippet}
+</SelectPrimitive.Item>

--- a/ui/src/lib/components/ui/select/select-label.svelte
+++ b/ui/src/lib/components/ui/select/select-label.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { cn, type WithElementRef } from "$lib/utils.js";
+	import type { HTMLAttributes } from "svelte/elements";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		...restProps
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {} = $props();
+</script>
+
+<div
+	bind:this={ref}
+	data-slot="select-label"
+	class={cn("text-muted-foreground px-1.5 py-1 text-xs", className)}
+	{...restProps}
+>
+	{@render children?.()}
+</div>

--- a/ui/src/lib/components/ui/select/select-portal.svelte
+++ b/ui/src/lib/components/ui/select/select-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+
+	let { ...restProps }: SelectPrimitive.PortalProps = $props();
+</script>
+
+<SelectPrimitive.Portal {...restProps} />

--- a/ui/src/lib/components/ui/select/select-scroll-down-button.svelte
+++ b/ui/src/lib/components/ui/select/select-scroll-down-button.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<SelectPrimitive.ScrollDownButtonProps> = $props();
+</script>
+
+<SelectPrimitive.ScrollDownButton
+	bind:ref
+	data-slot="select-scroll-down-button"
+	class={cn("bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4 bottom-0 w-full", className)}
+	{...restProps}
+>
+	<ChevronDownIcon  />
+</SelectPrimitive.ScrollDownButton>

--- a/ui/src/lib/components/ui/select/select-scroll-up-button.svelte
+++ b/ui/src/lib/components/ui/select/select-scroll-up-button.svelte
@@ -1,0 +1,20 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import ChevronUpIcon from '@lucide/svelte/icons/chevron-up';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: WithoutChildrenOrChild<SelectPrimitive.ScrollUpButtonProps> = $props();
+</script>
+
+<SelectPrimitive.ScrollUpButton
+	bind:ref
+	data-slot="select-scroll-up-button"
+	class={cn("bg-popover z-10 flex cursor-default items-center justify-center py-1 [&_svg:not([class*='size-'])]:size-4 top-0 w-full", className)}
+	{...restProps}
+>
+	<ChevronUpIcon  />
+</SelectPrimitive.ScrollUpButton>

--- a/ui/src/lib/components/ui/select/select-separator.svelte
+++ b/ui/src/lib/components/ui/select/select-separator.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+	import type { Separator as SeparatorPrimitive } from "bits-ui";
+	import { Separator } from "$lib/components/ui/separator/index.js";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: SeparatorPrimitive.RootProps = $props();
+</script>
+
+<Separator
+	bind:ref
+	data-slot="select-separator"
+	class={cn("bg-border -mx-1 my-1 h-px pointer-events-none", className)}
+	{...restProps}
+/>

--- a/ui/src/lib/components/ui/select/select-trigger.svelte
+++ b/ui/src/lib/components/ui/select/select-trigger.svelte
@@ -1,0 +1,29 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+	import { cn, type WithoutChild } from "$lib/utils.js";
+	import ChevronDownIcon from '@lucide/svelte/icons/chevron-down';
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		children,
+		size = "default",
+		...restProps
+	}: WithoutChild<SelectPrimitive.TriggerProps> & {
+		size?: "sm" | "default";
+	} = $props();
+</script>
+
+<SelectPrimitive.Trigger
+	bind:ref
+	data-slot="select-trigger"
+	data-size={size}
+	class={cn(
+		"border-input data-placeholder:text-muted-foreground dark:bg-input/30 dark:hover:bg-input/50 focus-visible:border-ring focus-visible:ring-ring/50 aria-invalid:ring-destructive/20 dark:aria-invalid:ring-destructive/40 aria-invalid:border-destructive dark:aria-invalid:border-destructive/50 gap-1.5 rounded-lg border bg-transparent py-2 pr-2 pl-2.5 text-sm transition-colors select-none focus-visible:ring-3 aria-invalid:ring-3 data-[size=default]:h-8 data-[size=sm]:h-7 data-[size=sm]:rounded-[min(var(--radius-md),10px)] *:data-[slot=select-value]:flex *:data-[slot=select-value]:gap-1.5 [&_svg:not([class*='size-'])]:size-4 flex w-fit items-center justify-between whitespace-nowrap outline-none disabled:cursor-not-allowed disabled:opacity-50 *:data-[slot=select-value]:line-clamp-1 *:data-[slot=select-value]:flex *:data-[slot=select-value]:items-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+		className
+	)}
+	{...restProps}
+>
+	{@render children?.()}
+	<ChevronDownIcon class="text-muted-foreground size-4 pointer-events-none" />
+</SelectPrimitive.Trigger>

--- a/ui/src/lib/components/ui/select/select.svelte
+++ b/ui/src/lib/components/ui/select/select.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Select as SelectPrimitive } from "bits-ui";
+
+	let {
+		open = $bindable(false),
+		value = $bindable(),
+		...restProps
+	}: SelectPrimitive.RootProps = $props();
+</script>
+
+<SelectPrimitive.Root bind:open bind:value={value as never} {...restProps} />

--- a/ui/src/lib/components/ui/separator/index.ts
+++ b/ui/src/lib/components/ui/separator/index.ts
@@ -1,0 +1,7 @@
+import Root from "./separator.svelte";
+
+export {
+	Root,
+	//
+	Root as Separator,
+};

--- a/ui/src/lib/components/ui/separator/separator.svelte
+++ b/ui/src/lib/components/ui/separator/separator.svelte
@@ -1,0 +1,23 @@
+<script lang="ts">
+	import { Separator as SeparatorPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		"data-slot": dataSlot = "separator",
+		...restProps
+	}: SeparatorPrimitive.RootProps = $props();
+</script>
+
+<SeparatorPrimitive.Root
+	bind:ref
+	data-slot={dataSlot}
+	class={cn(
+		"bg-border shrink-0 data-[orientation=horizontal]:h-px data-[orientation=horizontal]:w-full data-[orientation=vertical]:w-px",
+		// this is different in shadcn/ui but self-stretch breaks things for us
+		"data-[orientation=vertical]:h-full",
+		className
+	)}
+	{...restProps}
+/>

--- a/ui/src/lib/utils.ts
+++ b/ui/src/lib/utils.ts
@@ -1,0 +1,12 @@
+import { type ClassValue, clsx } from "clsx";
+import { twMerge } from "tailwind-merge";
+
+export type {
+	WithElementRef,
+	WithoutChild,
+	WithoutChildrenOrChild
+} from "bits-ui";
+
+export function cn(...inputs: ClassValue[]) {
+	return twMerge(clsx(inputs));
+}

--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -1,40 +1,21 @@
 <script>
+	import '../app.css';
 	let { children } = $props();
 </script>
 
 <svelte:head>
-	<style>
-		:root {
-			--bg: #0a0a0a;
-			--bg-card: #141414;
-			--bg-hover: #1a1a1a;
-			--border: #2a2a2a;
-			--text: #e5e5e5;
-			--text-muted: #888;
-			--accent: #3b82f6;
-			--green: #22c55e;
-			--red: #ef4444;
-			--yellow: #eab308;
-			--orange: #f97316;
-			font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-		}
-		body {
-			margin: 0;
-			background: var(--bg);
-			color: var(--text);
-		}
-	</style>
+	<title>Aileron</title>
 </svelte:head>
 
-<nav style="border-bottom: 1px solid var(--border); padding: 0.75rem 1.5rem; display: flex; align-items: center; gap: 2rem;">
-	<a href="/" style="font-weight: 700; font-size: 1.1rem; text-decoration: none; color: var(--text);">Aileron</a>
-	<a href="/approvals" style="text-decoration: none; color: var(--text-muted); font-size: 0.9rem;">Approvals</a>
-	<a href="/traces" style="text-decoration: none; color: var(--text-muted); font-size: 0.9rem;">Traces</a>
-	<a href="/policies" style="text-decoration: none; color: var(--text-muted); font-size: 0.9rem;">Policies</a>
-	<a href="/marketplace" style="text-decoration: none; color: var(--text-muted); font-size: 0.9rem;">Marketplace</a>
-	<a href="/servers" style="text-decoration: none; color: var(--text-muted); font-size: 0.9rem;">Servers</a>
+<nav class="border-b border-border px-6 py-3 flex items-center gap-8">
+	<a href="/" class="font-bold text-lg no-underline text-foreground">Aileron</a>
+	<a href="/approvals" class="no-underline text-muted-foreground text-sm">Approvals</a>
+	<a href="/traces" class="no-underline text-muted-foreground text-sm">Traces</a>
+	<a href="/policies" class="no-underline text-muted-foreground text-sm">Policies</a>
+	<a href="/marketplace" class="no-underline text-muted-foreground text-sm">Marketplace</a>
+	<a href="/servers" class="no-underline text-muted-foreground text-sm">Servers</a>
 </nav>
 
-<main style="max-width: 960px; margin: 0 auto; padding: 1.5rem;">
+<main class="max-w-[960px] mx-auto p-6">
 	{@render children()}
 </main>

--- a/ui/src/routes/+page.svelte
+++ b/ui/src/routes/+page.svelte
@@ -1,29 +1,29 @@
+<script lang="ts">
+	import * as Card from '$lib/components/ui/card';
+</script>
+
 <svelte:head>
 	<title>Aileron</title>
 </svelte:head>
 
-<h1 style="font-size: 1.5rem; margin-bottom: 0.5rem;">Aileron</h1>
-<p style="color: var(--text-muted);">Agentic control plane</p>
+<h1 class="text-2xl font-semibold mb-2">Aileron</h1>
+<p class="text-muted-foreground">Agentic control plane</p>
 
-<div style="display: grid; grid-template-columns: repeat(auto-fit, minmax(200px, 1fr)); gap: 1rem; margin-top: 2rem;">
-	<a href="/approvals" style="display: block; padding: 1.5rem; border: 1px solid var(--border); border-radius: 8px; text-decoration: none; color: var(--text); background: var(--bg-card);">
-		<div style="font-size: 1.1rem; font-weight: 600; margin-bottom: 0.5rem;">Approvals</div>
-		<div style="font-size: 0.85rem; color: var(--text-muted);">Review and act on pending approval requests</div>
-	</a>
-	<a href="/traces" style="display: block; padding: 1.5rem; border: 1px solid var(--border); border-radius: 8px; text-decoration: none; color: var(--text); background: var(--bg-card);">
-		<div style="font-size: 1.1rem; font-weight: 600; margin-bottom: 0.5rem;">Traces</div>
-		<div style="font-size: 0.85rem; color: var(--text-muted);">Audit trail of all control plane events</div>
-	</a>
-	<a href="/policies" style="display: block; padding: 1.5rem; border: 1px solid var(--border); border-radius: 8px; text-decoration: none; color: var(--text); background: var(--bg-card);">
-		<div style="font-size: 1.1rem; font-weight: 600; margin-bottom: 0.5rem;">Policies</div>
-		<div style="font-size: 0.85rem; color: var(--text-muted);">View and manage policy rules</div>
-	</a>
-	<a href="/marketplace" style="display: block; padding: 1.5rem; border: 1px solid var(--border); border-radius: 8px; text-decoration: none; color: var(--text); background: var(--bg-card);">
-		<div style="font-size: 1.1rem; font-weight: 600; margin-bottom: 0.5rem;">Marketplace</div>
-		<div style="font-size: 0.85rem; color: var(--text-muted);">Browse and install MCP servers from the registry</div>
-	</a>
-	<a href="/servers" style="display: block; padding: 1.5rem; border: 1px solid var(--border); border-radius: 8px; text-decoration: none; color: var(--text); background: var(--bg-card);">
-		<div style="font-size: 1.1rem; font-weight: 600; margin-bottom: 0.5rem;">Servers</div>
-		<div style="font-size: 0.85rem; color: var(--text-muted);">Manage installed MCP server configurations</div>
-	</a>
+<div class="grid grid-cols-[repeat(auto-fit,minmax(200px,1fr))] gap-4 mt-8">
+	{#each [
+		{ href: '/approvals', title: 'Approvals', desc: 'Review and act on pending approval requests' },
+		{ href: '/traces', title: 'Traces', desc: 'Audit trail of all control plane events' },
+		{ href: '/policies', title: 'Policies', desc: 'View and manage policy rules' },
+		{ href: '/marketplace', title: 'Marketplace', desc: 'Browse and install MCP servers from the registry' },
+		{ href: '/servers', title: 'Servers', desc: 'Manage installed MCP server configurations' },
+	] as item}
+		<a href={item.href} class="no-underline text-foreground">
+			<Card.Root class="h-full hover:bg-muted/50 transition-colors">
+				<Card.Header>
+					<Card.Title>{item.title}</Card.Title>
+					<Card.Description>{item.desc}</Card.Description>
+				</Card.Header>
+			</Card.Root>
+		</a>
+	{/each}
 </div>

--- a/ui/src/routes/approvals/+page.svelte
+++ b/ui/src/routes/approvals/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { listApprovals } from '$lib/api';
 	import { onMount } from 'svelte';
+	import { approvalStatusColor } from '$lib/colors';
+	import * as Card from '$lib/components/ui/card';
 
 	let approvals = $state<any[]>([]);
 	let loading = $state(true);
@@ -22,48 +24,44 @@
 		const interval = setInterval(load, 5000);
 		return () => clearInterval(interval);
 	});
-
-	function statusColor(status: string) {
-		switch (status) {
-			case 'pending': return 'var(--yellow)';
-			case 'approved': return 'var(--green)';
-			case 'denied': return 'var(--red)';
-			case 'modified': return 'var(--orange)';
-			default: return 'var(--text-muted)';
-		}
-	}
 </script>
 
 <svelte:head>
 	<title>Approvals - Aileron</title>
 </svelte:head>
 
-<h1 style="font-size: 1.3rem; margin-bottom: 1rem;">Approvals</h1>
+<h1 class="text-xl font-semibold mb-4">Approvals</h1>
 
 {#if loading}
-	<p style="color: var(--text-muted);">Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p style="color: var(--red);">{error}</p>
+	<p class="text-destructive">{error}</p>
 {:else if approvals.length === 0}
-	<p style="color: var(--text-muted);">No approval requests yet. Submit an intent via the API or MCP server.</p>
+	<p class="text-muted-foreground">No approval requests yet. Submit an intent via the API or MCP server.</p>
 {:else}
-	<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+	<div class="flex flex-col gap-3">
 		{#each approvals as approval}
-			<a href="/approvals/{approval.approval_id}" style="display: block; padding: 1rem; border: 1px solid var(--border); border-radius: 8px; text-decoration: none; color: var(--text); background: var(--bg-card);">
-				<div style="display: flex; justify-content: space-between; align-items: center;">
-					<div>
-						<span style="font-weight: 600;">{approval.approval_id}</span>
-						{#if approval.rationale}
-							<span style="color: var(--text-muted); margin-left: 0.75rem; font-size: 0.85rem;">{approval.rationale}</span>
-						{/if}
-					</div>
-					<span style="color: {statusColor(approval.status)}; font-weight: 600; font-size: 0.85rem; text-transform: uppercase;">
-						{approval.status}
-					</span>
-				</div>
-				<div style="margin-top: 0.5rem; font-size: 0.8rem; color: var(--text-muted);">
-					Intent: {approval.intent_id} | Requested: {new Date(approval.requested_at).toLocaleString()}
-				</div>
+			<a href="/approvals/{approval.approval_id}" class="no-underline text-foreground">
+				<Card.Root class="hover:bg-muted/50 transition-colors">
+					<Card.Header>
+						<div class="flex justify-between items-center">
+							<div>
+								<span class="font-semibold">{approval.approval_id}</span>
+								{#if approval.rationale}
+									<span class="text-muted-foreground ml-3 text-sm">{approval.rationale}</span>
+								{/if}
+							</div>
+							<span class="font-semibold text-sm uppercase" style="color: {approvalStatusColor(approval.status)}">
+								{approval.status}
+							</span>
+						</div>
+					</Card.Header>
+					<Card.Content>
+						<div class="text-xs text-muted-foreground">
+							Intent: {approval.intent_id} | Requested: {new Date(approval.requested_at).toLocaleString()}
+						</div>
+					</Card.Content>
+				</Card.Root>
 			</a>
 		{/each}
 	</div>

--- a/ui/src/routes/approvals/[id]/+page.svelte
+++ b/ui/src/routes/approvals/[id]/+page.svelte
@@ -2,6 +2,10 @@
 	import { page } from '$app/stores';
 	import { getApproval, getIntent, approveRequest, denyRequest } from '$lib/api';
 	import { onMount } from 'svelte';
+	import { approvalStatusColor, riskColor } from '$lib/colors';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
 
 	let approval = $state<any>(null);
 	let intent = $state<any>(null);
@@ -58,154 +62,143 @@
 			acting = false;
 		}
 	}
-
-	function statusColor(status: string) {
-		switch (status) {
-			case 'pending': return 'var(--yellow)';
-			case 'approved': return 'var(--green)';
-			case 'denied': return 'var(--red)';
-			case 'modified': return 'var(--orange)';
-			default: return 'var(--text-muted)';
-		}
-	}
-
-	function riskColor(level: string) {
-		switch (level) {
-			case 'low': return 'var(--green)';
-			case 'medium': return 'var(--yellow)';
-			case 'high': return 'var(--orange)';
-			case 'critical': return 'var(--red)';
-			default: return 'var(--text-muted)';
-		}
-	}
 </script>
 
 <svelte:head>
 	<title>Approval {id} - Aileron</title>
 </svelte:head>
 
-<a href="/approvals" style="color: var(--text-muted); text-decoration: none; font-size: 0.85rem;">&larr; Back to approvals</a>
+<a href="/approvals" class="text-muted-foreground no-underline text-sm">&larr; Back to approvals</a>
 
 {#if loading}
-	<p style="color: var(--text-muted); margin-top: 1rem;">Loading...</p>
+	<p class="text-muted-foreground mt-4">Loading...</p>
 {:else if error}
-	<p style="color: var(--red); margin-top: 1rem;">{error}</p>
+	<p class="text-destructive mt-4">{error}</p>
 {:else if approval}
-	<div style="margin-top: 1rem;">
-		<div style="display: flex; align-items: center; gap: 1rem; margin-bottom: 1.5rem;">
-			<h1 style="font-size: 1.3rem; margin: 0;">Approval Request</h1>
-			<span style="color: {statusColor(approval.status)}; font-weight: 600; font-size: 0.9rem; text-transform: uppercase; padding: 0.2rem 0.6rem; border: 1px solid {statusColor(approval.status)}; border-radius: 4px;">
+	<div class="mt-4">
+		<div class="flex items-center gap-4 mb-6">
+			<h1 class="text-xl font-semibold m-0">Approval Request</h1>
+			<span class="font-semibold text-sm uppercase rounded border px-2.5 py-0.5" style="color: {approvalStatusColor(approval.status)}; border-color: {approvalStatusColor(approval.status)}">
 				{approval.status}
 			</span>
 		</div>
 
-		<!-- Intent details -->
 		{#if intent}
-			<div style="border: 1px solid var(--border); border-radius: 8px; padding: 1rem; background: var(--bg-card); margin-bottom: 1rem;">
-				<div style="font-weight: 600; margin-bottom: 0.75rem;">Intent</div>
-				<div style="display: grid; grid-template-columns: 120px 1fr; gap: 0.5rem; font-size: 0.9rem;">
-					<span style="color: var(--text-muted);">Action:</span>
-					<span>{intent.action.type}</span>
-					<span style="color: var(--text-muted);">Summary:</span>
-					<span>{intent.action.summary}</span>
-					{#if intent.action.justification}
-						<span style="color: var(--text-muted);">Justification:</span>
-						<span>{intent.action.justification}</span>
-					{/if}
-					<span style="color: var(--text-muted);">Agent:</span>
-					<span>{intent.agent.id}</span>
-					<span style="color: var(--text-muted);">Risk:</span>
-					<span style="color: {riskColor(intent.decision.risk_level)}; font-weight: 600; text-transform: uppercase;">{intent.decision.risk_level}</span>
-
-					{#if intent.action.domain?.git}
-						<span style="color: var(--text-muted);">Repository:</span>
-						<span>{intent.action.domain.git.repository || '-'}</span>
-						<span style="color: var(--text-muted);">Branch:</span>
-						<span>{intent.action.domain.git.branch || '-'} &rarr; {intent.action.domain.git.base_branch || '-'}</span>
-						{#if intent.action.domain.git.pr_title}
-							<span style="color: var(--text-muted);">PR Title:</span>
-							<span>{intent.action.domain.git.pr_title}</span>
+			<Card.Root class="mb-4">
+				<Card.Header>
+					<Card.Title>Intent</Card.Title>
+				</Card.Header>
+				<Card.Content>
+					<div class="grid grid-cols-[120px_1fr] gap-2 text-sm">
+						<span class="text-muted-foreground">Action:</span>
+						<span>{intent.action.type}</span>
+						<span class="text-muted-foreground">Summary:</span>
+						<span>{intent.action.summary}</span>
+						{#if intent.action.justification}
+							<span class="text-muted-foreground">Justification:</span>
+							<span>{intent.action.justification}</span>
 						{/if}
-					{/if}
+						<span class="text-muted-foreground">Agent:</span>
+						<span>{intent.agent.id}</span>
+						<span class="text-muted-foreground">Risk:</span>
+						<span class="font-semibold uppercase" style="color: {riskColor(intent.decision.risk_level)}">{intent.decision.risk_level}</span>
 
-					{#if intent.action.domain?.payment}
-						<span style="color: var(--text-muted);">Vendor:</span>
-						<span>{intent.action.domain.payment.vendor_name || '-'}</span>
-						{#if intent.action.domain.payment.amount}
-							<span style="color: var(--text-muted);">Amount:</span>
-							<span>{(intent.action.domain.payment.amount.amount / 100).toFixed(2)} {intent.action.domain.payment.amount.currency}</span>
+						{#if intent.action.domain?.git}
+							<span class="text-muted-foreground">Repository:</span>
+							<span>{intent.action.domain.git.repository || '-'}</span>
+							<span class="text-muted-foreground">Branch:</span>
+							<span>{intent.action.domain.git.branch || '-'} &rarr; {intent.action.domain.git.base_branch || '-'}</span>
+							{#if intent.action.domain.git.pr_title}
+								<span class="text-muted-foreground">PR Title:</span>
+								<span>{intent.action.domain.git.pr_title}</span>
+							{/if}
 						{/if}
-					{/if}
-				</div>
 
-				{#if intent.decision.matched_policies?.length}
-					<div style="margin-top: 1rem; border-top: 1px solid var(--border); padding-top: 0.75rem;">
-						<div style="font-weight: 600; font-size: 0.85rem; margin-bottom: 0.5rem;">Matched Policies</div>
-						{#each intent.decision.matched_policies as match}
-							<div style="font-size: 0.85rem; color: var(--text-muted);">
-								{match.explanation || match.rule_id} <span style="opacity: 0.5;">({match.policy_id})</span>
-							</div>
-						{/each}
+						{#if intent.action.domain?.payment}
+							<span class="text-muted-foreground">Vendor:</span>
+							<span>{intent.action.domain.payment.vendor_name || '-'}</span>
+							{#if intent.action.domain.payment.amount}
+								<span class="text-muted-foreground">Amount:</span>
+								<span>{(intent.action.domain.payment.amount.amount / 100).toFixed(2)} {intent.action.domain.payment.amount.currency}</span>
+							{/if}
+						{/if}
 					</div>
-				{/if}
-			</div>
+
+					{#if intent.decision.matched_policies?.length}
+						<div class="mt-4 border-t border-border pt-3">
+							<div class="font-semibold text-sm mb-2">Matched Policies</div>
+							{#each intent.decision.matched_policies as match}
+								<div class="text-sm text-muted-foreground">
+									{match.explanation || match.rule_id} <span class="opacity-50">({match.policy_id})</span>
+								</div>
+							{/each}
+						</div>
+					{/if}
+				</Card.Content>
+			</Card.Root>
 		{/if}
 
-		<!-- Approval metadata -->
-		<div style="border: 1px solid var(--border); border-radius: 8px; padding: 1rem; background: var(--bg-card); margin-bottom: 1rem;">
-			<div style="display: grid; grid-template-columns: 120px 1fr; gap: 0.5rem; font-size: 0.9rem;">
-				<span style="color: var(--text-muted);">ID:</span>
-				<span style="font-family: monospace; font-size: 0.85rem;">{approval.approval_id}</span>
-				<span style="color: var(--text-muted);">Intent:</span>
-				<span style="font-family: monospace; font-size: 0.85rem;">{approval.intent_id}</span>
-				<span style="color: var(--text-muted);">Requested:</span>
-				<span>{new Date(approval.requested_at).toLocaleString()}</span>
-				{#if approval.expires_at}
-					<span style="color: var(--text-muted);">Expires:</span>
-					<span>{new Date(approval.expires_at).toLocaleString()}</span>
-				{/if}
-				{#if approval.resolved_at}
-					<span style="color: var(--text-muted);">Resolved:</span>
-					<span>{new Date(approval.resolved_at).toLocaleString()}</span>
-				{/if}
-			</div>
-		</div>
-
-		<!-- Action buttons -->
-		{#if approval.status === 'pending'}
-			<div style="border: 1px solid var(--border); border-radius: 8px; padding: 1rem; background: var(--bg-card);">
-				<div style="font-weight: 600; margin-bottom: 0.75rem;">Action</div>
-				<div style="display: flex; gap: 0.75rem; align-items: flex-end;">
-					<button
-						onclick={handleApprove}
-						disabled={acting}
-						style="padding: 0.5rem 1.5rem; background: var(--green); color: #000; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; font-size: 0.9rem;"
-					>
-						{acting ? 'Processing...' : 'Approve'}
-					</button>
-					<div style="flex: 1; display: flex; gap: 0.5rem;">
-						<input
-							type="text"
-							bind:value={denyReason}
-							placeholder="Reason for denial..."
-							style="flex: 1; padding: 0.5rem; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.9rem;"
-						/>
-						<button
-							onclick={handleDeny}
-							disabled={acting}
-							style="padding: 0.5rem 1.5rem; background: var(--red); color: #fff; border: none; border-radius: 6px; font-weight: 600; cursor: pointer; font-size: 0.9rem;"
-						>
-							Deny
-						</button>
-					</div>
+		<Card.Root class="mb-4">
+			<Card.Content>
+				<div class="grid grid-cols-[120px_1fr] gap-2 text-sm">
+					<span class="text-muted-foreground">ID:</span>
+					<span class="font-mono text-sm">{approval.approval_id}</span>
+					<span class="text-muted-foreground">Intent:</span>
+					<span class="font-mono text-sm">{approval.intent_id}</span>
+					<span class="text-muted-foreground">Requested:</span>
+					<span>{new Date(approval.requested_at).toLocaleString()}</span>
+					{#if approval.expires_at}
+						<span class="text-muted-foreground">Expires:</span>
+						<span>{new Date(approval.expires_at).toLocaleString()}</span>
+					{/if}
+					{#if approval.resolved_at}
+						<span class="text-muted-foreground">Resolved:</span>
+						<span>{new Date(approval.resolved_at).toLocaleString()}</span>
+					{/if}
 				</div>
-			</div>
+			</Card.Content>
+		</Card.Root>
+
+		{#if approval.status === 'pending'}
+			<Card.Root>
+				<Card.Header>
+					<Card.Title>Action</Card.Title>
+				</Card.Header>
+				<Card.Content>
+					<div class="flex gap-3 items-end">
+						<Button
+							onclick={handleApprove}
+							disabled={acting}
+							class="bg-status-green text-black hover:bg-status-green/80"
+						>
+							{acting ? 'Processing...' : 'Approve'}
+						</Button>
+						<div class="flex-1 flex gap-2">
+							<Input
+								type="text"
+								bind:value={denyReason}
+								placeholder="Reason for denial..."
+								class="flex-1"
+							/>
+							<Button
+								variant="destructive"
+								onclick={handleDeny}
+								disabled={acting}
+							>
+								Deny
+							</Button>
+						</div>
+					</div>
+				</Card.Content>
+			</Card.Root>
 		{/if}
 
 		{#if actionResult}
-			<div style="margin-top: 0.75rem; padding: 0.75rem; border-radius: 6px; background: var(--bg-card); border: 1px solid var(--border); font-size: 0.9rem;">
-				{actionResult}
-			</div>
+			<Card.Root class="mt-3">
+				<Card.Content>
+					{actionResult}
+				</Card.Content>
+			</Card.Root>
 		{/if}
 	</div>
 {/if}

--- a/ui/src/routes/marketplace/+page.svelte
+++ b/ui/src/routes/marketplace/+page.svelte
@@ -1,6 +1,10 @@
 <script lang="ts">
 	import { searchMarketplace, installMarketplaceServer, setMCPServerCredential } from '$lib/api';
 	import { onMount } from 'svelte';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import { Badge } from '$lib/components/ui/badge';
 
 	function clickOutside(node: HTMLElement, callback: () => void) {
 		function handleClick(e: MouseEvent) {
@@ -92,125 +96,132 @@
 	<title>Marketplace - Aileron</title>
 </svelte:head>
 
-<h1 style="font-size: 1.3rem; margin-bottom: 1rem;">Marketplace</h1>
+<h1 class="text-xl font-semibold mb-4">Marketplace</h1>
 
-<input
+<Input
 	type="text"
 	placeholder="Search servers..."
 	bind:value={query}
 	oninput={handleInput}
-	style="width: 100%; padding: 0.6rem 0.75rem; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.9rem; margin-bottom: 1.5rem; box-sizing: border-box;"
+	class="mb-6"
 />
 
 {#if installResult}
-	<div style="padding: 1.25rem; border: 1px solid var(--accent); border-radius: 8px; background: var(--bg-card); margin-bottom: 1.5rem;">
-		<div style="font-weight: 600; margin-bottom: 0.75rem;">Configure Credentials for {installResult.server.name}</div>
-		<p style="font-size: 0.85rem; color: var(--text-muted); margin-bottom: 1rem;">This server requires credentials to function. You can configure them now or later from the server detail page.</p>
-		{#each installResult.required_credentials as cred}
-			<div style="margin-bottom: 0.75rem;">
-				<!-- svelte-ignore a11y_label_has_associated_control -->
-				<label style="display: block; font-size: 0.85rem; font-weight: 600; margin-bottom: 0.25rem;">
-					{cred.name}
-					{#if cred.required}<span style="color: var(--red);">*</span>{/if}
-				</label>
-				{#if cred.description}
-					<div style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.25rem;">{cred.description}</div>
-				{/if}
-				<input
-					type="password"
-					bind:value={credentialValues[cred.name]}
-					placeholder="Enter value..."
-					style="width: 100%; padding: 0.5rem 0.6rem; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.85rem; box-sizing: border-box;"
-				/>
+	<Card.Root class="mb-6 border-status-blue">
+		<Card.Header>
+			<Card.Title>Configure Credentials for {installResult.server.name}</Card.Title>
+			<Card.Description>This server requires credentials to function. You can configure them now or later from the server detail page.</Card.Description>
+		</Card.Header>
+		<Card.Content>
+			{#each installResult.required_credentials as cred}
+				<div class="mb-3">
+					<!-- svelte-ignore a11y_label_has_associated_control -->
+					<label class="block text-sm font-semibold mb-1">
+						{cred.name}
+						{#if cred.required}<span class="text-destructive">*</span>{/if}
+					</label>
+					{#if cred.description}
+						<div class="text-xs text-muted-foreground mb-1">{cred.description}</div>
+					{/if}
+					<Input
+						type="password"
+						bind:value={credentialValues[cred.name]}
+						placeholder="Enter value..."
+					/>
+				</div>
+			{/each}
+			{#if credError}
+				<p class="text-destructive text-sm mb-3">{credError}</p>
+			{/if}
+			<div class="flex gap-3 mt-2">
+				<Button
+					onclick={handleSaveCredentials}
+					disabled={credSaving}
+				>
+					{credSaving ? 'Saving...' : 'Save Credentials'}
+				</Button>
+				<Button
+					variant="outline"
+					onclick={handleSkipCredentials}
+				>
+					Skip for now
+				</Button>
 			</div>
-		{/each}
-		{#if credError}
-			<p style="color: var(--red); font-size: 0.85rem; margin-bottom: 0.75rem;">{credError}</p>
-		{/if}
-		<div style="display: flex; gap: 0.75rem; margin-top: 0.5rem;">
-			<button
-				onclick={handleSaveCredentials}
-				disabled={credSaving}
-				style="padding: 0.5rem 1rem; background: var(--accent); color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem;"
-			>
-				{credSaving ? 'Saving...' : 'Save Credentials'}
-			</button>
-			<button
-				onclick={handleSkipCredentials}
-				style="padding: 0.5rem 1rem; background: transparent; color: var(--text-muted); border: 1px solid var(--border); border-radius: 6px; cursor: pointer; font-size: 0.85rem;"
-			>
-				Skip for now
-			</button>
-		</div>
-	</div>
+		</Card.Content>
+	</Card.Root>
 {/if}
 
 {#if loading}
-	<p style="color: var(--text-muted);">Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p style="color: var(--red);">{error}</p>
+	<p class="text-destructive">{error}</p>
 {:else if servers.length === 0}
-	<p style="color: var(--text-muted);">No servers found.{query ? ' Try a different search.' : ''}</p>
+	<p class="text-muted-foreground">No servers found.{query ? ' Try a different search.' : ''}</p>
 {:else}
-	<div style="display: grid; grid-template-columns: repeat(auto-fill, minmax(280px, 1fr)); gap: 1rem;">
+	<div class="grid grid-cols-[repeat(auto-fill,minmax(280px,1fr))] gap-4">
 		{#each servers as server}
 			{@const versions = server.versions || []}
 			{@const latestVersion = versions[0]?.version}
 			{@const versionCount = versions.length}
-			<div style="padding: 1.25rem; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-card); display: flex; flex-direction: column; position: relative;">
-				<div style="font-weight: 600; margin-bottom: 0.25rem;">{server.name}</div>
-				{#if server.description}
-					<div style="font-size: 0.85rem; color: var(--text-muted); margin-bottom: 0.75rem; flex: 1;">{server.description}</div>
-				{/if}
-				<div style="display: flex; align-items: center; justify-content: space-between; margin-top: auto;">
-					<div>
-						{#if !server.installed && versionCount > 1}
-							<button
-								onclick={() => { expandedInstall = expandedInstall === server.registry_id ? null : server.registry_id; if (!selectedVersions[server.registry_id]) selectedVersions[server.registry_id] = versions[0].version; }}
-								style="padding: 0.35rem 0.7rem; background: transparent; color: var(--text-muted); border: 1px solid var(--border); border-radius: 6px; cursor: pointer; font-size: 0.8rem;"
+			<Card.Root class="relative flex flex-col">
+				<Card.Header class="flex-1">
+					<Card.Title>{server.name}</Card.Title>
+					{#if server.description}
+						<Card.Description>{server.description}</Card.Description>
+					{/if}
+				</Card.Header>
+				<Card.Content>
+					<div class="flex items-center justify-between">
+						<div>
+							{#if !server.installed && versionCount > 1}
+								<Button
+									variant="outline"
+									size="xs"
+									onclick={() => { expandedInstall = expandedInstall === server.registry_id ? null : server.registry_id; if (!selectedVersions[server.registry_id]) selectedVersions[server.registry_id] = versions[0].version; }}
+								>
+									Select version
+								</Button>
+							{/if}
+						</div>
+						{#if server.installed}
+							<Badge variant="outline" class="text-status-green border-status-green">Installed</Badge>
+						{:else}
+							<Button
+								size="sm"
+								onclick={() => handleInstall(server.registry_id)}
+								disabled={installing === server.registry_id}
 							>
-								Select version
-							</button>
+								{installing === server.registry_id ? 'Installing...' : `Install v${selectedVersions[server.registry_id] || latestVersion}`}
+							</Button>
 						{/if}
 					</div>
-					{#if server.installed}
-						<span style="color: var(--green); border: 1px solid var(--green); border-radius: 4px; padding: 0.2rem 0.6rem; font-size: 0.8rem; font-weight: 600;">Installed</span>
-					{:else}
-						<button
-							onclick={() => handleInstall(server.registry_id)}
-							disabled={installing === server.registry_id}
-							style="padding: 0.35rem 0.7rem; background: var(--accent); color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.8rem; font-weight: 600; white-space: nowrap;"
-						>
-							{installing === server.registry_id ? 'Installing...' : `Install v${selectedVersions[server.registry_id] || latestVersion}`}
-						</button>
-					{/if}
-				</div>
+				</Card.Content>
 				{#if expandedInstall === server.registry_id}
 					<!-- svelte-ignore a11y_no_static_element_interactions -->
-				<div
-					use:clickOutside={() => { expandedInstall = null; }}
-					style="position: absolute; left: 0; right: 0; bottom: 0; padding: 0.75rem 1.25rem 1.25rem; background: var(--bg-card); border: 1px solid var(--border); border-radius: 0 0 8px 8px; z-index: 10;"
-				>
-						<div style="display: flex; gap: 0.5rem; align-items: center;">
+					<div
+						use:clickOutside={() => { expandedInstall = null; }}
+						class="absolute left-0 right-0 bottom-0 px-4 pb-4 pt-3 bg-card border border-border rounded-b-xl z-10"
+					>
+						<div class="flex gap-2 items-center">
 							<select
 								bind:value={selectedVersions[server.registry_id]}
-								style="flex: 1; padding: 0.4rem 0.5rem; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.8rem;"
+								class="flex-1 h-8 rounded-lg border border-input bg-transparent px-2.5 py-1 text-sm text-foreground"
 							>
 								{#each versions as ver}
 									<option value={ver.version}>v{ver.version}</option>
 								{/each}
 							</select>
-							<button
+							<Button
+								size="sm"
 								onclick={() => handleInstall(server.registry_id)}
 								disabled={installing === server.registry_id}
-								style="padding: 0.4rem 0.75rem; background: var(--accent); color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.8rem; font-weight: 600; white-space: nowrap;"
 							>
 								Install
-							</button>
+							</Button>
 						</div>
 					</div>
 				{/if}
-			</div>
+			</Card.Root>
 		{/each}
 	</div>
 {/if}

--- a/ui/src/routes/policies/+page.svelte
+++ b/ui/src/routes/policies/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { listPolicies } from '$lib/api';
 	import { onMount } from 'svelte';
+	import { effectColor } from '$lib/colors';
+	import * as Card from '$lib/components/ui/card';
+	import { Badge } from '$lib/components/ui/badge';
 
 	let policies = $state<any[]>([]);
 	let loading = $state(true);
@@ -18,64 +21,58 @@
 	}
 
 	onMount(() => { load(); });
-
-	function effectColor(effect: string) {
-		switch (effect) {
-			case 'allow': return 'var(--green)';
-			case 'deny': return 'var(--red)';
-			case 'require_approval': return 'var(--yellow)';
-			case 'allow_with_modification': return 'var(--orange)';
-			default: return 'var(--text-muted)';
-		}
-	}
 </script>
 
 <svelte:head>
 	<title>Policies - Aileron</title>
 </svelte:head>
 
-<h1 style="font-size: 1.3rem; margin-bottom: 1rem;">Policies</h1>
+<h1 class="text-xl font-semibold mb-4">Policies</h1>
 
 {#if loading}
-	<p style="color: var(--text-muted);">Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p style="color: var(--red);">{error}</p>
+	<p class="text-destructive">{error}</p>
 {:else if policies.length === 0}
-	<p style="color: var(--text-muted);">No policies configured.</p>
+	<p class="text-muted-foreground">No policies configured.</p>
 {:else}
-	<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+	<div class="flex flex-col gap-3">
 		{#each policies as policy}
-			<div style="border: 1px solid var(--border); border-radius: 8px; padding: 1rem; background: var(--bg-card);">
-				<div style="display: flex; justify-content: space-between; align-items: center; margin-bottom: 0.75rem;">
-					<div style="font-weight: 600;">{policy.name}</div>
-					<span style="font-size: 0.8rem; color: var(--text-muted); text-transform: uppercase;">{policy.status}</span>
-				</div>
-				{#if policy.description}
-					<p style="font-size: 0.85rem; color: var(--text-muted); margin: 0 0 0.75rem;">{policy.description}</p>
-				{/if}
-				{#each policy.rules as rule}
-					<div style="padding: 0.5rem 0.75rem; margin-top: 0.5rem; border: 1px solid var(--border); border-radius: 6px; font-size: 0.85rem;">
-						<div style="display: flex; justify-content: space-between; align-items: center;">
-							<span style="color: {effectColor(rule.effect)}; font-weight: 600; text-transform: uppercase;">{rule.effect}</span>
-							{#if rule.priority != null}
-								<span style="color: var(--text-muted); font-size: 0.8rem;">Priority: {rule.priority}</span>
+			<Card.Root>
+				<Card.Header>
+					<div class="flex justify-between items-center">
+						<Card.Title>{policy.name}</Card.Title>
+						<span class="text-xs text-muted-foreground uppercase">{policy.status}</span>
+					</div>
+					{#if policy.description}
+						<Card.Description>{policy.description}</Card.Description>
+					{/if}
+				</Card.Header>
+				<Card.Content>
+					{#each policy.rules as rule}
+						<div class="px-3 py-2 mt-2 border border-border rounded-md text-sm">
+							<div class="flex justify-between items-center">
+								<span class="font-semibold uppercase" style="color: {effectColor(rule.effect)}">{rule.effect}</span>
+								{#if rule.priority != null}
+									<span class="text-muted-foreground text-xs">Priority: {rule.priority}</span>
+								{/if}
+							</div>
+							{#if rule.description}
+								<div class="text-muted-foreground mt-1">{rule.description}</div>
+							{/if}
+							{#if rule.conditions}
+								<div class="mt-2">
+									{#each rule.conditions as cond}
+										<div class="font-mono text-xs text-muted-foreground">
+											{cond.field} {cond.operator} {JSON.stringify(cond.value)}
+										</div>
+									{/each}
+								</div>
 							{/if}
 						</div>
-						{#if rule.description}
-							<div style="color: var(--text-muted); margin-top: 0.25rem;">{rule.description}</div>
-						{/if}
-						{#if rule.conditions}
-							<div style="margin-top: 0.5rem;">
-								{#each rule.conditions as cond}
-									<div style="font-family: monospace; font-size: 0.8rem; color: var(--text-muted);">
-										{cond.field} {cond.operator} {JSON.stringify(cond.value)}
-									</div>
-								{/each}
-							</div>
-						{/if}
-					</div>
-				{/each}
-			</div>
+					{/each}
+				</Card.Content>
+			</Card.Root>
 		{/each}
 	</div>
 {/if}

--- a/ui/src/routes/servers/+page.svelte
+++ b/ui/src/routes/servers/+page.svelte
@@ -1,6 +1,9 @@
 <script lang="ts">
 	import { listMCPServers, deleteMCPServer } from '$lib/api';
 	import { onMount } from 'svelte';
+	import { serverStatusColor, modeColor } from '$lib/colors';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
 
 	let servers = $state<any[]>([]);
 	let loading = $state(true);
@@ -24,18 +27,6 @@
 		return () => clearInterval(interval);
 	});
 
-	function statusColor(status: string) {
-		switch (status) {
-			case 'running': return 'var(--green)';
-			case 'error': return 'var(--red)';
-			default: return 'var(--text-muted)';
-		}
-	}
-
-	function modeColor(mode: string) {
-		return mode === 'remote' ? 'var(--orange)' : 'var(--accent)';
-	}
-
 	async function handleDelete(e: Event, id: string, name: string) {
 		e.preventDefault();
 		e.stopPropagation();
@@ -56,54 +47,61 @@
 	<title>Servers - Aileron</title>
 </svelte:head>
 
-<h1 style="font-size: 1.3rem; margin-bottom: 1rem;">Installed Servers</h1>
+<h1 class="text-xl font-semibold mb-4">Installed Servers</h1>
 
 {#if loading}
-	<p style="color: var(--text-muted);">Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p style="color: var(--red);">{error}</p>
+	<p class="text-destructive">{error}</p>
 {:else if servers.length === 0}
-	<p style="color: var(--text-muted);">No MCP servers installed. <a href="/marketplace" style="color: var(--accent);">Browse the marketplace</a> to get started.</p>
+	<p class="text-muted-foreground">No MCP servers installed. <a href="/marketplace" class="text-status-blue">Browse the marketplace</a> to get started.</p>
 {:else}
-	<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+	<div class="flex flex-col gap-3">
 		{#each servers as server}
-			<a href="/servers/{server.id}" style="display: block; padding: 1rem; border: 1px solid var(--border); border-radius: 8px; text-decoration: none; color: var(--text); background: var(--bg-card);">
-				<div style="display: flex; justify-content: space-between; align-items: center;">
-					<div>
-						<span style="font-weight: 600;">{server.name}</span>
-						{#if server.version}
-							<span style="font-size: 0.8rem; color: var(--text-muted); margin-left: 0.5rem;">v{server.version}</span>
+			<a href="/servers/{server.id}" class="no-underline text-foreground">
+				<Card.Root class="hover:bg-muted/50 transition-colors">
+					<Card.Header>
+						<div class="flex justify-between items-center">
+							<div>
+								<span class="font-semibold">{server.name}</span>
+								{#if server.version}
+									<span class="text-xs text-muted-foreground ml-2">v{server.version}</span>
+								{/if}
+							</div>
+							<div class="flex gap-2 items-center">
+								<span class="rounded border px-2 py-0.5 text-xs font-semibold uppercase" style="color: {serverStatusColor(server.status)}; border-color: {serverStatusColor(server.status)}">
+									{server.status || 'stopped'}
+								</span>
+								<span class="rounded border px-2 py-0.5 text-xs font-semibold uppercase" style="color: {modeColor(server.mode)}; border-color: {modeColor(server.mode)}">
+									{server.mode || 'local'}
+								</span>
+							</div>
+						</div>
+					</Card.Header>
+					<Card.Content>
+						{#if server.description}
+							<div class="text-sm text-muted-foreground mb-2">{server.description}</div>
 						{/if}
-					</div>
-					<div style="display: flex; gap: 0.5rem; align-items: center;">
-						<span style="color: {statusColor(server.status)}; border: 1px solid {statusColor(server.status)}; border-radius: 4px; padding: 0.15rem 0.5rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase;">
-							{server.status || 'stopped'}
-						</span>
-						<span style="color: {modeColor(server.mode)}; border: 1px solid {modeColor(server.mode)}; border-radius: 4px; padding: 0.15rem 0.5rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase;">
-							{server.mode || 'local'}
-						</span>
-					</div>
-				</div>
-				{#if server.description}
-					<div style="margin-top: 0.4rem; font-size: 0.85rem; color: var(--text-muted);">{server.description}</div>
-				{/if}
-				<div style="margin-top: 0.5rem; display: flex; justify-content: space-between; align-items: center; font-size: 0.8rem; color: var(--text-muted);">
-					<div>
-						{#if server.registry_id}
-							<span style="font-family: monospace;">From: {server.registry_id}</span>
-						{/if}
-						{#if server.created_at}
-							<span style="margin-left: 0.75rem;">Created: {new Date(server.created_at).toLocaleDateString()}</span>
-						{/if}
-					</div>
-					<button
-						onclick={(e) => handleDelete(e, server.id, server.name)}
-						disabled={deleting === server.id}
-						style="padding: 0.25rem 0.6rem; background: transparent; color: var(--red); border: 1px solid var(--red); border-radius: 4px; cursor: pointer; font-size: 0.75rem;"
-					>
-						{deleting === server.id ? 'Removing...' : 'Remove'}
-					</button>
-				</div>
+						<div class="flex justify-between items-center text-xs text-muted-foreground">
+							<div>
+								{#if server.registry_id}
+									<span class="font-mono">From: {server.registry_id}</span>
+								{/if}
+								{#if server.created_at}
+									<span class="ml-3">Created: {new Date(server.created_at).toLocaleDateString()}</span>
+								{/if}
+							</div>
+							<Button
+								variant="destructive"
+								size="xs"
+								onclick={(e: Event) => handleDelete(e, server.id, server.name)}
+								disabled={deleting === server.id}
+							>
+								{deleting === server.id ? 'Removing...' : 'Remove'}
+							</Button>
+						</div>
+					</Card.Content>
+				</Card.Root>
 			</a>
 		{/each}
 	</div>

--- a/ui/src/routes/servers/[id]/+page.svelte
+++ b/ui/src/routes/servers/[id]/+page.svelte
@@ -3,6 +3,10 @@
 	import { goto } from '$app/navigation';
 	import { getMCPServer, deleteMCPServer, setMCPServerCredential } from '$lib/api';
 	import { onMount } from 'svelte';
+	import { serverStatusColor, modeColor } from '$lib/colors';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
 
 	let server = $state<any>(null);
 	let loading = $state(true);
@@ -29,18 +33,6 @@
 	onMount(() => {
 		load();
 	});
-
-	function statusColor(status: string) {
-		switch (status) {
-			case 'running': return 'var(--green)';
-			case 'error': return 'var(--red)';
-			default: return 'var(--text-muted)';
-		}
-	}
-
-	function modeColor(mode: string) {
-		return mode === 'remote' ? 'var(--orange)' : 'var(--accent)';
-	}
 
 	async function handleSetCredential() {
 		if (!credEnvVar.trim() || !credValue.trim()) return;
@@ -76,137 +68,147 @@
 	<title>{server?.name || 'Server'} - Aileron</title>
 </svelte:head>
 
-<a href="/servers" style="color: var(--text-muted); text-decoration: none; font-size: 0.85rem;">&larr; Back to Servers</a>
+<a href="/servers" class="text-muted-foreground no-underline text-sm">&larr; Back to Servers</a>
 
 {#if loading}
-	<p style="color: var(--text-muted); margin-top: 1rem;">Loading...</p>
+	<p class="text-muted-foreground mt-4">Loading...</p>
 {:else if error}
-	<p style="color: var(--red); margin-top: 1rem;">{error}</p>
+	<p class="text-destructive mt-4">{error}</p>
 {:else if server}
-	<div style="display: flex; align-items: center; gap: 0.75rem; margin-top: 1rem; margin-bottom: 1.5rem;">
-		<h1 style="font-size: 1.3rem; margin: 0;">{server.name}</h1>
+	<div class="flex items-center gap-3 mt-4 mb-6">
+		<h1 class="text-xl font-semibold m-0">{server.name}</h1>
 		{#if server.version}
-			<span style="font-size: 0.85rem; color: var(--text-muted);">v{server.version}</span>
+			<span class="text-sm text-muted-foreground">v{server.version}</span>
 		{/if}
-		<span style="color: {statusColor(server.status)}; border: 1px solid {statusColor(server.status)}; border-radius: 4px; padding: 0.15rem 0.5rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase;">
+		<span class="rounded border px-2 py-0.5 text-xs font-semibold uppercase" style="color: {serverStatusColor(server.status)}; border-color: {serverStatusColor(server.status)}">
 			{server.status || 'stopped'}
 		</span>
-		<span style="color: {modeColor(server.mode)}; border: 1px solid {modeColor(server.mode)}; border-radius: 4px; padding: 0.15rem 0.5rem; font-size: 0.75rem; font-weight: 600; text-transform: uppercase;">
+		<span class="rounded border px-2 py-0.5 text-xs font-semibold uppercase" style="color: {modeColor(server.mode)}; border-color: {modeColor(server.mode)}">
 			{server.mode || 'local'}
 		</span>
 	</div>
 
-	<!-- Configuration -->
-	<div style="padding: 1rem; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-card); margin-bottom: 1rem;">
-		<div style="font-weight: 600; margin-bottom: 0.75rem;">Configuration</div>
-		<div style="display: grid; grid-template-columns: auto 1fr; gap: 0.4rem 1rem; font-size: 0.85rem;">
-			<span style="color: var(--text-muted);">ID</span>
-			<span style="font-family: monospace;">{server.id}</span>
+	<Card.Root class="mb-4">
+		<Card.Header>
+			<Card.Title>Configuration</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
+				<span class="text-muted-foreground">ID</span>
+				<span class="font-mono">{server.id}</span>
 
-			{#if server.description}
-				<span style="color: var(--text-muted);">Description</span>
-				<span>{server.description}</span>
-			{/if}
+				{#if server.description}
+					<span class="text-muted-foreground">Description</span>
+					<span>{server.description}</span>
+				{/if}
 
-			<span style="color: var(--text-muted);">Command</span>
-			<span style="font-family: monospace;">{(server.command || []).join(' ')}</span>
+				<span class="text-muted-foreground">Command</span>
+				<span class="font-mono">{(server.command || []).join(' ')}</span>
 
-			<span style="color: var(--text-muted);">Mode</span>
-			<span>{server.mode || 'local'}</span>
+				<span class="text-muted-foreground">Mode</span>
+				<span>{server.mode || 'local'}</span>
 
-			{#if server.version}
-				<span style="color: var(--text-muted);">Version</span>
-				<span>{server.version}</span>
-			{/if}
+				{#if server.version}
+					<span class="text-muted-foreground">Version</span>
+					<span>{server.version}</span>
+				{/if}
 
-			{#if server.registry_id}
-				<span style="color: var(--text-muted);">Registry ID</span>
-				<span style="font-family: monospace;">{server.registry_id}</span>
-			{/if}
+				{#if server.registry_id}
+					<span class="text-muted-foreground">Registry ID</span>
+					<span class="font-mono">{server.registry_id}</span>
+				{/if}
 
-			{#if server.policy_mapping?.tool_prefix}
-				<span style="color: var(--text-muted);">Tool Prefix</span>
-				<span style="font-family: monospace;">{server.policy_mapping.tool_prefix}</span>
-			{/if}
+				{#if server.policy_mapping?.tool_prefix}
+					<span class="text-muted-foreground">Tool Prefix</span>
+					<span class="font-mono">{server.policy_mapping.tool_prefix}</span>
+				{/if}
 
-			{#if server.created_at}
-				<span style="color: var(--text-muted);">Created</span>
-				<span>{new Date(server.created_at).toLocaleString()}</span>
-			{/if}
+				{#if server.created_at}
+					<span class="text-muted-foreground">Created</span>
+					<span>{new Date(server.created_at).toLocaleString()}</span>
+				{/if}
 
-			{#if server.updated_at}
-				<span style="color: var(--text-muted);">Updated</span>
-				<span>{new Date(server.updated_at).toLocaleString()}</span>
-			{/if}
-		</div>
-	</div>
-
-	<!-- Environment Variables -->
-	{#if server.env && Object.keys(server.env).length > 0}
-		<div style="padding: 1rem; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-card); margin-bottom: 1rem;">
-			<div style="font-weight: 600; margin-bottom: 0.75rem;">Environment Variables</div>
-			<div style="display: grid; grid-template-columns: auto 1fr; gap: 0.4rem 1rem; font-size: 0.85rem;">
-				{#each Object.entries(server.env) as [key, value]}
-					<span style="font-family: monospace;">{key}</span>
-					<span style="font-family: monospace; color: var(--text-muted);">
-						{#if typeof value === 'string' && value.startsWith('vault://')}
-							<span title={String(value)}>&#128274; vault-backed</span>
-						{:else}
-							{value || '(empty)'}
-						{/if}
-					</span>
-				{/each}
+				{#if server.updated_at}
+					<span class="text-muted-foreground">Updated</span>
+					<span>{new Date(server.updated_at).toLocaleString()}</span>
+				{/if}
 			</div>
-		</div>
+		</Card.Content>
+	</Card.Root>
+
+	{#if server.env && Object.keys(server.env).length > 0}
+		<Card.Root class="mb-4">
+			<Card.Header>
+				<Card.Title>Environment Variables</Card.Title>
+			</Card.Header>
+			<Card.Content>
+				<div class="grid grid-cols-[auto_1fr] gap-x-4 gap-y-1.5 text-sm">
+					{#each Object.entries(server.env) as [key, value]}
+						<span class="font-mono">{key}</span>
+						<span class="font-mono text-muted-foreground">
+							{#if typeof value === 'string' && value.startsWith('vault://')}
+								<span title={String(value)}>&#128274; vault-backed</span>
+							{:else}
+								{value || '(empty)'}
+							{/if}
+						</span>
+					{/each}
+				</div>
+			</Card.Content>
+		</Card.Root>
 	{/if}
 
-	<!-- Set Credential -->
-	<div style="padding: 1rem; border: 1px solid var(--border); border-radius: 8px; background: var(--bg-card); margin-bottom: 1rem;">
-		<div style="font-weight: 600; margin-bottom: 0.75rem;">Set Credential</div>
-		<p style="font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.75rem;">Store a secret in the vault for this server.</p>
-		<div style="display: flex; gap: 0.5rem; align-items: flex-end; flex-wrap: wrap;">
-			<div>
-				<label for="cred-env-var" style="display: block; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.2rem;">Env var name</label>
-				<input
-					id="cred-env-var"
-					type="text"
-					bind:value={credEnvVar}
-					placeholder="e.g. API_KEY"
-					style="padding: 0.45rem 0.6rem; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.85rem; font-family: monospace;"
-				/>
+	<Card.Root class="mb-4">
+		<Card.Header>
+			<Card.Title>Set Credential</Card.Title>
+			<Card.Description>Store a secret in the vault for this server.</Card.Description>
+		</Card.Header>
+		<Card.Content>
+			<div class="flex gap-2 items-end flex-wrap">
+				<div>
+					<label for="cred-env-var" class="block text-xs text-muted-foreground mb-1">Env var name</label>
+					<Input
+						id="cred-env-var"
+						type="text"
+						bind:value={credEnvVar}
+						placeholder="e.g. API_KEY"
+						class="font-mono"
+					/>
+				</div>
+				<div>
+					<label for="cred-secret" class="block text-xs text-muted-foreground mb-1">Secret value</label>
+					<Input
+						id="cred-secret"
+						type="password"
+						bind:value={credValue}
+						placeholder="Enter secret..."
+					/>
+				</div>
+				<Button
+					onclick={handleSetCredential}
+					disabled={credSaving}
+				>
+					{credSaving ? 'Saving...' : 'Save'}
+				</Button>
 			</div>
-			<div>
-				<label for="cred-secret" style="display: block; font-size: 0.8rem; color: var(--text-muted); margin-bottom: 0.2rem;">Secret value</label>
-				<input
-					id="cred-secret"
-					type="password"
-					bind:value={credValue}
-					placeholder="Enter secret..."
-					style="padding: 0.45rem 0.6rem; background: var(--bg); border: 1px solid var(--border); border-radius: 6px; color: var(--text); font-size: 0.85rem;"
-				/>
-			</div>
-			<button
-				onclick={handleSetCredential}
-				disabled={credSaving}
-				style="padding: 0.45rem 0.85rem; background: var(--accent); color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem;"
-			>
-				{credSaving ? 'Saving...' : 'Save'}
-			</button>
-		</div>
-		{#if credResult}
-			<p style="margin-top: 0.5rem; font-size: 0.8rem; color: {credResult.startsWith('Error') ? 'var(--red)' : 'var(--green)'};">{credResult}</p>
-		{/if}
-	</div>
+			{#if credResult}
+				<p class="mt-2 text-xs" style="color: {credResult.startsWith('Error') ? 'var(--color-status-red)' : 'var(--color-status-green)'}">{credResult}</p>
+			{/if}
+		</Card.Content>
+	</Card.Root>
 
-	<!-- Danger Zone -->
-	<div style="padding: 1rem; border: 1px solid var(--red); border-radius: 8px; background: var(--bg-card);">
-		<div style="font-weight: 600; margin-bottom: 0.5rem; color: var(--red);">Danger Zone</div>
-		<button
-			onclick={handleDelete}
-			disabled={deleting}
-			style="padding: 0.4rem 0.85rem; background: var(--red); color: #fff; border: none; border-radius: 6px; cursor: pointer; font-size: 0.85rem;"
-		>
-			{deleting ? 'Removing...' : 'Delete Server'}
-		</button>
-	</div>
+	<Card.Root class="border-destructive">
+		<Card.Header>
+			<Card.Title class="text-destructive">Danger Zone</Card.Title>
+		</Card.Header>
+		<Card.Content>
+			<Button
+				variant="destructive"
+				onclick={handleDelete}
+				disabled={deleting}
+			>
+				{deleting ? 'Removing...' : 'Delete Server'}
+			</Button>
+		</Card.Content>
+	</Card.Root>
 {/if}

--- a/ui/src/routes/traces/+page.svelte
+++ b/ui/src/routes/traces/+page.svelte
@@ -1,6 +1,8 @@
 <script lang="ts">
 	import { listTraces } from '$lib/api';
 	import { onMount } from 'svelte';
+	import { eventColor } from '$lib/colors';
+	import * as Card from '$lib/components/ui/card';
 
 	let traces = $state<any[]>([]);
 	let loading = $state(true);
@@ -23,67 +25,57 @@
 		const interval = setInterval(load, 5000);
 		return () => clearInterval(interval);
 	});
-
-	function eventColor(eventType: string) {
-		if (eventType.includes('submitted')) return 'var(--accent)';
-		if (eventType.includes('approved')) return 'var(--green)';
-		if (eventType.includes('denied')) return 'var(--red)';
-		if (eventType.includes('succeeded')) return 'var(--green)';
-		if (eventType.includes('failed')) return 'var(--red)';
-		if (eventType.includes('granted') || eventType.includes('issued')) return 'var(--green)';
-		return 'var(--text-muted)';
-	}
 </script>
 
 <svelte:head>
 	<title>Traces - Aileron</title>
 </svelte:head>
 
-<h1 style="font-size: 1.3rem; margin-bottom: 1rem;">Audit Traces</h1>
+<h1 class="text-xl font-semibold mb-4">Audit Traces</h1>
 
 {#if loading}
-	<p style="color: var(--text-muted);">Loading...</p>
+	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
-	<p style="color: var(--red);">{error}</p>
+	<p class="text-destructive">{error}</p>
 {:else if traces.length === 0}
-	<p style="color: var(--text-muted);">No traces yet.</p>
+	<p class="text-muted-foreground">No traces yet.</p>
 {:else}
-	<div style="display: flex; flex-direction: column; gap: 0.75rem;">
+	<div class="flex flex-col gap-3">
 		{#each traces as trace}
-			<div style="border: 1px solid var(--border); border-radius: 8px; background: var(--bg-card); overflow: hidden;">
+			<Card.Root class="overflow-hidden">
 				<button
 					onclick={() => expandedTrace = expandedTrace === trace.trace_id ? null : trace.trace_id}
-					style="width: 100%; padding: 1rem; background: none; border: none; color: var(--text); text-align: left; cursor: pointer; display: flex; justify-content: space-between; align-items: center;"
+					class="w-full px-4 py-3 bg-transparent border-none text-foreground text-left cursor-pointer flex justify-between items-center"
 				>
 					<div>
-						<span style="font-weight: 600; font-family: monospace; font-size: 0.85rem;">{trace.intent_id}</span>
-						<span style="color: var(--text-muted); margin-left: 0.5rem; font-size: 0.85rem;">{trace.events?.length || 0} events</span>
+						<span class="font-semibold font-mono text-sm">{trace.intent_id}</span>
+						<span class="text-muted-foreground ml-2 text-sm">{trace.events?.length || 0} events</span>
 					</div>
-					<span style="color: var(--text-muted);">{expandedTrace === trace.trace_id ? '−' : '+'}</span>
+					<span class="text-muted-foreground">{expandedTrace === trace.trace_id ? '\u2212' : '+'}</span>
 				</button>
 
 				{#if expandedTrace === trace.trace_id && trace.events}
-					<div style="border-top: 1px solid var(--border); padding: 1rem;">
+					<div class="border-t border-border px-4 py-3">
 						{#each trace.events as event, i}
-							<div style="display: flex; gap: 1rem; align-items: flex-start; padding: 0.5rem 0; {i > 0 ? 'border-top: 1px solid var(--border);' : ''}">
-								<div style="width: 6px; height: 6px; border-radius: 50%; background: {eventColor(event.event_type)}; margin-top: 0.45rem; flex-shrink: 0;"></div>
-								<div style="flex: 1; min-width: 0;">
-									<div style="display: flex; justify-content: space-between; align-items: baseline;">
-										<span style="font-weight: 600; font-size: 0.85rem; color: {eventColor(event.event_type)};">{event.event_type}</span>
-										<span style="font-size: 0.75rem; color: var(--text-muted);">{new Date(event.timestamp).toLocaleTimeString()}</span>
+							<div class="flex gap-4 items-start py-2 {i > 0 ? 'border-t border-border' : ''}">
+								<div class="w-1.5 h-1.5 rounded-full mt-[0.45rem] shrink-0" style="background: {eventColor(event.event_type)}"></div>
+								<div class="flex-1 min-w-0">
+									<div class="flex justify-between items-baseline">
+										<span class="font-semibold text-sm" style="color: {eventColor(event.event_type)}">{event.event_type}</span>
+										<span class="text-xs text-muted-foreground">{new Date(event.timestamp).toLocaleTimeString()}</span>
 									</div>
-									<div style="font-size: 0.8rem; color: var(--text-muted);">
+									<div class="text-xs text-muted-foreground">
 										{event.actor.type}: {event.actor.id}
 									</div>
 									{#if event.payload}
-										<pre style="font-size: 0.75rem; color: var(--text-muted); margin: 0.25rem 0 0; white-space: pre-wrap; word-break: break-all;">{JSON.stringify(event.payload, null, 2)}</pre>
+										<pre class="text-xs text-muted-foreground mt-1 whitespace-pre-wrap break-all">{JSON.stringify(event.payload, null, 2)}</pre>
 									{/if}
 								</div>
 							</div>
 						{/each}
 					</div>
 				{/if}
-			</div>
+			</Card.Root>
 		{/each}
 	</div>
 {/if}

--- a/ui/vite.config.ts
+++ b/ui/vite.config.ts
@@ -1,6 +1,7 @@
 import { sveltekit } from '@sveltejs/kit/vite';
+import tailwindcss from '@tailwindcss/vite';
 import { defineConfig } from 'vite';
 
 export default defineConfig({
-	plugins: [sveltekit()]
+	plugins: [tailwindcss(), sveltekit()]
 });


### PR DESCRIPTION
## Summary

- **Replace 203 inline `style` attributes** across all UI pages with Tailwind CSS v4 utility classes and shadcn-svelte components
- **Install Tailwind CSS v4** with native Vite plugin (zero PostCSS config) and **shadcn-svelte** component library (badge, button, card, input, select, collapsible)
- **Extract shared color utilities** (`approvalStatusColor`, `serverStatusColor`, `modeColor`, `riskColor`, `effectColor`, `eventColor`) into `src/lib/colors.ts`
- **Configure neutral dark theme** via shadcn design tokens in `app.css`, replacing the hand-rolled CSS custom properties

Only 11 `style=` attributes remain — all for dynamic data-driven color values (status badges, event indicators, risk levels) where Tailwind classes can't be used.

## Files changed

| Area | Files |
|------|-------|
| Config | `package.json`, `pnpm-lock.yaml`, `vite.config.ts`, `app.html`, `app.css`, `components.json` |
| New shared code | `src/lib/utils.ts`, `src/lib/colors.ts`, `src/lib/components/ui/*` |
| Refactored pages | `+layout.svelte`, `+page.svelte`, all 7 route pages |

## Test plan

- [ ] `pnpm run check` passes (0 errors, 0 warnings — verified)
- [ ] `pnpm run build` succeeds (verified)
- [ ] Visual inspection of all pages via `pnpm run dev`:
  - [ ] Home dashboard cards
  - [ ] Approvals list + detail (status badges, action buttons)
  - [ ] Traces (expandable accordion, event timeline)
  - [ ] Policies (rule cards, effect colors)
  - [ ] Marketplace (search, install flow, version selector, credential form)
  - [ ] Servers list + detail (status/mode badges, config grid, credential form, danger zone)

🤖 Generated with [Claude Code](https://claude.com/claude-code)