### PR TITLE
feat(account): separate Slack user OAuth from bot installation

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -10,7 +10,7 @@
 #        - roles/artifactregistry.writer (push images)
 #        - roles/compute.instanceAdmin.v1 (reset VM) — or a custom role with compute.instances.reset
 #      - See: https://github.com/google-github-actions/auth#workload-identity-federation
-#   2. GitHub repository variables:
+#   2. GitHub repository secrets:
 #      - GCP_PROJECT: GCP project ID
 #      - GCP_REGION: Artifact Registry region (e.g., us-central1)
 #      - GCP_WORKLOAD_IDENTITY_PROVIDER: projects/<id>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
@@ -20,7 +20,6 @@
 #      - RAILWAY_PROJECT_ID: Railway project ID
 #      - RAILWAY_SERVICE_ID: Railway server service ID
 #      - RAILWAY_ENVIRONMENT_ID: Railway environment ID (production)
-#   3. GitHub repository secrets:
 #      - RAILWAY_TOKEN: Railway API token
 
 name: Enclave Publish
@@ -49,7 +48,7 @@ jobs:
     name: Build, Push & Deploy Enclave
     runs-on: ubuntu-latest
     env:
-      REGISTRY: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/aileron-enclave
+      REGISTRY: ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/aileron-enclave
     steps:
       - uses: actions/checkout@v5
 
@@ -60,8 +59,8 @@ jobs:
         id: gcp-auth
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
@@ -69,7 +68,7 @@ jobs:
       - name: Login to Artifact Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ vars.GCP_REGION }}-docker.pkg.dev
+          registry: ${{ secrets.GCP_REGION }}-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
@@ -92,7 +91,7 @@ jobs:
           IMAGE_DIGEST=$(gcloud artifacts docker images describe \
             $REGISTRY/aileron-enclave:latest \
             --format='value(image_summary.digest)' \
-            --project=${{ vars.GCP_PROJECT }})
+            --project=${{ secrets.GCP_PROJECT }})
           echo "digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
           echo "Image digest: $IMAGE_DIGEST"
 
