### PR TITLE
fix(slack): allow self-mention to trigger draft

### DIFF
--- a/core/app/handlers_slack_webhook.go
+++ b/core/app/handlers_slack_webhook.go
@@ -168,11 +168,10 @@ func (s *apiServer) processSlackEvent(payload slackWebhookPayload) {
 
 	msg := comms.BuildIncomingMessage(evt.TS, evt.Channel, evt.User, evt.Text)
 
-	// Notify each mentioned user (skip the message author).
+	// Notify each mentioned user. If the author @mentions themselves,
+	// they still get a draft — they explicitly asked for it.
+	// Only skip the author when they are NOT mentioned.
 	for _, acct := range accounts {
-		if acct.ExternalUserID == evt.User {
-			continue // don't draft for your own messages
-		}
 		if !isSlackMention(evt.Text, acct.ExternalUserID) {
 			continue // only draft when the user is @mentioned
 		}

--- a/core/app/handlers_slack_webhook_test.go
+++ b/core/app/handlers_slack_webhook_test.go
@@ -217,6 +217,54 @@ func TestSlackWebhook_OwnMessage_Skipped(t *testing.T) {
 	}
 }
 
+func TestSlackWebhook_SelfMention_GetsDraft(t *testing.T) {
+	// Regression test: @mentioning yourself should trigger a draft.
+	// Previously, the author was always skipped even when self-mentioned.
+	srv := newSlackWebhookServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:             "conn_s1",
+		UserID:         "usr_alice",
+		Provider:       model.ConnectedAccountProviderSlack,
+		ExternalUserID: "U_ALICE",
+		ExternalTeamID: "T001TEAM",
+		Status:         model.ConnectedAccountStatusActive,
+	})
+
+	var mu sync.Mutex
+	called := false
+	srv.onSlackMessage = func(_ context.Context, _ string, _ comms.IncomingMessage) {
+		mu.Lock()
+		called = true
+		mu.Unlock()
+	}
+
+	body, _ := json.Marshal(map[string]any{
+		"type":     "event_callback",
+		"team_id":  "T001TEAM",
+		"event_id": "ev_selfmention",
+		"event": map[string]any{
+			"type":    "message",
+			"user":    "U_ALICE",
+			"text":    "<@U_ALICE> remind me to review PR #247",
+			"channel": "C0BACKEND",
+			"ts":      "123.789",
+		},
+	})
+	ts, sig := signSlackRequest(body, testSigningSecret)
+
+	w := httptest.NewRecorder()
+	srv.handleSlackEvent(w, slackWebhookRequest(body, ts, sig))
+
+	time.Sleep(50 * time.Millisecond)
+	mu.Lock()
+	defer mu.Unlock()
+	if !called {
+		t.Error("expected self-mention to trigger a draft")
+	}
+}
+
 func TestSlackWebhook_NoMention_NoDraft(t *testing.T) {
 	srv := newSlackWebhookServer()
 	ctx := context.Background()


### PR DESCRIPTION
## Summary

@mentioning yourself should trigger a draft — you explicitly asked for it. Previously, the message author was always skipped even when self-mentioned.

**Before:** Author is skipped unconditionally → self-mention produces no draft
**After:** Only check if user is @mentioned → self-mention works, own messages without mention still skipped

Also fixes the case where you @mention yourself to test the system.

## Regression test

`TestSlackWebhook_SelfMention_GetsDraft` — Alice sends `<@U_ALICE> remind me to review PR #247`, draft is triggered. Would have failed before this fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)