### PR TITLE
fix(slack): return external user/team IDs from enclave OAuth exchange

### DIFF
--- a/cmd/aileron-enclave/oauth.go
+++ b/cmd/aileron-enclave/oauth.go
@@ -14,7 +14,16 @@ import (
 // doOAuthExchange calls the provider's token endpoint to exchange an
 // authorization code for tokens. Returns the full token JSON (for encrypted
 // vault storage), the access token (for fetching user info), and the token type.
-func doOAuthExchange(ctx context.Context, req enclave.OAuthExchangeRequest) (tokenJSON []byte, accessToken, tokenType string, err error) {
+// oauthExchangeResult holds the results of an OAuth token exchange.
+type oauthExchangeResult struct {
+	tokenJSON      []byte
+	accessToken    string
+	tokenType      string
+	externalUserID string // provider-specific user ID (e.g. Slack authed_user.id)
+	externalTeamID string // provider-specific team ID (e.g. Slack team.id)
+}
+
+func doOAuthExchange(ctx context.Context, req enclave.OAuthExchangeRequest) (*oauthExchangeResult, error) {
 	form := url.Values{
 		"grant_type":    {"authorization_code"},
 		"code":          {req.Code},
@@ -25,7 +34,7 @@ func doOAuthExchange(ctx context.Context, req enclave.OAuthExchangeRequest) (tok
 
 	httpReq, err := http.NewRequestWithContext(ctx, http.MethodPost, req.TokenEndpoint, nil)
 	if err != nil {
-		return nil, "", "", err
+		return nil, err
 	}
 	httpReq.Header.Set("Content-Type", "application/x-www-form-urlencoded")
 	httpReq.Header.Set("Accept", "application/json")
@@ -33,17 +42,17 @@ func doOAuthExchange(ctx context.Context, req enclave.OAuthExchangeRequest) (tok
 
 	resp, err := http.DefaultClient.Do(httpReq)
 	if err != nil {
-		return nil, "", "", err
+		return nil, err
 	}
 	defer resp.Body.Close()
 
 	body, err := io.ReadAll(resp.Body)
 	if err != nil {
-		return nil, "", "", err
+		return nil, err
 	}
 
 	if resp.StatusCode != http.StatusOK {
-		return nil, "", "", fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
+		return nil, fmt.Errorf("token endpoint returned %d: %s", resp.StatusCode, string(body))
 	}
 
 	var tokenData struct {
@@ -63,19 +72,23 @@ func doOAuthExchange(ctx context.Context, req enclave.OAuthExchangeRequest) (tok
 		} `json:"team"`
 	}
 	if err := json.Unmarshal(body, &tokenData); err != nil {
-		return nil, "", "", fmt.Errorf("parsing token response: %w", err)
+		return nil, fmt.Errorf("parsing token response: %w", err)
 	}
 
-	accessToken = tokenData.AccessToken
-	tokenType = tokenData.TokenType
-	storedJSON := body
+	result := &oauthExchangeResult{
+		accessToken: tokenData.AccessToken,
+		tokenType:   tokenData.TokenType,
+		tokenJSON:   body,
+	}
 
 	// Slack's oauth.v2.access nests the user token under authed_user.
 	// Normalize to store only the user token fields, matching the direct
 	// (non-TEE) code path in SlackService.HandleCallback.
 	if req.Provider == "slack" && tokenData.AuthedUser.AccessToken != "" {
-		accessToken = tokenData.AuthedUser.AccessToken
-		tokenType = tokenData.AuthedUser.TokenType
+		result.accessToken = tokenData.AuthedUser.AccessToken
+		result.tokenType = tokenData.AuthedUser.TokenType
+		result.externalUserID = tokenData.AuthedUser.ID
+		result.externalTeamID = tokenData.Team.ID
 		normalized, err := json.Marshal(map[string]string{
 			"access_token": tokenData.AuthedUser.AccessToken,
 			"token_type":   tokenData.AuthedUser.TokenType,
@@ -85,16 +98,16 @@ func doOAuthExchange(ctx context.Context, req enclave.OAuthExchangeRequest) (tok
 			"user_id":      tokenData.AuthedUser.ID,
 		})
 		if err != nil {
-			return nil, "", "", fmt.Errorf("marshalling normalized token: %w", err)
+			return nil, fmt.Errorf("marshalling normalized token: %w", err)
 		}
-		storedJSON = normalized
+		result.tokenJSON = normalized
 	}
 
-	if accessToken == "" {
-		return nil, "", "", fmt.Errorf("no access token returned")
+	if result.accessToken == "" {
+		return nil, fmt.Errorf("no access token returned")
 	}
 
-	return storedJSON, accessToken, tokenType, nil
+	return result, nil
 }
 
 // doFetchEmail retrieves the user's email from the userinfo endpoint.

--- a/cmd/aileron-enclave/server.go
+++ b/cmd/aileron-enclave/server.go
@@ -176,18 +176,18 @@ func (s *enclaveServer) handleOAuthExchange(w http.ResponseWriter, r *http.Reque
 	defer zeroBytes(kek)
 
 	// Exchange authorization code for tokens.
-	tokenJSON, accessToken, tokenType, err := doOAuthExchange(r.Context(), req)
+	oauthResult, err := doOAuthExchange(r.Context(), req)
 	if err != nil {
 		writeErr(w, http.StatusBadGateway, "OAuth exchange failed: "+err.Error())
 		return
 	}
-	defer zeroBytes(tokenJSON)
+	defer zeroBytes(oauthResult.tokenJSON)
 
 	// Fetch user email.
-	email, _ := doFetchEmail(r.Context(), req.UserInfoEndpoint, accessToken)
+	email, _ := doFetchEmail(r.Context(), req.UserInfoEndpoint, oauthResult.accessToken)
 
 	// Encrypt token JSON with user's KEK.
-	encrypted, err := crypto.Encrypt(tokenJSON, kek)
+	encrypted, err := crypto.Encrypt(oauthResult.tokenJSON, kek)
 	if err != nil {
 		writeErr(w, http.StatusInternalServerError, "encrypting token: "+err.Error())
 		return
@@ -196,7 +196,9 @@ func (s *enclaveServer) handleOAuthExchange(w http.ResponseWriter, r *http.Reque
 	writeJSON(w, http.StatusOK, enclave.OAuthExchangeResponse{
 		EncryptedToken: encrypted,
 		Email:          email,
-		TokenType:      tokenType,
+		TokenType:      oauthResult.tokenType,
+		ExternalUserID: oauthResult.externalUserID,
+		ExternalTeamID: oauthResult.externalTeamID,
 	})
 }
 

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -771,6 +771,71 @@ func TestOAuthExchangeSlackNestedUserToken(t *testing.T) {
 	if tokenData["team_id"] != "T001" {
 		t.Fatalf("expected T001, got %q", tokenData["team_id"])
 	}
+
+	// Regression: ExternalUserID and ExternalTeamID must be populated in the
+	// response so the host can store them on the connected account. Without
+	// these, resolveAileronUserBySlack fails with "Could not find your
+	// Aileron account" on every slash command, message shortcut, and agent DM.
+	if result.ExternalUserID != "U_USER" {
+		t.Fatalf("expected ExternalUserID 'U_USER', got %q", result.ExternalUserID)
+	}
+	if result.ExternalTeamID != "T001" {
+		t.Fatalf("expected ExternalTeamID 'T001', got %q", result.ExternalTeamID)
+	}
+}
+
+func TestOAuthExchangeStandardProvider_NoExternalIDs(t *testing.T) {
+	// Standard OAuth providers (Google, GitHub) should NOT populate
+	// ExternalUserID/ExternalTeamID — those are Slack-specific.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "ya29-google-token",
+			"token_type":    "Bearer",
+			"refresh_token": "1//google-refresh",
+		})
+	}))
+	defer tokenServer.Close()
+
+	userinfoServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]string{"email": "alice@example.com"})
+	}))
+	defer userinfoServer.Close()
+
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	resp := postJSON(t, server, "/oauth/exchange", enclave.OAuthExchangeRequest{
+		UserID:           "user-1",
+		Provider:         "google",
+		Code:             "auth-code",
+		RedirectURI:      "http://localhost/cb",
+		ClientID:         "cid",
+		ClientSecret:     "csec",
+		TokenEndpoint:    tokenServer.URL,
+		UserInfoEndpoint: userinfoServer.URL,
+	})
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		t.Fatalf("expected 200, got %d: %s", resp.StatusCode, string(body))
+	}
+
+	result := decodeResp[enclave.OAuthExchangeResponse](t, resp)
+	if result.Email != "alice@example.com" {
+		t.Fatalf("expected email 'alice@example.com', got %q", result.Email)
+	}
+	if result.ExternalUserID != "" {
+		t.Fatalf("expected empty ExternalUserID for Google, got %q", result.ExternalUserID)
+	}
+	if result.ExternalTeamID != "" {
+		t.Fatalf("expected empty ExternalTeamID for Google, got %q", result.ExternalTeamID)
+	}
 }
 
 func TestOAuthExchangeAcceptJSON(t *testing.T) {


### PR DESCRIPTION
## Summary

The production enclave server (`cmd/aileron-enclave`) has its own OAuth exchange handler separate from `enclave/local/client.go`. PR 253 fixed the local client but missed the production enclave.

The `doOAuthExchange` function already parsed Slack's `authed_user.id` and `team.id`, but didn't return them to the caller. The `handleOAuthExchange` handler built the `OAuthExchangeResponse` without the new `ExternalUserID`/`ExternalTeamID` fields.

**Fix:** Refactor `doOAuthExchange` to return an `oauthExchangeResult` struct with the external IDs, and include them in the response.

## Test plan

- [x] Enclave server tests pass
- [ ] Merge → enclave publish workflow deploys new image
- [ ] Disconnect and reconnect Slack
- [ ] Verify `external_user_id` is populated (should be `U0ATG8KF3U2`)
- [ ] `/aileron` command works

🤖 Generated with [Claude Code](https://claude.com/claude-code)