### PR TITLE
perf(auth): make bcrypt cost configurable to speed up CI

### DIFF
--- a/core/auth/handler.go
+++ b/core/auth/handler.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/store"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // Handler serves the authentication HTTP routes.
@@ -31,7 +32,9 @@ type Handler struct {
 	uiRedirect        string // URL to redirect to after successful auth
 	refreshTTL        time.Duration
 	verificationTTL   time.Duration
-	autoVerifyEmail bool
+	autoVerifyEmail   bool
+	bcryptCost        int    // bcrypt cost parameter (default 12)
+	dummyHash         string // pre-computed dummy hash for timing-safe rejection
 }
 
 // HandlerConfig configures the auth handler.
@@ -48,9 +51,10 @@ type HandlerConfig struct {
 	Mailer            Mailer
 	NewID             func() string
 	UIRedirect        string        // UI base URL, e.g. "http://localhost:5173" or "/"
-	AutoVerifyEmail bool          // skip email verification (dev/CI only)
-	RefreshTTL      time.Duration // e.g. 7 * 24 * time.Hour
-	VerificationTTL time.Duration // e.g. 15 * time.Minute
+	AutoVerifyEmail   bool          // skip email verification (dev/CI only)
+	RefreshTTL        time.Duration // e.g. 7 * 24 * time.Hour
+	VerificationTTL   time.Duration // e.g. 15 * time.Minute
+	BcryptCost        int           // bcrypt cost (default 12; use bcrypt.MinCost in tests)
 }
 
 // NewHandler creates an auth handler.
@@ -64,6 +68,14 @@ func NewHandler(cfg HandlerConfig) *Handler {
 	if cfg.UIRedirect == "" {
 		cfg.UIRedirect = "/"
 	}
+	if cfg.BcryptCost == 0 {
+		cfg.BcryptCost = 12
+	}
+
+	// Pre-compute a dummy hash at the configured cost for timing-safe rejection
+	// of logins for nonexistent users (prevents email enumeration via timing).
+	dummy, _ := bcrypt.GenerateFromPassword([]byte("dummy"), cfg.BcryptCost)
+
 	return &Handler{
 		log:               cfg.Log,
 		registry:          cfg.Registry,
@@ -79,7 +91,9 @@ func NewHandler(cfg HandlerConfig) *Handler {
 		uiRedirect:        cfg.UIRedirect,
 		refreshTTL:        cfg.RefreshTTL,
 		verificationTTL:   cfg.VerificationTTL,
-		autoVerifyEmail: cfg.AutoVerifyEmail,
+		autoVerifyEmail:   cfg.AutoVerifyEmail,
+		bcryptCost:        cfg.BcryptCost,
+		dummyHash:         string(dummy),
 	}
 }
 

--- a/core/auth/handler_email.go
+++ b/core/auth/handler_email.go
@@ -49,8 +49,8 @@ func (h *Handler) handleSignup(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Hash password with bcrypt (cost 12).
-	hash, err := bcrypt.GenerateFromPassword([]byte(body.Password), 12)
+	// Hash password with bcrypt.
+	hash, err := bcrypt.GenerateFromPassword([]byte(body.Password), h.bcryptCost)
 	if err != nil {
 		h.log.Error("failed to hash password", "error", err)
 		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
@@ -224,7 +224,7 @@ func (h *Handler) handleEmailLogin(w http.ResponseWriter, r *http.Request) {
 	user, err := h.users.GetByEmail(ctx, body.Email)
 	if err != nil {
 		// Constant-time-ish: still run bcrypt comparison to prevent timing attacks.
-		bcrypt.CompareHashAndPassword([]byte("$2a$12$xxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxxx"), []byte(body.Password))
+		bcrypt.CompareHashAndPassword([]byte(h.dummyHash), []byte(body.Password))
 		http.Error(w, `{"error":"invalid email or password"}`, http.StatusUnauthorized)
 		return
 	}

--- a/core/auth/handler_email_test.go
+++ b/core/auth/handler_email_test.go
@@ -26,7 +26,7 @@ func TestGenerateVerificationCode(t *testing.T) {
 
 func TestBcryptHashAndCompare(t *testing.T) {
 	password := "my-secure-password-123"
-	hash, err := bcrypt.GenerateFromPassword([]byte(password), 12)
+	hash, err := bcrypt.GenerateFromPassword([]byte(password), bcrypt.MinCost)
 	if err != nil {
 		t.Fatalf("GenerateFromPassword: %v", err)
 	}

--- a/core/auth/testhelper_test.go
+++ b/core/auth/testhelper_test.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/ALRubinger/aileron/core/model"
 	"github.com/ALRubinger/aileron/core/store"
+	"golang.org/x/crypto/bcrypt"
 )
 
 // --- Stub stores ---
@@ -370,6 +371,7 @@ func newTestEnv() *testEnv {
 		NewID:             idGen,
 		RefreshTTL:        7 * 24 * time.Hour,
 		VerificationTTL:   15 * time.Minute,
+		BcryptCost:        bcrypt.MinCost,
 	})
 
 	mux := http.NewServeMux()


### PR DESCRIPTION
## Summary

- Make bcrypt cost configurable on `HandlerConfig` (defaults to 12 in production, `bcrypt.MinCost` in tests)
- Pre-compute a valid dummy hash at handler creation for timing-safe rejection of nonexistent-user logins (fixes a bug where the old hardcoded string was invalid bcrypt, defeating the timing-attack protection)
- **`core/auth` tests: 84s → 3s** (30x faster)

## Test plan

- [x] `go test -race ./core/... ./enclave/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...` — all pass
- [x] `go vet` clean
- [x] Verified production caller (`core/app/app.go:345`) does not set `BcryptCost`, so it defaults to 12
- [ ] CI passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)