### PR TITLE
fix(build): remove unrelated workspace modules from Dockerfiles

### DIFF
--- a/cmd/aileron-enclave/Dockerfile
+++ b/cmd/aileron-enclave/Dockerfile
@@ -4,15 +4,6 @@ WORKDIR /build
 # Build outside the workspace so we only need the modules the enclave imports.
 ENV GOWORK=off
 
-# Copy module files first for layer caching.
-COPY cmd/aileron-enclave/go.mod cmd/aileron-enclave/go.sum cmd/aileron-enclave/
-COPY core/go.mod core/go.sum core/
-COPY enclave/go.mod enclave/
-
-WORKDIR /build/cmd/aileron-enclave
-RUN go mod download
-
-WORKDIR /build
 COPY enclave/ enclave/
 COPY core/ core/
 COPY cmd/aileron-enclave/ cmd/aileron-enclave/

--- a/cmd/aileron-enclave/Dockerfile
+++ b/cmd/aileron-enclave/Dockerfile
@@ -1,14 +1,22 @@
 FROM golang:1.25 AS builder
 WORKDIR /build
-COPY go.work go.work.sum ./
-COPY cmd/aileron/go.mod cmd/aileron/go.mod
-COPY cmd/aileron-sh/go.mod cmd/aileron-sh/go.mod
-COPY cmd/aileron-mcp/go.mod cmd/aileron-mcp/go.mod
-COPY sdk/go/go.mod sdk/go/go.mod
-COPY test/integration/go.mod test/integration/go.mod
+
+# Build outside the workspace so we only need the modules the enclave imports.
+ENV GOWORK=off
+
+# Copy module files first for layer caching.
+COPY cmd/aileron-enclave/go.mod cmd/aileron-enclave/go.sum cmd/aileron-enclave/
+COPY core/go.mod core/go.sum core/
+COPY enclave/go.mod enclave/
+
+WORKDIR /build/cmd/aileron-enclave
+RUN go mod download
+
+WORKDIR /build
 COPY enclave/ enclave/
 COPY core/ core/
 COPY cmd/aileron-enclave/ cmd/aileron-enclave/
+
 WORKDIR /build/cmd/aileron-enclave
 RUN CGO_ENABLED=0 go build -o /aileron-enclave .
 

--- a/cmd/aileron-enclave/go.mod
+++ b/cmd/aileron-enclave/go.mod
@@ -1,6 +1,6 @@
 module github.com/ALRubinger/aileron/cmd/aileron-enclave
 
-go 1.25
+go 1.25.0
 
 require (
 	github.com/ALRubinger/aileron/core v0.0.0
@@ -8,8 +8,8 @@ require (
 )
 
 require (
-	golang.org/x/crypto v0.36.0 // indirect
-	golang.org/x/sys v0.31.0 // indirect
+	golang.org/x/crypto v0.49.0 // indirect
+	golang.org/x/sys v0.42.0 // indirect
 )
 
 replace (

--- a/cmd/aileron-enclave/go.sum
+++ b/cmd/aileron-enclave/go.sum
@@ -1,4 +1,4 @@
-golang.org/x/crypto v0.36.0 h1:AnAEvhDddvBdpY+uR+MyHmuZzzNqXSe/GvuDeob5L34=
-golang.org/x/crypto v0.36.0/go.mod h1:Y4J0ReaxCR1IMaabaSMugxJES1EpwhBHhv2bDHklZvc=
-golang.org/x/sys v0.31.0 h1:ioabZlmFYtWhL+TRYpcnNlLwhyxaM9kWTDEmfnprqik=
-golang.org/x/sys v0.31.0/go.mod h1:BJP2sWEmIv4KK5OTEluFJCKSidICx8ciO85XgH3Ak8k=
+golang.org/x/crypto v0.49.0 h1:+Ng2ULVvLHnJ/ZFEq4KdcDd/cfjrrjjNSXNzxg0Y4U4=
+golang.org/x/crypto v0.49.0/go.mod h1:ErX4dUh2UM+CFYiXZRTcMpEcN8b/1gxEuv3nODoYtCA=
+golang.org/x/sys v0.42.0 h1:omrd2nAlyT5ESRdCLYdm3+fMfNFE/+Rf4bDIQImRJeo=
+golang.org/x/sys v0.42.0/go.mod h1:4GL1E5IUh+htKOUEOaiffhrAeqysfVGipDYzABqnCmw=

--- a/core/server/Dockerfile
+++ b/core/server/Dockerfile
@@ -2,16 +2,13 @@ FROM golang:1.25-alpine AS builder
 
 WORKDIR /src
 
+# Build outside the workspace so we only need the modules the server imports.
+ENV GOWORK=off
+
 # Copy module files first for layer caching.
-COPY go.work go.work.sum* ./
-COPY cmd/aileron/go.mod ./cmd/aileron/
-COPY cmd/aileron-enclave/go.mod ./cmd/aileron-enclave/
-COPY cmd/aileron-mcp/go.mod ./cmd/aileron-mcp/
-COPY cmd/aileron-sh/go.mod ./cmd/aileron-sh/
 COPY core/go.mod core/go.sum ./core/
 COPY enclave/go.mod ./enclave/
 COPY sdk/go/go.mod sdk/go/go.sum* ./sdk/go/
-COPY test/integration/go.mod ./test/integration/
 
 RUN cd core && go mod download
 


### PR DESCRIPTION
## Summary

- Both the server and enclave Dockerfiles were copying `go.work` and every workspace member's `go.mod` (including `test/integration`, `cmd/aileron`, `cmd/aileron-sh`, `cmd/aileron-mcp`, `sdk/go`) into the builder stage solely to satisfy workspace resolution during `go mod download`
- Set `GOWORK=off` in both Dockerfiles so each binary only needs the modules it actually imports — no unrelated `go.mod` files, no test code in the build context
- Also added proper layer caching (`go mod download` before source copy) to the enclave Dockerfile, which was missing it

No functional change to the built binaries.

## Test plan

- [ ] Railway deploy of `core/server` succeeds and server starts normally
- [ ] Railway deploy of `cmd/aileron-enclave` succeeds and enclave starts normally
- [ ] Verify `COVERAGE=true` server build still works for integration tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)