### PR TITLE
feat(enclave): authenticate enclave requests

### DIFF
--- a/cmd/aileron-enclave/server.go
+++ b/cmd/aileron-enclave/server.go
@@ -21,7 +21,11 @@ import (
 	"github.com/ALRubinger/aileron/internal/source"
 )
 
-const enclaveSessionTTL = 30 * time.Minute
+const (
+	enclaveSessionTTL     = 30 * time.Minute
+	requestAuthMaxSkew    = 5 * time.Minute
+	requestAuthNonceBytes = 32
+)
 
 type enclaveServer struct {
 	log            *slog.Logger
@@ -31,8 +35,10 @@ type enclaveServer struct {
 	mu             sync.Mutex
 	enclaveKey     *ecdh.PrivateKey
 	sessionKey     []byte
+	requestAuthKey []byte
 	sessionID      string
 	expiresAt      time.Time
+	seenNonces     map[string]time.Time
 	keks           *kekStore
 	escrow         *escrowStore
 }
@@ -47,6 +53,7 @@ func newEnclaveServer(log *slog.Logger, registry *connector.Registry, sourceReg 
 		registry:       registry,
 		sourceRegistry: sourceReg,
 		provider:       provider,
+		seenNonces:     make(map[string]time.Time),
 		keks:           newKEKStore(),
 		escrow:         escrow,
 	}, nil
@@ -134,29 +141,41 @@ func (s *enclaveServer) handleSession(w http.ResponseWriter, r *http.Request) {
 	}
 	h := sha256.Sum256(raw)
 
-	// Zero previous session key.
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		writeErr(w, http.StatusInternalServerError, "generating session ID")
+		return
+	}
+
+	requestAuthKey := make([]byte, requestAuthNonceBytes)
+	if _, err := rand.Read(requestAuthKey); err != nil {
+		writeErr(w, http.StatusInternalServerError, "generating request auth key")
+		return
+	}
+
+	// Zero previous session material only after the new session is ready.
 	zeroBytes(s.sessionKey)
+	zeroBytes(s.requestAuthKey)
 
 	s.sessionKey = h[:]
+	s.requestAuthKey = requestAuthKey
 	s.expiresAt = time.Now().Add(enclaveSessionTTL)
-
-	b := make([]byte, 16)
-	rand.Read(b)
 	s.sessionID = hex.EncodeToString(b)
