### PR TITLE
feat: credential brokering with encrypted vault and http_request tool

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,9 +244,9 @@ notifications:
       - "#random"
 ```
 
-Plaintext tokens (`xapp-...`, `xoxb-...`) also work directly in the YAML fields if you prefer.
+Token fields in `aileron.yaml` **must** use `vault:` references. Aileron rejects plaintext tokens to prevent secrets from being committed to version control. The `aileron.yaml` policy file is designed to be checked in and reviewed in PRs — credentials don't belong there.
 
-**4. Launch as usual** — Aileron prompts for the vault passphrase if needed, then starts the Slack listener:
+**4. Launch as usual** — Aileron prompts for the vault passphrase, then starts the Slack listener:
 
 ```sh
 ./build/aileron launch claude

--- a/README.md
+++ b/README.md
@@ -218,13 +218,21 @@ Aileron can receive Slack messages in your terminal while you work. Incoming mes
 - A **Bot Token** (`xoxb-...`) with `channels:history`, `channels:read`, `chat:write`, `users:read` scopes
 - Subscribe to the `message.channels` event
 
-**2. Add the tokens to your `aileron.yaml`:**
+**2. Store tokens in the encrypted vault** (instead of plaintext in YAML):
+
+```sh
+./build/aileron secret set slack_app_token    # prompts for passphrase + token
+./build/aileron secret set slack_bot_token
+./build/aileron secret list                   # shows stored names
+```
+
+**3. Reference them in `aileron.yaml`:**
 
 ```yaml
 notifications:
   slack:
-    app_token: xapp-1-A0123456789-...
-    bot_token: xoxb-...
+    app_token: vault:slack_app_token
+    bot_token: vault:slack_bot_token
     channels:
       - name: "#backend"
         show: all
@@ -236,7 +244,9 @@ notifications:
       - "#random"
 ```
 
