### PR TITLE
fix(slack): delegate to install handler regardless of auth state

### DIFF
--- a/core/app/handlers_connected_accounts.go
+++ b/core/app/handlers_connected_accounts.go
@@ -7,7 +7,6 @@ import (
 
 	"github.com/ALRubinger/aileron/core/account"
 	api "github.com/ALRubinger/aileron/core/api/gen"
-	"github.com/ALRubinger/aileron/core/auth"
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/vault"
@@ -257,15 +256,14 @@ func (s *apiServer) ConnectAccount(w http.ResponseWriter, r *http.Request, provi
 func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Request, providerStr string, params api.ConnectAccountCallbackParams) {
 	// Slack Marketplace and App Directory installs may redirect here instead
 	// of /v1/slack/install/callback (we don't control the redirect URL Slack
-	// chooses). Detect this case: provider is slack, no state cookie (the
+	// chooses). Detect this case: provider is slack and no state cookie. The
 	// cookie is only set when a user starts the connect flow from Aileron's
-	// UI), and no authentication credentials.
+	// UI, so its absence means this is a bot install — even if the admin
+	// happens to be logged into Aileron.
 	if providerStr == "slack" {
 		if _, err := r.Cookie("aileron_connect_state"); err != nil {
-			if auth.ClaimsFromContext(r.Context()) == nil {
-				s.handleSlackInstall(w, r)
-				return
-			}
+			s.handleSlackInstall(w, r)
+			return
 		}
 	}
 

--- a/core/app/handlers_connected_accounts_test.go
+++ b/core/app/handlers_connected_accounts_test.go
@@ -763,6 +763,51 @@ func TestConnectAccountCallback_SlackInstallDelegation(t *testing.T) {
 	}
 }
 
+func TestConnectAccountCallback_SlackInstallDelegation_Authenticated(t *testing.T) {
+	// Regression: an admin logged into Aileron clicks the Slack-generated
+	// install URL. There's no state cookie (the flow wasn't started from
+	// Aileron's UI), but there ARE auth claims from the session. The handler
+	// must still delegate to handleSlackInstall.
+	srv := newConnectedAccountServer()
+	srv.systemVault = vault.NewMemVault()
+	srv.slackClientID = "test-client-id"
+	srv.slackClientSecret = "test-client-secret"
+	srv.slackBotExchanger = func(_, _, code, _ string) (*slackBotInstallResponse, error) {
+		if code != "admin-install-code" {
+			t.Errorf("code = %q, want admin-install-code", code)
+		}
+		return &slackBotInstallResponse{
+			OK:          true,
+			AccessToken: "xoxb-admin-install",
+			BotUserID:   "U_BOT",
+			Team: struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}{"T_ADMIN", "admin-ws"},
+		}, nil
+	}
+
+	req := httptest.NewRequest("GET", "/v1/connect/slack/callback?code=admin-install-code", nil)
+	// Authenticated user — no state cookie.
+	ctx := auth.ContextWithClaims(req.Context(), &auth.Claims{})
+	req = req.WithContext(ctx)
+
+	w := httptest.NewRecorder()
+	srv.ConnectAccountCallback(w, req, "slack", api.ConnectAccountCallbackParams{Code: "admin-install-code", State: nil})
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200 (install delegation), got %d: %s", w.Code, w.Body.String())
+	}
+
+	secret, err := srv.systemVault.Get(context.Background(), "slack-workspaces/T_ADMIN/bot-token")
+	if err != nil {
+		t.Fatalf("expected bot token in system vault: %v", err)
+	}
+	if string(secret.Value) != "xoxb-admin-install" {
+		t.Errorf("stored token = %q, want xoxb-admin-install", secret.Value)
+	}
+}
+
 func TestConnectAccountCallback_SlackWithAuth_DoesNotDelegate(t *testing.T) {
 	// When an authenticated Slack request hits the connect callback with a
 	// state cookie, it should follow the normal user account connection flow,


### PR DESCRIPTION
## Summary

- The Slack install delegation in `ConnectAccountCallback` required no state cookie **and** no auth claims. An admin logged into Aileron who clicks the Slack-generated install URL has auth claims from their session cookie, so the delegation was skipped and the handler returned "state mismatch; possible CSRF".
- Removed the auth claims check — the state cookie alone is the differentiator. No cookie means the flow wasn't started from Aileron's connect UI, so it's a bot install regardless of auth state.

## Test plan

- [x] New regression test: authenticated user, no state cookie → delegates to install handler (200)
- [x] Existing test: unauthenticated, no state cookie → delegates (200)
- [x] Existing test: authenticated with state cookie → normal connect flow (does not delegate)
- [x] Full `./core/...` test suite passes
- [ ] Log into Aileron, click the Slack-generated install URL, verify install completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)