### PR TITLE
feat(draft): two-round pipeline — research then ghostwrite

### DIFF
--- a/AILERON.md
+++ b/AILERON.md
@@ -1,10 +1,35 @@
-# Identity
+# Research Prompt
+
+You are a research assistant gathering context to help draft a reply to a message.
+
+Your job is to find ALL relevant information needed to write a good reply. Use the available tools to search broadly and thoroughly.
+
+## Time Ranges
+
+If the message references a time range ("this week," "since Monday," "last sprint"), search the FULL range. Today is {{today}}. Make multiple searches with different queries and date ranges to cover the full period — do not rely on a single search that only returns recent results.
+
+## Thoroughness
+
+- Search for PRs, issues, commits, messages, calendar events — whatever is relevant to the question.
+- Include full URLs (e.g. https://github.com/org/repo/pull/123) for everything you find.
+- Use multiple tool calls. A weekly summary might need 5+ searches across different queries and date ranges.
+- Be thorough. It's better to find too much than too little — the ghostwriter will decide what to include.
+
+## Output
+
+Output a structured summary of what you found. Include all relevant details, links, dates, and context. This output is internal — it will be fed to a ghostwriter, never shown directly to anyone.
+
+---
+
+# Ghostwrite Prompt
+
+## Identity
 
 You are ghostwriting a message as a specific person. Your output will be sent directly as their message in a communication channel. The recipient must not be able to tell it was drafted by AI. You are invisible.
 
 You are NOT an assistant talking TO the user. You ARE the user, writing their reply.
 
-# Output Rules
+## Output Rules
 
 Output ONLY the message text. Nothing else. Every single character of your output will be posted as the person's message. There is no separate "thinking" area — if you write it, it gets sent.
 
@@ -16,9 +41,8 @@ Output ONLY the message text. Nothing else. Every single character of your outpu
 - No markdown headers in casual channels (use them only if the channel's tone uses them)
 - No bullet lists unless the person typically writes in bullet lists
 - The output must read like something this specific person would actually type
-- If you use tools to look things up, DO NOT narrate the lookup. Just use the results silently.
 
-# Voice
+## Voice
 
 Match the person's communication style:
 
@@ -32,35 +56,26 @@ When you don't have enough signal about the person's style, default to:
 - No filler or pleasantries
 - Conversational but professional
 
-# Answering the Question
+## Answering the Question
 
 Read the question carefully. Answer exactly what was asked — no more, no less.
 
 - **Match the requested level of detail.** "Executive summary" = high-level themes in a few sentences. "Detailed report" = comprehensive breakdown. "Quick update" = one or two lines. Don't write a detailed report when asked for a summary.
-- **Cover the full scope.** If asked for "this week," search and cover the full week — not just the most recent 2-3 items. If your tool results only show recent activity, make additional searches with date ranges to cover the full period.
-- **Don't add unrequested sections.** If they ask "what shipped?" don't add "what's next" unless they asked for it. If they ask "what's next?" answer that specifically.
+- **Cover the full scope.** Use all the context provided — don't ignore information from the research phase.
+- **Don't add unrequested sections.** If they ask "what shipped?" don't add "what's next" unless they asked for it.
 - **Answer about the specific thing asked.** Don't provide unsolicited broader context.
 
-# References
+## References
 
 When referencing PRs, issues, commits, or other linkable resources:
 
 - In Slack: use full URLs so they render as clickable links (e.g. `https://github.com/org/repo/pull/123`)
 - Don't use shorthand like "PR #123" without a link — the reader can't click on that
-- Only reference things you actually found via tools — never fabricate references
+- Only reference things from the provided context — never fabricate references
 
-# Tool Use
+## Low Context
 
-Use tools proactively to ground your response in real data. Don't guess when you can look it up. Never narrate tool usage — use the results silently.
-
-- **Search broadly when the question is broad.** "What happened this week" means search the full week of activity, not just the default/recent results. Make multiple searches if needed to cover the full time range.
-- **Search specifically when the question is specific.** "Does PR #247 change the claims?" means look up that specific PR.
-- **Use multiple tool calls when needed.** A weekly summary might need several searches across different date ranges to cover the full week.
-- **Synthesize, don't dump.** Just because you found 15 PRs doesn't mean you list all 15. Group, summarize, and present at the level of detail the question requested. An "executive summary" of 15 PRs is 3-4 themes, not 15 bullet points.
-
-# Low Context
-
-When you don't have enough context to write something useful:
+When the provided context doesn't contain enough information to write a useful reply:
 
 "Not sure off the top of my head — let me check and get back to you."
 

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -226,11 +226,12 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		// LLM-powered draft generation pipeline.
 		if authCfg.LLMEnabled() {
 			llmClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModel)
-			sysPrompt := draft.LoadSystemPrompt()
-			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log, sysPrompt)
+			prompts := draft.LoadPrompts()
+			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log, prompts)
 			log.Info("enabled cloud draft generation",
 				"model", authCfg.LLMModel,
-				"prompt_length", len(sysPrompt),
+				"research_prompt_length", len(prompts.Research),
+				"ghostwrite_prompt_length", len(prompts.Ghostwrite),
 				"prompt_source", draft.PromptSource())
 		}
 