-**3. Launch as usual** — Aileron starts the Slack listener automatically:
+Plaintext tokens (`xapp-...`, `xoxb-...`) also work directly in the YAML fields if you prefer.
+
+**4. Launch as usual** — Aileron prompts for the vault passphrase if needed, then starts the Slack listener:
 
 ```sh
 ./build/aileron launch claude

--- a/cmd/aileron-mcp/main.go
+++ b/cmd/aileron-mcp/main.go
@@ -117,6 +117,21 @@ var sendMessageTool = toolDef{
 	},
 }
 
+var httpRequestTool = toolDef{
+	Name:        "http_request",
+	Description: "Make an authenticated HTTP request. Aileron matches the URL against configured secrets and injects credentials. Requires human approval.",
+	InputSchema: schema{
+		Type: "object",
+		Properties: map[string]schemaProp{
+			"method":  {Type: "string", Description: "HTTP method (GET, POST, PUT, DELETE, PATCH)"},
+			"url":     {Type: "string", Description: "Target URL"},
+			"headers": {Type: "string", Description: "JSON object of request headers (optional)"},
+			"body":    {Type: "string", Description: "Request body string (optional)"},
+		},
+		Required: []string{"method", "url"},
+	},
+}
+
 // submitIntentTool is the legacy cloud tool.
 var submitIntentTool = toolDef{
 	Name:        "submit_intent",
@@ -230,7 +245,7 @@ func (s *server) handle(req jsonrpcRequest) *jsonrpcResponse {
 func (s *server) availableTools() []toolDef {
 	var tools []toolDef
 	if s.commsSocket != "" {
-		tools = append(tools, readMessagesTool, sendMessageTool)
+		tools = append(tools, readMessagesTool, sendMessageTool, httpRequestTool)
 	}
 	if s.aileronURL != "" {
 		tools = append(tools, submitIntentTool)
@@ -246,6 +261,8 @@ func (s *server) dispatchTool(ctx context.Context, name string, args map[string]
 		return s.readMessages(args)
 	case "send_message":
 		return s.sendMessage(args)
+	case "http_request":
+		return s.httpRequest(args)
 	default:
 		return errorResult("unknown tool: " + name)
 	}
@@ -297,6 +314,41 @@ func (s *server) sendMessage(args map[string]any) toolResult {
 	}
 }
 
+func (s *server) httpRequest(args map[string]any) toolResult {
+	if s.commsSocket == "" {
+		return errorResult("comms not available (not launched via aileron)")
+	}
+
+	method, _ := args["method"].(string)
+	url, _ := args["url"].(string)
+	headers, _ := args["headers"].(string)
+	body, _ := args["body"].(string)
+
+	if method == "" || url == "" {
+		return errorResult("method and url are required")
+	}
+
+	resp := requestComms(s.commsSocket, commsRequest{
+		Method:  "http_request",
+		Service: method,  // repurpose Service field for HTTP method
+		Channel: url,     // repurpose Channel field for URL
+		Body:    body,
+		ReplyTo: headers, // repurpose ReplyTo field for headers JSON
+	})
+	if resp.Error != "" {
+		return errorResult(resp.Error)
+	}
+	// Response body is in the first message's Body field.
+	if len(resp.Messages) > 0 {
+		return toolResult{
+			Content: []toolContent{{Type: "text", Text: resp.Messages[0].Body}},
+		}
+	}
+	return toolResult{
+		Content: []toolContent{{Type: "text", Text: "Request completed (no response body)."}},
+	}
+}
+
 // --- Comms IPC types (mirrors core/launch/commsserver.go) ---
 
 type commsRequest struct {
@@ -304,6 +356,7 @@ type commsRequest struct {
 	Service string `json:"service,omitempty"`
 	Channel string `json:"channel,omitempty"`
 	Body    string `json:"body,omitempty"`
+	ReplyTo string `json:"reply_to,omitempty"`
 }
 
 type commsResponse struct {

--- a/cmd/aileron-mcp/main_test.go
+++ b/cmd/aileron-mcp/main_test.go
@@ -82,15 +82,15 @@ func TestHandle_ToolsList_WithComms(t *testing.T) {
 	})
 	result := resp.Result.(map[string]any)
 	tools := result["tools"].([]toolDef)
-	if len(tools) != 2 {
-		t.Fatalf("expected 2 tools (read_messages, send_message), got %d", len(tools))
+	if len(tools) != 3 {
+		t.Fatalf("expected 3 tools (read_messages, send_message, http_request), got %d", len(tools))
 	}
 	names := map[string]bool{}
 	for _, tool := range tools {
 		names[tool.Name] = true
 	}
-	if !names["read_messages"] || !names["send_message"] {
-		t.Errorf("expected read_messages and send_message, got %v", names)
+	if !names["read_messages"] || !names["send_message"] || !names["http_request"] {
+		t.Errorf("expected read_messages, send_message, and http_request, got %v", names)
 	}
 }
 
@@ -103,8 +103,8 @@ func TestHandle_ToolsList_Both(t *testing.T) {
 	})
 	result := resp.Result.(map[string]any)
 	tools := result["tools"].([]toolDef)
-	if len(tools) != 3 {
-		t.Fatalf("expected 3 tools, got %d", len(tools))
+	if len(tools) != 4 {
+		t.Fatalf("expected 4 tools, got %d", len(tools))
 	}
 }
 
@@ -306,6 +306,101 @@ func containsStr(s, sub string) bool {
 		}
 	}
 	return false
+}
+
+func TestHttpRequest_NoSocket(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	result := s.httpRequest(map[string]any{"method": "GET", "url": "https://example.com"})
+	if !result.IsError {
+		t.Fatal("expected error without comms socket")
+	}
+}
+
+func TestHttpRequest_MissingFields(t *testing.T) {
+	s := &server{commsSocket: "/tmp/test.sock", httpClient: &http.Client{}}
+	result := s.httpRequest(map[string]any{})
+	if !result.IsError {
+		t.Fatal("expected error for missing fields")
+	}
+}
+
+func TestHttpRequest_WithServer(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-mcp-test-http.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req commsRequest
+			json.NewDecoder(conn).Decode(&req)
+			json.NewEncoder(conn).Encode(commsResponse{
+				OK: true,
+				Messages: []commsMessage{
+					{ID: "200", Body: `{"result": "ok"}`},
+				},
+			})
+			conn.Close()
+		}
+	}()
+
+	s := &server{commsSocket: socketPath, httpClient: &http.Client{}}
+	result := s.httpRequest(map[string]any{"method": "GET", "url": "https://api.example.com/test"})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+	}
+	if !contains(result.Content[0].Text, "ok") {
+		t.Errorf("expected response body, got %s", result.Content[0].Text)
+	}
+}
+
+func TestHttpRequest_WithServer_NoBody(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-mcp-test-http-nobody.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req commsRequest
+			json.NewDecoder(conn).Decode(&req)
+			json.NewEncoder(conn).Encode(commsResponse{OK: true})
+			conn.Close()
+		}
+	}()
+
+	s := &server{commsSocket: socketPath, httpClient: &http.Client{}}
+	result := s.httpRequest(map[string]any{"method": "GET", "url": "https://example.com"})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+	}
+	if !contains(result.Content[0].Text, "no response body") {
+		t.Errorf("expected 'no response body' message, got %s", result.Content[0].Text)
+	}
+}
+
+func TestDispatchTool_HttpRequest(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	result := s.dispatchTool(context.Background(), "http_request", map[string]any{"method": "GET", "url": "https://example.com"})
+	if !result.IsError {
+		t.Fatal("expected error without comms socket")
+	}
 }
 
 func TestHandle_Ping(t *testing.T) {

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -13,7 +13,9 @@ import (
 	"github.com/ALRubinger/aileron/core/launch"
 	"github.com/ALRubinger/aileron/core/launch/agents"
 	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/vault"
 	"github.com/ALRubinger/aileron/core/version"
+	"golang.org/x/term"
 )
 
 func main() {
@@ -71,6 +73,8 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		}
 		fmt.Fprintln(stderr, "usage: aileron policy test <command> [command...]")
 		return 1
+	case "secret":
+		return runSecret(args[1:], stdout, stderr)
 	case "log":
 		return runLog(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
@@ -90,6 +94,8 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron init                       Scaffold aileron.yaml for this project")
 	fmt.Fprintln(w, "  aileron launch <agent> [args...]   Launch an agent with policy-enforced shell")
 	fmt.Fprintln(w, "  aileron policy test <cmd> [cmd..]  Dry-run commands against loaded policy")
+	fmt.Fprintln(w, "  aileron secret set <name>          Store a secret in the encrypted vault")
+	fmt.Fprintln(w, "  aileron secret list                List stored secret names")
 	fmt.Fprintln(w, "  aileron log [flags]                View the audit trail")
 	fmt.Fprintln(w, "  aileron version                    Print version information")
 	fmt.Fprintln(w, "  aileron help                       Show this help")
@@ -201,6 +207,112 @@ func runLog(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "%s  %-13s  %-12s  %s\n", ts, e.Disposition, e.RuleID, e.Command)
 	}
 	return 0
+}
+
+// runSecret handles the "aileron secret" subcommands.
+func runSecret(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: aileron secret <set|list>")
+		return 1
+	}
+
+	switch args[0] {
+	case "set":
+		return runSecretSet(args[1:], stdout, stderr)
+	case "list":
+		return runSecretList(stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown secret command: %q\n", args[0])
+		fmt.Fprintln(stderr, "usage: aileron secret <set|list>")
+		return 1
+	}
+}
+
+// runSecretSet stores a secret in the local vault.
+func runSecretSet(args []string, stdout, stderr io.Writer) int {
+	if len(args) < 1 {
+		fmt.Fprintln(stderr, "usage: aileron secret set <name>")
+		return 1
+	}
+	name := args[0]
+
+	passphrase, err := promptPassphrase("Vault passphrase: ", stderr)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprint(stderr, "Secret value: ")
+	value, err := promptPassphrase("", nil) // already printed prompt
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Fprintln(stderr) // newline after hidden input
+
+	v, err := launch.OpenLocalVault(launch.DefaultVaultPath(), passphrase)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if err := v.Put(context.Background(), name, []byte(value), vault.Metadata{Type: "secret"}); err != nil {
+		fmt.Fprintf(stderr, "error storing secret: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Stored secret %q\n", name)
+	fmt.Fprintf(stdout, "Use vault:%s in aileron.yaml to reference it.\n", name)
+	return 0
+}
+
+// runSecretList lists secret names in the vault.
+func runSecretList(stdout, stderr io.Writer) int {
+	vaultPath := launch.DefaultVaultPath()
+	fv, err := vault.NewFileVault(vaultPath)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	names := fv.Names()
+	if len(names) == 0 {
+		fmt.Fprintln(stdout, "No secrets stored.")
+		return 0
+	}
+
+	for _, name := range names {
+		fmt.Fprintln(stdout, name)
+	}
+	return 0
+}
+
+// promptPassphrase reads a password from the terminal without echoing.
+func promptPassphrase(prompt string, w io.Writer) (string, error) {
+	if w != nil && prompt != "" {
+		fmt.Fprint(w, prompt)
+	}
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return "", fmt.Errorf("cannot open terminal: %w", err)
+	}
+	defer tty.Close()
+
+	pass, err := readPassword(int(tty.Fd()))
+	if err != nil {
+		return "", fmt.Errorf("reading input: %w", err)
+	}
+	if w != nil {
+		fmt.Fprintln(w) // newline after hidden input
+	}
+	return string(pass), nil
+}
+
+// readPassword reads a password from a file descriptor. Extracted for testing.
+var readPassword = defaultReadPassword
+
+func defaultReadPassword(fd int) ([]byte, error) {
+	return term.ReadPassword(fd)
 }
 
 // resolveShim finds the aileron-sh binary next to this executable, or on PATH.

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -356,3 +356,84 @@ func TestRunLog_HelpShownInUsage(t *testing.T) {
 		t.Error("expected 'aileron log' in help output")
 	}
 }
+
+func TestRunSecret_NoSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"secret"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "usage: aileron secret") {
+		t.Errorf("expected usage message, got: %s", stderr.String())
+	}
+}
+
+func TestRunSecret_UnknownSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"secret", "bogus"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), `unknown secret command: "bogus"`) {
+		t.Errorf("expected unknown command error, got: %s", stderr.String())
+	}
+}
+
+func TestRunSecret_SetNoName(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"secret", "set"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "usage: aileron secret set") {
+		t.Errorf("expected usage message, got: %s", stderr.String())
+	}
+}
+
+func TestRunSecret_ListEmpty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"secret", "list"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No secrets stored") {
+		t.Errorf("expected 'No secrets stored', got: %s", stdout.String())
+	}
+}
+
+func TestRunSecret_ListWithSecrets(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	// Pre-populate the vault file directly (skip encryption for test).
+	vaultPath := filepath.Join(dir, ".aileron", "secrets.json")
+	os.MkdirAll(filepath.Dir(vaultPath), 0o700)
+	os.WriteFile(vaultPath, []byte(`{"salt":"AAAA","secrets":{"slack_bot_token":{"value":"ZW5j","metadata":{"type":"secret"}},"discord_token":{"value":"ZW5j","metadata":{"type":"secret"}}}}`), 0o600)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"secret", "list"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Errorf("expected exit code 0, got %d; stderr: %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "slack_bot_token") {
+		t.Errorf("expected 'slack_bot_token' in output, got: %s", out)
+	}
+	if !strings.Contains(out, "discord_token") {
+		t.Errorf("expected 'discord_token' in output, got: %s", out)
+	}
+}
+
+func TestRunSecret_InHelp(t *testing.T) {
+	var stdout bytes.Buffer
+	run([]string{"help"}, newTestRegistry(), &stdout, &bytes.Buffer{})
+	if !strings.Contains(stdout.String(), "aileron secret set") {
+		t.Error("expected 'aileron secret set' in help output")
+	}
+	if !strings.Contains(stdout.String(), "aileron secret list") {
+		t.Error("expected 'aileron secret list' in help output")
+	}
+}

--- a/core/launch/commsserver.go
+++ b/core/launch/commsserver.go
@@ -3,7 +3,9 @@ package launch
 import (
 	"encoding/json"
 	"fmt"
+	"io"
 	"net"
+	"net/http"
 	"os"
 	"strings"
 	"sync"
@@ -11,6 +13,8 @@ import (
 
 	"github.com/ALRubinger/aileron/core/audit"
 	"github.com/ALRubinger/aileron/core/comms"
+	launchpolicy "github.com/ALRubinger/aileron/core/policy/launch"
+	"github.com/ALRubinger/aileron/core/vault"
 )
 
 // CommsRequest is sent by aileron-mcp to read or send messages.
@@ -52,6 +56,9 @@ type CommsServer struct {
 	router     *KeyRouter
 	auditLog   string
 	sessionID  string
+	secrets    launchpolicy.SecretsConfig
+	vault      vault.Vault
+	httpClient *http.Client
 
 	mu   sync.Mutex
 	done bool
@@ -117,6 +124,8 @@ func (cs *CommsServer) handleConn(conn net.Conn) {
 		resp = cs.readMessages(req)
 	case "send_message":
 		resp = cs.sendMessage(req)
+	case "http_request":
+		resp = cs.httpRequest(req)
 	default:
 		resp = CommsResponse{Error: "unknown method: " + req.Method}
 	}
@@ -300,6 +309,113 @@ func (cs *CommsServer) DirectSend(service, channel, body string) error {
 		cs.logMessage("reply_sent", service, channel, "", body, "")
 	}
 	return err
+}
+
+// SetSecrets configures the secrets mapping and vault for http_request
+// credential injection. Called after vault is opened at launch time.
+func (cs *CommsServer) SetSecrets(secrets launchpolicy.SecretsConfig, v vault.Vault) {
+	cs.secrets = secrets
+	cs.vault = v
+	cs.httpClient = &http.Client{}
+}
+
+func (cs *CommsServer) httpRequest(req CommsRequest) CommsResponse {
+	// Fields are repurposed: Service=HTTP method, Channel=URL, Body=body, ReplyTo=headers JSON.
+	method := req.Service
+	url := req.Channel
+	body := req.Body
+	headersJSON := req.ReplyTo
+
+	if method == "" || url == "" {
+		return CommsResponse{Error: "method and url are required"}
+	}
+
+	// Match URL against secrets config to find credential.
+	secretName, _ := cs.matchSecret(url)
+
+	// Prompt user approval.
+	detail := fmt.Sprintf("%s %s", method, url)
+	if secretName != "" {
+		detail += fmt.Sprintf(" (credential: %s)", secretName)
+	}
+	decision := cs.promptSendApproval("http", detail, body)
+	if decision != "approve" {
+		cs.logMessage("http_request_denied", method, url, "", body, "")
+		return CommsResponse{Error: "request denied by user"}
+	}
+
+	// Build HTTP request.
+	var bodyReader io.Reader
+	if body != "" {
+		bodyReader = strings.NewReader(body)
+	}
+	httpReq, err := http.NewRequest(method, url, bodyReader)
+	if err != nil {
+		return CommsResponse{Error: "invalid request: " + err.Error()}
+	}
+
+	// Parse and set headers.
+	if headersJSON != "" {
+		var headers map[string]string
+		if err := json.Unmarshal([]byte(headersJSON), &headers); err == nil {
+			for k, v := range headers {
+				httpReq.Header.Set(k, v)
+			}
+		}
+	}
+
+	// Inject credential if matched.
+	if secretName != "" && cs.vault != nil {
+		secret, err := cs.vault.Get(nil, secretName)
+		if err == nil {
+			httpReq.Header.Set("Authorization", "Bearer "+string(secret.Value))
+		}
+	}
+
+	// Execute request.
+	client := cs.httpClient
+	if client == nil {
+		client = &http.Client{}
+	}
+	resp, err := client.Do(httpReq)
+	if err != nil {
+		return CommsResponse{Error: "request failed: " + err.Error()}
+	}
+	defer resp.Body.Close()
+
+	respBody, _ := io.ReadAll(io.LimitReader(resp.Body, 1<<20)) // 1MB limit
+	cs.logMessage("http_request_sent", method, url, "", string(respBody), "")
+
+	return CommsResponse{
+		OK: true,
+		Messages: []CommsMessageDTO{{
+			ID:   fmt.Sprintf("%d", resp.StatusCode),
+			Body: string(respBody),
+		}},
+	}
+}
+
+// matchSecret finds the first secret whose target patterns match the URL.
+func (cs *CommsServer) matchSecret(url string) (string, bool) {
+	for name, def := range cs.secrets {
+		for _, pattern := range def.Targets {
+			if URLMatchesPattern(url, pattern) {
+				return name, true
+			}
+		}
+	}
+	return "", false
+}
+
+// URLMatchesPattern checks if a URL matches a target pattern.
+// Patterns use simple prefix matching with optional trailing wildcard.
+// Examples: "slack.com/api/*" matches "https://slack.com/api/chat.postMessage"
+func URLMatchesPattern(url, pattern string) bool {
+	if strings.HasSuffix(pattern, "*") {
+		prefix := strings.TrimSuffix(pattern, "*")
+		return strings.Contains(url, prefix)
+	}
+	return strings.Contains(url, pattern)
 }
 
 func (cs *CommsServer) logMessage(event, service, channel, author, body, inReplyTo string) {

--- a/core/launch/commsserver_test.go
+++ b/core/launch/commsserver_test.go
@@ -515,6 +515,61 @@ func TestCommsServer_HttpRequest_WithApproval(t *testing.T) {
 	}
 }
 
+func TestCommsServer_HttpRequest_WithHeadersAndBody(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-http-headers.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	mockAPI := &mockHTTPServer{
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			ct := r.Header.Get("Content-Type")
+			w.Write([]byte("ct:" + ct))
+		},
+	}
+	ts := mockAPI.start()
+	defer ts.Close()
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+	router := launch.NewKeyRouter(stdinR, &safeBuf{}, &simpleOverlay{})
+	go router.Run()
+
+	queue := launch.NewNotifyQueue(10, nil)
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, copier, router, "", "")
+	go srv.Serve()
+	defer srv.Close()
+
+	done := make(chan launch.CommsResponse, 1)
+	go func() {
+		done <- launch.RequestComms(socketPath, launch.CommsRequest{
+			Method:  "http_request",
+			Service: "POST",
+			Channel: ts.URL + "/api",
+			Body:    `{"key":"value"}`,
+			ReplyTo: `{"Content-Type":"application/json"}`,
+		})
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	stdinW.Write([]byte("y"))
+
+	select {
+	case resp := <-done:
+		if !resp.OK {
+			t.Fatalf("expected OK, got error: %s", resp.Error)
+		}
+		if !strings.Contains(resp.Messages[0].Body, "application/json") {
+			t.Errorf("expected Content-Type header passed through, got %q", resp.Messages[0].Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
 func TestCommsServer_HttpRequest_Denied(t *testing.T) {
 	socketPath := os.TempDir() + "/aileron-test-comms-http-deny.sock"
 	t.Cleanup(func() { os.Remove(socketPath) })

--- a/core/launch/commsserver_test.go
+++ b/core/launch/commsserver_test.go
@@ -3,15 +3,38 @@ package launch_test
 import (
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/ALRubinger/aileron/core/audit"
 	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/launch"
+	launchpolicy "github.com/ALRubinger/aileron/core/policy/launch"
+	"github.com/ALRubinger/aileron/core/vault"
 )
+
+type mockHTTPServer struct {
+	responseBody string
+	statusCode   int
+	handler      func(http.ResponseWriter, *http.Request)
+}
+
+func (m *mockHTTPServer) start() *httptest.Server {
+	if m.handler != nil {
+		return httptest.NewServer(http.HandlerFunc(m.handler))
+	}
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if m.statusCode != 0 {
+			w.WriteHeader(m.statusCode)
+		}
+		w.Write([]byte(m.responseBody))
+	}))
+}
 
 type mockSender struct {
 	service string
@@ -437,6 +460,203 @@ func TestCommsServer_DirectSend_Success(t *testing.T) {
 	}
 	if sender.lastMsg.Body != "my reply" {
 		t.Errorf("expected body 'my reply', got %q", sender.lastMsg.Body)
+	}
+}
+
+func TestCommsServer_HttpRequest_WithApproval(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-http.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	// Set up a mock HTTP server.
+	mockAPI := &mockHTTPServer{responseBody: `{"ok": true}`, statusCode: 200}
+	ts := mockAPI.start()
+	defer ts.Close()
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+	router := launch.NewKeyRouter(stdinR, &safeBuf{}, &simpleOverlay{})
+	go router.Run()
+
+	queue := launch.NewNotifyQueue(10, nil)
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, copier, router, "", "")
+	go srv.Serve()
+	defer srv.Close()
+
+	done := make(chan launch.CommsResponse, 1)
+	go func() {
+		done <- launch.RequestComms(socketPath, launch.CommsRequest{
+			Method:  "http_request",
+			Service: "GET",
+			Channel: ts.URL + "/test",
+		})
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	stdinW.Write([]byte("y"))
+
+	select {
+	case resp := <-done:
+		if !resp.OK {
+			t.Errorf("expected OK, got error: %s", resp.Error)
+		}
+		if len(resp.Messages) == 0 {
+			t.Fatal("expected response body in messages")
+		}
+		if !strings.Contains(resp.Messages[0].Body, "ok") {
+			t.Errorf("expected response body containing 'ok', got %q", resp.Messages[0].Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestCommsServer_HttpRequest_Denied(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-http-deny.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+	router := launch.NewKeyRouter(stdinR, &safeBuf{}, &simpleOverlay{})
+	go router.Run()
+
+	queue := launch.NewNotifyQueue(10, nil)
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, copier, router, "", "")
+	go srv.Serve()
+	defer srv.Close()
+
+	done := make(chan launch.CommsResponse, 1)
+	go func() {
+		done <- launch.RequestComms(socketPath, launch.CommsRequest{
+			Method:  "http_request",
+			Service: "GET",
+			Channel: "https://example.com/api",
+		})
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	stdinW.Write([]byte("n"))
+
+	select {
+	case resp := <-done:
+		if resp.OK {
+			t.Error("expected denial")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestCommsServer_HttpRequest_MissingFields(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-http-missing.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	queue := launch.NewNotifyQueue(10, nil)
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, nil, nil, "", "")
+	go srv.Serve()
+	defer srv.Close()
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{
+		Method: "http_request",
+		// Missing Service (method) and Channel (url)
+	})
+	if resp.OK {
+		t.Error("expected error for missing fields")
+	}
+}
+
+func TestCommsServer_HttpRequest_WithSecretInjection(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-http-secret.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	// Mock HTTP server that echoes the Authorization header.
+	mockAPI := &mockHTTPServer{
+		handler: func(w http.ResponseWriter, r *http.Request) {
+			w.Write([]byte("auth:" + r.Header.Get("Authorization")))
+		},
+	}
+	ts := mockAPI.start()
+	defer ts.Close()
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	stdinR, stdinW := io.Pipe()
+	defer stdinW.Close()
+	router := launch.NewKeyRouter(stdinR, &safeBuf{}, &simpleOverlay{})
+	go router.Run()
+
+	queue := launch.NewNotifyQueue(10, nil)
+	srv, _ := launch.NewCommsServer(socketPath, queue, nil, nil, copier, router, "", "")
+
+	// Set up secrets with a vault.
+	v := vault.NewMemVault()
+	v.Put(nil, "SLACK_TOKEN", []byte("xoxb-secret-123"), vault.Metadata{})
+	secrets := map[string]launchpolicy.SecretDef{
+		"SLACK_TOKEN": {Targets: []string{"slack.com/api/*"}},
+	}
+	// The mock server URL won't match slack.com, so use a pattern that matches.
+	secrets["SLACK_TOKEN"] = launchpolicy.SecretDef{Targets: []string{ts.URL[7:]}} // strip "http://"
+	srv.SetSecrets(secrets, v)
+
+	go srv.Serve()
+	defer srv.Close()
+
+	done := make(chan launch.CommsResponse, 1)
+	go func() {
+		done <- launch.RequestComms(socketPath, launch.CommsRequest{
+			Method:  "http_request",
+			Service: "GET",
+			Channel: ts.URL + "/api/test",
+		})
+	}()
+
+	time.Sleep(300 * time.Millisecond)
+	stdinW.Write([]byte("y"))
+
+	select {
+	case resp := <-done:
+		if !resp.OK {
+			t.Fatalf("expected OK, got error: %s", resp.Error)
+		}
+		if len(resp.Messages) == 0 {
+			t.Fatal("expected response")
+		}
+		if !strings.Contains(resp.Messages[0].Body, "Bearer xoxb-secret-123") {
+			t.Errorf("expected injected Bearer token, got %q", resp.Messages[0].Body)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+}
+
+func TestURLMatchesPattern(t *testing.T) {
+	tests := []struct {
+		url, pattern string
+		want         bool
+	}{
+		{"https://slack.com/api/chat.postMessage", "slack.com/api/*", true},
+		{"https://discord.com/api/channels", "discord.com/api/*", true},
+		{"https://example.com/other", "slack.com/api/*", false},
+		{"https://slack.com/api/users", "slack.com/api/users", true},
+		{"https://example.com", "example.com", true},
+	}
+	for _, tt := range tests {
+		got := launch.URLMatchesPattern(tt.url, tt.pattern)
+		if got != tt.want {
+			t.Errorf("URLMatchesPattern(%q, %q) = %v, want %v", tt.url, tt.pattern, got, tt.want)
+		}
 	}
 }
 

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -528,9 +528,50 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		return nil
 	}
 
+	// Collect all token values that might be vault references.
+	var tokenRefs []string
+	if cfg := pf.Notifications.Slack; cfg != nil {
+		tokenRefs = append(tokenRefs, cfg.AppToken, cfg.BotToken)
+	}
+	if cfg := pf.Notifications.Discord; cfg != nil {
+		tokenRefs = append(tokenRefs, cfg.BotToken)
+	}
+
+	// If any token is a vault reference, resolve them.
+	var vaultResolver func(string) (string, error)
+	needsVault := false
+	for _, ref := range tokenRefs {
+		if IsVaultRef(ref) {
+			needsVault = true
+			break
+		}
+	}
+	if needsVault {
+		v, err := promptAndOpenVault(os.Stderr)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "aileron: vault: %v\n", err)
+			return nil
+		}
+		vaultResolver = func(val string) (string, error) {
+			return ResolveVaultRef(val, v)
+		}
+	} else {
+		vaultResolver = func(val string) (string, error) { return val, nil }
+	}
+
 	autoDraft := make(map[string]bool)
 	var created []comms.Listener
 	if cfg := pf.Notifications.Slack; cfg != nil && cfg.AppToken != "" && cfg.BotToken != "" {
+		appToken, err := vaultResolver(cfg.AppToken)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
+			return nil
+		}
+		botToken, err := vaultResolver(cfg.BotToken)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
+			return nil
+		}
 		channels := make([]string, 0, len(cfg.Channels))
 		for _, ch := range cfg.Channels {
 			channels = append(channels, ch.Name)
@@ -538,14 +579,19 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 				autoDraft[ch.Name] = true
 			}
 		}
-		created = append(created, comms.NewSlackListener(cfg.AppToken, cfg.BotToken, channels, cfg.Ignore))
+		created = append(created, comms.NewSlackListener(appToken, botToken, channels, cfg.Ignore))
 	}
 	if cfg := pf.Notifications.Discord; cfg != nil && cfg.BotToken != "" {
+		botToken, err := vaultResolver(cfg.BotToken)
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
+			return nil
+		}
 		channels := make([]string, 0, len(cfg.Channels))
 		for _, ch := range cfg.Channels {
 			channels = append(channels, ch.Name)
 		}
-		created = append(created, comms.NewDiscordListener(cfg.BotToken, channels, cfg.Ignore))
+		created = append(created, comms.NewDiscordListener(botToken, channels, cfg.Ignore))
 	}
 
 	return StartListeners(ctx, created, queue, os.Stderr, autoDraft, auditLog, sessionID)

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -528,6 +528,24 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		return nil
 	}
 
+	// Validate that token fields use vault references, not plaintext.
+	if cfg := pf.Notifications.Slack; cfg != nil {
+		if err := ValidateTokenRef("slack.app_token", cfg.AppToken); err != nil {
+			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
+			return nil
+		}
+		if err := ValidateTokenRef("slack.bot_token", cfg.BotToken); err != nil {
+			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
+			return nil
+		}
+	}
+	if cfg := pf.Notifications.Discord; cfg != nil {
+		if err := ValidateTokenRef("discord.bot_token", cfg.BotToken); err != nil {
+			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
+			return nil
+		}
+	}
+
 	// Collect all token values that might be vault references.
 	var tokenRefs []string
 	if cfg := pf.Notifications.Slack; cfg != nil {

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -560,7 +560,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 	for _, ref := range tokenRefs {
 		if IsVaultRef(ref) {
 			var err error
-			v, err = promptAndOpenVault(os.Stderr)
+			v, err = OpenVaultFunc(os.Stderr)
 			if err != nil {
 				fmt.Fprintf(os.Stderr, "aileron: vault: %v\n", err)
 				return nil

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -15,6 +15,7 @@ import (
 	"github.com/ALRubinger/aileron/core/audit"
 	"github.com/ALRubinger/aileron/core/comms"
 	launchpolicy "github.com/ALRubinger/aileron/core/policy/launch"
+	"github.com/ALRubinger/aileron/core/vault"
 	"github.com/creack/pty/v2"
 	"golang.org/x/term"
 )
@@ -546,7 +547,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		}
 	}
 
-	// Collect all token values that might be vault references.
+	// Collect token values and open vault if any are vault references.
 	var tokenRefs []string
 	if cfg := pf.Notifications.Slack; cfg != nil {
 		tokenRefs = append(tokenRefs, cfg.AppToken, cfg.BotToken)
@@ -555,41 +556,32 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		tokenRefs = append(tokenRefs, cfg.BotToken)
 	}
 
-	// If any token is a vault reference, resolve them.
-	var vaultResolver func(string) (string, error)
-	needsVault := false
+	var v vault.Vault
 	for _, ref := range tokenRefs {
 		if IsVaultRef(ref) {
-			needsVault = true
+			var err error
+			v, err = promptAndOpenVault(os.Stderr)
+			if err != nil {
+				fmt.Fprintf(os.Stderr, "aileron: vault: %v\n", err)
+				return nil
+			}
 			break
 		}
 	}
-	if needsVault {
-		v, err := promptAndOpenVault(os.Stderr)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "aileron: vault: %v\n", err)
-			return nil
-		}
-		vaultResolver = func(val string) (string, error) {
-			return ResolveVaultRef(val, v)
-		}
-	} else {
-		vaultResolver = func(val string) (string, error) { return val, nil }
+
+	resolved, err := ResolveTokens(tokenRefs, v)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
+		return nil
 	}
 
+	// Map resolved tokens back to config positions.
+	idx := 0
 	autoDraft := make(map[string]bool)
 	var created []comms.Listener
 	if cfg := pf.Notifications.Slack; cfg != nil && cfg.AppToken != "" && cfg.BotToken != "" {
-		appToken, err := vaultResolver(cfg.AppToken)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
-			return nil
-		}
-		botToken, err := vaultResolver(cfg.BotToken)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
-			return nil
-		}
+		appToken, botToken := resolved[idx], resolved[idx+1]
+		idx += 2
 		channels := make([]string, 0, len(cfg.Channels))
 		for _, ch := range cfg.Channels {
 			channels = append(channels, ch.Name)
@@ -600,11 +592,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		created = append(created, comms.NewSlackListener(appToken, botToken, channels, cfg.Ignore))
 	}
 	if cfg := pf.Notifications.Discord; cfg != nil && cfg.BotToken != "" {
-		botToken, err := vaultResolver(cfg.BotToken)
-		if err != nil {
-			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
-			return nil
-		}
+		botToken := resolved[idx]
 		channels := make([]string, 0, len(cfg.Channels))
 		for _, ch := range cfg.Channels {
 			channels = append(channels, ch.Name)

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -640,6 +640,92 @@ func TestBridgeMessages_AutoDraft(t *testing.T) {
 	}
 }
 
+func TestLaunch_RejectsPlaintextTokens(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+notifications:
+  slack:
+    app_token: xapp-plaintext-token
+    bot_token: xoxb-plaintext-token
+    channels:
+      - name: "#test"
+`), 0o644)
+
+	script := filepath.Join(dir, "noop.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\ntrue\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("launch should succeed even if token validation fails: %v", err)
+	}
+}
+
+func TestLaunch_VaultRefsNoTTY(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+notifications:
+  slack:
+    app_token: vault:slack_app_token
+    bot_token: vault:slack_bot_token
+    channels:
+      - name: "#test"
+`), 0o644)
+
+	script := filepath.Join(dir, "noop.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\ntrue\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("launch should succeed even if vault prompt fails: %v", err)
+	}
+}
+
+func TestLaunch_DiscordPlaintextRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+notifications:
+  discord:
+    bot_token: plaintext-discord-token
+    channels:
+      - name: "123456"
+`), 0o644)
+
+	script := filepath.Join(dir, "noop.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\ntrue\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("launch should succeed: %v", err)
+	}
+}
+
 func TestBridgeMessages_AuditLog(t *testing.T) {
 	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
 	queue := launch.NewNotifyQueue(10, nil)

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -9,9 +9,12 @@ import (
 	"testing"
 	"time"
 
+	"io"
+
 	"github.com/ALRubinger/aileron/core/audit"
 	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/launch"
+	"github.com/ALRubinger/aileron/core/vault"
 	"github.com/creack/pty/v2"
 )
 
@@ -637,6 +640,114 @@ func TestBridgeMessages_AutoDraft(t *testing.T) {
 	}
 	if all[1].AutoDraft {
 		t.Error("expected AutoDraft=false for #general message")
+	}
+}
+
+func TestLaunch_VaultRefsResolved(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+notifications:
+  slack:
+    app_token: vault:slack_app
+    bot_token: vault:slack_bot
+    channels:
+      - name: "#test"
+`), 0o644)
+
+	// Mock the vault opener to return a vault with the tokens.
+	v := vault.NewMemVault()
+	v.Put(nil, "slack_app", []byte("xapp-resolved"), vault.Metadata{})
+	v.Put(nil, "slack_bot", []byte("xoxb-resolved"), vault.Metadata{})
+
+	old := launch.OpenVaultFunc
+	launch.OpenVaultFunc = func(w io.Writer) (vault.Vault, error) { return v, nil }
+	defer func() { launch.OpenVaultFunc = old }()
+
+	script := filepath.Join(dir, "noop.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\ntrue\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("launch with vault refs should succeed: %v", err)
+	}
+}
+
+func TestLaunch_VaultRefsWithDiscord(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+notifications:
+  discord:
+    bot_token: vault:discord_bot
+    channels:
+      - name: "123456"
+`), 0o644)
+
+	v := vault.NewMemVault()
+	v.Put(nil, "discord_bot", []byte("discord-token-resolved"), vault.Metadata{})
+
+	old := launch.OpenVaultFunc
+	launch.OpenVaultFunc = func(w io.Writer) (vault.Vault, error) { return v, nil }
+	defer func() { launch.OpenVaultFunc = old }()
+
+	script := filepath.Join(dir, "noop.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\ntrue\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("launch with discord vault ref should succeed: %v", err)
+	}
+}
+
+func TestLaunch_VaultOpenError(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+notifications:
+  slack:
+    app_token: vault:slack_app
+    bot_token: vault:slack_bot
+    channels:
+      - name: "#test"
+`), 0o644)
+
+	old := launch.OpenVaultFunc
+	launch.OpenVaultFunc = func(w io.Writer) (vault.Vault, error) {
+		return nil, fmt.Errorf("vault locked")
+	}
+	defer func() { launch.OpenVaultFunc = old }()
+
+	script := filepath.Join(dir, "noop.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\ntrue\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("launch should succeed even if vault fails: %v", err)
 	}
 }
 

--- a/core/launch/secrets.go
+++ b/core/launch/secrets.go
@@ -65,14 +65,10 @@ func ValidateTokenRef(field, value string) error {
 	return fmt.Errorf("%s contains a plaintext token — use 'aileron secret set <name>' and reference it as 'vault:<name>' instead", field)
 }
 
-// promptAndOpenVault prompts the user for a vault passphrase on /dev/tty
-// and opens the local encrypted vault. The readPass function is injectable
-// for testing.
-var readPass = defaultReadPass
-
-func defaultReadPass(fd int) ([]byte, error) {
-	return term.ReadPassword(fd)
-}
+// OpenVaultFunc is the function used to open the vault when vault
+// references are found in token fields. Defaults to prompting for a
+// passphrase on /dev/tty. Replaceable in tests.
+var OpenVaultFunc = promptAndOpenVault
 
 func promptAndOpenVault(w io.Writer) (vault.Vault, error) {
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
@@ -82,7 +78,7 @@ func promptAndOpenVault(w io.Writer) (vault.Vault, error) {
 	defer tty.Close()
 
 	fmt.Fprint(w, "aileron: vault passphrase: ")
-	passphrase, err := readPass(int(tty.Fd()))
+	passphrase, err := term.ReadPassword(int(tty.Fd()))
 	fmt.Fprintln(w) // newline after hidden input
 	if err != nil {
 		return nil, fmt.Errorf("reading passphrase: %w", err)

--- a/core/launch/secrets.go
+++ b/core/launch/secrets.go
@@ -55,6 +55,16 @@ func IsVaultRef(value string) bool {
 	return strings.HasPrefix(value, vaultPrefix)
 }
 
+// ValidateTokenRef checks that a token value is either empty or a vault
+// reference. Plaintext tokens are rejected to prevent secrets from being
+// committed to version control in aileron.yaml.
+func ValidateTokenRef(field, value string) error {
+	if value == "" || IsVaultRef(value) {
+		return nil
+	}
+	return fmt.Errorf("%s contains a plaintext token — use 'aileron secret set <name>' and reference it as 'vault:<name>' instead", field)
+}
+
 // promptAndOpenVault prompts the user for a vault passphrase on /dev/tty
 // and opens the local encrypted vault.
 func promptAndOpenVault(w io.Writer) (vault.Vault, error) {

--- a/core/launch/secrets.go
+++ b/core/launch/secrets.go
@@ -66,7 +66,14 @@ func ValidateTokenRef(field, value string) error {
 }
 
 // promptAndOpenVault prompts the user for a vault passphrase on /dev/tty
-// and opens the local encrypted vault.
+// and opens the local encrypted vault. The readPass function is injectable
+// for testing.
+var readPass = defaultReadPass
+
+func defaultReadPass(fd int) ([]byte, error) {
+	return term.ReadPassword(fd)
+}
+
 func promptAndOpenVault(w io.Writer) (vault.Vault, error) {
 	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
 	if err != nil {
@@ -75,7 +82,7 @@ func promptAndOpenVault(w io.Writer) (vault.Vault, error) {
 	defer tty.Close()
 
 	fmt.Fprint(w, "aileron: vault passphrase: ")
-	passphrase, err := term.ReadPassword(int(tty.Fd()))
+	passphrase, err := readPass(int(tty.Fd()))
 	fmt.Fprintln(w) // newline after hidden input
 	if err != nil {
 		return nil, fmt.Errorf("reading passphrase: %w", err)
@@ -85,6 +92,29 @@ func promptAndOpenVault(w io.Writer) (vault.Vault, error) {
 	}
 
 	return OpenLocalVault(DefaultVaultPath(), string(passphrase))
+}
+
+// ResolveTokens resolves a slice of token values that may contain vault
+// references. Returns the resolved values in the same order. If any token
+// is a vault reference, the provided vault is used for lookups. If v is
+// nil and vault references exist, an error is returned.
+func ResolveTokens(tokens []string, v vault.Vault) ([]string, error) {
+	resolved := make([]string, len(tokens))
+	for i, tok := range tokens {
+		if !IsVaultRef(tok) {
+			resolved[i] = tok
+			continue
+		}
+		if v == nil {
+			return nil, fmt.Errorf("vault reference %q requires a vault", tok)
+		}
+		val, err := ResolveVaultRef(tok, v)
+		if err != nil {
+			return nil, err
+		}
+		resolved[i] = val
+	}
+	return resolved, nil
 }
 
 // ResolveVaultRef resolves a value that may be a vault reference. If it

--- a/core/launch/secrets.go
+++ b/core/launch/secrets.go
@@ -1,0 +1,93 @@
+package launch
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ALRubinger/aileron/core/crypto"
+	"github.com/ALRubinger/aileron/core/vault"
+	"golang.org/x/term"
+)
+
+const vaultPrefix = "vault:"
+
+// DefaultVaultPath returns the default vault file path (~/.aileron/secrets.json).
+func DefaultVaultPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".aileron", "secrets.json")
+	}
+	return filepath.Join(home, ".aileron", "secrets.json")
+}
+
+// OpenLocalVault opens the local encrypted vault, deriving a KEK from the
+// passphrase and the salt stored in the vault file. If the vault file
+// doesn't exist yet, it is created with a fresh salt.
+func OpenLocalVault(vaultPath, passphrase string) (vault.Vault, error) {
+	fv, err := vault.NewFileVault(vaultPath)
+	if err != nil {
+		return nil, fmt.Errorf("opening vault: %w", err)
+	}
+
+	salt, err := fv.Salt()
+	if err != nil {
+		return nil, fmt.Errorf("vault salt: %w", err)
+	}
+
+	kek, err := crypto.DeriveKEK([]byte(passphrase), salt)
+	if err != nil {
+		return nil, fmt.Errorf("deriving key: %w", err)
+	}
+
+	ev, err := vault.NewEncryptedVault(fv, kek)
+	if err != nil {
+		return nil, fmt.Errorf("creating encrypted vault: %w", err)
+	}
+	return ev, nil
+}
+
+// IsVaultRef returns true if the value is a vault reference (starts with "vault:").
+func IsVaultRef(value string) bool {
+	return strings.HasPrefix(value, vaultPrefix)
+}
+
+// promptAndOpenVault prompts the user for a vault passphrase on /dev/tty
+// and opens the local encrypted vault.
+func promptAndOpenVault(w io.Writer) (vault.Vault, error) {
+	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	if err != nil {
+		return nil, fmt.Errorf("cannot open /dev/tty for passphrase prompt: %w", err)
+	}
+	defer tty.Close()
+
+	fmt.Fprint(w, "aileron: vault passphrase: ")
+	passphrase, err := term.ReadPassword(int(tty.Fd()))
+	fmt.Fprintln(w) // newline after hidden input
+	if err != nil {
+		return nil, fmt.Errorf("reading passphrase: %w", err)
+	}
+	if len(passphrase) == 0 {
+		return nil, fmt.Errorf("passphrase cannot be empty")
+	}
+
+	return OpenLocalVault(DefaultVaultPath(), string(passphrase))
+}
+
+// ResolveVaultRef resolves a value that may be a vault reference. If it
+// starts with "vault:", the remainder is looked up in the vault. Otherwise
+// the value is returned as-is.
+func ResolveVaultRef(value string, v vault.Vault) (string, error) {
+	if !IsVaultRef(value) {
+		return value, nil
+	}
+	name := strings.TrimPrefix(value, vaultPrefix)
+	secret, err := v.Get(context.Background(), name)
+	if err != nil {
+		return "", fmt.Errorf("resolving vault:%s: %w", name, err)
+	}
+	return string(secret.Value), nil
+}

--- a/core/launch/secrets_test.go
+++ b/core/launch/secrets_test.go
@@ -122,6 +122,68 @@ func TestValidateTokenRef_Plaintext(t *testing.T) {
 	}
 }
 
+func TestResolveTokens_PlainValues(t *testing.T) {
+	resolved, err := launch.ResolveTokens([]string{"token-a", "token-b"}, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved[0] != "token-a" || resolved[1] != "token-b" {
+		t.Errorf("expected plain values unchanged, got %v", resolved)
+	}
+}
+
+func TestResolveTokens_VaultRefs(t *testing.T) {
+	v := vault.NewMemVault()
+	v.Put(context.Background(), "slack_app", []byte("xapp-resolved"), vault.Metadata{})
+	v.Put(context.Background(), "slack_bot", []byte("xoxb-resolved"), vault.Metadata{})
+
+	resolved, err := launch.ResolveTokens([]string{"vault:slack_app", "vault:slack_bot"}, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved[0] != "xapp-resolved" || resolved[1] != "xoxb-resolved" {
+		t.Errorf("expected resolved values, got %v", resolved)
+	}
+}
+
+func TestResolveTokens_MixedRefs(t *testing.T) {
+	v := vault.NewMemVault()
+	v.Put(context.Background(), "my_token", []byte("secret"), vault.Metadata{})
+
+	resolved, err := launch.ResolveTokens([]string{"", "vault:my_token"}, v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if resolved[0] != "" || resolved[1] != "secret" {
+		t.Errorf("expected ['', 'secret'], got %v", resolved)
+	}
+}
+
+func TestResolveTokens_VaultRefWithNilVault(t *testing.T) {
+	_, err := launch.ResolveTokens([]string{"vault:missing"}, nil)
+	if err == nil {
+		t.Error("expected error when vault is nil but ref exists")
+	}
+}
+
+func TestResolveTokens_VaultRefNotFound(t *testing.T) {
+	v := vault.NewMemVault()
+	_, err := launch.ResolveTokens([]string{"vault:nonexistent"}, v)
+	if err == nil {
+		t.Error("expected error for missing vault secret")
+	}
+}
+
+func TestResolveTokens_Empty(t *testing.T) {
+	resolved, err := launch.ResolveTokens(nil, nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(resolved) != 0 {
+		t.Errorf("expected empty, got %v", resolved)
+	}
+}
+
 func TestOpenLocalVault_EmptyPassphrase(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "secrets.json")
 	_, err := launch.OpenLocalVault(path, "")

--- a/core/launch/secrets_test.go
+++ b/core/launch/secrets_test.go
@@ -122,6 +122,21 @@ func TestValidateTokenRef_Plaintext(t *testing.T) {
 	}
 }
 
+func TestOpenLocalVault_EmptyPassphrase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	_, err := launch.OpenLocalVault(path, "")
+	if err == nil {
+		t.Error("expected error for empty passphrase")
+	}
+}
+
+func TestOpenLocalVault_BadPath(t *testing.T) {
+	_, err := launch.OpenLocalVault("/dev/null/impossible/secrets.json", "pass")
+	if err == nil {
+		t.Error("expected error for bad path")
+	}
+}
+
 func TestDefaultVaultPath(t *testing.T) {
 	path := launch.DefaultVaultPath()
 	if path == "" {

--- a/core/launch/secrets_test.go
+++ b/core/launch/secrets_test.go
@@ -3,6 +3,7 @@ package launch_test
 import (
 	"context"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ALRubinger/aileron/core/launch"
@@ -91,6 +92,33 @@ func TestOpenLocalVault_WrongPassphrase(t *testing.T) {
 	_, err := v2.Get(context.Background(), "token")
 	if err == nil {
 		t.Error("expected error with wrong passphrase")
+	}
+}
+
+func TestValidateTokenRef_VaultRef(t *testing.T) {
+	err := launch.ValidateTokenRef("slack.bot_token", "vault:my_token")
+	if err != nil {
+		t.Errorf("vault ref should be valid, got %v", err)
+	}
+}
+
+func TestValidateTokenRef_Empty(t *testing.T) {
+	err := launch.ValidateTokenRef("slack.bot_token", "")
+	if err != nil {
+		t.Errorf("empty should be valid, got %v", err)
+	}
+}
+
+func TestValidateTokenRef_Plaintext(t *testing.T) {
+	err := launch.ValidateTokenRef("slack.bot_token", "xoxb-real-token-here")
+	if err == nil {
+		t.Fatal("expected error for plaintext token")
+	}
+	if !strings.Contains(err.Error(), "plaintext token") {
+		t.Errorf("expected 'plaintext token' in error, got %q", err.Error())
+	}
+	if !strings.Contains(err.Error(), "slack.bot_token") {
+		t.Errorf("expected field name in error, got %q", err.Error())
 	}
 }
 

--- a/core/launch/secrets_test.go
+++ b/core/launch/secrets_test.go
@@ -1,0 +1,108 @@
+package launch_test
+
+import (
+	"context"
+	"path/filepath"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/launch"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+func TestIsVaultRef(t *testing.T) {
+	if !launch.IsVaultRef("vault:slack_bot_token") {
+		t.Error("expected true for vault: prefix")
+	}
+	if launch.IsVaultRef("xoxb-plain-token") {
+		t.Error("expected false for plain value")
+	}
+	if launch.IsVaultRef("") {
+		t.Error("expected false for empty string")
+	}
+}
+
+func TestResolveVaultRef_PlainValue(t *testing.T) {
+	v := vault.NewMemVault()
+	got, err := launch.ResolveVaultRef("plain-token", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "plain-token" {
+		t.Errorf("expected 'plain-token', got %q", got)
+	}
+}
+
+func TestResolveVaultRef_VaultLookup(t *testing.T) {
+	v := vault.NewMemVault()
+	v.Put(context.Background(), "slack_bot_token", []byte("xoxb-secret"), vault.Metadata{})
+
+	got, err := launch.ResolveVaultRef("vault:slack_bot_token", v)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got != "xoxb-secret" {
+		t.Errorf("expected 'xoxb-secret', got %q", got)
+	}
+}
+
+func TestResolveVaultRef_NotFound(t *testing.T) {
+	v := vault.NewMemVault()
+	_, err := launch.ResolveVaultRef("vault:missing", v)
+	if err == nil {
+		t.Error("expected error for missing vault secret")
+	}
+}
+
+func TestOpenLocalVault_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	passphrase := "test-passphrase"
+
+	// Store a secret.
+	v1, err := launch.OpenLocalVault(path, passphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	err = v1.Put(context.Background(), "my-token", []byte("secret-value"), vault.Metadata{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Retrieve with same passphrase.
+	v2, err := launch.OpenLocalVault(path, passphrase)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := v2.Get(context.Background(), "my-token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Value) != "secret-value" {
+		t.Errorf("expected 'secret-value', got %q", got.Value)
+	}
+}
+
+func TestOpenLocalVault_WrongPassphrase(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+
+	v1, _ := launch.OpenLocalVault(path, "correct")
+	v1.Put(context.Background(), "token", []byte("value"), vault.Metadata{})
+
+	v2, _ := launch.OpenLocalVault(path, "wrong")
+	_, err := v2.Get(context.Background(), "token")
+	if err == nil {
+		t.Error("expected error with wrong passphrase")
+	}
+}
+
+func TestDefaultVaultPath(t *testing.T) {
+	path := launch.DefaultVaultPath()
+	if path == "" {
+		t.Error("expected non-empty path")
+	}
+	if !filepath.IsAbs(path) {
+		// May not be absolute if HOME is unset, but should at least contain the filename.
+		if filepath.Base(path) != "secrets.json" {
+			t.Errorf("expected secrets.json, got %q", filepath.Base(path))
+		}
+	}
+}

--- a/core/policy/launch/schema.go
+++ b/core/policy/launch/schema.go
@@ -16,9 +16,20 @@ type PolicyFile struct {
 	Settings      *Settings        `yaml:"settings,omitempty"`
 	Env           *EnvConfig       `yaml:"env,omitempty"`
 	Notifications *NotifyConfig    `yaml:"notifications,omitempty"`
+	Secrets       SecretsConfig    `yaml:"secrets,omitempty"`
 	Allow         []Rule           `yaml:"allow,omitempty"`
 	Deny          []Rule           `yaml:"deny,omitempty"`
 	Ask           []Rule           `yaml:"ask,omitempty"`
+}
+
+// SecretsConfig maps secret names to their target URL patterns. When an
+// http_request matches a target pattern, the corresponding secret is
+// injected into the request's Authorization header.
+type SecretsConfig map[string]SecretDef
+
+// SecretDef defines which URL targets a secret can be injected into.
+type SecretDef struct {
+	Targets []string `yaml:"targets"` // URL patterns (e.g. "slack.com/api/*")
 }
 
 // Settings holds launch session configuration.

--- a/core/vault/file.go
+++ b/core/vault/file.go
@@ -1,0 +1,126 @@
+package vault
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/ALRubinger/aileron/core/crypto"
+)
+
+// FileVault is a Vault backed by a JSON file on disk. Secrets are stored
+// as raw bytes (callers should wrap with EncryptedVault for encryption).
+// The file also stores an Argon2id salt for key derivation.
+type FileVault struct {
+	path string
+	mu   sync.Mutex
+	data fileData
+}
+
+type fileData struct {
+	Salt    []byte                `json:"salt"`
+	Secrets map[string]fileSecret `json:"secrets"`
+}
+
+type fileSecret struct {
+	Value    []byte   `json:"value"`
+	Metadata Metadata `json:"metadata"`
+}
+
+// NewFileVault opens or creates a vault file at path. If the file exists,
+// its contents are loaded into memory. If not, an empty vault is created.
+func NewFileVault(path string) (*FileVault, error) {
+	fv := &FileVault{
+		path: path,
+		data: fileData{Secrets: make(map[string]fileSecret)},
+	}
+
+	raw, err := os.ReadFile(path)
+	if err == nil {
+		if err := json.Unmarshal(raw, &fv.data); err != nil {
+			return nil, fmt.Errorf("vault: parsing %s: %w", path, err)
+		}
+		if fv.data.Secrets == nil {
+			fv.data.Secrets = make(map[string]fileSecret)
+		}
+	} else if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("vault: reading %s: %w", path, err)
+	}
+
+	return fv, nil
+}
+
+// Salt returns the stored salt, generating one if it doesn't exist yet.
+func (fv *FileVault) Salt() ([]byte, error) {
+	fv.mu.Lock()
+	defer fv.mu.Unlock()
+
+	if len(fv.data.Salt) >= crypto.SaltLen {
+		return fv.data.Salt, nil
+	}
+
+	salt, err := crypto.GenerateSalt()
+	if err != nil {
+		return nil, err
+	}
+	fv.data.Salt = salt
+	if err := fv.flush(); err != nil {
+		return nil, err
+	}
+	return salt, nil
+}
+
+func (fv *FileVault) Get(_ context.Context, path string) (Secret, error) {
+	fv.mu.Lock()
+	defer fv.mu.Unlock()
+
+	s, ok := fv.data.Secrets[path]
+	if !ok {
+		return Secret{}, &errNotFound{path: path}
+	}
+	return Secret{Path: path, Value: s.Value, Metadata: s.Metadata}, nil
+}
+
+func (fv *FileVault) Put(_ context.Context, path string, value []byte, meta Metadata) error {
+	fv.mu.Lock()
+	defer fv.mu.Unlock()
+
+	fv.data.Secrets[path] = fileSecret{Value: value, Metadata: meta}
+	return fv.flush()
+}
+
+func (fv *FileVault) Delete(_ context.Context, path string) error {
+	fv.mu.Lock()
+	defer fv.mu.Unlock()
+
+	delete(fv.data.Secrets, path)
+	return fv.flush()
+}
+
+// Names returns the paths of all stored secrets.
+func (fv *FileVault) Names() []string {
+	fv.mu.Lock()
+	defer fv.mu.Unlock()
+
+	names := make([]string, 0, len(fv.data.Secrets))
+	for k := range fv.data.Secrets {
+		names = append(names, k)
+	}
+	return names
+}
+
+func (fv *FileVault) flush() error {
+	raw, err := json.MarshalIndent(fv.data, "", "  ")
+	if err != nil {
+		return fmt.Errorf("vault: encoding: %w", err)
+	}
+
+	if err := os.MkdirAll(filepath.Dir(fv.path), 0o700); err != nil {
+		return fmt.Errorf("vault: creating directory: %w", err)
+	}
+
+	return os.WriteFile(fv.path, raw, 0o600)
+}

--- a/core/vault/file_test.go
+++ b/core/vault/file_test.go
@@ -180,6 +180,32 @@ func TestFileVault_MalformedFile(t *testing.T) {
 	}
 }
 
+func TestFileVault_FlushErrorReadOnlyDir(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "readonly", "secrets.json")
+	os.MkdirAll(filepath.Join(dir, "readonly"), 0o555)
+	t.Cleanup(func() { os.Chmod(filepath.Join(dir, "readonly"), 0o755) })
+
+	fv, _ := NewFileVault(path)
+	// Put should fail because the directory is read-only.
+	err := fv.Put(context.Background(), "test", []byte("val"), Metadata{})
+	if err == nil {
+		t.Error("expected error writing to read-only directory")
+	}
+}
+
+func TestErrNotFound_ErrorMessage(t *testing.T) {
+	v := NewMemVault()
+	_, err := v.Get(context.Background(), "my/secret/path")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	msg := err.Error()
+	if msg != "vault: secret not found: my/secret/path" {
+		t.Errorf("unexpected error message: %q", msg)
+	}
+}
+
 func TestIsNotFound(t *testing.T) {
 	if IsNotFound(nil) {
 		t.Error("nil should not be NotFound")

--- a/core/vault/file_test.go
+++ b/core/vault/file_test.go
@@ -1,0 +1,195 @@
+package vault
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/crypto"
+)
+
+func TestFileVault_RoundTrip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	fv, err := NewFileVault(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	err = fv.Put(ctx, "slack/bot_token", []byte("xoxb-test"), Metadata{Type: "bot_token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := fv.Get(ctx, "slack/bot_token")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Value) != "xoxb-test" {
+		t.Errorf("expected 'xoxb-test', got %q", got.Value)
+	}
+	if got.Metadata.Type != "bot_token" {
+		t.Errorf("expected metadata type 'bot_token', got %q", got.Metadata.Type)
+	}
+}
+
+func TestFileVault_Persistence(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	ctx := context.Background()
+
+	// Write with first instance.
+	fv1, _ := NewFileVault(path)
+	fv1.Put(ctx, "my-secret", []byte("val"), Metadata{})
+
+	// Read with second instance.
+	fv2, err := NewFileVault(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	got, err := fv2.Get(ctx, "my-secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Value) != "val" {
+		t.Errorf("expected 'val', got %q", got.Value)
+	}
+}
+
+func TestFileVault_Delete(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	ctx := context.Background()
+
+	fv, _ := NewFileVault(path)
+	fv.Put(ctx, "to-delete", []byte("val"), Metadata{})
+	fv.Delete(ctx, "to-delete")
+
+	_, err := fv.Get(ctx, "to-delete")
+	if !IsNotFound(err) {
+		t.Errorf("expected not found after delete, got %v", err)
+	}
+}
+
+func TestFileVault_NotFound(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	fv, _ := NewFileVault(path)
+
+	_, err := fv.Get(context.Background(), "nonexistent")
+	if !IsNotFound(err) {
+		t.Errorf("expected not found error, got %v", err)
+	}
+}
+
+func TestFileVault_Salt(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	fv, _ := NewFileVault(path)
+
+	salt1, err := fv.Salt()
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(salt1) < crypto.SaltLen {
+		t.Errorf("expected salt length >= %d, got %d", crypto.SaltLen, len(salt1))
+	}
+
+	// Second call returns same salt.
+	salt2, _ := fv.Salt()
+	if string(salt1) != string(salt2) {
+		t.Error("salt should be stable across calls")
+	}
+
+	// Salt persists across instances.
+	fv2, _ := NewFileVault(path)
+	salt3, _ := fv2.Salt()
+	if string(salt1) != string(salt3) {
+		t.Error("salt should persist across instances")
+	}
+}
+
+func TestFileVault_Names(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	fv, _ := NewFileVault(path)
+	ctx := context.Background()
+
+	fv.Put(ctx, "a", []byte("1"), Metadata{})
+	fv.Put(ctx, "b", []byte("2"), Metadata{})
+
+	names := fv.Names()
+	if len(names) != 2 {
+		t.Fatalf("expected 2 names, got %d", len(names))
+	}
+}
+
+func TestFileVault_NewFileCreatesDir(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "subdir", "secrets.json")
+	fv, err := NewFileVault(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	err = fv.Put(ctx, "test", []byte("val"), Metadata{})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("expected file to exist at %s", path)
+	}
+}
+
+func TestFileVault_WithEncryptedVault(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	fv, _ := NewFileVault(path)
+
+	kek := testKEK(t)
+	ev, err := NewEncryptedVault(fv, kek)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	ctx := context.Background()
+	err = ev.Put(ctx, "secret", []byte("plaintext-value"), Metadata{Type: "token"})
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Read back through encrypted vault — should be plaintext.
+	got, err := ev.Get(ctx, "secret")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got.Value) != "plaintext-value" {
+		t.Errorf("expected 'plaintext-value', got %q", got.Value)
+	}
+
+	// Read raw from file vault — should be ciphertext (not plaintext).
+	raw, _ := fv.Get(ctx, "secret")
+	if string(raw.Value) == "plaintext-value" {
+		t.Error("raw value should be encrypted, not plaintext")
+	}
+}
+
+func TestFileVault_MalformedFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "secrets.json")
+	os.WriteFile(path, []byte("not json"), 0o600)
+
+	_, err := NewFileVault(path)
+	if err == nil {
+		t.Error("expected error for malformed file")
+	}
+}
+
+func TestIsNotFound(t *testing.T) {
+	if IsNotFound(nil) {
+		t.Error("nil should not be NotFound")
+	}
+	if IsNotFound(os.ErrNotExist) {
+		t.Error("os.ErrNotExist should not match IsNotFound")
+	}
+	v := NewMemVault()
+	_, err := v.Get(context.Background(), "missing")
+	if !IsNotFound(err) {
+		t.Error("MemVault missing key should be NotFound")
+	}
+}

--- a/core/vault/mem.go
+++ b/core/vault/mem.go
@@ -48,3 +48,9 @@ type errNotFound struct {
 func (e *errNotFound) Error() string {
 	return "vault: secret not found: " + e.path
 }
+
+// IsNotFound returns true if the error indicates a secret was not found.
+func IsNotFound(err error) bool {
+	_, ok := err.(*errNotFound)
+	return ok
+}


### PR DESCRIPTION
## Summary

- **FileVault** (`core/vault/file.go`): persistent local vault backed by `~/.aileron/secrets.json`, composable with `EncryptedVault` for AES-256-GCM encryption at rest. Includes `IsNotFound` export.
- **`aileron secret set/list`** (`cmd/aileron/main.go`): CLI commands to store and list encrypted secrets with passphrase-derived KEK (Argon2id)
- **`vault:` references** (`core/launch/secrets.go`): token fields like `vault:slack_bot_token` in `aileron.yaml` are resolved at launch by prompting for the vault passphrase once
- **`http_request` MCP tool** (`cmd/aileron-mcp/main.go` + `core/launch/commsserver.go`): agent calls with method/url/headers/body, Aileron matches URL against secrets config targets, injects credential as Bearer token, prompts user approval, makes the HTTP call, returns the response
- **SecretsConfig** (`core/policy/launch/schema.go`): maps secret names to URL target patterns for credential injection

Closes the remaining Phase 3 item (bot token vault storage) and implements Phase 4 (credential brokering).

## Test plan

- [ ] `task build:cli && task build:mcp && task build:sh` — compiles
- [ ] `cd core && go test ./vault/... -count=1` — passes (91.7% coverage)
- [ ] `cd core && go test ./launch/... -count=1` — passes (84.6% coverage)
- [ ] `cd cmd/aileron && go test ./... -count=1` — passes
- [ ] New tests: FileVault round-trip/persistence/delete/salt/encryption/malformed, IsNotFound, OpenLocalVault round-trip/wrong passphrase, ResolveVaultRef plain/vault/missing, http_request approval/denied/missing fields/secret injection, URLMatchesPattern, secret CLI set/list/help
- [ ] Manual: `aileron secret set slack_bot_token`, configure `vault:slack_bot_token` in YAML, `aileron launch claude` — resolves token

🤖 Generated with [Claude Code](https://claude.com/claude-code)