### PR TITLE
feat: unify slash command and agent DM through intent resolution

### DIFF
--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -1125,8 +1125,20 @@ func (s *apiServer) executeGrant(ctx context.Context, grantID, userID string) (*
 		return &executeGrantResult{ExecutionID: execID, Status: api.ExecutionStatusFailed, Error: "no connector"}, nil
 	}
 
-	// Build params.
+	// Build params. If the intent was created from the Slack flow, the
+	// domain fields are in metadata (model types, not API types). Extract
+	// them directly.
 	params := buildConnectorParams(intent.Action)
+	if intent.Action.Metadata != nil {
+		if domainRaw, ok := (*intent.Action.Metadata)["_model_domain"]; ok {
+			if domainJSON, err := json.Marshal(domainRaw); err == nil {
+				var domain model.DomainAction
+				if json.Unmarshal(domainJSON, &domain) == nil {
+					params = buildModelDomainParams(intent.Action.Type, domain)
+				}
+			}
+		}
+	}
 	if grant.BoundedParameters != nil {
 		for k, v := range *grant.BoundedParameters {
 			params[k] = v
@@ -1319,6 +1331,68 @@ func (s *apiServer) requireEnclave(w http.ResponseWriter, r *http.Request) bool 
 		return false
 	}
 	return true
+}
+
+// buildModelDomainParams extracts connector parameters from a model.DomainAction.
+// Used when the intent was created internally (Slack flow) with model types
+// rather than API types.
+func buildModelDomainParams(actionType string, domain model.DomainAction) map[string]any {
+	params := map[string]any{"action_type": actionType}
+
+	if domain.Email != nil {
+		e := domain.Email
+		params["to"] = e.To
+		params["cc"] = e.CC
+		params["bcc"] = e.BCC
+		params["subject"] = e.Subject
+		params["body_text"] = e.BodyText
+		params["body_html"] = e.BodyHTML
+		params["send_mode"] = e.SendMode
+		params["thread_ref"] = e.ThreadRef
+	}
+	if domain.Calendar != nil {
+		c := domain.Calendar
+		params["title"] = c.Title
+		params["description"] = c.Description
+		params["timezone"] = c.Timezone
+		params["location"] = c.Location
+		params["calendar_id"] = c.CalendarID
+		params["conference_type"] = c.ConferenceType
+		params["visibility"] = c.Visibility
+		if c.StartTime != nil {
+			params["start_time"] = c.StartTime.Format("2006-01-02T15:04:05")
+		}
+		if c.EndTime != nil {
+			params["end_time"] = c.EndTime.Format("2006-01-02T15:04:05")
+		}
+		if len(c.Attendees) > 0 {
+			var attendees []map[string]any
+			for _, a := range c.Attendees {
+				attendees = append(attendees, map[string]any{
+					"email": a.Email, "name": a.Name, "optional": a.Optional,
+				})
+			}
+			params["attendees"] = attendees
+		}
+	}
+	if domain.Git != nil {
+		g := domain.Git
+		params["repository"] = g.Repository
+		params["branch"] = g.Branch
+		params["base_branch"] = g.BaseBranch
+		params["pr_title"] = g.PRTitle
+		params["pr_body"] = g.PRBody
+		params["issue_title"] = g.IssueTitle
+		params["issue_body"] = g.IssueBody
+		if len(g.IssueLabels) > 0 {
+			params["issue_labels"] = g.IssueLabels
+		}
+		if len(g.IssueAssignees) > 0 {
+			params["issue_assignees"] = g.IssueAssignees
+		}
+	}
+
+	return params
 }
 
 func resolveConnector(actionType string) (connType, provider string) {

--- a/internal/app/handlers_helpers_test.go
+++ b/internal/app/handlers_helpers_test.go
@@ -838,3 +838,156 @@ func TestExecuteGrant_TEEMode_WithEscrowIndex(t *testing.T) {
 		t.Errorf("Status = %q, want succeeded", result.Status)
 	}
 }
