### PR TITLE
fix(build): add .dockerignore to shrink Docker build context

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,25 @@
+# Git and CI
+.git
+.github
+.gitignore
+
+# Claude Code
+.claude
+
+# Build artifacts
+build
+
+# Node / UI (separate Railway service with its own root)
+ui
+node_modules
+
+# Test fixtures
+test
+
+# Deploy configs (not needed inside images)
+deploy
+saas
+
+# Documentation (docs service only needs docs/ and core/api/openapi.yaml)
+*.md
+!AILERON.md


### PR DESCRIPTION
## Summary
- Railway server builds were hanging 13+ minutes uploading ~350MB of build context (mostly `.git/`) before any `COPY` instruction ran
- Adds a `.dockerignore` at the repo root excluding `.git/`, `.claude/`, `build/`, `ui/`, `test/`, `deploy/`, `saas/`, and non-essential markdown files
- Reduces build context from ~350MB to ~17KB for server, ~87KB for enclave, ~447KB for docs
- All three Dockerfiles verified to build successfully with the new ignore rules

## Test plan
- [x] `docker build -f core/server/Dockerfile .` — context 17KB, AILERON.md copies correctly
- [x] `docker build -f cmd/aileron-enclave/Dockerfile .` — context 87KB, all sources copied
- [x] `docker build -f docs/Dockerfile .` — context 447KB, openapi.yaml copied
- [ ] Deploy to Railway and confirm server build completes without hanging

🤖 Generated with [Claude Code](https://claude.com/claude-code)