### PR TITLE
fix(ci): quote metadata value in enclave deploy

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -132,11 +132,11 @@ jobs:
 
       - name: Update and restart Confidential Space VM
         run: |
-          IMAGE=${{ env.REGISTRY }}/aileron-enclave@${{ steps.digest.outputs.digest }}
+          IMAGE="${{ env.REGISTRY }}/aileron-enclave@${{ steps.digest.outputs.digest }}"
           gcloud compute instances update ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
             --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT }} \
-            --metadata=tee-image-reference=$IMAGE
+            --metadata="tee-image-reference=${IMAGE}"
           gcloud compute instances reset ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
             --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT }}


### PR DESCRIPTION
## Summary

The `--metadata=tee-image-reference=$IMAGE` flag was misinterpreted by gcloud because the image reference contains `@sha256:` which introduces multiple `=` signs after shell expansion. Quote the variable and flag value to fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)