### PR TITLE
feat(draft): backward pass to fill date gaps in research

### DIFF
--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -1,8 +1,12 @@
 // Package draft orchestrates cloud-hosted draft generation.
 //
-// The Pipeline uses a two-round approach:
+// The Pipeline uses a multi-round approach:
 //   Round 1 (research): LLM has tools, searches broadly, gathers context.
 //     Its output is internal — never shown to anyone.
+//   Round 1b (backward pass): If the message implies a time range and the
+//     research output has date gaps, a targeted follow-up research call
+//     fills them. This is deterministic — it fires based on what was found,
+//     not what the LLM decided to do.
 //   Round 2 (ghostwrite): LLM has NO tools, receives the gathered context,
 //     writes the reply in the user's voice. No narration possible because
 //     there's no research phase.
@@ -104,6 +108,7 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 		msg.Author, msg.Channel, msg.Body,
 	)
 
+	now := time.Now()
 	var gatheredContext string
 	if len(tools) > 0 {
 		researchResp, err := p.researchLLM.GenerateWithTools(ctx, llm.GenerateRequest{
@@ -122,6 +127,11 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 				"tool_calls", len(researchResp.ToolCalls),
 				"context_length", len(gatheredContext),
 			)
+
+			// --- Round 1b: Backward pass ---
+			// If the message implies a time range and the research output has
+			// date gaps, make a targeted follow-up call to fill them.
+			gatheredContext = p.backwardPass(ctx, gatheredContext, msg.Body, now, researchSysPrompt, tools, executor, userID)
 		}
 	} else {
 		gatheredContext = "(No source connectors available — replying with general knowledge only.)"
@@ -191,6 +201,60 @@ func (p *Pipeline) assembleSystemPrompt(ctx context.Context, userID string) (str
 	}
 
 	return prompt, nil
+}
+
+// backwardPass checks whether the research output covers the full time range
+// implied by the message. If date gaps are found, it makes a targeted follow-up
+// research call and appends the results to the gathered context.
+func (p *Pipeline) backwardPass(
+	ctx context.Context,
+	gatheredContext string,
+	messageBody string,
+	now time.Time,
+	sysPrompt string,
+	tools []source.ToolDefinition,
+	executor llm.ToolExecutor,
+	userID string,
+) string {
+	tr := DetectTimeRange(messageBody, now)
+	if tr == nil {
+		return gatheredContext
+	}
+
+	uncovered := FindUncoveredDays(gatheredContext, *tr)
+	if len(uncovered) == 0 {
+		p.log.Info("backward pass: full date coverage",
+			"user_id", userID,
+			"range", tr.Label,
+		)
+		return gatheredContext
+	}
+
+	p.log.Info("backward pass: date gaps detected",
+		"user_id", userID,
+		"range", tr.Label,
+		"uncovered_days", len(uncovered),
+	)
+
+	gapPrompt := FormatGapPrompt(uncovered, messageBody)
+	gapResp, err := p.researchLLM.GenerateWithTools(ctx, llm.GenerateRequest{
+		SystemPrompt: sysPrompt,
+		UserMessage:  gapPrompt,
+		Tools:        tools,
+		ToolExecutor: executor,
+	})
+	if err != nil {
+		p.log.Error("backward pass failed", "user_id", userID, "error", err)
+		return gatheredContext
+	}
+
+	p.log.Info("backward pass complete",
+		"user_id", userID,
+		"tool_calls", len(gapResp.ToolCalls),
+		"additional_context_length", len(gapResp.Text),
+	)
+
+	return gatheredContext + "\n\n---\n\nAdditional context (targeted search for " + tr.Label + "):\n\n" + gapResp.Text
 }
 
 // buildToolExecutor creates a closure that resolves credentials from the vault

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -193,7 +193,7 @@ func TestPipeline_GenerateDraft_SeparateClients(t *testing.T) {
 
 	draftText, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah",
-		Body: "What shipped this week?",
+		Body: "What's the status of the auth refactor?",
 	})
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
@@ -203,6 +203,7 @@ func TestPipeline_GenerateDraft_SeparateClients(t *testing.T) {
 	}
 
 	// Research client should have received the tool-bearing request.
+	// (No time range in message, so no backward pass — just 1 research call.)
 	if len(researchMock.requests) != 1 {
 		t.Fatalf("expected 1 research call, got %d", len(researchMock.requests))
 	}
