### PR TITLE
docs: update architecture diagram with draft lifecycle flow

### DIFF
--- a/docs/src/content/docs/getting-started/slack-cloud-integration.md
+++ b/docs/src/content/docs/getting-started/slack-cloud-integration.md
@@ -114,7 +114,8 @@ Draft Generation Pipeline
     │   └─ LLM generates draft from assembled context
     │
     ▼
-Draft ready for user review (delivery TBD)
+Draft stored as "pending" → GET /v1/drafts
+  → User approves/edits/discards → Sent to Slack as user
 ```
 
 ## Context retrieval tools


### PR DESCRIPTION
## Summary

- Update architecture diagram in Slack cloud integration guide — replace "delivery TBD" with the actual draft API flow

One-line fix. The draft lifecycle endpoints (PR #123) were built but the diagram still said TBD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)