### PR TITLE
[codex] Require Confidential Space identity pins

### DIFF
--- a/internal/app/enclave.go
+++ b/internal/app/enclave.go
@@ -29,6 +29,12 @@ func newEnclaveClient(cfg *config.TEEConfig, log *slog.Logger, registry *connect
 		if cfg.EnclaveURL == "" {
 			return nil, nil, fmt.Errorf("AILERON_ENCLAVE_URL required for confidential-space provider")
 		}
+		if cfg.ImageDigest == "" {
+			return nil, nil, fmt.Errorf("AILERON_ENCLAVE_IMAGE_DIGEST required for confidential-space provider")
+		}
+		if cfg.ProjectID == "" {
+			return nil, nil, fmt.Errorf("AILERON_GCP_PROJECT_ID required for confidential-space provider")
+		}
 		log.Info("TEE provider: Google Confidential Space", "url", cfg.EnclaveURL)
 		client := gcs.New(gcs.Config{BaseURL: cfg.EnclaveURL})
 		verifier := &gcs.Verifier{

--- a/internal/app/enclave_test.go
+++ b/internal/app/enclave_test.go
@@ -67,6 +67,48 @@ func TestNewEnclaveClient_ConfidentialSpaceNoURL(t *testing.T) {
 	}
 }
 
+func TestNewEnclaveClient_ConfidentialSpaceRequiresImageDigest(t *testing.T) {
+	cfg := &config.TEEConfig{
+		Provider:   "confidential-space",
+		EnclaveURL: "https://enclave.example.com:8443",
+		ProjectID:  "my-project",
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	registry := connector.NewRegistry()
+
+	client, verifier, err := newEnclaveClient(cfg, log, registry)
+	if err == nil {
+		t.Fatal("expected error for confidential-space without ImageDigest")
+	}
+	if client != nil {
+		t.Fatal("expected nil client on error")
+	}
+	if verifier != nil {
+		t.Fatal("expected nil verifier on error")
+	}
+}
+
+func TestNewEnclaveClient_ConfidentialSpaceRequiresProjectID(t *testing.T) {
+	cfg := &config.TEEConfig{
+		Provider:    "confidential-space",
+		EnclaveURL:  "https://enclave.example.com:8443",
+		ImageDigest: "sha256:abc123",
+	}
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	registry := connector.NewRegistry()
+
+	client, verifier, err := newEnclaveClient(cfg, log, registry)
+	if err == nil {
+		t.Fatal("expected error for confidential-space without ProjectID")
+	}
+	if client != nil {
+		t.Fatal("expected nil client on error")
+	}
+	if verifier != nil {
+		t.Fatal("expected nil verifier on error")
+	}
+}
+
 func TestNewEnclaveClient_ConfidentialSpaceWithURL(t *testing.T) {
 	cfg := &config.TEEConfig{
 		Provider:    "confidential-space",

--- a/internal/enclave/gcs/verifier.go
+++ b/internal/enclave/gcs/verifier.go
@@ -82,17 +82,23 @@ func (v *Verifier) Verify(ctx context.Context, token string, nonce []byte) (encl
 		return enclave.AttestationClaims{}, fmt.Errorf("gcs: decoding JWT claims: %w", err)
 	}
 	var claims struct {
-		Iss          string   `json:"iss"`
-		Exp          int64    `json:"exp"`
-		Iat          int64    `json:"iat"`
-		EatNonce     []string `json:"eat_nonce"`
-		ImageDigest  string   `json:"image_digest"`
-		ProjectID    string   `json:"project_id"`
-		HWModel      string   `json:"hwmodel"`
-		SwName       string   `json:"swname"`
+		Iss         string   `json:"iss"`
+		Exp         int64    `json:"exp"`
+		Iat         int64    `json:"iat"`
+		EatNonce    []string `json:"eat_nonce"`
+		ImageDigest string   `json:"image_digest"`
+		ProjectID   string   `json:"project_id"`
+		HWModel     string   `json:"hwmodel"`
+		SwName      string   `json:"swname"`
 	}
 	if err := json.Unmarshal(claimsBytes, &claims); err != nil {
 		return enclave.AttestationClaims{}, fmt.Errorf("gcs: parsing JWT claims: %w", err)
+	}
+	if v.ExpectedImageDigest == "" {
+		return enclave.AttestationClaims{}, errors.New("gcs: expected image digest is required")
+	}
+	if v.ExpectedProjectID == "" {
+		return enclave.AttestationClaims{}, errors.New("gcs: expected project ID is required")
 	}
 
 	now := time.Now()
@@ -124,10 +130,10 @@ func (v *Verifier) Verify(ctx context.Context, token string, nonce []byte) (encl
 	}
 
 	// Validate workload identity.
-	if v.ExpectedImageDigest != "" && claims.ImageDigest != v.ExpectedImageDigest {
+	if claims.ImageDigest != v.ExpectedImageDigest {
 		return enclave.AttestationClaims{}, fmt.Errorf("gcs: image digest mismatch: got %q, want %q", claims.ImageDigest, v.ExpectedImageDigest)
 	}
-	if v.ExpectedProjectID != "" && claims.ProjectID != v.ExpectedProjectID {
+	if claims.ProjectID != v.ExpectedProjectID {
 		return enclave.AttestationClaims{}, fmt.Errorf("gcs: project ID mismatch: got %q, want %q", claims.ProjectID, v.ExpectedProjectID)
 	}
 

--- a/internal/enclave/gcs/verifier_test.go
+++ b/internal/enclave/gcs/verifier_test.go
@@ -16,6 +16,11 @@ import (
 	"time"
 )
 
+const (
+	testImageDigest = "sha256:abc123"
+	testProjectID   = "my-project"
+)
+
 // buildTestJWT creates a signed JWT for testing.
 func buildTestJWT(t *testing.T, key *rsa.PrivateKey, kid string, claims map[string]any) string {
 	t.Helper()
@@ -85,14 +90,14 @@ func TestVerifyValidToken(t *testing.T) {
 		"exp":          expTime.Unix(),
 		"iat":          now.Unix(),
 		"eat_nonce":    []string{nonceB64},
-		"image_digest": "sha256:abc123",
-		"project_id":   "my-project",
+		"image_digest": testImageDigest,
+		"project_id":   testProjectID,
 		"hwmodel":      "GCP_AMD_SEV",
 	})
 
 	v := &Verifier{
-		ExpectedImageDigest: "sha256:abc123",
-		ExpectedProjectID:   "my-project",
+		ExpectedImageDigest: testImageDigest,
+		ExpectedProjectID:   testProjectID,
 		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
 	}
 
@@ -120,6 +125,56 @@ func TestVerifyValidToken(t *testing.T) {
 	}
 }
 
+func TestVerifyRequiresExpectedImageDigest(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	kid := "test-key-1"
+	server := setupTestServer(t, &key.PublicKey, kid)
+	defer server.Close()
+
+	nonce := []byte("nonce")
+	token := buildTestJWT(t, key, kid, map[string]any{
+		"iss":          "https://accounts.google.com",
+		"exp":          time.Now().Add(time.Hour).Unix(),
+		"eat_nonce":    []string{base64.RawURLEncoding.EncodeToString(nonce)},
+		"image_digest": testImageDigest,
+		"project_id":   testProjectID,
+	})
+
+	v := &Verifier{
+		ExpectedProjectID: testProjectID,
+		DiscoveryURL:      server.URL + "/.well-known/openid-configuration",
+	}
+	_, err := v.Verify(context.Background(), token, nonce)
+	if err == nil {
+		t.Fatal("expected error for missing expected image digest")
+	}
+}
+
+func TestVerifyRequiresExpectedProjectID(t *testing.T) {
+	key, _ := rsa.GenerateKey(rand.Reader, 2048)
+	kid := "test-key-1"
+	server := setupTestServer(t, &key.PublicKey, kid)
+	defer server.Close()
+
+	nonce := []byte("nonce")
+	token := buildTestJWT(t, key, kid, map[string]any{
+		"iss":          "https://accounts.google.com",
+		"exp":          time.Now().Add(time.Hour).Unix(),
+		"eat_nonce":    []string{base64.RawURLEncoding.EncodeToString(nonce)},
+		"image_digest": testImageDigest,
+		"project_id":   testProjectID,
+	})
+
+	v := &Verifier{
+		ExpectedImageDigest: testImageDigest,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
+	}
+	_, err := v.Verify(context.Background(), token, nonce)
+	if err == nil {
+		t.Fatal("expected error for missing expected project ID")
+	}
+}
+
 func TestVerifyExpiredToken(t *testing.T) {
 	key, _ := rsa.GenerateKey(rand.Reader, 2048)
 	kid := "test-key-1"
@@ -133,7 +188,11 @@ func TestVerifyExpiredToken(t *testing.T) {
 		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
 	})
 
-	v := &Verifier{DiscoveryURL: server.URL + "/.well-known/openid-configuration"}
+	v := &Verifier{
+		ExpectedImageDigest: testImageDigest,
+		ExpectedProjectID:   testProjectID,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
+	}
 	_, err := v.Verify(context.Background(), token, nonce)
 	if err == nil {
 		t.Fatal("expected error for expired token")
@@ -153,7 +212,11 @@ func TestVerifyWrongIssuer(t *testing.T) {
 		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
 	})
 
-	v := &Verifier{DiscoveryURL: server.URL + "/.well-known/openid-configuration"}
+	v := &Verifier{
+		ExpectedImageDigest: testImageDigest,
+		ExpectedProjectID:   testProjectID,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
+	}
 	_, err := v.Verify(context.Background(), token, nonce)
 	if err == nil {
 		t.Fatal("expected error for wrong issuer")
@@ -172,7 +235,11 @@ func TestVerifyNonceMismatch(t *testing.T) {
 		"eat_nonce": []string{"wrong-nonce"},
 	})
 
-	v := &Verifier{DiscoveryURL: server.URL + "/.well-known/openid-configuration"}
+	v := &Verifier{
+		ExpectedImageDigest: testImageDigest,
+		ExpectedProjectID:   testProjectID,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
+	}
 	_, err := v.Verify(context.Background(), token, []byte("correct-nonce"))
 	if err == nil {
 		t.Fatal("expected error for nonce mismatch")
@@ -196,6 +263,7 @@ func TestVerifyImageDigestMismatch(t *testing.T) {
 
 	v := &Verifier{
 		ExpectedImageDigest: "sha256:correct",
+		ExpectedProjectID:   testProjectID,
 		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
 	}
 	_, err := v.Verify(context.Background(), token, nonce)
@@ -228,8 +296,9 @@ func TestVerifyProjectIDMismatch(t *testing.T) {
 	})
 
 	v := &Verifier{
-		ExpectedProjectID: "my-project",
-		DiscoveryURL:      server.URL + "/.well-known/openid-configuration",
+		ExpectedImageDigest: "sha256:abc",
+		ExpectedProjectID:   testProjectID,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
 	}
 	_, err := v.Verify(context.Background(), token, nonce)
 	if err == nil {
@@ -250,7 +319,11 @@ func TestVerifyKeyNotFound(t *testing.T) {
 		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
 	})
 
-	v := &Verifier{DiscoveryURL: server.URL + "/.well-known/openid-configuration"}
+	v := &Verifier{
+		ExpectedImageDigest: testImageDigest,
+		ExpectedProjectID:   testProjectID,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
+	}
 	_, err := v.Verify(context.Background(), token, nonce)
 	if err == nil {
 		t.Fatal("expected error for key not found")
@@ -279,8 +352,10 @@ func TestVerifyWithNowFunc(t *testing.T) {
 
 	// Use NowFunc to simulate time far in the future (expired).
 	v := &Verifier{
-		DiscoveryURL: server.URL + "/.well-known/openid-configuration",
-		NowFunc:      func() time.Time { return time.Now().Add(2 * time.Hour) },
+		ExpectedImageDigest: testImageDigest,
+		ExpectedProjectID:   testProjectID,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
+		NowFunc:             func() time.Time { return time.Now().Add(2 * time.Hour) },
 	}
 	_, err := v.Verify(context.Background(), token, nonce)
 	if err == nil {
@@ -296,14 +371,18 @@ func TestVerifyWithCustomHTTPClient(t *testing.T) {
 
 	nonce := []byte("nonce")
 	token := buildTestJWT(t, key, kid, map[string]any{
-		"iss":       "https://accounts.google.com",
-		"exp":       time.Now().Add(time.Hour).Unix(),
-		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
+		"iss":          "https://accounts.google.com",
+		"exp":          time.Now().Add(time.Hour).Unix(),
+		"eat_nonce":    []string{base64.RawURLEncoding.EncodeToString(nonce)},
+		"image_digest": testImageDigest,
+		"project_id":   testProjectID,
 	})
 
 	v := &Verifier{
-		DiscoveryURL: server.URL + "/.well-known/openid-configuration",
-		HTTPClient:   &http.Client{Timeout: 5 * time.Second},
+		ExpectedImageDigest: testImageDigest,
+		ExpectedProjectID:   testProjectID,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
+		HTTPClient:          &http.Client{Timeout: 5 * time.Second},
 	}
 	_, err := v.Verify(context.Background(), token, nonce)
 	if err != nil {
@@ -348,9 +427,11 @@ func TestVerifyES256Token(t *testing.T) {
 	// Build ES256 JWT.
 	header, _ := json.Marshal(map[string]string{"alg": "ES256", "kid": kid})
 	claims, _ := json.Marshal(map[string]any{
-		"iss":       "https://accounts.google.com",
-		"exp":       time.Now().Add(time.Hour).Unix(),
-		"eat_nonce": []string{nonceB64},
+		"iss":          "https://accounts.google.com",
+		"exp":          time.Now().Add(time.Hour).Unix(),
+		"eat_nonce":    []string{nonceB64},
+		"image_digest": testImageDigest,
+		"project_id":   testProjectID,
 	})
 	headerB64 := base64.RawURLEncoding.EncodeToString(header)
 	claimsB64 := base64.RawURLEncoding.EncodeToString(claims)
@@ -365,7 +446,11 @@ func TestVerifyES256Token(t *testing.T) {
 	sigB64 := base64.RawURLEncoding.EncodeToString(sig)
 	token := signingInput + "." + sigB64
 
-	v := &Verifier{DiscoveryURL: server.URL + "/.well-known/openid-configuration"}
+	v := &Verifier{
+		ExpectedImageDigest: testImageDigest,
+		ExpectedProjectID:   testProjectID,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
+	}
 	_, err = v.Verify(context.Background(), token, nonce)
 	if err != nil {
 		t.Fatalf("Verify ES256: %v", err)
@@ -411,7 +496,11 @@ func TestVerifyWrongSignature(t *testing.T) {
 		"eat_nonce": []string{base64.RawURLEncoding.EncodeToString(nonce)},
 	})
 
-	v := &Verifier{DiscoveryURL: server.URL + "/.well-known/openid-configuration"}
+	v := &Verifier{
+		ExpectedImageDigest: testImageDigest,
+		ExpectedProjectID:   testProjectID,
+		DiscoveryURL:        server.URL + "/.well-known/openid-configuration",
+	}
 	_, err := v.Verify(context.Background(), token, nonce)
 	if err == nil {
 		t.Fatal("expected error for wrong signature")


### PR DESCRIPTION
## Summary

Phase 1 of #326: make Confidential Space enclave identity pinning mandatory before production enclave startup or attestation verification can proceed.

## Changes

- Reject `confidential-space` startup when `AILERON_ENCLAVE_IMAGE_DIGEST` is missing.
- Reject `confidential-space` startup when `AILERON_GCP_PROJECT_ID` is missing.
- Make the GCS verifier reject verification if either expected identity pin is not configured.
- Update verifier tests so successful verification always exercises pinned image/project identity.

## Validation

- `go test ./internal/app ./internal/enclave/gcs`
- `go test -cover ./internal/app ./internal/enclave/gcs`
  - `internal/app`: 76.2%
  - `internal/enclave/gcs`: 87.0%
- `go test ./internal/...`

## Notes

After this PR is merged, the Phase 1 checklist in #326 can be checked off. This PR intentionally does not close #326; later phases still need enclave-enforced escrow scope, request integrity, verifiable grants, sealed escrow key handling, and browser/client-visible identity work.