### PR TITLE
feat(auth): derive OAuth callback URL dynamically from request host

### DIFF
--- a/README.md
+++ b/README.md
@@ -336,7 +336,7 @@ When `AILERON_DATABASE_URL` is set, the server enables:
 | `AILERON_UI_REDIRECT_URL` | No | `/` | Redirect destination after successful login |
 | `GOOGLE_CLIENT_ID` | No | | Google OAuth 2.0 client ID |
 | `GOOGLE_CLIENT_SECRET` | No | | Google OAuth 2.0 client secret |
-| `GOOGLE_REDIRECT_URL` | No | | OAuth callback URL (e.g. `https://api.example.com/auth/google/callback`) |
+| `GOOGLE_REDIRECT_URL` | No | _(derived from request)_ | OAuth callback URL override (e.g. `https://api.example.com/auth/google/callback`). When unset, the callback URL is derived dynamically from the incoming request host, enabling OAuth to work on branch deployments without manual configuration. |
 
 ## Deployment
 
@@ -357,7 +357,6 @@ To customize, edit `deploy/.env` (gitignored). For example, to enable Google OAu
 AILERON_JWT_SIGNING_KEY=local-dev-signing-key-not-for-production
 GOOGLE_CLIENT_ID=your-client-id
 GOOGLE_CLIENT_SECRET=your-client-secret
-GOOGLE_REDIRECT_URL=http://localhost:8080/auth/google/callback
 ```
 
 Verification codes are printed to the server log (dev mailer). To also enable Google OAuth:
@@ -365,7 +364,6 @@ Verification codes are printed to the server log (dev mailer). To also enable Go
 ```sh
 export GOOGLE_CLIENT_ID="your-client-id"
 export GOOGLE_CLIENT_SECRET="your-client-secret"
-export GOOGLE_REDIRECT_URL="http://localhost:8080/auth/google/callback"
 ```
 
 ### Cloud (Provider-Agnostic)
@@ -394,8 +392,8 @@ Aileron is a standard Docker container with no infrastructure-specific assumptio
    AILERON_JWT_SIGNING_KEY=<random-32-char-string>
    GOOGLE_CLIENT_ID=<from-google-cloud-console>
    GOOGLE_CLIENT_SECRET=<from-google-cloud-console>
-   GOOGLE_REDIRECT_URL=https://api.yourdomain.com/auth/google/callback
    ```
+   `GOOGLE_REDIRECT_URL` is optional. When omitted, the OAuth callback URL is derived from the request host automatically. Set it explicitly only if the server is behind a reverse proxy that obscures the public hostname.
 
 4. **Deploy the container.** The entrypoint automatically runs Atlas schema migrations against `AILERON_DATABASE_URL` before starting the server. Migrations are declarative and idempotent — safe to run on every deploy.
 
@@ -422,13 +420,15 @@ Aileron is currently hosted on [Railway](https://railway.com). The server servic
    | `AILERON_JWT_SIGNING_KEY` | Generate with `openssl rand -hex 32` |
    | `GOOGLE_CLIENT_ID` | From Google Cloud Console |
    | `GOOGLE_CLIENT_SECRET` | From Google Cloud Console |
-   | `GOOGLE_REDIRECT_URL` | `https://<your-server-domain>.railway.app/auth/google/callback` |
+
+   `GOOGLE_REDIRECT_URL` is **not required** on Railway. The callback URL is derived automatically from the request host, so Google OAuth works on both the production domain and branch deployments without any per-branch configuration.
 
 3. **Deploy** — push to the branch Railway is watching. The Dockerfile builds the image, and on startup the entrypoint applies schema migrations automatically.
 
 4. **Google OAuth setup** — in the [Google Cloud Console](https://console.cloud.google.com/apis/credentials):
    - Create an OAuth 2.0 Client ID (Web application type)
-   - Add `https://<your-server-domain>.railway.app/auth/google/callback` as an authorized redirect URI
+   - Add `https://<your-production-domain>.railway.app/auth/google/callback` as an authorized redirect URI
+   - For branch deployments, add the branch URL (e.g. `https://<branch-name>.railway.app/auth/google/callback`) as an additional authorized redirect URI — the callback URL is derived from the request host automatically, so no env var changes are needed per branch
    - Copy the client ID and secret into the Railway variables above
 
 ## Architecture Principles

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -153,7 +153,6 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			authRegistry.Register(googleauth.New(
 				authCfg.GoogleClientID,
 				authCfg.GoogleClientSecret,
-				authCfg.GoogleRedirectURL,
 			))
 			log.Info("registered Google OAuth provider")
 		}
@@ -174,6 +173,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			Mailer:            mailer,
 			NewID:             idGen,
 			UIRedirect:        authCfg.UIRedirectURL,
+			OAuthRedirectURL:  authCfg.GoogleRedirectURL,
 			RefreshTTL:        authCfg.RefreshTokenTTL,
 			AutoVerifyEmail:   authCfg.AutoVerifyEmail,
 		})

