### PR TITLE
feat(auth): add ResendMailer for transactional email delivery

### DIFF
--- a/README.md
+++ b/README.md
@@ -345,7 +345,7 @@ GITHUB_OAUTH_CLIENT_ID=your-github-client-id
 GITHUB_OAUTH_CLIENT_SECRET=your-github-client-secret
 ```
 
-Verification codes for email/password signup are printed to the server log (dev mailer). Each OAuth provider is independently optional — configure whichever you need.
+Verification codes for email/password signup are printed to the server log when `RESEND_API_KEY` is not set (dev mode). To send real emails, add `RESEND_API_KEY` (and optionally `MAIL_FROM`) to your `.env`. Each OAuth provider is independently optional — configure whichever you need.
 
 ### Cloud
 
@@ -387,6 +387,8 @@ Each service needs a domain or URL. The auth domain points to the **server** ser
 | `GOOGLE_CLIENT_SECRET` | No | | Google OAuth 2.0 client secret |
 | `GITHUB_OAUTH_CLIENT_ID` | No | | GitHub OAuth 2.0 client ID |
 | `GITHUB_OAUTH_CLIENT_SECRET` | No | | GitHub OAuth 2.0 client secret |
+| `RESEND_API_KEY` | No | | [Resend](https://resend.com) API key. When set, verification emails are delivered via Resend. When unset, codes are printed to the log (dev/CI mode). |
+| `MAIL_FROM` | No | `noreply@withaileron.ai` | Sender address for transactional emails (requires `RESEND_API_KEY`) |
 
 **UI service:**
 

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -181,7 +181,17 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 
 		enforcer := auth.NewStoreEnforcer(enterpriseStore)
 
-		mailer := auth.NewLogMailer(log)
+		var mailer auth.Mailer
+		if authCfg.ResendEnabled() {
+			mailer = auth.NewResendMailer(auth.ResendMailerConfig{
+				APIKey: authCfg.ResendAPIKey,
+				From:   authCfg.MailFrom,
+			})
+			log.Info("email delivery via Resend", "from", authCfg.MailFrom)
+		} else {
+			mailer = auth.NewLogMailer(log)
+			log.Warn("RESEND_API_KEY not set — verification codes will be printed to the log (dev mode)")
+		}
 
 		authHandler := auth.NewHandler(auth.HandlerConfig{
 			Log:               log,

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -181,17 +181,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 
 		enforcer := auth.NewStoreEnforcer(enterpriseStore)
 
-		var mailer auth.Mailer
-		if authCfg.ResendEnabled() {
-			mailer = auth.NewResendMailer(auth.ResendMailerConfig{
-				APIKey: authCfg.ResendAPIKey,
-				From:   authCfg.MailFrom,
-			})
-			log.Info("email delivery via Resend", "from", authCfg.MailFrom)
-		} else {
-			mailer = auth.NewLogMailer(log)
-			log.Warn("RESEND_API_KEY not set — verification codes will be printed to the log (dev mode)")
-		}
+		mailer := newMailer(log, authCfg)
 
 		authHandler := auth.NewHandler(auth.HandlerConfig{
 			Log:               log,
@@ -222,4 +212,18 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	handler = corsMiddleware(handler)
 
 	return handler, nil
+}
+
+// newMailer returns a ResendMailer when a Resend API key is configured,
+// otherwise a LogMailer for development/CI.
+func newMailer(log *slog.Logger, cfg *config.AuthConfig) auth.Mailer {
+	if cfg.ResendEnabled() {
+		log.Info("email delivery via Resend", "from", cfg.MailFrom)
+		return auth.NewResendMailer(auth.ResendMailerConfig{
+			APIKey: cfg.ResendAPIKey,
+			From:   cfg.MailFrom,
+		})
+	}
+	log.Warn("RESEND_API_KEY not set — verification codes will be printed to the log (dev mode)")
+	return auth.NewLogMailer(log)
 }

--- a/core/app/app_test.go
+++ b/core/app/app_test.go
@@ -8,6 +8,9 @@ import (
 	"net/http/httptest"
 	"strings"
 	"testing"
+
+	"github.com/ALRubinger/aileron/core/auth"
+	"github.com/ALRubinger/aileron/core/config"
 )
 
 func newTestHandler(t *testing.T) http.Handler {
@@ -253,5 +256,28 @@ func TestNewHandler_RequestIDMiddleware(t *testing.T) {
 
 	if got := resp2.Header.Get("X-Request-ID"); got != "my-request-id" {
 		t.Errorf("X-Request-ID = %q, want %q", got, "my-request-id")
+	}
+}
+
+func TestNewMailer_Resend(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	cfg := &config.AuthConfig{
+		ResendAPIKey: "re_test_key",
+		MailFrom:     "hello@example.com",
+	}
+
+	m := newMailer(log, cfg)
+	if _, ok := m.(*auth.ResendMailer); !ok {
+		t.Errorf("expected *auth.ResendMailer, got %T", m)
+	}
+}
+
+func TestNewMailer_LogFallback(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	cfg := &config.AuthConfig{}
+
+	m := newMailer(log, cfg)
+	if _, ok := m.(*auth.LogMailer); !ok {
+		t.Errorf("expected *auth.LogMailer, got %T", m)
 	}
 }

--- a/core/auth/mailer.go
+++ b/core/auth/mailer.go
@@ -1,12 +1,16 @@
 package auth
 
 import (
+	"bytes"
 	"context"
+	"encoding/json"
+	"fmt"
 	"log/slog"
+	"net/http"
 )
 
 // Mailer sends transactional emails. Implementations may delegate to
-// Mailgun, AWS SES, SendGrid, SMTP, etc. The built-in LogMailer prints
+// Resend, AWS SES, SendGrid, SMTP, etc. The built-in LogMailer prints
 // to the server log for development.
 type Mailer interface {
 	// SendVerificationCode sends an email with the verification code.
@@ -28,5 +32,83 @@ func (m *LogMailer) SendVerificationCode(_ context.Context, to string, code stri
 		"to", to,
 		"code", code,
 	)
+	return nil
+}
+
+// ResendMailer sends transactional emails via the Resend REST API.
+type ResendMailer struct {
+	apiKey     string
+	from       string
+	httpClient *http.Client
+}
+
+// ResendMailerConfig holds configuration for constructing a ResendMailer.
+type ResendMailerConfig struct {
+	// APIKey is the Resend API key. Required.
+	// Env: RESEND_API_KEY
+	APIKey string
+	// From is the sender email address shown to recipients.
+	// Env: MAIL_FROM (default: "noreply@withaileron.ai")
+	From string
+	// HTTPClient is an optional custom HTTP client. Defaults to http.DefaultClient.
+	HTTPClient *http.Client
+}
+
+// NewResendMailer returns a Mailer that sends emails via Resend.
+func NewResendMailer(cfg ResendMailerConfig) *ResendMailer {
+	hc := cfg.HTTPClient
+	if hc == nil {
+		hc = http.DefaultClient
+	}
+	from := cfg.From
+	if from == "" {
+		from = "noreply@withaileron.ai"
+	}
+	return &ResendMailer{
+		apiKey:     cfg.APIKey,
+		from:       from,
+		httpClient: hc,
+	}
+}
+
+// SendVerificationCode sends a verification code email via the Resend API.
+func (m *ResendMailer) SendVerificationCode(ctx context.Context, to string, code string) error {
+	body := map[string]any{
+		"from":    m.from,
+		"to":      []string{to},
+		"subject": "Your Aileron verification code",
+		"html": fmt.Sprintf(
+			`<p>Your Aileron verification code is: <strong>%s</strong></p>`+
+				`<p>This code expires in 15 minutes.</p>`,
+			code,
+		),
+	}
+
+	payload, err := json.Marshal(body)
+	if err != nil {
+		return fmt.Errorf("resend: marshal request: %w", err)
+	}
+
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, "https://api.resend.com/emails", bytes.NewReader(payload))
+	if err != nil {
+		return fmt.Errorf("resend: create request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+m.apiKey)
+	req.Header.Set("Content-Type", "application/json")
+
+	resp, err := m.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("resend: send request: %w", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		var errBody struct {
+			Message string `json:"message"`
+		}
+		_ = json.NewDecoder(resp.Body).Decode(&errBody)
+		return fmt.Errorf("resend: unexpected status %d: %s", resp.StatusCode, errBody.Message)
+	}
+
 	return nil
 }

--- a/core/auth/mailer_test.go
+++ b/core/auth/mailer_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -131,6 +132,25 @@ func TestResendMailer_SendVerificationCode_ErrorResponse(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for non-2xx response")
 	}
+}
+
+func TestResendMailer_SendVerificationCode_NetworkError(t *testing.T) {
+	mailer := NewResendMailer(ResendMailerConfig{
+		APIKey: "re_test",
+		HTTPClient: &http.Client{Transport: &failingTransport{}},
+	})
+
+	err := mailer.SendVerificationCode(context.Background(), "bob@example.com", "123456")
+	if err == nil {
+		t.Fatal("expected error for network failure")
+	}
+}
+
+// failingTransport always returns a connection error.
+type failingTransport struct{}
+
+func (t *failingTransport) RoundTrip(*http.Request) (*http.Response, error) {
+	return nil, fmt.Errorf("connection refused")
 }
 
 // hostOverrideTransport rewrites requests targeting `replace` to `target`.

--- a/core/auth/mailer_test.go
+++ b/core/auth/mailer_test.go
@@ -3,7 +3,10 @@ package auth
 import (
 	"bytes"
 	"context"
+	"encoding/json"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 )
 
@@ -31,4 +34,111 @@ func TestLogMailer_SendVerificationCode(t *testing.T) {
 
 func TestLogMailer_ImplementsMailer(t *testing.T) {
 	var _ Mailer = NewLogMailer(slog.Default())
+}
+
+func TestResendMailer_ImplementsMailer(t *testing.T) {
+	var _ Mailer = NewResendMailer(ResendMailerConfig{APIKey: "re_test"})
+}
+
+func TestResendMailer_SendVerificationCode(t *testing.T) {
+	var gotReq struct {
+		From    string   `json:"from"`
+		To      []string `json:"to"`
+		Subject string   `json:"subject"`
+		HTML    string   `json:"html"`
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		if auth := r.Header.Get("Authorization"); auth != "Bearer re_testkey" {
+			t.Errorf("unexpected Authorization header: %s", auth)
+		}
+		if ct := r.Header.Get("Content-Type"); ct != "application/json" {
+			t.Errorf("unexpected Content-Type: %s", ct)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotReq); err != nil {
+			t.Errorf("decode body: %v", err)
+		}
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"id":"abc123"}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	// Point the mailer at the fake server by using a custom HTTP client
+	// with a transport that rewrites the host.
+	transport := &hostOverrideTransport{
+		base:    http.DefaultTransport,
+		target:  srv.URL,
+		replace: "https://api.resend.com",
+	}
+	mailer := NewResendMailer(ResendMailerConfig{
+		APIKey:     "re_testkey",
+		From:       "test@example.com",
+		HTTPClient: &http.Client{Transport: transport},
+	})
+
+	if err := mailer.SendVerificationCode(context.Background(), "bob@example.com", "654321"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if gotReq.From != "test@example.com" {
+		t.Errorf("from: got %q, want %q", gotReq.From, "test@example.com")
+	}
+	if len(gotReq.To) != 1 || gotReq.To[0] != "bob@example.com" {
+		t.Errorf("to: got %v, want [bob@example.com]", gotReq.To)
+	}
+	if gotReq.Subject == "" {
+		t.Error("subject should not be empty")
+	}
+	if gotReq.HTML == "" {
+		t.Error("html body should not be empty")
+	}
+}
+
+func TestResendMailer_SendVerificationCode_ErrorResponse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"message":"Invalid API key"}`)) //nolint:errcheck
+	}))
+	defer srv.Close()
+
+	transport := &hostOverrideTransport{
+		base:    http.DefaultTransport,
+		target:  srv.URL,
+		replace: "https://api.resend.com",
+	}
+	mailer := NewResendMailer(ResendMailerConfig{
+		APIKey:     "bad_key",
+		HTTPClient: &http.Client{Transport: transport},
+	})
+
+	err := mailer.SendVerificationCode(context.Background(), "bob@example.com", "000000")
+	if err == nil {
+		t.Fatal("expected error for non-2xx response")
+	}
+}
+
+// hostOverrideTransport rewrites requests targeting `replace` to `target`.
+type hostOverrideTransport struct {
+	base    http.RoundTripper
+	target  string // e.g. "http://127.0.0.1:PORT"
+	replace string // e.g. "https://api.resend.com"
+}
+
+func (t *hostOverrideTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	cloned := req.Clone(req.Context())
+	url := cloned.URL.String()
+	if len(url) >= len(t.replace) && url[:len(t.replace)] == t.replace {
+		cloned.URL.Scheme = "http"
+		cloned.URL.Host = req.URL.Host
+		// parse target host
+		parsed, err := http.NewRequest(http.MethodGet, t.target, nil)
+		if err == nil {
+			cloned.URL.Host = parsed.URL.Host
+			cloned.URL.Scheme = parsed.URL.Scheme
+		}
+	}
+	return t.base.RoundTrip(cloned)
 }

