### PR TITLE
fix: upsert connected accounts on reconnect instead of failing on duplicate

### DIFF
--- a/core/account/github_service.go
+++ b/core/account/github_service.go
@@ -154,11 +154,12 @@ func (s *GitHubAccountService) HandleCallback(ctx context.Context, _ model.Conne
 		return nil, fmt.Errorf("storing token in vault: %w", err)
 	}
 
-	if err := s.accounts.Create(ctx, account); err != nil {
-		return nil, fmt.Errorf("creating account record: %w", err)
+	upserted, err := s.accounts.Upsert(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("upserting account record: %w", err)
 	}
 
-	return &CallbackResult{Account: account}, nil
+	return &CallbackResult{Account: upserted}, nil
 }
 
 func (s *GitHubAccountService) List(ctx context.Context, userID string) ([]model.ConnectedAccount, error) {

--- a/core/account/service.go
+++ b/core/account/service.go
@@ -233,12 +233,13 @@ func (s *GoogleService) HandleCallback(ctx context.Context, provider model.Conne
 		return nil, fmt.Errorf("storing token in vault: %w", err)
 	}
 
-	// Create the account record.
-	if err := s.accounts.Create(ctx, account); err != nil {
-		return nil, fmt.Errorf("creating account record: %w", err)
+	// Upsert the account record — allows reconnecting to refresh tokens/scopes.
+	upserted, err := s.accounts.Upsert(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("upserting account record: %w", err)
 	}
 
-	return &CallbackResult{Account: account}, nil
+	return &CallbackResult{Account: upserted}, nil
 }
 
 func (s *GoogleService) List(ctx context.Context, userID string) ([]model.ConnectedAccount, error) {

--- a/core/account/slack_service.go
+++ b/core/account/slack_service.go
@@ -193,11 +193,12 @@ func (s *SlackService) HandleCallback(ctx context.Context, _ model.ConnectedAcco
 		return nil, fmt.Errorf("storing token in vault: %w", err)
 	}
 
-	if err := s.accounts.Create(ctx, account); err != nil {
-		return nil, fmt.Errorf("creating account record: %w", err)
+	upserted, err := s.accounts.Upsert(ctx, account)
+	if err != nil {
+		return nil, fmt.Errorf("upserting account record: %w", err)
 	}
 
-	return &CallbackResult{Account: account}, nil
+	return &CallbackResult{Account: upserted}, nil
 }
 
 func (s *SlackService) List(ctx context.Context, userID string) ([]model.ConnectedAccount, error) {

--- a/core/app/handlers_connected_accounts.go
+++ b/core/app/handlers_connected_accounts.go
@@ -69,12 +69,13 @@ func (s *apiServer) handleCreateConnectedAccount(w http.ResponseWriter, r *http.
 		}
 	}
 
-	if err := s.connectedAccounts.Create(r.Context(), acct); err != nil {
+	upserted, err := s.connectedAccounts.Upsert(r.Context(), acct)
+	if err != nil {
 		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
 		return
 	}
 
-	writeJSON(w, http.StatusCreated, connectedAccountToAPI(acct))
+	writeJSON(w, http.StatusCreated, connectedAccountToAPI(upserted))
 }
 
 func (s *apiServer) ListConnectedAccounts(w http.ResponseWriter, r *http.Request) {
@@ -320,8 +321,8 @@ func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Reques
 			writeError(w, http.StatusInternalServerError, "vault_error", "failed to store encrypted token")
 			return
 		}
-		if err := s.connectedAccounts.Create(r.Context(), acct); err != nil {
-			writeError(w, http.StatusInternalServerError, "store_error", "failed to create account record")
+		if _, err := s.connectedAccounts.Upsert(r.Context(), acct); err != nil {
+			writeError(w, http.StatusInternalServerError, "store_error", "failed to upsert account record")
 			return
 		}
 

--- a/core/store/mem/connected_account.go
+++ b/core/store/mem/connected_account.go
@@ -26,6 +26,22 @@ func (s *ConnectedAccountStore) Create(_ context.Context, account model.Connecte
 	return nil
 }
 
+func (s *ConnectedAccountStore) Upsert(_ context.Context, account model.ConnectedAccount) (model.ConnectedAccount, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	// Check if an account already exists for this user+provider.
+	for id, existing := range s.accounts {
+		if existing.UserID == account.UserID && existing.Provider == account.Provider {
+			account.ID = id
+			account.CreatedAt = existing.CreatedAt
+			s.accounts[id] = account
+			return account, nil
+		}
+	}
+	s.accounts[account.ID] = account
+	return account, nil
+}
+
 func (s *ConnectedAccountStore) Get(_ context.Context, accountID string) (model.ConnectedAccount, error) {
 	s.mu.RLock()
 	defer s.mu.RUnlock()

--- a/core/store/mem/connected_account_test.go
+++ b/core/store/mem/connected_account_test.go
@@ -173,3 +173,64 @@ func TestConnectedAccountStore_DeleteNotFound(t *testing.T) {
 	}
 }
 
+func TestConnectedAccountStore_Upsert_Insert(t *testing.T) {
+	s := mem.NewConnectedAccountStore()
+	ctx := context.Background()
+
+	acct := newTestAccount("conn_1", "usr_1", model.ConnectedAccountProviderSlack)
+	result, err := s.Upsert(ctx, acct)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if result.ID != "conn_1" {
+		t.Errorf("expected conn_1, got %s", result.ID)
+	}
+
+	// Should be in the store.
+	got, err := s.Get(ctx, "conn_1")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if got.UserID != "usr_1" {
+		t.Errorf("expected usr_1, got %s", got.UserID)
+	}
+}
+
+func TestConnectedAccountStore_Upsert_Update(t *testing.T) {
+	// Regression test: reconnecting a provider (e.g. Slack) previously failed
+	// with "duplicate key value violates unique constraint" because
+	// HandleCallback always called Create. Now it calls Upsert which updates
+	// the existing record instead of failing.
+	s := mem.NewConnectedAccountStore()
+	ctx := context.Background()
+
+	// First connection.
+	acct1 := newTestAccount("conn_1", "usr_1", model.ConnectedAccountProviderSlack)
+	acct1.ExternalUserID = "U_OLD"
+	s.Upsert(ctx, acct1)
+
+	// Reconnect — same user+provider, different metadata.
+	acct2 := newTestAccount("conn_new", "usr_1", model.ConnectedAccountProviderSlack)
+	acct2.ExternalUserID = "U_NEW"
+	result, err := s.Upsert(ctx, acct2)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	// Should reuse the original ID, not create a new one.
+	if result.ID != "conn_1" {
+		t.Errorf("expected original ID conn_1, got %s", result.ID)
+	}
+
+	// Metadata should be updated.
+	if result.ExternalUserID != "U_NEW" {
+		t.Errorf("expected U_NEW, got %s", result.ExternalUserID)
+	}
+
+	// Should still be only 1 account in the store.
+	all, _ := s.List(ctx, store.ConnectedAccountFilter{UserID: "usr_1"})
+	if len(all) != 1 {
+		t.Fatalf("expected 1 account after upsert, got %d", len(all))
+	}
+}
+

--- a/core/store/postgres/connected_account.go
+++ b/core/store/postgres/connected_account.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"time"
 
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/store"
@@ -34,6 +35,30 @@ func (s *ConnectedAccountStore) Create(ctx context.Context, a model.ConnectedAcc
 		a.CreatedAt, a.UpdatedAt,
 	)
 	return err
+}
+
+func (s *ConnectedAccountStore) Upsert(ctx context.Context, a model.ConnectedAccount) (model.ConnectedAccount, error) {
+	scopes, _ := json.Marshal(a.Scopes)
+	var id string
+	var createdAt time.Time
+	err := s.db.Pool.QueryRow(ctx,
+		`INSERT INTO connected_accounts
+			(`+connectedAccountColumns+`)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8,$9)
+		 ON CONFLICT (user_id, provider) DO UPDATE SET
+			scopes = $4, status = $5, external_user_id = $6,
+			external_team_id = $7, updated_at = $9
+		 RETURNING id, created_at`,
+		a.ID, a.UserID, string(a.Provider), string(scopes),
+		string(a.Status), a.ExternalUserID, a.ExternalTeamID,
+		a.CreatedAt, a.UpdatedAt,
+	).Scan(&id, &createdAt)
+	if err != nil {
+		return model.ConnectedAccount{}, err
+	}
+	a.ID = id
+	a.CreatedAt = createdAt
+	return a, nil
 }
 
 func (s *ConnectedAccountStore) Get(ctx context.Context, accountID string) (model.ConnectedAccount, error) {

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -189,6 +189,11 @@ type SSOConfigStore interface {
 // etc.) to Aileron so it can execute irreversible actions on the user's behalf.
 type ConnectedAccountStore interface {
 	Create(ctx context.Context, account model.ConnectedAccount) error
+	// Upsert creates or updates a connected account by user+provider.
+	// If an account already exists for this user+provider, it updates the
+	// metadata (scopes, external IDs, timestamps) and returns the existing ID.
+	// Used by OAuth callbacks when a user reconnects.
+	Upsert(ctx context.Context, account model.ConnectedAccount) (model.ConnectedAccount, error)
 	Get(ctx context.Context, accountID string) (model.ConnectedAccount, error)
 	List(ctx context.Context, filter ConnectedAccountFilter) ([]model.ConnectedAccount, error)
 	Delete(ctx context.Context, accountID string) error

--- a/test/integration/connected_accounts_test.go
+++ b/test/integration/connected_accounts_test.go
@@ -239,3 +239,64 @@ func TestConnectedAccounts_Unauthorized(t *testing.T) {
 		t.Fatalf("expected 401 or 200 (auth disabled), got %d", resp.StatusCode)
 	}
 }
+
+func TestConnectedAccounts_ReconnectDoesNotFail(t *testing.T) {
+	// Regression test: reconnecting a provider (same user+provider) previously
+	// failed with "duplicate key value violates unique constraint". Now it
+	// upserts — updates the existing record instead of failing.
+
+	// First connection.
+	resp1 := authedPost(t, apiURL()+"/v1/connected-accounts", map[string]any{
+		"provider":         "slack",
+		"scopes":           []string{"channels:history"},
+		"external_user_id": "U_RECONNECT",
+		"external_team_id": "T_RECONNECT",
+		"token": map[string]string{
+			"access_token": "xoxp-old",
+		},
+	})
+	defer resp1.Body.Close()
+	if resp1.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp1.Body)
+		t.Fatalf("first create: expected 201, got %d: %s", resp1.StatusCode, body)
+	}
+	var created1 map[string]any
+	json.NewDecoder(resp1.Body).Decode(&created1)
+	id1 := stringField(created1, "id")
+
+	// Second connection — same provider. Should NOT fail.
+	resp2 := authedPost(t, apiURL()+"/v1/connected-accounts", map[string]any{
+		"provider":         "slack",
+		"scopes":           []string{"channels:history", "search:read"},
+		"external_user_id": "U_RECONNECT_NEW",
+		"external_team_id": "T_RECONNECT",
+		"token": map[string]string{
+			"access_token": "xoxp-new",
+		},
+	})
+	defer resp2.Body.Close()
+	if resp2.StatusCode != http.StatusCreated {
+		body, _ := io.ReadAll(resp2.Body)
+		t.Fatalf("reconnect: expected 201, got %d: %s", resp2.StatusCode, body)
+	}
+
+	// Should still be only 1 Slack account.
+	listResp := authedGet(t, apiURL()+"/v1/connected-accounts?provider=slack")
+	defer listResp.Body.Close()
+	var listResult map[string]any
+	json.NewDecoder(listResp.Body).Decode(&listResult)
+	items, _ := listResult["items"].([]any)
+	slackCount := 0
+	for _, item := range items {
+		m, _ := item.(map[string]any)
+		if stringField(m, "provider") == "slack" {
+			slackCount++
+		}
+	}
+	if slackCount != 1 {
+		t.Fatalf("expected 1 Slack account after reconnect, got %d", slackCount)
+	}
+
+	// Clean up.
+	authedDelete(t, apiURL()+"/v1/connected-accounts/"+id1).Body.Close()
+}


### PR DESCRIPTION
## Summary

Reconnecting a provider (e.g. re-authorizing Slack for new scopes) failed with `duplicate key value violates unique constraint`. The OAuth callback always called `Create`, which fails when a connection already exists for that user+provider.

Now uses `Upsert` — if an account exists for this user+provider, updates the metadata (scopes, external IDs, timestamps) and preserves the original ID. If not, creates a new one.

All three account services (Slack, Google, GitHub) and the programmatic create endpoint now use `Upsert`.

## Regression tests

- **Unit:** Upsert insert (new account), Upsert update (same user+provider reuses ID, updates metadata, only 1 account in store)
- **Integration:** Create twice with same provider, verify no error and only 1 account exists

Fixes: #157

🤖 Generated with [Claude Code](https://claude.com/claude-code)