### PR TITLE
feat: persist connected accounts, drafts, instructions, and feedback in Postgres

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 3%
+        threshold: 2%
         after_n_builds: 2
     patch: off
 
@@ -30,7 +30,6 @@ flags:
 
 ignore:
   - "core/api/gen/**"       # generated code (oapi-codegen) — DO NOT EDIT
-  - "core/store/postgres/**" # requires live PostgreSQL — covered by integration tests
   - "ui/**"                  # SvelteKit UI — needs its own test framework
   - "docs/**"                # documentation and ADRs
 

--- a/codecov.yml
+++ b/codecov.yml
@@ -7,7 +7,7 @@ coverage:
     project:
       default:
         target: auto
-        threshold: 2%
+        threshold: 3%
         after_n_builds: 2
     patch: off
 

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -190,6 +190,15 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		server.userKeyMaterials = userKeyMaterialStore
 		server.escrowTTL = authCfg.EscrowTTL()
 
+		// Switch to Postgres-backed stores now that the database is available.
+		pgConnectedAccountStore := postgres.NewConnectedAccountStore(db)
+		server.connectedAccounts = pgConnectedAccountStore
+		server.drafts = postgres.NewDraftStore(db)
+		pgInstructionStore := postgres.NewUserInstructionStore(db)
+		server.instructions = pgInstructionStore
+		server.feedback = postgres.NewDraftFeedbackStore(db)
+		log.Info("using Postgres-backed stores for connected accounts, drafts, instructions, and feedback")
+
 		tokenIssuer := auth.NewTokenIssuer(
 			[]byte(authCfg.JWTSigningKey),
 			authCfg.JWTIssuer,
@@ -210,7 +219,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			accountRegistry.Register(account.NewGoogleService(
 				authCfg.GoogleClientID,
 				authCfg.GoogleClientSecret,
-				connectedAccountStore,
+				pgConnectedAccountStore,
 				v,
 			))
 			sourceReg.Register(gmailsource.New())
@@ -222,7 +231,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			accountRegistry.Register(account.NewSlackService(
 				authCfg.SlackClientID,
 				authCfg.SlackClientSecret,
-				connectedAccountStore,
+				pgConnectedAccountStore,
 				v,
 			))
 			sourceReg.Register(slacksource.New())
@@ -236,7 +245,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		// LLM-powered draft generation pipeline.
 		if authCfg.LLMEnabled() {
 			llmClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModel)
-			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, connectedAccountStore, instructionStore, v, log)
+			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log)
 			log.Info("enabled cloud draft generation", "model", authCfg.LLMModel)
 		}
 
@@ -284,7 +293,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			accountRegistry.Register(account.NewGitHubAccountService(
 				authCfg.GitHubClientID,
 				authCfg.GitHubClientSecret,
-				connectedAccountStore,
+				pgConnectedAccountStore,
 				v,
 			))
 			sourceReg.Register(githubsource.New())

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -150,9 +150,14 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	mux.HandleFunc("DELETE /v1/instructions/", server.handleInstructionByID)
 
 	// Draft feedback API (context store envelope).
+	mux.HandleFunc("POST /v1/feedback", server.handleCreateFeedback)
 	mux.HandleFunc("GET /v1/feedback", server.handleListFeedback)
 
+	// Connected accounts — programmatic create (in addition to OAuth flow).
+	mux.HandleFunc("POST /v1/connected-accounts", server.handleCreateConnectedAccount)
+
 	// Draft lifecycle API.
+	mux.HandleFunc("POST /v1/drafts", server.handleCreateDraft)
 	mux.HandleFunc("GET /v1/drafts", server.handleListDrafts)
 	mux.HandleFunc("GET /v1/drafts/", server.handleGetDraft)
 	mux.HandleFunc("POST /v1/drafts/", server.handleDraftAction)