@@ -368,6 +369,167 @@ func TestPipeline_GenerateDraft_NoInstructions(t *testing.T) {
 	// System prompt should NOT contain instructions section.
 	if strings.Contains(mock.lastRequest.SystemPrompt, "User Instructions") {
 		t.Error("expected no User Instructions section when none exist")
+	}
+}
+
+// sequencingLLMClient returns different responses for sequential calls with
+// tools. Used to test the backward pass where both the initial research and
+// the gap-fill call have tools.
+type sequencingLLMClient struct {
+	requests  []*llm.GenerateRequest
+	responses []*llm.GenerateResponse
+	callIndex int
+}
+
+func (s *sequencingLLMClient) GenerateWithTools(_ context.Context, req llm.GenerateRequest) (*llm.GenerateResponse, error) {
+	s.requests = append(s.requests, &req)
+	idx := s.callIndex
+	s.callIndex++
+	if idx < len(s.responses) {
+		return s.responses[idx], nil
+	}
+	return &llm.GenerateResponse{Text: "fallback"}, nil
+}
+
+func TestPipeline_GenerateDraft_BackwardPass_FillsGaps(t *testing.T) {
+	// Research returns context that only mentions Monday and Friday.
+	// The message asks about "this week" (Mon–Fri).
+	// The backward pass should detect Tue/Wed/Thu gaps and make a second call.
+	researchMock := &sequencingLLMClient{
+		responses: []*llm.GenerateResponse{
+			{Text: "On Monday we merged PR #1. On Friday we deployed v2.3."},
+			{Text: "Tuesday: standup discussed auth. Wednesday: code review on PR #5. Thursday: fixed the CI flake."},
+		},
+	}
+	ghostwriteMock := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "Busy week — merged PRs, fixed CI, deployed v2.3."},
+	}
+
+	accounts := mem.NewConnectedAccountStore()
+	v := vault.NewMemVault()
+	ctx := context.Background()
+
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_1",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	v.Put(ctx, "connected-accounts/usr_1/slack", []byte(`{"access_token":"xoxp-test"}`), vault.Metadata{})
+
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&mockSourceConnector{})
+
+	p := draft.NewPipeline(researchMock, ghostwriteMock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research\n\nToday is {{today}}.", Ghostwrite: "test ghostwrite"})
+
+	draftText, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
+		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah",
+		Body: "What happened this week?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if draftText == "" {
+		t.Fatal("expected non-empty draft")
+	}
+
+	// Research mock should have been called twice: initial + backward pass.
+	if len(researchMock.requests) != 2 {
+		t.Fatalf("expected 2 research calls (initial + backward pass), got %d", len(researchMock.requests))
+	}
+
+	// Second call should mention the gap dates.
+	backwardReq := researchMock.requests[1]
+	if !strings.Contains(backwardReq.UserMessage, "NO activity") {
+		t.Error("expected backward pass prompt to mention missing activity")
+	}
+
+	// Ghostwrite should receive both the initial and backward pass context.
+	gwMsg := ghostwriteMock.lastRequest.UserMessage
+	if !strings.Contains(gwMsg, "On Monday we merged PR #1") {
+		t.Error("expected initial context in ghostwrite")
+	}
+	if !strings.Contains(gwMsg, "Tuesday: standup discussed auth") {
+		t.Error("expected backward pass context in ghostwrite")
+	}
+}
+
+func TestPipeline_GenerateDraft_BackwardPass_SkipsWhenFullCoverage(t *testing.T) {
+	// Research mentions all days — no backward pass needed.
+	researchMock := &sequencingLLMClient{
+		responses: []*llm.GenerateResponse{
+			{Text: "Monday: standup. Tuesday: PR review. Wednesday: deploy. Thursday: bug fix. Friday: retro."},
+			{Text: "this should not be reached"},
+		},
+	}
+	ghostwriteMock := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "Full week summary."},
+	}
+
+	accounts := mem.NewConnectedAccountStore()
+	v := vault.NewMemVault()
+	ctx := context.Background()
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_1",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	v.Put(ctx, "connected-accounts/usr_1/slack", []byte(`{"access_token":"xoxp-test"}`), vault.Metadata{})
+
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&mockSourceConnector{})
+
+	p := draft.NewPipeline(researchMock, ghostwriteMock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research\n\nToday is {{today}}.", Ghostwrite: "test ghostwrite"})
+
+	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
+		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah",
+		Body: "What happened this week?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Only 1 research call — no backward pass.
+	if len(researchMock.requests) != 1 {
+		t.Errorf("expected 1 research call (no backward pass), got %d", len(researchMock.requests))
+	}
+}
+
+func TestPipeline_GenerateDraft_BackwardPass_SkipsNoTimeRange(t *testing.T) {
+	// Message doesn't imply a time range — no backward pass.
+	researchMock := &sequencingLLMClient{
+		responses: []*llm.GenerateResponse{
+			{Text: "The auth refactor is in PR #247."},
+		},
+	}
+	ghostwriteMock := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "PR #247."},
+	}
+
+	accounts := mem.NewConnectedAccountStore()
+	v := vault.NewMemVault()
+	ctx := context.Background()
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_1",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	v.Put(ctx, "connected-accounts/usr_1/slack", []byte(`{"access_token":"xoxp-test"}`), vault.Metadata{})
+
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&mockSourceConnector{})
+
+	p := draft.NewPipeline(researchMock, ghostwriteMock, sourceReg, accounts, mem.NewUserInstructionStore(), v, slog.Default(), draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+
+	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
+		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah",
+		Body: "What's the status of the auth refactor?",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	if len(researchMock.requests) != 1 {
+		t.Errorf("expected 1 research call (no time range), got %d", len(researchMock.requests))
 	}
 }
 

