### PR TITLE
fix(slack): populate external user/team IDs in TEE OAuth path

### DIFF
--- a/core/app/handlers_connected_accounts.go
+++ b/core/app/handlers_connected_accounts.go
@@ -329,15 +329,25 @@ func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Reques
 
 		// Store the encrypted token in the vault — server never saw plaintext.
 		now := time.Now().UTC()
+
+		// Use provider-specific external IDs when available (e.g. Slack
+		// returns user ID + team ID in the token response). Fall back to
+		// email for providers that use standard OAuth (Google, etc.).
+		externalUserID := oauthResp.ExternalUserID
+		if externalUserID == "" {
+			externalUserID = oauthResp.Email
+		}
+
 		acct := model.ConnectedAccount{
-			ID:        "conn_" + s.newID(),
-			UserID:    userID,
+			ID:             "conn_" + s.newID(),
+			UserID:         userID,
 			Provider:       provider,
 			Scopes:         providerSvc.ScopesFor(provider),
-			ExternalUserID: oauthResp.Email,
-			Status:    model.ConnectedAccountStatusActive,
-			CreatedAt: now,
-			UpdatedAt: now,
+			ExternalUserID: externalUserID,
+			ExternalTeamID: oauthResp.ExternalTeamID,
+			Status:         model.ConnectedAccountStatusActive,
+			CreatedAt:      now,
+			UpdatedAt:      now,
 		}
 		if err := s.vault.Put(r.Context(), acct.VaultPath(), oauthResp.EncryptedToken, vault.Metadata{
 			Type: "oauth_refresh_token",

--- a/enclave/local/client.go
+++ b/enclave/local/client.go
@@ -178,6 +178,8 @@ func (c *Client) OAuthExchange(ctx context.Context, req enclave.OAuthExchangeReq
 		EncryptedToken: encrypted,
 		Email:          email,
 		TokenType:      tokenResp.tokenType,
+		ExternalUserID: tokenResp.externalUserID,
+		ExternalTeamID: tokenResp.externalTeamID,
 	}, nil
 }
 
@@ -255,9 +257,11 @@ func (c *Client) Close() error {
 // --- OAuth helpers ---
 
 type oauthTokenResponse struct {
-	accessToken  string
-	tokenType    string
-	tokenJSON    []byte // full JSON for vault storage
+	accessToken    string
+	tokenType      string
+	tokenJSON      []byte // full JSON for vault storage
+	externalUserID string // provider-specific user ID (Slack: authed_user.id)
+	externalTeamID string // provider-specific team ID (Slack: team.id)
 }
 
 func exchangeOAuthCode(ctx context.Context, req enclave.OAuthExchangeRequest) (*oauthTokenResponse, error) {
@@ -289,24 +293,47 @@ func exchangeOAuthCode(ctx context.Context, req enclave.OAuthExchangeRequest) (*
 		return nil, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
 	}
 
+	// Parse the token response. Slack uses a non-standard format with
+	// nested authed_user and team fields; standard OAuth uses top-level fields.
 	var tokenData struct {
+		OK           bool   `json:"ok"`                      // Slack-specific
 		AccessToken  string `json:"access_token"`
 		TokenType    string `json:"token_type"`
 		RefreshToken string `json:"refresh_token"`
+		AuthedUser   struct {
+			ID          string `json:"id"`
+			AccessToken string `json:"access_token"`
+			TokenType   string `json:"token_type"`
+		} `json:"authed_user"` // Slack-specific
+		Team struct {
+			ID   string `json:"id"`
+			Name string `json:"name"`
+		} `json:"team"` // Slack-specific
 	}
 	if err := json.Unmarshal(body, &tokenData); err != nil {
 		return nil, fmt.Errorf("parsing token response: %w", err)
 	}
 
+	result := &oauthTokenResponse{
+		tokenJSON: body,
+	}
+
+	// Slack OAuth v2: user token is under authed_user, no refresh_token.
+	if tokenData.AuthedUser.AccessToken != "" {
+		result.accessToken = tokenData.AuthedUser.AccessToken
+		result.tokenType = tokenData.AuthedUser.TokenType
+		result.externalUserID = tokenData.AuthedUser.ID
+		result.externalTeamID = tokenData.Team.ID
+		return result, nil
+	}
+
+	// Standard OAuth: top-level access_token + refresh_token.
 	if tokenData.RefreshToken == "" {
 		return nil, fmt.Errorf("no refresh token returned; user may need to re-consent")
 	}
-
-	return &oauthTokenResponse{
-		accessToken: tokenData.AccessToken,
-		tokenType:   tokenData.TokenType,
-		tokenJSON:   body,
-	}, nil
+	result.accessToken = tokenData.AccessToken
+	result.tokenType = tokenData.TokenType
+	return result, nil
 }
 
 func fetchUserEmail(ctx context.Context, userinfoEndpoint, accessToken string) (string, error) {

--- a/enclave/protocol.go
+++ b/enclave/protocol.go
@@ -59,6 +59,12 @@ type OAuthExchangeResponse struct {
 	Email string `json:"email"`
 	// TokenType is the OAuth token type (typically "Bearer").
 	TokenType string `json:"token_type"`
+	// ExternalUserID is the provider-specific user ID (e.g. Slack user ID "U...").
+	// Only populated for providers that return this in the token response.
+	ExternalUserID string `json:"external_user_id,omitempty"`
+	// ExternalTeamID is the provider-specific workspace/team ID (e.g. Slack "T...").
+	// Only populated for providers that return this in the token response.
+	ExternalTeamID string `json:"external_team_id,omitempty"`
 }
 
 // ExecuteRequest is sent from the host to the enclave to execute a connector


### PR DESCRIPTION
## Summary

The TEE/enclave OAuth exchange used a generic response that only returned an email address. For Slack, this meant `external_user_id` and `external_team_id` were empty on the connected account, causing `resolveAileronUserBySlack` to fail with "Could not find your Aileron account" on every slash command, message shortcut, and agent DM.

**Root cause:** The enclave's `exchangeOAuthCode` parsed only standard OAuth fields (`access_token`, `refresh_token`). Slack's OAuth v2 puts the user token under `authed_user.access_token` and includes `authed_user.id` + `team.id` — none of which were extracted.

**Fix:**
- Add `ExternalUserID` and `ExternalTeamID` to `OAuthExchangeResponse` (enclave protocol)
- Parse Slack's non-standard response in the enclave: `authed_user.id` → `ExternalUserID`, `team.id` → `ExternalTeamID`
- Handle Slack's lack of `refresh_token` (user tokens are long-lived, not refreshed)
- Use provider-specific IDs in the host's TEE account creation, falling back to email for Google providers

**Action required:** Users who connected Slack while this bug was present need to disconnect and reconnect.

## Test plan

- [x] All existing tests pass
- [ ] Deploy, disconnect Slack account, reconnect — verify `external_user_id` and `external_team_id` are populated
- [ ] Run `/aileron` command — should no longer show "Could not find your Aileron account"

🤖 Generated with [Claude Code](https://claude.com/claude-code)