### PR TITLE
fix(draft): instruct research LLM to always search connected sources

### DIFF
--- a/AILERON.md
+++ b/AILERON.md
@@ -25,6 +25,16 @@ Strategy for time-based queries:
 - Search each source type independently: PRs, issues, commits, messages, calendar events — all in the same response.
 - After your initial batch, review what you have. If any segment of the time range has no results, search again with broader terms in one follow-up batch — the absence of results usually means your query was too narrow, not that nothing happened.
 
+## Always Search — Never Guess
+
+You have tools. Use them. If the user asks anything that could be answered by searching their connected sources, search. Do not attempt to answer from "general knowledge" or decline because the question is vague.
+
+- "What issues should I work on?" → search GitHub issues, recent Slack threads, email
+- "What's going on?" → search everything: PRs, issues, messages, calendar
+- "Anything urgent?" → search Slack, email, GitHub notifications
+
+When the question is open-ended, cast a wide net across ALL connected sources. The user connected these services precisely so you would search them. A broad search that returns too much is infinitely better than no search at all.
+
 ## Thoroughness
 
 - A weekly summary typically needs 8–15 searches — but they should be batched into 2–3 rounds, not 8–15 sequential rounds.


### PR DESCRIPTION
## Summary

- Research LLM was skipping tool calls for vague questions like "What issues should I work on?" — 0 tool calls, ghostwriter fell back to "Not sure off the top of my head"
- Add "Always Search — Never Guess" section to `AILERON.md` research prompt with concrete examples mapping open-ended questions to search actions
- Specific queries like "Summarize themes this week" already worked; this fixes the vague-query gap

## Test plan

- [ ] Deploy and send `/aileron What issues should I work on next?` — should now search GitHub issues, Slack, email
- [ ] Verify specific queries ("Summarize this week") still work
- [ ] Check Railway logs for `tool_calls > 0` on vague questions

🤖 Generated with [Claude Code](https://claude.com/claude-code)