### PR TITLE
feat(launch): notification overlay, draft workflow, unified Panel UI

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,6 +37,7 @@ Today's agent hosts give you two modes: approve every command individually (50 p
 │  │ cmd string → │  │ http_request │  │             │  │
 │  │ policy eval  │  │ send_message │  │ inbound →   │  │
 │  │ exec | deny  │  │ read_messages│  │ /dev/tty    │  │
+│  │              │  │ draft_reply  │  │             │  │
 │  └──────┬───────┘  └──────┬───────┘  └──────┬──────┘  │
 │         │                 │                  │         │
 │         ▼                 ▼                  ▼         │
@@ -89,13 +90,23 @@ Aileron works out of the box. Language toolchain rules (Go, Node, Python, Rust, 
 
 **4. Teammates message you — the agent drafts a reply**
 
-Slack and Discord messages arrive in your terminal. On channels configured with `auto_draft: true`, the agent drafts a reply using its live codebase context. You approve with one keypress:
+Slack and Discord messages arrive in your terminal. Press **Ctrl-]** to open the notification overlay, select a message, and press **a** to ask the agent to draft a reply using its codebase context. The agent submits a draft via the `draft_reply` tool — Aileron shows it for your review:
 
 ```
-  📝 aileron: agent drafted a reply to Sarah in #backend
-    "No, the claims structure isn't changing. The refactor
-     only affects validation logic in middleware.go."
-    [y] send  [e] edit and send  [n] discard
+│ aileron notifications (1 messages)
+│ ──────────────────────────────────────
+│ > ● slack · Sarah: Does the refactor change JWT claims?
+│
+│ ──────────────────────────────────────
+│  #backend · Sarah
+│  Does the refactor change JWT claims?
+│
+│  ── Draft Reply ──
+│  No, the claims structure isn't changing. The refactor
+│  only affects validation logic in middleware.go.
+│
+│ ──────────────────────────────────────
+│ y send  e edit  c revise  n discard  q return
 ```
 
 **5. Credentials are brokered, never exposed**

--- a/README.md
+++ b/README.md
@@ -244,7 +244,7 @@ This creates a minimal `aileron.yaml` with project-specific deny rules and env s
 
 ### Slack notifications
 
