### PR TITLE
feat(slack): instructions prompt for draft reply, echo questions

### DIFF
--- a/core/app/handlers_slack_agent.go
+++ b/core/app/handlers_slack_agent.go
@@ -177,8 +177,8 @@ func (s *apiServer) handleAssistantMessage(ctx context.Context, teamID, channelI
 }
 
 // handleMessageShortcut handles the "Draft reply with Aileron" message shortcut.
-// It opens a modal immediately (within Slack's 3s trigger_id window), then
-// generates a draft asynchronously and updates the modal with the result.
+// It opens a modal prompting the user for drafting instructions, then generates
+// a draft asynchronously when the user submits.
 func (s *apiServer) handleMessageShortcut(ctx context.Context, payload slackInteractionPayload) {
 	teamID := ""
 	if payload.Team != nil {
@@ -192,79 +192,80 @@ func (s *apiServer) handleMessageShortcut(ctx context.Context, payload slackInte
 	}
 
 	channelID := ""
-	channelName := ""
 	if payload.Channel != nil {
 		channelID = payload.Channel.ID
-		channelName = payload.Channel.Name
 	}
 
 	messageText := ""
 	messageTS := ""
 	messageThreadTS := ""
-	messageAuthorID := ""
 	if payload.Message != nil {
 		messageText = payload.Message.Text
 		messageTS = payload.Message.TS
 		messageThreadTS = payload.Message.ThreadTS
-		messageAuthorID = payload.Message.User
 	}
 	if messageThreadTS == "" {
 		messageThreadTS = messageTS
 	}
 
 	meta := DraftModalMeta{
-		TargetChannel:  channelID,
-		TargetThreadTS: messageThreadTS,
+		TargetChannel:   channelID,
+		TargetThreadTS:  messageThreadTS,
 		OriginalMessage: messageText,
-		UserID:         payload.User.ID,
+		UserID:          payload.User.ID,
+		TeamID:          teamID,
 	}
 
-	// Open the modal immediately — must be within 3s of trigger_id.
-	viewResp, err := openDraftModal(ctx, botToken, payload.TriggerID, meta)
+	// Open the instructions modal — must be within 3s of trigger_id.
+	if _, err := openDraftInstructionsModal(ctx, botToken, payload.TriggerID, meta); err != nil {
+		s.log.Error("message shortcut: failed to open instructions modal", "error", err)
+	}
+}
+
+// generateDraftFromInstructions runs draft generation after the user submits
+// instructions from the message shortcut modal. It updates the modal with the
+// result (or an error).
+func (s *apiServer) generateDraftFromInstructions(ctx context.Context, viewID string, meta DraftModalMeta) {
+	botToken, err := s.resolveWorkspaceBotToken(ctx, meta.TeamID)
 	if err != nil {
-		s.log.Error("message shortcut: failed to open modal", "error", err)
+		s.log.Error("draft from instructions: failed to resolve bot token", "error", err)
 		return
 	}
 
-	// Resolve Aileron user.
-	userID, err := s.resolveAileronUserBySlack(ctx, payload.User.ID, teamID)
+	userID, err := s.resolveAileronUserBySlack(ctx, meta.UserID, meta.TeamID)
 	if err != nil {
-		s.log.Error("message shortcut: failed to resolve user", "error", err)
-		_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Could not find your Aileron account.", meta)
+		s.log.Error("draft from instructions: failed to resolve user", "error", err)
+		_ = updateDraftModalError(ctx, botToken, viewID, "Could not find your Aileron account.", meta)
 		return
 	}
 
 	pipeline := s.resolvePipelineVault(userID)
 	if pipeline == nil {
 		if s.draftPipeline == nil {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation is not configured.", meta)
+			_ = updateDraftModalError(ctx, botToken, viewID, "Draft generation is not configured.", meta)
 		} else {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.vaultLockedMessage(), meta)
+			_ = updateDraftModalError(ctx, botToken, viewID, s.vaultLockedMessage(), meta)
 		}
 		return
 	}
 
-	// Build message context.
-	preview := messageText
+	// Build message context with user instructions.
+	preview := meta.OriginalMessage
 	if len(preview) > 200 {
 		preview = preview[:200] + "..."
 	}
-	messageAuthor := comms.ResolveSlackDisplayName(ctx, botToken, messageAuthorID)
-	msg := comms.BuildIncomingMessage(messageTS, "#"+channelName, messageAuthor, fmt.Sprintf(
-		"[Message from %s in #%s]: %s", messageAuthor, channelName, preview,
-	))
+	messageContent := fmt.Sprintf("[Original message]: %s\n\n[User instructions]: %s", preview, meta.Instructions)
+	msg := comms.BuildIncomingMessage("", meta.TargetChannel, "", messageContent)
 
-	// Generate draft (non-streaming for modal — we update once when done).
 	draftText, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
-		s.log.Error("message shortcut: draft generation failed", "error", err)
-		_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation failed. Please try again.", meta)
+		s.log.Error("draft from instructions: generation failed", "error", err)
+		_ = updateDraftModalError(ctx, botToken, viewID, "Draft generation failed. Please try again.", meta)
 		return
 	}
 
