### PR TITLE
fix(llm): correct Anthropic tool input_schema structure

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,6 +18,7 @@ Tests must be written against the **contract** of the code — the expected inpu
 - **Test the happy path completely.** Verify the feature produces correct results under normal conditions. If a test can't exercise the happy path due to a dependency (e.g. a hardcoded external URL), fix the dependency — add test hooks, mock endpoints, inject configuration — rather than asserting on the failure.
 - **Test exceptional conditions from the contract.** Every error code, validation rule, or edge case documented in the API spec or function signature should have a test. These are the contract's stated failure modes.
 - **Never assert on implementation accidents.** If a test passes because of how the code happens to be structured (e.g. "this fails because it tries to reach Google"), that's not a test — it's a mirror. It tells you nothing about whether the feature works and breaks when the implementation changes.
+- **Every bug fix must include a regression test.** When fixing a bug, first write a test that reproduces the failure — it should fail before the fix and pass after. This proves the fix works and prevents the bug from recurring. No fix is complete without a test that demonstrates the broken behavior.
 - **Tests must survive refactoring.** If the implementation changes but the contract stays the same, all tests should still pass. If they don't, the tests were coupled to internals, not behavior.
 
 # Commit Message Format

--- a/core/llm/anthropic.go
+++ b/core/llm/anthropic.go
@@ -46,7 +46,7 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 		maxRounds = defaultMaxToolRounds
 	}
 
-	tools := convertTools(req.Tools)
+	tools := ConvertTools(req.Tools)
 
 	messages := []anthropic.MessageParam{
 		anthropic.NewUserMessage(anthropic.NewTextBlock(req.UserMessage)),
@@ -159,8 +159,9 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 	return nil, fmt.Errorf("exceeded maximum tool rounds (%d)", maxRounds)
 }
 
-// convertTools converts source.ToolDefinition to Anthropic ToolParam format.
-func convertTools(tools []source.ToolDefinition) []anthropic.ToolUnionParam {
+// ConvertTools converts source.ToolDefinition to Anthropic ToolParam format.
+// Exported for testing schema structure.
+func ConvertTools(tools []source.ToolDefinition) []anthropic.ToolUnionParam {
 	if len(tools) == 0 {
 		return nil
 	}
@@ -182,12 +183,8 @@ func convertTools(tools []source.ToolDefinition) []anthropic.ToolUnionParam {
 		}
 
 		schema := anthropic.ToolInputSchemaParam{
-			Type: "object",
-			Properties: map[string]any{
-				"properties": properties,
-				"required":   required,
-				"type":       "object",
-			},
+			Properties: properties,
+			Required:   required,
 		}
 
 		result = append(result, anthropic.ToolUnionParam{

--- a/core/llm/anthropic_test.go
+++ b/core/llm/anthropic_test.go
@@ -69,6 +69,76 @@ func anthropicToolUseResponse(toolID, toolName string, input map[string]any) htt
 	}
 }
 
+func TestConvertTools_SchemaStructure(t *testing.T) {
+	// This test validates that the tool input_schema has the correct structure
+	// for the Anthropic API. Previously, properties were double-nested:
+	//   input_schema.properties = {"properties": {...}, "required": [...], "type": "object"}
+	// which Anthropic rejected with "JSON schema is invalid."
+	// The correct structure is:
+	//   input_schema.properties = {"channel": {"type": "string", ...}}
+	//   input_schema.required = ["channel"]
+
+	tools := llm.ConvertTools([]source.ToolDefinition{
+		{
+			Name:        "slack_channel_history",
+			Description: "Get channel messages",
+			Parameters: []source.ToolParam{
+				{Name: "channel", Type: "string", Description: "Channel ID", Required: true},
+				{Name: "limit", Type: "integer", Description: "Max results", Required: false},
+			},
+		},
+	})
+
+	if len(tools) != 1 {
+		t.Fatalf("expected 1 tool, got %d", len(tools))
+	}
+
+	// Marshal the tool to JSON and inspect the schema structure.
+	toolJSON, err := json.Marshal(tools[0])
+	if err != nil {
+		t.Fatalf("failed to marshal tool: %v", err)
+	}
+
+	var toolMap map[string]any
+	json.Unmarshal(toolJSON, &toolMap)
+
+	schema, ok := toolMap["input_schema"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected input_schema to be an object, got %T", toolMap["input_schema"])
+	}
+
+	// Properties should contain "channel" and "limit" directly — NOT a nested
+	// {"properties": ..., "type": "object"} wrapper.
+	props, ok := schema["properties"].(map[string]any)
+	if !ok {
+		t.Fatalf("expected properties to be an object, got %T", schema["properties"])
+	}
+
+	if _, hasChannel := props["channel"]; !hasChannel {
+		t.Error("expected 'channel' in properties")
+	}
+	if _, hasLimit := props["limit"]; !hasLimit {
+		t.Error("expected 'limit' in properties")
+	}
+
+	// Properties should NOT contain a nested "type" key — that was the bug.
+	if _, hasNestedType := props["type"]; hasNestedType {
+		t.Error("properties contains nested 'type' key — schema is double-nested (the bug)")
+	}
+	if _, hasNestedRequired := props["required"]; hasNestedRequired {
+		t.Error("properties contains nested 'required' key — schema is double-nested (the bug)")
+	}
+
+	// Required should be at the schema level, containing "channel".
+	required, ok := schema["required"].([]any)
+	if !ok {
+		t.Fatalf("expected required to be an array, got %T", schema["required"])
+	}
+	if len(required) != 1 || required[0] != "channel" {
+		t.Errorf("expected required=[channel], got %v", required)
+	}
+}
+
 func TestAnthropicClient_SimpleTextGeneration(t *testing.T) {
 	server := mockAnthropicServer(anthropicTextResponse("Hello, I'm Claude."))
 	defer server.Close()


### PR DESCRIPTION
## Summary

Tool definitions were rejected by the Anthropic API with "JSON schema is invalid." The `input_schema` was double-nested — properties were wrapped in `{"properties": ..., "required": ..., "type": "object"}` inside `ToolInputSchemaParam.Properties`, which already has its own `Required` and `Type` fields.

Fix: set `Properties` and `Required` directly on `ToolInputSchemaParam`.

Found during manual testing of #131 runbook — draft generation failed at Part 8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)