### PR TITLE
fix(slack): add search:read scope for message search

### DIFF
--- a/core/account/slack_service.go
+++ b/core/account/slack_service.go
@@ -29,6 +29,7 @@ var slackUserScopes = []string{
 	"channels:history",
 	"channels:read",
 	"chat:write",
+	"search:read",
 	"users:read",
 }
 

--- a/core/account/slack_service_test.go
+++ b/core/account/slack_service_test.go
@@ -62,6 +62,24 @@ func TestSlackService_ScopesFor(t *testing.T) {
 	}
 }
 
+func TestSlackService_ScopesIncludeSearchRead(t *testing.T) {
+	// slack_search_messages requires the search:read OAuth user scope.
+	// Without it, Slack returns a permissions error when the LLM tries
+	// to search message history during draft generation.
+	svc := account.NewSlackService("id", "secret", mem.NewConnectedAccountStore(), vault.NewMemVault())
+	scopes := svc.ScopesFor(model.ConnectedAccountProviderSlack)
+
+	found := false
+	for _, s := range scopes {
+		if s == "search:read" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("expected search:read in Slack user scopes — required by slack_search_messages tool")
+	}
+}
+
 func TestSlackService_AuthorizationURL(t *testing.T) {
 	svc := account.NewSlackService("test-client-id", "secret", mem.NewConnectedAccountStore(), vault.NewMemVault())
 	result, err := svc.AuthorizationURL(context.Background(), model.ConnectedAccountProviderSlack, "state123", "http://localhost/callback")


### PR DESCRIPTION
## Summary

Add `search:read` to Slack OAuth user scopes. The `slack_search_messages` tool requires this scope — without it, the LLM gets a permissions error when searching Slack history during draft generation.

After merge/deploy, existing Slack connections need to be re-authorized (disconnect + reconnect) to pick up the new scope.

Also update #131 runbook Part 1.2 to include `search:read`.

Found during manual testing of #131 runbook (Part 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)