### PR TITLE
feat(launch): wire env scrubbing from aileron.yaml into buildEnv

### DIFF
--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -13,6 +13,7 @@ import (
 	"syscall"
 
 	"github.com/ALRubinger/aileron/core/audit"
+	launchpolicy "github.com/ALRubinger/aileron/core/policy/launch"
 	"github.com/creack/pty/v2"
 	"golang.org/x/term"
 )
@@ -84,8 +85,9 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 
 	sessionID := generateSessionID()
 	auditLog := resolveAuditLog(config.Dir)
+	envConfig := loadEnvConfig(config.Dir)
 
-	env := buildEnv(config.ShellShim, wrapperPath, config.Agent.Name(), sessionID, auditLog, config.Agent.Env())
+	env := buildEnv(config.ShellShim, wrapperPath, config.Agent.Name(), sessionID, auditLog, envConfig, config.Agent.Env())
 
 	// Agent-required args come first, then user-supplied args.
 	allArgs := append(config.Agent.Args(), config.Args...)
@@ -248,7 +250,7 @@ func exitResult(err error) (LaunchResult, error) {
 //   - Sets CLAUDE_CODE_SHELL to the wrapper path (whose name contains "bash")
 //   - Sets AILERON_REAL_SHELL to the original SHELL value
 //   - Merges any agent-specific env vars
-func buildEnv(shimPath, wrapperPath, agentName, sessionID, auditLog string, agentEnv map[string]string) []string {
+func buildEnv(shimPath, wrapperPath, agentName, sessionID, auditLog string, envConfig *launchpolicy.EnvConfig, agentEnv map[string]string) []string {
 	origShell := os.Getenv("SHELL")
 	if origShell == "" {
 		origShell = "/bin/sh"
@@ -283,7 +285,11 @@ func buildEnv(shimPath, wrapperPath, agentName, sessionID, auditLog string, agen
 			filtered = append(filtered, e)
 			continue
 		}
-		if managed[e[:eqIdx]] {
+		key := e[:eqIdx]
+		if managed[key] {
+			continue
+		}
+		if shouldScrub(key, envConfig) {
 			continue
 		}
 		filtered = append(filtered, e)
@@ -388,4 +394,55 @@ func PrintSessionSummary(w io.Writer, auditPath, sessionID string) {
 	if userDenied > 0 {
 		fmt.Fprintf(w, "  %d command(s) denied by user\n", userDenied)
 	}
+}
+
+// loadEnvConfig loads the merged policy's EnvConfig for env scrubbing.
+func loadEnvConfig(dir string) *launchpolicy.EnvConfig {
+	if dir == "" {
+		dir, _ = os.Getwd()
+	}
+	policyPath := FindPolicyFile(dir)
+	if policyPath == "" {
+		return nil
+	}
+	pf := loadPolicyFileFrom(policyPath)
+	return pf.Env
+}
+
+// shouldScrub returns true if the env var key matches a scrub pattern
+// and is not in the passthrough list.
+func shouldScrub(key string, cfg *launchpolicy.EnvConfig) bool {
+	if cfg == nil {
+		return false
+	}
+	// Passthrough beats scrub.
+	for _, p := range cfg.Passthrough {
+		if envGlobMatch(p, key) {
+			return false
+		}
+	}
+	for _, s := range cfg.Scrub {
+		if envGlobMatch(s, key) {
+			return true
+		}
+	}
+	return false
+}
+
+// envGlobMatch matches an env var name against a pattern with * wildcards.
+// Supports prefix (AWS_*), suffix (*_SECRET), and exact match.
+func envGlobMatch(pattern, name string) bool {
+	if pattern == "*" {
+		return true
+	}
+	if strings.HasPrefix(pattern, "*") && strings.HasSuffix(pattern, "*") {
+		return strings.Contains(name, pattern[1:len(pattern)-1])
+	}
+	if strings.HasPrefix(pattern, "*") {
+		return strings.HasSuffix(name, pattern[1:])
+	}
+	if strings.HasSuffix(pattern, "*") {
+		return strings.HasPrefix(name, pattern[:len(pattern)-1])
+	}
+	return pattern == name
 }

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -327,6 +327,92 @@ func TestInstallWrapper_ReadOnlyDir(t *testing.T) {
 	}
 }
 
+func TestLaunch_EnvScrubbing(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// Set env vars that should be scrubbed.
+	t.Setenv("AWS_SECRET_KEY", "supersecret")
+	t.Setenv("MY_TOKEN", "tok123")
+	t.Setenv("SAFE_VAR", "keepme")
+
+	// Write an aileron.yaml with scrub config.
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+env:
+  scrub:
+    - "AWS_*"
+    - "*_TOKEN"
+  passthrough:
+    - "SAFE_VAR"
+`), 0o644)
+
+	outFile := filepath.Join(dir, "env.txt")
+	script := filepath.Join(dir, "capture-env.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\nenv > "+outFile+"\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("launch failed: %v", err)
+	}
+
+	data, _ := os.ReadFile(outFile)
+	envStr := string(data)
+
+	if strings.Contains(envStr, "AWS_SECRET_KEY") {
+		t.Error("AWS_SECRET_KEY should have been scrubbed")
+	}
+	if strings.Contains(envStr, "MY_TOKEN") {
+		t.Error("MY_TOKEN should have been scrubbed")
+	}
+	if !strings.Contains(envStr, "SAFE_VAR=keepme") {
+		t.Error("SAFE_VAR should have been preserved (passthrough)")
+	}
+}
+
+func TestLaunch_EnvScrubPassthroughBeatsScrub(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("HOME_DIR", "/home/user")
+
+	// HOME_DIR matches HOME* scrub pattern but HOME is in passthrough.
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+env:
+  scrub:
+    - "HOME*"
+  passthrough:
+    - "HOME"
+    - "HOME_DIR"
+`), 0o644)
+
+	outFile := filepath.Join(dir, "env.txt")
+	script := filepath.Join(dir, "capture-env.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\nenv > "+outFile+"\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+
+	data, _ := os.ReadFile(outFile)
+	envStr := string(data)
+
+	// HOME_DIR is in passthrough, so passthrough beats scrub.
+	if !strings.Contains(envStr, "HOME_DIR=/home/user") {
+		t.Error("HOME_DIR should be preserved (passthrough beats scrub)")
+	}
+}
+
 func TestResolveAuditLogFromCwd(t *testing.T) {
 	dir := t.TempDir()
 	// No aileron.yaml → falls back to cwd/.aileron/audit.jsonl.


### PR DESCRIPTION
## Summary

- The `env.scrub` and `env.passthrough` config in `aileron.yaml` now actually controls which environment variables reach the agent process
- Variables matching scrub patterns (e.g. `AWS_*`, `*_SECRET`, `*_TOKEN`) are removed from the child environment
- Passthrough entries override scrub — `passthrough` beats `scrub`
- Supports `*`, `PREFIX*`, `*SUFFIX`, and exact match patterns

This was a gap — the schema existed since #64 but `buildEnv` wasn't applying it.

Part of #63.

## Test plan

- [x] `TestLaunch_EnvScrubbing` — `AWS_*` and `*_TOKEN` vars scrubbed, `SAFE_VAR` preserved
- [x] `TestLaunch_EnvScrubPassthroughBeatsScrub` — passthrough overrides scrub for matching vars
- [x] All existing tests pass
- [x] 84.6% coverage on launch package

🤖 Generated with [Claude Code](https://claude.com/claude-code)