### PR TITLE
fix(enclave): handle OAuth providers without refresh tokens and non-JSON responses

### DIFF
--- a/cmd/aileron-enclave/oauth.go
+++ b/cmd/aileron-enclave/oauth.go
@@ -28,6 +28,7 @@ func doOAuthExchange(ctx context.Context, req enclave.OAuthExchangeRequest) (tok
 		return nil, "", "", err
 	}
 	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	httpReq.Header.Set("Accept", "application/json")
 	httpReq.Body = io.NopCloser(stringReader(form.Encode()))
 
 	resp, err := http.DefaultClient.Do(httpReq)
@@ -54,8 +55,8 @@ func doOAuthExchange(ctx context.Context, req enclave.OAuthExchangeRequest) (tok
 		return nil, "", "", fmt.Errorf("parsing token response: %w", err)
 	}
 
-	if tokenData.RefreshToken == "" {
-		return nil, "", "", fmt.Errorf("no refresh token returned; user may need to re-consent")
+	if tokenData.AccessToken == "" {
+		return nil, "", "", fmt.Errorf("no access token returned")
 	}
 
 	return body, tokenData.AccessToken, tokenData.TokenType, nil

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -661,6 +661,107 @@ func TestOAuthExchangeEndpoint(t *testing.T) {
 	}
 }
 
+func TestOAuthExchangeNoRefreshToken(t *testing.T) {
+	// Slack-like provider: returns access_token but no refresh_token.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"access_token": "xoxu-slack-token",
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	resp := postJSON(t, server, "/oauth/exchange", enclave.OAuthExchangeRequest{
+		UserID:        "user-1",
+		Provider:      "slack",
+		Code:          "auth-code",
+		RedirectURI:   "http://localhost/cb",
+		ClientID:      "cid",
+		ClientSecret:  "csec",
+		TokenEndpoint: tokenServer.URL,
+	})
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	result := decodeResp[enclave.OAuthExchangeResponse](t, resp)
+	if result.TokenType != "bearer" {
+		t.Fatalf("expected bearer, got %q", result.TokenType)
+	}
+	if len(result.EncryptedToken) == 0 {
+		t.Fatal("expected non-empty encrypted token")
+	}
+}
+
+func TestOAuthExchangeAcceptJSON(t *testing.T) {
+	// GitHub-like provider: returns JSON only when Accept header is set.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		accept := r.Header.Get("Accept")
+		if accept != "application/json" {
+			// GitHub returns form-encoded without Accept header.
+			w.Header().Set("Content-Type", "application/x-www-form-urlencoded")
+			w.Write([]byte("access_token=gho_xxx&token_type=bearer"))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{
+			"access_token": "gho_xxx",
+			"token_type":   "bearer",
+		})
+	}))
+	defer tokenServer.Close()
+
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	resp := postJSON(t, server, "/oauth/exchange", enclave.OAuthExchangeRequest{
+		UserID:        "user-1",
+		Provider:      "github",
+		Code:          "auth-code",
+		RedirectURI:   "http://localhost/cb",
+		ClientID:      "cid",
+		ClientSecret:  "csec",
+		TokenEndpoint: tokenServer.URL,
+	})
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	result := decodeResp[enclave.OAuthExchangeResponse](t, resp)
+	if len(result.EncryptedToken) == 0 {
+		t.Fatal("expected non-empty encrypted token")
+	}
+
+	// Verify decrypted token has the right access_token.
+	tokenJSON, err := crypto.Decrypt(result.EncryptedToken, userKEK)
+	if err != nil {
+		t.Fatalf("decrypting token: %v", err)
+	}
+	var tokenData map[string]string
+	if err := json.Unmarshal(tokenJSON, &tokenData); err != nil {
+		t.Fatalf("unmarshaling token: %v", err)
+	}
+	if tokenData["access_token"] != "gho_xxx" {
+		t.Fatalf("expected gho_xxx, got %q", tokenData["access_token"])
+	}
+}
+
 func TestOAuthExchangeWithoutKEK(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()


### PR DESCRIPTION
## Summary

Two fixes in the enclave's `OAuthExchange` handler:

- **Send `Accept: application/json`** — GitHub returns `application/x-www-form-urlencoded` by default, causing JSON parse errors. With this header, GitHub (and all other providers) return JSON.
- **Don't require `refresh_token`** — Slack and GitHub use long-lived access tokens without refresh tokens. Now only `access_token` is required.

## Test plan

- [x] `TestOAuthExchangeEndpoint` — existing test with refresh token still passes
- [x] `TestOAuthExchangeNoRefreshToken` — Slack-like provider (no refresh token)
- [x] `TestOAuthExchangeAcceptJSON` — GitHub-like provider (form-encoded without Accept, JSON with)
- [x] All enclave tests pass
- [ ] Manual: connect GitHub account through TEE
- [ ] Manual: connect Slack account through TEE

Closes #226
Closes #227

🤖 Generated with [Claude Code](https://claude.com/claude-code)