### PR TITLE
fix(slack): log ephemeral delivery failures at error level with actionable messages

### DIFF
--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -432,7 +432,7 @@ func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, dr
 		Provider: &slackProvider,
 	})
 	if err != nil || len(accounts) == 0 {
-		s.log.Debug("ephemeral: no slack account for ephemeral delivery", "user_id", userID)
+		s.log.Error("ephemeral: no slack account — user must connect Slack via /v1/connect/slack", "user_id", userID)
 		return
 	}
 
@@ -441,25 +441,27 @@ func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, dr
 	// Get the token data from vault.
 	secret, err := s.vault.Get(ctx, acct.VaultPath())
 	if err != nil {
-		s.log.Debug("ephemeral: failed to get vault token", "user_id", userID, "error", err)
+		s.log.Error("ephemeral: failed to get vault token", "user_id", userID, "error", err)
 		return
 	}
 
 	var tokenData map[string]string
 	if err := json.Unmarshal(secret.Value, &tokenData); err != nil {
-		s.log.Debug("ephemeral: failed to parse token", "user_id", userID, "error", err)
+		s.log.Error("ephemeral: failed to parse token — reconnect Slack", "user_id", userID, "error", err)
 		return
 	}
 
 	botToken := tokenData["bot_access_token"]
 	if botToken == "" {
-		s.log.Debug("ephemeral: no bot token available", "user_id", userID)
+		s.log.Error("ephemeral: no bot token — Slack app needs chat:write bot scope, then reconnect Slack",
+			"user_id", userID,
+			"has_user_token", tokenData["access_token"] != "")
 		return
 	}
 
 	slackUserID := acct.ExternalUserID
 	if slackUserID == "" {
-		s.log.Debug("ephemeral: no slack user ID", "user_id", userID)
+		s.log.Error("ephemeral: no slack user ID on connected account — reconnect Slack", "user_id", userID)
 		return
 	}
 


### PR DESCRIPTION
## Summary

Failed ephemeral draft delivery was logged at Debug level — invisible in production and silently swallowed. If the bot token is missing, the Slack user ID is empty, or the vault token can't be read, the user never sees their draft in Slack with no indication of why.

Each failure case now logs at Error with a specific actionable message:

| Failure | Log message |
|---|---|
| No Slack connected account | "user must connect Slack via /v1/connect/slack" |
| Vault token retrieval fails | error detail included |
| Token JSON parse fails | "reconnect Slack" |
| No bot token in token data | "Slack app needs chat:write bot scope, then reconnect" |
| No Slack user ID on account | "reconnect Slack" |

This is permanent behavior — a failed ephemeral delivery is always an error worth surfacing, not a debug detail.

🤖 Generated with [Claude Code](https://claude.com/claude-code)