### PR TITLE
docs: rewrite docs site with Aileron vision and value proposition

### DIFF
--- a/VISION.md
+++ b/VISION.md
@@ -1,0 +1,41 @@
+# Aileron
+
+You already know the answer to most messages you receive.
+
+The hard part was never the knowing. It's the work that comes before the reply: pull up the PR, check the calendar, reread the thread, remember what was decided last week, figure out who's waiting on what, compose something that sounds like you. That assembly work — the gathering, the context-switching, the cognitive overhead of being a connected knowledge worker — is what eats your hours and breaks your flow.
+
+Aileron does the assembly.
+
+It connects to the tools you already use — your code, your calendar, your conversations, your issue tracker — and builds a living memory of your work. Not a static profile. Not a document you maintain. A context that grows and sharpens every day because you're working, not because you're writing about working.
+
+When a message arrives, the reply is ready. Correct, specific, grounded in the actual code and the actual conversation history, written in your voice. You review it, approve it, and move on. Or you edit it, and Aileron learns from the edit. Or you discard it, and Aileron learns from that too.
+
+No one on your team knows it exists unless you tell them. There's no bot in the channel, no AI avatar in the thread. Messages come from you, because they are from you — Aileron just did the homework.
+
+---
+
+This isn't retrieval. It's not search. It's not a glorified wiki that summarizes your Slack history.
+
+Every other tool in this space asks you to feed it: write the docs, tag the knowledge, curate the corpus, maintain the runbook. The incentive is always *do more work so the AI can find it later.* That's just search with extra steps, and it fails for the same reason every knowledge management initiative fails — the cost falls on the writer, the benefit goes to a future reader, and the writer is busy right now.
+
+Aileron learns by being there. It watches the PR land. It sees the thread where the team debated the migration approach. It registers that you're direct with engineering and diplomatic with product. It absorbs the sprint reprioritization, the new teammate, the calendar shift. Nobody curates this. Nobody documents it. The context grows because you're doing real work, and real work is the best source of truth there is.
+
+Day one, the drafts are generic. Week two, they reference the right PRs. Month three, they match your tone per audience. Six months in, Aileron knows your team's architecture, your communication patterns, your decision-making instincts — not because anyone described them, but because it learned them from what actually happened.
+
+---
+
+For you, this means the cognitive overhead of communication drops to near zero. You stay in flow. You stop being the bottleneck on every thread that needs your context. You get hours back — not in theory, but in the felt experience of a day where you approved six replies in ninety seconds instead of spending forty minutes composing them.
+
+For your team, something quieter happens. Every PR that informs a draft, every architectural decision that gets referenced in a reply, every scheduling pattern that shapes a response — it all feeds a shared context. Institutional memory builds itself, not from documentation initiatives that die on the vine, but from the real work people are already doing. When the new engineer asks how the auth service works, the answer comes from actual code and actual conversations, not a wiki page that was outdated the day after it was written. When someone goes on vacation, their knowledge doesn't go with them.
+
+No one mandated a knowledge management system. No one asked anyone to write a handoff doc. The organization got smarter because its people used a tool that made their own work easier. That's the only incentive structure that has ever worked at scale.
+
+---
+
+Everything runs through a secure enclave. Aileron's operators cannot read your messages — not as a policy, but as a cryptographic property that your security team can independently verify through remote attestation. Your data, your keys, your approval on every action. You can disconnect at any time and take everything with you.
+
+The AI model is pluggable. The messaging integrations are plumbing. The thing that makes Aileron *Aileron* is the context — the living, compounding memory of how you and your team actually work. A competitor can ship the same integrations and plug in the same LLM tomorrow. They cannot replicate six months of learned context. Every day you use Aileron, the gap widens.
+
+---
+
+Aileron already did the homework.

