### PR TITLE
docs(pivot): reconcile legacy docs with Pivot framing (Phase 4)

### DIFF
--- a/docs/src/content/docs/for-individuals.md
+++ b/docs/src/content/docs/for-individuals.md
@@ -10,6 +10,8 @@ The more they rely on you, the more of your day disappears into messages, replie
 
 Aileron gives you that time back.
 
+The AI agents you already use — Claude, Cursor, ChatGPT, the assistant baked into your editor or your phone — finally have a runtime they can call when they need to *act* on your behalf. Sealed credentials, deterministic execution, your approval where it matters. Your agent can finish the work, not just talk about it.
+
 It connects to the things you already use — your conversations, your calendar, your projects, your email — and learns how you think, how you communicate, and what matters to you. Not because you told it. Because it was there when you made the decision, wrote the reply, edited the draft, scheduled the meeting.
 
 When a message comes in, Aileron has the reply ready. In your voice. With the right context. You glance at it, tap approve, and you're done. Or you tweak it, and Aileron learns from the tweak. Over time, the tweaks get fewer. The drafts get sharper. The time you spend on communication overhead shrinks to almost nothing.
@@ -20,6 +22,8 @@ This isn't about working faster. It's about spending less time on the things tha
 
 Aileron is invisible. Nobody knows you're using it. There's no bot in the channel, no assistant in the meeting, no AI label on your messages. Everything comes from you, because it is from you. Aileron just did the preparation you didn't have time for.
 
-Your data stays yours. Sensitive operations run through a secure enclave that Aileron's own operators cannot access — not as a promise, but as a cryptographic property your security-minded friends can verify. You can disconnect at any time and take everything with you.
+Your data stays yours. Your credentials live in a zero-knowledge vault that even Aileron's operators can't read; consequential actions wait for your approval on a channel the agent itself can't tamper with. Optional hardware-isolated enclaves add a stronger boundary for users who need it. You can disconnect at any time and take everything with you.
 
 The longer you use Aileron, the better it gets. Not because you're training it, but because you're living your life and it's paying attention. That's the deal: you do what you were going to do anyway, and the overhead disappears.
+
+Want the full picture? See the four wedge personas in [Pivot — The Customer](/pivot/customer), or the hero use cases in [What Your Agent Can Now Do](/pivot/what-your-agent-can-do).

--- a/docs/src/content/docs/for-organizations.md
+++ b/docs/src/content/docs/for-organizations.md
@@ -1,23 +1,15 @@
 ---
 title: "For Organizations"
-description: "Institutional memory that builds itself"
+description: "How Aileron's architecture preserves an enterprise path"
 order: 2
 ---
 
-Your organization's real knowledge has never been in a wiki.
+Aileron's v1 wedge is the individual developer — see [The Customer](/pivot/customer) for the four named personas. Organizations land here later, by design.
 
-It's in the engineer who knows why the auth service is built that way. In the thread where the team debated the migration plan. In the calendar of the one person who remembers the client's scheduling preferences. In a hundred small decisions made by people who are too busy doing the work to write it down.
+The architecture is built so the enterprise path is preserved without rewriting anything. Sandboxed connectors with content-addressed binaries, capability binding that federates through Aileron Control, audit trails that come for free because Runtime sits in the request path by construction — these are the same primitives an individual developer uses. What changes for organizations is what's productized around them: multi-user vault, RBAC, federated bindings, signed-connector supply chains, audit retention beyond cloud limits, on-prem deployment.
 
-Every attempt to capture this knowledge has failed for the same reason: it asks people to do extra work with no immediate reward. Write the doc. Update the runbook. Tag the article. Nobody does, because the cost falls on the writer and the benefit goes to a future reader who may never come.
+Until the dedicated enterprise document lands, the closest reading material lives in the Pivot section:
 
