### PR TITLE
feat(comms): CommsServer IPC and MCP tools for read_messages/send_message

### DIFF
--- a/cmd/aileron-mcp/main.go
+++ b/cmd/aileron-mcp/main.go
@@ -18,6 +18,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
@@ -86,10 +87,37 @@ type toolContent struct {
 type server struct {
 	aileronURL   string
 	aileronToken string
+	commsSocket  string
 	httpClient   *http.Client
 }
 
-// submitIntentTool is the single tool exposed by the Aileron MCP server.
+var readMessagesTool = toolDef{
+	Name:        "read_messages",
+	Description: "Read pending messages from communication channels (Slack, Discord). Returns unread messages from the notification queue.",
+	InputSchema: schema{
+		Type: "object",
+		Properties: map[string]schemaProp{
+			"service": {Type: "string", Description: "Filter by service: 'slack', 'discord', or empty for all"},
+			"channel": {Type: "string", Description: "Filter by channel name, or empty for all channels"},
+		},
+	},
+}
+
+var sendMessageTool = toolDef{
+	Name:        "send_message",
+	Description: "Send a message to a communication channel (Slack, Discord). Requires human approval.",
+	InputSchema: schema{
+		Type: "object",
+		Properties: map[string]schemaProp{
+			"service": {Type: "string", Description: "Target service: 'slack' or 'discord'"},
+			"channel": {Type: "string", Description: "Channel name or ID to send to"},
+			"body":    {Type: "string", Description: "Message text to send"},
+		},
+		Required: []string{"service", "channel", "body"},
+	},
+}
+
+// submitIntentTool is the legacy cloud tool.
 var submitIntentTool = toolDef{
 	Name:        "submit_intent",
 	Description: "Submit a governed intent to Aileron for execution",
@@ -106,17 +134,10 @@ var submitIntentTool = toolDef{
 }
 
 func main() {
-	aileronURL := os.Getenv("AILERON_URL")
-	aileronToken := os.Getenv("AILERON_TOKEN")
-
-	if aileronURL == "" {
-		fmt.Fprintln(os.Stderr, "aileron-mcp: AILERON_URL is required")
-		os.Exit(1)
-	}
-
 	s := &server{
-		aileronURL:   aileronURL,
-		aileronToken: aileronToken,
+		aileronURL:   os.Getenv("AILERON_URL"),
+		aileronToken: os.Getenv("AILERON_TOKEN"),
+		commsSocket:  os.Getenv("AILERON_COMMS_SOCKET"),
 		httpClient:   &http.Client{},
 	}
 
@@ -172,11 +193,12 @@ func (s *server) handle(req jsonrpcRequest) *jsonrpcResponse {
 		return nil // no response for notifications
 
 	case "tools/list":
+		tools := s.availableTools()
 		return &jsonrpcResponse{
 			JSONRPC: "2.0",
 			ID:      req.ID,
 			Result: map[string]any{
-				"tools": []toolDef{submitIntentTool},
+				"tools": tools,
 			},
 		}
 
@@ -205,13 +227,116 @@ func (s *server) handle(req jsonrpcRequest) *jsonrpcResponse {
 	}
 }
 
+func (s *server) availableTools() []toolDef {
+	var tools []toolDef
+	if s.commsSocket != "" {
+		tools = append(tools, readMessagesTool, sendMessageTool)
+	}
+	if s.aileronURL != "" {
+		tools = append(tools, submitIntentTool)
+	}
+	return tools
+}
+
 func (s *server) dispatchTool(ctx context.Context, name string, args map[string]any) toolResult {
 	switch name {
 	case "submit_intent":
 		return s.submitIntent(ctx, args)
+	case "read_messages":
+		return s.readMessages(args)
+	case "send_message":
+		return s.sendMessage(args)
 	default:
 		return errorResult("unknown tool: " + name)
 	}
+}
+
+func (s *server) readMessages(args map[string]any) toolResult {
+	if s.commsSocket == "" {
+		return errorResult("comms not available (not launched via aileron)")
+	}
+
+	service, _ := args["service"].(string)
+	channel, _ := args["channel"].(string)
+
+	resp := requestComms(s.commsSocket, commsRequest{
+		Method:  "read_messages",
+		Service: service,
+		Channel: channel,
+	})
+	if resp.Error != "" {
+		return errorResult(resp.Error)
+	}
+	return jsonResult(resp.Messages)
+}
+
+func (s *server) sendMessage(args map[string]any) toolResult {
+	if s.commsSocket == "" {
+		return errorResult("comms not available (not launched via aileron)")
+	}
+
+	service, _ := args["service"].(string)
+	channel, _ := args["channel"].(string)
+	body, _ := args["body"].(string)
+
+	if service == "" || channel == "" || body == "" {
+		return errorResult("service, channel, and body are required")
+	}
+
+	resp := requestComms(s.commsSocket, commsRequest{
+		Method:  "send_message",
+		Service: service,
+		Channel: channel,
+		Body:    body,
+	})
+	if resp.Error != "" {
+		return errorResult(resp.Error)
+	}
+	return toolResult{
+		Content: []toolContent{{Type: "text", Text: "Message sent successfully."}},
+	}
+}
+
+// --- Comms IPC types (mirrors core/launch/commsserver.go) ---
+
+type commsRequest struct {
+	Method  string `json:"method"`
+	Service string `json:"service,omitempty"`
+	Channel string `json:"channel,omitempty"`
+	Body    string `json:"body,omitempty"`
+}
+
+type commsResponse struct {
+	OK       bool           `json:"ok"`
+	Error    string         `json:"error,omitempty"`
+	Messages []commsMessage `json:"messages,omitempty"`
+}
+
+type commsMessage struct {
+	ID        string `json:"id"`
+	Service   string `json:"service"`
+	Channel   string `json:"channel"`
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	Timestamp string `json:"timestamp"`
+}
+
+func requestComms(socketPath string, req commsRequest) commsResponse {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return commsResponse{Error: "connection failed: " + err.Error()}
+	}
+	defer conn.Close()
+
+	if err := json.NewEncoder(conn).Encode(req); err != nil {
+		return commsResponse{Error: "encode failed: " + err.Error()}
+	}
+
+	var resp commsResponse
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		return commsResponse{Error: "decode failed: " + err.Error()}
+	}
+	return resp
 }
 
 func (s *server) submitIntent(ctx context.Context, args map[string]any) toolResult {

--- a/cmd/aileron-mcp/main_test.go
+++ b/cmd/aileron-mcp/main_test.go
@@ -48,7 +48,7 @@ func TestHandle_NotificationsInitialized(t *testing.T) {
 	}
 }
 
-func TestHandle_ToolsList(t *testing.T) {
+func TestHandle_ToolsList_CloudOnly(t *testing.T) {
 	s := &server{aileronURL: "http://localhost", httpClient: &http.Client{}}
 	resp := s.handle(jsonrpcRequest{
 		JSONRPC: "2.0",
@@ -64,10 +64,92 @@ func TestHandle_ToolsList(t *testing.T) {
 	}
 	tools, ok := result["tools"].([]toolDef)
 	if !ok || len(tools) != 1 {
-		t.Fatal("expected exactly one tool")
+		t.Fatal("expected exactly one tool (submit_intent)")
 	}
 	if tools[0].Name != "submit_intent" {
-		t.Errorf("expected submit_intent tool, got %s", tools[0].Name)
+		t.Errorf("expected submit_intent, got %s", tools[0].Name)
+	}
+}
+
+func TestHandle_ToolsList_WithComms(t *testing.T) {
+	s := &server{commsSocket: "/tmp/test.sock", httpClient: &http.Client{}}
+	resp := s.handle(jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`2`),
+		Method:  "tools/list",
+	})
+	result := resp.Result.(map[string]any)
+	tools := result["tools"].([]toolDef)
+	if len(tools) != 2 {
+		t.Fatalf("expected 2 tools (read_messages, send_message), got %d", len(tools))
+	}
+	names := map[string]bool{}
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	if !names["read_messages"] || !names["send_message"] {
+		t.Errorf("expected read_messages and send_message, got %v", names)
+	}
+}
+
+func TestHandle_ToolsList_Both(t *testing.T) {
+	s := &server{aileronURL: "http://localhost", commsSocket: "/tmp/test.sock", httpClient: &http.Client{}}
+	resp := s.handle(jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`2`),
+		Method:  "tools/list",
+	})
+	result := resp.Result.(map[string]any)
+	tools := result["tools"].([]toolDef)
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools, got %d", len(tools))
+	}
+}
+
+func TestReadMessages_NoSocket(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	result := s.readMessages(map[string]any{})
+	if !result.IsError {
+		t.Fatal("expected error without comms socket")
+	}
+}
+
+func TestSendMessage_NoSocket(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	result := s.sendMessage(map[string]any{"service": "slack", "channel": "#test", "body": "hi"})
+	if !result.IsError {
+		t.Fatal("expected error without comms socket")
+	}
+}
+
+func TestSendMessage_MissingFields(t *testing.T) {
+	s := &server{commsSocket: "/tmp/test.sock", httpClient: &http.Client{}}
+	result := s.sendMessage(map[string]any{})
+	if !result.IsError {
+		t.Fatal("expected error for missing fields")
+	}
+}
+
+func TestRequestComms_NoSocket(t *testing.T) {
+	resp := requestComms("/nonexistent/socket.sock", commsRequest{Method: "read_messages"})
+	if resp.Error == "" {
+		t.Fatal("expected error for missing socket")
+	}
+}
+
+func TestDispatchTool_ReadMessages(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	result := s.dispatchTool(context.Background(), "read_messages", nil)
+	if !result.IsError {
+		t.Fatal("expected error without comms socket")
+	}
+}
+
+func TestDispatchTool_SendMessage(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	result := s.dispatchTool(context.Background(), "send_message", map[string]any{"service": "slack", "channel": "#x", "body": "y"})
+	if !result.IsError {
+		t.Fatal("expected error without comms socket")
 	}
 }
 

