### PR TITLE
fix(slack): show vault unlock message when credentials are unavailable

### DIFF
--- a/core/app/handlers_slack_agent.go
+++ b/core/app/handlers_slack_agent.go
@@ -66,6 +66,16 @@ func (s *apiServer) vaultLockedMessage() string {
 	return ":lock: Your Aileron session has expired. Please unlock your vault in the Aileron app to reconnect your accounts."
 }
 
+// isVaultError checks whether err indicates that vault credentials are
+// unavailable (locked vault or stale escrow). When true it returns the
+// user-facing vault unlock message.
+func (s *apiServer) isVaultError(err error) (string, bool) {
+	if errors.Is(err, vault.ErrCredentialUnavailable) {
+		return s.vaultLockedMessage(), true
+	}
+	return "", false
+}
+
 // handleAssistantThreadStarted is called when a user opens the Aileron agent DM.
 // It sets suggested prompts and a thread title.
 func (s *apiServer) handleAssistantThreadStarted(ctx context.Context, teamID, channelID, threadTS string) {
@@ -156,8 +166,8 @@ func (s *apiServer) handleAssistantMessage(ctx context.Context, teamID, channelI
 	// Check for pipeline errors.
 	if err := <-errCh; err != nil {
 		s.log.Error("agent message: pipeline error", "user_id", userID, "error", err)
-		if errors.Is(err, vault.ErrCredentialUnavailable) {
-			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS, s.vaultLockedMessage())
+		if msg, ok := s.isVaultError(err); ok {
+			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS, msg)
 		}
 		_ = s.slackAgentClient.SetStatus(ctx, botToken, channelID, threadTS, "")
 		return
@@ -264,8 +274,8 @@ func (s *apiServer) generateDraftFromInstructions(ctx context.Context, viewID st
 	draftText, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("draft from instructions: generation failed", "error", err)
-		if errors.Is(err, vault.ErrCredentialUnavailable) {
-			_ = updateDraftModalError(ctx, botToken, viewID, s.vaultLockedMessage(), meta)
+		if msg, ok := s.isVaultError(err); ok {
+			_ = updateDraftModalError(ctx, botToken, viewID, msg, meta)
 		} else {
 			_ = updateDraftModalError(ctx, botToken, viewID, "Draft generation failed. Please try again.", meta)
 		}

--- a/core/app/handlers_slack_agent.go
+++ b/core/app/handlers_slack_agent.go
@@ -57,24 +57,26 @@ func (s *apiServer) resolvePipelineVault(userID string) *draft.Pipeline {
 	return nil
 }
 
-// vaultLockedMessage returns a user-facing message with a link to unlock
-// the vault. Uses Slack mrkdwn format for clickable links.
-func (s *apiServer) vaultLockedMessage() string {
+// vaultUnlockURL returns the URL to the vault unlock page, falling back
+// to the production URL when AILERON_UI_URL is not configured.
+func (s *apiServer) vaultUnlockURL() string {
 	base := s.uiBaseURL
 	if base == "" {
 		base = "https://app.withaileron.ai"
 	}
-	return ":lock: Your Aileron session has expired. <" + base + "/setup-vault|Unlock your vault> to reconnect your accounts (takes 10 seconds, lasts 7 days)."
+	return base + "/setup-vault"
+}
+
+// vaultLockedSlackMessage returns a Slack mrkdwn-formatted message with a
+// clickable link to unlock the vault.
+func (s *apiServer) vaultLockedSlackMessage() string {
+	return ":lock: Your Aileron session has expired. <" + s.vaultUnlockURL() + "|Unlock your vault> to reconnect your accounts (takes 10 seconds, lasts 7 days)."
 }
 
 // isVaultError checks whether err indicates that vault credentials are
-// unavailable (locked vault or stale escrow). When true it returns the
-// user-facing vault unlock message.
-func (s *apiServer) isVaultError(err error) (string, bool) {
-	if errors.Is(err, vault.ErrCredentialUnavailable) {
-		return s.vaultLockedMessage(), true
-	}
-	return "", false
+// unavailable (locked vault or stale escrow).
+func isVaultError(err error) bool {
+	return errors.Is(err, vault.ErrCredentialUnavailable)
 }
 
 // handleAssistantThreadStarted is called when a user opens the Aileron agent DM.
@@ -123,7 +125,7 @@ func (s *apiServer) handleAssistantMessage(ctx context.Context, teamID, channelI
 			s.log.Warn("agent message: draft pipeline not configured")
 		} else {
 			s.log.Warn("agent message: vault locked for user", "user_id", userID)
-			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS, s.vaultLockedMessage())
+			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS, s.vaultLockedSlackMessage())
 		}
 		_ = s.slackAgentClient.SetStatus(ctx, botToken, channelID, threadTS, "")
 		return
@@ -167,8 +169,8 @@ func (s *apiServer) handleAssistantMessage(ctx context.Context, teamID, channelI
 	// Check for pipeline errors.
 	if err := <-errCh; err != nil {
 		s.log.Error("agent message: pipeline error", "user_id", userID, "error", err)
-		if msg, ok := s.isVaultError(err); ok {
-			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS, msg)
+		if isVaultError(err) {
+			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS, s.vaultLockedSlackMessage())
 		}
 		_ = s.slackAgentClient.SetStatus(ctx, botToken, channelID, threadTS, "")
 		return
@@ -259,7 +261,7 @@ func (s *apiServer) generateDraftFromInstructions(ctx context.Context, viewID st
 		if s.draftPipeline == nil {
 			_ = updateDraftModalError(ctx, botToken, viewID, "Draft generation is not configured.", meta)
 		} else {
-			_ = updateDraftModalError(ctx, botToken, viewID, s.vaultLockedMessage(), meta)
+			_ = updateDraftModalError(ctx, botToken, viewID, s.vaultLockedSlackMessage(), meta)
 		}
 		return
 	}
@@ -275,8 +277,8 @@ func (s *apiServer) generateDraftFromInstructions(ctx context.Context, viewID st
 	draftText, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("draft from instructions: generation failed", "error", err)
-		if msg, ok := s.isVaultError(err); ok {
-			_ = updateDraftModalError(ctx, botToken, viewID, msg, meta)
+		if isVaultError(err) {
+			_ = updateDraftModalError(ctx, botToken, viewID, s.vaultLockedSlackMessage(), meta)
 		} else {
 			_ = updateDraftModalError(ctx, botToken, viewID, "Draft generation failed. Please try again.", meta)
 		}

--- a/core/app/handlers_slack_agent.go
+++ b/core/app/handlers_slack_agent.go
@@ -60,10 +60,11 @@ func (s *apiServer) resolvePipelineVault(userID string) *draft.Pipeline {
 // vaultLockedMessage returns a user-facing message with a link to unlock
 // the vault. Uses Slack mrkdwn format for clickable links.
 func (s *apiServer) vaultLockedMessage() string {
-	if s.uiBaseURL != "" {
-		return ":lock: Your Aileron session has expired. <" + s.uiBaseURL + "/setup-vault|Unlock your vault> to reconnect your accounts (takes 10 seconds, lasts 7 days)."
+	base := s.uiBaseURL
+	if base == "" {
+		base = "https://app.withaileron.ai"
 	}
-	return ":lock: Your Aileron session has expired. Please unlock your vault in the Aileron app to reconnect your accounts."
+	return ":lock: Your Aileron session has expired. <" + base + "/setup-vault|Unlock your vault> to reconnect your accounts (takes 10 seconds, lasts 7 days)."
 }
 
 // isVaultError checks whether err indicates that vault credentials are

--- a/core/app/handlers_slack_agent.go
+++ b/core/app/handlers_slack_agent.go
@@ -264,7 +264,11 @@ func (s *apiServer) generateDraftFromInstructions(ctx context.Context, viewID st
 	draftText, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("draft from instructions: generation failed", "error", err)
-		_ = updateDraftModalError(ctx, botToken, viewID, "Draft generation failed. Please try again.", meta)
+		if errors.Is(err, vault.ErrCredentialUnavailable) {
+			_ = updateDraftModalError(ctx, botToken, viewID, s.vaultLockedMessage(), meta)
+		} else {
+			_ = updateDraftModalError(ctx, botToken, viewID, "Draft generation failed. Please try again.", meta)
+		}
 		return
 	}
 

--- a/core/app/handlers_slack_agent_test.go
+++ b/core/app/handlers_slack_agent_test.go
@@ -1226,7 +1226,7 @@ func TestHandleAssistantMessage_VaultLocked_NoUIURL(t *testing.T) {
 	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
 	srv.draftPipeline = newStreamingTestPipeline("ctx", []string{"Hello"})
 	srv.kekSessionCache = auth.NewKEKSessionCache(24 * time.Hour)
-	// No uiBaseURL set.
+	// No uiBaseURL set — should fall back to production URL.
 
 	srv.handleAssistantMessage(ctx, "T001", "D_CHAN", "999.001", "U_ALICE", "hi")
 
@@ -1237,8 +1237,11 @@ func TestHandleAssistantMessage_VaultLocked_NoUIURL(t *testing.T) {
 		t.Fatalf("expected 1 PostMessage call, got %d", len(agent.messageCalls))
 	}
 	msg := agent.messageCalls[0]
-	if !strings.Contains(msg, "unlock your vault") {
-		t.Errorf("expected unlock instruction in message, got: %s", msg)
+	if !strings.Contains(msg, "Unlock your vault") {
+		t.Errorf("expected unlock link in message, got: %s", msg)
+	}
+	if !strings.Contains(msg, "app.withaileron.ai/setup-vault") {
+		t.Errorf("expected production setup-vault URL in message, got: %s", msg)
 	}
 }
 

--- a/core/app/handlers_slack_agent_test.go
+++ b/core/app/handlers_slack_agent_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -1192,6 +1193,35 @@ func TestBuildStreamingPipeline_VaultLocked(t *testing.T) {
 	}
 }
 
+func TestVaultUnlockURL_UsesConfiguredBase(t *testing.T) {
+	srv := &apiServer{uiBaseURL: "https://custom.example.com"}
+	url := srv.vaultUnlockURL()
+	if url != "https://custom.example.com/setup-vault" {
+		t.Errorf("expected custom URL, got %q", url)
+	}
+}
+
+func TestVaultUnlockURL_FallsBackToProduction(t *testing.T) {
+	srv := &apiServer{}
+	url := srv.vaultUnlockURL()
+	if url != "https://app.withaileron.ai/setup-vault" {
+		t.Errorf("expected production fallback URL, got %q", url)
+	}
+}
+
+func TestIsVaultError_MatchesCredentialUnavailable(t *testing.T) {
+	wrapped := fmt.Errorf("escrow retrieve: %w", vault.ErrCredentialUnavailable)
+	if !isVaultError(wrapped) {
+		t.Error("expected isVaultError to return true for wrapped ErrCredentialUnavailable")
+	}
+}
+
+func TestIsVaultError_FalseForOtherErrors(t *testing.T) {
+	if isVaultError(fmt.Errorf("network timeout")) {
+		t.Error("expected isVaultError to return false for unrelated error")
+	}
+}
+
 func TestHandleAssistantMessage_VaultLocked_PostsUnlockMessage(t *testing.T) {
 	srv, agent := newAgentTestServer()
 	ctx := context.Background()
@@ -1294,6 +1324,81 @@ func TestHandleAssistantMessage_CredentialUnavailable_PostsUnlockMessage(t *test
 	}
 	if !strings.Contains(msg, "setup-vault") {
 		t.Errorf("expected setup-vault URL in message, got: %s", msg)
+	}
+}
+
+func TestGenerateDraftFromInstructions_CredentialUnavailable_SendsVaultUnlockMessage(t *testing.T) {
+	// When the pipeline returns ErrCredentialUnavailable during draft
+	// generation from instructions, the modal should show the vault
+	// unlock message instead of "Draft generation failed."
+	var mu sync.Mutex
+	var modalMessage string
+	slackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		modalMessage = string(body)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":   true,
+			"view": map[string]any{"id": "V_MODAL_123"},
+		})
+	}))
+	defer slackServer.Close()
+
+	comms.SetAgentAPIURL(slackServer.URL + "/")
+	defer comms.SetAgentAPIURL("")
+
+	srv, _ := newAgentTestServer()
+	srv.uiBaseURL = "https://app.withaileron.ai"
+	ctx := context.Background()
+
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
+	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
+
+	accounts := mem.NewConnectedAccountStore()
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_a", UserID: "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&stubSourceConnector{})
+
+	srv.draftPipeline = draft.NewPipeline(
+		&mockLLMClient{err: fmt.Errorf("vault: escrow retrieve: %w", vault.ErrCredentialUnavailable)},
+		&mockLLMClient{response: "draft"},
+		sourceReg,
+		accounts,
+		mem.NewUserInstructionStore(),
+		vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	)
+	srv.kekSessionCache = nil
+
+	meta := DraftModalMeta{
+		TargetChannel:   "C123",
+		OriginalMessage: "Can someone review PR #42?",
+		Instructions:    "Be polite",
+		UserID:          "U_ALICE",
+		TeamID:          "T001",
+	}
+
+	srv.generateDraftFromInstructions(ctx, "V_MODAL_123", meta)
+
+	mu.Lock()
+	view := modalMessage
+	mu.Unlock()
+
+	if !strings.Contains(view, "Unlock your vault") {
+		t.Errorf("expected vault unlock message in modal, got: %s", view)
+	}
+	if !strings.Contains(view, "setup-vault") {
+		t.Errorf("expected setup-vault URL in modal, got: %s", view)
+	}
+	if strings.Contains(view, "Draft generation failed") {
+		t.Errorf("should not show generic error for vault issues, got: %s", view)
 	}
 }
 

--- a/core/app/handlers_slack_commands.go
+++ b/core/app/handlers_slack_commands.go
@@ -101,7 +101,7 @@ func (s *apiServer) processSlashCommandDraft(ctx context.Context, teamID, slackU
 		if s.draftPipeline == nil {
 			_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation is not configured.", meta)
 		} else {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.vaultLockedMessage(), meta)
+			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.vaultLockedSlackMessage(), meta)
 		}
 		return
 	}
@@ -111,8 +111,8 @@ func (s *apiServer) processSlashCommandDraft(ctx context.Context, teamID, slackU
 	draftText, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("slash command draft: generation failed", "error", err)
-		if msg, ok := s.isVaultError(err); ok {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, msg, meta)
+		if isVaultError(err) {
+			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.vaultLockedSlackMessage(), meta)
 		} else {
 			_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation failed. Please try again.", meta)
 		}
@@ -139,7 +139,7 @@ func (s *apiServer) processSlashCommandQuestion(ctx context.Context, teamID, sla
 		if s.draftPipeline == nil {
 			s.respondViaURL(responseURL, "Draft generation is not configured.")
 		} else {
-			s.respondViaURL(responseURL, s.vaultLockedMessage())
+			s.respondViaURL(responseURL, s.vaultLockedSlackMessage())
 		}
 		return
 	}
@@ -150,8 +150,8 @@ func (s *apiServer) processSlashCommandQuestion(ctx context.Context, teamID, sla
 	answer, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("slash command question: generation failed", "error", err)
-		if msg, ok := s.isVaultError(err); ok {
-			s.respondViaURL(responseURL, msg)
+		if isVaultError(err) {
+			s.respondViaURL(responseURL, s.vaultLockedSlackMessage())
 		} else {
 			s.respondViaURL(responseURL, "> /aileron "+text+"\n\nSomething went wrong. Please try again.")
 		}

--- a/core/app/handlers_slack_commands.go
+++ b/core/app/handlers_slack_commands.go
@@ -4,12 +4,14 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/ALRubinger/aileron/core/comms"
+	"github.com/ALRubinger/aileron/core/vault"
 )
 
 // draftKeywords are words that indicate the user wants a draft (not a question).
@@ -111,7 +113,11 @@ func (s *apiServer) processSlashCommandDraft(ctx context.Context, teamID, slackU
 	draftText, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("slash command draft: generation failed", "error", err)
-		_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation failed. Please try again.", meta)
+		if errors.Is(err, vault.ErrCredentialUnavailable) {
+			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.vaultLockedMessage(), meta)
+		} else {
+			_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation failed. Please try again.", meta)
+		}
 		return
 	}
 
@@ -146,7 +152,11 @@ func (s *apiServer) processSlashCommandQuestion(ctx context.Context, teamID, sla
 	answer, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("slash command question: generation failed", "error", err)
-		s.respondViaURL(responseURL, "> /aileron "+text+"\n\nSomething went wrong. Please try again.")
+		if errors.Is(err, vault.ErrCredentialUnavailable) {
+			s.respondViaURL(responseURL, s.vaultLockedMessage())
+		} else {
+			s.respondViaURL(responseURL, "> /aileron "+text+"\n\nSomething went wrong. Please try again.")
+		}
 		return
 	}
 

--- a/core/app/handlers_slack_commands.go
+++ b/core/app/handlers_slack_commands.go
@@ -4,14 +4,12 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
-	"errors"
 	"io"
 	"net/http"
 	"net/url"
 	"strings"
 
 	"github.com/ALRubinger/aileron/core/comms"
-	"github.com/ALRubinger/aileron/core/vault"
 )
 
 // draftKeywords are words that indicate the user wants a draft (not a question).
