### PR TITLE
feat(slack): add bot installation callback endpoint

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -298,12 +298,15 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		}
 
 		if authCfg.SlackEnabled() {
+			server.slackClientID = authCfg.SlackClientID
+			server.slackClientSecret = authCfg.SlackClientSecret
 			server.slackSigningSecret = authCfg.SlackSigningSecret
 			server.slackDedup = newSlackEventDedup()
 			server.onSlackMessage = server.handleIncomingSlackMessage
 			mux.HandleFunc("POST /v1/webhooks/slack/events", server.handleSlackEvent)
 			mux.HandleFunc("POST /v1/webhooks/slack/interactions", server.handleSlackInteraction)
-			log.Info("enabled Slack Events API webhook and interaction endpoints")
+			mux.HandleFunc("GET /v1/slack/install/callback", server.handleSlackInstall)
+			log.Info("enabled Slack Events API webhook, interaction, and install endpoints")
 		}
 
 		enforcer := auth.NewStoreEnforcer(enterpriseStore)
@@ -334,6 +337,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			"/v1/tee/jwks":                      true,
 			"/v1/webhooks/slack/events":          true,
 			"/v1/webhooks/slack/interactions":    true,
+			"/v1/slack/install/callback":         true,
 		}
 		handler = auth.Middleware(tokenIssuer, skipPaths)(handler)
 		log.Info("auth middleware enabled")

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -59,7 +59,11 @@ type apiServer struct {
 	ephemeralPoster    EphemeralPoster        // injectable for testing; defaults to comms.PostEphemeralDraft
 	ephemeralTextPoster EphemeralTextPoster   // injectable for testing; defaults to comms.PostEphemeralText
 	threadChecker      ThreadChecker          // injectable for testing; defaults to comms.SlackThreadHasReplies
+	slackClientID      string                  // Slack app client ID (for bot install OAuth exchange)
+	slackClientSecret  string                  // Slack app client secret (for bot install OAuth exchange)
 	slackSigningSecret string                  // Slack Events API signing secret for webhook verification
+	slackBotExchanger  slackBotTokenExchanger  // injectable for testing; defaults to defaultSlackBotTokenExchange
+	slackTokenURL      string                  // overrides slackTokenURL const for testing
 	slackDedup         *slackEventDedup        // deduplication cache for Slack events
 	onSlackMessage     func(ctx context.Context, userID string, msg comms.IncomingMessage) // callback for incoming Slack messages
 	llmConfigs         store.LLMConfigStore   // per-user/per-org LLM provider config

--- a/core/app/handlers_slack_install.go
+++ b/core/app/handlers_slack_install.go
@@ -1,0 +1,165 @@
+package app
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+
+	"github.com/ALRubinger/aileron/core/account"
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+// slackInstallResponse is the HTML page shown after a successful bot installation.
+const slackInstallSuccessHTML = `<!DOCTYPE html>
+<html><head><title>Aileron — Installed</title></head>
+<body style="font-family:system-ui;display:flex;justify-content:center;align-items:center;height:100vh;margin:0">
+<div style="text-align:center">
+<h2>Aileron has been installed in your Slack workspace</h2>
+<p>You can close this tab.</p>
+</div>
+</body></html>`
+
+// slackBotInstallResponse is the Slack oauth.v2.access response when an admin
+// installs the app. The top-level access_token is the bot token.
+type slackBotInstallResponse struct {
+	OK          bool   `json:"ok"`
+	Error       string `json:"error,omitempty"`
+	AccessToken string `json:"access_token"` // bot token (xoxb-...)
+	TokenType   string `json:"token_type"`
+	BotUserID   string `json:"bot_user_id"`
+	Team        struct {
+		ID   string `json:"id"`
+		Name string `json:"name"`
+	} `json:"team"`
+}
+
+// slackBotTokenExchanger exchanges a code for a bot install response.
+type slackBotTokenExchanger func(clientID, clientSecret, code, redirectURI string) (*slackBotInstallResponse, error)
+
+// handleSlackInstall handles GET /v1/slack/install/callback.
+// This is the OAuth redirect endpoint for Slack bot installation. When a
+// workspace admin installs the Aileron app from the Slack App Directory,
+// Slack redirects here with an authorization code. We exchange it for a bot
+// token and store it in the system vault.
+//
+// This endpoint is unauthenticated — the admin may not have an Aileron account.
+func (s *apiServer) handleSlackInstall(w http.ResponseWriter, r *http.Request) {
+	code := r.URL.Query().Get("code")
+	if code == "" {
+		http.Error(w, "missing code parameter", http.StatusBadRequest)
+		return
+	}
+
+	if s.systemVault == nil {
+		s.log.Error("slack install: system vault not configured")
+		http.Error(w, "system vault not configured", http.StatusInternalServerError)
+		return
+	}
+
+	exchanger := s.slackBotExchanger
+	if exchanger == nil {
+		exchanger = s.defaultSlackBotTokenExchange
+	}
+
+	redirectURI := buildRedirectURI(r, "/v1/slack/install/callback")
+	resp, err := exchanger(s.slackClientID, s.slackClientSecret, code, redirectURI)
+	if err != nil {
+		s.log.Error("slack install: token exchange failed", "error", err)
+		http.Error(w, "token exchange failed: "+err.Error(), http.StatusBadGateway)
+		return
+	}
+
+	if resp.AccessToken == "" {
+		s.log.Error("slack install: no bot token in response")
+		http.Error(w, "no bot token returned by Slack", http.StatusBadGateway)
+		return
+	}
+
+	teamID := resp.Team.ID
+	if teamID == "" {
+		s.log.Error("slack install: no team ID in response")
+		http.Error(w, "no team ID returned by Slack", http.StatusBadGateway)
+		return
+	}
+
+	// Store the bot token in the system vault (encrypted at rest).
+	path := account.SlackBotTokenVaultPath(teamID)
+	if err := s.systemVault.Put(r.Context(), path, []byte(resp.AccessToken), vault.Metadata{
+		Type: "slack_bot_token",
+		Labels: map[string]string{
+			"team_id":    teamID,
+			"team_name":  resp.Team.Name,
+			"bot_user_id": resp.BotUserID,
+		},
+	}); err != nil {
+		s.log.Error("slack install: failed to store bot token", "error", err, "team_id", teamID)
+		http.Error(w, "failed to store bot token", http.StatusInternalServerError)
+		return
+	}
+
+	s.log.Info("slack bot installed",
+		"team_id", teamID,
+		"team_name", resp.Team.Name,
+		"bot_user_id", resp.BotUserID)
+
+	w.Header().Set("Content-Type", "text/html; charset=utf-8")
+	w.WriteHeader(http.StatusOK)
+	fmt.Fprint(w, slackInstallSuccessHTML)
+}
+
+// defaultSlackBotTokenExchange performs the Slack OAuth v2 token exchange for
+// bot installation. The top-level access_token in the response is the bot token.
+func (s *apiServer) getSlackTokenURL() string {
+	if s.slackTokenURL != "" {
+		return s.slackTokenURL
+	}
+	return slackTokenURL
+}
+
+func (s *apiServer) defaultSlackBotTokenExchange(clientID, clientSecret, code, redirectURI string) (*slackBotInstallResponse, error) {
+	data := url.Values{
+		"client_id":     {clientID},
+		"client_secret": {clientSecret},
+		"code":          {code},
+		"redirect_uri":  {redirectURI},
+	}
+	resp, err := http.PostForm(s.getSlackTokenURL(), data)
+	if err != nil {
+		return nil, fmt.Errorf("posting to token endpoint: %w", err)
+	}
+	defer resp.Body.Close()
+
+	body, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return nil, fmt.Errorf("reading token response: %w", err)
+	}
+
+	var oauthResp slackBotInstallResponse
+	if err := json.Unmarshal(body, &oauthResp); err != nil {
+		return nil, fmt.Errorf("decoding token response: %w", err)
+	}
+
+	if !oauthResp.OK {
+		return nil, fmt.Errorf("slack oauth error: %s", oauthResp.Error)
+	}
+
+	return &oauthResp, nil
+}
+
+// slackTokenURL is the Slack OAuth v2 token exchange endpoint.
+const slackTokenURL = "https://slack.com/api/oauth.v2.access"
+
+// buildRedirectURI reconstructs the redirect URI from the incoming request.
+func buildRedirectURI(r *http.Request, path string) string {
+	scheme := "https"
+	if r.TLS == nil {
+		if fwd := r.Header.Get("X-Forwarded-Proto"); fwd != "" {
+			scheme = fwd
+		} else {
+			scheme = "http"
+		}
+	}
+	return scheme + "://" + r.Host + path
+}