+
+// --- buildModelDomainParams tests ---
+
+func TestBuildModelDomainParams_Email(t *testing.T) {
+	domain := model.DomainAction{
+		Email: &model.EmailAction{
+			To:       []model.Recipient{{Name: "Alice", Email: "alice@example.com"}},
+			CC:       []model.Recipient{{Email: "bob@example.com"}},
+			Subject:  "Report",
+			BodyText: "Here it is.",
+			SendMode: "send_now",
+		},
+	}
+	params := buildModelDomainParams("email.send", domain)
+	if params["subject"] != "Report" {
+		t.Errorf("subject = %v", params["subject"])
+	}
+	if params["body_text"] != "Here it is." {
+		t.Errorf("body_text = %v", params["body_text"])
+	}
+	if params["send_mode"] != "send_now" {
+		t.Errorf("send_mode = %v", params["send_mode"])
+	}
+	if params["to"] == nil {
+		t.Error("to should not be nil")
+	}
+}
+
+func TestBuildModelDomainParams_Calendar(t *testing.T) {
+	start := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 25, 10, 30, 0, 0, time.UTC)
+	domain := model.DomainAction{
+		Calendar: &model.CalendarAction{
+			Title:     "Standup",
+			StartTime: &start,
+			EndTime:   &end,
+			Timezone:  "America/New_York",
+			Location:  "Room B",
+			Attendees: []model.CalendarAttendee{{Email: "alice@example.com", Name: "Alice"}},
+		},
+	}
+	params := buildModelDomainParams("calendar.event.create", domain)
+	if params["title"] != "Standup" {
+		t.Errorf("title = %v", params["title"])
+	}
+	if params["timezone"] != "America/New_York" {
+		t.Errorf("timezone = %v", params["timezone"])
+	}
+	if params["location"] != "Room B" {
+		t.Errorf("location = %v", params["location"])
+	}
+	if params["start_time"] == nil {
+		t.Error("start_time should not be nil")
+	}
+	if params["attendees"] == nil {
+		t.Error("attendees should not be nil")
+	}
+}
+
+func TestBuildModelDomainParams_GitIssue(t *testing.T) {
+	domain := model.DomainAction{
+		Git: &model.GitAction{
+			Repository:     "acme/app",
+			IssueTitle:     "Bug report",
+			IssueBody:      "Details...",
+			IssueLabels:    []string{"bug"},
+			IssueAssignees: []string{"alice"},
+		},
+	}
+	params := buildModelDomainParams("git.issue.create", domain)
+	if params["repository"] != "acme/app" {
+		t.Errorf("repository = %v", params["repository"])
+	}
+	if params["issue_title"] != "Bug report" {
+		t.Errorf("issue_title = %v", params["issue_title"])
+	}
+	if params["issue_labels"] == nil {
+		t.Error("issue_labels should not be nil")
+	}
+}
+
+func TestBuildModelDomainParams_EmptyDomain(t *testing.T) {
+	params := buildModelDomainParams("unknown.action", model.DomainAction{})
+	if params["action_type"] != "unknown.action" {
+		t.Errorf("action_type = %v", params["action_type"])
+	}
+}
+
+func TestExecuteGrant_ConnectorReturnsError(t *testing.T) {
+	s := newExecutionServer()
+	enableVaultEncryption(s, "usr_exec")
+	ctx := context.Background()
+
+	conn := &stubConnector{err: fmt.Errorf("connection refused")}
+	s.registry.Register(ctx, conn)
+	storeEncryptedToken(s, "connectors/github/default", []byte("token"))
+	seedGrantAndIntent(ctx, s, "grt_cerr", "int_cerr")
+
+	result, err := s.executeGrant(ctx, "grt_cerr", "usr_exec")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != api.ExecutionStatusFailed {
+		t.Errorf("Status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "connection refused") {
+		t.Errorf("Error = %q, want connection refused", result.Error)
+	}
+}
+
+func TestExecuteGrant_DecryptionFailure(t *testing.T) {
+	s := newExecutionServer()
+	enableVaultEncryption(s, "usr_dec")
+	ctx := context.Background()
+
+	conn := &stubConnector{result: connectorpkg.ExecutionResult{Status: connectorpkg.ExecutionStatusSucceeded}}
+	s.registry.Register(ctx, conn)
+	seedGrantAndIntent(ctx, s, "grt_dec", "int_dec")
+	// Overwrite the valid credential with garbage → decryption fails.
+	s.vault.Put(ctx, "connectors/github/default", []byte("not-encrypted-garbage"), vault.Metadata{
+		Type:   "api_key",
+		Labels: map[string]string{vault.EncryptedLabel: "true"},
+	})
+
+	result, err := s.executeGrant(ctx, "grt_dec", "usr_dec")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if result.Status != api.ExecutionStatusFailed {
+		t.Errorf("Status = %q, want failed", result.Status)
+	}
+	if !strings.Contains(result.Error, "credential decryption failed") {
+		t.Errorf("Error = %q, want credential decryption failed", result.Error)
+	}
+}
+
+func TestResolveCredentialVaultPath_GoogleCalendar(t *testing.T) {
+	accounts := mem.NewConnectedAccountStore()
+	ctx := context.Background()
+
+	accounts.Create(ctx, model.ConnectedAccount{
+		ID: "conn_cal", UserID: "usr_cal",
+		Provider: model.ConnectedAccountProviderGoogleCalendar,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+
+	s := &apiServer{log: slog.Default(), connectedAccounts: accounts}
+	ctx = setTestUserClaims(ctx, "usr_cal")
+	path := s.resolveCredentialVaultPath(ctx, "google_calendar")
+	if path != "connected-accounts/usr_cal/google_calendar" {
+		t.Errorf("path = %q, want connected-accounts/usr_cal/google_calendar", path)
+	}
+}

--- a/internal/app/handlers_slack_agent_test.go
+++ b/internal/app/handlers_slack_agent_test.go
@@ -176,27 +176,6 @@ func TestHandleAssistantMessage_NoUser(t *testing.T) {
 	}
 }
 
-func TestIsDraftRequest(t *testing.T) {
-	tests := []struct {
-		text string
-		want bool
-	}{
-		{"Draft me a weekly status update", true},
-		{"Write a message to the team", true},
-		{"Compose an email", true},
-		{"Reply to Sarah's question", true},
-		{"How many hours on calls today?", false},
-		{"What's the status of PR #42?", false},
-		{"Summarize the meeting", false},
-		{"", false},
-	}
-	for _, tt := range tests {
-		if got := isDraftRequest(tt.text); got != tt.want {
-			t.Errorf("isDraftRequest(%q) = %v, want %v", tt.text, got, tt.want)
-		}
-	}
-}
-
 func TestResolveAileronUserBySlack(t *testing.T) {
 	srv, _ := newAgentTestServer()
 	ctx := context.Background()
@@ -751,16 +730,14 @@ func TestProcessSlashCommandDraft_HappyPath(t *testing.T) {
 	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
 	srv.draftPipeline = newTestPipeline("context", "Draft: this is your message.")
 
-	meta := DraftModalMeta{TargetChannel: "C_GENERAL", UserID: "U_ALICE"}
-	srv.processSlashCommandDraft(ctx, "T001", "U_ALICE", "draft a weekly update", "trig_1", meta)
-	// No panic; modal opened and updated with draft.
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "draft a weekly update", "trig_1", "")
+	// No panic; intent resolved and presented.
 }
 
 func TestProcessSlashCommandDraft_NoBotToken(t *testing.T) {
 	srv, _ := newAgentTestServer()
-	meta := DraftModalMeta{TargetChannel: "C_GENERAL", UserID: "U_ALICE"}
 	// No token — should bail early.
-	srv.processSlashCommandDraft(context.Background(), "T_MISSING", "U_ALICE", "draft", "trig_1", meta)
+	srv.processSlashCommand(context.Background(), "T_MISSING", "C_CHAN", "U_ALICE", "draft", "trig_1", "")
 }
 
 func TestProcessSlashCommandDraft_NoUser(t *testing.T) {
@@ -781,8 +758,7 @@ func TestProcessSlashCommandDraft_NoUser(t *testing.T) {
 
 	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
 	// No user seeded.
-	meta := DraftModalMeta{TargetChannel: "C_GENERAL", UserID: "U_NOBODY"}
-	srv.processSlashCommandDraft(ctx, "T001", "U_NOBODY", "draft something", "trig_1", meta)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "draft something", "trig_1", "")
 	// Should update modal with error.
 }
 
@@ -805,8 +781,7 @@ func TestProcessSlashCommandDraft_NoPipeline(t *testing.T) {
 	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
 	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
 	// No pipeline.
-	meta := DraftModalMeta{TargetChannel: "C_GENERAL", UserID: "U_ALICE"}
-	srv.processSlashCommandDraft(ctx, "T001", "U_ALICE", "draft something", "trig_1", meta)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "draft something", "trig_1", "")
 }
 
 func TestProcessSlashCommandDraft_PipelineError(t *testing.T) {
@@ -841,13 +816,11 @@ func TestProcessSlashCommandDraft_PipelineError(t *testing.T) {
 		draft.Prompts{Research: "research", Ghostwrite: "ghostwrite"},
 	)
 
-	meta := DraftModalMeta{TargetChannel: "C_GENERAL", UserID: "U_ALICE"}
-	srv.processSlashCommandDraft(ctx, "T001", "U_ALICE", "draft something", "trig_1", meta)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "draft something", "trig_1", "")
 	// Should update modal with error, no panic.
 }
 
 func TestProcessSlashCommandQuestion_HappyPath(t *testing.T) {
-	// Set up a response_url server to capture the final response.
 	var receivedBody string
 	responseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		body := make([]byte, r.ContentLength)
@@ -860,10 +833,11 @@ func TestProcessSlashCommandQuestion_HappyPath(t *testing.T) {
 	srv, _ := newAgentTestServer()
 	ctx := context.Background()
 
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
 	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
 	srv.draftPipeline = newTestPipeline("context", "The answer is 42.")
 
-	srv.processSlashCommandQuestion(ctx, "T001", "U_ALICE", "How many hours on calls?", responseServer.URL)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "How many hours on calls?", "", responseServer.URL)
 
 	// Verify the response was sent to the response URL.
 	if receivedBody == "" {
@@ -899,15 +873,16 @@ func TestProcessSlashCommandQuestion_NoUser(t *testing.T) {
 	defer responseServer.Close()
 
 	srv, _ := newAgentTestServer()
+	srv.systemVault.Put(context.Background(), "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
 	// No user seeded.
-	srv.processSlashCommandQuestion(context.Background(), "T001", "U_UNKNOWN", "question?", responseServer.URL)
+	srv.processSlashCommand(context.Background(), "T001", "C_CHAN", "U_UNKNOWN", "question?", "", responseServer.URL)
 
 	if receivedBody == "" {
 		t.Fatal("expected error response sent to response_url")
 	}
 	var resp map[string]any
 	json.Unmarshal([]byte(receivedBody), &resp)
-	if text, ok := resp["text"].(string); !ok || text != "Could not find your Aileron account." {
+	if text, ok := resp["text"].(string); !ok || !strings.Contains(text, "Could not find your Aileron account") {
 		t.Errorf("expected account error message, got %v", resp["text"])
 	}
 }
@@ -924,14 +899,15 @@ func TestProcessSlashCommandQuestion_NoPipeline(t *testing.T) {
 
 	srv, _ := newAgentTestServer()
 	ctx := context.Background()
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
 	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
 	// No pipeline.
 
-	srv.processSlashCommandQuestion(ctx, "T001", "U_ALICE", "question?", responseServer.URL)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "question?", "", responseServer.URL)
 
 	var resp map[string]any
 	json.Unmarshal([]byte(receivedBody), &resp)
-	if text, ok := resp["text"].(string); !ok || text != "Draft generation is not configured." {
+	if text, ok := resp["text"].(string); !ok || !strings.Contains(text, "not configured") {
 		t.Errorf("expected pipeline not configured message, got %v", resp["text"])
 	}
 }
@@ -948,6 +924,7 @@ func TestProcessSlashCommandQuestion_PipelineError(t *testing.T) {
 
 	srv, _ := newAgentTestServer()
 	ctx := context.Background()
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
 	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
 
 	errClient := &mockLLMClient{err: fmt.Errorf("LLM down")}
@@ -962,7 +939,7 @@ func TestProcessSlashCommandQuestion_PipelineError(t *testing.T) {
 		draft.Prompts{Research: "r", Ghostwrite: "g"},
 	)
 
-	srv.processSlashCommandQuestion(ctx, "T001", "U_ALICE", "question?", responseServer.URL)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "question?", "", responseServer.URL)
 
 	var resp map[string]any
 	json.Unmarshal([]byte(receivedBody), &resp)
@@ -1576,8 +1553,7 @@ func TestProcessSlashCommandDraft_VaultLocked(t *testing.T) {
 	srv.draftPipeline = newTestPipeline("research", "draft")
 	srv.kekSessionCache = &auth.KEKSessionCache{}
 
-	meta := DraftModalMeta{TargetChannel: "C123", UserID: "U_ALICE"}
-	srv.processSlashCommandDraft(ctx, "T001", "U_ALICE", "Draft something", "trig_123", meta)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "draft something", "trig_1", "")
 	// Should not panic — vault locked error shown in modal.
 }
 
@@ -1593,7 +1569,7 @@ func TestProcessSlashCommandQuestion_VaultLocked(t *testing.T) {
 	srv.draftPipeline = newTestPipeline("research", "answer")
 	srv.kekSessionCache = &auth.KEKSessionCache{}
 
-	srv.processSlashCommandQuestion(ctx, "T001", "U_ALICE", "How many calls?", respServer.URL)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "How many calls?", "", respServer.URL)
 	// Should not panic — vault locked error sent via response_url.
 }
 

--- a/internal/app/handlers_slack_commands.go
+++ b/internal/app/handlers_slack_commands.go
@@ -7,16 +7,30 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"strings"
 
 	"github.com/ALRubinger/aileron/internal/comms"
+	"github.com/ALRubinger/aileron/internal/draft"
+	"github.com/slack-go/slack"
 )
 
-// draftKeywords are words that indicate the user wants a draft (not a question).
-var draftKeywords = []string{"draft", "write", "compose", "reply", "respond", "message"}
+const (
+	intentModalCallbackID  = "aileron_intent_modal"
+	intentContentBlockID   = "intent_content"
+	intentContentActionID  = "intent_content_text"
+)
+
+// IntentModalMeta carries intent details across the modal lifecycle.
+type IntentModalMeta struct {
+	IntentType string `json:"intent_type"`
+	UserID     string `json:"user_id"`     // Aileron user ID
+	ChannelID  string `json:"channel_id"`
+	ActionJSON string `json:"action_json"` // serialized model.ActionIntent
+}
 
 // handleSlackCommand handles POST /v1/webhooks/slack/commands.
-// This is the endpoint for the /aileron slash command.
+// This is the endpoint for the /aileron slash command. Every request goes
+// through intent resolution — the LLM decides whether it's informational
+// or a write action.
 func (s *apiServer) handleSlackCommand(w http.ResponseWriter, r *http.Request) {
 	if r.Method != http.MethodPost {
 		http.Error(w, "method not allowed", http.StatusMethodNotAllowed)
@@ -47,118 +61,210 @@ func (s *apiServer) handleSlackCommand(w http.ResponseWriter, r *http.Request) {
 	slackUserID := params.Get("user_id")
 	responseURL := params.Get("response_url")
 
-	isDraft := isDraftRequest(text)
-
-	if isDraft && triggerID != "" {
-		// Draft request — open a modal immediately.
-		w.Header().Set("Content-Type", "application/json")
-		w.WriteHeader(http.StatusOK)
-
-		meta := DraftModalMeta{
-			TargetChannel: channelID,
-			UserID:        slackUserID,
-		}
-
-		go s.processSlashCommandDraft(context.Background(), teamID, slackUserID, text, triggerID, meta)
-		return
-	}
-
-	// Question or no trigger_id — respond ephemerally.
-	// Include the user's question so they have a record of what they asked.
+	// Respond immediately — Slack requires a response within 3s.
 	w.Header().Set("Content-Type", "application/json")
 	json.NewEncoder(w).Encode(map[string]any{
 		"response_type": "ephemeral",
 		"text":          "> /aileron " + text + "\n\n:hourglass_flowing_sand: Working on it...",
 	})
 
-	go s.processSlashCommandQuestion(context.Background(), teamID, slackUserID, text, responseURL)
+	go s.processSlashCommand(context.Background(), teamID, channelID, slackUserID, text, triggerID, responseURL)
 }
 
-// processSlashCommandDraft handles a draft-type slash command by opening a modal
-// and generating a draft asynchronously.
-func (s *apiServer) processSlashCommandDraft(ctx context.Context, teamID, slackUserID, text, triggerID string, meta DraftModalMeta) {
+// processSlashCommand resolves the user's intent and presents the result.
+// Write actions open a modal with an editable preview. Informational
+// requests respond via response_url.
+func (s *apiServer) processSlashCommand(ctx context.Context, teamID, channelID, slackUserID, text, triggerID, responseURL string) {
 	botToken, err := s.resolveWorkspaceBotToken(ctx, teamID)
 	if err != nil {
-		s.log.Error("slash command draft: failed to resolve bot token", "error", err)
-		return
-	}
-
-	viewResp, err := openDraftModal(ctx, botToken, triggerID, meta)
-	if err != nil {
-		s.log.Error("slash command draft: failed to open modal", "error", err)
+		s.log.Error("slash command: failed to resolve bot token", "error", err)
+		s.respondViaURL(responseURL, ":x: Failed to resolve workspace configuration.")
 		return
 	}
 
 	userID, err := s.resolveAileronUserBySlack(ctx, slackUserID, teamID)
 	if err != nil {
-		s.log.Error("slash command draft: failed to resolve user", "error", err)
-		_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Could not find your Aileron account.", meta)
+		s.log.Error("slash command: failed to resolve user", "error", err)
+		s.respondViaURL(responseURL, ":x: Could not find your Aileron account.")
 		return
 	}
 
 	pipeline := s.resolvePipelineVault(userID)
 	if pipeline == nil {
 		if s.draftPipeline == nil {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation is not configured.", meta)
-		} else {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.vaultLockedSlackMessage(), meta)
-		}
-		return
-	}
-
-	displayName := comms.ResolveSlackDisplayName(ctx, botToken, slackUserID)
-	msg := comms.BuildIncomingMessage("", meta.TargetChannel, displayName, text)
-	draftText, err := pipeline.GenerateDraft(ctx, userID, msg)
-	if err != nil {
-		s.log.Error("slash command draft: generation failed", "error", err)
-		if isVaultError(err) {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, s.credentialErrorMessage(err), meta)
-		} else {
-			_ = updateDraftModalError(ctx, botToken, viewResp.ID, "Draft generation failed. Please try again.", meta)
-		}
-		return
-	}
-
-	if err := updateDraftModalWithDraft(ctx, botToken, viewResp.ID, draftText, meta); err != nil {
-		s.log.Error("slash command draft: failed to update modal", "error", err)
-	}
-}
-
-// processSlashCommandQuestion handles a question-type slash command by running
-// the pipeline and updating via response_url.
-func (s *apiServer) processSlashCommandQuestion(ctx context.Context, teamID, slackUserID, text, responseURL string) {
-	userID, err := s.resolveAileronUserBySlack(ctx, slackUserID, teamID)
-	if err != nil {
-		s.log.Error("slash command question: failed to resolve user", "error", err)
-		s.respondViaURL(responseURL, "Could not find your Aileron account.")
-		return
-	}
-
-	pipeline := s.resolvePipelineVault(userID)
-	if pipeline == nil {
-		if s.draftPipeline == nil {
-			s.respondViaURL(responseURL, "Draft generation is not configured.")
+			s.respondViaURL(responseURL, ":x: Draft generation is not configured.")
+		} else if s.enclaveClient != nil && s.enclaveReady(ctx) != nil {
+			s.respondViaURL(responseURL, ":warning: Aileron is still starting up. Please try again in about 30 seconds.")
 		} else {
 			s.respondViaURL(responseURL, s.vaultLockedSlackMessage())
 		}
 		return
 	}
 
-	botToken, _ := s.resolveWorkspaceBotToken(ctx, teamID)
 	displayName := comms.ResolveSlackDisplayName(ctx, botToken, slackUserID)
-	msg := comms.BuildIncomingMessage("", "", displayName, text)
-	answer, err := pipeline.GenerateDraft(ctx, userID, msg)
+	msg := comms.BuildIncomingMessage("", channelID, displayName, text)
+
+	intents, err := pipeline.ResolveIntents(ctx, userID, msg)
 	if err != nil {
-		s.log.Error("slash command question: generation failed", "error", err)
+		s.log.Error("slash command: intent resolution failed", "user_id", userID, "error", err)
 		if isVaultError(err) {
 			s.respondViaURL(responseURL, s.credentialErrorMessage(err))
 		} else {
-			s.respondViaURL(responseURL, "> /aileron "+text+"\n\nSomething went wrong. Please try again.")
+			s.respondViaURL(responseURL, "> /aileron "+text+"\n\n:x: Something went wrong. Please try again.")
 		}
 		return
 	}
 
-	s.respondViaURL(responseURL, "> /aileron "+text+"\n\n"+answer)
+	if len(intents) == 0 {
+		s.respondViaURL(responseURL, "> /aileron "+text+"\n\n:shrug: I couldn't determine what to do.")
+		return
+	}
+
+	intent := intents[0]
+
+	if intent.IsWriteAction() {
+		// Write action — open a modal with editable preview.
+		if triggerID == "" {
+			// No trigger_id (rare) — fall back to response_url.
+			s.respondViaURL(responseURL, formatIntentPreview(intent))
+			return
+		}
+		s.openIntentModal(ctx, botToken, triggerID, userID, channelID, intent)
+	} else {
+		// Informational — respond via response_url.
+		s.respondViaURL(responseURL, "> /aileron "+text+"\n\n"+intent.ResponseText)
+	}
+
+	s.log.Info("slash command: intent delivered",
+		"user_id", userID,
+		"type", string(intent.Type),
+		"is_write", intent.IsWriteAction(),
+	)
+}
+
+// openIntentModal opens a Slack modal with an editable preview of a write
+// action intent. The user can edit the content and click Send to approve.
+func (s *apiServer) openIntentModal(ctx context.Context, botToken, triggerID, userID, channelID string, intent draft.ResolvedIntent) {
+	preview := formatIntentPreview(intent)
+
+	// Store intent details in modal metadata so the submission handler
+	// can create and execute the intent.
+	intentJSON, _ := json.Marshal(intent.Action)
+	meta := IntentModalMeta{
+		IntentType: string(intent.Type),
+		UserID:     userID,
+		ChannelID:  channelID,
+		ActionJSON: string(intentJSON),
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	draftInput := slack.NewPlainTextInputBlockElement(
+		slack.NewTextBlockObject(slack.PlainTextType, "Edit the content...", false, false),
+		intentContentActionID,
+	)
+	draftInput.Multiline = true
+	if len(preview) > maxModalTextLength {
+		preview = preview[:maxModalTextLength]
+	}
+	draftInput.InitialValue = preview
+
+	blocks := []slack.Block{
+		slack.NewSectionBlock(
+			slack.NewTextBlockObject(slack.MarkdownType, "*"+intentTypeLabel(intent.Type)+"*", false, false),
+			nil, nil,
+		),
+		slack.NewInputBlock(
+			intentContentBlockID,
+			slack.NewTextBlockObject(slack.PlainTextType, "Content", false, false),
+			nil,
+			draftInput,
+		),
+	}
+
+	view := slack.ModalViewRequest{
+		Type:            slack.VTModal,
+		CallbackID:      intentModalCallbackID,
+		Title:           slack.NewTextBlockObject(slack.PlainTextType, "Review & Send", false, false),
+		Submit:          slack.NewTextBlockObject(slack.PlainTextType, "Send", false, false),
+		Close:           slack.NewTextBlockObject(slack.PlainTextType, "Cancel", false, false),
+		PrivateMetadata: string(metaJSON),
+		Blocks: slack.Blocks{
+			BlockSet: blocks,
+		},
+	}
+
+	if _, err := comms.OpenModal(ctx, botToken, triggerID, view); err != nil {
+		s.log.Error("slash command: failed to open intent modal", "error", err)
+	}
+}
+
+// formatIntentPreview generates a readable text preview of a write action intent.
+func formatIntentPreview(intent draft.ResolvedIntent) string {
+	if intent.Action == nil {
+		return intent.Summary
+	}
+	switch {
+	case intent.Action.Domain.Email != nil:
+		e := intent.Action.Domain.Email
+		preview := "To: " + formatRecipientList(e.To) + "\n"
+		if e.Subject != "" {
+			preview += "Subject: " + e.Subject + "\n"
+		}
+		preview += "\n" + e.BodyText
+		return preview
+
+	case intent.Action.Domain.Calendar != nil:
+		c := intent.Action.Domain.Calendar
+		preview := "Title: " + c.Title + "\n"
+		if c.StartTime != nil {
+			preview += "When: " + c.StartTime.Format("Mon Jan 2, 3:04 PM")
+			if c.EndTime != nil {
+				preview += " – " + c.EndTime.Format("3:04 PM")
+			}
+			preview += "\n"
+		}
+		if c.Location != "" {
+			preview += "Location: " + c.Location + "\n"
+		}
+		if c.Description != "" {
+			preview += "\n" + c.Description
+		}
+		return preview
+
+	case intent.Action.Domain.Git != nil:
+		g := intent.Action.Domain.Git
+		if g.IssueTitle != "" {
+			preview := "Repo: " + g.Repository + "\nTitle: " + g.IssueTitle + "\n"
+			if g.IssueBody != "" {
+				preview += "\n" + g.IssueBody
+			}
+			return preview
+		}
+		return intent.Summary
+
+	default:
+		return intent.Summary
+	}
+}
+
+// intentTypeLabel returns a human-readable label for an intent type.
+func intentTypeLabel(t draft.IntentType) string {
+	switch t {
+	case draft.IntentTypeEmailSend:
+		return "Send Email"
+	case draft.IntentTypeEmailDraft:
+		return "Save Email Draft"
+	case draft.IntentTypeCalendarEventCreate:
+		return "Create Calendar Event"
+	case draft.IntentTypeGitIssueCreate:
+		return "Create GitHub Issue"
+	case draft.IntentTypeGitIssueComment:
+		return "Comment on GitHub Issue"
+	case draft.IntentTypeSlackSend:
+		return "Send Slack Message"
+	default:
+		return string(t)
+	}
 }
 
 // respondViaURL sends an ephemeral response update via Slack's response_url.
@@ -167,9 +273,9 @@ func (s *apiServer) respondViaURL(responseURL, text string) {
 		return
 	}
 	body, _ := json.Marshal(map[string]any{
-		"response_type":   "ephemeral",
+		"response_type":    "ephemeral",
 		"replace_original": true,
-		"text":            text,
+		"text":             text,
 	})
 	resp, err := http.Post(responseURL, "application/json", bytes.NewReader(body))
 	if err != nil {
@@ -178,16 +284,3 @@ func (s *apiServer) respondViaURL(responseURL, text string) {
 	}
 	resp.Body.Close()
 }
-
-// isDraftRequest returns true if the text appears to be a draft request
-// rather than a question.
-func isDraftRequest(text string) bool {
-	lower := strings.ToLower(text)
-	for _, kw := range draftKeywords {
-		if strings.Contains(lower, kw) {
-			return true
-		}
-	}
-	return false
-}
-

--- a/internal/app/handlers_slack_commands_test.go
+++ b/internal/app/handlers_slack_commands_test.go
@@ -18,6 +18,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/internal/auth"
 	"github.com/ALRubinger/aileron/internal/comms"
 	"github.com/ALRubinger/aileron/internal/draft"
 	"github.com/ALRubinger/aileron/internal/model"
@@ -198,7 +199,7 @@ func TestSlashCommandQuestion_CredentialUnavailable_SendsVaultUnlockMessage(t *t
 	// Disable KEK check so resolvePipelineVault falls through to tier 3.
 	srv.kekSessionCache = nil
 
-	srv.processSlashCommandQuestion(ctx, "T001", "U_ALICE", "what's in my email?", responseServer.URL)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "what's in my email?", "", responseServer.URL)
 
 	mu.Lock()
 	body := capturedBody
@@ -238,18 +239,6 @@ func TestSlashCommandDraft_CredentialUnavailable_SendsVaultUnlockMessage(t *test
 	// generation, the modal should show the vault unlock message instead
 	// of "Draft generation failed."
 	var mu sync.Mutex
-	var modalMessage string
-	slackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		body, _ := io.ReadAll(r.Body)
-		mu.Lock()
-		modalMessage = string(body)
-		mu.Unlock()
-		slackViewOK(w)
-	}))
-	defer slackServer.Close()
-
-	comms.SetAgentAPIURL(slackServer.URL + "/")
-	defer comms.SetAgentAPIURL("")
 
 	srv := newCommandTestServer()
 	srv.uiBaseURL = "https://app.withaileron.ai"
@@ -267,27 +256,31 @@ func TestSlashCommandDraft_CredentialUnavailable_SendsVaultUnlockMessage(t *test
 	srv.draftPipeline = newVaultErrorPipeline(accounts)
 	srv.kekSessionCache = nil
 
-	meta := DraftModalMeta{
-		TargetChannel:   "C123",
-		OriginalMessage: "Help with PR",
-		UserID:          "U_ALICE",
-		TeamID:          "T001",
-	}
+	// New flow: vault locked errors go via response_url, not modal.
+	var responseBody string
+	responseServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		responseBody = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer responseServer.Close()
 
-	srv.processSlashCommandDraft(ctx, "T001", "U_ALICE", "draft a reply", "trig_123", meta)
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "draft a reply", "trig_123", responseServer.URL)
 
 	mu.Lock()
-	view := modalMessage
+	body := responseBody
 	mu.Unlock()
 
-	if !strings.Contains(view, "Unlock your vault") {
-		t.Errorf("expected vault unlock message in modal, got: %s", view)
+	if !strings.Contains(body, "Unlock your vault") {
+		t.Errorf("expected vault unlock message in response, got: %s", body)
 	}
-	if !strings.Contains(view, "vault") {
-		t.Errorf("expected vault URL in modal, got: %s", view)
+	if !strings.Contains(body, "vault") {
+		t.Errorf("expected vault URL in response, got: %s", body)
 	}
-	if strings.Contains(view, "Draft generation failed") {
-		t.Errorf("should not show generic error for vault issues, got: %s", view)
+	if strings.Contains(body, "Draft generation failed") {
+		t.Errorf("should not show generic error for vault issues, got: %s", body)
 	}
 }
 
@@ -314,4 +307,322 @@ func TestSlackCommand_InvalidFormData(t *testing.T) {
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400 for invalid form data, got %d", w.Code)
 	}
+}
+
+// --- formatIntentPreview tests ---
+
+func TestFormatIntentPreview_Email(t *testing.T) {
+	intent := draft.ResolvedIntent{
+		Type:    draft.IntentTypeEmailSend,
+		Summary: "Send email",
+		Action: &model.ActionIntent{
+			Type: "email.send",
+			Domain: model.DomainAction{Email: &model.EmailAction{
+				To:       []model.Recipient{{Name: "Alice", Email: "alice@example.com"}},
+				Subject:  "Weekly Report",
+				BodyText: "Here is the report.",
+			}},
+		},
+	}
+	preview := formatIntentPreview(intent)
+	for _, want := range []string{"alice@example.com", "Weekly Report", "Here is the report."} {
+		if !strings.Contains(preview, want) {
+			t.Errorf("preview missing %q: %s", want, preview)
+		}
+	}
+}
+
+func TestFormatIntentPreview_Calendar(t *testing.T) {
+	start := time.Date(2026, 4, 25, 10, 0, 0, 0, time.UTC)
+	end := time.Date(2026, 4, 25, 10, 30, 0, 0, time.UTC)
+	intent := draft.ResolvedIntent{
+		Type: draft.IntentTypeCalendarEventCreate,
+		Action: &model.ActionIntent{
+			Type: "calendar.event.create",
+			Domain: model.DomainAction{Calendar: &model.CalendarAction{
+				Title: "Standup", StartTime: &start, EndTime: &end,
+				Location: "Room A", Description: "Daily sync",
+			}},
+		},
+	}
+	preview := formatIntentPreview(intent)
+	for _, want := range []string{"Standup", "Room A", "Daily sync"} {
+		if !strings.Contains(preview, want) {
+			t.Errorf("preview missing %q: %s", want, preview)
+		}
+	}
+}
+
+func TestFormatIntentPreview_GitIssue(t *testing.T) {
+	intent := draft.ResolvedIntent{
+		Type: draft.IntentTypeGitIssueCreate,
+		Action: &model.ActionIntent{
+			Type: "git.issue.create",
+			Domain: model.DomainAction{Git: &model.GitAction{
+				Repository: "acme/app", IssueTitle: "Login bug", IssueBody: "Steps to reproduce.",
+			}},
+		},
+	}
+	preview := formatIntentPreview(intent)
+	for _, want := range []string{"acme/app", "Login bug", "Steps to reproduce."} {
+		if !strings.Contains(preview, want) {
+			t.Errorf("preview missing %q: %s", want, preview)
+		}
+	}
+}
+
+func TestFormatIntentPreview_NilAction(t *testing.T) {
+	intent := draft.ResolvedIntent{Type: draft.IntentTypeEmailSend, Summary: "fallback text"}
+	if got := formatIntentPreview(intent); got != "fallback text" {
+		t.Errorf("expected summary fallback, got %q", got)
+	}
+}
+
+// --- intentTypeLabel tests ---
+
+func TestIntentTypeLabel(t *testing.T) {
+	tests := []struct {
+		t    draft.IntentType
+		want string
+	}{
+		{draft.IntentTypeEmailSend, "Send Email"},
+		{draft.IntentTypeEmailDraft, "Save Email Draft"},
+		{draft.IntentTypeCalendarEventCreate, "Create Calendar Event"},
+		{draft.IntentTypeGitIssueCreate, "Create GitHub Issue"},
+		{draft.IntentTypeGitIssueComment, "Comment on GitHub Issue"},
+		{draft.IntentTypeSlackSend, "Send Slack Message"},
+		{draft.IntentType("custom.action"), "custom.action"},
+	}
+	for _, tt := range tests {
+		if got := intentTypeLabel(tt.t); got != tt.want {
+			t.Errorf("intentTypeLabel(%q) = %q, want %q", tt.t, got, tt.want)
+		}
+	}
+}
+
+// --- respondViaURL tests ---
+
+func TestCommandRespondViaURL_EmptyURL(t *testing.T) {
+	srv := newCommandTestServer()
+	// Should not panic with empty URL.
+	srv.respondViaURL("", "test")
+}
+
+func TestCommandRespondViaURL_SendsResponse(t *testing.T) {
+	var mu sync.Mutex
+	var body string
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer server.Close()
+
+	srv := newCommandTestServer()
+	srv.respondViaURL(server.URL, "hello world")
+
+	mu.Lock()
+	got := body
+	mu.Unlock()
+
+	if !strings.Contains(got, "hello world") {
+		t.Errorf("expected 'hello world' in body, got %s", got)
+	}
+	if !strings.Contains(got, "ephemeral") {
+		t.Errorf("expected ephemeral response type, got %s", got)
+	}
+}
+
+// --- processSlashCommand write action path ---
+
+func TestProcessSlashCommand_WriteAction_NoTriggerID_FallsBackToResponseURL(t *testing.T) {
+	var mu sync.Mutex
+	var body string
+	respServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer respServer.Close()
+
+	srv := newCommandTestServer()
+	ctx := context.Background()
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
+	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
+
+	// Pipeline that returns an email.send intent.
+	research := &mockLLMClient{response: `{"type":"email.send","to":[{"email":"bob@example.com"}],"subject":"Hi","body_text":"Hello"}`}
+	srv.draftPipeline = draft.NewPipeline(research, research, source.NewRegistry(),
+		mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(),
+		vault.NewMemVault(), slog.Default(),
+		draft.Prompts{Research: "r", IntentResolution: "i", Ghostwrite: "g"})
+
+	// No trigger_id → should fall back to response_url.
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "Send email to Bob", "", respServer.URL)
+
+	mu.Lock()
+	got := body
+	mu.Unlock()
+	// Should contain the email preview text.
+	if got == "" {
+		t.Error("expected response sent to response_url for write action without trigger_id")
+	}
+}
+
+func TestProcessSlashCommand_EnclaveNotReady(t *testing.T) {
+	var mu sync.Mutex
+	var body string
+	respServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer respServer.Close()
+
+	srv := newCommandTestServer()
+	ctx := context.Background()
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
+	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
+	srv.draftPipeline = newTestPipeline("ctx", "answer")
+	srv.enclaveClient = &failingEnclaveClient{}
+	// Set kekSessionCache so Tier 4 (no-auth) doesn't bypass enclave check.
+	srv.kekSessionCache = auth.NewKEKSessionCache(24 * time.Hour)
+
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "question?", "", respServer.URL)
+
+	mu.Lock()
+	got := body
+	mu.Unlock()
+	if !strings.Contains(got, "starting up") {
+		t.Errorf("expected starting up message, got: %s", got)
+	}
+}
+
+func TestFormatIntentPreview_GitPR(t *testing.T) {
+	// Git action without issue fields → falls back to summary.
+	intent := draft.ResolvedIntent{
+		Type:    draft.IntentType("git.pull_request.create"),
+		Summary: "Create PR for feature",
+		Action: &model.ActionIntent{
+			Type: "git.pull_request.create",
+			Domain: model.DomainAction{Git: &model.GitAction{
+				Repository: "acme/app", Branch: "feat/x", BaseBranch: "main",
+			}},
+		},
+	}
+	got := formatIntentPreview(intent)
+	if got != "Create PR for feature" {
+		t.Errorf("expected summary fallback for PR, got %q", got)
+	}
+}
+
+func TestFormatIntentPreview_DefaultAction(t *testing.T) {
+	intent := draft.ResolvedIntent{
+		Type:    draft.IntentType("custom.action"),
+		Summary: "Do something custom",
+		Action:  &model.ActionIntent{Type: "custom.action", Summary: "Do something custom"},
+	}
+	got := formatIntentPreview(intent)
+	if got != "Do something custom" {
+		t.Errorf("expected summary fallback, got %q", got)
+	}
+}
+
+// --- openIntentModal test ---
+
+func TestOpenIntentModal_CallsSlackAPI(t *testing.T) {
+	var mu sync.Mutex
+	var receivedBody string
+	slackServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		receivedBody = string(b)
+		mu.Unlock()
+		w.Header().Set("Content-Type", "application/json")
+		json.NewEncoder(w).Encode(map[string]any{
+			"ok":   true,
+			"view": map[string]any{"id": "V_MODAL"},
+		})
+	}))
+	defer slackServer.Close()
+
+	comms.SetAgentAPIURL(slackServer.URL + "/")
+	defer comms.SetAgentAPIURL("")
+
+	srv := newCommandTestServer()
+	intent := draft.ResolvedIntent{
+		Type:    draft.IntentTypeEmailSend,
+		Summary: "Send email",
+		Action: &model.ActionIntent{
+			Type: "email.send",
+			Domain: model.DomainAction{Email: &model.EmailAction{
+				To: []model.Recipient{{Email: "alice@example.com"}},
+				Subject: "Test", BodyText: "Hello",
+			}},
+		},
+	}
+
+	srv.openIntentModal(context.Background(), "xoxb-test", "trig_123", "usr_a", "C_CHAN", intent)
+
+	mu.Lock()
+	body := receivedBody
+	mu.Unlock()
+
+	if body == "" {
+		t.Fatal("expected Slack API call for modal")
+	}
+	if !strings.Contains(body, intentModalCallbackID) {
+		t.Errorf("expected callback_id in modal request, got: %s", body)
+	}
+	if !strings.Contains(body, "Review") {
+		t.Errorf("expected 'Review' title in modal, got: %s", body)
+	}
+}
+
+func TestProcessSlashCommand_EmptyIntents(t *testing.T) {
+	var mu sync.Mutex
+	var body string
+	respServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer respServer.Close()
+
+	srv := newCommandTestServer()
+	ctx := context.Background()
+	srv.systemVault.Put(ctx, "slack-workspaces/T001/bot-token", []byte("xoxb-test"), vault.Metadata{})
+	seedTestUser(ctx, srv, "U_ALICE", "T001", "usr_a")
+
+	// Pipeline returns empty intents.
+	emptyClient := &mockLLMClient{response: ""}
+	srv.draftPipeline = draft.NewPipeline(emptyClient, emptyClient, source.NewRegistry(),
+		mem.NewConnectedAccountStore(), mem.NewUserInstructionStore(),
+		vault.NewMemVault(), slog.Default(),
+		draft.Prompts{Research: "r", Ghostwrite: "g"})
+
+	srv.processSlashCommand(ctx, "T001", "C_CHAN", "U_ALICE", "something", "", respServer.URL)
+
+	mu.Lock()
+	got := body
+	mu.Unlock()
+	// Should get a response even with empty ghostwrite (informational with empty text).
+	if got == "" {
+		t.Error("expected response to response_url")
+	}
+}
+
+func TestCommandRespondViaURL_HTTPError(t *testing.T) {
+	srv := newCommandTestServer()
+	// URL that immediately closes connection.
+	srv.respondViaURL("http://127.0.0.1:1/bad", "test message")
+	// Should not panic — just logs the error.
 }