--- a/core/app/handlers_connected_accounts.go
+++ b/core/app/handlers_connected_accounts.go
@@ -1,8 +1,8 @@
 package app
 
 import (
+	"encoding/json"
 	"net/http"
-
 	"time"
 
 	"github.com/ALRubinger/aileron/core/account"
@@ -16,23 +16,81 @@ import (
 
 // --- Connected Accounts ---
 
-func (s *apiServer) ListConnectedAccounts(w http.ResponseWriter, r *http.Request) {
+// handleCreateConnectedAccount creates a connected account directly
+// (for programmatic/admin use and testing). The normal user flow is
+// the OAuth connect path (/v1/connect/{provider}).
+// POST /v1/connected-accounts
+func (s *apiServer) handleCreateConnectedAccount(w http.ResponseWriter, r *http.Request) {
 	userID, _, ok := s.requireAuth(w, r)
 	if !ok {
-		s.log.Warn("list connected accounts: auth failed")
 		return
 	}
 
-	s.log.Info("list connected accounts", "user_id", userID)
+	var req struct {
+		Provider       string   `json:"provider"`
+		Email          string   `json:"email"`
+		Scopes         []string `json:"scopes"`
+		ExternalUserID string   `json:"external_user_id"`
+		ExternalTeamID string   `json:"external_team_id"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid JSON request body")
+		return
+	}
+	if req.Provider == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body", "provider is required")
+		return
+	}
 
-	accounts, err := s.connectedAccounts.List(r.Context(), store.ConnectedAccountFilter{UserID: userID})
-	if err != nil {
-		s.log.Error("list connected accounts: store error", "error", err)
+	now := time.Now().UTC()
+	acct := model.ConnectedAccount{
+		ID:             "conn_" + s.newID(),
+		UserID:         userID,
+		Provider:       model.ConnectedAccountProvider(req.Provider),
+		Email:          req.Email,
+		Scopes:         req.Scopes,
+		Status:         model.ConnectedAccountStatusActive,
+		ExternalUserID: req.ExternalUserID,
+		ExternalTeamID: req.ExternalTeamID,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	if err := s.connectedAccounts.Create(r.Context(), acct); err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
 
-	s.log.Info("list connected accounts: found", "count", len(accounts))
+	writeJSON(w, http.StatusCreated, connectedAccountToAPI(acct))
+}
+
+func (s *apiServer) ListConnectedAccounts(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	filter := store.ConnectedAccountFilter{UserID: userID}
+	if providerParam := r.URL.Query().Get("provider"); providerParam != "" {
+		provider := model.ConnectedAccountProvider(providerParam)
+		filter.Provider = &provider
+	}
+	if statusParam := r.URL.Query().Get("status"); statusParam != "" {
+		status := model.ConnectedAccountStatus(statusParam)
+		filter.Status = &status
+	}
+	if extUser := r.URL.Query().Get("external_user_id"); extUser != "" {
+		filter.ExternalUserID = extUser
+	}
+	if extTeam := r.URL.Query().Get("external_team_id"); extTeam != "" {
+		filter.ExternalTeamID = extTeam
+	}
+
+	accounts, err := s.connectedAccounts.List(r.Context(), filter)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
 
 	items := make([]api.ConnectedAccount, 0, len(accounts))
 	for _, a := range accounts {

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -12,6 +12,54 @@ import (
 	"github.com/ALRubinger/aileron/core/store"
 )
 
+// handleCreateDraft creates a draft directly (for programmatic/admin use).
+// POST /v1/drafts
+func (s *apiServer) handleCreateDraft(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Service     string `json:"service"`
+		Channel     string `json:"channel"`
+		Author      string `json:"author"`
+		MessageBody string `json:"message_body"`
+		MessageTS   string `json:"message_ts"`
+		DraftBody   string `json:"draft_body"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid JSON request body")
+		return
+	}
+	if req.DraftBody == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body", "draft_body is required")
+		return
+	}
+
+	now := time.Now().UTC()
+	d := model.Draft{
+		ID:          "dft_" + s.newID(),
+		UserID:      userID,
+		Status:      model.DraftStatusPending,
+		Service:     req.Service,
+		Channel:     req.Channel,
+		Author:      req.Author,
+		MessageBody: req.MessageBody,
+		MessageTS:   req.MessageTS,
+		DraftBody:   req.DraftBody,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+	}
+
+	if err := s.drafts.Create(r.Context(), d); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, d)
+}
+
 // handleListDrafts returns pending drafts for the authenticated user.
 // GET /v1/drafts?status=pending
 func (s *apiServer) handleListDrafts(w http.ResponseWriter, r *http.Request) {
@@ -290,6 +338,58 @@ func (s *apiServer) recordFeedback(ctx context.Context, draft model.Draft, signa
 	if err := s.feedback.Create(ctx, fb); err != nil {
 		s.log.Error("failed to record feedback", "draft_id", draft.ID, "signal", signal, "error", err)
 	}
+}
+
+// handleCreateFeedback creates a feedback signal directly (for programmatic/admin use).
+// POST /v1/feedback
+func (s *apiServer) handleCreateFeedback(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	if s.feedback == nil {
+		writeError(w, http.StatusNotImplemented, "not_implemented", "feedback store not configured")
+		return
+	}
+
+	var req struct {
+		DraftID   string   `json:"draft_id"`
+		Signal    string   `json:"signal"`
+		Service   string   `json:"service"`
+		Channel   string   `json:"channel"`
+		DraftBody string   `json:"draft_body"`
+		SentBody  string   `json:"sent_body"`
+		ToolsUsed []string `json:"tools_used"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid JSON request body")
+		return
+	}
+	if req.Signal == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body", "signal is required")
+		return
+	}
+
+	fb := model.DraftFeedback{
+		ID:        "fb_" + s.newID(),
+		UserID:    userID,
+		DraftID:   req.DraftID,
+		Signal:    model.FeedbackSignal(req.Signal),
+		Service:   req.Service,
+		Channel:   req.Channel,
+		DraftBody: req.DraftBody,
+		SentBody:  req.SentBody,
+		ToolsUsed: req.ToolsUsed,
+		CreatedAt: time.Now().UTC(),
+	}
+
+	if err := s.feedback.Create(r.Context(), fb); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusCreated, fb)
 }
 
 // handleListFeedback returns the user's draft feedback signals.

--- a/core/schema/schema.hcl
+++ b/core/schema/schema.hcl
@@ -398,3 +398,274 @@ table "sso_configs" {
     unique  = true
   }
 }
+
+table "connected_accounts" {
+  schema = schema.public
+
+  column "id" {
+    type    = varchar(64)
+    null    = false
+    comment = "Surrogate key (conn_ + UUID)"
+  }
+  column "user_id" {
+    type = varchar(64)
+    null = false
+  }
+  column "provider" {
+    type    = varchar(64)
+    null    = false
+    comment = "External service provider (gmail, slack, github_repos, etc.)"
+  }
+  column "email" {
+    type    = varchar(255)
+    null    = false
+    default = ""
+  }
+  column "scopes" {
+    type    = text
+    null    = false
+    default = "[]"
+    comment = "JSON array of granted OAuth scopes"
+  }
+  column "status" {
+    type    = varchar(32)
+    null    = false
+    default = "active"
+  }
+  column "external_user_id" {
+    type    = varchar(255)
+    null    = false
+    default = ""
+    comment = "Provider-specific user ID (e.g. Slack U...)"
+  }
+  column "external_team_id" {
+    type    = varchar(255)
+    null    = false
+    default = ""
+    comment = "Provider-specific workspace/team ID (e.g. Slack T...)"
+  }
+  column "created_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+  column "updated_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+
+  foreign_key "fk_connected_accounts_user" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_delete   = CASCADE
+  }
+
+  index "idx_connected_accounts_user" {
+    columns = [column.user_id]
+  }
+
+  index "idx_connected_accounts_user_provider" {
+    columns = [column.user_id, column.provider]
+    unique  = true
+  }
+}
+
+table "drafts" {
+  schema = schema.public
+
+  column "id" {
+    type    = varchar(64)
+    null    = false
+    comment = "Surrogate key (dft_ + UUID)"
+  }
+  column "user_id" {
+    type = varchar(64)
+    null = false
+  }
+  column "status" {
+    type    = varchar(32)
+    null    = false
+    default = "pending"
+  }
+  column "service" {
+    type    = varchar(64)
+    null    = false
+    comment = "Source service (slack, discord, etc.)"
+  }
+  column "channel" {
+    type = varchar(255)
+    null = false
+  }
+  column "author" {
+    type = varchar(255)
+    null = false
+  }
+  column "message_body" {
+    type = text
+    null = false
+  }
+  column "message_ts" {
+    type    = varchar(64)
+    null    = false
+    comment = "Original message timestamp for threading"
+  }
+  column "draft_body" {
+    type = text
+    null = false
+  }
+  column "sent_body" {
+    type    = text
+    null    = false
+    default = ""
+    comment = "What was actually sent; empty until approved or edited"
+  }
+  column "created_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+  column "updated_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+
+  foreign_key "fk_drafts_user" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_delete   = CASCADE
+  }
+
+  index "idx_drafts_user" {
+    columns = [column.user_id]
+  }
+}
+
+table "user_instructions" {
+  schema = schema.public
+
+  column "id" {
+    type    = varchar(64)
+    null    = false
+    comment = "Surrogate key (ins_ + UUID)"
+  }
+  column "user_id" {
+    type = varchar(64)
+    null = false
+  }
+  column "body" {
+    type = text
+    null = false
+  }
+  column "scope" {
+    type    = text
+    null    = false
+    default = ""
+    comment = "Optional free-text context: channel, person, topic, or empty for global"
+  }
+  column "active" {
+    type    = boolean
+    null    = false
+    default = true
+  }
+  column "created_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+  column "updated_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+
+  foreign_key "fk_user_instructions_user" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_delete   = CASCADE
+  }
+
+  index "idx_user_instructions_user" {
+    columns = [column.user_id]
+  }
+}
+
+table "draft_feedback" {
+  schema = schema.public
+
+  column "id" {
+    type    = varchar(64)
+    null    = false
+    comment = "Surrogate key (fb_ + UUID)"
+  }
+  column "user_id" {
+    type = varchar(64)
+    null = false
+  }
+  column "draft_id" {
+    type    = varchar(64)
+    null    = false
+    comment = "The draft this feedback is for"
+  }
+  column "signal" {
+    type    = varchar(32)
+    null    = false
+    comment = "approved, edited, or discarded"
+  }
+  column "service" {
+    type    = varchar(64)
+    null    = false
+  }
+  column "channel" {
+    type = varchar(255)
+    null = false
+  }
+  column "draft_body" {
+    type = text
+    null = false
+  }
+  column "sent_body" {
+    type    = text
+    null    = false
+    default = ""
+    comment = "What was actually sent; empty if discarded"
+  }
+  column "tools_used" {
+    type    = text
+    null    = false
+    default = "[]"
+    comment = "JSON array of source connector tools called during generation"
+  }
+  column "created_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+
+  foreign_key "fk_draft_feedback_user" {
+    columns     = [column.user_id]
+    ref_columns = [table.users.column.id]
+    on_delete   = CASCADE
+  }
+
+  index "idx_draft_feedback_user" {
+    columns = [column.user_id]
+  }
+}

--- a/core/store/mem/connected_account.go
+++ b/core/store/mem/connected_account.go
@@ -36,17 +36,6 @@ func (s *ConnectedAccountStore) Get(_ context.Context, accountID string) (model.
 	return acc, nil
 }
 
-func (s *ConnectedAccountStore) GetByUserAndProvider(_ context.Context, userID string, provider model.ConnectedAccountProvider) (model.ConnectedAccount, error) {
-	s.mu.RLock()
-	defer s.mu.RUnlock()
-	for _, acc := range s.accounts {
-		if acc.UserID == userID && acc.Provider == provider {
-			return acc, nil
-		}
-	}
-	return model.ConnectedAccount{}, &store.ErrNotFound{Entity: "connected_account", ID: userID + "/" + string(provider)}
-}
-
 func (s *ConnectedAccountStore) List(_ context.Context, filter store.ConnectedAccountFilter) ([]model.ConnectedAccount, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()
@@ -72,15 +61,6 @@ func (s *ConnectedAccountStore) List(_ context.Context, filter store.ConnectedAc
 	return result, nil
 }
 
-func (s *ConnectedAccountStore) Update(_ context.Context, account model.ConnectedAccount) error {
-	s.mu.Lock()
-	defer s.mu.Unlock()
-	if _, ok := s.accounts[account.ID]; !ok {
-		return &store.ErrNotFound{Entity: "connected_account", ID: account.ID}
-	}
-	s.accounts[account.ID] = account
-	return nil
-}
 
 func (s *ConnectedAccountStore) Delete(_ context.Context, accountID string) error {
 	s.mu.Lock()

--- a/core/store/mem/connected_account_test.go
+++ b/core/store/mem/connected_account_test.go
@@ -53,28 +53,6 @@ func TestConnectedAccountStore_GetNotFound(t *testing.T) {
 	}
 }
 
-func TestConnectedAccountStore_GetByUserAndProvider(t *testing.T) {
-	s := mem.NewConnectedAccountStore()
-	ctx := context.Background()
-
-	acc := newTestAccount("conn_1", "usr_1", model.ConnectedAccountProviderGmail)
-	s.Create(ctx, acc)
-
-	got, err := s.GetByUserAndProvider(ctx, "usr_1", model.ConnectedAccountProviderGmail)
-	if err != nil {
-		t.Fatal(err)
-	}
-	if got.ID != "conn_1" {
-		t.Fatalf("expected conn_1, got %s", got.ID)
-	}
-
-	// Not found case.
-	_, err = s.GetByUserAndProvider(ctx, "usr_1", model.ConnectedAccountProviderGoogleCalendar)
-	if err == nil {
-		t.Fatal("expected error for missing provider")
-	}
-}
-
 func TestConnectedAccountStore_List(t *testing.T) {
 	s := mem.NewConnectedAccountStore()
 	ctx := context.Background()
@@ -168,33 +146,6 @@ func TestConnectedAccountStore_ListByExternalIDs(t *testing.T) {
 	}
 	if len(accounts) != 0 {
 		t.Fatalf("expected 0 accounts for unknown team, got %d", len(accounts))
-	}
-}
-
-func TestConnectedAccountStore_Update(t *testing.T) {
-	s := mem.NewConnectedAccountStore()
-	ctx := context.Background()
-
-	acc := newTestAccount("conn_1", "usr_1", model.ConnectedAccountProviderGmail)
-	s.Create(ctx, acc)
-
-	acc.Status = model.ConnectedAccountStatusExpired
-	if err := s.Update(ctx, acc); err != nil {
-		t.Fatal(err)
-	}
-
-	got, _ := s.Get(ctx, "conn_1")
-	if got.Status != model.ConnectedAccountStatusExpired {
-		t.Fatalf("expected expired, got %s", got.Status)
-	}
-}
-
-func TestConnectedAccountStore_UpdateNotFound(t *testing.T) {
-	s := mem.NewConnectedAccountStore()
-	acc := newTestAccount("conn_nonexistent", "usr_1", model.ConnectedAccountProviderGmail)
-	err := s.Update(context.Background(), acc)
-	if err == nil {
-		t.Fatal("expected error")
 	}
 }
 

--- a/core/store/postgres/connected_account.go
+++ b/core/store/postgres/connected_account.go
@@ -41,12 +41,6 @@ func (s *ConnectedAccountStore) Get(ctx context.Context, accountID string) (mode
 		`SELECT `+connectedAccountColumns+` FROM connected_accounts WHERE id = $1`, accountID)
 }
 
-func (s *ConnectedAccountStore) GetByUserAndProvider(ctx context.Context, userID string, provider model.ConnectedAccountProvider) (model.ConnectedAccount, error) {
-	return s.scanOne(ctx,
-		`SELECT `+connectedAccountColumns+` FROM connected_accounts WHERE user_id = $1 AND provider = $2`,
-		userID, string(provider))
-}
-
 func (s *ConnectedAccountStore) List(ctx context.Context, filter store.ConnectedAccountFilter) ([]model.ConnectedAccount, error) {
 	query := `SELECT ` + connectedAccountColumns + ` FROM connected_accounts WHERE 1=1`
 	args := []any{}
@@ -80,11 +74,6 @@ func (s *ConnectedAccountStore) List(ctx context.Context, filter store.Connected
 
 	query += " ORDER BY created_at ASC"
 
-	if filter.PageSize > 0 {
-		query += fmt.Sprintf(" LIMIT $%d", argIdx)
-		args = append(args, filter.PageSize)
-	}
-
 	rows, err := s.db.Pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err
@@ -100,25 +89,6 @@ func (s *ConnectedAccountStore) List(ctx context.Context, filter store.Connected
 		accounts = append(accounts, a)
 	}
 	return accounts, rows.Err()
-}
-
-func (s *ConnectedAccountStore) Update(ctx context.Context, a model.ConnectedAccount) error {
-	scopes, _ := json.Marshal(a.Scopes)
-	tag, err := s.db.Pool.Exec(ctx,
-		`UPDATE connected_accounts
-		 SET provider=$2, email=$3, scopes=$4, status=$5,
-			 external_user_id=$6, external_team_id=$7, updated_at=$8
-		 WHERE id=$1`,
-		a.ID, string(a.Provider), a.Email, string(scopes),
-		string(a.Status), a.ExternalUserID, a.ExternalTeamID, a.UpdatedAt,
-	)
-	if err != nil {
-		return err
-	}
-	if tag.RowsAffected() == 0 {
-		return &store.ErrNotFound{Entity: "connected_account", ID: a.ID}
-	}
-	return nil
 }
 
 func (s *ConnectedAccountStore) Delete(ctx context.Context, accountID string) error {

--- a/core/store/postgres/connected_account.go
+++ b/core/store/postgres/connected_account.go
@@ -1,0 +1,172 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/jackc/pgx/v5"
+)
+
+// ConnectedAccountStore is a PostgreSQL implementation of store.ConnectedAccountStore.
+type ConnectedAccountStore struct {
+	db *DB
+}
+
+// NewConnectedAccountStore returns a PostgreSQL-backed connected account store.
+func NewConnectedAccountStore(db *DB) *ConnectedAccountStore {
+	return &ConnectedAccountStore{db: db}
+}
+
+const connectedAccountColumns = `id, user_id, provider, email, scopes, status,
+	external_user_id, external_team_id, created_at, updated_at`
+
+func (s *ConnectedAccountStore) Create(ctx context.Context, a model.ConnectedAccount) error {
+	scopes, _ := json.Marshal(a.Scopes)
+	_, err := s.db.Pool.Exec(ctx,
+		`INSERT INTO connected_accounts
+			(`+connectedAccountColumns+`)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+		a.ID, a.UserID, string(a.Provider), a.Email, string(scopes),
+		string(a.Status), a.ExternalUserID, a.ExternalTeamID,
+		a.CreatedAt, a.UpdatedAt,
+	)
+	return err
+}
+
+func (s *ConnectedAccountStore) Get(ctx context.Context, accountID string) (model.ConnectedAccount, error) {
+	return s.scanOne(ctx,
+		`SELECT `+connectedAccountColumns+` FROM connected_accounts WHERE id = $1`, accountID)
+}
+
+func (s *ConnectedAccountStore) GetByUserAndProvider(ctx context.Context, userID string, provider model.ConnectedAccountProvider) (model.ConnectedAccount, error) {
+	return s.scanOne(ctx,
+		`SELECT `+connectedAccountColumns+` FROM connected_accounts WHERE user_id = $1 AND provider = $2`,
+		userID, string(provider))
+}
+
+func (s *ConnectedAccountStore) List(ctx context.Context, filter store.ConnectedAccountFilter) ([]model.ConnectedAccount, error) {
+	query := `SELECT ` + connectedAccountColumns + ` FROM connected_accounts WHERE 1=1`
+	args := []any{}
+	argIdx := 1
+
+	if filter.UserID != "" {
+		query += fmt.Sprintf(" AND user_id = $%d", argIdx)
+		args = append(args, filter.UserID)
+		argIdx++
+	}
+	if filter.Provider != nil {
+		query += fmt.Sprintf(" AND provider = $%d", argIdx)
+		args = append(args, string(*filter.Provider))
+		argIdx++
+	}
+	if filter.Status != nil {
+		query += fmt.Sprintf(" AND status = $%d", argIdx)
+		args = append(args, string(*filter.Status))
+		argIdx++
+	}
+	if filter.ExternalUserID != "" {
+		query += fmt.Sprintf(" AND external_user_id = $%d", argIdx)
+		args = append(args, filter.ExternalUserID)
+		argIdx++
+	}
+	if filter.ExternalTeamID != "" {
+		query += fmt.Sprintf(" AND external_team_id = $%d", argIdx)
+		args = append(args, filter.ExternalTeamID)
+		argIdx++
+	}
+
+	query += " ORDER BY created_at ASC"
+
+	if filter.PageSize > 0 {
+		query += fmt.Sprintf(" LIMIT $%d", argIdx)
+		args = append(args, filter.PageSize)
+	}
+
+	rows, err := s.db.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var accounts []model.ConnectedAccount
+	for rows.Next() {
+		a, err := scanConnectedAccount(rows)
+		if err != nil {
+			return nil, err
+		}
+		accounts = append(accounts, a)
+	}
+	return accounts, rows.Err()
+}
+
+func (s *ConnectedAccountStore) Update(ctx context.Context, a model.ConnectedAccount) error {
+	scopes, _ := json.Marshal(a.Scopes)
+	tag, err := s.db.Pool.Exec(ctx,
+		`UPDATE connected_accounts
+		 SET provider=$2, email=$3, scopes=$4, status=$5,
+			 external_user_id=$6, external_team_id=$7, updated_at=$8
+		 WHERE id=$1`,
+		a.ID, string(a.Provider), a.Email, string(scopes),
+		string(a.Status), a.ExternalUserID, a.ExternalTeamID, a.UpdatedAt,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Entity: "connected_account", ID: a.ID}
+	}
+	return nil
+}
+
+func (s *ConnectedAccountStore) Delete(ctx context.Context, accountID string) error {
+	tag, err := s.db.Pool.Exec(ctx,
+		`DELETE FROM connected_accounts WHERE id = $1`, accountID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Entity: "connected_account", ID: accountID}
+	}
+	return nil
+}
+
+func (s *ConnectedAccountStore) scanOne(ctx context.Context, query string, args ...any) (model.ConnectedAccount, error) {
+	row := s.db.Pool.QueryRow(ctx, query, args...)
+	var a model.ConnectedAccount
+	var provider, status, scopesJSON string
+	err := row.Scan(
+		&a.ID, &a.UserID, &provider, &a.Email, &scopesJSON,
+		&status, &a.ExternalUserID, &a.ExternalTeamID,
+		&a.CreatedAt, &a.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return model.ConnectedAccount{}, &store.ErrNotFound{Entity: "connected_account", ID: fmt.Sprint(args...)}
+		}
+		return model.ConnectedAccount{}, err
+	}
+	a.Provider = model.ConnectedAccountProvider(provider)
+	a.Status = model.ConnectedAccountStatus(status)
+	_ = json.Unmarshal([]byte(scopesJSON), &a.Scopes)
+	return a, nil
+}
+
+func scanConnectedAccount(rows pgx.Rows) (model.ConnectedAccount, error) {
+	var a model.ConnectedAccount
+	var provider, status, scopesJSON string
+	err := rows.Scan(
+		&a.ID, &a.UserID, &provider, &a.Email, &scopesJSON,
+		&status, &a.ExternalUserID, &a.ExternalTeamID,
+		&a.CreatedAt, &a.UpdatedAt,
+	)
+	if err != nil {
+		return model.ConnectedAccount{}, err
+	}
+	a.Provider = model.ConnectedAccountProvider(provider)
+	a.Status = model.ConnectedAccountStatus(status)
+	_ = json.Unmarshal([]byte(scopesJSON), &a.Scopes)
+	return a, nil
+}

