### PR TITLE
feat(enclave): require session-bound requests

### DIFF
--- a/cmd/aileron-enclave/server.go
+++ b/cmd/aileron-enclave/server.go
@@ -151,6 +151,10 @@ func (s *enclaveServer) handleSession(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *enclaveServer) handleTransmitKEK(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSession(w, r) {
+		return
+	}
+
 	var req enclave.TransmitKEKRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeErr(w, http.StatusBadRequest, err.Error())
@@ -182,6 +186,10 @@ func (s *enclaveServer) handleTransmitKEK(w http.ResponseWriter, r *http.Request
 }
 
 func (s *enclaveServer) handleOAuthExchange(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSession(w, r) {
+		return
+	}
+
 	var req enclave.OAuthExchangeRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeErr(w, http.StatusBadRequest, err.Error())
@@ -224,6 +232,10 @@ func (s *enclaveServer) handleOAuthExchange(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *enclaveServer) handleExecute(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSession(w, r) {
+		return
+	}
+
 	var req enclave.ExecuteRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeErr(w, http.StatusBadRequest, err.Error())
@@ -299,6 +311,10 @@ func (s *enclaveServer) handleExecute(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSession(w, r) {
+		return
+	}
+
 	var req enclave.EscrowStoreRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeErr(w, http.StatusBadRequest, err.Error())
@@ -350,12 +366,20 @@ func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request
 	writeJSON(w, http.StatusOK, enclave.EscrowStoreResponse{EscrowID: id})
 }
 
-func (s *enclaveServer) handleEscrowList(w http.ResponseWriter, _ *http.Request) {
+func (s *enclaveServer) handleEscrowList(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSession(w, r) {
+		return
+	}
+
 	entries := s.escrow.List()
 	writeJSON(w, http.StatusOK, enclave.EscrowListResponse{Entries: entries})
 }
 
 func (s *enclaveServer) handleEscrowRevoke(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSession(w, r) {
+		return
+	}
+
 	var req enclave.EscrowRevokeRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeErr(w, http.StatusBadRequest, err.Error())
@@ -371,6 +395,10 @@ func (s *enclaveServer) handleEscrowRevoke(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *enclaveServer) handleSourceExecute(w http.ResponseWriter, r *http.Request) {
+	if !s.requireSession(w, r) {
+		return
+	}
+
 	var req enclave.SourceExecuteRequest
 	if err := decodeJSON(r, &req); err != nil {
 		writeErr(w, http.StatusBadRequest, err.Error())
@@ -422,6 +450,29 @@ func (s *enclaveServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
 		"provider":       s.provider,
 		"session_active": hasSession,
 	})
+}
+
+func (s *enclaveServer) requireSession(w http.ResponseWriter, r *http.Request) bool {
+	sid := r.Header.Get(enclave.HeaderSessionID)
+
+	s.mu.Lock()
+	activeID := s.sessionID
+	hasActiveSession := s.sessionKey != nil && time.Now().Before(s.expiresAt)
+	s.mu.Unlock()
+
+	if !hasActiveSession {
+		writeErr(w, http.StatusPreconditionFailed, "no active session")
+		return false
+	}
+	if sid == "" {
+		writeErr(w, http.StatusUnauthorized, "missing session")
+		return false
+	}
+	if sid != activeID {
+		writeErr(w, http.StatusUnauthorized, "invalid session")
+		return false
+	}
+	return true
 }
 
 // resolveConnectorID splits "type/provider" into its components.

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -12,6 +12,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"sync"
 	"testing"
 	"time"
 
@@ -20,6 +21,8 @@ import (
 	"github.com/ALRubinger/aileron/internal/enclave"
 	"github.com/ALRubinger/aileron/internal/source"
 )
+
+var testSessionIDs sync.Map
 
 // stubConnector returns a fixed result for testing.
 type stubConnector struct{}
@@ -78,7 +81,55 @@ func setupTestEnclaveServerWithSource(t *testing.T, sc source.SourceConnector) (
 func postJSON(t *testing.T, server *httptest.Server, path string, body any) *http.Response {
 	t.Helper()
 	payload, _ := json.Marshal(body)
-	resp, err := http.Post(server.URL+path, "application/json", bytes.NewReader(payload))
+	req, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("creating POST %s: %v", path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sid, ok := testSessionIDs.Load(server.URL); ok {
+		req.Header.Set(enclave.HeaderSessionID, sid.(string))
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	return resp
+}
+
+func postJSONWithoutSession(t *testing.T, server *httptest.Server, path string, body any) *http.Response {
+	t.Helper()
+	return postJSONWithSessionID(t, server, path, body, "")
+}
+
+func postJSONWithSessionID(t *testing.T, server *httptest.Server, path string, body any, sessionID string) *http.Response {
+	t.Helper()
+	payload, _ := json.Marshal(body)
+	req, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewReader(payload))
+	if err != nil {
+		t.Fatalf("creating POST %s: %v", path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sessionID != "" {
+		req.Header.Set(enclave.HeaderSessionID, sessionID)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	return resp
+}
+
+func postRawWithSession(t *testing.T, server *httptest.Server, path string, body []byte) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("creating POST %s: %v", path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sid, ok := testSessionIDs.Load(server.URL); ok {
+		req.Header.Set(enclave.HeaderSessionID, sid.(string))
+	}
+	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		t.Fatalf("POST %s: %v", path, err)
 	}
@@ -134,6 +185,10 @@ func establishTestSession(t *testing.T, server *httptest.Server) []byte {
 	if sessResult.SessionID == "" {
 		t.Fatal("empty session ID")
 	}
+	testSessionIDs.Store(server.URL, sessResult.SessionID)
+	t.Cleanup(func() {
+		testSessionIDs.Delete(server.URL)
+	})
 
 	// Derive shared secret.
 	enclavePub, _ := ecdh.P256().NewPublicKey(attestResult.PublicKey)
@@ -453,6 +508,8 @@ func TestEscrowStoreRequiresScopeFields(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
+	establishTestSession(t, server)
+
 	base := validEscrowStoreRequest([]byte("encrypted"))
 	tests := []struct {
 		name   string
@@ -531,6 +588,8 @@ func TestEscrowRevokeNotFoundViaHTTP(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
+	establishTestSession(t, server)
+
 	resp := postJSON(t, server, "/escrow/revoke", enclave.EscrowRevokeRequest{
 		EscrowID: "nonexistent",
 		GrantID:  "g1",
@@ -591,10 +650,9 @@ func TestExecuteBadJSON(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
-	resp, err := http.Post(server.URL+"/execute", "application/json", bytes.NewReader([]byte("bad")))
-	if err != nil {
-		t.Fatalf("POST /execute: %v", err)
-	}
+	establishTestSession(t, server)
+
+	resp := postRawWithSession(t, server, "/execute", []byte("bad"))
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
@@ -605,10 +663,9 @@ func TestEscrowStoreBadJSON(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
-	resp, err := http.Post(server.URL+"/escrow", "application/json", bytes.NewReader([]byte("[")))
-	if err != nil {
-		t.Fatalf("POST /escrow: %v", err)
-	}
+	establishTestSession(t, server)
+
+	resp := postRawWithSession(t, server, "/escrow", []byte("["))
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
@@ -619,10 +676,9 @@ func TestEscrowRevokeBadJSON(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
-	resp, err := http.Post(server.URL+"/escrow/revoke", "application/json", bytes.NewReader([]byte("}")))
-	if err != nil {
-		t.Fatalf("POST /escrow/revoke: %v", err)
-	}
+	establishTestSession(t, server)
+
+	resp := postRawWithSession(t, server, "/escrow/revoke", []byte("}"))
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
@@ -690,6 +746,37 @@ func TestTransmitKEKWithoutSession(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestSensitiveEndpointsRequireMatchingSession(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	establishTestSession(t, server)
+
+	body := enclave.ExecuteRequest{
+		UserID:              "user-1",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: []byte("data"),
+	}
+
+	missing := postJSONWithoutSession(t, server, "/execute", body)
+	if missing.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for missing session, got %d", missing.StatusCode)
+	}
+	missing.Body.Close()
+
+	wrong := postJSONWithSessionID(t, server, "/execute", body, "wrong-session")
+	if wrong.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for wrong session, got %d", wrong.StatusCode)
+	}
+	wrong.Body.Close()
+
+	matching := postJSON(t, server, "/execute", body)
+	if matching.StatusCode != http.StatusPreconditionFailed {
+		t.Fatalf("expected 412 after valid session reaches KEK check, got %d", matching.StatusCode)
+	}
+	matching.Body.Close()
+}
+
 func TestTransmitKEKBadDecryption(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
@@ -710,10 +797,9 @@ func TestTransmitKEKBadJSON(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
-	resp, err := http.Post(server.URL+"/kek", "application/json", bytes.NewReader([]byte("bad")))
-	if err != nil {
-		t.Fatalf("POST /kek: %v", err)
-	}
+	establishTestSession(t, server)
+
+	resp := postRawWithSession(t, server, "/kek", []byte("bad"))
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
@@ -1067,10 +1153,9 @@ func TestOAuthExchangeBadJSON(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
-	resp, err := http.Post(server.URL+"/oauth/exchange", "application/json", bytes.NewReader([]byte("bad")))
-	if err != nil {
-		t.Fatalf("POST /oauth/exchange: %v", err)
-	}
+	establishTestSession(t, server)
+
+	resp := postRawWithSession(t, server, "/oauth/exchange", []byte("bad"))
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusBadRequest {
 		t.Fatalf("expected 400, got %d", resp.StatusCode)
@@ -1081,11 +1166,10 @@ func TestEscrowListEndpoint(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
+	establishTestSession(t, server)
+
 	// Empty list.
-	resp, err := http.Post(server.URL+"/escrow/list", "application/json", bytes.NewReader([]byte("{}")))
-	if err != nil {
-		t.Fatalf("POST /escrow/list: %v", err)
-	}
+	resp := postRawWithSession(t, server, "/escrow/list", []byte("{}"))
 	result := decodeResp[enclave.EscrowListResponse](t, resp)
 	if len(result.Entries) != 0 {
 		t.Fatalf("expected 0 entries, got %d", len(result.Entries))
@@ -1104,10 +1188,7 @@ func TestEscrowListEndpoint(t *testing.T) {
 	storeResp := postJSON(t, server, "/escrow", listReq)
 	storeResult := decodeResp[enclave.EscrowStoreResponse](t, storeResp)
 
-	resp2, err := http.Post(server.URL+"/escrow/list", "application/json", bytes.NewReader([]byte("{}")))
-	if err != nil {
-		t.Fatalf("POST /escrow/list: %v", err)
-	}
+	resp2 := postRawWithSession(t, server, "/escrow/list", []byte("{}"))
 	result2 := decodeResp[enclave.EscrowListResponse](t, resp2)
 	if len(result2.Entries) != 1 {
 		t.Fatalf("expected 1 entry, got %d", len(result2.Entries))
@@ -1143,6 +1224,8 @@ func TestSourceExecute_HappyPath(t *testing.T) {
 	server, srv := setupTestEnclaveServer(t)
 	defer server.Close()
 
+	establishTestSession(t, server)
+
 	// Store a credential in escrow.
 	escrowReq := testEscrowRequest("g1", "oauth2", nil)
 	escrowID := srv.escrow.Store(escrowReq, []byte(`{"access_token":"test"}`), time.Now().Add(time.Hour))
@@ -1173,6 +1256,8 @@ func TestSourceExecute_EscrowNotFound(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
+	establishTestSession(t, server)
+
 	resp := postJSON(t, server, "/source/execute", enclave.SourceExecuteRequest{
 		EscrowID: "esc_nonexistent",
 		Tool:     "test_search",
@@ -1186,6 +1271,8 @@ func TestSourceExecute_EscrowNotFound(t *testing.T) {
 func TestSourceExecute_RejectsScopeMismatch(t *testing.T) {
 	server, srv := setupTestEnclaveServer(t)
 	defer server.Close()
+
+	establishTestSession(t, server)
 
 	escrowReq := testEscrowRequest("g1", "oauth2", nil)
 	escrowID := srv.escrow.Store(escrowReq, []byte(`{"access_token":"test"}`), time.Now().Add(time.Hour))
@@ -1209,6 +1296,8 @@ func TestSourceExecute_ToolError(t *testing.T) {
 		err: fmt.Errorf("gmail API error: 401 Invalid Credentials"),
 	})
 	defer server.Close()
+
+	establishTestSession(t, server)
 
 	escrowReq := testEscrowRequest("g1", "oauth2", nil)
 	escrowID := srv.escrow.Store(escrowReq, []byte(`{"access_token":"test"}`), time.Now().Add(time.Hour))

--- a/internal/enclave/gcs/client.go
+++ b/internal/enclave/gcs/client.go
@@ -168,7 +168,7 @@ func (c *Client) post(ctx context.Context, path string, body any, result any) er
 	sid := c.sessionID
 	c.mu.Unlock()
 	if sid != "" {
-		req.Header.Set("X-Session-ID", sid)
+		req.Header.Set(enclave.HeaderSessionID, sid)
 	}
 
 	resp, err := c.httpClient.Do(req)

--- a/internal/enclave/gcs/client_test.go
+++ b/internal/enclave/gcs/client_test.go
@@ -69,7 +69,7 @@ func TestClientEstablishSession(t *testing.T) {
 func TestClientExecute(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify session header is sent after session establishment.
-		if sid := r.Header.Get("X-Session-ID"); sid != "sess-abc" {
+		if sid := r.Header.Get(enclave.HeaderSessionID); sid != "sess-abc" {
 			t.Fatalf("expected session ID sess-abc, got %q", sid)
 		}
 		json.NewEncoder(w).Encode(enclave.ExecuteResponse{

--- a/internal/enclave/protocol.go
+++ b/internal/enclave/protocol.go
@@ -143,6 +143,10 @@ type SessionResponse struct {
 	ExpiresAt string `json:"expires_at"` // RFC 3339
 }
 
+// HeaderSessionID binds post-attestation enclave requests to the active
+// ECDH session established by SessionRequest/SessionResponse.
+const HeaderSessionID = "X-Session-ID"
+
 // EscrowStoreRequest asks the enclave to escrow a credential for
 // asynchronous or scheduled execution when the user is offline.
 type EscrowStoreRequest struct {


### PR DESCRIPTION
## Summary

This is Phase 3a for #326.

- Require sensitive post-attestation enclave endpoints to carry the active `X-Session-ID` before processing requests.
- Share the session header name through the enclave protocol package and update the GCS client to use it.
- Expand enclave HTTP tests so successful flows include the session header and missing/mismatched session IDs are rejected.

## Notes

This intentionally splits Phase 3. The current browser-mediated ECDH flow means the app host does not know the browser/enclave session key, so it cannot HMAC later host-originated enclave requests with that key without a protocol change. Phase 3b should add the stronger request MAC/signature design.

## Validation

- `go test ./cmd/aileron-enclave/... ./internal/enclave/gcs/...`
- `go test ./internal/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...`
- `go test -cover ./cmd/aileron-enclave ./internal/enclave ./internal/enclave/gcs`

Coverage from the changed packages:

- `cmd/aileron-enclave`: 81.4%
- `internal/enclave`: 86.7%
- `internal/enclave/gcs`: 87.0%