--- a/internal/app/handlers_slack_interactions.go
+++ b/internal/app/handlers_slack_interactions.go
@@ -129,6 +129,31 @@ func (s *apiServer) handleSlackInteraction(w http.ResponseWriter, r *http.Reques
 		return
 	}
 
+	// Handle intent modal submission — user clicked "Send" on a write action preview.
+	if payload.Type == "view_submission" && payload.View != nil && payload.View.CallbackID == intentModalCallbackID {
+		var intentMeta IntentModalMeta
+		if err := json.Unmarshal([]byte(payload.View.PrivateMetadata), &intentMeta); err != nil {
+			s.log.Error("intent modal submit: failed to parse metadata", "error", err)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Deserialize the action.
+		var action model.ActionIntent
+		if err := json.Unmarshal([]byte(intentMeta.ActionJSON), &action); err != nil {
+			s.log.Error("intent modal submit: failed to parse action", "error", err)
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+
+		// Close the modal.
+		w.WriteHeader(http.StatusOK)
+
+		// Submit the intent asynchronously.
+		go s.executeIntentFromModal(context.Background(), intentMeta, action)
+		return
+	}
+
 	// Return 200 immediately — Slack requires fast response.
 	w.WriteHeader(http.StatusOK)
 
@@ -491,6 +516,85 @@ func (s *apiServer) processApproveIntent(ctx context.Context, actionValue string
 			msg += " " + result.ReceiptRef
 		}
 		s.respondToInteraction(payload.ResponseURL, msg)
+	}
+}
+
+// executeIntentFromModal handles the submission of an intent modal. It creates
+// the intent, evaluates policy, issues a grant, and executes — same flow as
+// processApproveIntent but initiated from a modal submission.
+func (s *apiServer) executeIntentFromModal(ctx context.Context, meta IntentModalMeta, action model.ActionIntent) {
+	now := time.Now().UTC()
+	intentID := "int_" + s.newID()
+
+	apiAction := api.ActionIntent{
+		Type:    action.Type,
+		Summary: action.Summary,
+	}
+	apiAction.Metadata = &map[string]interface{}{
+		"_model_domain": action.Domain,
+	}
+
+	envelope := api.IntentEnvelope{
+		IntentId:    intentID,
+		WorkspaceId: "default",
+		Agent:       api.ActorRef{Id: "aileron_slack", Type: api.Agent},
+		Action:      apiAction,
+		Status:      api.PendingPolicy,
+		CreatedAt:   now,
+		UpdatedAt:   now,
+		Decision:    api.Decision{Disposition: api.DecisionDispositionAllow, RiskLevel: api.Low},
+	}
+
+	if err := s.intents.Create(ctx, envelope); err != nil {
+		s.log.Error("intent modal: failed to create intent", "error", err)
+		return
+	}
+
+	decision, err := s.policyEngine.Evaluate(ctx, policy.EvaluationRequest{
+		WorkspaceID: "default",
+		AgentID:     "aileron_slack",
+		Action:      action,
+	})
+	if err != nil {
+		s.log.Error("intent modal: policy evaluation failed", "error", err)
+		return
+	}
+
+	if decision.Disposition == model.DispositionDeny {
+		envelope.Status = api.Denied
+		s.intents.Update(ctx, envelope)
+		s.log.Warn("intent modal: denied by policy", "intent_id", intentID, "reason", decision.DenialReason)
+		// TODO: Notify user via Slack DM that the action was denied.
+		return
+	}
+
+	grantID := "grt_" + s.newID()
+	s.grants.Create(ctx, api.ExecutionGrant{
+		GrantId:   grantID,
+		IntentId:  intentID,
+		Status:    api.ExecutionGrantStatusActive,
+		ExpiresAt: now.Add(5 * time.Minute),
+	})
+	envelope.Status = api.Approved
+	envelope.UpdatedAt = time.Now().UTC()
+	s.intents.Update(ctx, envelope)
+
+	result, execErr := s.executeGrant(ctx, grantID, meta.UserID)
+	if execErr != nil {
+		s.log.Error("intent modal: execution failed", "error", execErr)
+		return
+	}
+
+	if result.Status == api.ExecutionStatusFailed {
+		s.log.Error("intent modal: connector failed",
+			"execution_id", result.ExecutionID,
+			"error", result.Error,
+		)
+	} else {
+		s.log.Info("intent modal: execution succeeded",
+			"execution_id", result.ExecutionID,
+			"receipt_ref", result.ReceiptRef,
+		)
 	}
 }
 

