### PR TITLE
feat(policy): replace priority points with layer overrides and specificity

### DIFF
--- a/README.md
+++ b/README.md
@@ -159,7 +159,7 @@ Aileron is a **local-first CLI tool** centered on `aileron launch` — the conne
 **Core:**
 - `aileron launch <agent>` with policy-enforced shell (`aileron-sh`)
 - Built-in policy defaults for all language toolchains and OS-specific protections (ADR-0015)
-- Three-layer policy merge: built-in defaults → project `aileron.yaml` → user `~/.aileron/settings.yaml`
+- Three-layer policy merge: built-in defaults → user `~/.aileron/settings.yaml` → project `aileron.yaml`. Later layer wins for same pattern; more specific patterns win regardless of layer (ADR-0016)
 - Zero-config experience — works without any `aileron.yaml`
 
 **Communication:**
@@ -237,7 +237,7 @@ Optionally, scaffold a project-specific policy:
 
 This creates a minimal `aileron.yaml` with project-specific deny rules and env scrubbing. Language toolchain and OS rules are built in — you don't need to list them.
 
-**Three-layer policy merge:** Built-in defaults → project `aileron.yaml` → user `~/.aileron/settings.yaml`. Each layer overrides the previous. Your project file only needs what's specific to this repo.
+**Three-layer policy merge:** Built-in defaults → user `~/.aileron/settings.yaml` → project `aileron.yaml`. Later layer wins for the same command pattern; more specific patterns win regardless of layer. Your project file only needs what's specific to this repo. See [ADR-0016](docs/adr/0016-layer-overrides-and-specificity.md) for details.
 
 ### Slack notifications
 

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -169,7 +169,11 @@ func runPolicyTest(args []string, stdout, stderr io.Writer) int {
 			fmt.Fprintf(stdout, "  (%s)", result.Reason)
 		}
 		if result.RuleID != "" {
-			fmt.Fprintf(stdout, "  [%s]", result.RuleID)
+			if result.Layer != "" {
+				fmt.Fprintf(stdout, "  [%s] (%s)", result.RuleID, result.Layer)
+			} else {
+				fmt.Fprintf(stdout, "  [%s]", result.RuleID)
+			}
 		}
 		fmt.Fprintln(stdout)
 	}

--- a/core/launch/eval.go
+++ b/core/launch/eval.go
@@ -19,6 +19,7 @@ type EvalResult struct {
 	Disposition model.Disposition
 	Reason      string
 	RuleID      string // which policy rule matched
+	Layer       string // "default", "project", "user", or "" if unknown
 }
 
 // EvaluateCommand loads policy from the given file (or uses an empty default)
@@ -32,7 +33,7 @@ func EvaluateCommand(policyPath, command, workingDir string) EvalResult {
 
 	active := policy.ActiveStatus()
 	if err := store.Create(ctx, policy.MakePolicy("launch", "default", rules, active)); err != nil {
-		return EvalResult{model.DispositionRequireApproval, "policy load error", ""}
+		return EvalResult{Disposition: model.DispositionRequireApproval, Reason: "policy load error"}
 	}
 
 	engine := policy.NewRuleEngine(store)
@@ -71,7 +72,7 @@ func EvaluateCommand(policyPath, command, workingDir string) EvalResult {
 		},
 	})
 	if err != nil {
-		return EvalResult{model.DispositionRequireApproval, "policy evaluation error", ""}
+		return EvalResult{Disposition: model.DispositionRequireApproval, Reason: "policy evaluation error"}
 	}
 
 	ruleID := ""
@@ -79,18 +80,24 @@ func EvaluateCommand(policyPath, command, workingDir string) EvalResult {
 		ruleID = decision.MatchedPolicies[0].RuleID
 	}
 