--- a/core/app/handlers_slack_install_test.go
+++ b/core/app/handlers_slack_install_test.go
@@ -1,0 +1,382 @@
+package app
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/vault"
+)
+
+func newInstallTestServer(t *testing.T) *apiServer {
+	t.Helper()
+	return &apiServer{
+		log:               slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		systemVault:       vault.NewMemVault(),
+		slackClientID:     "test-client-id",
+		slackClientSecret: "test-client-secret",
+	}
+}
+
+func TestHandleSlackInstall_Success(t *testing.T) {
+	srv := newInstallTestServer(t)
+	srv.slackBotExchanger = func(clientID, clientSecret, code, redirectURI string) (*slackBotInstallResponse, error) {
+		if clientID != "test-client-id" {
+			t.Errorf("clientID = %q, want test-client-id", clientID)
+		}
+		if clientSecret != "test-client-secret" {
+			t.Errorf("clientSecret = %q, want test-client-secret", clientSecret)
+		}
+		if code != "test-code-123" {
+			t.Errorf("code = %q, want test-code-123", code)
+		}
+		return &slackBotInstallResponse{
+			OK:          true,
+			AccessToken: "xoxb-test-bot-token",
+			TokenType:   "bot",
+			BotUserID:   "U_BOT",
+			Team:        struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}{"T001", "test-workspace"},
+		}, nil
+	}
+
+	req := httptest.NewRequest("GET", "/v1/slack/install/callback?code=test-code-123", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	resp := w.Result()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, body)
+	}
+
+	// Verify HTML response.
+	body, _ := io.ReadAll(resp.Body)
+	if !strings.Contains(string(body), "installed in your Slack workspace") {
+		t.Errorf("expected success HTML, got: %s", body)
+	}
+
+	// Verify bot token stored in system vault.
+	secret, err := srv.systemVault.Get(context.Background(), "slack-workspaces/T001/bot-token")
+	if err != nil {
+		t.Fatalf("expected bot token in system vault: %v", err)
+	}
+	if string(secret.Value) != "xoxb-test-bot-token" {
+		t.Errorf("stored token = %q, want xoxb-test-bot-token", secret.Value)
+	}
+	if secret.Metadata.Type != "slack_bot_token" {
+		t.Errorf("metadata type = %q, want slack_bot_token", secret.Metadata.Type)
+	}
+	if secret.Metadata.Labels["team_id"] != "T001" {
+		t.Errorf("metadata team_id = %q, want T001", secret.Metadata.Labels["team_id"])
+	}
+	if secret.Metadata.Labels["team_name"] != "test-workspace" {
+		t.Errorf("metadata team_name = %q, want test-workspace", secret.Metadata.Labels["team_name"])
+	}
+	if secret.Metadata.Labels["bot_user_id"] != "U_BOT" {
+		t.Errorf("metadata bot_user_id = %q, want U_BOT", secret.Metadata.Labels["bot_user_id"])
+	}
+}
+
+func TestHandleSlackInstall_MissingCode(t *testing.T) {
+	srv := newInstallTestServer(t)
+
+	req := httptest.NewRequest("GET", "/v1/slack/install/callback", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("expected 400, got %d", w.Code)
+	}
+}
+
+func TestHandleSlackInstall_NoSystemVault(t *testing.T) {
+	srv := newInstallTestServer(t)
+	srv.systemVault = nil
+
+	req := httptest.NewRequest("GET", "/v1/slack/install/callback?code=test", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+func TestHandleSlackInstall_ExchangeFails(t *testing.T) {
+	srv := newInstallTestServer(t)
+	srv.slackBotExchanger = func(_, _, _, _ string) (*slackBotInstallResponse, error) {
+		return nil, io.ErrUnexpectedEOF
+	}
+
+	req := httptest.NewRequest("GET", "/v1/slack/install/callback?code=bad-code", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", w.Code)
+	}
+}
+
+func TestHandleSlackInstall_NoBotToken(t *testing.T) {
+	srv := newInstallTestServer(t)
+	srv.slackBotExchanger = func(_, _, _, _ string) (*slackBotInstallResponse, error) {
+		return &slackBotInstallResponse{
+			OK:   true,
+			Team: struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}{"T001", "ws"},
+		}, nil
+	}
+
+	req := httptest.NewRequest("GET", "/v1/slack/install/callback?code=test", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", w.Code)
+	}
+}
+
+func TestHandleSlackInstall_NoTeamID(t *testing.T) {
+	srv := newInstallTestServer(t)
+	srv.slackBotExchanger = func(_, _, _, _ string) (*slackBotInstallResponse, error) {
+		return &slackBotInstallResponse{
+			OK:          true,
+			AccessToken: "xoxb-token",
+		}, nil
+	}
+
+	req := httptest.NewRequest("GET", "/v1/slack/install/callback?code=test", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("expected 502, got %d", w.Code)
+	}
+}
+
+func TestHandleSlackInstall_OverwritesExistingToken(t *testing.T) {
+	srv := newInstallTestServer(t)
+	ctx := context.Background()
+
+	// Pre-existing bot token.
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-old"), vault.Metadata{Type: "slack_bot_token"})
+
+	srv.slackBotExchanger = func(_, _, _, _ string) (*slackBotInstallResponse, error) {
+		return &slackBotInstallResponse{
+			OK:          true,
+			AccessToken: "xoxb-new",
+			BotUserID:   "U_BOT",
+			Team:        struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}{"T001", "ws"},
+		}, nil
+	}
+
+	req := httptest.NewRequest("GET", "/v1/slack/install/callback?code=reinstall", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	secret, err := srv.systemVault.Get(ctx, "slack-workspaces/T001/bot-token")
+	if err != nil {
+		t.Fatalf("get after overwrite: %v", err)
+	}
+	if string(secret.Value) != "xoxb-new" {
+		t.Errorf("token = %q, want xoxb-new", secret.Value)
+	}
+}
+
+func TestHandleSlackInstall_NoAuthRequired(t *testing.T) {
+	srv := newInstallTestServer(t)
+	srv.slackBotExchanger = func(_, _, _, _ string) (*slackBotInstallResponse, error) {
+		return &slackBotInstallResponse{
+			OK:          true,
+			AccessToken: "xoxb-token",
+			BotUserID:   "U_BOT",
+			Team:        struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}{"T002", "ws"},
+		}, nil
+	}
+
+	// No Authorization header — this endpoint must work without auth.
+	req := httptest.NewRequest("GET", "/v1/slack/install/callback?code=test", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("expected 200 without auth, got %d", w.Code)
+	}
+}
+
+func TestHandleSlackInstall_VaultPutFails(t *testing.T) {
+	srv := newInstallTestServer(t)
+	// Use a failing vault — Get works but Put always fails.
+	srv.systemVault = &failPutVault{}
+	srv.slackBotExchanger = func(_, _, _, _ string) (*slackBotInstallResponse, error) {
+		return &slackBotInstallResponse{
+			OK:          true,
+			AccessToken: "xoxb-token",
+			BotUserID:   "U_BOT",
+			Team: struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}{"T001", "ws"},
+		}, nil
+	}
+
+	req := httptest.NewRequest("GET", "/v1/slack/install/callback?code=test", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("expected 500, got %d", w.Code)
+	}
+}
+
+// failPutVault is a vault that always fails on Put.
+type failPutVault struct{}
+
+func (v *failPutVault) Get(_ context.Context, _ string) (vault.Secret, error) {
+	return vault.Secret{}, nil
+}
+func (v *failPutVault) Put(_ context.Context, _ string, _ []byte, _ vault.Metadata) error {
+	return io.ErrUnexpectedEOF
+}
+func (v *failPutVault) Delete(_ context.Context, _ string) error {
+	return nil
+}
+
+func TestDefaultSlackBotTokenExchange_Success(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Errorf("expected POST, got %s", r.Method)
+		}
+		r.ParseForm()
+		if r.FormValue("client_id") != "cid" {
+			t.Errorf("client_id = %q", r.FormValue("client_id"))
+		}
+		if r.FormValue("code") != "test-code" {
+			t.Errorf("code = %q", r.FormValue("code"))
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":true,"access_token":"xoxb-bot","token_type":"bot","bot_user_id":"U_BOT","team":{"id":"T001","name":"ws"}}`))
+	}))
+	defer mockServer.Close()
+
+	srv := newInstallTestServer(t)
+	srv.slackTokenURL = mockServer.URL
+
+	resp, err := srv.defaultSlackBotTokenExchange("cid", "csecret", "test-code", "http://localhost/callback")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if resp.AccessToken != "xoxb-bot" {
+		t.Errorf("access_token = %q, want xoxb-bot", resp.AccessToken)
+	}
+	if resp.Team.ID != "T001" {
+		t.Errorf("team_id = %q, want T001", resp.Team.ID)
+	}
+}
+
+func TestDefaultSlackBotTokenExchange_SlackError(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"ok":false,"error":"invalid_code"}`))
+	}))
+	defer mockServer.Close()
+
+	srv := newInstallTestServer(t)
+	srv.slackTokenURL = mockServer.URL
+
+	_, err := srv.defaultSlackBotTokenExchange("cid", "csecret", "bad", "http://localhost/callback")
+	if err == nil {
+		t.Fatal("expected error for Slack error response")
+	}
+	if !strings.Contains(err.Error(), "invalid_code") {
+		t.Errorf("error = %q, want to contain invalid_code", err.Error())
+	}
+}
+
+func TestDefaultSlackBotTokenExchange_InvalidJSON(t *testing.T) {
+	mockServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(`not json`))
+	}))
+	defer mockServer.Close()
+
+	srv := newInstallTestServer(t)
+	srv.slackTokenURL = mockServer.URL
+
+	_, err := srv.defaultSlackBotTokenExchange("cid", "csecret", "code", "http://localhost/callback")
+	if err == nil {
+		t.Fatal("expected error for invalid JSON")
+	}
+}
+
+func TestGetSlackTokenURL_Default(t *testing.T) {
+	srv := newInstallTestServer(t)
+	if got := srv.getSlackTokenURL(); got != slackTokenURL {
+		t.Errorf("getSlackTokenURL = %q, want %q", got, slackTokenURL)
+	}
+}
+
+func TestGetSlackTokenURL_Override(t *testing.T) {
+	srv := newInstallTestServer(t)
+	srv.slackTokenURL = "http://localhost:9999/token"
+	if got := srv.getSlackTokenURL(); got != "http://localhost:9999/token" {
+		t.Errorf("getSlackTokenURL = %q, want http://localhost:9999/token", got)
+	}
+}
+
+func TestBuildRedirectURI(t *testing.T) {
+	tests := []struct {
+		name     string
+		url      string
+		header   http.Header
+		path     string
+		expected string
+	}{
+		{
+			name:     "plain http",
+			url:      "http://localhost:8080/v1/slack/install/callback?code=test",
+			path:     "/v1/slack/install/callback",
+			expected: "http://localhost:8080/v1/slack/install/callback",
+		},
+		{
+			name:     "forwarded https",
+			url:      "http://aileron.example.com/v1/slack/install/callback?code=test",
+			header:   http.Header{"X-Forwarded-Proto": {"https"}},
+			path:     "/v1/slack/install/callback",
+			expected: "https://aileron.example.com/v1/slack/install/callback",
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := httptest.NewRequest("GET", tt.url, nil)
+			for k, vs := range tt.header {
+				for _, v := range vs {
+					req.Header.Set(k, v)
+				}
+			}
+			got := buildRedirectURI(req, tt.path)
+			if got != tt.expected {
+				t.Errorf("buildRedirectURI = %q, want %q", got, tt.expected)
+			}
+		})
+	}
+}

--- a/docs/src/content/docs/getting-started/slack-cloud-integration.md
+++ b/docs/src/content/docs/getting-started/slack-cloud-integration.md
@@ -33,11 +33,14 @@ Under **User Token Scopes**, add:
 - `search:read` — search message history for context
 - `users:read` — look up user names
 
-Under **Redirect URLs**, add:
+Under **Redirect URLs**, add both:
 
 ```
