### PR TITLE
ci: parallelize pipeline and merge generate into lint

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,8 +11,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  generate:
-    name: Verify Generated Code
+  lint:
+    name: Lint & Verify
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -28,27 +28,11 @@ jobs:
             sdk/go/go.mod
             test/integration/go.mod
 
-      - name: Run code generation
+      - name: Verify generated code
         working-directory: core
-        run: go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config api/oapi-codegen.yaml api/openapi.yaml
-
-      - name: Verify no diff
-        run: git diff --exit-code core/api/gen/
-
-  lint:
-    name: Lint
-    needs: generate
-    runs-on: ubuntu-latest
-    steps:
-      - uses: actions/checkout@v5
-
-      - uses: actions/setup-go@v6
-        with:
-          go-version: "1.25"
-          cache-dependency-path: |
-            core/go.mod
-            sdk/go/go.mod
-            test/integration/go.mod
+        run: |
+          go run github.com/oapi-codegen/oapi-codegen/v2/cmd/oapi-codegen --config api/oapi-codegen.yaml api/openapi.yaml
+          git diff --exit-code api/gen/
 
       - uses: pnpm/action-setup@v5
         with:
@@ -73,7 +57,6 @@ jobs:
 
   test:
     name: Unit Tests
-    needs: generate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -107,7 +90,6 @@ jobs:
 
   test-ui:
     name: UI Tests
-    needs: generate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -183,7 +165,6 @@ jobs:
 
   build:
     name: Build Docker Images
-    needs: generate
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -224,9 +205,9 @@ jobs:
           cache-from: type=gha,scope=docs
           cache-to: type=gha,mode=max,scope=docs
 
-  integration:
-    name: Integration Tests
-    needs: [build, lint, test, test-ui]
+  integration-go:
+    name: Integration Tests (Go)
+    needs: [build]
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v5
@@ -257,18 +238,6 @@ jobs:
           docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml logs
           exit 1
 
-      - name: Wait for healthy UI
-        run: |
-          for i in $(seq 1 20); do
-            if curl -sf http://localhost:3000; then
-              echo "UI healthy"
-              exit 0
-            fi
-            sleep 2
-          done
-          echo "UI did not become healthy"
-          exit 1
-
       - uses: actions/setup-go@v6
         with:
           go-version: "1.25"
@@ -282,29 +251,6 @@ jobs:
 
       - name: Run Go integration tests
         run: gotestsum --junitfile junit-integration.xml -- -tags=integration -race -coverprofile=coverage-store.txt -coverpkg=./core/store/postgres/... ./test/integration/... ./core/store/postgres/...
-        env:
-          AILERON_API_URL: http://localhost:8080
-          AILERON_UI_URL: http://localhost:3000
-
-      - uses: pnpm/action-setup@v4
-        with:
-          version: 10
-
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 24
-          cache: pnpm
-          cache-dependency-path: ui/pnpm-lock.yaml
-
-      - name: Install Playwright dependencies
-        working-directory: ui
-        run: |
-          pnpm install --frozen-lockfile
-          pnpm exec playwright install --with-deps chromium
-
-      - name: Run Playwright integration E2E tests
-        working-directory: ui
-        run: pnpm test:e2e:integration
         env:
           AILERON_API_URL: http://localhost:8080
           AILERON_UI_URL: http://localhost:3000
@@ -331,7 +277,7 @@ jobs:
         uses: codecov/test-results-action@v1
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
-          files: junit-integration.xml,ui/test-results/junit-playwright-integration.xml
+          files: junit-integration.xml
 
       - name: Dump logs on failure
         if: failure()
@@ -340,3 +286,83 @@ jobs:
       - name: Tear down
         if: always()
         run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml down -v
+
+  integration-e2e:
+    name: Integration Tests (E2E)
+    needs: [build]
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Start full stack
+        run: docker compose -f deploy/docker-compose.yml up -d --build --wait
+        timeout-minutes: 5
+        env:
+          AILERON_DATABASE_URL: postgres://aileron:aileron@postgres:5432/aileron?sslmode=disable
+          AILERON_JWT_SIGNING_KEY: ci-test-signing-key-not-for-production
+          AILERON_AUTO_VERIFY_EMAIL: "true"
+          AILERON_SYSTEM_VAULT_KEY: "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+      - name: Wait for healthy server
+        run: |
+          for i in $(seq 1 60); do
+            if curl -sf http://localhost:8080/v1/health; then
+              echo ""
+              echo "Server healthy"
+              exit 0
+            fi
+            sleep 3
+          done
+          echo "Server did not become healthy"
+          docker compose -f deploy/docker-compose.yml logs
+          exit 1
+
+      - name: Wait for healthy UI
+        run: |
+          for i in $(seq 1 20); do
+            if curl -sf http://localhost:3000; then
+              echo "UI healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "UI did not become healthy"
+          exit 1
+
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 10
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 24
+          cache: pnpm
+          cache-dependency-path: ui/pnpm-lock.yaml
+
+      - name: Install Playwright dependencies
+        working-directory: ui
+        run: |
+          pnpm install --frozen-lockfile
+          pnpm exec playwright install --with-deps chromium
+
+      - name: Run Playwright integration E2E tests
+        working-directory: ui
+        run: pnpm test:e2e:integration
+        env:
+          AILERON_API_URL: http://localhost:8080
+          AILERON_UI_URL: http://localhost:3000
+
+      - name: Upload test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: ui/test-results/junit-playwright-integration.xml
+
+      - name: Dump logs on failure
+        if: failure()
+        run: docker compose -f deploy/docker-compose.yml logs
+
+      - name: Tear down
+        if: always()
+        run: docker compose -f deploy/docker-compose.yml down -v


### PR DESCRIPTION
## Summary

- Fold the standalone `generate` (Verify Generated Code) job into `lint`, renamed to "Lint & Verify", eliminating a sequential dependency
- Remove `needs: generate` from unit tests, UI tests, and build so they start immediately on checkout
- Split the single `integration` job into parallel `integration-go` (Go API tests) and `integration-e2e` (Playwright tests), each depending only on `build`

**New pipeline shape:**
```
         ┌─ lint (Lint & Verify)
         ├─ test (Unit Tests)
checkout ┤
         ├─ test-ui (UI Tests)
         └─ build ──┬── integration-go
                    └── integration-e2e
```

## Test plan

- [ ] CI pipeline passes on this branch
- [ ] Verify lint job runs codegen check and golangci-lint
- [ ] Verify integration-go and integration-e2e run in parallel
- [ ] Compare total pipeline duration against previous runs on main

🤖 Generated with [Claude Code](https://claude.com/claude-code)