### PR TITLE
feat(launch): pluggable agent SPI with pi.dev support

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ Today's agent hosts give you two modes: approve every command individually (50 p
 │  └─────────────────────────────────────────────────┘   │
 │                                                        │
 │  ┌─────────────────────────────────────────────────┐   │
-│  │  Agent (claude, codex, goose, opencode, ...)    │   │
+│  │  Agent (claude, pi, codex, goose, opencode, ...) │   │
 │  │  Inherits: SHELL=aileron-sh, scrubbed env,      │   │
 │  │            aileron-mcp registered               │   │
 │  └─────────────────────────────────────────────────┘   │
@@ -125,6 +125,7 @@ aileron status vault        # stored secrets (names only)
 | Agent | Shell policy | MCP tools | Full experience |
 |-------|-------------|-----------|-----------------|
 | Claude Code | Yes | Yes | Yes |
+| [pi.dev](https://github.com/badlogic/pi-mono/tree/main/packages/coding-agent) | Yes | Not yet | Shell policy now |
 | OpenCode | Yes | Yes | Yes |
 | Goose | Yes | Yes | Yes |
 | Amp | Yes | Yes | Yes |
@@ -225,9 +226,11 @@ task build:docker    # Docker containers
 
 ```sh
 ./build/aileron launch claude
+# or
+./build/aileron launch pi
 ```
 
-This works with zero configuration. Built-in defaults allow common toolchain commands (go, npm, cargo, etc.) and deny dangerous operations (recursive delete, push to main). Every command flows through `aileron-sh` and the policy engine. Aileron is the single approval layer — Claude Code's native Bash approval is suppressed.
+This works with zero configuration. Built-in defaults allow common toolchain commands (go, npm, cargo, etc.) and deny dangerous operations (recursive delete, push to main). Every command flows through `aileron-sh` and the policy engine. Aileron is the single approval layer — the agent's native tool approval is suppressed.
 
 Optionally, scaffold a project-specific policy:
 

--- a/cmd/aileron-sh/main.go
+++ b/cmd/aileron-sh/main.go
@@ -12,12 +12,12 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
-	"strings"
 	"syscall"
 	"time"
 
 	"github.com/ALRubinger/aileron/core/audit"
 	"github.com/ALRubinger/aileron/core/launch"
+	"github.com/ALRubinger/aileron/core/launch/agents"
 	"github.com/ALRubinger/aileron/core/model"
 	launchpolicy "github.com/ALRubinger/aileron/core/policy/launch"
 )
