### PR TITLE
fix: distinguish vault-locked from auth-expired error messages

### DIFF
--- a/internal/app/handlers_slack_agent.go
+++ b/internal/app/handlers_slack_agent.go
@@ -100,11 +100,12 @@ func (s *apiServer) vaultLockedSlackMessage() string {
 // credentialErrorMessage returns the appropriate Slack message for a
 // credential-related error: vault-locked vs. auth-expired.
 func (s *apiServer) credentialErrorMessage(err error) string {
+	var authErr *source.AuthFailedError
+	if errors.As(err, &authErr) {
+		services := formatProviderNames(authErr.Providers)
+		return ":warning: Your " + services + " connection has expired. Please <" + s.vaultUnlockURL() + "|reconnect it> in your connected accounts."
+	}
 	if errors.Is(err, source.ErrAuthFailed) {
-		services := extractExpiredServices(err.Error())
-		if services != "" {
-			return ":warning: Your " + services + " connection has expired. Please <" + s.vaultUnlockURL() + "|reconnect it> in your connected accounts."
-		}
 		return ":warning: One or more connected accounts have expired credentials. Please <" + s.vaultUnlockURL() + "|reconnect them> in your connected accounts."
 	}
 	return s.vaultLockedSlackMessage()
@@ -118,29 +119,11 @@ var providerDisplayNames = map[string]string{
 	"github_repos":    "GitHub",
 }
 
-// extractExpiredServices parses provider names from an error like
-// "credentials expired for gmail, gmail, google_calendar: source: ..."
-// and returns a deduplicated, human-readable string like "Gmail and Google Calendar".
-func extractExpiredServices(errMsg string) string {
-	const prefix = "credentials expired for "
-	idx := strings.Index(errMsg, prefix)
-	if idx < 0 {
-		return ""
-	}
-	rest := errMsg[idx+len(prefix):]
-	if colonIdx := strings.Index(rest, ":"); colonIdx >= 0 {
-		rest = rest[:colonIdx]
-	}
-
-	// Deduplicate and map to display names.
-	seen := make(map[string]bool)
-	var names []string
-	for _, p := range strings.Split(rest, ", ") {
-		p = strings.TrimSpace(p)
-		if p == "" || seen[p] {
-			continue
-		}
-		seen[p] = true
+// formatProviderNames converts provider IDs to a human-readable string
+// like "Gmail and Google Calendar".
+func formatProviderNames(providers []string) string {
+	names := make([]string, 0, len(providers))
+	for _, p := range providers {
 		if display, ok := providerDisplayNames[p]; ok {
 			names = append(names, display)
 		} else {
@@ -150,7 +133,7 @@ func extractExpiredServices(errMsg string) string {
 
 	switch len(names) {
 	case 0:
-		return ""
+		return "unknown service"
 	case 1:
 		return names[0]
 	case 2:

--- a/internal/app/handlers_slack_agent.go
+++ b/internal/app/handlers_slack_agent.go
@@ -97,6 +97,22 @@ func (s *apiServer) vaultLockedSlackMessage() string {
 	return ":lock: Your Aileron session has expired. <" + s.vaultUnlockURL() + "|Unlock your vault> to reconnect your accounts (takes 10 seconds, lasts 7 days)."
 }
 
+// authExpiredSlackMessage returns a message telling the user to reconnect
+// their account when OAuth tokens have been revoked or expired at the
+// provider (e.g. Google's 7-day testing mode limit).
+func (s *apiServer) authExpiredSlackMessage() string {
+	return ":warning: One or more connected accounts have expired credentials. Please <" + s.vaultUnlockURL() + "|visit your connected accounts> and reconnect the affected service."
+}
+
+// credentialErrorMessage returns the appropriate Slack message for a
+// credential-related error: vault-locked vs. auth-expired.
+func (s *apiServer) credentialErrorMessage(err error) string {
+	if errors.Is(err, source.ErrAuthFailed) {
+		return s.authExpiredSlackMessage()
+	}
+	return s.vaultLockedSlackMessage()
+}
+
 // newEnclaveSourceExecutor returns a SourceExecutor that delegates tool
 // execution to the TEE enclave. Credentials never leave the enclave —
 // only the tool results are returned to the host.
@@ -240,7 +256,7 @@ func (s *apiServer) handleAssistantMessage(ctx context.Context, teamID, channelI
 	if err := <-errCh; err != nil {
 		s.log.Error("agent message: pipeline error", "user_id", userID, "error", err)
 		if isVaultError(err) {
-			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS, s.vaultLockedSlackMessage())
+			_ = s.slackAgentClient.PostMessage(ctx, botToken, channelID, threadTS, s.credentialErrorMessage(err))
 		}
 		_ = s.slackAgentClient.SetStatus(ctx, botToken, channelID, threadTS, "")
 		return
@@ -390,7 +406,7 @@ func (s *apiServer) generateDraftFromInstructions(ctx context.Context, viewID st
 	if err != nil {
 		s.log.Error("draft from instructions: generation failed", "error", err)
 		if isVaultError(err) {
-			_ = updateDraftModalError(ctx, botToken, viewID, s.vaultLockedSlackMessage(), meta)
+			_ = updateDraftModalError(ctx, botToken, viewID, s.credentialErrorMessage(err), meta)
 		} else {
 			_ = updateDraftModalError(ctx, botToken, viewID, "Draft generation failed. Please try again.", meta)
 		}

--- a/internal/app/handlers_slack_agent.go
+++ b/internal/app/handlers_slack_agent.go
@@ -97,20 +97,67 @@ func (s *apiServer) vaultLockedSlackMessage() string {
 	return ":lock: Your Aileron session has expired. <" + s.vaultUnlockURL() + "|Unlock your vault> to reconnect your accounts (takes 10 seconds, lasts 7 days)."
 }
 
-// authExpiredSlackMessage returns a message telling the user to reconnect
-// their account when OAuth tokens have been revoked or expired at the
-// provider (e.g. Google's 7-day testing mode limit).
-func (s *apiServer) authExpiredSlackMessage() string {
-	return ":warning: One or more connected accounts have expired credentials. Please <" + s.vaultUnlockURL() + "|visit your connected accounts> and reconnect the affected service."
-}
-
 // credentialErrorMessage returns the appropriate Slack message for a
 // credential-related error: vault-locked vs. auth-expired.
 func (s *apiServer) credentialErrorMessage(err error) string {
 	if errors.Is(err, source.ErrAuthFailed) {
-		return s.authExpiredSlackMessage()
+		services := extractExpiredServices(err.Error())
+		if services != "" {
+			return ":warning: Your " + services + " connection has expired. Please <" + s.vaultUnlockURL() + "|reconnect it> in your connected accounts."
+		}
+		return ":warning: One or more connected accounts have expired credentials. Please <" + s.vaultUnlockURL() + "|reconnect them> in your connected accounts."
 	}
 	return s.vaultLockedSlackMessage()
+}
+
+// providerDisplayNames maps internal provider names to user-facing names.
+var providerDisplayNames = map[string]string{
+	"gmail":           "Gmail",
+	"google_calendar": "Google Calendar",
+	"slack":           "Slack",
+	"github_repos":    "GitHub",
+}
+
+// extractExpiredServices parses provider names from an error like
+// "credentials expired for gmail, gmail, google_calendar: source: ..."
+// and returns a deduplicated, human-readable string like "Gmail and Google Calendar".
+func extractExpiredServices(errMsg string) string {
+	const prefix = "credentials expired for "
+	idx := strings.Index(errMsg, prefix)
+	if idx < 0 {
+		return ""
+	}
+	rest := errMsg[idx+len(prefix):]
+	if colonIdx := strings.Index(rest, ":"); colonIdx >= 0 {
+		rest = rest[:colonIdx]
+	}
+
+	// Deduplicate and map to display names.
+	seen := make(map[string]bool)
+	var names []string
+	for _, p := range strings.Split(rest, ", ") {
+		p = strings.TrimSpace(p)
+		if p == "" || seen[p] {
+			continue
+		}
+		seen[p] = true
+		if display, ok := providerDisplayNames[p]; ok {
+			names = append(names, display)
+		} else {
+			names = append(names, p)
+		}
+	}
+
+	switch len(names) {
+	case 0:
+		return ""
+	case 1:
+		return names[0]
+	case 2:
+		return names[0] + " and " + names[1]
+	default:
+		return strings.Join(names[:len(names)-1], ", ") + ", and " + names[len(names)-1]
+	}
 }
 
 // newEnclaveSourceExecutor returns a SourceExecutor that delegates tool

--- a/internal/app/handlers_slack_agent_test.go
+++ b/internal/app/handlers_slack_agent_test.go
@@ -1638,6 +1638,64 @@ func waitFor(ms int) <-chan struct{} {
 	return ch
 }
 
+func TestExtractExpiredServices(t *testing.T) {
+	tests := []struct {
+		name string
+		err  string
+		want string
+	}{
+		{
+			name: "single provider",
+			err:  "research round: credentials expired for gmail: source: authentication failed",
+			want: "Gmail",
+		},
+		{
+			name: "two providers deduplicated",
+			err:  "research round: credentials expired for gmail, gmail, google_calendar: source: authentication failed",
+			want: "Gmail and Google Calendar",
+		},
+		{
+			name: "three providers",
+			err:  "research round: credentials expired for gmail, slack, github_repos: source: authentication failed",
+			want: "Gmail, Slack, and GitHub",
+		},
+		{
+			name: "no match",
+			err:  "some other error",
+			want: "",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got := extractExpiredServices(tt.err)
+			if got != tt.want {
+				t.Errorf("extractExpiredServices(%q) = %q, want %q", tt.err, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestCredentialErrorMessage_AuthFailed(t *testing.T) {
+	srv := &apiServer{uiBaseURL: "https://app.test"}
+	err := fmt.Errorf("research round: credentials expired for gmail, google_calendar: %w", source.ErrAuthFailed)
+	msg := srv.credentialErrorMessage(err)
+	if !strings.Contains(msg, "Gmail and Google Calendar") {
+		t.Errorf("expected message to mention services, got: %s", msg)
+	}
+	if !strings.Contains(msg, "reconnect") {
+		t.Errorf("expected message to say reconnect, got: %s", msg)
+	}
+}
+
+func TestCredentialErrorMessage_VaultLocked(t *testing.T) {
+	srv := &apiServer{uiBaseURL: "https://app.test"}
+	err := fmt.Errorf("vault locked: %w", vault.ErrCredentialUnavailable)
+	msg := srv.credentialErrorMessage(err)
+	if !strings.Contains(msg, "Unlock your vault") {
+		t.Errorf("expected vault-locked message, got: %s", msg)
+	}
+}
+
 func TestNewEnclaveSourceExecutor_HappyPath(t *testing.T) {
 	resultJSON, _ := json.Marshal(map[string]any{"messages": []string{"hello"}})
 	client := &sourceExecuteEnclaveClient{

--- a/internal/app/handlers_slack_agent_test.go
+++ b/internal/app/handlers_slack_agent_test.go
@@ -1638,52 +1638,49 @@ func waitFor(ms int) <-chan struct{} {
 	return ch
 }
 
-func TestExtractExpiredServices(t *testing.T) {
+func TestFormatProviderNames(t *testing.T) {
 	tests := []struct {
-		name string
-		err  string
-		want string
+		name      string
+		providers []string
+		want      string
 	}{
-		{
-			name: "single provider",
-			err:  "research round: credentials expired for gmail: source: authentication failed",
-			want: "Gmail",
-		},
-		{
-			name: "two providers deduplicated",
-			err:  "research round: credentials expired for gmail, gmail, google_calendar: source: authentication failed",
-			want: "Gmail and Google Calendar",
-		},
-		{
-			name: "three providers",
-			err:  "research round: credentials expired for gmail, slack, github_repos: source: authentication failed",
-			want: "Gmail, Slack, and GitHub",
-		},
-		{
-			name: "no match",
-			err:  "some other error",
-			want: "",
-		},
+		{"single", []string{"gmail"}, "Gmail"},
+		{"two", []string{"gmail", "google_calendar"}, "Gmail and Google Calendar"},
+		{"three", []string{"gmail", "slack", "github_repos"}, "Gmail, Slack, and GitHub"},
+		{"unknown", []string{"some_new_provider"}, "some_new_provider"},
+		{"empty", nil, "unknown service"},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			got := extractExpiredServices(tt.err)
+			got := formatProviderNames(tt.providers)
 			if got != tt.want {
-				t.Errorf("extractExpiredServices(%q) = %q, want %q", tt.err, got, tt.want)
+				t.Errorf("formatProviderNames(%v) = %q, want %q", tt.providers, got, tt.want)
 			}
 		})
 	}
 }
 
-func TestCredentialErrorMessage_AuthFailed(t *testing.T) {
+func TestCredentialErrorMessage_AuthFailedWithProviders(t *testing.T) {
 	srv := &apiServer{uiBaseURL: "https://app.test"}
-	err := fmt.Errorf("research round: credentials expired for gmail, google_calendar: %w", source.ErrAuthFailed)
+	err := fmt.Errorf("research round: %w", &source.AuthFailedError{
+		Providers: []string{"gmail", "google_calendar"},
+	})
 	msg := srv.credentialErrorMessage(err)
 	if !strings.Contains(msg, "Gmail and Google Calendar") {
 		t.Errorf("expected message to mention services, got: %s", msg)
 	}
 	if !strings.Contains(msg, "reconnect") {
 		t.Errorf("expected message to say reconnect, got: %s", msg)
+	}
+}
+
+func TestCredentialErrorMessage_AuthFailedSentinel(t *testing.T) {
+	// Bare ErrAuthFailed without AuthFailedError — fallback message.
+	srv := &apiServer{uiBaseURL: "https://app.test"}
+	err := fmt.Errorf("something: %w", source.ErrAuthFailed)
+	msg := srv.credentialErrorMessage(err)
+	if !strings.Contains(msg, "One or more") {
+		t.Errorf("expected generic auth message, got: %s", msg)
 	}
 }
 

--- a/internal/app/handlers_slack_commands.go
+++ b/internal/app/handlers_slack_commands.go
@@ -112,7 +112,7 @@ func (s *apiServer) processSlashCommandDraft(ctx context.Context, teamID, slackU
 	if err != nil {
 		s.log.Error("slash command draft: generation failed", "error", err)
 		if isVaultError(err) {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.vaultLockedSlackMessage(), meta)
+			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.credentialErrorMessage(err), meta)
 		} else {
 			_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation failed. Please try again.", meta)
 		}
@@ -151,7 +151,7 @@ func (s *apiServer) processSlashCommandQuestion(ctx context.Context, teamID, sla
 	if err != nil {
 		s.log.Error("slash command question: generation failed", "error", err)
 		if isVaultError(err) {
-			s.respondViaURL(responseURL, s.vaultLockedSlackMessage())
+			s.respondViaURL(responseURL, s.credentialErrorMessage(err))
 		} else {
 			s.respondViaURL(responseURL, "> /aileron "+text+"\n\nSomething went wrong. Please try again.")
 		}

--- a/internal/draft/pipeline.go
+++ b/internal/draft/pipeline.go
@@ -222,8 +222,9 @@ func (p *Pipeline) GenerateDraft(ctx context.Context, userID string, msg comms.I
 			"user_id", userID,
 			"providers", failedProviders,
 		)
-		return "", fmt.Errorf("research round: credentials expired for %s: %w",
-			strings.Join(failedProviders, ", "), source.ErrAuthFailed)
+		return "", fmt.Errorf("research round: %w", &source.AuthFailedError{
+			Providers: dedupStrings(failedProviders),
+		})
 	}
 
 	p.log.Debug("gathered context for ghostwriter",
@@ -364,8 +365,9 @@ func (p *Pipeline) GenerateDraftStream(ctx context.Context, userID string, msg c
 				"user_id", userID,
 				"providers", failedProviders,
 			)
-			errCh <- fmt.Errorf("research round: credentials expired for %s: %w",
-				strings.Join(failedProviders, ", "), source.ErrAuthFailed)
+			errCh <- fmt.Errorf("research round: %w", &source.AuthFailedError{
+				Providers: dedupStrings(failedProviders),
+			})
 			return
 		}
 
@@ -742,4 +744,16 @@ func truncate(s string, max int) string {
 		return s
 	}
 	return s[:max] + "..."
+}
+
+func dedupStrings(ss []string) []string {
+	seen := make(map[string]bool, len(ss))
+	out := make([]string, 0, len(ss))
+	for _, s := range ss {
+		if !seen[s] {
+			seen[s] = true
+			out = append(out, s)
+		}
+	}
+	return out
 }

--- a/internal/source/spi.go
+++ b/internal/source/spi.go
@@ -14,6 +14,8 @@ package source
 import (
 	"context"
 	"errors"
+	"fmt"
+	"strings"
 )
 
 // SourceConnector retrieves context from an external system.
@@ -42,9 +44,21 @@ type ToolDefinition struct {
 }
 
 // ErrAuthFailed indicates that a connector's credentials are invalid, expired,
-// or revoked. The pipeline should treat this as fatal and abort the LLM loop
-// so the handler can tell the user to reconnect.
+// or revoked. Used as a sentinel for errors.Is checks.
 var ErrAuthFailed = errors.New("source: authentication failed")
+
+// AuthFailedError is a structured error that carries the names of providers
+// whose credentials failed. Use errors.Is(err, ErrAuthFailed) to detect it,
+// then errors.As(err, &authErr) to extract the provider list.
+type AuthFailedError struct {
+	Providers []string // deduplicated provider names that failed
+}
+
+func (e *AuthFailedError) Error() string {
+	return fmt.Sprintf("credentials expired for %s: %s", strings.Join(e.Providers, ", "), ErrAuthFailed)
+}
+
+func (e *AuthFailedError) Unwrap() error { return ErrAuthFailed }
 
 // TokenSaver persists a refreshed OAuth token back to the vault.
 type TokenSaver func(ctx context.Context, newToken []byte) error


### PR DESCRIPTION
## Summary

- When OAuth tokens are revoked/expired at the provider, show "credentials have expired, please reconnect" instead of the misleading "unlock your vault"
- Add `credentialErrorMessage(err)` that checks the error type and returns the appropriate message
- `ErrCredentialUnavailable` → vault-locked message (unlock your vault)
- `ErrAuthFailed` → auth-expired message (reconnect the affected service)

## Problem

When Google OAuth tokens expire (e.g. 7-day testing mode limit), the vault IS unlocked and the token IS escrowed — the token itself is dead at Google's end. Telling the user to "unlock your vault" is confusing and wrong. They need to disconnect and reconnect the affected service.

## Test plan

- [x] All existing tests pass
- [ ] Trigger an auth failure (expired Google token) → verify new message shown
- [ ] Trigger a vault-locked condition (no KEK) → verify original message shown

🤖 Generated with [Claude Code](https://claude.com/claude-code)