-Aileron inverts this.
-
-When your people use Aileron, they're not documenting anything. They're just handling their messages, making decisions, doing their jobs. But every conversation that informs a draft, every decision that gets referenced in a reply, every correction that sharpens a future response — it all feeds a shared understanding. Your organization's institutional memory builds itself, not from documentation initiatives, but from real work.
-
-The new engineer asks how the auth service works. The answer comes from actual code, actual conversations, actual decisions — not a page that was outdated the day after someone wrote it. Someone goes on vacation. Their knowledge doesn't go with them, because the team's shared context already includes their contributions. A critical question comes in at 2am in a timezone where nobody's awake. The draft is ready when they wake up.
-
-This is not surveillance. Aileron works for the individual first, always. Each person controls what they connect, approves every action, and owns their data. The organization benefits because its people work better — not because it's watching them. Admins see aggregate metrics: time saved, messages handled, adoption. Never individual message content. The secure enclave architecture makes this a technical guarantee, not a policy.
-
-The result is an organization that gets smarter every day without asking anyone to do anything differently. Knowledge stops being trapped in people's heads. Communication latency drops. New hires ramp faster. Vacations stop creating bottlenecks. And it compounds — the more people who use Aileron, the richer everyone's context becomes.
-
-No one mandated a knowledge management system. No one asked anyone to write a handoff doc. The organization got smarter because its people used something that made their own lives easier. That's the only incentive structure that has ever worked at scale.
+- [Pivot — Enterprise, Addressed Later](/pivot/enterprise-later) — why enterprise is intentionally out of the v1 pitch and which architectural commitments preserve it as a future path.
+- [Pivot — Aileron Control](/pivot/control) — the governance surface enterprise tiers productize.
+- [Pivot — The Business](/pivot/business) — Aileron Enterprise (Surface 7), Connector Certification (4), Insights (6), and Connector Studio (5) are the revenue surfaces aimed at this audience.

--- a/docs/src/content/docs/how-aileron-works.md
+++ b/docs/src/content/docs/how-aileron-works.md
@@ -4,7 +4,9 @@ description: "The building blocks that make Aileron trustworthy with real life"
 order: 3
 ---
 
-Aileron handles things that matter. Your messages, your money, your schedule, your credentials. That only works if you can trust it. Not trust as in "we promise to be careful." Trust as in "the system is designed so that even we can't violate it."
+Aileron handles things that matter. Your messages, your money, your schedule, your credentials. The way it earns the right to do that is by drawing a hard line between two things current AI architectures usually conflate: **deciding what to do** and **actually doing it.** Language models are great at the first; they shouldn't be trusted with the second. Aileron is the layer that takes the model's proposed action — at the LLM endpoint, before anything irreversible happens — and executes it deterministically, with sealed credentials and your explicit approval where it counts.
+
+Trust isn't "we promise to be careful." It's "the system is designed so that even we can't violate it."
 
 Here's how.
 
@@ -12,7 +14,7 @@ Here's how.
 
 Nothing happens without your approval. Aileron prepares, assembles, and recommends. You decide. Every message, every payment, every action waits for you to say yes. If you say no, nothing moves. If you edit, Aileron learns. If you walk away, everything stops.
 
-This isn't a safety net bolted on at the end. It's the foundation everything else is built on.
+This isn't a safety net bolted on at the end. It's the foundation everything else is built on. The approval flow itself runs on a channel the agent can't tamper with — see [Aileron Control](/pivot/control) for the architecture.
 
 ## LLMs express intent. Aileron owns execution.
 
@@ -20,7 +22,7 @@ Language models are good at understanding what needs to happen. They are not goo
 
 The model figures out what you'd probably want to do. Aileron is the one that actually does it. Your credentials, your OAuth tokens, your payment instruments never touch the model. It sees results, not secrets. It can suggest "reply to Sarah's message about the migration," but it cannot access your Slack token, your bank account, or anything else without Aileron brokering the interaction on your behalf, with your approval.
 
-This means a prompt injection, a model hallucination, or a bad suggestion can't do damage. The worst it can do is recommend something you'd decline.
+This means a prompt injection, a model hallucination, or a bad suggestion can't do damage. The worst it can do is recommend something you'd decline. The architectural commitments behind this — the connector model, the action model, capability binding, sandboxing — live in the [Pivot Architecture](/pivot/architecture/) section.
 
 ## The zero-knowledge vault
 
@@ -32,13 +34,7 @@ When you need a credential for an action, you unlock your vault once. The decryp
 
 This isn't new or experimental. Zero-knowledge encryption is the same proven technique behind password managers like 1Password and Bitwarden, secure email like Proton Mail, and end-to-end encrypted messaging like Signal. It's the standard the security community trusts for protecting data that matters.
 