@@ -113,8 +111,8 @@ func (s *apiServer) processSlashCommandDraft(ctx context.Context, teamID, slackU
 	draftText, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("slash command draft: generation failed", "error", err)
-		if errors.Is(err, vault.ErrCredentialUnavailable) {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.vaultLockedMessage(), meta)
+		if msg, ok := s.isVaultError(err); ok {
+			_ = updateDraftModalError(ctx, botToken, viewResp.ID, msg, meta)
 		} else {
 			_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation failed. Please try again.", meta)
 		}
@@ -152,8 +150,8 @@ func (s *apiServer) processSlashCommandQuestion(ctx context.Context, teamID, sla
 	answer, err := pipeline.GenerateDraft(ctx, userID, msg)
 	if err != nil {
 		s.log.Error("slash command question: generation failed", "error", err)
-		if errors.Is(err, vault.ErrCredentialUnavailable) {
-			s.respondViaURL(responseURL, s.vaultLockedMessage())
+		if msg, ok := s.isVaultError(err); ok {
+			s.respondViaURL(responseURL, msg)
 		} else {
 			s.respondViaURL(responseURL, "> /aileron "+text+"\n\nSomething went wrong. Please try again.")
 		}

--- a/core/app/handlers_slack_commands_test.go
+++ b/core/app/handlers_slack_commands_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"context"
 	"crypto/hmac"
 	"crypto/sha256"
 	"encoding/hex"
@@ -12,9 +13,13 @@ import (
 	"net/url"
 	"strconv"
 	"strings"
+	"sync"
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/core/draft"
+	"github.com/ALRubinger/aileron/core/model"
+	"github.com/ALRubinger/aileron/core/source"
 	"github.com/ALRubinger/aileron/core/store/mem"
 	"github.com/ALRubinger/aileron/core/vault"
 )
@@ -152,6 +157,72 @@ func TestSlackCommand_DraftNoTriggerID_FallsBackToEphemeral(t *testing.T) {
 	text, _ := resp["text"].(string)
 	if !strings.Contains(text, "Draft me a status update") {
 		t.Errorf("expected ephemeral to echo user's request, got %q", text)
+	}
+}
+
+func TestSlashCommandQuestion_CredentialUnavailable_SendsVaultUnlockMessage(t *testing.T) {
+	// When GenerateDraft returns ErrCredentialUnavailable (stale escrow or
+	// locked vault), the handler should respond with the vault unlock message
+	// instead of the generic "Something went wrong" error.
+	var mu sync.Mutex
+	var capturedBody string
+	responseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		defer r.Body.Close()
+		b := make([]byte, 4096)
+		n, _ := r.Body.Read(b)
+		mu.Lock()
+		capturedBody = string(b[:n])
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer responseServer.Close()
+
+	srv := newCommandTestServer()
+	srv.uiBaseURL = "https://app.withaileron.ai"
+	ctx := context.Background()
+
+	// Seed user mapping.
+	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
+
+	// Configure pipeline with a research LLM that fails with ErrCredentialUnavailable.
+	accounts := mem.NewConnectedAccountStore()
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_a", UserID: "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&stubSourceConnector{})
+
+	srv.draftPipeline = draft.NewPipeline(
+		&mockLLMClient{err: fmt.Errorf("vault: escrow retrieve: %w", vault.ErrCredentialUnavailable)},
+		&mockLLMClient{response: "draft"},
+		sourceReg,
+		accounts,
+		mem.NewUserInstructionStore(),
+		vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	)
+	// Disable KEK check so resolvePipelineVault falls through to tier 3.
+	srv.kekSessionCache = nil
+
+	srv.processSlashCommandQuestion(ctx, "T001", "U_ALICE", "what's in my email?", responseServer.URL)
+
+	mu.Lock()
+	body := capturedBody
+	mu.Unlock()
+
+	if !strings.Contains(body, "Unlock your vault") {
+		t.Errorf("expected vault unlock message, got: %s", body)
+	}
+	if !strings.Contains(body, "setup-vault") {
+		t.Errorf("expected setup-vault URL in response, got: %s", body)
+	}
+	// Should NOT contain the generic error message.
+	if strings.Contains(body, "Something went wrong") {
+		t.Errorf("should not contain generic error when vault is locked, got: %s", body)
 	}
 }
 

--- a/core/app/handlers_slack_commands_test.go
+++ b/core/app/handlers_slack_commands_test.go
@@ -7,6 +7,7 @@ import (
 	"encoding/hex"
 	"encoding/json"
 	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -17,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/draft"
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/source"
@@ -192,19 +194,7 @@ func TestSlashCommandQuestion_CredentialUnavailable_SendsVaultUnlockMessage(t *t
 		Provider: model.ConnectedAccountProviderSlack,
 		Status:   model.ConnectedAccountStatusActive,
 	})
-	sourceReg := source.NewRegistry()
-	sourceReg.Register(&stubSourceConnector{})
-
-	srv.draftPipeline = draft.NewPipeline(
-		&mockLLMClient{err: fmt.Errorf("vault: escrow retrieve: %w", vault.ErrCredentialUnavailable)},
-		&mockLLMClient{response: "draft"},
-		sourceReg,
-		accounts,
-		mem.NewUserInstructionStore(),
-		vault.NewMemVault(),
-		slog.Default(),
-		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
-	)
+	srv.draftPipeline = newVaultErrorPipeline(accounts)
 	// Disable KEK check so resolvePipelineVault falls through to tier 3.
 	srv.kekSessionCache = nil
 
@@ -223,6 +213,81 @@ func TestSlashCommandQuestion_CredentialUnavailable_SendsVaultUnlockMessage(t *t
 	// Should NOT contain the generic error message.
 	if strings.Contains(body, "Something went wrong") {
 		t.Errorf("should not contain generic error when vault is locked, got: %s", body)
+	}
+}
+
+// newVaultErrorPipeline returns a pipeline whose research LLM fails with
+// ErrCredentialUnavailable, simulating a stale escrow or locked vault.
+func newVaultErrorPipeline(accounts *mem.ConnectedAccountStore) *draft.Pipeline {
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&stubSourceConnector{})
+	return draft.NewPipeline(
+		&mockLLMClient{err: fmt.Errorf("vault: escrow retrieve: %w", vault.ErrCredentialUnavailable)},
+		&mockLLMClient{response: "draft"},
+		sourceReg,
+		accounts,
+		mem.NewUserInstructionStore(),
+		vault.NewMemVault(),
+		slog.Default(),
+		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
+	)
+}
+
+func TestSlashCommandDraft_CredentialUnavailable_SendsVaultUnlockMessage(t *testing.T) {
+	// When GenerateDraft returns ErrCredentialUnavailable during draft
+	// generation, the modal should show the vault unlock message instead
+	// of "Draft generation failed."
+	var mu sync.Mutex
+	var modalMessage string
+	slackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		modalMessage = string(body)
+		mu.Unlock()
+		slackViewOK(w)
+	}))
+	defer slackServer.Close()
+
+	comms.SetAgentAPIURL(slackServer.URL + "/")
+	defer comms.SetAgentAPIURL("")
+
+	srv := newCommandTestServer()
+	srv.uiBaseURL = "https://app.withaileron.ai"
+	ctx := context.Background()
+
+	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
+
+	accounts := mem.NewConnectedAccountStore()
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_a", UserID: "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	srv.draftPipeline = newVaultErrorPipeline(accounts)
+	srv.kekSessionCache = nil
+
+	meta := DraftModalMeta{
+		TargetChannel:   "C123",
+		OriginalMessage: "Help with PR",
+		UserID:          "U_ALICE",
+		TeamID:          "T001",
+	}
+
+	srv.processSlashCommandDraft(ctx, "T001", "U_ALICE", "draft a reply", "trig_123", meta)
+
+	mu.Lock()
+	view := modalMessage
+	mu.Unlock()
+
+	if !strings.Contains(view, "Unlock your vault") {
+		t.Errorf("expected vault unlock message in modal, got: %s", view)
+	}
+	if !strings.Contains(view, "setup-vault") {
+		t.Errorf("expected setup-vault URL in modal, got: %s", view)
+	}
+	if strings.Contains(view, "Draft generation failed") {
+		t.Errorf("should not show generic error for vault issues, got: %s", view)
 	}
 }
 