-	// Update the modal with the draft.
-	if err := updateDraftModalWithDraft(ctx, botToken, viewResp.ID, draftText, meta); err != nil {
-		s.log.Error("message shortcut: failed to update modal", "error", err)
+	if err := updateDraftModalWithDraft(ctx, botToken, viewID, draftText, meta); err != nil {
+		s.log.Error("draft from instructions: failed to update modal", "error", err)
 	}
 }
 

--- a/core/app/handlers_slack_agent_test.go
+++ b/core/app/handlers_slack_agent_test.go
@@ -867,8 +867,15 @@ func TestProcessSlashCommandQuestion_HappyPath(t *testing.T) {
 	if err := json.Unmarshal([]byte(receivedBody), &resp); err != nil {
 		t.Fatalf("failed to parse response body: %v", err)
 	}
-	if resp["text"] != "The answer is 42." {
-		t.Errorf("expected answer text, got %v", resp["text"])
+	text, _ := resp["text"].(string)
+	if !strings.Contains(text, "The answer is 42.") {
+		t.Errorf("expected answer text in response, got %v", text)
+	}
+	if !strings.Contains(text, "/aileron") {
+		t.Errorf("expected /aileron prefix in response, got %v", text)
+	}
+	if !strings.Contains(text, "How many hours on calls?") {
+		t.Errorf("expected question echoed in response, got %v", text)
 	}
 	if resp["response_type"] != "ephemeral" {
 		t.Errorf("expected ephemeral response type, got %v", resp["response_type"])
@@ -953,7 +960,7 @@ func TestProcessSlashCommandQuestion_PipelineError(t *testing.T) {
 
 	var resp map[string]any
 	json.Unmarshal([]byte(receivedBody), &resp)
-	if text, ok := resp["text"].(string); !ok || text != "Something went wrong. Please try again." {
+	if text, ok := resp["text"].(string); !ok || !strings.Contains(text, "Something went wrong. Please try again.") {
 		t.Errorf("expected error message, got %v", resp["text"])
 	}
 }

--- a/core/app/handlers_slack_commands.go
+++ b/core/app/handlers_slack_commands.go
@@ -64,10 +64,11 @@ func (s *apiServer) handleSlackCommand(w http.ResponseWriter, r *http.Request) {
 	}
 
 	// Question or no trigger_id — respond ephemerally.
+	// Include the user's question so they have a record of what they asked.
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
 		"response_type": "ephemeral",
-		"text":          ":hourglass_flowing_sand: Working on it...",
+		"text":          "> /aileron " + text + "\n\n:hourglass_flowing_sand: Working on it...",
 	})
 
 	go s.processSlashCommandQuestion(context.Background(), teamID, slackUserID, text, responseURL)
@@ -145,11 +146,11 @@ func (s *apiServer) processSlashCommandQuestion(ctx context.Context, teamID, sla
 	answer, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("slash command question: generation failed", "error", err)
-		s.respondViaURL(responseURL, "Something went wrong. Please try again.")
+		s.respondViaURL(responseURL, "> /aileron "+text+"\n\nSomething went wrong. Please try again.")
 		return
 	}
 
-	s.respondViaURL(responseURL, answer)
+	s.respondViaURL(responseURL, "> /aileron "+text+"\n\n"+answer)
 }
 
 // respondViaURL sends an ephemeral response update via Slack's response_url.

--- a/core/app/handlers_slack_commands_test.go
+++ b/core/app/handlers_slack_commands_test.go
@@ -94,6 +94,13 @@ func TestSlackCommand_Question_Returns200(t *testing.T) {
 	if resp["response_type"] != "ephemeral" {
 		t.Errorf("expected ephemeral response, got %v", resp["response_type"])
 	}
+	text, _ := resp["text"].(string)
+	if !strings.Contains(text, "How many hours on calls today?") {
+		t.Errorf("expected ephemeral to echo user's question, got %q", text)
+	}
+	if !strings.Contains(text, "/aileron") {
+		t.Errorf("expected ephemeral to include /aileron prefix, got %q", text)
+	}
 }
 
 func TestSlackCommand_Draft_Returns200(t *testing.T) {
@@ -141,6 +148,10 @@ func TestSlackCommand_DraftNoTriggerID_FallsBackToEphemeral(t *testing.T) {
 	json.NewDecoder(w.Body).Decode(&resp)
 	if resp["response_type"] != "ephemeral" {
 		t.Errorf("expected ephemeral response when no trigger_id, got %v", resp["response_type"])
+	}
+	text, _ := resp["text"].(string)
+	if !strings.Contains(text, "Draft me a status update") {
+		t.Errorf("expected ephemeral to echo user's request, got %q", text)
 	}
 }
 

--- a/core/app/handlers_slack_interactions.go
+++ b/core/app/handlers_slack_interactions.go
@@ -92,6 +92,38 @@ func (s *apiServer) handleSlackInteraction(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Handle instructions modal submission specially — we need to return a
+	// response_action to update the view in-place before generating the draft.
+	if payload.Type == "view_submission" && payload.View != nil && payload.View.CallbackID == instructionsModalCallbackID {
+		meta, err := parseDraftModalMeta(payload.View.PrivateMetadata)
+		if err != nil {
+			s.log.Error("instructions submit: failed to parse metadata", "error", err)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Extract the user's instructions from the modal state.
+		if payload.View.State != nil {
+			if block, ok := payload.View.State.Values[instructionsInputBlockID]; ok {
+				if input, ok := block[instructionsInputActionID]; ok {
+					meta.Instructions = input.Value
+				}
+			}
+		}
+
+		// Respond with an updated loading view — keeps the modal open.
+		loadingView := buildDraftLoadingView(meta)
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"response_action": "update",
+			"view":            loadingView,
+		})
+
+		// Generate the draft asynchronously.
+		go s.generateDraftFromInstructions(context.Background(), payload.View.ID, meta)
+		return
+	}
+
 	// Return 200 immediately — Slack requires fast response.
 	w.WriteHeader(http.StatusOK)
 

--- a/core/app/handlers_slack_interactions_test.go
+++ b/core/app/handlers_slack_interactions_test.go
@@ -939,6 +939,91 @@ func TestInteraction_RefineAction_BadMetadata(t *testing.T) {
 	time.Sleep(50 * time.Millisecond)
 }
 
+func TestInteraction_InstructionsSubmission_ReturnsUpdateAction(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	meta, _ := json.Marshal(DraftModalMeta{
+		TargetChannel:   "C0BACKEND",
+		TargetThreadTS:  "111.222",
+		OriginalMessage: "Can someone review PR #42?",
+		UserID:          "U_ALICE",
+		TeamID:          "T001",
+	})
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "view_submission",
+		"user": map[string]any{"id": "U_ALICE"},
+		"team": map[string]any{"id": "T001"},
+		"view": map[string]any{
+			"id":               "V_INSTR_123",
+			"callback_id":      instructionsModalCallbackID,
+			"private_metadata": string(meta),
+			"state": map[string]any{
+				"values": map[string]any{
+					instructionsInputBlockID: map[string]any{
+						instructionsInputActionID: map[string]any{
+							"value": "Politely decline and suggest next week",
+						},
+					},
+				},
+			},
+		},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	// Verify the response contains a response_action: "update" to keep the modal open.
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("failed to decode response: %v", err)
+	}
+	if resp["response_action"] != "update" {
+		t.Errorf("expected response_action 'update', got %v", resp["response_action"])
+	}
+
+	// Verify the updated view has the draft modal callback ID (loading state).
+	viewMap, ok := resp["view"].(map[string]any)
+	if !ok {
+		t.Fatal("expected view in response")
+	}
+	if viewMap["callback_id"] != draftModalCallbackID {
+		t.Errorf("expected callback_id %q, got %v", draftModalCallbackID, viewMap["callback_id"])
+	}
+
+	// The async generateDraftFromInstructions will fail (no bot token) but
+	// the key assertion is that the response_action flow works correctly.
+	time.Sleep(50 * time.Millisecond)
+}
+
+func TestInteraction_InstructionsSubmission_BadMetadata(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "view_submission",
+		"user": map[string]any{"id": "U_ALICE"},
+		"view": map[string]any{
+			"id":               "V_INSTR_123",
+			"callback_id":      instructionsModalCallbackID,
+			"private_metadata": "not-valid-json",
+		},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+	// Bad metadata — should return 200 without crashing.
+}
+
 func TestInteraction_UnknownAction(t *testing.T) {
 	srv := newInteractionTestServer()
 

--- a/core/app/handlers_slack_modal.go
+++ b/core/app/handlers_slack_modal.go
@@ -14,18 +14,24 @@ type DraftModalMeta struct {
 	TargetChannel   string `json:"channel"`
 	TargetThreadTS  string `json:"thread_ts,omitempty"`
 	OriginalMessage string `json:"original_message,omitempty"`
-	UserID          string `json:"user_id"` // Slack user ID
+	UserID          string `json:"user_id"`               // Slack user ID
+	TeamID          string `json:"team_id,omitempty"`      // Slack workspace ID
+	Instructions    string `json:"instructions,omitempty"` // user's drafting instructions
 }
 
 const (
-	draftModalCallbackID   = "aileron_draft_modal"
-	draftInputBlockID      = "draft_input"
-	draftInputActionID     = "draft_text"
-	instructionBlockID     = "instruction_input"
-	instructionActionID    = "instruction_text"
-	refineActionID         = "refine_draft"
-	refineBlockID          = "refine_actions"
-	maxModalTextLength     = 3000
+	draftModalCallbackID        = "aileron_draft_modal"
+	instructionsModalCallbackID = "aileron_draft_instructions"
+	draftInputBlockID           = "draft_input"
+	draftInputActionID          = "draft_text"
+	instructionBlockID          = "instruction_input"
+	instructionActionID         = "instruction_text"
+	instructionsInputBlockID    = "instructions_prompt_input"
+	instructionsInputActionID   = "instructions_prompt_text"
+	messagePreviewBlockID       = "message_preview"
+	refineActionID              = "refine_draft"
+	refineBlockID               = "refine_actions"
+	maxModalTextLength          = 3000
 )
 
 // openDraftModal opens a modal in loading state. Must be called within 3s of
@@ -171,6 +177,74 @@ func updateDraftModalError(ctx context.Context, botToken, viewID, message string
 
 	_, err := comms.UpdateModal(ctx, botToken, viewID, view)
 	return err
+}
+
+// openDraftInstructionsModal opens a modal that prompts the user for drafting
+// instructions before generating a draft. Shows a preview of the original
+// message and a text input for the user's direction.
+func openDraftInstructionsModal(ctx context.Context, botToken, triggerID string, meta DraftModalMeta) (*slack.ViewResponse, error) {
+	metaJSON, _ := json.Marshal(meta)
+
+	preview := meta.OriginalMessage
+	if len(preview) > 200 {
+		preview = preview[:200] + "..."
+	}
+
+	blocks := []slack.Block{
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, "*Replying to:*\n> "+preview, false, false),
+			nil, nil,
+		),
+		slack.NewDividerBlock(),
+	}
+
+	instructionsInput := slack.NewPlainTextInputBlockElement(
+		slack.NewTextBlockObject(slack.PlainTextType, "e.g. Politely decline, suggest next week instead", false, false),
+		instructionsInputActionID,
+	)
+	instructionsInput.Multiline = true
+
+	blocks = append(blocks, slack.NewInputBlock(
+		instructionsInputBlockID,
+		slack.NewTextBlockObject(slack.PlainTextType, "What should the reply say?", false, false),
+		nil,
+		instructionsInput,
+	))
+
+	view := slack.ModalViewRequest{
+		Type:            slack.VTModal,
+		CallbackID:      instructionsModalCallbackID,
+		Title:           slack.NewTextBlockObject(slack.PlainTextType, "Draft with Aileron", false, false),
+		Submit:          slack.NewTextBlockObject(slack.PlainTextType, "Start Draft", false, false),
+		Close:           slack.NewTextBlockObject(slack.PlainTextType, "Cancel", false, false),
+		PrivateMetadata: string(metaJSON),
+		Blocks: slack.Blocks{
+			BlockSet: blocks,
+		},
+	}
+
+	return comms.OpenModal(ctx, botToken, triggerID, view)
+}
+
+// buildDraftLoadingView returns a modal view request showing a loading state.
+// Used as the response_action update when transitioning from instructions to draft generation.
+func buildDraftLoadingView(meta DraftModalMeta) slack.ModalViewRequest {
+	metaJSON, _ := json.Marshal(meta)
+
+	return slack.ModalViewRequest{
+		Type:            slack.VTModal,
+		CallbackID:      draftModalCallbackID,
+		Title:           slack.NewTextBlockObject(slack.PlainTextType, "Draft with Aileron", false, false),
+		PrivateMetadata: string(metaJSON),
+		Blocks: slack.Blocks{
+			BlockSet: []slack.Block{
+				slack.NewSectionBlock(
+					slack.NewTextBlockObject(slack.MarkdownType, ":hourglass_flowing_sand: *Researching...*", false, false),
+					nil, nil,
+				),
+			},
+		},
+	}
 }
 
 // parseDraftModalMeta extracts the DraftModalMeta from a view's private_metadata.

