### PR TITLE
feat(vault,slack): durable escrow storage + conversational draft refinement

### DIFF
--- a/cmd/aileron-enclave/escrow.go
+++ b/cmd/aileron-enclave/escrow.go
@@ -3,15 +3,20 @@ package main
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"encoding/json"
+	"fmt"
+	"os"
+	"path/filepath"
 	"sync"
 	"time"
 
+	"github.com/ALRubinger/aileron/core/crypto"
 	"github.com/ALRubinger/aileron/enclave"
 )
 
 type escrowEntry struct {
 	grantID     string
-	credential  []byte // plaintext, held in enclave memory only
+	credential  []byte // plaintext, held in enclave memory
 	credType    string
 	actionTypes []string
 	expiresAt   time.Time
@@ -20,10 +25,46 @@ type escrowEntry struct {
 type escrowStore struct {
 	mu      sync.RWMutex
 	entries map[string]*escrowEntry
+	dataDir string // empty = in-memory only (no persistence)
+	encKey  []byte // 32-byte DEK for at-rest encryption
 }
 
-func newEscrowStore() *escrowStore {
-	return &escrowStore{entries: make(map[string]*escrowEntry)}
+// persistedEntry is the JSON-serializable form of an escrow entry.
+type persistedEntry struct {
+	GrantID     string    `json:"grant_id"`
+	Credential  []byte    `json:"credential"`
+	CredType    string    `json:"cred_type"`
+	ActionTypes []string  `json:"action_types"`
+	ExpiresAt   time.Time `json:"expires_at"`
+}
+
+func newEscrowStore(dataDir string) (*escrowStore, error) {
+	s := &escrowStore{entries: make(map[string]*escrowEntry)}
+
+	if dataDir == "" {
+		return s, nil
+	}
+
+	s.dataDir = dataDir
+	if err := os.MkdirAll(dataDir, 0700); err != nil {
+		return nil, fmt.Errorf("creating escrow data dir: %w", err)
+	}
+
+	key, err := enclave.LoadOrCreateKey(filepath.Join(dataDir, "escrow.key"))
+	if err != nil {
+		return nil, err
+	}
+	s.encKey = key
+
+	// Load existing entries from disk.
+	if err := s.load(); err != nil {
+		return nil, err
+	}
+
+	// Evict any expired entries loaded from disk.
+	s.EvictExpired()
+
+	return s, nil
 }
 
 // Store adds a plaintext credential to the escrow. Returns the escrow ID.
@@ -40,6 +81,7 @@ func (s *escrowStore) Store(grantID string, credential []byte, credType string, 
 		actionTypes: actionTypes,
 		expiresAt:   expiresAt,
 	}
+	s.persistLocked()
 	s.mu.Unlock()
 	return id
 }
@@ -60,6 +102,26 @@ func (s *escrowStore) Get(escrowID string) ([]byte, error) {
 	return copyBytes(entry.credential), nil
 }
 
+// List returns metadata for all non-expired escrow entries.
+func (s *escrowStore) List() []enclave.EscrowListEntry {
+	now := time.Now()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var entries []enclave.EscrowListEntry
+	for id, entry := range s.entries {
+		if now.After(entry.expiresAt) {
+			continue
+		}
+		entries = append(entries, enclave.EscrowListEntry{
+			EscrowID:  id,
+			GrantID:   entry.grantID,
+			ExpiresAt: entry.expiresAt.Format(time.RFC3339),
+		})
+	}
+	return entries
+}
+
 // Revoke removes an escrow entry and zeros the credential bytes.
 func (s *escrowStore) Revoke(escrowID, grantID string) error {
 	s.mu.Lock()
@@ -74,6 +136,7 @@ func (s *escrowStore) Revoke(escrowID, grantID string) error {
 	}
 	zeroBytes(entry.credential)
 	delete(s.entries, escrowID)
+	s.persistLocked()
 	return nil
 }
 
@@ -82,11 +145,16 @@ func (s *escrowStore) EvictExpired() {
 	now := time.Now()
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	evicted := false
 	for id, entry := range s.entries {
 		if now.After(entry.expiresAt) {
 			zeroBytes(entry.credential)
 			delete(s.entries, id)
+			evicted = true
 		}
+	}
+	if evicted {
+		s.persistLocked()
 	}
 }
 
@@ -96,5 +164,75 @@ func (s *escrowStore) revokeByID(escrowID string) {
 	if entry, ok := s.entries[escrowID]; ok {
 		zeroBytes(entry.credential)
 		delete(s.entries, escrowID)
+		s.persistLocked()
 	}
+}
+
+// persistLocked writes all entries to disk encrypted. Caller must hold mu.
+func (s *escrowStore) persistLocked() {
+	if s.dataDir == "" {
+		return
+	}
+
+	persisted := make(map[string]*persistedEntry, len(s.entries))
+	for id, e := range s.entries {
+		persisted[id] = &persistedEntry{
+			GrantID:     e.grantID,
+			Credential:  e.credential,
+			CredType:    e.credType,
+			ActionTypes: e.actionTypes,
+			ExpiresAt:   e.expiresAt,
+		}
+	}
+
+	data, err := json.Marshal(persisted)
+	if err != nil {
+		return // best-effort; in-memory state is still correct
+	}
+
+	ciphertext, err := crypto.Encrypt(data, s.encKey)
+	if err != nil {
+		return
+	}
+
+	path := filepath.Join(s.dataDir, "escrow.dat")
+	tmp := path + ".tmp"
+	if err := os.WriteFile(tmp, ciphertext, 0600); err != nil {
+		return
+	}
+	os.Rename(tmp, path)
+}
+
+// load reads and decrypts entries from disk into the in-memory map.
+func (s *escrowStore) load() error {
+	path := filepath.Join(s.dataDir, "escrow.dat")
+	ciphertext, err := os.ReadFile(path)
+	if os.IsNotExist(err) {
+		return nil // no data yet
+	}
+	if err != nil {
+		return fmt.Errorf("reading escrow data: %w", err)
+	}
+
+	data, err := crypto.Decrypt(ciphertext, s.encKey)
+	if err != nil {
+		// Corrupt or wrong key — start fresh rather than fail.
+		return nil
+	}
+
+	var persisted map[string]*persistedEntry
+	if err := json.Unmarshal(data, &persisted); err != nil {
+		return nil // corrupt JSON — start fresh
+	}
+
+	for id, pe := range persisted {
+		s.entries[id] = &escrowEntry{
+			grantID:     pe.GrantID,
+			credential:  pe.Credential,
+			credType:    pe.CredType,
+			actionTypes: pe.ActionTypes,
+			expiresAt:   pe.ExpiresAt,
+		}
+	}
+	return nil
 }

--- a/cmd/aileron-enclave/escrow_test.go
+++ b/cmd/aileron-enclave/escrow_test.go
@@ -1,14 +1,24 @@
 package main
 
 import (
+	"os"
 	"testing"
 	"time"
 
 	"github.com/ALRubinger/aileron/enclave"
 )
 
+func mustNewEscrowStore(t *testing.T) *escrowStore {
+	t.Helper()
+	s, err := newEscrowStore("") // in-memory only
+	if err != nil {
+		t.Fatalf("newEscrowStore: %v", err)
+	}
+	return s
+}
+
 func TestEscrowStoreAndGet(t *testing.T) {
-	s := newEscrowStore()
+	s := mustNewEscrowStore(t)
 	cred := []byte("test-cred")
 	id := s.Store("grant-1", cred, "api_key", []string{"action"}, time.Now().Add(time.Hour))
 
@@ -29,7 +39,7 @@ func TestEscrowStoreAndGet(t *testing.T) {
 }
 
 func TestEscrowNotFound(t *testing.T) {
-	s := newEscrowStore()
+	s := mustNewEscrowStore(t)
 	_, err := s.Get("nonexistent")
 	if err != enclave.ErrEscrowNotFound {
 		t.Fatalf("expected ErrEscrowNotFound, got %v", err)
@@ -37,7 +47,7 @@ func TestEscrowNotFound(t *testing.T) {
 }
 
 func TestEscrowExpired(t *testing.T) {
-	s := newEscrowStore()
+	s := mustNewEscrowStore(t)
 	id := s.Store("g1", []byte("dead"), "api_key", nil, time.Now().Add(-time.Second))
 	_, err := s.Get(id)
 	if err != enclave.ErrEscrowExpired {
@@ -46,7 +56,7 @@ func TestEscrowExpired(t *testing.T) {
 }
 
 func TestEscrowRevokeWrongGrant(t *testing.T) {
-	s := newEscrowStore()
+	s := mustNewEscrowStore(t)
 	id := s.Store("grant-1", []byte("cred"), "api_key", nil, time.Now().Add(time.Hour))
 	err := s.Revoke(id, "wrong-grant")
 	if err != enclave.ErrEscrowNotFound {
@@ -55,7 +65,7 @@ func TestEscrowRevokeWrongGrant(t *testing.T) {
 }
 
 func TestEscrowEvictExpired(t *testing.T) {
-	s := newEscrowStore()
+	s := mustNewEscrowStore(t)
 	live := []byte("live")
 	dead := []byte("dead")
 	liveID := s.Store("g1", live, "api_key", nil, time.Now().Add(time.Hour))
@@ -75,9 +85,98 @@ func TestEscrowEvictExpired(t *testing.T) {
 }
 
 func TestEscrowRevokeNotFound(t *testing.T) {
-	s := newEscrowStore()
+	s := mustNewEscrowStore(t)
 	err := s.Revoke("nonexistent", "grant")
 	if err != enclave.ErrEscrowNotFound {
 		t.Fatalf("expected ErrEscrowNotFound, got %v", err)
+	}
+}
+
+func TestEscrowPersistence_RoundTrip(t *testing.T) {
+	dir := t.TempDir()
+
+	// Store entries in one escrow store.
+	s1, err := newEscrowStore(dir)
+	if err != nil {
+		t.Fatalf("newEscrowStore: %v", err)
+	}
+	id1 := s1.Store("grant-1", []byte("cred-one"), "oauth", nil, time.Now().Add(time.Hour))
+	id2 := s1.Store("grant-2", []byte("cred-two"), "api_key", []string{"email.send"}, time.Now().Add(2*time.Hour))
+
+	// Create a new escrow store from the same directory — simulates restart.
+	s2, err := newEscrowStore(dir)
+	if err != nil {
+		t.Fatalf("newEscrowStore after restart: %v", err)
+	}
+
+	got1, err := s2.Get(id1)
+	if err != nil {
+		t.Fatalf("Get id1 after restart: %v", err)
+	}
+	if string(got1) != "cred-one" {
+		t.Errorf("id1 = %q, want cred-one", got1)
+	}
+
+	got2, err := s2.Get(id2)
+	if err != nil {
+		t.Fatalf("Get id2 after restart: %v", err)
+	}
+	if string(got2) != "cred-two" {
+		t.Errorf("id2 = %q, want cred-two", got2)
+	}
+}
+
+func TestEscrowPersistence_ExpiredNotLoaded(t *testing.T) {
+	dir := t.TempDir()
+
+	s1, err := newEscrowStore(dir)
+	if err != nil {
+		t.Fatalf("newEscrowStore: %v", err)
+	}
+	// Store an already-expired entry.
+	id := s1.Store("g1", []byte("expired-cred"), "oauth", nil, time.Now().Add(-time.Second))
+
+	// Restart — expired entry should be evicted on load.
+	s2, err := newEscrowStore(dir)
+	if err != nil {
+		t.Fatalf("newEscrowStore after restart: %v", err)
+	}
+	_, err = s2.Get(id)
+	if err == nil {
+		t.Fatal("expected error for expired entry after restart")
+	}
+}
+
+func TestEscrowPersistence_CorruptFile(t *testing.T) {
+	dir := t.TempDir()
+
+	// Write garbage to the data file.
+	os.WriteFile(dir+"/escrow.dat", []byte("not encrypted"), 0600)
+
+	// Generate a valid key so newEscrowStore doesn't fail on key load.
+	enclave.LoadOrCreateKey(dir + "/escrow.key")
+
+	// Should start fresh, not error out.
+	s, err := newEscrowStore(dir)
+	if err != nil {
+		t.Fatalf("newEscrowStore with corrupt file: %v", err)
+	}
+
+	// Should be empty.
+	entries := s.List()
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries after corrupt file, got %d", len(entries))
+	}
+}
+
+func TestEscrowList(t *testing.T) {
+	s := mustNewEscrowStore(t)
+	s.Store("g1", []byte("c1"), "oauth", nil, time.Now().Add(time.Hour))
+	s.Store("g2", []byte("c2"), "api_key", nil, time.Now().Add(time.Hour))
+	s.Store("g3", []byte("expired"), "api_key", nil, time.Now().Add(-time.Second))
+
+	entries := s.List()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 non-expired entries, got %d", len(entries))
 	}
 }

--- a/cmd/aileron-enclave/escrow_test.go
+++ b/cmd/aileron-enclave/escrow_test.go
@@ -5,8 +5,13 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/core/crypto"
 	"github.com/ALRubinger/aileron/enclave"
 )
+
+func encryptForTest(data, key []byte) ([]byte, error) {
+	return crypto.Encrypt(data, key)
+}
 
 func mustNewEscrowStore(t *testing.T) *escrowStore {
 	t.Helper()
@@ -166,6 +171,64 @@ func TestEscrowPersistence_CorruptFile(t *testing.T) {
 	entries := s.List()
 	if len(entries) != 0 {
 		t.Errorf("expected 0 entries after corrupt file, got %d", len(entries))
+	}
+}
+
+func TestNewEscrowStore_MkdirFailure(t *testing.T) {
+	// Use a file as the "directory" path — MkdirAll will fail.
+	dir := t.TempDir()
+	blockingFile := dir + "/blocker"
+	os.WriteFile(blockingFile, []byte("x"), 0600)
+
+	_, err := newEscrowStore(blockingFile + "/subdir")
+	if err == nil {
+		t.Fatal("expected error when data dir path is blocked by a file")
+	}
+}
+
+func TestEscrowPersistence_ReadError(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create a valid key.
+	enclave.LoadOrCreateKey(dir + "/escrow.key")
+
+	// Make escrow.dat a directory so ReadFile fails with a non-NotExist error.
+	os.Mkdir(dir+"/escrow.dat", 0700)
+
+	_, err := newEscrowStore(dir)
+	if err == nil {
+		t.Fatal("expected error when escrow.dat is a directory")
+	}
+}
+
+func TestEscrowPersistence_CorruptJSON(t *testing.T) {
+	dir := t.TempDir()
+
+	// Create store and persist an entry to generate key + valid encrypted blob.
+	s1, err := newEscrowStore(dir)
+	if err != nil {
+		t.Fatalf("newEscrowStore: %v", err)
+	}
+	s1.Store("g1", []byte("cred"), "api_key", nil, time.Now().Add(time.Hour))
+
+	// Now overwrite escrow.dat with data that decrypts to invalid JSON.
+	// We use the existing key to encrypt garbage JSON.
+	key, _ := os.ReadFile(dir + "/escrow.key")
+	badJSON := []byte("{invalid json")
+	encrypted, err := encryptForTest(badJSON, key)
+	if err != nil {
+		t.Fatalf("encrypting bad JSON: %v", err)
+	}
+	os.WriteFile(dir+"/escrow.dat", encrypted, 0600)
+
+	// Should start fresh (not error).
+	s2, err := newEscrowStore(dir)
+	if err != nil {
+		t.Fatalf("newEscrowStore with corrupt JSON: %v", err)
+	}
+	entries := s2.List()
+	if len(entries) != 0 {
+		t.Errorf("expected 0 entries, got %d", len(entries))
 	}
 }
 

--- a/cmd/aileron-enclave/main.go
+++ b/cmd/aileron-enclave/main.go
@@ -36,6 +36,16 @@ func main() {
 		provider = "local"
 	}
 
+	dataDir := os.Getenv("AILERON_ENCLAVE_DATA_DIR")
+	if dataDir == "" {
+		if provider == "confidential-space" {
+			dataDir = "/data/enclave"
+		} else {
+			home, _ := os.UserHomeDir()
+			dataDir = home + "/.aileron/enclave"
+		}
+	}
+
 	// Build connector registry.
 	ctx := context.Background()
 	registry := connector.NewRegistry()
@@ -43,7 +53,11 @@ func main() {
 	registry.Register(ctx, googlecalendar.New())
 	registry.Register(ctx, github.New())
 
-	srv := newEnclaveServer(log, registry, provider)
+	srv, err := newEnclaveServer(log, registry, provider, dataDir)
+	if err != nil {
+		log.Error("failed to initialize enclave server", "error", err)
+		os.Exit(1)
+	}
 	mux := http.NewServeMux()
 	srv.registerRoutes(mux)
 
@@ -53,6 +67,15 @@ func main() {
 		ReadTimeout:  30 * time.Second,
 		WriteTimeout: 30 * time.Second,
 	}
+
+	// Background escrow cleanup.
+	go func() {
+		ticker := time.NewTicker(10 * time.Minute)
+		defer ticker.Stop()
+		for range ticker.C {
+			srv.escrow.EvictExpired()
+		}
+	}()
 
 	// Graceful shutdown.
 	done := make(chan os.Signal, 1)

--- a/cmd/aileron-enclave/server.go
+++ b/cmd/aileron-enclave/server.go
@@ -33,14 +33,18 @@ type enclaveServer struct {
 	escrow     *escrowStore
 }
 
-func newEnclaveServer(log *slog.Logger, registry *connector.Registry, provider string) *enclaveServer {
+func newEnclaveServer(log *slog.Logger, registry *connector.Registry, provider, dataDir string) (*enclaveServer, error) {
+	escrow, err := newEscrowStore(dataDir)
+	if err != nil {
+		return nil, fmt.Errorf("initializing escrow store: %w", err)
+	}
 	return &enclaveServer{
 		log:      log,
 		registry: registry,
 		provider: provider,
 		keks:     newKEKStore(),
-		escrow:   newEscrowStore(),
-	}
+		escrow:   escrow,
+	}, nil
 }
 
 func (s *enclaveServer) registerRoutes(mux *http.ServeMux) {
@@ -51,6 +55,7 @@ func (s *enclaveServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /execute", s.handleExecute)
 	mux.HandleFunc("POST /escrow", s.handleEscrowStore)
 	mux.HandleFunc("POST /escrow/retrieve", s.handleEscrowRetrieve)
+	mux.HandleFunc("POST /escrow/list", s.handleEscrowList)
 	mux.HandleFunc("POST /escrow/revoke", s.handleEscrowRevoke)
 	mux.HandleFunc("GET /health", s.handleHealth)
 }
@@ -324,6 +329,11 @@ func (s *enclaveServer) handleEscrowRetrieve(w http.ResponseWriter, r *http.Requ
 	}
 
 	writeJSON(w, http.StatusOK, enclave.EscrowRetrieveResponse{Credential: plaintext})
+}
+
+func (s *enclaveServer) handleEscrowList(w http.ResponseWriter, _ *http.Request) {
+	entries := s.escrow.List()
+	writeJSON(w, http.StatusOK, enclave.EscrowListResponse{Entries: entries})
 }
 
 func (s *enclaveServer) handleEscrowRevoke(w http.ResponseWriter, r *http.Request) {

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -37,7 +37,10 @@ func setupTestEnclaveServer(t *testing.T) (*httptest.Server, *enclaveServer) {
 	log := slog.New(slog.NewJSONHandler(io.Discard, nil))
 	registry := connector.NewRegistry()
 	registry.Register(context.Background(), &stubConnector{})
-	srv := newEnclaveServer(log, registry, "local")
+	srv, err := newEnclaveServer(log, registry, "local", "")
+	if err != nil {
+		t.Fatalf("newEnclaveServer: %v", err)
+	}
 	mux := http.NewServeMux()
 	srv.registerRoutes(mux)
 	return httptest.NewServer(mux), srv

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -1000,6 +1000,66 @@ func TestOAuthExchangeBadJSON(t *testing.T) {
 	}
 }
 
+func TestEscrowListEndpoint(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	// Empty list.
+	resp, err := http.Post(server.URL+"/escrow/list", "application/json", bytes.NewReader([]byte("{}")))
+	if err != nil {
+		t.Fatalf("POST /escrow/list: %v", err)
+	}
+	result := decodeResp[enclave.EscrowListResponse](t, resp)
+	if len(result.Entries) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(result.Entries))
+	}
+
+	// Store some entries, then list.
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	encrypted, _ := crypto.Encrypt([]byte("cred-1"), userKEK)
+	storeResp := postJSON(t, server, "/escrow", enclave.EscrowStoreRequest{
+		UserID:              "user-1",
+		GrantID:             "g1",
+		EncryptedCredential: encrypted,
+		CredentialType:      "oauth_token",
+		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
+	})
+	storeResult := decodeResp[enclave.EscrowStoreResponse](t, storeResp)
+
+	resp2, err := http.Post(server.URL+"/escrow/list", "application/json", bytes.NewReader([]byte("{}")))
+	if err != nil {
+		t.Fatalf("POST /escrow/list: %v", err)
+	}
+	result2 := decodeResp[enclave.EscrowListResponse](t, resp2)
+	if len(result2.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(result2.Entries))
+	}
+	if result2.Entries[0].EscrowID != storeResult.EscrowID {
+		t.Fatalf("expected %q, got %q", storeResult.EscrowID, result2.Entries[0].EscrowID)
+	}
+	if result2.Entries[0].GrantID != "g1" {
+		t.Fatalf("expected grant g1, got %q", result2.Entries[0].GrantID)
+	}
+}
+
+func TestEscrowRetrieveBadJSON(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	resp, err := http.Post(server.URL+"/escrow/retrieve", "application/json", bytes.NewReader([]byte("bad")))
+	if err != nil {
+		t.Fatalf("POST /escrow/retrieve: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+}
+
 func TestResolveConnectorID(t *testing.T) {
 	tests := []struct {
 		input      string

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -226,7 +226,6 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 				kekCache.EvictExpired()
 			}
 		}()
-
 		// Switch to Postgres-backed stores and vault now that the database is available.
 		pgConnectedAccountStore := postgres.NewConnectedAccountStore(db)
 		server.connectedAccounts = pgConnectedAccountStore
@@ -236,6 +235,29 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		server.feedback = postgres.NewDraftFeedbackStore(db)
 		v = vault.NewPostgresVault(db.Pool)
 		server.vault = v
+		escrowIndexStore := postgres.NewEscrowIndexStore(db)
+		server.escrowIndexStore = escrowIndexStore
+
+		// Background cleanup of expired escrow index entries.
+		go func() {
+			ticker := time.NewTicker(10 * time.Minute)
+			defer ticker.Stop()
+			for range ticker.C {
+				if n, err := escrowIndexStore.DeleteExpired(context.Background()); err == nil && n > 0 {
+					log.Info("cleaned expired escrow index entries", "count", n)
+				}
+			}
+		}()
+
+		// Load persisted escrow index so async flows (Slack) work after restart.
+		if idx, err := escrowIndexStore.LoadAll(ctx); err == nil {
+			for path, id := range idx {
+				server.escrowIndex.Store(path, id)
+			}
+			if len(idx) > 0 {
+				log.Info("loaded escrow index from database", "entries", len(idx))
+			}
+		}
 		log.Info("using Postgres-backed stores and vault")
 
 		// System vault for infrastructure secrets (ADR-0020).

--- a/core/app/handlers.go
+++ b/core/app/handlers.go
@@ -25,6 +25,7 @@ import (
 	"github.com/ALRubinger/aileron/core/policy"
 	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/store/mem"
+	"github.com/ALRubinger/aileron/core/store/postgres"
 	"github.com/ALRubinger/aileron/core/vault"
 	"github.com/ALRubinger/aileron/core/version"
 	"github.com/ALRubinger/aileron/enclave"
@@ -86,6 +87,7 @@ type apiServer struct {
 	teeState           *teeState                  // nil when TEE is disabled
 	escrowTTL          time.Duration              // TTL for auto-escrowed credentials
 	escrowIndex        sync.Map                   // vault path (string) -> escrow ID (string)
+	escrowIndexStore   *postgres.EscrowIndexStore // nil when auth is disabled; persists escrowIndex across restarts
 	uiBaseURL          string                     // base URL for the web UI (for constructing unlock links)
 	newID              func() string
 }

--- a/core/app/handlers_execution_test.go
+++ b/core/app/handlers_execution_test.go
@@ -58,6 +58,9 @@ func (e *stubEnclaveClient) EscrowStore(_ context.Context, _ enclave.EscrowStore
 func (e *stubEnclaveClient) EscrowRetrieve(_ context.Context, _ enclave.EscrowRetrieveRequest) (enclave.EscrowRetrieveResponse, error) {
 	return enclave.EscrowRetrieveResponse{}, nil
 }
+func (e *stubEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowListResponse, error) {
+	return enclave.EscrowListResponse{}, nil
+}
 func (e *stubEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }

--- a/core/app/handlers_passphrase_test.go
+++ b/core/app/handlers_passphrase_test.go
@@ -61,6 +61,9 @@ func (c *mockEscrowClient) EscrowRetrieve(_ context.Context, req enclave.EscrowR
 	}
 	return enclave.EscrowRetrieveResponse{}, enclave.ErrEscrowNotFound
 }
+func (c *mockEscrowClient) EscrowList(_ context.Context) (enclave.EscrowListResponse, error) {
+	return enclave.EscrowListResponse{}, nil
+}
 func (c *mockEscrowClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }

--- a/core/app/handlers_slack_agent_test.go
+++ b/core/app/handlers_slack_agent_test.go
@@ -663,6 +663,9 @@ func (stubEscrowEnclaveClient) EscrowStore(_ context.Context, _ enclave.EscrowSt
 func (stubEscrowEnclaveClient) EscrowRetrieve(_ context.Context, req enclave.EscrowRetrieveRequest) (enclave.EscrowRetrieveResponse, error) {
 	return enclave.EscrowRetrieveResponse{Credential: []byte("escrow-plaintext")}, nil
 }
+func (stubEscrowEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowListResponse, error) {
+	return enclave.EscrowListResponse{}, nil
+}
 func (stubEscrowEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }

--- a/core/app/handlers_slack_interactions.go
+++ b/core/app/handlers_slack_interactions.go
@@ -40,7 +40,7 @@ type slackInteractionPayload struct {
 				Value string `json:"value"`
 			} `json:"values"`
 		} `json:"state"`
-	} `json:"view,omitempty"` // view_submission only
+	} `json:"view,omitempty"` // view_submission and modal block_actions
 	ResponseURL string `json:"response_url"`
 }
 
@@ -140,8 +140,93 @@ func (s *apiServer) processInteraction(actionID, actionValue string, payload sla
 			"channel", sendMeta.Channel,
 		)
 
+	case refineActionID:
+		s.processRefineDraft(ctx, payload)
+
 	default:
 		s.log.Debug("interaction: unknown action", "action_id", actionID)
+	}
+}
+
+// processRefineDraft handles the "Refine" button click in the draft modal.
+// It extracts the current draft and feedback from the view state, runs the
+// pipeline's RefineDraft method, and updates the modal with the revised draft.
+func (s *apiServer) processRefineDraft(ctx context.Context, payload slackInteractionPayload) {
+	if payload.View == nil {
+		s.log.Error("refine: no view in payload")
+		return
+	}
+
+	meta, err := parseDraftModalMeta(payload.View.PrivateMetadata)
+	if err != nil {
+		s.log.Error("refine: failed to parse metadata", "error", err)
+		return
+	}
+
+	// Extract current draft and feedback from view state.
+	var draftText, feedback string
+	if payload.View.State != nil {
+		if block, ok := payload.View.State.Values[draftInputBlockID]; ok {
+			if input, ok := block[draftInputActionID]; ok {
+				draftText = input.Value
+			}
+		}
+		if block, ok := payload.View.State.Values[instructionBlockID]; ok {
+			if input, ok := block[instructionActionID]; ok {
+				feedback = input.Value
+			}
+		}
+	}
+
+	if draftText == "" {
+		s.log.Warn("refine: empty draft text")
+		return
+	}
+	if feedback == "" {
+		s.log.Warn("refine: no feedback provided")
+		return
+	}
+
+	teamID := ""
+	if payload.Team != nil {
+		teamID = payload.Team.ID
+	}
+
+	botToken, err := s.resolveWorkspaceBotToken(ctx, teamID)
+	if err != nil {
+		s.log.Error("refine: failed to resolve bot token", "error", err)
+		return
+	}
+
+	// Show loading state while refining.
+	_ = updateDraftModalLoading(ctx, botToken, payload.View.ID, "Refining...", meta)
+
+	userID, err := s.resolveAileronUserBySlack(ctx, meta.UserID, teamID)
+	if err != nil {
+		s.log.Error("refine: failed to resolve user", "error", err)
+		_ = updateDraftModalError(ctx, botToken, payload.View.ID, "Could not find your Aileron account.", meta)
+		return
+	}
+
+	pipeline := s.resolvePipelineVault(userID)
+	if pipeline == nil {
+		if s.draftPipeline == nil {
+			_ = updateDraftModalError(ctx, botToken, payload.View.ID, "Draft generation is not configured.", meta)
+		} else {
+			_ = updateDraftModalError(ctx, botToken, payload.View.ID, s.vaultLockedMessage(), meta)
+		}
+		return
+	}
+
+	refined, err := pipeline.RefineDraft(ctx, userID, meta.OriginalMessage, draftText, feedback)
+	if err != nil {
+		s.log.Error("refine: pipeline error", "error", err)
+		_ = updateDraftModalError(ctx, botToken, payload.View.ID, "Refinement failed. Please try again.", meta)
+		return
+	}
+
+	if err := updateDraftModalWithDraft(ctx, botToken, payload.View.ID, refined, meta); err != nil {
+		s.log.Error("refine: failed to update modal", "error", err)
 	}
 }
 

--- a/core/app/handlers_slack_interactions_test.go
+++ b/core/app/handlers_slack_interactions_test.go
@@ -17,7 +17,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/core/auth"
+	"github.com/ALRubinger/aileron/core/draft"
 	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/source"
 	"github.com/ALRubinger/aileron/core/store/mem"
 	"github.com/ALRubinger/aileron/core/vault"
 )
@@ -722,6 +725,191 @@ func TestInteraction_RefineAction_UserNotFound(t *testing.T) {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
 	time.Sleep(100 * time.Millisecond)
+}
+
+func TestInteraction_RefineAction_VaultLocked(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.systemVault = vault.NewMemVault()
+	srv.draftPipeline = newTestPipeline("context", "Draft reply")
+
+	// Bot token present.
+	srv.systemVault.Put(context.Background(), "slack-workspaces/T001/bot-token",
+		[]byte("xoxb-test-bot-token"), vault.Metadata{Type: "bot_token"})
+
+	// Set kekSessionCache so resolvePipelineVault doesn't fall through to
+	// tier 3 (no-auth local dev). Without a KEK for this user, it hits vault-locked.
+	srv.kekSessionCache = auth.NewKEKSessionCache(24 * time.Hour)
+
+	srv.connectedAccounts.Create(context.Background(), model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U_ALICE", ExternalTeamID: "T001",
+	})
+
+	meta, _ := json.Marshal(DraftModalMeta{
+		TargetChannel:   "C0BACKEND",
+		OriginalMessage: "Original msg",
+		UserID:          "U_ALICE",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_ALICE"},
+		"team": map[string]any{"id": "T001"},
+		"view": map[string]any{
+			"id":               "V_123",
+			"callback_id":      draftModalCallbackID,
+			"private_metadata": string(meta),
+			"state": map[string]any{
+				"values": map[string]any{
+					draftInputBlockID: map[string]any{
+						draftInputActionID: map[string]any{"value": "My draft"},
+					},
+					instructionBlockID: map[string]any{
+						instructionActionID: map[string]any{"value": "Make shorter"},
+					},
+				},
+			},
+		},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	// processRefineDraft should hit the vaultLockedMessage branch (L216).
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestInteraction_RefineAction_FullPipeline(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.systemVault = vault.NewMemVault()
+	srv.draftPipeline = newTestPipeline("context", "Refined draft text")
+
+	// Bot token.
+	srv.systemVault.Put(context.Background(), "slack-workspaces/T001/bot-token",
+		[]byte("xoxb-test-bot-token"), vault.Metadata{Type: "bot_token"})
+
+	// Connected account.
+	srv.connectedAccounts.Create(context.Background(), model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U_ALICE", ExternalTeamID: "T001",
+	})
+
+	// Unlock vault so resolvePipelineVault returns a pipeline (tier 3: no auth).
+	// kekSessionCache=nil signals local dev mode where vault is not required.
+
+	meta, _ := json.Marshal(DraftModalMeta{
+		TargetChannel:   "C0BACKEND",
+		OriginalMessage: "Can you review this PR?",
+		UserID:          "U_ALICE",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_ALICE"},
+		"team": map[string]any{"id": "T001"},
+		"view": map[string]any{
+			"id":               "V_123",
+			"callback_id":      draftModalCallbackID,
+			"private_metadata": string(meta),
+			"state": map[string]any{
+				"values": map[string]any{
+					draftInputBlockID: map[string]any{
+						draftInputActionID: map[string]any{"value": "Here is my draft review"},
+					},
+					instructionBlockID: map[string]any{
+						instructionActionID: map[string]any{"value": "Make it more professional"},
+					},
+				},
+			},
+		},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	// Exercises L202 (updateDraftModalLoading), L221 (RefineDraft), L228 (updateDraftModalWithDraft).
+	time.Sleep(200 * time.Millisecond)
+}
+
+func TestInteraction_RefineAction_PipelineError(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.systemVault = vault.NewMemVault()
+
+	// Pipeline that always errors.
+	errClient := &mockLLMClient{err: fmt.Errorf("LLM down")}
+	srv.draftPipeline = draft.NewPipeline(
+		errClient, errClient,
+		source.NewRegistry(),
+		mem.NewConnectedAccountStore(),
+		mem.NewUserInstructionStore(),
+		vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "r", Ghostwrite: "g"},
+	)
+
+	srv.systemVault.Put(context.Background(), "slack-workspaces/T001/bot-token",
+		[]byte("xoxb-test-bot-token"), vault.Metadata{Type: "bot_token"})
+	srv.connectedAccounts.Create(context.Background(), model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U_ALICE", ExternalTeamID: "T001",
+	})
+
+	meta, _ := json.Marshal(DraftModalMeta{
+		TargetChannel:   "C0BACKEND",
+		OriginalMessage: "Original msg",
+		UserID:          "U_ALICE",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_ALICE"},
+		"team": map[string]any{"id": "T001"},
+		"view": map[string]any{
+			"id":               "V_123",
+			"callback_id":      draftModalCallbackID,
+			"private_metadata": string(meta),
+			"state": map[string]any{
+				"values": map[string]any{
+					draftInputBlockID: map[string]any{
+						draftInputActionID: map[string]any{"value": "My draft"},
+					},
+					instructionBlockID: map[string]any{
+						instructionActionID: map[string]any{"value": "Feedback"},
+					},
+				},
+			},
+		},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	// Exercises L221-226 (pipeline error → updateDraftModalError).
+	time.Sleep(200 * time.Millisecond)
 }
 
 func TestInteraction_RefineAction_BadMetadata(t *testing.T) {

--- a/core/app/handlers_slack_interactions_test.go
+++ b/core/app/handlers_slack_interactions_test.go
@@ -425,6 +425,200 @@ func TestInteraction_SendDraftAgent_BadJSON(t *testing.T) {
 	// No crash — bad JSON logged and returned.
 }
 
+func TestInteraction_RefineAction_RoutedCorrectly(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	meta, _ := json.Marshal(DraftModalMeta{
+		TargetChannel:   "C0BACKEND",
+		OriginalMessage: "Original msg",
+		UserID:          "U_ALICE",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_ALICE"},
+		"team": map[string]any{"id": "T001"},
+		"view": map[string]any{
+			"id":               "V_123",
+			"callback_id":      draftModalCallbackID,
+			"private_metadata": string(meta),
+			"state": map[string]any{
+				"values": map[string]any{
+					draftInputBlockID: map[string]any{
+						draftInputActionID: map[string]any{
+							"value": "Current draft text",
+						},
+					},
+					instructionBlockID: map[string]any{
+						instructionActionID: map[string]any{
+							"value": "Make it shorter",
+						},
+					},
+				},
+			},
+		},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	// processRefineDraft runs async; it will fail on bot token resolution
+	// but the key assertion is that routing works and doesn't crash.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestInteraction_RefineAction_NoView(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_ALICE"},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+		// No view — processRefineDraft should log and return.
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestInteraction_RefineAction_EmptyDraft(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	meta, _ := json.Marshal(DraftModalMeta{
+		TargetChannel: "C0BACKEND",
+		UserID:        "U_ALICE",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_ALICE"},
+		"team": map[string]any{"id": "T001"},
+		"view": map[string]any{
+			"id":               "V_123",
+			"callback_id":      draftModalCallbackID,
+			"private_metadata": string(meta),
+			"state": map[string]any{
+				"values": map[string]any{
+					draftInputBlockID: map[string]any{
+						draftInputActionID: map[string]any{
+							"value": "", // empty draft
+						},
+					},
+					instructionBlockID: map[string]any{
+						instructionActionID: map[string]any{
+							"value": "Some feedback",
+						},
+					},
+				},
+			},
+		},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestInteraction_RefineAction_NoFeedback(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	meta, _ := json.Marshal(DraftModalMeta{
+		TargetChannel: "C0BACKEND",
+		UserID:        "U_ALICE",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_ALICE"},
+		"team": map[string]any{"id": "T001"},
+		"view": map[string]any{
+			"id":               "V_123",
+			"callback_id":      draftModalCallbackID,
+			"private_metadata": string(meta),
+			"state": map[string]any{
+				"values": map[string]any{
+					draftInputBlockID: map[string]any{
+						draftInputActionID: map[string]any{
+							"value": "Some draft",
+						},
+					},
+					// No feedback block
+				},
+			},
+		},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestInteraction_RespondToInteraction_Success(t *testing.T) {
+	var receivedBody string
+	respServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		var payload map[string]any
+		json.NewDecoder(r.Body).Decode(&payload)
+		if text, ok := payload["text"].(string); ok {
+			receivedBody = text
+		}
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer respServer.Close()
+
+	srv := newInteractionTestServer()
+	srv.respondToInteraction(respServer.URL, "Draft sent!")
+
+	if receivedBody != "Draft sent!" {
+		t.Fatalf("expected 'Draft sent!', got %q", receivedBody)
+	}
+}
+
+func TestInteraction_RespondToInteraction_ServerError(t *testing.T) {
+	respServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer respServer.Close()
+
+	srv := newInteractionTestServer()
+	// Should not panic on error response.
+	srv.respondToInteraction(respServer.URL, "test message")
+}
+
 func TestInteraction_UnknownAction(t *testing.T) {
 	srv := newInteractionTestServer()
 

--- a/core/app/handlers_slack_interactions_test.go
+++ b/core/app/handlers_slack_interactions_test.go
@@ -619,6 +619,138 @@ func TestInteraction_RespondToInteraction_ServerError(t *testing.T) {
 	srv.respondToInteraction(respServer.URL, "test message")
 }
 
+func TestInteraction_RefineAction_NoPipeline(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.systemVault = vault.NewMemVault()
+
+	// Store a bot token so resolveWorkspaceBotToken succeeds.
+	srv.systemVault.Put(context.Background(), "slack-workspaces/T001/bot-token",
+		[]byte("xoxb-test-bot-token"), vault.Metadata{Type: "bot_token"})
+
+	// Create connected account so resolveAileronUserBySlack succeeds.
+	srv.connectedAccounts.Create(context.Background(), model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_a", Provider: model.ConnectedAccountProviderSlack,
+		Status: model.ConnectedAccountStatusActive, ExternalUserID: "U_ALICE", ExternalTeamID: "T001",
+	})
+
+	// No draftPipeline — should hit the "not configured" branch.
+	meta, _ := json.Marshal(DraftModalMeta{
+		TargetChannel:   "C0BACKEND",
+		OriginalMessage: "Original msg",
+		UserID:          "U_ALICE",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_ALICE"},
+		"team": map[string]any{"id": "T001"},
+		"view": map[string]any{
+			"id":               "V_123",
+			"callback_id":      draftModalCallbackID,
+			"private_metadata": string(meta),
+			"state": map[string]any{
+				"values": map[string]any{
+					draftInputBlockID: map[string]any{
+						draftInputActionID: map[string]any{"value": "Draft text"},
+					},
+					instructionBlockID: map[string]any{
+						instructionActionID: map[string]any{"value": "Make shorter"},
+					},
+				},
+			},
+		},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestInteraction_RefineAction_UserNotFound(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.systemVault = vault.NewMemVault()
+
+	srv.systemVault.Put(context.Background(), "slack-workspaces/T001/bot-token",
+		[]byte("xoxb-test-bot-token"), vault.Metadata{Type: "bot_token"})
+
+	// No connected account — resolveAileronUserBySlack will fail.
+	meta, _ := json.Marshal(DraftModalMeta{
+		TargetChannel:   "C0BACKEND",
+		OriginalMessage: "Original msg",
+		UserID:          "U_UNKNOWN",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_UNKNOWN"},
+		"team": map[string]any{"id": "T001"},
+		"view": map[string]any{
+			"id":               "V_123",
+			"callback_id":      draftModalCallbackID,
+			"private_metadata": string(meta),
+			"state": map[string]any{
+				"values": map[string]any{
+					draftInputBlockID: map[string]any{
+						draftInputActionID: map[string]any{"value": "Draft text"},
+					},
+					instructionBlockID: map[string]any{
+						instructionActionID: map[string]any{"value": "Feedback"},
+					},
+				},
+			},
+		},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	time.Sleep(100 * time.Millisecond)
+}
+
+func TestInteraction_RefineAction_BadMetadata(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions",
+		"user": map[string]any{"id": "U_ALICE"},
+		"view": map[string]any{
+			"id":               "V_123",
+			"callback_id":      draftModalCallbackID,
+			"private_metadata": "not-valid-json",
+		},
+		"actions": []map[string]any{{
+			"action_id": refineActionID,
+			"value":     "refine",
+		}},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	time.Sleep(50 * time.Millisecond)
+}
+
 func TestInteraction_UnknownAction(t *testing.T) {
 	srv := newInteractionTestServer()
 

--- a/core/app/handlers_slack_modal.go
+++ b/core/app/handlers_slack_modal.go
@@ -23,6 +23,8 @@ const (
 	draftInputActionID     = "draft_text"
 	instructionBlockID     = "instruction_input"
 	instructionActionID    = "instruction_text"
+	refineActionID         = "refine_draft"
+	refineBlockID          = "refine_actions"
 	maxModalTextLength     = 3000
 )
 
@@ -92,12 +94,21 @@ func updateDraftModalWithDraft(ctx context.Context, botToken, viewID, draftText 
 
 	instructionInputBlock := slack.NewInputBlock(
 		instructionBlockID,
-		slack.NewTextBlockObject(slack.PlainTextType, "Instructions (optional)", false, false),
+		slack.NewTextBlockObject(slack.PlainTextType, "Feedback (optional)", false, false),
 		nil,
 		instructionInput,
 	)
 	instructionInputBlock.Optional = true
 	blocks = append(blocks, instructionInputBlock)
+
+	// Refine button — triggers a block_actions callback to regenerate
+	// the draft using the feedback above.
+	refineBtn := slack.NewButtonBlockElement(
+		refineActionID,
+		"refine",
+		slack.NewTextBlockObject(slack.PlainTextType, "Refine", false, false),
+	)
+	blocks = append(blocks, slack.NewActionBlock(refineBlockID, refineBtn))
 
 	view := slack.ModalViewRequest{
 		Type:            slack.VTModal,
@@ -108,6 +119,29 @@ func updateDraftModalWithDraft(ctx context.Context, botToken, viewID, draftText 
 		PrivateMetadata: string(metaJSON),
 		Blocks: slack.Blocks{
 			BlockSet: blocks,
+		},
+	}
+
+	_, err := comms.UpdateModal(ctx, botToken, viewID, view)
+	return err
+}
+
+// updateDraftModalLoading updates the modal to show a loading state.
+func updateDraftModalLoading(ctx context.Context, botToken, viewID, message string, meta DraftModalMeta) error {
+	metaJSON, _ := json.Marshal(meta)
+
+	view := slack.ModalViewRequest{
+		Type:            slack.VTModal,
+		CallbackID:      draftModalCallbackID,
+		Title:           slack.NewTextBlockObject(slack.PlainTextType, "Draft with Aileron", false, false),
+		PrivateMetadata: string(metaJSON),
+		Blocks: slack.Blocks{
+			BlockSet: []slack.Block{
+				slack.NewSectionBlock(
+					slack.NewTextBlockObject(slack.MarkdownType, ":hourglass_flowing_sand: *"+message+"*", false, false),
+					nil, nil,
+				),
+			},
 		},
 	}
 

--- a/core/app/handlers_tee.go
+++ b/core/app/handlers_tee.go
@@ -333,6 +333,9 @@ func (s *apiServer) autoEscrowCredentials(ctx context.Context, userID string) in
 		}
 
 		s.escrowIndex.Store(acc.VaultPath(), resp.EscrowID)
+		if s.escrowIndexStore != nil {
+			_ = s.escrowIndexStore.Upsert(ctx, acc.VaultPath(), resp.EscrowID, userID, expiresAt)
+		}
 		escrowed++
 	}
 	return escrowed

--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -353,6 +353,42 @@ func (p *Pipeline) GenerateDraftStream(ctx context.Context, userID string, msg c
 	return chunkCh, errCh
 }
 
+// RefineDraft revises a previously generated draft based on user feedback.
+// It skips the research round (context was already gathered for the original
+// draft) and runs only the ghostwrite round with the previous draft and
+// feedback as additional context.
+func (p *Pipeline) RefineDraft(ctx context.Context, userID string, originalMessage, previousDraft, feedback string) (string, error) {
+	_, synthesisClient := p.researchLLM, p.ghostwriteLLM
+	if p.clientResolver != nil {
+		var resolveErr error
+		_, synthesisClient, resolveErr = p.clientResolver.Resolve(ctx, userID)
+		if resolveErr != nil {
+			return "", fmt.Errorf("resolving LLM config: %w", resolveErr)
+		}
+	}
+
+	ghostwritePrompt, err := p.assembleSystemPrompt(ctx, userID)
+	if err != nil {
+		return "", fmt.Errorf("assembling system prompt: %w", err)
+	}
+
+	ghostwriteMessage := fmt.Sprintf(
+		"Original message:\n\n%s\n\n---\n\nPrevious draft:\n\n%s\n\n---\n\nUser feedback:\n\n%s\n\nRevise the draft based on the feedback. Output only the revised draft — no commentary.",
+		originalMessage, previousDraft, feedback,
+	)
+
+	resp, err := synthesisClient.GenerateWithTools(ctx, llm.GenerateRequest{
+		SystemPrompt: ghostwritePrompt,
+		UserMessage:  ghostwriteMessage,
+	})
+	if err != nil {
+		return "", fmt.Errorf("refine draft failed: %w", err)
+	}
+
+	p.log.Info("draft refined", "user_id", userID, "draft_length", len(resp.Text))
+	return resp.Text, nil
+}
+
 // assembleSystemPrompt builds the system prompt from the base prompt plus
 // the user's active instructions. Instructions are the highest-priority
 // context — they override learned patterns and behavioral model inferences.

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -13,6 +13,7 @@ import (
 	"github.com/ALRubinger/aileron/core/llm"
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/source"
+	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/store/mem"
 	"github.com/ALRubinger/aileron/core/vault"
 )
@@ -919,6 +920,96 @@ func TestWithClientResolver(t *testing.T) {
 		t.Fatal("WithClientResolver returned nil")
 	}
 }
+
+// failingInstructionStore always returns an error on List.
+type failingInstructionStore struct{}
+
+func (f *failingInstructionStore) Create(_ context.Context, _ model.UserInstruction) error {
+	return nil
+}
+func (f *failingInstructionStore) Get(_ context.Context, _ string) (model.UserInstruction, error) {
+	return model.UserInstruction{}, nil
+}
+func (f *failingInstructionStore) List(_ context.Context, _ store.UserInstructionFilter) ([]model.UserInstruction, error) {
+	return nil, fmt.Errorf("instruction store unavailable")
+}
+func (f *failingInstructionStore) Update(_ context.Context, _ model.UserInstruction) error {
+	return nil
+}
+func (f *failingInstructionStore) Delete(_ context.Context, _ string) error { return nil }
+
+func TestRefineDraft_AssemblePromptError(t *testing.T) {
+	mockClient := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "ok"},
+	}
+	p := draft.NewPipeline(
+		mockClient, mockClient,
+		source.NewRegistry(),
+		mem.NewConnectedAccountStore(),
+		&failingInstructionStore{}, vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	)
+
+	_, err := p.RefineDraft(context.Background(), "usr_1",
+		"Original", "Draft", "Feedback",
+	)
+	if err == nil {
+		t.Fatal("expected error from assembleSystemPrompt failure")
+	}
+	if !strings.Contains(err.Error(), "assembling system prompt") {
+		t.Errorf("expected 'assembling system prompt' in error, got: %v", err)
+	}
+}
+
+func TestRefineDraft_ClientResolverError(t *testing.T) {
+	mockClient := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "ok"},
+	}
+	p := draft.NewPipeline(
+		mockClient, mockClient,
+		source.NewRegistry(),
+		mem.NewConnectedAccountStore(),
+		nil, vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	)
+
+	// Create a resolver that will fail (no default API key, no per-user config).
+	resolver := llm.NewClientResolver(
+		mem.NewLLMConfigStore(),
+		&stubUserStoreForResolver{},
+		vault.NewMemVault(),
+		"", "", "", // empty defaults → will fail
+		slog.Default(),
+	)
+	p2 := p.WithClientResolver(resolver)
+
+	_, err := p2.RefineDraft(context.Background(), "usr_1",
+		"Original", "Draft", "Feedback",
+	)
+	if err == nil {
+		t.Fatal("expected error from client resolver")
+	}
+	if !strings.Contains(err.Error(), "resolving LLM config") {
+		t.Errorf("expected 'resolving LLM config' in error, got: %v", err)
+	}
+}
+
+// stubUserStoreForResolver satisfies store.UserStore for the resolver.
+type stubUserStoreForResolver struct{}
+
+func (s *stubUserStoreForResolver) Create(_ context.Context, _ model.User) error { return nil }
+func (s *stubUserStoreForResolver) Get(_ context.Context, _ string) (model.User, error) {
+	return model.User{}, nil
+}
+func (s *stubUserStoreForResolver) GetByEmail(_ context.Context, _ string) (model.User, error) {
+	return model.User{}, nil
+}
+func (s *stubUserStoreForResolver) List(_ context.Context, _ store.UserFilter) ([]model.User, error) {
+	return nil, nil
+}
+func (s *stubUserStoreForResolver) Update(_ context.Context, _ model.User) error { return nil }
 
 func TestRefineDraft(t *testing.T) {
 	mockClient := &mockLLMClient{

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -854,3 +854,44 @@ func TestPipeline_GenerateDraftStream_ResearchError(t *testing.T) {
 		t.Error("expected draft output despite research failure")
 	}
 }
+
+func TestRefineDraft(t *testing.T) {
+	mockClient := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "Revised: shorter version"},
+	}
+	p := draft.NewPipeline(
+		mockClient, mockClient,
+		source.NewRegistry(),
+		mem.NewConnectedAccountStore(),
+		nil, vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	)
+
+	result, err := p.RefineDraft(context.Background(), "usr_1",
+		"Original message text",
+		"Here is my previous long draft...",
+		"Make it more concise",
+	)
+	if err != nil {
+		t.Fatalf("RefineDraft: %v", err)
+	}
+	if result != "Revised: shorter version" {
+		t.Errorf("result = %q, want 'Revised: shorter version'", result)
+	}
+
+	// Verify the LLM received the right context.
+	if mockClient.lastRequest == nil {
+		t.Fatal("expected LLM call")
+	}
+	msg := mockClient.lastRequest.UserMessage
+	if !strings.Contains(msg, "Previous draft") {
+		t.Errorf("expected 'Previous draft' in prompt, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Make it more concise") {
+		t.Errorf("expected feedback in prompt, got: %s", msg)
+	}
+	if !strings.Contains(msg, "Original message text") {
+		t.Errorf("expected original message in prompt, got: %s", msg)
+	}
+}

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -855,6 +855,71 @@ func TestPipeline_GenerateDraftStream_ResearchError(t *testing.T) {
 	}
 }
 
+func TestRefineDraft_LLMError(t *testing.T) {
+	mockClient := &mockLLMClient{
+		err: fmt.Errorf("LLM unavailable"),
+	}
+	p := draft.NewPipeline(
+		mockClient, mockClient,
+		source.NewRegistry(),
+		mem.NewConnectedAccountStore(),
+		nil, vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	)
+
+	_, err := p.RefineDraft(context.Background(), "usr_1",
+		"Original", "Draft", "Feedback",
+	)
+	if err == nil {
+		t.Fatal("expected error from LLM failure")
+	}
+	if !strings.Contains(err.Error(), "refine draft failed") {
+		t.Errorf("expected 'refine draft failed' in error, got: %v", err)
+	}
+}
+
+func TestWithVault(t *testing.T) {
+	mockClient := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "ok"},
+	}
+	p := draft.NewPipeline(
+		mockClient, mockClient,
+		source.NewRegistry(),
+		mem.NewConnectedAccountStore(),
+		nil, vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	)
+
+	v := vault.NewMemVault()
+	p2 := p.WithVault(v)
+	if p2 == nil {
+		t.Fatal("WithVault returned nil")
+	}
+	// Original pipeline should not be affected.
+	_ = p
+}
+
+func TestWithClientResolver(t *testing.T) {
+	mockClient := &mockLLMClient{
+		response: &llm.GenerateResponse{Text: "ok"},
+	}
+	p := draft.NewPipeline(
+		mockClient, mockClient,
+		source.NewRegistry(),
+		mem.NewConnectedAccountStore(),
+		nil, vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	)
+
+	p2 := p.WithClientResolver(nil)
+	if p2 == nil {
+		t.Fatal("WithClientResolver returned nil")
+	}
+}
+
 func TestRefineDraft(t *testing.T) {
 	mockClient := &mockLLMClient{
 		response: &llm.GenerateResponse{Text: "Revised: shorter version"},

--- a/core/schema/schema.hcl
+++ b/core/schema/schema.hcl
@@ -740,6 +740,37 @@ table "system_vault_secrets" {
   }
 }
 
+table "escrow_index" {
+  schema = schema.public
+  comment = "Server-side index mapping vault paths to TEE escrow IDs. Survives server restarts so async flows (Slack agent) can resolve escrowed credentials without re-unlock."
+
+  column "vault_path" {
+    type = varchar(512)
+    null = false
+  }
+  column "escrow_id" {
+    type = varchar(128)
+    null = false
+  }
+  column "user_id" {
+    type = varchar(64)
+    null = false
+  }
+  column "expires_at" {
+    type = timestamptz
+    null = false
+  }
+  column "created_at" {
+    type    = timestamptz
+    null    = false
+    default = sql("now()")
+  }
+
+  primary_key {
+    columns = [column.vault_path]
+  }
+}
+
 table "llm_configs" {
   schema = schema.public
 

--- a/core/store/postgres/escrow_index.go
+++ b/core/store/postgres/escrow_index.go
@@ -1,0 +1,71 @@
+package postgres
+
+import (
+	"context"
+	"time"
+)
+
+// EscrowIndexStore persists the server-side escrow index in PostgreSQL so it
+// survives server restarts. Maps vault paths to enclave escrow IDs.
+type EscrowIndexStore struct {
+	db *DB
+}
+
+// NewEscrowIndexStore returns a PostgreSQL-backed escrow index store.
+func NewEscrowIndexStore(db *DB) *EscrowIndexStore {
+	return &EscrowIndexStore{db: db}
+}
+
+// Upsert creates or updates an escrow index entry.
+func (s *EscrowIndexStore) Upsert(ctx context.Context, vaultPath, escrowID, userID string, expiresAt time.Time) error {
+	_, err := s.db.Pool.Exec(ctx,
+		`INSERT INTO escrow_index (vault_path, escrow_id, user_id, expires_at)
+		 VALUES ($1, $2, $3, $4)
+		 ON CONFLICT (vault_path) DO UPDATE SET
+			escrow_id = $2, user_id = $3, expires_at = $4`,
+		vaultPath, escrowID, userID, expiresAt,
+	)
+	return err
+}
+
+// Delete removes an escrow index entry by vault path.
+func (s *EscrowIndexStore) Delete(ctx context.Context, vaultPath string) error {
+	_, err := s.db.Pool.Exec(ctx,
+		`DELETE FROM escrow_index WHERE vault_path = $1`,
+		vaultPath,
+	)
+	return err
+}
+
+// LoadAll returns all non-expired escrow index entries as a map of
+// vault_path → escrow_id.
+func (s *EscrowIndexStore) LoadAll(ctx context.Context) (map[string]string, error) {
+	rows, err := s.db.Pool.Query(ctx,
+		`SELECT vault_path, escrow_id FROM escrow_index WHERE expires_at > now()`,
+	)
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+
+	result := make(map[string]string)
+	for rows.Next() {
+		var path, id string
+		if err := rows.Scan(&path, &id); err != nil {
+			return nil, err
+		}
+		result[path] = id
+	}
+	return result, rows.Err()
+}
+
+// DeleteExpired removes all expired entries and returns the count removed.
+func (s *EscrowIndexStore) DeleteExpired(ctx context.Context) (int, error) {
+	tag, err := s.db.Pool.Exec(ctx,
+		`DELETE FROM escrow_index WHERE expires_at <= now()`,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return int(tag.RowsAffected()), nil
+}

--- a/core/vault/escrow_vault_test.go
+++ b/core/vault/escrow_vault_test.go
@@ -36,6 +36,9 @@ func (m *mockEnclaveClient) EscrowStore(_ context.Context, _ enclave.EscrowStore
 func (m *mockEnclaveClient) EscrowRetrieve(_ context.Context, req enclave.EscrowRetrieveRequest) (enclave.EscrowRetrieveResponse, error) {
 	return m.retrieveResp, m.retrieveErr
 }
+func (m *mockEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowListResponse, error) {
+	return enclave.EscrowListResponse{}, nil
+}
 func (m *mockEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }

--- a/docs/src/content/docs/deployment/tee-enclave.md
+++ b/docs/src/content/docs/deployment/tee-enclave.md
@@ -191,6 +191,7 @@ Set these environment variables on your Aileron server (wherever it's hosted):
 | `AILERON_ENCLAVE_URL` | `http://$ENCLAVE_IP:8443` (the static IP from step 7) |
 | `AILERON_ENCLAVE_IMAGE_DIGEST` | `$IMAGE_DIGEST` (captured in step 3) |
 | `AILERON_GCP_PROJECT_ID` | `$GCP_PROJECT` |
+| `AILERON_ENCLAVE_DATA_DIR` | Directory for persistent escrow data (see [Persistent escrow storage](#persistent-escrow-storage) below) |
 
 ### 9. Verify
 
@@ -207,6 +208,37 @@ Expected response:
 ```
 
 `attested` and `session_active` become `true` after a user unlocks their vault.
+
+## Persistent escrow storage
+
+Escrowed credentials are persisted to disk so they survive enclave restarts. The enclave writes two files inside its data directory:
+
+| File | Purpose |
+|------|---------|
+| `escrow.key` | AES-256-GCM data encryption key (DEK), generated on first start |
+| `escrow.dat` | Encrypted escrow entries (credentials, grant IDs, expiry times) |
+
+The data directory is controlled by `AILERON_ENCLAVE_DATA_DIR`:
+
+| Provider | Default |
+|----------|---------|
+| `confidential-space` | `/data/enclave` |
+| `local` | `~/.aileron/enclave` |
+
+### When to set `AILERON_ENCLAVE_DATA_DIR`
+
+The defaults work for most deployments. Override the directory when:
+
+- **Mounted persistent disk** — Confidential Space VMs use ephemeral boot disks by default. To survive VM recreation (not just restarts), attach a persistent disk and point `AILERON_ENCLAVE_DATA_DIR` to its mount point (e.g. `/mnt/escrow`).
+- **Custom local paths** — If `~/.aileron/enclave` conflicts with another tool or you prefer a different location for local development.
+- **Shared filesystem** — If running multiple enclave replicas that need to share escrow state (not typical).
+
+### Security notes
+
+- The DEK (`escrow.key`) is a 32-byte random key stored in plaintext on disk. In production, the Confidential Space VM's memory and disk are hardware-encrypted by AMD SEV-SNP, so the key is protected at rest by the TEE.
+- `escrow.dat` is encrypted with AES-256-GCM using the DEK. Even if the file is exfiltrated without the key, the contents are unreadable.
+- If either file is corrupt or missing, the enclave starts fresh with an empty escrow store. Existing in-memory entries are not affected.
+- Expired entries are evicted on startup and periodically (every 10 minutes).
 
 ## How attestation works
 

--- a/docs/src/content/docs/getting-started/zero-knowledge-enclave.md
+++ b/docs/src/content/docs/getting-started/zero-knowledge-enclave.md
@@ -77,6 +77,8 @@ After unlocking your vault, `attested` and `session_active` become `true`.
 
 When you unlock your vault, the server automatically escrows your connected account credentials into the enclave. This allows Aileron to process incoming Slack messages and generate drafts even when you're offline — the enclave has the credentials it needs without requiring an active browser session.
 
+Escrowed credentials are **durable** — they survive enclave and server restarts. The enclave persists them to disk encrypted with AES-256-GCM, so a routine restart or redeployment doesn't require users to re-unlock.
+
 Escrowed credentials expire after a configurable TTL (default 7 days, set via `AILERON_ESCROW_TTL`). After expiry, you must unlock again for Aileron to access your connected accounts.
 
 ## Deployment
@@ -94,4 +96,5 @@ For local development, set `AILERON_TEE_PROVIDER=local` on the server. This uses
 | Session expired | ECDH session has a 30-minute TTL. The client re-attests automatically on next vault operation. |
 | "Enclave unreachable" | Network connectivity between Railway and GCP. Check firewall rules and `AILERON_ENCLAVE_URL`. |
 | Escrowed credentials expired | User hasn't unlocked vault in >7 days. Unlock to re-escrow. |
+| Escrow lost after restart | `AILERON_ENCLAVE_DATA_DIR` points to an ephemeral disk. Attach persistent storage or set the var to a durable mount. See [TEE deployment guide](/deployment/tee-enclave#persistent-escrow-storage). |
 | 403 on direct unlock | Expected — when TEE is enabled, direct unlock is blocked. The UI uses the TEE path automatically. |

--- a/enclave/client.go
+++ b/enclave/client.go
@@ -44,6 +44,10 @@ type Client interface {
 	// actions should use Execute with EscrowID instead.
 	EscrowRetrieve(ctx context.Context, req EscrowRetrieveRequest) (EscrowRetrieveResponse, error)
 
+	// EscrowList returns metadata for all non-expired escrow entries.
+	// Used by the server to reconcile its escrow index on startup.
+	EscrowList(ctx context.Context) (EscrowListResponse, error)
+
 	// EscrowRevoke removes a previously escrowed credential and zeros the
 	// plaintext from enclave memory.
 	EscrowRevoke(ctx context.Context, req EscrowRevokeRequest) error

--- a/enclave/escrow_key.go
+++ b/enclave/escrow_key.go
@@ -1,0 +1,41 @@
+package enclave
+
+import (
+	"crypto/rand"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// LoadOrCreateKey loads a 32-byte encryption key from the given path, or
+// generates one and writes it to disk if the file doesn't exist. The key
+// file is created with 0600 permissions.
+func LoadOrCreateKey(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err == nil {
+		if len(data) != 32 {
+			return nil, fmt.Errorf("escrow key at %s: expected 32 bytes, got %d", path, len(data))
+		}
+		return data, nil
+	}
+	if !os.IsNotExist(err) {
+		return nil, fmt.Errorf("reading escrow key: %w", err)
+	}
+
+	// Generate a new key.
+	key := make([]byte, 32)
+	if _, err := rand.Read(key); err != nil {
+		return nil, fmt.Errorf("generating escrow key: %w", err)
+	}
+
+	// Ensure parent directory exists.
+	if err := os.MkdirAll(filepath.Dir(path), 0700); err != nil {
+		return nil, fmt.Errorf("creating escrow key directory: %w", err)
+	}
+
+	if err := os.WriteFile(path, key, 0600); err != nil {
+		return nil, fmt.Errorf("writing escrow key: %w", err)
+	}
+
+	return key, nil
+}

--- a/enclave/escrow_key_test.go
+++ b/enclave/escrow_key_test.go
@@ -1,0 +1,78 @@
+package enclave
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadOrCreateKey_GeneratesNew(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "escrow.key")
+
+	key, err := LoadOrCreateKey(path)
+	if err != nil {
+		t.Fatalf("LoadOrCreateKey: %v", err)
+	}
+	if len(key) != 32 {
+		t.Fatalf("expected 32 bytes, got %d", len(key))
+	}
+
+	// File should exist with 0600 permissions.
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatalf("stat: %v", err)
+	}
+	if perm := info.Mode().Perm(); perm != 0600 {
+		t.Fatalf("expected 0600 permissions, got %o", perm)
+	}
+}
+
+func TestLoadOrCreateKey_LoadsExisting(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "escrow.key")
+
+	// Create key first time.
+	key1, err := LoadOrCreateKey(path)
+	if err != nil {
+		t.Fatalf("first call: %v", err)
+	}
+
+	// Load same key second time.
+	key2, err := LoadOrCreateKey(path)
+	if err != nil {
+		t.Fatalf("second call: %v", err)
+	}
+
+	if string(key1) != string(key2) {
+		t.Fatal("expected same key on second load")
+	}
+}
+
+func TestLoadOrCreateKey_RejectsWrongSize(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "escrow.key")
+
+	// Write a key with wrong size.
+	if err := os.WriteFile(path, []byte("too-short"), 0600); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := LoadOrCreateKey(path)
+	if err == nil {
+		t.Fatal("expected error for wrong-size key")
+	}
+}
+
+func TestLoadOrCreateKey_CreatesParentDirs(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", "deep", "escrow.key")
+
+	key, err := LoadOrCreateKey(path)
+	if err != nil {
+		t.Fatalf("LoadOrCreateKey: %v", err)
+	}
+	if len(key) != 32 {
+		t.Fatalf("expected 32 bytes, got %d", len(key))
+	}
+}

--- a/enclave/escrow_key_test.go
+++ b/enclave/escrow_key_test.go
@@ -76,3 +76,42 @@ func TestLoadOrCreateKey_CreatesParentDirs(t *testing.T) {
 		t.Fatalf("expected 32 bytes, got %d", len(key))
 	}
 }
+
+func TestLoadOrCreateKey_ReadError(t *testing.T) {
+	// Path is a directory, not a file — os.ReadFile will return an error
+	// that is not os.ErrNotExist.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "subdir")
+	os.Mkdir(path, 0700)
+
+	_, err := LoadOrCreateKey(path)
+	if err == nil {
+		t.Fatal("expected error when path is a directory")
+	}
+}
+
+func TestLoadOrCreateKey_WriteError(t *testing.T) {
+	// Parent directory is read-only — WriteFile will fail.
+	dir := t.TempDir()
+	readOnlyDir := filepath.Join(dir, "readonly")
+	os.Mkdir(readOnlyDir, 0500)
+	path := filepath.Join(readOnlyDir, "escrow.key")
+
+	_, err := LoadOrCreateKey(path)
+	if err == nil {
+		t.Fatal("expected error when directory is read-only")
+	}
+}
+
+func TestLoadOrCreateKey_MkdirError(t *testing.T) {
+	// Parent path exists as a file, not a directory — MkdirAll will fail.
+	dir := t.TempDir()
+	blockingFile := filepath.Join(dir, "blocker")
+	os.WriteFile(blockingFile, []byte("x"), 0600)
+	path := filepath.Join(blockingFile, "nested", "escrow.key")
+
+	_, err := LoadOrCreateKey(path)
+	if err == nil {
+		t.Fatal("expected error when parent is a file")
+	}
+}

--- a/enclave/gcs/client.go
+++ b/enclave/gcs/client.go
@@ -110,6 +110,15 @@ func (c *Client) EscrowRetrieve(ctx context.Context, req enclave.EscrowRetrieveR
 	return resp, nil
 }
 
+// EscrowList returns metadata for all non-expired escrow entries.
+func (c *Client) EscrowList(ctx context.Context) (enclave.EscrowListResponse, error) {
+	var resp enclave.EscrowListResponse
+	if err := c.post(ctx, "/escrow/list", struct{}{}, &resp); err != nil {
+		return enclave.EscrowListResponse{}, fmt.Errorf("gcs: escrow list: %w", err)
+	}
+	return resp, nil
+}
+
 // EscrowRevoke sends an escrow revoke request to the enclave.
 func (c *Client) EscrowRevoke(ctx context.Context, req enclave.EscrowRevokeRequest) error {
 	if err := c.post(ctx, "/escrow/revoke", req, nil); err != nil {

--- a/enclave/gcs/client_test.go
+++ b/enclave/gcs/client_test.go
@@ -241,6 +241,89 @@ func TestClientOAuthExchangeError(t *testing.T) {
 	}
 }
 
+func TestClientEscrowRetrieve(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/escrow/retrieve" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		var req enclave.EscrowRetrieveRequest
+		json.NewDecoder(r.Body).Decode(&req)
+		if req.EscrowID != "esc-456" {
+			t.Fatalf("expected escrow ID esc-456, got %q", req.EscrowID)
+		}
+		json.NewEncoder(w).Encode(enclave.EscrowRetrieveResponse{
+			Credential: []byte("plaintext-cred"),
+		})
+	}))
+	defer server.Close()
+
+	c := New(Config{BaseURL: server.URL})
+	resp, err := c.EscrowRetrieve(context.Background(), enclave.EscrowRetrieveRequest{
+		EscrowID: "esc-456",
+	})
+	if err != nil {
+		t.Fatalf("EscrowRetrieve: %v", err)
+	}
+	if string(resp.Credential) != "plaintext-cred" {
+		t.Fatalf("expected plaintext-cred, got %q", resp.Credential)
+	}
+}
+
+func TestClientEscrowRetrieveError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+		w.Write([]byte("not found"))
+	}))
+	defer server.Close()
+
+	c := New(Config{BaseURL: server.URL})
+	_, err := c.EscrowRetrieve(context.Background(), enclave.EscrowRetrieveRequest{EscrowID: "bad"})
+	if err == nil {
+		t.Fatal("expected error for 404 response on EscrowRetrieve")
+	}
+}
+
+func TestClientEscrowList(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/escrow/list" {
+			t.Fatalf("unexpected path %q", r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(enclave.EscrowListResponse{
+			Entries: []enclave.EscrowListEntry{
+				{EscrowID: "esc-1", GrantID: "g1", ExpiresAt: "2026-12-31T00:00:00Z"},
+				{EscrowID: "esc-2", GrantID: "g2", ExpiresAt: "2026-12-31T00:00:00Z"},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := New(Config{BaseURL: server.URL})
+	resp, err := c.EscrowList(context.Background())
+	if err != nil {
+		t.Fatalf("EscrowList: %v", err)
+	}
+	if len(resp.Entries) != 2 {
+		t.Fatalf("expected 2 entries, got %d", len(resp.Entries))
+	}
+	if resp.Entries[0].EscrowID != "esc-1" {
+		t.Fatalf("expected esc-1, got %q", resp.Entries[0].EscrowID)
+	}
+}
+
+func TestClientEscrowListError(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("list failed"))
+	}))
+	defer server.Close()
+
+	c := New(Config{BaseURL: server.URL})
+	_, err := c.EscrowList(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 500 response on EscrowList")
+	}
+}
+
 func TestClientEscrowRevokeError(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusInternalServerError)

--- a/enclave/local/client.go
+++ b/enclave/local/client.go
@@ -246,6 +246,11 @@ func (c *Client) EscrowRetrieve(_ context.Context, req enclave.EscrowRetrieveReq
 	return enclave.EscrowRetrieveResponse{Credential: plaintext}, nil
 }
 
+// EscrowList returns metadata for all non-expired escrow entries.
+func (c *Client) EscrowList(_ context.Context) (enclave.EscrowListResponse, error) {
+	return enclave.EscrowListResponse{Entries: c.escrow.List()}, nil
+}
+
 // EscrowRevoke removes an escrowed credential and zeros its plaintext.
 func (c *Client) EscrowRevoke(_ context.Context, req enclave.EscrowRevokeRequest) error {
 	return c.escrow.Revoke(req.EscrowID, req.GrantID)

--- a/enclave/local/client_test.go
+++ b/enclave/local/client_test.go
@@ -262,6 +262,50 @@ func TestEscrowRetrieve_NotFound(t *testing.T) {
 	}
 }
 
+func TestEscrowListViaClient(t *testing.T) {
+	c := New(nil)
+	defer c.Close()
+
+	ctx := context.Background()
+	sessionKey := establishSession(t, c)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitKEK(t, c, sessionKey, "user-1", userKEK)
+
+	// Empty list initially.
+	resp, err := c.EscrowList(ctx)
+	if err != nil {
+		t.Fatalf("EscrowList: %v", err)
+	}
+	if len(resp.Entries) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(resp.Entries))
+	}
+
+	// Store a credential, then list.
+	encrypted, _ := encryptAESGCM([]byte("test-cred"), userKEK)
+	storeResp, err := c.EscrowStore(ctx, enclave.EscrowStoreRequest{
+		UserID:              "user-1",
+		GrantID:             "g1",
+		EncryptedCredential: encrypted,
+		CredentialType:      "oauth_token",
+		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
+	})
+	if err != nil {
+		t.Fatalf("EscrowStore: %v", err)
+	}
+
+	resp, err = c.EscrowList(ctx)
+	if err != nil {
+		t.Fatalf("EscrowList: %v", err)
+	}
+	if len(resp.Entries) != 1 {
+		t.Fatalf("expected 1 entry, got %d", len(resp.Entries))
+	}
+	if resp.Entries[0].EscrowID != storeResp.EscrowID {
+		t.Fatalf("expected %q, got %q", storeResp.EscrowID, resp.Entries[0].EscrowID)
+	}
+}
+
 func TestEscrowRevoke(t *testing.T) {
 	c := New(func(_ context.Context, _ enclave.ExecuteRequest, _ []byte) (enclave.ExecuteResponse, error) {
 		return enclave.ExecuteResponse{Status: "succeeded"}, nil

--- a/enclave/local/escrow.go
+++ b/enclave/local/escrow.go
@@ -61,6 +61,26 @@ func (s *escrowStore) Get(escrowID string) ([]byte, error) {
 	return copyBytes(entry.credential), nil
 }
 
+// List returns metadata for all non-expired escrow entries.
+func (s *escrowStore) List() []enclave.EscrowListEntry {
+	now := time.Now()
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+
+	var entries []enclave.EscrowListEntry
+	for id, entry := range s.entries {
+		if now.After(entry.expiresAt) {
+			continue
+		}
+		entries = append(entries, enclave.EscrowListEntry{
+			EscrowID:  id,
+			GrantID:   entry.grantID,
+			ExpiresAt: entry.expiresAt.Format(time.RFC3339),
+		})
+	}
+	return entries
+}
+
 // Revoke removes an escrow entry and zeros the credential bytes. The grantID
 // must match the original grant that created the escrow.
 func (s *escrowStore) Revoke(escrowID, grantID string) error {

--- a/enclave/local/escrow_test.go
+++ b/enclave/local/escrow_test.go
@@ -103,6 +103,41 @@ func TestEscrowEvictExpired(t *testing.T) {
 	}
 }
 
+func TestEscrowList(t *testing.T) {
+	s := newEscrowStore()
+
+	// Empty store returns nil/empty.
+	entries := s.List()
+	if len(entries) != 0 {
+		t.Fatalf("expected 0 entries, got %d", len(entries))
+	}
+
+	// Add a mix of live and expired entries.
+	s.Store("g1", []byte("cred-1"), "api_key", nil, time.Now().Add(time.Hour))
+	s.Store("g2", []byte("cred-2"), "oauth", nil, time.Now().Add(time.Hour))
+	s.Store("g3", []byte("cred-3"), "api_key", nil, time.Now().Add(-time.Second)) // expired
+
+	entries = s.List()
+	if len(entries) != 2 {
+		t.Fatalf("expected 2 non-expired entries, got %d", len(entries))
+	}
+
+	// Verify grant IDs are present.
+	grants := map[string]bool{}
+	for _, e := range entries {
+		grants[e.GrantID] = true
+		if e.EscrowID == "" {
+			t.Fatal("EscrowID should not be empty")
+		}
+		if e.ExpiresAt == "" {
+			t.Fatal("ExpiresAt should not be empty")
+		}
+	}
+	if !grants["g1"] || !grants["g2"] {
+		t.Fatalf("expected grants g1 and g2, got %v", grants)
+	}
+}
+
 func TestEscrowClear(t *testing.T) {
 	s := newEscrowStore()
 	cred := []byte("clear-me")

--- a/enclave/protocol.go
+++ b/enclave/protocol.go
@@ -165,6 +165,18 @@ type EscrowRetrieveResponse struct {
 	Credential []byte `json:"credential"`
 }
 
+// EscrowListResponse contains metadata for all non-expired escrow entries.
+type EscrowListResponse struct {
+	Entries []EscrowListEntry `json:"entries"`
+}
+
+// EscrowListEntry is metadata for a single escrowed credential.
+type EscrowListEntry struct {
+	EscrowID  string `json:"escrow_id"`
+	GrantID   string `json:"grant_id"`
+	ExpiresAt string `json:"expires_at"` // RFC 3339
+}
+
 // EscrowRevokeRequest removes an escrowed credential from the enclave.
 type EscrowRevokeRequest struct {
 	EscrowID string `json:"escrow_id"`


### PR DESCRIPTION
## Summary

### Durable Escrow Storage
- Escrowed credentials now survive server and enclave restarts
- Enclave persists escrow entries to disk encrypted with AES-256-GCM
- Server persists escrow index to PostgreSQL (`escrow_index` table) and loads it on startup
- `autoEscrowCredentials` writes to both in-memory sync.Map and database
- Background tickers clean expired entries
- Adds `EscrowList` to enclave Client interface for index reconciliation
- Adds `AILERON_ENCLAVE_DATA_DIR` env var

### Conversational Draft Refinement
- "Refine" button in the draft modal for iterative feedback
- User types feedback → clicks Refine → draft revised by LLM → repeat until ready → Send
- `RefineDraft` pipeline method: ghostwrite-only (skips research), uses previous draft + feedback
- `processRefineDraft` interaction handler for block_actions callback
- Renamed instructions field to "Feedback" for clarity

## Test plan

- [x] Escrow persistence round-trip: store → restart → entries survive
- [x] Expired entries not loaded on restart
- [x] Corrupt data file handled gracefully
- [x] RefineDraft pipeline test with mock LLM
- [x] All existing tests pass (30 packages)
- [ ] Manual: escrow → restart → Slack works without re-unlock
- [ ] Manual: draft → type feedback → Refine → see revised draft → Send

🤖 Generated with [Claude Code](https://claude.com/claude-code)