-https://api.withaileron.ai/v1/connect/slack/callback
+https://your-domain/v1/connect/slack/callback
+https://your-domain/v1/slack/install/callback
 ```
+
+The first handles user OAuth (connecting individual accounts). The second handles bot installation (when a workspace admin installs the app from the Slack App Directory).
 
 ### App Credentials
 
@@ -49,9 +52,12 @@ From **Basic Information**, note:
 
 ### Install to workspace (admin, once per workspace)
 
-A workspace admin installs the bot once. This grants the bot token (`xoxb-...`) used for ephemeral draft previews.
+A workspace admin installs the bot once. This grants the bot token (`xoxb-...`) needed for Aileron to respond in Slack. The admin can install via:
 
-Sidebar → **Install App** → **Install to Workspace**. Authorize the requested bot scopes.
+- **Slack App Directory** — if public distribution is enabled
+- **Sidebar → Install App → Install to Workspace** — for the development workspace
+
+When the admin authorizes the app, Slack redirects to `https://your-domain/v1/slack/install/callback`. Aileron exchanges the code for a bot token and stores it in the [system vault](/getting-started/credential-vault#system-vault) (encrypted at rest, keyed by workspace). The admin sees a success page and can close the tab.
 
 Individual users do **not** need to install the app — they only connect their own account (step 4), which requests user-level scopes without repeating the bot install prompt.
 


