### PR TITLE
feat(observability): add debug logging and AILERON_LOG_LEVEL

### DIFF
--- a/core/comms/slack_agent.go
+++ b/core/comms/slack_agent.go
@@ -3,23 +3,33 @@ package comms
 import (
 	"context"
 	"fmt"
+	"sync"
 
 	"github.com/slack-go/slack"
 )
 
 // slackAgentAPIURL overrides the Slack API URL for testing.
-var slackAgentAPIURL string
+var (
+	slackAgentAPIURL string
+	slackAgentMu     sync.RWMutex
+)
 
 // SetAgentAPIURL sets the Slack API URL for agent functions. Call with empty string to reset.
 func SetAgentAPIURL(url string) {
+	slackAgentMu.Lock()
 	slackAgentAPIURL = url
+	slackAgentMu.Unlock()
 }
 
 // newAgentClient creates a one-shot Slack client for agent operations.
 func newAgentClient(botToken string) *slack.Client {
+	slackAgentMu.RLock()
+	apiURL := slackAgentAPIURL
+	slackAgentMu.RUnlock()
+
 	var opts []slack.Option
-	if slackAgentAPIURL != "" {
-		opts = append(opts, slack.OptionAPIURL(slackAgentAPIURL))
+	if apiURL != "" {
+		opts = append(opts, slack.OptionAPIURL(apiURL))
 	}
 	return slack.New(botToken, opts...)
 }

--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -121,17 +121,30 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 	for _, acct := range accounts {
 		if acct.Status == model.ConnectedAccountStatusActive {
 			connectedProviders[string(acct.Provider)] = true
+			p.log.Debug("connected account active", "provider", acct.Provider, "user_id", userID, "vault_path", acct.VaultPath())
 		}
 	}
 
+	var registeredProviders []string
 	var tools []source.ToolDefinition
 	if p.sourceRegistry != nil {
 		for _, provider := range p.sourceRegistry.Providers() {
+			registeredProviders = append(registeredProviders, provider)
 			if connectedProviders[provider] {
-				tools = append(tools, p.sourceRegistry.ToolsForProvider(provider)...)
+				providerTools := p.sourceRegistry.ToolsForProvider(provider)
+				tools = append(tools, providerTools...)
+				p.log.Debug("matched provider", "provider", provider, "tools", len(providerTools))
+			} else {
+				p.log.Debug("provider not connected", "provider", provider)
 			}
 		}
 	}
+	p.log.Debug("tool resolution",
+		"user_id", userID,
+		"connected_providers", fmt.Sprintf("%v", connectedProviders),
+		"registered_providers", fmt.Sprintf("%v", registeredProviders),
+		"total_tools", len(tools),
+	)
 
 	executor := p.buildToolExecutor(ctx, userID, accounts)
 
@@ -178,6 +191,12 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 		gatheredContext = "(No source connectors available — replying with general knowledge only.)"
 	}
 
+	p.log.Debug("gathered context for ghostwriter",
+		"user_id", userID,
+		"context_length", len(gatheredContext),
+		"context_preview", truncate(gatheredContext, 500),
+	)
+
 	// --- Round 2: Ghostwrite ---
 	// The LLM writes the reply using AILERON.md instructions + user
 	// instructions + gathered context. NO tools — just text in, text out.
