### PR TITLE
chore: add Taskfile target for enclave production build + push

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,6 +69,24 @@ tasks:
     cmds:
       - go build -ldflags "-X github.com/ALRubinger/aileron/core/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/core/version.Commit={{.COMMIT}}" -o build/aileron-enclave ./cmd/aileron-enclave
 
+  build:enclave:production:
+    desc: Build and push the enclave container image to GCP Artifact Registry
+    requires:
+      vars:
+        - GCP_PROJECT
+        - GCP_REGION
+    vars:
+      REGISTRY: '{{.GCP_REGION}}-docker.pkg.dev/{{.GCP_PROJECT}}/aileron-enclave'
+      IMAGE: '{{.REGISTRY}}/aileron-enclave:latest'
+    cmds:
+      - docker build --platform linux/amd64 -f cmd/aileron-enclave/Dockerfile -t {{.IMAGE}} .
+      - docker push {{.IMAGE}}
+      - |
+        DIGEST=$(gcloud artifacts docker images describe {{.IMAGE}} \
+          --format='value(image_summary.digest)' \
+          --project={{.GCP_PROJECT}})
+        echo "Image digest: $DIGEST"
+
   build:cli:
     desc: Build the aileron CLI binary locally
     vars:

--- a/docs/src/content/docs/deployment/tee-enclave.md
+++ b/docs/src/content/docs/deployment/tee-enclave.md
@@ -76,7 +76,16 @@ Configure Docker to authenticate with Artifact Registry for pushing:
 gcloud auth configure-docker $REGION-docker.pkg.dev
 ```
 
-Then build and push:
+Then build and push using the Taskfile target:
+
+```sh
+task build:enclave:production GCP_PROJECT=$GCP_PROJECT GCP_REGION=$REGION
+```
+
+The task builds the image for `linux/amd64`, pushes it to Artifact Registry, and prints the image digest.
+
+<details>
+<summary>Manual commands (equivalent)</summary>
 
 ```sh
 export REGISTRY=$REGION-docker.pkg.dev/$GCP_PROJECT/aileron-enclave
@@ -97,6 +106,8 @@ export IMAGE_DIGEST=$(gcloud artifacts docker images describe \
 
 echo "Image digest: $IMAGE_DIGEST"
 ```
+
+</details>
 
 ### 4. Create a service account for the enclave VM
 

--- a/docs/src/content/docs/development/building-from-source.md
+++ b/docs/src/content/docs/development/building-from-source.md
@@ -39,3 +39,20 @@ task build:ui        # SvelteKit UI
 task build:docs      # Documentation site
 task build:docker    # Docker containers
 ```
+
+## Enclave production image
+
+Build and push the enclave container image to GCP Artifact Registry:
+
+```sh
+task build:enclave:production GCP_PROJECT=my-project GCP_REGION=us-central1
+```
+
+| Variable | Description |
+|----------|-------------|
+| `GCP_PROJECT` | GCP project ID (required) |
+| `GCP_REGION` | Artifact Registry region, must match the region of your enclave repository (required) |
+
+The task builds for `linux/amd64` (required by Confidential Space), pushes to Artifact Registry, and prints the image digest. You must have Docker running and `gcloud auth configure-docker` set up for the target region.
+
+This is for manual one-off builds. CI handles production builds automatically via the [Enclave Publish](https://github.com/ALRubinger/aileron/actions/workflows/enclave-publish.yml) workflow. See the [TEE Enclave deployment guide](/deployment/tee-enclave/#3-build-and-push-the-enclave-container-image) for full setup context.


### PR DESCRIPTION
## Summary

- Add `build:enclave:production` Taskfile target that builds the enclave image for `linux/amd64`, pushes to GCP Artifact Registry, and prints the image digest
- Requires `GCP_PROJECT` and `GCP_REGION` as explicit vars (no implicit gcloud state)
- Update TEE deployment guide (step 3) to reference the task, with manual commands in a collapsible block

Closes #210

## Test plan

- [x] `task --list` shows the new target
- [x] Running without required vars fails with clear error message

🤖 Generated with [Claude Code](https://claude.com/claude-code)