### PR TITLE
ci(enclave): use secrets instead of variables for workflow config

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -10,7 +10,7 @@
 #        - roles/artifactregistry.writer (push images)
 #        - roles/compute.instanceAdmin.v1 (reset VM) — or a custom role with compute.instances.reset
 #      - See: https://github.com/google-github-actions/auth#workload-identity-federation
-#   2. GitHub repository variables:
+#   2. GitHub repository secrets:
 #      - GCP_PROJECT: GCP project ID
 #      - GCP_REGION: Artifact Registry region (e.g., us-central1)
 #      - GCP_WORKLOAD_IDENTITY_PROVIDER: projects/<id>/locations/global/workloadIdentityPools/<pool>/providers/<provider>
@@ -20,7 +20,6 @@
 #      - RAILWAY_PROJECT_ID: Railway project ID
 #      - RAILWAY_SERVICE_ID: Railway server service ID
 #      - RAILWAY_ENVIRONMENT_ID: Railway environment ID (production)
-#   3. GitHub repository secrets:
 #      - RAILWAY_TOKEN: Railway API token
 
 name: Enclave Publish
@@ -49,7 +48,7 @@ jobs:
     name: Build, Push & Deploy Enclave
     runs-on: ubuntu-latest
     env:
-      REGISTRY: ${{ vars.GCP_REGION }}-docker.pkg.dev/${{ vars.GCP_PROJECT }}/aileron-enclave
+      REGISTRY: ${{ secrets.GCP_REGION }}-docker.pkg.dev/${{ secrets.GCP_PROJECT }}/aileron-enclave
     steps:
       - uses: actions/checkout@v5
 
@@ -60,8 +59,8 @@ jobs:
         id: gcp-auth
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ vars.GCP_WORKLOAD_IDENTITY_PROVIDER }}
-          service_account: ${{ vars.GCP_SERVICE_ACCOUNT }}
+          workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
+          service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2
@@ -69,7 +68,7 @@ jobs:
       - name: Login to Artifact Registry
         uses: docker/login-action@v3
         with:
-          registry: ${{ vars.GCP_REGION }}-docker.pkg.dev
+          registry: ${{ secrets.GCP_REGION }}-docker.pkg.dev
           username: oauth2accesstoken
           password: ${{ steps.gcp-auth.outputs.access_token }}
 
@@ -92,7 +91,7 @@ jobs:
           IMAGE_DIGEST=$(gcloud artifacts docker images describe \
             $REGISTRY/aileron-enclave:latest \
             --format='value(image_summary.digest)' \
-            --project=${{ vars.GCP_PROJECT }})
+            --project=${{ secrets.GCP_PROJECT }})
           echo "digest=$IMAGE_DIGEST" >> "$GITHUB_OUTPUT"
           echo "Image digest: $IMAGE_DIGEST"
 
@@ -117,9 +116,9 @@ jobs:
               "query": "mutation($input: VariableUpsertInput!) { variableUpsert(input: $input) }",
               "variables": {
                 "input": {
-                  "projectId": "${{ vars.RAILWAY_PROJECT_ID }}",
-                  "environmentId": "${{ vars.RAILWAY_ENVIRONMENT_ID }}",
-                  "serviceId": "${{ vars.RAILWAY_SERVICE_ID }}",
+                  "projectId": "${{ secrets.RAILWAY_PROJECT_ID }}",
+                  "environmentId": "${{ secrets.RAILWAY_ENVIRONMENT_ID }}",
+                  "serviceId": "${{ secrets.RAILWAY_SERVICE_ID }}",
                   "name": "AILERON_ENCLAVE_IMAGE_DIGEST",
                   "value": "${{ steps.digest.outputs.digest }}"
                 }
@@ -128,6 +127,6 @@ jobs:
 
       - name: Restart Confidential Space VM
         run: |
-          gcloud compute instances reset ${{ vars.GCP_ENCLAVE_INSTANCE }} \
-            --zone=${{ vars.GCP_ENCLAVE_ZONE }} \
-            --project=${{ vars.GCP_PROJECT }}
+          gcloud compute instances reset ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
+            --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
+            --project=${{ secrets.GCP_PROJECT }}


### PR DESCRIPTION
## Summary

- All `vars.*` references in `enclave-publish.yml` changed to `secrets.*` to avoid exposing GCP project IDs, service account emails, and infrastructure details in a public repo
- Workflow comment header consolidated to a single "repository secrets" section

Refs #230

## Test plan

- [ ] Verify secrets are configured in repo settings (Settings → Secrets and variables → Actions → Secrets)
- [ ] Trigger workflow and confirm GCP auth succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)