-	return EvalResult{decision.Disposition, decision.DenialReason, ruleID}
+	return EvalResult{
+		Disposition: decision.Disposition,
+		Reason:      decision.DenialReason,
+		RuleID:      ruleID,
+		Layer:       extractLayer(ruleID),
+	}
 }
 
 func loadPolicyFileFrom(path string) *launchpolicy.PolicyFile {
 	if path == "" {
-		// No project policy file — still load user settings so personal
-		// rules apply even in repos without an aileron.yaml.
-		pf, err := launchpolicy.LoadUserSettings()
+		// No project policy file — load defaults + user settings so
+		// personal rules and built-in defaults apply even without aileron.yaml.
+		base := launchpolicy.DefaultPolicy()
+		userSettings, err := launchpolicy.LoadUserSettings()
 		if err != nil {
-			return &launchpolicy.PolicyFile{Version: 1}
+			return base
 		}
-		return pf
+		return launchpolicy.Merge(base, userSettings)
 	}
 	pf, err := launchpolicy.LoadWithProfiles(path)
 	if err != nil {
@@ -125,6 +132,9 @@ func WriteDeny(w io.Writer, command, reason, ruleID, policyPath string) {
 	if source := describeRuleSource(ruleID, policyPath); source != "" {
 		fmt.Fprintf(w, "Policy: %s\n", source)
 	}
+	if hint := overrideHint(ruleID); hint != "" {
+		fmt.Fprintf(w, "Hint: %s\n", hint)
+	}
 }
 
 // WriteDenyByUser writes a user-denied message to the writer.
@@ -132,18 +142,56 @@ func WriteDenyByUser(w io.Writer, command string) {
 	fmt.Fprintf(w, "[✈️ Aileron] Denied ⛔: %s\n", command)
 }
 
+// extractLayer parses a layer prefix from a rule ID (e.g. "project:deny_0" → "project").
+// Returns empty string if no layer prefix is present.
+func extractLayer(ruleID string) string {
+	if strings.HasPrefix(ruleID, "builtin_") {
+		return "default"
+	}
+	if idx := strings.Index(ruleID, ":"); idx > 0 {
+		return ruleID[:idx]
+	}
+	return ""
+}
+
 // describeRuleSource returns a human-readable description of where a
 // policy rule came from.
 func describeRuleSource(ruleID, policyPath string) string {
+	layer := extractLayer(ruleID)
+	switch layer {
+	case "default":
+		return "built-in defaults"
+	case "user":
+		return "personal settings (~/.aileron/settings.yaml)"
+	case "project":
+		if policyPath != "" {
+			return policyPath
+		}
+		return "project policy (aileron.yaml)"
+	}
+
+	// Legacy fallback for untagged rule IDs.
 	if strings.HasPrefix(ruleID, "builtin_") {
 		return "built-in rule"
 	}
 	if policyPath == "" {
 		return ""
 	}
-	// Shorten the path for display.
 	if strings.Contains(policyPath, "/.aileron/settings.yaml") {
 		return "personal settings (~/.aileron/settings.yaml)"
 	}
 	return policyPath
+}
+
+// overrideHint returns a hint about how to override a deny rule.
+func overrideHint(ruleID string) string {
+	layer := extractLayer(ruleID)
+	switch layer {
+	case "default":
+		return "override in aileron.yaml or ~/.aileron/settings.yaml to allow"
+	case "project":
+		return "override in ~/.aileron/settings.yaml to allow"
+	default:
+		return ""
+	}
 }

--- a/core/launch/eval_test.go
+++ b/core/launch/eval_test.go
@@ -83,8 +83,9 @@ default: allow
 	}
 }
 
