### PR TITLE
feat(launch): auto-draft replies for incoming messages

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ notifications:
 ./build/aileron launch claude
 ```
 
-Messages from configured channels appear in the notification bar. Press **Ctrl-A** to view the full queue, navigate with **j/k** or arrow keys, and **Escape** to return.
+Messages from configured channels appear in the notification bar. Press **Ctrl-A** to view the full queue, navigate with **j/k** or arrow keys, press **a** to ask the agent to draft a reply, **d** to dismiss, and **Escape** to return. On channels with `auto_draft: true`, the agent drafts replies automatically when messages arrive.
 
 ### Run tests
 

--- a/core/launch/draftinjector.go
+++ b/core/launch/draftinjector.go
@@ -1,0 +1,28 @@
+package launch
+
+import (
+	"fmt"
+	"io"
+)
+
+// DraftInjector writes draft-request prompts into the agent's pty stdin.
+// When the agent reads from stdin, it sees the prompt as user input and
+// can use the send_message MCP tool to draft a reply.
+type DraftInjector struct {
+	ptmx io.Writer
+}
+
+// NewDraftInjector creates an injector that writes to the given pty master.
+func NewDraftInjector(ptmx io.Writer) *DraftInjector {
+	return &DraftInjector{ptmx: ptmx}
+}
+
+// Inject writes a draft-request prompt for the given message into the
+// agent's pty. The trailing newline submits it as user input.
+func (di *DraftInjector) Inject(msg Message) {
+	prompt := fmt.Sprintf(
+		"A teammate sent a message in %s. %s says: %q Please draft a reply using the send_message tool with service=%q and channel=%q.\n",
+		msg.Channel, msg.Author, msg.Body, msg.Source, msg.Channel,
+	)
+	di.ptmx.Write([]byte(prompt))
+}

--- a/core/launch/draftinjector_test.go
+++ b/core/launch/draftinjector_test.go
@@ -1,0 +1,64 @@
+package launch_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/launch"
+)
+
+func TestDraftInjector_Inject(t *testing.T) {
+	var buf bytes.Buffer
+	di := launch.NewDraftInjector(&buf)
+
+	di.Inject(launch.Message{
+		Source:  "slack",
+		Channel: "#backend",
+		Author:  "Sarah",
+		Body:    "Does the new auth middleware change the JWT claims?",
+	})
+
+	out := buf.String()
+
+	if !strings.Contains(out, "#backend") {
+		t.Error("expected channel in injected prompt")
+	}
+	if !strings.Contains(out, "Sarah") {
+		t.Error("expected author in injected prompt")
+	}
+	if !strings.Contains(out, "JWT claims") {
+		t.Error("expected message body in injected prompt")
+	}
+	if !strings.Contains(out, "send_message") {
+		t.Error("expected send_message tool reference in injected prompt")
+	}
+	if !strings.Contains(out, `service="slack"`) {
+		t.Error("expected service parameter in injected prompt")
+	}
+	if !strings.Contains(out, `channel="#backend"`) {
+		t.Error("expected channel parameter in injected prompt")
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Error("expected trailing newline to submit as user input")
+	}
+}
+
+func TestDraftInjector_InjectMultiple(t *testing.T) {
+	var buf bytes.Buffer
+	di := launch.NewDraftInjector(&buf)
+
+	di.Inject(launch.Message{Source: "slack", Channel: "#general", Author: "Alice", Body: "first"})
+	di.Inject(launch.Message{Source: "discord", Channel: "dev-chat", Author: "Bob", Body: "second"})
+
+	out := buf.String()
+	if strings.Count(out, "\n") != 2 {
+		t.Errorf("expected 2 newlines for 2 injections, got %d", strings.Count(out, "\n"))
+	}
+	if !strings.Contains(out, "Alice") {
+		t.Error("expected first author")
+	}
+	if !strings.Contains(out, "Bob") {
+		t.Error("expected second author")
+	}
+}

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -186,6 +186,16 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 	router := NewKeyRouter(os.Stdin, ptmx, overlay)
 	overlay.onDismiss = router.DeactivateOverlay
 
+	// Wire draft injection: overlay 'a' key and auto-draft messages both
+	// inject a prompt into the agent's pty stdin.
+	injector := NewDraftInjector(ptmx)
+	overlay.OnDraftRequest = func(msg Message) {
+		injector.Inject(msg)
+	}
+	queue.SetOnAutoDraft(func(msg Message) {
+		injector.Inject(msg)
+	})
+
 	// Start the approval server so aileron-sh can request user approvals
 	// on the real terminal (not the pty).
 	approvalSrv, err := NewApprovalServer(approvalSocket, bar, outputCopier, router, ptmx)
@@ -502,22 +512,27 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue) []
 		return nil
 	}
 
+	autoDraft := make(map[string]bool)
 	var created []comms.Listener
 	if cfg := pf.Notifications.Slack; cfg != nil && cfg.AppToken != "" && cfg.BotToken != "" {
 		channels := make([]string, 0, len(cfg.Channels))
 		for _, ch := range cfg.Channels {
 			channels = append(channels, ch.Name)
+			if ch.AutoDraft {
+				autoDraft[ch.Name] = true
+			}
 		}
 		created = append(created, comms.NewSlackListener(cfg.AppToken, cfg.BotToken, channels, cfg.Ignore))
 	}
 
-	return StartListeners(ctx, created, queue, os.Stderr)
+	return StartListeners(ctx, created, queue, os.Stderr, autoDraft)
 }
 
 // StartListeners connects and starts each listener, bridging incoming
-// messages to the NotifyQueue. Returns the successfully started
+// messages to the NotifyQueue. The autoDraft map controls which channels
+// trigger automatic draft replies. Returns the successfully started
 // listeners. Errors are written to w.
-func StartListeners(ctx context.Context, listeners []comms.Listener, queue *NotifyQueue, w io.Writer) []comms.Listener {
+func StartListeners(ctx context.Context, listeners []comms.Listener, queue *NotifyQueue, w io.Writer, autoDraft map[string]bool) []comms.Listener {
 	var started []comms.Listener
 	for _, l := range listeners {
 		if err := l.Connect(ctx); err != nil {
@@ -530,14 +545,15 @@ func StartListeners(ctx context.Context, listeners []comms.Listener, queue *Noti
 			continue
 		}
 		started = append(started, l)
-		go BridgeMessages(msgs, queue)
+		go BridgeMessages(msgs, queue, autoDraft)
 	}
 	return started
 }
 
 // BridgeMessages reads from a comms listener channel and pushes messages
-// into the NotifyQueue. Exported for testing.
-func BridgeMessages(msgs <-chan comms.IncomingMessage, queue *NotifyQueue) {
+// into the NotifyQueue. The autoDraft map controls which channels trigger
+// automatic draft replies. Exported for testing.
+func BridgeMessages(msgs <-chan comms.IncomingMessage, queue *NotifyQueue, autoDraft map[string]bool) {
 	for msg := range msgs {
 		preview := msg.Body
 		if len(preview) > 80 {
@@ -551,6 +567,7 @@ func BridgeMessages(msgs <-chan comms.IncomingMessage, queue *NotifyQueue) {
 			Preview:   preview,
 			Body:      msg.Body,
 			Timestamp: msg.Timestamp,
+			AutoDraft: autoDraft[msg.Channel],
 		})
 	}
 }

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -186,15 +186,7 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 	router := NewKeyRouter(os.Stdin, ptmx, overlay)
 	overlay.onDismiss = router.DeactivateOverlay
 
-	// Wire draft injection: overlay 'a' key and auto-draft messages both
-	// inject a prompt into the agent's pty stdin.
-	injector := NewDraftInjector(ptmx)
-	overlay.OnDraftRequest = func(msg Message) {
-		injector.Inject(msg)
-	}
-	queue.SetOnAutoDraft(func(msg Message) {
-		injector.Inject(msg)
-	})
+	WireDraftInjection(ptmx, overlay, queue)
 
 	// Start the approval server so aileron-sh can request user approvals
 	// on the real terminal (not the pty).
@@ -243,6 +235,19 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 	CleanupTerminalScreen(os.Stdout, rows)
 
 	return exitResult(err)
+}
+
+// WireDraftInjection connects the overlay's draft-request action and the
+// queue's auto-draft callback to a DraftInjector that writes prompts into
+// the agent's pty stdin. Exported for testing.
+func WireDraftInjection(ptmx io.Writer, overlay *Overlay, queue *NotifyQueue) {
+	injector := NewDraftInjector(ptmx)
+	overlay.OnDraftRequest = func(msg Message) {
+		injector.Inject(msg)
+	}
+	queue.SetOnAutoDraft(func(msg Message) {
+		injector.Inject(msg)
+	})
 }
 
 // ComputeAgentRows returns the number of rows available for the agent,

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -554,6 +554,45 @@ func TestBridgeMessages(t *testing.T) {
 	}
 }
 
+func TestWireDraftInjection_OverlayCallback(t *testing.T) {
+	var buf strings.Builder
+	q := launch.NewNotifyQueue(10, nil)
+	o := launch.NewOverlay(q, nil, &buf, 24, 80, nil)
+
+	launch.WireDraftInjection(&buf, o, q)
+
+	// Simulate overlay draft request.
+	msg := launch.Message{Source: "slack", Channel: "#backend", Author: "Sarah", Body: "question?"}
+	o.OnDraftRequest(msg)
+
+	out := buf.String()
+	if !strings.Contains(out, "send_message") {
+		t.Error("expected send_message in injected prompt from overlay callback")
+	}
+	if !strings.Contains(out, "Sarah") {
+		t.Error("expected author in injected prompt")
+	}
+}
+
+func TestWireDraftInjection_AutoDraftCallback(t *testing.T) {
+	var buf strings.Builder
+	q := launch.NewNotifyQueue(10, nil)
+	o := launch.NewOverlay(q, nil, &buf, 24, 80, nil)
+
+	launch.WireDraftInjection(&buf, o, q)
+
+	// Push an auto-draft message — should trigger injection.
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Bob", Body: "help?", AutoDraft: true})
+
+	out := buf.String()
+	if !strings.Contains(out, "send_message") {
+		t.Error("expected send_message in injected prompt from auto-draft callback")
+	}
+	if !strings.Contains(out, "Bob") {
+		t.Error("expected author in injected prompt")
+	}
+}
+
 func TestBridgeMessages_AutoDraft(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	msgs := make(chan comms.IncomingMessage, 3)

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -522,7 +522,7 @@ func TestBridgeMessages(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	msgs := make(chan comms.IncomingMessage, 5)
 
-	go launch.BridgeMessages(msgs, queue)
+	go launch.BridgeMessages(msgs, queue, nil)
 
 	msgs <- comms.IncomingMessage{
 		ID:        "msg-1",
@@ -554,11 +554,35 @@ func TestBridgeMessages(t *testing.T) {
 	}
 }
 
+func TestBridgeMessages_AutoDraft(t *testing.T) {
+	queue := launch.NewNotifyQueue(10, nil)
+	msgs := make(chan comms.IncomingMessage, 3)
+
+	autoDraft := map[string]bool{"#backend": true}
+	go launch.BridgeMessages(msgs, queue, autoDraft)
+
+	msgs <- comms.IncomingMessage{ID: "1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "question"}
+	msgs <- comms.IncomingMessage{ID: "2", Service: "slack", Channel: "#general", Author: "Bob", Body: "chat"}
+	close(msgs)
+	time.Sleep(50 * time.Millisecond)
+
+	all := queue.Messages()
+	if len(all) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(all))
+	}
+	if !all[0].AutoDraft {
+		t.Error("expected AutoDraft=true for #backend message")
+	}
+	if all[1].AutoDraft {
+		t.Error("expected AutoDraft=false for #general message")
+	}
+}
+
 func TestBridgeMessages_LongPreviewTruncated(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	msgs := make(chan comms.IncomingMessage, 1)
 
-	go launch.BridgeMessages(msgs, queue)
+	go launch.BridgeMessages(msgs, queue, nil)
 
 	longBody := strings.Repeat("x", 100)
 	msgs <- comms.IncomingMessage{
@@ -606,7 +630,7 @@ func TestStartListeners_Success(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr)
+	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr, nil)
 
 	if len(started) != 1 {
 		t.Fatalf("expected 1 started listener, got %d", len(started))
@@ -633,7 +657,7 @@ func TestStartListeners_ConnectError(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr)
+	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr, nil)
 
 	if len(started) != 0 {
 		t.Error("expected 0 started listeners on connect error")
@@ -651,7 +675,7 @@ func TestStartListeners_ListenError(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr)
+	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr, nil)
 
 	if len(started) != 0 {
 		t.Error("expected 0 started listeners on listen error")
@@ -664,7 +688,7 @@ func TestStartListeners_ListenError(t *testing.T) {
 func TestStartListeners_Empty(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), nil, queue, &stderr)
+	started := launch.StartListeners(context.Background(), nil, queue, &stderr, nil)
 	if len(started) != 0 {
 		t.Error("expected 0 listeners for nil input")
 	}
@@ -676,7 +700,7 @@ func TestStartListeners_Mixed(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), []comms.Listener{bad, good}, queue, &stderr)
+	started := launch.StartListeners(context.Background(), []comms.Listener{bad, good}, queue, &stderr, nil)
 
 	if len(started) != 1 {
 		t.Fatalf("expected 1 started, got %d", len(started))

--- a/core/launch/notifyqueue.go
+++ b/core/launch/notifyqueue.go
@@ -15,16 +15,19 @@ type Message struct {
 	Body      string // full text for overlay
 	Timestamp time.Time
 	Read      bool
+	AutoDraft bool // channel is configured for automatic draft replies
 }
 
 // NotifyQueue is a bounded, thread-safe FIFO of incoming messages.
 // The onChange callback fires (outside the lock) whenever the queue
-// state changes, so the status bar can re-render.
+// state changes, so the status bar can re-render. The onAutoDraft
+// callback fires for messages with AutoDraft set.
 type NotifyQueue struct {
-	mu       sync.Mutex
-	messages []Message
-	maxSize  int
-	onChange func()
+	mu          sync.Mutex
+	messages    []Message
+	maxSize     int
+	onChange    func()
+	onAutoDraft func(Message)
 }
 
 // NewNotifyQueue creates a queue with the given capacity. The onChange
@@ -49,6 +52,17 @@ func (q *NotifyQueue) Push(msg Message) {
 	if q.onChange != nil {
 		q.onChange()
 	}
+	if msg.AutoDraft && q.onAutoDraft != nil {
+		q.onAutoDraft(msg)
+	}
+}
+
+// SetOnAutoDraft sets a callback that fires when an AutoDraft message
+// is pushed. The callback runs outside the lock.
+func (q *NotifyQueue) SetOnAutoDraft(fn func(Message)) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.onAutoDraft = fn
 }
 
 // Messages returns a snapshot (copy) of all messages.

--- a/core/launch/notifyqueue_test.go
+++ b/core/launch/notifyqueue_test.go
@@ -162,6 +162,45 @@ func TestNotifyQueue_MessagesReturnsSnapshot(t *testing.T) {
 	}
 }
 
+func TestNotifyQueue_AutoDraftCallbackFires(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	var got []string
+	q.SetOnAutoDraft(func(msg launch.Message) {
+		got = append(got, msg.ID)
+	})
+
+	q.Push(launch.Message{ID: "1", AutoDraft: true})
+	q.Push(launch.Message{ID: "2", AutoDraft: false})
+	q.Push(launch.Message{ID: "3", AutoDraft: true})
+
+	if len(got) != 2 {
+		t.Fatalf("expected onAutoDraft called 2 times, got %d", len(got))
+	}
+	if got[0] != "1" || got[1] != "3" {
+		t.Errorf("expected IDs [1, 3], got %v", got)
+	}
+}
+
+func TestNotifyQueue_AutoDraftNilCallback(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	// Should not panic when onAutoDraft is nil.
+	q.Push(launch.Message{ID: "1", AutoDraft: true})
+}
+
+func TestNotifyQueue_AutoDraftRoundtrip(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", AutoDraft: true})
+	q.Push(launch.Message{ID: "2", AutoDraft: false})
+
+	msgs := q.Messages()
+	if !msgs[0].AutoDraft {
+		t.Error("expected AutoDraft=true on first message")
+	}
+	if msgs[1].AutoDraft {
+		t.Error("expected AutoDraft=false on second message")
+	}
+}
+
 func TestNotifyQueue_ConcurrentAccess(t *testing.T) {
 	q := launch.NewNotifyQueue(100, nil)
 	var wg sync.WaitGroup

--- a/core/launch/overlay.go
+++ b/core/launch/overlay.go
@@ -20,8 +20,9 @@ type Overlay struct {
 	cols      int
 	scrollPos int // index of top visible message
 	cursorPos int // index of selected message
-	active    bool
-	onDismiss func()
+	active         bool
+	onDismiss      func()
+	OnDraftRequest func(msg Message)
 
 	// Escape sequence state machine for arrow keys.
 	escState int // 0=normal, 1=got ESC, 2=got ESC+[
@@ -128,6 +129,8 @@ func (o *Overlay) HandleKey(b byte) {
 		o.moveCursor(1)
 	case 'd':
 		o.dismissSelected()
+	case 'a':
+		o.draftSelected()
 	}
 }
 
@@ -193,6 +196,36 @@ func (o *Overlay) dismissSelected() {
 	}
 }
 
+func (o *Overlay) draftSelected() {
+	msgs := o.queue.Messages()
+	if o.cursorPos >= len(msgs) {
+		return
+	}
+	msg := msgs[o.cursorPos]
+	o.queue.MarkRead(msg.ID)
+
+	// Dismiss the overlay first, then fire the draft callback.
+	o.active = false
+	fmt.Fprint(o.stdout, "\033[?25h\033[?1049l")
+	if o.copier != nil {
+		o.mu.Unlock()
+		o.copier.Flush()
+		o.mu.Lock()
+	}
+	if o.onDismiss != nil {
+		cb := o.onDismiss
+		o.mu.Unlock()
+		cb()
+		o.mu.Lock()
+	}
+	if o.OnDraftRequest != nil {
+		cb := o.OnDraftRequest
+		o.mu.Unlock()
+		cb(msg)
+		o.mu.Lock()
+	}
+}
+
 func (o *Overlay) render() {
 	msgs := o.queue.Messages()
 
@@ -208,8 +241,10 @@ func (o *Overlay) render() {
 	fmt.Fprintf(&buf, "\033[1m%s\033[0m\n", header)
 	buf.WriteString(strings.Repeat("─", o.cols) + "\n")
 
+	// Reserve rows for the detail pane (separator + channel/author + up to 5 body lines).
+	detailRows := 8
 	// Message list.
-	visible := o.rows - 4
+	visible := o.rows - 4 - detailRows
 	if visible < 1 {
 		visible = 1
 	}
@@ -241,11 +276,27 @@ func (o *Overlay) render() {
 			}
 			buf.WriteString(line + "\n")
 		}
+
+		// Detail pane for selected message.
+		if o.cursorPos < len(msgs) {
+			selected := msgs[o.cursorPos]
+			buf.WriteString("\n" + strings.Repeat("─", o.cols) + "\n")
+			buf.WriteString(fmt.Sprintf(" \033[1m%s · %s\033[0m\n", selected.Channel, selected.Author))
+			bodyLines := wrapText(selected.Body, o.cols-2)
+			maxBodyLines := 5
+			for i, line := range bodyLines {
+				if i >= maxBodyLines {
+					buf.WriteString("  ...\n")
+					break
+				}
+				buf.WriteString(" " + line + "\n")
+			}
+		}
 	}
 
 	// Footer.
 	footer := "\n" + strings.Repeat("─", o.cols) + "\n"
-	footer += " j/k or ↑/↓ navigate  d dismiss  q return"
+	footer += " j/k or ↑/↓ navigate  a draft reply  d dismiss  q return"
 	buf.WriteString(footer)
 
 	fmt.Fprint(o.stdout, buf.String())

--- a/core/launch/overlay_test.go
+++ b/core/launch/overlay_test.go
@@ -297,6 +297,30 @@ func TestOverlay_ExpandedBodyRendered(t *testing.T) {
 	}
 }
 
+func TestOverlay_ExpandedBodyLongTruncated(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	// Create a message with a very long body that exceeds 5 lines at 80 cols.
+	longBody := strings.Repeat("This is a very long sentence that should wrap across multiple lines. ", 10)
+	q.Push(launch.Message{
+		ID:      "1",
+		Source:  "slack",
+		Channel: "#backend",
+		Author:  "Sarah",
+		Preview: "Long msg...",
+		Body:    longBody,
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.Show()
+	out := w.String()
+
+	// Body is long enough to exceed 5 lines, so truncation indicator should appear.
+	if !strings.Contains(out, "...") {
+		t.Error("expected '...' truncation indicator for long body")
+	}
+}
+
 func TestOverlay_FooterShowsDraftAction(t *testing.T) {
 	q := launch.NewNotifyQueue(10, nil)
 	var w testWriter

--- a/core/launch/overlay_test.go
+++ b/core/launch/overlay_test.go
@@ -216,8 +216,10 @@ func TestOverlay_DraftRequestKey(t *testing.T) {
 	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "Does the auth change JWT claims?"})
 
 	var w testWriter
+	// Use a real OutputCopier so the copier branch in draftSelected is exercised.
+	copier := launch.NewOutputCopier(strings.NewReader(""), &w, nil)
 	dismissed := false
-	o := launch.NewOverlay(q, nil, &w, 24, 80, func() {
+	o := launch.NewOverlay(q, copier, &w, 24, 80, func() {
 		dismissed = true
 	})
 

--- a/core/launch/overlay_test.go
+++ b/core/launch/overlay_test.go
@@ -211,6 +211,102 @@ func TestOverlay_DismissSelected(t *testing.T) {
 	}
 }
 
+func TestOverlay_DraftRequestKey(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "Does the auth change JWT claims?"})
+
+	var w testWriter
+	dismissed := false
+	o := launch.NewOverlay(q, nil, &w, 24, 80, func() {
+		dismissed = true
+	})
+
+	var draftMsg launch.Message
+	draftCalled := false
+	o.OnDraftRequest = func(msg launch.Message) {
+		draftCalled = true
+		draftMsg = msg
+	}
+
+	o.Show()
+	o.HandleKey('a')
+
+	if !draftCalled {
+		t.Fatal("expected onDraftRequest to be called")
+	}
+	if draftMsg.ID != "1" {
+		t.Errorf("expected message ID '1', got %q", draftMsg.ID)
+	}
+	if draftMsg.Author != "Sarah" {
+		t.Errorf("expected author 'Sarah', got %q", draftMsg.Author)
+	}
+	if o.IsActive() {
+		t.Error("overlay should be dismissed after draft request")
+	}
+	if !dismissed {
+		t.Error("onDismiss should have been called")
+	}
+	// Message should be marked read.
+	if q.UnreadCount() != 0 {
+		t.Errorf("expected 0 unread, got %d", q.UnreadCount())
+	}
+}
+
+func TestOverlay_DraftRequestEmptyQueue(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 24, 80, nil)
+
+	draftCalled := false
+	o.OnDraftRequest = func(msg launch.Message) {
+		draftCalled = true
+	}
+
+	o.Show()
+	o.HandleKey('a') // should not panic
+
+	if draftCalled {
+		t.Error("onDraftRequest should not be called on empty queue")
+	}
+}
+
+func TestOverlay_ExpandedBodyRendered(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{
+		ID:      "1",
+		Source:  "slack",
+		Channel: "#backend",
+		Author:  "Sarah",
+		Preview: "Does the auth...",
+		Body:    "Does the new auth middleware change the JWT claims? I need to know before updating the mobile client.",
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.Show()
+	out := w.String()
+
+	// Should show the full body text (not just the preview).
+	if !strings.Contains(out, "JWT claims") {
+		t.Error("expected full message body in detail pane")
+	}
+	if !strings.Contains(out, "#backend") {
+		t.Error("expected channel in detail pane header")
+	}
+}
+
+func TestOverlay_FooterShowsDraftAction(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 24, 80, nil)
+	o.Show()
+	out := w.String()
+
+	if !strings.Contains(out, "a draft reply") {
+		t.Error("expected 'a draft reply' in footer")
+	}
+}
+
 func TestOverlay_Resize(t *testing.T) {
 	q := launch.NewNotifyQueue(10, nil)
 	q.Push(launch.Message{ID: "1", Preview: "msg"})


### PR DESCRIPTION
## Summary

- Add pty injection mechanism (`DraftInjector`) that writes draft-request prompts into the agent's stdin, triggering the agent to call `send_message` and flow through the existing approval UI
- On channels with `auto_draft: true` in `aileron.yaml`, incoming messages automatically trigger the agent to draft a reply
- Overlay now shows expanded message body for the selected notification and supports `a` to manually ask the agent to draft a reply
- Thread `AutoDraft` channel config from policy through `BridgeMessages` to stamp each queued message

## Test plan

- [ ] `go build ./...` compiles all modules
- [ ] `go test ./core/launch/... -count=1` passes (86.7% coverage)
- [ ] New tests: `TestDraftInjector_Inject`, `TestDraftInjector_InjectMultiple`, `TestNotifyQueue_AutoDraftCallbackFires`, `TestNotifyQueue_AutoDraftNilCallback`, `TestNotifyQueue_AutoDraftRoundtrip`, `TestOverlay_DraftRequestKey`, `TestOverlay_DraftRequestEmptyQueue`, `TestOverlay_ExpandedBodyRendered`, `TestOverlay_FooterShowsDraftAction`, `TestBridgeMessages_AutoDraft`
- [ ] Manual: `aileron launch claude` with Slack `auto_draft: true` channel — verify agent drafts reply and approval prompt appears

🤖 Generated with [Claude Code](https://claude.com/claude-code)