### PR TITLE
feat: Phase 3 TEE deployment infrastructure and documentation

### DIFF
--- a/cmd/aileron-enclave/Dockerfile
+++ b/cmd/aileron-enclave/Dockerfile
@@ -10,6 +10,15 @@ COPY cmd/aileron-enclave/ cmd/aileron-enclave/
 WORKDIR /build/cmd/aileron-enclave
 RUN CGO_ENABLED=0 go build -o /aileron-enclave .
 
-FROM gcr.io/confidential-space-images/confidential-space:latest
+# Production: use Confidential Space base image (requires GCP auth to pull).
+# Build with: docker build --target production -f cmd/aileron-enclave/Dockerfile .
+FROM gcr.io/confidential-space-images/confidential-space:latest AS production
+COPY --from=builder /aileron-enclave /aileron-enclave
+ENTRYPOINT ["/aileron-enclave"]
+
+# Local/CI: minimal alpine image (no GCP auth needed).
+# This is the default target used by docker-compose and CI.
+FROM alpine:3.21 AS local
+RUN apk add --no-cache ca-certificates
 COPY --from=builder /aileron-enclave /aileron-enclave
 ENTRYPOINT ["/aileron-enclave"]

--- a/cmd/aileron-enclave/Dockerfile
+++ b/cmd/aileron-enclave/Dockerfile
@@ -4,6 +4,8 @@ COPY go.work go.work.sum ./
 COPY cmd/aileron/go.mod cmd/aileron/go.mod
 COPY cmd/aileron-sh/go.mod cmd/aileron-sh/go.mod
 COPY cmd/aileron-mcp/go.mod cmd/aileron-mcp/go.mod
+COPY sdk/go/go.mod sdk/go/go.mod
+COPY test/integration/go.mod test/integration/go.mod
 COPY enclave/ enclave/
 COPY core/ core/
 COPY cmd/aileron-enclave/ cmd/aileron-enclave/

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -17,6 +17,17 @@ services:
       timeout: 5s
       retries: 5
 
+  enclave:
+    build:
+      context: ..
+      dockerfile: cmd/aileron-enclave/Dockerfile
+    restart: unless-stopped
+    environment:
+      AILERON_TEE_PROVIDER: "local"
+      AILERON_ENCLAVE_PORT: "8443"
+    ports:
+      - "8443:8443"
+
   server:
     build:
       context: ..
@@ -25,6 +36,8 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+      enclave:
+        condition: service_started
     environment:
       AILERON_ADDR: ":8080"
       AILERON_DATABASE_URL: "postgres://aileron:aileron@postgres:5432/aileron?sslmode=disable"
@@ -41,6 +54,8 @@ services:
       AILERON_OAUTH_CALLBACK_BASE_URL: "${AILERON_OAUTH_CALLBACK_BASE_URL:-}"
       AILERON_TRUSTED_ORIGINS: "${AILERON_TRUSTED_ORIGINS:-}"
       AILERON_TEE_PROVIDER: "${AILERON_TEE_PROVIDER:-local}"
+      AILERON_ENCLAVE_URL: "${AILERON_ENCLAVE_URL:-http://enclave:8443}"
+      AILERON_ESCROW_TTL: "${AILERON_ESCROW_TTL:-168h}"
     ports:
       - "8080:8080"
 

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -21,6 +21,7 @@ services:
     build:
       context: ..
       dockerfile: cmd/aileron-enclave/Dockerfile
+      target: local
     restart: unless-stopped
     environment:
       AILERON_TEE_PROVIDER: "local"

--- a/docs/src/content/docs/deployment/tee-enclave.md
+++ b/docs/src/content/docs/deployment/tee-enclave.md
@@ -48,7 +48,9 @@ gcloud artifacts repositories create aileron-enclave \
 ```sh
 export REGISTRY=$REGION-docker.pkg.dev/$GCP_PROJECT/aileron-enclave
 
-docker build -f cmd/aileron-enclave/Dockerfile -t $REGISTRY/aileron-enclave:latest .
+# The --target production flag selects the Confidential Space base image.
+# (The default target is "local" which uses alpine for dev/CI.)
+docker build --target production -f cmd/aileron-enclave/Dockerfile -t $REGISTRY/aileron-enclave:latest .
 docker push $REGISTRY/aileron-enclave:latest
 ```
 

