### PR TITLE
feat: per-user and per-org LLM provider and model selection

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -55,6 +55,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	draftStore := mem.NewDraftStore()
 	instructionStore := mem.NewUserInstructionStore()
 	feedbackStore := mem.NewDraftFeedbackStore()
+	llmConfigStore := mem.NewLLMConfigStore()
 
 	// --- Connector registry ---
 	registry := connector.NewRegistry()
@@ -127,6 +128,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		feedback:          feedbackStore,
 		credentials:       credentialStore,
 		fundingSources:    fundingSourceStore,
+		llmConfigs:        llmConfigStore,
 		traces:            traceStore,
 		sourceRegistry:    sourceReg,
 		enclaveClient:     enclaveClient,
@@ -153,6 +155,15 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	// Draft feedback API (context store envelope).
 	mux.HandleFunc("POST /v1/feedback", server.handleCreateFeedback)
 	mux.HandleFunc("GET /v1/feedback", server.handleListFeedback)
+
+	// LLM provider configuration (per-user).
+	mux.HandleFunc("PUT /v1/llm-config", server.handleUpsertUserLLMConfig)
+	mux.HandleFunc("GET /v1/llm-config", server.handleGetUserLLMConfig)
+	mux.HandleFunc("DELETE /v1/llm-config", server.handleDeleteUserLLMConfig)
+	// LLM provider configuration (per-enterprise, admin only).
+	mux.HandleFunc("PUT /v1/enterprises/{id}/llm-config", server.handleUpsertEnterpriseLLMConfig)
+	mux.HandleFunc("GET /v1/enterprises/{id}/llm-config", server.handleGetEnterpriseLLMConfig)
+	mux.HandleFunc("DELETE /v1/enterprises/{id}/llm-config", server.handleDeleteEnterpriseLLMConfig)
 
 	// Connected accounts — programmatic create (in addition to OAuth flow).
 	mux.HandleFunc("POST /v1/connected-accounts", server.handleCreateConnectedAccount)
@@ -222,12 +233,27 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			server.accountService = accountRegistry
 		}
 
+		// Per-user/per-org LLM configuration store.
+		pgLLMConfigStore := postgres.NewLLMConfigStore(db)
+		server.llmConfigs = pgLLMConfigStore
+
 		// LLM-powered draft generation pipeline.
 		if authCfg.LLMEnabled() {
 			researchClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModelResearch, llm.WithLogger(log))
 			synthesisClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModelSynthesis, llm.WithLogger(log))
 			prompts := draft.LoadPrompts()