--- a/core/draft/timerange.go
+++ b/core/draft/timerange.go
@@ -1,0 +1,182 @@
+package draft
+
+import (
+	"fmt"
+	"regexp"
+	"strings"
+	"time"
+)
+
+// TimeRange represents a date window extracted from a message.
+type TimeRange struct {
+	Start time.Time
+	End   time.Time
+	Label string // human-readable label, e.g. "this week (Mon Apr 14 – Fri Apr 18)"
+}
+
+// Days returns each date in the range as a slice, inclusive of Start and End.
+func (tr TimeRange) Days() []time.Time {
+	var days []time.Time
+	for d := tr.Start; !d.After(tr.End); d = d.AddDate(0, 0, 1) {
+		days = append(days, d)
+	}
+	return days
+}
+
+// DetectTimeRange parses a message for time-range signals and returns the
+// expected date window relative to the given reference time (usually now).
+// Returns nil if no time range is detected.
+func DetectTimeRange(message string, now time.Time) *TimeRange {
+	lower := strings.ToLower(message)
+
+	// Normalize today to midnight for clean date arithmetic.
+	today := time.Date(now.Year(), now.Month(), now.Day(), 0, 0, 0, 0, now.Location())
+	weekday := today.Weekday()
+
+	// "this week" / "the week" — Monday through today (or Friday if weekend).
+	if matchesAny(lower, `this week`, `the week`, `this past week`) {
+		monday := today.AddDate(0, 0, -int(weekday-time.Monday))
+		if weekday == time.Sunday {
+			monday = today.AddDate(0, 0, -6)
+		}
+		end := today
+		if weekday == time.Saturday || weekday == time.Sunday {
+			end = lastWeekday(today, time.Friday)
+		}
+		return &TimeRange{
+			Start: monday,
+			End:   end,
+			Label: fmt.Sprintf("this week (%s – %s)", fmtDate(monday), fmtDate(end)),
+		}
+	}
+
+	// "last week" — previous Monday through Friday.
+	if matchesAny(lower, `last week`, `previous week`, `the past week`) {
+		thisMonday := today.AddDate(0, 0, -int(weekday-time.Monday))
+		if weekday == time.Sunday {
+			thisMonday = today.AddDate(0, 0, -6)
+		}
+		lastMonday := thisMonday.AddDate(0, 0, -7)
+		lastFriday := lastMonday.AddDate(0, 0, 4)
+		return &TimeRange{
+			Start: lastMonday,
+			End:   lastFriday,
+			Label: fmt.Sprintf("last week (%s – %s)", fmtDate(lastMonday), fmtDate(lastFriday)),
+		}
+	}
+
+	// "since <day>" — e.g., "since Monday", "since Tuesday".
+	if m := sinceDayPattern.FindStringSubmatch(lower); m != nil {
+		targetDay := parseDayName(m[1])
+		if targetDay >= 0 {
+			start := lastWeekday(today, targetDay)
+			return &TimeRange{
+				Start: start,
+				End:   today,
+				Label: fmt.Sprintf("since %s (%s – %s)", m[1], fmtDate(start), fmtDate(today)),
+			}
+		}
+	}
+
+	return nil
+}
+
+var sinceDayPattern = regexp.MustCompile(`since\s+(monday|tuesday|wednesday|thursday|friday|saturday|sunday)`)
+
+// FindUncoveredDays checks which days in the range have no mention in the
+// gathered context. It looks for YYYY-MM-DD, "Mon Jan 2", day names (Monday,
+// Tuesday, etc.), and short dates (Apr 14, April 14).
+func FindUncoveredDays(gathered string, tr TimeRange) []time.Time {
+	lower := strings.ToLower(gathered)
+
+	var uncovered []time.Time
+	for _, day := range tr.Days() {
+		if !dayMentioned(lower, day) {
+			uncovered = append(uncovered, day)
+		}
+	}
+	return uncovered
+}
+
+// dayMentioned checks if a specific date is mentioned in the text using
+// multiple common formats.
+func dayMentioned(lowerText string, day time.Time) bool {
+	patterns := []string{
+		day.Format("2006-01-02"),                          // 2026-04-14
+		strings.ToLower(day.Format("Monday")),             // monday
+		strings.ToLower(day.Format("Mon")),                // mon
+		strings.ToLower(day.Format("Jan 2")),              // apr 14
+		strings.ToLower(day.Format("January 2")),          // april 14
+		strings.ToLower(day.Format("Jan 02")),             // apr 14 (zero-padded)
+		strings.ToLower(day.Format("1/2")),                // 4/14
+		strings.ToLower(day.Format("01/02")),              // 04/14
+	}
+	for _, p := range patterns {
+		if strings.Contains(lowerText, p) {
+			return true
+		}
+	}
+	return false
+}
+
+// FormatGapPrompt builds the follow-up prompt for uncovered days.
+func FormatGapPrompt(uncovered []time.Time, originalMessage string) string {
+	dayStrs := make([]string, len(uncovered))
+	for i, d := range uncovered {
+		dayStrs[i] = d.Format("Monday 2006-01-02")
+	}
+
+	return fmt.Sprintf(
+		"Your initial research found NO activity for these dates: %s\n\n"+
+			"Search specifically for activity on those dates. Use explicit date filters "+
+			"(after:/before: parameters) and broad query terms. The absence of results in "+
+			"your first pass usually means the queries were too narrow, not that nothing happened.\n\n"+
+			"Original message: %s",
+		strings.Join(dayStrs, ", "),
+		originalMessage,
+	)
+}
+
+// matchesAny returns true if text contains any of the given substrings.
+func matchesAny(text string, subs ...string) bool {
+	for _, s := range subs {
+		if strings.Contains(text, s) {
+			return true
+		}
+	}
+	return false
+}
+
+// lastWeekday returns the most recent date with the given weekday,
+// on or before ref. If ref is that weekday, it returns ref.
+func lastWeekday(ref time.Time, target time.Weekday) time.Time {
+	diff := int(ref.Weekday()) - int(target)
+	if diff < 0 {
+		diff += 7
+	}
+	return ref.AddDate(0, 0, -diff)
+}
+
+func parseDayName(name string) time.Weekday {
+	switch strings.ToLower(name) {
+	case "monday":
+		return time.Monday
+	case "tuesday":
+		return time.Tuesday
+	case "wednesday":
+		return time.Wednesday
+	case "thursday":
+		return time.Thursday
+	case "friday":
+		return time.Friday
+	case "saturday":
+		return time.Saturday
+	case "sunday":
+		return time.Sunday
+	}
+	return -1
+}
+
+func fmtDate(t time.Time) string {
+	return t.Format("Mon Jan 2")
+}