--- a/cmd/aileron-mcp/main_test.go
+++ b/cmd/aileron-mcp/main_test.go
@@ -3,8 +3,10 @@ package main
 import (
 	"context"
 	"encoding/json"
+	"net"
 	"net/http"
 	"net/http/httptest"
+	"os"
 	"testing"
 )
 
@@ -151,6 +153,159 @@ func TestDispatchTool_SendMessage(t *testing.T) {
 	if !result.IsError {
 		t.Fatal("expected error without comms socket")
 	}
+}
+
+// TestReadMessages_WithServer starts a real CommsServer to test the
+// full read_messages path through the Unix socket.
+func TestReadMessages_WithServer(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-mcp-test-read.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	// Start a minimal comms server that serves from a mock socket.
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			// Read request, respond with canned messages.
+			var req commsRequest
+			json.NewDecoder(conn).Decode(&req)
+			json.NewEncoder(conn).Encode(commsResponse{
+				OK: true,
+				Messages: []commsMessage{
+					{ID: "1", Service: "slack", Channel: "#backend", Author: "Alice", Body: "hello"},
+				},
+			})
+			conn.Close()
+		}
+	}()
+
+	s := &server{commsSocket: socketPath, httpClient: &http.Client{}}
+	result := s.readMessages(map[string]any{})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+	}
+	// Result should contain the message data as JSON.
+	text := result.Content[0].Text
+	if !contains(text, "Alice") || !contains(text, "#backend") {
+		t.Errorf("expected Alice and #backend in result, got %s", text)
+	}
+}
+
+// TestSendMessage_WithServer tests the full send_message path.
+// The mock server auto-approves.
+func TestSendMessage_WithServer(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-mcp-test-send.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req commsRequest
+			json.NewDecoder(conn).Decode(&req)
+			json.NewEncoder(conn).Encode(commsResponse{OK: true})
+			conn.Close()
+		}
+	}()
+
+	s := &server{commsSocket: socketPath, httpClient: &http.Client{}}
+	result := s.sendMessage(map[string]any{"service": "slack", "channel": "#test", "body": "hello"})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+	}
+	if result.Content[0].Text != "Message sent successfully." {
+		t.Errorf("unexpected result: %s", result.Content[0].Text)
+	}
+}
+
+// TestSendMessage_WithServer_Denied tests the denial path.
+func TestSendMessage_WithServer_Denied(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-mcp-test-deny.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req commsRequest
+			json.NewDecoder(conn).Decode(&req)
+			json.NewEncoder(conn).Encode(commsResponse{Error: "message denied by user"})
+			conn.Close()
+		}
+	}()
+
+	s := &server{commsSocket: socketPath, httpClient: &http.Client{}}
+	result := s.sendMessage(map[string]any{"service": "slack", "channel": "#test", "body": "denied"})
+	if !result.IsError {
+		t.Fatal("expected error for denied message")
+	}
+}
+
+// TestReadMessages_FilterArgs tests that filter args are passed through.
+func TestReadMessages_FilterArgs(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-mcp-test-filter.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	var receivedReq commsRequest
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		conn, err := ln.Accept()
+		if err != nil {
+			return
+		}
+		json.NewDecoder(conn).Decode(&receivedReq)
+		json.NewEncoder(conn).Encode(commsResponse{OK: true})
+		conn.Close()
+	}()
+
+	s := &server{commsSocket: socketPath, httpClient: &http.Client{}}
+	s.readMessages(map[string]any{"service": "discord", "channel": "dev-chat"})
+
+	if receivedReq.Service != "discord" || receivedReq.Channel != "dev-chat" {
+		t.Errorf("expected filter args passed through, got service=%q channel=%q", receivedReq.Service, receivedReq.Channel)
+	}
+}
+
+func contains(s, substr string) bool {
+	return len(s) >= len(substr) && (s == substr || len(s) > 0 && containsStr(s, substr))
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i+len(sub) <= len(s); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
 }
 
 func TestHandle_Ping(t *testing.T) {

--- a/core/launch/commsserver.go
+++ b/core/launch/commsserver.go
@@ -1,0 +1,318 @@
+package launch
+
+import (
+	"encoding/json"
+	"fmt"
+	"net"
+	"os"
+	"strings"
+	"sync"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/comms"
+)
+
+// CommsRequest is sent by aileron-mcp to read or send messages.
+type CommsRequest struct {
+	Method  string `json:"method"` // "read_messages" or "send_message"
+	Service string `json:"service,omitempty"`
+	Channel string `json:"channel,omitempty"`
+	Body    string `json:"body,omitempty"`
+	ReplyTo string `json:"reply_to,omitempty"`
+}
+
+// CommsResponse is returned to aileron-mcp.
+type CommsResponse struct {
+	OK       bool              `json:"ok"`
+	Error    string            `json:"error,omitempty"`
+	Messages []CommsMessageDTO `json:"messages,omitempty"`
+}
+
+// CommsMessageDTO is the wire format for a message.
+type CommsMessageDTO struct {
+	ID        string `json:"id"`
+	Service   string `json:"service"`
+	Channel   string `json:"channel"`
+	Author    string `json:"author"`
+	Body      string `json:"body"`
+	Timestamp string `json:"timestamp"`
+}
+
+// CommsServer handles IPC requests from aileron-mcp for reading and
+// sending messages. It bridges MCP tools to the NotifyQueue and
+// comms Listeners.
+type CommsServer struct {
+	socketPath string
+	listener   net.Listener
+	queue      *NotifyQueue
+	senders    map[string]comms.Listener // keyed by service name
+	bar        *StatusBar
+	copier     *OutputCopier
+	router     *KeyRouter
+
+	mu   sync.Mutex
+	done bool
+}
+
+// NewCommsServer creates a comms IPC server.
+func NewCommsServer(socketPath string, queue *NotifyQueue, senders []comms.Listener, bar *StatusBar, copier *OutputCopier, router *KeyRouter) (*CommsServer, error) {
+	os.Remove(socketPath)
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		return nil, fmt.Errorf("comms socket: %w", err)
+	}
+
+	senderMap := make(map[string]comms.Listener, len(senders))
+	for _, s := range senders {
+		senderMap[s.Service()] = s
+	}
+
+	return &CommsServer{
+		socketPath: socketPath,
+		listener:   ln,
+		queue:      queue,
+		senders:    senderMap,
+		bar:        bar,
+		copier:     copier,
+		router:     router,
+	}, nil
+}
+
+// Serve accepts connections. Blocks until Close. Run in a goroutine.
+func (cs *CommsServer) Serve() {
+	for {
+		conn, err := cs.listener.Accept()
+		if err != nil {
+			cs.mu.Lock()
+			done := cs.done
+			cs.mu.Unlock()
+			if done {
+				return
+			}
+			continue
+		}
+		go cs.handleConn(conn)
+	}
+}
+
+func (cs *CommsServer) handleConn(conn net.Conn) {
+	defer conn.Close()
+
+	var req CommsRequest
+	if err := json.NewDecoder(conn).Decode(&req); err != nil {
+		json.NewEncoder(conn).Encode(CommsResponse{Error: "invalid request"})
+		return
+	}
+
+	var resp CommsResponse
+	switch req.Method {
+	case "read_messages":
+		resp = cs.readMessages(req)
+	case "send_message":
+		resp = cs.sendMessage(req)
+	default:
+		resp = CommsResponse{Error: "unknown method: " + req.Method}
+	}
+
+	json.NewEncoder(conn).Encode(resp)
+}
+
+func (cs *CommsServer) readMessages(req CommsRequest) CommsResponse {
+	msgs := cs.queue.Messages()
+	var dtos []CommsMessageDTO
+	for _, m := range msgs {
+		if req.Service != "" && m.Source != req.Service {
+			continue
+		}
+		if req.Channel != "" && m.Channel != req.Channel {
+			continue
+		}
+		dtos = append(dtos, CommsMessageDTO{
+			ID:        m.ID,
+			Service:   m.Source,
+			Channel:   m.Channel,
+			Author:    m.Author,
+			Body:      m.Body,
+			Timestamp: m.Timestamp.Format(time.RFC3339),
+		})
+	}
+	cs.queue.MarkAllRead()
+	return CommsResponse{OK: true, Messages: dtos}
+}
+
+func (cs *CommsServer) sendMessage(req CommsRequest) CommsResponse {
+	if req.Service == "" || req.Channel == "" || req.Body == "" {
+		return CommsResponse{Error: "service, channel, and body are required"}
+	}
+
+	sender, ok := cs.senders[req.Service]
+	if !ok {
+		return CommsResponse{Error: "no listener for service: " + req.Service}
+	}
+
+	// Prompt the developer for approval before sending.
+	decision := cs.promptSendApproval(req.Service, req.Channel, req.Body)
+	if decision != "approve" {
+		return CommsResponse{Error: "message denied by user"}
+	}
+
+	if err := sender.Send(nil, comms.OutgoingMessage{
+		Channel: req.Channel,
+		Body:    req.Body,
+	}); err != nil {
+		return CommsResponse{Error: "send failed: " + err.Error()}
+	}
+
+	return CommsResponse{OK: true}
+}
+
+// promptSendApproval shows the developer a draft message for approval
+// using the same alternate-screen pattern as the shell approval prompt.
+func (cs *CommsServer) promptSendApproval(service, channel, body string) string {
+	var inputCh <-chan byte
+	if cs.router != nil {
+		inputCh = cs.router.StealInput()
+		defer cs.router.ReleaseInput()
+	}
+
+	if cs.copier != nil {
+		cs.copier.SetPaused(true)
+	}
+	defer func() {
+		if cs.copier != nil {
+			cs.copier.SetPaused(false)
+		}
+	}()
+
+	w := 74
+	termRows, termCols := 24, 80
+	if cs.bar != nil {
+		termRows, termCols = cs.bar.Dims()
+	}
+
+	var lines []string
+	lines = append(lines, fmt.Sprintf("\033[33m┌─ ✈️ Aileron ─ Send Message %s┐\033[0m", strings.Repeat("─", w-27)))
+	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
+	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  To: \033[1m%s %s\033[0m%s\033[33m│\033[0m",
+		service, channel, strings.Repeat(" ", max(0, w-6-len(service)-1-len(channel)))))
+
+	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
+
+	// Wrap the body text into lines that fit the box.
+	bodyLines := wrapText(body, w-4)
+	for _, bl := range bodyLines {
+		lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  %s%s\033[33m│\033[0m",
+			bl, strings.Repeat(" ", max(0, w-2-len(bl)))))
+	}
+
+	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
+	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  \033[1m[y]\033[0m  Send%s\033[33m│\033[0m", strings.Repeat(" ", w-11)))
+	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  \033[1m[n]\033[0m  Discard%s\033[33m│\033[0m", strings.Repeat(" ", w-14)))
+	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
+	lines = append(lines, fmt.Sprintf("\033[33m└%s┘\033[0m", strings.Repeat("─", w)))
+
+	boxWidth := w + 2
+	leftPad := max(0, (termCols-boxWidth)/2)
+	topPad := max(0, (termRows-len(lines)-2)/2)
+	margin := strings.Repeat(" ", leftPad)
+
+	var prompt strings.Builder
+	prompt.WriteString("\033[?1049h\033[2J\033[1;1H")
+	for i := 0; i < topPad; i++ {
+		prompt.WriteString("\r\n")
+	}
+	for _, line := range lines {
+		fmt.Fprintf(&prompt, "%s%s\r\n", margin, line)
+	}
+	prompt.WriteString("\r\n")
+	fmt.Fprintf(&prompt, "%s  > ", margin)
+
+	if cs.copier != nil {
+		cs.copier.WriteExclusive([]byte(prompt.String()))
+	}
+
+	if inputCh == nil {
+		return "deny"
+	}
+	for {
+		b := <-inputCh
+		switch b {
+		case 'y', 'Y':
+			// Restore screen.
+			if cs.copier != nil {
+				cs.copier.WriteExclusive([]byte("\033[?1049l"))
+			}
+			return "approve"
+		case 'n', 'N':
+			if cs.copier != nil {
+				cs.copier.WriteExclusive([]byte("\033[?1049l"))
+			}
+			return "deny"
+		default:
+			continue
+		}
+	}
+}
+
+// wrapText splits text into lines of at most maxWidth characters.
+func wrapText(text string, maxWidth int) []string {
+	if len(text) <= maxWidth {
+		return []string{text}
+	}
+	var lines []string
+	for len(text) > maxWidth {
+		// Find a space to break at.
+		idx := strings.LastIndex(text[:maxWidth], " ")
+		if idx < 0 {
+			idx = maxWidth
+		}
+		lines = append(lines, text[:idx])
+		text = strings.TrimLeft(text[idx:], " ")
+	}
+	if len(text) > 0 {
+		lines = append(lines, text)
+	}
+	return lines
+}
+
+// SocketPath returns the socket path.
+func (cs *CommsServer) SocketPath() string {
+	return cs.socketPath
+}
+
+// Close shuts down the comms server.
+func (cs *CommsServer) Close() {
+	cs.mu.Lock()
+	cs.done = true
+	cs.mu.Unlock()
+	cs.listener.Close()
+	os.Remove(cs.socketPath)
+}
+
+// RequestComms connects to the comms server and makes a request.
+// Called from aileron-mcp.
+func RequestComms(socketPath string, req CommsRequest) CommsResponse {
+	conn, err := net.Dial("unix", socketPath)
+	if err != nil {
+		return CommsResponse{Error: "connection failed: " + err.Error()}
+	}
+	defer conn.Close()
+
+	if err := json.NewEncoder(conn).Encode(req); err != nil {
+		return CommsResponse{Error: "encode failed: " + err.Error()}
+	}
+
+	var resp CommsResponse
+	if err := json.NewDecoder(conn).Decode(&resp); err != nil {
+		return CommsResponse{Error: "decode failed: " + err.Error()}
+	}
+	return resp
+}
+
+func max(a, b int) int {
+	if a > b {
+		return a
+	}
+	return b
+}

--- a/core/launch/commsserver_test.go
+++ b/core/launch/commsserver_test.go
@@ -1,0 +1,298 @@
+package launch_test
+
+import (
+	"context"
+	"io"
+	"os"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/comms"
+	"github.com/ALRubinger/aileron/core/launch"
+)
+
+type mockSender struct {
+	service string
+	sent    bool
+	lastMsg comms.OutgoingMessage
+}
+
+func (m *mockSender) Service() string                                              { return m.service }
+func (m *mockSender) Connect(ctx context.Context) error                            { return nil }
+func (m *mockSender) Listen(ctx context.Context) (<-chan comms.IncomingMessage, error) { return nil, nil }
+func (m *mockSender) Send(ctx context.Context, msg comms.OutgoingMessage) error {
+	m.sent = true
+	m.lastMsg = msg
+	return nil
+}
+func (m *mockSender) Close() error { return nil }
+
+func TestCommsServer_ReadMessages(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-read.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	queue := launch.NewNotifyQueue(10, nil)
+	queue.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Alice", Body: "Is the deploy done?", Timestamp: time.Now()})
+	queue.Push(launch.Message{ID: "2", Source: "discord", Channel: "dev-chat", Author: "Bob", Body: "PR looks good", Timestamp: time.Now()})
+
+	srv, err := launch.NewCommsServer(socketPath, queue, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	go srv.Serve()
+	defer srv.Close()
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{Method: "read_messages"})
+	if !resp.OK {
+		t.Fatalf("expected OK, got error: %s", resp.Error)
+	}
+	if len(resp.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(resp.Messages))
+	}
+	if resp.Messages[0].Author != "Alice" {
+		t.Errorf("msg[0].Author = %q, want Alice", resp.Messages[0].Author)
+	}
+	if resp.Messages[1].Service != "discord" {
+		t.Errorf("msg[1].Service = %q, want discord", resp.Messages[1].Service)
+	}
+}
+
+func TestCommsServer_ReadMessages_FilterByService(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-filter.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	queue := launch.NewNotifyQueue(10, nil)
+	queue.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Body: "slack msg"})
+	queue.Push(launch.Message{ID: "2", Source: "discord", Channel: "dev", Body: "discord msg"})
+
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, nil, nil)
+	go srv.Serve()
+	defer srv.Close()
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{Method: "read_messages", Service: "slack"})
+	if len(resp.Messages) != 1 || resp.Messages[0].Service != "slack" {
+		t.Errorf("expected 1 slack message, got %v", resp.Messages)
+	}
+}
+
+func TestCommsServer_ReadMessages_MarksRead(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-markread.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	queue := launch.NewNotifyQueue(10, nil)
+	queue.Push(launch.Message{ID: "1", Source: "slack", Body: "hello"})
+
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, nil, nil)
+	go srv.Serve()
+	defer srv.Close()
+
+	launch.RequestComms(socketPath, launch.CommsRequest{Method: "read_messages"})
+
+	if queue.UnreadCount() != 0 {
+		t.Errorf("expected 0 unread after read, got %d", queue.UnreadCount())
+	}
+}
+
+func TestCommsServer_SendMessage_NoSender(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-nosender.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	queue := launch.NewNotifyQueue(10, nil)
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, nil, nil)
+	go srv.Serve()
+	defer srv.Close()
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{
+		Method:  "send_message",
+		Service: "slack",
+		Channel: "#test",
+		Body:    "hello",
+	})
+	if resp.OK {
+		t.Error("expected error when no sender configured")
+	}
+	if resp.Error == "" {
+		t.Error("expected error message")
+	}
+}
+
+func TestCommsServer_SendMessage_MissingFields(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-missing.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	queue := launch.NewNotifyQueue(10, nil)
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, nil, nil)
+	go srv.Serve()
+	defer srv.Close()
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{Method: "send_message"})
+	if resp.OK {
+		t.Error("expected error for missing fields")
+	}
+}
+
+func TestCommsServer_SendMessage_WithApproval(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-send.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	// Set up copier and router for the approval prompt.
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+	router := launch.NewKeyRouter(stdinR, &safeBuf{}, &simpleOverlay{})
+	go router.Run()
+
+	// Use a mock sender.
+	sender := &mockSender{service: "slack"}
+	queue := launch.NewNotifyQueue(10, nil)
+
+	srv, _ := launch.NewCommsServer(socketPath, queue, []comms.Listener{sender}, nil, copier, router)
+	go srv.Serve()
+	defer srv.Close()
+
+	done := make(chan launch.CommsResponse, 1)
+	go func() {
+		done <- launch.RequestComms(socketPath, launch.CommsRequest{
+			Method:  "send_message",
+			Service: "slack",
+			Channel: "#backend",
+			Body:    "The deploy is complete.",
+		})
+	}()
+
+	// Wait for prompt, then approve.
+	time.Sleep(300 * time.Millisecond)
+	stdinW.Write([]byte("y"))
+
+	select {
+	case resp := <-done:
+		if !resp.OK {
+			t.Errorf("expected OK after approval, got error: %s", resp.Error)
+		}
+		if !sender.sent {
+			t.Error("expected message to be sent")
+		}
+		if sender.lastMsg.Body != "The deploy is complete." {
+			t.Errorf("sent body = %q", sender.lastMsg.Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestCommsServer_SendMessage_Denied(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-deny.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+	router := launch.NewKeyRouter(stdinR, &safeBuf{}, &simpleOverlay{})
+	go router.Run()
+
+	sender := &mockSender{service: "slack"}
+	queue := launch.NewNotifyQueue(10, nil)
+
+	srv, _ := launch.NewCommsServer(socketPath, queue, []comms.Listener{sender}, nil, copier, router)
+	go srv.Serve()
+	defer srv.Close()
+
+	done := make(chan launch.CommsResponse, 1)
+	go func() {
+		done <- launch.RequestComms(socketPath, launch.CommsRequest{
+			Method:  "send_message",
+			Service: "slack",
+			Channel: "#backend",
+			Body:    "Draft reply",
+		})
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	stdinW.Write([]byte("n"))
+
+	select {
+	case resp := <-done:
+		if resp.OK {
+			t.Error("expected denial")
+		}
+		if sender.sent {
+			t.Error("message should not have been sent")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestCommsServer_UnknownMethod(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-unknown.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	queue := launch.NewNotifyQueue(10, nil)
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, nil, nil)
+	go srv.Serve()
+	defer srv.Close()
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{Method: "bogus"})
+	if resp.OK {
+		t.Error("expected error for unknown method")
+	}
+}
+
+func TestRequestComms_NoSocket(t *testing.T) {
+	resp := launch.RequestComms("/nonexistent/comms.sock", launch.CommsRequest{Method: "read_messages"})
+	if resp.OK {
+		t.Error("expected error when socket unavailable")
+	}
+}
+
+func TestCommsServer_WrapText(t *testing.T) {
+	// Verify long messages don't break the send approval prompt.
+	socketPath := os.TempDir() + "/aileron-test-comms-wrap.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	dst := &safeBuf{}
+	copier := launch.NewOutputCopier(srcR, dst, nil)
+	go copier.Run()
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+	router := launch.NewKeyRouter(stdinR, &safeBuf{}, &simpleOverlay{})
+	go router.Run()
+
+	sender := &mockSender{service: "slack"}
+	queue := launch.NewNotifyQueue(10, nil)
+
+	srv, _ := launch.NewCommsServer(socketPath, queue, []comms.Listener{sender}, nil, copier, router)
+	go srv.Serve()
+	defer srv.Close()
+
+	longBody := "This is a very long message that should be wrapped across multiple lines in the approval prompt to ensure it fits within the box boundaries."
+
+	done := make(chan launch.CommsResponse, 1)
+	go func() {
+		done <- launch.RequestComms(socketPath, launch.CommsRequest{
+			Method:  "send_message",
+			Service: "slack",
+			Channel: "#backend",
+			Body:    longBody,
+		})
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	stdinW.Write([]byte("y"))
+	<-done
+
+	if sender.lastMsg.Body != longBody {
+		t.Error("full body should be sent regardless of wrapping")
+	}
+}

--- a/core/launch/commsserver_test.go
+++ b/core/launch/commsserver_test.go
@@ -246,6 +246,22 @@ func TestCommsServer_UnknownMethod(t *testing.T) {
 	}
 }
 
+func TestCommsServer_SocketPath(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-path.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	queue := launch.NewNotifyQueue(10, nil)
+	srv, err := launch.NewCommsServer(socketPath, queue, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	if srv.SocketPath() != socketPath {
+		t.Errorf("SocketPath = %q, want %q", srv.SocketPath(), socketPath)
+	}
+}
+
 func TestRequestComms_NoSocket(t *testing.T) {
 	resp := launch.RequestComms("/nonexistent/comms.sock", launch.CommsRequest{Method: "read_messages"})
 	if resp.OK {

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -88,9 +88,11 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	auditLog := resolveAuditLog(config.Dir)
 	envConfig := loadEnvConfig(config.Dir)
 	approvalSocket := filepath.Join(os.TempDir(), "ai-"+sessionID+".sock")
+	commsSocket := filepath.Join(os.TempDir(), "ai-comms-"+sessionID+".sock")
 
 	env := buildEnv(config.ShellShim, wrapperPath, config.Agent.Name(), sessionID, auditLog, envConfig, config.Agent.Env())
 	env = append(env, "AILERON_APPROVAL_SOCKET="+approvalSocket)
+	env = append(env, "AILERON_COMMS_SOCKET="+commsSocket)
 
 	// Agent-required args come first, then user-supplied args.
 	allArgs := append(config.Agent.Args(), config.Args...)
@@ -108,7 +110,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	// If stdin is a terminal, use the pty proxy with status bar.
 	var result LaunchResult
 	if term.IsTerminal(int(os.Stdin.Fd())) {
-		result, err = launchWithPty(cmd, config, queue, approvalSocket)
+		result, err = launchWithPty(cmd, config, queue, listeners, approvalSocket, commsSocket)
 	} else {
 		result, err = launchDirect(cmd, config)
 	}
@@ -146,7 +148,7 @@ func launchDirect(cmd *exec.Cmd, config LaunchConfig) (LaunchResult, error) {
 }
 
 // launchWithPty runs the agent inside a pty with a status bar at the bottom.
-func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, approvalSocket string) (LaunchResult, error) {
+func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, listeners []comms.Listener, approvalSocket, commsSocket string) (LaunchResult, error) {
 	stdinFd := int(os.Stdin.Fd())
 
 	cols, rows, err := term.GetSize(stdinFd)
@@ -192,6 +194,14 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, appro
 	}
 	defer approvalSrv.Close()
 	go approvalSrv.Serve()
+
+	// Start the comms server so aileron-mcp can read/send messages.
+	commsSrv, err := NewCommsServer(commsSocket, queue, listeners, bar, outputCopier, router)
+	if err != nil {
+		return LaunchResult{}, fmt.Errorf("starting comms server: %w", err)
+	}
+	defer commsSrv.Close()
+	go commsSrv.Serve()
 
 	// Wire onChange to re-render the status bar when notifications arrive.
 	queue.onChange = func() { bar.Render(os.Stdout) }


### PR DESCRIPTION
## Summary

Phase 1 of Track C: the backbone for bidirectional communication.

### New components

- **CommsServer** (`core/launch/commsserver.go`) — Unix socket server handling `read_messages` and `send_message` requests from aileron-mcp. Send approval uses the same alternate-screen pattern as shell approvals.
- **MCP tools** (`cmd/aileron-mcp/main.go`) — `read_messages` returns unread messages from the NotifyQueue. `send_message` triggers a centered approval prompt before delivery.

### Changes

- **Launcher** — Creates CommsServer alongside ApprovalServer, passes `AILERON_COMMS_SOCKET` to the agent's env
- **aileron-mcp** — No longer requires `AILERON_URL`. Works in local-only mode with comms socket. Tools available when `AILERON_COMMS_SOCKET` is set.

### Flow

```
Agent calls read_messages → aileron-mcp → CommsServer → NotifyQueue → returns messages
Agent calls send_message  → aileron-mcp → CommsServer → approval prompt → Listener.Send()
```

Part of #65 and #63.

## Test plan

- [x] ReadMessages: all, filter by service, marks read — 3 tests
- [x] SendMessage: with approval (y), denied (n), missing fields, no sender, long body wrapping — 5 tests  
- [x] Unknown method, no socket fallback — 2 tests
- [x] All existing tests pass
- [x] Race detector clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)