### PR TITLE
fix: use correct issuer for Google Confidential Space attestation tokens

### DIFF
--- a/enclave/gcs/verifier.go
+++ b/enclave/gcs/verifier.go
@@ -101,7 +101,7 @@ func (v *Verifier) Verify(ctx context.Context, token string, nonce []byte) (encl
 	}
 
 	// Validate issuer.
-	if claims.Iss != "https://confidentialcomputing.googleapis.com" {
+	if claims.Iss != "https://accounts.google.com" {
 		return enclave.AttestationClaims{}, fmt.Errorf("gcs: unexpected issuer %q", claims.Iss)
 	}
 

--- a/enclave/gcs/verifier_test.go
+++ b/enclave/gcs/verifier_test.go
@@ -79,7 +79,7 @@ func TestVerifyValidToken(t *testing.T) {
 	nonceB64 := base64.RawURLEncoding.EncodeToString(nonce)
 
 	token := buildTestJWT(t, key, kid, map[string]any{
-		"iss":          "https://confidentialcomputing.googleapis.com",
+		"iss":          "https://accounts.google.com",
 		"exp":          time.Now().Add(time.Hour).Unix(),
 		"iat":          time.Now().Unix(),
 		"eat_nonce":    []string{nonceB64},
@@ -113,7 +113,7 @@ func TestVerifyExpiredToken(t *testing.T) {
 
 	nonce := []byte("nonce")
 	token := buildTestJWT(t, key, kid, map[string]any{
-		"iss":       "https://confidentialcomputing.googleapis.com",
+		"iss":       "https://accounts.google.com",
 		"exp":       time.Now().Add(-time.Hour).Unix(),
 		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
 	})
@@ -152,7 +152,7 @@ func TestVerifyNonceMismatch(t *testing.T) {
 	defer server.Close()
 
 	token := buildTestJWT(t, key, kid, map[string]any{
-		"iss":       "https://confidentialcomputing.googleapis.com",
+		"iss":       "https://accounts.google.com",
 		"exp":       time.Now().Add(time.Hour).Unix(),
 		"eat_nonce": []string{"wrong-nonce"},
 	})
@@ -172,7 +172,7 @@ func TestVerifyImageDigestMismatch(t *testing.T) {
 
 	nonce := []byte("nonce")
 	token := buildTestJWT(t, key, kid, map[string]any{
-		"iss":          "https://confidentialcomputing.googleapis.com",
+		"iss":          "https://accounts.google.com",
 		"exp":          time.Now().Add(time.Hour).Unix(),
 		"eat_nonce":    []string{base64.RawURLEncoding.EncodeToString(nonce)},
 		"image_digest": "sha256:wrong",
@@ -205,7 +205,7 @@ func TestVerifyProjectIDMismatch(t *testing.T) {
 
 	nonce := []byte("nonce")
 	token := buildTestJWT(t, key, kid, map[string]any{
-		"iss":          "https://confidentialcomputing.googleapis.com",
+		"iss":          "https://accounts.google.com",
 		"exp":          time.Now().Add(time.Hour).Unix(),
 		"eat_nonce":    []string{base64.RawURLEncoding.EncodeToString(nonce)},
 		"image_digest": "sha256:abc",
@@ -230,7 +230,7 @@ func TestVerifyKeyNotFound(t *testing.T) {
 	nonce := []byte("nonce")
 	// Token uses kid "other-key" which doesn't exist in JWKS.
 	token := buildTestJWT(t, key, "other-key", map[string]any{
-		"iss":       "https://confidentialcomputing.googleapis.com",
+		"iss":       "https://accounts.google.com",
 		"exp":       time.Now().Add(time.Hour).Unix(),
 		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
 	})
@@ -257,7 +257,7 @@ func TestVerifyWithNowFunc(t *testing.T) {
 
 	nonce := []byte("nonce")
 	token := buildTestJWT(t, key, kid, map[string]any{
-		"iss":       "https://confidentialcomputing.googleapis.com",
+		"iss":       "https://accounts.google.com",
 		"exp":       time.Now().Add(time.Hour).Unix(),
 		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
 	})
@@ -281,7 +281,7 @@ func TestVerifyWithCustomHTTPClient(t *testing.T) {
 
 	nonce := []byte("nonce")
 	token := buildTestJWT(t, key, kid, map[string]any{
-		"iss":       "https://confidentialcomputing.googleapis.com",
+		"iss":       "https://accounts.google.com",
 		"exp":       time.Now().Add(time.Hour).Unix(),
 		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
 	})
@@ -333,7 +333,7 @@ func TestVerifyES256Token(t *testing.T) {
 	// Build ES256 JWT.
 	header, _ := json.Marshal(map[string]string{"alg": "ES256", "kid": kid})
 	claims, _ := json.Marshal(map[string]any{
-		"iss":       "https://confidentialcomputing.googleapis.com",
+		"iss":       "https://accounts.google.com",
 		"exp":       time.Now().Add(time.Hour).Unix(),
 		"eat_nonce": []string{nonceB64},
 	})
@@ -391,7 +391,7 @@ func TestVerifyWrongSignature(t *testing.T) {
 
 	nonce := []byte("nonce")
 	token := buildTestJWT(t, key1, kid, map[string]any{
-		"iss":       "https://confidentialcomputing.googleapis.com",
+		"iss":       "https://accounts.google.com",
 		"exp":       time.Now().Add(time.Hour).Unix(),
 		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
 	})

--- a/ui/src/lib/crypto/attestation.test.ts
+++ b/ui/src/lib/crypto/attestation.test.ts
@@ -72,7 +72,7 @@ describe('verifyAttestation', () => {
 
 		it('verifies a valid RS256 JWT', async () => {
 			const claims = {
-				iss: 'https://confidentialcomputing.googleapis.com',
+				iss: 'https://accounts.google.com',
 				exp: Math.floor(Date.now() / 1000) + 3600
 			};
 			const token = await createSignedJWT(claims, keyPair, kid, 'RS256');
@@ -95,7 +95,7 @@ describe('verifyAttestation', () => {
 
 		it('throws on expired token', async () => {
 			const claims = {
-				iss: 'https://confidentialcomputing.googleapis.com',
+				iss: 'https://accounts.google.com',
 				exp: Math.floor(Date.now() / 1000) - 60
 			};
 			const token = await createSignedJWT(claims, keyPair, kid, 'RS256');
@@ -114,7 +114,7 @@ describe('verifyAttestation', () => {
 			);
 
 			const claims = {
-				iss: 'https://confidentialcomputing.googleapis.com',
+				iss: 'https://accounts.google.com',
 				exp: Math.floor(Date.now() / 1000) + 3600
 			};
 			const token = await createSignedJWT(claims, keyPair, kid, 'RS256');
@@ -126,14 +126,14 @@ describe('verifyAttestation', () => {
 
 		it('throws on tampered payload', async () => {
 			const claims = {
-				iss: 'https://confidentialcomputing.googleapis.com',
+				iss: 'https://accounts.google.com',
 				exp: Math.floor(Date.now() / 1000) + 3600
 			};
 			const token = await createSignedJWT(claims, keyPair, kid, 'RS256');
 
 			// Tamper with the payload.
 			const parts = token.split('.');
-			const tamperedClaims = { ...claims, iss: 'https://confidentialcomputing.googleapis.com', extra: 'tampered' };
+			const tamperedClaims = { ...claims, iss: 'https://accounts.google.com', extra: 'tampered' };
 			parts[1] = base64UrlEncodeString(JSON.stringify(tamperedClaims));
 			const tampered = parts.join('.');
 
@@ -165,7 +165,7 @@ describe('verifyAttestation', () => {
 
 		it('verifies a valid ES256 JWT', async () => {
 			const claims = {
-				iss: 'https://confidentialcomputing.googleapis.com',
+				iss: 'https://accounts.google.com',
 				exp: Math.floor(Date.now() / 1000) + 3600
 			};
 			const token = await createSignedJWT(claims, keyPair, kid, 'ES256');
@@ -184,7 +184,7 @@ describe('verifyAttestation', () => {
 		);
 
 		const claims = {
-			iss: 'https://confidentialcomputing.googleapis.com',
+			iss: 'https://accounts.google.com',
 			exp: Math.floor(Date.now() / 1000) + 3600
 		};
 		const header = base64UrlEncodeString(JSON.stringify({ alg: 'EdDSA', kid: 'ed-key' }));
@@ -202,7 +202,7 @@ describe('verifyAttestation', () => {
 		);
 
 		const claims = {
-			iss: 'https://confidentialcomputing.googleapis.com',
+			iss: 'https://accounts.google.com',
 			exp: Math.floor(Date.now() / 1000) + 3600
 		};
 		// Create a minimal JWT (signature won't matter since fetch fails before verify).

--- a/ui/src/lib/crypto/attestation.ts
+++ b/ui/src/lib/crypto/attestation.ts
@@ -25,7 +25,7 @@ export async function verifyAttestation(
 
 // --- JWT verification internals ---
 
-const EXPECTED_ISSUER = 'https://confidentialcomputing.googleapis.com';
+const EXPECTED_ISSUER = 'https://accounts.google.com';
 
 interface JWTClaims {
 	iss: string;


### PR DESCRIPTION
## Summary

- Fix attestation issuer check: real Confidential Space tokens use `iss: "https://accounts.google.com"`, not `"https://confidentialcomputing.googleapis.com"`
- Update both server-side (`enclave/gcs/verifier.go`) and client-side (`ui/src/lib/crypto/attestation.ts`) verifiers
- Update all corresponding tests

## Context

Vault unlock was failing with `Unexpected issuer: https://accounts.google.com` because the hardcoded expected issuer didn't match what Google actually puts in Confidential Space attestation tokens.

## Test plan

- [x] `go test ./enclave/...` — all pass
- [x] `task test:ui` — 53 tests pass
- [ ] Manual: verify vault unlock completes successfully in production

Closes #217

🤖 Generated with [Claude Code](https://claude.com/claude-code)