--- a/docs/src/content/docs/for-individuals.md
+++ b/docs/src/content/docs/for-individuals.md
@@ -1,0 +1,25 @@
+---
+title: "For Individuals"
+description: "Aileron gives you your time back"
+order: 1
+---
+
+People rely on you. That's how it works.
+
+The more they rely on you, the more of your day disappears into messages, replies, check-ins, payments, and follow-ups. Not because any one of them is hard, but because each one requires you to stop what you're doing, find the context, hold it in your head, and compose something thoughtful. By the time you're done, you've forgotten where you were.
+
+Aileron gives you that time back.
+
+It connects to the things you already use — your conversations, your calendar, your projects, your email — and learns how you think, how you communicate, and what matters to you. Not because you told it. Because it was there when you made the decision, wrote the reply, edited the draft, scheduled the meeting.
+
+When a message comes in, Aileron has the reply ready. In your voice. With the right context. You glance at it, tap approve, and you're done. Or you tweak it, and Aileron learns from the tweak. Over time, the tweaks get fewer. The drafts get sharper. The time you spend on communication overhead shrinks to almost nothing.
+
+A bill comes due and Aileron has it ready for you to approve. The right amount, the right account, no digging through email to find the invoice.
+
+This isn't about working faster. It's about spending less time on the things that pull you away from the things you actually care about — the deep work, the creative problem, the afternoon with your family that you're always one more reply away from.
+
+Aileron is invisible. Nobody knows you're using it. There's no bot in the channel, no assistant in the meeting, no AI label on your messages. Everything comes from you, because it is from you. Aileron just did the preparation you didn't have time for.
+
+Your data stays yours. Sensitive operations run through a secure enclave that Aileron's own operators cannot access — not as a promise, but as a cryptographic property your security-minded friends can verify. You can disconnect at any time and take everything with you.
+
+The longer you use Aileron, the better it gets. Not because you're training it, but because you're living your life and it's paying attention. That's the deal: you do what you were going to do anyway, and the overhead disappears.

--- a/docs/src/content/docs/for-organizations.md
+++ b/docs/src/content/docs/for-organizations.md
@@ -1,0 +1,23 @@
+---
+title: "For Organizations"
+description: "Institutional memory that builds itself"
+order: 2
+---
+
+Your organization's real knowledge has never been in a wiki.
+
+It's in the engineer who knows why the auth service is built that way. In the thread where the team debated the migration plan. In the calendar of the one person who remembers the client's scheduling preferences. In a hundred small decisions made by people who are too busy doing the work to write it down.
+
+Every attempt to capture this knowledge has failed for the same reason: it asks people to do extra work with no immediate reward. Write the doc. Update the runbook. Tag the article. Nobody does, because the cost falls on the writer and the benefit goes to a future reader who may never come.
+
+Aileron inverts this.
+
+When your people use Aileron, they're not documenting anything. They're just handling their messages, making decisions, doing their jobs. But every conversation that informs a draft, every decision that gets referenced in a reply, every correction that sharpens a future response — it all feeds a shared understanding. Your organization's institutional memory builds itself, not from documentation initiatives, but from real work.
+
+The new engineer asks how the auth service works. The answer comes from actual code, actual conversations, actual decisions — not a page that was outdated the day after someone wrote it. Someone goes on vacation. Their knowledge doesn't go with them, because the team's shared context already includes their contributions. A critical question comes in at 2am in a timezone where nobody's awake. The draft is ready when they wake up.
+
+This is not surveillance. Aileron works for the individual first, always. Each person controls what they connect, approves every action, and owns their data. The organization benefits because its people work better — not because it's watching them. Admins see aggregate metrics: time saved, messages handled, adoption. Never individual message content. The secure enclave architecture makes this a technical guarantee, not a policy.
+
+The result is an organization that gets smarter every day without asking anyone to do anything differently. Knowledge stops being trapped in people's heads. Communication latency drops. New hires ramp faster. Vacations stop creating bottlenecks. And it compounds — the more people who use Aileron, the richer everyone's context becomes.
+
+No one mandated a knowledge management system. No one asked anyone to write a handoff doc. The organization got smarter because its people used something that made their own lives easier. That's the only incentive structure that has ever worked at scale.

