### PR TITLE
fix(auth): rename AILERON_UI_REDIRECT_URL to AILERON_UI_BASE_URL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -239,7 +239,7 @@ jobs:
         run: gotestsum --junitfile junit-integration.xml -- -tags=integration -race -coverprofile=coverage-store.txt -coverpkg=./core/store/postgres/... ./test/integration/... ./core/store/postgres/...
         env:
           AILERON_API_URL: http://localhost:8080
-          AILERON_UI_URL: http://localhost:3000
+          AILERON_UI_BASE_URL: http://localhost:3000
 
       - name: Stop server to flush coverage data
         if: ${{ !cancelled() }}
@@ -335,7 +335,7 @@ jobs:
         run: pnpm test:e2e:integration
         env:
           AILERON_API_URL: http://localhost:8080
-          AILERON_UI_URL: http://localhost:3000
+          AILERON_UI_BASE_URL: http://localhost:3000
 
       - name: Upload test results to Codecov
         if: ${{ !cancelled() }}

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -215,7 +215,7 @@ tasks:
       - go test -tags=integration -race ./test/integration/... ./core/store/postgres/...
     env:
       AILERON_API_URL: http://localhost:8080
-      AILERON_UI_URL: http://localhost:3000
+      AILERON_UI_BASE_URL: http://localhost:3000
 
   test:e2e:integration:
     desc: Run Playwright E2E tests against running services
@@ -226,7 +226,7 @@ tasks:
       - pnpm test:e2e:integration
     env:
       AILERON_API_URL: http://localhost:8080
-      AILERON_UI_URL: http://localhost:3000
+      AILERON_UI_BASE_URL: http://localhost:3000
 
   test:integration:coverage:
     desc: Start a coverage-instrumented stack, run integration tests, and emit coverage-integration.txt
@@ -239,7 +239,7 @@ tasks:
       - docker compose -f {{.COMPOSE_FILE}} -f deploy/docker-compose.coverage.yml down -v
     env:
       AILERON_API_URL: http://localhost:8080
-      AILERON_UI_URL: http://localhost:3000
+      AILERON_UI_BASE_URL: http://localhost:3000
 
   ci:
     desc: Run the full CI pipeline locally

--- a/core/app/app.go
+++ b/core/app/app.go
@@ -354,7 +354,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			VerificationCodes: verificationCodeStore,
 			Mailer:            mailer,
 			NewID:             idGen,
-			UIRedirect:        authCfg.UIRedirectURL,
+			UIBaseURL:         authCfg.UIBaseURL,
 			RefreshTTL:        authCfg.RefreshTokenTTL,
 			AutoVerifyEmail: authCfg.AutoVerifyEmail,
 		})

--- a/core/app/handlers_slack_agent.go
+++ b/core/app/handlers_slack_agent.go
@@ -73,7 +73,7 @@ func (s *apiServer) resolvePipelineVault(userID string) *draft.Pipeline {
 }
 
 // vaultUnlockURL returns the URL to the vault unlock page, falling back
