### PR TITLE
feat(enclave): enforce issued capability lifecycle

### DIFF
--- a/cmd/aileron-enclave/escrow.go
+++ b/cmd/aileron-enclave/escrow.go
@@ -27,6 +27,7 @@ type escrowEntry struct {
 	sourceTools       []string
 	allowedParameters map[string]any
 	expiresAt         time.Time
+	issuedCapability  *enclave.SignedGrantCapability
 }
 
 type escrowStore struct {
@@ -38,17 +39,18 @@ type escrowStore struct {
 
 // persistedEntry is the JSON-serializable form of an escrow entry.
 type persistedEntry struct {
-	UserID            string         `json:"user_id"`
-	GrantID           string         `json:"grant_id"`
-	EnforceGrantID    bool           `json:"enforce_grant_id,omitempty"`
-	VaultPath         string         `json:"vault_path"`
-	Provider          string         `json:"provider"`
-	Credential        []byte         `json:"credential"`
-	CredType          string         `json:"cred_type"`
-	ActionTypes       []string       `json:"action_types"`
-	SourceTools       []string       `json:"source_tools,omitempty"`
-	AllowedParameters map[string]any `json:"allowed_parameters,omitempty"`
-	ExpiresAt         time.Time      `json:"expires_at"`
+	UserID            string                         `json:"user_id"`
+	GrantID           string                         `json:"grant_id"`
+	EnforceGrantID    bool                           `json:"enforce_grant_id,omitempty"`
+	VaultPath         string                         `json:"vault_path"`
+	Provider          string                         `json:"provider"`
+	Credential        []byte                         `json:"credential"`
+	CredType          string                         `json:"cred_type"`
+	ActionTypes       []string                       `json:"action_types"`
+	SourceTools       []string                       `json:"source_tools,omitempty"`
+	AllowedParameters map[string]any                 `json:"allowed_parameters,omitempty"`
+	ExpiresAt         time.Time                      `json:"expires_at"`
+	IssuedCapability  *enclave.SignedGrantCapability `json:"issued_capability,omitempty"`
 }
 
 func newEscrowStore(dataDir string) (*escrowStore, error) {
@@ -99,6 +101,7 @@ func (s *escrowStore) Store(req enclave.EscrowStoreRequest, credential []byte, e
 		sourceTools:       append([]string(nil), req.SourceTools...),
 		allowedParameters: cloneMap(req.AllowedParameters),
 		expiresAt:         expiresAt,
+		issuedCapability:  cloneSignedGrantCapability(req.IssuedCapability),
 	}
 	s.persistLocked()
 	s.mu.Unlock()
@@ -149,6 +152,9 @@ func (s *escrowStore) GetForExecute(req enclave.ExecuteRequest) ([]byte, error) 
 	if len(entry.allowedParameters) > 0 && !reflect.DeepEqual(entry.allowedParameters, req.Parameters) {
 		return nil, enclave.ErrEscrowScopeMismatch
 	}
+	if !entry.matchesIssuedExecute(req) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
 	return copyBytes(entry.credential), nil
 }
 
@@ -174,7 +180,62 @@ func (s *escrowStore) GetForSource(req enclave.SourceExecuteRequest) ([]byte, er
 	if len(entry.allowedParameters) > 0 && !reflect.DeepEqual(entry.allowedParameters, req.Params) {
 		return nil, enclave.ErrEscrowScopeMismatch
 	}
+	if !entry.matchesIssuedSource(req) {
+		return nil, enclave.ErrEscrowScopeMismatch
+	}
 	return copyBytes(entry.credential), nil
+}
+
+func (e *escrowEntry) matchesIssuedExecute(req enclave.ExecuteRequest) bool {
+	if e.issuedCapability == nil {
+		return true
+	}
+	cap := e.issuedCapability.Capability
+	if cap.GrantID != "" && cap.GrantID != req.GrantID {
+		return false
+	}
+	if cap.UserID != "" && cap.UserID != req.UserID {
+		return false
+	}
+	if cap.VaultPath != "" && cap.VaultPath != req.VaultPath {
+		return false
+	}
+	if cap.Provider != "" && cap.Provider != req.Provider {
+		return false
+	}
+	if cap.CredentialType != "" && cap.CredentialType != req.CredentialType {
+		return false
+	}
+	if cap.ActionType != "" {
+		return cap.ActionType == req.ActionType
+	}
+	if len(cap.ActionTypes) > 0 {
+		return containsString(cap.ActionTypes, req.ActionType)
+	}
+	return true
+}
+
+func (e *escrowEntry) matchesIssuedSource(req enclave.SourceExecuteRequest) bool {
+	if e.issuedCapability == nil {
+		return true
+	}
+	cap := e.issuedCapability.Capability
+	if cap.UserID != "" && cap.UserID != req.UserID {
+		return false
+	}
+	if cap.VaultPath != "" && cap.VaultPath != req.VaultPath {
+		return false
+	}
+	if cap.Provider != "" && cap.Provider != req.Provider {
+		return false
+	}
+	if cap.Tool != "" {
+		return cap.Tool == req.Tool
+	}
+	if len(cap.SourceTools) > 0 {
+		return containsString(cap.SourceTools, req.Tool)
+	}
+	return true
 }
 
 func (s *escrowStore) entry(escrowID string) (*escrowEntry, error) {
@@ -302,6 +363,7 @@ func (s *escrowStore) persistLocked() {
 			SourceTools:       e.sourceTools,
 			AllowedParameters: e.allowedParameters,
 			ExpiresAt:         e.expiresAt,
+			IssuedCapability:  cloneSignedGrantCapability(e.issuedCapability),
 		}
 	}
 
@@ -358,9 +420,34 @@ func (s *escrowStore) load() error {
 			sourceTools:       pe.SourceTools,
 			allowedParameters: pe.AllowedParameters,
 			expiresAt:         pe.ExpiresAt,
+			issuedCapability:  cloneSignedGrantCapability(pe.IssuedCapability),
 		}
 	}
 	return nil
+}
+
+func cloneSignedGrantCapability(in *enclave.SignedGrantCapability) *enclave.SignedGrantCapability {
+	if in == nil {
+		return nil
+	}
+	return &enclave.SignedGrantCapability{
+		Capability: enclave.GrantCapability{
+			GrantID:        in.Capability.GrantID,
+			IntentID:       in.Capability.IntentID,
+			UserID:         in.Capability.UserID,
+			VaultPath:      in.Capability.VaultPath,
+			Provider:       in.Capability.Provider,
+			CredentialType: in.Capability.CredentialType,
+			ActionType:     in.Capability.ActionType,
+			Tool:           in.Capability.Tool,
+			Parameters:     cloneMap(in.Capability.Parameters),
+			ActionTypes:    append([]string(nil), in.Capability.ActionTypes...),
+			SourceTools:    append([]string(nil), in.Capability.SourceTools...),
+			ExpiresAt:      in.Capability.ExpiresAt,
+			Nonce:          in.Capability.Nonce,
+		},
+		Signature: in.Signature,
+	}
 }
 
 func cloneMap(in map[string]any) map[string]any {

--- a/cmd/aileron-enclave/escrow_test.go
+++ b/cmd/aileron-enclave/escrow_test.go
@@ -100,6 +100,79 @@ func TestEscrowGetForExecuteEnforcesScope(t *testing.T) {
 	}
 }
 