-Aileron can receive Slack messages in your terminal while you work. Incoming messages appear in the status bar; press **Ctrl-A** to open the full notification overlay.
+Aileron can receive Slack messages in your terminal while you work. Incoming messages appear in the status bar; press **Ctrl-]** to open the full notification overlay.
 
 **1. Create a Slack app** with [Socket Mode](https://api.slack.com/apis/socket-mode) enabled. You need:
 - An **App-Level Token** (`xapp-...`) with `connections:write` scope
@@ -285,7 +285,7 @@ Token fields in `aileron.yaml` **must** use `vault:` references. Aileron rejects
 ./build/aileron launch claude
 ```
 
-Messages from configured channels appear in the notification bar. Press **Ctrl-A** to view the full queue, navigate with **j/k** or arrow keys, press **r** to type a reply directly, **a** to ask the agent to draft a reply, **d** to dismiss, and **Escape** to return. On channels with `auto_draft: true`, the agent drafts replies automatically when messages arrive.
+Messages from configured channels appear in the notification bar. Press **Ctrl-]** to view the full queue, navigate with **j/k** or arrow keys, press **r** to type a reply directly, **a** to ask the agent to draft a reply, **d** to dismiss, and **Escape** to return. When a draft is ready, press **y** to send, **e** to edit, **c** to revise with feedback, or **n** to discard. On channels with `auto_draft: true`, messages are flagged for drafting — open the overlay and press **a** to trigger the agent.
 
 ### Discord notifications
 

--- a/cmd/aileron-mcp/main.go
+++ b/cmd/aileron-mcp/main.go
@@ -93,7 +93,7 @@ type server struct {
 
 var readMessagesTool = toolDef{
 	Name:        "read_messages",
-	Description: "Read pending messages from communication channels (Slack, Discord). Returns unread messages from the notification queue.",
+	Description: "Read pending messages from communication channels (Slack, Discord). Returns unread messages from the notification queue. Messages with draft_request=true need a reply drafted — call draft_reply with the message ID and your suggested reply.",
 	InputSchema: schema{
 		Type: "object",
 		Properties: map[string]schemaProp{
@@ -114,6 +114,19 @@ var sendMessageTool = toolDef{
 			"body":    {Type: "string", Description: "Message text to send"},
 		},
 		Required: []string{"service", "channel", "body"},
+	},
+}
+
+var draftReplyTool = toolDef{
+	Name:        "draft_reply",
+	Description: "Submit a draft reply to a message. The draft is shown to the user for review — they can send, edit, or discard it. Use this when read_messages returns messages with draft_request=true. Do NOT use send_message for drafts; Aileron handles sending after user approval.",
+	InputSchema: schema{
+		Type: "object",
+		Properties: map[string]schemaProp{
+			"message_id": {Type: "string", Description: "ID of the message to reply to (from read_messages)"},
+			"body":       {Type: "string", Description: "Your suggested reply text"},
+		},
+		Required: []string{"message_id", "body"},
 	},
 }
 
@@ -245,7 +258,7 @@ func (s *server) handle(req jsonrpcRequest) *jsonrpcResponse {
 func (s *server) availableTools() []toolDef {
 	var tools []toolDef
 	if s.commsSocket != "" {
-		tools = append(tools, readMessagesTool, sendMessageTool, httpRequestTool)
+		tools = append(tools, readMessagesTool, draftReplyTool, sendMessageTool, httpRequestTool)
 	}
 	if s.aileronURL != "" {
 		tools = append(tools, submitIntentTool)
@@ -259,6 +272,8 @@ func (s *server) dispatchTool(ctx context.Context, name string, args map[string]
 		return s.submitIntent(ctx, args)
 	case "read_messages":
 		return s.readMessages(args)
+	case "draft_reply":
+		return s.draftReply(args)
 	case "send_message":
 		return s.sendMessage(args)
 	case "http_request":
@@ -285,6 +300,31 @@ func (s *server) readMessages(args map[string]any) toolResult {
 		return errorResult(resp.Error)
 	}
 	return jsonResult(resp.Messages)
+}
+
+func (s *server) draftReply(args map[string]any) toolResult {
+	if s.commsSocket == "" {
+		return errorResult("comms not available (not launched via aileron)")
+	}
+
+	messageID, _ := args["message_id"].(string)
+	body, _ := args["body"].(string)
+
+	if messageID == "" || body == "" {
+		return errorResult("message_id and body are required")
+	}
+
+	resp := requestComms(s.commsSocket, commsRequest{
+		Method:  "draft_reply",
+		ReplyTo: messageID,
+		Body:    body,
+	})
+	if resp.Error != "" {
+		return errorResult(resp.Error)
+	}
+	return toolResult{
+		Content: []toolContent{{Type: "text", Text: "Draft submitted for user review."}},
+	}
 }
 
 func (s *server) sendMessage(args map[string]any) toolResult {

--- a/cmd/aileron-mcp/main_test.go
+++ b/cmd/aileron-mcp/main_test.go
@@ -640,6 +640,68 @@ func TestJsonResult(t *testing.T) {
 	}
 }
 
+func TestDraftReply_NoSocket(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	result := s.draftReply(map[string]any{"message_id": "1", "body": "text"})
+	if !result.IsError {
+		t.Error("expected error when comms socket not set")
+	}
+}
+
+func TestDraftReply_MissingFields(t *testing.T) {
+	s := &server{commsSocket: "/tmp/fake.sock", httpClient: &http.Client{}}
+	result := s.draftReply(map[string]any{})
+	if !result.IsError {
+		t.Error("expected error for missing fields")
+	}
+}
+
+func TestDraftReply_WithServer(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-mcp-test-draft.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	ln, err := net.Listen("unix", socketPath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+
+	go func() {
+		for {
+			conn, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			var req commsRequest
+			json.NewDecoder(conn).Decode(&req)
+			if req.Method == "draft_reply" && req.ReplyTo != "" && req.Body != "" {
+				json.NewEncoder(conn).Encode(commsResponse{OK: true})
+			} else {
+				json.NewEncoder(conn).Encode(commsResponse{Error: "bad request"})
+			}
+			conn.Close()
+		}
+	}()
+
+	s := &server{commsSocket: socketPath, httpClient: &http.Client{}}
+	result := s.draftReply(map[string]any{"message_id": "msg-1", "body": "my draft"})
+	if result.IsError {
+		t.Fatalf("expected success, got error: %s", result.Content[0].Text)
+	}
+	if !contains(result.Content[0].Text, "Draft submitted") {
+		t.Errorf("expected success message, got %s", result.Content[0].Text)
+	}
+}
+
+func TestDispatchTool_DraftReply(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	result := s.dispatchTool(context.Background(), "draft_reply", map[string]any{"message_id": "1", "body": "text"})
+	// No comms socket → error, but should not panic.
+	if !result.IsError {
+		t.Error("expected error without comms socket")
+	}
+}
+
 func TestErrorResponse(t *testing.T) {
 	resp := errorResponse(json.RawMessage(`99`), -32600, "invalid request")
 	if resp.JSONRPC != "2.0" {

--- a/cmd/aileron-mcp/main_test.go
+++ b/cmd/aileron-mcp/main_test.go
@@ -82,15 +82,15 @@ func TestHandle_ToolsList_WithComms(t *testing.T) {
 	})
 	result := resp.Result.(map[string]any)
 	tools := result["tools"].([]toolDef)
-	if len(tools) != 3 {
-		t.Fatalf("expected 3 tools (read_messages, send_message, http_request), got %d", len(tools))
+	if len(tools) != 4 {
+		t.Fatalf("expected 4 tools (read_messages, draft_reply, send_message, http_request), got %d", len(tools))
 	}
 	names := map[string]bool{}
 	for _, tool := range tools {
 		names[tool.Name] = true
 	}
-	if !names["read_messages"] || !names["send_message"] || !names["http_request"] {
-		t.Errorf("expected read_messages, send_message, and http_request, got %v", names)
+	if !names["read_messages"] || !names["draft_reply"] || !names["send_message"] || !names["http_request"] {
+		t.Errorf("expected read_messages, draft_reply, send_message, and http_request, got %v", names)
 	}
 }
 
@@ -103,8 +103,8 @@ func TestHandle_ToolsList_Both(t *testing.T) {
 	})
 	result := resp.Result.(map[string]any)
 	tools := result["tools"].([]toolDef)
-	if len(tools) != 4 {
-		t.Fatalf("expected 4 tools, got %d", len(tools))
+	if len(tools) != 5 {
+		t.Fatalf("expected 5 tools, got %d", len(tools))
 	}
 }
 

--- a/core/launch/approval.go
+++ b/core/launch/approval.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"net"
 	"os"
-	"strings"
 	"sync"
 
 	ptyPkg "github.com/creack/pty/v2"
@@ -126,10 +125,17 @@ func (s *ApprovalServer) promptOnTerminal(command, reason string) string {
 		s.triggerRedraw()
 	}()
 
-	// Switch to alternate screen buffer — preserves scrollback history.
-	w := 74 // inner width of the box
+	// Build the panel content and render using the shared Panel component.
+	termRows, termCols := 24, 80
+	if s.bar != nil {
+		termRows, termCols = s.bar.Dims()
+	}
+	panel := NewPanel(PanelConfig{
+		Title:      "✈️ Aileron",
+		InnerWidth: 74,
+		Centered:   true,
+	}, termRows, termCols)
 
-	// Build the box lines first so we can count them for vertical centering.
 	type opt struct {
 		key, label, desc string
 	}
@@ -140,66 +146,23 @@ func (s *ApprovalServer) promptOnTerminal(command, reason string) string {
 		{"m", "Allow for me            ", "Add a rule in my personal policy"},
 	}
 
-	var lines []string
-	lines = append(lines, fmt.Sprintf("\033[33m┌─ ✈️ Aileron %s┐\033[0m", strings.Repeat("─", w-12)))
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  ⚠️  The agent wants to run:%s\033[33m│\033[0m", strings.Repeat(" ", w-29)))
-	cmdPad := w - 2 - len(command)
-	if cmdPad < 0 {
-		cmdPad = 0
-	}
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  \033[1;36m%s\033[0m%s\033[33m│\033[0m", command, strings.Repeat(" ", cmdPad)))
+	var content []string
+	content = append(content, panel.BlankLine())
+	content = append(content, panel.PadLine("  ⚠️  The agent wants to run:"))
+	content = append(content, panel.PadLine("  \033[1;36m"+command+"\033[0m"))
 	if reason != "" {
-		rPad := w - 2 - len(reason)
-		if rPad < 0 {
-			rPad = 0
-		}
-		lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  \033[2m%s\033[0m%s\033[33m│\033[0m", reason, strings.Repeat(" ", rPad)))
+		content = append(content, panel.PadLine("  \033[2m"+reason+"\033[0m"))
 	}
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
+	content = append(content, panel.BlankLine())
 	for _, o := range opts {
-		visible := fmt.Sprintf("[%s]  %s%s", o.key, o.label, o.desc)
-		gap := w - 2 - len(visible)
-		if gap < 0 {
-			gap = 0
-		}
-		lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  \033[1m[%s]\033[0m  %s%s%s\033[33m│\033[0m",
-			o.key, o.label, o.desc, strings.Repeat(" ", gap)))
+		content = append(content, panel.PadLine(fmt.Sprintf("  \033[1m[%s]\033[0m  %s%s", o.key, o.label, o.desc)))
 	}
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
-	lines = append(lines, fmt.Sprintf("\033[33m└%s┘\033[0m", strings.Repeat("─", w)))
+	content = append(content, panel.BlankLine())
 
-	// Calculate centering offsets.
-	termRows, termCols := 24, 80
-	if s.bar != nil {
-		termRows, termCols = s.bar.Dims()
-	}
-	boxWidth := w + 2 // inner + left/right border chars
-	leftPad := (termCols - boxWidth) / 2
-	if leftPad < 0 {
-		leftPad = 0
-	}
-	topPad := (termRows - len(lines) - 2) / 2 // -2 for the > line
-	if topPad < 0 {
-		topPad = 0
-	}
-	margin := strings.Repeat(" ", leftPad)
-
-	var prompt strings.Builder
-	prompt.WriteString("\033[?1049h\033[2J\033[1;1H")
-	// Vertical padding.
-	for i := 0; i < topPad; i++ {
-		prompt.WriteString("\r\n")
-	}
-	// Box lines with horizontal centering.
-	for _, line := range lines {
-		fmt.Fprintf(&prompt, "%s%s\r\n", margin, line)
-	}
-	prompt.WriteString("\r\n")
-	fmt.Fprintf(&prompt, "%s  > ", margin)
+	prompt := panel.RenderToAltScreen(content) + "\r\n  > "
 
 	if s.copier != nil {
-		s.copier.WriteExclusive([]byte(prompt.String()))
+		s.copier.WriteExclusive([]byte(prompt))
 	}
 
 	// Read keypresses until we get a valid response.

--- a/core/launch/approval.go
+++ b/core/launch/approval.go
@@ -131,9 +131,7 @@ func (s *ApprovalServer) promptOnTerminal(command, reason string) string {
 		termRows, termCols = s.bar.Dims()
 	}
 	panel := NewPanel(PanelConfig{
-		Title:      "✈️ Aileron",
-		InnerWidth: 74,
-		Centered:   true,
+		Title: "✈️ Aileron",
 	}, termRows, termCols)
 
 	type opt struct {
@@ -147,17 +145,17 @@ func (s *ApprovalServer) promptOnTerminal(command, reason string) string {
 	}
 
 	var content []string
-	content = append(content, panel.BlankLine())
-	content = append(content, panel.PadLine("  ⚠️  The agent wants to run:"))
-	content = append(content, panel.PadLine("  \033[1;36m"+command+"\033[0m"))
+	content = append(content, "")
+	content = append(content, "  ⚠️  The agent wants to run:")
+	content = append(content, "  \033[1;36m"+command+"\033[0m")
 	if reason != "" {
-		content = append(content, panel.PadLine("  \033[2m"+reason+"\033[0m"))
+		content = append(content, "  \033[2m"+reason+"\033[0m")
 	}
-	content = append(content, panel.BlankLine())
+	content = append(content, "")
 	for _, o := range opts {
-		content = append(content, panel.PadLine(fmt.Sprintf("  \033[1m[%s]\033[0m  %s%s", o.key, o.label, o.desc)))
+		content = append(content, fmt.Sprintf("  \033[1m[%s]\033[0m  %s%s", o.key, o.label, o.desc))
 	}
-	content = append(content, panel.BlankLine())
+	content = append(content, "")
 
 	prompt := panel.RenderToAltScreen(content) + "\r\n  > "
 

--- a/core/launch/commsserver.go
+++ b/core/launch/commsserver.go
@@ -300,51 +300,32 @@ func (cs *CommsServer) promptSendApproval(service, channel, body string) string 
 		}
 	}()
 
-	w := 74
 	termRows, termCols := 24, 80
 	if cs.bar != nil {
 		termRows, termCols = cs.bar.Dims()
 	}
+	panel := NewPanel(PanelConfig{
+		Title:      "✈️ Aileron ─ Send Message",
+		InnerWidth: 74,
+		Centered:   true,
+	}, termRows, termCols)
 
-	var lines []string
-	lines = append(lines, fmt.Sprintf("\033[33m┌─ ✈️ Aileron ─ Send Message %s┐\033[0m", strings.Repeat("─", w-27)))
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  To: \033[1m%s %s\033[0m%s\033[33m│\033[0m",
-		service, channel, strings.Repeat(" ", max(0, w-6-len(service)-1-len(channel)))))
-
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
-
-	// Wrap the body text into lines that fit the box.
-	bodyLines := wrapText(body, w-4)
-	for _, bl := range bodyLines {
-		lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  %s%s\033[33m│\033[0m",
-			bl, strings.Repeat(" ", max(0, w-2-len(bl)))))
+	var content []string
+	content = append(content, panel.BlankLine())
+	content = append(content, panel.PadLine(fmt.Sprintf("  To: \033[1m%s %s\033[0m", service, channel)))
+	content = append(content, panel.BlankLine())
+	for _, bl := range wrapText(body, panel.InnerWidth()-4) {
+		content = append(content, panel.PadLine("  "+bl))
 	}
+	content = append(content, panel.BlankLine())
+	content = append(content, panel.PadLine("  \033[1m[y]\033[0m  Send"))
+	content = append(content, panel.PadLine("  \033[1m[n]\033[0m  Discard"))
+	content = append(content, panel.BlankLine())
 
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  \033[1m[y]\033[0m  Send%s\033[33m│\033[0m", strings.Repeat(" ", w-11)))
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m  \033[1m[n]\033[0m  Discard%s\033[33m│\033[0m", strings.Repeat(" ", w-14)))
-	lines = append(lines, fmt.Sprintf("\033[33m│\033[0m%s\033[33m│\033[0m", strings.Repeat(" ", w)))
-	lines = append(lines, fmt.Sprintf("\033[33m└%s┘\033[0m", strings.Repeat("─", w)))
-
-	boxWidth := w + 2
-	leftPad := max(0, (termCols-boxWidth)/2)
-	topPad := max(0, (termRows-len(lines)-2)/2)
-	margin := strings.Repeat(" ", leftPad)
-
-	var prompt strings.Builder
-	prompt.WriteString("\033[?1049h\033[2J\033[1;1H")
-	for i := 0; i < topPad; i++ {
-		prompt.WriteString("\r\n")
-	}
-	for _, line := range lines {
-		fmt.Fprintf(&prompt, "%s%s\r\n", margin, line)
-	}
-	prompt.WriteString("\r\n")
-	fmt.Fprintf(&prompt, "%s  > ", margin)
+	prompt := panel.RenderToAltScreen(content) + "\r\n  > "
 
 	if cs.copier != nil {
-		cs.copier.WriteExclusive([]byte(prompt.String()))
+		cs.copier.WriteExclusive([]byte(prompt))
 	}
 
 	if inputCh == nil {
@@ -368,27 +349,6 @@ func (cs *CommsServer) promptSendApproval(service, channel, body string) string 
 			continue
 		}
 	}
-}
-
-// wrapText splits text into lines of at most maxWidth characters.
-func wrapText(text string, maxWidth int) []string {
-	if len(text) <= maxWidth {
-		return []string{text}
-	}
-	var lines []string
-	for len(text) > maxWidth {
-		// Find a space to break at.
-		idx := strings.LastIndex(text[:maxWidth], " ")
-		if idx < 0 {
-			idx = maxWidth
-		}
-		lines = append(lines, text[:idx])
-		text = strings.TrimLeft(text[idx:], " ")
-	}
-	if len(text) > 0 {
-		lines = append(lines, text)
-	}
-	return lines
 }
 
 // DirectSend sends a message without an approval prompt. Used for

--- a/core/launch/commsserver.go
+++ b/core/launch/commsserver.go
@@ -305,22 +305,20 @@ func (cs *CommsServer) promptSendApproval(service, channel, body string) string 
 		termRows, termCols = cs.bar.Dims()
 	}
 	panel := NewPanel(PanelConfig{
-		Title:      "✈️ Aileron ─ Send Message",
-		InnerWidth: 74,
-		Centered:   true,
+		Title: "✈️ Aileron ─ Send Message",
 	}, termRows, termCols)
 
 	var content []string
-	content = append(content, panel.BlankLine())
-	content = append(content, panel.PadLine(fmt.Sprintf("  To: \033[1m%s %s\033[0m", service, channel)))
-	content = append(content, panel.BlankLine())
-	for _, bl := range wrapText(body, panel.InnerWidth()-4) {
-		content = append(content, panel.PadLine("  "+bl))
+	content = append(content, "")
+	content = append(content, fmt.Sprintf("  To: \033[1m%s %s\033[0m", service, channel))
+	content = append(content, "")
+	for _, bl := range wrapText(body, panel.ContentWidth()-4) {
+		content = append(content, "  "+bl)
 	}
-	content = append(content, panel.BlankLine())
-	content = append(content, panel.PadLine("  \033[1m[y]\033[0m  Send"))
-	content = append(content, panel.PadLine("  \033[1m[n]\033[0m  Discard"))
-	content = append(content, panel.BlankLine())
+	content = append(content, "")
+	content = append(content, "  \033[1m[y]\033[0m  Send")
+	content = append(content, "  \033[1m[n]\033[0m  Discard")
+	content = append(content, "")
 
 	prompt := panel.RenderToAltScreen(content) + "\r\n  > "
 

--- a/core/launch/commsserver.go
+++ b/core/launch/commsserver.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"context"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -376,18 +377,30 @@ func (cs *CommsServer) promptSendApproval(service, channel, body string) string 
 // user-authored replies from the overlay (the user typed it, so no
 // approval is needed).
 func (cs *CommsServer) DirectSend(service, channel, body string) error {
+	fmt.Fprintf(os.Stderr, "aileron: DEBUG DirectSend: service=%q channel=%q body_len=%d senders=%v\n", service, channel, len(body), cs.senderNames())
 	sender, ok := cs.senders[service]
 	if !ok {
 		return fmt.Errorf("no listener for service: %s", service)
 	}
-	err := sender.Send(nil, comms.OutgoingMessage{
+	err := sender.Send(context.Background(), comms.OutgoingMessage{
 		Channel: channel,
 		Body:    body,
 	})
-	if err == nil {
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "aileron: DEBUG DirectSend error: %v\n", err)
+	} else {
+		fmt.Fprintf(os.Stderr, "aileron: DEBUG DirectSend success\n")
 		cs.logMessage("reply_sent", service, channel, "", body, "")
 	}
 	return err
+}
+
+func (cs *CommsServer) senderNames() []string {
+	names := make([]string, 0, len(cs.senders))
+	for k := range cs.senders {
+		names = append(names, k)
+	}
+	return names
 }
 
 // SetSecrets configures the secrets mapping and vault for http_request

--- a/core/launch/commsserver.go
+++ b/core/launch/commsserver.go
@@ -35,12 +35,13 @@ type CommsResponse struct {
 
 // CommsMessageDTO is the wire format for a message.
 type CommsMessageDTO struct {
-	ID        string `json:"id"`
-	Service   string `json:"service"`
-	Channel   string `json:"channel"`
-	Author    string `json:"author"`
-	Body      string `json:"body"`
-	Timestamp string `json:"timestamp"`
+	ID           string `json:"id"`
+	Service      string `json:"service"`
+	Channel      string `json:"channel"`
+	Author       string `json:"author"`
+	Body         string `json:"body"`
+	Timestamp    string `json:"timestamp"`
+	DraftRequest bool   `json:"draft_request,omitempty"` // true if a reply draft is requested
 }
 
 // CommsServer handles IPC requests from aileron-mcp for reading and
@@ -124,6 +125,8 @@ func (cs *CommsServer) handleConn(conn net.Conn) {
 		resp = cs.readMessages(req)
 	case "send_message":
 		resp = cs.sendMessage(req)
+	case "draft_reply":
+		resp = cs.draftReply(req)
 	case "http_request":
 		resp = cs.httpRequest(req)
 	default:
@@ -143,17 +146,37 @@ func (cs *CommsServer) readMessages(req CommsRequest) CommsResponse {
 		if req.Channel != "" && m.Channel != req.Channel {
 			continue
 		}
-		dtos = append(dtos, CommsMessageDTO{
+		dto := CommsMessageDTO{
 			ID:        m.ID,
 			Service:   m.Source,
 			Channel:   m.Channel,
 			Author:    m.Author,
 			Body:      m.Body,
 			Timestamp: m.Timestamp.Format(time.RFC3339),
-		})
+		}
+		if m.AutoDraft && m.Draft == "" {
+			dto.DraftRequest = true
+		}
+		dtos = append(dtos, dto)
 	}
 	cs.queue.MarkAllRead()
 	return CommsResponse{OK: true, Messages: dtos}
+}
+
+// draftReply stores a draft reply on a message without sending it.
+// The user reviews the draft in the overlay and decides to send,
+// edit, or discard. Aileron handles sending — not the agent.
+func (cs *CommsServer) draftReply(req CommsRequest) CommsResponse {
+	if req.ReplyTo == "" || req.Body == "" {
+		return CommsResponse{Error: "reply_to and body are required"}
+	}
+
+	if !cs.queue.SetDraft(req.ReplyTo, req.Body) {
+		return CommsResponse{Error: "message not found: " + req.ReplyTo}
+	}
+
+	cs.logMessage("draft_queued", "", "", "", req.Body, req.ReplyTo)
+	return CommsResponse{OK: true}
 }
 
 func (cs *CommsServer) sendMessage(req CommsRequest) CommsResponse {

--- a/core/launch/commsserver.go
+++ b/core/launch/commsserver.go
@@ -377,7 +377,6 @@ func (cs *CommsServer) promptSendApproval(service, channel, body string) string 
 // user-authored replies from the overlay (the user typed it, so no
 // approval is needed).
 func (cs *CommsServer) DirectSend(service, channel, body string) error {
-	fmt.Fprintf(os.Stderr, "aileron: DEBUG DirectSend: service=%q channel=%q body_len=%d senders=%v\n", service, channel, len(body), cs.senderNames())
 	sender, ok := cs.senders[service]
 	if !ok {
 		return fmt.Errorf("no listener for service: %s", service)
@@ -386,21 +385,10 @@ func (cs *CommsServer) DirectSend(service, channel, body string) error {
 		Channel: channel,
 		Body:    body,
 	})
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "aileron: DEBUG DirectSend error: %v\n", err)
-	} else {
-		fmt.Fprintf(os.Stderr, "aileron: DEBUG DirectSend success\n")
+	if err == nil {
 		cs.logMessage("reply_sent", service, channel, "", body, "")
 	}
 	return err
-}
-
-func (cs *CommsServer) senderNames() []string {
-	names := make([]string, 0, len(cs.senders))
-	for k := range cs.senders {
-		names = append(names, k)
-	}
-	return names
 }
 
 // SetSecrets configures the secrets mapping and vault for http_request

--- a/core/launch/commsserver_test.go
+++ b/core/launch/commsserver_test.go
@@ -1096,3 +1096,127 @@ func TestCommsServer_ReadMessages_FilterByChannel(t *testing.T) {
 		t.Errorf("expected 1 #frontend message, got %v", resp.Messages)
 	}
 }
+
+func TestCommsServer_DraftReply(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-draftreply.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	queue := launch.NewNotifyQueue(10, nil)
+	queue.Push(launch.Message{ID: "msg-1", Source: "slack", Channel: "#backend", Author: "Alice", Body: "question?"})
+
+	srv, err := launch.NewCommsServer(socketPath, queue, nil, nil, copier, nil, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	go srv.Serve()
+	time.Sleep(100 * time.Millisecond)
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{
+		Method:  "draft_reply",
+		ReplyTo: "msg-1",
+		Body:    "Here is my draft.",
+	})
+	if !resp.OK {
+		t.Fatalf("expected OK, got error: %s", resp.Error)
+	}
+
+	// Verify draft was set on the message.
+	msg, ok := queue.FindByID("msg-1")
+	if !ok {
+		t.Fatal("message not found")
+	}
+	if msg.Draft != "Here is my draft." {
+		t.Errorf("expected draft text, got %q", msg.Draft)
+	}
+}
+
+func TestCommsServer_DraftReply_MissingFields(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-draftreply-missing.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	srv, err := launch.NewCommsServer(socketPath, launch.NewNotifyQueue(10, nil), nil, nil, copier, nil, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	go srv.Serve()
+	time.Sleep(100 * time.Millisecond)
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{
+		Method: "draft_reply",
+	})
+	if resp.OK {
+		t.Error("expected error for missing fields")
+	}
+}
+
+func TestCommsServer_DraftReply_NotFound(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-draftreply-notfound.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	srv, err := launch.NewCommsServer(socketPath, launch.NewNotifyQueue(10, nil), nil, nil, copier, nil, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	go srv.Serve()
+	time.Sleep(100 * time.Millisecond)
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{
+		Method:  "draft_reply",
+		ReplyTo: "nonexistent",
+		Body:    "draft text",
+	})
+	if resp.OK {
+		t.Error("expected error for nonexistent message")
+	}
+}
+
+func TestCommsServer_ReadMessages_DraftRequestFlag(t *testing.T) {
+	socketPath := os.TempDir() + "/aileron-test-comms-draftflag.sock"
+	t.Cleanup(func() { os.Remove(socketPath) })
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	queue := launch.NewNotifyQueue(10, nil)
+	queue.Push(launch.Message{ID: "1", Source: "slack", Channel: "#ch", AutoDraft: true})
+	queue.Push(launch.Message{ID: "2", Source: "slack", Channel: "#ch", AutoDraft: false})
+
+	srv, err := launch.NewCommsServer(socketPath, queue, nil, nil, copier, nil, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+	go srv.Serve()
+	time.Sleep(100 * time.Millisecond)
+
+	resp := launch.RequestComms(socketPath, launch.CommsRequest{Method: "read_messages"})
+	if len(resp.Messages) != 2 {
+		t.Fatalf("expected 2 messages, got %d", len(resp.Messages))
+	}
+	if !resp.Messages[0].DraftRequest {
+		t.Error("expected DraftRequest=true on auto-draft message")
+	}
+	if resp.Messages[1].DraftRequest {
+		t.Error("expected DraftRequest=false on non-auto-draft message")
+	}
+}

--- a/core/launch/draftinjector.go
+++ b/core/launch/draftinjector.go
@@ -22,8 +22,8 @@ func NewDraftInjector(ptmx io.Writer) *DraftInjector {
 // agent's pty. The trailing newline submits it as user input.
 func (di *DraftInjector) Inject(msg Message) {
 	prompt := fmt.Sprintf(
-		"You have a new message to draft a reply to. Use the read_messages tool to see it, then use the draft_reply tool with message_id=%q and your suggested reply. Do not use send_message.\n",
-		msg.ID,
+		"I got this message from %s in %s: %q — draft a reply for me using draft_reply with message_id=%q\n",
+		msg.Author, msg.Channel, msg.Body, msg.ID,
 	)
 	di.ptmx.Write([]byte(prompt))
 }
@@ -32,7 +32,7 @@ func (di *DraftInjector) Inject(msg Message) {
 // feedback so the agent can produce an improved draft.
 func (di *DraftInjector) InjectRevision(msg Message, feedback string) {
 	prompt := fmt.Sprintf(
-		"The user wants you to revise your draft reply to message %q. Feedback: %q Use the draft_reply tool with your revised text. Do not use send_message.\n",
+		"Revise the draft reply to message %q — %s. Use draft_reply with your revised text.\n",
 		msg.ID, feedback,
 	)
 	di.ptmx.Write([]byte(prompt))

--- a/core/launch/draftinjector.go
+++ b/core/launch/draftinjector.go
@@ -7,7 +7,8 @@ import (
 
 // DraftInjector writes draft-request prompts into the agent's pty stdin.
 // When the agent reads from stdin, it sees the prompt as user input and
-// can use the send_message MCP tool to draft a reply.
+// uses the draft_reply MCP tool to submit draft text for user review.
+// Aileron handles sending — the agent only drafts.
 type DraftInjector struct {
 	ptmx io.Writer
 }
@@ -21,19 +22,18 @@ func NewDraftInjector(ptmx io.Writer) *DraftInjector {
 // agent's pty. The trailing newline submits it as user input.
 func (di *DraftInjector) Inject(msg Message) {
 	prompt := fmt.Sprintf(
-		"A teammate sent a message in %s. %s says: %q Please draft a reply using the send_message tool with service=%q and channel=%q.\n",
-		msg.Channel, msg.Author, msg.Body, msg.Source, msg.Channel,
+		"You have a new message to draft a reply to. Use the read_messages tool to see it, then use the draft_reply tool with message_id=%q and your suggested reply. Do not use send_message.\n",
+		msg.ID,
 	)
 	di.ptmx.Write([]byte(prompt))
 }
 
-// InjectRevision writes a revision prompt that includes the original
-// message, the current draft, and the user's feedback so the agent can
-// produce an improved draft.
+// InjectRevision writes a revision prompt that includes the user's
+// feedback so the agent can produce an improved draft.
 func (di *DraftInjector) InjectRevision(msg Message, feedback string) {
 	prompt := fmt.Sprintf(
-		"A teammate sent a message in %s. %s says: %q Your previous draft reply was: %q The user wants you to revise. Feedback: %q Please draft a new reply using the send_message tool with service=%q and channel=%q.\n",
-		msg.Channel, msg.Author, msg.Body, msg.Draft, feedback, msg.Source, msg.Channel,
+		"The user wants you to revise your draft reply to message %q. Feedback: %q Use the draft_reply tool with your revised text. Do not use send_message.\n",
+		msg.ID, feedback,
 	)
 	di.ptmx.Write([]byte(prompt))
 }

--- a/core/launch/draftinjector.go
+++ b/core/launch/draftinjector.go
@@ -26,3 +26,14 @@ func (di *DraftInjector) Inject(msg Message) {
 	)
 	di.ptmx.Write([]byte(prompt))
 }
+
+// InjectRevision writes a revision prompt that includes the original
+// message, the current draft, and the user's feedback so the agent can
+// produce an improved draft.
+func (di *DraftInjector) InjectRevision(msg Message, feedback string) {
+	prompt := fmt.Sprintf(
+		"A teammate sent a message in %s. %s says: %q Your previous draft reply was: %q The user wants you to revise. Feedback: %q Please draft a new reply using the send_message tool with service=%q and channel=%q.\n",
+		msg.Channel, msg.Author, msg.Body, msg.Draft, feedback, msg.Source, msg.Channel,
+	)
+	di.ptmx.Write([]byte(prompt))
+}

--- a/core/launch/draftinjector_test.go
+++ b/core/launch/draftinjector_test.go
@@ -62,3 +62,43 @@ func TestDraftInjector_InjectMultiple(t *testing.T) {
 		t.Error("expected second author")
 	}
 }
+
+func TestDraftInjector_InjectRevision(t *testing.T) {
+	var buf bytes.Buffer
+	di := launch.NewDraftInjector(&buf)
+
+	di.InjectRevision(launch.Message{
+		Source:  "slack",
+		Channel: "#backend",
+		Author:  "Sarah",
+		Body:    "Does the new auth middleware change the JWT claims?",
+		Draft:   "Yes, we added a role claim.",
+	}, "make it more casual and mention the PR number")
+
+	out := buf.String()
+
+	if !strings.Contains(out, "#backend") {
+		t.Error("expected channel in revision prompt")
+	}
+	if !strings.Contains(out, "Sarah") {
+		t.Error("expected author in revision prompt")
+	}
+	if !strings.Contains(out, "JWT claims") {
+		t.Error("expected original message body in revision prompt")
+	}
+	if !strings.Contains(out, "Yes, we added a role claim.") {
+		t.Error("expected previous draft in revision prompt")
+	}
+	if !strings.Contains(out, "make it more casual") {
+		t.Error("expected user feedback in revision prompt")
+	}
+	if !strings.Contains(out, "send_message") {
+		t.Error("expected send_message tool reference in revision prompt")
+	}
+	if !strings.Contains(out, `service="slack"`) {
+		t.Error("expected service parameter in revision prompt")
+	}
+	if !strings.HasSuffix(out, "\n") {
+		t.Error("expected trailing newline to submit as user input")
+	}
+}

--- a/core/launch/draftinjector_test.go
+++ b/core/launch/draftinjector_test.go
@@ -13,6 +13,7 @@ func TestDraftInjector_Inject(t *testing.T) {
 	di := launch.NewDraftInjector(&buf)
 
 	di.Inject(launch.Message{
+		ID:      "msg-1",
 		Source:  "slack",
 		Channel: "#backend",
 		Author:  "Sarah",
@@ -21,23 +22,14 @@ func TestDraftInjector_Inject(t *testing.T) {
 
 	out := buf.String()
 
-	if !strings.Contains(out, "#backend") {
-		t.Error("expected channel in injected prompt")
+	if !strings.Contains(out, "msg-1") {
+		t.Error("expected message ID in injected prompt")
 	}
-	if !strings.Contains(out, "Sarah") {
-		t.Error("expected author in injected prompt")
+	if !strings.Contains(out, "read_messages") {
+		t.Error("expected read_messages tool reference in injected prompt")
 	}
-	if !strings.Contains(out, "JWT claims") {
-		t.Error("expected message body in injected prompt")
-	}
-	if !strings.Contains(out, "send_message") {
-		t.Error("expected send_message tool reference in injected prompt")
-	}
-	if !strings.Contains(out, `service="slack"`) {
-		t.Error("expected service parameter in injected prompt")
-	}
-	if !strings.Contains(out, `channel="#backend"`) {
-		t.Error("expected channel parameter in injected prompt")
+	if !strings.Contains(out, "draft_reply") {
+		t.Error("expected draft_reply tool reference in injected prompt")
 	}
 	if !strings.HasSuffix(out, "\n") {
 		t.Error("expected trailing newline to submit as user input")
@@ -48,18 +40,12 @@ func TestDraftInjector_InjectMultiple(t *testing.T) {
 	var buf bytes.Buffer
 	di := launch.NewDraftInjector(&buf)
 
-	di.Inject(launch.Message{Source: "slack", Channel: "#general", Author: "Alice", Body: "first"})
-	di.Inject(launch.Message{Source: "discord", Channel: "dev-chat", Author: "Bob", Body: "second"})
+	di.Inject(launch.Message{ID: "1", Source: "slack", Channel: "#general", Author: "Alice", Body: "first"})
+	di.Inject(launch.Message{ID: "2", Source: "discord", Channel: "dev-chat", Author: "Bob", Body: "second"})
 
 	out := buf.String()
 	if strings.Count(out, "\n") != 2 {
 		t.Errorf("expected 2 newlines for 2 injections, got %d", strings.Count(out, "\n"))
-	}
-	if !strings.Contains(out, "Alice") {
-		t.Error("expected first author")
-	}
-	if !strings.Contains(out, "Bob") {
-		t.Error("expected second author")
 	}
 }
 
@@ -68,6 +54,7 @@ func TestDraftInjector_InjectRevision(t *testing.T) {
 	di := launch.NewDraftInjector(&buf)
 
 	di.InjectRevision(launch.Message{
+		ID:      "msg-1",
 		Source:  "slack",
 		Channel: "#backend",
 		Author:  "Sarah",
@@ -77,26 +64,14 @@ func TestDraftInjector_InjectRevision(t *testing.T) {
 
 	out := buf.String()
 
-	if !strings.Contains(out, "#backend") {
-		t.Error("expected channel in revision prompt")
-	}
-	if !strings.Contains(out, "Sarah") {
-		t.Error("expected author in revision prompt")
-	}
-	if !strings.Contains(out, "JWT claims") {
-		t.Error("expected original message body in revision prompt")
-	}
-	if !strings.Contains(out, "Yes, we added a role claim.") {
-		t.Error("expected previous draft in revision prompt")
+	if !strings.Contains(out, "msg-1") {
+		t.Error("expected message ID in revision prompt")
 	}
 	if !strings.Contains(out, "make it more casual") {
 		t.Error("expected user feedback in revision prompt")
 	}
-	if !strings.Contains(out, "send_message") {
-		t.Error("expected send_message tool reference in revision prompt")
-	}
-	if !strings.Contains(out, `service="slack"`) {
-		t.Error("expected service parameter in revision prompt")
+	if !strings.Contains(out, "draft_reply") {
+		t.Error("expected draft_reply tool reference in revision prompt")
 	}
 	if !strings.HasSuffix(out, "\n") {
 		t.Error("expected trailing newline to submit as user input")

--- a/core/launch/draftinjector_test.go
+++ b/core/launch/draftinjector_test.go
@@ -25,11 +25,14 @@ func TestDraftInjector_Inject(t *testing.T) {
 	if !strings.Contains(out, "msg-1") {
 		t.Error("expected message ID in injected prompt")
 	}
-	if !strings.Contains(out, "read_messages") {
-		t.Error("expected read_messages tool reference in injected prompt")
-	}
 	if !strings.Contains(out, "draft_reply") {
 		t.Error("expected draft_reply tool reference in injected prompt")
+	}
+	if !strings.Contains(out, "Sarah") {
+		t.Error("expected author in injected prompt")
+	}
+	if !strings.Contains(out, "#backend") {
+		t.Error("expected channel in injected prompt")
 	}
 	if !strings.HasSuffix(out, "\n") {
 		t.Error("expected trailing newline to submit as user input")

--- a/core/launch/export_test.go
+++ b/core/launch/export_test.go
@@ -5,3 +5,9 @@ var OpenSessionLogger = openSessionLogger
 
 // SessionLogPath exposes sessionLogPath for testing.
 var SessionLogPath = sessionLogPath
+
+// WrapTextForTest exposes wrapText for testing.
+var WrapTextForTest = wrapText
+
+// VisibleWidthForTest exposes visibleWidth for testing.
+var VisibleWidthForTest = visibleWidth

--- a/core/launch/keyrouter.go
+++ b/core/launch/keyrouter.go
@@ -8,9 +8,14 @@ import (
 )
 
 const (
-	// ctrlA is the byte value for Ctrl-A in raw terminal mode.
-	ctrlA = 0x01
-	// doubleTapTimeout is the window for a second Ctrl-A to pass through
+	// overlayPrefix is the traditional byte value for Ctrl-] in raw
+	// terminal mode. Modern terminals using the kitty keyboard protocol
+	// encode this as CSI 93;5u instead, which the router also recognises.
+	overlayPrefix = 0x1D
+	// overlayCodepoint is the Unicode codepoint for ']' (used in kitty
+	// keyboard protocol CSI u sequences: ESC [ 93 ; <mod> u).
+	overlayCodepoint = 93
+	// doubleTapTimeout is the window for a second Ctrl-] to pass through
 	// as a literal byte (like tmux prefix handling).
 	doubleTapTimeout = 500 * time.Millisecond
 )
@@ -26,9 +31,13 @@ type OverlayController interface {
 }
 
 // KeyRouter reads from stdin byte-by-byte and routes keystrokes to
-// either the pty (normal mode) or the overlay (overlay mode). Ctrl-A
-// toggles overlay mode. Double Ctrl-A within 500ms sends a literal
-// Ctrl-A to the pty.
+// either the pty (normal mode) or the overlay (overlay mode). Ctrl-]
+// toggles overlay mode. Double Ctrl-] within 500ms sends a literal
+// Ctrl-] to the pty.
+//
+// The router recognises Ctrl-] both as the traditional byte 0x1D and as
+// the kitty keyboard protocol encoding ESC [ 93 ; <mod> u (where mod
+// indicates Ctrl is held, i.e. mod & 4 != 0).
 type KeyRouter struct {
 	stdin   io.Reader
 	ptmx    io.Writer
@@ -37,12 +46,20 @@ type KeyRouter struct {
 	overlayActive atomic.Bool
 
 	mu           sync.Mutex
-	pendingCtrlA bool
-	ctrlATimer   *time.Timer
+	pendingPrefix bool
+	prefixTimer   *time.Timer
 
 	// inputSink, when set, receives all stdin bytes instead of routing
 	// them to the pty or overlay. Used by the approval server.
 	inputSink chan byte
+
+	// CSI u state machine for kitty keyboard protocol detection.
+	// States: 0=normal, 1=got ESC, 2=got ESC+[, 3=accumulating codepoint
+	// digits, 4=got semicolon, 5=accumulating modifier digits.
+	csiState    int
+	csiCP       int // accumulated codepoint
+	csiMod      int // accumulated modifier
+	csiBuf      []byte // buffered bytes for replay on mismatch
 }
 
 // NewKeyRouter creates a key router that reads from stdin and writes
@@ -55,8 +72,6 @@ func NewKeyRouter(stdin io.Reader, ptmx io.Writer, overlay OverlayController) *K
 	}
 }
 
-// Run reads from stdin and routes each byte. This blocks until stdin
-// returns an error or EOF. Call in a goroutine.
 // StealInput redirects all stdin bytes to the returned channel.
 // Call ReleaseInput to restore normal routing.
 func (kr *KeyRouter) StealInput() <-chan byte {
@@ -77,6 +92,8 @@ func (kr *KeyRouter) ReleaseInput() {
 	}
 }
 
+// Run reads from stdin and routes each byte. This blocks until stdin
+// returns an error or EOF. Call in a goroutine.
 func (kr *KeyRouter) Run() {
 	buf := make([]byte, 1)
 	for {
@@ -100,50 +117,180 @@ func (kr *KeyRouter) Run() {
 			continue
 		}
 
-		if b == ctrlA {
-			kr.handleCtrlA()
+		// Feed byte through the CSI u state machine. If it detects the
+		// overlay prefix sequence, it calls handlePrefix and returns true.
+		// If the sequence is incomplete, the byte is buffered and we
+		// continue reading. If the sequence doesn't match, buffered bytes
+		// are replayed to the normal routing path.
+		if kr.feedCSIu(b) {
 			continue
 		}
 
-		kr.mu.Lock()
-		if kr.pendingCtrlA {
-			// Non-Ctrl-A byte after a pending Ctrl-A — activate overlay
-			// and forward this byte to the overlay.
-			kr.pendingCtrlA = false
-			if kr.ctrlATimer != nil {
-				kr.ctrlATimer.Stop()
-			}
-			kr.mu.Unlock()
-			kr.activateOverlay()
-			kr.overlay.HandleKey(b)
-			continue
-		}
-		kr.mu.Unlock()
-
-		kr.ptmx.Write(buf[:n])
+		kr.routeByte(b)
 	}
 }
 
-func (kr *KeyRouter) handleCtrlA() {
-	kr.mu.Lock()
-	defer kr.mu.Unlock()
-
-	if kr.pendingCtrlA {
-		// Double Ctrl-A — send literal Ctrl-A to pty.
-		kr.pendingCtrlA = false
-		if kr.ctrlATimer != nil {
-			kr.ctrlATimer.Stop()
-		}
-		kr.ptmx.Write([]byte{ctrlA})
+// routeByte handles a single byte through the normal (non-CSI-u) path:
+// overlay prefix detection, pending-prefix handling, or passthrough to pty.
+func (kr *KeyRouter) routeByte(b byte) {
+	if b == overlayPrefix {
+		kr.handlePrefix()
 		return
 	}
 
-	// First Ctrl-A — start the timer.
-	kr.pendingCtrlA = true
-	kr.ctrlATimer = time.AfterFunc(doubleTapTimeout, func() {
+	kr.mu.Lock()
+	if kr.pendingPrefix {
+		// Non-prefix byte after a pending Ctrl-] — activate overlay
+		// and forward this byte to the overlay.
+		kr.pendingPrefix = false
+		if kr.prefixTimer != nil {
+			kr.prefixTimer.Stop()
+		}
+		kr.mu.Unlock()
+		kr.activateOverlay()
+		kr.overlay.HandleKey(b)
+		return
+	}
+	kr.mu.Unlock()
+
+	kr.ptmx.Write([]byte{b})
+}
+
+// feedCSIu advances the kitty keyboard protocol state machine. Returns
+// true if the byte was consumed (buffered or matched). When a complete
+// CSI u sequence matching the overlay prefix is detected, handlePrefix
+// is called. On mismatch, all buffered bytes are replayed through
+// routeByte.
+func (kr *KeyRouter) feedCSIu(b byte) bool {
+	switch kr.csiState {
+	case 0: // normal
+		if b == 0x1B {
+			kr.csiState = 1
+			kr.csiBuf = append(kr.csiBuf[:0], b)
+			return true
+		}
+		return false
+
+	case 1: // got ESC
+		kr.csiBuf = append(kr.csiBuf, b)
+		if b == '[' {
+			kr.csiState = 2
+			return true
+		}
+		// Not a CSI sequence — replay buffered bytes.
+		kr.replayCSIBuf()
+		return true
+
+	case 2: // got ESC + [
+		kr.csiBuf = append(kr.csiBuf, b)
+		if b >= '0' && b <= '9' {
+			kr.csiCP = int(b - '0')
+			kr.csiState = 3
+			return true
+		}
+		// Not a numeric codepoint — replay.
+		kr.replayCSIBuf()
+		return true
+
+	case 3: // accumulating codepoint digits
+		kr.csiBuf = append(kr.csiBuf, b)
+		if b >= '0' && b <= '9' {
+			kr.csiCP = kr.csiCP*10 + int(b-'0')
+			return true
+		}
+		if b == ';' {
+			kr.csiState = 4
+			return true
+		}
+		if b == 'u' {
+			// CSI <cp> u with no modifier — not Ctrl, replay.
+			kr.replayCSIBuf()
+			return true
+		}
+		// Not a CSI u sequence — replay.
+		kr.replayCSIBuf()
+		return true
+
+	case 4: // got semicolon, expecting modifier digits
+		kr.csiBuf = append(kr.csiBuf, b)
+		if b >= '0' && b <= '9' {
+			kr.csiMod = int(b - '0')
+			kr.csiState = 5
+			return true
+		}
+		// Not a digit after semicolon — replay.
+		kr.replayCSIBuf()
+		return true
+
+	case 5: // accumulating modifier digits
+		kr.csiBuf = append(kr.csiBuf, b)
+		if b >= '0' && b <= '9' {
+			kr.csiMod = kr.csiMod*10 + int(b-'0')
+			return true
+		}
+		if b == 'u' {
+			// Complete CSI <codepoint> ; <modifier> u sequence.
+			// Modifier uses xterm encoding: value = 1 + bitmask.
+			// Ctrl = bit 2 (value 4), so mod & 4 != 0 means Ctrl held.
+			isCtrl := (kr.csiMod-1)&0x04 != 0
+			cp := kr.csiCP
+			if cp == overlayCodepoint && isCtrl {
+				kr.resetCSI()
+				kr.handlePrefix()
+				return true
+			}
+			// Not our prefix — send the raw sequence to the pty.
+			saved := make([]byte, len(kr.csiBuf))
+			copy(saved, kr.csiBuf)
+			kr.resetCSI()
+			kr.ptmx.Write(saved)
+			return true
+		}
+		// Unexpected terminator — replay.
+		kr.replayCSIBuf()
+		return true
+	}
+
+	return false
+}
+
+// replayCSIBuf replays all buffered CSI bytes through routeByte and resets state.
+func (kr *KeyRouter) replayCSIBuf() {
+	saved := make([]byte, len(kr.csiBuf))
+	copy(saved, kr.csiBuf)
+	kr.resetCSI()
+	for _, rb := range saved {
+		kr.routeByte(rb)
+	}
+}
+
+func (kr *KeyRouter) resetCSI() {
+	kr.csiState = 0
+	kr.csiCP = 0
+	kr.csiMod = 0
+	kr.csiBuf = kr.csiBuf[:0]
+}
+
+func (kr *KeyRouter) handlePrefix() {
+	kr.mu.Lock()
+	defer kr.mu.Unlock()
+
+	if kr.pendingPrefix {
+		// Double Ctrl-] — send literal Ctrl-] to pty.
+		kr.pendingPrefix = false
+		if kr.prefixTimer != nil {
+			kr.prefixTimer.Stop()
+		}
+		kr.ptmx.Write([]byte{overlayPrefix})
+		return
+	}
+
+	// First Ctrl-] — start the timer.
+	kr.pendingPrefix = true
+	kr.prefixTimer = time.AfterFunc(doubleTapTimeout, func() {
 		kr.mu.Lock()
-		pending := kr.pendingCtrlA
-		kr.pendingCtrlA = false
+		pending := kr.pendingPrefix
+		kr.pendingPrefix = false
 		kr.mu.Unlock()
 
 		if pending {

--- a/core/launch/keyrouter_test.go
+++ b/core/launch/keyrouter_test.go
@@ -326,3 +326,69 @@ func TestKeyRouter_CSIu_CtrlShiftBracket_ActivatesOverlay(t *testing.T) {
 		t.Error("overlay should have been shown for Ctrl+Shift+] CSI u")
 	}
 }
+
+func TestKeyRouter_CSIu_NoModifier_PassesThrough(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &mockOverlay{}
+
+	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go kr.Run()
+
+	// CSI 93 u — codepoint ']' but no modifier (bare key, no Ctrl).
+	stdinW.Write([]byte("\x1b[93u"))
+	time.Sleep(50 * time.Millisecond)
+	stdinW.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if overlay.wasShown() {
+		t.Error("overlay should not show for bare ] without Ctrl modifier")
+	}
+}
+
+func TestKeyRouter_CSIu_EscNonBracket_PassesThrough(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &mockOverlay{}
+
+	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go kr.Run()
+
+	// ESC followed by 'O' (not '[') — e.g. SS3 sequence. Should pass through.
+	stdinW.Write([]byte("\x1bOP"))
+	time.Sleep(50 * time.Millisecond)
+	stdinW.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if overlay.wasShown() {
+		t.Error("overlay should not show for SS3 sequence")
+	}
+	if ptmxBuf.Len() == 0 {
+		t.Error("expected SS3 sequence to pass to pty")
+	}
+}
+
+func TestKeyRouter_CSIu_IncompleteSequence_PassesThrough(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &mockOverlay{}
+
+	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go kr.Run()
+
+	// ESC [ followed by a non-digit — incomplete CSI u, should replay.
+	stdinW.Write([]byte("\x1b[X"))
+	time.Sleep(50 * time.Millisecond)
+	stdinW.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if overlay.wasShown() {
+		t.Error("overlay should not show for incomplete CSI sequence")
+	}
+	if ptmxBuf.Len() == 0 {
+		t.Error("expected incomplete sequence to pass to pty")
+	}
+}

--- a/core/launch/keyrouter_test.go
+++ b/core/launch/keyrouter_test.go
@@ -80,7 +80,7 @@ func TestKeyRouter_NormalBytesPassThrough(t *testing.T) {
 	}
 }
 
-func TestKeyRouter_CtrlA_ActivatesOverlay(t *testing.T) {
+func TestKeyRouter_CtrlBracket_ActivatesOverlay(t *testing.T) {
 	stdinR, stdinW := io.Pipe()
 	ptmxBuf := &safeBuf{}
 	overlay := &mockOverlay{}
@@ -88,20 +88,20 @@ func TestKeyRouter_CtrlA_ActivatesOverlay(t *testing.T) {
 	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
 	go kr.Run()
 
-	// Send Ctrl-A then wait for the timeout to fire.
-	stdinW.Write([]byte{0x01})
+	// Send Ctrl-] then wait for the timeout to fire.
+	stdinW.Write([]byte{0x1D})
 	time.Sleep(600 * time.Millisecond)
 	stdinW.Close()
 
 	if !overlay.wasShown() {
-		t.Error("overlay should have been shown after Ctrl-A timeout")
+		t.Error("overlay should have been shown after Ctrl-] timeout")
 	}
 	if ptmxBuf.Len() != 0 {
-		t.Errorf("Ctrl-A should not have passed to pty, got %q", ptmxBuf.String())
+		t.Errorf("Ctrl-] should not have passed to pty, got %q", ptmxBuf.String())
 	}
 }
 
-func TestKeyRouter_DoubleCtrlA_PassesThrough(t *testing.T) {
+func TestKeyRouter_DoubleCtrlBracket_PassesThrough(t *testing.T) {
 	stdinR, stdinW := io.Pipe()
 	ptmxBuf := &safeBuf{}
 	overlay := &mockOverlay{}
@@ -109,24 +109,24 @@ func TestKeyRouter_DoubleCtrlA_PassesThrough(t *testing.T) {
 	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
 	go kr.Run()
 
-	// Double Ctrl-A within the timeout window.
-	stdinW.Write([]byte{0x01})
+	// Double Ctrl-] within the timeout window.
+	stdinW.Write([]byte{0x1D})
 	time.Sleep(50 * time.Millisecond)
-	stdinW.Write([]byte{0x01})
+	stdinW.Write([]byte{0x1D})
 	time.Sleep(50 * time.Millisecond)
 	stdinW.Close()
 
 	time.Sleep(50 * time.Millisecond)
 
 	if overlay.wasShown() {
-		t.Error("overlay should not have been shown for double Ctrl-A")
+		t.Error("overlay should not have been shown for double Ctrl-]")
 	}
-	if ptmxBuf.String() != "\x01" {
-		t.Errorf("expected literal Ctrl-A in pty, got %q", ptmxBuf.String())
+	if ptmxBuf.String() != "\x1D" {
+		t.Errorf("expected literal Ctrl-] in pty, got %q", ptmxBuf.String())
 	}
 }
 
-func TestKeyRouter_CtrlAThenKey_ActivatesAndForwards(t *testing.T) {
+func TestKeyRouter_CtrlBracketThenKey_ActivatesAndForwards(t *testing.T) {
 	stdinR, stdinW := io.Pipe()
 	ptmxBuf := &safeBuf{}
 	overlay := &mockOverlay{}
@@ -134,9 +134,9 @@ func TestKeyRouter_CtrlAThenKey_ActivatesAndForwards(t *testing.T) {
 	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
 	go kr.Run()
 
-	// Ctrl-A followed by a regular key before timeout — activates overlay
+	// Ctrl-] followed by a regular key before timeout — activates overlay
 	// and forwards the key to the overlay.
-	stdinW.Write([]byte{0x01})
+	stdinW.Write([]byte{0x1D})
 	time.Sleep(50 * time.Millisecond)
 	stdinW.Write([]byte{'x'})
 	time.Sleep(50 * time.Millisecond)
@@ -164,8 +164,8 @@ func TestKeyRouter_OverlayMode_KeysGoToOverlay(t *testing.T) {
 	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
 	go kr.Run()
 
-	// Activate overlay via Ctrl-A + timeout.
-	stdinW.Write([]byte{0x01})
+	// Activate overlay via Ctrl-] + timeout.
+	stdinW.Write([]byte{0x1D})
 	time.Sleep(600 * time.Millisecond)
 
 	// Now send keys — they should go to the overlay, not the pty.
@@ -193,7 +193,7 @@ func TestKeyRouter_DeactivateOverlay(t *testing.T) {
 	go kr.Run()
 
 	// Activate overlay.
-	stdinW.Write([]byte{0x01})
+	stdinW.Write([]byte{0x1D})
 	time.Sleep(600 * time.Millisecond)
 
 	// Deactivate.
@@ -209,5 +209,120 @@ func TestKeyRouter_DeactivateOverlay(t *testing.T) {
 
 	if ptmxBuf.String() != "after" {
 		t.Errorf("expected 'after' in pty after deactivate, got %q", ptmxBuf.String())
+	}
+}
+
+// CSI u (kitty keyboard protocol) tests.
+
+func TestKeyRouter_CSIu_CtrlBracket_ActivatesOverlay(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &mockOverlay{}
+
+	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go kr.Run()
+
+	// Send CSI u encoding of Ctrl-]: ESC [ 93 ; 5 u
+	// (codepoint 93 = ']', modifier 5 = 1+4 where 4=Ctrl)
+	stdinW.Write([]byte("\x1b[93;5u"))
+	time.Sleep(600 * time.Millisecond)
+	stdinW.Close()
+
+	if !overlay.wasShown() {
+		t.Error("overlay should have been shown after CSI u Ctrl-]")
+	}
+	if ptmxBuf.Len() != 0 {
+		t.Errorf("CSI u Ctrl-] should not pass to pty, got %q", ptmxBuf.String())
+	}
+}
+
+func TestKeyRouter_CSIu_DoubleCtrlBracket_PassesThrough(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &mockOverlay{}
+
+	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go kr.Run()
+
+	// Two CSI u Ctrl-] within the timeout window.
+	stdinW.Write([]byte("\x1b[93;5u"))
+	time.Sleep(50 * time.Millisecond)
+	stdinW.Write([]byte("\x1b[93;5u"))
+	time.Sleep(50 * time.Millisecond)
+	stdinW.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if overlay.wasShown() {
+		t.Error("overlay should not have been shown for double CSI u Ctrl-]")
+	}
+	if ptmxBuf.String() != "\x1D" {
+		t.Errorf("expected literal 0x1D in pty, got %q", ptmxBuf.String())
+	}
+}
+
+func TestKeyRouter_CSIu_NonPrefix_PassesThrough(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &mockOverlay{}
+
+	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go kr.Run()
+
+	// Send CSI u encoding of Ctrl-A: ESC [ 97 ; 5 u — not our prefix.
+	stdinW.Write([]byte("\x1b[97;5u"))
+	time.Sleep(50 * time.Millisecond)
+	stdinW.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if overlay.wasShown() {
+		t.Error("overlay should not show for Ctrl-A CSI u")
+	}
+	// The raw sequence should pass through to the pty.
+	if ptmxBuf.Len() == 0 {
+		t.Error("expected non-prefix CSI u sequence to pass to pty")
+	}
+}
+
+func TestKeyRouter_CSIu_OtherEscSequence_PassesThrough(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &mockOverlay{}
+
+	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go kr.Run()
+
+	// Arrow up: ESC [ A — not a CSI u sequence.
+	stdinW.Write([]byte("\x1b[A"))
+	time.Sleep(50 * time.Millisecond)
+	stdinW.Close()
+
+	time.Sleep(50 * time.Millisecond)
+
+	if overlay.wasShown() {
+		t.Error("overlay should not show for arrow key")
+	}
+	if ptmxBuf.Len() == 0 {
+		t.Error("expected arrow key sequence to pass to pty")
+	}
+}
+
+func TestKeyRouter_CSIu_CtrlShiftBracket_ActivatesOverlay(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &mockOverlay{}
+
+	kr := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go kr.Run()
+
+	// Ctrl+Shift+]: ESC [ 93 ; 6 u (modifier 6 = 1+4+1 = Ctrl+Shift)
+	// Should still activate because Ctrl bit is set.
+	stdinW.Write([]byte("\x1b[93;6u"))
+	time.Sleep(600 * time.Millisecond)
+	stdinW.Close()
+
+	if !overlay.wasShown() {
+		t.Error("overlay should have been shown for Ctrl+Shift+] CSI u")
 	}
 }

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -113,7 +113,8 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 
 	// If the comms socket is set, register aileron-mcp as an MCP server
 	// so the agent has access to read_messages, draft_reply, etc.
-	if mcpBin, err := resolveSibling(agentPath, "aileron-mcp"); err == nil {
+	selfPath, _ := os.Executable()
+	if mcpBin, err := resolveSibling(selfPath, "aileron-mcp"); err == nil {
 		mcpConfig := fmt.Sprintf(
 			`{"mcpServers":{"aileron":{"command":%q,"env":{"AILERON_COMMS_SOCKET":%q}}}}`,
 			mcpBin, commsSocket,

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -218,7 +218,7 @@ func launchWithPty(ctx context.Context, cmd *exec.Cmd, config LaunchConfig, queu
 	if commsConf != nil {
 		var v vault.Vault
 		if commsConf.needsVault {
-			v = PromptVaultWithPanel(outputCopier, router, bar)
+			v = PromptVaultWithPanel(outputCopier, router, bar, ptmx)
 		}
 		listeners = startCommsWithVault(ctx, commsConf, v, queue, auditLog, sessionID)
 	}

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -260,17 +260,19 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 	return exitResult(err)
 }
 
-// WireDraftInjection connects the overlay's draft-request action and the
-// queue's auto-draft callback to a DraftInjector that writes prompts into
-// the agent's pty stdin. Exported for testing.
+// WireDraftInjection connects the overlay's draft-request and converse
+// actions to a DraftInjector that writes prompts into the agent's pty
+// stdin. Auto-draft messages are NOT injected automatically — the user
+// must explicitly request a draft from the overlay. Exported for testing.
 func WireDraftInjection(ptmx io.Writer, overlay *Overlay, queue *NotifyQueue) {
 	injector := NewDraftInjector(ptmx)
 	overlay.OnDraftRequest = func(msg Message) {
 		injector.Inject(msg)
 	}
-	queue.SetOnAutoDraft(func(msg Message) {
-		injector.Inject(msg)
-	})
+	overlay.OnDraftConverse = func(msg Message, feedback string) {
+		injector.InjectRevision(msg, feedback)
+	}
+	// No queue.SetOnAutoDraft — user must open the overlay and press 'a'.
 }
 
 // WireReply connects the overlay's reply callback to the CommsServer's
@@ -299,9 +301,9 @@ func SetupTerminalScreen(w io.Writer, agentRows int, bar *StatusBar) {
 	fmt.Fprintf(w, "\033[1;1H")
 }
 
-// CleanupTerminalScreen clears the status bar area.
+// CleanupTerminalScreen clears the status bar area (3 rows).
 func CleanupTerminalScreen(w io.Writer, totalRows int) {
-	fmt.Fprintf(w, "\033[%d;1H\033[J", totalRows-1)
+	fmt.Fprintf(w, "\033[%d;1H\033[J", totalRows-2)
 }
 
 // HandleResize updates the pty size and re-renders the status bar after a

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -53,6 +53,17 @@ func ResolveBinary(names []string) (string, error) {
 	return "", fmt.Errorf("could not find any of %v on PATH", names)
 }
 
+// resolveSibling looks for a binary next to the given executable path,
+// then falls back to searching PATH.
+func resolveSibling(selfPath, name string) (string, error) {
+	dir := filepath.Dir(selfPath)
+	candidate := filepath.Join(dir, name)
+	if _, err := os.Stat(candidate); err == nil {
+		return filepath.Abs(candidate)
+	}
+	return exec.LookPath(name)
+}
+
 // ResolveShim looks for the aileron-sh binary next to the given executable
 // path, then falls back to searching PATH.
 func ResolveShim(selfPath string) (string, error) {
@@ -99,6 +110,17 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 
 	// Agent-required args come first, then user-supplied args.
 	allArgs := append(config.Agent.Args(), config.Args...)
+
+	// If the comms socket is set, register aileron-mcp as an MCP server
+	// so the agent has access to read_messages, draft_reply, etc.
+	if mcpBin, err := resolveSibling(agentPath, "aileron-mcp"); err == nil {
+		mcpConfig := fmt.Sprintf(
+			`{"mcpServers":{"aileron":{"command":%q,"env":{"AILERON_COMMS_SOCKET":%q}}}}`,
+			mcpBin, commsSocket,
+		)
+		allArgs = append(allArgs, "--mcp-config", mcpConfig)
+	}
+
 	cmd := exec.CommandContext(ctx, agentPath, allArgs...)
 	cmd.Env = env
 	if config.Dir != "" {

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -330,10 +330,16 @@ func WireReply(overlay *Overlay, commsSrv *CommsServer) {
 // text; Aileron sends it after user approval. Exported for testing.
 func WireDraftSend(overlay *Overlay, commsSrv *CommsServer) {
 	overlay.OnDraftApprove = func(msg Message) {
-		commsSrv.DirectSend(msg.Source, msg.Channel, msg.Draft)
+		fmt.Fprintf(os.Stderr, "aileron: DEBUG draft approve: source=%q channel=%q draft=%q\n", msg.Source, msg.Channel, msg.Draft)
+		if err := commsSrv.DirectSend(msg.Source, msg.Channel, msg.Draft); err != nil {
+			fmt.Fprintf(os.Stderr, "aileron: ERROR sending draft: %v\n", err)
+		}
 	}
 	overlay.OnDraftEdit = func(msg Message, edited string) {
-		commsSrv.DirectSend(msg.Source, msg.Channel, edited)
+		fmt.Fprintf(os.Stderr, "aileron: DEBUG draft edit send: source=%q channel=%q body=%q\n", msg.Source, msg.Channel, edited)
+		if err := commsSrv.DirectSend(msg.Source, msg.Channel, edited); err != nil {
+			fmt.Fprintf(os.Stderr, "aileron: ERROR sending edited draft: %v\n", err)
+		}
 	}
 }
 

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -330,16 +330,10 @@ func WireReply(overlay *Overlay, commsSrv *CommsServer) {
 // text; Aileron sends it after user approval. Exported for testing.
 func WireDraftSend(overlay *Overlay, commsSrv *CommsServer) {
 	overlay.OnDraftApprove = func(msg Message) {
-		fmt.Fprintf(os.Stderr, "aileron: DEBUG draft approve: source=%q channel=%q draft=%q\n", msg.Source, msg.Channel, msg.Draft)
-		if err := commsSrv.DirectSend(msg.Source, msg.Channel, msg.Draft); err != nil {
-			fmt.Fprintf(os.Stderr, "aileron: ERROR sending draft: %v\n", err)
-		}
+		commsSrv.DirectSend(msg.Source, msg.Channel, msg.Draft)
 	}
 	overlay.OnDraftEdit = func(msg Message, edited string) {
-		fmt.Fprintf(os.Stderr, "aileron: DEBUG draft edit send: source=%q channel=%q body=%q\n", msg.Source, msg.Channel, edited)
-		if err := commsSrv.DirectSend(msg.Source, msg.Channel, edited); err != nil {
-			fmt.Fprintf(os.Stderr, "aileron: ERROR sending edited draft: %v\n", err)
-		}
+		commsSrv.DirectSend(msg.Source, msg.Channel, edited)
 	}
 }
 

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -105,7 +105,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		cmd.Dir = config.Dir
 	}
 
-	// Create the notification queue and start any comms listeners.
+	// Create the notification queue and prepare comms config.
 	queue := NewNotifyQueue(100, nil)
 	wireQuietHours(config.Dir, queue)
 	sessionLog, closeSessionLog := openSessionLogger(config.Dir, config.LogLevel)
@@ -119,16 +119,20 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		"binary", agentPath,
 	)
 
-	listeners := startCommsListeners(ctx, config.Dir, queue, auditLog, sessionID, sessionLog)
-	defer stopCommsListeners(listeners)
+	commsConf := prepareCommsConfig(config.Dir, sessionLog)
 
 	// If stdin is a terminal, use the pty proxy with status bar.
+	// The pty path defers vault opening so it can show a Panel prompt.
 	var result LaunchResult
+	var listeners []comms.Listener
 	if term.IsTerminal(int(os.Stdin.Fd())) {
-		result, err = launchWithPty(cmd, config, queue, listeners, approvalSocket, commsSocket, auditLog, sessionID)
+		result, listeners, err = launchWithPty(ctx, cmd, config, queue, commsConf, approvalSocket, commsSocket, auditLog, sessionID)
 	} else {
+		// Non-pty path: use legacy tty-based vault prompt.
+		listeners = startCommsListeners(ctx, config.Dir, queue, auditLog, sessionID, sessionLog)
 		result, err = launchDirect(cmd, config)
 	}
+	defer stopCommsListeners(listeners)
 
 	sessionLog.Info("session ended", "exit_code", result.ExitCode)
 	if auditLog != "" {
@@ -164,12 +168,12 @@ func launchDirect(cmd *exec.Cmd, config LaunchConfig) (LaunchResult, error) {
 }
 
 // launchWithPty runs the agent inside a pty with a status bar at the bottom.
-func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, listeners []comms.Listener, approvalSocket, commsSocket, auditLog, sessionID string) (LaunchResult, error) {
+func launchWithPty(ctx context.Context, cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, commsConf *commsSetup, approvalSocket, commsSocket, auditLog, sessionID string) (LaunchResult, []comms.Listener, error) {
 	stdinFd := int(os.Stdin.Fd())
 
 	cols, rows, err := term.GetSize(stdinFd)
 	if err != nil {
-		return LaunchResult{}, fmt.Errorf("getting terminal size: %w", err)
+		return LaunchResult{}, nil, fmt.Errorf("getting terminal size: %w", err)
 	}
 
 	bar := NewStatusBar(rows, cols, "Flying ✈️ withaileron.ai ")
@@ -180,13 +184,13 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 		Cols: uint16(cols),
 	})
 	if err != nil {
-		return LaunchResult{}, fmt.Errorf("failed to start %s in pty: %w", config.Agent.Name(), err)
+		return LaunchResult{}, nil, fmt.Errorf("failed to start %s in pty: %w", config.Agent.Name(), err)
 	}
 	defer ptmx.Close()
 
 	oldState, err := term.MakeRaw(stdinFd)
 	if err != nil {
-		return LaunchResult{}, fmt.Errorf("setting raw mode: %w", err)
+		return LaunchResult{}, nil, fmt.Errorf("setting raw mode: %w", err)
 	}
 	defer term.Restore(stdinFd, oldState)
 
@@ -204,11 +208,26 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 
 	WireDraftInjection(ptmx, overlay, queue)
 
+	// Start the router early so vault prompt can steal input.
+	go router.Run()
+	go outputCopier.Run()
+
+	// Now that the PTY, router, and copier are up, open the vault
+	// (with Panel-based retry prompt) and start comms listeners.
+	var listeners []comms.Listener
+	if commsConf != nil {
+		var v vault.Vault
+		if commsConf.needsVault {
+			v = PromptVaultWithPanel(outputCopier, router, bar)
+		}
+		listeners = startCommsWithVault(ctx, commsConf, v, queue, auditLog, sessionID)
+	}
+
 	// Start the approval server so aileron-sh can request user approvals
 	// on the real terminal (not the pty).
 	approvalSrv, err := NewApprovalServer(approvalSocket, bar, outputCopier, router, ptmx)
 	if err != nil {
-		return LaunchResult{}, fmt.Errorf("starting approval server: %w", err)
+		return LaunchResult{}, listeners, fmt.Errorf("starting approval server: %w", err)
 	}
 	defer approvalSrv.Close()
 	go approvalSrv.Serve()
@@ -216,7 +235,7 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 	// Start the comms server so aileron-mcp can read/send messages.
 	commsSrv, err := NewCommsServer(commsSocket, queue, listeners, bar, outputCopier, router, auditLog, sessionID)
 	if err != nil {
-		return LaunchResult{}, fmt.Errorf("starting comms server: %w", err)
+		return LaunchResult{}, listeners, fmt.Errorf("starting comms server: %w", err)
 	}
 	defer commsSrv.Close()
 	go commsSrv.Serve()
@@ -243,9 +262,6 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 		}
 	}()
 
-	go router.Run()
-	go outputCopier.Run()
-
 	err = cmd.Wait()
 	signal.Stop(sigCh)
 	close(sigCh)
@@ -257,7 +273,8 @@ func launchWithPty(cmd *exec.Cmd, config LaunchConfig, queue *NotifyQueue, liste
 
 	CleanupTerminalScreen(os.Stdout, rows)
 
-	return exitResult(err)
+	r, exitErr := exitResult(err)
+	return r, listeners, exitErr
 }
 
 // WireDraftInjection connects the overlay's draft-request and converse
@@ -556,9 +573,20 @@ func EnvGlobMatch(pattern, name string) bool {
 	return pattern == name
 }
 
-// startCommsListeners reads the notification config from the policy file,
-// creates listeners, and starts them.
-func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, auditLog, sessionID string, sessionLog *slog.Logger) []comms.Listener {
+// commsSetup holds the parsed notification config from the policy file,
+// ready for vault resolution and listener creation.
+type commsSetup struct {
+	pf         *launchpolicy.PolicyFile
+	tokenRefs  []string
+	needsVault bool
+	sessionLog *slog.Logger
+}
+
+// prepareCommsConfig reads the notification policy and validates token
+// refs. Returns a commsSetup indicating whether a vault is needed. Does
+// NOT open the vault or start listeners — that is deferred until after
+// the PTY is set up so we can show a Panel-based passphrase prompt.
+func prepareCommsConfig(dir string, sessionLog *slog.Logger) *commsSetup {
 	if dir == "" {
 		dir, _ = os.Getwd()
 	}
@@ -594,7 +622,6 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		}
 	}
 
-	// Collect token values and open vault if any are vault references.
 	var tokenRefs []string
 	if cfg := pf.Notifications.Slack; cfg != nil {
 		tokenRefs = append(tokenRefs, cfg.AppToken, cfg.BotToken)
@@ -603,21 +630,31 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		tokenRefs = append(tokenRefs, cfg.BotToken)
 	}
 
-	var v vault.Vault
+	needsVault := false
 	for _, ref := range tokenRefs {
 		if IsVaultRef(ref) {
-			var err error
-			v, err = OpenVaultFunc(os.Stderr)
-			if err != nil {
-				sessionLog.Warn("vault open failed", "error", err)
-				fmt.Fprintf(os.Stderr, "aileron: vault: %v\n", err)
-				return nil
-			}
+			needsVault = true
 			break
 		}
 	}
 
-	resolved, err := ResolveTokens(tokenRefs, v)
+	return &commsSetup{
+		pf:         pf,
+		tokenRefs:  tokenRefs,
+		needsVault: needsVault,
+		sessionLog: sessionLog,
+	}
+}
+
+// startCommsWithVault resolves tokens (using the provided vault, which
+// may be nil), creates listeners, and starts them.
+func startCommsWithVault(ctx context.Context, setup *commsSetup, v vault.Vault, queue *NotifyQueue, auditLog, sessionID string) []comms.Listener {
+	if setup == nil {
+		return nil
+	}
+	sessionLog := setup.sessionLog
+
+	resolved, err := ResolveTokens(setup.tokenRefs, v)
 	if err != nil {
 		sessionLog.Warn("token resolution failed", "error", err)
 		fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
@@ -634,7 +671,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 	autoDraft := make(map[string]bool)
 	priority := make(map[string]string)
 	var created []comms.Listener
-	if cfg := pf.Notifications.Slack; cfg != nil && cfg.AppToken != "" && cfg.BotToken != "" {
+	if cfg := setup.pf.Notifications.Slack; cfg != nil && cfg.AppToken != "" && cfg.BotToken != "" {
 		appToken, botToken := resolved[idx], resolved[idx+1]
 		idx += 2
 		channels := make([]string, 0, len(cfg.Channels))
@@ -654,7 +691,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		sl := comms.NewSlackListener(appToken, botToken, channels, cfg.Ignore, sessionLog.With("component", "slack"))
 		created = append(created, sl)
 	}
-	if cfg := pf.Notifications.Discord; cfg != nil && cfg.BotToken != "" {
+	if cfg := setup.pf.Notifications.Discord; cfg != nil && cfg.BotToken != "" {
 		botToken := resolved[idx]
 		channels := make([]string, 0, len(cfg.Channels))
 		for _, ch := range cfg.Channels {
@@ -672,6 +709,29 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 	}
 
 	return StartListeners(ctx, created, queue, os.Stderr, autoDraft, priority, auditLog, sessionID, sessionLog)
+}
+
+// startCommsListeners is the legacy convenience wrapper that prepares
+// config, opens the vault via the old tty prompt, and starts listeners.
+// Used by the non-pty (direct) launch path.
+func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, auditLog, sessionID string, sessionLog *slog.Logger) []comms.Listener {
+	setup := prepareCommsConfig(dir, sessionLog)
+	if setup == nil {
+		return nil
+	}
+
+	var v vault.Vault
+	if setup.needsVault {
+		var err error
+		v, err = OpenVaultFunc(os.Stderr)
+		if err != nil {
+			sessionLog.Warn("vault open failed", "error", err)
+			fmt.Fprintf(os.Stderr, "aileron: vault: %v\n", err)
+			return nil
+		}
+	}
+
+	return startCommsWithVault(ctx, setup, v, queue, auditLog, sessionID)
 }
 
 // StartListeners connects and starts each listener, bridging incoming

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -241,6 +241,7 @@ func launchWithPty(ctx context.Context, cmd *exec.Cmd, config LaunchConfig, queu
 	go commsSrv.Serve()
 
 	WireReply(overlay, commsSrv)
+	WireDraftSend(overlay, commsSrv)
 
 	// Wire onChange to re-render the status bar when notifications arrive.
 	queue.onChange = func() { bar.Render(os.Stdout) }
@@ -298,6 +299,18 @@ func WireDraftInjection(ptmx io.Writer, overlay *Overlay, queue *NotifyQueue) {
 func WireReply(overlay *Overlay, commsSrv *CommsServer) {
 	overlay.OnReply = func(msg Message, reply string) {
 		commsSrv.DirectSend(msg.Source, msg.Channel, reply)
+	}
+}
+
+// WireDraftSend connects the overlay's draft-approve and draft-edit
+// callbacks to send directly via the CommsServer. The agent drafts the
+// text; Aileron sends it after user approval. Exported for testing.
+func WireDraftSend(overlay *Overlay, commsSrv *CommsServer) {
+	overlay.OnDraftApprove = func(msg Message) {
+		commsSrv.DirectSend(msg.Source, msg.Channel, msg.Draft)
+	}
+	overlay.OnDraftEdit = func(msg Message, edited string) {
+		commsSrv.DirectSend(msg.Source, msg.Channel, edited)
 	}
 }
 

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -562,15 +562,15 @@ func TestWireDraftInjection_OverlayCallback(t *testing.T) {
 	launch.WireDraftInjection(&buf, o, q)
 
 	// Simulate overlay draft request.
-	msg := launch.Message{Source: "slack", Channel: "#backend", Author: "Sarah", Body: "question?"}
+	msg := launch.Message{ID: "msg-1", Source: "slack", Channel: "#backend", Author: "Sarah", Body: "question?"}
 	o.OnDraftRequest(msg)
 
 	out := buf.String()
-	if !strings.Contains(out, "send_message") {
-		t.Error("expected send_message in injected prompt from overlay callback")
+	if !strings.Contains(out, "draft_reply") {
+		t.Error("expected draft_reply in injected prompt from overlay callback")
 	}
-	if !strings.Contains(out, "Sarah") {
-		t.Error("expected author in injected prompt")
+	if !strings.Contains(out, "msg-1") {
+		t.Error("expected message ID in injected prompt")
 	}
 }
 
@@ -585,7 +585,7 @@ func TestWireDraftInjection_AutoDraftNoLongerInjects(t *testing.T) {
 	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Bob", Body: "help?", AutoDraft: true})
 
 	out := buf.String()
-	if strings.Contains(out, "send_message") {
+	if strings.Contains(out, "draft_reply") {
 		t.Error("auto-draft should no longer inject prompts automatically")
 	}
 }
@@ -598,6 +598,7 @@ func TestWireDraftInjection_ConverseCallback(t *testing.T) {
 	launch.WireDraftInjection(&buf, o, q)
 
 	msg := launch.Message{
+		ID:      "msg-1",
 		Source:  "slack",
 		Channel: "#backend",
 		Author:  "Sarah",
@@ -607,14 +608,11 @@ func TestWireDraftInjection_ConverseCallback(t *testing.T) {
 	o.OnDraftConverse(msg, "make it shorter")
 
 	out := buf.String()
-	if !strings.Contains(out, "send_message") {
-		t.Error("expected send_message in converse revision prompt")
+	if !strings.Contains(out, "draft_reply") {
+		t.Error("expected draft_reply in converse revision prompt")
 	}
 	if !strings.Contains(out, "make it shorter") {
 		t.Error("expected user feedback in converse revision prompt")
-	}
-	if !strings.Contains(out, "Here is my draft.") {
-		t.Error("expected previous draft in converse revision prompt")
 	}
 }
 

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -639,6 +639,48 @@ func TestWireReply(t *testing.T) {
 	// Just verify no panic and the callback is wired.
 }
 
+func TestWireDraftSend_Approve(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "comms.sock")
+	sender := &testListener{service: "slack", msgs: make(chan comms.IncomingMessage, 1)}
+	queue := launch.NewNotifyQueue(10, nil)
+
+	srv, err := launch.NewCommsServer(socketPath, queue, []comms.Listener{sender}, nil, nil, nil, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	var buf strings.Builder
+	o := launch.NewOverlay(queue, nil, &buf, 24, 80, nil)
+
+	launch.WireDraftSend(o, srv)
+
+	msg := launch.Message{Source: "slack", Channel: "#backend", Draft: "my draft text"}
+	o.OnDraftApprove(msg)
+	// Verify no panic and the callback is wired.
+}
+
+func TestWireDraftSend_Edit(t *testing.T) {
+	socketPath := filepath.Join(t.TempDir(), "comms.sock")
+	sender := &testListener{service: "slack", msgs: make(chan comms.IncomingMessage, 1)}
+	queue := launch.NewNotifyQueue(10, nil)
+
+	srv, err := launch.NewCommsServer(socketPath, queue, []comms.Listener{sender}, nil, nil, nil, "", "")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer srv.Close()
+
+	var buf strings.Builder
+	o := launch.NewOverlay(queue, nil, &buf, 24, 80, nil)
+
+	launch.WireDraftSend(o, srv)
+
+	msg := launch.Message{Source: "slack", Channel: "#backend", Draft: "original"}
+	o.OnDraftEdit(msg, "edited text")
+	// Verify no panic and the callback is wired.
+}
+
 func TestBridgeMessages_AutoDraft(t *testing.T) {
 	queue := launch.NewNotifyQueue(10, nil)
 	msgs := make(chan comms.IncomingMessage, 3)

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -574,22 +574,47 @@ func TestWireDraftInjection_OverlayCallback(t *testing.T) {
 	}
 }
 
-func TestWireDraftInjection_AutoDraftCallback(t *testing.T) {
+func TestWireDraftInjection_AutoDraftNoLongerInjects(t *testing.T) {
 	var buf strings.Builder
 	q := launch.NewNotifyQueue(10, nil)
 	o := launch.NewOverlay(q, nil, &buf, 24, 80, nil)
 
 	launch.WireDraftInjection(&buf, o, q)
 
-	// Push an auto-draft message — should trigger injection.
+	// Push an auto-draft message — should NOT trigger injection anymore.
 	q.Push(launch.Message{ID: "1", Source: "slack", Channel: "#backend", Author: "Bob", Body: "help?", AutoDraft: true})
 
 	out := buf.String()
-	if !strings.Contains(out, "send_message") {
-		t.Error("expected send_message in injected prompt from auto-draft callback")
+	if strings.Contains(out, "send_message") {
+		t.Error("auto-draft should no longer inject prompts automatically")
 	}
-	if !strings.Contains(out, "Bob") {
-		t.Error("expected author in injected prompt")
+}
+
+func TestWireDraftInjection_ConverseCallback(t *testing.T) {
+	var buf strings.Builder
+	q := launch.NewNotifyQueue(10, nil)
+	o := launch.NewOverlay(q, nil, &buf, 24, 80, nil)
+
+	launch.WireDraftInjection(&buf, o, q)
+
+	msg := launch.Message{
+		Source:  "slack",
+		Channel: "#backend",
+		Author:  "Sarah",
+		Body:    "question?",
+		Draft:   "Here is my draft.",
+	}
+	o.OnDraftConverse(msg, "make it shorter")
+
+	out := buf.String()
+	if !strings.Contains(out, "send_message") {
+		t.Error("expected send_message in converse revision prompt")
+	}
+	if !strings.Contains(out, "make it shorter") {
+		t.Error("expected user feedback in converse revision prompt")
+	}
+	if !strings.Contains(out, "Here is my draft.") {
+		t.Error("expected previous draft in converse revision prompt")
 	}
 }
 
@@ -1130,9 +1155,9 @@ func TestCleanupTerminalScreen(t *testing.T) {
 	launch.CleanupTerminalScreen(&buf, 24)
 	out := buf.String()
 
-	// Should move to bar area and clear
-	if !strings.Contains(out, "\033[23;1H\033[J") {
-		t.Errorf("expected clear at row 23, got %q", out)
+	// Should move to bar area and clear (3-row bar: starts at totalRows-2)
+	if !strings.Contains(out, "\033[22;1H\033[J") {
+		t.Errorf("expected clear at row 22, got %q", out)
 	}
 }
 

--- a/core/launch/notifyqueue.go
+++ b/core/launch/notifyqueue.go
@@ -124,6 +124,21 @@ func (q *NotifyQueue) HighPriorityUnreadCount() int {
 	return count
 }
 
+// DraftPendingCount returns the number of unread auto-draft messages
+// that do not yet have a draft reply. These are messages awaiting the
+// user to open the overlay and request a draft.
+func (q *NotifyQueue) DraftPendingCount() int {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	count := 0
+	for _, m := range q.messages {
+		if !m.Read && m.AutoDraft && m.Draft == "" {
+			count++
+		}
+	}
+	return count
+}
+
 // Latest returns the most recent message, or false if empty.
 func (q *NotifyQueue) Latest() (Message, bool) {
 	q.mu.Lock()

--- a/core/launch/notifyqueue_test.go
+++ b/core/launch/notifyqueue_test.go
@@ -574,3 +574,24 @@ func TestNotifyQueue_ConcurrentAccess(t *testing.T) {
 		t.Errorf("Len = %d, should be <= 100", q.Len())
 	}
 }
+
+func TestNotifyQueue_DraftPendingCount(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+
+	// Auto-draft without a draft yet — counts as pending.
+	q.Push(launch.Message{ID: "1", AutoDraft: true})
+	// Non-auto-draft — not counted.
+	q.Push(launch.Message{ID: "2", AutoDraft: false})
+	// Auto-draft with a draft already — not pending.
+	q.Push(launch.Message{ID: "3", AutoDraft: true, Draft: "reply", DraftFor: "3"})
+
+	if got := q.DraftPendingCount(); got != 1 {
+		t.Errorf("DraftPendingCount = %d, want 1", got)
+	}
+
+	// Mark the pending message as read — no longer counted.
+	q.MarkRead("1")
+	if got := q.DraftPendingCount(); got != 0 {
+		t.Errorf("DraftPendingCount after MarkRead = %d, want 0", got)
+	}
+}

--- a/core/launch/overlay.go
+++ b/core/launch/overlay.go
@@ -449,28 +449,38 @@ func (o *Overlay) cancelReply() {
 func (o *Overlay) render() {
 	msgs := o.queue.Messages()
 
-	var buf strings.Builder
-	// Clear screen and move to top.
-	buf.WriteString("\033[2J\033[1;1H")
-
-	// Header.
-	header := fmt.Sprintf(" aileron notifications (%d messages) — Esc/q to return", len(msgs))
-	if len(header) > o.cols {
-		header = header[:o.cols]
+	// Determine footer hints based on current mode.
+	var hints []string
+	if o.replyMode {
+		hints = []string{"Enter send", "Esc cancel"}
+	} else if o.selectedIsDraft() {
+		hints = []string{"j/k navigate", "y send", "e edit", "c revise", "n discard", "q return"}
+	} else {
+		hints = []string{"j/k navigate", "r reply", "a draft reply", "d dismiss", "q return"}
 	}
-	fmt.Fprintf(&buf, "\033[1m%s\033[0m\n", header)
-	buf.WriteString(strings.Repeat("─", o.cols) + "\n")
 
-	// Reserve rows for the detail pane (separator + channel/author + up to 5 body lines).
+	panel := NewPanel(PanelConfig{
+		Title:       fmt.Sprintf("aileron notifications (%d messages)", len(msgs)),
+		InnerWidth:  0, // auto
+		Centered:    false,
+		FooterHints: hints,
+	}, o.rows, o.cols)
+
+	w := panel.InnerWidth()
+
+	// Reserve rows for detail pane.
 	detailRows := 8
-	// Message list.
 	visible := o.rows - 4 - detailRows
 	if visible < 1 {
 		visible = 1
 	}
 
+	var content []string
+
 	if len(msgs) == 0 {
-		buf.WriteString("\n  No notifications.\n")
+		content = append(content, panel.BlankLine())
+		content = append(content, panel.PadLine("  No notifications."))
+		content = append(content, panel.BlankLine())
 	} else {
 		end := o.scrollPos + visible
 		if end > len(msgs) {
@@ -496,67 +506,58 @@ func (o *Overlay) render() {
 					cursor, readMark, m.Source, m.Author, m.Preview)
 			}
 
-			// Truncate to terminal width.
-			if displayWidth(line) > o.cols {
-				line = line[:o.cols]
+			// Truncate to inner width.
+			if visibleWidth(line) > w {
+				line = line[:w]
 			}
-			buf.WriteString(line + "\n")
+			content = append(content, panel.PadLine(line))
 		}
 
 		// Detail pane for selected message.
 		if o.cursorPos < len(msgs) {
 			selected := msgs[o.cursorPos]
-			buf.WriteString("\n" + strings.Repeat("─", o.cols) + "\n")
-			buf.WriteString(fmt.Sprintf(" \033[1m%s · %s\033[0m\n", selected.Channel, selected.Author))
-			bodyLines := wrapText(selected.Body, o.cols-2)
+			content = append(content, panel.BlankLine())
+			content = append(content, panel.SeparatorLine())
+			content = append(content, panel.PadLine(fmt.Sprintf(" \033[1m%s · %s\033[0m", selected.Channel, selected.Author)))
+			bodyLines := wrapText(selected.Body, w-2)
 			maxBodyLines := 5
 			for i, line := range bodyLines {
 				if i >= maxBodyLines {
-					buf.WriteString("  ...\n")
+					content = append(content, panel.PadLine("  ..."))
 					break
 				}
-				buf.WriteString(" " + line + "\n")
+				content = append(content, panel.PadLine(" "+line))
 			}
 
-			// Show draft text below the original message.
+			// Draft reply section.
 			if selected.Draft != "" {
-				buf.WriteString("\n")
-				buf.WriteString(" \033[36m── Draft Reply ──\033[0m\n")
-				draftLines := wrapText(selected.Draft, o.cols-2)
+				content = append(content, panel.BlankLine())
+				content = append(content, panel.PadLine(" \033[36m── Draft Reply ──\033[0m"))
+				draftLines := wrapText(selected.Draft, w-2)
 				for i, line := range draftLines {
 					if i >= maxBodyLines {
-						buf.WriteString("  ...\n")
+						content = append(content, panel.PadLine("  ..."))
 						break
 					}
-					buf.WriteString(" " + line + "\n")
+					content = append(content, panel.PadLine(" "+line))
 				}
 			}
 
 			// Reply input box.
 			if o.replyMode {
-				buf.WriteString("\n")
+				content = append(content, panel.BlankLine())
 				label := "\033[33m>\033[0m"
 				if o.converseMode {
 					label = "\033[33mfeedback>\033[0m"
 				}
-				buf.WriteString(fmt.Sprintf(" %s %s\033[7m \033[0m\n", label, o.replyBuf.String()))
+				content = append(content, panel.PadLine(fmt.Sprintf(" %s %s\033[7m \033[0m", label, o.replyBuf.String())))
 			}
 		}
 	}
 
-	// Footer.
-	var footer string
-	if o.replyMode {
-		footer = "\n" + strings.Repeat("─", o.cols) + "\n"
-		footer += " Enter send  Esc cancel"
-	} else if o.selectedIsDraft() {
-		footer = "\n" + strings.Repeat("─", o.cols) + "\n"
-		footer += " j/k or ↑/↓ navigate  y send  e edit  c revise  n discard  q return"
-	} else {
-		footer = "\n" + strings.Repeat("─", o.cols) + "\n"
-		footer += " j/k or ↑/↓ navigate  r reply  a draft reply  d dismiss  q return"
-	}
-	buf.WriteString(footer)
-
+	// Clear screen and render the panel.
+	var buf strings.Builder
+	buf.WriteString("\033[2J\033[1;1H")
+	buf.WriteString(panel.Render(content))
 	fmt.Fprint(o.stdout, buf.String())
 }

--- a/core/launch/overlay.go
+++ b/core/launch/overlay.go
@@ -27,11 +27,13 @@ type Overlay struct {
 	OnDraftApprove func(msg Message)         // called when user presses 'y' on a draft
 	OnDraftDiscard func(msg Message)         // called when user presses 'n' on a draft
 	OnDraftEdit    func(msg Message, edited string) // called when user edits and sends a draft
+	OnDraftConverse func(msg Message, feedback string) // called when user provides revision feedback
 
 	// Reply mode state.
-	replyMode bool
-	replyBuf  strings.Builder
-	replyMsg  Message
+	replyMode    bool
+	converseMode bool // true when reply mode is collecting revision feedback
+	replyBuf     strings.Builder
+	replyMsg     Message
 
 	// Escape sequence state machine for arrow keys.
 	escState int // 0=normal, 1=got ESC, 2=got ESC+[
@@ -151,6 +153,8 @@ func (o *Overlay) HandleKey(b byte) {
 		o.approveDraft()
 	case 'e':
 		o.editDraft()
+	case 'c':
+		o.converseDraft()
 	case 'n':
 		o.discardDraft()
 	}
@@ -313,6 +317,23 @@ func (o *Overlay) editDraft() {
 	o.render()
 }
 
+func (o *Overlay) converseDraft() {
+	msgs := o.queue.Messages()
+	if o.cursorPos >= len(msgs) {
+		return
+	}
+	msg := msgs[o.cursorPos]
+	if msg.Draft == "" {
+		return
+	}
+	// Enter reply mode for revision feedback (empty buffer).
+	o.replyMode = true
+	o.converseMode = true
+	o.replyMsg = msg
+	o.replyBuf.Reset()
+	o.render()
+}
+
 func (o *Overlay) startReply() {
 	msgs := o.queue.Messages()
 	if o.cursorPos >= len(msgs) {
@@ -375,8 +396,10 @@ func (o *Overlay) handleReplyKey(b byte) {
 func (o *Overlay) submitReply() {
 	reply := o.replyBuf.String()
 	msg := o.replyMsg
-	isDraftEdit := msg.Draft != ""
+	isConverse := o.converseMode
+	isDraftEdit := !isConverse && msg.Draft != ""
 	o.replyMode = false
+	o.converseMode = false
 	o.replyBuf.Reset()
 	o.queue.MarkRead(msg.ID)
 
@@ -395,7 +418,14 @@ func (o *Overlay) submitReply() {
 		o.mu.Lock()
 	}
 	if reply != "" {
-		if isDraftEdit && o.OnDraftEdit != nil {
+		if isConverse && o.OnDraftConverse != nil {
+			// Clear the current draft so the revision cycle can restart.
+			o.queue.ClearDraft(msg.ID)
+			cb := o.OnDraftConverse
+			o.mu.Unlock()
+			cb(msg, reply)
+			o.mu.Lock()
+		} else if isDraftEdit && o.OnDraftEdit != nil {
 			cb := o.OnDraftEdit
 			o.mu.Unlock()
 			cb(msg, reply)
@@ -411,6 +441,7 @@ func (o *Overlay) submitReply() {
 
 func (o *Overlay) cancelReply() {
 	o.replyMode = false
+	o.converseMode = false
 	o.replyBuf.Reset()
 	o.render()
 }
@@ -504,7 +535,11 @@ func (o *Overlay) render() {
 			// Reply input box.
 			if o.replyMode {
 				buf.WriteString("\n")
-				buf.WriteString(fmt.Sprintf(" \033[33m>\033[0m %s\033[7m \033[0m\n", o.replyBuf.String()))
+				label := "\033[33m>\033[0m"
+				if o.converseMode {
+					label = "\033[33mfeedback>\033[0m"
+				}
+				buf.WriteString(fmt.Sprintf(" %s %s\033[7m \033[0m\n", label, o.replyBuf.String()))
 			}
 		}
 	}
@@ -516,7 +551,7 @@ func (o *Overlay) render() {
 		footer += " Enter send  Esc cancel"
 	} else if o.selectedIsDraft() {
 		footer = "\n" + strings.Repeat("─", o.cols) + "\n"
-		footer += " j/k or ↑/↓ navigate  y send  e edit  n discard  q return"
+		footer += " j/k or ↑/↓ navigate  y send  e edit  c revise  n discard  q return"
 	} else {
 		footer = "\n" + strings.Repeat("─", o.cols) + "\n"
 		footer += " j/k or ↑/↓ navigate  r reply  a draft reply  d dismiss  q return"

--- a/core/launch/overlay.go
+++ b/core/launch/overlay.go
@@ -449,24 +449,29 @@ func (o *Overlay) cancelReply() {
 func (o *Overlay) render() {
 	msgs := o.queue.Messages()
 
+	// Left accent bar: yellow │ prefix on every content line.
+	accent := "\033[33m│\033[0m "
+	// Content width: terminal minus the 2-char accent prefix.
+	w := o.cols - 2
+
 	// Determine footer hints based on current mode.
-	var hints []string
+	var footer string
 	if o.replyMode {
-		hints = []string{"Enter send", "Esc cancel"}
+		footer = "Enter send  Esc cancel"
 	} else if o.selectedIsDraft() {
-		hints = []string{"j/k navigate", "y send", "e edit", "c revise", "n discard", "q return"}
+		footer = "j/k navigate  y send  e edit  c revise  n discard  q return"
 	} else {
-		hints = []string{"j/k navigate", "r reply", "a draft reply", "d dismiss", "q return"}
+		footer = "j/k navigate  r reply  a draft reply  d dismiss  q return"
 	}
 
-	panel := NewPanel(PanelConfig{
-		Title:       fmt.Sprintf("aileron notifications (%d messages)", len(msgs)),
-		InnerWidth:  0, // auto
-		Centered:    false,
-		FooterHints: hints,
-	}, o.rows, o.cols)
+	var buf strings.Builder
+	buf.WriteString("\033[2J\033[1;1H")
 
-	w := panel.InnerWidth()
+	// Header.
+	buf.WriteString(accent)
+	fmt.Fprintf(&buf, "\033[1maileron notifications (%d messages)\033[0m\n", len(msgs))
+	buf.WriteString(accent)
+	buf.WriteString("\033[2m" + strings.Repeat("─", w) + "\033[0m\n")
 
 	// Reserve rows for detail pane.
 	detailRows := 8
@@ -475,12 +480,10 @@ func (o *Overlay) render() {
 		visible = 1
 	}
 
-	var content []string
-
 	if len(msgs) == 0 {
-		content = append(content, panel.BlankLine())
-		content = append(content, panel.PadLine("  No notifications."))
-		content = append(content, panel.BlankLine())
+		buf.WriteString(accent + "\n")
+		buf.WriteString(accent + "  No notifications.\n")
+		buf.WriteString(accent + "\n")
 	} else {
 		end := o.scrollPos + visible
 		if end > len(msgs) {
@@ -506,58 +509,55 @@ func (o *Overlay) render() {
 					cursor, readMark, m.Source, m.Author, m.Preview)
 			}
 
-			// Truncate to inner width.
-			if visibleWidth(line) > w {
-				line = line[:w]
-			}
-			content = append(content, panel.PadLine(line))
+			buf.WriteString(accent + line + "\n")
 		}
 
 		// Detail pane for selected message.
 		if o.cursorPos < len(msgs) {
 			selected := msgs[o.cursorPos]
-			content = append(content, panel.BlankLine())
-			content = append(content, panel.SeparatorLine())
-			content = append(content, panel.PadLine(fmt.Sprintf(" \033[1m%s · %s\033[0m", selected.Channel, selected.Author)))
-			bodyLines := wrapText(selected.Body, w-2)
+			buf.WriteString(accent + "\n")
+			buf.WriteString(accent + "\033[2m" + strings.Repeat("─", w) + "\033[0m\n")
+			fmt.Fprintf(&buf, "%s \033[1m%s · %s\033[0m\n", accent, selected.Channel, selected.Author)
+			bodyLines := wrapText(selected.Body, w-1)
 			maxBodyLines := 5
 			for i, line := range bodyLines {
 				if i >= maxBodyLines {
-					content = append(content, panel.PadLine("  ..."))
+					buf.WriteString(accent + "  ...\n")
 					break
 				}
-				content = append(content, panel.PadLine(" "+line))
+				buf.WriteString(accent + " " + line + "\n")
 			}
 
 			// Draft reply section.
 			if selected.Draft != "" {
-				content = append(content, panel.BlankLine())
-				content = append(content, panel.PadLine(" \033[36m── Draft Reply ──\033[0m"))
-				draftLines := wrapText(selected.Draft, w-2)
+				buf.WriteString(accent + "\n")
+				buf.WriteString(accent + " \033[36m── Draft Reply ──\033[0m\n")
+				draftLines := wrapText(selected.Draft, w-1)
 				for i, line := range draftLines {
 					if i >= maxBodyLines {
-						content = append(content, panel.PadLine("  ..."))
+						buf.WriteString(accent + "  ...\n")
 						break
 					}
-					content = append(content, panel.PadLine(" "+line))
+					buf.WriteString(accent + " " + line + "\n")
 				}
 			}
 
 			// Reply input box.
 			if o.replyMode {
-				content = append(content, panel.BlankLine())
+				buf.WriteString(accent + "\n")
 				label := "\033[33m>\033[0m"
 				if o.converseMode {
 					label = "\033[33mfeedback>\033[0m"
 				}
-				content = append(content, panel.PadLine(fmt.Sprintf(" %s %s\033[7m \033[0m", label, o.replyBuf.String())))
+				fmt.Fprintf(&buf, "%s %s %s\033[7m \033[0m\n", accent, label, o.replyBuf.String())
 			}
 		}
 	}
 
-	// Clear screen and render the panel.
-	var buf strings.Builder
-	buf.WriteString("\033[2J\033[1;1H")
-	buf.WriteString(panel.Render(content))
+	// Footer.
+	buf.WriteString(accent + "\n")
+	buf.WriteString(accent + "\033[2m" + strings.Repeat("─", w) + "\033[0m\n")
+	buf.WriteString(accent + "\033[2m" + footer + "\033[0m")
+
 	fmt.Fprint(o.stdout, buf.String())
 }

--- a/core/launch/overlay.go
+++ b/core/launch/overlay.go
@@ -270,14 +270,28 @@ func (o *Overlay) approveDraft() {
 		return
 	}
 	o.queue.MarkRead(msg.ID)
+	o.queue.ClearDraft(msg.ID)
 
+	// Dismiss the overlay, then fire the approve callback.
+	o.active = false
+	fmt.Fprint(o.stdout, "\033[?25h\033[?1049l")
+	if o.copier != nil {
+		o.mu.Unlock()
+		o.copier.Flush()
+		o.mu.Lock()
+	}
+	if o.onDismiss != nil {
+		cb := o.onDismiss
+		o.mu.Unlock()
+		cb()
+		o.mu.Lock()
+	}
 	if o.OnDraftApprove != nil {
 		cb := o.OnDraftApprove
 		o.mu.Unlock()
 		cb(msg)
 		o.mu.Lock()
 	}
-	o.render()
 }
 
 func (o *Overlay) discardDraft() {
@@ -290,14 +304,28 @@ func (o *Overlay) discardDraft() {
 		return
 	}
 	o.queue.MarkRead(msg.ID)
+	o.queue.ClearDraft(msg.ID)
 
+	// Dismiss the overlay, then fire the discard callback.
+	o.active = false
+	fmt.Fprint(o.stdout, "\033[?25h\033[?1049l")
+	if o.copier != nil {
+		o.mu.Unlock()
+		o.copier.Flush()
+		o.mu.Lock()
+	}
+	if o.onDismiss != nil {
+		cb := o.onDismiss
+		o.mu.Unlock()
+		cb()
+		o.mu.Lock()
+	}
 	if o.OnDraftDiscard != nil {
 		cb := o.OnDraftDiscard
 		o.mu.Unlock()
 		cb(msg)
 		o.mu.Lock()
 	}
-	o.render()
 }
 
 func (o *Overlay) editDraft() {

--- a/core/launch/overlay.go
+++ b/core/launch/overlay.go
@@ -449,29 +449,22 @@ func (o *Overlay) cancelReply() {
 func (o *Overlay) render() {
 	msgs := o.queue.Messages()
 
-	// Left accent bar: yellow │ prefix on every content line.
-	accent := "\033[33m│\033[0m "
-	// Content width: terminal minus the 2-char accent prefix.
-	w := o.cols - 2
-
 	// Determine footer hints based on current mode.
-	var footer string
+	var hints []string
 	if o.replyMode {
-		footer = "Enter send  Esc cancel"
+		hints = []string{"Enter send", "Esc cancel"}
 	} else if o.selectedIsDraft() {
-		footer = "j/k navigate  y send  e edit  c revise  n discard  q return"
+		hints = []string{"j/k navigate", "y send", "e edit", "c revise", "n discard", "q return"}
 	} else {
-		footer = "j/k navigate  r reply  a draft reply  d dismiss  q return"
+		hints = []string{"j/k navigate", "r reply", "a draft reply", "d dismiss", "q return"}
 	}
 
-	var buf strings.Builder
-	buf.WriteString("\033[2J\033[1;1H")
+	panel := NewPanel(PanelConfig{
+		Title:       fmt.Sprintf("aileron notifications (%d messages)", len(msgs)),
+		FooterHints: hints,
+	}, o.rows, o.cols)
 
-	// Header.
-	buf.WriteString(accent)
-	fmt.Fprintf(&buf, "\033[1maileron notifications (%d messages)\033[0m\n", len(msgs))
-	buf.WriteString(accent)
-	buf.WriteString("\033[2m" + strings.Repeat("─", w) + "\033[0m\n")
+	w := panel.ContentWidth()
 
 	// Reserve rows for detail pane.
 	detailRows := 8
@@ -480,10 +473,12 @@ func (o *Overlay) render() {
 		visible = 1
 	}
 
+	var content []string
+
 	if len(msgs) == 0 {
-		buf.WriteString(accent + "\n")
-		buf.WriteString(accent + "  No notifications.\n")
-		buf.WriteString(accent + "\n")
+		content = append(content, "")
+		content = append(content, "  No notifications.")
+		content = append(content, "")
 	} else {
 		end := o.scrollPos + visible
 		if end > len(msgs) {
@@ -508,56 +503,54 @@ func (o *Overlay) render() {
 				line = fmt.Sprintf("%s%s %s · %s: %s",
 					cursor, readMark, m.Source, m.Author, m.Preview)
 			}
-
-			buf.WriteString(accent + line + "\n")
+			content = append(content, line)
 		}
 
 		// Detail pane for selected message.
 		if o.cursorPos < len(msgs) {
 			selected := msgs[o.cursorPos]
-			buf.WriteString(accent + "\n")
-			buf.WriteString(accent + "\033[2m" + strings.Repeat("─", w) + "\033[0m\n")
-			fmt.Fprintf(&buf, "%s \033[1m%s · %s\033[0m\n", accent, selected.Channel, selected.Author)
+			content = append(content, "")
+			content = append(content, panel.SeparatorLine())
+			content = append(content, fmt.Sprintf(" \033[1m%s · %s\033[0m", selected.Channel, selected.Author))
 			bodyLines := wrapText(selected.Body, w-1)
 			maxBodyLines := 5
 			for i, line := range bodyLines {
 				if i >= maxBodyLines {
-					buf.WriteString(accent + "  ...\n")
+					content = append(content, "  ...")
 					break
 				}
-				buf.WriteString(accent + " " + line + "\n")
+				content = append(content, " "+line)
 			}
 
 			// Draft reply section.
 			if selected.Draft != "" {
-				buf.WriteString(accent + "\n")
-				buf.WriteString(accent + " \033[36m── Draft Reply ──\033[0m\n")
+				content = append(content, "")
+				content = append(content, " \033[36m── Draft Reply ──\033[0m")
 				draftLines := wrapText(selected.Draft, w-1)
 				for i, line := range draftLines {
 					if i >= maxBodyLines {
-						buf.WriteString(accent + "  ...\n")
+						content = append(content, "  ...")
 						break
 					}
-					buf.WriteString(accent + " " + line + "\n")
+					content = append(content, " "+line)
 				}
 			}
 
 			// Reply input box.
 			if o.replyMode {
-				buf.WriteString(accent + "\n")
+				content = append(content, "")
 				label := "\033[33m>\033[0m"
 				if o.converseMode {
 					label = "\033[33mfeedback>\033[0m"
 				}
-				fmt.Fprintf(&buf, "%s %s %s\033[7m \033[0m\n", accent, label, o.replyBuf.String())
+				content = append(content, fmt.Sprintf(" %s %s\033[7m \033[0m", label, o.replyBuf.String()))
 			}
 		}
 	}
 
-	// Footer.
-	buf.WriteString(accent + "\n")
-	buf.WriteString(accent + "\033[2m" + strings.Repeat("─", w) + "\033[0m\n")
-	buf.WriteString(accent + "\033[2m" + footer + "\033[0m")
-
+	// Clear screen and render.
+	var buf strings.Builder
+	buf.WriteString("\033[2J\033[1;1H")
+	buf.WriteString(panel.Render(content))
 	fmt.Fprint(o.stdout, buf.String())
 }

--- a/core/launch/overlay_test.go
+++ b/core/launch/overlay_test.go
@@ -1302,3 +1302,56 @@ func TestOverlay_Converse_ClearsDraftForCycle(t *testing.T) {
 		t.Errorf("expected draft to be cleared after converse, got %q", msg.Draft)
 	}
 }
+
+func TestOverlay_DraftApprove_DismissesOverlay(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{
+		ID: "1", Source: "slack", Channel: "#backend", Author: "Alice",
+		Preview: "question", Body: "question?",
+		Draft: "my draft", DraftFor: "1",
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.OnDraftApprove = func(msg launch.Message) {}
+
+	o.Show()
+	o.HandleKey('y')
+
+	if o.IsActive() {
+		t.Error("overlay should be dismissed after draft approve")
+	}
+	// Draft should be cleared from queue.
+	msg, _ := q.FindByID("1")
+	if msg.Draft != "" {
+		t.Errorf("expected draft cleared after approve, got %q", msg.Draft)
+	}
+	// Output should contain alt-screen exit.
+	if !strings.Contains(w.String(), "\033[?1049l") {
+		t.Error("expected alt-screen exit in output")
+	}
+}
+
+func TestOverlay_DraftDiscard_DismissesOverlay(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{
+		ID: "1", Source: "slack", Channel: "#backend", Author: "Alice",
+		Preview: "question", Body: "question?",
+		Draft: "my draft", DraftFor: "1",
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.OnDraftDiscard = func(msg launch.Message) {}
+
+	o.Show()
+	o.HandleKey('n')
+
+	if o.IsActive() {
+		t.Error("overlay should be dismissed after draft discard")
+	}
+	msg, _ := q.FindByID("1")
+	if msg.Draft != "" {
+		t.Errorf("expected draft cleared after discard, got %q", msg.Draft)
+	}
+}

--- a/core/launch/overlay_test.go
+++ b/core/launch/overlay_test.go
@@ -1127,3 +1127,178 @@ func TestOverlay_Resize(t *testing.T) {
 		t.Error("expected re-render after resize")
 	}
 }
+
+func TestOverlay_ConverseKey_EntersReplyMode(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{
+		ID: "1", Source: "slack", Channel: "#backend", Author: "Alice",
+		Preview: "question", Body: "question?",
+		Draft: "my draft", DraftFor: "1",
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.Show()
+	w.Reset()
+
+	// Press 'c' to enter converse mode.
+	o.HandleKey('c')
+	out := w.String()
+
+	// Should show the feedback prompt label.
+	if !strings.Contains(out, "feedback>") {
+		t.Error("expected 'feedback>' prompt in converse mode")
+	}
+}
+
+func TestOverlay_ConverseKey_NonDraftNoOp(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{
+		ID: "1", Source: "slack", Author: "Alice",
+		Preview: "normal msg", Body: "normal",
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.Show()
+	w.Reset()
+
+	// Press 'c' on non-draft message — should do nothing.
+	o.HandleKey('c')
+	out := w.String()
+
+	if strings.Contains(out, "feedback>") {
+		t.Error("converse should not activate on non-draft message")
+	}
+}
+
+func TestOverlay_ConverseKey_EmptyQueue(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.Show()
+
+	// Should not panic.
+	o.HandleKey('c')
+}
+
+func TestOverlay_Converse_SubmitCallsConverse(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{
+		ID: "1", Source: "slack", Channel: "#backend", Author: "Alice",
+		Preview: "question", Body: "question?",
+		Draft: "my draft", DraftFor: "1",
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	var gotMsg launch.Message
+	var gotFeedback string
+	converseCalled := false
+	o.OnDraftConverse = func(msg launch.Message, feedback string) {
+		converseCalled = true
+		gotMsg = msg
+		gotFeedback = feedback
+	}
+
+	o.Show()
+	o.HandleKey('c')                  // enter converse mode
+	for _, b := range "be shorter" { // type feedback
+		o.HandleKey(byte(b))
+	}
+	o.HandleKey('\r') // submit
+
+	if !converseCalled {
+		t.Fatal("expected OnDraftConverse to be called")
+	}
+	if gotMsg.ID != "1" {
+		t.Errorf("expected message ID '1', got %q", gotMsg.ID)
+	}
+	if gotFeedback != "be shorter" {
+		t.Errorf("expected feedback 'be shorter', got %q", gotFeedback)
+	}
+	// Should have dismissed the overlay.
+	if o.IsActive() {
+		t.Error("overlay should be dismissed after converse submit")
+	}
+}
+
+func TestOverlay_Converse_EscCancels(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{
+		ID: "1", Source: "slack", Channel: "#backend", Author: "Alice",
+		Preview: "question", Body: "question?",
+		Draft: "my draft", DraftFor: "1",
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+
+	converseCalled := false
+	o.OnDraftConverse = func(msg launch.Message, feedback string) {
+		converseCalled = true
+	}
+
+	o.Show()
+	o.HandleKey('c')                  // enter converse mode
+	for _, b := range "some text" {
+		o.HandleKey(byte(b))
+	}
+	o.HandleKey(0x1B)                  // ESC
+	time.Sleep(150 * time.Millisecond) // wait for ESC timer
+
+	if converseCalled {
+		t.Error("OnDraftConverse should not be called after cancel")
+	}
+	// Should still be active (cancel returns to overlay, doesn't dismiss).
+	// Actually, standalone ESC in reply mode cancels reply, returning to overlay.
+	// The overlay is still showing.
+}
+
+func TestOverlay_FooterShowsConverseAction(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{
+		ID: "1", Source: "slack", Channel: "#backend", Author: "Alice",
+		Preview: "question", Body: "question?",
+		Draft: "my draft", DraftFor: "1",
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.Show()
+	out := w.String()
+
+	if !strings.Contains(out, "c revise") {
+		t.Error("expected 'c revise' in footer for draft message")
+	}
+}
+
+func TestOverlay_Converse_ClearsDraftForCycle(t *testing.T) {
+	q := launch.NewNotifyQueue(10, nil)
+	q.Push(launch.Message{
+		ID: "1", Source: "slack", Channel: "#backend", Author: "Alice",
+		Preview: "question", Body: "question?",
+		Draft: "my draft", DraftFor: "1",
+	})
+
+	var w testWriter
+	o := launch.NewOverlay(q, nil, &w, 30, 80, nil)
+	o.OnDraftConverse = func(msg launch.Message, feedback string) {}
+
+	o.Show()
+	o.HandleKey('c')
+	for _, b := range "revise it" {
+		o.HandleKey(byte(b))
+	}
+	o.HandleKey('\r')
+
+	// Draft should be cleared so the revision cycle can restart.
+	msg, ok := q.FindByID("1")
+	if !ok {
+		t.Fatal("message should still be in queue")
+	}
+	if msg.Draft != "" {
+		t.Errorf("expected draft to be cleared after converse, got %q", msg.Draft)
+	}
+}

--- a/core/launch/panel.go
+++ b/core/launch/panel.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"fmt"
 	"regexp"
 	"strings"
 )
@@ -10,148 +11,82 @@ var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x1b]*\x1b\\`)
 
 // PanelConfig configures the visual chrome of a panel.
 type PanelConfig struct {
-	Title       string   // e.g. "✈️ Aileron" or "✈️ Aileron ─ Send Message"
-	InnerWidth  int      // 0 = auto (termCols - 4, capped at 80)
-	Centered    bool     // vertically and horizontally center the box
-	FooterHints []string // e.g. ["y send", "n discard"] rendered in └─ ... ─┘
+	Title       string   // e.g. "✈️ Aileron" or "✈️ Aileron ─ Vault"
+	FooterHints []string // e.g. ["y send", "n discard"] rendered in footer
 }
 