@@ -117,9 +116,9 @@ jobs:
               "query": "mutation($input: VariableUpsertInput!) { variableUpsert(input: $input) }",
               "variables": {
                 "input": {
-                  "projectId": "${{ vars.RAILWAY_PROJECT_ID }}",
-                  "environmentId": "${{ vars.RAILWAY_ENVIRONMENT_ID }}",
-                  "serviceId": "${{ vars.RAILWAY_SERVICE_ID }}",
+                  "projectId": "${{ secrets.RAILWAY_PROJECT_ID }}",
+                  "environmentId": "${{ secrets.RAILWAY_ENVIRONMENT_ID }}",
+                  "serviceId": "${{ secrets.RAILWAY_SERVICE_ID }}",
                   "name": "AILERON_ENCLAVE_IMAGE_DIGEST",
                   "value": "${{ steps.digest.outputs.digest }}"
                 }
@@ -128,6 +127,6 @@ jobs:
 
       - name: Restart Confidential Space VM
         run: |
-          gcloud compute instances reset ${{ vars.GCP_ENCLAVE_INSTANCE }} \
-            --zone=${{ vars.GCP_ENCLAVE_ZONE }} \
-            --project=${{ vars.GCP_PROJECT }}
+          gcloud compute instances reset ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
+            --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
+            --project=${{ secrets.GCP_PROJECT }}

--- a/core/account/slack_service.go
+++ b/core/account/slack_service.go
@@ -33,12 +33,12 @@ var slackUserScopes = []string{
 	"users:read",
 }
 
-// slackBotScopes are the OAuth bot scopes requested for Slack.
-// The bot token is used for posting ephemeral messages (draft previews
-// visible only to the user). The bot is silent — it never posts visible
-// messages. Replies are sent via the user token.
-var slackBotScopes = []string{
-	"chat:write",
+// SlackBotTokenVaultPath returns the vault path for a workspace-level Slack
+// bot token. Bot tokens are stored per-workspace (keyed by team_id), not
+// per-user. The bot is installed once by an admin; each user only authorizes
+// their own user-level scopes.
+func SlackBotTokenVaultPath(teamID string) string {
+	return "slack-workspaces/" + teamID + "/bot-token"
 }
 
 // slackOAuthResponse is the non-standard response from Slack's oauth.v2.access endpoint.
@@ -144,9 +144,11 @@ func (s *SlackService) Providers() []model.ConnectedAccountProvider {
 }
 
 func (s *SlackService) AuthorizationURL(_ context.Context, _ model.ConnectedAccountProvider, state, redirectURL string) (*ConnectResult, error) {
+	// Only request user_scope — omitting scope skips the bot install prompt.
+	// The bot is installed separately by a workspace admin via the Slack App
+	// Directory; each user only authorizes their own user-level access here.
 	params := url.Values{
 		"client_id":    {s.clientID},
-		"scope":        {strings.Join(slackBotScopes, ",")},
 		"user_scope":   {strings.Join(slackUserScopes, ",")},
 		"redirect_uri": {redirectURL},
 		"state":        {state},
@@ -176,16 +178,15 @@ func (s *SlackService) HandleCallback(ctx context.Context, _ model.ConnectedAcco
 		UpdatedAt:      time.Now().UTC(),
 	}
 
-	// Store both user and bot tokens in the vault.
+	// Store only the user token. Bot tokens are stored at the workspace
+	// level (keyed by team_id) during bot installation, not per-user.
 	tokenJSON, err := json.Marshal(map[string]string{
-		"access_token":     resp.AuthedUser.AccessToken,
-		"bot_access_token": resp.AccessToken,
-		"token_type":       resp.AuthedUser.TokenType,
-		"scope":            resp.AuthedUser.Scope,
-		"team_id":          resp.Team.ID,
-		"team_name":        resp.Team.Name,
-		"user_id":          resp.AuthedUser.ID,
-		"bot_user_id":      resp.BotUserID,
+		"access_token": resp.AuthedUser.AccessToken,
+		"token_type":   resp.AuthedUser.TokenType,
+		"scope":        resp.AuthedUser.Scope,
+		"team_id":      resp.Team.ID,
+		"team_name":    resp.Team.Name,
+		"user_id":      resp.AuthedUser.ID,
 	})
 	if err != nil {
 		return nil, fmt.Errorf("marshalling token: %w", err)

--- a/core/account/slack_service_test.go
+++ b/core/account/slack_service_test.go
@@ -5,6 +5,7 @@ import (
 	"encoding/json"
 	"net/http"
 	"net/http/httptest"
+	"net/url"
 	"testing"
 
 	"github.com/ALRubinger/aileron/core/account"
@@ -98,11 +99,30 @@ func TestSlackService_AuthorizationURL(t *testing.T) {
 	if !contains(result.URL, "state123") {
 		t.Errorf("expected state in URL, got %s", result.URL)
 	}
-	if !contains(result.URL, "chat%3Awrite") || !contains(result.URL, "chat:write") {
-		// URL-encoded or not, the scope should be present
-		if !contains(result.URL, "chat") {
-			t.Errorf("expected user scopes in URL, got %s", result.URL)
-		}
+	if !contains(result.URL, "user_scope=") {
+		t.Errorf("expected user_scope parameter in URL, got %s", result.URL)
+	}
+}
+
+func TestSlackService_AuthorizationURL_NoBotScope(t *testing.T) {
+	// The user OAuth flow must NOT include the scope parameter (bot scopes).
+	// Omitting scope causes Slack to skip the bot install prompt and only
+	// ask for user consent.
+	svc := account.NewSlackService("test-client-id", "secret", mem.NewConnectedAccountStore(), vault.NewMemVault())
+	result, err := svc.AuthorizationURL(context.Background(), model.ConnectedAccountProviderSlack, "state123", "http://localhost/callback")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if contains(result.URL, "scope=") && !contains(result.URL, "user_scope=") {
+		t.Errorf("URL should not contain bare scope= parameter (bot scopes), got %s", result.URL)
+	}
+	// More precise: parse the URL and check there's no "scope" key
+	u, err := url.Parse(result.URL)
+	if err != nil {
+		t.Fatalf("failed to parse URL: %v", err)
+	}
+	if u.Query().Get("scope") != "" {
+		t.Errorf("expected no scope parameter (bot scopes), but found: %s", u.Query().Get("scope"))
 	}
 }
 
@@ -172,6 +192,17 @@ func TestSlackService_HandleCallback_Success(t *testing.T) {
 	}
 	if tokenData["team_id"] != "T001TEAM" {
 		t.Errorf("expected T001TEAM in token data, got %s", tokenData["team_id"])
+	}
+	// Bot token must NOT be stored per-user — it lives at the workspace level.
+	if tokenData["bot_access_token"] != "" {
+		t.Errorf("expected no bot_access_token in per-user token data, got %s", tokenData["bot_access_token"])
+	}
+}
+
+func TestSlackBotTokenVaultPath(t *testing.T) {
+	path := account.SlackBotTokenVaultPath("T001TEAM")
+	if path != "slack-workspaces/T001TEAM/bot-token" {
+		t.Errorf("expected slack-workspaces/T001TEAM/bot-token, got %s", path)
 	}
 }
 

--- a/core/app/handlers_drafts.go
+++ b/core/app/handlers_drafts.go
@@ -8,6 +8,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ALRubinger/aileron/core/account"
 	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/store"
@@ -437,9 +438,9 @@ type slackCredentials struct {
 }
 
 // resolveSlackCredentials looks up the user's connected Slack account and
-// retrieves their bot token and Slack user ID from the vault.
-// If the user has an active KEK session, the vault is wrapped with
-// UserScopedVault for transparent decryption.
+// retrieves the workspace bot token and the user's Slack user ID.
+// The bot token is stored at the workspace level (keyed by team_id),
+// not per-user — it is installed once by a workspace admin.
 func (s *apiServer) resolveSlackCredentials(ctx context.Context, userID string) (*slackCredentials, error) {
 	slackProvider := model.ConnectedAccountProviderSlack
 	accounts, err := s.connectedAccounts.List(ctx, store.ConnectedAccountFilter{
@@ -452,25 +453,25 @@ func (s *apiServer) resolveSlackCredentials(ctx context.Context, userID string) 
 
 	acct := accounts[0]
 
-	vlt := s.userVault(userID)
-	secret, err := vlt.Get(ctx, acct.VaultPath())
-	if err != nil {
-		return nil, fmt.Errorf("failed to get vault token: %w", err)
-	}
-
-	var tokenData map[string]string
-	if err := json.Unmarshal(secret.Value, &tokenData); err != nil {
-		return nil, fmt.Errorf("failed to parse token: %w", err)
-	}
-
-	botToken := tokenData["bot_access_token"]
-	if botToken == "" {
-		return nil, fmt.Errorf("no bot token — Slack app needs chat:write bot scope")
-	}
-
 	slackUserID := acct.ExternalUserID
 	if slackUserID == "" {
 		return nil, fmt.Errorf("no slack user ID on connected account")
+	}
+
+	teamID := acct.ExternalTeamID
+	if teamID == "" {
+		return nil, fmt.Errorf("no team ID on connected account for user %s", userID)
+	}
+
+	// Look up the workspace-level bot token (installed by admin, not per-user).
+	botSecret, err := s.vault.Get(ctx, account.SlackBotTokenVaultPath(teamID))
+	if err != nil {
+		return nil, fmt.Errorf("no bot token for workspace %s — an admin must install the Slack app first", teamID)
+	}
+
+	botToken := string(botSecret.Value)
+	if botToken == "" {
+		return nil, fmt.Errorf("empty bot token for workspace %s", teamID)
 	}
 
 	return &slackCredentials{BotToken: botToken, SlackUserID: slackUserID}, nil

--- a/core/app/handlers_drafts_test.go
+++ b/core/app/handlers_drafts_test.go
@@ -229,7 +229,7 @@ func TestDraftAction_Routing(t *testing.T) {
 func newDraftsTestServerWithSend() *apiServer {
 	srv := newDraftsTestServer()
 	enableVaultEncryption(srv, "usr_a")
-	// Set up a connected Slack account + encrypted vault token so send works.
+	// Set up a connected Slack account + encrypted user token so send works.
 	ctx := context.Background()
 	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
 		ID:             "conn_s1",
@@ -237,8 +237,13 @@ func newDraftsTestServerWithSend() *apiServer {
 		Provider:       model.ConnectedAccountProviderSlack,
 		Status:         model.ConnectedAccountStatusActive,
 		ExternalUserID: "U123ABC",
+		ExternalTeamID: "T001TEST",
 	})
-	storeEncryptedToken(srv, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test","bot_access_token":"xoxb-test"}`))
+	storeEncryptedToken(srv, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test"}`))
+	// Store workspace-level bot token (installed by admin, not per-user).
+	srv.vault.Put(ctx, "slack-workspaces/T001TEST/bot-token", []byte("xoxb-test"), vault.Metadata{
+		Type: "slack_bot_token",
+	})
 	// Mock sender so we don't call real Slack.
 	srv.slackSender = func(_ context.Context, token, channel, body, threadTS string) error {
 		return nil
@@ -682,12 +687,13 @@ func TestDeliverEphemeralDraft_NoBotToken(t *testing.T) {
 	enableVaultEncryption(srv, "usr_a")
 	ctx := context.Background()
 
-	// Connected account without bot token.
+	// Connected account exists but no workspace-level bot token installed.
 	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
 		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
-		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123",
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123", ExternalTeamID: "T001",
 	})
 	storeEncryptedToken(srv, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test"}`))
+	// No workspace bot token at slack-workspaces/T001/bot-token.
 
 	var posted bool
 	srv.ephemeralPoster = func(_ context.Context, _ comms.SlackDraftMessage) error {
@@ -697,7 +703,7 @@ func TestDeliverEphemeralDraft_NoBotToken(t *testing.T) {
 
 	srv.deliverEphemeralDraft(ctx, "usr_a", model.Draft{ID: "dft_1", Channel: "C123", DraftBody: "test"})
 	if posted {
-		t.Error("should not post when bot token missing")
+		t.Error("should not post when workspace bot token missing")
 	}
 }
 
@@ -765,9 +771,11 @@ func TestDeliverEphemeralDraft_NoExternalUserID(t *testing.T) {
 	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
 		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
 		Status: model.ConnectedAccountStatusActive,
+		ExternalTeamID: "T001",
 		// ExternalUserID is empty
 	})
-	storeEncryptedToken(srv, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp","bot_access_token":"xoxb"}`))
+	storeEncryptedToken(srv, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp"}`))
+	srv.vault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb"), vault.Metadata{Type: "slack_bot_token"})
 
 	var posted bool
 	srv.ephemeralPoster = func(_ context.Context, _ comms.SlackDraftMessage) error {
@@ -1034,52 +1042,48 @@ func TestResolveSlackCredentials_NoAccount(t *testing.T) {
 	}
 }
 
-func TestResolveSlackCredentials_BadTokenJSON(t *testing.T) {
-	srv := newDraftsTestServer()
-	enableVaultEncryption(srv, "usr_a")
-	ctx := context.Background()
-	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
-		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
-		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123",
-	})
-	storeEncryptedToken(srv, "connected-accounts/usr_a/slack", []byte("not-json"))
-
-	_, err := srv.resolveSlackCredentials(ctx, "usr_a")
-	if err == nil {
-		t.Fatal("expected error for bad token JSON")
-	}
-}
-
 func TestResolveSlackCredentials_NoBotToken(t *testing.T) {
 	srv := newDraftsTestServer()
-	enableVaultEncryption(srv, "usr_a")
 	ctx := context.Background()
 	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
 		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
-		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123",
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123", ExternalTeamID: "T001",
 	})
-	storeEncryptedToken(srv, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test"}`))
+	// No workspace bot token stored — admin hasn't installed the app yet.
 
 	_, err := srv.resolveSlackCredentials(ctx, "usr_a")
 	if err == nil {
-		t.Fatal("expected error when bot token missing")
+		t.Fatal("expected error when workspace bot token missing")
 	}
 }
 
 func TestResolveSlackCredentials_NoExternalUserID(t *testing.T) {
 	srv := newDraftsTestServer()
-	enableVaultEncryption(srv, "usr_a")
 	ctx := context.Background()
 	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
 		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
-		Status: model.ConnectedAccountStatusActive,
+		Status: model.ConnectedAccountStatusActive, ExternalTeamID: "T001",
 		// No ExternalUserID
 	})
-	storeEncryptedToken(srv, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp","bot_access_token":"xoxb"}`))
 
 	_, err := srv.resolveSlackCredentials(ctx, "usr_a")
 	if err == nil {
 		t.Fatal("expected error when external user ID missing")
+	}
+}
+
+func TestResolveSlackCredentials_NoTeamID(t *testing.T) {
+	srv := newDraftsTestServer()
+	ctx := context.Background()
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123",
+		// No ExternalTeamID
+	})
+
+	_, err := srv.resolveSlackCredentials(ctx, "usr_a")
+	if err == nil {
+		t.Fatal("expected error when team ID missing")
 	}
 }
 

--- a/core/app/handlers_slack_interactions_test.go
+++ b/core/app/handlers_slack_interactions_test.go
@@ -79,13 +79,15 @@ func TestInteraction_ApproveDraft(t *testing.T) {
 		DraftBody:   "No, the claims stay the same.",
 	})
 
-	// Seed connected account + encrypted vault token for sending.
+	// Seed connected account + encrypted user token for sending.
 	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
 		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
-		Status: model.ConnectedAccountStatusActive,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U123", ExternalTeamID: "T001TEST",
 	})
 	storeEncryptedToken(srv, "connected-accounts/usr_a/slack",
-		[]byte(`{"access_token":"xoxp-test","bot_access_token":"xoxb-test"}`))
+		[]byte(`{"access_token":"xoxp-test"}`))
+	// Workspace-level bot token (installed by admin).
+	srv.vault.Put(ctx, "slack-workspaces/T001TEST/bot-token", []byte("xoxb-test"), vault.Metadata{Type: "slack_bot_token"})
 
 	payload, _ := json.Marshal(map[string]any{
 		"type": "block_actions",

--- a/test/integration/vault_test.go
+++ b/test/integration/vault_test.go
@@ -17,9 +17,8 @@ func TestVault_TokenStoredAndRetrievableViaAccountLifecycle(t *testing.T) {
 		"external_user_id": "U_VAULT_FULL",
 		"external_team_id": "T_VAULT_FULL",
 		"token": map[string]string{
-			"access_token":     "xoxp-test-vault-token",
-			"bot_access_token": "xoxb-test-vault-bot",
-			"token_type":       "user",
+			"access_token": "xoxp-test-vault-token",
+			"token_type":   "user",
 		},
 	})
 	defer resp.Body.Close()
@@ -72,8 +71,7 @@ func TestVault_GetViaDraftApprove(t *testing.T) {
 		"external_user_id": "U_VAULT_GET",
 		"external_team_id": "T_VAULT_GET",
 		"token": map[string]string{
-			"access_token":     "xoxp-vault-get-test",
-			"bot_access_token": "xoxb-vault-get-test",
+			"access_token": "xoxp-vault-get-test",
 		},
 	})
 	defer acctResp.Body.Close()


### PR DESCRIPTION
## Summary

- **Slack user OAuth** now only requests `user_scope` (omits `scope`), so Slack skips the bot install prompt and only asks for user consent. Bot tokens are stored at the workspace level (`slack-workspaces/{team_id}/bot-token`) and looked up by `team_id` at runtime, not stored per-user.
- **Enclave CI workflow** switched from `vars.*` to `secrets.*` for all repository configuration to avoid exposing GCP project IDs and service account emails in the public repo.

Closes #225, refs #230

## Test plan

- [x] `TestSlackService_AuthorizationURL_NoBotScope` — verifies no `scope` param in OAuth URL
- [x] `TestSlackBotTokenVaultPath` — verifies workspace vault path convention
- [x] `TestSlackService_HandleCallback_Success` — verifies no `bot_access_token` stored per-user
- [x] `TestResolveSlackCredentials_Success` — resolves bot token from workspace vault
- [x] `TestResolveSlackCredentials_NoBotToken` — errors when workspace bot token missing
- [x] `TestResolveSlackCredentials_NoTeamID` — errors when team ID missing on account
- [x] All existing tests pass (`go test ./... -short` green)

🤖 Generated with [Claude Code](https://claude.com/claude-code)