### PR TITLE
feat(draft): draft lifecycle API — review, approve, edit, discard

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
+	"time"
 
 	"github.com/ALRubinger/aileron/core/account"
 	api "github.com/ALRubinger/aileron/core/api/gen"
@@ -14,6 +15,7 @@ import (
 	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/draft"
 	"github.com/ALRubinger/aileron/core/llm"
+	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/source"
 	slacksource "github.com/ALRubinger/aileron/core/source/slack"
 	"github.com/ALRubinger/aileron/core/auth"
@@ -49,6 +51,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	fundingSourceStore := mem.NewFundingSourceStore()
 	traceStore := mem.NewTraceStore()
 	connectedAccountStore := mem.NewConnectedAccountStore()
+	draftStore := mem.NewDraftStore()
 
 	// --- Connector registry ---
 	registry := connector.NewRegistry()
@@ -115,6 +118,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		executions:     executionStore,
 		connectors:     connectorStore,
 		connectedAccounts: connectedAccountStore,
+		drafts:            draftStore,
 		credentials:       credentialStore,
 		fundingSources:    fundingSourceStore,
 		traces:            traceStore,
@@ -132,6 +136,11 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	// Source connector tools API (read-only context retrieval).
 	mux.HandleFunc("GET /v1/tools", server.handleListTools)
 	mux.HandleFunc("POST /v1/tools/execute", server.handleExecuteTool)
+
+	// Draft lifecycle API.
+	mux.HandleFunc("GET /v1/drafts", server.handleListDrafts)
+	mux.HandleFunc("GET /v1/drafts/", server.handleGetDraft)
+	mux.HandleFunc("POST /v1/drafts/", server.handleDraftAction)
 
 	registerDocsRoutes(mux)
 
@@ -230,11 +239,30 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 						log.Error("draft generation failed", "user_id", userID, "error", err)
 						return
 					}
-					log.Info("draft ready",
+
+					now := time.Now().UTC()
+					d := model.Draft{
+						ID:          "dft_" + server.newID(),
+						UserID:      userID,
+						Status:      model.DraftStatusPending,
+						Service:     msg.Service,
+						Channel:     msg.Channel,
+						Author:      msg.Author,
+						MessageBody: msg.Body,
+						MessageTS:   msg.ID,
+						DraftBody:   draftText,
+						CreatedAt:   now,
+						UpdatedAt:   now,
+					}
+					if err := draftStore.Create(ctx, d); err != nil {
+						log.Error("failed to store draft", "error", err)
+						return
+					}
+					log.Info("draft pending review",
+						"draft_id", d.ID,
 						"user_id", userID,
 						"channel", msg.Channel,
-						"draft_length", len(draftText),
-						"draft_preview", draftText[:min(len(draftText), 100)])
+						"draft_length", len(draftText))
 				}
 			}
 			mux.HandleFunc("POST /v1/webhooks/slack/events", server.handleSlackEvent)

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -7,7 +7,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"time"
 
 	"github.com/ALRubinger/aileron/core/account"
 	api "github.com/ALRubinger/aileron/core/api/gen"
@@ -15,7 +14,6 @@ import (
 	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/draft"
 	"github.com/ALRubinger/aileron/core/llm"
-	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/source"
 	slacksource "github.com/ALRubinger/aileron/core/source/slack"
 	"github.com/ALRubinger/aileron/core/auth"
@@ -240,21 +238,8 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 						return
 					}
 
