### PR TITLE
fix(source): persist refreshed OAuth tokens and surface auth errors

### DIFF
--- a/core/draft/pipeline.go
+++ b/core/draft/pipeline.go
@@ -613,8 +613,24 @@ func (p *Pipeline) buildToolExecutor(ctx context.Context, userID string, account
 			"metadata_encrypted", isEnc,
 		)
 
+		// Inject a token saver so connectors can persist refreshed OAuth
+		// tokens (including rotated refresh tokens) back to the vault.
+		execCtx = source.WithTokenSaver(execCtx, func(saveCtx context.Context, newToken []byte) error {
+			p.log.Info("persisting refreshed OAuth token",
+				"provider", provider,
+				"vault_path", acct.VaultPath(),
+			)
+			return p.vault.Put(saveCtx, acct.VaultPath(), newToken, secret.Metadata)
+		})
+
 		result, execErr := p.sourceRegistry.ExecuteTool(execCtx, tool, params, secret.Value)
 		if execErr != nil {
+			// Auth failures are unrecoverable — every subsequent call will
+			// fail too. Wrap as fatal so the LLM loop aborts and the handler
+			// can tell the user to reconnect.
+			if errors.Is(execErr, source.ErrAuthFailed) {
+				return nil, &llm.ToolFatalError{Err: execErr}
+			}
 			p.log.Error("tool execution failed", "tool", tool, "provider", provider, "error", execErr)
 		} else {
 			resultSize := 0

--- a/core/draft/pipeline_test.go
+++ b/core/draft/pipeline_test.go
@@ -1228,3 +1228,72 @@ func TestPipeline_GenerateDraftStream_CredentialUnavailable_Propagates(t *testin
 		t.Errorf("expected error wrapping ErrCredentialUnavailable, got: %v", err)
 	}
 }
+
+// authFailSourceConnector returns source.ErrAuthFailed from Execute.
+type authFailSourceConnector struct{}
+
+func (m *authFailSourceConnector) Provider() string { return "slack" }
+func (m *authFailSourceConnector) Tools() []source.ToolDefinition {
+	return []source.ToolDefinition{
+		{Name: "slack_channel_history", Description: "Get channel messages",
+			Parameters: []source.ToolParam{{Name: "channel", Type: "string", Required: true}}},
+	}
+}
+func (m *authFailSourceConnector) Execute(_ context.Context, _ string, _ map[string]any, _ []byte) (map[string]any, error) {
+	return nil, fmt.Errorf("googleapi: Error 401: Invalid Credentials: %w", source.ErrAuthFailed)
+}
+
+func TestPipeline_GenerateDraft_ToolExecutor_AuthFailed(t *testing.T) {
+	// When a source connector returns source.ErrAuthFailed (e.g. Google 401),
+	// the tool executor should return a ToolFatalError so the LLM loop aborts.
+	mock := &mockLLMClient{
+		researchResp:   &llm.GenerateResponse{Text: "context gathered"},
+		ghostwriteResp: &llm.GenerateResponse{Text: "draft"},
+	}
+
+	accounts := mem.NewConnectedAccountStore()
+	ctx := context.Background()
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_1", Provider: "slack",
+		Status: model.ConnectedAccountStatusActive,
+	})
+
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&authFailSourceConnector{})
+
+	v := vault.NewMemVault()
+	v.Put(ctx, "connected-accounts/usr_1/slack", []byte(`{"access_token":"test"}`), vault.Metadata{})
+
+	p := draft.NewPipeline(mock, mock, sourceReg, accounts, mem.NewUserInstructionStore(),
+		v, slog.Default(), draft.Prompts{Research: "test", Ghostwrite: "test"})
+
+	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
+		ID: "msg_1", Service: "slack", Channel: "#test", Author: "Alice", Body: "hi",
+	})
+	if err != nil {
+		t.Fatalf("unexpected top-level error: %v", err)
+	}
+
+	// Extract the tool executor from the research round.
+	if len(mock.requests) < 1 {
+		t.Fatal("expected at least 1 LLM call")
+	}
+	researchReq := mock.requests[0]
+	if researchReq.ToolExecutor == nil {
+		t.Fatal("expected ToolExecutor in research round")
+	}
+
+	// Execute a tool — should return a ToolFatalError wrapping ErrAuthFailed.
+	_, execErr := researchReq.ToolExecutor(ctx, "slack_channel_history", map[string]any{"channel": "C123"})
+	if execErr == nil {
+		t.Fatal("expected error from auth failure")
+	}
+
+	var fatal *llm.ToolFatalError
+	if !errors.As(execErr, &fatal) {
+		t.Fatalf("expected *llm.ToolFatalError, got %T: %v", execErr, execErr)
+	}
+	if !errors.Is(fatal.Err, source.ErrAuthFailed) {
+		t.Errorf("expected ToolFatalError to wrap ErrAuthFailed, got: %v", fatal.Err)
+	}
+}

