### PR TITLE
feat: post draft previews and sent replies in Slack threads

### DIFF
--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -131,7 +131,7 @@ func (s *apiServer) handleApproveDraft(w http.ResponseWriter, r *http.Request) {
 		return // error already written
 	}
 
-	if err := s.sendDraftMessage(r.Context(), draft.UserID, draft.Channel, draft.DraftBody); err != nil {
+	if err := s.sendDraftMessage(r.Context(), draft.UserID, draft.Channel, draft.DraftBody, draft.MessageTS); err != nil {
 		s.log.Error("failed to send draft", "draft_id", draftID, "error", err)
 		writeError(w, http.StatusInternalServerError, "send_error", "failed to send message: "+err.Error())
 		return
@@ -168,7 +168,7 @@ func (s *apiServer) handleEditDraft(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	if err := s.sendDraftMessage(r.Context(), draft.UserID, draft.Channel, req.Body); err != nil {
+	if err := s.sendDraftMessage(r.Context(), draft.UserID, draft.Channel, req.Body, draft.MessageTS); err != nil {
 		s.log.Error("failed to send edited draft", "draft_id", draftID, "error", err)
 		writeError(w, http.StatusInternalServerError, "send_error", "failed to send message: "+err.Error())
 		return
@@ -242,10 +242,11 @@ type EphemeralPoster func(ctx context.Context, msg comms.SlackDraftMessage) erro
 
 // SlackSender is the function used to send messages to Slack.
 // Defaults to comms.SendSlackMessage. Override in tests.
-type SlackSender func(ctx context.Context, token, channel, body string) error
+type SlackSender func(ctx context.Context, token, channel, body, threadTS string) error
 
 // sendDraftMessage sends a message to Slack using the user's connected account token.
-func (s *apiServer) sendDraftMessage(ctx context.Context, userID, channel, body string) error {
+// When threadTS is non-empty the message is posted as a threaded reply.
+func (s *apiServer) sendDraftMessage(ctx context.Context, userID, channel, body, threadTS string) error {
 	slackProvider := model.ConnectedAccountProviderSlack
 	accounts, err := s.connectedAccounts.List(ctx, store.ConnectedAccountFilter{
 		UserID:   userID,
@@ -277,7 +278,7 @@ func (s *apiServer) sendDraftMessage(ctx context.Context, userID, channel, body 
 	if sender == nil {
 		sender = comms.SendSlackMessage
 	}
-	return sender(ctx, token, channel, body)
+	return sender(ctx, token, channel, body, threadTS)
 }
 
 // extractDraftID extracts the draft ID from /v1/drafts/{draft_id}
@@ -477,6 +478,7 @@ func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, dr
 		Author:   draft.Author,
 		Body:     draft.MessageBody,
 		Draft:    draft.DraftBody,
+		ThreadTS: draft.MessageTS,
 	})
 	if err != nil {
 		s.log.Error("ephemeral: failed to post", "user_id", userID, "draft_id", draft.ID, "error", err)

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -254,6 +254,79 @@ func TestApproveDraft_Success(t *testing.T) {
 	}
 }
 
+func TestApproveDraft_PassesThreadTS(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	var capturedThreadTS string
+	srv.slackSender = func(_ context.Context, _, _, _, threadTS string) error {
+		capturedThreadTS = threadTS
+		return nil
+	}
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/approve", "", userAClaims)
+	srv.handleApproveDraft(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if capturedThreadTS != "1234567890.123456" {
+		t.Errorf("expected threadTS = %q, got %q", "1234567890.123456", capturedThreadTS)
+	}
+}
+
+func TestEditDraft_PassesThreadTS(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
+
+	var capturedThreadTS string
+	srv.slackSender = func(_ context.Context, _, _, _, threadTS string) error {
+		capturedThreadTS = threadTS
+		return nil
+	}
+
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/drafts/dft_1/edit", `{"body":"edited reply"}`, userAClaims)
+	srv.handleEditDraft(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+	if capturedThreadTS != "1234567890.123456" {
+		t.Errorf("expected threadTS = %q, got %q", "1234567890.123456", capturedThreadTS)
+	}
+}
+
+func TestDeliverEphemeralDraft_PassesThreadTS(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	ctx := context.Background()
+
+	var capturedThreadTS string
+	srv.ephemeralPoster = func(_ context.Context, msg comms.SlackDraftMessage) error {
+		capturedThreadTS = msg.ThreadTS
+		return nil
+	}
+
+	draft := model.Draft{
+		ID:        "dft_1",
+		UserID:    "usr_a",
+		Status:    model.DraftStatusPending,
+		Service:   "slack",
+		Channel:   "C0BACKEND",
+		Author:    "Sarah",
+		DraftBody: "Draft reply",
+		MessageTS: "1234567890.123456",
+	}
+	srv.deliverEphemeralDraft(ctx, "usr_a", draft)
+
+	if capturedThreadTS != "1234567890.123456" {
+		t.Errorf("expected ThreadTS = %q, got %q", "1234567890.123456", capturedThreadTS)
+	}
+}
+
 func TestApproveDraft_OwnershipCheck(t *testing.T) {
 	srv := newDraftsTestServerWithSend()
 	ctx := context.Background()

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -222,7 +222,7 @@ func newDraftsTestServerWithSend() *apiServer {
 	})
 	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test","bot_access_token":"xoxb-test"}`), vault.Metadata{})
 	// Mock sender so we don't call real Slack.
-	srv.slackSender = func(_ context.Context, token, channel, body string) error {
+	srv.slackSender = func(_ context.Context, token, channel, body, threadTS string) error {
 		return nil
 	}
 	// Mock ephemeral poster.
@@ -296,7 +296,7 @@ func TestApproveDraft_NotFound(t *testing.T) {
 
 func TestApproveDraft_SendFails(t *testing.T) {
 	srv := newDraftsTestServerWithSend()
-	srv.slackSender = func(_ context.Context, _, _, _ string) error {
+	srv.slackSender = func(_ context.Context, _, _, _, _ string) error {
 		return fmt.Errorf("slack API unavailable")
 	}
 	ctx := context.Background()
@@ -313,7 +313,7 @@ func TestApproveDraft_SendFails(t *testing.T) {
 
 func TestApproveDraft_NoSlackAccount(t *testing.T) {
 	srv := newDraftsTestServer() // no connected account seeded
-	srv.slackSender = func(_ context.Context, _, _, _ string) error { return nil }
+	srv.slackSender = func(_ context.Context, _, _, _, _ string) error { return nil }
 	ctx := context.Background()
 	seedDraft(ctx, srv.drafts, "dft_1", "usr_a", model.DraftStatusPending)
 
@@ -354,7 +354,7 @@ func TestEditDraft_Success(t *testing.T) {
 
 func TestEditDraft_SendFails(t *testing.T) {
 	srv := newDraftsTestServerWithSend()
-	srv.slackSender = func(_ context.Context, _, _, _ string) error {
+	srv.slackSender = func(_ context.Context, _, _, _, _ string) error {
 		return fmt.Errorf("slack error")
 	}
 	ctx := context.Background()
@@ -464,7 +464,7 @@ func TestSendDraftMessage_BadTokenJSON(t *testing.T) {
 	// Store invalid JSON as token.
 	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte("not-json"), vault.Metadata{})
 
-	err := srv.sendDraftMessage(ctx, "usr_a", "C123", "hello")
+	err := srv.sendDraftMessage(ctx, "usr_a", "C123", "hello", "")
 	if err == nil {
 		t.Fatal("expected error for bad token JSON")
 	}
@@ -482,7 +482,7 @@ func TestSendDraftMessage_EmptyAccessToken(t *testing.T) {
 	})
 	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"token_type":"user"}`), vault.Metadata{})
 
-	err := srv.sendDraftMessage(ctx, "usr_a", "C123", "hello")
+	err := srv.sendDraftMessage(ctx, "usr_a", "C123", "hello", "")
 	if err == nil {
 		t.Fatal("expected error for missing access_token")
 	}

--- a/core/app/handlers_slack_interactions.go
+++ b/core/app/handlers_slack_interactions.go
@@ -102,7 +102,7 @@ func (s *apiServer) processInteraction(actionID, draftID string, payload slackIn
 
 	switch actionID {
 	case "approve_draft":
-		if err := s.sendDraftMessage(ctx, draft.UserID, draft.Channel, draft.DraftBody); err != nil {
+		if err := s.sendDraftMessage(ctx, draft.UserID, draft.Channel, draft.DraftBody, draft.MessageTS); err != nil {
 			s.log.Error("interaction: failed to send approved draft", "draft_id", draftID, "error", err)
 			s.respondToInteraction(payload.ResponseURL, "Failed to send: "+err.Error())
 			return

--- a/core/app/handlers_slack_interactions_test.go
+++ b/core/app/handlers_slack_interactions_test.go
@@ -33,7 +33,7 @@ func newInteractionTestServer() *apiServer {
 		users:              &stubUserStore{},
 		newID:              func() string { return "test-id" },
 	}
-	srv.slackSender = func(_ context.Context, _, _, _ string) error { return nil }
+	srv.slackSender = func(_ context.Context, _, _, _, _ string) error { return nil }
 	return srv
 }
 

--- a/core/comms/slack_ephemeral.go
+++ b/core/comms/slack_ephemeral.go
@@ -17,6 +17,7 @@ type SlackDraftMessage struct {
 	Author   string // who sent the original message
 	Body     string // the original message text
 	Draft    string // the AI-generated draft reply
+	ThreadTS string // original message timestamp for threading (empty = top-level)
 }
 
 // PostEphemeralDraft posts an ephemeral message with the draft and
@@ -35,9 +36,14 @@ func PostEphemeralDraft(ctx context.Context, msg SlackDraftMessage) error {
 	client := slack.New(msg.BotToken)
 	blocks := BuildDraftBlocks(msg)
 
-	_, err := client.PostEphemeralContext(ctx, msg.Channel, msg.UserID,
+	opts := []slack.MsgOption{
 		slack.MsgOptionBlocks(blocks...),
-	)
+	}
+	if msg.ThreadTS != "" {
+		opts = append(opts, slack.MsgOptionTS(msg.ThreadTS))
+	}
+
+	_, err := client.PostEphemeralContext(ctx, msg.Channel, msg.UserID, opts...)
 	return err
 }
 

--- a/core/comms/slack_send.go
+++ b/core/comms/slack_send.go
@@ -11,8 +11,9 @@ import (
 // Unlike SlackListener.Send() which requires a persistent Socket Mode connection,
 // this creates a fresh client from the provided OAuth token, posts the message,
 // and discards the client. Suitable for cloud-mode where no persistent Slack
-// connection exists.
-func SendSlackMessage(ctx context.Context, token, channel, body string) error {
+// connection exists. When threadTS is non-empty the message is posted as a
+// threaded reply.
+func SendSlackMessage(ctx context.Context, token, channel, body, threadTS string) error {
 	if token == "" {
 		return fmt.Errorf("slack: token is required")
 	}
@@ -20,9 +21,14 @@ func SendSlackMessage(ctx context.Context, token, channel, body string) error {
 		return fmt.Errorf("slack: channel is required")
 	}
 
-	client := slack.New(token)
-	_, _, err := client.PostMessageContext(ctx, channel,
+	opts := []slack.MsgOption{
 		slack.MsgOptionText(body, false),
-	)
+	}
+	if threadTS != "" {
+		opts = append(opts, slack.MsgOptionTS(threadTS))
+	}
+
+	client := slack.New(token)
+	_, _, err := client.PostMessageContext(ctx, channel, opts...)
 	return err
 }

--- a/core/comms/slack_send_test.go
+++ b/core/comms/slack_send_test.go
@@ -8,14 +8,14 @@ import (
 )
 
 func TestSendSlackMessage_EmptyToken(t *testing.T) {
-	err := comms.SendSlackMessage(context.Background(), "", "C123", "hello")
+	err := comms.SendSlackMessage(context.Background(), "", "C123", "hello", "")
 	if err == nil {
 		t.Fatal("expected error for empty token")
 	}
 }
 
 func TestSendSlackMessage_EmptyChannel(t *testing.T) {
-	err := comms.SendSlackMessage(context.Background(), "xoxp-test", "", "hello")
+	err := comms.SendSlackMessage(context.Background(), "xoxp-test", "", "hello", "")
 	if err == nil {
 		t.Fatal("expected error for empty channel")
 	}


### PR DESCRIPTION
## Summary
- Ephemeral draft previews and approved/edited replies now appear in the same Slack thread as the original message
- `SendSlackMessage` and `PostEphemeralDraft` accept `threadTS` — when non-empty, passed as `MsgOptionTS` to the Slack API
- The `MessageTS` already captured from the Slack event is threaded through `sendDraftMessage` and the ephemeral poster
- Top-level messages (empty `threadTS`) continue to work as before

## Test plan
- [x] All `core/...` tests pass (27 packages)
- [x] Existing draft approve/edit/discard tests updated for new signature
- [x] `SendSlackMessage` validation tests updated

🤖 Generated with [Claude Code](https://claude.com/claude-code)