--- a/core/auth/google/provider.go
+++ b/core/auth/google/provider.go
@@ -21,20 +21,30 @@ const userinfoURL = "https://www.googleapis.com/oauth2/v3/userinfo"
 
 // Provider implements auth.AuthProvider for Google OAuth 2.0.
 type Provider struct {
-	cfg *oauth2.Config
+	clientID     string
+	clientSecret string
+	endpoint     oauth2.Endpoint
 }
 
 // New creates a Google OAuth provider with the given credentials.
-// redirectURL is the callback URL (e.g. "https://app.example.com/auth/google/callback").
-func New(clientID, clientSecret, redirectURL string) *Provider {
+// The redirect URL is supplied per-request via AuthorizationURL and HandleCallback,
+// allowing it to be derived dynamically from the incoming request host.
+func New(clientID, clientSecret string) *Provider {
 	return &Provider{
-		cfg: &oauth2.Config{
-			ClientID:     clientID,
-			ClientSecret: clientSecret,
-			RedirectURL:  redirectURL,
-			Endpoint:     google.Endpoint,
-			Scopes:       []string{"openid", "email", "profile"},
-		},
+		clientID:     clientID,
+		clientSecret: clientSecret,
+		endpoint:     google.Endpoint,
+	}
+}
+
+// newConfig builds an oauth2.Config for a single request using the given redirectURL.
+func (p *Provider) newConfig(redirectURL string) *oauth2.Config {
+	return &oauth2.Config{
+		ClientID:     p.clientID,
+		ClientSecret: p.clientSecret,
+		RedirectURL:  redirectURL,
+		Endpoint:     p.endpoint,
+		Scopes:       []string{"openid", "email", "profile"},
 	}
 }
 
@@ -42,19 +52,22 @@ func New(clientID, clientSecret, redirectURL string) *Provider {
 func (p *Provider) Provider() string { return "google" }
 
 // AuthorizationURL returns the Google OAuth consent URL.
-func (p *Provider) AuthorizationURL(_ context.Context, state string) (string, error) {
-	url := p.cfg.AuthCodeURL(state, oauth2.AccessTypeOffline)
+// redirectURL must be the callback URL registered in the Google Cloud Console
+// (or match the dynamic URL derived from the request host).
+func (p *Provider) AuthorizationURL(_ context.Context, state, redirectURL string) (string, error) {
+	url := p.newConfig(redirectURL).AuthCodeURL(state, oauth2.AccessTypeOffline)
 	return url, nil
 }
 
 // HandleCallback exchanges the authorization code for user identity.
 func (p *Provider) HandleCallback(ctx context.Context, req auth.CallbackRequest) (*auth.Identity, error) {
-	token, err := p.cfg.Exchange(ctx, req.Code)
+	cfg := p.newConfig(req.RedirectURL)
+	token, err := cfg.Exchange(ctx, req.Code)
 	if err != nil {
 		return nil, fmt.Errorf("exchanging code: %w", err)
 	}
 
-	client := p.cfg.Client(ctx, token)
+	client := cfg.Client(ctx, token)
 	resp, err := client.Get(userinfoURL)
 	if err != nil {
 		return nil, fmt.Errorf("fetching userinfo: %w", err)

--- a/core/auth/google/provider_test.go
+++ b/core/auth/google/provider_test.go
@@ -13,15 +13,15 @@ import (
 )
 
 func TestProvider_Provider(t *testing.T) {
-	p := New("id", "secret", "https://example.com/callback")
+	p := New("id", "secret")
 	if p.Provider() != "google" {
 		t.Errorf("Provider() = %q, want google", p.Provider())
 	}
 }
 
 func TestProvider_AuthorizationURL(t *testing.T) {
-	p := New("my-client-id", "my-secret", "https://example.com/callback")
-	url, err := p.AuthorizationURL(context.Background(), "test-state-123")
+	p := New("my-client-id", "my-secret")
+	url, err := p.AuthorizationURL(context.Background(), "test-state-123", "https://example.com/callback")
 	if err != nil {
 		t.Fatalf("AuthorizationURL: %v", err)
 	}
@@ -73,29 +73,12 @@ func TestProvider_HandleCallback_Success(t *testing.T) {
 	defer userinfoServer.Close()
 
 	p := &Provider{
-		cfg: &oauth2.Config{
-			ClientID:     "test-client",
-			ClientSecret: "test-secret",
-			Endpoint: oauth2.Endpoint{
-				TokenURL: tokenServer.URL,
-			},
+		clientID:     "test-client",
+		clientSecret: "test-secret",
+		endpoint: oauth2.Endpoint{
+			TokenURL: tokenServer.URL,
 		},
 	}
-
-	// Override the userinfo URL for this test.
-	origURL := userinfoURL
-	// We can't override the const, so we'll use a custom approach:
-	// create the provider with a custom HTTP client that redirects
-	// userinfo requests to our fake server. Actually, the simpler
-	// approach is to test using the provider's internals.
-	// Let's just test the full flow by having the token server
-	// return a token, then manually calling the userinfo endpoint.
-
-	// Actually, HandleCallback calls p.cfg.Client(ctx, token).Get(userinfoURL)
-	// which goes to the real Google URL. We need to intercept that.
-	// The cleanest way: override the HTTP transport.
-
-	_ = origURL // we'll use a different approach
 
 	// Create a transport that routes userinfo requests to our fake server.
 	transport := &fakeTransport{
@@ -108,8 +91,9 @@ func TestProvider_HandleCallback_Success(t *testing.T) {
 	})
 
 	identity, err := p.HandleCallback(ctx, auth.CallbackRequest{
-		Code:  "fake-auth-code",
-		State: "test-state",
+		Code:        "fake-auth-code",
+		State:       "test-state",
+		RedirectURL: "https://example.com/callback",
 	})
 	if err != nil {
 		t.Fatalf("HandleCallback: %v", err)
@@ -143,12 +127,10 @@ func TestProvider_HandleCallback_TokenExchangeError(t *testing.T) {
 	defer tokenServer.Close()
 
 	p := &Provider{
-		cfg: &oauth2.Config{
-			ClientID:     "test-client",
-			ClientSecret: "test-secret",
-			Endpoint: oauth2.Endpoint{
-				TokenURL: tokenServer.URL,
-			},
+		clientID:     "test-client",
+		clientSecret: "test-secret",
+		endpoint: oauth2.Endpoint{
+			TokenURL: tokenServer.URL,
 		},
 	}
 
@@ -181,12 +163,10 @@ func TestProvider_HandleCallback_UserinfoError(t *testing.T) {
 	defer userinfoServer.Close()
 
 	p := &Provider{
-		cfg: &oauth2.Config{
-			ClientID:     "test-client",
-			ClientSecret: "test-secret",
-			Endpoint: oauth2.Endpoint{
-				TokenURL: tokenServer.URL,
-			},
+		clientID:     "test-client",
+		clientSecret: "test-secret",
+		endpoint: oauth2.Endpoint{
+			TokenURL: tokenServer.URL,
 		},
 	}
 

--- a/core/auth/handler.go
+++ b/core/auth/handler.go
@@ -28,6 +28,7 @@ type Handler struct {
 	mailer            Mailer
 	newID             func() string
 	uiRedirect        string // URL to redirect to after successful auth
+	oauthRedirectURL  string // optional override for OAuth callback URL
 	refreshTTL        time.Duration
 	verificationTTL   time.Duration
 	autoVerifyEmail   bool
@@ -49,6 +50,11 @@ type HandlerConfig struct {
 	AutoVerifyEmail   bool          // skip email verification (dev/CI only)
 	RefreshTTL        time.Duration // e.g. 7 * 24 * time.Hour
 	VerificationTTL   time.Duration // e.g. 15 * time.Minute
+	// OAuthRedirectURL is an optional override for the OAuth callback URL
+	// (e.g. "https://api.example.com/auth/google/callback"). When empty, the
+	// callback URL is derived dynamically from the incoming request host.
+	// Corresponds to the GOOGLE_REDIRECT_URL environment variable.
+	OAuthRedirectURL string
 }
 
 // NewHandler creates an auth handler.
@@ -74,6 +80,7 @@ func NewHandler(cfg HandlerConfig) *Handler {
 		mailer:            cfg.Mailer,
 		newID:             cfg.NewID,
 		uiRedirect:        cfg.UIRedirect,
+		oauthRedirectURL:  cfg.OAuthRedirectURL,
 		refreshTTL:        cfg.RefreshTTL,
 		verificationTTL:   cfg.VerificationTTL,
 		autoVerifyEmail:   cfg.AutoVerifyEmail,
@@ -117,7 +124,7 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 		Secure:   r.TLS != nil,
 	})
 
-	url, err := provider.AuthorizationURL(r.Context(), state)
+	url, err := provider.AuthorizationURL(r.Context(), state, h.callbackURL(r, providerName))
 	if err != nil {
 		h.log.Error("failed to generate auth URL", "error", err)
 		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
@@ -125,6 +132,26 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	}
 
 	http.Redirect(w, r, url, http.StatusTemporaryRedirect)
+}
+
+// callbackURL returns the OAuth callback URL for the given provider.
+// If OAuthRedirectURL is configured it is returned as-is (useful for
+// production deployments with a custom domain). Otherwise the URL is
+// derived from the incoming request so that branch deployments (e.g. on
+// Railway) work without any manual configuration.
+func (h *Handler) callbackURL(r *http.Request, provider string) string {
+	if h.oauthRedirectURL != "" {
+		return h.oauthRedirectURL
+	}
+	scheme := "https"
+	if r.TLS == nil && r.Header.Get("X-Forwarded-Proto") != "https" {
+		scheme = "http"
+	}
+	host := r.Host
+	if fwdHost := r.Header.Get("X-Forwarded-Host"); fwdHost != "" {
+		host = fwdHost
+	}
+	return fmt.Sprintf("%s://%s/auth/%s/callback", scheme, host, provider)
 }
 
 // handleCallback processes the OAuth callback and creates a session.
@@ -163,8 +190,9 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 
 	// Exchange code for identity.
 	identity, err := provider.HandleCallback(r.Context(), CallbackRequest{
-		Code:  r.URL.Query().Get("code"),
-		State: stateCookie.Value,
+		Code:        r.URL.Query().Get("code"),
+		State:       stateCookie.Value,
+		RedirectURL: h.callbackURL(r, providerName),
 	})
 	if err != nil {
 		h.log.Error("callback exchange failed", "provider", providerName, "error", err)

--- a/core/auth/handler_oauth_test.go
+++ b/core/auth/handler_oauth_test.go
@@ -19,7 +19,7 @@ type fakeProvider struct {
 
 func (f *fakeProvider) Provider() string { return f.name }
 
-func (f *fakeProvider) AuthorizationURL(_ context.Context, state string) (string, error) {
+func (f *fakeProvider) AuthorizationURL(_ context.Context, state, _ string) (string, error) {
 	return "https://fake-provider.example.com/auth?state=" + state, nil
 }
 

--- a/core/auth/handler_test.go
+++ b/core/auth/handler_test.go
@@ -1,6 +1,82 @@
 package auth
 
-import "testing"
+import (
+	"net/http/httptest"
+	"testing"
+)
+
+func TestCallbackURL_Dynamic(t *testing.T) {
+	h := &Handler{} // no override set
+
+	tests := []struct {
+		name     string
+		host     string
+		fwdProto string
+		fwdHost  string
+		provider string
+		want     string
+	}{
+		{
+			name:     "http request derives http callback",
+			host:     "localhost:8080",
+			provider: "google",
+			want:     "http://localhost:8080/auth/google/callback",
+		},
+		{
+			name:     "X-Forwarded-Proto https upgrades scheme",
+			host:     "localhost:8080",
+			fwdProto: "https",
+			provider: "google",
+			want:     "https://localhost:8080/auth/google/callback",
+		},
+		{
+			name:     "X-Forwarded-Host overrides host",
+			host:     "internal:8080",
+			fwdProto: "https",
+			fwdHost:  "feat-foo-up.railway.app",
+			provider: "google",
+			want:     "https://feat-foo-up.railway.app/auth/google/callback",
+		},
+		{
+			name:     "provider name included in path",
+			host:     "api.example.com",
+			fwdProto: "https",
+			provider: "okta",
+			want:     "https://api.example.com/auth/okta/callback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			r := httptest.NewRequest("GET", "/auth/"+tt.provider+"/login", nil)
+			r.Host = tt.host
+			if tt.fwdProto != "" {
+				r.Header.Set("X-Forwarded-Proto", tt.fwdProto)
+			}
+			if tt.fwdHost != "" {
+				r.Header.Set("X-Forwarded-Host", tt.fwdHost)
+			}
+			got := h.callbackURL(r, tt.provider)
+			if got != tt.want {
+				t.Errorf("callbackURL = %q, want %q", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCallbackURL_Override(t *testing.T) {
+	override := "https://api.example.com/auth/google/callback"
+	h := &Handler{oauthRedirectURL: override}
+
+	r := httptest.NewRequest("GET", "/auth/google/login", nil)
+	r.Host = "some-branch.railway.app"
+	r.Header.Set("X-Forwarded-Proto", "https")
+
+	got := h.callbackURL(r, "google")
+	if got != override {
+		t.Errorf("callbackURL = %q, want override %q", got, override)
+	}
+}
 
 func TestIsPersonalEmail(t *testing.T) {
 	tests := []struct {

--- a/core/auth/spi.go
+++ b/core/auth/spi.go
@@ -25,8 +25,9 @@ type AuthProvider interface {
 
 	// AuthorizationURL returns the URL to redirect the user to for login.
 	// The state parameter is an opaque CSRF token that must be echoed back
-	// in the callback.
-	AuthorizationURL(ctx context.Context, state string) (string, error)
+	// in the callback. redirectURL is the callback URL the provider should
+	// redirect to after authentication.
+	AuthorizationURL(ctx context.Context, state, redirectURL string) (string, error)
 
 	// HandleCallback exchanges the authorization code from the IdP callback
 	// for a resolved user identity.
@@ -35,8 +36,9 @@ type AuthProvider interface {
 
 // CallbackRequest contains the data from the OAuth/OIDC callback.
 type CallbackRequest struct {
-	Code  string
-	State string
+	Code        string
+	State       string
+	RedirectURL string // must match the redirectURL used in AuthorizationURL
 }
 
 // Identity is the authenticated user identity returned by a provider.


### PR DESCRIPTION
Closes #31

Derives the OAuth callback URL at runtime from the incoming request host, enabling Google OAuth to work on Railway branch deployments without manual env var changes. `GOOGLE_REDIRECT_URL` is retained as an optional override for production custom domains.

Generated with [Claude Code](https://claude.ai/code)