### PR TITLE
feat(enclave): enforce capability revocation

### DIFF
--- a/cmd/aileron-enclave/escrow.go
+++ b/cmd/aileron-enclave/escrow.go
@@ -294,6 +294,20 @@ func (s *escrowStore) Revoke(escrowID, grantID string) error {
 	return nil
 }
 
+func (s *escrowStore) GrantID(escrowID string) (string, error) {
+	s.mu.RLock()
+	entry, ok := s.entries[escrowID]
+	s.mu.RUnlock()
+	if !ok {
+		return "", enclave.ErrEscrowNotFound
+	}
+	if time.Now().After(entry.expiresAt) {
+		s.revokeByID(escrowID)
+		return "", enclave.ErrEscrowExpired
+	}
+	return entry.grantID, nil
+}
+
 // Update replaces the credential for an existing escrow entry. The old
 // credential bytes are zeroed before replacement. This is used when an OAuth
 // token is refreshed inside the enclave — the enclave updates its own copy

--- a/cmd/aileron-enclave/escrow_test.go
+++ b/cmd/aileron-enclave/escrow_test.go
@@ -306,6 +306,35 @@ func TestEscrowRevokeWrongGrant(t *testing.T) {
 	}
 }
 
+func TestEscrowGrantID(t *testing.T) {
+	s := mustNewEscrowStore(t)
+	id := s.Store(testEscrowRequest("grant-1", "api_key", nil), []byte("cred"), time.Now().Add(time.Hour))
+	grantID, err := s.GrantID(id)
+	if err != nil {
+		t.Fatalf("GrantID: %v", err)
+	}
+	if grantID != "grant-1" {
+		t.Fatalf("grant ID = %q, want grant-1", grantID)
+	}
+}
+
+func TestEscrowGrantIDNotFound(t *testing.T) {
+	s := mustNewEscrowStore(t)
+	_, err := s.GrantID("missing")
+	if err != enclave.ErrEscrowNotFound {
+		t.Fatalf("expected ErrEscrowNotFound, got %v", err)
+	}
+}
+
+func TestEscrowGrantIDExpired(t *testing.T) {
+	s := mustNewEscrowStore(t)
+	id := s.Store(testEscrowRequest("grant-1", "api_key", nil), []byte("cred"), time.Now().Add(-time.Second))
+	_, err := s.GrantID(id)
+	if err != enclave.ErrEscrowExpired {
+		t.Fatalf("expected ErrEscrowExpired, got %v", err)
+	}
+}
+
 func TestEscrowEvictExpired(t *testing.T) {
 	s := mustNewEscrowStore(t)
 	live := []byte("live")

--- a/cmd/aileron-enclave/server.go
+++ b/cmd/aileron-enclave/server.go
@@ -41,6 +41,7 @@ type enclaveServer struct {
 	expiresAt             time.Time
 	seenNonces            map[string]time.Time
 	usedGrantCapabilities map[string]time.Time
+	revokedGrantIDs       map[string]time.Time
 	keks                  *kekStore
 	escrow                *escrowStore
 }
@@ -57,6 +58,7 @@ func newEnclaveServer(log *slog.Logger, registry *connector.Registry, sourceReg 
 		provider:              provider,
 		seenNonces:            make(map[string]time.Time),
 		usedGrantCapabilities: make(map[string]time.Time),
+		revokedGrantIDs:       make(map[string]time.Time),
 		keks:                  newKEKStore(),
 		escrow:                escrow,
 	}, nil
@@ -442,10 +444,17 @@ func (s *enclaveServer) handleEscrowRevoke(w http.ResponseWriter, r *http.Reques
 	}
 	zeroBytes(authKey)
 
-	if err := s.escrow.Revoke(req.EscrowID, req.GrantID); err != nil {
-		writeErr(w, http.StatusNotFound, err.Error())
+	if req.GrantID == "" {
+		writeErr(w, http.StatusBadRequest, "grant_id required")
 		return
 	}
+	if req.EscrowID != "" {
+		if err := s.escrow.Revoke(req.EscrowID, req.GrantID); err != nil {
+			writeErr(w, http.StatusNotFound, err.Error())
+			return
+		}
+	}
+	s.revokeGrant(req.GrantID)
 
 	w.WriteHeader(http.StatusNoContent)
 }
@@ -463,6 +472,13 @@ func (s *enclaveServer) handleSourceExecute(w http.ResponseWriter, r *http.Reque
 	defer zeroBytes(authKey)
 	if !enclave.VerifySourceExecuteCapability(authKey, req) {
 		writeErr(w, http.StatusForbidden, "invalid grant capability")
+		return
+	}
+	if grantID, err := s.escrow.GrantID(req.EscrowID); err != nil {
+		writeEscrowErr(w, err)
+		return
+	} else if s.isGrantRevoked(grantID) {
+		writeErr(w, http.StatusForbidden, enclave.ErrCapabilityRevoked.Error())
 		return
 	}
 
@@ -526,6 +542,9 @@ func (s *enclaveServer) verifyIssuedEscrowCapability(req enclave.EscrowStoreRequ
 	if !enclave.VerifySignedGrantCapability(key, req.IssuedCapability, expected) {
 		return fmt.Errorf("invalid issued grant capability")
 	}
+	if s.isGrantRevoked(req.IssuedCapability.Capability.GrantID) {
+		return enclave.ErrCapabilityRevoked
+	}
 	return verifyCapabilityExpiry(req.IssuedCapability)
 }
 
@@ -542,6 +561,9 @@ func (s *enclaveServer) verifyIssuedExecuteCapability(req enclave.ExecuteRequest
 	if !enclave.VerifySignedGrantCapability(key, req.IssuedCapability, expected) {
 		return fmt.Errorf("invalid issued grant capability")
 	}
+	if s.isGrantRevoked(req.IssuedCapability.Capability.GrantID) {
+		return enclave.ErrCapabilityRevoked
+	}
 	if err := verifyCapabilityExpiry(req.IssuedCapability); err != nil {
 		return err
 	}
@@ -555,6 +577,25 @@ func (s *enclaveServer) grantSigningKey() []byte {
 	s.mu.Lock()
 	defer s.mu.Unlock()
 	return copyBytes(s.grantCapabilityKey)
+}
+
+func (s *enclaveServer) revokeGrant(grantID string) {
+	if grantID == "" {
+		return
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	s.revokedGrantIDs[grantID] = time.Now()
+}
+
+func (s *enclaveServer) isGrantRevoked(grantID string) bool {
+	if grantID == "" {
+		return false
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	_, ok := s.revokedGrantIDs[grantID]
+	return ok
 }
 
 func (s *enclaveServer) consumeIssuedCapability(capability *enclave.SignedGrantCapability) bool {
@@ -713,7 +754,7 @@ func writeErr(w http.ResponseWriter, status int, msg string) {
 
 func writeEscrowErr(w http.ResponseWriter, err error) {
 	status := http.StatusNotFound
-	if err == enclave.ErrEscrowScopeMismatch {
+	if err == enclave.ErrEscrowScopeMismatch || err == enclave.ErrCapabilityRevoked {
 		status = http.StatusForbidden
 	}
 	writeErr(w, status, err.Error())

--- a/cmd/aileron-enclave/server_test.go
+++ b/cmd/aileron-enclave/server_test.go
@@ -527,6 +527,71 @@ func TestExecuteRejectsReplayedIssuedCapability(t *testing.T) {
 	resp.Body.Close()
 }
 
+func TestExecuteRejectsRevokedIssuedCapability(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	revokeResp := postJSON(t, server, "/escrow/revoke", enclave.EscrowRevokeRequest{GrantID: "grant-revoked"})
+	if revokeResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected revoke 204, got %d", revokeResp.StatusCode)
+	}
+	revokeResp.Body.Close()
+
+	encrypted, _ := crypto.Encrypt([]byte("cred"), userKEK)
+	resp := postJSON(t, server, "/execute", enclave.ExecuteRequest{
+		RequestID:           "exec-revoked",
+		UserID:              "user-1",
+		GrantID:             "grant-revoked",
+		ActionType:          "test.action",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: encrypted,
+		CredentialType:      "api_key",
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for revoked issued capability, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestExecuteRejectsRevokedIssuedCapabilityAfterNewSession(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	revokeResp := postJSON(t, server, "/escrow/revoke", enclave.EscrowRevokeRequest{GrantID: "grant-revoked-session"})
+	if revokeResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected revoke 204, got %d", revokeResp.StatusCode)
+	}
+	revokeResp.Body.Close()
+
+	sessionKey = establishTestSession(t, server)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	encrypted, _ := crypto.Encrypt([]byte("cred"), userKEK)
+	resp := postJSON(t, server, "/execute", enclave.ExecuteRequest{
+		RequestID:           "exec-revoked-session",
+		UserID:              "user-1",
+		GrantID:             "grant-revoked-session",
+		ActionType:          "test.action",
+		ConnectorID:         "test/stub",
+		EncryptedCredential: encrypted,
+		CredentialType:      "api_key",
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for revoked issued capability after new session, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
 func TestVerifyCapabilityExpiryRejectsMissingAndInvalidExpiry(t *testing.T) {
 	tests := []struct {
 		name       string
@@ -664,8 +729,8 @@ func TestEscrowFlow(t *testing.T) {
 		CredentialType: "api_key",
 		EscrowID:       storeResult.EscrowID,
 	})
-	if execResp2.StatusCode != http.StatusNotFound {
-		t.Fatalf("expected 404 after revoke, got %d", execResp2.StatusCode)
+	if execResp2.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 after revoke, got %d", execResp2.StatusCode)
 	}
 	execResp2.Body.Close()
 }
@@ -688,6 +753,29 @@ func TestEscrowStoreRejectsIssuedCapabilityScopeMismatch(t *testing.T) {
 	resp := postJSON(t, server, "/escrow", req)
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403 for escrow issued capability scope mismatch, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestEscrowStoreRejectsRevokedIssuedCapability(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	sessionKey := establishTestSession(t, server)
+	userKEK := make([]byte, 32)
+	rand.Read(userKEK)
+	transmitTestKEK(t, server, sessionKey, "user-1", userKEK)
+
+	revokeResp := postJSON(t, server, "/escrow/revoke", enclave.EscrowRevokeRequest{GrantID: "grant-1"})
+	if revokeResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected revoke 204, got %d", revokeResp.StatusCode)
+	}
+	revokeResp.Body.Close()
+
+	encrypted, _ := crypto.Encrypt([]byte("escrowed-cred"), userKEK)
+	resp := postJSON(t, server, "/escrow", validEscrowStoreRequest(encrypted))
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for revoked escrow issued capability, got %d", resp.StatusCode)
 	}
 	resp.Body.Close()
 }
@@ -917,6 +1005,27 @@ func TestEscrowRevokeNotFoundViaHTTP(t *testing.T) {
 		t.Fatalf("expected 404, got %d", resp.StatusCode)
 	}
 	resp.Body.Close()
+}
+
+func TestEscrowRevokeRequiresGrantID(t *testing.T) {
+	server, _ := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	establishTestSession(t, server)
+
+	resp := postJSON(t, server, "/escrow/revoke", enclave.EscrowRevokeRequest{EscrowID: "esc_123"})
+	if resp.StatusCode != http.StatusBadRequest {
+		t.Fatalf("expected 400, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestRevokeGrantIgnoresEmptyGrantID(t *testing.T) {
+	_, srv := setupTestEnclaveServer(t)
+	srv.revokeGrant("")
+	if srv.isGrantRevoked("") {
+		t.Fatal("empty grant ID should not be considered revoked")
+	}
 }
 
 func TestHealthWithActiveSession(t *testing.T) {
@@ -1758,6 +1867,35 @@ func TestSourceExecute_RejectsScopeMismatch(t *testing.T) {
 	})
 	if resp.StatusCode != http.StatusForbidden {
 		t.Fatalf("expected 403, got %d", resp.StatusCode)
+	}
+	resp.Body.Close()
+}
+
+func TestSourceExecuteRejectsRevokedEscrowGrant(t *testing.T) {
+	server, srv := setupTestEnclaveServer(t)
+	defer server.Close()
+
+	establishTestSession(t, server)
+
+	escrowReq := testEscrowRequest("g1", "oauth2", nil)
+	escrowID := srv.escrow.Store(escrowReq, []byte(`{"access_token":"test"}`), time.Now().Add(time.Hour))
+
+	revokeResp := postJSON(t, server, "/escrow/revoke", enclave.EscrowRevokeRequest{GrantID: "g1"})
+	if revokeResp.StatusCode != http.StatusNoContent {
+		t.Fatalf("expected revoke 204, got %d", revokeResp.StatusCode)
+	}
+	revokeResp.Body.Close()
+
+	resp := postJSON(t, server, "/source/execute", enclave.SourceExecuteRequest{
+		EscrowID:  escrowID,
+		UserID:    "user-1",
+		VaultPath: "connected-accounts/user-1/gmail",
+		Provider:  "gmail",
+		Tool:      "test_search",
+		Params:    map[string]any{"query": "hello"},
+	})
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("expected 403 for revoked source grant, got %d", resp.StatusCode)
 	}
 	resp.Body.Close()
 }

--- a/internal/enclave/errors.go
+++ b/internal/enclave/errors.go
@@ -20,6 +20,10 @@ var (
 	// not match the ownership or scope bound to the escrow entry.
 	ErrEscrowScopeMismatch = errors.New("enclave: escrow scope mismatch")
 
+	// ErrCapabilityRevoked indicates that the issued grant capability has
+	// been revoked inside the enclave boundary.
+	ErrCapabilityRevoked = errors.New("enclave: issued grant capability revoked")
+
 	// ErrNoKEK indicates that no KEK has been transmitted for the given user.
 	ErrNoKEK = errors.New("enclave: no KEK stored for user")
 )


### PR DESCRIPTION
## Summary
- record revoked grant IDs inside the enclave when `/escrow/revoke` succeeds, or when called with a grant-only revocation
- reject execute and escrow-store requests whose issued capability grant has been revoked
- reject source execution for escrow entries whose grant has been revoked
- add hostile-host tests for revoked direct execution, revoked escrow-store, revoked source execution, revoke validation, and revocation across a new session

Refs #326

## Tests
- `go test ./cmd/aileron-enclave ./internal/enclave/... ./internal/app`
- `go test -coverprofile=/tmp/phase4d-all.out ./cmd/aileron-enclave ./internal/enclave/... ./internal/app`

Focused coverage:
- `cmd/aileron-enclave`: 83.4%
- `internal/enclave`: 87.3%
- `internal/enclave/gcs`: 87.1%
- `internal/enclave/local`: 91.1%

Local patch-line approximation from the combined coverage profile: 50/50, 100%.