### PR TITLE
fix(source): use refreshing token source for Google API calls

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -324,8 +324,8 @@ func registerProviders(
 			accounts,
 			v,
 		))
-		sourceReg.Register(gmailsource.New())
-		sourceReg.Register(calendarsource.New())
+		sourceReg.Register(gmailsource.New(cfg.GoogleConnectorClientID, cfg.GoogleConnectorClientSecret))
+		sourceReg.Register(calendarsource.New(cfg.GoogleConnectorClientID, cfg.GoogleConnectorClientSecret))
 		log.Info("enabled Google connected accounts and source connectors (Gmail, Calendar)")
 	}
 

--- a/core/source/calendar/connector.go
+++ b/core/source/calendar/connector.go
@@ -9,18 +9,26 @@ import (
 
 	"github.com/ALRubinger/aileron/core/source"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 	cal "google.golang.org/api/calendar/v3"
 	"google.golang.org/api/option"
 )
 
 // Connector implements source.SourceConnector for Google Calendar.
 type Connector struct {
+	oauthConfig  *oauth2.Config
 	clientOption option.ClientOption
 }
 
-// New creates a new Calendar source connector.
-func New() *Connector {
-	return &Connector{}
+// New creates a new Calendar source connector with OAuth credentials for token refresh.
+func New(clientID, clientSecret string) *Connector {
+	return &Connector{
+		oauthConfig: &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Endpoint:     google.Endpoint,
+		},
+	}
 }
 
 // WithClientOption returns a copy with a custom client option (for testing).