+func TestEscrowGetForExecuteEnforcesIssuedCapabilityBinding(t *testing.T) {
+	baseCap := enclave.GrantCapability{
+		GrantID:        "grant-1",
+		UserID:         "user-1",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "oauth2",
+		ActionType:     "email.send",
+		Nonce:          "nonce-1",
+	}
+	s := mustNewEscrowStore(t)
+	id := s.Store(enclave.EscrowStoreRequest{
+		IssuedCapability: &enclave.SignedGrantCapability{Capability: baseCap, Signature: "sig"},
+	}, []byte("scoped-cred"), time.Now().Add(time.Hour))
+
+	valid := enclave.ExecuteRequest{
+		EscrowID:       id,
+		GrantID:        "grant-1",
+		UserID:         "user-1",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "oauth2",
+		ActionType:     "email.send",
+	}
+	if _, err := s.GetForExecute(valid); err != nil {
+		t.Fatalf("GetForExecute valid issued scope: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*enclave.ExecuteRequest)
+	}{
+		{"grant", func(r *enclave.ExecuteRequest) { r.GrantID = "grant-2" }},
+		{"user", func(r *enclave.ExecuteRequest) { r.UserID = "user-2" }},
+		{"vault", func(r *enclave.ExecuteRequest) { r.VaultPath = "connected-accounts/user-2/gmail" }},
+		{"provider", func(r *enclave.ExecuteRequest) { r.Provider = "drive" }},
+		{"credential type", func(r *enclave.ExecuteRequest) { r.CredentialType = "api_key" }},
+		{"action", func(r *enclave.ExecuteRequest) { r.ActionType = "email.delete" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := valid
+			tt.mutate(&candidate)
+			_, err := s.GetForExecute(candidate)
+			if err != enclave.ErrEscrowScopeMismatch {
+				t.Fatalf("expected ErrEscrowScopeMismatch, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEscrowGetForExecuteEnforcesIssuedCapabilityActionTypes(t *testing.T) {
+	s := mustNewEscrowStore(t)
+	id := s.Store(enclave.EscrowStoreRequest{
+		IssuedCapability: &enclave.SignedGrantCapability{
+			Capability: enclave.GrantCapability{
+				ActionTypes: []string{"email.send", "email.archive"},
+				Nonce:       "nonce-1",
+			},
+			Signature: "sig",
+		},
+	}, []byte("scoped-cred"), time.Now().Add(time.Hour))
+
+	valid := enclave.ExecuteRequest{EscrowID: id, ActionType: "email.archive"}
+	if _, err := s.GetForExecute(valid); err != nil {
+		t.Fatalf("GetForExecute valid action type: %v", err)
+	}
+	invalid := enclave.ExecuteRequest{EscrowID: id, ActionType: "email.delete"}
+	if _, err := s.GetForExecute(invalid); err != enclave.ErrEscrowScopeMismatch {
+		t.Fatalf("expected ErrEscrowScopeMismatch, got %v", err)
+	}
+}
+
 func TestEscrowGetForSourceEnforcesScope(t *testing.T) {
 	s := mustNewEscrowStore(t)
 	req := testEscrowRequest("grant-1", "oauth2", nil)
@@ -137,6 +210,73 @@ func TestEscrowGetForSourceEnforcesScope(t *testing.T) {
 				t.Fatalf("expected ErrEscrowScopeMismatch, got %v", err)
 			}
 		})
+	}
+}
+
+func TestEscrowGetForSourceEnforcesIssuedCapabilityBinding(t *testing.T) {
+	baseCap := enclave.GrantCapability{
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "gmail_search",
+		Nonce:     "nonce-1",
+	}
+	s := mustNewEscrowStore(t)
+	id := s.Store(enclave.EscrowStoreRequest{
+		IssuedCapability: &enclave.SignedGrantCapability{Capability: baseCap, Signature: "sig"},
+	}, []byte("token"), time.Now().Add(time.Hour))
+
+	valid := enclave.SourceExecuteRequest{
+		EscrowID:  id,
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "gmail_search",
+	}
+	if _, err := s.GetForSource(valid); err != nil {
+		t.Fatalf("GetForSource valid issued scope: %v", err)
+	}
+
+	tests := []struct {
+		name   string
+		mutate func(*enclave.SourceExecuteRequest)
+	}{
+		{"user", func(r *enclave.SourceExecuteRequest) { r.UserID = "user-2" }},
+		{"vault", func(r *enclave.SourceExecuteRequest) { r.VaultPath = "connected-accounts/user-2/gmail" }},
+		{"provider", func(r *enclave.SourceExecuteRequest) { r.Provider = "drive" }},
+		{"tool", func(r *enclave.SourceExecuteRequest) { r.Tool = "gmail_delete" }},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			candidate := valid
+			tt.mutate(&candidate)
+			_, err := s.GetForSource(candidate)
+			if err != enclave.ErrEscrowScopeMismatch {
+				t.Fatalf("expected ErrEscrowScopeMismatch, got %v", err)
+			}
+		})
+	}
+}
+
+func TestEscrowGetForSourceEnforcesIssuedCapabilitySourceTools(t *testing.T) {
+	s := mustNewEscrowStore(t)
+	id := s.Store(enclave.EscrowStoreRequest{
+		IssuedCapability: &enclave.SignedGrantCapability{
+			Capability: enclave.GrantCapability{
+				SourceTools: []string{"gmail_search", "gmail_threads"},
+				Nonce:       "nonce-1",
+			},
+			Signature: "sig",
+		},
+	}, []byte("token"), time.Now().Add(time.Hour))
+
+	valid := enclave.SourceExecuteRequest{EscrowID: id, Tool: "gmail_threads"}
+	if _, err := s.GetForSource(valid); err != nil {
+		t.Fatalf("GetForSource valid source tool: %v", err)
+	}
+	invalid := enclave.SourceExecuteRequest{EscrowID: id, Tool: "gmail_delete"}
+	if _, err := s.GetForSource(invalid); err != enclave.ErrEscrowScopeMismatch {
+		t.Fatalf("expected ErrEscrowScopeMismatch, got %v", err)
 	}
 }
 

--- a/cmd/aileron-enclave/server.go
+++ b/cmd/aileron-enclave/server.go
@@ -28,19 +28,21 @@ const (
 )
 
 type enclaveServer struct {
-	log            *slog.Logger
-	registry       *connector.Registry
-	sourceRegistry *source.Registry
-	provider       string
-	mu             sync.Mutex
-	enclaveKey     *ecdh.PrivateKey
-	sessionKey     []byte
-	requestAuthKey []byte
-	sessionID      string
-	expiresAt      time.Time
-	seenNonces     map[string]time.Time
-	keks           *kekStore
-	escrow         *escrowStore
+	log                   *slog.Logger
+	registry              *connector.Registry
+	sourceRegistry        *source.Registry
+	provider              string
+	mu                    sync.Mutex
+	enclaveKey            *ecdh.PrivateKey
+	sessionKey            []byte
+	requestAuthKey        []byte
+	grantCapabilityKey    []byte
+	sessionID             string
+	expiresAt             time.Time
+	seenNonces            map[string]time.Time
+	usedGrantCapabilities map[string]time.Time
+	keks                  *kekStore
+	escrow                *escrowStore
 }
 
 func newEnclaveServer(log *slog.Logger, registry *connector.Registry, sourceReg *source.Registry, provider, dataDir string) (*enclaveServer, error) {
@@ -49,13 +51,14 @@ func newEnclaveServer(log *slog.Logger, registry *connector.Registry, sourceReg 
 		return nil, fmt.Errorf("initializing escrow store: %w", err)
 	}
 	return &enclaveServer{
-		log:            log,
-		registry:       registry,
-		sourceRegistry: sourceReg,
-		provider:       provider,
-		seenNonces:     make(map[string]time.Time),
-		keks:           newKEKStore(),
-		escrow:         escrow,
+		log:                   log,
+		registry:              registry,
+		sourceRegistry:        sourceReg,
+		provider:              provider,
+		seenNonces:            make(map[string]time.Time),
+		usedGrantCapabilities: make(map[string]time.Time),
+		keks:                  newKEKStore(),
+		escrow:                escrow,
 	}, nil
 }
 
@@ -152,21 +155,33 @@ func (s *enclaveServer) handleSession(w http.ResponseWriter, r *http.Request) {
 		writeErr(w, http.StatusInternalServerError, "generating request auth key")
 		return
 	}
+	grantCapabilityKey := copyBytes(req.GrantCapabilityKey)
+	if len(grantCapabilityKey) == 0 {
+		grantCapabilityKey = make([]byte, requestAuthNonceBytes)
+		if _, err := rand.Read(grantCapabilityKey); err != nil {
+			writeErr(w, http.StatusInternalServerError, "generating grant capability key")
+			return
+		}
+	}
 
 	// Zero previous session material only after the new session is ready.
 	zeroBytes(s.sessionKey)
 	zeroBytes(s.requestAuthKey)
+	zeroBytes(s.grantCapabilityKey)
 
 	s.sessionKey = h[:]
 	s.requestAuthKey = requestAuthKey
+	s.grantCapabilityKey = grantCapabilityKey
 	s.expiresAt = time.Now().Add(enclaveSessionTTL)
 	s.sessionID = hex.EncodeToString(b)
 	clear(s.seenNonces)
+	clear(s.usedGrantCapabilities)
 
 	writeJSON(w, http.StatusOK, enclave.SessionResponse{
-		SessionID:      s.sessionID,
-		ExpiresAt:      s.expiresAt.Format(time.RFC3339),
-		RequestAuthKey: copyBytes(s.requestAuthKey),
+		SessionID:          s.sessionID,
+		ExpiresAt:          s.expiresAt.Format(time.RFC3339),
+		RequestAuthKey:     copyBytes(s.requestAuthKey),
+		GrantCapabilityKey: copyBytes(s.grantCapabilityKey),
 	})
 }
 