--- a/core/store/postgres/draft.go
+++ b/core/store/postgres/draft.go
@@ -57,11 +57,6 @@ func (s *DraftStore) List(ctx context.Context, filter store.DraftFilter) ([]mode
 
 	query += " ORDER BY created_at DESC"
 
-	if filter.PageSize > 0 {
-		query += fmt.Sprintf(" LIMIT $%d", argIdx)
-		args = append(args, filter.PageSize)
-	}
-
 	rows, err := s.db.Pool.Query(ctx, query, args...)
 	if err != nil {
 		return nil, err

--- a/core/store/postgres/draft.go
+++ b/core/store/postgres/draft.go
@@ -1,0 +1,132 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/jackc/pgx/v5"
+)
+
+// DraftStore is a PostgreSQL implementation of store.DraftStore.
+type DraftStore struct {
+	db *DB
+}
+
+// NewDraftStore returns a PostgreSQL-backed draft store.
+func NewDraftStore(db *DB) *DraftStore {
+	return &DraftStore{db: db}
+}
+
+const draftColumns = `id, user_id, status, service, channel, author,
+	message_body, message_ts, draft_body, sent_body, created_at, updated_at`
+
+func (s *DraftStore) Create(ctx context.Context, d model.Draft) error {
+	_, err := s.db.Pool.Exec(ctx,
+		`INSERT INTO drafts
+			(`+draftColumns+`)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10,$11,$12)`,
+		d.ID, d.UserID, string(d.Status), d.Service, d.Channel, d.Author,
+		d.MessageBody, d.MessageTS, d.DraftBody, d.SentBody,
+		d.CreatedAt, d.UpdatedAt,
+	)
+	return err
+}
+
+func (s *DraftStore) Get(ctx context.Context, draftID string) (model.Draft, error) {
+	return s.scanOne(ctx,
+		`SELECT `+draftColumns+` FROM drafts WHERE id = $1`, draftID)
+}
+
+func (s *DraftStore) List(ctx context.Context, filter store.DraftFilter) ([]model.Draft, error) {
+	query := `SELECT ` + draftColumns + ` FROM drafts WHERE 1=1`
+	args := []any{}
+	argIdx := 1
+
+	if filter.UserID != "" {
+		query += fmt.Sprintf(" AND user_id = $%d", argIdx)
+		args = append(args, filter.UserID)
+		argIdx++
+	}
+	if filter.Status != nil {
+		query += fmt.Sprintf(" AND status = $%d", argIdx)
+		args = append(args, string(*filter.Status))
+		argIdx++
+	}
+
+	query += " ORDER BY created_at DESC"
+
+	if filter.PageSize > 0 {
+		query += fmt.Sprintf(" LIMIT $%d", argIdx)
+		args = append(args, filter.PageSize)
+	}
+
+	rows, err := s.db.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var drafts []model.Draft
+	for rows.Next() {
+		d, err := scanDraft(rows)
+		if err != nil {
+			return nil, err
+		}
+		drafts = append(drafts, d)
+	}
+	return drafts, rows.Err()
+}
+
+func (s *DraftStore) Update(ctx context.Context, d model.Draft) error {
+	tag, err := s.db.Pool.Exec(ctx,
+		`UPDATE drafts
+		 SET status=$2, service=$3, channel=$4, author=$5,
+			 message_body=$6, message_ts=$7, draft_body=$8, sent_body=$9, updated_at=$10
+		 WHERE id=$1`,
+		d.ID, string(d.Status), d.Service, d.Channel, d.Author,
+		d.MessageBody, d.MessageTS, d.DraftBody, d.SentBody, d.UpdatedAt,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Entity: "draft", ID: d.ID}
+	}
+	return nil
+}
+
+func (s *DraftStore) scanOne(ctx context.Context, query string, args ...any) (model.Draft, error) {
+	row := s.db.Pool.QueryRow(ctx, query, args...)
+	var d model.Draft
+	var status string
+	err := row.Scan(
+		&d.ID, &d.UserID, &status, &d.Service, &d.Channel, &d.Author,
+		&d.MessageBody, &d.MessageTS, &d.DraftBody, &d.SentBody,
+		&d.CreatedAt, &d.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return model.Draft{}, &store.ErrNotFound{Entity: "draft", ID: fmt.Sprint(args...)}
+		}
+		return model.Draft{}, err
+	}
+	d.Status = model.DraftStatus(status)
+	return d, nil
+}
+
+func scanDraft(rows pgx.Rows) (model.Draft, error) {
+	var d model.Draft
+	var status string
+	err := rows.Scan(
+		&d.ID, &d.UserID, &status, &d.Service, &d.Channel, &d.Author,
+		&d.MessageBody, &d.MessageTS, &d.DraftBody, &d.SentBody,
+		&d.CreatedAt, &d.UpdatedAt,
+	)
+	if err != nil {
+		return model.Draft{}, err
+	}
+	d.Status = model.DraftStatus(status)
+	return d, nil
+}

