### PR TITLE
perf(draft): use Haiku for research, batch tool calls, add timing

### DIFF
--- a/AILERON.md
+++ b/AILERON.md
@@ -6,19 +6,28 @@ Your job is to find ALL relevant information needed to write a good reply. Use t
 
 Today is {{today}}.
 
+## CRITICAL: Batch All Tool Calls
+
+Each tool-call round costs a full network round-trip. Minimize the number of rounds by requesting ALL independent tool calls in a single response.
+
+- **Plan first, then execute.** Decide which searches you need, then request them ALL at once.
+- **Never request one tool at a time.** If you need to search Slack, GitHub, Gmail, and Calendar — request all four in one response.
+- **Aim for 2–3 rounds maximum.** Round 1: broad initial searches across all sources. Round 2: follow-up searches to fill gaps. Round 3 (if needed): final targeted lookups.
+- **Do NOT serialize searches.** Searching Slack, then GitHub, then Calendar in separate responses wastes time. Request them in parallel.
+
 ## Time Range Coverage
 
-When the message references a time period ("this week," "since Monday," "last sprint," "recently"), you MUST cover the FULL range systematically. Do not rely on a single search — APIs return recent results first and silently drop older ones.
+When the message references a time period ("this week," "since Monday," "last sprint," "recently"), cover the FULL range. APIs return recent results first and silently drop older ones.
 
 Strategy for time-based queries:
-- Break the range into segments. For "this week" (Mon–Fri), search Mon–Tue, Wed–Thu, and Fri separately.
-- Use different query terms for each segment. A search for "deploy" won't find a PR titled "migrate stores to postgres."
-- Search each source type independently: PRs, issues, commits, messages, calendar events.
-- After your initial searches, review what you have. If any segment of the time range has no results, search again with broader terms — the absence of results usually means your query was too narrow, not that nothing happened.
+- Break the range into segments and search each segment — but request ALL segments in one response.
+- Use different query terms across segments. A search for "deploy" won't find a PR titled "migrate stores to postgres."
+- Search each source type independently: PRs, issues, commits, messages, calendar events — all in the same response.
+- After your initial batch, review what you have. If any segment has no results, fill the gaps in one follow-up batch.
 
 ## Thoroughness
 
-- Use many tool calls. A weekly summary typically needs 8–15 searches across different queries, date ranges, and source types.
+- A weekly summary typically needs 8–15 searches — but they should be batched into 2–3 rounds, not 8–15 sequential rounds.
 - Search with varied terms: feature names, component names, people's names, broad terms ("merged," "shipped," "fixed").
 - Include full URLs (e.g. https://github.com/org/repo/pull/123) for everything you find.
 - It is far better to find too much than too little. The ghostwriter will synthesize — your job is to ensure nothing is missed.

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -224,11 +224,13 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 
 		// LLM-powered draft generation pipeline.
 		if authCfg.LLMEnabled() {
-			llmClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModel)
+			researchClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMResearchModel, llm.WithLogger(log))
+			ghostwriteClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModel, llm.WithLogger(log))
 			prompts := draft.LoadPrompts()
-			server.draftPipeline = draft.NewPipeline(llmClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log, prompts)
+			server.draftPipeline = draft.NewPipeline(researchClient, ghostwriteClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log, prompts)
 			log.Info("enabled cloud draft generation",
-				"model", authCfg.LLMModel,
+				"research_model", authCfg.LLMResearchModel,
+				"ghostwrite_model", authCfg.LLMModel,
 				"research_prompt_length", len(prompts.Research),
 				"ghostwrite_prompt_length", len(prompts.Ghostwrite),
 				"prompt_source", draft.PromptSource())

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -224,13 +224,13 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 
 		// LLM-powered draft generation pipeline.
 		if authCfg.LLMEnabled() {
-			researchClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMResearchModel, llm.WithLogger(log))
-			ghostwriteClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModel, llm.WithLogger(log))
+			researchClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModelResearch, llm.WithLogger(log))
+			synthesisClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModelSynthesis, llm.WithLogger(log))
 			prompts := draft.LoadPrompts()
