### PR TITLE
docs: add AILERON_UI_URL to deployment guides

### DIFF
--- a/docs/src/content/docs/deployment/cloud.md
+++ b/docs/src/content/docs/deployment/cloud.md
@@ -58,6 +58,7 @@ Each service needs a domain or URL. The auth domain points to the **server** ser
 | `ANTHROPIC_API_KEY` | No | | Anthropic API key. Enables AI-powered draft generation when set |
 | `AILERON_LLM_MODEL_RESEARCH` | No | `claude-haiku-4-5-20251001` | Model for the research round (tool-call decisions, context gathering). Use a fast model — quality is less important than speed here. Any Anthropic model ID works |
 | `AILERON_LLM_MODEL_SYNTHESIS` | No | `claude-sonnet-4-6` | Model for the synthesis round (composing the final reply in the user's voice). Use a capable model — this is the quality-sensitive step |
+| `AILERON_UI_URL` | No | | Base URL of the web UI (e.g. `https://app.yourdomain.com`). Used to construct user-facing links such as the vault unlock link sent via Slack. No trailing slash |
 
 ### UI service
 

--- a/docs/src/content/docs/deployment/railway.md
+++ b/docs/src/content/docs/deployment/railway.md
@@ -40,6 +40,7 @@ Link the Postgres plugin to the server service.
 | `ANTHROPIC_API_KEY` | Anthropic API key for draft generation (optional) |
 | `AILERON_LLM_MODEL_RESEARCH` | Research model (default: `claude-haiku-4-5-20251001`) (optional) |
 | `AILERON_LLM_MODEL_SYNTHESIS` | Synthesis model (default: `claude-sonnet-4-6`) (optional) |
+| `AILERON_UI_URL` | `https://app.withaileron.ai` |
 
 **UI service:**
 


### PR DESCRIPTION
## Summary

- Add `AILERON_UI_URL` to the server env vars table in both the cloud deployment and Railway guides
- This env var is required for Slack vault unlock links to include a clickable URL — without it, users get a generic "unlock your vault in the Aileron app" message with no link

## Test plan

- [x] Verify the env var format matches what `core/config/auth.go` reads (`AILERON_UI_URL`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)