### PR TITLE
fix(ci): use tee-image-reference metadata for Confidential Space VM

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -132,7 +132,11 @@ jobs:
 
       - name: Update and restart Confidential Space VM
         run: |
-          gcloud compute instances update-container ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
+          IMAGE=${{ env.REGISTRY }}/aileron-enclave@${{ steps.digest.outputs.digest }}
+          gcloud compute instances update ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
             --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT }} \
-            --container-image=${{ env.REGISTRY }}/aileron-enclave@${{ steps.digest.outputs.digest }}
+            --metadata=tee-image-reference=$IMAGE
+          gcloud compute instances reset ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
+            --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
+            --project=${{ secrets.GCP_PROJECT }}


### PR DESCRIPTION
## Summary

Follow-up to #254. `gcloud compute instances update-container` doesn't work for Confidential Space VMs — they don't use `gce-container-declaration` metadata.

Confidential Space VMs specify the workload image via the `tee-image-reference` metadata key. This fix:
1. Updates `tee-image-reference` to the new image digest via `gcloud compute instances update --metadata`
2. Resets the VM to pick up the new image

## Test plan

- [ ] Merge and trigger enclave publish workflow
- [ ] Verify "Update and restart" step succeeds
- [ ] Disconnect and reconnect Slack — `external_user_id` should be populated

🤖 Generated with [Claude Code](https://claude.com/claude-code)