--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -12,6 +12,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 	"time"
 
 	"github.com/ALRubinger/aileron/core/comms"
@@ -22,19 +23,6 @@ import (
 	"github.com/ALRubinger/aileron/core/vault"
 )
 
-// researchPrompt instructs the LLM to gather context using tools.
-// Its output is internal — fed to the ghostwriting round, never shown to users.
-const researchPrompt = `You are a research assistant gathering context to help draft a reply to a message.
-
-Your job is to find all relevant information needed to write a good reply. Use the available tools to search broadly and thoroughly.
-
-IMPORTANT:
-- If the message references a time range ("this week," "since Monday," "last sprint"), search the FULL range. Today is %s. Make multiple searches with different queries to cover the full period — do not rely on a single search that only returns recent results.
-- Search for PRs, issues, commits, messages, events — whatever is relevant to the question.
-- Include links (full URLs) to everything you find.
-- Output a structured summary of what you found. Include all relevant details — the ghostwriter will decide what to include in the final reply.
-- Be thorough. It's better to find too much than too little.`
-
 // Pipeline orchestrates draft generation for incoming messages.
 type Pipeline struct {
 	llm               llm.Client
@@ -43,11 +31,11 @@ type Pipeline struct {
 	instructions      store.UserInstructionStore
 	vault             vault.Vault
 	log               *slog.Logger
-	systemPrompt      string
+	researchPrompt    string
+	ghostwritePrompt  string
 }
 
-// NewPipeline creates a draft generation pipeline. The systemPrompt is the
-// base prompt loaded from AILERON.md.
+// NewPipeline creates a draft generation pipeline.
 func NewPipeline(
 	llmClient llm.Client,
 	sourceReg *source.Registry,
@@ -55,7 +43,7 @@ func NewPipeline(
 	instructions store.UserInstructionStore,
 	v vault.Vault,
 	log *slog.Logger,
-	systemPrompt string,
+	prompts Prompts,
 ) *Pipeline {
 	return &Pipeline{
 		llm:               llmClient,
@@ -64,7 +52,8 @@ func NewPipeline(
 		instructions:      instructions,
 		vault:             v,
 		log:               log,
-		systemPrompt:      systemPrompt,
+		researchPrompt:    prompts.Research,
+		ghostwritePrompt:  prompts.Ghostwrite,
 	}
 }
 
@@ -100,7 +89,11 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 	// --- Round 1: Research ---
 	// The LLM gathers context using tools. Its output is a structured
 	// summary of what it found — never shown to the user.
-	researchSysPrompt := fmt.Sprintf(researchPrompt, time.Now().Format("2006-01-02 (Monday)"))
+	researchSysPrompt := strings.ReplaceAll(
+		p.researchPrompt,
+		"{{today}}",
+		time.Now().Format("2006-01-02 (Monday)"),
+	)
 	researchMessage := fmt.Sprintf(
 		"Find relevant context to help reply to this message from %s in %s:\n\n%s",
 		msg.Author, msg.Channel, msg.Body,
@@ -165,7 +158,7 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 // the user's active instructions. Instructions are the highest-priority
 // context — they override learned patterns and behavioral model inferences.
 func (p *Pipeline) assembleSystemPrompt(ctx context.Context, userID string) (string, error) {
-	prompt := p.systemPrompt
+	prompt := p.ghostwritePrompt
 
 	if p.instructions == nil {
 		return prompt, nil

--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -1,15 +1,18 @@
 // Package draft orchestrates cloud-hosted draft generation.
 //
-// The Pipeline assembles context from source connectors, calls an LLM with
-// tool access, and returns a draft reply. It bridges the source connector
-// layer (read-only context retrieval), the LLM client (text generation with
-// tool use), and the vault (credential management).
+// The Pipeline uses a two-round approach:
+//   Round 1 (research): LLM has tools, searches broadly, gathers context.
+//     Its output is internal — never shown to anyone.
+//   Round 2 (ghostwrite): LLM has NO tools, receives the gathered context,
+//     writes the reply in the user's voice. No narration possible because
+//     there's no research phase.
 package draft
 
 import (
 	"context"
 	"fmt"
 	"log/slog"
+	"time"
 
 	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/llm"
@@ -18,6 +21,19 @@ import (
 	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/vault"
 )
+
+// researchPrompt instructs the LLM to gather context using tools.
+// Its output is internal — fed to the ghostwriting round, never shown to users.
+const researchPrompt = `You are a research assistant gathering context to help draft a reply to a message.
+
+Your job is to find all relevant information needed to write a good reply. Use the available tools to search broadly and thoroughly.
+
+IMPORTANT:
+- If the message references a time range ("this week," "since Monday," "last sprint"), search the FULL range. Today is %s. Make multiple searches with different queries to cover the full period — do not rely on a single search that only returns recent results.
+- Search for PRs, issues, commits, messages, events — whatever is relevant to the question.
+- Include links (full URLs) to everything you find.
+- Output a structured summary of what you found. Include all relevant details — the ghostwriter will decide what to include in the final reply.
+- Be thorough. It's better to find too much than too little.`
 
 // Pipeline orchestrates draft generation for incoming messages.
 type Pipeline struct {
@@ -31,7 +47,7 @@ type Pipeline struct {
 }
 
 // NewPipeline creates a draft generation pipeline. The systemPrompt is the
-// base prompt loaded from AILERON.md (or the hardcoded default).
+// base prompt loaded from AILERON.md.
 func NewPipeline(
 	llmClient llm.Client,
 	sourceReg *source.Registry,
@@ -52,31 +68,17 @@ func NewPipeline(
 	}
 }
 
-// GenerateDraft produces a draft reply for an incoming message.
-// It assembles context from source connectors available to the user,
-// calls the LLM with tool access, and returns the draft text.
+// GenerateDraft produces a draft reply using a two-round approach:
+//   Round 1: Research — LLM uses tools to gather context. Output is internal.
+//   Round 2: Ghostwrite — LLM writes the reply using the gathered context.
+//     No tools, no narration.
 func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.IncomingMessage) (string, error) {
-	// Assemble the system prompt from base + user instructions.
-	prompt, err := p.assembleSystemPrompt(ctx, userID)
-	if err != nil {
-		return "", fmt.Errorf("assembling system prompt: %w", err)
-	}
-
-	// Present the message as context — don't say "draft a reply" as that
-	// triggers assistant-mode behavior. The system prompt already establishes
-	// the identity and role.
-	userMessage := fmt.Sprintf(
-		"Message from %s in %s:\n\n%s",
-		msg.Author, msg.Channel, msg.Body,
-	)
-
-	// Get the user's connected accounts to determine available tools.
+	// Get available tools.
 	accounts, err := p.connectedAccounts.List(ctx, store.ConnectedAccountFilter{UserID: userID})
 	if err != nil {
 		return "", fmt.Errorf("listing connected accounts: %w", err)
 	}
 
-	// Collect tools from source connectors matching connected accounts.
 	connectedProviders := make(map[string]bool)
 	for _, acct := range accounts {
 		if acct.Status == model.ConnectedAccountStatusActive {
@@ -93,27 +95,70 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 		}
 	}
 
-	// Build a tool executor that resolves credentials and calls source connectors.
 	executor := p.buildToolExecutor(ctx, userID, accounts)
 
-	resp, err := p.llm.GenerateWithTools(ctx, llm.GenerateRequest{
-		SystemPrompt: prompt,
-		UserMessage:  userMessage,
-		Tools:        tools,
-		ToolExecutor: executor,
+	// --- Round 1: Research ---
+	// The LLM gathers context using tools. Its output is a structured
+	// summary of what it found — never shown to the user.
+	researchSysPrompt := fmt.Sprintf(researchPrompt, time.Now().Format("2006-01-02 (Monday)"))
+	researchMessage := fmt.Sprintf(
+		"Find relevant context to help reply to this message from %s in %s:\n\n%s",
+		msg.Author, msg.Channel, msg.Body,
+	)
+
+	var gatheredContext string
+	if len(tools) > 0 {
+		researchResp, err := p.llm.GenerateWithTools(ctx, llm.GenerateRequest{
+			SystemPrompt: researchSysPrompt,
+			UserMessage:  researchMessage,
+			Tools:        tools,
+			ToolExecutor: executor,
+		})
+		if err != nil {
+			p.log.Error("research round failed", "user_id", userID, "error", err)
+			gatheredContext = "(No additional context available — tool search failed.)"
+		} else {
+			gatheredContext = researchResp.Text
+			p.log.Info("research round complete",
+				"user_id", userID,
+				"tool_calls", len(researchResp.ToolCalls),
+				"context_length", len(gatheredContext),
+			)
+		}
+	} else {
+		gatheredContext = "(No source connectors available — replying with general knowledge only.)"
+	}
+
+	// --- Round 2: Ghostwrite ---
+	// The LLM writes the reply using AILERON.md instructions + user
+	// instructions + gathered context. NO tools — just text in, text out.
+	// This eliminates narration because there's no research to narrate.
+	ghostwritePrompt, err := p.assembleSystemPrompt(ctx, userID)
+	if err != nil {
+		return "", fmt.Errorf("assembling system prompt: %w", err)
+	}
+
+	ghostwriteMessage := fmt.Sprintf(
+		"Message from %s in %s:\n\n%s\n\n---\n\nContext gathered from connected sources:\n\n%s",
+		msg.Author, msg.Channel, msg.Body, gatheredContext,
+	)
+
+	draftResp, err := p.llm.GenerateWithTools(ctx, llm.GenerateRequest{
+		SystemPrompt: ghostwritePrompt,
+		UserMessage:  ghostwriteMessage,
+		// No tools — force text-only output.
 	})
 	if err != nil {
-		return "", fmt.Errorf("LLM generation failed: %w", err)
+		return "", fmt.Errorf("ghostwrite round failed: %w", err)
 	}
 
 	p.log.Info("draft generated",
 		"user_id", userID,
 		"channel", msg.Channel,
-		"tool_calls", len(resp.ToolCalls),
-		"draft_length", len(resp.Text),
+		"draft_length", len(draftResp.Text),
 	)
 
-	return resp.Text, nil
+	return draftResp.Text, nil
 }
 
 // assembleSystemPrompt builds the system prompt from the base prompt plus

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -15,17 +15,29 @@ import (
 	"github.com/ALRubinger/aileron/core/vault"
 )
 
-// mockLLMClient records requests and returns a configured response.
+// mockLLMClient records requests and returns configured responses.
+// Supports two-round pipeline: first call is research, second is ghostwrite.
 type mockLLMClient struct {
-	lastRequest *llm.GenerateRequest
-	response    *llm.GenerateResponse
-	err         error
+	requests       []*llm.GenerateRequest
+	lastRequest    *llm.GenerateRequest
+	researchResp   *llm.GenerateResponse // response for round 1 (with tools)
+	ghostwriteResp *llm.GenerateResponse // response for round 2 (no tools)
+	response       *llm.GenerateResponse // fallback if specific round responses not set
+	err            error
 }
 
 func (m *mockLLMClient) GenerateWithTools(_ context.Context, req llm.GenerateRequest) (*llm.GenerateResponse, error) {
+	m.requests = append(m.requests, &req)
 	m.lastRequest = &req
 	if m.err != nil {
 		return nil, m.err
+	}
+	// If specific round responses are set, use them based on whether tools are present.
+	if len(req.Tools) > 0 && m.researchResp != nil {
+		return m.researchResp, nil
+	}
+	if len(req.Tools) == 0 && m.ghostwriteResp != nil {
+		return m.ghostwriteResp, nil
 	}
 	return m.response, nil
 }
@@ -87,9 +99,12 @@ func TestPipeline_GenerateDraft_Simple(t *testing.T) {
 
 func TestPipeline_GenerateDraft_WithTools(t *testing.T) {
 	mock := &mockLLMClient{
-		response: &llm.GenerateResponse{
-			Text:      "Based on the channel history, the answer is yes.",
+		researchResp: &llm.GenerateResponse{
+			Text:      "Found PR #247 which refactors JWT validation.",
 			ToolCalls: []llm.ToolCall{{Tool: "slack_channel_history"}},
+		},
+		ghostwriteResp: &llm.GenerateResponse{
+			Text: "Based on the channel history, the answer is yes.",
 		},
 	}
 
@@ -97,7 +112,6 @@ func TestPipeline_GenerateDraft_WithTools(t *testing.T) {
 	v := vault.NewMemVault()
 	ctx := context.Background()
 
-	// Seed a connected Slack account.
 	accounts.Create(ctx, model.ConnectedAccount{
 		ID:       "conn_s1",
 		UserID:   "usr_1",
@@ -126,28 +140,33 @@ func TestPipeline_GenerateDraft_WithTools(t *testing.T) {
 		t.Fatal("expected non-empty draft")
 	}
 
-	// Verify tools were provided to the LLM.
-	if len(mock.lastRequest.Tools) != 1 {
-		t.Fatalf("expected 1 tool, got %d", len(mock.lastRequest.Tools))
-	}
-	if mock.lastRequest.Tools[0].Name != "slack_channel_history" {
-		t.Errorf("expected slack_channel_history, got %s", mock.lastRequest.Tools[0].Name)
+	// Two-round pipeline: should have made 2 LLM calls.
+	if len(mock.requests) != 2 {
+		t.Fatalf("expected 2 LLM calls (research + ghostwrite), got %d", len(mock.requests))
 	}
 
-	// Verify tool executor was provided.
-	if mock.lastRequest.ToolExecutor == nil {
-		t.Error("expected ToolExecutor to be set")
+	// Round 1 (research) should have tools.
+	if len(mock.requests[0].Tools) != 1 {
+		t.Fatalf("expected 1 tool in research round, got %d", len(mock.requests[0].Tools))
+	}
+	if mock.requests[0].ToolExecutor == nil {
+		t.Error("expected ToolExecutor in research round")
+	}
+
+	// Round 2 (ghostwrite) should have NO tools.
+	if len(mock.requests[1].Tools) != 0 {
+		t.Errorf("expected 0 tools in ghostwrite round, got %d", len(mock.requests[1].Tools))
 	}
 }
 
 func TestPipeline_GenerateDraft_ToolExecutor(t *testing.T) {
-	// This test verifies the tool executor resolves credentials and calls the source connector.
-	var executorCalled bool
+	// Verify the research round's tool executor resolves credentials
+	// and calls the source connector.
 	mock := &mockLLMClient{
-		response: &llm.GenerateResponse{Text: "draft"},
+		researchResp:   &llm.GenerateResponse{Text: "context gathered"},
+		ghostwriteResp: &llm.GenerateResponse{Text: "draft"},
 	}
 
-	// Override: capture the executor and call it ourselves.
 	accounts := mem.NewConnectedAccountStore()
 	v := vault.NewMemVault()
 	ctx := context.Background()
@@ -172,19 +191,21 @@ func TestPipeline_GenerateDraft_ToolExecutor(t *testing.T) {
 		t.Fatalf("unexpected error: %v", err)
 	}
 
-	// Now call the tool executor that was passed to the LLM.
-	if mock.lastRequest.ToolExecutor != nil {
-		result, execErr := mock.lastRequest.ToolExecutor(ctx, "slack_channel_history", map[string]any{"channel": "C123"})
-		if execErr != nil {
-			t.Fatalf("tool executor error: %v", execErr)
-		}
-		if result["executed"] != true {
-			t.Error("expected tool to be executed")
-		}
-		executorCalled = true
+	// The tool executor is on the research round (first request).
+	if len(mock.requests) < 1 {
+		t.Fatal("expected at least 1 LLM call")
 	}
-	if !executorCalled {
-		t.Error("expected executor to be callable")
+	researchReq := mock.requests[0]
+	if researchReq.ToolExecutor == nil {
+		t.Fatal("expected ToolExecutor in research round")
+	}
+
+	result, execErr := researchReq.ToolExecutor(ctx, "slack_channel_history", map[string]any{"channel": "C123"})
+	if execErr != nil {
+		t.Fatalf("tool executor error: %v", execErr)
+	}
+	if result["executed"] != true {
+		t.Error("expected tool to be executed")
 	}
 }
 

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -66,7 +66,7 @@ func TestPipeline_GenerateDraft_Simple(t *testing.T) {
 	v := vault.NewMemVault()
 	sourceReg := source.NewRegistry()
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), "test system prompt")
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	draftText, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID:      "msg_1",
@@ -123,7 +123,7 @@ func TestPipeline_GenerateDraft_WithTools(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), "test system prompt")
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	draftText, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID:      "msg_1",
@@ -182,7 +182,7 @@ func TestPipeline_GenerateDraft_ToolExecutor(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), "test system prompt")
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -219,7 +219,7 @@ func TestPipeline_GenerateDraft_NoConnectedAccounts(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), "test system prompt")
+	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	draftText, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -259,7 +259,7 @@ func TestPipeline_GenerateDraft_WithInstructions(t *testing.T) {
 	})
 
 	sourceReg := source.NewRegistry()
-	p := draft.NewPipeline(mock, sourceReg, accounts, instructions, v, slog.Default(), "test system prompt")
+	p := draft.NewPipeline(mock, sourceReg, accounts, instructions, v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -292,7 +292,7 @@ func TestPipeline_GenerateDraft_NoInstructions(t *testing.T) {
 		response: &llm.GenerateResponse{Text: "Draft without instructions"},
 	}
 
-	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), "test system prompt")
+	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	_, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -312,7 +312,7 @@ func TestPipeline_GenerateDraft_LLMError(t *testing.T) {
 		err: context.DeadlineExceeded,
 	}
 
-	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), "test system prompt")
+	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	_, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",

--- a/core/draft/prompt.go
+++ b/core/draft/prompt.go
@@ -6,20 +6,25 @@ import (
 	"strings"
 )
 
-// promptSource records where the system prompt was loaded from.
+// promptSource records where the prompts were loaded from.
 var promptSource string
 
-// PromptSource returns the path the system prompt was loaded from.
+// PromptSource returns the path the prompts were loaded from.
 func PromptSource() string {
 	return promptSource
 }
 
-// LoadSystemPrompt reads the AILERON.md file and returns its contents as the
-// system prompt. The path can be overridden via the AILERON_PROMPT_FILE
-// environment variable. Panics if the file is missing or empty — the system
-// prompt is required for draft generation and must not silently fall back to
-// a hardcoded default.
-func LoadSystemPrompt() string {
+// Prompts holds the two prompts loaded from AILERON.md.
+type Prompts struct {
+	Research   string // Round 1: context gathering with tools
+	Ghostwrite string // Round 2: writing the reply in the user's voice
+}
+
+// LoadPrompts reads AILERON.md and splits it into research and ghostwrite
+// prompts. The file uses a "---" line separator between sections.
+// Research prompt comes first, ghostwrite prompt second.
+// Panics if the file is missing or empty.
+func LoadPrompts() Prompts {
 	path := os.Getenv("AILERON_PROMPT_FILE")
 	if path == "" {
 		path = "AILERON.md"
@@ -27,14 +32,31 @@ func LoadSystemPrompt() string {
 
 	data, err := os.ReadFile(path)
 	if err != nil {
-		panic(fmt.Sprintf("AILERON.md not found at %q: %v — the system prompt is required for draft generation", path, err))
+		panic(fmt.Sprintf("AILERON.md not found at %q: %v — required for draft generation", path, err))
 	}
 
 	content := strings.TrimSpace(string(data))
 	if content == "" {
-		panic(fmt.Sprintf("AILERON.md at %q is empty — the system prompt is required for draft generation", path))
+		panic(fmt.Sprintf("AILERON.md at %q is empty — required for draft generation", path))
 	}
 
 	promptSource = path
-	return content
+
+	// Split on "---" separator between research and ghostwrite prompts.
+	parts := strings.SplitN(content, "\n---\n", 2)
+	if len(parts) != 2 {
+		// Single section — use as ghostwrite prompt, no research prompt.
+		return Prompts{Ghostwrite: content}
+	}
+
+	return Prompts{
+		Research:   strings.TrimSpace(parts[0]),
+		Ghostwrite: strings.TrimSpace(parts[1]),
+	}
+}
+
+// LoadSystemPrompt is a backward-compatible wrapper that returns the
+// ghostwrite prompt.
+func LoadSystemPrompt() string {
+	return LoadPrompts().Ghostwrite
 }

--- a/core/draft/prompt_test.go
+++ b/core/draft/prompt_test.go
@@ -72,3 +72,36 @@ func TestLoadSystemPrompt_SetsPromptSource(t *testing.T) {
 		t.Errorf("expected source %q, got %q", path, PromptSource())
 	}
 }
+
+func TestLoadPrompts_TwoSections(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AILERON.md")
+	content := "# Research Prompt\n\nGather context.\n\n---\n\n# Ghostwrite Prompt\n\nWrite the reply."
+	os.WriteFile(path, []byte(content), 0644)
+
+	t.Setenv("AILERON_PROMPT_FILE", path)
+
+	prompts := LoadPrompts()
+	if prompts.Research != "# Research Prompt\n\nGather context." {
+		t.Errorf("unexpected research prompt: %q", prompts.Research)
+	}
+	if prompts.Ghostwrite != "# Ghostwrite Prompt\n\nWrite the reply." {
+		t.Errorf("unexpected ghostwrite prompt: %q", prompts.Ghostwrite)
+	}
+}
+
+func TestLoadPrompts_SingleSection(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "AILERON.md")
+	os.WriteFile(path, []byte("Single section prompt"), 0644)
+
+	t.Setenv("AILERON_PROMPT_FILE", path)
+
+	prompts := LoadPrompts()
+	if prompts.Research != "" {
+		t.Errorf("expected empty research prompt, got %q", prompts.Research)
+	}
+	if prompts.Ghostwrite != "Single section prompt" {
+		t.Errorf("expected single section as ghostwrite, got %q", prompts.Ghostwrite)
+	}
+}


### PR DESCRIPTION
## Problem

Despite AILERON.md instructions, the LLM narrates its research process as part of the draft output: "Got everything I need. Here's the summary:", reasoning blocks, `---` separators between thinking and reply. This happens because the LLM has tools AND writes the reply in a single call — it naturally narrates the research phase.

Brittle narration-stripping (pattern matching on prefixes) is not a sustainable fix.

## Solution

Split into two distinct LLM calls:

**Round 1 — Research:** LLM has tools, searches broadly, gathers all relevant context. Its output is a structured summary — internal, never shown to users. Dedicated prompt includes today's date and instructs thorough searching across the full time range.

**Round 2 — Ghostwrite:** LLM has NO tools, receives the gathered context + AILERON.md instructions + user instructions. Writes the reply in the user's voice. No tools = no research = nothing to narrate.

## What this fixes

- "Got everything I need" — eliminated (narration stays in Round 1)
- Recency bias — research prompt explicitly says to search the full time range with today's date
- Too comprehensive — ghostwrite round uses AILERON.md which says "match the requested level of detail"
- Process narration — architecturally impossible in Round 2 (no tools to narrate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)