### PR TITLE
feat(gateway): tool-call interception with stub action executor

### DIFF
--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -1,0 +1,65 @@
+package action
+
+import (
+	"context"
+	"encoding/json"
+)
+
+// Executor runs an installed action with the given call-time arguments
+// and returns a Result whose Content becomes the tool-result message
+// the LLM observes.
+//
+// Per [ADR-0010], action-side failures are returned as Results with
+// IsError=true rather than as Go errors — the LLM sees the failure as
+// a tool result and can decide how to proceed (retry, fall back to a
+// different action, ask the user). A returned `error` is reserved for
+// gateway-fatal conditions that should terminate the conversation
+// turn (e.g. action not found, executor misconfigured).
+//
+// [ADR-0010]: https://docs.withaileron.ai/adr/0010-failure-handling
+type Executor interface {
+	Execute(ctx context.Context, name string, args map[string]any) (Result, error)
+}
+
+// Result is the synthesized tool-result content surfaced to the LLM.
+// Both OpenAI's `tool` message and Anthropic's `tool_result` content
+// block use a string body; the IsError flag is mapped to Anthropic's
+// `is_error` field and prepended to OpenAI's content as a marker.
+type Result struct {
+	// Content is the JSON-encoded tool result body. Implementations
+	// SHOULD return JSON the LLM can parse, but plain prose is
+	// acceptable when the action's output is naturally a sentence.
+	Content string
+
+	// IsError reports whether the action failed in a way the LLM
+	// should be informed of. Per ADR-0010, this surfaces as
+	// `is_error: true` on Anthropic tool_result blocks and is encoded
+	// into the OpenAI tool-message body as a sentinel JSON shape.
+	IsError bool
+}
+
+// StubExecutor returns a placeholder JSON result describing what
+// would have been executed. It exists so the interception machinery
+// can be exercised end-to-end before the connector-orchestration
+// runtime is wired up. Real action execution lands in a follow-up
+// issue.
+type StubExecutor struct{}
+
+// Execute returns a Result whose Content is a small JSON object
+// summarising the call. Always succeeds; never returns a Go error.
+func (StubExecutor) Execute(_ context.Context, name string, args map[string]any) (Result, error) {
+	if args == nil {
+		args = map[string]any{}
+	}
+	body, err := json.Marshal(map[string]any{
+		"executed": false,
+		"stub":     true,
+		"action":   name,
+		"args":     args,
+		"note":     "Action execution is not yet implemented; this is a placeholder result.",
+	})
+	if err != nil {
+		return Result{}, err
+	}
+	return Result{Content: string(body)}, nil
+}

--- a/internal/action/executor_test.go
+++ b/internal/action/executor_test.go
@@ -1,0 +1,52 @@
+package action
+
+import (
+	"context"
+	"encoding/json"
+	"testing"
+)
+
+// StubExecutor must always succeed (no Go error), produce a JSON
+// payload the LLM can parse, and reflect the action name and args.
+// Per ADR-0010, action-side errors should be Results with IsError=true,
+// not error returns — the stub never errors.
+
+func TestStubExecutor_ReturnsPlaceholderJSON(t *testing.T) {
+	res, err := StubExecutor{}.Execute(context.Background(), "ship_update",
+		map[string]any{"channel": "#engineering"})
+	if err != nil {
+		t.Fatalf("Execute returned error: %v", err)
+	}
+	if res.IsError {
+		t.Error("StubExecutor unexpectedly marked Result as error")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(res.Content), &payload); err != nil {
+		t.Fatalf("decode result content: %v\n%s", err, res.Content)
+	}
+	if payload["action"] != "ship_update" {
+		t.Errorf("action = %v, want ship_update", payload["action"])
+	}
+	if payload["stub"] != true {
+		t.Errorf("stub = %v, want true", payload["stub"])
+	}
+	args, _ := payload["args"].(map[string]any)
+	if args["channel"] != "#engineering" {
+		t.Errorf("args.channel = %v, want #engineering", args["channel"])
+	}
+}
+
+func TestStubExecutor_HandlesNilArgs(t *testing.T) {
+	res, err := StubExecutor{}.Execute(context.Background(), "x", nil)
+	if err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(res.Content), &payload); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	args, _ := payload["args"].(map[string]any)
+	if args == nil {
+		t.Error("args missing in stub payload")
+	}
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -27,6 +27,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/connector/payments/stripe"
 	"github.com/ALRubinger/aileron/internal/draft"
 	"github.com/ALRubinger/aileron/internal/enclave"
+	"github.com/ALRubinger/aileron/internal/intercept"
 	"github.com/ALRubinger/aileron/internal/notify"
 	"github.com/ALRubinger/aileron/internal/policy"
 	"github.com/ALRubinger/aileron/internal/source"
@@ -173,6 +174,24 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 			log.Warn("action manifest failed to load", "file", e.File, "line", e.Line, "class", e.Class, "message", e.Message)
 		}
 	}
+
+	// --- Intercept engine (stage 4) ---
+	// The engine handles tool-call interception. Real action
+	// execution lands in a follow-up issue; for now we wire a stub
+	// executor that returns a placeholder result so the interception
+	// machinery can be exercised end-to-end.
+	engine, engineErr := intercept.New(intercept.Config{
+		OpenAIUpstream:    gatewayCfg.OpenAIBaseURL,
+		AnthropicUpstream: gatewayCfg.AnthropicBaseURL,
+		Actions:           server.actions,
+		Executor:          action.StubExecutor{},
+		Log:               log,
+	})
+	if engineErr != nil {
+		return nil, fmt.Errorf("intercept engine: %w", engineErr)
+	}
+	server.interceptEngine = engine
+
 	if teeCfg.TEEEnabled() {
 		server.teeState = newTeeState()
 	}

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -93,6 +93,7 @@ type apiServer struct {
 	uiBaseURL          string                      // base URL for the web UI (for constructing unlock links)
 	openAIProxy        http.Handler                // upstream proxy for /v1/chat/completions; nil disables the endpoint
 	anthropicProxy     http.Handler                // upstream proxy for /v1/messages; nil disables the endpoint
+	interceptEngine    interceptEngineHandle       // tool-call intercept engine; nil disables interception (proxy passthrough only)
 	newID              func() string
 	actions            *action.Store // installed actions in ~/.aileron/actions/ (ADR-0003)
 }

--- a/internal/app/handlers_gateway.go
+++ b/internal/app/handlers_gateway.go
@@ -1,104 +1,59 @@
 package app
 
 import (
-	"bytes"
-	"io"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
-	"strconv"
 
-	"github.com/ALRubinger/aileron/internal/augment"
-)
-
-// gatewayProtocol identifies which augmenter applies to a request.
-type gatewayProtocol int
-
-const (
-	protocolOpenAI gatewayProtocol = iota
-	protocolAnthropic
+	"github.com/ALRubinger/aileron/internal/intercept"
 )
 
 // PostChatCompletions handles POST /v1/chat/completions.
 //
-// Stage 3: transparent reverse proxy to the upstream OpenAI provider
-// with tool augmentation. The agent's request body is decoded, the
-// user's installed actions ([ADR-0003]) are appended to the `tools`
-// array per ADR-0008's collision rules, and the modified body is
-// forwarded upstream. Tool-call interception lands in stage 4;
-// pre-LLM bypass in stage 5.
-//
-// [ADR-0003]: https://docs.withaileron.ai/adr/0003-action-model
+// When no actions are installed, the request is forwarded through a
+// transparent reverse proxy (stage 2 behavior). When the user has
+// installed actions, the request is delegated to the intercept engine
+// which augments the tool catalog (stage 3) and intercepts Aileron
+// tool calls (stage 4) before forwarding the final assistant message
+// to the agent.
 func (s *apiServer) PostChatCompletions(w http.ResponseWriter, r *http.Request) {
 	if s.openAIProxy == nil {
 		writeError(w, http.StatusServiceUnavailable, "gateway_not_configured",
 			"OpenAI gateway upstream is not configured")
 		return
 	}
-	if err := s.augmentRequest(r, protocolOpenAI); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request",
-			"failed to augment request: "+err.Error())
+	if !s.hasInstalledActions() {
+		s.openAIProxy.ServeHTTP(w, r)
 		return
 	}
-	s.openAIProxy.ServeHTTP(w, r)
+	s.interceptEngine.HandleOpenAI(w, r)
 }
 
-// PostMessages handles POST /v1/messages.
-//
-// Stage 3: transparent reverse proxy to the upstream Anthropic
-// provider with tool augmentation. Mirrors PostChatCompletions in
-// the Anthropic shape (`tools` array of name/description/input_schema).
+// PostMessages handles POST /v1/messages with the same logic shaped
+// for the Anthropic Messages protocol.
 func (s *apiServer) PostMessages(w http.ResponseWriter, r *http.Request) {
 	if s.anthropicProxy == nil {
 		writeError(w, http.StatusServiceUnavailable, "gateway_not_configured",
 			"Anthropic gateway upstream is not configured")
 		return
 	}
-	if err := s.augmentRequest(r, protocolAnthropic); err != nil {
-		writeError(w, http.StatusBadRequest, "invalid_request",
-			"failed to augment request: "+err.Error())
+	if !s.hasInstalledActions() {
+		s.anthropicProxy.ServeHTTP(w, r)
 		return
 	}
-	s.anthropicProxy.ServeHTTP(w, r)
+	s.interceptEngine.HandleAnthropic(w, r)
 }
 
-// augmentRequest reads the request body, appends installed actions to
-// the appropriate `tools` shape, and rewires the body so the proxy
-// forwards the augmented payload. When no actions are installed the
-// body is left untouched (passthrough — the stage-2 behavior).
-func (s *apiServer) augmentRequest(r *http.Request, proto gatewayProtocol) error {
-	if s.actions == nil {
-		return nil
+// hasInstalledActions reports whether at least one action is loaded
+// in the user's actions store. Without actions there is nothing to
+// augment or intercept, so the gateway can stay on the lightweight
+// reverse-proxy path.
+func (s *apiServer) hasInstalledActions() bool {
+	if s.actions == nil || s.interceptEngine == nil {
+		return false
 	}
-	loaded := s.actions.List()
-	if len(loaded) == 0 {
-		return nil
-	}
-
-	body, err := io.ReadAll(r.Body)
-	if err != nil {
-		return err
-	}
-	_ = r.Body.Close()
-
-	derived := augment.DeriveAll(loaded)
-
-	var augmented []byte
-	switch proto {
-	case protocolOpenAI:
-		augmented, err = augment.AugmentOpenAI(body, derived, s.log)
-	case protocolAnthropic:
-		augmented, err = augment.AugmentAnthropic(body, derived, s.log)
-	}
-	if err != nil {
-		return err
-	}
-
-	r.Body = io.NopCloser(bytes.NewReader(augmented))
-	r.ContentLength = int64(len(augmented))
-	r.Header.Set("Content-Length", strconv.Itoa(len(augmented)))
-	return nil
+	return len(s.actions.List()) > 0
 }
 
 // newGatewayProxy builds an HTTP reverse proxy that forwards requests
@@ -130,3 +85,14 @@ func newGatewayProxy(upstream *url.URL, providerLabel string, log *slog.Logger) 
 	}
 	return rp
 }
+
+// interceptEngineHandle is the contract apiServer relies on. The
+// concrete implementation lives in internal/intercept; the interface
+// keeps this package decoupled from intercept's internal state.
+type interceptEngineHandle interface {
+	HandleOpenAI(w http.ResponseWriter, r *http.Request)
+	HandleAnthropic(w http.ResponseWriter, r *http.Request)
+}
+
+// Compile-time assertion: *intercept.Engine satisfies the handle.
+var _ interceptEngineHandle = (*intercept.Engine)(nil)

--- a/internal/app/handlers_gateway_test.go
+++ b/internal/app/handlers_gateway_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/action"
 	api "github.com/ALRubinger/aileron/internal/api/gen"
+	"github.com/ALRubinger/aileron/internal/intercept"
 )
 
 // Stage 2 contract (#368, ratified by ADR-0008):
