### PR TITLE
fix(ci): fail workflow on Railway API errors

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -109,7 +109,7 @@ jobs:
         env:
           RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}
         run: |
-          curl -sf -X POST https://backboard.railway.com/graphql/v2 \
+          RESPONSE=$(curl -sf -X POST https://backboard.railway.com/graphql/v2 \
             -H "Authorization: Bearer $RAILWAY_TOKEN" \
             -H "Content-Type: application/json" \
             -d '{
@@ -123,7 +123,11 @@ jobs:
                   "value": "${{ steps.digest.outputs.digest }}"
                 }
               }
-            }'
+            }')
+          if echo "$RESPONSE" | grep -q '"errors"'; then
+            echo "Railway API error: $RESPONSE" >&2
+            exit 1
+          fi
 
       - name: Restart Confidential Space VM
         run: |


### PR DESCRIPTION
## Summary

- Railway returns HTTP 200 with a JSON error body for auth/permission failures, so `curl -sf` doesn't detect errors
- Now checks the response for an `errors` field and fails the step explicitly

Refs #230

## Test plan

- [ ] Workflow fails visibly when Railway token is invalid
- [ ] Workflow succeeds when Railway token is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)