### PR DESCRIPTION
## Summary

- New `GET /v1/slack/install/callback` endpoint — receives the OAuth redirect when a workspace admin installs the Aileron Slack app from the App Directory
- Exchanges the authorization code for a bot token (`xoxb-...`) via Slack's `oauth.v2.access`
- Stores the bot token in the system vault (ADR-0020) at `slack-workspaces/{team_id}/bot-token`, encrypted at rest
- Unauthenticated — the admin installing the app may not have an Aileron account
- Returns an HTML success page ("Aileron has been installed in your Slack workspace")
- Overwrites on reinstallation (token rotation)

## How it works

```
Admin clicks "Install to Workspace" in Slack App Directory
  → Slack shows bot permission consent
  → Admin approves
  → Slack redirects to /v1/slack/install/callback?code=...
  → Aileron exchanges code for bot token
  → Stores in system vault (encrypted at rest)
  → Returns success HTML page
```

## Changes

- `core/app/handlers_slack_install.go` — handler, token exchange, redirect URI helper
- `core/app/handlers_slack_install_test.go` — 8 test cases + redirect URI table test
- `core/app/handlers.go` — new fields: `slackClientID`, `slackClientSecret`, `slackBotExchanger`
- `core/app/app.go` — route registration + JWT skip path
- `docs/getting-started/slack-cloud-integration.md` — updated redirect URLs and install flow

Closes #239

## Test plan

- [x] Success: code exchanged, token stored in system vault with metadata
- [x] Missing code parameter → 400
- [x] System vault not configured → 500
- [x] Token exchange failure → 502
- [x] No bot token in response → 502
- [x] No team ID in response → 502
- [x] Reinstallation overwrites existing token
- [x] Works without authentication (no JWT required)
- [x] Redirect URI construction (plain HTTP, X-Forwarded-Proto)
- [x] All existing tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)