### PR TITLE
fix(draft): fail fast on missing AILERON.md, copy into Docker image

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -228,7 +228,10 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			llmClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModel)
 			sysPrompt := draft.LoadSystemPrompt()
 			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log, sysPrompt)
-			log.Info("enabled cloud draft generation", "model", authCfg.LLMModel)
+			log.Info("enabled cloud draft generation",
+				"model", authCfg.LLMModel,
+				"prompt_length", len(sysPrompt),
+				"prompt_source", draft.PromptSource())
 		}
 
 		if authCfg.SlackEnabled() {

--- a/core/draft/prompt.go
+++ b/core/draft/prompt.go
@@ -1,29 +1,24 @@
 package draft
 
 import (
+	"fmt"
 	"os"
 	"strings"
 )
 
-// defaultSystemPrompt is the fallback when AILERON.md is missing.
-const defaultSystemPrompt = `You draft reply messages on behalf of a user. Your output will be sent directly as a message in a communication channel (e.g. Slack) — the user will review it first but your output IS the message text.
+// promptSource records where the system prompt was loaded from.
+var promptSource string
 
-CRITICAL: Output ONLY the message text that would be sent. Nothing else. No commentary, no notes, no warnings, no explanations, no "Here's a draft:", no markdown headers, no "Note:" sections. The entire output must be something that could be pasted directly into a chat message and sent.
-
-Good output: "No, the JWT claims are unchanged. PR #247 only moves validation into middleware."
-Bad output: "Here's a draft reply:\n\nNo, the JWT claims are unchanged.\n\n Note: I'm not certain about this."
-
-Guidelines:
-- Be direct and specific. Reference concrete details (PR numbers, file names, code, dates).
-- Match the formality and tone of the channel and the message.
-- If you have access to tools, use them to look up relevant context before drafting.
-- Keep replies concise unless the question requires a detailed explanation.
-- If you don't have enough context to write a useful reply, write a short honest reply like "Not sure off the top of my head — let me check and get back to you."
-- Never include caveats, disclaimers, or meta-commentary about the draft itself.`
+// PromptSource returns the path the system prompt was loaded from.
+func PromptSource() string {
+	return promptSource
+}
 
 // LoadSystemPrompt reads the AILERON.md file and returns its contents as the
-// system prompt. If the file does not exist, it returns the hardcoded default.
-// The path can be overridden via the AILERON_PROMPT_FILE environment variable.
+// system prompt. The path can be overridden via the AILERON_PROMPT_FILE
+// environment variable. Panics if the file is missing or empty — the system
+// prompt is required for draft generation and must not silently fall back to
+// a hardcoded default.
 func LoadSystemPrompt() string {
 	path := os.Getenv("AILERON_PROMPT_FILE")
 	if path == "" {
@@ -32,12 +27,14 @@ func LoadSystemPrompt() string {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		return defaultSystemPrompt
+		panic(fmt.Sprintf("AILERON.md not found at %q: %v — the system prompt is required for draft generation", path, err))
 	}
 
 	content := strings.TrimSpace(string(data))
 	if content == "" {
-		return defaultSystemPrompt
+		panic(fmt.Sprintf("AILERON.md at %q is empty — the system prompt is required for draft generation", path))
 	}
+
+	promptSource = path
 	return content
 }

--- a/core/draft/prompt_test.go
+++ b/core/draft/prompt_test.go
@@ -19,38 +19,32 @@ func TestLoadSystemPrompt_FromFile(t *testing.T) {
 	}
 }
 
-func TestLoadSystemPrompt_FallbackWhenMissing(t *testing.T) {
+func TestLoadSystemPrompt_PanicsWhenMissing(t *testing.T) {
 	t.Setenv("AILERON_PROMPT_FILE", "/nonexistent/AILERON.md")
 
-	got := LoadSystemPrompt()
-	if got != defaultSystemPrompt {
-		t.Error("expected default prompt when file is missing")
-	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when AILERON.md is missing")
+		}
+	}()
+	LoadSystemPrompt()
 }
 
-func TestLoadSystemPrompt_FallbackWhenEmpty(t *testing.T) {
+func TestLoadSystemPrompt_PanicsWhenEmpty(t *testing.T) {
 	dir := t.TempDir()
 	path := filepath.Join(dir, "AILERON.md")
 	os.WriteFile(path, []byte("   \n  "), 0644)
 
 	t.Setenv("AILERON_PROMPT_FILE", path)
 
-	got := LoadSystemPrompt()
-	if got != defaultSystemPrompt {
-		t.Error("expected default prompt when file is empty/whitespace")
-	}
-}
-
-func TestLoadSystemPrompt_DefaultPath(t *testing.T) {
-	// Unset the env var — should look for AILERON.md in working dir.
-	t.Setenv("AILERON_PROMPT_FILE", "")
-
-	// From the test working directory, AILERON.md doesn't exist,
-	// so it should fall back to the default.
-	got := LoadSystemPrompt()
-	if got != defaultSystemPrompt {
-		t.Error("expected default prompt when AILERON.md not in working dir")
-	}
+	defer func() {
+		r := recover()
+		if r == nil {
+			t.Fatal("expected panic when AILERON.md is empty")
+		}
+	}()
+	LoadSystemPrompt()
 }
 
 func TestLoadSystemPrompt_TrimsWhitespace(t *testing.T) {
@@ -63,5 +57,18 @@ func TestLoadSystemPrompt_TrimsWhitespace(t *testing.T) {
 	got := LoadSystemPrompt()
 	if got != "Custom prompt content" {
 		t.Errorf("expected trimmed content, got %q", got)
+	}
+}
+
+func TestLoadSystemPrompt_SetsPromptSource(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AILERON.md")
+	os.WriteFile(path, []byte("test prompt"), 0644)
+
+	t.Setenv("AILERON_PROMPT_FILE", path)
+	LoadSystemPrompt()
+
+	if PromptSource() != path {
+		t.Errorf("expected source %q, got %q", path, PromptSource())
 	}
 }

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -40,11 +40,14 @@ RUN apk add --no-cache curl && \
 COPY --from=builder /aileron-server /usr/local/bin/aileron-server
 COPY core/schema/schema.hcl /schema/schema.hcl
 COPY core/server/entrypoint.sh /usr/local/bin/entrypoint.sh
+COPY AILERON.md /app/AILERON.md
 
 # Create output directory for coverage-instrumented builds (used when COVERAGE=true).
 RUN mkdir -p /tmp/gocoverdir && chown aileron:aileron /tmp/gocoverdir
 
 USER aileron
+
+WORKDIR /app
 
 EXPOSE 8080
 

--- a/test/integration/prompt_test.go
+++ b/test/integration/prompt_test.go
@@ -1,0 +1,36 @@
+//go:build integration
+
+package integration
+
+import (
+	"net/http"
+	"testing"
+)
+
+func TestServer_StartsWithAILERONMD(t *testing.T) {
+	// The server should be running — which means AILERON.md was found and
+	// loaded successfully. If it were missing, the server would have panicked
+	// at startup and this test wouldn't reach the health check.
+	resp, err := http.Get(apiURL() + "/v1/health")
+	if err != nil {
+		t.Fatalf("server not running — AILERON.md may be missing from the Docker image: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from health check, got %d", resp.StatusCode)
+	}
+}
+
+func TestServer_DraftEndpointAvailable(t *testing.T) {
+	// The draft pipeline should be enabled (LLM configured) — which means
+	// the system prompt was loaded from AILERON.md. Verify by checking that
+	// the drafts endpoint works (returns 200, not 501).
+	resp := authedGet(t, apiURL()+"/v1/drafts")
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotImplemented {
+		t.Fatal("drafts endpoint returned 501 — LLM/prompt may not be configured")
+	}
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("expected 200 from drafts endpoint, got %d", resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Problem

1. **AILERON.md not in Docker image** — Dockerfile didn't copy it, server silently fell back to hardcoded default. All prompt improvements in AILERON.md were ignored in production.
2. **Silent fallback** — missing AILERON.md degraded to a generic prompt with no error. The system prompt IS the product experience.

## Fix

1. **Dockerfile:** Copy AILERON.md into image at `/app/AILERON.md`, set WORKDIR to `/app`
2. **Fail fast:** Panic if AILERON.md is missing or empty — no silent fallback
3. **Startup logging:** Log prompt source path and length for debugging
4. **Integration tests:** Server starts (proves AILERON.md exists), drafts endpoint available

## Regression tests

- `TestLoadSystemPrompt_PanicsWhenMissing` — fails before fix (silent fallback), passes after (panic)
- `TestLoadSystemPrompt_PanicsWhenEmpty` — same
- Integration: `TestServer_StartsWithAILERONMD`, `TestServer_DraftEndpointAvailable`

🤖 Generated with [Claude Code](https://claude.com/claude-code)