### PR TITLE
chore(docs): clean derived openapi.yaml in task clean

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -123,6 +123,7 @@ tasks:
       - rm -rf build
       - rm -rf ui/.svelte-kit ui/build ui/node_modules
       - rm -rf docs/.astro docs/dist docs/node_modules
+      - rm -f docs/public/openapi.yaml
 
   logs:
     desc: Tail service logs


### PR DESCRIPTION
## Summary
- Adds `rm -f docs/public/openapi.yaml` to the `clean` task so the derived OpenAPI spec copy (produced by `build:docs` and `dev:docs`) is removed alongside other Astro build artifacts

## Test plan
- [x] Run `task build:docs` — confirm `docs/public/openapi.yaml` is created
- [x] Run `task clean` — confirm `docs/public/openapi.yaml` is removed

🤖 Generated with [Claude Code](https://claude.com/claude-code)