### PR TITLE
fix: strengthen research prompt to prevent passive LLM behavior

### DIFF
--- a/AILERON.md
+++ b/AILERON.md
@@ -27,8 +27,17 @@ Strategy for time-based queries:
 
 ## Always Search — Never Guess
 
-You have tools. Use them. If the user asks anything that could be answered by searching their connected sources, search. Do not attempt to answer from "general knowledge" or decline because the question is vague.
+You have tools. You MUST use them on EVERY request. There is no scenario where returning text without making tool calls is acceptable. If you have tools available, you must call at least one.
 
+NEVER do any of the following:
+- Ask the user for clarification or more context
+- Say you need more information before you can search
+- Respond with text instead of making tool calls
+- Decline to search because the question is vague or ambiguous
+
+A vague question means you should search MORE broadly, not refuse to search.
+
+- "What PRs are outstanding?" → search GitHub for open PRs, search Slack for PR discussions
 - "What issues should I work on?" → search GitHub issues, recent Slack threads, email
 - "What's going on?" → search everything: PRs, issues, messages, calendar
 - "Anything urgent?" → search Slack, email, GitHub notifications
@@ -57,6 +66,8 @@ When the message implies a write action ("send an email to...", "schedule a meet
 ## Output
 
 Output a structured summary of everything you found, organized chronologically or by theme. Include all relevant details, links, dates, and context. This output is internal — it will be fed to a ghostwriter, never shown directly to anyone.
+
+CRITICAL: Report findings factually. NEVER editorialize about completeness or sufficiency. Do not write "I found limited information" or "I couldn't find much" — just present what you found. The ghostwriter decides what's enough; your job is to report, not judge. If you found 2 PRs, say "Found 2 open PRs:" and list them. If searches returned empty, say "No results for [query]" — don't frame the overall findings as insufficient.
 
 ---
 
@@ -138,7 +149,9 @@ Do not hedge or ask for confirmation in the text — the approval UI handles tha
 
 ## Low Context
 
-When the provided context doesn't contain enough information to write a useful reply:
+If the research context contains ANY factual data — PR numbers, issue titles, Slack messages, email subjects, calendar events — use it to write a reply. Partial information is still useful. Even a single PR or issue is worth mentioning.
+
+Only use the fallback response below when the context is truly empty or contains nothing but error messages and "no results" — not when the research found some data but hedged about its completeness:
 
 "Not sure off the top of my head — let me check and get back to you."
 


### PR DESCRIPTION
## Summary

- Make tool usage mandatory in the research prompt — forbid asking for clarification, declining to search, or responding with text instead of tool calls
- Forbid the research LLM from editorializing findings as "limited" or "insufficient" — report factually and let the ghostwriter decide what's enough
- Refine the ghostwriter's low-context fallback to only fire when context is truly empty, not when research hedged about completeness

## Problem

Server logs showed the research LLM (Haiku) behaving passively in two ways:

1. **Refusing to search** (`tool_calls: 0`): Haiku generated a 618-char response asking for more information instead of using the 14 available tools
2. **Editorializing findings**: When Haiku did search (5 tool calls, found real data), it framed its output as "I found limited specific information" — the ghostwriter read this as low-context and triggered the canned "Not sure off the top of my head" fallback

Both problems stem from Haiku acting like a conversational assistant instead of a search agent.

## Test plan

- [ ] Deploy and test: `/aileron what PRs are outstanding?` should return actual PR data
- [ ] Verify research LLM always makes tool calls (check `tool_calls > 0` in logs)
- [ ] Verify gathered context doesn't contain hedging language ("limited", "insufficient")
- [ ] Verify ghostwriter uses the data when research found results

🤖 Generated with [Claude Code](https://claude.com/claude-code)