### PR TITLE
feat: externalize system prompts into AILERON.md

### DIFF
--- a/AILERON.md
+++ b/AILERON.md
@@ -1,0 +1,25 @@
+# System Prompt
+
+You draft reply messages on behalf of a user. Your output will be sent directly as a message in a communication channel (e.g. Slack) — the user will review it first but your output IS the message text.
+
+CRITICAL: Output ONLY the message text that would be sent. Nothing else. No commentary, no notes, no warnings, no explanations, no "Here's a draft:", no markdown headers, no "Note:" sections. The entire output must be something that could be pasted directly into a chat message and sent.
+
+Good output: "No, the JWT claims are unchanged. PR #247 only moves validation into middleware."
+Bad output: "Here's a draft reply:\n\nNo, the JWT claims are unchanged.\n\n Note: I'm not certain about this."
+
+# Draft Guidelines
+
+- Be direct and specific. Reference concrete details (PR numbers, file names, code, dates).
+- Match the formality and tone of the channel and the message.
+- If you have access to tools, use them to look up relevant context before drafting.
+- Keep replies concise unless the question requires a detailed explanation.
+- Never include caveats, disclaimers, or meta-commentary about the draft itself.
+
+# Low Context Fallback
+
+When insufficient context is available to write a useful reply, write a short honest reply like:
+"Not sure off the top of my head — let me check and get back to you."
+
+# Tool Use Instructions
+
+If you have access to tools, use them to look up relevant context before drafting. Prefer specific lookups over broad searches.

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -226,7 +226,8 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		// LLM-powered draft generation pipeline.
 		if authCfg.LLMEnabled() {
 			llmClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModel)
-			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log)
+			sysPrompt := draft.LoadSystemPrompt()
+			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log, sysPrompt)
 			log.Info("enabled cloud draft generation", "model", authCfg.LLMModel)
 		}
 

--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -19,21 +19,6 @@ import (
 	"github.com/ALRubinger/aileron/core/vault"
 )
 
-const systemPrompt = `You draft reply messages on behalf of a user. Your output will be sent directly as a message in a communication channel (e.g. Slack) — the user will review it first but your output IS the message text.
-
-CRITICAL: Output ONLY the message text that would be sent. Nothing else. No commentary, no notes, no warnings, no explanations, no "Here's a draft:", no markdown headers, no "Note:" sections. The entire output must be something that could be pasted directly into a chat message and sent.
-
-Good output: "No, the JWT claims are unchanged. PR #247 only moves validation into middleware."
-Bad output: "Here's a draft reply:\n\nNo, the JWT claims are unchanged.\n\n⚠️ Note: I'm not certain about this."
-
-Guidelines:
-- Be direct and specific. Reference concrete details (PR numbers, file names, code, dates).
-- Match the formality and tone of the channel and the message.
-- If you have access to tools, use them to look up relevant context before drafting.
-- Keep replies concise unless the question requires a detailed explanation.
-- If you don't have enough context to write a useful reply, write a short honest reply like "Not sure off the top of my head — let me check and get back to you."
-- Never include caveats, disclaimers, or meta-commentary about the draft itself.`
-
 // Pipeline orchestrates draft generation for incoming messages.
 type Pipeline struct {
 	llm               llm.Client
@@ -42,9 +27,11 @@ type Pipeline struct {
 	instructions      store.UserInstructionStore
 	vault             vault.Vault
 	log               *slog.Logger
+	systemPrompt      string
 }
 
-// NewPipeline creates a draft generation pipeline.
+// NewPipeline creates a draft generation pipeline. The systemPrompt is the
+// base prompt loaded from AILERON.md (or the hardcoded default).
 func NewPipeline(
 	llmClient llm.Client,
 	sourceReg *source.Registry,
@@ -52,6 +39,7 @@ func NewPipeline(
 	instructions store.UserInstructionStore,
 	v vault.Vault,
 	log *slog.Logger,
+	systemPrompt string,
 ) *Pipeline {
 	return &Pipeline{
 		llm:               llmClient,
@@ -60,6 +48,7 @@ func NewPipeline(
 		instructions:      instructions,
 		vault:             v,
 		log:               log,
+		systemPrompt:      systemPrompt,
 	}
 }
 
@@ -129,7 +118,7 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 // the user's active instructions. Instructions are the highest-priority
 // context — they override learned patterns and behavioral model inferences.
 func (p *Pipeline) assembleSystemPrompt(ctx context.Context, userID string) (string, error) {
-	prompt := systemPrompt
+	prompt := p.systemPrompt
 
 	if p.instructions == nil {
 		return prompt, nil

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -54,7 +54,7 @@ func TestPipeline_GenerateDraft_Simple(t *testing.T) {
 	v := vault.NewMemVault()
 	sourceReg := source.NewRegistry()
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default())
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), "test system prompt")
 
 	draftText, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID:      "msg_1",
@@ -109,7 +109,7 @@ func TestPipeline_GenerateDraft_WithTools(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default())
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), "test system prompt")
 
 	draftText, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID:      "msg_1",
@@ -163,7 +163,7 @@ func TestPipeline_GenerateDraft_ToolExecutor(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default())
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), "test system prompt")
 
 	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -198,7 +198,7 @@ func TestPipeline_GenerateDraft_NoConnectedAccounts(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default())
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), "test system prompt")
 
 	draftText, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -238,7 +238,7 @@ func TestPipeline_GenerateDraft_WithInstructions(t *testing.T) {
 	})
 
 	sourceReg := source.NewRegistry()
