### PR TITLE
security: reject plaintext credential ingress in enclave mode

### DIFF
--- a/internal/app/handlers_connected_accounts.go
+++ b/internal/app/handlers_connected_accounts.go
@@ -56,10 +56,11 @@ func (s *apiServer) handleCreateConnectedAccount(w http.ResponseWriter, r *http.
 
 	// Store token in vault if provided.
 	if len(req.Token) > 0 {
-		// Enclave mode: reject plaintext token ingress. In TEE deployments,
-		// credentials must flow through the OAuth callback which routes
-		// through the enclave for KEK-encrypted storage.
-		if s.enclaveClient != nil {
+		// Production enclave mode: reject plaintext token ingress. In TEE
+		// deployments, credentials must flow through the OAuth callback
+		// which routes through the enclave for KEK-encrypted storage.
+		// The local dev provider is exempt since it has no real isolation.
+		if s.enclaveClient != nil && s.teeCfg != nil && s.teeCfg.Provider != "local" {
 			writeError(w, http.StatusForbidden, "enclave_mode", "plaintext token submission is not permitted in enclave mode; use the OAuth connect flow")
 			return
 		}

--- a/internal/app/handlers_connected_accounts.go
+++ b/internal/app/handlers_connected_accounts.go
@@ -56,6 +56,14 @@ func (s *apiServer) handleCreateConnectedAccount(w http.ResponseWriter, r *http.
 
 	// Store token in vault if provided.
 	if len(req.Token) > 0 {
+		// Enclave mode: reject plaintext token ingress. In TEE deployments,
+		// credentials must flow through the OAuth callback which routes
+		// through the enclave for KEK-encrypted storage.
+		if s.enclaveClient != nil {
+			writeError(w, http.StatusForbidden, "enclave_mode", "plaintext token submission is not permitted in enclave mode; use the OAuth connect flow")
+			return
+		}
+
 		tokenJSON, _ := json.Marshal(req.Token)
 		if err := s.vault.Put(r.Context(), acct.VaultPath(), tokenJSON, vault.Metadata{
 			Type: "oauth_token",

--- a/internal/app/handlers_connected_accounts_test.go
+++ b/internal/app/handlers_connected_accounts_test.go
@@ -12,6 +12,7 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/account"
 	api "github.com/ALRubinger/aileron/internal/api/gen"
+	"github.com/ALRubinger/aileron/internal/config"
 	"github.com/ALRubinger/aileron/internal/auth"
 	"github.com/ALRubinger/aileron/internal/crypto"
 	"github.com/ALRubinger/aileron/internal/model"
@@ -904,7 +905,8 @@ func TestConnectedAccountToAPI(t *testing.T) {
 
 func TestCreateConnectedAccount_EnclaveMode_TokenForbidden(t *testing.T) {
 	srv := newConnectedAccountServer()
-	srv.enclaveClient = &toolsEnclaveClient{} // enclave active
+	srv.enclaveClient = &toolsEnclaveClient{}
+	srv.teeCfg = &config.TEEConfig{Provider: "confidential-space"}
 
 	body := `{"provider":"slack","token":{"access_token":"xoxp-test"}}`
 	w := httptest.NewRecorder()

--- a/internal/app/handlers_connected_accounts_test.go
+++ b/internal/app/handlers_connected_accounts_test.go
@@ -902,3 +902,33 @@ func TestConnectedAccountToAPI(t *testing.T) {
 	}
 }
 
+func TestCreateConnectedAccount_EnclaveMode_TokenForbidden(t *testing.T) {
+	srv := newConnectedAccountServer()
+	srv.enclaveClient = &toolsEnclaveClient{} // enclave active
+
+	body := `{"provider":"slack","token":{"access_token":"xoxp-test"}}`
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/connected-accounts", body, userAClaims)
+	srv.handleCreateConnectedAccount(w, r)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}
+
+func TestCreateConnectedAccount_EnclaveMode_NoToken_Allowed(t *testing.T) {
+	// Creating a connected account WITHOUT a token should still work
+	// in enclave mode — only plaintext credential ingress is blocked.
+	srv := newConnectedAccountServer()
+	srv.enclaveClient = &toolsEnclaveClient{} // enclave active
+
+	body := `{"provider":"slack","external_user_id":"U123"}`
+	w := httptest.NewRecorder()
+	r := mcpRequest("POST", "/v1/connected-accounts", body, userAClaims)
+	srv.handleCreateConnectedAccount(w, r)
+
+	if w.Code != http.StatusCreated {
+		t.Fatalf("expected 201, got %d: %s", w.Code, w.Body.String())
+	}
+}
+

--- a/internal/app/handlers_llm_config.go
+++ b/internal/app/handlers_llm_config.go
@@ -37,6 +37,13 @@ func (s *apiServer) handleUpsertUserLLMConfig(w http.ResponseWriter, r *http.Req
 		return
 	}
 
+	// Enclave mode: reject plaintext API key ingress. In TEE deployments,
+	// credentials must never traverse host memory as plaintext.
+	if s.enclaveClient != nil {
+		writeError(w, http.StatusForbidden, "enclave_mode", "plaintext API key submission is not permitted in enclave mode")
+		return
+	}
+
 	now := time.Now().UTC()
 	cfg := model.LLMConfig{
 		ID:             "llm_" + s.newID(),
@@ -152,6 +159,12 @@ func (s *apiServer) handleUpsertEnterpriseLLMConfig(w http.ResponseWriter, r *ht
 	}
 	if req.APIKey == "" {
 		writeError(w, http.StatusBadRequest, "invalid_body", "api_key is required")
+		return
+	}
+
+	// Enclave mode: reject plaintext API key ingress.
+	if s.enclaveClient != nil {
+		writeError(w, http.StatusForbidden, "enclave_mode", "plaintext API key submission is not permitted in enclave mode")
 		return
 	}
 

--- a/internal/app/handlers_llm_config.go
+++ b/internal/app/handlers_llm_config.go
@@ -37,9 +37,10 @@ func (s *apiServer) handleUpsertUserLLMConfig(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	// Enclave mode: reject plaintext API key ingress. In TEE deployments,
-	// credentials must never traverse host memory as plaintext.
-	if s.enclaveClient != nil {
+	// Production enclave mode: reject plaintext API key ingress. In TEE
+	// deployments, credentials must never traverse host memory as plaintext.
+	// The local dev provider is exempt since it has no real isolation.
+	if s.enclaveClient != nil && s.teeCfg != nil && s.teeCfg.Provider != "local" {
 		writeError(w, http.StatusForbidden, "enclave_mode", "plaintext API key submission is not permitted in enclave mode")
 		return
 	}

--- a/internal/app/handlers_llm_config_test.go
+++ b/internal/app/handlers_llm_config_test.go
@@ -748,3 +748,34 @@ func TestHandleDeleteEnterpriseLLMConfig_BadPath(t *testing.T) {
 		t.Fatalf("expected 400, got %d", w.Code)
 	}
 }
+
+func TestHandleUpsertUserLLMConfig_EnclaveMode_Forbidden(t *testing.T) {
+	s := newTestLLMConfigServer()
+	s.enclaveClient = &toolsEnclaveClient{} // enclave active
+
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-test"}`
+	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
+	w := httptest.NewRecorder()
+	s.handleUpsertUserLLMConfig(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("enclave_mode")) {
+		t.Errorf("expected enclave_mode error code, got %s", w.Body.String())
+	}
+}
+
+func TestHandleUpsertEnterpriseLLMConfig_EnclaveMode_Forbidden(t *testing.T) {
+	s := newTestEnterpriseLLMConfigServer()
+	s.enclaveClient = &toolsEnclaveClient{} // enclave active
+
+	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-test"}`
+	req := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)))
+	w := httptest.NewRecorder()
+	s.handleUpsertEnterpriseLLMConfig(w, req)
+
+	if w.Code != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d: %s", w.Code, w.Body.String())
+	}
+}

--- a/internal/app/handlers_llm_config_test.go
+++ b/internal/app/handlers_llm_config_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ALRubinger/aileron/internal/auth"
+	"github.com/ALRubinger/aileron/internal/config"
 	"github.com/golang-jwt/jwt/v5"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/store"
@@ -751,7 +752,8 @@ func TestHandleDeleteEnterpriseLLMConfig_BadPath(t *testing.T) {
 
 func TestHandleUpsertUserLLMConfig_EnclaveMode_Forbidden(t *testing.T) {
 	s := newTestLLMConfigServer()
-	s.enclaveClient = &toolsEnclaveClient{} // enclave active
+	s.enclaveClient = &toolsEnclaveClient{}
+	s.teeCfg = &config.TEEConfig{Provider: "confidential-space"}
 
 	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-test"}`
 	req := httptest.NewRequest("PUT", "/v1/llm-config", bytes.NewBufferString(body))
@@ -768,7 +770,8 @@ func TestHandleUpsertUserLLMConfig_EnclaveMode_Forbidden(t *testing.T) {
 
 func TestHandleUpsertEnterpriseLLMConfig_EnclaveMode_Forbidden(t *testing.T) {
 	s := newTestEnterpriseLLMConfigServer()
-	s.enclaveClient = &toolsEnclaveClient{} // enclave active
+	s.enclaveClient = &toolsEnclaveClient{}
+	s.teeCfg = &config.TEEConfig{Provider: "confidential-space"}
 
 	body := `{"provider":"anthropic","model_research":"haiku","model_synthesis":"sonnet","api_key":"sk-test"}`
 	req := withAdminAuth(httptest.NewRequest("PUT", "/v1/enterprises/ent_1/llm-config", bytes.NewBufferString(body)))


### PR DESCRIPTION
## Summary

- `PUT /v1/llm-config`, `PUT /v1/enterprises/{id}/llm-config`, and `POST /v1/connected-accounts` (with token) now return 403 when running in a production TEE provider (e.g., `confidential-space`) — plaintext credentials must never traverse host memory in multitenant TEE deployments
- The guard is scoped to production providers; the local dev TEE provider is exempt since it has no real hardware isolation and is used for development/testing
- Creating a connected account without a token (metadata only) remains allowed in all modes
- The `EncryptedLabel` metadata gap noted in the review is not a defect: `autoEscrowCredentials` correctly skips non-KEK-encrypted credentials because the enclave can only decrypt with the user's KEK

Phase 3 of #321. Phase 4 (attestation hardening) will be a separate PR.

## Test plan

- [x] All existing unit tests pass
- [x] `TestHandleUpsertUserLLMConfig_EnclaveMode_Forbidden` — returns 403 with confidential-space provider
- [x] `TestHandleUpsertEnterpriseLLMConfig_EnclaveMode_Forbidden` — returns 403
- [x] `TestCreateConnectedAccount_EnclaveMode_TokenForbidden` — returns 403 when token provided
- [x] `TestCreateConnectedAccount_EnclaveMode_NoToken_Allowed` — 201 when no token (metadata only)
- [x] Integration tests pass — local TEE provider is exempt from the guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)