### PR TITLE
chore: trim whitespace on env vars and add signature debug logging

### DIFF
--- a/core/app/handlers_slack_webhook.go
+++ b/core/app/handlers_slack_webhook.go
@@ -179,21 +179,30 @@ func (s *apiServer) processSlackEvent(payload slackWebhookPayload) {
 // verifySlackSignature validates the HMAC-SHA256 signature from Slack.
 func (s *apiServer) verifySlackSignature(r *http.Request, body []byte) bool {
 	if s.slackSigningSecret == "" {
+		s.log.Debug("slack signature: no signing secret configured")
 		return false
 	}
 
 	timestamp := r.Header.Get("X-Slack-Request-Timestamp")
 	signature := r.Header.Get("X-Slack-Signature")
 	if timestamp == "" || signature == "" {
+		s.log.Debug("slack signature: missing headers",
+			"has_timestamp", timestamp != "",
+			"has_signature", signature != "")
 		return false
 	}
 
 	// Reject stale timestamps (>5 minutes) to prevent replay attacks.
 	ts, err := strconv.ParseInt(timestamp, 10, 64)
 	if err != nil {
+		s.log.Debug("slack signature: invalid timestamp", "timestamp", timestamp)
 		return false
 	}
-	if math.Abs(float64(time.Now().Unix()-ts)) > 300 {
+	age := time.Now().Unix() - ts
+	if math.Abs(float64(age)) > 300 {
+		s.log.Debug("slack signature: stale timestamp",
+			"timestamp", timestamp,
+			"age_seconds", age)
 		return false
 	}
 
@@ -203,6 +212,15 @@ func (s *apiServer) verifySlackSignature(r *http.Request, body []byte) bool {
 	mac.Write([]byte(baseString))
 	expected := "v0=" + hex.EncodeToString(mac.Sum(nil))
 
-	return hmac.Equal([]byte(expected), []byte(signature))
+	if !hmac.Equal([]byte(expected), []byte(signature)) {
+		s.log.Debug("slack signature: mismatch",
+			"expected_prefix", expected[:20],
+			"received_prefix", signature[:min(len(signature), 20)],
+			"body_length", len(body),
+			"secret_length", len(s.slackSigningSecret))
+		return false
+	}
+
+	return true
 }
 

--- a/core/config/auth.go
+++ b/core/config/auth.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"os"
+	"strings"
 	"time"
 )
 
@@ -71,21 +72,21 @@ type AuthConfig struct {
 // enabled (indicated by AILERON_DATABASE_URL being set).
 func LoadAuthConfig() (*AuthConfig, error) {
 	cfg := &AuthConfig{
-		DatabaseURL:        os.Getenv("AILERON_DATABASE_URL"),
-		JWTSigningKey:      os.Getenv("AILERON_JWT_SIGNING_KEY"),
+		DatabaseURL:        envTrimmed("AILERON_DATABASE_URL"),
+		JWTSigningKey:      envTrimmed("AILERON_JWT_SIGNING_KEY"),
 		JWTIssuer:          envOrDefault("AILERON_JWT_ISSUER", "aileron"),
 		UIRedirectURL:      envOrDefault("AILERON_UI_REDIRECT_URL", "/"),
-		AutoVerifyEmail:    os.Getenv("AILERON_AUTO_VERIFY_EMAIL") == "true",
-		GoogleClientID:       os.Getenv("GOOGLE_CLIENT_ID"),
-		GoogleClientSecret:   os.Getenv("GOOGLE_CLIENT_SECRET"),
-		GitHubClientID:     os.Getenv("GITHUB_OAUTH_CLIENT_ID"),
-		GitHubClientSecret: os.Getenv("GITHUB_OAUTH_CLIENT_SECRET"),
-		SlackClientID:      os.Getenv("SLACK_CLIENT_ID"),
-		SlackClientSecret:  os.Getenv("SLACK_CLIENT_SECRET"),
-		SlackSigningSecret: os.Getenv("SLACK_SIGNING_SECRET"),
-		ResendAPIKey:       os.Getenv("RESEND_API_KEY"),
+		AutoVerifyEmail:    envTrimmed("AILERON_AUTO_VERIFY_EMAIL") == "true",
+		GoogleClientID:       envTrimmed("GOOGLE_CLIENT_ID"),
+		GoogleClientSecret:   envTrimmed("GOOGLE_CLIENT_SECRET"),
+		GitHubClientID:     envTrimmed("GITHUB_OAUTH_CLIENT_ID"),
+		GitHubClientSecret: envTrimmed("GITHUB_OAUTH_CLIENT_SECRET"),
+		SlackClientID:      envTrimmed("SLACK_CLIENT_ID"),
+		SlackClientSecret:  envTrimmed("SLACK_CLIENT_SECRET"),
+		SlackSigningSecret: envTrimmed("SLACK_SIGNING_SECRET"),
+		ResendAPIKey:       envTrimmed("RESEND_API_KEY"),
 		MailFrom:           envOrDefault("MAIL_FROM", "noreply@withaileron.ai"),
-		AnthropicAPIKey:    os.Getenv("ANTHROPIC_API_KEY"),
+		AnthropicAPIKey:    envTrimmed("ANTHROPIC_API_KEY"),
 		LLMModel:           envOrDefault("AILERON_LLM_MODEL", "claude-sonnet-4-6"),
 	}
 
@@ -170,15 +171,22 @@ func (c *AuthConfig) EscrowTTL() time.Duration {
 	return d
 }
 
+// envTrimmed reads an environment variable and trims leading/trailing
+// whitespace. Prevents copy-paste errors in web UIs (Railway, Docker)
+// where invisible trailing spaces cause cryptic failures.
+func envTrimmed(key string) string {
+	return strings.TrimSpace(os.Getenv(key))
+}
+
 func envOrDefault(key, def string) string {
-	if v := os.Getenv(key); v != "" {
+	if v := envTrimmed(key); v != "" {
 		return v
 	}
 	return def
 }
 
 func parseDurationOrDefault(envKey string, def time.Duration) (time.Duration, error) {
-	v := os.Getenv(envKey)
+	v := envTrimmed(envKey)
 	if v == "" {
 		return def, nil
 	}

--- a/core/config/auth_test.go
+++ b/core/config/auth_test.go
@@ -335,6 +335,72 @@ func TestLoadAuthConfig_LLMModelDefault(t *testing.T) {
 	}
 }
 
+func TestLoadAuthConfig_TrimsWhitespace(t *testing.T) {
+	t.Setenv("AILERON_DATABASE_URL", "")
+	t.Setenv("SLACK_CLIENT_ID", "  slack-id  ")
+	t.Setenv("SLACK_CLIENT_SECRET", "slack-secret\n")
+	t.Setenv("SLACK_SIGNING_SECRET", "\tsigning-secret ")
+	t.Setenv("ANTHROPIC_API_KEY", " sk-ant-key ")
+	t.Setenv("GOOGLE_CLIENT_ID", "google-id\t")
+	t.Setenv("GITHUB_OAUTH_CLIENT_ID", " github-id")
+
+	cfg, err := LoadAuthConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.SlackClientID != "slack-id" {
+		t.Errorf("SlackClientID not trimmed: %q", cfg.SlackClientID)
+	}
+	if cfg.SlackClientSecret != "slack-secret" {
+		t.Errorf("SlackClientSecret not trimmed: %q", cfg.SlackClientSecret)
+	}
+	if cfg.SlackSigningSecret != "signing-secret" {
+		t.Errorf("SlackSigningSecret not trimmed: %q", cfg.SlackSigningSecret)
+	}
+	if cfg.AnthropicAPIKey != "sk-ant-key" {
+		t.Errorf("AnthropicAPIKey not trimmed: %q", cfg.AnthropicAPIKey)
+	}
+	if cfg.GoogleClientID != "google-id" {
+		t.Errorf("GoogleClientID not trimmed: %q", cfg.GoogleClientID)
+	}
+	if cfg.GitHubClientID != "github-id" {
+		t.Errorf("GitHubClientID not trimmed: %q", cfg.GitHubClientID)
+	}
+}
+
+func TestLoadAuthConfig_TrimsWhitespace_EnvOrDefault(t *testing.T) {
+	t.Setenv("AILERON_DATABASE_URL", "")
+	t.Setenv("AILERON_LLM_MODEL", " claude-haiku-4-5 ")
+	t.Setenv("MAIL_FROM", " custom@example.com\n")
+
+	cfg, err := LoadAuthConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.LLMModel != "claude-haiku-4-5" {
+		t.Errorf("LLMModel not trimmed: %q", cfg.LLMModel)
+	}
+	if cfg.MailFrom != "custom@example.com" {
+		t.Errorf("MailFrom not trimmed: %q", cfg.MailFrom)
+	}
+}
+
+func TestLoadAuthConfig_TrimsWhitespace_DatabaseURL(t *testing.T) {
+	t.Setenv("AILERON_DATABASE_URL", " postgres://localhost/test ")
+	t.Setenv("AILERON_JWT_SIGNING_KEY", " test-key ")
+
+	cfg, err := LoadAuthConfig()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if cfg.DatabaseURL != "postgres://localhost/test" {
+		t.Errorf("DatabaseURL not trimmed: %q", cfg.DatabaseURL)
+	}
+	if cfg.JWTSigningKey != "test-key" {
+		t.Errorf("JWTSigningKey not trimmed: %q", cfg.JWTSigningKey)
+	}
+}
+
 func TestLoadAuthConfig_MailFromDefault(t *testing.T) {
 	t.Setenv("AILERON_DATABASE_URL", "")
 	t.Setenv("MAIL_FROM", "")


### PR DESCRIPTION
## Summary

### Env var whitespace trimming

Add `envTrimmed()` helper that strips leading/trailing whitespace from all environment variables in `LoadAuthConfig()`. Prevents a class of copy-paste bugs where invisible trailing spaces in web UIs (Railway, Docker) cause cryptic failures.

**Motivated by a real incident:** A trailing space on `SLACK_SIGNING_SECRET` produced a 33-character secret instead of 32. The HMAC computation produced a different signature, returning "invalid signature" with no indication of the root cause. With trimming, this would have worked.

All `os.Getenv()` calls in `LoadAuthConfig()` now go through `envTrimmed()`. The `envOrDefault()` and `parseDurationOrDefault()` helpers also trim.

### Signature debug logging

Add debug-level logging to each step of Slack signature verification. Silent by default (debug level), enable when troubleshooting webhook issues. Logs: missing headers, stale timestamp, signature mismatch (with prefix and body/secret length — no full secrets logged).

## Test plan

- [x] Whitespace trimming: leading spaces, trailing spaces, tabs, newlines on Slack, Anthropic, Google, GitHub, database URL, JWT key, LLM model, mail from
- [x] envOrDefault trimming (LLM model, mail from)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)