### PR TITLE
fix: skip empty email in connectedAccountToAPI to prevent silent JSON failure

### DIFF
--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -74,9 +74,18 @@ type apiServer struct {
 // --- JSON helpers ---
 
 func writeJSON(w http.ResponseWriter, status int, v any) {
+	data, err := json.Marshal(v)
+	if err != nil {
+		// Log to stderr since we don't have the logger here.
+		// This should never happen with well-formed data — if it does,
+		// it's a bug (e.g. a type with a broken MarshalJSON).
+		slog.Error("writeJSON: marshal failed", "error", err)
+		http.Error(w, `{"error":{"code":"internal_error","message":"response serialization failed"}}`, http.StatusInternalServerError)
+		return
+	}
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
-	json.NewEncoder(w).Encode(v)
+	w.Write(data)
 }
 
 func writeError(w http.ResponseWriter, status int, code, message string) {

--- a/core/app/handlers_connected_accounts.go
+++ b/core/app/handlers_connected_accounts.go
@@ -249,17 +249,23 @@ func requestScheme(r *http.Request) string {
 func connectedAccountToAPI(a model.ConnectedAccount) api.ConnectedAccount {
 	provider := api.ConnectedAccountProvider(a.Provider)
 	status := api.ConnectedAccountStatus(a.Status)
-	email := openapi_types.Email(a.Email)
 	createdAt := a.CreatedAt
 	updatedAt := a.UpdatedAt
-	return api.ConnectedAccount{
+	result := api.ConnectedAccount{
 		Id:        &a.ID,
 		UserId:    &a.UserID,
 		Provider:  &provider,
-		Email:     &email,
 		Scopes:    &a.Scopes,
 		Status:    &status,
 		CreatedAt: &createdAt,
 		UpdatedAt: &updatedAt,
 	}
+	// Only set Email when non-empty — openapi_types.Email validates via
+	// regex on marshal and rejects empty strings, which causes silent
+	// JSON encoding failures (200 with empty body).
+	if a.Email != "" {
+		email := openapi_types.Email(a.Email)
+		result.Email = &email
+	}
+	return result
 }

--- a/core/app/handlers_connected_accounts_test.go
+++ b/core/app/handlers_connected_accounts_test.go
@@ -241,6 +241,78 @@ func TestDeleteConnectedAccount_Unauthorized(t *testing.T) {
 	}
 }
 
+func TestWriteJSON_MarshalError(t *testing.T) {
+	w := httptest.NewRecorder()
+	// A channel cannot be JSON-marshaled — triggers the error path.
+	writeJSON(w, http.StatusOK, map[string]any{"bad": make(chan int)})
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500 on marshal failure, got %d", w.Code)
+	}
+	if w.Body.Len() == 0 {
+		t.Fatal("expected error body, got empty")
+	}
+}
+
+func TestWriteJSON_Success(t *testing.T) {
+	w := httptest.NewRecorder()
+	writeJSON(w, http.StatusOK, map[string]any{"items": []string{}})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if w.Body.Len() == 0 {
+		t.Fatal("expected non-empty body")
+	}
+}
+
+func TestListConnectedAccounts_SlackWithEmptyEmail(t *testing.T) {
+	srv := newConnectedAccountServerWithAuth()
+	ctx := context.Background()
+
+	// Slack accounts have no email — this previously caused a silent
+	// JSON marshal failure (200 with empty body) because
+	// openapi_types.Email rejects empty strings in MarshalJSON.
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:             "conn_slack",
+		UserID:         "usr_a",
+		Provider:       model.ConnectedAccountProviderSlack,
+		Email:          "", // empty — Slack OAuth doesn't return email
+		Scopes:         []string{"channels:history"},
+		Status:         model.ConnectedAccountStatusActive,
+		ExternalUserID: "U123",
+		ExternalTeamID: "T001",
+	})
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/connected-accounts", "", userAClaims)
+	srv.ListConnectedAccounts(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	if w.Body.Len() == 0 {
+		t.Fatal("expected non-empty response body (was previously 0 bytes due to Email marshal failure)")
+	}
+
+	var resp struct {
+		Items []api.ConnectedAccount `json:"items"`
+	}
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if len(resp.Items) != 1 {
+		t.Fatalf("expected 1 account, got %d", len(resp.Items))
+	}
+	if *resp.Items[0].Id != "conn_slack" {
+		t.Errorf("expected conn_slack, got %s", *resp.Items[0].Id)
+	}
+	// Email should be nil (omitted), not an empty string.
+	if resp.Items[0].Email != nil {
+		t.Errorf("expected nil email for Slack account, got %v", resp.Items[0].Email)
+	}
+}
+
 func TestConnectAccount_RedirectsToGoogle(t *testing.T) {
 	srv := newConnectedAccountServer()
 	reg := account.NewRegistry()


### PR DESCRIPTION
## Summary

`openapi_types.Email` has a custom `MarshalJSON` that validates via regex. Empty strings fail validation, causing `json.Encode` to return an error silently after `WriteHeader(200)` — the client gets 200 with empty body.

Slack connected accounts have no email (Slack OAuth doesn't return it). Every `GET /v1/connected-accounts` request with a Slack account returned 200 with 0 bytes.

Fix: only set the `Email` field when non-empty. Also removes the debug logging from PR #147 (root cause found).

Found during manual testing of #131 runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)