### PR TITLE
feat(launch): unified session logging with --log-level flag

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -38,12 +38,21 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		fmt.Fprintf(stdout, "aileron %s (%s)\n", version.Version, version.Commit)
 		return 0
 	case "launch":
-		if len(args) < 2 {
-			fmt.Fprintln(stderr, "usage: aileron launch <agent> [args...]")
+		// Parse aileron-level flags before the agent name.
+		launchFlags := flag.NewFlagSet("launch", flag.ContinueOnError)
+		launchFlags.SetOutput(stderr)
+		verbose := launchFlags.Bool("verbose", false, "Enable verbose logging for comms listeners")
+		if err := launchFlags.Parse(args[1:]); err != nil {
+			return 1
+		}
+		launchArgs := launchFlags.Args()
+
+		if len(launchArgs) < 1 {
+			fmt.Fprintln(stderr, "usage: aileron launch [--verbose] <agent> [args...]")
 			fmt.Fprintf(stderr, "agents: %s\n", strings.Join(registry.Names(), ", "))
 			return 1
 		}
-		agentName := args[1]
+		agentName := launchArgs[0]
 		agent, ok := registry.Get(agentName)
 		if !ok {
 			fmt.Fprintf(stderr, "unknown agent: %q\n", agentName)
@@ -60,7 +69,8 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		result, err := launch.Launch(context.Background(), launch.LaunchConfig{
 			Agent:     agent,
 			ShellShim: shimPath,
-			Args:      args[2:],
+			Args:      launchArgs[1:],
+			Verbose:   *verbose,
 		})
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %v\n", err)
@@ -101,7 +111,7 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "usage:")
 	fmt.Fprintln(w, "  aileron init                       Scaffold aileron.yaml for this project")
-	fmt.Fprintln(w, "  aileron launch <agent> [args...]   Launch an agent with policy-enforced shell")
+	fmt.Fprintln(w, "  aileron launch [--verbose] <agent>  Launch an agent with policy-enforced shell")
 	fmt.Fprintln(w, "  aileron policy test <cmd> [cmd..]  Dry-run commands against loaded policy")
 	fmt.Fprintln(w, "  aileron policy save [flags]        Save user-approved commands as policy rules")
 	fmt.Fprintln(w, "  aileron secret set <name>          Store a secret in the encrypted vault")

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -41,14 +41,14 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		// Parse aileron-level flags before the agent name.
 		launchFlags := flag.NewFlagSet("launch", flag.ContinueOnError)
 		launchFlags.SetOutput(stderr)
-		verbose := launchFlags.Bool("verbose", false, "Enable verbose logging for comms listeners")
+		logLevel := launchFlags.String("log-level", "warn", "Log level: trace, debug, info, warn, error")
 		if err := launchFlags.Parse(args[1:]); err != nil {
 			return 1
 		}
 		launchArgs := launchFlags.Args()
 
 		if len(launchArgs) < 1 {
-			fmt.Fprintln(stderr, "usage: aileron launch [--verbose] <agent> [args...]")
+			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] <agent> [args...]")
 			fmt.Fprintf(stderr, "agents: %s\n", strings.Join(registry.Names(), ", "))
 			return 1
 		}
@@ -70,7 +70,7 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 			Agent:     agent,
 			ShellShim: shimPath,
 			Args:      launchArgs[1:],
-			Verbose:   *verbose,
+			LogLevel:  launch.ParseLogLevel(*logLevel),
 		})
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %v\n", err)

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -104,6 +104,30 @@ func TestRun_LaunchUnknownAgent(t *testing.T) {
 	}
 }
 