+	clear(s.seenNonces)
 
 	writeJSON(w, http.StatusOK, enclave.SessionResponse{
-		SessionID: s.sessionID,
-		ExpiresAt: s.expiresAt.Format(time.RFC3339),
+		SessionID:      s.sessionID,
+		ExpiresAt:      s.expiresAt.Format(time.RFC3339),
+		RequestAuthKey: copyBytes(s.requestAuthKey),
 	})
 }
 
 func (s *enclaveServer) handleTransmitKEK(w http.ResponseWriter, r *http.Request) {
-	if !s.requireSession(w, r) {
-		return
-	}
-
 	var req enclave.TransmitKEKRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+		if err == errResponseWritten {
+			return
+		}
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -186,12 +205,11 @@ func (s *enclaveServer) handleTransmitKEK(w http.ResponseWriter, r *http.Request
 }
 
 func (s *enclaveServer) handleOAuthExchange(w http.ResponseWriter, r *http.Request) {
-	if !s.requireSession(w, r) {
-		return
-	}
-
 	var req enclave.OAuthExchangeRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+		if err == errResponseWritten {
+			return
+		}
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -232,12 +250,11 @@ func (s *enclaveServer) handleOAuthExchange(w http.ResponseWriter, r *http.Reque
 }
 
 func (s *enclaveServer) handleExecute(w http.ResponseWriter, r *http.Request) {
-	if !s.requireSession(w, r) {
-		return
-	}
-
 	var req enclave.ExecuteRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+		if err == errResponseWritten {
+			return
+		}
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -311,12 +328,11 @@ func (s *enclaveServer) handleExecute(w http.ResponseWriter, r *http.Request) {
 }
 
 func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request) {
-	if !s.requireSession(w, r) {
-		return
-	}
-
 	var req enclave.EscrowStoreRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+		if err == errResponseWritten {
+			return
+		}
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -367,7 +383,7 @@ func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request
 }
 
 func (s *enclaveServer) handleEscrowList(w http.ResponseWriter, r *http.Request) {
-	if !s.requireSession(w, r) {
+	if _, ok := s.requireAuthenticatedRequest(w, r); !ok {
 		return
 	}
 
@@ -376,12 +392,11 @@ func (s *enclaveServer) handleEscrowList(w http.ResponseWriter, r *http.Request)
 }
 
 func (s *enclaveServer) handleEscrowRevoke(w http.ResponseWriter, r *http.Request) {
-	if !s.requireSession(w, r) {
-		return
-	}
-
 	var req enclave.EscrowRevokeRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+		if err == errResponseWritten {
+			return
+		}
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -395,12 +410,11 @@ func (s *enclaveServer) handleEscrowRevoke(w http.ResponseWriter, r *http.Reques
 }
 
 func (s *enclaveServer) handleSourceExecute(w http.ResponseWriter, r *http.Request) {
-	if !s.requireSession(w, r) {
-		return
-	}
-
 	var req enclave.SourceExecuteRequest
-	if err := decodeJSON(r, &req); err != nil {
+	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+		if err == errResponseWritten {
+			return
+		}
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
@@ -452,27 +466,90 @@ func (s *enclaveServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
-func (s *enclaveServer) requireSession(w http.ResponseWriter, r *http.Request) bool {
+func (s *enclaveServer) decodeAuthenticatedJSON(w http.ResponseWriter, r *http.Request, v any) error {
+	body, ok := s.requireAuthenticatedRequest(w, r)
+	if !ok {
+		return errResponseWritten
+	}
+	return json.Unmarshal(body, v)
+}
+
+var errResponseWritten = fmt.Errorf("response already written")
+
+func (s *enclaveServer) requireAuthenticatedRequest(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+	body, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "reading body: "+err.Error())
+		return nil, false
+	}
+	defer r.Body.Close()
+
 	sid := r.Header.Get(enclave.HeaderSessionID)
+	timestamp := r.Header.Get(enclave.HeaderRequestTimestamp)
+	nonce := r.Header.Get(enclave.HeaderRequestNonce)
+	reqMAC := r.Header.Get(enclave.HeaderRequestMAC)
 
 	s.mu.Lock()
 	activeID := s.sessionID
-	hasActiveSession := s.sessionKey != nil && time.Now().Before(s.expiresAt)
+	authKey := copyBytes(s.requestAuthKey)
+	expiresAt := s.expiresAt
+	hasActiveSession := s.sessionKey != nil && len(s.requestAuthKey) > 0 && time.Now().Before(s.expiresAt)
 	s.mu.Unlock()
+	defer zeroBytes(authKey)
 
 	if !hasActiveSession {
 		writeErr(w, http.StatusPreconditionFailed, "no active session")
-		return false
+		return nil, false
 	}
 	if sid == "" {
 		writeErr(w, http.StatusUnauthorized, "missing session")
-		return false
+		return nil, false
 	}
 	if sid != activeID {
 		writeErr(w, http.StatusUnauthorized, "invalid session")
-		return false
+		return nil, false
 	}
-	return true
+	if timestamp == "" || nonce == "" || reqMAC == "" {
+		writeErr(w, http.StatusUnauthorized, "missing request authentication")
+		return nil, false
+	}
+
+	requestTime, err := time.Parse(time.RFC3339, timestamp)
+	if err != nil {
+		writeErr(w, http.StatusUnauthorized, "invalid request timestamp")
+		return nil, false
+	}
+	now := time.Now()
+	if requestTime.Before(now.Add(-requestAuthMaxSkew)) || requestTime.After(now.Add(requestAuthMaxSkew)) || requestTime.After(expiresAt) {
+		writeErr(w, http.StatusUnauthorized, "stale request")
+		return nil, false
+	}
+	if !enclave.VerifyRequestMAC(authKey, r.Method, r.URL.Path, body, sid, timestamp, nonce, reqMAC) {
+		writeErr(w, http.StatusUnauthorized, "invalid request authentication")
+		return nil, false
+	}
+
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if s.sessionID != sid || s.sessionKey == nil || time.Now().After(s.expiresAt) {
+		writeErr(w, http.StatusPreconditionFailed, "no active session")
+		return nil, false
+	}
+	pruneSeenNonces(s.seenNonces, now.Add(-requestAuthMaxSkew))
+	if _, ok := s.seenNonces[nonce]; ok {
+		writeErr(w, http.StatusUnauthorized, "replayed request")
+		return nil, false
+	}
+	s.seenNonces[nonce] = now
+	return body, true
+}
+
+func pruneSeenNonces(seen map[string]time.Time, before time.Time) {
+	for nonce, seenAt := range seen {
+		if seenAt.Before(before) {
+			delete(seen, nonce)
+		}
+	}
 }
 
 // resolveConnectorID splits "type/provider" into its components.

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/ecdh"
 	"crypto/rand"
 	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -22,7 +23,12 @@ import (
 	"github.com/ALRubinger/aileron/internal/source"
 )
 
-var testSessionIDs sync.Map
+type testSessionAuth struct {
+	sessionID string
+	authKey   []byte
+}
+
+var testSessions sync.Map
 
 // stubConnector returns a fixed result for testing.
 type stubConnector struct{}
@@ -81,19 +87,7 @@ func setupTestEnclaveServerWithSource(t *testing.T, sc source.SourceConnector) (
 func postJSON(t *testing.T, server *httptest.Server, path string, body any) *http.Response {
 	t.Helper()
 	payload, _ := json.Marshal(body)
-	req, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewReader(payload))
-	if err != nil {
-		t.Fatalf("creating POST %s: %v", path, err)
-	}
-	req.Header.Set("Content-Type", "application/json")
-	if sid, ok := testSessionIDs.Load(server.URL); ok {
-		req.Header.Set(enclave.HeaderSessionID, sid.(string))
-	}
-	resp, err := http.DefaultClient.Do(req)
-	if err != nil {
-		t.Fatalf("POST %s: %v", path, err)
-	}
-	return resp
+	return postRaw(t, server, path, payload, true)
 }
 
 func postJSONWithoutSession(t *testing.T, server *httptest.Server, path string, body any) *http.Response {
@@ -104,7 +98,38 @@ func postJSONWithoutSession(t *testing.T, server *httptest.Server, path string, 
 func postJSONWithSessionID(t *testing.T, server *httptest.Server, path string, body any, sessionID string) *http.Response {
 	t.Helper()
 	payload, _ := json.Marshal(body)
-	req, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewReader(payload))
+	return postRawWithExplicitSessionID(t, server, path, payload, sessionID)
+}
+
+func postRawWithSession(t *testing.T, server *httptest.Server, path string, body []byte) *http.Response {
+	t.Helper()
+	return postRaw(t, server, path, body, true)
+}
+
+func postRaw(t *testing.T, server *httptest.Server, path string, body []byte, sign bool) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewReader(body))
+	if err != nil {
+		t.Fatalf("creating POST %s: %v", path, err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	if sessAny, ok := testSessions.Load(server.URL); ok {
+		sess := sessAny.(testSessionAuth)
+		req.Header.Set(enclave.HeaderSessionID, sess.sessionID)
+		if sign {
+			signTestRequest(t, req, path, body, sess)
+		}
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST %s: %v", path, err)
+	}
+	return resp
+}
+
+func postRawWithExplicitSessionID(t *testing.T, server *httptest.Server, path string, body []byte, sessionID string) *http.Response {
+	t.Helper()
+	req, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("creating POST %s: %v", path, err)
 	}
@@ -119,21 +144,44 @@ func postJSONWithSessionID(t *testing.T, server *httptest.Server, path string, b
 	return resp
 }
 
-func postRawWithSession(t *testing.T, server *httptest.Server, path string, body []byte) *http.Response {
+func signTestRequest(t *testing.T, req *http.Request, path string, body []byte, sess testSessionAuth) string {
+	t.Helper()
+	nonceBytes := make([]byte, 16)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		t.Fatalf("generating nonce: %v", err)
+	}
+	nonce := hex.EncodeToString(nonceBytes)
+	timestamp := time.Now().UTC().Format(time.RFC3339)
+	signTestRequestWith(t, req, path, body, sess, timestamp, nonce)
+	return nonce
+}
+
+func signTestRequestWith(t *testing.T, req *http.Request, path string, body []byte, sess testSessionAuth, timestamp, nonce string) {
+	t.Helper()
+	req.Header.Set(enclave.HeaderRequestTimestamp, timestamp)
+	req.Header.Set(enclave.HeaderRequestNonce, nonce)
+	req.Header.Set(enclave.HeaderRequestMAC, enclave.RequestMAC(sess.authKey, req.Method, path, body, sess.sessionID, timestamp, nonce))
+}
+
+func signedTestRequest(t *testing.T, server *httptest.Server, path string, body []byte, sess testSessionAuth) *http.Request {
 	t.Helper()
 	req, err := http.NewRequest(http.MethodPost, server.URL+path, bytes.NewReader(body))
 	if err != nil {
 		t.Fatalf("creating POST %s: %v", path, err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	if sid, ok := testSessionIDs.Load(server.URL); ok {
-		req.Header.Set(enclave.HeaderSessionID, sid.(string))
-	}
-	resp, err := http.DefaultClient.Do(req)
+	req.Header.Set(enclave.HeaderSessionID, sess.sessionID)
+	signTestRequest(t, req, path, body, sess)
+	return req
+}
+
+func mustJSON(t *testing.T, body any) []byte {
+	t.Helper()
+	payload, err := json.Marshal(body)
 	if err != nil {
-		t.Fatalf("POST %s: %v", path, err)
+		t.Fatalf("marshaling JSON: %v", err)
 	}
-	return resp
+	return payload
 }
 
 func decodeResp[T any](t *testing.T, resp *http.Response) T {
@@ -185,9 +233,15 @@ func establishTestSession(t *testing.T, server *httptest.Server) []byte {
 	if sessResult.SessionID == "" {
 		t.Fatal("empty session ID")
 	}
-	testSessionIDs.Store(server.URL, sessResult.SessionID)
+	if len(sessResult.RequestAuthKey) == 0 {
+		t.Fatal("empty request auth key")
+	}
+	testSessions.Store(server.URL, testSessionAuth{
+		sessionID: sessResult.SessionID,
+		authKey:   sessResult.RequestAuthKey,
+	})
 	t.Cleanup(func() {
-		testSessionIDs.Delete(server.URL)
+		testSessions.Delete(server.URL)
 	})
 
 	// Derive shared secret.
@@ -775,6 +829,146 @@ func TestSensitiveEndpointsRequireMatchingSession(t *testing.T) {
 		t.Fatalf("expected 412 after valid session reaches KEK check, got %d", matching.StatusCode)
 	}
 	matching.Body.Close()
+}
+
+func TestSensitiveEndpointsRequireRequestAuthentication(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	establishTestSession(t, server)
+
+	body := enclave.ExecuteRequest{
+		UserID:              "user-1",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: []byte("data"),
+	}
+
+	unsigned := postRaw(t, server, "/execute", mustJSON(t, body), false)
+	if unsigned.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for unsigned request, got %d", unsigned.StatusCode)
+	}
+	unsigned.Body.Close()
+}
+
+func TestSensitiveEndpointsRejectTamperedRequest(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	establishTestSession(t, server)
+
+	originalBody := []byte(`{"user_id":"user-1","connector_id":"test/stub","encrypted_credential":"ZGF0YQ=="}`)
+	tamperedBody := []byte(`{"user_id":"user-2","connector_id":"test/stub","encrypted_credential":"ZGF0YQ=="}`)
+	req, err := http.NewRequest(http.MethodPost, server.URL+"/execute", bytes.NewReader(tamperedBody))
+	if err != nil {
+		t.Fatalf("creating request: %v", err)
+	}
+	req.Header.Set("Content-Type", "application/json")
+	sessAny, _ := testSessions.Load(server.URL)
+	sess := sessAny.(testSessionAuth)
+	req.Header.Set(enclave.HeaderSessionID, sess.sessionID)
+	signTestRequest(t, req, "/execute", originalBody, sess)
+
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("POST /execute: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for tampered body, got %d", resp.StatusCode)
+	}
+}
+
+func TestSensitiveEndpointsRejectReplay(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	establishTestSession(t, server)
+
+	body := mustJSON(t, enclave.ExecuteRequest{
+		UserID:              "user-1",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: []byte("data"),
+	})
+	sessAny, _ := testSessions.Load(server.URL)
+	sess := sessAny.(testSessionAuth)
+	req1 := signedTestRequest(t, server, "/execute", body, sess)
+
+	first, err := http.DefaultClient.Do(req1)
+	if err != nil {
+		t.Fatalf("POST /execute: %v", err)
+	}
+	first.Body.Close()
+	if first.StatusCode != http.StatusPreconditionFailed {
+		t.Fatalf("expected first request to pass auth and fail at KEK check with 412, got %d", first.StatusCode)
+	}
+
+	req2 := signedTestRequest(t, server, "/execute", body, sess)
+	req2.Header.Set(enclave.HeaderRequestTimestamp, req1.Header.Get(enclave.HeaderRequestTimestamp))
+	req2.Header.Set(enclave.HeaderRequestNonce, req1.Header.Get(enclave.HeaderRequestNonce))
+	req2.Header.Set(enclave.HeaderRequestMAC, req1.Header.Get(enclave.HeaderRequestMAC))
+	second, err := http.DefaultClient.Do(req2)
+	if err != nil {
+		t.Fatalf("POST /execute replay: %v", err)
+	}
+	defer second.Body.Close()
+	if second.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for replay, got %d", second.StatusCode)
+	}
+}
+
+func TestSensitiveEndpointsRejectInvalidAndStaleTimestamps(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	establishTestSession(t, server)
+
+	body := mustJSON(t, enclave.ExecuteRequest{
+		UserID:              "user-1",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: []byte("data"),
+	})
+	sessAny, _ := testSessions.Load(server.URL)
+	sess := sessAny.(testSessionAuth)
+
+	invalid := signedTestRequest(t, server, "/execute", body, sess)
+	invalid.Header.Set(enclave.HeaderRequestTimestamp, "not-a-time")
+	resp, err := http.DefaultClient.Do(invalid)
+	if err != nil {
+		t.Fatalf("POST /execute invalid timestamp: %v", err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for invalid timestamp, got %d", resp.StatusCode)
+	}
+
+	stale := signedTestRequest(t, server, "/execute", body, sess)
+	staleTime := time.Now().UTC().Add(-10 * time.Minute).Format(time.RFC3339)
+	signTestRequestWith(t, stale, "/execute", body, sess, staleTime, "stale-nonce")
+	resp, err = http.DefaultClient.Do(stale)
+	if err != nil {
+		t.Fatalf("POST /execute stale timestamp: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("expected 401 for stale timestamp, got %d", resp.StatusCode)
+	}
+}
+
+func TestPruneSeenNonces(t *testing.T) {
+	now := time.Now()
+	seen := map[string]time.Time{
+		"old":    now.Add(-10 * time.Minute),
+		"recent": now,
+	}
+
+	pruneSeenNonces(seen, now.Add(-5*time.Minute))
+
+	if _, ok := seen["old"]; ok {
+		t.Fatal("expected old nonce to be pruned")
+	}
+	if _, ok := seen["recent"]; !ok {
+		t.Fatal("expected recent nonce to remain")
+	}
 }
 
 func TestTransmitKEKBadDecryption(t *testing.T) {

--- a/internal/enclave/gcs/client.go
+++ b/internal/enclave/gcs/client.go
@@ -6,11 +6,14 @@ package gcs
 import (
 	"bytes"
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"encoding/json"
 	"fmt"
 	"io"
 	"net/http"
 	"sync"
+	"time"
 
 	"github.com/ALRubinger/aileron/internal/enclave"
 )
@@ -22,6 +25,7 @@ type Client struct {
 	baseURL    string
 	httpClient *http.Client
 	sessionID  string
+	authKey    []byte
 }
 
 // Config holds configuration for the GCS enclave client.
@@ -61,6 +65,7 @@ func (c *Client) EstablishSession(ctx context.Context, req enclave.SessionReques
 	}
 	c.mu.Lock()
 	c.sessionID = resp.SessionID
+	c.authKey = copyBytes(resp.RequestAuthKey)
 	c.mu.Unlock()
 	return resp, nil
 }
@@ -146,8 +151,13 @@ func (c *Client) Ready(ctx context.Context) error {
 	return nil
 }
 
-// Close is a no-op for the HTTP client.
+// Close clears session-bound request authentication material.
 func (c *Client) Close() error {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	zeroBytes(c.authKey)
+	c.authKey = nil
+	c.sessionID = ""
 	return nil
 }
 
@@ -166,10 +176,22 @@ func (c *Client) post(ctx context.Context, path string, body any, result any) er
 
 	c.mu.Lock()
 	sid := c.sessionID
+	authKey := copyBytes(c.authKey)
 	c.mu.Unlock()
 	if sid != "" {
 		req.Header.Set(enclave.HeaderSessionID, sid)
 	}
+	if sid != "" && len(authKey) > 0 && requiresRequestAuth(path) {
+		timestamp := time.Now().UTC().Format(time.RFC3339)
+		nonce, err := randomNonce()
+		if err != nil {
+			return fmt.Errorf("generating request nonce: %w", err)
+		}
+		req.Header.Set(enclave.HeaderRequestTimestamp, timestamp)
+		req.Header.Set(enclave.HeaderRequestNonce, nonce)
+		req.Header.Set(enclave.HeaderRequestMAC, enclave.RequestMAC(authKey, http.MethodPost, path, payload, sid, timestamp, nonce))
+	}
+	zeroBytes(authKey)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -188,4 +210,36 @@ func (c *Client) post(ctx context.Context, path string, body any, result any) er
 		}
 	}
 	return nil
+}
+
+func requiresRequestAuth(path string) bool {
+	switch path {
+	case "/kek", "/oauth/exchange", "/execute", "/escrow", "/escrow/list", "/escrow/revoke", "/source/execute":
+		return true
+	default:
+		return false
+	}
+}
+
+func randomNonce() (string, error) {
+	b := make([]byte, 16)
+	if _, err := rand.Read(b); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b), nil
+}
+
+func copyBytes(b []byte) []byte {
+	if b == nil {
+		return nil
+	}
+	c := make([]byte, len(b))
+	copy(c, b)
+	return c
+}
+
+func zeroBytes(b []byte) {
+	for i := range b {
+		b[i] = 0
+	}
 }

--- a/internal/enclave/gcs/client_test.go
+++ b/internal/enclave/gcs/client_test.go
@@ -3,6 +3,7 @@ package gcs
 import (
 	"context"
 	"encoding/json"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"testing"
@@ -45,11 +46,40 @@ func TestClientAttest(t *testing.T) {
 	}
 }
 
+func TestClientDoesNotSignUnauthenticatedEndpoints(t *testing.T) {
+	authKey := []byte("01234567890123456789012345678901")
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Header.Get(enclave.HeaderRequestMAC) != "" {
+			t.Fatal("did not expect request MAC on attestation request")
+		}
+		if r.Header.Get(enclave.HeaderRequestTimestamp) != "" {
+			t.Fatal("did not expect request timestamp on attestation request")
+		}
+		if r.Header.Get(enclave.HeaderRequestNonce) != "" {
+			t.Fatal("did not expect request nonce on attestation request")
+		}
+		json.NewEncoder(w).Encode(enclave.AttestationResponse{
+			Token:     "test-token",
+			PublicKey: []byte("test-pubkey"),
+		})
+	}))
+	defer server.Close()
+
+	c := New(Config{BaseURL: server.URL})
+	c.sessionID = "sess-abc"
+	c.authKey = authKey
+
+	if _, err := c.Attest(context.Background(), enclave.AttestationRequest{}); err != nil {
+		t.Fatalf("Attest: %v", err)
+	}
+}
+
 func TestClientEstablishSession(t *testing.T) {
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		json.NewEncoder(w).Encode(enclave.SessionResponse{
-			SessionID: "sess-123",
-			ExpiresAt: "2026-12-31T23:59:59Z",
+			SessionID:      "sess-123",
+			ExpiresAt:      "2026-12-31T23:59:59Z",
+			RequestAuthKey: []byte("request-auth-key"),
 		})
 	}))
 	defer server.Close()
