### PR TITLE
fix: surface auth failures to user instead of swallowing silently

### DIFF
--- a/internal/app/handlers_slack_agent.go
+++ b/internal/app/handlers_slack_agent.go
@@ -10,6 +10,7 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/comms"
 	"github.com/ALRubinger/aileron/internal/draft"
+	"github.com/ALRubinger/aileron/internal/source"
 	"github.com/ALRubinger/aileron/internal/vault"
 	"github.com/slack-go/slack"
 )
@@ -91,9 +92,10 @@ func (s *apiServer) vaultLockedSlackMessage() string {
 }
 
 // isVaultError checks whether err indicates that vault credentials are
-// unavailable (locked vault or stale escrow).
+// unavailable (locked vault, stale escrow, or expired OAuth tokens).
 func isVaultError(err error) bool {
-	return errors.Is(err, vault.ErrCredentialUnavailable)
+	return errors.Is(err, vault.ErrCredentialUnavailable) ||
+		errors.Is(err, source.ErrAuthFailed)
 }
 
 // handleAssistantThreadStarted is called when a user opens the Aileron agent DM.

--- a/internal/app/handlers_slack_agent_test.go
+++ b/internal/app/handlers_slack_agent_test.go
@@ -1253,6 +1253,15 @@ func TestIsVaultError_FalseForOtherErrors(t *testing.T) {
 	}
 }
 
+func TestIsVaultError_MatchesAuthFailed(t *testing.T) {
+	// Auth failures (e.g. expired OAuth tokens) should be treated as vault
+	// errors so the handler sends the unlock message to the user.
+	wrapped := fmt.Errorf("credentials expired for gmail: %w", source.ErrAuthFailed)
+	if !isVaultError(wrapped) {
+		t.Error("expected isVaultError to return true for wrapped ErrAuthFailed")
+	}
+}
+
 func TestHandleAssistantMessage_VaultLocked_PostsUnlockMessage(t *testing.T) {
 	srv, agent := newAgentTestServer()
 	ctx := context.Background()

--- a/internal/draft/pipeline.go
+++ b/internal/draft/pipeline.go
@@ -19,6 +19,7 @@ import (
 	"fmt"
 	"log/slog"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/comms"
@@ -148,7 +149,8 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 		"total_tools", len(tools),
 	)
 
-	executor := p.buildToolExecutor(ctx, userID, accounts)
+	authTracker := &authErrorTracker{}
+	executor := p.buildToolExecutor(ctx, userID, accounts, authTracker)
 
 	// --- Round 1: Research ---
 	// The LLM gathers context using tools. Its output is a structured
@@ -194,6 +196,17 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 		}
 	} else {
 		gatheredContext = "(No source connectors available — replying with general knowledge only.)"
+	}
+
+	// If any providers had auth failures, propagate so the handler can
+	// tell the user to re-authenticate — even if other providers succeeded.
+	if failedProviders := authTracker.failed(); len(failedProviders) > 0 {
+		p.log.Warn("providers with auth failures",
+			"user_id", userID,
+			"providers", failedProviders,
+		)
+		return "", fmt.Errorf("research round: credentials expired for %s: %w",
+			strings.Join(failedProviders, ", "), source.ErrAuthFailed)
 	}
 
 	p.log.Debug("gathered context for ghostwriter",
@@ -298,7 +311,8 @@ func (p *Pipeline) GenerateDraftStream(ctx context.Context, userID string, msg c
 			}
 		}
 
-		executor := p.buildToolExecutor(ctx, userID, accounts)
+		authTracker := &authErrorTracker{}
+		executor := p.buildToolExecutor(ctx, userID, accounts, authTracker)
 		now := p.clock()
 
 		var gatheredContext string
@@ -324,6 +338,18 @@ func (p *Pipeline) GenerateDraftStream(ctx context.Context, userID string, msg c
 			}
 		} else {
 			gatheredContext = "(No source connectors available — replying with general knowledge only.)"
+		}
+
+		// If any providers had auth failures, propagate so the handler can
+		// tell the user to re-authenticate.
+		if failedProviders := authTracker.failed(); len(failedProviders) > 0 {
+			p.log.Warn("providers with auth failures",
+				"user_id", userID,
+				"providers", failedProviders,
+			)
+			errCh <- fmt.Errorf("research round: credentials expired for %s: %w",
+				strings.Join(failedProviders, ", "), source.ErrAuthFailed)
+			return
 		}
 
 		// --- Ghostwrite round: stream if possible ---
