### PR TITLE
docs(tee): harden deployment guide and make TEE status public

### DIFF
--- a/cmd/aileron-enclave/Dockerfile
+++ b/cmd/aileron-enclave/Dockerfile
@@ -12,15 +12,9 @@ COPY cmd/aileron-enclave/ cmd/aileron-enclave/
 WORKDIR /build/cmd/aileron-enclave
 RUN CGO_ENABLED=0 go build -o /aileron-enclave .
 
-# Production: use Confidential Space base image (requires GCP auth to pull).
-# Build with: docker build --target production -f cmd/aileron-enclave/Dockerfile .
-FROM gcr.io/confidential-space-images/confidential-space:latest AS production
-COPY --from=builder /aileron-enclave /aileron-enclave
-ENTRYPOINT ["/aileron-enclave"]
-
-# Local/CI: minimal alpine image (no GCP auth needed).
-# This is the default target used by docker-compose and CI.
-FROM alpine:3.21 AS local
+# Minimal runtime image. The Confidential Space VM provides hardware
+# isolation around the container — no special base image needed.
+FROM alpine:3.21
 RUN apk add --no-cache ca-certificates
 COPY --from=builder /aileron-enclave /aileron-enclave
 ENTRYPOINT ["/aileron-enclave"]

--- a/core/api/gen/server.gen.go
+++ b/core/api/gen/server.gen.go
@@ -3878,12 +3878,6 @@ func (siw *ServerInterfaceWrapper) EstablishTeeSession(w http.ResponseWriter, r 
 // GetTeeStatus operation middleware
 func (siw *ServerInterfaceWrapper) GetTeeStatus(w http.ResponseWriter, r *http.Request) {
 
-	ctx := r.Context()
-
-	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
-
-	r = r.WithContext(ctx)
-
 	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		siw.Handler.GetTeeStatus(w, r)
 	}))
