### PR TITLE
fix(policy): normalize binary paths in command matching

### DIFF
--- a/core/launch/eval.go
+++ b/core/launch/eval.go
@@ -41,10 +41,20 @@ func EvaluateCommand(policyPath, command, workingDir string) EvalResult {
 	binaryName := ""
 	argsStr := ""
 	if len(parts) > 0 {
-		binaryName = parts[0]
+		binaryName = filepath.Base(parts[0])
 	}
 	if len(parts) > 1 {
 		argsStr = strings.Join(parts[1:], " ")
+	}
+
+	// Rebuild the command with the normalized binary name so that
+	// rules like "ls *" match even when the agent calls "/bin/ls -la ...".
+	normalizedCommand := command
+	if binaryName != "" && len(parts) > 0 && parts[0] != binaryName {
+		normalizedCommand = binaryName
+		if argsStr != "" {
+			normalizedCommand += " " + argsStr
+		}
 	}
 
 	decision, err := engine.Evaluate(ctx, policy.EvaluationRequest{
@@ -53,7 +63,7 @@ func EvaluateCommand(policyPath, command, workingDir string) EvalResult {
 			Type:    "shell.exec",
 			Summary: command,
 			Metadata: map[string]any{
-				"shell.command":     command,
+				"shell.command":     normalizedCommand,
 				"shell.binary":      binaryName,
 				"shell.args":        argsStr,
 				"shell.working_dir": workingDir,

--- a/core/launch/eval_test.go
+++ b/core/launch/eval_test.go
@@ -282,6 +282,63 @@ allow:
 	}
 }
 
+func TestEvaluateCommand_NormalizesAbsoluteBinaryPath(t *testing.T) {
+	path := writePolicyFile(t, `
+version: 1
+default: deny
+allow:
+  - "ls *"
+`)
+	// Agent calls "/bin/ls -la /tmp" — should still match "ls *".
+	result := launch.EvaluateCommand(path, "/bin/ls -la /tmp", "/tmp")
+	if result.Disposition != model.DispositionAllow {
+		t.Errorf("expected allow after path normalization, got %q", result.Disposition)
+	}
+}
+
+func TestEvaluateCommand_NormalizesBinaryForDenyRule(t *testing.T) {
+	path := writePolicyFile(t, `
+version: 1
+default: allow
+deny:
+  - command: "rm -rf *"
+    description: "no recursive delete"
+`)
+	// Agent calls "/usr/bin/rm -rf /important" — should still be denied.
+	result := launch.EvaluateCommand(path, "/usr/bin/rm -rf /important", "/tmp")
+	if result.Disposition != model.DispositionDeny {
+		t.Errorf("expected deny after path normalization, got %q", result.Disposition)
+	}
+}
+
+func TestEvaluateCommand_NormalizesBinaryField(t *testing.T) {
+	path := writePolicyFile(t, `
+version: 1
+default: deny
+allow:
+  - binary: "go"
+`)
+	// Agent calls "/usr/local/go/bin/go test ./..." — binary should normalize to "go".
+	result := launch.EvaluateCommand(path, "/usr/local/go/bin/go test ./...", "/tmp")
+	if result.Disposition != model.DispositionAllow {
+		t.Errorf("expected allow by normalized binary match, got %q", result.Disposition)
+	}
+}
+
+func TestEvaluateCommand_BareBinaryUnchanged(t *testing.T) {
+	path := writePolicyFile(t, `
+version: 1
+default: deny
+allow:
+  - "echo *"
+`)
+	// Bare binary (no path prefix) should still work as before.
+	result := launch.EvaluateCommand(path, "echo hello", "/tmp")
+	if result.Disposition != model.DispositionAllow {
+		t.Errorf("expected allow for bare binary, got %q", result.Disposition)
+	}
+}
+
 func TestWriteDeny_BuiltinRule(t *testing.T) {
 	var buf bytes.Buffer
 	launch.WriteDeny(&buf, "eval bad", "", "builtin_eval", "")


### PR DESCRIPTION
## Summary
- Strips directory prefix from binary names before policy evaluation (`/bin/ls` → `ls`)
- Rebuilds `shell.command` with the normalized binary so both command and binary rule matching work consistently
- Adds 4 tests covering absolute paths in allow rules, deny rules, binary-field rules, and bare binary regression

## Context
Claude Code was observed bypassing a policy rule by using `/bin/ls` instead of `ls` (see audit log in #82). The shim still caught it via default-ask, but the explicit rule didn't match.

Closes #82

## Test plan
- [x] `/bin/ls -la /tmp` matches allow rule `"ls *"`
- [x] `/usr/bin/rm -rf /important` matches deny rule `"rm -rf *"`
- [x] `/usr/local/go/bin/go test ./...` matches `binary: "go"` rule
- [x] Bare binaries (`echo hello`) still match as before
- [x] All 126 tests in `core/launch` pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)