### PR TITLE
ci: move docs out of docker-compose into dedicated CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -163,6 +163,35 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ui/test-results/junit-vitest.xml,ui/test-results/junit-playwright.xml
 
+  docs:
+    name: Docs
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v5
+
+      - name: Build docs image
+        run: docker build -t aileron-docs -f docs/Dockerfile .
+
+      - name: Start docs container
+        run: docker run -d --name docs -p 3001:3000 aileron-docs
+
+      - name: Verify docs respond
+        run: |
+          for i in $(seq 1 15); do
+            if curl -sf http://localhost:3001; then
+              echo "Docs site healthy"
+              exit 0
+            fi
+            sleep 2
+          done
+          echo "Docs site did not respond"
+          docker logs docs
+          exit 1
+
+      - name: Tear down
+        if: always()
+        run: docker rm -f docs
+
   integration-go:
     name: Integration Tests (Go)
     runs-on: ubuntu-latest

--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -75,13 +75,5 @@ services:
     ports:
       - "3000:3000"
 
-  docs:
-    build:
-      context: ..
-      dockerfile: docs/Dockerfile
-    restart: unless-stopped
-    ports:
-      - "3001:3000"
-
 volumes:
   postgres_data:

--- a/docs/src/content/docs/operations/running-locally.md
+++ b/docs/src/content/docs/operations/running-locally.md
@@ -9,7 +9,9 @@ For the full server/UI stack:
 task up
 ```
 
-This starts the API server, management UI, API documentation, and PostgreSQL. The API is available at `http://localhost:8080`, the UI at `http://localhost:3000`.
+This starts PostgreSQL, the enclave, the API server, and the management UI. The API is available at `http://localhost:8080`, the UI at `http://localhost:3000`.
+
+To run the docs site locally, use `task dev:docs` (available at `http://localhost:4321`).
 
 On first run, `task up` copies `deploy/.env.example` to `deploy/.env` with safe local defaults (including `AILERON_JWT_SIGNING_KEY`). No manual setup needed.
 


### PR DESCRIPTION
## Summary

- Remove docs service from `deploy/docker-compose.yml` — it's an independent static site, not part of the application stack
- Add a dedicated `docs` CI job that builds the Docker image and verifies the site responds to HTTP requests
- The new job runs in parallel with all other CI jobs

## Test plan

- [ ] CI passes — new docs job builds and smoke-tests the docs image
- [ ] Integration tests still pass without the docs service in compose

🤖 Generated with [Claude Code](https://claude.com/claude-code)