--- a/core/source/calendar/connector.go
+++ b/core/source/calendar/connector.go
@@ -5,12 +5,15 @@ package calendar
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
+	"strings"
 
 	"github.com/ALRubinger/aileron/core/source"
 	"golang.org/x/oauth2"
 	"golang.org/x/oauth2/google"
 	cal "google.golang.org/api/calendar/v3"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -78,17 +81,25 @@ func (c *Connector) Tools() []source.ToolDefinition {
 func (c *Connector) Execute(ctx context.Context, tool string, params map[string]any, token []byte) (map[string]any, error) {
 	svc, err := c.newService(ctx, token)
 	if err != nil {
+		if isAuthError(err) {
+			return nil, fmt.Errorf("%s: %w", err.Error(), source.ErrAuthFailed)
+		}
 		return nil, err
 	}
 
+	var result map[string]any
 	switch tool {
 	case "calendar_events":
-		return c.events(ctx, svc, params)
+		result, err = c.events(ctx, svc, params)
 	case "calendar_free_busy":
-		return c.freeBusy(ctx, svc, params)
+		result, err = c.freeBusy(ctx, svc, params)
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", tool)
 	}
+	if err != nil && isAuthError(err) {
+		return nil, fmt.Errorf("%s: %w", err.Error(), source.ErrAuthFailed)
+	}
+	return result, err
 }
 
 func (c *Connector) newService(ctx context.Context, token []byte) (*cal.Service, error) {
@@ -209,6 +220,8 @@ func (c *Connector) freeBusy(ctx context.Context, svc *cal.Service, params map[s
 
 // tokenSource parses the stored OAuth token and returns a token source that
 // automatically refreshes expired access tokens using the OAuth client credentials.
+// If a TokenSaver is present in the context, the returned token source will
+// persist refreshed tokens back to the vault so rotated refresh tokens survive.
 func (c *Connector) tokenSource(ctx context.Context, tokenJSON []byte) (oauth2.TokenSource, error) {
 	var tok oauth2.Token
 	if err := json.Unmarshal(tokenJSON, &tok); err != nil {
@@ -217,7 +230,23 @@ func (c *Connector) tokenSource(ctx context.Context, tokenJSON []byte) (oauth2.T
 	if tok.RefreshToken == "" && tok.AccessToken == "" {
 		return nil, fmt.Errorf("token has neither access_token nor refresh_token")
 	}
-	return c.oauthConfig.TokenSource(ctx, &tok), nil
+	base := c.oauthConfig.TokenSource(ctx, &tok)
+	if saver := source.GetTokenSaver(ctx); saver != nil {
+		return source.NewPersistingTokenSource(base, &tok, saver, ctx), nil
+	}
+	return base, nil
+}
+
+// isAuthError reports whether err indicates invalid or expired credentials.
+func isAuthError(err error) bool {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && (apiErr.Code == 401 || apiErr.Code == 403) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "oauth2: cannot fetch token") ||
+		strings.Contains(msg, "token has been revoked") ||
+		strings.Contains(msg, "invalid_grant")
 }
 
 func toInt64(v any, def int64) int64 {

--- a/core/source/calendar/connector_test.go
+++ b/core/source/calendar/connector_test.go
@@ -3,12 +3,14 @@ package calendar_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"net/http"
 	"net/http/httptest"
 	"sync/atomic"
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/core/source"
 	calendarsource "github.com/ALRubinger/aileron/core/source/calendar"
 	"google.golang.org/api/option"
 )
@@ -299,5 +301,63 @@ func TestConnector_Events_RefreshesExpiredToken(t *testing.T) {
 	}
 	if events[0]["summary"] != "Team Standup" {
 		t.Errorf("expected Team Standup, got %v", events[0]["summary"])
+	}
+}
+
+func TestConnector_Events_AuthError_WrapsErrAuthFailed(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    401,
+				"message": "Invalid Credentials",
+			},
+		})
+	}))
+	defer apiServer.Close()
+
+	c := calendarsource.New("test-client-id", "test-client-secret").
+		WithClientOption(option.WithEndpoint(apiServer.URL))
+
+	_, err := c.Execute(context.Background(), "calendar_events", map[string]any{
+		"start": "2026-04-15T00:00:00Z",
+		"end":   "2026-04-16T00:00:00Z",
+	}, testToken())
+
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !errors.Is(err, source.ErrAuthFailed) {
+		t.Errorf("expected error to wrap source.ErrAuthFailed, got: %v", err)
+	}
+}
+
+func TestConnector_FreeBusy_AuthError_WrapsErrAuthFailed(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    401,
+				"message": "Invalid Credentials",
+			},
+		})
+	}))
+	defer apiServer.Close()
+
+	c := calendarsource.New("test-client-id", "test-client-secret").
+		WithClientOption(option.WithEndpoint(apiServer.URL))
+
+	_, err := c.Execute(context.Background(), "calendar_free_busy", map[string]any{
+		"start": "2026-04-15T00:00:00Z",
+		"end":   "2026-04-16T00:00:00Z",
+	}, testToken())
+
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !errors.Is(err, source.ErrAuthFailed) {
+		t.Errorf("expected error to wrap source.ErrAuthFailed, got: %v", err)
 	}
 }

