### PR TITLE
security: route tool execution through enclave via SourceExecute

### DIFF
--- a/internal/app/handlers_tools.go
+++ b/internal/app/handlers_tools.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"net/http"
 
+	"github.com/ALRubinger/aileron/internal/enclave"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/source"
 	"github.com/ALRubinger/aileron/internal/store"
@@ -108,14 +109,51 @@ func (s *apiServer) handleExecuteTool(w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	// Get the OAuth token from the vault.
-	secret, err := s.vault.Get(r.Context(), acct.VaultPath())
+	vaultPath := acct.VaultPath()
+
+	// Enclave path: if the credential is escrowed in the TEE, execute the
+	// tool inside the enclave so plaintext never reaches the host.
+	if s.enclaveClient != nil {
+		if escrowIDVal, ok := s.escrowIndex.Load(vaultPath); ok {
+			resp, err := s.enclaveClient.SourceExecute(r.Context(), enclave.SourceExecuteRequest{
+				EscrowID: escrowIDVal.(string),
+				Tool:     req.Tool,
+				Params:   req.Params,
+			})
+			if err != nil {
+				s.log.Error("enclave tool execution failed", "tool", req.Tool, "error", err)
+				writeError(w, http.StatusInternalServerError, "execution_error", err.Error())
+				return
+			}
+			if resp.Error != "" {
+				writeError(w, http.StatusInternalServerError, "execution_error", resp.Error)
+				return
+			}
+			if resp.Result == nil {
+				writeJSON(w, http.StatusOK, map[string]any{})
+				return
+			}
+			var result map[string]any
+			if err := json.Unmarshal(resp.Result, &result); err != nil {
+				writeError(w, http.StatusInternalServerError, "execution_error", "failed to parse tool result")
+				return
+			}
+			writeJSON(w, http.StatusOK, result)
+			return
+		}
+
+		// Enclave is active but no escrow entry — vault is locked.
+		writeError(w, http.StatusForbidden, "vault_locked", "credentials are not available; unlock your vault to escrow them into the enclave")
+		return
+	}
+
+	// Non-enclave path: read credentials from the vault on the host.
+	secret, err := s.vault.Get(r.Context(), vaultPath)
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "vault_error", "failed to retrieve credentials")
 		return
 	}
 