-					now := time.Now().UTC()
-					d := model.Draft{
-						ID:          "dft_" + server.newID(),
-						UserID:      userID,
-						Status:      model.DraftStatusPending,
-						Service:     msg.Service,
-						Channel:     msg.Channel,
-						Author:      msg.Author,
-						MessageBody: msg.Body,
-						MessageTS:   msg.ID,
-						DraftBody:   draftText,
-						CreatedAt:   now,
-						UpdatedAt:   now,
-					}
-					if err := draftStore.Create(ctx, d); err != nil {
+					d, err := server.createDraftFromMessage(ctx, userID, msg, draftText)
+					if err != nil {
 						log.Error("failed to store draft", "error", err)
 						return
 					}

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -51,6 +51,7 @@ type apiServer struct {
 	sourceRegistry     *source.Registry       // read-only source connectors for context retrieval
 	draftPipeline      *draft.Pipeline        // nil when LLM not configured
 	drafts             store.DraftStore       // draft lifecycle store
+	slackSender        SlackSender            // injectable for testing; defaults to comms.SendSlackMessage
 	slackSigningSecret string                  // Slack Events API signing secret for webhook verification
 	slackDedup         *slackEventDedup        // deduplication cache for Slack events
 	onSlackMessage     func(ctx context.Context, userID string, msg comms.IncomingMessage) // callback for incoming Slack messages

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -50,6 +50,7 @@ type apiServer struct {
 	accountService     *account.Registry      // nil when no account providers configured
 	sourceRegistry     *source.Registry       // read-only source connectors for context retrieval
 	draftPipeline      *draft.Pipeline        // nil when LLM not configured
+	drafts             store.DraftStore       // draft lifecycle store
 	slackSigningSecret string                  // Slack Events API signing secret for webhook verification
 	slackDedup         *slackEventDedup        // deduplication cache for Slack events
 	onSlackMessage     func(ctx context.Context, userID string, msg comms.IncomingMessage) // callback for incoming Slack messages

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -1,0 +1,266 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/comms"
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+)
+
+// handleListDrafts returns pending drafts for the authenticated user.
+// GET /v1/drafts?status=pending
+func (s *apiServer) handleListDrafts(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	filter := store.DraftFilter{UserID: userID}
+	if statusParam := r.URL.Query().Get("status"); statusParam != "" {
+		status := model.DraftStatus(statusParam)
+		filter.Status = &status
+	}
+
+	drafts, err := s.drafts.List(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if drafts == nil {
+		drafts = []model.Draft{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": drafts})
+}
+
+// handleGetDraft returns a specific draft with ownership check.
+// GET /v1/drafts/{draft_id}
+func (s *apiServer) handleGetDraft(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	draftID := extractDraftID(r.URL.Path)
+	if draftID == "" {
+		writeError(w, http.StatusBadRequest, "invalid_path", "draft_id is required")
+		return
+	}
+
+	draft, err := s.drafts.Get(r.Context(), draftID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "draft not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	if draft.UserID != userID {
+		writeError(w, http.StatusNotFound, "not_found", "draft not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, draft)
+}
+
+// handleApproveDraft approves a draft and sends it as-is.
+// POST /v1/drafts/{draft_id}/approve
+func (s *apiServer) handleApproveDraft(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	draftID := extractDraftIDFromAction(r.URL.Path, "/approve")
+	draft, err := s.getDraftForAction(w, r, draftID, userID)
+	if err != nil {
+		return // error already written
+	}
+
+	if err := s.sendDraftMessage(r.Context(), draft.UserID, draft.Channel, draft.DraftBody); err != nil {
+		s.log.Error("failed to send draft", "draft_id", draftID, "error", err)
+		writeError(w, http.StatusInternalServerError, "send_error", "failed to send message: "+err.Error())
+		return
+	}
+
+	draft.Status = model.DraftStatusApproved
+	draft.SentBody = draft.DraftBody
+	draft.UpdatedAt = time.Now().UTC()
+	s.drafts.Update(r.Context(), draft)
+
+	writeJSON(w, http.StatusOK, draft)
+}
+
+// handleEditDraft edits a draft body and sends the revised version.
+// POST /v1/drafts/{draft_id}/edit  { "body": "revised text" }
+func (s *apiServer) handleEditDraft(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	draftID := extractDraftIDFromAction(r.URL.Path, "/edit")
+	draft, err := s.getDraftForAction(w, r, draftID, userID)
+	if err != nil {
+		return
+	}
+
+	var req struct {
+		Body string `json:"body"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil || req.Body == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body", "body field is required")
+		return
+	}
+
+	if err := s.sendDraftMessage(r.Context(), draft.UserID, draft.Channel, req.Body); err != nil {
+		s.log.Error("failed to send edited draft", "draft_id", draftID, "error", err)
+		writeError(w, http.StatusInternalServerError, "send_error", "failed to send message: "+err.Error())
+		return
+	}
+
+	draft.Status = model.DraftStatusEdited
+	draft.SentBody = req.Body
+	draft.UpdatedAt = time.Now().UTC()
+	s.drafts.Update(r.Context(), draft)
+
+	writeJSON(w, http.StatusOK, draft)
+}
+
+// handleDiscardDraft discards a draft without sending.
+// POST /v1/drafts/{draft_id}/discard
+func (s *apiServer) handleDiscardDraft(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	draftID := extractDraftIDFromAction(r.URL.Path, "/discard")
+	draft, err := s.getDraftForAction(w, r, draftID, userID)
+	if err != nil {
+		return
+	}
+
+	draft.Status = model.DraftStatusDiscarded
+	draft.UpdatedAt = time.Now().UTC()
+	s.drafts.Update(r.Context(), draft)
+
+	writeJSON(w, http.StatusOK, draft)
+}
+
+// getDraftForAction loads a draft, checks ownership and status.
+// Writes error response and returns error if the draft can't be acted on.
+func (s *apiServer) getDraftForAction(w http.ResponseWriter, r *http.Request, draftID, userID string) (model.Draft, error) {
+	if draftID == "" {
+		writeError(w, http.StatusBadRequest, "invalid_path", "draft_id is required")
+		return model.Draft{}, errBadRequest
+	}
+
+	draft, err := s.drafts.Get(r.Context(), draftID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "draft not found")
+		} else {
+			writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		}
+		return model.Draft{}, err
+	}
+
+	if draft.UserID != userID {
+		writeError(w, http.StatusNotFound, "not_found", "draft not found")
+		return model.Draft{}, errNotFound
+	}
+
+	if draft.Status != model.DraftStatusPending {
+		writeError(w, http.StatusConflict, "already_actioned", "draft has already been "+string(draft.Status))
+		return model.Draft{}, errConflict
+	}
+
+	return draft, nil
+}
+
+// sendDraftMessage sends a message to Slack using the user's connected account token.
+func (s *apiServer) sendDraftMessage(ctx context.Context, userID, channel, body string) error {
+	slackProvider := model.ConnectedAccountProviderSlack
+	accounts, err := s.connectedAccounts.List(ctx, store.ConnectedAccountFilter{
+		UserID:   userID,
+		Provider: &slackProvider,
+	})
+	if err != nil {
+		return err
+	}
+	if len(accounts) == 0 {
+		return errNoSlackAccount
+	}
+
+	secret, err := s.vault.Get(ctx, accounts[0].VaultPath())
+	if err != nil {
+		return err
+	}
+
+	var tokenData map[string]string
+	if err := json.Unmarshal(secret.Value, &tokenData); err != nil {
+		return err
+	}
+
+	token := tokenData["access_token"]
+	if token == "" {
+		return errNoSlackToken
+	}
+
+	return comms.SendSlackMessage(ctx, token, channel, body)
+}
+
+// extractDraftID extracts the draft ID from /v1/drafts/{draft_id}
+func extractDraftID(path string) string {
+	const prefix = "/v1/drafts/"
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	id := strings.TrimPrefix(path, prefix)
+	// Remove trailing slash if present.
+	id = strings.TrimSuffix(id, "/")
+	return id
+}
+
+// extractDraftIDFromAction extracts the draft ID from /v1/drafts/{draft_id}/action
+func extractDraftIDFromAction(path, action string) string {
+	const prefix = "/v1/drafts/"
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	rest := strings.TrimPrefix(path, prefix)
+	rest = strings.TrimSuffix(rest, action)
+	rest = strings.TrimSuffix(rest, "/")
+	return rest
+}
+
+// handleDraftAction routes POST /v1/drafts/{id}/action to the correct handler.
+func (s *apiServer) handleDraftAction(w http.ResponseWriter, r *http.Request) {
+	path := r.URL.Path
+	switch {
+	case strings.HasSuffix(path, "/approve"):
+		s.handleApproveDraft(w, r)
+	case strings.HasSuffix(path, "/edit"):
+		s.handleEditDraft(w, r)
+	case strings.HasSuffix(path, "/discard"):
+		s.handleDiscardDraft(w, r)
+	default:
+		writeError(w, http.StatusNotFound, "not_found", "unknown draft action")
+	}
+}
+
+// Sentinel errors for draft handlers.
+var (
+	errBadRequest      = &store.ErrNotFound{Entity: "request", ID: "bad"}
+	errNotFound        = &store.ErrNotFound{Entity: "draft", ID: "not_found"}
+	errConflict        = &store.ErrNotFound{Entity: "draft", ID: "conflict"}
+	errNoSlackAccount  = &store.ErrNotFound{Entity: "slack_account", ID: "missing"}
+	errNoSlackToken    = &store.ErrNotFound{Entity: "slack_token", ID: "missing"}
+)

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -185,6 +185,10 @@ func (s *apiServer) getDraftForAction(w http.ResponseWriter, r *http.Request, dr
 	return draft, nil
 }
 
+// SlackSender is the function used to send messages to Slack.
+// Defaults to comms.SendSlackMessage. Override in tests.
+type SlackSender func(ctx context.Context, token, channel, body string) error
+
 // sendDraftMessage sends a message to Slack using the user's connected account token.
 func (s *apiServer) sendDraftMessage(ctx context.Context, userID, channel, body string) error {
 	slackProvider := model.ConnectedAccountProviderSlack
@@ -214,7 +218,11 @@ func (s *apiServer) sendDraftMessage(ctx context.Context, userID, channel, body 
 		return errNoSlackToken
 	}
 
-	return comms.SendSlackMessage(ctx, token, channel, body)
+	sender := s.slackSender
+	if sender == nil {
+		sender = comms.SendSlackMessage
+	}
+	return sender(ctx, token, channel, body)
 }
 
 // extractDraftID extracts the draft ID from /v1/drafts/{draft_id}

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -264,6 +264,29 @@ func (s *apiServer) handleDraftAction(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
+// createDraftFromMessage stores a generated draft as pending in the draft store.
+// Extracted from the onSlackMessage closure so it can be unit tested.
+func (s *apiServer) createDraftFromMessage(ctx context.Context, userID string, msg comms.IncomingMessage, draftText string) (model.Draft, error) {
+	now := time.Now().UTC()
+	d := model.Draft{
+		ID:          "dft_" + s.newID(),
+		UserID:      userID,
+		Status:      model.DraftStatusPending,
+		Service:     msg.Service,
+		Channel:     msg.Channel,
+		Author:      msg.Author,
+		MessageBody: msg.Body,
+		MessageTS:   msg.ID,
+		DraftBody:   draftText,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+	if err := s.drafts.Create(ctx, d); err != nil {
+		return model.Draft{}, err
+	}
+	return d, nil
+}
+
 // Sentinel errors for draft handlers.
 var (
 	errBadRequest      = &store.ErrNotFound{Entity: "request", ID: "bad"}

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/store/mem"
@@ -371,5 +372,179 @@ func TestDraftAction_UnknownAction(t *testing.T) {
 
 	if w.Code != http.StatusNotFound {
 		t.Fatalf("expected 404 for unknown action, got %d", w.Code)
+	}
+}
+
+func TestDraftAction_ApproveRouting(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userAClaims)
+	srv.handleDraftAction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 via action router for approve, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDraftAction_EditRouting(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/edit", `{"body":"revised"}`, userAClaims)
+	srv.handleDraftAction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 via action router for edit, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateDraftFromMessage(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+
+	msg := comms.IncomingMessage{
+		ID:      "1234567890.123456",
+		Service: "slack",
+		Channel: "C0BACKEND",
+		Author:  "Sarah",
+		Body:    "Does the JWT refactor change the claims?",
+	}
+
+	d, err := srv.createDraftFromMessage(ctx, "usr_a", msg, "No, the claims stay the same.")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if d.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+	if d.Status != model.DraftStatusPending {
+		t.Errorf("expected pending, got %s", d.Status)
+	}
+	if d.UserID != "usr_a" {
+		t.Errorf("expected usr_a, got %s", d.UserID)
+	}
+	if d.DraftBody != "No, the claims stay the same." {
+		t.Errorf("unexpected draft body: %s", d.DraftBody)
+	}
+	if d.MessageTS != "1234567890.123456" {
+		t.Errorf("expected message timestamp preserved, got %s", d.MessageTS)
+	}
+
+	// Verify it's in the store.
+	got, err := srv.drafts.Get(ctx, d.ID)
+	if err != nil {
+		t.Fatalf("draft not in store: %v", err)
+	}
+	if got.Channel != "C0BACKEND" {
+		t.Errorf("expected C0BACKEND, got %s", got.Channel)
+	}
+}
+
+func TestSendDraftMessage_BadTokenJSON(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	// Store invalid JSON as token.
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte("not-json"), vault.Metadata{})
+
+	err := srv.sendDraftMessage(ctx, "usr_a", "C123", "hello")
+	if err == nil {
+		t.Fatal("expected error for bad token JSON")
+	}
+}
+
+func TestSendDraftMessage_EmptyAccessToken(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"token_type":"user"}`), vault.Metadata{})
+
+	err := srv.sendDraftMessage(ctx, "usr_a", "C123", "hello")
+	if err == nil {
+		t.Fatal("expected error for missing access_token")
+	}
+}
+
+func TestListDrafts_Empty(t *testing.T) {
+	srv := newDraftsTestServer()
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/drafts", "", userAClaims)
+	srv.handleListDrafts(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp struct {
+		Items []model.Draft `json:"items"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Items) != 0 {
+		t.Fatalf("expected empty list, got %d", len(resp.Items))
+	}
+}
+
+func TestGetDraft_EmptyID(t *testing.T) {
+	srv := newDraftsTestServer()
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/drafts/", "", userAClaims)
+	srv.handleGetDraft(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty ID, got %d", w.Code)
+	}
+}
+
+func TestExtractDraftID(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/v1/drafts/dft_123", "dft_123"},
+		{"/v1/drafts/dft_123/", "dft_123"},
+		{"/v1/drafts/", ""},
+		{"/other/path", ""},
+	}
+	for _, tt := range tests {
+		got := extractDraftID(tt.path)
+		if got != tt.want {
+			t.Errorf("extractDraftID(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestExtractDraftIDFromAction(t *testing.T) {
+	tests := []struct {
+		path   string
+		action string
+		want   string
+	}{
+		{"/v1/drafts/dft_123/approve", "/approve", "dft_123"},
+		{"/v1/drafts/dft_123/edit", "/edit", "dft_123"},
+		{"/other/path/approve", "/approve", ""},
+	}
+	for _, tt := range tests {
+		got := extractDraftIDFromAction(tt.path, tt.action)
+		if got != tt.want {
+			t.Errorf("extractDraftIDFromAction(%q, %q) = %q, want %q", tt.path, tt.action, got, tt.want)
+		}
 	}
 }

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -203,6 +204,161 @@ func TestDraftAction_Routing(t *testing.T) {
 
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200 via action router, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func newDraftsTestServerWithSend() *apiServer {
+	srv := newDraftsTestServer()
+	// Set up a connected Slack account + vault token so send works.
+	ctx := context.Background()
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test"}`), vault.Metadata{})
+	// Mock sender so we don't call real Slack.
+	srv.slackSender = func(_ context.Context, token, channel, body string) error {
+		return nil
+	}
+	return srv
+}
+
+func TestApproveDraft_Success(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userAClaims)
+	srv.handleApproveDraft(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var d model.Draft
+	json.NewDecoder(w.Body).Decode(&d)
+	if d.Status != model.DraftStatusApproved {
+		t.Errorf("expected approved, got %s", d.Status)
+	}
+	if d.SentBody != "No, the claims stay the same." {
+		t.Errorf("expected SentBody to match DraftBody, got %q", d.SentBody)
+	}
+}
+
+func TestApproveDraft_OwnershipCheck(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userBClaims)
+	srv.handleApproveDraft(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestApproveDraft_AlreadyActioned(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusDiscarded)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userAClaims)
+	srv.handleApproveDraft(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d", w.Code)
+	}
+}
+
+func TestApproveDraft_NotFound(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/nonexistent/approve", "", userAClaims)
+	srv.handleApproveDraft(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestApproveDraft_SendFails(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	srv.slackSender = func(_ context.Context, _, _, _ string) error {
+		return fmt.Errorf("slack API unavailable")
+	}
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userAClaims)
+	srv.handleApproveDraft(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestApproveDraft_NoSlackAccount(t *testing.T) {
+	srv := newDraftsTestServer() // no connected account seeded
+	srv.slackSender = func(_ context.Context, _, _, _ string) error { return nil }
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userAClaims)
+	srv.handleApproveDraft(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestEditDraft_Success(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/edit", `{"body":"Actually, yes it does change."}`, userAClaims)
+	srv.handleEditDraft(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var d model.Draft
+	json.NewDecoder(w.Body).Decode(&d)
+	if d.Status != model.DraftStatusEdited {
+		t.Errorf("expected edited, got %s", d.Status)
+	}
+	if d.SentBody != "Actually, yes it does change." {
+		t.Errorf("expected edited SentBody, got %q", d.SentBody)
+	}
+	// DraftBody should still be the original.
+	if d.DraftBody != "No, the claims stay the same." {
+		t.Errorf("expected original DraftBody preserved, got %q", d.DraftBody)
+	}
+}
+
+func TestEditDraft_SendFails(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	srv.slackSender = func(_ context.Context, _, _, _ string) error {
+		return fmt.Errorf("slack error")
+	}
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/edit", `{"body":"revised"}`, userAClaims)
+	srv.handleEditDraft(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
 	}
 }
 

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -1,0 +1,219 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/store/mem"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+func newDraftsTestServer() *apiServer {
+	return &apiServer{
+		log:               slog.Default(),
+		drafts:            mem.NewDraftStore(),
+		connectedAccounts: mem.NewConnectedAccountStore(),
+		vault:             vault.NewMemVault(),
+		users:             &stubUserStore{},
+		newID:             func() string { return "test-id" },
+	}
+}
+
+func seedDraft(ctx context.Context, s store.DraftStore, id, userID string, status model.DraftStatus) {
+	s.Create(ctx, model.Draft{
+		ID:          id,
+		UserID:      userID,
+		Status:      status,
+		Service:     "slack",
+		Channel:     "C0BACKEND",
+		Author:      "Sarah",
+		MessageBody: "Does the JWT refactor change the claims?",
+		MessageTS:   "1234567890.123456",
+		DraftBody:   "No, the claims stay the same.",
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	})
+}
+
+func TestListDrafts_Pending(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+	seedDraft(ctx, srv.drafts, "dft_2", "usr_a", model.DraftStatusApproved)
+	seedDraft(ctx, srv.drafts, "dft_3", "usr_b", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/drafts?status=pending", "", userAClaims)
+	srv.handleListDrafts(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var resp struct {
+		Items []model.Draft `json:"items"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 pending draft for usr_a, got %d", len(resp.Items))
+	}
+	if resp.Items[0].ID != "dft_1" {
+		t.Errorf("expected dft_1, got %s", resp.Items[0].ID)
+	}
+}
+
+func TestListDrafts_AllForUser(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+	seedDraft(ctx, srv.drafts, "dft_2", "usr_a", model.DraftStatusApproved)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/drafts", "", userAClaims)
+	srv.handleListDrafts(w, r)
+
+	var resp struct {
+		Items []model.Draft `json:"items"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 drafts for usr_a, got %d", len(resp.Items))
+	}
+}
+
+func TestListDrafts_Unauthorized(t *testing.T) {
+	srv := newDraftsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/drafts", "", nil)
+	srv.handleListDrafts(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestGetDraft_Success(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/drafts/dft_1", "", userAClaims)
+	srv.handleGetDraft(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var d model.Draft
+	json.NewDecoder(w.Body).Decode(&d)
+	if d.ID != "dft_1" {
+		t.Errorf("expected dft_1, got %s", d.ID)
+	}
+}
+
+func TestGetDraft_OwnershipCheck(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/drafts/dft_1", "", userBClaims)
+	srv.handleGetDraft(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for ownership violation, got %d", w.Code)
+	}
+}
+
+func TestGetDraft_NotFound(t *testing.T) {
+	srv := newDraftsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/drafts/nonexistent", "", userAClaims)
+	srv.handleGetDraft(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDiscardDraft_Success(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/discard", "", userAClaims)
+	srv.handleDiscardDraft(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var d model.Draft
+	json.NewDecoder(w.Body).Decode(&d)
+	if d.Status != model.DraftStatusDiscarded {
+		t.Errorf("expected discarded, got %s", d.Status)
+	}
+}
+
+func TestDiscardDraft_AlreadyActioned(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusApproved)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/discard", "", userAClaims)
+	srv.handleDiscardDraft(w, r)
+
+	if w.Code != http.StatusConflict {
+		t.Fatalf("expected 409, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestEditDraft_MissingBody(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/edit", `{"body":""}`, userAClaims)
+	srv.handleEditDraft(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty body, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDraftAction_Routing(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/discard", "", userAClaims)
+	srv.handleDraftAction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 via action router, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestDraftAction_UnknownAction(t *testing.T) {
+	srv := newDraftsTestServer()
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/unknown", "", userAClaims)
+	srv.handleDraftAction(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 for unknown action, got %d", w.Code)
+	}
+}

--- a/core/comms/slack_send.go
+++ b/core/comms/slack_send.go
@@ -1,0 +1,28 @@
+package comms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+// SendSlackMessage sends a message to a Slack channel using a one-shot client.
+// Unlike SlackListener.Send() which requires a persistent Socket Mode connection,
+// this creates a fresh client from the provided OAuth token, posts the message,
+// and discards the client. Suitable for cloud-mode where no persistent Slack
+// connection exists.
+func SendSlackMessage(ctx context.Context, token, channel, body string) error {
+	if token == "" {
+		return fmt.Errorf("slack: token is required")
+	}
+	if channel == "" {
+		return fmt.Errorf("slack: channel is required")
+	}
+
+	client := slack.New(token)
+	_, _, err := client.PostMessageContext(ctx, channel,
+		slack.MsgOptionText(body, false),
+	)
+	return err
+}

--- a/core/comms/slack_send_test.go
+++ b/core/comms/slack_send_test.go
@@ -1,0 +1,22 @@
+package comms_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/comms"
+)
+
+func TestSendSlackMessage_EmptyToken(t *testing.T) {
+	err := comms.SendSlackMessage(context.Background(), "", "C123", "hello")
+	if err == nil {
+		t.Fatal("expected error for empty token")
+	}
+}
+
+func TestSendSlackMessage_EmptyChannel(t *testing.T) {
+	err := comms.SendSlackMessage(context.Background(), "xoxp-test", "", "hello")
+	if err == nil {
+		t.Fatal("expected error for empty channel")
+	}
+}

--- a/core/model/draft.go
+++ b/core/model/draft.go
@@ -1,0 +1,32 @@
+package model
+
+import "time"
+
+// DraftStatus tracks the lifecycle state of a draft reply.
+type DraftStatus string
+
+const (
+	DraftStatusPending   DraftStatus = "pending"
+	DraftStatusApproved  DraftStatus = "approved"
+	DraftStatusEdited    DraftStatus = "edited"
+	DraftStatusDiscarded DraftStatus = "discarded"
+)
+
+// Draft represents an AI-generated reply awaiting user review.
+// Created by the draft generation pipeline when a message arrives.
+// The user reviews and either approves (send as-is), edits (send
+// revised text), or discards (don't send).
+type Draft struct {
+	ID          string      // dft_ + UUID
+	UserID      string      // owning user (usr_ + UUID)
+	Status      DraftStatus // pending → approved | edited | discarded
+	Service     string      // "slack", "discord"
+	Channel     string      // channel ID where the original message arrived
+	Author      string      // who sent the original message
+	MessageBody string      // the original message text
+	MessageTS   string      // original message timestamp (for threading)
+	DraftBody   string      // the AI-generated draft reply
+	SentBody    string      // what was actually sent (empty until approved/edited)
+	CreatedAt   time.Time
+	UpdatedAt   time.Time
+}

--- a/core/store/mem/draft.go
+++ b/core/store/mem/draft.go
@@ -1,0 +1,63 @@
+package mem
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+)
+
+// DraftStore is a thread-safe in-memory implementation of store.DraftStore.
+type DraftStore struct {
+	mu     sync.RWMutex
+	drafts map[string]model.Draft
+}
+
+// NewDraftStore returns an empty in-memory draft store.
+func NewDraftStore() *DraftStore {
+	return &DraftStore{drafts: make(map[string]model.Draft)}
+}
+
+func (s *DraftStore) Create(_ context.Context, draft model.Draft) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.drafts[draft.ID] = draft
+	return nil
+}
+
+func (s *DraftStore) Get(_ context.Context, draftID string) (model.Draft, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	d, ok := s.drafts[draftID]
+	if !ok {
+		return model.Draft{}, &store.ErrNotFound{Entity: "draft", ID: draftID}
+	}
+	return d, nil
+}
+
+func (s *DraftStore) List(_ context.Context, filter store.DraftFilter) ([]model.Draft, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []model.Draft
+	for _, d := range s.drafts {
+		if filter.UserID != "" && d.UserID != filter.UserID {
+			continue
+		}
+		if filter.Status != nil && d.Status != *filter.Status {
+			continue
+		}
+		result = append(result, d)
+	}
+	return result, nil
+}
+
+func (s *DraftStore) Update(_ context.Context, draft model.Draft) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.drafts[draft.ID]; !ok {
+		return &store.ErrNotFound{Entity: "draft", ID: draft.ID}
+	}
+	s.drafts[draft.ID] = draft
+	return nil
+}

--- a/core/store/mem/draft_test.go
+++ b/core/store/mem/draft_test.go
@@ -1,0 +1,113 @@
+package mem_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/store/mem"
+)
+
+func newTestDraft(id, userID string, status model.DraftStatus) model.Draft {
+	return model.Draft{
+		ID:          id,
+		UserID:      userID,
+		Status:      status,
+		Service:     "slack",
+		Channel:     "#backend",
+		Author:      "Sarah",
+		MessageBody: "Does the JWT refactor change the claims?",
+		DraftBody:   "No, the claims stay the same.",
+		CreatedAt:   time.Now().UTC(),
+		UpdatedAt:   time.Now().UTC(),
+	}
+}
+
+func TestDraftStore_CreateAndGet(t *testing.T) {
+	s := mem.NewDraftStore()
+	ctx := context.Background()
+	d := newTestDraft("dft_1", "usr_1", model.DraftStatusPending)
+
+	if err := s.Create(ctx, d); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get(ctx, "dft_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.ID != "dft_1" {
+		t.Errorf("expected dft_1, got %s", got.ID)
+	}
+	if got.DraftBody != "No, the claims stay the same." {
+		t.Errorf("unexpected draft body: %s", got.DraftBody)
+	}
+}
+
+func TestDraftStore_GetNotFound(t *testing.T) {
+	s := mem.NewDraftStore()
+	_, err := s.Get(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing draft")
+	}
+}
+
+func TestDraftStore_List(t *testing.T) {
+	s := mem.NewDraftStore()
+	ctx := context.Background()
+
+	s.Create(ctx, newTestDraft("dft_1", "usr_1", model.DraftStatusPending))
+	s.Create(ctx, newTestDraft("dft_2", "usr_1", model.DraftStatusApproved))
+	s.Create(ctx, newTestDraft("dft_3", "usr_2", model.DraftStatusPending))
+
+	// List all for user 1.
+	drafts, err := s.List(ctx, store.DraftFilter{UserID: "usr_1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drafts) != 2 {
+		t.Fatalf("expected 2 drafts for usr_1, got %d", len(drafts))
+	}
+
+	// Filter by status.
+	pending := model.DraftStatusPending
+	drafts, err = s.List(ctx, store.DraftFilter{UserID: "usr_1", Status: &pending})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(drafts) != 1 {
+		t.Fatalf("expected 1 pending draft, got %d", len(drafts))
+	}
+}
+
+func TestDraftStore_Update(t *testing.T) {
+	s := mem.NewDraftStore()
+	ctx := context.Background()
+
+	d := newTestDraft("dft_1", "usr_1", model.DraftStatusPending)
+	s.Create(ctx, d)
+
+	d.Status = model.DraftStatusApproved
+	d.SentBody = d.DraftBody
+	if err := s.Update(ctx, d); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := s.Get(ctx, "dft_1")
+	if got.Status != model.DraftStatusApproved {
+		t.Errorf("expected approved, got %s", got.Status)
+	}
+	if got.SentBody != "No, the claims stay the same." {
+		t.Errorf("unexpected sent body: %s", got.SentBody)
+	}
+}
+
+func TestDraftStore_UpdateNotFound(t *testing.T) {
+	s := mem.NewDraftStore()
+	err := s.Update(context.Background(), model.Draft{ID: "nonexistent"})
+	if err == nil {
+		t.Fatal("expected error for missing draft")
+	}
+}

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -206,6 +206,21 @@ type ConnectedAccountFilter struct {
 	PageSize       int
 }
 
+// DraftStore persists and retrieves AI-generated draft replies.
+type DraftStore interface {
+	Create(ctx context.Context, draft model.Draft) error
+	Get(ctx context.Context, draftID string) (model.Draft, error)
+	List(ctx context.Context, filter DraftFilter) ([]model.Draft, error)
+	Update(ctx context.Context, draft model.Draft) error
+}
+
+// DraftFilter scopes a draft list query.
+type DraftFilter struct {
+	UserID   string
+	Status   *model.DraftStatus
+	PageSize int
+}
+
 // UserKeyMaterialStore persists and retrieves user key material for the
 // zero-knowledge vault. The KEK itself is never stored — only the Argon2id
 // salt and an encrypted verification blob.

--- a/docs/src/content/docs/getting-started/slack-cloud-integration.md
+++ b/docs/src/content/docs/getting-started/slack-cloud-integration.md
@@ -151,6 +151,43 @@ Content-Type: application/json
 
 The execute endpoint retrieves the user's Slack OAuth token from the vault and passes it to the tool. The LLM never sees the token directly — Aileron is the access-controlled gateway.
 
+## Draft lifecycle
+
+When a Slack message arrives and `ANTHROPIC_API_KEY` is configured, Aileron generates a draft reply and stores it as `pending`. Use the draft API to review and act on drafts from any surface:
+
+**List pending drafts:**
+
+```
+GET /v1/drafts?status=pending
+Authorization: Bearer <token>
+```
+
+**Approve (send as-is):**
+
+```
+POST /v1/drafts/{draft_id}/approve
+Authorization: Bearer <token>
+```
+
+**Edit and send:**
+
+```
+POST /v1/drafts/{draft_id}/edit
+Authorization: Bearer <token>
+Content-Type: application/json
+
+{ "body": "Revised reply text" }
+```
+
+**Discard:**
+
+```
+POST /v1/drafts/{draft_id}/discard
+Authorization: Bearer <token>
+```
+
+On approve or edit, Aileron sends the message to Slack using your OAuth user token — the reply comes from you, not a bot.
+
 ## Security
 
 - **Signature verification:** Every webhook request is verified using HMAC-SHA256 with the signing secret. Invalid or stale (>5 minutes) signatures are rejected.


### PR DESCRIPTION
## Summary

- **Draft model** (`core/model/draft.go`) — `Draft` resource with `pending → approved | edited | discarded` status lifecycle
- **DraftStore** (`core/store/mem/draft.go`) — In-memory store following existing patterns
- **Slack send utility** (`core/comms/slack_send.go`) — One-shot `SendSlackMessage` for cloud mode (no persistent Socket Mode connection)
- **Draft lifecycle API** — `GET /v1/drafts`, `GET /v1/drafts/{id}`, `POST .../approve`, `POST .../edit`, `POST .../discard`
- **Pipeline wiring** — `onSlackMessage` now stores generated drafts as `pending` instead of logging. Any surface can poll and act.
- **Feedback signals** — Approve sets `SentBody = DraftBody` (positive). Edit captures the diff (correction). Discard is negative signal. Ready for context store feedback loop (ADR-0018).

## End-to-end flow

```
Slack message → webhook → draft pipeline → LLM generates draft
  → Draft stored as "pending"
  → GET /v1/drafts?status=pending returns it
  → POST /v1/drafts/{id}/approve
    → Aileron sends to Slack via user's OAuth token
    → Draft status → "approved"
```

## Test plan

- [x] DraftStore CRUD tests
- [x] Draft handler tests (list, get, ownership, approve, edit, discard, already actioned, auth)
- [x] All existing tests pass
- [x] Docs site builds
- [ ] E2E: Slack message → draft generated → GET /v1/drafts → approve → message in Slack (staging)

Refs: #112, #122

🤖 Generated with [Claude Code](https://claude.com/claude-code)