### PR TITLE
feat(enclave): add attested escrow key release

### DIFF
--- a/cmd/aileron-enclave/escrow.go
+++ b/cmd/aileron-enclave/escrow.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"crypto/rand"
 	"encoding/hex"
 	"encoding/json"
@@ -39,6 +40,7 @@ type escrowStore struct {
 
 type escrowKeyConfig struct {
 	key          []byte
+	keyProvider  escrowKeyProvider
 	allowRawFile bool
 }
 
@@ -63,10 +65,21 @@ func newEscrowStore(dataDir string) (*escrowStore, error) {
 }
 
 func newEscrowStoreWithKeyConfig(dataDir string, cfg escrowKeyConfig) (*escrowStore, error) {
+	return newEscrowStoreWithKeyConfigContext(context.Background(), dataDir, cfg)
+}
+
+func newEscrowStoreWithKeyConfigContext(ctx context.Context, dataDir string, cfg escrowKeyConfig) (*escrowStore, error) {
 	s := &escrowStore{entries: make(map[string]*escrowEntry)}
 
 	if dataDir == "" {
 		return s, nil
+	}
+	if cfg.keyProvider != nil {
+		key, err := cfg.keyProvider.Key(ctx)
+		if err != nil {
+			return nil, fmt.Errorf("loading escrow key: %w", err)
+		}
+		cfg.key = key
 	}
 	if len(cfg.key) > 0 && len(cfg.key) != 32 {
 		return nil, fmt.Errorf("escrow key: expected 32 bytes, got %d", len(cfg.key))

--- a/cmd/aileron-enclave/escrow_key_provider.go
+++ b/cmd/aileron-enclave/escrow_key_provider.go
@@ -1,0 +1,89 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+)
+
+type escrowKeyProvider interface {
+	Key(ctx context.Context) ([]byte, error)
+}
+
+type staticEscrowKeyProvider struct {
+	key []byte
+}
+
+func (p staticEscrowKeyProvider) Key(context.Context) ([]byte, error) {
+	return copyBytes(p.key), nil
+}
+
+type attestedEscrowKeyProvider struct {
+	provider     string
+	releaseURL   string
+	audience     string
+	httpClient   *http.Client
+	tokenFetcher func(provider, audience string, nonces []string) (string, error)
+}
+
+type keyReleaseRequest struct {
+	AttestationToken string `json:"attestation_token"`
+}
+
+type keyReleaseResponse struct {
+	EscrowKey string `json:"escrow_key_b64"`
+}
+
+func (p attestedEscrowKeyProvider) Key(ctx context.Context) ([]byte, error) {
+	if p.releaseURL == "" {
+		return nil, fmt.Errorf("escrow key release URL required")
+	}
+	fetch := p.tokenFetcher
+	if fetch == nil {
+		fetch = fetchAttestationToken
+	}
+	token, err := fetch(p.provider, p.audience, nil)
+	if err != nil {
+		return nil, fmt.Errorf("fetching key-release attestation token: %w", err)
+	}
+
+	payload, err := json.Marshal(keyReleaseRequest{AttestationToken: token})
+	if err != nil {
+		return nil, err
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, p.releaseURL, bytes.NewReader(payload))
+	if err != nil {
+		return nil, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+
+	client := p.httpClient
+	if client == nil {
+		client = &http.Client{Timeout: 10 * time.Second}
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("requesting escrow key release: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode < 200 || resp.StatusCode >= 300 {
+		return nil, fmt.Errorf("escrow key release returned %d", resp.StatusCode)
+	}
+
+	var out keyReleaseResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decoding escrow key release response: %w", err)
+	}
+	key, err := base64.StdEncoding.DecodeString(out.EscrowKey)
+	if err != nil {
+		return nil, fmt.Errorf("decoding released escrow key: %w", err)
+	}
+	if len(key) != 32 {
+		return nil, fmt.Errorf("released escrow key: expected 32 bytes, got %d", len(key))
+	}
+	return key, nil
+}

--- a/cmd/aileron-enclave/escrow_key_provider_test.go
+++ b/cmd/aileron-enclave/escrow_key_provider_test.go
@@ -1,0 +1,140 @@
+package main
+
+import (
+	"context"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestAttestedEscrowKeyProviderReleasesKey(t *testing.T) {
+	key := []byte("01234567890123456789012345678901")
+	var gotRequest keyReleaseRequest
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPost {
+			t.Fatalf("method = %s, want POST", r.Method)
+		}
+		if got := r.Header.Get("Content-Type"); got != "application/json" {
+			t.Fatalf("content type = %q, want application/json", got)
+		}
+		if err := json.NewDecoder(r.Body).Decode(&gotRequest); err != nil {
+			t.Fatalf("Decode request: %v", err)
+		}
+		if gotRequest.AttestationToken != "token-123" {
+			t.Fatalf("attestation token = %q", gotRequest.AttestationToken)
+		}
+		if err := json.NewEncoder(w).Encode(keyReleaseResponse{
+			EscrowKey: base64.StdEncoding.EncodeToString(key),
+		}); err != nil {
+			t.Fatalf("Encode response: %v", err)
+		}
+	}))
+	defer server.Close()
+
+	provider := attestedEscrowKeyProvider{
+		provider:   "confidential-space",
+		releaseURL: server.URL,
+		audience:   "key-release-audience",
+		httpClient: server.Client(),
+		tokenFetcher: func(provider, audience string, nonces []string) (string, error) {
+			if provider != "confidential-space" {
+				t.Fatalf("provider = %q", provider)
+			}
+			if audience != "key-release-audience" {
+				t.Fatalf("audience = %q", audience)
+			}
+			if len(nonces) != 0 {
+				t.Fatalf("nonces = %v, want none", nonces)
+			}
+			return "token-123", nil
+		},
+	}
+
+	got, err := provider.Key(context.Background())
+	if err != nil {
+		t.Fatalf("Key: %v", err)
+	}
+	if string(got) != string(key) {
+		t.Fatalf("key = %q, want %q", got, key)
+	}
+}
+
+func TestAttestedEscrowKeyProviderRequiresReleaseURL(t *testing.T) {
+	provider := attestedEscrowKeyProvider{}
+
+	if _, err := provider.Key(context.Background()); err == nil {
+		t.Fatal("expected missing release URL to fail")
+	}
+}
+
+func TestAttestedEscrowKeyProviderReportsTokenFetchError(t *testing.T) {
+	provider := attestedEscrowKeyProvider{
+		releaseURL: "https://key-release.example.com/escrow",
+		tokenFetcher: func(string, string, []string) (string, error) {
+			return "", errors.New("token unavailable")
+		},
+	}
+
+	if _, err := provider.Key(context.Background()); err == nil {
+		t.Fatal("expected token fetch failure")
+	}
+}
+
+func TestAttestedEscrowKeyProviderReportsReleaseStatus(t *testing.T) {
+	server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "denied", http.StatusForbidden)
+	}))
+	defer server.Close()
+
+	provider := attestedEscrowKeyProvider{
+		releaseURL:   server.URL,
+		httpClient:   server.Client(),
+		tokenFetcher: func(string, string, []string) (string, error) { return "token-123", nil },
+	}
+
+	if _, err := provider.Key(context.Background()); err == nil {
+		t.Fatal("expected non-2xx release response to fail")
+	}
+}
+
+func TestAttestedEscrowKeyProviderRejectsMalformedResponse(t *testing.T) {
+	tests := []struct {
+		name     string
+		response string
+	}{
+		{
+			name:     "invalid json",
+			response: "{",
+		},
+		{
+			name:     "invalid base64",
+			response: `{"escrow_key_b64":"not base64"}`,
+		},
+		{
+			name:     "wrong key size",
+			response: `{"escrow_key_b64":"` + base64.StdEncoding.EncodeToString([]byte("short")) + `"}`,
+		},
+	}
+
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			server := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				w.Header().Set("Content-Type", "application/json")
+				_, _ = w.Write([]byte(tt.response))
+			}))
+			defer server.Close()
+
+			provider := attestedEscrowKeyProvider{
+				releaseURL:   server.URL,
+				httpClient:   server.Client(),
+				tokenFetcher: func(string, string, []string) (string, error) { return "token-123", nil },
+			}
+			if _, err := provider.Key(context.Background()); err == nil {
+				t.Fatal("expected malformed release response to fail")
+			}
+		})
+	}
+}