--- a/core/store/postgres/draft_feedback.go
+++ b/core/store/postgres/draft_feedback.go
@@ -1,0 +1,86 @@
+package postgres
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/jackc/pgx/v5"
+)
+
+// DraftFeedbackStore is a PostgreSQL implementation of store.DraftFeedbackStore.
+type DraftFeedbackStore struct {
+	db *DB
+}
+
+// NewDraftFeedbackStore returns a PostgreSQL-backed draft feedback store.
+func NewDraftFeedbackStore(db *DB) *DraftFeedbackStore {
+	return &DraftFeedbackStore{db: db}
+}
+
+const draftFeedbackColumns = `id, user_id, draft_id, signal, service, channel,
+	draft_body, sent_body, tools_used, created_at`
+
+func (s *DraftFeedbackStore) Create(ctx context.Context, f model.DraftFeedback) error {
+	tools, _ := json.Marshal(f.ToolsUsed)
+	_, err := s.db.Pool.Exec(ctx,
+		`INSERT INTO draft_feedback
+			(`+draftFeedbackColumns+`)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9,$10)`,
+		f.ID, f.UserID, f.DraftID, string(f.Signal), f.Service, f.Channel,
+		f.DraftBody, f.SentBody, string(tools), f.CreatedAt,
+	)
+	return err
+}
+
+func (s *DraftFeedbackStore) List(ctx context.Context, filter store.DraftFeedbackFilter) ([]model.DraftFeedback, error) {
+	query := `SELECT ` + draftFeedbackColumns + ` FROM draft_feedback WHERE 1=1`
+	args := []any{}
+	argIdx := 1
+
+	if filter.UserID != "" {
+		query += fmt.Sprintf(" AND user_id = $%d", argIdx)
+		args = append(args, filter.UserID)
+		argIdx++
+	}
+	if filter.Signal != nil {
+		query += fmt.Sprintf(" AND signal = $%d", argIdx)
+		args = append(args, string(*filter.Signal))
+		argIdx++
+	}
+
+	query += " ORDER BY created_at DESC"
+
+	rows, err := s.db.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var feedbacks []model.DraftFeedback
+	for rows.Next() {
+		f, err := scanDraftFeedback(rows)
+		if err != nil {
+			return nil, err
+		}
+		feedbacks = append(feedbacks, f)
+	}
+	return feedbacks, rows.Err()
+}
+
+func scanDraftFeedback(rows pgx.Rows) (model.DraftFeedback, error) {
+	var f model.DraftFeedback
+	var signal, toolsJSON string
+	err := rows.Scan(
+		&f.ID, &f.UserID, &f.DraftID, &signal, &f.Service, &f.Channel,
+		&f.DraftBody, &f.SentBody, &toolsJSON, &f.CreatedAt,
+	)
+	if err != nil {
+		return model.DraftFeedback{}, err
+	}
+	f.Signal = model.FeedbackSignal(signal)
+	_ = json.Unmarshal([]byte(toolsJSON), &f.ToolsUsed)
+	return f, nil
+}

