### PR TITLE
feat(draft): post immediate drafting indicator before LLM runs

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -246,6 +246,15 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 					"preview", msg.Body[:min(len(msg.Body), 80)])
 
 				if server.draftPipeline != nil {
+					// Post immediate "drafting..." indicator so the user
+					// knows Aileron is working while the LLM runs.
+					creds, err := server.resolveSlackCredentials(ctx, userID)
+					if err != nil {
+						log.Error("failed to resolve slack credentials", "user_id", userID, "error", err)
+					} else {
+						server.postDraftingIndicator(ctx, creds, msg.Channel, msg.ID)
+					}
+
 					draftText, err := server.draftPipeline.GenerateDraft(ctx, userID, msg)
 					if err != nil {
 						log.Error("draft generation failed", "user_id", userID, "error", err)

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -11,7 +11,6 @@ import (
 	"github.com/ALRubinger/aileron/core/account"
 	api "github.com/ALRubinger/aileron/core/api/gen"
 	"github.com/ALRubinger/aileron/core/approval"
-	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/draft"
 	"github.com/ALRubinger/aileron/core/llm"
 	"github.com/ALRubinger/aileron/core/source"
@@ -238,44 +237,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		if authCfg.SlackEnabled() {
 			server.slackSigningSecret = authCfg.SlackSigningSecret
 			server.slackDedup = newSlackEventDedup()
-			server.onSlackMessage = func(ctx context.Context, userID string, msg comms.IncomingMessage) {
-				log.Info("slack cloud message received",
-					"user_id", userID,
-					"channel", msg.Channel,
-					"author", msg.Author,
-					"preview", msg.Body[:min(len(msg.Body), 80)])
-
-				if server.draftPipeline != nil {
-					// Post immediate "drafting..." indicator so the user
-					// knows Aileron is working while the LLM runs.
-					creds, err := server.resolveSlackCredentials(ctx, userID)
-					if err != nil {
-						log.Error("failed to resolve slack credentials", "user_id", userID, "error", err)
-					} else {
-						server.postDraftingIndicator(ctx, creds, msg.Channel, msg.ID)
-					}
-
-					draftText, err := server.draftPipeline.GenerateDraft(ctx, userID, msg)
-					if err != nil {
-						log.Error("draft generation failed", "user_id", userID, "error", err)
-						return
-					}
-
-					d, err := server.createDraftFromMessage(ctx, userID, msg, draftText)
-					if err != nil {
-						log.Error("failed to store draft", "error", err)
-						return
-					}
-					log.Info("draft pending review",
-						"draft_id", d.ID,
-						"user_id", userID,
-						"channel", msg.Channel,
-						"draft_length", len(draftText))
-
-					// Post ephemeral draft preview in Slack.
-					server.deliverEphemeralDraft(ctx, userID, d)
-				}
-			}
+			server.onSlackMessage = server.handleIncomingSlackMessage
 			mux.HandleFunc("POST /v1/webhooks/slack/events", server.handleSlackEvent)
 			mux.HandleFunc("POST /v1/webhooks/slack/interactions", server.handleSlackInteraction)
 			log.Info("enabled Slack Events API webhook and interaction endpoints")

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -55,6 +55,7 @@ type apiServer struct {
 	feedback           store.DraftFeedbackStore  // draft feedback signals for behavioral model
 	slackSender        SlackSender            // injectable for testing; defaults to comms.SendSlackMessage
 	ephemeralPoster    EphemeralPoster        // injectable for testing; defaults to comms.PostEphemeralDraft
+	ephemeralTextPoster EphemeralTextPoster   // injectable for testing; defaults to comms.PostEphemeralText
 	threadChecker      ThreadChecker          // injectable for testing; defaults to comms.SlackThreadHasReplies
 	slackSigningSecret string                  // Slack Events API signing secret for webhook verification
 	slackDedup         *slackEventDedup        // deduplication cache for Slack events

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"strings"
 	"time"
@@ -427,46 +428,84 @@ func (s *apiServer) handleListFeedback(w http.ResponseWriter, r *http.Request) {
 	writeJSON(w, http.StatusOK, map[string]any{"items": feedback})
 }
 
-// deliverEphemeralDraft posts an ephemeral Block Kit message in the Slack
-// channel where the original message was, showing the draft with
-// approve/edit/discard buttons. Only the target user sees it.
-func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, draft model.Draft) {
+// slackCredentials holds resolved Slack bot token and user ID for a user.
+type slackCredentials struct {
+	BotToken    string
+	SlackUserID string
+}
+
+// resolveSlackCredentials looks up the user's connected Slack account and
+// retrieves their bot token and Slack user ID from the vault.
+func (s *apiServer) resolveSlackCredentials(ctx context.Context, userID string) (*slackCredentials, error) {
 	slackProvider := model.ConnectedAccountProviderSlack
 	accounts, err := s.connectedAccounts.List(ctx, store.ConnectedAccountFilter{
 		UserID:   userID,
 		Provider: &slackProvider,
 	})
 	if err != nil || len(accounts) == 0 {
-		s.log.Error("ephemeral: no slack account — user must connect Slack via /v1/connect/slack", "user_id", userID)
-		return
+		return nil, fmt.Errorf("no slack account for user %s", userID)
 	}
 
 	acct := accounts[0]
 
-	// Get the token data from vault.
 	secret, err := s.vault.Get(ctx, acct.VaultPath())
 	if err != nil {
-		s.log.Error("ephemeral: failed to get vault token", "user_id", userID, "error", err)
-		return
+		return nil, fmt.Errorf("failed to get vault token: %w", err)
 	}
 
 	var tokenData map[string]string
 	if err := json.Unmarshal(secret.Value, &tokenData); err != nil {
-		s.log.Error("ephemeral: failed to parse token — reconnect Slack", "user_id", userID, "error", err)
-		return
+		return nil, fmt.Errorf("failed to parse token: %w", err)
 	}
 
 	botToken := tokenData["bot_access_token"]
 	if botToken == "" {
-		s.log.Error("ephemeral: no bot token — Slack app needs chat:write bot scope, then reconnect Slack",
-			"user_id", userID,
-			"has_user_token", tokenData["access_token"] != "")
-		return
+		return nil, fmt.Errorf("no bot token — Slack app needs chat:write bot scope")
 	}
 
 	slackUserID := acct.ExternalUserID
 	if slackUserID == "" {
-		s.log.Error("ephemeral: no slack user ID on connected account — reconnect Slack", "user_id", userID)
+		return nil, fmt.Errorf("no slack user ID on connected account")
+	}
+
+	return &slackCredentials{BotToken: botToken, SlackUserID: slackUserID}, nil
+}
+
+// EphemeralTextPoster posts a simple text ephemeral message.
+// Defaults to comms.PostEphemeralText. Override in tests.
+type EphemeralTextPoster func(ctx context.Context, botToken, channel, userID, text, threadTS string) error
+
+// postDraftingIndicator posts a transient "Drafting a reply..." ephemeral
+// message so the user gets immediate feedback while the LLM works.
+func (s *apiServer) postDraftingIndicator(ctx context.Context, creds *slackCredentials, channel, messageTS string) {
+	// Resolve thread safety: only post in-thread if thread has replies.
+	checker := s.threadChecker
+	if checker == nil {
+		checker = comms.SlackThreadHasReplies
+	}
+	threadTS := ""
+	if messageTS != "" {
+		if checker(ctx, creds.BotToken, channel, messageTS) {
+			threadTS = messageTS
+		}
+	}
+
+	poster := s.ephemeralTextPoster
+	if poster == nil {
+		poster = comms.PostEphemeralText
+	}
+	if err := poster(ctx, creds.BotToken, channel, creds.SlackUserID, ":writing_hand: Drafting a reply…", threadTS); err != nil {
+		s.log.Error("drafting indicator: failed to post", "error", err)
+	}
+}
+
+// deliverEphemeralDraft posts an ephemeral Block Kit message in the Slack
+// channel where the original message was, showing the draft with
+// approve/edit/discard buttons. Only the target user sees it.
+func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, draft model.Draft) {
+	creds, err := s.resolveSlackCredentials(ctx, userID)
+	if err != nil {
+		s.log.Error("ephemeral: "+err.Error(), "user_id", userID)
 		return
 	}
 
@@ -479,7 +518,7 @@ func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, dr
 	}
 	threadTS := ""
 	if draft.MessageTS != "" {
-		if checker(ctx, botToken, draft.Channel, draft.MessageTS) {
+		if checker(ctx, creds.BotToken, draft.Channel, draft.MessageTS) {
 			threadTS = draft.MessageTS
 		}
 	}
@@ -489,9 +528,9 @@ func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, dr
 		poster = comms.PostEphemeralDraft
 	}
 	err = poster(ctx, comms.SlackDraftMessage{
-		BotToken: botToken,
+		BotToken: creds.BotToken,
 		Channel:  draft.Channel,
-		UserID:   slackUserID,
+		UserID:   creds.SlackUserID,
 		DraftID:  draft.ID,
 		Author:   draft.Author,
 		Body:     draft.MessageBody,

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -548,6 +548,50 @@ func (s *apiServer) deliverEphemeralDraft(ctx context.Context, userID string, dr
 		"channel", draft.Channel)
 }
 
+// handleIncomingSlackMessage processes an incoming Slack message that mentions
+// the user. It posts a drafting indicator, generates a draft via the LLM
+// pipeline, stores it, and delivers an ephemeral preview with action buttons.
+func (s *apiServer) handleIncomingSlackMessage(ctx context.Context, userID string, msg comms.IncomingMessage) {
+	s.log.Info("slack cloud message received",
+		"user_id", userID,
+		"channel", msg.Channel,
+		"author", msg.Author,
+		"preview", msg.Body[:min(len(msg.Body), 80)])
+
+	if s.draftPipeline == nil {
+		return
+	}
+
+	// Post immediate "drafting..." indicator so the user
+	// knows Aileron is working while the LLM runs.
+	creds, err := s.resolveSlackCredentials(ctx, userID)
+	if err != nil {
+		s.log.Error("failed to resolve slack credentials", "user_id", userID, "error", err)
+	} else {
+		s.postDraftingIndicator(ctx, creds, msg.Channel, msg.ID)
+	}
+
+	draftText, err := s.draftPipeline.GenerateDraft(ctx, userID, msg)
+	if err != nil {
+		s.log.Error("draft generation failed", "user_id", userID, "error", err)
+		return
+	}
+
+	d, err := s.createDraftFromMessage(ctx, userID, msg, draftText)
+	if err != nil {
+		s.log.Error("failed to store draft", "error", err)
+		return
+	}
+	s.log.Info("draft pending review",
+		"draft_id", d.ID,
+		"user_id", userID,
+		"channel", msg.Channel,
+		"draft_length", len(draftText))
+
+	// Post ephemeral draft preview in Slack.
+	s.deliverEphemeralDraft(ctx, userID, d)
+}
+
 // createDraftFromMessage stores a generated draft as pending in the draft store.
 // Extracted from the onSlackMessage closure so it can be unit tested.
 func (s *apiServer) createDraftFromMessage(ctx context.Context, userID string, msg comms.IncomingMessage, draftText string) (model.Draft, error) {

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -1011,6 +1011,80 @@ func TestResolveSlackCredentials_NoAccount(t *testing.T) {
 	}
 }
 
+func TestResolveSlackCredentials_BadTokenJSON(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123",
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte("not-json"), vault.Metadata{})
+
+	_, err := srv.resolveSlackCredentials(ctx, "usr_a")
+	if err == nil {
+		t.Fatal("expected error for bad token JSON")
+	}
+}
+
+func TestResolveSlackCredentials_NoBotToken(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123",
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test"}`), vault.Metadata{})
+
+	_, err := srv.resolveSlackCredentials(ctx, "usr_a")
+	if err == nil {
+		t.Fatal("expected error when bot token missing")
+	}
+}
+
+func TestResolveSlackCredentials_NoExternalUserID(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive,
+		// No ExternalUserID
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp","bot_access_token":"xoxb"}`), vault.Metadata{})
+
+	_, err := srv.resolveSlackCredentials(ctx, "usr_a")
+	if err == nil {
+		t.Fatal("expected error when external user ID missing")
+	}
+}
+
+func TestPostDraftingIndicator_NoMessageTS(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	var capturedThreadTS string
+	srv.ephemeralTextPoster = func(_ context.Context, _, _, _, _, threadTS string) error {
+		capturedThreadTS = threadTS
+		return nil
+	}
+
+	creds := &slackCredentials{BotToken: "xoxb-test", SlackUserID: "U123ABC"}
+	srv.postDraftingIndicator(context.Background(), creds, "C0BACKEND", "")
+
+	if capturedThreadTS != "" {
+		t.Errorf("expected empty threadTS when messageTS is empty, got %q", capturedThreadTS)
+	}
+}
+
+func TestPostDraftingIndicator_PosterError(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	srv.threadChecker = func(_ context.Context, _, _, _ string) bool { return false }
+	srv.ephemeralTextPoster = func(_ context.Context, _, _, _, _, _ string) error {
+		return fmt.Errorf("slack API error")
+	}
+
+	creds := &slackCredentials{BotToken: "xoxb-test", SlackUserID: "U123ABC"}
+	// Should not panic — just logs the error.
+	srv.postDraftingIndicator(context.Background(), creds, "C0BACKEND", "1234567890.123456")
+}
+
 func TestListFeedback_NilStore(t *testing.T) {
 	srv := newDraftsTestServer()
 	srv.feedback = nil

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -945,6 +945,72 @@ func TestListFeedback_Empty(t *testing.T) {
 	}
 }
 
+func TestPostDraftingIndicator_PostsEphemeralText(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	srv.threadChecker = func(_ context.Context, _, _, _ string) bool { return false }
+
+	var capturedText, capturedChannel, capturedUserID string
+	srv.ephemeralTextPoster = func(_ context.Context, _, channel, userID, text, _ string) error {
+		capturedChannel = channel
+		capturedUserID = userID
+		capturedText = text
+		return nil
+	}
+
+	creds := &slackCredentials{BotToken: "xoxb-test", SlackUserID: "U123ABC"}
+	srv.postDraftingIndicator(context.Background(), creds, "C0BACKEND", "1234567890.123456")
+
+	if capturedChannel != "C0BACKEND" {
+		t.Errorf("expected channel C0BACKEND, got %s", capturedChannel)
+	}
+	if capturedUserID != "U123ABC" {
+		t.Errorf("expected user U123ABC, got %s", capturedUserID)
+	}
+	if capturedText == "" {
+		t.Error("expected non-empty indicator text")
+	}
+}
+
+func TestPostDraftingIndicator_ThreadTS_WhenRepliesExist(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	srv.threadChecker = func(_ context.Context, _, _, _ string) bool { return true }
+
+	var capturedThreadTS string
+	srv.ephemeralTextPoster = func(_ context.Context, _, _, _, _, threadTS string) error {
+		capturedThreadTS = threadTS
+		return nil
+	}
+
+	creds := &slackCredentials{BotToken: "xoxb-test", SlackUserID: "U123ABC"}
+	srv.postDraftingIndicator(context.Background(), creds, "C0BACKEND", "1234567890.123456")
+
+	if capturedThreadTS != "1234567890.123456" {
+		t.Errorf("expected threadTS when thread has replies, got %q", capturedThreadTS)
+	}
+}
+
+func TestResolveSlackCredentials_Success(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	creds, err := srv.resolveSlackCredentials(context.Background(), "usr_a")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if creds.BotToken != "xoxb-test" {
+		t.Errorf("expected xoxb-test, got %s", creds.BotToken)
+	}
+	if creds.SlackUserID != "U123ABC" {
+		t.Errorf("expected U123ABC, got %s", creds.SlackUserID)
+	}
+}
+
+func TestResolveSlackCredentials_NoAccount(t *testing.T) {
+	srv := newDraftsTestServer()
+	_, err := srv.resolveSlackCredentials(context.Background(), "usr_a")
+	if err == nil {
+		t.Fatal("expected error when no slack account")
+	}
+}
+
 func TestListFeedback_NilStore(t *testing.T) {
 	srv := newDraftsTestServer()
 	srv.feedback = nil

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -11,11 +11,27 @@ import (
 	"time"
 
 	"github.com/ALRubinger/aileron/core/comms"
+	"github.com/ALRubinger/aileron/core/draft"
+	"github.com/ALRubinger/aileron/core/llm"
 	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/source"
 	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/store/mem"
 	"github.com/ALRubinger/aileron/core/vault"
 )
+
+// stubLLMClient returns a fixed response for all LLM calls.
+type stubLLMClient struct {
+	response *llm.GenerateResponse
+	err      error
+}
+
+func (s *stubLLMClient) GenerateWithTools(_ context.Context, _ llm.GenerateRequest) (*llm.GenerateResponse, error) {
+	if s.err != nil {
+		return nil, s.err
+	}
+	return s.response, nil
+}
 
 func newDraftsTestServer() *apiServer {
 	return &apiServer{
@@ -1070,6 +1086,134 @@ func TestPostDraftingIndicator_NoMessageTS(t *testing.T) {
 
 	if capturedThreadTS != "" {
 		t.Errorf("expected empty threadTS when messageTS is empty, got %q", capturedThreadTS)
+	}
+}
+
+func TestHandleIncomingSlackMessage_FullPipeline(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	srv.threadChecker = func(_ context.Context, _, _, _ string) bool { return false }
+
+	mockLLM := &stubLLMClient{
+		response: &llm.GenerateResponse{Text: "Draft reply text"},
+	}
+	srv.draftPipeline = draft.NewPipeline(
+		mockLLM, source.NewRegistry(), srv.connectedAccounts,
+		mem.NewUserInstructionStore(), srv.vault, slog.Default(),
+		draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"},
+	)
+
+	var indicatorPosted, draftPosted bool
+	srv.ephemeralTextPoster = func(_ context.Context, _, _, _, _, _ string) error {
+		indicatorPosted = true
+		return nil
+	}
+	srv.ephemeralPoster = func(_ context.Context, msg comms.SlackDraftMessage) error {
+		draftPosted = true
+		if msg.Draft != "Draft reply text" {
+			t.Errorf("expected draft text, got %q", msg.Draft)
+		}
+		return nil
+	}
+
+	srv.handleIncomingSlackMessage(context.Background(), "usr_a", comms.IncomingMessage{
+		ID: "123.456", Service: "slack", Channel: "C0BACKEND", Author: "Sarah",
+		Body: "What happened this week?",
+	})
+
+	if !indicatorPosted {
+		t.Error("expected drafting indicator to be posted")
+	}
+	if !draftPosted {
+		t.Error("expected draft ephemeral to be posted")
+	}
+
+	// Verify draft was stored.
+	drafts, _ := srv.drafts.List(context.Background(), store.DraftFilter{UserID: "usr_a"})
+	if len(drafts) != 1 {
+		t.Fatalf("expected 1 draft in store, got %d", len(drafts))
+	}
+	if drafts[0].DraftBody != "Draft reply text" {
+		t.Errorf("unexpected stored draft body: %q", drafts[0].DraftBody)
+	}
+}
+
+func TestHandleIncomingSlackMessage_NoPipeline(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	srv.draftPipeline = nil // no pipeline configured
+
+	called := false
+	srv.ephemeralTextPoster = func(_ context.Context, _, _, _, _, _ string) error {
+		called = true
+		return nil
+	}
+
+	srv.handleIncomingSlackMessage(context.Background(), "usr_a", comms.IncomingMessage{
+		ID: "123.456", Service: "slack", Channel: "C0BACKEND", Author: "Sarah",
+		Body: "Hello",
+	})
+
+	if called {
+		t.Error("should not post indicator when pipeline is nil")
+	}
+}
+
+func TestHandleIncomingSlackMessage_LLMError(t *testing.T) {
+	srv := newDraftsTestServerWithSend()
+	srv.threadChecker = func(_ context.Context, _, _, _ string) bool { return false }
+
+	mockLLM := &stubLLMClient{err: fmt.Errorf("LLM unavailable")}
+	srv.draftPipeline = draft.NewPipeline(
+		mockLLM, source.NewRegistry(), srv.connectedAccounts,
+		mem.NewUserInstructionStore(), srv.vault, slog.Default(),
+		draft.Prompts{Research: "test", Ghostwrite: "test"},
+	)
+
+	srv.ephemeralTextPoster = func(_ context.Context, _, _, _, _, _ string) error { return nil }
+
+	var draftPosted bool
+	srv.ephemeralPoster = func(_ context.Context, _ comms.SlackDraftMessage) error {
+		draftPosted = true
+		return nil
+	}
+
+	srv.handleIncomingSlackMessage(context.Background(), "usr_a", comms.IncomingMessage{
+		ID: "123.456", Service: "slack", Channel: "C0BACKEND", Author: "Sarah",
+		Body: "Hello",
+	})
+
+	if draftPosted {
+		t.Error("should not post draft when LLM fails")
+	}
+
+	// Verify no draft was stored.
+	drafts, _ := srv.drafts.List(context.Background(), store.DraftFilter{UserID: "usr_a"})
+	if len(drafts) != 0 {
+		t.Fatalf("expected 0 drafts after LLM error, got %d", len(drafts))
+	}
+}
+
+func TestHandleIncomingSlackMessage_NoSlackCredentials(t *testing.T) {
+	// User has no connected Slack account — indicator should be skipped
+	// but draft generation should still proceed.
+	srv := newDraftsTestServer() // no connected account
+	mockLLM := &stubLLMClient{
+		response: &llm.GenerateResponse{Text: "Draft without indicator"},
+	}
+	srv.draftPipeline = draft.NewPipeline(
+		mockLLM, source.NewRegistry(), srv.connectedAccounts,
+		mem.NewUserInstructionStore(), srv.vault, slog.Default(),
+		draft.Prompts{Research: "test", Ghostwrite: "test"},
+	)
+
+	srv.handleIncomingSlackMessage(context.Background(), "usr_a", comms.IncomingMessage{
+		ID: "123.456", Service: "slack", Channel: "C0BACKEND", Author: "Sarah",
+		Body: "Hello",
+	})
+
+	// Draft should still be stored even without credentials for indicator.
+	drafts, _ := srv.drafts.List(context.Background(), store.DraftFilter{UserID: "usr_a"})
+	if len(drafts) != 1 {
+		t.Fatalf("expected 1 draft, got %d", len(drafts))
 	}
 }
 

--- a/core/comms/slack_ephemeral.go
+++ b/core/comms/slack_ephemeral.go
@@ -47,17 +47,40 @@ func PostEphemeralDraft(ctx context.Context, msg SlackDraftMessage) error {
 	return err
 }
 
+// slackEphemeralAPIURL overrides the Slack API URL for testing.
+var slackEphemeralAPIURL string
+
+// SetEphemeralAPIURL sets the Slack API URL for testing. Call with empty string to reset.
+func SetEphemeralAPIURL(url string) {
+	slackEphemeralAPIURL = url
+}
+
 // PostEphemeralText posts a simple text-only ephemeral message to a user.
 // Used for transient status indicators like "Drafting a reply...".
 func PostEphemeralText(ctx context.Context, botToken, channel, userID, text, threadTS string) error {
-	client := slack.New(botToken)
-	opts := []slack.MsgOption{
+	if botToken == "" {
+		return fmt.Errorf("slack: bot token is required for ephemeral messages")
+	}
+	if channel == "" {
+		return fmt.Errorf("slack: channel is required")
+	}
+	if userID == "" {
+		return fmt.Errorf("slack: user ID is required")
+	}
+
+	var opts []slack.Option
+	if slackEphemeralAPIURL != "" {
+		opts = append(opts, slack.OptionAPIURL(slackEphemeralAPIURL))
+	}
+	client := slack.New(botToken, opts...)
+
+	msgOpts := []slack.MsgOption{
 		slack.MsgOptionText(text, false),
 	}
 	if threadTS != "" {
-		opts = append(opts, slack.MsgOptionTS(threadTS))
+		msgOpts = append(msgOpts, slack.MsgOptionTS(threadTS))
 	}
-	_, err := client.PostEphemeralContext(ctx, channel, userID, opts...)
+	_, err := client.PostEphemeralContext(ctx, channel, userID, msgOpts...)
 	return err
 }
 

--- a/core/comms/slack_ephemeral.go
+++ b/core/comms/slack_ephemeral.go
@@ -47,6 +47,20 @@ func PostEphemeralDraft(ctx context.Context, msg SlackDraftMessage) error {
 	return err
 }
 
+// PostEphemeralText posts a simple text-only ephemeral message to a user.
+// Used for transient status indicators like "Drafting a reply...".
+func PostEphemeralText(ctx context.Context, botToken, channel, userID, text, threadTS string) error {
+	client := slack.New(botToken)
+	opts := []slack.MsgOption{
+		slack.MsgOptionText(text, false),
+	}
+	if threadTS != "" {
+		opts = append(opts, slack.MsgOptionTS(threadTS))
+	}
+	_, err := client.PostEphemeralContext(ctx, channel, userID, opts...)
+	return err
+}
+
 // BuildDraftBlocks constructs the Block Kit layout for a draft ephemeral
 // message. Exported for testing.
 func BuildDraftBlocks(msg SlackDraftMessage) []slack.Block {

--- a/core/comms/slack_ephemeral_test.go
+++ b/core/comms/slack_ephemeral_test.go
@@ -2,6 +2,9 @@ package comms_test
 
 import (
 	"context"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -40,6 +43,90 @@ func TestPostEphemeralDraft_EmptyUserID(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected error for empty user ID")
+	}
+}
+
+func TestPostEphemeralText_EmptyBotToken(t *testing.T) {
+	err := comms.PostEphemeralText(context.Background(), "", "C123", "U123", "hello", "")
+	if err == nil {
+		t.Fatal("expected error for empty bot token")
+	}
+}
+
+func TestPostEphemeralText_EmptyChannel(t *testing.T) {
+	err := comms.PostEphemeralText(context.Background(), "xoxb-test", "", "U123", "hello", "")
+	if err == nil {
+		t.Fatal("expected error for empty channel")
+	}
+}
+
+func TestPostEphemeralText_EmptyUserID(t *testing.T) {
+	err := comms.PostEphemeralText(context.Background(), "xoxb-test", "C123", "", "hello", "")
+	if err == nil {
+		t.Fatal("expected error for empty user ID")
+	}
+}
+
+func TestPostEphemeralText_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":         true,
+			"message_ts": "1234567890.123456",
+		})
+	}))
+	defer server.Close()
+
+	comms.SetEphemeralAPIURL(server.URL + "/")
+	defer comms.SetEphemeralAPIURL("")
+
+	err := comms.PostEphemeralText(context.Background(), "xoxb-test", "C123", "U456", "Drafting a reply...", "")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+}
+
+func TestPostEphemeralText_WithThreadTS(t *testing.T) {
+	var capturedBody string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		r.ParseForm()
+		capturedBody = r.FormValue("thread_ts")
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":         true,
+			"message_ts": "1234567890.123456",
+		})
+	}))
+	defer server.Close()
+
+	comms.SetEphemeralAPIURL(server.URL + "/")
+	defer comms.SetEphemeralAPIURL("")
+
+	err := comms.PostEphemeralText(context.Background(), "xoxb-test", "C123", "U456", "Drafting...", "999.888")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if capturedBody != "999.888" {
+		t.Errorf("expected thread_ts=999.888, got %q", capturedBody)
+	}
+}
+
+func TestPostEphemeralText_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":    false,
+			"error": "channel_not_found",
+		})
+	}))
+	defer server.Close()
+
+	comms.SetEphemeralAPIURL(server.URL + "/")
+	defer comms.SetEphemeralAPIURL("")
+
+	err := comms.PostEphemeralText(context.Background(), "xoxb-test", "C123", "U456", "hello", "")
+	if err == nil {
+		t.Fatal("expected error on API failure")
 	}
 }
 


### PR DESCRIPTION
## Summary

- Posts an ephemeral ":writing_hand: Drafting a reply…" message immediately when an @mention triggers draft generation, so the user gets feedback while the LLM works (10-30s)
- Full draft with approve/edit/discard buttons follows when generation completes
- Extracts `resolveSlackCredentials` helper to share credential resolution between the indicator and draft delivery
- Adds `PostEphemeralText` to `comms` for simple text-only ephemeral messages

## Test plan

- [ ] `TestPostDraftingIndicator_PostsEphemeralText` — verifies indicator posts to correct channel/user
- [ ] `TestPostDraftingIndicator_ThreadTS_WhenRepliesExist` — verifies threading behavior
- [ ] `TestResolveSlackCredentials_Success` / `_NoAccount` — verifies credential resolution
- [ ] Deploy to staging and trigger @mention — confirm "Drafting a reply…" appears immediately, then draft with buttons follows

🤖 Generated with [Claude Code](https://claude.com/claude-code)