### PR TITLE
feat(vault): auto-escrow credentials on OAuth connect

### DIFF
--- a/core/app/handlers_connected_accounts.go
+++ b/core/app/handlers_connected_accounts.go
@@ -380,6 +380,13 @@ func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Reques
 			return
 		}
 
+		// Auto-escrow all credentials so async flows (Slack agent) work
+		// immediately without requiring a separate vault unlock step.
+		escrowed := s.autoEscrowCredentials(r.Context(), userID)
+		if escrowed > 0 {
+			s.log.Info("auto-escrowed credentials on connect", "user_id", userID, "count", escrowed)
+		}
+
 		http.Redirect(w, r, returnTo, http.StatusFound)
 		return
 	}
@@ -409,6 +416,14 @@ func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Reques
 		s.log.Error("connected account callback failed", "error", err, "provider", providerStr)
 		writeError(w, http.StatusInternalServerError, "callback_error", "failed to connect account: "+err.Error())
 		return
+	}
+
+	// Auto-escrow in direct mode (no-op if enclaveClient is nil).
+	if s.enclaveClient != nil {
+		escrowed := s.autoEscrowCredentials(r.Context(), userID)
+		if escrowed > 0 {
+			s.log.Info("auto-escrowed credentials on connect", "user_id", userID, "count", escrowed)
+		}
 	}
 
 	http.Redirect(w, r, returnTo, http.StatusFound)

--- a/core/app/handlers_tee_test.go
+++ b/core/app/handlers_tee_test.go
@@ -760,4 +760,14 @@ func TestConnectAccountCallbackTEEBranch(t *testing.T) {
 	if secret.Metadata.Labels["encrypted"] != "true" {
 		t.Fatal("expected encrypted=true label on vault secret")
 	}
+
+	// Verify the credential was auto-escrowed for async access.
+	vaultPath := accounts[0].VaultPath()
+	escrowID, ok := srv.escrowIndex.Load(vaultPath)
+	if !ok {
+		t.Fatalf("expected escrow index entry for %q after connect", vaultPath)
+	}
+	if escrowID.(string) == "" {
+		t.Fatal("expected non-empty escrow ID")
+	}
 }


### PR DESCRIPTION
## Summary

- Calls `autoEscrowCredentials` immediately after storing a connected account credential in the OAuth callback
- TEE mode: escrow fires right after encrypted token is stored and account record upserted
- Direct mode: escrow fires after `HandleCallback` succeeds, guarded by `enclaveClient != nil`
- Closes the gap where connecting Slack required a separate vault unlock before async Slack operations worked

**User flow after this change:**
1. User connects Slack account (vault is already unlocked for this)
2. Credential auto-escrowed to TEE (7-day TTL)
3. User talks to Aileron in Slack — works immediately

## Test plan

- [x] `TestConnectAccountCallbackTEEBranch` extended to verify escrow index is populated after connect
- [x] All existing tests pass
- [ ] Manual: connect Slack account → immediately talk to Aileron in Slack → response generated

🤖 Generated with [Claude Code](https://claude.com/claude-code)