### PR TITLE
ci(enclave): automate enclave image build, push, and deploy

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -1,0 +1,133 @@
+# Enclave Image Publish
+#
+# Builds the enclave container image and pushes it to GCP Artifact Registry,
+# then updates the image digest on Railway and restarts the Confidential Space VM.
+#
+# Prerequisites (one-time manual setup):
+#   1. GCP Workload Identity Federation:
+#      - Create an identity pool and OIDC provider for GitHub Actions
+#      - Grant the pool's service account these roles:
+#        - roles/artifactregistry.writer (push images)
+#        - roles/compute.instanceAdmin.v1 (reset VM) — or a custom role with compute.instances.reset
+#      - See: https://github.com/google-github-actions/auth#workload-identity-federation
+#   2. GitHub repository variables:
+#      - GCP_PROJECT: GCP project ID
+#      - GCP_REGION: Artifact Registry region (e.g., us-central1)
+#      - GCP_WORKLOAD_IDENTITY_PROVIDER: projects/<id>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
+#      - GCP_SERVICE_ACCOUNT: <name>@<project>.iam.gserviceaccount.com
+#      - GCP_ENCLAVE_ZONE: Confidential Space VM zone (e.g., us-central1-a)
+#      - GCP_ENCLAVE_INSTANCE: Confidential Space VM instance name (e.g., aileron-enclave)
+#      - RAILWAY_PROJECT_ID: Railway project ID
+#      - RAILWAY_SERVICE_ID: Railway server service ID
+#      - RAILWAY_ENVIRONMENT_ID: Railway environment ID (production)
+#   3. GitHub repository secrets:
+#      - RAILWAY_TOKEN: Railway API token
+
+name: Enclave Publish
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - "cmd/aileron-enclave/**"
+      - "enclave/**"
+      - "core/**"
+      - "go.work"
+      - "go.work.sum"
+  workflow_dispatch:
+
+concurrency:
+  group: enclave-publish
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  id-token: write
+
+jobs:
+  publish:
+    name: Build, Push & Deploy Enclave
+    runs-on: ubuntu-latest
+    env:
+      REGISTRY: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/aileron-enclave
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v4
+
+      - name: Authenticate to GCP
+        id: gcp-auth
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+
+      - name: Set up gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Login to Artifact Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ vars.GCP_REGION }}-docker.pkg.dev
+          username: oauth2accesstoken
+          password: ${{ steps.gcp-auth.outputs.access_token }}
+
+      - name: Build and push enclave image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: cmd/aileron-enclave/Dockerfile
+          platforms: linux/amd64
+          push: true
+          tags: |
+            ${{ env.REGISTRY }}/aileron-enclave:latest
+            ${{ env.REGISTRY }}/aileron-enclave:${{ github.sha }}
+          cache-from: type=gha,scope=enclave
+          cache-to: type=gha,mode=max,scope=enclave
+
+      - name: Capture image digest
+        id: digest
+        run: |
+          IMAGE_DIGEST=$(gcloud artifacts docker images describe \
+            $REGISTRY/aileron-enclave:latest \
+            --format='value(image_summary.digest)' \
+            --project=${{ vars.GCP_PROJECT }})
+          echo "digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
+          echo "Image digest: $IMAGE_DIGEST"
+
+      - name: Write job summary
+        run: |
+          echo "## Enclave Image Published" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "| Field | Value |" >> "$GITHUB_STEP_SUMMARY"
+          echo "|-------|-------|" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Registry** | \`$REGISTRY/aileron-enclave\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Tag** | \`${{ github.sha }}\` |" >> "$GITHUB_STEP_SUMMARY"
+          echo "| **Digest** | \`${{ steps.digest.outputs.digest }}\` |" >> "$GITHUB_STEP_SUMMARY"
+
+      - name: Update enclave image digest on Railway
+        env:
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
+        run: |
+          curl -sf -X POST https://backboard.railway.com/graphql/v2 \
+            -H "Authorization: Bearer $RAILWAY_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "query": "mutation($input: VariableUpsertInput!) { variableUpsert(input: $input) }",
+              "variables": {
+                "input": {
+                  "projectId": "${{ vars.RAILWAY_PROJECT_ID }}",
+                  "environmentId": "${{ vars.RAILWAY_ENVIRONMENT_ID }}",
+                  "serviceId": "${{ vars.RAILWAY_SERVICE_ID }}",
+                  "name": "AILERON_ENCLAVE_IMAGE_DIGEST",
+                  "value": "${{ steps.digest.outputs.digest }}"
+                }
+              }
+            }'
+
+      - name: Restart Confidential Space VM
+        run: |
+          gcloud compute instances reset ${{ vars.GCP_ENCLAVE_INSTANCE }} \
+            --zone=${{ vars.GCP_ENCLAVE_ZONE }} \
+            --project=${{ vars.GCP_PROJECT }}

--- a/docs/src/content/docs/deployment/tee-enclave.md
+++ b/docs/src/content/docs/deployment/tee-enclave.md
@@ -68,7 +68,7 @@ gcloud artifacts repositories create aileron-enclave \
 
 ### 3. Build and push the enclave container image
 
-> These are the manual steps for initial setup. For ongoing deployments, this should be automated in CI on merge to main — see [issue #211](https://github.com/ALRubinger/aileron/issues/211).
+> **CI handles this automatically.** The [Enclave Publish](https://github.com/ALRubinger/aileron/actions/workflows/enclave-publish.yml) workflow triggers when enclave-related code is merged to main (or via manual dispatch). It builds the image, pushes it to Artifact Registry, updates `AILERON_ENCLAVE_IMAGE_DIGEST` on Railway, and restarts the Confidential Space VM. The image digest is printed in the workflow run summary. The manual steps below are for initial setup or one-off builds.
 
 Configure Docker to authenticate with Artifact Registry for pushing:
 
@@ -228,15 +228,29 @@ Expected response:
 
 ## Updating the enclave
 
-1. Build and push the new image.
-2. Record the new image digest.
-3. Update `AILERON_ENCLAVE_IMAGE_DIGEST` on the Aileron server.
-4. Restart the Confidential Space VM:
+CI automates the full update cycle when enclave-related code is merged to main:
+
+1. Builds and pushes the new image to Artifact Registry.
+2. Captures the image digest.
+3. Updates `AILERON_ENCLAVE_IMAGE_DIGEST` on Railway via the Railway API.
+4. Restarts the Confidential Space VM (`gcloud compute instances reset`).
+5. The server re-attests against the new image digest on its next attestation request.
+
+You can also trigger the workflow manually from the [Actions tab](https://github.com/ALRubinger/aileron/actions/workflows/enclave-publish.yml) or via CLI:
+
+```sh
+gh workflow run enclave-publish.yml
+```
+
+For manual updates (e.g., without CI), the steps are:
+
+1. Build and push the new image (see step 3 above).
+2. Update `AILERON_ENCLAVE_IMAGE_DIGEST` on the Aileron server.
+3. Restart the Confidential Space VM:
    ```sh
