### PR TITLE
fix(draft): output only sendable message text, no commentary

### DIFF
--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -19,18 +19,20 @@ import (
 	"github.com/ALRubinger/aileron/core/vault"
 )
 
-const systemPrompt = `You are an AI assistant that drafts reply messages on behalf of a user.
+const systemPrompt = `You draft reply messages on behalf of a user. Your output will be sent directly as a message in a communication channel (e.g. Slack) — the user will review it first but your output IS the message text.
 
-You will receive a message from someone in a communication channel (e.g. Slack).
-Your job is to draft a helpful, accurate reply that the user can review before sending.
+CRITICAL: Output ONLY the message text that would be sent. Nothing else. No commentary, no notes, no warnings, no explanations, no "Here's a draft:", no markdown headers, no "Note:" sections. The entire output must be something that could be pasted directly into a chat message and sent.
+
+Good output: "No, the JWT claims are unchanged. PR #247 only moves validation into middleware."
+Bad output: "Here's a draft reply:\n\nNo, the JWT claims are unchanged.\n\n⚠️ Note: I'm not certain about this."
 
 Guidelines:
 - Be direct and specific. Reference concrete details (PR numbers, file names, code, dates).
-- Match the formality of the channel and the message.
+- Match the formality and tone of the channel and the message.
 - If you have access to tools, use them to look up relevant context before drafting.
 - Keep replies concise unless the question requires a detailed explanation.
-- Do not make up information. If you don't have enough context, say so.
-- Write the reply text only — no preamble like "Here's a draft:" or metadata.`
+- If you don't have enough context to write a useful reply, write a short honest reply like "Not sure off the top of my head — let me check and get back to you."
+- Never include caveats, disclaimers, or meta-commentary about the draft itself.`
 
 // Pipeline orchestrates draft generation for incoming messages.
 type Pipeline struct {


### PR DESCRIPTION
## Summary

The LLM was including reasoning, caveats, warnings, and meta-commentary alongside the draft reply:

```
Yes, Aileron is connected! 🤖

⚠️ Note: I'm not fully certain of Aileron's current status...
```

The output is sent directly as a Slack message — it must be ONLY the message text. No notes, no disclaimers, no "Here's a draft:".

Rewrite system prompt to:
- State explicitly that output IS the message text
- Provide good/bad output examples
- Prohibit commentary, notes, warnings
- Handle low-context gracefully ("Not sure — let me check")

Found during manual testing of #131 runbook (Part 8).

🤖 Generated with [Claude Code](https://claude.com/claude-code)