@@ -59,7 +59,7 @@ func main() {
 	// intervening shell flags (-l, -i, etc.).
 	cwd, _ := os.Getwd()
 	rawCommand, hasCommand := extractCommand(args)
-	command, shouldEval := normalizeCommand(os.Getenv("AILERON_AGENT"), rawCommand)
+	command, shouldEval := agents.NormalizeCommand(os.Getenv("AILERON_AGENT"), rawCommand)
 	policyPath := launch.FindPolicyFile(cwd)
 	if hasCommand && shouldEval && policyPath != "" {
 		result := launch.EvaluateCommand(policyPath, command, cwd)
@@ -175,72 +175,6 @@ func extractCommand(args []string) (string, bool) {
 	return "", false
 }
 
-// normalizeCommand applies agent-specific command transformations before
-// policy evaluation. Returns the normalized command and whether policy
-// should be evaluated. For Claude Code, only eval-wrapped commands are
-// user commands — everything else is infrastructure (snapshot scripts,
-// etc.) and should pass through without policy evaluation.
-func normalizeCommand(agent, command string) (string, bool) {
-	switch agent {
-	case "claude":
-		inner := unwrapClaudeEval(command)
-		if inner == command {
-			// No eval wrapper found — this is a Claude Code infrastructure
-			// command (snapshot creation, etc.), not a user command.
-			return command, false
-		}
-		return inner, true
-	default:
-		return command, true
-	}
-}
-
-// unwrapClaudeEval extracts the inner command from Claude Code's wrapper template.
-// Claude Code sends commands in the form:
-//
-//	shopt -u extglob 2>/dev/null || true && eval 'actual command' < /dev/null && pwd -P >| /tmp/...
-//
-// This function finds the eval '...' segment and returns the inner command.
-// If the input doesn't match the wrapper pattern, it is returned unchanged.
-func unwrapClaudeEval(command string) string {
-	// Try quoted form first: eval '...'
-	const quotedPrefix = "eval '"
-	if idx := strings.Index(command, quotedPrefix); idx >= 0 {
-		inner := command[idx+len(quotedPrefix):]
-
-		var b strings.Builder
-		for i := 0; i < len(inner); {
-			if inner[i] == '\'' {
-				if i+3 < len(inner) && inner[i:i+4] == `'\''` {
-					b.WriteByte('\'')
-					i += 4
-					continue
-				}
-				return b.String()
-			}
-			b.WriteByte(inner[i])
-			i++
-		}
-	}
-
-	// Try unquoted form: eval <command> \< /dev/null
-	// Claude Code sometimes sends: shopt ... && eval ls \< /dev/null && pwd ...
-	const unquotedPrefix = "eval "
-	if idx := strings.Index(command, unquotedPrefix); idx >= 0 {
-		rest := command[idx+len(unquotedPrefix):]
-
-		// The user command is everything up to the first escaped redirect
-		// (\<) or && or the end of string.
-		for _, sep := range []string{` \<`, ` \>`, " &&", " ||"} {
-			if end := strings.Index(rest, sep); end >= 0 {
-				return strings.TrimSpace(rest[:end])
-			}
-		}
-		return strings.TrimSpace(rest)
-	}
-
-	return command
-}
 
 // promptApproval requests user approval via the launcher's approval
 // server. The launcher owns the real terminal and handles the prompt.

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -22,6 +22,7 @@ import (
 func main() {
 	registry := launch.NewRegistry()
 	registry.Register(agents.Claude{})
+	registry.Register(agents.Pi{})
 	os.Exit(run(os.Args[1:], registry, os.Stdout, os.Stderr))
 }
 

--- a/core/launch/agent.go
+++ b/core/launch/agent.go
@@ -18,6 +18,18 @@ type Agent interface {
 	// process, beyond the standard SHELL/AILERON_REAL_SHELL manipulation.
 	// Returns nil if no extra env is needed.
 	Env() map[string]string
+	// NormalizeCommand extracts the user command from the agent's shell
+	// wrapper before policy evaluation. Returns the normalized command and
+	// whether policy should evaluate it. Agents that don't wrap commands
+	// return (raw, true).
+	NormalizeCommand(raw string) (command string, evaluate bool)
+	// ConfigureShell performs any agent-specific setup needed to make the
+	// agent use the aileron-sh shim for shell execution. shimPath is the
+	// absolute path to aileron-sh. dir is the working directory where the
+	// agent will run. Agents that respect $SHELL can return nil. Agents
+	// that use their own shell resolution (e.g. a config file) should
+	// write the necessary configuration here.
+	ConfigureShell(shimPath, dir string) error
 }
 
 // Registry maps agent names to their definitions.

--- a/core/launch/agent_test.go
+++ b/core/launch/agent_test.go
@@ -54,7 +54,9 @@ type testAgent struct {
 }
 
 
-func (a testAgent) Name() string           { return a.name }
-func (a testAgent) BinaryNames() []string  { return []string{a.name} }
-func (a testAgent) Args() []string         { return nil }
-func (a testAgent) Env() map[string]string { return nil }
+func (a testAgent) Name() string                              { return a.name }
+func (a testAgent) BinaryNames() []string                     { return []string{a.name} }
+func (a testAgent) Args() []string                            { return nil }
+func (a testAgent) Env() map[string]string                    { return nil }
+func (a testAgent) NormalizeCommand(raw string) (string, bool) { return raw, true }
+func (a testAgent) ConfigureShell(_, _ string) error           { return nil }

--- a/core/launch/agents/claude.go
+++ b/core/launch/agents/claude.go
@@ -1,6 +1,12 @@
 package agents
 
-import "strings"
+import (
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ALRubinger/aileron/core/launch"
+)
 
 // Claude is the agent definition for Claude Code.
 // Claude Code sends bash-specific commands (shopt, etc.), so the real
@@ -16,15 +22,26 @@ func (c Claude) Args() []string {
 	return []string{"--allowedTools", "Bash(*)"}
 }
 
+// Env returns Claude-specific environment variables. CLAUDE_CODE_SHELL
+// is set to ~/.aileron/bash (installed by ConfigureShell) because Claude
+// Code validates that the shell path contains "bash".
 func (c Claude) Env() map[string]string {
-	return map[string]string{
+	env := map[string]string{
 		"AILERON_REAL_SHELL": "/bin/bash",
 	}
+	if home, err := os.UserHomeDir(); err == nil {
+		env["CLAUDE_CODE_SHELL"] = filepath.Join(home, ".aileron", "bash")
+	}
+	return env
 }
 
-// ConfigureShell is a no-op for Claude Code. Claude respects the $SHELL
-// env var and CLAUDE_CODE_SHELL, both set by the launcher.
-func (c Claude) ConfigureShell(_, _ string) error { return nil }
+// ConfigureShell installs a wrapper script at ~/.aileron/bash whose path
+// contains "bash" so Claude Code accepts it as a valid shell. The wrapper
+// delegates to aileron-sh for policy enforcement.
+func (c Claude) ConfigureShell(shimPath, _ string) error {
+	_, err := launch.InstallWrapper(shimPath)
+	return err
+}
 
 // NormalizeCommand extracts the user command from Claude Code's eval
 // wrapper. Claude Code sends commands as:

--- a/core/launch/agents/claude.go
+++ b/core/launch/agents/claude.go
@@ -1,5 +1,7 @@
 package agents
 
+import "strings"
+
 // Claude is the agent definition for Claude Code.
 // Claude Code sends bash-specific commands (shopt, etc.), so the real
 // shell must be bash regardless of the user's login shell.
@@ -18,4 +20,61 @@ func (c Claude) Env() map[string]string {
 	return map[string]string{
 		"AILERON_REAL_SHELL": "/bin/bash",
 	}
+}
+
+// ConfigureShell is a no-op for Claude Code. Claude respects the $SHELL
+// env var and CLAUDE_CODE_SHELL, both set by the launcher.
+func (c Claude) ConfigureShell(_, _ string) error { return nil }
+
+// NormalizeCommand extracts the user command from Claude Code's eval
+// wrapper. Claude Code sends commands as:
+//
+//	shopt -u extglob 2>/dev/null || true && eval 'actual command' < /dev/null && pwd -P >| /tmp/...
+//
+// Commands without the eval wrapper are Claude Code infrastructure
+// (snapshot scripts, etc.) and should pass through without policy.
+func (c Claude) NormalizeCommand(raw string) (string, bool) {
+	inner := unwrapClaudeEval(raw)
+	if inner == raw {
+		return raw, false
+	}
+	return inner, true
+}
+
+// unwrapClaudeEval extracts the inner command from Claude Code's wrapper template.
+func unwrapClaudeEval(command string) string {
+	// Try quoted form first: eval '...'
+	const quotedPrefix = "eval '"
+	if idx := strings.Index(command, quotedPrefix); idx >= 0 {
+		inner := command[idx+len(quotedPrefix):]
+
+		var b strings.Builder
+		for i := 0; i < len(inner); {
+			if inner[i] == '\'' {
+				if i+3 < len(inner) && inner[i:i+4] == `'\''` {
+					b.WriteByte('\'')
+					i += 4
+					continue
+				}
+				return b.String()
+			}
+			b.WriteByte(inner[i])
+			i++
+		}
+	}
+
+	// Try unquoted form: eval <command> \< /dev/null
+	const unquotedPrefix = "eval "
+	if idx := strings.Index(command, unquotedPrefix); idx >= 0 {
+		rest := command[idx+len(unquotedPrefix):]
+
+		for _, sep := range []string{` \<`, ` \>`, " &&", " ||"} {
+			if end := strings.Index(rest, sep); end >= 0 {
+				return strings.TrimSpace(rest[:end])
+			}
+		}
+		return strings.TrimSpace(rest)
+	}
+
+	return command
 }

--- a/core/launch/agents/claude_test.go
+++ b/core/launch/agents/claude_test.go
@@ -40,3 +40,55 @@ func TestClaude(t *testing.T) {
 		t.Errorf("expected AILERON_REAL_SHELL=/bin/bash, got %q", env["AILERON_REAL_SHELL"])
 	}
 }
+
+func TestClaude_NormalizeCommand_EvalWrapper(t *testing.T) {
+	c := agents.Claude{}
+
+	wrapped := "shopt -u extglob 2>/dev/null || true && eval 'echo hello' < /dev/null && pwd -P >| /tmp/cwd"
+	cmd, eval := c.NormalizeCommand(wrapped)
+	if !eval {
+		t.Fatal("expected evaluate=true for eval-wrapped command")
+	}
+	if cmd != "echo hello" {
+		t.Errorf("expected 'echo hello', got %q", cmd)
+	}
+}
+
+func TestClaude_NormalizeCommand_UnquotedEval(t *testing.T) {
+	c := agents.Claude{}
+
+	wrapped := `shopt -u extglob 2>/dev/null || true && eval echo hello \< /dev/null && pwd -P >| /tmp/cwd`
+	cmd, eval := c.NormalizeCommand(wrapped)
+	if !eval {
+		t.Fatal("expected evaluate=true for unquoted eval command")
+	}
+	if cmd != "echo hello" {
+		t.Errorf("expected 'echo hello', got %q", cmd)
+	}
+}
+
+func TestClaude_NormalizeCommand_Infrastructure(t *testing.T) {
+	c := agents.Claude{}
+
+	infra := `SNAPSHOT_FILE=/tmp/test.sh; echo "# snapshot" > "$SNAPSHOT_FILE"`
+	cmd, eval := c.NormalizeCommand(infra)
+	if eval {
+		t.Fatal("expected evaluate=false for infrastructure command")
+	}
+	if cmd != infra {
+		t.Errorf("expected command unchanged, got %q", cmd)
+	}
+}
+
+func TestClaude_NormalizeCommand_EvalWithEscapedQuotes(t *testing.T) {
+	c := agents.Claude{}
+
+	wrapped := `shopt -u extglob 2>/dev/null || true && eval 'echo '\''hello world'\''' < /dev/null && pwd -P >| /tmp/cwd`
+	cmd, eval := c.NormalizeCommand(wrapped)
+	if !eval {
+		t.Fatal("expected evaluate=true")
+	}
+	if cmd != "echo 'hello world'" {
+		t.Errorf("expected \"echo 'hello world'\", got %q", cmd)
+	}
+}

--- a/core/launch/agents/claude_test.go
+++ b/core/launch/agents/claude_test.go
@@ -1,6 +1,9 @@
 package agents_test
 
 import (
+	"os"
+	"path/filepath"
+	"strings"
 	"testing"
 
 	"github.com/ALRubinger/aileron/core/launch/agents"
@@ -38,6 +41,12 @@ func TestClaude(t *testing.T) {
 	}
 	if env["AILERON_REAL_SHELL"] != "/bin/bash" {
 		t.Errorf("expected AILERON_REAL_SHELL=/bin/bash, got %q", env["AILERON_REAL_SHELL"])
+	}
+	if env["CLAUDE_CODE_SHELL"] == "" {
+		t.Error("expected CLAUDE_CODE_SHELL to be set")
+	}
+	if !strings.Contains(env["CLAUDE_CODE_SHELL"], "bash") {
+		t.Errorf("CLAUDE_CODE_SHELL path must contain 'bash', got %q", env["CLAUDE_CODE_SHELL"])
 	}
 }
 
@@ -77,6 +86,39 @@ func TestClaude_NormalizeCommand_Infrastructure(t *testing.T) {
 	}
 	if cmd != infra {
 		t.Errorf("expected command unchanged, got %q", cmd)
+	}
+}
+
+func TestClaude_ConfigureShell_InstallsWrapper(t *testing.T) {
+	c := agents.Claude{}
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	if err := c.ConfigureShell("/usr/local/bin/aileron-sh", t.TempDir()); err != nil {
+		t.Fatalf("ConfigureShell failed: %v", err)
+	}
+
+	wrapperPath := filepath.Join(dir, ".aileron", "bash")
+	info, err := os.Stat(wrapperPath)
+	if err != nil {
+		t.Fatalf("expected wrapper at %s: %v", wrapperPath, err)
+	}
+	if info.Mode()&0o111 == 0 {
+		t.Error("wrapper should be executable")
+	}
+}
+
+func TestClaude_NormalizeCommand_UnquotedEvalNoSeparator(t *testing.T) {
+	c := agents.Claude{}
+
+	// Unquoted eval with no separator — the entire rest is the command.
+	wrapped := "shopt -u extglob 2>/dev/null || true && eval ls"
+	cmd, eval := c.NormalizeCommand(wrapped)
+	if !eval {
+		t.Fatal("expected evaluate=true")
+	}
+	if cmd != "ls" {
+		t.Errorf("expected 'ls', got %q", cmd)
 	}
 }
 

--- a/core/launch/agents/normalize.go
+++ b/core/launch/agents/normalize.go
@@ -1,0 +1,27 @@
+package agents
+
+// NormalizeCommand looks up the agent by name and delegates to its
+// NormalizeCommand method. Unknown agents pass the command through
+// for policy evaluation unchanged.
+//
+// This function bridges the Agent interface to the aileron-sh binary,
+// which only knows the agent name (from AILERON_AGENT env var) and
+// cannot hold a reference to the Agent struct directly.
+func NormalizeCommand(agent, command string) (string, bool) {
+	if a, ok := registry[agent]; ok {
+		return a.NormalizeCommand(command)
+	}
+	return command, true
+}
+
+// registry maps agent names to their instances for normalization lookup.
+// Each agent registers itself here so aileron-sh can find it by name.
+var registry = map[string]normalizer{
+	"claude": Claude{},
+	"pi":     Pi{},
+}
+
+// normalizer is the subset of Agent needed for command normalization.
+type normalizer interface {
+	NormalizeCommand(raw string) (string, bool)
+}

--- a/core/launch/agents/normalize_test.go
+++ b/core/launch/agents/normalize_test.go
@@ -1,0 +1,49 @@
+package agents_test
+
+import (
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/launch/agents"
+)
+
+func TestNormalizeCommand_Claude(t *testing.T) {
+	wrapped := "shopt -u extglob 2>/dev/null || true && eval 'rm -rf /tmp' < /dev/null && pwd -P >| /tmp/cwd"
+	cmd, eval := agents.NormalizeCommand("claude", wrapped)
+	if !eval {
+		t.Fatal("expected evaluate=true for claude eval-wrapped command")
+	}
+	if cmd != "rm -rf /tmp" {
+		t.Errorf("expected 'rm -rf /tmp', got %q", cmd)
+	}
+}
+
+func TestNormalizeCommand_ClaudeInfrastructure(t *testing.T) {
+	infra := `SNAPSHOT_FILE=/tmp/test.sh; echo done`
+	cmd, eval := agents.NormalizeCommand("claude", infra)
+	if eval {
+		t.Fatal("expected evaluate=false for claude infrastructure command")
+	}
+	if cmd != infra {
+		t.Errorf("expected command unchanged, got %q", cmd)
+	}
+}
+
+func TestNormalizeCommand_Pi(t *testing.T) {
+	cmd, eval := agents.NormalizeCommand("pi", "echo hello")
+	if !eval {
+		t.Fatal("expected evaluate=true for pi")
+	}
+	if cmd != "echo hello" {
+		t.Errorf("expected 'echo hello', got %q", cmd)
+	}
+}
+
+func TestNormalizeCommand_UnknownAgent(t *testing.T) {
+	cmd, eval := agents.NormalizeCommand("unknown-agent", "echo hello")
+	if !eval {
+		t.Fatal("expected evaluate=true for unknown agent")
+	}
+	if cmd != "echo hello" {
+		t.Errorf("expected 'echo hello', got %q", cmd)
+	}
+}

--- a/core/launch/agents/pi.go
+++ b/core/launch/agents/pi.go
@@ -1,0 +1,74 @@
+package agents
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Pi is the agent definition for the pi.dev coding agent.
+// Pi ignores $SHELL and resolves its shell via its own settings file,
+// so ConfigureShell writes .pi/settings.json with the shim path.
+type Pi struct{}
+
+func (p Pi) Name() string          { return "pi" }
+func (p Pi) BinaryNames() []string { return []string{"pi"} }
+
+// Args returns the flags needed to make Pi auto-approve shell commands
+// so that Aileron is the single approval layer. Pi's --tools flag
+// controls which built-in tools are enabled.
+func (p Pi) Args() []string {
+	return []string{"--tools", "bash,read,edit,write,grep,find,ls"}
+}
+
+func (p Pi) Env() map[string]string {
+	return map[string]string{
+		"AILERON_REAL_SHELL": "/bin/bash",
+	}
+}
+
+// NormalizeCommand returns the command as-is for policy evaluation.
+// Pi does not wrap commands in a template like Claude Code does.
+func (p Pi) NormalizeCommand(raw string) (string, bool) {
+	return raw, true
+}
+
+// ConfigureShell writes a project-local .pi/settings.json that points
+// Pi's shellPath at aileron-sh. Pi ignores $SHELL and resolves its
+// shell from this settings file instead.
+func (p Pi) ConfigureShell(shimPath, dir string) error {
+	if dir == "" {
+		var err error
+		dir, err = os.Getwd()
+		if err != nil {
+			return fmt.Errorf("determining working directory: %w", err)
+		}
+	}
+
+	piDir := filepath.Join(dir, ".pi")
+	if err := os.MkdirAll(piDir, 0o755); err != nil {
+		return fmt.Errorf("creating .pi directory: %w", err)
+	}
+
+	settingsPath := filepath.Join(piDir, "settings.json")
+
+	// Read existing settings to preserve other fields.
+	existing := make(map[string]any)
+	if data, err := os.ReadFile(settingsPath); err == nil {
+		_ = json.Unmarshal(data, &existing)
+	}
+
+	existing["shellPath"] = shimPath
+
+	data, err := json.MarshalIndent(existing, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshaling Pi settings: %w", err)
+	}
+
+	if err := os.WriteFile(settingsPath, append(data, '\n'), 0o644); err != nil {
+		return fmt.Errorf("writing %s: %w", settingsPath, err)
+	}
+
+	return nil
+}

--- a/core/launch/agents/pi_test.go
+++ b/core/launch/agents/pi_test.go
@@ -88,6 +88,35 @@ func TestPi_ConfigureShell_WritesSettings(t *testing.T) {
 	}
 }
 
+func TestPi_ConfigureShell_DefaultsToWorkingDir(t *testing.T) {
+	p := agents.Pi{}
+	// Empty dir should fall back to os.Getwd(). Since we can't predict
+	// the cwd in tests reliably, just verify it doesn't error.
+	// The settings file will be written relative to cwd.
+	origDir, _ := os.Getwd()
+	dir := t.TempDir()
+	os.Chdir(dir)
+	defer os.Chdir(origDir)
+
+	if err := p.ConfigureShell("/usr/local/bin/aileron-sh", ""); err != nil {
+		t.Fatalf("ConfigureShell with empty dir failed: %v", err)
+	}
+
+	settingsPath := filepath.Join(dir, ".pi", "settings.json")
+	if _, err := os.Stat(settingsPath); err != nil {
+		t.Fatalf("expected settings file at %s: %v", settingsPath, err)
+	}
+}
+
+func TestPi_ConfigureShell_UnwritableDir(t *testing.T) {
+	p := agents.Pi{}
+	// Point at a path that can't be created.
+	err := p.ConfigureShell("/usr/local/bin/aileron-sh", "/dev/null/impossible")
+	if err == nil {
+		t.Fatal("expected error for unwritable directory")
+	}
+}
+
 func TestPi_ConfigureShell_PreservesExistingSettings(t *testing.T) {
 	p := agents.Pi{}
 	dir := t.TempDir()

--- a/core/launch/agents/pi_test.go
+++ b/core/launch/agents/pi_test.go
@@ -1,0 +1,120 @@
+package agents_test
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/launch/agents"
+)
+
+func TestPi(t *testing.T) {
+	p := agents.Pi{}
+
+	if p.Name() != "pi" {
+		t.Errorf("expected name 'pi', got %q", p.Name())
+	}
+
+	names := p.BinaryNames()
+	if len(names) != 1 || names[0] != "pi" {
+		t.Errorf("expected BinaryNames [\"pi\"], got %v", names)
+	}
+
+	args := p.Args()
+	if len(args) < 2 {
+		t.Fatal("expected Args with --tools")
+	}
+	if args[0] != "--tools" {
+		t.Errorf("expected first arg '--tools', got %q", args[0])
+	}
+
+	env := p.Env()
+	if env == nil {
+		t.Fatal("expected non-nil Env")
+	}
+	if env["AILERON_REAL_SHELL"] != "/bin/bash" {
+		t.Errorf("expected AILERON_REAL_SHELL=/bin/bash, got %q", env["AILERON_REAL_SHELL"])
+	}
+}
+
+func TestPi_NormalizeCommand_Passthrough(t *testing.T) {
+	p := agents.Pi{}
+
+	cmd, eval := p.NormalizeCommand("echo hello")
+	if !eval {
+		t.Fatal("expected evaluate=true")
+	}
+	if cmd != "echo hello" {
+		t.Errorf("expected 'echo hello', got %q", cmd)
+	}
+}
+
+func TestPi_NormalizeCommand_ComplexCommand(t *testing.T) {
+	p := agents.Pi{}
+
+	complex := "git push origin main && echo done"
+	cmd, eval := p.NormalizeCommand(complex)
+	if !eval {
+		t.Fatal("expected evaluate=true")
+	}
+	if cmd != complex {
+		t.Errorf("expected command unchanged, got %q", cmd)
+	}
+}
+
+func TestPi_ConfigureShell_WritesSettings(t *testing.T) {
+	p := agents.Pi{}
+	dir := t.TempDir()
+	shimPath := "/usr/local/bin/aileron-sh"
+
+	if err := p.ConfigureShell(shimPath, dir); err != nil {
+		t.Fatalf("ConfigureShell failed: %v", err)
+	}
+
+	settingsPath := filepath.Join(dir, ".pi", "settings.json")
+	data, err := os.ReadFile(settingsPath)
+	if err != nil {
+		t.Fatalf("expected settings file at %s: %v", settingsPath, err)
+	}
+
+	var settings map[string]any
+	if err := json.Unmarshal(data, &settings); err != nil {
+		t.Fatalf("invalid JSON: %v", err)
+	}
+
+	if settings["shellPath"] != shimPath {
+		t.Errorf("expected shellPath %q, got %v", shimPath, settings["shellPath"])
+	}
+}
+
+func TestPi_ConfigureShell_PreservesExistingSettings(t *testing.T) {
+	p := agents.Pi{}
+	dir := t.TempDir()
+	piDir := filepath.Join(dir, ".pi")
+	os.MkdirAll(piDir, 0o755)
+
+	// Write existing settings with other fields.
+	existing := map[string]any{"thinking": "high", "theme": "dark"}
+	data, _ := json.Marshal(existing)
+	os.WriteFile(filepath.Join(piDir, "settings.json"), data, 0o644)
+
+	shimPath := "/usr/local/bin/aileron-sh"
+	if err := p.ConfigureShell(shimPath, dir); err != nil {
+		t.Fatalf("ConfigureShell failed: %v", err)
+	}
+
+	result, _ := os.ReadFile(filepath.Join(piDir, "settings.json"))
+	var settings map[string]any
+	json.Unmarshal(result, &settings)
+
+	if settings["shellPath"] != shimPath {
+		t.Errorf("expected shellPath %q, got %v", shimPath, settings["shellPath"])
+	}
+	if settings["thinking"] != "high" {
+		t.Errorf("expected existing 'thinking' preserved, got %v", settings["thinking"])
+	}
+	if settings["theme"] != "dark" {
+		t.Errorf("expected existing 'theme' preserved, got %v", settings["theme"])
+	}
+}

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -85,6 +85,13 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		return LaunchResult{}, fmt.Errorf("installing shell wrapper: %w", err)
 	}
 
