### PR TITLE
feat(source): add Google Drive tools (search + get doc)

### DIFF
--- a/core/account/service.go
+++ b/core/account/service.go
@@ -33,6 +33,7 @@ var googleProviders = map[model.ConnectedAccountProvider]providerConfig{
 			"https://www.googleapis.com/auth/gmail.readonly",
 			"https://www.googleapis.com/auth/gmail.send",
 			"https://www.googleapis.com/auth/gmail.compose",
+			"https://www.googleapis.com/auth/drive.readonly",
 			"https://www.googleapis.com/auth/userinfo.email",
 		},
 		endpoint: google.Endpoint,

--- a/core/source/gmail/connector.go
+++ b/core/source/gmail/connector.go
@@ -1,14 +1,21 @@
-// Package gmail implements a SourceConnector for Gmail, providing read-only
-// tools for searching emails and reading threads.
+// Package gmail implements a SourceConnector for Gmail and Google Drive,
+// providing read-only tools for searching emails, reading threads,
+// searching Drive files, and reading document contents.
+//
+// Gmail and Drive share the same Google OAuth token. The Gmail OAuth
+// scopes should include drive.readonly for Drive tools to work.
 package gmail
 
 import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
+
 	"github.com/ALRubinger/aileron/core/source"
 	"golang.org/x/oauth2"
-	gmail "google.golang.org/api/gmail/v1"
+	driveapi "google.golang.org/api/drive/v3"
+	gmailapi "google.golang.org/api/gmail/v1"
 	"google.golang.org/api/option"
 )
 
@@ -49,6 +56,21 @@ func (c *Connector) Tools() []source.ToolDefinition {
 				{Name: "thread_id", Type: "string", Description: "The Gmail thread ID", Required: true},
 			},
 		},
+		{
+			Name:        "drive_search",
+			Description: "Search Google Drive files by name or content. Returns file names, types, and IDs.",
+			Parameters: []source.ToolParam{
+				{Name: "query", Type: "string", Description: "Search query (e.g. 'migration plan')", Required: true},
+				{Name: "max_results", Type: "integer", Description: "Maximum results (default 10, max 25)", Required: false},
+			},
+		},
+		{
+			Name:        "drive_get_doc",
+			Description: "Get the text content of a Google Doc. Returns the document as plain text.",
+			Parameters: []source.ToolParam{
+				{Name: "file_id", Type: "string", Description: "The Google Drive file ID", Required: true},
+			},
+		},
 	}
 }
 
@@ -63,12 +85,16 @@ func (c *Connector) Execute(ctx context.Context, tool string, params map[string]
 		return c.search(ctx, svc, params)
 	case "gmail_get_thread":
 		return c.getThread(ctx, svc, params)
+	case "drive_search":
+		return c.driveSearch(ctx, token, params)
+	case "drive_get_doc":
+		return c.driveGetDoc(ctx, token, params)
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", tool)
 	}
 }
 