--- a/core/source/gmail/connector.go
+++ b/core/source/gmail/connector.go
@@ -9,8 +9,10 @@ package gmail
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
+	"strings"
 
 	"github.com/ALRubinger/aileron/core/source"
 	"golang.org/x/oauth2"
@@ -18,6 +20,7 @@ import (
 	"golang.org/x/sync/errgroup"
 	driveapi "google.golang.org/api/drive/v3"
 	gmailapi "google.golang.org/api/gmail/v1"
+	"google.golang.org/api/googleapi"
 	"google.golang.org/api/option"
 )
 
@@ -101,21 +104,29 @@ func (c *Connector) Tools() []source.ToolDefinition {
 func (c *Connector) Execute(ctx context.Context, tool string, params map[string]any, token []byte) (map[string]any, error) {
 	svc, err := c.newService(ctx, token)
 	if err != nil {
+		if isAuthError(err) {
+			return nil, fmt.Errorf("%s: %w", err.Error(), source.ErrAuthFailed)
+		}
 		return nil, err
 	}
 
+	var result map[string]any
 	switch tool {
 	case "gmail_search":
-		return c.search(ctx, svc, params)
+		result, err = c.search(ctx, svc, params)
 	case "gmail_get_thread":
-		return c.getThread(ctx, svc, params)
+		result, err = c.getThread(ctx, svc, params)
 	case "drive_search":
-		return c.driveSearch(ctx, token, params)
+		result, err = c.driveSearch(ctx, token, params)
 	case "drive_get_doc":
-		return c.driveGetDoc(ctx, token, params)
+		result, err = c.driveGetDoc(ctx, token, params)
 	default:
 		return nil, fmt.Errorf("unknown tool: %s", tool)
 	}
+	if err != nil && isAuthError(err) {
+		return nil, fmt.Errorf("%s: %w", err.Error(), source.ErrAuthFailed)
+	}
+	return result, err
 }
 
 func (c *Connector) newService(ctx context.Context, token []byte) (*gmailapi.Service, error) {
@@ -333,6 +344,8 @@ func (c *Connector) driveGetDoc(ctx context.Context, token []byte, params map[st
 
 // tokenSource parses the stored OAuth token and returns a token source that
 // automatically refreshes expired access tokens using the OAuth client credentials.
+// If a TokenSaver is present in the context, the returned token source will
+// persist refreshed tokens back to the vault so rotated refresh tokens survive.
 func (c *Connector) tokenSource(ctx context.Context, tokenJSON []byte) (oauth2.TokenSource, error) {
 	var tok oauth2.Token
 	if err := json.Unmarshal(tokenJSON, &tok); err != nil {
@@ -341,9 +354,23 @@ func (c *Connector) tokenSource(ctx context.Context, tokenJSON []byte) (oauth2.T
 	if tok.RefreshToken == "" && tok.AccessToken == "" {
 		return nil, fmt.Errorf("token has neither access_token nor refresh_token")
 	}
-	// ReuseTokenSourceWithExpiry returns the existing access token if still valid,
-	// and transparently refreshes via the oauth2.Config when it expires.
-	return c.oauthConfig.TokenSource(ctx, &tok), nil
+	base := c.oauthConfig.TokenSource(ctx, &tok)
+	if saver := source.GetTokenSaver(ctx); saver != nil {
+		return source.NewPersistingTokenSource(base, &tok, saver, ctx), nil
+	}
+	return base, nil
+}
+
+// isAuthError reports whether err indicates invalid or expired credentials.
+func isAuthError(err error) bool {
+	var apiErr *googleapi.Error
+	if errors.As(err, &apiErr) && (apiErr.Code == 401 || apiErr.Code == 403) {
+		return true
+	}
+	msg := err.Error()
+	return strings.Contains(msg, "oauth2: cannot fetch token") ||
+		strings.Contains(msg, "token has been revoked") ||
+		strings.Contains(msg, "invalid_grant")
 }
 
 func toInt64(v any, def int64) int64 {

--- a/core/source/gmail/connector_test.go
+++ b/core/source/gmail/connector_test.go
@@ -3,6 +3,7 @@ package gmail_test
 import (
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"net/http"
 	"net/http/httptest"
@@ -12,7 +13,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/core/source"
 	gmailsource "github.com/ALRubinger/aileron/core/source/gmail"
+	"golang.org/x/oauth2"
 	"google.golang.org/api/option"
 )
 
@@ -671,5 +674,198 @@ func TestConnector_Search_RefreshesExpiredToken(t *testing.T) {
 	messages := result["messages"].([]map[string]any)
 	if len(messages) != 1 {
 		t.Errorf("expected 1 message, got %d", len(messages))
+	}
+}
+
+func TestConnector_Search_PersistsRefreshedToken(t *testing.T) {
+	// When a token refresh occurs and a TokenSaver is in the context,
+	// the refreshed token (including any rotated refresh token) must be
+	// persisted back via the saver.
+
+	// Mock OAuth token endpoint — returns a fresh token with a rotated refresh token.
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token":  "fresh-access-token",
+			"refresh_token": "rotated-refresh-token",
+			"token_type":    "bearer",
+			"expires_in":    3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	// Mock Gmail API.
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/messages/") {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id": "msg_1", "snippet": "Hello",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "Subject", "value": "Test"},
+						{"name": "From", "value": "test@example.com"},
+						{"name": "Date", "value": "Mon, 20 Apr 2026"},
+					},
+				},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"messages":           []map[string]any{{"id": "msg_1", "threadId": "t_1"}},
+			"resultSizeEstimate": 1,
+		})
+	}))
+	defer apiServer.Close()
+
+	// Token with an expired access token.
+	expiredToken, _ := json.Marshal(map[string]any{
+		"access_token":  "expired-token",
+		"refresh_token": "original-refresh-token",
+		"token_type":    "bearer",
+		"expiry":        time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+	})
+
+	var savedToken []byte
+	ctx := source.WithTokenSaver(context.Background(), func(_ context.Context, newToken []byte) error {
+		savedToken = newToken
+		return nil
+	})
+
+	c := gmailsource.New("test-client-id", "test-client-secret").
+		WithTokenEndpoint(tokenServer.URL).
+		WithClientOption(option.WithEndpoint(apiServer.URL))
+
+	_, err := c.Execute(ctx, "gmail_search", map[string]any{"query": "test"}, expiredToken)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+	if savedToken == nil {
+		t.Fatal("expected token saver to be called with refreshed token")
+	}
+
+	var parsed oauth2.Token
+	if err := json.Unmarshal(savedToken, &parsed); err != nil {
+		t.Fatalf("failed to parse saved token: %v", err)
+	}
+	if parsed.RefreshToken != "rotated-refresh-token" {
+		t.Errorf("expected rotated refresh token, got %s", parsed.RefreshToken)
+	}
+	if parsed.AccessToken != "fresh-access-token" {
+		t.Errorf("expected fresh access token, got %s", parsed.AccessToken)
+	}
+}
+
+func TestConnector_Search_NoSaveWithoutSaver(t *testing.T) {
+	// Without a TokenSaver in context, refresh still works but nothing is saved.
+	// This is the existing behavior — no regression.
+
+	tokenServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"access_token": "fresh-access-token",
+			"token_type":   "bearer",
+			"expires_in":   3600,
+		})
+	}))
+	defer tokenServer.Close()
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		if strings.Contains(r.URL.Path, "/messages/") {
+			json.NewEncoder(w).Encode(map[string]any{
+				"id": "msg_1", "snippet": "Hello",
+				"payload": map[string]any{
+					"headers": []map[string]any{
+						{"name": "Subject", "value": "Test"},
+						{"name": "From", "value": "test@example.com"},
+						{"name": "Date", "value": "Mon, 20 Apr 2026"},
+					},
+				},
+			})
+			return
+		}
+		json.NewEncoder(w).Encode(map[string]any{
+			"messages":           []map[string]any{{"id": "msg_1", "threadId": "t_1"}},
+			"resultSizeEstimate": 1,
+		})
+	}))
+	defer apiServer.Close()
+
+	expiredToken, _ := json.Marshal(map[string]any{
+		"access_token":  "expired-token",
+		"refresh_token": "valid-refresh-token",
+		"token_type":    "bearer",
+		"expiry":        time.Now().Add(-1 * time.Hour).Format(time.RFC3339),
+	})
+
+	c := gmailsource.New("test-client-id", "test-client-secret").
+		WithTokenEndpoint(tokenServer.URL).
+		WithClientOption(option.WithEndpoint(apiServer.URL))
+
+	// Plain context without a saver — should succeed without panicking.
+	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{"query": "test"}, expiredToken)
+	if err != nil {
+		t.Fatalf("expected success, got: %v", err)
+	}
+}
+
+func TestConnector_Search_AuthError_WrapsErrAuthFailed(t *testing.T) {
+	// When the Gmail API returns 401, the error must wrap source.ErrAuthFailed.
+
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    401,
+				"message": "Invalid Credentials",
+				"errors": []map[string]any{
+					{"reason": "authError", "message": "Invalid Credentials"},
+				},
+			},
+		})
+	}))
+	defer apiServer.Close()
+
+	c := gmailsource.New("test-client-id", "test-client-secret").
+		WithClientOption(option.WithEndpoint(apiServer.URL))
+
+	_, err := c.Execute(context.Background(), "gmail_search", map[string]any{
+		"query": "test",
+	}, testToken())
+
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !errors.Is(err, source.ErrAuthFailed) {
+		t.Errorf("expected error to wrap source.ErrAuthFailed, got: %v", err)
+	}
+}
+
+func TestConnector_GetThread_AuthError_WrapsErrAuthFailed(t *testing.T) {
+	apiServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnauthorized)
+		json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    401,
+				"message": "Invalid Credentials",
+			},
+		})
+	}))
+	defer apiServer.Close()
+
+	c := gmailsource.New("test-client-id", "test-client-secret").
+		WithClientOption(option.WithEndpoint(apiServer.URL))
+
+	_, err := c.Execute(context.Background(), "gmail_get_thread", map[string]any{
+		"thread_id": "t_123",
+	}, testToken())
+
+	if err == nil {
+		t.Fatal("expected error for 401 response")
+	}
+	if !errors.Is(err, source.ErrAuthFailed) {
+		t.Errorf("expected error to wrap source.ErrAuthFailed, got: %v", err)
 	}
 }