-			server.draftPipeline = draft.NewPipeline(researchClient, synthesisClient, sourceReg, pgConnectedAccountStore, pgInstructionStore, v, log, prompts)
+
+			resolver := llm.NewClientResolver(
+				pgLLMConfigStore, userStore, v,
+				authCfg.AnthropicAPIKey, authCfg.LLMModelResearch, authCfg.LLMModelSynthesis,
+				log,
+			)
+
+			server.draftPipeline = draft.NewPipeline(
+				researchClient, synthesisClient, sourceReg,
+				pgConnectedAccountStore, pgInstructionStore, v, log, prompts,
+			).WithClientResolver(resolver)
+
 			log.Info("enabled cloud draft generation",
 				"research_model", authCfg.LLMModelResearch,
 				"synthesis_model", authCfg.LLMModelSynthesis,

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -12,7 +12,6 @@ import (
 	api "github.com/ALRubinger/aileron/core/api/gen"
 	"github.com/ALRubinger/aileron/core/approval"
 	"github.com/ALRubinger/aileron/core/draft"
-	"github.com/ALRubinger/aileron/core/llm"
 	"github.com/ALRubinger/aileron/core/source"
 	calendarsource "github.com/ALRubinger/aileron/core/source/calendar"
 	githubsource "github.com/ALRubinger/aileron/core/source/github"
@@ -239,21 +238,20 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 
 		// LLM-powered draft generation pipeline.
 		if authCfg.LLMEnabled() {
-			researchClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModelResearch, llm.WithLogger(log))
-			synthesisClient := llm.NewAnthropicClient(authCfg.AnthropicAPIKey, authCfg.LLMModelSynthesis, llm.WithLogger(log))
 			prompts := draft.LoadPrompts()
-
-			resolver := llm.NewClientResolver(
-				pgLLMConfigStore, userStore, v,
-				authCfg.AnthropicAPIKey, authCfg.LLMModelResearch, authCfg.LLMModelSynthesis,
-				log,
-			)
-
-			server.draftPipeline = draft.NewPipeline(
-				researchClient, synthesisClient, sourceReg,
-				pgConnectedAccountStore, pgInstructionStore, v, log, prompts,
-			).WithClientResolver(resolver)
-
+			server.draftPipeline = buildDraftPipeline(draftPipelineDeps{
+				apiKey:         authCfg.AnthropicAPIKey,
+				modelResearch:  authCfg.LLMModelResearch,
+				modelSynthesis: authCfg.LLMModelSynthesis,
+				llmConfigs:     pgLLMConfigStore,
+				users:          userStore,
+				accounts:       pgConnectedAccountStore,
+				instructions:   pgInstructionStore,
+				vault:          v,
+				sourceReg:      sourceReg,
+				log:            log,
+				prompts:        prompts,
+			})
 			log.Info("enabled cloud draft generation",
 				"research_model", authCfg.LLMModelResearch,
 				"synthesis_model", authCfg.LLMModelSynthesis,

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -60,6 +60,7 @@ type apiServer struct {
 	slackSigningSecret string                  // Slack Events API signing secret for webhook verification
 	slackDedup         *slackEventDedup        // deduplication cache for Slack events
 	onSlackMessage     func(ctx context.Context, userID string, msg comms.IncomingMessage) // callback for incoming Slack messages
+	llmConfigs         store.LLMConfigStore   // per-user/per-org LLM provider config
 	enterprises        store.EnterpriseStore  // nil when auth is disabled
 	users              store.UserStore        // nil when auth is disabled
 	userAuthProviders  store.UserAuthProviderStore // nil when auth is disabled

--- a/core/app/handlers_llm_config.go
+++ b/core/app/handlers_llm_config.go
@@ -1,0 +1,314 @@
+package app
+
+import (
+	"encoding/json"
+	"net/http"
+	"strings"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+// handleUpsertUserLLMConfig creates or updates the calling user's LLM config.
+// PUT /v1/llm-config
+func (s *apiServer) handleUpsertUserLLMConfig(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	var req struct {
+		Provider       string `json:"provider"`
+		ModelResearch  string `json:"model_research"`
+		ModelSynthesis string `json:"model_synthesis"`
+		APIKey         string `json:"api_key"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid JSON request body")
+		return
+	}
+	if req.Provider == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body", "provider is required")
+		return
+	}
+	if req.APIKey == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body", "api_key is required")
+		return
+	}
+
+	now := time.Now().UTC()
+	cfg := model.LLMConfig{
+		ID:             "llm_" + s.newID(),
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        userID,
+		Provider:       model.LLMProvider(req.Provider),
+		ModelResearch:  req.ModelResearch,
+		ModelSynthesis: req.ModelSynthesis,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	// Store API key in vault.
+	if err := s.vault.Put(r.Context(), cfg.VaultPath(), []byte(req.APIKey), vault.Metadata{
+		Type:   "llm_api_key",
+		Labels: map[string]string{"owner_type": "user", "owner_id": userID},
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "failed to store API key")
+		return
+	}
+
+	result, err := s.llmConfigs.Upsert(r.Context(), cfg)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, llmConfigResponse(result, true))
+}
+
+// handleGetUserLLMConfig returns the calling user's LLM config.
+// GET /v1/llm-config
+func (s *apiServer) handleGetUserLLMConfig(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	cfg, err := s.llmConfigs.GetByOwner(r.Context(), model.LLMConfigOwnerUser, userID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "no LLM configuration found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, llmConfigResponse(cfg, true))
+}
+
+// handleDeleteUserLLMConfig deletes the calling user's LLM config.
+// DELETE /v1/llm-config
+func (s *apiServer) handleDeleteUserLLMConfig(w http.ResponseWriter, r *http.Request) {
+	userID, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	cfg, err := s.llmConfigs.GetByOwner(r.Context(), model.LLMConfigOwnerUser, userID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "no LLM configuration found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	// Remove API key from vault.
+	_ = s.vault.Delete(r.Context(), cfg.VaultPath())
+
+	if err := s.llmConfigs.Delete(r.Context(), cfg.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// handleUpsertEnterpriseLLMConfig creates or updates an enterprise's LLM config.
+// PUT /v1/enterprises/{id}/llm-config
+func (s *apiServer) handleUpsertEnterpriseLLMConfig(w http.ResponseWriter, r *http.Request) {
+	_, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	enterpriseID := extractEnterpriseLLMConfigID(r.URL.Path)
+	if enterpriseID == "" {
+		writeError(w, http.StatusBadRequest, "invalid_path", "enterprise_id is required")
+		return
+	}
+
+	// Verify caller has admin/owner access to this enterprise.
+	if !s.requireEnterpriseAdmin(w, r, enterpriseID) {
+		return
+	}
+
+	var req struct {
+		Provider       string `json:"provider"`
+		ModelResearch  string `json:"model_research"`
+		ModelSynthesis string `json:"model_synthesis"`
+		APIKey         string `json:"api_key"`
+	}
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid JSON request body")
+		return
+	}
+	if req.Provider == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body", "provider is required")
+		return
+	}
+	if req.APIKey == "" {
+		writeError(w, http.StatusBadRequest, "invalid_body", "api_key is required")
+		return
+	}
+
+	now := time.Now().UTC()
+	cfg := model.LLMConfig{
+		ID:             "llm_" + s.newID(),
+		OwnerType:      model.LLMConfigOwnerEnterprise,
+		OwnerID:        enterpriseID,
+		Provider:       model.LLMProvider(req.Provider),
+		ModelResearch:  req.ModelResearch,
+		ModelSynthesis: req.ModelSynthesis,
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	if err := s.vault.Put(r.Context(), cfg.VaultPath(), []byte(req.APIKey), vault.Metadata{
+		Type:   "llm_api_key",
+		Labels: map[string]string{"owner_type": "enterprise", "owner_id": enterpriseID},
+	}); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", "failed to store API key")
+		return
+	}
+
+	result, err := s.llmConfigs.Upsert(r.Context(), cfg)
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, llmConfigResponse(result, true))
+}
+
+// handleGetEnterpriseLLMConfig returns an enterprise's LLM config.
+// GET /v1/enterprises/{id}/llm-config
+func (s *apiServer) handleGetEnterpriseLLMConfig(w http.ResponseWriter, r *http.Request) {
+	_, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	enterpriseID := extractEnterpriseLLMConfigID(r.URL.Path)
+	if enterpriseID == "" {
+		writeError(w, http.StatusBadRequest, "invalid_path", "enterprise_id is required")
+		return
+	}
+
+	if !s.requireEnterpriseAdmin(w, r, enterpriseID) {
+		return
+	}
+
+	cfg, err := s.llmConfigs.GetByOwner(r.Context(), model.LLMConfigOwnerEnterprise, enterpriseID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "no LLM configuration found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	writeJSON(w, http.StatusOK, llmConfigResponse(cfg, true))
+}
+
+// handleDeleteEnterpriseLLMConfig deletes an enterprise's LLM config.
+// DELETE /v1/enterprises/{id}/llm-config
+func (s *apiServer) handleDeleteEnterpriseLLMConfig(w http.ResponseWriter, r *http.Request) {
+	_, _, ok := s.requireAuth(w, r)
+	if !ok {
+		return
+	}
+
+	enterpriseID := extractEnterpriseLLMConfigID(r.URL.Path)
+	if enterpriseID == "" {
+		writeError(w, http.StatusBadRequest, "invalid_path", "enterprise_id is required")
+		return
+	}
+
+	if !s.requireEnterpriseAdmin(w, r, enterpriseID) {
+		return
+	}
+
+	cfg, err := s.llmConfigs.GetByOwner(r.Context(), model.LLMConfigOwnerEnterprise, enterpriseID)
+	if err != nil {
+		if isNotFound(err) {
+			writeError(w, http.StatusNotFound, "not_found", "no LLM configuration found")
+			return
+		}
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	_ = s.vault.Delete(r.Context(), cfg.VaultPath())
+
+	if err := s.llmConfigs.Delete(r.Context(), cfg.ID); err != nil {
+		writeError(w, http.StatusInternalServerError, "internal_error", err.Error())
+		return
+	}
+
+	w.WriteHeader(http.StatusNoContent)
+}
+
+// requireEnterpriseAdmin checks that the calling user has admin or owner role
+// in the specified enterprise. Returns false and writes an error if not.
+func (s *apiServer) requireEnterpriseAdmin(w http.ResponseWriter, r *http.Request, enterpriseID string) bool {
+	if s.users == nil {
+		return true // auth disabled (dev mode)
+	}
+
+	userID, callerEnterpriseID, _ := s.requireAuth(w, r)
+
+	// Check enterprise membership.
+	if callerEnterpriseID != enterpriseID {
+		writeError(w, http.StatusForbidden, "forbidden", "not a member of this enterprise")
+		return false
+	}
+
+	user, err := s.users.Get(r.Context(), userID)
+	if err != nil {
+		writeError(w, http.StatusForbidden, "forbidden", "user not found")
+		return false
+	}
+
+	if user.Role != model.UserRoleOwner && user.Role != model.UserRoleAdmin {
+		writeError(w, http.StatusForbidden, "forbidden", "admin or owner role required")
+		return false
+	}
+
+	return true
+}
+
+// llmConfigResponse builds the API response for an LLM config.
+// Never includes the actual API key — just whether one is configured.
+func llmConfigResponse(cfg model.LLMConfig, apiKeyConfigured bool) map[string]any {
+	return map[string]any{
+		"id":                 cfg.ID,
+		"owner_type":         cfg.OwnerType,
+		"owner_id":           cfg.OwnerID,
+		"provider":           cfg.Provider,
+		"model_research":     cfg.ModelResearch,
+		"model_synthesis":    cfg.ModelSynthesis,
+		"api_key_configured": apiKeyConfigured,
+		"created_at":         cfg.CreatedAt,
+		"updated_at":         cfg.UpdatedAt,
+	}
+}
+
+// extractEnterpriseLLMConfigID extracts the enterprise ID from paths like
+// /v1/enterprises/{id}/llm-config
+func extractEnterpriseLLMConfigID(path string) string {
+	const prefix = "/v1/enterprises/"
+	const suffix = "/llm-config"
+	if !strings.HasPrefix(path, prefix) || !strings.HasSuffix(path, suffix) {
+		return ""
+	}
+	id := path[len(prefix) : len(path)-len(suffix)]
+	if id == "" || strings.Contains(id, "/") {
+		return ""
+	}
+	return id
+}

--- a/core/app/handlers_llm_config_test.go
+++ b/core/app/handlers_llm_config_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"fmt"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -11,9 +12,51 @@ import (
 	"github.com/ALRubinger/aileron/core/auth"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/store/mem"
 	"github.com/ALRubinger/aileron/core/vault"
 )
+
+// --- Mocks for error path testing ---
+
+// failingVault returns errors on Put.
+type failingVault struct {
+	vault.Vault
+}
+
+func (f *failingVault) Get(_ context.Context, _ string) (vault.Secret, error) {
+	return vault.Secret{}, fmt.Errorf("vault unavailable")
+}
+func (f *failingVault) Put(_ context.Context, _ string, _ []byte, _ vault.Metadata) error {
+	return fmt.Errorf("vault write failed")
+}
+func (f *failingVault) Delete(_ context.Context, _ string) error { return nil }
+
+// failingLLMConfigStore returns errors on Upsert and GetByOwner.
+type failingLLMConfigStore struct{}
+
+func (f *failingLLMConfigStore) Upsert(_ context.Context, _ model.LLMConfig) (model.LLMConfig, error) {
+	return model.LLMConfig{}, fmt.Errorf("store write failed")
+}
+func (f *failingLLMConfigStore) GetByOwner(_ context.Context, _ model.LLMConfigOwnerType, _ string) (model.LLMConfig, error) {
+	return model.LLMConfig{}, fmt.Errorf("store read failed")
+}
+func (f *failingLLMConfigStore) Delete(_ context.Context, _ string) error {
+	return fmt.Errorf("store delete failed")
+}
+
+// storeWithConfig returns a fixed config from GetByOwner but fails on Delete.
+type storeWithConfig struct {
+	store.LLMConfigStore
+	cfg model.LLMConfig
+}
+
+func (s *storeWithConfig) GetByOwner(_ context.Context, _ model.LLMConfigOwnerType, _ string) (model.LLMConfig, error) {
+	return s.cfg, nil
+}
+func (s *storeWithConfig) Delete(_ context.Context, _ string) error {
+	return fmt.Errorf("delete failed")
+}
 
 func newTestLLMConfigServer() *apiServer {
 	return &apiServer{
@@ -463,6 +506,243 @@ func TestHandleUpsertUserLLMConfig_InvalidJSON(t *testing.T) {
 	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString("not json"))
 	w := httptest.NewRecorder()
 	s.handleUpsertUserLLMConfig(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+// --- Error path tests using mocks ---
+
+func TestHandleUpsertUserLLMConfig_VaultPutError(t *testing.T) {
+	s := &apiServer{
+		llmConfigs: mem.NewLLMConfigStore(),
+		vault:      &failingVault{},
+		users:      nil,
+		newID:      func() string { return "test-id" },
+	}
+
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-test"}`
+	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	s.handleUpsertUserLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpsertUserLLMConfig_StoreUpsertError(t *testing.T) {
+	s := &apiServer{
+		llmConfigs: &failingLLMConfigStore{},
+		vault:      vault.NewMemVault(),
+		users:      nil,
+		newID:      func() string { return "test-id" },
+	}
+
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-test"}`
+	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	s.handleUpsertUserLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleGetUserLLMConfig_StoreError(t *testing.T) {
+	s := &apiServer{
+		llmConfigs: &failingLLMConfigStore{},
+		vault:      vault.NewMemVault(),
+		users:      nil,
+		newID:      func() string { return "test-id" },
+	}
+
+	req := httptest.NewRequest("GET", "/v1/llm-config", nil)
+	w := httptest.NewRecorder()
+	s.handleGetUserLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleDeleteUserLLMConfig_StoreGetError(t *testing.T) {
+	s := &apiServer{
+		llmConfigs: &failingLLMConfigStore{},
+		vault:      vault.NewMemVault(),
+		users:      nil,
+		newID:      func() string { return "test-id" },
+	}
+
+	req := httptest.NewRequest("DELETE", "/v1/llm-config", nil)
+	w := httptest.NewRecorder()
+	s.handleDeleteUserLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleDeleteUserLLMConfig_StoreDeleteError(t *testing.T) {
+	s := &apiServer{
+		llmConfigs: &storeWithConfig{cfg: model.LLMConfig{ID: "llm_1", OwnerType: model.LLMConfigOwnerUser, OwnerID: ""}},
+		vault:      vault.NewMemVault(),
+		users:      nil,
+		newID:      func() string { return "test-id" },
+	}
+
+	req := httptest.NewRequest("DELETE", "/v1/llm-config", nil)
+	w := httptest.NewRecorder()
+	s.handleDeleteUserLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpsertEnterpriseLLMConfig_VaultPutError(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+	s.vault = &failingVault{}
+
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-org"}`
+	req := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)))
+	w := httptest.NewRecorder()
+	s.handleUpsertEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpsertEnterpriseLLMConfig_StoreError(t *testing.T) {
+	users := mem.NewUserStore()
+	users.Create(context.Background(), model.User{
+		ID: "usr_admin", EnterpriseID: "ent_1", Email: "a@x.com", Role: model.UserRoleAdmin,
+	})
+	s := &apiServer{
+		llmConfigs: &failingLLMConfigStore{},
+		vault:      vault.NewMemVault(),
+		users:      users,
+		newID:      func() string { return "test-id" },
+	}
+
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-org"}`
+	req := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)))
+	w := httptest.NewRecorder()
+	s.handleUpsertEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleGetEnterpriseLLMConfig_StoreError(t *testing.T) {
+	users := mem.NewUserStore()
+	users.Create(context.Background(), model.User{
+		ID: "usr_admin", EnterpriseID: "ent_1", Email: "a@x.com", Role: model.UserRoleAdmin,
+	})
+	s := &apiServer{
+		llmConfigs: &failingLLMConfigStore{},
+		vault:      vault.NewMemVault(),
+		users:      users,
+		newID:      func() string { return "test-id" },
+	}
+
+	req := withAdminAuth(httptest.NewRequest("GET", "/v1/enterprises/ent_1/llm-config", nil))
+	w := httptest.NewRecorder()
+	s.handleGetEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleDeleteEnterpriseLLMConfig_StoreGetError(t *testing.T) {
+	users := mem.NewUserStore()
+	users.Create(context.Background(), model.User{
+		ID: "usr_admin", EnterpriseID: "ent_1", Email: "a@x.com", Role: model.UserRoleAdmin,
+	})
+	s := &apiServer{
+		llmConfigs: &failingLLMConfigStore{},
+		vault:      vault.NewMemVault(),
+		users:      users,
+		newID:      func() string { return "test-id" },
+	}
+
+	req := withAdminAuth(httptest.NewRequest("DELETE", "/v1/enterprises/ent_1/llm-config", nil))
+	w := httptest.NewRecorder()
+	s.handleDeleteEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleDeleteEnterpriseLLMConfig_StoreDeleteError(t *testing.T) {
+	users := mem.NewUserStore()
+	users.Create(context.Background(), model.User{
+		ID: "usr_admin", EnterpriseID: "ent_1", Email: "a@x.com", Role: model.UserRoleAdmin,
+	})
+	s := &apiServer{
+		llmConfigs: &storeWithConfig{cfg: model.LLMConfig{ID: "llm_1", OwnerType: model.LLMConfigOwnerEnterprise, OwnerID: "ent_1"}},
+		vault:      vault.NewMemVault(),
+		users:      users,
+		newID:      func() string { return "test-id" },
+	}
+
+	req := withAdminAuth(httptest.NewRequest("DELETE", "/v1/enterprises/ent_1/llm-config", nil))
+	w := httptest.NewRecorder()
+	s.handleDeleteEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpsertEnterpriseLLMConfig_InvalidJSON(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	req := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString("bad")))
+	w := httptest.NewRecorder()
+	s.handleUpsertEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleUpsertEnterpriseLLMConfig_MissingAPIKey(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	body := `{"provider":"anthropic","model_research":"haiku"}`
+	req := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)))
+	w := httptest.NewRecorder()
+	s.handleUpsertEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleGetEnterpriseLLMConfig_BadPath(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	req := withAdminAuth(httptest.NewRequest("GET", "/v1/enterprises//llm-config", nil))
+	w := httptest.NewRecorder()
+	s.handleGetEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleDeleteEnterpriseLLMConfig_BadPath(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	req := withAdminAuth(httptest.NewRequest("DELETE", "/v1/enterprises//llm-config", nil))
+	w := httptest.NewRecorder()
+	s.handleDeleteEnterpriseLLMConfig(w, req)
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", w.Code)

--- a/core/app/handlers_llm_config_test.go
+++ b/core/app/handlers_llm_config_test.go
@@ -1,0 +1,237 @@
+package app
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store/mem"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+func newTestLLMConfigServer() *apiServer {
+	return &apiServer{
+		llmConfigs: mem.NewLLMConfigStore(),
+		vault:      vault.NewMemVault(),
+		users:      nil, // nil = auth disabled (dev mode), requireAuth allows all
+		newID:      func() string { return "test-id" },
+	}
+}
+
+func TestHandleUpsertUserLLMConfig(t *testing.T) {
+	s := newTestLLMConfigServer()
+
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-test"}`
+	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+
+	s.handleUpsertUserLLMConfig(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["provider"] != "anthropic" {
+		t.Errorf("expected anthropic, got %v", resp["provider"])
+	}
+	if resp["api_key_configured"] != true {
+		t.Error("expected api_key_configured=true")
+	}
+	// API key must NOT be in response.
+	if _, ok := resp["api_key"]; ok {
+		t.Error("api_key should not be in response")
+	}
+}
+
+func TestHandleUpsertUserLLMConfig_MissingProvider(t *testing.T) {
+	s := newTestLLMConfigServer()
+
+	body := `{"api_key":"sk-test"}`
+	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+
+	s.handleUpsertUserLLMConfig(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleUpsertUserLLMConfig_MissingAPIKey(t *testing.T) {
+	s := newTestLLMConfigServer()
+
+	body := `{"provider":"anthropic"}`
+	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+
+	s.handleUpsertUserLLMConfig(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleGetUserLLMConfig(t *testing.T) {
+	s := newTestLLMConfigServer()
+
+	// First create a config.
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-test"}`
+	createReq := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
+	createW := httptest.NewRecorder()
+	s.handleUpsertUserLLMConfig(createW, createReq)
+
+	// Then get it.
+	req := httptest.NewRequest("GET", "/v1/llm-config", nil)
+	w := httptest.NewRecorder()
+	s.handleGetUserLLMConfig(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["provider"] != "anthropic" {
+		t.Errorf("expected anthropic, got %v", resp["provider"])
+	}
+}
+
+func TestHandleGetUserLLMConfig_NotFound(t *testing.T) {
+	s := newTestLLMConfigServer()
+
+	req := httptest.NewRequest("GET", "/v1/llm-config", nil)
+	w := httptest.NewRecorder()
+	s.handleGetUserLLMConfig(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleDeleteUserLLMConfig(t *testing.T) {
+	s := newTestLLMConfigServer()
+
+	// Create a config.
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-test"}`
+	createReq := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
+	createW := httptest.NewRecorder()
+	s.handleUpsertUserLLMConfig(createW, createReq)
+
+	// Delete it.
+	req := httptest.NewRequest("DELETE", "/v1/llm-config", nil)
+	w := httptest.NewRecorder()
+	s.handleDeleteUserLLMConfig(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify it's gone.
+	getReq := httptest.NewRequest("GET", "/v1/llm-config", nil)
+	getW := httptest.NewRecorder()
+	s.handleGetUserLLMConfig(getW, getReq)
+
+	if getW.Code != http.StatusNotFound {
+		t.Fatalf("expected 404 after delete, got %d", getW.Code)
+	}
+}
+
+func TestHandleDeleteUserLLMConfig_NotFound(t *testing.T) {
+	s := newTestLLMConfigServer()
+
+	req := httptest.NewRequest("DELETE", "/v1/llm-config", nil)
+	w := httptest.NewRecorder()
+	s.handleDeleteUserLLMConfig(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleUpsertUserLLMConfig_Upsert(t *testing.T) {
+	s := newTestLLMConfigServer()
+
+	// Create initial config.
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-first"}`
+	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	s.handleUpsertUserLLMConfig(w, req)
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Update with different model.
+	body2 := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"opus","api_key":"sk-second"}`
+	req2 := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body2))
+	w2 := httptest.NewRecorder()
+	s.handleUpsertUserLLMConfig(w2, req2)
+	if w2.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w2.Code)
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w2.Body.Bytes(), &resp)
+	if resp["model_synthesis"] != "opus" {
+		t.Errorf("expected opus, got %v", resp["model_synthesis"])
+	}
+}
+
+func TestExtractEnterpriseLLMConfigID(t *testing.T) {
+	tests := []struct {
+		path string
+		want string
+	}{
+		{"/v1/enterprises/ent_123/llm-config", "ent_123"},
+		{"/v1/enterprises//llm-config", ""},
+		{"/v1/enterprises/ent_123", ""},
+		{"/v1/llm-config", ""},
+		{"/v1/enterprises/ent_123/nested/llm-config", ""},
+	}
+
+	for _, tt := range tests {
+		got := extractEnterpriseLLMConfigID(tt.path)
+		if got != tt.want {
+			t.Errorf("extractEnterpriseLLMConfigID(%q) = %q, want %q", tt.path, got, tt.want)
+		}
+	}
+}
+
+func TestRequireEnterpriseAdmin_DevMode(t *testing.T) {
+	s := &apiServer{
+		users: nil, // auth disabled
+	}
+
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	if !s.requireEnterpriseAdmin(w, req, "ent_1") {
+		t.Error("expected true in dev mode (no users store)")
+	}
+}
+
+func TestRequireEnterpriseAdmin_NonMember(t *testing.T) {
+	users := mem.NewUserStore()
+	users.Create(nil, model.User{
+		ID:           "usr_1",
+		EnterpriseID: "ent_other",
+		Email:        "test@example.com",
+		Role:         model.UserRoleAdmin,
+	})
+
+	s := &apiServer{users: users}
+
+	// requireAuth returns empty enterpriseID in test (no auth context).
+	req := httptest.NewRequest("GET", "/", nil)
+	w := httptest.NewRecorder()
+
+	// Calling with a different enterprise should fail because callerEnterpriseID
+	// (empty in test) doesn't match "ent_1".
+	if s.requireEnterpriseAdmin(w, req, "ent_1") {
+		t.Error("expected false for non-member")
+	}
+}

--- a/core/app/handlers_llm_config_test.go
+++ b/core/app/handlers_llm_config_test.go
@@ -2,11 +2,14 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
 	"testing"
 
+	"github.com/ALRubinger/aileron/core/auth"
+	"github.com/golang-jwt/jwt/v5"
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/store/mem"
 	"github.com/ALRubinger/aileron/core/vault"
@@ -216,7 +219,7 @@ func TestRequireEnterpriseAdmin_DevMode(t *testing.T) {
 
 func TestRequireEnterpriseAdmin_NonMember(t *testing.T) {
 	users := mem.NewUserStore()
-	users.Create(nil, model.User{
+	users.Create(context.Background(), model.User{
 		ID:           "usr_1",
 		EnterpriseID: "ent_other",
 		Email:        "test@example.com",
@@ -225,13 +228,243 @@ func TestRequireEnterpriseAdmin_NonMember(t *testing.T) {
 
 	s := &apiServer{users: users}
 
-	// requireAuth returns empty enterpriseID in test (no auth context).
-	req := httptest.NewRequest("GET", "/", nil)
+	// Auth context with a different enterprise.
+	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "usr_1"},
+		EnterpriseID:     "ent_other",
+	})
+	req := httptest.NewRequest("GET", "/", nil).WithContext(ctx)
 	w := httptest.NewRecorder()
 
-	// Calling with a different enterprise should fail because callerEnterpriseID
-	// (empty in test) doesn't match "ent_1".
 	if s.requireEnterpriseAdmin(w, req, "ent_1") {
 		t.Error("expected false for non-member")
+	}
+}
+
+func TestRequireEnterpriseAdmin_MemberNotAdmin(t *testing.T) {
+	users := mem.NewUserStore()
+	users.Create(context.Background(), model.User{
+		ID:           "usr_1",
+		EnterpriseID: "ent_1",
+		Email:        "test@example.com",
+		Role:         model.UserRoleMember,
+	})
+
+	s := &apiServer{users: users}
+
+	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "usr_1"},
+		EnterpriseID:     "ent_1",
+	})
+	req := httptest.NewRequest("GET", "/", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	if s.requireEnterpriseAdmin(w, req, "ent_1") {
+		t.Error("expected false for non-admin member")
+	}
+	if w.Code != http.StatusForbidden {
+		t.Errorf("expected 403, got %d", w.Code)
+	}
+}
+
+func TestRequireEnterpriseAdmin_Admin(t *testing.T) {
+	users := mem.NewUserStore()
+	users.Create(context.Background(), model.User{
+		ID:           "usr_1",
+		EnterpriseID: "ent_1",
+		Email:        "test@example.com",
+		Role:         model.UserRoleAdmin,
+	})
+
+	s := &apiServer{users: users}
+
+	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "usr_1"},
+		EnterpriseID:     "ent_1",
+	})
+	req := httptest.NewRequest("GET", "/", nil).WithContext(ctx)
+	w := httptest.NewRecorder()
+
+	if !s.requireEnterpriseAdmin(w, req, "ent_1") {
+		t.Error("expected true for admin")
+	}
+}
+
+// --- Enterprise handler tests (with auth context) ---
+
+func newTestEnterpriseLLMConfigServer() *apiServer {
+	users := mem.NewUserStore()
+	users.Create(context.Background(), model.User{
+		ID:           "usr_admin",
+		EnterpriseID: "ent_1",
+		Email:        "admin@example.com",
+		Role:         model.UserRoleAdmin,
+	})
+	return &apiServer{
+		llmConfigs: mem.NewLLMConfigStore(),
+		vault:      vault.NewMemVault(),
+		users:      users,
+		newID:      func() string { return "test-id" },
+	}
+}
+
+func withAdminAuth(req *http.Request) *http.Request {
+	ctx := auth.ContextWithClaims(req.Context(), &auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "usr_admin"},
+		EnterpriseID:     "ent_1",
+	})
+	return req.WithContext(ctx)
+}
+
+func TestHandleUpsertEnterpriseLLMConfig(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-org"}`
+	req := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)))
+	w := httptest.NewRecorder()
+
+	s.handleUpsertEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	if resp["owner_type"] != "enterprise" {
+		t.Errorf("expected enterprise, got %v", resp["owner_type"])
+	}
+	if resp["api_key_configured"] != true {
+		t.Error("expected api_key_configured=true")
+	}
+}
+
+func TestHandleUpsertEnterpriseLLMConfig_MissingProvider(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	body := `{"api_key":"sk-org"}`
+	req := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)))
+	w := httptest.NewRecorder()
+
+	s.handleUpsertEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleGetEnterpriseLLMConfig(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	// Create first.
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-org"}`
+	createReq := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)))
+	createW := httptest.NewRecorder()
+	s.handleUpsertEnterpriseLLMConfig(createW, createReq)
+
+	// Get.
+	req := withAdminAuth(httptest.NewRequest("GET", "/v1/enterprises/ent_1/llm-config", nil))
+	w := httptest.NewRecorder()
+	s.handleGetEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleGetEnterpriseLLMConfig_NotFound(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	req := withAdminAuth(httptest.NewRequest("GET", "/v1/enterprises/ent_1/llm-config", nil))
+	w := httptest.NewRecorder()
+	s.handleGetEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleDeleteEnterpriseLLMConfig(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	// Create.
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-org"}`
+	createReq := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)))
+	createW := httptest.NewRecorder()
+	s.handleUpsertEnterpriseLLMConfig(createW, createReq)
+
+	// Delete.
+	req := withAdminAuth(httptest.NewRequest("DELETE", "/v1/enterprises/ent_1/llm-config", nil))
+	w := httptest.NewRecorder()
+	s.handleDeleteEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusNoContent {
+		t.Fatalf("expected 204, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleDeleteEnterpriseLLMConfig_NotFound(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	req := withAdminAuth(httptest.NewRequest("DELETE", "/v1/enterprises/ent_1/llm-config", nil))
+	w := httptest.NewRecorder()
+	s.handleDeleteEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusNotFound {
+		t.Fatalf("expected 404, got %d", w.Code)
+	}
+}
+
+func TestHandleUpsertEnterpriseLLMConfig_Forbidden(t *testing.T) {
+	users := mem.NewUserStore()
+	users.Create(context.Background(), model.User{
+		ID:           "usr_member",
+		EnterpriseID: "ent_1",
+		Email:        "member@example.com",
+		Role:         model.UserRoleMember,
+	})
+	s := &apiServer{
+		llmConfigs: mem.NewLLMConfigStore(),
+		vault:      vault.NewMemVault(),
+		users:      users,
+		newID:      func() string { return "test-id" },
+	}
+
+	body := `{"provider":"anthropic","api_key":"sk-org"}`
+	ctx := auth.ContextWithClaims(context.Background(), &auth.Claims{
+		RegisteredClaims: jwt.RegisteredClaims{Subject: "usr_member"},
+		EnterpriseID:     "ent_1",
+	})
+	req := httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)).WithContext(ctx)
+	w := httptest.NewRecorder()
+	s.handleUpsertEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestHandleUpsertEnterpriseLLMConfig_BadPath(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+
+	body := `{"provider":"anthropic","api_key":"sk-org"}`
+	req := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises//llm-config", bytes.NewBufferString(body)))
+	w := httptest.NewRecorder()
+	s.handleUpsertEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleUpsertUserLLMConfig_InvalidJSON(t *testing.T) {
+	s := newTestLLMConfigServer()
+
+	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString("not json"))
+	w := httptest.NewRecorder()
+	s.handleUpsertUserLLMConfig(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }

--- a/core/app/pipeline.go
+++ b/core/app/pipeline.go
@@ -1,0 +1,47 @@
+package app
+
+import (
+	"log/slog"
+
+	"github.com/ALRubinger/aileron/core/draft"
+	"github.com/ALRubinger/aileron/core/llm"
+	"github.com/ALRubinger/aileron/core/source"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+// draftPipelineDeps groups dependencies for building a draft pipeline with
+// per-user/per-org LLM resolution. Extracted for testability.
+type draftPipelineDeps struct {
+	apiKey         string
+	modelResearch  string
+	modelSynthesis string
+	llmConfigs     store.LLMConfigStore
+	users          store.UserStore
+	accounts       store.ConnectedAccountStore
+	instructions   store.UserInstructionStore
+	vault          vault.Vault
+	sourceReg      *source.Registry
+	log            *slog.Logger
+	prompts        draft.Prompts
+}
+
+// buildDraftPipeline constructs a draft.Pipeline with a ClientResolver that
+// supports per-user and per-org LLM provider selection, falling back to the
+// server-default API key and models.
+func buildDraftPipeline(deps draftPipelineDeps) *draft.Pipeline {
+	researchClient := llm.NewAnthropicClient(deps.apiKey, deps.modelResearch, llm.WithLogger(deps.log))
+	synthesisClient := llm.NewAnthropicClient(deps.apiKey, deps.modelSynthesis, llm.WithLogger(deps.log))
+
+	resolver := llm.NewClientResolver(
+		deps.llmConfigs, deps.users, deps.vault,
+		deps.apiKey, deps.modelResearch, deps.modelSynthesis,
+		deps.log,
+	)
+
+	return draft.NewPipeline(
+		researchClient, synthesisClient, deps.sourceReg,
+		deps.accounts, deps.instructions, deps.vault,
+		deps.log, deps.prompts,
+	).WithClientResolver(resolver)
+}

--- a/core/app/pipeline_test.go
+++ b/core/app/pipeline_test.go
@@ -1,0 +1,53 @@
+package app
+
+import (
+	"log/slog"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/draft"
+	"github.com/ALRubinger/aileron/core/source"
+	"github.com/ALRubinger/aileron/core/store/mem"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+func TestBuildDraftPipeline(t *testing.T) {
+	deps := draftPipelineDeps{
+		apiKey:         "sk-test-key",
+		modelResearch:  "claude-haiku-4-5-20251001",
+		modelSynthesis: "claude-sonnet-4-6",
+		llmConfigs:     mem.NewLLMConfigStore(),
+		users:          mem.NewUserStore(),
+		accounts:       mem.NewConnectedAccountStore(),
+		instructions:   mem.NewUserInstructionStore(),
+		vault:          vault.NewMemVault(),
+		sourceReg:      source.NewRegistry(),
+		log:            slog.Default(),
+		prompts:        draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"},
+	}
+
+	pipeline := buildDraftPipeline(deps)
+	if pipeline == nil {
+		t.Fatal("expected non-nil pipeline")
+	}
+}
+
+func TestBuildDraftPipeline_NilUsers(t *testing.T) {
+	deps := draftPipelineDeps{
+		apiKey:         "sk-test-key",
+		modelResearch:  "haiku",
+		modelSynthesis: "sonnet",
+		llmConfigs:     mem.NewLLMConfigStore(),
+		users:          nil,
+		accounts:       mem.NewConnectedAccountStore(),
+		instructions:   mem.NewUserInstructionStore(),
+		vault:          vault.NewMemVault(),
+		sourceReg:      source.NewRegistry(),
+		log:            slog.Default(),
+		prompts:        draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	}
+
+	pipeline := buildDraftPipeline(deps)
+	if pipeline == nil {
+		t.Fatal("expected non-nil pipeline even with nil users store")
+	}
+}

--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -32,6 +32,7 @@ import (
 type Pipeline struct {
 	researchLLM       llm.Client
 	ghostwriteLLM     llm.Client
+	clientResolver    *llm.ClientResolver // optional; overrides researchLLM/ghostwriteLLM per-user
 	sourceRegistry    *source.Registry
 	connectedAccounts store.ConnectedAccountStore
 	instructions      store.UserInstructionStore
@@ -69,6 +70,15 @@ func NewPipeline(
 	}
 }
 
+// WithClientResolver returns a copy of the pipeline that resolves per-user
+// LLM clients at draft generation time. When set, the resolver's result
+// overrides the default researchLLM and ghostwriteLLM clients.
+func (p *Pipeline) WithClientResolver(r *llm.ClientResolver) *Pipeline {
+	cp := *p
+	cp.clientResolver = r
+	return &cp
+}
+
 // WithClock returns a copy of the pipeline that uses the given clock function
 // instead of time.Now. For testing only.
 func (p *Pipeline) WithClock(clock func() time.Time) *Pipeline {
@@ -82,6 +92,16 @@ func (p *Pipeline) WithClock(clock func() time.Time) *Pipeline {
 //   Round 2: Ghostwrite — LLM writes the reply using the gathered context.
 //     No tools, no narration.
 func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.IncomingMessage) (string, error) {
+	// Resolve LLM clients: per-user/per-org config overrides defaults.
+	researchClient, synthesisClient := p.researchLLM, p.ghostwriteLLM
+	if p.clientResolver != nil {
+		var resolveErr error
+		researchClient, synthesisClient, resolveErr = p.clientResolver.Resolve(ctx, userID)
+		if resolveErr != nil {
+			return "", fmt.Errorf("resolving LLM config: %w", resolveErr)
+		}
+	}
+
 	// Get available tools.
 	accounts, err := p.connectedAccounts.List(ctx, store.ConnectedAccountFilter{UserID: userID})
 	if err != nil {
@@ -122,7 +142,7 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 	now := p.clock()
 	var gatheredContext string
 	if len(tools) > 0 {
-		researchResp, err := p.researchLLM.GenerateWithTools(ctx, llm.GenerateRequest{
+		researchResp, err := researchClient.GenerateWithTools(ctx, llm.GenerateRequest{
 			SystemPrompt: researchSysPrompt,
 			UserMessage:  researchMessage,
 			Tools:        tools,
@@ -163,7 +183,7 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 		msg.Author, msg.Channel, msg.Body, gatheredContext,
 	)
 
-	draftResp, err := p.ghostwriteLLM.GenerateWithTools(ctx, llm.GenerateRequest{
+	draftResp, err := synthesisClient.GenerateWithTools(ctx, llm.GenerateRequest{
 		SystemPrompt: ghostwritePrompt,
 		UserMessage:  ghostwriteMessage,
 		// No tools — force text-only output.

--- a/core/llm/resolver.go
+++ b/core/llm/resolver.go
@@ -1,0 +1,125 @@
+package llm
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"log/slog"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+// ClientResolver resolves which LLM Client to use for a given user.
+// Resolution order: per-user config → per-org config → server default.
+type ClientResolver struct {
+	configs          store.LLMConfigStore
+	users            store.UserStore
+	vault            vault.Vault
+	defaultAPIKey    string
+	defaultResearch  string
+	defaultSynthesis string
+	log              *slog.Logger
+}
+
+// NewClientResolver creates a resolver that looks up per-user/per-org LLM
+// configurations and falls back to server defaults when none are found.
+func NewClientResolver(
+	configs store.LLMConfigStore,
+	users store.UserStore,
+	v vault.Vault,
+	defaultAPIKey, defaultResearch, defaultSynthesis string,
+	log *slog.Logger,
+) *ClientResolver {
+	return &ClientResolver{
+		configs:          configs,
+		users:            users,
+		vault:            v,
+		defaultAPIKey:    defaultAPIKey,
+		defaultResearch:  defaultResearch,
+		defaultSynthesis: defaultSynthesis,
+		log:              log,
+	}
+}
+
+// Resolve returns research and synthesis LLM clients for the given user.
+// It checks for a per-user config first, then per-org, then falls back
+// to server defaults.
+func (r *ClientResolver) Resolve(ctx context.Context, userID string) (research, synthesis Client, err error) {
+	// 1. Try per-user config.
+	cfg, err := r.configs.GetByOwner(ctx, model.LLMConfigOwnerUser, userID)
+	if err == nil {
+		research, synthesis, err = r.buildClients(ctx, cfg)
+		if err == nil {
+			r.log.Debug("using per-user LLM config", "user_id", userID, "provider", cfg.Provider)
+			return research, synthesis, nil
+		}
+		r.log.Warn("per-user LLM config failed, falling through", "user_id", userID, "error", err)
+	} else if !isNotFound(err) {
+		return nil, nil, fmt.Errorf("checking user LLM config: %w", err)
+	}
+
+	// 2. Try per-org config.
+	if r.users != nil {
+		user, userErr := r.users.Get(ctx, userID)
+		if userErr == nil && user.EnterpriseID != "" {
+			cfg, err = r.configs.GetByOwner(ctx, model.LLMConfigOwnerEnterprise, user.EnterpriseID)
+			if err == nil {
+				research, synthesis, err = r.buildClients(ctx, cfg)
+				if err == nil {
+					r.log.Debug("using per-org LLM config",
+						"user_id", userID, "enterprise_id", user.EnterpriseID, "provider", cfg.Provider)
+					return research, synthesis, nil
+				}
+				r.log.Warn("per-org LLM config failed, falling through",
+					"user_id", userID, "enterprise_id", user.EnterpriseID, "error", err)
+			} else if !isNotFound(err) {
+				return nil, nil, fmt.Errorf("checking org LLM config: %w", err)
+			}
+		}
+	}
+
+	// 3. Server defaults.
+	r.log.Debug("using server default LLM config", "user_id", userID)
+	return r.defaultClients()
+}
+
+// buildClients constructs LLM clients from an LLMConfig, loading the API key from vault.
+func (r *ClientResolver) buildClients(ctx context.Context, cfg model.LLMConfig) (Client, Client, error) {
+	secret, err := r.vault.Get(ctx, cfg.VaultPath())
+	if err != nil {
+		return nil, nil, fmt.Errorf("retrieving API key from vault: %w", err)
+	}
+	apiKey := string(secret.Value)
+	if apiKey == "" {
+		return nil, nil, fmt.Errorf("empty API key at vault path %s", cfg.VaultPath())
+	}
+
+	return r.newClients(cfg.Provider, apiKey, cfg.ModelResearch, cfg.ModelSynthesis)
+}
+
+// defaultClients constructs LLM clients from server-default configuration.
+func (r *ClientResolver) defaultClients() (Client, Client, error) {
+	if r.defaultAPIKey == "" {
+		return nil, nil, fmt.Errorf("no default LLM API key configured")
+	}
+	return r.newClients(model.LLMProviderAnthropic, r.defaultAPIKey, r.defaultResearch, r.defaultSynthesis)
+}
+
+// newClients constructs a pair of LLM clients for the given provider.
+func (r *ClientResolver) newClients(provider model.LLMProvider, apiKey, researchModel, synthesisModel string) (Client, Client, error) {
+	switch provider {
+	case model.LLMProviderAnthropic:
+		research := NewAnthropicClient(apiKey, researchModel, WithLogger(r.log))
+		synthesis := NewAnthropicClient(apiKey, synthesisModel, WithLogger(r.log))
+		return research, synthesis, nil
+	default:
+		return nil, nil, fmt.Errorf("unsupported LLM provider: %s", provider)
+	}
+}
+
+func isNotFound(err error) bool {
+	var nf *store.ErrNotFound
+	return errors.As(err, &nf)
+}

--- a/core/llm/resolver_test.go
+++ b/core/llm/resolver_test.go
@@ -2,6 +2,7 @@ package llm_test
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"strings"
 	"testing"
@@ -9,9 +10,24 @@ import (
 
 	"github.com/ALRubinger/aileron/core/llm"
 	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/store/mem"
 	"github.com/ALRubinger/aileron/core/vault"
 )
+
+// failingConfigStore returns a non-ErrNotFound error from GetByOwner.
+type failingConfigStore struct{}
+
+func (f *failingConfigStore) Upsert(_ context.Context, cfg model.LLMConfig) (model.LLMConfig, error) {
+	return cfg, nil
+}
+func (f *failingConfigStore) GetByOwner(_ context.Context, _ model.LLMConfigOwnerType, _ string) (model.LLMConfig, error) {
+	return model.LLMConfig{}, fmt.Errorf("database connection lost")
+}
+func (f *failingConfigStore) Delete(_ context.Context, _ string) error { return nil }
+
+// Verify interface compliance.
+var _ store.LLMConfigStore = (*failingConfigStore)(nil)
 
 func TestClientResolver_ServerDefault(t *testing.T) {
 	configs := mem.NewLLMConfigStore()
@@ -227,5 +243,70 @@ func TestClientResolver_NoDefaultKey(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "no default LLM API key") {
 		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestClientResolver_StoreError_PropagatesFromUserLookup(t *testing.T) {
+	users := mem.NewUserStore()
+	v := vault.NewMemVault()
+
+	resolver := llm.NewClientResolver(&failingConfigStore{}, users, v,
+		"default-key", "haiku", "sonnet", slog.Default())
+
+	_, _, err := resolver.Resolve(context.Background(), "usr_1")
+	if err == nil {
+		t.Fatal("expected error from store failure")
+	}
+	if !strings.Contains(err.Error(), "checking user LLM config") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}
+
+func TestClientResolver_EmptyAPIKeyInVault(t *testing.T) {
+	configs := mem.NewLLMConfigStore()
+	users := mem.NewUserStore()
+	v := vault.NewMemVault()
+
+	now := time.Now()
+	configs.Upsert(context.Background(), model.LLMConfig{
+		ID:             "llm_1",
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        "usr_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelResearch:  "haiku",
+		ModelSynthesis: "sonnet",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	// Store empty key in vault.
+	v.Put(context.Background(), "llm-config/user/usr_1", []byte(""), vault.Metadata{})
+
+	resolver := llm.NewClientResolver(configs, users, v,
+		"default-key", "haiku", "sonnet", slog.Default())
+
+	// Empty key should fall through to server default.
+	research, synthesis, err := resolver.Resolve(context.Background(), "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if research == nil || synthesis == nil {
+		t.Fatal("expected fallback to server default")
+	}
+}
+
+func TestClientResolver_NilUsersStore(t *testing.T) {
+	configs := mem.NewLLMConfigStore()
+	v := vault.NewMemVault()
+
+	// No user config, no users store — should use server default.
+	resolver := llm.NewClientResolver(configs, nil, v,
+		"default-key", "haiku", "sonnet", slog.Default())
+
+	research, synthesis, err := resolver.Resolve(context.Background(), "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if research == nil || synthesis == nil {
+		t.Fatal("expected server default clients")
 	}
 }

--- a/core/llm/resolver_test.go
+++ b/core/llm/resolver_test.go
@@ -1,0 +1,231 @@
+package llm_test
+
+import (
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/llm"
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store/mem"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+func TestClientResolver_ServerDefault(t *testing.T) {
+	configs := mem.NewLLMConfigStore()
+	users := mem.NewUserStore()
+	v := vault.NewMemVault()
+
+	resolver := llm.NewClientResolver(configs, users, v,
+		"default-key", "haiku", "sonnet", slog.Default())
+
+	research, synthesis, err := resolver.Resolve(context.Background(), "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if research == nil || synthesis == nil {
+		t.Fatal("expected non-nil clients")
+	}
+}
+
+func TestClientResolver_PerUser(t *testing.T) {
+	configs := mem.NewLLMConfigStore()
+	users := mem.NewUserStore()
+	v := vault.NewMemVault()
+
+	now := time.Now()
+	configs.Upsert(context.Background(), model.LLMConfig{
+		ID:             "llm_1",
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        "usr_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelResearch:  "user-research",
+		ModelSynthesis: "user-synthesis",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	v.Put(context.Background(), "llm-config/user/usr_1", []byte("user-api-key"), vault.Metadata{})
+
+	resolver := llm.NewClientResolver(configs, users, v,
+		"default-key", "haiku", "sonnet", slog.Default())
+
+	research, synthesis, err := resolver.Resolve(context.Background(), "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if research == nil || synthesis == nil {
+		t.Fatal("expected non-nil clients from user config")
+	}
+}
+
+func TestClientResolver_PerOrg(t *testing.T) {
+	configs := mem.NewLLMConfigStore()
+	users := mem.NewUserStore()
+	v := vault.NewMemVault()
+
+	now := time.Now()
+
+	// Create user with enterprise.
+	users.Create(context.Background(), model.User{
+		ID:           "usr_1",
+		EnterpriseID: "ent_1",
+		Email:        "test@example.com",
+	})
+
+	// Create enterprise config (no user config).
+	configs.Upsert(context.Background(), model.LLMConfig{
+		ID:             "llm_ent",
+		OwnerType:      model.LLMConfigOwnerEnterprise,
+		OwnerID:        "ent_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelResearch:  "org-research",
+		ModelSynthesis: "org-synthesis",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	v.Put(context.Background(), "llm-config/enterprise/ent_1", []byte("org-api-key"), vault.Metadata{})
+
+	resolver := llm.NewClientResolver(configs, users, v,
+		"default-key", "haiku", "sonnet", slog.Default())
+
+	research, synthesis, err := resolver.Resolve(context.Background(), "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if research == nil || synthesis == nil {
+		t.Fatal("expected non-nil clients from org config")
+	}
+}
+
+func TestClientResolver_UserOverridesOrg(t *testing.T) {
+	configs := mem.NewLLMConfigStore()
+	users := mem.NewUserStore()
+	v := vault.NewMemVault()
+
+	now := time.Now()
+
+	users.Create(context.Background(), model.User{
+		ID:           "usr_1",
+		EnterpriseID: "ent_1",
+		Email:        "test@example.com",
+	})
+
+	// Both user and org configs exist.
+	configs.Upsert(context.Background(), model.LLMConfig{
+		ID:             "llm_user",
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        "usr_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelResearch:  "user-research",
+		ModelSynthesis: "user-synthesis",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	configs.Upsert(context.Background(), model.LLMConfig{
+		ID:             "llm_ent",
+		OwnerType:      model.LLMConfigOwnerEnterprise,
+		OwnerID:        "ent_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelResearch:  "org-research",
+		ModelSynthesis: "org-synthesis",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	v.Put(context.Background(), "llm-config/user/usr_1", []byte("user-key"), vault.Metadata{})
+	v.Put(context.Background(), "llm-config/enterprise/ent_1", []byte("org-key"), vault.Metadata{})
+
+	resolver := llm.NewClientResolver(configs, users, v,
+		"default-key", "haiku", "sonnet", slog.Default())
+
+	// Should resolve to user config (user overrides org).
+	research, synthesis, err := resolver.Resolve(context.Background(), "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if research == nil || synthesis == nil {
+		t.Fatal("expected non-nil clients")
+	}
+}
+
+func TestClientResolver_VaultFailure_FallsThrough(t *testing.T) {
+	configs := mem.NewLLMConfigStore()
+	users := mem.NewUserStore()
+	v := vault.NewMemVault()
+
+	now := time.Now()
+
+	// User config exists but vault path has no key.
+	configs.Upsert(context.Background(), model.LLMConfig{
+		ID:             "llm_1",
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        "usr_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelResearch:  "user-research",
+		ModelSynthesis: "user-synthesis",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	// Note: no vault.Put — key doesn't exist.
+
+	resolver := llm.NewClientResolver(configs, users, v,
+		"default-key", "haiku", "sonnet", slog.Default())
+
+	// Should fall through to server default.
+	research, synthesis, err := resolver.Resolve(context.Background(), "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if research == nil || synthesis == nil {
+		t.Fatal("expected non-nil clients from server default fallback")
+	}
+}
+
+func TestClientResolver_UnsupportedProvider(t *testing.T) {
+	configs := mem.NewLLMConfigStore()
+	users := mem.NewUserStore()
+	v := vault.NewMemVault()
+
+	now := time.Now()
+	configs.Upsert(context.Background(), model.LLMConfig{
+		ID:             "llm_1",
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        "usr_1",
+		Provider:       model.LLMProviderOpenAI,
+		ModelResearch:  "gpt-4o",
+		ModelSynthesis: "gpt-4o",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+	v.Put(context.Background(), "llm-config/user/usr_1", []byte("openai-key"), vault.Metadata{})
+
+	resolver := llm.NewClientResolver(configs, users, v,
+		"default-key", "haiku", "sonnet", slog.Default())
+
+	// OpenAI is not yet supported — should fall through to default.
+	research, synthesis, err := resolver.Resolve(context.Background(), "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if research == nil || synthesis == nil {
+		t.Fatal("expected fallback to server default for unsupported provider")
+	}
+}
+
+func TestClientResolver_NoDefaultKey(t *testing.T) {
+	configs := mem.NewLLMConfigStore()
+	users := mem.NewUserStore()
+	v := vault.NewMemVault()
+
+	resolver := llm.NewClientResolver(configs, users, v,
+		"", "haiku", "sonnet", slog.Default())
+
+	_, _, err := resolver.Resolve(context.Background(), "usr_1")
+	if err == nil {
+		t.Fatal("expected error when no default API key")
+	}
+	if !strings.Contains(err.Error(), "no default LLM API key") {
+		t.Errorf("unexpected error: %v", err)
+	}
+}

--- a/core/model/llm_config.go
+++ b/core/model/llm_config.go
@@ -1,0 +1,38 @@
+package model
+
+import "time"
+
+// LLMProvider identifies the LLM service provider.
+type LLMProvider string
+
+const (
+	LLMProviderAnthropic LLMProvider = "anthropic"
+	LLMProviderOpenAI    LLMProvider = "openai"
+)
+
+// LLMConfigOwnerType distinguishes user-level from org-level configuration.
+type LLMConfigOwnerType string
+
+const (
+	LLMConfigOwnerUser       LLMConfigOwnerType = "user"
+	LLMConfigOwnerEnterprise LLMConfigOwnerType = "enterprise"
+)
+
+// LLMConfig stores per-user or per-org LLM provider configuration.
+// At most one config exists per owner (unique on owner_type + owner_id).
+// The API key is stored in the vault, not in this model.
+type LLMConfig struct {
+	ID             string             `json:"id"`              // llm_ + UUID
+	OwnerType      LLMConfigOwnerType `json:"owner_type"`      // "user" or "enterprise"
+	OwnerID        string             `json:"owner_id"`        // usr_xxx or enterprise ID
+	Provider       LLMProvider        `json:"provider"`        // "anthropic", "openai"
+	ModelResearch  string             `json:"model_research"`  // model for research round
+	ModelSynthesis string             `json:"model_synthesis"` // model for synthesis round
+	CreatedAt      time.Time          `json:"created_at"`
+	UpdatedAt      time.Time          `json:"updated_at"`
+}
+
+// VaultPath returns the vault key where the LLM API key is stored.
+func (c LLMConfig) VaultPath() string {
+	return "llm-config/" + string(c.OwnerType) + "/" + c.OwnerID
+}

--- a/core/schema/schema.hcl
+++ b/core/schema/schema.hcl
@@ -699,3 +699,56 @@ table "vault_secrets" {
     columns = [column.path]
   }
 }
+
+table "llm_configs" {
+  schema = schema.public
+
+  column "id" {
+    type = varchar(64)
+    null = false
+  }
+  column "owner_type" {
+    type    = varchar(32)
+    null    = false
+    comment = "user or enterprise"
+  }
+  column "owner_id" {
+    type    = varchar(64)
+    null    = false
+    comment = "usr_xxx or enterprise ID"
+  }
+  column "provider" {
+    type    = varchar(32)
+    null    = false
+    comment = "anthropic, openai, etc."
+  }
+  column "model_research" {
+    type    = varchar(128)
+    null    = false
+    default = ""
+  }
+  column "model_synthesis" {
+    type    = varchar(128)
+    null    = false
+    default = ""
+  }
+  column "created_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+  column "updated_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.id]
+  }
+
+  index "idx_llm_configs_owner" {
+    columns = [column.owner_type, column.owner_id]
+    unique  = true
+  }
+}

--- a/core/store/mem/llm_config.go
+++ b/core/store/mem/llm_config.go
@@ -1,0 +1,61 @@
+package mem
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+)
+
+// LLMConfigStore is a thread-safe in-memory implementation of store.LLMConfigStore.
+type LLMConfigStore struct {
+	mu      sync.RWMutex
+	configs map[string]model.LLMConfig
+}
+
+// NewLLMConfigStore returns an empty in-memory LLM config store.
+func NewLLMConfigStore() *LLMConfigStore {
+	return &LLMConfigStore{configs: make(map[string]model.LLMConfig)}
+}
+
+func (s *LLMConfigStore) Upsert(_ context.Context, cfg model.LLMConfig) (model.LLMConfig, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	// Check if a config already exists for this owner.
+	for id, existing := range s.configs {
+		if existing.OwnerType == cfg.OwnerType && existing.OwnerID == cfg.OwnerID {
+			cfg.ID = id
+			cfg.CreatedAt = existing.CreatedAt
+			s.configs[id] = cfg
+			return cfg, nil
+		}
+	}
+
+	s.configs[cfg.ID] = cfg
+	return cfg, nil
+}
+
+func (s *LLMConfigStore) GetByOwner(_ context.Context, ownerType model.LLMConfigOwnerType, ownerID string) (model.LLMConfig, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	for _, cfg := range s.configs {
+		if cfg.OwnerType == ownerType && cfg.OwnerID == ownerID {
+			return cfg, nil
+		}
+	}
+	return model.LLMConfig{}, &store.ErrNotFound{Entity: "llm_config", ID: string(ownerType) + "/" + ownerID}
+}
+
+func (s *LLMConfigStore) Delete(_ context.Context, configID string) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+
+	if _, ok := s.configs[configID]; !ok {
+		return &store.ErrNotFound{Entity: "llm_config", ID: configID}
+	}
+	delete(s.configs, configID)
+	return nil
+}

--- a/core/store/mem/llm_config_test.go
+++ b/core/store/mem/llm_config_test.go
@@ -1,0 +1,176 @@
+package mem_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/store/mem"
+)
+
+func TestLLMConfigStore_Upsert_Create(t *testing.T) {
+	s := mem.NewLLMConfigStore()
+	now := time.Now()
+
+	cfg := model.LLMConfig{
+		ID:             "llm_1",
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        "usr_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelResearch:  "claude-haiku-4-5-20251001",
+		ModelSynthesis: "claude-sonnet-4-6",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+
+	result, err := s.Upsert(context.Background(), cfg)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ID != "llm_1" {
+		t.Errorf("expected ID llm_1, got %s", result.ID)
+	}
+
+	got, err := s.GetByOwner(context.Background(), model.LLMConfigOwnerUser, "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Provider != model.LLMProviderAnthropic {
+		t.Errorf("expected anthropic, got %s", got.Provider)
+	}
+}
+
+func TestLLMConfigStore_Upsert_Update(t *testing.T) {
+	s := mem.NewLLMConfigStore()
+	now := time.Now()
+
+	cfg := model.LLMConfig{
+		ID:             "llm_1",
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        "usr_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelResearch:  "claude-haiku-4-5-20251001",
+		ModelSynthesis: "claude-sonnet-4-6",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	}
+	s.Upsert(context.Background(), cfg)
+
+	// Upsert with new model — should keep original ID and CreatedAt.
+	updated := model.LLMConfig{
+		ID:             "llm_2_ignored",
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        "usr_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelResearch:  "claude-haiku-4-5-20251001",
+		ModelSynthesis: "claude-opus-4-6",
+		CreatedAt:      now.Add(time.Hour),
+		UpdatedAt:      now.Add(time.Hour),
+	}
+	result, err := s.Upsert(context.Background(), updated)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.ID != "llm_1" {
+		t.Errorf("expected original ID llm_1, got %s", result.ID)
+	}
+	if !result.CreatedAt.Equal(now) {
+		t.Errorf("expected original CreatedAt preserved")
+	}
+	if result.ModelSynthesis != "claude-opus-4-6" {
+		t.Errorf("expected updated model, got %s", result.ModelSynthesis)
+	}
+}
+
+func TestLLMConfigStore_GetByOwner_NotFound(t *testing.T) {
+	s := mem.NewLLMConfigStore()
+	_, err := s.GetByOwner(context.Background(), model.LLMConfigOwnerUser, "usr_nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing config")
+	}
+	var notFound *store.ErrNotFound
+	if !errors.As(err, &notFound) {
+		t.Errorf("expected ErrNotFound, got %T", err)
+	}
+}
+
+func TestLLMConfigStore_Delete(t *testing.T) {
+	s := mem.NewLLMConfigStore()
+	now := time.Now()
+	cfg := model.LLMConfig{
+		ID:        "llm_1",
+		OwnerType: model.LLMConfigOwnerUser,
+		OwnerID:   "usr_1",
+		Provider:  model.LLMProviderAnthropic,
+		CreatedAt: now,
+		UpdatedAt: now,
+	}
+	s.Upsert(context.Background(), cfg)
+
+	if err := s.Delete(context.Background(), "llm_1"); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	_, err := s.GetByOwner(context.Background(), model.LLMConfigOwnerUser, "usr_1")
+	if err == nil {
+		t.Fatal("expected ErrNotFound after delete")
+	}
+}
+
+func TestLLMConfigStore_Delete_NotFound(t *testing.T) {
+	s := mem.NewLLMConfigStore()
+	err := s.Delete(context.Background(), "llm_nonexistent")
+	if err == nil {
+		t.Fatal("expected error for missing config")
+	}
+	var notFound *store.ErrNotFound
+	if !errors.As(err, &notFound) {
+		t.Errorf("expected ErrNotFound, got %T", err)
+	}
+}
+
+func TestLLMConfigStore_SeparateOwners(t *testing.T) {
+	s := mem.NewLLMConfigStore()
+	now := time.Now()
+
+	// User config.
+	s.Upsert(context.Background(), model.LLMConfig{
+		ID:             "llm_user",
+		OwnerType:      model.LLMConfigOwnerUser,
+		OwnerID:        "usr_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelSynthesis: "user-model",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+
+	// Enterprise config for different owner.
+	s.Upsert(context.Background(), model.LLMConfig{
+		ID:             "llm_ent",
+		OwnerType:      model.LLMConfigOwnerEnterprise,
+		OwnerID:        "ent_1",
+		Provider:       model.LLMProviderAnthropic,
+		ModelSynthesis: "enterprise-model",
+		CreatedAt:      now,
+		UpdatedAt:      now,
+	})
+
+	userCfg, err := s.GetByOwner(context.Background(), model.LLMConfigOwnerUser, "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if userCfg.ModelSynthesis != "user-model" {
+		t.Errorf("expected user-model, got %s", userCfg.ModelSynthesis)
+	}
+
+	entCfg, err := s.GetByOwner(context.Background(), model.LLMConfigOwnerEnterprise, "ent_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if entCfg.ModelSynthesis != "enterprise-model" {
+		t.Errorf("expected enterprise-model, got %s", entCfg.ModelSynthesis)
+	}
+}

--- a/core/store/mem/user.go
+++ b/core/store/mem/user.go
@@ -1,0 +1,74 @@
+package mem
+
+import (
+	"context"
+	"sync"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+)
+
+// UserStore is a thread-safe in-memory implementation of store.UserStore.
+type UserStore struct {
+	mu    sync.RWMutex
+	users map[string]model.User
+}
+
+// NewUserStore returns an empty in-memory user store.
+func NewUserStore() *UserStore {
+	return &UserStore{users: make(map[string]model.User)}
+}
+
+func (s *UserStore) Create(_ context.Context, user model.User) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.users[user.ID] = user
+	return nil
+}
+
+func (s *UserStore) Get(_ context.Context, userID string) (model.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	u, ok := s.users[userID]
+	if !ok {
+		return model.User{}, &store.ErrNotFound{Entity: "user", ID: userID}
+	}
+	return u, nil
+}
+
+func (s *UserStore) GetByEmail(_ context.Context, email string) (model.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	for _, u := range s.users {
+		if u.Email == email {
+			return u, nil
+		}
+	}
+	return model.User{}, &store.ErrNotFound{Entity: "user", ID: email}
+}
+
+func (s *UserStore) List(_ context.Context, filter store.UserFilter) ([]model.User, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	var result []model.User
+	for _, u := range s.users {
+		if filter.EnterpriseID != "" && u.EnterpriseID != filter.EnterpriseID {
+			continue
+		}
+		if filter.Status != nil && u.Status != *filter.Status {
+			continue
+		}
+		result = append(result, u)
+	}
+	return result, nil
+}
+
+func (s *UserStore) Update(_ context.Context, user model.User) error {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if _, ok := s.users[user.ID]; !ok {
+		return &store.ErrNotFound{Entity: "user", ID: user.ID}
+	}
+	s.users[user.ID] = user
+	return nil
+}

--- a/core/store/mem/user_test.go
+++ b/core/store/mem/user_test.go
@@ -1,0 +1,137 @@
+package mem_test
+
+import (
+	"context"
+	"errors"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/store/mem"
+)
+
+func TestUserStore_CreateAndGet(t *testing.T) {
+	s := mem.NewUserStore()
+	user := model.User{
+		ID:           "usr_1",
+		EnterpriseID: "ent_1",
+		Email:        "test@example.com",
+		DisplayName:  "Test User",
+		Role:         model.UserRoleAdmin,
+		Status:       model.UserStatusActive,
+	}
+
+	if err := s.Create(context.Background(), user); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, err := s.Get(context.Background(), "usr_1")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.Email != "test@example.com" {
+		t.Errorf("expected test@example.com, got %s", got.Email)
+	}
+}
+
+func TestUserStore_Get_NotFound(t *testing.T) {
+	s := mem.NewUserStore()
+	_, err := s.Get(context.Background(), "usr_missing")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("expected ErrNotFound, got %T", err)
+	}
+}
+
+func TestUserStore_GetByEmail(t *testing.T) {
+	s := mem.NewUserStore()
+	s.Create(context.Background(), model.User{
+		ID:    "usr_1",
+		Email: "found@example.com",
+	})
+
+	got, err := s.GetByEmail(context.Background(), "found@example.com")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got.ID != "usr_1" {
+		t.Errorf("expected usr_1, got %s", got.ID)
+	}
+}
+
+func TestUserStore_GetByEmail_NotFound(t *testing.T) {
+	s := mem.NewUserStore()
+	_, err := s.GetByEmail(context.Background(), "missing@example.com")
+	if err == nil {
+		t.Fatal("expected error")
+	}
+}
+
+func TestUserStore_List(t *testing.T) {
+	s := mem.NewUserStore()
+	s.Create(context.Background(), model.User{ID: "usr_1", EnterpriseID: "ent_1", Email: "a@x.com"})
+	s.Create(context.Background(), model.User{ID: "usr_2", EnterpriseID: "ent_2", Email: "b@x.com"})
+
+	// List all.
+	all, err := s.List(context.Background(), store.UserFilter{})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(all) != 2 {
+		t.Fatalf("expected 2, got %d", len(all))
+	}
+
+	// Filter by enterprise.
+	filtered, err := s.List(context.Background(), store.UserFilter{EnterpriseID: "ent_1"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1, got %d", len(filtered))
+	}
+}
+
+func TestUserStore_List_FilterByStatus(t *testing.T) {
+	s := mem.NewUserStore()
+	active := model.UserStatusActive
+	s.Create(context.Background(), model.User{ID: "usr_1", Email: "a@x.com", Status: model.UserStatusActive})
+	s.Create(context.Background(), model.User{ID: "usr_2", Email: "b@x.com", Status: model.UserStatusSuspended})
+
+	filtered, err := s.List(context.Background(), store.UserFilter{Status: &active})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if len(filtered) != 1 {
+		t.Fatalf("expected 1, got %d", len(filtered))
+	}
+}
+
+func TestUserStore_Update(t *testing.T) {
+	s := mem.NewUserStore()
+	s.Create(context.Background(), model.User{ID: "usr_1", Email: "old@x.com"})
+
+	err := s.Update(context.Background(), model.User{ID: "usr_1", Email: "new@x.com"})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	got, _ := s.Get(context.Background(), "usr_1")
+	if got.Email != "new@x.com" {
+		t.Errorf("expected new@x.com, got %s", got.Email)
+	}
+}
+
+func TestUserStore_Update_NotFound(t *testing.T) {
+	s := mem.NewUserStore()
+	err := s.Update(context.Background(), model.User{ID: "usr_missing"})
+	if err == nil {
+		t.Fatal("expected error")
+	}
+	var nf *store.ErrNotFound
+	if !errors.As(err, &nf) {
+		t.Errorf("expected ErrNotFound, got %T", err)
+	}
+}

--- a/core/store/postgres/llm_config.go
+++ b/core/store/postgres/llm_config.go
@@ -1,0 +1,78 @@
+package postgres
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/store"
+	"github.com/jackc/pgx/v5"
+)
+
+// LLMConfigStore is a PostgreSQL implementation of store.LLMConfigStore.
+type LLMConfigStore struct {
+	db *DB
+}
+
+// NewLLMConfigStore returns a PostgreSQL-backed LLM config store.
+func NewLLMConfigStore(db *DB) *LLMConfigStore {
+	return &LLMConfigStore{db: db}
+}
+
+const llmConfigColumns = `id, owner_type, owner_id, provider, model_research, model_synthesis, created_at, updated_at`
+
+func (s *LLMConfigStore) Upsert(ctx context.Context, cfg model.LLMConfig) (model.LLMConfig, error) {
+	err := s.db.Pool.QueryRow(ctx,
+		`INSERT INTO llm_configs (`+llmConfigColumns+`)
+		 VALUES ($1,$2,$3,$4,$5,$6,$7,$8)
+		 ON CONFLICT (owner_type, owner_id) DO UPDATE SET
+			provider = $4, model_research = $5, model_synthesis = $6, updated_at = $8
+		 RETURNING id, created_at`,
+		cfg.ID, string(cfg.OwnerType), cfg.OwnerID, string(cfg.Provider),
+		cfg.ModelResearch, cfg.ModelSynthesis,
+		cfg.CreatedAt, cfg.UpdatedAt,
+	).Scan(&cfg.ID, &cfg.CreatedAt)
+	if err != nil {
+		return model.LLMConfig{}, err
+	}
+	return cfg, nil
+}
+
+func (s *LLMConfigStore) GetByOwner(ctx context.Context, ownerType model.LLMConfigOwnerType, ownerID string) (model.LLMConfig, error) {
+	row := s.db.Pool.QueryRow(ctx,
+		`SELECT `+llmConfigColumns+` FROM llm_configs WHERE owner_type = $1 AND owner_id = $2`,
+		string(ownerType), ownerID,
+	)
+
+	var cfg model.LLMConfig
+	var ownerTypeStr, providerStr string
+	err := row.Scan(
+		&cfg.ID, &ownerTypeStr, &cfg.OwnerID, &providerStr,
+		&cfg.ModelResearch, &cfg.ModelSynthesis,
+		&cfg.CreatedAt, &cfg.UpdatedAt,
+	)
+	if err != nil {
+		if err == pgx.ErrNoRows {
+			return model.LLMConfig{}, &store.ErrNotFound{
+				Entity: "llm_config",
+				ID:     fmt.Sprintf("%s/%s", ownerType, ownerID),
+			}
+		}
+		return model.LLMConfig{}, err
+	}
+	cfg.OwnerType = model.LLMConfigOwnerType(ownerTypeStr)
+	cfg.Provider = model.LLMProvider(providerStr)
+	return cfg, nil
+}
+
+func (s *LLMConfigStore) Delete(ctx context.Context, configID string) error {
+	tag, err := s.db.Pool.Exec(ctx,
+		`DELETE FROM llm_configs WHERE id = $1`, configID)
+	if err != nil {
+		return err
+	}
+	if tag.RowsAffected() == 0 {
+		return &store.ErrNotFound{Entity: "llm_config", ID: configID}
+	}
+	return nil
+}

--- a/core/store/store.go
+++ b/core/store/store.go
@@ -260,6 +260,17 @@ type UserKeyMaterialStore interface {
 	Update(ctx context.Context, material model.UserKeyMaterial) error
 }
 
+// LLMConfigStore persists and retrieves per-user and per-org LLM provider
+// configurations. At most one config exists per owner (unique on owner_type + owner_id).
+type LLMConfigStore interface {
+	// Upsert creates or updates an LLM config by owner_type + owner_id.
+	Upsert(ctx context.Context, cfg model.LLMConfig) (model.LLMConfig, error)
+	// GetByOwner returns the config for a specific owner, or ErrNotFound.
+	GetByOwner(ctx context.Context, ownerType model.LLMConfigOwnerType, ownerID string) (model.LLMConfig, error)
+	// Delete removes an LLM config by ID.
+	Delete(ctx context.Context, configID string) error
+}
+
 // ErrNotFound is returned when a requested entity does not exist.
 type ErrNotFound struct {
 	Entity string


### PR DESCRIPTION
## Summary

- Add `LLMConfig` model with owner_type/owner_id polymorphism — one model for both user and enterprise configs
- `ClientResolver` in `core/llm/` resolves LLM clients per-user with three-level fallback: user config → org config → server defaults (env vars)
- Pipeline integration via `WithClientResolver()` builder method — zero changes to `NewPipeline` signature, all 12+ existing tests untouched
- REST API for user-level (`PUT/GET/DELETE /v1/llm-config`) and enterprise-level (`PUT/GET/DELETE /v1/enterprises/{id}/llm-config`) configuration
- API keys stored in vault at `llm-config/{ownerType}/{ownerID}`, never returned in API responses (`api_key_configured: bool` instead)
- Enterprise endpoints require admin/owner role
- Only `anthropic` provider supported currently; `openai` enum ready for #141

## New files (8)

| File | Purpose |
|------|---------|
| `core/model/llm_config.go` | LLMConfig model, provider/owner types, VaultPath() |
| `core/store/mem/llm_config.go` | In-memory LLMConfigStore |
| `core/store/mem/user.go` | In-memory UserStore (needed for resolver tests) |
| `core/store/postgres/llm_config.go` | Postgres LLMConfigStore with UPSERT |
| `core/llm/resolver.go` | ClientResolver with three-level fallback |
| `core/llm/resolver_test.go` | 7 tests covering all resolution paths |
| `core/app/handlers_llm_config.go` | 6 HTTP handlers + requireEnterpriseAdmin |
| `core/app/handlers_llm_config_test.go` | 11 handler tests |

## Modified files (5)

- `core/store/store.go` — `LLMConfigStore` interface
- `core/schema/schema.hcl` — `llm_configs` table
- `core/draft/pipeline.go` — `clientResolver` field, resolution in `GenerateDraft`
- `core/app/handlers.go` — `llmConfigs` field on apiServer
- `core/app/app.go` — wire store, resolver, routes

## Test plan

- [x] 6 in-memory store tests (CRUD, upsert, separate owners)
- [x] 7 resolver tests (server default, per-user, per-org, user overrides org, vault failure fallthrough, unsupported provider, no default key)
- [x] 11 handler tests (upsert, get, delete, not-found, validation, path extraction, admin checks)
- [x] All 12+ existing pipeline tests pass unchanged
- [x] Full `core` module: all tests pass
- [x] Coverage: llm 92.9%, draft 83.3%

Closes #142

🤖 Generated with [Claude Code](https://claude.com/claude-code)