--- a/core/app/handlers_slack_modal_test.go
+++ b/core/app/handlers_slack_modal_test.go
@@ -99,6 +99,92 @@ func TestUpdateDraftModalWithDraft_Truncation(t *testing.T) {
 	// No panic, truncation handled internally.
 }
 
+func TestOpenDraftInstructionsModal_Success(t *testing.T) {
+	var receivedPath string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		receivedPath = r.URL.Path
+		slackViewOK(w)
+	}))
+	defer server.Close()
+
+	comms.SetAgentAPIURL(server.URL + "/")
+	defer comms.SetAgentAPIURL("")
+
+	meta := DraftModalMeta{
+		TargetChannel:   "C123",
+		TargetThreadTS:  "111.222",
+		OriginalMessage: "Can someone review PR #42?",
+		UserID:          "U_ALICE",
+		TeamID:          "T001",
+	}
+
+	viewResp, err := openDraftInstructionsModal(context.Background(), "xoxb-test", "trigger_456", meta)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if viewResp == nil {
+		t.Fatal("expected non-nil view response")
+	}
+	if viewResp.ID != "V_MODAL_123" {
+		t.Errorf("expected view ID V_MODAL_123, got %q", viewResp.ID)
+	}
+	if !strings.Contains(receivedPath, "views.open") {
+		t.Errorf("expected views.open call, got path %q", receivedPath)
+	}
+}
+
+func TestOpenDraftInstructionsModal_LongMessageTruncated(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		slackViewOK(w)
+	}))
+	defer server.Close()
+
+	comms.SetAgentAPIURL(server.URL + "/")
+	defer comms.SetAgentAPIURL("")
+
+	longMessage := strings.Repeat("A", 300)
+	meta := DraftModalMeta{
+		TargetChannel:   "C123",
+		OriginalMessage: longMessage,
+		UserID:          "U_ALICE",
+	}
+
+	viewResp, err := openDraftInstructionsModal(context.Background(), "xoxb-test", "trigger_789", meta)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if viewResp == nil {
+		t.Fatal("expected non-nil view response")
+	}
+}
+
+func TestBuildDraftLoadingView(t *testing.T) {
+	meta := DraftModalMeta{
+		TargetChannel:   "C123",
+		OriginalMessage: "Test message",
+		UserID:          "U_ALICE",
+		Instructions:    "Make it polite",
+	}
+
+	view := buildDraftLoadingView(meta)
+
+	if view.CallbackID != draftModalCallbackID {
+		t.Errorf("expected callback_id %q, got %q", draftModalCallbackID, view.CallbackID)
+	}
+	if len(view.Blocks.BlockSet) != 1 {
+		t.Fatalf("expected 1 block, got %d", len(view.Blocks.BlockSet))
+	}
+
+	// Verify metadata round-trips correctly including instructions.
+	parsed, err := parseDraftModalMeta(view.PrivateMetadata)
+	if err != nil {
+		t.Fatalf("failed to parse metadata: %v", err)
+	}
+	if parsed.Instructions != "Make it polite" {
+		t.Errorf("expected instructions 'Make it polite', got %q", parsed.Instructions)
+	}
+}
+
 func TestUpdateDraftModalError_Success(t *testing.T) {
 	var receivedPath string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary
- **Draft a Reply** (message shortcut): Now opens an instructions modal first, prompting users with "What should the reply say?" and showing a preview of the original message. After submitting instructions, the modal transitions to a loading state and generates a draft informed by the user's direction.
- **/aileron question**: Ephemeral responses now echo the user's question (as `> /aileron <question>`) before showing the loading indicator and the final answer, giving users a record of what they asked.

## Test plan
- [x] Verify "Draft a Reply" from 3-dot menu opens instructions modal with message preview
- [x] Submit instructions and confirm draft generates with user's direction applied
- [x] Verify Refine and Send still work after instructions-based draft generation
- [x] Run `/aileron <question>` and verify the ephemeral shows the question in both loading and final states
- [x] Run `/aileron draft <text>` and verify the modal flow still works (unchanged)
- [x] Confirm all tests pass: `go test ./core/app/... -count=1`

🤖 Generated with [Claude Code](https://claude.com/claude-code)