### PR TITLE
docs: update vault and enclave docs for Phase 3 completion

### DIFF
--- a/docs/src/content/docs/deployment/tee-enclave.md
+++ b/docs/src/content/docs/deployment/tee-enclave.md
@@ -214,8 +214,9 @@ Expected response:
 2. The enclave fetches an OIDC JWT from the GCE metadata service. This token is signed by Google and contains claims about the workload: container image digest, GCP project ID, and hardware model.
 3. The server verifies the JWT signature against Google's JWKS.
 4. The server validates: the issuer is `https://accounts.google.com`, the token is not expired, the nonce matches, and the image digest and project ID match the expected values.
-5. On success, the server and enclave perform an ECDH key exchange to establish an encrypted channel.
-6. Subsequent requests encrypt credentials with the session key before sending them to the enclave. The enclave decrypts inside hardware-isolated memory, executes the connector, and returns only the structured result.
+5. The browser also verifies the JWT signature via `GET /v1/tee/jwks`, which proxies Google's JWKS endpoint (the browser cannot fetch directly due to CORS). This is a defense-in-depth check — the ECDH key exchange in step 6 is the primary cryptographic protection.
+6. On success, the server and enclave perform an ECDH key exchange to establish an encrypted channel.
+7. Subsequent requests encrypt credentials with the session key before sending them to the enclave. The enclave decrypts inside hardware-isolated memory, executes the connector, and returns only the structured result.
 
 ## Network requirements
 

--- a/docs/src/content/docs/getting-started/credential-vault.md
+++ b/docs/src/content/docs/getting-started/credential-vault.md
@@ -9,8 +9,8 @@ Aileron's credential vault uses a zero-knowledge architecture. Your secrets are 
 
 1. You set a vault passphrase. Aileron derives a 256-bit Key Encryption Key (KEK) using Argon2id, stores only the salt and a verification blob, then discards the KEK from memory.
 2. When you store a secret, it's encrypted with AES-256-GCM using your KEK before storage. The database holds only ciphertext.
-3. To use credentials, you verify your passphrase to unlock a time-limited session (default: 24 hours). The KEK is held in memory only for the session duration.
-4. When an agent triggers an action that needs a credential, Aileron decrypts it, makes the call, and discards the plaintext.
+3. To use credentials, you verify your passphrase to unlock a time-limited session (default: 24 hours). When the [zero-knowledge enclave](/getting-started/zero-knowledge-enclave) is enabled, your KEK is transmitted via an end-to-end encrypted channel (ECDH) to hardware-isolated memory — the server never holds it. Without the enclave, the KEK is cached in server memory for the session duration.
+4. When an agent triggers an action that needs a credential, the enclave (or server) decrypts it, makes the call, and discards the plaintext.
 
 ## Managing secrets
 

--- a/docs/src/content/docs/getting-started/zero-knowledge-enclave.md
+++ b/docs/src/content/docs/getting-started/zero-knowledge-enclave.md
@@ -31,13 +31,17 @@ Browser
   ├─ 1. Derive KEK from passphrase (Argon2id, client-side)
   ├─ 2. Verify passphrase locally (decrypt verification blob)
   ├─ 3. Request attestation from enclave
-  ├─ 4. Verify enclave's identity (JWT from Google, image digest check)
+  ├─ 4. Verify enclave's identity:
+  │     a. Validate JWT claims (issuer, expiry)
+  │     b. Fetch JWKS from /v1/tee/jwks (server-proxied)
+  │     c. Verify JWT signature via Web Crypto
   ├─ 5. ECDH key exchange (establish encrypted channel)
   ├─ 6. Encrypt KEK with shared secret, send to enclave
   │
   ▼
 Aileron Server (Railway)
   │  Passes opaque blobs — cannot decrypt
+  │  Proxies Google JWKS for client verification
   ▼
 Enclave (GCP Confidential Space)
   ├─ Receives KEK via encrypted channel


### PR DESCRIPTION
## Summary

- Update `credential-vault.md` to mention TEE path where KEK is transmitted to the enclave via ECDH instead of cached in server memory
- Update `zero-knowledge-enclave.md` to expand the attestation flow diagram with client-side JWKS fetch and signature verification steps
- Update `tee-enclave.md` to add browser-side JWT verification as a step in the attestation flow

Also updated issue #158 to mark Phase 3 as complete with all related PRs.

## Test plan

- [x] Docs-only changes, no code affected
- [ ] After merge, close #158

🤖 Generated with [Claude Code](https://claude.com/claude-code)