### PR TITLE
fix(slack): resolve display names in agent DM pipeline context

### DIFF
--- a/core/app/handlers_slack_agent.go
+++ b/core/app/handlers_slack_agent.go
@@ -70,7 +70,8 @@ func (s *apiServer) handleAssistantMessage(ctx context.Context, teamID, channelI
 	// Set status to "Researching..."
 	_ = s.slackAgentClient.SetStatus(ctx, botToken, channelID, threadTS, "Researching...")
 
-	msg := comms.BuildIncomingMessage("", channelID, slackUserID, text)
+	displayName := comms.ResolveSlackDisplayName(ctx, botToken, slackUserID)
+	msg := comms.BuildIncomingMessage("", "Agent DM", displayName, text)
 	chunkCh, errCh := pipeline.GenerateDraftStream(ctx, userID, msg)
 
 	var streamTS string
@@ -150,10 +151,12 @@ func (s *apiServer) handleMessageShortcut(ctx context.Context, payload slackInte
 	messageText := ""
 	messageTS := ""
 	messageThreadTS := ""
+	messageAuthorID := ""
 	if payload.Message != nil {
 		messageText = payload.Message.Text
 		messageTS = payload.Message.TS
 		messageThreadTS = payload.Message.ThreadTS
+		messageAuthorID = payload.Message.User
 	}
 	if messageThreadTS == "" {
 		messageThreadTS = messageTS
@@ -201,8 +204,9 @@ func (s *apiServer) handleMessageShortcut(ctx context.Context, payload slackInte
 	if len(preview) > 200 {
 		preview = preview[:200] + "..."
 	}
-	msg := comms.BuildIncomingMessage(messageTS, channelID, "", fmt.Sprintf(
-		"[Message from #%s]: %s", channelName, preview,
+	messageAuthor := comms.ResolveSlackDisplayName(ctx, botToken, messageAuthorID)
+	msg := comms.BuildIncomingMessage(messageTS, "#"+channelName, messageAuthor, fmt.Sprintf(
+		"[Message from %s in #%s]: %s", messageAuthor, channelName, preview,
 	))
 
 	// Generate draft (non-streaming for modal — we update once when done).

--- a/core/app/handlers_slack_commands.go
+++ b/core/app/handlers_slack_commands.go
@@ -110,7 +110,8 @@ func (s *apiServer) processSlashCommandDraft(ctx context.Context, teamID, slackU
 		return
 	}
 
-	msg := comms.BuildIncomingMessage("", meta.TargetChannel, "", text)
+	displayName := comms.ResolveSlackDisplayName(ctx, botToken, slackUserID)
+	msg := comms.BuildIncomingMessage("", meta.TargetChannel, displayName, text)
 	draftText, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("slash command draft: generation failed", "error", err)
@@ -147,7 +148,9 @@ func (s *apiServer) processSlashCommandQuestion(ctx context.Context, teamID, sla
 		return
 	}
 
-	msg := comms.BuildIncomingMessage("", "", "", text)
+	botToken, _ := s.resolveWorkspaceBotToken(ctx, teamID)
+	displayName := comms.ResolveSlackDisplayName(ctx, botToken, slackUserID)
+	msg := comms.BuildIncomingMessage("", "", displayName, text)
 	answer, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("slash command question: generation failed", "error", err)

--- a/core/comms/slack_agent.go
+++ b/core/comms/slack_agent.go
@@ -152,3 +152,23 @@ func OpenConversation(ctx context.Context, botToken, userID string) (string, err
 	}
 	return channel.ID, nil
 }
+
+// ResolveSlackDisplayName looks up a Slack user's display name via users.info.
+// Returns the display name, or falls back to real_name, then the raw user ID.
+func ResolveSlackDisplayName(ctx context.Context, botToken, slackUserID string) string {
+	if botToken == "" || slackUserID == "" {
+		return slackUserID
+	}
+	client := newAgentClient(botToken)
+	user, err := client.GetUserInfoContext(ctx, slackUserID)
+	if err != nil {
+		return slackUserID
+	}
+	if user.Profile.DisplayName != "" {
+		return user.Profile.DisplayName
+	}
+	if user.RealName != "" {
+		return user.RealName
+	}
+	return slackUserID
+}

--- a/core/comms/slack_agent_test.go
+++ b/core/comms/slack_agent_test.go
@@ -221,6 +221,80 @@ func TestOpenConversation_Success(t *testing.T) {
 	}
 }
 
+func TestResolveSlackDisplayName_Success(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"user": map[string]any{
+				"id":        "U_ALICE",
+				"real_name": "Alice Smith",
+				"profile": map[string]any{
+					"display_name": "alice",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	comms.SetAgentAPIURL(server.URL + "/")
+	defer comms.SetAgentAPIURL("")
+
+	name := comms.ResolveSlackDisplayName(context.Background(), "xoxb-test", "U_ALICE")
+	if name != "alice" {
+		t.Errorf("expected 'alice', got %q", name)
+	}
+}
+
+func TestResolveSlackDisplayName_FallsBackToRealName(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok": true,
+			"user": map[string]any{
+				"id":        "U_BOB",
+				"real_name": "Bob Jones",
+				"profile": map[string]any{
+					"display_name": "",
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	comms.SetAgentAPIURL(server.URL + "/")
+	defer comms.SetAgentAPIURL("")
+
+	name := comms.ResolveSlackDisplayName(context.Background(), "xoxb-test", "U_BOB")
+	if name != "Bob Jones" {
+		t.Errorf("expected 'Bob Jones', got %q", name)
+	}
+}
+
+func TestResolveSlackDisplayName_FallsBackToUserID(t *testing.T) {
+	// Empty token — can't call API, returns raw user ID.
+	name := comms.ResolveSlackDisplayName(context.Background(), "", "U_ALICE")
+	if name != "U_ALICE" {
+		t.Errorf("expected 'U_ALICE', got %q", name)
+	}
+}
+
+func TestResolveSlackDisplayName_APIError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{"ok": false, "error": "user_not_found"})
+	}))
+	defer server.Close()
+
+	comms.SetAgentAPIURL(server.URL + "/")
+	defer comms.SetAgentAPIURL("")
+
+	name := comms.ResolveSlackDisplayName(context.Background(), "xoxb-test", "U_UNKNOWN")
+	if name != "U_UNKNOWN" {
+		t.Errorf("expected fallback to 'U_UNKNOWN', got %q", name)
+	}
+}
+
 func TestOpenModal_EmptyToken(t *testing.T) {
 	_, err := comms.OpenModal(context.Background(), "", "trigger123", comms.EmptyModalView())
 	if err == nil {


### PR DESCRIPTION
## Summary

The LLM prompt was showing raw Slack IDs (`U_ABC123`, `D_DMCHANNEL`) instead of human-readable names. Now resolves display names via Slack's `users.info` API before building the pipeline message.

**Before:** `Message from U0ATG8KF3U2 in D08S3K2PQRS: Draft me a reply`
**After:** `Message from Alice in Agent DM: Draft me a reply`

- Add `ResolveSlackDisplayName(ctx, botToken, slackUserID)` to `core/comms/slack_agent.go`
- Falls back gracefully: display_name → real_name → raw user ID
- Updated all 4 `BuildIncomingMessage` call sites in agent handlers and slash commands
- Agent DM channel shows "Agent DM" instead of raw channel ID
- Message shortcut includes resolved author name and `#channel` prefix

Closes #249

## Test plan

- [x] All existing tests pass
- [x] `ResolveSlackDisplayName`: success, fallback to real_name, fallback to user ID, API error
- [ ] Manual: `/aileron` shows your display name in the draft prompt context

🤖 Generated with [Claude Code](https://claude.com/claude-code)