### PR TITLE
feat(comms): user OAuth token for Slack, vault passphrase safety

### DIFF
--- a/README.md
+++ b/README.md
@@ -259,14 +259,19 @@ Aileron can receive Slack messages in your terminal while you work. Incoming mes
 
 **1. Create a Slack app** with [Socket Mode](https://api.slack.com/apis/socket-mode) enabled. You need:
 - An **App-Level Token** (`xapp-...`) with `connections:write` scope
-- A **Bot Token** (`xoxb-...`) with `channels:history`, `channels:read`, `chat:write`, `users:read` scopes
+- A **Bot Token** (`xoxb-...`) with `channels:history`, `channels:read`, `users:read` scopes — used for receiving messages
+- (Optional) A **User OAuth Token** (`xoxp-...`) with `chat:write` scope — used for sending messages as yourself instead of the bot
 - Subscribe to the `message.channels` event
+- Invite the bot to channels it should listen on (`/invite @your-bot`)
+
+If you only provide a bot token, replies are sent as the bot. Add a user token so replies come from your identity.
 
 **2. Store tokens in the encrypted vault** (instead of plaintext in YAML):
 
 ```sh
 ./build/aileron secret set slack_app_token    # prompts for passphrase + token
 ./build/aileron secret set slack_bot_token
+./build/aileron secret set slack_user_token   # optional — for sending as yourself
 ./build/aileron secret list                   # shows stored names
 ```
 
@@ -277,6 +282,7 @@ notifications:
   slack:
     app_token: vault:slack_app_token
     bot_token: vault:slack_bot_token
+    user_token: vault:slack_user_token   # optional — omit to send as bot
     channels:
       - name: "#backend"
         show: all

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -440,7 +440,7 @@ func runSecretSet(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	fmt.Fprint(stderr, "Secret value: ")
+	fmt.Fprintf(stderr, "Value for new secret: %s: ", name)
 	value, err := promptPassphrase("", nil) // already printed prompt
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -486,7 +486,10 @@ func runSecretList(stdout, stderr io.Writer) int {
 }
 
 // promptPassphrase reads a password from the terminal without echoing.
-func promptPassphrase(prompt string, w io.Writer) (string, error) {
+// Replaceable in tests.
+var promptPassphrase = defaultPromptPassphrase
+
+func defaultPromptPassphrase(prompt string, w io.Writer) (string, error) {
 	if w != nil && prompt != "" {
 		fmt.Fprint(w, prompt)
 	}

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -440,7 +440,7 @@ func runSecretSet(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 
-	fmt.Fprintf(stderr, "Value for new secret: %s: ", name)
+	fmt.Fprintf(stderr, "Value for new secret, %q: ", name)
 	value, err := promptPassphrase("", nil) // already printed prompt
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -399,10 +399,45 @@ func runSecretSet(args []string, stdout, stderr io.Writer) int {
 	}
 	name := args[0]
 
+	// Check if this is a brand-new vault (no existing secrets).
+	vaultPath := launch.DefaultVaultPath()
+	isNewVault := true
+	if fv, err := vault.NewFileVault(vaultPath); err == nil {
+		isNewVault = len(fv.Names()) == 0
+	}
+
+	if isNewVault {
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "  Creating a new Aileron vault.")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "  The passphrase you choose protects all secrets in this vault.")
+		fmt.Fprintln(stderr, "  It is never stored, transmitted, or recoverable. No one can")
+		fmt.Fprintln(stderr, "  read it, tell you what it is, or help you retrieve it.")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "  If you lose this passphrase, you must delete the vault file")
+		fmt.Fprintf(stderr, "  (%s) and re-add all secrets.\n", vaultPath)
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintln(stderr, "  Store this passphrase securely. Do not share it.")
+		fmt.Fprintln(stderr, "")
+	}
+
 	passphrase, err := promptPassphrase("Vault passphrase: ", stderr)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
+	}
+
+	// For a new vault, require confirmation.
+	if isNewVault {
+		confirm, err := promptPassphrase("Confirm passphrase: ", stderr)
+		if err != nil {
+			fmt.Fprintf(stderr, "error: %v\n", err)
+			return 1
+		}
+		if passphrase != confirm {
+			fmt.Fprintln(stderr, "error: passphrases do not match")
+			return 1
+		}
 	}
 
 	fmt.Fprint(stderr, "Secret value: ")
@@ -413,7 +448,7 @@ func runSecretSet(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintln(stderr) // newline after hidden input
 
-	v, err := launch.OpenLocalVault(launch.DefaultVaultPath(), passphrase)
+	v, err := launch.OpenLocalVault(vaultPath, passphrase)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -2,6 +2,8 @@ package main
 
 import (
 	"bytes"
+	"fmt"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -1147,5 +1149,86 @@ func TestRunSecret_InHelp(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "aileron secret list") {
 		t.Error("expected 'aileron secret list' in help output")
+	}
+}
+
+func mockPromptPassphrase(responses []string) func() {
+	calls := 0
+	old := promptPassphrase
+	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
+		if calls >= len(responses) {
+			return "", fmt.Errorf("unexpected prompt call %d", calls)
+		}
+		r := responses[calls]
+		calls++
+		return r, nil
+	}
+	return func() { promptPassphrase = old }
+}
+
+func TestRunSecretSet_NewVault(t *testing.T) {
+	dir := t.TempDir()
+	origDefault := launch.DefaultVaultPath
+	launch.DefaultVaultPath = func() string { return filepath.Join(dir, "secrets.json") }
+	defer func() { launch.DefaultVaultPath = origDefault }()
+
+	// Passphrase, confirm, secret value.
+	restore := mockPromptPassphrase([]string{"mypass", "mypass", "secret-value"})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := runSecretSet([]string{"test_token"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit 0, got %d; stderr: %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Stored secret") {
+		t.Error("expected success message")
+	}
+	if !strings.Contains(stderr.String(), "Creating a new Aileron vault") {
+		t.Error("expected new vault warning")
+	}
+}
+
+func TestRunSecretSet_WrongPassphrase(t *testing.T) {
+	dir := t.TempDir()
+	vaultPath := filepath.Join(dir, "secrets.json")
+	origDefault := launch.DefaultVaultPath
+	launch.DefaultVaultPath = func() string { return vaultPath }
+	defer func() { launch.DefaultVaultPath = origDefault }()
+
+	// Create a vault with one secret.
+	restore := mockPromptPassphrase([]string{"correct", "correct", "val"})
+	var discard bytes.Buffer
+	runSecretSet([]string{"existing"}, &discard, &discard)
+	restore()
+
+	// Now try to add with wrong passphrase.
+	restore = mockPromptPassphrase([]string{"wrong", "also-wrong"})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := runSecretSet([]string{"new_token"}, &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected non-zero exit for wrong passphrase")
+	}
+}
+
+func TestRunSecretSet_MismatchedConfirmation(t *testing.T) {
+	dir := t.TempDir()
+	origDefault := launch.DefaultVaultPath
+	launch.DefaultVaultPath = func() string { return filepath.Join(dir, "secrets.json") }
+	defer func() { launch.DefaultVaultPath = origDefault }()
+
+	// Passphrase and confirm don't match.
+	restore := mockPromptPassphrase([]string{"pass1", "pass2"})
+	defer restore()
+
+	var stdout, stderr bytes.Buffer
+	code := runSecretSet([]string{"test_token"}, &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected non-zero exit for mismatched passphrases")
+	}
+	if !strings.Contains(stderr.String(), "do not match") {
+		t.Error("expected mismatch error")
 	}
 }

--- a/core/comms/slack.go
+++ b/core/comms/slack.go
@@ -16,17 +16,19 @@ import (
 // It connects via WebSocket (no public URL required) and delivers
 // incoming messages to a channel.
 type SlackListener struct {
-	appToken string
-	botToken string
-	channels map[string]bool // channel names to listen on
-	ignore   map[string]bool // channel names to ignore
-	log      *slog.Logger
+	appToken  string
+	botToken  string
+	userToken string // optional; when set, Send() uses this token (messages come from the user)
+	channels  map[string]bool // channel names to listen on
+	ignore    map[string]bool // channel names to ignore
+	log       *slog.Logger
 
 	// apiURL overrides the Slack API base URL for testing.
 	apiURL string
 
-	api    *slack.Client
-	socket *socketmode.Client
+	api     *slack.Client // bot client — used for receiving, channel/user lookups
+	sendAPI *slack.Client // client used for Send(); user client if userToken set, else bot client
+	socket  *socketmode.Client
 }
 
 // SetAPIURL overrides the Slack API base URL. Call before Connect.
@@ -36,8 +38,9 @@ func (s *SlackListener) SetAPIURL(url string) {
 }
 
 // NewSlackListener creates a Slack listener with the given tokens and
-// channel configuration.
-func NewSlackListener(appToken, botToken string, channels, ignore []string, log *slog.Logger) *SlackListener {
+// channel configuration. The userToken is optional — when provided,
+// Send() uses it so messages appear from the user instead of the bot.
+func NewSlackListener(appToken, botToken, userToken string, channels, ignore []string, log *slog.Logger) *SlackListener {
 	chMap := make(map[string]bool, len(channels))
 	for _, ch := range channels {
 		chMap[ch] = true
@@ -47,11 +50,12 @@ func NewSlackListener(appToken, botToken string, channels, ignore []string, log 
 		igMap[ch] = true
 	}
 	return &SlackListener{
-		appToken: appToken,
-		botToken: botToken,
-		channels: chMap,
-		ignore:   igMap,
-		log:      log,
+		appToken:  appToken,
+		botToken:  botToken,
+		userToken: userToken,
+		channels:  chMap,
+		ignore:    igMap,
+		log:       log,
 	}
 }
 
@@ -75,7 +79,19 @@ func (s *SlackListener) Connect(ctx context.Context) error {
 		socketmode.OptionLog(log.New(log.Writer(), "slack-socket: ", log.LstdFlags)),
 	)
 
-	s.log.Debug("slack: connected", "channels", len(s.channels))
+	// Use the user token for sending if provided, so messages come from
+	// the user's identity instead of the bot.
+	if s.userToken != "" {
+		var sendOpts []slack.Option
+		if s.apiURL != "" {
+			sendOpts = append(sendOpts, slack.OptionAPIURL(s.apiURL))
+		}
+		s.sendAPI = slack.New(s.userToken, sendOpts...)
+	} else {
+		s.sendAPI = s.api
+	}
+
+	s.log.Debug("slack: connected", "channels", len(s.channels), "user_token", s.userToken != "")
 	return nil
 }
 
@@ -231,12 +247,13 @@ func BuildIncomingMessage(ts, channel, author, text string) IncomingMessage {
 	}
 }
 
-// Send posts a message to the given Slack channel.
+// Send posts a message to the given Slack channel. If a user token was
+// provided, messages are sent as the user; otherwise as the bot.
 func (s *SlackListener) Send(ctx context.Context, msg OutgoingMessage) error {
-	if s.api == nil {
+	if s.sendAPI == nil {
 		return fmt.Errorf("slack: not connected")
 	}
-	_, _, err := s.api.PostMessageContext(ctx, msg.Channel,
+	_, _, err := s.sendAPI.PostMessageContext(ctx, msg.Channel,
 		slack.MsgOptionText(msg.Body, false),
 	)
 	return err

--- a/core/comms/slack_integration_test.go
+++ b/core/comms/slack_integration_test.go
@@ -57,7 +57,7 @@ func TestSlackListener_ResolveChannelAndAuthor(t *testing.T) {
 	srv := newMockSlackServer()
 	defer srv.Close()
 
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 	sl.SetAPIURL(srv.URL + "/")
 
 	if err := sl.Connect(context.Background()); err != nil {
@@ -114,7 +114,7 @@ func TestSlackListener_ResolveAuthorFallbackToName(t *testing.T) {
 	srv := httptest.NewServer(mux)
 	defer srv.Close()
 
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 	sl.SetAPIURL(srv.URL + "/")
 	sl.Connect(context.Background())
 
@@ -135,7 +135,7 @@ func TestSlackListener_Send(t *testing.T) {
 	srv := newMockSlackServer()
 	defer srv.Close()
 
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 	sl.SetAPIURL(srv.URL + "/")
 	sl.Connect(context.Background())
 
@@ -152,7 +152,7 @@ func TestSlackListener_SendConnected(t *testing.T) {
 	srv := newMockSlackServer()
 	defer srv.Close()
 
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 	sl.SetAPIURL(srv.URL + "/")
 	sl.Connect(context.Background())
 

--- a/core/comms/slack_test.go
+++ b/core/comms/slack_test.go
@@ -26,6 +26,7 @@ func TestNewSlackListener(t *testing.T) {
 	sl := comms.NewSlackListener(
 		"xapp-test",
 		"xoxb-test",
+		"",
 		[]string{"#backend", "#incidents"},
 		[]string{"#random"},
 		nopLogger(),
@@ -36,7 +37,7 @@ func TestNewSlackListener(t *testing.T) {
 }
 
 func TestSlackListener_ConnectMissingTokens(t *testing.T) {
-	sl := comms.NewSlackListener("", "", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("", "", "", nil, nil, nopLogger())
 	err := sl.Connect(context.Background())
 	if err == nil {
 		t.Fatal("expected error for missing tokens")
@@ -44,7 +45,7 @@ func TestSlackListener_ConnectMissingTokens(t *testing.T) {
 }
 
 func TestSlackListener_ConnectValidTokens(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 	err := sl.Connect(context.Background())
 	if err != nil {
 		t.Fatalf("expected no error, got %v", err)
@@ -52,7 +53,7 @@ func TestSlackListener_ConnectValidTokens(t *testing.T) {
 }
 
 func TestSlackListener_ListenWithoutConnect(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 	// Don't call Connect.
 	_, err := sl.Listen(context.Background())
 	if err == nil {
@@ -61,7 +62,7 @@ func TestSlackListener_ListenWithoutConnect(t *testing.T) {
 }
 
 func TestSlackListener_SendWithoutConnect(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 	err := sl.Send(context.Background(), comms.OutgoingMessage{
 		Channel: "#test",
 		Body:    "hello",
@@ -72,7 +73,7 @@ func TestSlackListener_SendWithoutConnect(t *testing.T) {
 }
 
 func TestSlackListener_Close(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 	// Close without connect should not panic.
 	if err := sl.Close(); err != nil {
 		t.Fatalf("Close failed: %v", err)
@@ -80,7 +81,7 @@ func TestSlackListener_Close(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test",
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "",
 		[]string{"C123"}, []string{"C999"}, nopLogger())
 
 	msg, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
@@ -104,7 +105,7 @@ func TestSlackListener_ProcessMessageEvent(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent_BotSkipped(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 
 	_, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
 		User:    "U123",
@@ -118,7 +119,7 @@ func TestSlackListener_ProcessMessageEvent_BotSkipped(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent_IgnoredChannel(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, []string{"C999"}, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, []string{"C999"}, nopLogger())
 
 	_, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
 		User:    "U123",
@@ -131,7 +132,7 @@ func TestSlackListener_ProcessMessageEvent_IgnoredChannel(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent_UnlistedChannel(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test",
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "",
 		[]string{"C123"}, nil, nopLogger()) // only listen on C123
 
 	_, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
@@ -145,7 +146,7 @@ func TestSlackListener_ProcessMessageEvent_UnlistedChannel(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent_LongPreview(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 
 	longText := strings.Repeat("x", 100)
 	msg, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
@@ -162,7 +163,7 @@ func TestSlackListener_ProcessMessageEvent_LongPreview(t *testing.T) {
 }
 
 func TestSlackListener_ProcessMessageEvent_NoChannelFilter(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, nopLogger()) // no channel filter
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger()) // no channel filter
 
 	_, ok := sl.ProcessMessageEvent(&slackevents.MessageEvent{
 		User:    "U123",
@@ -203,7 +204,7 @@ func TestBuildIncomingMessage_LongTextTruncated(t *testing.T) {
 }
 
 func TestSlackListener_DebugLogging(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test",
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "",
 		[]string{"C123"}, []string{"C999"}, debugLogger())
 
 	// Connect — exercises the "connected" log line.
@@ -236,7 +237,7 @@ func TestSlackListener_DebugLogging(t *testing.T) {
 }
 
 func TestSlackListener_HandleEvent_NonMessageTypes(t *testing.T) {
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test", nil, nil, debugLogger())
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, debugLogger())
 	if err := sl.Connect(context.Background()); err != nil {
 		t.Fatalf("Connect: %v", err)
 	}
@@ -272,7 +273,7 @@ func TestSlackListener_ChannelNameMatching(t *testing.T) {
 	// Config uses channel name "#backend" but Slack sends channel ID "C123".
 	// Without API connection, resolveChannelName returns raw ID, so the
 	// channel filter uses both ID and name for matching.
-	sl := comms.NewSlackListener("xapp-test", "xoxb-test",
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "",
 		[]string{"#backend"}, nil, nopLogger())
 
 	// Channel ID "C123" doesn't match "#backend" by ID, and without

--- a/core/comms/slack_test.go
+++ b/core/comms/slack_test.go
@@ -52,6 +52,25 @@ func TestSlackListener_ConnectValidTokens(t *testing.T) {
 	}
 }
 
+func TestSlackListener_ConnectWithUserToken(t *testing.T) {
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "xoxp-user", nil, nil, nopLogger())
+	err := sl.Connect(context.Background())
+	if err != nil {
+		t.Fatalf("expected no error, got %v", err)
+	}
+	// Send should use the user token client (we can't verify the token
+	// directly, but Connect should not error with a user token set).
+}
+
+func TestSlackListener_SendWithoutConnect_UserToken(t *testing.T) {
+	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "xoxp-user", nil, nil, nopLogger())
+	// Don't call Connect — sendAPI is nil.
+	err := sl.Send(context.Background(), comms.OutgoingMessage{Channel: "#test", Body: "hi"})
+	if err == nil {
+		t.Fatal("expected error when sending without connect")
+	}
+}
+
 func TestSlackListener_ListenWithoutConnect(t *testing.T) {
 	sl := comms.NewSlackListener("xapp-test", "xoxb-test", "", nil, nil, nopLogger())
 	// Don't call Connect.

--- a/core/launch/launcher.go
+++ b/core/launch/launcher.go
@@ -658,9 +658,20 @@ func prepareCommsConfig(dir string, sessionLog *slog.Logger) *commsSetup {
 		}
 	}
 
+	if cfg := pf.Notifications.Slack; cfg != nil && cfg.UserToken != "" {
+		if err := ValidateTokenRef("slack.user_token", cfg.UserToken); err != nil {
+			sessionLog.Warn("slack token validation failed", "error", err)
+			fmt.Fprintf(os.Stderr, "aileron: %v\n", err)
+			return nil
+		}
+	}
+
 	var tokenRefs []string
 	if cfg := pf.Notifications.Slack; cfg != nil {
 		tokenRefs = append(tokenRefs, cfg.AppToken, cfg.BotToken)
+		if cfg.UserToken != "" {
+			tokenRefs = append(tokenRefs, cfg.UserToken)
+		}
 	}
 	if cfg := pf.Notifications.Discord; cfg != nil {
 		tokenRefs = append(tokenRefs, cfg.BotToken)
@@ -710,6 +721,11 @@ func startCommsWithVault(ctx context.Context, setup *commsSetup, v vault.Vault, 
 	if cfg := setup.pf.Notifications.Slack; cfg != nil && cfg.AppToken != "" && cfg.BotToken != "" {
 		appToken, botToken := resolved[idx], resolved[idx+1]
 		idx += 2
+		var userToken string
+		if cfg.UserToken != "" {
+			userToken = resolved[idx]
+			idx++
+		}
 		channels := make([]string, 0, len(cfg.Channels))
 		for _, ch := range cfg.Channels {
 			channels = append(channels, ch.Name)
@@ -723,8 +739,9 @@ func startCommsWithVault(ctx context.Context, setup *commsSetup, v vault.Vault, 
 		sessionLog.Info("slack listener configured",
 			"channels", channels,
 			"ignore", cfg.Ignore,
+			"user_token", userToken != "",
 		)
-		sl := comms.NewSlackListener(appToken, botToken, channels, cfg.Ignore, sessionLog.With("component", "slack"))
+		sl := comms.NewSlackListener(appToken, botToken, userToken, channels, cfg.Ignore, sessionLog.With("component", "slack"))
 		created = append(created, sl)
 	}
 	if cfg := setup.pf.Notifications.Discord; cfg != nil && cfg.BotToken != "" {

--- a/core/launch/launcher_test.go
+++ b/core/launch/launcher_test.go
@@ -743,6 +743,76 @@ notifications:
 	}
 }
 
+func TestLaunch_VaultRefsWithUserToken(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+notifications:
+  slack:
+    app_token: vault:slack_app
+    bot_token: vault:slack_bot
+    user_token: vault:slack_user
+    channels:
+      - name: "#test"
+`), 0o644)
+
+	v := vault.NewMemVault()
+	v.Put(nil, "slack_app", []byte("xapp-resolved"), vault.Metadata{})
+	v.Put(nil, "slack_bot", []byte("xoxb-resolved"), vault.Metadata{})
+	v.Put(nil, "slack_user", []byte("xoxp-resolved"), vault.Metadata{})
+
+	old := launch.OpenVaultFunc
+	launch.OpenVaultFunc = func(w io.Writer) (vault.Vault, error) { return v, nil }
+	defer func() { launch.OpenVaultFunc = old }()
+
+	script := filepath.Join(dir, "noop.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\ntrue\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("launch with user_token vault ref should succeed: %v", err)
+	}
+}
+
+func TestLaunch_UserTokenPlaintextRejected(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
+version: 1
+default: allow
+notifications:
+  slack:
+    app_token: vault:slack_app
+    bot_token: vault:slack_bot
+    user_token: xoxp-plaintext-bad
+    channels:
+      - name: "#test"
+`), 0o644)
+
+	script := filepath.Join(dir, "noop.sh")
+	os.WriteFile(script, []byte("#!/bin/sh\ntrue\n"), 0o755)
+
+	agent := scriptAgent{script: script}
+	// Should succeed (launch continues without notifications when validation fails).
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:     agent,
+		ShellShim: "/tmp/fake-shim",
+		Dir:       dir,
+	})
+	if err != nil {
+		t.Fatalf("launch should succeed even when user_token is rejected: %v", err)
+	}
+}
+
 func TestLaunch_VaultRefsWithDiscord(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)

--- a/core/launch/secrets.go
+++ b/core/launch/secrets.go
@@ -18,7 +18,8 @@ import (
 const vaultPrefix = "vault:"
 
 // DefaultVaultPath returns the default vault file path (~/.aileron/secrets.json).
-func DefaultVaultPath() string {
+// Replaceable in tests.
+var DefaultVaultPath = func() string {
 	home, err := os.UserHomeDir()
 	if err != nil {
 		return filepath.Join(".aileron", "secrets.json")

--- a/core/launch/secrets.go
+++ b/core/launch/secrets.go
@@ -49,6 +49,17 @@ func OpenLocalVault(vaultPath, passphrase string) (vault.Vault, error) {
 	if err != nil {
 		return nil, fmt.Errorf("creating encrypted vault: %w", err)
 	}
+
+	// Validate the passphrase by trying to decrypt an existing secret.
+	// This prevents adding secrets with a wrong passphrase, which would
+	// leave the vault in a state where no single passphrase can decrypt
+	// all secrets.
+	if names := fv.Names(); len(names) > 0 {
+		if _, err := ev.Get(context.Background(), names[0]); err != nil {
+			return nil, fmt.Errorf("vault: decrypting secret at %q: %w", names[0], err)
+		}
+	}
+
 	return ev, nil
 }
 

--- a/core/launch/secrets_test.go
+++ b/core/launch/secrets_test.go
@@ -87,11 +87,15 @@ func TestOpenLocalVault_RoundTrip(t *testing.T) {
 func TestOpenLocalVault_WrongPassphrase(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "secrets.json")
 
-	v1, _ := launch.OpenLocalVault(path, "correct")
+	v1, err := launch.OpenLocalVault(path, "correct")
+	if err != nil {
+		t.Fatalf("first open: %v", err)
+	}
 	v1.Put(context.Background(), "token", []byte("value"), vault.Metadata{})
 
-	v2, _ := launch.OpenLocalVault(path, "wrong")
-	_, err := v2.Get(context.Background(), "token")
+	// Opening with the wrong passphrase should fail immediately now that
+	// the vault validates the passphrase against existing secrets.
+	_, err = launch.OpenLocalVault(path, "wrong")
 	if err == nil {
 		t.Error("expected error with wrong passphrase")
 	}

--- a/core/policy/launch/schema.go
+++ b/core/policy/launch/schema.go
@@ -56,10 +56,11 @@ type QuietHoursConfig struct {
 
 // SlackNotifyConfig configures Slack integration.
 type SlackNotifyConfig struct {
-	AppToken string         `yaml:"app_token,omitempty"` // xapp-... Socket Mode token
-	BotToken string         `yaml:"bot_token,omitempty"` // xoxb-... Bot token
-	Channels []ChannelConfig `yaml:"channels,omitempty"`
-	Ignore   []string       `yaml:"ignore,omitempty"`
+	AppToken  string          `yaml:"app_token,omitempty"`  // xapp-... Socket Mode token
+	BotToken  string          `yaml:"bot_token,omitempty"`  // xoxb-... Bot token (receiving)
+	UserToken string          `yaml:"user_token,omitempty"` // xoxp-... User OAuth token (sending as you)
+	Channels  []ChannelConfig `yaml:"channels,omitempty"`
+	Ignore    []string        `yaml:"ignore,omitempty"`
 }
 
 // DiscordNotifyConfig configures Discord integration.


### PR DESCRIPTION
## Summary

- **Send Slack messages as yourself**: Optional `user_token` (`xoxp-...`) field in Slack config. When provided, replies come from your identity instead of the bot. Bot token continues to handle receiving via Socket Mode.
- **Vault passphrase validation**: `OpenLocalVault` now tries to decrypt an existing secret when opening. Wrong passphrase is rejected immediately, preventing secrets encrypted under different keys.
- **New vault passphrase confirmation**: First `aileron secret set` explains that the passphrase is unrecoverable, requires typing it twice, and warns the user to store it securely.
- **Clearer secret prompt**: Shows `Value for new secret, "slack_app_token":` instead of the generic `Secret value:`.

## Test plan

- [x] `go test ./core/... ./cmd/aileron/...` — all tests pass
- [x] `aileron secret set` on empty vault shows security warning and requires confirmation
- [x] `aileron secret set` with wrong passphrase on existing vault is rejected
- [x] Slack messages sent with user_token appear from user identity
- [x] README updated with user_token setup instructions

🤖 Generated with [Claude Code](https://claude.com/claude-code)