+	// Let the agent perform any agent-specific shell configuration.
+	// For example, Pi writes .pi/settings.json with shellPath pointing
+	// at aileron-sh because it doesn't respect $SHELL.
+	if err := config.Agent.ConfigureShell(config.ShellShim, config.Dir); err != nil {
+		return LaunchResult{}, fmt.Errorf("configuring shell for %s: %w", config.Agent.Name(), err)
+	}
+
 	sessionID := generateSessionID()
 	auditLog := resolveAuditLog(config.Dir)
 	envConfig := loadEnvConfig(config.Dir)

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -78,16 +78,8 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		return LaunchResult{}, fmt.Errorf("agent %q: %w", config.Agent.Name(), err)
 	}
 
-	// Install a wrapper script at ~/.aileron/bash whose path contains "bash"
-	// so that Claude Code accepts it as a valid shell.
-	wrapperPath, err := InstallWrapper(config.ShellShim)
-	if err != nil {
-		return LaunchResult{}, fmt.Errorf("installing shell wrapper: %w", err)
-	}
-
 	// Let the agent perform any agent-specific shell configuration.
-	// For example, Pi writes .pi/settings.json with shellPath pointing
-	// at aileron-sh because it doesn't respect $SHELL.
+	// Claude installs a wrapper script; Pi writes .pi/settings.json.
 	if err := config.Agent.ConfigureShell(config.ShellShim, config.Dir); err != nil {
 		return LaunchResult{}, fmt.Errorf("configuring shell for %s: %w", config.Agent.Name(), err)
 	}