+func TestRun_LaunchLogLevelFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	// --log-level is parsed before the agent name; exercises the flag path.
+	code := run([]string{"launch", "--log-level=debug", "claude"}, newTestRegistry(), &stdout, &stderr)
+	// Will fail at shim resolution, but the flag parsing should succeed.
+	if code != 1 {
+		t.Errorf("expected exit code 1 (shim not found), got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "error:") {
+		t.Errorf("expected shim error, got %q", stderr.String())
+	}
+}
+
+func TestRun_LaunchLogLevelNoAgent(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"launch", "--log-level=debug"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "usage: aileron launch") {
+		t.Error("expected launch usage in stderr")
+	}
+}
+
 func TestRunInit_CreatesFile(t *testing.T) {
 	dir := t.TempDir()
 

--- a/core/comms/discord.go
+++ b/core/comms/discord.go
@@ -27,7 +27,7 @@ type DiscordListener struct {
 
 // NewDiscordListener creates a Discord listener with the given bot token
 // and channel configuration.
-func NewDiscordListener(botToken string, channels, ignore []string) *DiscordListener {
+func NewDiscordListener(botToken string, channels, ignore []string, log *slog.Logger) *DiscordListener {
 	chMap := make(map[string]bool, len(channels))
 	for _, ch := range channels {
 		chMap[ch] = true
@@ -40,19 +40,11 @@ func NewDiscordListener(botToken string, channels, ignore []string) *DiscordList
 		botToken: botToken,
 		channels: chMap,
 		ignore:   igMap,
+		log:      log,
 	}
 }
 
 func (d *DiscordListener) Service() string { return "discord" }
-
-// SetLogger sets an optional logger for verbose diagnostics.
-func (d *DiscordListener) SetLogger(l *slog.Logger) { d.log = l }
-
-func (d *DiscordListener) debug(msg string, args ...any) {
-	if d.log != nil {
-		d.log.Debug(msg, args...)
-	}
-}
 
 // SetOpenGateway overrides the function used to open the Discord Gateway
 // connection. Call after Connect. Used in tests to skip the real WebSocket.
@@ -90,7 +82,7 @@ func (d *DiscordListener) Connect(ctx context.Context) error {
 	session.Identify.Intents = discordgo.IntentsGuildMessages | discordgo.IntentsMessageContent
 	d.session = session
 	d.openGateway = session.Open
-	d.debug("discord: connected", "channels", len(d.channels))
+	d.log.Debug("discord: connected", "channels", len(d.channels))
 	return nil
 }
 
@@ -113,7 +105,7 @@ func (d *DiscordListener) Listen(ctx context.Context) (<-chan IncomingMessage, e
 		return nil, fmt.Errorf("discord: failed to open gateway: %w", err)
 	}
 
-	d.debug("discord: listening via Gateway WebSocket")
+	d.log.Debug("discord: listening via Gateway WebSocket")
 
 	// Close the message channel when the context is cancelled.
 	go func() {
@@ -130,24 +122,24 @@ func (d *DiscordListener) Listen(ctx context.Context) (<-chan IncomingMessage, e
 func (d *DiscordListener) processMessage(m *discordgo.MessageCreate) (IncomingMessage, bool) {
 	// Skip bot messages (including our own).
 	if m.Author == nil || m.Author.Bot {
-		d.debug("discord: skipping bot message", "channel", m.ChannelID)
+		d.log.Debug("discord: skipping bot message", "channel", m.ChannelID)
 		return IncomingMessage{}, false
 	}
 
 	channelID := m.ChannelID
 	if d.ignore[channelID] {
-		d.debug("discord: skipping ignored channel", "channel", channelID)
+		d.log.Debug("discord: skipping ignored channel", "channel", channelID)
 		return IncomingMessage{}, false
 	}
 	if len(d.channels) > 0 && !d.channels[channelID] {
-		d.debug("discord: skipping unconfigured channel", "channel", channelID)
+		d.log.Debug("discord: skipping unconfigured channel", "channel", channelID)
 		return IncomingMessage{}, false
 	}
 
 	channelName := d.resolveChannelName(channelID)
 	author := d.resolveAuthor(m)
 
-	d.debug("discord: delivering message", "channel", channelName, "author", author)
+	d.log.Debug("discord: delivering message", "channel", channelName, "author", author)
 	return IncomingMessage{
 		ID:        m.ID,
 		Service:   "discord",
@@ -167,7 +159,7 @@ func (d *DiscordListener) resolveChannelName(id string) string {
 	if d.session != nil {
 		ch, err := d.session.Channel(id)
 		if err != nil {
-			d.debug("discord: failed to resolve channel name", "channel_id", id, "error", err)
+			d.log.Debug("discord: failed to resolve channel name", "channel_id", id, "error", err)
 		} else if ch.Name != "" {
 			return "#" + ch.Name
 		}

--- a/core/comms/discord.go
+++ b/core/comms/discord.go
@@ -3,6 +3,7 @@ package comms
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"time"
 
 	"github.com/bwmarrin/discordgo"
@@ -14,6 +15,7 @@ type DiscordListener struct {
 	botToken string
 	channels map[string]bool // channel IDs to listen on
 	ignore   map[string]bool // channel IDs to ignore
+	log      *slog.Logger
 
 	// openGateway opens the Discord WebSocket connection. Defaults to
 	// session.Open but can be overridden for testing.
@@ -42,6 +44,15 @@ func NewDiscordListener(botToken string, channels, ignore []string) *DiscordList
 }
 
 func (d *DiscordListener) Service() string { return "discord" }
+
+// SetLogger sets an optional logger for verbose diagnostics.
+func (d *DiscordListener) SetLogger(l *slog.Logger) { d.log = l }
+
+func (d *DiscordListener) debug(msg string, args ...any) {
+	if d.log != nil {
+		d.log.Debug(msg, args...)
+	}
+}
 
 // SetOpenGateway overrides the function used to open the Discord Gateway
 // connection. Call after Connect. Used in tests to skip the real WebSocket.
@@ -79,6 +90,7 @@ func (d *DiscordListener) Connect(ctx context.Context) error {
 	session.Identify.Intents = discordgo.IntentsGuildMessages | discordgo.IntentsMessageContent
 	d.session = session
 	d.openGateway = session.Open
+	d.debug("discord: connected", "channels", len(d.channels))
 	return nil
 }
 
@@ -101,6 +113,8 @@ func (d *DiscordListener) Listen(ctx context.Context) (<-chan IncomingMessage, e
 		return nil, fmt.Errorf("discord: failed to open gateway: %w", err)
 	}
 
+	d.debug("discord: listening via Gateway WebSocket")
+
 	// Close the message channel when the context is cancelled.
 	go func() {
 		<-ctx.Done()
@@ -116,20 +130,24 @@ func (d *DiscordListener) Listen(ctx context.Context) (<-chan IncomingMessage, e
 func (d *DiscordListener) processMessage(m *discordgo.MessageCreate) (IncomingMessage, bool) {
 	// Skip bot messages (including our own).
 	if m.Author == nil || m.Author.Bot {
+		d.debug("discord: skipping bot message", "channel", m.ChannelID)
 		return IncomingMessage{}, false
 	}
 
 	channelID := m.ChannelID
 	if d.ignore[channelID] {
+		d.debug("discord: skipping ignored channel", "channel", channelID)
 		return IncomingMessage{}, false
 	}
 	if len(d.channels) > 0 && !d.channels[channelID] {
+		d.debug("discord: skipping unconfigured channel", "channel", channelID)
 		return IncomingMessage{}, false
 	}
 
 	channelName := d.resolveChannelName(channelID)
 	author := d.resolveAuthor(m)
 
+	d.debug("discord: delivering message", "channel", channelName, "author", author)
 	return IncomingMessage{
 		ID:        m.ID,
 		Service:   "discord",
@@ -147,7 +165,10 @@ func (d *DiscordListener) ProcessMessageCreate(m *discordgo.MessageCreate) (Inco
 
 func (d *DiscordListener) resolveChannelName(id string) string {
 	if d.session != nil {
-		if ch, err := d.session.Channel(id); err == nil && ch.Name != "" {
+		ch, err := d.session.Channel(id)
+		if err != nil {
+			d.debug("discord: failed to resolve channel name", "channel_id", id, "error", err)
+		} else if ch.Name != "" {
 			return "#" + ch.Name
 		}
 	}

--- a/core/comms/discord_integration_test.go
+++ b/core/comms/discord_integration_test.go
@@ -57,7 +57,7 @@ func newMockDiscordServer() *httptest.Server {
 // endpoints to point at the mock server.
 func connectWithMockAPI(t *testing.T, srv *httptest.Server, channels, ignore []string) *comms.DiscordListener {
 	t.Helper()
-	dl := comms.NewDiscordListener("bot-token-test", channels, ignore)
+	dl := comms.NewDiscordListener("bot-token-test", channels, ignore, nopLogger())
 	if err := dl.Connect(context.Background()); err != nil {
 		t.Fatal(err)
 	}

--- a/core/comms/discord_test.go
+++ b/core/comms/discord_test.go
@@ -15,6 +15,7 @@ func TestNewDiscordListener(t *testing.T) {
 		"bot-token-test",
 		[]string{"123456", "789012"},
 		[]string{"999999"},
+		nopLogger(),
 	)
 	if dl.Service() != "discord" {
 		t.Errorf("Service() = %q, want 'discord'", dl.Service())
@@ -22,7 +23,7 @@ func TestNewDiscordListener(t *testing.T) {
 }
 
 func TestDiscordListener_ConnectMissingToken(t *testing.T) {
-	dl := comms.NewDiscordListener("", nil, nil)
+	dl := comms.NewDiscordListener("", nil, nil, nopLogger())
 	err := dl.Connect(context.Background())
 	if err == nil {
 		t.Fatal("expected error for missing token")
@@ -30,7 +31,7 @@ func TestDiscordListener_ConnectMissingToken(t *testing.T) {
 }
 
 func TestDiscordListener_ConnectValidToken(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 	err := dl.Connect(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -38,7 +39,7 @@ func TestDiscordListener_ConnectValidToken(t *testing.T) {
 }
 
 func TestDiscordListener_ListenWithoutConnect(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 	_, err := dl.Listen(context.Background())
 	if err == nil {
 		t.Fatal("expected error when listening without connect")
@@ -46,7 +47,7 @@ func TestDiscordListener_ListenWithoutConnect(t *testing.T) {
 }
 
 func TestDiscordListener_SendWithoutConnect(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 	err := dl.Send(context.Background(), comms.OutgoingMessage{
 		Channel: "123456",
 		Body:    "hello",
@@ -57,7 +58,7 @@ func TestDiscordListener_SendWithoutConnect(t *testing.T) {
 }
 
 func TestDiscordListener_Close(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 	// Close without connect should not panic.
 	if err := dl.Close(); err != nil {
 		t.Fatalf("Close failed: %v", err)
@@ -66,7 +67,7 @@ func TestDiscordListener_Close(t *testing.T) {
 
 func TestDiscordListener_ProcessMessageCreate(t *testing.T) {
 	dl := comms.NewDiscordListener("bot-token-test",
-		[]string{"C123"}, []string{"C999"})
+		[]string{"C123"}, []string{"C999"}, nopLogger())
 
 	msg, ok := dl.ProcessMessageCreate(&discordgo.MessageCreate{
 		Message: &discordgo.Message{
@@ -99,7 +100,7 @@ func TestDiscordListener_ProcessMessageCreate(t *testing.T) {
 }
 
 func TestDiscordListener_ProcessMessageCreate_BotSkipped(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 
 	_, ok := dl.ProcessMessageCreate(&discordgo.MessageCreate{
 		Message: &discordgo.Message{
@@ -117,7 +118,7 @@ func TestDiscordListener_ProcessMessageCreate_BotSkipped(t *testing.T) {
 }
 
 func TestDiscordListener_ProcessMessageCreate_NilAuthor(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 
 	_, ok := dl.ProcessMessageCreate(&discordgo.MessageCreate{
 		Message: &discordgo.Message{
@@ -132,7 +133,7 @@ func TestDiscordListener_ProcessMessageCreate_NilAuthor(t *testing.T) {
 }
 
 func TestDiscordListener_ProcessMessageCreate_IgnoredChannel(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, []string{"C999"})
+	dl := comms.NewDiscordListener("bot-token-test", nil, []string{"C999"}, nopLogger())
 
 	_, ok := dl.ProcessMessageCreate(&discordgo.MessageCreate{
 		Message: &discordgo.Message{
@@ -148,7 +149,7 @@ func TestDiscordListener_ProcessMessageCreate_IgnoredChannel(t *testing.T) {
 
 func TestDiscordListener_ProcessMessageCreate_UnlistedChannel(t *testing.T) {
 	dl := comms.NewDiscordListener("bot-token-test",
-		[]string{"C123"}, nil) // only listen on C123
+		[]string{"C123"}, nil, nopLogger()) // only listen on C123
 
 	_, ok := dl.ProcessMessageCreate(&discordgo.MessageCreate{
 		Message: &discordgo.Message{
@@ -163,7 +164,7 @@ func TestDiscordListener_ProcessMessageCreate_UnlistedChannel(t *testing.T) {
 }
 
 func TestDiscordListener_ProcessMessageCreate_NoChannelFilter(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 
 	_, ok := dl.ProcessMessageCreate(&discordgo.MessageCreate{
 		Message: &discordgo.Message{
@@ -178,7 +179,7 @@ func TestDiscordListener_ProcessMessageCreate_NoChannelFilter(t *testing.T) {
 }
 
 func TestDiscordListener_ProcessMessageCreate_NicknamePriority(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 
 	msg, ok := dl.ProcessMessageCreate(&discordgo.MessageCreate{
 		Message: &discordgo.Message{
@@ -203,7 +204,7 @@ func TestDiscordListener_ProcessMessageCreate_NicknamePriority(t *testing.T) {
 }
 
 func TestDiscordListener_ProcessMessageCreate_FallbackToUsername(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 
 	msg, ok := dl.ProcessMessageCreate(&discordgo.MessageCreate{
 		Message: &discordgo.Message{
@@ -224,7 +225,7 @@ func TestDiscordListener_ProcessMessageCreate_FallbackToUsername(t *testing.T) {
 }
 
 func TestDiscordListener_ListenSuccess(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 	if err := dl.Connect(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -250,7 +251,7 @@ func TestDiscordListener_ListenSuccess(t *testing.T) {
 }
 
 func TestDiscordListener_ListenOpenFails(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 	if err := dl.Connect(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -262,20 +263,20 @@ func TestDiscordListener_ListenOpenFails(t *testing.T) {
 }
 
 func TestDiscordListener_ServiceName(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 	if got := dl.Service(); got != "discord" {
 		t.Errorf("Service() = %q, want 'discord'", got)
 	}
 }
 
 func TestDiscordListener_SetEndpointURL_NilSession(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 	// Should not panic when session is nil.
 	dl.SetEndpointURL("http://localhost:1234/")
 }
 
 func TestDiscordListener_CloseAfterConnect(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 	if err := dl.Connect(context.Background()); err != nil {
 		t.Fatal(err)
 	}
@@ -286,7 +287,7 @@ func TestDiscordListener_CloseAfterConnect(t *testing.T) {
 }
 
 func TestDiscordListener_ProcessMessageCreate_NilAuthorEmptyResult(t *testing.T) {
-	dl := comms.NewDiscordListener("bot-token-test", nil, nil)
+	dl := comms.NewDiscordListener("bot-token-test", nil, nil, nopLogger())
 
 	// Message with a non-bot author but nil Member — exercises the
 	// resolveAuthor path where Author is non-nil but Member is nil
@@ -310,12 +311,12 @@ func TestDiscordListener_ProcessMessageCreate_NilAuthorEmptyResult(t *testing.T)
 	}
 }
 
-func TestDiscordListener_VerboseLogging(t *testing.T) {
+func TestDiscordListener_DebugLogging(t *testing.T) {
 	dl := comms.NewDiscordListener("bot-token-test",
-		[]string{"C123"}, []string{"C999"})
-	dl.SetLogger(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	})))
+		[]string{"C123"}, []string{"C999"},
+		slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+			Level: slog.LevelDebug,
+		})))
 
 	// Connect — exercises the "connected" log line.
 	if err := dl.Connect(context.Background()); err != nil {

--- a/core/comms/discord_test.go
+++ b/core/comms/discord_test.go
@@ -2,6 +2,8 @@ package comms_test
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"testing"
 
 	"github.com/ALRubinger/aileron/core/comms"
@@ -305,6 +307,54 @@ func TestDiscordListener_ProcessMessageCreate_NilAuthorEmptyResult(t *testing.T)
 	// With empty Username and GlobalName and nil Member, author should be "".
 	if msg.Author != "" {
 		t.Errorf("Author = %q, want empty string", msg.Author)
+	}
+}
+
+func TestDiscordListener_VerboseLogging(t *testing.T) {
+	dl := comms.NewDiscordListener("bot-token-test",
+		[]string{"C123"}, []string{"C999"})
+	dl.SetLogger(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+
+	// Connect — exercises the "connected" log line.
+	if err := dl.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	// Bot message.
+	dl.ProcessMessageCreate(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ChannelID: "C123", Content: "bot",
+			Author: &discordgo.User{ID: "U1", Bot: true},
+		},
+	})
+	// Ignored channel.
+	dl.ProcessMessageCreate(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ChannelID: "C999", Content: "ignored",
+			Author: &discordgo.User{ID: "U1", Username: "u"},
+		},
+	})
+	// Unconfigured channel.
+	dl.ProcessMessageCreate(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ChannelID: "C_OTHER", Content: "other",
+			Author: &discordgo.User{ID: "U1", Username: "u"},
+		},
+	})
+	// Delivered message.
+	msg, ok := dl.ProcessMessageCreate(&discordgo.MessageCreate{
+		Message: &discordgo.Message{
+			ID: "msg-1", ChannelID: "C123", Content: "hello",
+			Author: &discordgo.User{ID: "U1", Username: "alice"},
+		},
+	})
+	if !ok {
+		t.Fatal("expected message to be delivered")
+	}
+	if msg.Body != "hello" {
+		t.Errorf("Body = %q", msg.Body)
 	}
 }
 

--- a/core/comms/export_test.go
+++ b/core/comms/export_test.go
@@ -1,0 +1,8 @@
+package comms
+
+import "github.com/slack-go/slack/socketmode"
+
+// HandleEvent exposes handleEvent for testing.
+func (s *SlackListener) HandleEvent(evt socketmode.Event, msgs chan<- IncomingMessage) {
+	s.handleEvent(evt, msgs)
+}

--- a/core/comms/slack.go
+++ b/core/comms/slack.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log"
+	"log/slog"
 	"time"
 
 	"github.com/slack-go/slack"
@@ -19,6 +20,7 @@ type SlackListener struct {
 	botToken string
 	channels map[string]bool // channel names to listen on
 	ignore   map[string]bool // channel names to ignore
+	log      *slog.Logger
 
 	// apiURL overrides the Slack API base URL for testing.
 	apiURL string
@@ -54,6 +56,15 @@ func NewSlackListener(appToken, botToken string, channels, ignore []string) *Sla
 
 func (s *SlackListener) Service() string { return "slack" }
 
+// SetLogger sets an optional logger for verbose diagnostics.
+func (s *SlackListener) SetLogger(l *slog.Logger) { s.log = l }
+
+func (s *SlackListener) debug(msg string, args ...any) {
+	if s.log != nil {
+		s.log.Debug(msg, args...)
+	}
+}
+
 // Connect initializes the Slack API and Socket Mode clients.
 func (s *SlackListener) Connect(ctx context.Context) error {
 	if s.appToken == "" || s.botToken == "" {
@@ -71,6 +82,8 @@ func (s *SlackListener) Connect(ctx context.Context) error {
 		s.api,
 		socketmode.OptionLog(log.New(log.Writer(), "slack-socket: ", log.LstdFlags)),
 	)
+
+	s.debug("slack: connected", "channels", len(s.channels))
 	return nil
 }
 
@@ -104,6 +117,7 @@ func (s *SlackListener) Listen(ctx context.Context) (<-chan IncomingMessage, err
 		close(msgs)
 	}()
 
+	s.debug("slack: listening via Socket Mode")
 	return msgs, nil
 }
 
@@ -112,16 +126,31 @@ func (s *SlackListener) handleEvent(evt socketmode.Event, msgs chan<- IncomingMe
 	case socketmode.EventTypeEventsAPI:
 		eventsAPIEvent, ok := evt.Data.(slackevents.EventsAPIEvent)
 		if !ok {
+			s.debug("slack: received EventsAPI event with unexpected data type")
 			return
 		}
 		s.socket.Ack(*evt.Request)
 
 		if innerEvt, ok := eventsAPIEvent.InnerEvent.Data.(*slackevents.MessageEvent); ok {
+			s.debug("slack: received message event", "channel", innerEvt.Channel, "user", innerEvt.User)
 			if msg, deliver := s.ProcessMessageEvent(innerEvt); deliver {
 				msgs <- msg
 			}
+		} else {
+			s.debug("slack: received non-message event", "type", eventsAPIEvent.InnerEvent.Type)
 		}
+	case socketmode.EventTypeConnectionError:
+		s.debug("slack: connection error", "event", fmt.Sprintf("%+v", evt.Data))
+	case socketmode.EventTypeConnecting:
+		s.debug("slack: connecting to Socket Mode")
+	case socketmode.EventTypeConnected:
+		s.debug("slack: Socket Mode connection established")
+	case socketmode.EventTypeDisconnect:
+		s.debug("slack: disconnected from Socket Mode")
+	case socketmode.EventTypeHello:
+		s.debug("slack: received hello from Socket Mode")
 	default:
+		s.debug("slack: unhandled event", "type", evt.Type)
 		if evt.Request != nil {
 			s.socket.Ack(*evt.Request)
 		}
@@ -134,27 +163,44 @@ func (s *SlackListener) handleEvent(evt socketmode.Event, msgs chan<- IncomingMe
 // (bot message, ignored channel, etc.).
 func (s *SlackListener) ProcessMessageEvent(evt *slackevents.MessageEvent) (IncomingMessage, bool) {
 	if evt.BotID != "" {
-		return IncomingMessage{}, false
-	}
-	channel := evt.Channel
-	if s.ignore[channel] {
-		return IncomingMessage{}, false
-	}
-	if len(s.channels) > 0 && !s.channels[channel] {
+		s.debug("slack: skipping bot message", "bot_id", evt.BotID, "channel", evt.Channel)
 		return IncomingMessage{}, false
 	}
 
-	channelName := s.resolveChannelName(channel)
+	// Slack delivers channel IDs (C07ABC...) but aileron.yaml configures
+	// channel names (#backend). Resolve the ID to a name before filtering
+	// so both forms work in the config.
+	channelID := evt.Channel
+	channelName := s.resolveChannelName(channelID)
+
+	if s.matchChannel(channelID, channelName, s.ignore) {
+		s.debug("slack: skipping ignored channel", "channel", channelName, "id", channelID)
+		return IncomingMessage{}, false
+	}
+	if len(s.channels) > 0 && !s.matchChannel(channelID, channelName, s.channels) {
+		s.debug("slack: skipping unconfigured channel", "channel", channelName, "id", channelID)
+		return IncomingMessage{}, false
+	}
+
 	author := s.resolveAuthor(evt.User)
 
+	s.debug("slack: delivering message", "channel", channelName, "author", author)
 	return BuildIncomingMessage(evt.TimeStamp, channelName, author, evt.Text), true
+}
+
+// matchChannel checks if a channel matches any entry in the map by ID or name.
+func (s *SlackListener) matchChannel(id, name string, m map[string]bool) bool {
+	return m[id] || m[name]
 }
 
 func (s *SlackListener) resolveChannelName(id string) string {
 	if s.api != nil {
-		if info, err := s.api.GetConversationInfo(&slack.GetConversationInfoInput{
+		info, err := s.api.GetConversationInfo(&slack.GetConversationInfoInput{
 			ChannelID: id,
-		}); err == nil && info != nil {
+		})
+		if err != nil {
+			s.debug("slack: failed to resolve channel name", "channel_id", id, "error", err)
+		} else if info != nil {
 			return "#" + info.Name
 		}
 	}
@@ -163,7 +209,10 @@ func (s *SlackListener) resolveChannelName(id string) string {
 
 func (s *SlackListener) resolveAuthor(userID string) string {
 	if s.api != nil {
-		if user, err := s.api.GetUserInfo(userID); err == nil {
+		user, err := s.api.GetUserInfo(userID)
+		if err != nil {
+			s.debug("slack: failed to resolve user", "user_id", userID, "error", err)
+		} else {
 			if user.RealName != "" {
 				return user.RealName
 			}

--- a/core/comms/slack.go
+++ b/core/comms/slack.go
@@ -37,7 +37,7 @@ func (s *SlackListener) SetAPIURL(url string) {
 
 // NewSlackListener creates a Slack listener with the given tokens and
 // channel configuration.
-func NewSlackListener(appToken, botToken string, channels, ignore []string) *SlackListener {
+func NewSlackListener(appToken, botToken string, channels, ignore []string, log *slog.Logger) *SlackListener {
 	chMap := make(map[string]bool, len(channels))
 	for _, ch := range channels {
 		chMap[ch] = true
@@ -51,19 +51,11 @@ func NewSlackListener(appToken, botToken string, channels, ignore []string) *Sla
 		botToken: botToken,
 		channels: chMap,
 		ignore:   igMap,
+		log:      log,
 	}
 }
 
 func (s *SlackListener) Service() string { return "slack" }
-
-// SetLogger sets an optional logger for verbose diagnostics.
-func (s *SlackListener) SetLogger(l *slog.Logger) { s.log = l }
-
-func (s *SlackListener) debug(msg string, args ...any) {
-	if s.log != nil {
-		s.log.Debug(msg, args...)
-	}
-}
 
 // Connect initializes the Slack API and Socket Mode clients.
 func (s *SlackListener) Connect(ctx context.Context) error {
@@ -83,7 +75,7 @@ func (s *SlackListener) Connect(ctx context.Context) error {
 		socketmode.OptionLog(log.New(log.Writer(), "slack-socket: ", log.LstdFlags)),
 	)
 
-	s.debug("slack: connected", "channels", len(s.channels))
+	s.log.Debug("slack: connected", "channels", len(s.channels))
 	return nil
 }
 
@@ -117,7 +109,7 @@ func (s *SlackListener) Listen(ctx context.Context) (<-chan IncomingMessage, err
 		close(msgs)
 	}()
 
-	s.debug("slack: listening via Socket Mode")
+	s.log.Debug("slack: listening via Socket Mode")
 	return msgs, nil
 }
 
@@ -126,31 +118,31 @@ func (s *SlackListener) handleEvent(evt socketmode.Event, msgs chan<- IncomingMe
 	case socketmode.EventTypeEventsAPI:
 		eventsAPIEvent, ok := evt.Data.(slackevents.EventsAPIEvent)
 		if !ok {
-			s.debug("slack: received EventsAPI event with unexpected data type")
+			s.log.Debug("slack: received EventsAPI event with unexpected data type")
 			return
 		}
 		s.socket.Ack(*evt.Request)
 
 		if innerEvt, ok := eventsAPIEvent.InnerEvent.Data.(*slackevents.MessageEvent); ok {
-			s.debug("slack: received message event", "channel", innerEvt.Channel, "user", innerEvt.User)
+			s.log.Debug("slack: received message event", "channel", innerEvt.Channel, "user", innerEvt.User)
 			if msg, deliver := s.ProcessMessageEvent(innerEvt); deliver {
 				msgs <- msg
 			}
 		} else {
-			s.debug("slack: received non-message event", "type", eventsAPIEvent.InnerEvent.Type)
+			s.log.Debug("slack: received non-message event", "type", eventsAPIEvent.InnerEvent.Type)
 		}
 	case socketmode.EventTypeConnectionError:
-		s.debug("slack: connection error", "event", fmt.Sprintf("%+v", evt.Data))
+		s.log.Debug("slack: connection error", "event", fmt.Sprintf("%+v", evt.Data))
 	case socketmode.EventTypeConnecting:
-		s.debug("slack: connecting to Socket Mode")
+		s.log.Debug("slack: connecting to Socket Mode")
 	case socketmode.EventTypeConnected:
-		s.debug("slack: Socket Mode connection established")
+		s.log.Debug("slack: Socket Mode connection established")
 	case socketmode.EventTypeDisconnect:
-		s.debug("slack: disconnected from Socket Mode")
+		s.log.Debug("slack: disconnected from Socket Mode")
 	case socketmode.EventTypeHello:
-		s.debug("slack: received hello from Socket Mode")
+		s.log.Debug("slack: received hello from Socket Mode")
 	default:
-		s.debug("slack: unhandled event", "type", evt.Type)
+		s.log.Debug("slack: unhandled event", "type", evt.Type)
 		if evt.Request != nil {
 			s.socket.Ack(*evt.Request)
 		}
@@ -163,7 +155,7 @@ func (s *SlackListener) handleEvent(evt socketmode.Event, msgs chan<- IncomingMe
 // (bot message, ignored channel, etc.).
 func (s *SlackListener) ProcessMessageEvent(evt *slackevents.MessageEvent) (IncomingMessage, bool) {
 	if evt.BotID != "" {
-		s.debug("slack: skipping bot message", "bot_id", evt.BotID, "channel", evt.Channel)
+		s.log.Debug("slack: skipping bot message", "bot_id", evt.BotID, "channel", evt.Channel)
 		return IncomingMessage{}, false
 	}
 
@@ -174,17 +166,17 @@ func (s *SlackListener) ProcessMessageEvent(evt *slackevents.MessageEvent) (Inco
 	channelName := s.resolveChannelName(channelID)
 
 	if s.matchChannel(channelID, channelName, s.ignore) {
-		s.debug("slack: skipping ignored channel", "channel", channelName, "id", channelID)
+		s.log.Debug("slack: skipping ignored channel", "channel", channelName, "id", channelID)
 		return IncomingMessage{}, false
 	}
 	if len(s.channels) > 0 && !s.matchChannel(channelID, channelName, s.channels) {
-		s.debug("slack: skipping unconfigured channel", "channel", channelName, "id", channelID)
+		s.log.Debug("slack: skipping unconfigured channel", "channel", channelName, "id", channelID)
 		return IncomingMessage{}, false
 	}
 
 	author := s.resolveAuthor(evt.User)
 
-	s.debug("slack: delivering message", "channel", channelName, "author", author)
+	s.log.Debug("slack: delivering message", "channel", channelName, "author", author)
 	return BuildIncomingMessage(evt.TimeStamp, channelName, author, evt.Text), true
 }
 
@@ -199,7 +191,7 @@ func (s *SlackListener) resolveChannelName(id string) string {
 			ChannelID: id,
 		})
 		if err != nil {
-			s.debug("slack: failed to resolve channel name", "channel_id", id, "error", err)
+			s.log.Debug("slack: failed to resolve channel name", "channel_id", id, "error", err)
 		} else if info != nil {
 			return "#" + info.Name
 		}
@@ -211,7 +203,7 @@ func (s *SlackListener) resolveAuthor(userID string) string {
 	if s.api != nil {
 		user, err := s.api.GetUserInfo(userID)
 		if err != nil {
-			s.debug("slack: failed to resolve user", "user_id", userID, "error", err)
+			s.log.Debug("slack: failed to resolve user", "user_id", userID, "error", err)
 		} else {
 			if user.RealName != "" {
 				return user.RealName

--- a/core/comms/slack_integration_test.go
+++ b/core/comms/slack_integration_test.go
@@ -57,7 +57,7 @@ func TestSlackListener_ResolveChannelAndAuthor(t *testing.T) {
 	srv := newMockSlackServer()
 	defer srv.Close()
 
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 	sl.SetAPIURL(srv.URL + "/")
 
 	if err := sl.Connect(context.Background()); err != nil {
@@ -114,7 +114,7 @@ func TestSlackListener_ResolveAuthorFallbackToName(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 	sl.SetAPIURL(srv.URL + "/")
 	sl.Connect(context.Background())
 
@@ -135,7 +135,7 @@ func TestSlackListener_Send(t *testing.T) {
 	srv := newMockSlackServer()
 	defer srv.Close()
 
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 	sl.SetAPIURL(srv.URL + "/")
 	sl.Connect(context.Background())
 
@@ -152,7 +152,7 @@ func TestSlackListener_SendConnected(t *testing.T) {
 	srv := newMockSlackServer()
 	defer srv.Close()
 
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 	sl.SetAPIURL(srv.URL + "/")
 	sl.Connect(context.Background())
 

--- a/core/comms/slack_test.go
+++ b/core/comms/slack_test.go
@@ -9,7 +9,18 @@ import (
 
 	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/slack-go/slack/slackevents"
+	"github.com/slack-go/slack/socketmode"
 )
+
+func nopLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func debugLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+}
 
 func TestNewSlackListener(t *testing.T) {
 	sl := comms.NewSlackListener(
@@ -17,6 +28,7 @@ func TestNewSlackListener(t *testing.T) {
 		"xoxb-test",
 		[]string{"#backend", "#incidents"},
 		[]string{"#random"},
+		nopLogger(),
 	)
 	if sl.Service() != "slack" {
 		t.Errorf("Service() = %q, want 'slack'", sl.Service())
@@ -24,7 +36,7 @@ func TestNewSlackListener(t *testing.T) {
 }
 
 func TestSlackListener_ConnectMissingTokens(t *testing.T) {
-	sl := comms.NewSlackListener("", "", nil, nil)
+	sl := comms.NewSlackListener("", "", nil, nil, nopLogger())
 	err := sl.Connect(context.Background())
 	if err == nil {
 		t.Fatal("expected error for missing tokens")
@@ -32,7 +44,7 @@ func TestSlackListener_ConnectMissingTokens(t *testing.T) {
 }
 
 func TestSlackListener_ConnectValidTokens(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 	err := sl.Connect(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -40,7 +52,7 @@ func TestSlackListener_ConnectValidTokens(t *testing.T) {
 }
 
 func TestSlackListener_ListenWithoutConnect(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 	// Don't call Connect.
 	_, err := sl.Listen(context.Background())
 	if err == nil {
@@ -49,7 +61,7 @@ func TestSlackListener_ListenWithoutConnect(t *testing.T) {
 }
 
 func TestSlackListener_SendWithoutConnect(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 	err := sl.Send(context.Background(), comms.OutgoingMessage{
 		Channel: "#test",
 		Body:    "hello",
@@ -60,7 +72,7 @@ func TestSlackListener_SendWithoutConnect(t *testing.T) {
 }
 
 func TestSlackListener_Close(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 	// Close without connect should not panic.
 	if err := sl.Close(); err != nil {
 		t.Fatalf("Close failed: %v", err)
@@ -69,7 +81,7 @@ func TestSlackListener_Close(t *testing.T) {
 
 func TestSlackListener_ProcessMessageEvent(t *testing.T) {
 	sl := comms.NewSlackListener("xapp-test", "xoxb-test",
-		[]string{"C123"}, []string{"C999"})
+		[]string{"C123"}, []string{"C999"}, nopLogger())
 
 	msg, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
 		User:      "U123",
@@ -92,7 +104,7 @@ func TestSlackListener_ProcessMessageEvent(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent_BotSkipped(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 
 	_, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
 		User:    "U123",
@@ -106,7 +118,7 @@ func TestSlackListener_ProcessMessageEvent_BotSkipped(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent_IgnoredChannel(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, []string{"C999"})
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, []string{"C999"}, nopLogger())
 
 	_, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
 		User:    "U123",
@@ -120,7 +132,7 @@ func TestSlackListener_ProcessMessageEvent_IgnoredChannel(t *testing.T) {
 
 func TestSlackListener_ProcessMessageEvent_UnlistedChannel(t *testing.T) {
 	sl := comms.NewSlackListener("xapp-test", "xoxb-test",
-		[]string{"C123"}, nil) // only listen on C123
+		[]string{"C123"}, nil, nopLogger()) // only listen on C123
 
 	_, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
 		User:    "U123",
@@ -133,7 +145,7 @@ func TestSlackListener_ProcessMessageEvent_UnlistedChannel(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent_LongPreview(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil)
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
 
 	longText := strings.Repeat("x", 100)
 	msg, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
@@ -150,7 +162,7 @@ func TestSlackListener_ProcessMessageEvent_LongPreview(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent_NoChannelFilter(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil) // no channel filter
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger()) // no channel filter
 
 	_, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
 		User:    "U123",
@@ -190,12 +202,9 @@ func TestBuildIncomingMessage_LongTextTruncated(t *testing.T) {
 	// Preview is internal to the IncomingMessage — Body is preserved.
 }
 
-func TestSlackListener_VerboseLogging(t *testing.T) {
+func TestSlackListener_DebugLogging(t *testing.T) {
 	sl := comms.NewSlackListener("xapp-test", "xoxb-test",
-		[]string{"C123"}, []string{"C999"})
-	sl.SetLogger(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
-	})))
+		[]string{"C123"}, []string{"C999"}, debugLogger())
 
 	// Connect — exercises the "connected" log line.
 	if err := sl.Connect(context.Background()); err != nil {
@@ -223,6 +232,64 @@ func TestSlackListener_VerboseLogging(t *testing.T) {
 	}
 	if msg.Body != "hello" {
 		t.Errorf("Body = %q", msg.Body)
+	}
+}
+
+func TestSlackListener_HandleEvent_NonMessageTypes(t *testing.T) {
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, debugLogger())
+	if err := sl.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect: %v", err)
+	}
+
+	msgs := make(chan comms.IncomingMessage, 10)
+
+	// Exercise all non-message event types via handleEvent.
+	eventTypes := []socketmode.EventType{
+		socketmode.EventTypeConnectionError,
+		socketmode.EventTypeConnecting,
+		socketmode.EventTypeConnected,
+		socketmode.EventTypeDisconnect,
+		socketmode.EventTypeHello,
+		"unknown_event_type", // default case
+	}
+	for _, et := range eventTypes {
+		sl.HandleEvent(socketmode.Event{Type: et}, msgs)
+	}
+
+	// Also test EventsAPI with wrong data type.
+	sl.HandleEvent(socketmode.Event{
+		Type: socketmode.EventTypeEventsAPI,
+		Data: "not-an-events-api-event",
+	}, msgs)
+
+	// No messages should have been delivered.
+	if len(msgs) != 0 {
+		t.Errorf("expected no messages, got %d", len(msgs))
+	}
+}
+
+func TestSlackListener_ChannelNameMatching(t *testing.T) {
+	// Config uses channel name "#backend" but Slack sends channel ID "C123".
+	// Without API connection, resolveChannelName returns raw ID, so the
+	// channel filter uses both ID and name for matching.
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test",
+		[]string{"#backend"}, nil, nopLogger())
+
+	// Channel ID "C123" doesn't match "#backend" by ID, and without
+	// an API client to resolve the name, it falls through.
+	_, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
+		User: "U1", Channel: "C123", Text: "hello",
+	})
+	if ok {
+		t.Error("without API resolution, channel ID should not match channel name config")
+	}
+
+	// Channel name "#backend" should match directly.
+	_, ok = sl.ProcessMessageEvent(&slackevents.MessageEvent{
+		User: "U1", Channel: "#backend", Text: "hello",
+	})
+	if !ok {
+		t.Error("channel name should match directly")
 	}
 }
 

--- a/core/comms/slack_test.go
+++ b/core/comms/slack_test.go
@@ -2,6 +2,8 @@ package comms_test
 
 import (
 	"context"
+	"io"
+	"log/slog"
 	"strings"
 	"testing"
 
@@ -186,6 +188,42 @@ func TestBuildIncomingMessage_LongTextTruncated(t *testing.T) {
 		t.Error("body should be full text")
 	}
 	// Preview is internal to the IncomingMessage — Body is preserved.
+}
+
+func TestSlackListener_VerboseLogging(t *testing.T) {
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test",
+		[]string{"C123"}, []string{"C999"})
+	sl.SetLogger(slog.New(slog.NewTextHandler(io.Discard, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	})))
+
+	// Connect — exercises the "connected" log line.
+	if err := sl.Connect(context.Background()); err != nil {
+		t.Fatalf("Connect failed: %v", err)
+	}
+
+	// Bot message — exercises "skipping bot message" log.
+	sl.ProcessMessageEvent(&slackevents.MessageEvent{
+		BotID: "B1", Channel: "C123", Text: "bot",
+	})
+	// Ignored channel — exercises "skipping ignored channel" log.
+	sl.ProcessMessageEvent(&slackevents.MessageEvent{
+		User: "U1", Channel: "C999", Text: "ignored",
+	})
+	// Unconfigured channel — exercises "skipping unconfigured channel" log.
+	sl.ProcessMessageEvent(&slackevents.MessageEvent{
+		User: "U1", Channel: "C_OTHER", Text: "other",
+	})
+	// Delivered message — exercises "delivering message" log.
+	msg, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
+		User: "U1", Channel: "C123", Text: "hello", TimeStamp: "123.456",
+	})
+	if !ok {
+		t.Fatal("expected message to be delivered")
+	}
+	if msg.Body != "hello" {
+		t.Errorf("Body = %q", msg.Body)
+	}
 }
 
 // Verify SlackListener implements the Listener interface.

--- a/core/launch/export_test.go
+++ b/core/launch/export_test.go
@@ -1,0 +1,7 @@
+package launch
+
+// OpenSessionLogger exposes openSessionLogger for testing.
+var OpenSessionLogger = openSessionLogger
+
+// SessionLogPath exposes sessionLogPath for testing.
+var SessionLogPath = sessionLogPath

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -574,16 +574,19 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 	// Validate that token fields use vault references, not plaintext.
 	if cfg := pf.Notifications.Slack; cfg != nil {
 		if err := ValidateTokenRef("slack.app_token", cfg.AppToken); err != nil {
+			sessionLog.Warn("slack token validation failed", "error", err)
 			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
 			return nil
 		}
 		if err := ValidateTokenRef("slack.bot_token", cfg.BotToken); err != nil {
+			sessionLog.Warn("slack token validation failed", "error", err)
 			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
 			return nil
 		}
 	}
 	if cfg := pf.Notifications.Discord; cfg != nil {
 		if err := ValidateTokenRef("discord.bot_token", cfg.BotToken); err != nil {
+			sessionLog.Warn("discord token validation failed", "error", err)
 			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
 			return nil
 		}
@@ -604,6 +607,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 			var err error
 			v, err = OpenVaultFunc(os.Stderr)
 			if err != nil {
+				sessionLog.Warn("vault open failed", "error", err)
 				fmt.Fprintf(os.Stderr, "aileron: vault: %v\n", err)
 				return nil
 			}
@@ -613,6 +617,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 
 	resolved, err := ResolveTokens(tokenRefs, v)
 	if err != nil {
+		sessionLog.Warn("token resolution failed", "error", err)
 		fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
 		if strings.Contains(err.Error(), "decryption failed") {
 			fmt.Fprintln(os.Stderr, "aileron: wrong vault passphrase — notifications will not be available this session")

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"fmt"
 	"io"
+	"log/slog"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -31,6 +32,8 @@ type LaunchConfig struct {
 	// Dir is the working directory for the agent. If empty, the current
 	// directory is used.
 	Dir string
+	// Verbose enables debug logging for comms listeners (Slack, Discord).
+	Verbose bool
 }
 
 // LaunchResult holds the outcome of a launched agent process.
@@ -105,7 +108,18 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	// Create the notification queue and start any comms listeners.
 	queue := NewNotifyQueue(100, nil)
 	wireQuietHours(config.Dir, queue)
-	listeners := startCommsListeners(ctx, config.Dir, queue, auditLog, sessionID)
+	var commsLog *slog.Logger
+	var closeCommsLog func()
+	if config.Verbose {
+		commsLog, closeCommsLog = openCommsLogger(config.Dir)
+		if commsLog != nil {
+			fmt.Fprintf(os.Stderr, "aileron: verbose comms log → %s\n", commsLogPath(config.Dir))
+		}
+	}
+	if closeCommsLog != nil {
+		defer closeCommsLog()
+	}
+	listeners := startCommsListeners(ctx, config.Dir, queue, auditLog, sessionID, commsLog)
 	defer stopCommsListeners(listeners)
 
 	// If stdin is a terminal, use the pty proxy with status bar.
@@ -541,7 +555,7 @@ func EnvGlobMatch(pattern, name string) bool {
 
 // startCommsListeners reads the notification config from the policy file,
 // creates listeners, and starts them.
-func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, auditLog, sessionID string) []comms.Listener {
+func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, auditLog, sessionID string, commsLog *slog.Logger) []comms.Listener {
 	if dir == "" {
 		dir, _ = os.Getwd()
 	}
@@ -597,6 +611,11 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 	resolved, err := ResolveTokens(tokenRefs, v)
 	if err != nil {
 		fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
+		if strings.Contains(err.Error(), "decryption failed") {
+			fmt.Fprintln(os.Stderr, "aileron: wrong vault passphrase — notifications will not be available this session")
+		} else {
+			fmt.Fprintln(os.Stderr, "aileron: notifications will not be available this session")
+		}
 		return nil
 	}
 
@@ -618,7 +637,11 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 				priority[ch.Name] = ch.Priority
 			}
 		}
-		created = append(created, comms.NewSlackListener(appToken, botToken, channels, cfg.Ignore))
+		sl := comms.NewSlackListener(appToken, botToken, channels, cfg.Ignore)
+		if commsLog != nil {
+			sl.SetLogger(commsLog)
+		}
+		created = append(created, sl)
 	}
 	if cfg := pf.Notifications.Discord; cfg != nil && cfg.BotToken != "" {
 		botToken := resolved[idx]
@@ -629,7 +652,11 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 				priority[ch.Name] = ch.Priority
 			}
 		}
-		created = append(created, comms.NewDiscordListener(botToken, channels, cfg.Ignore))
+		dl := comms.NewDiscordListener(botToken, channels, cfg.Ignore)
+		if commsLog != nil {
+			dl.SetLogger(commsLog)
+		}
+		created = append(created, dl)
 	}
 
 	return StartListeners(ctx, created, queue, os.Stderr, autoDraft, priority, auditLog, sessionID)
@@ -702,4 +729,35 @@ func stopCommsListeners(listeners []comms.Listener) {
 	for _, l := range listeners {
 		l.Close()
 	}
+}
+
+// commsLogPath returns the path to the comms debug log file,
+// located alongside the audit log in .aileron/.
+func commsLogPath(dir string) string {
+	if dir == "" {
+		dir, _ = os.Getwd()
+	}
+	policyPath := FindPolicyFile(dir)
+	if policyPath != "" {
+		return filepath.Join(filepath.Dir(policyPath), ".aileron", "comms.log")
+	}
+	return filepath.Join(dir, ".aileron", "comms.log")
+}
+
+// openCommsLogger creates an slog.Logger that writes debug-level messages
+// to .aileron/comms.log. Returns the logger and a cleanup function to
+// close the file. Used when --verbose is passed to aileron launch.
+func openCommsLogger(dir string) (*slog.Logger, func()) {
+	path := commsLogPath(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, func() {}
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
+	if err != nil {
+		return nil, func() {}
+	}
+	logger := slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{
+		Level: slog.LevelDebug,
+	}))
+	return logger, func() { f.Close() }
 }

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -111,8 +111,17 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	sessionLog, closeSessionLog := openSessionLogger(config.Dir, config.LogLevel)
 	defer closeSessionLog()
 	fmt.Fprintf(os.Stderr, "aileron: session log → %s\n", sessionLogPath(config.Dir))
+
+	sessionLog.Info("session started",
+		"agent", config.Agent.Name(),
+		"session_id", sessionID,
+		"dir", config.Dir,
+		"binary", agentPath,
+	)
+
 	listeners := startCommsListeners(ctx, config.Dir, queue, auditLog, sessionID, sessionLog)
 	defer stopCommsListeners(listeners)
+	sessionLog.Debug("comms listeners started", "count", len(listeners))
 
 	// If stdin is a terminal, use the pty proxy with status bar.
 	var result LaunchResult
@@ -122,6 +131,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		result, err = launchDirect(cmd, config)
 	}
 
+	sessionLog.Info("session ended", "exit_code", result.ExitCode)
 	if auditLog != "" {
 		PrintSessionSummary(os.Stderr, auditLog, sessionID)
 	}
@@ -553,6 +563,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 	}
 	policyPath := FindPolicyFile(dir)
 	if policyPath == "" {
+		sessionLog.Debug("no policy file found, skipping comms listeners")
 		return nil
 	}
 	pf := loadPolicyFileFrom(policyPath)

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -121,7 +121,6 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 
 	listeners := startCommsListeners(ctx, config.Dir, queue, auditLog, sessionID, sessionLog)
 	defer stopCommsListeners(listeners)
-	sessionLog.Debug("comms listeners started", "count", len(listeners))
 
 	// If stdin is a terminal, use the pty proxy with status bar.
 	var result LaunchResult
@@ -568,6 +567,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 	}
 	pf := loadPolicyFileFrom(policyPath)
 	if pf.Notifications == nil {
+		sessionLog.Debug("no notifications configured in policy file")
 		return nil
 	}
 
@@ -640,6 +640,10 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 				priority[ch.Name] = ch.Priority
 			}
 		}
+		sessionLog.Info("slack listener configured",
+			"channels", channels,
+			"ignore", cfg.Ignore,
+		)
 		sl := comms.NewSlackListener(appToken, botToken, channels, cfg.Ignore, sessionLog.With("component", "slack"))
 		created = append(created, sl)
 	}
@@ -652,6 +656,10 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 				priority[ch.Name] = ch.Priority
 			}
 		}
+		sessionLog.Info("discord listener configured",
+			"channels", channels,
+			"ignore", cfg.Ignore,
+		)
 		dl := comms.NewDiscordListener(botToken, channels, cfg.Ignore, sessionLog.With("component", "discord"))
 		created = append(created, dl)
 	}

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -32,8 +32,8 @@ type LaunchConfig struct {
 	// Dir is the working directory for the agent. If empty, the current
 	// directory is used.
 	Dir string
-	// Verbose enables debug logging for comms listeners (Slack, Discord).
-	Verbose bool
+	// LogLevel sets the session log verbosity (e.g. slog.LevelDebug).
+	LogLevel slog.Level
 }
 
 // LaunchResult holds the outcome of a launched agent process.
@@ -108,18 +108,10 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	// Create the notification queue and start any comms listeners.
 	queue := NewNotifyQueue(100, nil)
 	wireQuietHours(config.Dir, queue)
-	var commsLog *slog.Logger
-	var closeCommsLog func()
-	if config.Verbose {
-		commsLog, closeCommsLog = openCommsLogger(config.Dir)
-		if commsLog != nil {
-			fmt.Fprintf(os.Stderr, "aileron: verbose comms log → %s\n", commsLogPath(config.Dir))
-		}
-	}
-	if closeCommsLog != nil {
-		defer closeCommsLog()
-	}
-	listeners := startCommsListeners(ctx, config.Dir, queue, auditLog, sessionID, commsLog)
+	sessionLog, closeSessionLog := openSessionLogger(config.Dir, config.LogLevel)
+	defer closeSessionLog()
+	fmt.Fprintf(os.Stderr, "aileron: session log → %s\n", sessionLogPath(config.Dir))
+	listeners := startCommsListeners(ctx, config.Dir, queue, auditLog, sessionID, sessionLog)
 	defer stopCommsListeners(listeners)
 
 	// If stdin is a terminal, use the pty proxy with status bar.
@@ -555,7 +547,7 @@ func EnvGlobMatch(pattern, name string) bool {
 
 // startCommsListeners reads the notification config from the policy file,
 // creates listeners, and starts them.
-func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, auditLog, sessionID string, commsLog *slog.Logger) []comms.Listener {
+func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, auditLog, sessionID string, sessionLog *slog.Logger) []comms.Listener {
 	if dir == "" {
 		dir, _ = os.Getwd()
 	}
@@ -637,10 +629,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 				priority[ch.Name] = ch.Priority
 			}
 		}
-		sl := comms.NewSlackListener(appToken, botToken, channels, cfg.Ignore)
-		if commsLog != nil {
-			sl.SetLogger(commsLog)
-		}
+		sl := comms.NewSlackListener(appToken, botToken, channels, cfg.Ignore, sessionLog.With("component", "slack"))
 		created = append(created, sl)
 	}
 	if cfg := pf.Notifications.Discord; cfg != nil && cfg.BotToken != "" {
@@ -652,10 +641,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 				priority[ch.Name] = ch.Priority
 			}
 		}
-		dl := comms.NewDiscordListener(botToken, channels, cfg.Ignore)
-		if commsLog != nil {
-			dl.SetLogger(commsLog)
-		}
+		dl := comms.NewDiscordListener(botToken, channels, cfg.Ignore, sessionLog.With("component", "discord"))
 		created = append(created, dl)
 	}
 
@@ -731,33 +717,34 @@ func stopCommsListeners(listeners []comms.Listener) {
 	}
 }
 
-// commsLogPath returns the path to the comms debug log file,
+// sessionLogPath returns the path to the session log file,
 // located alongside the audit log in .aileron/.
-func commsLogPath(dir string) string {
+func sessionLogPath(dir string) string {
 	if dir == "" {
 		dir, _ = os.Getwd()
 	}
 	policyPath := FindPolicyFile(dir)
 	if policyPath != "" {
-		return filepath.Join(filepath.Dir(policyPath), ".aileron", "comms.log")
+		return filepath.Join(filepath.Dir(policyPath), ".aileron", "session.log")
 	}
-	return filepath.Join(dir, ".aileron", "comms.log")
+	return filepath.Join(dir, ".aileron", "session.log")
 }
 
-// openCommsLogger creates an slog.Logger that writes debug-level messages
-// to .aileron/comms.log. Returns the logger and a cleanup function to
-// close the file. Used when --verbose is passed to aileron launch.
-func openCommsLogger(dir string) (*slog.Logger, func()) {
-	path := commsLogPath(dir)
+// openSessionLogger creates an slog.Logger that writes to
+// .aileron/session.log at the given level. Returns the logger and a
+// cleanup function to close the file. If the file cannot be created,
+// returns a discard logger so callers never receive nil.
+func openSessionLogger(dir string, level slog.Level) (*slog.Logger, func()) {
+	path := sessionLogPath(dir)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return nil, func() {}
+		return slog.New(slog.NewTextHandler(io.Discard, nil)), func() {}
 	}
 	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_TRUNC, 0o644)
 	if err != nil {
-		return nil, func() {}
+		return slog.New(slog.NewTextHandler(io.Discard, nil)), func() {}
 	}
 	logger := slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{
-		Level: slog.LevelDebug,
+		Level: level,
 	}))
 	return logger, func() { f.Close() }
 }

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -656,7 +656,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		created = append(created, dl)
 	}
 
-	return StartListeners(ctx, created, queue, os.Stderr, autoDraft, priority, auditLog, sessionID)
+	return StartListeners(ctx, created, queue, os.Stderr, autoDraft, priority, auditLog, sessionID, sessionLog)
 }
 
 // StartListeners connects and starts each listener, bridging incoming
@@ -664,20 +664,23 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 // trigger automatic draft replies. The priority map controls the
 // priority level ("normal", "high") per channel. Returns the
 // successfully started listeners. Errors are written to w.
-func StartListeners(ctx context.Context, listeners []comms.Listener, queue *NotifyQueue, w io.Writer, autoDraft map[string]bool, priority map[string]string, auditLog, sessionID string) []comms.Listener {
+func StartListeners(ctx context.Context, listeners []comms.Listener, queue *NotifyQueue, w io.Writer, autoDraft map[string]bool, priority map[string]string, auditLog, sessionID string, log *slog.Logger) []comms.Listener {
 	var started []comms.Listener
 	for _, l := range listeners {
 		if err := l.Connect(ctx); err != nil {
 			fmt.Fprintf(w, "aileron: %s connect failed: %v\n", l.Service(), err)
+			log.Warn("listener connect failed", "service", l.Service(), "error", err)
 			continue
 		}
 		msgs, err := l.Listen(ctx)
 		if err != nil {
 			fmt.Fprintf(w, "aileron: %s listen failed: %v\n", l.Service(), err)
+			log.Warn("listener listen failed", "service", l.Service(), "error", err)
 			continue
 		}
+		log.Info("listener started", "service", l.Service())
 		started = append(started, l)
-		go BridgeMessages(msgs, queue, autoDraft, priority, auditLog, sessionID)
+		go BridgeMessages(msgs, queue, autoDraft, priority, auditLog, sessionID, log)
 	}
 	return started
 }
@@ -686,7 +689,7 @@ func StartListeners(ctx context.Context, listeners []comms.Listener, queue *Noti
 // into the NotifyQueue. The autoDraft map controls which channels trigger
 // automatic draft replies. The priority map sets the priority level per
 // channel. Exported for testing.
-func BridgeMessages(msgs <-chan comms.IncomingMessage, queue *NotifyQueue, autoDraft map[string]bool, priority map[string]string, auditLog, sessionID string) {
+func BridgeMessages(msgs <-chan comms.IncomingMessage, queue *NotifyQueue, autoDraft map[string]bool, priority map[string]string, auditLog, sessionID string, log *slog.Logger) {
 	for msg := range msgs {
 		preview := msg.Body
 		if len(preview) > 80 {
@@ -696,6 +699,13 @@ func BridgeMessages(msgs <-chan comms.IncomingMessage, queue *NotifyQueue, autoD
 		if pri == "" {
 			pri = "normal"
 		}
+		log.Debug("message received",
+			"service", msg.Service,
+			"channel", msg.Channel,
+			"author", msg.Author,
+			"priority", pri,
+			"preview", preview,
+		)
 		queue.Push(Message{
 			ID:        msg.ID,
 			Source:    msg.Service,

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -18,6 +18,10 @@ import (
 	"github.com/creack/pty/v2"
 )
 
+func nopLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
 func TestResolveBinary_Found(t *testing.T) {
 	// "echo" should be on every Unix PATH
 	path, err := launch.ResolveBinary([]string{"echo"})
@@ -518,7 +522,7 @@ func TestBridgeMessages(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	msgs := make(chan comms.IncomingMessage, 5)
 
-	go launch.BridgeMessages(msgs, queue, nil, nil, "", "")
+	go launch.BridgeMessages(msgs, queue, nil, nil, "", "", nopLogger())
 
 	msgs <- comms.IncomingMessage{
 		ID:        "msg-1",
@@ -617,7 +621,7 @@ func TestBridgeMessages_AutoDraft(t *testing.T) {
 	msgs := make(chan comms.IncomingMessage, 3)
 
 	autoDraft := map[string]bool{"#backend": true}
-	go launch.BridgeMessages(msgs, queue, autoDraft, nil, "", "")
+	go launch.BridgeMessages(msgs, queue, autoDraft, nil, "", "", nopLogger())
 
 	msgs <- comms.IncomingMessage{ID: "1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "question"}
 	msgs <- comms.IncomingMessage{ID: "2", Service: "slack", Channel: "#general", Author: "Bob", Body: "chat"}
@@ -835,7 +839,7 @@ func TestBridgeMessages_AuditLog(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	msgs := make(chan comms.IncomingMessage, 2)
 
-	go launch.BridgeMessages(msgs, queue, nil, nil, auditPath, "test-session")
+	go launch.BridgeMessages(msgs, queue, nil, nil, auditPath, "test-session", nopLogger())
 
 	msgs <- comms.IncomingMessage{ID: "1", Service: "slack", Channel: "#backend", Author: "Alice", Body: "hello", Timestamp: time.Now()}
 	msgs <- comms.IncomingMessage{ID: "2", Service: "discord", Channel: "dev-chat", Author: "Bob", Body: "hi", Timestamp: time.Now()}
@@ -867,7 +871,7 @@ func TestBridgeMessages_LongPreviewTruncated(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	msgs := make(chan comms.IncomingMessage, 1)
 
-	go launch.BridgeMessages(msgs, queue, nil, nil, "", "")
+	go launch.BridgeMessages(msgs, queue, nil, nil, "", "", nopLogger())
 
 	longBody := strings.Repeat("x", 100)
 	msgs <- comms.IncomingMessage{
@@ -915,7 +919,7 @@ func TestStartListeners_Success(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr, nil, nil, "", "")
+	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr, nil, nil, "", "", nopLogger())
 
 	if len(started) != 1 {
 		t.Fatalf("expected 1 started listener, got %d", len(started))
@@ -942,7 +946,7 @@ func TestStartListeners_ConnectError(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr, nil, nil, "", "")
+	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr, nil, nil, "", "", nopLogger())
 
 	if len(started) != 0 {
 		t.Error("expected 0 started listeners on connect error")
@@ -960,7 +964,7 @@ func TestStartListeners_ListenError(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr, nil, nil, "", "")
+	started := launch.StartListeners(context.Background(), []comms.Listener{l}, queue, &stderr, nil, nil, "", "", nopLogger())
 
 	if len(started) != 0 {
 		t.Error("expected 0 started listeners on listen error")
@@ -973,7 +977,7 @@ func TestStartListeners_ListenError(t *testing.T) {
 func TestStartListeners_Empty(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), nil, queue, &stderr, nil, nil, "", "")
+	started := launch.StartListeners(context.Background(), nil, queue, &stderr, nil, nil, "", "", nopLogger())
 	if len(started) != 0 {
 		t.Error("expected 0 listeners for nil input")
 	}
@@ -985,7 +989,7 @@ func TestStartListeners_Mixed(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 
 	var stderr strings.Builder
-	started := launch.StartListeners(context.Background(), []comms.Listener{bad, good}, queue, &stderr, nil, nil, "", "")
+	started := launch.StartListeners(context.Background(), []comms.Listener{bad, good}, queue, &stderr, nil, nil, "", "", nopLogger())
 
 	if len(started) != 1 {
 		t.Fatalf("expected 1 started, got %d", len(started))

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -3,13 +3,13 @@ package launch_test
 import (
 	"context"
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
 	"time"
-
-	"io"
 
 	"github.com/ALRubinger/aileron/core/audit"
 	"github.com/ALRubinger/aileron/core/comms"
@@ -1221,3 +1221,98 @@ func (a scriptAgent) Args() []string                            { return nil }
 func (a scriptAgent) Env() map[string]string                    { return a.extraEnv }
 func (a scriptAgent) NormalizeCommand(raw string) (string, bool) { return raw, true }
 func (a scriptAgent) ConfigureShell(_, _ string) error           { return nil }
+
+func TestOpenSessionLogger_Success(t *testing.T) {
+	dir := t.TempDir()
+	logger, cleanup := launch.OpenSessionLogger(dir, slog.LevelDebug)
+	defer cleanup()
+
+	if logger == nil {
+		t.Fatal("expected non-nil logger")
+	}
+
+	// Verify the log file was created.
+	logPath := launch.SessionLogPath(dir)
+	if _, err := os.Stat(logPath); err != nil {
+		t.Fatalf("session log file not created at %s: %v", logPath, err)
+	}
+
+	// Write a message and verify it appears in the file.
+	logger.Info("test message", "key", "value")
+	cleanup() // flush and close
+
+	data, err := os.ReadFile(logPath)
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	content := string(data)
+	if !strings.Contains(content, "test message") {
+		t.Errorf("log file should contain 'test message', got: %s", content)
+	}
+	if !strings.Contains(content, "key=value") {
+		t.Errorf("log file should contain 'key=value', got: %s", content)
+	}
+}
+
+func TestOpenSessionLogger_LevelFiltering(t *testing.T) {
+	dir := t.TempDir()
+	logger, cleanup := launch.OpenSessionLogger(dir, slog.LevelWarn)
+	defer cleanup()
+
+	// Debug message should be filtered out at warn level.
+	logger.Debug("should not appear")
+	logger.Warn("should appear")
+	cleanup()
+
+	data, err := os.ReadFile(launch.SessionLogPath(dir))
+	if err != nil {
+		t.Fatalf("reading log file: %v", err)
+	}
+	content := string(data)
+	if strings.Contains(content, "should not appear") {
+		t.Error("debug message should be filtered at warn level")
+	}
+	if !strings.Contains(content, "should appear") {
+		t.Error("warn message should be present")
+	}
+}
+
+func TestOpenSessionLogger_ReadOnlyDir(t *testing.T) {
+	dir := t.TempDir()
+	readOnly := filepath.Join(dir, "readonly")
+	if err := os.MkdirAll(readOnly, 0o555); err != nil {
+		t.Fatal(err)
+	}
+	// Use a subpath under the read-only dir so MkdirAll fails.
+	badDir := filepath.Join(readOnly, "sub", "deep")
+	logger, cleanup := launch.OpenSessionLogger(badDir, slog.LevelDebug)
+	defer cleanup()
+
+	if logger == nil {
+		t.Fatal("expected non-nil discard logger, got nil")
+	}
+	// Logger should still be usable (writes to discard).
+	logger.Info("this should not panic")
+}
+
+func TestSessionLogPath_WithPolicyFile(t *testing.T) {
+	dir := t.TempDir()
+	// Create an aileron.yaml to simulate a policy file.
+	if err := os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte("{}"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := launch.SessionLogPath(dir)
+	want := filepath.Join(dir, ".aileron", "session.log")
+	if got != want {
+		t.Errorf("SessionLogPath = %q, want %q", got, want)
+	}
+}
+
+func TestSessionLogPath_WithoutPolicyFile(t *testing.T) {
+	dir := t.TempDir()
+	got := launch.SessionLogPath(dir)
+	want := filepath.Join(dir, ".aileron", "session.log")
+	if got != want {
+		t.Errorf("SessionLogPath = %q, want %q", got, want)
+	}
+}

--- a/core/launch/loglevel.go
+++ b/core/launch/loglevel.go
@@ -1,0 +1,30 @@
+package launch
+
+import (
+	"log/slog"
+	"strings"
+)
+
+// LevelTrace is a custom slog level below Debug, reserved for
+// high-volume tracing output.
+const LevelTrace = slog.Level(-8)
+
+// ParseLogLevel converts a string level name to an slog.Level.
+// Accepted values: "trace", "debug", "info", "warn", "error".
+// Returns slog.LevelWarn for unrecognized input.
+func ParseLogLevel(s string) slog.Level {
+	switch strings.ToLower(s) {
+	case "trace":
+		return LevelTrace
+	case "debug":
+		return slog.LevelDebug
+	case "info":
+		return slog.LevelInfo
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelWarn
+	}
+}

--- a/core/launch/loglevel_test.go
+++ b/core/launch/loglevel_test.go
@@ -1,0 +1,40 @@
+package launch_test
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/launch"
+)
+
+func TestParseLogLevel(t *testing.T) {
+	tests := []struct {
+		input string
+		want  slog.Level
+	}{
+		{"trace", launch.LevelTrace},
+		{"TRACE", launch.LevelTrace},
+		{"debug", slog.LevelDebug},
+		{"DEBUG", slog.LevelDebug},
+		{"info", slog.LevelInfo},
+		{"Info", slog.LevelInfo},
+		{"warn", slog.LevelWarn},
+		{"WARN", slog.LevelWarn},
+		{"error", slog.LevelError},
+		{"Error", slog.LevelError},
+		{"", slog.LevelWarn},
+		{"bogus", slog.LevelWarn},
+	}
+	for _, tt := range tests {
+		got := launch.ParseLogLevel(tt.input)
+		if got != tt.want {
+			t.Errorf("ParseLogLevel(%q) = %v, want %v", tt.input, got, tt.want)
+		}
+	}
+}
+
+func TestLevelTrace_BelowDebug(t *testing.T) {
+	if launch.LevelTrace >= slog.LevelDebug {
+		t.Errorf("LevelTrace (%d) should be below LevelDebug (%d)", launch.LevelTrace, slog.LevelDebug)
+	}
+}


### PR DESCRIPTION
## Summary

- Replace `--verbose` boolean flag with `--log-level` flag accepting standard levels: `trace`, `debug`, `info`, `warn`, `error` (default: `warn`)
- Introduce a unified session log (`.aileron/session.log`) that is always created, level-gated by `--log-level`
- Define `LevelTrace` custom slog level for future high-volume tracing
- Pass `*slog.Logger` at construction to Slack/Discord listeners — removes `SetLogger()` and nil-guard `debug()` helpers
- Fix Slack channel name vs ID matching so `#backend` in config matches `C07ABC...` from the API

## Changes

| File | What |
|------|------|
| `core/launch/loglevel.go` | New: `LevelTrace`, `ParseLogLevel()` |
| `core/launch/launcher.go` | `LaunchConfig.LogLevel`, `openSessionLogger`, `sessionLogPath` |
| `core/comms/slack.go` | Logger param in constructor, direct `s.log.Debug()` calls |
| `core/comms/discord.go` | Same pattern as Slack |
| `cmd/aileron/main.go` | `--log-level` flag replaces `--verbose` |

## Test plan

- [x] `go test ./core/launch/` — 91.0% coverage
- [x] `go test ./core/comms/` — 85.8% coverage
- [x] `go test ./cmd/aileron/` — 84.5% coverage
- [x] `go vet` passes on all changed packages
- [ ] Manual: `aileron launch --log-level=debug claude` creates `.aileron/session.log` with debug output

🤖 Generated with [Claude Code](https://claude.com/claude-code)