-// Panel renders a bordered box with caller-supplied content lines.
+// Panel renders content with a yellow left accent bar. All Aileron UI
+// uses this style for a consistent look: a colored │ prefix on every
+// line, with a title header and optional footer hints.
 type Panel struct {
 	config   PanelConfig
 	termRows int
 	termCols int
-	inner    int // effective inner width
 }
 
 // NewPanel creates a panel with the given config and terminal dimensions.
 func NewPanel(cfg PanelConfig, termRows, termCols int) *Panel {
-	inner := cfg.InnerWidth
-	if inner <= 0 {
-		inner = termCols - 4
-		if inner > 80 {
-			inner = 80
-		}
+	return &Panel{config: cfg, termRows: termRows, termCols: termCols}
+}
+
+// ContentWidth returns the usable width for content (terminal width
+// minus the 2-char accent prefix "│ ").
+func (p *Panel) ContentWidth() int {
+	w := p.termCols - 2
+	if w < 10 {
+		w = 10
 	}
-	if inner < 10 {
-		inner = 10
-	}
-	return &Panel{config: cfg, termRows: termRows, termCols: termCols, inner: inner}
+	return w
 }
 
-// InnerWidth returns the effective inner width of the box content area.
-func (p *Panel) InnerWidth() int {
-	return p.inner
+// accent returns the yellow left-border prefix.
+func accent() string {
+	return "\033[33m│\033[0m "
 }
 
-// borderColor wraps s in the yellow border color.
-func borderColor(s string) string {
-	return "\033[33m" + s + "\033[0m"
-}
-
-// Render builds the complete bordered box as a string. contentLines are
-// pre-formatted lines to display inside the box. Each line is padded to
-// InnerWidth visible characters. Lines longer than InnerWidth are truncated.
+// Render builds the complete panel as a string. contentLines are
+// pre-formatted lines displayed between the header and footer.
 func (p *Panel) Render(contentLines []string) string {
-	w := p.inner
+	w := p.ContentWidth()
+	a := accent()
+
 	var buf strings.Builder
 
-	// Top border: ┌─ Title ─────┐
-	titleStr := " " + p.config.Title + " "
-	titleWidth := visibleWidth(titleStr)
-	dashesAfterTitle := w - titleWidth - 1 // -1 for the leading ─
-	if dashesAfterTitle < 1 {
-		dashesAfterTitle = 1
-	}
-	buf.WriteString(borderColor("┌─"+titleStr+strings.Repeat("─", dashesAfterTitle)+"┐") + "\r\n")
+	// Header: accent + bold title.
+	buf.WriteString(a)
+	fmt.Fprintf(&buf, "\033[1m%s\033[0m\r\n", p.config.Title)
+	// Header separator.
+	buf.WriteString(a)
+	buf.WriteString("\033[2m" + strings.Repeat("─", w) + "\033[0m\r\n")
 
-	// Content lines: │ content padded │
+	// Content lines.
 	for _, line := range contentLines {
-		vw := visibleWidth(line)
-		pad := w - vw
-		if pad < 0 {
-			pad = 0
-		}
-		buf.WriteString(borderColor("│") + line + strings.Repeat(" ", pad) + borderColor("│") + "\r\n")
+		buf.WriteString(a)
+		buf.WriteString(line)
+		buf.WriteString("\r\n")
 	}
 
-	// Bottom border: └─ footer ─────┘  or  └─────────┘
+	// Footer.
+	buf.WriteString(a + "\r\n")
+	buf.WriteString(a)
+	buf.WriteString("\033[2m" + strings.Repeat("─", w) + "\033[0m\r\n")
 	if len(p.config.FooterHints) > 0 {
-		footer := " " + strings.Join(p.config.FooterHints, "  ") + " "
-		footerWidth := len(footer)
-		dashesAfterFooter := w - footerWidth - 1
-		if dashesAfterFooter < 1 {
-			dashesAfterFooter = 1
-		}
-		buf.WriteString(borderColor("└─"+footer+strings.Repeat("─", dashesAfterFooter)+"┘") + "\r\n")
-	} else {
-		buf.WriteString(borderColor("└" + strings.Repeat("─", w) + "┘") + "\r\n")
+		buf.WriteString(a)
+		buf.WriteString("\033[2m" + strings.Join(p.config.FooterHints, "  ") + "\033[0m")
 	}
 
 	return buf.String()
 }
 
 // RenderToAltScreen wraps Render() output with alternate screen buffer
-// enter, clear screen, and centering. Does NOT include alt-screen exit.
+// enter and clear screen. Does NOT include alt-screen exit.
 func (p *Panel) RenderToAltScreen(contentLines []string) string {
-	rendered := p.Render(contentLines)
-
-	if !p.config.Centered {
-		return "\033[?1049h\033[2J\033[1;1H" + rendered
-	}
-
-	// Count rendered lines for vertical centering.
-	lines := strings.Split(rendered, "\r\n")
-	// Remove trailing empty element from split.
-	if len(lines) > 0 && lines[len(lines)-1] == "" {
-		lines = lines[:len(lines)-1]
-	}
-	boxHeight := len(lines)
-	boxWidth := p.inner + 2 // inner + left/right border chars
-
-	topPad := (p.termRows - boxHeight) / 2
-	if topPad < 0 {
-		topPad = 0
-	}
-	leftPad := (p.termCols - boxWidth) / 2
-	if leftPad < 0 {
-		leftPad = 0
-	}
-	margin := strings.Repeat(" ", leftPad)
-
-	var buf strings.Builder
-	buf.WriteString("\033[?1049h\033[2J\033[1;1H")
-	for i := 0; i < topPad; i++ {
-		buf.WriteString("\r\n")
-	}
-	for _, line := range lines {
-		buf.WriteString(margin)
-		buf.WriteString(line)
-		buf.WriteString("\r\n")
-	}
-	return buf.String()
+	return "\033[?1049h\033[2J\033[1;1H" + p.Render(contentLines)
 }
 
-// SeparatorLine returns a horizontal separator that spans the inner width
-// of the panel, using ├ and ┤ side connectors.
+// SeparatorLine returns a dim horizontal rule for in-panel dividers.
 func (p *Panel) SeparatorLine() string {
-	return borderColor("├") + borderColor(strings.Repeat("─", p.inner)) + borderColor("┤")
-}
-
-// PadLine returns a line padded with spaces to the panel's inner width.
-// Useful for building content lines with left-aligned text.
-func (p *Panel) PadLine(text string) string {
-	vw := visibleWidth(text)
-	pad := p.inner - vw
-	if pad < 0 {
-		pad = 0
-	}
-	return text + strings.Repeat(" ", pad)
-}
-
-// BlankLine returns an empty content line (all spaces, inner width).
-func (p *Panel) BlankLine() string {
-	return strings.Repeat(" ", p.inner)
+	return "\033[2m" + strings.Repeat("─", p.ContentWidth()) + "\033[0m"
 }
 
 // visibleWidth returns the display width of a string, excluding ANSI

--- a/core/launch/panel.go
+++ b/core/launch/panel.go
@@ -1,0 +1,183 @@
+package launch
+
+import (
+	"regexp"
+	"strings"
+)
+
+// ansiRE matches ANSI escape sequences (CSI and OSC).
+var ansiRE = regexp.MustCompile(`\x1b\[[0-9;]*[a-zA-Z]|\x1b\][^\x1b]*\x1b\\`)
+
+// PanelConfig configures the visual chrome of a panel.
+type PanelConfig struct {
+	Title       string   // e.g. "✈️ Aileron" or "✈️ Aileron ─ Send Message"
+	InnerWidth  int      // 0 = auto (termCols - 4, capped at 80)
+	Centered    bool     // vertically and horizontally center the box
+	FooterHints []string // e.g. ["y send", "n discard"] rendered in └─ ... ─┘
+}
+
+// Panel renders a bordered box with caller-supplied content lines.
+type Panel struct {
+	config   PanelConfig
+	termRows int
+	termCols int
+	inner    int // effective inner width
+}
+
+// NewPanel creates a panel with the given config and terminal dimensions.
+func NewPanel(cfg PanelConfig, termRows, termCols int) *Panel {
+	inner := cfg.InnerWidth
+	if inner <= 0 {
+		inner = termCols - 4
+		if inner > 80 {
+			inner = 80
+		}
+	}
+	if inner < 10 {
+		inner = 10
+	}
+	return &Panel{config: cfg, termRows: termRows, termCols: termCols, inner: inner}
+}
+
+// InnerWidth returns the effective inner width of the box content area.
+func (p *Panel) InnerWidth() int {
+	return p.inner
+}
+
+// borderColor wraps s in the yellow border color.
+func borderColor(s string) string {
+	return "\033[33m" + s + "\033[0m"
+}
+
+// Render builds the complete bordered box as a string. contentLines are
+// pre-formatted lines to display inside the box. Each line is padded to
+// InnerWidth visible characters. Lines longer than InnerWidth are truncated.
+func (p *Panel) Render(contentLines []string) string {
+	w := p.inner
+	var buf strings.Builder
+
+	// Top border: ┌─ Title ─────┐
+	titleStr := " " + p.config.Title + " "
+	titleWidth := visibleWidth(titleStr)
+	dashesAfterTitle := w - titleWidth - 1 // -1 for the leading ─
+	if dashesAfterTitle < 1 {
+		dashesAfterTitle = 1
+	}
+	buf.WriteString(borderColor("┌─"+titleStr+strings.Repeat("─", dashesAfterTitle)+"┐") + "\r\n")
+
+	// Content lines: │ content padded │
+	for _, line := range contentLines {
+		vw := visibleWidth(line)
+		pad := w - vw
+		if pad < 0 {
+			pad = 0
+		}
+		buf.WriteString(borderColor("│") + line + strings.Repeat(" ", pad) + borderColor("│") + "\r\n")
+	}
+
+	// Bottom border: └─ footer ─────┘  or  └─────────┘
+	if len(p.config.FooterHints) > 0 {
+		footer := " " + strings.Join(p.config.FooterHints, "  ") + " "
+		footerWidth := len(footer)
+		dashesAfterFooter := w - footerWidth - 1
+		if dashesAfterFooter < 1 {
+			dashesAfterFooter = 1
+		}
+		buf.WriteString(borderColor("└─"+footer+strings.Repeat("─", dashesAfterFooter)+"┘") + "\r\n")
+	} else {
+		buf.WriteString(borderColor("└" + strings.Repeat("─", w) + "┘") + "\r\n")
+	}
+
+	return buf.String()
+}
+
+// RenderToAltScreen wraps Render() output with alternate screen buffer
+// enter, clear screen, and centering. Does NOT include alt-screen exit.
+func (p *Panel) RenderToAltScreen(contentLines []string) string {
+	rendered := p.Render(contentLines)
+
+	if !p.config.Centered {
+		return "\033[?1049h\033[2J\033[1;1H" + rendered
+	}
+
+	// Count rendered lines for vertical centering.
+	lines := strings.Split(rendered, "\r\n")
+	// Remove trailing empty element from split.
+	if len(lines) > 0 && lines[len(lines)-1] == "" {
+		lines = lines[:len(lines)-1]
+	}
+	boxHeight := len(lines)
+	boxWidth := p.inner + 2 // inner + left/right border chars
+
+	topPad := (p.termRows - boxHeight) / 2
+	if topPad < 0 {
+		topPad = 0
+	}
+	leftPad := (p.termCols - boxWidth) / 2
+	if leftPad < 0 {
+		leftPad = 0
+	}
+	margin := strings.Repeat(" ", leftPad)
+
+	var buf strings.Builder
+	buf.WriteString("\033[?1049h\033[2J\033[1;1H")
+	for i := 0; i < topPad; i++ {
+		buf.WriteString("\r\n")
+	}
+	for _, line := range lines {
+		buf.WriteString(margin)
+		buf.WriteString(line)
+		buf.WriteString("\r\n")
+	}
+	return buf.String()
+}
+
+// SeparatorLine returns a horizontal separator that spans the inner width
+// of the panel, using ├ and ┤ side connectors.
+func (p *Panel) SeparatorLine() string {
+	return borderColor("├") + borderColor(strings.Repeat("─", p.inner)) + borderColor("┤")
+}
+
+// PadLine returns a line padded with spaces to the panel's inner width.
+// Useful for building content lines with left-aligned text.
+func (p *Panel) PadLine(text string) string {
+	vw := visibleWidth(text)
+	pad := p.inner - vw
+	if pad < 0 {
+		pad = 0
+	}
+	return text + strings.Repeat(" ", pad)
+}
+
+// BlankLine returns an empty content line (all spaces, inner width).
+func (p *Panel) BlankLine() string {
+	return strings.Repeat(" ", p.inner)
+}
+
+// visibleWidth returns the display width of a string, excluding ANSI
+// escape sequences. Emoji and supplementary-plane characters count as 2.
+func visibleWidth(s string) int {
+	stripped := ansiRE.ReplaceAllString(s, "")
+	return displayWidth(stripped)
+}
+
+// wrapText splits text into lines of at most maxWidth characters,
+// breaking at word boundaries where possible.
+func wrapText(text string, maxWidth int) []string {
+	if len(text) <= maxWidth {
+		return []string{text}
+	}
+	var lines []string
+	for len(text) > maxWidth {
+		idx := strings.LastIndex(text[:maxWidth], " ")
+		if idx < 0 {
+			idx = maxWidth
+		}
+		lines = append(lines, text[:idx])
+		text = strings.TrimLeft(text[idx:], " ")
+	}
+	if len(text) > 0 {
+		lines = append(lines, text)
+	}
+	return lines
+}

--- a/core/launch/panel_test.go
+++ b/core/launch/panel_test.go
@@ -1,0 +1,239 @@
+package launch_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/launch"
+)
+
+func TestPanel_Render_BasicBox(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:      "✈️ Aileron",
+		InnerWidth: 40,
+	}, 24, 80)
+
+	out := p.Render([]string{
+		p.PadLine("  Hello, world!"),
+	})
+
+	if !strings.Contains(out, "┌") {
+		t.Error("expected top-left corner")
+	}
+	if !strings.Contains(out, "┘") {
+		t.Error("expected bottom-right corner")
+	}
+	if !strings.Contains(out, "Aileron") {
+		t.Error("expected title in top border")
+	}
+	if !strings.Contains(out, "Hello, world!") {
+		t.Error("expected content")
+	}
+	if !strings.Contains(out, "│") {
+		t.Error("expected side borders")
+	}
+}
+
+func TestPanel_Render_FooterHints(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:       "✈️ Aileron",
+		InnerWidth:  40,
+		FooterHints: []string{"y send", "n discard"},
+	}, 24, 80)
+
+	out := p.Render([]string{p.BlankLine()})
+
+	if !strings.Contains(out, "y send") {
+		t.Error("expected 'y send' in footer")
+	}
+	if !strings.Contains(out, "n discard") {
+		t.Error("expected 'n discard' in footer")
+	}
+	if !strings.Contains(out, "└") {
+		t.Error("expected bottom-left corner")
+	}
+}
+
+func TestPanel_Render_NoFooter(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:      "Test",
+		InnerWidth: 30,
+	}, 24, 80)
+
+	out := p.Render([]string{p.BlankLine()})
+
+	if !strings.Contains(out, "└") {
+		t.Error("expected bottom border")
+	}
+	// Should not have stray text in footer area.
+	lines := strings.Split(out, "\r\n")
+	for _, line := range lines {
+		if strings.Contains(line, "└") && strings.Contains(line, "y ") {
+			t.Error("should not contain hint text when FooterHints is empty")
+		}
+	}
+}
+
+func TestPanel_InnerWidth_Auto(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title: "Test",
+	}, 24, 100)
+
+	// Auto: termCols - 4, capped at 80.
+	if p.InnerWidth() != 80 {
+		t.Errorf("expected auto inner width 80 (capped), got %d", p.InnerWidth())
+	}
+
+	p2 := launch.NewPanel(launch.PanelConfig{Title: "Test"}, 24, 60)
+	if p2.InnerWidth() != 56 {
+		t.Errorf("expected auto inner width 56 (60-4), got %d", p2.InnerWidth())
+	}
+}
+
+func TestPanel_InnerWidth_Explicit(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:      "Test",
+		InnerWidth: 74,
+	}, 24, 80)
+
+	if p.InnerWidth() != 74 {
+		t.Errorf("expected inner width 74, got %d", p.InnerWidth())
+	}
+}
+
+func TestPanel_SeparatorLine(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:      "Test",
+		InnerWidth: 30,
+	}, 24, 80)
+
+	sep := p.SeparatorLine()
+	if !strings.Contains(sep, "├") {
+		t.Error("expected ├ in separator")
+	}
+	if !strings.Contains(sep, "┤") {
+		t.Error("expected ┤ in separator")
+	}
+	if !strings.Contains(sep, "─") {
+		t.Error("expected ─ in separator")
+	}
+}
+
+func TestPanel_PadLine(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:      "Test",
+		InnerWidth: 20,
+	}, 24, 80)
+
+	padded := p.PadLine("hi")
+	// "hi" is 2 chars, inner width 20, so 18 trailing spaces.
+	if len(padded) != 20 {
+		t.Errorf("expected padded length 20, got %d", len(padded))
+	}
+}
+
+func TestPanel_PadLine_WithANSI(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:      "Test",
+		InnerWidth: 20,
+	}, 24, 80)
+
+	// ANSI codes should not count toward visible width.
+	padded := p.PadLine("\033[1mhi\033[0m")
+	// Visible "hi" = 2, so 18 spaces of padding, but total bytes > 20 due to ANSI.
+	if !strings.HasSuffix(padded, strings.Repeat(" ", 18)) {
+		t.Error("expected 18 trailing spaces for ANSI-styled 2-char text")
+	}
+}
+
+func TestPanel_BlankLine(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:      "Test",
+		InnerWidth: 15,
+	}, 24, 80)
+
+	blank := p.BlankLine()
+	if len(blank) != 15 {
+		t.Errorf("expected blank line length 15, got %d", len(blank))
+	}
+}
+
+func TestPanel_RenderToAltScreen_Centered(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:      "Test",
+		InnerWidth: 40,
+		Centered:   true,
+	}, 24, 80)
+
+	out := p.RenderToAltScreen([]string{p.PadLine("content")})
+
+	if !strings.HasPrefix(out, "\033[?1049h") {
+		t.Error("expected alt-screen enter at start")
+	}
+	if !strings.Contains(out, "content") {
+		t.Error("expected content in output")
+	}
+	// Should have leading spaces for horizontal centering.
+	// Box width = 42 (40 inner + 2 borders), terminal = 80, margin = 19.
+	if !strings.Contains(out, strings.Repeat(" ", 19)) {
+		t.Error("expected horizontal centering margin")
+	}
+}
+
+func TestPanel_RenderToAltScreen_NotCentered(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{
+		Title:      "Test",
+		InnerWidth: 40,
+		Centered:   false,
+	}, 24, 80)
+
+	out := p.RenderToAltScreen([]string{p.PadLine("content")})
+
+	if !strings.HasPrefix(out, "\033[?1049h") {
+		t.Error("expected alt-screen enter")
+	}
+	// Non-centered should not have leading margin spaces before the box.
+	afterClear := strings.TrimPrefix(out, "\033[?1049h\033[2J\033[1;1H")
+	if strings.HasPrefix(afterClear, "   ") {
+		t.Error("non-centered output should not have large left margin")
+	}
+}
+
+func TestVisibleWidth_PlainText(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{Title: "T", InnerWidth: 20}, 24, 80)
+	line := p.PadLine("hello")
+	// "hello" = 5 visible chars, padded to 20.
+	if len(line) != 20 {
+		t.Errorf("expected length 20 for 'hello' padded, got %d", len(line))
+	}
+}
+
+func TestVisibleWidth_ANSIStripped(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{Title: "T", InnerWidth: 20}, 24, 80)
+	// Bold "hi" is 2 visible chars.
+	line := p.PadLine("\033[1mhi\033[0m")
+	// Should end with 18 spaces.
+	if !strings.HasSuffix(line, strings.Repeat(" ", 18)) {
+		t.Errorf("expected 18 trailing spaces, got line=%q", line)
+	}
+}
+
+func TestWrapText_ShortLine(t *testing.T) {
+	lines := launch.WrapTextForTest("short", 20)
+	if len(lines) != 1 || lines[0] != "short" {
+		t.Errorf("expected single line 'short', got %v", lines)
+	}
+}
+
+func TestWrapText_LongLine(t *testing.T) {
+	text := "the quick brown fox jumps over the lazy dog"
+	lines := launch.WrapTextForTest(text, 20)
+	if len(lines) < 2 {
+		t.Errorf("expected multiple lines, got %d", len(lines))
+	}
+	for _, line := range lines {
+		if len(line) > 20 {
+			t.Errorf("line exceeds maxWidth: %q", line)
+		}
+	}
+}