@@ -567,7 +593,27 @@ func filterReplayable(calls []llm.ToolCall) []llm.ToolCall {
 
 // buildToolExecutor creates a closure that resolves credentials from the vault
 // and dispatches tool calls to the source connector registry.
-func (p *Pipeline) buildToolExecutor(ctx context.Context, userID string, accounts []model.ConnectedAccount) llm.ToolExecutor {
+// authErrorTracker records providers that returned authentication errors
+// during tool execution. This allows the research round to continue with
+// working providers while still surfacing the auth failures afterward.
+type authErrorTracker struct {
+	mu        sync.Mutex
+	providers []string // providers that returned ErrAuthFailed
+}
+
+func (t *authErrorTracker) record(provider string) {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	t.providers = append(t.providers, provider)
+}
+
+func (t *authErrorTracker) failed() []string {
+	t.mu.Lock()
+	defer t.mu.Unlock()
+	return append([]string(nil), t.providers...)
+}
+
+func (p *Pipeline) buildToolExecutor(ctx context.Context, userID string, accounts []model.ConnectedAccount, authTracker *authErrorTracker) llm.ToolExecutor {
 	return func(execCtx context.Context, tool string, params map[string]any) (map[string]any, error) {
 		if p.sourceRegistry == nil {
 			return nil, fmt.Errorf("no source registry configured")
@@ -625,11 +671,13 @@ func (p *Pipeline) buildToolExecutor(ctx context.Context, userID string, account
 
 		result, execErr := p.sourceRegistry.ExecuteTool(execCtx, tool, params, secret.Value)
 		if execErr != nil {
-			// Auth failures are unrecoverable — every subsequent call will
-			// fail too. Wrap as fatal so the LLM loop aborts and the handler
-			// can tell the user to reconnect.
 			if errors.Is(execErr, source.ErrAuthFailed) {
-				return nil, &llm.ToolFatalError{Err: execErr}
+				// Auth failure for this provider — record it so we can
+				// surface it to the user after research completes, but
+				// don't abort the loop. Other providers may still work.
+				authTracker.record(provider)
+				p.log.Warn("tool auth failed, continuing with other providers",
+					"tool", tool, "provider", provider, "error", execErr)
 			}
 			p.log.Error("tool execution failed", "tool", tool, "provider", provider, "error", execErr)
 		} else {

--- a/internal/draft/pipeline_test.go
+++ b/internal/draft/pipeline_test.go
@@ -1244,11 +1244,35 @@ func (m *authFailSourceConnector) Execute(_ context.Context, _ string, _ map[str
 	return nil, fmt.Errorf("googleapi: Error 401: Invalid Credentials: %w", source.ErrAuthFailed)
 }
 
-func TestPipeline_GenerateDraft_ToolExecutor_AuthFailed(t *testing.T) {
+// toolCallingLLMClient invokes the ToolExecutor for a configured tool name
+// during the research round, then returns the ghostwrite response.
+type toolCallingLLMClient struct {
+	toolName       string
+	toolParams     map[string]any
+	ghostwriteResp *llm.GenerateResponse
+}
+
+func (m *toolCallingLLMClient) GenerateWithTools(_ context.Context, req llm.GenerateRequest) (*llm.GenerateResponse, error) {
+	if len(req.Tools) > 0 && req.ToolExecutor != nil {
+		// Simulate the LLM requesting a tool call.
+		_, err := req.ToolExecutor(context.Background(), m.toolName, m.toolParams)
+		if err != nil {
+			// Non-fatal errors are fed back to the LLM in the real loop;
+			// here we just return whatever text we have.
+			return &llm.GenerateResponse{Text: "partial context"}, nil
+		}
+		return &llm.GenerateResponse{Text: "context gathered"}, nil
+	}
+	return m.ghostwriteResp, nil
+}
+
+func TestPipeline_GenerateDraft_AuthFailed_Propagates(t *testing.T) {
 	// When a source connector returns source.ErrAuthFailed (e.g. Google 401),
-	// the tool executor should return a ToolFatalError so the LLM loop aborts.
-	mock := &mockLLMClient{
-		researchResp:   &llm.GenerateResponse{Text: "context gathered"},
+	// the pipeline should propagate the error so the handler can tell the
+	// user to re-authenticate — not swallow it with a generic placeholder.
+	mock := &toolCallingLLMClient{
+		toolName:       "slack_channel_history",
+		toolParams:     map[string]any{"channel": "C123"},
 		ghostwriteResp: &llm.GenerateResponse{Text: "draft"},
 	}
 
@@ -1271,30 +1295,51 @@ func TestPipeline_GenerateDraft_ToolExecutor_AuthFailed(t *testing.T) {
 	_, err := p.GenerateDraft(ctx, "usr_1", comms.IncomingMessage{
 		ID: "msg_1", Service: "slack", Channel: "#test", Author: "Alice", Body: "hi",
 	})
-	if err != nil {
-		t.Fatalf("unexpected top-level error: %v", err)
+	if err == nil {
+		t.Fatal("expected error from auth failure, got nil")
+	}
+	if !errors.Is(err, source.ErrAuthFailed) {
+		t.Errorf("expected error to wrap source.ErrAuthFailed, got: %v", err)
+	}
+}
+
+func TestPipeline_GenerateDraftStream_AuthFailed_Propagates(t *testing.T) {
+	// Streaming path: when a source connector returns ErrAuthFailed,
+	// the error should appear on errCh so the handler can notify the user.
+	mock := &toolCallingLLMClient{
+		toolName:       "slack_channel_history",
+		toolParams:     map[string]any{"channel": "C123"},
+		ghostwriteResp: &llm.GenerateResponse{Text: "draft"},
 	}
 
-	// Extract the tool executor from the research round.
-	if len(mock.requests) < 1 {
-		t.Fatal("expected at least 1 LLM call")
-	}
-	researchReq := mock.requests[0]
-	if researchReq.ToolExecutor == nil {
-		t.Fatal("expected ToolExecutor in research round")
-	}
+	accounts := mem.NewConnectedAccountStore()
+	ctx := context.Background()
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_s1", UserID: "usr_1", Provider: "slack",
+		Status: model.ConnectedAccountStatusActive,
+	})
 
-	// Execute a tool — should return a ToolFatalError wrapping ErrAuthFailed.
-	_, execErr := researchReq.ToolExecutor(ctx, "slack_channel_history", map[string]any{"channel": "C123"})
-	if execErr == nil {
-		t.Fatal("expected error from auth failure")
-	}
+	sourceReg := source.NewRegistry()
+	sourceReg.Register(&authFailSourceConnector{})
 
-	var fatal *llm.ToolFatalError
-	if !errors.As(execErr, &fatal) {
-		t.Fatalf("expected *llm.ToolFatalError, got %T: %v", execErr, execErr)
+	v := vault.NewMemVault()
+	v.Put(ctx, "connected-accounts/usr_1/slack", []byte(`{"access_token":"test"}`), vault.Metadata{})
+
+	p := draft.NewPipeline(mock, mock, sourceReg, accounts, mem.NewUserInstructionStore(),
+		v, slog.Default(), draft.Prompts{Research: "test", Ghostwrite: "test"})
+
+	chunkCh, errCh := p.GenerateDraftStream(ctx, "usr_1", comms.IncomingMessage{
+		ID: "msg_1", Service: "slack", Channel: "#test", Author: "Alice", Body: "hi",
+	})
+
+	// Drain chunks.
+	for range chunkCh {
 	}
-	if !errors.Is(fatal.Err, source.ErrAuthFailed) {
-		t.Errorf("expected ToolFatalError to wrap ErrAuthFailed, got: %v", fatal.Err)
+	err := <-errCh
+	if err == nil {
+		t.Fatal("expected error from auth failure on errCh, got nil")
+	}
+	if !errors.Is(err, source.ErrAuthFailed) {
+		t.Errorf("expected error wrapping ErrAuthFailed, got: %v", err)
 	}
 }


### PR DESCRIPTION
## Summary

- Stop wrapping `ErrAuthFailed` as `ToolFatalError` — track per-provider auth failures via `authErrorTracker` so the LLM loop continues with working providers
- Propagate `ErrAuthFailed` after research completes so the handler sends the vault-unlock message instead of a vague "let me check" response
- Expand `isVaultError()` to recognize `source.ErrAuthFailed` alongside `vault.ErrCredentialUnavailable`

Fixes phase 1 of #311.

## Test plan

- [x] `TestPipeline_GenerateDraft_AuthFailed_Propagates` — verifies `GenerateDraft` propagates `ErrAuthFailed`
- [x] `TestPipeline_GenerateDraftStream_AuthFailed_Propagates` — same for streaming path
- [x] `TestIsVaultError_MatchesAuthFailed` — verifies handler recognizes auth errors
- [x] All existing tests pass (85.4% draft coverage, 74.6% app coverage)
- [ ] Deploy and verify: Slack agent shows vault-unlock message on expired Google credentials

🤖 Generated with [Claude Code](https://claude.com/claude-code)