@@ -64,13 +94,30 @@ func TestClientEstablishSession(t *testing.T) {
 	if resp.SessionID != "sess-123" {
 		t.Fatalf("expected sess-123, got %q", resp.SessionID)
 	}
+	if string(c.authKey) != "request-auth-key" {
+		t.Fatalf("expected request auth key to be stored")
+	}
 }
 
 func TestClientExecute(t *testing.T) {
+	authKey := []byte("01234567890123456789012345678901")
 	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		// Verify session header is sent after session establishment.
 		if sid := r.Header.Get(enclave.HeaderSessionID); sid != "sess-abc" {
 			t.Fatalf("expected session ID sess-abc, got %q", sid)
+		}
+		timestamp := r.Header.Get(enclave.HeaderRequestTimestamp)
+		nonce := r.Header.Get(enclave.HeaderRequestNonce)
+		mac := r.Header.Get(enclave.HeaderRequestMAC)
+		if timestamp == "" || nonce == "" || mac == "" {
+			t.Fatalf("expected request authentication headers")
+		}
+		body, err := io.ReadAll(r.Body)
+		if err != nil {
+			t.Fatalf("reading body: %v", err)
+		}
+		if !enclave.VerifyRequestMAC(authKey, r.Method, r.URL.Path, body, "sess-abc", timestamp, nonce, mac) {
+			t.Fatalf("request MAC did not verify")
 		}
 		json.NewEncoder(w).Encode(enclave.ExecuteResponse{
 			RequestID:  "exec-1",
@@ -84,6 +131,7 @@ func TestClientExecute(t *testing.T) {
 	c := New(Config{BaseURL: server.URL})
 	// Set session ID manually for this test.
 	c.sessionID = "sess-abc"
+	c.authKey = authKey
 
 	resp, err := c.Execute(context.Background(), enclave.ExecuteRequest{
 		RequestID: "exec-1",
@@ -93,6 +141,32 @@ func TestClientExecute(t *testing.T) {
 	}
 	if resp.Status != "succeeded" {
 		t.Fatalf("expected succeeded, got %q", resp.Status)
+	}
+}
+
+func TestRequiresRequestAuth(t *testing.T) {
+	tests := []struct {
+		path string
+		want bool
+	}{
+		{path: "/kek", want: true},
+		{path: "/oauth/exchange", want: true},
+		{path: "/execute", want: true},
+		{path: "/escrow", want: true},
+		{path: "/escrow/list", want: true},
+		{path: "/escrow/revoke", want: true},
+		{path: "/source/execute", want: true},
+		{path: "/attest", want: false},
+		{path: "/session", want: false},
+		{path: "/health", want: false},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.path, func(t *testing.T) {
+			if got := requiresRequestAuth(tt.path); got != tt.want {
+				t.Fatalf("requiresRequestAuth(%q) = %v, want %v", tt.path, got, tt.want)
+			}
+		})
 	}
 }
 
@@ -107,6 +181,22 @@ func TestClientErrorResponse(t *testing.T) {
 	_, err := c.Attest(context.Background(), enclave.AttestationRequest{})
 	if err == nil {
 		t.Fatal("expected error for 500 response")
+	}
+}
+
+func TestClientCloseClearsSessionAuth(t *testing.T) {
+	c := New(Config{BaseURL: "http://example.test"})
+	c.sessionID = "sess-abc"
+	c.authKey = []byte("01234567890123456789012345678901")
+
+	if err := c.Close(); err != nil {
+		t.Fatalf("Close: %v", err)
+	}
+	if c.sessionID != "" {
+		t.Fatalf("expected session ID to be cleared")
+	}
+	if c.authKey != nil {
+		t.Fatalf("expected auth key to be cleared")
 	}
 }
 

--- a/internal/enclave/protocol.go
+++ b/internal/enclave/protocol.go
@@ -139,13 +139,20 @@ type SessionRequest struct {
 // SessionResponse confirms that the session is established and credentials
 // can be transmitted.
 type SessionResponse struct {
-	SessionID string `json:"session_id"`
-	ExpiresAt string `json:"expires_at"` // RFC 3339
+	SessionID      string `json:"session_id"`
+	ExpiresAt      string `json:"expires_at"` // RFC 3339
+	RequestAuthKey []byte `json:"request_auth_key,omitempty"`
 }
 
 // HeaderSessionID binds post-attestation enclave requests to the active
 // ECDH session established by SessionRequest/SessionResponse.
 const HeaderSessionID = "X-Session-ID"
+
+const (
+	HeaderRequestTimestamp = "X-Request-Timestamp"
+	HeaderRequestNonce     = "X-Request-Nonce"
+	HeaderRequestMAC       = "X-Request-MAC"
+)
 
 // EscrowStoreRequest asks the enclave to escrow a credential for
 // asynchronous or scheduled execution when the user is offline.

--- a/internal/enclave/request_auth.go
+++ b/internal/enclave/request_auth.go
@@ -1,0 +1,33 @@
+package enclave
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"strings"
+)
+
+// RequestMAC returns a base64url-encoded HMAC over the request binding fields.
+func RequestMAC(key []byte, method, path string, body []byte, sessionID, timestamp, nonce string) string {
+	mac := hmac.New(sha256.New, key)
+	mac.Write([]byte(requestMACPayload(method, path, body, sessionID, timestamp, nonce)))
+	return base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+}
+
+// VerifyRequestMAC checks that mac authenticates the request binding fields.
+func VerifyRequestMAC(key []byte, method, path string, body []byte, sessionID, timestamp, nonce, mac string) bool {
+	expected := RequestMAC(key, method, path, body, sessionID, timestamp, nonce)
+	return hmac.Equal([]byte(mac), []byte(expected))
+}
+
+func requestMACPayload(method, path string, body []byte, sessionID, timestamp, nonce string) string {
+	bodyHash := sha256.Sum256(body)
+	return strings.Join([]string{
+		method,
+		path,
+		sessionID,
+		timestamp,
+		nonce,
+		base64.RawURLEncoding.EncodeToString(bodyHash[:]),
+	}, "\n")
+}

--- a/internal/enclave/request_auth_test.go
+++ b/internal/enclave/request_auth_test.go
@@ -1,0 +1,26 @@
+package enclave
+
+import "testing"
+
+func TestRequestMACVerifiesBoundFields(t *testing.T) {
+	key := []byte("01234567890123456789012345678901")
+	body := []byte(`{"user_id":"user-1"}`)
+
+	mac := RequestMAC(key, "POST", "/execute", body, "sess-1", "2026-04-26T08:00:00Z", "nonce-1")
+
+	if !VerifyRequestMAC(key, "POST", "/execute", body, "sess-1", "2026-04-26T08:00:00Z", "nonce-1", mac) {
+		t.Fatal("expected MAC to verify")
+	}
+	if VerifyRequestMAC(key, "POST", "/execute", []byte(`{"user_id":"user-2"}`), "sess-1", "2026-04-26T08:00:00Z", "nonce-1", mac) {
+		t.Fatal("expected body tamper to fail")
+	}
+	if VerifyRequestMAC(key, "POST", "/escrow", body, "sess-1", "2026-04-26T08:00:00Z", "nonce-1", mac) {
+		t.Fatal("expected path tamper to fail")
+	}
+	if VerifyRequestMAC(key, "POST", "/execute", body, "sess-2", "2026-04-26T08:00:00Z", "nonce-1", mac) {
+		t.Fatal("expected session tamper to fail")
+	}
+	if VerifyRequestMAC(key, "POST", "/execute", body, "sess-1", "2026-04-26T08:00:00Z", "nonce-2", mac) {
+		t.Fatal("expected nonce tamper to fail")
+	}
+}


### PR DESCRIPTION
## Summary

This is Phase 3b for #326.

- Add a session-scoped request authentication key returned by `/session`.
- Sign sensitive GCS enclave client requests with HMAC over method, path, body hash, session ID, timestamp, and nonce.
- Require sensitive enclave HTTP endpoints to verify the request MAC, timestamp freshness, and nonce uniqueness before processing bodies.
- Reject unsigned, tampered, stale, and replayed enclave operation requests.
- Expand tests for invalid/stale timestamps, nonce pruning, sensitive endpoint classification, and ensuring unauthenticated endpoints remain unsigned.

## Notes

Phase 3a already required `X-Session-ID` on sensitive endpoints. This PR completes the next layer by binding each sensitive request to a per-session MAC and nonce replay cache.

## Validation

- `go test ./cmd/aileron-enclave/... ./internal/enclave/...`
- `go test ./internal/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...`
- `go test -cover ./cmd/aileron-enclave ./internal/enclave ./internal/enclave/gcs`

Coverage from the changed packages:

- `cmd/aileron-enclave`: 81.7%
- `internal/enclave`: 90.9%
- `internal/enclave/gcs`: 87.8%