--- a/core/store/postgres/user_instruction.go
+++ b/core/store/postgres/user_instruction.go
@@ -1,0 +1,129 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/jackc/pgx/v5"
+)
+
+// UserInstructionStore is a PostgreSQL implementation of store.UserInstructionStore.
+type UserInstructionStore struct {
+	db *DB
+}
+
+// NewUserInstructionStore returns a PostgreSQL-backed user instruction store.
+func NewUserInstructionStore(db *DB) *UserInstructionStore {
+	return &UserInstructionStore{db: db}
+}
+
+const userInstructionColumns = `id, user_id, body, scope, active, created_at, updated_at`
+
+func (s *UserInstructionStore) Create(ctx context.Context, ins model.UserInstruction) error {
+	_, err := s.db.Pool.Exec(ctx,
+		`INSERT INTO user_instructions
+			(`+userInstructionColumns+`)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7)`,
+		ins.ID, ins.UserID, ins.Body, ins.Scope, ins.Active,
+		ins.CreatedAt, ins.UpdatedAt,
+	)
+	return err
+}
+
+func (s *UserInstructionStore) Get(ctx context.Context, instructionID string) (model.UserInstruction, error) {
+	return s.scanOne(ctx,
+		`SELECT `+userInstructionColumns+` FROM user_instructions WHERE id = $1`, instructionID)
+}
+
+func (s *UserInstructionStore) List(ctx context.Context, filter store.UserInstructionFilter) ([]model.UserInstruction, error) {
+	query := `SELECT ` + userInstructionColumns + ` FROM user_instructions WHERE 1=1`
+	args := []any{}
+	argIdx := 1
+
+	if filter.UserID != "" {
+		query += fmt.Sprintf(" AND user_id = $%d", argIdx)
+		args = append(args, filter.UserID)
+		argIdx++
+	}
+	if filter.Active != nil {
+		query += fmt.Sprintf(" AND active = $%d", argIdx)
+		args = append(args, *filter.Active)
+		argIdx++
+	}
+
+	query += " ORDER BY created_at ASC"
+
+	rows, err := s.db.Pool.Query(ctx, query, args...)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	var instructions []model.UserInstruction
+	for rows.Next() {
+		ins, err := scanUserInstruction(rows)
+		if err != nil {
+			return nil, err
+		}
+		instructions = append(instructions, ins)
+	}
+	return instructions, rows.Err()
+}
+
+func (s *UserInstructionStore) Update(ctx context.Context, ins model.UserInstruction) error {
+	tag, err := s.db.Pool.Exec(ctx,
+		`UPDATE user_instructions
+		 SET body=$2, scope=$3, active=$4, updated_at=$5
+		 WHERE id=$1`,
+		ins.ID, ins.Body, ins.Scope, ins.Active, ins.UpdatedAt,
+	)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Entity: "user_instruction", ID: ins.ID}
+	}
+	return nil
+}
+
+func (s *UserInstructionStore) Delete(ctx context.Context, instructionID string) error {
+	tag, err := s.db.Pool.Exec(ctx,
+		`DELETE FROM user_instructions WHERE id = $1`, instructionID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Entity: "user_instruction", ID: instructionID}
+	}
+	return nil
+}
+
+func (s *UserInstructionStore) scanOne(ctx context.Context, query string, args ...any) (model.UserInstruction, error) {
+	row := s.db.Pool.QueryRow(ctx, query, args...)
+	var ins model.UserInstruction
+	err := row.Scan(
+		&ins.ID, &ins.UserID, &ins.Body, &ins.Scope, &ins.Active,
+		&ins.CreatedAt, &ins.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return model.UserInstruction{}, &store.ErrNotFound{Entity: "user_instruction", ID: fmt.Sprint(args...)}
+		}
+		return model.UserInstruction{}, err
+	}
+	return ins, nil
+}
+
+func scanUserInstruction(rows pgx.Rows) (model.UserInstruction, error) {
+	var ins model.UserInstruction
+	err := rows.Scan(
+		&ins.ID, &ins.UserID, &ins.Body, &ins.Scope, &ins.Active,
+		&ins.CreatedAt, &ins.UpdatedAt,
+	)
+	if err != nil {
+		return model.UserInstruction{}, err
+	}
+	return ins, nil
+}

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -190,9 +190,7 @@ type SSOConfigStore interface {
 type ConnectedAccountStore interface {
 	Create(ctx context.Context, account model.ConnectedAccount) error
 	Get(ctx context.Context, accountID string) (model.ConnectedAccount, error)
-	GetByUserAndProvider(ctx context.Context, userID string, provider model.ConnectedAccountProvider) (model.ConnectedAccount, error)
 	List(ctx context.Context, filter ConnectedAccountFilter) ([]model.ConnectedAccount, error)
-	Update(ctx context.Context, account model.ConnectedAccount) error
 	Delete(ctx context.Context, accountID string) error
 }
 
@@ -203,7 +201,6 @@ type ConnectedAccountFilter struct {
 	Status         *model.ConnectedAccountStatus
 	ExternalUserID string // filter by provider-specific user ID (e.g. Slack user)
 	ExternalTeamID string // filter by provider-specific team/workspace ID (e.g. Slack team)
-	PageSize       int
 }
 
 // DraftStore persists and retrieves AI-generated draft replies.
@@ -216,9 +213,8 @@ type DraftStore interface {
 
 // DraftFilter scopes a draft list query.
 type DraftFilter struct {
-	UserID   string
-	Status   *model.DraftStatus
-	PageSize int
+	UserID string
+	Status *model.DraftStatus
 }
 
 // DraftFeedbackStore persists and retrieves feedback signals from draft

--- a/test/integration/auth_helper_test.go
+++ b/test/integration/auth_helper_test.go
@@ -128,6 +128,29 @@ func authedDelete(t *testing.T, url string) *http.Response {
 	return resp
 }
 
+// authedPatch sends an authenticated PATCH request with JSON body.
+func authedPatch(t *testing.T, url string, body any) *http.Response {
+	t.Helper()
+	token := ensureAuth(t)
+	data, err := json.Marshal(body)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	req, err := http.NewRequest("PATCH", url, bytes.NewReader(data))
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("PATCH %s: %v", url, err)
+	}
+	return resp
+}
+
 // authedGet sends an authenticated GET request.
 func authedGet(t *testing.T, url string) *http.Response {
 	t.Helper()

--- a/test/integration/connected_accounts_test.go
+++ b/test/integration/connected_accounts_test.go
@@ -1,0 +1,211 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestConnectedAccounts_CRUD(t *testing.T) {
+	// Create a connected account directly.
+	resp := authedPost(t, apiURL()+"/v1/connected-accounts", map[string]any{
+		"provider":         "slack",
+		"email":            "",
+		"scopes":           []string{"channels:history", "chat:write"},
+		"external_user_id": "U_INTEGRATION_TEST",
+		"external_team_id": "T_INTEGRATION_TEST",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: expected 201, got %d: %s", resp.StatusCode, body)
+	}
+
+	var created map[string]any
+	json.NewDecoder(resp.Body).Decode(&created)
+	acctID := stringField(created, "id")
+	if acctID == "" {
+		t.Fatalf("expected account ID in response, got: %v", created)
+	}
+	t.Logf("created connected account: %s", acctID)
+
+	// List — should contain the one we created.
+	listResp := authedGet(t, apiURL()+"/v1/connected-accounts")
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("list: expected 200, got %d: %s", listResp.StatusCode, body)
+	}
+
+	var listResult map[string]any
+	json.NewDecoder(listResp.Body).Decode(&listResult)
+	items, _ := listResult["items"].([]any)
+	found := false
+	for _, item := range items {
+		m, _ := item.(map[string]any)
+		if stringField(m, "id") == acctID {
+			found = true
+		}
+	}
+	if !found {
+		t.Fatalf("list: created account %s not found in results", acctID)
+	}
+
+	// Get the specific account.
+	getResp := authedGet(t, apiURL()+"/v1/connected-accounts/"+acctID)
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(getResp.Body)
+		t.Fatalf("get: expected 200, got %d: %s", getResp.StatusCode, body)
+	}
+
+	// Delete the account.
+	deleteResp := authedDelete(t, apiURL()+"/v1/connected-accounts/"+acctID)
+	defer deleteResp.Body.Close()
+	if deleteResp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(deleteResp.Body)
+		t.Fatalf("delete: expected 204, got %d: %s", deleteResp.StatusCode, body)
+	}
+
+	// Verify deleted.
+	getAfterDelete := authedGet(t, apiURL()+"/v1/connected-accounts/"+acctID)
+	defer getAfterDelete.Body.Close()
+	if getAfterDelete.StatusCode != http.StatusNotFound {
+		t.Fatalf("get after delete: expected 404, got %d", getAfterDelete.StatusCode)
+	}
+}
+
+func TestConnectedAccounts_CreateAndListWithFilters(t *testing.T) {
+	// Create two accounts with different providers.
+	resp1 := authedPost(t, apiURL()+"/v1/connected-accounts", map[string]any{
+		"provider":         "slack",
+		"scopes":           []string{"channels:history"},
+		"external_user_id": "U_FILTER_TEST_1",
+		"external_team_id": "T_FILTER_TEST",
+	})
+	defer resp1.Body.Close()
+	if resp1.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp1.Body)
+		t.Fatalf("create slack: expected 201, got %d: %s", resp1.StatusCode, body)
+	}
+	var created1 map[string]any
+	json.NewDecoder(resp1.Body).Decode(&created1)
+	id1 := stringField(created1, "id")
+
+	resp2 := authedPost(t, apiURL()+"/v1/connected-accounts", map[string]any{
+		"provider":         "github_repos",
+		"email":            "test@github.com",
+		"scopes":           []string{"repo"},
+		"external_user_id": "ghuser",
+	})
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("create github: expected 201, got %d: %s", resp2.StatusCode, body)
+	}
+	var created2 map[string]any
+	json.NewDecoder(resp2.Body).Decode(&created2)
+	id2 := stringField(created2, "id")
+
+	// List all — should have at least 2.
+	listAll := authedGet(t, apiURL()+"/v1/connected-accounts")
+	defer listAll.Body.Close()
+	var allResult map[string]any
+	json.NewDecoder(listAll.Body).Decode(&allResult)
+	items, _ := allResult["items"].([]any)
+	if len(items) < 2 {
+		t.Fatalf("expected at least 2 accounts, got %d", len(items))
+	}
+
+	// Filter by provider.
+	slackResp := authedGet(t, apiURL()+"/v1/connected-accounts?provider=slack")
+	defer slackResp.Body.Close()
+	if slackResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(slackResp.Body)
+		t.Fatalf("filter provider: expected 200, got %d: %s", slackResp.StatusCode, body)
+	}
+	var slackResult map[string]any
+	json.NewDecoder(slackResp.Body).Decode(&slackResult)
+	slackItems, _ := slackResult["items"].([]any)
+	for _, item := range slackItems {
+		m, _ := item.(map[string]any)
+		if stringField(m, "provider") != "slack" {
+			t.Errorf("expected provider=slack, got %v", m["provider"])
+		}
+	}
+
+	// Filter by external_user_id.
+	extUserResp := authedGet(t, apiURL()+"/v1/connected-accounts?external_user_id=U_FILTER_TEST_1")
+	defer extUserResp.Body.Close()
+	if extUserResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(extUserResp.Body)
+		t.Fatalf("filter external_user_id: expected 200, got %d: %s", extUserResp.StatusCode, body)
+	}
+	var extUserResult map[string]any
+	json.NewDecoder(extUserResp.Body).Decode(&extUserResult)
+	extUserItems, _ := extUserResult["items"].([]any)
+	if len(extUserItems) != 1 {
+		t.Fatalf("expected 1 result for external_user_id filter, got %d", len(extUserItems))
+	}
+
+	// Filter by external_team_id.
+	extTeamResp := authedGet(t, apiURL()+"/v1/connected-accounts?external_team_id=T_FILTER_TEST")
+	defer extTeamResp.Body.Close()
+	if extTeamResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(extTeamResp.Body)
+		t.Fatalf("filter external_team_id: expected 200, got %d: %s", extTeamResp.StatusCode, body)
+	}
+
+	// Filter by status.
+	activeResp := authedGet(t, apiURL()+"/v1/connected-accounts?status=active")
+	defer activeResp.Body.Close()
+	if activeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(activeResp.Body)
+		t.Fatalf("filter status: expected 200, got %d: %s", activeResp.StatusCode, body)
+	}
+
+	// Clean up.
+	authedDelete(t, apiURL()+"/v1/connected-accounts/"+id1).Body.Close()
+	authedDelete(t, apiURL()+"/v1/connected-accounts/"+id2).Body.Close()
+}
+
+func TestConnectedAccounts_GetNotFound(t *testing.T) {
+	resp := authedGet(t, apiURL()+"/v1/connected-accounts/conn_nonexistent")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestConnectedAccounts_DeleteNotFound(t *testing.T) {
+	resp := authedDelete(t, apiURL()+"/v1/connected-accounts/conn_nonexistent")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestConnectedAccounts_CreateValidation(t *testing.T) {
+	// Empty provider should fail.
+	resp := authedPost(t, apiURL()+"/v1/connected-accounts", map[string]any{
+		"provider": "",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty provider, got %d", resp.StatusCode)
+	}
+}
+
+func TestConnectedAccounts_Unauthorized(t *testing.T) {
+	resp, err := http.Get(apiURL() + "/v1/connected-accounts")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 401 or 200 (auth disabled), got %d", resp.StatusCode)
+	}
+}

--- a/test/integration/drafts_test.go
+++ b/test/integration/drafts_test.go
@@ -1,0 +1,347 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestDrafts_CRUD(t *testing.T) {
+	// Create a draft directly.
+	resp := authedPost(t, apiURL()+"/v1/drafts", map[string]any{
+		"service":      "slack",
+		"channel":      "C_TEST",
+		"author":       "Sarah",
+		"message_body": "Does the JWT refactor change the claims?",
+		"message_ts":   "1234567890.123456",
+		"draft_body":   "No, the claims stay the same.",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: expected 201, got %d: %s", resp.StatusCode, body)
+	}
+
+	var created map[string]any
+	json.NewDecoder(resp.Body).Decode(&created)
+	draftID := stringField(created, "ID", "id")
+	if draftID == "" {
+		t.Fatalf("expected draft ID in response, got: %v", created)
+	}
+	t.Logf("created draft: %s", draftID)
+
+	// List — should contain the one we created.
+	listResp := authedGet(t, apiURL()+"/v1/drafts")
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("list: expected 200, got %d: %s", listResp.StatusCode, body)
+	}
+	var listResult map[string]any
+	json.NewDecoder(listResp.Body).Decode(&listResult)
+	items, _ := listResult["items"].([]any)
+	if len(items) == 0 {
+		t.Fatal("list: expected at least 1 draft")
+	}
+
+	// List by status.
+	pendingResp := authedGet(t, apiURL()+"/v1/drafts?status=pending")
+	defer pendingResp.Body.Close()
+	if pendingResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(pendingResp.Body)
+		t.Fatalf("list pending: expected 200, got %d: %s", pendingResp.StatusCode, body)
+	}
+
+	// Get the specific draft.
+	getResp := authedGet(t, apiURL()+"/v1/drafts/"+draftID)
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(getResp.Body)
+		t.Fatalf("get: expected 200, got %d: %s", getResp.StatusCode, body)
+	}
+
+	// Discard it (sends don't work without a real Slack token).
+	discardResp := authedPost(t, apiURL()+"/v1/drafts/"+draftID+"/discard", nil)
+	defer discardResp.Body.Close()
+	if discardResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(discardResp.Body)
+		t.Fatalf("discard: expected 200, got %d: %s", discardResp.StatusCode, body)
+	}
+
+	// Verify status changed — discarding again should be conflict.
+	discardAgain := authedPost(t, apiURL()+"/v1/drafts/"+draftID+"/discard", nil)
+	defer discardAgain.Body.Close()
+	if discardAgain.StatusCode != http.StatusConflict {
+		t.Fatalf("discard again: expected 409, got %d", discardAgain.StatusCode)
+	}
+}
+
+func TestDrafts_EditWithoutSlack(t *testing.T) {
+	// Create a draft.
+	resp := authedPost(t, apiURL()+"/v1/drafts", map[string]any{
+		"service":      "slack",
+		"channel":      "C_EDIT_TEST",
+		"author":       "Alex",
+		"message_body": "What's the status?",
+		"message_ts":   "999.111",
+		"draft_body":   "Everything is on track.",
+	})
+	defer resp.Body.Close()
+	var created map[string]any
+	json.NewDecoder(resp.Body).Decode(&created)
+	draftID := stringField(created, "ID", "id")
+
+	// Edit — will fail at send (no Slack token) but exercises the edit path
+	// through getDraftForAction and the status check.
+	editResp := authedPost(t, apiURL()+"/v1/drafts/"+draftID+"/edit", map[string]string{
+		"body": "Everything is on track. Shipping Friday.",
+	})
+	defer editResp.Body.Close()
+	// Expect 500 (send fails) or 200 (if somehow it works).
+	// The important thing is the handler ran and hit the store.
+	t.Logf("edit status: %d", editResp.StatusCode)
+
+	// If edit failed, discard to clean up.
+	if editResp.StatusCode != http.StatusOK {
+		discardResp := authedPost(t, apiURL()+"/v1/drafts/"+draftID+"/discard", nil)
+		defer discardResp.Body.Close()
+	}
+}
+
+func TestDrafts_MultipleAndFilter(t *testing.T) {
+	// Create multiple drafts.
+	for i, body := range []string{"Draft one", "Draft two", "Draft three"} {
+		resp := authedPost(t, apiURL()+"/v1/drafts", map[string]any{
+			"service":      "slack",
+			"channel":      "C_MULTI",
+			"author":       "Bot",
+			"message_body": "msg",
+			"message_ts":   "100." + string(rune('0'+i)),
+			"draft_body":   body,
+		})
+		resp.Body.Close()
+		if resp.StatusCode != http.StatusCreated {
+			t.Fatalf("create %d: expected 201, got %d", i, resp.StatusCode)
+		}
+	}
+
+	// List all.
+	listResp := authedGet(t, apiURL()+"/v1/drafts")
+	defer listResp.Body.Close()
+	var result map[string]any
+	json.NewDecoder(listResp.Body).Decode(&result)
+	items, _ := result["items"].([]any)
+	if len(items) < 3 {
+		t.Fatalf("expected at least 3 drafts, got %d", len(items))
+	}
+
+	// Filter by pending.
+	pendingResp := authedGet(t, apiURL()+"/v1/drafts?status=pending")
+	defer pendingResp.Body.Close()
+	if pendingResp.StatusCode != http.StatusOK {
+		t.Fatalf("filter pending: expected 200, got %d", pendingResp.StatusCode)
+	}
+
+	// Filter by approved (should be empty or fewer).
+	approvedResp := authedGet(t, apiURL()+"/v1/drafts?status=approved")
+	defer approvedResp.Body.Close()
+	if approvedResp.StatusCode != http.StatusOK {
+		t.Fatalf("filter approved: expected 200, got %d", approvedResp.StatusCode)
+	}
+}
+
+func TestDrafts_CreateValidation(t *testing.T) {
+	resp := authedPost(t, apiURL()+"/v1/drafts", map[string]any{
+		"draft_body": "",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty draft_body, got %d", resp.StatusCode)
+	}
+}
+
+func TestDrafts_GetNotFound(t *testing.T) {
+	resp := authedGet(t, apiURL()+"/v1/drafts/dft_nonexistent")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestDrafts_ApproveNotFound(t *testing.T) {
+	resp := authedPost(t, apiURL()+"/v1/drafts/dft_nonexistent/approve", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestDrafts_DiscardNotFound(t *testing.T) {
+	resp := authedPost(t, apiURL()+"/v1/drafts/dft_nonexistent/discard", nil)
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestDrafts_EditNotFound(t *testing.T) {
+	resp := authedPost(t, apiURL()+"/v1/drafts/dft_nonexistent/edit", map[string]string{
+		"body": "revised",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", resp.StatusCode)
+	}
+}
+
+func TestDrafts_Unauthorized(t *testing.T) {
+	resp, err := http.Get(apiURL() + "/v1/drafts")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 401 or 200 (auth disabled), got %d", resp.StatusCode)
+	}
+}
+
+func TestFeedback_CRUD(t *testing.T) {
+	// Create feedback directly.
+	resp := authedPost(t, apiURL()+"/v1/feedback", map[string]any{
+		"draft_id":   "dft_test",
+		"signal":     "approved",
+		"service":    "slack",
+		"channel":    "C_TEST",
+		"draft_body": "The original draft",
+		"sent_body":  "The original draft",
+		"tools_used": []string{"slack_channel_history"},
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: expected 201, got %d: %s", resp.StatusCode, body)
+	}
+
+	// Create another with different signal.
+	resp2 := authedPost(t, apiURL()+"/v1/feedback", map[string]any{
+		"draft_id":   "dft_test2",
+		"signal":     "edited",
+		"service":    "slack",
+		"channel":    "C_TEST",
+		"draft_body": "Original",
+		"sent_body":  "Revised by user",
+	})
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("create edited: expected 201, got %d: %s", resp2.StatusCode, body)
+	}
+
+	// List all feedback.
+	listResp := authedGet(t, apiURL()+"/v1/feedback")
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("list: expected 200, got %d: %s", listResp.StatusCode, body)
+	}
+	var listResult map[string]any
+	json.NewDecoder(listResp.Body).Decode(&listResult)
+	items, _ := listResult["items"].([]any)
+	if len(items) < 2 {
+		t.Fatalf("list: expected at least 2 feedback items, got %d", len(items))
+	}
+
+	// Filter by signal.
+	approvedResp := authedGet(t, apiURL()+"/v1/feedback?signal=approved")
+	defer approvedResp.Body.Close()
+	if approvedResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(approvedResp.Body)
+		t.Fatalf("filter approved: expected 200, got %d: %s", approvedResp.StatusCode, body)
+	}
+
+	editedResp := authedGet(t, apiURL()+"/v1/feedback?signal=edited")
+	defer editedResp.Body.Close()
+	if editedResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(editedResp.Body)
+		t.Fatalf("filter edited: expected 200, got %d: %s", editedResp.StatusCode, body)
+	}
+}
+
+func TestFeedback_Discarded(t *testing.T) {
+	resp := authedPost(t, apiURL()+"/v1/feedback", map[string]any{
+		"draft_id":   "dft_discard_test",
+		"signal":     "discarded",
+		"service":    "slack",
+		"channel":    "C_DISC",
+		"draft_body": "Bad draft",
+		"sent_body":  "",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create discarded: expected 201, got %d: %s", resp.StatusCode, body)
+	}
+
+	// Filter by discarded.
+	discardedResp := authedGet(t, apiURL()+"/v1/feedback?signal=discarded")
+	defer discardedResp.Body.Close()
+	if discardedResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(discardedResp.Body)
+		t.Fatalf("filter discarded: expected 200, got %d: %s", discardedResp.StatusCode, body)
+	}
+	var result map[string]any
+	json.NewDecoder(discardedResp.Body).Decode(&result)
+	items, _ := result["items"].([]any)
+	if len(items) == 0 {
+		t.Fatal("expected at least 1 discarded feedback")
+	}
+}
+
+func TestFeedback_CreateValidation(t *testing.T) {
+	resp := authedPost(t, apiURL()+"/v1/feedback", map[string]any{
+		"signal": "",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty signal, got %d", resp.StatusCode)
+	}
+}
+
+func TestFeedback_Unauthorized(t *testing.T) {
+	resp, err := http.Get(apiURL() + "/v1/feedback")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 401 or 200 (auth disabled), got %d", resp.StatusCode)
+	}
+}
+
+func TestTools_List(t *testing.T) {
+	resp := authedGet(t, apiURL()+"/v1/tools")
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+	var result map[string]any
+	json.NewDecoder(resp.Body).Decode(&result)
+	if _, ok := result["tools"]; !ok {
+		t.Fatal("expected 'tools' key in response")
+	}
+}
+
+func TestTools_Unauthorized(t *testing.T) {
+	resp, err := http.Get(apiURL() + "/v1/tools")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 401 or 200 (auth disabled), got %d", resp.StatusCode)
+	}
+}

--- a/test/integration/instructions_test.go
+++ b/test/integration/instructions_test.go
@@ -1,0 +1,171 @@
+//go:build integration
+
+package integration
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"testing"
+)
+
+func TestInstructions_CRUD(t *testing.T) {
+	// Create an instruction.
+	resp := authedPost(t, apiURL()+"/v1/instructions", map[string]string{
+		"body":  "Always reference PR numbers when discussing code changes.",
+		"scope": "#backend",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("create: expected 201, got %d: %s", resp.StatusCode, body)
+	}
+
+	var created map[string]any
+	json.NewDecoder(resp.Body).Decode(&created)
+	// Handle both "ID" (pre-json-tag-fix) and "id" (post-fix).
+	insID := stringField(created, "ID", "id")
+	if insID == "" {
+		t.Fatalf("expected instruction ID in response, got: %v", created)
+	}
+	t.Logf("created instruction: %s", insID)
+
+	// List instructions — should contain the one we created.
+	listResp := authedGet(t, apiURL()+"/v1/instructions")
+	defer listResp.Body.Close()
+	if listResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(listResp.Body)
+		t.Fatalf("list: expected 200, got %d: %s", listResp.StatusCode, body)
+	}
+
+	var listResult map[string]any
+	json.NewDecoder(listResp.Body).Decode(&listResult)
+	items, _ := listResult["items"].([]any)
+	if len(items) == 0 {
+		t.Fatal("list: expected at least 1 instruction")
+	}
+
+	// List with active filter.
+	activeResp := authedGet(t, apiURL()+"/v1/instructions?active=true")
+	defer activeResp.Body.Close()
+	if activeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(activeResp.Body)
+		t.Fatalf("list active: expected 200, got %d: %s", activeResp.StatusCode, body)
+	}
+
+	// Get the specific instruction.
+	getResp := authedGet(t, apiURL()+"/v1/instructions/"+insID)
+	defer getResp.Body.Close()
+	if getResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(getResp.Body)
+		t.Fatalf("get: expected 200, got %d: %s", getResp.StatusCode, body)
+	}
+
+	// Get non-existent instruction — should be 404.
+	notFoundResp := authedGet(t, apiURL()+"/v1/instructions/ins_nonexistent")
+	defer notFoundResp.Body.Close()
+	if notFoundResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("get nonexistent: expected 404, got %d", notFoundResp.StatusCode)
+	}
+
+	// Update the instruction body.
+	updateResp := authedPatch(t, apiURL()+"/v1/instructions/"+insID, map[string]any{
+		"body": "Updated: always reference PR numbers.",
+	})
+	defer updateResp.Body.Close()
+	if updateResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(updateResp.Body)
+		t.Fatalf("update body: expected 200, got %d: %s", updateResp.StatusCode, body)
+	}
+
+	// Update the instruction scope.
+	updateScopeResp := authedPatch(t, apiURL()+"/v1/instructions/"+insID, map[string]any{
+		"scope": "#incidents",
+	})
+	defer updateScopeResp.Body.Close()
+	if updateScopeResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(updateScopeResp.Body)
+		t.Fatalf("update scope: expected 200, got %d: %s", updateScopeResp.StatusCode, body)
+	}
+
+	// Toggle active to false.
+	toggleResp := authedPatch(t, apiURL()+"/v1/instructions/"+insID, map[string]any{
+		"active": false,
+	})
+	defer toggleResp.Body.Close()
+	if toggleResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(toggleResp.Body)
+		t.Fatalf("toggle active: expected 200, got %d: %s", toggleResp.StatusCode, body)
+	}
+
+	// List inactive — should find our toggled instruction.
+	inactiveResp := authedGet(t, apiURL()+"/v1/instructions?active=false")
+	defer inactiveResp.Body.Close()
+	if inactiveResp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(inactiveResp.Body)
+		t.Fatalf("list inactive: expected 200, got %d: %s", inactiveResp.StatusCode, body)
+	}
+
+	// Update non-existent — should be 404.
+	updateNotFoundResp := authedPatch(t, apiURL()+"/v1/instructions/ins_nonexistent", map[string]any{
+		"body": "nope",
+	})
+	defer updateNotFoundResp.Body.Close()
+	if updateNotFoundResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("update nonexistent: expected 404, got %d", updateNotFoundResp.StatusCode)
+	}
+
+	// Delete the instruction.
+	deleteResp := authedDelete(t, apiURL()+"/v1/instructions/"+insID)
+	defer deleteResp.Body.Close()
+	if deleteResp.StatusCode != http.StatusNoContent {
+		body, _ := io.ReadAll(deleteResp.Body)
+		t.Fatalf("delete: expected 204, got %d: %s", deleteResp.StatusCode, body)
+	}
+
+	// Verify deleted.
+	getAfterDelete := authedGet(t, apiURL()+"/v1/instructions/"+insID)
+	defer getAfterDelete.Body.Close()
+	if getAfterDelete.StatusCode != http.StatusNotFound {
+		t.Fatalf("get after delete: expected 404, got %d", getAfterDelete.StatusCode)
+	}
+
+	// Delete non-existent — should be 404.
+	deleteNotFoundResp := authedDelete(t, apiURL()+"/v1/instructions/ins_nonexistent")
+	defer deleteNotFoundResp.Body.Close()
+	if deleteNotFoundResp.StatusCode != http.StatusNotFound {
+		t.Fatalf("delete nonexistent: expected 404, got %d", deleteNotFoundResp.StatusCode)
+	}
+}
+
+func TestInstructions_CreateValidation(t *testing.T) {
+	// Empty body should fail.
+	resp := authedPost(t, apiURL()+"/v1/instructions", map[string]string{
+		"body": "",
+	})
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400 for empty body, got %d", resp.StatusCode)
+	}
+}
+
+func TestInstructions_Unauthorized(t *testing.T) {
+	resp, err := http.Get(apiURL() + "/v1/instructions")
+	if err != nil {
+		t.Fatalf("request failed: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized && resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 401 or 200 (auth disabled), got %d", resp.StatusCode)
+	}
+}
+
+// stringField extracts a string field from a map, trying multiple key names.
+func stringField(m map[string]any, keys ...string) string {
+	for _, k := range keys {
+		if v, ok := m[k].(string); ok && v != "" {
+			return v
+		}
+	}
+	return ""
+}


### PR DESCRIPTION
Implements #151 - moves ConnectedAccountStore, DraftStore, UserInstructionStore, and DraftFeedbackStore from in-memory to Postgres when a database is available.

Generated with [Claude Code](https://claude.ai/code)