### PR TITLE
Design: Warm Parchment + Verdigris Aeronautical Theme

### DIFF
--- a/docs/src/components/Sidebar.svelte
+++ b/docs/src/components/Sidebar.svelte
@@ -1,193 +1,214 @@
 <script lang="ts">
-  import { onMount } from 'svelte';
-  import { slide } from 'svelte/transition';
-  import { externalLinks, isSection, type NavItem } from '../lib/navigation';
-  import Plane from '@lucide/svelte/icons/plane';
-  import Rocket from '@lucide/svelte/icons/rocket';
-  import Server from '@lucide/svelte/icons/server';
-  import Wrench from '@lucide/svelte/icons/wrench';
-  import GitFork from '@lucide/svelte/icons/git-fork';
-  import Braces from '@lucide/svelte/icons/braces';
-  import Cloud from '@lucide/svelte/icons/cloud';
-  import Compass from '@lucide/svelte/icons/compass';
-  import Layers from '@lucide/svelte/icons/layers';
-  import Terminal from '@lucide/svelte/icons/terminal';
+    import { onMount } from 'svelte';
+    import { slide } from 'svelte/transition';
+    import { externalLinks, isSection, type NavItem } from '../lib/navigation';
+    import Plane from '@lucide/svelte/icons/plane';
+    import Rocket from '@lucide/svelte/icons/rocket';
+    import Server from '@lucide/svelte/icons/server';
+    import Wrench from '@lucide/svelte/icons/wrench';
+    import GitFork from '@lucide/svelte/icons/git-fork';
+    import Braces from '@lucide/svelte/icons/braces';
+    import Cloud from '@lucide/svelte/icons/cloud';
+    import Compass from '@lucide/svelte/icons/compass';
+    import Layers from '@lucide/svelte/icons/layers';
+    import Terminal from '@lucide/svelte/icons/terminal';
 
-  let { currentPath = '', navigation = [] as NavItem[] }: { currentPath?: string; navigation?: NavItem[] } = $props();
-  let mobileOpen = $state(false);
-  let mounted = $state(false);
+    let { currentPath = '', navigation = [] as NavItem[] }: { currentPath?: string; navigation?: NavItem[] } = $props();
+    let mobileOpen = $state(false);
+    let mounted = $state(false);
 
-  // Track which sections the user has manually toggled (label → open/closed)
-  // Persisted in localStorage so state survives Astro page navigations
-  const STORAGE_KEY = 'sidebar-toggles';
+    const STORAGE_KEY = 'sidebar-toggles';
 
-  function loadToggles(): Record<string, boolean> {
-    try {
-      const stored = localStorage.getItem(STORAGE_KEY);
-      return stored ? JSON.parse(stored) : {};
-    } catch { return {}; }
-  }
+    function loadToggles(): Record<string, boolean> {
+      try {
+        const stored = localStorage.getItem(STORAGE_KEY);
+        return stored ? JSON.parse(stored) : {};
+      } catch { return {}; }
+    }
 
-  function saveToggles(toggles: Record<string, boolean>) {
-    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(toggles)); } catch {}
-  }
+    function saveToggles(toggles: Record<string, boolean>) {
+      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(toggles)); } catch {}
+    }
 
-  let manualToggles: Record<string, boolean> = $state(loadToggles());
+    let manualToggles: Record<string, boolean> = $state(loadToggles());
 
-  onMount(() => {
-    mounted = true;
-  });
+    onMount(() => { mounted = true; });
 
-  function isSectionOpen(item: import('../lib/navigation').NavSection): boolean {
-    // Manual toggle always wins
-    const manual = manualToggles[item.label];
-    if (manual !== undefined) return manual;
-    // Default: open if it contains the active page, or if defaultOpen
-    return sectionContainsActive(item) || item.defaultOpen !== false;
-  }
+    function isSectionOpen(item: import('../lib/navigation').NavSection): boolean {
+      const manual = manualToggles[item.label];
+      if (manual !== undefined) return manual;
+      return sectionContainsActive(item) || item.defaultOpen !== false;
+    }
 
-  function toggleSection(label: string, currentlyOpen: boolean) {
-    manualToggles[label] = !currentlyOpen;
-    saveToggles(manualToggles);
-  }
+    function toggleSection(label: string, currentlyOpen: boolean) {
+      manualToggles[label] = !currentlyOpen;
+      saveToggles(manualToggles);
+    }
 
-  // Map top-level labels to icons
-  const iconMap: Record<string, typeof Plane> = {
-    'Meet Aileron': Plane,
-    'Architecture': Compass,
-    'Getting Started': Rocket,
-    'Operations': Server,
-    'Deployment': Cloud,
-    'Development': Wrench,
-    'Architecture Decisions': GitFork,
-    'Concepts': Layers,
-    'CLI Reference': Terminal,
-    'API Reference': Braces
-  };
+    const iconMap: Record<string, typeof Plane> = {
+      'Meet Aileron': Plane,
+      'Architecture': Compass,
+      'Getting Started': Rocket,
+      'Operations': Server,
+      'Deployment': Cloud,
+      'Development': Wrench,
+      'Architecture Decisions': GitFork,
+      'Concepts': Layers,
+      'CLI Reference': Terminal,
+      'API Reference': Braces
+    };
 
-  function isActive(href: string): boolean {
-    return currentPath === href || currentPath === href + '/';
-  }
+    function isActive(href: string): boolean {
+      return currentPath === href || currentPath === href + '/';
+    }
 
-  function sectionContainsActive(item: NavItem): boolean {
-    if (!isSection(item)) return isActive(item.href);
-    return item.children.some(child => sectionContainsActive(child));
-  }
-</script>
+    function sectionContainsActive(item: NavItem): boolean {
+      if (!isSection(item)) return isActive(item.href);
+      return item.children.some(child => sectionContainsActive(child));
+    }
+  </script>
 
