### PR TITLE
fix(draft): remove 'Draft a reply' instruction to prevent assistant mode

### DIFF
--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -62,9 +62,11 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 		return "", fmt.Errorf("assembling system prompt: %w", err)
 	}
 
-	// Build the user message from the incoming message.
+	// Present the message as context — don't say "draft a reply" as that
+	// triggers assistant-mode behavior. The system prompt already establishes
+	// the identity and role.
 	userMessage := fmt.Sprintf(
-		"Draft a reply to this message from %s in %s:\n\n%s",
+		"Message from %s in %s:\n\n%s",
 		msg.Author, msg.Channel, msg.Body,
 	)
 


### PR DESCRIPTION
## Problem

The LLM output included meta-commentary and process narration:
- "I have a solid picture now. Let me craft the weekly summary."
- "**Themes bucketed:**"
- Unsolicited "Most important thing to work on next"

This happened despite AILERON.md saying "You ARE the user" and "Output ONLY the message text."

## Root cause

The user message sent to the LLM said:

> "Draft a reply to this message from Sarah in #backend: ..."

The phrase **"Draft a reply"** reframed the task as an assistant request, overriding the system prompt's identity framing. The LLM went into "helpful assistant drafting a reply" mode instead of "I am this person, writing my reply" mode.

## Fix

Remove the task instruction from the user message:

**Before:** `"Draft a reply to this message from Sarah in #backend: ..."`
**After:** `"Message from Sarah in #backend: ..."`

The system prompt already establishes the role. The user message just provides context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)