### PR TITLE
fix: add json tags to model structs for consistent API response casing

### DIFF
--- a/core/model/connected_account.go
+++ b/core/model/connected_account.go
@@ -29,15 +29,15 @@ const (
 // refresh token is stored in the vault at a well-known path; this record
 // holds metadata only.
 type ConnectedAccount struct {
-	ID             string                   // conn_ + UUID
-	UserID         string                   // owning user (usr_ + UUID)
-	Provider       ConnectedAccountProvider // which external service
-	Scopes         []string                 // OAuth scopes granted
-	Status         ConnectedAccountStatus
-	ExternalUserID string // provider-specific user ID (e.g. Slack U...), empty for providers that don't need it
-	ExternalTeamID string // provider-specific workspace/team ID (e.g. Slack T...), empty for providers that don't need it
-	CreatedAt      time.Time
-	UpdatedAt      time.Time
+	ID             string                   `json:"id"`               // conn_ + UUID
+	UserID         string                   `json:"user_id"`          // owning user (usr_ + UUID)
+	Provider       ConnectedAccountProvider `json:"provider"`         // which external service
+	Scopes         []string                 `json:"scopes"`           // OAuth scopes granted
+	Status         ConnectedAccountStatus   `json:"status"`
+	ExternalUserID string                   `json:"external_user_id"` // provider-specific user ID (e.g. Slack U...)
+	ExternalTeamID string                   `json:"external_team_id"` // provider-specific workspace/team ID (e.g. Slack T...)
+	CreatedAt      time.Time                `json:"created_at"`
+	UpdatedAt      time.Time                `json:"updated_at"`
 }
 
 // VaultPath returns the vault key where the OAuth refresh token is stored.

--- a/core/model/draft.go
+++ b/core/model/draft.go
@@ -17,16 +17,16 @@ const (
 // The user reviews and either approves (send as-is), edits (send
 // revised text), or discards (don't send).
 type Draft struct {
-	ID          string      // dft_ + UUID
-	UserID      string      // owning user (usr_ + UUID)
-	Status      DraftStatus // pending → approved | edited | discarded
-	Service     string      // "slack", "discord"
-	Channel     string      // channel ID where the original message arrived
-	Author      string      // who sent the original message
-	MessageBody string      // the original message text
-	MessageTS   string      // original message timestamp (for threading)
-	DraftBody   string      // the AI-generated draft reply
-	SentBody    string      // what was actually sent (empty until approved/edited)
-	CreatedAt   time.Time
-	UpdatedAt   time.Time
+	ID          string      `json:"id"`           // dft_ + UUID
+	UserID      string      `json:"user_id"`      // owning user (usr_ + UUID)
+	Status      DraftStatus `json:"status"`       // pending → approved | edited | discarded
+	Service     string      `json:"service"`      // "slack", "discord"
+	Channel     string      `json:"channel"`      // channel ID where the original message arrived
+	Author      string      `json:"author"`       // who sent the original message
+	MessageBody string      `json:"message_body"` // the original message text
+	MessageTS   string      `json:"message_ts"`   // original message timestamp (for threading)
+	DraftBody   string      `json:"draft_body"`   // the AI-generated draft reply
+	SentBody    string      `json:"sent_body"`    // what was actually sent (empty until approved/edited)
+	CreatedAt   time.Time   `json:"created_at"`
+	UpdatedAt   time.Time   `json:"updated_at"`
 }

--- a/core/model/enterprise.go
+++ b/core/model/enterprise.go
@@ -17,17 +17,17 @@ const (
 // A personal enterprise (Personal == true) is auto-created for users who sign
 // in with a personal email (e.g. Gmail) that is not tied to an organization.
 type Enterprise struct {
-	ID                   string
-	Name                 string
-	Slug                 string // URL-friendly, unique
-	Plan                 EnterprisePlan
-	Personal             bool   // true for single-user personal accounts
-	BillingEmail         string
-	SSORequired          bool
-	AllowedAuthProviders []string // e.g. ["google", "okta"]
-	AllowedEmailDomains  []string // e.g. ["acme.com"]
-	CreatedAt            time.Time
-	UpdatedAt            time.Time
+	ID                   string         `json:"id"`
+	Name                 string         `json:"name"`
+	Slug                 string         `json:"slug"`                    // URL-friendly, unique
+	Plan                 EnterprisePlan `json:"plan"`
+	Personal             bool           `json:"personal"`                // true for single-user personal accounts
+	BillingEmail         string         `json:"billing_email"`
+	SSORequired          bool           `json:"sso_required"`
+	AllowedAuthProviders []string       `json:"allowed_auth_providers"`  // e.g. ["google", "okta"]
+	AllowedEmailDomains  []string       `json:"allowed_email_domains"`   // e.g. ["acme.com"]
+	CreatedAt            time.Time      `json:"created_at"`
+	UpdatedAt            time.Time      `json:"updated_at"`
 }
 
 // UserRole classifies a user's permissions within an enterprise.
@@ -54,49 +54,49 @@ const (
 // logical identity used to deduplicate across OAuth providers — when any
 // provider returns an email, we look up or create the user by email.
 type User struct {
-	ID            string // usr_ + UUID — immutable surrogate key
-	EnterpriseID  string
-	Email         string // unique, used for cross-provider deduplication
-	DisplayName   string
-	AvatarURL     string
-	Role          UserRole
-	Status        UserStatus
-	PasswordHash  string // bcrypt hash; empty for OAuth-only users
-	LastLoginAt   *time.Time
-	CreatedAt     time.Time
-	UpdatedAt     time.Time
-	AuthProviders []UserAuthProvider // populated by handler; not stored on users table
+	ID            string             `json:"id"`              // usr_ + UUID — immutable surrogate key
+	EnterpriseID  string             `json:"enterprise_id"`
+	Email         string             `json:"email"`           // unique, used for cross-provider deduplication
+	DisplayName   string             `json:"display_name"`
+	AvatarURL     string             `json:"avatar_url"`
+	Role          UserRole           `json:"role"`
+	Status        UserStatus         `json:"status"`
+	PasswordHash  string             `json:"-"`               // bcrypt hash; never exposed via API
+	LastLoginAt   *time.Time         `json:"last_login_at"`
+	CreatedAt     time.Time          `json:"created_at"`
+	UpdatedAt     time.Time          `json:"updated_at"`
+	AuthProviders []UserAuthProvider `json:"auth_providers"`  // populated by handler; not stored on users table
 }
 
 // UserAuthProvider links a user to an external OAuth/SSO identity provider.
 // Each row represents one connected provider (e.g. Google, GitHub).
 type UserAuthProvider struct {
-	ID        string // uap_ + UUID
-	UserID    string
-	Provider  string // "google", "github", "okta", "saml", etc.
-	SubjectID string // external IdP subject identifier
-	CreatedAt time.Time
+	ID        string    `json:"id"`         // uap_ + UUID
+	UserID    string    `json:"user_id"`
+	Provider  string    `json:"provider"`   // "google", "github", "okta", "saml", etc.
+	SubjectID string    `json:"subject_id"` // external IdP subject identifier
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // VerificationCode is a single-use code sent to a user's email to verify
 // their account. Codes are hashed (SHA-256) before storage.
 type VerificationCode struct {
-	ID        string
-	UserID    string
-	CodeHash  string // SHA-256 of the 6-digit code
-	ExpiresAt time.Time
-	Used      bool
-	CreatedAt time.Time
+	ID        string    `json:"id"`
+	UserID    string    `json:"user_id"`
+	CodeHash  string    `json:"-"`          // SHA-256 of the 6-digit code; never exposed via API
+	ExpiresAt time.Time `json:"expires_at"`
+	Used      bool      `json:"used"`
+	CreatedAt time.Time `json:"created_at"`
 }
 
 // Session is a login session backed by a refresh token.
 type Session struct {
-	ID               string
-	UserID           string
-	TokenHash        string // SHA-256 of access token
-	RefreshTokenHash string // SHA-256 of refresh token
-	ExpiresAt        time.Time
-	CreatedAt        time.Time
+	ID               string    `json:"id"`
+	UserID           string    `json:"user_id"`
+	TokenHash        string    `json:"-"`          // SHA-256 of access token; never exposed via API
+	RefreshTokenHash string    `json:"-"`          // SHA-256 of refresh token; never exposed via API
+	ExpiresAt        time.Time `json:"expires_at"`
+	CreatedAt        time.Time `json:"created_at"`
 }
 
 // SSOProvider identifies the type of SSO integration.
@@ -110,12 +110,12 @@ const (
 
 // SSOConfig stores per-enterprise SSO provider configuration.
 type SSOConfig struct {
-	ID           string
-	EnterpriseID string
-	Provider     SSOProvider
-	ClientID     string // stored encrypted
-	IssuerURL    string
-	Enabled      bool
-	CreatedAt    time.Time
-	UpdatedAt    time.Time
+	ID           string      `json:"id"`
+	EnterpriseID string      `json:"enterprise_id"`
+	Provider     SSOProvider `json:"provider"`
+	ClientID     string      `json:"-"`              // stored encrypted; never exposed via API
+	IssuerURL    string      `json:"issuer_url"`
+	Enabled      bool        `json:"enabled"`
+	CreatedAt    time.Time   `json:"created_at"`
+	UpdatedAt    time.Time   `json:"updated_at"`
 }

--- a/core/model/feedback.go
+++ b/core/model/feedback.go
@@ -16,14 +16,14 @@ const (
 // and tone, edited drafts provide correction signals (the diff between
 // DraftBody and SentBody), and discarded drafts are negative signals.
 type DraftFeedback struct {
-	ID        string         // fb_ + UUID
-	UserID    string         // owning user
-	DraftID   string         // the draft this feedback is for
-	Signal    FeedbackSignal // approved, edited, discarded
-	Service   string         // "slack", etc.
-	Channel   string         // where the original message was
-	DraftBody string         // what the AI generated
-	SentBody  string         // what was actually sent (empty if discarded)
-	ToolsUsed []string       // source connector tools called during generation
-	CreatedAt time.Time
+	ID        string         `json:"id"`         // fb_ + UUID
+	UserID    string         `json:"user_id"`    // owning user
+	DraftID   string         `json:"draft_id"`   // the draft this feedback is for
+	Signal    FeedbackSignal `json:"signal"`     // approved, edited, discarded
+	Service   string         `json:"service"`    // "slack", etc.
+	Channel   string         `json:"channel"`    // where the original message was
+	DraftBody string         `json:"draft_body"` // what the AI generated
+	SentBody  string         `json:"sent_body"`  // what was actually sent (empty if discarded)
+	ToolsUsed []string       `json:"tools_used"` // source connector tools called during generation
+	CreatedAt time.Time      `json:"created_at"`
 }

--- a/core/model/instruction.go
+++ b/core/model/instruction.go
@@ -7,11 +7,11 @@ import "time"
 // system prompt during draft generation — they are the highest-priority
 // context, overriding learned patterns and behavioral model inferences.
 type UserInstruction struct {
-	ID        string    // ins_ + UUID
-	UserID    string    // owning user (usr_ + UUID)
-	Body      string    // the instruction text
-	Scope     string    // optional free-text context: channel, person, topic, or empty for global
-	Active    bool      // toggleable without deleting
-	CreatedAt time.Time
-	UpdatedAt time.Time
+	ID        string    `json:"id"`         // ins_ + UUID
+	UserID    string    `json:"user_id"`    // owning user (usr_ + UUID)
+	Body      string    `json:"body"`       // the instruction text
+	Scope     string    `json:"scope"`      // optional free-text context: channel, person, topic, or empty for global
+	Active    bool      `json:"active"`     // toggleable without deleting
+	CreatedAt time.Time `json:"created_at"`
+	UpdatedAt time.Time `json:"updated_at"`
 }

--- a/core/model/json_tags_test.go
+++ b/core/model/json_tags_test.go
@@ -1,0 +1,164 @@
+package model_test
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+)
+
+// TestUserInstruction_JSONKeys verifies snake_case JSON serialization.
+func TestUserInstruction_JSONKeys(t *testing.T) {
+	inst := model.UserInstruction{
+		ID:        "ins_123",
+		UserID:    "usr_456",
+		Body:      "Always be concise",
+		Scope:     "global",
+		Active:    true,
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt: time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+
+	b, err := json.Marshal(inst)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	required := []string{"id", "user_id", "body", "scope", "active", "created_at", "updated_at"}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing expected key %q in JSON output", key)
+		}
+	}
+
+	// Verify no PascalCase keys leaked through.
+	banned := []string{"ID", "UserID", "Body", "Scope", "Active", "CreatedAt", "UpdatedAt"}
+	for _, key := range banned {
+		if _, ok := m[key]; ok {
+			t.Errorf("unexpected PascalCase key %q in JSON output", key)
+		}
+	}
+}
+
+// TestDraft_JSONKeys verifies snake_case JSON serialization.
+func TestDraft_JSONKeys(t *testing.T) {
+	draft := model.Draft{
+		ID:          "dft_123",
+		UserID:      "usr_456",
+		Status:      model.DraftStatusPending,
+		Service:     "slack",
+		Channel:     "C123",
+		Author:      "sarah",
+		MessageBody: "original message",
+		MessageTS:   "1234567890.123456",
+		DraftBody:   "draft reply",
+		SentBody:    "",
+		CreatedAt:   time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+		UpdatedAt:   time.Date(2026, 1, 2, 0, 0, 0, 0, time.UTC),
+	}
+
+	b, err := json.Marshal(draft)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	required := []string{"id", "user_id", "status", "service", "channel", "author",
+		"message_body", "message_ts", "draft_body", "sent_body", "created_at", "updated_at"}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing expected key %q in JSON output", key)
+		}
+	}
+
+	banned := []string{"MessageBody", "MessageTS", "DraftBody", "SentBody"}
+	for _, key := range banned {
+		if _, ok := m[key]; ok {
+			t.Errorf("unexpected PascalCase key %q in JSON output", key)
+		}
+	}
+}
+
+// TestDraftFeedback_JSONKeys verifies snake_case JSON serialization.
+func TestDraftFeedback_JSONKeys(t *testing.T) {
+	fb := model.DraftFeedback{
+		ID:        "fb_123",
+		UserID:    "usr_456",
+		DraftID:   "dft_789",
+		Signal:    model.FeedbackSignalApproved,
+		Service:   "slack",
+		Channel:   "C123",
+		DraftBody: "draft text",
+		SentBody:  "sent text",
+		ToolsUsed: []string{"gmail_search"},
+		CreatedAt: time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC),
+	}
+
+	b, err := json.Marshal(fb)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	required := []string{"id", "user_id", "draft_id", "signal", "service", "channel",
+		"draft_body", "sent_body", "tools_used", "created_at"}
+	for _, key := range required {
+		if _, ok := m[key]; !ok {
+			t.Errorf("missing expected key %q in JSON output", key)
+		}
+	}
+
+	banned := []string{"DraftID", "DraftBody", "SentBody", "ToolsUsed"}
+	for _, key := range banned {
+		if _, ok := m[key]; ok {
+			t.Errorf("unexpected PascalCase key %q in JSON output", key)
+		}
+	}
+}
+
+// TestUser_JSONKeys verifies sensitive fields are excluded from JSON.
+func TestUser_JSONKeys(t *testing.T) {
+	user := model.User{
+		ID:           "usr_123",
+		EnterpriseID: "ent_456",
+		Email:        "test@example.com",
+		PasswordHash: "secret-hash",
+	}
+
+	b, err := json.Marshal(user)
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+
+	var m map[string]any
+	if err := json.Unmarshal(b, &m); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+
+	// PasswordHash must be excluded via json:"-".
+	if _, ok := m["password_hash"]; ok {
+		t.Error("password_hash should not appear in JSON output")
+	}
+	if _, ok := m["PasswordHash"]; ok {
+		t.Error("PasswordHash should not appear in JSON output")
+	}
+
+	// Other fields should be present with snake_case keys.
+	if _, ok := m["enterprise_id"]; !ok {
+		t.Error("expected enterprise_id in JSON output")
+	}
+}

--- a/core/model/model.go
+++ b/core/model/model.go
@@ -9,9 +9,9 @@ import "time"
 
 // ActorRef identifies who or what performed an action.
 type ActorRef struct {
-	ID          string
-	Type        ActorType
-	DisplayName string
+	ID          string    `json:"id"`
+	Type        ActorType `json:"type"`
+	DisplayName string    `json:"display_name"`
 }
 
 // ActorType classifies the actor.
@@ -26,188 +26,188 @@ const (
 
 // ActionTarget describes the resource an action operates on.
 type ActionTarget struct {
-	Kind        string
-	ID          string
-	DisplayName string
+	Kind        string `json:"kind"`
+	ID          string `json:"id"`
+	DisplayName string `json:"display_name"`
 }
 
 // ActionIntent describes what an agent intends to do.
 type ActionIntent struct {
 	// Type is a dot-namespaced action identifier, e.g. "payment.charge",
 	// "git.pull_request.create", "calendar.event.create".
-	Type          string
-	Summary       string
-	Justification string
-	Target        ActionTarget
-	Domain        DomainAction
-	Metadata      map[string]any
+	Type          string         `json:"type"`
+	Summary       string         `json:"summary"`
+	Justification string         `json:"justification"`
+	Target        ActionTarget   `json:"target"`
+	Domain        DomainAction   `json:"domain"`
+	Metadata      map[string]any `json:"metadata"`
 }
 
 // DomainAction carries action-type-specific fields.
 // Exactly one field should be populated, corresponding to the ActionIntent.Type prefix.
 type DomainAction struct {
-	Git         *GitAction
-	Deploy      *DeployAction
-	Cloud       *CloudAction
-	Email       *EmailAction
-	Calendar    *CalendarAction
-	Payment     *PaymentAction
-	Procurement *ProcurementAction
+	Git         *GitAction         `json:"git,omitempty"`
+	Deploy      *DeployAction      `json:"deploy,omitempty"`
+	Cloud       *CloudAction       `json:"cloud,omitempty"`
+	Email       *EmailAction       `json:"email,omitempty"`
+	Calendar    *CalendarAction    `json:"calendar,omitempty"`
+	Payment     *PaymentAction     `json:"payment,omitempty"`
+	Procurement *ProcurementAction `json:"procurement,omitempty"`
 }
 
 // Money represents an amount in minor units (e.g. cents) with a currency code.
 type Money struct {
-	Amount   int64
-	Currency string // ISO 4217, e.g. "USD"
+	Amount   int64  `json:"amount"`
+	Currency string `json:"currency"` // ISO 4217, e.g. "USD"
 }
 
 // GitAction carries git/source-control-specific intent fields.
 type GitAction struct {
-	Provider       string // "github", "gitlab", "bitbucket", "custom"
-	Repository     string
-	Branch         string
-	BaseBranch     string
-	CommitSHAs     []string
-	FilesChanged   []string
-	PRTitle        string
-	PRBody         string
-	Labels         []string
-	Reviewers      []string
-	ChecksRequired []string
+	Provider       string   `json:"provider"`        // "github", "gitlab", "bitbucket", "custom"
+	Repository     string   `json:"repository"`
+	Branch         string   `json:"branch"`
+	BaseBranch     string   `json:"base_branch"`
+	CommitSHAs     []string `json:"commit_shas"`
+	FilesChanged   []string `json:"files_changed"`
+	PRTitle        string   `json:"pr_title"`
+	PRBody         string   `json:"pr_body"`
+	Labels         []string `json:"labels"`
+	Reviewers      []string `json:"reviewers"`
+	ChecksRequired []string `json:"checks_required"`
 }
 
 // DeployAction carries deployment-specific intent fields.
 type DeployAction struct {
-	Provider            string // "kubernetes", "vercel", "netlify", etc.
-	Service             string
-	Environment         string
-	ArtifactRef         string
-	ImageRef            string
-	Cluster             string
-	Namespace           string
-	Strategy            string // "rolling", "blue_green", "canary", "replace", "custom"
-	RollbackSupported   bool
-	ChangeTicketID      string
-	MaintenanceWindowID string
+	Provider            string `json:"provider"` // "kubernetes", "vercel", "netlify", etc.
+	Service             string `json:"service"`
+	Environment         string `json:"environment"`
+	ArtifactRef         string `json:"artifact_ref"`
+	ImageRef            string `json:"image_ref"`
+	Cluster             string `json:"cluster"`
+	Namespace           string `json:"namespace"`
+	Strategy            string `json:"strategy"` // "rolling", "blue_green", "canary", "replace", "custom"
+	RollbackSupported   bool   `json:"rollback_supported"`
+	ChangeTicketID      string `json:"change_ticket_id"`
+	MaintenanceWindowID string `json:"maintenance_window_id"`
 }
 
 // CloudAction carries cloud-resource-specific intent fields.
 type CloudAction struct {
-	Provider      string // "aws", "gcp", "azure", "cloudflare", "custom"
-	AccountID     string
-	Region        string
-	ResourceType  string
-	ResourceID    string
-	Operation     string
-	EstimatedCost *Money
-	Tags          map[string]string
+	Provider      string            `json:"provider"` // "aws", "gcp", "azure", "cloudflare", "custom"
+	AccountID     string            `json:"account_id"`
+	Region        string            `json:"region"`
+	ResourceType  string            `json:"resource_type"`
+	ResourceID    string            `json:"resource_id"`
+	Operation     string            `json:"operation"`
+	EstimatedCost *Money            `json:"estimated_cost,omitempty"`
+	Tags          map[string]string `json:"tags"`
 }
 
 // EmailAction carries email-specific intent fields.
 type EmailAction struct {
-	From        *Recipient
-	To          []Recipient
-	CC          []Recipient
-	BCC         []Recipient
-	Subject     string
-	BodyText    string
-	BodyHTML    string
-	Attachments []AttachmentRef
-	ThreadRef   string
-	SendMode    string // "send_now", "draft_only"
+	From        *Recipient      `json:"from,omitempty"`
+	To          []Recipient     `json:"to"`
+	CC          []Recipient     `json:"cc,omitempty"`
+	BCC         []Recipient     `json:"bcc,omitempty"`
+	Subject     string          `json:"subject"`
+	BodyText    string          `json:"body_text"`
+	BodyHTML    string          `json:"body_html"`
+	Attachments []AttachmentRef `json:"attachments,omitempty"`
+	ThreadRef   string          `json:"thread_ref"`
+	SendMode    string          `json:"send_mode"` // "send_now", "draft_only"
 }
 
 // Recipient identifies an email participant.
 type Recipient struct {
-	Name  string
-	Email string
+	Name  string `json:"name"`
+	Email string `json:"email"`
 }
 
 // AttachmentRef references a file attachment.
 type AttachmentRef struct {
-	Name       string
-	MIMEType   string
-	URL        string
-	StorageRef string
+	Name       string `json:"name"`
+	MIMEType   string `json:"mime_type"`
+	URL        string `json:"url"`
+	StorageRef string `json:"storage_ref"`
 }
 
 // CalendarAction carries calendar-specific intent fields.
 type CalendarAction struct {
-	Provider       string // "google_calendar", "outlook", "custom"
-	Title          string
-	Description    string
-	Attendees      []CalendarAttendee
-	StartTime      *time.Time
-	EndTime        *time.Time
-	Timezone       string
-	Location       string
-	ConferenceType string // "none", "google_meet", "zoom", "teams", "custom"
-	CalendarID     string
-	Visibility     string // "default", "public", "private"
+	Provider       string             `json:"provider"` // "google_calendar", "outlook", "custom"
+	Title          string             `json:"title"`
+	Description    string             `json:"description"`
+	Attendees      []CalendarAttendee `json:"attendees,omitempty"`
+	StartTime      *time.Time         `json:"start_time,omitempty"`
+	EndTime        *time.Time         `json:"end_time,omitempty"`
+	Timezone       string             `json:"timezone"`
+	Location       string             `json:"location"`
+	ConferenceType string             `json:"conference_type"` // "none", "google_meet", "zoom", "teams", "custom"
+	CalendarID     string             `json:"calendar_id"`
+	Visibility     string             `json:"visibility"` // "default", "public", "private"
 }
 
 // CalendarAttendee is a participant in a calendar event.
 type CalendarAttendee struct {
-	Name     string
-	Email    string
-	Optional bool
+	Name     string `json:"name"`
+	Email    string `json:"email"`
+	Optional bool   `json:"optional"`
 }
 
 // PaymentAction carries payment-specific intent fields.
 type PaymentAction struct {
-	VendorName                   string
-	VendorID                     string
-	Amount                       Money
-	MerchantCategory             string
-	BudgetCode                   string
-	FundingSourceID              string
-	PaymentInstrumentPreference  string // "virtual_card", "ach", "wallet", "network_proxy", "unspecified"
-	Beneficiary                  *PaymentBeneficiary
-	LineItems                    []LineItem
-	Renewal                      bool
-	ContractTerm                 string
-	RecurringInterval            string // "none", "monthly", "quarterly", "annual"
-	MerchantReference            string
+	VendorName                  string              `json:"vendor_name"`
+	VendorID                    string              `json:"vendor_id"`
+	Amount                      Money               `json:"amount"`
+	MerchantCategory            string              `json:"merchant_category"`
+	BudgetCode                  string              `json:"budget_code"`
+	FundingSourceID             string              `json:"funding_source_id"`
+	PaymentInstrumentPreference string              `json:"payment_instrument_preference"` // "virtual_card", "ach", "wallet", "network_proxy", "unspecified"
+	Beneficiary                 *PaymentBeneficiary `json:"beneficiary,omitempty"`
+	LineItems                   []LineItem          `json:"line_items,omitempty"`
+	Renewal                     bool                `json:"renewal"`
+	ContractTerm                string              `json:"contract_term"`
+	RecurringInterval           string              `json:"recurring_interval"` // "none", "monthly", "quarterly", "annual"
+	MerchantReference           string              `json:"merchant_reference"`
 }
 
 // PaymentBeneficiary identifies the person or team benefiting from a payment.
 type PaymentBeneficiary struct {
-	Name       string
-	Email      string
-	Department string
+	Name       string `json:"name"`
+	Email      string `json:"email"`
+	Department string `json:"department"`
 }
 
 // LineItem is a single item in a payment or procurement request.
 type LineItem struct {
-	Description string
-	Quantity    int
-	UnitAmount  Money
-	SKU         string
+	Description string `json:"description"`
+	Quantity    int    `json:"quantity"`
+	UnitAmount  Money  `json:"unit_amount"`
+	SKU         string `json:"sku"`
 }
 
 // ProcurementAction carries procurement-specific intent fields.
 type ProcurementAction struct {
-	RequestType            string // "software", "travel", "equipment", "contractor", "services", "other"
-	VendorName             string
-	AmountEstimate         *Money
-	Justification          string
-	Requestor              string
-	CostCenter             string
-	LegalReviewRequired    bool
-	SecurityReviewRequired bool
-	LineItems              []LineItem
+	RequestType            string     `json:"request_type"` // "software", "travel", "equipment", "contractor", "services", "other"
+	VendorName             string     `json:"vendor_name"`
+	AmountEstimate         *Money     `json:"amount_estimate,omitempty"`
+	Justification          string     `json:"justification"`
+	Requestor              string     `json:"requestor"`
+	CostCenter             string     `json:"cost_center"`
+	LegalReviewRequired    bool       `json:"legal_review_required"`
+	SecurityReviewRequired bool       `json:"security_review_required"`
+	LineItems              []LineItem `json:"line_items,omitempty"`
 }
 
 // IntentContext carries runtime context used by policy rules.
 type IntentContext struct {
-	Environment      string
-	SourcePlatform   string
-	SourceSessionID  string
-	SourceTraceID    string
-	IPAddress        string
-	UserPresent      bool
-	RiskHints        []string
-	TemporaryGrantID string
+	Environment      string   `json:"environment"`
+	SourcePlatform   string   `json:"source_platform"`
+	SourceSessionID  string   `json:"source_session_id"`
+	SourceTraceID    string   `json:"source_trace_id"`
+	IPAddress        string   `json:"ip_address"`
+	UserPresent      bool     `json:"user_present"`
+	RiskHints        []string `json:"risk_hints,omitempty"`
+	TemporaryGrantID string   `json:"temporary_grant_id"`
 }
 
 // Disposition is the outcome of policy evaluation.
@@ -233,18 +233,18 @@ const (
 
 // Decision is the output of policy evaluation.
 type Decision struct {
-	Disposition     Disposition
-	RiskLevel       RiskLevel
-	MatchedPolicies []PolicyMatch
-	DenialReason    string
+	Disposition     Disposition   `json:"disposition"`
+	RiskLevel       RiskLevel     `json:"risk_level"`
+	MatchedPolicies []PolicyMatch `json:"matched_policies,omitempty"`
+	DenialReason    string        `json:"denial_reason"`
 }
 
 // PolicyMatch records which policy rule produced a decision.
 type PolicyMatch struct {
-	PolicyID      string
-	PolicyVersion int
-	RuleID        string
-	Explanation   string
+	PolicyID      string `json:"policy_id"`
+	PolicyVersion int    `json:"policy_version"`
+	RuleID        string `json:"rule_id"`
+	Explanation   string `json:"explanation"`
 }
 
 // EventType identifies the kind of audit event.

--- a/core/model/user_key_material.go
+++ b/core/model/user_key_material.go
@@ -10,9 +10,9 @@ import "time"
 // the KEK) are persisted. This enables passphrase verification without
 // revealing the KEK.
 type UserKeyMaterial struct {
-	UserID          string    // owning user (usr_ + UUID)
-	Salt            []byte    // Argon2id salt for KEK derivation
-	KEKVerification []byte    // known constant encrypted with KEK — used to verify passphrase
-	CreatedAt       time.Time
-	UpdatedAt       time.Time
+	UserID          string    `json:"user_id"`          // owning user (usr_ + UUID)
+	Salt            []byte    `json:"-"`                // Argon2id salt for KEK derivation; never exposed via API
+	KEKVerification []byte    `json:"-"`                // known constant encrypted with KEK; never exposed via API
+	CreatedAt       time.Time `json:"created_at"`
+	UpdatedAt       time.Time `json:"updated_at"`
 }


### PR DESCRIPTION
## Summary

- Add `json:"snake_case"` tags to all manually-defined model structs (`UserInstruction`, `Draft`, `DraftFeedback`, `Enterprise`, `User`, `UserAuthProvider`, `VerificationCode`, `Session`, `SSOConfig`, `ConnectedAccount`, `UserKeyMaterial`, and all domain action types in `model.go`)
- Sensitive fields (`PasswordHash`, `TokenHash`, `RefreshTokenHash`, `CodeHash`, `Salt`, `KEKVerification`, `SSOConfig.ClientID`) use `json:"-"` to prevent accidental API exposure
- Pointer/slice fields that are optional use `omitempty`

## Test plan

- [x] New `TestUserInstruction_JSONKeys` — verifies snake_case keys present, PascalCase absent
- [x] New `TestDraft_JSONKeys` — verifies all 12 fields serialize as snake_case
- [x] New `TestDraftFeedback_JSONKeys` — verifies all 10 fields serialize as snake_case
- [x] New `TestUser_JSONKeys` — verifies `PasswordHash` excluded from JSON output
- [x] All existing tests pass across the full `core` module

Closes #149

🤖 Generated with [Claude Code](https://claude.com/claude-code)