### PR TITLE
fix(ci): use add-metadata to update Confidential Space VM image

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -133,7 +133,7 @@ jobs:
       - name: Update and restart Confidential Space VM
         run: |
           IMAGE="${{ env.REGISTRY }}/aileron-enclave@${{ steps.digest.outputs.digest }}"
-          gcloud compute instances update ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
+          gcloud compute instances add-metadata ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
             --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
             --project=${{ secrets.GCP_PROJECT }} \
             --metadata="tee-image-reference=${IMAGE}"


### PR DESCRIPTION
## Summary

`gcloud compute instances update` doesn't have a `--metadata` flag. The correct command is `gcloud compute instances add-metadata` which upserts metadata key-value pairs on existing instances.

Changes `instances update --metadata` → `instances add-metadata --metadata`.

## References

- [gcloud compute instances add-metadata](https://cloud.google.com/sdk/gcloud/reference/compute/instances/add-metadata)

🤖 Generated with [Claude Code](https://claude.com/claude-code)