### PR TITLE
docs(pivot): sharpen audience and pain articulation (Phase 3)

### DIFF
--- a/docs/src/content/docs/pivot/customer.md
+++ b/docs/src/content/docs/pivot/customer.md
@@ -1,20 +1,56 @@
 ---
 title: "The Customer"
-description: "Who Aileron is for in v1: individual developers using AI coding tools, local-first power users, and indie agent builders"
+description: "Who Aileron is for in v1: four developer personas where Aileron lands in their week, plus an honest cut-list of who isn't a fit yet"
 order: 6
 ---
 
-> **Section:** part of the Pivot strategy. See [Overview](/pivot/overview) for the pitch and [What Your Agent Can Now Do](/pivot/what-your-agent-can-do) for hero use cases that ground the wedge.
+> **Section:** part of the Pivot strategy. See [Overview](/pivot/overview) for the pitch, [The Problem](/pivot/the-problem) for the pains these developers live with, and [What Your Agent Can Now Do](/pivot/what-your-agent-can-do) for hero use cases that ground the wedge.
 
-## Individual developers — productivity that secures itself
+The wedge is the individual developer. Below: four concrete personas where Aileron lands in their week, an honest list of who Aileron isn't for in v1, and a pointer to the separate enterprise treatment.
 
-- AI coding tool users (Claude Code, Cursor, Continue.dev, Copilot) who want their agents to actually finish the work — write the code, ship it, tell the team — instead of stopping at the boundary of "code only."
-- Local-first developers running Ollama, llama.cpp, or MLX, frustrated with the configuration tax and leaving 30–50% of hardware capability unused.
-- Privacy-first power users automating personal workflows where data must not leave the device.
-- Indie agent builders shipping products where per-request token cost is a line item.
+## Productivity that secures itself
+
+### The indie agent builder
+
+Two weeks from launching her side-project agent SaaS. The hard work — model orchestration, prompt design, the user-facing flow — is mostly done. The remaining checklist is the part she didn't sign up for: Slack OAuth, audit logging, "what happens if a user's API key shows up in a trace," approval UX for the destructive actions her agent can take. Every hour on safety infra is an hour not on the product.
+
+> **Where Aileron lands:** she points her agent at `localhost:8721/v1`, installs `slack` and `stripe` connectors from the Hub, drops in a `ship-update` action, and inherits approval flows, credential isolation, and a deterministic execution path she didn't have to write. The launch checklist gets shorter, not longer.
+
+### The AI-coding-tool power user
+
+Lives in Claude Code or Cursor. The agent is great at code; it stops at code. Posting a ship update to Slack, filing a follow-up ticket in Linear, blocking time on the calendar — those happen in five other tabs because the agent can't be trusted to act outside the editor. Productivity hits a wall the moment the work crosses an organizational boundary.
+
+> **Where Aileron lands:** the agent's tool catalog gains `ship-update`, `slack.post`, `linear.create_issue`, `cal.block`. Each executes deterministically, asks for approval where it matters, and finishes the work the editor used to stop short of. The editor stays the same; the seam behind it changes.
+
+### The local-first developer
+
+Runs Ollama, llama.cpp, or MLX heavily. Picked a model. Picked a quantization. Did some benchmarks. Three months later a new chip shipped, the right quantization changed, and the model lineup turned over twice. Hardware is 30–50% underused on average because nobody other than them is doing this tuning work, and they don't have the time to redo it every quarter.
+
+> **Where Aileron lands:** Runtime profiles the hardware, benchmarks engines, picks per-machine. Trivial turns run free locally on whatever engine measured fastest this week. Cloud overflow only when the local quality bar isn't met. They stop being their own ML ops team.
+
+### The privacy-conscious power user
+
+Automating personal workflows where the data must not leave the device — medical reminders, financial review, journal summaries, family calendar. Every available agent product wants to send the data to someone's cloud. They've built the equivalent in a pile of shell scripts because that's the only stack where they trust where the data lives.
+
+> **Where Aileron lands:** actions execute locally with vault-held credentials, the LLM portion routes to local engines first, and "route this through cloud" is opt-in per request — visible, not silent. Their shell-script pile becomes a small, declarative set of action files they can read in five minutes.
 
 The wedge is the individual developer. The expansion is structurally aligned: the same install pattern scales to every system the developer touches, and the same architecture that gives an individual developer their first hero moment also gives an enterprise its first compliance-grade deployment.
 