--- a/docs/src/content/docs/how-aileron-works.md
+++ b/docs/src/content/docs/how-aileron-works.md
@@ -1,0 +1,75 @@
+---
+title: "How Aileron Works"
+description: "The building blocks that make Aileron trustworthy with real life"
+order: 3
+---
+
+Aileron handles things that matter. Your messages, your money, your schedule, your credentials. That only works if you can trust it. Not trust as in "we promise to be careful." Trust as in "the system is designed so that even we can't violate it."
+
+Here's how.
+
+## You are always in control
+
+Nothing happens without your approval. Aileron prepares, assembles, and recommends. You decide. Every message, every payment, every action waits for you to say yes. If you say no, nothing moves. If you edit, Aileron learns. If you walk away, everything stops.
+
+This isn't a safety net bolted on at the end. It's the foundation everything else is built on.
+
+## LLMs express intent. Aileron owns execution.
+
+Language models are good at understanding what needs to happen. They are not good at holding your credentials, sending your money, or acting as you. So we separated the two.
+
+The model figures out what you'd probably want to do. Aileron is the one that actually does it. Your credentials, your OAuth tokens, your payment instruments never touch the model. It sees results, not secrets. It can suggest "reply to Sarah's message about the migration," but it cannot access your Slack token, your bank account, or anything else without Aileron brokering the interaction on your behalf, with your approval.
+
+This means a prompt injection, a model hallucination, or a bad suggestion can't do damage. The worst it can do is recommend something you'd decline.
+
+## The zero-knowledge vault
+
+Your secrets are encrypted before they're stored. The key lives with you, not with us.
+
+When you add a credential to Aileron, it's encrypted using a key derived from your passphrase. We never see the passphrase. We never store the key. Our database holds ciphertext that is useless without you. If someone compromised every server we run, they'd get encrypted blobs and nothing else.
+
+When you need a credential for an action, you unlock your vault once. The decrypted key lives in memory for a session, then it's gone. Your secrets exist in plaintext only for as long as they're needed, and nowhere else.
+
+This isn't new or experimental. Zero-knowledge encryption is the same proven technique behind password managers like 1Password and Bitwarden, secure email like Proton Mail, and end-to-end encrypted messaging like Signal. It's the standard the security community trusts for protecting data that matters.
+
+## The secure enclave
+
+Some operations need to happen in a place where no one can look, not even us.
+
+A secure enclave is a hardware-isolated environment that runs code in a way that the host machine cannot inspect or tamper with. Not the operating system, not the cloud provider, not Aileron's operators. The code inside is sealed and verifiable through remote attestation, which means your security team can independently confirm what's running without trusting anyone's word.
+
+When Aileron handles your messages, routes your data, or brokers a credential, the sensitive parts happen inside the enclave. Your data passes through, gets processed, and leaves. Nothing is retained. Nothing is visible to the outside.
+
+## The personal context store
+
+A language model predicts the next word. That's all it does. Context is the only thing that makes the prediction useful.
+
+Without context, you get generic filler. With the right context, you get something you'd trust with your name on it. The difference isn't the model. It's what the model knows when it runs.
+
+Aileron builds that context around how you actually work and communicate. Your conversations, your projects, your decisions, your preferences. It learns from what you approve, what you edit, and what you throw away. Nobody fills out a profile. Nobody writes a prompt. The context grows because you're living your life, and it gets better every day because it's learning from you.
+
+This is the thing that makes everything else work. The vault protects your credentials. The enclave protects your data. The context store is what makes the output worth protecting.
+
+## The audit trail
+
+Every action Aileron takes is recorded. Who did what, when, and why. Not just that a message was sent, but which context informed it, which model generated the draft, and that you approved it.
+
+This is accountability. If something goes wrong, there's a complete record. If a regulator asks, there's proof of human control. If you just want to understand what happened last Tuesday, the trail is there.
+
+For organizations, this is how you demonstrate that your people are in control of the tools acting on their behalf. For you, it's the confidence that nothing is happening in the dark.
+
+## Policy as code
+
+Every action Aileron takes on your behalf runs through a policy layer. These are rules you can read, review, and change. They live in a file, not a dashboard. They can be checked into a repository and reviewed in a pull request.
+
+Safe actions are approved automatically. Dangerous actions are blocked. Everything in between asks you once. The rules are transparent, auditable, and yours.
+
+## What this unlocks
+
+These aren't features on a checklist. They're building blocks that solve a single problem: how do you trust a service with your real life?
+
+The zero-knowledge vault means your credentials are safe even if everything else fails. The separation of intent and execution means a bad model output can't cause real harm. The secure enclave means sensitive operations are private by physics, not by policy. The personal context store means every interaction gets better. The audit trail means there's proof. The human in control means nothing consequential happens without you.
+
+Together, they let Aileron do something no other service can: work with your actual life. Your real messages, your real money, your real relationships, your real schedule. Not a sandbox. Not a demo. The things that matter, handled responsibly, so you can spend your time on what matters more.
+
+A partner to crush the overhead of everyday life and work, and give time back to you where it counts.

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -1,30 +1,21 @@
 ---
 title: "Aileron"
