### PR TITLE
docs(adr): ADR-0003 action model + ADR-0002 amendment for FQN connector identity

### DIFF
--- a/docs/src/content/docs/adr/0002-connector-model.md
+++ b/docs/src/content/docs/adr/0002-connector-model.md
@@ -70,31 +70,37 @@ The hash is verified at install time *and* before every execution. The runtime r
 - Manifest desynchronization (the manifest was edited locally to grant more capability than the original publisher signed).
 - Accidental corruption.
 
-There are no version ranges, no `^1.2.x`-style ranges, no "latest" pseudo-version. What an action file declares is what runs. Updating a connector is an explicit, visible edit to the action files that reference it.
+There are no version ranges, no `^1.2.x`-style ranges, no "latest" pseudo-version. What an action file declares is what runs. Updating a connector is an explicit, visible edit to the action files that reference it. (See "Versioning is strict SemVer" below for the full version model.)
 
 ### Connector identity is a fully-qualified URI
 
-Connector names are not bare strings. They are fully-qualified URIs that encode both the *publication channel* and the *publisher's identity within that channel*:
+Connector names are not bare strings. They are fully-qualified URIs that encode the *publication channel*, the *publisher's identity within that channel*, and an optional *subpath* locating the connector within the publication source:
 
 ```
-<scheme>://<owner>/<connector>
+<scheme>://<owner>/<repo-or-namespace>/<...subpath>/<connector>
 ```
+
+For git-host schemes (`github://`, `gitlab://`), the first two segments after the scheme are the repo (`<owner>/<repo>`) and any further segments locate the connector within the repo's tree. For `hub://`, the path after the owner is the publisher's organizational choice within their Hub namespace.
 
 Examples:
 
 | FQN | Meaning |
 |---|---|
-| `github://aileron/slack` | Published from the `aileron` GitHub organization, repo `slack` |
-| `github://acme/stripe` | Published from the `acme` GitHub organization, repo `stripe` |
-| `gitlab://team/linear` | Published from the `team` GitLab namespace, repo `linear` |
-| `hub://aileron/slack` | Published to the Aileron Hub under `aileron`'s namespace |
+| `github://aileron/slack` | Repo `aileron/slack` on GitHub; one connector at the repo root |
+| `github://aileron/integrations/connectors/slack` | Repo `aileron/integrations` on GitHub; connector lives at `connectors/slack/` (monorepo) |
+| `github://aileron/integrations/connectors/discord` | Same repo as above; sibling connector |
+| `gitlab://team/linear` | Repo `team/linear` on GitLab; one connector at the repo root |
+| `hub://aileron/slack` | Aileron Hub, owner `aileron`, connector `slack` |
+| `hub://aileron/integrations/slack` | Aileron Hub, owner `aileron`, organized under `integrations/` |
 
-This is decentralized. The scheme plus path uniquely identifies a publication source; there is no central naming authority. Two organizations both publishing a connector named `slack` cannot collide — `github://acme/slack` and `github://other/slack` are distinct identities and produce distinct content hashes.
+This is decentralized. The scheme plus full path uniquely identifies a publication source; there is no central naming authority. Two organizations both publishing a connector named `slack` cannot collide — `github://acme/slack` and `github://other/slack` are distinct identities and produce distinct content hashes.
+
+**Monorepo support is first-class.** A single repo can house many connectors (and many actions — see ADR-0003) at distinct subpaths. Each artifact has its own manifest at its own path within the repo. Publishers organize subpaths however they like; common conventions like `connectors/<name>/` or `integrations/<service>/` will emerge but nothing is enforced.
 
 **Initial scheme set:**
 
-- `github://` — published as a GitHub release artifact under the named owner/repo.
-- `gitlab://` — published as a GitLab release artifact under the named owner/repo.
+- `github://` — published as a GitHub release artifact under the named owner/repo, optionally at a subpath within the repo.
+- `gitlab://` — published as a GitLab release artifact under the named owner/repo, optionally at a subpath within the repo.
 - `hub://` — published to the Aileron Hub. The Hub is one source among many, not a privileged namespace. `hub://` connectors are subject to the same identity, hash, and signing checks as any other source.
 
 Forward-compatible: additional schemes (custom forges, OCI registries, signed HTTPS URLs) can be added as the ecosystem matures. Schemes are added by code in Aileron's resolver, not by user configuration; an unknown scheme is a hard error at install.
@@ -110,6 +116,32 @@ All three checks must pass. The FQN alone grants nothing; the hash alone tells y
 **Forks are distinct connectors.** If `acme` forks `aileron/slack`, the fork's FQN is `github://acme/slack`. It is a separate connector from `github://aileron/slack` with its own version line, its own hash chain, and its own signing identity. Action files reference one or the other explicitly; there is no ambient "I forked it but kept the name" ambiguity.
 
 **Repository moves are republications.** If a publisher migrates from GitHub to GitLab, the connector's FQN changes from `github://owner/x` to `gitlab://owner/x`. Existing action references continue to work against locally-cached binaries (the hash is unchanged); updating to the new location is an explicit edit to the action file, never an automatic redirect.
