### PR TITLE
feat(ci): instrument integration tests for CodeCov coverage

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,7 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
           slug: ALRubinger/aileron
+          flags: unit
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
@@ -151,8 +152,11 @@ jobs:
     steps:
       - uses: actions/checkout@v5
 
-      - name: Start full stack
-        run: docker compose -f deploy/docker-compose.yml up -d --build --wait
+      - name: Create coverage directory for server-side coverage collection
+        run: mkdir -p gocoverdir && chmod 777 gocoverdir
+
+      - name: Start full stack with coverage-instrumented server
+        run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml up -d --build --wait
         timeout-minutes: 5
         env:
           AILERON_DATABASE_URL: postgres://aileron:aileron@postgres:5432/aileron?sslmode=disable
@@ -170,7 +174,7 @@ jobs:
             sleep 3
           done
           echo "Server did not become healthy"
-          docker compose -f deploy/docker-compose.yml logs
+          docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml logs
           exit 1
 
       - name: Wait for healthy UI
@@ -202,6 +206,23 @@ jobs:
           AILERON_API_URL: http://localhost:8080
           AILERON_UI_URL: http://localhost:3000
 
+      - name: Stop server to flush coverage data
+        if: ${{ !cancelled() }}
+        run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml stop server
+
+      - name: Convert server coverage to text format
+        if: ${{ !cancelled() }}
+        run: go tool covdata textfmt -i=gocoverdir -o=coverage-integration.txt
+
+      - name: Upload integration coverage to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/codecov-action@v5
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ALRubinger/aileron
+          files: coverage-integration.txt
+          flags: integration
+
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}
         uses: codecov/test-results-action@v1
@@ -211,8 +232,8 @@ jobs:
 
       - name: Dump logs on failure
         if: failure()
-        run: docker compose -f deploy/docker-compose.yml logs
+        run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml logs
 
       - name: Tear down
         if: always()
-        run: docker compose -f deploy/docker-compose.yml down -v
+        run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml down -v

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -138,6 +138,19 @@ tasks:
       AILERON_API_URL: http://localhost:8080
       AILERON_UI_URL: http://localhost:3000
 
+  test:integration:coverage:
+    desc: Start a coverage-instrumented stack, run integration tests, and emit coverage-integration.txt
+    cmds:
+      - mkdir -p gocoverdir && chmod 777 gocoverdir
+      - docker compose -f {{.COMPOSE_FILE}} -f deploy/docker-compose.coverage.yml up -d --build --wait
+      - go test -tags=integration -race ./test/integration/...
+      - docker compose -f {{.COMPOSE_FILE}} -f deploy/docker-compose.coverage.yml stop server
+      - go tool covdata textfmt -i=gocoverdir -o=coverage-integration.txt
+      - docker compose -f {{.COMPOSE_FILE}} -f deploy/docker-compose.coverage.yml down -v
+    env:
+      AILERON_API_URL: http://localhost:8080
+      AILERON_UI_URL: http://localhost:3000
+
   ci:
     desc: Run the full CI pipeline locally
     cmds:

--- a/codecov.yml
+++ b/codecov.yml
@@ -4,9 +4,22 @@ coverage:
       default:
         target: auto
         threshold: 1%
+        after_n_builds: 2
     patch:
       default:
         target: 80%
+        after_n_builds: 2
+
+flags:
+  unit:
+    paths:
+      - core/
+      - sdk/go/
+    carryforward: false
+  integration:
+    paths:
+      - core/
+    carryforward: false
 
 ignore:
   - "core/api/gen/**"   # generated code (oapi-codegen) — DO NOT EDIT

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -14,7 +14,14 @@ RUN cd core && go mod download
 COPY core/ ./core/
 COPY sdk/go/ ./sdk/go/
 
-RUN cd core && go build -o /aileron-server ./server
+# COVERAGE=true builds with Go -cover instrumentation for integration test coverage.
+# The resulting binary writes coverage data to $GOCOVERDIR on exit.
+ARG COVERAGE=false
+RUN if [ "$COVERAGE" = "true" ]; then \
+    cd core && go build -cover -o /aileron-server ./server; \
+  else \
+    cd core && go build -o /aileron-server ./server; \
+  fi
 
 FROM alpine:3.20
 
@@ -28,6 +35,9 @@ RUN apk add --no-cache curl && \
 COPY --from=builder /aileron-server /usr/local/bin/aileron-server
 COPY core/schema/schema.hcl /schema/schema.hcl
 COPY core/server/entrypoint.sh /usr/local/bin/entrypoint.sh
+
+# Create output directory for coverage-instrumented builds (used when COVERAGE=true).
+RUN mkdir -p /tmp/gocoverdir && chown aileron:aileron /tmp/gocoverdir
 
 USER aileron
 

--- a/deploy/docker-compose.coverage.yml
+++ b/deploy/docker-compose.coverage.yml
@@ -1,0 +1,25 @@
+# Coverage override for docker-compose.yml.
+#
+# Builds the server with Go's -cover instrumentation so that integration tests
+# capture server-side coverage. The binary writes coverage data to GOCOVERDIR
+# on graceful shutdown; the bind mount makes that data available on the host.
+#
+# Usage:
+#   mkdir -p gocoverdir && chmod 777 gocoverdir
+#   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml up -d --build --wait
+#   # ... run integration tests ...
+#   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml stop server
+#   go tool covdata textfmt -i=gocoverdir -o=coverage-integration.txt
+#   docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml down -v
+
+services:
+  server:
+    build:
+      args:
+        COVERAGE: "true"
+    environment:
+      GOCOVERDIR: /tmp/gocoverdir
+    volumes:
+      - type: bind
+        source: ../gocoverdir
+        target: /tmp/gocoverdir


### PR DESCRIPTION
## Summary
- Build server with Go `-cover` instrumentation during CI integration tests, stop gracefully to flush coverage data, convert to text format, and upload to Codecov with `integration` flag
- Add `flags: unit` to unit test coverage upload and define `unit`/`integration` flag definitions in `codecov.yml`
- Add `after_n_builds: 2` so Codecov waits for both uploads before posting status checks
- Add `test:integration:coverage` task to Taskfile for local reproduction

## Test plan
- [ ] CI unit test job uploads coverage with `flags: unit`
- [ ] CI integration job builds coverage-instrumented server, runs tests, stops server, converts and uploads coverage with `flags: integration`
- [ ] Codecov PR comment shows both unit and integration flag breakdowns
- [ ] Codecov status checks wait for both uploads before reporting

Closes #46

🤖 Generated with [Claude Code](https://claude.ai/claude-code)