### PR TITLE
fix(ci): stop/start Confidential Space VM for image update

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -133,10 +133,19 @@ jobs:
       - name: Update and restart Confidential Space VM
         run: |
           IMAGE="${{ env.REGISTRY }}/aileron-enclave@${{ steps.digest.outputs.digest }}"
-          gcloud compute instances add-metadata ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
-            --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
-            --project=${{ secrets.GCP_PROJECT }} \
+          INSTANCE=${{ secrets.GCP_ENCLAVE_INSTANCE }}
+          ZONE=${{ secrets.GCP_ENCLAVE_ZONE }}
+          PROJECT=${{ secrets.GCP_PROJECT }}
+
+          echo "Stopping VM..."
+          gcloud compute instances stop "$INSTANCE" \
+            --zone="$ZONE" --project="$PROJECT" --quiet
+
+          echo "Updating tee-image-reference to $IMAGE"
+          gcloud compute instances add-metadata "$INSTANCE" \
+            --zone="$ZONE" --project="$PROJECT" \
             --metadata="tee-image-reference=${IMAGE}"
-          gcloud compute instances reset ${{ secrets.GCP_ENCLAVE_INSTANCE }} \
-            --zone=${{ secrets.GCP_ENCLAVE_ZONE }} \
-            --project=${{ secrets.GCP_PROJECT }}
+
+          echo "Starting VM..."
+          gcloud compute instances start "$INSTANCE" \
+            --zone="$ZONE" --project="$PROJECT"


### PR DESCRIPTION
## Summary

Replace `add-metadata` + `reset` with `stop` → `add-metadata` → `start`. A full boot sequence ensures the Confidential Space launcher re-reads `tee-image-reference` and pulls the new workload image.

## Prerequisite (manual, one-time)

The `add-metadata` error from #258 shows the CI service account needs `iam.serviceAccountUser` on the enclave VM's service account. Grant it in GCP IAM:

```sh
gcloud iam service-accounts add-iam-policy-binding \
  ENCLAVE_VM_SERVICE_ACCOUNT@PROJECT.iam.gserviceaccount.com \
  --member="serviceAccount:CI_SERVICE_ACCOUNT@PROJECT.iam.gserviceaccount.com" \
  --role="roles/iam.serviceAccountUser" \
  --project=PROJECT
```

This is needed because `stop` and `start` (unlike `reset`) impersonate the VM's service account.

🤖 Generated with [Claude Code](https://claude.com/claude-code)