### PR TITLE
fix(docs): scrollable right sidebar and 2xl breakpoint

### DIFF
--- a/docs/src/components/TableOfContents.svelte
+++ b/docs/src/components/TableOfContents.svelte
@@ -41,7 +41,7 @@
 </script>
 
 {#if tocHeadings.length > 0}
-  <nav class="hidden xl:block w-56 shrink-0" aria-label="On this page">
+  <nav class="hidden 2xl:block w-56 shrink-0" aria-label="On this page">
     <div class="sticky top-8">
       <p class="text-sm font-medium text-foreground mb-3">On this page</p>
       <ul class="space-y-1 text-sm list-none p-0 m-0">

--- a/docs/src/layouts/DocsLayout.astro
+++ b/docs/src/layouts/DocsLayout.astro
@@ -20,8 +20,8 @@ const { title, headings = [], slug = '', rawMarkdown = '' } = Astro.props;
       <slot />
     </article>
 
-    <aside class="w-0 xl:w-56 shrink-0 opacity-0 invisible translate-x-12 xl:opacity-100 xl:visible xl:translate-x-0 transition-[opacity,visibility,translate,width] duration-200 overflow-hidden xl:overflow-visible">
-      <div class="sticky top-8">
+    <aside class="w-0 2xl:w-56 shrink-0 opacity-0 invisible translate-x-12 2xl:opacity-100 2xl:visible 2xl:translate-x-0 transition-[opacity,visibility,translate,width] duration-200 overflow-hidden 2xl:overflow-visible">
+      <div class="sticky top-20 max-h-[calc(100vh-5rem)] overflow-y-auto pb-4">
         <div class="mb-10">
           <MarkdownForAI slug={slug} rawMarkdown={rawMarkdown} client:load />
         </div>


### PR DESCRIPTION
## Summary

- **Independent scrolling.** The right sidebar's sticky wrapper had no max-height or overflow, so on viewports shorter than the TOC + AI-actions block the bottom of the sidebar was unreachable unless you scrolled the entire page past it. Cap the sticky element to \`calc(100vh - 5rem)\` and add \`overflow-y-auto\` so the sidebar scrolls on its own.
- **Clears the fixed header.** Bumped the sticky offset from \`top-8\` (32px) to \`top-20\` (80px) so the sticky content sits below the 64px fixed header instead of being clipped by it.
- **Bumped breakpoint to \`2xl\`.** At Tailwind's \`xl\` (1280px) the article was getting squeezed to ~600px the moment the sidebar appeared. \`2xl\` (1536px) is closer to the viewport at which the layout actually has room for both columns. Applies to both \`DocsLayout.astro\` and the redundant nested \`TableOfContents.svelte\` breakpoint.

## Test plan

- [x] Load a long ADR (e.g. \`/adr/0010-failure-handling/\`) on a viewport ≥ 1536px and confirm the right sidebar scrolls independently when its content overflows.
- [x] Confirm the sticky right column starts below the fixed header (no overlap).
- [x] Resize across the 1536px breakpoint and confirm the slide-in/slide-out animation still plays smoothly.
- [x] At viewports between 1280–1535px, confirm the right sidebar is hidden and the article fills the column.

🤖 Generated with [Claude Code](https://claude.com/claude-code)