### PR TITLE
feat(slack): ephemeral draft delivery with Approve/Edit/Discard buttons

### DIFF
--- a/core/account/slack_service.go
+++ b/core/account/slack_service.go
@@ -32,11 +32,22 @@ var slackUserScopes = []string{
 	"users:read",
 }
 
+// slackBotScopes are the OAuth bot scopes requested for Slack.
+// The bot token is used for posting ephemeral messages (draft previews
+// visible only to the user). The bot is silent — it never posts visible
+// messages. Replies are sent via the user token.
+var slackBotScopes = []string{
+	"chat:write",
+}
+
 // slackOAuthResponse is the non-standard response from Slack's oauth.v2.access endpoint.
 type slackOAuthResponse struct {
-	OK         bool   `json:"ok"`
-	Error      string `json:"error,omitempty"`
-	AuthedUser struct {
+	OK          bool   `json:"ok"`
+	Error       string `json:"error,omitempty"`
+	AccessToken string `json:"access_token,omitempty"` // bot token (top-level)
+	TokenType   string `json:"token_type,omitempty"`
+	BotUserID   string `json:"bot_user_id,omitempty"`
+	AuthedUser  struct {
 		ID          string `json:"id"`
 		AccessToken string `json:"access_token"`
 		Scope       string `json:"scope"`
@@ -127,6 +138,7 @@ func (s *SlackService) Providers() []model.ConnectedAccountProvider {
 func (s *SlackService) AuthorizationURL(_ context.Context, _ model.ConnectedAccountProvider, state, redirectURL string) (*ConnectResult, error) {
 	params := url.Values{
 		"client_id":    {s.clientID},
+		"scope":        {strings.Join(slackBotScopes, ",")},
 		"user_scope":   {strings.Join(slackUserScopes, ",")},
 		"redirect_uri": {redirectURL},
 		"state":        {state},
@@ -157,14 +169,16 @@ func (s *SlackService) HandleCallback(ctx context.Context, _ model.ConnectedAcco
 		UpdatedAt:      time.Now().UTC(),
 	}
 
-	// Store the user token in the vault.
+	// Store both user and bot tokens in the vault.
 	tokenJSON, err := json.Marshal(map[string]string{
-		"access_token": resp.AuthedUser.AccessToken,
-		"token_type":   resp.AuthedUser.TokenType,
-		"scope":        resp.AuthedUser.Scope,
-		"team_id":      resp.Team.ID,
-		"team_name":    resp.Team.Name,
-		"user_id":      resp.AuthedUser.ID,
+		"access_token":     resp.AuthedUser.AccessToken,
+		"bot_access_token": resp.AccessToken,
+		"token_type":       resp.AuthedUser.TokenType,
+		"scope":            resp.AuthedUser.Scope,
+		"team_id":          resp.Team.ID,
+		"team_name":        resp.Team.Name,
+		"user_id":          resp.AuthedUser.ID,
+		"bot_user_id":      resp.BotUserID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshalling token: %w", err)

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -267,10 +267,14 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 						"user_id", userID,
 						"channel", msg.Channel,
 						"draft_length", len(draftText))
+
+					// Post ephemeral draft preview in Slack.
+					server.deliverEphemeralDraft(ctx, userID, d)
 				}
 			}
 			mux.HandleFunc("POST /v1/webhooks/slack/events", server.handleSlackEvent)
-			log.Info("enabled Slack Events API webhook endpoint")
+			mux.HandleFunc("POST /v1/webhooks/slack/interactions", server.handleSlackInteraction)
+			log.Info("enabled Slack Events API webhook and interaction endpoints")
 		}
 		if authCfg.GitHubEnabled() {
 			authRegistry.Register(githubauth.New(
@@ -310,8 +314,9 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		authHandler.RegisterRoutes(mux)
 
 		skipPaths := map[string]bool{
-			"/v1/health":                    true,
-			"/v1/webhooks/slack/events":     true,
+			"/v1/health":                        true,
+			"/v1/webhooks/slack/events":          true,
+			"/v1/webhooks/slack/interactions":    true,
 		}
 		handler = auth.Middleware(tokenIssuer, skipPaths)(handler)
 		log.Info("auth middleware enabled")

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -54,6 +54,7 @@ type apiServer struct {
 	instructions       store.UserInstructionStore // user instructions for context store
 	feedback           store.DraftFeedbackStore  // draft feedback signals for behavioral model
 	slackSender        SlackSender            // injectable for testing; defaults to comms.SendSlackMessage
+	ephemeralPoster    EphemeralPoster        // injectable for testing; defaults to comms.PostEphemeralDraft
 	slackSigningSecret string                  // Slack Events API signing secret for webhook verification
 	slackDedup         *slackEventDedup        // deduplication cache for Slack events
 	onSlackMessage     func(ctx context.Context, userID string, msg comms.IncomingMessage) // callback for incoming Slack messages

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -188,6 +188,10 @@ func (s *apiServer) getDraftForAction(w http.ResponseWriter, r *http.Request, dr
 	return draft, nil
 }
 
+// EphemeralPoster is the function used to post ephemeral draft messages.
+// Defaults to comms.PostEphemeralDraft. Override in tests.
+type EphemeralPoster func(ctx context.Context, msg comms.SlackDraftMessage) error
+
 // SlackSender is the function used to send messages to Slack.
 // Defaults to comms.SendSlackMessage. Override in tests.
 type SlackSender func(ctx context.Context, token, channel, body string) error
@@ -359,7 +363,11 @@ func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, dr
 		return
 	}
 
-	err = comms.PostEphemeralDraft(ctx, comms.SlackDraftMessage{
+	poster := s.ephemeralPoster
+	if poster == nil {
+		poster = comms.PostEphemeralDraft
+	}
+	err = poster(ctx, comms.SlackDraftMessage{
 		BotToken: botToken,
 		Channel:  draft.Channel,
 		UserID:   slackUserID,

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -318,6 +318,67 @@ func (s *apiServer) handleListFeedback(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"items": feedback})
 }
 
+// deliverEphemeralDraft posts an ephemeral Block Kit message in the Slack
+// channel where the original message was, showing the draft with
+// approve/edit/discard buttons. Only the target user sees it.
+func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, draft model.Draft) {
+	slackProvider := model.ConnectedAccountProviderSlack
+	accounts, err := s.connectedAccounts.List(ctx, store.ConnectedAccountFilter{
+		UserID:   userID,
+		Provider: &slackProvider,
+	})
+	if err != nil || len(accounts) == 0 {
+		s.log.Debug("ephemeral: no slack account for ephemeral delivery", "user_id", userID)
+		return
+	}
+
+	acct := accounts[0]
+
+	// Get the token data from vault.
+	secret, err := s.vault.Get(ctx, acct.VaultPath())
+	if err != nil {
+		s.log.Debug("ephemeral: failed to get vault token", "user_id", userID, "error", err)
+		return
+	}
+
+	var tokenData map[string]string
+	if err := json.Unmarshal(secret.Value, &tokenData); err != nil {
+		s.log.Debug("ephemeral: failed to parse token", "user_id", userID, "error", err)
+		return
+	}
+
+	botToken := tokenData["bot_access_token"]
+	if botToken == "" {
+		s.log.Debug("ephemeral: no bot token available", "user_id", userID)
+		return
+	}
+
+	slackUserID := acct.ExternalUserID
+	if slackUserID == "" {
+		s.log.Debug("ephemeral: no slack user ID", "user_id", userID)
+		return
+	}
+
+	err = comms.PostEphemeralDraft(ctx, comms.SlackDraftMessage{
+		BotToken: botToken,
+		Channel:  draft.Channel,
+		UserID:   slackUserID,
+		DraftID:  draft.ID,
+		Author:   draft.Author,
+		Body:     draft.MessageBody,
+		Draft:    draft.DraftBody,
+	})
+	if err != nil {
+		s.log.Error("ephemeral: failed to post", "user_id", userID, "draft_id", draft.ID, "error", err)
+		return
+	}
+
+	s.log.Info("ephemeral draft delivered",
+		"draft_id", draft.ID,
+		"user_id", userID,
+		"channel", draft.Channel)
+}
+
 // createDraftFromMessage stores a generated draft as pending in the draft store.
 // Extracted from the onSlackMessage closure so it can be unit tested.
 func (s *apiServer) createDraftFromMessage(ctx context.Context, userID string, msg comms.IncomingMessage, draftText string) (model.Draft, error) {

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -214,14 +214,19 @@ func newDraftsTestServerWithSend() *apiServer {
 	// Set up a connected Slack account + vault token so send works.
 	ctx := context.Background()
 	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
-		ID:       "conn_s1",
-		UserID:   "usr_a",
-		Provider: model.ConnectedAccountProviderSlack,
-		Status:   model.ConnectedAccountStatusActive,
+		ID:             "conn_s1",
+		UserID:         "usr_a",
+		Provider:       model.ConnectedAccountProviderSlack,
+		Status:         model.ConnectedAccountStatusActive,
+		ExternalUserID: "U123ABC",
 	})
-	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test"}`), vault.Metadata{})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test","bot_access_token":"xoxb-test"}`), vault.Metadata{})
 	// Mock sender so we don't call real Slack.
 	srv.slackSender = func(_ context.Context, token, channel, body string) error {
+		return nil
+	}
+	// Mock ephemeral poster.
+	srv.ephemeralPoster = func(_ context.Context, msg comms.SlackDraftMessage) error {
 		return nil
 	}
 	return srv
@@ -511,6 +516,97 @@ func TestGetDraft_EmptyID(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for empty ID, got %d", w.Code)
+	}
+}
+
+func TestDeliverEphemeralDraft_Success(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	var posted bool
+	srv.ephemeralPoster = func(_ context.Context, msg comms.SlackDraftMessage) error {
+		posted = true
+		if msg.BotToken != "xoxb-test" {
+			t.Errorf("expected bot token xoxb-test, got %s", msg.BotToken)
+		}
+		if msg.UserID != "U123ABC" {
+			t.Errorf("expected user ID U123ABC, got %s", msg.UserID)
+		}
+		if msg.DraftID != "dft_eph" {
+			t.Errorf("expected draft ID dft_eph, got %s", msg.DraftID)
+		}
+		return nil
+	}
+
+	ctx := context.Background()
+	srv.deliverEphemeralDraft(ctx, "usr_a", model.Draft{
+		ID:        "dft_eph",
+		UserID:    "usr_a",
+		Channel:   "C0BACKEND",
+		Author:    "Sarah",
+		DraftBody: "Draft reply text",
+	})
+
+	if !posted {
+		t.Error("expected ephemeral to be posted")
+	}
+}
+
+func TestDeliverEphemeralDraft_NoBotToken(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+
+	// Connected account without bot token.
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123",
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test"}`), vault.Metadata{})
+
+	var posted bool
+	srv.ephemeralPoster = func(_ context.Context, _ comms.SlackDraftMessage) error {
+		posted = true
+		return nil
+	}
+
+	srv.deliverEphemeralDraft(ctx, "usr_a", model.Draft{ID: "dft_1", Channel: "C123", DraftBody: "test"})
+	if posted {
+		t.Error("should not post when bot token missing")
+	}
+}
+
+func TestDeliverEphemeralDraft_NoSlackAccount(t *testing.T) {
+	srv := newDraftsTestServer()
+	var posted bool
+	srv.ephemeralPoster = func(_ context.Context, _ comms.SlackDraftMessage) error {
+		posted = true
+		return nil
+	}
+
+	srv.deliverEphemeralDraft(context.Background(), "usr_a", model.Draft{ID: "dft_1"})
+	if posted {
+		t.Error("should not post when no slack account")
+	}
+}
+
+func TestDeliverEphemeralDraft_NoExternalUserID(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive,
+		// ExternalUserID is empty
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp","bot_access_token":"xoxb"}`), vault.Metadata{})
+
+	var posted bool
+	srv.ephemeralPoster = func(_ context.Context, _ comms.SlackDraftMessage) error {
+		posted = true
+		return nil
+	}
+
+	srv.deliverEphemeralDraft(ctx, "usr_a", model.Draft{ID: "dft_1", Channel: "C123", DraftBody: "test"})
+	if posted {
+		t.Error("should not post when external user ID missing")
 	}
 }
 

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -587,6 +587,47 @@ func TestDeliverEphemeralDraft_NoSlackAccount(t *testing.T) {
 	}
 }
 
+func TestDeliverEphemeralDraft_BadTokenJSON(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123",
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte("not-json"), vault.Metadata{})
+
+	var posted bool
+	srv.ephemeralPoster = func(_ context.Context, _ comms.SlackDraftMessage) error {
+		posted = true
+		return nil
+	}
+
+	srv.deliverEphemeralDraft(ctx, "usr_a", model.Draft{ID: "dft_1", Channel: "C123", DraftBody: "test"})
+	if posted {
+		t.Error("should not post when token JSON is invalid")
+	}
+}
+
+func TestDeliverEphemeralDraft_PosterError(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	srv.ephemeralPoster = func(_ context.Context, _ comms.SlackDraftMessage) error {
+		return fmt.Errorf("slack API unavailable")
+	}
+
+	// Should not panic — just logs the error.
+	srv.deliverEphemeralDraft(context.Background(), "usr_a", model.Draft{
+		ID: "dft_1", Channel: "C0BACKEND", Author: "Sarah", DraftBody: "test",
+	})
+}
+
+func TestRecordFeedback_NilStore(t *testing.T) {
+	srv := newDraftsTestServer()
+	srv.feedback = nil
+	// Should not panic.
+	srv.recordFeedback(context.Background(), model.Draft{ID: "dft_1"}, model.FeedbackSignalApproved)
+}
+
 func TestDeliverEphemeralDraft_NoExternalUserID(t *testing.T) {
 	srv := newDraftsTestServer()
 	ctx := context.Background()

--- a/core/app/handlers_slack_interactions.go
+++ b/core/app/handlers_slack_interactions.go
@@ -1,0 +1,151 @@
+package app
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+)
+
+// slackInteractionPayload is the payload Slack sends when a user clicks
+// a button or interacts with a Block Kit element.
+type slackInteractionPayload struct {
+	Type string `json:"type"`
+	User struct {
+		ID string `json:"id"`
+	} `json:"user"`
+	Actions []struct {
+		ActionID string `json:"action_id"`
+		Value    string `json:"value"` // draft ID
+	} `json:"actions"`
+	ResponseURL string `json:"response_url"`
+}
+
+// handleSlackInteraction handles POST /v1/webhooks/slack/interactions.
+// Slack sends interaction payloads as application/x-www-form-urlencoded
+// with a "payload" field containing JSON.
+func (s *apiServer) handleSlackInteraction(w http.ResponseWriter, r *http.Request) {
+	if r.Method != http.MethodPost {
+		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
+		return
+	}
+
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		http.Error(w, "failed to read body", http.StatusBadRequest)
+		return
+	}
+
+	// Verify Slack signature (same mechanism as events webhook).
+	if !s.verifySlackSignature(r, body) {
+		http.Error(w, "invalid signature", http.StatusUnauthorized)
+		return
+	}
+
+	// Parse the URL-encoded payload.
+	values, err := url.ParseQuery(string(body))
+	if err != nil {
+		http.Error(w, "invalid form data", http.StatusBadRequest)
+		return
+	}
+
+	payloadJSON := values.Get("payload")
+	if payloadJSON == "" {
+		http.Error(w, "missing payload", http.StatusBadRequest)
+		return
+	}
+
+	var payload slackInteractionPayload
+	if err := json.Unmarshal([]byte(payloadJSON), &payload); err != nil {
+		http.Error(w, "invalid payload JSON", http.StatusBadRequest)
+		return
+	}
+
+	if payload.Type != "block_actions" || len(payload.Actions) == 0 {
+		w.WriteHeader(http.StatusOK)
+		return
+	}
+
+	action := payload.Actions[0]
+	draftID := action.Value
+
+	// Return 200 immediately — Slack requires fast response.
+	w.WriteHeader(http.StatusOK)
+
+	// Process async.
+	go s.processInteraction(action.ActionID, draftID, payload)
+}
+
+// processInteraction handles a button click on a draft ephemeral message.
+func (s *apiServer) processInteraction(actionID, draftID string, payload slackInteractionPayload) {
+	ctx := context.Background()
+
+	draft, err := s.drafts.Get(ctx, draftID)
+	if err != nil {
+		s.log.Error("interaction: draft not found", "draft_id", draftID, "error", err)
+		return
+	}
+
+	if draft.Status != model.DraftStatusPending {
+		s.log.Debug("interaction: draft already actioned", "draft_id", draftID, "status", draft.Status)
+		return
+	}
+
+	// Look up the Aileron user from the Slack user ID.
+	// The draft already has the UserID, so we use that.
+
+	switch actionID {
+	case "approve_draft":
+		if err := s.sendDraftMessage(ctx, draft.UserID, draft.Channel, draft.DraftBody); err != nil {
+			s.log.Error("interaction: failed to send approved draft", "draft_id", draftID, "error", err)
+			s.respondToInteraction(payload.ResponseURL, "Failed to send: "+err.Error())
+			return
+		}
+		draft.Status = model.DraftStatusApproved
+		draft.SentBody = draft.DraftBody
+		draft.UpdatedAt = time.Now().UTC()
+		s.drafts.Update(ctx, draft)
+		s.recordFeedback(ctx, draft, model.FeedbackSignalApproved)
+		s.respondToInteraction(payload.ResponseURL, "Sent.")
+
+	case "discard_draft":
+		draft.Status = model.DraftStatusDiscarded
+		draft.UpdatedAt = time.Now().UTC()
+		s.drafts.Update(ctx, draft)
+		s.recordFeedback(ctx, draft, model.FeedbackSignalDiscarded)
+		s.respondToInteraction(payload.ResponseURL, "Draft discarded.")
+
+	case "edit_draft":
+		// For MVP, respond with the draft text for the user to copy/edit manually.
+		// A full Slack modal (views.open) for inline editing is a follow-up.
+		s.respondToInteraction(payload.ResponseURL,
+			fmt.Sprintf("Edit and send manually:\n\n```%s```", draft.DraftBody))
+
+	default:
+		s.log.Debug("interaction: unknown action", "action_id", actionID)
+	}
+}
+
+// respondToInteraction sends a response to Slack's response_url,
+// replacing the ephemeral message with a status update.
+func (s *apiServer) respondToInteraction(responseURL, text string) {
+	if responseURL == "" {
+		return
+	}
+	body, _ := json.Marshal(map[string]any{
+		"replace_original": true,
+		"text":             text,
+	})
+	resp, err := http.Post(responseURL, "application/json", bytes.NewReader(body))
+	if err != nil {
+		s.log.Error("interaction: failed to respond", "error", err)
+		return
+	}
+	resp.Body.Close()
+}

--- a/core/app/handlers_slack_interactions_test.go
+++ b/core/app/handlers_slack_interactions_test.go
@@ -1,0 +1,273 @@
+package app
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strconv"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/store/mem"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+func newInteractionTestServer() *apiServer {
+	srv := &apiServer{
+		log:                slog.Default(),
+		drafts:             mem.NewDraftStore(),
+		feedback:           mem.NewDraftFeedbackStore(),
+		connectedAccounts:  mem.NewConnectedAccountStore(),
+		vault:              vault.NewMemVault(),
+		slackSigningSecret: testSigningSecret,
+		users:              &stubUserStore{},
+		newID:              func() string { return "test-id" },
+	}
+	srv.slackSender = func(_ context.Context, _, _, _ string) error { return nil }
+	return srv
+}
+
+func signedInteractionRequest(payloadJSON string) (*http.Request, string) {
+	formData := url.Values{"payload": {payloadJSON}}.Encode()
+	body := []byte(formData)
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	baseString := fmt.Sprintf("v0:%s:%s", ts, string(body))
+	mac := hmac.New(sha256.New, []byte(testSigningSecret))
+	mac.Write([]byte(baseString))
+	sig := "v0=" + hex.EncodeToString(mac.Sum(nil))
+
+	r := httptest.NewRequest("POST", "/v1/webhooks/slack/interactions",
+		strings.NewReader(formData))
+	r.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	r.Header.Set("X-Slack-Request-Timestamp", ts)
+	r.Header.Set("X-Slack-Signature", sig)
+	return r, ts
+}
+
+func TestInteraction_ApproveDraft(t *testing.T) {
+	srv := newInteractionTestServer()
+	ctx := context.Background()
+
+	// Seed a pending draft.
+	srv.drafts.Create(ctx, model.Draft{
+		ID:          "dft_1",
+		UserID:      "usr_a",
+		Status:      model.DraftStatusPending,
+		Service:     "slack",
+		Channel:     "C0BACKEND",
+		Author:      "Sarah",
+		DraftBody:   "No, the claims stay the same.",
+	})
+
+	// Seed connected account + vault token for sending.
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive,
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack",
+		[]byte(`{"access_token":"xoxp-test","bot_access_token":"xoxb-test"}`), vault.Metadata{})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U123"},
+		"actions": []map[string]any{
+			{"action_id": "approve_draft", "value": "dft_1"},
+		},
+		"response_url": "",
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Wait for async processing.
+	time.Sleep(50 * time.Millisecond)
+
+	draft, _ := srv.drafts.Get(ctx, "dft_1")
+	if draft.Status != model.DraftStatusApproved {
+		t.Errorf("expected approved, got %s", draft.Status)
+	}
+
+	fb, _ := srv.feedback.List(ctx, store.DraftFeedbackFilter{UserID: "usr_a"})
+	if len(fb) != 1 || fb[0].Signal != model.FeedbackSignalApproved {
+		t.Error("expected approved feedback signal")
+	}
+}
+
+func TestInteraction_DiscardDraft(t *testing.T) {
+	srv := newInteractionTestServer()
+	ctx := context.Background()
+
+	srv.drafts.Create(ctx, model.Draft{
+		ID: "dft_1", UserID: "usr_a", Status: model.DraftStatusPending,
+		DraftBody: "draft text",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type":    "block_actions",
+		"user":    map[string]any{"id": "U123"},
+		"actions": []map[string]any{{"action_id": "discard_draft", "value": "dft_1"}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	time.Sleep(50 * time.Millisecond)
+
+	draft, _ := srv.drafts.Get(ctx, "dft_1")
+	if draft.Status != model.DraftStatusDiscarded {
+		t.Errorf("expected discarded, got %s", draft.Status)
+	}
+}
+
+func TestInteraction_InvalidSignature(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	r := httptest.NewRequest("POST", "/v1/webhooks/slack/interactions",
+		strings.NewReader("payload={}"))
+	r.Header.Set("X-Slack-Request-Timestamp", strconv.FormatInt(time.Now().Unix(), 10))
+	r.Header.Set("X-Slack-Signature", "v0=invalid")
+
+	w := httptest.NewRecorder()
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestInteraction_MethodNotAllowed(t *testing.T) {
+	srv := newInteractionTestServer()
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest("GET", "/v1/webhooks/slack/interactions", nil)
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusMethodNotAllowed {
+		t.Fatalf("expected 405, got %d", w.Code)
+	}
+}
+
+func TestInteraction_MissingPayload(t *testing.T) {
+	srv := newInteractionTestServer()
+	body := []byte("other=data")
+	ts := strconv.FormatInt(time.Now().Unix(), 10)
+	baseString := fmt.Sprintf("v0:%s:%s", ts, string(body))
+	mac := hmac.New(sha256.New, []byte(testSigningSecret))
+	mac.Write([]byte(baseString))
+	sig := "v0=" + hex.EncodeToString(mac.Sum(nil))
+
+	r := httptest.NewRequest("POST", "/v1/webhooks/slack/interactions",
+		strings.NewReader(string(body)))
+	r.Header.Set("X-Slack-Request-Timestamp", ts)
+	r.Header.Set("X-Slack-Signature", sig)
+
+	w := httptest.NewRecorder()
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestInteraction_NonBlockActions(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "view_submission",
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 for non-block_actions, got %d", w.Code)
+	}
+}
+
+func TestInteraction_DraftNotFound(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	payload, _ := json.Marshal(map[string]any{
+		"type":    "block_actions",
+		"user":    map[string]any{"id": "U123"},
+		"actions": []map[string]any{{"action_id": "approve_draft", "value": "nonexistent"}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	// Should still return 200 (Slack requires it).
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestInteraction_AlreadyActioned(t *testing.T) {
+	srv := newInteractionTestServer()
+	ctx := context.Background()
+
+	srv.drafts.Create(ctx, model.Draft{
+		ID: "dft_1", UserID: "usr_a", Status: model.DraftStatusApproved,
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type":    "block_actions",
+		"user":    map[string]any{"id": "U123"},
+		"actions": []map[string]any{{"action_id": "approve_draft", "value": "dft_1"}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	time.Sleep(50 * time.Millisecond)
+	// Draft status should remain approved, not re-processed.
+	draft, _ := srv.drafts.Get(ctx, "dft_1")
+	if draft.Status != model.DraftStatusApproved {
+		t.Errorf("expected status unchanged, got %s", draft.Status)
+	}
+}
+
+func TestInteraction_EditDraft(t *testing.T) {
+	srv := newInteractionTestServer()
+	ctx := context.Background()
+
+	srv.drafts.Create(ctx, model.Draft{
+		ID: "dft_1", UserID: "usr_a", Status: model.DraftStatusPending,
+		DraftBody: "Draft text for editing",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type":    "block_actions",
+		"user":    map[string]any{"id": "U123"},
+		"actions": []map[string]any{{"action_id": "edit_draft", "value": "dft_1"}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	// Edit just shows the text — draft stays pending for now.
+	time.Sleep(50 * time.Millisecond)
+	draft, _ := srv.drafts.Get(ctx, "dft_1")
+	if draft.Status != model.DraftStatusPending {
+		t.Errorf("expected pending (edit shows text), got %s", draft.Status)
+	}
+}

--- a/core/app/handlers_slack_interactions_test.go
+++ b/core/app/handlers_slack_interactions_test.go
@@ -54,9 +54,18 @@ func signedInteractionRequest(payloadJSON string) (*http.Request, string) {
 	return r, ts
 }
 
+func newMockResponseURLServer() *httptest.Server {
+	return httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	}))
+}
+
 func TestInteraction_ApproveDraft(t *testing.T) {
 	srv := newInteractionTestServer()
 	ctx := context.Background()
+
+	responseServer := newMockResponseURLServer()
+	defer responseServer.Close()
 
 	// Seed a pending draft.
 	srv.drafts.Create(ctx, model.Draft{
@@ -83,7 +92,7 @@ func TestInteraction_ApproveDraft(t *testing.T) {
 		"actions": []map[string]any{
 			{"action_id": "approve_draft", "value": "dft_1"},
 		},
-		"response_url": "",
+		"response_url": responseServer.URL,
 	})
 
 	w := httptest.NewRecorder()
@@ -112,15 +121,19 @@ func TestInteraction_DiscardDraft(t *testing.T) {
 	srv := newInteractionTestServer()
 	ctx := context.Background()
 
+	responseServer := newMockResponseURLServer()
+	defer responseServer.Close()
+
 	srv.drafts.Create(ctx, model.Draft{
 		ID: "dft_1", UserID: "usr_a", Status: model.DraftStatusPending,
 		DraftBody: "draft text",
 	})
 
 	payload, _ := json.Marshal(map[string]any{
-		"type":    "block_actions",
-		"user":    map[string]any{"id": "U123"},
-		"actions": []map[string]any{{"action_id": "discard_draft", "value": "dft_1"}},
+		"type":         "block_actions",
+		"user":         map[string]any{"id": "U123"},
+		"actions":      []map[string]any{{"action_id": "discard_draft", "value": "dft_1"}},
+		"response_url": responseServer.URL,
 	})
 
 	w := httptest.NewRecorder()
@@ -245,9 +258,18 @@ func TestInteraction_AlreadyActioned(t *testing.T) {
 	}
 }
 
+func TestInteraction_RespondToInteraction_EmptyURL(t *testing.T) {
+	srv := newInteractionTestServer()
+	// Should not panic with empty response URL.
+	srv.respondToInteraction("", "test message")
+}
+
 func TestInteraction_EditDraft(t *testing.T) {
 	srv := newInteractionTestServer()
 	ctx := context.Background()
+
+	responseServer := newMockResponseURLServer()
+	defer responseServer.Close()
 
 	srv.drafts.Create(ctx, model.Draft{
 		ID: "dft_1", UserID: "usr_a", Status: model.DraftStatusPending,
@@ -255,9 +277,10 @@ func TestInteraction_EditDraft(t *testing.T) {
 	})
 
 	payload, _ := json.Marshal(map[string]any{
-		"type":    "block_actions",
-		"user":    map[string]any{"id": "U123"},
-		"actions": []map[string]any{{"action_id": "edit_draft", "value": "dft_1"}},
+		"type":         "block_actions",
+		"user":         map[string]any{"id": "U123"},
+		"actions":      []map[string]any{{"action_id": "edit_draft", "value": "dft_1"}},
+		"response_url": responseServer.URL,
 	})
 
 	w := httptest.NewRecorder()

--- a/core/comms/slack_ephemeral.go
+++ b/core/comms/slack_ephemeral.go
@@ -1,0 +1,61 @@
+package comms
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/slack-go/slack"
+)
+
+// SlackDraftMessage contains the data needed to post an ephemeral draft
+// preview to a user in a Slack channel.
+type SlackDraftMessage struct {
+	BotToken string // bot token for posting ephemeral messages
+	Channel  string // channel where the original message was
+	UserID   string // Slack user ID to show the ephemeral message to
+	DraftID  string // Aileron draft ID for button callback data
+	Author   string // who sent the original message
+	Body     string // the original message text
+	Draft    string // the AI-generated draft reply
+}
+
+// PostEphemeralDraft posts an ephemeral message with the draft and
+// approve/edit/discard buttons. Only the target user sees it.
+func PostEphemeralDraft(ctx context.Context, msg SlackDraftMessage) error {
+	if msg.BotToken == "" {
+		return fmt.Errorf("slack: bot token is required for ephemeral messages")
+	}
+
+	client := slack.New(msg.BotToken)
+
+	// Truncate draft for preview if very long.
+	draftPreview := msg.Draft
+	if len(draftPreview) > 500 {
+		draftPreview = draftPreview[:497] + "..."
+	}
+
+	blocks := []slack.Block{
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject("mrkdwn",
+				fmt.Sprintf("*Draft reply to %s:*\n\n%s", msg.Author, draftPreview),
+				false, false),
+			nil, nil,
+		),
+		slack.NewActionBlock("draft_actions",
+			slack.NewButtonBlockElement("approve_draft", msg.DraftID,
+				slack.NewTextBlockObject("plain_text", "Approve", false, false),
+			).WithStyle(slack.StylePrimary),
+			slack.NewButtonBlockElement("edit_draft", msg.DraftID,
+				slack.NewTextBlockObject("plain_text", "Edit", false, false),
+			),
+			slack.NewButtonBlockElement("discard_draft", msg.DraftID,
+				slack.NewTextBlockObject("plain_text", "Discard", false, false),
+			).WithStyle(slack.StyleDanger),
+		),
+	}
+
+	_, err := client.PostEphemeralContext(ctx, msg.Channel, msg.UserID,
+		slack.MsgOptionBlocks(blocks...),
+	)
+	return err
+}

--- a/core/comms/slack_ephemeral.go
+++ b/core/comms/slack_ephemeral.go
@@ -25,16 +25,31 @@ func PostEphemeralDraft(ctx context.Context, msg SlackDraftMessage) error {
 	if msg.BotToken == "" {
 		return fmt.Errorf("slack: bot token is required for ephemeral messages")
 	}
+	if msg.Channel == "" {
+		return fmt.Errorf("slack: channel is required")
+	}
+	if msg.UserID == "" {
+		return fmt.Errorf("slack: user ID is required")
+	}
 
 	client := slack.New(msg.BotToken)
+	blocks := BuildDraftBlocks(msg)
 
-	// Truncate draft for preview if very long.
+	_, err := client.PostEphemeralContext(ctx, msg.Channel, msg.UserID,
+		slack.MsgOptionBlocks(blocks...),
+	)
+	return err
+}
+
+// BuildDraftBlocks constructs the Block Kit layout for a draft ephemeral
+// message. Exported for testing.
+func BuildDraftBlocks(msg SlackDraftMessage) []slack.Block {
 	draftPreview := msg.Draft
 	if len(draftPreview) > 500 {
 		draftPreview = draftPreview[:497] + "..."
 	}
 
-	blocks := []slack.Block{
+	return []slack.Block{
 		slack.NewSectionBlock(
 			slack.NewTextBlockObject("mrkdwn",
 				fmt.Sprintf("*Draft reply to %s:*\n\n%s", msg.Author, draftPreview),
@@ -53,9 +68,4 @@ func PostEphemeralDraft(ctx context.Context, msg SlackDraftMessage) error {
 			).WithStyle(slack.StyleDanger),
 		),
 	}
-
-	_, err := client.PostEphemeralContext(ctx, msg.Channel, msg.UserID,
-		slack.MsgOptionBlocks(blocks...),
-	)
-	return err
 }

--- a/core/comms/slack_ephemeral_test.go
+++ b/core/comms/slack_ephemeral_test.go
@@ -2,6 +2,7 @@ package comms_test
 
 import (
 	"context"
+	"strings"
 	"testing"
 
 	"github.com/ALRubinger/aileron/core/comms"
@@ -17,5 +18,65 @@ func TestPostEphemeralDraft_EmptyBotToken(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for empty bot token")
+	}
+}
+
+func TestPostEphemeralDraft_EmptyChannel(t *testing.T) {
+	err := comms.PostEphemeralDraft(context.Background(), comms.SlackDraftMessage{
+		BotToken: "xoxb-test",
+		Channel:  "",
+		UserID:   "U123",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty channel")
+	}
+}
+
+func TestPostEphemeralDraft_EmptyUserID(t *testing.T) {
+	err := comms.PostEphemeralDraft(context.Background(), comms.SlackDraftMessage{
+		BotToken: "xoxb-test",
+		Channel:  "C123",
+		UserID:   "",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+}
+
+func TestBuildDraftBlocks_Basic(t *testing.T) {
+	blocks := comms.BuildDraftBlocks(comms.SlackDraftMessage{
+		Author:  "Sarah",
+		DraftID: "dft_123",
+		Draft:   "No, the claims stay the same.",
+	})
+
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks (section + actions), got %d", len(blocks))
+	}
+}
+
+func TestBuildDraftBlocks_LongDraftTruncated(t *testing.T) {
+	longDraft := strings.Repeat("x", 600)
+	blocks := comms.BuildDraftBlocks(comms.SlackDraftMessage{
+		Author:  "Sarah",
+		DraftID: "dft_123",
+		Draft:   longDraft,
+	})
+
+	// Should still produce valid blocks without error.
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks, got %d", len(blocks))
+	}
+}
+
+func TestBuildDraftBlocks_EmptyDraft(t *testing.T) {
+	blocks := comms.BuildDraftBlocks(comms.SlackDraftMessage{
+		Author:  "Sarah",
+		DraftID: "dft_123",
+		Draft:   "",
+	})
+
+	if len(blocks) != 2 {
+		t.Fatalf("expected 2 blocks even with empty draft, got %d", len(blocks))
 	}
 }

--- a/core/comms/slack_ephemeral_test.go
+++ b/core/comms/slack_ephemeral_test.go
@@ -1,0 +1,21 @@
+package comms_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/comms"
+)
+
+func TestPostEphemeralDraft_EmptyBotToken(t *testing.T) {
+	err := comms.PostEphemeralDraft(context.Background(), comms.SlackDraftMessage{
+		BotToken: "",
+		Channel:  "C123",
+		UserID:   "U123",
+		DraftID:  "dft_1",
+		Draft:    "test draft",
+	})
+	if err == nil {
+		t.Fatal("expected error for empty bot token")
+	}
+}


### PR DESCRIPTION
## Summary

Slack-native draft review UX. When a draft is generated, Aileron posts an ephemeral Block Kit message in the channel — visible only to the user — with the draft text and interactive buttons.

```
┌──────────────────────────────────────────────┐
│ Draft reply to Sarah:                         │
│                                              │
│ "No, the claims stay the same. PR #247 only  │
│ moves validation into middleware."            │
│                                              │
│ [Approve]  [Edit]  [Discard]                 │
└──────────────────────────────────────────────┘
```

### What's new

- **Bot token capture** — Slack OAuth now stores both user token (for sending replies as the user) and bot token (for posting ephemeral messages)
- **Bot scope** — `chat:write` bot scope added to OAuth URL
- **Ephemeral delivery** — `PostEphemeralDraft` utility with Block Kit layout (draft text + 3 action buttons)
- **Interaction webhook** — `POST /v1/webhooks/slack/interactions` handles button clicks with signature verification
- **Approve** — sends reply via user token, records approved feedback, replaces ephemeral with "Sent."
- **Discard** — records discarded feedback, replaces ephemeral with "Draft discarded."
- **Edit** — shows draft text for manual editing (Slack modal for inline editing is a follow-up)

### The bot tradeoff

The bot is present in channels (required for `chat.postEphemeral`) but **silent** — it never posts visible messages. Replies come from the user's identity. Teammates see the bot in the member list but never see it speak.

### Slack app config required

After merging, the Slack app needs:
1. Add **Bot Token Scope**: `chat:write`
2. Enable **Interactivity & Shortcuts** with Request URL: `https://api.withaileron.ai/v1/webhooks/slack/interactions`
3. Reinstall the app to the workspace

## Test plan

- [x] Interaction handler: approve, discard, edit, invalid signature, method not allowed, missing payload, non-block_actions, draft not found, already actioned
- [x] All existing tests pass
- [ ] E2E: message → draft → ephemeral appears → click Approve → reply posted as user (staging)

Refs: #132

🤖 Generated with [Claude Code](https://claude.com/claude-code)