### PR TITLE
docs(slack): restructure for single published app model

### DIFF
--- a/docs/src/content/docs/getting-started/slack-app-install.md
+++ b/docs/src/content/docs/getting-started/slack-app-install.md
@@ -1,150 +1,36 @@
 ---
-title: "Installing the Aileron Slack App"
-description: "Workspace admin guide: create, configure, and install the Aileron Slack app"
+title: "Installing Aileron to Your Slack Workspace"
+description: "Workspace admin guide: install the Aileron app from the Slack App Directory"
 ---
 
-This guide is for **workspace admins** (or the developer deploying Aileron). It covers creating the Slack app, configuring the Aileron server, and installing the bot to your workspace.
+This guide is for **workspace admins** who want to add Aileron to their Slack workspace. It takes about a minute.
 
-Once complete, users can [connect their Slack accounts](/getting-started/slack-connect) to start using Aileron.
+Once installed, users in your workspace can [connect their Slack accounts](/getting-started/slack-connect) to start drafting replies, asking questions, and writing messages with AI.
 
-For an overview of what the integration does, see [Slack Cloud Integration](/getting-started/slack-cloud-integration).
+For an overview of what Aileron does in Slack, see [Slack Cloud Integration](/getting-started/slack-cloud-integration).
 
-## 1. Create a Slack App
+## Install from the Slack App Directory
 
-Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app from scratch.
+1. Visit the [Aileron app page](https://slack.com/apps) in the Slack App Directory
+2. Click **Install to Workspace**
+3. Review the requested permissions and click **Allow**
 
-### Enable Agents & AI Apps
+That's it. Aileron is now available in your workspace.
 
-Sidebar → **Agents & AI Apps** → toggle ON. This enables the agent DM experience with suggested prompts, thinking indicators, and streaming responses.
+## What happens during installation
 
-### OAuth & Permissions
+- Slack grants Aileron a **bot token** for your workspace
+- Aileron stores this token in its [system vault](/getting-started/credential-vault#system-vault) (encrypted at rest, keyed by your workspace ID)
+- The Aileron bot appears in your workspace's app list
+- Users can open a DM with Aileron, use the `/aileron` command, and see the "Draft reply with Aileron" message shortcut
 
-Under **Bot Token Scopes**, add:
-
-- `assistant:write` — agent thread interactions (auto-added when Agents feature is enabled)
-- `chat:write` — post messages and stream responses
-- `im:history` — receive DM messages from users
-- `commands` — register slash commands
-
-Under **User Token Scopes**, add:
-
-- `channels:history` — read messages in public channels
-- `channels:read` — list channels and their info
-- `chat:write` — send messages as the user
-- `search:read` — search message history for context
-- `users:read` — look up user names
-
-Under **Redirect URLs**, add both:
-
-```
-https://your-domain/v1/connect/slack/callback
-https://your-domain/v1/slack/install/callback
-```
-
-The first handles user OAuth (when individual users connect their accounts). The second handles bot installation (this guide).
-
-### App Credentials
-
-From **Basic Information**, note:
-
-- **Client ID** → `SLACK_CLIENT_ID`
-- **Client Secret** → `SLACK_CLIENT_SECRET`
-- **Signing Secret** → `SLACK_SIGNING_SECRET`
-
-### Enable public distribution
-
-By default, a Slack app can only be installed in the workspace where it was created. To allow users from any workspace to connect:
-
-1. Sidebar → **Manage Distribution**
-2. Under "Share Your App with Other Workspaces", ensure all checklist items are complete
-3. Click **Activate Public Distribution**
-
-Without this step, users outside the development workspace will see `invalid_team_for_non_distributed_app` when trying to connect.
-
-> **Do NOT configure Event Subscriptions, Interactivity, or Slash Commands yet.** The Aileron server must be running first — see step 3.
-
-## 2. Configure environment variables
-
-Set these on your Aileron cloud server:
-
-```sh
-SLACK_CLIENT_ID=your-client-id
-SLACK_CLIENT_SECRET=your-client-secret
-SLACK_SIGNING_SECRET=your-signing-secret
-
-# For AI-powered draft generation:
-ANTHROPIC_API_KEY=sk-ant-your-key
-
-# Optional — these are the defaults:
-AILERON_LLM_MODEL_RESEARCH=claude-haiku-4-5-20251001   # fast model for tool-call decisions
-AILERON_LLM_MODEL_SYNTHESIS=claude-sonnet-4-6           # capable model for composing the reply
-```
-
-The draft pipeline uses two models: a fast model gathers context via tool calls (research), and a capable model composes the reply in your voice (synthesis). This keeps latency low without sacrificing quality.
-
-You also need `AILERON_SYSTEM_VAULT_KEY` configured — the Slack bot token (from workspace installation) is stored in the [system vault](/getting-started/credential-vault#system-vault), which requires this key for at-rest encryption.
-
-Verify the server logs show:
-
-```
-enabled Slack connected accounts and source connector
-enabled cloud draft generation  research_model=claude-haiku-4-5-20251001  synthesis_model=claude-sonnet-4-6
-enabled Slack Events API webhook, interaction, command, and install endpoints
-```
-
-## 3. Enable Event Subscriptions, Interactivity, and Slash Commands
-
-The server must be running before this step — Slack sends verification challenges immediately.
-
-### Event Subscriptions
-
-1. Sidebar → **Event Subscriptions** → toggle ON
-2. **Request URL:** `https://your-domain/v1/webhooks/slack/events`
-3. Wait for the green checkmark ✓
-4. Under **Subscribe to bot events**, add:
-   - `assistant_thread_started`
-   - `assistant_thread_context_changed`
-   - `message.im`
-5. Click **Save Changes**
-
-### Interactivity & Shortcuts
-
-1. Sidebar → **Interactivity & Shortcuts** → toggle ON
-2. **Request URL:** `https://your-domain/v1/webhooks/slack/interactions`
-3. Under **Shortcuts**, create a **Message Shortcut**:
-   - **Name:** Draft reply with Aileron
-   - **Short Description:** Generate an AI-drafted reply to this message
-   - **Callback ID:** `draft_reply`
-4. Click **Save Changes**
-
-### Slash Commands
-
-1. Sidebar → **Slash Commands** → **Create New Command**
-2. **Command:** `/aileron`
-3. **Request URL:** `https://your-domain/v1/webhooks/slack/commands`
-4. **Short Description:** Draft messages or ask questions with AI
-5. **Usage Hint:** `[draft a reply | ask a question]`
-6. Click **Save**
-
-## 4. Install to workspace
-
-Install the bot to the workspace. This grants the bot token (`xoxb-...`) needed for Aileron to respond in Slack.
-
-- **Sidebar → Install App → Install to Workspace** (or **Reinstall** if updating an existing install)
-
-When you authorize the app, Slack redirects to `https://your-domain/v1/slack/install/callback`. Aileron exchanges the code for a bot token and stores it in the [system vault](/getting-started/credential-vault#system-vault) (encrypted at rest, keyed by workspace). You'll see a success page and can close the tab.
-
-Users do **not** need to repeat this step — they only [connect their own accounts](/getting-started/slack-connect).
+The bot token allows Aileron to post messages, stream responses, and set agent thread status. It does **not** give Aileron access to read messages in channels — that requires each user to [connect their own account](/getting-started/slack-connect) individually.
 
 ## Troubleshooting
 
 | Symptom | Likely cause |
 |---------|-------------|
-| `invalid_team_for_non_distributed_app` | Public distribution not enabled |
-| url_verification fails | Server not running, wrong URL, signing secret mismatch |
-| No events arriving | App not installed, event subscriptions not saved, Agents feature not enabled |
-| Agent DM shows no suggested prompts | `assistant_thread_started` event not subscribed, or bot token missing from system vault |
-| Message shortcut missing from ⋯ menu | Shortcut not registered in Slack app settings, or callback_id mismatch |
-| `/aileron` command not found | Slash command not registered, wrong request URL |
-| Draft generated but modal doesn't update | `trigger_id` expired (>3s), check server logs for modal update errors |
-| Interactivity buttons don't work | Interactivity not enabled, wrong Request URL |
+| "This app is not available for your workspace" | The app may not be published to the App Directory yet — contact the Aileron team |
+| Install succeeds but Aileron doesn't respond | Check that the Aileron server is running and the install callback URL is reachable |
+| Users can't find Aileron in Slack | The app is installed but users need to search for "Aileron" in Apps or use `/aileron` |
+| `/aileron` command not found | Try reinstalling the app, or check that the command is registered |

--- a/docs/src/content/docs/getting-started/slack-cloud-integration.md
+++ b/docs/src/content/docs/getting-started/slack-cloud-integration.md
@@ -35,9 +35,9 @@ In all cases, replies are sent as **you** (via your user token), not as the bot.
 
 Setup has two parts, performed by different people:
 
-1. **[Installing the Aileron Slack App](/getting-started/slack-app-install)** — A workspace admin creates and configures the Slack app, sets up the Aileron server, and installs the bot to the workspace. Done once per workspace.
+1. **[Install Aileron to your workspace](/getting-started/slack-app-install)** — A workspace admin installs Aileron from the Slack App Directory. One click, done once per workspace.
 
-2. **[Connecting your Slack account](/getting-started/slack-connect)** — Each user connects their own Slack account to Aileron via OAuth. Takes under a minute.
+2. **[Connect your Slack account](/getting-started/slack-connect)** — Each user connects their own Slack account to Aileron via OAuth. Takes under a minute.
 
 ## Architecture
 

--- a/docs/src/content/docs/getting-started/slack-connect.md
+++ b/docs/src/content/docs/getting-started/slack-connect.md
@@ -3,7 +3,7 @@ title: "Connecting Your Slack Account"
 description: "Connect your Slack account to Aileron and start drafting"
 ---
 
-This guide is for **users** who want to use Aileron in Slack. A workspace admin must have already [installed the Aileron Slack app](/getting-started/slack-app-install) to your workspace.
+This guide is for **users** who want to use Aileron in Slack. A workspace admin must have already [installed Aileron from the Slack App Directory](/getting-started/slack-app-install) to your workspace.
 
 For an overview of what the integration does, see [Slack Cloud Integration](/getting-started/slack-cloud-integration).
 

--- a/docs/src/content/docs/operations/slack-app-configuration.md
+++ b/docs/src/content/docs/operations/slack-app-configuration.md
@@ -1,0 +1,143 @@
+---
+title: "Slack App Configuration"
+description: "Creating and configuring the Aileron Slack app for the App Directory"
+---
+
+This page documents how to create, configure, and publish the Aileron Slack app. This is an **Aileron developer/ops** task — workspace admins and users don't need this page.
+
+- Workspace admins: see [Installing Aileron to your workspace](/getting-started/slack-app-install)
+- Users: see [Connecting your Slack account](/getting-started/slack-connect)
+
+## Create the Slack app
+
+Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app from scratch.
+
+### Enable Agents & AI Apps
+
+Sidebar → **Agents & AI Apps** → toggle ON. This enables the agent DM experience with suggested prompts, thinking indicators, and streaming responses.
+
+### OAuth & Permissions
+
+Under **Bot Token Scopes**, add:
+
+- `assistant:write` — agent thread interactions (auto-added when Agents feature is enabled)
+- `chat:write` — post messages and stream responses
+- `im:history` — receive DM messages from users
+- `commands` — register slash commands
+
+Under **User Token Scopes**, add:
+
+- `channels:history` — read messages in public channels
+- `channels:read` — list channels and their info
+- `chat:write` — send messages as the user
+- `search:read` — search message history for context
+- `users:read` — look up user names
+
+Under **Redirect URLs**, add both:
+
+```
+https://your-domain/v1/connect/slack/callback
+https://your-domain/v1/slack/install/callback
+```
+
+The first handles user OAuth (when individual users connect their accounts). The second handles workspace bot installation.
+
+### App Credentials
+
+From **Basic Information**, note:
+
+- **Client ID** → `SLACK_CLIENT_ID`
+- **Client Secret** → `SLACK_CLIENT_SECRET`
+- **Signing Secret** → `SLACK_SIGNING_SECRET`
+
+## Configure environment variables
+
+Set these on the Aileron cloud server:
+
+```sh
+SLACK_CLIENT_ID=your-client-id
+SLACK_CLIENT_SECRET=your-client-secret
+SLACK_SIGNING_SECRET=your-signing-secret
+
+# For AI-powered draft generation:
+ANTHROPIC_API_KEY=sk-ant-your-key
+
+# Optional — these are the defaults:
+AILERON_LLM_MODEL_RESEARCH=claude-haiku-4-5-20251001   # fast model for tool-call decisions
+AILERON_LLM_MODEL_SYNTHESIS=claude-sonnet-4-6           # capable model for composing the reply
+```
+
+The draft pipeline uses two models: a fast model gathers context via tool calls (research), and a capable model composes the reply in your voice (synthesis).
+
+You also need `AILERON_SYSTEM_VAULT_KEY` configured — the Slack bot token (from workspace installation) is stored in the [system vault](/getting-started/credential-vault#system-vault), which requires this key for at-rest encryption.
+
+Verify the server logs show:
+
+```
+enabled Slack connected accounts and source connector
+enabled cloud draft generation  research_model=claude-haiku-4-5-20251001  synthesis_model=claude-sonnet-4-6
+enabled Slack Events API webhook, interaction, command, and install endpoints
+```
+
+## Enable Event Subscriptions, Interactivity, and Slash Commands
+
+The Aileron server must be running before this step — Slack sends verification challenges immediately.
+
+### Event Subscriptions
+
+1. Sidebar → **Event Subscriptions** → toggle ON
+2. **Request URL:** `https://your-domain/v1/webhooks/slack/events`
+3. Wait for the green checkmark
+4. Under **Subscribe to bot events**, add:
+   - `assistant_thread_started`
+   - `assistant_thread_context_changed`
+   - `message.im`
+5. Click **Save Changes**
+
+### Interactivity & Shortcuts
+
+1. Sidebar → **Interactivity & Shortcuts** → toggle ON
+2. **Request URL:** `https://your-domain/v1/webhooks/slack/interactions`
+3. Under **Shortcuts**, create a **Message Shortcut**:
+   - **Name:** Draft reply with Aileron
+   - **Short Description:** Generate an AI-drafted reply to this message
+   - **Callback ID:** `draft_reply`
+4. Click **Save Changes**
+
+### Slash Commands
+
+1. Sidebar → **Slash Commands** → **Create New Command**
+2. **Command:** `/aileron`
+3. **Request URL:** `https://your-domain/v1/webhooks/slack/commands`
+4. **Short Description:** Draft messages or ask questions with AI
+5. **Usage Hint:** `[draft a reply | ask a question]`
+6. Click **Save**
+
+## Publish to the Slack App Directory
+
+1. Sidebar → **Manage Distribution**
+2. Under "Share Your App with Other Workspaces", ensure all checklist items are complete (redirect URLs, bot user, app description, privacy policy, etc.)
+3. Click **Activate Public Distribution**
+4. Submit for Slack review if required
+
+Once published, workspace admins can install Aileron with one click from the App Directory.
+
+## Install to development workspace
+
+For testing before publishing:
+
+- **Sidebar → Install App → Install to Workspace**
+
+When you authorize the app, Slack redirects to `https://your-domain/v1/slack/install/callback`. Aileron exchanges the code for a bot token and stores it in the system vault.
+
+## Troubleshooting
+
+| Symptom | Likely cause |
+|---------|-------------|
+| url_verification fails | Server not running, wrong URL, signing secret mismatch |
+| No events arriving | Event subscriptions not saved, Agents feature not enabled |
+| Agent DM shows no suggested prompts | `assistant_thread_started` event not subscribed, bot token missing from system vault |
+| Message shortcut missing from menu | Shortcut not registered, callback_id mismatch |
+| `/aileron` command not found | Slash command not registered, wrong request URL |
+| `trigger_id` expired | Modal must open within 3s — check server performance |
+| `invalid_team_for_non_distributed_app` | Public distribution not activated |

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -65,7 +65,8 @@ export const navigation: NavItem[] = [
     children: [
       { label: 'Supported Agents', href: '/operations/supported-agents' },
       { label: 'Status & Audit', href: '/operations/status-and-audit' },
-      { label: 'Running Locally', href: '/operations/running-locally' }
+      { label: 'Running Locally', href: '/operations/running-locally' },
+      { label: 'Slack App Configuration', href: '/operations/slack-app-configuration' }
     ]
   },
   {


### PR DESCRIPTION
## Summary

Restructures the Slack docs so that workspace admins install a single published app from the Slack App Directory instead of creating their own.

**Three audience-specific pages:**

| Page | Audience | What it covers |
|---|---|---|
| [Slack App Install](/getting-started/slack-app-install) | Workspace admin | One-click install from App Directory |
| [Slack Connect](/getting-started/slack-connect) | Each user | OAuth account connection + usage guide |
| [Slack App Configuration](/operations/slack-app-configuration) | Aileron dev/ops | Full app creation, scopes, events, shortcuts, commands, env vars, App Directory publishing |

The app creation details moved from Getting Started to Operations — end users never need to see them.

## Test plan

- [ ] Verify all internal doc links resolve
- [ ] Read each page from its audience's perspective

🤖 Generated with [Claude Code](https://claude.com/claude-code)