-<!-- Mobile toggle button -->
-<button
-  class="fixed top-4 left-3 z-50 p-2 rounded-md bg-background border border-border opacity-100 visible translate-x-0 transition-[opacity,visibility,translate] duration-200 lg:opacity-0 lg:invisible lg:-translate-x-12"
-  onclick={() => mobileOpen = !mobileOpen}
-  aria-label="Toggle navigation"
->
-  <svg xmlns="http://www.w3.org/2000/svg" width="20" height="20" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-    {#if mobileOpen}
-      <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-    {:else}
-      <line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="18" x2="21" y2="18" />
-    {/if}
-  </svg>
-</button>
+  <!-- Mobile toggle -->
+  <button
+    class="fixed top-3.5 left-3 z-50 p-2 rounded-md bg-background border border-border opacity-100 visible translate-x-0 transition-[opacity,visibility,translate] duration-200 lg:opacity-0 lg:invisible lg:-translate-x-12"
+    onclick={() => mobileOpen = !mobileOpen}
+    aria-label="Toggle navigation"
+  >
+    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+      {#if mobileOpen}
+        <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+      {:else}
+        <line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="18" x2="21" y2="18" />
+      {/if}
+    </svg>
+  </button>
 
-<!-- Backdrop for mobile -->
-{#if mobileOpen}
-  <div
-    class="lg:hidden fixed inset-0 z-30 bg-black/50"
-    onclick={() => mobileOpen = false}
-    onkeydown={(e) => { if (e.key === 'Escape') mobileOpen = false; }}
-    role="button"
-    tabindex="-1"
-    aria-label="Close navigation"
-  ></div>
-{/if}
+  <!-- Mobile backdrop -->
+  {#if mobileOpen}
+    <div
+      class="lg:hidden fixed inset-0 z-30 bg-black/30"
+      onclick={() => mobileOpen = false}
+      onkeydown={(e) => { if (e.key === 'Escape') mobileOpen = false; }}
+      role="button"
+      tabindex="-1"
+      aria-label="Close navigation"
+    ></div>
+  {/if}
 
-<!-- Sidebar -->
-<aside
-  class="fixed top-16 left-0 z-40 h-[calc(100vh-4rem)] w-80 shrink-0 border-r border-border bg-background overflow-y-auto transition-transform duration-200
-    {mobileOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0 lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"
->
-  <div class="p-4">
-    <nav class="flex flex-col gap-4 {mounted ? 'visible' : 'invisible'}">
-      {#each navigation as item}
-        {#if isSection(item)}
-          {@render section(item, 0)}
-        {:else}
-          {@const active = isActive(item.href)}
-          {@const Icon = iconMap[item.label]}
-          <a
-            href={item.href}
-            class="group flex items-center gap-2 py-1.5 px-2 rounded text-sm no-underline
-              {active ? 'bg-accent text-accent-foreground font-medium' : 'text-muted-foreground hover:text-accent-foreground hover:bg-accent/70'}"
-            onclick={() => mobileOpen = false}
-          >
-            {#if Icon}
-              <Icon size={16} class="shrink-0 transition-transform duration-150 {active ? 'scale-125' : 'group-hover:scale-125'}" />
-            {/if}
-            {item.label}
-          </a>
-        {/if}
-      {/each}
-
-      <!-- External links -->
-      <div class="mt-6 pt-4 border-t border-border">
-        {#each externalLinks as link}
-          {@const active = currentPath === link.href || currentPath === link.href + '/'}
-          {@const Icon = iconMap[link.label]}
-          <a
-            href={link.href}
-            class="group flex items-center gap-2 py-1.5 px-2 rounded text-sm no-underline
-              {active ? 'bg-accent text-accent-foreground font-medium' : 'text-muted-foreground hover:text-accent-foreground hover:bg-accent/70'}"
-            onclick={() => mobileOpen = false}
-          >
-            {#if Icon}
-              <Icon size={16} class="shrink-0 transition-transform duration-150 {active ? 'scale-125' : 'group-hover:scale-125'}" />
-            {/if}
-            {link.label}
-          </a>
-        {/each}
-      </div>
-    </nav>
-  </div>
-</aside>
-
-{#snippet section(item: import('../lib/navigation').NavSection, depth: number)}
-  {@const active = sectionContainsActive(item)}
-  {@const open = isSectionOpen(item)}
-  {@const Icon = iconMap[item.label]}
-  <div class="group {depth > 0 ? 'ml-2' : ''} rounded border border-border {active ? 'bg-accent' : 'bg-muted'}">
-    <button
-      class="w-full flex items-center justify-between py-1.5 px-2 rounded text-sm font-medium select-none cursor-pointer
-        {active ? 'text-accent-foreground' : 'text-foreground'} hover:bg-accent/50"
-      onclick={() => toggleSection(item.label, open)}
-    >
-      <span class="flex items-center gap-2">
-        {#if Icon}
-          <Icon size={16} class="shrink-0 transition-transform duration-150 {active ? 'scale-125' : 'group-hover:scale-125'}" />
-        {/if}
-        {item.label}
-      </span>
-      <svg class="w-4 h-4 transition-transform duration-200 {open ? 'rotate-90' : ''}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-        <polyline points="9 18 15 12 9 6" />
+  <!-- Sidebar -->
+  <aside
+    class="fixed top-14 left-0 z-40 h-[calc(100vh-3.5rem)] w-72 shrink-0 border-r border-border bg-card chart-graticule overflow-y-auto transition-transform duration-200
+      {mobileOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0 lg:sticky lg:top-14 lg:h-[calc(100vh-3.5rem)]"
+  >
+    <!-- Faint VOR range rings in lower corner — aeronautical texture -->
+    <div class="pointer-events-none absolute bottom-0 left-0 overflow-hidden w-48 h-48 opacity-[0.055]" aria-hidden="true">
+      <svg viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-full h-full">
+        <circle cx="20" cy="180" r="100" stroke="oklch(0.44 0.13 188)" stroke-width="1"/>
+        <circle cx="20" cy="180" r="65"  stroke="oklch(0.44 0.13 188)" stroke-width="0.7"/>
+        <circle cx="20" cy="180" r="32"  stroke="oklch(0.44 0.13 188)" stroke-width="0.7"/>
+        <line x1="20" y1="80"  x2="20"  y2="180" stroke="oklch(0.44 0.13 188)" stroke-width="0.6" stroke-dasharray="3 3"/>
+        <line x1="-80" y1="180" x2="120" y2="180" stroke="oklch(0.44 0.13 188)" stroke-width="0.6" stroke-dasharray="3 3"/>
       </svg>
-    </button>
-    {#if open}
-      <div class="ml-2 pl-2" transition:slide={{ duration: mounted ? 150 : 0 }}>
-        {#each item.children as child}
-          {#if isSection(child)}
-            {@render section(child, depth + 1)}
+    </div>
+
+    <div class="p-4 relative z-10">
+      <nav class="flex flex-col gap-5 {mounted ? 'visible' : 'invisible'}">
+        {#each navigation as item}
+          {#if isSection(item)}
+            {@render section(item, 0)}
           {:else}
+            {@const active = isActive(item.href)}
+            {@const Icon = iconMap[item.label]}
             <a
-              href={child.href}
-              class="block py-1 px-2 rounded text-sm no-underline
-                {isActive(child.href) ? 'bg-accent text-accent-foreground font-medium' : 'text-muted-foreground hover:text-accent-foreground hover:bg-accent/70'}"
+              href={item.href}
+              class="group flex items-center gap-2 py-1.5 px-2 rounded text-sm no-underline relative
+                {active
+                  ? 'text-primary font-semibold bg-primary/[0.07] pl-5'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'}"
               onclick={() => mobileOpen = false}
             >
-              {child.label}
+              {#if active}
+                <!-- Waypoint diamond (aeronautical fix symbol) -->
+                <span class="absolute left-1.5 top-1/2 -translate-y-1/2 w-2 h-2 rotate-45 bg-primary" aria-hidden="true"></span>
+              {:else if Icon}
+                <Icon size={15} class="shrink-0" />
+              {/if}
+              {item.label}
             </a>
           {/if}
         {/each}
-      </div>
-    {/if}
-  </div>
-{/snippet}
+
+        <!-- External links -->
+        <div class="pt-4 border-t border-border">
+          {#each externalLinks as link}
+            {@const active = currentPath === link.href || currentPath === link.href + '/'}
+            {@const Icon = iconMap[link.label]}
+            <a
+              href={link.href}
+              class="group flex items-center gap-2 py-1.5 px-2 rounded text-sm no-underline relative
+                {active
+                  ? 'text-primary font-semibold bg-primary/[0.07] pl-5'
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'}"
+              onclick={() => mobileOpen = false}
+            >
+              {#if active}
+                <span class="absolute left-1.5 top-1/2 -translate-y-1/2 w-2 h-2 rotate-45 bg-primary" aria-hidden="true"></span>
+              {:else if Icon}
+                <Icon size={15} class="shrink-0" />
+              {/if}
+              {link.label}
+            </a>
+          {/each}
+        </div>
+      </nav>
+    </div>
+  </aside>
+
+  {#snippet section(item: import('../lib/navigation').NavSection, depth: number)}
+    {@const active = sectionContainsActive(item)}
+    {@const open = isSectionOpen(item)}
+    {@const Icon = iconMap[item.label]}
+    <div class="{depth > 0 ? 'ml-2' : ''} rounded border border-border {active ? 'bg-primary/[0.05]' : 'bg-background/40'}">
+      <button
+        class="w-full flex items-center justify-between py-1.5 px-2 rounded text-[11px] font-bold uppercase tracking-widest select-none cursor-pointer
+          {active ? 'text-primary' : 'text-muted-foreground'} hover:bg-accent/50"
+        onclick={() => toggleSection(item.label, open)}
+      >
+        <span class="flex items-center gap-2">
+          {#if Icon}
+            <Icon size={13} class="shrink-0 {active ? 'text-primary' : ''}" />
+          {/if}
+          {item.label}
+        </span>
+        <svg class="w-3.5 h-3.5 transition-transform duration-200 {open ? 'rotate-90' : ''}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+          <polyline points="9 18 15 12 9 6" />
+        </svg>
+      </button>
+      {#if open}
+        <div class="ml-2 border-l border-border" transition:slide={{ duration: mounted ? 150 : 0 }}>
+          {#each item.children as child}
+            {#if isSection(child)}
+              {@render section(child, depth + 1)}
+            {:else}
+              {@const childActive = isActive(child.href)}
+              <a
+                href={child.href}
+                class="flex items-center py-1 px-3 text-[13px] no-underline relative
+                  {childActive
+                    ? 'text-primary font-semibold bg-primary/[0.07] pl-5'
+                    : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
+                onclick={() => mobileOpen = false}
+              >
+                {#if childActive}
+                  <!-- Waypoint diamond -->
+                  <span class="absolute left-1.5 top-1/2 -translate-y-1/2 w-1.5 h-1.5 rotate-45 bg-primary" aria-hidden="true"></span>
+                {/if}
+                {child.label}
+              </a>
+            {/if}
+          {/each}
+        </div>
+      {/if}
+    </div>
+  {/snippet}
+  

--- a/docs/src/components/Sidebar.svelte
+++ b/docs/src/components/Sidebar.svelte
@@ -1,214 +1,214 @@
 <script lang="ts">
-    import { onMount } from 'svelte';
-    import { slide } from 'svelte/transition';
-    import { externalLinks, isSection, type NavItem } from '../lib/navigation';
-    import Plane from '@lucide/svelte/icons/plane';
-    import Rocket from '@lucide/svelte/icons/rocket';
-    import Server from '@lucide/svelte/icons/server';
-    import Wrench from '@lucide/svelte/icons/wrench';
-    import GitFork from '@lucide/svelte/icons/git-fork';
-    import Braces from '@lucide/svelte/icons/braces';
-    import Cloud from '@lucide/svelte/icons/cloud';
-    import Compass from '@lucide/svelte/icons/compass';
-    import Layers from '@lucide/svelte/icons/layers';
-    import Terminal from '@lucide/svelte/icons/terminal';
+  import { onMount } from 'svelte';
+  import { slide } from 'svelte/transition';
+  import { externalLinks, isSection, type NavItem } from '../lib/navigation';
+  import Plane from '@lucide/svelte/icons/plane';
+  import Rocket from '@lucide/svelte/icons/rocket';
+  import Server from '@lucide/svelte/icons/server';
+  import Wrench from '@lucide/svelte/icons/wrench';
+  import GitFork from '@lucide/svelte/icons/git-fork';
+  import Braces from '@lucide/svelte/icons/braces';
+  import Cloud from '@lucide/svelte/icons/cloud';
+  import Compass from '@lucide/svelte/icons/compass';
+  import Layers from '@lucide/svelte/icons/layers';
+  import Terminal from '@lucide/svelte/icons/terminal';
 
-    let { currentPath = '', navigation = [] as NavItem[] }: { currentPath?: string; navigation?: NavItem[] } = $props();
-    let mobileOpen = $state(false);
-    let mounted = $state(false);
+  let { currentPath = '', navigation = [] as NavItem[] }: { currentPath?: string; navigation?: NavItem[] } = $props();
+  let mobileOpen = $state(false);
+  let mounted = $state(false);
 
-    const STORAGE_KEY = 'sidebar-toggles';
+  const STORAGE_KEY = 'sidebar-toggles';
 
-    function loadToggles(): Record<string, boolean> {
-      try {
-        const stored = localStorage.getItem(STORAGE_KEY);
-        return stored ? JSON.parse(stored) : {};
-      } catch { return {}; }
-    }
+  function loadToggles(): Record<string, boolean> {
+    try {
+      const stored = localStorage.getItem(STORAGE_KEY);
+      return stored ? JSON.parse(stored) : {};
+    } catch { return {}; }
+  }
 
-    function saveToggles(toggles: Record<string, boolean>) {
-      try { localStorage.setItem(STORAGE_KEY, JSON.stringify(toggles)); } catch {}
-    }
+  function saveToggles(toggles: Record<string, boolean>) {
+    try { localStorage.setItem(STORAGE_KEY, JSON.stringify(toggles)); } catch {}
+  }
 
-    let manualToggles: Record<string, boolean> = $state(loadToggles());
+  let manualToggles: Record<string, boolean> = $state(loadToggles());
 
-    onMount(() => { mounted = true; });
+  onMount(() => { mounted = true; });
 
-    function isSectionOpen(item: import('../lib/navigation').NavSection): boolean {
-      const manual = manualToggles[item.label];
-      if (manual !== undefined) return manual;
-      return sectionContainsActive(item) || item.defaultOpen !== false;
-    }
+  function isSectionOpen(item: import('../lib/navigation').NavSection): boolean {
+    const manual = manualToggles[item.label];
+    if (manual !== undefined) return manual;
+    return sectionContainsActive(item) || item.defaultOpen !== false;
+  }
 
-    function toggleSection(label: string, currentlyOpen: boolean) {
-      manualToggles[label] = !currentlyOpen;
-      saveToggles(manualToggles);
-    }
+  function toggleSection(label: string, currentlyOpen: boolean) {
+    manualToggles[label] = !currentlyOpen;
+    saveToggles(manualToggles);
+  }
 
-    const iconMap: Record<string, typeof Plane> = {
-      'Meet Aileron': Plane,
-      'Architecture': Compass,
-      'Getting Started': Rocket,
-      'Operations': Server,
-      'Deployment': Cloud,
-      'Development': Wrench,
-      'Architecture Decisions': GitFork,
-      'Concepts': Layers,
-      'CLI Reference': Terminal,
-      'API Reference': Braces
-    };
+  const iconMap: Record<string, typeof Plane> = {
+    'Meet Aileron': Plane,
+    'Architecture': Compass,
+    'Getting Started': Rocket,
+    'Operations': Server,
+    'Deployment': Cloud,
+    'Development': Wrench,
+    'Architecture Decisions': GitFork,
+    'Concepts': Layers,
+    'CLI Reference': Terminal,
+    'API Reference': Braces
+  };
 
-    function isActive(href: string): boolean {
-      return currentPath === href || currentPath === href + '/';
-    }
+  function isActive(href: string): boolean {
+    return currentPath === href || currentPath === href + '/';
+  }
 
-    function sectionContainsActive(item: NavItem): boolean {
-      if (!isSection(item)) return isActive(item.href);
-      return item.children.some(child => sectionContainsActive(child));
-    }
-  </script>
+  function sectionContainsActive(item: NavItem): boolean {
+    if (!isSection(item)) return isActive(item.href);
+    return item.children.some(child => sectionContainsActive(child));
+  }
+</script>
 
   <!-- Mobile toggle -->
-  <button
-    class="fixed top-3.5 left-3 z-50 p-2 rounded-md bg-background border border-border opacity-100 visible translate-x-0 transition-[opacity,visibility,translate] duration-200 lg:opacity-0 lg:invisible lg:-translate-x-12"
-    onclick={() => mobileOpen = !mobileOpen}
-    aria-label="Toggle navigation"
-  >
-    <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-      {#if mobileOpen}
-        <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
-      {:else}
-        <line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="18" x2="21" y2="18" />
-      {/if}
-    </svg>
-  </button>
+<button
+  class="fixed top-3.5 left-3 z-50 p-2 rounded-md bg-background border border-border opacity-100 visible translate-x-0 transition-[opacity,visibility,translate] duration-200 lg:opacity-0 lg:invisible lg:-translate-x-12"
+  onclick={() => mobileOpen = !mobileOpen}
+  aria-label="Toggle navigation"
+>
+  <svg xmlns="http://www.w3.org/2000/svg" width="18" height="18" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    {#if mobileOpen}
+      <line x1="18" y1="6" x2="6" y2="18" /><line x1="6" y1="6" x2="18" y2="18" />
+    {:else}
+      <line x1="3" y1="12" x2="21" y2="12" /><line x1="3" y1="6" x2="21" y2="6" /><line x1="3" y1="18" x2="21" y2="18" />
+    {/if}
+  </svg>
+</button>
 
   <!-- Mobile backdrop -->
-  {#if mobileOpen}
-    <div
-      class="lg:hidden fixed inset-0 z-30 bg-black/30"
-      onclick={() => mobileOpen = false}
-      onkeydown={(e) => { if (e.key === 'Escape') mobileOpen = false; }}
-      role="button"
-      tabindex="-1"
-      aria-label="Close navigation"
-    ></div>
-  {/if}
+{#if mobileOpen}
+  <div
+    class="lg:hidden fixed inset-0 z-30 bg-black/30"
+    onclick={() => mobileOpen = false}
+    onkeydown={(e) => { if (e.key === 'Escape') mobileOpen = false; }}
+    role="button"
+    tabindex="-1"
+    aria-label="Close navigation"
+  ></div>
+{/if}
 
-  <!-- Sidebar -->
-  <aside
-    class="fixed top-14 left-0 z-40 h-[calc(100vh-3.5rem)] w-72 shrink-0 border-r border-border bg-card chart-graticule overflow-y-auto transition-transform duration-200
-      {mobileOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0 lg:sticky lg:top-14 lg:h-[calc(100vh-3.5rem)]"
-  >
-    <!-- Faint VOR range rings in lower corner — aeronautical texture -->
-    <div class="pointer-events-none absolute bottom-0 left-0 overflow-hidden w-48 h-48 opacity-[0.055]" aria-hidden="true">
-      <svg viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-full h-full">
-        <circle cx="20" cy="180" r="100" stroke="oklch(0.44 0.13 188)" stroke-width="1"/>
-        <circle cx="20" cy="180" r="65"  stroke="oklch(0.44 0.13 188)" stroke-width="0.7"/>
-        <circle cx="20" cy="180" r="32"  stroke="oklch(0.44 0.13 188)" stroke-width="0.7"/>
-        <line x1="20" y1="80"  x2="20"  y2="180" stroke="oklch(0.44 0.13 188)" stroke-width="0.6" stroke-dasharray="3 3"/>
-        <line x1="-80" y1="180" x2="120" y2="180" stroke="oklch(0.44 0.13 188)" stroke-width="0.6" stroke-dasharray="3 3"/>
+<!-- Sidebar -->
+<aside
+  class="fixed top-14 left-0 z-40 h-[calc(100vh-3.5rem)] w-72 shrink-0 border-r border-border bg-card chart-graticule overflow-y-auto transition-transform duration-200
+    {mobileOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0 lg:sticky lg:top-14 lg:h-[calc(100vh-3.5rem)]"
+>
+  <!-- Faint VOR range rings in lower corner — aeronautical texture -->
+  <div class="pointer-events-none absolute bottom-0 left-0 overflow-hidden w-48 h-48 opacity-[0.055]" aria-hidden="true">
+    <svg viewBox="0 0 200 200" fill="none" xmlns="http://www.w3.org/2000/svg" class="w-full h-full">
+      <circle cx="20" cy="180" r="100" stroke="oklch(0.44 0.13 188)" stroke-width="1"/>
+      <circle cx="20" cy="180" r="65"  stroke="oklch(0.44 0.13 188)" stroke-width="0.7"/>
+      <circle cx="20" cy="180" r="32"  stroke="oklch(0.44 0.13 188)" stroke-width="0.7"/>
+      <line x1="20" y1="80"  x2="20"  y2="180" stroke="oklch(0.44 0.13 188)" stroke-width="0.6" stroke-dasharray="3 3"/>
+      <line x1="-80" y1="180" x2="120" y2="180" stroke="oklch(0.44 0.13 188)" stroke-width="0.6" stroke-dasharray="3 3"/>
+    </svg>
+  </div>
+
+  <div class="p-4 relative z-10">
+    <nav class="flex flex-col gap-5 {mounted ? 'visible' : 'invisible'}">
+      {#each navigation as item}
+        {#if isSection(item)}
+          {@render section(item, 0)}
+        {:else}
+          {@const active = isActive(item.href)}
+          {@const Icon = iconMap[item.label]}
+          <a
+            href={item.href}
+            class="group flex items-center gap-2 py-1.5 px-2 rounded text-sm no-underline relative
+              {active
+                ? 'text-primary font-semibold bg-primary/[0.07] pl-5'
+                : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'}"
+            onclick={() => mobileOpen = false}
+          >
+            {#if active}
+              <!-- Waypoint diamond (aeronautical fix symbol) -->
+              <span class="absolute left-1.5 top-1/2 -translate-y-1/2 w-2 h-2 rotate-45 bg-primary" aria-hidden="true"></span>
+            {:else if Icon}
+              <Icon size={15} class="shrink-0" />
+            {/if}
+            {item.label}
+          </a>
+        {/if}
+      {/each}
+
+      <!-- External links -->
+      <div class="pt-4 border-t border-border">
+        {#each externalLinks as link}
+          {@const active = currentPath === link.href || currentPath === link.href + '/'}
+          {@const Icon = iconMap[link.label]}
+          <a
+            href={link.href}
+            class="group flex items-center gap-2 py-1.5 px-2 rounded text-sm no-underline relative
+              {active
+                ? 'text-primary font-semibold bg-primary/[0.07] pl-5'
+                : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'}"
+            onclick={() => mobileOpen = false}
+          >
+            {#if active}
+              <span class="absolute left-1.5 top-1/2 -translate-y-1/2 w-2 h-2 rotate-45 bg-primary" aria-hidden="true"></span>
+            {:else if Icon}
+              <Icon size={15} class="shrink-0" />
+            {/if}
+            {link.label}
+          </a>
+        {/each}
+      </div>
+    </nav>
+  </div>
+</aside>
+
+{#snippet section(item: import('../lib/navigation').NavSection, depth: number)}
+  {@const active = sectionContainsActive(item)}
+  {@const open = isSectionOpen(item)}
+  {@const Icon = iconMap[item.label]}
+  <div class="{depth > 0 ? 'ml-2' : ''} rounded border border-border {active ? 'bg-primary/[0.05]' : 'bg-background/40'}">
+    <button
+      class="w-full flex items-center justify-between py-1.5 px-2 rounded text-[11px] font-bold uppercase tracking-widest select-none cursor-pointer
+        {active ? 'text-primary' : 'text-muted-foreground'} hover:bg-accent/50"
+      onclick={() => toggleSection(item.label, open)}
+    >
+      <span class="flex items-center gap-2">
+        {#if Icon}
+          <Icon size={13} class="shrink-0 {active ? 'text-primary' : ''}" />
+        {/if}
+        {item.label}
+      </span>
+      <svg class="w-3.5 h-3.5 transition-transform duration-200 {open ? 'rotate-90' : ''}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+        <polyline points="9 18 15 12 9 6" />
       </svg>
-    </div>
-
-    <div class="p-4 relative z-10">
-      <nav class="flex flex-col gap-5 {mounted ? 'visible' : 'invisible'}">
-        {#each navigation as item}
-          {#if isSection(item)}
-            {@render section(item, 0)}
+    </button>
+    {#if open}
+      <div class="ml-2 border-l border-border" transition:slide={{ duration: mounted ? 150 : 0 }}>
+        {#each item.children as child}
+          {#if isSection(child)}
+            {@render section(child, depth + 1)}
           {:else}
-            {@const active = isActive(item.href)}
-            {@const Icon = iconMap[item.label]}
+            {@const childActive = isActive(child.href)}
             <a
-              href={item.href}
-              class="group flex items-center gap-2 py-1.5 px-2 rounded text-sm no-underline relative
-                {active
+              href={child.href}
+              class="flex items-center py-1 px-3 text-[13px] no-underline relative
+                {childActive
                   ? 'text-primary font-semibold bg-primary/[0.07] pl-5'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'}"
+                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
               onclick={() => mobileOpen = false}
             >
-              {#if active}
-                <!-- Waypoint diamond (aeronautical fix symbol) -->
-                <span class="absolute left-1.5 top-1/2 -translate-y-1/2 w-2 h-2 rotate-45 bg-primary" aria-hidden="true"></span>
-              {:else if Icon}
-                <Icon size={15} class="shrink-0" />
+              {#if childActive}
+                <!-- Waypoint diamond -->
+                <span class="absolute left-1.5 top-1/2 -translate-y-1/2 w-1.5 h-1.5 rotate-45 bg-primary" aria-hidden="true"></span>
               {/if}
-              {item.label}
+              {child.label}
             </a>
           {/if}
         {/each}
-
-        <!-- External links -->
-        <div class="pt-4 border-t border-border">
-          {#each externalLinks as link}
-            {@const active = currentPath === link.href || currentPath === link.href + '/'}
-            {@const Icon = iconMap[link.label]}
-            <a
-              href={link.href}
-              class="group flex items-center gap-2 py-1.5 px-2 rounded text-sm no-underline relative
-                {active
-                  ? 'text-primary font-semibold bg-primary/[0.07] pl-5'
-                  : 'text-muted-foreground hover:text-foreground hover:bg-accent/60'}"
-              onclick={() => mobileOpen = false}
-            >
-              {#if active}
-                <span class="absolute left-1.5 top-1/2 -translate-y-1/2 w-2 h-2 rotate-45 bg-primary" aria-hidden="true"></span>
-              {:else if Icon}
-                <Icon size={15} class="shrink-0" />
-              {/if}
-              {link.label}
-            </a>
-          {/each}
-        </div>
-      </nav>
-    </div>
-  </aside>
-
-  {#snippet section(item: import('../lib/navigation').NavSection, depth: number)}
-    {@const active = sectionContainsActive(item)}
-    {@const open = isSectionOpen(item)}
-    {@const Icon = iconMap[item.label]}
-    <div class="{depth > 0 ? 'ml-2' : ''} rounded border border-border {active ? 'bg-primary/[0.05]' : 'bg-background/40'}">
-      <button
-        class="w-full flex items-center justify-between py-1.5 px-2 rounded text-[11px] font-bold uppercase tracking-widest select-none cursor-pointer
-          {active ? 'text-primary' : 'text-muted-foreground'} hover:bg-accent/50"
-        onclick={() => toggleSection(item.label, open)}
-      >
-        <span class="flex items-center gap-2">
-          {#if Icon}
-            <Icon size={13} class="shrink-0 {active ? 'text-primary' : ''}" />
-          {/if}
-          {item.label}
-        </span>
-        <svg class="w-3.5 h-3.5 transition-transform duration-200 {open ? 'rotate-90' : ''}" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-          <polyline points="9 18 15 12 9 6" />
-        </svg>
-      </button>
-      {#if open}
-        <div class="ml-2 border-l border-border" transition:slide={{ duration: mounted ? 150 : 0 }}>
-          {#each item.children as child}
-            {#if isSection(child)}
-              {@render section(child, depth + 1)}
-            {:else}
-              {@const childActive = isActive(child.href)}
-              <a
-                href={child.href}
-                class="flex items-center py-1 px-3 text-[13px] no-underline relative
-                  {childActive
-                    ? 'text-primary font-semibold bg-primary/[0.07] pl-5'
-                    : 'text-muted-foreground hover:text-foreground hover:bg-accent/50'}"
-                onclick={() => mobileOpen = false}
-              >
-                {#if childActive}
-                  <!-- Waypoint diamond -->
-                  <span class="absolute left-1.5 top-1/2 -translate-y-1/2 w-1.5 h-1.5 rotate-45 bg-primary" aria-hidden="true"></span>
-                {/if}
-                {child.label}
-              </a>
-            {/if}
-          {/each}
-        </div>
-      {/if}
-    </div>
-  {/snippet}
+      </div>
+    {/if}
+  </div>
+{/snippet}
   

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -1,51 +1,60 @@
 ---
-import Sidebar from '../components/Sidebar.svelte';
-import { navigation } from '../lib/navigation';
-import '../styles/global.css';
+  import Sidebar from '../components/Sidebar.svelte';
+  import { navigation } from '../lib/navigation';
+  import '../styles/global.css';
 
-interface Props {
-  title: string;
-}
+  interface Props {
+    title: string;
+  }
 
-const { title } = Astro.props;
-const currentPath = Astro.url.pathname;
+  const { title } = Astro.props;
+  const currentPath = Astro.url.pathname;
 
-// Navigation is currently a flat structure (homepage only).
-// Historical content lives in `docs/archive/` off-site; nav will be rebuilt as
-// new pages are written. ADR auto-injection from content collections has been
-// removed since both `adr/` and `archived-adr/` are now archived off-site.
-const nav = navigation;
----
+  const nav = navigation;
+  ---
 
-<!doctype html>
-<html lang="en" class="dark">
-  <head>
-    <meta charset="utf-8" />
-    <meta name="viewport" content="width=device-width, initial-scale=1" />
-    <meta name="slack-app-id" content="A0ATKS91VPW" />
-    <title>{title} - Aileron Docs</title>
-    <script is:inline>
-      !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Dr qr Ci Br Zr Pr capture calculateEventProperties Ur register register_once register_for_session unregister unregister_for_session Xr getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Jr identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Gr Hr createPersonProfile setInternalOrTestUser Wr Fr tn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing $r debug ki Yr getPageViewId captureTraceFeedback captureTraceMetric Rr".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-      posthog.init('phc_CQuEfquiVnj6iEDdSy9RV2T63kBTuPz7V3dJysGZrAiA', {
-        api_host: 'https://f.withaileron.ai',
-        ui_host: 'https://us.posthog.com',
-        defaults: '2026-01-30',
-        person_profiles: 'identified_only',
-      })
-    </script>
-  </head>
-  <body>
-    <header class="fixed top-0 left-0 right-0 z-50 h-16 flex items-center pl-16 pr-6 lg:px-6 border-b border-border bg-background transition-[padding] duration-200">
-      <a href="/" class="font-bold text-lg text-foreground no-underline hover:text-foreground">
-        Aileron Docs
-      </a>
-    </header>
-    <div class="flex min-h-screen pt-16">
-      <Sidebar currentPath={currentPath} navigation={nav} client:load />
-
-      <div class="flex-1">
-        <slot />
+  <!doctype html>
+  <html lang="en">
+    <head>
+      <meta charset="utf-8" />
+      <meta name="viewport" content="width=device-width, initial-scale=1" />
+      <meta name="slack-app-id" content="A0ATKS91VPW" />
+      <title>{title} - Aileron Docs</title>
+      <link rel="preconnect" href="https://fonts.googleapis.com" />
+      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+      <script is:inline>
+        !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Dr qr Ci Br Zr Pr capture calculateEventProperties Ur register register_once register_for_session unregister unregister_for_session Xr getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Jr identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Gr Hr createPersonProfile setInternalOrTestUser Wr Fr tn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing $r debug ki Yr getPageViewId captureTraceFeedback captureTraceMetric Rr".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+        posthog.init('phc_CQuEfquiVnj6iEDdSy9RV2T63kBTuPz7V3dJysGZrAiA', {
+          api_host: 'https://f.withaileron.ai',
+          ui_host: 'https://us.posthog.com',
+          defaults: '2026-01-30',
+          person_profiles: 'identified_only',
+        })
+      </script>
+    </head>
+    <body class="chart-graticule">
+      <header class="fixed top-0 left-0 right-0 z-50 h-14 flex items-center pl-16 pr-6 lg:px-6 border-b border-border bg-background/95 backdrop-blur-md transition-[padding] duration-200 chart-graticule">
+        <div class="flex items-center gap-2">
+          <div class="bg-primary/[0.07] border border-primary/20 rounded-md p-1.5 flex items-center justify-center">
+            <!-- Plane icon inline SVG (lucide) -->
+            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+              stroke="oklch(0.44 0.13 188)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+              <path d="M17.8 19.2 16 11l3.5-3.5C21 6 21 4 19 4c-1.5 0-3 .5-4.1 1.3L9 5.2l-1.4 2.4 5.6 2.8-1.6 2.8-4.3-.2-1.2 2 4.4 1.6"/>
+            </svg>
+          </div>
+          <a href="/" class="no-underline leading-none">
+            <span class="font-extrabold text-[15px] tracking-tight text-primary uppercase" style="letter-spacing:0.06em">Aileron</span>
+            <span class="font-normal text-[13px] text-muted-foreground ml-1.5">Docs</span>
+          </a>
+        </div>
+      </header>
+      <div class="flex min-h-screen pt-14">
+        <Sidebar currentPath={currentPath} navigation={nav} client:load />
+        <div class="flex-1">
+          <slot />
+        </div>
       </div>
-    </div>
-  </body>
-</html>
+    </body>
+  </html>
+  

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -1,60 +1,60 @@
 ---
-  import Sidebar from '../components/Sidebar.svelte';
-  import { navigation } from '../lib/navigation';
-  import '../styles/global.css';
+import Sidebar from '../components/Sidebar.svelte';
+import { navigation } from '../lib/navigation';
+import '../styles/global.css';
 
-  interface Props {
-    title: string;
-  }
+interface Props {
+  title: string;
+}
 
-  const { title } = Astro.props;
-  const currentPath = Astro.url.pathname;
+const { title } = Astro.props;
+const currentPath = Astro.url.pathname;
 
-  const nav = navigation;
-  ---
+const nav = navigation;
+---
 
-  <!doctype html>
-  <html lang="en">
-    <head>
-      <meta charset="utf-8" />
-      <meta name="viewport" content="width=device-width, initial-scale=1" />
-      <meta name="slack-app-id" content="A0ATKS91VPW" />
-      <title>{title} - Aileron Docs</title>
-      <link rel="preconnect" href="https://fonts.googleapis.com" />
-      <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-      <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
-      <script is:inline>
-        !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Dr qr Ci Br Zr Pr capture calculateEventProperties Ur register register_once register_for_session unregister unregister_for_session Xr getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Jr identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Gr Hr createPersonProfile setInternalOrTestUser Wr Fr tn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing $r debug ki Yr getPageViewId captureTraceFeedback captureTraceMetric Rr".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
-        posthog.init('phc_CQuEfquiVnj6iEDdSy9RV2T63kBTuPz7V3dJysGZrAiA', {
-          api_host: 'https://f.withaileron.ai',
-          ui_host: 'https://us.posthog.com',
-          defaults: '2026-01-30',
-          person_profiles: 'identified_only',
-        })
-      </script>
-    </head>
-    <body class="chart-graticule">
-      <header class="fixed top-0 left-0 right-0 z-50 h-14 flex items-center pl-16 pr-6 lg:px-6 border-b border-border bg-background/95 backdrop-blur-md transition-[padding] duration-200 chart-graticule">
-        <div class="flex items-center gap-2">
-          <div class="bg-primary/[0.07] border border-primary/20 rounded-md p-1.5 flex items-center justify-center">
-            <!-- Plane icon inline SVG (lucide) -->
-            <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
-              stroke="oklch(0.44 0.13 188)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-              <path d="M17.8 19.2 16 11l3.5-3.5C21 6 21 4 19 4c-1.5 0-3 .5-4.1 1.3L9 5.2l-1.4 2.4 5.6 2.8-1.6 2.8-4.3-.2-1.2 2 4.4 1.6"/>
-            </svg>
-          </div>
-          <a href="/" class="no-underline leading-none">
-            <span class="font-extrabold text-[15px] tracking-tight text-primary uppercase" style="letter-spacing:0.06em">Aileron</span>
-            <span class="font-normal text-[13px] text-muted-foreground ml-1.5">Docs</span>
-          </a>
+<!doctype html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <meta name="slack-app-id" content="A0ATKS91VPW" />
+    <title>{title} - Aileron Docs</title>
+    <link rel="preconnect" href="https://fonts.googleapis.com" />
+    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap" rel="stylesheet" />
+    <script is:inline>
+      !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Dr qr Ci Br Zr Pr capture calculateEventProperties Ur register register_once register_for_session unregister unregister_for_session Xr getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Jr identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Gr Hr createPersonProfile setInternalOrTestUser Wr Fr tn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing $r debug ki Yr getPageViewId captureTraceFeedback captureTraceMetric Rr".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
+      posthog.init('phc_CQuEfquiVnj6iEDdSy9RV2T63kBTuPz7V3dJysGZrAiA', {
+        api_host: 'https://f.withaileron.ai',
+        ui_host: 'https://us.posthog.com',
+        defaults: '2026-01-30',
+        person_profiles: 'identified_only',
+      })
+    </script>
+  </head>
+  <body class="chart-graticule">
+    <header class="fixed top-0 left-0 right-0 z-50 h-14 flex items-center pl-16 pr-6 lg:px-6 border-b border-border bg-background/95 backdrop-blur-md transition-[padding] duration-200 chart-graticule">
+      <div class="flex items-center gap-2">
+        <div class="bg-primary/[0.07] border border-primary/20 rounded-md p-1.5 flex items-center justify-center">
+          <!-- Plane icon inline SVG (lucide) -->
+          <svg xmlns="http://www.w3.org/2000/svg" width="14" height="14" viewBox="0 0 24 24" fill="none"
+            stroke="oklch(0.44 0.13 188)" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+            <path d="M17.8 19.2 16 11l3.5-3.5C21 6 21 4 19 4c-1.5 0-3 .5-4.1 1.3L9 5.2l-1.4 2.4 5.6 2.8-1.6 2.8-4.3-.2-1.2 2 4.4 1.6"/>
+          </svg>
         </div>
-      </header>
-      <div class="flex min-h-screen pt-14">
-        <Sidebar currentPath={currentPath} navigation={nav} client:load />
-        <div class="flex-1">
-          <slot />
-        </div>
+        <a href="/" class="no-underline leading-none">
+          <span class="font-extrabold text-[15px] tracking-tight text-primary uppercase" style="letter-spacing:0.06em">Aileron</span>
+          <span class="font-normal text-[13px] text-muted-foreground ml-1.5">Docs</span>
+      </a>
+    </div>
+    </header>
+    <div class="flex min-h-screen pt-14">
+      <Sidebar currentPath={currentPath} navigation={nav} client:load />
+      <div class="flex-1">
+        <slot />
       </div>
-    </body>
-  </html>
+    </div>
+  </body>
+</html>
   

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1,109 +1,180 @@
 @import "tailwindcss";
+  @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
 
-@custom-variant dark (&:is(.dark *));
+  @custom-variant dark (&:is(.dark *));
 
-:root {
-	--background: oklch(1 0 0);
-	--foreground: oklch(0.145 0 0);
-	--muted: oklch(0.97 0 0);
-	--muted-foreground: oklch(0.556 0 0);
-	--border: oklch(0.922 0 0);
-	--primary: oklch(0.205 0 0);
-	--primary-foreground: oklch(0.985 0 0);
-	--accent: oklch(0.97 0 0);
-	--accent-foreground: oklch(0.205 0 0);
-	/* shadcn-svelte additional tokens */
-	--card: oklch(1 0 0);
-	--card-foreground: oklch(0.145 0 0);
-	--popover: oklch(1 0 0);
-	--popover-foreground: oklch(0.145 0 0);
-	--secondary: oklch(0.97 0 0);
-	--secondary-foreground: oklch(0.205 0 0);
-	--destructive: oklch(0.577 0.245 27.325);
-	--destructive-foreground: oklch(0.985 0 0);
-	--ring: oklch(0.708 0 0);
-	--input: oklch(0.922 0 0);
-}
+  /* ── Aileron Design System — Warm Parchment + Verdigris ──────────────────
+   *
+   * Light mode default: warm cream paper backgrounds, dark ink foreground,
+   * and verdigris (oxidized copper, oklch hue ~188) as the primary accent.
+   *
+   * The parchment palette uses very low chroma (~0.010–0.013) neutrals at
+   * hue angle 70–80 so backgrounds feel warm without reading as yellow.
+   *
+   * Verdigris (oklch(0.44 0.13 188)) is the colour of antique scientific
+   * instruments, aeronautical charts, and maritime compasses — distinct from
+   * both Claude amber and generic teal, and legible on cream at WCAG AA.
+   * ────────────────────────────────────────────────────────────────────────── */
 
-.dark {
-	--background: oklch(0.22 0 0);
-	--foreground: oklch(0.92 0 0);
-	--muted: oklch(0.269 0 0);
-	--muted-foreground: oklch(0.708 0 0);
-	--border: oklch(1 0 0 / 10%);
-	--primary: oklch(0.922 0 0);
-	--primary-foreground: oklch(0.205 0 0);
-	--accent: oklch(0.371 0 0);
-	--accent-foreground: oklch(0.985 0 0);
-	/* shadcn-svelte additional tokens */
-	--card: oklch(0.269 0 0);
-	--card-foreground: oklch(0.92 0 0);
-	--popover: oklch(0.269 0 0);
-	--popover-foreground: oklch(0.92 0 0);
-	--secondary: oklch(0.269 0 0);
-	--secondary-foreground: oklch(0.985 0 0);
-	--destructive: oklch(0.396 0.141 25.723);
-	--destructive-foreground: oklch(0.985 0 0);
-	--ring: oklch(0.439 0 0);
-	--input: oklch(1 0 0 / 15%);
-}
+  :root {
+    /* Warm parchment backgrounds */
+    --background:         oklch(0.97 0.010 80);   /* cream page          */
+    --foreground:         oklch(0.18 0.015 55);   /* warm dark ink       */
 
-@theme inline {
-	--color-background: var(--background);
-	--color-foreground: var(--foreground);
-	--color-muted: var(--muted);
-	--color-muted-foreground: var(--muted-foreground);
-	--color-border: var(--border);
-	--color-primary: var(--primary);
-	--color-primary-foreground: var(--primary-foreground);
-	--color-accent: var(--accent);
-	--color-accent-foreground: var(--accent-foreground);
-	--color-card: var(--card);
-	--color-card-foreground: var(--card-foreground);
-	--color-popover: var(--popover);
-	--color-popover-foreground: var(--popover-foreground);
-	--color-secondary: var(--secondary);
-	--color-secondary-foreground: var(--secondary-foreground);
-	--color-destructive: var(--destructive);
-	--color-destructive-foreground: var(--destructive-foreground);
-	--color-ring: var(--ring);
-	--color-input: var(--input);
-}
+    --muted:              oklch(0.90 0.012 74);   /* warm tinted surface */
+    --muted-foreground:   oklch(0.46 0.016 58);   /* mid warm gray       */
 
-@layer base {
-	* {
-		@apply border-border;
-	}
-	body {
-		@apply bg-background text-foreground;
-		font-family: -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-		margin: 0;
-	}
-}
+    --card:               oklch(0.93 0.013 75);   /* buff sidebar/card   */
+    --card-foreground:    oklch(0.18 0.015 55);
 
-/* Prose typography for markdown content */
-.prose {
-	line-height: 1.75;
-	max-width: 85ch;
-}
-.prose h1 { font-size: 2.25rem; font-weight: 800; margin-top: 0; margin-bottom: 0.8rem; line-height: 1.1; }
-.prose h2 { font-size: 1.5rem; font-weight: 700; margin-top: 2rem; margin-bottom: 0.75rem; line-height: 1.3; border-bottom: 1px solid var(--border); padding-bottom: 0.3rem; }
-.prose h3 { font-size: 1.25rem; font-weight: 600; margin-top: 1.6rem; margin-bottom: 0.6rem; }
-.prose p { margin-top: 0; margin-bottom: 1.25rem; }
-.prose a { color: var(--primary); text-decoration: underline; text-underline-offset: 2px; }
-.prose a:hover { opacity: 0.8; }
-.prose strong { font-weight: 600; }
-.prose ul, .prose ol { margin-top: 0; margin-bottom: 1.25rem; padding-left: 1.625rem; }
-.prose li { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-.prose code { font-size: 0.875em; background: var(--muted); padding: 0.2em 0.4em; border-radius: 0.25rem; }
-.prose pre { background: var(--muted); padding: 1rem; border-radius: 0.5rem; overflow-x: auto; margin-top: 0; margin-bottom: 1.25rem; }
-.prose pre code { background: none; padding: 0; font-size: 0.875em; }
-.prose blockquote { border-left: 4px solid var(--border); padding-left: 1rem; margin-left: 0; margin-right: 0; color: var(--muted-foreground); }
-.prose hr { border-color: var(--border); margin: 2rem 0; }
-.prose table { width: 100%; border-collapse: collapse; margin-bottom: 1.25rem; }
-.prose th, .prose td { border: 1px solid var(--border); padding: 0.5rem 0.75rem; text-align: left; }
-.prose th { font-weight: 600; background: var(--muted); }
-.prose .meta { font-size: 0.8125rem; color: var(--muted-foreground); }
-.prose .meta table { width: auto; }
-.prose .meta th { font-weight: 500; background: none; white-space: nowrap; }
-.prose .meta td { color: var(--foreground); }
+    --popover:            oklch(0.97 0.010 80);
+    --popover-foreground: oklch(0.18 0.015 55);
+
+    --border:             oklch(0 0 0 / 8%);
+    --input:              oklch(0 0 0 / 11%);
+
+    /* Verdigris accent — the only real hue in the palette */
+    --primary:            oklch(0.44 0.13 188);
+    --primary-foreground: oklch(0.97 0.010 80);
+
+    --secondary:          oklch(0.90 0.012 74);
+    --secondary-foreground: oklch(0.18 0.015 55);
+
+    --accent:             oklch(0.90 0.012 74);
+    --accent-foreground:  oklch(0.18 0.015 55);
+
+    --destructive:        oklch(0.577 0.245 27.325);
+    --destructive-foreground: oklch(0.97 0.010 80);
+
+    --ring:               oklch(0.44 0.13 188);
+  }
+
+  @theme inline {
+    --color-background: var(--background);
+    --color-foreground: var(--foreground);
+    --color-muted: var(--muted);
+    --color-muted-foreground: var(--muted-foreground);
+    --color-border: var(--border);
+    --color-primary: var(--primary);
+    --color-primary-foreground: var(--primary-foreground);
+    --color-accent: var(--accent);
+    --color-accent-foreground: var(--accent-foreground);
+    --color-card: var(--card);
+    --color-card-foreground: var(--card-foreground);
+    --color-popover: var(--popover);
+    --color-popover-foreground: var(--popover-foreground);
+    --color-secondary: var(--secondary);
+    --color-secondary-foreground: var(--secondary-foreground);
+    --color-destructive: var(--destructive);
+    --color-destructive-foreground: var(--destructive-foreground);
+    --color-ring: var(--ring);
+    --color-input: var(--input);
+  }
+
+  @layer base {
+    * {
+      @apply border-border;
+    }
+    body {
+      @apply bg-background text-foreground;
+      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+      margin: 0;
+    }
+    code, pre, kbd, samp {
+      font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+    }
+  }
+
+  /* ── Aeronautical chart graticule overlay ────────────────────────────────
+   * Subtle latitude/longitude grid — the texture of sectional charts.
+   * Applied to page and sidebar backgrounds via .chart-graticule.
+   * ──────────────────────────────────────────────────────────────────────── */
+  .chart-graticule {
+    background-image:
+      repeating-linear-gradient(
+        0deg,
+        oklch(0.44 0.13 188 / 0.025) 0px,
+        oklch(0.44 0.13 188 / 0.025) 1px,
+        transparent 1px,
+        transparent 56px
+      ),
+      repeating-linear-gradient(
+        90deg,
+        oklch(0.44 0.13 188 / 0.025) 0px,
+        oklch(0.44 0.13 188 / 0.025) 1px,
+        transparent 1px,
+        transparent 56px
+      );
+  }
+
+  /* ── Bearing arrow — precedes h2 headings like a chart course indicator ──
+   * Usage: <h2 class="bearing-heading">…</h2>
+   * ──────────────────────────────────────────────────────────────────────── */
+  .bearing-heading::before {
+    content: '';
+    display: inline-block;
+    width: 22px;
+    height: 10px;
+    margin-right: 10px;
+    vertical-align: middle;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='10' viewBox='0 0 22 10'%3E%3Cline x1='0' y1='5' x2='16' y2='5' stroke='oklch(0.44 0.13 188)' stroke-width='1.5'/%3E%3Cpolygon points='13,2 22,5 13,8' fill='oklch(0.44 0.13 188)'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: contain;
+  }
+
+  /* ── Prose typography for markdown content ───────────────────────────────── */
+  .prose {
+    line-height: 1.75;
+    max-width: 85ch;
+  }
+  .prose h1 { font-size: 2.25rem; font-weight: 800; margin-top: 0; margin-bottom: 0.8rem; line-height: 1.1; }
+  .prose h2 {
+    font-size: 1.5rem; font-weight: 700; margin-top: 2rem; margin-bottom: 0.75rem;
+    line-height: 1.3; border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;
+    display: flex; align-items: center;
+  }
+  .prose h2::before {
+    content: '';
+    display: inline-block;
+    width: 22px;
+    height: 10px;
+    margin-right: 10px;
+    flex-shrink: 0;
+    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='10' viewBox='0 0 22 10'%3E%3Cline x1='0' y1='5' x2='16' y2='5' stroke='oklch(0.44 0.13 188)' stroke-width='1.5'/%3E%3Cpolygon points='13,2 22,5 13,8' fill='oklch(0.44 0.13 188)'/%3E%3C/svg%3E");
+    background-repeat: no-repeat;
+    background-size: contain;
+  }
+  .prose h3 { font-size: 1.25rem; font-weight: 600; margin-top: 1.6rem; margin-bottom: 0.6rem; }
+  .prose p { margin-top: 0; margin-bottom: 1.25rem; }
+  .prose a { color: var(--primary); text-decoration: underline; text-underline-offset: 2px; }
+  .prose a:hover { opacity: 0.8; }
+  .prose strong { font-weight: 600; }
+  .prose ul, .prose ol { margin-top: 0; margin-bottom: 1.25rem; padding-left: 1.625rem; }
+  .prose li { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+  .prose code { font-size: 0.875em; background: var(--muted); padding: 0.2em 0.4em; border-radius: 0.25rem; }
+  .prose pre {
+    background: var(--muted); padding: 1rem; border-radius: 0.5rem;
+    overflow-x: auto; margin-top: 0; margin-bottom: 1.25rem;
+    border: 1px solid var(--border);
+    border-top: 2px solid var(--primary);
+  }
+  .prose pre code { background: none; padding: 0; font-size: 0.875em; }
+  .prose blockquote {
+    border-left: 3px solid var(--primary); padding-left: 1rem;
+    margin-left: 0; margin-right: 0; color: var(--muted-foreground);
+  }
+  .prose hr { border-color: var(--border); margin: 2rem 0; }
+  .prose table { width: 100%; border-collapse: collapse; margin-bottom: 1.25rem; }
+  .prose th, .prose td { border: 1px solid var(--border); padding: 0.5rem 0.75rem; text-align: left; }
+  .prose th { font-weight: 600; background: var(--muted); }
+  .prose .meta { font-size: 0.8125rem; color: var(--muted-foreground); }
+  .prose .meta table { width: auto; }
+  .prose .meta th { font-weight: 500; background: none; white-space: nowrap; }
+  .prose .meta td { color: var(--foreground); }
+
+  /* ── Custom scrollbar ────────────────────────────────────────────────────── */
+  ::-webkit-scrollbar { width: 6px; height: 6px; }
+  ::-webkit-scrollbar-track { background: transparent; }
+  ::-webkit-scrollbar-thumb { background: oklch(0 0 0 / 0.13); border-radius: 3px; }
+  ::-webkit-scrollbar-thumb:hover { background: oklch(0.44 0.13 188 / 0.4); }
+  

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -1,7 +1,7 @@
 @import "tailwindcss";
   @import url('https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700;800&family=JetBrains+Mono:wght@400;500&display=swap');
 
-  @custom-variant dark (&:is(.dark *));
+@custom-variant dark (&:is(.dark *));
 
   /* ── Aileron Design System — Warm Parchment + Verdigris ──────────────────
    *
@@ -16,165 +16,165 @@
    * both Claude amber and generic teal, and legible on cream at WCAG AA.
    * ────────────────────────────────────────────────────────────────────────── */
 
-  :root {
-    /* Warm parchment backgrounds */
-    --background:         oklch(0.97 0.010 80);   /* cream page          */
-    --foreground:         oklch(0.18 0.015 55);   /* warm dark ink       */
+:root {
+	/* Warm parchment backgrounds */
+	--background:         oklch(0.97 0.010 80);   /* cream page          */
+	--foreground:         oklch(0.18 0.015 55);   /* warm dark ink       */
 
-    --muted:              oklch(0.90 0.012 74);   /* warm tinted surface */
-    --muted-foreground:   oklch(0.46 0.016 58);   /* mid warm gray       */
+	--muted:              oklch(0.90 0.012 74);   /* warm tinted surface */
+	--muted-foreground:   oklch(0.46 0.016 58);   /* mid warm gray       */
 
-    --card:               oklch(0.93 0.013 75);   /* buff sidebar/card   */
-    --card-foreground:    oklch(0.18 0.015 55);
+	--card:               oklch(0.93 0.013 75);   /* buff sidebar/card   */
+	--card-foreground:    oklch(0.18 0.015 55);
 
-    --popover:            oklch(0.97 0.010 80);
-    --popover-foreground: oklch(0.18 0.015 55);
+	--popover:            oklch(0.97 0.010 80);
+	--popover-foreground: oklch(0.18 0.015 55);
 
-    --border:             oklch(0 0 0 / 8%);
-    --input:              oklch(0 0 0 / 11%);
+	--border:             oklch(0 0 0 / 8%);
+	--input:              oklch(0 0 0 / 11%);
 
-    /* Verdigris accent — the only real hue in the palette */
-    --primary:            oklch(0.44 0.13 188);
-    --primary-foreground: oklch(0.97 0.010 80);
+	/* Verdigris accent — the only real hue in the palette */
+	--primary:            oklch(0.44 0.13 188);
+	--primary-foreground: oklch(0.97 0.010 80);
 
-    --secondary:          oklch(0.90 0.012 74);
-    --secondary-foreground: oklch(0.18 0.015 55);
+	--secondary:          oklch(0.90 0.012 74);
+	--secondary-foreground: oklch(0.18 0.015 55);
 
-    --accent:             oklch(0.90 0.012 74);
-    --accent-foreground:  oklch(0.18 0.015 55);
+	--accent:             oklch(0.90 0.012 74);
+	--accent-foreground:  oklch(0.18 0.015 55);
 
-    --destructive:        oklch(0.577 0.245 27.325);
-    --destructive-foreground: oklch(0.97 0.010 80);
+	--destructive:        oklch(0.577 0.245 27.325);
+	--destructive-foreground: oklch(0.97 0.010 80);
 
-    --ring:               oklch(0.44 0.13 188);
-  }
+	--ring:               oklch(0.44 0.13 188);
+}
 
-  @theme inline {
-    --color-background: var(--background);
-    --color-foreground: var(--foreground);
-    --color-muted: var(--muted);
-    --color-muted-foreground: var(--muted-foreground);
-    --color-border: var(--border);
-    --color-primary: var(--primary);
-    --color-primary-foreground: var(--primary-foreground);
-    --color-accent: var(--accent);
-    --color-accent-foreground: var(--accent-foreground);
-    --color-card: var(--card);
-    --color-card-foreground: var(--card-foreground);
-    --color-popover: var(--popover);
-    --color-popover-foreground: var(--popover-foreground);
-    --color-secondary: var(--secondary);
-    --color-secondary-foreground: var(--secondary-foreground);
-    --color-destructive: var(--destructive);
-    --color-destructive-foreground: var(--destructive-foreground);
-    --color-ring: var(--ring);
-    --color-input: var(--input);
-  }
+@theme inline {
+	--color-background: var(--background);
+	--color-foreground: var(--foreground);
+	--color-muted: var(--muted);
+	--color-muted-foreground: var(--muted-foreground);
+	--color-border: var(--border);
+	--color-primary: var(--primary);
+	--color-primary-foreground: var(--primary-foreground);
+	--color-accent: var(--accent);
+	--color-accent-foreground: var(--accent-foreground);
+	--color-card: var(--card);
+	--color-card-foreground: var(--card-foreground);
+	--color-popover: var(--popover);
+	--color-popover-foreground: var(--popover-foreground);
+	--color-secondary: var(--secondary);
+	--color-secondary-foreground: var(--secondary-foreground);
+	--color-destructive: var(--destructive);
+	--color-destructive-foreground: var(--destructive-foreground);
+	--color-ring: var(--ring);
+	--color-input: var(--input);
+}
 
-  @layer base {
-    * {
-      @apply border-border;
-    }
-    body {
-      @apply bg-background text-foreground;
-      font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
-      margin: 0;
-    }
-    code, pre, kbd, samp {
-      font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
-    }
-  }
+@layer base {
+	* {
+		@apply border-border;
+	}
+	body {
+		@apply bg-background text-foreground;
+		font-family: 'Inter', -apple-system, BlinkMacSystemFont, 'Segoe UI', system-ui, sans-serif;
+		margin: 0;
+	  }
+	  code, pre, kbd, samp {
+		font-family: 'JetBrains Mono', 'Fira Code', ui-monospace, monospace;
+	}
+}
 
   /* ── Aeronautical chart graticule overlay ────────────────────────────────
    * Subtle latitude/longitude grid — the texture of sectional charts.
    * Applied to page and sidebar backgrounds via .chart-graticule.
    * ──────────────────────────────────────────────────────────────────────── */
   .chart-graticule {
-    background-image:
-      repeating-linear-gradient(
-        0deg,
-        oklch(0.44 0.13 188 / 0.025) 0px,
-        oklch(0.44 0.13 188 / 0.025) 1px,
-        transparent 1px,
-        transparent 56px
-      ),
-      repeating-linear-gradient(
-        90deg,
-        oklch(0.44 0.13 188 / 0.025) 0px,
-        oklch(0.44 0.13 188 / 0.025) 1px,
-        transparent 1px,
-        transparent 56px
-      );
+	background-image:
+	  repeating-linear-gradient(
+		0deg,
+		oklch(0.44 0.13 188 / 0.025) 0px,
+		oklch(0.44 0.13 188 / 0.025) 1px,
+		transparent 1px,
+		transparent 56px
+	  ),
+	  repeating-linear-gradient(
+		90deg,
+		oklch(0.44 0.13 188 / 0.025) 0px,
+		oklch(0.44 0.13 188 / 0.025) 1px,
+		transparent 1px,
+		transparent 56px
+	  );
   }
 
   /* ── Bearing arrow — precedes h2 headings like a chart course indicator ──
    * Usage: <h2 class="bearing-heading">…</h2>
    * ──────────────────────────────────────────────────────────────────────── */
   .bearing-heading::before {
-    content: '';
-    display: inline-block;
-    width: 22px;
-    height: 10px;
-    margin-right: 10px;
-    vertical-align: middle;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='10' viewBox='0 0 22 10'%3E%3Cline x1='0' y1='5' x2='16' y2='5' stroke='oklch(0.44 0.13 188)' stroke-width='1.5'/%3E%3Cpolygon points='13,2 22,5 13,8' fill='oklch(0.44 0.13 188)'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-size: contain;
+	content: '';
+	display: inline-block;
+	width: 22px;
+	height: 10px;
+	margin-right: 10px;
+	vertical-align: middle;
+	background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='10' viewBox='0 0 22 10'%3E%3Cline x1='0' y1='5' x2='16' y2='5' stroke='oklch(0.44 0.13 188)' stroke-width='1.5'/%3E%3Cpolygon points='13,2 22,5 13,8' fill='oklch(0.44 0.13 188)'/%3E%3C/svg%3E");
+	background-repeat: no-repeat;
+	background-size: contain;
   }
 
   /* ── Prose typography for markdown content ───────────────────────────────── */
-  .prose {
-    line-height: 1.75;
-    max-width: 85ch;
-  }
-  .prose h1 { font-size: 2.25rem; font-weight: 800; margin-top: 0; margin-bottom: 0.8rem; line-height: 1.1; }
-  .prose h2 {
-    font-size: 1.5rem; font-weight: 700; margin-top: 2rem; margin-bottom: 0.75rem;
-    line-height: 1.3; border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;
-    display: flex; align-items: center;
-  }
-  .prose h2::before {
-    content: '';
-    display: inline-block;
-    width: 22px;
-    height: 10px;
-    margin-right: 10px;
-    flex-shrink: 0;
-    background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='10' viewBox='0 0 22 10'%3E%3Cline x1='0' y1='5' x2='16' y2='5' stroke='oklch(0.44 0.13 188)' stroke-width='1.5'/%3E%3Cpolygon points='13,2 22,5 13,8' fill='oklch(0.44 0.13 188)'/%3E%3C/svg%3E");
-    background-repeat: no-repeat;
-    background-size: contain;
-  }
-  .prose h3 { font-size: 1.25rem; font-weight: 600; margin-top: 1.6rem; margin-bottom: 0.6rem; }
-  .prose p { margin-top: 0; margin-bottom: 1.25rem; }
-  .prose a { color: var(--primary); text-decoration: underline; text-underline-offset: 2px; }
-  .prose a:hover { opacity: 0.8; }
-  .prose strong { font-weight: 600; }
-  .prose ul, .prose ol { margin-top: 0; margin-bottom: 1.25rem; padding-left: 1.625rem; }
-  .prose li { margin-top: 0.25rem; margin-bottom: 0.25rem; }
-  .prose code { font-size: 0.875em; background: var(--muted); padding: 0.2em 0.4em; border-radius: 0.25rem; }
-  .prose pre {
-    background: var(--muted); padding: 1rem; border-radius: 0.5rem;
-    overflow-x: auto; margin-top: 0; margin-bottom: 1.25rem;
-    border: 1px solid var(--border);
-    border-top: 2px solid var(--primary);
-  }
-  .prose pre code { background: none; padding: 0; font-size: 0.875em; }
-  .prose blockquote {
-    border-left: 3px solid var(--primary); padding-left: 1rem;
-    margin-left: 0; margin-right: 0; color: var(--muted-foreground);
-  }
-  .prose hr { border-color: var(--border); margin: 2rem 0; }
-  .prose table { width: 100%; border-collapse: collapse; margin-bottom: 1.25rem; }
-  .prose th, .prose td { border: 1px solid var(--border); padding: 0.5rem 0.75rem; text-align: left; }
-  .prose th { font-weight: 600; background: var(--muted); }
-  .prose .meta { font-size: 0.8125rem; color: var(--muted-foreground); }
-  .prose .meta table { width: auto; }
-  .prose .meta th { font-weight: 500; background: none; white-space: nowrap; }
-  .prose .meta td { color: var(--foreground); }
+.prose {
+	line-height: 1.75;
+	max-width: 85ch;
+}
+.prose h1 { font-size: 2.25rem; font-weight: 800; margin-top: 0; margin-bottom: 0.8rem; line-height: 1.1; }
+.prose h2 {
+  font-size: 1.5rem; font-weight: 700; margin-top: 2rem; margin-bottom: 0.75rem;
+  line-height: 1.3; border-bottom: 1px solid var(--border); padding-bottom: 0.3rem;
+  display: flex; align-items: center;
+}
+.prose h2::before {
+  content: '';
+  display: inline-block;
+  width: 22px;
+  height: 10px;
+  margin-right: 10px;
+  flex-shrink: 0;
+  background-image: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='22' height='10' viewBox='0 0 22 10'%3E%3Cline x1='0' y1='5' x2='16' y2='5' stroke='oklch(0.44 0.13 188)' stroke-width='1.5'/%3E%3Cpolygon points='13,2 22,5 13,8' fill='oklch(0.44 0.13 188)'/%3E%3C/svg%3E");
+  background-repeat: no-repeat;
+  background-size: contain;
+}
+.prose h3 { font-size: 1.25rem; font-weight: 600; margin-top: 1.6rem; margin-bottom: 0.6rem; }
+.prose p { margin-top: 0; margin-bottom: 1.25rem; }
+.prose a { color: var(--primary); text-decoration: underline; text-underline-offset: 2px; }
+.prose a:hover { opacity: 0.8; }
+.prose strong { font-weight: 600; }
+.prose ul, .prose ol { margin-top: 0; margin-bottom: 1.25rem; padding-left: 1.625rem; }
+.prose li { margin-top: 0.25rem; margin-bottom: 0.25rem; }
+.prose code { font-size: 0.875em; background: var(--muted); padding: 0.2em 0.4em; border-radius: 0.25rem; }
+.prose pre {
+  background: var(--muted); padding: 1rem; border-radius: 0.5rem;
+  overflow-x: auto; margin-top: 0; margin-bottom: 1.25rem;
+  border: 1px solid var(--border);
+  border-top: 2px solid var(--primary);
+}
+.prose pre code { background: none; padding: 0; font-size: 0.875em; }
+.prose blockquote {
+  border-left: 3px solid var(--primary); padding-left: 1rem;
+  margin-left: 0; margin-right: 0; color: var(--muted-foreground);
+}
+.prose hr { border-color: var(--border); margin: 2rem 0; }
+.prose table { width: 100%; border-collapse: collapse; margin-bottom: 1.25rem; }
+.prose th, .prose td { border: 1px solid var(--border); padding: 0.5rem 0.75rem; text-align: left; }
+.prose th { font-weight: 600; background: var(--muted); }
+.prose .meta { font-size: 0.8125rem; color: var(--muted-foreground); }
+.prose .meta table { width: auto; }
+.prose .meta th { font-weight: 500; background: none; white-space: nowrap; }
+.prose .meta td { color: var(--foreground); }
 
-  /* ── Custom scrollbar ────────────────────────────────────────────────────── */
-  ::-webkit-scrollbar { width: 6px; height: 6px; }
-  ::-webkit-scrollbar-track { background: transparent; }
-  ::-webkit-scrollbar-thumb { background: oklch(0 0 0 / 0.13); border-radius: 3px; }
-  ::-webkit-scrollbar-thumb:hover { background: oklch(0.44 0.13 188 / 0.4); }
+/* ── Custom scrollbar ────────────────────────────────────────────────────── */
+::-webkit-scrollbar { width: 6px; height: 6px; }
+::-webkit-scrollbar-track { background: transparent; }
+::-webkit-scrollbar-thumb { background: oklch(0 0 0 / 0.13); border-radius: 3px; }
+::-webkit-scrollbar-thumb:hover { background: oklch(0.44 0.13 188 / 0.4); }
   


### PR DESCRIPTION
## Design proposal: Warm Parchment + Verdigris Aeronautical Theme

  This PR proposes a new visual design direction for the Aileron docs site, developed through an iterative exploration. It replaces the current neutral gray palette with a warm, distinctive system built around two ideas:

  ### The palette

  **Warm parchment backgrounds** — the base uses very-low-chroma cream/buff neutrals (oklch hue ~75–80) so pages feel like reading quality paper rather than staring at a screen. The sidebar is slightly warmer/darker than the page body, giving a tonal separation like a book's margin vs its text block.

  **Verdigris accent** (`oklch(0.44 0.13 188)`) — the oxidised-copper green of antique scientific instruments, aeronautical charts, and maritime compasses. It reads as distinctive without being loud, contrasts cleanly on cream at WCAG AA, and is completely clear of Claude's amber/orange brand space.

  ### The aeronautical layer

  "Aileron" is a flight control surface. The design folds in aeronautical chart language as a subtle texture layer — visible to anyone who knows aviation, invisible as theming to everyone else:

  - **Graticule grid** — the latitude/longitude crosshatch of a VFR sectional chart runs at very low opacity across the page and sidebar (`.chart-graticule` CSS utility class)
  - **Compass rose watermark** — in the main content area (currently in mockup only — can be added as a background SVG to the prose layout if desired)
  - **Bearing arrows** — section headings (`h2`) get a small verdigris vector arrow prefix via CSS `::before`, matching the course-heading notation on aeronautical charts
  - **Waypoint diamond** — the active sidebar item is marked with a small filled rotated square (the standard aeronautical waypoint fix symbol), replacing the plain left border bar
  - **VOR range rings** — faint concentric circles in the sidebar's lower corner, like a VHF Omnidirectional Range station radius on a sectional chart
  - **Brand wordmark** — "AILERON" in verdigris, spaced as a chart label, with "Docs" in muted foreground beside it

  ### Typography

  - **Inter** replaces the system font stack for body and headings — tighter, more architectural
  - **JetBrains Mono** replaces the default monospace for all code blocks

  ### Files changed

  | File | Change |
  |------|--------|
  | `docs/src/styles/global.css` | New warm-parchment + verdigris CSS variable system, graticule utility, bearing-arrow heading pseudo-element, Inter/JetBrains Mono imports, verdigris scrollbar |
  | `docs/src/layouts/BaseLayout.astro` | Google Fonts preconnect + stylesheet link, updated header with verdigris wordmark + plane icon badge, `chart-graticule` on body and header, removed hardcoded `.dark` class |
  | `docs/src/components/Sidebar.svelte` | Verdigris active states (`text-primary`), waypoint diamond indicator, VOR range ring SVG, section header labels in uppercase tracking style |

  ### What this does not change

  - No Astro content files, no MDX, no navigation structure
  - No package.json changes (fonts loaded via CDN `<link>`)
  - No shadcn component changes — all colour tokens map through the existing CSS variable system

  ---

  *Mockup developed interactively in Replit — canvas previews available showing all explored directions (dark verdigris, ink blue, claret, and the final warm-parchment variant).*