@@ -4472,25 +4466,25 @@ var swaggerSpec = []string{
 	"VGHCFCUxGeEbZb90GJyGQL/8+exnM7od4YIWwNeM56KqH9YoVbZwXwv3uUlvKyTjIBQAhF7QLebpNeZw",
 	"RATL9K1cDjnjuyV6UZfoEi7zsl/Cq05VYaoEtJy5dHZ7IrZ1DbHD7blWTbiH32/tKmnBO3ebq9shBlK9",
 	"HD+f/Ywkx1SY1N0ea2+VjfOWVpGG953peI1JVvIH3a7VIuuaXy4buZqVm5ECc3DnVinz+2S6umbagZfQ",
-	"Xc53Vk7NzdVFM7xSbyM7W1EVid9HIIjGY9vRsok1jscc1t6bJv82o4TrVo1ZUSz6vpwNRbr1qwjAPKho",
-	"oBRqDSaGXgVjgQrO1iQU6lNHXP0mbL6fA62F7n8gykpXiNlzfJWtOuPwqkC4X0xVLx4bIVMVKg+ltfjl",
-	"iR749OtbRvX84fWVoUCnnsVv7SmdBP+oKnfSSixYZydqb7icXYEW+UxSrk7tI5QRelkL162USq7k0wV9",
-	"aaXCOlWQap5hITUFohzklqVVESGdxjAvhURbLXVSXSb8gtbpbioAdFZAv6RPSG6rUxT5ZVrGkhi+bdRW",
-	"kcwH/xEsN0vULLfy+B5p7MbPi0AKqArAbg6oh1Kj95U2CvvFbCbQc7OkS1g/Ojc6gVeP3A5gS4U7QdUv",
-	"X4Rqfch8c0GNKlPpG6YIdLZDpSB0U1VYXDjFSiCMLim7po1+Ne3qculWX9HFURjNTJHyCp5aO1OAVBui",
-	"nu4FdWCbqlIZYKtnrZROA3yJfqXaPUitLZU6dkAsjBZ3Q4RUQF/C7oLmWAInOENEIM6kPgAeqdbAhdl8",
-	"HI4sPLaEjdHhBBKgNo6EbPc4tN0a5eYPdEQES9o/tGWrAuAcZyPuoVVZTgHSqZjrMst2X+gYOTe6uFn4",
-	"YKmjyTvwOGPNCKh2YXLAvE5P+weBEpxsjf3BHB3W8uB09E6itQta0ZdA10T7jipRED1/+gyVVJKsWWap",
-	"pLa8Et5gQkMU+sZVYT2kLBgqjxWgDd3MFoTaS4JDllxaXJgaSIC5h/J5S6sY0ySB3PFBw8pcOoSWQFB3",
-	"vDCVQgndXFDLnAVJvYK2GuFL9CITDBGaagFVoOveal0XtO48tOI/+vxCbdfoq2AM547xe4V796t8+x2b",
-	"ac9YfrOT+vd2fU6ivmOyEg49QCqLnSGXC9o+S5VSYs9I9alf7thaJC3PYOqfn96/f3u+vKCeFdOcvcYi",
-	"qLmATfppR+0c+eZUVue05c1mx9TTIdTyp4q2na3k/fs3S6TNBuojqg/1C7oC7yyvjZ66jB3JIMywQoTr",
-	"lYw+lLbVLUr9wAfpLE7pkPXtpKbQANvV1lnX661w5Kp3z+bMjaKb07LVOArsUL+maZ8N+/Km39qXjOfs",
-	"eCO1qr1u97ZnxSfCwCCZiUBACeMcEklBCP9m4oIaiVeAHdNjKMZ0PMr3/9osVPoA/N8fcZC020uyL/Yf",
-	"VHAmUJqm1q4lO0xe16Fil1YGY7zasYsG39Q+8LsLKkkOhv32n+5o9HD3WMhXI9Pt9yC/quTErjG9WsVm",
-	"0GOzzueHj7cf1Wu1mXrsHbWzvq43rUt9itPjY1yQpeJcmGTAGV1ioj0W7PCfnanDFvKvfvsJd7zHBlrv",
-	"wesqZq7uqqqK4T30XAGrZ41EuPXIdXi897Qd4ep308hsVz2uzOY1YFXRvi4Qfq5lv5OzM/+nDTC9/Xj7",
-	"/wMAAP//zj5zqqHzAAA=",
+	"Xc53Vk7NzdVFM7xSbyM7W1EVib9jIMiA44XGatvtsolDjsfc196bJv82qoSrWI3ZVCz6vpxFRbr1qwjA",
+	"PKhooBRqDSYGYgUjgwrO1iQU+FPHX/0mbPafA62F7n8g5krXi9lztJWtQePwqkC4X4RVLx4bAVQVKg+l",
+	"w/jFih74LOxbRvX84bWXobCnnsVv7SmdEv+oKn7SSjNY5ypqb7icXYEWAE2Krk4lJJQRelmL2q0ES64A",
+	"1AV9aWXEOnGQap5hITUFohzklqVVSSGd1DAvhURbLYNSXTT8gtbJbyoAdI5Av8BPSIqrExb5RVvGUhq+",
+	"bVRakcwH/xEsN0vULL7y+B5J7cbPi0BCqArAbkaoh1Kq95VECvulbSbQc7PAS1hbOjcagled3A5gC4c7",
+	"sdUvZoRq7ch8c0GNYlNpH6YkdLZDpSB0U9VbXDg1SyCMLim7po1+Ne3q4ulWe9GlUhjNTMnyCp5aV1OA",
+	"VBuinu4FdWCbGlMZYKt1rZSGA3yJfqXaWUitLZU6kkAsjE53Q4RUQF/C7oLmWAInOENEIM6kPgAeqdbA",
+	"hdl8HI4sPLagjdHoBBKgNo6EbPc4tN0axecPdEQEC9w/tJ2rAuAcZyPOolWRTgHSKZzrMst2X+gYOTea",
+	"uVn4YOGjyTvwOGPNeKh2mXLAvE5W+weBEpxsjTXCHB3WDuE09k7atQta0ZdA10R7kipRED1/+gyVVJKs",
+	"WXSppLbYEt5gQkMU+sbVZD2kLBgqlhWgDd3MlofaS7pDllxaXJiKSIC5h/J5S6sY0ySB3PFBw8pccoSW",
+	"QFB3vDB1QwndXFDLnAVJvfK2GuFL9CITDBGaagFVoOve2l0XtO48tOI/+vxCbdfoq2AM547xe2V8762K",
+	"N7QEv2Mz7RnLb3ZS/96uz0nUd0xWwqEHSGW/M+RyQdtnqVJK7BmpPvWLH1v7pOUZTP3z0/v3b8+XF9Sz",
+	"aZqz19gHNRewKUDtqJ0j35zK6py2vNnsmHo6hFr+VNG2s5y8f/9mibTZQH1E9aF+QVfgneW1CVQXtSMZ",
+	"hBlWiHC9AtKH0ra6Jaof+CCdxSkdsr6dRBUaYLvaOgd7vRWOXC3v2Zy5UYJzWu4aR4Ed6tc07bNhX970",
+	"W/uS8Zwdb6RWtdft3vZs+kQYGCQz8QgoYZxDIikI4d9TXFAj8QqwY3oMxRiSR/n+X5tlSx+A//sjDpJ2",
+	"e0n2xf6DCs4EStPU2rVrh8nrOlT60spgjFc7dtHgm9ojfndBJcnBsN/+0x2NHu4eC/lqZLr9HuRXlZzY",
+	"NaZXq9i0xDerfn74ePtRvVabqcfeUbvu6+rTuvCnOD0+xgVZKs6FSQac0SUm2n/BDv/ZmTpsWf/qt59+",
+	"x3tsoPUevK4i6OquqhoZ3kPPMbB61kiLW49cB8t7T9vxrn43jTx31ePKbF4DVpXw6wLhZ172Ozk783/a",
+	"cNPbj7f/PwAA//9+ScGCr/MAAA==",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/core/api/openapi.yaml
+++ b/core/api/openapi.yaml
@@ -1381,6 +1381,7 @@ paths:
       tags: [TEE]
       summary: Get TEE status
       operationId: getTeeStatus
+      security: []
       responses:
         "200":
           description: TEE configuration and session status

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -311,6 +311,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 
 		skipPaths := map[string]bool{
 			"/v1/health":                        true,
+			"/v1/tee/status":                    true,
 			"/v1/webhooks/slack/events":          true,
 			"/v1/webhooks/slack/interactions":    true,
 		}

--- a/core/app/handlers_tee_test.go
+++ b/core/app/handlers_tee_test.go
@@ -75,6 +75,30 @@ func TestGetTeeStatusEnabled(t *testing.T) {
 	}
 }
 