--- a/docs/src/content/docs/deployment/tee-enclave.md
+++ b/docs/src/content/docs/deployment/tee-enclave.md
@@ -182,4 +182,61 @@ Expected response:
    ```
 5. The server will re-attest against the new image digest on its next attestation request.
 
+## Hybrid topology: Railway + GCP
+
+The recommended production topology keeps the Aileron server, UI, docs, and Postgres on Railway (preserving per-branch preview deployments and managed infrastructure), with only the enclave running on GCP Confidential Space.
+
+```
+Browser
+  │
+  ▼
+Railway (app.withaileron.ai)
+  ├─ server (API, auth, draft pipeline)
+  ├─ ui (SvelteKit)
+  ├─ docs (Astro)
+  └─ Postgres
+        │
+        │  HTTPS (attestation, session, execute)
+        ▼
+GCP Confidential Space (enclave)
+  ├─ AMD SEV-SNP hardware isolation
+  ├─ KEK storage (in encrypted memory)
+  ├─ OAuth token exchange
+  ├─ Connector execution
+  └─ Credential escrow
+        │
+        │  HTTPS (external API calls)
+        ▼
+Google, Slack, GitHub APIs
+```
+
+### Firewall configuration
+
+Restrict the enclave VM to accept traffic only from Railway's egress IPs:
+
+```sh
+# Get Railway's egress IPs from their docs or support.
+# As of 2026, Railway uses a set of static egress IPs per region.
+
+gcloud compute firewall-rules update allow-aileron-enclave \
+  --project=$GCP_PROJECT \
+  --source-ranges=<RAILWAY_EGRESS_IP_1>/32,<RAILWAY_EGRESS_IP_2>/32 \
+  --allow=tcp:8443
+```
+
+Contact Railway support or check their [networking docs](https://docs.railway.com/reference/networking) for current egress IP ranges.
+
+### Railway server configuration
+
+Set these environment variables on the Railway server service:
+
+| Variable | Value |
+|----------|-------|
+| `AILERON_TEE_PROVIDER` | `confidential-space` |
+| `AILERON_ENCLAVE_URL` | `http://<ENCLAVE_INTERNAL_IP>:8443` |
+| `AILERON_ENCLAVE_IMAGE_DIGEST` | `sha256:...` (from step 3 above) |
+| `AILERON_GCP_PROJECT_ID` | Your GCP project ID |
+
+If the enclave VM is in a different VPC or region than Railway's egress, use the external IP with TLS (terminate at the enclave or use a load balancer).
+
 For design rationale, see [ADR-0010: Zero-Knowledge Vault](/adr/0010-zero-knowledge-vault-trust-model), [ADR-0011: TEE Provider SPI](/adr/0011-tee-provider-spi-and-confidential-space), and [ADR-0012: Auto-Escrow & Session Lifetimes](/adr/0012-auto-escrow-and-decoupled-session-lifetimes).