--- a/internal/app/handlers_slack_interactions_test.go
+++ b/internal/app/handlers_slack_interactions_test.go
@@ -1235,3 +1235,505 @@ func TestInteraction_ApproveIntent_CreatesIntentAndGrant(t *testing.T) {
 		t.Errorf("grant intent_id = %q", grant.IntentId)
 	}
 }
+
+// --- executeIntentFromModal tests ---
+
+func TestInteraction_IntentModalSubmit_CreatesIntentAndGrant(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.intents = mem.NewIntentStore()
+	srv.grants = mem.NewGrantStore()
+	srv.executions = mem.NewExecutionStore()
+	srv.traces = mem.NewTraceStore()
+	srv.registry = connectorpkg.NewRegistry()
+	srv.policyEngine = policy.NewRuleEngine(mem.NewPolicyStore())
+
+	action := model.ActionIntent{
+		Type:    "git.issue.create",
+		Summary: "Create bug",
+		Domain: model.DomainAction{
+			Git: &model.GitAction{
+				Repository: "acme/app",
+				IssueTitle: "Login bug",
+			},
+		},
+	}
+	actionJSON, _ := json.Marshal(action)
+	meta := IntentModalMeta{
+		IntentType: "git.issue.create",
+		UserID:     "usr_a",
+		ChannelID:  "C_CHAN",
+		ActionJSON: string(actionJSON),
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "view_submission",
+		"user": map[string]any{"id": "U_ALICE"},
+		"view": map[string]any{
+			"id":               "view_123",
+			"callback_id":      intentModalCallbackID,
+			"private_metadata": string(metaJSON),
+		},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+
+	time.Sleep(200 * time.Millisecond)
+
+	ctx := context.Background()
+	intent, err := srv.intents.Get(ctx, "int_test-id")
+	if err != nil {
+		t.Fatalf("expected intent created: %v", err)
+	}
+	if intent.Action.Type != "git.issue.create" {
+		t.Errorf("action type = %q", intent.Action.Type)
+	}
+
+	grant, err := srv.grants.Get(ctx, "grt_test-id")
+	if err != nil {
+		t.Fatalf("expected grant created: %v", err)
+	}
+	if grant.IntentId != "int_test-id" {
+		t.Errorf("grant intent_id = %q", grant.IntentId)
+	}
+}
+
+func TestInteraction_IntentModalSubmit_BadMetadata(t *testing.T) {
+	srv := newInteractionTestServer()
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "view_submission",
+		"user": map[string]any{"id": "U_ALICE"},
+		"view": map[string]any{
+			"id":               "view_bad",
+			"callback_id":      intentModalCallbackID,
+			"private_metadata": "not-json",
+		},
+	})
+
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+
+	// Should not panic, just return 200.
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d", w.Code)
+	}
+}
+
+func TestInteraction_ApproveIntent_PolicyDeny(t *testing.T) {
+	srv := newInteractionTestServer()
+	policyStore := mem.NewPolicyStore()
+	// Create a deny policy for email.send.
+	denyEffect := api.PolicyRuleEffectDeny
+	actionField := "action.type"
+	eqOp := api.Eq
+	emailSend := "email.send"
+	condVal := api.PolicyCondition_Value{}
+	condVal.FromPolicyConditionValue0(emailSend)
+	priority := 100
+	desc := "deny email"
+	policyStore.Create(context.Background(), api.Policy{
+		PolicyId: "pol_deny", WorkspaceId: "default", Version: 1,
+		Status: api.PolicyStatusActive,
+		Rules: []api.PolicyRule{{
+			RuleId: "rule_deny", Effect: denyEffect, Priority: &priority,
+			Description: &desc,
+			Conditions: &[]api.PolicyCondition{{
+				Field: &actionField, Operator: &eqOp, Value: &condVal,
+			}},
+		}},
+	})
+	srv.intents = mem.NewIntentStore()
+	srv.grants = mem.NewGrantStore()
+	srv.executions = mem.NewExecutionStore()
+	srv.traces = mem.NewTraceStore()
+	srv.registry = connectorpkg.NewRegistry()
+	srv.policyEngine = policy.NewRuleEngine(policyStore)
+
+	var mu sync.Mutex
+	var body string
+	respServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer respServer.Close()
+
+	actionValue, _ := json.Marshal(map[string]any{
+		"type": "email.send", "user_id": "usr_a",
+		"action": map[string]any{"type": "email.send", "summary": "Send email"},
+	})
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions", "user": map[string]any{"id": "U_ALICE"},
+		"response_url": respServer.URL,
+		"actions": []map[string]any{{"action_id": "approve_intent", "value": string(actionValue)}},
+	})
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	got := body
+	mu.Unlock()
+	if !strings.Contains(got, "Denied by policy") {
+		t.Errorf("expected denial message, got: %s", got)
+	}
+}
+
+func TestInteraction_ApproveIntent_ExecutionSucceeds(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.intents = mem.NewIntentStore()
+	srv.grants = mem.NewGrantStore()
+	srv.executions = mem.NewExecutionStore()
+	srv.traces = mem.NewTraceStore()
+	srv.policyEngine = policy.NewRuleEngine(mem.NewPolicyStore())
+	enableVaultEncryption(srv, "usr_a")
+
+	conn := &stubConnector{
+		result: connectorpkg.ExecutionResult{
+			Status: connectorpkg.ExecutionStatusSucceeded, ReceiptRef: "https://example.com/done",
+		},
+	}
+	srv.registry = connectorpkg.NewRegistry()
+	srv.registry.Register(context.Background(), conn)
+	storeEncryptedToken(srv, "connectors/github/default", []byte("token"))
+
+	var mu sync.Mutex
+	var body string
+	respServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer respServer.Close()
+
+	actionValue, _ := json.Marshal(map[string]any{
+		"type": "git.push", "user_id": "usr_a",
+		"action": map[string]any{"type": "git.push", "summary": "Push code"},
+	})
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions", "user": map[string]any{"id": "U_ALICE"},
+		"response_url": respServer.URL,
+		"actions": []map[string]any{{"action_id": "approve_intent", "value": string(actionValue)}},
+	})
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	got := body
+	mu.Unlock()
+	if !strings.Contains(got, "Done") {
+		t.Errorf("expected success message, got: %s", got)
+	}
+}
+
+func TestInteraction_ApproveIntent_ExecutionFails(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.intents = mem.NewIntentStore()
+	srv.grants = mem.NewGrantStore()
+	srv.executions = mem.NewExecutionStore()
+	srv.traces = mem.NewTraceStore()
+	srv.policyEngine = policy.NewRuleEngine(mem.NewPolicyStore())
+	// No vault encryption → execution will fail with "vault locked"
+	srv.registry = connectorpkg.NewRegistry()
+	srv.registry.Register(context.Background(), &stubConnector{})
+	srv.vault.Put(context.Background(), "connectors/github/default", []byte("token"), vault.Metadata{})
+
+	var mu sync.Mutex
+	var body string
+	respServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer respServer.Close()
+
+	actionValue, _ := json.Marshal(map[string]any{
+		"type": "git.push", "user_id": "usr_fail",
+		"action": map[string]any{"type": "git.push", "summary": "Push"},
+	})
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions", "user": map[string]any{"id": "U_ALICE"},
+		"response_url": respServer.URL,
+		"actions": []map[string]any{{"action_id": "approve_intent", "value": string(actionValue)}},
+	})
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+	time.Sleep(300 * time.Millisecond)
+
+	mu.Lock()
+	got := body
+	mu.Unlock()
+	if !strings.Contains(got, "Execution failed") {
+		t.Errorf("expected failure message, got: %s", got)
+	}
+}
+
+func TestInteraction_IntentModalSubmit_PolicyDeny(t *testing.T) {
+	srv := newInteractionTestServer()
+	policyStore := mem.NewPolicyStore()
+	denyEffect := api.PolicyRuleEffectDeny
+	actionField := "action.type"
+	eqOp := api.Eq
+	emailSend := "email.send"
+	condVal := api.PolicyCondition_Value{}
+	condVal.FromPolicyConditionValue0(emailSend)
+	priority := 100
+	desc := "deny email"
+	policyStore.Create(context.Background(), api.Policy{
+		PolicyId: "pol_deny", WorkspaceId: "default", Version: 1,
+		Status: api.PolicyStatusActive,
+		Rules: []api.PolicyRule{{
+			RuleId: "rule_deny", Effect: denyEffect, Priority: &priority,
+			Description: &desc,
+			Conditions: &[]api.PolicyCondition{{
+				Field: &actionField, Operator: &eqOp, Value: &condVal,
+			}},
+		}},
+	})
+	srv.intents = mem.NewIntentStore()
+	srv.grants = mem.NewGrantStore()
+	srv.executions = mem.NewExecutionStore()
+	srv.traces = mem.NewTraceStore()
+	srv.registry = connectorpkg.NewRegistry()
+	srv.policyEngine = policy.NewRuleEngine(policyStore)
+
+	action := model.ActionIntent{Type: "email.send", Summary: "Send email"}
+	actionJSON, _ := json.Marshal(action)
+	meta := IntentModalMeta{
+		IntentType: "email.send", UserID: "usr_a",
+		ChannelID: "C_CHAN", ActionJSON: string(actionJSON),
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "view_submission",
+		"user": map[string]any{"id": "U_ALICE"},
+		"view": map[string]any{
+			"id": "view_deny", "callback_id": intentModalCallbackID,
+			"private_metadata": string(metaJSON),
+		},
+	})
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+	time.Sleep(200 * time.Millisecond)
+
+	intent, _ := srv.intents.Get(context.Background(), "int_test-id")
+	if intent.Status != api.Denied {
+		t.Errorf("intent status = %q, want denied", intent.Status)
+	}
+}
+
+func TestInteraction_IntentModalSubmit_ExecutionSucceeds(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.intents = mem.NewIntentStore()
+	srv.grants = mem.NewGrantStore()
+	srv.executions = mem.NewExecutionStore()
+	srv.traces = mem.NewTraceStore()
+	srv.policyEngine = policy.NewRuleEngine(mem.NewPolicyStore())
+	enableVaultEncryption(srv, "usr_a")
+
+	conn := &stubConnector{
+		result: connectorpkg.ExecutionResult{
+			Status: connectorpkg.ExecutionStatusSucceeded,
+			ReceiptRef: "https://example.com/result",
+		},
+	}
+	srv.registry = connectorpkg.NewRegistry()
+	srv.registry.Register(context.Background(), conn)
+	storeEncryptedToken(srv, "connectors/github/default", []byte("token"))
+
+	action := model.ActionIntent{Type: "git.push", Summary: "Push code"}
+	actionJSON, _ := json.Marshal(action)
+	meta := IntentModalMeta{
+		IntentType: "git.push", UserID: "usr_a",
+		ChannelID: "C_CHAN", ActionJSON: string(actionJSON),
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "view_submission",
+		"user": map[string]any{"id": "U_ALICE"},
+		"view": map[string]any{
+			"id": "view_ok", "callback_id": intentModalCallbackID,
+			"private_metadata": string(metaJSON),
+		},
+	})
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+	time.Sleep(300 * time.Millisecond)
+
+	// Verify execution record was created.
+	exec, err := srv.executions.Get(context.Background(), "exe_test-id")
+	if err != nil {
+		t.Fatalf("expected execution record: %v", err)
+	}
+	if exec.IntentId != "int_test-id" {
+		t.Errorf("execution intent_id = %q", exec.IntentId)
+	}
+}
+
+func TestInteraction_IntentModalSubmit_ExecutionFails(t *testing.T) {
+	srv := newInteractionTestServer()
+	srv.intents = mem.NewIntentStore()
+	srv.grants = mem.NewGrantStore()
+	srv.executions = mem.NewExecutionStore()
+	srv.traces = mem.NewTraceStore()
+	srv.policyEngine = policy.NewRuleEngine(mem.NewPolicyStore())
+	// No vault encryption → vault locked error.
+	srv.registry = connectorpkg.NewRegistry()
+	srv.registry.Register(context.Background(), &stubConnector{})
+
+	action := model.ActionIntent{Type: "git.push", Summary: "Push"}
+	actionJSON, _ := json.Marshal(action)
+	meta := IntentModalMeta{
+		IntentType: "git.push", UserID: "usr_fail",
+		ChannelID: "C_CHAN", ActionJSON: string(actionJSON),
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "view_submission",
+		"user": map[string]any{"id": "U_ALICE"},
+		"view": map[string]any{
+			"id": "view_fail", "callback_id": intentModalCallbackID,
+			"private_metadata": string(metaJSON),
+		},
+	})
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+	time.Sleep(300 * time.Millisecond)
+
+	// Intent should exist but execution should have failed.
+	intent, _ := srv.intents.Get(context.Background(), "int_test-id")
+	if intent.IntentId == "" {
+		t.Fatal("expected intent to be created")
+	}
+}
+
+func TestInteraction_RespondToInteraction_HTTPError(t *testing.T) {
+	srv := newInteractionTestServer()
+	// Unreachable URL — should not panic.
+	srv.respondToInteraction("http://127.0.0.1:1/bad", "test")
+}
+
+func TestInteraction_ApproveIntent_DenyWithEmptyReason(t *testing.T) {
+	srv := newInteractionTestServer()
+	policyStore := mem.NewPolicyStore()
+	// Deny policy with NO description → should use default "blocked by policy".
+	denyEffect := api.PolicyRuleEffectDeny
+	actionField := "action.type"
+	eqOp := api.Eq
+	condVal := api.PolicyCondition_Value{}
+	condVal.FromPolicyConditionValue0("email.send")
+	priority := 100
+	policyStore.Create(context.Background(), api.Policy{
+		PolicyId: "pol_deny", WorkspaceId: "default", Version: 1,
+		Status: api.PolicyStatusActive,
+		Rules: []api.PolicyRule{{
+			RuleId: "rule_deny", Effect: denyEffect, Priority: &priority,
+			// No Description field → empty denial reason.
+			Conditions: &[]api.PolicyCondition{{
+				Field: &actionField, Operator: &eqOp, Value: &condVal,
+			}},
+		}},
+	})
+	srv.intents = mem.NewIntentStore()
+	srv.grants = mem.NewGrantStore()
+	srv.executions = mem.NewExecutionStore()
+	srv.traces = mem.NewTraceStore()
+	srv.registry = connectorpkg.NewRegistry()
+	srv.policyEngine = policy.NewRuleEngine(policyStore)
+
+	var mu sync.Mutex
+	var body string
+	respServer := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		b, _ := io.ReadAll(r.Body)
+		mu.Lock()
+		body = string(b)
+		mu.Unlock()
+		w.WriteHeader(http.StatusOK)
+	}))
+	defer respServer.Close()
+
+	actionValue, _ := json.Marshal(map[string]any{
+		"type": "email.send", "user_id": "usr_a",
+		"action": map[string]any{"type": "email.send", "summary": "Send"},
+	})
+	payload, _ := json.Marshal(map[string]any{
+		"type": "block_actions", "user": map[string]any{"id": "U_ALICE"},
+		"response_url": respServer.URL,
+		"actions": []map[string]any{{"action_id": "approve_intent", "value": string(actionValue)}},
+	})
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+	time.Sleep(200 * time.Millisecond)
+
+	mu.Lock()
+	got := body
+	mu.Unlock()
+	if !strings.Contains(got, "Denied by policy") {
+		t.Errorf("expected denial message, got: %s", got)
+	}
+}
+
+func TestInteraction_IntentModalSubmit_ExecutionError(t *testing.T) {
+	// executeIntentFromModal where executeGrant itself returns an error
+	// (not a failed result, but an actual Go error — e.g., grant expired).
+	srv := newInteractionTestServer()
+	srv.intents = mem.NewIntentStore()
+	srv.grants = mem.NewGrantStore()
+	srv.executions = mem.NewExecutionStore()
+	srv.traces = mem.NewTraceStore()
+	srv.policyEngine = policy.NewRuleEngine(mem.NewPolicyStore())
+	srv.registry = connectorpkg.NewRegistry()
+	// Don't seed any vault credentials — execution will fail.
+
+	action := model.ActionIntent{Type: "git.push", Summary: "Push"}
+	actionJSON, _ := json.Marshal(action)
+	meta := IntentModalMeta{
+		IntentType: "git.push", UserID: "usr_x",
+		ChannelID: "C_CHAN", ActionJSON: string(actionJSON),
+	}
+	metaJSON, _ := json.Marshal(meta)
+
+	payload, _ := json.Marshal(map[string]any{
+		"type": "view_submission",
+		"user": map[string]any{"id": "U_ALICE"},
+		"view": map[string]any{
+			"id": "view_err", "callback_id": intentModalCallbackID,
+			"private_metadata": string(metaJSON),
+		},
+	})
+	w := httptest.NewRecorder()
+	r, _ := signedInteractionRequest(string(payload))
+	srv.handleSlackInteraction(w, r)
+	time.Sleep(300 * time.Millisecond)
+
+	// Should not panic. Intent should exist.
+	intent, _ := srv.intents.Get(context.Background(), "int_test-id")
+	if intent.IntentId == "" {
+		t.Fatal("expected intent to be created even if execution fails")
+	}
+}