@@ -390,8 +391,9 @@ channel = "${args.channel}"
 Posts a 'shipped' announcement to a Slack channel.
 `
 
-// newGatewayTestServerWithActions wires a populated action.Store into
-// the test server so augmentation has something to derive from.
+// newGatewayTestServerWithActions wires a populated action.Store and
+// an intercept engine into the test server so augmentation +
+// interception have something to operate on.
 func newGatewayTestServerWithActions(t *testing.T, openAIUpstream, anthropicUpstream *url.URL, manifests map[string]string) *apiServer {
 	t.Helper()
 	s := newGatewayTestServer(t, openAIUpstream, anthropicUpstream)
@@ -412,6 +414,17 @@ func newGatewayTestServerWithActions(t *testing.T, openAIUpstream, anthropicUpst
 		t.Fatalf("load errors: %+v", res.Errors)
 	}
 	s.actions = store
+	engine, err := intercept.New(intercept.Config{
+		OpenAIUpstream:    openAIUpstream,
+		AnthropicUpstream: anthropicUpstream,
+		Actions:           store,
+		Executor:          action.StubExecutor{},
+		Log:               s.log,
+	})
+	if err != nil {
+		t.Fatalf("intercept.New: %v", err)
+	}
+	s.interceptEngine = engine
 	return s
 }
 

--- a/internal/augment/augment.go
+++ b/internal/augment/augment.go
@@ -120,30 +120,45 @@ func deriveParameters(m *action.Manifest) map[string]any {
 	return schema
 }
 
+// Augmented is the result of running [AugmentOpenAI] or
+// [AugmentAnthropic]. Body is the re-encoded request payload to
+// forward upstream; OurNames is the post-collision list of tool names
+// the gateway now owns. The interception layer uses OurNames to
+// decide whether a tool call coming back from the upstream LLM should
+// be intercepted (Aileron-owned) or passed through unchanged
+// (agent-declared).
+type Augmented struct {
+	Body     []byte
+	OurNames []string
+}
+
 // AugmentOpenAI parses an OpenAI Chat Completions request body, applies
 // collision rules, appends the derived actions to the `tools` array,
-// and returns the re-encoded body. When `actions` is empty the body is
-// returned untouched.
-func AugmentOpenAI(body []byte, actions []DerivedAction, log Logger) ([]byte, error) {
+// and returns the re-encoded body alongside the post-collision list
+// of Aileron-owned tool names. When `actions` is empty the body is
+// returned untouched and OurNames is empty.
+func AugmentOpenAI(body []byte, actions []DerivedAction, log Logger) (Augmented, error) {
 	if len(actions) == 0 {
-		return body, nil
+		return Augmented{Body: body}, nil
 	}
 	if log == nil {
 		log = nopLogger{}
 	}
 	var req map[string]any
 	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, err
+		return Augmented{}, err
 	}
 
 	tools, _ := req["tools"].([]any)
 	declared := agentDeclaredOpenAI(tools, log)
 
+	ourNames := make([]string, 0, len(actions))
 	for _, a := range actions {
 		finalName := a.Name
 		if declared[finalName] {
 			finalName = "aileron." + finalName
 		}
+		ourNames = append(ourNames, finalName)
 		tools = append(tools, map[string]any{
 			"type": "function",
 			"function": map[string]any{
@@ -154,34 +169,40 @@ func AugmentOpenAI(body []byte, actions []DerivedAction, log Logger) ([]byte, er
 		})
 	}
 	req["tools"] = tools
-	return json.Marshal(req)
+	out, err := json.Marshal(req)
+	if err != nil {
+		return Augmented{}, err
+	}
+	return Augmented{Body: out, OurNames: ourNames}, nil
 }
 
 // AugmentAnthropic parses an Anthropic Messages request body, applies
 // collision rules, appends the derived actions to the `tools` array
 // (Anthropic shape: name/description/input_schema), and returns the
-// re-encoded body. When `actions` is empty the body is returned
-// untouched.
-func AugmentAnthropic(body []byte, actions []DerivedAction, log Logger) ([]byte, error) {
+// re-encoded body alongside the post-collision list of Aileron-owned
+// tool names.
+func AugmentAnthropic(body []byte, actions []DerivedAction, log Logger) (Augmented, error) {
 	if len(actions) == 0 {
-		return body, nil
+		return Augmented{Body: body}, nil
 	}
 	if log == nil {
 		log = nopLogger{}
 	}
 	var req map[string]any
 	if err := json.Unmarshal(body, &req); err != nil {
-		return nil, err
+		return Augmented{}, err
 	}
 
 	tools, _ := req["tools"].([]any)
 	declared := agentDeclaredAnthropic(tools, log)
 
+	ourNames := make([]string, 0, len(actions))
 	for _, a := range actions {
 		finalName := a.Name
 		if declared[finalName] {
 			finalName = "aileron." + finalName
 		}
+		ourNames = append(ourNames, finalName)
 		tools = append(tools, map[string]any{
 			"name":         finalName,
 			"description":  a.Description,
@@ -189,7 +210,11 @@ func AugmentAnthropic(body []byte, actions []DerivedAction, log Logger) ([]byte,
 		})
 	}
 	req["tools"] = tools
-	return json.Marshal(req)
+	out, err := json.Marshal(req)
+	if err != nil {
+		return Augmented{}, err
+	}
+	return Augmented{Body: out, OurNames: ourNames}, nil
 }
 
 // agentDeclaredOpenAI walks the OpenAI-shape tools array, applies the

--- a/internal/augment/augment_test.go
+++ b/internal/augment/augment_test.go
@@ -150,8 +150,11 @@ func TestAugmentOpenAI_NoActions_ReturnsBodyUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("AugmentOpenAI: %v", err)
 	}
-	if string(got) != string(body) {
-		t.Errorf("body modified despite no actions: %s", got)
+	if string(got.Body) != string(body) {
+		t.Errorf("body modified despite no actions: %s", got.Body)
+	}
+	if len(got.OurNames) != 0 {
+		t.Errorf("OurNames = %v, want empty when no actions provided", got.OurNames)
 	}
 }
 
@@ -168,7 +171,7 @@ func TestAugmentOpenAI_AppendsAction(t *testing.T) {
 	}
 
 	var req map[string]any
-	if err := json.Unmarshal(got, &req); err != nil {
+	if err := json.Unmarshal(got.Body, &req); err != nil {
 		t.Fatalf("decode: %v", err)
 	}
 	tools, _ := req["tools"].([]any)
@@ -186,6 +189,9 @@ func TestAugmentOpenAI_AppendsAction(t *testing.T) {
 	if fn["description"] != "post a ship update" {
 		t.Errorf("description = %v", fn["description"])
 	}
+	if len(got.OurNames) != 1 || got.OurNames[0] != "ship_update" {
+		t.Errorf("OurNames = %v, want [ship_update]", got.OurNames)
+	}
 }
 
 func TestAugmentOpenAI_PreservesAgentTools(t *testing.T) {
@@ -196,7 +202,7 @@ func TestAugmentOpenAI_PreservesAgentTools(t *testing.T) {
 		t.Fatalf("AugmentOpenAI: %v", err)
 	}
 	var req map[string]any
-	json.Unmarshal(got, &req)
+	json.Unmarshal(got.Body, &req)
 	tools, _ := req["tools"].([]any)
 	if len(tools) != 2 {
 		t.Fatalf("got %d tools, want 2", len(tools))
@@ -215,7 +221,7 @@ func TestAugmentOpenAI_NameCollision_RenamesAileronAction(t *testing.T) {
 		t.Fatalf("AugmentOpenAI: %v", err)
 	}
 	var req map[string]any
-	json.Unmarshal(got, &req)
+	json.Unmarshal(got.Body, &req)
 	tools := req["tools"].([]any)
 	if len(tools) != 2 {
 		t.Fatalf("got %d tools, want 2", len(tools))
@@ -228,6 +234,9 @@ func TestAugmentOpenAI_NameCollision_RenamesAileronAction(t *testing.T) {
 	if aileronName != "aileron.search" {
 		t.Errorf("Aileron action name = %v, want aileron.search", aileronName)
 	}
+	if len(got.OurNames) != 1 || got.OurNames[0] != "aileron.search" {
+		t.Errorf("OurNames = %v, want [aileron.search] (post-collision)", got.OurNames)
+	}
 }
 
 func TestAugmentOpenAI_ReverseCollision_RenamesAgentTool(t *testing.T) {
@@ -239,7 +248,7 @@ func TestAugmentOpenAI_ReverseCollision_RenamesAgentTool(t *testing.T) {
 		t.Fatalf("AugmentOpenAI: %v", err)
 	}
 	var req map[string]any
-	json.Unmarshal(got, &req)
+	json.Unmarshal(got.Body, &req)
 	tools := req["tools"].([]any)
 	agentName := tools[0].(map[string]any)["function"].(map[string]any)["name"]
 	if agentName != "agent.search" {
@@ -264,7 +273,7 @@ func TestAugmentAnthropic_AppendsActionInAnthropicShape(t *testing.T) {
 		t.Fatalf("AugmentAnthropic: %v", err)
 	}
 	var req map[string]any
-	json.Unmarshal(got, &req)
+	json.Unmarshal(got.Body, &req)
 	tools, _ := req["tools"].([]any)
 	if len(tools) != 1 {
 		t.Fatalf("got %d tools, want 1", len(tools))
@@ -293,7 +302,7 @@ func TestAugmentAnthropic_NameCollision_RenamesAileronAction(t *testing.T) {
 		t.Fatalf("AugmentAnthropic: %v", err)
 	}
 	var req map[string]any
-	json.Unmarshal(got, &req)
+	json.Unmarshal(got.Body, &req)
 	tools := req["tools"].([]any)
 	if len(tools) != 2 {
 		t.Fatalf("got %d tools, want 2", len(tools))
@@ -315,7 +324,7 @@ func TestAugmentAnthropic_ReverseCollision_RenamesAgentTool(t *testing.T) {
 		t.Fatalf("AugmentAnthropic: %v", err)
 	}
 	var req map[string]any
-	json.Unmarshal(got, &req)
+	json.Unmarshal(got.Body, &req)
 	tools := req["tools"].([]any)
 	if tools[0].(map[string]any)["name"] != "agent.search" {
 		t.Errorf("agent tool name = %v, want agent.search", tools[0].(map[string]any)["name"])

--- a/internal/augment/augment_test.go
+++ b/internal/augment/augment_test.go
@@ -346,3 +346,92 @@ func TestAugmentOpenAI_InvalidJSON_ReturnsError(t *testing.T) {
 		t.Logf("error message: %v", err)
 	}
 }
+
+func TestAugmentAnthropic_InvalidJSON_ReturnsError(t *testing.T) {
+	_, err := AugmentAnthropic([]byte(`{not-json`), []DerivedAction{{Name: "x"}}, nil)
+	if err == nil {
+		t.Fatal("expected error decoding invalid JSON")
+	}
+}
+
+func TestAugmentAnthropic_NoActions_ReturnsBodyUnchanged(t *testing.T) {
+	body := []byte(`{"model":"c","max_tokens":1,"messages":[]}`)
+	got, err := AugmentAnthropic(body, nil, nil)
+	if err != nil {
+		t.Fatalf("AugmentAnthropic: %v", err)
+	}
+	if string(got.Body) != string(body) {
+		t.Errorf("body modified despite no actions: %s", got.Body)
+	}
+	if len(got.OurNames) != 0 {
+		t.Errorf("OurNames = %v, want empty", got.OurNames)
+	}
+}
+
+// --- DeriveAll covers list iteration ---
+
+func TestDeriveAll_PreservesOrder(t *testing.T) {
+	actions := []action.LoadedAction{
+		loadedAction(t, "ship-update", "first body", nil),
+		loadedAction(t, "file-bug", "second body", nil),
+	}
+	got := DeriveAll(actions)
+	if len(got) != 2 {
+		t.Fatalf("DeriveAll length = %d, want 2", len(got))
+	}
+	if got[0].Name != "ship_update" {
+		t.Errorf("got[0].Name = %q, want ship_update", got[0].Name)
+	}
+	if got[1].Name != "file_bug" {
+		t.Errorf("got[1].Name = %q, want file_bug", got[1].Name)
+	}
+}
+
+// --- nopLogger.Warn is exercised when caller passes nil ---
+
+func TestAugmentOpenAI_NilLogger_DoesNotPanicOnReverseCollision(t *testing.T) {
+	// Reverse collision triggers a Warn call. Passing nil log must
+	// route through nopLogger and not panic.
+	body := []byte(`{"model":"gpt-4","messages":[],"tools":[{"type":"function","function":{"name":"aileron.search"}}]}`)
+	actions := []DerivedAction{{Name: "ship_update", Description: "x", Parameters: map[string]any{"type": "object"}}}
+	_, err := AugmentOpenAI(body, actions, nil)
+	if err != nil {
+		t.Fatalf("AugmentOpenAI: %v", err)
+	}
+}
+
+func TestAugmentAnthropic_NilLogger_DoesNotPanicOnReverseCollision(t *testing.T) {
+	body := []byte(`{"model":"c","max_tokens":1,"messages":[],"tools":[{"name":"aileron.search","input_schema":{"type":"object"}}]}`)
+	actions := []DerivedAction{{Name: "ship_update", Description: "x", Parameters: map[string]any{"type": "object"}}}
+	_, err := AugmentAnthropic(body, actions, nil)
+	if err != nil {
+		t.Fatalf("AugmentAnthropic: %v", err)
+	}
+}
+
+// --- Malformed tool entries are skipped, not panicked ---
+
+func TestAugmentOpenAI_SkipsMalformedToolEntries(t *testing.T) {
+	body := []byte(`{"model":"gpt-4","messages":[],"tools":["not-an-object",{"type":"function"},{"type":"function","function":"not-an-object"},{"type":"function","function":{}}]}`)
+	actions := []DerivedAction{{Name: "ship_update", Description: "x", Parameters: map[string]any{"type": "object"}}}
+	got, err := AugmentOpenAI(body, actions, nil)
+	if err != nil {
+		t.Fatalf("AugmentOpenAI: %v", err)
+	}
+	// Action still appended; malformed entries didn't cause a crash.
+	if len(got.OurNames) != 1 || got.OurNames[0] != "ship_update" {
+		t.Errorf("OurNames = %v, want [ship_update]", got.OurNames)
+	}
+}
+
+func TestAugmentAnthropic_SkipsMalformedToolEntries(t *testing.T) {
+	body := []byte(`{"model":"c","max_tokens":1,"messages":[],"tools":["not-an-object",{}]}`)
+	actions := []DerivedAction{{Name: "ship_update", Description: "x", Parameters: map[string]any{"type": "object"}}}
+	got, err := AugmentAnthropic(body, actions, nil)
+	if err != nil {
+		t.Fatalf("AugmentAnthropic: %v", err)
+	}
+	if len(got.OurNames) != 1 || got.OurNames[0] != "ship_update" {
+		t.Errorf("OurNames = %v, want [ship_update]", got.OurNames)
+	}
+}

--- a/internal/intercept/anthropic.go
+++ b/internal/intercept/anthropic.go
@@ -1,0 +1,314 @@
+package intercept
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/augment"
+)
+
+// HandleAnthropic mirrors HandleOpenAI for the Anthropic Messages
+// protocol. Tool calls arrive as `tool_use` content blocks on
+// assistant messages; tool results inject as `tool_result` content
+// blocks on a synthesized user message.
+func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
+	if e.anthropicUpstream == nil {
+		writeError(w, http.StatusServiceUnavailable, "gateway_not_configured",
+			"Anthropic gateway upstream is not configured")
+		return
+	}
+
+	origBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"failed to read request body: "+err.Error())
+		return
+	}
+	_ = r.Body.Close()
+
+	wantStream := agentRequestedStreaming(origBody)
+
+	derived := e.derived()
+	aug, err := augment.AugmentAnthropic(origBody, derived, e.log)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"failed to augment request: "+err.Error())
+		return
+	}
+
+	currentBody, err := setStream(aug.Body, false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"failed to prepare upstream body: "+err.Error())
+		return
+	}
+
+	ourNames := nameSet(aug.OurNames)
+
+	for round := 0; round < maxRounds; round++ {
+		respStatus, respHeaders, respBody, err := e.sendAnthropic(r, currentBody)
+		if err != nil {
+			writeError(w, http.StatusBadGateway, "upstream_error",
+				"upstream Anthropic request failed: "+err.Error())
+			return
+		}
+		if respStatus != http.StatusOK {
+			passThrough(w, respStatus, respHeaders, respBody)
+			return
+		}
+
+		assistantContent, toolUses, err := parseAnthropicResponse(respBody)
+		if err != nil {
+			passThrough(w, respStatus, respHeaders, respBody)
+			return
+		}
+
+		ours, theirs := classifyAnthropicToolUses(toolUses, ourNames)
+
+		if len(ours) == 0 {
+			emitAnthropicTerminal(w, respBody, wantStream)
+			return
+		}
+		if len(theirs) > 0 {
+			writeError(w, http.StatusBadGateway, "mixed_tool_calls_unsupported",
+				"the gateway does not yet support a single response that mixes Aileron tool calls with agent-declared tool calls")
+			return
+		}
+
+		toolResultBlocks, execErr := e.executeAnthropicToolUses(r.Context(), ours)
+		if execErr != nil {
+			writeError(w, http.StatusInternalServerError, "executor_error",
+				"action executor returned a fatal error: "+execErr.Error())
+			return
+		}
+
+		nextBody, err := appendAnthropicContinuation(currentBody, assistantContent, toolResultBlocks)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "continuation_error",
+				"failed to build continuation request: "+err.Error())
+			return
+		}
+		currentBody = nextBody
+	}
+
+	writeError(w, http.StatusBadGateway, "max_intercept_rounds",
+		"interception loop exceeded maximum rounds; aborting to avoid infinite cycle")
+}
+
+// sendAnthropic posts the body to the configured Anthropic upstream
+// and returns status, headers, and body.
+func (e *Engine) sendAnthropic(orig *http.Request, body []byte) (int, http.Header, []byte, error) {
+	target := *e.anthropicUpstream
+	if target.Path == "" || target.Path == "/" {
+		target.Path = "/v1/messages"
+	} else {
+		target.Path = strings.TrimRight(target.Path, "/") + "/v1/messages"
+	}
+	req, err := http.NewRequestWithContext(orig.Context(), http.MethodPost, target.String(), bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	copyForwardableHeaders(orig.Header, req.Header)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	return resp.StatusCode, resp.Header.Clone(), respBody, nil
+}
+
+// parseAnthropicResponse extracts the assistant content blocks and
+// the subset that are tool_use blocks.
+func parseAnthropicResponse(body []byte) (content []any, toolUses []map[string]any, err error) {
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, nil, err
+	}
+	if t, _ := resp["type"].(string); t != "message" {
+		return nil, nil, fmt.Errorf("unexpected response type: %v", resp["type"])
+	}
+	rawContent, _ := resp["content"].([]any)
+	for _, b := range rawContent {
+		bm, ok := b.(map[string]any)
+		if !ok {
+			continue
+		}
+		if bm["type"] == "tool_use" {
+			toolUses = append(toolUses, bm)
+		}
+	}
+	return rawContent, toolUses, nil
+}
+
+func classifyAnthropicToolUses(uses []map[string]any, ours map[string]bool) (mine, theirs []map[string]any) {
+	for _, u := range uses {
+		name, _ := u["name"].(string)
+		if ours[name] {
+			mine = append(mine, u)
+		} else {
+			theirs = append(theirs, u)
+		}
+	}
+	return mine, theirs
+}
+
+// executeAnthropicToolUses runs each Aileron tool_use block through
+// the engine's Executor and produces matching tool_result content
+// blocks for injection as a synthesized user message.
+func (e *Engine) executeAnthropicToolUses(ctx context.Context, uses []map[string]any) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(uses))
+	for _, u := range uses {
+		id, _ := u["id"].(string)
+		name, _ := u["name"].(string)
+		input, _ := u["input"].(map[string]any)
+		if input == nil {
+			input = map[string]any{}
+		}
+
+		res, err := e.executor.Execute(ctx, name, input)
+		if err != nil {
+			return nil, err
+		}
+		block := map[string]any{
+			"type":        "tool_result",
+			"tool_use_id": id,
+			"content":     res.Content,
+		}
+		if res.IsError {
+			block["is_error"] = true
+		}
+		out = append(out, block)
+	}
+	return out, nil
+}
+
+// appendAnthropicContinuation builds the next-round request by adding
+// the assistant message (with the model's content blocks including
+// the tool_use) and a synthesized user message carrying the
+// tool_result blocks.
+func appendAnthropicContinuation(currentBody []byte, assistantContent []any, toolResultBlocks []map[string]any) ([]byte, error) {
+	var req map[string]any
+	if err := json.Unmarshal(currentBody, &req); err != nil {
+		return nil, err
+	}
+	rawMessages, _ := req["messages"].([]any)
+	rawMessages = append(rawMessages, map[string]any{
+		"role":    "assistant",
+		"content": assistantContent,
+	})
+	userBlocks := make([]any, 0, len(toolResultBlocks))
+	for _, b := range toolResultBlocks {
+		userBlocks = append(userBlocks, b)
+	}
+	rawMessages = append(rawMessages, map[string]any{
+		"role":    "user",
+		"content": userBlocks,
+	})
+	req["messages"] = rawMessages
+	return json.Marshal(req)
+}
+
+// emitAnthropicTerminal writes the terminal Anthropic response back
+// to the agent. When the agent asked for streaming, the JSON message
+// is reshaped into a minimal SSE event sequence covering the
+// content blocks plus message_stop.
+func emitAnthropicTerminal(w http.ResponseWriter, body []byte, wantStream bool) {
+	if !wantStream {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+		return
+	}
+
+	events, err := anthropicEventsFromMessage(body)
+	if err != nil {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	for _, ev := range events {
+		fmt.Fprintf(w, "event: %s\ndata: %s\n\n", ev.Name, ev.Data)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+}
+
+// anthropicEvent is a single SSE event with a named type and JSON
+// payload, matching Anthropic's streaming protocol.
+type anthropicEvent struct {
+	Name string
+	Data string
+}
+
+// anthropicEventsFromMessage converts a non-streamed Anthropic
+// Messages response into a minimal event sequence: message_start,
+// then per-content-block start/delta/stop, then message_delta and
+// message_stop. Sufficient for a simple agent that just needs the
+// final assistant message.
+func anthropicEventsFromMessage(body []byte) ([]anthropicEvent, error) {
+	var msg map[string]any
+	if err := json.Unmarshal(body, &msg); err != nil {
+		return nil, err
+	}
+	content, _ := msg["content"].([]any)
+	if content == nil {
+		return nil, errors.New("response missing content array")
+	}
+
+	startData, _ := json.Marshal(map[string]any{
+		"type":    "message_start",
+		"message": msg,
+	})
+	events := []anthropicEvent{{Name: "message_start", Data: string(startData)}}
+
+	for i, b := range content {
+		bm, _ := b.(map[string]any)
+		if bm == nil {
+			continue
+		}
+		startBlockData, _ := json.Marshal(map[string]any{
+			"type":          "content_block_start",
+			"index":         i,
+			"content_block": bm,
+		})
+		stopBlockData, _ := json.Marshal(map[string]any{
+			"type":  "content_block_stop",
+			"index": i,
+		})
+		events = append(events,
+			anthropicEvent{Name: "content_block_start", Data: string(startBlockData)},
+			anthropicEvent{Name: "content_block_stop", Data: string(stopBlockData)},
+		)
+	}
+
+	deltaData, _ := json.Marshal(map[string]any{
+		"type":  "message_delta",
+		"delta": map[string]any{"stop_reason": msg["stop_reason"], "stop_sequence": msg["stop_sequence"]},
+		"usage": msg["usage"],
+	})
+	stopData, _ := json.Marshal(map[string]any{"type": "message_stop"})
+	events = append(events,
+		anthropicEvent{Name: "message_delta", Data: string(deltaData)},
+		anthropicEvent{Name: "message_stop", Data: string(stopData)},
+	)
+	return events, nil
+}

--- a/internal/intercept/helpers.go
+++ b/internal/intercept/helpers.go
@@ -1,0 +1,110 @@
+package intercept
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// nameSet builds a set lookup from a slice for O(1) membership tests.
+func nameSet(names []string) map[string]bool {
+	out := make(map[string]bool, len(names))
+	for _, n := range names {
+		out[n] = true
+	}
+	return out
+}
+
+// agentRequestedStreaming reports whether the agent's request body
+// declared `stream: true`. A malformed body returns false so the
+// engine defaults to non-streaming responses.
+func agentRequestedStreaming(body []byte) bool {
+	var req map[string]any
+	if err := json.Unmarshal(body, &req); err != nil {
+		return false
+	}
+	v, _ := req["stream"].(bool)
+	return v
+}
+
+// setStream rewrites the request body's top-level `stream` field
+// (creating it if missing). Used to force `stream: false` on upstream
+// requests during intercept rounds.
+func setStream(body []byte, stream bool) ([]byte, error) {
+	var req map[string]any
+	if err := json.Unmarshal(body, &req); err != nil {
+		return nil, err
+	}
+	req["stream"] = stream
+	return json.Marshal(req)
+}
+
+// hopByHopHeaders are headers that must not be propagated when proxying
+// per RFC 7230. Connection-related metadata belongs to the immediate
+// hop, not the request.
+var hopByHopHeaders = map[string]bool{
+	"Connection":          true,
+	"Proxy-Connection":    true,
+	"Keep-Alive":          true,
+	"Te":                  true,
+	"Trailer":             true,
+	"Transfer-Encoding":   true,
+	"Upgrade":             true,
+	"Proxy-Authenticate":  true,
+	"Proxy-Authorization": true,
+}
+
+// copyForwardableHeaders copies headers from the agent's request to
+// the upstream request, dropping hop-by-hop headers and ones the
+// engine sets explicitly (Content-Type, Content-Length, Accept, Host).
+func copyForwardableHeaders(src, dst http.Header) {
+	for k, vs := range src {
+		if hopByHopHeaders[http.CanonicalHeaderKey(k)] {
+			continue
+		}
+		switch http.CanonicalHeaderKey(k) {
+		case "Content-Length", "Content-Type", "Accept", "Host":
+			continue
+		}
+		for _, v := range vs {
+			dst.Add(k, v)
+		}
+	}
+}
+
+// passThrough writes an upstream response (status, headers, body)
+// to the agent unchanged. Used when the upstream produced a non-200
+// status or a response shape we couldn't parse — the agent should
+// see the upstream's error verbatim rather than a synthesized one.
+func passThrough(w http.ResponseWriter, status int, headers http.Header, body []byte) {
+	for k, vs := range headers {
+		if hopByHopHeaders[http.CanonicalHeaderKey(k)] {
+			continue
+		}
+		for _, v := range vs {
+			w.Header().Add(k, v)
+		}
+	}
+	w.WriteHeader(status)
+	w.Write(body)
+}
+
+// errorBody is the JSON shape this package writes for gateway-side
+// errors, kept compatible with the api.Error schema in
+// internal/api/openapi.yaml.
+type errorBody struct {
+	Error errorBodyInner `json:"error"`
+}
+
+type errorBodyInner struct {
+	Code    string `json:"code"`
+	Message string `json:"message"`
+}
+
+// writeError emits a structured JSON error matching the Aileron API
+// contract.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	body, _ := json.Marshal(errorBody{Error: errorBodyInner{Code: code, Message: message}})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	w.Write(body)
+}

--- a/internal/intercept/intercept.go
+++ b/internal/intercept/intercept.go
@@ -1,0 +1,86 @@
+// Package intercept implements the dual-protocol tool-call interception
+// loop ratified by [ADR-0008]. When the upstream LLM emits a tool call
+// that targets an Aileron-augmented action, the engine intercepts it,
+// runs the action through an [action.Executor], injects the synthetic
+// tool result back into the conversation, and continues with a fresh
+// upstream call until the LLM produces a final assistant message.
+//
+// Tool calls for agent-declared tools pass through unchanged — the
+// agent's host code executes them as it always has.
+//
+// [ADR-0008]: https://docs.withaileron.ai/adr/0008-intent-matching
+package intercept
+
+import (
+	"errors"
+	"log/slog"
+	"net/http"
+	"net/url"
+
+	"github.com/ALRubinger/aileron/internal/action"
+	"github.com/ALRubinger/aileron/internal/augment"
+)
+
+// maxRounds caps the number of intercept iterations a single agent
+// request can drive. Without a cap, a misbehaving LLM/action pair
+// could loop forever; ten back-to-back tool calls is well above the
+// observed ceiling for realistic conversations.
+const maxRounds = 10
+
+// Engine runs the augmentation+interception loop for both OpenAI and
+// Anthropic protocol shapes.
+type Engine struct {
+	openAIUpstream    *url.URL
+	anthropicUpstream *url.URL
+	actions           *action.Store
+	executor          action.Executor
+	httpClient        *http.Client
+	log               *slog.Logger
+}
+
+// Config groups the dependencies required to build an Engine. The
+// constructor validates that the required fields are present so
+// misconfiguration is caught at startup rather than on the first
+// request.
+type Config struct {
+	OpenAIUpstream    *url.URL
+	AnthropicUpstream *url.URL
+	Actions           *action.Store
+	Executor          action.Executor
+	HTTPClient        *http.Client // optional; defaults to http.DefaultClient
+	Log               *slog.Logger // optional; defaults to slog.Default()
+}
+
+// New builds an Engine from a Config.
+func New(cfg Config) (*Engine, error) {
+	if cfg.Actions == nil {
+		return nil, errors.New("intercept: Actions store is required")
+	}
+	if cfg.Executor == nil {
+		return nil, errors.New("intercept: Executor is required")
+	}
+	client := cfg.HTTPClient
+	if client == nil {
+		client = http.DefaultClient
+	}
+	log := cfg.Log
+	if log == nil {
+		log = slog.Default()
+	}
+	return &Engine{
+		openAIUpstream:    cfg.OpenAIUpstream,
+		anthropicUpstream: cfg.AnthropicUpstream,
+		actions:           cfg.Actions,
+		executor:          cfg.Executor,
+		httpClient:        client,
+		log:               log,
+	}, nil
+}
+
+// derived returns the protocol-neutral DerivedAction list for every
+// installed action. An empty list means the engine should defer to a
+// transparent passthrough caller — there is nothing to augment or
+// intercept.
+func (e *Engine) derived() []augment.DerivedAction {
+	return augment.DeriveAll(e.actions.List())
+}

--- a/internal/intercept/intercept_test.go
+++ b/internal/intercept/intercept_test.go
@@ -680,3 +680,464 @@ func TestAgentRequestedStreaming_Detects(t *testing.T) {
 		t.Error("expected false on malformed body")
 	}
 }
+
+func TestSetStream_RejectsMalformedBody(t *testing.T) {
+	if _, err := setStream([]byte(`not-json`), false); err == nil {
+		t.Error("expected error on malformed body")
+	}
+}
+
+func TestCopyForwardableHeaders_DropsHopByHop(t *testing.T) {
+	src := http.Header{}
+	src.Set("Authorization", "Bearer x")
+	src.Set("X-Custom", "keep")
+	src.Set("Connection", "close")        // hop-by-hop
+	src.Set("Keep-Alive", "timeout=5")    // hop-by-hop
+	src.Set("Transfer-Encoding", "chunked") // hop-by-hop
+	src.Set("Content-Length", "100")      // explicitly stripped
+	src.Set("Host", "x.example")          // explicitly stripped
+
+	dst := http.Header{}
+	copyForwardableHeaders(src, dst)
+
+	if dst.Get("Authorization") != "Bearer x" {
+		t.Error("Authorization not forwarded")
+	}
+	if dst.Get("X-Custom") != "keep" {
+		t.Error("X-Custom not forwarded")
+	}
+	for _, k := range []string{"Connection", "Keep-Alive", "Transfer-Encoding", "Content-Length", "Host"} {
+		if dst.Get(k) != "" {
+			t.Errorf("%s should not be forwarded", k)
+		}
+	}
+}
+
+func TestPassThrough_FiltersHopByHop(t *testing.T) {
+	headers := http.Header{}
+	headers.Set("Content-Type", "application/json")
+	headers.Set("Connection", "close")
+	headers.Set("X-Upstream-ID", "abc")
+
+	w := httptest.NewRecorder()
+	passThrough(w, http.StatusTeapot, headers, []byte(`{"x":1}`))
+
+	if w.Code != http.StatusTeapot {
+		t.Errorf("status = %d, want 418", w.Code)
+	}
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Error("Content-Type not propagated")
+	}
+	if w.Header().Get("X-Upstream-ID") != "abc" {
+		t.Error("X-Upstream-ID not propagated")
+	}
+	if w.Header().Get("Connection") != "" {
+		t.Error("Connection should not be propagated")
+	}
+}
+
+// --- OpenAI: invalid JSON request body fails augmentation ---
+
+func TestHandleOpenAI_InvalidJSONBody_Returns400(t *testing.T) {
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("upstream should not be reached when augmentation fails")
+	}))
+	t.Cleanup(srv.Close)
+	e := engineFor(t, srv.URL, "", store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{not-json`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "invalid_request") {
+		t.Errorf("body = %s, want invalid_request error", w.Body.String())
+	}
+}
+
+// --- OpenAI: upstream connection failure → 502 ---
+
+func TestHandleOpenAI_UpstreamUnreachable_Returns502(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	upstreamURL := srv.URL
+	srv.Close()
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, upstreamURL, "", store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "upstream_error") {
+		t.Errorf("body = %s, want upstream_error code", w.Body.String())
+	}
+}
+
+// --- OpenAI: executor returning a fatal error → 500 ---
+
+type erroringExecutor struct {
+	err error
+}
+
+func (e erroringExecutor) Execute(_ context.Context, _ string, _ map[string]any) (action.Result, error) {
+	return action.Result{}, e.err
+}
+
+func TestHandleOpenAI_ExecutorFatalError_Returns500(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"c","type":"function","function":{"name":"ship_update","arguments":"{}"}}]}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := erroringExecutor{err: fmt.Errorf("connector unavailable")}
+	e := engineFor(t, upstream.URL, "", store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "executor_error") {
+		t.Errorf("body = %s, want executor_error code", w.Body.String())
+	}
+}
+
+// =====================================================================
+// Anthropic-side parity tests
+// =====================================================================
+
+// --- Anthropic: gateway not configured ---
+
+func TestHandleAnthropic_UpstreamNotConfigured_Returns503(t *testing.T) {
+	store := loadStore(t, nil)
+	e := engineFor(t, "", "", store, nil)
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1,"messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+// --- Anthropic: invalid JSON body ---
+
+func TestHandleAnthropic_InvalidJSONBody_Returns400(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		t.Errorf("upstream should not be reached")
+	}))
+	t.Cleanup(srv.Close)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", srv.URL, store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{not-json`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusBadRequest {
+		t.Errorf("status = %d, want 400", w.Code)
+	}
+}
+
+// --- Anthropic: upstream unreachable ---
+
+func TestHandleAnthropic_UpstreamUnreachable_Returns502(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {}))
+	upstreamURL := srv.URL
+	srv.Close()
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", upstreamURL, store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1,"messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", w.Code)
+	}
+}
+
+// --- Anthropic: upstream non-200 propagates ---
+
+func TestHandleAnthropic_UpstreamErrorPassesThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"type":"error","error":{"type":"authentication_error","message":"bad key"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", srv.URL, store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1,"messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (passed through)", w.Code)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("bad key")) {
+		t.Errorf("body lost upstream message: %s", w.Body.String())
+	}
+}
+
+// --- Anthropic: executor fatal error ---
+
+func TestHandleAnthropic_ExecutorFatalError_Returns500(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"m1","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"tu","name":"ship_update","input":{}}],"stop_reason":"tool_use"}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := erroringExecutor{err: fmt.Errorf("nope")}
+	e := engineFor(t, "", upstream.URL, store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1,"messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusInternalServerError {
+		t.Errorf("status = %d, want 500", w.Code)
+	}
+}
+
+// --- Anthropic: mixed tool uses → 502 ---
+
+func TestHandleAnthropic_MixedToolUses_Returns502(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"m1","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"a","name":"ship_update","input":{}},{"type":"tool_use","id":"b","name":"agent_thing","input":{}}],"stop_reason":"tool_use"}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", upstream.URL, store, nil)
+
+	body := `{"model":"c","max_tokens":1,"messages":[],"tools":[{"name":"agent_thing","input_schema":{"type":"object"}}]}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 (mixed unsupported)", w.Code)
+	}
+}
+
+// --- Anthropic: agent's tool_use passes through ---
+
+func TestHandleAnthropic_AgentToolUsePassesThrough(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"m1","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"a","name":"agent_thing","input":{}}],"stop_reason":"tool_use"}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{}
+	e := engineFor(t, "", upstream.URL, store, exec)
+
+	body := `{"model":"c","max_tokens":1,"messages":[],"tools":[{"name":"agent_thing","input_schema":{"type":"object"}}]}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"name":"agent_thing"`) {
+		t.Errorf("agent should see its own tool_use; got %s", w.Body.String())
+	}
+	if len(exec.calls) != 0 {
+		t.Errorf("executor called %d times for agent's tool; want 0", len(exec.calls))
+	}
+}
+
+// --- Anthropic: max rounds cap ---
+
+func TestHandleAnthropic_MaxRoundsCap(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"m","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"t","name":"ship_update","input":{}}],"stop_reason":"tool_use"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", srv.URL, store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1,"messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 (max rounds)", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "max_intercept_rounds") {
+		t.Errorf("body = %s, want max_intercept_rounds error code", w.Body.String())
+	}
+}
+
+// --- Anthropic: multi-turn ---
+
+func TestHandleAnthropic_MultiTurnInterception(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"m1","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"t1","name":"ship_update","input":{"channel":"#x"}}],"stop_reason":"tool_use"}`,
+		`{"id":"m2","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"t2","name":"file_bug","input":{"title":"bug"}}],"stop_reason":"tool_use"}`,
+		`{"id":"m3","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"Done."}],"stop_reason":"end_turn"}`,
+	)
+	store := loadStore(t, map[string]string{
+		"ship-update.md": shipUpdateAction,
+		"file-bug.md":    fileBugAction,
+	})
+	exec := &staticExecutor{result: action.Result{Content: `{"ok":true}`}}
+	e := engineFor(t, "", upstream.URL, store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1,"messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"text":"Done."`) {
+		t.Errorf("agent didn't see final text: %s", w.Body.String())
+	}
+	if len(exec.calls) != 2 {
+		t.Errorf("executor called %d times; want 2", len(exec.calls))
+	}
+}
+
+// --- Anthropic: action error → tool_result with is_error ---
+
+// --- Upstream returns 200 but unparseable shape → passThrough ---
+
+func TestHandleOpenAI_UpstreamShapeUnparseable_PassesThrough(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t, `{}`)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, upstream.URL, "", store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (passThrough)", w.Code)
+	}
+	if w.Body.String() != `{}` {
+		t.Errorf("body = %q, want passthrough of upstream %q", w.Body.String(), `{}`)
+	}
+}
+
+func TestHandleAnthropic_UpstreamShapeUnparseable_PassesThrough(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t, `{"not":"a message"}`)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", upstream.URL, store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1,"messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 (passThrough)", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), `"a message"`) {
+		t.Errorf("body lost upstream payload: %s", w.Body.String())
+	}
+}
+
+// --- Streaming fallback when terminal response can't be reshaped ---
+
+func TestEmitOpenAITerminal_StreamingFallbackOnUnparseableBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	emitOpenAITerminal(w, []byte(`not-json`), true /*wantStream*/)
+	// Falls back to JSON when chunk synthesis fails — at least the
+	// raw upstream body reaches the agent.
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json (fallback)", w.Header().Get("Content-Type"))
+	}
+	if w.Body.String() != "not-json" {
+		t.Errorf("body = %q, want fallback raw passthrough", w.Body.String())
+	}
+}
+
+func TestEmitAnthropicTerminal_StreamingFallbackOnUnparseableBody(t *testing.T) {
+	w := httptest.NewRecorder()
+	emitAnthropicTerminal(w, []byte(`not-json`), true /*wantStream*/)
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json (fallback)", w.Header().Get("Content-Type"))
+	}
+}
+
+func TestEmitAnthropicTerminal_StreamingFallbackOnMissingContent(t *testing.T) {
+	// Valid JSON but no `content` field — anthropicEventsFromMessage
+	// returns an error and the helper falls back to JSON.
+	w := httptest.NewRecorder()
+	emitAnthropicTerminal(w, []byte(`{"id":"x","type":"message"}`), true /*wantStream*/)
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q, want application/json fallback", w.Header().Get("Content-Type"))
+	}
+}
+
+func TestOpenAIChunksFromCompletion_ErrorOnNoChoices(t *testing.T) {
+	if _, err := openAIChunksFromCompletion([]byte(`{"id":"x"}`)); err == nil {
+		t.Error("expected error when response has no choices")
+	}
+}
+
+func TestAnthropicEventsFromMessage_ErrorOnInvalidJSON(t *testing.T) {
+	if _, err := anthropicEventsFromMessage([]byte(`not-json`)); err == nil {
+		t.Error("expected error decoding malformed JSON")
+	}
+}
+
+func TestParseAnthropicResponse_ErrorOnInvalidJSON(t *testing.T) {
+	_, _, err := parseAnthropicResponse([]byte(`not-json`))
+	if err == nil {
+		t.Error("expected error decoding malformed JSON")
+	}
+}
+
+func TestParseAnthropicResponse_ErrorOnWrongType(t *testing.T) {
+	_, _, err := parseAnthropicResponse([]byte(`{"type":"error"}`))
+	if err == nil {
+		t.Error("expected error when type != message")
+	}
+}
+
+func TestHandleAnthropic_ActionErrorBecomesIsError(t *testing.T) {
+	upstream, captured := newScriptedUpstream(t,
+		`{"id":"m1","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"t","name":"ship_update","input":{}}],"stop_reason":"tool_use"}`,
+		`{"id":"m2","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"Got error."}],"stop_reason":"end_turn"}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{result: action.Result{Content: "rate limited", IsError: true}}
+	e := engineFor(t, "", upstream.URL, store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1,"messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	contMessages, _ := captured.captured[1]["messages"].([]any)
+	user := contMessages[len(contMessages)-1].(map[string]any)
+	blocks := user["content"].([]any)
+	first := blocks[0].(map[string]any)
+	if first["is_error"] != true {
+		t.Errorf("tool_result.is_error = %v, want true", first["is_error"])
+	}
+}

--- a/internal/intercept/intercept_test.go
+++ b/internal/intercept/intercept_test.go
@@ -1,0 +1,682 @@
+package intercept
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/action"
+)
+
+// Stage 4 contract (#370, ratified by ADR-0008):
+//
+//   - When the upstream LLM emits a tool call targeting an
+//     Aileron-augmented action, the engine intercepts it, executes the
+//     action, injects the synthetic tool result, and continues with a
+//     fresh upstream call until the LLM produces a final assistant
+//     message.
+//   - Tool calls for agent-declared tools pass through unchanged.
+//   - Multi-turn (tool A → result → tool B → result → final) works.
+//   - Action execution failures surface as tool-result errors per
+//     ADR-0010, not as gateway 5xxs.
+//   - Streaming preservation — tool-call deltas buffered until
+//     complete; result injection doesn't break the agent's streaming
+//     contract.
+//
+// The tests below drive the engine end-to-end against a stateful
+// fake upstream so they exercise the same code path the live gateway
+// will see.
+
+// --- fixtures ---
+
+const shipUpdateAction = `+++
+name = "ship-update"
+version = "1.0.0"
+source = "hub://aileron/ship-update@1.0.0"
+
+[[requires.connectors]]
+name = "github://aileron/slack"
+version = "1.2.0"
+hash = "sha256:abc"
+capabilities = ["chat:write"]
+
+[match]
+intent = "tell team I shipped"
+
+[[inputs]]
+name = "channel"
+type = "string"
+description = "Slack channel."
+
+[[execute]]
+id = "post"
+connector = "github://aileron/slack"
+op = "post_message"
+
+[execute.inputs]
+channel = "${args.channel}"
++++
+
+# Ship Update
+
+Posts a 'shipped' announcement to a Slack channel.
+`
+
+const fileBugAction = `+++
+name = "file-bug"
+version = "1.0.0"
+source = "hub://aileron/file-bug@1.0.0"
+
+[[requires.connectors]]
+name = "github://aileron/linear"
+version = "1.0.0"
+hash = "sha256:def"
+capabilities = ["issues:write"]
+
+[match]
+intent = "file a bug"
+
+[[inputs]]
+name = "title"
+type = "string"
+description = "Issue title."
+
+[[execute]]
+id = "create"
+connector = "github://aileron/linear"
+op = "issue_create"
+
+[execute.inputs]
+title = "${args.title}"
++++
+
+# File Bug
+`
+
+// loadStore writes the given manifests to a temp dir, loads them
+// into a store, and returns the populated store.
+func loadStore(t *testing.T, manifests map[string]string) *action.Store {
+	t.Helper()
+	dir := t.TempDir()
+	for filename, body := range manifests {
+		path := filepath.Join(dir, filename)
+		if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+			t.Fatalf("write fixture: %v", err)
+		}
+	}
+	s := action.NewStore(dir)
+	res, err := s.Load()
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	if res.HasErrors() {
+		t.Fatalf("load errors: %+v", res.Errors)
+	}
+	return s
+}
+
+// staticExecutor returns a fixed Result for any call.
+type staticExecutor struct {
+	result action.Result
+	calls  []struct {
+		Name string
+		Args map[string]any
+	}
+}
+
+func (s *staticExecutor) Execute(_ context.Context, name string, args map[string]any) (action.Result, error) {
+	s.calls = append(s.calls, struct {
+		Name string
+		Args map[string]any
+	}{Name: name, Args: args})
+	return s.result, nil
+}
+
+// scriptedUpstream serves a sequence of pre-canned JSON responses,
+// one per request, capturing each request body as it goes. Tests use
+// it to assert what the engine sent upstream and what it forwarded
+// back to the agent.
+type scriptedUpstream struct {
+	t         *testing.T
+	responses []string
+	captured  []map[string]any
+	calls     int
+}
+
+func newScriptedUpstream(t *testing.T, responses ...string) (*httptest.Server, *scriptedUpstream) {
+	t.Helper()
+	s := &scriptedUpstream{t: t, responses: responses}
+	srv := httptest.NewServer(s)
+	t.Cleanup(srv.Close)
+	return srv, s
+}
+
+func (s *scriptedUpstream) ServeHTTP(w http.ResponseWriter, r *http.Request) {
+	body, _ := io.ReadAll(r.Body)
+	var decoded map[string]any
+	if err := json.Unmarshal(body, &decoded); err != nil {
+		s.t.Errorf("upstream received non-JSON body: %s", body)
+	}
+	s.captured = append(s.captured, decoded)
+	idx := s.calls
+	if idx >= len(s.responses) {
+		s.t.Errorf("upstream call #%d but only %d scripted responses", idx+1, len(s.responses))
+		http.Error(w, "no more responses", http.StatusInternalServerError)
+		return
+	}
+	s.calls++
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(http.StatusOK)
+	w.Write([]byte(s.responses[idx]))
+}
+
+// engineFor builds an Engine wired to the given upstreams, action
+// store, and executor. Defaults to StubExecutor when exec is nil.
+func engineFor(t *testing.T, openAIURL, anthropicURL string, store *action.Store, exec action.Executor) *Engine {
+	t.Helper()
+	var oa, an *url.URL
+	if openAIURL != "" {
+		u, _ := url.Parse(openAIURL)
+		oa = u
+	}
+	if anthropicURL != "" {
+		u, _ := url.Parse(anthropicURL)
+		an = u
+	}
+	if exec == nil {
+		exec = action.StubExecutor{}
+	}
+	e, err := New(Config{
+		OpenAIUpstream:    oa,
+		AnthropicUpstream: an,
+		Actions:           store,
+		Executor:          exec,
+	})
+	if err != nil {
+		t.Fatalf("intercept.New: %v", err)
+	}
+	return e
+}
+
+// --- engine construction ---
+
+func TestNew_RequiresActions(t *testing.T) {
+	if _, err := New(Config{Executor: action.StubExecutor{}}); err == nil {
+		t.Error("expected error when Actions is nil")
+	}
+}
+
+func TestNew_RequiresExecutor(t *testing.T) {
+	store := loadStore(t, nil)
+	if _, err := New(Config{Actions: store}); err == nil {
+		t.Error("expected error when Executor is nil")
+	}
+}
+
+// --- OpenAI: gateway not configured ---
+
+func TestHandleOpenAI_UpstreamNotConfigured_Returns503(t *testing.T) {
+	store := loadStore(t, nil)
+	e := engineFor(t, "", "", store, nil)
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+	if w.Code != http.StatusServiceUnavailable {
+		t.Errorf("status = %d, want 503", w.Code)
+	}
+}
+
+// --- OpenAI: passthrough when LLM picks no tool ---
+
+func TestHandleOpenAI_NoToolCall_PassesResponseThrough(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"chatcmpl-1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Hello there!"}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, upstream.URL, "", store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`))
+	r.Header.Set("Authorization", "Bearer sk-test")
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	choices, _ := resp["choices"].([]any)
+	msg := choices[0].(map[string]any)["message"].(map[string]any)
+	if msg["content"] != "Hello there!" {
+		t.Errorf("content = %v, want passthrough", msg["content"])
+	}
+}
+
+// --- OpenAI: tool-call interception (single round) ---
+
+func TestHandleOpenAI_InterceptsAileronToolCall(t *testing.T) {
+	// Round 1: LLM picks ship_update. Round 2: LLM produces final text.
+	upstream, captured := newScriptedUpstream(t,
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"ship_update","arguments":"{\"channel\":\"#engineering\"}"}}]}}]}`,
+		`{"id":"r2","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Posted to #engineering."}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{result: action.Result{Content: `{"posted":true,"ts":"123"}`}}
+	e := engineFor(t, upstream.URL, "", store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"tell team I shipped"}]}`))
+	r.Header.Set("Authorization", "Bearer sk-test")
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	// Agent should see the FINAL assistant message, never the tool call.
+	var resp map[string]any
+	if err := json.NewDecoder(w.Body).Decode(&resp); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	choices, _ := resp["choices"].([]any)
+	msg := choices[0].(map[string]any)["message"].(map[string]any)
+	if msg["content"] != "Posted to #engineering." {
+		t.Errorf("content = %v, want final text", msg["content"])
+	}
+	if _, hasToolCalls := msg["tool_calls"]; hasToolCalls {
+		t.Error("agent saw tool_calls; should have been intercepted server-side")
+	}
+
+	// Executor was called exactly once with the LLM's args.
+	if len(exec.calls) != 1 {
+		t.Fatalf("executor calls = %d, want 1", len(exec.calls))
+	}
+	if exec.calls[0].Name != "ship_update" {
+		t.Errorf("called name = %q, want ship_update", exec.calls[0].Name)
+	}
+	if exec.calls[0].Args["channel"] != "#engineering" {
+		t.Errorf("called args.channel = %v, want #engineering", exec.calls[0].Args["channel"])
+	}
+
+	// Continuation request must include the assistant tool-call message
+	// AND the synthesized tool result.
+	if len(captured.captured) != 2 {
+		t.Fatalf("upstream calls = %d, want 2 (initial + continuation)", len(captured.captured))
+	}
+	contMessages, _ := captured.captured[1]["messages"].([]any)
+	if len(contMessages) < 3 {
+		t.Fatalf("continuation messages = %d, want ≥3 (user + assistant + tool)", len(contMessages))
+	}
+	last := contMessages[len(contMessages)-1].(map[string]any)
+	if last["role"] != "tool" {
+		t.Errorf("last message role = %v, want tool", last["role"])
+	}
+	if !strings.Contains(fmt.Sprintf("%v", last["content"]), "posted") {
+		t.Errorf("last message content = %v, expected executor's result", last["content"])
+	}
+}
+
+// --- OpenAI: agent-declared tool passes through ---
+
+func TestHandleOpenAI_AgentToolCallPassesThrough(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"agent_search","arguments":"{}"}}]}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{}
+	e := engineFor(t, upstream.URL, "", store, exec)
+
+	body := `{"model":"gpt-4","messages":[],"tools":[{"type":"function","function":{"name":"agent_search","description":"agent's"}}]}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	// Agent sees the tool_call to handle locally.
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	choices, _ := resp["choices"].([]any)
+	msg := choices[0].(map[string]any)["message"].(map[string]any)
+	if _, hasToolCalls := msg["tool_calls"]; !hasToolCalls {
+		t.Error("agent should see tool_calls for its own tool; got message without tool_calls")
+	}
+	if len(exec.calls) != 0 {
+		t.Errorf("executor called %d times for agent's tool; want 0", len(exec.calls))
+	}
+}
+
+// --- OpenAI: multi-turn (action A → result → action B → result → final) ---
+
+func TestHandleOpenAI_MultiTurnInterception(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		// Round 1: ship_update
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"c1","type":"function","function":{"name":"ship_update","arguments":"{\"channel\":\"#eng\"}"}}]}}]}`,
+		// Round 2: file_bug
+		`{"id":"r2","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"c2","type":"function","function":{"name":"file_bug","arguments":"{\"title\":\"oops\"}"}}]}}]}`,
+		// Round 3: final
+		`{"id":"r3","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Done!"}}]}`,
+	)
+	store := loadStore(t, map[string]string{
+		"ship-update.md": shipUpdateAction,
+		"file-bug.md":    fileBugAction,
+	})
+	exec := &staticExecutor{result: action.Result{Content: `{"ok":true}`}}
+	e := engineFor(t, upstream.URL, "", store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"go"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	var resp map[string]any
+	json.NewDecoder(w.Body).Decode(&resp)
+	choices, _ := resp["choices"].([]any)
+	msg := choices[0].(map[string]any)["message"].(map[string]any)
+	if msg["content"] != "Done!" {
+		t.Errorf("content = %v, want Done!", msg["content"])
+	}
+	if len(exec.calls) != 2 {
+		t.Errorf("executor called %d times; want 2 (ship_update, file_bug)", len(exec.calls))
+	}
+}
+
+// --- OpenAI: action error surfaces as tool-result, not gateway 5xx ---
+
+func TestHandleOpenAI_ActionErrorBecomesToolResultError(t *testing.T) {
+	// Round 1: tool call. Round 2: final after error result.
+	upstream, captured := newScriptedUpstream(t,
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"ship_update","arguments":"{\"channel\":\"#x\"}"}}]}}]}`,
+		`{"id":"r2","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Got an error from the action."}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{result: action.Result{Content: "rate limited", IsError: true}}
+	e := engineFor(t, upstream.URL, "", store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"ship"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (action errors are tool-results, not gateway 5xxs)", w.Code)
+	}
+	contMessages, _ := captured.captured[1]["messages"].([]any)
+	last := contMessages[len(contMessages)-1].(map[string]any)
+	content, _ := last["content"].(string)
+	if !strings.Contains(content, "error") || !strings.Contains(content, "rate limited") {
+		t.Errorf("error content not surfaced to LLM: %v", content)
+	}
+}
+
+// --- OpenAI: streaming response synthesized when agent asked for it ---
+
+func TestHandleOpenAI_StreamingResponseEmittedAsSSE(t *testing.T) {
+	upstream, captured := newScriptedUpstream(t,
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Hi!"}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, upstream.URL, "", store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}],"stream":true}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if !strings.HasPrefix(w.Header().Get("Content-Type"), "text/event-stream") {
+		t.Errorf("Content-Type = %q, want text/event-stream", w.Header().Get("Content-Type"))
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, `"content":"Hi!"`) {
+		t.Errorf("SSE body missing assistant content; got %s", body)
+	}
+	if !strings.Contains(body, "data: [DONE]") {
+		t.Errorf("SSE body missing [DONE] terminator; got %s", body)
+	}
+	// Engine forces upstream stream=false during intercept rounds.
+	streamFlag, _ := captured.captured[0]["stream"].(bool)
+	if streamFlag {
+		t.Error("upstream received stream=true; engine should force stream=false on intercept rounds")
+	}
+}
+
+// --- OpenAI: upstream non-200 propagates ---
+
+func TestHandleOpenAI_UpstreamErrorPassesThrough(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":{"message":"bad key"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, srv.URL, "", store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusUnauthorized {
+		t.Errorf("status = %d, want 401 (upstream propagated)", w.Code)
+	}
+	if !bytes.Contains(w.Body.Bytes(), []byte("bad key")) {
+		t.Errorf("body lost upstream message: %s", w.Body.String())
+	}
+}
+
+// --- OpenAI: mixed tool calls in one response → 502 ---
+
+func TestHandleOpenAI_MixedToolCalls_Returns502(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"a","type":"function","function":{"name":"ship_update","arguments":"{}"}},{"id":"b","type":"function","function":{"name":"agent_thing","arguments":"{}"}}]}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, upstream.URL, "", store, nil)
+
+	body := `{"model":"gpt-4","messages":[],"tools":[{"type":"function","function":{"name":"agent_thing"}}]}`
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions", strings.NewReader(body))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 (mixed unsupported)", w.Code)
+	}
+}
+
+// --- OpenAI: max rounds cap ---
+
+func TestHandleOpenAI_MaxRoundsCap(t *testing.T) {
+	// Always returns a tool_calls response, never finishes.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.Write([]byte(`{"id":"x","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"c","type":"function","function":{"name":"ship_update","arguments":"{}"}}]}}]}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, srv.URL, "", store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502 (max rounds)", w.Code)
+	}
+	if !strings.Contains(w.Body.String(), "max_intercept_rounds") {
+		t.Errorf("body = %s, want max_intercept_rounds error code", w.Body.String())
+	}
+}
+
+// --- Anthropic: passthrough when no tool_use ---
+
+func TestHandleAnthropic_NoToolUse_PassesThrough(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"msg_x","type":"message","role":"assistant","model":"claude-sonnet-4-6","content":[{"type":"text","text":"Hi!"}],"stop_reason":"end_turn"}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", upstream.URL, store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"claude-sonnet-4-6","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"text":"Hi!"`) {
+		t.Errorf("body lost upstream content: %s", w.Body.String())
+	}
+}
+
+// --- Anthropic: tool_use interception ---
+
+func TestHandleAnthropic_InterceptsAileronToolUse(t *testing.T) {
+	upstream, captured := newScriptedUpstream(t,
+		`{"id":"msg1","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"tu_1","name":"ship_update","input":{"channel":"#eng"}}],"stop_reason":"tool_use"}`,
+		`{"id":"msg2","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"Posted!"}],"stop_reason":"end_turn"}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{result: action.Result{Content: `{"posted":true}`}}
+	e := engineFor(t, "", upstream.URL, store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1024,"messages":[{"role":"user","content":"ship"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if !strings.Contains(w.Body.String(), `"text":"Posted!"`) {
+		t.Errorf("agent didn't see final text: %s", w.Body.String())
+	}
+	if strings.Contains(w.Body.String(), `"tool_use"`) {
+		t.Error("agent saw tool_use; should have been intercepted")
+	}
+	if len(exec.calls) != 1 {
+		t.Errorf("executor calls = %d, want 1", len(exec.calls))
+	}
+	// Continuation includes assistant + user(tool_result) messages.
+	contMessages, _ := captured.captured[1]["messages"].([]any)
+	if len(contMessages) < 3 {
+		t.Fatalf("continuation messages = %d, want ≥3", len(contMessages))
+	}
+	user := contMessages[len(contMessages)-1].(map[string]any)
+	if user["role"] != "user" {
+		t.Errorf("expected synthesized user message; got role=%v", user["role"])
+	}
+	contentBlocks := user["content"].([]any)
+	if contentBlocks[0].(map[string]any)["type"] != "tool_result" {
+		t.Errorf("expected tool_result block; got %v", contentBlocks[0])
+	}
+}
+
+// --- Anthropic: streaming SSE emission ---
+
+func TestHandleAnthropic_StreamingEmittedAsSSE(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"msg_x","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"Hi!"}],"stop_reason":"end_turn"}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", upstream.URL, store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1024,"messages":[],"stream":true}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if !strings.HasPrefix(w.Header().Get("Content-Type"), "text/event-stream") {
+		t.Errorf("Content-Type = %q, want text/event-stream", w.Header().Get("Content-Type"))
+	}
+	body := w.Body.String()
+	if !strings.Contains(body, "event: message_start") {
+		t.Errorf("SSE missing message_start: %s", body)
+	}
+	if !strings.Contains(body, "event: message_stop") {
+		t.Errorf("SSE missing message_stop: %s", body)
+	}
+}
+
+// --- OpenAI: invalid LLM JSON args become tool-result errors ---
+
+func TestHandleOpenAI_InvalidArgsJSON_BecomesToolResultError(t *testing.T) {
+	upstream, captured := newScriptedUpstream(t,
+		// Round 1: tool call with malformed JSON arguments
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"c","type":"function","function":{"name":"ship_update","arguments":"{not-json"}}]}}]}`,
+		`{"id":"r2","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Sorry."}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{}
+	e := engineFor(t, upstream.URL, "", store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; bad-args should surface as tool-result error", w.Code)
+	}
+	// Executor should NOT have been called — invalid JSON skips it.
+	if len(exec.calls) != 0 {
+		t.Errorf("executor calls = %d, want 0 (bad args skipped)", len(exec.calls))
+	}
+	// The continuation request's last message should be a tool error.
+	contMessages, _ := captured.captured[1]["messages"].([]any)
+	last := contMessages[len(contMessages)-1].(map[string]any)
+	content, _ := last["content"].(string)
+	if !strings.Contains(content, "error") || !strings.Contains(content, "invalid JSON") {
+		t.Errorf("error not surfaced; content=%v", content)
+	}
+}
+
+// --- Helpers tests ---
+
+func TestSetStream_Toggles(t *testing.T) {
+	in := []byte(`{"model":"x","stream":true}`)
+	out, err := setStream(in, false)
+	if err != nil {
+		t.Fatalf("setStream: %v", err)
+	}
+	var got map[string]any
+	json.Unmarshal(out, &got)
+	if got["stream"] != false {
+		t.Errorf("stream = %v, want false", got["stream"])
+	}
+}
+
+func TestAgentRequestedStreaming_Detects(t *testing.T) {
+	if !agentRequestedStreaming([]byte(`{"stream":true}`)) {
+		t.Error("expected true for stream=true")
+	}
+	if agentRequestedStreaming([]byte(`{"stream":false}`)) {
+		t.Error("expected false for stream=false")
+	}
+	if agentRequestedStreaming([]byte(`{}`)) {
+		t.Error("expected false when stream is absent")
+	}
+	if agentRequestedStreaming([]byte(`not-json`)) {
+		t.Error("expected false on malformed body")
+	}
+}

--- a/internal/intercept/openai.go
+++ b/internal/intercept/openai.go
@@ -1,0 +1,389 @@
+package intercept
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/action"
+	"github.com/ALRubinger/aileron/internal/augment"
+)
+
+// HandleOpenAI runs the augmentation + interception loop for an
+// OpenAI Chat Completions request. The request body is read once,
+// augmented with installed actions, and forwarded upstream. The
+// upstream response is parsed; tool calls targeting Aileron-owned
+// names are executed via the engine's Executor and the conversation
+// continues with a fresh upstream call until the LLM produces a
+// terminal assistant message. The final message is then written back
+// to the agent — either as JSON or as a single-shot SSE stream
+// depending on whether the original request set `stream: true`.
+//
+// Note: during intercept rounds the engine forces upstream `stream:
+// false` so the per-round response is a single JSON document.
+// The agent still sees a streaming response (synthesized as SSE)
+// when it asked for one. True upstream-side streaming preservation
+// for non-intercepted text deltas is a future optimization.
+func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
+	if e.openAIUpstream == nil {
+		writeError(w, http.StatusServiceUnavailable, "gateway_not_configured",
+			"OpenAI gateway upstream is not configured")
+		return
+	}
+
+	origBody, err := io.ReadAll(r.Body)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"failed to read request body: "+err.Error())
+		return
+	}
+	_ = r.Body.Close()
+
+	// Detect whether the agent asked for streaming so we can shape
+	// the final response correspondingly. We don't fail when the
+	// body is non-JSON; the upstream will be the authority on that.
+	wantStream := agentRequestedStreaming(origBody)
+
+	derived := e.derived()
+	aug, err := augment.AugmentOpenAI(origBody, derived, e.log)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"failed to augment request: "+err.Error())
+		return
+	}
+
+	// Force non-streaming upstream during intercept rounds so we get
+	// a single parsable JSON document per round. The engine
+	// synthesizes streaming back to the agent when needed.
+	currentBody, err := setStream(aug.Body, false)
+	if err != nil {
+		writeError(w, http.StatusBadRequest, "invalid_request",
+			"failed to prepare upstream body: "+err.Error())
+		return
+	}
+
+	ourNames := nameSet(aug.OurNames)
+
+	for round := 0; round < maxRounds; round++ {
+		respStatus, respHeaders, respBody, err := e.sendOpenAI(r, currentBody)
+		if err != nil {
+			writeError(w, http.StatusBadGateway, "upstream_error",
+				"upstream OpenAI request failed: "+err.Error())
+			return
+		}
+		if respStatus != http.StatusOK {
+			passThrough(w, respStatus, respHeaders, respBody)
+			return
+		}
+
+		assistantMsg, toolCalls, err := parseOpenAIChoice(respBody)
+		if err != nil {
+			passThrough(w, respStatus, respHeaders, respBody)
+			return
+		}
+
+		ours, theirs := classifyOpenAIToolCalls(toolCalls, ourNames)
+
+		if len(ours) == 0 {
+			// No Aileron tool calls — terminal for this round.
+			// Either pure-text response or agent's tools to handle.
+			emitOpenAITerminal(w, respBody, wantStream)
+			return
+		}
+		if len(theirs) > 0 {
+			writeError(w, http.StatusBadGateway, "mixed_tool_calls_unsupported",
+				"the gateway does not yet support a single response that mixes Aileron tool calls with agent-declared tool calls")
+			return
+		}
+
+		toolMessages, execErr := e.executeOpenAIToolCalls(r.Context(), ours)
+		if execErr != nil {
+			writeError(w, http.StatusInternalServerError, "executor_error",
+				"action executor returned a fatal error: "+execErr.Error())
+			return
+		}
+
+		nextBody, err := appendOpenAIContinuation(currentBody, assistantMsg, toolMessages)
+		if err != nil {
+			writeError(w, http.StatusInternalServerError, "continuation_error",
+				"failed to build continuation request: "+err.Error())
+			return
+		}
+		currentBody = nextBody
+	}
+
+	writeError(w, http.StatusBadGateway, "max_intercept_rounds",
+		"interception loop exceeded maximum rounds; aborting to avoid infinite cycle")
+}
+
+// sendOpenAI POSTs the given body to the configured OpenAI upstream,
+// preserving auth-relevant request headers from the original request.
+// Returns status, response headers, and the full response body. The
+// caller is responsible for inspecting the status — non-200 responses
+// are returned without error so they can be propagated to the agent
+// unchanged.
+func (e *Engine) sendOpenAI(orig *http.Request, body []byte) (int, http.Header, []byte, error) {
+	target := *e.openAIUpstream
+	if target.Path == "" || target.Path == "/" {
+		target.Path = "/v1/chat/completions"
+	} else {
+		target.Path = strings.TrimRight(target.Path, "/") + "/v1/chat/completions"
+	}
+	req, err := http.NewRequestWithContext(orig.Context(), http.MethodPost, target.String(), bytes.NewReader(body))
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	copyForwardableHeaders(orig.Header, req.Header)
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := e.httpClient.Do(req)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	defer resp.Body.Close()
+	respBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	return resp.StatusCode, resp.Header.Clone(), respBody, nil
+}
+
+// parseOpenAIChoice extracts the first choice's assistant message and
+// tool_calls (if any) from a non-streamed Chat Completions response.
+func parseOpenAIChoice(body []byte) (assistantMsg map[string]any, toolCalls []map[string]any, err error) {
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, nil, err
+	}
+	choices, _ := resp["choices"].([]any)
+	if len(choices) == 0 {
+		return nil, nil, errors.New("response has no choices")
+	}
+	choice0, _ := choices[0].(map[string]any)
+	if choice0 == nil {
+		return nil, nil, errors.New("choice[0] is not an object")
+	}
+	msg, _ := choice0["message"].(map[string]any)
+	if msg == nil {
+		return nil, nil, errors.New("choice[0].message missing")
+	}
+	rawCalls, _ := msg["tool_calls"].([]any)
+	for _, rc := range rawCalls {
+		tc, ok := rc.(map[string]any)
+		if !ok {
+			continue
+		}
+		toolCalls = append(toolCalls, tc)
+	}
+	return msg, toolCalls, nil
+}
+
+// classifyOpenAIToolCalls partitions tool calls into Aileron-owned
+// and agent-declared based on the post-collision name set.
+func classifyOpenAIToolCalls(calls []map[string]any, ours map[string]bool) (mine, theirs []map[string]any) {
+	for _, tc := range calls {
+		fn, _ := tc["function"].(map[string]any)
+		name, _ := fn["name"].(string)
+		if ours[name] {
+			mine = append(mine, tc)
+		} else {
+			theirs = append(theirs, tc)
+		}
+	}
+	return mine, theirs
+}
+
+// executeOpenAIToolCalls runs each Aileron tool call through the
+// engine's Executor and produces the matching `tool` role messages
+// to inject into the continuation request.
+func (e *Engine) executeOpenAIToolCalls(ctx context.Context, calls []map[string]any) ([]map[string]any, error) {
+	out := make([]map[string]any, 0, len(calls))
+	for _, tc := range calls {
+		id, _ := tc["id"].(string)
+		fn, _ := tc["function"].(map[string]any)
+		name, _ := fn["name"].(string)
+		argsRaw, _ := fn["arguments"].(string)
+
+		args := map[string]any{}
+		if argsRaw != "" {
+			if err := json.Unmarshal([]byte(argsRaw), &args); err != nil {
+				// LLM produced invalid JSON args. Surface this as a
+				// tool-result error so the LLM can correct, rather
+				// than failing the whole turn.
+				out = append(out, openAIErrorToolMessage(id, name,
+					fmt.Sprintf("invalid JSON arguments: %s", err.Error())))
+				continue
+			}
+		}
+
+		res, err := e.executor.Execute(ctx, name, args)
+		if err != nil {
+			return nil, err
+		}
+		content := res.Content
+		if res.IsError {
+			content = fmt.Sprintf(`{"error":true,"content":%s}`, jsonString(res.Content))
+		}
+		out = append(out, map[string]any{
+			"role":         "tool",
+			"tool_call_id": id,
+			"name":         name,
+			"content":      content,
+		})
+	}
+	return out, nil
+}
+
+// openAIErrorToolMessage builds a synthesized tool-result message
+// surfacing an action-side error to the LLM.
+func openAIErrorToolMessage(id, name, msg string) map[string]any {
+	return map[string]any{
+		"role":         "tool",
+		"tool_call_id": id,
+		"name":         name,
+		"content":      fmt.Sprintf(`{"error":true,"message":%s}`, jsonString(msg)),
+	}
+}
+
+// appendOpenAIContinuation builds the next-round request body by
+// appending the assistant message (with tool_calls) and the
+// synthesized tool messages to the existing `messages` array.
+func appendOpenAIContinuation(currentBody []byte, assistantMsg map[string]any, toolMessages []map[string]any) ([]byte, error) {
+	var req map[string]any
+	if err := json.Unmarshal(currentBody, &req); err != nil {
+		return nil, err
+	}
+	rawMessages, _ := req["messages"].([]any)
+	rawMessages = append(rawMessages, assistantMsg)
+	for _, tm := range toolMessages {
+		rawMessages = append(rawMessages, tm)
+	}
+	req["messages"] = rawMessages
+	return json.Marshal(req)
+}
+
+// emitOpenAITerminal writes the terminal assistant response to the
+// agent. When the agent requested streaming, the JSON response is
+// reshaped into a single-shot SSE stream that follows the OpenAI
+// chunk format.
+func emitOpenAITerminal(w http.ResponseWriter, body []byte, wantStream bool) {
+	if !wantStream {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+		return
+	}
+
+	chunks, err := openAIChunksFromCompletion(body)
+	if err != nil {
+		// Fall back to JSON delivery; the agent at worst sees a
+		// non-streaming response when it asked for streaming.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write(body)
+		return
+	}
+	w.Header().Set("Content-Type", "text/event-stream")
+	w.Header().Set("Cache-Control", "no-cache")
+	w.WriteHeader(http.StatusOK)
+	flusher, _ := w.(http.Flusher)
+	for _, c := range chunks {
+		fmt.Fprintf(w, "data: %s\n\n", c)
+		if flusher != nil {
+			flusher.Flush()
+		}
+	}
+	fmt.Fprint(w, "data: [DONE]\n\n")
+	if flusher != nil {
+		flusher.Flush()
+	}
+}
+
+// openAIChunksFromCompletion converts a non-streamed Chat Completions
+// response into the SSE chunk shape the agent expects. We emit two
+// chunks: one carrying the message content (or the tool_calls), and
+// a finish_reason chunk. This is sufficient for an agent that only
+// needs the final assistant message.
+func openAIChunksFromCompletion(body []byte) ([]string, error) {
+	var resp map[string]any
+	if err := json.Unmarshal(body, &resp); err != nil {
+		return nil, err
+	}
+	choices, _ := resp["choices"].([]any)
+	if len(choices) == 0 {
+		return nil, errors.New("no choices to stream")
+	}
+	choice0, _ := choices[0].(map[string]any)
+	msg, _ := choice0["message"].(map[string]any)
+	finishReason, _ := choice0["finish_reason"].(string)
+
+	id, _ := resp["id"].(string)
+	model, _ := resp["model"].(string)
+	created, _ := resp["created"].(float64)
+
+	delta := map[string]any{}
+	if role, ok := msg["role"]; ok {
+		delta["role"] = role
+	}
+	if content, ok := msg["content"]; ok && content != nil {
+		delta["content"] = content
+	}
+	if tc, ok := msg["tool_calls"]; ok && tc != nil {
+		delta["tool_calls"] = tc
+	}
+
+	first := map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": int64(created),
+		"model":   model,
+		"choices": []any{
+			map[string]any{
+				"index":         0,
+				"delta":         delta,
+				"finish_reason": nil,
+			},
+		},
+	}
+	last := map[string]any{
+		"id":      id,
+		"object":  "chat.completion.chunk",
+		"created": int64(created),
+		"model":   model,
+		"choices": []any{
+			map[string]any{
+				"index":         0,
+				"delta":         map[string]any{},
+				"finish_reason": finishReason,
+			},
+		},
+	}
+	firstJSON, err := json.Marshal(first)
+	if err != nil {
+		return nil, err
+	}
+	lastJSON, err := json.Marshal(last)
+	if err != nil {
+		return nil, err
+	}
+	return []string{string(firstJSON), string(lastJSON)}, nil
+}
+
+// jsonString returns the JSON-encoded form of s with surrounding
+// quotes — used to safely embed strings into hand-built JSON shapes
+// (where we don't want to round-trip through json.Marshal of the
+// containing object).
+func jsonString(s string) string {
+	b, _ := json.Marshal(s)
+	return string(b)
+}
+
+// _ keeps action import in scope for documentation; Executor is used
+// transitively via Engine.
+var _ = action.Result{}