--- a/docs/src/content/docs/getting-started/zero-knowledge-enclave.md
+++ b/docs/src/content/docs/getting-started/zero-knowledge-enclave.md
@@ -1,0 +1,93 @@
+---
+title: "Zero-Knowledge Enclave"
+description: "Hardware-isolated credential execution — Aileron provably cannot access your data"
+---
+
+The zero-knowledge enclave is a hardware-isolated service that handles all credential operations: OAuth token exchange, API calls to Gmail/Calendar/Slack/GitHub, and connector execution. Your encryption key (KEK) and plaintext tokens only exist inside the enclave's AMD SEV-SNP protected memory — the Aileron server never sees them.
+
+## What it gives you
+
+Without the enclave (Phase 2), the server briefly holds your KEK in process memory during active sessions. A compromised server could theoretically extract it.
+
+With the enclave (Phase 3), the server only passes opaque encrypted blobs. Even with full root access to the server, an attacker cannot read enclave memory — it's encrypted at the hardware level.
+
+| Threat | Without enclave | With enclave |
+|--------|----------------|--------------|
+| Database breach | Protected (ciphertext) | Protected |
+| Network sniffing | Protected (TLS) | Protected |
+| Compromised server | Exposed | **Protected** |
+| Malicious operator | Exposed | **Protected** |
+| Host memory dump | Exposed | **Protected** (AMD SEV-SNP) |
+
+## What changes for you as a user
+
+Nothing visible. The unlock flow is the same — enter your passphrase, and your vault unlocks. Under the hood, your KEK is transmitted via an end-to-end encrypted channel (ECDH) to the enclave instead of being cached in server memory. The enclave proves its identity via hardware attestation before receiving your key.
+
+## How it works
+
+```
+Browser
+  │
+  ├─ 1. Derive KEK from passphrase (Argon2id, client-side)
+  ├─ 2. Verify passphrase locally (decrypt verification blob)
+  ├─ 3. Request attestation from enclave
+  ├─ 4. Verify enclave's identity (JWT from Google, image digest check)
+  ├─ 5. ECDH key exchange (establish encrypted channel)
+  ├─ 6. Encrypt KEK with shared secret, send to enclave
+  │
+  ▼
+Aileron Server (Railway)
+  │  Passes opaque blobs — cannot decrypt
+  ▼
+Enclave (GCP Confidential Space)
+  ├─ Receives KEK via encrypted channel
+  ├─ Stores KEK in hardware-isolated memory
+  ├─ Decrypts OAuth tokens when needed
+  ├─ Makes API calls (Gmail, Calendar, Slack)
+  └─ Returns only structured results (no raw tokens)
+```
+
+## Verifying it's active
+
+Check the TEE status endpoint:
+
+```sh
+curl -H "Authorization: Bearer $TOKEN" \
+  https://api.yourdomain.com/v1/tee/status
+```
+
+Expected response:
+
+```json
+{
+  "enabled": true,
+  "provider": "confidential-space",
+  "attested": false,
+  "session_active": false
+}
+```
+
+After unlocking your vault, `attested` and `session_active` become `true`.
+
+## Credential escrow (offline execution)
+
+When you unlock your vault, the server automatically escrows your connected account credentials into the enclave. This allows Aileron to process incoming Slack messages and generate drafts even when you're offline — the enclave has the credentials it needs without requiring an active browser session.
+
+Escrowed credentials expire after a configurable TTL (default 7 days, set via `AILERON_ESCROW_TTL`). After expiry, you must unlock again for Aileron to access your connected accounts.
+
+## Deployment
+
+The enclave runs as a separate service on GCP Confidential Space. See the [TEE Enclave deployment guide](/deployment/tee-enclave) for full provisioning instructions.
+
+For local development, set `AILERON_TEE_PROVIDER=local` on the server. This uses the same ECDH protocol but without hardware isolation — useful for testing the attestation and session flow end-to-end.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|-------------|
+| "TEE is not enabled" | `AILERON_TEE_PROVIDER` not set on the server |
+| Attestation fails | Image digest mismatch — enclave was updated but `AILERON_ENCLAVE_IMAGE_DIGEST` wasn't. Update the digest and restart. |
+| Session expired | ECDH session has a 30-minute TTL. The client re-attests automatically on next vault operation. |
+| "Enclave unreachable" | Network connectivity between Railway and GCP. Check firewall rules and `AILERON_ENCLAVE_URL`. |
+| Escrowed credentials expired | User hasn't unlocked vault in >7 days. Unlock to re-escrow. |
+| 403 on direct unlock | Expected — when TEE is enabled, direct unlock is blocked. The UI uses the TEE path automatically. |

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -54,7 +54,8 @@ export const navigation: NavItem[] = [
       { label: 'Google Integration', href: '/getting-started/google-integration' },
       { label: 'Slack Cloud Integration', href: '/getting-started/slack-cloud-integration' },
       { label: 'GitHub Integration', href: '/getting-started/github-integration' },
-      { label: 'Discord Integration', href: '/getting-started/discord-integration' }
+      { label: 'Discord Integration', href: '/getting-started/discord-integration' },
+      { label: 'Zero-Knowledge Enclave', href: '/getting-started/zero-knowledge-enclave' }
     ]
   },
   {


### PR DESCRIPTION
## Summary
- Add enclave service to `docker-compose.yml` for local dev (5 services now: postgres, enclave, server, ui, docs)
- Wire `AILERON_ENCLAVE_URL` and `AILERON_ESCROW_TTL` env vars to server
- Document Railway + GCP Confidential Space hybrid topology in deployment docs
- New getting-started guide: "Zero-Knowledge Enclave" — what it does, why it matters, architecture diagram, troubleshooting
- Add to docs sidebar navigation

## Deployment topology

```
Railway (existing)          GCP Confidential Space (new)
├─ server                   └─ enclave (n2d-standard-2, AMD SEV-SNP)
├─ ui                           ├─ KEK storage
├─ docs                         ├─ OAuth exchange
└─ Postgres                     ├─ Connector execution
                                └─ Credential escrow
```

## Next steps (manual ops, not code)
1. Provision GCP infrastructure per `deployment/tee-enclave.md`
2. Build + push enclave image, record digest
3. Set env vars on Railway: `AILERON_TEE_PROVIDER=confidential-space`, `AILERON_ENCLAVE_URL`, `AILERON_ENCLAVE_IMAGE_DIGEST`, `AILERON_GCP_PROJECT_ID`
4. Verify: `GET /v1/tee/status` returns `enabled: true, provider: confidential-space`

## Test plan
- [x] All 29 Go packages pass (core + enclave)
- [x] Docs site builds cleanly (87 pages)
- [ ] `docker compose up` in `deploy/` — all 5 services start, TEE status returns enabled
- [ ] After GCP provisioning: full attestation + session flow works end-to-end

🤖 Generated with [Claude Code](https://claude.com/claude-code)