### PR TITLE
fix(escrow): self-heal stale escrow index entries on retrieval failure

### DIFF
--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -15,6 +15,7 @@ package draft
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"log/slog"
 	"strings"
@@ -586,6 +587,13 @@ func (p *Pipeline) buildToolExecutor(ctx context.Context, userID string, account
 		// Get the OAuth token from the vault.
 		secret, err := p.vault.Get(ctx, acct.VaultPath())
 		if err != nil {
+			if errors.Is(err, vault.ErrEscrowStale) {
+				return nil, fmt.Errorf(
+					"the user's %s credentials are unavailable because their vault session has expired; "+
+						"tell the user to open the Aileron app and unlock their vault to reconnect",
+					provider,
+				)
+			}
 			return nil, fmt.Errorf("failed to retrieve %s credentials: %w", provider, err)
 		}
 

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
@@ -16,6 +17,7 @@ import (
 	"github.com/ALRubinger/aileron/core/store"
 	"github.com/ALRubinger/aileron/core/store/mem"
 	"github.com/ALRubinger/aileron/core/vault"
+	"github.com/ALRubinger/aileron/enclave"
 )
 
 // mockLLMClient records requests and returns configured responses.
@@ -1049,5 +1051,109 @@ func TestRefineDraft(t *testing.T) {
 	}
 	if !strings.Contains(msg, "Original message text") {
 		t.Errorf("expected original message in prompt, got: %s", msg)
+	}
+}
+
+// stubEnclaveClient implements enclave.Client for testing stale escrow in the pipeline.
+type stubEnclaveClient struct {
+	retrieveErr error
+}
+
+func (s *stubEnclaveClient) Attest(_ context.Context, _ enclave.AttestationRequest) (enclave.AttestationResponse, error) {
+	return enclave.AttestationResponse{}, nil
+}
+func (s *stubEnclaveClient) EstablishSession(_ context.Context, _ enclave.SessionRequest) (enclave.SessionResponse, error) {
+	return enclave.SessionResponse{}, nil
+}
+func (s *stubEnclaveClient) TransmitKEK(_ context.Context, _ enclave.TransmitKEKRequest) (enclave.TransmitKEKResponse, error) {
+	return enclave.TransmitKEKResponse{}, nil
+}
+func (s *stubEnclaveClient) OAuthExchange(_ context.Context, _ enclave.OAuthExchangeRequest) (enclave.OAuthExchangeResponse, error) {
+	return enclave.OAuthExchangeResponse{}, nil
+}
+func (s *stubEnclaveClient) Execute(_ context.Context, _ enclave.ExecuteRequest) (enclave.ExecuteResponse, error) {
+	return enclave.ExecuteResponse{}, nil
+}
+func (s *stubEnclaveClient) EscrowStore(_ context.Context, _ enclave.EscrowStoreRequest) (enclave.EscrowStoreResponse, error) {
+	return enclave.EscrowStoreResponse{}, nil
+}
+func (s *stubEnclaveClient) EscrowRetrieve(_ context.Context, _ enclave.EscrowRetrieveRequest) (enclave.EscrowRetrieveResponse, error) {
+	return enclave.EscrowRetrieveResponse{}, s.retrieveErr
+}
+func (s *stubEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowListResponse, error) {
+	return enclave.EscrowListResponse{}, nil
+}
+func (s *stubEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
+	return nil
+}
+func (s *stubEnclaveClient) Close() error { return nil }
+
+func TestPipeline_GenerateDraft_ToolExecutor_StaleEscrow(t *testing.T) {
+	// When the escrow vault returns ErrEscrowStale, the tool executor should
+	// return a user-actionable message telling Claude to ask the user to
+	// unlock their vault, rather than a raw error stack trace.
+	mock := &mockLLMClient{
+		researchResp:   &llm.GenerateResponse{Text: "context gathered"},
+		ghostwriteResp: &llm.GenerateResponse{Text: "draft"},
+	}
+
+	accounts := mem.NewConnectedAccountStore()
+	ctx := context.Background()
+
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_1",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+
+	// Build an EscrowVault with a failing enclave client and a stale index entry.
+	idx := &sync.Map{}
+	idx.Store("connected-accounts/usr_1/slack", "esc_stale_123")
+	escrowVault := vault.NewEscrowVault(
+		&stubEnclaveClient{retrieveErr: enclave.ErrEscrowNotFound},
+		idx,
+		vault.NewMemVault(),
+	)
+
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&mockSourceConnector{})
+
+	p := draft.NewPipeline(mock, mock, sourceReg, accounts, mem.NewUserInstructionStore(),
+		escrowVault, slog.Default(),
+		draft.Prompts{Research: "test research", Ghostwrite: "test ghostwrite"})
+
+	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
+		ID: "msg_1", Service: "slack", Channel: "#backend", Author: "Sarah", Body: "Hello",
+	})
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	// Extract the tool executor from the research round request.
+	if len(mock.requests) < 1 {
+		t.Fatal("expected at least 1 LLM call")
+	}
+	researchReq := mock.requests[0]
+	if researchReq.ToolExecutor == nil {
+		t.Fatal("expected ToolExecutor in research round")
+	}
+
+	// Execute a tool — should fail with the user-actionable message.
+	_, execErr := researchReq.ToolExecutor(ctx, "slack_channel_history", map[string]any{"channel": "C123"})
+	if execErr == nil {
+		t.Fatal("expected error from stale escrow")
+	}
+
+	errMsg := execErr.Error()
+	if !strings.Contains(errMsg, "vault session has expired") {
+		t.Errorf("expected user-actionable 'vault session has expired' message, got: %s", errMsg)
+	}
+	if !strings.Contains(errMsg, "unlock their vault") {
+		t.Errorf("expected 'unlock their vault' guidance, got: %s", errMsg)
+	}
+	// Should NOT contain raw error wrapping that would confuse the LLM.
+	if strings.Contains(errMsg, "ErrEscrowStale") {
+		t.Error("error message should not expose internal sentinel error name")
 	}
 }

