### PR TITLE
docs: add Railway watched paths and fix docs root directory

### DIFF
--- a/docs/src/content/docs/deployment/railway.md
+++ b/docs/src/content/docs/deployment/railway.md
@@ -13,10 +13,18 @@ In the Railway dashboard, create three services and one database:
 |---------|----------------|----------------|
 | **server** | `core/server/Dockerfile` | `/` (repo root) |
 | **ui** | `ui/Dockerfile` | `ui/` |
-| **docs** | `docs/Dockerfile` | `docs/` |
+| **docs** | `docs/Dockerfile` | `/` (repo root) |
 | **Postgres** | -- (Railway-managed plugin) | -- |
 
 Link the Postgres plugin to the server service.
+
+Configure **watched paths** under each service's **Settings > Build > Watched Paths** so services only rebuild when relevant files change:
+
+| Service | Watched Paths |
+|---------|---------------|
+| **server** | `core/`, `enclave/`, `sdk/go/`, `AILERON.md`, `.dockerignore` |
+| **ui** | `ui/` |
+| **docs** | `docs/`, `core/api/openapi.yaml`, `.dockerignore` |
 
 ## 2. Set environment variables
 


### PR DESCRIPTION
## Summary
- Add watched paths table to Railway deployment docs so each service only rebuilds when relevant files change
- Fix docs service root directory from `docs/` to `/` (repo root) — its Dockerfile references `core/api/openapi.yaml` outside `docs/`

## Test plan
- [x] Verify watched paths match what each Dockerfile actually needs
- [x] Confirm docs service root directory matches Railway dashboard config

🤖 Generated with [Claude Code](https://claude.com/claude-code)