### PR TITLE
fix(github): paginate search results instead of truncating at 10

### DIFF
--- a/internal/source/github/connector.go
+++ b/internal/source/github/connector.go
@@ -7,11 +7,17 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"log/slog"
 	"strconv"
 
 	"github.com/ALRubinger/aileron/internal/source"
 	gh "github.com/google/go-github/v69/github"
 	"golang.org/x/oauth2"
+)
+
+const (
+	searchPerPage  = 100 // GitHub Search API maximum
+	searchMaxPages = 5   // ceiling: 500 results
 )
 
 // Connector implements source.SourceConnector for GitHub.
@@ -124,23 +130,44 @@ func (c *Connector) searchCode(ctx context.Context, client *gh.Client, params ma
 		query = query + " repo:" + repo
 	}
 
-	result, _, err := client.Search.Code(ctx, query, &gh.SearchOptions{
-		ListOptions: gh.ListOptions{PerPage: 10},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("github API error: %w", err)
+	opts := &gh.SearchOptions{
+		ListOptions: gh.ListOptions{PerPage: searchPerPage, Page: 1},
+	}
+	var items []map[string]any
+	var total int
+	for {
+		result, resp, err := client.Search.Code(ctx, query, opts)
+		if err != nil {
+			return nil, fmt.Errorf("github API error: %w", err)
+		}
+		total = result.GetTotal()
+
+		for _, r := range result.CodeResults {
+			items = append(items, map[string]any{
+				"repo": r.GetRepository().GetFullName(),
+				"path": r.GetPath(),
+				"name": r.GetName(),
+			})
+		}
+
+		if resp.NextPage == 0 || opts.ListOptions.Page >= searchMaxPages {
+			break
+		}
+		opts.ListOptions.Page = resp.NextPage
 	}
 
-	items := make([]map[string]any, 0, len(result.CodeResults))
-	for _, r := range result.CodeResults {
-		items = append(items, map[string]any{
-			"repo": r.GetRepository().GetFullName(),
-			"path": r.GetPath(),
-			"name": r.GetName(),
-		})
-	}
+	slog.Debug("github_search_code results",
+		"query", query,
+		"api_total", total,
+		"returned", len(items),
+	)
 
-	return map[string]any{"results": items, "total": result.GetTotal()}, nil
+	return map[string]any{
+		"results":   items,
+		"total":     total,
+		"returned":  len(items),
+		"truncated": len(items) < total,
+	}, nil
 }
 
 func (c *Connector) searchIssues(ctx context.Context, client *gh.Client, params map[string]any) (map[string]any, error) {
@@ -159,29 +186,50 @@ func (c *Connector) searchIssues(ctx context.Context, client *gh.Client, params 
 		query += " updated:<=" + before
 	}
 
-	result, _, err := client.Search.Issues(ctx, query, &gh.SearchOptions{
-		ListOptions: gh.ListOptions{PerPage: 10},
-	})
-	if err != nil {
-		return nil, fmt.Errorf("github API error: %w", err)
+	opts := &gh.SearchOptions{
+		ListOptions: gh.ListOptions{PerPage: searchPerPage, Page: 1},
+	}
+	var items []map[string]any
+	var total int
+	for {
+		result, resp, err := client.Search.Issues(ctx, query, opts)
+		if err != nil {
+			return nil, fmt.Errorf("github API error: %w", err)
+		}
+		total = result.GetTotal()
+
+		for _, issue := range result.Issues {
+			item := map[string]any{
+				"number": issue.GetNumber(),
+				"title":  issue.GetTitle(),
+				"state":  issue.GetState(),
+				"author": issue.GetUser().GetLogin(),
+				"url":    issue.GetHTMLURL(),
+			}
+			if issue.PullRequestLinks != nil {
+				item["is_pr"] = true
+			}
+			items = append(items, item)
+		}
+
+		if resp.NextPage == 0 || opts.ListOptions.Page >= searchMaxPages {
+			break
+		}
+		opts.ListOptions.Page = resp.NextPage
 	}
 
-	items := make([]map[string]any, 0, len(result.Issues))
-	for _, issue := range result.Issues {
-		item := map[string]any{
-			"number": issue.GetNumber(),
-			"title":  issue.GetTitle(),
-			"state":  issue.GetState(),
-			"author": issue.GetUser().GetLogin(),
-			"url":    issue.GetHTMLURL(),
-		}
-		if issue.PullRequestLinks != nil {
-			item["is_pr"] = true
-		}
-		items = append(items, item)
-	}
+	slog.Debug("github_search_issues results",
+		"query", query,
+		"api_total", total,
+		"returned", len(items),
+	)
 
-	return map[string]any{"results": items, "total": result.GetTotal()}, nil
+	return map[string]any{
+		"results":   items,
+		"total":     total,
+		"returned":  len(items),
+		"truncated": len(items) < total,
+	}, nil
 }
 
 func (c *Connector) getPR(ctx context.Context, client *gh.Client, params map[string]any) (map[string]any, error) {

--- a/internal/source/github/connector_test.go
+++ b/internal/source/github/connector_test.go
@@ -173,6 +173,168 @@ func TestConnector_SearchIssues(t *testing.T) {
 	}
 }
 
+func TestConnector_SearchIssues_PaginatesMultiplePages(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		page := r.URL.Query().Get("page")
+
+		var items []map[string]any
+		switch page {
+		case "", "1":
+			for i := 1; i <= 3; i++ {
+				items = append(items, map[string]any{
+					"number":   i,
+					"title":    "PR " + strings.Repeat("x", i),
+					"state":    "closed",
+					"html_url": "https://github.com/owner/repo/pull/" + strings.Repeat("x", i),
+					"user":     map[string]any{"login": "alice"},
+					"pull_request": map[string]any{
+						"url": "https://api.github.com/repos/owner/repo/pulls/" + strings.Repeat("x", i),
+					},
+				})
+			}
+			// Simulate Link header for next page.
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+		case "2":
+			for i := 4; i <= 5; i++ {
+				items = append(items, map[string]any{
+					"number":   i,
+					"title":    "PR " + strings.Repeat("x", i),
+					"state":    "closed",
+					"html_url": "https://github.com/owner/repo/pull/" + strings.Repeat("x", i),
+					"user":     map[string]any{"login": "alice"},
+					"pull_request": map[string]any{
+						"url": "https://api.github.com/repos/owner/repo/pulls/" + strings.Repeat("x", i),
+					},
+				})
+			}
+			// No Link header — last page.
+		}
+
+		json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 5,
+			"items":       items,
+		})
+	}))
+	defer server.Close()
+
+	c := githubsource.New().WithBaseURL(server.URL + "/")
+	result, err := c.Execute(context.Background(), "github_search_issues", map[string]any{
+		"query": "is:pr is:merged",
+	}, testToken())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	results := result["results"].([]map[string]any)
+	if len(results) != 5 {
+		t.Errorf("expected 5 results across 2 pages, got %d", len(results))
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls (2 pages), got %d", callCount)
+	}
+	if result["total"] != 5 {
+		t.Errorf("expected total=5, got %v", result["total"])
+	}
+	if result["returned"] != 5 {
+		t.Errorf("expected returned=5, got %v", result["returned"])
+	}
+	if result["truncated"] != false {
+		t.Errorf("expected truncated=false, got %v", result["truncated"])
+	}
+}
+
+func TestConnector_SearchCode_PaginatesMultiplePages(t *testing.T) {
+	callCount := 0
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		callCount++
+		page := r.URL.Query().Get("page")
+
+		var items []map[string]any
+		switch page {
+		case "", "1":
+			items = append(items, map[string]any{
+				"name": "a.go",
+				"path": "pkg/a.go",
+				"repository": map[string]any{
+					"full_name": "owner/repo",
+				},
+			})
+			w.Header().Set("Link", `<`+r.URL.Path+`?page=2>; rel="next"`)
+		case "2":
+			items = append(items, map[string]any{
+				"name": "b.go",
+				"path": "pkg/b.go",
+				"repository": map[string]any{
+					"full_name": "owner/repo",
+				},
+			})
+		}
+
+		json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 2,
+			"items":       items,
+		})
+	}))
+	defer server.Close()
+
+	c := githubsource.New().WithBaseURL(server.URL + "/")
+	result, err := c.Execute(context.Background(), "github_search_code", map[string]any{
+		"query": "func main",
+	}, testToken())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+
+	results := result["results"].([]map[string]any)
+	if len(results) != 2 {
+		t.Errorf("expected 2 results across 2 pages, got %d", len(results))
+	}
+	if callCount != 2 {
+		t.Errorf("expected 2 API calls, got %d", callCount)
+	}
+	if result["truncated"] != false {
+		t.Errorf("expected truncated=false, got %v", result["truncated"])
+	}
+}
+
+func TestConnector_SearchIssues_TruncatedField(t *testing.T) {
+	// Return total_count higher than items to simulate truncation.
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		json.NewEncoder(w).Encode(map[string]any{
+			"total_count": 999,
+			"items": []map[string]any{
+				{
+					"number":   1,
+					"title":    "PR 1",
+					"state":    "open",
+					"html_url": "https://github.com/owner/repo/pull/1",
+					"user":     map[string]any{"login": "alice"},
+				},
+			},
+		})
+	}))
+	defer server.Close()
+
+	c := githubsource.New().WithBaseURL(server.URL + "/")
+	result, err := c.Execute(context.Background(), "github_search_issues", map[string]any{
+		"query": "is:pr",
+	}, testToken())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result["total"] != 999 {
+		t.Errorf("expected total=999, got %v", result["total"])
+	}
+	if result["returned"] != 1 {
+		t.Errorf("expected returned=1, got %v", result["returned"])
+	}
+	if result["truncated"] != true {
+		t.Errorf("expected truncated=true, got %v", result["truncated"])
+	}
+}
+
 func TestConnector_SearchIssues_WithDateFilters(t *testing.T) {
 	var gotQuery string
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {


### PR DESCRIPTION
## Summary

- GitHub search tools (`github_search_issues`, `github_search_code`) hard-coded `PerPage: 10`, silently dropping all results past the first page — the bot reported 10 merged PRs when the real count was 93
- Increased `PerPage` to 100 (GitHub API max) and added auto-pagination up to 5 pages (500 results ceiling)
- Search responses now include `returned` and `truncated` fields so the research LLM knows when data is incomplete
- Added `slog.Debug` logging showing `api_total` vs `returned` for each search call

## Test plan

- [x] `TestConnector_SearchIssues_PaginatesMultiplePages` — verifies 2-page pagination collects all 5 results
- [x] `TestConnector_SearchCode_PaginatesMultiplePages` — same for code search
- [x] `TestConnector_SearchIssues_TruncatedField` — verifies `truncated: true` when `total > returned`
- [x] All 23 existing tests pass, 87.9% coverage

Closes #318

🤖 Generated with [Claude Code](https://claude.com/claude-code)