### PR TITLE
docs: rewrite README, add CLI Reference, prep #335 for Phase 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,43 +4,20 @@
 ![GitHub Actions Workflow Status](https://img.shields.io/github/actions/workflow/status/ALRubinger/aileron/ci.yml?style=for-the-badge&logo=github)
 ![Codecov](https://img.shields.io/codecov/c/github/ALRubinger/aileron?style=for-the-badge)
 
-Time is our most precious asset. We pour it into purpose, into connection. Managing our modern life demands time, and we believe it should take far less.
+Aileron is a local LLM gateway that gives your AI agent the ability to take consequential action on your behalf — post the deploy update, file the ticket, send the email — without ever holding your credentials in the agent's process.
 
-Aileron learns how you already live and work. Your conversations, your decisions, your preferences, your corrections. It builds an understanding of your world that no one had to write down, and that understanding is what makes the difference between an answer that wastes your time and one you'd trust with your name on it.
+The agent points its API base URL at Aileron instead of OpenAI or Anthropic. Aileron speaks both Chat Completions and Messages, augments the agent's tool catalog with installed actions, and intercepts those actions for deterministic execution: sandboxed connectors, sealed credentials, capability-bounded calls, audited everywhere.
 
 **[Read the full story at docs.withaileron.ai](https://docs.withaileron.ai)**
 
-## Quick start
-
-```sh
-aileron launch claude
-```
-
-Aileron wraps your agent in a policy-enforced shell. Safe commands auto-approve. Dangerous ones are blocked. Ambiguous ones ask you once. Zero config required.
-
-## What Aileron does
-
-- **Policy-enforced shell.** Every command flows through `aileron-sh` and your `aileron.yaml` rules. The policy lives in version control, is reviewable in PRs, and learns from use.
-- **Credential brokering.** Secrets in a zero-knowledge encrypted vault. The agent uses them but never sees them.
-- **Bidirectional messaging.** Slack and Discord messages arrive in your terminal. The agent drafts replies using codebase context. You approve with one keypress.
-- **Audit trail.** Every decision is logged. What the agent did, what the policy decided, what you authorized.
-- **Agent-portable.** Switch agents and your policy, credentials, and audit trail come with you.
-
-## Install
-
-Download the latest release from [GitHub Releases](https://github.com/ALRubinger/aileron/releases). Place `aileron` and `aileron-sh` in the same directory on your PATH.
-
 ## Documentation
 
-Full documentation, guides, and architecture decisions are at **[docs.withaileron.ai](https://docs.withaileron.ai)**.
+Everything lives at **[docs.withaileron.ai](https://docs.withaileron.ai)**:
 
-- [For Individuals](https://docs.withaileron.ai/for-individuals) - How Aileron gives you your time back
-- [For Organizations](https://docs.withaileron.ai/for-organizations) - Institutional memory that builds itself
-- [How Aileron Works](https://docs.withaileron.ai/how-aileron-works) - The building blocks that make it trustworthy
-- [Getting Started](https://docs.withaileron.ai/getting-started/installation) - Installation, policy, integrations
-- [Deployment](https://docs.withaileron.ai/deployment/cloud) - Cloud, Railway, and TEE enclave setup
-- [API Reference](https://docs.withaileron.ai/api) - Full OpenAPI specification
-- [Architecture Decision Records](https://docs.withaileron.ai/adr/0001-hybrid-mcp-execution-model) - Design decisions and rationale
+- [Overview](https://docs.withaileron.ai/) — what Aileron is and the pitch
+- [Concepts](https://docs.withaileron.ai/concepts/deterministic-agentic-execution/) — the architecture, layered: deterministic execution, the LLM gateway, actions, connectors, the vault
+- [Architecture Decisions](https://docs.withaileron.ai/adr/) — the eleven ADRs that ratify the post-Pivot architecture
+- [API Reference](https://docs.withaileron.ai/api) — full OpenAPI specification
 
 ## Development
 
@@ -48,11 +25,7 @@ Full documentation, guides, and architecture decisions are at **[docs.withailero
 task build           # build everything
 task test:go         # unit tests
 task test:integration # integration tests (requires running server)
-task up              # run full stack locally
-task down            # stop
 ```
-
-See the [Development guide](https://docs.withaileron.ai/development/building-from-source) for prerequisites and project structure.
 
 ## License
 

--- a/docs/src/components/Sidebar.svelte
+++ b/docs/src/components/Sidebar.svelte
@@ -11,6 +11,7 @@
   import Cloud from '@lucide/svelte/icons/cloud';
   import Compass from '@lucide/svelte/icons/compass';
   import Layers from '@lucide/svelte/icons/layers';
+  import Terminal from '@lucide/svelte/icons/terminal';
 
   let { currentPath = '', navigation = [] as NavItem[] }: { currentPath?: string; navigation?: NavItem[] } = $props();
   let mobileOpen = $state(false);
@@ -60,6 +61,7 @@
     'Development': Wrench,
     'Architecture Decisions': GitFork,
     'Concepts': Layers,
+    'CLI Reference': Terminal,
     'API Reference': Braces
   };
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -1,0 +1,87 @@
+---
+title: "CLI Reference"
+description: "The aileron command-line interface. Every command is a thin HTTP client over the Aileron server's OpenAPI-spec'd API."
+order: 1
+---
+
+The `aileron` CLI is a thin HTTP client over the Aileron server's API. The same CLI talks to a locally-running Aileron (the v1 default) or — eventually — a hosted Aileron Cloud, with no client-side change beyond the configured endpoint.
+
+The server's API is defined in [`internal/api/openapi.yaml`](https://github.com/ALRubinger/aileron/blob/main/internal/api/openapi.yaml) and is the **authoritative source** for every endpoint. CLI commands are routed to specific HTTP operations there. New CLI surface lands by extending the OpenAPI spec, regenerating the server stubs (`task generate:api`), implementing the handler, and wiring the CLI command to call it.
+
+This page is the human-readable index of CLI commands grouped by concern. Each command lists its purpose, its options, and the ADR(s) that ratify its behavior.
+
+## Runtime lifecycle
+
+| Command | Purpose | Ratified by |
+|---|---|---|
+| `aileron launch` | Start the local Aileron server. Prompts for the vault passphrase if one is set; creates a vault on first run. Listens on `http://localhost:8721/v1` by default. | [ADR-0011](/adr/0011-local-credential-vault) |
+| `aileron status` | Report the running runtime: version, listen address, action count, connector count, binding count, vault state. Read-only; safe to run frequently. | — |
+
+## Actions
+
+| Command | Purpose | Ratified by |
+|---|---|---|
+| `aileron action add <FQN>@<version>` | Fetch an action template from the named source and copy it into `~/.aileron/actions/`. Walks declared connector dependencies and prompts for each. | [ADR-0003](/adr/0003-action-model), [ADR-0007](/adr/0007-install-consent) |
+| `aileron action update <name>` | Fetch the latest version of an installed action's template; show a diff against the local file; apply on confirmation. | [ADR-0003](/adr/0003-action-model) |
+| `aileron action list` | List every action in `~/.aileron/actions/` with its source FQN, version, and connector dependencies. | [ADR-0003](/adr/0003-action-model) |
+| `aileron action audit` | Show every action and connector currently installed plus declared capabilities and binding identities. | [ADR-0003](/adr/0003-action-model) |
+| `aileron action remove <name>` | Delete an installed action file. Connectors no longer referenced are *not* automatically removed; use `aileron connector gc`. | [ADR-0003](/adr/0003-action-model) |
+
+## Connectors
+
+| Command | Purpose | Ratified by |
+|---|---|---|
+| `aileron connector install <FQN>@<version>` | Install a connector by FQN: fetch, verify signature, verify hash, store in the content-addressed store at `~/.aileron/store/`. | [ADR-0002](/adr/0002-connector-model), [ADR-0004](/adr/0004-dependency-resolution), [ADR-0007](/adr/0007-install-consent) |
+| `aileron connector check` | Walk every connector referenced by installed actions; query upstream sources for newer versions; print a per-connector update report. Network-dependent. Pre-release versions excluded by default. | [ADR-0004](/adr/0004-dependency-resolution) |
+| `aileron connector update <FQN>` | Bump the version reference for a connector across all action files that use it, after explicit confirmation. | [ADR-0003](/adr/0003-action-model), [ADR-0004](/adr/0004-dependency-resolution) |
+| `aileron connector list` | List every connector in the local store with its FQN, version, hash, and which installed actions reference it. | [ADR-0004](/adr/0004-dependency-resolution) |
+
+## Bindings
+
+| Command | Purpose | Ratified by |
+|---|---|---|
+| `aileron binding setup [<connector-FQN>]` | Pre-bind every capability the connector declares (or every capability across all installed connectors when run without an argument). Used for headless setup and proactive setup. | [ADR-0006](/adr/0006-capability-binding-ux) |
+| `aileron binding list` | List every binding on this machine: kind, scope, identity, last-used timestamp, refresh status. | [ADR-0006](/adr/0006-capability-binding-ux) |
+| `aileron binding inspect <name>` | Show one binding's metadata: capability type, scope, account, created/last-used/last-refresh timestamps, connectors that use it. | [ADR-0006](/adr/0006-capability-binding-ux) |
+| `aileron binding rebind <name>` | Replace an existing binding with a fresh credential (after rotation, after revocation). Same flow as first-use binding. | [ADR-0006](/adr/0006-capability-binding-ux) |
+| `aileron binding revoke <name>` | Remove a binding entirely. Subsequent invocations of any connector that would have used it trigger first-use binding. | [ADR-0006](/adr/0006-capability-binding-ux) |
+
+## Sync and verify
+
+| Command | Purpose | Ratified by |
+|---|---|---|
+| `aileron sync` | Walk `~/.aileron/actions/`; install any missing connectors into the local store; surface unbound capability requirements. Idempotent. | [ADR-0004](/adr/0004-dependency-resolution) |
+| `aileron sync --bind-all` | Like `sync`, but additionally pre-binds every required capability before exiting. Useful for fresh-machine setup. | [ADR-0006](/adr/0006-capability-binding-ux) |
+| `aileron sync --yes` | Headless mode. Auto-approves install consent for every new connector encountered. Per-command flag; no global config. | [ADR-0007](/adr/0007-install-consent) |
+
+## Utility
+
+| Command | Purpose | Ratified by |
+|---|---|---|
+| `aileron version` | Print the runtime version. | — |
+| `aileron help [<command>]` | Show CLI help. | — |
+
+## In-band commands
+
+A subset of read-only commands can be invoked from inside an active agent conversation by sending `/aileron <command>` as a chat message. Aileron intercepts before the LLM is called and returns a synthetic assistant response.
+
+Eligible: `status`, `binding list`, `version`. Mutating commands (`action add`, `binding rebind`, `connector install`, etc.) are not eligible in-band — they require explicit terminal invocation so the install consent flow can fire on a tamper-resistant surface.
+
+See [ADR-0009: User Channel](/adr/0009-user-channel) for the in-band convention and its trust caveats.
+
+## Architecture: CLI is an HTTP client
+
+Every command above resolves to one or more HTTP operations against the Aileron server. The server may be:
+
+- **Local** — a process the user started with `aileron launch`, listening on `localhost:8721/v1` (the v1 default).
+- **Hosted** — a future Aileron Cloud deployment reachable over HTTPS (post-MVP, paired with the hosted backend introduced in [ADR-0009](/adr/0009-user-channel) Phase 2).
+
+The CLI doesn't care which. It reads its target endpoint from configuration, opens HTTP, and invokes the spec'd operations. This separation means:
+
+- New server functionality is added by extending [`internal/api/openapi.yaml`](https://github.com/ALRubinger/aileron/blob/main/internal/api/openapi.yaml), regenerating Go stubs (`task generate:api`), and implementing the handler.
+- New CLI commands are shells over those endpoints — argument parsing, output formatting, occasionally orchestrating multiple calls.
+- The same CLI binary works against any conformant Aileron server.
+
+The OpenAPI spec is the authoritative source of truth for every API change. CLI commands are documentation of which commands wrap which endpoints; the underlying contract lives in the spec.
+
+For the full HTTP API, see [API Reference](/api).

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -77,5 +77,6 @@ export const navigation: NavItem[] = [
  * Standalone nav entries rendered below the main tree (e.g. API Reference).
  */
 export const externalLinks: NavLink[] = [
+  { label: 'CLI Reference', href: '/cli/' },
   { label: 'API Reference', href: '/api' }
 ];


### PR DESCRIPTION
## Summary

Final cleanup before Phase 6 implementation begins. Three things:

### 1. README rewrite

The previous README described pre-Pivot Aileron (the policy-enforced shell model) and linked to dead pages on the docs site. Rewritten to match the post-Pivot architecture: Aileron is a local LLM gateway (OpenAI- and Anthropic-compatible), trim, points readers at [docs.withaileron.ai](https://docs.withaileron.ai).

### 2. CLI Reference (new docs section)

A single page at \`/cli/\` enumerating every \`aileron\` command grouped by concern (lifecycle, actions, connectors, bindings, sync, utility). Each entry names its purpose and the ADR(s) that ratify its behavior. Sidebar gets a Terminal icon for the new section, parallel to API Reference at the bottom of the tree.

The page makes the architectural relationship explicit: **the CLI is a thin HTTP client over the server's OpenAPI-spec'd API.** Same CLI binary works against local Aileron (v1 default) or a future hosted Aileron Cloud, with no client-side change. New server functionality goes through \`internal/api/openapi.yaml\` first, regenerated via \`task generate:api\`.

### 3. Issue #335 prepped for Phase 6

(Out of band, no diff in this PR — done via \`gh issue edit\`.)

- Added an "Implementation Status (2026-04-29)" section at the top documenting the architectural ratification work that landed (11 ADRs, Concepts section, CLI Reference) and the scope decisions made along the way.
- Replaced the inline Phase 6 workstream list with a curated set of tracking issues (#356–#366):
  1. #356 Runtime: dual-protocol LLM gateway (Chat Completions + Messages)
  2. #357 Action storage and parser
  3. #358 Connector store, FQN resolver, and install pipeline
  4. #359 WASM connector runtime and capability enforcement
  5. #360 Credential mediation: capability handles and host-side injection
  6. #361 Local credential vault wiring (Stage 1)
  7. #362 Capability binding endpoints and CLI
  8. #363 Install consent flow and CLI
  9. #364 Sync, check, and status (server + CLI)
  10. #365 Structured failure envelope and audit log
  11. #366 First reference connector and first reference action
- Each issue names the ADR(s) that gate it and includes acceptance criteria.
- Definition of Done updated: all eleven ADRs landed; Concepts section landed; Phase 6 implementation tracked across the spun-out issues.

## Test plan

- [x] \`task build:docs\` — clean; 39 pages built (was 37 before this PR).
- [x] \`task lint:docs\` — 0 errors, 0 warnings, 0 hints.
- [ ] Visual review of \`/cli/\` once deployed.
- [ ] Confirm sidebar shows the new **CLI Reference** entry with the Terminal icon, parallel to API Reference.
- [ ] Confirm README renders cleanly on the GitHub repo page.

🤖 Generated with [Claude Code](https://claude.com/claude-code)