### PR TITLE
fix(auth): redirect OAuth callback to /auth/callback for proper post-login routing

### DIFF
--- a/core/auth/handler.go
+++ b/core/auth/handler.go
@@ -47,7 +47,7 @@ type HandlerConfig struct {
 	VerificationCodes store.VerificationCodeStore
 	Mailer            Mailer
 	NewID             func() string
-	UIRedirect        string        // e.g. "http://localhost:5173"
+	UIRedirect        string        // UI base URL, e.g. "http://localhost:5173" or "/"
 	AutoVerifyEmail bool          // skip email verification (dev/CI only)
 	RefreshTTL      time.Duration // e.g. 7 * 24 * time.Hour
 	VerificationTTL time.Duration // e.g. 15 * time.Minute
@@ -362,7 +362,7 @@ issueTokens:
 	})
 
 	h.log.Info("user authenticated", "user_id", user.ID, "provider", providerName)
-	http.Redirect(w, r, h.uiRedirect, http.StatusTemporaryRedirect)
+	http.Redirect(w, r, strings.TrimRight(h.uiRedirect, "/")+"/auth/callback", http.StatusTemporaryRedirect)
 }
 
 // handleRefresh exchanges a refresh token for a new access token.


### PR DESCRIPTION
## Summary

- After OAuth login (Google/GitHub), the backend was redirecting users to `/` (Dashboard) instead of the frontend's `/auth/callback` page
- The frontend callback page already had logic to read `sessionStorage` for the original destination (e.g. `/vault`) and redirect there, but it was never reached
- Changed the backend to redirect to `{uiRedirect}/auth/callback` so the existing frontend routing logic is used

## Test plan

- [ ] Visit `https://app.withaileron.ai/vault` while logged out
- [ ] Complete Google OAuth login
- [ ] Verify redirect lands on `/vault`, not Dashboard
- [ ] Verify direct login (no redirectTo) still lands on Dashboard
- [ ] Verify email/password login still works with redirectTo

🤖 Generated with [Claude Code](https://claude.com/claude-code)