--- a/core/auth/mailer_test.go
+++ b/core/auth/mailer_test.go
@@ -40,6 +40,19 @@ func TestResendMailer_ImplementsMailer(t *testing.T) {
 	var _ Mailer = NewResendMailer(ResendMailerConfig{APIKey: "re_test"})
 }
 
+func TestNewResendMailer_Defaults(t *testing.T) {
+	m := NewResendMailer(ResendMailerConfig{APIKey: "re_test"})
+	if m.from != "noreply@withaileron.ai" {
+		t.Errorf("from = %q, want noreply@withaileron.ai", m.from)
+	}
+	if m.httpClient != http.DefaultClient {
+		t.Error("expected default http client when none provided")
+	}
+	if m.apiKey != "re_test" {
+		t.Errorf("apiKey = %q, want re_test", m.apiKey)
+	}
+}
+
 func TestResendMailer_SendVerificationCode(t *testing.T) {
 	var gotReq struct {
 		From    string   `json:"from"`

--- a/core/config/auth.go
+++ b/core/config/auth.go
@@ -46,6 +46,15 @@ type AuthConfig struct {
 	// GitHub OAuth configuration.
 	GitHubClientID     string // Env: GITHUB_OAUTH_CLIENT_ID
 	GitHubClientSecret string // Env: GITHUB_OAUTH_CLIENT_SECRET
+
+	// Resend email configuration.
+	// ResendAPIKey enables real email sending via Resend. When set, ResendMailer
+	// is used; otherwise LogMailer is used (prints to log, safe for dev/CI).
+	// Env: RESEND_API_KEY
+	ResendAPIKey string
+	// MailFrom is the sender address for outgoing emails.
+	// Env: MAIL_FROM (default: "noreply@withaileron.ai")
+	MailFrom string
 }
 
 // LoadAuthConfig loads auth configuration from environment variables.
@@ -62,6 +71,8 @@ func LoadAuthConfig() (*AuthConfig, error) {
 		GoogleClientSecret:   os.Getenv("GOOGLE_CLIENT_SECRET"),
 		GitHubClientID:     os.Getenv("GITHUB_OAUTH_CLIENT_ID"),
 		GitHubClientSecret: os.Getenv("GITHUB_OAUTH_CLIENT_SECRET"),
+		ResendAPIKey:       os.Getenv("RESEND_API_KEY"),
+		MailFrom:           envOrDefault("MAIL_FROM", "noreply@withaileron.ai"),
 	}
 
 	// Parse durations with defaults.
@@ -101,6 +112,11 @@ func (c *AuthConfig) GoogleEnabled() bool {
 // GitHubEnabled reports whether GitHub OAuth is configured.
 func (c *AuthConfig) GitHubEnabled() bool {
 	return c.GitHubClientID != "" && c.GitHubClientSecret != ""
+}
+
+// ResendEnabled reports whether Resend email delivery is configured.
+func (c *AuthConfig) ResendEnabled() bool {
+	return c.ResendAPIKey != ""
 }
 
 func envOrDefault(key, def string) string {

--- a/core/config/auth_test.go
+++ b/core/config/auth_test.go
@@ -159,3 +159,49 @@ func TestLoadAuthConfig_GitHubDisabled(t *testing.T) {
 		t.Error("expected GitHub disabled when credentials missing")
 	}
 }
+
+func TestLoadAuthConfig_ResendEnabled(t *testing.T) {
+	t.Setenv("AILERON_DATABASE_URL", "")
+	t.Setenv("RESEND_API_KEY", "re_test_key")
+	t.Setenv("MAIL_FROM", "hello@example.com")
+
+	cfg, err := LoadAuthConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !cfg.ResendEnabled() {
+		t.Error("expected Resend enabled")
+	}
+	if cfg.ResendAPIKey != "re_test_key" {
+		t.Errorf("ResendAPIKey = %q", cfg.ResendAPIKey)
+	}
+	if cfg.MailFrom != "hello@example.com" {
+		t.Errorf("MailFrom = %q, want hello@example.com", cfg.MailFrom)
+	}
+}
+
+func TestLoadAuthConfig_ResendDisabled(t *testing.T) {
+	t.Setenv("AILERON_DATABASE_URL", "")
+	t.Setenv("RESEND_API_KEY", "")
+
+	cfg, err := LoadAuthConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.ResendEnabled() {
+		t.Error("expected Resend disabled when API key missing")
+	}
+}
+
+func TestLoadAuthConfig_MailFromDefault(t *testing.T) {
+	t.Setenv("AILERON_DATABASE_URL", "")
+	t.Setenv("MAIL_FROM", "")
+
+	cfg, err := LoadAuthConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.MailFrom != "noreply@withaileron.ai" {
+		t.Errorf("MailFrom = %q, want noreply@withaileron.ai", cfg.MailFrom)
+	}
+}


### PR DESCRIPTION
Fixes #40

Add ResendMailer using the Resend REST API so verification codes are emailed to users on signup. When RESEND_API_KEY is set, ResendMailer is used; otherwise LogMailer is retained for dev/CI with a warning logged.

Generated with [Claude Code](https://claude.ai/code)) | [`claude/issue-40-20260406-0844`](https://github.com/ALRubinger/aileron/tree/claude/issue-40-20260406-0844) | [View job run](https://github.com/ALRubinger/aileron/actions/runs/24025284320