### PR TITLE
feat(action): add storage and parser for action manifests

### DIFF
--- a/internal/action/capability.go
+++ b/internal/action/capability.go
@@ -1,0 +1,66 @@
+package action
+
+// EnforceCapability checks whether the given action manifest permits the
+// supplied connector operation under its declared capability subset, per
+// ADR-0003.
+//
+// The action boundary is the second of the two defense-in-depth checks
+// (the connector manifest is the first). A call that requires a capability
+// outside the action's declared subset is denied here before it ever reaches
+// the connector. Returns nil on permitted calls; on denial returns a
+// structured *Error of class capability_denied with enough context for the
+// caller to surface a precise message to the agent and audit log.
+//
+// `connectorFQN` is the connector's fully-qualified URI (e.g.
+// "github://aileron/slack"); it must match one of the manifest's
+// [[requires.connectors]] entries exactly. `capability` is the operation the
+// caller is attempting (e.g. "chat:write").
+func EnforceCapability(m *Manifest, connectorFQN, capability string) error {
+	if m == nil {
+		return &Error{
+			Class:    ClassCapabilityDenied,
+			Boundary: BoundaryAction,
+			Message:  "no action manifest in scope",
+			Details: map[string]any{
+				"connector":  connectorFQN,
+				"capability": capability,
+			},
+		}
+	}
+
+	for _, c := range m.Requires.Connectors {
+		if c.Name != connectorFQN {
+			continue
+		}
+		for _, declared := range c.Capabilities {
+			if declared == capability {
+				return nil
+			}
+		}
+		return &Error{
+			Class:    ClassCapabilityDenied,
+			Boundary: BoundaryAction,
+			Message:  "capability not in declared subset",
+			Details: map[string]any{
+				"action":           m.Name,
+				"action_version":   m.Version,
+				"connector":        connectorFQN,
+				"connector_version": c.Version,
+				"requested":        capability,
+				"declared_subset":  append([]string(nil), c.Capabilities...),
+			},
+		}
+	}
+
+	return &Error{
+		Class:    ClassCapabilityDenied,
+		Boundary: BoundaryAction,
+		Message:  "connector not declared as a dependency",
+		Details: map[string]any{
+			"action":         m.Name,
+			"action_version": m.Version,
+			"connector":      connectorFQN,
+			"requested":      capability,
+		},
+	}
+}

--- a/internal/action/capability_test.go
+++ b/internal/action/capability_test.go
@@ -1,0 +1,90 @@
+package action
+
+import (
+	"errors"
+	"reflect"
+	"testing"
+)
+
+func capabilityManifest() *Manifest {
+	return &Manifest{
+		Name:    "ship-update",
+		Version: "1.0.0",
+		Requires: Requires{
+			Connectors: []RequiresConnector{
+				{
+					Name:         "github://aileron/slack",
+					Version:      "1.2.0",
+					Hash:         "sha256:abc",
+					Capabilities: []string{"chat:write", "channels:read"},
+				},
+				{
+					Name:         "github://aileron/git",
+					Version:      "2.1.0",
+					Hash:         "sha256:def",
+					Capabilities: []string{"read"},
+				},
+			},
+		},
+	}
+}
+
+func TestEnforceCapability_DeclaredAllowed(t *testing.T) {
+	m := capabilityManifest()
+	if err := EnforceCapability(m, "github://aileron/slack", "chat:write"); err != nil {
+		t.Errorf("EnforceCapability(declared) error = %v, want nil", err)
+	}
+	if err := EnforceCapability(m, "github://aileron/git", "read"); err != nil {
+		t.Errorf("EnforceCapability(read) error = %v, want nil", err)
+	}
+}
+
+func TestEnforceCapability_OutOfSubsetDenied(t *testing.T) {
+	m := capabilityManifest()
+	err := EnforceCapability(m, "github://aileron/slack", "users:read")
+	if err == nil {
+		t.Fatal("EnforceCapability succeeded; want capability_denied")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if aerr.Class != ClassCapabilityDenied {
+		t.Errorf("Class = %s, want %s", aerr.Class, ClassCapabilityDenied)
+	}
+	if aerr.Boundary != BoundaryAction {
+		t.Errorf("Boundary = %s, want action", aerr.Boundary)
+	}
+	if aerr.Details["requested"] != "users:read" {
+		t.Errorf("Details.requested = %v", aerr.Details["requested"])
+	}
+	if !reflect.DeepEqual(aerr.Details["declared_subset"], []string{"chat:write", "channels:read"}) {
+		t.Errorf("Details.declared_subset = %v", aerr.Details["declared_subset"])
+	}
+}
+
+func TestEnforceCapability_UndeclaredConnectorDenied(t *testing.T) {
+	m := capabilityManifest()
+	err := EnforceCapability(m, "github://other/foo", "do:thing")
+	if err == nil {
+		t.Fatal("EnforceCapability succeeded; want capability_denied")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) || aerr.Class != ClassCapabilityDenied {
+		t.Fatalf("expected ClassCapabilityDenied, got %v", err)
+	}
+	if aerr.Message == "" || aerr.Details["connector"] != "github://other/foo" {
+		t.Errorf("expected denial details to name the connector; got %+v", aerr.Details)
+	}
+}
+
+func TestEnforceCapability_NilManifestDenies(t *testing.T) {
+	err := EnforceCapability(nil, "github://aileron/slack", "chat:write")
+	if err == nil {
+		t.Fatal("EnforceCapability(nil) succeeded; want denial")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) || aerr.Class != ClassCapabilityDenied {
+		t.Errorf("expected capability_denied, got %v", err)
+	}
+}

--- a/internal/action/errors.go
+++ b/internal/action/errors.go
@@ -1,0 +1,108 @@
+package action
+
+import (
+	"fmt"
+)
+
+// Boundary identifies which layer produced an error, per ADR-0010.
+//
+// Action loading and capability enforcement live at the action boundary.
+type Boundary string
+
+const (
+	// BoundaryAction names the action layer (manifest parse failures and
+	// capability-subset denials).
+	BoundaryAction Boundary = "action"
+	// BoundaryRuntime names the surrounding runtime layer.
+	BoundaryRuntime Boundary = "runtime"
+)
+
+// FailureClass is the closed-set classification of failures per ADR-0010.
+// Adding a new class requires an ADR amendment.
+type FailureClass string
+
+const (
+	// ClassParseError is a structured parse failure for an action manifest.
+	// Not part of the ADR-0010 closed taxonomy directly; surfaces during
+	// load before any execution path runs.
+	ClassParseError FailureClass = "parse_error"
+
+	// ClassValidationError is a structured validation failure for an action
+	// manifest (missing required field, invalid FQN, etc.).
+	ClassValidationError FailureClass = "validation_error"
+
+	// ClassCapabilityDenied is the canonical class from ADR-0010 for a
+	// capability-subset refusal at the action boundary.
+	ClassCapabilityDenied FailureClass = "capability_denied"
+
+	// ClassNotFound names an action lookup that did not match any installed
+	// action by name.
+	ClassNotFound FailureClass = "not_found"
+)
+
+// Error is a structured action-layer error per ADR-0010. Loading and
+// enforcement errors carry enough context (file, line, boundary) for callers
+// to surface a precise message to the user without re-parsing or
+// re-formatting.
+type Error struct {
+	// Class is the canonical failure classification.
+	Class FailureClass
+	// Message is a human-readable description; safe to surface to the user.
+	// Does not contain credentials.
+	Message string
+	// Retriable signals whether the failure is safe to retry. Per ADR-0010,
+	// validation failures and capability denials are terminal.
+	Retriable bool
+	// Boundary is the layer that produced the error.
+	Boundary Boundary
+	// File is the path of the action file that produced the error, when
+	// applicable.
+	File string
+	// Line is the line within File where the error was detected, when
+	// applicable. Zero means "unknown / not applicable".
+	Line int
+	// Details is class-specific structured context (e.g. denied capability,
+	// requested op). Keys are stable strings.
+	Details map[string]any
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	loc := ""
+	switch {
+	case e.File != "" && e.Line > 0:
+		loc = fmt.Sprintf(" (%s:%d)", e.File, e.Line)
+	case e.File != "":
+		loc = fmt.Sprintf(" (%s)", e.File)
+	}
+	return fmt.Sprintf("%s: %s%s", e.Class, e.Message, loc)
+}
+
+// ErrNotFound is the sentinel matched by errors.Is for "no installed action
+// with the given name".
+var ErrNotFound = &Error{
+	Class:    ClassNotFound,
+	Boundary: BoundaryAction,
+	Message:  "action not found",
+}
+
+// newParseErr builds a ClassParseError with the given file/line context.
+func newParseErr(file string, line int, format string, args ...any) *Error {
+	return &Error{
+		Class:    ClassParseError,
+		Message:  fmt.Sprintf(format, args...),
+		Boundary: BoundaryAction,
+		File:     file,
+		Line:     line,
+	}
+}
+
+// newValidationErr builds a ClassValidationError with the given file context.
+func newValidationErr(file string, format string, args ...any) *Error {
+	return &Error{
+		Class:    ClassValidationError,
+		Message:  fmt.Sprintf(format, args...),
+		Boundary: BoundaryAction,
+		File:     file,
+	}
+}

--- a/internal/action/internal_test.go
+++ b/internal/action/internal_test.go
@@ -1,0 +1,83 @@
+package action
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// nearLineErr emulates a TOML decoder that does not implement the Line()
+// method but embeds a "Near line N" prefix in its message — tomlErrorLine's
+// fallback parser must handle this shape.
+type nearLineErr struct{ msg string }
+
+func (e nearLineErr) Error() string { return e.msg }
+
+func TestTomlErrorLine_FallbackParsesNearLineN(t *testing.T) {
+	got := tomlErrorLine(nearLineErr{msg: "Near line 7 (last key parsed): bogus"})
+	if got != 6 { // 1-based "Near line 7" → frontmatter-relative line 6 (0-based offset)
+		t.Errorf("tomlErrorLine = %d, want 6", got)
+	}
+}
+
+func TestTomlErrorLine_FallbackOnUnparseableErrorReturnsZero(t *testing.T) {
+	got := tomlErrorLine(errors.New("no line here"))
+	if got != 0 {
+		t.Errorf("tomlErrorLine = %d, want 0", got)
+	}
+}
+
+func TestValidateConnectorFQN_InvalidURI(t *testing.T) {
+	cases := []struct {
+		in   string
+		want string
+	}{
+		{"://no-scheme", "scheme"},
+		{"github://", "owner"},
+		{"github://owner", "path"},
+		{"\x7f://bad", "URI"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			err := validateConnectorFQN(tc.in)
+			if err == nil {
+				t.Fatalf("validateConnectorFQN(%q) succeeded; want error", tc.in)
+			}
+		})
+	}
+}
+
+func TestValidateSourceFQN_RejectsNonSemverTail(t *testing.T) {
+	if err := validateSourceFQN("hub://aileron/x@notsemver"); err == nil {
+		t.Fatal("validateSourceFQN succeeded; want SemVer error")
+	}
+}
+
+func TestDefaultDir_FallbackWhenHomeUnset(t *testing.T) {
+	// Force os.UserHomeDir to fail by clearing the env vars it consults.
+	t.Setenv("HOME", "")
+	t.Setenv("USERPROFILE", "")
+	got := DefaultDir()
+	if got == "" {
+		t.Fatal("DefaultDir returned empty string")
+	}
+	want := filepath.Join(".aileron", "actions")
+	if got != want {
+		t.Errorf("DefaultDir() = %q, want %q (fallback)", got, want)
+	}
+}
+
+func TestStore_Load_DirIsAFileReturnsError(t *testing.T) {
+	// ReadDir on a regular file returns an error — Load surfaces it rather
+	// than silently treating the path as empty.
+	tmp := t.TempDir()
+	notADir := filepath.Join(tmp, "file")
+	if err := os.WriteFile(notADir, []byte("x"), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	s := NewStore(notADir)
+	if _, err := s.Load(); err == nil {
+		t.Fatal("Load() succeeded on a regular file path; want error")
+	}
+}

--- a/internal/action/loader.go
+++ b/internal/action/loader.go
@@ -1,0 +1,173 @@
+package action
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"sort"
+	"sync"
+)
+
+// Store is a thread-safe in-memory index of installed actions, keyed by
+// `Manifest.Name`.
+//
+// The store is the runtime's view of `~/.aileron/actions/` after a successful
+// `Load`. Subsequent reloads replace the index atomically.
+type Store struct {
+	mu      sync.RWMutex
+	dir     string
+	actions map[string]LoadedAction
+}
+
+// LoadedAction pairs a parsed manifest with the absolute path of its source
+// file on disk.
+type LoadedAction struct {
+	Manifest *Manifest
+	Path     string
+}
+
+// NewStore constructs an empty Store rooted at dir. Use Load to populate it.
+func NewStore(dir string) *Store {
+	return &Store{
+		dir:     dir,
+		actions: map[string]LoadedAction{},
+	}
+}
+
+// Dir returns the directory the store is rooted at.
+func (s *Store) Dir() string {
+	return s.dir
+}
+
+// Load walks the store's directory and parses every `*.md` file it finds as
+// an action manifest. Per-file errors are aggregated into a LoadResult so
+// callers can surface every failure in a single pass rather than only the
+// first.
+//
+// A non-existent directory is not an error — it simply yields an empty
+// store. The action surface is optional; users with no installed actions
+// should not see startup failures.
+func (s *Store) Load() (*LoadResult, error) {
+	res := &LoadResult{}
+	loaded := map[string]LoadedAction{}
+
+	entries, err := os.ReadDir(s.dir)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			s.replace(loaded)
+			return res, nil
+		}
+		return nil, err
+	}
+
+	// Stable iteration order so error reports and listings are deterministic.
+	sort.Slice(entries, func(i, j int) bool { return entries[i].Name() < entries[j].Name() })
+
+	nameToPath := map[string]string{}
+
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		if filepath.Ext(e.Name()) != ".md" {
+			continue
+		}
+		path := filepath.Join(s.dir, e.Name())
+		data, readErr := os.ReadFile(path)
+		if readErr != nil {
+			res.Errors = append(res.Errors, &Error{
+				Class:    ClassParseError,
+				Boundary: BoundaryAction,
+				File:     path,
+				Message:  "read failed: " + readErr.Error(),
+			})
+			continue
+		}
+		manifest, parseErr := Parse(path, data)
+		if parseErr != nil {
+			var aerr *Error
+			if errors.As(parseErr, &aerr) {
+				res.Errors = append(res.Errors, aerr)
+			} else {
+				res.Errors = append(res.Errors, newParseErr(path, 0, "%s", parseErr.Error()))
+			}
+			continue
+		}
+		if vErr := Validate(manifest, path); vErr != nil {
+			var aerr *Error
+			if errors.As(vErr, &aerr) {
+				res.Errors = append(res.Errors, aerr)
+			} else {
+				res.Errors = append(res.Errors, newValidationErr(path, "%s", vErr.Error()))
+			}
+			continue
+		}
+		if existing, dup := nameToPath[manifest.Name]; dup {
+			res.Errors = append(res.Errors, newValidationErr(path,
+				"duplicate action name %q also declared in %s", manifest.Name, existing))
+			continue
+		}
+		nameToPath[manifest.Name] = path
+		loaded[manifest.Name] = LoadedAction{Manifest: manifest, Path: path}
+	}
+
+	s.replace(loaded)
+	return res, nil
+}
+
+// Get returns the loaded action for the given name. A miss returns
+// ErrNotFound.
+func (s *Store) Get(name string) (LoadedAction, error) {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	a, ok := s.actions[name]
+	if !ok {
+		return LoadedAction{}, ErrNotFound
+	}
+	return a, nil
+}
+
+// List returns all loaded actions, sorted by name.
+func (s *Store) List() []LoadedAction {
+	s.mu.RLock()
+	defer s.mu.RUnlock()
+	out := make([]LoadedAction, 0, len(s.actions))
+	for _, a := range s.actions {
+		out = append(out, a)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Manifest.Name < out[j].Manifest.Name })
+	return out
+}
+
+func (s *Store) replace(loaded map[string]LoadedAction) {
+	s.mu.Lock()
+	s.actions = loaded
+	s.mu.Unlock()
+}
+
+// LoadResult aggregates per-file failures from a Load call. A LoadResult
+// with a non-empty Errors slice still represents a successful Load — the
+// store contains the actions that did parse and validate. Callers decide
+// whether to log, surface, or fail closed on the errors.
+type LoadResult struct {
+	// Errors holds one *Error per failed action file. Files that loaded
+	// successfully produce no entry.
+	Errors []*Error
+}
+
+// HasErrors reports whether any per-file failures were recorded.
+func (r *LoadResult) HasErrors() bool {
+	return r != nil && len(r.Errors) > 0
+}
+
+// DefaultDir returns the user-level actions directory `~/.aileron/actions`.
+// Falls back to `./.aileron/actions` if the user's home directory is not
+// resolvable, matching the existing `internal/launch` behavior.
+func DefaultDir() string {
+	const subdir = "actions"
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".aileron", subdir)
+	}
+	return filepath.Join(".aileron", subdir)
+}