-	// Execute the tool.
 	result, err := s.sourceRegistry.ExecuteTool(r.Context(), req.Tool, req.Params, secret.Value)
 	if err != nil {
 		s.log.Error("tool execution failed", "tool", req.Tool, "error", err)

--- a/internal/app/handlers_tools_test.go
+++ b/internal/app/handlers_tools_test.go
@@ -9,11 +9,51 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ALRubinger/aileron/internal/enclave"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/source"
 	"github.com/ALRubinger/aileron/internal/store/mem"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
+
+// toolsEnclaveClient implements enclave.Client for tool handler tests,
+// capturing SourceExecute calls.
+type toolsEnclaveClient struct {
+	sourceResp enclave.SourceExecuteResponse
+	sourceErr  error
+	sourceReq  *enclave.SourceExecuteRequest // last captured request
+}
+
+func (c *toolsEnclaveClient) Attest(_ context.Context, _ enclave.AttestationRequest) (enclave.AttestationResponse, error) {
+	return enclave.AttestationResponse{}, nil
+}
+func (c *toolsEnclaveClient) EstablishSession(_ context.Context, _ enclave.SessionRequest) (enclave.SessionResponse, error) {
+	return enclave.SessionResponse{}, nil
+}
+func (c *toolsEnclaveClient) TransmitKEK(_ context.Context, _ enclave.TransmitKEKRequest) (enclave.TransmitKEKResponse, error) {
+	return enclave.TransmitKEKResponse{}, nil
+}
+func (c *toolsEnclaveClient) OAuthExchange(_ context.Context, _ enclave.OAuthExchangeRequest) (enclave.OAuthExchangeResponse, error) {
+	return enclave.OAuthExchangeResponse{}, nil
+}
+func (c *toolsEnclaveClient) Execute(_ context.Context, _ enclave.ExecuteRequest) (enclave.ExecuteResponse, error) {
+	return enclave.ExecuteResponse{}, nil
+}
+func (c *toolsEnclaveClient) EscrowStore(_ context.Context, _ enclave.EscrowStoreRequest) (enclave.EscrowStoreResponse, error) {
+	return enclave.EscrowStoreResponse{}, nil
+}
+func (c *toolsEnclaveClient) EscrowList(_ context.Context) (enclave.EscrowListResponse, error) {
+	return enclave.EscrowListResponse{}, nil
+}
+func (c *toolsEnclaveClient) EscrowRevoke(_ context.Context, _ enclave.EscrowRevokeRequest) error {
+	return nil
+}
+func (c *toolsEnclaveClient) SourceExecute(_ context.Context, req enclave.SourceExecuteRequest) (enclave.SourceExecuteResponse, error) {
+	c.sourceReq = &req
+	return c.sourceResp, c.sourceErr
+}
+func (c *toolsEnclaveClient) Ready(_ context.Context) error { return nil }
+func (c *toolsEnclaveClient) Close() error                  { return nil }
 
 // stubSourceConnector is a minimal SourceConnector for handler tests.
 type stubSourceConnector struct{}
@@ -269,5 +309,164 @@ func TestExecuteTool_InactiveAccount(t *testing.T) {
 
 	if w.Code != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestExecuteTool_EnclaveRoute_Success(t *testing.T) {
+	// When the enclave is active and credentials are escrowed, tool execution
+	// must route through SourceExecute — plaintext never touches the host.
+	srv := newToolsTestServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+
+	resultJSON, _ := json.Marshal(map[string]any{"messages": []string{"hello"}})
+	mock := &toolsEnclaveClient{
+		sourceResp: enclave.SourceExecuteResponse{Result: resultJSON},
+	}
+	srv.enclaveClient = mock
+	srv.escrowIndex.Store("connected-accounts/usr_a/slack", "esc_123")
+
+	body := `{"tool":"slack_channel_history","params":{"channel":"C0BACKEND"}}`
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/tools/execute", body, userAClaims)
+	srv.handleExecuteTool(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
+	}
+
+	// Verify the request was routed through the enclave.
+	if mock.sourceReq == nil {
+		t.Fatal("expected SourceExecute to be called")
+	}
+	if mock.sourceReq.EscrowID != "esc_123" {
+		t.Errorf("EscrowID = %q, want esc_123", mock.sourceReq.EscrowID)
+	}
+	if mock.sourceReq.Tool != "slack_channel_history" {
+		t.Errorf("Tool = %q, want slack_channel_history", mock.sourceReq.Tool)
+	}
+
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	if resp["messages"] == nil {
+		t.Errorf("expected messages in response, got %v", resp)
+	}
+}
+
+func TestExecuteTool_EnclaveRoute_Error(t *testing.T) {
+	// When SourceExecute returns a tool-level error, it should be surfaced.
+	srv := newToolsTestServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+
+	mock := &toolsEnclaveClient{
+		sourceResp: enclave.SourceExecuteResponse{Error: "channel not found"},
+	}
+	srv.enclaveClient = mock
+	srv.escrowIndex.Store("connected-accounts/usr_a/slack", "esc_123")
+
+	body := `{"tool":"slack_channel_history","params":{"channel":"C_NONEXIST"}}`
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/tools/execute", body, userAClaims)
+	srv.handleExecuteTool(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "channel not found") {
+		t.Errorf("expected error message in response, got %s", w.Body.String())
+	}
+}
+
+func TestExecuteTool_EnclaveActive_NoEscrow_Forbidden(t *testing.T) {
+	// When the enclave is active but the user has no escrowed credentials,
+	// the endpoint must reject the request — not fall through to host-side
+	// credential access.
+	srv := newToolsTestServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+
+	srv.enclaveClient = &toolsEnclaveClient{}
+	// No escrow entries — vault is locked.
+
+	body := `{"tool":"slack_channel_history","params":{"channel":"C0BACKEND"}}`
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/tools/execute", body, userAClaims)
+	srv.handleExecuteTool(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), "vault_locked") {
+		t.Errorf("expected vault_locked error code, got %s", w.Body.String())
+	}
+}
+
+func TestExecuteTool_EnclaveRoute_TransportError(t *testing.T) {
+	// When the enclave is unreachable, the transport error is surfaced.
+	srv := newToolsTestServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+
+	mock := &toolsEnclaveClient{
+		sourceErr: context.DeadlineExceeded,
+	}
+	srv.enclaveClient = mock
+	srv.escrowIndex.Store("connected-accounts/usr_a/slack", "esc_123")
+
+	body := `{"tool":"slack_channel_history","params":{"channel":"C0BACKEND"}}`
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/tools/execute", body, userAClaims)
+	srv.handleExecuteTool(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Fatalf("expected 500, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestExecuteTool_NoEnclave_HostExecution(t *testing.T) {
+	// Without an enclave, tool execution uses the host vault — existing behavior.
+	srv := newToolsTestServer()
+	ctx := context.Background()
+
+	srv.connectedAccounts.Create(ctx, model.ConnectedAccount{
+		ID:       "conn_s1",
+		UserID:   "usr_a",
+		Provider: model.ConnectedAccountProviderSlack,
+		Status:   model.ConnectedAccountStatusActive,
+	})
+	srv.vault.Put(ctx, "connected-accounts/usr_a/slack", []byte(`{"access_token":"xoxp-test"}`), vault.Metadata{Type: "oauth_user_token"})
+
+	body := `{"tool":"slack_channel_history","params":{"channel":"C0BACKEND"}}`
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/tools/execute", body, userAClaims)
+	srv.handleExecuteTool(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("expected 200, got %d: %s", w.Code, w.Body.String())
 	}
 }


### PR DESCRIPTION
## Summary

- When enclave is active and credentials are escrowed, `handleExecuteTool` now routes through `SourceExecute` inside the TEE — plaintext credentials never touch host memory
- When enclave is active but no escrow entry exists, returns 403 `vault_locked` instead of falling through to host-side credential access
- Host-side execution preserved only when no enclave is configured (local dev)

Phase 2 of #321.

## Test plan

- [x] All existing tests pass (`go test ./internal/... ./cmd/aileron-enclave/...`)
- [x] `handleExecuteTool` at 82% coverage
- [x] `TestExecuteTool_EnclaveRoute_Success` — verifies SourceExecute is called with correct escrow ID and tool params
- [x] `TestExecuteTool_EnclaveRoute_Error` — tool-level errors surfaced correctly
- [x] `TestExecuteTool_EnclaveRoute_TransportError` — enclave transport failures surfaced
- [x] `TestExecuteTool_EnclaveActive_NoEscrow_Forbidden` — returns 403 when vault is locked
- [x] `TestExecuteTool_NoEnclave_HostExecution` — existing host-side path preserved

🤖 Generated with [Claude Code](https://claude.com/claude-code)