@@ -98,7 +90,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	approvalSocket := filepath.Join(os.TempDir(), "ai-"+sessionID+".sock")
 	commsSocket := filepath.Join(os.TempDir(), "ai-comms-"+sessionID+".sock")
 
-	env := buildEnv(config.ShellShim, wrapperPath, config.Agent.Name(), sessionID, auditLog, envConfig, config.Agent.Env())
+	env := buildEnv(config.ShellShim, config.Agent.Name(), sessionID, auditLog, envConfig, config.Agent.Env())
 	env = append(env, "AILERON_APPROVAL_SOCKET="+approvalSocket)
 	env = append(env, "AILERON_COMMS_SOCKET="+commsSocket)
 
@@ -327,10 +319,9 @@ func exitResult(err error) (LaunchResult, error) {
 // buildEnv creates the environment for the child process:
 //   - Copies the current environment
 //   - Replaces SHELL with the shim path
-//   - Sets CLAUDE_CODE_SHELL to the wrapper path (whose name contains "bash")
 //   - Sets AILERON_REAL_SHELL to the original SHELL value
-//   - Merges any agent-specific env vars
-func buildEnv(shimPath, wrapperPath, agentName, sessionID, auditLog string, envConfig *launchpolicy.EnvConfig, agentEnv map[string]string) []string {
+//   - Merges any agent-specific env vars (including agent-specific vars like CLAUDE_CODE_SHELL)
+func buildEnv(shimPath, agentName, sessionID, auditLog string, envConfig *launchpolicy.EnvConfig, agentEnv map[string]string) []string {
 	origShell := os.Getenv("SHELL")
 	if origShell == "" {
 		origShell = "/bin/sh"
@@ -351,7 +342,6 @@ func buildEnv(shimPath, wrapperPath, agentName, sessionID, auditLog string, envC
 		"AILERON_AGENT":      true,
 		"AILERON_SESSION_ID": true,
 		"AILERON_AUDIT_LOG":  true,
-		"CLAUDE_CODE_SHELL":  true,
 	}
 	for k := range agentEnv {
 		managed[k] = true
@@ -382,10 +372,6 @@ func buildEnv(shimPath, wrapperPath, agentName, sessionID, auditLog string, envC
 	if auditLog != "" {
 		filtered = append(filtered, "AILERON_AUDIT_LOG="+auditLog)
 	}
-	if wrapperPath != "" {
-		filtered = append(filtered, "CLAUDE_CODE_SHELL="+wrapperPath)
-	}
-
 	for k, v := range agentEnv {
 		if k == "AILERON_REAL_SHELL" {
 			continue // already handled above

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -121,20 +121,13 @@ func TestLaunch_EnvironmentSetup(t *testing.T) {
 	if !strings.Contains(envStr, "AILERON_REAL_SHELL=") {
 		t.Error("AILERON_REAL_SHELL not set in child env")
 	}
-	if !strings.Contains(envStr, "CLAUDE_CODE_SHELL=") {
-		t.Error("CLAUDE_CODE_SHELL not set in child env")
-	}
 	if !strings.Contains(envStr, "AILERON_AGENT=test-script") {
 		t.Error("AILERON_AGENT not set in child env")
 	}
-	// CLAUDE_CODE_SHELL path must contain "bash" for Claude Code to accept it
-	for _, line := range strings.Split(envStr, "\n") {
-		if strings.HasPrefix(line, "CLAUDE_CODE_SHELL=") {
-			val := strings.TrimPrefix(line, "CLAUDE_CODE_SHELL=")
-			if !strings.Contains(val, "bash") {
-				t.Errorf("CLAUDE_CODE_SHELL path must contain 'bash', got %q", val)
-			}
-		}
+	// CLAUDE_CODE_SHELL should NOT be set for non-Claude agents.
+	// Only Claude sets it via its Env() method.
+	if strings.Contains(envStr, "CLAUDE_CODE_SHELL=") {
+		t.Error("CLAUDE_CODE_SHELL should not be set for non-Claude agents")
 	}
 }
 
@@ -263,11 +256,10 @@ func TestLaunch_WorkingDirectory(t *testing.T) {
 	}
 }
 
-func TestLaunch_EmptyWrapperPathSkipsCLAUDE_CODE_SHELL(t *testing.T) {
-	// When wrapperPath is empty, CLAUDE_CODE_SHELL should not be set.
-	// We can't easily test this through Launch (it always installs wrapper),
-	// so this is a note that the branch is covered by the empty-path guard.
-	// The buildEnv function is unexported, so we verify indirectly.
+func TestLaunch_AgentEnvVarsFlowThrough(t *testing.T) {
+	// Agent-specific env vars (from Env()) should appear in the child
+	// process environment. This covers vars like CLAUDE_CODE_SHELL
+	// which are now set by the agent, not the launcher.
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 	outFile := filepath.Join(dir, "env.txt")
@@ -277,7 +269,10 @@ func TestLaunch_EmptyWrapperPathSkipsCLAUDE_CODE_SHELL(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	agent := scriptAgent{script: script}
+	agent := scriptAgent{
+		script:   script,
+		extraEnv: map[string]string{"MY_AGENT_VAR": "test-value"},
+	}
 	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
 		Agent:     agent,
 		ShellShim: "/tmp/fake-shim",
@@ -290,11 +285,9 @@ func TestLaunch_EmptyWrapperPathSkipsCLAUDE_CODE_SHELL(t *testing.T) {
 	if err != nil {
 		t.Fatal(err)
 	}
-	// CLAUDE_CODE_SHELL should be set (wrapper IS installed by Launch)
-	if !strings.Contains(string(data), "CLAUDE_CODE_SHELL=") {
-		t.Error("expected CLAUDE_CODE_SHELL to be set when wrapper is installed")
+	if !strings.Contains(string(data), "MY_AGENT_VAR=test-value") {
+		t.Error("expected agent-specific env var to flow through to child process")
 	}
-	// AILERON_AGENT should be set
 	if !strings.Contains(string(data), "AILERON_AGENT=") {
 		t.Error("expected AILERON_AGENT to be set")
 	}

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -1222,7 +1222,9 @@ type scriptAgent struct {
 	extraEnv map[string]string
 }
 
-func (a scriptAgent) Name() string           { return "test-script" }
-func (a scriptAgent) BinaryNames() []string  { return []string{a.script} }
-func (a scriptAgent) Args() []string         { return nil }
-func (a scriptAgent) Env() map[string]string { return a.extraEnv }
+func (a scriptAgent) Name() string                              { return "test-script" }
+func (a scriptAgent) BinaryNames() []string                     { return []string{a.script} }
+func (a scriptAgent) Args() []string                            { return nil }
+func (a scriptAgent) Env() map[string]string                    { return a.extraEnv }
+func (a scriptAgent) NormalizeCommand(raw string) (string, bool) { return raw, true }
+func (a scriptAgent) ConfigureShell(_, _ string) error           { return nil }

--- a/docs/adr/0017-pluggable-agent-spi.md
+++ b/docs/adr/0017-pluggable-agent-spi.md
@@ -1,0 +1,58 @@
+# ADR-0017: Pluggable Agent SPI
+
+**Status:** Accepted
+**Date:** 2026-04-11
+
+## Context
+
+ADR-0013 positioned Aileron as a local policy-enforced shell that intercepts agent commands via `SHELL=aileron-sh`. The initial implementation hardcoded agent-specific behavior:
+
+1. **Command normalization** lived in `aileron-sh` as a `switch` statement. Claude Code wraps commands in `eval '...'`; other agents don't. Adding a new agent required editing the shim binary.
+
+2. **Shell configuration** was Claude-specific. The launcher unconditionally installed a wrapper script at `~/.aileron/bash` and set `CLAUDE_CODE_SHELL` — an env var only Claude Code reads. Other agents that ignore `$SHELL` (e.g. Pi, which hardcodes `/bin/bash` and reads its shell from a settings file) had no hook to configure their shell resolution.
+
+3. **The `Agent` interface** had four methods (`Name`, `BinaryNames`, `Args`, `Env`) — enough to launch an agent but not enough to handle the behavioral differences between agents.
+
+The community requested Pi.dev support ([#98](https://github.com/ALRubinger/aileron/issues/98)), which exposed all three gaps: Pi wraps commands differently (not at all), resolves its shell differently (settings file, not `$SHELL`), and needs agent-specific pre-launch setup.
+
+## Decision
+
+Extend the `Agent` interface into a Service Provider Interface (SPI) with three additional methods:
+
+### 1. `NormalizeCommand(raw string) (command string, evaluate bool)`
+
+Each agent owns its command-unwrapping logic. The shim (`aileron-sh`) calls `agents.NormalizeCommand(agentName, raw)` which delegates to the registered agent's implementation. No switch statements.
+
+- **Claude:** Unwraps `eval '...'` from the `shopt ... && eval 'cmd' < /dev/null && pwd ...` template. Returns `(cmd, true)` for user commands, `(raw, false)` for infrastructure commands (snapshots, etc.).
+- **Pi:** Passthrough — `(raw, true)`. Pi doesn't wrap commands.
+- **Unknown agents:** Passthrough — `(raw, true)`. Safe default.
+
+### 2. `ConfigureShell(shimPath, dir string) error`
+
+Agents that need pre-launch setup to use `aileron-sh` implement this. Called by the launcher before spawning the agent process.
+
+- **Claude:** Installs a wrapper script at `~/.aileron/bash` (path must contain "bash" for Claude Code's shell validation). Sets `CLAUDE_CODE_SHELL` via `Env()`.
+- **Pi:** Writes `.pi/settings.json` with `"shellPath": "/path/to/aileron-sh"`. Pi ignores `$SHELL` and reads its shell from this file.
+- **Agents that respect `$SHELL`:** Return `nil` (no-op).
+
+### 3. Normalizer registry (bridge pattern)
+
+`aileron-sh` is a separate binary that cannot hold Go references to `Agent` structs. It only knows the agent name from the `AILERON_AGENT` env var. The `agents.NormalizeCommand(name, raw)` function bridges this gap with a package-level registry mapping agent names to their normalizer implementations.
+
+## Consequences
+
+### Adding a new agent
+
+One file (`core/launch/agents/<name>.go`) implementing the seven-method `Agent` interface, plus one `Register()` call in `cmd/aileron/main.go` and one entry in the normalizer registry. No edits to `aileron-sh`, the launcher, or any existing agent.
+
+### Agent-specific behavior is self-contained
+
+Claude's eval unwrapping, wrapper installation, and `CLAUDE_CODE_SHELL` env var are all defined in `claude.go`. Pi's settings.json writing is in `pi.go`. The launcher and shim are agent-agnostic.
+
+### The normalizer registry is a pragmatic compromise
+
+A pure SPI would have zero static registrations. The normalizer registry (`agents/normalize.go`) exists because `aileron-sh` is a compiled binary that resolves agents by string name at runtime. The registry is the thinnest possible bridge — a map of name to interface. If Aileron later supports plugin-based agents (shared libraries, external binaries), this registry becomes the integration point.
+
+### `$SHELL` is not universal
+
+The assumption in ADR-0013 that "any agent that respects `$SHELL`" would work was optimistic. Pi hardcodes `/bin/bash`. Other agents may resolve their shell from config files, env vars, or CLI flags. `ConfigureShell` absorbs this variance without complicating the launcher.


### PR DESCRIPTION
## Summary

- Extends the `Agent` interface into a proper SPI with `NormalizeCommand`, `ConfigureShell`, and a shared normalizer registry — new agents are added in a single file with no edits to existing code
- Adds first community-requested agent: **pi.dev** (`aileron launch pi`) — policy evaluation, audit trail, and approval prompts work end-to-end
- Ports all Claude-specific behavior (eval unwrapping, wrapper installation, `CLAUDE_CODE_SHELL`) out of the launcher and shim into `claude.go` — the launcher is now fully agent-agnostic
- Documents the design in ADR-0017

## Motivation

Pi.dev ignores `$SHELL` and hardcodes `/bin/bash`, so the existing `SHELL=aileron-sh` env var approach doesn't work. The new `ConfigureShell` SPI method lets each agent handle its own shell configuration — Pi writes `.pi/settings.json`, Claude installs its bash wrapper script. The launcher doesn't need to know the details.

Addresses #98 (feature request from @maxandersen)

## What changed

| File | Change |
|------|--------|
| `core/launch/agent.go` | Added `NormalizeCommand` and `ConfigureShell` to Agent interface |
| `core/launch/agents/claude.go` | Moved eval-unwrap + wrapper install + CLAUDE_CODE_SHELL here |
| `core/launch/agents/pi.go` | New agent: passthrough normalizer, writes .pi/settings.json |
| `core/launch/agents/normalize.go` | Shared normalizer registry keyed by agent name |
| `cmd/aileron-sh/main.go` | Replaced 66-line switch+unwrap with `agents.NormalizeCommand()` call |
| `cmd/aileron/main.go` | Register Pi agent |
| `core/launch/launcher.go` | Removed Claude-specific wrapper/env code, calls `ConfigureShell` |
| `README.md` | Added pi.dev to supported agents, updated examples |
| `docs/adr/0017-pluggable-agent-spi.md` | Architecture decision record for the SPI design |

## Test plan

- [x] All existing tests pass (launch, agents, aileron-sh, CLI)
- [x] Claude: NormalizeCommand (eval wrapper, unquoted eval, unquoted no separator, infrastructure, escaped quotes)
- [x] Claude: ConfigureShell installs wrapper, Env includes CLAUDE_CODE_SHELL
- [x] Pi: NormalizeCommand passthrough, ConfigureShell writes/preserves settings, empty dir fallback, unwritable dir error
- [x] Normalizer registry: claude, pi, unknown agent fallback
- [x] Launcher: agent env vars flow through, non-Claude agents don't get CLAUDE_CODE_SHELL
- [x] Coverage: 95.1% agents, 91.1% launch, 84.5% CLI
- [x] Manual: `aileron launch pi` with policy — verify commands flow through aileron-sh

🤖 Generated with [Claude Code](https://claude.com/claude-code)