### PR TITLE
docs: improve sidebar navigation, top navbar, and markdown-for-AI tools

### DIFF
--- a/docs/src/assets/markdown-mark.svg
+++ b/docs/src/assets/markdown-mark.svg
@@ -1,0 +1,4 @@
+<svg xmlns="http://www.w3.org/2000/svg" width="100%" height="100%" viewBox="0 0 208 128">
+  <rect width="198" height="118" x="5" y="5" ry="10" stroke="currentColor" stroke-width="10" fill="none"/>
+  <path fill="currentColor" d="M30 98V30h20l20 25 20-25h20v68H90V59L70 84 50 59v39zm125 0l-30-33h20V30h20v35h20z"/>
+</svg>

--- a/docs/src/components/MarkdownForAI.svelte
+++ b/docs/src/components/MarkdownForAI.svelte
@@ -1,0 +1,65 @@
+<script lang="ts">
+  import Copy from '@lucide/svelte/icons/copy';
+  import Eye from '@lucide/svelte/icons/eye';
+  import Download from '@lucide/svelte/icons/download';
+  import Check from '@lucide/svelte/icons/check';
+  import markdownIcon from '../assets/markdown-mark.svg?raw';
+
+  let { slug = '', rawMarkdown = '' }: { slug?: string; rawMarkdown?: string } = $props();
+  let copied = $state(false);
+
+  function copyToClipboard() {
+    navigator.clipboard.writeText(rawMarkdown);
+    copied = true;
+    setTimeout(() => copied = false, 2000);
+  }
+
+  function downloadMarkdown() {
+    const filename = slug ? slug.split('/').pop() + '.md' : 'document.md';
+    const blob = new Blob([rawMarkdown], { type: 'text/markdown' });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement('a');
+    a.href = url;
+    a.download = filename;
+    a.click();
+    URL.revokeObjectURL(url);
+  }
+</script>
+
+<div class="flex items-center gap-3 rounded border border-border px-3 py-2 text-xs text-muted-foreground">
+  <div class="flex flex-col items-center gap-0.5 text-muted-foreground">
+    <div class="w-[26px] h-[16px]">{@html markdownIcon}</div>
+    <span class="font-medium leading-none">Markdown</span>
+  </div>
+  <div class="flex flex-col gap-1 flex-1">
+    <button
+      onclick={copyToClipboard}
+      class="inline-flex items-center justify-center gap-1 w-full py-0.5 rounded border border-border hover:bg-accent hover:text-accent-foreground cursor-pointer"
+      title="Copy markdown to clipboard"
+    >
+      {#if copied}
+        <Check size={12} />
+        Copied
+      {:else}
+        <Copy size={12} />
+        Copy
+      {/if}
+    </button>
+    <a
+      href="/raw/{slug}"
+      class="inline-flex items-center justify-center gap-1 w-full py-0.5 rounded border border-border hover:bg-accent hover:text-accent-foreground no-underline text-muted-foreground"
+      title="View raw markdown"
+    >
+      <Eye size={12} />
+      View
+    </a>
+    <button
+      onclick={downloadMarkdown}
+      class="inline-flex items-center justify-center gap-1 w-full py-0.5 rounded border border-border hover:bg-accent hover:text-accent-foreground cursor-pointer"
+      title="Download markdown file"
+    >
+      <Download size={12} />
+      Download
+    </button>
+  </div>
+</div>

--- a/docs/src/components/Sidebar.svelte
+++ b/docs/src/components/Sidebar.svelte
@@ -1,4 +1,6 @@
 <script lang="ts">
+  import { onMount } from 'svelte';
+  import { slide } from 'svelte/transition';
   import { externalLinks, isSection, type NavItem } from '../lib/navigation';
   import Plane from '@lucide/svelte/icons/plane';
   import Rocket from '@lucide/svelte/icons/rocket';
@@ -10,6 +12,41 @@
 
   let { currentPath = '', navigation = [] as NavItem[] }: { currentPath?: string; navigation?: NavItem[] } = $props();
   let mobileOpen = $state(false);
+  let mounted = $state(false);
+
+  // Track which sections the user has manually toggled (label → open/closed)
+  // Persisted in localStorage so state survives Astro page navigations
+  const STORAGE_KEY = 'sidebar-toggles';
+
+  function loadToggles(): Record<string, boolean> {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? JSON.parse(stored) : {};
+    } catch { return {}; }
+  }
+
+  function saveToggles(toggles: Record<string, boolean>) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(toggles)); } catch {}
+  }
+
+  let manualToggles: Record<string, boolean> = $state(loadToggles());
+
+  onMount(() => {
+    mounted = true;
+  });
+
+  function isSectionOpen(item: import('../lib/navigation').NavSection): boolean {
+    // Manual toggle always wins
+    const manual = manualToggles[item.label];
+    if (manual !== undefined) return manual;
+    // Default: open if it contains the active page, or if defaultOpen
+    return sectionContainsActive(item) || item.defaultOpen !== false;
+  }
+
+  function toggleSection(label: string, currentlyOpen: boolean) {
+    manualToggles[label] = !currentlyOpen;
+    saveToggles(manualToggles);
+  }
 
   // Map top-level labels to icons
   const iconMap: Record<string, typeof Plane> = {
@@ -28,14 +65,13 @@
 
   function sectionContainsActive(item: NavItem): boolean {
     if (!isSection(item)) return isActive(item.href);
-    if (item.href && isActive(item.href)) return true;
     return item.children.some(child => sectionContainsActive(child));
   }
 </script>
 
 <!-- Mobile toggle button -->
 <button
-  class="lg:hidden fixed top-3 left-3 z-50 p-2 rounded-md bg-background border border-border"
+  class="fixed top-4 left-3 z-50 p-2 rounded-md bg-background border border-border opacity-100 visible translate-x-0 transition-[opacity,visibility,translate] duration-200 lg:opacity-0 lg:invisible lg:-translate-x-12"
   onclick={() => mobileOpen = !mobileOpen}
   aria-label="Toggle navigation"
 >
@@ -62,14 +98,11 @@
 
 <!-- Sidebar -->
 <aside
-  class="fixed top-0 left-0 z-40 h-screen w-80 shrink-0 border-r border-border bg-background overflow-y-auto transition-transform duration-200
-    {mobileOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0 lg:sticky lg:top-0"
+  class="fixed top-16 left-0 z-40 h-[calc(100vh-4rem)] w-80 shrink-0 border-r border-border bg-background overflow-y-auto transition-transform duration-200
+    {mobileOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0 lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"
 >
   <div class="p-4">
-    <a href="/" class="font-bold text-lg block mb-6 text-foreground no-underline hover:text-foreground">
-      Aileron Docs
-    </a>
-    <nav>
+    <nav class="flex flex-col gap-4 {mounted ? 'visible' : 'invisible'}">
       {#each navigation as item}
         {#if isSection(item)}
           {@render section(item, 0)}
@@ -114,64 +147,41 @@
 
 {#snippet section(item: import('../lib/navigation').NavSection, depth: number)}
   {@const active = sectionContainsActive(item)}
-  {@const open = active || item.defaultOpen !== false}
+  {@const open = isSectionOpen(item)}
   {@const Icon = iconMap[item.label]}
-  <details open={open} class="group/section {depth > 0 ? 'ml-2' : ''} rounded border {active ? 'bg-accent/30 border-border' : 'border-transparent'}">
-    <summary
-      class="group/summary flex items-center justify-between py-1.5 px-2 rounded text-sm font-medium select-none
-        {item.href && isActive(item.href) ? 'bg-accent text-accent-foreground' : active ? 'text-accent-foreground' : 'text-foreground'} hover:bg-accent/50 list-none [&::-webkit-details-marker]:hidden
-        {item.href ? '' : 'cursor-pointer'}"
-      onclick={item.href ? (e: MouseEvent) => { e.preventDefault(); } : undefined}
+  <div class="group {depth > 0 ? 'ml-2' : ''} rounded border border-border {active ? 'bg-accent' : 'bg-muted'}">
+    <button
+      class="w-full flex items-center justify-between py-1.5 px-2 rounded text-sm font-medium select-none cursor-pointer
+        {active ? 'text-accent-foreground' : 'text-foreground'} hover:bg-accent/50"
+      onclick={() => toggleSection(item.label, open)}
     >
-      {#if item.href}
-        <a
-          href={item.href}
-          class="flex-1 flex items-center gap-2 no-underline {active && isActive(item.href) ? 'text-accent-foreground' : 'text-inherit'}"
-          onclick={(e) => { e.stopPropagation(); mobileOpen = false; }}
-        >
-          {#if Icon}
-            <Icon size={16} class="shrink-0 transition-transform duration-150 {active ? 'scale-125' : 'group-hover/section:scale-125'}" />
-          {/if}
-          {item.label}
-        </a>
-      {:else}
-        <span class="flex items-center gap-2">
-          {#if Icon}
-            <Icon size={16} class="shrink-0 transition-transform duration-150 {active ? 'scale-125' : 'group-hover/section:scale-125'}" />
-          {/if}
-          {item.label}
-        </span>
-      {/if}
-      <button
-        class="p-0.5 rounded hover:bg-accent/70 cursor-pointer"
-        onclick={(e) => {
-          e.stopPropagation();
-          e.preventDefault();
-          const details = (e.currentTarget as HTMLElement).closest('details');
-          if (details) details.open = !details.open;
-        }}
-        aria-label="Toggle section"
-      >
-        <svg class="w-4 h-4 transition-transform group-open/section:rotate-90" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="9 18 15 12 9 6" />
-        </svg>
-      </button>
-    </summary>
-    <div class="ml-2 border-l border-border pl-2">
-      {#each item.children as child}
-        {#if isSection(child)}
-          {@render section(child, depth + 1)}
-        {:else}
-          <a
-            href={child.href}
-            class="block py-1 px-2 rounded text-sm no-underline
-              {isActive(child.href) ? 'bg-accent text-accent-foreground font-medium' : 'text-muted-foreground hover:text-accent-foreground hover:bg-accent/70'}"
-            onclick={() => mobileOpen = false}
-          >
-            {child.label}
-          </a>
+      <span class="flex items-center gap-2">
+        {#if Icon}
+          <Icon size={16} class="shrink-0 transition-transform duration-150 {active ? 'scale-125' : 'group-hover:scale-125'}" />
         {/if}
-      {/each}
-    </div>
-  </details>
+        {item.label}
+      </span>
+      <svg class="w-4 h-4 transition-transform duration-200 {open ? 'rotate-90' : ''}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="9 18 15 12 9 6" />
+      </svg>
+    </button>
+    {#if open}
+      <div class="ml-2 pl-2" transition:slide={{ duration: mounted ? 150 : 0 }}>
+        {#each item.children as child}
+          {#if isSection(child)}
+            {@render section(child, depth + 1)}
+          {:else}
+            <a
+              href={child.href}
+              class="block py-1 px-2 rounded text-sm no-underline
+                {isActive(child.href) ? 'bg-accent text-accent-foreground font-medium' : 'text-muted-foreground hover:text-accent-foreground hover:bg-accent/70'}"
+              onclick={() => mobileOpen = false}
+            >
+              {child.label}
+            </a>
+          {/if}
+        {/each}
+      </div>
+    {/if}
+  </div>
 {/snippet}

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -38,7 +38,12 @@ const nav = navigation.map((item) => {
     <title>{title} - Aileron Docs</title>
   </head>
   <body>
-    <div class="flex min-h-screen">
+    <header class="fixed top-0 left-0 right-0 z-50 h-16 flex items-center pl-16 pr-6 lg:px-6 border-b border-border bg-background transition-[padding] duration-200">
+      <a href="/" class="font-bold text-lg text-foreground no-underline hover:text-foreground">
+        Aileron Docs
+      </a>
+    </header>
+    <div class="flex min-h-screen pt-16">
       <Sidebar currentPath={currentPath} navigation={nav} client:load />
 
       <div class="flex-1">

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -1,22 +1,32 @@
 ---
 import BaseLayout from './BaseLayout.astro';
 import TableOfContents from '../components/TableOfContents.svelte';
+import MarkdownForAI from '../components/MarkdownForAI.svelte';
 
 interface Props {
   title: string;
   headings?: { slug: string; text: string; depth: number }[];
+  slug?: string;
+  rawMarkdown?: string;
 }
 
-const { title, headings = [] } = Astro.props;
+const { title, headings = [], slug = '', rawMarkdown = '' } = Astro.props;
 ---
 
 <BaseLayout title={title}>
-  <main class="px-6 pt-14 pb-8 lg:px-10 lg:pt-8 flex gap-8">
+  <main class="px-6 pt-8 pb-8 lg:px-10 flex gap-8">
     <article class="prose flex-1 min-w-0">
       <h1>{title}</h1>
       <slot />
     </article>
 
-    <TableOfContents headings={headings} client:load />
+    <aside class="w-0 xl:w-56 shrink-0 opacity-0 invisible translate-x-12 xl:opacity-100 xl:visible xl:translate-x-0 transition-[opacity,visibility,translate,width] duration-200 overflow-hidden xl:overflow-visible">
+      <div class="sticky top-8">
+        <div class="mb-10">
+          <MarkdownForAI slug={slug} rawMarkdown={rawMarkdown} client:load />
+        </div>
+        <TableOfContents headings={headings} client:load />
+      </div>
+    </aside>
   </main>
 </BaseLayout>

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -17,7 +17,6 @@ export type NavLink = {
 export type NavSection = {
   label: string;
   children: NavItem[];
-  href?: string;
   defaultOpen?: boolean;
   icon?: Component;
 };
@@ -37,8 +36,8 @@ export function isSection(item: NavItem): item is NavSection {
 export const navigation: NavItem[] = [
   {
     label: 'Meet Aileron',
-    href: '/',
     children: [
+      { label: 'Overview', href: '/' },
       { label: 'For Individuals', href: '/for-individuals' },
       { label: 'For Organizations', href: '/for-organizations' },
       { label: 'How Aileron Works', href: '/how-aileron-works' }
@@ -46,8 +45,8 @@ export const navigation: NavItem[] = [
   },
   {
     label: 'Getting Started',
-    href: '/getting-started/installation',
     children: [
+      { label: 'Installation', href: '/getting-started/installation' },
       { label: 'Quick Start', href: '/getting-started/quick-start' },
       { label: 'Policy Configuration', href: '/getting-started/policy-configuration' },
       { label: 'Credential Vault', href: '/getting-started/credential-vault' },

--- a/docs/src/pages/[...slug].astro
+++ b/docs/src/pages/[...slug].astro
@@ -12,8 +12,9 @@ export async function getStaticPaths() {
 
 const { entry } = Astro.props;
 const { Content, headings } = await render(entry);
+const slug = entry.id === 'index' ? '' : entry.id;
 ---
 
-<DocsLayout title={entry.data.title} headings={headings}>
+<DocsLayout title={entry.data.title} headings={headings} slug={slug} rawMarkdown={entry.body ?? ''}>
   <Content />
 </DocsLayout>

--- a/docs/src/pages/raw/[...slug].astro
+++ b/docs/src/pages/raw/[...slug].astro
@@ -1,0 +1,23 @@
+---
+import { getCollection } from 'astro:content';
+import BaseLayout from '../../layouts/BaseLayout.astro';
+
+export async function getStaticPaths() {
+  const docs = await getCollection('docs');
+  return docs.map((entry) => ({
+    params: { slug: entry.id === 'index' ? undefined : entry.id },
+    props: { entry }
+  }));
+}
+
+const { entry } = Astro.props;
+---
+
+<BaseLayout title={`${entry.data.title} — Raw Markdown`}>
+  <main class="px-6 pt-14 pb-8 lg:px-10 lg:pt-8">
+    <div class="mb-4 flex items-center gap-4">
+      <a href={entry.id === 'index' ? '/' : `/${entry.id}`} class="text-sm text-muted-foreground hover:text-foreground no-underline">&larr; Back to formatted view</a>
+    </div>
+    <pre class="bg-muted text-foreground p-6 rounded-lg overflow-x-auto text-sm whitespace-pre-wrap">{entry.body}</pre>
+  </main>
+</BaseLayout>

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -15,8 +15,8 @@
 }
 
 .dark {
-	--background: oklch(0.145 0 0);
-	--foreground: oklch(0.985 0 0);
+	--background: oklch(0.22 0 0);
+	--foreground: oklch(0.92 0 0);
 	--muted: oklch(0.269 0 0);
 	--muted-foreground: oklch(0.708 0 0);
 	--border: oklch(1 0 0 / 10%);


### PR DESCRIPTION
## Summary

- **Sidebar navigation overhaul**: Replaced `<details>` elements with state-managed collapsible sections using Svelte `slide` transitions. Open/close state persists in `localStorage` across page navigations. Sections are now pure toggles — former section-level pages (Overview, Installation) moved to children.
- **Markdown for AI**: New component in the right sidebar with Copy, View, and Download buttons for raw markdown content. Includes `/raw/[slug]` pages for viewing markdown source. Uses the official Markdown logo icon.
- **Top navbar**: Fixed header with "Aileron Docs" branding spanning full width. Responsive animations for hamburger slide-in, header padding transition, and right sidebar slide-in.
- **UI polish**: Softer dark theme contrast, section borders always visible with muted/accent backgrounds, independent sidebar scrolling, responsive spacing.

## Test plan

- [ ] Verify sidebar sections open/close with slide animation on click
- [ ] Close a section, navigate to another page, confirm it stays closed
- [ ] Verify Copy button copies raw markdown to clipboard
- [ ] Verify View button shows raw markdown page with back link
- [ ] Verify Download button downloads .md file
- [ ] Resize viewport to test hamburger/right sidebar animations
- [ ] Check dark theme contrast is comfortable for reading

🤖 Generated with [Claude Code](https://claude.com/claude-code)