+---
+
+## Who Aileron isn't for in v1
+
+Being honest about the cut-list is part of being honest about the wedge.
+
+- **Enterprise governance buyers who need turnkey vendor support today.** Federated vault, audit retention beyond cloud limits, signed-connector supply chain at scale, SSO/RBAC, dedicated security review — these matter and the architecture supports them, but they aren't the v1 sell. See [Enterprise — addressed later](/pivot/enterprise-later).
+- **No-code workflow authors.** Aileron is a developer tool. If the right answer is "drag boxes, connect them, click run," the right tools are Zapier, Make, or n8n — not Aileron.
+- **Teams committed to a managed/cloud-only stack.** Aileron's value is local-first by default with cloud overflow. Teams that have decided everything must run as a managed cloud SaaS will find the architecture pulling against them; the fit improves once Aileron Cloud and Aileron Control are in place, but the v1 wedge is local.
+- **Agent framework authors.** Aileron is orthogonal to LangChain, CrewAI, Mastra, AutoGen, Pydantic-AI, and the rest. It sits behind the LLM endpoint, not in the framework layer. Framework authors are potential *users* of Aileron, not competitors with it — they're already solving a different problem.
+
+If you're in one of these groups today, Aileron will likely be relevant later; it just isn't the right tool to reach for in v1.
+
+---
+
 ## Enterprise — addressed in detail later
 
-Compliance, vault federation, audit retention, signed connectors, attested execution — these matter to enterprises and the architecture supports them. They get a dedicated treatment in a separate document. This document is for the developer who needs to feel productive in five minutes.
+Compliance, vault federation, audit retention, signed connectors, attested execution — these matter to enterprises and the architecture supports them. They get a dedicated treatment at [Enterprise — addressed later](/pivot/enterprise-later) and in a separate enterprise document beyond that. This page is for the developer who needs to feel productive in five minutes.

--- a/docs/src/content/docs/pivot/enterprise-later.md
+++ b/docs/src/content/docs/pivot/enterprise-later.md
@@ -1,0 +1,34 @@
+---
+title: "Enterprise — Addressed Later"
+description: "Why enterprise is intentionally out of the v1 developer-facing pitch, and what's preserved architecturally for it"
+order: 9
+---
+
+> **Section:** part of the Pivot strategy. See [The Customer](/pivot/customer) for the v1 wedge, [Aileron Control](/pivot/control) for the governance surface, and [The Business](/pivot/business) for the revenue tiers that productize this.
+
+## Why this isn't in the v1 pitch
+
+The v1 pitch is for the individual developer who can install Aileron in five minutes and feel productive in fifteen. Enterprise concerns — federated vault, audit retention beyond cloud limits, attested execution, signed-connector supply chains, SSO/RBAC, dedicated security review, on-prem deployment, six-figure annual contracts — are real and the architecture supports them. But putting them in the developer-facing pitch dilutes what makes the wedge work: that an indie agent builder, an AI-coding-tool power user, a local-first developer, and a privacy-conscious power user can each install the same Runtime and get something useful in their first hour. Compliance language doesn't help any of those four close the gap.
+
+## What's preserved architecturally for enterprise
+
+The architectural commitments are deliberately designed so the same codebase serves both wedge and enterprise without a rewrite:
+
+- **[The Connector Model](/pivot/architecture/connector-model)** ships sandboxed binaries with publisher signing and content-addressed hashes. The supply-chain story enterprise compliance teams expect is in the manifest by construction.
+- **[The Capability Model](/pivot/architecture/capability-model)** binds connectors to abstract requirements, not vault paths. Federated org-shared credentials slot into the same name-binding model individual developers use.
+- **[Sandboxing](/pivot/architecture/sandboxing)** runs connectors in WASM by default and offers OS-process escalation for ultra-sensitive credentials — the boundary enterprise audit teams will demand for banking, healthcare, and similar domains.
+- **[The User Channel](/pivot/architecture/user-channel)** has approvals on a tamper-resistant out-of-band surface — structurally protected from agent mediation, which no chat-completion-mediated tool layer can match. This is the property regulated industries have been waiting for.
+- **[Failure Handling](/pivot/architecture/failure-handling)** refuses LLM fallback for side-effecting actions at install time. Auditability isn't an opt-in; it's structural.
+- **[Project Portability](/pivot/architecture/project-portability)** lets bindings federate through Aileron Control for service accounts and shared credentials, without changing how action files are written.
+
+In other words: the wedge architecture *is* the enterprise architecture. The difference is what's productized around it (multi-user vault, RBAC, audit retention, on-prem deployment, certified connectors, vendor SLAs), not the load-bearing design.
+
+## Where the enterprise document lives
+
+A dedicated enterprise document — covering compliance frameworks, deployment topology, federation patterns, supply-chain assurance, audit retention policies, attested execution flows, certification programs, and pricing/packaging for the Enterprise tier — is intentionally separate from this Pivot section. It's a different audience, a different reading order, and a different sales motion. It will be linked here once it lands.
+
+In the meantime, the closest reading material:
+
+- **[Aileron Control](/pivot/control)** — the governance surface enterprise tiers productize.
+- **[The Business](/pivot/business)** — Aileron Enterprise (Surface 7), Aileron Connector Certification (Surface 4), Aileron Insights (Surface 6), and Aileron Connector Studio (Surface 5) are the revenue surfaces aimed at this audience.
+- **[Why This Is Structurally Defensible](/pivot/why-defensible)** — the competitive comparison includes 1Password Agent Access, Salesforce Agent Fabric, and other adjacent enterprise-leaning offerings; the seam Aileron occupies remains empty for them too.

