### PR TITLE
fix(slack): handle bot install via connect callback for Marketplace installs

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -341,7 +341,12 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			"/v1/webhooks/slack/commands":        true,
 			"/v1/slack/install/callback":         true,
 		}
-		handler = auth.Middleware(tokenIssuer, skipPaths)(handler)
+		handler = auth.MiddlewareWithConfig(tokenIssuer, auth.MiddlewareConfig{
+			SkipPaths: skipPaths,
+			OptionalAuthPrefixes: []string{
+				"/v1/connect/", // OAuth callbacks may be unauthenticated (e.g. Slack Marketplace installs)
+			},
+		})(handler)
 		log.Info("auth middleware enabled")
 	}
 

--- a/core/app/handlers_connected_accounts.go
+++ b/core/app/handlers_connected_accounts.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/ALRubinger/aileron/core/account"
 	api "github.com/ALRubinger/aileron/core/api/gen"
+	"github.com/ALRubinger/aileron/core/auth"
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/vault"
@@ -254,6 +255,20 @@ func (s *apiServer) ConnectAccount(w http.ResponseWriter, r *http.Request, provi
 }
 
 func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Request, providerStr string, params api.ConnectAccountCallbackParams) {
+	// Slack Marketplace and App Directory installs may redirect here instead
+	// of /v1/slack/install/callback (we don't control the redirect URL Slack
+	// chooses). Detect this case: provider is slack, no state cookie (the
+	// cookie is only set when a user starts the connect flow from Aileron's
+	// UI), and no authentication credentials.
+	if providerStr == "slack" {
+		if _, err := r.Cookie("aileron_connect_state"); err != nil {
+			if auth.ClaimsFromContext(r.Context()) == nil {
+				s.handleSlackInstall(w, r)
+				return
+			}
+		}
+	}
+
 	if s.accountService == nil {
 		writeError(w, http.StatusNotImplemented, "not_implemented", "connected accounts not configured")
 		return

--- a/core/app/handlers_connected_accounts_test.go
+++ b/core/app/handlers_connected_accounts_test.go
@@ -717,6 +717,77 @@ func TestConnectAccount_RedirectURL_HTTP_WithoutProxy(t *testing.T) {
 	}
 }
 
+func TestConnectAccountCallback_SlackInstallDelegation(t *testing.T) {
+	// When an unauthenticated Slack request hits the connect callback
+	// without a state cookie (e.g. Slack Marketplace install), it should
+	// delegate to handleSlackInstall instead of returning a 401 or CSRF error.
+	srv := newConnectedAccountServer()
+	srv.systemVault = vault.NewMemVault()
+	srv.slackClientID = "test-client-id"
+	srv.slackClientSecret = "test-client-secret"
+	srv.slackBotExchanger = func(clientID, clientSecret, code, redirectURI string) (*slackBotInstallResponse, error) {
+		if code != "marketplace-code" {
+			t.Errorf("code = %q, want marketplace-code", code)
+		}
+		return &slackBotInstallResponse{
+			OK:          true,
+			AccessToken: "xoxb-marketplace-token",
+			BotUserID:   "U_BOT",
+			Team: struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}{"T_MKT", "marketplace-ws"},
+		}, nil
+	}
+	// Enable auth so requireAuth would reject unauthenticated requests.
+	srv.users = mem.NewUserStore()
+
+	// No auth cookies/headers, no state cookie — simulates a Slack Marketplace redirect.
+	req := httptest.NewRequest("GET", "/v1/connect/slack/callback?code=marketplace-code&state=", nil)
+	w := httptest.NewRecorder()
+	srv.ConnectAccountCallback(w, req, "slack", api.ConnectAccountCallbackParams{Code: "marketplace-code", State: ""})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (install success), got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the bot token was stored.
+	secret, err := srv.systemVault.Get(context.Background(), "slack-workspaces/T_MKT/bot-token")
+	if err != nil {
+		t.Fatalf("expected bot token in system vault: %v", err)
+	}
+	if string(secret.Value) != "xoxb-marketplace-token" {
+		t.Errorf("stored token = %q, want xoxb-marketplace-token", secret.Value)
+	}
+}
+
+func TestConnectAccountCallback_SlackWithAuth_DoesNotDelegate(t *testing.T) {
+	// When an authenticated Slack request hits the connect callback with a
+	// state cookie, it should follow the normal user account connection flow,
+	// not the bot install flow.
+	srv := newConnectedAccountServer()
+	srv.systemVault = vault.NewMemVault()
+	srv.slackClientID = "test-client-id"
+	srv.slackClientSecret = "test-client-secret"
+	srv.slackBotExchanger = func(_, _, _, _ string) (*slackBotInstallResponse, error) {
+		t.Error("install handler should not be called for authenticated requests with state cookie")
+		return nil, nil
+	}
+	srv.accountService = newGoogleAccountRegistry(srv.connectedAccounts, srv.vault)
+
+	req := httptest.NewRequest("GET", "/v1/connect/slack/callback?code=user-code&state=valid-state", nil)
+	req.AddCookie(&http.Cookie{Name: "aileron_connect_state", Value: "valid-state"})
+	// Add auth claims to context (simulates authenticated user).
+	ctx := auth.ContextWithClaims(req.Context(), &auth.Claims{})
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	srv.ConnectAccountCallback(w, req, "slack", api.ConnectAccountCallbackParams{Code: "user-code", State: "valid-state"})
+
+	// Should NOT have called the install exchanger — the state cookie is present,
+	// so it proceeds with the normal account connection flow.
+}
+
 func TestConnectedAccountToAPI(t *testing.T) {
 	acc := model.ConnectedAccount{
 		ID:             "conn_1",

--- a/core/auth/middleware.go
+++ b/core/auth/middleware.go
@@ -24,14 +24,31 @@ func ContextWithClaims(ctx context.Context, claims *Claims) context.Context {
 	return context.WithValue(ctx, claimsKey, claims)
 }
 
+// MiddlewareConfig holds the configuration for the auth middleware.
+type MiddlewareConfig struct {
+	// SkipPaths are paths that bypass authentication entirely.
+	SkipPaths map[string]bool
+	// OptionalAuthPrefixes are path prefixes where authentication is attempted
+	// but not required. If credentials are present and valid, claims are
+	// injected into the context. If credentials are absent, the request
+	// proceeds without claims. This allows handlers to support both
+	// authenticated and unauthenticated flows on the same endpoint.
+	OptionalAuthPrefixes []string
+}
+
 // Middleware returns HTTP middleware that validates Bearer JWTs and injects
 // claims into the request context. Requests to paths in skipPaths bypass
 // authentication (e.g. health checks, auth callbacks).
 func Middleware(issuer *TokenIssuer, skipPaths map[string]bool) func(http.Handler) http.Handler {
+	return MiddlewareWithConfig(issuer, MiddlewareConfig{SkipPaths: skipPaths})
+}
+
+// MiddlewareWithConfig returns HTTP middleware using the full MiddlewareConfig.
+func MiddlewareWithConfig(issuer *TokenIssuer, cfg MiddlewareConfig) func(http.Handler) http.Handler {
 	return func(next http.Handler) http.Handler {
 		return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 			// Skip auth for explicitly excluded paths.
-			if skipPaths[r.URL.Path] {
+			if cfg.SkipPaths[r.URL.Path] {
 				next.ServeHTTP(w, r)
 				return
 			}
@@ -40,6 +57,21 @@ func Middleware(issuer *TokenIssuer, skipPaths map[string]bool) func(http.Handle
 			if strings.HasPrefix(r.URL.Path, "/auth/") {
 				next.ServeHTTP(w, r)
 				return
+			}
+
+			// Optional auth: attempt to authenticate but don't require it.
+			for _, prefix := range cfg.OptionalAuthPrefixes {
+				if strings.HasPrefix(r.URL.Path, prefix) {
+					if token := extractBearerToken(r); token != "" {
+						if claims, err := issuer.Validate(token); err == nil {
+							ctx := context.WithValue(r.Context(), claimsKey, claims)
+							next.ServeHTTP(w, r.WithContext(ctx))
+							return
+						}
+					}
+					next.ServeHTTP(w, r)
+					return
+				}
 			}
 
 			token := extractBearerToken(r)

--- a/core/auth/middleware_test.go
+++ b/core/auth/middleware_test.go
@@ -135,6 +135,107 @@ func TestContextWithClaims_NilReturnsNil(t *testing.T) {
 	}
 }
 
+func TestMiddleware_OptionalAuth_NoCredentials(t *testing.T) {
+	issuer := NewTokenIssuer([]byte("test-secret-key-32-bytes-long!!!"), "test", 15*time.Minute)
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		claims := ClaimsFromContext(r.Context())
+		if claims != nil {
+			t.Error("expected no claims when no credentials provided")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := MiddlewareWithConfig(issuer, MiddlewareConfig{
+		OptionalAuthPrefixes: []string{"/v1/connect/"},
+	})(inner)
+	req := httptest.NewRequest(http.MethodGet, "/v1/connect/slack/callback?code=abc&state=", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("handler should be called for optional auth paths without credentials")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestMiddleware_OptionalAuth_WithValidCredentials(t *testing.T) {
+	issuer := NewTokenIssuer([]byte("test-secret-key-32-bytes-long!!!"), "test", 15*time.Minute)
+	token, _ := issuer.Issue("usr_1", "ent_1", "alice@example.com", "owner")
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		claims := ClaimsFromContext(r.Context())
+		if claims == nil {
+			t.Error("expected claims when valid credentials provided")
+			return
+		}
+		if claims.Subject != "usr_1" {
+			t.Errorf("Subject = %q, want %q", claims.Subject, "usr_1")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := MiddlewareWithConfig(issuer, MiddlewareConfig{
+		OptionalAuthPrefixes: []string{"/v1/connect/"},
+	})(inner)
+	req := httptest.NewRequest(http.MethodGet, "/v1/connect/slack/callback?code=abc&state=xyz", nil)
+	req.AddCookie(&http.Cookie{Name: "access_token", Value: token})
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestMiddleware_OptionalAuth_WithInvalidCredentials(t *testing.T) {
+	issuer := NewTokenIssuer([]byte("test-secret-key-32-bytes-long!!!"), "test", 15*time.Minute)
+	called := false
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		claims := ClaimsFromContext(r.Context())
+		if claims != nil {
+			t.Error("expected no claims when invalid credentials provided")
+		}
+		w.WriteHeader(http.StatusOK)
+	})
+
+	handler := MiddlewareWithConfig(issuer, MiddlewareConfig{
+		OptionalAuthPrefixes: []string{"/v1/connect/"},
+	})(inner)
+	req := httptest.NewRequest(http.MethodGet, "/v1/connect/slack/callback?code=abc&state=", nil)
+	req.Header.Set("Authorization", "Bearer invalid-token")
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if !called {
+		t.Error("handler should be called even with invalid credentials on optional auth paths")
+	}
+	if rec.Code != http.StatusOK {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusOK)
+	}
+}
+
+func TestMiddleware_OptionalAuth_NonMatchingPath(t *testing.T) {
+	issuer := NewTokenIssuer([]byte("test-secret-key-32-bytes-long!!!"), "test", 15*time.Minute)
+	inner := http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Error("handler should not be called")
+	})
+
+	handler := MiddlewareWithConfig(issuer, MiddlewareConfig{
+		OptionalAuthPrefixes: []string{"/v1/connect/"},
+	})(inner)
+	req := httptest.NewRequest(http.MethodGet, "/v1/intents", nil)
+	rec := httptest.NewRecorder()
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want %d", rec.Code, http.StatusUnauthorized)
+	}
+}
+
 func TestMiddleware_CookieToken(t *testing.T) {
 	issuer := NewTokenIssuer([]byte("test-secret-key-32-bytes-long!!!"), "test", 15*time.Minute)
 	token, _ := issuer.Issue("usr_1", "ent_1", "alice@example.com", "owner")


### PR DESCRIPTION
## Summary

- Slack Marketplace installs redirect to `/v1/connect/slack/callback` (the user-account-connection endpoint) instead of `/v1/slack/install/callback` (the bot-installation endpoint). We don't control which redirect URL Slack chooses, so the connect callback must handle both flows.
- Adds **optional auth** middleware (`MiddlewareWithConfig` with `OptionalAuthPrefixes`) so `/v1/connect/` paths attempt authentication without requiring it — claims are injected when valid, requests pass through without claims otherwise.
- When `ConnectAccountCallback` receives an unauthenticated Slack request with no state cookie, it delegates to `handleSlackInstall`. Authenticated requests with a state cookie proceed through the normal user-connect flow.

## Test plan

- [x] 4 new middleware tests: optional auth with no credentials, valid credentials, invalid credentials, non-matching path
- [x] `TestConnectAccountCallback_SlackInstallDelegation` — unauthenticated Slack request delegates to install handler, bot token stored in system vault
- [x] `TestConnectAccountCallback_SlackWithAuth_DoesNotDelegate` — authenticated request with state cookie does NOT delegate
- [x] All existing tests pass (auth + app suites)
- [ ] **Manual**: Configure Slack app redirect URLs with both endpoints, install from Marketplace, verify bot token stored successfully
- [ ] **Manual**: After Marketplace install, verify user account connection flow still works with auth

🤖 Generated with [Claude Code](https://claude.com/claude-code)