### PR TITLE
fix: redirect connected account OAuth callback to UI origin

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -194,6 +194,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		server.userAuthProviders = userAuthProviderStore
 		server.userKeyMaterials = userKeyMaterialStore
 		server.escrowTTL = authCfg.EscrowTTL()
+		server.uiRedirect = authCfg.UIRedirectURL
 
 		// Switch to Postgres-backed stores now that the database is available.
 		pgConnectedAccountStore := postgres.NewConnectedAccountStore(db)

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -67,6 +67,7 @@ type apiServer struct {
 	teeCfg             *config.TEEConfig          // nil when TEE is disabled
 	teeState           *teeState                  // nil when TEE is disabled
 	escrowTTL          time.Duration              // TTL for auto-escrowed credentials
+	uiRedirect         string                     // base URL for UI redirects (e.g. "https://app.withaileron.ai")
 	escrowIndex        sync.Map                   // vault path (string) -> escrow ID (string)
 	newID              func() string
 }

--- a/core/app/handlers_connected_accounts.go
+++ b/core/app/handlers_connected_accounts.go
@@ -271,7 +271,7 @@ func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
-		http.Redirect(w, r, "/settings/connected-accounts", http.StatusFound)
+		http.Redirect(w, r, s.uiRedirect+"/settings/connected-accounts", http.StatusFound)
 		return
 	}
 
@@ -293,7 +293,7 @@ func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
-	http.Redirect(w, r, "/settings/connected-accounts", http.StatusFound)
+	http.Redirect(w, r, s.uiRedirect+"/settings/connected-accounts", http.StatusFound)
 }
 
 // requestScheme returns "https" or "http" based on the request. It checks

--- a/core/app/handlers_connected_accounts_test.go
+++ b/core/app/handlers_connected_accounts_test.go
@@ -411,6 +411,94 @@ func TestConnectAccountCallback_StateMismatch(t *testing.T) {
 	}
 }
 
+func TestConnectAccountCallback_RedirectsToUIBaseURL(t *testing.T) {
+	// Regression test: after a successful OAuth callback the server must redirect
+	// to the UI origin (e.g. https://app.withaileron.ai), not to a relative path
+	// on the API host.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"authed_user": map[string]any{
+				"id":           "U123ABC",
+				"access_token": "xoxp-user-token-123",
+				"scope":        "channels:history",
+				"token_type":   "user",
+			},
+			"team": map[string]any{
+				"id":   "T001TEAM",
+				"name": "Test Workspace",
+			},
+		})
+	}))
+	defer tokenServer.Close()
+
+	srv := newConnectedAccountServerWithAuth()
+	srv.uiRedirect = "https://app.withaileron.ai"
+	slackSvc := account.NewSlackService("id", "secret", srv.connectedAccounts, srv.vault).
+		WithEndpoints("https://slack.com/oauth/v2/authorize", tokenServer.URL)
+	reg := account.NewRegistry()
+	reg.Register(slackSvc)
+	srv.accountService = reg
+
+	state := "test-state-123"
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/connect/slack/callback?code=valid&state="+state, "", userAClaims)
+	r.AddCookie(&http.Cookie{Name: "aileron_connect_state", Value: state})
+	srv.ConnectAccountCallback(w, r, "slack", api.ConnectAccountCallbackParams{Code: "valid", State: state})
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d: %s", w.Code, w.Body.String())
+	}
+	loc := w.Header().Get("Location")
+	want := "https://app.withaileron.ai/settings/connected-accounts"
+	if loc != want {
+		t.Errorf("Location = %q, want %q", loc, want)
+	}
+}
+
+func TestConnectAccountCallback_DefaultRedirectWhenUINotSet(t *testing.T) {
+	// When uiRedirect is empty (local dev), the redirect should be a relative path.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"authed_user": map[string]any{
+				"id":           "U123ABC",
+				"access_token": "xoxp-user-token-123",
+				"scope":        "channels:history",
+				"token_type":   "user",
+			},
+			"team": map[string]any{
+				"id":   "T001TEAM",
+				"name": "Test Workspace",
+			},
+		})
+	}))
+	defer tokenServer.Close()
+
+	srv := newConnectedAccountServerWithAuth()
+	// uiRedirect left as "" (default)
+	slackSvc := account.NewSlackService("id", "secret", srv.connectedAccounts, srv.vault).
+		WithEndpoints("https://slack.com/oauth/v2/authorize", tokenServer.URL)
+	reg := account.NewRegistry()
+	reg.Register(slackSvc)
+	srv.accountService = reg
+
+	state := "test-state-456"
+	w := httptest.NewRecorder()
+	r := mcpRequest("GET", "/v1/connect/slack/callback?code=valid&state="+state, "", userAClaims)
+	r.AddCookie(&http.Cookie{Name: "aileron_connect_state", Value: state})
+	srv.ConnectAccountCallback(w, r, "slack", api.ConnectAccountCallbackParams{Code: "valid", State: state})
+
+	if w.Code != http.StatusFound {
+		t.Fatalf("expected 302, got %d: %s", w.Code, w.Body.String())
+	}
+	loc := w.Header().Get("Location")
+	want := "/settings/connected-accounts"
+	if loc != want {
+		t.Errorf("Location = %q, want %q", loc, want)
+	}
+}
+
 func TestListConnectedAccounts_Unauthorized(t *testing.T) {
 	srv := newConnectedAccountServerWithAuth()
 	w := httptest.NewRecorder()


### PR DESCRIPTION
## Summary
- Connected account OAuth callbacks (Slack, Gmail, etc.) were redirecting to `/settings/connected-accounts` on the API host (`api.withaileron.ai`) instead of the UI host (`app.withaileron.ai`)
- Wired the existing `AILERON_UI_REDIRECT_URL` config into `apiServer` and prefixed the post-callback redirects with it — same pattern the auth handler already uses
- Added regression tests for both the configured and default (empty) cases

## Test plan
- [x] `TestConnectAccountCallback_RedirectsToUIBaseURL` — verifies redirect goes to `https://app.withaileron.ai/settings/connected-accounts`
- [x] `TestConnectAccountCallback_DefaultRedirectWhenUINotSet` — verifies relative path fallback for local dev
- [x] All existing `core/app` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)