--- a/core/source/spi.go
+++ b/core/source/spi.go
@@ -11,7 +11,10 @@
 // to any LLM's function calling format by a thin adapter layer.
 package source
 
-import "context"
+import (
+	"context"
+	"errors"
+)
 
 // SourceConnector retrieves context from an external system.
 type SourceConnector interface {
@@ -36,6 +39,31 @@ type ToolDefinition struct {
 
 	// Parameters describes the expected input parameters.
 	Parameters []ToolParam `json:"parameters"`
+}
+
+// ErrAuthFailed indicates that a connector's credentials are invalid, expired,
+// or revoked. The pipeline should treat this as fatal and abort the LLM loop
+// so the handler can tell the user to reconnect.
+var ErrAuthFailed = errors.New("source: authentication failed")
+
+// TokenSaver persists a refreshed OAuth token back to the vault.
+type TokenSaver func(ctx context.Context, newToken []byte) error
+
+type tokenSaverKey struct{}
+
+// WithTokenSaver returns a context carrying a TokenSaver callback. Connectors
+// that support automatic token refresh call the saver when the underlying
+// oauth2.TokenSource returns a new token.
+func WithTokenSaver(ctx context.Context, saver TokenSaver) context.Context {
+	return context.WithValue(ctx, tokenSaverKey{}, saver)
+}
+
+// GetTokenSaver retrieves the TokenSaver from the context, or nil if none.
+func GetTokenSaver(ctx context.Context) TokenSaver {
+	if s, ok := ctx.Value(tokenSaverKey{}).(TokenSaver); ok {
+		return s
+	}
+	return nil
 }
 
 // ToolParam describes a single parameter for a tool.

--- a/core/source/token_source.go
+++ b/core/source/token_source.go
@@ -1,0 +1,54 @@
+package source
+
+import (
+	"context"
+	"encoding/json"
+	"log/slog"
+
+	"golang.org/x/oauth2"
+)
+
+// PersistingTokenSource wraps an oauth2.TokenSource and calls a TokenSaver
+// when a refresh produces a new token. This ensures rotated refresh tokens
+// are written back to the vault so they survive across requests.
+type PersistingTokenSource struct {
+	base     oauth2.TokenSource
+	original *oauth2.Token
+	saver    TokenSaver
+	ctx      context.Context
+	saved    bool // prevents redundant saves within one Execute call
+}
+
+// NewPersistingTokenSource wraps base so that the first token refresh triggers
+// a save via saver. The original token is used to detect whether a refresh
+// actually occurred (by comparing access tokens).
+func NewPersistingTokenSource(base oauth2.TokenSource, original *oauth2.Token, saver TokenSaver, ctx context.Context) *PersistingTokenSource {
+	return &PersistingTokenSource{
+		base:     base,
+		original: original,
+		saver:    saver,
+		ctx:      ctx,
+	}
+}
+
+// Token returns the current token, persisting it to the vault if a refresh
+// occurred. Vault write failures are logged but do not fail the API call —
+// the refreshed token is still valid in memory for this request.
+func (p *PersistingTokenSource) Token() (*oauth2.Token, error) {
+	tok, err := p.base.Token()
+	if err != nil {
+		return nil, err
+	}
+	if !p.saved && tok.AccessToken != p.original.AccessToken {
+		tokenJSON, marshalErr := json.Marshal(tok)
+		if marshalErr != nil {
+			slog.Warn("failed to marshal refreshed token", "error", marshalErr)
+			return tok, nil
+		}
+		if saveErr := p.saver(p.ctx, tokenJSON); saveErr != nil {
+			slog.Warn("failed to persist refreshed token to vault", "error", saveErr)
+		}
+		p.saved = true
+	}
+	return tok, nil
+}

--- a/core/source/token_source_test.go
+++ b/core/source/token_source_test.go
@@ -1,0 +1,172 @@
+package source_test
+
+import (
+	"context"
+	"encoding/json"
+	"sync/atomic"
+	"testing"
+
+	"github.com/ALRubinger/aileron/core/source"
+	"golang.org/x/oauth2"
+)
+
+// staticTokenSource returns the same token every time.
+type staticTokenSource struct {
+	tok *oauth2.Token
+}
+
+func (s *staticTokenSource) Token() (*oauth2.Token, error) {
+	return s.tok, nil
+}
+
+func TestPersistingTokenSource_SavesOnRefresh(t *testing.T) {
+	original := &oauth2.Token{
+		AccessToken:  "old-access",
+		RefreshToken: "old-refresh",
+	}
+	refreshed := &oauth2.Token{
+		AccessToken:  "new-access",
+		RefreshToken: "new-refresh",
+		TokenType:    "bearer",
+	}
+
+	var saved atomic.Bool
+	var savedJSON []byte
+	saver := func(_ context.Context, newToken []byte) error {
+		saved.Store(true)
+		savedJSON = newToken
+		return nil
+	}
+
+	pts := source.NewPersistingTokenSource(
+		&staticTokenSource{tok: refreshed},
+		original,
+		saver,
+		context.Background(),
+	)
+
+	tok, err := pts.Token()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if tok.AccessToken != "new-access" {
+		t.Errorf("expected new-access, got %s", tok.AccessToken)
+	}
+	if !saved.Load() {
+		t.Fatal("expected saver to be called")
+	}
+
+	// Verify the saved JSON contains the refreshed token.
+	var parsed oauth2.Token
+	if err := json.Unmarshal(savedJSON, &parsed); err != nil {
+		t.Fatalf("failed to unmarshal saved token: %v", err)
+	}
+	if parsed.RefreshToken != "new-refresh" {
+		t.Errorf("expected new-refresh in saved token, got %s", parsed.RefreshToken)
+	}
+}
+
+func TestPersistingTokenSource_NoSaveWhenUnchanged(t *testing.T) {
+	original := &oauth2.Token{
+		AccessToken:  "same-access",
+		RefreshToken: "same-refresh",
+	}
+
+	var saved atomic.Bool
+	saver := func(_ context.Context, _ []byte) error {
+		saved.Store(true)
+		return nil
+	}
+
+	pts := source.NewPersistingTokenSource(
+		&staticTokenSource{tok: original},
+		original,
+		saver,
+		context.Background(),
+	)
+
+	_, err := pts.Token()
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if saved.Load() {
+		t.Error("saver should not be called when token is unchanged")
+	}
+}
+
+func TestPersistingTokenSource_SavesOnlyOnce(t *testing.T) {
+	original := &oauth2.Token{AccessToken: "old"}
+	refreshed := &oauth2.Token{AccessToken: "new"}
+
+	var saveCount atomic.Int32
+	saver := func(_ context.Context, _ []byte) error {
+		saveCount.Add(1)
+		return nil
+	}
+
+	pts := source.NewPersistingTokenSource(
+		&staticTokenSource{tok: refreshed},
+		original,
+		saver,
+		context.Background(),
+	)
+
+	// Call Token() multiple times — saver should fire only once.
+	for range 5 {
+		if _, err := pts.Token(); err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+	}
+	if saveCount.Load() != 1 {
+		t.Errorf("expected saver called once, got %d", saveCount.Load())
+	}
+}
+
+func TestPersistingTokenSource_SaveErrorDoesNotFailToken(t *testing.T) {
+	original := &oauth2.Token{AccessToken: "old"}
+	refreshed := &oauth2.Token{AccessToken: "new"}
+
+	saver := func(_ context.Context, _ []byte) error {
+		return context.DeadlineExceeded // simulate vault write failure
+	}
+
+	pts := source.NewPersistingTokenSource(
+		&staticTokenSource{tok: refreshed},
+		original,
+		saver,
+		context.Background(),
+	)
+
+	tok, err := pts.Token()
+	if err != nil {
+		t.Fatalf("save failure should not propagate, got: %v", err)
+	}
+	if tok.AccessToken != "new" {
+		t.Errorf("expected new access token, got %s", tok.AccessToken)
+	}
+}
+
+func TestWithTokenSaver_RoundTrip(t *testing.T) {
+	ctx := context.Background()
+	if source.GetTokenSaver(ctx) != nil {
+		t.Fatal("expected nil saver on bare context")
+	}
+
+	var called bool
+	saver := func(_ context.Context, _ []byte) error {
+		called = true
+		return nil
+	}
+	ctx = source.WithTokenSaver(ctx, saver)
+
+	got := source.GetTokenSaver(ctx)
+	if got == nil {
+		t.Fatal("expected non-nil saver after WithTokenSaver")
+	}
+	if err := got(ctx, nil); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if !called {
+		t.Error("expected saver to be invoked")
+	}
+}


### PR DESCRIPTION
## Summary

- **Persist refreshed OAuth tokens**: When Google rotates a refresh token during an automatic access token refresh, the new token is now written back to the vault. Previously the rotated refresh token was silently discarded, causing permanent 401 errors that required manual reconnection.
- **Surface auth errors to users**: Google API 401/403 errors are now detected by connectors and wrapped with `source.ErrAuthFailed`. The pipeline converts this to `ToolFatalError`, aborting the LLM loop so the handler can tell the user to reconnect — instead of silently producing drafts without email context.
- **Context-based injection**: `TokenSaver` callback is passed via context (concurrency-safe), avoiding changes to the `SourceConnector` interface. Both Gmail and Calendar connectors wrap their `oauth2.TokenSource` with a shared `PersistingTokenSource`.

## Test plan

- [x] `PersistingTokenSource` unit tests: saves on refresh, no-save when unchanged, saves only once, save-error doesn't fail the API call
- [x] Gmail connector: token persistence on refresh with rotated refresh token, no-save without saver (regression), 401→`ErrAuthFailed` for search and getThread
- [x] Calendar connector: 401→`ErrAuthFailed` for events and freeBusy
- [x] Pipeline: `ErrAuthFailed`→`ToolFatalError` conversion
- [x] Full test suite passes (27 packages), `go vet` clean, coverage >80% on all changed packages

🤖 Generated with [Claude Code](https://claude.com/claude-code)