+
+### Versioning is strict SemVer; hash is the immutable trust anchor
+
+Every connector version is a strict [Semantic Versioning](https://semver.org) string (`MAJOR.MINOR.PATCH`, with optional pre-release like `2.0.0-rc.1` and optional build metadata like `1.2.0+sha.abc`). The `version` field in the connector manifest and in action `[[requires.connectors]]` references must be a valid SemVer.
+
+Specifically excluded:
+- No `latest` pseudo-version. There is no implicit "give me the newest" — a version is always pinned.
+- No version ranges (`^1.2.x`, `~1.2`, `>=1.0`). Each reference resolves to one and only one version.
+- No date-based versioning (`2026.04.29`), no branch names, no commit SHAs in the `version` field. Commit identity is captured by the hash, not by the version.
+
+This is a deliberate constraint. Strict SemVer gives ecosystem tooling a known schema for "what's the next compatible release?" and "what would a major bump break?" Strict pinning ensures reproducibility from git: the action file declares exactly what runs, and what runs cannot change without a visible TOML edit.
+
+**Version is for human reasoning. Hash is for machine verification.**
+
+- The `version` field says *which release this claims to be*. It corresponds to a tag in the publication source.
+- The `hash` field says *exactly which bytes will run*. It is the SHA-256 of the connector binary plus its manifest.
+
+Tags are mutable on git hosts (a publisher can re-tag, force-push, delete and recreate a release). The hash is immutable. If the two ever disagree — for example, the publisher re-tagged `v1.2.0` after release with different bytes — the runtime detects the mismatch on next install or execution and fails loudly. Trust flows from the hash; the version is a label.
+
+**Multiple versions of the same connector coexist by construction.** Two actions in the same project can reference `github://aileron/slack@1.2.0` and `github://aileron/slack@2.0.0` simultaneously. Different hashes mean different entries in the content-addressed store; the runtime loads the version each action declares. There is no project-wide version resolution step; there is no "this conflicts with that" check.
+
+This drops out of the content-addressed model directly, but is worth stating explicitly because it makes monorepos and gradual migrations work without ceremony. Action A can pin an old, stable version while Action B adopts a new major; both run side by side.
+
+**Compact reference form.** In commands and provenance fields, `@<version>` is the canonical compact form: `aileron connector install github://aileron/slack@1.2.0`, `source = "hub://aileron/ship-update@1.0.0"`. In TOML manifests, the canonical form is `name` and `version` as separate fields so each is queryable, diffable, and updatable independently. Both forms are equivalent; the FQN identity does not include the version.
+
+The mechanics of *how* a version maps to a concrete fetch (tag conventions, release-asset layout, update discovery, prerelease handling) are resolver concerns and are deferred to the dependency-resolution ADR.
 
 ### Connectors declare their needs in a manifest
 
@@ -235,6 +267,7 @@ Rejected as deliberate scope reduction. Capability abstraction would require: a 
 
 ### Open implementation questions (deferred to subsequent ADRs)
 
+- *How does a `version` map to a concrete tag and release artifact in each scheme? How does `aileron connector check` discover available updates? How are pre-releases handled?* — deferred to the dependency-resolution ADR.
 - *How is the connector store laid out on disk, and how does the integrity-check pipeline interact with concurrent installs?* — deferred to the dependency-resolution ADR.
 - *Which sandbox technology is the default, and what are the OS-process escalation criteria?* — deferred to the sandbox-choice ADR.
 - *What does the install consent flow show, and what does the user actually click?* — deferred to the install-consent ADR.

--- a/docs/src/content/docs/adr/0002-connector-model.md
+++ b/docs/src/content/docs/adr/0002-connector-model.md
@@ -53,13 +53,13 @@ This keeps the runtime small, vendor-neutral, and decoupled from the long tail o
 
 ### Connectors are content-addressed: name + exact version + content hash
 
-A connector is identified by the triple `(name, version, hash)`. The name is a human-readable handle. The version is a semantic version. The hash is the content hash of the connector binary plus its manifest, taken together as a single byte stream.
+A connector is identified by the triple `(name, version, hash)`. The name is a fully-qualified URI (see next section). The version is a semantic version. The hash is the content hash of the connector binary plus its manifest, taken together as a single byte stream.
 
 Action files reference connectors by all three:
 
 ```toml
 [[requires.connectors]]
-name = "slack"
+name = "github://aileron/slack"
 version = "1.2.0"
 hash = "sha256:abc123..."
 ```
@@ -72,15 +72,53 @@ The hash is verified at install time *and* before every execution. The runtime r
 
 There are no version ranges, no `^1.2.x`-style ranges, no "latest" pseudo-version. What an action file declares is what runs. Updating a connector is an explicit, visible edit to the action files that reference it.
 
+### Connector identity is a fully-qualified URI
+
+Connector names are not bare strings. They are fully-qualified URIs that encode both the *publication channel* and the *publisher's identity within that channel*:
+
+```
+<scheme>://<owner>/<connector>
+```
+
+Examples:
+
+| FQN | Meaning |
+|---|---|
+| `github://aileron/slack` | Published from the `aileron` GitHub organization, repo `slack` |
+| `github://acme/stripe` | Published from the `acme` GitHub organization, repo `stripe` |
+| `gitlab://team/linear` | Published from the `team` GitLab namespace, repo `linear` |
+| `hub://aileron/slack` | Published to the Aileron Hub under `aileron`'s namespace |
+
+This is decentralized. The scheme plus path uniquely identifies a publication source; there is no central naming authority. Two organizations both publishing a connector named `slack` cannot collide — `github://acme/slack` and `github://other/slack` are distinct identities and produce distinct content hashes.
+
+**Initial scheme set:**
+
+- `github://` — published as a GitHub release artifact under the named owner/repo.
+- `gitlab://` — published as a GitLab release artifact under the named owner/repo.
+- `hub://` — published to the Aileron Hub. The Hub is one source among many, not a privileged namespace. `hub://` connectors are subject to the same identity, hash, and signing checks as any other source.
+
+Forward-compatible: additional schemes (custom forges, OCI registries, signed HTTPS URLs) can be added as the ecosystem matures. Schemes are added by code in Aileron's resolver, not by user configuration; an unknown scheme is a hard error at install.
+
+**FQN, hash, and signature relationships:**
+
+- The FQN is *identification*. It says where the connector came from and who is responsible for it.
+- The content hash is *the trust anchor for what runs*. The runtime executes only bytes whose hash matches.
+- The signature is *the identity that vouches for the binary at publish time*. Install tooling verifies the signature against keys associated with the FQN's authority (e.g., signing keys configured in the source repo).
+
+All three checks must pass. The FQN alone grants nothing; the hash alone tells you content but not provenance; the signature alone tells you who signed but not what. Together they are sufficient.
+
+**Forks are distinct connectors.** If `acme` forks `aileron/slack`, the fork's FQN is `github://acme/slack`. It is a separate connector from `github://aileron/slack` with its own version line, its own hash chain, and its own signing identity. Action files reference one or the other explicitly; there is no ambient "I forked it but kept the name" ambiguity.
+
+**Repository moves are republications.** If a publisher migrates from GitHub to GitLab, the connector's FQN changes from `github://owner/x` to `gitlab://owner/x`. Existing action references continue to work against locally-cached binaries (the hash is unchanged); updating to the new location is an explicit edit to the action file, never an automatic redirect.
+
 ### Connectors declare their needs in a manifest
 
 The manifest is a pure-TOML file shipped alongside the binary. Its only job is to declare what the connector requires from the runtime:
 
 ```toml
 [connector]
-name = "gmail"
+name = "github://acme/gmail"
 version = "1.2.3"
-publisher = "acme.dev"
 provenance_hash = "sha256:abc123..."
 
 [capabilities.network]
@@ -97,11 +135,13 @@ imports = ["wasi:http/outgoing-handler", "wasi:cli/stdout"]
 intents = ["send_email", "draft_email"]
 ```
 
+The `name` field must match the FQN under which the binary was published. Install tooling verifies this — a binary fetched from `github://acme/gmail` whose manifest declares `name = "github://other/gmail"` is rejected.
+
 The manifest is a *request*. The runtime grants nothing that is not declared in it. Capability requests at execution time that exceed the manifest's grant are denied at the sandbox boundary; the connector's process is terminated and the action fails with a structured error.
 
 Manifest fields:
 
-- `[connector]` — identity. Name, version, publisher, provenance hash for the binary.
+- `[connector]` — identity. Fully-qualified URI name, semantic version, content hash of the binary.
 - `[capabilities.network]` — outbound network grants. Pinned to specific `host:port` pairs; no wildcards.
 - `[capabilities.credential]` — credential kinds and scopes the connector needs. The connector declares the *type*; the user binds a concrete vault entry at install or first use.
 - `[capabilities.runtime]` — host-function imports the connector uses (audit emit, logging, time, RNG, etc.).
@@ -117,11 +157,13 @@ This is a structural property, not a UX preference. A malicious connector cannot
 
 The mechanics of how the user binds an abstract capability to a concrete resource (the install-time UI, the first-use flow, the rebind command) are out of scope for this ADR.
 
-### Publisher identity and provenance hash
+### Publisher identity, signing, and provenance hash
 
-Each manifest carries `publisher` and `provenance_hash` fields. The publisher is the cryptographic identity that signed the binary. The provenance hash records the build artifact's hash at publish time.
+The publisher is implicit in the FQN's authority — `github://acme/gmail` is published by the `acme` GitHub organization. Signing keys are associated with that authority through the publication channel's own conventions (e.g., signing keys configured in the source repo or via sigstore identities tied to the org).
 
-The runtime treats publisher identity as *information*, not as authorization. A connector signed by a known publisher and a connector signed by an unknown publisher both go through the same install consent path; the publisher field is shown to the user, and the Hub may use it to organize browse views, but signature presence does not bypass anything.
+Install tooling verifies the binary's signature against keys authorized for the FQN's authority. A connector named `github://acme/gmail` signed by a key not associated with `acme`'s GitHub org is rejected at install. The `provenance_hash` field in the manifest records the binary's content hash at publish time; the runtime checks this matches actual on-disk bytes before every execution.
+
+The runtime treats signature *presence* as information, not as authorization. A signed connector and an unsigned connector both go through the same install consent path; signature status is shown to the user (and the Hub may use it to organize browse views), but a valid signature does not bypass any capability check or skip the consent prompt.
 
 This keeps the trust model honest. Signing tells the user *who* is making a claim about a binary; it does not tell the runtime *whether* to grant the binary capabilities. Capability grants come exclusively from the user's install consent.
 
@@ -174,15 +216,16 @@ Rejected as deliberate scope reduction. Capability abstraction would require: a 
 
 ### For action authors
 
-- Actions name connectors directly: `slack@1.2.0` with hash. No abstract capability names to look up.
+- Actions name connectors by FQN: `github://aileron/slack` at version `1.2.0` with hash. No abstract capability names to look up; no bare `slack` that could mean any of several publishers.
 - The capability subset an action uses is declared in the action file (e.g. `capabilities = ["chat:write"]` is a subset of the connector's full grant). The runtime enforces this subset *in addition* to the connector's manifest. Defense in depth.
 - Updating a connector is a visible edit to action files that reference it. There is no automatic "follow latest" behavior.
 
 ### For the Hub and distribution
 
-- The Hub indexes connectors by `(name, version, publisher, hash)` and serves their binaries plus manifests.
+- The Hub indexes connectors by `(FQN, version, hash)` and serves their binaries plus manifests. Hub-published connectors carry `hub://` FQNs.
+- The Hub does not own a privileged namespace. A developer browsing the Hub may install a `hub://` connector or a `github://` / `gitlab://` connector through the same flow; the Hub surfaces what it serves and the FQN tells the user where everything else came from.
 - Discovery surfaces (browse, search) use the `provides.intents` field and the connector's documentation.
-- The Hub validates manifests at publish time. Manifests with malformed or contradictory capability declarations do not enter the catalog.
+- The Hub validates manifests at publish time. Manifests with malformed or contradictory capability declarations, or whose `name` does not match the FQN they're being published under, do not enter the catalog.
 
 ### For security and audit
 
@@ -203,9 +246,8 @@ Rejected as deliberate scope reduction. Capability abstraction would require: a 
 
 ```toml
 [connector]
-name = "gmail"
+name = "github://acme/gmail"
 version = "1.2.3"
-publisher = "acme.dev"
 provenance_hash = "sha256:abc123..."
 
 [capabilities.network]
@@ -226,13 +268,13 @@ intents = ["send_email", "draft_email"]
 
 ```toml
 [[requires.connectors]]
-name = "gmail"
+name = "github://acme/gmail"
 version = "1.2.3"
 hash = "sha256:abc123..."
 capabilities = ["oauth2"]
 ```
 
-The action declares the connector it needs (with exact version and hash) and the subset of the connector's capability grant it actually uses. The runtime enforces both: the connector cannot exceed its manifest, and the action cannot use capabilities the action did not declare. Two boundaries. Defense in depth.
+The action declares the connector it needs (with FQN, exact version, and hash) and the subset of the connector's capability grant it actually uses. The runtime enforces both: the connector cannot exceed its manifest, and the action cannot use capabilities the action did not declare. Two boundaries. Defense in depth.
 
 ### Capability denial at runtime
 
@@ -242,7 +284,7 @@ A connector whose manifest declares only `gmail.googleapis.com:443` attempts to 
 {
   "error": {
     "class": "capability_denied",
-    "connector": "gmail@1.2.3",
+    "connector": "github://acme/gmail@1.2.3",
     "requested": "network:evil.example.com:443",
     "granted": ["network:gmail.googleapis.com:443", "network:oauth2.googleapis.com:443"],
     "audit_id": "audit-7f3e..."

--- a/docs/src/content/docs/adr/0003-action-model.md
+++ b/docs/src/content/docs/adr/0003-action-model.md
@@ -1,0 +1,279 @@
+---
+title: "ADR-0003: Action Model"
+description: "Atomic actions; depend on connectors with explicit version + hash + capability subsets; copied into the project on install"
+order: 3
+---
+
+
+<div class="meta">
+<table>
+  <tr><th>Status</th><td>Accepted</td></tr>
+  <tr><th>Date</th><td>2026-04-29</td></tr>
+  <tr><th>Tracking</th><td><a href="https://github.com/ALRubinger/aileron/issues/343">#343</a></td></tr>
+</table>
+</div>
+
+## Context
+
+Connectors (ADR-0002) bring the ability to talk to a specific external service: an OAuth flow, an HTTP request shape, the right error handling. Actions are the layer above connectors — they describe a *purpose* the agent can fulfill. "Post a ship-update to Slack." "File a bug in Linear." "Send an email reply." Each action composes one or more connector operations into a unit the agent can invoke and the user can reason about.
+
+The architectural questions for actions are different from those for connectors:
+
+- Where does the action manifest *live*? In a registry the runtime fetches from, or in the developer's own repo?
+- Who *owns* the action after it's installed — the publisher who wrote it, or the developer who installed it?
+- How do actions *compose* — through an internal dependency graph, or by emergent agent orchestration?
+- What does the action declare beyond "use this connector" — does it pin a capability subset, or inherit the connector's full grant?
+
+These are not decisions about runtime mechanics; they are decisions about the contract between Aileron, the action author, the developer, and the agent. They shape what code lives where, what gets reviewed in PRs, and what surprises are possible at runtime.
+
+This ADR ratifies that contract.
+
+## Decision
+
+### An action is a single declarative file owned by the developer
+
+An action is a single file: TOML frontmatter declaring the contract, Markdown body documenting the action and serving as the LLM-facing function description (per ADR-0001). It lives in the developer's project, by convention under `actions/`, and is checked into git like any other source file.
+
+```
+project/
+├── actions/
+│   ├── ship-update.md
+│   ├── reply-to-pm.md
+│   └── file-bug.md
+├── aileron.toml
+└── src/
+```
+
+The action file is *the* contract Aileron executes. There is no separate manifest, no generated artifact, no lock file. Reading the file tells you exactly what will run, against which connector versions, with which capabilities. PR review is meaningful by construction — the diff *is* the change in execution.
+
+### Actions are copied on install, not registered
+
+`aileron action add ship-update` fetches a template from the Hub, *copies* it into the developer's project, and exits. From that moment the developer owns the file. They can edit it, restructure it, retitle it, change the connector versions it references, modify the prompts and triggers — and none of it requires anyone's permission or a republish to the Hub.
+
+```
+$ aileron action add ship-update
+→ Fetching action 'ship-update' from Aileron Hub...
+✓ Action file written to actions/ship-update.md
+  Source: hub://aileron/ship-update@1.0.0
+```
+
+This is the ShadCN distribution model applied to actions: the Hub is a curated catalog of *starting-point templates*, not a runtime registry. Aileron does not phone the Hub at runtime to "load an action"; it reads the local file. A project can be reproduced from git alone, with no Hub access.
+
+The action file records its provenance (`source = "hub://..."`) so update tooling can later offer to fetch a newer template version, but the local copy remains canonical until the developer accepts a diff.
+
+### Actions are atomic — no inter-action dependencies
+
+An action does one thing. It does not declare dependencies on other actions. There is no action-to-action import mechanism, no "extends," no shared lifecycle, no compositional language for chaining actions.
+
+When a developer wants a compound operation — "ship-update + create-followup-ticket + block-calendar" — they have two options:
+
+1. **Let the agent orchestrate.** The agent already calls actions; chaining `ship-update` then `create-followup-ticket` then `block-calendar` in conversation is its native mode. This is the default and almost always the right choice.
+2. **Write a new action that performs all three.** The new action declares dependencies on `slack`, `linear`, and `gcal` connectors (rather than on three other actions) and orchestrates the connector calls itself.
+
+Both options keep the dependency graph at depth 1: actions depend on connectors. Connectors depend on nothing inside Aileron.
+
+This is a deliberate simplification, not a deferred decision. Action-to-action dependencies would introduce a transitive dependency graph (versioning, conflict resolution, lifecycle ordering, partial-failure semantics, debugging across action boundaries) for marginal value. The two existing composition paths cover the use cases without the graph.
+
+### Action files declare connector dependencies and capability subsets
+
+Each action file lists the connectors it uses. For each connector, it pins the exact version, the content hash (per ADR-0002), and the *subset* of the connector's declared capabilities that the action actually exercises:
+
+```toml
+[[requires.connectors]]
+name = "slack"
+version = "1.2.0"
+hash = "sha256:abc123..."
+capabilities = ["chat:write", "channels:read"]
+
+[[requires.connectors]]
+name = "git"
+version = "2.1.0"
+hash = "sha256:def456..."
+capabilities = ["read"]
+```
+
+The `capabilities` field is the action's declared subset of what the connector is *capable* of doing. The Slack connector might also expose `chat:read`, `users:read`, and `files:upload`; if `ship-update` only needs `chat:write` and `channels:read`, that's all the action declares.
+
+This is enforced at runtime. If `ship-update` at execution time tries to invoke `chat:read`, the runtime denies the call at the *action* boundary — even if the connector itself is capable of the operation. Two boundaries, two checks: the connector cannot exceed its manifest, the action cannot exceed its declared subset.
+
+Defense in depth, with two practical benefits:
+
+- **Audit is precise without reading the execution body.** A reviewer can scan the `[[requires.connectors]]` blocks at the top of the file and know exactly what the action will touch.
+- **Capability creep is visible.** If a developer or upstream Hub update adds a new capability to an action, the change shows up as a TOML diff in the same file. There is no hidden expansion of what the action is allowed to do.
+
+### The Markdown body is the documentation and the LLM-facing description
+
+Per ADR-0001, the body of the action file is Markdown. It serves three readers simultaneously:
+
+- The **developer** reading the action to understand what it does and how to maintain it.
+- The **Hub** rendering the action as a documentation page when browsing.
+- The **LLM**, which receives the body (or its first paragraph, or a designated section) as the `description` of the function when Aileron exposes the action as a tool to the agent.
+
+Authors write one piece of prose. There is no separate "LLM hint" field to keep in sync with the human documentation.
+
+### Updates are visible, never silent
+
+When the Hub publishes a new version of `ship-update`, the developer's local file does not change. `aileron action update ship-update` fetches the new template and produces a diff against the local file. The developer accepts, rejects, or merges manually. Updates always go through git review.
+
+Aileron will not silently update an installed action. There is no "auto-follow latest" mode. If an upstream connector publishes a security fix, the developer (or their tooling) must explicitly bump the connector version in the action files that reference it. The runtime will not switch transitively.
+
+## Alternatives Considered
+
+### Actions as a hosted catalog the runtime fetches at execution time (rejected)
+
+The Hub serves actions as a live registry. The runtime fetches `slack/ship-update@1.0.0` at execution time and runs the freshly fetched code.
+
+Rejected because it inverts the trust model. Runtime fetch means the action's behavior at any moment is whatever the Hub serves at that moment, with no local artifact to review. PR review becomes meaningless (the diff is the file path, not the code). Reproducibility from git is broken (the same commit produces different behavior across time as the Hub updates). And it introduces a hard runtime dependency on the Hub's availability and integrity. Local-first execution is non-negotiable for this trust profile.
+
+### Actions as imported library functions (rejected)
+
+Actions are functions exposed by a published library that the developer imports into application code. Aileron loads the library and invokes the functions.
+
+Rejected because it removes the declarative property. An action defined in code is opaque to PR review (the reviewer must read the function body and reason about its behavior); it can take arbitrary runtime branches; it can read state outside its declaration. A declarative action file is auditable from its frontmatter alone — capabilities, connectors, and execution steps are all visible without running anything.
+
+### Actions with inter-action dependencies (rejected)
+
+Actions can declare `requires.actions = ["other-action@1.0.0"]` and Aileron resolves a dependency graph at install time, much like a package manager.
+
+Rejected on a cost-benefit basis. The graph would require: version-range resolution, conflict detection between transitively-pulled versions, install ordering, lifecycle hooks for cleanup, partial-failure semantics across the graph, and a debug story when something goes wrong three levels deep. The benefit — reusable building blocks — is already addressed by either letting the agent compose actions in conversation or by writing a new action that exercises the underlying connectors directly. The cost-to-value ratio doesn't justify the complexity.
+
+### Actions inherit the connector's full capability grant (rejected)
+
+The action file declares which connectors it uses; the runtime lets the action invoke any operation the connector is *capable* of performing. The connector is the only enforcement boundary.
+
+Rejected because it removes defense in depth. A bug or compromise in an action's execution path could exercise more of the connector's grant than intended without any second check. By requiring the action to also declare its capability subset, capability creep is *visible* (in the TOML diff) and *enforced* (at the action boundary). The cost — three lines of TOML per connector reference — is trivial.
+
+### Built-in catalog of actions in Aileron core (rejected)
+
+Aileron ships with first-party actions for common tasks ("send-email", "post-to-slack", "create-calendar-event") that developers don't need to install.
+
+Rejected because it ossifies behavior at a layer that should remain flexible. A first-party `send-email` action implies one canonical authoring style, one default tone, one canonical set of trigger phrases. Real users want their actions to reflect their voice, their team's conventions, their project's preferences. The ShadCN model — install a template, then own and edit the file — is the right shape for this layer. The Hub provides starting points; developers customize.
+
+## Consequences
+
+### For developers
+
+- Actions live in `actions/` (or wherever the project chooses) alongside the rest of the project's source. They are checked into git, reviewed in PRs, diffed like any other code.
+- The set of actions a project can perform is fully determined by reading its action files. No hidden registries, no runtime resolution surprises.
+- Customizing an installed action is just editing a file. The Hub's template is a starting point; the developer's copy is canonical from install onward.
+- Compound operations are either composed in agent conversation or written as a new action. Either is a normal authoring activity, not a special framework feature.
+
+### For action authors (publishing to the Hub)
+
+- An action is a single file. Publishing is uploading that file to the Hub.
+- Authors do not control how their action is used after install. The developer who runs `aileron action add` owns the resulting file outright.
+- An action that wants new capability or a new connector dependency requires republishing a new template version. The developer chooses whether and when to apply the diff.
+
+### For Aileron runtime
+
+- The runtime reads action files from the local filesystem on startup (or on action invocation; either is acceptable). It does not phone home, does not consult a registry, does not authenticate to an external service to load an action.
+- Capability enforcement runs at *both* boundaries: the connector's manifest grant (per ADR-0002) and the action's declared subset. A violation at either boundary terminates the call.
+- The runtime parses the TOML frontmatter and extracts the Markdown body separately; the body becomes the LLM-facing function description when actions are surfaced to the agent.
+
+### For the Hub
+
+- The Hub is a curated catalog of action templates and connector binaries. It is *not* a runtime dependency.
+- Action discovery, search, and browse happen on the Hub. Installation is a copy operation; the Hub is not consulted again until the developer asks for an update.
+- The Hub validates action templates at publish time: TOML frontmatter parses; declared connectors exist at the named version+hash; declared capability subsets are valid against the connector's manifest; Markdown body parses.
+
+### For composition and agent orchestration
+
+- Compound flows are emergent from agent conversation. The agent calls action A, sees the result, decides whether to call action B. This is the natural mode.
+- Authors who want a specific compound flow as a single tool write a new atomic action that exercises multiple connectors. There is no special "compose two actions" primitive.
+- The atomicity rule keeps the dependency graph at depth 1 forever: actions → connectors → primitive capabilities. No transitive dependency resolution exists in the system.
+
+### Open implementation questions (deferred to subsequent ADRs)
+
+- *How does `aileron action add` resolve missing connector dependencies and walk the developer through bindings?* — deferred to the dependency-resolution and install-consent ADRs.
+- *How does the runtime match agent intent to a specific installed action?* — deferred to the intent-matching ADR.
+- *How does an action behave when one of its connector calls fails partway through?* — deferred to the failure-handling ADR.
+- *How are action files synced across teammates with different credential bindings?* — deferred to the project-portability ADR.
+
+## Examples
+
+### A complete action file (`actions/ship-update.md`)
+
+````markdown
++++
+name = "ship-update"
+version = "1.0.0"
+source = "hub://aileron/ship-update@1.0.0"
+
+[[requires.connectors]]
+name = "slack"
+version = "1.2.0"
+hash = "sha256:abc123..."
+capabilities = ["chat:write", "channels:read"]
+
+[[requires.connectors]]
+name = "git"
+version = "2.1.0"
+hash = "sha256:def456..."
+capabilities = ["read"]
+
+[match]
+intent = "tell team I shipped"
+
+[[execute]]
+id = "recent_merge"
+connector = "git"
+op = "read_recent_merge"
+
+[[execute]]
+id = "post"
+connector = "slack"
+op = "post_message"
+
+[execute.inputs]
+channel = "${args.channel}"
+message = "${recent_merge.summary} → ${recent_merge.pr_url}"
++++
+
+# Ship Update
+
+Posts a "shipped" announcement to a Slack channel with the merged PR link.
+
+## When it fires
+
+Triggered when the user tells their agent things like:
+
+- "tell team I shipped the migration"
+- "post a ship update to #engineering"
+- "let the team know I merged the PR"
+
+## What it does
+
+1. Reads the most recent merge commit from local git.
+2. Extracts the PR URL from the commit body.
+3. Formats a message and posts it to the specified Slack channel.
+````
+
+### Capability denial at the action boundary
+
+`ship-update` declares `slack: capabilities = ["chat:write", "channels:read"]`. At runtime, an `[[execute]]` step attempts `slack.list_users`. The Slack connector's manifest *does* permit `users:read`, but the action did not declare it. The runtime denies the call at the action boundary before it reaches the connector:
+
+```json
+{
+  "error": {
+    "class": "capability_denied",
+    "boundary": "action",
+    "action": "ship-update@1.0.0",
+    "connector": "slack@1.2.0",
+    "requested": "users:read",
+    "declared_subset": ["chat:write", "channels:read"],
+    "audit_id": "audit-9c2a..."
+  }
+}
+```
+
+The action fails fast and visibly. The developer sees the boundary that denied it (action vs. connector), which makes the fix obvious: declare the capability if it's intended, or remove the call if it's not.
+
+### Composing two actions
+
+Compound flow: post a ship-update *and* file a follow-up ticket. Two paths:
+
+**Agent-orchestrated (default).** The agent calls `ship-update`, observes the result, then calls `file-followup-ticket`. No new code is written.
+
+**A new atomic action.** The developer writes `actions/ship-and-followup.md` declaring connectors for both Slack and Linear; the action's own `[[execute]]` steps perform the post and the ticket-creation. The new action does *not* declare a dependency on `ship-update` or `file-followup-ticket`. It exists as a sibling action, exercising the same connectors directly.
+
+Either path keeps the action dependency graph flat.

--- a/docs/src/content/docs/adr/0003-action-model.md
+++ b/docs/src/content/docs/adr/0003-action-model.md
@@ -48,18 +48,29 @@ The action file is *the* contract Aileron executes. There is no separate manifes
 
 ### Actions are copied on install, not registered
 
-`aileron action add ship-update` fetches a template from the Hub, *copies* it into the developer's project, and exits. From that moment the developer owns the file. They can edit it, restructure it, retitle it, change the connector versions it references, modify the prompts and triggers — and none of it requires anyone's permission or a republish to the Hub.
+`aileron action add <FQN>` fetches a template from any supported source, *copies* it into the developer's project, and exits. From that moment the developer owns the file. They can edit it, restructure it, retitle it, change the connector versions it references, modify the prompts and triggers — and none of it requires anyone's permission or a republish.
 
 ```
-$ aileron action add ship-update
-→ Fetching action 'ship-update' from Aileron Hub...
+$ aileron action add hub://aileron/ship-update@1.0.0
+→ Fetching action from hub://aileron/ship-update@1.0.0...
 ✓ Action file written to actions/ship-update.md
   Source: hub://aileron/ship-update@1.0.0
+
+$ aileron action add github://acme/templates/actions/file-bug@2.1.0
+→ Fetching action from github://acme/templates/actions/file-bug@2.1.0...
+✓ Action file written to actions/file-bug.md
+  Source: github://acme/templates/actions/file-bug@2.1.0
 ```
 
-This is the ShadCN distribution model applied to actions: the Hub is a curated catalog of *starting-point templates*, not a runtime registry. Aileron does not phone the Hub at runtime to "load an action"; it reads the local file. A project can be reproduced from git alone, with no Hub access.
+This is the ShadCN distribution model applied to actions: a source is a curated catalog of *starting-point templates*, not a runtime registry. Aileron does not phone the source at runtime to "load an action"; it reads the local file. A project can be reproduced from git alone, with no network access to the original source.
 
-The action file records its provenance with a fully-qualified URI in the `source` field (e.g., `source = "hub://aileron/ship-update@1.0.0"`, `source = "github://aileron/ship-update@1.0.0"`). Update tooling uses this to offer newer template versions when they become available, but the local copy remains canonical until the developer accepts a diff.
+**Action templates are hostable from any scheme.** Actions and connectors are symmetric in their distribution model: both are FQN-identified, both can live on `github://`, `gitlab://`, `hub://`, or any future scheme the resolver knows. The Hub is a curated catalog with discoverability and review, not a privileged source. Publishers who prefer to host their own action templates on GitHub or GitLab can do so; install commands and provenance fields use the FQN of the chosen source.
+
+Monorepo support carries over from ADR-0002. A single repo can host multiple action templates at distinct subpaths: `github://aileron/integrations/actions/ship-update`, `github://aileron/integrations/actions/file-bug`. The Hub similarly allows organizational subpaths within an owner's namespace.
+
+**Versioning inherits the rules from ADR-0002.** Action templates are pinned to strict SemVer; the `source` field includes `@<version>`; the local action file records the exact source FQN+version it was copied from. The local copy is canonical from install onward; the source version is provenance, not a runtime dependency.
+
+The action file records its provenance with a fully-qualified URI in the `source` field. Update tooling uses this to offer newer template versions when they become available, but the local copy remains canonical until the developer accepts a diff.
 
 Note the asymmetry between the action's *own* `name` and its references to other artifacts:
 
@@ -105,7 +116,7 @@ This is enforced at runtime. If `ship-update` at execution time tries to invoke 
 Defense in depth, with two practical benefits:
 
 - **Audit is precise without reading the execution body.** A reviewer can scan the `[[requires.connectors]]` blocks at the top of the file and know exactly what the action will touch.
-- **Capability creep is visible.** If a developer or upstream Hub update adds a new capability to an action, the change shows up as a TOML diff in the same file. There is no hidden expansion of what the action is allowed to do.
+- **Capability creep is visible.** If a developer or an upstream template update adds a new capability to an action, the change shows up as a TOML diff in the same file. There is no hidden expansion of what the action is allowed to do.
 
 ### The Markdown body is the documentation and the LLM-facing description
 
@@ -119,7 +130,7 @@ Authors write one piece of prose. There is no separate "LLM hint" field to keep 
 
 ### Updates are visible, never silent
 
-When the Hub publishes a new version of `ship-update`, the developer's local file does not change. `aileron action update ship-update` fetches the new template and produces a diff against the local file. The developer accepts, rejects, or merges manually. Updates always go through git review.
+When the source publishes a new version of `ship-update`, the developer's local file does not change. `aileron action update ship-update` fetches the new template (from the FQN recorded in `source`) and produces a diff against the local file. The developer accepts, rejects, or merges manually. Updates always go through git review.
 
 Aileron will not silently update an installed action. There is no "auto-follow latest" mode. If an upstream connector publishes a security fix, the developer (or their tooling) must explicitly bump the connector version in the action files that reference it. The runtime will not switch transitively.
 
@@ -127,9 +138,9 @@ Aileron will not silently update an installed action. There is no "auto-follow l
 
 ### Actions as a hosted catalog the runtime fetches at execution time (rejected)
 
-The Hub serves actions as a live registry. The runtime fetches `slack/ship-update@1.0.0` at execution time and runs the freshly fetched code.
+The source (Hub, GitHub, or any other) serves actions as a live registry. The runtime fetches the action FQN at execution time and runs the freshly fetched code.
 
-Rejected because it inverts the trust model. Runtime fetch means the action's behavior at any moment is whatever the Hub serves at that moment, with no local artifact to review. PR review becomes meaningless (the diff is the file path, not the code). Reproducibility from git is broken (the same commit produces different behavior across time as the Hub updates). And it introduces a hard runtime dependency on the Hub's availability and integrity. Local-first execution is non-negotiable for this trust profile.
+Rejected because it inverts the trust model. Runtime fetch means the action's behavior at any moment is whatever the source serves at that moment, with no local artifact to review. PR review becomes meaningless (the diff is the file path, not the code). Reproducibility from git is broken (the same commit produces different behavior across time as the source updates). And it introduces a hard runtime dependency on the source's availability and integrity. Local-first execution is non-negotiable for this trust profile.
 
 ### Actions as imported library functions (rejected)
 
@@ -153,7 +164,7 @@ Rejected because it removes defense in depth. A bug or compromise in an action's
 
 Aileron ships with first-party actions for common tasks ("send-email", "post-to-slack", "create-calendar-event") that developers don't need to install.
 
-Rejected because it ossifies behavior at a layer that should remain flexible. A first-party `send-email` action implies one canonical authoring style, one default tone, one canonical set of trigger phrases. Real users want their actions to reflect their voice, their team's conventions, their project's preferences. The ShadCN model — install a template, then own and edit the file — is the right shape for this layer. The Hub provides starting points; developers customize.
+Rejected because it ossifies behavior at a layer that should remain flexible. A first-party `send-email` action implies one canonical authoring style, one default tone, one canonical set of trigger phrases. Real users want their actions to reflect their voice, their team's conventions, their project's preferences. The ShadCN model — install a template, then own and edit the file — is the right shape for this layer. Sources (Hub, GitHub, GitLab, etc.) provide starting points; developers customize.
 
 ## Consequences
 
@@ -161,12 +172,13 @@ Rejected because it ossifies behavior at a layer that should remain flexible. A 
 
 - Actions live in `actions/` (or wherever the project chooses) alongside the rest of the project's source. They are checked into git, reviewed in PRs, diffed like any other code.
 - The set of actions a project can perform is fully determined by reading its action files. No hidden registries, no runtime resolution surprises.
-- Customizing an installed action is just editing a file. The Hub's template is a starting point; the developer's copy is canonical from install onward.
+- Customizing an installed action is just editing a file. The source's template is a starting point; the developer's copy is canonical from install onward.
 - Compound operations are either composed in agent conversation or written as a new action. Either is a normal authoring activity, not a special framework feature.
 
-### For action authors (publishing to the Hub)
+### For action authors
 
-- An action is a single file. Publishing is uploading that file to the Hub.
+- An action is a single file. Publishing is making that file available at an FQN — pushing to a GitHub release, a GitLab release, the Aileron Hub, or any future scheme the resolver knows.
+- Publishers choose where to host. The Hub offers discoverability, search, and curation. Self-hosting on `github://` or `gitlab://` keeps the publisher in full control of release cadence and access policy.
 - Authors do not control how their action is used after install. The developer who runs `aileron action add` owns the resulting file outright.
 - An action that wants new capability or a new connector dependency requires republishing a new template version. The developer chooses whether and when to apply the diff.
 
@@ -176,11 +188,11 @@ Rejected because it ossifies behavior at a layer that should remain flexible. A 
 - Capability enforcement runs at *both* boundaries: the connector's manifest grant (per ADR-0002) and the action's declared subset. A violation at either boundary terminates the call.
 - The runtime parses the TOML frontmatter and extracts the Markdown body separately; the body becomes the LLM-facing function description when actions are surfaced to the agent.
 
-### For the Hub
+### For sources (Hub, GitHub releases, GitLab releases, etc.)
 
-- The Hub is a curated catalog of action templates and connector binaries. It is *not* a runtime dependency.
-- Action discovery, search, and browse happen on the Hub. Installation is a copy operation; the Hub is not consulted again until the developer asks for an update.
-- The Hub validates action templates at publish time: TOML frontmatter parses; declared connectors exist at the named version+hash; declared capability subsets are valid against the connector's manifest; Markdown body parses.
+- A source is a curated catalog of action templates and connector binaries that publishers push to. It is *not* a runtime dependency.
+- Action discovery, search, and browse happen on the source's surface (the Hub provides this natively; GitHub/GitLab provide it through their own browse and search). Installation is a copy operation; the source is not consulted again until the developer asks for an update.
+- The Hub validates action templates at publish time: TOML frontmatter parses; declared connectors exist at the named FQN+version+hash; declared capability subsets are valid against the connector's manifest; Markdown body parses. Other schemes do not enforce validation server-side; install tooling validates locally before writing to the project.
 
 ### For composition and agent orchestration
 

--- a/docs/src/content/docs/adr/0003-action-model.md
+++ b/docs/src/content/docs/adr/0003-action-model.md
@@ -59,7 +59,13 @@ $ aileron action add ship-update
 
 This is the ShadCN distribution model applied to actions: the Hub is a curated catalog of *starting-point templates*, not a runtime registry. Aileron does not phone the Hub at runtime to "load an action"; it reads the local file. A project can be reproduced from git alone, with no Hub access.
 
-The action file records its provenance (`source = "hub://..."`) so update tooling can later offer to fetch a newer template version, but the local copy remains canonical until the developer accepts a diff.
+The action file records its provenance with a fully-qualified URI in the `source` field (e.g., `source = "hub://aileron/ship-update@1.0.0"`, `source = "github://aileron/ship-update@1.0.0"`). Update tooling uses this to offer newer template versions when they become available, but the local copy remains canonical until the developer accepts a diff.
+
+Note the asymmetry between the action's *own* `name` and its references to other artifacts:
+
+- The action's `name` field is a **bare local handle** (e.g., `name = "ship-update"`). The developer owns the file post-install and chooses the name; FQN doesn't apply to a file the developer owns.
+- The `source` field is a **fully-qualified URI** indicating where the template came from.
+- The `[[requires.connectors]]` blocks reference connectors by their **fully-qualified URI** (per ADR-0002), since connectors are shared, sandboxed binaries that need unambiguous identification across the ecosystem.
 
 ### Actions are atomic — no inter-action dependencies
 
@@ -68,7 +74,7 @@ An action does one thing. It does not declare dependencies on other actions. The
 When a developer wants a compound operation — "ship-update + create-followup-ticket + block-calendar" — they have two options:
 
 1. **Let the agent orchestrate.** The agent already calls actions; chaining `ship-update` then `create-followup-ticket` then `block-calendar` in conversation is its native mode. This is the default and almost always the right choice.
-2. **Write a new action that performs all three.** The new action declares dependencies on `slack`, `linear`, and `gcal` connectors (rather than on three other actions) and orchestrates the connector calls itself.
+2. **Write a new action that performs all three.** The new action declares dependencies on the relevant connectors (e.g., `github://aileron/slack`, `github://aileron/linear`, `github://aileron/gcal`) rather than on three other actions, and orchestrates the connector calls itself.
 
 Both options keep the dependency graph at depth 1: actions depend on connectors. Connectors depend on nothing inside Aileron.
 
@@ -76,17 +82,17 @@ This is a deliberate simplification, not a deferred decision. Action-to-action d
 
 ### Action files declare connector dependencies and capability subsets
 
-Each action file lists the connectors it uses. For each connector, it pins the exact version, the content hash (per ADR-0002), and the *subset* of the connector's declared capabilities that the action actually exercises:
+Each action file lists the connectors it uses. For each connector, it pins the fully-qualified URI name (per ADR-0002), the exact version, the content hash, and the *subset* of the connector's declared capabilities that the action actually exercises:
 
 ```toml
 [[requires.connectors]]
-name = "slack"
+name = "github://aileron/slack"
 version = "1.2.0"
 hash = "sha256:abc123..."
 capabilities = ["chat:write", "channels:read"]
 
 [[requires.connectors]]
-name = "git"
+name = "github://aileron/git"
 version = "2.1.0"
 hash = "sha256:def456..."
 capabilities = ["read"]
@@ -200,13 +206,13 @@ version = "1.0.0"
 source = "hub://aileron/ship-update@1.0.0"
 
 [[requires.connectors]]
-name = "slack"
+name = "github://aileron/slack"
 version = "1.2.0"
 hash = "sha256:abc123..."
 capabilities = ["chat:write", "channels:read"]
 
 [[requires.connectors]]
-name = "git"
+name = "github://aileron/git"
 version = "2.1.0"
 hash = "sha256:def456..."
 capabilities = ["read"]
@@ -216,12 +222,12 @@ intent = "tell team I shipped"
 
 [[execute]]
 id = "recent_merge"
-connector = "git"
+connector = "github://aileron/git"
 op = "read_recent_merge"
 
 [[execute]]
 id = "post"
-connector = "slack"
+connector = "github://aileron/slack"
 op = "post_message"
 
 [execute.inputs]
@@ -250,7 +256,7 @@ Triggered when the user tells their agent things like:
 
 ### Capability denial at the action boundary
 
-`ship-update` declares `slack: capabilities = ["chat:write", "channels:read"]`. At runtime, an `[[execute]]` step attempts `slack.list_users`. The Slack connector's manifest *does* permit `users:read`, but the action did not declare it. The runtime denies the call at the action boundary before it reaches the connector:
+`ship-update` declares `github://aileron/slack` with `capabilities = ["chat:write", "channels:read"]`. At runtime, an `[[execute]]` step attempts `slack.list_users`. The Slack connector's manifest *does* permit `users:read`, but the action did not declare it. The runtime denies the call at the action boundary before it reaches the connector:
 
 ```json
 {
@@ -258,7 +264,7 @@ Triggered when the user tells their agent things like:
     "class": "capability_denied",
     "boundary": "action",
     "action": "ship-update@1.0.0",
-    "connector": "slack@1.2.0",
+    "connector": "github://aileron/slack@1.2.0",
     "requested": "users:read",
     "declared_subset": ["chat:write", "channels:read"],
     "audit_id": "audit-9c2a..."

--- a/docs/src/content/docs/adr/index.md
+++ b/docs/src/content/docs/adr/index.md
@@ -10,6 +10,7 @@ This section holds the architecture decision records (ADRs) that define Aileron'
 
 - [ADR-0001: Manifest Format Conventions](/adr/0001-manifest-format) — Markdown body + TOML frontmatter for actions; pure TOML for connectors and project config; JSON for runtime IPC.
 - [ADR-0002: Connector Model](/adr/0002-connector-model) — Connectors are sandboxed, content-addressed binaries; Aileron core ships only primitive capability types.
+- [ADR-0003: Action Model](/adr/0003-action-model) — Atomic actions copied into the project on install; depend on connectors with explicit version + hash + capability subsets; capability enforcement at the action boundary in addition to the connector boundary.
 
 ## What's coming
 
@@ -17,7 +18,7 @@ The full sequence is tracked in [issue #343](https://github.com/ALRubinger/ailer
 
 1. **Manifest Format Conventions** — *landed (ADR-0001)*
 2. **Connector Model** — *landed (ADR-0002)*
-3. Action model
+3. **Action Model** — *landed (ADR-0003)*
 4. Dependency resolution
 5. Sandbox choice
 6. Capability binding UX

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -50,7 +50,8 @@ export const navigation: NavItem[] = [
     children: [
       { label: 'Overview', href: '/adr/' },
       { label: 'ADR-0001: Manifest Format', href: '/adr/0001-manifest-format/' },
-      { label: 'ADR-0002: Connector Model', href: '/adr/0002-connector-model/' }
+      { label: 'ADR-0002: Connector Model', href: '/adr/0002-connector-model/' },
+      { label: 'ADR-0003: Action Model', href: '/adr/0003-action-model/' }
     ]
   }
 ];


### PR DESCRIPTION
## Summary

This PR bundles three related decisions:

### 1. Lands ADR-0003: Action Model

- An action is a single declarative file (TOML frontmatter + Markdown body, per ADR-0001) owned by the developer and checked into git.
- **ShadCN distribution**: \`aileron action add\` *copies* a template into the project; sources are catalogs of starting points, not runtime registries.
- **Atomic by design**: no inter-action dependencies. Compound flows compose via agent orchestration or by writing a new atomic action.
- **Capability subsets**: each action declares the subset of the connector's capabilities it actually uses; runtime enforces this at the action boundary *in addition to* the connector boundary (defense in depth).
- Updates are visible (git diffs from \`aileron action update\`); never silent.
- Alternatives rejected: live-fetched hosted catalog, actions as imported library functions, inter-action dependencies, capability inheritance from connector, built-in action catalog in core.

### 2. Amends ADR-0002 (and ADR-0003): connector identity is a fully-qualified URI

While reviewing ADR-0003, surfaced that bare \`name = \"slack\"\` would replicate the namespace-collision and typo-squatting problems that plague npm and PyPI. Per the editable-pre-MVP convention, amended both ADRs in place:

- Connector names are FQNs: \`github://aileron/slack\`, \`gitlab://team/linear\`, \`hub://aileron/slack\`.
- Decentralized — scheme + path uniquely identifies a publication source. No central naming authority.
- Initial scheme set: \`github://\`, \`gitlab://\`, \`hub://\`. Forward-compatible.
- Hub is *one source among many*, not a privileged namespace.
- Hash remains the trust anchor; FQN is identification + provenance.
- Forks (\`github://acme/slack\` of \`github://aileron/slack\`) are distinct connectors with distinct hashes.
- Dropped redundant \`publisher\` field from connector manifests; FQN's authority encodes it.

### 3. Amends ADR-0002 + ADR-0003: monorepo subpaths, versioning rules, source symmetry

Continued the conversation: bare FQN like \`github://owner/repo\` implied one artifact per repo, which is restricting. Also versioning needed to be made explicit.

- **Monorepo support** via Go modules-style subpaths: \`github://aileron/integrations/connectors/slack\`, \`github://aileron/integrations/actions/ship-update\`. First two segments are owner/repo; remaining segments locate the artifact within the repo. Same pattern for the Hub.
- **Strict SemVer** for the \`version\` field. No ranges, no \`latest\`, no calver, no commit SHAs. Strict pinning ensures reproducibility from git.
- **Hash is the immutable trust anchor; version is the human label.** Tags can be re-pushed; the hash detects the mismatch and fails loudly.
- **Multiple versions coexist by construction** — drops out of the content-addressed model. Two actions in the same project can pin different versions of the same connector with no resolution step.
- **\`@<version>\`** is the canonical compact form for CLI and \`source\` strings; TOML keeps \`name\` and \`version\` as separate fields.
- **Actions are hostable from any scheme**, not just \`hub://\`. Symmetric with connectors. \`aileron action add github://acme/templates/actions/file-bug@2.1.0\` works identically to \`aileron action add hub://aileron/ship-update@1.0.0\`.
- Resolver mechanics (tag conventions, fetch, update discovery, prerelease handling) deferred to the dependency-resolution ADR (next ADR in the sequence).

Refs #343.

## Test plan

- [x] \`task build:docs\` — clean; 13 pages built.
- [x] \`task lint:docs\` — 0 errors, 0 warnings, 0 hints.
- [ ] Visual review of \`/adr/0003-action-model/\` and the amended \`/adr/0002-connector-model/\` once deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)