### PR TITLE
[codex] Enforce enclave escrow ownership scope

### DIFF
--- a/cmd/aileron-enclave/escrow.go
+++ b/cmd/aileron-enclave/escrow.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"reflect"
 	"sync"
 	"time"
 
@@ -15,11 +16,17 @@ import (
 )
 
 type escrowEntry struct {
-	grantID     string
-	credential  []byte // plaintext, held in enclave memory
-	credType    string
-	actionTypes []string
-	expiresAt   time.Time
+	userID            string
+	grantID           string
+	enforceGrantID    bool
+	vaultPath         string
+	provider          string
+	credential        []byte // plaintext, held in enclave memory
+	credType          string
+	actionTypes       []string
+	sourceTools       []string
+	allowedParameters map[string]any
+	expiresAt         time.Time
 }
 
 type escrowStore struct {
@@ -31,11 +38,17 @@ type escrowStore struct {
 
 // persistedEntry is the JSON-serializable form of an escrow entry.
 type persistedEntry struct {
-	GrantID     string    `json:"grant_id"`
-	Credential  []byte    `json:"credential"`
-	CredType    string    `json:"cred_type"`
-	ActionTypes []string  `json:"action_types"`
-	ExpiresAt   time.Time `json:"expires_at"`
+	UserID            string         `json:"user_id"`
+	GrantID           string         `json:"grant_id"`
+	EnforceGrantID    bool           `json:"enforce_grant_id,omitempty"`
+	VaultPath         string         `json:"vault_path"`
+	Provider          string         `json:"provider"`
+	Credential        []byte         `json:"credential"`
+	CredType          string         `json:"cred_type"`
+	ActionTypes       []string       `json:"action_types"`
+	SourceTools       []string       `json:"source_tools,omitempty"`
+	AllowedParameters map[string]any `json:"allowed_parameters,omitempty"`
+	ExpiresAt         time.Time      `json:"expires_at"`
 }
 
 func newEscrowStore(dataDir string) (*escrowStore, error) {
@@ -68,18 +81,24 @@ func newEscrowStore(dataDir string) (*escrowStore, error) {
 }
 
 // Store adds a plaintext credential to the escrow. Returns the escrow ID.
-func (s *escrowStore) Store(grantID string, credential []byte, credType string, actionTypes []string, expiresAt time.Time) string {
+func (s *escrowStore) Store(req enclave.EscrowStoreRequest, credential []byte, expiresAt time.Time) string {
 	b := make([]byte, 16)
 	rand.Read(b)
 	id := "esc_" + hex.EncodeToString(b)
 
 	s.mu.Lock()
 	s.entries[id] = &escrowEntry{
-		grantID:     grantID,
-		credential:  credential,
-		credType:    credType,
-		actionTypes: actionTypes,
-		expiresAt:   expiresAt,
+		userID:            req.UserID,
+		grantID:           req.GrantID,
+		enforceGrantID:    req.EnforceGrantID,
+		vaultPath:         req.VaultPath,
+		provider:          req.Provider,
+		credential:        credential,
+		credType:          req.CredentialType,
+		actionTypes:       append([]string(nil), req.ActionTypes...),
+		sourceTools:       append([]string(nil), req.SourceTools...),
+		allowedParameters: cloneMap(req.AllowedParameters),
+		expiresAt:         expiresAt,
 	}
 	s.persistLocked()
 	s.mu.Unlock()
@@ -102,6 +121,77 @@ func (s *escrowStore) Get(escrowID string) ([]byte, error) {
 	return copyBytes(entry.credential), nil
 }
 
+// GetForExecute retrieves a credential only when the execution request matches
+// the owner and scope bound to the escrow entry.
+func (s *escrowStore) GetForExecute(req enclave.ExecuteRequest) ([]byte, error) {
+	entry, err := s.entry(req.EscrowID)
+	if err != nil {
+		return nil, err
+	}
+	if entry.userID != "" && entry.userID != req.UserID {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.enforceGrantID && entry.grantID != req.GrantID {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.vaultPath != "" && entry.vaultPath != req.VaultPath {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.provider != "" && entry.provider != req.Provider {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.credType != "" && entry.credType != req.CredentialType {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if len(entry.actionTypes) > 0 && !containsString(entry.actionTypes, req.ActionType) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if len(entry.allowedParameters) > 0 && !reflect.DeepEqual(entry.allowedParameters, req.Parameters) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	return copyBytes(entry.credential), nil
+}
+
+// GetForSource retrieves a credential only when the source tool request matches
+// the owner and scope bound to the escrow entry.
+func (s *escrowStore) GetForSource(req enclave.SourceExecuteRequest) ([]byte, error) {
+	entry, err := s.entry(req.EscrowID)
+	if err != nil {
+		return nil, err
+	}
+	if entry.userID != "" && entry.userID != req.UserID {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.vaultPath != "" && entry.vaultPath != req.VaultPath {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.provider != "" && entry.provider != req.Provider {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if len(entry.sourceTools) > 0 && !containsString(entry.sourceTools, req.Tool) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if len(entry.allowedParameters) > 0 && !reflect.DeepEqual(entry.allowedParameters, req.Params) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	return copyBytes(entry.credential), nil
+}
+
+func (s *escrowStore) entry(escrowID string) (*escrowEntry, error) {
+	s.mu.RLock()
+	entry, ok := s.entries[escrowID]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, enclave.ErrEscrowNotFound
+	}
+	if time.Now().After(entry.expiresAt) {
+		s.revokeByID(escrowID)
+		return nil, enclave.ErrEscrowExpired
+	}
+	return entry, nil
+}
+
 // List returns metadata for all non-expired escrow entries.
 func (s *escrowStore) List() []enclave.EscrowListEntry {
 	now := time.Now()
@@ -116,6 +206,9 @@ func (s *escrowStore) List() []enclave.EscrowListEntry {
 		entries = append(entries, enclave.EscrowListEntry{
 			EscrowID:  id,
 			GrantID:   entry.grantID,
+			UserID:    entry.userID,
+			VaultPath: entry.vaultPath,
+			Provider:  entry.provider,
 			ExpiresAt: entry.expiresAt.Format(time.RFC3339),
 		})
 	}
@@ -198,11 +291,17 @@ func (s *escrowStore) persistLocked() {
 	persisted := make(map[string]*persistedEntry, len(s.entries))
 	for id, e := range s.entries {
 		persisted[id] = &persistedEntry{
-			GrantID:     e.grantID,
-			Credential:  e.credential,
-			CredType:    e.credType,
-			ActionTypes: e.actionTypes,
-			ExpiresAt:   e.expiresAt,
+			UserID:            e.userID,
+			GrantID:           e.grantID,
+			EnforceGrantID:    e.enforceGrantID,
+			VaultPath:         e.vaultPath,
+			Provider:          e.provider,
+			Credential:        e.credential,
+			CredType:          e.credType,
+			ActionTypes:       e.actionTypes,
+			SourceTools:       e.sourceTools,
+			AllowedParameters: e.allowedParameters,
+			ExpiresAt:         e.expiresAt,
 		}
 	}
 
@@ -248,12 +347,38 @@ func (s *escrowStore) load() error {
 
 	for id, pe := range persisted {
 		s.entries[id] = &escrowEntry{
-			grantID:     pe.GrantID,
-			credential:  pe.Credential,
-			credType:    pe.CredType,
-			actionTypes: pe.ActionTypes,
-			expiresAt:   pe.ExpiresAt,
+			userID:            pe.UserID,
+			grantID:           pe.GrantID,
+			enforceGrantID:    pe.EnforceGrantID,
+			vaultPath:         pe.VaultPath,
+			provider:          pe.Provider,
+			credential:        pe.Credential,
+			credType:          pe.CredType,
+			actionTypes:       pe.ActionTypes,
+			sourceTools:       pe.SourceTools,
+			allowedParameters: pe.AllowedParameters,
+			expiresAt:         pe.ExpiresAt,
 		}
 	}
 	return nil
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }

--- a/cmd/aileron-enclave/escrow_test.go
+++ b/cmd/aileron-enclave/escrow_test.go
@@ -22,10 +22,23 @@ func mustNewEscrowStore(t *testing.T) *escrowStore {
 	return s
 }
 
+func testEscrowRequest(grantID, credType string, actionTypes []string) enclave.EscrowStoreRequest {
+	return enclave.EscrowStoreRequest{
+		UserID:         "user-1",
+		GrantID:        grantID,
+		EnforceGrantID: true,
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: credType,
+		ActionTypes:    actionTypes,
+		SourceTools:    []string{"test_search", "gmail_search"},
+	}
+}
+
 func TestEscrowStoreAndGet(t *testing.T) {
 	s := mustNewEscrowStore(t)
 	cred := []byte("test-cred")
-	id := s.Store("grant-1", cred, "api_key", []string{"action"}, time.Now().Add(time.Hour))
+	id := s.Store(testEscrowRequest("grant-1", "api_key", []string{"action"}), cred, time.Now().Add(time.Hour))
 
 	got, err := s.Get(id)
 	if err != nil {
@@ -43,6 +56,90 @@ func TestEscrowStoreAndGet(t *testing.T) {
 	}
 }
 
+func TestEscrowGetForExecuteEnforcesScope(t *testing.T) {
+	s := mustNewEscrowStore(t)
+	req := testEscrowRequest("grant-1", "api_key", []string{"email.send"})
+	req.AllowedParameters = map[string]any{"to": "a@example.com"}
+	id := s.Store(req, []byte("scoped-cred"), time.Now().Add(time.Hour))
+
+	valid := enclave.ExecuteRequest{
+		EscrowID:       id,
+		UserID:         "user-1",
+		GrantID:        "grant-1",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "api_key",
+		ActionType:     "email.send",
+		Parameters:     map[string]any{"to": "a@example.com"},
+	}
+	if _, err := s.GetForExecute(valid); err != nil {
+		t.Fatalf("GetForExecute valid scope: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*enclave.ExecuteRequest)
+	}{
+		{"user", func(r *enclave.ExecuteRequest) { r.UserID = "user-2" }},
+		{"grant", func(r *enclave.ExecuteRequest) { r.GrantID = "grant-2" }},
+		{"vault", func(r *enclave.ExecuteRequest) { r.VaultPath = "connected-accounts/user-2/gmail" }},
+		{"provider", func(r *enclave.ExecuteRequest) { r.Provider = "slack" }},
+		{"credential type", func(r *enclave.ExecuteRequest) { r.CredentialType = "oauth2" }},
+		{"action", func(r *enclave.ExecuteRequest) { r.ActionType = "email.delete" }},
+		{"params", func(r *enclave.ExecuteRequest) { r.Parameters = map[string]any{"to": "b@example.com"} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := valid
+			tt.mutate(&candidate)
+			_, err := s.GetForExecute(candidate)
+			if err != enclave.ErrEscrowScopeMismatch {
+				t.Fatalf("expected ErrEscrowScopeMismatch, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEscrowGetForSourceEnforcesScope(t *testing.T) {
+	s := mustNewEscrowStore(t)
+	req := testEscrowRequest("grant-1", "oauth2", nil)
+	req.AllowedParameters = map[string]any{"query": "from:boss"}
+	id := s.Store(req, []byte("token"), time.Now().Add(time.Hour))
+
+	valid := enclave.SourceExecuteRequest{
+		EscrowID:  id,
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "gmail_search",
+		Params:    map[string]any{"query": "from:boss"},
+	}
+	if _, err := s.GetForSource(valid); err != nil {
+		t.Fatalf("GetForSource valid scope: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*enclave.SourceExecuteRequest)
+	}{
+		{"user", func(r *enclave.SourceExecuteRequest) { r.UserID = "user-2" }},
+		{"vault", func(r *enclave.SourceExecuteRequest) { r.VaultPath = "connected-accounts/user-2/gmail" }},
+		{"provider", func(r *enclave.SourceExecuteRequest) { r.Provider = "slack" }},
+		{"tool", func(r *enclave.SourceExecuteRequest) { r.Tool = "gmail_delete_everything" }},
+		{"params", func(r *enclave.SourceExecuteRequest) { r.Params = map[string]any{"query": "to:boss"} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := valid
+			tt.mutate(&candidate)
+			_, err := s.GetForSource(candidate)
+			if err != enclave.ErrEscrowScopeMismatch {
+				t.Fatalf("expected ErrEscrowScopeMismatch, got %v", err)
+			}
+		})
+	}
+}
+
 func TestEscrowNotFound(t *testing.T) {
 	s := mustNewEscrowStore(t)
 	_, err := s.Get("nonexistent")
@@ -53,7 +150,7 @@ func TestEscrowNotFound(t *testing.T) {
 
 func TestEscrowExpired(t *testing.T) {
 	s := mustNewEscrowStore(t)
-	id := s.Store("g1", []byte("dead"), "api_key", nil, time.Now().Add(-time.Second))
+	id := s.Store(testEscrowRequest("g1", "api_key", nil), []byte("dead"), time.Now().Add(-time.Second))
 	_, err := s.Get(id)
 	if err != enclave.ErrEscrowExpired {
 		t.Fatalf("expected ErrEscrowExpired, got %v", err)
@@ -62,7 +159,7 @@ func TestEscrowExpired(t *testing.T) {
 
 func TestEscrowRevokeWrongGrant(t *testing.T) {
 	s := mustNewEscrowStore(t)
-	id := s.Store("grant-1", []byte("cred"), "api_key", nil, time.Now().Add(time.Hour))
+	id := s.Store(testEscrowRequest("grant-1", "api_key", nil), []byte("cred"), time.Now().Add(time.Hour))
 	err := s.Revoke(id, "wrong-grant")
 	if err != enclave.ErrEscrowNotFound {
 		t.Fatalf("expected ErrEscrowNotFound, got %v", err)
@@ -73,8 +170,8 @@ func TestEscrowEvictExpired(t *testing.T) {
 	s := mustNewEscrowStore(t)
 	live := []byte("live")
 	dead := []byte("dead")
-	liveID := s.Store("g1", live, "api_key", nil, time.Now().Add(time.Hour))
-	s.Store("g2", dead, "api_key", nil, time.Now().Add(-time.Second))
+	liveID := s.Store(testEscrowRequest("g1", "api_key", nil), live, time.Now().Add(time.Hour))
+	s.Store(testEscrowRequest("g2", "api_key", nil), dead, time.Now().Add(-time.Second))
 
 	s.EvictExpired()
 
@@ -105,8 +202,8 @@ func TestEscrowPersistence_RoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newEscrowStore: %v", err)
 	}
-	id1 := s1.Store("grant-1", []byte("cred-one"), "oauth", nil, time.Now().Add(time.Hour))
-	id2 := s1.Store("grant-2", []byte("cred-two"), "api_key", []string{"email.send"}, time.Now().Add(2*time.Hour))
+	id1 := s1.Store(testEscrowRequest("grant-1", "oauth", nil), []byte("cred-one"), time.Now().Add(time.Hour))
+	id2 := s1.Store(testEscrowRequest("grant-2", "api_key", []string{"email.send"}), []byte("cred-two"), time.Now().Add(2*time.Hour))
 
 	// Create a new escrow store from the same directory — simulates restart.
 	s2, err := newEscrowStore(dir)
@@ -139,7 +236,7 @@ func TestEscrowPersistence_ExpiredNotLoaded(t *testing.T) {
 		t.Fatalf("newEscrowStore: %v", err)
 	}
 	// Store an already-expired entry.
-	id := s1.Store("g1", []byte("expired-cred"), "oauth", nil, time.Now().Add(-time.Second))
+	id := s1.Store(testEscrowRequest("g1", "oauth", nil), []byte("expired-cred"), time.Now().Add(-time.Second))
 
 	// Restart — expired entry should be evicted on load.
 	s2, err := newEscrowStore(dir)
@@ -209,7 +306,7 @@ func TestEscrowPersistence_CorruptJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("newEscrowStore: %v", err)
 	}
-	s1.Store("g1", []byte("cred"), "api_key", nil, time.Now().Add(time.Hour))
+	s1.Store(testEscrowRequest("g1", "api_key", nil), []byte("cred"), time.Now().Add(time.Hour))
 
 	// Now overwrite escrow.dat with data that decrypts to invalid JSON.
 	// We use the existing key to encrypt garbage JSON.
@@ -235,7 +332,7 @@ func TestEscrowPersistence_CorruptJSON(t *testing.T) {
 func TestEscrowUpdate_HappyPath(t *testing.T) {
 	s := mustNewEscrowStore(t)
 	original := []byte(`{"access_token":"old","refresh_token":"r1"}`)
-	id := s.Store("g1", original, "oauth2", nil, time.Now().Add(time.Hour))
+	id := s.Store(testEscrowRequest("g1", "oauth2", nil), original, time.Now().Add(time.Hour))
 
 	updated := []byte(`{"access_token":"new","refresh_token":"r2"}`)
 	if err := s.Update(id, updated); err != nil {
@@ -268,7 +365,7 @@ func TestEscrowUpdate_NotFound(t *testing.T) {
 
 func TestEscrowUpdate_Expired(t *testing.T) {
 	s := mustNewEscrowStore(t)
-	id := s.Store("g1", []byte("cred"), "oauth2", nil, time.Now().Add(-time.Second))
+	id := s.Store(testEscrowRequest("g1", "oauth2", nil), []byte("cred"), time.Now().Add(-time.Second))
 	err := s.Update(id, []byte("new"))
 	if err != enclave.ErrEscrowExpired {
 		t.Errorf("expected ErrEscrowExpired, got %v", err)
@@ -282,7 +379,7 @@ func TestEscrowUpdate_Persistence(t *testing.T) {
 		t.Fatalf("newEscrowStore: %v", err)
 	}
 
-	id := s1.Store("g1", []byte("old"), "oauth2", nil, time.Now().Add(time.Hour))
+	id := s1.Store(testEscrowRequest("g1", "oauth2", nil), []byte("old"), time.Now().Add(time.Hour))
 	if err := s1.Update(id, []byte("refreshed")); err != nil {
 		t.Fatalf("Update: %v", err)
 	}
@@ -303,9 +400,9 @@ func TestEscrowUpdate_Persistence(t *testing.T) {
 
 func TestEscrowList(t *testing.T) {
 	s := mustNewEscrowStore(t)
-	s.Store("g1", []byte("c1"), "oauth", nil, time.Now().Add(time.Hour))
-	s.Store("g2", []byte("c2"), "api_key", nil, time.Now().Add(time.Hour))
-	s.Store("g3", []byte("expired"), "api_key", nil, time.Now().Add(-time.Second))
+	s.Store(testEscrowRequest("g1", "oauth", nil), []byte("c1"), time.Now().Add(time.Hour))
+	s.Store(testEscrowRequest("g2", "api_key", nil), []byte("c2"), time.Now().Add(time.Hour))
+	s.Store(testEscrowRequest("g3", "api_key", nil), []byte("expired"), time.Now().Add(-time.Second))
 
 	entries := s.List()
 	if len(entries) != 2 {

--- a/cmd/aileron-enclave/server.go
+++ b/cmd/aileron-enclave/server.go
@@ -59,7 +59,7 @@ func (s *enclaveServer) registerRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("POST /oauth/exchange", s.handleOAuthExchange)
 	mux.HandleFunc("POST /execute", s.handleExecute)
 	mux.HandleFunc("POST /escrow", s.handleEscrowStore)
-mux.HandleFunc("POST /escrow/list", s.handleEscrowList)
+	mux.HandleFunc("POST /escrow/list", s.handleEscrowList)
 	mux.HandleFunc("POST /escrow/revoke", s.handleEscrowRevoke)
 	mux.HandleFunc("POST /source/execute", s.handleSourceExecute)
 	mux.HandleFunc("GET /health", s.handleHealth)
@@ -233,9 +233,9 @@ func (s *enclaveServer) handleExecute(w http.ResponseWriter, r *http.Request) {
 	// Resolve credential.
 	var credential []byte
 	if req.EscrowID != "" {
-		cred, err := s.escrow.Get(req.EscrowID)
+		cred, err := s.escrow.GetForExecute(req)
 		if err != nil {
-			writeErr(w, http.StatusNotFound, err.Error())
+			writeEscrowErr(w, err)
 			return
 		}
 		credential = cred
@@ -304,6 +304,26 @@ func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	if req.UserID == "" {
+		writeErr(w, http.StatusBadRequest, "user_id required")
+		return
+	}
+	if req.GrantID == "" {
+		writeErr(w, http.StatusBadRequest, "grant_id required")
+		return
+	}
+	if req.VaultPath == "" {
+		writeErr(w, http.StatusBadRequest, "vault_path required")
+		return
+	}
+	if req.Provider == "" {
+		writeErr(w, http.StatusBadRequest, "provider required")
+		return
+	}
+	if req.CredentialType == "" {
+		writeErr(w, http.StatusBadRequest, "credential_type required")
+		return
+	}
 
 	// Decrypt credential with user's KEK.
 	kek, err := s.keks.Get(req.UserID)
@@ -326,7 +346,7 @@ func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	id := s.escrow.Store(req.GrantID, plaintext, req.CredentialType, req.ActionTypes, expiresAt)
+	id := s.escrow.Store(req, plaintext, expiresAt)
 	writeJSON(w, http.StatusOK, enclave.EscrowStoreResponse{EscrowID: id})
 }
 
@@ -358,9 +378,9 @@ func (s *enclaveServer) handleSourceExecute(w http.ResponseWriter, r *http.Reque
 	}
 
 	// Resolve credential from escrow — plaintext stays inside the enclave.
-	credential, err := s.escrow.Get(req.EscrowID)
+	credential, err := s.escrow.GetForSource(req)
 	if err != nil {
-		writeErr(w, http.StatusNotFound, err.Error())
+		writeEscrowErr(w, err)
 		return
 	}
 
@@ -431,6 +451,14 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 
 func writeErr(w http.ResponseWriter, status int, msg string) {
 	writeJSON(w, status, map[string]string{"error": msg})
+}
+
+func writeEscrowErr(w http.ResponseWriter, err error) {
+	status := http.StatusNotFound
+	if err == enclave.ErrEscrowScopeMismatch {
+		status = http.StatusForbidden
+	}
+	writeErr(w, status, err.Error())
 }
 
 func zeroBytes(b []byte) {

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -4,10 +4,10 @@ import (
 	"bytes"
 	"context"
 	"crypto/ecdh"
-	"fmt"
 	"crypto/rand"
 	"crypto/sha256"
 	"encoding/json"
+	"fmt"
 	"io"
 	"log/slog"
 	"net/http"
@@ -93,6 +93,21 @@ func decodeResp[T any](t *testing.T, resp *http.Response) T {
 		t.Fatalf("decoding response: %v", err)
 	}
 	return v
+}
+
+func validEscrowStoreRequest(encrypted []byte) enclave.EscrowStoreRequest {
+	return enclave.EscrowStoreRequest{
+		UserID:              "user-1",
+		GrantID:             "grant-1",
+		EnforceGrantID:      true,
+		VaultPath:           "connected-accounts/user-1/gmail",
+		Provider:            "gmail",
+		EncryptedCredential: encrypted,
+		CredentialType:      "api_key",
+		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
+		ActionTypes:         []string{"test.action"},
+		SourceTools:         []string{"test_search"},
+	}
 }
 
 // establishTestSession performs attest → session and returns the session key.
@@ -263,13 +278,7 @@ func TestEscrowFlow(t *testing.T) {
 	encrypted, _ := crypto.Encrypt([]byte("escrowed-cred"), userKEK)
 
 	// Store.
-	storeResp := postJSON(t, server, "/escrow", enclave.EscrowStoreRequest{
-		UserID:              "user-1",
-		GrantID:             "grant-1",
-		EncryptedCredential: encrypted,
-		CredentialType:      "api_key",
-		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
-	})
+	storeResp := postJSON(t, server, "/escrow", validEscrowStoreRequest(encrypted))
 	storeResult := decodeResp[enclave.EscrowStoreResponse](t, storeResp)
 	if storeResult.EscrowID == "" {
 		t.Fatal("empty escrow ID")
@@ -277,9 +286,15 @@ func TestEscrowFlow(t *testing.T) {
 
 	// Execute with escrow.
 	execResp := postJSON(t, server, "/execute", enclave.ExecuteRequest{
-		RequestID:   "exec-escrow",
-		ConnectorID: "test/stub",
-		EscrowID:    storeResult.EscrowID,
+		RequestID:      "exec-escrow",
+		UserID:         "user-1",
+		GrantID:        "grant-1",
+		ActionType:     "test.action",
+		ConnectorID:    "test/stub",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "api_key",
+		EscrowID:       storeResult.EscrowID,
 	})
 	execResult := decodeResp[enclave.ExecuteResponse](t, execResp)
 	if execResult.Status != "succeeded" {
@@ -298,13 +313,49 @@ func TestEscrowFlow(t *testing.T) {
 
 	// Execute after revoke should fail.
 	execResp2 := postJSON(t, server, "/execute", enclave.ExecuteRequest{
-		ConnectorID: "test/stub",
-		EscrowID:    storeResult.EscrowID,
+		UserID:         "user-1",
+		GrantID:        "grant-1",
+		ActionType:     "test.action",
+		ConnectorID:    "test/stub",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "api_key",
+		EscrowID:       storeResult.EscrowID,
 	})
 	if execResp2.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404 after revoke, got %d", execResp2.StatusCode)
 	}
 	execResp2.Body.Close()
+}
+
+func TestExecuteWithEscrowRejectsScopeMismatch(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	encrypted, _ := crypto.Encrypt([]byte("escrowed-cred"), userKEK)
+	storeResp := postJSON(t, server, "/escrow", validEscrowStoreRequest(encrypted))
+	storeResult := decodeResp[enclave.EscrowStoreResponse](t, storeResp)
+
+	execResp := postJSON(t, server, "/execute", enclave.ExecuteRequest{
+		RequestID:      "exec-escrow",
+		UserID:         "user-2",
+		GrantID:        "grant-1",
+		ActionType:     "test.action",
+		ConnectorID:    "test/stub",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "api_key",
+		EscrowID:       storeResult.EscrowID,
+	})
+	if execResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for scope mismatch, got %d", execResp.StatusCode)
+	}
+	execResp.Body.Close()
 }
 
 func TestAttestEndpoint(t *testing.T) {
@@ -386,13 +437,45 @@ func TestEscrowStoreWithoutKEK(t *testing.T) {
 	establishTestSession(t, server)
 
 	resp := postJSON(t, server, "/escrow", enclave.EscrowStoreRequest{
-		UserID:  "no-kek-user",
-		GrantID: "g1",
+		UserID:         "no-kek-user",
+		GrantID:        "g1",
+		VaultPath:      "connected-accounts/no-kek-user/gmail",
+		Provider:       "gmail",
+		CredentialType: "api_key",
 	})
 	if resp.StatusCode != http.StatusPreconditionFailed {
 		t.Fatalf("expected 412, got %d", resp.StatusCode)
 	}
 	resp.Body.Close()
+}
+
+func TestEscrowStoreRequiresScopeFields(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	base := validEscrowStoreRequest([]byte("encrypted"))
+	tests := []struct {
+		name   string
+		mutate func(*enclave.EscrowStoreRequest)
+	}{
+		{"user_id", func(r *enclave.EscrowStoreRequest) { r.UserID = "" }},
+		{"grant_id", func(r *enclave.EscrowStoreRequest) { r.GrantID = "" }},
+		{"vault_path", func(r *enclave.EscrowStoreRequest) { r.VaultPath = "" }},
+		{"provider", func(r *enclave.EscrowStoreRequest) { r.Provider = "" }},
+		{"credential_type", func(r *enclave.EscrowStoreRequest) { r.CredentialType = "" }},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := base
+			tt.mutate(&req)
+			resp := postJSON(t, server, "/escrow", req)
+			if resp.StatusCode != http.StatusBadRequest {
+				t.Fatalf("expected 400, got %d", resp.StatusCode)
+			}
+			resp.Body.Close()
+		})
+	}
 }
 
 func TestEscrowStoreBadDecryption(t *testing.T) {
@@ -407,7 +490,10 @@ func TestEscrowStoreBadDecryption(t *testing.T) {
 	resp := postJSON(t, server, "/escrow", enclave.EscrowStoreRequest{
 		UserID:              "user-1",
 		GrantID:             "g1",
+		VaultPath:           "connected-accounts/user-1/gmail",
+		Provider:            "gmail",
 		EncryptedCredential: []byte("bad"),
+		CredentialType:      "api_key",
 		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
 	})
 	if resp.StatusCode != http.StatusBadRequest {
@@ -429,7 +515,10 @@ func TestEscrowStoreBadExpiry(t *testing.T) {
 	resp := postJSON(t, server, "/escrow", enclave.EscrowStoreRequest{
 		UserID:              "user-1",
 		GrantID:             "g1",
+		VaultPath:           "connected-accounts/user-1/gmail",
+		Provider:            "gmail",
 		EncryptedCredential: encrypted,
+		CredentialType:      "api_key",
 		ExpiresAt:           "not-a-date",
 	})
 	if resp.StatusCode != http.StatusBadRequest {
@@ -552,20 +641,23 @@ func TestExecuteWithExpiredEscrow(t *testing.T) {
 	encrypted, _ := crypto.Encrypt([]byte("cred"), userKEK)
 
 	// Store with past expiry.
-	storeResp := postJSON(t, server, "/escrow", enclave.EscrowStoreRequest{
-		UserID:              "user-1",
-		GrantID:             "g1",
-		EncryptedCredential: encrypted,
-		CredentialType:      "api_key",
-		ExpiresAt:           time.Now().Add(-time.Second).Format(time.RFC3339),
-	})
+	expiredReq := validEscrowStoreRequest(encrypted)
+	expiredReq.GrantID = "g1"
+	expiredReq.ExpiresAt = time.Now().Add(-time.Second).Format(time.RFC3339)
+	storeResp := postJSON(t, server, "/escrow", expiredReq)
 	storeResult := decodeResp[enclave.EscrowStoreResponse](t, storeResp)
 
 	// Execute with expired escrow.
 	_ = srv // keep reference
 	execResp := postJSON(t, server, "/execute", enclave.ExecuteRequest{
-		ConnectorID: "test/stub",
-		EscrowID:    storeResult.EscrowID,
+		UserID:         "user-1",
+		GrantID:        "g1",
+		ActionType:     "test.action",
+		ConnectorID:    "test/stub",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "api_key",
+		EscrowID:       storeResult.EscrowID,
 	})
 	if execResp.StatusCode != http.StatusNotFound {
 		t.Fatalf("expected 404 for expired escrow, got %d", execResp.StatusCode)
@@ -1006,13 +1098,10 @@ func TestEscrowListEndpoint(t *testing.T) {
 	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
 
 	encrypted, _ := crypto.Encrypt([]byte("cred-1"), userKEK)
-	storeResp := postJSON(t, server, "/escrow", enclave.EscrowStoreRequest{
-		UserID:              "user-1",
-		GrantID:             "g1",
-		EncryptedCredential: encrypted,
-		CredentialType:      "oauth_token",
-		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
-	})
+	listReq := validEscrowStoreRequest(encrypted)
+	listReq.GrantID = "g1"
+	listReq.CredentialType = "oauth_token"
+	storeResp := postJSON(t, server, "/escrow", listReq)
 	storeResult := decodeResp[enclave.EscrowStoreResponse](t, storeResp)
 
 	resp2, err := http.Post(server.URL+"/escrow/list", "application/json", bytes.NewReader([]byte("{}")))
@@ -1033,9 +1122,9 @@ func TestEscrowListEndpoint(t *testing.T) {
 
 func TestResolveConnectorID(t *testing.T) {
 	tests := []struct {
-		input      string
-		wantType   string
-		wantProv   string
+		input    string
+		wantType string
+		wantProv string
 	}{
 		{"payments/stripe", "payments", "stripe"},
 		{"git/github", "git", "github"},
@@ -1055,12 +1144,16 @@ func TestSourceExecute_HappyPath(t *testing.T) {
 	defer server.Close()
 
 	// Store a credential in escrow.
-	escrowID := srv.escrow.Store("g1", []byte(`{"access_token":"test"}`), "oauth2", nil, time.Now().Add(time.Hour))
+	escrowReq := testEscrowRequest("g1", "oauth2", nil)
+	escrowID := srv.escrow.Store(escrowReq, []byte(`{"access_token":"test"}`), time.Now().Add(time.Hour))
 
 	resp := postJSON(t, server, "/source/execute", enclave.SourceExecuteRequest{
-		EscrowID: escrowID,
-		Tool:     "test_search",
-		Params:   map[string]any{"query": "hello"},
+		EscrowID:  escrowID,
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "test_search",
+		Params:    map[string]any{"query": "hello"},
 	})
 	if resp.StatusCode != 200 {
 		body, _ := io.ReadAll(resp.Body)
@@ -1090,18 +1183,43 @@ func TestSourceExecute_EscrowNotFound(t *testing.T) {
 	}
 }
 
+func TestSourceExecute_RejectsScopeMismatch(t *testing.T) {
+	server, srv := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	escrowReq := testEscrowRequest("g1", "oauth2", nil)
+	escrowID := srv.escrow.Store(escrowReq, []byte(`{"access_token":"test"}`), time.Now().Add(time.Hour))
+
+	resp := postJSON(t, server, "/source/execute", enclave.SourceExecuteRequest{
+		EscrowID:  escrowID,
+		UserID:    "user-2",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "test_search",
+		Params:    map[string]any{"query": "hello"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
 func TestSourceExecute_ToolError(t *testing.T) {
 	server, srv := setupTestEnclaveServerWithSource(t, &stubSourceConnector{
 		err: fmt.Errorf("gmail API error: 401 Invalid Credentials"),
 	})
 	defer server.Close()
 
-	escrowID := srv.escrow.Store("g1", []byte(`{"access_token":"test"}`), "oauth2", nil, time.Now().Add(time.Hour))
+	escrowReq := testEscrowRequest("g1", "oauth2", nil)
+	escrowID := srv.escrow.Store(escrowReq, []byte(`{"access_token":"test"}`), time.Now().Add(time.Hour))
 
 	resp := postJSON(t, server, "/source/execute", enclave.SourceExecuteRequest{
-		EscrowID: escrowID,
-		Tool:     "test_search",
-		Params:   map[string]any{"query": "hello"},
+		EscrowID:  escrowID,
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "test_search",
+		Params:    map[string]any{"query": "hello"},
 	})
 	if resp.StatusCode != 200 {
 		t.Fatalf("expected 200 (error in body), got %d", resp.StatusCode)

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -12,17 +12,17 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/account"
 	api "github.com/ALRubinger/aileron/internal/api/gen"
-	"github.com/ALRubinger/aileron/internal/comms"
-	"github.com/ALRubinger/aileron/internal/draft"
-	"github.com/ALRubinger/aileron/internal/source"
 	"github.com/ALRubinger/aileron/internal/approval"
 	"github.com/ALRubinger/aileron/internal/auth"
+	"github.com/ALRubinger/aileron/internal/comms"
 	"github.com/ALRubinger/aileron/internal/config"
 	connectorpkg "github.com/ALRubinger/aileron/internal/connector"
 	"github.com/ALRubinger/aileron/internal/crypto"
+	"github.com/ALRubinger/aileron/internal/draft"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/notify"
 	"github.com/ALRubinger/aileron/internal/policy"
+	"github.com/ALRubinger/aileron/internal/source"
 	"github.com/ALRubinger/aileron/internal/store"
 	"github.com/ALRubinger/aileron/internal/store/mem"
 	"github.com/ALRubinger/aileron/internal/store/postgres"
@@ -776,6 +776,8 @@ func (s *apiServer) RunExecution(w http.ResponseWriter, r *http.Request) {
 			IntentID:            grant.IntentId,
 			ActionType:          intent.Action.Type,
 			ConnectorID:         connType + "/" + connProvider,
+			VaultPath:           vaultPath,
+			Provider:            connProvider,
 			Parameters:          params,
 			EncryptedCredential: secret.Value,
 			CredentialType:      secret.Metadata.Type,
@@ -1172,6 +1174,8 @@ func (s *apiServer) executeGrant(ctx context.Context, grantID, userID string) (*
 			IntentID:            grant.IntentId,
 			ActionType:          intent.Action.Type,
 			ConnectorID:         connType + "/" + connProvider,
+			VaultPath:           vaultPath,
+			Provider:            connProvider,
 			Parameters:          params,
 			EncryptedCredential: secret.Value,
 			CredentialType:      secret.Metadata.Type,

--- a/internal/app/handlers_slack_agent.go
+++ b/internal/app/handlers_slack_agent.go
@@ -154,11 +154,15 @@ func (s *apiServer) newEnclaveSourceExecutor() draft.SourceExecutor {
 			return nil, fmt.Errorf("no escrow entry for %s: %w", vaultPath, vault.ErrCredentialUnavailable)
 		}
 		escrowID := escrowIDVal.(string)
+		userID, provider := escrowScopeFromVaultPath(vaultPath)
 
 		resp, err := s.enclaveClient.SourceExecute(ctx, enclave.SourceExecuteRequest{
-			EscrowID: escrowID,
-			Tool:     tool,
-			Params:   params,
+			EscrowID:  escrowID,
+			UserID:    userID,
+			VaultPath: vaultPath,
+			Provider:  provider,
+			Tool:      tool,
+			Params:    params,
 		})
 		if err != nil {
 			return nil, fmt.Errorf("enclave source execute: %w", err)

--- a/internal/app/handlers_tee.go
+++ b/internal/app/handlers_tee.go
@@ -15,11 +15,12 @@ import (
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/auth"
+	"github.com/ALRubinger/aileron/internal/enclave"
 	"github.com/ALRubinger/aileron/internal/model"
+	"github.com/ALRubinger/aileron/internal/source"
 	"github.com/ALRubinger/aileron/internal/store"
 	"github.com/ALRubinger/aileron/internal/store/postgres"
 	"github.com/ALRubinger/aileron/internal/vault"
-	"github.com/ALRubinger/aileron/internal/enclave"
 )
 
 const jwksCacheTTL = 1 * time.Hour
@@ -383,10 +384,13 @@ func (s *apiServer) autoEscrowCredentials(ctx context.Context, userID string) in
 		resp, err := s.enclaveClient.EscrowStore(ctx, enclave.EscrowStoreRequest{
 			UserID:              userID,
 			GrantID:             grantID,
+			VaultPath:           acc.VaultPath(),
+			Provider:            string(acc.Provider),
 			EncryptedCredential: secret.Value,
 			CredentialType:      secret.Metadata.Type,
 			ExpiresAt:           expiresAt.Format(time.RFC3339),
 			ActionTypes:         actionTypesForProvider(acc.Provider),
+			SourceTools:         sourceToolsForProvider(s.sourceRegistry, acc.Provider),
 		})
 		if err != nil {
 			continue
@@ -399,6 +403,51 @@ func (s *apiServer) autoEscrowCredentials(ctx context.Context, userID string) in
 		escrowed++
 	}
 	return escrowed
+}
+
+func sourceToolsForProvider(registry *source.Registry, provider model.ConnectedAccountProvider) []string {
+	if registry == nil {
+		return nil
+	}
+	sourceProvider := sourceProviderForConnectedAccount(provider)
+	if sourceProvider == "" {
+		return nil
+	}
+	tools := registry.ToolsForProvider(sourceProvider)
+	names := make([]string, 0, len(tools))
+	for _, tool := range tools {
+		names = append(names, tool.Name)
+	}
+	return names
+}
+
+func sourceProviderForConnectedAccount(provider model.ConnectedAccountProvider) string {
+	switch provider {
+	case model.ConnectedAccountProviderGmail:
+		return "gmail"
+	case model.ConnectedAccountProviderGoogleCalendar:
+		return "calendar"
+	case model.ConnectedAccountProviderSlack:
+		return "slack"
+	case model.ConnectedAccountProviderGitHub:
+		return "github"
+	default:
+		return ""
+	}
+}
+
+func escrowScopeFromVaultPath(vaultPath string) (userID string, provider string) {
+	const prefix = "connected-accounts/"
+	if len(vaultPath) <= len(prefix) || vaultPath[:len(prefix)] != prefix {
+		return "", ""
+	}
+	rest := vaultPath[len(prefix):]
+	for i, c := range rest {
+		if c == '/' {
+			return rest[:i], rest[i+1:]
+		}
+	}
+	return "", ""
 }
 
 // reconcileEscrowIndex prunes escrow index entries that the enclave no longer

--- a/internal/app/handlers_tee_test.go
+++ b/internal/app/handlers_tee_test.go
@@ -18,12 +18,13 @@ import (
 	"github.com/ALRubinger/aileron/internal/auth"
 	"github.com/ALRubinger/aileron/internal/config"
 	"github.com/ALRubinger/aileron/internal/crypto"
+	"github.com/ALRubinger/aileron/internal/enclave"
+	"github.com/ALRubinger/aileron/internal/enclave/local"
 	"github.com/ALRubinger/aileron/internal/model"
+	"github.com/ALRubinger/aileron/internal/source"
 	"github.com/ALRubinger/aileron/internal/store"
 	"github.com/ALRubinger/aileron/internal/store/mem"
 	"github.com/ALRubinger/aileron/internal/vault"
-	"github.com/ALRubinger/aileron/internal/enclave"
-	"github.com/ALRubinger/aileron/internal/enclave/local"
 	"github.com/golang-jwt/jwt/v5"
 )
 
@@ -879,6 +880,59 @@ func (c *reconcileEnclaveClient) SourceExecute(_ context.Context, _ enclave.Sour
 }
 func (c *reconcileEnclaveClient) Ready(_ context.Context) error { return nil }
 func (c *reconcileEnclaveClient) Close() error                  { return nil }
+
+func TestSourceToolsForProvider(t *testing.T) {
+	registry := source.NewRegistry()
+	registry.Register(&stubSourceConnector{})
+
+	providerTests := map[model.ConnectedAccountProvider]string{
+		model.ConnectedAccountProviderGmail:          "gmail",
+		model.ConnectedAccountProviderGoogleCalendar: "calendar",
+		model.ConnectedAccountProviderSlack:          "slack",
+		model.ConnectedAccountProviderGitHub:         "github",
+		model.ConnectedAccountProviderOutlook:        "",
+	}
+	for provider, want := range providerTests {
+		if got := sourceProviderForConnectedAccount(provider); got != want {
+			t.Fatalf("sourceProviderForConnectedAccount(%q) = %q, want %q", provider, got, want)
+		}
+	}
+
+	got := sourceToolsForProvider(registry, model.ConnectedAccountProviderSlack)
+	want := []string{"slack_channel_history", "slack_search_messages"}
+	if len(got) != len(want) {
+		t.Fatalf("sourceToolsForProvider = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("sourceToolsForProvider[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+
+	if tools := sourceToolsForProvider(nil, model.ConnectedAccountProviderSlack); tools != nil {
+		t.Fatalf("nil registry tools = %v, want nil", tools)
+	}
+	if tools := sourceToolsForProvider(registry, model.ConnectedAccountProviderOutlook); tools != nil {
+		t.Fatalf("unsupported provider tools = %v, want nil", tools)
+	}
+}
+
+func TestEscrowScopeFromVaultPath(t *testing.T) {
+	userID, provider := escrowScopeFromVaultPath("connected-accounts/usr_1/gmail")
+	if userID != "usr_1" || provider != "gmail" {
+		t.Fatalf("scope = (%q, %q), want (usr_1, gmail)", userID, provider)
+	}
+
+	userID, provider = escrowScopeFromVaultPath("system/payments/stripe")
+	if userID != "" || provider != "" {
+		t.Fatalf("non-connected scope = (%q, %q), want empty", userID, provider)
+	}
+
+	userID, provider = escrowScopeFromVaultPath("connected-accounts/usr_1")
+	if userID != "" || provider != "" {
+		t.Fatalf("malformed connected scope = (%q, %q), want empty", userID, provider)
+	}
+}
 
 func TestReconcileEscrowIndex_PrunesStaleEntries(t *testing.T) {
 	var index sync.Map

--- a/internal/app/handlers_tools.go
+++ b/internal/app/handlers_tools.go
@@ -116,9 +116,12 @@ func (s *apiServer) handleExecuteTool(w http.ResponseWriter, r *http.Request) {
 	if s.enclaveClient != nil {
 		if escrowIDVal, ok := s.escrowIndex.Load(vaultPath); ok {
 			resp, err := s.enclaveClient.SourceExecute(r.Context(), enclave.SourceExecuteRequest{
-				EscrowID: escrowIDVal.(string),
-				Tool:     req.Tool,
-				Params:   req.Params,
+				EscrowID:  escrowIDVal.(string),
+				UserID:    acct.UserID,
+				VaultPath: vaultPath,
+				Provider:  string(acct.Provider),
+				Tool:      req.Tool,
+				Params:    req.Params,
 			})
 			if err != nil {
 				s.log.Error("enclave tool execution failed", "tool", req.Tool, "error", err)

--- a/internal/enclave/errors.go
+++ b/internal/enclave/errors.go
@@ -16,6 +16,10 @@ var (
 	// ErrEscrowExpired indicates that the escrow entry has passed its expiry time.
 	ErrEscrowExpired = errors.New("enclave: escrow entry expired")
 
+	// ErrEscrowScopeMismatch indicates that the requested credential use does
+	// not match the ownership or scope bound to the escrow entry.
+	ErrEscrowScopeMismatch = errors.New("enclave: escrow scope mismatch")
+
 	// ErrNoKEK indicates that no KEK has been transmitted for the given user.
 	ErrNoKEK = errors.New("enclave: no KEK stored for user")
 )

--- a/internal/enclave/local/client.go
+++ b/internal/enclave/local/client.go
@@ -43,7 +43,7 @@ type Client struct {
 	sessionID       string
 	expiresAt       time.Time
 	sessionTTL      time.Duration
-	keks            *kekStore   // per-user KEK storage
+	keks            *kekStore // per-user KEK storage
 	escrow          *escrowStore
 }
 
@@ -200,7 +200,7 @@ func (c *Client) OAuthExchange(ctx context.Context, req enclave.OAuthExchangeReq
 func (c *Client) Execute(ctx context.Context, req enclave.ExecuteRequest) (enclave.ExecuteResponse, error) {
 	// If EscrowID is set, use the escrowed credential instead.
 	if req.EscrowID != "" {
-		credential, err := c.escrow.Get(req.EscrowID)
+		credential, err := c.escrow.GetForExecute(req)
 		if err != nil {
 			return enclave.ExecuteResponse{}, err
 		}
@@ -228,6 +228,22 @@ func (c *Client) Execute(ctx context.Context, req enclave.ExecuteRequest) (encla
 // EscrowStore decrypts the credential using the user's KEK and stores it
 // in the in-memory escrow.
 func (c *Client) EscrowStore(_ context.Context, req enclave.EscrowStoreRequest) (enclave.EscrowStoreResponse, error) {
+	if req.UserID == "" {
+		return enclave.EscrowStoreResponse{}, fmt.Errorf("local: user_id required")
+	}
+	if req.GrantID == "" {
+		return enclave.EscrowStoreResponse{}, fmt.Errorf("local: grant_id required")
+	}
+	if req.VaultPath == "" {
+		return enclave.EscrowStoreResponse{}, fmt.Errorf("local: vault_path required")
+	}
+	if req.Provider == "" {
+		return enclave.EscrowStoreResponse{}, fmt.Errorf("local: provider required")
+	}
+	if req.CredentialType == "" {
+		return enclave.EscrowStoreResponse{}, fmt.Errorf("local: credential_type required")
+	}
+
 	kek, err := c.keks.Get(req.UserID)
 	if err != nil {
 		return enclave.EscrowStoreResponse{}, err
@@ -245,7 +261,7 @@ func (c *Client) EscrowStore(_ context.Context, req enclave.EscrowStoreRequest) 
 		return enclave.EscrowStoreResponse{}, fmt.Errorf("local: parsing escrow expiry: %w", err)
 	}
 
-	id := c.escrow.Store(req.GrantID, plaintext, req.CredentialType, req.ActionTypes, expiresAt)
+	id := c.escrow.Store(req, plaintext, expiresAt)
 	return enclave.EscrowStoreResponse{EscrowID: id}, nil
 }
 
@@ -267,7 +283,7 @@ func (c *Client) SourceExecute(ctx context.Context, req enclave.SourceExecuteReq
 		return enclave.SourceExecuteResponse{}, fmt.Errorf("local: no source execute function configured")
 	}
 
-	credential, err := c.escrow.Get(req.EscrowID)
+	credential, err := c.escrow.GetForSource(req)
 	if err != nil {
 		return enclave.SourceExecuteResponse{}, err
 	}
@@ -352,7 +368,7 @@ func exchangeOAuthCode(ctx context.Context, req enclave.OAuthExchangeRequest) (*
 	// Parse the token response. Slack uses a non-standard format with
 	// nested authed_user and team fields; standard OAuth uses top-level fields.
 	var tokenData struct {
-		OK           bool   `json:"ok"`                      // Slack-specific
+		OK           bool   `json:"ok"` // Slack-specific
 		AccessToken  string `json:"access_token"`
 		TokenType    string `json:"token_type"`
 		RefreshToken string `json:"refresh_token"`
@@ -476,11 +492,18 @@ func copyBytes(b []byte) []byte {
 	return c
 }
 
-type stringReaderType struct{ s string; i int }
+type stringReaderType struct {
+	s string
+	i int
+}
 
 func (r *stringReaderType) Read(b []byte) (int, error) {
-	if r.i >= len(r.s) { return 0, io.EOF }
-	n := copy(b, r.s[r.i:]); r.i += n; return n, nil
+	if r.i >= len(r.s) {
+		return 0, io.EOF
+	}
+	n := copy(b, r.s[r.i:])
+	r.i += n
+	return n, nil
 }
 
 func stringReader(s string) io.Reader { return &stringReaderType{s: s} }

--- a/internal/enclave/local/client_test.go
+++ b/internal/enclave/local/client_test.go
@@ -190,6 +190,8 @@ func TestEscrowStoreAndExecute(t *testing.T) {
 	storeResp, err := c.EscrowStore(ctx, enclave.EscrowStoreRequest{
 		UserID:              "user-1",
 		GrantID:             "grant-1",
+		VaultPath:           "connected-accounts/user-1/gmail",
+		Provider:            "gmail",
 		EncryptedCredential: kekEncrypted,
 		CredentialType:      "api_key",
 		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
@@ -201,8 +203,14 @@ func TestEscrowStoreAndExecute(t *testing.T) {
 
 	// Execute using the escrowed credential.
 	resp, err := c.Execute(ctx, enclave.ExecuteRequest{
-		RequestID: "exec-escrow",
-		EscrowID:  storeResp.EscrowID,
+		RequestID:      "exec-escrow",
+		UserID:         "user-1",
+		GrantID:        "grant-1",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		ActionType:     "payment.charge",
+		CredentialType: "api_key",
+		EscrowID:       storeResp.EscrowID,
 	})
 	if err != nil {
 		t.Fatalf("Execute with escrow: %v", err)
@@ -239,6 +247,8 @@ func TestEscrowListViaClient(t *testing.T) {
 	storeResp, err := c.EscrowStore(ctx, enclave.EscrowStoreRequest{
 		UserID:              "user-1",
 		GrantID:             "g1",
+		VaultPath:           "connected-accounts/user-1/gmail",
+		Provider:            "gmail",
 		EncryptedCredential: encrypted,
 		CredentialType:      "oauth_token",
 		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
@@ -276,6 +286,8 @@ func TestEscrowRevoke(t *testing.T) {
 	storeResp, err := c.EscrowStore(ctx, enclave.EscrowStoreRequest{
 		UserID:              "user-1",
 		GrantID:             "grant-1",
+		VaultPath:           "connected-accounts/user-1/gmail",
+		Provider:            "gmail",
 		EncryptedCredential: encrypted,
 		CredentialType:      "api_key",
 		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
@@ -579,7 +591,11 @@ func TestEscrowStoreWithoutKEK(t *testing.T) {
 
 	_, err := c.EscrowStore(context.Background(), enclave.EscrowStoreRequest{
 		UserID:              "no-kek",
+		GrantID:             "grant-1",
+		VaultPath:           "connected-accounts/no-kek/gmail",
+		Provider:            "gmail",
 		EncryptedCredential: []byte("data"),
+		CredentialType:      "api_key",
 		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
 	})
 	if err != enclave.ErrNoKEK {
@@ -598,7 +614,11 @@ func TestEscrowStoreBadDecryption(t *testing.T) {
 
 	_, err := c.EscrowStore(context.Background(), enclave.EscrowStoreRequest{
 		UserID:              "user-1",
+		GrantID:             "grant-1",
+		VaultPath:           "connected-accounts/user-1/gmail",
+		Provider:            "gmail",
 		EncryptedCredential: []byte("bad-ciphertext"),
+		CredentialType:      "api_key",
 		ExpiresAt:           time.Now().Add(time.Hour).Format(time.RFC3339),
 	})
 	if err == nil {
@@ -618,7 +638,11 @@ func TestEscrowStoreBadExpiry(t *testing.T) {
 	encrypted, _ := encryptAESGCM([]byte("cred"), userKEK)
 	_, err := c.EscrowStore(context.Background(), enclave.EscrowStoreRequest{
 		UserID:              "user-1",
+		GrantID:             "grant-1",
+		VaultPath:           "connected-accounts/user-1/gmail",
+		Provider:            "gmail",
 		EncryptedCredential: encrypted,
+		CredentialType:      "api_key",
 		ExpiresAt:           "not-a-date",
 	})
 	if err == nil {
@@ -732,12 +756,15 @@ func TestClient_SourceExecute_HappyPath(t *testing.T) {
 	_ = err
 
 	// Use the escrow store directly since EscrowStore requires KEK decryption.
-	escrowID := c.escrow.Store("g1", []byte(`{"access_token":"test"}`), "oauth2", nil, time.Now().Add(time.Hour))
+	escrowID := c.escrow.Store(testEscrowRequest("g1", "oauth2", nil), []byte(`{"access_token":"test"}`), time.Now().Add(time.Hour))
 
 	resp, err := c.SourceExecute(context.Background(), enclave.SourceExecuteRequest{
-		EscrowID: escrowID,
-		Tool:     "test_search",
-		Params:   map[string]any{"query": "hello"},
+		EscrowID:  escrowID,
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "test_search",
+		Params:    map[string]any{"query": "hello"},
 	})
 	if err != nil {
 		t.Fatalf("SourceExecute: %v", err)
@@ -792,12 +819,15 @@ func TestClient_SourceExecute_TokenRefresh(t *testing.T) {
 	}
 	c := New(nil, WithSourceExecuteFn(executeFn))
 
-	escrowID := c.escrow.Store("g1", []byte(`{"access_token":"old"}`), "oauth2", nil, time.Now().Add(time.Hour))
+	escrowID := c.escrow.Store(testEscrowRequest("g1", "oauth2", nil), []byte(`{"access_token":"old"}`), time.Now().Add(time.Hour))
 
 	_, err := c.SourceExecute(context.Background(), enclave.SourceExecuteRequest{
-		EscrowID: escrowID,
-		Tool:     "test_search",
-		Params:   map[string]any{"query": "hello"},
+		EscrowID:  escrowID,
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "gmail_search",
+		Params:    map[string]any{"query": "hello"},
 	})
 	if err != nil {
 		t.Fatalf("SourceExecute: %v", err)

--- a/internal/enclave/local/escrow.go
+++ b/internal/enclave/local/escrow.go
@@ -3,6 +3,7 @@ package local
 import (
 	"crypto/rand"
 	"encoding/hex"
+	"reflect"
 	"sync"
 	"time"
 
@@ -10,11 +11,17 @@ import (
 )
 
 type escrowEntry struct {
-	grantID     string
-	credential  []byte // plaintext, held in memory
-	credType    string
-	actionTypes []string
-	expiresAt   time.Time
+	userID            string
+	grantID           string
+	enforceGrantID    bool
+	vaultPath         string
+	provider          string
+	credential        []byte // plaintext, held in memory
+	credType          string
+	actionTypes       []string
+	sourceTools       []string
+	allowedParameters map[string]any
+	expiresAt         time.Time
 }
 
 type escrowStore struct {
@@ -28,18 +35,24 @@ func newEscrowStore() *escrowStore {
 
 // Store adds a credential to the escrow. The credential is already decrypted
 // and is held in plaintext in memory. Returns the escrow ID.
-func (s *escrowStore) Store(grantID string, credential []byte, credType string, actionTypes []string, expiresAt time.Time) string {
+func (s *escrowStore) Store(req enclave.EscrowStoreRequest, credential []byte, expiresAt time.Time) string {
 	b := make([]byte, 16)
 	rand.Read(b)
 	id := "esc_" + hex.EncodeToString(b)
 
 	s.mu.Lock()
 	s.entries[id] = &escrowEntry{
-		grantID:     grantID,
-		credential:  credential,
-		credType:    credType,
-		actionTypes: actionTypes,
-		expiresAt:   expiresAt,
+		userID:            req.UserID,
+		grantID:           req.GrantID,
+		enforceGrantID:    req.EnforceGrantID,
+		vaultPath:         req.VaultPath,
+		provider:          req.Provider,
+		credential:        credential,
+		credType:          req.CredentialType,
+		actionTypes:       append([]string(nil), req.ActionTypes...),
+		sourceTools:       append([]string(nil), req.SourceTools...),
+		allowedParameters: cloneMap(req.AllowedParameters),
+		expiresAt:         expiresAt,
 	}
 	s.mu.Unlock()
 	return id
@@ -61,6 +74,73 @@ func (s *escrowStore) Get(escrowID string) ([]byte, error) {
 	return copyBytes(entry.credential), nil
 }
 
+func (s *escrowStore) GetForExecute(req enclave.ExecuteRequest) ([]byte, error) {
+	entry, err := s.entry(req.EscrowID)
+	if err != nil {
+		return nil, err
+	}
+	if entry.userID != "" && entry.userID != req.UserID {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.enforceGrantID && entry.grantID != req.GrantID {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.vaultPath != "" && entry.vaultPath != req.VaultPath {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.provider != "" && entry.provider != req.Provider {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.credType != "" && entry.credType != req.CredentialType {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if len(entry.actionTypes) > 0 && !containsString(entry.actionTypes, req.ActionType) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if len(entry.allowedParameters) > 0 && !reflect.DeepEqual(entry.allowedParameters, req.Parameters) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	return copyBytes(entry.credential), nil
+}
+
+func (s *escrowStore) GetForSource(req enclave.SourceExecuteRequest) ([]byte, error) {
+	entry, err := s.entry(req.EscrowID)
+	if err != nil {
+		return nil, err
+	}
+	if entry.userID != "" && entry.userID != req.UserID {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.vaultPath != "" && entry.vaultPath != req.VaultPath {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if entry.provider != "" && entry.provider != req.Provider {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if len(entry.sourceTools) > 0 && !containsString(entry.sourceTools, req.Tool) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	if len(entry.allowedParameters) > 0 && !reflect.DeepEqual(entry.allowedParameters, req.Params) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
+	return copyBytes(entry.credential), nil
+}
+
+func (s *escrowStore) entry(escrowID string) (*escrowEntry, error) {
+	s.mu.RLock()
+	entry, ok := s.entries[escrowID]
+	s.mu.RUnlock()
+
+	if !ok {
+		return nil, enclave.ErrEscrowNotFound
+	}
+	if time.Now().After(entry.expiresAt) {
+		s.revokeByID(escrowID)
+		return nil, enclave.ErrEscrowExpired
+	}
+	return entry, nil
+}
+
 // List returns metadata for all non-expired escrow entries.
 func (s *escrowStore) List() []enclave.EscrowListEntry {
 	now := time.Now()
@@ -75,6 +155,9 @@ func (s *escrowStore) List() []enclave.EscrowListEntry {
 		entries = append(entries, enclave.EscrowListEntry{
 			EscrowID:  id,
 			GrantID:   entry.grantID,
+			UserID:    entry.userID,
+			VaultPath: entry.vaultPath,
+			Provider:  entry.provider,
 			ExpiresAt: entry.expiresAt.Format(time.RFC3339),
 		})
 	}
@@ -147,4 +230,24 @@ func (s *escrowStore) revokeByID(escrowID string) {
 		zeroBytes(entry.credential)
 		delete(s.entries, escrowID)
 	}
+}
+
+func cloneMap(in map[string]any) map[string]any {
+	if len(in) == 0 {
+		return nil
+	}
+	out := make(map[string]any, len(in))
+	for k, v := range in {
+		out[k] = v
+	}
+	return out
+}
+
+func containsString(values []string, target string) bool {
+	for _, value := range values {
+		if value == target {
+			return true
+		}
+	}
+	return false
 }

--- a/internal/enclave/local/escrow_test.go
+++ b/internal/enclave/local/escrow_test.go
@@ -7,11 +7,24 @@ import (
 	"github.com/ALRubinger/aileron/internal/enclave"
 )
 
+func testEscrowRequest(grantID, credType string, actionTypes []string) enclave.EscrowStoreRequest {
+	return enclave.EscrowStoreRequest{
+		UserID:         "user-1",
+		GrantID:        grantID,
+		EnforceGrantID: true,
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: credType,
+		ActionTypes:    actionTypes,
+		SourceTools:    []string{"test_search", "gmail_search"},
+	}
+}
+
 func TestEscrowStoreAndGet(t *testing.T) {
 	s := newEscrowStore()
 
 	cred := []byte("test-credential")
-	id := s.Store("grant-1", cred, "api_key", []string{"payment.charge"}, time.Now().Add(time.Hour))
+	id := s.Store(testEscrowRequest("grant-1", "api_key", []string{"payment.charge"}), cred, time.Now().Add(time.Hour))
 
 	got, err := s.Get(id)
 	if err != nil {
@@ -29,6 +42,86 @@ func TestEscrowStoreAndGet(t *testing.T) {
 	}
 }
 
+func TestEscrowGetForExecuteEnforcesScope(t *testing.T) {
+	s := newEscrowStore()
+	id := s.Store(testEscrowRequest("grant-1", "api_key", []string{"payment.charge"}), []byte("test-credential"), time.Now().Add(time.Hour))
+
+	valid := enclave.ExecuteRequest{
+		EscrowID:       id,
+		UserID:         "user-1",
+		GrantID:        "grant-1",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "api_key",
+		ActionType:     "payment.charge",
+	}
+	if _, err := s.GetForExecute(valid); err != nil {
+		t.Fatalf("valid GetForExecute: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*enclave.ExecuteRequest)
+	}{
+		{"user", func(r *enclave.ExecuteRequest) { r.UserID = "user-2" }},
+		{"grant", func(r *enclave.ExecuteRequest) { r.GrantID = "grant-2" }},
+		{"vault", func(r *enclave.ExecuteRequest) { r.VaultPath = "connected-accounts/user-2/gmail" }},
+		{"provider", func(r *enclave.ExecuteRequest) { r.Provider = "slack" }},
+		{"credential type", func(r *enclave.ExecuteRequest) { r.CredentialType = "oauth2" }},
+		{"action", func(r *enclave.ExecuteRequest) { r.ActionType = "payment.refund" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := valid
+			tt.mutate(&req)
+			_, err := s.GetForExecute(req)
+			if err != enclave.ErrEscrowScopeMismatch {
+				t.Fatalf("expected ErrEscrowScopeMismatch, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEscrowGetForSourceEnforcesScope(t *testing.T) {
+	s := newEscrowStore()
+	req := testEscrowRequest("grant-1", "oauth2", nil)
+	req.AllowedParameters = map[string]any{"query": "from:boss"}
+	id := s.Store(req, []byte("token"), time.Now().Add(time.Hour))
+
+	valid := enclave.SourceExecuteRequest{
+		EscrowID:  id,
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "gmail_search",
+		Params:    map[string]any{"query": "from:boss"},
+	}
+	if _, err := s.GetForSource(valid); err != nil {
+		t.Fatalf("valid GetForSource: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*enclave.SourceExecuteRequest)
+	}{
+		{"user", func(r *enclave.SourceExecuteRequest) { r.UserID = "user-2" }},
+		{"vault", func(r *enclave.SourceExecuteRequest) { r.VaultPath = "connected-accounts/user-2/gmail" }},
+		{"provider", func(r *enclave.SourceExecuteRequest) { r.Provider = "slack" }},
+		{"tool", func(r *enclave.SourceExecuteRequest) { r.Tool = "gmail_delete" }},
+		{"params", func(r *enclave.SourceExecuteRequest) { r.Params = map[string]any{"query": "to:boss"} }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			req := valid
+			tt.mutate(&req)
+			_, err := s.GetForSource(req)
+			if err != enclave.ErrEscrowScopeMismatch {
+				t.Fatalf("expected ErrEscrowScopeMismatch, got %v", err)
+			}
+		})
+	}
+}
+
 func TestEscrowNotFound(t *testing.T) {
 	s := newEscrowStore()
 	_, err := s.Get("nonexistent")
@@ -40,7 +133,7 @@ func TestEscrowNotFound(t *testing.T) {
 func TestEscrowExpired(t *testing.T) {
 	s := newEscrowStore()
 	cred := []byte("expired-cred")
-	id := s.Store("grant-1", cred, "api_key", nil, time.Now().Add(-time.Second))
+	id := s.Store(testEscrowRequest("grant-1", "api_key", nil), cred, time.Now().Add(-time.Second))
 
 	_, err := s.Get(id)
 	if err != enclave.ErrEscrowExpired {
@@ -57,7 +150,7 @@ func TestEscrowExpired(t *testing.T) {
 func TestEscrowRevokeDirectly(t *testing.T) {
 	s := newEscrowStore()
 	cred := []byte("revoke-me")
-	id := s.Store("grant-1", cred, "api_key", nil, time.Now().Add(time.Hour))
+	id := s.Store(testEscrowRequest("grant-1", "api_key", nil), cred, time.Now().Add(time.Hour))
 
 	// Wrong grant ID.
 	err := s.Revoke(id, "wrong-grant")
@@ -84,8 +177,8 @@ func TestEscrowEvictExpired(t *testing.T) {
 	live := []byte("live")
 	expired := []byte("dead")
 
-	liveID := s.Store("g1", live, "api_key", nil, time.Now().Add(time.Hour))
-	s.Store("g2", expired, "api_key", nil, time.Now().Add(-time.Second))
+	liveID := s.Store(testEscrowRequest("g1", "api_key", nil), live, time.Now().Add(time.Hour))
+	s.Store(testEscrowRequest("g2", "api_key", nil), expired, time.Now().Add(-time.Second))
 
 	s.EvictExpired()
 
@@ -113,9 +206,9 @@ func TestEscrowList(t *testing.T) {
 	}
 
 	// Add a mix of live and expired entries.
-	s.Store("g1", []byte("cred-1"), "api_key", nil, time.Now().Add(time.Hour))
-	s.Store("g2", []byte("cred-2"), "oauth", nil, time.Now().Add(time.Hour))
-	s.Store("g3", []byte("cred-3"), "api_key", nil, time.Now().Add(-time.Second)) // expired
+	s.Store(testEscrowRequest("g1", "api_key", nil), []byte("cred-1"), time.Now().Add(time.Hour))
+	s.Store(testEscrowRequest("g2", "oauth", nil), []byte("cred-2"), time.Now().Add(time.Hour))
+	s.Store(testEscrowRequest("g3", "api_key", nil), []byte("cred-3"), time.Now().Add(-time.Second)) // expired
 
 	entries = s.List()
 	if len(entries) != 2 {
@@ -141,7 +234,7 @@ func TestEscrowList(t *testing.T) {
 func TestEscrowUpdate(t *testing.T) {
 	s := newEscrowStore()
 	original := []byte(`{"access_token":"old","refresh_token":"r1"}`)
-	id := s.Store("g1", original, "oauth2", nil, time.Now().Add(time.Hour))
+	id := s.Store(testEscrowRequest("g1", "oauth2", nil), original, time.Now().Add(time.Hour))
 
 	// Update with refreshed token.
 	updated := []byte(`{"access_token":"new","refresh_token":"r2"}`)
@@ -176,7 +269,7 @@ func TestEscrowUpdate_NotFound(t *testing.T) {
 
 func TestEscrowUpdate_Expired(t *testing.T) {
 	s := newEscrowStore()
-	id := s.Store("g1", []byte("cred"), "oauth2", nil, time.Now().Add(-time.Second))
+	id := s.Store(testEscrowRequest("g1", "oauth2", nil), []byte("cred"), time.Now().Add(-time.Second))
 	err := s.Update(id, []byte("new"))
 	if err != enclave.ErrEscrowExpired {
 		t.Errorf("expected ErrEscrowExpired, got %v", err)
@@ -186,7 +279,7 @@ func TestEscrowUpdate_Expired(t *testing.T) {
 func TestEscrowClear(t *testing.T) {
 	s := newEscrowStore()
 	cred := []byte("clear-me")
-	id := s.Store("g1", cred, "api_key", nil, time.Now().Add(time.Hour))
+	id := s.Store(testEscrowRequest("g1", "api_key", nil), cred, time.Now().Add(time.Hour))
 
 	s.Clear()
 

--- a/internal/enclave/protocol.go
+++ b/internal/enclave/protocol.go
@@ -86,6 +86,10 @@ type ExecuteRequest struct {
 	ActionType string `json:"action_type"`
 	// ConnectorID is "<type>/<provider>", e.g. "payments/stripe".
 	ConnectorID string `json:"connector_id"`
+	// VaultPath is the vault path whose credential is being used.
+	VaultPath string `json:"vault_path,omitempty"`
+	// Provider is the connected-account or connector provider for scope checks.
+	Provider string `json:"provider,omitempty"`
 	// Parameters are the bounded, approved parameters for execution.
 	Parameters map[string]any `json:"parameters"`
 	// EncryptedCredential is the KEK-encrypted ciphertext from the vault.
@@ -142,12 +146,17 @@ type SessionResponse struct {
 // EscrowStoreRequest asks the enclave to escrow a credential for
 // asynchronous or scheduled execution when the user is offline.
 type EscrowStoreRequest struct {
-	UserID              string   `json:"user_id"`
-	GrantID             string   `json:"grant_id"`
-	EncryptedCredential []byte   `json:"encrypted_credential"`
-	CredentialType      string   `json:"credential_type"`
-	ExpiresAt           string   `json:"expires_at"` // RFC 3339
-	ActionTypes         []string `json:"action_types"`
+	UserID              string         `json:"user_id"`
+	GrantID             string         `json:"grant_id"`
+	EnforceGrantID      bool           `json:"enforce_grant_id,omitempty"`
+	VaultPath           string         `json:"vault_path"`
+	Provider            string         `json:"provider"`
+	EncryptedCredential []byte         `json:"encrypted_credential"`
+	CredentialType      string         `json:"credential_type"`
+	ExpiresAt           string         `json:"expires_at"` // RFC 3339
+	ActionTypes         []string       `json:"action_types"`
+	SourceTools         []string       `json:"source_tools,omitempty"`
+	AllowedParameters   map[string]any `json:"allowed_parameters,omitempty"`
 }
 
 // EscrowStoreResponse confirms that the credential has been escrowed.
@@ -164,6 +173,9 @@ type EscrowListResponse struct {
 type EscrowListEntry struct {
 	EscrowID  string `json:"escrow_id"`
 	GrantID   string `json:"grant_id"`
+	UserID    string `json:"user_id,omitempty"`
+	VaultPath string `json:"vault_path,omitempty"`
+	Provider  string `json:"provider,omitempty"`
 	ExpiresAt string `json:"expires_at"` // RFC 3339
 }
 
@@ -179,6 +191,12 @@ type EscrowRevokeRequest struct {
 type SourceExecuteRequest struct {
 	// EscrowID identifies the escrowed credential to use.
 	EscrowID string `json:"escrow_id"`
+	// UserID identifies the user requesting escrowed credential use.
+	UserID string `json:"user_id,omitempty"`
+	// VaultPath is the vault path whose credential is being used.
+	VaultPath string `json:"vault_path,omitempty"`
+	// Provider is the source connector provider for scope checks.
+	Provider string `json:"provider,omitempty"`
 	// Tool is the source connector tool name, e.g. "gmail_search".
 	Tool string `json:"tool"`
 	// Params are the tool parameters (query, filters, etc.).


### PR DESCRIPTION
## Summary

Phase 2 of #326: bind escrowed credentials to enclave-owned ownership and scope metadata, then enforce that scope before escrow-backed credential use.

## Changes

- Extend enclave escrow protocol metadata with user ID, vault path, provider, source tools, bounded params, and optional grant enforcement.
- Persist the new escrow scope metadata in the remote enclave escrow store.
- Enforce escrow scope for `/execute` and `/source/execute`, returning `403` on ownership/scope mismatch.
- Mirror the same scope checks in the local-dev enclave implementation.
- Thread vault/provider/user scope context through host enclave execution and source-tool requests.
- Add regression tests for hostile user mismatch, action/tool mismatch, required scope fields, and scope persistence paths.

## Validation

- `go test ./internal/app ./cmd/aileron-enclave ./internal/enclave/local ./internal/enclave ./internal/enclave/gcs`
- `go test ./internal/... ./cmd/aileron-enclave`
- `go test -cover ./cmd/aileron-enclave ./internal/enclave ./internal/enclave/local ./internal/enclave/gcs ./internal/app`
  - `cmd/aileron-enclave`: 81.4%
  - `internal/enclave`: 86.7%
  - `internal/enclave/local`: 86.8%
  - `internal/enclave/gcs`: 87.0%
  - `internal/app`: 75.9%

## CI note

I also ran `go test ./cmd/aileron/... ./cmd/aileron-mcp/... ./cmd/aileron-sh/...`; `cmd/aileron-sh` currently fails on policy-output/audit expectations unrelated to this PR. The repository CI workflow does not run `cmd/aileron-sh` tests today: `.github/workflows/ci.yml` covers `./internal/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...`.

## Notes

This does not close #326. Later phases still need post-attestation request integrity, enclave-verifiable grants/capabilities, sealed escrow key handling, and browser/client-visible identity work.