### PR TITLE
feat(context): user instructions — first context store envelope type

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -50,6 +50,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	traceStore := mem.NewTraceStore()
 	connectedAccountStore := mem.NewConnectedAccountStore()
 	draftStore := mem.NewDraftStore()
+	instructionStore := mem.NewUserInstructionStore()
 
 	// --- Connector registry ---
 	registry := connector.NewRegistry()
@@ -117,6 +118,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		connectors:     connectorStore,
 		connectedAccounts: connectedAccountStore,
 		drafts:            draftStore,
+		instructions:      instructionStore,
 		credentials:       credentialStore,
 		fundingSources:    fundingSourceStore,
 		traces:            traceStore,
@@ -134,6 +136,13 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	// Source connector tools API (read-only context retrieval).
 	mux.HandleFunc("GET /v1/tools", server.handleListTools)
 	mux.HandleFunc("POST /v1/tools/execute", server.handleExecuteTool)
+
+	// User instructions API (context store envelope).
+	mux.HandleFunc("POST /v1/instructions", server.handleCreateInstruction)
+	mux.HandleFunc("GET /v1/instructions", server.handleListInstructions)
+	mux.HandleFunc("GET /v1/instructions/", server.handleInstructionByID)
+	mux.HandleFunc("PATCH /v1/instructions/", server.handleInstructionByID)
+	mux.HandleFunc("DELETE /v1/instructions/", server.handleInstructionByID)
 
 	// Draft lifecycle API.
 	mux.HandleFunc("GET /v1/drafts", server.handleListDrafts)
@@ -217,7 +226,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		// LLM-powered draft generation pipeline.
 		if authCfg.LLMEnabled() {
 			llmClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModel)