-			server.draftPipeline = draft.NewPipeline(researchClient, ghostwriteClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log, prompts)
+			server.draftPipeline = draft.NewPipeline(researchClient, synthesisClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log, prompts)
 			log.Info("enabled cloud draft generation",
-				"research_model", authCfg.LLMResearchModel,
-				"ghostwrite_model", authCfg.LLMModel,
+				"research_model", authCfg.LLMModelResearch,
+				"synthesis_model", authCfg.LLMModelSynthesis,
 				"research_prompt_length", len(prompts.Research),
 				"ghostwrite_prompt_length", len(prompts.Ghostwrite),
 				"prompt_source", draft.PromptSource())

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -1097,7 +1097,7 @@ func TestHandleIncomingSlackMessage_FullPipeline(t *testing.T) {
 		response: &llm.GenerateResponse{Text: "Draft reply text"},
 	}
 	srv.draftPipeline = draft.NewPipeline(
-		mockLLM, source.NewRegistry(), srv.connectedAccounts,
+		mockLLM, mockLLM, source.NewRegistry(), srv.connectedAccounts,
 		mem.NewUserInstructionStore(), srv.vault, slog.Default(),
 		draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"},
 	)
@@ -1163,7 +1163,7 @@ func TestHandleIncomingSlackMessage_LLMError(t *testing.T) {
 
 	mockLLM := &stubLLMClient{err: fmt.Errorf("LLM unavailable")}
 	srv.draftPipeline = draft.NewPipeline(
-		mockLLM, source.NewRegistry(), srv.connectedAccounts,
+		mockLLM, mockLLM, source.NewRegistry(), srv.connectedAccounts,
 		mem.NewUserInstructionStore(), srv.vault, slog.Default(),
 		draft.Prompts{Research: "test", Ghostwrite: "test"},
 	)
@@ -1200,7 +1200,7 @@ func TestHandleIncomingSlackMessage_NoSlackCredentials(t *testing.T) {
 		response: &llm.GenerateResponse{Text: "Draft without indicator"},
 	}
 	srv.draftPipeline = draft.NewPipeline(
-		mockLLM, source.NewRegistry(), srv.connectedAccounts,
+		mockLLM, mockLLM, source.NewRegistry(), srv.connectedAccounts,
 		mem.NewUserInstructionStore(), srv.vault, slog.Default(),
 		draft.Prompts{Research: "test", Ghostwrite: "test"},
 	)

--- a/core/config/auth.go
+++ b/core/config/auth.go
@@ -71,9 +71,11 @@ type AuthConfig struct {
 	MailFrom string
 
 	// LLM configuration for cloud-hosted draft generation.
-	AnthropicAPIKey  string // Env: ANTHROPIC_API_KEY
-	LLMModel         string // Env: AILERON_LLM_MODEL (default: "claude-sonnet-4-6")
-	LLMResearchModel string // Env: AILERON_LLM_RESEARCH_MODEL (default: "claude-haiku-4-5-20251001")
+	// Two models: research (fast, cheap — tool-call decisions) and synthesis
+	// (capable — composing the final reply in the user's voice).
+	AnthropicAPIKey   string // Env: ANTHROPIC_API_KEY
+	LLMModelResearch  string // Env: AILERON_LLM_MODEL_RESEARCH (default: "claude-haiku-4-5-20251001")
+	LLMModelSynthesis string // Env: AILERON_LLM_MODEL_SYNTHESIS (default: "claude-sonnet-4-6")
 }
 
 // LoadAuthConfig loads auth configuration from environment variables.
@@ -100,8 +102,8 @@ func LoadAuthConfig() (*AuthConfig, error) {
 		ResendAPIKey:       envTrimmed("RESEND_API_KEY"),
 		MailFrom:           envOrDefault("MAIL_FROM", "noreply@withaileron.ai"),
 		AnthropicAPIKey:    envTrimmed("ANTHROPIC_API_KEY"),
-		LLMModel:           envOrDefault("AILERON_LLM_MODEL", "claude-sonnet-4-6"),
-		LLMResearchModel:   envOrDefault("AILERON_LLM_RESEARCH_MODEL", "claude-haiku-4-5-20251001"),
+		LLMModelResearch:  envOrDefault("AILERON_LLM_MODEL_RESEARCH", "claude-haiku-4-5-20251001"),
+		LLMModelSynthesis: envOrDefault("AILERON_LLM_MODEL_SYNTHESIS", "claude-sonnet-4-6"),
 	}
 
 	// Parse durations with defaults.

--- a/core/config/auth.go
+++ b/core/config/auth.go
@@ -71,8 +71,9 @@ type AuthConfig struct {
 	MailFrom string
 
 	// LLM configuration for cloud-hosted draft generation.
-	AnthropicAPIKey string // Env: ANTHROPIC_API_KEY
-	LLMModel        string // Env: AILERON_LLM_MODEL (default: "claude-sonnet-4-6")
+	AnthropicAPIKey  string // Env: ANTHROPIC_API_KEY
+	LLMModel         string // Env: AILERON_LLM_MODEL (default: "claude-sonnet-4-6")
+	LLMResearchModel string // Env: AILERON_LLM_RESEARCH_MODEL (default: "claude-haiku-4-5-20251001")
 }
 
 // LoadAuthConfig loads auth configuration from environment variables.
@@ -100,6 +101,7 @@ func LoadAuthConfig() (*AuthConfig, error) {
 		MailFrom:           envOrDefault("MAIL_FROM", "noreply@withaileron.ai"),
 		AnthropicAPIKey:    envTrimmed("ANTHROPIC_API_KEY"),
 		LLMModel:           envOrDefault("AILERON_LLM_MODEL", "claude-sonnet-4-6"),
+		LLMResearchModel:   envOrDefault("AILERON_LLM_RESEARCH_MODEL", "claude-haiku-4-5-20251001"),
 	}
 
 	// Parse durations with defaults.

--- a/core/config/auth_test.go
+++ b/core/config/auth_test.go
@@ -354,7 +354,7 @@ func TestLoadAuthConfig_SlackPartial(t *testing.T) {
 func TestLoadAuthConfig_LLMEnabled(t *testing.T) {
 	t.Setenv("AILERON_DATABASE_URL", "")
 	t.Setenv("ANTHROPIC_API_KEY", "sk-ant-test-key")
-	t.Setenv("AILERON_LLM_MODEL", "claude-haiku-4-5")
+	t.Setenv("AILERON_LLM_MODEL_SYNTHESIS", "claude-haiku-4-5")
 
 	cfg, err := LoadAuthConfig()
 	if err != nil {
@@ -366,8 +366,8 @@ func TestLoadAuthConfig_LLMEnabled(t *testing.T) {
 	if cfg.AnthropicAPIKey != "sk-ant-test-key" {
 		t.Errorf("AnthropicAPIKey = %q", cfg.AnthropicAPIKey)
 	}
-	if cfg.LLMModel != "claude-haiku-4-5" {
-		t.Errorf("LLMModel = %q", cfg.LLMModel)
+	if cfg.LLMModelSynthesis != "claude-haiku-4-5" {
+		t.Errorf("LLMModelSynthesis = %q", cfg.LLMModelSynthesis)
 	}
 }
 
@@ -384,16 +384,20 @@ func TestLoadAuthConfig_LLMDisabled(t *testing.T) {
 	}
 }
 
-func TestLoadAuthConfig_LLMModelDefault(t *testing.T) {
+func TestLoadAuthConfig_LLMModelDefaults(t *testing.T) {
 	t.Setenv("AILERON_DATABASE_URL", "")
-	t.Setenv("AILERON_LLM_MODEL", "")
+	t.Setenv("AILERON_LLM_MODEL_RESEARCH", "")
+	t.Setenv("AILERON_LLM_MODEL_SYNTHESIS", "")
 
 	cfg, err := LoadAuthConfig()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.LLMModel != "claude-sonnet-4-6" {
-		t.Errorf("LLMModel = %q, want claude-sonnet-4-6", cfg.LLMModel)
+	if cfg.LLMModelResearch != "claude-haiku-4-5-20251001" {
+		t.Errorf("LLMModelResearch = %q, want claude-haiku-4-5-20251001", cfg.LLMModelResearch)
+	}
+	if cfg.LLMModelSynthesis != "claude-sonnet-4-6" {
+		t.Errorf("LLMModelSynthesis = %q, want claude-sonnet-4-6", cfg.LLMModelSynthesis)
 	}
 }
 
@@ -432,15 +436,15 @@ func TestLoadAuthConfig_TrimsWhitespace(t *testing.T) {
 
 func TestLoadAuthConfig_TrimsWhitespace_EnvOrDefault(t *testing.T) {
 	t.Setenv("AILERON_DATABASE_URL", "")
-	t.Setenv("AILERON_LLM_MODEL", " claude-haiku-4-5 ")
+	t.Setenv("AILERON_LLM_MODEL_SYNTHESIS", " claude-haiku-4-5 ")
 	t.Setenv("MAIL_FROM", " custom@example.com\n")
 
 	cfg, err := LoadAuthConfig()
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if cfg.LLMModel != "claude-haiku-4-5" {
-		t.Errorf("LLMModel not trimmed: %q", cfg.LLMModel)
+	if cfg.LLMModelSynthesis != "claude-haiku-4-5" {
+		t.Errorf("LLMModelSynthesis not trimmed: %q", cfg.LLMModelSynthesis)
 	}
 	if cfg.MailFrom != "custom@example.com" {
 		t.Errorf("MailFrom not trimmed: %q", cfg.MailFrom)

--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -25,7 +25,8 @@ import (
 
 // Pipeline orchestrates draft generation for incoming messages.
 type Pipeline struct {
-	llm               llm.Client
+	researchLLM       llm.Client
+	ghostwriteLLM     llm.Client
 	sourceRegistry    *source.Registry
 	connectedAccounts store.ConnectedAccountStore
 	instructions      store.UserInstructionStore
@@ -36,8 +37,11 @@ type Pipeline struct {
 }
 
 // NewPipeline creates a draft generation pipeline.
+// researchLLM handles tool-use context gathering (can be a fast/cheap model).
+// ghostwriteLLM handles the final reply composition (should be a capable model).
 func NewPipeline(
-	llmClient llm.Client,
+	researchLLM llm.Client,
+	ghostwriteLLM llm.Client,
 	sourceReg *source.Registry,
 	accounts store.ConnectedAccountStore,
 	instructions store.UserInstructionStore,
@@ -46,7 +50,8 @@ func NewPipeline(
 	prompts Prompts,
 ) *Pipeline {
 	return &Pipeline{
-		llm:               llmClient,
+		researchLLM:       researchLLM,
+		ghostwriteLLM:     ghostwriteLLM,
 		sourceRegistry:    sourceReg,
 		connectedAccounts: accounts,
 		instructions:      instructions,
@@ -101,7 +106,7 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 
 	var gatheredContext string
 	if len(tools) > 0 {
-		researchResp, err := p.llm.GenerateWithTools(ctx, llm.GenerateRequest{
+		researchResp, err := p.researchLLM.GenerateWithTools(ctx, llm.GenerateRequest{
 			SystemPrompt: researchSysPrompt,
 			UserMessage:  researchMessage,
 			Tools:        tools,
@@ -136,7 +141,7 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 		msg.Author, msg.Channel, msg.Body, gatheredContext,
 	)
 
-	draftResp, err := p.llm.GenerateWithTools(ctx, llm.GenerateRequest{
+	draftResp, err := p.ghostwriteLLM.GenerateWithTools(ctx, llm.GenerateRequest{
 		SystemPrompt: ghostwritePrompt,
 		UserMessage:  ghostwriteMessage,
 		// No tools — force text-only output.

--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -37,8 +37,8 @@ type Pipeline struct {
 }
 
 // NewPipeline creates a draft generation pipeline.
-// researchLLM handles tool-use context gathering (can be a fast/cheap model).
-// ghostwriteLLM handles the final reply composition (should be a capable model).
+// researchLLM handles tool-use context gathering (fast/cheap model like Haiku).
+// ghostwriteLLM handles synthesis — composing the reply (capable model like Sonnet).
 func NewPipeline(
 	researchLLM llm.Client,
 	ghostwriteLLM llm.Client,

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -66,7 +66,7 @@ func TestPipeline_GenerateDraft_Simple(t *testing.T) {
 	v := vault.NewMemVault()
 	sourceReg := source.NewRegistry()
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+	p := draft.NewPipeline(mock, mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	draftText, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID:      "msg_1",
@@ -123,7 +123,7 @@ func TestPipeline_GenerateDraft_WithTools(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+	p := draft.NewPipeline(mock, mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	draftText, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID:      "msg_1",
@@ -159,6 +159,70 @@ func TestPipeline_GenerateDraft_WithTools(t *testing.T) {
 	}
 }
 
+func TestPipeline_GenerateDraft_SeparateClients(t *testing.T) {
+	// Verify the pipeline dispatches research to one client and ghostwriting
+	// to another — enabling a fast model for research and a capable model
+	// for composition.
+	researchMock := &mockLLMClient{
+		response: &llm.GenerateResponse{
+			Text: "Context gathered from Slack and GitHub.",
+		},
+	}
+	ghostwriteMock := &mockLLMClient{
+		response: &llm.GenerateResponse{
+			Text: "Deployed the new auth middleware on Tuesday.",
+		},
+	}
+
+	accounts := mem.NewConnectedAccountStore()
+	v := vault.NewMemVault()
+	ctx := context.Background()
+
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_1",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	v.Put(ctx, "connected-accounts/usr_1/slack", []byte(`{"access_token":"xoxp-test"}`), vault.Metadata{})
+
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&mockSourceConnector{})
+
+	p := draft.NewPipeline(researchMock, ghostwriteMock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+
+	draftText, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
+		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah",
+		Body: "What shipped this week?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if draftText != "Deployed the new auth middleware on Tuesday." {
+		t.Errorf("unexpected draft: %q", draftText)
+	}
+
+	// Research client should have received the tool-bearing request.
+	if len(researchMock.requests) != 1 {
+		t.Fatalf("expected 1 research call, got %d", len(researchMock.requests))
+	}
+	if len(researchMock.requests[0].Tools) == 0 {
+		t.Error("expected tools in research request")
+	}
+
+	// Ghostwrite client should have received the tool-free request.
+	if len(ghostwriteMock.requests) != 1 {
+		t.Fatalf("expected 1 ghostwrite call, got %d", len(ghostwriteMock.requests))
+	}
+	if len(ghostwriteMock.requests[0].Tools) != 0 {
+		t.Errorf("expected 0 tools in ghostwrite request, got %d", len(ghostwriteMock.requests[0].Tools))
+	}
+	// Ghostwrite should receive the gathered context.
+	if !strings.Contains(ghostwriteMock.requests[0].UserMessage, "Context gathered from Slack and GitHub.") {
+		t.Error("expected gathered context in ghostwrite user message")
+	}
+}
+
 func TestPipeline_GenerateDraft_ToolExecutor(t *testing.T) {
 	// Verify the research round's tool executor resolves credentials
 	// and calls the source connector.
@@ -182,7 +246,7 @@ func TestPipeline_GenerateDraft_ToolExecutor(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+	p := draft.NewPipeline(mock, mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -219,7 +283,7 @@ func TestPipeline_GenerateDraft_NoConnectedAccounts(t *testing.T) {
 	sourceReg := source.NewRegistry()
 	sourceReg.Register(&mockSourceConnector{})
 
-	p := draft.NewPipeline(mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+	p := draft.NewPipeline(mock, mock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	draftText, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -259,7 +323,7 @@ func TestPipeline_GenerateDraft_WithInstructions(t *testing.T) {
 	})
 
 	sourceReg := source.NewRegistry()
-	p := draft.NewPipeline(mock, sourceReg, accounts, instructions, v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+	p := draft.NewPipeline(mock, mock, sourceReg, accounts, instructions, v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -292,7 +356,7 @@ func TestPipeline_GenerateDraft_NoInstructions(t *testing.T) {
 		response: &llm.GenerateResponse{Text: "Draft without instructions"},
 	}
 
-	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+	p := draft.NewPipeline(mock, mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	_, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
@@ -312,7 +376,7 @@ func TestPipeline_GenerateDraft_LLMError(t *testing.T) {
 		err: context.DeadlineExceeded,
 	}
 
-	p := draft.NewPipeline(mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+	p := draft.NewPipeline(mock, mock, source.NewRegistry(), mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(), vault.NewMemVault(), slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
 
 	_, err := p.GenerateDraft(context.Background(), "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",

--- a/core/llm/anthropic.go
+++ b/core/llm/anthropic.go
@@ -4,7 +4,9 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"sync"
+	"time"
 
 	"github.com/ALRubinger/aileron/core/source"
 	anthropic "github.com/anthropics/anthropic-sdk-go"
@@ -18,17 +20,33 @@ const defaultMaxToolRounds = 15
 type AnthropicClient struct {
 	client *anthropic.Client
 	model  anthropic.Model
+	log    *slog.Logger
 }
 
 // NewAnthropicClient creates an Anthropic LLM client.
-func NewAnthropicClient(apiKey, model string) *AnthropicClient {
+func NewAnthropicClient(apiKey, model string, opts ...AnthropicOption) *AnthropicClient {
 	c := anthropic.NewClient(option.WithAPIKey(apiKey))
 	if model == "" {
 		model = "claude-sonnet-4-6"
 	}
-	return &AnthropicClient{
+	ac := &AnthropicClient{
 		client: &c,
 		model:  anthropic.Model(model),
+		log:    slog.Default(),
+	}
+	for _, opt := range opts {
+		opt(ac)
+	}
+	return ac
+}
+
+// AnthropicOption configures an AnthropicClient.
+type AnthropicOption func(*AnthropicClient)
+
+// WithLogger sets the logger for the AnthropicClient.
+func WithLogger(log *slog.Logger) AnthropicOption {
+	return func(c *AnthropicClient) {
+		c.log = log
 	}
 }
 
@@ -43,6 +61,7 @@ func (a *AnthropicClient) SetBaseURL(url string) {
 }
 
 func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateRequest) (*GenerateResponse, error) {
+	totalStart := time.Now()
 	maxRounds := req.MaxToolRounds
 	if maxRounds <= 0 {
 		maxRounds = defaultMaxToolRounds
@@ -71,10 +90,19 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 			params.Tools = tools
 		}
 
+		apiStart := time.Now()
 		resp, err := a.client.Messages.New(ctx, params)
+		apiDur := time.Since(apiStart)
 		if err != nil {
 			return nil, fmt.Errorf("anthropic API error: %w", err)
 		}
+		a.log.Info("llm api call",
+			"round", round,
+			"model", string(a.model),
+			"duration_ms", apiDur.Milliseconds(),
+			"input_tokens", resp.Usage.InputTokens,
+			"output_tokens", resp.Usage.OutputTokens,
+		)
 
 		// Check if the response contains tool use requests.
 		var toolUseBlocks []anthropic.ContentBlockUnion
@@ -100,6 +128,12 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 				}
 				text += t
 			}
+			a.log.Info("llm generation complete",
+				"model", string(a.model),
+				"rounds", round,
+				"tool_calls", len(allToolCalls),
+				"total_ms", time.Since(totalStart).Milliseconds(),
+			)
 			return &GenerateResponse{
 				Text:      text,
 				ToolCalls: allToolCalls,
@@ -136,6 +170,7 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 		}
 		execResults := make([]toolExecResult, len(toolUseBlocks))
 
+		toolStart := time.Now()
 		g, gCtx := errgroup.WithContext(ctx)
 		var mu sync.Mutex
 		for i, block := range toolUseBlocks {
@@ -163,6 +198,11 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 			})
 		}
 		g.Wait()
+		a.log.Info("tool execution complete",
+			"round", round,
+			"tools", len(toolUseBlocks),
+			"duration_ms", time.Since(toolStart).Milliseconds(),
+		)
 
 		// Build tool results in original order.
 		var toolResults []anthropic.ContentBlockParamUnion
@@ -186,6 +226,12 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 	// the LLM to produce a text response with whatever context it has
 	// gathered so far. This prevents silent failures where the user gets
 	// no draft at all.
+	a.log.Warn("tool rounds exhausted, forcing text output",
+		"model", string(a.model),
+		"max_rounds", maxRounds,
+		"tool_calls", len(allToolCalls),
+		"elapsed_ms", time.Since(totalStart).Milliseconds(),
+	)
 	finalParams := anthropic.MessageNewParams{
 		Model:     a.model,
 		MaxTokens: 4096,
@@ -215,6 +261,12 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 		}
 		text += t
 	}
+	a.log.Info("llm generation complete (after exhaustion fallback)",
+		"model", string(a.model),
+		"rounds", maxRounds+1,
+		"tool_calls", len(allToolCalls),
+		"total_ms", time.Since(totalStart).Milliseconds(),
+	)
 	return &GenerateResponse{
 		Text:      text,
 		ToolCalls: allToolCalls,

--- a/deploy/.env.example
+++ b/deploy/.env.example
@@ -18,6 +18,11 @@ AILERON_AUTO_VERIFY_EMAIL=true
 # Zero-knowledge vault (optional — defaults shown)
 # AILERON_KEK_SESSION_TTL=30m
 
+# AI-powered draft generation (optional — set ANTHROPIC_API_KEY to enable)
+# ANTHROPIC_API_KEY=
+# AILERON_LLM_MODEL_RESEARCH=claude-haiku-4-5-20251001    # fast model for tool-call decisions
+# AILERON_LLM_MODEL_SYNTHESIS=claude-sonnet-4-6            # capable model for composing replies
+
 # PostHog analytics (optional — set your project API key to enable)
 # PUBLIC_POSTHOG_KEY=
 # PUBLIC_POSTHOG_HOST=https://us.i.posthog.com

--- a/docs/src/content/docs/deployment/cloud.md
+++ b/docs/src/content/docs/deployment/cloud.md
@@ -55,6 +55,9 @@ Each service needs a domain or URL. The auth domain points to the **server** ser
 | `AILERON_ENCLAVE_URL` | No | | Base URL of the enclave binary. Required when `AILERON_TEE_PROVIDER=confidential-space` |
 | `AILERON_ENCLAVE_IMAGE_DIGEST` | No | | Expected container image digest (`sha256:...`) for attestation verification |
 | `AILERON_GCP_PROJECT_ID` | No | | Expected GCP project ID for attestation verification |
+| `ANTHROPIC_API_KEY` | No | | Anthropic API key. Enables AI-powered draft generation when set |
+| `AILERON_LLM_MODEL_RESEARCH` | No | `claude-haiku-4-5-20251001` | Model for the research round (tool-call decisions, context gathering). Use a fast model — quality is less important than speed here. Any Anthropic model ID works |
+| `AILERON_LLM_MODEL_SYNTHESIS` | No | `claude-sonnet-4-6` | Model for the synthesis round (composing the final reply in the user's voice). Use a capable model — this is the quality-sensitive step |
 
 ### UI service
 

--- a/docs/src/content/docs/deployment/railway.md
+++ b/docs/src/content/docs/deployment/railway.md
@@ -38,7 +38,8 @@ Link the Postgres plugin to the server service.
 | `SLACK_CLIENT_SECRET` | From Slack app Basic Information (optional) |
 | `SLACK_SIGNING_SECRET` | From Slack app Basic Information (optional) |
 | `ANTHROPIC_API_KEY` | Anthropic API key for draft generation (optional) |
-| `AILERON_LLM_MODEL` | LLM model (default: `claude-sonnet-4-6`) (optional) |
+| `AILERON_LLM_MODEL_RESEARCH` | Research model (default: `claude-haiku-4-5-20251001`) (optional) |
+| `AILERON_LLM_MODEL_SYNTHESIS` | Synthesis model (default: `claude-sonnet-4-6`) (optional) |
 
 **UI service:**
 

--- a/docs/src/content/docs/getting-started/slack-cloud-integration.md
+++ b/docs/src/content/docs/getting-started/slack-cloud-integration.md
@@ -64,14 +64,19 @@ SLACK_SIGNING_SECRET=your-signing-secret
 
 # For AI-powered draft generation:
 ANTHROPIC_API_KEY=sk-ant-your-key
-AILERON_LLM_MODEL=claude-sonnet-4-6  # optional, this is the default
+
+# Optional — these are the defaults:
+AILERON_LLM_MODEL_RESEARCH=claude-haiku-4-5-20251001   # fast model for tool-call decisions
+AILERON_LLM_MODEL_SYNTHESIS=claude-sonnet-4-6           # capable model for composing the reply
 ```
+
+The draft pipeline uses two models: a fast model gathers context via tool calls (research), and a capable model composes the reply in your voice (synthesis). This keeps latency low without sacrificing quality.
 
 Verify the server logs show:
 
 ```
 enabled Slack connected accounts and source connector
-enabled cloud draft generation  model=claude-sonnet-4-6
+enabled cloud draft generation  research_model=claude-haiku-4-5-20251001  synthesis_model=claude-sonnet-4-6
 enabled Slack Events API webhook and interaction endpoints
 ```
 


### PR DESCRIPTION
## Summary

- **Dual-model pipeline**: Research round uses a fast model for tool-call decisions; synthesis round uses a capable model for composing the reply in the user's voice
  - `AILERON_LLM_MODEL_RESEARCH` (default: `claude-haiku-4-5-20251001`) — speed over quality
  - `AILERON_LLM_MODEL_SYNTHESIS` (default: `claude-sonnet-4-6`) — quality for the final reply
- **Prompt-driven batching**: Updated research prompt to instruct the LLM to batch all tool calls into 2–3 rounds instead of 8–15 sequential round-trips
- **Per-round observability**: Every LLM API call and tool execution round now logs duration, token usage, and total elapsed time
- **Documentation**: Both env vars documented in cloud.md, railway.md, slack-cloud-integration.md, and .env.example with guidance on model selection

Closes #184 follow-up. Expected to reduce research phase from ~2 minutes to ~15–30 seconds.

## Test plan

- [x] All existing tests pass with dual-client Pipeline signature
- [x] New `TestPipeline_GenerateDraft_SeparateClients` verifies research and synthesis dispatch to different clients
- [x] Config tests verify defaults (`claude-haiku-4-5-20251001` / `claude-sonnet-4-6`) and whitespace trimming
- [x] Coverage: llm 92.2%, draft 86.9%
- [ ] Deploy to staging and compare timing logs before/after

🤖 Generated with [Claude Code](https://claude.com/claude-code)