--- a/core/app/handlers_slack_interactions.go
+++ b/core/app/handlers_slack_interactions.go
@@ -245,7 +245,7 @@ func (s *apiServer) processRefineDraft(ctx context.Context, payload slackInterac
 		if s.draftPipeline == nil {
 			_ = updateDraftModalError(ctx, botToken, payload.View.ID, "Draft generation is not configured.", meta)
 		} else {
-			_ = updateDraftModalError(ctx, botToken, payload.View.ID, s.vaultLockedMessage(), meta)
+			_ = updateDraftModalError(ctx, botToken, payload.View.ID, s.vaultLockedSlackMessage(), meta)
 		}
 		return
 	}

--- a/core/app/handlers_slack_interactions_test.go
+++ b/core/app/handlers_slack_interactions_test.go
@@ -783,7 +783,7 @@ func TestInteraction_RefineAction_VaultLocked(t *testing.T) {
 	if w.Code != http.StatusOK {
 		t.Fatalf("expected 200, got %d", w.Code)
 	}
-	// processRefineDraft should hit the vaultLockedMessage branch (L216).
+	// processRefineDraft should hit the vaultLockedSlackMessage branch.
 	time.Sleep(100 * time.Millisecond)
 }
 


### PR DESCRIPTION
## Summary

- Three Slack handlers (`/aileron` question, `/aileron` draft modal, agent draft-from-instructions modal) showed generic error messages when `GenerateDraft` failed with `ErrCredentialUnavailable` — users saw "Something went wrong" instead of being told to unlock their vault
- Added `errors.Is(err, vault.ErrCredentialUnavailable)` checks to all three handlers, matching the pattern already used in the streaming agent handler
- Users now see the vault unlock message with a clickable link to `/setup-vault`

## Test plan

- [x] Added `TestSlashCommandQuestion_CredentialUnavailable_SendsVaultUnlockMessage` — verifies the vault unlock message (with setup-vault URL) is returned instead of the generic error
- [x] All existing tests pass (`go test ./core/app/...`)
- [ ] Deploy to staging and trigger stale escrow by restarting the enclave, then use `/aileron` slash command — should see vault unlock message

🤖 Generated with [Claude Code](https://claude.com/claude-code)