### PR TITLE
fix: add enclave readiness checks and fail gracefully when unavailable

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -27,6 +27,11 @@ services:
       AILERON_ENCLAVE_PORT: "8443"
     ports:
       - "8443:8443"
+    healthcheck:
+      test: ["CMD-SHELL", "wget -qO- http://localhost:8443/health || exit 1"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
 
   server:
     build:
@@ -37,7 +42,7 @@ services:
       postgres:
         condition: service_healthy
       enclave:
-        condition: service_started
+        condition: service_healthy
     environment:
       AILERON_ADDR: ":8080"
       AILERON_DATABASE_URL: "postgres://aileron:aileron@postgres:5432/aileron?sslmode=disable"

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -136,6 +136,20 @@ func isNotFound(err error) bool {
 // --- Health ---
 
 func (s *apiServer) GetHealth(w http.ResponseWriter, r *http.Request) {
+	// When TEE is configured, verify the enclave is reachable.
+	if s.enclaveClient != nil {
+		if err := s.enclaveClient.Ready(r.Context()); err != nil {
+			s.log.Warn("health check: enclave not ready", "error", err)
+			writeJSON(w, http.StatusServiceUnavailable, api.HealthResponse{
+				Status:    "enclave_not_ready",
+				Service:   "aileron",
+				Version:   version.Version,
+				Timestamp: time.Now().UTC(),
+			})
+			return
+		}
+	}
+
 	writeJSON(w, http.StatusOK, api.HealthResponse{
 		Status:    "ok",
 		Service:   "aileron",
@@ -747,6 +761,10 @@ func (s *apiServer) RunExecution(w http.ResponseWriter, r *http.Request) {
 	// KEK-encrypted; only the enclave (which holds the user's KEK) can
 	// decrypt it. The server never sees the plaintext credential.
 	if s.enclaveClient != nil {
+		if !s.requireEnclave(w, r) {
+			finishExecution(s, ctx, exec, intent, api.ExecutionStatusFailed, nil, "", "enclave not ready")
+			return
+		}
 		var execUserID string
 		if claims := auth.ClaimsFromContext(ctx); claims != nil {
 			execUserID = claims.Subject
@@ -1117,6 +1135,28 @@ func (s *apiServer) resolveCredentialVaultPath(ctx context.Context, connProvider
 
 	// Fall back to infrastructure credential.
 	return fmt.Sprintf("connectors/%s/default", connProvider)
+}
+
+// enclaveReady checks whether the enclave is reachable. Returns nil if TEE
+// is not configured or the enclave is healthy. Returns an error if TEE is
+// configured but the enclave is unreachable.
+func (s *apiServer) enclaveReady(ctx context.Context) error {
+	if s.enclaveClient == nil {
+		return nil
+	}
+	return s.enclaveClient.Ready(ctx)
+}
+
+// requireEnclave checks enclave readiness and writes a 503 error if it's
+// unavailable. Returns true if the enclave is ready (or not configured).
+func (s *apiServer) requireEnclave(w http.ResponseWriter, r *http.Request) bool {
+	if err := s.enclaveReady(r.Context()); err != nil {
+		s.log.Error("enclave not ready", "error", err)
+		writeError(w, http.StatusServiceUnavailable, "enclave_not_ready",
+			"Aileron is still starting up — please try again in a moment.")
+		return false
+	}
+	return true
 }
 
 func resolveConnector(actionType string) (connType, provider string) {

--- a/internal/app/handlers_connected_accounts.go
+++ b/internal/app/handlers_connected_accounts.go
@@ -314,6 +314,10 @@ func (s *apiServer) ConnectAccountCallback(w http.ResponseWriter, r *http.Reques
 	// the code for tokens, encrypts them with the user's KEK, and returns
 	// only the ciphertext. The server never sees the plaintext tokens.
 	if s.enclaveClient != nil {
+		// Verify enclave is reachable before attempting OAuth exchange.
+		if !s.requireEnclave(w, r) {
+			return
+		}
 		// Verify passphrase exists (enclave has escrowed KEK).
 		if s.userKeyMaterials != nil {
 			if _, err := s.userKeyMaterials.Get(r.Context(), userID); err != nil && isNotFound(err) {

--- a/internal/app/handlers_execution_test.go
+++ b/internal/app/handlers_execution_test.go
@@ -64,7 +64,8 @@ func (e *stubEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowListRes
 func (e *stubEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }
-func (e *stubEnclaveClient) Close() error { return nil }
+func (e *stubEnclaveClient) Ready(_ context.Context) error { return nil }
+func (e *stubEnclaveClient) Close() error                  { return nil }
 
 func newExecutionServer() *apiServer {
 	return &apiServer{

--- a/internal/app/handlers_helpers_test.go
+++ b/internal/app/handlers_helpers_test.go
@@ -2,7 +2,10 @@ package app
 
 import (
 	"context"
+	"fmt"
 	"log/slog"
+	"net/http"
+	"net/http/httptest"
 	"testing"
 	"time"
 
@@ -481,5 +484,87 @@ func TestResolveCredentialVaultPath_UnknownProvider(t *testing.T) {
 	// Stripe has no connected account provider mapping.
 	if path != "connectors/stripe/default" {
 		t.Errorf("vaultPath = %q, want connectors/stripe/default", path)
+	}
+}
+
+// --- Enclave readiness tests ---
+
+type failingEnclaveClient struct {
+	stubEnclaveClient
+}
+
+func (f *failingEnclaveClient) Ready(_ context.Context) error {
+	return fmt.Errorf("enclave not reachable: connection refused")
+}
+
+func TestGetHealth_NoEnclave(t *testing.T) {
+	s := &apiServer{log: slog.Default()}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	s.GetHealth(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestGetHealth_EnclaveHealthy(t *testing.T) {
+	s := &apiServer{
+		log:           slog.Default(),
+		enclaveClient: &stubEnclaveClient{},
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	s.GetHealth(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200", w.Code)
+	}
+}
+
+func TestGetHealth_EnclaveNotReady(t *testing.T) {
+	s := &apiServer{
+		log:           slog.Default(),
+		enclaveClient: &failingEnclaveClient{},
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodGet, "/v1/health", nil)
+	s.GetHealth(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+func TestRequireEnclave_NoEnclave(t *testing.T) {
+	s := &apiServer{log: slog.Default()}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/test", nil)
+	if !s.requireEnclave(w, r) {
+		t.Error("requireEnclave should return true when no enclave configured")
+	}
+}
+
+func TestRequireEnclave_EnclaveHealthy(t *testing.T) {
+	s := &apiServer{
+		log:           slog.Default(),
+		enclaveClient: &stubEnclaveClient{},
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/test", nil)
+	if !s.requireEnclave(w, r) {
+		t.Error("requireEnclave should return true when enclave is healthy")
+	}
+}
+
+func TestRequireEnclave_EnclaveDown(t *testing.T) {
+	s := &apiServer{
+		log:           slog.Default(),
+		enclaveClient: &failingEnclaveClient{},
+	}
+	w := httptest.NewRecorder()
+	r := httptest.NewRequest(http.MethodPost, "/v1/test", nil)
+	if s.requireEnclave(w, r) {
+		t.Error("requireEnclave should return false when enclave is down")
+	}
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
 	}
 }

--- a/internal/app/handlers_passphrase_test.go
+++ b/internal/app/handlers_passphrase_test.go
@@ -67,7 +67,8 @@ func (c *mockEscrowClient) EscrowList(_ context.Context) (enclave.EscrowListResp
 func (c *mockEscrowClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }
-func (c *mockEscrowClient) Close() error { return nil }
+func (c *mockEscrowClient) Ready(_ context.Context) error { return nil }
+func (c *mockEscrowClient) Close() error                  { return nil }
 
 // failingTransmitClient is an enclave client whose TransmitKEK always fails.
 type failingTransmitClient struct {

--- a/internal/app/handlers_slack_agent.go
+++ b/internal/app/handlers_slack_agent.go
@@ -34,7 +34,7 @@ func (s *apiServer) resolvePipelineVault(userID string) *draft.Pipeline {
 	}
 
 	// Tier 2: Escrowed credentials in TEE.
-	if s.enclaveClient != nil {
+	if s.enclaveClient != nil && s.enclaveReady(context.Background()) == nil {
 		// Check if this specific user has escrowed credentials.
 		// Vault paths are "connected-accounts/{userID}/{provider}".
 		prefix := "connected-accounts/" + userID + "/"
@@ -140,6 +140,10 @@ func (s *apiServer) handleAssistantMessage(ctx context.Context, teamID, channelI
 	if pipeline == nil {
 		if s.draftPipeline == nil {
 			s.log.Warn("agent message: draft pipeline not configured")
+		} else if s.enclaveClient != nil && s.enclaveReady(ctx) != nil {
+			s.log.Warn("agent message: enclave not ready", "user_id", userID)
+			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS,
+				":warning: Aileron is still starting up. Please try again in about 30 seconds.")
 		} else {
 			s.log.Warn("agent message: vault locked for user", "user_id", userID)
 			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS, s.vaultLockedSlackMessage())

--- a/internal/app/handlers_slack_agent_test.go
+++ b/internal/app/handlers_slack_agent_test.go
@@ -724,7 +724,8 @@ func (stubEscrowEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowList
 func (stubEscrowEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }
-func (stubEscrowEnclaveClient) Close() error { return nil }
+func (stubEscrowEnclaveClient) Ready(_ context.Context) error { return nil }
+func (stubEscrowEnclaveClient) Close() error                  { return nil }
 
 func TestProcessSlashCommandDraft_HappyPath(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {

--- a/internal/app/handlers_tee_test.go
+++ b/internal/app/handlers_tee_test.go
@@ -877,7 +877,8 @@ func (c *reconcileEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowLi
 func (c *reconcileEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }
-func (c *reconcileEnclaveClient) Close() error { return nil }
+func (c *reconcileEnclaveClient) Ready(_ context.Context) error { return nil }
+func (c *reconcileEnclaveClient) Close() error                  { return nil }
 
 func TestReconcileEscrowIndex_PrunesStaleEntries(t *testing.T) {
 	var index sync.Map

--- a/internal/draft/pipeline_test.go
+++ b/internal/draft/pipeline_test.go
@@ -1087,7 +1087,8 @@ func (s *stubEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowListRes
 func (s *stubEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }
-func (s *stubEnclaveClient) Close() error { return nil }
+func (s *stubEnclaveClient) Ready(_ context.Context) error { return nil }
+func (s *stubEnclaveClient) Close() error                  { return nil }
 
 func TestPipeline_GenerateDraft_ToolExecutor_StaleEscrow(t *testing.T) {
 	// When the escrow vault returns ErrEscrowStale, the tool executor should

--- a/internal/enclave/client.go
+++ b/internal/enclave/client.go
@@ -52,6 +52,12 @@ type Client interface {
 	// plaintext from enclave memory.
 	EscrowRevoke(ctx context.Context, req EscrowRevokeRequest) error
 
+	// Ready checks whether the enclave is reachable and healthy.
+	// Returns nil if the enclave can accept requests, or an error describing
+	// why it cannot. Callers should check Ready before performing operations
+	// that depend on the enclave (OAuth exchange, execution, escrow).
+	Ready(ctx context.Context) error
+
 	// Close releases any resources held by this client.
 	Close() error
 }

--- a/internal/enclave/gcs/client.go
+++ b/internal/enclave/gcs/client.go
@@ -127,6 +127,24 @@ func (c *Client) EscrowRevoke(ctx context.Context, req enclave.EscrowRevokeReque
 	return nil
 }
 
+// Ready checks whether the enclave is reachable by calling GET /health.
+func (c *Client) Ready(ctx context.Context) error {
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, c.baseURL+"/health", nil)
+	if err != nil {
+		return fmt.Errorf("gcs: creating health request: %w", err)
+	}
+	resp, err := c.httpClient.Do(req)
+	if err != nil {
+		return fmt.Errorf("enclave not reachable: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(resp.Body)
+		return fmt.Errorf("enclave health check failed (%d): %s", resp.StatusCode, string(b))
+	}
+	return nil
+}
+
 // Close is a no-op for the HTTP client.
 func (c *Client) Close() error {
 	return nil

--- a/internal/enclave/gcs/client_test.go
+++ b/internal/enclave/gcs/client_test.go
@@ -370,3 +370,40 @@ func TestClientEscrowRevoke(t *testing.T) {
 		t.Fatalf("EscrowRevoke: %v", err)
 	}
 }
+
+func TestClientReady_Healthy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/health" || r.Method != http.MethodGet {
+			t.Fatalf("unexpected %s %s", r.Method, r.URL.Path)
+		}
+		json.NewEncoder(w).Encode(map[string]any{"status": "ok"})
+	}))
+	defer server.Close()
+
+	client := New(Config{BaseURL: server.URL})
+	if err := client.Ready(context.Background()); err != nil {
+		t.Fatalf("Ready: %v", err)
+	}
+}
+
+func TestClientReady_Unhealthy(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		w.Write([]byte("enclave error"))
+	}))
+	defer server.Close()
+
+	client := New(Config{BaseURL: server.URL})
+	err := client.Ready(context.Background())
+	if err == nil {
+		t.Fatal("expected error for unhealthy enclave")
+	}
+}
+
+func TestClientReady_Unreachable(t *testing.T) {
+	client := New(Config{BaseURL: "http://127.0.0.1:1"})
+	err := client.Ready(context.Background())
+	if err == nil {
+		t.Fatal("expected error for unreachable enclave")
+	}
+}

--- a/internal/enclave/local/client.go
+++ b/internal/enclave/local/client.go
@@ -256,6 +256,11 @@ func (c *Client) EscrowRevoke(_ context.Context, req enclave.EscrowRevokeRequest
 	return c.escrow.Revoke(req.EscrowID, req.GrantID)
 }
 
+// Ready always returns nil for the local client since it runs in-process.
+func (c *Client) Ready(_ context.Context) error {
+	return nil
+}
+
 // Close zeros the session key, KEKs, and clears the escrow store.
 func (c *Client) Close() error {
 	c.mu.Lock()

--- a/internal/enclave/local/client_test.go
+++ b/internal/enclave/local/client_test.go
@@ -752,3 +752,10 @@ func TestNewDefaultTTLs(t *testing.T) {
 		t.Fatalf("default keks.ttl = %v, want 24h", c.keks.ttl)
 	}
 }
+
+func TestClient_Ready(t *testing.T) {
+	c := New(nil)
+	if err := c.Ready(context.Background()); err != nil {
+		t.Fatalf("Ready: %v (local client should always be ready)", err)
+	}
+}

--- a/internal/vault/escrow_vault_test.go
+++ b/internal/vault/escrow_vault_test.go
@@ -42,7 +42,8 @@ func (m *mockEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowListRes
 func (m *mockEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
 	return nil
 }
-func (m *mockEnclaveClient) Close() error { return nil }
+func (m *mockEnclaveClient) Ready(_ context.Context) error { return nil }
+func (m *mockEnclaveClient) Close() error                  { return nil }
 
 func TestEscrowVault_Get_EscrowHit(t *testing.T) {
 	client := &mockEnclaveClient{


### PR DESCRIPTION
## Summary

- **`Ready(ctx) error`** added to `enclave.Client` interface — GCS client hits `GET /health`, local client always returns nil
- **Server health endpoint** returns 503 when TEE is configured but enclave is unreachable, preventing Railway from routing traffic to unready replicas
- **Fail-fast on enclave-dependent operations**: OAuth callback, execution handler, and Slack agent check readiness before proceeding
- **Slack agent**: shows "Aileron is still starting up" message instead of generic vault-locked error when enclave is down
- **Docker compose**: enclave gets a healthcheck (`wget /health`), server depends on `service_healthy` instead of `service_started`

## Test plan

- [x] `Ready()` tests for GCS client: healthy, unhealthy (500), unreachable
- [x] `Ready()` test for local client: always ready
- [x] Health endpoint: 200 with no enclave, 200 with healthy enclave, 503 with failing enclave
- [x] `requireEnclave`: returns true when no enclave, true when healthy, false+503 when down
- [x] All existing tests pass (5 test stubs updated for new interface method)
- [x] Race detector clean

Closes #306

🤖 Generated with [Claude Code](https://claude.com/claude-code)