--- a/docs/src/content/docs/pivot/the-problem.md
+++ b/docs/src/content/docs/pivot/the-problem.md
@@ -1,31 +1,45 @@
 ---
 title: "The Problem"
-description: "Six structural pains in the current AI agent stack that the Aileron pivot resolves"
+description: "Six structural pains in the current AI agent stack — illustrated with the kind of moments developers actually live"
 order: 1
 ---
 
 > **Section:** part of the Pivot strategy. Start at [Overview](/pivot/overview) for the one-sentence pitch and architectural insight; see [Aileron Runtime](/pivot/runtime) and [Aileron Control](/pivot/control) for what Aileron does about it.
 
-## Agents are probabilistic where they should be deterministic
+The six pains below are the ones the agent stack imposes on the people using it. Each starts with a moment a working developer might have lived, then names the structural cause, then the cost of letting it stand.
 
-When an agent says "send the invoice to acme@example.com for $4,200," there is one correct outcome. The current architecture runs that intent through a stochastic model that may hallucinate the recipient, the amount, or the action itself. The model is asked to make decisions a deterministic function should make. Production agents accumulate this debt every turn.
+## You verified everything. You became its fact-checker.
 
-## LLMs touch credentials they should never see
+The agent confidently says the bug is in `auth.go:42`. You open the file. There's no `auth.go:42`; the function it described doesn't exist. You scroll, search the codebase, find the actual call site three packages over, and patch it. Tomorrow the same agent will be just as confident about something else — and you'll re-verify, because you've learned you have to.
+
+When an agent says "send the invoice to acme@example.com for $4,200," there is one correct outcome. The current architecture runs that intent through a stochastic model that may hallucinate the recipient, the amount, or the action itself. The model is asked to make decisions a deterministic function should make. Production agents accumulate this debt every turn — and developers absorb the verification cost as a tax they didn't sign up for.
+
+## Your secrets are in places you didn't put them.
+
+You paste your Stripe test key into `.env` and tell your agent to "use it for testing." A week later you're reading a prompt-trace log and the key is *in* a tool-call argument the LLM stitched together — not because anything broke, but because the model decided that string was relevant context. You rotate. You don't know who else saw the trace.
 
 To execute real-world actions, agents pass API keys, tokens, and secrets through the LLM context — sometimes inadvertently, often unavoidably. The model could leak them in a response, log them in a trace, or return them as part of a tool argument it composed. "LLM never sees the key" is now table stakes (1Password, HashiCorp Vault, NVIDIA OpenShell all ship it), but every solution requires the agent author to opt in.
 
-## The agent itself is in the trust path for consent
+## You're not sure if you confirmed that, or the agent just said you did.
+
+The agent's response says *"Confirmed: dropping table `users`. Done."* You re-read it. Did you actually click confirm? Or did the agent compose that sentence as a fluent continuation of an earlier turn, and the destructive call went out without you ever seeing the prompt? The audit trail is the agent's word about itself.
 
 Approvals, denials, and configuration changes all flow through the agent UI today. A buggy or compromised agent can rewrite a denial as an approval, substitute one action's ID for another, or fabricate user consent that never happened. Existing tool-execution layers — gateways, MCP servers, agent frameworks — accept this risk because they have no separate channel for user intent. Aileron does.
 