--- a/core/vault/escrow_vault.go
+++ b/core/vault/escrow_vault.go
@@ -33,6 +33,10 @@ func NewEscrowVault(client enclave.Client, escrowIndex *sync.Map, fallback Vault
 
 // Get retrieves a secret. If the path has an escrowed credential, it retrieves
 // the plaintext from the enclave. Otherwise it delegates to the fallback vault.
+//
+// If the enclave no longer has the escrow entry (restart, expiry, etc.), Get
+// removes the stale index entry so that future lookups fall through to the
+// fallback vault, and returns ErrEscrowStale.
 func (v *EscrowVault) Get(ctx context.Context, path string) (Secret, error) {
 	escrowID, ok := v.escrowIndex.Load(path)
 	if !ok {
@@ -43,7 +47,10 @@ func (v *EscrowVault) Get(ctx context.Context, path string) (Secret, error) {
 		EscrowID: escrowID.(string),
 	})
 	if err != nil {
-		return Secret{}, fmt.Errorf("vault: escrow retrieve for %q: %w", path, err)
+		// The enclave no longer has this entry — prune the stale index so
+		// subsequent requests don't repeat the failed lookup.
+		v.escrowIndex.Delete(path)
+		return Secret{}, fmt.Errorf("vault: escrow retrieve for %q: %w", path, ErrEscrowStale)
 	}
 
 	return Secret{

--- a/core/vault/escrow_vault_test.go
+++ b/core/vault/escrow_vault_test.go
@@ -83,7 +83,7 @@ func TestEscrowVault_Get_EscrowMiss_FallsThrough(t *testing.T) {
 	}
 }
 
-func TestEscrowVault_Get_EscrowExpired(t *testing.T) {
+func TestEscrowVault_Get_EscrowExpired_PrunesIndex(t *testing.T) {
 	client := &mockEnclaveClient{
 		retrieveErr: enclave.ErrEscrowExpired,
 	}
@@ -95,11 +95,67 @@ func TestEscrowVault_Get_EscrowExpired(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for expired escrow")
 	}
-	if !errors.Is(err, enclave.ErrEscrowExpired) {
-		// The error is wrapped, so check the message.
-		if !containsStr(err.Error(), "escrow") {
-			t.Errorf("error = %v, want escrow-related error", err)
-		}
+	if !errors.Is(err, ErrEscrowStale) {
+		t.Errorf("error = %v, want ErrEscrowStale", err)
+	}
+
+	// The stale index entry must be removed so subsequent lookups
+	// fall through to the fallback vault.
+	if _, ok := idx.Load("connected-accounts/usr_1/slack"); ok {
+		t.Error("stale index entry was not pruned after escrow retrieval failure")
+	}
+}
+
+func TestEscrowVault_Get_EscrowNotFound_PrunesIndex(t *testing.T) {
+	client := &mockEnclaveClient{
+		retrieveErr: enclave.ErrEscrowNotFound,
+	}
+	idx := &sync.Map{}
+	idx.Store("connected-accounts/usr_1/github_repos", "esc_gone")
+
+	v := NewEscrowVault(client, idx, NewMemVault())
+	_, err := v.Get(context.Background(), "connected-accounts/usr_1/github_repos")
+	if err == nil {
+		t.Fatal("expected error for missing escrow")
+	}
+	if !errors.Is(err, ErrEscrowStale) {
+		t.Errorf("error = %v, want ErrEscrowStale", err)
+	}
+
+	// Index entry must be pruned.
+	if _, ok := idx.Load("connected-accounts/usr_1/github_repos"); ok {
+		t.Error("stale index entry was not pruned after escrow not found")
+	}
+}
+
+// TestEscrowVault_Get_StaleEntry_FallsThrough_OnRetry verifies the full
+// self-healing cycle: after a stale escrow entry is pruned, a subsequent
+// Get for the same path falls through to the fallback vault.
+func TestEscrowVault_Get_StaleEntry_FallsThrough_OnRetry(t *testing.T) {
+	client := &mockEnclaveClient{
+		retrieveErr: enclave.ErrEscrowNotFound,
+	}
+	idx := &sync.Map{}
+	idx.Store("connected-accounts/usr_1/github_repos", "esc_gone")
+
+	inner := NewMemVault()
+	inner.Put(context.Background(), "connected-accounts/usr_1/github_repos", []byte("fallback-token"), Metadata{})
+
+	v := NewEscrowVault(client, idx, inner)
+
+	// First call: fails and prunes the stale entry.
+	_, err := v.Get(context.Background(), "connected-accounts/usr_1/github_repos")
+	if !errors.Is(err, ErrEscrowStale) {
+		t.Fatalf("first call: error = %v, want ErrEscrowStale", err)
+	}
+
+	// Second call: falls through to fallback vault.
+	secret, err := v.Get(context.Background(), "connected-accounts/usr_1/github_repos")
+	if err != nil {
+		t.Fatalf("second call: unexpected error: %v", err)
+	}
+	if string(secret.Value) != "fallback-token" {
+		t.Errorf("second call: Value = %q, want fallback-token", secret.Value)
 	}
 }
 

--- a/core/vault/spi.go
+++ b/core/vault/spi.go
@@ -10,7 +10,16 @@
 // to HashiCorp Vault, AWS Secrets Manager, GCP Secret Manager, etc.
 package vault
 
-import "context"
+import (
+	"context"
+	"errors"
+)
+
+// ErrEscrowStale indicates that an escrow index entry pointed to an enclave
+// escrow ID that no longer exists (enclave restarted, entry expired, etc.).
+// The stale index entry has been removed; the caller should treat the
+// credential as unavailable and prompt the user to re-unlock their vault.
+var ErrEscrowStale = errors.New("vault: escrow entry is stale")
 
 // Vault stores and retrieves secrets by path.
 type Vault interface {


### PR DESCRIPTION
## Summary

- **Self-healing**: `EscrowVault.Get` now deletes stale escrow index entries when the enclave returns an error (not found, expired, enclave restarted), so subsequent requests fall through to the vault-locked path and show the user a proper "unlock your vault" message
- **Better first-request UX**: The pipeline tool executor detects `ErrEscrowStale` and returns a user-actionable message ("vault session expired, unlock your vault") instead of a raw error, so Claude relays useful guidance rather than "let me check and get back to you"
- **New sentinel error**: `vault.ErrEscrowStale` signals that an escrow index entry was stale and has been cleaned up

## Test plan

- [x] `TestEscrowVault_Get_EscrowExpired_PrunesIndex` — expired escrow prunes the index entry
- [x] `TestEscrowVault_Get_EscrowNotFound_PrunesIndex` — missing escrow (enclave restart) prunes the index entry
- [x] `TestEscrowVault_Get_StaleEntry_FallsThrough_OnRetry` — full self-healing cycle: first call prunes, second call falls through to fallback
- [x] All existing `core/...` tests pass
- [x] 100% coverage on `escrow_vault.go`

🤖 Generated with [Claude Code](https://claude.com/claude-code)