--- a/core/launch/panel_test.go
+++ b/core/launch/panel_test.go
@@ -7,41 +7,31 @@ import (
 	"github.com/ALRubinger/aileron/core/launch"
 )
 
-func TestPanel_Render_BasicBox(t *testing.T) {
+func TestPanel_Render_LeftAccent(t *testing.T) {
 	p := launch.NewPanel(launch.PanelConfig{
-		Title:      "✈️ Aileron",
-		InnerWidth: 40,
+		Title: "✈️ Aileron",
 	}, 24, 80)
 
-	out := p.Render([]string{
-		p.PadLine("  Hello, world!"),
-	})
+	out := p.Render([]string{"  Hello, world!"})
 
-	if !strings.Contains(out, "┌") {
-		t.Error("expected top-left corner")
-	}
-	if !strings.Contains(out, "┘") {
-		t.Error("expected bottom-right corner")
+	if !strings.Contains(out, "│") {
+		t.Error("expected left accent bar")
 	}
 	if !strings.Contains(out, "Aileron") {
-		t.Error("expected title in top border")
+		t.Error("expected title in header")
 	}
 	if !strings.Contains(out, "Hello, world!") {
 		t.Error("expected content")
-	}
-	if !strings.Contains(out, "│") {
-		t.Error("expected side borders")
 	}
 }
 
 func TestPanel_Render_FooterHints(t *testing.T) {
 	p := launch.NewPanel(launch.PanelConfig{
 		Title:       "✈️ Aileron",
-		InnerWidth:  40,
 		FooterHints: []string{"y send", "n discard"},
 	}, 24, 80)
 
-	out := p.Render([]string{p.BlankLine()})
+	out := p.Render([]string{""})
 
 	if !strings.Contains(out, "y send") {
 		t.Error("expected 'y send' in footer")
@@ -49,123 +39,48 @@ func TestPanel_Render_FooterHints(t *testing.T) {
 	if !strings.Contains(out, "n discard") {
 		t.Error("expected 'n discard' in footer")
 	}
-	if !strings.Contains(out, "└") {
-		t.Error("expected bottom-left corner")
-	}
 }
 
 func TestPanel_Render_NoFooter(t *testing.T) {
 	p := launch.NewPanel(launch.PanelConfig{
-		Title:      "Test",
-		InnerWidth: 30,
-	}, 24, 80)
-
-	out := p.Render([]string{p.BlankLine()})
-
-	if !strings.Contains(out, "└") {
-		t.Error("expected bottom border")
-	}
-	// Should not have stray text in footer area.
-	lines := strings.Split(out, "\r\n")
-	for _, line := range lines {
-		if strings.Contains(line, "└") && strings.Contains(line, "y ") {
-			t.Error("should not contain hint text when FooterHints is empty")
-		}
-	}
-}
-
-func TestPanel_InnerWidth_Auto(t *testing.T) {
-	p := launch.NewPanel(launch.PanelConfig{
 		Title: "Test",
-	}, 24, 100)
+	}, 24, 80)
 
-	// Auto: termCols - 4, capped at 80.
-	if p.InnerWidth() != 80 {
-		t.Errorf("expected auto inner width 80 (capped), got %d", p.InnerWidth())
-	}
+	out := p.Render([]string{""})
 
-	p2 := launch.NewPanel(launch.PanelConfig{Title: "Test"}, 24, 60)
-	if p2.InnerWidth() != 56 {
-		t.Errorf("expected auto inner width 56 (60-4), got %d", p2.InnerWidth())
+	// Footer separator should still appear.
+	if !strings.Contains(out, "─") {
+		t.Error("expected separator in output")
 	}
 }
 
-func TestPanel_InnerWidth_Explicit(t *testing.T) {
-	p := launch.NewPanel(launch.PanelConfig{
-		Title:      "Test",
-		InnerWidth: 74,
-	}, 24, 80)
+func TestPanel_ContentWidth(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{Title: "Test"}, 24, 80)
+	if p.ContentWidth() != 78 {
+		t.Errorf("expected content width 78 (80-2), got %d", p.ContentWidth())
+	}
 
-	if p.InnerWidth() != 74 {
-		t.Errorf("expected inner width 74, got %d", p.InnerWidth())
+	p2 := launch.NewPanel(launch.PanelConfig{Title: "Test"}, 24, 5)
+	if p2.ContentWidth() != 10 {
+		t.Errorf("expected content width 10 (minimum), got %d", p2.ContentWidth())
 	}
 }
 
 func TestPanel_SeparatorLine(t *testing.T) {
-	p := launch.NewPanel(launch.PanelConfig{
-		Title:      "Test",
-		InnerWidth: 30,
-	}, 24, 80)
+	p := launch.NewPanel(launch.PanelConfig{Title: "Test"}, 24, 80)
 
 	sep := p.SeparatorLine()
-	if !strings.Contains(sep, "├") {
-		t.Error("expected ├ in separator")
-	}
-	if !strings.Contains(sep, "┤") {
-		t.Error("expected ┤ in separator")
-	}
 	if !strings.Contains(sep, "─") {
 		t.Error("expected ─ in separator")
 	}
 }
 
-func TestPanel_PadLine(t *testing.T) {
+func TestPanel_RenderToAltScreen(t *testing.T) {
 	p := launch.NewPanel(launch.PanelConfig{
-		Title:      "Test",
-		InnerWidth: 20,
+		Title: "Test",
 	}, 24, 80)
 
-	padded := p.PadLine("hi")
-	// "hi" is 2 chars, inner width 20, so 18 trailing spaces.
-	if len(padded) != 20 {
-		t.Errorf("expected padded length 20, got %d", len(padded))
-	}
-}
-
-func TestPanel_PadLine_WithANSI(t *testing.T) {
-	p := launch.NewPanel(launch.PanelConfig{
-		Title:      "Test",
-		InnerWidth: 20,
-	}, 24, 80)
-
-	// ANSI codes should not count toward visible width.
-	padded := p.PadLine("\033[1mhi\033[0m")
-	// Visible "hi" = 2, so 18 spaces of padding, but total bytes > 20 due to ANSI.
-	if !strings.HasSuffix(padded, strings.Repeat(" ", 18)) {
-		t.Error("expected 18 trailing spaces for ANSI-styled 2-char text")
-	}
-}
-
-func TestPanel_BlankLine(t *testing.T) {
-	p := launch.NewPanel(launch.PanelConfig{
-		Title:      "Test",
-		InnerWidth: 15,
-	}, 24, 80)
-
-	blank := p.BlankLine()
-	if len(blank) != 15 {
-		t.Errorf("expected blank line length 15, got %d", len(blank))
-	}
-}
-
-func TestPanel_RenderToAltScreen_Centered(t *testing.T) {
-	p := launch.NewPanel(launch.PanelConfig{
-		Title:      "Test",
-		InnerWidth: 40,
-		Centered:   true,
-	}, 24, 80)
-
-	out := p.RenderToAltScreen([]string{p.PadLine("content")})
+	out := p.RenderToAltScreen([]string{"content"})
 
 	if !strings.HasPrefix(out, "\033[?1049h") {
 		t.Error("expected alt-screen enter at start")
@@ -173,48 +88,35 @@ func TestPanel_RenderToAltScreen_Centered(t *testing.T) {
 	if !strings.Contains(out, "content") {
 		t.Error("expected content in output")
 	}
-	// Should have leading spaces for horizontal centering.
-	// Box width = 42 (40 inner + 2 borders), terminal = 80, margin = 19.
-	if !strings.Contains(out, strings.Repeat(" ", 19)) {
-		t.Error("expected horizontal centering margin")
-	}
 }
 
-func TestPanel_RenderToAltScreen_NotCentered(t *testing.T) {
-	p := launch.NewPanel(launch.PanelConfig{
-		Title:      "Test",
-		InnerWidth: 40,
-		Centered:   false,
-	}, 24, 80)
+func TestPanel_Render_CRLFLineEndings(t *testing.T) {
+	p := launch.NewPanel(launch.PanelConfig{Title: "Test"}, 24, 80)
+	out := p.Render([]string{"line1", "line2"})
 
-	out := p.RenderToAltScreen([]string{p.PadLine("content")})
-
-	if !strings.HasPrefix(out, "\033[?1049h") {
-		t.Error("expected alt-screen enter")
+	// Every line should use \r\n for raw terminal mode.
+	lines := strings.Split(out, "\r\n")
+	if len(lines) < 4 {
+		t.Errorf("expected at least 4 CRLF-delimited lines (header, sep, content, footer), got %d", len(lines))
 	}
-	// Non-centered should not have leading margin spaces before the box.
-	afterClear := strings.TrimPrefix(out, "\033[?1049h\033[2J\033[1;1H")
-	if strings.HasPrefix(afterClear, "   ") {
-		t.Error("non-centered output should not have large left margin")
+	// Should NOT contain bare \n (without preceding \r).
+	cleaned := strings.ReplaceAll(out, "\r\n", "")
+	if strings.Contains(cleaned, "\n") {
+		t.Error("found bare \\n without \\r — will misalign in raw terminal mode")
 	}
 }
 
 func TestVisibleWidth_PlainText(t *testing.T) {
-	p := launch.NewPanel(launch.PanelConfig{Title: "T", InnerWidth: 20}, 24, 80)
-	line := p.PadLine("hello")
-	// "hello" = 5 visible chars, padded to 20.
-	if len(line) != 20 {
-		t.Errorf("expected length 20 for 'hello' padded, got %d", len(line))
+	// "hello" is 5 visible chars.
+	if launch.VisibleWidthForTest("hello") != 5 {
+		t.Errorf("expected 5, got %d", launch.VisibleWidthForTest("hello"))
 	}
 }
 
 func TestVisibleWidth_ANSIStripped(t *testing.T) {
-	p := launch.NewPanel(launch.PanelConfig{Title: "T", InnerWidth: 20}, 24, 80)
 	// Bold "hi" is 2 visible chars.
-	line := p.PadLine("\033[1mhi\033[0m")
-	// Should end with 18 spaces.
-	if !strings.HasSuffix(line, strings.Repeat(" ", 18)) {
-		t.Errorf("expected 18 trailing spaces, got line=%q", line)
+	if launch.VisibleWidthForTest("\033[1mhi\033[0m") != 2 {
+		t.Errorf("expected 2, got %d", launch.VisibleWidthForTest("\033[1mhi\033[0m"))
 	}
 }
 

--- a/core/launch/secrets.go
+++ b/core/launch/secrets.go
@@ -90,6 +90,84 @@ func promptAndOpenVault(w io.Writer) (vault.Vault, error) {
 	return OpenLocalVault(DefaultVaultPath(), string(passphrase))
 }
 
+// PromptVaultWithPanel shows a Panel-based passphrase prompt with retry.
+// The user can enter their passphrase, see errors on wrong input, and
+// retry or press Esc to skip. Returns nil if the user skips.
+func PromptVaultWithPanel(copier *OutputCopier, router *KeyRouter, bar *StatusBar) vault.Vault {
+	inputCh := router.StealInput()
+	defer router.ReleaseInput()
+
+	copier.SetPaused(true)
+	defer copier.SetPaused(false)
+
+	termRows, termCols := 24, 80
+	if bar != nil {
+		termRows, termCols = bar.Dims()
+	}
+
+	var passBuf []byte
+	var errMsg string
+
+	for {
+		panel := NewPanel(PanelConfig{
+			Title:      "✈️ Aileron ─ Vault",
+			InnerWidth: 74,
+			Centered:   true,
+		}, termRows, termCols)
+
+		var content []string
+		content = append(content, panel.BlankLine())
+		content = append(content, panel.PadLine("  Enter your vault passphrase to unlock notifications."))
+		content = append(content, panel.BlankLine())
+		masked := strings.Repeat("*", len(passBuf))
+		content = append(content, panel.PadLine("  Passphrase: "+masked+"\033[7m \033[0m"))
+		content = append(content, panel.BlankLine())
+		if errMsg != "" {
+			content = append(content, panel.PadLine("  \033[31m"+errMsg+"\033[0m"))
+			content = append(content, panel.BlankLine())
+		}
+		content = append(content, panel.PadLine("  \033[2mEnter to unlock  Esc to skip\033[0m"))
+		content = append(content, panel.BlankLine())
+
+		screen := panel.RenderToAltScreen(content)
+		copier.WriteExclusive([]byte(screen))
+
+		// Read one byte at a time.
+		b := <-inputCh
+		switch {
+		case b == 0x1B: // Esc — skip vault
+			copier.WriteExclusive([]byte("\033[?1049l"))
+			return nil
+		case b == '\r' || b == '\n': // Enter — try unlock
+			if len(passBuf) == 0 {
+				errMsg = "Passphrase cannot be empty."
+				continue
+			}
+			v, err := OpenLocalVault(DefaultVaultPath(), string(passBuf))
+			if err != nil {
+				passBuf = passBuf[:0]
+				if strings.Contains(err.Error(), "decryption failed") {
+					errMsg = "Wrong passphrase. Try again or press Esc to skip."
+				} else {
+					errMsg = err.Error()
+				}
+				continue
+			}
+			// Success — restore screen and return.
+			copier.WriteExclusive([]byte("\033[?1049l"))
+			return v
+		case b == 0x7F || b == 0x08: // Backspace
+			if len(passBuf) > 0 {
+				passBuf = passBuf[:len(passBuf)-1]
+			}
+		default:
+			if b >= 0x20 && b < 0x7F { // printable ASCII
+				passBuf = append(passBuf, b)
+			}
+		}
+	}
+}
+
 // ResolveTokens resolves a slice of token values that may contain vault
 // references. Returns the resolved values in the same order. If any token
 // is a vault reference, the provided vault is used for lookups. If v is

--- a/core/launch/secrets.go
+++ b/core/launch/secrets.go
@@ -8,6 +8,8 @@ import (
 	"path/filepath"
 	"strings"
 
+	ptyPkg "github.com/creack/pty/v2"
+
 	"github.com/ALRubinger/aileron/core/crypto"
 	"github.com/ALRubinger/aileron/core/vault"
 	"golang.org/x/term"
@@ -92,13 +94,26 @@ func promptAndOpenVault(w io.Writer) (vault.Vault, error) {
 
 // PromptVaultWithPanel shows a Panel-based passphrase prompt with retry.
 // The user can enter their passphrase, see errors on wrong input, and
-// retry or press Esc to skip. Returns nil if the user skips.
-func PromptVaultWithPanel(copier *OutputCopier, router *KeyRouter, bar *StatusBar) vault.Vault {
+// retry or press Esc to skip. Returns nil if the user skips. The ptmx
+// parameter is the agent's pty master — used to trigger a SIGWINCH
+// redraw after the prompt closes.
+func PromptVaultWithPanel(copier *OutputCopier, router *KeyRouter, bar *StatusBar, ptmx *os.File) vault.Vault {
 	inputCh := router.StealInput()
 	defer router.ReleaseInput()
 
 	copier.SetPaused(true)
 	defer copier.SetPaused(false)
+
+	// restoreScreen exits the alt-screen buffer and triggers a SIGWINCH
+	// on the agent's pty so it redraws its TUI.
+	restoreScreen := func() {
+		copier.WriteExclusive([]byte("\033[?1049l"))
+		if ptmx != nil {
+			if ws, err := ptyPkg.GetsizeFull(ptmx); err == nil {
+				ptyPkg.Setsize(ptmx, ws)
+			}
+		}
+	}
 
 	termRows, termCols := 24, 80
 	if bar != nil {
@@ -136,7 +151,7 @@ func PromptVaultWithPanel(copier *OutputCopier, router *KeyRouter, bar *StatusBa
 		b := <-inputCh
 		switch {
 		case b == 0x1B: // Esc — skip vault
-			copier.WriteExclusive([]byte("\033[?1049l"))
+			restoreScreen()
 			return nil
 		case b == '\r' || b == '\n': // Enter — try unlock
 			if len(passBuf) == 0 {
@@ -154,7 +169,7 @@ func PromptVaultWithPanel(copier *OutputCopier, router *KeyRouter, bar *StatusBa
 				continue
 			}
 			// Success — restore screen and return.
-			copier.WriteExclusive([]byte("\033[?1049l"))
+			restoreScreen()
 			return v
 		case b == 0x7F || b == 0x08: // Backspace
 			if len(passBuf) > 0 {

--- a/core/launch/secrets.go
+++ b/core/launch/secrets.go
@@ -125,24 +125,22 @@ func PromptVaultWithPanel(copier *OutputCopier, router *KeyRouter, bar *StatusBa
 
 	for {
 		panel := NewPanel(PanelConfig{
-			Title:      "✈️ Aileron ─ Vault",
-			InnerWidth: 74,
-			Centered:   true,
+			Title: "✈️ Aileron ─ Vault",
 		}, termRows, termCols)
 
 		var content []string
-		content = append(content, panel.BlankLine())
-		content = append(content, panel.PadLine("  Enter your vault passphrase to unlock notifications."))
-		content = append(content, panel.BlankLine())
+		content = append(content, "")
+		content = append(content, "  Enter your vault passphrase to unlock notifications.")
+		content = append(content, "")
 		masked := strings.Repeat("*", len(passBuf))
-		content = append(content, panel.PadLine("  Passphrase: "+masked+"\033[7m \033[0m"))
-		content = append(content, panel.BlankLine())
+		content = append(content, "  Passphrase: "+masked+"\033[7m \033[0m")
+		content = append(content, "")
 		if errMsg != "" {
-			content = append(content, panel.PadLine("  \033[31m"+errMsg+"\033[0m"))
-			content = append(content, panel.BlankLine())
+			content = append(content, "  \033[31m"+errMsg+"\033[0m")
+			content = append(content, "")
 		}
-		content = append(content, panel.PadLine("  \033[2mEnter to unlock  Esc to skip\033[0m"))
-		content = append(content, panel.BlankLine())
+		content = append(content, "  \033[2mEnter to unlock  Esc to skip\033[0m")
+		content = append(content, "")
 
 		screen := panel.RenderToAltScreen(content)
 		copier.WriteExclusive([]byte(screen))

--- a/core/launch/secrets_test.go
+++ b/core/launch/secrets_test.go
@@ -249,3 +249,83 @@ func TestPromptVaultWithPanel_EscSkips(t *testing.T) {
 	}
 	stdinW.Close()
 }
+
+func TestPromptVaultWithPanel_EmptyPassphrase(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &simpleOverlay{}
+	router := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go router.Run()
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	outBuf := &safeBuf{}
+	copier := launch.NewOutputCopier(srcR, outBuf, nil)
+	go copier.Run()
+
+	bar := launch.NewStatusBar(24, 80, "test")
+
+	done := make(chan vault.Vault, 1)
+	go func() {
+		done <- launch.PromptVaultWithPanel(copier, router, bar, nil)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Press Enter with empty passphrase — should show error, not crash.
+	stdinW.Write([]byte{'\r'})
+	time.Sleep(100 * time.Millisecond)
+
+	// Then Esc to exit.
+	stdinW.Write([]byte{0x1B})
+
+	select {
+	case v := <-done:
+		if v != nil {
+			t.Error("expected nil vault")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+	stdinW.Close()
+}
+
+func TestPromptVaultWithPanel_TypeAndBackspace(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &simpleOverlay{}
+	router := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go router.Run()
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	outBuf := &safeBuf{}
+	copier := launch.NewOutputCopier(srcR, outBuf, nil)
+	go copier.Run()
+
+	bar := launch.NewStatusBar(24, 80, "test")
+
+	done := make(chan vault.Vault, 1)
+	go func() {
+		done <- launch.PromptVaultWithPanel(copier, router, bar, nil)
+	}()
+
+	time.Sleep(100 * time.Millisecond)
+
+	// Type some chars, backspace, then Esc.
+	stdinW.Write([]byte("abc"))
+	time.Sleep(50 * time.Millisecond)
+	stdinW.Write([]byte{0x7F}) // backspace
+	time.Sleep(50 * time.Millisecond)
+	stdinW.Write([]byte{0x1B}) // Esc
+
+	select {
+	case v := <-done:
+		if v != nil {
+			t.Error("expected nil vault")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out")
+	}
+	stdinW.Close()
+}

--- a/core/launch/secrets_test.go
+++ b/core/launch/secrets_test.go
@@ -2,9 +2,11 @@ package launch_test
 
 import (
 	"context"
+	"io"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 
 	"github.com/ALRubinger/aileron/core/launch"
 	"github.com/ALRubinger/aileron/core/vault"
@@ -210,4 +212,40 @@ func TestDefaultVaultPath(t *testing.T) {
 			t.Errorf("expected secrets.json, got %q", filepath.Base(path))
 		}
 	}
+}
+
+func TestPromptVaultWithPanel_EscSkips(t *testing.T) {
+	stdinR, stdinW := io.Pipe()
+	ptmxBuf := &safeBuf{}
+	overlay := &simpleOverlay{}
+	router := launch.NewKeyRouter(stdinR, ptmxBuf, overlay)
+	go router.Run()
+
+	srcR, srcW := io.Pipe()
+	defer srcW.Close()
+	copier := launch.NewOutputCopier(srcR, &safeBuf{}, nil)
+	go copier.Run()
+
+	bar := launch.NewStatusBar(24, 80, "test")
+
+	done := make(chan vault.Vault, 1)
+	go func() {
+		done <- launch.PromptVaultWithPanel(copier, router, bar)
+	}()
+
+	// Give the prompt time to render and steal input.
+	time.Sleep(100 * time.Millisecond)
+
+	// Press Esc to skip.
+	stdinW.Write([]byte{0x1B})
+
+	select {
+	case v := <-done:
+		if v != nil {
+			t.Error("expected nil vault after Esc")
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("timed out waiting for vault prompt")
+	}
+	stdinW.Close()
 }

--- a/core/launch/secrets_test.go
+++ b/core/launch/secrets_test.go
@@ -230,7 +230,7 @@ func TestPromptVaultWithPanel_EscSkips(t *testing.T) {
 
 	done := make(chan vault.Vault, 1)
 	go func() {
-		done <- launch.PromptVaultWithPanel(copier, router, bar)
+		done <- launch.PromptVaultWithPanel(copier, router, bar, nil)
 	}()
 
 	// Give the prompt time to render and steal input.

--- a/core/launch/statusbar.go
+++ b/core/launch/statusbar.go
@@ -8,9 +8,9 @@ import (
 )
 
 // StatusBar renders a persistent notification bar at the bottom of the
-// terminal. It occupies 2 rows: a separator line and a content line.
-// When a NotifyQueue is connected, unread messages are shown on the left
-// with the branding text on the right.
+// terminal. It occupies 3 rows: a separator line, a content line, and
+// a hint line showing keybindings. When a NotifyQueue is connected,
+// unread messages are shown on the left with the branding text on the right.
 type StatusBar struct {
 	mu    sync.Mutex
 	rows  int
@@ -32,10 +32,11 @@ func (b *StatusBar) Resize(w io.Writer, rows, cols int) {
 	defer b.mu.Unlock()
 
 	// Clear old bar position before updating dimensions.
-	if b.rows >= 3 {
-		oldSep := b.rows - 1
-		oldText := b.rows
-		fmt.Fprintf(w, "\0337\033[%d;1H\033[2K\033[%d;1H\033[2K\0338", oldSep, oldText)
+	if b.rows >= 4 {
+		oldSep := b.rows - 2
+		oldContent := b.rows - 1
+		oldHint := b.rows
+		fmt.Fprintf(w, "\0337\033[%d;1H\033[2K\033[%d;1H\033[2K\033[%d;1H\033[2K\0338", oldSep, oldContent, oldHint)
 	}
 
 	b.rows = rows
@@ -43,8 +44,8 @@ func (b *StatusBar) Resize(w io.Writer, rows, cols int) {
 	b.render(w)
 }
 
-// Render draws the status bar. It saves the cursor, draws the separator
-// and content in the bottom 2 rows, then restores the cursor.
+// Render draws the status bar. It saves the cursor, draws the separator,
+// content, and hint in the bottom 3 rows, then restores the cursor.
 func (b *StatusBar) Render(w io.Writer) {
 	b.mu.Lock()
 	defer b.mu.Unlock()
@@ -60,12 +61,13 @@ func (b *StatusBar) SetQueue(q *NotifyQueue) {
 }
 
 func (b *StatusBar) render(w io.Writer) {
-	if b.rows < 3 || b.cols < 1 {
+	if b.rows < 4 || b.cols < 1 {
 		return
 	}
 
-	sepRow := b.rows - 1
-	textRow := b.rows
+	sepRow := b.rows - 2
+	contentRow := b.rows - 1
+	hintRow := b.rows
 
 	// Build the separator line: dim thin rule
 	sep := strings.Repeat("─", b.cols)
@@ -73,13 +75,18 @@ func (b *StatusBar) render(w io.Writer) {
 	// Build the content line: notifications on the left, branding on the right.
 	content := b.buildContent()
 
+	// Build the hint line: keybinding instructions.
+	hint := b.buildHintLine()
+
 	var buf strings.Builder
 	// Save cursor position
 	buf.WriteString("\0337")
 	// Move to separator row, clear line, draw dim separator
 	fmt.Fprintf(&buf, "\033[%d;1H\033[2K\033[2m%s\033[0m", sepRow, sep)
-	// Move to text row, clear line, draw content
-	fmt.Fprintf(&buf, "\033[%d;1H\033[2K%s", textRow, content)
+	// Move to content row, clear line, draw content
+	fmt.Fprintf(&buf, "\033[%d;1H\033[2K%s", contentRow, content)
+	// Move to hint row, clear line, draw hint
+	fmt.Fprintf(&buf, "\033[%d;1H\033[2K%s", hintRow, hint)
 	// Restore cursor position
 	buf.WriteString("\0338")
 
@@ -125,6 +132,13 @@ func (b *StatusBar) buildContent() string {
 	left := fmt.Sprintf("\033[33m[%d unread]\033[0m", unread)
 	leftDisplay := len(fmt.Sprintf("[%d unread]", unread)) // display width without ANSI
 
+	// Append draft-pending indicator if any auto-draft messages are waiting.
+	if draftPending := b.queue.DraftPendingCount(); draftPending > 0 {
+		tag := fmt.Sprintf(" [%d awaiting draft]", draftPending)
+		left += fmt.Sprintf(" \033[36m[%d awaiting draft]\033[0m", draftPending)
+		leftDisplay += len(tag)
+	}
+
 	// Add preview if there's room.
 	previewSpace := b.cols - leftDisplay - brandWidth - 3 // 3 for spacing
 	if previewSpace > 10 && latest.Preview != "" {
@@ -164,7 +178,12 @@ func (b *StatusBar) Dims() (int, int) {
 
 // BarHeight returns the number of terminal rows the bar occupies.
 func (b *StatusBar) BarHeight() int {
-	return 2
+	return 3
+}
+
+// buildHintLine composes the keybinding hint shown at the bottom of the bar.
+func (b *StatusBar) buildHintLine() string {
+	return "\033[2mCtrl-] notifications\033[0m"
 }
 
 // SetScrollRegion writes the ANSI escape to confine scrolling to the top

--- a/core/launch/statusbar_test.go
+++ b/core/launch/statusbar_test.go
@@ -31,11 +31,15 @@ func TestStatusBar_Render(t *testing.T) {
 	if !strings.Contains(out, "─") {
 		t.Error("expected separator line")
 	}
-	// Should position at row 23 (rows-1) for separator
+	// Should position at row 22 (rows-2) for separator
+	if !strings.Contains(out, "\033[22;1H") {
+		t.Errorf("expected cursor move to row 22, got %q", out)
+	}
+	// Should position at row 23 (rows-1) for content
 	if !strings.Contains(out, "\033[23;1H") {
 		t.Errorf("expected cursor move to row 23, got %q", out)
 	}
-	// Should position at row 24 (rows) for text
+	// Should position at row 24 (rows) for hint
 	if !strings.Contains(out, "\033[24;1H") {
 		t.Errorf("expected cursor move to row 24, got %q", out)
 	}
@@ -48,26 +52,26 @@ func TestStatusBar_Resize(t *testing.T) {
 	bar.Resize(&buf, 30, 120)
 	out := buf.String()
 
-	// After resize to 30 rows, separator should be at row 29
-	if !strings.Contains(out, "\033[29;1H") {
-		t.Errorf("expected cursor move to row 29 after resize, got %q", out)
+	// After resize to 30 rows, separator should be at row 28 (rows-2)
+	if !strings.Contains(out, "\033[28;1H") {
+		t.Errorf("expected cursor move to row 28 after resize, got %q", out)
 	}
 }
 
 func TestStatusBar_TooSmallTerminal(t *testing.T) {
-	bar := launch.NewStatusBar(2, 80, "test")
+	bar := launch.NewStatusBar(3, 80, "test")
 	var buf bytes.Buffer
 	bar.Render(&buf)
-	// With only 2 rows, bar should not render (needs at least 3)
+	// With only 3 rows, bar should not render (needs at least 4)
 	if buf.Len() != 0 {
-		t.Errorf("expected no output for 2-row terminal, got %q", buf.String())
+		t.Errorf("expected no output for 3-row terminal, got %q", buf.String())
 	}
 }
 
 func TestStatusBar_BarHeight(t *testing.T) {
 	bar := launch.NewStatusBar(24, 80, "test")
-	if bar.BarHeight() != 2 {
-		t.Errorf("expected bar height 2, got %d", bar.BarHeight())
+	if bar.BarHeight() != 3 {
+		t.Errorf("expected bar height 3, got %d", bar.BarHeight())
 	}
 }
 
@@ -325,5 +329,53 @@ func TestStatusBar_OutsideQuietHoursShowsNormal(t *testing.T) {
 	}
 	if !strings.Contains(out, "1 unread") {
 		t.Errorf("expected '1 unread' outside quiet hours, got:\n%s", out)
+	}
+}
+
+func TestStatusBar_DraftPendingIndicator(t *testing.T) {
+	bar := launch.NewStatusBar(24, 120, "brand")
+	q := launch.NewNotifyQueue(10, nil)
+	bar.SetQueue(q)
+
+	// Auto-draft message without a draft yet.
+	q.Push(launch.Message{ID: "1", Preview: "hello", AutoDraft: true})
+
+	var buf bytes.Buffer
+	bar.Render(&buf)
+	out := buf.String()
+
+	if !strings.Contains(out, "1 awaiting draft") {
+		t.Errorf("expected '1 awaiting draft' indicator, got:\n%s", out)
+	}
+}
+
+func TestStatusBar_DraftPendingDisappearsAfterDraft(t *testing.T) {
+	bar := launch.NewStatusBar(24, 120, "brand")
+	q := launch.NewNotifyQueue(10, nil)
+	bar.SetQueue(q)
+
+	q.Push(launch.Message{ID: "1", Preview: "hello", AutoDraft: true})
+	q.SetDraft("1", "my reply")
+
+	var buf bytes.Buffer
+	bar.Render(&buf)
+	out := buf.String()
+
+	if strings.Contains(out, "awaiting draft") {
+		t.Errorf("should not show 'awaiting draft' after draft is set, got:\n%s", out)
+	}
+}
+
+func TestStatusBar_HintLineShown(t *testing.T) {
+	bar := launch.NewStatusBar(24, 80, "brand")
+	var buf bytes.Buffer
+	bar.Render(&buf)
+	out := buf.String()
+
+	if !strings.Contains(out, "Ctrl-]") {
+		t.Error("expected 'Ctrl-]' in hint line")
+	}
+	if !strings.Contains(out, "notifications") {
+		t.Error("expected 'notifications' in hint line")
 	}
 }


### PR DESCRIPTION
## Summary

- **Overlay-gated drafts**: Auto-draft messages no longer inject prompts automatically. User opens the notification overlay (Ctrl-]), selects a message, and presses `a` to ask the agent to draft. Four actions on a draft: send (y), edit (e), revise with feedback (c), discard (n).
- **Ctrl-] keybinding with CSI u support**: Changed overlay prefix from Ctrl-A to Ctrl-] (safe across Claude Code, tmux, screen). Added kitty keyboard protocol state machine so Ctrl-] works in modern terminals like Ghostty that encode it as ESC[93;5u.
- **draft_reply MCP tool**: Separates drafting (agent's job) from sending (Aileron's job). Agent calls `draft_reply` to submit text; Aileron shows the draft for user review and handles sending after approval.
- **Auto-register aileron-mcp**: `aileron launch` now passes `--mcp-config` to Claude Code so the MCP tools (read_messages, draft_reply, send_message, http_request) are available immediately — no manual `claude mcp add` needed.
- **Unified Panel UI**: All Aileron screens (notifications, approval prompt, send-message prompt, vault passphrase) use the same left accent bar (yellow │) via a shared Panel component.
- **Vault passphrase retry**: Wrong passphrase now shows a Panel-based error with retry, instead of silently logging to stderr. Vault opening is deferred until after the PTY is set up.
- **3-row statusbar**: Expanded from 2 to 3 rows with a keybinding hint line showing `Ctrl-] notifications`.

## Test plan

- [x] `go test ./core/launch/...` — all tests pass (88.9% coverage)
- [x] `go build ./core/... ./cmd/aileron/... ./cmd/aileron-mcp/...` — clean build
- [x] Manual: `aileron launch` → Ctrl-] opens overlay → press a to draft → agent calls draft_reply → draft appears → y sends to Slack
- [x] Manual: wrong vault passphrase → Panel error with retry → correct passphrase → session starts
- [x] Manual: Ctrl-] works in Ghostty (CSI u protocol)

🤖 Generated with [Claude Code](https://claude.com/claude-code)