-// to the production URL when AILERON_UI_URL is not configured.
+// to the production URL when AILERON_UI_BASE_URL is not configured.
 func (s *apiServer) vaultUnlockURL() string {
 	base := s.uiBaseURL
 	if base == "" {

--- a/core/auth/handler.go
+++ b/core/auth/handler.go
@@ -29,7 +29,7 @@ type Handler struct {
 	verificationCodes store.VerificationCodeStore
 	mailer            Mailer
 	newID             func() string
-	uiRedirect        string // URL to redirect to after successful auth
+	uiBaseURL         string // UI origin, e.g. "https://app.example.com"
 	refreshTTL        time.Duration
 	verificationTTL   time.Duration
 	autoVerifyEmail   bool
@@ -50,7 +50,7 @@ type HandlerConfig struct {
 	VerificationCodes store.VerificationCodeStore
 	Mailer            Mailer
 	NewID             func() string
-	UIRedirect        string        // UI base URL, e.g. "http://localhost:5173" or "/"
+	UIBaseURL         string        // UI origin, e.g. "http://localhost:5173" or "/"
 	AutoVerifyEmail   bool          // skip email verification (dev/CI only)
 	RefreshTTL        time.Duration // e.g. 7 * 24 * time.Hour
 	VerificationTTL   time.Duration // e.g. 15 * time.Minute
@@ -65,8 +65,8 @@ func NewHandler(cfg HandlerConfig) *Handler {
 	if cfg.VerificationTTL == 0 {
 		cfg.VerificationTTL = 15 * time.Minute
 	}
-	if cfg.UIRedirect == "" {
-		cfg.UIRedirect = "/"
+	if cfg.UIBaseURL == "" {
+		cfg.UIBaseURL = "/"
 	}
 	if cfg.BcryptCost == 0 {
 		cfg.BcryptCost = 12
@@ -88,7 +88,7 @@ func NewHandler(cfg HandlerConfig) *Handler {
 		verificationCodes: cfg.VerificationCodes,
 		mailer:            cfg.Mailer,
 		newID:             cfg.NewID,
-		uiRedirect:        cfg.UIRedirect,
+		uiBaseURL:         cfg.UIBaseURL,
 		refreshTTL:        cfg.RefreshTTL,
 		verificationTTL:   cfg.VerificationTTL,
 		autoVerifyEmail:   cfg.AutoVerifyEmail,
@@ -376,7 +376,7 @@ issueTokens:
 	})
 
 	h.log.Info("user authenticated", "user_id", user.ID, "provider", providerName)
-	http.Redirect(w, r, strings.TrimRight(h.uiRedirect, "/")+"/auth/callback", http.StatusTemporaryRedirect)
+	http.Redirect(w, r, strings.TrimRight(h.uiBaseURL, "/")+"/auth/callback", http.StatusTemporaryRedirect)
 }
 
 // handleRefresh exchanges a refresh token for a new access token.

--- a/core/config/auth.go
+++ b/core/config/auth.go
@@ -31,9 +31,11 @@ type AuthConfig struct {
 	// Env: AILERON_REFRESH_TOKEN_TTL (default: "168h" = 7 days)
 	RefreshTokenTTL time.Duration
 
-	// UIRedirectURL is where users are sent after successful auth.
-	// Env: AILERON_UI_REDIRECT_URL (default: "/")
-	UIRedirectURL string
+	// UIBaseURL is the UI origin (e.g. "https://app.example.com"), used for
+	// post-auth redirects and constructing user-facing links (e.g. vault unlock).
+	// Must not include any path — the server appends paths automatically.
+	// Env: AILERON_UI_BASE_URL (default: "/")
+	UIBaseURL string
 
 	// AutoVerifyEmail skips email verification on signup, activating
 	// accounts immediately. For development and CI only.
@@ -70,11 +72,6 @@ type AuthConfig struct {
 	// Env: MAIL_FROM (default: "noreply@withaileron.ai")
 	MailFrom string
 
-	// UIBaseURL is the base URL of the Aileron web UI, used to construct
-	// user-facing links (e.g. vault unlock from Slack).
-	// Env: AILERON_UI_URL (default: "")
-	UIBaseURL string
-
 	// SystemVaultKey is the AES-256 encryption key for the system vault
 	// (ADR-0020). Infrastructure secrets (Slack bot tokens, webhook keys)
 	// are encrypted at rest with this key. 32 bytes, hex-encoded (64 chars).
@@ -97,7 +94,7 @@ func LoadAuthConfig() (*AuthConfig, error) {
 		DatabaseURL:        envTrimmed("AILERON_DATABASE_URL"),
 		JWTSigningKey:      envTrimmed("AILERON_JWT_SIGNING_KEY"),
 		JWTIssuer:          envOrDefault("AILERON_JWT_ISSUER", "aileron"),
-		UIRedirectURL:      envOrDefault("AILERON_UI_REDIRECT_URL", "/"),
+		UIBaseURL:          envOrDefault("AILERON_UI_BASE_URL", "/"),
 		AutoVerifyEmail:    envTrimmed("AILERON_AUTO_VERIFY_EMAIL") == "true",
 		GoogleSigninClientID:        envTrimmed("GOOGLE_SIGNIN_CLIENT_ID"),
 		GoogleSigninClientSecret:    envTrimmed("GOOGLE_SIGNIN_CLIENT_SECRET"),
@@ -110,7 +107,6 @@ func LoadAuthConfig() (*AuthConfig, error) {
 		SlackClientID:      envTrimmed("SLACK_CLIENT_ID"),
 		SlackClientSecret:  envTrimmed("SLACK_CLIENT_SECRET"),
 		SlackSigningSecret: envTrimmed("SLACK_SIGNING_SECRET"),
-		UIBaseURL:          envTrimmed("AILERON_UI_URL"),
 		SystemVaultKey:     envTrimmed("AILERON_SYSTEM_VAULT_KEY"),
 		ResendAPIKey:       envTrimmed("RESEND_API_KEY"),
 		MailFrom:           envOrDefault("MAIL_FROM", "noreply@withaileron.ai"),

--- a/core/config/auth_test.go
+++ b/core/config/auth_test.go
@@ -51,7 +51,7 @@ func TestLoadAuthConfig_Defaults(t *testing.T) {
 	t.Setenv("AILERON_JWT_ISSUER", "")
 	t.Setenv("AILERON_ACCESS_TOKEN_TTL", "")
 	t.Setenv("AILERON_REFRESH_TOKEN_TTL", "")
-	t.Setenv("AILERON_UI_REDIRECT_URL", "")
+	t.Setenv("AILERON_UI_BASE_URL", "")
 
 	cfg, err := LoadAuthConfig()
 	if err != nil {
@@ -66,8 +66,8 @@ func TestLoadAuthConfig_Defaults(t *testing.T) {
 	if cfg.RefreshTokenTTL != 7*24*time.Hour {
 		t.Errorf("RefreshTokenTTL = %v, want 168h", cfg.RefreshTokenTTL)
 	}
-	if cfg.UIRedirectURL != "/" {
-		t.Errorf("UIRedirectURL = %q, want /", cfg.UIRedirectURL)
+	if cfg.UIBaseURL != "/" {
+		t.Errorf("UIBaseURL = %q, want /", cfg.UIBaseURL)
 	}
 }
 

--- a/docs/src/content/docs/deployment/cloud.md
+++ b/docs/src/content/docs/deployment/cloud.md
@@ -37,7 +37,7 @@ Each service needs a domain or URL. The auth domain points to the **server** ser
 | `AILERON_JWT_ISSUER` | No | `aileron` | `iss` claim in issued JWTs |
 | `AILERON_ACCESS_TOKEN_TTL` | No | `15m` | Access token lifetime |
 | `AILERON_REFRESH_TOKEN_TTL` | No | `168h` | Refresh token lifetime (7 days) |
-| `AILERON_UI_REDIRECT_URL` | No | `/` | Redirect destination after successful login |
+| `AILERON_UI_BASE_URL` | No | `/` | UI origin (e.g. `https://app.example.com`). Must not include any path — the server appends `/auth/callback` automatically. |
 | `AILERON_AUTO_VERIFY_EMAIL` | No | `false` | Skip email verification on signup. **Never enable in production.** |
 | `GOOGLE_SIGNIN_CLIENT_ID` | No | | Google OAuth client ID for sign-in |
 | `GOOGLE_SIGNIN_CLIENT_SECRET` | No | | Google OAuth client secret for sign-in |
@@ -58,7 +58,6 @@ Each service needs a domain or URL. The auth domain points to the **server** ser
 | `ANTHROPIC_API_KEY` | No | | Anthropic API key. Enables AI-powered draft generation when set |
 | `AILERON_LLM_MODEL_RESEARCH` | No | `claude-haiku-4-5-20251001` | Model for the research round (tool-call decisions, context gathering). Use a fast model — quality is less important than speed here. Any Anthropic model ID works |
 | `AILERON_LLM_MODEL_SYNTHESIS` | No | `claude-sonnet-4-6` | Model for the synthesis round (composing the final reply in the user's voice). Use a capable model — this is the quality-sensitive step |
-| `AILERON_UI_URL` | No | | Base URL of the web UI (e.g. `https://app.yourdomain.com`). Used to construct user-facing links such as the vault unlock link sent via Slack. No trailing slash |
 
 ### UI service
 

--- a/docs/src/content/docs/deployment/railway.md
+++ b/docs/src/content/docs/deployment/railway.md
@@ -48,7 +48,7 @@ Configure **watched paths** under each service's **Settings > Build > Watched Pa
 | `ANTHROPIC_API_KEY` | Anthropic API key for draft generation (optional) |
 | `AILERON_LLM_MODEL_RESEARCH` | Research model (default: `claude-haiku-4-5-20251001`) (optional) |
 | `AILERON_LLM_MODEL_SYNTHESIS` | Synthesis model (default: `claude-sonnet-4-6`) (optional) |
-| `AILERON_UI_URL` | `https://app.withaileron.ai` |
+| `AILERON_UI_BASE_URL` | `https://app.withaileron.ai` |
 
 **UI service:**
 

--- a/ui/playwright.integration.config.ts
+++ b/ui/playwright.integration.config.ts
@@ -21,7 +21,7 @@ export default defineConfig({
 		? [['github'], ['junit', { outputFile: 'test-results/junit-playwright-integration.xml' }]]
 		: 'html',
 	use: {
-		baseURL: process.env.AILERON_UI_URL || 'http://localhost:3000',
+		baseURL: process.env.AILERON_UI_BASE_URL || 'http://localhost:3000',
 		trace: 'on-first-retry'
 	},
 	projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }]


### PR DESCRIPTION
## Summary

- Renames `AILERON_UI_REDIRECT_URL` → `AILERON_UI_BASE_URL` — the value is a UI origin, not a redirect URL. The old name led to misconfiguration where the full callback path was included, producing a doubled `/auth/callback/auth/callback` redirect after OAuth sign-in.
- Consolidates the duplicate `AILERON_UI_URL` env var (used for Slack vault-unlock links) into the same `AILERON_UI_BASE_URL`.
- Removes stale `auth.withaileron.ai` references from docs.

## After merge

Update Railway env vars on the **server** service:
1. Remove `AILERON_UI_REDIRECT_URL` and `AILERON_UI_URL`
2. Add `AILERON_UI_BASE_URL` = `https://app.withaileron.ai` (no path, no trailing slash)

## Test plan

- [x] `go test ./auth/ ./config/ ./app/` all pass
- [ ] Deploy and verify Google OAuth redirects to `/auth/callback` (not doubled)
- [ ] Verify Slack vault-unlock link points to correct URL

🤖 Generated with [Claude Code](https://claude.com/claude-code)