### PR TITLE
feat(enclave): require external escrow key in strict mode

### DIFF
--- a/cmd/aileron-enclave/escrow.go
+++ b/cmd/aileron-enclave/escrow.go
@@ -37,6 +37,11 @@ type escrowStore struct {
 	encKey  []byte // 32-byte DEK for at-rest encryption
 }
 
+type escrowKeyConfig struct {
+	key          []byte
+	allowRawFile bool
+}
+
 // persistedEntry is the JSON-serializable form of an escrow entry.
 type persistedEntry struct {
 	UserID            string                         `json:"user_id"`
@@ -54,10 +59,17 @@ type persistedEntry struct {
 }
 
 func newEscrowStore(dataDir string) (*escrowStore, error) {
+	return newEscrowStoreWithKeyConfig(dataDir, escrowKeyConfig{allowRawFile: true})
+}
+
+func newEscrowStoreWithKeyConfig(dataDir string, cfg escrowKeyConfig) (*escrowStore, error) {
 	s := &escrowStore{entries: make(map[string]*escrowEntry)}
 
 	if dataDir == "" {
 		return s, nil
+	}
+	if len(cfg.key) > 0 && len(cfg.key) != 32 {
+		return nil, fmt.Errorf("escrow key: expected 32 bytes, got %d", len(cfg.key))
 	}
 
 	s.dataDir = dataDir
@@ -65,11 +77,26 @@ func newEscrowStore(dataDir string) (*escrowStore, error) {
 		return nil, fmt.Errorf("creating escrow data dir: %w", err)
 	}
 
-	key, err := enclave.LoadOrCreateKey(filepath.Join(dataDir, "escrow.key"))
-	if err != nil {
-		return nil, err
+	rawKeyPath := filepath.Join(dataDir, "escrow.key")
+	if len(cfg.key) > 0 {
+		if !cfg.allowRawFile {
+			if _, err := os.Stat(rawKeyPath); err == nil {
+				return nil, fmt.Errorf("raw escrow key file present at %s; remove it before using external escrow key strict mode", rawKeyPath)
+			} else if !os.IsNotExist(err) {
+				return nil, fmt.Errorf("checking raw escrow key file: %w", err)
+			}
+		}
+		s.encKey = copyBytes(cfg.key)
+	} else {
+		if !cfg.allowRawFile {
+			return nil, fmt.Errorf("escrow key required: set AILERON_ENCLAVE_ESCROW_KEY_B64 or explicitly allow raw escrow.key files")
+		}
+		key, err := enclave.LoadOrCreateKey(rawKeyPath)
+		if err != nil {
+			return nil, err
+		}
+		s.encKey = key
 	}
-	s.encKey = key
 
 	// Load existing entries from disk.
 	if err := s.load(); err != nil {

--- a/cmd/aileron-enclave/escrow_test.go
+++ b/cmd/aileron-enclave/escrow_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"os"
+	"path/filepath"
 	"testing"
 	"time"
 
@@ -394,6 +395,79 @@ func TestEscrowPersistence_RoundTrip(t *testing.T) {
 	}
 	if string(got2) != "cred-two" {
 		t.Errorf("id2 = %q, want cred-two", got2)
+	}
+}
+
+func TestEscrowPersistence_ExternalKeyDoesNotWriteRawKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	key := []byte("01234567890123456789012345678901")
+
+	s1, err := newEscrowStoreWithKeyConfig(dir, escrowKeyConfig{key: key})
+	if err != nil {
+		t.Fatalf("newEscrowStoreWithKeyConfig: %v", err)
+	}
+	id := s1.Store(testEscrowRequest("grant-1", "oauth", nil), []byte("cred-one"), time.Now().Add(time.Hour))
+	if _, err := os.Stat(filepath.Join(dir, "escrow.key")); !os.IsNotExist(err) {
+		t.Fatalf("expected no raw escrow.key file, got err=%v", err)
+	}
+
+	s2, err := newEscrowStoreWithKeyConfig(dir, escrowKeyConfig{key: key})
+	if err != nil {
+		t.Fatalf("reload with external key: %v", err)
+	}
+	got, err := s2.Get(id)
+	if err != nil {
+		t.Fatalf("Get after reload: %v", err)
+	}
+	if string(got) != "cred-one" {
+		t.Fatalf("got %q, want cred-one", got)
+	}
+}
+
+func TestEscrowPersistence_ExternalKeyRejectsExistingRawKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	key := []byte("01234567890123456789012345678901")
+	if err := os.WriteFile(filepath.Join(dir, "escrow.key"), []byte("abcdefghijklmnopqrstuvwxzy123456"), 0600); err != nil {
+		t.Fatalf("writing raw key: %v", err)
+	}
+
+	_, err := newEscrowStoreWithKeyConfig(dir, escrowKeyConfig{key: key})
+	if err == nil {
+		t.Fatal("expected strict external key mode to reject existing raw escrow.key")
+	}
+}
+
+func TestEscrowPersistence_ExternalKeyCannotBeDecryptedWithWrongKey(t *testing.T) {
+	dir := t.TempDir()
+	key := []byte("01234567890123456789012345678901")
+	wrongKey := []byte("abcdefghijklmnopqrstuvwxzy123456")
+
+	s1, err := newEscrowStoreWithKeyConfig(dir, escrowKeyConfig{key: key})
+	if err != nil {
+		t.Fatalf("newEscrowStoreWithKeyConfig: %v", err)
+	}
+	id := s1.Store(testEscrowRequest("grant-1", "oauth", nil), []byte("cred-one"), time.Now().Add(time.Hour))
+
+	s2, err := newEscrowStoreWithKeyConfig(dir, escrowKeyConfig{key: wrongKey})
+	if err != nil {
+		t.Fatalf("reload with wrong external key: %v", err)
+	}
+	if _, err := s2.Get(id); err != enclave.ErrEscrowNotFound {
+		t.Fatalf("expected wrong key to start with empty escrow store, got %v", err)
+	}
+}
+
+func TestEscrowPersistence_StrictModeRequiresExternalKey(t *testing.T) {
+	_, err := newEscrowStoreWithKeyConfig(t.TempDir(), escrowKeyConfig{})
+	if err == nil {
+		t.Fatal("expected strict mode without key to fail")
+	}
+}
+
+func TestEscrowPersistence_RejectsWrongSizeExternalKey(t *testing.T) {
+	_, err := newEscrowStoreWithKeyConfig(t.TempDir(), escrowKeyConfig{key: []byte("short")})
+	if err == nil {
+		t.Fatal("expected wrong-size external key to fail")
 	}
 }
 

--- a/cmd/aileron-enclave/main.go
+++ b/cmd/aileron-enclave/main.go
@@ -10,6 +10,8 @@ package main
 
 import (
 	"context"
+	"encoding/base64"
+	"fmt"
 	"log/slog"
 	"net/http"
 	"os"
@@ -70,7 +72,13 @@ func main() {
 	sourceReg.Register(slacksource.New())
 	sourceReg.Register(githubsource.New())
 
-	srv, err := newEnclaveServer(log, registry, sourceReg, provider, dataDir)
+	escrowKeyCfg, err := escrowKeyConfigFromEnv(provider)
+	if err != nil {
+		log.Error("failed to configure escrow key", "error", err)
+		os.Exit(1)
+	}
+
+	srv, err := newEnclaveServerWithEscrowKeyConfig(log, registry, sourceReg, provider, dataDir, escrowKeyCfg)
 	if err != nil {
 		log.Error("failed to initialize enclave server", "error", err)
 		os.Exit(1)
@@ -111,4 +119,25 @@ func main() {
 	shutdownCtx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	httpServer.Shutdown(shutdownCtx)
+}
+
+func escrowKeyConfigFromEnv(provider string) (escrowKeyConfig, error) {
+	cfg := escrowKeyConfig{allowRawFile: provider != "confidential-space"}
+	if os.Getenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY") == "true" {
+		cfg.allowRawFile = true
+	}
+	keyB64 := os.Getenv("AILERON_ENCLAVE_ESCROW_KEY_B64")
+	if keyB64 == "" {
+		return cfg, nil
+	}
+	key, err := base64.StdEncoding.DecodeString(keyB64)
+	if err != nil {
+		return escrowKeyConfig{}, fmt.Errorf("decoding AILERON_ENCLAVE_ESCROW_KEY_B64: %w", err)
+	}
+	if len(key) != 32 {
+		return escrowKeyConfig{}, fmt.Errorf("AILERON_ENCLAVE_ESCROW_KEY_B64: expected 32 decoded bytes, got %d", len(key))
+	}
+	cfg.key = key
+	cfg.allowRawFile = false
+	return cfg, nil
 }

--- a/cmd/aileron-enclave/main_test.go
+++ b/cmd/aileron-enclave/main_test.go
@@ -1,0 +1,81 @@
+package main
+
+import (
+	"encoding/base64"
+	"testing"
+)
+
+func TestEscrowKeyConfigFromEnvConfidentialSpaceRequiresExternalKey(t *testing.T) {
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", "")
+	t.Setenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY", "")
+
+	cfg, err := escrowKeyConfigFromEnv("confidential-space")
+	if err != nil {
+		t.Fatalf("escrowKeyConfigFromEnv: %v", err)
+	}
+	if cfg.allowRawFile {
+		t.Fatal("confidential-space should not allow raw escrow key files by default")
+	}
+	if len(cfg.key) != 0 {
+		t.Fatal("expected no external key")
+	}
+}
+
+func TestEscrowKeyConfigFromEnvLocalAllowsRawKeyFile(t *testing.T) {
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", "")
+	t.Setenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY", "")
+
+	cfg, err := escrowKeyConfigFromEnv("local")
+	if err != nil {
+		t.Fatalf("escrowKeyConfigFromEnv: %v", err)
+	}
+	if !cfg.allowRawFile {
+		t.Fatal("local provider should allow raw escrow key files by default")
+	}
+}
+
+func TestEscrowKeyConfigFromEnvExternalKey(t *testing.T) {
+	key := []byte("01234567890123456789012345678901")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", base64.StdEncoding.EncodeToString(key))
+	t.Setenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY", "true")
+
+	cfg, err := escrowKeyConfigFromEnv("confidential-space")
+	if err != nil {
+		t.Fatalf("escrowKeyConfigFromEnv: %v", err)
+	}
+	if cfg.allowRawFile {
+		t.Fatal("external key should disable raw escrow key files")
+	}
+	if string(cfg.key) != string(key) {
+		t.Fatal("decoded external key mismatch")
+	}
+}
+
+func TestEscrowKeyConfigFromEnvAllowsRawOverride(t *testing.T) {
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", "")
+	t.Setenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY", "true")
+
+	cfg, err := escrowKeyConfigFromEnv("confidential-space")
+	if err != nil {
+		t.Fatalf("escrowKeyConfigFromEnv: %v", err)
+	}
+	if !cfg.allowRawFile {
+		t.Fatal("raw escrow key override should be allowed")
+	}
+}
+
+func TestEscrowKeyConfigFromEnvRejectsBadBase64(t *testing.T) {
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", "not base64")
+
+	if _, err := escrowKeyConfigFromEnv("confidential-space"); err == nil {
+		t.Fatal("expected invalid base64 to fail")
+	}
+}
+
+func TestEscrowKeyConfigFromEnvRejectsWrongKeySize(t *testing.T) {
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", base64.StdEncoding.EncodeToString([]byte("short")))
+
+	if _, err := escrowKeyConfigFromEnv("confidential-space"); err == nil {
+		t.Fatal("expected wrong key size to fail")
+	}
+}

--- a/cmd/aileron-enclave/server.go
+++ b/cmd/aileron-enclave/server.go
@@ -47,7 +47,11 @@ type enclaveServer struct {
 }
 
 func newEnclaveServer(log *slog.Logger, registry *connector.Registry, sourceReg *source.Registry, provider, dataDir string) (*enclaveServer, error) {
-	escrow, err := newEscrowStore(dataDir)
+	return newEnclaveServerWithEscrowKeyConfig(log, registry, sourceReg, provider, dataDir, escrowKeyConfig{allowRawFile: true})
+}
+
+func newEnclaveServerWithEscrowKeyConfig(log *slog.Logger, registry *connector.Registry, sourceReg *source.Registry, provider, dataDir string, keyCfg escrowKeyConfig) (*enclaveServer, error) {
+	escrow, err := newEscrowStoreWithKeyConfig(dataDir, keyCfg)
 	if err != nil {
 		return nil, fmt.Errorf("initializing escrow store: %w", err)
 	}

--- a/docs/src/content/docs/deployment/cloud.md
+++ b/docs/src/content/docs/deployment/cloud.md
@@ -55,6 +55,8 @@ Each service needs a domain or URL. The auth domain points to the **server** ser
 | `AILERON_ENCLAVE_URL` | No | | Base URL of the enclave binary. Required when `AILERON_TEE_PROVIDER=confidential-space` |
 | `AILERON_ENCLAVE_IMAGE_DIGEST` | No | | Expected container image digest (`sha256:...`) for attestation verification |
 | `AILERON_GCP_PROJECT_ID` | No | | Expected GCP project ID for attestation verification |
+| `AILERON_ENCLAVE_ESCROW_KEY_B64` | Required for production enclave persistence | | Base64-encoded 32-byte escrow encryption key supplied only to the enclave workload |
+| `AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY` | No | `false` in Confidential Space, `true` locally | Legacy override that allows `escrow.key` in the enclave data directory |
 | `ANTHROPIC_API_KEY` | No | | Anthropic API key. Enables AI-powered draft generation when set |
 | `AILERON_LLM_MODEL_RESEARCH` | No | `claude-haiku-4-5-20251001` | Model for the research round (tool-call decisions, context gathering). Use a fast model — quality is less important than speed here. Any Anthropic model ID works |
 | `AILERON_LLM_MODEL_SYNTHESIS` | No | `claude-sonnet-4-6` | Model for the synthesis round (composing the final reply in the user's voice). Use a capable model — this is the quality-sensitive step |

--- a/docs/src/content/docs/deployment/tee-enclave.md
+++ b/docs/src/content/docs/deployment/tee-enclave.md
@@ -222,7 +222,20 @@ Expected response:
 
 ## Persistent escrow storage
 
-Escrowed credentials are persisted to disk so they survive enclave restarts. The enclave writes two files inside its data directory:
+Escrowed credentials are persisted to disk so they survive enclave restarts. In strict Confidential Space mode, the enclave requires the escrow data-encryption key to be supplied from outside the operator-mounted data directory:
+
+| Environment variable | Purpose |
+|----------------------|---------|
+| `AILERON_ENCLAVE_ESCROW_KEY_B64` | Base64-encoded 32-byte AES-256-GCM data-encryption key for `escrow.dat` |
+| `AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY=true` | Legacy/dev override that allows `escrow.key` to be read or created in the data directory |
+
+When `AILERON_ENCLAVE_ESCROW_KEY_B64` is set, the enclave writes only encrypted escrow data and refuses to start if a raw `escrow.key` file is present in the data directory:
+
+| File | Purpose |
+|------|---------|
+| `escrow.dat` | Encrypted escrow entries (credentials, grant IDs, expiry times) |
+
+When the legacy raw-key override is enabled, the enclave also writes a raw key file:
 
 | File | Purpose |
 |------|---------|
@@ -246,9 +259,10 @@ The defaults work for most deployments. Override the directory when:
 
 ### Security notes
 
-- The DEK (`escrow.key`) is a 32-byte random key stored in plaintext on disk. In production, the Confidential Space VM's memory and disk are hardware-encrypted by AMD SEV-SNP, so the key is protected at rest by the TEE.
+- In `confidential-space` mode, the enclave refuses to create or read raw `escrow.key` files unless `AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY=true` is explicitly set.
+- `AILERON_ENCLAVE_ESCROW_KEY_B64` must be injected only into the expected enclave workload. Do not place this value on the mounted escrow data disk.
 - `escrow.dat` is encrypted with AES-256-GCM using the DEK. Even if the file is exfiltrated without the key, the contents are unreadable.
-- If either file is corrupt or missing, the enclave starts fresh with an empty escrow store. Existing in-memory entries are not affected.
+- If `escrow.dat` is corrupt or cannot be decrypted with the supplied key, the enclave starts fresh with an empty escrow store. Existing in-memory entries are not affected.
 - Expired entries are evicted on startup and periodically (every 10 minutes).
 
 ## How attestation works


### PR DESCRIPTION
## Summary
- add strict escrow key configuration for the enclave binary
- require `AILERON_ENCLAVE_ESCROW_KEY_B64` in `confidential-space` mode unless the legacy raw-key override is explicitly enabled
- stop writing `escrow.key` when an external key is supplied
- reject strict external-key startup if a raw `escrow.key` already exists in the data directory
- document strict-mode escrow key behavior and deployment variables
- add tests proving escrow data cannot be decrypted with the wrong external key

Refs #326

## Tests
- `go test ./cmd/aileron-enclave ./internal/enclave/...`
- `go test -coverprofile=/tmp/phase5-all.out ./cmd/aileron-enclave ./internal/enclave/...`

Focused coverage:
- `cmd/aileron-enclave`: 83.5%
- `internal/enclave`: 87.3%
- `internal/enclave/gcs`: 87.1%
- `internal/enclave/local`: 91.1%

Local patch-line approximation from the combined coverage profile: 43/53, 81.13%.