@@ -266,6 +281,10 @@ func (s *enclaveServer) handleExecute(w http.ResponseWriter, r *http.Request) {
 	defer zeroBytes(authKey)
 	if !enclave.VerifyExecuteCapability(authKey, req) {
 		writeErr(w, http.StatusForbidden, "invalid grant capability")
+		return
+	}
+	if err := s.verifyIssuedExecuteCapability(req); err != nil {
+		writeErr(w, http.StatusForbidden, err.Error())
 		return
 	}
 
@@ -372,6 +391,15 @@ func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request
 		writeErr(w, http.StatusBadRequest, "credential_type required")
 		return
 	}
+	expiresAt, err := time.Parse(time.RFC3339, req.ExpiresAt)
+	if err != nil {
+		writeErr(w, http.StatusBadRequest, "invalid expires_at: "+err.Error())
+		return
+	}
+	if err := s.verifyIssuedEscrowCapability(req); err != nil {
+		writeErr(w, http.StatusForbidden, err.Error())
+		return
+	}
 
 	// Decrypt credential with user's KEK.
 	kek, err := s.keks.Get(req.UserID)
@@ -384,13 +412,6 @@ func (s *enclaveServer) handleEscrowStore(w http.ResponseWriter, r *http.Request
 	zeroBytes(kek)
 	if err != nil {
 		writeErr(w, http.StatusBadRequest, "decryption failed: "+err.Error())
-		return
-	}
-
-	expiresAt, err := time.Parse(time.RFC3339, req.ExpiresAt)
-	if err != nil {
-		zeroBytes(plaintext)
-		writeErr(w, http.StatusBadRequest, "invalid expires_at: "+err.Error())
 		return
 	}
 
@@ -490,6 +511,85 @@ func (s *enclaveServer) handleHealth(w http.ResponseWriter, _ *http.Request) {
 		"provider":       s.provider,
 		"session_active": hasSession,
 	})