-func (c *Connector) newService(ctx context.Context, token []byte) (*gmail.Service, error) {
+func (c *Connector) newService(ctx context.Context, token []byte) (*gmailapi.Service, error) {
 	accessToken, err := extractAccessToken(token)
 	if err != nil {
 		return nil, fmt.Errorf("invalid token: %w", err)
@@ -79,14 +105,14 @@ func (c *Connector) newService(ctx context.Context, token []byte) (*gmail.Servic
 	if c.clientOption != nil {
 		opts = append(opts, c.clientOption)
 	}
-	svc, err := gmail.NewService(ctx, opts...)
+	svc, err := gmailapi.NewService(ctx, opts...)
 	if err != nil {
 		return nil, fmt.Errorf("creating gmail service: %w", err)
 	}
 	return svc, nil
 }
 
-func (c *Connector) search(ctx context.Context, svc *gmail.Service, params map[string]any) (map[string]any, error) {
+func (c *Connector) search(ctx context.Context, svc *gmailapi.Service, params map[string]any) (map[string]any, error) {
 	query, ok := params["query"].(string)
 	if !ok || query == "" {
 		return nil, fmt.Errorf("query parameter is required")
@@ -134,7 +160,7 @@ func (c *Connector) search(ctx context.Context, svc *gmail.Service, params map[s
 	return map[string]any{"messages": messages, "total": resp.ResultSizeEstimate}, nil
 }
 
-func (c *Connector) getThread(ctx context.Context, svc *gmail.Service, params map[string]any) (map[string]any, error) {
+func (c *Connector) getThread(ctx context.Context, svc *gmailapi.Service, params map[string]any) (map[string]any, error) {
 	threadID, ok := params["thread_id"].(string)
 	if !ok || threadID == "" {
 		return nil, fmt.Errorf("thread_id parameter is required")
@@ -166,6 +192,96 @@ func (c *Connector) getThread(ctx context.Context, svc *gmail.Service, params ma
 	}
 
 	return map[string]any{"messages": messages}, nil
+}
+
+func (c *Connector) newDriveService(ctx context.Context, token []byte) (*driveapi.Service, error) {
+	accessToken, err := extractAccessToken(token)
+	if err != nil {
+		return nil, fmt.Errorf("invalid token: %w", err)
+	}
+
+	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
+	opts := []option.ClientOption{option.WithTokenSource(ts)}
+	if c.clientOption != nil {
+		opts = append(opts, c.clientOption)
+	}
+	svc, err := driveapi.NewService(ctx, opts...)
+	if err != nil {
+		return nil, fmt.Errorf("creating drive service: %w", err)
+	}
+	return svc, nil
+}
+
+func (c *Connector) driveSearch(ctx context.Context, token []byte, params map[string]any) (map[string]any, error) {
+	query, ok := params["query"].(string)
+	if !ok || query == "" {
+		return nil, fmt.Errorf("query parameter is required")
+	}
+
+	svc, err := c.newDriveService(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	maxResults := int64(10)
+	if mr, ok := params["max_results"]; ok {
+		maxResults = toInt64(mr, 10)
+	}
+	if maxResults > 25 {
+		maxResults = 25
+	}
+
+	driveQuery := fmt.Sprintf("fullText contains '%s' and trashed = false", query)
+	resp, err := svc.Files.List().Q(driveQuery).
+		PageSize(maxResults).
+		Fields("files(id, name, mimeType, modifiedTime, webViewLink)").
+		Context(ctx).Do()
+	if err != nil {
+		return nil, fmt.Errorf("drive API error: %w", err)
+	}
+
+	files := make([]map[string]any, 0, len(resp.Files))
+	for _, f := range resp.Files {
+		files = append(files, map[string]any{
+			"id":            f.Id,
+			"name":          f.Name,
+			"mime_type":     f.MimeType,
+			"modified_time": f.ModifiedTime,
+			"url":           f.WebViewLink,
+		})
+	}
+
+	return map[string]any{"files": files}, nil
+}
+
+func (c *Connector) driveGetDoc(ctx context.Context, token []byte, params map[string]any) (map[string]any, error) {
+	fileID, ok := params["file_id"].(string)
+	if !ok || fileID == "" {
+		return nil, fmt.Errorf("file_id parameter is required")
+	}
+
+	svc, err := c.newDriveService(ctx, token)
+	if err != nil {
+		return nil, err
+	}
+
+	resp, err := svc.Files.Export(fileID, "text/plain").Context(ctx).Download()
+	if err != nil {
+		return nil, fmt.Errorf("drive API error: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading document: %w", err)
+	}
+
+	content := string(body)
+	if len(content) > 20000 {
+		content = content[:20000] + "\n... (truncated)"
+	}
+
+	return map[string]any{"content": content}, nil
 }
 
 // extractAccessToken parses stored token JSON and returns the access token.

--- a/core/source/gmail/connector_test.go
+++ b/core/source/gmail/connector_test.go
@@ -240,6 +240,60 @@ func TestConnector_DriveSearch_MissingQuery(t *testing.T) {
 	}
 }
 
+func TestConnector_DriveGetDoc_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// The Drive export endpoint returns plain text directly.
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write([]byte("This is the migration plan document content.\n\nPhase 1: Schema changes\nPhase 2: Data migration"))
+	}))
+	defer server.Close()
+
+	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	result, err := c.Execute(context.Background(), "drive_get_doc", map[string]any{
+		"file_id": "doc_123",
+	}, testToken())
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	content, ok := result["content"].(string)
+	if !ok || content == "" {
+		t.Fatal("expected non-empty content")
+	}
+	if !containsStr(content, "migration plan") {
+		t.Errorf("expected content to contain 'migration plan', got: %s", content)
+	}
+}
+
+func TestConnector_DriveGetDoc_InvalidToken(t *testing.T) {
+	c := gmailsource.New()
+	_, err := c.Execute(context.Background(), "drive_get_doc", map[string]any{
+		"file_id": "doc_123",
+	}, []byte("not-json"))
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}
+
+func TestConnector_DriveSearch_InvalidToken(t *testing.T) {
+	c := gmailsource.New()
+	_, err := c.Execute(context.Background(), "drive_search", map[string]any{
+		"query": "test",
+	}, []byte("not-json"))
+	if err == nil {
+		t.Fatal("expected error for invalid token")
+	}
+}
+
+func containsStr(s, sub string) bool {
+	for i := 0; i <= len(s)-len(sub); i++ {
+		if s[i:i+len(sub)] == sub {
+			return true
+		}
+	}
+	return false
+}
+
 func TestConnector_DriveGetDoc_MissingFileID(t *testing.T) {
 	c := gmailsource.New()
 	_, err := c.Execute(context.Background(), "drive_get_doc", map[string]any{}, testToken())

--- a/core/source/gmail/connector_test.go
+++ b/core/source/gmail/connector_test.go
@@ -29,18 +29,17 @@ func TestConnector_Provider(t *testing.T) {
 func TestConnector_Tools(t *testing.T) {
 	c := gmailsource.New()
 	tools := c.Tools()
-	if len(tools) != 2 {
-		t.Fatalf("expected 2 tools, got %d", len(tools))
+	if len(tools) != 4 {
+		t.Fatalf("expected 4 tools, got %d", len(tools))
 	}
 	names := make(map[string]bool)
 	for _, tool := range tools {
 		names[tool.Name] = true
 	}
-	if !names["gmail_search"] {
-		t.Error("expected gmail_search tool")
-	}
-	if !names["gmail_get_thread"] {
-		t.Error("expected gmail_get_thread tool")
+	for _, expected := range []string{"gmail_search", "gmail_get_thread", "drive_search", "drive_get_doc"} {
+		if !names[expected] {
+			t.Errorf("expected %s tool", expected)
+		}
 	}
 }
 
@@ -196,6 +195,91 @@ func TestConnector_OAuthTokenFormat(t *testing.T) {
 	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{"query": "test"}, token)
 	if err != nil {
 		t.Fatalf("unexpected error with oauth2 token format: %v", err)
+	}
+}
+
+func TestConnector_DriveSearch_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"files": []map[string]any{
+				{
+					"id":           "doc_123",
+					"name":         "Migration Plan",
+					"mimeType":     "application/vnd.google-apps.document",
+					"modifiedTime": "2026-04-10T10:00:00Z",
+					"webViewLink":  "https://docs.google.com/document/d/doc_123",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	result, err := c.Execute(context.Background(), "drive_search", map[string]any{
+		"query": "migration plan",
+	}, testToken())
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	files := result["files"].([]map[string]any)
+	if len(files) != 1 {
+		t.Fatalf("expected 1 file, got %d", len(files))
+	}
+	if files[0]["name"] != "Migration Plan" {
+		t.Errorf("expected Migration Plan, got %v", files[0]["name"])
+	}
+}
+
+func TestConnector_DriveSearch_MissingQuery(t *testing.T) {
+	c := gmailsource.New()
+	_, err := c.Execute(context.Background(), "drive_search", map[string]any{}, testToken())
+	if err == nil {
+		t.Fatal("expected error for missing query")
+	}
+}
+
+func TestConnector_DriveGetDoc_MissingFileID(t *testing.T) {
+	c := gmailsource.New()
+	_, err := c.Execute(context.Background(), "drive_get_doc", map[string]any{}, testToken())
+	if err == nil {
+		t.Fatal("expected error for missing file_id")
+	}
+}
+
+func TestConnector_ToolsIncludeDrive(t *testing.T) {
+	c := gmailsource.New()
+	tools := c.Tools()
+	if len(tools) != 4 {
+		t.Fatalf("expected 4 tools (2 gmail + 2 drive), got %d", len(tools))
+	}
+	names := make(map[string]bool)
+	for _, tool := range tools {
+		names[tool.Name] = true
+	}
+	if !names["drive_search"] {
+		t.Error("expected drive_search tool")
+	}
+	if !names["drive_get_doc"] {
+		t.Error("expected drive_get_doc tool")
+	}
+}
+
+func TestConnector_DriveSearch_WithMaxResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"files": []map[string]any{}})
+	}))
+	defer server.Close()
+
+	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	_, err := c.Execute(context.Background(), "drive_search", map[string]any{
+		"query":       "test",
+		"max_results": float64(5),
+	}, testToken())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
 	}
 }
 

--- a/core/source/gmail/connector_test.go
+++ b/core/source/gmail/connector_test.go
@@ -337,6 +337,70 @@ func TestConnector_DriveSearch_WithMaxResults(t *testing.T) {
 	}
 }
 
+func TestConnector_DriveGetDoc_LargeContent(t *testing.T) {
+	// Generate content > 20KB to test truncation.
+	largeContent := make([]byte, 25000)
+	for i := range largeContent {
+		largeContent[i] = 'x'
+	}
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "text/plain")
+		w.Write(largeContent)
+	}))
+	defer server.Close()
+
+	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	result, err := c.Execute(context.Background(), "drive_get_doc", map[string]any{
+		"file_id": "doc_big",
+	}, testToken())
+
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	content := result["content"].(string)
+	if !containsStr(content, "truncated") {
+		t.Error("expected truncation marker in large document")
+	}
+}
+
+func TestConnector_Search_IntMaxResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"messages":           []map[string]any{},
+			"resultSizeEstimate": 0,
+		})
+	}))
+	defer server.Close()
+
+	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	// Test with int type (not float64).
+	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{
+		"query":       "test",
+		"max_results": 3,
+	}, testToken())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestConnector_DriveSearch_IntMaxResults(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"files": []map[string]any{}})
+	}))
+	defer server.Close()
+
+	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	_, err := c.Execute(context.Background(), "drive_search", map[string]any{
+		"query":       "test",
+		"max_results": 3,
+	}, testToken())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
 func TestConnector_Search_MissingQuery(t *testing.T) {
 	token, _ := json.Marshal(map[string]string{"access_token": "test"})
 	c := gmailsource.New()


### PR DESCRIPTION
## Summary

- Add `drive_search` and `drive_get_doc` tools to the Gmail source connector (shared Google OAuth token)
- Add `drive.readonly` scope to Gmail OAuth configuration
- Document text truncated at 20KB to protect context window

Drive tools are registered under the `gmail` provider since they share the same Google connected account. When a user connects Gmail, they also authorize Drive read access.

## Complete source connector inventory

| Source | Tools | Status |
|---|---|---|
| Slack | channel_history, thread_replies, search_messages | Merged |
| GitHub | search_code, search_issues, get_pr, get_pr_diff, get_file | Merged |
| Gmail | search, get_thread | Merged |
| Calendar | events, free_busy | Merged |
| Drive | search, get_doc | This PR |

## Test plan

- [x] Drive search with mock server
- [x] Drive search parameter validation (missing query, max_results)
- [x] Drive get_doc parameter validation (missing file_id)
- [x] Tools list includes all 4 tools (gmail + drive)
- [x] All existing tests pass

Refs: #134, #135

🤖 Generated with [Claude Code](https://claude.com/claude-code)