### PR TITLE
feat(enclave): verify grant capabilities

### DIFF
--- a/cmd/aileron-enclave/server.go
+++ b/cmd/aileron-enclave/server.go
@@ -172,13 +172,15 @@ func (s *enclaveServer) handleSession(w http.ResponseWriter, r *http.Request) {
 
 func (s *enclaveServer) handleTransmitKEK(w http.ResponseWriter, r *http.Request) {
 	var req enclave.TransmitKEKRequest
-	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+	authKey, err := s.decodeAuthenticatedJSON(w, r, &req)
+	if err != nil {
 		if err == errResponseWritten {
 			return
 		}
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	zeroBytes(authKey)
 
 	s.mu.Lock()
 	sessionKey := copyBytes(s.sessionKey)
@@ -206,13 +208,15 @@ func (s *enclaveServer) handleTransmitKEK(w http.ResponseWriter, r *http.Request
 
 func (s *enclaveServer) handleOAuthExchange(w http.ResponseWriter, r *http.Request) {
 	var req enclave.OAuthExchangeRequest
-	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+	authKey, err := s.decodeAuthenticatedJSON(w, r, &req)
+	if err != nil {
 		if err == errResponseWritten {
 			return
 		}
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	zeroBytes(authKey)
 
 	// Get user's KEK.
 	kek, err := s.keks.Get(req.UserID)
@@ -251,11 +255,17 @@ func (s *enclaveServer) handleOAuthExchange(w http.ResponseWriter, r *http.Reque
 
 func (s *enclaveServer) handleExecute(w http.ResponseWriter, r *http.Request) {
 	var req enclave.ExecuteRequest
-	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+	authKey, err := s.decodeAuthenticatedJSON(w, r, &req)
+	if err != nil {
 		if err == errResponseWritten {
 			return
 		}
 		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	defer zeroBytes(authKey)
+	if !enclave.VerifyExecuteCapability(authKey, req) {
+		writeErr(w, http.StatusForbidden, "invalid grant capability")
 		return
 	}
 
@@ -329,11 +339,17 @@ func (s *enclaveServer) handleExecute(w http.ResponseWriter, r *http.Request) {
 
 func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request) {
 	var req enclave.EscrowStoreRequest
-	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+	authKey, err := s.decodeAuthenticatedJSON(w, r, &req)
+	if err != nil {
 		if err == errResponseWritten {
 			return
 		}
 		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	defer zeroBytes(authKey)
+	if !enclave.VerifyEscrowStoreCapability(authKey, req) {
+		writeErr(w, http.StatusForbidden, "invalid grant capability")
 		return
 	}
 	if req.UserID == "" {
@@ -383,9 +399,11 @@ func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request
 }
 
 func (s *enclaveServer) handleEscrowList(w http.ResponseWriter, r *http.Request) {
-	if _, ok := s.requireAuthenticatedRequest(w, r); !ok {
+	_, authKey, ok := s.requireAuthenticatedRequest(w, r)
+	if !ok {
 		return
 	}
+	zeroBytes(authKey)
 
 	entries := s.escrow.List()
 	writeJSON(w, http.StatusOK, enclave.EscrowListResponse{Entries: entries})
@@ -393,13 +411,15 @@ func (s *enclaveServer) handleEscrowList(w http.ResponseWriter, r *http.Request)
 
 func (s *enclaveServer) handleEscrowRevoke(w http.ResponseWriter, r *http.Request) {
 	var req enclave.EscrowRevokeRequest
-	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+	authKey, err := s.decodeAuthenticatedJSON(w, r, &req)
+	if err != nil {
 		if err == errResponseWritten {
 			return
 		}
 		writeErr(w, http.StatusBadRequest, err.Error())
 		return
 	}
+	zeroBytes(authKey)
 
 	if err := s.escrow.Revoke(req.EscrowID, req.GrantID); err != nil {
 		writeErr(w, http.StatusNotFound, err.Error())
@@ -411,11 +431,17 @@ func (s *enclaveServer) handleEscrowRevoke(w http.ResponseWriter, r *http.Reques
 
 func (s *enclaveServer) handleSourceExecute(w http.ResponseWriter, r *http.Request) {
 	var req enclave.SourceExecuteRequest
-	if err := s.decodeAuthenticatedJSON(w, r, &req); err != nil {
+	authKey, err := s.decodeAuthenticatedJSON(w, r, &req)
+	if err != nil {
 		if err == errResponseWritten {
 			return
 		}
 		writeErr(w, http.StatusBadRequest, err.Error())
+		return
+	}
+	defer zeroBytes(authKey)
+	if !enclave.VerifySourceExecuteCapability(authKey, req) {
+		writeErr(w, http.StatusForbidden, "invalid grant capability")
 		return
 	}
 
@@ -466,21 +492,25 @@ func (s *enclaveServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
 	})
 }
 
-func (s *enclaveServer) decodeAuthenticatedJSON(w http.ResponseWriter, r *http.Request, v any) error {
-	body, ok := s.requireAuthenticatedRequest(w, r)
+func (s *enclaveServer) decodeAuthenticatedJSON(w http.ResponseWriter, r *http.Request, v any) ([]byte, error) {
+	body, authKey, ok := s.requireAuthenticatedRequest(w, r)
 	if !ok {
-		return errResponseWritten
+		return nil, errResponseWritten
 	}
-	return json.Unmarshal(body, v)
+	if err := json.Unmarshal(body, v); err != nil {
+		zeroBytes(authKey)
+		return nil, err
+	}
+	return authKey, nil
 }
 
 var errResponseWritten = fmt.Errorf("response already written")
 
-func (s *enclaveServer) requireAuthenticatedRequest(w http.ResponseWriter, r *http.Request) ([]byte, bool) {
+func (s *enclaveServer) requireAuthenticatedRequest(w http.ResponseWriter, r *http.Request) ([]byte, []byte, bool) {
 	body, err := io.ReadAll(r.Body)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, "reading body: "+err.Error())
-		return nil, false
+		return nil, nil, false
 	}
 	defer r.Body.Close()
 
@@ -499,49 +529,49 @@ func (s *enclaveServer) requireAuthenticatedRequest(w http.ResponseWriter, r *ht
 
 	if !hasActiveSession {
 		writeErr(w, http.StatusPreconditionFailed, "no active session")
-		return nil, false
+		return nil, nil, false
 	}
 	if sid == "" {
 		writeErr(w, http.StatusUnauthorized, "missing session")
-		return nil, false
+		return nil, nil, false
 	}
 	if sid != activeID {
 		writeErr(w, http.StatusUnauthorized, "invalid session")
-		return nil, false
+		return nil, nil, false
 	}
 	if timestamp == "" || nonce == "" || reqMAC == "" {
 		writeErr(w, http.StatusUnauthorized, "missing request authentication")
-		return nil, false
+		return nil, nil, false
 	}
 
 	requestTime, err := time.Parse(time.RFC3339, timestamp)
 	if err != nil {
 		writeErr(w, http.StatusUnauthorized, "invalid request timestamp")
-		return nil, false
+		return nil, nil, false
 	}
 	now := time.Now()
 	if requestTime.Before(now.Add(-requestAuthMaxSkew)) || requestTime.After(now.Add(requestAuthMaxSkew)) || requestTime.After(expiresAt) {
 		writeErr(w, http.StatusUnauthorized, "stale request")
-		return nil, false
+		return nil, nil, false
 	}
 	if !enclave.VerifyRequestMAC(authKey, r.Method, r.URL.Path, body, sid, timestamp, nonce, reqMAC) {
 		writeErr(w, http.StatusUnauthorized, "invalid request authentication")
-		return nil, false
+		return nil, nil, false
 	}
 
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	if s.sessionID != sid || s.sessionKey == nil || time.Now().After(s.expiresAt) {
 		writeErr(w, http.StatusPreconditionFailed, "no active session")
-		return nil, false
+		return nil, nil, false
 	}
 	pruneSeenNonces(s.seenNonces, now.Add(-requestAuthMaxSkew))
 	if _, ok := s.seenNonces[nonce]; ok {
 		writeErr(w, http.StatusUnauthorized, "replayed request")
-		return nil, false
+		return nil, nil, false
 	}
 	s.seenNonces[nonce] = now
-	return body, true
+	return body, copyBytes(authKey), true
 }
 
 func pruneSeenNonces(seen map[string]time.Time, before time.Time) {

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -86,6 +86,9 @@ func setupTestEnclaveServerWithSource(t *testing.T, sc source.SourceConnector) (
 
 func postJSON(t *testing.T, server *httptest.Server, path string, body any) *http.Response {
 	t.Helper()
+	if sessAny, ok := testSessions.Load(server.URL); ok {
+		body = attachTestCapability(t, path, body, sessAny.(testSessionAuth))
+	}
 	payload, _ := json.Marshal(body)
 	return postRaw(t, server, path, payload, true)
 }
@@ -161,6 +164,40 @@ func signTestRequestWith(t *testing.T, req *http.Request, path string, body []by
 	req.Header.Set(enclave.HeaderRequestTimestamp, timestamp)
 	req.Header.Set(enclave.HeaderRequestNonce, nonce)
 	req.Header.Set(enclave.HeaderRequestMAC, enclave.RequestMAC(sess.authKey, req.Method, path, body, sess.sessionID, timestamp, nonce))
+}
+
+func attachTestCapability(t *testing.T, path string, body any, sess testSessionAuth) any {
+	t.Helper()
+	nonceBytes := make([]byte, 16)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		t.Fatalf("generating capability nonce: %v", err)
+	}
+	nonce := hex.EncodeToString(nonceBytes)
+	switch req := body.(type) {
+	case enclave.ExecuteRequest:
+		capability, err := enclave.SignGrantCapability(sess.authKey, enclave.ExecuteGrantCapability(req, nonce))
+		if err != nil {
+			t.Fatalf("signing execute capability: %v", err)
+		}
+		req.Capability = capability
+		return req
+	case enclave.EscrowStoreRequest:
+		capability, err := enclave.SignGrantCapability(sess.authKey, enclave.EscrowStoreGrantCapability(req, nonce))
+		if err != nil {
+			t.Fatalf("signing escrow capability: %v", err)
+		}
+		req.Capability = capability
+		return req
+	case enclave.SourceExecuteRequest:
+		capability, err := enclave.SignGrantCapability(sess.authKey, enclave.SourceExecuteGrantCapability(req, nonce))
+		if err != nil {
+			t.Fatalf("signing source capability: %v", err)
+		}
+		req.Capability = capability
+		return req
+	default:
+		return body
+	}
 }
 
 func signedTestRequest(t *testing.T, server *httptest.Server, path string, body []byte, sess testSessionAuth) *http.Request {
@@ -850,21 +887,47 @@ func TestSensitiveEndpointsRequireRequestAuthentication(t *testing.T) {
 	unsigned.Body.Close()
 }
 
+func TestExecuteRejectsMissingGrantCapability(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	establishTestSession(t, server)
+
+	body := mustJSON(t, enclave.ExecuteRequest{
+		UserID:              "user-1",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: []byte("data"),
+	})
+
+	resp := postRaw(t, server, "/execute", body, true)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for missing capability, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
 func TestSensitiveEndpointsRejectTamperedRequest(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
 	establishTestSession(t, server)
 
-	originalBody := []byte(`{"user_id":"user-1","connector_id":"test/stub","encrypted_credential":"ZGF0YQ=="}`)
-	tamperedBody := []byte(`{"user_id":"user-2","connector_id":"test/stub","encrypted_credential":"ZGF0YQ=="}`)
+	sessAny, _ := testSessions.Load(server.URL)
+	sess := sessAny.(testSessionAuth)
+	originalReq := attachTestCapability(t, "/execute", enclave.ExecuteRequest{
+		UserID:              "user-1",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: []byte("data"),
+	}, sess).(enclave.ExecuteRequest)
+	tamperedReq := originalReq
+	tamperedReq.UserID = "user-2"
+	originalBody := mustJSON(t, originalReq)
+	tamperedBody := mustJSON(t, tamperedReq)
 	req, err := http.NewRequest(http.MethodPost, server.URL+"/execute", bytes.NewReader(tamperedBody))
 	if err != nil {
 		t.Fatalf("creating request: %v", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
-	sessAny, _ := testSessions.Load(server.URL)
-	sess := sessAny.(testSessionAuth)
 	req.Header.Set(enclave.HeaderSessionID, sess.sessionID)
 	signTestRequest(t, req, "/execute", originalBody, sess)
 
@@ -884,13 +947,13 @@ func TestSensitiveEndpointsRejectReplay(t *testing.T) {
 
 	establishTestSession(t, server)
 
-	body := mustJSON(t, enclave.ExecuteRequest{
+	sessAny, _ := testSessions.Load(server.URL)
+	sess := sessAny.(testSessionAuth)
+	body := mustJSON(t, attachTestCapability(t, "/execute", enclave.ExecuteRequest{
 		UserID:              "user-1",
 		ConnectorID:         "test/stub",
 		EncryptedCredential: []byte("data"),
-	})
-	sessAny, _ := testSessions.Load(server.URL)
-	sess := sessAny.(testSessionAuth)
+	}, sess))
 	req1 := signedTestRequest(t, server, "/execute", body, sess)
 
 	first, err := http.DefaultClient.Do(req1)
@@ -922,13 +985,13 @@ func TestSensitiveEndpointsRejectInvalidAndStaleTimestamps(t *testing.T) {
 
 	establishTestSession(t, server)
 
-	body := mustJSON(t, enclave.ExecuteRequest{
+	sessAny, _ := testSessions.Load(server.URL)
+	sess := sessAny.(testSessionAuth)
+	body := mustJSON(t, attachTestCapability(t, "/execute", enclave.ExecuteRequest{
 		UserID:              "user-1",
 		ConnectorID:         "test/stub",
 		EncryptedCredential: []byte("data"),
-	})
-	sessAny, _ := testSessions.Load(server.URL)
-	sess := sessAny.(testSessionAuth)
+	}, sess))
 
 	invalid := signedTestRequest(t, server, "/execute", body, sess)
 	invalid.Header.Set(enclave.HeaderRequestTimestamp, "not-a-time")

--- a/internal/enclave/capability.go
+++ b/internal/enclave/capability.go
@@ -1,0 +1,126 @@
+package enclave
+
+import (
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/base64"
+	"encoding/json"
+	"reflect"
+)
+
+// GrantCapability is the scope envelope the enclave verifies before using a
+// credential for a grant-backed operation.
+type GrantCapability struct {
+	GrantID        string         `json:"grant_id,omitempty"`
+	IntentID       string         `json:"intent_id,omitempty"`
+	UserID         string         `json:"user_id,omitempty"`
+	VaultPath      string         `json:"vault_path,omitempty"`
+	Provider       string         `json:"provider,omitempty"`
+	CredentialType string         `json:"credential_type,omitempty"`
+	ActionType     string         `json:"action_type,omitempty"`
+	Tool           string         `json:"tool,omitempty"`
+	Parameters     map[string]any `json:"parameters,omitempty"`
+	ActionTypes    []string       `json:"action_types,omitempty"`
+	SourceTools    []string       `json:"source_tools,omitempty"`
+	ExpiresAt      string         `json:"expires_at,omitempty"`
+	Nonce          string         `json:"nonce"`
+}
+
+type SignedGrantCapability struct {
+	Capability GrantCapability `json:"capability"`
+	Signature  string          `json:"signature"`
+}
+
+func SignGrantCapability(key []byte, cap GrantCapability) (*SignedGrantCapability, error) {
+	payload, err := json.Marshal(cap)
+	if err != nil {
+		return nil, err
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payload)
+	return &SignedGrantCapability{
+		Capability: cap,
+		Signature:  base64.RawURLEncoding.EncodeToString(mac.Sum(nil)),
+	}, nil
+}
+
+func VerifyExecuteCapability(key []byte, req ExecuteRequest) bool {
+	if req.Capability == nil {
+		return false
+	}
+	expected := ExecuteGrantCapability(req, req.Capability.Capability.Nonce)
+	return verifyGrantCapability(key, req.Capability, expected)
+}
+
+func VerifyEscrowStoreCapability(key []byte, req EscrowStoreRequest) bool {
+	if req.Capability == nil {
+		return false
+	}
+	expected := EscrowStoreGrantCapability(req, req.Capability.Capability.Nonce)
+	return verifyGrantCapability(key, req.Capability, expected)
+}
+
+func VerifySourceExecuteCapability(key []byte, req SourceExecuteRequest) bool {
+	if req.Capability == nil {
+		return false
+	}
+	expected := SourceExecuteGrantCapability(req, req.Capability.Capability.Nonce)
+	return verifyGrantCapability(key, req.Capability, expected)
+}
+
+func ExecuteGrantCapability(req ExecuteRequest, nonce string) GrantCapability {
+	return GrantCapability{
+		GrantID:        req.GrantID,
+		IntentID:       req.IntentID,
+		UserID:         req.UserID,
+		VaultPath:      req.VaultPath,
+		Provider:       req.Provider,
+		CredentialType: req.CredentialType,
+		ActionType:     req.ActionType,
+		Parameters:     req.Parameters,
+		Nonce:          nonce,
+	}
+}
+
+func EscrowStoreGrantCapability(req EscrowStoreRequest, nonce string) GrantCapability {
+	return GrantCapability{
+		GrantID:        req.GrantID,
+		UserID:         req.UserID,
+		VaultPath:      req.VaultPath,
+		Provider:       req.Provider,
+		CredentialType: req.CredentialType,
+		ActionTypes:    append([]string(nil), req.ActionTypes...),
+		SourceTools:    append([]string(nil), req.SourceTools...),
+		Parameters:     req.AllowedParameters,
+		ExpiresAt:      req.ExpiresAt,
+		Nonce:          nonce,
+	}
+}
+
+func SourceExecuteGrantCapability(req SourceExecuteRequest, nonce string) GrantCapability {
+	return GrantCapability{
+		UserID:     req.UserID,
+		VaultPath:  req.VaultPath,
+		Provider:   req.Provider,
+		Tool:       req.Tool,
+		Parameters: req.Params,
+		Nonce:      nonce,
+	}
+}
+
+func verifyGrantCapability(key []byte, signed *SignedGrantCapability, expected GrantCapability) bool {
+	if signed == nil || signed.Capability.Nonce == "" || signed.Signature == "" {
+		return false
+	}
+	if !reflect.DeepEqual(signed.Capability, expected) {
+		return false
+	}
+	payload, err := json.Marshal(signed.Capability)
+	if err != nil {
+		return false
+	}
+	mac := hmac.New(sha256.New, key)
+	mac.Write(payload)
+	expectedSig := base64.RawURLEncoding.EncodeToString(mac.Sum(nil))
+	return hmac.Equal([]byte(signed.Signature), []byte(expectedSig))
+}

--- a/internal/enclave/capability_test.go
+++ b/internal/enclave/capability_test.go
@@ -1,0 +1,98 @@
+package enclave
+
+import "testing"
+
+func TestExecuteCapabilityVerifiesBoundFields(t *testing.T) {
+	key := []byte("01234567890123456789012345678901")
+	req := ExecuteRequest{
+		GrantID:        "grant-1",
+		IntentID:       "intent-1",
+		UserID:         "user-1",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "oauth2",
+		ActionType:     "email.send",
+		Parameters:     map[string]any{"to": "a@example.com"},
+	}
+
+	capability, err := SignGrantCapability(key, ExecuteGrantCapability(req, "nonce-1"))
+	if err != nil {
+		t.Fatalf("SignGrantCapability: %v", err)
+	}
+	req.Capability = capability
+
+	if !VerifyExecuteCapability(key, req) {
+		t.Fatal("expected capability to verify")
+	}
+
+	req.UserID = "user-2"
+	if VerifyExecuteCapability(key, req) {
+		t.Fatal("expected user tamper to fail")
+	}
+}
+
+func TestEscrowStoreCapabilityVerifiesBoundFields(t *testing.T) {
+	key := []byte("01234567890123456789012345678901")
+	req := EscrowStoreRequest{
+		GrantID:           "grant-1",
+		UserID:            "user-1",
+		VaultPath:         "connected-accounts/user-1/gmail",
+		Provider:          "gmail",
+		CredentialType:    "oauth2",
+		ExpiresAt:         "2026-04-26T09:00:00Z",
+		ActionTypes:       []string{"email.send"},
+		SourceTools:       []string{"gmail_search"},
+		AllowedParameters: map[string]any{"to": "a@example.com"},
+	}
+
+	capability, err := SignGrantCapability(key, EscrowStoreGrantCapability(req, "nonce-1"))
+	if err != nil {
+		t.Fatalf("SignGrantCapability: %v", err)
+	}
+	req.Capability = capability
+
+	if !VerifyEscrowStoreCapability(key, req) {
+		t.Fatal("expected capability to verify")
+	}
+
+	req.AllowedParameters = map[string]any{"to": "b@example.com"}
+	if VerifyEscrowStoreCapability(key, req) {
+		t.Fatal("expected parameter tamper to fail")
+	}
+}
+
+func TestSourceExecuteCapabilityVerifiesBoundFields(t *testing.T) {
+	key := []byte("01234567890123456789012345678901")
+	req := SourceExecuteRequest{
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "gmail_search",
+		Params:    map[string]any{"query": "from:a@example.com"},
+	}
+
+	capability, err := SignGrantCapability(key, SourceExecuteGrantCapability(req, "nonce-1"))
+	if err != nil {
+		t.Fatalf("SignGrantCapability: %v", err)
+	}
+	req.Capability = capability
+
+	if !VerifySourceExecuteCapability(key, req) {
+		t.Fatal("expected capability to verify")
+	}
+
+	req.Tool = "gmail_delete"
+	if VerifySourceExecuteCapability(key, req) {
+		t.Fatal("expected tool tamper to fail")
+	}
+}
+
+func TestGrantCapabilityRejectsMissingSignature(t *testing.T) {
+	req := ExecuteRequest{
+		GrantID:    "grant-1",
+		Capability: &SignedGrantCapability{Capability: GrantCapability{GrantID: "grant-1", Nonce: "nonce-1"}},
+	}
+	if VerifyExecuteCapability([]byte("key"), req) {
+		t.Fatal("expected missing signature to fail")
+	}
+}

--- a/internal/enclave/gcs/client.go
+++ b/internal/enclave/gcs/client.go
@@ -163,6 +163,20 @@ func (c *Client) Close() error {
 
 // post sends a JSON POST request to the enclave and decodes the response.
 func (c *Client) post(ctx context.Context, path string, body any, result any) error {
+	c.mu.Lock()
+	sid := c.sessionID
+	authKey := copyBytes(c.authKey)
+	c.mu.Unlock()
+	defer zeroBytes(authKey)
+
+	if len(authKey) > 0 {
+		var err error
+		body, err = attachGrantCapability(body, authKey)
+		if err != nil {
+			return err
+		}
+	}
+
 	payload, err := json.Marshal(body)
 	if err != nil {
 		return fmt.Errorf("marshalling request: %w", err)
@@ -174,10 +188,6 @@ func (c *Client) post(ctx context.Context, path string, body any, result any) er
 	}
 	req.Header.Set("Content-Type", "application/json")
 
-	c.mu.Lock()
-	sid := c.sessionID
-	authKey := copyBytes(c.authKey)
-	c.mu.Unlock()
 	if sid != "" {
 		req.Header.Set(enclave.HeaderSessionID, sid)
 	}
@@ -191,7 +201,6 @@ func (c *Client) post(ctx context.Context, path string, body any, result any) er
 		req.Header.Set(enclave.HeaderRequestNonce, nonce)
 		req.Header.Set(enclave.HeaderRequestMAC, enclave.RequestMAC(authKey, http.MethodPost, path, payload, sid, timestamp, nonce))
 	}
-	zeroBytes(authKey)
 
 	resp, err := c.httpClient.Do(req)
 	if err != nil {
@@ -210,6 +219,38 @@ func (c *Client) post(ctx context.Context, path string, body any, result any) er
 		}
 	}
 	return nil
+}
+
+func attachGrantCapability(body any, authKey []byte) (any, error) {
+	nonce, err := randomNonce()
+	if err != nil {
+		return nil, fmt.Errorf("generating grant capability nonce: %w", err)
+	}
+	switch req := body.(type) {
+	case enclave.ExecuteRequest:
+		capability, err := enclave.SignGrantCapability(authKey, enclave.ExecuteGrantCapability(req, nonce))
+		if err != nil {
+			return nil, fmt.Errorf("signing execute capability: %w", err)
+		}
+		req.Capability = capability
+		return req, nil
+	case enclave.EscrowStoreRequest:
+		capability, err := enclave.SignGrantCapability(authKey, enclave.EscrowStoreGrantCapability(req, nonce))
+		if err != nil {
+			return nil, fmt.Errorf("signing escrow capability: %w", err)
+		}
+		req.Capability = capability
+		return req, nil
+	case enclave.SourceExecuteRequest:
+		capability, err := enclave.SignGrantCapability(authKey, enclave.SourceExecuteGrantCapability(req, nonce))
+		if err != nil {
+			return nil, fmt.Errorf("signing source capability: %w", err)
+		}
+		req.Capability = capability
+		return req, nil
+	default:
+		return body, nil
+	}
 }
 
 func requiresRequestAuth(path string) bool {

--- a/internal/enclave/gcs/client_test.go
+++ b/internal/enclave/gcs/client_test.go
@@ -119,6 +119,13 @@ func TestClientExecute(t *testing.T) {
 		if !enclave.VerifyRequestMAC(authKey, r.Method, r.URL.Path, body, "sess-abc", timestamp, nonce, mac) {
 			t.Fatalf("request MAC did not verify")
 		}
+		var req enclave.ExecuteRequest
+		if err := json.Unmarshal(body, &req); err != nil {
+			t.Fatalf("unmarshaling request: %v", err)
+		}
+		if !enclave.VerifyExecuteCapability(authKey, req) {
+			t.Fatalf("execute capability did not verify")
+		}
 		json.NewEncoder(w).Encode(enclave.ExecuteResponse{
 			RequestID:  "exec-1",
 			Status:     "succeeded",
@@ -167,6 +174,70 @@ func TestRequiresRequestAuth(t *testing.T) {
 				t.Fatalf("requiresRequestAuth(%q) = %v, want %v", tt.path, got, tt.want)
 			}
 		})
+	}
+}
+
+func TestAttachGrantCapability(t *testing.T) {
+	authKey := []byte("01234567890123456789012345678901")
+
+	execute, err := attachGrantCapability(enclave.ExecuteRequest{
+		GrantID:        "grant-1",
+		IntentID:       "intent-1",
+		UserID:         "user-1",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "oauth2",
+		ActionType:     "email.send",
+		Parameters:     map[string]any{"to": "a@example.com"},
+	}, authKey)
+	if err != nil {
+		t.Fatalf("attach execute capability: %v", err)
+	}
+	executeReq := execute.(enclave.ExecuteRequest)
+	if !enclave.VerifyExecuteCapability(authKey, executeReq) {
+		t.Fatal("expected execute capability to verify")
+	}
+
+	escrow, err := attachGrantCapability(enclave.EscrowStoreRequest{
+		GrantID:           "grant-1",
+		UserID:            "user-1",
+		VaultPath:         "connected-accounts/user-1/gmail",
+		Provider:          "gmail",
+		CredentialType:    "oauth2",
+		ExpiresAt:         "2026-04-26T09:00:00Z",
+		ActionTypes:       []string{"email.send"},
+		SourceTools:       []string{"gmail_search"},
+		AllowedParameters: map[string]any{"to": "a@example.com"},
+	}, authKey)
+	if err != nil {
+		t.Fatalf("attach escrow capability: %v", err)
+	}
+	escrowReq := escrow.(enclave.EscrowStoreRequest)
+	if !enclave.VerifyEscrowStoreCapability(authKey, escrowReq) {
+		t.Fatal("expected escrow capability to verify")
+	}
+
+	source, err := attachGrantCapability(enclave.SourceExecuteRequest{
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "gmail_search",
+		Params:    map[string]any{"query": "from:a@example.com"},
+	}, authKey)
+	if err != nil {
+		t.Fatalf("attach source capability: %v", err)
+	}
+	sourceReq := source.(enclave.SourceExecuteRequest)
+	if !enclave.VerifySourceExecuteCapability(authKey, sourceReq) {
+		t.Fatal("expected source capability to verify")
+	}
+
+	unchanged, err := attachGrantCapability(enclave.TransmitKEKRequest{UserID: "user-1"}, authKey)
+	if err != nil {
+		t.Fatalf("attach unsupported capability: %v", err)
+	}
+	if _, ok := unchanged.(enclave.TransmitKEKRequest); !ok {
+		t.Fatalf("expected unsupported request type to be returned unchanged")
 	}
 }
 

--- a/internal/enclave/protocol.go
+++ b/internal/enclave/protocol.go
@@ -100,6 +100,9 @@ type ExecuteRequest struct {
 	// EscrowID, if set, tells the enclave to use an escrowed credential
 	// instead of EncryptedCredential.
 	EscrowID string `json:"escrow_id,omitempty"`
+	// Capability is a signed, scoped grant envelope the enclave verifies
+	// before using credentials for this operation.
+	Capability *SignedGrantCapability `json:"capability,omitempty"`
 }
 
 // ExecuteResponse is returned by the enclave after connector execution.
@@ -157,17 +160,18 @@ const (
 // EscrowStoreRequest asks the enclave to escrow a credential for
 // asynchronous or scheduled execution when the user is offline.
 type EscrowStoreRequest struct {
-	UserID              string         `json:"user_id"`
-	GrantID             string         `json:"grant_id"`
-	EnforceGrantID      bool           `json:"enforce_grant_id,omitempty"`
-	VaultPath           string         `json:"vault_path"`
-	Provider            string         `json:"provider"`
-	EncryptedCredential []byte         `json:"encrypted_credential"`
-	CredentialType      string         `json:"credential_type"`
-	ExpiresAt           string         `json:"expires_at"` // RFC 3339
-	ActionTypes         []string       `json:"action_types"`
-	SourceTools         []string       `json:"source_tools,omitempty"`
-	AllowedParameters   map[string]any `json:"allowed_parameters,omitempty"`
+	UserID              string                 `json:"user_id"`
+	GrantID             string                 `json:"grant_id"`
+	EnforceGrantID      bool                   `json:"enforce_grant_id,omitempty"`
+	VaultPath           string                 `json:"vault_path"`
+	Provider            string                 `json:"provider"`
+	EncryptedCredential []byte                 `json:"encrypted_credential"`
+	CredentialType      string                 `json:"credential_type"`
+	ExpiresAt           string                 `json:"expires_at"` // RFC 3339
+	ActionTypes         []string               `json:"action_types"`
+	SourceTools         []string               `json:"source_tools,omitempty"`
+	AllowedParameters   map[string]any         `json:"allowed_parameters,omitempty"`
+	Capability          *SignedGrantCapability `json:"capability,omitempty"`
 }
 
 // EscrowStoreResponse confirms that the credential has been escrowed.
@@ -212,6 +216,9 @@ type SourceExecuteRequest struct {
 	Tool string `json:"tool"`
 	// Params are the tool parameters (query, filters, etc.).
 	Params map[string]any `json:"params"`
+	// Capability is a signed, scoped grant envelope the enclave verifies
+	// before using credentials for this operation.
+	Capability *SignedGrantCapability `json:"capability,omitempty"`
 }
 
 // SourceExecuteResponse contains the tool execution results. The credential


### PR DESCRIPTION
## Summary

This is the first Phase 4 slice for #326.

- Add signed grant capability envelopes to the enclave protocol.
- Bind capabilities to grant/user/vault/provider/credential/action/tool/parameter scope fields.
- Have the GCS enclave client attach scoped capabilities to execute, escrow-store, and source-execute requests.
- Have the enclave server verify capabilities before using credentials for those operations.
- Add tests for capability field binding, missing capability rejection, and GCS capability attachment.

## Notes

This builds on Phase 3b request authentication. The capability signature currently uses the session-bound request-auth key, so the enclave can verify that the scoped capability matches the request body fields before credential use.

## Validation

- `go test ./cmd/aileron-enclave/... ./internal/enclave/...`
- `go test ./internal/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...`
- `go test -cover ./cmd/aileron-enclave ./internal/enclave ./internal/enclave/gcs`

Coverage from the changed packages:

- `cmd/aileron-enclave`: 81.8%
- `internal/enclave`: 87.0%
- `internal/enclave/gcs`: 87.1%
