### PR TITLE
docs: remove auth subdomain, consolidate OAuth to api subdomain

### DIFF
--- a/README.md
+++ b/README.md
@@ -479,15 +479,14 @@ Add custom domains in each service's **Settings → Networking → Custom Domain
 | Domain | Railway Service | DNS Record |
 |--------|----------------|------------|
 | `api.withaileron.ai` | server | CNAME → Railway target |
-| `auth.withaileron.ai` | server | CNAME → Railway target |
 | `app.withaileron.ai` | ui | CNAME → Railway target |
 
 #### 4. Register OAuth callback URLs
 
-Register the production auth domain with each provider:
+Register the API domain with each provider:
 
-- **Google:** `https://auth.withaileron.ai/auth/google/callback`
-- **GitHub:** `https://auth.withaileron.ai/auth/github/callback`
+- **Google:** `https://api.withaileron.ai/auth/google/callback`
+- **GitHub:** `https://api.withaileron.ai/auth/github/callback`
 
 #### 5. Deploy
 
@@ -498,8 +497,6 @@ Push to the branch Railway is watching. The Dockerfile builds the image, and on 
 ```sh
 curl https://api.withaileron.ai/v1/health
 ```
-
-To verify the OAuth relay flow on a branch deploy, open the branch deployment URL and initiate sign-in.
 
 ## Architecture Principles
 

--- a/docs/adr/0006-stable-oauth-callback-domain.md
+++ b/docs/adr/0006-stable-oauth-callback-domain.md
@@ -1,6 +1,6 @@
 # ADR-0006: Stable OAuth Callback Domain for Branch Deployments
 
-**Status:** Accepted
+**Status:** Superseded by [ADR-0007](0007-remove-stable-oauth-callback-domain.md)
 **Date:** 2026-04-03
 **Supersedes:** ADR-0005 (specifically the "Removal of OAuthRedirectURL override" decision)
 

--- a/docs/adr/0007-remove-stable-oauth-callback-domain.md
+++ b/docs/adr/0007-remove-stable-oauth-callback-domain.md
@@ -1,0 +1,29 @@
+# ADR-0007: Remove Stable OAuth Callback Domain
+
+**Status:** Accepted
+**Date:** 2026-04-03
+**Supersedes:** ADR-0006
+
+## Context
+
+ADR-0006 introduced a stable `auth.withaileron.ai` subdomain to serve as an OAuth callback relay for Railway branch deployments. This allowed branch deploys with unpredictable hostnames to complete OAuth flows through a single registered redirect URI.
+
+In practice, this added significant complexity (state encoding, relay redirects, trusted origins validation) for a feature that didn't work reliably with Railway's generated hostnames. The relay mechanism was removed in commit 83ee28d, and branch deploy users authenticate via email/password instead.
+
+With the relay removed, the `auth.withaileron.ai` subdomain serves no purpose — it points to the same Railway service as `api.withaileron.ai` and has no distinct routing behavior.
+
+## Decision
+
+Remove the `auth.withaileron.ai` subdomain entirely. All API and auth traffic uses `api.withaileron.ai`. OAuth callback URLs registered with providers become:
+
+- **Google:** `https://api.withaileron.ai/auth/google/callback`
+- **GitHub:** `https://api.withaileron.ai/auth/github/callback`
+
+The callback URL derivation in `callbackURL()` remains fully dynamic from the incoming request host — no configuration needed.
+
+## Consequences
+
+- One fewer DNS record and Railway custom domain to maintain.
+- OAuth provider consoles reference the same domain as the API.
+- Branch deployments continue to work for non-OAuth auth (email/password).
+- The `AILERON_OAUTH_CALLBACK_BASE_URL` and `AILERON_TRUSTED_ORIGINS` env vars (already removed in code) are no longer documented.


### PR DESCRIPTION
## Summary
- Remove `auth.withaileron.ai` subdomain from README domain table and OAuth callback URLs
- Update OAuth callback URLs to use `api.withaileron.ai`
- Mark ADR-0006 (stable OAuth callback domain) as superseded
- Add ADR-0007 documenting the removal

## Infrastructure changes (manual)
- Google Cloud Console: redirect URI → `https://api.withaileron.ai/auth/google/callback`
- GitHub OAuth app: redirect URI → `https://api.withaileron.ai/auth/github/callback`
- Railway: remove `auth.withaileron.ai` custom domain from server service
- Railway: update `AILERON_UI_REDIRECT_URL` → `https://app.withaileron.ai/auth/callback`
- Cloudflare: delete `auth.withaileron.ai` DNS record

## Test plan
- [x] Google OAuth sign-in works in production after provider console + env var updates

🤖 Generated with [Claude Code](https://claude.com/claude-code)