### PR DESCRIPTION
## Summary

- **Unified slash command flow**: `/aileron` now uses `ResolveIntents` instead of separate draft/question paths. The LLM decides what to do — no more `isDraftRequest` heuristic.
- **Intent modal for write actions**: When the intent resolver classifies a write action, a Slack modal opens with an editable preview. User clicks Send to approve and execute.
- **Intent modal submission handler**: `executeIntentFromModal` creates intent, evaluates policy, issues grant, and calls `executeGrant` end-to-end.
- **`buildModelDomainParams`**: Fixes domain field serialization — the Slack flow stores model types in intent metadata, and this function extracts them into connector parameters.
- **Removed `isDraftRequest`**: The old keyword-based heuristic is gone. Intent classification is now handled by the LLM.

## What changed

The `/aileron` slash command had two paths:
1. `isDraftRequest` matched keywords → opened modal → `GenerateDraft` → text draft
2. Everything else → `processSlashCommandQuestion` → `GenerateDraft` → response_url

Now there's one path:
```
/aileron <anything> → ResolveIntents → 
    Write action: open modal with preview → Send → policy → execute
    Informational: respond via response_url
```

This is the same flow as the agent DM, just with different presentation (modal vs inline message).

## Test plan

- [x] All existing tests updated for new `processSlashCommand` signature
- [x] Full test suite passes
- [x] Server binary builds
- [ ] Manual: `/aileron send an email to X` → intent modal with email preview → Send → email sent
- [ ] Manual: `/aileron what's on my calendar?` → informational response via response_url

Relates to #309

🤖 Generated with [Claude Code](https://claude.com/claude-code)