### PR TITLE
ci: parallelize Docker build with lint and unit tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,7 +103,7 @@ jobs:
 
   build:
     name: Build Docker Images
-    needs: [generate, lint, test]
+    needs: generate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -146,7 +146,7 @@ jobs:
 
   integration:
     name: Integration Tests
-    needs: build
+    needs: [build, lint, test]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
## Summary

- Changed the `build` job's `needs` from `[generate, lint, test]` to just `generate`, allowing Docker image builds to run in parallel with lint and unit test jobs.
- Changed the `integration` job's `needs` from `build` to `[build, lint, test]`, ensuring all quality gates still pass before integration tests run.
- This reduces CI pipeline wall time while maintaining the same overall guarantees.

## Test plan

- [ ] Verify CI pipeline runs successfully on this PR
- [ ] Confirm `build` job starts as soon as `generate` completes (does not wait for `lint`/`test`)
- [ ] Confirm `integration` job waits for all three: `build`, `lint`, and `test`
- [ ] Verify overall pipeline still fails if any of `lint`, `test`, or `build` fails

🤖 Generated with [Claude Code](https://claude.com/claude-code)