+}
+
+func (s *enclaveServer) verifyIssuedEscrowCapability(req enclave.EscrowStoreRequest) error {
+	if req.IssuedCapability == nil {
+		return fmt.Errorf("missing issued grant capability")
+	}
+	key := s.grantSigningKey()
+	defer zeroBytes(key)
+	if len(key) == 0 {
+		return fmt.Errorf("grant capability signing key unavailable")
+	}
+	expected := enclave.EscrowStoreGrantCapability(req, req.IssuedCapability.Capability.Nonce)
+	if !enclave.VerifySignedGrantCapability(key, req.IssuedCapability, expected) {
+		return fmt.Errorf("invalid issued grant capability")
+	}
+	return verifyCapabilityExpiry(req.IssuedCapability)
+}
+
+func (s *enclaveServer) verifyIssuedExecuteCapability(req enclave.ExecuteRequest) error {
+	if req.IssuedCapability == nil {
+		return fmt.Errorf("missing issued grant capability")
+	}
+	key := s.grantSigningKey()
+	defer zeroBytes(key)
+	if len(key) == 0 {
+		return fmt.Errorf("grant capability signing key unavailable")
+	}
+	expected := enclave.IssuedExecuteGrantCapability(req, req.IssuedCapability.Capability.Nonce, req.IssuedCapability.Capability.ExpiresAt)
+	if !enclave.VerifySignedGrantCapability(key, req.IssuedCapability, expected) {
+		return fmt.Errorf("invalid issued grant capability")
+	}
+	if err := verifyCapabilityExpiry(req.IssuedCapability); err != nil {
+		return err
+	}
+	if !s.consumeIssuedCapability(req.IssuedCapability) {
+		return fmt.Errorf("replayed issued grant capability")
+	}
+	return nil
+}
+
+func (s *enclaveServer) grantSigningKey() []byte {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return copyBytes(s.grantCapabilityKey)
+}
+
+func (s *enclaveServer) consumeIssuedCapability(capability *enclave.SignedGrantCapability) bool {
+	key := capabilityReplayKey(capability)
+	now := time.Now()
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	pruneSeenNonces(s.usedGrantCapabilities, now.Add(-enclaveSessionTTL))
+	if _, ok := s.usedGrantCapabilities[key]; ok {
+		return false
+	}
+	s.usedGrantCapabilities[key] = now
+	return true
+}
+
+func capabilityReplayKey(capability *enclave.SignedGrantCapability) string {
+	if capability == nil {
+		return ""
+	}
+	return capability.Signature
+}
+
+func verifyCapabilityExpiry(capability *enclave.SignedGrantCapability) error {
+	expiresAt := capability.Capability.ExpiresAt
+	if expiresAt == "" {
+		return fmt.Errorf("issued grant capability has no expiry")
+	}
+	expiry, err := time.Parse(time.RFC3339, expiresAt)
+	if err != nil {
+		return fmt.Errorf("invalid issued grant capability expiry")
+	}
+	if !time.Now().Before(expiry) {
+		return fmt.Errorf("expired issued grant capability")
+	}
+	return nil
 }
 
 func (s *enclaveServer) decodeAuthenticatedJSON(w http.ResponseWriter, r *http.Request, v any) ([]byte, error) {

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -26,6 +26,7 @@ import (
 type testSessionAuth struct {
 	sessionID string
 	authKey   []byte
+	grantKey  []byte
 }
 
 var testSessions sync.Map
@@ -180,6 +181,13 @@ func attachTestCapability(t *testing.T, path string, body any, sess testSessionA
 			t.Fatalf("signing execute capability: %v", err)
 		}
 		req.Capability = capability
+		if req.IssuedCapability == nil {
+			issued, err := enclave.SignGrantCapability(sess.grantKey, enclave.IssuedExecuteGrantCapability(req, nonce+"-issued", time.Now().Add(time.Hour).UTC().Format(time.RFC3339)))
+			if err != nil {
+				t.Fatalf("signing issued execute capability: %v", err)
+			}
+			req.IssuedCapability = issued
+		}
 		return req
 	case enclave.EscrowStoreRequest:
 		capability, err := enclave.SignGrantCapability(sess.authKey, enclave.EscrowStoreGrantCapability(req, nonce))
@@ -187,6 +195,13 @@ func attachTestCapability(t *testing.T, path string, body any, sess testSessionA
 			t.Fatalf("signing escrow capability: %v", err)
 		}
 		req.Capability = capability
+		if req.IssuedCapability == nil {
+			issued, err := enclave.SignGrantCapability(sess.grantKey, enclave.EscrowStoreGrantCapability(req, nonce+"-issued"))
+			if err != nil {
+				t.Fatalf("signing issued escrow capability: %v", err)
+			}
+			req.IssuedCapability = issued
+		}
 		return req
 	case enclave.SourceExecuteRequest:
 		capability, err := enclave.SignGrantCapability(sess.authKey, enclave.SourceExecuteGrantCapability(req, nonce))
@@ -198,6 +213,60 @@ func attachTestCapability(t *testing.T, path string, body any, sess testSessionA
 	default:
 		return body
 	}
+}
+
+func attachTestRequestCapabilityOnly(t *testing.T, body any, sess testSessionAuth) any {
+	t.Helper()
+	nonceBytes := make([]byte, 16)
+	if _, err := rand.Read(nonceBytes); err != nil {
+		t.Fatalf("generating capability nonce: %v", err)
+	}
+	nonce := hex.EncodeToString(nonceBytes)
+	switch req := body.(type) {
+	case enclave.ExecuteRequest:
+		capability, err := enclave.SignGrantCapability(sess.authKey, enclave.ExecuteGrantCapability(req, nonce))
+		if err != nil {
+			t.Fatalf("signing execute capability: %v", err)
+		}
+		req.Capability = capability
+		return req
+	case enclave.EscrowStoreRequest:
+		capability, err := enclave.SignGrantCapability(sess.authKey, enclave.EscrowStoreGrantCapability(req, nonce))
+		if err != nil {
+			t.Fatalf("signing escrow capability: %v", err)
+		}
+		req.Capability = capability
+		return req
+	default:
+		return body
+	}
+}
+
+func testSession(t *testing.T, server *httptest.Server) testSessionAuth {
+	t.Helper()
+	sessAny, ok := testSessions.Load(server.URL)
+	if !ok {
+		t.Fatal("test session not established")
+	}
+	return sessAny.(testSessionAuth)
+}
+
+func signIssuedExecuteCapability(t *testing.T, sess testSessionAuth, req enclave.ExecuteRequest, expiresAt time.Time) *enclave.SignedGrantCapability {
+	t.Helper()
+	capability, err := enclave.SignGrantCapability(sess.grantKey, enclave.IssuedExecuteGrantCapability(req, "issued-"+req.RequestID, expiresAt.UTC().Format(time.RFC3339)))
+	if err != nil {
+		t.Fatalf("signing issued execute capability: %v", err)
+	}
+	return capability
+}
+
+func signIssuedEscrowCapability(t *testing.T, sess testSessionAuth, req enclave.EscrowStoreRequest) *enclave.SignedGrantCapability {
+	t.Helper()
+	capability, err := enclave.SignGrantCapability(sess.grantKey, enclave.EscrowStoreGrantCapability(req, "issued-"+req.GrantID))
+	if err != nil {
+		t.Fatalf("signing issued escrow capability: %v", err)
+	}
+	return capability
 }
 
 func signedTestRequest(t *testing.T, server *httptest.Server, path string, body []byte, sess testSessionAuth) *http.Request {
@@ -273,9 +342,13 @@ func establishTestSession(t *testing.T, server *httptest.Server) []byte {
 	if len(sessResult.RequestAuthKey) == 0 {
 		t.Fatal("empty request auth key")
 	}
+	if len(sessResult.GrantCapabilityKey) == 0 {
+		t.Fatal("empty grant capability key")
+	}
 	testSessions.Store(server.URL, testSessionAuth{
 		sessionID: sessResult.SessionID,
 		authKey:   sessResult.RequestAuthKey,
+		grantKey:  sessResult.GrantCapabilityKey,
 	})
 	t.Cleanup(func() {
 		testSessions.Delete(server.URL)
@@ -357,6 +430,129 @@ func TestFullExecuteFlow(t *testing.T) {
 	}
 	if execResult.ReceiptRef != "test-receipt" {
 		t.Fatalf("expected test-receipt, got %q", execResult.ReceiptRef)
+	}
+}
+
+func TestExecuteRequiresIssuedCapability(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	encrypted, _ := crypto.Encrypt([]byte("cred"), userKEK)
+	req := enclave.ExecuteRequest{
+		RequestID:           "exec-missing-issued",
+		UserID:              "user-1",
+		GrantID:             "grant-1",
+		ActionType:          "test.action",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: encrypted,
+		CredentialType:      "api_key",
+	}
+	req = attachTestRequestCapabilityOnly(t, req, testSession(t, server)).(enclave.ExecuteRequest)
+
+	resp := postRaw(t, server, "/execute", mustJSON(t, req), true)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for missing issued capability, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestExecuteRejectsIssuedCapabilityScopeMismatch(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	encrypted, _ := crypto.Encrypt([]byte("cred"), userKEK)
+	req := enclave.ExecuteRequest{
+		RequestID:           "exec-scope-mismatch",
+		UserID:              "user-1",
+		GrantID:             "grant-1",
+		ActionType:          "test.action",
+		ConnectorID:         "test/stub",
+		VaultPath:           "connected-accounts/user-1/gmail",
+		Provider:            "gmail",
+		EncryptedCredential: encrypted,
+		CredentialType:      "api_key",
+	}
+	issuedReq := req
+	issuedReq.Provider = "drive"
+	req.IssuedCapability = signIssuedExecuteCapability(t, testSession(t, server), issuedReq, time.Now().Add(time.Hour))
+
+	resp := postJSON(t, server, "/execute", req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for issued capability scope mismatch, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestExecuteRejectsReplayedIssuedCapability(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	encrypted, _ := crypto.Encrypt([]byte("cred"), userKEK)
+	req := enclave.ExecuteRequest{
+		RequestID:           "exec-replay",
+		UserID:              "user-1",
+		GrantID:             "grant-1",
+		ActionType:          "test.action",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: encrypted,
+		CredentialType:      "api_key",
+	}
+	req.IssuedCapability = signIssuedExecuteCapability(t, testSession(t, server), req, time.Now().Add(time.Hour))
+
+	resp := postJSON(t, server, "/execute", req)
+	result := decodeResp[enclave.ExecuteResponse](t, resp)
+	if result.Status != "succeeded" {
+		t.Fatalf("expected first execution succeeded, got %q", result.Status)
+	}
+
+	resp = postJSON(t, server, "/execute", req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for replayed issued capability, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestVerifyCapabilityExpiryRejectsMissingAndInvalidExpiry(t *testing.T) {
+	tests := []struct {
+		name       string
+		capability *enclave.SignedGrantCapability
+	}{
+		{
+			name:       "missing",
+			capability: &enclave.SignedGrantCapability{Capability: enclave.GrantCapability{Nonce: "nonce"}, Signature: "sig"},
+		},
+		{
+			name:       "invalid",
+			capability: &enclave.SignedGrantCapability{Capability: enclave.GrantCapability{Nonce: "nonce", ExpiresAt: "not-a-date"}, Signature: "sig"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if err := verifyCapabilityExpiry(tt.capability); err == nil {
+				t.Fatal("expected expiry validation error")
+			}
+		})
+	}
+}
+
+func TestCapabilityReplayKeyHandlesNil(t *testing.T) {
+	if got := capabilityReplayKey(nil); got != "" {
+		t.Fatalf("expected empty replay key for nil capability, got %q", got)
 	}
 }
 
@@ -474,6 +670,28 @@ func TestEscrowFlow(t *testing.T) {
 	execResp2.Body.Close()
 }
 
+func TestEscrowStoreRejectsIssuedCapabilityScopeMismatch(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	encrypted, _ := crypto.Encrypt([]byte("escrowed-cred"), userKEK)
+	req := validEscrowStoreRequest(encrypted)
+	issuedReq := req
+	issuedReq.VaultPath = "connected-accounts/user-1/drive"
+	req.IssuedCapability = signIssuedEscrowCapability(t, testSession(t, server), issuedReq)
+
+	resp := postJSON(t, server, "/escrow", req)
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for escrow issued capability scope mismatch, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
 func TestExecuteWithEscrowRejectsScopeMismatch(t *testing.T) {
 	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
@@ -529,8 +747,10 @@ func TestSessionEndpoint(t *testing.T) {
 	postJSON(t, server, "/attest", enclave.AttestationRequest{Nonce: []byte("n"), Audience: "a"})
 
 	hostKey, _ := ecdh.P256().GenerateKey(rand.Reader)
+	grantKey := []byte("01234567890123456789012345678901")
 	resp := postJSON(t, server, "/session", enclave.SessionRequest{
-		PublicKey: hostKey.PublicKey().Bytes(),
+		PublicKey:          hostKey.PublicKey().Bytes(),
+		GrantCapabilityKey: grantKey,
 	})
 	result := decodeResp[enclave.SessionResponse](t, resp)
 	if result.SessionID == "" {
@@ -538,6 +758,12 @@ func TestSessionEndpoint(t *testing.T) {
 	}
 	if result.ExpiresAt == "" {
 		t.Fatal("empty expires_at")
+	}
+	if len(result.GrantCapabilityKey) == 0 {
+		t.Fatal("empty grant capability key")
+	}
+	if !bytes.Equal(result.GrantCapabilityKey, grantKey) {
+		t.Fatal("expected enclave to use provided grant capability key")
 	}
 }
 
@@ -588,6 +814,8 @@ func TestEscrowStoreWithoutKEK(t *testing.T) {
 		VaultPath:      "connected-accounts/no-kek-user/gmail",
 		Provider:       "gmail",
 		CredentialType: "api_key",
+		ExpiresAt:      time.Now().Add(time.Hour).Format(time.RFC3339),
+		ActionTypes:    []string{"test.action"},
 	})
 	if resp.StatusCode != http.StatusPreconditionFailed {
 		t.Fatalf("expected 412, got %d", resp.StatusCode)
@@ -777,7 +1005,7 @@ func TestEscrowRevokeBadJSON(t *testing.T) {
 }
 
 func TestExecuteWithExpiredEscrow(t *testing.T) {
-	server, srv := setupTestEnclaveServer(t)
+	server, _ := setupTestEnclaveServer(t)
 	defer server.Close()
 
 	sessionKey := establishTestSession(t, server)
@@ -792,24 +1020,10 @@ func TestExecuteWithExpiredEscrow(t *testing.T) {
 	expiredReq.GrantID = "g1"
 	expiredReq.ExpiresAt = time.Now().Add(-time.Second).Format(time.RFC3339)
 	storeResp := postJSON(t, server, "/escrow", expiredReq)
-	storeResult := decodeResp[enclave.EscrowStoreResponse](t, storeResp)
-
-	// Execute with expired escrow.
-	_ = srv // keep reference
-	execResp := postJSON(t, server, "/execute", enclave.ExecuteRequest{
-		UserID:         "user-1",
-		GrantID:        "g1",
-		ActionType:     "test.action",
-		ConnectorID:    "test/stub",
-		VaultPath:      "connected-accounts/user-1/gmail",
-		Provider:       "gmail",
-		CredentialType: "api_key",
-		EscrowID:       storeResult.EscrowID,
-	})
-	if execResp.StatusCode != http.StatusNotFound {
-		t.Fatalf("expected 404 for expired escrow, got %d", execResp.StatusCode)
+	if storeResp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for expired issued capability, got %d", storeResp.StatusCode)
 	}
-	execResp.Body.Close()
+	storeResp.Body.Close()
 }
 
 func TestTransmitKEKEndpoint(t *testing.T) {

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -800,6 +800,7 @@ func (s *apiServer) RunExecution(w http.ResponseWriter, r *http.Request) {
 		if issuedCapability != nil {
 			applyIssuedCapabilityToExecuteRequest(&execReq, issuedCapability.Capability)
 			execReq.Capability = issuedCapability
+			execReq.IssuedCapability = issuedCapability
 		}
 		// If credential is escrowed in TEE memory, use the escrow ID
 		// instead of sending the encrypted credential. This allows
@@ -1201,6 +1202,7 @@ func (s *apiServer) executeGrant(ctx context.Context, grantID, userID string) (*
 		if issuedCapability != nil {
 			applyIssuedCapabilityToExecuteRequest(&execReq, issuedCapability.Capability)
 			execReq.Capability = issuedCapability
+			execReq.IssuedCapability = issuedCapability
 		}
 		if escrowID, ok := s.escrowIndex.Load(vaultPath); ok {
 			execReq.EscrowID = escrowID.(string)

--- a/internal/app/handlers_execution_test.go
+++ b/internal/app/handlers_execution_test.go
@@ -191,6 +191,9 @@ func TestRunExecution_TEEMode_Success(t *testing.T) {
 	if enclaveClient.execute.Capability == nil {
 		t.Fatal("expected issued capability to be forwarded to enclave client")
 	}
+	if enclaveClient.execute.IssuedCapability == nil {
+		t.Fatal("expected durable issued capability to be forwarded to enclave client")
+	}
 	if enclaveClient.execute.GrantID != "grant_2" {
 		t.Fatalf("enclave grant ID = %q, want grant_2", enclaveClient.execute.GrantID)
 	}

--- a/internal/app/handlers_tee.go
+++ b/internal/app/handlers_tee.go
@@ -309,7 +309,8 @@ func (s *apiServer) EstablishTeeSession(w http.ResponseWriter, r *http.Request) 
 	// Forward the client's public key to the enclave for ECDH key exchange.
 	// The server never generates its own key pair — it's a pass-through.
 	sessResp, err := s.enclaveClient.EstablishSession(r.Context(), enclave.SessionRequest{
-		PublicKey: req.ClientPublicKey,
+		PublicKey:          req.ClientPublicKey,
+		GrantCapabilityKey: append([]byte(nil), s.grantSigningKey()...),
 	})
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "session_error", err.Error())
@@ -326,6 +327,9 @@ func (s *apiServer) EstablishTeeSession(w http.ResponseWriter, r *http.Request) 
 	if transmitErr != nil {
 		writeError(w, http.StatusInternalServerError, "kek_error", "failed to transmit KEK to enclave: "+transmitErr.Error())
 		return
+	}
+	if len(sessResp.GrantCapabilityKey) > 0 {
+		s.grantCapabilityKey = append(s.grantCapabilityKey[:0], sessResp.GrantCapabilityKey...)
 	}
 
 	// Parse expiry.
@@ -380,8 +384,7 @@ func (s *apiServer) autoEscrowCredentials(ctx context.Context, userID string) in
 
 		expiresAt := time.Now().Add(s.escrowTTL)
 		grantID := "auto-escrow-" + acc.ID
-
-		resp, err := s.enclaveClient.EscrowStore(ctx, enclave.EscrowStoreRequest{
+		req := enclave.EscrowStoreRequest{
 			UserID:              userID,
 			GrantID:             grantID,
 			VaultPath:           acc.VaultPath(),
@@ -391,7 +394,14 @@ func (s *apiServer) autoEscrowCredentials(ctx context.Context, userID string) in
 			ExpiresAt:           expiresAt.Format(time.RFC3339),
 			ActionTypes:         actionTypesForProvider(acc.Provider),
 			SourceTools:         sourceToolsForProvider(s.sourceRegistry, acc.Provider),
-		})
+		}
+		capability, err := s.signIssuedGrantCapability(enclave.EscrowStoreGrantCapability(req, randomCapabilityNonce()))
+		if err != nil {
+			continue
+		}
+		req.IssuedCapability = capability
+
+		resp, err := s.enclaveClient.EscrowStore(ctx, req)
 		if err != nil {
 			continue
 		}

--- a/internal/app/handlers_tee_test.go
+++ b/internal/app/handlers_tee_test.go
@@ -669,6 +669,9 @@ func TestEstablishTeeSession_AutoEscrows(t *testing.T) {
 		}
 		t.Fatalf("expected escrowed_count=1, got %d", escrowed)
 	}
+	if len(srv.grantCapabilityKey) == 0 {
+		t.Fatal("expected TEE session grant capability key to be stored")
+	}
 }
 
 func TestInitiateAttestationBadJSON(t *testing.T) {

--- a/internal/enclave/capability.go
+++ b/internal/enclave/capability.go
@@ -86,6 +86,12 @@ func ExecuteGrantCapability(req ExecuteRequest, nonce string) GrantCapability {
 	}
 }
 
+func IssuedExecuteGrantCapability(req ExecuteRequest, nonce, expiresAt string) GrantCapability {
+	capability := ExecuteGrantCapability(req, nonce)
+	capability.ExpiresAt = expiresAt
+	return capability
+}
+
 func EscrowStoreGrantCapability(req EscrowStoreRequest, nonce string) GrantCapability {
 	return GrantCapability{
 		GrantID:        req.GrantID,
@@ -99,6 +105,14 @@ func EscrowStoreGrantCapability(req EscrowStoreRequest, nonce string) GrantCapab
 		ExpiresAt:      req.ExpiresAt,
 		Nonce:          nonce,
 	}
+}
+
+func IssuedSourceExecuteGrantCapability(req SourceExecuteRequest, nonce, grantID, expiresAt, credentialType string) GrantCapability {
+	capability := SourceExecuteGrantCapability(req, nonce)
+	capability.GrantID = grantID
+	capability.CredentialType = credentialType
+	capability.ExpiresAt = expiresAt
+	return capability
 }
 
 func SourceExecuteGrantCapability(req SourceExecuteRequest, nonce string) GrantCapability {

--- a/internal/enclave/capability_test.go
+++ b/internal/enclave/capability_test.go
@@ -87,6 +87,46 @@ func TestSourceExecuteCapabilityVerifiesBoundFields(t *testing.T) {
 	}
 }
 
+func TestIssuedExecuteGrantCapabilityBindsExpiry(t *testing.T) {
+	req := ExecuteRequest{
+		GrantID:        "grant-1",
+		IntentID:       "intent-1",
+		UserID:         "user-1",
+		VaultPath:      "connected-accounts/user-1/gmail",
+		Provider:       "gmail",
+		CredentialType: "oauth2",
+		ActionType:     "email.send",
+		Parameters:     map[string]any{"to": "a@example.com"},
+	}
+	capability := IssuedExecuteGrantCapability(req, "nonce-1", "2026-04-26T09:00:00Z")
+	if capability.ExpiresAt != "2026-04-26T09:00:00Z" {
+		t.Fatalf("expires_at = %q", capability.ExpiresAt)
+	}
+	if capability.GrantID != req.GrantID || capability.ActionType != req.ActionType {
+		t.Fatalf("issued execute capability did not bind request scope: %#v", capability)
+	}
+}
+
+func TestIssuedSourceExecuteGrantCapabilityBindsGrantAndExpiry(t *testing.T) {
+	req := SourceExecuteRequest{
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "gmail_search",
+		Params:    map[string]any{"query": "from:a@example.com"},
+	}
+	capability := IssuedSourceExecuteGrantCapability(req, "nonce-1", "grant-1", "2026-04-26T09:00:00Z", "oauth2")
+	if capability.GrantID != "grant-1" {
+		t.Fatalf("grant_id = %q", capability.GrantID)
+	}
+	if capability.CredentialType != "oauth2" {
+		t.Fatalf("credential_type = %q", capability.CredentialType)
+	}
+	if capability.ExpiresAt != "2026-04-26T09:00:00Z" {
+		t.Fatalf("expires_at = %q", capability.ExpiresAt)
+	}
+}
+
 func TestGrantCapabilityRejectsMissingSignature(t *testing.T) {
 	req := ExecuteRequest{
 		GrantID:    "grant-1",

--- a/internal/enclave/gcs/client_test.go
+++ b/internal/enclave/gcs/client_test.go
@@ -179,16 +179,21 @@ func TestRequiresRequestAuth(t *testing.T) {
 
 func TestAttachGrantCapability(t *testing.T) {
 	authKey := []byte("01234567890123456789012345678901")
+	issuedCapability := &enclave.SignedGrantCapability{
+		Capability: enclave.GrantCapability{GrantID: "grant-1", Nonce: "issued-nonce"},
+		Signature:  "issued-signature",
+	}
 
 	execute, err := attachGrantCapability(enclave.ExecuteRequest{
-		GrantID:        "grant-1",
-		IntentID:       "intent-1",
-		UserID:         "user-1",
-		VaultPath:      "connected-accounts/user-1/gmail",
-		Provider:       "gmail",
-		CredentialType: "oauth2",
-		ActionType:     "email.send",
-		Parameters:     map[string]any{"to": "a@example.com"},
+		GrantID:          "grant-1",
+		IntentID:         "intent-1",
+		UserID:           "user-1",
+		VaultPath:        "connected-accounts/user-1/gmail",
+		Provider:         "gmail",
+		CredentialType:   "oauth2",
+		ActionType:       "email.send",
+		Parameters:       map[string]any{"to": "a@example.com"},
+		IssuedCapability: issuedCapability,
 	}, authKey)
 	if err != nil {
 		t.Fatalf("attach execute capability: %v", err)
@@ -196,6 +201,9 @@ func TestAttachGrantCapability(t *testing.T) {
 	executeReq := execute.(enclave.ExecuteRequest)
 	if !enclave.VerifyExecuteCapability(authKey, executeReq) {
 		t.Fatal("expected execute capability to verify")
+	}
+	if executeReq.IssuedCapability != issuedCapability {
+		t.Fatal("expected issued capability to be preserved")
 	}
 
 	escrow, err := attachGrantCapability(enclave.EscrowStoreRequest{

--- a/internal/enclave/local/client.go
+++ b/internal/enclave/local/client.go
@@ -123,6 +123,10 @@ func (c *Client) EstablishSession(_ context.Context, req enclave.SessionRequest)
 	zeroBytes(c.sessionKey)
 
 	c.sessionKey = h[:]
+	grantCapabilityKey := copyBytes(req.GrantCapabilityKey)
+	if len(grantCapabilityKey) == 0 {
+		grantCapabilityKey = copyBytes(c.sessionKey)
+	}
 	c.expiresAt = time.Now().Add(c.sessionTTL)
 
 	b := make([]byte, 16)
@@ -130,8 +134,9 @@ func (c *Client) EstablishSession(_ context.Context, req enclave.SessionRequest)
 	c.sessionID = hex.EncodeToString(b)
 
 	return enclave.SessionResponse{
-		SessionID: c.sessionID,
-		ExpiresAt: c.expiresAt.Format(time.RFC3339),
+		SessionID:          c.sessionID,
+		ExpiresAt:          c.expiresAt.Format(time.RFC3339),
+		GrantCapabilityKey: grantCapabilityKey,
 	}, nil
 }
 

--- a/internal/enclave/protocol.go
+++ b/internal/enclave/protocol.go
@@ -101,8 +101,11 @@ type ExecuteRequest struct {
 	// instead of EncryptedCredential.
 	EscrowID string `json:"escrow_id,omitempty"`
 	// Capability is a signed, scoped grant envelope the enclave verifies
-	// before using credentials for this operation.
+	// for request authentication before using credentials for this operation.
 	Capability *SignedGrantCapability `json:"capability,omitempty"`
+	// IssuedCapability is the durable grant capability issued by the control
+	// plane and independently verified by the enclave.
+	IssuedCapability *SignedGrantCapability `json:"issued_capability,omitempty"`
 }
 
 // ExecuteResponse is returned by the enclave after connector execution.
@@ -137,14 +140,18 @@ type AttestationResponse struct {
 type SessionRequest struct {
 	// PublicKey is the host's ephemeral P-256 ECDH public key.
 	PublicKey []byte `json:"public_key"`
+	// GrantCapabilityKey is the HMAC key used to verify durable issued grant
+	// capabilities inside the enclave.
+	GrantCapabilityKey []byte `json:"grant_capability_key,omitempty"`
 }
 
 // SessionResponse confirms that the session is established and credentials
 // can be transmitted.
 type SessionResponse struct {
-	SessionID      string `json:"session_id"`
-	ExpiresAt      string `json:"expires_at"` // RFC 3339
-	RequestAuthKey []byte `json:"request_auth_key,omitempty"`
+	SessionID          string `json:"session_id"`
+	ExpiresAt          string `json:"expires_at"` // RFC 3339
+	RequestAuthKey     []byte `json:"request_auth_key,omitempty"`
+	GrantCapabilityKey []byte `json:"grant_capability_key,omitempty"`
 }
 
 // HeaderSessionID binds post-attestation enclave requests to the active
@@ -172,6 +179,7 @@ type EscrowStoreRequest struct {
 	SourceTools         []string               `json:"source_tools,omitempty"`
 	AllowedParameters   map[string]any         `json:"allowed_parameters,omitempty"`
 	Capability          *SignedGrantCapability `json:"capability,omitempty"`
+	IssuedCapability    *SignedGrantCapability `json:"issued_capability,omitempty"`
 }
 
 // EscrowStoreResponse confirms that the credential has been escrowed.
@@ -217,8 +225,11 @@ type SourceExecuteRequest struct {
 	// Params are the tool parameters (query, filters, etc.).
 	Params map[string]any `json:"params"`
 	// Capability is a signed, scoped grant envelope the enclave verifies
-	// before using credentials for this operation.
+	// for request authentication before using credentials for this operation.
 	Capability *SignedGrantCapability `json:"capability,omitempty"`
+	// IssuedCapability is the durable grant capability issued by the control
+	// plane and independently verified by the enclave.
+	IssuedCapability *SignedGrantCapability `json:"issued_capability,omitempty"`
 }
 
 // SourceExecuteResponse contains the tool execution results. The credential


### PR DESCRIPTION
## Summary
- add a separate `issued_capability` protocol field so durable grant capabilities survive request-bound session wrapping
- share the grant capability signing key with the enclave during session establishment and verify issued capabilities inside the enclave
- bind escrow entries to their issued capabilities, enforce expiry, and reject execute capability replay/scope mismatch
- add hostile-host coverage for missing, mismatched, expired, and replayed issued capabilities

Refs #326

## Tests
- `go test ./cmd/aileron-enclave ./internal/app ./internal/enclave/...`
- `go test -cover ./cmd/aileron-enclave ./internal/app ./internal/enclave/...`

Focused coverage:
- `cmd/aileron-enclave`: 80.4%
- `internal/enclave`: 87.3%
- `internal/enclave/gcs`: 87.1%
- `internal/enclave/local`: 91.1%

Note: a broader manual package run still shows existing unrelated `cmd/aileron-sh` policy expectation failures; this PR does not touch that package.