+func TestGetTeeStatus_PublicNoAuth(t *testing.T) {
+	// The TEE status endpoint must be accessible without authentication.
+	// This test verifies the handler returns 200 even with no claims in context.
+	s := &apiServer{
+		teeCfg:   &config.TEEConfig{Provider: "local"},
+		teeState: newTeeState(),
+	}
+
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/v1/tee/status", nil)
+	// No auth claims — simulating an unauthenticated request.
+	s.GetTeeStatus(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 without auth, got %d: %s", w.Code, w.Body.String())
+	}
+
+	var status api.TeeStatus
+	json.NewDecoder(w.Body).Decode(&status)
+	if !status.Enabled {
+		t.Fatal("expected enabled=true")
+	}
+}
+
 func TestGetTeeStatusConfidentialSpace(t *testing.T) {
 	s := &apiServer{
 		teeCfg:   &config.TEEConfig{Provider: "confidential-space"},

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -21,7 +21,6 @@ services:
     build:
       context: ..
       dockerfile: cmd/aileron-enclave/Dockerfile
-      target: local
     restart: unless-stopped
     environment:
       AILERON_TEE_PROVIDER: "local"

--- a/docs/src/content/docs/deployment/tee-enclave.md
+++ b/docs/src/content/docs/deployment/tee-enclave.md
@@ -15,15 +15,34 @@ Google Confidential Space runs containers inside AMD SEV-SNP confidential VMs wh
 
 ### Prerequisites
 
-- A GCP project with billing enabled
-- `gcloud` CLI installed and authenticated
+- `gcloud` CLI installed and authenticated with `gcloud init`
 - Docker (for building and pushing the enclave image)
-- A container registry (Artifact Registry or Container Registry)
+
+### 0. Enable billing on the GCP project
+
+Compute Engine, Artifact Registry, and Confidential Computing APIs all require an active billing account. If you created a new project via `gcloud init`, billing is not enabled by default.
+
+1. Go to [console.cloud.google.com/billing](https://console.cloud.google.com/billing)
+2. Select your project — you'll see **"Set the billing account for project"**
+3. Choose or create a billing account and save
+
+Or via CLI:
+
+```sh
+# List available billing accounts
+gcloud billing accounts list
+
+# Link your project to a billing account
+gcloud billing projects link $GCP_PROJECT \
+  --billing-account=<BILLING_ACCOUNT_ID>
+```
 
 ### 1. Enable required GCP APIs
 
 ```sh
-export GCP_PROJECT=your-project-id
+# Uses the default project set by gcloud init.
+# If you skipped gcloud init, set this manually: export GCP_PROJECT=your-project-id
+export GCP_PROJECT=$(gcloud config get-value project)
 
 gcloud services enable \
   compute.googleapis.com \
@@ -34,8 +53,12 @@ gcloud services enable \
 
 ### 2. Create an Artifact Registry repository
 
+We use GCP Artifact Registry (not GitHub Container Registry or Docker Hub) because the Confidential Space VM pulls images natively from Artifact Registry using its service account — no extra auth configuration needed. The attestation token includes the image digest from this registry.
+
+Choose a region close to your Railway deployment. See [available Artifact Registry locations](https://docs.cloud.google.com/artifact-registry/docs/repositories/repo-locations) or run `gcloud artifacts locations list`.
+
 ```sh
-export REGION=us-central1
+export REGION=us-central1  # change to your preferred region
 
 gcloud artifacts repositories create aileron-enclave \
   --repository-format=docker \
@@ -45,12 +68,20 @@ gcloud artifacts repositories create aileron-enclave \
 
 ### 3. Build and push the enclave container image
 
+> These are the manual steps for initial setup. For ongoing deployments, this should be automated in CI on merge to main — see [issue #211](https://github.com/ALRubinger/aileron/issues/211).
+
+Configure Docker to authenticate with Artifact Registry for pushing:
+
+```sh
+gcloud auth configure-docker $REGION-docker.pkg.dev
+```
+
+Then build and push:
+
 ```sh
 export REGISTRY=$REGION-docker.pkg.dev/$GCP_PROJECT/aileron-enclave
 
-# The --target production flag selects the Confidential Space base image.
-# (The default target is "local" which uses alpine for dev/CI.)
-docker build --target production -f cmd/aileron-enclave/Dockerfile -t $REGISTRY/aileron-enclave:latest .
+docker build -f cmd/aileron-enclave/Dockerfile -t $REGISTRY/aileron-enclave:latest .
 docker push $REGISTRY/aileron-enclave:latest
 ```
 
@@ -94,8 +125,7 @@ gcloud compute instances create aileron-enclave \
   --project=$GCP_PROJECT \
   --zone=$REGION-a \
   --machine-type=n2d-standard-2 \
-  --confidential-compute \
-  --min-cpu-platform="AMD Milan" \
+  --confidential-compute-type=SEV \
   --image-family=confidential-space \
   --image-project=confidential-space-images \
   --service-account=$ENCLAVE_SA \
@@ -106,45 +136,80 @@ gcloud compute instances create aileron-enclave \
 
 ### 6. Configure firewall rules
 
+Restrict traffic to only your Aileron server's static egress IP. Do not open port 8443 to `0.0.0.0/0` — the enclave should only accept connections from your server.
+
 ```sh
 gcloud compute firewall-rules create allow-aileron-enclave \
   --project=$GCP_PROJECT \
   --allow=tcp:8443 \
   --target-tags=aileron-enclave \
-  --source-ranges=0.0.0.0/0 \
-  --description="Allow traffic to Aileron enclave"
+  --source-ranges=<SERVER_EGRESS_IP>/32 \
+  --description="Allow traffic to Aileron enclave from server only"
 ```
 
-For production, restrict `--source-ranges` to the IP range of your Aileron server.
+Replace `<SERVER_EGRESS_IP>` with your Aileron server's static egress IP.
 
-### 7. Get the enclave VM's internal IP
+> **Railway:** Enable static IPs on the server service (requires Pro plan). Find the IP in Railway dashboard → service → Settings → Networking → Static IPs.
+
+### 7. Assign a static external IP
+
+Reserve a static IP so the enclave address survives reboots:
 
 ```sh
-export ENCLAVE_IP=$(gcloud compute instances describe aileron-enclave \
-  --zone=$REGION-a \
-  --format='value(networkInterfaces[0].networkIP)' \
-  --project=$GCP_PROJECT)
+gcloud compute addresses create aileron-enclave-ip \
+  --region=$REGION \
+  --project=$GCP_PROJECT
 
-echo "Enclave URL: http://$ENCLAVE_IP:8443"
+export ENCLAVE_IP=$(gcloud compute addresses describe aileron-enclave-ip \
+  --region=$REGION \
+  --project=$GCP_PROJECT \
+  --format='value(address)')
+
+echo "Enclave IP: $ENCLAVE_IP"
 ```
 
-If the Aileron server runs outside the same VPC, use the external IP or set up a load balancer with TLS.
+Assign it to the VM:
+
+```sh
+# Remove the existing (empty) access config
+gcloud compute instances delete-access-config aileron-enclave \
+  --zone=$REGION-a \
+  --access-config-name="external-nat" \
+  --project=$GCP_PROJECT
+
+# Assign the static IP
+gcloud compute instances add-access-config aileron-enclave \
+  --zone=$REGION-a \
+  --access-config-name="external-nat" \
+  --address=$ENCLAVE_IP \
+  --project=$GCP_PROJECT
+```
+
+The `$ENCLAVE_IP` from this step is what you'll use for `AILERON_ENCLAVE_URL` in the next step. If your server runs **inside the same GCP VPC**, you can use the internal IP instead for lower latency and no egress charges:
+
+```sh
+gcloud compute instances describe aileron-enclave \
+  --zone=$REGION-a \
+  --format='value(networkInterfaces[0].networkIP)' \
+  --project=$GCP_PROJECT
+```
 
 ### 8. Configure the Aileron server
 
-Set these environment variables on the Aileron server service:
+Set these environment variables on your Aileron server (wherever it's hosted):
 
 | Variable | Value |
 |----------|-------|
 | `AILERON_TEE_PROVIDER` | `confidential-space` |
-| `AILERON_ENCLAVE_URL` | `http://<ENCLAVE_IP>:8443` (or internal DNS) |
-| `AILERON_ENCLAVE_IMAGE_DIGEST` | The `sha256:...` digest from step 3 |
-| `AILERON_GCP_PROJECT_ID` | Your GCP project ID |
+| `AILERON_ENCLAVE_URL` | `http://$ENCLAVE_IP:8443` (the static IP from step 7) |
+| `AILERON_ENCLAVE_IMAGE_DIGEST` | `$IMAGE_DIGEST` (captured in step 3) |
+| `AILERON_GCP_PROJECT_ID` | `$GCP_PROJECT` |
 
 ### 9. Verify
 
+The enclave is only reachable from the Aileron server (per the firewall rule in step 6), so verify through the server's TEE status endpoint:
+
 ```sh
-curl http://$ENCLAVE_IP:8443/health
 curl https://api.yourdomain.com/v1/tee/status
 ```
 
@@ -153,6 +218,8 @@ Expected response:
 ```json
 {"enabled":true,"provider":"confidential-space","attested":false,"session_active":false}
 ```
+
+`attested` and `session_active` become `true` after a user unlocks their vault.
 
 ## How attestation works
 
@@ -184,19 +251,15 @@ Expected response:
    ```
 5. The server will re-attest against the new image digest on its next attestation request.
 
-## Hybrid topology: Railway + GCP
+## Hybrid topology
 
-The recommended production topology keeps the Aileron server, UI, docs, and Postgres on Railway (preserving per-branch preview deployments and managed infrastructure), with only the enclave running on GCP Confidential Space.
+The enclave runs on GCP Confidential Space while your Aileron server, UI, and database remain on your preferred hosting platform. Only the enclave requires GCP — everything else stays where it is.
 
 ```
 Browser
   │
   ▼
-Railway (app.withaileron.ai)
-  ├─ server (API, auth, draft pipeline)
-  ├─ ui (SvelteKit)
-  ├─ docs (Astro)
-  └─ Postgres
+Your hosting platform (server, UI, database)
         │
         │  HTTPS (attestation, session, execute)
         ▼
@@ -212,33 +275,6 @@ GCP Confidential Space (enclave)
 Google, Slack, GitHub APIs
 ```
 
-### Firewall configuration
-
-Restrict the enclave VM to accept traffic only from Railway's egress IPs:
-
-```sh
-# Get Railway's egress IPs from their docs or support.
-# As of 2026, Railway uses a set of static egress IPs per region.
-
-gcloud compute firewall-rules update allow-aileron-enclave \
-  --project=$GCP_PROJECT \
-  --source-ranges=<RAILWAY_EGRESS_IP_1>/32,<RAILWAY_EGRESS_IP_2>/32 \
-  --allow=tcp:8443
-```
-
-Contact Railway support or check their [networking docs](https://docs.railway.com/reference/networking) for current egress IP ranges.
-
-### Railway server configuration
-
-Set these environment variables on the Railway server service:
-
-| Variable | Value |
-|----------|-------|
-| `AILERON_TEE_PROVIDER` | `confidential-space` |
-| `AILERON_ENCLAVE_URL` | `http://<ENCLAVE_INTERNAL_IP>:8443` |
-| `AILERON_ENCLAVE_IMAGE_DIGEST` | `sha256:...` (from step 3 above) |
-| `AILERON_GCP_PROJECT_ID` | Your GCP project ID |
-
-If the enclave VM is in a different VPC or region than Railway's egress, use the external IP with TLS (terminate at the enclave or use a load balancer).
+> **Railway note:** Railway supports this topology well — enable static IPs on the server service for the firewall rule, set the 4 TEE env vars, and the server connects to the GCP enclave over the public internet. You keep per-branch preview deployments, managed Postgres, and zero-config deploys.
 
 For design rationale, see [ADR-0010: Zero-Knowledge Vault](/adr/0010-zero-knowledge-vault-trust-model), [ADR-0011: TEE Provider SPI](/adr/0011-tee-provider-spi-and-confidential-space), and [ADR-0012: Auto-Escrow & Session Lifetimes](/adr/0012-auto-escrow-and-decoupled-session-lifetimes).

--- a/test/integration/auth_helper_test.go
+++ b/test/integration/auth_helper_test.go
@@ -151,6 +151,16 @@ func authedPatch(t *testing.T, url string, body any) *http.Response {
 	return resp
 }
 
+// unauthGet sends a GET request without authentication.
+func unauthGet(t *testing.T, url string) *http.Response {
+	t.Helper()
+	resp, err := http.DefaultClient.Get(url)
+	if err != nil {
+		t.Fatalf("GET %s: %v", url, err)
+	}
+	return resp
+}
+
 // authedGet sends an authenticated GET request.
 func authedGet(t *testing.T, url string) *http.Response {
 	t.Helper()

--- a/test/integration/tee_test.go
+++ b/test/integration/tee_test.go
@@ -11,6 +11,32 @@ import (
 	"github.com/ALRubinger/aileron/core/crypto"
 )
 
+func TestTEE_Status_Public(t *testing.T) {
+	// GET /v1/tee/status is public (no auth required).
+	// Verifies the auth middleware skipPath is configured correctly.
+	resp := unauthGet(t, apiURL()+"/v1/tee/status")
+	defer resp.Body.Close()
+
+	if resp.StatusCode != 200 {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200 without auth, got %d: %s", resp.StatusCode, body)
+	}
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		t.Fatalf("reading body: %v", err)
+	}
+
+	var status map[string]any
+	if err := json.Unmarshal(body, &status); err != nil {
+		t.Fatalf("decoding body: %v", err)
+	}
+
+	if status["enabled"] != true {
+		t.Fatalf("expected enabled=true, got %v", status["enabled"])
+	}
+}
+
 func TestTEE_Status(t *testing.T) {
 	// GET /v1/tee/status should return the TEE configuration.
 	// When AILERON_TEE_PROVIDER=local (set in docker-compose), the


### PR DESCRIPTION
## Summary
Improvements from walking through the TEE deployment guide on real GCP infrastructure.

### Deployment guide fixes
- Add billing setup as prerequisite (step 0)
- Derive `GCP_PROJECT` from `gcloud config` instead of manual entry
- Link to Artifact Registry regions + `gcloud artifacts locations list`
- Explain why Artifact Registry (not GitHub CR / Docker Hub)
- Add `gcloud auth configure-docker` for push credentials
- Note CI automation for ongoing builds (#211)
- Reserve static external IP for enclave (survives reboots)
- Restrict firewall to server egress IP only (not `0.0.0.0/0`)
- Make docs provider-agnostic with Railway notes in callouts
- Fix deprecated `--confidential-compute` → `--confidential-compute-type=SEV`
- Remove unreachable direct health check from verify step

### Code changes
- `GET /v1/tee/status` is now public (no auth) — only returns operational metadata
- Enclave Dockerfile simplified to single alpine target (Confidential Space is the VM OS, not a container base image)

## Test plan
- [x] `go build ./core/...` compiles
- [ ] After merge + deploy: `curl https://api.withaileron.ai/v1/tee/status` returns without auth error
- [ ] Enclave reachable from Railway server

🤖 Generated with [Claude Code](https://claude.com/claude-code)