### PR TITLE
fix(ci): update enclave container image before restart

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -130,8 +130,9 @@ jobs:
             exit 1
           fi
 
-      - name: Restart Confidential Space VM
+      - name: Update and restart Confidential Space VM
         run: |
-          gcloud compute instances reset ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
+          gcloud compute instances update-container ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
             --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
-            --project=${{ secrets.GCP_PROJECT }}
+            --project=${{ secrets.GCP_PROJECT }} \
+            --container-image=${{ env.REGISTRY }}/aileron-enclave@${{ steps.digest.outputs.digest }}


### PR DESCRIPTION
## Summary

The enclave publish workflow used `gcloud compute instances reset` to restart the Confidential Space VM after pushing a new image. But `reset` only reboots — it doesn't update the container image in the instance metadata. The VM kept running the old image.

Replace with `gcloud compute instances update-container` which updates the metadata to the new image digest and restarts the VM with the new code.

This is why the Slack TEE OAuth fix (#253) didn't take effect after deployment.

## Test plan

- [ ] Merge this PR
- [ ] Trigger the enclave publish workflow (or push a change to `enclave/`)
- [ ] Verify the workflow step succeeds
- [ ] Disconnect and reconnect Slack — `external_user_id` and `external_team_id` should now be populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)