### PR TITLE
fix: use X-Forwarded-Proto for OAuth redirect URL scheme

### DIFF
--- a/core/app/handlers_connected_accounts.go
+++ b/core/app/handlers_connected_accounts.go
@@ -104,11 +104,7 @@ func (s *apiServer) ConnectAccount(w http.ResponseWriter, r *http.Request, provi
 	provider := model.ConnectedAccountProvider(providerStr)
 	state := s.newID()
 
-	scheme := "https"
-	if r.TLS == nil {
-		scheme = "http"
-	}
-	redirectURL := scheme + "://" + r.Host + "/v1/connect/" + providerStr + "/callback"
+	redirectURL := requestScheme(r) + "://" + r.Host + "/v1/connect/" + providerStr + "/callback"
 
 	result, err := s.accountService.AuthorizationURL(r.Context(), provider, state, redirectURL)
 	if err != nil {
@@ -155,11 +151,7 @@ func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Reques
 
 	provider := model.ConnectedAccountProvider(providerStr)
 
-	scheme := "https"
-	if r.TLS == nil {
-		scheme = "http"
-	}
-	redirectURL := scheme + "://" + r.Host + "/v1/connect/" + providerStr + "/callback"
+	redirectURL := requestScheme(r) + "://" + r.Host + "/v1/connect/" + providerStr + "/callback"
 
 	// TEE mode: forward the OAuth code to the enclave. The enclave exchanges
 	// the code for tokens, encrypts them with the user's KEK, and returns
@@ -238,6 +230,20 @@ func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Reques
 	}
 
 	http.Redirect(w, r, "/settings", http.StatusFound)
+}
+
+// requestScheme returns "https" or "http" based on the request. It checks
+// X-Forwarded-Proto first (set by reverse proxies like Railway, Cloudflare)
+// then falls back to r.TLS. Defaults to "https" when behind a proxy that
+// terminates TLS — the Go server sees plain HTTP but the client used HTTPS.
+func requestScheme(r *http.Request) string {
+	if proto := r.Header.Get("X-Forwarded-Proto"); proto != "" {
+		return proto
+	}
+	if r.TLS != nil {
+		return "https"
+	}
+	return "http"
 }
 
 func connectedAccountToAPI(a model.ConnectedAccount) api.ConnectedAccount {

--- a/core/app/handlers_connected_accounts_test.go
+++ b/core/app/handlers_connected_accounts_test.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"context"
+	"crypto/tls"
 	"encoding/json"
 	"log/slog"
 	"net/http"
@@ -346,6 +347,83 @@ func TestListConnectedAccounts_Unauthorized(t *testing.T) {
 
 	if w.Code != http.StatusUnauthorized {
 		t.Fatalf("expected 401, got %d", w.Code)
+	}
+}
+
+func TestRequestScheme_XForwardedProto(t *testing.T) {
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("X-Forwarded-Proto", "https")
+
+	if got := requestScheme(r); got != "https" {
+		t.Errorf("expected https from X-Forwarded-Proto, got %s", got)
+	}
+}
+
+func TestRequestScheme_XForwardedProtoHTTP(t *testing.T) {
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.Header.Set("X-Forwarded-Proto", "http")
+
+	if got := requestScheme(r); got != "http" {
+		t.Errorf("expected http from X-Forwarded-Proto, got %s", got)
+	}
+}
+
+func TestRequestScheme_TLSDirect(t *testing.T) {
+	r := httptest.NewRequest("GET", "/test", nil)
+	r.TLS = &tls.ConnectionState{} // simulate direct TLS connection
+	if got := requestScheme(r); got != "https" {
+		t.Errorf("expected https from TLS, got %s", got)
+	}
+}
+
+func TestRequestScheme_NoHeader_NoTLS(t *testing.T) {
+	r := httptest.NewRequest("GET", "/test", nil)
+	// No X-Forwarded-Proto, no TLS → http
+	if got := requestScheme(r); got != "http" {
+		t.Errorf("expected http without proxy or TLS, got %s", got)
+	}
+}
+
+func TestConnectAccount_RedirectURL_UsesHTTPS_BehindProxy(t *testing.T) {
+	srv := newConnectedAccountServer()
+	reg := account.NewRegistry()
+	reg.Register(account.NewGoogleService("test-client-id", "secret", srv.connectedAccounts, srv.vault))
+	srv.accountService = reg
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/connect/gmail", "", nil)
+	// Simulate reverse proxy (Railway, Cloudflare) setting X-Forwarded-Proto.
+	r.Header.Set("X-Forwarded-Proto", "https")
+	srv.ConnectAccount(w, r, "gmail")
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	// The redirect_uri parameter in the OAuth URL should be https://.
+	if !containsStr(loc, "redirect_uri=https") {
+		t.Errorf("expected https redirect_uri behind proxy, got: %s", loc)
+	}
+}
+
+func TestConnectAccount_RedirectURL_HTTP_WithoutProxy(t *testing.T) {
+	srv := newConnectedAccountServer()
+	reg := account.NewRegistry()
+	reg.Register(account.NewGoogleService("test-client-id", "secret", srv.connectedAccounts, srv.vault))
+	srv.accountService = reg
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/connect/gmail", "", nil)
+	// No X-Forwarded-Proto, no TLS → http (local dev).
+	srv.ConnectAccount(w, r, "gmail")
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d", w.Code)
+	}
+	loc := w.Header().Get("Location")
+	// Without a proxy, redirect_uri should be http:// (local dev).
+	if !containsStr(loc, "redirect_uri=http") {
+		t.Errorf("expected http redirect_uri without proxy, got: %s", loc)
 	}
 }
 


### PR DESCRIPTION
## Summary

OAuth redirect URL was generated as `http://` instead of `https://` because Railway terminates TLS at the edge proxy. `r.TLS` is nil on the Go server even though the client used HTTPS. This caused Slack OAuth to reject the redirect URL: "redirect_uri did not match any configured URIs."

Fix: check `X-Forwarded-Proto` header (set by Railway/Cloudflare) first, fall back to `r.TLS`. Standard pattern for apps behind reverse proxies.

Found during manual testing of #131 runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)