### PR TITLE
fix(auth): resolve Google OAuth callback 'Failed to fetch'

### DIFF
--- a/core/app/app_test.go
+++ b/core/app/app_test.go
@@ -205,14 +205,24 @@ func TestNewHandler_CORSHeaders(t *testing.T) {
 	srv := httptest.NewServer(handler)
 	defer srv.Close()
 
-	resp, err := http.Get(srv.URL + "/v1/health")
+	// CORS headers are only set when an Origin header is present.
+	req, err := http.NewRequest("GET", srv.URL+"/v1/health", nil)
+	if err != nil {
+		t.Fatalf("NewRequest: %v", err)
+	}
+	req.Header.Set("Origin", "https://app.withaileron.ai")
+
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("GET /v1/health: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "*" {
-		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "*")
+	if got := resp.Header.Get("Access-Control-Allow-Origin"); got != "https://app.withaileron.ai" {
+		t.Errorf("Access-Control-Allow-Origin = %q, want %q", got, "https://app.withaileron.ai")
+	}
+	if got := resp.Header.Get("Access-Control-Allow-Credentials"); got != "true" {
+		t.Errorf("Access-Control-Allow-Credentials = %q, want %q", got, "true")
 	}
 }
 

--- a/core/app/middleware.go
+++ b/core/app/middleware.go
@@ -71,14 +71,20 @@ func (w *statusWriter) Write(b []byte) (int, error) {
 	return w.ResponseWriter.Write(b)
 }
 
-// corsMiddleware adds permissive CORS headers for development. Production
-// deployments should restrict AllowedOrigins via configuration.
+// corsMiddleware adds CORS headers, echoing the request Origin so that
+// credentialed (cookie-based) requests work. The wildcard "*" is not
+// allowed when credentials: "include" is used by the browser.
 func corsMiddleware(next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		w.Header().Set("Access-Control-Allow-Origin", "*")
+		origin := r.Header.Get("Origin")
+		if origin != "" {
+			w.Header().Set("Access-Control-Allow-Origin", origin)
+			w.Header().Set("Access-Control-Allow-Credentials", "true")
+		}
 		w.Header().Set("Access-Control-Allow-Methods", "GET, POST, PATCH, DELETE, OPTIONS")
 		w.Header().Set("Access-Control-Allow-Headers", "Authorization, Content-Type, X-Request-ID")
 		w.Header().Set("Access-Control-Expose-Headers", "X-Request-ID")
+		w.Header().Set("Vary", "Origin")
 
 		if r.Method == http.MethodOptions {
 			w.WriteHeader(http.StatusNoContent)

--- a/core/auth/handler.go
+++ b/core/auth/handler.go
@@ -261,7 +261,8 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Set cookies for browser flow.
-	secure := r.TLS != nil
+	// Check both direct TLS and X-Forwarded-Proto (behind reverse proxy).
+	secure := r.TLS != nil || r.Header.Get("X-Forwarded-Proto") == "https"
 	http.SetCookie(w, &http.Cookie{
 		Name:     "access_token",
 		Value:    accessToken,

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -10,11 +10,11 @@ async function apiFetch(path: string, options?: RequestInit) {
 	};
 
 	const token = getToken();
-	if (token) {
+	if (token && token !== 'cookie-auth') {
 		headers['Authorization'] = `Bearer ${token}`;
 	}
 
-	let res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+	let res = await fetch(`${API_BASE}${path}`, { ...options, headers, credentials: 'include' });
 
 	// If unauthorized, attempt token refresh and retry once.
 	if (res.status === 401 && token) {
@@ -24,7 +24,7 @@ async function apiFetch(path: string, options?: RequestInit) {
 			if (newToken) {
 				headers['Authorization'] = `Bearer ${newToken}`;
 			}
-			res = await fetch(`${API_BASE}${path}`, { ...options, headers });
+			res = await fetch(`${API_BASE}${path}`, { ...options, headers, credentials: 'include' });
 		} else {
 			clearAuth();
 			if (typeof window !== 'undefined') {

--- a/ui/src/lib/auth.svelte.ts
+++ b/ui/src/lib/auth.svelte.ts
@@ -66,6 +66,7 @@ export async function refreshAuth(): Promise<boolean> {
 	try {
 		const res = await fetch(`${PUBLIC_API_BASE}/auth/refresh`, {
 			method: 'POST',
+			credentials: 'include',
 			headers: { 'Content-Type': 'application/json' },
 			body: JSON.stringify({ refresh_token: refreshToken })
 		});
@@ -85,8 +86,14 @@ export async function refreshAuth(): Promise<boolean> {
 
 /** Fetch the current user profile from /v1/users/me. */
 async function fetchCurrentUser() {
+	const headers: Record<string, string> = {};
+	// Use Bearer token for password-based auth; use cookies for OAuth flow.
+	if (_token && _token !== 'cookie-auth') {
+		headers['Authorization'] = `Bearer ${_token}`;
+	}
 	const res = await fetch(`${PUBLIC_API_BASE}/v1/users/me`, {
-		headers: { Authorization: `Bearer ${_token}` }
+		headers,
+		credentials: 'include'
 	});
 	if (!res.ok) throw new Error('Failed to fetch user');
 	_user = await res.json();


### PR DESCRIPTION
## Summary

- **CORS**: Replace wildcard `Access-Control-Allow-Origin: *` with echoed request `Origin` + `Access-Control-Allow-Credentials: true` so browsers allow credentialed (cookie) responses
- **Secure flag**: Check `X-Forwarded-Proto` header in addition to `r.TLS` so cookies get the `Secure` flag behind Railway's TLS-terminating proxy
- **Frontend credentials**: Add `credentials: 'include'` to all API fetch calls and skip sending the literal `"cookie-auth"` marker as a Bearer token

## Test plan

- [ ] Sign in with Google on `app.withaileron.ai` — callback should redirect to `/` instead of showing "Failed to fetch"
- [ ] Verify subsequent API calls (approvals list, marketplace, etc.) work after OAuth login
- [ ] Verify email/password login still works (Bearer token path unchanged)
- [ ] `go test ./core/app/... ./core/auth/...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)