### PR TITLE
fix(ui): show vault status instead of redirecting when unlocked

### DIFF
--- a/ui/src/routes/vault/+page.svelte
+++ b/ui/src/routes/vault/+page.svelte
@@ -38,11 +38,8 @@
 		try {
 			const status = await getVaultStatus();
 			if (status.has_passphrase && !status.locked) {
-				// Already set up and unlocked — go to dashboard.
-				goto('/');
-				return;
-			}
-			if (status.has_passphrase) {
+				step = 'done';
+			} else if (status.has_passphrase) {
 				step = 'unlock';
 			}
 		} catch {
@@ -100,8 +97,6 @@
 					setSessionExpiresAt(result.sessionExpiresAt);
 				}
 				step = 'done';
-				// Redirect to dashboard after brief success display.
-				setTimeout(() => goto('/'), 1500);
 			} else {
 				error = 'Incorrect passphrase';
 			}
@@ -115,7 +110,7 @@
 </script>
 
 <svelte:head>
-	<title>Set up vault — Aileron</title>
+	<title>Vault — Aileron</title>
 </svelte:head>
 
 <div class="flex items-center justify-center min-h-[70vh]">
@@ -212,9 +207,14 @@
 			<Card.Header>
 				<Card.Title class="text-xl">Vault unlocked</Card.Title>
 				<Card.Description>
-					Your vault is set up and ready. Redirecting to dashboard...
+					Your vault is set up and unlocked. Your encrypted credentials are available for this session.
 				</Card.Description>
 			</Card.Header>
+			<Card.Content>
+				<a href="/settings/connected-accounts">
+					<Button class="w-full">Manage connected services</Button>
+				</a>
+			</Card.Content>
 		</Card.Root>
 	{/if}
 </div>


### PR DESCRIPTION
## Summary

- `/vault` no longer redirects to the dashboard when the vault is already unlocked — it shows the unlocked state with a "Manage connected services" link to `/settings/connected-accounts`
- After a successful unlock, the user stays on the vault page instead of being auto-redirected after 1.5s
- Page title simplified from "Set up vault" to "Vault"

## Test plan

- [ ] Log in, set up vault, verify you land on the "Vault unlocked" card with the connected services link
- [ ] Navigate to `/vault` when already unlocked — confirm it shows status, not a redirect
- [ ] Navigate to `/vault` when vault is locked — confirm unlock flow still works
- [ ] Navigate to `/vault` when no passphrase is set — confirm setup flow still works
- [ ] Click "Manage connected services" button — confirm it navigates to `/settings/connected-accounts`

🤖 Generated with [Claude Code](https://claude.com/claude-code)