### PR TITLE
chore: remove .entire/ config after uninstalling Entire CLI

### DIFF
--- a/.entire/.gitignore
+++ b/.entire/.gitignore
@@ -1,4 +1,0 @@
-tmp/
-settings.local.json
-metadata/
-logs/

--- a/.entire/settings.json
+++ b/.entire/settings.json
@@ -1,4 +1,0 @@
-{
-  "enabled": true,
-  "telemetry": true
-}


### PR DESCRIPTION
## Summary
- Removed `.entire/.gitignore` and `.entire/settings.json` after uninstalling the Entire CLI from the repo (`entire disable --uninstall`).
- The `entire/checkpoints/v1` shadow branch on origin and all related git hooks, session state, and unreachable objects were also purged.

## Test plan
- [x] Verified `git status` is clean on the worktree after the delete commit
- [x] Verified no `entire/*` refs remain (`git for-each-ref | grep entire`)
- [x] Verified `.git/objects/` no longer holds Entire data (`git fsck --unreachable --no-reflogs` clean, `git count-objects -v` shows 0 garbage)

🤖 Generated with [Claude Code](https://claude.com/claude-code)