-## The secure enclave
-
-Some operations need to happen in a place where no one can look, not even us.
-
-A secure enclave is a hardware-isolated environment that runs code in a way that the host machine cannot inspect or tamper with. Not the operating system, not the cloud provider, not Aileron's operators. The code inside is sealed and verifiable through remote attestation, which means your security team can independently confirm what's running without trusting anyone's word.
-
-When Aileron handles your messages, routes your data, or brokers a credential, the sensitive parts happen inside the enclave. Your data passes through, gets processed, and leaves. Nothing is retained. Nothing is visible to the outside.
+For users who need a stronger boundary still, sensitive operations can additionally run inside a hardware-isolated enclave whose code is verifiable via remote attestation; see the [TEE Enclave deployment](/deployment/tee-enclave) guide. For everyday use, the vault is the guarantee.
 
 ## The personal context store
 
@@ -48,7 +44,7 @@ Without context, you get generic filler. With the right context, you get somethi
 
 Aileron builds that context around how you actually work and communicate. Your conversations, your projects, your decisions, your preferences. It learns from what you approve, what you edit, and what you throw away. Nobody fills out a profile. Nobody writes a prompt. The context grows because you're living your life, and it gets better every day because it's learning from you.
 
-This is the thing that makes everything else work. The vault protects your credentials. The enclave protects your data. The context store is what makes the output worth protecting.
+This is the thing that makes everything else work. The vault protects your credentials. Policy controls what gets to act on your behalf. The context store is what makes the output worth protecting.
 
 ## The audit trail
 
@@ -68,8 +64,8 @@ Safe actions are approved automatically. Dangerous actions are blocked. Everythi
 
 These aren't features on a checklist. They're building blocks that solve a single problem: how do you trust a service with your real life?
 
-The zero-knowledge vault means your credentials are safe even if everything else fails. The separation of intent and execution means a bad model output can't cause real harm. The secure enclave means sensitive operations are private by physics, not by policy. The personal context store means every interaction gets better. The audit trail means there's proof. The human in control means nothing consequential happens without you.
+The zero-knowledge vault means your credentials are safe even if everything else fails. The separation of intent and execution means a bad model output can't cause real harm. The personal context store means every interaction gets better. The audit trail means there's proof. The human in control means nothing consequential happens without you. (For users who need it, optional hardware-isolated enclaves add a stronger boundary still.)
 
 Together, they let Aileron do something no other service can: work with your actual life. Your real messages, your real money, your real relationships, your real schedule. Not a sandbox. Not a demo. The things that matter, handled responsibly, so you can spend your time on what matters more.
 
-A partner to crush the overhead of everyday life and work, and give time back to you where it counts.
+A partner to crush the overhead of everyday life and work, and give time back to you where it counts. For the architectural picture behind this, start at [Aileron Runtime](/pivot/runtime).

--- a/docs/src/content/docs/index.md
+++ b/docs/src/content/docs/index.md
@@ -6,6 +6,8 @@ order: 0
 
 *Accelerate your work and life. You in control. Throttle up.*
 
+Aileron is the **deterministic execution layer for the AI agents you already use.** Whether your agent is Claude, Cursor, ChatGPT, or something you built yourself, Aileron sits between the model and the things in your real life — your accounts, your messages, your money, your schedule — so your agent can actually *do* the work, not just talk about it. Sealed credentials, deterministic execution, your approval where it matters. See the [Pivot Overview](/pivot/overview) for the architecture and the [Pivot — The Problem](/pivot/the-problem) for the moments this is built to fix.
+
 Our time is precious. We pour it into purpose, into connection. Managing our modern life demands time, and we believe it should take far less.
 
 Aileron learns how you already live and work. Your conversations, your decisions, your preferences, your corrections. Not because you sit down and teach it, but because it's there, paying attention, getting sharper every day. It builds an understanding of your world that no one had to write down, and that understanding is what makes the difference between an answer that wastes your time and one you'd trust with your name on it.
@@ -19,8 +21,9 @@ Aileron is built for you. At home, at work, to get you back to real life sooner.
 
 ## Learn more
 