### PR DESCRIPTION
## Summary

Stage 4 of the staged LLM gateway rollout (umbrella: #356; this PR closes #370).

Closes the loop on the deterministic-execution architecture ratified by [ADR-0008](https://docs.withaileron.ai/adr/0008-intent-matching). When the upstream LLM emits a tool call targeting an Aileron-augmented action, the gateway intercepts it, runs the action through an `Executor`, injects the synthetic tool result, and continues the conversation server-side until the LLM produces a final assistant message — invisible to the agent's host code.

### What's new

- **`internal/intercept` (new package).** `Engine` runs the augment + interception loop for both protocols:
  - **OpenAI** (non-streaming + synthesized SSE): augment → forward upstream → parse `tool_calls` → execute Aileron's via `Executor` → build continuation messages → loop until no Aileron tool calls.
  - **Anthropic** (mirror): same loop with `tool_use`/`tool_result` content blocks and synthesized `message_start` / `content_block_*` / `message_stop` SSE.
  - Force `stream: false` upstream during intercept rounds for parsable JSON; synthesize SSE back to the agent when they asked for streaming.
  - Classifies tool calls against the post-collision set of Aileron-owned names. Agent-declared tools pass through unchanged. Mixed responses (Aileron + agent in one message) return 502 as a documented limitation. Max 10 rounds to bound runaway loops.
  - Action errors (`Result.IsError`) flow back as tool-results per [ADR-0010](https://docs.withaileron.ai/adr/0010-failure-handling), not as gateway 5xxs.
- **`internal/action/executor.go` (new).** `Executor` interface + `StubExecutor` returning a placeholder JSON result. Real connector orchestration is a follow-up.
- **`internal/augment` refactor.** `AugmentOpenAI`/`AugmentAnthropic` now return `Augmented{Body, OurNames}` — `OurNames` is the post-collision list the intercept layer needs.
- **`internal/app/handlers_gateway.go`.** Route through `interceptEngine` when actions are installed; keep stage-2 transparent reverse proxy when not, preserving lossless SSE for the no-action case.

### Scope cap

This stage ships the **interception machinery**. Action execution is stubbed: `StubExecutor.Execute` returns placeholder JSON describing what would have run. The seam is well-defined (`action.Executor` interface), and a follow-up issue can wire the connector-orchestration runtime without touching this code.

Pre-LLM bypass (#371) is the only remaining stage.

## Test plan

- [x] `task generate:api` clean (no spec changes this PR)
- [x] `task build` succeeds
- [x] `task lint:go` clean
- [x] All internal package tests pass
- [x] Coverage: action 96%, augment 88%, intercept 78.7% — full e2e behavioral coverage with stateful fake upstreams
- [x] Tests cover: passthrough; single intercept; multi-turn (A→result→B→result→final); agent-tool passthrough; action error → tool-result error; invalid LLM JSON args → tool-result error (executor not called); mixed-tool-call rejection (502); max-rounds cap; upstream error propagation; streaming SSE emission for both protocols; helpers (setStream, agentRequestedStreaming)

Closes #370. Refs #356.

🤖 Generated with [Claude Code](https://claude.com/claude-code)