### PR TITLE
fix(vault): persist user key material in PostgreSQL instead of memory

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -204,7 +204,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		sessionStore := postgres.NewSessionStore(db)
 		verificationCodeStore := postgres.NewVerificationCodeStore(db)
 
-		userKeyMaterialStore := mem.NewUserKeyMaterialStore()
+		userKeyMaterialStore := postgres.NewUserKeyMaterialStore(db)
 
 		// Wire stores into apiServer for /me endpoints.
 		server.enterprises = enterpriseStore

--- a/core/app/handlers_passphrase_test.go
+++ b/core/app/handlers_passphrase_test.go
@@ -856,6 +856,46 @@ func TestGetVaultStatus_TEESessionUnlocked(t *testing.T) {
 	}
 }
 
+// TestGetVaultStatus_PassphraseSurvivesNewServerInstance verifies that a
+// passphrase set on one apiServer is visible from a second apiServer backed
+// by the same store. This is the contract that was broken when the
+// userKeyMaterialStore used an in-memory store in production wiring —
+// each server restart created a fresh empty store, so has_passphrase was
+// always false after a redeploy.
+func TestGetVaultStatus_PassphraseSurvivesNewServerInstance(t *testing.T) {
+	// Shared backing store — in production this is PostgreSQL.
+	sharedStore := mem.NewUserKeyMaterialStore()
+
+	// Server 1: user sets a passphrase.
+	srv1 := &apiServer{
+		userKeyMaterials: sharedStore,
+		kekSessionCache:  auth.NewKEKSessionCache(24 * time.Hour),
+	}
+	clientSetPassphrase(t, srv1, "correct horse battery staple")
+
+	// Server 2: simulate a restart — new apiServer, same backing store.
+	srv2 := &apiServer{
+		userKeyMaterials: sharedStore,
+		kekSessionCache:  auth.NewKEKSessionCache(24 * time.Hour),
+	}
+
+	w := httptest.NewRecorder()
+	r := authedRequest(http.MethodGet, "/v1/users/me/vault/status", "", testClaims)
+	srv2.GetVaultStatus(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	var resp api.VaultStatusResponse
+	json.NewDecoder(w.Body).Decode(&resp)
+	if !resp.HasPassphrase {
+		t.Error("expected has_passphrase=true after server restart with same backing store")
+	}
+	if !resp.Locked {
+		t.Error("expected locked=true (KEK session cache is fresh)")
+	}
+}
+
 func TestGetVaultStatus_NoPassphrase(t *testing.T) {
 	srv := passphraseServer()
 	srv.kekSessionCache = auth.NewKEKSessionCache(24 * time.Hour)


### PR DESCRIPTION
## Summary

- **Root cause:** `userKeyMaterialStore` in `core/app/app.go` was initialized with the in-memory store (`mem.NewUserKeyMaterialStore()`), so vault passphrase data (salt + KEK verification blob) was lost on every server restart.
- **Effect:** After each restart/redeploy, `GetVaultStatus` returned `has_passphrase: false`, causing the UI to redirect users to the passphrase setup flow on every login.
- **Fix:** Switch to `postgres.NewUserKeyMaterialStore(db)`, consistent with all other auth-related stores in the same block. The PostgreSQL store and `user_key_materials` table already existed — they just weren't wired up.

## Test plan

- [x] `go build ./core/...` passes
- [x] All passphrase/vault handler tests pass (`go test ./core/app/... -run Passphrase`)
- [ ] Deploy and verify: log in, set passphrase, restart server, log in again — should show "Unlock your vault" instead of "Secure your vault"

🤖 Generated with [Claude Code](https://claude.com/claude-code)