@@ -71,12 +79,11 @@ func (c *Connector) Execute(ctx context.Context, tool string, params map[string]
 }
 
 func (c *Connector) newService(ctx context.Context, token []byte) (*cal.Service, error) {
-	accessToken, err := extractAccessToken(token)
+	ts, err := c.tokenSource(ctx, token)
 	if err != nil {
-		return nil, fmt.Errorf("invalid token: %w", err)
+		return nil, err
 	}
 
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
 	opts := []option.ClientOption{option.WithTokenSource(ts)}
 	if c.clientOption != nil {
 		opts = append(opts, c.clientOption)
@@ -187,18 +194,17 @@ func (c *Connector) freeBusy(ctx context.Context, svc *cal.Service, params map[s
 	return map[string]any{"busy": busySlots}, nil
 }
 
-func extractAccessToken(token []byte) (string, error) {
-	var oauthToken oauth2.Token
-	if err := json.Unmarshal(token, &oauthToken); err == nil && oauthToken.AccessToken != "" {
-		return oauthToken.AccessToken, nil
+// tokenSource parses the stored OAuth token and returns a token source that
+// automatically refreshes expired access tokens using the OAuth client credentials.
+func (c *Connector) tokenSource(ctx context.Context, tokenJSON []byte) (oauth2.TokenSource, error) {
+	var tok oauth2.Token
+	if err := json.Unmarshal(tokenJSON, &tok); err != nil {
+		return nil, fmt.Errorf("invalid token JSON: %w", err)
 	}
-	var data map[string]string
-	if err := json.Unmarshal(token, &data); err == nil {
-		if at := data["access_token"]; at != "" {
-			return at, nil
-		}
+	if tok.RefreshToken == "" && tok.AccessToken == "" {
+		return nil, fmt.Errorf("token has neither access_token nor refresh_token")
 	}
-	return "", fmt.Errorf("no access_token in token data")
+	return c.oauthConfig.TokenSource(ctx, &tok), nil
 }
 
 func toInt64(v any, def int64) int64 {
@@ -217,4 +223,3 @@ func toInt64(v any, def int64) int64 {
 		return def
 	}
 }
-

--- a/core/source/calendar/connector.go
+++ b/core/source/calendar/connector.go
@@ -38,6 +38,19 @@ func (c *Connector) WithClientOption(opt option.ClientOption) *Connector {
 	return &cp
 }
 
+// WithTokenEndpoint returns a copy that uses the given URL for OAuth token
+// refresh instead of Google's production endpoint. For testing only.
+func (c *Connector) WithTokenEndpoint(tokenURL string) *Connector {
+	cp := *c
+	cfg := *c.oauthConfig
+	cfg.Endpoint = oauth2.Endpoint{
+		AuthURL:  cfg.Endpoint.AuthURL,
+		TokenURL: tokenURL,
+	}
+	cp.oauthConfig = &cfg
+	return &cp
+}
+
 func (c *Connector) Provider() string { return "google_calendar" }
 
 func (c *Connector) Tools() []source.ToolDefinition {

--- a/core/source/calendar/connector_test.go
+++ b/core/source/calendar/connector_test.go
@@ -17,14 +17,14 @@ func testToken() []byte {
 }
 
 func TestConnector_Provider(t *testing.T) {
-	c := calendarsource.New()
+	c := calendarsource.New("test-client-id", "test-client-secret")
 	if c.Provider() != "google_calendar" {
 		t.Errorf("expected google_calendar, got %s", c.Provider())
 	}
 }
 
 func TestConnector_Tools(t *testing.T) {
-	c := calendarsource.New()
+	c := calendarsource.New("test-client-id", "test-client-secret")
 	tools := c.Tools()
 	if len(tools) != 2 {
 		t.Fatalf("expected 2 tools, got %d", len(tools))
@@ -42,7 +42,7 @@ func TestConnector_Tools(t *testing.T) {
 }
 
 func TestConnector_UnknownTool(t *testing.T) {
-	c := calendarsource.New()
+	c := calendarsource.New("test-client-id", "test-client-secret")
 	token, _ := json.Marshal(map[string]string{"access_token": "test"})
 	_, err := c.Execute(context.Background(), "calendar_nonexistent", nil, token)
 	if err == nil {
@@ -51,7 +51,7 @@ func TestConnector_UnknownTool(t *testing.T) {
 }
 
 func TestConnector_InvalidToken(t *testing.T) {
-	c := calendarsource.New()
+	c := calendarsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "calendar_events", map[string]any{
 		"start": "2026-04-15T00:00:00Z",
 		"end":   "2026-04-16T00:00:00Z",
@@ -63,7 +63,7 @@ func TestConnector_InvalidToken(t *testing.T) {
 
 func TestConnector_EmptyAccessToken(t *testing.T) {
 	token, _ := json.Marshal(map[string]string{"token_type": "bearer"})
-	c := calendarsource.New()
+	c := calendarsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "calendar_events", map[string]any{
 		"start": "2026-04-15T00:00:00Z",
 		"end":   "2026-04-16T00:00:00Z",
@@ -95,7 +95,7 @@ func TestConnector_Events_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := calendarsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := calendarsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	result, err := c.Execute(context.Background(), "calendar_events", map[string]any{
 		"start": "2026-04-15T00:00:00Z",
 		"end":   "2026-04-16T00:00:00Z",
@@ -132,7 +132,7 @@ func TestConnector_FreeBusy_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := calendarsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := calendarsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	result, err := c.Execute(context.Background(), "calendar_free_busy", map[string]any{
 		"start": "2026-04-15T00:00:00Z",
 		"end":   "2026-04-16T00:00:00Z",
@@ -154,7 +154,7 @@ func TestConnector_Events_WithMaxResults(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := calendarsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := calendarsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	_, err := c.Execute(context.Background(), "calendar_events", map[string]any{
 		"start":       "2026-04-15T00:00:00Z",
 		"end":         "2026-04-16T00:00:00Z",
@@ -177,7 +177,7 @@ func TestConnector_OAuthTokenFormat(t *testing.T) {
 		"token_type":   "bearer",
 		"expiry":       "2026-12-31T00:00:00Z",
 	})
-	c := calendarsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := calendarsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	_, err := c.Execute(context.Background(), "calendar_events", map[string]any{
 		"start": "2026-04-15T00:00:00Z",
 		"end":   "2026-04-16T00:00:00Z",
@@ -189,7 +189,7 @@ func TestConnector_OAuthTokenFormat(t *testing.T) {
 
 func TestConnector_Events_MissingStart(t *testing.T) {
 	token, _ := json.Marshal(map[string]string{"access_token": "test"})
-	c := calendarsource.New()
+	c := calendarsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "calendar_events", map[string]any{
 		"end": "2026-04-16T00:00:00Z",
 	}, token)
@@ -200,7 +200,7 @@ func TestConnector_Events_MissingStart(t *testing.T) {
 
 func TestConnector_Events_MissingEnd(t *testing.T) {
 	token, _ := json.Marshal(map[string]string{"access_token": "test"})
-	c := calendarsource.New()
+	c := calendarsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "calendar_events", map[string]any{
 		"start": "2026-04-15T00:00:00Z",
 	}, token)
@@ -211,7 +211,7 @@ func TestConnector_Events_MissingEnd(t *testing.T) {
 
 func TestConnector_FreeBusy_MissingStart(t *testing.T) {
 	token, _ := json.Marshal(map[string]string{"access_token": "test"})
-	c := calendarsource.New()
+	c := calendarsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "calendar_free_busy", map[string]any{
 		"end": "2026-04-16T00:00:00Z",
 	}, token)
@@ -222,7 +222,7 @@ func TestConnector_FreeBusy_MissingStart(t *testing.T) {
 
 func TestConnector_FreeBusy_MissingEnd(t *testing.T) {
 	token, _ := json.Marshal(map[string]string{"access_token": "test"})
-	c := calendarsource.New()
+	c := calendarsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "calendar_free_busy", map[string]any{
 		"start": "2026-04-15T00:00:00Z",
 	}, token)

--- a/core/source/calendar/connector_test.go
+++ b/core/source/calendar/connector_test.go
@@ -5,7 +5,9 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"sync/atomic"
 	"testing"
+	"time"
 
 	calendarsource "github.com/ALRubinger/aileron/core/source/calendar"
 	"google.golang.org/api/option"
@@ -228,5 +230,74 @@ func TestConnector_FreeBusy_MissingEnd(t *testing.T) {
 	}, token)
 	if err == nil {
 		t.Fatal("expected error for missing end")
+	}
+}
+
+func TestConnector_Events_RefreshesExpiredToken(t *testing.T) {
+	// Regression test: the connector must automatically refresh an expired
+	// access token using the refresh token + OAuth client credentials.
+	// Previously, StaticTokenSource was used, so expired tokens caused
+	// permanent auth failures until the user reconnected.
+
+	var tokenRefreshed atomic.Bool
+
+	// Mock OAuth token endpoint — returns a fresh access token.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRefreshed.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "fresh-access-token",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	// Mock Calendar API.
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"items": []map[string]any{
+				{
+					"id":      "evt_1",
+					"summary": "Team Standup",
+					"status":  "confirmed",
+					"start":   map[string]string{"dateTime": "2026-04-20T09:00:00Z"},
+					"end":     map[string]string{"dateTime": "2026-04-20T09:30:00Z"},
+				},
+			},
+		})
+	}))
+	defer apiServer.Close()
+
+	// Token with an expired access token but a valid refresh token.
+	expiredToken, _ := json.Marshal(map[string]any{
+		"access_token":  "expired-token",
+		"refresh_token": "valid-refresh-token",
+		"token_type":    "bearer",
+		"expiry":        time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+	})
+
+	c := calendarsource.New("test-client-id", "test-client-secret").
+		WithTokenEndpoint(tokenServer.URL).
+		WithClientOption(option.WithEndpoint(apiServer.URL))
+
+	result, err := c.Execute(context.Background(), "calendar_events", map[string]any{
+		"start": "2026-04-20T00:00:00Z",
+		"end":   "2026-04-21T00:00:00Z",
+	}, expiredToken)
+
+	if err != nil {
+		t.Fatalf("expected successful call after token refresh, got: %v", err)
+	}
+	if !tokenRefreshed.Load() {
+		t.Error("expected token endpoint to be called for refresh")
+	}
+	events := result["events"].([]map[string]any)
+	if len(events) != 1 {
+		t.Errorf("expected 1 event, got %d", len(events))
+	}
+	if events[0]["summary"] != "Team Standup" {
+		t.Errorf("expected Team Standup, got %v", events[0]["summary"])
 	}
 }

--- a/core/source/gmail/connector.go
+++ b/core/source/gmail/connector.go
@@ -14,6 +14,7 @@ import (
 
 	"github.com/ALRubinger/aileron/core/source"
 	"golang.org/x/oauth2"
+	"golang.org/x/oauth2/google"
 	"golang.org/x/sync/errgroup"
 	driveapi "google.golang.org/api/drive/v3"
 	gmailapi "google.golang.org/api/gmail/v1"
@@ -22,13 +23,20 @@ import (
 
 // Connector implements source.SourceConnector for Gmail.
 type Connector struct {
+	oauthConfig *oauth2.Config
 	// clientOption allows injecting a custom HTTP client for testing.
 	clientOption option.ClientOption
 }
 
-// New creates a new Gmail source connector.
-func New() *Connector {
-	return &Connector{}
+// New creates a new Gmail source connector with OAuth credentials for token refresh.
+func New(clientID, clientSecret string) *Connector {
+	return &Connector{
+		oauthConfig: &oauth2.Config{
+			ClientID:     clientID,
+			ClientSecret: clientSecret,
+			Endpoint:     google.Endpoint,
+		},
+	}
 }
 
 // WithClientOption returns a copy with a custom client option (for testing).
@@ -98,12 +106,11 @@ func (c *Connector) Execute(ctx context.Context, tool string, params map[string]
 }
 
 func (c *Connector) newService(ctx context.Context, token []byte) (*gmailapi.Service, error) {
-	accessToken, err := extractAccessToken(token)
+	ts, err := c.tokenSource(ctx, token)
 	if err != nil {
-		return nil, fmt.Errorf("invalid token: %w", err)
+		return nil, err
 	}
 
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
 	opts := []option.ClientOption{option.WithTokenSource(ts)}
 	if c.clientOption != nil {
 		opts = append(opts, c.clientOption)
@@ -223,12 +230,11 @@ func (c *Connector) getThread(ctx context.Context, svc *gmailapi.Service, params
 }
 
 func (c *Connector) newDriveService(ctx context.Context, token []byte) (*driveapi.Service, error) {
-	accessToken, err := extractAccessToken(token)
+	ts, err := c.tokenSource(ctx, token)
 	if err != nil {
-		return nil, fmt.Errorf("invalid token: %w", err)
+		return nil, err
 	}
 
-	ts := oauth2.StaticTokenSource(&oauth2.Token{AccessToken: accessToken})
 	opts := []option.ClientOption{option.WithTokenSource(ts)}
 	if c.clientOption != nil {
 		opts = append(opts, c.clientOption)
@@ -312,21 +318,19 @@ func (c *Connector) driveGetDoc(ctx context.Context, token []byte, params map[st
 	return map[string]any{"content": content}, nil
 }
 
-// extractAccessToken parses stored token JSON and returns the access token.
-func extractAccessToken(token []byte) (string, error) {
-	// Try OAuth2 token format.
-	var oauthToken oauth2.Token
-	if err := json.Unmarshal(token, &oauthToken); err == nil && oauthToken.AccessToken != "" {
-		return oauthToken.AccessToken, nil
+// tokenSource parses the stored OAuth token and returns a token source that
+// automatically refreshes expired access tokens using the OAuth client credentials.
+func (c *Connector) tokenSource(ctx context.Context, tokenJSON []byte) (oauth2.TokenSource, error) {
+	var tok oauth2.Token
+	if err := json.Unmarshal(tokenJSON, &tok); err != nil {
+		return nil, fmt.Errorf("invalid token JSON: %w", err)
 	}
-	// Try simple map.
-	var data map[string]string
-	if err := json.Unmarshal(token, &data); err == nil {
-		if at := data["access_token"]; at != "" {
-			return at, nil
-		}
+	if tok.RefreshToken == "" && tok.AccessToken == "" {
+		return nil, fmt.Errorf("token has neither access_token nor refresh_token")
 	}
-	return "", fmt.Errorf("no access_token in token data")
+	// ReuseTokenSourceWithExpiry returns the existing access token if still valid,
+	// and transparently refreshes via the oauth2.Config when it expires.
+	return c.oauthConfig.TokenSource(ctx, &tok), nil
 }
 
 func toInt64(v any, def int64) int64 {

--- a/core/source/gmail/connector.go
+++ b/core/source/gmail/connector.go
@@ -46,6 +46,19 @@ func (c *Connector) WithClientOption(opt option.ClientOption) *Connector {
 	return &cp
 }
 
+// WithTokenEndpoint returns a copy that uses the given URL for OAuth token
+// refresh instead of Google's production endpoint. For testing only.
+func (c *Connector) WithTokenEndpoint(tokenURL string) *Connector {
+	cp := *c
+	cfg := *c.oauthConfig
+	cfg.Endpoint = oauth2.Endpoint{
+		AuthURL:  cfg.Endpoint.AuthURL,
+		TokenURL: tokenURL,
+	}
+	cp.oauthConfig = &cfg
+	return &cp
+}
+
 func (c *Connector) Provider() string { return "gmail" }
 
 func (c *Connector) Tools() []source.ToolDefinition {

--- a/core/source/gmail/connector_test.go
+++ b/core/source/gmail/connector_test.go
@@ -602,3 +602,74 @@ func TestConnector_Search_ConcurrentFetch_ErrorPropagation(t *testing.T) {
 		t.Errorf("expected 'fetching message metadata' in error, got: %v", err)
 	}
 }
+
+func TestConnector_Search_RefreshesExpiredToken(t *testing.T) {
+	// Regression test: the connector must automatically refresh an expired
+	// access token using the refresh token + OAuth client credentials.
+	// Previously, StaticTokenSource was used, so expired tokens caused
+	// permanent auth failures until the user reconnected.
+
+	var tokenRefreshed atomic.Bool
+
+	// Mock OAuth token endpoint — returns a fresh access token.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		tokenRefreshed.Store(true)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "fresh-access-token",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	// Mock Gmail API.
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/messages/") {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id": "msg_1", "snippet": "Hello",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "Subject", "value": "Test"},
+						{"name": "From", "value": "test@example.com"},
+						{"name": "Date", "value": "Mon, 20 Apr 2026"},
+					},
+				},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"messages":           []map[string]any{{"id": "msg_1", "threadId": "t_1"}},
+			"resultSizeEstimate": 1,
+		})
+	}))
+	defer apiServer.Close()
+
+	// Token with an expired access token but a valid refresh token.
+	expiredToken, _ := json.Marshal(map[string]any{
+		"access_token":  "expired-token",
+		"refresh_token": "valid-refresh-token",
+		"token_type":    "bearer",
+		"expiry":        time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+	})
+
+	c := gmailsource.New("test-client-id", "test-client-secret").
+		WithTokenEndpoint(tokenServer.URL).
+		WithClientOption(option.WithEndpoint(apiServer.URL))
+
+	result, err := c.Execute(context.Background(), "gmail_search", map[string]any{
+		"query": "test",
+	}, expiredToken)
+
+	if err != nil {
+		t.Fatalf("expected successful call after token refresh, got: %v", err)
+	}
+	if !tokenRefreshed.Load() {
+		t.Error("expected token endpoint to be called for refresh")
+	}
+	messages := result["messages"].([]map[string]any)
+	if len(messages) != 1 {
+		t.Errorf("expected 1 message, got %d", len(messages))
+	}
+}

--- a/core/source/gmail/connector_test.go
+++ b/core/source/gmail/connector_test.go
@@ -25,14 +25,14 @@ func testToken() []byte {
 }
 
 func TestConnector_Provider(t *testing.T) {
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	if c.Provider() != "gmail" {
 		t.Errorf("expected gmail, got %s", c.Provider())
 	}
 }
 
 func TestConnector_Tools(t *testing.T) {
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	tools := c.Tools()
 	if len(tools) != 4 {
 		t.Fatalf("expected 4 tools, got %d", len(tools))
@@ -49,7 +49,7 @@ func TestConnector_Tools(t *testing.T) {
 }
 
 func TestConnector_UnknownTool(t *testing.T) {
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	token, _ := json.Marshal(map[string]string{"access_token": "test"})
 	_, err := c.Execute(context.Background(), "gmail_nonexistent", nil, token)
 	if err == nil {
@@ -58,7 +58,7 @@ func TestConnector_UnknownTool(t *testing.T) {
 }
 
 func TestConnector_InvalidToken(t *testing.T) {
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{"query": "test"}, []byte("not-json"))
 	if err == nil {
 		t.Fatal("expected error for invalid token")
@@ -67,7 +67,7 @@ func TestConnector_InvalidToken(t *testing.T) {
 
 func TestConnector_EmptyAccessToken(t *testing.T) {
 	token, _ := json.Marshal(map[string]string{"token_type": "bearer"})
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{"query": "test"}, token)
 	if err == nil {
 		t.Fatal("expected error for missing access_token")
@@ -99,7 +99,7 @@ func TestConnector_Search_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	result, err := c.Execute(context.Background(), "gmail_search", map[string]any{
 		"query": "migration proposal",
 	}, testToken())
@@ -141,7 +141,7 @@ func TestConnector_Search_WithDateFilters(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{
 		"query":  "migration",
 		"after":  "2026-04-14",
@@ -193,7 +193,7 @@ func TestConnector_GetThread_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	result, err := c.Execute(context.Background(), "gmail_get_thread", map[string]any{
 		"thread_id": "thread_1",
 	}, testToken())
@@ -217,7 +217,7 @@ func TestConnector_Search_WithMaxResults(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{
 		"query":       "test",
 		"max_results": float64(5),
@@ -242,7 +242,7 @@ func TestConnector_OAuthTokenFormat(t *testing.T) {
 		"token_type":   "bearer",
 		"expiry":       "2026-12-31T00:00:00Z",
 	})
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{"query": "test"}, token)
 	if err != nil {
 		t.Fatalf("unexpected error with oauth2 token format: %v", err)
@@ -266,7 +266,7 @@ func TestConnector_DriveSearch_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	result, err := c.Execute(context.Background(), "drive_search", map[string]any{
 		"query": "migration plan",
 	}, testToken())
@@ -284,7 +284,7 @@ func TestConnector_DriveSearch_Success(t *testing.T) {
 }
 
 func TestConnector_DriveSearch_MissingQuery(t *testing.T) {
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "drive_search", map[string]any{}, testToken())
 	if err == nil {
 		t.Fatal("expected error for missing query")
@@ -299,7 +299,7 @@ func TestConnector_DriveGetDoc_Success(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	result, err := c.Execute(context.Background(), "drive_get_doc", map[string]any{
 		"file_id": "doc_123",
 	}, testToken())
@@ -317,7 +317,7 @@ func TestConnector_DriveGetDoc_Success(t *testing.T) {
 }
 
 func TestConnector_DriveGetDoc_InvalidToken(t *testing.T) {
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "drive_get_doc", map[string]any{
 		"file_id": "doc_123",
 	}, []byte("not-json"))
@@ -327,7 +327,7 @@ func TestConnector_DriveGetDoc_InvalidToken(t *testing.T) {
 }
 
 func TestConnector_DriveSearch_InvalidToken(t *testing.T) {
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "drive_search", map[string]any{
 		"query": "test",
 	}, []byte("not-json"))
@@ -346,7 +346,7 @@ func containsStr(s, sub string) bool {
 }
 
 func TestConnector_DriveGetDoc_MissingFileID(t *testing.T) {
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "drive_get_doc", map[string]any{}, testToken())
 	if err == nil {
 		t.Fatal("expected error for missing file_id")
@@ -354,7 +354,7 @@ func TestConnector_DriveGetDoc_MissingFileID(t *testing.T) {
 }
 
 func TestConnector_ToolsIncludeDrive(t *testing.T) {
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	tools := c.Tools()
 	if len(tools) != 4 {
 		t.Fatalf("expected 4 tools (2 gmail + 2 drive), got %d", len(tools))
@@ -378,7 +378,7 @@ func TestConnector_DriveSearch_WithMaxResults(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	_, err := c.Execute(context.Background(), "drive_search", map[string]any{
 		"query":       "test",
 		"max_results": float64(5),
@@ -400,7 +400,7 @@ func TestConnector_DriveGetDoc_LargeContent(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	result, err := c.Execute(context.Background(), "drive_get_doc", map[string]any{
 		"file_id": "doc_big",
 	}, testToken())
@@ -424,7 +424,7 @@ func TestConnector_Search_IntMaxResults(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	// Test with int type (not float64).
 	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{
 		"query":       "test",
@@ -442,7 +442,7 @@ func TestConnector_DriveSearch_IntMaxResults(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	_, err := c.Execute(context.Background(), "drive_search", map[string]any{
 		"query":       "test",
 		"max_results": 3,
@@ -454,7 +454,7 @@ func TestConnector_DriveSearch_IntMaxResults(t *testing.T) {
 
 func TestConnector_Search_MissingQuery(t *testing.T) {
 	token, _ := json.Marshal(map[string]string{"access_token": "test"})
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{}, token)
 	if err == nil {
 		t.Fatal("expected error for missing query")
@@ -463,7 +463,7 @@ func TestConnector_Search_MissingQuery(t *testing.T) {
 
 func TestConnector_GetThread_MissingThreadID(t *testing.T) {
 	token, _ := json.Marshal(map[string]string{"access_token": "test"})
-	c := gmailsource.New()
+	c := gmailsource.New("test-client-id", "test-client-secret")
 	_, err := c.Execute(context.Background(), "gmail_get_thread", map[string]any{}, token)
 	if err == nil {
 		t.Fatal("expected error for missing thread_id")
@@ -531,7 +531,7 @@ func TestConnector_Search_ConcurrentFetch(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	result, err := c.Execute(context.Background(), "gmail_search", map[string]any{
 		"query": "test",
 	}, testToken())
@@ -590,7 +590,7 @@ func TestConnector_Search_ConcurrentFetch_ErrorPropagation(t *testing.T) {
 	}))
 	defer server.Close()
 
-	c := gmailsource.New().WithClientOption(option.WithEndpoint(server.URL))
+	c := gmailsource.New("test-client-id", "test-client-secret").WithClientOption(option.WithEndpoint(server.URL))
 	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{
 		"query": "test",
 	}, testToken())


### PR DESCRIPTION
## Summary
- Gmail and Calendar source connectors used `StaticTokenSource` with only the access token — once it expired (~1 hour), all Google API calls failed
- Both connectors now accept OAuth client credentials and use `oauth2.Config.TokenSource` which auto-refreshes using the stored refresh token
- Breaking change to `New()` constructors (now require `clientID, clientSecret` args) — all call sites updated

## Root cause
The vault stores the full `oauth2.Token` (access + refresh). The connectors extracted only the access token and never refreshed it. After ~1 hour, both Gmail and Calendar tools return auth errors, causing the LLM to report "running into an auth issue."

## Test plan
- [x] All 27 core packages pass
- [ ] Deploy and verify Gmail/Calendar tools work after >1 hour without reconnecting
- [ ] Verify new connection flow still works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)