-description: "Policy-enforced shell for AI coding agents"
+description: "Aileron already did the homework"
 order: 0
 ---
 
-**Policy-enforced shell for AI coding agents.**
+Time is our most precious asset. We pour it into purpose, into connection. Managing our modern life demands time, and we believe it should take far less.
 
-Aileron lets your agents fly. Security, privacy, and accountability keep you in control so you can put on the afterburner.
+Aileron learns how you already live and work. Your conversations, your decisions, your preferences, your corrections. Not because you sit down and teach it, but because it's there, paying attention, getting sharper every day. It builds an understanding of your world that no one had to write down, and that understanding is what makes the difference between an answer that wastes your time and one you'd trust with your name on it.
 
-## The Problem
+We built Aileron to work with your real life. Your real conversations, your real decisions, your real data. That meant designing from the ground up for privacy, for security, and for you to always be the one in control.
+A message comes in and the reply is ready. In your voice, with the right context, waiting for your approval. A decision needs to be made and the relevant information is already assembled. Something needs to happen and Aileron handles it responsibly, on your behalf, with your data staying yours. You review, approve, and move on. And tomorrow it's a little better than today, because it learned from what you did. That's not a feature. That's the whole point.
 
-AI coding agents run shell commands on your behalf — but giving them unrestricted access to your terminal is dangerous. Every team faces the same question: *"How do we let agents run commands without rubber-stamping everything or missing the dangerous ones?"*
+Aileron is built for you. At home, at work, to get you back to real life sooner.
 
-## The Solution
-
-`aileron launch claude` wraps your agent in a policy-enforced shell. Every command the agent runs flows through `aileron-sh`, which evaluates it against your `aileron.yaml` rules before allowing execution. Safe commands auto-approve. Dangerous commands are blocked. Ambiguous commands prompt you once.
-
-### Key Principles
-
-- **Policy-as-code** — Allow, deny, or ask rules defined in `aileron.yaml`, checked into your repo, reviewable in PRs.
-- **Single approval layer** — Aileron replaces the agent's native permission prompts. One policy, one prompt.
-- **Credential isolation** — Locally, credential brokering keeps secrets out of the agent's context. With the cloud vault (coming), secrets are encrypted with a key only you hold — Aileron architecturally *cannot* see them.
-- **Complete audit trail** — Every decision is logged. The audit trail is the ground truth for what happened.
-- **Agent-aware** — Works with Claude Code today, extensible to other agents. Agent-specific quirks (command wrapping, shell validation) are handled transparently.
+---
 
 ## Documentation
 
-- [API Reference](/api) — Full OpenAPI specification with interactive explorer
-- [Architecture Decision Records](/adr) — Design decisions and their rationale
+- [API Reference](/api) - Full OpenAPI specification with interactive explorer
+- [Architecture Decision Records](/adr) - Design decisions and their rationale

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -35,6 +35,9 @@ export function isSection(item: NavItem): item is NavSection {
  */
 export const navigation: NavItem[] = [
   { label: 'Home', href: '/' },
+  { label: 'For Individuals', href: '/for-individuals' },
+  { label: 'For Organizations', href: '/for-organizations' },
+  { label: 'How Aileron Works', href: '/how-aileron-works' },
   {
     label: 'Architecture Decisions',
     defaultOpen: false,


### PR DESCRIPTION
## Summary

- Rewrites the docs home page with Aileron's evolved vision: time back, context that learns from real life, privacy by design
- Adds **For Individuals** page: personal value prop around cognitive overhead, messaging, payments, invisibility
- Adds **For Organizations** page: institutional memory that builds itself from real work, not documentation mandates
- Adds **How Aileron Works** page: architectural primitives (human control, intent vs execution, zero-knowledge vault, secure enclave, personal context store, audit trail, policy as code) and how they unlock trust with real life
- Adds VISION.md as a working reference document
- Updates sidebar navigation with new pages

## Test plan

- [x] Run `task dev:docs` and verify all four pages render correctly
- [x] Verify sidebar navigation links work
- [x] Review copy for tone, accuracy, and consistency across pages

🤖 Generated with [Claude Code](https://claude.com/claude-code)