### PR TITLE
fix(ui): support vault unlock without TEE

### DIFF
--- a/core/app/handlers_passphrase.go
+++ b/core/app/handlers_passphrase.go
@@ -152,6 +152,13 @@ func (s *apiServer) UnlockVault(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
+	// When TEE is available, direct unlock is disabled — KEK must be
+	// transmitted via the encrypted enclave session (Phase 3).
+	if s.enclaveClient != nil {
+		writeError(w, http.StatusForbidden, "tee_required", "direct unlock disabled — use TEE session")
+		return
+	}
+
 	var req api.UnlockVaultRequest
 	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_body", "invalid request body")

--- a/core/app/handlers_passphrase_test.go
+++ b/core/app/handlers_passphrase_test.go
@@ -697,6 +697,25 @@ func TestUnlockVault_Success(t *testing.T) {
 	}
 }
 
+func TestUnlockVault_BlockedWhenTEEEnabled(t *testing.T) {
+	srv := unlockServer()
+	srv.enclaveClient = &mockEscrowClient{} // non-nil = TEE enabled
+
+	kek := make([]byte, 32)
+	for i := range kek {
+		kek[i] = byte(i + 1)
+	}
+	body, _ := json.Marshal(api.UnlockVaultRequest{Kek: kek})
+
+	w := httptest.NewRecorder()
+	r := authedRequest(http.MethodPost, "/v1/users/me/passphrase/unlock", string(body), testClaims)
+	srv.UnlockVault(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403 when TEE enabled, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestUnlockVault_WrongKEK(t *testing.T) {
 	srv := unlockServer()
 	body, _ := json.Marshal(api.UnlockVaultRequest{Kek: make([]byte, 32)})

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -202,6 +202,13 @@ export async function lockVault() {
 	return apiFetch('/v1/users/me/passphrase/lock', { method: 'POST' });
 }
 
+export async function unlockVaultDirect(kek: string) {
+	return apiFetch('/v1/users/me/passphrase/unlock', {
+		method: 'POST',
+		body: JSON.stringify({ kek })
+	});
+}
+
 // --- TEE ---
 
 export async function initiateAttestation(audience?: string) {

--- a/ui/src/lib/crypto/vault.svelte.ts
+++ b/ui/src/lib/crypto/vault.svelte.ts
@@ -14,8 +14,10 @@ import { VERIFICATION_CONSTANT, SALT_LENGTH } from './constants.js';
 import {
 	getPassphraseSalt,
 	getPassphraseVerification,
+	getTeeStatus,
 	initiateAttestation,
 	establishTeeSession,
+	unlockVaultDirect,
 	setPassphrase
 } from '$lib/api';
 
@@ -33,11 +35,12 @@ export interface UnlockResult {
 }
 
 /**
- * Unlocks the vault by deriving the KEK client-side, verifying the
- * passphrase locally, then transmitting the KEK to the enclave via
- * an end-to-end encrypted channel.
+ * Unlocks the vault by deriving the KEK client-side and verifying the
+ * passphrase locally.
  *
- * The passphrase and KEK never leave the browser in plaintext.
+ * If TEE is enabled: transmits KEK via end-to-end encrypted channel (ECDH).
+ * If TEE is disabled: sends KEK directly over HTTPS to the server's
+ * session cache. The passphrase never leaves the browser in either mode.
  */
 export async function unlockVault(
 	passphrase: string,
@@ -76,48 +79,64 @@ export async function unlockVault(
 			return { valid: false };
 		}
 
-		// 5. Initiate attestation.
-		onProgress?.('attesting');
-		const attestResp = await initiateAttestation();
-		const enclavePublicKey = base64ToBytes(attestResp.public_key);
+		// 5. Check if TEE is available.
+		const teeStatus = await getTeeStatus();
 
-		// 6. Verify attestation client-side.
-		const attResult = await verifyAttestation(
-			attestResp.token,
-			enclavePublicKey,
-			'aileron-enclave'
-		);
-		if (!attResult.verified) {
-			throw new Error('Enclave attestation verification failed');
+		if (teeStatus.enabled) {
+			// TEE mode: attestation + ECDH + encrypted KEK transmission.
+			return await unlockViaTee(kek, onProgress);
 		}
 
-		// 7. Generate ephemeral ECDH key pair.
+		// Direct mode: send KEK over HTTPS to server session cache.
 		onProgress?.('establishing');
-		const { privateKey, publicKey: clientPubKey } = await generateKeyPair();
-
-		// 8. Derive shared secret using enclave's attested public key.
-		const sharedSecret = await deriveSharedSecret(privateKey, attResult.enclavePublicKey);
-
-		// 9. Encrypt KEK with shared secret.
-		const encryptedKEK = await encrypt(kek, sharedSecret);
-
-		// 10. Send opaque blob through server to enclave.
-		const sessionResp = await establishTeeSession({
-			encrypted_kek: bytesToBase64(encryptedKEK),
-			client_public_key: bytesToBase64(clientPubKey)
-		});
+		const resp = await unlockVaultDirect(bytesToBase64(kek));
 
 		onProgress?.('done');
-
 		return {
 			valid: true,
-			sessionExpiresAt: sessionResp.expires_at ? new Date(sessionResp.expires_at) : undefined,
-			escrowedCount: sessionResp.escrowed_count
+			sessionExpiresAt: resp.expires_at ? new Date(resp.expires_at) : undefined
 		};
 	} finally {
-		// Best-effort memory zeroing (JS doesn't guarantee this, but we try).
 		kek.fill(0);
 	}
+}
+
+/**
+ * TEE unlock path: attestation, ECDH key exchange, encrypted KEK transmission.
+ */
+async function unlockViaTee(
+	kek: Uint8Array,
+	onProgress?: (step: UnlockProgress) => void
+): Promise<UnlockResult> {
+	onProgress?.('attesting');
+	const attestResp = await initiateAttestation();
+	const enclavePublicKey = base64ToBytes(attestResp.public_key);
+
+	const attResult = await verifyAttestation(
+		attestResp.token,
+		enclavePublicKey,
+		'aileron-enclave'
+	);
+	if (!attResult.verified) {
+		throw new Error('Enclave attestation verification failed');
+	}
+
+	onProgress?.('establishing');
+	const { privateKey, publicKey: clientPubKey } = await generateKeyPair();
+	const sharedSecret = await deriveSharedSecret(privateKey, attResult.enclavePublicKey);
+	const encryptedKEK = await encrypt(kek, sharedSecret);
+
+	const sessionResp = await establishTeeSession({
+		encrypted_kek: bytesToBase64(encryptedKEK),
+		client_public_key: bytesToBase64(clientPubKey)
+	});
+
+	onProgress?.('done');
+	return {
+		valid: true,
+		sessionExpiresAt: sessionResp.expires_at ? new Date(sessionResp.expires_at) : undefined,
+		escrowedCount: sessionResp.escrowed_count
+	};
 }
 
 /**


### PR DESCRIPTION
## Summary
- The vault unlock flow only had the TEE path (attestation + ECDH), which fails with "TEE is not enabled" when no enclave is configured
- Now checks `GET /v1/tee/status` first and branches:
  - **TEE enabled:** existing attestation + encrypted KEK path (Phase 3)
  - **TEE disabled:** sends KEK directly via `POST /v1/users/me/passphrase/unlock` (Phase 2)
- Adds `unlockVaultDirect` function to `api.ts`

## Test plan
- [ ] Navigate to `/setup-vault`, set passphrase, verify auto-unlock succeeds without TEE error
- [ ] Verify vault status shows unlocked after successful unlock
- [ ] Verify connected accounts can be linked after vault unlock

🤖 Generated with [Claude Code](https://claude.com/claude-code)