### PR TITLE
feat: encrypted vault for local/dev mode

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -4,7 +4,6 @@ package app
 
 import (
 	"context"
-	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -24,7 +23,6 @@ import (
 	googleauth "github.com/ALRubinger/aileron/core/auth/google"
 	"github.com/ALRubinger/aileron/core/config"
 	"github.com/ALRubinger/aileron/core/connector"
-	"github.com/ALRubinger/aileron/core/crypto"
 	googlecalendar "github.com/ALRubinger/aileron/core/connector/calendar/google"
 	"github.com/ALRubinger/aileron/core/connector/git/github"
 	"github.com/ALRubinger/aileron/core/connector/payments/stripe"
@@ -70,16 +68,10 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	// database is available. Even in local/dev mode, all secrets are encrypted
 	// at rest with an auto-generated KEK. This ensures a single code path for
 	// encryption — no plaintext bypass.
-	localKEK, err := crypto.GenerateRandomKEK()
+	v, err := newLocalEncryptedVault()
 	if err != nil {
-		return nil, fmt.Errorf("generating local vault KEK: %w", err)
+		return nil, err
 	}
-	var v vault.Vault
-	ev, err := vault.NewEncryptedVault(vault.NewMemVault(), localKEK)
-	if err != nil {
-		return nil, fmt.Errorf("creating encrypted vault: %w", err)
-	}
-	v = ev
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		v.Put(ctx, "connectors/github/default", []byte(token), vault.Metadata{
 			Type: "api_key",

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -4,6 +4,7 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -23,6 +24,7 @@ import (
 	googleauth "github.com/ALRubinger/aileron/core/auth/google"
 	"github.com/ALRubinger/aileron/core/config"
 	"github.com/ALRubinger/aileron/core/connector"
+	"github.com/ALRubinger/aileron/core/crypto"
 	googlecalendar "github.com/ALRubinger/aileron/core/connector/calendar/google"
 	"github.com/ALRubinger/aileron/core/connector/git/github"
 	"github.com/ALRubinger/aileron/core/connector/payments/stripe"
@@ -64,8 +66,20 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 	registry.Register(ctx, github.New())
 
 	// --- Vault ---
-	// Start with in-memory vault; upgrade to Postgres when database is available.
-	var v vault.Vault = vault.NewMemVault()
+	// Start with in-memory vault wrapped in encryption; upgrade to Postgres when
+	// database is available. Even in local/dev mode, all secrets are encrypted
+	// at rest with an auto-generated KEK. This ensures a single code path for
+	// encryption — no plaintext bypass.
+	localKEK, err := crypto.GenerateRandomKEK()
+	if err != nil {
+		return nil, fmt.Errorf("generating local vault KEK: %w", err)
+	}
+	var v vault.Vault
+	ev, err := vault.NewEncryptedVault(vault.NewMemVault(), localKEK)
+	if err != nil {
+		return nil, fmt.Errorf("creating encrypted vault: %w", err)
+	}
+	v = ev
 	if token := os.Getenv("GITHUB_TOKEN"); token != "" {
 		v.Put(ctx, "connectors/github/default", []byte(token), vault.Metadata{
 			Type: "api_key",

--- a/core/app/vault.go
+++ b/core/app/vault.go
@@ -1,0 +1,24 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/ALRubinger/aileron/core/crypto"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+// newLocalEncryptedVault creates an in-memory vault wrapped with AES-256-GCM
+// encryption using a randomly generated KEK. The KEK lives only in process
+// memory — it is regenerated on each server start. This ensures all secrets
+// are encrypted at rest even in local/dev mode.
+func newLocalEncryptedVault() (vault.Vault, error) {
+	kek, err := crypto.GenerateRandomKEK()
+	if err != nil {
+		return nil, fmt.Errorf("generating local vault KEK: %w", err)
+	}
+	ev, err := vault.NewEncryptedVault(vault.NewMemVault(), kek)
+	if err != nil {
+		return nil, fmt.Errorf("creating encrypted vault: %w", err)
+	}
+	return ev, nil
+}

--- a/core/app/vault_test.go
+++ b/core/app/vault_test.go
@@ -1,0 +1,59 @@
+package app
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+func TestNewLocalEncryptedVault(t *testing.T) {
+	v, err := newLocalEncryptedVault()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if v == nil {
+		t.Fatal("expected non-nil vault")
+	}
+}
+
+func TestNewLocalEncryptedVault_RoundTrip(t *testing.T) {
+	v, err := newLocalEncryptedVault()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	ctx := context.Background()
+	path := "test/secret"
+	value := []byte("my-secret-token")
+
+	if err := v.Put(ctx, path, value, vault.Metadata{Type: "token"}); err != nil {
+		t.Fatalf("Put: %v", err)
+	}
+
+	got, err := v.Get(ctx, path)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	if string(got.Value) != "my-secret-token" {
+		t.Fatalf("expected my-secret-token, got %s", got.Value)
+	}
+}
+
+func TestNewLocalEncryptedVault_UniqueKEKs(t *testing.T) {
+	// Two vaults should have different KEKs — a secret encrypted by one
+	// should not be decryptable by the other.
+	v1, _ := newLocalEncryptedVault()
+	v2, _ := newLocalEncryptedVault()
+
+	ctx := context.Background()
+	path := "test/secret"
+
+	v1.Put(ctx, path, []byte("secret"), vault.Metadata{})
+
+	// v2 has a different KEK and different MemVault — Get should fail (not found).
+	_, err := v2.Get(ctx, path)
+	if err == nil {
+		t.Fatal("expected error — different vault instances should be independent")
+	}
+}

--- a/core/crypto/kek.go
+++ b/core/crypto/kek.go
@@ -42,6 +42,17 @@ func DeriveKEKWithParams(passphrase, salt []byte, time, memory uint32, threads u
 	return kek, nil
 }
 
+// GenerateRandomKEK returns a cryptographically random 256-bit key suitable
+// for use as a Key Encryption Key. Used by local/dev mode where there is no
+// user passphrase — the KEK lives only in process memory.
+func GenerateRandomKEK() ([]byte, error) {
+	kek := make([]byte, KEKLen)
+	if _, err := rand.Read(kek); err != nil {
+		return nil, fmt.Errorf("crypto: generating random KEK: %w", err)
+	}
+	return kek, nil
+}
+
 // GenerateSalt returns a cryptographically random salt for Argon2id key derivation.
 func GenerateSalt() ([]byte, error) {
 	salt := make([]byte, SaltLen)

--- a/core/crypto/kek_test.go
+++ b/core/crypto/kek_test.go
@@ -88,6 +88,45 @@ func TestDeriveKEK_DefaultParams(t *testing.T) {
 	}
 }
 
+func TestGenerateRandomKEK(t *testing.T) {
+	k1, err := GenerateRandomKEK()
+	if err != nil {
+		t.Fatalf("GenerateRandomKEK: %v", err)
+	}
+	if len(k1) != KEKLen {
+		t.Fatalf("KEK length = %d, want %d", len(k1), KEKLen)
+	}
+
+	k2, err := GenerateRandomKEK()
+	if err != nil {
+		t.Fatalf("GenerateRandomKEK: %v", err)
+	}
+	if bytes.Equal(k1, k2) {
+		t.Fatal("two generated KEKs should not be equal")
+	}
+}
+
+func TestGenerateRandomKEK_UsableForEncryption(t *testing.T) {
+	kek, err := GenerateRandomKEK()
+	if err != nil {
+		t.Fatalf("GenerateRandomKEK: %v", err)
+	}
+
+	plaintext := []byte("secret data")
+	ciphertext, err := Encrypt(plaintext, kek)
+	if err != nil {
+		t.Fatalf("Encrypt: %v", err)
+	}
+
+	decrypted, err := Decrypt(ciphertext, kek)
+	if err != nil {
+		t.Fatalf("Decrypt: %v", err)
+	}
+	if !bytes.Equal(plaintext, decrypted) {
+		t.Fatal("decrypted data doesn't match original")
+	}
+}
+
 func TestGenerateSalt(t *testing.T) {
 	s1, err := GenerateSalt()
 	if err != nil {


### PR DESCRIPTION
## Summary

- Wrap `MemVault` with `EncryptedVault` in the non-auth (local dev) code path using an auto-generated random 32-byte KEK
- Add `crypto.GenerateRandomKEK()` for generating a random 256-bit key without passphrase derivation
- All vault secrets are now encrypted at rest even in dev mode — single encryption code path everywhere

## How it works

On server startup (non-auth path, lines 68-82 of `app.go`):
1. `crypto.GenerateRandomKEK()` generates a random 32-byte key
2. `vault.NewEncryptedVault(vault.NewMemVault(), kek)` wraps the in-memory vault
3. The GitHub token seed and all subsequent vault operations go through the encrypted layer

The KEK lives only in process memory — it's regenerated on each server start. The threat model is different from cloud (key is co-located with data), but the code path is identical, which means:
- Encryption bugs are caught in dev
- No `if encrypted` conditional branches
- Same `EncryptedVault` used by `aileron launch` (FileVault + passphrase KEK)

## Files

| File | Change |
|------|--------|
| `core/crypto/kek.go` | Add `GenerateRandomKEK()` |
| `core/crypto/kek_test.go` | Add 2 tests (uniqueness + usable for encryption) |
| `core/app/app.go` | Wrap MemVault with EncryptedVault |

## Test plan

- [x] `GenerateRandomKEK` produces 32 bytes, unique across calls
- [x] Generated KEK works for encrypt/decrypt round-trip
- [x] All existing tests pass (app, vault, crypto, full suite)
- [x] `go build ./...` succeeds

Closes #203

🤖 Generated with [Claude Code](https://claude.com/claude-code)