### PR TITLE
fix(vault): don't show vault-locked message when TEE session is active

### DIFF
--- a/core/app/handlers_slack_agent.go
+++ b/core/app/handlers_slack_agent.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"fmt"
 	"strings"
+	"time"
 
 	"github.com/ALRubinger/aileron/core/comms"
 	"github.com/ALRubinger/aileron/core/draft"
@@ -15,7 +16,8 @@ import (
 // available credential source for the given user:
 //  1. KEK session (user recently unlocked vault) → UserScopedVault
 //  2. Escrow (credentials escrowed in TEE) → EscrowVault
-//  3. Neither available → returns nil
+//  3. Active TEE session (vault unlocked, no escrow entries) → base pipeline
+//  4. Neither available → returns nil
 func (s *apiServer) resolvePipelineVault(userID string) *draft.Pipeline {
 	if s.draftPipeline == nil {
 		return nil
@@ -48,7 +50,20 @@ func (s *apiServer) resolvePipelineVault(userID string) *draft.Pipeline {
 		}
 	}
 
-	// Tier 3: Auth not enabled (local dev) — use base pipeline without vault.
+	// Tier 3: Active TEE session but no escrow entries (e.g. enclave
+	// restarted, or user has no connected accounts with stored creds).
+	// The vault IS unlocked — return the base pipeline so the user isn't
+	// told to unlock when they already have.
+	if s.teeState != nil {
+		s.teeState.mu.Lock()
+		teeExpiry, hasTeeSession := s.teeState.userSessions[userID]
+		s.teeState.mu.Unlock()
+		if hasTeeSession && time.Now().Before(teeExpiry) {
+			return s.draftPipeline
+		}
+	}
+
+	// Tier 4: Auth not enabled (local dev) — use base pipeline without vault.
 	if s.kekSessionCache == nil {
 		return s.draftPipeline
 	}

--- a/core/app/handlers_slack_agent_test.go
+++ b/core/app/handlers_slack_agent_test.go
@@ -1193,6 +1193,36 @@ func TestBuildStreamingPipeline_VaultLocked(t *testing.T) {
 	}
 }
 
+func TestResolvePipelineVault_ActiveTEESession_NoEscrow(t *testing.T) {
+	srv, _ := newAgentTestServer()
+	srv.draftPipeline = newTestPipeline("research", "draft")
+	srv.kekSessionCache = auth.NewKEKSessionCache(24 * time.Hour)
+	srv.teeState = newTeeState()
+
+	// Simulate an active TEE session with no escrow entries.
+	srv.teeState.userSessions["usr_a"] = time.Now().Add(1 * time.Hour)
+
+	result := srv.resolvePipelineVault("usr_a")
+	if result == nil {
+		t.Error("expected non-nil pipeline when TEE session is active")
+	}
+}
+
+func TestResolvePipelineVault_ExpiredTEESession_ReturnsNil(t *testing.T) {
+	srv, _ := newAgentTestServer()
+	srv.draftPipeline = newTestPipeline("research", "draft")
+	srv.kekSessionCache = auth.NewKEKSessionCache(24 * time.Hour)
+	srv.teeState = newTeeState()
+
+	// Simulate an expired TEE session.
+	srv.teeState.userSessions["usr_a"] = time.Now().Add(-1 * time.Hour)
+
+	result := srv.resolvePipelineVault("usr_a")
+	if result != nil {
+		t.Error("expected nil when TEE session is expired")
+	}
+}
+
 func TestVaultUnlockURL_UsesConfiguredBase(t *testing.T) {
 	srv := &apiServer{uiBaseURL: "https://custom.example.com"}
 	url := srv.vaultUnlockURL()


### PR DESCRIPTION
## Summary
- `resolvePipelineVault` returned nil when the user had an active TEE session but no escrow entries (enclave restarted, no connected accounts with stored creds, or escrow expired), causing the Slack agent to say "Your Aileron session has expired" even though the vault was unlocked
- Add tier 3 check: if the user has an active TEE session in `teeState.userSessions`, return the base pipeline instead of nil — matching the logic `GetVaultStatus` already uses
- Add tests for active and expired TEE session fallback

## Test plan
- [x] Go tests pass (`go test ./core/app/...`)
- [x] New tests cover active TEE session (returns pipeline) and expired TEE session (returns nil)
- [ ] Unlock vault via UI, confirm Slack agent no longer shows false "session expired" message

🤖 Generated with [Claude Code](https://claude.com/claude-code)