### PR TITLE
feat(ui): add LLM provider settings page

### DIFF
--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -132,6 +132,51 @@ export async function updateCurrentEnterprise(data: {
 	});
 }
 
+// --- LLM Provider Configuration ---
+
+export async function getUserLLMConfig() {
+	return apiFetch('/v1/llm-config');
+}
+
+export async function upsertUserLLMConfig(data: {
+	provider: string;
+	model_research: string;
+	model_synthesis: string;
+	api_key: string;
+}) {
+	return apiFetch('/v1/llm-config', {
+		method: 'PUT',
+		body: JSON.stringify(data)
+	});
+}
+
+export async function deleteUserLLMConfig() {
+	return apiFetch('/v1/llm-config', { method: 'DELETE' });
+}
+
+export async function getEnterpriseLLMConfig(enterpriseId: string) {
+	return apiFetch(`/v1/enterprises/${enterpriseId}/llm-config`);
+}
+
+export async function upsertEnterpriseLLMConfig(
+	enterpriseId: string,
+	data: {
+		provider: string;
+		model_research: string;
+		model_synthesis: string;
+		api_key: string;
+	}
+) {
+	return apiFetch(`/v1/enterprises/${enterpriseId}/llm-config`, {
+		method: 'PUT',
+		body: JSON.stringify(data)
+	});
+}
+
+export async function deleteEnterpriseLLMConfig(enterpriseId: string) {
+	return apiFetch(`/v1/enterprises/${enterpriseId}/llm-config`, { method: 'DELETE' });
+}
+
 // --- Vault / Passphrase ---
 
 export async function getPassphraseSalt() {

--- a/ui/src/routes/settings/+layout.svelte
+++ b/ui/src/routes/settings/+layout.svelte
@@ -7,7 +7,8 @@
 	const navItems = [
 		{ href: '/settings/profile', label: 'Profile' },
 		{ href: '/settings/organization', label: 'Organization' },
-		{ href: '/settings/connected-accounts', label: 'Connected Accounts' }
+		{ href: '/settings/connected-accounts', label: 'Connected Accounts' },
+		{ href: '/settings/llm', label: 'LLM Provider' }
 	];
 </script>
 

--- a/ui/src/routes/settings/llm/+page.svelte
+++ b/ui/src/routes/settings/llm/+page.svelte
@@ -1,0 +1,234 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { getUserLLMConfig, upsertUserLLMConfig, deleteUserLLMConfig } from '$lib/api';
+	import * as Card from '$lib/components/ui/card';
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { Input } from '$lib/components/ui/input';
+	import { Button } from '$lib/components/ui/button';
+	import { Badge } from '$lib/components/ui/badge';
+
+	let config = $state<any>(null);
+	let loading = $state(true);
+	let saving = $state(false);
+	let deleting = $state(false);
+	let error = $state('');
+	let success = $state('');
+	let confirmDeleteOpen = $state(false);
+	let showApiKey = $state(false);
+
+	let provider = $state('anthropic');
+	let modelResearch = $state('');
+	let modelSynthesis = $state('');
+	let apiKey = $state('');
+
+	onMount(async () => {
+		try {
+			config = await getUserLLMConfig();
+			provider = config.provider || 'anthropic';
+			modelResearch = config.model_research || '';
+			modelSynthesis = config.model_synthesis || '';
+		} catch (e: any) {
+			if (e.message?.includes('not found') || e.message?.includes('404')) {
+				config = null;
+			} else {
+				error = e.message;
+			}
+		} finally {
+			loading = false;
+		}
+	});
+
+	async function handleSave() {
+		error = '';
+		success = '';
+
+		if (!apiKey && !config) {
+			error = 'API key is required';
+			return;
+		}
+		if (!apiKey && config) {
+			error = 'Enter a new API key to update your configuration';
+			return;
+		}
+
+		saving = true;
+		try {
+			config = await upsertUserLLMConfig({
+				provider,
+				model_research: modelResearch,
+				model_synthesis: modelSynthesis,
+				api_key: apiKey
+			});
+			apiKey = '';
+			showApiKey = false;
+			success = 'LLM configuration saved';
+			setTimeout(() => (success = ''), 3000);
+		} catch (e: any) {
+			error = e.message;
+		} finally {
+			saving = false;
+		}
+	}
+
+	async function handleDelete() {
+		error = '';
+		success = '';
+		deleting = true;
+		try {
+			await deleteUserLLMConfig();
+			config = null;
+			provider = 'anthropic';
+			modelResearch = '';
+			modelSynthesis = '';
+			apiKey = '';
+			confirmDeleteOpen = false;
+			success = 'LLM configuration removed. Using server defaults.';
+			setTimeout(() => (success = ''), 3000);
+		} catch (e: any) {
+			error = e.message;
+		} finally {
+			deleting = false;
+		}
+	}
+</script>
+
+<svelte:head>
+	<title>LLM Provider - Aileron</title>
+</svelte:head>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading...</p>
+{:else}
+	<div class="flex flex-col gap-6">
+		<Card.Root>
+			<Card.Header>
+				<div class="flex items-center justify-between">
+					<div>
+						<Card.Title>LLM Provider</Card.Title>
+						<Card.Description>
+							Configure your LLM provider, models, and API key for draft generation
+						</Card.Description>
+					</div>
+					{#if config}
+						<Badge variant="outline" class="text-green-600 border-green-500/50">Configured</Badge>
+					{:else}
+						<Badge variant="secondary">Using server defaults</Badge>
+					{/if}
+				</div>
+			</Card.Header>
+			<Card.Content>
+				<div class="flex flex-col gap-4">
+					<p class="text-xs text-muted-foreground">
+						Your personal LLM configuration overrides organization and server defaults.
+						Remove your configuration to fall back to organization or server defaults.
+					</p>
+
+					<div class="flex flex-col gap-1.5">
+						<label for="llm_provider" class="text-sm font-medium">Provider</label>
+						<select
+							id="llm_provider"
+							bind:value={provider}
+							class="flex h-9 w-full max-w-sm rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+						>
+							<option value="anthropic">Anthropic</option>
+							<option value="openai" disabled>OpenAI (coming soon)</option>
+						</select>
+					</div>
+
+					<div class="flex flex-col gap-1.5">
+						<label for="llm_model_research" class="text-sm font-medium">Research model</label>
+						<Input
+							id="llm_model_research"
+							bind:value={modelResearch}
+							placeholder="e.g. claude-haiku-4-5-20251001"
+							class="max-w-sm"
+						/>
+						<p class="text-xs text-muted-foreground">
+							Fast model used for tool-based context gathering
+						</p>
+					</div>
+
+					<div class="flex flex-col gap-1.5">
+						<label for="llm_model_synthesis" class="text-sm font-medium">Synthesis model</label>
+						<Input
+							id="llm_model_synthesis"
+							bind:value={modelSynthesis}
+							placeholder="e.g. claude-sonnet-4-6"
+							class="max-w-sm"
+						/>
+						<p class="text-xs text-muted-foreground">
+							Capable model used for composing draft replies
+						</p>
+					</div>
+
+					<div class="flex flex-col gap-1.5">
+						<label for="llm_api_key" class="text-sm font-medium">API key</label>
+						<div class="flex items-center gap-2 max-w-sm">
+							<Input
+								id="llm_api_key"
+								type={showApiKey ? 'text' : 'password'}
+								bind:value={apiKey}
+								placeholder={config?.api_key_configured
+									? 'Enter new key to update'
+									: 'Enter your API key'}
+								class="flex-1"
+							/>
+							<Button
+								variant="ghost"
+								size="sm"
+								onclick={() => (showApiKey = !showApiKey)}
+							>
+								{showApiKey ? 'Hide' : 'Show'}
+							</Button>
+						</div>
+						{#if config?.api_key_configured}
+							<p class="text-xs text-muted-foreground">
+								A key is already configured. Enter a new key to replace it.
+							</p>
+						{/if}
+					</div>
+
+					{#if error}
+						<p class="text-sm text-destructive">{error}</p>
+					{/if}
+					{#if success}
+						<p class="text-sm text-green-600">{success}</p>
+					{/if}
+
+					<div class="flex items-center gap-3">
+						<Button onclick={handleSave} disabled={saving} size="sm">
+							{saving ? 'Saving...' : 'Save'}
+						</Button>
+						{#if config}
+							<Button
+								variant="destructive"
+								size="sm"
+								onclick={() => (confirmDeleteOpen = true)}
+							>
+								Remove configuration
+							</Button>
+						{/if}
+					</div>
+				</div>
+			</Card.Content>
+		</Card.Root>
+	</div>
+
+	<Dialog.Root bind:open={confirmDeleteOpen}>
+		<Dialog.Content>
+			<Dialog.Header>
+				<Dialog.Title>Remove LLM configuration?</Dialog.Title>
+				<Dialog.Description>
+					This will remove your personal LLM provider settings. Draft generation will
+					fall back to your organization's configuration or the server defaults.
+				</Dialog.Description>
+			</Dialog.Header>
+			<Dialog.Footer>
+				<Button variant="outline" onclick={() => (confirmDeleteOpen = false)}>Cancel</Button>
+				<Button variant="destructive" onclick={handleDelete} disabled={deleting}>
+					{deleting ? 'Removing...' : 'Remove'}
+				</Button>
+			</Dialog.Footer>
+		</Dialog.Content>
+	</Dialog.Root>
+{/if}

--- a/ui/src/routes/settings/organization/+page.svelte
+++ b/ui/src/routes/settings/organization/+page.svelte
@@ -1,8 +1,15 @@
 <script lang="ts">
 	import { onMount } from 'svelte';
-	import { getCurrentEnterprise, updateCurrentEnterprise } from '$lib/api';
+	import {
+		getCurrentEnterprise,
+		updateCurrentEnterprise,
+		getEnterpriseLLMConfig,
+		upsertEnterpriseLLMConfig,
+		deleteEnterpriseLLMConfig
+	} from '$lib/api';
 	import { getUser } from '$lib/auth.svelte.js';
 	import * as Card from '$lib/components/ui/card';
+	import * as Dialog from '$lib/components/ui/dialog';
 	import { Input } from '$lib/components/ui/input';
 	import { Button } from '$lib/components/ui/button';
 	import { Badge } from '$lib/components/ui/badge';
@@ -18,6 +25,20 @@
 	let ssoRequired = $state(false);
 	let allowedProviders = $state('');
 	let allowedDomains = $state('');
+
+	// LLM provider configuration state.
+	let llmConfig = $state<any>(null);
+	let llmSaving = $state(false);
+	let llmDeleting = $state(false);
+	let llmError = $state('');
+	let llmSuccess = $state('');
+	let llmConfirmDeleteOpen = $state(false);
+	let llmShowApiKey = $state(false);
+
+	let llmProvider = $state('anthropic');
+	let llmModelResearch = $state('');
+	let llmModelSynthesis = $state('');
+	let llmApiKey = $state('');
 
 	$effect(() => {
 		if (enterprise) {
@@ -39,6 +60,17 @@
 	onMount(async () => {
 		try {
 			enterprise = await getCurrentEnterprise();
+			// Load org LLM config (admin only, 404 is expected).
+			if (canEdit && enterprise) {
+				try {
+					llmConfig = await getEnterpriseLLMConfig(enterprise.id);
+					llmProvider = llmConfig.provider || 'anthropic';
+					llmModelResearch = llmConfig.model_research || '';
+					llmModelSynthesis = llmConfig.model_synthesis || '';
+				} catch {
+					llmConfig = null;
+				}
+			}
 		} catch (e: any) {
 			error = e.message;
 		} finally {
@@ -71,6 +103,59 @@
 			error = e.message;
 		} finally {
 			saving = false;
+		}
+	}
+
+	async function handleLLMSave() {
+		llmError = '';
+		llmSuccess = '';
+
+		if (!llmApiKey && !llmConfig) {
+			llmError = 'API key is required';
+			return;
+		}
+		if (!llmApiKey && llmConfig) {
+			llmError = 'Enter a new API key to update the configuration';
+			return;
+		}
+
+		llmSaving = true;
+		try {
+			llmConfig = await upsertEnterpriseLLMConfig(enterprise.id, {
+				provider: llmProvider,
+				model_research: llmModelResearch,
+				model_synthesis: llmModelSynthesis,
+				api_key: llmApiKey
+			});
+			llmApiKey = '';
+			llmShowApiKey = false;
+			llmSuccess = 'Organization LLM configuration saved';
+			setTimeout(() => (llmSuccess = ''), 3000);
+		} catch (e: any) {
+			llmError = e.message;
+		} finally {
+			llmSaving = false;
+		}
+	}
+
+	async function handleLLMDelete() {
+		llmError = '';
+		llmSuccess = '';
+		llmDeleting = true;
+		try {
+			await deleteEnterpriseLLMConfig(enterprise.id);
+			llmConfig = null;
+			llmProvider = 'anthropic';
+			llmModelResearch = '';
+			llmModelSynthesis = '';
+			llmApiKey = '';
+			llmConfirmDeleteOpen = false;
+			llmSuccess = 'Organization LLM configuration removed. Using server defaults.';
+			setTimeout(() => (llmSuccess = ''), 3000);
+		} catch (e: any) {
+			llmError = e.message;
+		} finally {
+			llmDeleting = false;
 		}
 	}
 
@@ -238,5 +323,137 @@
 				</div>
 			</Card.Content>
 		</Card.Root>
+		{#if canEdit}
+			<Card.Root>
+				<Card.Header>
+					<div class="flex items-center justify-between">
+						<div>
+							<Card.Title>LLM Provider</Card.Title>
+							<Card.Description>
+								Default LLM configuration for all organization members
+							</Card.Description>
+						</div>
+						{#if llmConfig}
+							<Badge variant="outline" class="text-green-600 border-green-500/50">Configured</Badge>
+						{:else}
+							<Badge variant="secondary">Using server defaults</Badge>
+						{/if}
+					</div>
+				</Card.Header>
+				<Card.Content>
+					<div class="flex flex-col gap-4">
+						<p class="text-xs text-muted-foreground">
+							This applies to all members who haven't set their own LLM configuration.
+							Individual members can override this in their personal settings.
+						</p>
+
+						<div class="flex flex-col gap-1.5">
+							<label for="org_llm_provider" class="text-sm font-medium">Provider</label>
+							<select
+								id="org_llm_provider"
+								bind:value={llmProvider}
+								class="flex h-9 w-full max-w-sm rounded-md border border-input bg-transparent px-3 py-1 text-sm shadow-sm transition-colors focus-visible:outline-none focus-visible:ring-1 focus-visible:ring-ring"
+							>
+								<option value="anthropic">Anthropic</option>
+								<option value="openai" disabled>OpenAI (coming soon)</option>
+							</select>
+						</div>
+
+						<div class="flex flex-col gap-1.5">
+							<label for="org_llm_research" class="text-sm font-medium">Research model</label>
+							<Input
+								id="org_llm_research"
+								bind:value={llmModelResearch}
+								placeholder="e.g. claude-haiku-4-5-20251001"
+								class="max-w-sm"
+							/>
+							<p class="text-xs text-muted-foreground">
+								Fast model used for tool-based context gathering
+							</p>
+						</div>
+
+						<div class="flex flex-col gap-1.5">
+							<label for="org_llm_synthesis" class="text-sm font-medium">Synthesis model</label>
+							<Input
+								id="org_llm_synthesis"
+								bind:value={llmModelSynthesis}
+								placeholder="e.g. claude-sonnet-4-6"
+								class="max-w-sm"
+							/>
+							<p class="text-xs text-muted-foreground">
+								Capable model used for composing draft replies
+							</p>
+						</div>
+
+						<div class="flex flex-col gap-1.5">
+							<label for="org_llm_api_key" class="text-sm font-medium">API key</label>
+							<div class="flex items-center gap-2 max-w-sm">
+								<Input
+									id="org_llm_api_key"
+									type={llmShowApiKey ? 'text' : 'password'}
+									bind:value={llmApiKey}
+									placeholder={llmConfig?.api_key_configured
+										? 'Enter new key to update'
+										: 'Enter your API key'}
+									class="flex-1"
+								/>
+								<Button
+									variant="ghost"
+									size="sm"
+									onclick={() => (llmShowApiKey = !llmShowApiKey)}
+								>
+									{llmShowApiKey ? 'Hide' : 'Show'}
+								</Button>
+							</div>
+							{#if llmConfig?.api_key_configured}
+								<p class="text-xs text-muted-foreground">
+									A key is already configured. Enter a new key to replace it.
+								</p>
+							{/if}
+						</div>
+
+						{#if llmError}
+							<p class="text-sm text-destructive">{llmError}</p>
+						{/if}
+						{#if llmSuccess}
+							<p class="text-sm text-green-600">{llmSuccess}</p>
+						{/if}
+
+						<div class="flex items-center gap-3">
+							<Button onclick={handleLLMSave} disabled={llmSaving} size="sm">
+								{llmSaving ? 'Saving...' : 'Save'}
+							</Button>
+							{#if llmConfig}
+								<Button
+									variant="destructive"
+									size="sm"
+									onclick={() => (llmConfirmDeleteOpen = true)}
+								>
+									Remove configuration
+								</Button>
+							{/if}
+						</div>
+					</div>
+				</Card.Content>
+			</Card.Root>
+
+			<Dialog.Root bind:open={llmConfirmDeleteOpen}>
+				<Dialog.Content>
+					<Dialog.Header>
+						<Dialog.Title>Remove organization LLM configuration?</Dialog.Title>
+						<Dialog.Description>
+							This will remove the organization's LLM provider settings. All members
+							without personal configurations will fall back to server defaults.
+						</Dialog.Description>
+					</Dialog.Header>
+					<Dialog.Footer>
+						<Button variant="outline" onclick={() => (llmConfirmDeleteOpen = false)}>Cancel</Button>
+						<Button variant="destructive" onclick={handleLLMDelete} disabled={llmDeleting}>
+							{llmDeleting ? 'Removing...' : 'Remove'}
+						</Button>
+					</Dialog.Footer>
+				</Dialog.Content>
+			</Dialog.Root>
+		{/if}
 	</div>
 {/if}


### PR DESCRIPTION
## Summary

- New `/settings/llm` page for user-level LLM provider configuration (provider dropdown, research/synthesis model inputs, masked API key)
- New "LLM Provider" card on `/settings/organization` page for org-level configuration (admin/owner only)
- 6 new API client functions in `api.ts` for user and enterprise LLM config CRUD
- "LLM Provider" nav item added to settings sidebar

## UX details

- **Status badges**: "Configured" (green) or "Using server defaults" (gray) on both pages
- **API key handling**: never displayed, `api_key_configured` boolean shown instead; placeholder changes based on state
- **Delete flow**: confirmation dialog explaining fallback behavior (user → org → server defaults)
- **Resolution hierarchy**: explained in help text on both pages
- **OpenAI**: shown in dropdown as disabled "coming soon" (ready for #141)

## Files

| File | Change |
|------|--------|
| `ui/src/lib/api.ts` | Add 6 LLM config API functions |
| `ui/src/routes/settings/+layout.svelte` | Add "LLM Provider" nav item |
| `ui/src/routes/settings/llm/+page.svelte` | New user LLM settings page |
| `ui/src/routes/settings/organization/+page.svelte` | Add org LLM config card (admin only) |

## Test plan

- [x] `task build:ui` — builds successfully
- [x] `pnpm run check` — 0 errors, 0 warnings (1092 files)
- [ ] Manual: navigate to /settings/llm, configure provider/models/key, verify save/delete
- [ ] Manual: navigate to /settings/organization as admin, verify LLM card appears
- [ ] Manual: verify non-admin users don't see org LLM card

Closes #199

🤖 Generated with [Claude Code](https://claude.com/claude-code)