-## Cost and latency are paid even when the work is deterministic
+## You paid for inference on work that didn't need a model.
+
+You watched your agent burn 11k tokens to format a JSON blob into a markdown table. The first 47 turns of last night's run did the same lookup-render-format cycle on different inputs. The shape never changed; the cost did. Your monthly bill rose with your turn count, not with the share of turns that genuinely needed a frontier model.
 
 A 50-step agent run sends every step through inference, including the steps where the answer is computable, the format is fixed, and the procedure is settled. The trivial turns and the hard turns pay the same token cost and incur the same network latency. Typical tool-call-heavy agents see 3–5x cost overhead from over-provisioning; substitution-dominant workloads can see 10x or more. The categorical wins are bigger still — substituted actions skip inference entirely, cutting end-to-end latency from seconds to milliseconds and producing identical results across runs.
 
-## Audit and compliance can't keep up with probabilism
+## Compliance asked what your agent did. You can't tell them.
+
+Compliance asks for a record of what your agent did to customer X's account on March 12. You have logs — prompts, completions, tool calls. Two of the calls have arguments the LLM constructed that don't appear anywhere in your code. Re-running the same prompt produces a different sequence. There is no reproduction; there is no answer.
 
 Regulated industries — finance, healthcare, legal — cannot deploy agents whose actions are non-reproducible. The same input produces different outputs across runs. The same prompt produces different tool invocations. There is no audit trail because there is no determinism to audit.
 
-## Governance products require integration the agent author doesn't perform
+## You evaluated the policy product. The integration assumed you'd done their job.
+
+You evaluated Cerbos for agent policy. The integration doc starts with *"wrap your tool execution function in..."* — but you don't *have* a tool execution function. Your agent is Claude Code with a handful of MCP servers. The policy layer never sees what's about to run, because the thing that runs lives inside an editor extension you don't control.
 
 Cerbos, Permit.io, Lakera, Pangea, Galileo all require SDK integration. The agent author is asked to be the safety engineer. Most aren't, and most won't be. The governance layer needs to be invisible to the agent — sitting in the path the agent already uses — or it doesn't get installed at all.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -61,6 +61,7 @@ export const navigation: NavItem[] = [
       },
       { label: 'Why This Is Defensible', href: '/pivot/why-defensible' },
       { label: 'The Customer', href: '/pivot/customer' },
+      { label: 'Enterprise — Addressed Later', href: '/pivot/enterprise-later' },
       { label: 'The Business', href: '/pivot/business' },
       { label: 'What Aileron Is Not', href: '/pivot/not' },
       { label: 'What Your Agent Can Now Do', href: '/pivot/what-your-agent-can-do' },


### PR DESCRIPTION
## Summary

Phase 3 of the Pivot docs work tracked in #335 — sharpening the audience and pain-point articulation so the Pivot section reads with concrete moments and named personas instead of abstract claims.

**The Problem (`/pivot/the-problem`)**
Each of the six pains now leads with a concrete vignette a working developer might have lived, then names the structural cause:
- "You verified everything. You became its fact-checker." (auth.go:42 doesn't exist)
- "Your secrets are in places you didn't put them." (Stripe key in a tool-call argument the LLM stitched together)
- "You're not sure if you confirmed that, or the agent just said you did." ("Confirmed: dropping table users")
- "You paid for inference on work that didn't need a model." (11k tokens to format a JSON blob)
- "Compliance asked what your agent did. You can't tell them." (calls with LLM-constructed args)
- "You evaluated the policy product. The integration assumed you'd done their job." (Cerbos wrap-your-tool-execution-function)

**The Customer (`/pivot/customer`)**
Replaces the bulleted segment list with four concrete personas, each as a "their week" vignette + a "where Aileron lands" line:
- The indie agent builder
- The AI-coding-tool power user
- The local-first developer
- The privacy-conscious power user

Adds a **"Who Aileron isn't for in v1"** cut-list (enterprise governance buyers, no-code workflow authors, managed/cloud-only teams, agent framework authors) so the wedge is honest about adjacencies.

**Enterprise — Addressed Later (`/pivot/enterprise-later`, new page)**
Pulls the enterprise stub out of `customer.md` into a dedicated page that explains why enterprise is intentionally out of the v1 pitch and which architectural commitments preserve enterprise as a future path. Wired into the sidebar between The Customer and The Business.

Refs #335 (Phase 3)

## Test plan

- [x] `task build:docs` — 147 pages built; new `/pivot/enterprise-later/` route present.
- [ ] Visual review in `pnpm dev:docs` to confirm the-problem reads cleanly with the moment-then-principle structure, and that the four personas render as intended.
- [ ] Click through cross-links from `/pivot/customer` → `/pivot/enterprise-later` → back to `/pivot/control` and `/pivot/business`.
- [ ] Verify no broken links (search for `the-deterministic-layer` already cleaned up; no other inbound references to changed sections).

🤖 Generated with [Claude Code](https://claude.com/claude-code)