-			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, connectedAccountStore, v, log)
+			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, connectedAccountStore, instructionStore, v, log)
 			log.Info("enabled cloud draft generation", "model", authCfg.LLMModel)
 		}
 

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -51,6 +51,7 @@ type apiServer struct {
 	sourceRegistry     *source.Registry       // read-only source connectors for context retrieval
 	draftPipeline      *draft.Pipeline        // nil when LLM not configured
 	drafts             store.DraftStore       // draft lifecycle store
+	instructions       store.UserInstructionStore // user instructions for context store
 	slackSender        SlackSender            // injectable for testing; defaults to comms.SendSlackMessage
 	slackSigningSecret string                  // Slack Events API signing secret for webhook verification
 	slackDedup         *slackEventDedup        // deduplication cache for Slack events

--- a/core/app/handlers_instructions.go
+++ b/core/app/handlers_instructions.go
@@ -1,0 +1,232 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+)
+
+// handleCreateInstruction creates a new user instruction.
+// POST /v1/instructions
+func (s *apiServer) handleCreateInstruction(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Body  string `json:"body"`
+		Scope string `json:"scope"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid JSON request body")
+		return
+	}
+	if req.Body == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body", "body field is required")
+		return
+	}
+
+	now := time.Now().UTC()
+	ins := model.UserInstruction{
+		ID:        "ins_" + s.newID(),
+		UserID:    userID,
+		Body:      req.Body,
+		Scope:     req.Scope,
+		Active:    true,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+
+	if err := s.instructions.Create(r.Context(), ins); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, ins)
+}
+
+// handleListInstructions returns the user's instructions.
+// GET /v1/instructions?active=true
+func (s *apiServer) handleListInstructions(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	filter := store.UserInstructionFilter{UserID: userID}
+	if activeParam := r.URL.Query().Get("active"); activeParam != "" {
+		active := activeParam == "true"
+		filter.Active = &active
+	}
+
+	instructions, err := s.instructions.List(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if instructions == nil {
+		instructions = []model.UserInstruction{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": instructions})
+}
+
+// handleGetInstruction returns a specific instruction with ownership check.
+// GET /v1/instructions/{id}
+func (s *apiServer) handleGetInstruction(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	insID := extractInstructionID(r.URL.Path)
+	if insID == "" {
+		writeError(w, http.StatusBadRequest, "invalid_path", "instruction_id is required")
+		return
+	}
+
+	ins, err := s.instructions.Get(r.Context(), insID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "instruction not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	if ins.UserID != userID {
+		writeError(w, http.StatusNotFound, "not_found", "instruction not found")
+		return
+	}
+
+	writeJSON(w, http.StatusOK, ins)
+}
+
+// handleUpdateInstruction updates an instruction's body, scope, or active flag.
+// PATCH /v1/instructions/{id}
+func (s *apiServer) handleUpdateInstruction(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	insID := extractInstructionID(r.URL.Path)
+	if insID == "" {
+		writeError(w, http.StatusBadRequest, "invalid_path", "instruction_id is required")
+		return
+	}
+
+	ins, err := s.instructions.Get(r.Context(), insID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "instruction not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	if ins.UserID != userID {
+		writeError(w, http.StatusNotFound, "not_found", "instruction not found")
+		return
+	}
+
+	var req struct {
+		Body   *string `json:"body"`
+		Scope  *string `json:"scope"`
+		Active *bool   `json:"active"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid JSON request body")
+		return
+	}
+
+	if req.Body != nil {
+		if *req.Body == "" {
+			writeError(w, http.StatusBadRequest, "invalid_body", "body cannot be empty")
+			return
+		}
+		ins.Body = *req.Body
+	}
+	if req.Scope != nil {
+		ins.Scope = *req.Scope
+	}
+	if req.Active != nil {
+		ins.Active = *req.Active
+	}
+	ins.UpdatedAt = time.Now().UTC()
+
+	if err := s.instructions.Update(r.Context(), ins); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, ins)
+}
+
+// handleDeleteInstruction permanently removes an instruction.
+// DELETE /v1/instructions/{id}
+func (s *apiServer) handleDeleteInstruction(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	insID := extractInstructionID(r.URL.Path)
+	if insID == "" {
+		writeError(w, http.StatusBadRequest, "invalid_path", "instruction_id is required")
+		return
+	}
+
+	ins, err := s.instructions.Get(r.Context(), insID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "instruction not found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	if ins.UserID != userID {
+		writeError(w, http.StatusNotFound, "not_found", "instruction not found")
+		return
+	}
+
+	if err := s.instructions.Delete(r.Context(), insID); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleInstructionByID routes GET/PATCH/DELETE to the correct handler based on method.
+func (s *apiServer) handleInstructionByID(w http.ResponseWriter, r *http.Request) {
+	switch r.Method {
+	case http.MethodGet:
+		s.handleGetInstruction(w, r)
+	case http.MethodPatch:
+		s.handleUpdateInstruction(w, r)
+	case http.MethodDelete:
+		s.handleDeleteInstruction(w, r)
+	default:
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+	}
+}
+
+// extractInstructionID extracts the instruction ID from /v1/instructions/{id}
+func extractInstructionID(path string) string {
+	const prefix = "/v1/instructions/"
+	if !strings.HasPrefix(path, prefix) {
+		return ""
+	}
+	id := strings.TrimPrefix(path, prefix)
+	id = strings.TrimSuffix(id, "/")
+	return id
+}

--- a/core/app/handlers_instructions_test.go
+++ b/core/app/handlers_instructions_test.go
@@ -1,0 +1,340 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store/mem"
+)
+
+func newInstructionsTestServer() *apiServer {
+	return &apiServer{
+		log:          slog.Default(),
+		instructions: mem.NewUserInstructionStore(),
+		users:        &stubUserStore{},
+		newID:        func() string { return "test-id" },
+	}
+}
+
+func TestCreateInstruction_Success(t *testing.T) {
+	srv := newInstructionsTestServer()
+	body := `{"body":"Always reference PR numbers","scope":"#backend"}`
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/instructions", body, userAClaims)
+	srv.handleCreateInstruction(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+	var ins model.UserInstruction
+	json.NewDecoder(w.Body).Decode(&ins)
+	if ins.Body != "Always reference PR numbers" {
+		t.Errorf("unexpected body: %s", ins.Body)
+	}
+	if ins.Scope != "#backend" {
+		t.Errorf("unexpected scope: %s", ins.Scope)
+	}
+	if !ins.Active {
+		t.Error("expected active by default")
+	}
+	if ins.ID == "" {
+		t.Error("expected non-empty ID")
+	}
+}
+
+func TestCreateInstruction_EmptyBody(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/instructions", `{"body":""}`, userAClaims)
+	srv.handleCreateInstruction(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateInstruction_InvalidJSON(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/instructions", "not-json", userAClaims)
+	srv.handleCreateInstruction(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestCreateInstruction_Unauthorized(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/instructions", `{"body":"test"}`, nil)
+	srv.handleCreateInstruction(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestListInstructions_Active(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule 1", Active: true})
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_2", UserID: "usr_a", Body: "Rule 2", Active: false})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/instructions?active=true", "", userAClaims)
+	srv.handleListInstructions(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp struct {
+		Items []model.UserInstruction `json:"items"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 active, got %d", len(resp.Items))
+	}
+}
+
+func TestListInstructions_All(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule 1", Active: true})
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_2", UserID: "usr_a", Body: "Rule 2", Active: false})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/instructions", "", userAClaims)
+	srv.handleListInstructions(w, r)
+
+	var resp struct {
+		Items []model.UserInstruction `json:"items"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2, got %d", len(resp.Items))
+	}
+}
+
+func TestListInstructions_Empty(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/instructions", "", userAClaims)
+	srv.handleListInstructions(w, r)
+
+	var resp struct {
+		Items []model.UserInstruction `json:"items"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Items) != 0 {
+		t.Fatalf("expected empty, got %d", len(resp.Items))
+	}
+}
+
+func TestGetInstruction_Success(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule 1", Active: true})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/instructions/ins_1", "", userAClaims)
+	srv.handleGetInstruction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestGetInstruction_OwnershipCheck(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule 1"})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/instructions/ins_1", "", userBClaims)
+	srv.handleGetInstruction(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestGetInstruction_NotFound(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/instructions/nonexistent", "", userAClaims)
+	srv.handleGetInstruction(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestGetInstruction_EmptyID(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/instructions/", "", userAClaims)
+	srv.handleGetInstruction(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateInstruction_Body(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Original", Active: true})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("PATCH", "/v1/instructions/ins_1", `{"body":"Updated"}`, userAClaims)
+	srv.handleUpdateInstruction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var ins model.UserInstruction
+	json.NewDecoder(w.Body).Decode(&ins)
+	if ins.Body != "Updated" {
+		t.Errorf("expected Updated, got %s", ins.Body)
+	}
+}
+
+func TestUpdateInstruction_Toggle(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule", Active: true})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("PATCH", "/v1/instructions/ins_1", `{"active":false}`, userAClaims)
+	srv.handleUpdateInstruction(w, r)
+
+	var ins model.UserInstruction
+	json.NewDecoder(w.Body).Decode(&ins)
+	if ins.Active {
+		t.Error("expected inactive")
+	}
+}
+
+func TestUpdateInstruction_EmptyBody(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule", Active: true})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("PATCH", "/v1/instructions/ins_1", `{"body":""}`, userAClaims)
+	srv.handleUpdateInstruction(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateInstruction_NotFound(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("PATCH", "/v1/instructions/nonexistent", `{"body":"x"}`, userAClaims)
+	srv.handleUpdateInstruction(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestUpdateInstruction_OwnershipCheck(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule"})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("PATCH", "/v1/instructions/ins_1", `{"body":"hacked"}`, userBClaims)
+	srv.handleUpdateInstruction(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDeleteInstruction_Success(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule"})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("DELETE", "/v1/instructions/ins_1", "", userAClaims)
+	srv.handleDeleteInstruction(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}
+
+func TestDeleteInstruction_NotFound(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("DELETE", "/v1/instructions/nonexistent", "", userAClaims)
+	srv.handleDeleteInstruction(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestDeleteInstruction_OwnershipCheck(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule"})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("DELETE", "/v1/instructions/ins_1", "", userBClaims)
+	srv.handleDeleteInstruction(w, r)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestInstructionByID_Routing(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule", Active: true})
+
+	// GET routes correctly.
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/instructions/ins_1", "", userAClaims)
+	srv.handleInstructionByID(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("GET expected 200, got %d", w.Code)
+	}
+
+	// Unknown method.
+	w = httptest.NewRecorder()
+	r = mcpRequest("PUT", "/v1/instructions/ins_1", "", userAClaims)
+	srv.handleInstructionByID(w, r)
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("PUT expected 405, got %d", w.Code)
+	}
+}
+
+func TestExtractInstructionID(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/v1/instructions/ins_123", "ins_123"},
+		{"/v1/instructions/ins_123/", "ins_123"},
+		{"/v1/instructions/", ""},
+		{"/other", ""},
+	}
+	for _, tt := range tests {
+		got := extractInstructionID(tt.path)
+		if got != tt.want {
+			t.Errorf("extractInstructionID(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}

--- a/core/app/handlers_instructions_test.go
+++ b/core/app/handlers_instructions_test.go
@@ -321,6 +321,90 @@ func TestInstructionByID_Routing(t *testing.T) {
 	}
 }
 
+func TestUpdateInstruction_InvalidJSON(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule", Active: true})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("PATCH", "/v1/instructions/ins_1", "not-json", userAClaims)
+	srv.handleUpdateInstruction(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateInstruction_EmptyID(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("PATCH", "/v1/instructions/", `{"body":"x"}`, userAClaims)
+	srv.handleUpdateInstruction(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestUpdateInstruction_Scope(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule", Scope: "old", Active: true})
+
+	scope := "new scope"
+	w := httptest.NewRecorder()
+	r := mcpRequest("PATCH", "/v1/instructions/ins_1", `{"scope":"`+scope+`"}`, userAClaims)
+	srv.handleUpdateInstruction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	var ins model.UserInstruction
+	json.NewDecoder(w.Body).Decode(&ins)
+	if ins.Scope != "new scope" {
+		t.Errorf("expected 'new scope', got %s", ins.Scope)
+	}
+}
+
+func TestDeleteInstruction_EmptyID(t *testing.T) {
+	srv := newInstructionsTestServer()
+	w := httptest.NewRecorder()
+	r := mcpRequest("DELETE", "/v1/instructions/", "", userAClaims)
+	srv.handleDeleteInstruction(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestInstructionByID_PatchRouting(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule", Active: true})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("PATCH", "/v1/instructions/ins_1", `{"body":"Updated via router"}`, userAClaims)
+	srv.handleInstructionByID(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestInstructionByID_DeleteRouting(t *testing.T) {
+	srv := newInstructionsTestServer()
+	ctx := context.Background()
+	srv.instructions.Create(ctx, model.UserInstruction{ID: "ins_1", UserID: "usr_a", Body: "Rule"})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("DELETE", "/v1/instructions/ins_1", "", userAClaims)
+	srv.handleInstructionByID(w, r)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d", w.Code)
+	}
+}
+
 func TestExtractInstructionID(t *testing.T) {
 	tests := []struct {
 		path string

--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -37,6 +37,7 @@ type Pipeline struct {
 	llm               llm.Client
 	sourceRegistry    *source.Registry
 	connectedAccounts store.ConnectedAccountStore
+	instructions      store.UserInstructionStore
 	vault             vault.Vault
 	log               *slog.Logger
 }
@@ -46,6 +47,7 @@ func NewPipeline(
 	llmClient llm.Client,
 	sourceReg *source.Registry,
 	accounts store.ConnectedAccountStore,
+	instructions store.UserInstructionStore,
 	v vault.Vault,
 	log *slog.Logger,
 ) *Pipeline {
@@ -53,6 +55,7 @@ func NewPipeline(
 		llm:               llmClient,
 		sourceRegistry:    sourceReg,
 		connectedAccounts: accounts,
+		instructions:      instructions,
 		vault:             v,
 		log:               log,
 	}
@@ -62,6 +65,12 @@ func NewPipeline(
 // It assembles context from source connectors available to the user,
 // calls the LLM with tool access, and returns the draft text.
 func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.IncomingMessage) (string, error) {
+	// Assemble the system prompt from base + user instructions.
+	prompt, err := p.assembleSystemPrompt(ctx, userID)
+	if err != nil {
+		return "", fmt.Errorf("assembling system prompt: %w", err)
+	}
+
 	// Build the user message from the incoming message.
 	userMessage := fmt.Sprintf(
 		"Draft a reply to this message from %s in %s:\n\n%s",
@@ -95,7 +104,7 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 	executor := p.buildToolExecutor(ctx, userID, accounts)
 
 	resp, err := p.llm.GenerateWithTools(ctx, llm.GenerateRequest{
-		SystemPrompt: systemPrompt,
+		SystemPrompt: prompt,
 		UserMessage:  userMessage,
 		Tools:        tools,
 		ToolExecutor: executor,
@@ -112,6 +121,40 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 	)
 
 	return resp.Text, nil
+}
+
+// assembleSystemPrompt builds the system prompt from the base prompt plus
+// the user's active instructions. Instructions are the highest-priority
+// context — they override learned patterns and behavioral model inferences.
+func (p *Pipeline) assembleSystemPrompt(ctx context.Context, userID string) (string, error) {
+	prompt := systemPrompt
+
+	if p.instructions == nil {
+		return prompt, nil
+	}
+
+	active := true
+	instructions, err := p.instructions.List(ctx, store.UserInstructionFilter{
+		UserID: userID,
+		Active: &active,
+	})
+	if err != nil {
+		return "", fmt.Errorf("listing instructions: %w", err)
+	}
+
+	if len(instructions) == 0 {
+		return prompt, nil
+	}
+
+	prompt += "\n\n## User Instructions\n\nThe user has set these explicit rules. Follow them precisely:\n"
+	for _, ins := range instructions {
+		prompt += "\n- " + ins.Body
+		if ins.Scope != "" {
+			prompt += " [scope: " + ins.Scope + "]"
+		}
+	}
+
+	return prompt, nil
 }
 
 // buildToolExecutor creates a closure that resolves credentials from the vault

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -3,6 +3,7 @@ package draft_test
 import (
 	"context"
 	"log/slog"
+	"strings"
 	"testing"
 
 	"github.com/ALRubinger/aileron/core/comms"
@@ -53,7 +54,7 @@ func TestPipeline_GenerateDraft_Simple(t *testing.T) {
 	v := vault.NewMemVault()
 	sourceReg := source.NewRegistry()
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, v, slog.Default())
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default())
 
 	draftText, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID:      "msg_1",
@@ -108,7 +109,7 @@ func TestPipeline_GenerateDraft_WithTools(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, v, slog.Default())
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default())
 
 	draftText, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID:      "msg_1",
@@ -162,7 +163,7 @@ func TestPipeline_GenerateDraft_ToolExecutor(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, v, slog.Default())
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default())
 
 	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -197,7 +198,7 @@ func TestPipeline_GenerateDraft_NoConnectedAccounts(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, v, slog.Default())
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default())
 
 	draftText, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -215,12 +216,82 @@ func TestPipeline_GenerateDraft_NoConnectedAccounts(t *testing.T) {
 	}
 }
 
+func TestPipeline_GenerateDraft_WithInstructions(t *testing.T) {
+	mock := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "Draft with instructions"},
+	}
+
+	accounts := mem.NewConnectedAccountStore()
+	instructions := mem.NewUserInstructionStore()
+	v := vault.NewMemVault()
+	ctx := context.Background()
+
+	// Seed instructions.
+	instructions.Create(ctx, model.UserInstruction{
+		ID: "ins_1", UserID: "usr_1", Body: "Always reference PR numbers", Scope: "#backend", Active: true,
+	})
+	instructions.Create(ctx, model.UserInstruction{
+		ID: "ins_2", UserID: "usr_1", Body: "Be brief in incidents", Active: true,
+	})
+	instructions.Create(ctx, model.UserInstruction{
+		ID: "ins_3", UserID: "usr_1", Body: "Inactive rule", Active: false, // should NOT appear
+	})
+
+	sourceReg := source.NewRegistry()
+	p := draft.NewPipeline(mock, sourceReg, accounts, instructions, v, slog.Default())
+
+	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
+		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Verify instructions were included in the system prompt.
+	prompt := mock.lastRequest.SystemPrompt
+	if !strings.Contains(prompt, "Always reference PR numbers") {
+		t.Error("expected instruction 1 in prompt")
+	}
+	if !strings.Contains(prompt, "[scope: #backend]") {
+		t.Error("expected scope annotation in prompt")
+	}
+	if !strings.Contains(prompt, "Be brief in incidents") {
+		t.Error("expected instruction 2 in prompt")
+	}
+	if strings.Contains(prompt, "Inactive rule") {
+		t.Error("inactive instruction should not appear in prompt")
+	}
+	if !strings.Contains(prompt, "User Instructions") {
+		t.Error("expected User Instructions section header")
+	}
+}
+
+func TestPipeline_GenerateDraft_NoInstructions(t *testing.T) {
+	mock := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "Draft without instructions"},
+	}
+
+	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default())
+
+	_, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
+		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// System prompt should NOT contain instructions section.
+	if strings.Contains(mock.lastRequest.SystemPrompt, "User Instructions") {
+		t.Error("expected no User Instructions section when none exist")
+	}
+}
+
 func TestPipeline_GenerateDraft_LLMError(t *testing.T) {
 	mock := &mockLLMClient{
 		err: context.DeadlineExceeded,
 	}
 
-	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), vault.NewMemVault(), slog.Default())
+	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default())
 
 	_, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",

--- a/core/model/instruction.go
+++ b/core/model/instruction.go
@@ -1,0 +1,17 @@
+package model
+
+import "time"
+
+// UserInstruction is an explicit rule the user gives Aileron for how
+// to communicate on their behalf. Instructions are included in the LLM
+// system prompt during draft generation — they are the highest-priority
+// context, overriding learned patterns and behavioral model inferences.
+type UserInstruction struct {
+	ID        string    // ins_ + UUID
+	UserID    string    // owning user (usr_ + UUID)
+	Body      string    // the instruction text
+	Scope     string    // optional free-text context: channel, person, topic, or empty for global
+	Active    bool      // toggleable without deleting
+	CreatedAt time.Time
+	UpdatedAt time.Time
+}

--- a/core/store/mem/instruction.go
+++ b/core/store/mem/instruction.go
@@ -1,0 +1,73 @@
+package mem
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+)
+
+// UserInstructionStore is a thread-safe in-memory implementation of store.UserInstructionStore.
+type UserInstructionStore struct {
+	mu           sync.RWMutex
+	instructions map[string]model.UserInstruction
+}
+
+// NewUserInstructionStore returns an empty in-memory instruction store.
+func NewUserInstructionStore() *UserInstructionStore {
+	return &UserInstructionStore{instructions: make(map[string]model.UserInstruction)}
+}
+
+func (s *UserInstructionStore) Create(_ context.Context, instruction model.UserInstruction) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.instructions[instruction.ID] = instruction
+	return nil
+}
+
+func (s *UserInstructionStore) Get(_ context.Context, instructionID string) (model.UserInstruction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	ins, ok := s.instructions[instructionID]
+	if !ok {
+		return model.UserInstruction{}, &store.ErrNotFound{Entity: "instruction", ID: instructionID}
+	}
+	return ins, nil
+}
+
+func (s *UserInstructionStore) List(_ context.Context, filter store.UserInstructionFilter) ([]model.UserInstruction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []model.UserInstruction
+	for _, ins := range s.instructions {
+		if filter.UserID != "" && ins.UserID != filter.UserID {
+			continue
+		}
+		if filter.Active != nil && ins.Active != *filter.Active {
+			continue
+		}
+		result = append(result, ins)
+	}
+	return result, nil
+}
+
+func (s *UserInstructionStore) Update(_ context.Context, instruction model.UserInstruction) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.instructions[instruction.ID]; !ok {
+		return &store.ErrNotFound{Entity: "instruction", ID: instruction.ID}
+	}
+	s.instructions[instruction.ID] = instruction
+	return nil
+}
+
+func (s *UserInstructionStore) Delete(_ context.Context, instructionID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.instructions[instructionID]; !ok {
+		return &store.ErrNotFound{Entity: "instruction", ID: instructionID}
+	}
+	delete(s.instructions, instructionID)
+	return nil
+}

--- a/core/store/mem/instruction_test.go
+++ b/core/store/mem/instruction_test.go
@@ -1,0 +1,130 @@
+package mem_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/store/mem"
+)
+
+func newTestInstruction(id, userID, body string, active bool) model.UserInstruction {
+	return model.UserInstruction{
+		ID:        id,
+		UserID:    userID,
+		Body:      body,
+		Active:    active,
+		CreatedAt: time.Now().UTC(),
+		UpdatedAt: time.Now().UTC(),
+	}
+}
+
+func TestInstructionStore_CreateAndGet(t *testing.T) {
+	s := mem.NewUserInstructionStore()
+	ctx := context.Background()
+	ins := newTestInstruction("ins_1", "usr_1", "Always reference PR numbers", true)
+
+	if err := s.Create(ctx, ins); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := s.Get(ctx, "ins_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.Body != "Always reference PR numbers" {
+		t.Errorf("unexpected body: %s", got.Body)
+	}
+}
+
+func TestInstructionStore_GetNotFound(t *testing.T) {
+	s := mem.NewUserInstructionStore()
+	_, err := s.Get(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInstructionStore_List(t *testing.T) {
+	s := mem.NewUserInstructionStore()
+	ctx := context.Background()
+
+	s.Create(ctx, newTestInstruction("ins_1", "usr_1", "Rule 1", true))
+	s.Create(ctx, newTestInstruction("ins_2", "usr_1", "Rule 2", false))
+	s.Create(ctx, newTestInstruction("ins_3", "usr_2", "Rule 3", true))
+
+	// All for user 1.
+	all, _ := s.List(ctx, store.UserInstructionFilter{UserID: "usr_1"})
+	if len(all) != 2 {
+		t.Fatalf("expected 2, got %d", len(all))
+	}
+
+	// Active only.
+	active := true
+	filtered, _ := s.List(ctx, store.UserInstructionFilter{UserID: "usr_1", Active: &active})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 active, got %d", len(filtered))
+	}
+
+	// Inactive only.
+	inactive := false
+	filtered, _ = s.List(ctx, store.UserInstructionFilter{UserID: "usr_1", Active: &inactive})
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 inactive, got %d", len(filtered))
+	}
+}
+
+func TestInstructionStore_Update(t *testing.T) {
+	s := mem.NewUserInstructionStore()
+	ctx := context.Background()
+
+	ins := newTestInstruction("ins_1", "usr_1", "Original", true)
+	s.Create(ctx, ins)
+
+	ins.Body = "Updated"
+	ins.Active = false
+	if err := s.Update(ctx, ins); err != nil {
+		t.Fatal(err)
+	}
+
+	got, _ := s.Get(ctx, "ins_1")
+	if got.Body != "Updated" {
+		t.Errorf("expected Updated, got %s", got.Body)
+	}
+	if got.Active {
+		t.Error("expected inactive")
+	}
+}
+
+func TestInstructionStore_UpdateNotFound(t *testing.T) {
+	s := mem.NewUserInstructionStore()
+	err := s.Update(context.Background(), model.UserInstruction{ID: "nonexistent"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestInstructionStore_Delete(t *testing.T) {
+	s := mem.NewUserInstructionStore()
+	ctx := context.Background()
+
+	s.Create(ctx, newTestInstruction("ins_1", "usr_1", "Rule", true))
+	if err := s.Delete(ctx, "ins_1"); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := s.Get(ctx, "ins_1")
+	if err == nil {
+		t.Fatal("expected not found after delete")
+	}
+}
+
+func TestInstructionStore_DeleteNotFound(t *testing.T) {
+	s := mem.NewUserInstructionStore()
+	err := s.Delete(context.Background(), "nonexistent")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -221,6 +221,22 @@ type DraftFilter struct {
 	PageSize int
 }
 
+// UserInstructionStore persists and retrieves user instructions for
+// the context store envelope.
+type UserInstructionStore interface {
+	Create(ctx context.Context, instruction model.UserInstruction) error
+	Get(ctx context.Context, instructionID string) (model.UserInstruction, error)
+	List(ctx context.Context, filter UserInstructionFilter) ([]model.UserInstruction, error)
+	Update(ctx context.Context, instruction model.UserInstruction) error
+	Delete(ctx context.Context, instructionID string) error
+}
+
+// UserInstructionFilter scopes an instruction list query.
+type UserInstructionFilter struct {
+	UserID string
+	Active *bool
+}
+
 // UserKeyMaterialStore persists and retrieves user key material for the
 // zero-knowledge vault. The KEK itself is never stored — only the Argon2id
 // salt and an encrypted verification blob.


### PR DESCRIPTION
## Summary

First concrete type in the context store envelope (ADR-0018).

- **UserInstruction model** — body (the rule), scope (optional free-text context), active flag (toggleable)
- **CRUD API** — `POST /v1/instructions`, `GET /v1/instructions`, `GET/PATCH/DELETE /v1/instructions/{id}`
- **Pipeline integration** — system prompt assembled from base + active user instructions. Instructions are highest-priority context.

A user who writes "Always mention PR numbers when discussing code changes" immediately gets better drafts. No ML, no embeddings, no training — just explicit rules in the system prompt.

## Example

```
POST /v1/instructions
{ "body": "Always reference PR numbers when discussing code changes", "scope": "#backend" }

POST /v1/instructions
{ "body": "Be brief in #incidents — facts only, no pleasantries", "scope": "#incidents" }
```

The assembled system prompt becomes:

```
[base prompt]

## User Instructions

The user has set these explicit rules. Follow them precisely:

- Always reference PR numbers when discussing code changes [scope: #backend]
- Be brief in #incidents — facts only, no pleasantries [scope: #incidents]
```

## Test plan

- [x] Instruction store CRUD tests
- [x] Handler tests (create, list, get, update, delete, ownership, auth, empty body)
- [x] Pipeline tests (instructions in prompt, scope annotation, inactive filtered, no instructions)
- [x] All existing tests pass
- [ ] E2E: create instruction → generate draft → verify instruction influenced output (staging)

Refs: #126, ADR-0018

🤖 Generated with [Claude Code](https://claude.com/claude-code)