@@ -190,6 +209,11 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 	ghostwriteMessage := fmt.Sprintf(
 		"Message from %s in %s:\n\n%s\n\n---\n\nContext gathered from connected sources:\n\n%s",
 		msg.Author, msg.Channel, msg.Body, gatheredContext,
+	)
+	p.log.Debug("ghostwrite input",
+		"user_id", userID,
+		"message_length", len(ghostwriteMessage),
+		"system_prompt_length", len(ghostwritePrompt),
 	)
 
 	draftResp, err := synthesisClient.GenerateWithTools(ctx, llm.GenerateRequest{
@@ -565,7 +589,35 @@ func (p *Pipeline) buildToolExecutor(ctx context.Context, userID string, account
 			return nil, fmt.Errorf("failed to retrieve %s credentials: %w", provider, err)
 		}
 
-		p.log.Debug("executing tool", "tool", tool, "provider", provider, "user_id", userID)
-		return p.sourceRegistry.ExecuteTool(execCtx, tool, params, secret.Value)
+		credLen := len(secret.Value)
+		isEnc := vault.IsEncrypted(secret.Metadata)
+		p.log.Debug("tool credential retrieved",
+			"tool", tool,
+			"provider", provider,
+			"vault_path", acct.VaultPath(),
+			"credential_bytes", credLen,
+			"metadata_encrypted", isEnc,
+		)
+
+		result, execErr := p.sourceRegistry.ExecuteTool(execCtx, tool, params, secret.Value)
+		if execErr != nil {
+			p.log.Error("tool execution failed", "tool", tool, "provider", provider, "error", execErr)
+		} else {
+			resultSize := 0
+			if result != nil {
+				if b, err := json.Marshal(result); err == nil {
+					resultSize = len(b)
+				}
+			}
+			p.log.Debug("tool execution succeeded", "tool", tool, "provider", provider, "result_bytes", resultSize)
+		}
+		return result, execErr
 	}
+}
+
+func truncate(s string, max int) string {
+	if len(s) <= max {
+		return s
+	}
+	return s[:max] + "..."
 }

--- a/core/llm/anthropic.go
+++ b/core/llm/anthropic.go
@@ -209,10 +209,13 @@ func (a *AnthropicClient) GenerateWithTools(ctx context.Context, req GenerateReq
 		for _, er := range execResults {
 			allToolCalls = append(allToolCalls, er.toolCall)
 			if er.err != nil {
-				toolResults = append(toolResults, anthropic.NewToolResultBlock(er.id, fmt.Sprintf("Error: %s", er.err.Error()), true))
+				errMsg := fmt.Sprintf("Error: %s", er.err.Error())
+				a.log.Debug("tool result error", "tool", er.toolCall.Tool, "error", er.err)
+				toolResults = append(toolResults, anthropic.NewToolResultBlock(er.id, errMsg, true))
 				continue
 			}
 			resultJSON, _ := json.Marshal(er.result)
+			a.log.Debug("tool result ok", "tool", er.toolCall.Tool, "result_bytes", len(resultJSON), "params", er.toolCall.Params)
 			toolResults = append(toolResults, anthropic.NewToolResultBlock(er.id, string(resultJSON), false))
 		}
 

--- a/core/server/main.go
+++ b/core/server/main.go
@@ -14,7 +14,18 @@ import (
 )
 
 func main() {
-	log := slog.New(slog.NewJSONHandler(os.Stdout, nil))
+	level := slog.LevelInfo
+	if l := os.Getenv("AILERON_LOG_LEVEL"); l != "" {
+		switch l {
+		case "debug":
+			level = slog.LevelDebug
+		case "warn":
+			level = slog.LevelWarn
+		case "error":
+			level = slog.LevelError
+		}
+	}
+	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
 
 	if err := run(log); err != nil {
 		log.Error("server exited with error", "error", err)


### PR DESCRIPTION
## Summary

- Add debug-level logging throughout the draft pipeline: provider matching, tool credential retrieval (vault path, size, encrypted flag), tool execution results, gathered context preview, ghostwrite input sizes
- Add debug logging to LLM client for tool call params and result sizes
- Add `AILERON_LOG_LEVEL` env var to server (`debug`/`info`/`warn`/`error`, default `info`)

Needed to diagnose why the research round makes tool calls but the ghostwriter still hits the low-context fallback. Set `AILERON_LOG_LEVEL=debug` on Railway to see what each tool returns.

## Test plan

- [x] `go build` and `go test` pass
- [ ] Deploy with `AILERON_LOG_LEVEL=debug`, send `/aileron` command, verify debug logs appear in Railway
- [ ] Check `tool credential retrieved` log for `metadata_encrypted: true` (would indicate ciphertext passed to API)
- [ ] Check `tool result ok` for `result_bytes` (small = empty results, large = data flowing)

🤖 Generated with [Claude Code](https://claude.com/claude-code)