### PR TITLE
fix(escrow): reconcile index against enclave on startup

### DIFF
--- a/core/app/app.go
+++ b/core/app/app.go
@@ -257,6 +257,11 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			if len(idx) > 0 {
 				log.Info("loaded escrow index from database", "entries", len(idx))
 			}
+
+			// Reconcile: prune index entries the enclave no longer has.
+			if enclaveClient != nil && len(idx) > 0 {
+				reconcileEscrowIndex(ctx, log, enclaveClient, &server.escrowIndex, escrowIndexStore, idx)
+			}
 		}
 		log.Info("using Postgres-backed stores and vault")
 

--- a/core/app/handlers_slack_agent.go
+++ b/core/app/handlers_slack_agent.go
@@ -30,11 +30,16 @@ func (s *apiServer) resolvePipelineVault(userID string) *draft.Pipeline {
 
 	// Tier 2: Escrowed credentials in TEE.
 	if s.enclaveClient != nil {
-		// Check if any escrow entries exist for this user by checking the index.
+		// Check if this specific user has escrowed credentials.
+		// Vault paths are "connected-accounts/{userID}/{provider}".
+		prefix := "connected-accounts/" + userID + "/"
 		hasEscrow := false
-		s.escrowIndex.Range(func(_, _ any) bool {
-			hasEscrow = true
-			return false // stop after first entry
+		s.escrowIndex.Range(func(key, _ any) bool {
+			if path, ok := key.(string); ok && strings.HasPrefix(path, prefix) {
+				hasEscrow = true
+				return false // found one, stop
+			}
+			return true // keep looking
 		})
 		if hasEscrow {
 			escrowVault := vault.NewEscrowVault(s.enclaveClient, &s.escrowIndex, s.vault)

--- a/core/app/handlers_slack_agent_test.go
+++ b/core/app/handlers_slack_agent_test.go
@@ -620,6 +620,60 @@ func TestResolvePipelineVault_EscrowTier(t *testing.T) {
 	}
 }
 
+func TestResolvePipelineVault_EscrowTier_OtherUserOnly(t *testing.T) {
+	srv, _ := newAgentTestServer()
+	srv.draftPipeline = newTestPipeline("ctx", "draft")
+	srv.kekSessionCache = auth.NewKEKSessionCache(24 * time.Hour)
+
+	srv.enclaveClient = &stubEscrowEnclaveClient{}
+	// Only user B has escrow entries — user A should NOT match tier 2.
+	srv.escrowIndex.Store("connected-accounts/usr_b/slack", "esc_b_1")
+	srv.escrowIndex.Store("connected-accounts/usr_b/gmail", "esc_b_2")
+
+	result := srv.resolvePipelineVault("usr_a")
+	if result != nil {
+		t.Fatal("expected nil — user A has no escrow entries, should not match tier 2")
+	}
+}
+
+func TestResolvePipelineVault_EscrowTier_MixedUsers(t *testing.T) {
+	srv, _ := newAgentTestServer()
+	srv.draftPipeline = newTestPipeline("ctx", "draft")
+	srv.kekSessionCache = auth.NewKEKSessionCache(24 * time.Hour)
+
+	srv.enclaveClient = &stubEscrowEnclaveClient{}
+	// Both users have escrow entries.
+	srv.escrowIndex.Store("connected-accounts/usr_a/slack", "esc_a_1")
+	srv.escrowIndex.Store("connected-accounts/usr_b/slack", "esc_b_1")
+
+	// User A should match tier 2.
+	resultA := srv.resolvePipelineVault("usr_a")
+	if resultA == nil {
+		t.Fatal("expected non-nil pipeline for user A (has escrow entries)")
+	}
+
+	// User B should also match tier 2.
+	resultB := srv.resolvePipelineVault("usr_b")
+	if resultB == nil {
+		t.Fatal("expected non-nil pipeline for user B (has escrow entries)")
+	}
+}
+
+func TestResolvePipelineVault_VaultLocked_AfterReconciliation(t *testing.T) {
+	srv, _ := newAgentTestServer()
+	srv.draftPipeline = newTestPipeline("ctx", "draft")
+	srv.kekSessionCache = auth.NewKEKSessionCache(24 * time.Hour) // auth enabled
+	srv.enclaveClient = &stubEscrowEnclaveClient{}
+
+	// Simulate post-reconciliation state: escrow index is empty
+	// (all stale entries pruned), KEK not in cache (server restarted).
+	// resolvePipelineVault should return nil → caller shows "vault locked".
+	result := srv.resolvePipelineVault("usr_a")
+	if result != nil {
+		t.Fatal("expected nil — no KEK, no escrow entries, auth enabled")
+	}
+}
+
 func TestResolvePipelineVault_NilPipeline(t *testing.T) {
 	srv, _ := newAgentTestServer()
 	// No pipeline configured.

--- a/core/app/handlers_tee.go
+++ b/core/app/handlers_tee.go
@@ -6,6 +6,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"log/slog"
 	"net/http"
 	"sync"
 	"time"
@@ -14,6 +15,7 @@ import (
 	"github.com/ALRubinger/aileron/core/auth"
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/store"
+	"github.com/ALRubinger/aileron/core/store/postgres"
 	"github.com/ALRubinger/aileron/core/vault"
 	"github.com/ALRubinger/aileron/enclave"
 )
@@ -373,6 +375,39 @@ func (s *apiServer) autoEscrowCredentials(ctx context.Context, userID string) in
 		escrowed++
 	}
 	return escrowed
+}
+
+// reconcileEscrowIndex prunes escrow index entries that the enclave no longer
+// has. This handles the case where the enclave restarted and lost its escrow
+// data but the server's PostgreSQL index still references the old entries.
+func reconcileEscrowIndex(ctx context.Context, log *slog.Logger, client enclave.Client, index *sync.Map, store *postgres.EscrowIndexStore, loaded map[string]string) {
+	enclaveResp, err := client.EscrowList(ctx)
+	if err != nil {
+		log.Warn("escrow reconcile: failed to list enclave entries, skipping", "error", err)
+		return
+	}
+
+	enclaveIDs := make(map[string]bool, len(enclaveResp.Entries))
+	for _, entry := range enclaveResp.Entries {
+		enclaveIDs[entry.EscrowID] = true
+	}
+
+	pruned := 0
+	for path, escrowID := range loaded {
+		if !enclaveIDs[escrowID] {
+			index.Delete(path)
+			if store != nil {
+				_ = store.Delete(ctx, path)
+			}
+			pruned++
+		}
+	}
+
+	if pruned > 0 {
+		log.Info("escrow reconcile: pruned stale entries", "pruned", pruned, "enclave_entries", len(enclaveResp.Entries))
+	} else {
+		log.Debug("escrow reconcile: all entries valid", "entries", len(loaded), "enclave_entries", len(enclaveResp.Entries))
+	}
 }
 
 // actionTypesForProvider returns the action types allowed for a connected

--- a/core/app/handlers_tee_test.go
+++ b/core/app/handlers_tee_test.go
@@ -5,9 +5,11 @@ import (
 	"context"
 	"encoding/base64"
 	"encoding/json"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -836,5 +838,133 @@ func TestConnectAccountCallbackTEEBranch(t *testing.T) {
 	}
 	if escrowID.(string) == "" {
 		t.Fatal("expected non-empty escrow ID")
+	}
+}
+
+// reconcileEnclaveClient is a minimal enclave.Client for reconcile tests.
+type reconcileEnclaveClient struct {
+	entries []enclave.EscrowListEntry
+	err     error
+}
+
+func (c *reconcileEnclaveClient) Attest(_ context.Context, _ enclave.AttestationRequest) (enclave.AttestationResponse, error) {
+	return enclave.AttestationResponse{}, nil
+}
+func (c *reconcileEnclaveClient) EstablishSession(_ context.Context, _ enclave.SessionRequest) (enclave.SessionResponse, error) {
+	return enclave.SessionResponse{}, nil
+}
+func (c *reconcileEnclaveClient) Execute(_ context.Context, _ enclave.ExecuteRequest) (enclave.ExecuteResponse, error) {
+	return enclave.ExecuteResponse{}, nil
+}
+func (c *reconcileEnclaveClient) EscrowStore(_ context.Context, _ enclave.EscrowStoreRequest) (enclave.EscrowStoreResponse, error) {
+	return enclave.EscrowStoreResponse{}, nil
+}
+func (c *reconcileEnclaveClient) TransmitKEK(_ context.Context, _ enclave.TransmitKEKRequest) (enclave.TransmitKEKResponse, error) {
+	return enclave.TransmitKEKResponse{}, nil
+}
+func (c *reconcileEnclaveClient) OAuthExchange(_ context.Context, _ enclave.OAuthExchangeRequest) (enclave.OAuthExchangeResponse, error) {
+	return enclave.OAuthExchangeResponse{}, nil
+}
+func (c *reconcileEnclaveClient) EscrowRetrieve(_ context.Context, _ enclave.EscrowRetrieveRequest) (enclave.EscrowRetrieveResponse, error) {
+	return enclave.EscrowRetrieveResponse{}, nil
+}
+func (c *reconcileEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowListResponse, error) {
+	if c.err != nil {
+		return enclave.EscrowListResponse{}, c.err
+	}
+	return enclave.EscrowListResponse{Entries: c.entries}, nil
+}
+func (c *reconcileEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
+	return nil
+}
+func (c *reconcileEnclaveClient) Close() error { return nil }
+
+func TestReconcileEscrowIndex_PrunesStaleEntries(t *testing.T) {
+	var index sync.Map
+	loaded := map[string]string{
+		"connected-accounts/usr_1/slack":        "esc_valid",
+		"connected-accounts/usr_1/gmail":        "esc_stale",
+		"connected-accounts/usr_1/github_repos": "esc_also_stale",
+	}
+	for k, v := range loaded {
+		index.Store(k, v)
+	}
+
+	client := &reconcileEnclaveClient{
+		entries: []enclave.EscrowListEntry{
+			{EscrowID: "esc_valid", GrantID: "g1", ExpiresAt: "2026-12-31T00:00:00Z"},
+		},
+	}
+
+	reconcileEscrowIndex(context.Background(), slog.Default(), client, &index, nil, loaded)
+
+	// Valid entry should remain.
+	if _, ok := index.Load("connected-accounts/usr_1/slack"); !ok {
+		t.Fatal("expected valid entry to remain")
+	}
+
+	// Stale entries should be pruned.
+	if _, ok := index.Load("connected-accounts/usr_1/gmail"); ok {
+		t.Fatal("expected stale gmail entry to be pruned")
+	}
+	if _, ok := index.Load("connected-accounts/usr_1/github_repos"); ok {
+		t.Fatal("expected stale github entry to be pruned")
+	}
+}
+
+func TestReconcileEscrowIndex_AllValid(t *testing.T) {
+	var index sync.Map
+	loaded := map[string]string{
+		"connected-accounts/usr_1/slack": "esc_1",
+	}
+	index.Store("connected-accounts/usr_1/slack", "esc_1")
+
+	client := &reconcileEnclaveClient{
+		entries: []enclave.EscrowListEntry{
+			{EscrowID: "esc_1", GrantID: "g1", ExpiresAt: "2026-12-31T00:00:00Z"},
+		},
+	}
+
+	reconcileEscrowIndex(context.Background(), slog.Default(), client, &index, nil, loaded)
+
+	if _, ok := index.Load("connected-accounts/usr_1/slack"); !ok {
+		t.Fatal("expected entry to remain")
+	}
+}
+
+func TestReconcileEscrowIndex_EnclaveError(t *testing.T) {
+	var index sync.Map
+	loaded := map[string]string{"path": "esc_1"}
+	index.Store("path", "esc_1")
+
+	client := &reconcileEnclaveClient{err: fmt.Errorf("enclave unreachable")}
+
+	// Should not panic or prune anything.
+	reconcileEscrowIndex(context.Background(), slog.Default(), client, &index, nil, loaded)
+
+	if _, ok := index.Load("path"); !ok {
+		t.Fatal("expected entry to remain when enclave is unreachable")
+	}
+}
+
+func TestReconcileEscrowIndex_EmptyEnclave(t *testing.T) {
+	var index sync.Map
+	loaded := map[string]string{
+		"path1": "esc_1",
+		"path2": "esc_2",
+	}
+	for k, v := range loaded {
+		index.Store(k, v)
+	}
+
+	client := &reconcileEnclaveClient{entries: nil}
+
+	reconcileEscrowIndex(context.Background(), slog.Default(), client, &index, nil, loaded)
+
+	// All entries should be pruned.
+	count := 0
+	index.Range(func(_, _ any) bool { count++; return true })
+	if count != 0 {
+		t.Fatalf("expected all entries pruned, got %d remaining", count)
 	}
 }


### PR DESCRIPTION
## Summary

- On server startup, call `EscrowList` on the enclave and prune any escrow index entries that the enclave no longer has
- Prevents stale PostgreSQL index entries from routing credential lookups to a dead escrow path (404 "escrow entry not found")
- Root cause: enclave restarts lose escrow data (ephemeral disk), but the server's PostgreSQL index survives and references stale IDs

## Test plan

- [x] `TestReconcileEscrowIndex_PrunesStaleEntries` — stale entries removed, valid entries kept
- [x] `TestReconcileEscrowIndex_AllValid` — no pruning when all entries match
- [x] `TestReconcileEscrowIndex_EnclaveError` — gracefully skips reconciliation if enclave is unreachable
- [x] `TestReconcileEscrowIndex_EmptyEnclave` — all entries pruned when enclave has nothing
- [x] Full test suite with `-race` passes
- [ ] Deploy, restart server, verify stale entries pruned in logs (`escrow reconcile: pruned stale entries`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)