### PR TITLE
perf(ci): revert to reset for enclave deploy (no stop/start)

### DIFF
--- a/.github/workflows/enclave-publish.yml
+++ b/.github/workflows/enclave-publish.yml
@@ -133,19 +133,10 @@ jobs:
       - name: Update and restart Confidential Space VM
         run: |
           IMAGE="${{ env.REGISTRY }}/aileron-enclave@${{ steps.digest.outputs.digest }}"
-          INSTANCE=${{ secrets.GCP_ENCLAVE_INSTANCE }}
-          ZONE=${{ secrets.GCP_ENCLAVE_ZONE }}
-          PROJECT=${{ secrets.GCP_PROJECT }}
-
-          echo "Stopping VM..."
-          gcloud compute instances stop "$INSTANCE" \
-            --zone="$ZONE" --project="$PROJECT" --quiet
-
-          echo "Updating tee-image-reference to $IMAGE"
-          gcloud compute instances add-metadata "$INSTANCE" \
-            --zone="$ZONE" --project="$PROJECT" \
+          gcloud compute instances add-metadata "${{ secrets.GCP_ENCLAVE_INSTANCE }}" \
+            --zone="${{ secrets.GCP_ENCLAVE_ZONE }}" \
+            --project="${{ secrets.GCP_PROJECT }}" \
             --metadata="tee-image-reference=${IMAGE}"
-
-          echo "Starting VM..."
-          gcloud compute instances start "$INSTANCE" \
-            --zone="$ZONE" --project="$PROJECT"
+          gcloud compute instances reset "${{ secrets.GCP_ENCLAVE_INSTANCE }}" \
+            --zone="${{ secrets.GCP_ENCLAVE_ZONE }}" \
+            --project="${{ secrets.GCP_PROJECT }}"


### PR DESCRIPTION
## Summary

Revert the enclave deploy from stop → add-metadata → start back to add-metadata → reset.

The stop/start approach was added thinking `reset` didn't pick up new images. But the actual bug was in `cmd/aileron-enclave/oauth.go` (PR 260) — the enclave code was unchanged in earlier deploys, so `reset` was restarting the same code every time. It wasn't a deployment problem.

`reset` is faster and avoids production downtime during the stop/start cycle.

## Verification

After PR 260's enclave publish runs with this workflow:
- Workflow completes without errors
- Disconnect and reconnect Slack → `external_user_id` populated = both the code fix AND reset-based deploy work

🤖 Generated with [Claude Code](https://claude.com/claude-code)