-   gcloud compute instances stop aileron-enclave --zone=$REGION-a --project=$GCP_PROJECT
-   gcloud compute instances start aileron-enclave --zone=$REGION-a --project=$GCP_PROJECT
+   gcloud compute instances reset aileron-enclave --zone=$REGION-a --project=$GCP_PROJECT
    ```
-5. The server will re-attest against the new image digest on its next attestation request.
+4. The server will re-attest against the new image digest on its next attestation request.
 
 ## Hybrid topology
 


### PR DESCRIPTION
## Summary

- Add `enclave-publish.yml` workflow that builds the enclave image, pushes to GCP Artifact Registry, updates `AILERON_ENCLAVE_IMAGE_DIGEST` on Railway, and restarts the Confidential Space VM
- Triggers automatically when enclave-related code (`cmd/aileron-enclave/`, `enclave/`, `core/`) is merged to main, or via manual `workflow_dispatch`
- Uses Workload Identity Federation for keyless GCP auth
- Update TEE deployment docs to reflect CI automation

## One-time setup required

Before the workflow can run, configure:
- GCP Workload Identity Federation (identity pool + OIDC provider for GitHub Actions)
- GitHub repository variables: `GCP_PROJECT`, `GCP_REGION`, `GCP_WORKLOAD_IDENTITY_PROVIDER`, `GCP_SERVICE_ACCOUNT`, `GCP_ENCLAVE_ZONE`, `GCP_ENCLAVE_INSTANCE`, `RAILWAY_PROJECT_ID`, `RAILWAY_SERVICE_ID`, `RAILWAY_ENVIRONMENT_ID`
- GitHub repository secret: `RAILWAY_TOKEN`

All prerequisites are documented in the workflow header comment.

## Test plan

- [ ] Verify workflow YAML syntax is valid
- [ ] Configure GCP WIF and GitHub variables/secrets
- [ ] Trigger manually via `gh workflow run enclave-publish.yml`
- [ ] Confirm image appears in Artifact Registry with correct tags
- [ ] Confirm Railway env var is updated with new digest
- [ ] Confirm Confidential Space VM restarts and pulls new image

Closes #211

🤖 Generated with [Claude Code](https://claude.com/claude-code)