### PR TITLE
fix(slack): use actual request path as redirect URI in token exchange

### DIFF
--- a/core/app/handlers_slack_install.go
+++ b/core/app/handlers_slack_install.go
@@ -38,11 +38,11 @@ type slackBotInstallResponse struct {
 // slackBotTokenExchanger exchanges a code for a bot install response.
 type slackBotTokenExchanger func(clientID, clientSecret, code, redirectURI string) (*slackBotInstallResponse, error)
 
-// handleSlackInstall handles GET /v1/slack/install/callback.
-// This is the OAuth redirect endpoint for Slack bot installation. When a
-// workspace admin installs the Aileron app from the Slack App Directory,
-// Slack redirects here with an authorization code. We exchange it for a bot
-// token and store it in the system vault.
+// handleSlackInstall handles Slack bot installation. It may be called directly
+// via GET /v1/slack/install/callback or delegated from ConnectAccountCallback
+// when Slack redirects to /v1/connect/slack/callback without a state cookie.
+// It exchanges the authorization code for a bot token and stores it in the
+// system vault.
 //
 // This endpoint is unauthenticated — the admin may not have an Aileron account.
 func (s *apiServer) handleSlackInstall(w http.ResponseWriter, r *http.Request) {
@@ -63,7 +63,7 @@ func (s *apiServer) handleSlackInstall(w http.ResponseWriter, r *http.Request) {
 		exchanger = s.defaultSlackBotTokenExchange
 	}
 
-	redirectURI := buildRedirectURI(r, "/v1/slack/install/callback")
+	redirectURI := buildRedirectURI(r, r.URL.Path)
 	resp, err := exchanger(s.slackClientID, s.slackClientSecret, code, redirectURI)
 	if err != nil {
 		s.log.Error("slack install: token exchange failed", "error", err)

--- a/core/app/handlers_slack_install_test.go
+++ b/core/app/handlers_slack_install_test.go
@@ -84,6 +84,37 @@ func TestHandleSlackInstall_Success(t *testing.T) {
 	}
 }
 
+func TestHandleSlackInstall_RedirectURIMatchesRequestPath(t *testing.T) {
+	// Regression: when handleSlackInstall is called via delegation from
+	// ConnectAccountCallback, the request path is /v1/connect/slack/callback,
+	// not /v1/slack/install/callback. The redirect_uri in the token exchange
+	// must match the actual request path.
+	srv := newInstallTestServer(t)
+	srv.slackBotExchanger = func(_, _, _, redirectURI string) (*slackBotInstallResponse, error) {
+		want := "http://api.example.com/v1/connect/slack/callback"
+		if redirectURI != want {
+			t.Errorf("redirectURI = %q, want %q", redirectURI, want)
+		}
+		return &slackBotInstallResponse{
+			OK:          true,
+			AccessToken: "xoxb-token",
+			BotUserID:   "U_BOT",
+			Team: struct {
+				ID   string `json:"id"`
+				Name string `json:"name"`
+			}{"T001", "ws"},
+		}, nil
+	}
+
+	req := httptest.NewRequest("GET", "http://api.example.com/v1/connect/slack/callback?code=test", nil)
+	w := httptest.NewRecorder()
+	srv.handleSlackInstall(w, req)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
 func TestHandleSlackInstall_MissingCode(t *testing.T) {
 	srv := newInstallTestServer(t)
 


### PR DESCRIPTION
## Summary

- `handleSlackInstall` hardcoded `/v1/slack/install/callback` as the `redirect_uri` for the Slack token exchange. When called via delegation from `ConnectAccountCallback` (where the request path is `/v1/connect/slack/callback`), the mismatch caused Slack to reject the exchange with a 502.
- Use `r.URL.Path` so the redirect URI always matches the path Slack actually redirected to.

## Test plan

- [x] Regression test verifying redirect URI matches `/v1/connect/slack/callback` when called via delegation path
- [x] All existing Slack install tests pass
- [x] Full `./core/...` test suite passes
- [ ] Click the Slack-generated install URL and verify install completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)