### PR TITLE
docs(pivot): add strategic pivot section

### DIFF
--- a/docs/src/components/Sidebar.svelte
+++ b/docs/src/components/Sidebar.svelte
@@ -9,6 +9,7 @@
   import GitFork from '@lucide/svelte/icons/git-fork';
   import Braces from '@lucide/svelte/icons/braces';
   import Cloud from '@lucide/svelte/icons/cloud';
+  import Compass from '@lucide/svelte/icons/compass';
 
   let { currentPath = '', navigation = [] as NavItem[] }: { currentPath?: string; navigation?: NavItem[] } = $props();
   let mobileOpen = $state(false);
@@ -50,6 +51,7 @@
 
   // Map top-level labels to icons
   const iconMap: Record<string, typeof Plane> = {
+    'Pivot': Compass,
     'Meet Aileron': Plane,
     'Getting Started': Rocket,
     'Operations': Server,

--- a/docs/src/content/docs/pivot/competitive-landscape.md
+++ b/docs/src/content/docs/pivot/competitive-landscape.md
@@ -1,0 +1,200 @@
+---
+title: "Competitive Landscape"
+description: "Where Aileron sits in the AI agent infrastructure ecosystem"
+order: 2
+---
+
+This page captures the competitive scan that informed the Aileron pivot. The takeaway is structural: **the LLM endpoint seam Aileron occupies is genuinely empty.** Adjacent products solve fragments of the pattern; none assembles the load-bearing pieces in the right place.
+
+This is informational, not a sales pitch. It exists so future agents and strategists can understand the landscape, name competitors precisely, and avoid relitigating questions we've already researched.
+
+## The pattern Aileron occupies
+
+The exact pattern: **a transparent OpenAI-compatible proxy that intercepts agent requests, executes deterministic actions in capability-isolated sandboxes when the agent's tool calls match installed actions, holds credentials the LLM never sees, and routes per-request to the cheapest LLM that meets quality when LLMs are needed.**
+
+To occupy this seam fully, a product needs all of:
+
+1. Declarative manifest format for actions
+2. Transparent OpenAI-compatible endpoint
+3. Deterministic terminal substitution (action runs in place of LLM call)
+4. Capability-bound connectors with sandbox isolation
+5. Credential vault that the LLM never touches
+6. Tamper-resistant out-of-band approval channel
+
+No vendor has assembled all six. Below is who solves what fragments.
+
+## Category 1 — Local AI runtimes / inference orchestration
+
+| Product | Solves | Doesn't |
+|---|---|---|
+| Ollama | Easy local LLM runner; launched Ollama Cloud in 2025 with cloud overflow ($20/mo Pro, $100/mo Max) | Single-engine focus; no action layer; routes only to Ollama-hosted models |
+| LM Studio | GUI-first local AI; freemium with Pro tier; acquired Locally AI in 2026 | No cross-engine orchestration; no per-request smart routing |
+| Jan | OSS desktop UI on llama.cpp (~5% overhead) | UI polish over performance; no routing |
+| llama.cpp / MLX / vLLM / SGLang | Inference engines (not orchestrators) | Each is best at something; no engine wins everywhere |
+| LocalAI | OpenAI-compatible local server; many backends | User picks engine manually; no routing intelligence |
+| GPT4All | Nomic-funded, on-device with LocalDocs RAG | Single-engine; no orchestration |
+| Clarifai Local Runners | "ngrok for AI models" — run on-prem, expose via cloud ($10/mo) | Tunneling product, not orchestrator |
+
+**Takeaway.** Nobody auto-profiles hardware to pick engine + model + quantization. Nobody other than Ollama does cloud overflow, and Ollama only overflows to itself.
+
+## Category 2 — LLM routers and gateways
+
+| Product | Solves | Doesn't |
+|---|---|---|
+| OpenRouter | Per-request routing on price/availability/latency | Not quality-aware; no local; no action layer |
+| LiteLLM | OSS self-hosted proxy; OpenAI-compatible; 100+ providers | No native governance; no local-aware routing; no tamper-resistant approval |
+| Portkey | Full "AI control plane" branding; routing + observability + guardrails + governance | Cloud-only; SDK integration required; no deterministic action substitution |
+| Helicone | Rust-based OSS gateway; observability-first | No local routing |
+| Kong AI Gateway 3.14 | Enterprise; added Agent Gateway for A2A | Enterprise-only; for orgs already on Kong |
+| Cloudflare AI Gateway | Edge proxy with caching, rate limits, retries; unified billing for OpenAI/Anthropic/Google added in 2026 | Cloud-only; no local |
+| Bifrost (Maxim AI) | OSS Go gateway, OpenAI-compatible | Same shape as LiteLLM; no action layer |
+
+**Takeaway.** Every gateway is cloud-side. None routes between local and cloud. None auto-profiles the user's machine. Portkey is closest on enterprise governance and has zero local presence.
+
+## Category 3 — Smart per-request model routing
+
+| Product | Solves | Doesn't |
+|---|---|---|
+| Martian | Real-time prompt analysis; claims 20–97% cost cut; ~$1.3B valuation as of April 2026 | Cloud-side; not local-aware; closed source |
+| NotDiamond | Predictive routing across frontier providers; 30–90% cost claim | Cloud-only |
+| RouteLLM | LMSys OSS framework; 85% cost reduction at 95% GPT-4 quality | Library, not product; embeddable |
+| Unify AI | Managed LLM routing with per-workload benchmarking | Cloud-only |
+| **NadirClaw** | **OSS (MIT), self-hosted, OpenAI-compatible drop-in proxy; ~10ms complexity classification via embeddings; routes between local Ollama/vLLM/LM Studio and cloud frontier; rate-limit, budget controls, OAuth credential storage; 40-70% savings; 433 GitHub stars; actively maintained as of April 2026** | **No auto-profiling of host; no action layer; user picks local model; no governance** |
+
+**Takeaway.** NadirClaw is the closest direct wedge competitor on Runtime — it does the local+cloud routing piece. It does not auto-profile, does not have an action layer, has no governance. Martian at $1.3B valuation is the cloud-side incumbent; if they add a local connector, the wedge tightens significantly.
+
+## Category 4 — Agent governance / action policy
+
+| Product | Solves | Doesn't |
+|---|---|---|
+| Cerbos | Policy engine with first-class agent support; sidecar/PDP model | Requires SDK integration |
+| Permit.io | OPA/OPAL-based agent + human authorization | SDK-integrated |
+| Lakera Guard | Prompt-injection / jailbreak detection; sub-50ms; 98% detection. **Acquired by Check Point Sep 2025**. | Pure content firewall; no execution governance |
+| Pangea | **Acquired by CrowdStrike in 2026** | Consolidating into security megavendors |
+| AWS Bedrock Guardrails | 88% harmful-content block, PII redaction, automated reasoning | AWS-only |
+| Galileo Agent Control | OSS centralized guardrails for enterprise agents (2026 launch) | Enterprise-deployed; not at the LLM endpoint seam |
+| Prisma AIRS 3.0 (Palo Alto) | Enterprise-grade autonomous-AI security suite (2026) | Enterprise; not transparent at endpoint |
+| **NVIDIA OpenShell** | **Sandboxed agent runtime with hot-reloadable YAML policies; transparent interception of outbound calls; credential injection where creds never enter sandbox FS; audit logging; inference rerouting (`openshell inference set` swaps backend, strips caller creds, injects backend creds). Apache 2.0, launched March 2026.** | **No approval workflows; no IDE/CLI inline approvals; sandbox-focused (sandboxes the agent process), not LLM-endpoint focused** |
+
+**Takeaway.** NVIDIA OpenShell is the closest thing to Aileron Control in the wild. It does request-path interception with credential isolation. It does *not* do tamper-resistant approvals, the user channel, action substitution, or sit at the LLM endpoint seam — it operates at the sandbox-agent-process seam, which is structurally different. The release is recent (March 2026) and NVIDIA-distributed; it's the biggest single moat threat.
+
+## Category 5 — Credential vaults for AI agents
+
+| Product | Solves | Status |
+|---|---|---|
+| 1Password Unified Access for Agents | Issues scoped credentials to agents/workloads at runtime | **Anthropic, Cursor, GitHub, Perplexity, Vercel partners.** Anthropic integrating into Claude Code / browser ext as of 2026. |
+| HashiCorp Vault MCP Server | LLM never gets static creds; MCP server validates token, issues short-lived scoped creds | Enterprise-targeted |
+| Doppler | Dev-friendly secrets | Not specifically agent-focused |
+| NVIDIA OpenShell providers | Named credential bundles injected as env vars at runtime; never written to sandbox FS | Part of OpenShell's broader play |
+
+**Takeaway.** "LLM never sees the actual key" is now table stakes — multiple credible vendors ship it. Aileron's credential isolation is no longer a differentiator on its own; it has to combine with the seam position and tamper-resistant approval to matter.
+
+## Category 6 — Threats from platform vendors
+
+| Vendor | Move | What it threatens |
+|---|---|---|
+| OpenAI | GPT-5.5 "auto" model-tier routing inside ChatGPT | Casual user routing, not Aileron's audience |
+| Anthropic + Claude Code | Agent infrastructure at the platform level: checkpointing, credential management, scoped permissions, multi-agent coordination | Threatens Aileron Control by absorbing governance — but only for Claude users |
+| Cursor | Multi-model routing within IDE across Claude/GPT-5/Gemini/Composer | No local; proprietary; server-side |
+| Continue.dev | OSS, supports Ollama, all local | Closest IDE-side analog; no smart routing |
+| GitHub Copilot Inline Agent Mode (April 2026) | Granular auto-approve rules for terminal/file edits inside the IDE | Eats Aileron Control's IDE inline-approval claim at GitHub footprint scale |
+
+## Category 7 — Hybrid local-cloud (direct wedge)
+
+The architectural consensus pattern as of 2026 is 70–80% local + 20–30% frontier. Direct competitors on the wedge:
+
+1. **NadirClaw** (most direct) — drop-in OSS proxy, complexity-classifying router across local+cloud, OAuth storage. Closest to Aileron Runtime minus auto-profiling.
+2. **Ollama Cloud** — local-first with cloud overflow, but only to Ollama's own models. Brand and install-base advantage.
+3. **ShareAI** — own infra first, decentralized network for overflow.
+4. **LiteLLM + Ollama** — the recipe most architectures recommend (DIY).
+
+## The deterministic-substitution pattern (narrower research)
+
+Beyond the broader landscape, there's a narrower question: who does *deterministic substitution at the LLM endpoint seam* — a transparent OpenAI-compatible proxy that runs deterministic actions in place of LLM calls? The closest matches:
+
+- **Aurelio Labs Semantic Router** — explicitly deterministic utterance→action dispatch with no LLM, marketed as "rather than waiting for slow LLM generations to make tool-use decisions." But it's a Python library, not an HTTP endpoint. Closest *conceptual* match.
+- **Docker Cagent** — proxy that returns OpenAI-shaped responses from YAML cassettes, no LLM call. Closest *structural* match. But scoped to CI replay; cassettes are *recordings*, not authored procedures; explicitly not for production.
+- **vLLM Semantic Router** (v0.1 "Iris" Jan 2026) — Envoy ExtProc that semantically routes OpenAI-compatible requests. Critically: even with the routing decision made deterministically, it routes to a *different model* — never to deterministic code as a terminal action.
+- **Node9 Proxy** — execution security layer with `PreToolUse` hook + MCP gateway interception. Wrong placement in the stack — it's *post-LLM*, after the LLM has already emitted the tool call.
+- **`snip`** (PreToolUse YAML pipeline rewriter) — same `PreToolUse` placement. Closest in spirit on the "declarative manifest of substitutions" pattern but again, the LLM is in the loop.
+- **Salesforce Agent Broker / Agent Fabric** (TDX 2026, GA Jun 2026) — coined "guided determinism" as a category framing. But the deterministic steps are workflow nodes inside a Salesforce-authored DAG, not pattern-matched LLM-endpoint substitutions; the architecture is no-code visual orchestration, not transparent SDK-compatible proxy.
+- **MockLLM, LangChain FakeListLLM** — same shape as Cagent but explicitly test fixtures.
+
+Academic prior art exists in neuro-symbolic systems (Logic-LM, SymCode, DANA, LogicGuard) — LLM produces a symbolic program, deterministic engine executes it. The LLM is still primary; the symbolic part validates or grounds. None proposes the proxy-shape: agent-facing OpenAI endpoint, deterministic terminal substitution, LLM optional.
+
+**The deterministic-substitution seam is genuinely empty as a productized layer.** Aileron is the first to claim it.
+
+## The whitespace
+
+After surveying the surrounding players, the seam Aileron occupies is genuinely empty. No vendor ships:
+
+- **Auto-profiling the host machine** to pick engine + model + quantization. NadirClaw, Ollama, LM Studio, LocalAI all expect the user to choose. Aileron's most defensible technical claim.
+- **Cross-engine meta-orchestration** (Ollama vs llama.cpp vs MLX vs vLLM picked per request based on hardware + workload). The benchmarks all say no engine wins everywhere; nobody's product addresses it.
+- **Inline approval workflow** stitched into chat/CLI/IDE through a transparent inference proxy. OpenShell does sandbox-level approvals; Copilot does IDE-level approvals; nobody does both stitched through the request path.
+- **Action-level capability subsetting** (an action declares only the connector capabilities it needs; runtime enforces beyond just the connector boundary). Defense in depth that no other product offers.
+- **Tamper-resistant approvals over OOB channels** combined with deterministic action execution and no agent in the trust path. Each piece exists somewhere; nobody assembles them.
+
+## Threat ranking
+
+**Biggest threats to Runtime (the wedge).**
+
+1. **Ollama Cloud** — distribution + brand. Existential to the wedge if they add multi-provider overflow.
+2. **NadirClaw** — closest direct OSS competitor. Small but feature-complete on the local+cloud routing piece.
+3. **Martian** ($1.3B valuation) — if they ship a local connector, the cloud-side wedge collapses.
+
+**Biggest threats to Control (the moat).**
+
+1. **NVIDIA OpenShell** — kills the "only zero-integration governance layer" claim Aileron Control might otherwise make. Apache 2.0, NVIDIA's distribution. Aileron Control's reframe lives in (a) inline approval UX, (b) developer-machine ergonomics (OpenShell is enterprise/sandboxed), and (c) integration with Runtime that OpenShell doesn't have.
+2. **Portkey** — owns enterprise governance for cloud-only.
+3. **1Password Agent Access** — owns the credential layer with Anthropic/Cursor/GitHub partnerships.
+
+**Biggest convergence threats (platform absorption).**
+
+1. **Anthropic / Claude Code** — absorbing governance into the platform; threatens Control for Claude users specifically.
+2. **GitHub Copilot Inline Agent Mode** — owns the IDE inline-approval surface for the GitHub footprint.
+
+## What this means strategically
+
+The pivot's claim — "deterministic execution layer at the LLM endpoint seam, with tamper-resistant OOB approvals and capability-isolated connectors" — is genuinely novel as a *combination*. Each fragment exists somewhere in the surrounding landscape. The combination, at the right seam, does not.
+
+The threats are real but bounded:
+
+- **Ollama Cloud doesn't yet route across providers.** If they do, Runtime's wedge needs to lean harder on auto-profiling and per-request quality routing.
+- **NVIDIA OpenShell doesn't sit at the LLM endpoint seam** and doesn't have inline approval UX. Aileron Control's differentiation comes from those two things and from being co-located with Runtime.
+- **Platform vendors (Anthropic, OpenAI, GitHub) are absorbing governance** into their products. Aileron's defense is being agent-agnostic and sitting at the protocol seam — any agent that speaks `chat/completions` can use Aileron.
+
+## Sources
+
+- [Ollama pricing](https://ollama.com/pricing)
+- [Ollama Cloud routing explainer](https://docs.bswen.com/blog/2026-04-20-what-is-ollama-cloud/)
+- [LM Studio + Locally AI](https://lmstudio.ai/blog/locally-ai-joins-lm-studio)
+- [OpenRouter Auto Router docs](https://openrouter.ai/docs/guides/routing/routers/auto-router)
+- [RouteLLM (LMSys)](https://github.com/lm-sys/RouteLLM)
+- [Martian valuation report (April 2026)](https://medium.com/@sarawgiapoorvwork347/martian-the-san-francisco-based-startup-that-invented-the-first-llm-router-is-reportedly-nearing-4211dd768296)
+- [NotDiamond pricing](https://www.notdiamond.ai/pricing)
+- [Top LLM Gateways 2026](https://dev.to/varshithvhegde/top-5-llm-gateways-in-2026-a-deep-dive-comparison-for-production-teams-34d2)
+- [Portkey AI Gateway](https://portkey.ai/features/ai-gateway)
+- [Cloudflare AI Gateway](https://developers.cloudflare.com/ai-gateway/)
+- [Kong AI Gateway 3.14](https://www.devopsdigest.com/kong-releases-ai-gateway-314)
+- [Cerbos agentic authorization](https://www.cerbos.dev/features-benefits-and-use-cases/agentic-authorization)
+- [Permit.io 2026 OSS authz roundup](https://www.permit.io/blog/top-open-source-authorization-tools-for-enterprises-in-2026)
+- [Lakera Guard](https://www.lakera.ai/lakera-guard)
+- [Check Point acquires Lakera (SecurityWeek)](https://www.securityweek.com/check-point-to-acquire-ai-security-firm-lakera/)
+- [AWS Bedrock Guardrails](https://aws.amazon.com/bedrock/guardrails/)
+- [1Password Unified Access for Agents](https://1password.com/press/2026/mar/1password-unified-access)
+- [HashiCorp Vault MCP Server](https://developer.hashicorp.com/vault/docs/mcp-server/prompt-model)
+- [NVIDIA OpenShell GitHub](https://github.com/NVIDIA/OpenShell)
+- [NVIDIA OpenShell announcement](https://blogs.nvidia.com/blog/secure-autonomous-ai-agents-openshell/)
+- [NVIDIA OpenShell coverage — Futurum](https://futurumgroup.com/insights/openshell-redraws-the-agent-control-plane-open-standard-or-product-launch/)
+- [Galileo Agent Control](https://thenewstack.io/galileo-agent-control-open-source/)
+- [Clarifai Local Runners](https://www.clarifai.com/products/local-runners)
+- [NadirClaw](https://github.com/doramirdor/NadirClaw)
+- [Hybrid LLM architecture guide 2026](https://www.sitepoint.com/hybrid-cloudlocal-llm-the-complete-architecture-guide-2026/)
+- [llama.cpp vs MLX vs Ollama vs vLLM Apple Silicon 2026](https://contracollective.com/blog/llama-cpp-vs-mlx-ollama-vllm-apple-silicon-2026)
+- [GitHub Copilot inline agent mode](https://github.blog/changelog/2026-04-24-inline-agent-mode-in-preview-and-more-in-github-copilot-for-jetbrains-ides/)
+- [Aurelio Labs Semantic Router](https://github.com/aurelio-labs/semantic-router)
+- [vLLM Semantic Router (v0.1 Iris, Jan 2026)](https://blog.vllm.ai/2026/01/05/vllm-sr-iris.html)
+- [Docker Cagent — deterministic testing with cassettes](https://www.docker.com/blog/deterministic-ai-testing-with-session-recording-in-cagent/)
+- [Salesforce Agent Fabric / Agent Broker (Apr 2026)](https://www.salesforce.com/news/stories/agent-fabric-control-plane-announcement/)
+- [Microsoft Agent Governance Toolkit (Apr 2 2026)](https://opensource.microsoft.com/blog/2026/04/02/introducing-the-agent-governance-toolkit-open-source-runtime-security-for-ai-agents/)
+- [Deterministic + Agentic AI (The Hacker News, Apr 2026)](https://thehackernews.com/2026/04/deterministic-agentic-ai-architecture.html)

--- a/docs/src/content/docs/pivot/the-deterministic-layer.md
+++ b/docs/src/content/docs/pivot/the-deterministic-layer.md
@@ -1,0 +1,620 @@
+---
+title: "The Deterministic Layer for AI Agents"
+description: "Strategy, architecture, and business model for the Aileron pivot"
+order: 0
+---
+
+**Aileron is the deterministic execution layer for AI agents. Whether the agent invokes an action via standard tool-calling or Aileron matches unambiguous intent before the LLM runs, the execution is the same: capability-isolated, credentials sealed in a vault the LLM never touches, with tamper-resistant approval for consequential actions. When the LLM is genuinely required, Aileron routes to the cheapest model that meets quality on the user's hardware.**
+
+It is two layers:
+
+- **Aileron Runtime** — a transparent OpenAI-compatible endpoint that intercepts every agent request. Aileron augments the agent's tool catalog with installed actions; the LLM selects what to call; Aileron executes the deterministic ones in capability-isolated sandboxes. For unambiguous intents, Aileron can bypass the LLM entirely. When no action applies, Runtime orchestrates inference engines per machine and routes to the cheapest model that meets the developer's quality bar.
+- **Aileron Control** — governance, vault, policy, approvals, and audit applied throughout, in the request path by construction.
+
+These layers are unified by architecture, not marketing. The LLM endpoint is the only seam in the agent stack where you can guarantee, simultaneously: zero SDK integration, credentials never leaked to the model, deterministic action execution regardless of how the LLM coordinated the call, tamper-resistant user consent for consequential actions, and a complete audit trail. Every other interception point has a structural compromise.
+
+> **Companion document:** for concrete hero use cases and the developer experience, see [What Your Agent Can Now Do](/pivot/what-your-agent-can-do). This document covers the strategy, architecture, and business model.
+
+---
+
+## The Architectural Insight
+
+Every agent in production speaks `chat/completions` (or its successor). That endpoint is the most concentrated decision point in the stack: it is where intent is expressed, where a model is asked to act, where credentials would be exposed if anyone were careless enough to put them there, and where probabilistic execution begins.
+
+Compare the available interception points:
+
+| Seam | What it can do | Compromise |
+|---|---|---|
+| Pre-tool-use hooks (Claude Code, Cursor) | Rewrite, block, or approve tool calls | LLM has already emitted the call; cost paid, intent shaped |
+| MCP server | Expose tools to the LLM | LLM still orchestrates; LLM in the loop |
+| Agent SDK middleware | Wrap framework operations | Requires SDK cooperation; framework-specific |
+| Sandboxed agent process | Intercept system calls | Cannot read LLM-shaped intent |
+| Post-LLM gateway | Filter, route, observe | LLM has run; cost and latency already paid |
+| **LLM endpoint substitution** | **Run a deterministic action in place of the LLM call, or execute the LLM's tool calls under capability isolation** | **None — invisible to the agent at the boundary that matters** |
+
+This is the seam where Aileron makes deterministic execution possible. The LLM may still select what to call (via standard function calling); Aileron ensures the *execution* is deterministic, sandboxed, audited, and tamper-resistant. For unambiguous intents, Aileron can also bypass the LLM entirely. Either way, the agent's tool calls land in a structurally safer place than what any current architecture provides.
+
+---
+
+## The Problem
+
+### Agents are probabilistic where they should be deterministic
+
+When an agent says "send the invoice to acme@example.com for $4,200," there is one correct outcome. The current architecture runs that intent through a stochastic model that may hallucinate the recipient, the amount, or the action itself. The model is asked to make decisions a deterministic function should make. Production agents accumulate this debt every turn.
+
+### LLMs touch credentials they should never see
+
+To execute real-world actions, agents pass API keys, tokens, and secrets through the LLM context — sometimes inadvertently, often unavoidably. The model could leak them in a response, log them in a trace, or return them as part of a tool argument it composed. "LLM never sees the key" is now table stakes (1Password, HashiCorp Vault, NVIDIA OpenShell all ship it), but every solution requires the agent author to opt in.
+
+### The agent itself is in the trust path for consent
+
+Approvals, denials, and configuration changes all flow through the agent UI today. A buggy or compromised agent can rewrite a denial as an approval, substitute one action's ID for another, or fabricate user consent that never happened. Existing tool-execution layers — gateways, MCP servers, agent frameworks — accept this risk because they have no separate channel for user intent. Aileron does.
+
+### Cost and latency are paid even when the work is deterministic
+
+A 50-step agent run sends every step through inference, including the steps where the answer is computable, the format is fixed, and the procedure is settled. The trivial turns and the hard turns pay the same token cost and incur the same network latency. Typical tool-call-heavy agents see 3–5x cost overhead from over-provisioning; substitution-dominant workloads can see 10x or more. The categorical wins are bigger still — substituted actions skip inference entirely, cutting end-to-end latency from seconds to milliseconds and producing identical results across runs.
+
+### Audit and compliance can't keep up with probabilism
+
+Regulated industries — finance, healthcare, legal — cannot deploy agents whose actions are non-reproducible. The same input produces different outputs across runs. The same prompt produces different tool invocations. There is no audit trail because there is no determinism to audit.
+
+### Governance products require integration the agent author doesn't perform
+
+Cerbos, Permit.io, Lakera, Pangea, Galileo all require SDK integration. The agent author is asked to be the safety engineer. Most aren't, and most won't be. The governance layer needs to be invisible to the agent — sitting in the path the agent already uses — or it doesn't get installed at all.
+
+---
+
+## What Aileron Is
+
+### Aileron Runtime — interception, substitution, and routing in one process
+
+Aileron Runtime is one process running locally. The agent points at `http://localhost:8721/v1` thinking it is talking to an LLM. Behind that endpoint, Runtime does three things in sequence on every request:
+
+**1. It augments the agent's tool catalog with installed actions and matches against `ACTIONS.md`.**
+
+Authors declare deterministic actions in a manifest:
+
+```yaml
+# actions/send_invoice.yaml
+match:
+  intent: "send invoice"
+  required_args: [customer_id, amount]
+execute:
+  steps:
+    - lookup: { source: crm, key: customer_id }
+    - render: { template: invoice_email.tmpl }
+    - send: { service: gmail, credential: aileron://vault/gmail }
+returns:
+  format: chat.completion
+```
+
+Aileron exposes installed actions to the LLM as functions the LLM can call. When the LLM calls one, Aileron executes the action deterministically — same inputs, same outputs, every time. For high-confidence intents, Aileron can also bypass the LLM entirely and execute the action directly.
+
+`ACTIONS.md` is the primitive. It composes like Anthropic's Skills — declarative, file-based, version-controlled, shareable — but at the seam where the LLM lives, with deterministic execution semantics. A community ecosystem of actions becomes possible: Stripe, Salesforce, Gmail, Google Calendar, GitHub, Postgres, and the long tail of services agents touch every day.
+
+**2. It orchestrates inference engines when no action matches.**
+
+Runtime profiles the hardware, benchmarks available engines (Ollama, llama.cpp, MLX, vLLM, others as they emerge), and learns which engine + model + quantization performs best on this specific machine. Over time it builds a per-machine performance profile that improves with use. The user does not pick the engine. Does not pick the quantization. Does not tune.
+
+This is structurally different from Ollama. Ollama is in the inference-engine business — they wrap llama.cpp and optimize that one experience. Routing across competing engines, including their own, is a conflict of interest they cannot resolve. Aileron is the layer above. We do not run inference; we decide who does.
+
+**3. It routes per request.**
+
+Runtime decides per request whether to run locally, route to a small cloud model, or escalate to a frontier model. Trivial turns run free on local hardware. Moderate turns route to small cloud models. Frontier models are reserved for the slice of work that genuinely requires them.
+
+The honest claim: Aileron does not promise frontier quality on a laptop. Aileron promises **the cheapest model that meets the developer's quality bar**.
+
+### Aileron Control — governance that comes for free
+
+Because Aileron Runtime is in the request path by construction, governance attaches without integration:
+
+- **Identity and credential vault.** Keys, tokens, secrets — held by Aileron, never reach the LLM, scoped per action.
+- **Policy enforcement.** Deterministic rules about what agents can do, with whom, under what conditions, applied before any action or LLM call executes.
+- **Tamper-resistant approvals.** When an action requires human confirmation, Aileron prompts via system notification, OS biometric prompt, dedicated TUI panel, or web UI — never through the agent UI. The user's consent travels on a channel the agent cannot reach. (No competitor offers approval flows that are structurally protected from agent mediation.)
+- **Audit and execution.** Every action execution is deterministic and reproducible. Every LLM call is logged with routing decisions. Every approval is recorded with the surface it came from.
+
+---
+
+## How Aileron Works
+
+The architectural decisions below will be ratified as ADRs. They're sketched here so the strategic choices are visible up front: Aileron core ships small, knows nothing about specific systems, and treats every connector as untrusted code with declared, enforced capabilities.
+
+### The connector model
+
+Aileron core ships only the *primitive capability types* — "network host:port," "vault credential of kind X," "host function Y" — not specific connectors. Gmail, Slack, GitHub, Stripe — these are connectors that arrive as separately distributed code, signed by their publishers, declaring what they need. Aileron core never has built-in knowledge of "Gmail" or "Slack."
+
+Each connector ships a manifest declaring its needs:
+
+```toml
+[connector]
+name = "gmail"
+version = "1.2.3"
+publisher = "acme.dev"
+provenance_hash = "sha256:abc123..."
+
+[capabilities.network]
+hosts = ["gmail.googleapis.com:443", "oauth2.googleapis.com:443"]
+
+[capabilities.credential]
+kind = "oauth2"
+scope = "https://www.googleapis.com/auth/gmail.send"
+
+[capabilities.runtime]
+imports = ["wasi:http/outgoing-handler", "wasi:cli/stdout"]
+
+[provides]
+intents = ["send_email", "draft_email"]
+```
+
+The manifest is a *request*. The runtime grants nothing not declared in it.
+
+### The capability model: types, not paths
+
+The connector cannot name a vault path. It declares an abstract requirement ("an OAuth2 credential with this scope"), and the user binds the requirement to a concrete vault entry at install time:
+
+```
+Connector "gmail" requests an OAuth2 credential with scope:
+  https://www.googleapis.com/auth/gmail.send
+
+You have:
+  ▸ gmail/work        (alr@workplace.com)
+  ▸ gmail/personal    (alr@home.com)
+  ▸ Add new account…
+
+Bind to: [gmail/work]
+```
+
+This is structurally important. A malicious connector cannot even *name* a key it shouldn't reach. It declares an abstract need; the user binds the specific resource. The Stripe connector requesting an OAuth2 scope of `gmail.send` would either fail (no matching credential exists) or be visibly wrong to the user.
+
+This pattern matches Android's `ContentProvider` model, iOS privacy entitlements, and macOS TCC. Well-trodden ground.
+
+### The action model
+
+Actions are the composable units developers work with. Each action is a declarative manifest that describes what intent it matches, which connectors it uses, and what those connectors do during execution.
+
+Actions are **atomic and do not depend on each other.** If a developer wants a compound operation — "ship-update + create-followup-ticket + block-calendar" — they either let the agent orchestrate the actions in sequence (the natural mode) or write a *new* action that performs all three using connectors. Action-to-action dependencies are deliberately not modeled. They open a dependency-graph problem unnecessary for the value we're after.
+
+Actions **do depend on connectors**, with explicit version ranges and capability subsets:
+
+An action file lives at `actions/ship-update.md` and is yours to evolve once installed:
+
+````markdown
++++
+name = "ship-update"
+version = "1.0.0"
+source = "hub://aileron/ship-update@1.0.0"
+
+[[requires.connectors]]
+name = "slack"
+version = "1.2.0"
+hash = "sha256:abc123..."
+capabilities = ["chat:write", "channels:read"]
+
+[[requires.connectors]]
+name = "git"
+version = "2.1.0"
+hash = "sha256:def456..."
+capabilities = ["read"]
+
+[match]
+intent = "tell team I shipped"
+
+[[execute]]
+id = "recent_merge"
+connector = "git"
+op = "read_recent_merge"
+
+[[execute]]
+id = "post"
+connector = "slack"
+op = "post_message"
+
+[execute.inputs]
+channel = "${args.channel}"
+message = "${recent_merge.summary} → ${recent_merge.pr_url}"
++++
+
+# Ship Update
+
+Posts a "shipped" announcement to a Slack channel with the merged PR link.
+
+## When it fires
+
+Triggered when the user tells their agent things like:
+
+- "tell team I shipped the migration"
+- "post a ship update to #engineering"
+- "let the team know I merged the PR"
+
+## What it does
+
+1. Reads the most recent merge commit from local git.
+2. Extracts the PR URL from the commit body.
+3. Formats a message and posts it to the specified Slack channel.
+````
+
+The TOML frontmatter is the contract Aileron executes; the Markdown body is human-facing documentation that doubles as the function description when this action is surfaced to the LLM as a tool.
+
+Three things make this declaration the source of truth:
+
+**1. Declared capabilities are enforced at runtime.** If `ship-update` declares `slack: chat:write` but at runtime tries to call `chat:read`, Runtime refuses. The connector might be capable of `chat:read`, but the action didn't declare it. Capability creep is blocked at the action boundary, not just the connector boundary. Defense in depth.
+
+**2. Audit becomes precise.** A reviewer reading the action manifest knows exactly what capabilities the action uses, without reading the execution body. Reviews stay tractable.
+
+**3. Install resolution becomes deterministic.** When a developer runs `aileron action add ship-update`, Aileron resolves the dependency graph in a single bundled consent moment, not a series of surprise prompts at first invocation:
+
+```
+$ aileron action add ship-update
+→ Fetching action 'ship-update' from Aileron Hub...
+✓ Action file written to actions/ship-update.md
+  Declares connectors: slack@1.2.0, git@2.1.0
+
+This action requires:
+  ✓ slack 1.2.0        (installed)
+    Capabilities:
+      ✓ chat:write     (already granted)
+      ✗ channels:read  (NOT granted to slack/work)
+  ✗ git 2.1.0          (not installed)
+
+Resolving:
+  → Re-bind slack connector to grant 'channels:read'?
+  → Install missing connector 'git' (hash verified)?
+
+[Continue]  [Customize…]  [Cancel]
+```
+
+There is no separate lock file. The action file itself is the contract — version pins, content hashes, declared capabilities, and execution steps, all in one place, owned by the developer in their git repo. Runtime verifies these constraints on every action invocation before execution begins. If any check fails, the action fails fast with a precise error rather than crashing mid-execution.
+
+**Action files are owned, not installed.** When `aileron action add ship-update` runs, the action file is *copied* into the developer's project and tracked by git. From that moment forward, the developer owns the file: customize it to fit project conventions, modify the connector versions, refine the templates, evolve it as the project evolves. The Aileron Hub is a curated catalog of starting-point templates; installation is a copy operation, not a runtime dependency. This follows the ShadCN distribution model — the right pattern for declarative source code that wants to live alongside the developer's other source files.
+
+### Connectors, not capabilities
+
+Actions bind to specific connectors (`slack@1.2.0`), not to abstract capabilities (`messaging:post_to_channel`). This is a deliberate simplification, not a deferred decision. Capability abstraction would add standardization governance (who defines `messaging:post_to_channel`?), parser complexity, a second trust layer (trust the spec *and* trust any implementation), and UX ambiguity ("I want messaging" vs "I want Slack") in exchange for marginal substitutability benefit.
+
+Aileron does not include capability abstraction. Action authors name the connector they want; if they need to swap implementations, they edit the action file. The ShadCN distribution model makes this trivial — the action file is theirs to evolve.
+
+### How intent matches to actions
+
+Aileron uses two mechanisms in tandem to translate user intent into action execution.
+
+**Primary: tool augmentation via function calling.** Modern agents (Claude Code, Cursor, Copilot, ChatGPT, etc.) speak function calling — they construct chat completion requests with a `tools` array describing available functions, and the LLM decides which (if any) to call. Aileron leverages this directly: on every incoming chat completion request, Aileron augments the agent's `tools` array with installed actions, translated into function definitions:
+
+```yaml
+# An action's match clause becomes a function description the LLM sees:
+- name: ship-update
+  description: "Post a 'shipped' update to a Slack channel with the merged PR link"
+  parameters:
+    type: object
+    properties:
+      channel: { type: string }
+```
+
+The augmented request goes to whichever LLM Runtime's per-request router selected. The LLM does the categorization — picking when to invoke an action and what arguments to pass. Aileron then executes the deterministic ones with capability isolation; agent-defined tools (like `bash` or `file_read`) pass through unchanged.
+
+This division leverages the strongest available intent-matcher — the LLM that's already processing the request — without adding inference cost or probabilism to the matching step. Selection is what LLMs are good at; execution is where determinism matters. Aileron stops competing with the LLM at categorization and instead focuses on what makes its execution layer different: capability isolation, vault-held credentials, deterministic outcomes, audit trails, and tamper-resistant approval.
+
+**Secondary: pre-LLM bypass for clear intents.** For high-confidence patterns, Aileron can short-circuit the LLM call entirely. The action manifest's `match` clause can declare deterministic patterns:
+
+```yaml
+match:
+  type: pattern
+  patterns:
+    - "(?i)post (?:an? )?ship update to #(\\w+) for (.+)"
+```
+
+When Aileron detects a clear pattern match in the user's last turn, it executes the action directly with extracted arguments — no LLM round-trip. Saves cost and latency for clear intents. Disabled by default; opt-in per action or globally.
+
+**Tool name collisions.** Agent-defined tools take precedence; Aileron actions with conflicting names are renamed with a namespace prefix (`aileron.ship_update`) and the developer is notified. The agent never sees two tools with the same name.
+
+**The agent visibility property.** Because Aileron exposes installed actions as tools to the LLM, the agent is naturally aware of what's available — they appear in the tool catalog. The architectural property the doc claims is not "the agent doesn't know actions exist" but rather: **the agent's tool calls have superpowers it can't perceive.** The agent sees a function called `send_invoice` and treats it like any other tool. What it doesn't see: `send_invoice` is executed by sandboxed code, with credentials the LLM never touched, against a real Stripe API call, with an immutable audit record, and with consent the agent itself cannot tamper with. The visible surface looks like a normal tool call. The execution semantics are categorically different.
+
+### Install consent: one path
+
+There is no tiered installation flow. Every connector and every action installs through the same path. The user sees the publisher identity, the signature status, and the full capability declaration; the user either clicks Install or Cancel. There is no option to selectively deny capabilities — the contract installs whole or not at all.
+
+This is a deliberate simplification. Partial-install state — where a connector is installed but missing some of the capabilities it declared — is a source of ambiguity: the connector might or might not work, the action might or might not run, errors become confusing. By removing the option to selectively deny, Aileron preserves a clear invariant: an installed connector has all of its declared capabilities; an installed action has all of its declared connector dependencies; if not, it isn't installed.
+
+Publisher identity and signature verification still matter — they appear in the install consent UI so the user can decide whether to install at all. A connector signed by a known publisher whose key Aileron has verified shows that signature; an unsigned connector from an unknown source shows "UNSIGNED" prominently. Verification is information shown to the user, not a different UX flow.
+
+The Hub may use signing and verification status to organize and rank entries (verified publishers may appear higher; unsigned entries may carry a warning badge in browse views). But once the user chooses to install, the consent flow is the same regardless: show what you're getting, get explicit user approval, install in full or not at all.
+
+### The install moment
+
+At install, Aileron presents a single readable summary:
+
+```
+Installing: gmail v1.2.3
+Publisher: acme.dev  (signature verified)
+
+This connector requests:
+
+  Network
+    • gmail.googleapis.com:443
+    • oauth2.googleapis.com:443
+
+  Credentials (bound at first-use)
+    • An OAuth2 token (scope: gmail.send)
+
+  Capabilities
+    • Outbound HTTP
+    • No filesystem access
+    • No environment access
+
+  Provides actions: send_email, draft_email
+
+[Install]  [Cancel]
+```
+
+The user installs the contract as declared, or cancels. There is no partial install; there is no per-capability customization. This preserves the invariant that an installed artifact carries all of its declared capabilities — no ambiguity, no half-state.
+
+### Capability binding UX: one auth path, triggered on demand
+
+Five architectural commitments shape how users authenticate and bind credentials. The detailed prompt sequences, multi-account UX, and conflict-resolution flows defer to the binding-UX ADR.
+
+**1. Bindings are always explicit user actions.** Aileron never silently associates a credential with a capability. The user confirms at the moment a binding is created or modified.
+
+**2. Capability *types* surface at install (transparency only).** When a connector or action is installed, Aileron shows what capabilities will be requested ("this connector will want OAuth2 access with scope `chat:write`"). No browser opens, no binding happens — this is just transparency about what the user is committing to allow later.
+
+**3. Capability *bindings* surface at first-use.** The actual OAuth dance and credential binding run when the action first needs the credential. This is the same code path that handles credential refresh after expiration or revocation. One auth flow, triggered whenever credentials are needed and missing or expired, regardless of whether it's the first time or the hundredth. Consistency is the win.
+
+**4. Pre-binding is opt-in for users who want it.** `aileron binding setup` (or `aileron sync --bind-now`) runs the auth flow eagerly for everything the project needs. Power users can pre-authenticate everything. Headless and autonomous workflows require this — non-interactive runs cannot complete OAuth flows mid-execution, so credentials must be pre-bound or federated through Control.
+
+**5. Bindings are managed visibly.** `aileron binding list`, `aileron binding inspect`, and `aileron binding rebind` give the user direct control. Bindings are observable, replaceable, and removable on demand.
+
+The detailed UX — exact prompt sequences, what happens when a binding name collides with an existing one, how multi-account workflows look, the precise behavior of `aileron sync --bind-now` in mixed-state projects — defers to the binding-UX ADR. These five commitments set the architectural posture; the ADR fills in the operational details with concrete implementation experience.
+
+### Two distribution mechanics: binaries and files
+
+Aileron uses two distinct distribution models for two different kinds of artifact, each suited to its purpose:
+
+- **Connectors are binaries.** Sandboxed WASM modules with capability declarations and signed publisher hashes. They live in a content-addressed store outside any specific project (similar to Docker's image cache or Cargo's crate cache). Action files reference them by name + exact version + hash. When an action loads, Aileron verifies the connector binary in the store matches the declared hash before executing.
+
+- **Actions are declarative source files.** They get copied into the developer's project on install, live in `actions/` (or wherever the project chooses), are tracked by git, and become the developer's own to evolve. The Hub serves them as starting-point templates; once installed they're indistinguishable from action files the developer wrote themselves.
+
+This is the ShadCN model for actions plus a content-addressed store for connectors. There is no project-level lock file — each action file declares its own dependencies (connector name + exact version + hash) and is therefore self-describing. Reproducibility comes from git.
+
+The CLI surface follows from this:
+
+- **`aileron connector install slack@1.2.0`** — fetches the binary into the local connector store, verifies the hash and signature, runs the install-time consent flow, registers capability bindings.
+- **`aileron action add ship-update`** — fetches the action template from the Hub, copies it into `actions/ship-update.md`, resolves any missing connector dependencies, prompts for capability bindings. From that moment on, the developer owns the file.
+- **`aileron sync`** — reads the action files in the project, installs missing connectors (verifying hashes), prompts for unbound credentials. Standard `npm ci`-shape, but driven by the action files themselves.
+
+Update tooling assists where useful, always editing action files visibly:
+
+- **`aileron action update <name>`** — fetches the latest version of an action from the Hub and generates a diff against the local file. The developer accepts or rejects via git review.
+- **`aileron connector check`** — scans all action files, lists available updates for any connector referenced anywhere.
+- **`aileron connector update <connector>`** — bumps a connector reference (name + version + hash) across all action files that use it, after explicit confirmation.
+- **`aileron action audit`** — lists every action and connector the project uses, every declared capability, every binding identity. Single command, full picture.
+
+Updates always show up as git diffs. Nothing happens silently.
+
+### Sandboxing and runtime enforcement
+
+Connectors run in a WASM sandbox by default — capability-based isolation, language-agnostic, fast startup, deterministic execution. Aileron's vault sits in the host process; credentials are issued to connectors as short-lived scoped tokens per call, never as long-term keys.
+
+The sandbox guarantees:
+
+- Connector A cannot read Connector B's memory.
+- Connector A cannot dial network hosts not in its grant.
+- Connector A cannot access vault entries outside its bound credentials.
+- Capability requests at runtime not in the install grant are denied at the WASM boundary.
+- Action requests at runtime not in the action's `requires` declaration are denied at the action boundary.
+
+For ultra-sensitive credentials (banking, healthcare), connectors can be escalated to OS-process isolation as a higher tier — slower, stronger boundary. Default is WASM; escalation is opt-in.
+
+### The user channel
+
+The agent UI is one path between the user and Aileron, but it's not the only one — and for security-critical interactions, it cannot be the only one.
+
+When a user types into an agent's prompt, their message reaches Aileron only after the agent transforms it into a chat completion request. That transformation can paraphrase, wrap, or rewrite the user's text. For most read-only interactions (status checks, audit queries, action explanations), this is fine — if the agent garbles the request, the user just retries. But for **consent-bearing interactions like approvals**, an agent in the trust path is a security risk: a buggy or compromised agent could rewrite a denial as an approval, or substitute a different action's ID. The user's consent must travel through a channel the agent cannot reach.
+
+Aileron solves this with two complementary mechanisms.
+
+**Output: streaming chat completions.** Aileron holds the agent's chat completion request open as a stream and writes progressive updates into it: *"Reviewing action…"*, *"Waiting for approval…"*, *"Approval received"*, *"Executing…"*, *"Done."* The agent UI displays this progression as the response unfolds. The full lifecycle of an action — including the pause for approval and the result after — surfaces inside the same chat turn that triggered it. The agent UI is a *passive viewer* of the flow; it cannot influence anything inside the stream beyond reading and rendering.
+
+**Consent: out-of-band surfaces.** The user's actual approval click does not travel through the agent UI or the chat completion path. It travels through a surface that connects directly to Aileron's local process, structurally bypassing the agent. Five surfaces, ordered from most-to-least visually integrated:
+
+| Tier | Surface | Visual integration | Reliability |
+|---|---|---|---|
+| 1 | OS-level biometric / confirmation dialog (macOS Touch ID, Windows UAC) | Overlays focused window; minimal context shift | Native, when supported |
+| 2 | System notification with action buttons | Banner over current app | Cross-platform default |
+| 3 | Aileron TUI as a docked side panel | Persistent always-open view; auto-updates with pending approvals | Power-user opt-in |
+| 4 | Web UI in browser tab (`localhost:8721/approve/<id>`) | Tab opens via clickable URL in stream | Universal fallback |
+| 5 | CLI (`aileron approve <id>`) | Manual terminal context-switch | Always works |
+
+Each surface shows the user the action description from Aileron's source of truth — not from the agent's rendering — so substitution attacks (where the agent silently approves the wrong action) are visible to the user. Each surface routes the click directly to Aileron via OS IPC or local-only HTTP, never through the agent.
+
+For v1, Tier 1 (where available) and Tier 2 (cross-platform default) are the recommended approval surfaces. Tier 5 is the always-available backstop. The remaining tiers fill in for cases where the primary surfaces aren't a fit.
+
+**The honest property.** Approval cannot be both fully in-band in the agent UI *and* immune to agent tampering — these are mutually exclusive given the topology of chat-completion-mediated agents. Aileron treats this as a security feature, not a UX bug: the user's consent for consequential actions is structurally protected from agent mediation. The cost is a small visual context shift to whichever OOB surface the user has configured. The cost is real but minimizable, and the security property — *the agent cannot fabricate, modify, or replay user consent* — is something no chat-completion-mediated tool layer can match without this design.
+
+**Read-only commands remain fluid in-band.** For status, audit, and explanation commands (where the trust requirement is low because the user can simply retry if garbled), an in-band convention works:
+
+```
+/aileron status
+/aileron actions
+/aileron explain "send invoice to acme"
+/aileron audit
+```
+
+These reach Aileron via the chat completion path, are best-effort but reliable across major agents, and avoid the OOB context shift for low-stakes interactions. The CLI (`aileron status`, etc.) and TUI offer the deterministic alternative when needed.
+
+### Failure handling: visible by default, not silent
+
+Four architectural commitments shape how Aileron behaves when an action fails. Specific retry budgets, manifest syntax for failure overrides, and detailed failure-class policies are deferred to the failure-handling ADR — they benefit from real implementation experience.
+
+**1. Visible failure is the default; never silent LLM fallback.** When an action fails, the agent receives a structured error. Aileron does not fall back to the LLM and let it produce a probabilistic response that masquerades as the action's output. Silent fallback is the worst possible failure mode because the user thinks the action succeeded when it didn't — the LLM hallucinates a confirmation while real-world state diverges from belief. This is a security commitment, not a UX preference.
+
+**2. LLM fallback is opt-in, gated to informational-class actions only.** Some actions are read-only or synthesis-style ("look up customer info," "summarize this thread") where degraded LLM answers beat no answers. For these, the action manifest can opt into LLM fallback explicitly, with the response clearly flagged as estimated. For any action with side effects — sends email, charges a card, modifies a database — Aileron refuses the fallback flag at install time. Side-effecting actions cannot fall back to probabilistic execution; the runtime structurally prevents it.
+
+**3. Errors are structured so agents can reason about them.** When an action fails inside a function-calling flow, the tool result includes a structured error payload (failure class, retriability, user-facing message, audit ID). When an action fails in pre-LLM bypass mode, the streaming response includes a recognizable marker block. Agents that want to retry, inform the user, or try a different approach have the information to do so.
+
+**4. Actions are designed for idempotency by default.** Idempotency keys derived from action inputs make retries safe. Authors writing genuinely non-idempotent actions opt out explicitly in the manifest; Aileron then disables auto-retry for those actions. This commitment shapes how the action manifest schema looks and how partial-failure recovery works — both of which become tractable when retries don't risk double-execution.
+
+The detailed policy — failure-class taxonomy, default retry budgets, manifest syntax for overrides, recovery semantics for partial failures, OAuth refresh as a first-class flow rather than a failure mode — is deferred to the failure-handling ADR. These four commitments set the architectural posture; the ADR fills in the operational details with concrete implementation experience.
+
+### Project portability: action files travel; credentials don't
+
+Four architectural commitments shape how project state survives across machines and team members. There is no separate lock file — the action files themselves are the contract. The detailed `aileron sync` UX, prompt sequences, conflict resolution, and Control-federation interactions defer to the project-portability ADR.
+
+**1. Action files are committable; credentials are not.** Action files (`actions/*.md`) live in the project repo, version-controlled by git. They contain everything needed to reproduce the project's action behavior: connector names, exact versions, hashes, declared capabilities, execution steps. They do not contain credentials or anything secret. Anything secret stays in the developer's local vault.
+
+**2. Bindings are personal; intent is shared.** Action files reference bindings by name (`slack/work`); each developer's local vault holds *their own* credential under that name. The team aligns on intent (which workspace conceptually, which environment); each developer's identity remains private. Two developers running the same project from the same action files each post to their own Slack via their own credentials — same name, different bound resource.
+
+**3. `aileron sync` is the guided-setup primitive.** A teammate cloning the repo runs one command. Aileron reads the action files, identifies missing connectors and unbound credentials, walks the developer through installing missing connectors (verifying hashes match the declarations in the action files), and completes the OAuth flows they need to bind their own credentials. Standard `npm ci`-shape — but driven by the action files themselves, not a separate lock file.
+
+**4. Shared credentials federate through Control.** For service accounts and organization-shared credentials (CI bots, automation identities, shared workspace tokens), Aileron Control hosts the binding centrally. The action files reference the same binding name; resolution differs depending on whether the developer's machine is signed into Control. The same project files work whether the developer is solo, on a team using personal bindings, or on a team using federated org-shared bindings — without changing how the action files are written.
+
+The detailed policy — exact `sync` UX, conflict resolution when actions disagree on connector versions, prompt sequences for OAuth in restrictive workspaces, how Control federation handles permission changes, the precise behavior when an action file's hash doesn't match what the Hub serves — defers to the project-portability ADR. These four commitments set the architectural posture; the ADR fills in the operational details with concrete implementation experience.
+
+### Manifest format: Markdown plus TOML frontmatter
+
+Aileron commits to specific format choices for each kind of artifact. The choices reflect a security-and-clarity preference for declarative source code that drives execution.
+
+| Artifact | Format |
+|---|---|
+| Action files | Markdown body + TOML frontmatter (`+++` delimited) |
+| Connector manifests | Pure TOML |
+| Project config | Pure TOML |
+| Runtime IPC and internal state | JSON |
+
+**Why TOML over YAML for the structured parts.** YAML's whitespace sensitivity, type coercion (the "Norway problem"), and parser-implementation differences are real footguns for content that drives execution. A misparsed action file isn't a broken build — it's the wrong action running with the wrong arguments, against real systems, with real credentials. TOML's strict, unambiguous syntax eliminates these footguns. Parser attack surface is also smaller; the deserialization-to-arbitrary-objects vulnerability class that has produced repeated YAML CVEs simply doesn't exist in TOML. For security-critical declarative content, TOML's strictness is a structural advantage, not just a stylistic preference.
+
+**Why Markdown for action files.** Action files have three audiences simultaneously: the runtime needs the structured contract, developers reading the project need documentation, and the LLM that surfaces the action as a tool needs a function description. Markdown with structured frontmatter is the established pattern for handling this — used by Anthropic Skills, AGENTS.md, Hugo, Jekyll, GitHub issues, and the broader "structured frontmatter + prose" convention. The Hub renders the Markdown for browsing; developers read the prose; the runtime parses the frontmatter; the LLM consumes the description from the body. One file, four readers, no impedance mismatch.
+
+**The body doubles as the LLM-facing description.** When Aileron augments the agent's tool catalog with installed actions, each function's `description` is drawn from the action file's Markdown body — typically the first paragraph or a designated section. The documentation the author writes for humans IS the description the LLM reads. One source of truth, no separate "LLM hint" field to keep in sync with the prose.
+
+**On YAML preference among action authors.** Some authors will prefer YAML for the frontmatter — particularly those coming from CI config or Anthropic Skills tooling. We're shipping TOML and watching for adoption friction. Format choice is reversible (clean conversion in either direction) and we can add YAML frontmatter support later if community feedback shows TOML is a real barrier. Starting with the safer format is the right default for security-critical content.
+
+### Why these decisions become ADRs
+
+The connector model, the action model, capability binding UX, dependency resolution, intent matching mechanisms, the user channel and out-of-band approval surfaces, failure-handling policy, project portability and the action-file-as-contract model, manifest format conventions, install consent flow, and sandbox choice are all foundational. Each will get an ADR with the trade-offs, alternatives considered, and decision criteria recorded explicitly. That documentation exists to keep these decisions reviewable and to make changes deliberate, not accidental.
+
+---
+
+## Why This Is Structurally Defensible
+
+Every other product in the surrounding space solves a fragment of the pattern but cannot occupy this seam.
+
+| Player | What they solve | Why they cannot do this |
+|---|---|---|
+| Aurelio Semantic Router | Deterministic intent → action dispatch | Python library; agent must integrate it |
+| Docker Cagent | Proxy returning chat-completion responses without LLM | CI replay tool; cassettes are recordings, not authored actions |
+| Anthropic Skills | Declarative capability manifest | LLM still executes; not deterministic |
+| MCP | Expose tools to the LLM | LLM in the loop; no tamper-resistant approval channel |
+| NVIDIA OpenShell | Sandbox-level interception of agent process | Cannot read LLM-shaped intent; not at the endpoint seam |
+| LiteLLM / Portkey / OpenRouter | OpenAI-compatible gateway | Always routes to *another* LLM |
+| Ollama Cloud | Local + cloud overflow | Local-only routing, no action layer, no governance |
+| Salesforce Agent Fabric | "Guided determinism" workflow handoffs | No-code orchestration DAG; not a transparent proxy |
+| 1Password Agent Access | Scoped credentials for agents | Vault layer, not execution substitution |
+
+The space is thoroughly *surrounded*. No vendor has assembled the load-bearing pieces — declarative manifest, transparent OpenAI-compatible endpoint, deterministic tool execution, capability-bound connectors, action-level capability subsetting, credential isolation, and tamper-resistant out-of-band approval — at the seam where they belong. Shipping that combination first, with an open manifest format, is a category-defining move.
+
+For the full competitive scan — including the deterministic-substitution-pattern research, threat ranking, and named players in each adjacent category — see [Competitive Landscape](/pivot/competitive-landscape).
+
+---
+
+## The Customer
+
+### Individual developers — productivity that secures itself
+
+- AI coding tool users (Claude Code, Cursor, Continue.dev, Copilot) who want their agents to actually finish the work — write the code, ship it, tell the team — instead of stopping at the boundary of "code only."
+- Local-first developers running Ollama, llama.cpp, or MLX, frustrated with the configuration tax and leaving 30–50% of hardware capability unused.
+- Privacy-first power users automating personal workflows where data must not leave the device.
+- Indie agent builders shipping products where per-request token cost is a line item.
+
+The wedge is the individual developer. The expansion is structurally aligned: the same install pattern scales to every system the developer touches, and the same architecture that gives an individual developer their first hero moment also gives an enterprise its first compliance-grade deployment.
+
+### Enterprise — addressed in detail later
+
+Compliance, vault federation, audit retention, signed connectors, attested execution — these matter to enterprises and the architecture supports them. They get a dedicated treatment in a separate document. This document is for the developer who needs to feel productive in five minutes.
+
+---
+
+## The Business: Revenue Atop the Open Source
+
+The core is open source. That is the distribution layer. Free is the right price because distribution is the asset.
+
+- **Aileron Runtime** — MIT, self-hosted, `brew install aileron`. Includes the action engine, the inference orchestration, the routing intelligence, the connector sandbox, and the capability enforcement layer.
+- **`ACTIONS.md` and the connector manifest format** — open primitives; community-authored actions and connectors available freely.
+- **Aileron Control basics** — local vault, basic policy, single-user audit.
+
+Revenue compounds across these surfaces:
+
+### 1. Aileron Cloud — overflow as a service
+
+When local execution is insufficient and a frontier model is required, requests route through Aileron Cloud. We select across providers, optimize cost and reliability, present unified billing, and apply the routing decisions as a margin-bearing service.
+
+- **Indie tier:** $20/mo for individuals, capped overflow.
+- **Pro tier:** $100/mo per developer, higher quotas, priority routing.
+- **Team tier:** usage-based, volume discounts.
+
+Comparable shape to OpenRouter; structural advantage is being the routing decision-maker, not a thin proxy.
+
+### 2. Aileron Control — governance for production agents
+
+Sold to teams shipping production agents that take real-world actions. The full Control surface: multi-user vault with scoped credentials, policy authoring and enforcement, inline approval workflows, full audit retention, RBAC, SSO.
+
+- **Team tier:** $50/seat/mo.
+- **Enterprise tier:** custom, with on-prem option, SLA, and dedicated support.
+
+The expansion vector is architectural: every Runtime install is a Control candidate the moment the agent takes its first real-world action.
+
+### 3. Aileron Hub — the unified marketplace surface
+
+The Hub is one developer-facing browse experience covering both connectors and actions. Internally there are two distinct distribution mechanics — connectors are sandboxed binaries with signing, version pinning, and capability declaration; actions are template manifests copied into the developer's project on install. Externally these appear as one unified surface where developers browse for capabilities ("I want Slack things") and find both connectors and actions related to that domain.
+
+Three tiers across both content types:
+
+- **Free tier:** community-published connectors and actions, unsigned, best-effort.
+- **Verified tier:** signed by Aileron, security-reviewed, SLA-backed.
+- **Enterprise tier:** built and supported by Aileron for SAP, Salesforce, Workday, ServiceNow, and other high-value vertical integrations.
+
+Aileron sits in the middle with a take rate. Pattern shape: Docker Hub, npm, GitHub Marketplace.
+
+### 4. Aileron Connector Certification — vendor-funded trust
+
+SaaS vendors pay Aileron to certify their official connector. Their logo gets the "Aileron Verified" badge. Customers get an audited supply chain. Vendor-funded, not customer-funded.
+
+### 5. Aileron Connector Studio — for organizations building their own
+
+Tooling for organizations building connectors against their own internal systems — sandbox primitives, capability declaration helpers, signing flow, CI integration, testing harness. Per-seat pricing.
+
+### 6. Aileron Insights — observability and cost analytics
+
+A first-party observability surface populated by every Runtime install:
+
+- **Determinism rate** per agent — what fraction of requests are substituted vs. LLM-mediated.
+- **Cost analytics** — savings from action substitution, savings from per-request routing.
+- **Quality metrics** — model selection performance against the developer's quality bar.
+- **Connector observability** — which connectors run hot, which fail, which capabilities are exercised.
+- **Action observability** — which actions are most-used, which fail, which capability surfaces are growing.
+
+Sold per seat or as part of higher Control tiers.
+
+### 7. Aileron Enterprise — the high-touch top
+
+The traditional enterprise tier: on-premises deployment, SSO, RBAC, audit retention beyond cloud limits, dedicated support, SLAs, security reviews, custom action and connector development. Six-figure annual contracts. Detailed treatment in the enterprise document.
+
+### The compounding logic
+
+Every Aileron Runtime install is a candidate for all surfaces. Cloud monetizes overflow inference. Control monetizes production governance. Hub monetizes the platform itself. Certification monetizes vendor reputation. Studio monetizes custom integration. Insights monetizes ongoing operations. Enterprise monetizes the long tail of high-value organizations. Each makes the others more valuable. All ride on a free OSS distribution layer.
+
+---
+
+## What Aileron Is Not
+
+- Not another model.
+- Not another agent framework.
+- Not a wrapper around Ollama — Ollama is one engine Aileron orchestrates.
+- Not a thin API gateway — the routing and action decisions are the value, not the proxy.
+- Not "near-frontier results on a laptop" — Aileron promises the cheapest model that meets the developer's quality bar.
+- Not a tool-calling framework — Aileron *executes* tool calls deterministically with capability isolation, rather than delegating to whatever code the LLM coordinates.
+- Not a content firewall — Aileron does not filter LLM output; it executes deterministic actions with structural safety guarantees.
+- Not a workflow orchestrator — agents do not author DAGs; they speak chat completions, and Aileron decides what happens behind that endpoint.
+
+---
+
+## The One-Sentence Pitch
+
+**Aileron is the deterministic execution layer for AI agents: it executes the tool calls agents make with capability isolation, sealed credentials, tamper-resistant approval, and a complete audit trail — and routes to the cheapest model that meets quality only when the LLM is genuinely required. The agent's tool calls have properties it can't perceive: deterministic execution and trustworthy consent.**

--- a/docs/src/content/docs/pivot/what-your-agent-can-do.md
+++ b/docs/src/content/docs/pivot/what-your-agent-can-do.md
@@ -1,0 +1,194 @@
+---
+title: "What Your Agent Can Now Do"
+description: "Hero use cases and the value Aileron unlocks for developers"
+order: 1
+---
+
+Aileron sits between your agent and your LLM, intercepting requests and running deterministic actions when intent is clear. The result: your existing agent — Claude Code, Cursor, Continue, anything that speaks `chat/completions` — becomes capable of doing things it could not do reliably before. This document shows what those things look like in practice.
+
+> **Companion document:** for the strategy, architecture, and business model behind Aileron, see [The Deterministic Layer for AI Agents](/pivot/the-deterministic-layer).
+
+Two heroes lead the document. Both are five-minute wins. Both deliver the moment where the agent does something it could not do before. They cover two developer contexts:
+
+- **Hero 1** — for any developer, anywhere, with no third-party setup or admin involvement.
+- **Hero 2** — for developers in workspaces where they (or their team) can install Slack apps.
+
+After the heroes, five expansion patterns show how the same install scales to the systems developers actually touch.
+
+---
+
+## Hero 1: Your Agent Searches All Your Code — and Never Hallucinates a Reference
+
+Every developer using an AI coding agent has had this moment: the agent confidently says *"we handle that in `auth.go` around line 42"* and you check and there's no such function, or the file doesn't exist, or it's in a completely different repo. Cursor's `@`-references help when you remember to use them. Claude Code's grep is fast but the agent picks the wrong search terms. Both fall over the moment your work spans multiple repos.
+
+This is the daily, low-grade reliability tax of working with an agent. You can't trust references. You verify everything. You become the agent's fact-checker.
+
+**Aileron makes hallucinated references structurally impossible.**
+
+### What Aileron does that's actually new
+
+Aileron Runtime intercepts code-search intent and routes it to a deterministic search action — symbol-aware, AST-grounded, indexed across every repo the user points it at. The agent gets back real file paths, real line numbers, real function signatures. The agent is not guessing; it is reporting ground truth.
+
+Today's agents *attempt* this; none does it reliably across repos. Cursor's index is per-workspace. Claude Code's grep is per-invocation. Neither agent can answer *"find every place I used the deprecated OAuth1 flow across my last three years of work"* with verified results.
+
+### The five-minute journey
+
+```
+$ brew install aileron
+$ aileron start
+✓ Aileron running on http://localhost:8721/v1
+
+$ aileron action add codebase-search
+✓ Installed: codebase-search@1.0.0 (no external connectors)
+  Detected repos:
+    ~/git    (23 repos, 142K files)
+    ~/code   (4 repos, 18K files)
+  Indexing… 38s
+  Symbol index ready
+```
+
+Total: ~5 minutes including the index. Pure local. No browser opens. No admin involved. Works on a fresh laptop in airplane mode.
+
+### The first moment
+
+In Claude Code (or whatever agent the developer already uses), the developer types:
+
+> "Find every place I authenticate against external APIs that still uses session tokens instead of OAuth."
+
+What the agent sees is a normal chat completion. What actually happens:
+
+1. Aileron Runtime intercepts. The `codebase-search` action matches.
+2. Aileron runs a deterministic, symbol-aware search across every indexed repo. AST-grounded, not regex.
+3. Returns a structured result to the agent: 7 locations across 4 repos, each with file path, line number, function signature, surrounding context.
+4. Agent narrates: *"Found 7 places — three in `aileron-go/internal/auth/`, two in `client-app/services/`, two in legacy code in `old-prototype/`. Want me to walk through each?"*
+
+Every reference is real. Every line number resolves. Every file exists. The developer can `cmd-click` any path and land exactly there.
+
+### Why this is the moment
+
+- **Universal daily pain.** Every developer has lost time to a hallucinated code reference. It happens multiple times a week, every week, with every agent.
+- **Pure local, fully autonomous.** No OAuth, no admin, no third-party service.
+- **Visible, immediate payoff.** The first query produces a result list with verifiable references. The developer can validate the value before the index is even fully warm.
+- **Genuinely new capability.** No existing agent does cross-repo, symbol-aware, deterministic search. Cursor and Claude Code each have a piece; neither has all three.
+- **Compounds.** Every subsequent *"where do we…"* question gets the same precision. The agent stops being a thing the developer fact-checks.
+
+---
+
+## Hero 2: Your Coding Agent Ships *and* Closes the Loop
+
+Every developer ends every shipping moment the same way: context-switch out of code, write a Slack message, update a ticket, maybe email someone. The closeout is the most repeated, most context-disruptive part of the day. Agents can write the code. They can't do the closeout.
+
+**Aileron closes that gap in five minutes.**
+
+### The five-minute journey
+
+```
+$ brew install aileron
+$ aileron start
+✓ Aileron running on http://localhost:8721/v1
+
+# Point your existing agent (Claude Code, Cursor, Continue) at this endpoint.
+# No agent changes. It thinks Aileron is an LLM.
+
+$ aileron connector install slack
+→ Opening browser for Slack OAuth…
+✓ Connected as alr@yourcompany (channels: #engineering, #shipping, #standups)
+
+$ aileron action add ship-update
+✓ Installed from Aileron Action Hub: ship-update@1.0.0
+  Uses connectors: slack, git
+```
+
+Total elapsed: ~3 minutes. Most of it is the Slack OAuth window.
+
+> **A note on Slack workspaces.** This five-minute flow works in personal and small-team workspaces where any member can install Slack apps. In admin-managed enterprise workspaces, the Aileron Slack app may need workspace-admin approval before the OAuth flow completes — Slack's standard third-party app gate, not specific to Aileron. For solo developers in restricted workspaces, Hero 1 is the better starting point.
+
+### The first moment
+
+In Claude Code (or any agent the developer already uses), the developer types:
+
+> "I just merged the migration. Tell #engineering and link the PR."
+
+What the agent sees is a normal chat completion. What actually happens:
+
+1. Aileron Runtime intercepts the request at its OpenAI-compatible endpoint.
+2. The `ship-update` action matches.
+3. Aileron deterministically reads the most recent merge commit from local git, extracts the PR URL, formats the message from the action's template, and posts to `#engineering` via the Slack connector — using credentials Aileron holds and the LLM never sees.
+4. Returns a chat completion to the agent: *"Posted to #engineering with PR link."*
+
+In the developer's Slack, a message appears within ~2 seconds. Cost: $0 in tokens. Hallucination risk: zero — channel, message format, and PR link are all resolved deterministically.
+
+**The agent just did something it could not do before, and it did it instantly, accurately, and for free.**
+
+### Why this is the moment
+
+- **Universal.** Every developer ships. Every developer closes the loop. The friction is daily.
+- **Visible.** The result lands in front of teammates, in real time.
+- **Genuinely new.** Native coding agents don't post to arbitrary Slack channels. MCP servers exist but require setup per integration.
+- **Composable.** Once Slack is wired, GitHub, Linear, Calendar, and Email install the same way.
+- **The architecture pays off without explanation.** The developer doesn't need to understand WASM sandboxing or capability binding to feel the difference. The message went to the right channel, with the right link, in two seconds, for free.
+
+---
+
+## What Else Opens Up
+
+The same install pattern scales to every system the developer touches. Each expansion is one connector install away.
+
+### 1. Coding agents that cannot delete production
+
+**Pain.** A developer uses Claude Code, Cursor, or a similar coding agent. The agent decides — probabilistically — to run `rm -rf node_modules` to clean up. The model misreads the path and runs `rm -rf /` against the wrong directory. The hook system catches some of these; many slip through.
+
+**Action.** An `ACTIONS.md` entry registers `clean_build_artifacts`. When the agent's intent is "clean the build," Aileron Runtime executes `task clean` (or the project's declared equivalent) directly. The LLM never composes the shell command. The action is reviewed, version-controlled, and behaves identically on every invocation.
+
+**Wins.** Acceleration: developers actually let agents run autonomously. Speed: zero LLM latency or token cost. Safety: destructive shell commands cannot be hallucinated into existence.
+
+### 2. Customer-facing communications without leaked PII
+
+**Pain.** A support agent uses an LLM to compose customer emails. The LLM sees the full customer record in context, which lands in inference logs and provider-side caches. The LLM sometimes hallucinates the recipient. Customer communications get sent to the wrong customer.
+
+**Action.** `ACTIONS.md` registers `send_customer_email`. Aileron looks up the customer in the CRM (deterministic), renders the message from a reviewed template, and sends via Gmail with credentials Aileron holds. The LLM never sees the customer record, never composes the body, never touches the credentials. Recipient hallucination becomes structurally impossible because the recipient is resolved from `customer_id`, not generated from text.
+
+**Wins.** Acceleration: support agents that have been gated by privacy review can ship. Speed: sub-100ms execution. Safety: PII never enters LLM context.
+
+### 3. Database queries that cannot be coerced
+
+**Pain.** Agents that touch databases either get full credentials (terrifying) or call function-calling endpoints that run LLM-generated SQL (also terrifying). Prompt injection that produces `DROP TABLE`-class queries is a published attack class.
+
+**Action.** `ACTIONS.md` registers query intents — `get_revenue_by_period`, `lookup_customer_by_id`. Each is a deterministic, parameterized query against the warehouse, with role-scoped read credentials Aileron holds. The agent expresses intent in natural language; Runtime parses intent and arguments, runs the bound query, returns results. The LLM never generates SQL.
+
+**Wins.** Acceleration: analytical agents that compliance has blocked become deployable. Speed: parameterized queries run as fast as the database allows. Safety: prompt-injected SQL becomes a category-eliminated bug class.
+
+### 4. Financial transactions with reproducible audit
+
+**Pain.** Deploying agents that issue refunds, charge customers, or transfer funds requires a reproducible action stream. SOX, PCI, and internal financial controls require deterministic, idempotent, auditable transactions. LLM-mediated execution cannot meet that bar.
+
+**Action.** `ACTIONS.md` registers `issue_refund`, `charge_customer`, `transfer_funds`. Each constructs the API call deterministically, with an idempotency key derived from action inputs, with required-approval flags routed through Aileron Control's inline approval UX, and with a complete pre-execution audit record.
+
+**Wins.** Acceleration: finance-team agents that have been blocked from deployment for two years can ship. Speed: parallel approvable actions; deterministic execution times. Safety: duplicate charges, hallucinated amounts, and recipient confusion become structural impossibilities.
+
+### 5. Personal automation on private data, locally
+
+**Pain.** Individual developers want agents that can read calendar, parse email, search local files, control screen, manage contacts. Every cloud-based agent service requires sending that data off the machine.
+
+**Action.** `ACTIONS.md` registers personal-data operations — `find_meeting`, `summarize_email_thread`, `pull_file_with_keywords`, `book_calendar_block`. Each runs locally, deterministically, against local data sources using OS-level entitlements Aileron holds. When LLM reasoning is genuinely needed, Runtime routes to the local model, on the user's hardware.
+
+**Wins.** Acceleration: personal-automation surface becomes broadly usable for the first time. Speed: local actions and local inference. Privacy: personal data never leaves the device.
+
+---
+
+## The Pattern
+
+Every hero, every expansion use case, every future capability built on Aileron uses the same architecture:
+
+1. The developer points an existing agent at Aileron's OpenAI-compatible endpoint.
+2. The agent makes natural-language requests, unaware that Aileron is anything other than an LLM.
+3. When the request matches a declared action, Aileron runs the action deterministically, with credentials it holds and never exposes, against the system in question.
+4. When the request does not match, Aileron routes the LLM call to the cheapest model that meets the developer's quality bar.
+
+The five-minute install pattern stays constant. Each new connector — Slack, Gmail, GitHub, Linear, Calendar, Postgres, Stripe, anything — installs the same way. Each new action snaps into the same `ACTIONS.md` file. The agent doesn't change. The developer's productivity scales with the actions and connectors they install.
+
+That is the unlock: the agent the developer already uses, every day, becomes capable of doing things it could not reliably do before — and every new capability is one install away.
+
+---
+
+> **For the architectural and strategic picture:** see [The Deterministic Layer for AI Agents](/pivot/the-deterministic-layer).

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -35,6 +35,14 @@ export function isSection(item: NavItem): item is NavSection {
  */
 export const navigation: NavItem[] = [
   {
+    label: 'Pivot',
+    children: [
+      { label: 'The Deterministic Layer', href: '/pivot/the-deterministic-layer' },
+      { label: 'What Your Agent Can Now Do', href: '/pivot/what-your-agent-can-do' },
+      { label: 'Competitive Landscape', href: '/pivot/competitive-landscape' }
+    ]
+  },
+  {
     label: 'Meet Aileron',
     children: [
       { label: 'Overview', href: '/' },


### PR DESCRIPTION
## Summary

- Adds a new **Pivot** section to the docs site landing the strategy work for repositioning Aileron as the deterministic execution layer for AI agents.
- Three pages: strategy/architecture (`/pivot/the-deterministic-layer`), hero use cases (`/pivot/what-your-agent-can-do`), and full competitive scan (`/pivot/competitive-landscape`).
- Wires the section into the sidebar navigation at the top, with a `Compass` icon.

## What's in the strategy

The Deterministic Layer page captures every architectural commitment from this work as firm postures, with operational details deferred to per-decision ADRs:

- Two-layer model (Runtime + Control) at the LLM endpoint seam
- Connector model (sandboxed binaries, capability declarations, content-addressed)
- Action model (atomic, ShadCN distribution, depends on connectors with explicit version + hash + capability subsets)
- No capability abstraction layer, no lock file, no version ranges
- Intent matching: tool augmentation primary, pre-LLM bypass secondary
- User channel: streaming output + five-tier OOB consent surfaces (agent never in trust path)
- Manifest format: Markdown + TOML frontmatter for actions; pure TOML for connectors and project config
- Failure handling: visible default, no silent LLM fallback, idempotency by default
- Project portability: action files travel; credentials don't; `aileron sync` is the guided primitive
- Install consent: one path, binary install/cancel, no per-capability denial
- Sandboxing: WASM default, OS-process escalation opt-in
- Capability binding UX: one auth path triggered on demand, with explicit pre-bind for headless workflows

## Companion documents

- Hero use cases page demonstrates the developer experience with two five-minute wins (codebase search; Slack ship-update with admin caveat) plus five expansion patterns.
- Competitive Landscape page captures the full scan across seven categories with named players, threat ranking, and the deterministic-substitution-pattern research.

## Tracking issue

This PR lands Phase 1 of #335 (Strategic Pivot). Subsequent phases — splitting the strategy doc into navigable subpages, sharper customer/pain articulation, ADRs, code implementation, and the marketing site — are tracked there.

## Test plan

- [x] `task build:docs` (or `pnpm run build`) succeeds — 103 pages built
- [x] New pages render at `/pivot/the-deterministic-layer`, `/pivot/what-your-agent-can-do`, `/pivot/competitive-landscape`
- [x] Cross-links between the three pages resolve
- [x] Sidebar shows Pivot section at top with Compass icon
- [ ] Manual review of rendered pages in dev server

🤖 Generated with [Claude Code](https://claude.com/claude-code)