+- [Pivot Overview](/pivot/overview) - The deterministic execution layer for AI agents
 - [For Individuals](/for-individuals) - How Aileron gives you your time back
-- [For Organizations](/for-organizations) - Institutional memory that builds itself
+- [For Organizations](/for-organizations) - How Aileron preserves an enterprise path
 - [How Aileron Works](/how-aileron-works) - The building blocks that make it trustworthy
 - [Getting Started](/getting-started/installation) - Install and launch your first session
 - [API Reference](/api) - Full OpenAPI specification


### PR DESCRIPTION
## Summary

Phase 4 of the Pivot docs work tracked in #335 — reconciling the four legacy "Meet Aileron" pages so they hand off cleanly to the Pivot section instead of competing with it. Each page now anchors to AI agents in the first 1–2 paragraphs, demotes enclave-as-headline language to opt-in mentions, and cross-links into the canonical Pivot content.

**Phase 1 audit surprise:** the broader docs (`getting-started/*`, `operations/*`, `deployment/*`, `development/*`) are already Pivot-clean. No `MCP gateway` or `control plane for intelligent systems` language survived earlier work; enclave-related pages (`zero-knowledge-enclave.md`, `tee-enclave.md`) already correctly position enclaves as optional infrastructure. Phase 4 collapsed to four page edits.

## Per-page changes

- **`index.md`** — adds a Pivot-anchoring paragraph naming AI agents and the deterministic-execution-layer framing; updates the Learn more block to lead with `/pivot/overview`; fixes the off-message "Institutional memory that builds itself" caption on the For Organizations link.
- **`how-aileron-works.md`** — rewrites the lead around the LLM-vs-execution seam (the page's own line 17 promoted to the top); demotes the H2 "secure enclave" section to a one-sentence opt-in mention inside the vault section; cross-links to `/pivot/control`, `/pivot/architecture/`, `/pivot/runtime`.
- **`for-individuals.md`** — adds a paragraph naming the AI agents the wedge already uses (Claude, Cursor, ChatGPT, etc.); softens the enclave paragraph to vault + policy as the everyday guarantee; closes with hand-off links to `/pivot/customer` (where the four personas live) and `/pivot/what-your-agent-can-do`.
- **`for-organizations.md`** — replaces the "institutional memory" body (~24 lines) with a thin hand-off page (~12 lines) pointing to `/pivot/enterprise-later`, `/pivot/control`, `/pivot/business`. Updates frontmatter description.

**Judgment call retained from plan:** issue #335's checklist said "for-individuals.md likely a complete rewrite" — but `pivot/customer.md` already carries the four-persona deep-dive landed in Phase 3. Light reframe is the right call; duplicating the personas here would create maintenance drift.

**Deferred** (with rationale, in plan file): moving `getting-started/zero-knowledge-enclave.md` or `deployment/tee-enclave.md` (UX nice-to-have, not Pivot-required); renaming the `Meet Aileron` sidebar group (cosmetic).

## Stats

- 4 files changed, 25 insertions(+), 30 deletions(-)
- Build: 147 pages (unchanged from Phase 3)
- Enclave headline mentions: 0 across all four pages (was 1 H2 + 4 paragraph references)
- Pivot cross-links added: 9

Refs #335 (Phase 4 — reconcile with existing docs site)

## Test plan

- [x] `task build:docs` — 147 pages built; no broken links.
- [x] Grep sweep — `MCP gateway` and `control plane for intelligent systems` confirmed absent from user-facing content (only surviving mentions are in immutable ADRs and one competitor reference).
- [x] Enclave count per page: index 0, how-aileron-works 2 (both opt-in), for-individuals 1, for-organizations 0.
- [ ] Visual review in `pnpm dev:docs` to confirm the four pages render and read cleanly with the new framing.
- [ ] Click through every new cross-link: `/pivot/overview`, `/pivot/the-problem`, `/pivot/control`, `/pivot/architecture/`, `/pivot/runtime`, `/pivot/customer`, `/pivot/what-your-agent-can-do`, `/pivot/enterprise-later`, `/pivot/business`, `/deployment/tee-enclave`.
- [ ] Read-aloud pass on each of the four pages: should land on AI agents within the first 1–2 paragraphs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)