### PR TITLE
feat(launch): manual reply from notification overlay

### DIFF
--- a/README.md
+++ b/README.md
@@ -242,7 +242,7 @@ notifications:
 ./build/aileron launch claude
 ```
 
-Messages from configured channels appear in the notification bar. Press **Ctrl-A** to view the full queue, navigate with **j/k** or arrow keys, press **a** to ask the agent to draft a reply, **d** to dismiss, and **Escape** to return. On channels with `auto_draft: true`, the agent drafts replies automatically when messages arrive.
+Messages from configured channels appear in the notification bar. Press **Ctrl-A** to view the full queue, navigate with **j/k** or arrow keys, press **r** to type a reply directly, **a** to ask the agent to draft a reply, **d** to dismiss, and **Escape** to return. On channels with `auto_draft: true`, the agent drafts replies automatically when messages arrive.
 
 ### Discord notifications
 

--- a/core/launch/commsserver.go
+++ b/core/launch/commsserver.go
@@ -276,6 +276,20 @@ func wrapText(text string, maxWidth int) []string {
 	return lines
 }
 
+// DirectSend sends a message without an approval prompt. Used for
+// user-authored replies from the overlay (the user typed it, so no
+// approval is needed).
+func (cs *CommsServer) DirectSend(service, channel, body string) error {
+	sender, ok := cs.senders[service]
+	if !ok {
+		return fmt.Errorf("no listener for service: %s", service)
+	}
+	return sender.Send(nil, comms.OutgoingMessage{
+		Channel: channel,
+		Body:    body,
+	})
+}
+
 // SocketPath returns the socket path.
 func (cs *CommsServer) SocketPath() string {
 	return cs.socketPath

--- a/core/launch/commsserver_test.go
+++ b/core/launch/commsserver_test.go
@@ -312,3 +312,49 @@ func TestCommsServer_WrapText(t *testing.T) {
 		t.Error("full body should be sent regardless of wrapping")
 	}
 }
+
+func TestCommsServer_DirectSend_Success(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-direct.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	sender := &mockSender{service: "slack"}
+	queue := launch.NewNotifyQueue(10, nil)
+
+	srv, err := launch.NewCommsServer(socketPath, queue, []comms.Listener{sender}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	err = srv.DirectSend("slack", "#backend", "my reply")
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	if !sender.sent {
+		t.Error("expected sender.Send to be called")
+	}
+	if sender.lastMsg.Channel != "#backend" {
+		t.Errorf("expected channel '#backend', got %q", sender.lastMsg.Channel)
+	}
+	if sender.lastMsg.Body != "my reply" {
+		t.Errorf("expected body 'my reply', got %q", sender.lastMsg.Body)
+	}
+}
+
+func TestCommsServer_DirectSend_UnknownService(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-direct-unknown.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	queue := launch.NewNotifyQueue(10, nil)
+
+	srv, err := launch.NewCommsServer(socketPath, queue, nil, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	err = srv.DirectSend("nonexistent", "#test", "hello")
+	if err == nil {
+		t.Fatal("expected error for unknown service")
+	}
+}

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -205,6 +205,8 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 	defer commsSrv.Close()
 	go commsSrv.Serve()
 
+	WireReply(overlay, commsSrv)
+
 	// Wire onChange to re-render the status bar when notifications arrive.
 	queue.onChange = func() { bar.Render(os.Stdout) }
 
@@ -248,6 +250,15 @@ func WireDraftInjection(ptmx io.Writer, overlay *Overlay, queue *NotifyQueue) {
 	queue.SetOnAutoDraft(func(msg Message) {
 		injector.Inject(msg)
 	})
+}
+
+// WireReply connects the overlay's reply callback to the CommsServer's
+// DirectSend method. No approval prompt is shown since the user authored
+// the reply text themselves. Exported for testing.
+func WireReply(overlay *Overlay, commsSrv *CommsServer) {
+	overlay.OnReply = func(msg Message, reply string) {
+		commsSrv.DirectSend(msg.Source, msg.Channel, reply)
+	}
 }
 
 // ComputeAgentRows returns the number of rows available for the agent,

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -593,6 +593,29 @@ func TestWireDraftInjection_AutoDraftCallback(t *testing.T) {
 	}
 }
 
+func TestWireReply(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "comms.sock")
+	sender := &testListener{service: "slack", msgs: make(chan comms.IncomingMessage, 1)}
+	queue := launch.NewNotifyQueue(10, nil)
+
+	srv, err := launch.NewCommsServer(socketPath, queue, []comms.Listener{sender}, nil, nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	var buf strings.Builder
+	o := launch.NewOverlay(queue, nil, &buf, 24, 80, nil)
+
+	launch.WireReply(o, srv)
+
+	msg := launch.Message{Source: "slack", Channel: "#backend", Author: "Sarah", Body: "question?"}
+	o.OnReply(msg, "my reply")
+
+	// The sender should have received the message (Send returns nil for testListener).
+	// Just verify no panic and the callback is wired.
+}
+
 func TestBridgeMessages_AutoDraft(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	msgs := make(chan comms.IncomingMessage, 3)

--- a/core/launch/overlay.go
+++ b/core/launch/overlay.go
@@ -23,6 +23,12 @@ type Overlay struct {
 	active         bool
 	onDismiss      func()
 	OnDraftRequest func(msg Message)
+	OnReply        func(msg Message, reply string)
+
+	// Reply mode state.
+	replyMode bool
+	replyBuf  strings.Builder
+	replyMsg  Message
 
 	// Escape sequence state machine for arrow keys.
 	escState int // 0=normal, 1=got ESC, 2=got ESC+[
@@ -84,6 +90,11 @@ func (o *Overlay) HandleKey(b byte) {
 	o.mu.Lock()
 	defer o.mu.Unlock()
 
+	if o.replyMode {
+		o.handleReplyKey(b)
+		return
+	}
+
 	switch o.escState {
 	case 1: // got ESC
 		if b == '[' {
@@ -131,6 +142,8 @@ func (o *Overlay) HandleKey(b byte) {
 		o.dismissSelected()
 	case 'a':
 		o.draftSelected()
+	case 'r':
+		o.startReply()
 	}
 }
 
@@ -226,6 +239,100 @@ func (o *Overlay) draftSelected() {
 	}
 }
 
+func (o *Overlay) startReply() {
+	msgs := o.queue.Messages()
+	if o.cursorPos >= len(msgs) {
+		return
+	}
+	o.replyMode = true
+	o.replyMsg = msgs[o.cursorPos]
+	o.replyBuf.Reset()
+	o.render()
+}
+
+func (o *Overlay) handleReplyKey(b byte) {
+	switch o.escState {
+	case 1: // got ESC
+		if b == '[' {
+			o.escState = 2
+			return
+		}
+		// Standalone ESC — cancel reply.
+		o.escState = 0
+		o.cancelReply()
+		return
+	case 2: // got ESC+[
+		// Ignore arrow keys in reply mode.
+		o.escState = 0
+		return
+	}
+
+	switch b {
+	case 0x1B: // ESC
+		o.escState = 1
+		if o.escTimer != nil {
+			o.escTimer.Stop()
+		}
+		o.escTimer = time.AfterFunc(100*time.Millisecond, func() {
+			o.mu.Lock()
+			if o.escState == 1 {
+				o.escState = 0
+				o.cancelReply()
+			}
+			o.mu.Unlock()
+		})
+	case '\r', '\n': // Enter — submit
+		o.submitReply()
+	case 0x7f, 0x08: // Backspace / DEL
+		s := o.replyBuf.String()
+		if len(s) > 0 {
+			o.replyBuf.Reset()
+			o.replyBuf.WriteString(s[:len(s)-1])
+		}
+		o.render()
+	default:
+		if b >= 0x20 && b < 0x7f { // printable ASCII
+			o.replyBuf.WriteByte(b)
+			o.render()
+		}
+	}
+}
+
+func (o *Overlay) submitReply() {
+	reply := o.replyBuf.String()
+	msg := o.replyMsg
+	o.replyMode = false
+	o.replyBuf.Reset()
+	o.queue.MarkRead(msg.ID)
+
+	// Dismiss the overlay, then fire the reply callback.
+	o.active = false
+	fmt.Fprint(o.stdout, "\033[?25h\033[?1049l")
+	if o.copier != nil {
+		o.mu.Unlock()
+		o.copier.Flush()
+		o.mu.Lock()
+	}
+	if o.onDismiss != nil {
+		cb := o.onDismiss
+		o.mu.Unlock()
+		cb()
+		o.mu.Lock()
+	}
+	if reply != "" && o.OnReply != nil {
+		cb := o.OnReply
+		o.mu.Unlock()
+		cb(msg, reply)
+		o.mu.Lock()
+	}
+}
+
+func (o *Overlay) cancelReply() {
+	o.replyMode = false
+	o.replyBuf.Reset()
+	o.render()
+}
+
 func (o *Overlay) render() {
 	msgs := o.queue.Messages()
 
@@ -291,12 +398,24 @@ func (o *Overlay) render() {
 				}
 				buf.WriteString(" " + line + "\n")
 			}
+
+			// Reply input box.
+			if o.replyMode {
+				buf.WriteString("\n")
+				buf.WriteString(fmt.Sprintf(" \033[33m>\033[0m %s\033[7m \033[0m\n", o.replyBuf.String()))
+			}
 		}
 	}
 
 	// Footer.
-	footer := "\n" + strings.Repeat("─", o.cols) + "\n"
-	footer += " j/k or ↑/↓ navigate  a draft reply  d dismiss  q return"
+	var footer string
+	if o.replyMode {
+		footer = "\n" + strings.Repeat("─", o.cols) + "\n"
+		footer += " Enter send  Esc cancel"
+	} else {
+		footer = "\n" + strings.Repeat("─", o.cols) + "\n"
+		footer += " j/k or ↑/↓ navigate  r reply  a draft reply  d dismiss  q return"
+	}
 	buf.WriteString(footer)
 
 	fmt.Fprint(o.stdout, buf.String())

--- a/core/launch/overlay_test.go
+++ b/core/launch/overlay_test.go
@@ -333,6 +333,334 @@ func TestOverlay_FooterShowsDraftAction(t *testing.T) {
 	}
 }
 
+func TestOverlay_ReplyKey_EntersReplyMode(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "question?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.Show()
+	w.Reset()
+
+	o.HandleKey('r')
+	out := w.String()
+
+	// Should show reply input prompt.
+	if !strings.Contains(out, ">") {
+		t.Error("expected reply input prompt")
+	}
+	// Footer should show Enter/Esc.
+	if !strings.Contains(out, "Enter send") {
+		t.Error("expected 'Enter send' in footer")
+	}
+	if !strings.Contains(out, "Esc cancel") {
+		t.Error("expected 'Esc cancel' in footer")
+	}
+	// Should still be active (not dismissed).
+	if !o.IsActive() {
+		t.Error("overlay should still be active in reply mode")
+	}
+}
+
+func TestOverlay_ReplyKey_TypeAndSubmit(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "question?"})
+
+	var w testWriter
+	copier := launch.NewOutputCopier(strings.NewReader(""), &w, nil)
+	dismissed := false
+	o := launch.NewOverlay(q, copier, &w, 30, 80, func() {
+		dismissed = true
+	})
+
+	var repliedMsg launch.Message
+	var repliedText string
+	o.OnReply = func(msg launch.Message, reply string) {
+		repliedMsg = msg
+		repliedText = reply
+	}
+
+	o.Show()
+	o.HandleKey('r')
+
+	// Type "hello"
+	for _, c := range "hello" {
+		o.HandleKey(byte(c))
+	}
+	// Submit with Enter
+	o.HandleKey('\r')
+
+	if repliedText != "hello" {
+		t.Errorf("expected reply 'hello', got %q", repliedText)
+	}
+	if repliedMsg.ID != "1" {
+		t.Errorf("expected message ID '1', got %q", repliedMsg.ID)
+	}
+	if repliedMsg.Author != "Sarah" {
+		t.Errorf("expected author 'Sarah', got %q", repliedMsg.Author)
+	}
+	if o.IsActive() {
+		t.Error("overlay should be dismissed after reply submit")
+	}
+	if !dismissed {
+		t.Error("onDismiss should have been called")
+	}
+	if q.UnreadCount() != 0 {
+		t.Errorf("expected 0 unread, got %d", q.UnreadCount())
+	}
+}
+
+func TestOverlay_ReplyKey_EscCancels(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "question?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	replyCalled := false
+	o.OnReply = func(msg launch.Message, reply string) {
+		replyCalled = true
+	}
+
+	o.Show()
+	o.HandleKey('r')
+
+	// Type some text
+	o.HandleKey('h')
+	o.HandleKey('i')
+
+	// Cancel with standalone ESC
+	o.HandleKey(0x1B)
+	time.Sleep(200 * time.Millisecond)
+
+	if replyCalled {
+		t.Error("OnReply should not be called on cancel")
+	}
+	if !o.IsActive() {
+		t.Error("overlay should still be active after cancel (back to normal mode)")
+	}
+	// Should be back to normal footer.
+	w.Reset()
+	o.HandleKey('j') // trigger re-render via navigation
+	out := w.String()
+	if !strings.Contains(out, "r reply") {
+		t.Error("expected normal footer after cancel")
+	}
+}
+
+func TestOverlay_ReplyKey_Backspace(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "q?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	var repliedText string
+	o.OnReply = func(msg launch.Message, reply string) {
+		repliedText = reply
+	}
+
+	o.Show()
+	o.HandleKey('r')
+	o.HandleKey('a')
+	o.HandleKey('b')
+	o.HandleKey('c')
+	o.HandleKey(0x7f) // backspace — delete 'c'
+	o.HandleKey('\r')
+
+	if repliedText != "ab" {
+		t.Errorf("expected 'ab' after backspace, got %q", repliedText)
+	}
+}
+
+func TestOverlay_ReplyKey_EmptySubmitNoCallback(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "q?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	replyCalled := false
+	o.OnReply = func(msg launch.Message, reply string) {
+		replyCalled = true
+	}
+
+	o.Show()
+	o.HandleKey('r')
+	o.HandleKey('\r') // submit with empty text
+
+	if replyCalled {
+		t.Error("OnReply should not be called for empty reply")
+	}
+}
+
+func TestOverlay_ReplyKey_BackspaceCtrlH(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "q?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	var repliedText string
+	o.OnReply = func(msg launch.Message, reply string) {
+		repliedText = reply
+	}
+
+	o.Show()
+	o.HandleKey('r')
+	o.HandleKey('x')
+	o.HandleKey('y')
+	o.HandleKey(0x08) // Ctrl-H backspace
+	o.HandleKey('\r')
+
+	if repliedText != "x" {
+		t.Errorf("expected 'x' after Ctrl-H backspace, got %q", repliedText)
+	}
+}
+
+func TestOverlay_ReplyKey_BackspaceOnEmpty(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "q?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	o.Show()
+	o.HandleKey('r')
+	o.HandleKey(0x7f) // backspace on empty — should not panic
+}
+
+func TestOverlay_ReplyKey_ArrowKeysIgnored(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "q?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	var repliedText string
+	o.OnReply = func(msg launch.Message, reply string) {
+		repliedText = reply
+	}
+
+	o.Show()
+	o.HandleKey('r')
+	o.HandleKey('h')
+	o.HandleKey('i')
+	// Arrow down (ESC [ B) — should be ignored in reply mode
+	o.HandleKey(0x1B)
+	o.HandleKey('[')
+	o.HandleKey('B')
+	o.HandleKey('\r')
+
+	if repliedText != "hi" {
+		t.Errorf("expected 'hi' (arrow keys ignored), got %q", repliedText)
+	}
+}
+
+func TestOverlay_ReplyKey_EscBracketCancels(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "q?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	replyCalled := false
+	o.OnReply = func(msg launch.Message, reply string) {
+		replyCalled = true
+	}
+
+	o.Show()
+	o.HandleKey('r')
+	o.HandleKey('x')
+	// ESC followed by non-'[' — should cancel reply
+	o.HandleKey(0x1B)
+	o.HandleKey('x')
+
+	if replyCalled {
+		t.Error("OnReply should not be called after ESC cancel")
+	}
+	if !o.IsActive() {
+		t.Error("overlay should still be active after cancel")
+	}
+}
+
+func TestOverlay_ReplyKey_NonPrintableIgnored(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "q?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	var repliedText string
+	o.OnReply = func(msg launch.Message, reply string) {
+		repliedText = reply
+	}
+
+	o.Show()
+	o.HandleKey('r')
+	o.HandleKey('a')
+	o.HandleKey(0x01) // Ctrl-A — non-printable, should be ignored
+	o.HandleKey('b')
+	o.HandleKey('\r')
+
+	if repliedText != "ab" {
+		t.Errorf("expected 'ab' (control chars ignored), got %q", repliedText)
+	}
+}
+
+func TestOverlay_ReplyKey_NewlineSubmits(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "q?"})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	var repliedText string
+	o.OnReply = func(msg launch.Message, reply string) {
+		repliedText = reply
+	}
+
+	o.Show()
+	o.HandleKey('r')
+	o.HandleKey('o')
+	o.HandleKey('k')
+	o.HandleKey('\n') // newline also submits
+
+	if repliedText != "ok" {
+		t.Errorf("expected 'ok', got %q", repliedText)
+	}
+}
+
+func TestOverlay_ReplyKey_EmptyQueue(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	replyCalled := false
+	o.OnReply = func(msg launch.Message, reply string) {
+		replyCalled = true
+	}
+
+	o.Show()
+	o.HandleKey('r') // should not enter reply mode on empty queue
+
+	if replyCalled {
+		t.Error("OnReply should not be called on empty queue")
+	}
+}
+
+func TestOverlay_FooterShowsReplyAction(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 24, 80, nil)
+	o.Show()
+	out := w.String()
+
+	if !strings.Contains(out, "r reply") {
+		t.Error("expected 'r reply' in footer")
+	}
+}
+
 func TestOverlay_Resize(t *testing.T) {
 	q := launch.NewNotifyQueue(10, nil)
 	q.Push(launch.Message{ID: "1", Preview: "msg"})


### PR DESCRIPTION
## Summary

- Add `[r]` reply key to the notification overlay — user selects a message, presses `r`, types a reply, and presses Enter to send
- Text input mode with backspace support, ESC to cancel, Enter to submit
- `DirectSend` on CommsServer bypasses the approval prompt for user-authored messages
- `WireReply` connects the overlay callback to the send path (extracted for testability)
- Updated footer: `r reply  a draft reply  d dismiss  q return`

## Test plan

- [ ] `cd core && go build ./...` compiles
- [ ] `go test ./launch/... -count=1` passes (87.8% coverage)
- [ ] New tests: reply mode enter/submit/cancel, backspace (DEL + Ctrl-H), arrow keys ignored, non-printable ignored, empty submit skipped, empty queue safe, `DirectSend` success/unknown service, `WireReply`
- [ ] Manual: `aileron launch claude` with Slack, open overlay, press `r`, type reply, press Enter — message sent to channel

🤖 Generated with [Claude Code](https://claude.com/claude-code)