### PR TITLE
fix(llm): bump tool rounds to 15 and gracefully handle exhaustion

### DIFF
--- a/core/llm/anthropic.go
+++ b/core/llm/anthropic.go
@@ -10,7 +10,7 @@ import (
 	"github.com/anthropics/anthropic-sdk-go/option"
 )
 
-const defaultMaxToolRounds = 5
+const defaultMaxToolRounds = 15
 
 // AnthropicClient implements Client using the Anthropic Messages API.
 type AnthropicClient struct {
@@ -156,7 +156,43 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 		})
 	}
 
-	return nil, fmt.Errorf("exceeded maximum tool rounds (%d)", maxRounds)
+	// Tool rounds exhausted. Make one final call WITHOUT tools to force
+	// the LLM to produce a text response with whatever context it has
+	// gathered so far. This prevents silent failures where the user gets
+	// no draft at all.
+	finalParams := anthropic.MessageNewParams{
+		Model:     a.model,
+		MaxTokens: 4096,
+		Messages:  messages,
+	}
+	if req.SystemPrompt != "" {
+		finalParams.System = []anthropic.TextBlockParam{
+			{Text: req.SystemPrompt},
+		}
+	}
+	// No tools — force text output.
+	resp, err := a.client.Messages.New(ctx, finalParams)
+	if err != nil {
+		return nil, fmt.Errorf("anthropic API error on final round: %w", err)
+	}
+
+	var textParts []string
+	for _, block := range resp.Content {
+		if block.Type == "text" && block.Text != "" {
+			textParts = append(textParts, block.Text)
+		}
+	}
+	text := ""
+	for _, t := range textParts {
+		if text != "" {
+			text += "\n"
+		}
+		text += t
+	}
+	return &GenerateResponse{
+		Text:      text,
+		ToolCalls: allToolCalls,
+	}, nil
 }
 
 // ConvertTools converts source.ToolDefinition to Anthropic ToolParam format.

--- a/core/llm/anthropic_test.go
+++ b/core/llm/anthropic_test.go
@@ -3,8 +3,11 @@ package llm_test
 import (
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"sync/atomic"
 	"testing"
 
@@ -223,6 +226,73 @@ func TestAnthropicClient_NoToolExecutor(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error when tool use requested but no executor")
+	}
+}
+
+func TestAnthropicClient_ToolRoundsExhausted_GracefulFallback(t *testing.T) {
+	// Regression test: when tool rounds are exhausted, the LLM should make
+	// one final call WITHOUT tools and return whatever text it can produce.
+	// Previously, this returned an error and the user got no draft.
+	var callCount atomic.Int32
+	server := mockAnthropicServer(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		count := callCount.Add(1)
+
+		// Check if tools are present in the request to detect the final call.
+		body, _ := io.ReadAll(r.Body)
+		hasTools := strings.Contains(string(body), `"tools"`)
+
+		if !hasTools {
+			// Final call without tools — return text.
+			json.NewEncoder(w).Encode(map[string]any{
+				"id": "msg_final", "type": "message", "role": "assistant",
+				"model": "claude-sonnet-4-6", "stop_reason": "end_turn",
+				"content": []map[string]any{
+					{"type": "text", "text": "Here's what I found with the context I gathered."},
+				},
+				"usage": map[string]any{"input_tokens": 10, "output_tokens": 20},
+			})
+			return
+		}
+
+		// Keep returning tool_use to exhaust rounds.
+		json.NewEncoder(w).Encode(map[string]any{
+			"id": fmt.Sprintf("msg_%d", count), "type": "message", "role": "assistant",
+			"model": "claude-sonnet-4-6", "stop_reason": "tool_use",
+			"content": []map[string]any{
+				{"type": "tool_use", "id": fmt.Sprintf("tool_%d", count),
+					"name": "slack_search_messages", "input": map[string]any{"query": "test"}},
+			},
+			"usage": map[string]any{"input_tokens": 10, "output_tokens": 20},
+		})
+	})
+	defer server.Close()
+
+	client := llm.NewAnthropicClient("test-key", "claude-sonnet-4-6")
+	client.SetBaseURL(server.URL)
+
+	resp, err := client.GenerateWithTools(context.Background(), llm.GenerateRequest{
+		SystemPrompt:  "You are helpful.",
+		UserMessage:   "Summarize the week.",
+		MaxToolRounds: 2, // low limit to trigger exhaustion quickly
+		Tools: []source.ToolDefinition{
+			{Name: "slack_search_messages", Description: "Search messages"},
+		},
+		ToolExecutor: func(_ context.Context, tool string, params map[string]any) (map[string]any, error) {
+			return map[string]any{"messages": []string{"result"}}, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("expected graceful fallback, got error: %v", err)
+	}
+	if resp.Text == "" {
+		t.Fatal("expected non-empty text from graceful fallback")
+	}
+	if resp.Text != "Here's what I found with the context I gathered." {
+		t.Errorf("unexpected text: %q", resp.Text)
+	}
+	if len(resp.ToolCalls) == 0 {
+		t.Error("expected tool calls to be recorded before exhaustion")
 	}
 }
 


### PR DESCRIPTION
## Problem

"Exceeded maximum tool rounds (5)" — weekly summary searches need more than 5 tool calls to cover the full week of GitHub activity. The draft silently fails and the user gets nothing.

## Fix

1. **Bump default from 5 to 15** — enough for broad searches across multiple date ranges
2. **Graceful exhaustion** — when rounds ARE exhausted, make one final LLM call WITHOUT tools to force a text response using whatever context was gathered. The user always gets a draft, even if incomplete.

**Before:** Tool rounds exhausted → error → no draft → user sees nothing
**After:** Tool rounds exhausted → final text-only call → draft with available context → user sees something

🤖 Generated with [Claude Code](https://claude.com/claude-code)