--- a/core/draft/timerange_test.go
+++ b/core/draft/timerange_test.go
@@ -1,0 +1,184 @@
+package draft
+
+import (
+	"strings"
+	"testing"
+	"time"
+)
+
+// wednesday 2026-04-15 at noon — a known midweek anchor.
+var testNow = time.Date(2026, 4, 15, 12, 0, 0, 0, time.UTC)
+
+func TestDetectTimeRange_ThisWeek(t *testing.T) {
+	for _, msg := range []string{
+		"What happened this week?",
+		"Give me a summary of the week",
+		"this past week has been wild",
+	} {
+		tr := DetectTimeRange(msg, testNow)
+		if tr == nil {
+			t.Fatalf("expected time range for %q", msg)
+		}
+		// Wednesday Apr 15 → this week starts Monday Apr 13.
+		if tr.Start.Weekday() != time.Monday {
+			t.Errorf("%q: start = %s, want Monday", msg, tr.Start.Format("Monday 2006-01-02"))
+		}
+		if !tr.End.Equal(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)) {
+			t.Errorf("%q: end = %s, want 2026-04-15", msg, tr.End.Format("2006-01-02"))
+		}
+	}
+}
+
+func TestDetectTimeRange_ThisWeek_Weekend(t *testing.T) {
+	// Saturday Apr 18 — "this week" should end on Friday.
+	saturday := time.Date(2026, 4, 18, 12, 0, 0, 0, time.UTC)
+	tr := DetectTimeRange("what happened this week", saturday)
+	if tr == nil {
+		t.Fatal("expected time range")
+	}
+	if tr.Start.Weekday() != time.Monday {
+		t.Errorf("start = %s, want Monday", tr.Start.Format("Monday"))
+	}
+	if tr.End.Weekday() != time.Friday {
+		t.Errorf("end = %s, want Friday", tr.End.Format("Monday"))
+	}
+}
+
+func TestDetectTimeRange_LastWeek(t *testing.T) {
+	tr := DetectTimeRange("summary of last week", testNow)
+	if tr == nil {
+		t.Fatal("expected time range")
+	}
+	// testNow is Wed Apr 15. Last week: Mon Apr 6 – Fri Apr 10.
+	if tr.Start.Weekday() != time.Monday {
+		t.Errorf("start = %s, want Monday", tr.Start.Format("Monday 2006-01-02"))
+	}
+	if tr.End.Weekday() != time.Friday {
+		t.Errorf("end = %s, want Friday", tr.End.Format("Monday 2006-01-02"))
+	}
+	if tr.Start.Day() != 6 {
+		t.Errorf("start = Apr %d, want Apr 6", tr.Start.Day())
+	}
+	if tr.End.Day() != 10 {
+		t.Errorf("end = Apr %d, want Apr 10", tr.End.Day())
+	}
+}
+
+func TestDetectTimeRange_SinceDay(t *testing.T) {
+	tr := DetectTimeRange("what's changed since monday?", testNow)
+	if tr == nil {
+		t.Fatal("expected time range")
+	}
+	if tr.Start.Weekday() != time.Monday {
+		t.Errorf("start = %s, want Monday", tr.Start.Format("Monday"))
+	}
+	if !tr.End.Equal(time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC)) {
+		t.Errorf("end = %s, want today", tr.End.Format("2006-01-02"))
+	}
+}
+
+func TestDetectTimeRange_NoRange(t *testing.T) {
+	for _, msg := range []string{
+		"What's the status of the auth refactor?",
+		"Can you help with this PR?",
+		"Hey, quick question about the deploy",
+	} {
+		tr := DetectTimeRange(msg, testNow)
+		if tr != nil {
+			t.Errorf("expected no time range for %q, got %+v", msg, tr)
+		}
+	}
+}
+
+func TestTimeRange_Days(t *testing.T) {
+	tr := TimeRange{
+		Start: time.Date(2026, 4, 13, 0, 0, 0, 0, time.UTC), // Monday
+		End:   time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC), // Wednesday
+	}
+	days := tr.Days()
+	if len(days) != 3 {
+		t.Fatalf("expected 3 days, got %d", len(days))
+	}
+	if days[0].Day() != 13 || days[1].Day() != 14 || days[2].Day() != 15 {
+		t.Errorf("days = %v", days)
+	}
+}
+
+func TestFindUncoveredDays_AllCovered(t *testing.T) {
+	tr := TimeRange{
+		Start: time.Date(2026, 4, 13, 0, 0, 0, 0, time.UTC),
+		End:   time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC),
+	}
+	gathered := "On Monday 2026-04-13 we merged PR #1. On Tuesday apr 14 there was a deploy. Wednesday morning standup covered the release."
+	uncovered := FindUncoveredDays(gathered, tr)
+	if len(uncovered) != 0 {
+		t.Errorf("expected 0 uncovered, got %d: %v", len(uncovered), uncovered)
+	}
+}
+
+func TestFindUncoveredDays_GapDetected(t *testing.T) {
+	tr := TimeRange{
+		Start: time.Date(2026, 4, 13, 0, 0, 0, 0, time.UTC), // Mon
+		End:   time.Date(2026, 4, 17, 0, 0, 0, 0, time.UTC), // Fri
+	}
+	// Only mentions Monday and Friday — Tue, Wed, Thu are gaps.
+	gathered := "On Monday we merged PR #1. On Friday we deployed."
+	uncovered := FindUncoveredDays(gathered, tr)
+	if len(uncovered) != 3 {
+		t.Fatalf("expected 3 uncovered days, got %d", len(uncovered))
+	}
+	// Tue, Wed, Thu
+	if uncovered[0].Day() != 14 || uncovered[1].Day() != 15 || uncovered[2].Day() != 16 {
+		t.Errorf("uncovered = %v", uncovered)
+	}
+}
+
+func TestFindUncoveredDays_DateFormats(t *testing.T) {
+	day := time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC)
+	tr := TimeRange{Start: day, End: day}
+
+	tests := []struct {
+		name    string
+		text    string
+		covered bool
+	}{
+		{"ISO date", "activity on 2026-04-14", true},
+		{"day name", "Tuesday was busy", true},
+		{"short day", "met on tue", true},
+		{"month day", "apr 14 deploy", true},
+		{"full month day", "april 14 release", true},
+		{"slash date", "deployed 4/14", true},
+		{"zero-padded slash", "04/14 standup", true},
+		{"no mention", "nothing relevant here", false},
+	}
+	for _, tt := range tests {
+		uncovered := FindUncoveredDays(tt.text, tr)
+		if tt.covered && len(uncovered) != 0 {
+			t.Errorf("%s: expected covered but got uncovered", tt.name)
+		}
+		if !tt.covered && len(uncovered) != 1 {
+			t.Errorf("%s: expected uncovered but got covered", tt.name)
+		}
+	}
+}
+
+func TestFormatGapPrompt(t *testing.T) {
+	uncovered := []time.Time{
+		time.Date(2026, 4, 14, 0, 0, 0, 0, time.UTC),
+		time.Date(2026, 4, 15, 0, 0, 0, 0, time.UTC),
+	}
+	prompt := FormatGapPrompt(uncovered, "What happened this week?")
+
+	if !strings.Contains(prompt, "Tuesday 2026-04-14") {
+		t.Error("expected Tuesday date in prompt")
+	}
+	if !strings.Contains(prompt, "Wednesday 2026-04-15") {
+		t.Error("expected Wednesday date in prompt")
+	}
+	if !strings.Contains(prompt, "What happened this week?") {
+		t.Error("expected original message in prompt")
+	}
+	if !strings.Contains(prompt, "NO activity") {
+		t.Error("expected gap framing in prompt")
+	}
+}


