### PR TITLE
fix(ci): add token_format to GCP auth for Docker registry login

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -61,6 +61,7 @@ jobs:
         with:
           workload_identity_provider: ${{ secrets.GCP_WORKLOAD_IDENTITY_PROVIDER }}
           service_account: ${{ secrets.GCP_SERVICE_ACCOUNT }}
+          token_format: access_token
 
       - name: Set up gcloud
         uses: google-github-actions/setup-gcloud@v2


### PR DESCRIPTION
## Summary

- Add `token_format: access_token` to the `google-github-actions/auth@v2` step in `enclave-publish.yml`
- Without this, the `access_token` output is empty and Docker login fails with "Password required"

Refs #230

## Test plan

- [ ] Enclave Publish workflow passes the "Login to Artifact Registry" step

🤖 Generated with [Claude Code](https://claude.com/claude-code)