-	p := draft.NewPipeline(mock, sourceReg, accounts, instructions, v, slog.Default())
+	p := draft.NewPipeline(mock, sourceReg, accounts, instructions, v, slog.Default(), "test system prompt")
 
 	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -271,7 +271,7 @@ func TestPipeline_GenerateDraft_NoInstructions(t *testing.T) {
 		response: &llm.GenerateResponse{Text: "Draft without instructions"},
 	}
 
-	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default())
+	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), "test system prompt")
 
 	_, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -291,7 +291,7 @@ func TestPipeline_GenerateDraft_LLMError(t *testing.T) {
 		err: context.DeadlineExceeded,
 	}
 
-	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default())
+	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), "test system prompt")
 
 	_, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",

--- a/core/draft/prompt.go
+++ b/core/draft/prompt.go
@@ -1,0 +1,43 @@
+package draft
+
+import (
+	"os"
+	"strings"
+)
+
+// defaultSystemPrompt is the fallback when AILERON.md is missing.
+const defaultSystemPrompt = `You draft reply messages on behalf of a user. Your output will be sent directly as a message in a communication channel (e.g. Slack) — the user will review it first but your output IS the message text.
+
+CRITICAL: Output ONLY the message text that would be sent. Nothing else. No commentary, no notes, no warnings, no explanations, no "Here's a draft:", no markdown headers, no "Note:" sections. The entire output must be something that could be pasted directly into a chat message and sent.
+
+Good output: "No, the JWT claims are unchanged. PR #247 only moves validation into middleware."
+Bad output: "Here's a draft reply:\n\nNo, the JWT claims are unchanged.\n\n Note: I'm not certain about this."
+
+Guidelines:
+- Be direct and specific. Reference concrete details (PR numbers, file names, code, dates).
+- Match the formality and tone of the channel and the message.
+- If you have access to tools, use them to look up relevant context before drafting.
+- Keep replies concise unless the question requires a detailed explanation.
+- If you don't have enough context to write a useful reply, write a short honest reply like "Not sure off the top of my head — let me check and get back to you."
+- Never include caveats, disclaimers, or meta-commentary about the draft itself.`
+
+// LoadSystemPrompt reads the AILERON.md file and returns its contents as the
+// system prompt. If the file does not exist, it returns the hardcoded default.
+// The path can be overridden via the AILERON_PROMPT_FILE environment variable.
+func LoadSystemPrompt() string {
+	path := os.Getenv("AILERON_PROMPT_FILE")
+	if path == "" {
+		path = "AILERON.md"
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return defaultSystemPrompt
+	}
+
+	content := strings.TrimSpace(string(data))
+	if content == "" {
+		return defaultSystemPrompt
+	}
+	return content
+}

--- a/core/draft/prompt_test.go
+++ b/core/draft/prompt_test.go
@@ -1,0 +1,67 @@
+package draft
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadSystemPrompt_FromFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AILERON.md")
+	os.WriteFile(path, []byte("# Custom Prompt\n\nBe helpful."), 0644)
+
+	t.Setenv("AILERON_PROMPT_FILE", path)
+
+	got := LoadSystemPrompt()
+	if got != "# Custom Prompt\n\nBe helpful." {
+		t.Errorf("expected custom prompt, got %q", got)
+	}
+}
+
+func TestLoadSystemPrompt_FallbackWhenMissing(t *testing.T) {
+	t.Setenv("AILERON_PROMPT_FILE", "/nonexistent/AILERON.md")
+
+	got := LoadSystemPrompt()
+	if got != defaultSystemPrompt {
+		t.Error("expected default prompt when file is missing")
+	}
+}
+
+func TestLoadSystemPrompt_FallbackWhenEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AILERON.md")
+	os.WriteFile(path, []byte("   \n  "), 0644)
+
+	t.Setenv("AILERON_PROMPT_FILE", path)
+
+	got := LoadSystemPrompt()
+	if got != defaultSystemPrompt {
+		t.Error("expected default prompt when file is empty/whitespace")
+	}
+}
+
+func TestLoadSystemPrompt_DefaultPath(t *testing.T) {
+	// Unset the env var — should look for AILERON.md in working dir.
+	t.Setenv("AILERON_PROMPT_FILE", "")
+
+	// From the test working directory, AILERON.md doesn't exist,
+	// so it should fall back to the default.
+	got := LoadSystemPrompt()
+	if got != defaultSystemPrompt {
+		t.Error("expected default prompt when AILERON.md not in working dir")
+	}
+}
+
+func TestLoadSystemPrompt_TrimsWhitespace(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AILERON.md")
+	os.WriteFile(path, []byte("\n  Custom prompt content  \n\n"), 0644)
+
+	t.Setenv("AILERON_PROMPT_FILE", path)
+
+	got := LoadSystemPrompt()
+	if got != "Custom prompt content" {
+		t.Errorf("expected trimmed content, got %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- Moves the hardcoded draft system prompt from a Go const into `AILERON.md` at the repo root
- Loaded at startup by `LoadSystemPrompt()` and passed to the draft pipeline
- Falls back to hardcoded default when file is missing or empty
- Path configurable via `AILERON_PROMPT_FILE` env var
- Prompt iteration is now a markdown edit + deploy instead of code change + build + deploy

Phase 2 (per-org database overrides) tracked in #172.

Closes #154

## Test plan
- [x] `TestLoadSystemPrompt_FromFile` — loads custom prompt from file
- [x] `TestLoadSystemPrompt_FallbackWhenMissing` — falls back when file doesn't exist
- [x] `TestLoadSystemPrompt_FallbackWhenEmpty` — falls back on empty/whitespace file
- [x] `TestLoadSystemPrompt_DefaultPath` — uses AILERON.md in working dir by default
- [x] `TestLoadSystemPrompt_TrimsWhitespace` — strips leading/trailing whitespace
- [x] `LoadSystemPrompt` has 100% coverage
- [x] All `core/...` tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)