--- a/cmd/aileron-enclave/escrow_test.go
+++ b/cmd/aileron-enclave/escrow_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"os"
 	"path/filepath"
 	"testing"
@@ -414,6 +415,38 @@ func TestEscrowPersistence_ExternalKeyDoesNotWriteRawKeyFile(t *testing.T) {
 	s2, err := newEscrowStoreWithKeyConfig(dir, escrowKeyConfig{key: key})
 	if err != nil {
 		t.Fatalf("reload with external key: %v", err)
+	}
+	got, err := s2.Get(id)
+	if err != nil {
+		t.Fatalf("Get after reload: %v", err)
+	}
+	if string(got) != "cred-one" {
+		t.Fatalf("got %q, want cred-one", got)
+	}
+}
+
+func TestEscrowPersistence_KeyProviderDoesNotWriteRawKeyFile(t *testing.T) {
+	dir := t.TempDir()
+	key := []byte("01234567890123456789012345678901")
+
+	s1, err := newEscrowStoreWithKeyConfigContext(context.Background(), dir, escrowKeyConfig{
+		keyProvider:  staticEscrowKeyProvider{key: key},
+		allowRawFile: false,
+	})
+	if err != nil {
+		t.Fatalf("newEscrowStoreWithKeyConfigContext: %v", err)
+	}
+	id := s1.Store(testEscrowRequest("grant-1", "oauth", nil), []byte("cred-one"), time.Now().Add(time.Hour))
+	if _, err := os.Stat(filepath.Join(dir, "escrow.key")); !os.IsNotExist(err) {
+		t.Fatalf("expected no raw escrow.key file, got err=%v", err)
+	}
+
+	s2, err := newEscrowStoreWithKeyConfigContext(context.Background(), dir, escrowKeyConfig{
+		keyProvider:  staticEscrowKeyProvider{key: key},
+		allowRawFile: false,
+	})
+	if err != nil {
+		t.Fatalf("reload with key provider: %v", err)
 	}
 	got, err := s2.Get(id)
 	if err != nil {

--- a/cmd/aileron-enclave/main.go
+++ b/cmd/aileron-enclave/main.go
@@ -127,9 +127,27 @@ func escrowKeyConfigFromEnv(provider string) (escrowKeyConfig, error) {
 		cfg.allowRawFile = true
 	}
 	keyB64 := os.Getenv("AILERON_ENCLAVE_ESCROW_KEY_B64")
+	releaseURL := os.Getenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL")
+	if keyB64 != "" && releaseURL != "" {
+		return escrowKeyConfig{}, fmt.Errorf("set only one of AILERON_ENCLAVE_ESCROW_KEY_B64 or AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL")
+	}
+	if releaseURL != "" {
+		audience := os.Getenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_AUDIENCE")
+		if audience == "" {
+			audience = releaseURL
+		}
+		cfg.keyProvider = attestedEscrowKeyProvider{
+			provider:   provider,
+			releaseURL: releaseURL,
+			audience:   audience,
+		}
+		cfg.allowRawFile = false
+		return cfg, nil
+	}
 	if keyB64 == "" {
 		return cfg, nil
 	}
+
 	key, err := base64.StdEncoding.DecodeString(keyB64)
 	if err != nil {
 		return escrowKeyConfig{}, fmt.Errorf("decoding AILERON_ENCLAVE_ESCROW_KEY_B64: %w", err)

--- a/cmd/aileron-enclave/main_test.go
+++ b/cmd/aileron-enclave/main_test.go
@@ -8,6 +8,7 @@ import (
 func TestEscrowKeyConfigFromEnvConfidentialSpaceRequiresExternalKey(t *testing.T) {
 	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", "")
 	t.Setenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY", "")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL", "")
 
 	cfg, err := escrowKeyConfigFromEnv("confidential-space")
 	if err != nil {
@@ -24,6 +25,7 @@ func TestEscrowKeyConfigFromEnvConfidentialSpaceRequiresExternalKey(t *testing.T
 func TestEscrowKeyConfigFromEnvLocalAllowsRawKeyFile(t *testing.T) {
 	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", "")
 	t.Setenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY", "")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL", "")
 
 	cfg, err := escrowKeyConfigFromEnv("local")
 	if err != nil {
@@ -38,6 +40,7 @@ func TestEscrowKeyConfigFromEnvExternalKey(t *testing.T) {
 	key := []byte("01234567890123456789012345678901")
 	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", base64.StdEncoding.EncodeToString(key))
 	t.Setenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY", "true")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL", "")
 
 	cfg, err := escrowKeyConfigFromEnv("confidential-space")
 	if err != nil {
@@ -51,9 +54,65 @@ func TestEscrowKeyConfigFromEnvExternalKey(t *testing.T) {
 	}
 }
 
+func TestEscrowKeyConfigFromEnvAttestedKeyRelease(t *testing.T) {
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", "")
+	t.Setenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY", "true")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL", "https://key-release.example.com/escrow")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_AUDIENCE", "key-release-audience")
+
+	cfg, err := escrowKeyConfigFromEnv("confidential-space")
+	if err != nil {
+		t.Fatalf("escrowKeyConfigFromEnv: %v", err)
+	}
+	if cfg.allowRawFile {
+		t.Fatal("attested key release should disable raw escrow key files")
+	}
+	if len(cfg.key) != 0 {
+		t.Fatal("expected no static key")
+	}
+	provider, ok := cfg.keyProvider.(attestedEscrowKeyProvider)
+	if !ok {
+		t.Fatalf("key provider = %T, want attestedEscrowKeyProvider", cfg.keyProvider)
+	}
+	if provider.releaseURL != "https://key-release.example.com/escrow" {
+		t.Fatalf("releaseURL = %q", provider.releaseURL)
+	}
+	if provider.audience != "key-release-audience" {
+		t.Fatalf("audience = %q", provider.audience)
+	}
+}
+
+func TestEscrowKeyConfigFromEnvAttestedKeyReleaseDefaultsAudienceToURL(t *testing.T) {
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL", "https://key-release.example.com/escrow")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_AUDIENCE", "")
+
+	cfg, err := escrowKeyConfigFromEnv("confidential-space")
+	if err != nil {
+		t.Fatalf("escrowKeyConfigFromEnv: %v", err)
+	}
+	provider, ok := cfg.keyProvider.(attestedEscrowKeyProvider)
+	if !ok {
+		t.Fatalf("key provider = %T, want attestedEscrowKeyProvider", cfg.keyProvider)
+	}
+	if provider.audience != provider.releaseURL {
+		t.Fatalf("audience = %q, want release URL %q", provider.audience, provider.releaseURL)
+	}
+}
+
+func TestEscrowKeyConfigFromEnvRejectsAmbiguousKeySources(t *testing.T) {
+	key := []byte("01234567890123456789012345678901")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", base64.StdEncoding.EncodeToString(key))
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL", "https://key-release.example.com/escrow")
+
+	if _, err := escrowKeyConfigFromEnv("confidential-space"); err == nil {
+		t.Fatal("expected multiple key sources to fail")
+	}
+}
+
 func TestEscrowKeyConfigFromEnvAllowsRawOverride(t *testing.T) {
 	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", "")
 	t.Setenv("AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY", "true")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL", "")
 
 	cfg, err := escrowKeyConfigFromEnv("confidential-space")
 	if err != nil {
@@ -66,6 +125,7 @@ func TestEscrowKeyConfigFromEnvAllowsRawOverride(t *testing.T) {
 
 func TestEscrowKeyConfigFromEnvRejectsBadBase64(t *testing.T) {
 	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", "not base64")
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL", "")
 
 	if _, err := escrowKeyConfigFromEnv("confidential-space"); err == nil {
 		t.Fatal("expected invalid base64 to fail")
@@ -74,6 +134,7 @@ func TestEscrowKeyConfigFromEnvRejectsBadBase64(t *testing.T) {
 
 func TestEscrowKeyConfigFromEnvRejectsWrongKeySize(t *testing.T) {
 	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_B64", base64.StdEncoding.EncodeToString([]byte("short")))
+	t.Setenv("AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL", "")
 
 	if _, err := escrowKeyConfigFromEnv("confidential-space"); err == nil {
 		t.Fatal("expected wrong key size to fail")

--- a/docs/src/content/docs/deployment/cloud.md
+++ b/docs/src/content/docs/deployment/cloud.md
@@ -55,7 +55,9 @@ Each service needs a domain or URL. The auth domain points to the **server** ser
 | `AILERON_ENCLAVE_URL` | No | | Base URL of the enclave binary. Required when `AILERON_TEE_PROVIDER=confidential-space` |
 | `AILERON_ENCLAVE_IMAGE_DIGEST` | No | | Expected container image digest (`sha256:...`) for attestation verification |
 | `AILERON_GCP_PROJECT_ID` | No | | Expected GCP project ID for attestation verification |
-| `AILERON_ENCLAVE_ESCROW_KEY_B64` | Required for production enclave persistence | | Base64-encoded 32-byte escrow encryption key supplied only to the enclave workload |
+| `AILERON_ENCLAVE_ESCROW_KEY_B64` | Required for production enclave persistence unless using attested release | | Base64-encoded 32-byte escrow encryption key supplied only to the enclave workload |
+| `AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL` | Required for attested production key release unless using `AILERON_ENCLAVE_ESCROW_KEY_B64` | | Endpoint that receives the enclave attestation token and returns `{"escrow_key_b64":"..."}` after verifying the expected workload identity |
+| `AILERON_ENCLAVE_ESCROW_KEY_RELEASE_AUDIENCE` | No | Release URL | Audience claim requested for the key-release attestation token |
 | `AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY` | No | `false` in Confidential Space, `true` locally | Legacy override that allows `escrow.key` in the enclave data directory |
 | `ANTHROPIC_API_KEY` | No | | Anthropic API key. Enables AI-powered draft generation when set |
 | `AILERON_LLM_MODEL_RESEARCH` | No | `claude-haiku-4-5-20251001` | Model for the research round (tool-call decisions, context gathering). Use a fast model — quality is less important than speed here. Any Anthropic model ID works |

--- a/docs/src/content/docs/deployment/tee-enclave.md
+++ b/docs/src/content/docs/deployment/tee-enclave.md
@@ -227,9 +227,13 @@ Escrowed credentials are persisted to disk so they survive enclave restarts. In 
 | Environment variable | Purpose |
 |----------------------|---------|
 | `AILERON_ENCLAVE_ESCROW_KEY_B64` | Base64-encoded 32-byte AES-256-GCM data-encryption key for `escrow.dat` |
+| `AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL` | Attested key-release endpoint that receives the enclave attestation token and returns `{"escrow_key_b64":"..."}` |
+| `AILERON_ENCLAVE_ESCROW_KEY_RELEASE_AUDIENCE` | Optional attestation audience for the key-release request; defaults to the release URL |
 | `AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY=true` | Legacy/dev override that allows `escrow.key` to be read or created in the data directory |
 
-When `AILERON_ENCLAVE_ESCROW_KEY_B64` is set, the enclave writes only encrypted escrow data and refuses to start if a raw `escrow.key` file is present in the data directory:
+Set exactly one of `AILERON_ENCLAVE_ESCROW_KEY_B64` or `AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL` in production. With attested key release, the enclave fetches a Confidential Space identity token, posts it to the release URL, and uses the returned 32-byte key only in enclave memory. The key-release service is responsible for verifying the token claims, including the expected project, audience, and image digest, before returning the key.
+
+When an external key source is set, the enclave writes only encrypted escrow data and refuses to start if a raw `escrow.key` file is present in the data directory:
 
 | File | Purpose |
 |------|---------|
@@ -260,7 +264,7 @@ The defaults work for most deployments. Override the directory when:
 ### Security notes
 
 - In `confidential-space` mode, the enclave refuses to create or read raw `escrow.key` files unless `AILERON_ENCLAVE_ALLOW_RAW_ESCROW_KEY=true` is explicitly set.
-- `AILERON_ENCLAVE_ESCROW_KEY_B64` must be injected only into the expected enclave workload. Do not place this value on the mounted escrow data disk.
+- External escrow keys must be released only to the expected enclave workload. Do not place `AILERON_ENCLAVE_ESCROW_KEY_B64` on the mounted escrow data disk.
 - `escrow.dat` is encrypted with AES-256-GCM using the DEK. Even if the file is exfiltrated without the key, the contents are unreadable.
 - If `escrow.dat` is corrupt or cannot be decrypted with the supplied key, the enclave starts fresh with an empty escrow store. Existing in-memory entries are not affected.
 - Expired entries are evicted on startup and periodically (every 10 minutes).


### PR DESCRIPTION
## Summary
- add an attested escrow key-release provider for the enclave
- support AILERON_ENCLAVE_ESCROW_KEY_RELEASE_URL and optional audience env configuration
- keep strict external-key mode rejecting raw escrow.key files and document the production contract

## Tests
- go test ./cmd/aileron-enclave ./internal/enclave/...
- go test -coverprofile=/tmp/phase5b-all.out ./cmd/aileron-enclave ./internal/enclave/...

Refs #326