--- a/internal/action/loader_test.go
+++ b/internal/action/loader_test.go
@@ -1,0 +1,188 @@
+package action
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func writeFile(t *testing.T, dir, name, content string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+func TestStore_Load_EmptyDirReturnsNoActions(t *testing.T) {
+	dir := t.TempDir()
+	s := NewStore(dir)
+	if s.Dir() != dir {
+		t.Errorf("Dir() = %q, want %q", s.Dir(), dir)
+	}
+	res, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if res.HasErrors() {
+		t.Errorf("expected no load errors, got %v", res.Errors)
+	}
+	if got := s.List(); len(got) != 0 {
+		t.Errorf("List() = %v, want empty", got)
+	}
+}
+
+func TestStore_Load_NonexistentDirIsNotAnError(t *testing.T) {
+	s := NewStore(filepath.Join(t.TempDir(), "does-not-exist"))
+	res, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v, want nil for missing dir", err)
+	}
+	if res.HasErrors() {
+		t.Errorf("expected no load errors, got %v", res.Errors)
+	}
+}
+
+func TestStore_Load_ParsesValidActionAndExposesIt(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "ship-update.md", validActionFile)
+
+	s := NewStore(dir)
+	res, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if res.HasErrors() {
+		t.Fatalf("unexpected load errors: %v", res.Errors)
+	}
+	all := s.List()
+	if len(all) != 1 {
+		t.Fatalf("got %d actions, want 1", len(all))
+	}
+	if all[0].Manifest.Name != "ship-update" {
+		t.Errorf("Name = %q", all[0].Manifest.Name)
+	}
+	got, err := s.Get("ship-update")
+	if err != nil {
+		t.Fatalf("Get(ship-update) error = %v", err)
+	}
+	if got.Path == "" {
+		t.Errorf("Path is empty")
+	}
+}
+
+func TestStore_Get_UnknownReturnsErrNotFound(t *testing.T) {
+	s := NewStore(t.TempDir())
+	_, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	_, err = s.Get("missing")
+	if !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get(missing) err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestStore_Load_CollectsPerFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "good.md", validActionFile)
+	writeFile(t, dir, "bad-toml.md", `+++
+this is = = bad toml
++++
+`)
+	writeFile(t, dir, "missing-required.md", `+++
+name = "x"
++++
+`)
+	// Non-md files are ignored.
+	writeFile(t, dir, "README.txt", "ignored")
+
+	s := NewStore(dir)
+	res, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !res.HasErrors() {
+		t.Fatal("expected load errors")
+	}
+	if len(res.Errors) != 2 {
+		t.Errorf("got %d errors, want 2: %v", len(res.Errors), res.Errors)
+	}
+	classes := map[FailureClass]int{}
+	for _, e := range res.Errors {
+		classes[e.Class]++
+	}
+	if classes[ClassParseError] != 1 || classes[ClassValidationError] != 1 {
+		t.Errorf("class counts = %v, want 1 parse_error and 1 validation_error", classes)
+	}
+
+	// The good action still loads despite the others' errors.
+	if _, err := s.Get("ship-update"); err != nil {
+		t.Errorf("Get(ship-update) after partial load err = %v", err)
+	}
+}
+
+func TestStore_Load_DuplicateNameSurfacesError(t *testing.T) {
+	dir := t.TempDir()
+	writeFile(t, dir, "a.md", validActionFile)
+	writeFile(t, dir, "b.md", validActionFile) // same name inside
+
+	s := NewStore(dir)
+	res, err := s.Load()
+	if err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if !res.HasErrors() {
+		t.Fatal("expected duplicate-name error")
+	}
+	found := false
+	for _, e := range res.Errors {
+		if e.Class == ClassValidationError && strings.Contains(e.Message, "duplicate action name") {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("expected duplicate-name error, got %v", res.Errors)
+	}
+	// Only the first parses into the store; the duplicate is rejected.
+	if got := s.List(); len(got) != 1 {
+		t.Errorf("List() = %d items, want 1", len(got))
+	}
+}
+
+func TestStore_Load_ReplacesPreviousIndex(t *testing.T) {
+	dir := t.TempDir()
+	path := writeFile(t, dir, "ship-update.md", validActionFile)
+
+	s := NewStore(dir)
+	if _, err := s.Load(); err != nil {
+		t.Fatalf("Load() error = %v", err)
+	}
+	if _, err := s.Get("ship-update"); err != nil {
+		t.Fatalf("first Get err = %v", err)
+	}
+
+	if err := os.Remove(path); err != nil {
+		t.Fatalf("remove: %v", err)
+	}
+	if _, err := s.Load(); err != nil {
+		t.Fatalf("second Load() err = %v", err)
+	}
+	if _, err := s.Get("ship-update"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("after reload Get err = %v, want ErrNotFound", err)
+	}
+}
+
+func TestDefaultDir_HasActionsSuffix(t *testing.T) {
+	got := DefaultDir()
+	if filepath.Base(got) != "actions" {
+		t.Errorf("DefaultDir() = %q, want path ending in /actions", got)
+	}
+	if filepath.Base(filepath.Dir(got)) != ".aileron" {
+		t.Errorf("DefaultDir() = %q, want parent .aileron", got)
+	}
+}
+

--- a/internal/action/manifest.go
+++ b/internal/action/manifest.go
@@ -1,0 +1,115 @@
+// Package action implements parsing, validation, storage, and capability
+// enforcement for Aileron action files.
+//
+// Per [ADR-0001] and [ADR-0003], an action is a single file in
+// ~/.aileron/actions/ with TOML frontmatter delimited by `+++` and a
+// Markdown body. The frontmatter is the contract Aileron executes; the body
+// doubles as the LLM-facing function description when the action is surfaced
+// to the agent's tool catalog.
+//
+// [ADR-0001]: https://docs.withaileron.ai/adr/0001-manifest-format
+// [ADR-0003]: https://docs.withaileron.ai/adr/0003-action-model
+package action
+
+// Manifest is the parsed contents of a single action file: TOML frontmatter
+// fields plus the Markdown body.
+type Manifest struct {
+	// Name is the bare local handle for the action (e.g. "ship-update").
+	// Per ADR-0003, the user owns the file post-install and chooses the name;
+	// FQN does not apply to the action's own identity.
+	Name string `toml:"name"`
+
+	// Version is a strict semantic version (e.g. "1.0.0").
+	Version string `toml:"version"`
+
+	// Source is a fully-qualified URI recording where the action template was
+	// copied from (e.g. "hub://aileron/ship-update@1.0.0"). Provenance only —
+	// not consulted at runtime.
+	Source string `toml:"source"`
+
+	// Requires holds dependency declarations.
+	Requires Requires `toml:"requires"`
+
+	// Match describes how the runtime matches agent intent to this action
+	// ([ADR-0008]). The shape evolves as intent matching matures; v1 only
+	// requires the `intent` phrase to be present.
+	//
+	// [ADR-0008]: https://docs.withaileron.ai/adr/0008-intent-matching
+	Match Match `toml:"match"`
+
+	// Execute is the ordered list of connector operations the action runs.
+	// v1 actions are linear chains with first-failure-terminates semantics
+	// (per ADR-0010).
+	Execute []ExecuteStep `toml:"execute"`
+
+	// Body is the Markdown content following the closing `+++` delimiter.
+	// The first paragraph (or a designated section) is surfaced to the LLM
+	// as the function `description` when the action is exposed as a tool.
+	Body string `toml:"-"`
+}
+
+// Requires is the `[requires]` table holding connector dependencies.
+type Requires struct {
+	// Connectors is the list of `[[requires.connectors]]` entries.
+	Connectors []RequiresConnector `toml:"connectors"`
+}
+
+// RequiresConnector pins a single connector dependency: its fully-qualified
+// URI name, exact version, content hash, and the subset of declared
+// capabilities the action will exercise. The capability subset is enforced
+// at the action boundary at runtime — calls outside the subset are denied
+// even when the connector's manifest permits the operation.
+type RequiresConnector struct {
+	// Name is the connector's fully-qualified URI per ADR-0002
+	// (e.g. "github://aileron/slack", "hub://aileron/slack").
+	Name string `toml:"name"`
+
+	// Version is the exact pinned semantic version.
+	Version string `toml:"version"`
+
+	// Hash is the content hash of the connector binary plus its manifest
+	// (e.g. "sha256:abc123..."). Verified at install time.
+	Hash string `toml:"hash"`
+
+	// Capabilities is the action's declared subset of operations on the
+	// connector (e.g. ["chat:write", "channels:read"]). Empty means the
+	// action declares no capabilities and may not invoke the connector.
+	Capabilities []string `toml:"capabilities"`
+}
+
+// Match holds intent-matching metadata for the action. Shape stays minimal
+// in v1; richer fields are added as ADR-0008 matures.
+type Match struct {
+	// Intent is the canonical natural-language phrase the runtime matches
+	// against agent requests when surfacing this action.
+	Intent string `toml:"intent"`
+}
+
+// ExecuteStep is one step in the action's execution chain. The runtime
+// invokes steps in declared order; on the first step failure the action
+// terminates and returns the failing step's structured error
+// (per ADR-0010). Successful prior steps are not auto-rolled-back.
+type ExecuteStep struct {
+	// ID is a label for the step. Subsequent steps may reference its outputs
+	// via `${id.field}` interpolation in `Inputs`.
+	ID string `toml:"id"`
+
+	// Connector is the FQN of the connector whose operation this step calls.
+	// Must appear in `Requires.Connectors` and must match one of those FQNs
+	// exactly.
+	Connector string `toml:"connector"`
+
+	// Op is the connector operation invoked at this step.
+	Op string `toml:"op"`
+
+	// Idempotent overrides the connector's declared idempotency for this
+	// call (per ADR-0010). v1 recognizes the field but the runtime uses
+	// the connector's manifest-level declaration as the authoritative
+	// retry signal; per-call overrides are flagged for post-MVP retry tuning.
+	Idempotent *bool `toml:"idempotent"`
+
+	// Inputs is the keyed argument map passed to the connector op. Values
+	// may be string interpolations referencing call-time arguments
+	// (`${args.X}`) or the outputs of prior steps (`${step_id.field}`).
+	Inputs map[string]any `toml:"inputs"`
+}

--- a/internal/action/parse.go
+++ b/internal/action/parse.go
@@ -1,0 +1,161 @@
+package action
+
+import (
+	"bufio"
+	"bytes"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// frontmatterDelim is the literal token that opens and closes the TOML
+// frontmatter block, per ADR-0001.
+const frontmatterDelim = "+++"
+
+// Parse splits the +++-delimited TOML frontmatter from the Markdown body and
+// returns the populated Manifest. `file` is the path to the source file (used
+// for structured error reporting); `data` is the file contents.
+//
+// The contract:
+//   - The file MUST begin with a `+++` line (after optional leading blank
+//     lines or BOMs are tolerated).
+//   - The frontmatter block MUST close with a line containing only `+++`.
+//   - Everything between is parsed as TOML.
+//   - Everything after is captured verbatim as the Markdown body.
+//
+// Any deviation surfaces as a ClassParseError carrying the offending file and
+// (when known) line. Validation of required fields is performed by Validate.
+func Parse(file string, data []byte) (*Manifest, error) {
+	frontmatter, body, fmStart, err := splitFrontmatter(file, data)
+	if err != nil {
+		return nil, err
+	}
+
+	m := &Manifest{}
+	meta, decErr := toml.Decode(frontmatter, m)
+	if decErr != nil {
+		// BurntSushi reports line numbers relative to the frontmatter
+		// substring; offset by the frontmatter's start line so the error
+		// points at the actual file line.
+		line := tomlErrorLine(decErr) + fmStart
+		return nil, newParseErr(file, line, "invalid TOML frontmatter: %s", decErr.Error())
+	}
+
+	// Reject unknown frontmatter keys: the schema is closed in v1, and a
+	// silently-ignored key in a security-relevant manifest is exactly the
+	// kind of footgun ADR-0001 chose TOML to avoid.
+	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+		keys := make([]string, 0, len(undecoded))
+		for _, k := range undecoded {
+			keys = append(keys, k.String())
+		}
+		return nil, newParseErr(file, fmStart, "unknown frontmatter key(s): %s", strings.Join(keys, ", "))
+	}
+
+	m.Body = body
+	return m, nil
+}
+
+// splitFrontmatter walks the input line-by-line, locates the opening and
+// closing `+++` delimiters, and returns the frontmatter (between the
+// delimiters), the Markdown body (after the closing delimiter), and the line
+// number of the first frontmatter content line (1-based — used to translate
+// TOML decoder line numbers to file line numbers).
+func splitFrontmatter(file string, data []byte) (frontmatter, body string, fmStart int, err error) {
+	scanner := bufio.NewScanner(bytes.NewReader(data))
+	// Accommodate longer lines than the default 64KB.
+	scanner.Buffer(make([]byte, 0, 64*1024), 1024*1024)
+
+	var (
+		opened     bool
+		closed     bool
+		fmLines    []string
+		bodyLines  []string
+		lineNo     int
+		closeLine  int
+	)
+
+	for scanner.Scan() {
+		lineNo++
+		line := scanner.Text()
+
+		// Tolerate BOM on the first line.
+		if lineNo == 1 {
+			line = strings.TrimPrefix(line, "\ufeff")
+		}
+
+		switch {
+		case !opened:
+			// Lines before the opening delimiter must be blank — anything
+			// else is a parse error so authors can't accidentally paste
+			// content above the manifest.
+			trimmed := strings.TrimSpace(line)
+			if trimmed == "" {
+				continue
+			}
+			if trimmed != frontmatterDelim {
+				return "", "", 0, newParseErr(file, lineNo, "expected %q at start of file, got %q", frontmatterDelim, trimmed)
+			}
+			opened = true
+			fmStart = lineNo + 1
+
+		case opened && !closed:
+			if strings.TrimSpace(line) == frontmatterDelim {
+				closed = true
+				closeLine = lineNo
+				continue
+			}
+			fmLines = append(fmLines, line)
+
+		default:
+			bodyLines = append(bodyLines, line)
+		}
+	}
+
+	if scanErr := scanner.Err(); scanErr != nil {
+		return "", "", 0, newParseErr(file, lineNo, "read error: %s", scanErr.Error())
+	}
+
+	if !opened {
+		return "", "", 0, newParseErr(file, 0, "missing %q opening delimiter", frontmatterDelim)
+	}
+	if !closed {
+		return "", "", 0, newParseErr(file, fmStart, "missing %q closing delimiter", frontmatterDelim)
+	}
+	_ = closeLine // currently unused; reserved for richer diagnostics.
+
+	frontmatter = strings.Join(fmLines, "\n")
+	if len(bodyLines) > 0 {
+		body = strings.Join(bodyLines, "\n")
+	}
+	return frontmatter, body, fmStart, nil
+}
+
+// tomlErrorLine extracts the line number from a BurntSushi/toml error when
+// the error is a *toml.ParseError. Returns 0 when the underlying type does
+// not expose a line.
+func tomlErrorLine(err error) int {
+	type lineError interface {
+		Line() int
+	}
+	if le, ok := err.(lineError); ok && le.Line() > 0 {
+		return le.Line() - 1 // BurntSushi lines are 1-based within the frontmatter; we add fmStart (also 1-based) so subtract 1
+	}
+	// Fall back to parsing "Near line N" prefixes some versions emit.
+	msg := err.Error()
+	const prefix = "Near line "
+	if i := strings.Index(msg, prefix); i >= 0 {
+		rest := msg[i+len(prefix):]
+		var n int
+		for _, r := range rest {
+			if r < '0' || r > '9' {
+				break
+			}
+			n = n*10 + int(r-'0')
+		}
+		if n > 0 {
+			return n - 1
+		}
+	}
+	return 0
+}

--- a/internal/action/parse_test.go
+++ b/internal/action/parse_test.go
@@ -1,0 +1,217 @@
+package action
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+const validActionFile = `+++
+name = "ship-update"
+version = "1.0.0"
+source = "hub://aileron/ship-update@1.0.0"
+
+[[requires.connectors]]
+name = "github://aileron/slack"
+version = "1.2.0"
+hash = "sha256:abc123"
+capabilities = ["chat:write", "channels:read"]
+
+[[requires.connectors]]
+name = "github://aileron/git"
+version = "2.1.0"
+hash = "sha256:def456"
+capabilities = ["read"]
+
+[match]
+intent = "tell team I shipped"
+
+[[execute]]
+id = "recent_merge"
+connector = "github://aileron/git"
+op = "read_recent_merge"
+
+[[execute]]
+id = "post"
+connector = "github://aileron/slack"
+op = "post_message"
+
+[execute.inputs]
+channel = "${args.channel}"
++++
+
+# Ship Update
+
+Posts a "shipped" announcement to a Slack channel.
+`
+
+func TestParse_ValidFrontmatterAndBody(t *testing.T) {
+	m, err := Parse("ship-update.md", []byte(validActionFile))
+	if err != nil {
+		t.Fatalf("Parse() error = %v, want nil", err)
+	}
+	if m.Name != "ship-update" {
+		t.Errorf("Name = %q, want ship-update", m.Name)
+	}
+	if m.Version != "1.0.0" {
+		t.Errorf("Version = %q, want 1.0.0", m.Version)
+	}
+	if m.Source != "hub://aileron/ship-update@1.0.0" {
+		t.Errorf("Source = %q, want hub URI", m.Source)
+	}
+	if len(m.Requires.Connectors) != 2 {
+		t.Fatalf("got %d connectors, want 2", len(m.Requires.Connectors))
+	}
+	if got := m.Requires.Connectors[0].Capabilities; len(got) != 2 || got[0] != "chat:write" {
+		t.Errorf("connectors[0].Capabilities = %v, want [chat:write channels:read]", got)
+	}
+	if m.Match.Intent != "tell team I shipped" {
+		t.Errorf("Match.Intent = %q", m.Match.Intent)
+	}
+	if len(m.Execute) != 2 {
+		t.Fatalf("got %d execute steps, want 2", len(m.Execute))
+	}
+	if m.Execute[1].Inputs["channel"] != "${args.channel}" {
+		t.Errorf("execute[1].inputs.channel = %v", m.Execute[1].Inputs["channel"])
+	}
+	if !strings.Contains(m.Body, "# Ship Update") {
+		t.Errorf("Body missing heading; got %q", m.Body)
+	}
+	if strings.Contains(m.Body, "+++") {
+		t.Errorf("Body should not contain frontmatter delimiter; got %q", m.Body)
+	}
+}
+
+func TestParse_MissingOpeningDelimiter(t *testing.T) {
+	data := `name = "x"
++++
+body
+`
+	_, err := Parse("bad.md", []byte(data))
+	if err == nil {
+		t.Fatal("Parse() succeeded; want missing-opening-delimiter error")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) {
+		t.Fatalf("expected *Error, got %T", err)
+	}
+	if aerr.Class != ClassParseError {
+		t.Errorf("Class = %s, want %s", aerr.Class, ClassParseError)
+	}
+	if aerr.File != "bad.md" {
+		t.Errorf("File = %q", aerr.File)
+	}
+}
+
+func TestParse_MissingClosingDelimiter(t *testing.T) {
+	data := `+++
+name = "x"
+version = "1.0.0"
+source = "hub://aileron/x@1.0.0"
+`
+	_, err := Parse("noclose.md", []byte(data))
+	if err == nil {
+		t.Fatal("Parse() succeeded; want missing-closing-delimiter error")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) || aerr.Class != ClassParseError {
+		t.Fatalf("expected ClassParseError, got %v", err)
+	}
+	if !strings.Contains(aerr.Message, "closing") {
+		t.Errorf("message %q does not mention closing delimiter", aerr.Message)
+	}
+}
+
+func TestParse_TOMLSyntaxErrorReportsLine(t *testing.T) {
+	data := `+++
+name = "x"
+this is not valid toml = =
++++
+`
+	_, err := Parse("bad-toml.md", []byte(data))
+	if err == nil {
+		t.Fatal("Parse() succeeded; want TOML syntax error")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) || aerr.Class != ClassParseError {
+		t.Fatalf("expected ClassParseError, got %v", err)
+	}
+	if aerr.Line == 0 {
+		t.Errorf("expected Line > 0, got %d (msg=%s)", aerr.Line, aerr.Message)
+	}
+}
+
+func TestParse_UnknownFrontmatterKeyRejected(t *testing.T) {
+	data := `+++
+name = "x"
+version = "1.0.0"
+source = "hub://aileron/x@1.0.0"
+unexpected_field = "nope"
+
+[[requires.connectors]]
+name = "github://aileron/slack"
+version = "1.0.0"
+hash = "sha256:abc"
+capabilities = ["chat:write"]
+
+[match]
+intent = "x"
+
+[[execute]]
+id = "a"
+connector = "github://aileron/slack"
+op = "post"
++++
+`
+	_, err := Parse("unknown.md", []byte(data))
+	if err == nil {
+		t.Fatal("Parse() succeeded; want unknown-key error")
+	}
+	if !strings.Contains(err.Error(), "unexpected_field") {
+		t.Errorf("error %q does not name the unknown field", err.Error())
+	}
+}
+
+func TestParse_LeadingBOMTolerated(t *testing.T) {
+	data := "\ufeff" + validActionFile
+	if _, err := Parse("bom.md", []byte(data)); err != nil {
+		t.Fatalf("Parse() with BOM error = %v", err)
+	}
+}
+
+func TestParse_LeadingBlankLinesTolerated(t *testing.T) {
+	data := "\n\n" + validActionFile
+	if _, err := Parse("blank.md", []byte(data)); err != nil {
+		t.Fatalf("Parse() with leading blanks error = %v", err)
+	}
+}
+
+func TestParse_NoBodyIsAllowed(t *testing.T) {
+	data := `+++
+name = "noop"
+version = "1.0.0"
+source = "hub://aileron/noop@1.0.0"
+
+[[requires.connectors]]
+name = "github://aileron/slack"
+version = "1.0.0"
+hash = "sha256:abc"
+capabilities = ["chat:write"]
+
+[match]
+intent = "noop"
+
+[[execute]]
+id = "a"
+connector = "github://aileron/slack"
+op = "post"
++++
+`
+	m, err := Parse("nobody.md", []byte(data))
+	if err != nil {
+		t.Fatalf("Parse() error = %v", err)
+	}
+	if m.Body != "" {
+		t.Errorf("Body = %q, want empty", m.Body)
+	}
+}

--- a/internal/action/validate.go
+++ b/internal/action/validate.go
@@ -1,0 +1,154 @@
+package action
+
+import (
+	"fmt"
+	"net/url"
+	"regexp"
+	"strings"
+)
+
+// semverRe matches strict SemVer 2.0.0 (no leading "v"), per ADR-0002 and
+// ADR-0003. Pre-release and build-metadata tails are accepted.
+var semverRe = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
+
+// nameRe validates the action's bare local handle. Per ADR-0003 the user
+// owns the file and chooses the name; we constrain it to a portable filename
+// shape so listing endpoints and on-disk discovery agree.
+var nameRe = regexp.MustCompile(`^[a-z0-9][a-z0-9._-]*$`)
+
+// fqnSchemes is the closed set of FQN schemes recognized in v1, per ADR-0002.
+// Adding a scheme requires an ADR amendment (or a future ADR delegating
+// scheme registration).
+var fqnSchemes = map[string]bool{
+	"github": true,
+	"gitlab": true,
+	"hub":    true,
+}
+
+// Validate checks a parsed manifest against the schema described in
+// ADR-0001 and ADR-0003. Returns a *Error on the first failure. Successive
+// fields are checked in declared order so authors see one specific message
+// at a time rather than a flood.
+func Validate(m *Manifest, file string) error {
+	if m == nil {
+		return newValidationErr(file, "manifest is nil")
+	}
+	if m.Name == "" {
+		return newValidationErr(file, "name is required")
+	}
+	if !nameRe.MatchString(m.Name) {
+		return newValidationErr(file, "name %q must match %s", m.Name, nameRe.String())
+	}
+	if m.Version == "" {
+		return newValidationErr(file, "version is required")
+	}
+	if !semverRe.MatchString(m.Version) {
+		return newValidationErr(file, "version %q must be strict SemVer (e.g. 1.2.3)", m.Version)
+	}
+	if m.Source == "" {
+		return newValidationErr(file, "source is required")
+	}
+	if err := validateSourceFQN(m.Source); err != nil {
+		return newValidationErr(file, "invalid source: %s", err.Error())
+	}
+	if len(m.Requires.Connectors) == 0 {
+		return newValidationErr(file, "[[requires.connectors]] is required (at least one connector)")
+	}
+	for i, c := range m.Requires.Connectors {
+		if c.Name == "" {
+			return newValidationErr(file, "requires.connectors[%d].name is required", i)
+		}
+		if err := validateConnectorFQN(c.Name); err != nil {
+			return newValidationErr(file, "requires.connectors[%d].name: %s", i, err.Error())
+		}
+		if c.Version == "" {
+			return newValidationErr(file, "requires.connectors[%d].version is required", i)
+		}
+		if !semverRe.MatchString(c.Version) {
+			return newValidationErr(file, "requires.connectors[%d].version %q must be strict SemVer", i, c.Version)
+		}
+		if c.Hash == "" {
+			return newValidationErr(file, "requires.connectors[%d].hash is required", i)
+		}
+		if !strings.HasPrefix(c.Hash, "sha256:") || len(c.Hash) <= len("sha256:") {
+			return newValidationErr(file, "requires.connectors[%d].hash %q must be prefixed with sha256:", i, c.Hash)
+		}
+		if len(c.Capabilities) == 0 {
+			return newValidationErr(file, "requires.connectors[%d].capabilities is required (declare the subset the action exercises)", i)
+		}
+		for j, cap := range c.Capabilities {
+			if strings.TrimSpace(cap) == "" {
+				return newValidationErr(file, "requires.connectors[%d].capabilities[%d] is empty", i, j)
+			}
+		}
+	}
+	if m.Match.Intent == "" {
+		return newValidationErr(file, "[match].intent is required")
+	}
+	if len(m.Execute) == 0 {
+		return newValidationErr(file, "[[execute]] is required (at least one step)")
+	}
+	connectorByFQN := map[string]bool{}
+	for _, c := range m.Requires.Connectors {
+		connectorByFQN[c.Name] = true
+	}
+	stepIDs := map[string]bool{}
+	for i, s := range m.Execute {
+		if s.ID == "" {
+			return newValidationErr(file, "execute[%d].id is required", i)
+		}
+		if stepIDs[s.ID] {
+			return newValidationErr(file, "execute[%d].id %q is duplicated", i, s.ID)
+		}
+		stepIDs[s.ID] = true
+		if s.Connector == "" {
+			return newValidationErr(file, "execute[%d].connector is required", i)
+		}
+		if !connectorByFQN[s.Connector] {
+			return newValidationErr(file, "execute[%d].connector %q is not declared in [[requires.connectors]]", i, s.Connector)
+		}
+		if s.Op == "" {
+			return newValidationErr(file, "execute[%d].op is required", i)
+		}
+	}
+	return nil
+}
+
+// validateSourceFQN parses an action source URI of the shape
+// `<scheme>://<owner>/<path>@<version>`. The version suffix is mandatory for
+// `source` per ADR-0003.
+func validateSourceFQN(s string) error {
+	at := strings.LastIndex(s, "@")
+	if at < 0 {
+		return fmt.Errorf("missing @<version> suffix")
+	}
+	base, ver := s[:at], s[at+1:]
+	if !semverRe.MatchString(ver) {
+		return fmt.Errorf("version %q must be strict SemVer", ver)
+	}
+	return validateConnectorFQN(base)
+}
+
+// validateConnectorFQN parses a connector URI of the shape
+// `<scheme>://<owner>/<path>` (no version suffix — the version pins live in
+// adjacent fields).
+func validateConnectorFQN(s string) error {
+	u, err := url.Parse(s)
+	if err != nil {
+		return fmt.Errorf("not a valid URI: %s", err.Error())
+	}
+	if !fqnSchemes[u.Scheme] {
+		schemes := make([]string, 0, len(fqnSchemes))
+		for k := range fqnSchemes {
+			schemes = append(schemes, k+"://")
+		}
+		return fmt.Errorf("scheme %q is not recognized (expected one of %s)", u.Scheme, strings.Join(schemes, ", "))
+	}
+	if u.Host == "" {
+		return fmt.Errorf("missing owner segment")
+	}
+	if u.Path == "" || u.Path == "/" {
+		return fmt.Errorf("missing path segment")
+	}
+	return nil
+}

--- a/internal/action/validate_test.go
+++ b/internal/action/validate_test.go
@@ -1,0 +1,108 @@
+package action
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// goodManifest returns a manifest that passes Validate; tests mutate one
+// field at a time to assert specific failures.
+func goodManifest() *Manifest {
+	return &Manifest{
+		Name:    "ship-update",
+		Version: "1.0.0",
+		Source:  "hub://aileron/ship-update@1.0.0",
+		Requires: Requires{
+			Connectors: []RequiresConnector{
+				{
+					Name:         "github://aileron/slack",
+					Version:      "1.2.0",
+					Hash:         "sha256:abc",
+					Capabilities: []string{"chat:write"},
+				},
+			},
+		},
+		Match: Match{Intent: "tell team I shipped"},
+		Execute: []ExecuteStep{
+			{ID: "post", Connector: "github://aileron/slack", Op: "post_message"},
+		},
+	}
+}
+
+func TestValidate_HappyPath(t *testing.T) {
+	if err := Validate(goodManifest(), "ok.md"); err != nil {
+		t.Fatalf("Validate() error = %v, want nil", err)
+	}
+}
+
+func TestValidate_RejectsBadFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(*Manifest)
+		want    string // substring expected in the error message
+	}{
+		{"empty name", func(m *Manifest) { m.Name = "" }, "name is required"},
+		{"bad name shape", func(m *Manifest) { m.Name = "Has Spaces" }, "must match"},
+		{"missing version", func(m *Manifest) { m.Version = "" }, "version is required"},
+		{"non-semver version", func(m *Manifest) { m.Version = "1.x" }, "strict SemVer"},
+		{"missing source", func(m *Manifest) { m.Source = "" }, "source is required"},
+		{"source missing version", func(m *Manifest) { m.Source = "hub://aileron/ship-update" }, "missing @<version>"},
+		{"source bad scheme", func(m *Manifest) { m.Source = "ftp://x/y@1.0.0" }, "scheme"},
+		{"no connectors", func(m *Manifest) { m.Requires.Connectors = nil }, "[[requires.connectors]]"},
+		{"connector empty name", func(m *Manifest) { m.Requires.Connectors[0].Name = "" }, "name is required"},
+		{"connector bad scheme", func(m *Manifest) { m.Requires.Connectors[0].Name = "ftp://acme/slack" }, "scheme"},
+		{"connector missing version", func(m *Manifest) { m.Requires.Connectors[0].Version = "" }, "version is required"},
+		{"connector bad version", func(m *Manifest) { m.Requires.Connectors[0].Version = "x" }, "strict SemVer"},
+		{"connector missing hash", func(m *Manifest) { m.Requires.Connectors[0].Hash = "" }, "hash is required"},
+		{"connector bad hash prefix", func(m *Manifest) { m.Requires.Connectors[0].Hash = "md5:abc" }, "sha256:"},
+		{"connector empty caps", func(m *Manifest) { m.Requires.Connectors[0].Capabilities = nil }, "capabilities is required"},
+		{"connector blank cap", func(m *Manifest) { m.Requires.Connectors[0].Capabilities = []string{"   "} }, "is empty"},
+		{"missing intent", func(m *Manifest) { m.Match.Intent = "" }, "intent is required"},
+		{"no execute steps", func(m *Manifest) { m.Execute = nil }, "[[execute]]"},
+		{"execute missing id", func(m *Manifest) { m.Execute[0].ID = "" }, "id is required"},
+		{"execute duplicate id", func(m *Manifest) {
+			m.Execute = append(m.Execute, ExecuteStep{ID: "post", Connector: "github://aileron/slack", Op: "x"})
+		}, "duplicated"},
+		{"execute missing connector", func(m *Manifest) { m.Execute[0].Connector = "" }, "connector is required"},
+		{"execute undeclared connector", func(m *Manifest) { m.Execute[0].Connector = "github://other/foo" }, "not declared"},
+		{"execute missing op", func(m *Manifest) { m.Execute[0].Op = "" }, "op is required"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := goodManifest()
+			tc.mutate(m)
+			err := Validate(m, "x.md")
+			if err == nil {
+				t.Fatalf("Validate() succeeded; want error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("error = %q; want substring %q", err.Error(), tc.want)
+			}
+			var aerr *Error
+			if !errors.As(err, &aerr) || aerr.Class != ClassValidationError {
+				t.Errorf("expected *Error/ClassValidationError, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_AcceptsAllRecognizedSchemes(t *testing.T) {
+	for _, scheme := range []string{"github", "gitlab", "hub"} {
+		t.Run(scheme, func(t *testing.T) {
+			m := goodManifest()
+			m.Source = scheme + "://aileron/ship-update@1.0.0"
+			m.Requires.Connectors[0].Name = scheme + "://aileron/slack"
+			m.Execute[0].Connector = m.Requires.Connectors[0].Name
+			if err := Validate(m, "x.md"); err != nil {
+				t.Errorf("Validate() error = %v", err)
+			}
+		})
+	}
+}
+
+func TestValidate_NilManifest(t *testing.T) {
+	if err := Validate(nil, "x.md"); err == nil {
+		t.Fatal("Validate(nil) succeeded; want error")
+	}
+}

--- a/internal/api/gen/server.gen.go
+++ b/internal/api/gen/server.gen.go
@@ -1290,6 +1290,43 @@ func (e UserStatus) Valid() bool {
 	}
 }
 
+// Action A user-installed action manifest. Per ADR-0001 and ADR-0003, an
+// action is a single Markdown file with TOML frontmatter; the parsed
+// frontmatter populates this object's structured fields and the
+// Markdown content following the closing `+++` populates `body`.
+type Action struct {
+	// Body Markdown content following the closing `+++` delimiter. The first
+	// paragraph (or a designated section) is surfaced to the LLM as the
+	// function description when the action is exposed as a tool.
+	Body    *string             `json:"body,omitempty"`
+	Execute []ActionExecuteStep `json:"execute"`
+	Match   ActionMatch         `json:"match"`
+
+	// Name Bare local handle for the action (e.g. "ship-update").
+	Name string `json:"name"`
+
+	// Path Absolute path of the source file on disk.
+	Path     *string        `json:"path,omitempty"`
+	Requires ActionRequires `json:"requires"`
+
+	// Source Fully-qualified URI of the template the action was installed from
+	// (e.g. "hub://aileron/ship-update@1.0.0"). Provenance only — not
+	// consulted at runtime.
+	Source string `json:"source"`
+
+	// Version Strict SemVer of the action manifest.
+	Version string `json:"version"`
+}
+
+// ActionExecuteStep defines model for ActionExecuteStep.
+type ActionExecuteStep struct {
+	Connector  string                  `json:"connector"`
+	Id         string                  `json:"id"`
+	Idempotent *bool                   `json:"idempotent,omitempty"`
+	Inputs     *map[string]interface{} `json:"inputs,omitempty"`
+	Op         string                  `json:"op"`
+}
+
 // ActionIntent defines model for ActionIntent.
 type ActionIntent struct {
 	// Domain Carries action-type-specific fields. Exactly one field must be populated,
@@ -1309,6 +1346,59 @@ type ActionIntent struct {
 	Summary       string                  `json:"summary"`
 	Target        *ActionTarget           `json:"target,omitempty"`
 	Type          string                  `json:"type"`
+}
+
+// ActionListResponse defines model for ActionListResponse.
+type ActionListResponse struct {
+	Items      *[]Action          `json:"items,omitempty"`
+	LoadErrors *[]ActionLoadError `json:"load_errors,omitempty"`
+}
+
+// ActionLoadError A structured error describing a single file in the actions directory
+// that failed to parse or validate, per ADR-0010. Loading is
+// non-fatal — files that load successfully appear in `items`; failed
+// files appear here so callers can surface a precise message.
+type ActionLoadError struct {
+	// Boundary Which layer produced the error (always "action" for load failures).
+	Boundary *string `json:"boundary,omitempty"`
+
+	// Class Canonical failure class (e.g. parse_error, validation_error).
+	Class string `json:"class"`
+
+	// File Absolute path of the offending file.
+	File string `json:"file"`
+
+	// Line Line within the file where the error was detected; 0 when unknown.
+	Line    *int   `json:"line,omitempty"`
+	Message string `json:"message"`
+}
+
+// ActionMatch defines model for ActionMatch.
+type ActionMatch struct {
+	// Intent Canonical phrase the runtime matches against agent intent.
+	Intent string `json:"intent"`
+}
+
+// ActionRequires defines model for ActionRequires.
+type ActionRequires struct {
+	Connectors *[]ActionRequiresConnector `json:"connectors,omitempty"`
+}
+
+// ActionRequiresConnector defines model for ActionRequiresConnector.
+type ActionRequiresConnector struct {
+	// Capabilities The action's declared subset of operations on the connector. Per
+	// ADR-0003, calls outside this subset are denied at the action
+	// boundary even when the connector permits the operation.
+	Capabilities []string `json:"capabilities"`
+
+	// Hash Content hash of the connector binary plus its manifest.
+	Hash string `json:"hash"`
+
+	// Name Connector FQN per ADR-0002 (e.g. "github://aileron/slack").
+	Name string `json:"name"`
+
+	// Version Pinned SemVer of the connector.
+	Version string `json:"version"`
 }
 
 // ActionTarget defines model for ActionTarget.
@@ -4034,6 +4124,12 @@ func (t *PolicyCondition_Value) UnmarshalJSON(b []byte) error {
 
 // ServerInterface represents all server handlers.
 type ServerInterface interface {
+	// List installed actions
+	// (GET /v1/actions)
+	ListActions(w http.ResponseWriter, r *http.Request)
+	// Get an installed action by name
+	// (GET /v1/actions/{name})
+	GetAction(w http.ResponseWriter, r *http.Request, name string)
 	// Get analytics summary
 	// (GET /v1/analytics/summary)
 	GetAnalyticsSummary(w http.ResponseWriter, r *http.Request, params GetAnalyticsSummaryParams)
@@ -4197,6 +4293,57 @@ type ServerInterfaceWrapper struct {
 }
 
 type MiddlewareFunc func(http.Handler) http.Handler
+
+// ListActions operation middleware
+func (siw *ServerInterfaceWrapper) ListActions(w http.ResponseWriter, r *http.Request) {
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.ListActions(w, r)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
+
+// GetAction operation middleware
+func (siw *ServerInterfaceWrapper) GetAction(w http.ResponseWriter, r *http.Request) {
+
+	var err error
+
+	// ------------- Path parameter "name" -------------
+	var name string
+
+	err = runtime.BindStyledParameterWithOptions("simple", "name", r.PathValue("name"), &name, runtime.BindStyledParameterOptions{ParamLocation: runtime.ParamLocationPath, Explode: false, Required: true, Type: "string", Format: ""})
+	if err != nil {
+		siw.ErrorHandlerFunc(w, r, &InvalidParamFormatError{ParamName: "name", Err: err})
+		return
+	}
+
+	ctx := r.Context()
+
+	ctx = context.WithValue(ctx, BearerAuthScopes, []string{})
+
+	r = r.WithContext(ctx)
+
+	handler := http.Handler(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		siw.Handler.GetAction(w, r, name)
+	}))
+
+	for _, middleware := range siw.HandlerMiddlewares {
+		handler = middleware(handler)
+	}
+
+	handler.ServeHTTP(w, r)
+}
 
 // GetAnalyticsSummary operation middleware
 func (siw *ServerInterfaceWrapper) GetAnalyticsSummary(w http.ResponseWriter, r *http.Request) {
@@ -5858,6 +6005,8 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 		ErrorHandlerFunc:   options.ErrorHandlerFunc,
 	}
 
+	m.HandleFunc("GET "+options.BaseURL+"/v1/actions", wrapper.ListActions)
+	m.HandleFunc("GET "+options.BaseURL+"/v1/actions/{name}", wrapper.GetAction)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/analytics/summary", wrapper.GetAnalyticsSummary)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/approvals", wrapper.ListApprovals)
 	m.HandleFunc("GET "+options.BaseURL+"/v1/approvals/{approval_id}", wrapper.GetApproval)
@@ -5916,238 +6065,261 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x9bZPbuNHgX0Hprsp2TtKM7U2eZPLlvPbsrne9WZfHm3xYuTQQ2ZKQIQEuAM6M4pqr",
-	"59P9gKvnF+aXXKEbIEGKpKR5sddP8sUekSDQaDQa3Y1++ThKVF4oCdKa0cnHUcE1z8GCxl8vikKrS569",
-	"Tt0vIUcno4Lb9Wg8kjyH0cmI+wZzkY7GIw2/lkJDOjqxuoTxyCRryLn71G4K19xYLeRqdHMzHr1UUkJi",
-	"le7tOwktDu/89BqS0golezuH0OLwzr/VXNrejlfu7eGdvpYWBnoV+Prwbt/yFZyJf0DV7a8l6E3db8FX",
-	"MDeuQdxPCkteZnZ08vvj8Sjn1yIv89HJs2P3S0j69XQchnOwrUBX471XFyAHB7TYYgfkKhPJphchBb4+",
-	"FCE3rrEplDSA9P01T9/BryUY634lCrHs/uRFkYmEOwI5+rtROJ262/+pYTk6Gf2Po3rvHNFbc3SqtdI0",
-	"VAom0aJwnYxORq/lJc9EyrQfkPbAMhPJJxg8jMSuhF2zpNQapGUajCp1AsxYbsFB9I3SC5GmtH4PjQ9T",
-	"LpciEQ6SAnQujBFKGgfGX5T9RpUyfXgo3gUUSGXZEse8GY9+lry0a6XFP+ATwPCjm7lcMaWZ8ETihgdp",
-	"/UAOpL+6HflGJRefAiIcjAnDMhyQ/fM//4uV0v0gAnr709l7dnT59Kg0oM1RDkcFN6ZYa27giBriJvYD",
-	"4VGSID+uoC60KkBbQRsxVTkXche8r7AV9eRw8vfSWLEMSNre7+NRDpan3CImeJoK15Bnb6OxiWX4D9Xi",
-	"75Dg1jRlnnO96ezUcr0CuwtYAvM9tb0JQ3wcwTXPi8wN/ctoJey0KLNs7pnCNNHgduIY3whjSuh8pPLc",
-	"odEtW5GpzVRDBty4RkmmynQaNvY0Ly19DDkX2dSATKsfqeZL10fCM5Ap11O4BBmBUPBNjg/Wbg7ugVZJ",
-	"qQEfBoBNuciFHX0Yd7Dwmi//Qm9rtH7oQHkDYdsUIkyR8c2c+H/Hqoi08/GFIDYC0p1av4wuQaZK46lR",
-	"KCOswtMJ5KXQSnqs8kI4WCHRECMoYG6uIRGFoLZWJBfUymF+HjDvHpTGqnw3ahDCHoQo/c5R2H0ho6JB",
-	"jwy+okmsy5zjgQz6UhDwlfClS2lFDrvngWcxNumcjOTZxorEnNU7qzmpSpbMuAWZbOa52W5U/P44mlkl",
-	"eoxHxZ9+3/XipgOUxWauhbmYZ3AJWT9n6Bplm08UQPTVBJNO2KSHfyjLs3kupNLzUgpr9gUcPzT9mDNz",
-	"lD4h7Qa+buZ3b1/DFKTwA22/rCRnM19ykfX1ETUzZZIApH0tSbbdEwk3naRl11oVIvkRjOEr2MXsW0tV",
-	"n6TNQ/AMF8ydylxrvmFqyXxbtnAnnGGPzy1c2/MxO7dKZfPSwPl4JumHBlNm+E7kfAXnYzadTp9M2dma",
-	"F8CWKsvUlWEV6I/MTHrwDQ6jeWKnMzzmtMoau9Yduo5LGSOM5XIP7os9jKupfhhC4nulssMw2EBbFzOS",
-	"RWnntUgy1HNzCb4/++kv7Aw/ZEulmV0Dc9h9ZBh2Oh11zKSHKbZQgq06EVG4LX16KVKQCUTqQXPS4Bug",
-	"fmKBeNWgsOU/eG0hj1gJ0tYWdFXvPRDiPh5goT38n9575X4vqMNYeBZtgz0eQSosX2QwXzjh2RwsaMF1",
-	"ITSYOUccL5XO3V+jlFuY4LkzHskyy9wQrT5iAgvacdekNSdguk/KihUOQdDxlVHZ5fBHO8F2Wle59wqc",
-	"Ueub8ehK6QtT8AS6Z9wipaaJJjYk+PFbOIipZIj6SFx759Xpw2mxtsBUJpOTj3uv9X64I3WjxtztMD6I",
-	"UN/lDkwpfQshrtBCJqLoR2E4GAYoK5wZjqe5l9XqpiM65/0fGay4kwd2HiUNoIZm/UYY208dFfM5iAt1",
-	"MaCCr4SsNMChXt7WLbvlCD/KO5pu3qmphs0xX2lVFn0rk6u0cWQ7/R6PYC43c7Wkj93PLIt//loqXXap",
-	"DOHVPFElQbXDENc7ubMDSSNXqVi2qSSw7RS1I5lAlnXSThi2/xj1Q86VP0or0+OSZ6be/wulMuAoDQXl",
-	"t5vuoZiXxZyXdj3nxrhxOoWSTgxZy5O167tT58pFDvOgQG2N3LuJjVWar2Cuqc+t96XOGidIqcVovA+4",
-	"L71W6s0h25i1FmQKsP8uq3r0X3bttqAL9xF+ouQSnOpT4yrQmVQSzRhKrTKY54Ba8z+Uyt18gedmSGce",
-	"75QyQaZzPHn3PsQzNWA5cmQpUtDxDDzokT1AlTZT6mIYcmO5tgfC5p7/wyGsU4EUtofxXwojFiITdhPD",
-	"HTbVeFSUi0wkaMsRl9z2aPX9tBYoY1sczrloEjI9GR+wVVRBgto+fKAtL+NgXcfRyzW3L1VeZOA6f7lW",
-	"IjlQQVwKKcx6roGbXgUnhetu5TavVdLBrdeAMuixWxYWHKfudNyCbff8vyklsotXxI3uT8frF2IaF4p3",
-	"U/2WHvpHhtXdduiA+6p63Vh/cOtBwbU1f2amYQlw8ysLYzXwfCYD93kUGQPYC5GBVpKlCgzeV/hJug6d",
-	"gOHNBb1L0bYjmI1xuuh426AwHjktG4/8S8jcfDsZGxo6EifD0GnQvlqhJWBKkoHknDkImKfeeOE6ujzg",
-	"2Gqs4nulspc8y3aq2IiN3VQRSS77U0WY4i3nUO3/7fPXCZbZNq5/dI+ZSEFaJ61pVjjpJ2VWNQiLBbrq",
-	"xD212e78b2uQDKeJnYUbVCYMQwPYEV4cTOjz84pOZ3JRLpegDZpsJm5RWQqZ5QY3NC9XTtaClHHc1IaV",
-	"0ooMh3BtZ1IYZqwuE1tqnmUblhCCwNF5l2RItFNx+OYk3nqErLUqV+texLBSJmsuV5BOQ5fb/G/0YuUm",
-	"nEKScY1YVpmp92ehwYC+BNzUBuouGZfpTHI0MBkmpLHcCc4VAjxQxDAWsFTa8Qd9xbUT0GcyQEsIuOXm",
-	"2LkxiMTGNRHvs0lqPe8A3olLddtN4o/yLhkVb7D6rM39ClvWLZXQnDtl933Oi+GzCW0I/t24wkiAZzfm",
-	"D7fWhkP0MGzHgkPHRVLV6X4XgfvNC9n4refW0ob0qszDNcO2pDEBmajUbUXfjhFg0wME2C6pYxwN3DXp",
-	"Pe/p9kdvfQk37voqQnemyrRXd0zQztBrujNW5G6LzRNldl6E/6gkbEi+B32YwsWv3F5YJWgq+Uepqxvu",
-	"pWO8w1qXhlXfUOGStteuFt73qvuWr8weN4ftFR28xvIecZC+SCorT4thEmMbMjpr4OlPMtv02k/h2oKW",
-	"HG+rdKfc9tYvxMQUkIilSJhrGgsXj2G6mjLUufAo/9b9NcZmjurpmbDflQt6yF6/wmdnGU8unuwDJcG1",
-	"s1mnku71ziFlPReJVkYtbf36wx5QmUQVHerQ6KcXpV0zesv8Faw7zL1AEJ/VHbTWOWh1mG2bcp20cAkN",
-	"G5yGS3VBFridkyiL9M5EFNHOjrYDhN5lE+elXe88mMLnDuve5lQ7inabhmrvjnv1EurXeoN7YlO66WML",
-	"tTE7Iug9rPoVKaTC8EVGlll06upU1zw32wu5713jgy+bWj67jY+rc8mfjAM3J80l3jbFgl2rhlePcoTz",
-	"jFx35hewQXNr5c8yD+cZPb2CxVqpizk5+PiHgydJMGn20FfNF/Zd6bbITRMaRMV93qfUO/BBL1SaxBRf",
-	"OZBrmTvc/UmLVg40OeD5Xrm2eY+sYEyMuDk5XtHFRaJzpPyictua51zyFZo1nPCPJx65dQ0s9Es8Xyuo",
-	"+y8tbsOlPgMTGmImn4AZDO5+xGEnwdMiaEB5g27juj0wPjlCt9zniNk40QJvnDQsNZh17d/eZD9brGeY",
-	"Gi95mdk5ur13AXOPaxGN1L8i35R4TXiG+7V3UQYd3+5/RYy/vAz843D/k/aaXgptS57NE67TeUFW0EWZ",
-	"rnC1loLb1mGSidXaSgfCFc+y6jhZ2KT5wFilIZ0veMabfj0PsKL9i0gOEf2MbS/LQMOV+2ZMXqS9F4I8",
-	"yxY8uZj7i86W5OyvfJjfGOznd2+m7P0amF9QVmRcArsSWUZe5yQ1MJJizUyizUwY9yHjZEYX3syu1UqD",
-	"MWiH81a/NbBMLCHZJBnM5GMS0xhc8qx0QvGYBecOVvnEhGeQHtGl+JhVrisziXd7jWeVmTJ94mYiDOOX",
-	"SqQEmgRIyfrpcEbgFyojq+e3p+RU7x0ijz6K9IaBTAslpCWb3/A1sffwu7b7+cW89I1R34K8UOR26zja",
-	"3RlOu8eITLbkQj5gpkCypWCgXrLdfTU8fFL035iU2QH2SQ9lmXVaJffzPaI+buvr1cKrZ+80ix7s+lP2",
-	"XqXL6Oz2kvMDy5kdA3YZT3yj346a+AULFE10ju8kYLyCRJhuQ2TTiXCndyB5rkd39bu/EAbjQPYgwwDm",
-	"q+iT2zsy5twma3AyRiYScTCb+dF93rWt/CKZOY/chLcvy5oREEPjvRPm4g02bNNAjLtGj0OL/KqJ8Ir0",
-	"s0xdkUecuppHXmd+wHo6uMqb6E2uNMw7PKZrXL8C2X96DDmU9Tp9tC+T+x0wXqEe22tp11YseWJ7/cPo",
-	"6nBO2m6vkJWVxvYoeru4GoYn9A6fc5RGnMw6vxIyVVd9MLitjgxgb+v+RbkALcHihdcl6ASvHSXYTCxR",
-	"YOiw/i+zjVA7zDXKS5ymLAqlmzeB0Q4IwU7dpjbNLawaXlSuXzI3LLIS5isNyJMTLrkmciwyvjPya5s+",
-	"4qDGLQH5JddagPFXxBP3dW2XXwrIUjNlp9c8sdmGKQn0jOWlsWwBrFBFmaFkO5OJ0nR17xSmcNdcaFiK",
-	"a6aWLJbqp26ck5lkbMJWwk5/x/75f/+f+4se+ahDeko/6AVFH9Jz/JseU7whPca/fesQeOg/8D/pZYg+",
-	"pHf+l38VxSH61/WTmXTaA96/a6bBYdkEYd6wqzVooIkHzDCKPfWIC741M4n8me7jETPM4cTji4TxnF/H",
-	"h/9TjI5vPWmxmmC+2tcTswp1JavYrs+iO72bYEHbfapF/OlmXHvyDQazuEb1NyuxU+X4Vti6vV/O3XIf",
-	"Nou+q9d557d10/B91+6LJ9LlQus9gg9wVW94EXecz4sk2buzd1WgaVdHKt3M1zbvdlvAt0EX3D4w7gmG",
-	"pVb5QR0YkOl8yzvePZR4/GNQ8lzJbNPtSlv2e2PYtQae9p5kVt3HlDtpSFrQhRadUTBOnIGUPNLDIWi6",
-	"nOUcpIllRqzkREjPnw1UnkmOz+eF3bAcuDSMZxnznU8HLxjbSxYgolBmYn4HAUT3vv7DewJqIfBsnR/g",
-	"RrzHZXjPtXIcgQ/SzvkiefrseSe99dvWQZs+X+UmIt/rkm7EKQZkghfi4XPmNTnj79TxJj2g/Emnl1uR",
-	"8YbgvNTgg/Mxjr0ixc7tk5Wr7aX++d2byVILkGm2YaUUv5YQ3fZ3egoaNa/F332iNva4dd7DsSXcHLpp",
-	"eEy0aadBGI1xu4RzyoCxfbXQ/TjxfKtD7bRctFxWb2GFjtw8a1/kvojFPe9jU4gcxj/sckdrXx5HmIrD",
-	"V7cwk/FFj/tc28SBR9J4lAl5gffWy+U8JIUYj0zihGqzVsFqriEBUYRf1k2bAqtHLc0IPa0iVWqHISQr",
-	"9/Dg8jYMat2Jk6D5d5HKLp+EOAFVVwNy7b9jiOlwZKwqbVHag4k1XpR9LB3eRn4Qp+7ydUigoOAzXUpJ",
-	"mlidWmA88tkIhiPS2vTeTAPWGR0bgT9IBC/9TUf/haXbXPOhrX0/C7IHMu8PgwNeHBVmMGPaNj4wYhzS",
-	"+f4hIltDJLzgdbzT/tElr0rtSBZPWkjJZ4vVnTHMs5MyJ96SCuivgHxLdPjoTD6we9+bRKsrsvptGmdn",
-	"CJBrQvqdumK1rdUwroGRb0Pq42KE9zmbzuSEuT5OmFTs/ekpexx/mEKiN24DMSHZWhm8IEvAmCfuOwOY",
-	"feukMZYBaZ3c5/oqQE/qO67HGniGm5c5WR27oJlB2uwjPGVCGpEC9oUXYGYjE5S40zKDlJUGUKluRQt6",
-	"uEYBcT1hpntkEdj6JrbWHsg4BzyxEiVNmTe88mpPvZ27Kcoe2MmLonkO7rh3pexlQ4PzVpegtUjh9puy",
-	"b0a74e3NJOA5/0Gru/N83euEOfQAGeCGDf+JAx0nlvTtfNht+RO5V3QruAm3sFJawIEej+H7HLQT6OyB",
-	"n+f8ek6K1dxqLs1+HgzeJb0zodMeTpZDzpVfnB/JNm3d3m+zQeP3eaXc3DwPeplcGyq3BRZuYL7QXCbd",
-	"N6gDr5I1JBemoTTvT+SJynNh52bND9wdS5GBmfvos8M+RQlozg1KSIduavp4odJudkavUWe8Vcf98e+3",
-	"6bPQ/ZAWemCwzugDYdflgrI1ZnyB5gm7KEOOwCEn4yodYbfSfyngqp25abeX8RZ5fwc8s+v+fTl8K9bm",
-	"jRhNkcJKc9IgUnUlu9mjyMFYnhf7n+CXoI3Y5/K11tSq9IXh23jgLobVdITa5WIaGw59ZLT3TzbWcZUV",
-	"2eHSsi9YazwSxZynqQbTEw0izMV8LQ4+Bj3zLjJuHXLbwKoCZJLxK3Sv5mUKc28Ycv9djzA0S665TA0F",
-	"zvhUokKGrHFClu7PjMvVSvNivSPhBUHjZfdeAczHWGneL9JYyAulud7MB6VWjEfBsNvGJXecLaJn6U8l",
-	"Bbjfqy/kHh9RYs87eOzdxvydRn42+zi6oBx9v3nu9tesDsnrdbh1+WB3xi5trO3G6LOpesqJ8H2YUZpm",
-	"d5/iU4vWH1R+aqzNdpqpYPkYVw8ix56uBFRew9rHWDWkaI9H319ddKkvq255TV92m296kgz3JB+23ae5",
-	"7ONinc+vO59udhOtG56A6yKz768uOvS5C9jsT1cOpbtim7DDrvHfCNlzm7DLn/fXkkvrbX5DedDGI3NR",
-	"dqNaCjvneQiz3U9XbLi+RSBGADV77pp1SPJ6u7wi/Jp8Qc1gtqEDvBXaqXOHUo4MJAzp8K6i5DLbeXHw",
-	"OSu0ygv7Z2Z2J9mtYJxJTJnzxOe5+ZdJ9xGhgNUYGB+4wrfL/TGOaW6Ynm+VAqROn3Q/F6cHp/doJ0Ua",
-	"yqqM1pdiKBMYvjdua8tkP5fv7avZ+88v4u03rSzQQ0lGflSpWG7ihJgHu86SCy9l2LujDbnZVTe8ErpS",
-	"ylccvrWh8TkTkmEWdkZZ2KPqNsddh0lsos359RuQK7senTzH76JfO/Lx5t51v+qua0JvG/JYc1YSru08",
-	"KqSz+w72pnOEULHjjGcDkuaam3ld3aMzO5RdAyVoQ9+WNTfMgGWcods/iz7u8gwxPOtYoa+5gT98VaVl",
-	"eaFXSj4TKXOt2WOVC2shZVdrkEyqaAgmcPAncazUYmN3+5e0pvlhEGN/BV0R5OfD3AVczC8jSLZHOJXh",
-	"zi9u507WBV7CJZnAzF0ihXA/iLd7nwu/sbvnwGbeK9vMAiQsRSJ8rYk9/Ey/jr64Cdb6ea/TT0jMN7eg",
-	"8ztc22RCwvwwfa4SnTtdh+giJdzI9IXi+lY6jpjqyN6ImJk74UVjHqN50fii67oDVeC104/x4oJ8+p2u",
-	"PC+0uiYh2fuw96hqGhxzdKjD4H0fxNK6Gs6VtOtsQ+K3tqDxby5lybOeXiVc9cXDUF2YvjXyb/szP/UR",
-	"89dNKmzrOQXXtvcEvXtO1U7AKs+Dg5ML3SIn7y0DL+vybr/NsMzbGJy27dmRbHGYNSqufudv5Vq2qMpG",
-	"VVvC+8NAaXYvlUxFN+vF2IienL2guU/lE/Yn/Ipb/ld0YnB/KsdARuPRyuI/aElGJ0Ab5FH0QQ4xcWbY",
-	"aU9J+Gk5OvllG5rqiSzzBeK1A9Udm78mpC0C+TCwh+7TQud35YNa5uLAwe2rjusi43IgPdvgjvRvB0nc",
-	"0V8vdfcAi7u2PypUNzP171NCIE7uT4c4Ef2hS1Xvlo4128kXl0sfxdAOf2yFNsa2UQyMvBJ2PY/1oc69",
-	"0lCY5hbyIuMWDlauCy2U9na2yk3t6XGncjS4uo1QSd+wwkI/RzoTeZnxVhbe+7ilue2ly52i8QeyHGxP",
-	"t4+rHH6Fs2W49C8G4Niy3YdSgZUrDNfJWlz2SG/boVc9svw8JJLcW6hPlLHzBKMcOjfW7oqQGayQcVwK",
-	"uGq4Y2yLhPcsmAe//bYFyKilvaJ0llbzS7S/ObjC3XLQM7Bqob/idoelcspjj6CLI6meNHJOuBZ2sx8S",
-	"Dpd86+ipB6gSsHfe/zpqPUI18dgcUlHmo/FoLVZ4k62FFUmP0nAGttb7e9nQblU8NhmwREm0MTKoFHSs",
-	"q4q5r0knT0G7DcZ+OP2BPV6gNWQPpXtPc8rTP0zc9y2zygqkE+YgZYtNBMrBqj6C0GGe6Fqm9wAvrAUn",
-	"rg6y+TIVILsM/afXBSZNZaFJVS2A1/2ykEBjD/JtQ9THiaXqhOcdl6nKGb5lpQnpfiJYMKWHBGP2WU4q",
-	"2BFy8mxZdzJ+CY8Mg2INOWiesdOXr75j9BG7gM1BpFNZE1vG0gj24A3AHv/0+tVL9v3f3uP0Xiq5FN7l",
-	"m525I2/MZqMULifqYjbCJplKePZkJ+0QVgMsjfn3kM8ZeZn026iRiOdDiHyJTQbx6KYAhG/8Ddd0ybMP",
-	"XqtNPr+Ai+3R3Q7v4AMOgooLmDXePFGWF/ZYFfzXEphVPtD9cHNcE6ZxB5Z2obtvXwQ//bpUVXO6f0Hd",
-	"DC/64rCG0qpJFCtAUQejcWdl0djXv6tUASYAQDCZbxzjZzjuqOGz1Lq69H0OxUa2WWHdXR8+K2Fru3yT",
-	"33XzJOMiN31niuN90RalxnXoCgaCeN8oDNYgqy59AumT0XhbE9yN3y3mejCm11c9tSy+4zp18hALggrD",
-	"hj5Cdjb69uXb+YsfX83PTv86Gz3pDPPFlCapWHmGsFUL33IhQTNsx6hd1b1Z82e//8MJXyTT6bRvAAwP",
-	"OhRDV9z4wKK9kYTN9fYo77FDeltBvra2MCdHRyGmeEopsKeJynvmUWjlSLGT2r99+Zb59+z1K2bX3DJ1",
-	"JSmPXWCFTsXJFE/3O1oDzQ1fhYS+19ywBUSk2nkJApJ88nu75BS+FC78BVbUWYpVqft69BLFnPa53QwI",
-	"HQHW0JQVQsYDBEnK5yPhMqXshKmXCxZaXRnQR8R+G7c0W/tymKorkJK7k/cQWVTjPAB9xA7VLXr3aVgu",
-	"obGa2/FiKGaQ0lRJJBNKS/RhgN17xbafiGQYvj5YBCaUCce1n3H3FacfZS/OStfC9pYn2NYxH9KCVyjr",
-	"PIc074pJwro++yu/2MvpZU+qkGG/z0Ev4MPMLlVXzRg6P5ne6RPgXQYmpQ9x6MVxeqM/8WVvWYmCb3C3",
-	"HOwFc6h3/Va56Saa5t5jJFgdhp3oEX33aQwncnxQW/jPMlPJxV95mdkhpX6nJv38GWnSTogPwjqKXtGV",
-	"+aXglaZ9sKDugOhC+s94A/VAucofIJLwVmF1N70Tr3Pu9M/8/lPvkKvebzIBz72Ados0PP0r3soRs09M",
-	"Bq3tHbP9/maz+fbP+GcD/Tt4R53wzl5NlxD1gryMvHpAabZF6iRiLpk3KZhSa7Xilqwcj0uj5+x/sZ9/",
-	"fv3qiaM0R3jCzCTKtFj3n2VqJRKe1SJw6QsPppCWReakWSe7aWUMo0I59baabUu5u3ZrVSUpkrlD6zoh",
-	"gq9ouddCO2Q5uELdozdCXnTu20tuuZ7vVbD5lvE5uyrCV/uylcCJcjYRX/jnf/4Xi5anwlL3EsTnUe8e",
-	"r7NK9ck1wbvrSul0T0c3zsIH6POGBjYHwFH12FFWd6XHLsXkpy4CdsgQeV4iLsZMgtPCyHJH6RTqGDlH",
-	"6gOZwDJu7BwhulNCnra7sbqSVHs1zXGuOaDnwofxQUdoCKVp6Y9CXgrSm02Jofw9F3b3k5yrSSV1zZYG",
-	"VVdeyJWDSmvDt2jpsMipzq3cl5vpwM3Zr5w2dhTDCmiPyfQyZhQPPGbqwvIxMzzPxgxsMt1tCY903AbA",
-	"XfNGOZaOmQHD7CHap5NnWxpoyy3Uyc9kPtzT3vfA3rAEz3C/1JEwYZrZxk+DPZYqaPjR1Lsy8LWWyQ87",
-	"3u3gGl29Yl1rn1MAuIaqzhX9+iYg9Pu/vcesaK61gwHf1jCtrS1GNzeoXC/V9tQvj6fPGFxbjD9x8184",
-	"dcTn8phQZY2qHAaZMrRI1qDHXrqsUw37w9KxaZ8X+Fth0Z5VlFlVLSOEtlALyiyLjTB9bfMtCRP40me7",
-	"bb73DpQ0Ru1RUDeayZdKRxNAuHztj8msPD5+DswX+AhOD9XzqszH41B0/kn1rs5yRMmetp+HJ2hpQBkm",
-	"pLA78S4UdSGRqDLIGOfCy1RY9uLtaxJXVuoStISUKoKE2Y2qIv8UfCQS9tIXRHmLy/bi7evIue9kdDx9",
-	"Nj32DnmSF2J0Mno+fTo9docDt2sktSPHao/oVEVXt+qBwqRj1RNfdiB+5JSQsoif4FmzmQSRpHr+MTCu",
-	"m6NQ+6XndQzJ5dMjLnm2sSIxRxU2P45WgNyqKh36Oh2djL4F+yI0PquSB8YZi375OHJdj34tAd+RRNX2",
-	"yKn3MZ3WROSdMnZ3f5j+dqif/c7S7s6tunvXWBCSDgQkgWfHx62wK16QjC6UPPq7D2uqBxmOLGstAXKi",
-	"1tEY2rCwpjfj0VfHT/v6roA9+lk6clFa/ANS+uj57o++UXoh0hSITdeb8lt3jGyBEsq4/lKDOUJ/T6RG",
-	"v39NLxW+Eca+qFpt0V8XpHWTo7d8BWfiH4Dup3u0xRufUR+t3Ddhh7wvo6FvH5S4PGIbZsUuAguM/NcS",
-	"Svg81OVg3CocZWLyqqhkm7yOPkY1Tm4GWV7tC3oYqYUPX6ejT7Jmg+sUUuV+qpVyX3y1+4u/KPuNKmXa",
-	"yTi2FvdWa+ufk2Tu62Y3F5n6qiyad15n7OZrn9voHpe4gvDmhsThByYo8iLdiw1oSJROA6kc7174r3la",
-	"zeaLIEm/BOFKkpIcHU6M6GjeS4lxwZzfIBnG4N00NTJ34P02aPIV1qL6F6BItxp3JUeMWBggSApI/w2T",
-	"ZHfE/G+WOH+MIkT+hZgm2jia6QQGyTVZc3vkC3qGIKFAoK0TiLKBPDIM85AWHM1oacmzSaGVVYnK2Js3",
-	"P7IVt3DFN1P2SqtiIhzysWwU1S5aKs3OKz+uQkxRnRfTROVd4Jyf4L5Dy4FdczuTThGANM5BsuJCGst+",
-	"KkC+eP3IVAVF0TfHRC3RqiesmUk0E/387g0ThmFbdDGkmxXyZJrO5Ex+DWt+KZQeM7dR0RFxsWEvXr2b",
-	"HB8f/5E99rYYDOoTcvXkxH00Yb/73XulMsbLlZszrsL0d7+r0qlo4N5aVRrQjzoSp8wkozv28/9zNOX0",
-	"2ZF/d3Q+9vfwhnG2LCXVbkphKaQg92ulGfBk7Xp57NQd90G1klHKb/zykWE/cn2RqivJFirdjFnFVlwH",
-	"tPHooyo/jJBFac0Tb+7x6V/sGvKQ8cXzn0c4k3NMJ3PelwamyllD93W41o9MNZjrATvAxOAhFU1MAP/8",
-	"z/9q4Brv+/BO/5KSd0+jRUHjdaKyDM1lxq0Lmoa53FqGRyZqnQLOBbdXoMhmwpwxIdWD756wKyHNn8O6",
-	"u881YBE5R4Sh6FblX1XN7Nyv+PQ8FC8TaLpGqiC0QRpQPGUvOqFhV2tlgCbAM0dyeG+Jk3CjdQxiPHh4",
-	"t3mOfU7RDpgoLVZC8mziXpNp8Jxy/zDG2RXX0q2jMCxTqxWkHt9vNUwcQ1hsCm4MGiInQj6pUO7AyJWx",
-	"jju7bYQ2cZ8txvUMvuibj5mlombcWtDSMLWs3isJW2tH00fq+wW/nxIUH84dmN5pbFxtSbJg+jF8D6nQ",
-	"4PrHSUqHcFu6kTkzG2nXYByjZ4ExU96ilGXiAhhnUumcZyxBlsVYzdGIyKvERw4/woRrO5zBlH1NCHO8",
-	"CB0k0O7ri+tQ0bZw4I7ZssyyiUcaa780IoUJBSFiviVWZWbitAXp7KHdjUhx6+jXiwdb7QR95s2aWZFD",
-	"tJcmDl60R+sEisDlqqVtzBFyJHkkTUSI+zQi0bDGXIY1mfgtXS3pON5InQvmeFYupDAY7JRt2OMCdGDX",
-	"z5+MKSpJl4k1RLnImc4DzQXHUiweSBuyzOzY+7RSnT1h2YInF+i/H7ZSIIEpQw7jhjZ1CexWVi285AlZ",
-	"u1wPNR+rwno8C8ESBolKMQzCT9ij/wwx6wD1DLE6ZL5Wds1M9frxOf19wpxkdv4k7Fqp5KRulasUiCaq",
-	"ipJT9lqyZosxrXUOqeAWAl8mKkghs3R50rt+NMCiXC5BI/+2VCYRL+WQkpDey8SWGlcvlBn/szuRMPBm",
-	"qZF7un5wxyAl+Cu7kGsM2RZ7sbSgh7b3OHBUT6RusV3fxOD9FrcioTkSKdD4bKnI84gtNgH+mNYfoXu0",
-	"FbKkRXEywYvSrvGSAx+dkKBRySmeqZvm0cnOX3h5Ej86n8k18BT0HqneqjOnqvYYmMJMun2IZz1etZHj",
-	"fospxa7kBjJyRllsmHZrlsNMBvfvMMHRuKXMvFXGvlxz+zISLB9GK2mO8pm0kjYQlVYyxmpQR+hyOqmT",
-	"Cda9tuNvnOg5wUAW/CZQp1qy8+YgxAFerkt5cT6T35/99BdG17DuoJXAHOc7T7nlJ+dEtk/GjNijj3+c",
-	"SXrNfnn1019OP5zTMrYt4FtqlYMiOs4i5veSMDl5vykAXajOt+Z+TiJ4ROZ4/93kUeOZxMDfK2GcmNJa",
-	"lHOfG/FTaXG/p4/uhUyoFlsHUk8DJ0AZbCWMRRa5KC3u3Q1YPOc3TDi8E1edsncokDgJOS0xx6SxWDRH",
-	"O/5UWkc0DtNBHyO8/f742cPP5+ctTgK+ae0hMDr55UOswJL6NnHDcCsWGaDwFJFazTAjjfZbmlykz5In",
-	"SXQLG904tP1PScSrdbG6ZjB9+yh4kznBAbcjlm+jQ8IHqsceBKoAM91iht6h70VV0r5l2tmqVejA0B44",
-	"9zfHw4zOroTy+uEZQy4zU/ajr4XMmeE5TIywwPjCqKy0pOU6WYRpyDiqRAW36yl7RekuMEnnkQHrJERz",
-	"VPU6qWKsKMnN1gUaicNzvMPd/wbtOZFf90I4UCqKaaL8tlv+2R42GPQtekNeLkMU+trp19yCp4llpq4c",
-	"xB5lTnSFa6ec1EUvI0KtvTo9HZjRh5sdpHAauvOkViOnHjasjlvUenEi16r+m9KqooN3YyOPrnlVwhmr",
-	"tWUKKyDkItHKqKWNX5uMJxdUCWJdLuZY4KHLx/1D796MHSi6rwWbmydUoNvPGcKXALjzXbGx3ML9knm1",
-	"z+r6qIVTQZRkmALcmEFS/I7LNAuEGHBIOofnEH6Aprl6PyL80ugpYlaDrgzV7KvJ31EkvEsEUBuYfWqb",
-	"bB+0eDFPGaVb5HRLgWf72j/2mfT2ynq0NsMzu4itd+WOPnrngBScztd1Yeeeb6Ftawm/6rBc+z2RClMN",
-	"fAez/h3ukSoAbnda9DlO7MbKPeo6W4TboSS0yfEenCLu6OKwvUXugy8e6IvUYlxK78WwlP5ina8+PDwh",
-	"Kr3LgypC4+fznkritWzRnXuI9NZ5MfwSwwOqpg9lR2mOcpAh5en9r+ngOjIfMfFbvs1tUMA7r9PXbIiC",
-	"jrvIYItFHH2MS+4OOtDFRHIYv6i+fGgXuj1X+At0otu9tOipTqlJm0vXCnW+h9W7fwbRE479qS2t+5GP",
-	"j6L67+vuQatxCD+pU1ENyxxRu38LHV3HpEfPTqkjQuRnFDsqKFiV1b4hgURQ7hRBqrYPK4NUw3wuISQC",
-	"IBQCGFzgL1oe6SCQXvrwvKSOgzVHFMfdY18nhwlKHhQ+qa+56ztRqo6vt03nTqYh20OdDuMhldtolK4V",
-	"92YQiFrd3crihIdku+d6DWqgWkJE+9LFHQmmB7foFxf6mTKfJByvgkHjBUGaC8m0ymB7GfzZ37kSDyVp",
-	"bOc/+cSixjAt1G+/BGGjS3Y4gObCvg9xnhOMGzVHH0PN2kGt5DR89q1rfbBUgV89tFrSgrFrwZtBs19W",
-	"eE8r4jde6PCma53NkS5lv8v6u1JWnz8QL6j6f1ce5tzx7IFA6Bf4agLhSQLFf2v1g+YKdeRY5eW1P2l9",
-	"rP7em4EczDuqLz8Z/ximjC/PrFFzjiqfya3Wt3HT281Oqv76b3kPXu4H5EgBys8lngxRXIDtXyDw5a0y",
-	"MZUmNe0M0akvXDehwnXDJpFvqO2Zb/pvq8gWLTYwtMsw4huzgPrPZxxZtiCpSSbAGNZ8l2mkgYAHtY40",
-	"RvpMBpLmbHcu8RdnHiFMU3RVNI9B+vB8ZQ08o0RHfcLMd9TiAXcjjTC0Bc+8P5mHdsjTyMkAptm8RoOf",
-	"SzV7iocb5qavfZvfFBu9lUsYCkP7LQlNuk6T2ZOTBCXokJr48JQmqyrH8ec5BmiWu/i/T1wMPlG8/Zwn",
-	"gKiIMZB0IM9dHP91KDF+GKuv8zF+HK2EfVtmce3xDhYUJx8bRTUi67JwlMjMd4gp1riB+UJzmaxHJyN8",
-	"OR5Vv5fi+ihZQ3KhSjux/HqiFTEzTMOX58LOzZojLihZ5FejD+PRUmRg5j68BOt+6OTI8uspIQ+MNfQT",
-	"jJ1SEvKMLyDDfhblaimuXf9+XPe60PMF4mz0fi0Me/uOLcU1GBbaMMuvWYCNAk3TFN3jtc/ah6NOMb/q",
-	"POQS+0ZcNz90ImEYNU5x6J0McQELZYTFOsIjnuRQoQcpplVwbXS2FkUN5KJcMZpb05Md56NVzpbAbamB",
-	"Ef6ZVcwviOU6WM0bSVE9YBgQ3YSGsoIivPPo4YWQ4bGfRu05uBJ26ihoHqJF6SjGZK+BWzjGQUWgr9Hl",
-	"cs6zYs1HjRqCjTK3DotpGbR9X/q5yLhdKp17t9trSmIKeaEsyGRDZYlGz56nf1g+54vJf8DyT5Ovnj+H",
-	"ySJ9BpPj5A98+dVi8fT4+Gm71OvJ6MrMQa6EBKjySPqyzW9Lnax9ssVIJfBP2RnnZ8yUi5r97NhBvttm",
-	"Me7w19M/Hh8fx0XyRz+fveooxO0Txo3+ziX8b4xnkBu3nFsltx1jFCs5ierjdRTUHi3N3ALP51GzuHDf",
-	"ltv4N2KVc/ZWK/aCSkVj/Whf6OPpeFRKYed7T8+dGB0Vt+OifjtqaLdLZzcK7hG0nTvtHUi4otycKIQB",
-	"pyS6W3gdd609lclmhIxMJCC9gbtn2xEcfo95EJf+md9i9DTaXn7i02Tteu3YVVFax7kqzB02lSqw/sZV",
-	"977645/+9If/SH6/mBw//+p48tV//PHphPPjZPLHJIVnsPzq6fHxs859tRTSwYXH9CFqCB1/n0n/oMFP",
-	"5SVkquiUMajFl6B4uC/+tPuLl0ouMxGSrFbUflYucmEZZ26n+DBoESSTbZGmKaYffayqhwyaXytR5zCB",
-	"nT57aMPr3rTwRaZlu9VaHoUahoN52ECmHneh9R0X+EFysYFMA3yfyc66m8ACgD4Tyn/rLEPW8mRdF8m0",
-	"aj8q9RkWPn12IS7tWqtCJCHBUICknViIUV6hmdxOLPQi9PEguYWq1BfnnfmP2GPbziU0nsk6gc2YFY00",
-	"K+MoKUOcmmNcJ3OYyThpxBPMn2MACA1hgpiBp1qgKXsllsF9jHENrg9SpaL41zUvwGDGHZ8I6X2Vtyds",
-	"jRBhW+F0gl81cwRh4qLzj2wrd9GYMg/NfVKim/MnYwyQdj36+GHsDjPl+MxIkyvtBsf0Gvk0QOWzdHCt",
-	"BWYaTBHKkEuCGwJoXho4Z56NsEWmkgvMHKIk48YIqnAcKOrPlHeHUkXQrClrCHZYJUKaU4N2t67POAGO",
-	"W1jQMe1RHhl5CdpUNZaxbDZOqs4IUhowTZrFTAJOZDXs8bnvf24s1/Z8jHB5UOYISnjTfowpPs59cv8/",
-	"+0QePq1Md96PCId+kmuVpYZSf1C6dvcYs5r35P64Q/aM6wkvxOQCNucz6Rb4vOIFE59V/JxRRg2zR0qN",
-	"viwXPwbO9kBJ93z3n+nwq4d/iJQWFZGyMI5/OZNUy26bXHtodSZ7iHWruSqwdei2alePo4rzJ3smw6jA",
-	"7s2CwfqSYFCFoYEsGOzfSTD+9ZJg1MdilAcjnAh75b/AehBix43229Do33fZPRXNdl5iBAx+vruLol7E",
-	"QA0VVLtuL2iSD3pR3axx94ktRH5+fQu3+XKvpIuwch1r3mIBR0bkZcbtgB3gzLd4UHrwNQJpqM+XpGsb",
-	"jIEL8qqVl+e/GEIJKxoKA8Elz0re8swcoJmP9N0um2BFMAeeH/jZQ9sEd+3+LyqqdGjD7wgovZ9FeqgA",
-	"j1scEJ+ORP6FIkj3OFEswBG3FoytSlN3nychRdaLqPHD0NB7iAf5TFTUBmKgfEfdrLaeVpm4Q2n9O+pn",
-	"zSHfn56i4hQq5DeXv0pmpiFXjg4aKxZI4f3paZMK/n51YXoD/t5qdS18BNq3mPzJqcNLEQIMz5ysz77/",
-	"2w9ntfXGKLI7LrS6MqBnMskEqv4Jl4wqsMWwse//9h7rRaNXBaVrdWrey5/enTFhTAlmOpM/wIYMcAlP",
-	"1pB6s+vEiJTCD5+ytSp1l0nnW7DvAb53s3xAusH+O6gE03j+DRbsB9iwM7CRrtq64uciI2PqEmyyJpwi",
-	"OQUT1k6nPvpE6QZ2MRssaxVZ7SUGX0NywKiPgTBEELSujwyDYg05aJ6x05evvmOYXDrBWrZohpVuN+hN",
-	"YSFlP5z+MJOLTC0oQS0tY23wWyi7DqY7v4UYj2s9F9yYSZVrGUvlWkdYbltQDn0qJLzG/MwGEg2WYfYJ",
-	"hABf/nD6A43uR5jJAvRS6ZymhXNwwMM1WQrH4WsTPqcM0sYqjZnfmZAzueY6veIaJsKoDJ3hcsiV3kzZ",
-	"i9KqicOiujKhYGcUvB9liOui31MsiizM+j3AmV+eB2PAfoDPx3wrAIZcXX2J14AYSHE5fjj9gW6ayOQf",
-	"nfPN73+IltaRRvQddbzkIiv1J+Xd1SIz1y4UsXWzCjNyYA7u3KrScp+A77AbfFwfdAmDT+zWyrm5NRJN",
-	"0zbys/UzuH389QBrRKy2o52aONR8V9TIe2rybwvb9qo7zOwysHn0fT7zmg3rVxEAPahooDRuDfbMf9AZ",
-	"kF9otRRd8fZ12oOfjU+6+UBrgf0PpDoo8f39JjkoaU4Brw6EuyU26MVjI29BhcqHUmjdAJ/pLOxbRvf8",
-	"06uyQ9kGeha/taewkvKkqpnfyuZdpwhtb7hcXVIREcqMS5qH3dRXMJmQF7Xe1cpr6hNDTmfypZcR63yd",
-	"rnnGjUUKZDnYtaLKQ1Xu8Lw0lq1RBqUE9lgnweeVrADAVNyh+D8zYLukuDpPaFzrf1fm8LeNAv1WxeA/",
-	"hulqypo1+5/cIXf07vPiq079kADcTsT6qSws95W7FakgwtQueo7q5vdqS2ekIdTKUtgAKTM8s5XYGqtn",
-	"rNaO6JuZDMXBvPbBMkXFcEoj5Iq90Csln4l0HNQswzi7kOqqqfYh7aJ/i9desMSXktmGNKYAT62rOUCq",
-	"DVFPl3wvHBxU4ygD7rUur/FP2U8SffTd2kpLjjlUSwuuhbEO6AvYzGTOLWjBsU6MVhYPgMdYMkkb2nwa",
-	"Jh4edsnLzHqNzjADbuNYyDZPurbbGdi39fo8zBHRGONzGT0rAM54tiNGK7RE1wSvcOL1+2c6Rs5IM6eF",
-	"98tbxIu2/w48ylQzDUFL9MmA60Z9Pm9FckSMR4e3QwSNfSvb8UxW9GXYlcAALicKsq+ePY+cn2gSwrBS",
-	"Zlh9gDwOuyj0jUousEzBQ8qCOADpY0O0gc1Y5usl3EOWcZVceFw4VpE49EcoP2xpHWPaSyAPfJBYWchJ",
-	"1hII6o7HjGeZukJ3N8+c0ZroaAIZLpVCYi8yo5iQKQqohl2twUkCtZCw5gZ3FJ/JuvMeQ2Rzu45+E4zh",
-	"LDD+IuIQd1XFG1pC3DFN+4Dlp53Uv7frc5L1HZOVcBgBUtnviFxmsn2WOqXEn5Hu0+fPJouNpX69fdLz",
-	"DOX++e79+7dn05mMbJp09pJ9MPgd42c06taRT6eyO6c9b6YdU09HSM+fKtoOlpP3799MGZoNyMjuDvWZ",
-	"XEB0ltcmUPRsFhl0M6wuwv0Z39XM6gG0rXqEz3SQHsQpA7K+nPxwCLBfbSx1VG+FCW2bW3DmxqXCfikj",
-	"AwVuUT/SdMyGY3kzbh1LxofseJJa3V73ezuy6QtDMFhFYcAsUVpDYiUYE99TzCRJvAaq2qUVQyFD8k6+",
-	"/9fmRcwn4P/xiIOk3V6S+2L/nQrOHpSG1Lpt1+4mr/hYrpial8GUrnbsuME3MRB1M8MSiMR++093tvNw",
-	"j1jIb0amu9+D/LKSE7eN6dUqNi3xH0dUlfJFadejk18+3Hxwr91m6rF31BGzpc5GJ6M49MdxrlDkmAt0",
-	"ZvHDfwymDhznZlz9jrNeRo8J2ujB6ypxRd1VVVo9ehh5iVbPGtUo6pHrHFXR03aambibRnrp6nFlNq8B",
-	"kzzbWJF0AREXPIk7OT2Nf/osL+5JcwFe9UdnhfqjpgB+4W9qKUKHYQXJqDAo8drtWIBxCHoK9XgbpbUT",
-	"bnmmVlX5bCeTdRdTH0dxUK6nZo1eizWIQ9OZ9JnEaMh8u6ZwXA44ABbVg55JXyq2qhLcKBHMQqXzKvpL",
-	"mLi2/Ez2F5cnRuLXJPh933y4+f8BAAD//+/vZnThKAEA",
+	"H4sIAAAAAAAC/+y93XLbOLYo/CoofV9VkhlJdpKe2TPum+123N3pTqZzYvfMRStFQyQkYUwCbAC0rUn5",
+	"1L46D3BqP+E8ySmsBYAgRVKSf5LOnrlJLBLEz8LCwvpfH0epLEopmDB6dPRxVFJFC2aYgl/HZankFc1f",
+	"Z/YXF6OjUUnNajQeCVqw0dGIugYJz0bjkWK/VlyxbHRkVMXGI52uWEHtp2Zd2ubaKC6Wo9vb8ehECsFS",
+	"I1Vv36lvsX/npzcsrQyXordz5lvs3/l3igrT2/HSvt2/09fCsIFeObzev9t3dMnO+D9Y6PbXiql13W9J",
+	"lyzRtkHcT8YWtMrN6OgPh+NRQW94URWjoxeH9hcX+Ov52A9n57ZkKox3Li+ZGBzQQIstM5c5T9e9ACnh",
+	"9b4AubWNdSmFZoDf39DsPfu1YtrYX6kEKNs/aVnmPKUWQQ7+riUsp+72/1dsMToa/X8H9dk5wLf64FQp",
+	"qXCojOlU8dJ2MjoavRZXNOcZUW5APAOLnKefYHA/ErnmZkXSSikmDFFMy0qljGhDDbMz+laqOc8y3L/H",
+	"hoeuFguecjuTkqmCa82l0HYaf5HmW1mJ7PFn8d6DQEhDFjDm7Xj0s6CVWUnF/8E+wRze2pWLJZGKcIck",
+	"dngmjBvITumv9kS+kenlp5gRDEa4JjkMSP75X/9NKmF/IAK9++nsnBxcPT+oNFP6oGAHJdW6XCmq2QE2",
+	"hEPsBoKrJMW+P7aGOia2jwkX2tA8Zxmh0JAUVPAF02ZK3jFFjl+9nxweHj4nVGT+x8sxoWImXHuuCSUW",
+	"jDkjb6m6zOS1IAueM5zx+U9v35CFksIU1BimviZmxUhJlWbZTEQvSCnLKqeGaWJWXBM5/ztLzRNNtFFV",
+	"airFMrLgLM80zMWs2EyE8dyukIXMc3lt99SOkuYS9vfi97///UXU/8VcZuuL6cySwlLJkinDkS7ZF5ug",
+	"2muYjOW84IapKTlfMbLgSpuZsNf7UtFyRZ5KRSjJmOZLQQ3LiGYAyGcWkrpSC5qyjBgJXb9585ZQjYtd",
+	"VAIhHk2OXK+YgJb1brCbUmq7n3ZjjJQ5LrRFksfuJsYbyrBCb0NaRCS84dmZYaXtxPVKlaJr+7ugJl3t",
+	"1tNbaHrrb5Y20L+hitljQHOyoiLLGVlIFS/1KZsup2Q20iteTqoyo4bNRs+mXUuFK2zzBMy1zCtjsdGs",
+	"iFxA544qAQJbWHN92dmlu/t2hNp739qeTRhhczrfVnm+nvxa0ZwvOMvIz+9f+0kZVpQWdePlX1NN6sO7",
+	"ULKYCQ+SVTU/OjigPGdKioMIQP/5fHo4PbRgIu+UvGKCitSuM18DqRHSzEQqha5yi5nUEFUJwwvWg0JX",
+	"TOlO4nJmlL30zljxV6b8KtoEZrPH25in+AURox4lgC6Cvse4Gp0/hF6Rgth5bqKu5bgbJz8wvR3sy3jE",
+	"s57HrCilvw/c67mUOaNwd3BRVsje0yzjdg40fxcNi2zTxnRl2c2axbABBqyeNHzUv/TX4dJqrjqTBeVi",
+	"Gw6/glbuIrkdj/5eacMX/o7sAkzBDM2ooXsvXVdFQdW6s1ND1ZKZ3Q7cObYNFOrjiN3Qoszt0L+MltxM",
+	"yyrPE8cTTlPFLCM2hjdc64p1PpJFYcFob+0yl+upYjmj2jZKc1llU8/XTYvK4MesoDyfaiay8CNTdGH7",
+	"SGnOREbVlF0xEU2hpOsCHqzsGvCKSivF4KGfsK7mBTfRjvegCbytwdqPIW+4Nu8di76JJ+GC2OOm6Loe",
+	"ckmzhFnuZ9/e3kiaObap3e1t/6LCRx3sT8RXwIzcvTq3V3ngaOAe4PEVq0nGFRy69UyYFTVkYQktXNnA",
+	"1lh2EphJatjYMtiOb3p+OCV2QrZ/rmdCSDFZUENzIL12IHvRU0MskIiu0pRpvbCXAqFlyahlUskFgOzi",
+	"azfoTOB3rsGKKXuDkdReCkqTlArPUhBKSsVSrhkpmNZ0ybr5n8qiZAcP9LcVT1ckp2vLqSmZVcClrJiD",
+	"3VOaX9O1JrMRQmk2gusalmKnWimmu+/mNKdab453QoUU3N7+7nMCDd2tD4BGRBp7YHMp8En3OBZQO/IA",
+	"crFgAvbJftTZW85FR29vuEC212EMssGwKzWo7MWdMcNSw7KvySGycJW4FPJaRGMF6d5SU9iw7ZcCwrL+",
+	"wK26/9S/9exa67iH66JvU1DkgFU5FoHARWxxcUktX0Lo0rLK2NX2u94N2T/V9xHD1XN170tTfJdBJbYP",
+	"bdn8eHNitKRznvNw2zaAeR5IyhOLEGlOLSnS1VwzYzHR9kSR4khEp7BQkM1mopbH7IHXRFZG84yh/OQ6",
+	"slx0xgRHdq4mYzPhzzqx908tSIRBUDdgNB4JPxmkGgHIm5d0i+KvqO5gvU+cIGXf+lNXDzznws6rzCtN",
+	"7AQGOMY+6SHsCvn2f/0lIsKHL4LcsOSmxSfnNL3sEyF6Wd13XAiWtVjdeqf2Z3IBYuMm8vQfi/PAFLU4",
+	"O67LnK4TD55dWdpLjtofJqrCTu+KiQz4S8VKqbm99iwnI664ksJxQ7TklsdgqWIxY+M5nsTeOyXHtoan",
+	"l9jKckyJ55jsg0obWWxnaWCGPQCR6r099A8FjMA7OmAASbNbVBUU5BGmrjhOPujMHTncvg7g4KFJ52IE",
+	"zdeGp/qs5oibiwomACsZinSdFB20sfzDYbSy6E4p//yHrhdd9G6+ThTXl0nOrljez9F3jbLJ35cM8atF",
+	"KUExmvbw/dLQPCm4kCqpBDd614nDh7ofcjoBowHLuidfN3Ncd19DS1/dQJsvg8FDJ8izbW0GrB/L+lri",
+	"TbkjEDrvL2FWSpY8fVvzFUNC2sZt280cnMGGWe4XiL8lhV5fNs9leqnJ0wvDbszFmFwYKfOk0uxiPBP4",
+	"QzFd5fCOF3TJLsZkOp0+m5KzFS2ZU7hpEqb+RM+Em76GYRRNjb2b7CGTeePUVppZWkS15tpQsYPUBD2M",
+	"w1I/DAHxXMp8Pwg2wNZFjERZmaTWJA/13NyCH85++gs5gw+DtsxC94km0Gl0G9Ur6SGKXddUJyBKe6RP",
+	"r3jGRMoiq05z0cw12JlF8z2+Nqzo5Mvi2YXee2YI53iAhPbQf3zP9mEsXY/H3ezkeMQybug8ZwmwX/vr",
+	"hthNabnOhAKMF1IV9q+RFTYncO+MR6LKcztEq48YwbxRs2vRyOfRvPumDKRwaAYdX2mZXw1/tHXa2lBT",
+	"7bwDZ9j6djy6lupSlzRl3StuoVLTsh7bf934LRjEWDKEfV5q6FOxbMPF2nAeLN1HH3fe691gh2rCGnJ3",
+	"g/ggQF2XWyDVJU1tZeJKxUXKy34Q+othALP8nVGiAqDe3WyE97z7I2dLavmBrVdJY1JDq35QBZyneB0E",
+	"qKRLLoLmdqiXd3XLbj7CjeIk4aJTw+wPR7JUsir7dqaQWePKRu2bhb5YJ3KBH9ufeR7//LWSquoSGfyr",
+	"JJUVzmqL/0Tv4s72RI1CZmC+aWCJJ9ugs6ciZXneiTt+2P5r1A2ZSOFNSM5jZEFzXZ//yAbhldbdeM/K",
+	"pCoTWplVQrW243QyJZ0QMoamK9t3p8xV8IIlXoDqldo7piQVXbJEYZ8b7yuVN26QSvFOEXtjuidOKq3t",
+	"4S3IGsNExtjupyz06L7sOm1eFu5D/FSKBbOiTw0rj2dCCjA/SLnMWVIwkJr/IWVh18tooYdk5vFWLpOJ",
+	"LIGbd+dLPJcDFh+LljxjKl6Bm3qkD5CVyaW8HJ65NlSZPedmn/9Dim6cMtz0EP4rrjkoWdbxvP2hGo/K",
+	"ap7zFNTk/IqaHqm+H9c8ZmyywwXlTUTGJ+M9jooskVHbhQ60+WUYrOs6OllRcyKLMme285OV5OmeAuKC",
+	"C65XiWJU9wo4GbvpFm4jVffg0WvM0suxmzplO05THR7Pbfv6v3U+F6+QGj2cjNfPxDT8QO8n+nmPkSea",
+	"1N12yIC7inrdUH907UFJldFfE93QBNj1VaU2itFiJjz1eRIpA8gx6nVJJpkGNzO3SLAecbF06oLerWjr",
+	"EfRaW1l0vKlQGI+slA1X/hXL7Xo7CRsoOlLLw+Bt0PaIwy0gUqCC5ILYGXhzne5US4cu97i2Grt4LmV+",
+	"QvN8q4gN0NiOFRHnsjtW+CXecQ3h/Hf4I8mM5R0eXfYx4RkTxnJripSW+wluVx6xiMerTthjmy5TKRME",
+	"lon2McfUE64JKMAOwOA/wc8vAp7OxLxaLJjSoLKZ2E0lGcsN1XCgabW0vFZw1NOkEobnaG6geT4TvPaV",
+	"o3m+JikCqOm8E3GGiDuBwrfMGg4gKyWr5aoXMKQS6YqKJcumvssOU9fx0i442LigVX0+S8U0U1dg/maa",
+	"1V0SKrKZoKBgip2dPADcpJBgzNlCKnASu6bKMugz4Wfbslntdzi2HgxEsXGNxLscklrO24N2wlbd9ZC4",
+	"q7yLRwXPkz5tc7/AlndzJbjmTt59l/ti+G4CHYJ7Nw4Q8fPZDvn9tbX+Et0P2jHj0GFICp3u5sCz27qA",
+	"jN95bS1pSC2rwpsZNjmNCROpzOxRdO2cu+50Dwa22w5aD9y16B3tdLuDtzbCjbu+isCdyyrrlR1T0DP0",
+	"qu604YU9Ykkq9VYHtrdSsDXy987mvrPARa/tWVimoCr5R6WCZ9rCEt5hqUuxZd9Q3kjbq1fz73vFfUOX",
+	"egfL4YYbwZAZy5n4WXacBi1Pi2AiYRtSOitGs59Evu7Vn7Ibw5SgYK1SnXzbO7cRE12ylC94Co71MXOB",
+	"Hgcgc8FV/p39awzNLNbjM26+r+b4kLx+Bc/OcppePttlljivrc06hXQndw4J6wVPldRyYerXH3aYlU5l",
+	"2eX58tNxZVYE3xJngrWXuWMIBv1LegYNl9mmKtdyC1esoYNT7EpeogZu6yLQcfp+SBThzpa2A4jepROn",
+	"ldnqbR8+t1B3Oqc6vq9bNVR7dzyod2+/1OujyprczVbvohihd9DqB1TIuKbzHDWz4B/aKa45arYTcM9t",
+	"472NTa1Qy8bH4V5yN+OA5aS5xZuqWGZWsuHVIy3ivEDXneSSrUHdGvxZEn+f4dNrNl9JeZmgg497OHiT",
+	"eJVmD37VdGHXnW6z3LigQVA8pD1lwEHwIQ0qTWSKTQ7oEq5DCEQCWg5QOcD9HlzSnUeWVyZG1Bwdr9Bw",
+	"kaoCML8MbltJQQVdglrDMv9w46Fb18BGn8D9Gmbdb7S4C5X6DERoiJh8AmIwePoBhp0Ij5ugGPAbaI3r",
+	"9sD45ADdcJ9DYmNZC7A4KbZQTK/qsOQm+dkgPcPYeEWr3CQ+1Gvj9QPuRTRS/458W4GZ8AzOa++mDDq+",
+	"PfyOaGe89PRjf/+T9p5ecWUqmicpVVlSohZ0XmVL2K0Fp6Z1meR8uTLCTuGa5nm4TuYmbT7QRiqWJXOa",
+	"06ZfzyPsaP8mokNEP2HbSTPQCMG6HaMXaa9BkOb5nKaXiTN0tjhnZ/Ih7mCQn9+/wThTt6GkzCnEIOQ5",
+	"Bgsj10CQi9UzATozru2HLrLUueiTUsmlYlqDHs5p/VaM5HzB0nWas5l4imwaYVc0ryxTPCbeuYMEnxj/",
+	"jGUHaBQfk+C6MhNg22s8C2rK7JldCdeEXkme4dQEYxlqPy3McPqlzFHr+d0pxkI7h8iDjzy7JUxkpeTC",
+	"oM5v2EzsPPxuzG5+MSeucRz4l66Bot2f4LR7jNBkgy+kA2oKQFvM4dCLtttNw8M3Rb/FpMr30E+6WVZ5",
+	"p1ZyN98j7OOuvl4tuDryjqvoga67ZR+Uu4zubsc5PzKf2TFgl/LENfrtiIlfMEPRBOf4XgzGK5Zy3a2I",
+	"bDoRbvUORM/1yFa//QuuIQ5kBzT003wVfXJ3R0YML7M8Rs5TvjeZCdkG2sfKh5InNHIT3jSWNSMghsZ7",
+	"z/XlG2jYxoEYdo0ehzb5VRPgAfXzXF6jR5y8TiKvMzdgvRzY5XX0ppCKJR0e0zWsXzHRf3sMOZT1On20",
+	"jcn9DhivQI7t1bQrwxc0Nb3+YWg6TFDa7WWy8kqbHkFvG1WD8ITe4QsK3IjlWZNrLjJ53TcHe9SBAOys",
+	"3b+s5kwJZsDgdcVUCmZHwUzOF8AwdGj/F/mayy3qGuk4Tl2VpVRNS2B0AnywU7eqTVHDlg0vKtsvqhvm",
+	"ecWSpWJAk1MqqEJ0LHO6NfJrEz/iZAQdEapKcaadiXhiv6718pg+ZkpOb2hq8jWRguEzUlTakDkLOWKy",
+	"8UykUqHpHiKBna25VGzBb4hckJirn9pxjmaCkAlZcjP9Hfnn//m/9i985LIF4FP8gS8wawA+h7/xMeYJ",
+	"wMfwt2vtEwa4D9xPfOmzBuA798u9ivIHuNf1k5mw0gPY3xVRzEJZe2ZeR7HLATIEc0Y4wHnfmpkA+hzn",
+	"+bAwcfBCZrygN/Hl/xySmrWetANonfpqV0/MkHgAtWLbPotserdeg7b9Vovo0+249uQbDGaxjepvlnyr",
+	"yPEdN3V7t53b+T5oFn1X7/PWb+um/vuu0xcvpMuF1nkE7+Gq3vAi7rif52m6c2fvQ6BpV0cyWycrU3S7",
+	"LcBbLwtuXhgPNIeFksVeHWgmsmTDO94+FHD9QzKRRIp83e1KW/V7Y5iVYjTrvcmMfIgld+KQMEyVindG",
+	"wVh2hmXoke4vQd3lLKcxxZDmSzHhwtFnzYJnkqXzRWnWpGBUaELznLjOp3sFsPsZYSgzEr+9JoR2X/fh",
+	"A01qzuFuTfZwI97BGN5jVo4z5zBhEjpPn7942Ylv/bp1pnSfr3IrLYKq0CKOMSATMIj7z4mT5HweELCk",
+	"e5A/6/RyK3PaYJwXirmkOhDHHlCx8/jk1XJzq39+/2ayUJyJLF+TSvBfKxZZ+zs9BbVMavZ3l6iNHazO",
+	"Ozi2eMuhXYaDRBt3GojRGLeLOQ/JdFqmhe7HqaNbHWKnobzlsnoHLXTk5tmbISVE6+1oj81Y5DD+YZs7",
+	"Wtt4HEEqDl/dgExO5z3uc20VB1xJkG/mEuzWi0XikzmNRzq1TLVeSa81VyxlvPS/jF02BlaPWpIReFpF",
+	"otQWRUhe7eDB5XQY2LoTJl7yH8jhsj38sacBuvbfM8R0ODJWVqaszN7IGm/KLpoOpyPfi1J3+TqkrMTg",
+	"M1UJgZJYnVpgPHLZCIYj0tr43sze3BkdG01/EAlOnKWj32BpD1cydLQfZkN2AObDQXDAiyNABhJdb8ID",
+	"IsZZluweIrIxREgqs94vuuRVpSzKwk3LMvTZInVnBPLjYRZKFAGdCci1BIePzuQD28+9TpW8Rq3funF3",
+	"+gC55ky/l9ek1rVqyH+Evg2Zi4vhzudsOhMTYvs4IkKS89NT8jT+MGOpWtsDRLggK6nBQJYyrZ/Z7zSD",
+	"pMlHjbE0E8byfbavkqlJbeN6qhjN4fBCsk3oAlfGsmYf/inhAnI52b7AAKbXIgWOO6tylpFKMxCqW9GC",
+	"bl4jD7ieMNMdsghsfBNra/cknAOeWJBttGh45dWeeltPU5T0vZMWRescPHHvK9FLhgbXLa+YUjxjdz+U",
+	"fSvaPt/eTAKO8u+1u1vv151umH0vkAFq2PCf2NNxYoHfJsNuy5/IvaJbwE2pYUupONvT49F/XzBlGTqz",
+	"5+cFvUlQsEqMokLv5sHgXNI7Ezrt4GQ55Fz5xfmRbOLW3f02Gzj+kCbl5uF5VGNyrajcZFioZslcUZF2",
+	"W1AHXqUrll7qhtC8O5Knsii4SfSK7nk6IJlq4qLP9vsUOKCEauCQ9j3U+LFPPr95ucJrkBnv1HF//Ptd",
+	"+ixV/0xLNTBYZ/QBJGHELMs5nYN6wswrnyNwyMk4pCPsFvqvOLtuZ27a7mW8gd7fM5qbVf+5HLaKtWkj",
+	"RFNkbKkoShCZvBbd5JEXTBtalLvf4FGGyp1EkDh9YZ19sh64i2A1HaG2uZjGikMXGe38k7WxVGWJeris",
+	"6gvWGo94mdAsU0z3RINwfZms+N7XoCPeZU6NBW57srJkIs3pNbhX0ypjiVMM2f9uINk6EysqMo2BMy4F",
+	"OBc+axwXlf0zp2IJVR+2JLzA2TjevZcBczFWivazNIYVpVRUrZNBrhXiUSDstjtz/W3v1p8KDHB/UF/I",
+	"HT7CxJ738Ni7i/o7i/xsdnF0AT76YfPc7S5Z7ZPXa3/t8t7ujF3SWNuN0WVTdZgTwXs/pTSu7iHZpxau",
+	"Pyr/1NibzTRTXvMxDg8ix56uBFROwtpFWTUkaI9HP1xfdokvy25+TV11q296kgz3JB823be56KNinc9v",
+	"Op+utyOtHR4n14VmP1xfdshzl2y9O15ZkG6LbYIOu8Z/w0WPNWGbP++vFRXG6fyG8qCNR/qy6ga14Cah",
+	"hQ+z3U1WbLi+RVOMJtTsuWvVPsnr3fKK0Bv0BdWD2Yb28FZop84dSjkykDCkw7sKk8ts5sWB56RUsijN",
+	"10RvT7Ib5jgTkDLnmctz8y+T7iMCAakhMN5zh++W+2Mc49wwPt8pBUidPulhDKd7p/doJ0UayqoM2pdy",
+	"KBMYvNf2aIt0N5fvTdPsw+cXcfqbVhbooSQjb2XGF+s4IeberrPowosZ9u6pQ2521T1fwbpSygcK3zrQ",
+	"8JxwQSALO8Es7FFR0sOuyyRW0Rb05g0TS7MaHb2E76JfW/LxFs51P3TXtaB3DX6suSrBbkwS1T/dboO9",
+	"7RzBF1o8o/kAp7miOqmLMnZmhzIrhgnawLdlRTWBSh0E3P5J9HGXZ4imuemqlqfZH78KaVmO1VKKFzwj",
+	"tjV5KgtuDMuwyIeQ0RBQdJCZZ3Gs1HxttvuXtJb5YRBif2UqIOTng9wlu0yuoplsjnAqvM0vbmdv1jkY",
+	"4dKcQ+YunjFvHwTr3ueCb+zuOXCYd8o2M2eCLXjKXa2JHfxMv4m+uPXa+qTX6ccn5ksMU8U9zDY5FyzZ",
+	"T54LrHOn6xAaUrxFpi8U17VSccRUR/ZGgEximRcFeYySsvFFl7kDROCVlY/BcIE+/VZWTkolb5BJdj7s",
+	"PaKaYpY4WtBB8L4LYmmZhgspzCpfI/utDFPwNxWionlPr4Jd98XDYF2Yvj1yb/szP/Uh8zdNLGzLOSVV",
+	"pvcGvX9O1c6JBc+DvZML3SEn7x0DL+uq3L/NsMy7KJw29dkRb7GfNiouWu6sci1dVNBR1Zrw/jBQXN2J",
+	"FBnvJr0QG9GTs5cp6lL5+PPJfoUj/ys4Mdg/pSUgo/FoaeAf0CSDE6Dx/Cj4IPuYOD3stCcF+2kxOvpl",
+	"czbhiaiKOcC1A9Qdh79GpA0E+TBwhh5SQ+dO5aNq5uLAwU1Tx02ZUzGQnm3wRLq3gyhu8a8Xu3smC6e2",
+	"PypUNTP171JCIE7uj5c4Iv2+W1Wflo4920oXFwsXxdAOf2yFNsa6UQiMvOZmlcTyUOdZaQhMia+2vLdw",
+	"XSouldOzBTe154edwtHg7jZCJV3DAIV+inTGiyqnrSy8D2GluavR5V7R+ANZDjaX20dV9jfhbCgu3YuB",
+	"eWzo7n2J3+AKQ1W64lc93Ntm6FUPL5/4RJI7M/Wp1CZJIcqh82Btr+ScsyUQjivOrhvuGJss4QMz5t5v",
+	"v60B0nJhrjGdpVH0CvRvdl7etuzlDKha6Ezc9rKUVnjsYXRhpJ7a39oy19ysdwPC/pxvHT31CFUCds77",
+	"X0etR6BGGluwjFfFaDxa8SVYshU3PO0RGs6YqeX+XjK0XRSPVQYklQJ0jIQFAd0Sdsx9jTJ5xpQ9YOTH",
+	"0x/J0zloQ3YQundUpzz/48R+31KrLJmwzBzLyHwdTWVvUR+m0KGe6Nqmc8aOjWGWXR0k81XGmehS9J/e",
+	"lJA0lfgmoVoArfslPoHGDujbnlEfJRaycz7vqchkQeAtqbRP9xPNBVJ6CAaFjbduJxbs8Dl5NrQ7Ob1i",
+	"TzRh5YoVTNGcnJ68+p7gR+SSrfdCnaBNbClLo7l7bwDy9KfXr07ID387h+WdSLHgzuWbnNkrb0xmo4xd",
+	"TeRlqJyd0vzZ9uqxAFU/l8b6e9DnDL1M+nXUgMTJECBPoMkgHO0SGMIbfrMbNPLsAtdwyJNLdrk5uj3h",
+	"HXTAziBQAb3CYsqQ5YU8lSX9tWLESBfovr86rjmncQeUtoG771x4P/26VFVzuX8B2QwMfXFYQ2XkJIoV",
+	"wKiDzurhTV//rlIFkAAApklc4xg+w3FHDZ+llunS9TkUG9kmhXV3ffAMzNZm+SZ36pI0p7zQfXcKVMKu",
+	"jyg2rkNXIBDE+UZBsAZqdfETlj3bqJm/E3w3iOvekF5d99Sy+J6qzPJDxDMqBBqGOtffnbxLjt++Ss5O",
+	"/zobPesM84WUJhlfOoKwWaubcsEUgXYE24Xu9Yq++MMfj+g8nU6nfQNAeNC+ELqm2gUW7QwkaK46aq1D",
+	"h/g2zHxlTKmPDg58TPEUU2BPU1n0rKNU0qJiJ7Z/d/KOuPfk9StiVtQQeS0wj50nhVbEySXNdrtaPc4N",
+	"m0J83yuqyZxFqNppBGECffJ7u6QYvuQN/hwq6iz4slJ9PTqOIsFzbtYDTIefq29KSi7iATwn5fKRUJFh",
+	"dsLM8QVzJa81UwdIfhtWmo1zOYzVYUrp/dF7CC3COI+AH7FDdQvfXRqWK9bYzc14MWAzUGgKHMkE0xJ9",
+	"GCD3TrDtRyLhh68vFg4JZfx17VbcbeJ0o+xEWdEsbO54g21c8z4teABZ5z2kaFdMEtT12V34hV5Or3pS",
+	"hQz7fQ56Ae+ndgldNWPo3GJ6l48T71IwSbWPQy+M0xv9CS97y0qUdA2nZW8vmH296zfKTTfBlDiPEa91",
+	"GHaiB/A9pDIc0fFRdeE/i1yml3+lVW6GhPqtkvTLFyhJWybeM+vAekUm8ytOg6S9N6NuJ9EF9J/BAvVI",
+	"ucofIZLwTmF1t70Lr3Pu9K/84VPvoKvebzIBz4NM7Q5pePp3vJUjZpeYDNzbe2b7/c1m8+1f8c+a9Z/g",
+	"LXXCO3vVXUzUMXoZOfEA02zzzHLEVBCnUtCVUnJJDWo5nlZaJeT35OefX796ZjHNIh7XMwE8LdT9J7lc",
+	"8pTmNQtcucKDGcuqMrfcrOXdlNSaYKGc+ljNNrncbac1VEmKeG7fuk6I4Cpa7rTRFlh2Xr7u0RsuLjvP",
+	"7RU1VCU7FWy+Y3zOtorw4Vy2EjhhziakC//8r/8m0fYEKHVvQXwf9Z7xOqtUH1/jvbuupcp2dHSjxH8A",
+	"Pm+gYLMTOAiPLWZ1V3rsEkx+6kJgCwxeFBXAYkwEs1IYau4wnUIdI2dRfSATWE61SWBG90rI03Y3ltcC",
+	"a69mBay1YOC58GG81xXqQ2la8iMXVxzlZl1BKH+Pwe5hknM1saSu2dLA6uCFHBxUWge+hUv7RU51HuW+",
+	"3Ex7Hs5+4bRxoghUQHuKqpcxwXjgMZGXho6JpkU+Jsyk0+2a8EjGbUy4a93Ax+I1M6CY3Uf6tPxsSwJt",
+	"uYVa/hnVhzvq+x7ZGxbnM9wvdsS1X2a+dssgT4X0En609K4MfK1tcsOOtzu4RqZXqGvtcgowqlioc4W/",
+	"vvUA/eFv55AVzba2c4C39ZxWxpSj21sQrhdyc+lXh9MXhN0YiD+x659bccTl8phgZY1QDgNVGYqnK6bG",
+	"jrusUw27y9KSaZcX+DtuQJ9VVnmoluFDW7AFZpaFRpC+tvkWmQl46bLdNt87B0oco/YoqBvNxIlU0QJg",
+	"Xq72x2RWHR6+ZMQV+PBOD+F5KPPx1Bedfxbe1VmOMNnT5nP/BDQNwMP4FHZHzoWiLiQSVQYZw1polXFD",
+	"jt+9RnZlKa+YEizDiiB+daNQ5B+Dj3hKTlxBlHewbcfvXkfOfUejw+mL6aFzyBO05KOj0cvp8+mhvRyo",
+	"WQGqHVhSe4C3Kri6hQcSko6FJ67sQPzICiFVGT+Bu2Y98SxJeP7RE67bA1/7ped1PJOr5wd+6UcfR0vW",
+	"QaPegMLNB0/V4VRcBJrxRJOL/30wpRiZ5Xs8uCAZVyDgrmfiackUOX71fnJ4ePjSMrU0XREmjFqT1CXb",
+	"rnkmkZGMwc0pUitdoVg8E/asyMq4qvR5Tt5SdZnJa0HmMkO2o9KMXPiSLn4mH+3tcHvhbdQz4YvFkIIK",
+	"vmDaTC1ivwtTfH44JpDFAxWsC3tmjISK74xIRa5ozjPgsA3JJc0I5OSiis2EkFZ2zJHMZUqWJcuOYMYX",
+	"tmUC6ej0hUt8rSu1oCmzfJkvus2ymYBGpASD3QK5DJhPrfiEXxbHAFpP4W64FPJaPMMV5lwwgg6ZLv22",
+	"K1dPMIIXhYBQG/Z15rb6OJwEX3AcUOPF4WErcIyWKGVwKQ7+7gKzkFzt5hbW0FwBNW3i3euNwL0yr6zM",
+	"tIakaLB+AD0C1B7Crw6f940dFnPws7AHQir+D5bhRy+3f/StVHOeZQwvoprs2EVshhiOfKXaX0YenODQ",
+	"uomSvafuPTOVclp9wHRAvSzgK5ELKz62h0YYcaNnonE0UOqEQ8Kx0zdv3k4WNAWEcAWLSTQFC+OZcOf1",
+	"OeCYP7xdmPMd8z5nlvDVKcx++TiytAaIoXeaPgoFcsJ9jlx7jT1tFu3Do2NjFwbimxrkFgiQsuZToZr9",
+	"4qvtX/xFmm9lJbIWbn5nmbgOFJmviduAfiQVNF8bnuqD0F3A082N943PQkLZLhT4tWLwzuFAy0tzd1wY",
+	"d/cHKdGH+tlNvuru3Mj7d/2oONzegi5s9m2I39PPQjERK9tTiXDRv4uw0fF0uhcL4eIKrTbwr2umdZOD",
+	"d3TJzvg/GIQk7NAWvABGfbjy0Ijtc4GNPhuBdIDddmH7duTXilXsM97H7WKCjfs4YMkmeh18jOpe3Q6S",
+	"vDo+YD9U8x++zkafZM8G98mnT/+irrP25t5pb91z1NZI3bHJ2Fewct17n6Gbb1y+uwfc4jDD21tUkTwy",
+	"QiGrsBMZUCyVKvOocrh947+hWVjNF4GSbgu8mwomvtsfGSH4qBcT4yJqv0E0jKd329TS2Qvvt4GTr6A+",
+	"4b8ARtrduC86QhTbAEJikpLfMEp2Z1H5zSLn2yhq8F+IaIImq5liZhBd0xU1B05v5xWWHkFbNxDqIZ9o",
+	"ArmpSwqmlayi+aRU0shU5uTNm7dkSQ27puspeaVkOeEW+FBKEOvZLaQiF8G3t+RTUPHyaSqLrulcHMG5",
+	"A22yWVEzE1YQYFmcl2pJrTBOfiqZOH79RIci0+CvqaOWoM0DLQ6YDn5+/4ZwTaAtuJ2jtR29W0Fz+Q1b",
+	"0Ssu1ZjYgwrO6fO119j8iTx1+nkI9OZi+ezIfjQhv/vduZQ5odXSrhl2Yfq734UUW4pRZ8FwWt4NTddM",
+	"EPS76tT/jp1vliY0VjItuOAYkiMVYTRd2V6eWnFn3FBB1WUg4MsnuqnuHZNAVmwHePDwo5AzjIuyMvqZ",
+	"MwG4lGBmxQqfBczRnyewkgtIMXbRlxos5DFDbRrs9RMdBrM9QAdQLMKnJ4sR4J//9d8NWIMPCPh5XWFB",
+	"h2m0KWDQTGWegwlF230Bc2GHSueJjlpnDNYCx8tjZDOJ2hiB6qZvn5BrLvTXft/t54pBYVGLhF5vFFTP",
+	"YWUXbsenF76gJRoFACsQbCzzIJ6S487ZkOuV1AwXQHOLcuDLAosArfnmINpND/xdLqDPKdiGUqn4kgua",
+	"T+xrNBddYD44Qii5pkrYfeSa5HK5BCW4hfc7xSaWIMzXJdUajFMTLp4FkNtpFFIbS53tMQI7qcsgZntm",
+	"rhCoy6OAhS6pMUwJTeQivJeCbarjYPmAfb/A91OcxYcLO03nSDwORxKtWm4M1wNaWXIoBmrxXDndMSV6",
+	"LcyKaUvoiSfMmMsuIzm/ZIQSIVVBc5ICySKkpmiI5CEZnoUP196VA1YwJd8gwCwtAqc5sAW6gmtYyNNf",
+	"uGPQYk8c0Ej7peYZm2BgOuTgI0HpT/EI4t2DpxuAYvfR7Rf19rsJxFHpFVhjorM0sfMFG6VKWempXNja",
+	"xhpZASgPqAkAsZ9GKOr3mAq/JxN3pMOWjuOD1LlhlmYVXHANAbD5mjStY2OMVFVVajRiLlCmC49zPtgA",
+	"CsrigaxyM3ZxDlh7lRsyp+klxHT5o+RRYEqAwtih0RracSw1GP59JkfbQ03HQqinIyFQ1iaVGYTGuQU7",
+	"8J8BZO1EHUEMl8w30qyIDq+fXuDfR8RyZhfP/KkVUkzqVoXMGOJEqDI8Ja8FabYY414XLOPUME+XEQsy",
+	"lhs0qPfuHw4wrxYLpoB+GyydC44agEk6GOtg97w18Wt7I0Ew5kIB9bT9wIkBTHBuHD7/JJAtcrwwTA0d",
+	"77GnqA5J7WbbvpHAuyNueIprRFTA8clCojcqma/9/GNcfwIhM4aLCjfF8gTHlVmB4RseHSGjEfgUR9R1",
+	"8+okF8eOn4SPLmZixWjG1A7pP8OdEyoAe6IwE/Ycwl0P7hcYzNUiSnF4kWY5OijO10TZPSvAzoshQX6B",
+	"G4ard1KbkxU1JxFj+ThSSXOUzySVtCcRpJIxVAg8gDCESZ1gtu61HZNpWc8JBDfCNx475YJcNAdBCnCy",
+	"qsTlxUz8cPbTXwi65tiLVjAwcl9k1NCjC0TbZ2OC5NHFxM8Evia/vPrpL6cfLnAb2xrwDbHKziK6ziLi",
+	"d4KQnJyvSwZutRcba79AFjxCc/CJatKo8UxAMohrri2b0tqUC5cv91NJcX/Ajx4ETbA+ZwdQTz0lAB5s",
+	"ybUBEjmvDJzdNTNwz68Jt3BHqjolaMy2HHJWQd5hbaCQmrL0qQJbtoW0l8cQbn84fPH46/l5g5Iw17T2",
+	"Ghsd/fIhFmBRfJvYYajh85wB8xShWk0wI4n2O1xcJM+id2HkmTPgDIAsXi2L1XXk8dsn3sPYMg5wHKGk",
+	"J14SLnlJ7FUmS6anG8TQOXkfo6f6pmpno36tnYZyk7N/U7jM8O5KMdcr3DHoRjklb119fEo0LdhEc8MI",
+	"nWuZVwalXMuLEMVyCiJRSc1qSl5hCiRI3HygmbEcoj4IvU5C3C0mPtswoCE7nIANd3cL2ktEv+6NAF8g",
+	"jzFNkN/1yL/YQQcD/qZv0PNxCENfW/maGuZwYpHLaztjBzLLurIbK5zUhZAjRK09/R0e6NGH2y2ocOq7",
+	"c6hWA6ce1u9O0xUkcrftt5SGKj/OtRm9fJNQ1h8qeOYSquIUPFVSy4WJX+ucppdYHWhVzRMo+tMV9/Sh",
+	"92zGTnXdZsHm4fFVSXdzhnBlYe5tK9aGGvawaB7OWV0zu7QiiBQEykJoPYiK31OR5R4RPQxR5nAUwg3Q",
+	"VFfvhoRfGj5FxGrQlSGsPiz+nizhfaJC25PZpd7V5kULhnmsMtBCpzsyPJtm/9iP3ukr69HaBE9vQ7be",
+	"nTv46JwDMmZlvi6DnX2+AbaNLfyqQ3PtzkTGdRj4Hmr9e9iRwgTudlv0OU5sh8oDyjobiNshJLTR8QGc",
+	"Iu7p4rB5RB6CLu7pi9QiXFLtRLCk+mKdrz48PiJKtc2DKgLj5/OeSuO9bOGdfQj41mkYPoGQsdD0sfQo",
+	"zVH2UqQ8f/g9HdxH4qLofsvW3AYGvHcyfU2GMBFFFxpskIiDj3EZ9kEHuhhJ9qMX4cvHdqHbcYe/QCe6",
+	"7VsL0UuYrrq5da30Fw+wew9PIHpSdHxqTetu6OMia//nunvgbuxDT+r0hMM8R9Tu30xH1zXpwLOV64gA",
+	"+RnZjjALEiqdNDiQaJZbWZDQ9nF5kDDM52JCogn44jCDG/xF8yMdCNKLH46W1LkR9AHm9tgabFd/Upu5",
+	"a5soy0C1MO0KgDtB3UOdIukxhdtolK4dd2oQFrW6v5bFMg/pZs/1HtSTajERbaOLvRJ0D2zBL873MyWu",
+	"cASYgpkCA0FWcEGUzNnmNri7v3MnHovT2MyJ9YlZjWFcqN9+CcxGF++wB875c+9j/yeQS0AffPR1zAel",
+	"klP/2Xe29d5cBXz12GJJa45dG95MpPBlhfe0skDEG+3fdO2zPlCV6HdZf1+J8Pkj0YLQ//tqP+eOF480",
+	"hX6Gr0YQmqas/B8tfuBaWR05Fry8dketj+HvnQnI3rQjfPnJ6McwZnx5ao2acoQcV3fa34alt5uchP76",
+	"rbx7b/cjUiQ/y8/FngxhnJ/bv0DgyzupYyxNa9wZwlNXzHSCxUyHVSLfYtsz1/TfWpENXGxAaJtixDUm",
+	"HvSfTzmyaM2kRhk/R7/n21QjDQA8qnakMdJnUpA0V7t1i7849QhCGqOronUM4oejKytGc0x+18fMfI8t",
+	"HvE04ghDR/DM+ZO52Q55GlkeQDeb12Bwawmrx3i4YWr62rX5TZHRO7mEATO025bgouvUyT05SYCD9unq",
+	"909psgx57z/PNYCr3Eb/XTJ75oqHmM+bY8wjo0dpj57bKL4rv7kvqa9z9H4cLbl5V+V5lCq7gwTFCSlH",
+	"Ud3gulQoJrd0HULaTapZMldUpKvR0Qhejkfh94LfHKQrll7KykwMvZkoicQMUrMWBTeJXlGABSYQ/mr0",
+	"YTyCrH2JCy+BWlAqPTD0ZorAY9po/Mm0mWJhipzOWQ79zKvlgt/Y/t249nWpEsj6dTQ6X3FN3r0nC37D",
+	"NPFtiKE3xM8NA02zDNzjlcvkCqNOIed24vNLfstvmh9altCPGqe9dU6GsIGl1NxAbfkRTQsWwAMY0yrC",
+	"OTpb8bKe5LxaElxb05Md1qNkQRaMmkoxgvAnRhK3IYYqrzVvJMp2E4OA6OZsMFM0zDeJHl5y4R+7ZdSe",
+	"g0tuphaDEh8tilcxJAD31MISDpOkMmM34HKZ0Lxc0VGjrmyj9LmFYlZ5aR/vxqTMqVlIVTi32xtMbM2K",
+	"Uhom0jWWqhu9eJn9cfGSzif/wRZ/nnz18iWbzLMXbHKY/pEuvprPnx8ePm+X/z4aXeuEiSUXjIXcwq6U",
+	"/7tKpSuXgDcSCdxTckbpGdHVvCY/W06Q67Yu6hr/9fxPh4eH4xHqTVPQpJ69gkIDzbL4Lono6O9UsP+E",
+	"eAaxttsJTatsyRDaoyNLGPlSTKKaqY7jSBxUYfkLnRhGiyRqFhdz3XAb/5YvC0reKUmOhajAWvdrRV3x",
+	"p+fjUSW4SXZenr0xCmYBKkySUsOWeFKi2TioJRyiK+HPsjYmHY2uuDIVzZOUQg7sRhFWnG3nSXvPBLvG",
+	"fM3AhDGKidU34Dru2nsKaycIjJynTDgFd8+xw3m4M+amuHDP3BHDp9Hxcgufpivba8epilL9JrLU9zhU",
+	"soSaTNfd5+pPf/7zH/8j/cN8cvjyq8PJV//xp+cTSg/TyZ/SjL1gi6+eHx6+6DxXCy7svOCa3kcMwevv",
+	"M8kfOPipuGK5LHuynEJihi9A8LBf/Hn7FydSLHLuE28HbD+r5gU3hBJ7UlwYNPecySZL02TTDz6GilKD",
+	"6tfA6uzHsONnj6143RkXvsi0bHfaywNf13YwDxsTmYOdb33PDX6UXGxMZH5+n0nPuh3B/ARdJpT/0VmG",
+	"jIEE437FRu6GpS7DwqfPLkSFWSlZ8tQnGPIzaScWIphXaCY2Ewsd+z4eJbdQSH1x0Zn/iDw17VxC45mo",
+	"E9iMSdlIszKOkjLEqTnGdTKHmYiTRjyD/DmaMQSDXyBk4AkbNCWv+MK7j2FCdi9KRfGvK1oyDRl3XCKk",
+	"85C3xx8NH2EbYDqBr5o5giBx0cVHspG7aIyZhxKXlOj24tkYAqRtjy5+GLqDTDkuM9LkWtnBIb1GMfWz",
+	"clk6qFIcMg1mMEufS4JqnFBSaXZBHBkh81yml5A5RApCteZY9d5j1NeYdwdTReCqMWsIdBgSISXYoN2t",
+	"7TNOgGM3lqkY9zCPjLhiSoe6+0bR1MCi6owglWa6ibOQScCyrJo8vXD9J9pQZS7GMC83lQSm4t+0H0OK",
+	"jwtX8OVrl8jDpZXpzvsRwdAtciXzTGPqDyzhYR9DpYue3B/3yJ5xM6Eln1yy9cVM2A2+CLRg4ipNXBDM",
+	"qKF3SKnRl+Xiradsj5R0z3X/mS6/evjHSGkRkJT4cdzLmcD6ppvo2oOrM9GDrBvNZQmtfbehXT2OLC+e",
+	"7ZgMI0y7NwsG6UuCgVXnBrJgkH8nwfjXS4JRX4tRHgx/I+yU/wJqBPEtFu13vtG/bdk9VS63GjE8BD+f",
+	"7aKsN9FjQ5jVNusFLvJRDdXNuqefWEPk1te3cesv1yRd+p3r2PMWCTjQvKhyagb0AGeuxaPig6sbi0N9",
+	"viRdm9MYMJCHVo6f/2IQxe+oLxbHrmhe0ZZn5gDOfMTvtukEA8LseX/AZ4+tE9x2+r+oqNKhA78loPRh",
+	"NumxAjzucEF8OhT5F4og3eFGMYwdUGOYNtTbTLvvE58i6zhq/Dg4dM7iQT4TFrUnMVC+o25Wa09DJm4w",
+	"7V2x+8pnzSHPT09BcHLJjlvbH5KZKVZIqLgY75hHhfPT0yYW/P36sr+m5Tslb7iLQPsOkj9ZcXjBfYDh",
+	"meX1yQ9/+/Gs1t5oiXrHuZLXmqmZSHMOon9KBcGqnPHcyA9/OyeaLwV4VWC6Vivmnfz0/oxwrSumpzPx",
+	"I1ujAi6l6YplTu060TzD8MPnZCUr1VNx75yxH+wqHxFvoP8OLIE0nn9jc/IjW5MzZiJZtWXih2KTxEiy",
+	"YCZdIUwBnbwKa6tTH34iVQO6kA2WtApv9yKDqys8oNSHQBhECNzXJ5qwcsUKpmhOTk9efU8guXQK9c1B",
+	"DSvsaVDr0rCM/Hj640zMcznHBLW4jbXCby7Nyqvu3BEiNK7/X1KtJyHXMpRPNxax7LHAHPpYXH4F+Zk1",
+	"SxUzBLJPwAzg5Y+nP+LoboSZKJlaSFXgsmANdvLsBjWFY/+19p9jBmltpILM74SLmVhRlV1TxSZcyxyc",
+	"4QpWSLWekuPKyImForzWvohzFLwfZYjrwt9TKJTP9eqcsTO3PY9GgN0An4/4hgkMubq6st8eMCyD7fjx",
+	"9Ee0NKHKP7rnm9//GG2tRY3oO+x4QXleqU9Ku8MmE9vOFza3q/IrstMcPLmh+n4fg2+h631cH3ULvU/s",
+	"xs7ZtTUSTeMxcqt1K7h7/PUAaQSotqOdmjBUdFvUyDk2+beGbXPXLWS2Kdgc+D6fes34/QsIgA8CDlTa",
+	"7sGO+Q86A/JLJRe8K96+Tnvws3ZJNx9pL6D/gVQHFbx/2CQHFa7Jw9VO4X6JDXrh2MhbEED5WAKtHeAz",
+	"3YV922iff3pRdijbQM/mt84UVNefeMOJbmXzrlOEtg9cIa+wiAhmxg2l74MJJufispa7WnlNXWLI6Uyc",
+	"OB6xztdpm+dUG8BAUjCzklh5KOQOLyptyAp4UExgD3USXF7JMAFIxW350mup7G1muri4Ok+oXca7Ovnu",
+	"YLpo3w4rqhgZT/8pmy6nBDPyjgm6mD+7R+7o7ffFV53yIU5wMxHrp9KwPFTuVsCCCFLb8NnueLlSzlW9",
+	"W1o6QwmhFpb8AciIprkJbGssnpFaOsJvZsIXB3PSB8klFsOpNBdLcqyWUrzg2diLWZpQcinkdVPsA9wF",
+	"/xYnvUCJLynyNUpMfj61rGYnEg5EvVz0vbDzwBpHOaNO6nIS/5T8JMBH3+6tMOiYg7W02A3Xxk76kq1n",
+	"oqCGKU6hToySBi6Ap1AySWk8fIpN3HzIFa1y4yQ6TTSzB8ewfP2s67idMfOu3p/HuSIaY3wupWeYwBnN",
+	"t8Ro+ZbgmuAETjC/f6Zr5Awlc9x4t71lvGm7n8CDXDbTELRYn5xR1ajP57RIFonh6nB6CC+xb2Q7nomA",
+	"X5pccwjgsqwg+erFy8j5CRfBNalEDtUH0OOwC0PfyPQSyhQ8Ji8IA6A8NoQb0Izkrl7CA2QZl+mlg4Ul",
+	"FakFfwTy/bbWEqadGHJPB5GU+ZxkLYag7nhMaJ7La3B3c8QZtIkWJ4DgYikkcpxrSbjIgEHV5HrFLCdQ",
+	"MwkrquFE0ZmoO+9RRDaP6+g3QRjOPOEvIwpxX1G8ISXEHeOy99h+PEn9Z7u+J0nfNRmYw2giQX+H6DIT",
+	"7bvUCiXujrSfvnwxma8N9uv0k45mSPvP9+fn786mMxHpNPHuRf2g9zuGz3DUjSsfb2V7TzvajCemXg4X",
+	"jj4F3Paak/PzN1MCagNUsttLfSbmLLrLaxUoeDbznHUTrC7E/Rne1cTqEaSteoTPdJHuRSk9sL6c/HAw",
+	"YbfbUOqoPgoTPDZ3oMwNo8JuKSM9Bm5gP+B0TIZjfjNuHXPG+5x45FrtWXdnO9Lpc41zMBLDgEkqlWKp",
+	"EUzr2E4xE8jxahZqlwaCgorkrXT/r01DzCeg//GIg6jd3pKHIv+dAs4OmAbYuqnX7kav+FoORM3xYFKF",
+	"Eztu0E0IRF3PoAQikt/+251svdwjEvKb4eke9iK/CnzipjI97GJTE/9xhFUpjyuzGh398uH2g31tD1OP",
+	"vqOOmK1UPjoaxaE/lnL5IseUgzOLG/6jV3XAOLfj8DvOehk9xtlGD16HxBV1V6G0evQw8hINzxrVKOrP",
+	"sURqYzJ12qroaTvzTNxzI+N0eBw06fVgguZrw9OuecU1UOJOTk/jny7xi33S3JNX/QFbviSpLhm9dMZb",
+	"DNohUFQyqhWK5HczPGDs46B8id5Gte2UGprLZaiobdm07vrq4yg0yvbULNtroCyxbzoTLrkYDllslhmO",
+	"KwT7iUUlomfCVY8NhYMbVYOJL34eAsK4jsvNz0R/vXmkLW5PvCv47Yfb/xcAAP//MF+rc788AQA=",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -29,6 +29,7 @@ tags:
   - name: Approvals
   - name: Policies
   - name: Connectors
+  - name: Actions
   - name: Executions
   - name: Funding Sources
   - name: Credentials
@@ -1012,6 +1013,62 @@ paths:
                 $ref: "#/components/schemas/Connector"
         "400":
           $ref: "#/components/responses/BadRequest"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+        "404":
+          $ref: "#/components/responses/NotFound"
+
+  /v1/actions:
+    get:
+      tags: [Actions]
+      summary: List installed actions
+      description: |
+        Lists actions installed in the user's `~/.aileron/actions/` directory
+        (per ADR-0003). Each entry carries identity and dependency metadata
+        without the full Markdown body — use `GET /v1/actions/{name}` for the
+        complete manifest.
+
+        Per ADR-0010, files that fail to parse or validate at load time are
+        not silently dropped: the `load_errors` field surfaces a structured
+        error per offending file with the file path and (when known) the
+        line number where parsing failed.
+      operationId: listActions
+      responses:
+        "200":
+          description: Installed actions plus any per-file load errors
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/ActionListResponse"
+        "401":
+          $ref: "#/components/responses/Unauthorized"
+        "403":
+          $ref: "#/components/responses/Forbidden"
+
+  /v1/actions/{name}:
+    get:
+      tags: [Actions]
+      summary: Get an installed action by name
+      description: |
+        Returns the full parsed manifest of an installed action plus its
+        Markdown body. The body is the LLM-facing function description per
+        ADR-0001 and ADR-0003.
+      operationId: getAction
+      parameters:
+        - name: name
+          in: path
+          required: true
+          schema:
+            type: string
+      responses:
+        "200":
+          description: Action manifest and body
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Action"
         "401":
           $ref: "#/components/responses/Unauthorized"
         "403":
@@ -2667,6 +2724,141 @@ components:
             $ref: "#/components/schemas/Connector"
         pagination:
           $ref: "#/components/schemas/Pagination"
+
+    Action:
+      type: object
+      description: |
+        A user-installed action manifest. Per ADR-0001 and ADR-0003, an
+        action is a single Markdown file with TOML frontmatter; the parsed
+        frontmatter populates this object's structured fields and the
+        Markdown content following the closing `+++` populates `body`.
+      required:
+        - name
+        - version
+        - source
+        - requires
+        - match
+        - execute
+      properties:
+        name:
+          type: string
+          description: Bare local handle for the action (e.g. "ship-update").
+        version:
+          type: string
+          description: Strict SemVer of the action manifest.
+        source:
+          type: string
+          description: |
+            Fully-qualified URI of the template the action was installed from
+            (e.g. "hub://aileron/ship-update@1.0.0"). Provenance only — not
+            consulted at runtime.
+        requires:
+          $ref: "#/components/schemas/ActionRequires"
+        match:
+          $ref: "#/components/schemas/ActionMatch"
+        execute:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActionExecuteStep"
+        body:
+          type: string
+          description: |
+            Markdown content following the closing `+++` delimiter. The first
+            paragraph (or a designated section) is surfaced to the LLM as the
+            function description when the action is exposed as a tool.
+        path:
+          type: string
+          description: Absolute path of the source file on disk.
+
+    ActionRequires:
+      type: object
+      properties:
+        connectors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActionRequiresConnector"
+
+    ActionRequiresConnector:
+      type: object
+      required: [name, version, hash, capabilities]
+      properties:
+        name:
+          type: string
+          description: Connector FQN per ADR-0002 (e.g. "github://aileron/slack").
+        version:
+          type: string
+          description: Pinned SemVer of the connector.
+        hash:
+          type: string
+          description: Content hash of the connector binary plus its manifest.
+        capabilities:
+          type: array
+          items:
+            type: string
+          description: |
+            The action's declared subset of operations on the connector. Per
+            ADR-0003, calls outside this subset are denied at the action
+            boundary even when the connector permits the operation.
+
+    ActionMatch:
+      type: object
+      required: [intent]
+      properties:
+        intent:
+          type: string
+          description: Canonical phrase the runtime matches against agent intent.
+
+    ActionExecuteStep:
+      type: object
+      required: [id, connector, op]
+      properties:
+        id:
+          type: string
+        connector:
+          type: string
+        op:
+          type: string
+        idempotent:
+          type: boolean
+        inputs:
+          type: object
+          additionalProperties: true
+
+    ActionLoadError:
+      type: object
+      description: |
+        A structured error describing a single file in the actions directory
+        that failed to parse or validate, per ADR-0010. Loading is
+        non-fatal — files that load successfully appear in `items`; failed
+        files appear here so callers can surface a precise message.
+      required: [class, message, file]
+      properties:
+        class:
+          type: string
+          description: Canonical failure class (e.g. parse_error, validation_error).
+        message:
+          type: string
+        file:
+          type: string
+          description: Absolute path of the offending file.
+        line:
+          type: integer
+          description: Line within the file where the error was detected; 0 when unknown.
+        boundary:
+          type: string
+          description: Which layer produced the error (always "action" for load failures).
+
+    ActionListResponse:
+      type: object
+      properties:
+        items:
+          type: array
+          items:
+            $ref: "#/components/schemas/Action"
+        load_errors:
+          type: array
+          items:
+            $ref: "#/components/schemas/ActionLoadError"
 
     ExecutionGrant:
       type: object

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -13,6 +13,7 @@ import (
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/account"
+	"github.com/ALRubinger/aileron/internal/action"
 	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/approval"
 	"github.com/ALRubinger/aileron/internal/auth"
@@ -153,6 +154,14 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		teeCfg:             teeCfg,
 		grantCapabilityKey: grantCapabilityKey,
 		newID:              idGen,
+		actions:            action.NewStore(action.DefaultDir()),
+	}
+	if res, err := server.actions.Load(); err != nil {
+		log.Warn("failed to load actions directory", "dir", server.actions.Dir(), "error", err)
+	} else if res.HasErrors() {
+		for _, e := range res.Errors {
+			log.Warn("action manifest failed to load", "file", e.File, "line", e.Line, "class", e.Class, "message", e.Message)
+		}
 	}
 	if teeCfg.TEEEnabled() {
 		server.teeState = newTeeState()

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -11,6 +11,7 @@ import (
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/account"
+	"github.com/ALRubinger/aileron/internal/action"
 	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/approval"
 	"github.com/ALRubinger/aileron/internal/auth"
@@ -91,6 +92,7 @@ type apiServer struct {
 	escrowIndexStore   *postgres.EscrowIndexStore  // nil when auth is disabled; persists escrowIndex across restarts
 	uiBaseURL          string                      // base URL for the web UI (for constructing unlock links)
 	newID              func() string
+	actions            *action.Store // installed actions in ~/.aileron/actions/ (ADR-0003)
 }
 
 // --- JSON helpers ---
@@ -988,6 +990,125 @@ func (s *apiServer) UpdateConnector(w http.ResponseWriter, r *http.Request, conn
 	}
 	s.connectors.Update(ctx, c)
 	writeJSON(w, http.StatusOK, c)
+}
+
+// --- Actions (ADR-0003) ---
+
+// ListActions returns the actions installed in ~/.aileron/actions/, plus a
+// per-file load_errors slice for any files that failed to parse or validate
+// (per ADR-0010). Aileron is user-level only at v1, so the action set is the
+// running server's view of the local actions directory.
+func (s *apiServer) ListActions(w http.ResponseWriter, r *http.Request) {
+	if s.actions == nil {
+		writeJSON(w, http.StatusOK, api.ActionListResponse{})
+		return
+	}
+	res, err := s.actions.Load()
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "actions_load_failed", err.Error())
+		return
+	}
+	loaded := s.actions.List()
+	items := make([]api.Action, 0, len(loaded))
+	for _, la := range loaded {
+		items = append(items, manifestToAPI(la))
+	}
+	resp := api.ActionListResponse{Items: &items}
+	if res.HasErrors() {
+		errs := make([]api.ActionLoadError, 0, len(res.Errors))
+		for _, e := range res.Errors {
+			errs = append(errs, loadErrorToAPI(e))
+		}
+		resp.LoadErrors = &errs
+	}
+	writeJSON(w, http.StatusOK, resp)
+}
+
+// GetAction returns a single installed action by its bare local handle. The
+// response carries the full parsed manifest plus the Markdown body, which
+// doubles as the LLM-facing function description per ADR-0001/ADR-0003.
+func (s *apiServer) GetAction(w http.ResponseWriter, r *http.Request, name string) {
+	if s.actions == nil {
+		writeError(w, http.StatusNotFound, "not_found", "action not found")
+		return
+	}
+	la, err := s.actions.Get(name)
+	if errors.Is(err, action.ErrNotFound) {
+		writeError(w, http.StatusNotFound, "not_found", "action not found")
+		return
+	}
+	if err != nil {
+		writeError(w, http.StatusInternalServerError, "actions_lookup_failed", err.Error())
+		return
+	}
+	writeJSON(w, http.StatusOK, manifestToAPI(la))
+}
+
+func manifestToAPI(la action.LoadedAction) api.Action {
+	m := la.Manifest
+	connectors := make([]api.ActionRequiresConnector, 0, len(m.Requires.Connectors))
+	for _, c := range m.Requires.Connectors {
+		connectors = append(connectors, api.ActionRequiresConnector{
+			Name:         c.Name,
+			Version:      c.Version,
+			Hash:         c.Hash,
+			Capabilities: append([]string(nil), c.Capabilities...),
+		})
+	}
+	steps := make([]api.ActionExecuteStep, 0, len(m.Execute))
+	for _, st := range m.Execute {
+		var inputs *map[string]interface{}
+		if st.Inputs != nil {
+			cp := make(map[string]interface{}, len(st.Inputs))
+			for k, v := range st.Inputs {
+				cp[k] = v
+			}
+			inputs = &cp
+		}
+		steps = append(steps, api.ActionExecuteStep{
+			Id:         st.ID,
+			Connector:  st.Connector,
+			Op:         st.Op,
+			Idempotent: st.Idempotent,
+			Inputs:     inputs,
+		})
+	}
+	body := m.Body
+	path := la.Path
+	out := api.Action{
+		Name:    m.Name,
+		Version: m.Version,
+		Source:  m.Source,
+		Requires: api.ActionRequires{
+			Connectors: &connectors,
+		},
+		Match:   api.ActionMatch{Intent: m.Match.Intent},
+		Execute: steps,
+	}
+	if body != "" {
+		out.Body = &body
+	}
+	if path != "" {
+		out.Path = &path
+	}
+	return out
+}
+
+func loadErrorToAPI(e *action.Error) api.ActionLoadError {
+	out := api.ActionLoadError{
+		Class:   string(e.Class),
+		Message: e.Message,
+		File:    e.File,
+	}
+	if e.Line > 0 {
+		line := e.Line
+		out.Line = &line
+	}
+	if e.Boundary != "" {
+		b := string(e.Boundary)
+		out.Boundary = &b
+	}
+	return out
 }
 
 // --- Credentials ---

--- a/internal/app/handlers_actions_test.go
+++ b/internal/app/handlers_actions_test.go
@@ -1,0 +1,260 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/action"
+	api "github.com/ALRubinger/aileron/internal/api/gen"
+)
+
+const actionsTestManifest = `+++
+name = "ship-update"
+version = "1.0.0"
+source = "hub://aileron/ship-update@1.0.0"
+
+[[requires.connectors]]
+name = "github://aileron/slack"
+version = "1.2.0"
+hash = "sha256:abc123"
+capabilities = ["chat:write", "channels:read"]
+
+[match]
+intent = "tell team I shipped"
+
+[[execute]]
+id = "post"
+connector = "github://aileron/slack"
+op = "post_message"
++++
+
+# Ship Update
+
+Posts a "shipped" announcement to a Slack channel.
+`
+
+const actionsTestBadManifest = `+++
+name = "broken"
+version = "x.y"
++++
+`
+
+func newActionsTestServer(t *testing.T, files map[string]string) *apiServer {
+	t.Helper()
+	dir := t.TempDir()
+	for name, body := range files {
+		if err := os.WriteFile(filepath.Join(dir, name), []byte(body), 0o644); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	store := action.NewStore(dir)
+	if _, err := store.Load(); err != nil {
+		t.Fatalf("Load(): %v", err)
+	}
+	return &apiServer{
+		log:     slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		actions: store,
+	}
+}
+
+func TestListActions_ReturnsInstalledManifests(t *testing.T) {
+	srv := newActionsTestServer(t, map[string]string{
+		"ship-update.md": actionsTestManifest,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/actions", nil)
+	rec := httptest.NewRecorder()
+	srv.ListActions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var got api.ActionListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Items == nil || len(*got.Items) != 1 {
+		t.Fatalf("Items = %v, want 1", got.Items)
+	}
+	a := (*got.Items)[0]
+	if a.Name != "ship-update" {
+		t.Errorf("Name = %q", a.Name)
+	}
+	if a.Match.Intent != "tell team I shipped" {
+		t.Errorf("Match.Intent = %q", a.Match.Intent)
+	}
+	if a.Requires.Connectors == nil || len(*a.Requires.Connectors) != 1 {
+		t.Fatalf("Requires.Connectors = %v", a.Requires.Connectors)
+	}
+	if a.Body == nil || (*a.Body == "") {
+		t.Errorf("Body should be populated")
+	}
+	if got.LoadErrors != nil && len(*got.LoadErrors) != 0 {
+		t.Errorf("LoadErrors = %v, want empty", got.LoadErrors)
+	}
+}
+
+func TestListActions_SurfacesLoadErrors(t *testing.T) {
+	srv := newActionsTestServer(t, map[string]string{
+		"good.md": actionsTestManifest,
+		"bad.md":  actionsTestBadManifest,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/actions", nil)
+	rec := httptest.NewRecorder()
+	srv.ListActions(rec, req)
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got api.ActionListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Items == nil || len(*got.Items) != 1 {
+		t.Errorf("Items count = %v, want 1 (the valid manifest)", got.Items)
+	}
+	if got.LoadErrors == nil || len(*got.LoadErrors) != 1 {
+		t.Fatalf("LoadErrors = %v, want one entry", got.LoadErrors)
+	}
+	le := (*got.LoadErrors)[0]
+	if le.File == "" {
+		t.Errorf("LoadError.File is empty")
+	}
+	if le.Class == "" {
+		t.Errorf("LoadError.Class is empty")
+	}
+}
+
+func TestListActions_NilStoreReturnsEmpty(t *testing.T) {
+	srv := &apiServer{log: slog.New(slog.NewJSONHandler(io.Discard, nil))}
+	req := httptest.NewRequest(http.MethodGet, "/v1/actions", nil)
+	rec := httptest.NewRecorder()
+	srv.ListActions(rec, req)
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rec.Code)
+	}
+	var got api.ActionListResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Items != nil && len(*got.Items) != 0 {
+		t.Errorf("Items = %v, want nil/empty", got.Items)
+	}
+}
+
+func TestGetAction_ReturnsManifest(t *testing.T) {
+	srv := newActionsTestServer(t, map[string]string{
+		"ship-update.md": actionsTestManifest,
+	})
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/actions/ship-update", nil)
+	rec := httptest.NewRecorder()
+	srv.GetAction(rec, req, "ship-update")
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", rec.Code, rec.Body.String())
+	}
+	var got api.Action
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if got.Name != "ship-update" {
+		t.Errorf("Name = %q", got.Name)
+	}
+	if got.Body == nil {
+		t.Fatal("Body is nil")
+	}
+	if got.Path == nil || *got.Path == "" {
+		t.Errorf("Path is empty")
+	}
+	if len(got.Execute) != 1 {
+		t.Errorf("Execute = %v, want 1 step", got.Execute)
+	}
+}
+
+func TestGetAction_NotFound(t *testing.T) {
+	srv := newActionsTestServer(t, nil)
+
+	req := httptest.NewRequest(http.MethodGet, "/v1/actions/missing", nil)
+	rec := httptest.NewRecorder()
+	srv.GetAction(rec, req, "missing")
+
+	if rec.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404; body=%s", rec.Code, rec.Body.String())
+	}
+}
+
+func TestGetAction_NilStoreReturns404(t *testing.T) {
+	srv := &apiServer{log: slog.New(slog.NewJSONHandler(io.Discard, nil))}
+	req := httptest.NewRequest(http.MethodGet, "/v1/actions/x", nil)
+	rec := httptest.NewRecorder()
+	srv.GetAction(rec, req, "x")
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
+func TestLoadErrorToAPI_PopulatesBoundaryAndLine(t *testing.T) {
+	got := loadErrorToAPI(&action.Error{
+		Class:    action.ClassParseError,
+		Message:  "boom",
+		File:     "x.md",
+		Line:     42,
+		Boundary: action.BoundaryAction,
+	})
+	if got.Line == nil || *got.Line != 42 {
+		t.Errorf("Line = %v, want *42", got.Line)
+	}
+	if got.Boundary == nil || *got.Boundary != string(action.BoundaryAction) {
+		t.Errorf("Boundary = %v, want *action", got.Boundary)
+	}
+}
+
+func TestLoadErrorToAPI_OmitsBlankBoundaryAndZeroLine(t *testing.T) {
+	got := loadErrorToAPI(&action.Error{
+		Class:   action.ClassParseError,
+		Message: "boom",
+		File:    "x.md",
+		// Boundary intentionally empty; Line zero.
+	})
+	if got.Boundary != nil {
+		t.Errorf("Boundary = %v, want nil when blank", got.Boundary)
+	}
+	if got.Line != nil {
+		t.Errorf("Line = %v, want nil when zero", got.Line)
+	}
+	if got.Class != string(action.ClassParseError) {
+		t.Errorf("Class = %q", got.Class)
+	}
+}
+
+func TestManifestToAPI_OmitsBlankBodyAndPath(t *testing.T) {
+	la := action.LoadedAction{
+		Manifest: &action.Manifest{
+			Name:    "x",
+			Version: "1.0.0",
+			Source:  "hub://aileron/x@1.0.0",
+			Match:   action.Match{Intent: "hi"},
+			Requires: action.Requires{Connectors: []action.RequiresConnector{
+				{Name: "github://aileron/slack", Version: "1.0.0", Hash: "sha256:a", Capabilities: []string{"chat:write"}},
+			}},
+			Execute: []action.ExecuteStep{{ID: "s", Connector: "github://aileron/slack", Op: "post"}},
+			// Body intentionally blank.
+		},
+		// Path intentionally blank.
+	}
+	got := manifestToAPI(la)
+	if got.Body != nil {
+		t.Errorf("Body = %v, want nil when blank", got.Body)
+	}
+	if got.Path != nil {
+		t.Errorf("Path = %v, want nil when blank", got.Path)
+	}
+}

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -3,6 +3,7 @@ module github.com/ALRubinger/aileron/internal
 go 1.25.0
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/anthropics/anthropic-sdk-go v1.36.0
 	github.com/bwmarrin/discordgo v0.29.0
 	github.com/creack/pty/v2 v2.0.1

--- a/internal/go.sum
+++ b/internal/go.sum
@@ -10,6 +10,8 @@ github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6 h1:He8af
 github.com/AdaLogics/go-fuzz-headers v0.0.0-20240806141605-e8a1dd7889d6/go.mod h1:8o94RPi1/7XTJvwPpRSzSUedZrtlirdB3r9Z20bi2f8=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c h1:udKWzYgxTojEKWjV8V+WSxDXJ4NFATAsZjh8iIbsQIg=
 github.com/Azure/go-ansiterm v0.0.0-20250102033503-faa5f7b0171c/go.mod h1:xomTg63KZ2rFqZQzSB4Vz2SUXa1BpHTVz9L5PTmPC4E=
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/Microsoft/go-winio v0.6.2 h1:F2VQgta7ecxGYO8k3ZZz3RS8fVIXVxONVUPlNERoyfY=
 github.com/Microsoft/go-winio v0.6.2/go.mod h1:yd8OoFMLzJbo9gZq8j5qaps8bJ9aShtEA8Ipt1oGCvU=
 github.com/RaveNoX/go-jsoncommentstrip v1.0.0/go.mod h1:78ihd09MekBnJnxpICcwzCMzGrKSKYe4AqU6PDYYpjk=


### PR DESCRIPTION
Closes #357.

## Summary

- Adds the `internal/action` package: parses `+++`-delimited TOML/Markdown action files in `~/.aileron/actions/` per [ADR-0001](https://docs.withaileron.ai/adr/0001-manifest-format) and [ADR-0003](https://docs.withaileron.ai/adr/0003-action-model), validates schema (`name`, `version`, `source` FQN, `[[requires.connectors]]`, `[match]`, `[[execute]]`), enforces declared capability subsets at the action boundary, and surfaces structured errors per [ADR-0010](https://docs.withaileron.ai/adr/0010-failure-handling) with `file`+`line` context.
- Extends `internal/api/openapi.yaml` with `GET /v1/actions` and `GET /v1/actions/{name}`; regenerates the server interface.
- Wires an `action.Store` into `apiServer`; loads on handler init and warns on per-file failures rather than failing closed.

## Acceptance criteria

- [x] Parse TOML frontmatter delimited by `+++` and extract the Markdown body as a separate field.
- [x] Validate the action manifest schema: `name`, `version`, `source` (FQN), `[[requires.connectors]]` (with FQN, version, hash, capability subset), `[match]`, `[[execute]]`.
- [x] Capability subset declared in the action manifest is enforced at the action boundary (refuses out-of-subset calls before they reach the connector).
- [x] Loading errors are structured (per ADR-0010) and surface specific file + line.
- [x] Server endpoint `GET /v1/actions` lists installed actions with metadata.
- [x] Server endpoint `GET /v1/actions/{name}` returns full action manifest plus parsed body.

## Coverage

- `internal/action`: 95.9% overall; every function ≥87.5%.
- `internal/app` action handlers: `loadErrorToAPI` 100%, `ListActions` 88.9%, `GetAction` 81.8%, `manifestToAPI` 81.0%.

## Test plan

- [ ] `task generate:api` is a no-op against the merged spec
- [ ] `go test ./internal/action/... ./internal/app/...` passes
- [ ] `task lint:go` passes
- [ ] Place a valid `~/.aileron/actions/ship-update.md`, start the server, hit `GET /v1/actions` and confirm it appears with metadata
- [ ] Hit `GET /v1/actions/ship-update` and confirm body + parsed fields are returned
- [ ] Place a malformed action file and confirm it surfaces in `load_errors` (file + line) without preventing valid actions from loading

🤖 Generated with [Claude Code](https://claude.com/claude-code)