### PR TITLE
feat(context): draft feedback capture — approve/edit/discard signals

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -51,6 +51,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	connectedAccountStore := mem.NewConnectedAccountStore()
 	draftStore := mem.NewDraftStore()
 	instructionStore := mem.NewUserInstructionStore()
+	feedbackStore := mem.NewDraftFeedbackStore()
 
 	// --- Connector registry ---
 	registry := connector.NewRegistry()
@@ -119,6 +120,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		connectedAccounts: connectedAccountStore,
 		drafts:            draftStore,
 		instructions:      instructionStore,
+		feedback:          feedbackStore,
 		credentials:       credentialStore,
 		fundingSources:    fundingSourceStore,
 		traces:            traceStore,
@@ -143,6 +145,9 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	mux.HandleFunc("GET /v1/instructions/", server.handleInstructionByID)
 	mux.HandleFunc("PATCH /v1/instructions/", server.handleInstructionByID)
 	mux.HandleFunc("DELETE /v1/instructions/", server.handleInstructionByID)
+
+	// Draft feedback API (context store envelope).
+	mux.HandleFunc("GET /v1/feedback", server.handleListFeedback)
 
 	// Draft lifecycle API.
 	mux.HandleFunc("GET /v1/drafts", server.handleListDrafts)

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -52,6 +52,7 @@ type apiServer struct {
 	draftPipeline      *draft.Pipeline        // nil when LLM not configured
 	drafts             store.DraftStore       // draft lifecycle store
 	instructions       store.UserInstructionStore // user instructions for context store
+	feedback           store.DraftFeedbackStore  // draft feedback signals for behavioral model
 	slackSender        SlackSender            // injectable for testing; defaults to comms.SendSlackMessage
 	slackSigningSecret string                  // Slack Events API signing secret for webhook verification
 	slackDedup         *slackEventDedup        // deduplication cache for Slack events

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -94,6 +94,7 @@ func (s *apiServer) handleApproveDraft(w http.ResponseWriter, r *http.Request) {
 	draft.UpdatedAt = time.Now().UTC()
 	s.drafts.Update(r.Context(), draft)
 
+	s.recordFeedback(r.Context(), draft, model.FeedbackSignalApproved)
 	writeJSON(w, http.StatusOK, draft)
 }
 
@@ -130,6 +131,7 @@ func (s *apiServer) handleEditDraft(w http.ResponseWriter, r *http.Request) {
 	draft.UpdatedAt = time.Now().UTC()
 	s.drafts.Update(r.Context(), draft)
 
+	s.recordFeedback(r.Context(), draft, model.FeedbackSignalEdited)
 	writeJSON(w, http.StatusOK, draft)
 }
 
@@ -151,6 +153,7 @@ func (s *apiServer) handleDiscardDraft(w http.ResponseWriter, r *http.Request) {
 	draft.UpdatedAt = time.Now().UTC()
 	s.drafts.Update(r.Context(), draft)
 
+	s.recordFeedback(r.Context(), draft, model.FeedbackSignalDiscarded)
 	writeJSON(w, http.StatusOK, draft)
 }
 
@@ -262,6 +265,57 @@ func (s *apiServer) handleDraftAction(w http.ResponseWriter, r *http.Request) {
 	default:
 		writeError(w, http.StatusNotFound, "not_found", "unknown draft action")
 	}
+}
+
+// recordFeedback writes a feedback signal for a draft action.
+func (s *apiServer) recordFeedback(ctx context.Context, draft model.Draft, signal model.FeedbackSignal) {
+	if s.feedback == nil {
+		return
+	}
+	fb := model.DraftFeedback{
+		ID:        "fb_" + s.newID(),
+		UserID:    draft.UserID,
+		DraftID:   draft.ID,
+		Signal:    signal,
+		Service:   draft.Service,
+		Channel:   draft.Channel,
+		DraftBody: draft.DraftBody,
+		SentBody:  draft.SentBody,
+		CreatedAt: time.Now().UTC(),
+	}
+	if err := s.feedback.Create(ctx, fb); err != nil {
+		s.log.Error("failed to record feedback", "draft_id", draft.ID, "signal", signal, "error", err)
+	}
+}
+
+// handleListFeedback returns the user's draft feedback signals.
+// GET /v1/feedback?signal=edited
+func (s *apiServer) handleListFeedback(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	if s.feedback == nil {
+		writeJSON(w, http.StatusOK, map[string]any{"items": []model.DraftFeedback{}})
+		return
+	}
+
+	filter := store.DraftFeedbackFilter{UserID: userID}
+	if signalParam := r.URL.Query().Get("signal"); signalParam != "" {
+		signal := model.FeedbackSignal(signalParam)
+		filter.Signal = &signal
+	}
+
+	feedback, err := s.feedback.List(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+	if feedback == nil {
+		feedback = []model.DraftFeedback{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": feedback})
 }
 
 // createDraftFromMessage stores a generated draft as pending in the draft store.

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -21,6 +21,7 @@ func newDraftsTestServer() *apiServer {
 	return &apiServer{
 		log:               slog.Default(),
 		drafts:            mem.NewDraftStore(),
+		feedback:          mem.NewDraftFeedbackStore(),
 		connectedAccounts: mem.NewConnectedAccountStore(),
 		vault:             vault.NewMemVault(),
 		users:             &stubUserStore{},
@@ -546,5 +547,168 @@ func TestExtractDraftIDFromAction(t *testing.T) {
 		if got != tt.want {
 			t.Errorf("extractDraftIDFromAction(%q, %q) = %q, want %q", tt.path, tt.action, got, tt.want)
 		}
+	}
+}
+
+func TestApproveDraft_RecordsFeedback(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userAClaims)
+	srv.handleApproveDraft(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	fb, _ := srv.feedback.List(ctx, store.DraftFeedbackFilter{UserID: "usr_a"})
+	if len(fb) != 1 {
+		t.Fatalf("expected 1 feedback signal, got %d", len(fb))
+	}
+	if fb[0].Signal != model.FeedbackSignalApproved {
+		t.Errorf("expected approved, got %s", fb[0].Signal)
+	}
+	if fb[0].DraftID != "dft_1" {
+		t.Errorf("expected dft_1, got %s", fb[0].DraftID)
+	}
+	if fb[0].SentBody != "No, the claims stay the same." {
+		t.Errorf("expected SentBody = DraftBody, got %q", fb[0].SentBody)
+	}
+}
+
+func TestEditDraft_RecordsFeedback(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/edit", `{"body":"Actually yes it does."}`, userAClaims)
+	srv.handleEditDraft(w, r)
+
+	fb, _ := srv.feedback.List(ctx, store.DraftFeedbackFilter{UserID: "usr_a"})
+	if len(fb) != 1 {
+		t.Fatalf("expected 1 feedback, got %d", len(fb))
+	}
+	if fb[0].Signal != model.FeedbackSignalEdited {
+		t.Errorf("expected edited, got %s", fb[0].Signal)
+	}
+	if fb[0].DraftBody != "No, the claims stay the same." {
+		t.Errorf("expected original DraftBody preserved, got %q", fb[0].DraftBody)
+	}
+	if fb[0].SentBody != "Actually yes it does." {
+		t.Errorf("expected edited SentBody, got %q", fb[0].SentBody)
+	}
+}
+
+func TestDiscardDraft_RecordsFeedback(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/discard", "", userAClaims)
+	srv.handleDiscardDraft(w, r)
+
+	fb, _ := srv.feedback.List(ctx, store.DraftFeedbackFilter{UserID: "usr_a"})
+	if len(fb) != 1 {
+		t.Fatalf("expected 1 feedback, got %d", len(fb))
+	}
+	if fb[0].Signal != model.FeedbackSignalDiscarded {
+		t.Errorf("expected discarded, got %s", fb[0].Signal)
+	}
+	if fb[0].SentBody != "" {
+		t.Errorf("expected empty SentBody for discard, got %q", fb[0].SentBody)
+	}
+}
+
+func TestListFeedback_Success(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+
+	// Generate feedback by approving and discarding drafts.
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+	w := httptest.NewRecorder()
+	srv.handleApproveDraft(w, mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userAClaims))
+
+	seedDraft(ctx, srv.drafts, "dft_2", "usr_a", model.DraftStatusPending)
+	w = httptest.NewRecorder()
+	srv.handleDiscardDraft(w, mcpRequest("POST", "/v1/drafts/dft_2/discard", "", userAClaims))
+
+	// List all feedback.
+	w = httptest.NewRecorder()
+	srv.handleListFeedback(w, mcpRequest("GET", "/v1/feedback", "", userAClaims))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp struct {
+		Items []model.DraftFeedback `json:"items"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Items) != 2 {
+		t.Fatalf("expected 2 feedback items, got %d", len(resp.Items))
+	}
+}
+
+func TestListFeedback_FilterBySignal(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+	w := httptest.NewRecorder()
+	srv.handleApproveDraft(w, mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userAClaims))
+
+	seedDraft(ctx, srv.drafts, "dft_2", "usr_a", model.DraftStatusPending)
+	w = httptest.NewRecorder()
+	srv.handleDiscardDraft(w, mcpRequest("POST", "/v1/drafts/dft_2/discard", "", userAClaims))
+
+	// Filter by approved only.
+	w = httptest.NewRecorder()
+	srv.handleListFeedback(w, mcpRequest("GET", "/v1/feedback?signal=approved", "", userAClaims))
+
+	var resp struct {
+		Items []model.DraftFeedback `json:"items"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 approved feedback, got %d", len(resp.Items))
+	}
+}
+
+func TestListFeedback_Unauthorized(t *testing.T) {
+	srv := newDraftsTestServer()
+	w := httptest.NewRecorder()
+	srv.handleListFeedback(w, mcpRequest("GET", "/v1/feedback", "", nil))
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestListFeedback_Empty(t *testing.T) {
+	srv := newDraftsTestServer()
+	w := httptest.NewRecorder()
+	srv.handleListFeedback(w, mcpRequest("GET", "/v1/feedback", "", userAClaims))
+
+	var resp struct {
+		Items []model.DraftFeedback `json:"items"`
+	}
+	json.NewDecoder(w.Body).Decode(&resp)
+	if len(resp.Items) != 0 {
+		t.Fatalf("expected empty, got %d", len(resp.Items))
+	}
+}
+
+func TestListFeedback_NilStore(t *testing.T) {
+	srv := newDraftsTestServer()
+	srv.feedback = nil
+
+	w := httptest.NewRecorder()
+	srv.handleListFeedback(w, mcpRequest("GET", "/v1/feedback", "", userAClaims))
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
 	}
 }

--- a/core/model/feedback.go
+++ b/core/model/feedback.go
@@ -1,0 +1,29 @@
+package model
+
+import "time"
+
+// FeedbackSignal identifies the type of user action on a draft.
+type FeedbackSignal string
+
+const (
+	FeedbackSignalApproved  FeedbackSignal = "approved"
+	FeedbackSignalEdited    FeedbackSignal = "edited"
+	FeedbackSignalDiscarded FeedbackSignal = "discarded"
+)
+
+// DraftFeedback records a user's action on a draft reply. These signals
+// feed the behavioral model — approved drafts reinforce context assembly
+// and tone, edited drafts provide correction signals (the diff between
+// DraftBody and SentBody), and discarded drafts are negative signals.
+type DraftFeedback struct {
+	ID        string         // fb_ + UUID
+	UserID    string         // owning user
+	DraftID   string         // the draft this feedback is for
+	Signal    FeedbackSignal // approved, edited, discarded
+	Service   string         // "slack", etc.
+	Channel   string         // where the original message was
+	DraftBody string         // what the AI generated
+	SentBody  string         // what was actually sent (empty if discarded)
+	ToolsUsed []string       // source connector tools called during generation
+	CreatedAt time.Time
+}

--- a/core/store/mem/feedback.go
+++ b/core/store/mem/feedback.go
@@ -1,0 +1,43 @@
+package mem
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+)
+
+// DraftFeedbackStore is a thread-safe in-memory implementation of store.DraftFeedbackStore.
+type DraftFeedbackStore struct {
+	mu       sync.RWMutex
+	feedback []model.DraftFeedback
+}
+
+// NewDraftFeedbackStore returns an empty in-memory feedback store.
+func NewDraftFeedbackStore() *DraftFeedbackStore {
+	return &DraftFeedbackStore{}
+}
+
+func (s *DraftFeedbackStore) Create(_ context.Context, feedback model.DraftFeedback) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.feedback = append(s.feedback, feedback)
+	return nil
+}
+
+func (s *DraftFeedbackStore) List(_ context.Context, filter store.DraftFeedbackFilter) ([]model.DraftFeedback, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []model.DraftFeedback
+	for _, fb := range s.feedback {
+		if filter.UserID != "" && fb.UserID != filter.UserID {
+			continue
+		}
+		if filter.Signal != nil && fb.Signal != *filter.Signal {
+			continue
+		}
+		result = append(result, fb)
+	}
+	return result, nil
+}

--- a/core/store/mem/feedback_test.go
+++ b/core/store/mem/feedback_test.go
@@ -1,0 +1,76 @@
+package mem_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/store/mem"
+)
+
+func TestFeedbackStore_CreateAndList(t *testing.T) {
+	s := mem.NewDraftFeedbackStore()
+	ctx := context.Background()
+
+	s.Create(ctx, model.DraftFeedback{
+		ID: "fb_1", UserID: "usr_1", DraftID: "dft_1",
+		Signal: model.FeedbackSignalApproved, Channel: "#backend",
+		DraftBody: "draft text", SentBody: "draft text",
+		CreatedAt: time.Now().UTC(),
+	})
+	s.Create(ctx, model.DraftFeedback{
+		ID: "fb_2", UserID: "usr_1", DraftID: "dft_2",
+		Signal: model.FeedbackSignalEdited, Channel: "#backend",
+		DraftBody: "original", SentBody: "revised",
+		CreatedAt: time.Now().UTC(),
+	})
+	s.Create(ctx, model.DraftFeedback{
+		ID: "fb_3", UserID: "usr_2", DraftID: "dft_3",
+		Signal: model.FeedbackSignalDiscarded, Channel: "#incidents",
+		DraftBody: "bad draft", CreatedAt: time.Now().UTC(),
+	})
+
+	// All for user 1.
+	all, err := s.List(ctx, store.DraftFeedbackFilter{UserID: "usr_1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2, got %d", len(all))
+	}
+
+	// Filter by signal.
+	edited := model.FeedbackSignalEdited
+	filtered, err := s.List(ctx, store.DraftFeedbackFilter{UserID: "usr_1", Signal: &edited})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1 edited, got %d", len(filtered))
+	}
+	if filtered[0].DraftBody != "original" {
+		t.Errorf("expected original, got %s", filtered[0].DraftBody)
+	}
+	if filtered[0].SentBody != "revised" {
+		t.Errorf("expected revised, got %s", filtered[0].SentBody)
+	}
+
+	// All signals (no filter).
+	everything, _ := s.List(ctx, store.DraftFeedbackFilter{})
+	if len(everything) != 3 {
+		t.Fatalf("expected 3 total, got %d", len(everything))
+	}
+}
+
+func TestFeedbackStore_Empty(t *testing.T) {
+	s := mem.NewDraftFeedbackStore()
+	result, err := s.List(context.Background(), store.DraftFeedbackFilter{UserID: "usr_1"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result != nil {
+		t.Fatalf("expected nil, got %v", result)
+	}
+}

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -221,6 +221,19 @@ type DraftFilter struct {
 	PageSize int
 }
 
+// DraftFeedbackStore persists and retrieves feedback signals from draft
+// approve/edit/discard actions. These signals feed the behavioral model.
+type DraftFeedbackStore interface {
+	Create(ctx context.Context, feedback model.DraftFeedback) error
+	List(ctx context.Context, filter DraftFeedbackFilter) ([]model.DraftFeedback, error)
+}
+
+// DraftFeedbackFilter scopes a feedback list query.
+type DraftFeedbackFilter struct {
+	UserID string
+	Signal *model.FeedbackSignal
+}
+
 // UserInstructionStore persists and retrieves user instructions for
 // the context store envelope.
 type UserInstructionStore interface {


### PR DESCRIPTION
## Summary

Second concrete type in the context store envelope (ADR-0018).

- **DraftFeedback model** — records signal (approved/edited/discarded), draft body, sent body, channel, service, tools used
- **Append-only store** with List filtered by user and signal type
- **Capture integration** — approve/edit/discard handlers now write a feedback signal automatically
- **Read API** — `GET /v1/feedback?signal=edited` for transparency ("what has Aileron learned from me?")

Every draft interaction is now a stored learning signal:
- **Approved:** DraftBody = SentBody → context assembly and tone were correct (positive)
- **Edited:** DraftBody ≠ SentBody → the diff is a correction signal (the behavioral model will learn from this)
- **Discarded:** empty SentBody → draft was wrong (negative)

This is a prerequisite for the behavioral model evaluation spike (#128) — we need real feedback data before we can evaluate memory infrastructure options.

## Test plan

- [x] Feedback store CRUD tests
- [x] Approve/edit/discard record feedback signals with correct metadata
- [x] List feedback endpoint (all, filter by signal, unauthorized, empty, nil store)
- [x] All existing tests pass

Refs: #129, #128, ADR-0018

🤖 Generated with [Claude Code](https://claude.com/claude-code)