-func TestEvaluateCommand_ProjectCannotOverrideBuiltinDeny(t *testing.T) {
-	// A project policy cannot whitelist a built-in deny rule.
+func TestEvaluateCommand_ProjectOverridesBuiltinDeny(t *testing.T) {
+	// Per ADR-0016, the project layer can override built-in default deny
+	// rules by defining the same command pattern. Later layer wins.
 	path := writePolicyFile(t, `
 version: 1
 default: allow
@@ -93,12 +94,12 @@ allow:
   - "rm -rf /*"
 `)
 	result := launch.EvaluateCommand(path, "gh repo delete my-org/repo", "/tmp")
-	if result.Disposition != model.DispositionDeny {
-		t.Errorf("expected built-in deny to win over project allow, got %q", result.Disposition)
+	if result.Disposition != model.DispositionAllow {
+		t.Errorf("expected project allow to override built-in deny, got %q", result.Disposition)
 	}
 	result = launch.EvaluateCommand(path, "rm -rf /", "/tmp")
-	if result.Disposition != model.DispositionDeny {
-		t.Errorf("expected built-in deny to win over project allow for rm -rf, got %q", result.Disposition)
+	if result.Disposition != model.DispositionAllow {
+		t.Errorf("expected project allow to override built-in deny for rm -rf, got %q", result.Disposition)
 	}
 }
 
@@ -220,17 +221,22 @@ func TestEvaluateCommand_InvalidPolicyFile(t *testing.T) {
 }
 
 func TestEvaluateCommand_NoPolicyFileNoHome(t *testing.T) {
-	// When HOME is empty and no policy path, should fall back gracefully.
+	// When HOME is empty and no policy path, built-in defaults still apply.
 	t.Setenv("HOME", "")
+	// "echo *" is in the built-in allow list.
 	result := launch.EvaluateCommand("", "echo hello", "/tmp")
-	// Empty user settings + no project policy → default ask.
+	if result.Disposition != model.DispositionAllow {
+		t.Errorf("expected allow from built-in defaults, got %q", result.Disposition)
+	}
+	// An unknown command should get default ask.
+	result = launch.EvaluateCommand("", "docker run myimage", "/tmp")
 	if result.Disposition != model.DispositionRequireApproval {
-		t.Errorf("expected ask fallback, got %q", result.Disposition)
+		t.Errorf("expected ask for unknown command, got %q", result.Disposition)
 	}
 }
 
 func TestEvaluateCommand_NoPolicyFileInvalidUserSettings(t *testing.T) {
-	// Covers line 74: LoadUserSettings returns error → fallback.
+	// Invalid user settings → falls back to defaults only.
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
@@ -238,10 +244,11 @@ func TestEvaluateCommand_NoPolicyFileInvalidUserSettings(t *testing.T) {
 	os.MkdirAll(settingsDir, 0o755)
 	os.WriteFile(filepath.Join(settingsDir, "settings.yaml"), []byte("{{invalid"), 0o644)
 
-	// No project policy path + invalid user settings → fallback to empty → default ask.
+	// No project policy path + invalid user settings → built-in defaults apply.
+	// "echo *" is in the built-in allow list.
 	result := launch.EvaluateCommand("", "echo hello", "/tmp")
-	if result.Disposition != model.DispositionRequireApproval {
-		t.Errorf("expected ask fallback for invalid user settings with no project, got %q", result.Disposition)
+	if result.Disposition != model.DispositionAllow {
+		t.Errorf("expected allow from built-in defaults, got %q", result.Disposition)
 	}
 }
 
@@ -385,8 +392,8 @@ allow:
 func TestWriteDeny_BuiltinRule(t *testing.T) {
 	var buf bytes.Buffer
 	launch.WriteDeny(&buf, "eval bad", "", "builtin_eval", "")
-	if !strings.Contains(buf.String(), "built-in rule") {
-		t.Errorf("expected 'built-in rule' source, got %q", buf.String())
+	if !strings.Contains(buf.String(), "built-in defaults") {
+		t.Errorf("expected 'built-in defaults' source, got %q", buf.String())
 	}
 }
 
@@ -430,5 +437,74 @@ func TestWriteDeny_NoReason(t *testing.T) {
 	lines := strings.Split(strings.TrimSpace(out), "\n")
 	if len(lines) != 1 {
 		t.Errorf("expected 1 line with no reason, got %d", len(lines))
+	}
+}
+
+// --- Layer extraction and override hint tests (ADR-0016) ---
+
+func TestEvalResult_LayerFromRuleID(t *testing.T) {
+	path := writePolicyFile(t, `
+version: 1
+default: deny
+allow:
+  - "echo *"
+`)
+	result := launch.EvaluateCommand(path, "echo hello", "/tmp")
+	if result.Disposition != model.DispositionAllow {
+		t.Fatalf("expected allow, got %q", result.Disposition)
+	}
+	// Rule ID should have a layer prefix from LoadWithProfiles.
+	if result.Layer == "" {
+		t.Error("expected non-empty layer in EvalResult")
+	}
+}
+
+func TestWriteDeny_DefaultLayerOverrideHint(t *testing.T) {
+	var buf bytes.Buffer
+	launch.WriteDeny(&buf, "security dump", "blocked", "default:deny_0", "")
+	out := buf.String()
+	if !strings.Contains(out, "built-in defaults") {
+		t.Errorf("expected 'built-in defaults' source, got %q", out)
+	}
+	if !strings.Contains(out, "override in aileron.yaml") {
+		t.Errorf("expected override hint, got %q", out)
+	}
+}
+
+func TestWriteDeny_ProjectLayerOverrideHint(t *testing.T) {
+	var buf bytes.Buffer
+	launch.WriteDeny(&buf, "deploy", "blocked", "project:deny_0", "/repo/aileron.yaml")
+	out := buf.String()
+	if !strings.Contains(out, "/repo/aileron.yaml") {
+		t.Errorf("expected project path, got %q", out)
+	}
+	if !strings.Contains(out, "override in ~/.aileron/settings.yaml") {
+		t.Errorf("expected user override hint, got %q", out)
+	}
+}
+
+func TestWriteDeny_UserLayerNoOverrideHint(t *testing.T) {
+	var buf bytes.Buffer
+	launch.WriteDeny(&buf, "deploy", "blocked", "user:deny_0", "")
+	out := buf.String()
+	if strings.Contains(out, "Hint:") {
+		t.Errorf("user layer should not have override hint, got %q", out)
+	}
+}
+
+func TestEvaluateCommand_SpecificDenyBeatsGeneralAllow(t *testing.T) {
+	// "rm -rf /" (deny, 8 literal chars) should beat "rm *" (allow, 3 literal chars).
+	path := writePolicyFile(t, `
+version: 1
+default: ask
+allow:
+  - "rm *"
+deny:
+  - command: "rm -rf /"
+    description: "block rm -rf root"
+`)
+	result := launch.EvaluateCommand(path, "rm -rf /", "/tmp")
+	if result.Disposition != model.DispositionDeny {
+		t.Errorf("expected specific deny to beat general allow, got %q", result.Disposition)
 	}
 }

--- a/core/launch/init.go
+++ b/core/launch/init.go
@@ -32,7 +32,9 @@ func generatePolicyYAML() string {
 # rules are built into Aileron. You only need to add project-specific
 # rules here.
 #
-# Three-layer merge: built-in defaults → this file → ~/.aileron/settings.yaml
+# Three-layer merge: built-in defaults → user ~/.aileron/settings.yaml → this file.
+# Later layer wins for the same pattern. More specific patterns win regardless
+# of layer. See ADR-0016 for details.
 # Docs: https://github.com/ALRubinger/aileron
 version: 1
 default: ask

--- a/core/policy/launch/builtin.go
+++ b/core/policy/launch/builtin.go
@@ -85,7 +85,8 @@ func BuiltinAskRules() []api.PolicyRule {
 
 	result := make([]api.PolicyRule, 0, len(rules))
 	for _, r := range rules {
-		priority := PriorityBuiltinAsk
+		// Compute specificity from pattern; ask offset (+1) for tie-breaking.
+		priority := PatternSpecificity(r.pattern)*3 + effectOffset(api.PolicyRuleEffectRequireApproval)
 		desc := r.desc
 		conditions := []api.PolicyCondition{
 			makeCondition("action.type", api.Eq, "shell.exec"),

--- a/core/policy/launch/loader.go
+++ b/core/policy/launch/loader.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 
 	api "github.com/ALRubinger/aileron/core/api/gen"
 	"gopkg.in/yaml.v3"
@@ -18,12 +19,11 @@ const (
 	userSettingsFile = "settings.yaml"
 )
 
-// Default priorities for each bucket.
+// Layer names tag rule IDs for auditability.
 const (
-	PriorityAllow      = 50
-	PriorityAsk        = 100
-	PriorityBuiltinAsk = 150 // built-in ask rules sit between user ask and user deny
-	PriorityDeny       = 200
+	LayerDefault = "default"
+	LayerUser    = "user"
+	LayerProject = "project"
 )
 
 // Load parses a single aileron.yaml file.
@@ -70,44 +70,72 @@ func LoadUserSettings() (*PolicyFile, error) {
 }
 
 // LoadWithProfiles loads a project policy file and merges it with built-in
-// defaults and user settings per ADR-0015.
+// defaults and user settings per ADR-0015 and ADR-0016.
 //
-// Composition order (each layer wins over the previous):
+// Composition order (each layer wins over the previous for same-pattern rules):
 //
 //	Built-in defaults (DefaultPolicy — all languages, OS-specific rules)
 //	  → User settings (~/.aileron/settings.yaml)
 //	    → Project aileron.yaml
-//	      → Built-in structural deny rules (injected by ToEngineRules)
+//	      → Built-in structural ask rules (injected by ToEngineRules)
+//
+// When two layers define a rule with the same command pattern, the later
+// layer replaces the earlier one. When patterns differ, the engine picks
+// the most specific match at eval time (specificity = non-wildcard chars).
 func LoadWithProfiles(path string) (*PolicyFile, error) {
 	project, err := Load(path)
 	if err != nil {
 		return nil, err
 	}
 
-	// Start from built-in defaults.
+	// Start from built-in defaults, tagged as "default" layer.
 	base := DefaultPolicy()
+	tagRules(base, LayerDefault)
 
 	// Layer user settings on top of defaults.
 	userSettings, err := LoadUserSettings()
 	if err != nil {
 		return nil, err
 	}
+	tagRules(userSettings, LayerUser)
 	base = Merge(base, userSettings)
 
 	// Project policy is the final overlay.
+	tagRules(project, LayerProject)
 	return Merge(base, project), nil
 }
 
-// Merge composes two policy files. The overlay's rules are appended to the
-// base's rules. Scalar settings use last-writer-wins (overlay wins). Env
-// scrub lists are unioned; passthrough at any layer beats scrub.
+// tagRules prefixes rule IDs with a layer name for auditability.
+// Rules that already have a layer prefix (contain ":") are skipped.
+func tagRules(pf *PolicyFile, layer string) {
+	tagBucket := func(rules []Rule, bucket string) {
+		for i := range rules {
+			if rules[i].ID == "" {
+				rules[i].ID = fmt.Sprintf("%s:%s_%d", layer, bucket, i)
+			} else if !strings.Contains(rules[i].ID, ":") {
+				rules[i].ID = fmt.Sprintf("%s:%s", layer, rules[i].ID)
+			}
+		}
+	}
+	tagBucket(pf.Allow, "allow")
+	tagBucket(pf.Deny, "deny")
+	tagBucket(pf.Ask, "ask")
+}
+
+// Merge composes two policy files. For rules with the same command
+// pattern, the overlay rule replaces the base rule (later layer wins).
+// Rules with different patterns coexist. Scalar settings use
+// last-writer-wins (overlay wins). Env scrub lists are unioned;
+// passthrough at any layer beats scrub.
 func Merge(base, overlay *PolicyFile) *PolicyFile {
+	// Merge rules with pattern-based replacement: overlay replaces base
+	// rules that have the same command pattern.
 	result := &PolicyFile{
 		Version: overlay.Version,
 		Default: base.Default,
-		Allow:    append(append([]Rule{}, base.Allow...), overlay.Allow...),
-		Deny:     append(append([]Rule{}, base.Deny...), overlay.Deny...),
-		Ask:      append(append([]Rule{}, base.Ask...), overlay.Ask...),
+		Allow:   mergeRuleBuckets(base.Allow, overlay.Allow, collectAllPatterns(overlay)),
+		Deny:    mergeRuleBuckets(base.Deny, overlay.Deny, collectAllPatterns(overlay)),
+		Ask:     mergeRuleBuckets(base.Ask, overlay.Ask, collectAllPatterns(overlay)),
 	}
 
 	// Last-writer-wins for default and settings.
@@ -152,6 +180,35 @@ func Merge(base, overlay *PolicyFile) *PolicyFile {
 	result.Allow = applyOverrides(result.Allow, allOverlaySources)
 	result.Ask = applyOverrides(result.Ask, allOverlaySources)
 
+	return result
+}
+
+// collectAllPatterns returns the set of command patterns from all buckets
+// of a policy file. Used to identify which base rules should be replaced.
+func collectAllPatterns(pf *PolicyFile) map[string]bool {
+	patterns := make(map[string]bool)
+	for _, buckets := range [][]Rule{pf.Allow, pf.Deny, pf.Ask} {
+		for _, r := range buckets {
+			if r.Command != "" {
+				patterns[r.Command] = true
+			}
+		}
+	}
+	return patterns
+}
+
+// mergeRuleBuckets merges a base and overlay bucket. Base rules whose
+// command pattern appears in the overlay's pattern set are dropped
+// (the overlay rule in whatever bucket replaces them).
+func mergeRuleBuckets(base, overlay []Rule, overlayPatterns map[string]bool) []Rule {
+	var result []Rule
+	for _, r := range base {
+		if r.Command != "" && overlayPatterns[r.Command] {
+			continue // overlay replaces this pattern
+		}
+		result = append(result, r)
+	}
+	result = append(result, overlay...)
 	return result
 }
 
@@ -313,22 +370,27 @@ func applyOverrides(rules []Rule, overrideSource []Rule) []Rule {
 }
 
 // ToEngineRules translates the policy file into api.PolicyRule types
-// suitable for the RuleEngine. It includes built-in structural deny rules
+// suitable for the RuleEngine. It includes built-in structural ask rules
 // and a catch-all default rule.
+//
+// Priority is computed from pattern specificity: count of non-wildcard
+// characters in the command pattern. The engine sorts by priority
+// descending, so more specific patterns win. For equal specificity,
+// a small offset biases toward safety: deny+2, ask+1, allow+0.
 func (pf *PolicyFile) ToEngineRules() []api.PolicyRule {
 	var rules []api.PolicyRule
 
 	for i, r := range pf.Allow {
-		rules = append(rules, ruleToEngine(r, api.PolicyRuleEffectAllow, PriorityAllow, "allow", i))
+		rules = append(rules, ruleToEngine(r, api.PolicyRuleEffectAllow, "allow", i))
 	}
 	for i, r := range pf.Ask {
-		rules = append(rules, ruleToEngine(r, api.PolicyRuleEffectRequireApproval, PriorityAsk, "ask", i))
+		rules = append(rules, ruleToEngine(r, api.PolicyRuleEffectRequireApproval, "ask", i))
 	}
 	for i, r := range pf.Deny {
-		rules = append(rules, ruleToEngine(r, api.PolicyRuleEffectDeny, PriorityDeny, "deny", i))
+		rules = append(rules, ruleToEngine(r, api.PolicyRuleEffectDeny, "deny", i))
 	}
 
-	// Add built-in structural deny rules.
+	// Add built-in structural ask rules.
 	rules = append(rules, BuiltinAskRules()...)
 
 	// Add default catch-all rule.
@@ -337,16 +399,44 @@ func (pf *PolicyFile) ToEngineRules() []api.PolicyRule {
 	return rules
 }
 
-func ruleToEngine(r Rule, effect api.PolicyRuleEffect, defaultPriority int, bucket string, index int) api.PolicyRule {
+// PatternSpecificity returns the number of non-wildcard characters in
+// a pattern. More literal characters means a more specific match.
+// Exported for testing.
+func PatternSpecificity(pattern string) int {
+	count := 0
+	for _, ch := range pattern {
+		if ch != '*' {
+			count++
+		}
+	}
+	return count
+}
+
+// effectOffset returns a small tie-breaker offset for equal-specificity
+// rules: deny > ask > allow (safety bias).
+func effectOffset(effect api.PolicyRuleEffect) int {
+	switch effect {
+	case api.PolicyRuleEffectDeny:
+		return 2
+	case api.PolicyRuleEffectRequireApproval:
+		return 1
+	default:
+		return 0
+	}
+}
+
+func ruleToEngine(r Rule, effect api.PolicyRuleEffect, bucket string, index int) api.PolicyRule {
 	id := r.ID
 	if id == "" {
 		id = fmt.Sprintf("%s_%d", bucket, index)
 	}
 
-	priority := defaultPriority
-	if r.Priority != nil {
-		priority = *r.Priority
+	// Compute specificity-based priority from the command pattern.
+	pattern := r.Command
+	if pattern == "" {
+		pattern = r.Binary
 	}
+	priority := PatternSpecificity(pattern)*3 + effectOffset(effect)
 
 	var conditions []api.PolicyCondition
 

--- a/core/policy/launch/loader_test.go
+++ b/core/policy/launch/loader_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 
 	api "github.com/ALRubinger/aileron/core/api/gen"
@@ -175,7 +176,7 @@ func TestToEngineRules_Count(t *testing.T) {
 	}
 }
 
-func TestToEngineRules_Priorities(t *testing.T) {
+func TestToEngineRules_SpecificityPriorities(t *testing.T) {
 	pf, _ := launch.Load(testdataPath("basic.yaml"))
 	rules := pf.ToEngineRules()
 
@@ -184,19 +185,31 @@ func TestToEngineRules_Priorities(t *testing.T) {
 			t.Errorf("rule %q has nil priority", r.RuleId)
 			continue
 		}
-		switch r.Effect {
-		case api.PolicyRuleEffectAllow:
-			if r.RuleId != "default" && *r.Priority != launch.PriorityAllow {
-				t.Errorf("allow rule %q priority = %d, want %d", r.RuleId, *r.Priority, launch.PriorityAllow)
+		// Every rule should have a non-negative specificity-based priority.
+		if *r.Priority < 0 {
+			t.Errorf("rule %q has negative priority %d", r.RuleId, *r.Priority)
+		}
+	}
+
+	// Verify that more specific patterns get higher priority.
+	// "git push origin main" (19 literal chars) should beat "git *" (4 literal chars).
+	findPriority := func(id string) int {
+		for _, r := range rules {
+			if r.RuleId == id {
+				return *r.Priority
 			}
-		case api.PolicyRuleEffectRequireApproval:
-			if r.RuleId != "default" && *r.Priority != launch.PriorityAsk && *r.Priority != launch.PriorityBuiltinAsk {
-				t.Errorf("ask rule %q priority = %d, want %d or %d", r.RuleId, *r.Priority, launch.PriorityAsk, launch.PriorityBuiltinAsk)
-			}
-		case api.PolicyRuleEffectDeny:
-			if *r.Priority != launch.PriorityDeny {
-				t.Errorf("deny rule %q priority = %d, want %d", r.RuleId, *r.Priority, launch.PriorityDeny)
-			}
+		}
+		return -1
+	}
+	// The default catch-all should have the lowest priority.
+	defaultPri := findPriority("default")
+	if defaultPri < 0 {
+		t.Fatal("default rule not found")
+	}
+	// Any rule with a pattern should have higher priority than the default.
+	for _, r := range rules {
+		if r.RuleId != "default" && *r.Priority <= defaultPri {
+			t.Errorf("rule %q (priority %d) should beat default (priority %d)", r.RuleId, *r.Priority, defaultPri)
 		}
 	}
 }
@@ -273,8 +286,8 @@ func TestBuiltinAskRules_Count(t *testing.T) {
 		if r.Effect != api.PolicyRuleEffectRequireApproval {
 			t.Errorf("builtin rule %q effect = %v, want RequireApproval", r.RuleId, r.Effect)
 		}
-		if r.Priority == nil || *r.Priority != launch.PriorityBuiltinAsk {
-			t.Errorf("builtin rule %q priority should be %d", r.RuleId, launch.PriorityBuiltinAsk)
+		if r.Priority == nil || *r.Priority <= 0 {
+			t.Errorf("builtin rule %q should have a positive specificity-based priority", r.RuleId)
 		}
 	}
 }
@@ -342,7 +355,6 @@ deny:
   - id: deny-rm
     command: "rm -rf *"
     description: "no recursive delete"
-    priority: 250
 `
 	pf, err := launch.Parse([]byte(yaml))
 	if err != nil {
@@ -355,8 +367,8 @@ deny:
 	if r.ID != "deny-rm" {
 		t.Errorf("ID = %q, want 'deny-rm'", r.ID)
 	}
-	if r.Priority == nil || *r.Priority != 250 {
-		t.Errorf("Priority = %v, want 250", r.Priority)
+	if r.Description != "no recursive delete" {
+		t.Errorf("Description = %q, want 'no recursive delete'", r.Description)
 	}
 }
 
@@ -434,5 +446,267 @@ func TestMerge_NilInputs(t *testing.T) {
 	merged := launch.Merge(base, overlay)
 	if merged.Default != "ask" {
 		t.Errorf("Default = %q, want 'ask' (base preserved when overlay empty)", merged.Default)
+	}
+}
+
+// --- Layer override and specificity tests (ADR-0016) ---
+
+func TestMerge_OverlayReplacesMatchingPattern(t *testing.T) {
+	// When the overlay has a rule with the same command pattern as the base,
+	// the base rule is replaced (later layer wins).
+	base := &launch.PolicyFile{
+		Version: 1,
+		Deny:    []launch.Rule{{Command: "security *", Description: "default deny"}},
+	}
+	overlay := &launch.PolicyFile{
+		Version: 1,
+		Allow:   []launch.Rule{{Command: "security *", Description: "project allows"}},
+	}
+
+	merged := launch.Merge(base, overlay)
+
+	// The deny rule for "security *" should be gone (replaced by overlay).
+	for _, r := range merged.Deny {
+		if r.Command == "security *" {
+			t.Error("expected default deny 'security *' to be replaced by overlay")
+		}
+	}
+	// The allow rule for "security *" should be present.
+	found := false
+	for _, r := range merged.Allow {
+		if r.Command == "security *" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected overlay allow 'security *' to be present")
+	}
+}
+
+func TestMerge_DifferentPatternsCoexist(t *testing.T) {
+	// Rules with different patterns from different layers coexist.
+	base := &launch.PolicyFile{
+		Version: 1,
+		Allow:   []launch.Rule{{Command: "git *"}},
+	}
+	overlay := &launch.PolicyFile{
+		Version: 1,
+		Deny:    []launch.Rule{{Command: "git push origin main"}},
+	}
+
+	merged := launch.Merge(base, overlay)
+
+	// Both should survive since they have different patterns.
+	foundAllow := false
+	for _, r := range merged.Allow {
+		if r.Command == "git *" {
+			foundAllow = true
+		}
+	}
+	if !foundAllow {
+		t.Error("expected base allow 'git *' to survive")
+	}
+	foundDeny := false
+	for _, r := range merged.Deny {
+		if r.Command == "git push origin main" {
+			foundDeny = true
+		}
+	}
+	if !foundDeny {
+		t.Error("expected overlay deny 'git push origin main' to be present")
+	}
+}
+
+func TestSpecificity_ExactBeatsWildcard(t *testing.T) {
+	// An exact match should have higher specificity than a wildcard.
+	exact := launch.PatternSpecificity("git status")
+	wildcard := launch.PatternSpecificity("git *")
+	if exact <= wildcard {
+		t.Errorf("exact (%d) should beat wildcard (%d)", exact, wildcard)
+	}
+}
+
+func TestSpecificity_PartialBeatsGeneral(t *testing.T) {
+	// "git push *" should be more specific than "git *".
+	partial := launch.PatternSpecificity("git push *")
+	general := launch.PatternSpecificity("git *")
+	if partial <= general {
+		t.Errorf("partial (%d) should beat general (%d)", partial, general)
+	}
+}
+
+func TestSpecificity_PureWildcardIsLeast(t *testing.T) {
+	pure := launch.PatternSpecificity("*")
+	if pure != 0 {
+		t.Errorf("pure wildcard should have specificity 0, got %d", pure)
+	}
+}
+
+func TestProjectOverridesBuiltinDeny(t *testing.T) {
+	// Project allow "security *" should override default deny "security *".
+	pf := &launch.PolicyFile{
+		Version: 1,
+		Default: "ask",
+		Deny:    []launch.Rule{{Command: "security *", Description: "default deny"}},
+	}
+	overlay := &launch.PolicyFile{
+		Version: 1,
+		Allow:   []launch.Rule{{Command: "security *", Description: "project allows"}},
+	}
+
+	merged := launch.Merge(pf, overlay)
+
+	// The deny should be gone.
+	for _, r := range merged.Deny {
+		if r.Command == "security *" {
+			t.Error("expected project allow to replace default deny for 'security *'")
+		}
+	}
+}
+
+func TestUserOverridesProjectDeny(t *testing.T) {
+	// User allow should override project deny for the same pattern.
+	project := &launch.PolicyFile{
+		Version: 1,
+		Deny:    []launch.Rule{{Command: "docker push *"}},
+	}
+	user := &launch.PolicyFile{
+		Version: 1,
+		Allow:   []launch.Rule{{Command: "docker push *"}},
+	}
+
+	merged := launch.Merge(project, user)
+
+	for _, r := range merged.Deny {
+		if r.Command == "docker push *" {
+			t.Error("expected user allow to replace project deny for 'docker push *'")
+		}
+	}
+	found := false
+	for _, r := range merged.Allow {
+		if r.Command == "docker push *" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected user allow 'docker push *' to be present")
+	}
+}
+
+func TestSpecificDenyBeatsGeneralAllow(t *testing.T) {
+	// A specific deny should beat a general allow via specificity in the engine.
+	pf := &launch.PolicyFile{
+		Version: 1,
+		Default: "ask",
+		Allow:   []launch.Rule{{Command: "rm *"}},
+		Deny:    []launch.Rule{{Command: "rm -rf /"}},
+	}
+
+	rules := pf.ToEngineRules()
+
+	var allowPri, denyPri int
+	for _, r := range rules {
+		if r.RuleId == "allow_0" {
+			allowPri = *r.Priority
+		}
+		if r.RuleId == "deny_0" {
+			denyPri = *r.Priority
+		}
+	}
+
+	if denyPri <= allowPri {
+		t.Errorf("deny 'rm -rf /' (priority %d) should beat allow 'rm *' (priority %d)", denyPri, allowPri)
+	}
+}
+
+func TestTagRules_LayerPrefix(t *testing.T) {
+	// Verify LoadWithProfiles tags rules with layer prefixes.
+	dir := t.TempDir()
+	policyPath := filepath.Join(dir, "aileron.yaml")
+	os.WriteFile(policyPath, []byte(`
+version: 1
+default: ask
+allow:
+  - "echo *"
+deny:
+  - command: "rm *"
+    description: "test deny"
+`), 0o644)
+
+	pf, err := launch.LoadWithProfiles(policyPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Check that project rules have "project:" prefix.
+	foundProjectAllow := false
+	for _, r := range pf.Allow {
+		if r.Command == "echo *" && strings.HasPrefix(r.ID, "project:") {
+			foundProjectAllow = true
+		}
+	}
+	if !foundProjectAllow {
+		t.Error("expected project allow rule to have 'project:' prefix")
+	}
+
+	// Check that default rules have "default:" prefix.
+	foundDefaultAllow := false
+	for _, r := range pf.Allow {
+		if strings.HasPrefix(r.ID, "default:") {
+			foundDefaultAllow = true
+		}
+	}
+	if !foundDefaultAllow {
+		t.Error("expected default allow rules to have 'default:' prefix")
+	}
+}
+
+func TestSpecificityTieBreaker_DenyBeatsAllow(t *testing.T) {
+	// For same-specificity patterns, deny should beat allow.
+	pf := &launch.PolicyFile{
+		Version: 1,
+		Allow:   []launch.Rule{{Command: "foo bar"}},
+		Deny:    []launch.Rule{{Command: "foo bar"}},
+	}
+
+	rules := pf.ToEngineRules()
+
+	var allowPri, denyPri int
+	for _, r := range rules {
+		if r.RuleId == "allow_0" {
+			allowPri = *r.Priority
+		}
+		if r.RuleId == "deny_0" {
+			denyPri = *r.Priority
+		}
+	}
+
+	if denyPri <= allowPri {
+		t.Errorf("deny (priority %d) should beat allow (priority %d) for same pattern", denyPri, allowPri)
+	}
+}
+
+func TestSpecificityTieBreaker_AskBeatsAllow(t *testing.T) {
+	// For same-specificity patterns, ask should beat allow.
+	pf := &launch.PolicyFile{
+		Version: 1,
+		Allow: []launch.Rule{{Command: "foo bar"}},
+		Ask:   []launch.Rule{{Command: "foo bar"}},
+	}
+
+	rules := pf.ToEngineRules()
+
+	var allowPri, askPri int
+	for _, r := range rules {
+		if r.RuleId == "allow_0" {
+			allowPri = *r.Priority
+		}
+		if r.RuleId == "ask_0" {
+			askPri = *r.Priority
+		}
+	}
+
+	if askPri <= allowPri {
+		t.Errorf("ask (priority %d) should beat allow (priority %d) for same pattern", askPri, allowPri)
 	}
 }

--- a/core/policy/launch/schema.go
+++ b/core/policy/launch/schema.go
@@ -103,7 +103,6 @@ type Rule struct {
 	ArgsContain string `yaml:"args_contain,omitempty"`
 	WorkingDir  string `yaml:"working_dir,omitempty"`
 	Description string `yaml:"description,omitempty"`
-	Priority    *int   `yaml:"priority,omitempty"`
 	Override    string `yaml:"override,omitempty"`
 }
 

--- a/core/policy/launch/schema_test.go
+++ b/core/policy/launch/schema_test.go
@@ -99,7 +99,7 @@ func TestRule_UnmarshalYAML_InvalidMappingField(t *testing.T) {
 	// A mapping with an invalid type for a known field should produce
 	// a decode error (the "decoding rule:" path).
 	input := `
-- priority: [1, 2, 3]
+- command: [1, 2, 3]
 `
 	var rules []launch.Rule
 	err := yaml.Unmarshal([]byte(input), &rules)

--- a/docs/adr/0016-layer-overrides-and-specificity.md
+++ b/docs/adr/0016-layer-overrides-and-specificity.md
@@ -1,0 +1,61 @@
+# ADR-0016: Layer Overrides and Pattern Specificity
+
+## Status
+
+Accepted
+
+## Context
+
+The priority point system (allow=50, ask=100, deny=200) introduced in ADR-0014 and ADR-0015 is overengineered. Users have to think about numeric priorities when they should just think about which layer they're writing rules in and how specific their patterns are.
+
+The three-layer model (defaults, user, project) needs a simpler conflict resolution mechanism.
+
+## Decision
+
+Replace the priority point system with two rules:
+
+### 1. Later layer wins for the same pattern
+
+When merging layers (defaults -> user -> project), if the overlay has a rule with the same command pattern as a base rule, the base rule is **replaced**. The overlay's bucket (allow/deny/ask) determines the effect.
+
+```
+Default: deny  "security *"
+Project: allow "security *"
+-> Only the project allow survives. The default deny is replaced.
+```
+
+### 2. More specific pattern wins regardless of layer
+
+When multiple rules match a command at eval time, the most specific pattern wins. Specificity is measured by counting non-wildcard characters in the pattern.
+
+```
+Default: allow "git *"           (specificity: 4)
+Project: deny  "git push origin main"  (specificity: 20)
+-> Both survive merge (different patterns). At eval, the deny wins
+   because it has higher specificity.
+```
+
+For equal specificity, a safety-biased tie-breaker applies: deny > ask > allow. This is implemented as a small offset added to the specificity score (deny+2, ask+1, allow+0), multiplied by 3 to create spacing.
+
+### Implementation
+
+- The `Priority` field is removed from the `Rule` struct. Users no longer assign numeric priorities.
+- `Merge()` drops base rules whose command pattern appears in the overlay (any bucket).
+- `ToEngineRules()` computes `PatternSpecificity(pattern) * 3 + effectOffset` as the engine priority. The existing engine sorts by priority descending, so no engine changes are needed.
+- Rule IDs are tagged with layer prefixes (`default:`, `user:`, `project:`) for auditability.
+- `BuiltinAskRules()` use the same specificity-based priority as all other rules.
+
+### Examples
+
+| Scenario | Default | Project | Result |
+|----------|---------|---------|--------|
+| Project allows what default denies | deny "security *" | allow "security *" | allow (project replaces default) |
+| Specific deny beats general allow | allow "git *" | deny "git push origin main" | deny wins for "git push origin main", allow wins for "git status" |
+| User overrides project | (project) deny "docker push *" | (user) allow "docker push *" | allow (user replaces project) |
+
+## Consequences
+
+- Users can override any default rule by defining the same pattern in their project or user config.
+- More specific patterns always win over general ones, regardless of which layer defined them.
+- The `priority` field in aileron.yaml is no longer supported. Existing files with `priority:` will have the field silently ignored (it's removed from the schema).
+- Built-in ask rules (pipe-to-shell, eval, etc.) can be overridden by project or user policy like any other default rule.


### PR DESCRIPTION
Replaces numeric priority system with layer overrides and pattern specificity per issue #91. Later layer wins for same pattern; more specific patterns win regardless of layer. Adds ADR-0016. Coverage above 80% across all packages. Closes #91