### PR DESCRIPTION
## Summary

- **Problem**: Research model (Haiku) batches tool calls that skew toward recent activity, silently dropping earlier days when asked about "this week" or "last week"
- **Fix**: After the research round, the pipeline detects which days in the implied time range are missing from the output and makes a targeted follow-up call to fill them
- **Key property**: This is deterministic — it fires based on what was found, not what the LLM decided. The LLM can't skip days by accident anymore

### How it works

1. `DetectTimeRange()` parses the message for time signals ("this week", "last week", "since Monday") → returns a date window
2. `FindUncoveredDays()` scans the research output for date mentions (YYYY-MM-DD, day names, "Apr 14", etc.) → returns days with no coverage
3. If gaps exist, `backwardPass()` makes one follow-up research call with an explicit prompt: "You found NO activity for Tuesday, Wednesday, Thursday. Search specifically for those dates."
4. Results are appended to the gathered context before the synthesis round

### Cost

- Zero latency when the research model gets it right (no gaps = no backward pass)
- One additional Haiku API call when gaps are detected (~1-3s)
- No changes to the synthesis round

## Test plan

- [x] `TestDetectTimeRange_*` — this week, last week, since day, weekend edge, no range
- [x] `TestFindUncoveredDays_*` — all covered, gaps detected, 8 date format variants
- [x] `TestPipeline_GenerateDraft_BackwardPass_FillsGaps` — verifies second research call with gap prompt, both contexts reach synthesis
- [x] `TestPipeline_GenerateDraft_BackwardPass_SkipsWhenFullCoverage` — no backward pass when all days mentioned
- [x] `TestPipeline_GenerateDraft_BackwardPass_SkipsNoTimeRange` — no backward pass for non-temporal queries
- [x] Coverage: draft 85.8%, all existing tests pass
- [ ] Deploy to staging — ask "what happened this week?" and verify full Mon–Fri coverage

🤖 Generated with [Claude Code](https://claude.com/claude-code)