### PR TITLE
fix(enclave): handle Slack nested user token in OAuth exchange

### DIFF
--- a/cmd/aileron-enclave/oauth.go
+++ b/cmd/aileron-enclave/oauth.go
@@ -50,16 +50,51 @@ func doOAuthExchange(ctx context.Context, req enclave.OAuthExchangeRequest) (tok
 		AccessToken  string `json:"access_token"`
 		TokenType    string `json:"token_type"`
 		RefreshToken string `json:"refresh_token"`
+		// Slack-specific: user token is nested under authed_user.
+		AuthedUser struct {
+			ID          string `json:"id"`
+			AccessToken string `json:"access_token"`
+			Scope       string `json:"scope"`
+			TokenType   string `json:"token_type"`
+		} `json:"authed_user"`
+		Team struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"team"`
 	}
 	if err := json.Unmarshal(body, &tokenData); err != nil {
 		return nil, "", "", fmt.Errorf("parsing token response: %w", err)
 	}
 
-	if tokenData.AccessToken == "" {
+	accessToken = tokenData.AccessToken
+	tokenType = tokenData.TokenType
+	storedJSON := body
+
+	// Slack's oauth.v2.access nests the user token under authed_user.
+	// Normalize to store only the user token fields, matching the direct
+	// (non-TEE) code path in SlackService.HandleCallback.
+	if req.Provider == "slack" && tokenData.AuthedUser.AccessToken != "" {
+		accessToken = tokenData.AuthedUser.AccessToken
+		tokenType = tokenData.AuthedUser.TokenType
+		normalized, err := json.Marshal(map[string]string{
+			"access_token": tokenData.AuthedUser.AccessToken,
+			"token_type":   tokenData.AuthedUser.TokenType,
+			"scope":        tokenData.AuthedUser.Scope,
+			"team_id":      tokenData.Team.ID,
+			"team_name":    tokenData.Team.Name,
+			"user_id":      tokenData.AuthedUser.ID,
+		})
+		if err != nil {
+			return nil, "", "", fmt.Errorf("marshalling normalized token: %w", err)
+		}
+		storedJSON = normalized
+	}
+
+	if accessToken == "" {
 		return nil, "", "", fmt.Errorf("no access token returned")
 	}
 
-	return body, tokenData.AccessToken, tokenData.TokenType, nil
+	return storedJSON, accessToken, tokenType, nil
 }
 
 // doFetchEmail retrieves the user's email from the userinfo endpoint.

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -703,6 +703,76 @@ func TestOAuthExchangeNoRefreshToken(t *testing.T) {
 	}
 }
 
+func TestOAuthExchangeSlackNestedUserToken(t *testing.T) {
+	// Slack oauth.v2.access returns the user token nested under authed_user,
+	// not at the top level. The enclave must extract the user token.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":          true,
+			"token_type":  "bot",
+			"bot_user_id": "U_BOT",
+			"authed_user": map[string]string{
+				"id":           "U_USER",
+				"access_token": "xoxp-user-token",
+				"scope":        "channels:history,channels:read",
+				"token_type":   "user",
+			},
+			"team": map[string]string{
+				"id":   "T001",
+				"name": "Test Workspace",
+			},
+		})
+	}))
+	defer tokenServer.Close()
+
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	resp := postJSON(t, server, "/oauth/exchange", enclave.OAuthExchangeRequest{
+		UserID:        "user-1",
+		Provider:      "slack",
+		Code:          "auth-code",
+		RedirectURI:   "http://localhost/cb",
+		ClientID:      "cid",
+		ClientSecret:  "csec",
+		TokenEndpoint: tokenServer.URL,
+	})
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	result := decodeResp[enclave.OAuthExchangeResponse](t, resp)
+	if result.TokenType != "user" {
+		t.Fatalf("expected token_type 'user', got %q", result.TokenType)
+	}
+
+	// Decrypt and verify the stored token is the normalized user token.
+	tokenJSON, err := crypto.Decrypt(result.EncryptedToken, userKEK)
+	if err != nil {
+		t.Fatalf("decrypting token: %v", err)
+	}
+	var tokenData map[string]string
+	if err := json.Unmarshal(tokenJSON, &tokenData); err != nil {
+		t.Fatalf("unmarshaling token: %v", err)
+	}
+	if tokenData["access_token"] != "xoxp-user-token" {
+		t.Fatalf("expected xoxp-user-token, got %q", tokenData["access_token"])
+	}
+	if tokenData["user_id"] != "U_USER" {
+		t.Fatalf("expected U_USER, got %q", tokenData["user_id"])
+	}
+	if tokenData["team_id"] != "T001" {
+		t.Fatalf("expected T001, got %q", tokenData["team_id"])
+	}
+}
+
 func TestOAuthExchangeAcceptJSON(t *testing.T) {
 	// GitHub-like provider: returns JSON only when Accept header is set.
 	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- Slack's `oauth.v2.access` returns the user token nested under `authed_user`, not at the top level — the generic enclave exchange only checked the top-level `access_token`, causing "no access token returned" errors
- Extract `authed_user.access_token` when provider is `slack` and normalize the stored token JSON to match the non-TEE code path in `SlackService.HandleCallback`
- Added regression test with a realistic Slack response (no top-level access token, user token nested under `authed_user`)

## Test plan
- [x] `TestOAuthExchangeSlackNestedUserToken` — verifies Slack nested token extraction and normalization
- [x] `TestOAuthExchangeNoRefreshToken` — existing test still passes (flat Slack-like response)
- [x] All other OAuth exchange tests pass (standard providers unaffected)
- [x] Full enclave test suite passes (43/43), coverage 80.9%
- [ ] Manual: connect Slack account through the UI and verify callback succeeds

🤖 Generated with [Claude Code](https://claude.com/claude-code)