### PR TITLE
fix(ui): render connected account dates in UTC

### DIFF
--- a/ui/src/routes/settings/connected-accounts/+page.svelte
+++ b/ui/src/routes/settings/connected-accounts/+page.svelte
@@ -173,7 +173,8 @@
 		return new Date(d).toLocaleDateString(undefined, {
 			year: 'numeric',
 			month: 'long',
-			day: 'numeric'
+			day: 'numeric',
+			timeZone: 'UTC'
 		});
 	}
 

--- a/ui/src/routes/settings/connected-accounts/page.test.ts
+++ b/ui/src/routes/settings/connected-accounts/page.test.ts
@@ -73,6 +73,17 @@ describe('Connected Accounts Page', () => {
 		expect(screen.getByText('alrubinger')).toBeInTheDocument();
 	});
 
+	it('renders dates in UTC so midnight timestamps do not shift to the previous day', async () => {
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('Slack')).toBeInTheDocument();
+		});
+		// Mock data has '2025-01-15T00:00:00Z' — without timeZone:'UTC', browsers
+		// west of UTC would render this as January 14, 2025.
+		expect(screen.getByText('Connected January 15, 2025')).toBeInTheDocument();
+		expect(screen.getByText('Connected February 20, 2025')).toBeInTheDocument();
+	});
+
 	it('shows status badges for each account', async () => {
 		render(Page);
 		await waitFor(() => {


### PR DESCRIPTION
## Summary

- Add `timeZone: 'UTC'` to `formatDate` in connected-accounts page so midnight UTC timestamps (e.g. `2025-01-15T00:00:00Z`) no longer display as the previous day for users west of UTC
- Add regression test asserting the rendered date text matches the UTC date

Closes #280

## Test plan

- [x] New unit test `renders dates in UTC so midnight timestamps do not shift to the previous day` passes
- [x] All 54 existing UI tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)