### PR TITLE
docs(slack): add new Slack pages to sidebar navigation

### DIFF
--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -53,6 +53,8 @@ export const navigation: NavItem[] = [
       { label: 'Slack Integration', href: '/getting-started/slack-integration' },
       { label: 'Google Integration', href: '/getting-started/google-integration' },
       { label: 'Slack Cloud Integration', href: '/getting-started/slack-cloud-integration' },
+      { label: 'Slack App Install (Admin)', href: '/getting-started/slack-app-install' },
+      { label: 'Slack Connect (User)', href: '/getting-started/slack-connect' },
       { label: 'GitHub Integration', href: '/getting-started/github-integration' },
       { label: 'Discord Integration', href: '/getting-started/discord-integration' },
       { label: 'Zero-Knowledge Enclave', href: '/getting-started/zero-knowledge-enclave' }


### PR DESCRIPTION
## Summary

- Add "Slack App Install (Admin)" and "Slack Connect (User)" to the Getting Started section of the docs sidebar
- These pages were created in #248 but not added to `docs/src/lib/navigation.ts`

## Test plan

- [ ] Verify sidebar shows the two new entries below "Slack Cloud Integration"

🤖 Generated with [Claude Code](https://claude.com/claude-code)