### PR TITLE
feat(failure): structured failure envelope, bounded retry, audit log

### DIFF
--- a/docs/src/content/docs/adr/0010-failure-handling.md
+++ b/docs/src/content/docs/adr/0010-failure-handling.md
@@ -233,10 +233,18 @@ Rejected because it imposes a class-hierarchy ceremony that doesn't pay off in t
 
 ### For Aileron runtime
 
-- The runtime implements bounded retry with exponential backoff for `retriable: true` errors. v1 default: 3 retries; uniform across actions.
+- The runtime implements bounded retry with exponential backoff for `retriable: true` errors. v1 default: 3 retries; uniform across actions. Implementation lives in [`internal/retry`](https://github.com/ALRubinger/aileron/blob/main/internal/retry); the [`internal/clock`](https://github.com/ALRubinger/aileron/blob/main/internal/clock) abstraction makes retry tests deterministic.
 - Idempotency is checked at the runtime/connector boundary; the runtime trusts the connector's `[connector.idempotency]` declaration but enforces the default-on-retry policy.
-- The structured error envelope is constructed at the boundary that produced the error and passed through unchanged. Boundaries don't rewrap each other's errors.
-- Audit logging records every failure with full context: class, message, boundary, retried-count, action and connector identity, time, audit ID.
+- The structured error envelope is constructed at the boundary that produced the error and passed through unchanged. Boundaries don't rewrap each other's errors. The closed taxonomy lives in [`internal/failure`](https://github.com/ALRubinger/aileron/blob/main/internal/failure); only the package's per-class constructors can produce a valid Failure value, so handlers cannot synthesize an arbitrary class string.
+- Audit logging records every failure with full context: class, message, boundary, retried-count, actor identity, time, audit ID. Implementation lives in [`internal/audit`](https://github.com/ALRubinger/aileron/blob/main/internal/audit) on top of the existing `Store` SPI; v1 ships an in-memory implementation, with Postgres persistence post-MVP.
+
+### Scope: which envelope applies where
+
+The ADR-0010 envelope applies to **errors returned to the calling action and through it to the agent** — the gateway endpoints (`/v1/chat/completions`, `/v1/messages`) and action / connector install responses.
+
+Other API endpoints (intents, approvals, policies, accounts, auth) retain the existing `api.Error` envelope (`{error: {code, message, details, request_id}}`). Those errors are CRUD-shaped and don't fit ADR-0010's runtime taxonomy of `network_error` / `capability_denied` / etc. Forcing them in would either expand the closed taxonomy beyond its semantic anchor or drop fidelity. Consumers that want a single unified shape can layer one in their own client; the server emits two stable envelopes by design.
+
+The `internal/auth` package was previously emitting a third, ad-hoc shape (`{"error": "<string>"}`). Stage 5 of #356 normalised those handlers to the standard `api.Error` shape so the v1 server emits exactly two envelope shapes — the gateway/action `FailureEnvelope` and the CRUD `api.Error`.
 
 ### For users
 

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -10,6 +10,7 @@ import (
 	"sync"
 
 	"github.com/ALRubinger/aileron/internal/cstore"
+	"github.com/ALRubinger/aileron/internal/failure"
 	"github.com/ALRubinger/aileron/internal/sandbox"
 )
 
@@ -17,12 +18,13 @@ import (
 // and returns a Result whose Content becomes the tool-result message
 // the LLM observes.
 //
-// Per [ADR-0010], action-side failures are returned as Results with
-// IsError=true rather than as Go errors — the LLM sees the failure as
-// a tool result and can decide how to proceed (retry, fall back to a
-// different action, ask the user). A returned `error` is reserved for
-// gateway-fatal conditions that should terminate the conversation
-// turn (e.g. action not found, executor misconfigured).
+// Per [ADR-0010], action-side failures are returned as Results carrying
+// a non-nil [failure.Failure] (mapped to ADR-0010's structured
+// envelope) rather than as Go errors — the LLM sees the failure as a
+// tool result and can decide how to proceed (retry, fall back, ask the
+// user). A returned `error` is reserved for gateway-fatal conditions
+// that should terminate the conversation turn (e.g. action not found,
+// executor misconfigured).
 //
 // [ADR-0010]: https://docs.withaileron.ai/adr/0010-failure-handling
 type Executor interface {
@@ -30,20 +32,25 @@ type Executor interface {
 }
 
 // Result is the synthesized tool-result content surfaced to the LLM.
-// Both OpenAI's `tool` message and Anthropic's `tool_result` content
-// block use a string body; the IsError flag is mapped to Anthropic's
-// `is_error` field and prepended to OpenAI's content as a marker.
+// Success and failure are mutually exclusive: when Failure is non-nil
+// the result is an error and Content is unused; when Failure is nil
+// the action succeeded and Content carries the payload (a JSON
+// document or plain prose).
+//
+// On the wire, Failure is rendered into the agent-visible tool-result
+// shape via [failure.ToOpenAIToolMessage] / [failure.ToAnthropicToolResult],
+// so the LLM sees a stable structured envelope regardless of provider.
 type Result struct {
-	// Content is the JSON-encoded tool result body. Implementations
-	// SHOULD return JSON the LLM can parse, but plain prose is
-	// acceptable when the action's output is naturally a sentence.
+	// Content is the success payload. JSON the LLM can parse is the
+	// preferred shape, but plain prose is acceptable for actions
+	// whose output is naturally a sentence.
 	Content string
 
-	// IsError reports whether the action failed in a way the LLM
-	// should be informed of. Per ADR-0010, this surfaces as
-	// `is_error: true` on Anthropic tool_result blocks and is encoded
-	// into the OpenAI tool-message body as a sentinel JSON shape.
-	IsError bool
+	// Failure marks an action-side error per ADR-0010. Mutually
+	// exclusive with a populated Content; the gateway's intercept
+	// layer renders the failure into the provider-shaped tool-result
+	// the LLM sees.
+	Failure *failure.Failure
 }
 
 // StubExecutor returns a placeholder JSON result describing what
@@ -88,16 +95,16 @@ func (StubExecutor) Execute(_ context.Context, name string, args map[string]any)
 //  6. Aggregate per-step outputs into the Result.
 //
 // First-failure-terminates per ADR-0010: the first step error returns
-// an IsError Result; later steps are not invoked. Successful prior
-// steps are *not* rolled back (ADR-0010's "no auto-compensation"
-// rule).
+// a Result whose Failure is populated; later steps are not invoked.
+// Successful prior steps are *not* rolled back (ADR-0010's "no
+// auto-compensation" rule).
 type SandboxExecutor struct {
-	Actions    *Store
-	Store      *cstore.Store
-	Runtime    sandbox.Runtime
+	Actions *Store
+	Store   *cstore.Store
+	Runtime sandbox.Runtime
 
-	mu       sync.Mutex
-	cache    map[string]sandbox.Connector // keyed by canonical hash "sha256:<hex>"
+	mu    sync.Mutex
+	cache map[string]sandbox.Connector // keyed by canonical hash "sha256:<hex>"
 }
 
 // NewSandboxExecutor builds a SandboxExecutor with the supplied
@@ -183,9 +190,9 @@ func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[str
 		// Last step's output is the action's output by convention.
 		if i == len(manifest.Execute)-1 {
 			body, mErr := json.Marshal(map[string]any{
-				"action":  name,
-				"output":  res.Output,
-				"steps":   stepOutputs,
+				"action": name,
+				"output": res.Output,
+				"steps":  stepOutputs,
 			})
 			if mErr != nil {
 				return Result{}, mErr
@@ -231,130 +238,127 @@ func (e *SandboxExecutor) connectorFor(ctx context.Context, m *Manifest, connect
 	if err != nil {
 		return nil, fmt.Errorf("read connector manifest: %w", err)
 	}
-	manifest, err := cstore.ParseManifest(filepath.Join(entryDir, "manifest.toml"), manifestBytes)
+	cmf, err := cstore.ParseManifest(filepath.Join(entryDir, "manifest.toml"), manifestBytes)
 	if err != nil {
 		return nil, err
 	}
-	binary, err := loadConnectorBinary(entryDir)
+	binPath := filepath.Join(entryDir, "connector.wasm")
+	if _, statErr := os.Stat(binPath); errors.Is(statErr, os.ErrNotExist) {
+		binPath = filepath.Join(entryDir, "connector.wat")
+	}
+	binBytes, err := os.ReadFile(binPath)
+	if err != nil {
+		return nil, fmt.Errorf("read connector binary: %w", err)
+	}
+	conn, err := e.Runtime.Compile(ctx, cmf, binBytes)
 	if err != nil {
 		return nil, err
 	}
-
-	conn, err := e.Runtime.Compile(ctx, manifest, binary)
-	if err != nil {
-		return nil, err
-	}
-
 	e.mu.Lock()
-	if existing, ok := e.cache[dep.Hash]; ok {
-		// A concurrent caller won the race; drop ours and use theirs.
-		e.mu.Unlock()
-		_ = conn.Close(ctx)
-		return existing, nil
-	}
 	e.cache[dep.Hash] = conn
 	e.mu.Unlock()
 	return conn, nil
 }
 
-// loadConnectorBinary reads the connector binary from the entry
-// directory. The file is named connector.wasm or connector.bin per
-// ADR-0004's tarball layout.
-func loadConnectorBinary(entryDir string) ([]byte, error) {
-	for _, name := range []string{"connector.wasm", "connector.bin"} {
-		data, err := os.ReadFile(filepath.Join(entryDir, name))
-		if err == nil {
-			return data, nil
-		}
-		if !errors.Is(err, os.ErrNotExist) {
-			return nil, err
-		}
-	}
-	return nil, fmt.Errorf("entry %s contains no connector binary (connector.wasm or connector.bin)", entryDir)
-}
-
 // mergeArgs combines the call-time args with the action's declared
-// step Inputs. Call-time args take precedence on key collisions —
-// untemplated step Inputs serve as defaults.
-func mergeArgs(callArgs map[string]any, stepInputs map[string]any) map[string]any {
-	out := make(map[string]any, len(callArgs)+len(stepInputs))
+// step inputs. Caller args win on key conflict (the LLM's
+// interpretation of the user message takes precedence over the
+// author's static defaults).
+func mergeArgs(args, stepInputs map[string]any) map[string]any {
+	out := make(map[string]any, len(args)+len(stepInputs))
 	for k, v := range stepInputs {
 		out[k] = v
 	}
-	for k, v := range callArgs {
+	for k, v := range args {
 		out[k] = v
 	}
 	return out
 }
 
-// allowedAuthorityFor returns the action's declared subset of
-// network host:port pairs for the given connector, used by the
-// sandbox's host-policy as the action-boundary capability subset.
-//
-// v1's action manifest does not separately list network hosts (the
-// action declares operation capabilities via `capabilities`). Until a
-// dedicated network-subset field lands, the empty slice signals "no
-// extra restriction" — the connector manifest's grant is the only
-// gate. The seam is here so the action-boundary network gate lights
-// up automatically when the schema gains the field.
+// allowedAuthorityFor returns the network authority subset the action
+// permits for the given connector — the intersection of the
+// connector's manifest network capability and the action's declared
+// subset. v1 doesn't yet enforce subset narrowing at the action layer
+// for network; the connector's manifest is authoritative until #362
+// lands binding-level scoping. This function exists so the call site
+// passes through whatever the action allows.
 func allowedAuthorityFor(_ *Manifest, _ string) []string {
+	// Returning nil tells the sandbox to defer to the connector
+	// manifest's `[capabilities.network].hosts`. Action-level
+	// subset narrowing for network capabilities lands in a follow-up.
 	return nil
 }
 
-// errorResult wraps a sandbox or capability error into a tool-result
-// that the LLM sees as IsError per ADR-0010. The structured error's
-// fields are preserved in the body so the LLM (and audit log) can
-// reason about class/boundary/details.
+// errorResult wraps a sandbox or capability error into a Result whose
+// Failure is the ADR-0010 envelope the LLM sees as a tool-result.
+// Recognised typed errors (`*action.Error`, `*sandbox.Error`,
+// `*cstore.Error`) carry Class/Boundary/Retriable/Details and map to
+// the corresponding [failure] constructor; other errors fall back to
+// `connector_runtime_error` with boundary `runtime`.
 func errorResult(err error) Result {
-	body, mErr := json.Marshal(map[string]any{
-		"error": errorEnvelope(err),
-	})
-	if mErr != nil {
-		return Result{Content: fmt.Sprintf(`{"error":{"class":"internal_error","message":%q}}`, err.Error()), IsError: true}
-	}
-	return Result{Content: string(body), IsError: true}
+	return Result{Failure: failureFromError(err)}
 }
 
-// errorEnvelope produces an ADR-0010-shaped JSON map from any error
-// the executor encountered. Recognized types (`*action.Error`,
-// `*sandbox.Error`, `*cstore.Error`) preserve their fields; other
-// errors are rendered as a generic envelope.
-func errorEnvelope(err error) map[string]any {
-	out := map[string]any{
-		"class":   "internal_error",
-		"message": err.Error(),
+// failureFromError converts an executor-side error into a
+// *failure.Failure whose class / boundary / retriable values fit
+// ADR-0010's closed taxonomy. The mapping preserves details and
+// wraps the original error as the Failure's cause.
+func failureFromError(err error) *failure.Failure {
+	if err == nil {
+		return nil
 	}
 	var aerr *Error
 	if errors.As(err, &aerr) {
-		out["class"] = string(aerr.Class)
-		out["message"] = aerr.Message
-		out["boundary"] = string(aerr.Boundary)
+		opts := []failure.Option{failure.WithCause(err)}
 		if aerr.Details != nil {
-			out["details"] = aerr.Details
+			opts = append(opts, failure.WithDetails(aerr.Details))
 		}
-		return out
+		switch aerr.Class {
+		case ClassCapabilityDenied:
+			return failure.CapabilityDeniedAt(failure.Action, aerr.Message, opts...)
+		}
+		// Other action-package classes (parse_error, validation_error,
+		// not_found) are install-time concerns; if they leak into a
+		// runtime call, surface as a runtime error so the LLM sees a
+		// closed-taxonomy class.
+		opts = append(opts, failure.WithBoundary(failure.Runtime))
+		return failure.ConnectorRuntime(aerr.Message, false, opts...)
 	}
 	var serr *sandbox.Error
 	if errors.As(err, &serr) {
-		out["class"] = string(serr.Class)
-		out["message"] = serr.Message
-		out["boundary"] = string(serr.Boundary)
-		out["retriable"] = serr.Retriable
+		opts := []failure.Option{failure.WithCause(err)}
 		if serr.Details != nil {
-			out["details"] = serr.Details
+			opts = append(opts, failure.WithDetails(serr.Details))
 		}
-		return out
+		switch serr.Class {
+		case sandbox.ClassCapabilityDenied:
+			return failure.CapabilityDeniedAt(failure.Sandbox, serr.Message, opts...)
+		case sandbox.ClassResourceLimitExceeded:
+			return failure.ResourceLimitFailure(serr.Message, opts...)
+		}
+		// connector_runtime_error or connector_load_failed — both map
+		// to ConnectorRuntimeError in ADR-0010's closed taxonomy.
+		return failure.ConnectorRuntime(serr.Message, serr.Retriable, opts...)
 	}
 	var cerr *cstore.Error
 	if errors.As(err, &cerr) {
-		out["class"] = string(cerr.Class)
-		out["message"] = cerr.Message
-		out["boundary"] = string(cerr.Boundary)
-		out["retriable"] = cerr.Retriable
+		opts := []failure.Option{failure.WithCause(err)}
 		if cerr.Details != nil {
-			out["details"] = cerr.Details
+			opts = append(opts, failure.WithDetails(cerr.Details))
 		}
-		return out
+		switch cerr.Class {
+		case cstore.ClassHashMismatch:
+			return failure.HashMismatchFailure(cerr.Message, opts...)
+		case cstore.ClassSignatureFailure:
+			return failure.SignatureFailureFailure(cerr.Message, opts...)
+		}
+		// Install-time classes (parse, validation, fetch, malformed,
+		// fqn_mismatch, unknown_scheme, store_unwritable) leaking into
+		// runtime → ConnectorRuntimeError, runtime boundary.
+		opts = append(opts, failure.WithBoundary(failure.Runtime))
+		return failure.ConnectorRuntime(cerr.Message, cerr.Retriable, opts...)
 	}
-	return out
+	return failure.ConnectorRuntime(err.Error(), false,
+		failure.WithBoundary(failure.Runtime),
+		failure.WithCause(err))
 }

--- a/internal/action/executor_sandbox_test.go
+++ b/internal/action/executor_sandbox_test.go
@@ -10,6 +10,7 @@ import (
 	"testing"
 
 	"github.com/ALRubinger/aileron/internal/cstore"
+	"github.com/ALRubinger/aileron/internal/failure"
 	"github.com/ALRubinger/aileron/internal/sandbox"
 )
 
@@ -154,7 +155,7 @@ func TestSandboxExecutor_HappyPath_RunsStepsInOrder(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute: %v", err)
 	}
-	if res.IsError {
+	if res.Failure != nil {
 		t.Errorf("expected non-error result; got %+v", res)
 	}
 	var body map[string]any
@@ -189,21 +190,16 @@ func TestSandboxExecutor_ActionBoundary_DeniesUndeclaredOp(t *testing.T) {
 
 	res, err := exec.Execute(context.Background(), "test-action", nil)
 	if err != nil {
-		t.Fatalf("Execute returned a Go error; want IsError result: %v", err)
+		t.Fatalf("Execute returned a Go error; want failure result: %v", err)
 	}
-	if !res.IsError {
-		t.Fatal("expected IsError=true on undeclared op")
+	if res.Failure == nil {
+		t.Fatal("expected Result.Failure on undeclared op")
 	}
-	var body map[string]any
-	if err := json.Unmarshal([]byte(res.Content), &body); err != nil {
-		t.Fatalf("decode body: %v", err)
+	if res.Failure.Class() != failure.CapabilityDenied {
+		t.Errorf("class = %q, want capability_denied", res.Failure.Class())
 	}
-	envelope, _ := body["error"].(map[string]any)
-	if envelope["class"] != "capability_denied" {
-		t.Errorf("error.class = %v, want capability_denied", envelope["class"])
-	}
-	if envelope["boundary"] != "action" {
-		t.Errorf("error.boundary = %v, want action", envelope["boundary"])
+	if res.Failure.Boundary() != failure.Action {
+		t.Errorf("boundary = %q, want action", res.Failure.Boundary())
 	}
 	// The runtime must NOT have been invoked when the action-boundary
 	// check denies — defense in depth means the inner check is unreachable.
@@ -234,7 +230,7 @@ func TestSandboxExecutor_FirstFailureTerminates_NoLaterStepsRun(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute Go error: %v", err)
 	}
-	if !res.IsError {
+	if res.Failure == nil {
 		t.Fatal("expected IsError=true on first-step failure")
 	}
 	// step2 must not have been invoked.
@@ -328,7 +324,7 @@ func TestSandboxExecutor_ConnectorBinaryMissingFromStoreSurfacesError(t *testing
 	if err != nil {
 		t.Fatalf("Execute Go err: %v", err)
 	}
-	if !res.IsError {
+	if res.Failure == nil {
 		t.Errorf("expected IsError=true when connector binary missing")
 	}
 }
@@ -353,55 +349,75 @@ func TestSandboxExecutor_Close_ClosesCachedConnectors(t *testing.T) {
 	}
 }
 
-func TestErrorEnvelope_PreservesStructuredErrors(t *testing.T) {
-	// Recognized error types preserve their fields in the envelope so
-	// the LLM and audit log see the boundary, class, and details.
+func TestFailureFromError_PreservesStructuredErrors(t *testing.T) {
+	// Recognized error types map to failure.Failure preserving the
+	// boundary, class, and details so the LLM and audit log see the
+	// canonical ADR-0010 envelope.
 	cases := []struct {
-		name string
-		err  error
-		want map[string]any
+		name         string
+		err          error
+		wantClass    failure.FailureClass
+		wantBoundary failure.Boundary
+		wantMessage  string
 	}{
 		{
-			"action error",
+			"action capability_denied",
 			&Error{Class: ClassCapabilityDenied, Boundary: BoundaryAction, Message: "no", Details: map[string]any{"x": 1}},
-			map[string]any{"class": "capability_denied", "boundary": "action", "message": "no", "details": map[string]any{"x": 1}},
+			failure.CapabilityDenied, failure.Action, "no",
 		},
 		{
-			"sandbox error",
+			"sandbox resource_limit_exceeded",
 			&sandbox.Error{Class: sandbox.ClassResourceLimitExceeded, Boundary: sandbox.BoundarySandbox, Message: "boom"},
-			map[string]any{"class": "resource_limit_exceeded", "boundary": "sandbox", "message": "boom", "retriable": false},
+			failure.ResourceLimitExceeded, failure.Sandbox, "boom",
 		},
 		{
-			"cstore error",
+			"cstore hash_mismatch",
 			&cstore.Error{Class: cstore.ClassHashMismatch, Boundary: cstore.BoundaryRuntime, Message: "diff"},
-			map[string]any{"class": "hash_mismatch", "boundary": "runtime", "message": "diff", "retriable": false},
+			failure.HashMismatch, failure.Runtime, "diff",
 		},
 		{
-			"plain error",
+			"plain error → connector_runtime_error",
 			errors.New("ouch"),
-			map[string]any{"class": "internal_error", "message": "ouch"},
+			failure.ConnectorRuntimeError, failure.Runtime, "ouch",
 		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
-			got := errorEnvelope(tc.err)
-			for k, v := range tc.want {
-				gotVal, ok := got[k]
-				if !ok {
-					t.Errorf("missing key %q in envelope %v", k, got)
-					continue
-				}
-				// reflect.DeepEqual would suffice but produces less
-				// helpful diagnostics here; spot-check the strings.
-				if gotStr, want := primitiveString(gotVal), primitiveString(v); gotStr != want {
-					t.Errorf("envelope[%q] = %v, want %v", k, gotVal, v)
-				}
+			got := failureFromError(tc.err)
+			if got == nil {
+				t.Fatalf("failureFromError(%v) = nil", tc.err)
+			}
+			if got.Class() != tc.wantClass {
+				t.Errorf("class = %q, want %q", got.Class(), tc.wantClass)
+			}
+			if got.Boundary() != tc.wantBoundary {
+				t.Errorf("boundary = %q, want %q", got.Boundary(), tc.wantBoundary)
+			}
+			if got.Message() != tc.wantMessage {
+				t.Errorf("message = %q, want %q", got.Message(), tc.wantMessage)
+			}
+			if !errors.Is(got, tc.err) {
+				t.Errorf("errors.Is(failure, original) = false; cause not wrapped")
 			}
 		})
 	}
 }
 
-func primitiveString(v any) string {
-	b, _ := json.Marshal(v)
-	return string(b)
+func TestFailureFromError_PreservesActionDetails(t *testing.T) {
+	src := &Error{
+		Class:    ClassCapabilityDenied,
+		Boundary: BoundaryAction,
+		Message:  "no",
+		Details:  map[string]any{"x": 1},
+	}
+	got := failureFromError(src)
+	if got.Details()["x"] != 1 {
+		t.Errorf("details.x = %v, want 1", got.Details()["x"])
+	}
+}
+
+func TestFailureFromError_NilErrorReturnsNil(t *testing.T) {
+	if got := failureFromError(nil); got != nil {
+		t.Errorf("failureFromError(nil) = %v, want nil", got)
+	}
 }

--- a/internal/action/executor_test.go
+++ b/internal/action/executor_test.go
@@ -8,8 +8,9 @@ import (
 
 // StubExecutor must always succeed (no Go error), produce a JSON
 // payload the LLM can parse, and reflect the action name and args.
-// Per ADR-0010, action-side errors should be Results with IsError=true,
-// not error returns — the stub never errors.
+// Per ADR-0010, action-side errors should be Results carrying a
+// non-nil *failure.Failure, not error returns — the stub never
+// errors.
 
 func TestStubExecutor_ReturnsPlaceholderJSON(t *testing.T) {
 	res, err := StubExecutor{}.Execute(context.Background(), "ship_update",
@@ -17,8 +18,8 @@ func TestStubExecutor_ReturnsPlaceholderJSON(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Execute returned error: %v", err)
 	}
-	if res.IsError {
-		t.Error("StubExecutor unexpectedly marked Result as error")
+	if res.Failure != nil {
+		t.Errorf("StubExecutor unexpectedly marked Result as failure: %v", res.Failure)
 	}
 	var payload map[string]any
 	if err := json.Unmarshal([]byte(res.Content), &payload); err != nil {

--- a/internal/api/gen/server.gen.go
+++ b/internal/api/gen/server.gen.go
@@ -876,6 +876,72 @@ func (e ExecutionRunResponseStatus) Valid() bool {
 	}
 }
 
+// Defines values for FailureBoundary.
+const (
+	FailureBoundaryAction            FailureBoundary = "action"
+	FailureBoundaryConnectorManifest FailureBoundary = "connector_manifest"
+	FailureBoundaryExternal          FailureBoundary = "external"
+	FailureBoundaryRuntime           FailureBoundary = "runtime"
+	FailureBoundarySandbox           FailureBoundary = "sandbox"
+)
+
+// Valid indicates whether the value is a known member of the FailureBoundary enum.
+func (e FailureBoundary) Valid() bool {
+	switch e {
+	case FailureBoundaryAction:
+		return true
+	case FailureBoundaryConnectorManifest:
+		return true
+	case FailureBoundaryExternal:
+		return true
+	case FailureBoundaryRuntime:
+		return true
+	case FailureBoundarySandbox:
+		return true
+	default:
+		return false
+	}
+}
+
+// Defines values for FailureClass.
+const (
+	BindingFailed         FailureClass = "binding_failed"
+	BindingRequired       FailureClass = "binding_required"
+	CapabilityDenied      FailureClass = "capability_denied"
+	ConnectorRuntimeError FailureClass = "connector_runtime_error"
+	ExternalApiError      FailureClass = "external_api_error"
+	HashMismatch          FailureClass = "hash_mismatch"
+	NetworkError          FailureClass = "network_error"
+	ResourceLimitExceeded FailureClass = "resource_limit_exceeded"
+	SignatureFailure      FailureClass = "signature_failure"
+)
+
+// Valid indicates whether the value is a known member of the FailureClass enum.
+func (e FailureClass) Valid() bool {
+	switch e {
+	case BindingFailed:
+		return true
+	case BindingRequired:
+		return true
+	case CapabilityDenied:
+		return true
+	case ConnectorRuntimeError:
+		return true
+	case ExternalApiError:
+		return true
+	case HashMismatch:
+		return true
+	case NetworkError:
+		return true
+	case ResourceLimitExceeded:
+		return true
+	case SignatureFailure:
+		return true
+	default:
+		return false
+	}
+}
+
 // Defines values for FundingSourceStatus.
 const (
 	FundingSourceStatusActive   FundingSourceStatus = "active"
@@ -1971,7 +2037,9 @@ type Enterprise struct {
 // EnterprisePlan defines model for Enterprise.Plan.
 type EnterprisePlan string
 
-// Error defines model for Error.
+// Error Generic error envelope used by CRUD endpoints (intents, approvals,
+// policies, accounts, auth). Action-execution and gateway endpoints
+// use the structured `FailureEnvelope` instead, per ADR-0010.
 type Error struct {
 	Error struct {
 		Code      string                    `json:"code"`
@@ -2060,6 +2128,46 @@ type ExecutionRunResponse struct {
 
 // ExecutionRunResponseStatus defines model for ExecutionRunResponse.Status.
 type ExecutionRunResponseStatus string
+
+// FailureBoundary Layer that produced the failure. The closed set excludes `user`
+// which is reserved for post-MVP per-invocation approval flows.
+type FailureBoundary string
+
+// FailureClass Closed taxonomy of failure classes per ADR-0010. Adding a value
+// requires an ADR amendment.
+type FailureClass string
+
+// FailureEnvelope Structured failure envelope ratified by [ADR-0010][adr10] for
+// errors returned to the calling action and through it to the
+// agent. Used on the gateway endpoints (`/v1/chat/completions`,
+// `/v1/messages`) and on action / connector install responses.
+//
+// [adr10]: https://docs.withaileron.ai/adr/0010-failure-handling
+type FailureEnvelope struct {
+	Error struct {
+		// AuditId Reference into the audit log for full context. Stamped
+		// by the audit recorder before the response is written.
+		AuditId *string `json:"audit_id,omitempty"`
+
+		// Boundary Layer that produced the failure. The closed set excludes `user`
+		// which is reserved for post-MVP per-invocation approval flows.
+		Boundary FailureBoundary `json:"boundary"`
+
+		// Class Closed taxonomy of failure classes per ADR-0010. Adding a value
+		// requires an ADR amendment.
+		Class FailureClass `json:"class"`
+
+		// Details Class-specific additional fields.
+		Details *map[string]interface{} `json:"details,omitempty"`
+
+		// Message Human-readable description; safe to show end users. Does
+		// not contain credentials or sensitive payload.
+		Message string `json:"message"`
+
+		// Retriable Whether the failure is safe to retry.
+		Retriable bool `json:"retriable"`
+	} `json:"error"`
+}
 
 // FundingSource defines model for FundingSource.
 type FundingSource struct {
@@ -2674,22 +2782,42 @@ type PageToken = string
 // PolicyId defines model for PolicyId.
 type PolicyId = string
 
-// BadRequest defines model for BadRequest.
+// BadRequest Generic error envelope used by CRUD endpoints (intents, approvals,
+// policies, accounts, auth). Action-execution and gateway endpoints
+// use the structured `FailureEnvelope` instead, per ADR-0010.
 type BadRequest = Error
 
-// Conflict defines model for Conflict.
+// Conflict Generic error envelope used by CRUD endpoints (intents, approvals,
+// policies, accounts, auth). Action-execution and gateway endpoints
+// use the structured `FailureEnvelope` instead, per ADR-0010.
 type Conflict = Error
 
-// Forbidden defines model for Forbidden.
+// Failure Structured failure envelope ratified by [ADR-0010][adr10] for
+// errors returned to the calling action and through it to the
+// agent. Used on the gateway endpoints (`/v1/chat/completions`,
+// `/v1/messages`) and on action / connector install responses.
+//
+// [adr10]: https://docs.withaileron.ai/adr/0010-failure-handling
+type Failure = FailureEnvelope
+
+// Forbidden Generic error envelope used by CRUD endpoints (intents, approvals,
+// policies, accounts, auth). Action-execution and gateway endpoints
+// use the structured `FailureEnvelope` instead, per ADR-0010.
 type Forbidden = Error
 
-// NotFound defines model for NotFound.
+// NotFound Generic error envelope used by CRUD endpoints (intents, approvals,
+// policies, accounts, auth). Action-execution and gateway endpoints
+// use the structured `FailureEnvelope` instead, per ADR-0010.
 type NotFound = Error
 
-// Unauthorized defines model for Unauthorized.
+// Unauthorized Generic error envelope used by CRUD endpoints (intents, approvals,
+// policies, accounts, auth). Action-execution and gateway endpoints
+// use the structured `FailureEnvelope` instead, per ADR-0010.
 type Unauthorized = Error
 
-// VaultLocked defines model for VaultLocked.
+// VaultLocked Generic error envelope used by CRUD endpoints (intents, approvals,
+// policies, accounts, auth). Action-execution and gateway endpoints
+// use the structured `FailureEnvelope` instead, per ADR-0010.
 type VaultLocked = Error
 
 // GetAnalyticsSummaryParams defines parameters for GetAnalyticsSummary.
@@ -6176,279 +6304,290 @@ func HandlerWithOptions(si ServerInterface, options StdHTTPServerOptions) http.H
 // Base64 encoded, gzipped, json marshaled Swagger object
 var swaggerSpec = []string{
 
-	"H4sIAAAAAAAC/+x933YbN5L3q+Dw23NszZCUbCezM8rNKrKSOLFjr6XMXIT+SLC7SGLUBDoAWhLj9Xfm",
-	"ah9gzzzhPMl3UAV0o8nuJqk/drwzN7bYjcbfQqGqUPWr971ELXMlQVrTO37fy7nmS7Cg8ddJnmt1xbMX",
-	"qfslZO+4l3O76PV7ki+hd9zjvsBYpL1+T8MvhdCQ9o6tLqDfM8kCltx9ale5K26sFnLe+/Ch3ztVUkJi",
-	"lW6tOwkl9q/87AaSwgolWyuHUGL/yr/VXNrWiufu7f6VvpAWOmoV+Hr/at/wOZyLX6Gs9pcC9KqqN+dz",
-	"GBtXIK4nhRkvMts7/vKo31vyG7Eslr3jp0ful5D060k/NOf6NgddtnehLkF2NmixxJaeq0wkq9YJyfH1",
-	"vhPywRU2uZIGkL6/5ulb+KUAY92vROEsuz95nmci4Y5ADv9qFA6nqvbfNMx6x73/c1jtnUN6aw7PtFaa",
-	"mkrBJFrkrpLece+FvOKZSJn2DdIemGUi+QiNh5bYtbALlhRag7RMg1GFToAZyy24Hn2j9FSkKa3fQ8+H",
-	"KWYzkQjXkxz0UhgjlDSuGz8q+40qZPrwvXgbpkAqy2bY5od+7yfJC7tQWvwKH6EPr9zI5ZwpzYQnEtc8",
-	"SOsbcl36s9uRL1Vy+TF6hI0xYViGDbJ//O3vrJDuBxHQm9fnF+zw6slhYUCbwyUc5tyYfKG5gUMqiJvY",
-	"N4RHSUJ1v19r6oS5OgZCGsuzDFLGsSBbcilmYOyQvQHNTp6/HRwdHT1hXKbhx7M+43IkfXlhGGduGjNg",
-	"r7i+TNW1ZDORAfX44vWrl2ymlbRLbi3or5hdAMu5NpCOZPSC5SovMm7BMLsQhqnpXyGxjwwzVheJLTSk",
-	"bCYgSw32xS5gJMv2/Kqwmcoyde3W1LWSZArXd/L73/9+EtU/map0NRmOHCvMtcpBW0F8yb3YnKq9mkkh",
-	"E0thQQ/ZxQLYTGhjR9Id73PN8wV7rDTjLAUj5pJbSJkBnMgDN5Om0DOeQMqswqpfvnzFuKHBzgpJMx51",
-	"jl0vQGLJajXgJlfGradbGKtURgNdY8l9fxLTCWVhabYRLRESnfBwbiF3lfhaudZ85X4LmRck0NSn8Dkk",
-	"GXdLmPAsG1ixBMb1vFi6FmqU9qzPqA625DlLhYbEZquR9BPy/fnrH9k59ohNKplp4smlnDQDYHByRvJE",
-	"ZKCV9PNi4tlam6I9puGF62PTBCy5TRa71fEKi34IR+v6lH3NNTg+wDO24DLNgM2Ujnv/GIbzIRv1zELk",
-	"gyJPuYVR72DYtNZ4hm+ygKlRWWHddrQLpmZYuWfLuIMdsQlz2VilP/x3nK+3obRjTtjCZne+KbJsNfil",
-	"4JmYCUjZT29fhE5ZWOZu78bDv+aGVdxrptVyJMOULIrp8eEhp5U/jCboP54Mj4ZHbprYG62uQHKZuHFm",
-	"K+S1UtmRTJQ0Rea2JrdMF9JRa8seugJtGrnrudXu1D+H5Z9Bh1Gsc9jNGj/EQtXPRBhVK+XURbMfKK7a",
-	"z+/KWmlPuH5u7l2nctRYXyn1N8hv/Z5IWx7DMlfhQPSvp0plwGWdHfA0Fa4PPHsTNUty40Z3Vd4sm8Zz",
-	"gxJo1Wn8qH3otF83Bl1btA16dKfNIIMryFiulYFG9iwkseeIGw2rRn52S/huGFU8YSZTtoWemjnBieeU",
-	"TKRONpkJ0AxXHU+d//szH/z6zv1zNPjT+N3v/m3StV/TJt6MWofBUekC6FBRS2EtpEN2DpbNeGbAvV9y",
-	"fUm07Ps0ktwwldPS+slw8zKY8cR1r5wVRgyhNvCIUujJetdidp9rd66KK2CurBsjSKcQ/RwG2S81on5P",
-	"Fssp/hGaeLfjXsNCdbGsi6oC6a+RlVpyIbdxxudYystnH/q9vxbGLa4XPZu22xIsT7nle28oUyyXXK8a",
-	"K7Vcz8HuxsYvqGy0XnDDl3nmmv65Nxd2mBdZNvaq1jDR4PSbPr4RxhTQ+EgtHSXhrOeZWg01ZMCNK5Rk",
-	"qkiHQV0aLgtLH8OSi2xoQKblj1Tzmasj4RnIlOshXIGMupDz1RIfLNwYSPJLCg34MHTYFNOlsNuJxVNJ",
-	"mNZ2CnkpjH3rNd9NOikFjj0kjyahI1M8HYNTKvat7aXiqddG1qv90D6o8qMGrSIS17FHXlydOmZQKgoo",
-	"XYhYcjVe1lPaCXsL7niOyIjVorbgtDTU0biFvtNbvcT45GjIXIdc/cKMpFRyMOOWZ3igu4acyMctc5PE",
-	"TJEkYMzMiRqM5zlwp/uxCU7Z5Cvf6EjSd77AArSTi1B2BW1YwmU4CpjjS5AIA2wJxvA5NKsVhSPJBtXi",
-	"LwuRLFjGV04B0iot8HRZgJ+7xzy75ivDRj2apVEPhUAciutqocE0S3xJxk2DHH7KpZLCyZT+c4YFvSyJ",
-	"E02E1A+TLZSkJ83tuInaUbJUsxlIXCf3UWNtmZANtb0UkrRJTzGkXeKqVFPlxMEULCQW0q/YER1ihbyU",
-	"6lpGbZVGM8dNccG2ixo0l9UHftTtu/5VUALWtnt5XLQtCmnyOCoveNJB72hxzp20y/gcJQGsarsE6Zts",
-	"7+rbSIxvEQj35SmhytLSvA9v2fx4s2M851ORiUYhrndRspRHjiC82mmKqQHrKNHVxInjKCKncqCoiI5k",
-	"pYm6DW+YKqwRKZBZwlfkdLMUpCAloWJjIxn2OnPnT6Wfl42Qyc2SHlp2Zk0B3Tyk1zj+gpsGhe7U2yfc",
-	"27DrqoanQrp+5VlhmEAFu1UPaZNEy1Vh3/znjxETPnpaaqNzYde0r4wnl22KaasC9UZICemaAlWt1P6q",
-	"E85Yv0487dviohSK1iQ7YfKMr8ZhenZVlC4FGVWDyHoFMkWtRUOujHDHHgq0V0Ir6aUhngsnY0CiIRZs",
-	"gsQzdudOLqisFckllXIS0zhITO5BYaxabhdpsIctE6L0W7fp72syStnRTwayNLdExZKjlgv6SlDny6so",
-	"zw63jwP1QizSOBjJs5UViTmvJOL6oMqbtYxbkMlqvGzgjfmXR9HIojMl/9OXTS+a+N10NdbCXI5RwWyX",
-	"6Jta2ZTvcyD6WuOUeN+QtMj9yvJsvBRS6XEhhTW7dhw/NO0zZ8Z4Fwdpc+erYl7qbivo+KtvaPNleY9o",
-	"xiSzbS2Goh+kbSXppNxxEhrPL2kXWuUieVXJFV1K2sZp2ywcnOOCOekXmb9jhcEMPc1UcmnY44mFGzvp",
-	"s4lVKhsXBib9kaQfGkyR4Tux5HOY9NlwODwYsvMFz8HbsQ0ru/7IjKTvvsFmNE/QVuE2mcpqu7YwqGBz",
-	"Y4SxXO6gNWEN/XKo77om8UKpbL8ZXLPlbDIjmRd2XF3QdNXcboUINlg3u48M2aqj06gaSQtTbDqmGici",
-	"d1v67EqkIBOILkvrgwZfYGcRLdT4wsKyUS6Le1fW3tJD3McdLLSF/9N72Eew9DWeNIuT/R6kwvJpBmMU",
-	"v/a3OMJN7qTOMcc5nim9dH/1nLKJtxVoUsoy18RaHTGBBV+BpkGTnMez5pOyZIVdPWj4yqjsqvujrd02",
-	"ltti5xU4p9If+r1rpS9NzhNoHvEaKdUdVmK3Ct/+2hzEVNJFfUFraDOxbKPFyh+ldCA5fr/zWu82d2Qm",
-	"rGbudjPeOaG+yi0z1aRNbRXici1kIvL2KQwHQwdlhTMjJwNAtbppj855/0cGc+7kga1HSa1TXaO+VwNc",
-	"4HgNDCjncyFLy21XLW+qks1yhG/Fa8LLRgtz2BzjuVZF3rYyS5XWjmyyvrnZl6uxmtHH7meWxT9/KZQu",
-	"mlSG8GqcqIJ6tcUtqXVw53uSxlKleClYo5LAtvEmiMsEsqyRdkKz7ceob3KsZLiY9I5YePHRdF8RjNbN",
-	"dA/5uMjHvLCLMTfGtdMolDTOkLU8Wbi6G3WupVjCOChQrVp7Q5eU5nMYa6pz432hs9oJUmjRqGJvdPfU",
-	"a6WVm8nazFoLMgXYfZeVNfovm3Zb0IXbCD9RcgZO9anmKtCZVBKvH5SaZzBeAmrNvyq1dOMFvjRdOnN/",
-	"q5QJMh3jybvzIZ6pjhsfR5YiBR2PwHc9sgeowmZKXXb33Fiu7Z59c89/VbKZpqywLYz/ShiBRpZV3O+w",
-	"qfq9vJhmIkEzubjitkWrb6e1QBmb4vCSizoh05P+HlslXGbuwgfW5WVsrOk4Ol1we6qWeQau8tOFEsme",
-	"CuJMSGEWYw3ctCo4Kdw0K7eRqbtz69V6GfTYTZuya6duDo/7tn3833hXpufEje5Px2sXYmru1XdT/YIj",
-	"1iPDojv/XpORYCdVr3nWH9x6kHNtzVfM1CwBbnxFbqwGvhzJwH0eRcYAFvypUgUGvTf9IPH2SMi5Nxe0",
-	"LsW6HcGsjNNF+5sGhX7Padl45F9B5sbbyNjQ0JE4GUY0eDd4MSplSpKBZMJcD8J1nWk0S5dV7nFs1Vbx",
-	"QqnslGfZVhUbZ2M7VUSSy+5UEYZ4yzGU+7/By02lkDU4SrrHsZdK7qSf0l0mEBYLdNU491Sm6aoUJPqn",
-	"9Ol+zAv1TBiGBrBDvPAf0OeTkk5HclrMZqANmmwGblFZCpnlBjc0L+ZO1ir9Xw0rpBUZXTfwLBtJUbmg",
-	"8ixbsYQmCFo9WZB2Sg6/dq3hJ2ShVTFftE4MK2Sy4HIO6TBU2XDVdTJ3Ay7vuLBUtT9zDQb0FXk8Gqiq",
-	"ZFymI8nRwBS70IUJ8J0ihjGFmdLoenjNtRPQRzL0dg+nyc3NsXVjEIn1KyLeZZNUet4evBOX6rabxB/l",
-	"TTIqep60WZvbFbasWSqhMTfK7rucF91nE9oQ/Lt+OSOhP9tnfn9rbThE95vtWHBouEgqK93NgWe3cSEb",
-	"v/XY1rSh4PPc7Oo2AJmo1G3F4PFHHRvuIcA234NWDTcNesd7ut2nt7qE6zd9FU13poq0VXdM0M7Qaroz",
-	"VizdFhsnymx1YHulJKxIvvd37jsrXPza7YV5gqaSXwtdeqbNHOPt1ro0zNuaCpe0rXa18L5V3bd8bna4",
-	"OdxwI+i6xvJX/JCeJKWVZ41hEmPrMjpr4Olrma1a7adwY0FLjrdVulFue+MXYmBySMRMJBivEgsX5HGA",
-	"Ohce5d+6v/pYzFE9PRP2u2JKD9mL5/jsPOPJ5cEuvaR+bS3WqKR7vbNLWV+KRCujZrZ6/W6HXplE5U2e",
-	"L69PCrtg9Jb5K1h3mHuBoNO/pKXR8jDbNOU6aeEKajY4DVfqkixwWwdB7vh3I6KIdraU7SD0Jps4L+zW",
-	"GI7yczfr3uZUhc02m4Yq74579e5t13pDsGZdutnqXRQT9A5W/ZIUUmH4NCPLLPqHNqprnpvtNLkXrvDe",
-	"l01rEcy1j8tzyZ+MHTcn9SXeNMWCXaiaV49yhPOUXHfGl7BCc2vpzzIO5xk9vYbpQqnLMTn4+IedJ0kw",
-	"abbQV8UXdl3pdZGbBtQ5Ffd5n9LhIHifFyp1YoqvHMgl3JSBNWO0cqDJAc/30iXde2QFY2LEzcnxii4u",
-	"Er1Eys9Lt63xkktOEQlO+McTj9y6Ohb6FM/Xstftlxa34VKfgAl1MZOPwAw6dz/OYSPB0yJoQHmDbuOa",
-	"PTA++oRuuM8Rs3GiBd44aZhpMIsq2r/OfjZYTzc1XvEis+MQQLjx+h7XImqpfUW+KfCa8Bz3a+uidDq+",
-	"3f+KGH95GfjH/v4n62t6JbQteDZOuE7HOVlBp0U6x9WaCW7XDpNMzBdWui5c8ywrj5OpTeoPjFUa0vGU",
-	"Z7zu1/MAK9q+iOQQ0c7YdrIM1EKwPvTJi7T1QpBn2ZQnl2N/0bkmOYf4Nb8x2E9vX1L4tl9QlmccYxCy",
-	"jGLwSWpgJMUaH54sjPvQB2x7F32WazXXYCjy2Fv9FsAyMYNklWQwko9JTGNwxbPCCcV9Fpw7WOkTE55B",
-	"ekiX4n1Wuq6MJN7t1Z6VZsr0wI1EGMavlEipaxIgJeunmzPqfq4ysnp+e0YQA94h8vC9SD8wkGmuhPRx",
-	"i93XxN7D78bu5hdz6gvH4aTJCjna3RnOeo0RmWzIhbzDTIFkS9AorWS7/Wq4+6RovzEpsj3sk76XRdZo",
-	"ldzN94jquK2v19q8evZOo2iZXX/K3qt0GZ3dXnJ+YDmzocEm44kv9NtREz9jgaI+nf07CRjPIRGm2RBZ",
-	"dyLc6h1InuvRXf32L4TBOJAdyDB083n0ye0dGSm8zMkYmUjE3mymxLBY31YBoGDMIzfhzcuyegREV3tv",
-	"hbl8iQXXaSCeu1qNXYv8vD7hJelnmbomjzh1PY68znyD1XBwlVfRm6XSMG7wmK7m+jnI9tOjy6Gs1elj",
-	"/TK53QHjOeqxrZZ2bcWMJ7bVP4yuDsek7bYKWVlhbIuit42rYXhCa/NLjtKIk1nH10Km6rqtD26rIwPY",
-	"2bp/WUxBS7B44XUFOsFrRwk2EzMUGBqs/7NsJdQWc43yEqcp8lzp+k1gtANCsFOzqU1zC/OaF5Wrl8wN",
-	"06yA8VwD8uSES66JHPOMb4382qSPGIygIUJVawHGXxEP3NeVXZ5QmYbs7IYnNlsxJYGesWVhLJtCCb2U",
-	"9kcyUZqu7jES2N815xpm4oapGYul+qFr53gkGRuwubDD37F//Pf/uL/okUcLoKf0g14QagA9x7/pMeEE",
-	"0GP825cOgAH+A/+TXgbUAHrnf/lXEX6Af109GUmnPeD9u2Ya3CybIMybKHa5nBlGmBF+4oJvzUgif47R",
-	"Y9yc+PkiYXzJb+LD/wliBa49WQ+g9earXT0xS+ABsopt+yy60/sQLGjbT7WIP33oV558ncEsrlD1zVxs",
-	"VTm+FbYq75dzu9yHxaLvqnXe+m1VNHzftPvigTS50HqP4D1c1WtexA3n8zRJdq7sbRlo2lSRSlfjhV02",
-	"uy3g26ALbh4Y99SHmVbLvSowINPxhne8eyjx+EcwkbGS2arZlbZo98awCw08bT3JrLqPITfSkLSgcy0a",
-	"o2CcOAMpeaSHQ9A0OcsZAq4yYi4HQnr+bKD0THJ8fpnbFVsCl4bxLGO+8uFeAeyhRxTKTMxvrw7Rva//",
-	"8J46NRV4to73cCPe4TK85Vo5Rs4Bacd8mjx5+qyR3tpt66BNm6/yGiyCLuhGnGJABnghHj5nXpMLOCB4",
-	"kx6m/KDRyy3PeE1wnmnwoDoYx16SYuP2yYr55lL/9PblYKYFyDRbsUKKXwqIbvsbPQWNGtdhrbZFbexw",
-	"67yDY0u4OXTD8DOxTjs1wqi12yScl2A6a1cLzY8Tz7ca1E7LxZrL6i2s0JGbZytCShmtt+N9bAqRw/i7",
-	"be5o65fH0UzF4asbM5PxaYv73LqJA48kxJu5xHvr2WwcwJz6PZM4odosVLCaa0hA5OGXdcOmwOremmaE",
-	"nlaRKrXFEJIVO3hweRsGlW6ck6D5d2C4bA9/bClArv13DDHtjoxVhfXgfHsRa7wou1g6vI18L07d5OuQ",
-	"QE7BZ7qQkjSxClqg3/NoBN0Raev0XgdFb4yOjbrfSQSn/qaj/cLSba5x19a+nwXZYTLvbwY7vDjKmUH8",
-	"+M35wIhxSMe7h4hsNFGCyqz2iy55XmhHsnjSQko+W6yqjCE+HmGbkgror4B8SXT4aAQf2L7vTaLVNVn9",
-	"VrWzMwTI1Xv6nbpmla3VIP4R+TakPi5GeJ+z4UgOmKvjmEnFLs7O2OP4wxQSvXIbiAnJFsrgBVkCxhy4",
-	"7wwgFvlxrS0D0jq5z9WVgx5Ud1yPNXCPJuxkdayCRgZpvY7wlAmJWE6uLrwAMyuZoMSdFhmkrDCASvVa",
-	"tKDvVy9MXEuY6Q4oAhvfxNbaPRlnhycWYtgua155lafe1t0U5VJo5EXRODt33NtCtrKhznGrK9BapHD7",
-	"Tdk2ou39bUUS8Jx/r9Xder7udMLse4B0cMOa/8SejhMz+nbc7bb8kdwrmhXchFuYKy1gT4/H8P0StBPo",
-	"7J6fL/nNmBSrsdVcmt08GLxLeiOg0w5Oll3OlZ+dH8kmbd3eb7NG4/d5pVzfPA96mVwZKjcFFm5gPNVc",
-	"Js03qB2vkgUkl6amNO9O5IlaLoUdmwXfc3cgmOrYR5/t9ylKQGNuUELad1PTxyGnw+bhiq9RZ7xVxe3x",
-	"77epM9ftPc11R2ON0QcIwkgoyxmfonnCTouAEdjlZFzCETYr/VcCrteRm7Z7GW+Q93fAM7to35fdt2Lr",
-	"vBGjKVKYa04aRKquZTN7FEswli/z3U/wCKFyJxUkhi+s0CerhpsY1guKwdzu8gs3OcbmjJvxP0s/tqRE",
-	"lEUo0McTs+BPv/zD8ag4OnqWLOAG/4DJgfdUw+bpug4vnIYjieG2psjzTEDKHttVjvWVgKbhI2FYqsUV",
-	"SDZdMS5LHFS36R8ZNvn55+AKMKwQZd+9w45NDvqMo6da4TQC7KtdcDuSZXA53X/xqdLW1NrF7DIT98l4",
-	"KQwWm1Bkq1R2QWjQ7FoLayFYjRmeWkP2lwjfvhrZTGnXa21saOOAIo1zkUMmJDANidKpYdcLbuEKdOgw",
-	"sOkKvQA9gnMLuP/sF7lb0osGXNVJM6zq5GA4kghPAOVlq5LA1Cx8MenjXxnHv9wDp3hdPblbQgvfqSfD",
-	"p8OjycGQ/aiYdtzd9J3SN8E0O3ayHaXVTUnVaMfWgLQrXCfTwNPVuAxlbkAFLvMa1GgIE8BINVA5m0LC",
-	"CwOOhEFavSICw9QOZa4FXG/fGoMbYZCA1GzmySPUi6jXeYQl/MVBW7Q4tjVOhd41PYsjYd/DrvQsntg2",
-	"nrcAB5f8oo1ThParcHGk+eGdWGZ9+UuM3mpOmiki9hrd5o8f37J4GAkfzGGsE8HmdGmRFm2Rrf2eyMc8",
-	"TTWYltA5YS7HC7G3zuAl3Tzj1p1E651VOcgk49cYi8KLFMbeiu7+u8F8JyAXXKaGogx9vgQhA8SmkIX7",
-	"M+NyjpmntqADUW+8oaNVW/UBqZq3638WlrnSXK/GnSo+Bu8hRkFz8pgPrUt/JgkN5F4dx3f4iFCQ7+De",
-	"fJu7wjRyStzFKxB5yv2Cgu5uhtoHBHH/q7i9fb+bTFfrPt8eetpTTjTf+93g0ejuU9dco/UHVTZra7OJ",
-	"yRfMxP3yQeQF2YTW581Ru1j2u6yS/d7315dNx/28WbnVV8227hZE9hakdtus+sg2Ltb4/Kbx6Wo70brm",
-	"qXNNZPb99WWD8esSVrvTlZvSbYGgWGFT+y+FbLl63Rb88EvBpfUXJF2gkf2euSyap1oKO+bLgEmwm2Gt",
-	"5iccdTHqUL3mplEHROzbgTDxG3KcN53QbHu4dq3jjHfhM3WgKzW4ohIS16bsj89ZrtUyt18xsx2RvOzj",
-	"SCK+2IEHBfunwUaKpoBVM9Dfc4VvB5TUj2mum55vhZdUYc3dj5fJ3lhI6whyXRD0aKrOu2AT8b1xW1sm",
-	"u8XHbPqx3D8Ykzd2r0HmdyEyvVKpmK1i9OC94wwo3oHgSO944Vavqrm/Epryb5Qcfm1D43MmJMOUFYxS",
-	"VkSJ0Y+aDpP4PmvJb16CnNtF7/gZfhf92gJevvRxTmV1TQN6U5PH6qOScGPHUQ727Q4rHxpbCMmez3nW",
-	"IWkuuBlXiaEbofTsAgjNEh0BF9wwTGvEMEaKRR83GS0Mz2xTwloDf/iixLA60XMln4qUudLscbC3oRFG",
-	"qqgJTHwM9iAOLJ2u7HZnvLVhvuucsT+DLgny083cJVyOr6KebLZwJoODRFzOnaxT9FhIMoEwhyKF4EyB",
-	"rhCfan5j3/iOzbwTNNcUJMxEInxinh2c8r+OvvgQrjbHrR6SAcV0bEEv73DHnQkJ4/30uVJ0bvSzpFvn",
-	"cH3dhlvgS+k4vLQB6hZnBq2hGkHfxnnti6a7YVSBF04/xlteCoByuvI41+qGhGQf8NOiqmlwzNFNHSKd",
-	"+Ii/NT+apZJ2ka1I/NYWNP7NpSx41lKrhOu24EFKotW2Rv5tO0xeGzF/XafCdT0n59q2nqB3B6Bu7Fjp",
-	"prU3EtstAMxvGaVegk39RmPYb2Nw2rRkR7LFftaoanpKF4Y1W1Rpo6oM4u0x8zS6UyVT0cx6MZCsBeAc",
-	"NPcXKWF/wi+45X9Bjy/3p3IMpNfvzS3+g5Zk9Ji2QR7FgI0QQGy6PZyVhNez3vHPm70pn/iMzdGTaqob",
-	"Nn9FSBsE8q5jD92nhc7vyge1zMVR1k23wRmXHViWnTvSv+0kcUd/rdTd0lncte0h9Lqe1mSXfCtxJhQ6",
-	"xIno912qarc0rNlWvjib+ZCv9VjxtTjw2DaKUeTXwi7GsT7UuFdqCtPYwjLPuIW9letcC6W9na306X1y",
-	"1Kgcda5uLa7cFyxnoZ0jnYtlkfE1yPL7uKW57aXLnaBLOiBhNofbxlX2v8LZMFz6Fx392LDdh3zopd8g",
-	"18lCXLVIb5txqi2y/Dig7u4s1CfK2HGCIWGNG2t72vsM5sg4rgRc13zXNkXCexbMQ5DTugXIqJm9Juxf",
-	"q/kV2t9cv8LdctAzMMWr9wdyh6VyymOLoIstqRbMTSdcC7vabRL2l3yrUNMHSKmyc5KUCuIjmmrisUtI",
-	"RbHs9XsLMcebbC2sSFqUhnOwld7fyoa2q+KxyYAlSqKNkUGpoAcPkaCTp6DdBmM/nP3AHk/RGrKD0r2j",
-	"OeXJHwbu+zWzyhykE+bQHSPqyt6qPnahwTzRtEwXACfWghNXO9l8kQqQTYb+M+/FxkKRMrUKr+plAW1o",
-	"B/Jd71EbJ5aqsT9vuUzVkuFbVpiAjRb1BfGPJGAW+K3LSdmNAoDZhnUn41fwyDDIF7AEzTN2dvr8O0Yf",
-	"sUtY7UU6pTVxzVga9T14A7DHr188P2Xf/+UCh3eq5Ez4+Bh27o68Phv1UrgaqMtRD4tkKuHZwfZU2zir",
-	"oS+18beQzzl5mbTbqJGIx10TeYpFOufRDQFovvE33NAlzy7zWm7y8SVcbrbudngDH3A9KLmAWVDmeYTE",
-	"Yo9Vzn8pgFnlUUH2N8fV+9RvmKVt0922L0JQU5XXrz7cH1E3w4u+OAassGoQBVZRiFav35iGOQ6Masrr",
-	"gmgp2E3mC8fz0x2kWfNZWru69HV2BZKvs8Kqurb5LIWtzVx3fteNk4yLpWk7Uxzvi7YoFa7i/DBqzvtG",
-	"YWQbWXXpE0gPev1NTXD7/G4w171nenHdkvjnO65TJw+xIKgwLOj9REe9b0/fjE9ePR+fn/151DtoxERA",
-	"/KdUzD1DWNvtZG8AzbAco3Jl9d5nkU+T4XDY1gDGUu47Q9fc+CjMnScJize4c15ghfS27PnC2twcHx4G",
-	"AIYh5QsYJmrZMo5cK0eKjdT+7ekb5t+zF8/RlZqpa0mO04EVOhUnUzzd7WgNNNd9FRLqXnDDphCRaovP",
-	"KwUwtVbJKdYzXPgLTD82E/NCt9UY/OJpn9tVh9AR+hqKslzIuIEgSXnwJi5TgnJNvVww1eragD4k9lu7",
-	"pdnYl91UXXYpuTt5d5FF2c4D0EccfbJG7x6z6gpqq7kZXItiBilNpUQyIAy3dx3s3iu27UQkQ/PVwSIQ",
-	"fSsc137EzVecvpWdOCtdC9tbnmAbx3zIoVBOWeM5pHlTACcmQdtd+cVazq5acJW6/T47vYD3M7uUVdUD",
-	"jv1gWodPHW8yMCm9j0MvttMaKo8vW3Pw5HyFu2VvL5h9Q5E2cvPXp2nsPUaC1aE74gin7z6N4USOD2oL",
-	"/0lmKrn8My8y26XUb9Wknz0lTdoJ8UFYR9ErujK/ErzUtPcW1F0nmib9J7yBeqDEDg8Qdn2rGOQPrQOv",
-	"AMraR37/OGXkqvebRCu7l67dArOsfcXXALV2icmgtb0jNPpvFvq8fcQ/GWjfwakwecZX+5hgXX0Nhhzy",
-	"MvLqAeUkEKmTiLlk3qRgCq3VnFuycjwujB6z37Offnrx/MBRmiM8YUaSoscQbyZTcwz2KkXgwmdpTSEt",
-	"8sxJs05208oYRlnFqm012pRyt+3WMqVcJHOH0hV6jE//u9NCu8ly/QpJ4l4Kedm4b6+45Xq8U3b7W8bn",
-	"dK905BGyhnZHAHfEF/7xt7+zaHnKWWpegvg8at3jFQRfm1wTvLuulU53dHTjLHyAPm9oYHMdOCwfO8pq",
-	"DnRsUkxeNxGwmwyxXBY4F30mMdKWLHeEPVPFyDlS74BNzLixY+zRndDL1t2N1bWkRNXpEse6BPRceNff",
-	"6wgNoTRr+qOQV4L0ZlMg7knLhd39IBnWqaRKcFWj6tILuXRQWdvwa7S0X+RU41ZuA7Lbc3O2K6e1HcUw",
-	"XeRjMr30GQVO95m6tLzPDF9mfQY2GW63hEc6bq3DTeNGOZaOmQ7D7D7ap5Nn1zTQNbdQJz+T+XBHe98D",
-	"e8NSf7rrpYqECcPMVn4Y7LFUQcOPht4EV7q2TL7Z/nYH1+jqlaLsCYAFuIYyKSD9+iZM6Pd/uUAISVfa",
-	"9QHfVn1aWJv3PnxA5XqmNod+dTR8yuDGYvwJQgs4dcQDHw0oDVGZO4hMGVokC9B9L11WuOz+sHRs2oOo",
-	"fyss2rPyIitTC4XQFipBMNxYCLG+629JmMCXHhq8/t47UFIblUdBVWgkT5WOBoD98omSBhRpznw2pOD0",
-	"UD4vcyI9Vh7m4qB8V0HCETLe5vPwBC0NKMMEvM9j70JRZV2K0ij1cSy8SIVlJ29ekLgyV1egJaSUPimM",
-	"DnVuBGmh4CORsFOfPeoNLtvJmxeRc99x72j4dHjkHfIkz0XvuPds+GR45A4HbhdIaoeO1R7SqYqubuUD",
-	"hQiN5ROfoyV+5JSQIo+f4FmzGgSRpHz+PjCuD4chUVbL67gnV08Ow9CP3/fm0MCjXqLBLQRPVeFUQpY8",
-	"45Fhk/93OAywFr7s4YSlQqOCuxrJxxEixjMn1PJk4TEQEp+ZoJKZZMpSwJNTJk67IrV4JN1eUYXFhmdu",
-	"A7zi+jJV15JNVUpiR2GATUL+q9CT9+50+DAJd9QjGTJrsSWXYgbGDh1hvym7+OSozxDyiAysM7dnrGI5",
-	"1waY0uyKZyJFCduyTPGUIYAh14DQJcyIjNhcqlWeQ3qMPZ64kmPE7jQTnyXAFHrGE3BymbG6SGyhIR1J",
-	"LIQgImo2IykD+1MZPvEXokq42XqMZ8OlVNfygEaIcBbkkOlzFbjOYz0YwUtKQJlI+0Xql/qk3AnaH2lI",
-	"Gk+PjtYCx3hOWoZQ8vCvPjCL2NVubmE1yxVy0zrdvdgI3MuzwulMK0SQxPHj1NOEuk34xdGTtrbLwRz+",
-	"JN2GUFr8Cil99Gz7R98oPRVpCnQQVWzHDWIzxLAX0nr/3AvTiQ6tmyTZuuvegi20t+ojpSPppSW9MjVz",
-	"6uN60zRHwpqRrG0N0jpxkwiq9OXLV4MZT5AgfHZ3FnWhBn3yBGksbN4myvkWgs+ZY3wV3uPP73uO1yAz",
-	"DE7Tx2U2sfI8J6m9op51Ee3dg1NjEwXSm2rK3SQgvtfHIjX3xRfbv/hR2W9UIdM12vzWCXENJDJdMb8A",
-	"7UQqebayIjGHZXUlnW4ufCh8XqJvN5HALwXgO08Da16au9NCv7k+zB/RVc9u+lVz5VbdveoHpeH1JWii",
-	"5lCGhTX9JByTqHK9KxEthncRNXqZzrRSIR5cZakN+mvqaVXk8A2fw7n4FTAkYYey6AXQa6OV+ybsAJzY",
-	"+2QM0k/stgM7lGO/FFDAJzyP1zOv1s7jkko2yevwfZQk8EMny6viA/YjtfDhi7T3Udasc51CronP6jhb",
-	"X9xbra1/TtYaZRoWmeoqb7nuvM5YzdceHPQel7js4YcPZCJ5YIIiUWEnNkBQi4FUjrYv/Nc8LUfzWZCk",
-	"X4IKMvN2xIjBR62UGGec/A2SYdy9D3UrnTvwfhs0+RyTuf4TUKRbjbuSI0axdRAkgZT8hkmyGUXlN0uc",
-	"r6KowX8ipomWrDrETCe5JgtuD73dLhgsA4GunUBkh3xkGAL55xyvVtKCZ4NcK6sSlbGXL1+xObdwzVdD",
-	"9lyrfCDc5GPeVUr+OVOaTUrf3lwM0cQrholaNnVncoz7Dq3JhH/sFAFIY1yqOXfKOHudgzx58ciUGfnR",
-	"X9NEJdGah1YcvDr46e1LJgzDsuh2Trft5N2KlsuvYcGvhNJ95jYqOqdPV8Fi80f22NvnAwruwbH7aMB+",
-	"97sLpTLGi7kbM67C8He/KyG2NHB/g+GtvBuWrpFk5HfVaP/te98sw3hsZJoJKSgkR2kGPFm4Wh47dadf",
-	"M0FVOXPwy0embu7ts5KtuApo49FHJWaYkHlhzYG/AvCQYHYBy4AC5vnPIxzJBCHGJm3QYCWOGVnTcK0f",
-	"mbIxVwNWgJl1AjxZTAD/+Nvfa3ONPiDo53VF2W+G0aLghWaisgyvUIxbF7wubDDpPDJR6RRwLLi9AkXW",
-	"QdQIEjt03z1h10Kar8K6u881YBZmR4TBblSansuRTfyKDych+y9dCiBV0LRBGqZ4yE4ae8OuF8oADSDg",
-	"MheGBoFW881GjO8e+rtMsM4hgR0rLeZC8mzgXgfYY8SDY4yza66lRxXP1HyORvAw34MEkdClBZ1AHnZC",
-	"eUFbgsI5xgFLnBbsvqsZP42G4fEU3PT7KR34ZS+XrB9PNl1VEZJdmO3U0fVSSGEwSDJbsfoNSp+iGXWR",
-	"WEOjQ+qdMI9sFhzSMUMzLVqR2b73hadkxsKyKU8uMe4nTHfg30OGVOiaphuzhqUzeDkc0P5cDRWtl+GA",
-	"nswwT1SiUgyf8gP203+OM+s66jdNyYi+VnbBTPn68YT+Pmbu9J4chJWVSg6qUkuVAu3BMm33kL2QrF6i",
-	"T2u9hFRwC2HvEhWkkFm6dG1dP2pgWsxmoHGPW8pFjZf5HlM/XOjg6oUbp68c18KAvZnGHebqQQcZpAR/",
-	"1R8wCpG02cnMQtmVJmrph13nidQttqubmAAzK2kXYEVCYyRSoPbZTJHHIpuuQv9jWn+EYRVWyIIWxZ0b",
-	"J4Vd4OUoPjqmw6g8y/zGN3X2yiYnXubAjyYjuQCegt4BIrLkS2VKbebFuJF0+xDPA7yip4Af4s6bFeKJ",
-	"mZET23TFtFuzJd4FUthIGODG5cYbZezpgtvTSPh4GMm13sonklzXO1FKrn1MuXmIruqDCoS0qnU9bs+J",
-	"JwMMgMNvAnWqGZvUGyEOcLoo5OVkJL8/f/0jI/cNwx4rCXgROkm55ccTItuDPiP26OOmR5Jes5+fv/7x",
-	"7N2kMTXCpujtesEqIS5ifqc0k4OLVQ7oejnZGPukSkYQ/DAMWFbnUf2RRMCAa2HcUba2KJMhc/RD8KJ9",
-	"Rs5ZyCX7xNtChxjtFuIW1dFaSkgb1D6SFStW3hGHS7ZQ+WC6GixUXtboZifPy5gpzIBxs/Jgrx9LBfny",
-	"6Om90S9l4m1Y7Z82WEJYN7oSZ489YBpdKffZxctz/+eI4Cq1k1bRv9MdZwdDFqocaLyvhZR9cXNz+OXN",
-	"jV9Ln1Ek5+gaGSQooVkQVOI1/4o46ZdHTx2volwmXGSFBlOyQDX1shdJp4dcOxWrRgMjGeUv8+v4Jal4",
-	"Dzu/35I+VRGjIG4dxeWVnsJBERuyc7AjOTl58fLs7esfx6/fnP148mL89cn52finty8n7LFyy5Rhpgw3",
-	"Sg+IM5ItutmEcIojr6/e8c/vYgWU1K+BGxm3wi1mUmcD1WEWaaR+cJE+St6BkWdNx2U+OcJUulQ49sK3",
-	"j4KHsBPqkFVi/mKiGA8+EnuFqZzydtQPKu+kfUKe5pummY1k3a4b2nfO/c1R0CC5IiGsVjz/yQ1yyF75",
-	"/DScGb6EgREWGA8pTlx9Tk50y8VRpcm5XQzZc1oxBF4+NGCtkHNzWNY6KONmCbhs4wKMttYY72B3vwF7",
-	"RhyleSHQlycwgfqU35brPd3BhoL+oi/Jc7GLQl84/dgxDKKJWaauXY/9lGF6mxsLOsr6HhFq5anv6cD0",
-	"3n3YQgpnoTpPatXkVM2G1am7ckTusu03nWVKM++aTF664+CA2MN0xZnCFGBLkWhl1MzGrzFREqVCWxTT",
-	"MWY4a4pbete6N2OnuOZrvfrmCSmYd3Nm8Gld7nzX6w4DuF8yL/dZIBWntM3BsVNM62BMJyl+x2WaBUIM",
-	"c0j6oOcQvoG6uXk3Ivzc6CliVp2uCOXoy8HfUVy/S1Tnemd2Se63ebbjxTplCVgjp1vKfJvX9rEfvLc3",
-	"Vq2tMzyzjdhaV+7wvb/cT8Hp400Xbu75xrRtLOEXDZZnvydSYcqG72CWv8M9UNmB250WbY4P22flHvXQ",
-	"DcJtUODWyfEenBru6KKwuUXugy/u6Uu0xriU3olhKf3ZOk+9e3hCVHqbB1Q0jZ/O+ymJ13KN7txDpLfG",
-	"i91TDPmqkjQ+kI2r3speRq4n97+mnevIfBTcb/k2tkYBb2EujEX4nSRax0Yy2GARh/5eqf1m9W0h6xlc",
-	"y7yq8eXEFwel9X+OWWW/+c8ff+9jZkayxLE/ZhqMyq6AzcAmC9Qf//Hf/8NSdS0ppoLrqWvEPaSwFwzK",
-	"57bQMJLhNvUSVoZxY1QieA3J7Zv//JH5qbUrrMRnqWXn350Mnn75h5FUMzaZCsn1iv3Xf5WO3hMs7LPW",
-	"+lYmtbS9ZPobyTK3rvuAW7UUib+aIiy1+FYUs37Gs02QQIc+Syc3C7qvOpyMpKuOYi7DSML8YUuYw1TI",
-	"FG4awlbgCvSKecMR8+ls6/ElZNQ6xnpGMqTe7VezGz7vsyXPZkrjVRutRt+vVigxkoXEuBO6gAWKs2Q/",
-	"difwdeqHr6HJ4r6eTPmBWFFbzuaPbHBvyI/bHg9DF8dlRj72mFCQMNstN+UNqkeeO3Ac5T755t36KuE6",
-	"9LWBKA5+404vTz+CjfrFOmMNpmnc8/tuVQp5rh8RoYXohCBmhfqXv/bwyXIhpZXZ/Qh5X/69zYc63tz7",
-	"iZzllw/tRb2jkPAZ+lFvlw4wgJUyFtSXbg0B6R5W7/4ZewtK08e+SN2NfDy4wv9ejz9ajX1E0gqhtltt",
-	"jcr9S29t0rT89GxVXKOJ/ISaa9kLVioJNSU26uVWLbYs+7BqbNnMp9Jjow6E/GCdC/xZq7QNBNJKH56X",
-	"VPA45pDgnbbGW1efVF5slcsTpGidHjbFQJ+S+bpCyXtI+2jUStOKe0s6RKXubqh3wkOyWXO1BlWn1oSI",
-	"dVcMdySYlrlF1+hQz5D53EHo6QUa75jTpZBMqww2l8Gf/Y0r8VCSxiYs4kcWNbppoXr7OQgbTbLDHjQX",
-	"9n2AfxkgnIw5fI//b9NKzsJn37rSe0sV+NVDqyVrfWxa8DqWzucV4bkGBBQvdHjTtM7mUBeyPWrpbSHL",
-	"zx+IF5T1vy328918+kBdaBf4KgLhSQL5/2r1g8YKVfBw6cS9O2m9L//emYHszTvKLz8a/+imjM/PrFFx",
-	"jhLm8FbrW3MWamYnZX3tjkJ7L/cDcqTQy08lnnRRXOjbP0Hs4xtlYipNKtrpolOfz3pA+ay7TSLfUNlz",
-	"X/RfVpENWqzN0DbDiC/MwtR/OuPIbK0nFcmEPoY132YaqU3Ag1pHai19IgNJfbRbl/izM4/QTFOAbTSO",
-	"TvrwfGUBPCP80zZh5jsq8YC7kVro2oLn3iXZ97bLWdXJAKZevJoGP5Zy9BQS3c1NX/gyvyk2eiuvYhSG",
-	"dr3idYOu0PNbYKlQgg4ZS/ZHtZqXqU8+zTFAo9zG/30+E/D5o+ynhZkMxBhIOpDnNo7vMzDvy+ormPb3",
-	"vbmwb4osi7IlNLCgGJO4F6WOr7JFE76xrxCRl7mB8VRzmSx6xz182e+Vv2fi5jBZQHKpCjuw/GaA0U6O",
-	"OPq9RC2Xwo7NguNcEIb8F713/R4Ct4599BumA9TJoeU3Q5o8MNbQTzB2SLmJMj6FDOuZFvOZuHH1+3bd",
-	"61yPEfjxuHexEIa9ectm4gYMC2WY5Tcs9I2wBtLUMA1z7cG8sdUhpl0YB4jhb8RN/UMnEoZWY+Rz76eO",
-	"C5grI6zCeefJEsrpQYpZy8PcO1+IvOrktJgzGls9GArHo9WSzYBcCmj+mVXML4jlOljNa7kSfMcQE6Pe",
-	"G0oWgP0dRw8vhQyP/TAq5/O5sENHQeMAGEBHMeaACNzCMQ47TlQKN+i1P+ZZvuC9WmpxkFdCK0nZ6Xvk",
-	"AOUVcjobx3nG7UzppY/cuKHcBrDMlQWZrChbae/ps/QPs2d8Ovh3mP1p8MWzZzCYpk9hcJT8gc++mE6f",
-	"HB096a1nyepdmzHIuZAAJbx8TpDabwqdLDwGe6QS+KfsnPNzZoppxX627CBfbZXXO/7ryR+Pjo76PbKb",
-	"JmhJPX+OuWZAwkwkwoN6ehzp3l+5hP/AkDi5csuJRYt0DjTbvWPHGMVcDqK02V7iGPtZxeHPzNgCX46j",
-	"YnE+743Io2/EfMnZG63YiZQF3tb9UnCf/+9Jv1dIYcc7D8+dGEtwEyrtOOEW5rRTot74WRsLBE/AP/Pq",
-	"Mum4dyW0LXg2TjimQajl4abeNu60t4C+TTe50CiEAafcGhvz2m9ae45jZzQZmUhAegN3y7ajfvg95rs4",
-	"88/8FqOn0fbyAx8mC1drw66K0N7HKjd32FQqx7R818376o9/+tMf/j35cjo4evbF0eCLf//jkwHnR8ng",
-	"j0kKT2H2xZOjo6eN+2ompOsXHtP7qCF0/H0i/YMaP5NXkKm8BegasXk+A8XDffGn7V+cKjnLRMi9UFL7",
-	"eTFdCss4czvFo5yIIJlsijR1Mf3wfZlUsNP8Woo6+wns9NlDG153poXPEpnzVmt5GFKbd0Jxgkz93IXS",
-	"d1zgB4HjBJmG/n0yT+JtBBY66MGw/lcDzVmLOSbCiK3ajUo9gNLHB5jj0i60ykUSMOZCT9ax5RhBy8UY",
-	"HyFO4STU8SDwciWy1aQRAo89tutwcv2RrDDM+hHGUoy01Y+wmWIIqAP2j7/9fSQNAA07DAhB18oFGbLn",
-	"YhbcxSgHR1CdIsiEBc/BIMiax767KKHawlYIzujlHA7wqzosHGLVTd6zDbi6PoHNjT0O3YfJQR/RL1yN",
-	"HnICq0NwNA+GN7jWHLFXnOA0DL3yoFtca4Hgsin2MkBDcUMdGhcGJsFhm00zlVwiEJiSjBsjjOXSBjAw",
-	"8xVBrRHyE42aQMCwwhL7bkwF1qt1dSJqRaiuj4g8Ea0hCpqSV6CNT4evpNU8sTioCuCrMGDqNIrAQE5E",
-	"NezxxNc/NpZrO+ljv3xXxtiV8Gb9MSJ2TbzD+1cel0vIuUeia4DxiubQD3KhstQQkhdlbXKPMblRC5TX",
-	"HcCwbgY8F4NLWE1G0i3wpNz7Ax/oMykBerYjZLWBVr0KnOyBcFZ99Z/osKuafwiEqpJIWWiHBXgdSmm9",
-	"Sa4ttDqSLcS6UVzlWDpUW5ar2lE54dvsgG1VdrsV1Iq1YVpRotEOUCvWiWk1kl2gVqwb02ok20Gt2BZM",
-	"qwAqtwFqxf6FafUvTKtPhml18uPFd29fv3lxujesVU0i3I5sVQkuEbhVOLN3ArXCxH1ii4/Bm1DoX94F",
-	"Lamnt14rhRn8dLdJebWIgRrKXm27T6JBPqjrQD0Z+Ue22fnxtS3c6vN1EsjDyjWs+RoLODRiWWTcdlhm",
-	"zn2JB6UHn8ydmvp0qKib3ehwWShLeY3rsyGUsKIhgytc8azga76yHTTznr7bZqUtCWbP8wM/e2gr7bbd",
-	"/1nF+XZt+C0hvvezSA8VcnOLA+Ljkcg/UUzvDieKBTjk1oKxPNxiN58nAffyJCr8MDR0AXEjn4iK1jvR",
-	"kVOrKlbZs0s9GS9br+AOiuqTTdvIxdkZKjognW6YboBIeIRSDUuFaZDjFQukcHF2VqeCv15ftieafqPV",
-	"jfAxgd8ioiM7dVpWCPk8d7I++/4vP5xX9jWjyDI81eragB7JJBNonEm4DJhBUd/Y93+5qKAzCB9fFZad",
-	"vn57zoQxBZjhSP6AiEIaWMKTBaTeED4wIqWA0CdsoQrdkgb3AuB7N8oHpBusv4FKEDf9LzBlP8DKqaCR",
-	"EWLN6YJMA1Z5LB+cUySnoOZudbOkT5SuzS7C79O0B8+IDmLwyf47rlkwNIkIgtb1kWGQL2AJmmfs7PT5",
-	"dywvpplI2CVQ1nAu3W7Qq9xCyn44+2Ekp5maUkYAWsbKJDtVdhGMq34LMY5JO1TOfykAk1sMyuQW//jb",
-	"35mwjrDctqDENoRds8CEGAYSDZYhHgj2AF/+cPYDte5bGMkc9EzpJQ0Lx+A6Dzdk2eqHr034nIxmCMOC",
-	"GTuEHMkF1+k11zAQRmXonriEpdKrITsprBq4WVTXlLjlCqKwaRPBvjbR75mxfJoJs7gAOPfL82AM2Dfw",
-	"6Zhv2YEu52Ny34MwMZDicvxw9gPd/dGlTHTO17//IVpaRxrRd1SxN4Z9TN5dLjJz5fwuxFGFEbludu5c",
-	"8g3uEPDd7Aav4wddwuClvLFybmy1zB60jfxo/QhuHxHfwRpxVtfjz+pzqPm2OJ4LKvIvC9vmqruZ2WZg",
-	"89P36cxrNqxfSQD0oKSBwrg12BGRohEiIddqJpoQECogip+MR9J+oLXA+jvAJwp8f7+wEwWNKcyr68Ld",
-	"oCZa57GGJFFO5UMptK6BT3QWti2je/7xVdku/IeWxV/bU4euukG4ETNrKToq3O/1DbdUV5S1jeDuSfOw",
-	"q+puLRPystK71sDKPdrzcCRPvYxYgXC74hk3FimQLcEuFKUDLBOCLAtj2QJlUMoYhImpPFh02QHMr+Hk",
-	"0mul3Wlmm6S4CvzbDeNNhajfmQMilKMUdlbF3X8Mw/mQEcx+n5HT/8EdEkJsPy++aNQPqYOb6Oofy8Jy",
-	"X4DsSAXRTG2jZ7fi+UL74IFmbemcNIRKWQobIGWGZ7YUW2P1jFXaEX0zkiFjp9c+WKYo+2BhhJyzEz1X",
-	"8qlI+0HNMowzgn+N60XaRQ8kr71g3k0lM7qNL/tT6WquI+WGqIZL3jGuH5gij2XAvdblNf4hey0xasKt",
-	"rbTkOkUJLuFGGOs6fQmrkVxyC1pwTMynlcUD4LErDdrQ5tMw8P1hV7zIrNfoDDPgNo6FbHXQtN3Owb6p",
-	"1udhjohaG5/K6Fl24JxnW6LmQkl0HvEK56zIstUnOkbOSTOnhffLm8eLtvsOPMxUHRhiTfTJgOta0lxv",
-	"RXJEjEeHt0MEjX0jhcFIlvRl2LXAkDonCrIvnj6L3NNoEMKwQmaYUoh8QJso9KVKLjH30EPKgtgA6WNd",
-	"tIHFWOaTIN1D6hCVXPq5cKwicdMfTfl+S+sY004CeeCDxMoCStyaQFBV3Gc8y9Q1OiR65ozWREcTyHAp",
-	"9yQ7yYxiQqYooBp2vQDv5uSFhAU3uKP4SFaVtxgi69u195tgDOeB8ecRh7irKl7TEuKKadh7LD/tpPa9",
-	"XZ2TrO2YLIXDqCOl/Y7IZSTXz1KnlPgz0n367OlgurJUb8DHJp6h3D/fXVy8OR+OZGTTpLOX7IPBE7yE",
-	"1U43j3w6lRUi2CNvph1TDUdIz59K2g6Wk4uLl0OGZgMysrtDfSSnEJ3llQkUfc1FBs0Mq4lwf8J3FbN6",
-	"AG2rauETHaR7ccowWZ8PYh922K82egdWW2FA2+YWnLl2qbAbiGegwA3qR5qO2XAsb8alY8l4nx1PUqvb",
-	"635vRzZ9YagPVlFgNkuU1pBYCcbE9xQjSRKvAd9mxFDIkLyV7/+5fhHzEfh/3GInaa8vyX2x/0YFZwdK",
-	"Q2rdtGs3k1d8LJdMzctg6FJLf/drfBNDg1cjzDlN7Lf9dGdbD/eIhfxmZLr7PcivSjlx05hermLdEv++",
-	"R2nATwq76B3//O7DO/fabaYWe0cVw1zorHfci11vHefyqVuGXKAzi2/+fTB1YDsf+uXvGIc0eky9jR68",
-	"KKFEqqoQmJDgt8uHkZdo+ayWYqr6nHLS1zpTAYlFT9exgOKaaxjg5ePSkl41Jnm2siJp6lec2Cyu5Ows",
-	"/umheNyT+po8bw+hC87iJgd+6S9vKayKYRbvKDk7sd/NAI5+iExzM1Cm139kKDYq4ZZnal46tDsxDcV4",
-	"EVKehNT//Sh4zdVUhWyRsKQMlEVH0sO9UZNLlgIlLhfGCjxAiBlQNFboGCXsN25rYA5wtxUQIq9M1FEG",
-	"UdB9/ZCVIXrCMMcrZsInRvdJmf7IHlPoI8XwCTn3xgy/JsEV/MO7D/8/AAD//yRd5HDYTAEA",
+	"H4sIAAAAAAAC/+y93XbbOLI/+ipYOv+1Ys9IspN0z55x3/zdTro73UknO3ZmLlo5EkRCEsYkwAZA25rs",
+	"nDVX+wH2miecJzkLVQAIUiQl+SPp7JmbxCJBfBYKVYWqX30YJDIvpGDC6MHJh0FBFc2ZYQp+nRaFklc0",
+	"e5HaX1wMTgYFNavBcCBozgYnA+oKTHk6GA4U+7XkiqWDE6NKNhzoZMVyaj8168IW10ZxsRx8/DgcnEkh",
+	"WGKk6qw78SX2r/z5DUtKw6XorJz5EvtX/r2iwnRWvLRv96/0hTCsp1YOr/ev9g1dsnP+Nxaq/bVkal3V",
+	"W9Alm2pbIK4nZQtaZmZw8vXxcJDTG56X+eDkybH9xQX+ejz0zdm+LZkK7V3ISyZ6GzRQYkvPZcaTdeeE",
+	"FPB63wn5aAvrQgrNgL6/pelb9mvJtLG/EgmzbP+kRZHxhFoCOfqrljCcqtr/o9hicDL4f46qvXOEb/XR",
+	"c6WkwqZSphPFC1vJ4GTwQlzRjKdEuQZxDywynnyCxn1L5JqbFUlKpZgwRDEtS5Uwog01zPboO8qzUrF7",
+	"65Cr77m4YpksWFvXzo0qE1MqlpIFlibMFScFU+T02dvR8fHjY3JAE/vJKGxdQkU6EUtq2DVdk7Cwh+OJ",
+	"gLFINedpirT40Gury8WCJ9zOasFUzrXmUmjbjZ+l+U6WIn34Xrz1yymkIQto8+Nw8E7Q0qyk4n9jn6AP",
+	"r+zIxZJIRbgjeNs8E8Y1ZLv0Z8tdXsrk8lP0CBojXJMMGiT//Ps/SCnsD9wMb16fX5Cjq8dHpWZKH+Xs",
+	"qKBaFytFNTvCgsCQXENwLCZY94dGU6fE1jHiQhuaZSwlSLEkp4IvmDZj8iYQ9PFjS77+x9MhoWIiXHmu",
+	"CSV2GjNGXlF1mcprQRY8Y9jji9evXpKFksLk1BimviFmxUhBlWbpREQvSCGLMqOGaWJWXBM5/ytLzCNN",
+	"dLTnOMtSDX0xKzYRoT23KmQhs0xe2zW1rSSZhPWd/f73v59F9c/mMl3P7M4bDgolC6YMRx5rX2xO1V7N",
+	"pCzjOTdMjcnFipEFV9pMhBVVlooWK3IgFaEkZZovBTUsJZrBRB7amdSlWtCEpcRIqPrly1eEahzsohQ4",
+	"41HnyPWKCShZrQa7KaS262kXxkiZ4UAbx8vQSRV42hqW621Ei4SE0go7N6ywlbhaqVJ0bX9zUZQonNWn",
+	"8BlLMmqXMKFZNjI8Z4SqZZnbFmqU9nRIsA6S04KkXLHEZOuJcBPy4/nrn8k59IjMKvlv5sglTJpmTMPk",
+	"TMQpz5iSws2LjmerMUV7TMML28e2CcipSVa71fEKin70YkJzyr6lilk+QDOyoiLNGFlIFff+gI2XYzIZ",
+	"6BUvRmWRUsMmg8Nx21qDPLLJAuZaZqWx29GsiFxA5Y4tww62xMb1ZWuVTpDZcb7e+tKWOUELm935rsyy",
+	"9ejXkmZ8wVlK3r194TtlWF7YvRsP/5pqUnGvhZL5RPgpWZXzk6Mjiit/FE3Q/308Ph4f22kib5S8YoKK",
+	"xI4zWwOvFdJMRCKFLjO7NakhqhSWWjv20BVTupW7nhtlJZhzlv+ZKT+KJofdrPFjLCD+goRRtRKmLpp9",
+	"T3HVfn4fasU9Yfu5uXet+lRjfUGDaZFFhwOedjxmeSH9gehez6XMGBV1dkDTlNs+0OxN1CzKwBvdlUW7",
+	"nB3PDUjTVafho+6h437dGHRt0Tbo0Z42o4xdsYwUSmrWyp65QPYccaNx1cgvdgnfj6OKZ0Rn0nTQUzsn",
+	"OHWckvDUyiYLzhSBVYdT5//9hY7+9t7+czz60/T97/7PrG+/pm28GTQoDaNSJcNDRebcGJaOyTkzZEEz",
+	"zez7nKpLpGXXp4mgmsgCl9ZNhp2X0YImtnthVggyhNrAI0rBJ82uxey+UPZc5VeM2LJ2jExY5e4XP8hh",
+	"0O6GA1Hmc/jDN/F+x70GhepiWR9VedJvkJXMKRfbOOMzKOXks4/DwV9LbRfXiZ5t2y1nhqbU0L03lC7z",
+	"nKp1a6WGqiUzu7HxCywbrRe7oXmR2aZ/GSy5GRdllk2d2jhOFLO62hDecK1L1vpI5paSYNaLTK7HimWM",
+	"alsoyWSZjr3qN85Lgx+znPJsrJlIw49U0YWtI6EZEylVY3bFRNSFgq5zeLCyY0DJLykVg4e+w7qc59xs",
+	"JxZHJX5auynkJdfmrVP2NukkCBx7SB5tQkcmaTplVqnYt7aXkqZOG2lW+7F7UOGjFq0iEtehR05cnVtm",
+	"EBQFkC54LLlqJ+tJZYW9FTWgYCOrBW3Bammgo1HDhjVle0xsh2z9XE+EkGK0oIZmcKDbhqzIRw2xk0R0",
+	"mSRM64UVNQgtCkat7kdmMGWzb1yjE4HfuQIrpqxcBLIrU5okVPijgFi+xBKuGcmZ1nTJ2tWK0pJki2rx",
+	"lxVPViSja6sAKZmWcLqsmJu7A5pd07UmkwHO0mQAQiAMxRkgdLvEl2RUt8jhZ1RIwa1M6e0XUNDJkjDR",
+	"SEhDP9lcCnzS3o6dqB0lS7lYMAHrZD9qrS3joqW2l1ygNukoBrVLWJVqqqw4mDLDEsPSb8gxHmKluBTy",
+	"WkRtBQOg5aawYNtFDZzL6gM36u5d/8orAY3tHo6LrkVBTR5G5QRPPOgtLS6plXYJXYIkAFVtlyBdk91d",
+	"fRuJ8R0C4b48xVcZrOb78JbNjzc7Rgs65xlvFeIGF4GlPLIE4dROXc41M5YSbU0UOY5EcgoDBUV0IipN",
+	"1G54TWRpNE8ZmiVcRVY3S5ngqCRUbGwi/F4n9vyp9PPQCJrcDOqhoTMNBXTzkG5w/BXVLQrdmbNP2Ld+",
+	"11UNz7mw/SqyUhMOCnanHtIliYZVId/9588REz5+ErTRJTcN7SujyWWXYtqpQL3hQrC0oUBVK7W/6gQz",
+	"NqwTT/e2uAhCUUOy47rI6Hrqp2dXRemSo1HVi6xXTKSgtShWSM3tsQcC7RVXUjhpiBbcyhgsUSwWbLzE",
+	"M7XnTsGxrOHJJZayEtPUS0z2QamNzLeLNNDDjgmR6q3d9Pc1GUF2dJMBLM0uUZlT0HKZuuLY+XCt5tjh",
+	"9nGAXghFWgcjaLY2PNHnlURcH1S4JcyoYSJZT/MW3lh8fRyNLDpTij993faijd/N11PF9eUUFMxuib6t",
+	"lU35vmBIXw1OCXcnSYfcLw3NpjkXUk1LwY3etePwoe6eOT2Fe0WWtne+Kuak7q6Clr+6hjZfhosVPUWZ",
+	"bWsxEP1Y2lUST8odJ6H1/BJmpWTBk1eVXNGnpG2ctu3CwTksmJV+gflbVujN0PNMJpeaHMwMuzGzIZkZ",
+	"KbNpqdlsOBH4QzFdZvCO53TJZkMyHo8Px+R8RQvm7NiahK4/0hPhuq+hGUUT466olMxqu7bUoGBTrbk2",
+	"VOygNUENwzDU932TeCFltt8MNmw5m8xIFKWZVhc0fTV3WyG8DdbO7iONturoNKpG0sEU246p1oko7JZ+",
+	"fsVTJhIWXfzWB81cgZ1FNF/jC8PyVrks7l2ovaOHsI97WGgH/8f3bB/B0tV42i5ODgcs5YbOMzYF8Wt/",
+	"iyO7KazUOaUwxwupcvvXwCqbcFsBJqUss0006ogJzPs9tA0a5TyatZ+UgRX29aDlKy2zq/6PtnZbG2rK",
+	"nVfgHEt/HA6upbrUBU1Y+4gbpFR3voldRFz7jTmIqaSP+rzW0GVi2UaLlW9NcIY5+bDzWu82d2gmrGbu",
+	"djPeO6Guyi0z1aZNbRXiCsVFwovuKfQHQw9l+TOjQANAtbrpAM9590fGltTKA1uPklqn+kZ9rwY4z/Fa",
+	"GFBBl1wEy21fLW+qku1yhGvFacJ5q4XZb47pUsmy6FqZXKa1Ixutb3b2xXoqF/ix/Zll8c9fS6nKNpXB",
+	"v5omssRebXGx6hzc+Z6kkcsULgVrVOLZNtwEUZGwLGulHd9s9zHqmpxK4S8mnVMZXHy03Vd4o3U73bNi",
+	"WhZTWprVlGpt22kVSlpnyBiarGzdrTpXznM29QpUp9be0iWp6JJNFda58b5UWe0EKRVvVbE3unvmtNLK",
+	"zaQxs8YwkTK2+y4LNbov23ab14W7CD+RYsGs6lPNlaczIQVcP0i5zNg0Z6A1/03K3I6X0Vz36czDrVIm",
+	"E+kUTt6dD/FM9tz4WLLkKVPxCFzXI3uALE0m5WV/z7WhyuzZN/v8b1K005ThpoPxX3HNwciyjvvtN9Vw",
+	"UJTzjCdgJudX1HRo9d205iljUxzOKa8TMj4Z7rFV/GXmLnygKS9DY23H0dmKmjOZFxmzlZ+tJE/2VBAX",
+	"XHC9mipGdaeCk7KbduU2MnX3br1aL70eu2lTtu3UzeFx37aP/zvnyvQMudH96XjdQkzNVfxuqp93xHqk",
+	"SXTnP2gzEuyk6rXP+oNbDwqqjP6G6JolwI6vLLRRjOYT4bnPo8gYQLw/VSqZBu9NN0i4PeJi6cwFnUvR",
+	"tCPotba66HDToDAcWC0bjnz0sVWtjA0MHYmVYXiLd4MTo1IiBRpIZsT2wF/X6VazdKhyj2OrtooXUmZn",
+	"NMu2qtgwG9upIpJcdqcKP8RbjiHs/xYvN5myrMVR0j6OvVQKK/0EdxlPWMTTVevcY5m2q1ImwD9liPdj",
+	"TqgnXBMwgB3Bhf8IP58FOp2IeblYMKXBZDOyi0pSlhmqYUPTcmllreD/qkkpDM/wuoFm2UTwygWVZtma",
+	"JDhBrNOTBWgncPjGtYabkJWS5XLVOTGkFMmKiiVLx77Klquu06UdcLjjglLV/iwU00xdocejZlWV6IpO",
+	"wcAUu9D5CXCdQoYxZwupwPXwmioroE+E7+0eTpObm2PrxkASG1ZEvMsmqfS8PXgnLNVtN4k7yttkVPA8",
+	"6bI2dytsWbtUgmNuld13OS/6zyawIbh3wzAjvj/bZ35/a60/RPeb7VhwaLlICpXu5sCz27iAjd96bA1t",
+	"yPs8t7u6jZhIZGq3ovf4w46N9xBg2+9Bq4bbBr3jPd3u01tdwg3bvoqmO5Nl2qk7JmBn6DTdacNzu8Wm",
+	"idRbHdheScHWKN+7O/edFS56bffCMgFTyd9KFTzTFpbx9mtdii27mvKXtJ12Nf++U903dKl3uDnccCPo",
+	"u8ZyV/wsPU2ClafBMJGx9RmdFaPpa5GtO+2n7MYwJSjcVqlWue2NW4iRLljCFzyBeJVYuECPA9C54Cj/",
+	"3v41hGKW6vEZNz+Uc3xIXjyDZ+cZTS4Pd+kl9mtrsVYl3emdfcp6zhMltVyY6vX7HXqlE1m0eb68Pi3N",
+	"iuBb4q5g7WHuBIJe/5KORsNhtmnKtdLCFavZ4BS7kpdogds6CHTHvxsRRbSzpWwPobfZxGlptsZwhM/t",
+	"rDubUxUC3G4aqrw77tW7t1vr9YGndelmq3dRTNA7WPUDKaRc03mGllnwD21V1xw322lyL2zhvS+bGtHY",
+	"tY/DueROxp6bk/oSb5pimVnJmlePtITzBF13ppdsDebW4M8y9ecZPr1m85WUl1N08HEPe08Sb9LsoK+K",
+	"L+y60k2RGwfUOxX3eZ/S4yB4nxcqdWKKrxzQJVyHwJopWDnA5ADne3BJdx5Z3pgYcXN0vMKLi0TlQPlF",
+	"cNua5lRQjEiwwj+ceOjW1bPQZ3C+hl53X1rchkt9BibUx0w+ATPo3f0wh60Ej4ugGMgbeBvX7oHxySd0",
+	"w30OmY0VLeDGSbGFYnpVIRfU2c8G6+mnxitaZmbqAwg3Xt/jWkQtda/IdyVcE57Dfu1clF7Ht/tfEe0u",
+	"Lz3/2N//pLmmV1yZkmbThKp0WqAVdF6mS1itBaemcZhkfLkywnbhmmZZOE7mJqk/0EYqlk7nNKN1v54H",
+	"WNHuRUSHiG7GtpNloBaC9XGIXqSdF4I0y+Y0uZy6i86G5Ozj19zGIO/evsTwbbegpMgoxCBkGcbgo9RA",
+	"UIrVLjyZa/uhC9h2LvqkUHKpmMbIY2f1WzGS8QVL1knGJuIAxTTCrmhWWqF4SLxzBwk+Mf4ZS4/wUnxI",
+	"guvKRMDdXu1ZMFOmh3YkXBN6JXmKXROMpWj9tHOG3S9khlbP758jxIBziDz6wNOPhIm0kFy4uMX+a2Ln",
+	"4XdjdvOLOXOF43DSZA0c7e4Mp1ljRCYbciHtMVMA2SLMSyfZbr8a7j8pum9MymwP+6TrZZm1WiV38z3C",
+	"Om7r69WYV8fecRQds+tO2XuVLqOz20nODyxntjTYZjxxhX47auIXLFDUp3N4JwHjGUu4bjdE1p0It3oH",
+	"oud6dFe//QuuIQ5kBzL03XwWfXJ7R0YML7MyRsYTvjebCRgWzW3lAQqmNHIT3rwsq0dA9LX3luvLl1Cw",
+	"SQPx3NVq7FvkZ/UJD6SfZfIaPeLk9TTyOnMNVsOBVV5Hb3Kp2LTFY7qa62dMdJ8efQ5lnU4fzcvkbgeM",
+	"Z6DHdlraleELmphO/zC8OpyittspZGWlNh2K3jauBuEJnc3nFKQRK7NOr7lI5XVXH+xWBwaws3X/spwz",
+	"JZiBC68rphK4dhTMZHwBAkOL9X+RrbncYq6RTuLUZVFIVb8JjHaAD3ZqN7Upatiy5kVl60Vzwzwr2XSp",
+	"GPDkhAqqkByLjG6N/NqkjxiMoCVCVSnOtLsiHtmvK7s8ojKNyfMbmphsTaRg+IzkpTZkzgL0UjqciEQq",
+	"vLqHSGB311wotuA3RC5ILNWPbTsnE0HIiCy5Gf+O/PO//8f+hY8cWgA+xR/4AlED8Dn8jY8RJwAfw9+u",
+	"tAcMcB+4n/jSowbgO/fLvYrwA9zr6slEWO0B7t8VUczOsvbCvI5il8PMEMSMcBPnfWsmAvhzjB5j58TN",
+	"FwrjOb2JD//HgHvYeNIMoHXmq109MQPwAFrFtn0W3el99Ba07adaxJ8+DitPvt5gFluo+mbJt6oc33NT",
+	"lXfLuV3ug2LRd9U6b/22Kuq/b9t98UDaXGidR/Aeruo1L+KW83meJDtX9jYEmrZVJNP1dGXydrcFeOt1",
+	"wc0D4576sFAy36sCzUQ63fCOtw8FHP8AJjKVIlu3u9KW3d4YZqUYTTtPMiPvY8itNCQMU4XirVEwVpxh",
+	"KXqk+0NQtznLaQSu0nwpRlw4/qxZ8EyyfD4vzJrkjApNaJYRV/l4rwB23yMMZUbmt1eH8N7XfXhPnZpz",
+	"OFune7gR73AZ3nGtHCPnMGGmdJ48fvK0ld66betM6S5f5QYsgirxRhxjQEZwIe4/J06T8zggcJPup/yw",
+	"1cutyGhNcF4o5kB1II49kGLr9snK5eZSv3v7crRQnIk0W5NS8F9LFt32t3oKajmtw1pti9rY4dZ5B8cW",
+	"f3Noh+Fmokk7NcKotdsmnHeA6XzPBFM8cQAnAWi21Cwl8zU5e/vuWTDMaXLgDHaV9VAPJ8LrdcOwxkMA",
+	"OT0cO1GrDlFLPEJtqHciSodIEiH7zBpYuTNwI2Q0bSDztGDhMD/WpvqTtpN4ygzlDT/cW5jWI9/VTtiX",
+	"EIK44yVzyiIv+PfbfOyaN+LR8scxuRszk9F5h09g024D5yyA6FzCZfxiMfUIVcOBTqymoFfSXwUoljBe",
+	"+F/GDhujxQcNdQ/cxyL9cIt1Jyt3cEtzhhks3Tonnip7gGm2x3R2FMB4hTvGzfaH+8rSOMTBvYg1XpRd",
+	"zDfO8L/X8dPmwJGwAiPqVCkEqpcVXsJw4CAW+sPsmvReR61vDfmNut9LBGfu+qb7FtZurmnf1r6fBdlh",
+	"Mu9vBntcU8LMAMD/5nxAGDxLp7vHvWw0EZBy1vuFzDwrlSVZEB9Yio5opKqMAOgfAraiXuvutVxJ8GJp",
+	"RVTYvu91ouQ1mjLXNYHAR/3Ve/qDvCaVAVkDqBM6bKQu2Ic7R7rxRIyIreOECEkunj8nB/GHKUvU2m4g",
+	"wgVZSQ23fgnT+tB+pxkArJ/U2tJMGCvM2roKpqJT+EAx6iCSrQICVeDIWFqvwz+1hy9PGdQFt3p6LRJQ",
+	"I9IyY6kVGOAgboRAun4N/MR1xM7uAI2w8U1sgt6Tcfa4lwEwb15zNazcD7fupijZRSsvisbZu+PelqKT",
+	"DfWOW14xpXjKbr8pu0a0vb+d8AiO8++1ulvP151OmH0PkB5u6KTRbzthFl8CwCLAQNZQFh0IorvrzwA3",
+	"XTND2E2SlSnTZGb1pNlEXANOI9fEBdUggyikNqNXf34DO5iLKxfJW13fLzJ5rce1zaepSOfypgZu5ZHY",
+	"qktomCY3/95XunV3uqGfdcA94pAMvZFC5hD+V8N9ZLqBpHmapgjUCZLZRPhrHEKFLUVozkQKJs/aoCr2",
+	"Pg0h+3OOPjFhSatH4TAMLu6AmT9lN+G83ED+QhBKtMxfS3UZfgdXclrw8HBF9Wqac+3BsRFtv1Rs6sbf",
+	"N5khA0hbOGVn/g9FDeKWz9fkFz+j73+hqXp8/N6Sy0QgRCtRzJRKVHFxCQXVMaDSiypAjBtXaCLAcWFM",
+	"3mmMZbQfbihr5GB2dPX4KFlRc5SEKBYNeFD2hQ+mmh1CK7YxbPMowgl0EWFVkpLxREyEG8gJWRlT6JOj",
+	"o1QmenzNzcoB/Y0pP6KpOrLDHrnZGQFyPUSN7aoI0jLlpiOS092qE+7TAUBhksklbMdFmWXE+Z6Mybmh",
+	"ecHSiZivo7KKJVKlTPnAtmYo4bXixjDRgc8dA7nukEomMKQYkHWH73A315Xf3QUw+Lq6nqk+9Dc1bcJV",
+	"JDo3hKQyp2KkGE1BqotefkM0XQAquF7Ja0uEEGahx+SZZIDEa2A1KBc1sUUqK/1oxPIu6DqTNO2Yb8WM",
+	"4qgAtYSDmhVTMRuHDBquS/bL9XiwNWR/E9u1ajNa7zto9zWPxT1dFRf47bQ/UOgTOTS2m5QTathSKs72",
+	"jDHw3+dMJSvavNvY+nlOb6ZoypwaRYXezWfQBYG1QijuENbQF87wxXlubtLW7SMlajR+n05c9c3zoO5b",
+	"1dXgpjZNNZvOFRVJu89Sz6tkxZJLXTNT707kicytWKRXdM/dAfDlUxfvvd+noJ5PqQb1fd9NjR/7LEqb",
+	"mh+8BoPmrSruRpy5TZ2F6u5poXoaa433A9hjzGuQ0TkIu2ZeelTevrCeAADcbpG+4uy6iZW4Pa5ng7x/",
+	"YDQzq+592e+H0uSNEL+YsqWiKK6n8lq0s0eeM20lsd3VywgTeif7WAwYXOE9Vw23MawXKONuD7JhNwVE",
+	"w07bEbeD53gSMNwBfPtgplf0ydd/OJmUx8dPkxW7gT/Y7ND5hqOIDQ4yoKOMJwIALnRZFJnVIg7MuoD6",
+	"AoS4/4hrkip+xYTVNKgIyON20z/SZPbLL15rG1cY7u/fQ8dmh0NCwTe8NCzFvlq1eCICnAt6nNC5VEbX",
+	"2oV8brOaZjVDLAkhzQrzL3j52as2cGqNyV+ijDLVyEAnggRpvo1DxPYoeMEyLpiT1jW5XlHDrpjyHWZk",
+	"vga/e6fNd4iPi1/FbmmmWpDMZ+1A5rPD8UQAIBAL7k1SMKtZuy9mQ/gro/CXfUC4IFeP75ZCynXq8fjJ",
+	"+Hh2OCY/S6Isd9dDIiSZQWI7M9uOi26npGq0Z2uwtC9ANrMKwXoawENacPhDJqEaDUHKNSFHsiBzltBS",
+	"M0vCTBi1RgIDXTdkN4L1dq0RdsM1EJBcLBx5+Hohz0QRofd/ddiFzwJtTVOudk2IZknY9bAvIZojto3n",
+	"HVD9gV90cQrffgXQAjQ/vhPLrC9/QMWv5qSdIuI4jW0RcLFfgwNucuGT2lgRbImWgLTswpIYDngxpWmq",
+	"mO4IVuf6crrie+sMTtItMmrsSdTsrCyYSDJ6DdGftEzZ1F3x2v9uIMMYEysqUo1x/S5DERce1JqL0v6Z",
+	"UbGEXI9b8PiwN84K32lKdRAQinbrf4blhVRUrae99mcIlwdUoPZ0bR87lz42iN1bqNYOH2HegTsEFN3G",
+	"OyeNwgB28cMHnnK/MNy735HsAzu8v/PL3tFWbfcqzSgrl+whGLrDfO/nM4Oju09ds0HrD6ps1tZmEwXX",
+	"32EOw4Mo7qANH9fdlexy7dx3ZTYc/Hh92XbcL9uVW3XVfhHbkQOlIzeKaVd9RBcXa31+0/p0vZ1obfPY",
+	"uTYy+/H6ssX4dcnWu9OVndJt0AtQYVv7L7no8AvaFm74a0mFcbf3fTDNw4G+LNunWnAzpblHAdrNsFaL",
+	"zIm6GHWoXnPbqH0OitvBHtIbDFXTvWCoezhTNzN79CEi9uAZtgR/IPblpuwPz0mhZF6Yb4jengMk9HEi",
+	"ANHTJ5b/l0EjjKaAVDMw3HOFbwdNOIxprp+eb4VQWKG73o8L5N7og03M1r6kL2CqLvqAiuG9tltbJLtF",
+	"pG46Wd4//KEzdjeS1PRhIL6SKV+sY7z+vSP7MMIQ3Qbu6A1Sr6q9v4K1ZbwKHL6xoeE54YJAkiiCSaKG",
+	"1WFy3HaYxPdZOb15ycTSrAYnT+G76NeWdCG5iywO1bUN6E1NHquPSrAbMy3okrmw5e3elB9bW9AakzKe",
+	"06xH0lxRPS1C2f7bSnC9X1ENniaUQFQyiT5uM1pompm2FPGa/eGrgBp5qpZSPOEpsaXJgbe3gRFGyKgJ",
+	"uChl5jCGcpivzXb398Yw3/fO2J+ZCgT5+Wbukl1Or6KebLbwXHjvvbicPVnn4FaQZByAhXnKvKcf+Ol9",
+	"rvmNo9F6NvNOYJhzJtiCJ3wHnwbX8LfRFx/91ea0033f44ZPDVP5He64My7YdD99LojOrUEAeOvsr6+7",
+	"kIJcKRUDOrSAy8PMgDVUAczqtKh90XY3DCrwyurHcMsbOTYVSt6gkOx8ODpUNcUsc7RTB9hiLsa+4eSZ",
+	"S2FW2RrFb2WYgr+pEGWHQ5ligl13hetj2squNXJvu4Fpu4j52zoVNvWcgirTeYLePeVDa8eCD/He2Ke3",
+	"SBlyS1yYAO/4G0WNuY3BadOSHckW+1mjqukJLgwNW1SwUVUG8W6UGhzdmRQpb2e94F3VkVKEKeouUvz+",
+	"ZL/Clv8V3JHtn9IykMFwsDTwD1iSIZzHeHkUQiQ9ZIfuD7+Rgr1eDE5+2exNeCLKfA7z2jLVLZu/IqQN",
+	"Annfs4fu00LnduWDWuZiXJO22+CMih706N4d6d72krilv07q7ugs7Npu0BpVTyS2S4azOPcYHuJI9Psu",
+	"VbVbWtZsK19cLFyQdROdpYG8EttGAbflmpvVNNaHWvdKTWGaGpYXGTVsb+W6UFwqZ2cLASePj1uVo97V",
+	"rSG5uIJhFro50jnPy4w2koTcxy3NbS9d7gQW1gPCtjncLq6y/xXOhuHSvejpx4btHkAD3BCuEHQ/WfGr",
+	"DultExmiQ5afepz7nYX6RGozTSAIu3Vj/bXUpqYPbUrbbAmM44qz65rv2qZIeM+CuY/AbVqAtFyYa0Tb",
+	"N4pegf3N9svfLXs9A7z/nT+QPSylVR47BF1oSXagXFvhmpv1bpOwv+RbgTs8QBKzndOSVaBa0VQjj81Z",
+	"yst8MBys+BJushU3POlQGs6ZqfT+Tja0XRWPTQYkkQJsjIQFBd17iHidPGXKbjDy0/OfyMEcrCE7KN07",
+	"mlMe/2Fkv2+YVZZMWGEO4zyqruyt6kMXWswTbct0wdipMcyKq71svkw5E22G/ufOi434IiGZGa3qJR7f",
+	"bwfybfaoixML2dqft1SkMifwFvEMIG4x6gsgDgoGvvlblxPzCXrI0A3rTkav2CNNWLFiOVM0I8/Pnv1A",
+	"8CNyydZ7kU6wJjaMpVHfvTcAOXj94tkZ+fEvFzC8MykW3EVBkHN75A3JZJCyq5G8nAygSCYTmh1upR2c",
+	"Vd+X2vg7yOccvUy6bdRAxNO+iTyDIr3zuACYCphv+M1u8JJnl3kNm3x6yS43W7c7vIUP2B4ELqBXcPOE",
+	"IJTkQBb01xLjUwCHa39zXL1Pw5ZZ2jbdXfvCR9xWmXTrw/0ZdDO46IsDlEsjR1HUL8YPD9okzXrUblsm",
+	"NcAng24SVzien34EgZrPUuPq0tXZB93SZIVVdV3zGYStzeyybtdNk4zyXHedKZb3RVsUC1dB6BDS7Xyj",
+	"IOwarbr4CUsPN6PXdpnfDea690yvrjtS7f1AVWrlIeIFFQIFnZ/oZPD92Zvp6atn0/Pnf54MDltRiABx",
+	"MeVLxxAaux3tDUwRKEewXKje+SzSeTIej7sagED/fWfommoHEbDzJEHxFnfOC6gQ34ae+/BFD4czxgw9",
+	"40TmHeMolLSk2Ert35+9Ie49efEMI4zltUDHac8KrYqTSZrudrR6muu/CvF1r6gmcxaRaofPKwYwdVZJ",
+	"EYjAX/hzSPi54MtSddXo/eJxn5t1j9Dh++qLkoKLuAEvSTm4RCpSBE9PnVwwV/JaM3WE7Ld2S7OxL/up",
+	"OnQpuTt595FFaOcB6COOPmnQu0OJvGK11dxEfgAxA5WmIJGMEDX1fQ+7d4ptNxEJ33x1sHDAu/THtRtx",
+	"+xWna2UnzorXwuaWJ9jGMe+zFoUpaz2HFG0L4IS0o7srv1DL86sOJMN+v89eL+D9zC6hqjoahhtM5/Cx",
+	"420GJqn2ceiFdjpxXOBlZ9Y7FzK8vxfMvqFITTK5qk/T1HmMeKtDf8QRTN99GsORHB/UFv5OZDK5/DMt",
+	"M9On1G/VpJ8+QU3aCvFeWAfRK7oyv+I0aNp7C+q2E22T/g5uoB4oldIDhF3fKgb5Y+fAK0jQ7pHfPzIo",
+	"uur9JvFB76Vrt0AJ7V7xBoTlLjEZuLZ3TEbym0020j3id5p17+CU6yKj631MsLa+FkMOehk59QCRgXhq",
+	"JWIqiDMp6FIpuaQGrRwHpVZT8nvy7t2LZ4eW0izhcT0RGD0GsBmZXEKwVxCBS5cXPWVpWWRWmrWym5Ja",
+	"E8zjWW2rFuyUbbs1JHGNZG5fuoI2cwn3d1poO1m2Xz4t60suLlv37RU1VPk0S1sTBd3GnaJ/pSOPkAa+",
+	"LELKIl/459//QaLlCbPUvgTxedS5xyvQ2y65xnt3XUuV7ujoRon/AHzewMBmO3AUHlvKag90bFNMXrcR",
+	"sJ0MnuclzMWQCIi0RcsdAqNVMXKW1HuAijOqzRR6dCdozaa7sbwWQKk0zWGsOQPPhffDvY5QH0rT0B+5",
+	"uOKoN+sScE86LuzuBzu4TiVVSskaVQcv5OCg0tjwDVraL3KqdSt3oazuuTm7ldPajiKQoPkATS9DgoHT",
+	"QyIvDR0STfNsSJhJxtst4ZGOW+tw27hBjsVjpscwu4/2aeXZhgbacAu18jOaD3e09z2wNyz2p79erIhr",
+	"P8xs7YZBDoT0Gn409MPtKEuu2eF2B9fo6hWj7BGAhVHFQhpe/PWdn9Af/3IB+Ma2tO0DvK36tDKmGHz8",
+	"CMr1Qm4O/ep4/ISwGwPxJwAtYNURB3w0wsR/IVsfmjIUT1ZMDZ10WUFtucPSsmmXtuR7bsCeVZRZSObn",
+	"Q1uwBCa+gEKQXaP+FoUJeOmScdTfOwdKbKPyKKgKTcSZVNEAoF8uNeEII82Jyz/onR7C8wBjeCAdzMVh",
+	"eFfhlSJs6+Zz/wQsDSDDeDDqE+dCUSGVR4kLhzAWBGs7ffMCxZWlvGKAmAfRo350oHMDSAsGH/GEnLl8",
+	"jW9g2U7fvIic+04Gx+Mn42PnkCdowQcng6fjx+NjezhQswJSO7Ks9ghPVXB1Cw8kwAeHJy4rWvzIKiFl",
+	"ET+Bs2Y98iJJeP7BM66PRz41ZcfruCdXj4/80E8+DJashUe9BIObD56qwqm4CDzjkSaz/+9o7GEtXNmj",
+	"GUm5AgV3PREHESLGUyvU0mTlMBASlwuokplESlIGJ6dIrHaFavFE2L0iS4MQbXYDvKLqMpXXgsxlimJH",
+	"qRmZ+YyTvicf7OnwcebvqCfC57IkHigTEAnfRMiVQwKQR2hgXdg9YyQpqNKMSEWuaMZTkLANySRNCaDr",
+	"UsUQpE7zDNlcqmRRsPQEejyzJRFQUs9cXh5dqgVNmJXLKjR8h+sIICJysUApA/pTGT7hF6BK2Nk6gLPh",
+	"UshrcYgjBDgLdMh02YFs56EeiOBFJQD9SLkUL1K31KdhJwS0RksTT46PG4FjtEAtg0tx9FcXmIXsaje3",
+	"sJrlCrhpne5ebATuFVlpdaY1gKPC+GHqcULtJvzq+HFX22EwR++E3RBS8b+xFD96uv2j76Sa8zRleBBV",
+	"bMcOYjPE0LIRugTx1k8nOLRukmTnrnsLiJ66onQgvTTQK5ELqz42m8Y54kZPRG1roNYJm4RjpS9fvhot",
+	"aAIEUQr8OOpCDfrkMdCY37xtlPM98z5nlvFVYMS/fBhYXgPM0DtNn4T8neE8R6m9op6miPb+wamxjQLx",
+	"TTXldhIA3+tTkZr94qvtX/wszXeyFGmDNr+3QlwLiczXxC1AN5EKmq0NT/RRqC7Q6ebC+8LnITVEGwn8",
+	"WjJ452ig4aW5Oy0M2+uDjE199eymX7VXbuTdq35QGm4uQRs1+zLEr+ln4ZhIlc2uRLTo30XU6LPPdFIh",
+	"HFyh1Ab9tfW0KnL0hi7ZOf8bg5CEHcqCF8Cgi1bum7A9cOLgszFIN7HbDmxfjvxaspJ9xvO4meu8dh4H",
+	"Ktkkr6MPUVrej70sr4oP2I/U/Icv0sEnWbPedfJY0F/UcdZc3FutrXuO1hqpWxYZ6wq3XHdeZ6jmWwcO",
+	"eo9LHHr48SOaSB6YoFBU2IkNOGB0RyrH2xf+W5qG0XwRJOmWoILMvB0xQvBRJyXGOZ5/g2QYd+9j3Upn",
+	"D7zfBk0+g/Tp/wIUaVfjruQIUWw9BIkgJb9hkmxHUfnNEuerKGrwX4hpgiWrDjHTS67NFCQxgTZOILRD",
+	"PtIEgPwLClcraUmzUaGkkYnMyMuXr3yykzF5pmQx4nbyIdM5ptteSEVmwbe34GMw8fJxIvPWjCgnsO/A",
+	"moz4x1YRYGmMS7WkVhknrwsmTl880iHLCvhr6qgkWPPAigNXB+/eviRcEygLbud4247erWC5/Jat6BWX",
+	"alhLGuMsNn/0mTyJR8E9PLEfjcjvfnchZUZoubRjhlUY/+53AWJLMepuMJyVd8PSNREE/a5a7b9D55ul",
+	"CY2NTAsuOIbkSEUYTVa2lgOr7gxrJqgqoRt8+UjXzb1DEtiKrQA3Hn4UMMO4KEqjD90VgIMEMyuWexQw",
+	"x38ewUhmADE264IGCzhmaE2DtX6kQ2O2BqgA0r4VIa9Ttaz//Ps/anMNPiDg53WFqdnG0aLAhWYiswyu",
+	"ULRdF7gubDHpPNJR6ZTBWGB7eYqsg6ghJLbvvn1CrrnQ3/h1t58rZmsEU6K3GwXTcxjZzCfqmfl8+3gp",
+	"AFSB08ZSP8VjctraG3K9kprhADwuc6lxEGA132xEu+6Bv8sM0xgh2LFUfMkFzUb2tYc9Bjw4Qii5pko4",
+	"VPFMLpdgBPfzPUoACV0YphJW+J0QLmgDKJxlHCyHaYHu25rh02gYDk8BUlxh50du2cOSDePJxqsqRLLz",
+	"s51aus654BqCJLM1qd+gDDGaUZWJ0Tg6oN4Zcchm3iHdjtctWpmZofOF/ytLjF1cMqfJJcT9+On2/HtM",
+	"gApt03hj1rJ0Gi6HPdqfraGi9RAO6MgMkhgmMoXwKTdgN/3nMLO2o27TBEb0rTQrosPrgxn+fULs6Y0p",
+	"p2yrQopRVSqXKcM9qMuikMqwdExeCFIvMcS1zlnKqWF+7yIVpCwzeOnauX7YwLxcLJiCPW545qcwcZj6",
+	"/kIHVs/fOH1juRYE7C0U7DBbDzjIACW4q36PUYgZuk4XhoWutFHL0O86R6R2sW3dyASIXguzYoYnOEYk",
+	"BWyfLCR6LJL52vc/pvVHEFZhuChxUey5cVqaFVyOwqMTPIzCWeY2vq6zVzI7dTIHfDSbiBWjKVM7QEQG",
+	"vkRCRgEnxk2E3YdwHsAVPQb8IHferBBOzAyd2OZr4rLATYQPG/ED3LjceCO1OVtRcxYJHw8judZb+UyS",
+	"a7MTQXIdQj7oI3BVH1UgpFWtzbg9K56MIAAOvvHUKRdkVm8EOcDZqhSXs4n48fz1zwTdNzQ5kILBRegs",
+	"pYaezJBsD4cE2aOLm54IfE1+efb65+fvZ62pETZFb9sLUglxEfM7w5kcXawLBq6Xs42xz6pkBN4PQzND",
+	"6jxqOBEAGHDNtT3KGosyGxNLPwgvOiTonAVccoi8LSSSw92C3KI6WoOEtEHtE1GxYukccaggK1mM5uvR",
+	"ShahRjs7RRFipiADxs3agb3upIK4HHM76x9R+a+Pn9wb3TZzLbas97sNpuBXDi/FyYGDTMNL5SG5eHnu",
+	"/pwgYKWy8ip4eNoD7XBMfJWjkIPxq5ubo69vbtxqupwiBQXnSC9DcUW8qBKv+jfIS78+fmK5FWYzwVHp",
+	"wATl3ElfKJ8eUWWVrBoVTESUwcyRmBU1W7LsN5Prw5o8/ZRr8r1LORlImCOPj6L5gn+xV9/G5JyZiZid",
+	"vnj5/O3rn6ev3zz/+fTF9NvT8+fTd29fzsiBtEubrX1eSwejMxEdGt0M0Y0jX7HByS/vY7UVlbaRHSM1",
+	"3BJAUmce1REY6bFucJEWiz6FkT9OjwsAus9UGpg/LP23j7xfsRUFgcFCSn6kMgdZEvuSyQKzfdSPN+fa",
+	"fYr+6ZsGncYWevsSsyFi5+zfFMQTlEYSRHjVJDhPjskrl9WGEk1zNtLcMEJ9YhRbn5Uu7XJRl8DRrMbk",
+	"Ga4YwDUfaWYMF0t9FGodhWhbhDvbuDbD7TiFm9vd782eIj9qXwjwAPKMoz7ltzXXPNnB8gJepi/R37GP",
+	"Ql9YrdoyGaSJRSavbY/dlEFSHJfY1q9TRKiVf7+jAz14/3ELKTz31TlSqyanatavTt0BJHKy7b4fDYnQ",
+	"nEMz+vZOvdviADLwZxISh+U8UVLLhYlfQ3olTKC2KudTyIvWFu30vnNvxq507ZeB9c1z5ovv5ALhksHc",
+	"+YbYHiDsfsk87DNPKlbVWzLLTiEZhNa9pPgDFWnmCdHPIWqRjkO4BupG6t2I8Eujp4hZ9TowhNGHwd9R",
+	"yL9LLGizM7ukBNw82+E6HnMLNMjplsbqzcv+2HveWSmr1poMT28jts6VO/rgXAJSZrX4tms6+3xj2jaW",
+	"8KsWe7XbEynXoeE7GPPvcHsUOnC706LLXWL7rNyj9rpBuC1qX5Mc78EV4o6ODZtb5D744p4eSA3GJdVO",
+	"DEuqL9bl6v3DE6JU2/ymomn8fD5TSbyWDbqzD4HeWq+DzyBQrErt+ECWsXore5nGHt//mvauI3Gxc7/l",
+	"O9waBbxlS64NgPYk0Tq2ksEGizhyt1Hd97FvS1HP+xqyscZXGl8dhjuDJeSi/e4/f/69i7SZiIB+f0IU",
+	"0zK7YmTBTLIC/fGf//0/JJXXAiMxqJrbRuxDDJaBUH5qSsUmwt/BXrK1JlRrmXBaw3/77j9/Jm5qzRoq",
+	"cbltyfkPp6MnX/9hIuSCzOZcULUm//VfwT18BoVdrlvXyqyW7BcNhhMRMvLaD6iROU/chRYisMV3qZAr",
+	"NJ5tBBI6crk9qV7hLdfRbCJsdRip6Ufi5w9agsynXKTspiXYhV0xtSbO2ERcEtx6VAoawk6gnonwCXuH",
+	"1ez6z4ckp9lCKrigw9UYutXyJSaiFBCtgte2DKMzyc/9aX+t+uFqaLPTN1MwPxAr6sr0/InN9C1Zdbuj",
+	"aPC6OeTxIweInQQ5cqkO964Or+7QcpT75Jt366tg176vLURx+Bt3lXlyfxbu53YD9sxcxVi9ORv2/L5b",
+	"FQOl60eEbyE6IZBZgf7lLktcil2W4srsfoR8CH9v87yON/d+Imf48qF9r3cUEr5A7+vt0gGEvWKeg/rS",
+	"NXCT7mH17p+xd2A7ferr193Ix0Ey/O/1E8TV2EckrXBt+9XWqNy/9dY2TctNz1bFNZrIz6i5hl6QoCTU",
+	"lNiol1u12FD2YdXY0Mzn0mOjDvisYr0L/EWrtC0E0kkfjpdUoDr6CEGhtkZpV59Uvm+VoxRLwTo9bouc",
+	"PkPzdYWt95D20aiVthV3lnQWlbq7od4KD8lmzdUaVJ1qCBFN9w17JOiOuQWHal/PmLiMQ+AfxhTcMac5",
+	"F0TJjG0ugzv7W1fioSSNTTDFTyxq9NNC9fZLEDbaZIc9aM7vew8aMwIQGn30Af7fppU89599b0vvLVXA",
+	"Vw+tljT62LbgdQSeLysutAEfFC+0f9O2zvpIlaI71ultKcLnD8QLQv1vy/08Pp88UBe6Bb6KQGiSsOJ/",
+	"tfqBY2VVyHFw/d6dtD6Ev3dmIHvzjvDlJ+Mf/ZTx5Zk1Ks4RwBFvtb41Z6F2dhLq63YU2nu5H5Aj+V5+",
+	"LvGkj+J83/4FIibfSB1TaVLRTh+duizYI8yC3W8S+Q7Lnrui/7aKbDoyxzO0zTDiChM/9Z/POLJo9KQi",
+	"Gd9Hv+bbTCO1CXhQ60itpc9kIKmPdusSf3HmEZxpDMuNxtFLH46vrBjNEDW1S5j5AUs84G7EFvq24Llz",
+	"SXa97XNWtTKArhevpsGNJYweA6n7uekLV+Y3xUZv5VUMwtCuV7x20BXmfgeYFUjQPs/J/lhYy5Aw5fMc",
+	"AzjKbfzfZUFhLuuU+bzglJ4YPUl78tzG8V3e5n1ZfQXu/mGw5OZNmWVRjoUWFhQjGQ+ihPNVjmlERXYV",
+	"Al4z1Ww6V1Qkq8HJAF4OB+H3gt8cJSuWXMrSjAy9GUGElCWO4SCRec7NVK8ozAUiz381eD8cANzr1MXM",
+	"QRJBlRwZejPGyWPaaPzJtBljRqOMzlkG9czL5YLf2Ppdu/Z1oaYAF3kyuFhxTd68JQt+wzTxZYihN8T3",
+	"DREK0lQTxZbKQYBDq2NI1jD1wMTf8Zv6h1Yk9K3GeOnOTx0WsJCaGwnzTpOchekBimlkbx6cr3hRdXJe",
+	"LgmOrR4MBeNRMicLhi4FOP/ESOIWxFDlrea1DAuuY4CkUe8NphiA/k6jh5dc+MduGJXz+ZKbsaWgqYcZ",
+	"wKMYMkd4bmEZh5kmMmU34LU/pVmxooNaQnImrriSAnPaD9AByinkeDZOi4yahVS5i9y4wYwILC+kYSJZ",
+	"Y47TwZOn6R8WT+l89B9s8afRV0+fstE8fcJGx8kf6OKr+fzx8fHjQTO31uBaT5lYcsFYAKUvEIj7TamS",
+	"lUNuj1QC95ScU3pOdDmv2M+WHeSqrbKBx389/uPx8fFwgHbTBCyp588gQw0TbMET7qBAHfr04K9UsP8L",
+	"IXFibZcTipbpkuFsD04sY+RLMYqSbTuJY+pmFYa/0FPDaD6NisVZwDcij77jy5ySN0qSUyFKuK37taQu",
+	"a+Dj4aAU3Ex3Hp49MXJmJ1SYaUINW+JOiXrjZm3KAXIB/iyqy6STwRVXpqTZNKGQPKGWvRt727rT3jLw",
+	"bbopuAIhjFHMyLExr8O2tacwdoKTkfGECWfg7th22A+3x1wXF+6Z22L4NNpebuDjZGVrbdlVEUb8VBb6",
+	"DptKFpDM77p9X/3xT3/6w38kX89Hx0+/Oh599R9/fDyi9DgZ/TFJ2RO2+Orx8fGT1n214ML2C47pfdQQ",
+	"PP4+k/6BjfeFzWKJL0HxsF/8afsXZ1IsMu4zNgRqPy/nOTeEErtTHDYK95LJpkhTF9OPPoRUhL3m1yDq",
+	"7Cew42cPbXjdmRa+SDzPW63lkU+I3gvgyUTq5s6XvuMCPwiIJxOp799n8yTeRmC+gw5C6381PJ0xkJnC",
+	"j9jI3ajUwS59elg6KsxKyYInHpnO96SJSEcQkC5GBvFxCqe+jgcBpQt4WLNW4DxyYJogdMOJqJDPhhEy",
+	"U4zPNYwQnWLgqEPyz7//YyI0YzhsPyCAagsLMibP+MK7i2HmDq86RZAJK1owDdBsDjHvIgC8+a3gndHD",
+	"HI7gqzqYHCDczT6QDZC7IULUTR163cfZ4RDQL2yNDnICqgNINQehN7pWFBBbrOA09r1yUF1UKQ6QtCn0",
+	"0gNKUY0dmpaazbzDNplnMrkE+DApCNWaa0OF8RBi+hsEaEO8KBw1QodBhQExb4oFmtXaOgG1wlc3RLSR",
+	"itYAO02KK6a0S6IvhVE0MTCoChas1EzXaRTghKyIqsnBzNU/1YYqMxtCv1xXptAV/6b5GHC+Zs7h/RuH",
+	"5sXF0uHXtYB/RXPoBrmSWaoR/wtzPdnHkBKpAwDsDhBaNyNa8NElW88mwi7wLOz9kQv0mQVYn+24Wl1Q",
+	"V688J3sgdFZX/Wc67KrmHwLXKhAp8e0QD8mDibA3ybWDVieig1g3issCSvtqQ7mqHVkgvs0OiFih251Q",
+	"WKQLCQvTk/ZAYZFeJKyJ6IPCIv1IWBPRDYVFtiBheSi6DSgs8m8krH8jYX1hSFinP1/88Pb1mxdne4Nh",
+	"1eTI7XhYlbgTQWL5k34nKCxIEsi3eCa88YX+7ZPQkeZ662WUn8HPdwdVVIvoqSH0atstFA7yQR0O6onP",
+	"P7Glz42va+HWX65rQeFXrmXNGyzgSPO8zKjpseecuxIPSg8ucTw29fkQWDe70ePoEEo5Pe2LIRS/oj5b",
+	"LLuiWUkbHrY9NPMBv9tm2w0Es+f5AZ89tG132+7/oqKD+zb8lsDg+1mkhwrUucUB8elI5F8oEniHE8Uw",
+	"dkSNYdpQf/fdfp54tMzTqPDD0NAFixv5TFTU7ERP/q6qWGUFD9o1XNFe3T6739f4Ub3Ji+fPQdFhwuqT",
+	"6Qb0hMM1VSyXkHI5XjFPChfPn9ep4K/Xl91Jrd8oecNdJOH3gANJzqyW5QNFz62sT378y0/nlVVOS7Qn",
+	"z5W81kxNRJJxMOkkVHikoahv5Me/XFSAG4jFL0tDzl6/PSdc65Lp8UT8BDhEipGEJiuWOvP5SPMUw0gf",
+	"k5UsVUfK3QvGfrSjfEC6gfpbqAQw2v/C5uQntrYqaGTCaLhqoDnBSIcABHMK5OTV3K3OmfiJVLXZBah/",
+	"nHbvT9FDDBodqnouZyCgCQkC1/WRJqxYsZwpmpHnZ89+IEU5z3hCLhlmKKfC7ga1LgxLyU/Pf5qIeSbn",
+	"mH0Al7Ey5M6lWXmTrNtChEKCEFnQX0sGiTRGIZHGP//+D8KNJSy7LTCJDiLerCD5hmaJYoYAigj0AF7+",
+	"9PwnbN21MBEFUwupchwWjMF2nt2gPWzov9b+czS1AXgLZAfhYiJWVKXXVLER1zIDp8ac5VKtx+S0NHJk",
+	"Z1FeY5KYKxYFW+sILLaNfp9rQ+cZ16sLxs7d8jwYA3YNfD7mGzrQ57KMTn/MTwxLYTl+ev4T3hjiVU50",
+	"zte//ylaWksa0XdY8WJP6+Q98O6wyMSWc7sQRuVHZLvZu3PRo7hHwLez632VH3QJvW/zxsrZsdWyiOA2",
+	"cqN1I7h9HH0Pa4RZbUat1edQ0W3RPxdY5N8Wts1VtzOzzcDmpu/zmdeMX79AAPgg0ECp7RrsiGPRCqxQ",
+	"KLngbbgJFXzFO+3wtx9oLaD+HsiKEt7fL1hFiWPy82q7cDeAis55rOFPhKl8KIXWNvCZzsKuZbTPP70q",
+	"24ca0bH4jT11ZKsb+Vs03UjsUaGFNzdcLq8wQxyC5KPmYdbVfVzGxWWldzUgzh1G9HgizpyMWEF32+IZ",
+	"1QYokOTMrCSmHgxpRPJSG7ICGRSzE0ESLAcxHToAWTmsXHotlT3NTJsUV0GG22G8qXD4ezNH+HKYLs/I",
+	"uPsHbLwcEwTnHxIMFTi8QxqJ7efFV636IXZwE5P9U1lY7gvGHaggmqlt9GxXvFgpF3LQri2do4ZQKUt+",
+	"A6RE08wEsTVWz0ilHeE3E+Gzgzrtg2QSMx2WmoslOVVLKZ7wdOjVLE0oQdDYuF6gXfBbctoL5PiUIsM7",
+	"/NCfSlezHQkbohou+tTYfkA6PpIx6rQup/GPyWsBsRZ2bYVBhytMpsluuDa205dsPRE5NUxxCkkAlTRw",
+	"ABzY0kxp3HyKjVx/yBUtM+M0Ok00sxvHsGx92Lbdzpl5U63PwxwRtTY+l9EzdOCcZlti7XxJcDlxCuei",
+	"zLL1ZzpGzlEzx4V3y1vEi7b7DjzKZB1OoiH6ZIyqWoJeZ0WyRAxHh7NDeI19I/HBRAT60uSaQyCeFQXJ",
+	"V0+eRk5tOAiuSSkySESEnqNtFPpSJpeQseghZUFoAPWxPtqAYiRzqZPuIeGITC7dXFhWkdjpj6Z8v6W1",
+	"jGkngdzzQWRlHluuIRBUFQ8JzTJ5DW6MjjmDNdHSBDBczHNJTjMtCRcpCKiaXK+Yc45yQsKKathRdCKq",
+	"yjsMkfXtOvhNMIZzz/iLiEPcVRWvaQlxxTjsPZYfd1L33q7OSdJ1TAbhMOpIsN8huUxE8yy1Sok7I+2n",
+	"T5+M5muD9XpUbeQZ0v7zw8XFm/PxREQ2TTx70T7o/ccDGHe6eeTjqSwB9x54M+6YajhcOP4UaNtbTi4u",
+	"Xo4JmA3QyG4P9YmYs+gsr0yg4KHOM9bOsNoI9x28q5jVA2hbVQuf6SDdi1P6yfpycP6gw261waOw2goj",
+	"3Da34My1S4XdoD89BW5QP9B0zIZjeTMuHUvG++x4lFrtXnd7O7Lpc419MBLDuUkilWKJEUzr+J5iIlDi",
+	"1cy1GTEUNCRv5ft/rl/EfAL+H7fYS9rNJbkv9t+q4OxAaUCtm3btdvKKj+XA1JwMBm64+PewxjchoHg9",
+	"gfzWyH67T3ey9XCPWMhvRqa734P8KsiJm8b0sIp1S/yHAaYcPy3NanDyy/uP7+1ru5k67B1V5HOpssHJ",
+	"IHa9tZzLJXwZUw7OLK75D97UAe18HIbfMXpp9Bh7Gz14EQBIqqoAzhBBu8PDyEs0PKslpqo+x/z3tc5U",
+	"8GPR0yaCUFxzDTk8PA6W9KoxQbO14Ulbv+J0aHElz5/HPx2Aj31SX5Nn3YF33sFcF4xeustbDMYikDE8",
+	"SgSP7Hcz7GPo49nsDIRU/o80RlQl1NBMLoMTvBXTQIznPlGKC3XWwyjkzdZUBXqhsCStzOeKToQDicMm",
+	"c5IyTJLOteFwgCAzwBgu3zG9FmbFtN0akG/cbgUA1gvpPULoBd7Xj0kI7OOaWF6x4C4Ju0vl9EdygAGT",
+	"GPnHxdIZM9yaeFfwj+8//v8BAAD//4F4W0aCVQEA",
 }
 
 // GetSwagger returns the content of the embedded swagger specification file

--- a/internal/api/openapi.yaml
+++ b/internal/api/openapi.yaml
@@ -1650,20 +1650,20 @@ paths:
                   JSON objects (one per `data:` frame), terminated by
                   `data: [DONE]`.
         "400":
-          $ref: "#/components/responses/BadRequest"
+          $ref: "#/components/responses/Failure"
         "401":
-          $ref: "#/components/responses/Unauthorized"
+          $ref: "#/components/responses/Failure"
         "502":
           description: |
             Upstream provider request failed (network error, TLS error,
             or unreachable host). Upstream-returned 4xx/5xx statuses
             propagate with their original status code; this 502 is for
             failures Aileron observed before/around the upstream
-            transaction.
+            transaction. Body is a `FailureEnvelope` per ADR-0010.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/FailureEnvelope"
         "503":
           description: |
             Gateway upstream is not configured for this protocol. Set
@@ -1672,7 +1672,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/FailureEnvelope"
 
   /v1/messages:
     post:
@@ -1732,20 +1732,20 @@ paths:
                   `content_block_delta`, `content_block_stop`,
                   `message_delta`, `message_stop`).
         "400":
-          $ref: "#/components/responses/BadRequest"
+          $ref: "#/components/responses/Failure"
         "401":
-          $ref: "#/components/responses/Unauthorized"
+          $ref: "#/components/responses/Failure"
         "502":
           description: |
             Upstream provider request failed (network error, TLS error,
             or unreachable host). Upstream-returned 4xx/5xx statuses
             propagate with their original status code; this 502 is for
             failures Aileron observed before/around the upstream
-            transaction.
+            transaction. Body is a `FailureEnvelope` per ADR-0010.
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/FailureEnvelope"
         "503":
           description: |
             Gateway upstream is not configured for this protocol. Set
@@ -1754,7 +1754,7 @@ paths:
           content:
             application/json:
               schema:
-                $ref: "#/components/schemas/Error"
+                $ref: "#/components/schemas/FailureEnvelope"
 
 components:
   securitySchemes:
@@ -1845,6 +1845,14 @@ components:
         application/json:
           schema:
             $ref: "#/components/schemas/Error"
+    Failure:
+      description: |
+        Structured failure envelope per ADR-0010 (action-execution and
+        gateway responses).
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/FailureEnvelope"
 
   schemas:
     Jwks:
@@ -1897,6 +1905,10 @@ components:
     Error:
       type: object
       required: [error]
+      description: |
+        Generic error envelope used by CRUD endpoints (intents, approvals,
+        policies, accounts, auth). Action-execution and gateway endpoints
+        use the structured `FailureEnvelope` instead, per ADR-0010.
       properties:
         error:
           type: object
@@ -1910,6 +1922,71 @@ components:
                 type: object
                 additionalProperties: true
             request_id: { type: string }
+
+    FailureEnvelope:
+      type: object
+      required: [error]
+      description: |
+        Structured failure envelope ratified by [ADR-0010][adr10] for
+        errors returned to the calling action and through it to the
+        agent. Used on the gateway endpoints (`/v1/chat/completions`,
+        `/v1/messages`) and on action / connector install responses.
+
+        [adr10]: https://docs.withaileron.ai/adr/0010-failure-handling
+      properties:
+        error:
+          type: object
+          required: [class, message, retriable, boundary]
+          properties:
+            class:
+              $ref: "#/components/schemas/FailureClass"
+            message:
+              type: string
+              description: |
+                Human-readable description; safe to show end users. Does
+                not contain credentials or sensitive payload.
+            retriable:
+              type: boolean
+              description: Whether the failure is safe to retry.
+            boundary:
+              $ref: "#/components/schemas/FailureBoundary"
+            audit_id:
+              type: string
+              description: |
+                Reference into the audit log for full context. Stamped
+                by the audit recorder before the response is written.
+            details:
+              type: object
+              additionalProperties: true
+              description: Class-specific additional fields.
+
+    FailureClass:
+      type: string
+      description: |
+        Closed taxonomy of failure classes per ADR-0010. Adding a value
+        requires an ADR amendment.
+      enum:
+        - capability_denied
+        - binding_required
+        - binding_failed
+        - resource_limit_exceeded
+        - connector_runtime_error
+        - network_error
+        - external_api_error
+        - hash_mismatch
+        - signature_failure
+
+    FailureBoundary:
+      type: string
+      description: |
+        Layer that produced the failure. The closed set excludes `user`
+        which is reserved for post-MVP per-invocation approval flows.
+      enum:
+        - sandbox
+        - connector_manifest
+        - action
+        - runtime
+        - external
 
     Pagination:
       type: object

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -26,6 +26,7 @@ import (
 	gmailconnector "github.com/ALRubinger/aileron/internal/connector/email/gmail"
 	"github.com/ALRubinger/aileron/internal/connector/git/github"
 	"github.com/ALRubinger/aileron/internal/connector/payments/stripe"
+	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/draft"
 	"github.com/ALRubinger/aileron/internal/enclave"
 	"github.com/ALRubinger/aileron/internal/intercept"
@@ -191,6 +192,15 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		server.sandboxRuntime = sandboxRT
 	}
 
+	// --- Audit log (ADR-0010) ---
+	// The in-memory store is sufficient for v1 dev/test; Postgres
+	// persistence is post-MVP. The recorder mints audit IDs and
+	// stamps them onto failures so the agent's response carries a
+	// working back-reference into the audit log.
+	auditStore := audit.NewMemStore()
+	recorder := audit.NewRecorder(auditStore, nil, nil)
+	server.auditStore = auditStore
+
 	// --- Intercept engine (stage 4) ---
 	engine, engineErr := intercept.New(intercept.Config{
 		OpenAIUpstream:    gatewayCfg.OpenAIBaseURL,
@@ -198,6 +208,7 @@ func NewHandler(log *slog.Logger) (http.Handler, error) {
 		Actions:           server.actions,
 		Executor:          executor,
 		Log:               log,
+		Recorder:          recorder,
 	})
 	if engineErr != nil {
 		return nil, fmt.Errorf("intercept engine: %w", engineErr)

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -16,6 +16,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/sandbox"
 	"github.com/ALRubinger/aileron/internal/approval"
+	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/auth"
 	"github.com/ALRubinger/aileron/internal/comms"
 	"github.com/ALRubinger/aileron/internal/config"
@@ -96,6 +97,7 @@ type apiServer struct {
 	openAIProxy        http.Handler                // upstream proxy for /v1/chat/completions; nil disables the endpoint
 	anthropicProxy     http.Handler                // upstream proxy for /v1/messages; nil disables the endpoint
 	interceptEngine    interceptEngineHandle       // tool-call intercept engine; nil disables interception (proxy passthrough only)
+	auditStore         *audit.MemStore             // ADR-0010 audit store; in-memory for v1, Postgres post-MVP
 	newID              func() string
 	actions            *action.Store     // installed actions in ~/.aileron/actions/ (ADR-0003)
 	installer          *cstore.Installer // connector install pipeline (ADR-0004); nil disables /v1/connectors/install

--- a/internal/app/handlers_gateway_test.go
+++ b/internal/app/handlers_gateway_test.go
@@ -18,6 +18,7 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/action"
 	api "github.com/ALRubinger/aileron/internal/api/gen"
+	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/intercept"
 )
 
@@ -420,6 +421,7 @@ func newGatewayTestServerWithActions(t *testing.T, openAIUpstream, anthropicUpst
 		Actions:           store,
 		Executor:          action.StubExecutor{},
 		Log:               s.log,
+		Recorder:          audit.NewRecorder(audit.NewMemStore(), nil, nil),
 	})
 	if err != nil {
 		t.Fatalf("intercept.New: %v", err)

--- a/internal/audit/mem.go
+++ b/internal/audit/mem.go
@@ -1,0 +1,155 @@
+package audit
+
+import (
+	"context"
+	"sort"
+	"sync"
+
+	"github.com/ALRubinger/aileron/internal/model"
+	"github.com/ALRubinger/aileron/internal/store"
+)
+
+// MemStore is an in-memory implementation of the [Store] SPI suitable
+// for v1 dev/test environments. Events are kept in a single ordered
+// slice; lookups are filtered linearly. Trace IDs come from the
+// caller — typically the audit_id of an envelope or an upstream
+// trace correlation ID — and are stored alongside the event.
+//
+// Persistence to Postgres is post-MVP; the SPI is identical so the
+// switch is a wiring change.
+type MemStore struct {
+	mu     sync.RWMutex
+	events []eventWithTrace
+}
+
+// eventWithTrace carries the optional trace correlation ID alongside
+// the SPI's Event. The SPI's Event has no TraceID field, so we keep
+// it next to the event in this storage layer.
+type eventWithTrace struct {
+	traceID     string
+	intentID    string
+	workspaceID string
+	event       Event
+}
+
+// NewMemStore returns an empty MemStore.
+func NewMemStore() *MemStore { return &MemStore{} }
+
+// Append records a new event.
+func (m *MemStore) Append(_ context.Context, event Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, eventWithTrace{event: event})
+	return nil
+}
+
+// AppendToTrace records an event scoped to a specific trace
+// (intent/workspace). The base [Store] interface deliberately keeps
+// trace correlation out of the Event struct; this helper is the
+// canonical way to associate an event with a trace.
+func (m *MemStore) AppendToTrace(_ context.Context, traceID, intentID, workspaceID string, event Event) error {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.events = append(m.events, eventWithTrace{
+		traceID:     traceID,
+		intentID:    intentID,
+		workspaceID: workspaceID,
+		event:       event,
+	})
+	return nil
+}
+
+// GetByEventID returns the recorded event with the given EventID and
+// reports whether one was found. Useful for tests asserting that an
+// audit_id stamped on a [failure.Failure] resolves to a real event.
+func (m *MemStore) GetByEventID(eventID string) (Event, bool) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	for _, e := range m.events {
+		if e.event.EventID == eventID {
+			return e.event, true
+		}
+	}
+	return Event{}, false
+}
+
+// ListTraces returns traces matching the filter. Events without a
+// trace ID are grouped under TraceID=="" and surface only when the
+// filter is permissive.
+func (m *MemStore) ListTraces(_ context.Context, filter Filter) ([]Trace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	byTrace := map[string]*Trace{}
+	for _, e := range m.events {
+		if !matchFilter(e, filter) {
+			continue
+		}
+		t, ok := byTrace[e.traceID]
+		if !ok {
+			t = &Trace{
+				TraceID:     e.traceID,
+				IntentID:    e.intentID,
+				WorkspaceID: e.workspaceID,
+			}
+			byTrace[e.traceID] = t
+		}
+		t.Events = append(t.Events, e.event)
+	}
+	out := make([]Trace, 0, len(byTrace))
+	for _, t := range byTrace {
+		out = append(out, *t)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].TraceID < out[j].TraceID })
+	return out, nil
+}
+
+// GetTrace returns the trace with the given TraceID.
+func (m *MemStore) GetTrace(_ context.Context, traceID string) (Trace, error) {
+	m.mu.RLock()
+	defer m.mu.RUnlock()
+	t := Trace{TraceID: traceID}
+	found := false
+	for _, e := range m.events {
+		if e.traceID != traceID {
+			continue
+		}
+		found = true
+		t.IntentID = e.intentID
+		t.WorkspaceID = e.workspaceID
+		t.Events = append(t.Events, e.event)
+	}
+	if !found {
+		return Trace{}, &store.ErrNotFound{Entity: "trace", ID: traceID}
+	}
+	return t, nil
+}
+
+func matchFilter(e eventWithTrace, f Filter) bool {
+	if f.WorkspaceID != "" && e.workspaceID != f.WorkspaceID {
+		return false
+	}
+	if f.IntentID != "" && e.intentID != f.IntentID {
+		return false
+	}
+	if f.ActorID != "" && e.event.Actor.ID != f.ActorID {
+		return false
+	}
+	if f.EventType != "" && e.event.EventType != f.EventType {
+		return false
+	}
+	if f.From != nil && e.event.Timestamp.Before(*f.From) {
+		return false
+	}
+	if f.To != nil && e.event.Timestamp.After(*f.To) {
+		return false
+	}
+	return true
+}
+
+// Compile-time check that MemStore satisfies the SPI.
+var _ Store = (*MemStore)(nil)
+
+// helperEnsureModelImported is a compile-time hint that pulls in
+// model so the package imports stay tidy when other helpers refer
+// to model types via interface satisfaction.
+var _ model.ActorRef

--- a/internal/audit/record.go
+++ b/internal/audit/record.go
@@ -1,0 +1,110 @@
+package audit
+
+import (
+	"context"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/failure"
+	"github.com/ALRubinger/aileron/internal/model"
+	"github.com/google/uuid"
+)
+
+// Recorder writes audit events for failures and successes flowing
+// through the gateway, action installer, and connector installer.
+//
+// The package-level [Store] SPI handles persistence; Recorder layers
+// on top of it to mint the audit_id, format the [Event] payload, and
+// stamp the audit_id back onto [failure.Failure] so the envelope
+// returned to the caller carries a working back-reference.
+type Recorder interface {
+	// RecordFailure persists the failure as an audit event and
+	// returns the minted audit_id. The same id is also stamped onto
+	// the failure via failure.SetAuditID so callers can write the
+	// envelope without an extra lookup.
+	RecordFailure(ctx context.Context, f *failure.Failure, actor model.ActorRef) string
+
+	// RecordSuccess persists a non-failure event with the given type
+	// and payload. Returns the minted event_id.
+	RecordSuccess(ctx context.Context, eventType model.EventType, actor model.ActorRef, payload map[string]any) string
+}
+
+// NewRecorder returns a Recorder backed by the given Store. clk
+// supplies timestamps; pass clock.System{} in production. idFn mints
+// audit_ids; pass DefaultIDFn for the default UUID-based scheme.
+func NewRecorder(s Store, clk Clock, idFn func() string) Recorder {
+	if idFn == nil {
+		idFn = DefaultIDFn
+	}
+	if clk == nil {
+		clk = systemClock{}
+	}
+	return &recorder{store: s, clk: clk, idFn: idFn}
+}
+
+// Clock is the minimal interface Recorder needs from a clock. It
+// matches the shape of internal/clock.Clock without taking the
+// dependency, so this package stays small.
+type Clock interface {
+	Now() time.Time
+}
+
+type systemClock struct{}
+
+func (systemClock) Now() time.Time { return time.Now().UTC() }
+
+// DefaultIDFn returns a UUIDv4-based audit_id prefixed with `audit-`
+// per ADR-0010's example shape.
+func DefaultIDFn() string {
+	return "audit-" + uuid.NewString()
+}
+
+type recorder struct {
+	store Store
+	clk   Clock
+	idFn  func() string
+}
+
+// RecordFailure mints an audit_id, stamps it on f, and appends an
+// event of type EventTypeExecutionFailed with the failure shape.
+//
+// The store error is intentionally swallowed: ADR-0010 wants the
+// audit log to be a best-effort companion to the response — a
+// failed audit write must not block the failure response. Production
+// stores wrap this with an alerter / fallback.
+func (r *recorder) RecordFailure(ctx context.Context, f *failure.Failure, actor model.ActorRef) string {
+	id := r.idFn()
+	if f != nil {
+		f.SetAuditID(id)
+	}
+	payload := map[string]any{}
+	if f != nil {
+		payload["class"] = string(f.Class())
+		payload["boundary"] = string(f.Boundary())
+		payload["retriable"] = f.Retriable()
+		payload["message"] = f.Message()
+		if d := f.Details(); len(d) > 0 {
+			payload["details"] = d
+		}
+	}
+	_ = r.store.Append(ctx, Event{
+		EventID:   id,
+		EventType: model.EventTypeExecutionFailed,
+		Actor:     actor,
+		Payload:   payload,
+		Timestamp: r.clk.Now(),
+	})
+	return id
+}
+
+// RecordSuccess appends a non-failure event with the given type.
+func (r *recorder) RecordSuccess(ctx context.Context, eventType model.EventType, actor model.ActorRef, payload map[string]any) string {
+	id := r.idFn()
+	_ = r.store.Append(ctx, Event{
+		EventID:   id,
+		EventType: eventType,
+		Actor:     actor,
+		Payload:   payload,
+		Timestamp: r.clk.Now(),
+	})
+	return id
+}

--- a/internal/audit/record_test.go
+++ b/internal/audit/record_test.go
@@ -1,0 +1,203 @@
+package audit_test
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/failure"
+	"github.com/ALRubinger/aileron/internal/model"
+)
+
+// Recorder contract:
+//   - RecordFailure mints an audit_id, stamps it on the failure, and
+//     appends an EventTypeExecutionFailed event whose payload carries
+//     class/boundary/retriable/message/details.
+//   - RecordSuccess appends an event with the given type/payload.
+//   - Clock and idFn are injectable for deterministic tests.
+//   - Store.Append errors are swallowed (best-effort audit per ADR-0010).
+
+type fixedClock struct{ t time.Time }
+
+func (f fixedClock) Now() time.Time { return f.t }
+
+func newRecorderWithMem(t *testing.T) (*audit.MemStore, audit.Recorder, func() string) {
+	t.Helper()
+	store := audit.NewMemStore()
+	var counter int
+	idFn := func() string {
+		counter++
+		return "audit-" + string(rune('a'+counter-1))
+	}
+	r := audit.NewRecorder(store, fixedClock{t: time.Date(2026, 5, 1, 12, 0, 0, 0, time.UTC)}, idFn)
+	return store, r, idFn
+}
+
+func TestRecordFailure_StampsAuditIDAndAppends(t *testing.T) {
+	store, r, _ := newRecorderWithMem(t)
+	f := failure.Upstream(503, "service unavailable",
+		failure.WithDetails(map[string]any{"retried": 2}))
+	id := r.RecordFailure(context.Background(), f, model.ActorRef{ID: "agent-1", Type: model.ActorTypeAgent})
+
+	if id == "" {
+		t.Fatal("RecordFailure returned empty id")
+	}
+	if f.AuditID() != id {
+		t.Errorf("audit_id stamp = %q, want %q", f.AuditID(), id)
+	}
+	ev, ok := store.GetByEventID(id)
+	if !ok {
+		t.Fatalf("event %q not found in store", id)
+	}
+	if ev.EventType != model.EventTypeExecutionFailed {
+		t.Errorf("event type = %q, want execution.failed", ev.EventType)
+	}
+	if ev.Payload["class"] != string(failure.ExternalAPIError) {
+		t.Errorf("payload.class = %v", ev.Payload["class"])
+	}
+	if ev.Payload["retriable"] != true {
+		t.Errorf("payload.retriable = %v", ev.Payload["retriable"])
+	}
+	if ev.Payload["message"] != "service unavailable" {
+		t.Errorf("payload.message = %v", ev.Payload["message"])
+	}
+	if d, ok := ev.Payload["details"].(map[string]any); !ok || d["retried"] != 2 {
+		t.Errorf("payload.details = %v", ev.Payload["details"])
+	}
+	if ev.Actor.ID != "agent-1" {
+		t.Errorf("actor.id = %q", ev.Actor.ID)
+	}
+}
+
+func TestRecordFailure_NilFailureNoCrash(t *testing.T) {
+	_, r, _ := newRecorderWithMem(t)
+	id := r.RecordFailure(context.Background(), nil, model.ActorRef{})
+	if id == "" {
+		t.Error("RecordFailure(nil) should still mint an id")
+	}
+}
+
+func TestRecordSuccess_AppendsEvent(t *testing.T) {
+	store, r, _ := newRecorderWithMem(t)
+	id := r.RecordSuccess(context.Background(),
+		model.EventTypeToolCallIntercepted,
+		model.ActorRef{ID: "aileron", Type: model.ActorTypeService},
+		map[string]any{"tool": "ship_update"},
+	)
+	if id == "" {
+		t.Fatal("RecordSuccess returned empty id")
+	}
+	ev, ok := store.GetByEventID(id)
+	if !ok {
+		t.Fatalf("event %q not found", id)
+	}
+	if ev.EventType != model.EventTypeToolCallIntercepted {
+		t.Errorf("event type = %q", ev.EventType)
+	}
+	if ev.Payload["tool"] != "ship_update" {
+		t.Errorf("payload.tool = %v", ev.Payload["tool"])
+	}
+}
+
+func TestNewRecorder_DefaultsAreUsable(t *testing.T) {
+	r := audit.NewRecorder(audit.NewMemStore(), nil, nil)
+	id := r.RecordSuccess(context.Background(),
+		model.EventTypeIntentSubmitted, model.ActorRef{}, nil)
+	if id == "" || id == "audit-" {
+		t.Errorf("default idFn produced empty/odd id %q", id)
+	}
+}
+
+func TestDefaultIDFn_PrefixedAndUnique(t *testing.T) {
+	a := audit.DefaultIDFn()
+	b := audit.DefaultIDFn()
+	if a == b {
+		t.Error("DefaultIDFn returned duplicate ids")
+	}
+	for _, id := range []string{a, b} {
+		if len(id) < len("audit-") || id[:len("audit-")] != "audit-" {
+			t.Errorf("id %q lacks audit- prefix", id)
+		}
+	}
+}
+
+func TestMemStore_AppendAndList(t *testing.T) {
+	store := audit.NewMemStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+
+	if err := store.AppendToTrace(ctx, "trace-1", "intent-1", "ws-1", audit.Event{
+		EventID:   "e-1",
+		EventType: model.EventTypeIntentSubmitted,
+		Actor:     model.ActorRef{ID: "u1"},
+		Timestamp: now,
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if err := store.AppendToTrace(ctx, "trace-1", "intent-1", "ws-1", audit.Event{
+		EventID:   "e-2",
+		EventType: model.EventTypeExecutionSucceeded,
+		Actor:     model.ActorRef{ID: "agent-x"},
+		Timestamp: now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	traces, err := store.ListTraces(ctx, audit.Filter{IntentID: "intent-1"})
+	if err != nil {
+		t.Fatalf("ListTraces: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("got %d traces, want 1", len(traces))
+	}
+	if len(traces[0].Events) != 2 {
+		t.Errorf("trace.Events = %d, want 2", len(traces[0].Events))
+	}
+
+	got, err := store.GetTrace(ctx, "trace-1")
+	if err != nil {
+		t.Fatalf("GetTrace: %v", err)
+	}
+	if got.IntentID != "intent-1" || got.WorkspaceID != "ws-1" {
+		t.Errorf("GetTrace fields = %+v", got)
+	}
+	if _, err := store.GetTrace(ctx, "missing"); err == nil {
+		t.Error("GetTrace(missing) should return error")
+	}
+}
+
+func TestMemStore_FilterByEventTypeAndActorAndTime(t *testing.T) {
+	store := audit.NewMemStore()
+	ctx := context.Background()
+	now := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	for _, e := range []audit.Event{
+		{EventID: "1", EventType: model.EventTypeIntentSubmitted, Actor: model.ActorRef{ID: "a"}, Timestamp: now},
+		{EventID: "2", EventType: model.EventTypeExecutionFailed, Actor: model.ActorRef{ID: "a"}, Timestamp: now.Add(time.Hour)},
+		{EventID: "3", EventType: model.EventTypeExecutionFailed, Actor: model.ActorRef{ID: "b"}, Timestamp: now.Add(2 * time.Hour)},
+	} {
+		store.Append(ctx, e)
+	}
+	out, err := store.ListTraces(ctx, audit.Filter{EventType: model.EventTypeExecutionFailed, ActorID: "a"})
+	if err != nil {
+		t.Fatalf("ListTraces: %v", err)
+	}
+	got := 0
+	for _, tr := range out {
+		got += len(tr.Events)
+	}
+	if got != 1 {
+		t.Errorf("filtered events = %d, want 1", got)
+	}
+
+	from := now.Add(30 * time.Minute)
+	to := now.Add(90 * time.Minute)
+	out, _ = store.ListTraces(ctx, audit.Filter{From: &from, To: &to})
+	got = 0
+	for _, tr := range out {
+		got += len(tr.Events)
+	}
+	if got != 1 {
+		t.Errorf("range-filtered events = %d, want 1", got)
+	}
+}

--- a/internal/auth/errors.go
+++ b/internal/auth/errors.go
@@ -1,0 +1,31 @@
+package auth
+
+import (
+	"encoding/json"
+	"net/http"
+)
+
+// writeError emits an api.Error-compatible structured envelope:
+//
+//	{"error": {"code": "<code>", "message": "<prose>"}}
+//
+// Auth handlers historically used `http.Error(w, "{\"error\": ...}",
+// status)` with a string-valued `error` key — incompatible with the
+// rest of the CRUD API. ADR-0010 (#365) ratified the envelope shape
+// for action/gateway responses; auth stays on the existing CRUD
+// envelope but is normalized here so all v1 endpoints emit the same
+// nested-object shape.
+func writeError(w http.ResponseWriter, status int, code, message string) {
+	body, _ := json.Marshal(struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}{Error: struct {
+		Code    string `json:"code"`
+		Message string `json:"message"`
+	}{Code: code, Message: message}})
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(status)
+	_, _ = w.Write(body)
+}

--- a/internal/auth/handler.go
+++ b/internal/auth/handler.go
@@ -113,13 +113,13 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	providerName := r.PathValue("provider")
 	provider, ok := h.registry.Get(providerName)
 	if !ok {
-		http.Error(w, `{"error":"unknown auth provider"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "unknown_provider", "unknown auth provider")
 		return
 	}
 
 	state, err := generateState()
 	if err != nil {
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -137,7 +137,7 @@ func (h *Handler) handleLogin(w http.ResponseWriter, r *http.Request) {
 	result, err := provider.AuthorizationURL(r.Context(), state, h.callbackURL(r, providerName))
 	if err != nil {
 		h.log.Error("failed to generate auth URL", "error", err)
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -177,7 +177,7 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	providerName := r.PathValue("provider")
 	provider, ok := h.registry.Get(providerName)
 	if !ok {
-		http.Error(w, `{"error":"unknown auth provider"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "unknown_provider", "unknown auth provider")
 		return
 	}
 
@@ -186,11 +186,11 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	// Validate CSRF state.
 	stateCookie, err := r.Cookie("oauth_state")
 	if err != nil || stateCookie.Value == "" {
-		http.Error(w, `{"error":"missing state cookie"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "missing_state", "missing state cookie")
 		return
 	}
 	if stateParam != stateCookie.Value {
-		http.Error(w, `{"error":"state mismatch"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "state_mismatch", "state mismatch")
 		return
 	}
 	// Clear the state cookie.
@@ -204,7 +204,7 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	// Check for error from provider.
 	if errParam := r.URL.Query().Get("error"); errParam != "" {
 		h.log.Warn("auth provider returned error", "provider", providerName, "error", errParam)
-		http.Error(w, fmt.Sprintf(`{"error":"provider error: %s"}`, errParam), http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "provider_error", "provider error: "+errParam)
 		return
 	}
 
@@ -230,7 +230,7 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 	})
 	if err != nil {
 		h.log.Error("callback exchange failed", "provider", providerName, "error", err)
-		http.Error(w, `{"error":"authentication failed"}`, http.StatusUnauthorized)
+		writeError(w, http.StatusUnauthorized, "unauthenticated", "authentication failed")
 		return
 	}
 
@@ -246,7 +246,7 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 		user, err = h.users.Get(ctx, link.UserID)
 		if err != nil {
 			h.log.Error("user lookup by link failed", "error", err)
-			http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 			return
 		}
 	} else if isNotFound(err) {
@@ -254,7 +254,7 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 		user, err = h.users.GetByEmail(ctx, identity.Email)
 		if err != nil && !isNotFound(err) {
 			h.log.Error("user lookup failed", "error", err)
-			http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 			return
 		}
 		if isNotFound(err) {
@@ -262,7 +262,7 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 			user, err = h.createEnterpriseAndUser(ctx, identity)
 			if err != nil {
 				h.log.Error("failed to create enterprise/user", "error", err)
-				http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+				writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 				return
 			}
 			// createEnterpriseAndUser already created the auth provider link.
@@ -282,7 +282,7 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 		}
 	} else {
 		h.log.Error("auth provider lookup failed", "error", err)
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -291,22 +291,22 @@ func (h *Handler) handleCallback(w http.ResponseWriter, r *http.Request) {
 		allowed, err := h.enforcer.IsProviderAllowed(ctx, user.EnterpriseID, identity.Provider)
 		if err != nil {
 			h.log.Error("provider check failed", "error", err)
-			http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 			return
 		}
 		if !allowed {
-			http.Error(w, `{"error":"auth provider not allowed for this enterprise"}`, http.StatusForbidden)
+			writeError(w, http.StatusForbidden, "provider_not_allowed", "auth provider not allowed for this enterprise")
 			return
 		}
 
 		domainAllowed, err := h.enforcer.IsEmailDomainAllowed(ctx, user.EnterpriseID, identity.Email)
 		if err != nil {
 			h.log.Error("domain check failed", "error", err)
-			http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+			writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 			return
 		}
 		if !domainAllowed {
-			http.Error(w, `{"error":"email domain not allowed for this enterprise"}`, http.StatusForbidden)
+			writeError(w, http.StatusForbidden, "domain_not_allowed", "email domain not allowed for this enterprise")
 			return
 		}
 
@@ -327,14 +327,14 @@ issueTokens:
 	accessToken, err := h.issuer.Issue(user.ID, user.EnterpriseID, user.Email, string(user.Role))
 	if err != nil {
 		h.log.Error("failed to issue token", "error", err)
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
 	refreshRaw, refreshHash, err := GenerateRefreshToken()
 	if err != nil {
 		h.log.Error("failed to generate refresh token", "error", err)
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -349,7 +349,7 @@ issueTokens:
 	}
 	if err := h.sessions.Create(ctx, session); err != nil {
 		h.log.Error("failed to create session", "error", err)
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -395,7 +395,7 @@ func (h *Handler) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 	if refreshToken == "" {
-		http.Error(w, `{"error":"missing refresh token"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "missing_refresh_token", "missing refresh token")
 		return
 	}
 
@@ -403,32 +403,32 @@ func (h *Handler) handleRefresh(w http.ResponseWriter, r *http.Request) {
 	hash := HashToken(refreshToken)
 	session, err := h.sessions.GetByRefreshTokenHash(ctx, hash)
 	if err != nil {
-		http.Error(w, `{"error":"invalid refresh token"}`, http.StatusUnauthorized)
+		writeError(w, http.StatusUnauthorized, "invalid_refresh_token", "invalid refresh token")
 		return
 	}
 	if time.Now().After(session.ExpiresAt) {
 		_ = h.sessions.Delete(ctx, session.ID)
-		http.Error(w, `{"error":"refresh token expired"}`, http.StatusUnauthorized)
+		writeError(w, http.StatusUnauthorized, "refresh_token_expired", "refresh token expired")
 		return
 	}
 
 	user, err := h.users.Get(ctx, session.UserID)
 	if err != nil {
-		http.Error(w, `{"error":"user not found"}`, http.StatusUnauthorized)
+		writeError(w, http.StatusUnauthorized, "user_not_found", "user not found")
 		return
 	}
 
 	// Issue new access token.
 	accessToken, err := h.issuer.Issue(user.ID, user.EnterpriseID, user.Email, string(user.Role))
 	if err != nil {
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
 	// Rotate refresh token.
 	newRefreshRaw, newRefreshHash, err := GenerateRefreshToken()
 	if err != nil {
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -444,7 +444,7 @@ func (h *Handler) handleRefresh(w http.ResponseWriter, r *http.Request) {
 		CreatedAt:        now,
 	}
 	if err := h.sessions.Create(ctx, newSession); err != nil {
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 

--- a/internal/auth/handler_email.go
+++ b/internal/auth/handler_email.go
@@ -24,17 +24,17 @@ func (h *Handler) handleSignup(w http.ResponseWriter, r *http.Request) {
 		DisplayName string `json:"display_name"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid request body")
 		return
 	}
 
 	body.Email = strings.TrimSpace(strings.ToLower(body.Email))
 	if body.Email == "" || !strings.Contains(body.Email, "@") {
-		http.Error(w, `{"error":"valid email is required"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "invalid_email", "valid email is required")
 		return
 	}
 	if len(body.Password) < 8 {
-		http.Error(w, `{"error":"password must be at least 8 characters"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "invalid_password", "password must be at least 8 characters")
 		return
 	}
 	if body.DisplayName == "" {
@@ -45,7 +45,7 @@ func (h *Handler) handleSignup(w http.ResponseWriter, r *http.Request) {
 
 	// Check if email is already taken.
 	if _, err := h.users.GetByEmail(ctx, body.Email); err == nil {
-		http.Error(w, `{"error":"email already registered"}`, http.StatusConflict)
+		writeError(w, http.StatusConflict, "email_exists", "email already registered")
 		return
 	}
 
@@ -53,7 +53,7 @@ func (h *Handler) handleSignup(w http.ResponseWriter, r *http.Request) {
 	hash, err := bcrypt.GenerateFromPassword([]byte(body.Password), h.bcryptCost)
 	if err != nil {
 		h.log.Error("failed to hash password", "error", err)
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -82,7 +82,7 @@ func (h *Handler) handleSignup(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.enterprises.Create(ctx, enterprise); err != nil {
 		h.log.Error("failed to create enterprise", "error", err)
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -104,7 +104,7 @@ func (h *Handler) handleSignup(w http.ResponseWriter, r *http.Request) {
 	}
 	if err := h.users.Create(ctx, user); err != nil {
 		h.log.Error("failed to create user", "error", err)
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -144,14 +144,14 @@ func (h *Handler) handleVerifyEmail(w http.ResponseWriter, r *http.Request) {
 		Code  string `json:"code"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid request body")
 		return
 	}
 
 	body.Email = strings.TrimSpace(strings.ToLower(body.Email))
 	body.Code = strings.TrimSpace(body.Code)
 	if body.Email == "" || body.Code == "" {
-		http.Error(w, `{"error":"email and code are required"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "missing_field", "email and code are required")
 		return
 	}
 
@@ -159,24 +159,24 @@ func (h *Handler) handleVerifyEmail(w http.ResponseWriter, r *http.Request) {
 
 	user, err := h.users.GetByEmail(ctx, body.Email)
 	if err != nil {
-		http.Error(w, `{"error":"user not found"}`, http.StatusNotFound)
+		writeError(w, http.StatusNotFound, "not_found", "user not found")
 		return
 	}
 
 	if user.Status != model.UserStatusPendingVerification {
-		http.Error(w, `{"error":"account already verified"}`, http.StatusConflict)
+		writeError(w, http.StatusConflict, "already_verified", "account already verified")
 		return
 	}
 
 	code, err := h.verificationCodes.GetActiveByUserID(ctx, user.ID)
 	if err != nil {
-		http.Error(w, `{"error":"no active verification code — request a new one"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "no_verification_code", "no active verification code — request a new one")
 		return
 	}
 
 	// Compare hashed code.
 	if HashToken(body.Code) != code.CodeHash {
-		http.Error(w, `{"error":"invalid verification code"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "invalid_verification", "invalid verification code")
 		return
 	}
 
@@ -189,7 +189,7 @@ func (h *Handler) handleVerifyEmail(w http.ResponseWriter, r *http.Request) {
 	user.UpdatedAt = now
 	if err := h.users.Update(ctx, user); err != nil {
 		h.log.Error("failed to activate user", "error", err)
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -209,13 +209,13 @@ func (h *Handler) handleEmailLogin(w http.ResponseWriter, r *http.Request) {
 		Password string `json:"password"`
 	}
 	if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
-		http.Error(w, `{"error":"invalid request body"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "invalid_body", "invalid request body")
 		return
 	}
 
 	body.Email = strings.TrimSpace(strings.ToLower(body.Email))
 	if body.Email == "" || body.Password == "" {
-		http.Error(w, `{"error":"email and password are required"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "missing_field", "email and password are required")
 		return
 	}
 
@@ -225,27 +225,27 @@ func (h *Handler) handleEmailLogin(w http.ResponseWriter, r *http.Request) {
 	if err != nil {
 		// Constant-time-ish: still run bcrypt comparison to prevent timing attacks.
 		bcrypt.CompareHashAndPassword([]byte(h.dummyHash), []byte(body.Password))
-		http.Error(w, `{"error":"invalid email or password"}`, http.StatusUnauthorized)
+		writeError(w, http.StatusUnauthorized, "invalid_credentials", "invalid email or password")
 		return
 	}
 
 	if user.PasswordHash == "" {
 		// OAuth-only user — no password set.
-		http.Error(w, `{"error":"this account uses OAuth sign-in"}`, http.StatusBadRequest)
+		writeError(w, http.StatusBadRequest, "oauth_account", "this account uses OAuth sign-in")
 		return
 	}
 
 	if err := bcrypt.CompareHashAndPassword([]byte(user.PasswordHash), []byte(body.Password)); err != nil {
-		http.Error(w, `{"error":"invalid email or password"}`, http.StatusUnauthorized)
+		writeError(w, http.StatusUnauthorized, "invalid_credentials", "invalid email or password")
 		return
 	}
 
 	if user.Status == model.UserStatusPendingVerification {
-		http.Error(w, `{"error":"email not verified — check your inbox"}`, http.StatusForbidden)
+		writeError(w, http.StatusForbidden, "email_unverified", "email not verified — check your inbox")
 		return
 	}
 	if user.Status == model.UserStatusSuspended {
-		http.Error(w, `{"error":"account suspended"}`, http.StatusForbidden)
+		writeError(w, http.StatusForbidden, "account_suspended", "account suspended")
 		return
 	}
 
@@ -258,13 +258,13 @@ func (h *Handler) handleEmailLogin(w http.ResponseWriter, r *http.Request) {
 	// Issue tokens.
 	accessToken, err := h.issuer.Issue(user.ID, user.EnterpriseID, user.Email, string(user.Role))
 	if err != nil {
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
 	refreshRaw, refreshHash, err := GenerateRefreshToken()
 	if err != nil {
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 
@@ -277,7 +277,7 @@ func (h *Handler) handleEmailLogin(w http.ResponseWriter, r *http.Request) {
 		CreatedAt:        now,
 	}
 	if err := h.sessions.Create(ctx, session); err != nil {
-		http.Error(w, `{"error":"internal error"}`, http.StatusInternalServerError)
+		writeError(w, http.StatusInternalServerError, "internal_error", "internal error")
 		return
 	}
 

--- a/internal/clock/clock.go
+++ b/internal/clock/clock.go
@@ -1,0 +1,108 @@
+// Package clock abstracts wall-clock time for testability. Production
+// code uses [System], which delegates to the standard `time` package;
+// tests use [Fake], which advances deterministically.
+//
+// The interface is intentionally narrow — only the operations the
+// retry primitive needs (current time and a timer channel). Adding
+// methods is a deliberate API decision, not an oversight.
+package clock
+
+import (
+	"sync"
+	"time"
+)
+
+// Clock is the minimal time abstraction used by retry/backoff and
+// any other code that needs sleep-with-cancellation semantics.
+type Clock interface {
+	// Now returns the current time.
+	Now() time.Time
+
+	// After returns a channel that fires once after d has elapsed.
+	// Equivalent to time.After but routed through the clock so
+	// fakes can advance deterministically.
+	After(d time.Duration) <-chan time.Time
+}
+
+// System is the production [Clock] backed by the real wall clock.
+type System struct{}
+
+// Now returns time.Now().
+func (System) Now() time.Time { return time.Now() }
+
+// After returns time.After(d).
+func (System) After(d time.Duration) <-chan time.Time { return time.After(d) }
+
+// Fake is a deterministic [Clock] for tests. The current time advances
+// only when [Fake.Advance] is called; pending timers fire when their
+// scheduled time is reached.
+//
+// Fake is safe for concurrent use: callers may call Advance on one
+// goroutine while another waits on a channel returned by After.
+type Fake struct {
+	mu     sync.Mutex
+	now    time.Time
+	timers []*fakeTimer
+}
+
+type fakeTimer struct {
+	at time.Time
+	ch chan time.Time
+}
+
+// NewFake returns a [Fake] starting at the given time. Use the zero
+// value `time.Time{}` to start from the epoch.
+func NewFake(start time.Time) *Fake {
+	return &Fake{now: start}
+}
+
+// Now returns the fake's current time.
+func (f *Fake) Now() time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return f.now
+}
+
+// After returns a channel that fires when [Fake.Advance] has moved
+// the clock past `now+d`. The channel is buffered (size 1) so the
+// fire side never blocks.
+func (f *Fake) After(d time.Duration) <-chan time.Time {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	t := &fakeTimer{
+		at: f.now.Add(d),
+		ch: make(chan time.Time, 1),
+	}
+	if !f.now.Before(t.at) {
+		// Zero-duration timer: fire immediately.
+		t.ch <- f.now
+	} else {
+		f.timers = append(f.timers, t)
+	}
+	return t.ch
+}
+
+// Advance moves the fake forward by d. Any pending timers whose
+// scheduled time falls within [now, now+d] fire on their channels.
+func (f *Fake) Advance(d time.Duration) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.now = f.now.Add(d)
+	remaining := f.timers[:0]
+	for _, t := range f.timers {
+		if !f.now.Before(t.at) {
+			t.ch <- f.now
+			continue
+		}
+		remaining = append(remaining, t)
+	}
+	f.timers = remaining
+}
+
+// Pending reports the number of timers waiting to fire. Useful for
+// tests that want to assert something was scheduled.
+func (f *Fake) Pending() int {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return len(f.timers)
+}

--- a/internal/clock/clock_test.go
+++ b/internal/clock/clock_test.go
@@ -1,0 +1,118 @@
+package clock
+
+import (
+	"testing"
+	"time"
+)
+
+// Clock contract:
+//   - System.Now is monotonic with the wall clock; System.After fires
+//     after the requested duration.
+//   - Fake.Now returns the start time until Advance is called; After
+//     returns a channel that fires when the fake has advanced past
+//     the scheduled time.
+//   - Zero-duration After fires immediately.
+
+func TestSystem_NowAdvances(t *testing.T) {
+	c := System{}
+	t1 := c.Now()
+	time.Sleep(2 * time.Millisecond)
+	t2 := c.Now()
+	if !t2.After(t1) {
+		t.Errorf("System.Now did not advance: t1=%v t2=%v", t1, t2)
+	}
+}
+
+func TestSystem_AfterFires(t *testing.T) {
+	c := System{}
+	select {
+	case <-c.After(5 * time.Millisecond):
+		// fine
+	case <-time.After(time.Second):
+		t.Fatal("System.After did not fire within 1s")
+	}
+}
+
+func TestFake_StartsAtConfiguredTime(t *testing.T) {
+	start := time.Date(2026, 1, 1, 0, 0, 0, 0, time.UTC)
+	f := NewFake(start)
+	if !f.Now().Equal(start) {
+		t.Errorf("Now() = %v, want %v", f.Now(), start)
+	}
+}
+
+func TestFake_AdvanceMovesTime(t *testing.T) {
+	f := NewFake(time.Time{})
+	f.Advance(5 * time.Second)
+	if got := f.Now().Sub(time.Time{}); got != 5*time.Second {
+		t.Errorf("after Advance(5s), elapsed = %v, want 5s", got)
+	}
+}
+
+func TestFake_AfterFiresAfterAdvance(t *testing.T) {
+	f := NewFake(time.Time{})
+	ch := f.After(2 * time.Second)
+	select {
+	case <-ch:
+		t.Fatal("After channel fired before Advance")
+	default:
+	}
+	f.Advance(1 * time.Second)
+	select {
+	case <-ch:
+		t.Fatal("After channel fired before full duration elapsed")
+	default:
+	}
+	f.Advance(1 * time.Second)
+	select {
+	case <-ch:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("After channel did not fire after total duration elapsed")
+	}
+}
+
+func TestFake_AfterZeroDuration_FiresImmediately(t *testing.T) {
+	f := NewFake(time.Time{})
+	ch := f.After(0)
+	select {
+	case <-ch:
+	case <-time.After(100 * time.Millisecond):
+		t.Fatal("zero-duration After did not fire immediately")
+	}
+}
+
+func TestFake_PendingReportsScheduledTimers(t *testing.T) {
+	f := NewFake(time.Time{})
+	if got := f.Pending(); got != 0 {
+		t.Errorf("Pending() = %d before any timers, want 0", got)
+	}
+	_ = f.After(time.Second)
+	_ = f.After(2 * time.Second)
+	if got := f.Pending(); got != 2 {
+		t.Errorf("Pending() = %d, want 2", got)
+	}
+	f.Advance(time.Second + time.Millisecond)
+	if got := f.Pending(); got != 1 {
+		t.Errorf("Pending() = %d after firing one, want 1", got)
+	}
+}
+
+func TestFake_AdvanceFiresMultipleEligibleTimers(t *testing.T) {
+	f := NewFake(time.Time{})
+	c1 := f.After(time.Second)
+	c2 := f.After(2 * time.Second)
+	c3 := f.After(5 * time.Second)
+	f.Advance(3 * time.Second)
+	for _, ch := range []<-chan time.Time{c1, c2} {
+		select {
+		case <-ch:
+		case <-time.After(100 * time.Millisecond):
+			t.Error("eligible timer did not fire after Advance")
+		}
+	}
+	select {
+	case <-c3:
+		t.Error("c3 fired prematurely")
+	default:
+	}
+}

--- a/internal/cstore/manifest.go
+++ b/internal/cstore/manifest.go
@@ -33,6 +33,18 @@ type Manifest struct {
 	Provides ManifestProvides `toml:"provides"`
 }
 
+// IsIdempotent reports whether the runtime should treat this connector
+// as idempotent for retry purposes. Per ADR-0010, idempotency is the
+// default; a connector opts out via `[connector.idempotency] default
+// = "not_idempotent"`. The retry primitive consults this before
+// attempting a retry.
+func (m *Manifest) IsIdempotent() bool {
+	if m == nil || m.Connector.Idempotency == nil {
+		return true
+	}
+	return m.Connector.Idempotency.Default != IdempotencyNotIdempotent
+}
+
 // ManifestConnector is the `[connector]` table — the connector's identity.
 type ManifestConnector struct {
 	// Name is the fully-qualified URI of this connector
@@ -51,7 +63,31 @@ type ManifestConnector struct {
 	// Publisher is the human-readable publisher name shown in the Hub /
 	// install consent UI. Not load-bearing; provenance lives in the FQN.
 	Publisher string `toml:"publisher"`
+
+	// Idempotency is the optional `[connector.idempotency]` block per
+	// ADR-0010. Absent → idempotent default; present → must declare
+	// `default = "idempotent" | "not_idempotent"`. The retry primitive
+	// reads this via [Manifest.IsIdempotent] to decide whether to
+	// retry a failed call.
+	Idempotency *ManifestIdempotency `toml:"idempotency"`
 }
+
+// ManifestIdempotency is `[connector.idempotency]` — the connector's
+// declaration of whether a retry could double-send a side effect.
+type ManifestIdempotency struct {
+	// Default is one of [IdempotencyIdempotent] or
+	// [IdempotencyNotIdempotent]. Empty value is rejected at validation
+	// time; absent block is treated as idempotent.
+	Default string `toml:"default"`
+}
+
+// Idempotency declarations recognised by the runtime. Per ADR-0010,
+// the closed set is just two values; an empty `default` is invalid
+// (authors must opt in explicitly to opt out).
+const (
+	IdempotencyIdempotent    = "idempotent"
+	IdempotencyNotIdempotent = "not_idempotent"
+)
 
 // ManifestCapabilities holds the sub-tables for each primitive capability
 // type the runtime knows about (per ADR-0002).
@@ -135,6 +171,19 @@ func ValidateManifest(m *Manifest, file string) error {
 			if !strings.Contains(h, ":") {
 				return newValidationErr(file, "[capabilities.network].hosts[%d] %q must be host:port", i, h)
 			}
+		}
+	}
+	if m.Connector.Idempotency != nil {
+		switch m.Connector.Idempotency.Default {
+		case IdempotencyIdempotent, IdempotencyNotIdempotent:
+		case "":
+			return newValidationErr(file,
+				"[connector.idempotency].default is required when the table is present (use %q or %q)",
+				IdempotencyIdempotent, IdempotencyNotIdempotent)
+		default:
+			return newValidationErr(file,
+				"[connector.idempotency].default %q must be %q or %q",
+				m.Connector.Idempotency.Default, IdempotencyIdempotent, IdempotencyNotIdempotent)
 		}
 	}
 	return nil

--- a/internal/cstore/manifest_test.go
+++ b/internal/cstore/manifest_test.go
@@ -126,3 +126,90 @@ func TestValidateManifest_NilManifest(t *testing.T) {
 		t.Fatal("ValidateManifest(nil) succeeded; want error")
 	}
 }
+
+// Idempotency declaration (ADR-0010).
+
+func TestIsIdempotent_DefaultsToTrue(t *testing.T) {
+	m, err := ParseManifest("m.toml", []byte(validManifestTOML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !m.IsIdempotent() {
+		t.Error("default (no idempotency block) should be idempotent")
+	}
+}
+
+func TestIsIdempotent_RespectsExplicitIdempotent(t *testing.T) {
+	m := &Manifest{Connector: ManifestConnector{
+		Idempotency: &ManifestIdempotency{Default: IdempotencyIdempotent},
+	}}
+	if !m.IsIdempotent() {
+		t.Error("explicit idempotent value should be idempotent")
+	}
+}
+
+func TestIsIdempotent_NotIdempotentOptOut(t *testing.T) {
+	m := &Manifest{Connector: ManifestConnector{
+		Idempotency: &ManifestIdempotency{Default: IdempotencyNotIdempotent},
+	}}
+	if m.IsIdempotent() {
+		t.Error("not_idempotent declaration should opt out of retry")
+	}
+}
+
+func TestIsIdempotent_NilManifestSafe(t *testing.T) {
+	var m *Manifest
+	if !m.IsIdempotent() {
+		t.Error("nil manifest should default to idempotent (safe)")
+	}
+}
+
+func TestValidateManifest_RejectsBadIdempotencyValues(t *testing.T) {
+	cases := []struct {
+		name string
+		val  string
+		want string
+	}{
+		{"empty", "", "is required when the table is present"},
+		{"unknown", "maybe", "must be"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m, _ := ParseManifest("m.toml", []byte(validManifestTOML))
+			m.Connector.Idempotency = &ManifestIdempotency{Default: tc.val}
+			err := ValidateManifest(m, "m.toml")
+			if err == nil {
+				t.Fatalf("accepted bad value %q", tc.val)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q; want substring %q", err.Error(), tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateManifest_AcceptsValidIdempotencyValues(t *testing.T) {
+	for _, v := range []string{IdempotencyIdempotent, IdempotencyNotIdempotent} {
+		t.Run(v, func(t *testing.T) {
+			m, _ := ParseManifest("m.toml", []byte(validManifestTOML))
+			m.Connector.Idempotency = &ManifestIdempotency{Default: v}
+			if err := ValidateManifest(m, "m.toml"); err != nil {
+				t.Errorf("ValidateManifest(%q) err = %v", v, err)
+			}
+		})
+	}
+}
+
+func TestParseManifest_AcceptsIdempotencyTOML(t *testing.T) {
+	body := validManifestTOML + "\n[connector.idempotency]\ndefault = \"not_idempotent\"\n"
+	m, err := ParseManifest("m.toml", []byte(body))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.Connector.Idempotency == nil {
+		t.Fatal("Idempotency block not parsed")
+	}
+	if m.Connector.Idempotency.Default != IdempotencyNotIdempotent {
+		t.Errorf("Default = %q", m.Connector.Idempotency.Default)
+	}
+}

--- a/internal/failure/api_drift_test.go
+++ b/internal/failure/api_drift_test.go
@@ -1,0 +1,71 @@
+package failure_test
+
+import (
+	"sort"
+	"testing"
+
+	api "github.com/ALRubinger/aileron/internal/api/gen"
+	"github.com/ALRubinger/aileron/internal/failure"
+)
+
+// The closed taxonomy is enforced in two places: this package's
+// FailureClass / Boundary consts, and the generated OpenAPI enums.
+// They must agree — drift between them is the source of bugs the
+// type system can't catch (a server emitting a class no client
+// schema knows about, or vice versa).
+//
+// These tests fail loudly if anyone amends one set without the other.
+
+func TestClassEnumMatchesAPI(t *testing.T) {
+	wantSlice := failure.AllClasses()
+	want := make([]string, 0, len(wantSlice))
+	for _, c := range wantSlice {
+		want = append(want, string(c))
+	}
+	got := []string{
+		string(api.CapabilityDenied),
+		string(api.BindingRequired),
+		string(api.BindingFailed),
+		string(api.ResourceLimitExceeded),
+		string(api.ConnectorRuntimeError),
+		string(api.NetworkError),
+		string(api.ExternalApiError),
+		string(api.HashMismatch),
+		string(api.SignatureFailure),
+	}
+	sort.Strings(want)
+	sort.Strings(got)
+	if len(want) != len(got) {
+		t.Fatalf("class count drift: pkg=%d api=%d", len(want), len(got))
+	}
+	for i := range want {
+		if want[i] != got[i] {
+			t.Errorf("class drift: pkg=%q api=%q", want[i], got[i])
+		}
+	}
+}
+
+func TestBoundaryEnumMatchesAPI(t *testing.T) {
+	wantSlice := failure.AllBoundaries()
+	want := make([]string, 0, len(wantSlice))
+	for _, b := range wantSlice {
+		want = append(want, string(b))
+	}
+	got := []string{
+		string(api.FailureBoundarySandbox),
+		string(api.FailureBoundaryConnectorManifest),
+		string(api.FailureBoundaryAction),
+		string(api.FailureBoundaryRuntime),
+		string(api.FailureBoundaryExternal),
+	}
+	sort.Strings(want)
+	sort.Strings(got)
+	if len(want) != len(got) {
+		t.Fatalf("boundary count drift: pkg=%d api=%d", len(want), len(got))
+	}
+	for i := range want {
+		if want[i] != got[i] {
+			t.Errorf("boundary drift: pkg=%q api=%q", want[i], got[i])
+		}
+	}
+}

--- a/internal/failure/constructors.go
+++ b/internal/failure/constructors.go
@@ -1,0 +1,139 @@
+package failure
+
+// Per-class constructors. Each one hard-codes the class, default
+// boundary, and default retriable value per ADR-0010's taxonomy.
+// Options override boundary or attach details/cause.
+
+// CapabilityDeniedAt builds a CapabilityDenied failure attributed to
+// the given boundary (sandbox, connector_manifest, or action). The
+// caller must pass one of those three boundaries — Runtime/External
+// don't make sense for capability denial.
+func CapabilityDeniedAt(b Boundary, message string, opts ...Option) *Failure {
+	f := &Failure{
+		class:     CapabilityDenied,
+		boundary:  b,
+		message:   message,
+		retriable: false,
+	}
+	applyOpts(f, opts)
+	return f
+}
+
+// BindingRequiredFailure builds a BindingRequired failure. The user
+// needs to bind a credential and retry; not retriable until they do.
+func BindingRequiredFailure(message string, opts ...Option) *Failure {
+	f := &Failure{
+		class:     BindingRequired,
+		boundary:  Runtime,
+		message:   message,
+		retriable: false,
+	}
+	applyOpts(f, opts)
+	return f
+}
+
+// BindingFailedFailure builds a BindingFailed failure. The retriable
+// flag is caller-determined — token refresh might succeed, while a
+// revoked key won't.
+func BindingFailedFailure(message string, retriable bool, opts ...Option) *Failure {
+	f := &Failure{
+		class:     BindingFailed,
+		boundary:  Runtime,
+		message:   message,
+		retriable: retriable,
+	}
+	applyOpts(f, opts)
+	return f
+}
+
+// ResourceLimitFailure builds a ResourceLimitExceeded failure. The
+// connector instance hit a memory/wall-time/fuel limit; not retriable
+// because the same call would hit the same limit.
+func ResourceLimitFailure(message string, opts ...Option) *Failure {
+	f := &Failure{
+		class:     ResourceLimitExceeded,
+		boundary:  Sandbox,
+		message:   message,
+		retriable: false,
+	}
+	applyOpts(f, opts)
+	return f
+}
+
+// ConnectorRuntime builds a ConnectorRuntimeError failure. Retriable
+// is caller-determined — a panic might be transient, a contract
+// violation is not.
+func ConnectorRuntime(message string, retriable bool, opts ...Option) *Failure {
+	f := &Failure{
+		class:     ConnectorRuntimeError,
+		boundary:  Sandbox,
+		message:   message,
+		retriable: retriable,
+	}
+	applyOpts(f, opts)
+	return f
+}
+
+// Network builds a NetworkError failure for outbound network calls
+// that failed before reaching a server. Always retriable.
+func Network(message string, opts ...Option) *Failure {
+	f := &Failure{
+		class:     NetworkError,
+		boundary:  External,
+		message:   message,
+		retriable: true,
+	}
+	applyOpts(f, opts)
+	return f
+}
+
+// Upstream builds an ExternalAPIError failure for upstream HTTP
+// responses. Status is recorded in details.status. Retriable when
+// status is 429 or 5xx; non-retriable otherwise.
+func Upstream(status int, message string, opts ...Option) *Failure {
+	f := &Failure{
+		class:     ExternalAPIError,
+		boundary:  External,
+		message:   message,
+		retriable: isHTTPRetriable(status),
+		details:   map[string]any{"status": status},
+	}
+	applyOpts(f, opts)
+	return f
+}
+
+// HashMismatchFailure builds a HashMismatch failure. Bytes on disk
+// don't match the declared hash; never retriable.
+func HashMismatchFailure(message string, opts ...Option) *Failure {
+	f := &Failure{
+		class:     HashMismatch,
+		boundary:  Runtime,
+		message:   message,
+		retriable: false,
+	}
+	applyOpts(f, opts)
+	return f
+}
+
+// SignatureFailureFailure builds a SignatureFailure failure. A
+// binary's signature didn't verify; never retriable.
+func SignatureFailureFailure(message string, opts ...Option) *Failure {
+	f := &Failure{
+		class:     SignatureFailure,
+		boundary:  Runtime,
+		message:   message,
+		retriable: false,
+	}
+	applyOpts(f, opts)
+	return f
+}
+
+// isHTTPRetriable reports whether an HTTP status code from an
+// upstream service should be retried per ADR-0010's policy: 429 and
+// any 5xx are retriable; everything else is not.
+func isHTTPRetriable(status int) bool {
+	if status == 429 {
+		return true
+	}
+	return status >= 500 && status <= 599
+}

--- a/internal/failure/envelope.go
+++ b/internal/failure/envelope.go
@@ -1,0 +1,126 @@
+package failure
+
+import (
+	"encoding/json"
+	"fmt"
+	"net/http"
+)
+
+// Envelope is the wire shape of the failure response described by
+// ADR-0010. The JSON serialization matches the OpenAPI
+// `FailureEnvelope` schema; tests in this package assert no drift.
+type Envelope struct {
+	Error EnvelopeError `json:"error"`
+}
+
+// EnvelopeError is the inner object of [Envelope].
+type EnvelopeError struct {
+	Class     FailureClass   `json:"class"`
+	Message   string         `json:"message"`
+	Retriable bool           `json:"retriable"`
+	Boundary  Boundary       `json:"boundary"`
+	AuditID   string         `json:"audit_id,omitempty"`
+	Details   map[string]any `json:"details,omitempty"`
+}
+
+// ToEnvelope renders the failure as the wire-format envelope.
+func ToEnvelope(f *Failure) Envelope {
+	return Envelope{
+		Error: EnvelopeError{
+			Class:     f.class,
+			Message:   f.message,
+			Retriable: f.retriable,
+			Boundary:  f.boundary,
+			AuditID:   f.auditID,
+			Details:   f.details,
+		},
+	}
+}
+
+// HTTPStatus returns the HTTP status code most appropriate for the
+// failure's class, per ADR-0010's mapping. Boundaries don't affect
+// the status; only class does.
+func HTTPStatus(f *Failure) int {
+	switch f.class {
+	case CapabilityDenied:
+		return http.StatusForbidden
+	case BindingRequired, BindingFailed:
+		// Both are precondition failures from the runtime's view: the
+		// request is well-formed but the credential isn't usable.
+		return http.StatusPreconditionFailed
+	case ResourceLimitExceeded:
+		return http.StatusInsufficientStorage
+	case ConnectorRuntimeError:
+		return http.StatusInternalServerError
+	case NetworkError, ExternalAPIError:
+		return http.StatusBadGateway
+	case HashMismatch, SignatureFailure:
+		// Integrity violations refuse to serve.
+		return http.StatusUnprocessableEntity
+	}
+	return http.StatusInternalServerError
+}
+
+// WriteHTTP serialises the failure as JSON and writes it to w with
+// the per-class HTTP status. Sets Content-Type to application/json.
+func WriteHTTP(w http.ResponseWriter, f *Failure) {
+	body, _ := json.Marshal(ToEnvelope(f))
+	w.Header().Set("Content-Type", "application/json")
+	w.WriteHeader(HTTPStatus(f))
+	_, _ = w.Write(body)
+}
+
+// ToOpenAIToolMessage builds an OpenAI Chat Completions `tool` role
+// message that surfaces a failure to the agent's LLM as a tool
+// result. Used by the gateway's intercept layer when an Aileron tool
+// call fails — the LLM sees the failure as a normal tool result and
+// can decide what to do.
+func ToOpenAIToolMessage(f *Failure, callID, toolName string) map[string]any {
+	return map[string]any{
+		"role":         "tool",
+		"tool_call_id": callID,
+		"name":         toolName,
+		"content":      string(mustJSON(toolResultPayload(f))),
+	}
+}
+
+// ToAnthropicToolResult builds an Anthropic `tool_result` content
+// block carrying a failure. Anthropic uses the `is_error` flag to
+// mark error results explicitly; ADR-0010's envelope is encoded into
+// the content text.
+func ToAnthropicToolResult(f *Failure, useID string) map[string]any {
+	block := map[string]any{
+		"type":        "tool_result",
+		"tool_use_id": useID,
+		"content":     string(mustJSON(toolResultPayload(f))),
+	}
+	if f.class != "" { // any structured failure is an error to the LLM
+		block["is_error"] = true
+	}
+	return block
+}
+
+// toolResultPayload is the JSON body the LLM sees as the tool's
+// content. It mirrors the envelope but without the outer `error`
+// wrapper, which is HTTP-specific.
+func toolResultPayload(f *Failure) any {
+	return EnvelopeError{
+		Class:     f.class,
+		Message:   f.message,
+		Retriable: f.retriable,
+		Boundary:  f.boundary,
+		AuditID:   f.auditID,
+		Details:   f.details,
+	}
+}
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		// Failures are constructed in-package; marshal can only fail
+		// if a Detail value is non-marshalable. We surface that as
+		// best-effort prose rather than panicking.
+		return []byte(fmt.Sprintf(`{"class":"connector_runtime_error","message":"failure marshaling failed: %s"}`, err.Error()))
+	}
+	return b
+}

--- a/internal/failure/failure.go
+++ b/internal/failure/failure.go
@@ -1,0 +1,213 @@
+// Package failure implements the structured failure envelope ratified
+// by [ADR-0010]: a closed taxonomy of failure classes, a closed set of
+// boundaries, and a single [Failure] type that carries enough context
+// for the agent (and the audit log) to reason about what went wrong.
+//
+// The envelope schema is:
+//
+//	{
+//	  "error": {
+//	    "class":     "<failure-class>",
+//	    "message":   "<user-facing description>",
+//	    "retriable": true|false,
+//	    "boundary":  "<which-layer>",
+//	    "audit_id":  "audit-<id>",
+//	    "details":   { ...class-specific... }
+//	  }
+//	}
+//
+// The closed taxonomy is enforced through the type system: Class and
+// Boundary are unexported on [Failure] and only the package's
+// constructors can produce a valid value. Code outside this package
+// cannot synthesize a Failure with an arbitrary class string.
+//
+// [ADR-0010]: https://docs.withaileron.ai/adr/0010-failure-handling
+package failure
+
+import "fmt"
+
+// FailureClass is the closed taxonomy of failure classes. Adding a
+// class requires an ADR amendment per ADR-0010.
+type FailureClass string
+
+const (
+	// CapabilityDenied — a capability check refused the operation.
+	// Defense-in-depth check at sandbox, connector_manifest, or
+	// action boundaries.
+	CapabilityDenied FailureClass = "capability_denied"
+
+	// BindingRequired — no credential is bound for a required
+	// capability. The user must bind one and retry.
+	BindingRequired FailureClass = "binding_required"
+
+	// BindingFailed — an existing binding refused: token expired,
+	// key revoked, scope changed.
+	BindingFailed FailureClass = "binding_failed"
+
+	// ResourceLimitExceeded — the connector instance hit a resource
+	// limit (memory, wall time, fuel).
+	ResourceLimitExceeded FailureClass = "resource_limit_exceeded"
+
+	// ConnectorRuntimeError — the connector code itself failed:
+	// panicked, returned an unexpected shape, threw an exception.
+	ConnectorRuntimeError FailureClass = "connector_runtime_error"
+
+	// NetworkError — outbound network call failed before reaching
+	// a server (DNS, connection refused, TLS error).
+	NetworkError FailureClass = "network_error"
+
+	// ExternalAPIError — the upstream service returned an error
+	// response. Retriable for 5xx and 429; not retriable for most
+	// 4xx. Status code lives in details.status.
+	ExternalAPIError FailureClass = "external_api_error"
+
+	// HashMismatch — a connector or action's on-disk bytes don't
+	// match the declared hash.
+	HashMismatch FailureClass = "hash_mismatch"
+
+	// SignatureFailure — a binary's signature doesn't verify.
+	SignatureFailure FailureClass = "signature_failure"
+)
+
+// Boundary identifies which layer produced an error.
+type Boundary string
+
+const (
+	// Sandbox is the connector sandbox (WASM runtime, capability
+	// gates, resource limits).
+	Sandbox Boundary = "sandbox"
+
+	// ConnectorManifest is the connector's manifest-level capability
+	// check: hosts, scope, runtime imports.
+	ConnectorManifest Boundary = "connector_manifest"
+
+	// Action is the action's declared capability subset check —
+	// even when the connector permits the operation, the action's
+	// declared subset must include it.
+	Action Boundary = "action"
+
+	// Runtime is the runtime layer outside any connector: hash
+	// verification, signature verification, manifest parse,
+	// orchestration.
+	Runtime Boundary = "runtime"
+
+	// External is the upstream service the connector talked to.
+	External Boundary = "external"
+)
+
+// AllClasses returns every valid [FailureClass] in declaration order.
+// Used by tests and for emitting documentation that enumerates the
+// taxonomy.
+func AllClasses() []FailureClass {
+	return []FailureClass{
+		CapabilityDenied,
+		BindingRequired,
+		BindingFailed,
+		ResourceLimitExceeded,
+		ConnectorRuntimeError,
+		NetworkError,
+		ExternalAPIError,
+		HashMismatch,
+		SignatureFailure,
+	}
+}
+
+// AllBoundaries returns every valid [Boundary] in declaration order.
+func AllBoundaries() []Boundary {
+	return []Boundary{Sandbox, ConnectorManifest, Action, Runtime, External}
+}
+
+// Failure is the structured error returned across boundaries that
+// follow ADR-0010's envelope contract.
+//
+// Class and boundary are unexported so the only path to a valid
+// Failure is through this package's constructors (New, Network,
+// External, CapabilityDenied, etc.). This is what makes the closed
+// taxonomy actually closed — handlers cannot synthesize an arbitrary
+// class string.
+type Failure struct {
+	class     FailureClass
+	boundary  Boundary
+	message   string
+	retriable bool
+	auditID   string
+	details   map[string]any
+	cause     error
+}
+
+// Class returns the canonical failure class.
+func (f *Failure) Class() FailureClass { return f.class }
+
+// Boundary returns the layer that produced the failure.
+func (f *Failure) Boundary() Boundary { return f.boundary }
+
+// Message is the user-facing prose. Safe to show to end users.
+func (f *Failure) Message() string { return f.message }
+
+// Retriable reports whether the failure is safe to retry.
+func (f *Failure) Retriable() bool { return f.retriable }
+
+// AuditID returns the audit-log entry identifier that records this
+// failure. Empty until Recorder.RecordFailure stamps it.
+func (f *Failure) AuditID() string { return f.auditID }
+
+// SetAuditID stamps the audit-log entry identifier onto the failure.
+// Called by the audit recorder right after appending the event.
+func (f *Failure) SetAuditID(id string) { f.auditID = id }
+
+// Details returns class-specific additional context. The map is
+// owned by the Failure; callers must not mutate it.
+func (f *Failure) Details() map[string]any { return f.details }
+
+// SetDetail attaches or overwrites a single detail key. Used by the
+// retry primitive to add `retried: N` after exhausting retries.
+func (f *Failure) SetDetail(key string, value any) {
+	if f.details == nil {
+		f.details = map[string]any{}
+	}
+	f.details[key] = value
+}
+
+// Error implements the error interface.
+func (f *Failure) Error() string {
+	if f.cause != nil {
+		return fmt.Sprintf("%s: %s: %s", f.class, f.message, f.cause.Error())
+	}
+	return fmt.Sprintf("%s: %s", f.class, f.message)
+}
+
+// Unwrap returns the wrapped cause, if any.
+func (f *Failure) Unwrap() error { return f.cause }
+
+// Option is a constructor option that customises a Failure beyond
+// what the per-class constructor sets by default.
+type Option func(*Failure)
+
+// WithDetails attaches additional detail fields to the Failure.
+// Provided pairs replace any existing keys with the same name.
+func WithDetails(d map[string]any) Option {
+	return func(f *Failure) {
+		if f.details == nil {
+			f.details = make(map[string]any, len(d))
+		}
+		for k, v := range d {
+			f.details[k] = v
+		}
+	}
+}
+
+// WithCause wraps an underlying Go error so callers can use
+// errors.Is / errors.As across the boundary.
+func WithCause(err error) Option { return func(f *Failure) { f.cause = err } }
+
+// WithBoundary overrides the default boundary for the class. Used
+// for `capability_denied` which can fire at sandbox, connector_manifest,
+// or action layers depending on which check tripped.
+func WithBoundary(b Boundary) Option { return func(f *Failure) { f.boundary = b } }
+
+// applyOpts mutates f with each option in order.
+func applyOpts(f *Failure, opts []Option) {
+	for _, opt := range opts {
+		opt(f)
+	}
+}

--- a/internal/failure/failure_test.go
+++ b/internal/failure/failure_test.go
@@ -1,0 +1,341 @@
+package failure
+
+import (
+	"encoding/json"
+	"errors"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+// Closed taxonomy:
+//   - AllClasses() / AllBoundaries() enumerate every valid value.
+//   - Each value is unique, non-empty, and lowercase-snake-case.
+//   - Constructors set the canonical class and boundary; callers
+//     can override boundary only via WithBoundary.
+
+func TestAllClasses_Enumerates9(t *testing.T) {
+	got := AllClasses()
+	if len(got) != 9 {
+		t.Fatalf("AllClasses count = %d, want 9", len(got))
+	}
+	seen := map[FailureClass]bool{}
+	for _, c := range got {
+		if c == "" {
+			t.Errorf("empty class in AllClasses")
+		}
+		if seen[c] {
+			t.Errorf("duplicate class %q", c)
+		}
+		seen[c] = true
+	}
+}
+
+func TestAllBoundaries_Enumerates5(t *testing.T) {
+	got := AllBoundaries()
+	if len(got) != 5 {
+		t.Fatalf("AllBoundaries count = %d, want 5", len(got))
+	}
+	seen := map[Boundary]bool{}
+	for _, b := range got {
+		if b == "" {
+			t.Errorf("empty boundary in AllBoundaries")
+		}
+		if seen[b] {
+			t.Errorf("duplicate boundary %q", b)
+		}
+		seen[b] = true
+	}
+}
+
+// Constructors set canonical class and retriable defaults.
+
+func TestNetwork_RetriableTrue(t *testing.T) {
+	f := Network("dial tcp: connection refused")
+	if f.Class() != NetworkError {
+		t.Errorf("class = %q, want network_error", f.Class())
+	}
+	if !f.Retriable() {
+		t.Error("Network() must be retriable")
+	}
+	if f.Boundary() != External {
+		t.Errorf("boundary = %q, want external", f.Boundary())
+	}
+}
+
+func TestExternal_5xxRetriable(t *testing.T) {
+	for _, s := range []int{500, 502, 503, 599} {
+		f := Upstream(s, "upstream error")
+		if !f.Retriable() {
+			t.Errorf("Upstream(%d) not retriable", s)
+		}
+		if f.Details()["status"] != s {
+			t.Errorf("Upstream(%d).Details[status] = %v", s, f.Details()["status"])
+		}
+	}
+}
+
+func TestExternal_429Retriable(t *testing.T) {
+	if !Upstream(429, "rate limited").Retriable() {
+		t.Error("Upstream(429) must be retriable")
+	}
+}
+
+func TestExternal_4xxNotRetriable(t *testing.T) {
+	for _, s := range []int{400, 401, 403, 404, 409, 422} {
+		if Upstream(s, "client error").Retriable() {
+			t.Errorf("Upstream(%d) must NOT be retriable", s)
+		}
+	}
+}
+
+func TestCapabilityDenied_BoundaryRequired(t *testing.T) {
+	for _, b := range []Boundary{Sandbox, ConnectorManifest, Action} {
+		f := CapabilityDeniedAt(b, "denied")
+		if f.Boundary() != b {
+			t.Errorf("CapabilityDeniedAt(%q) boundary = %q", b, f.Boundary())
+		}
+		if f.Retriable() {
+			t.Error("CapabilityDenied must not be retriable")
+		}
+	}
+}
+
+func TestBindingRequired_NotRetriable(t *testing.T) {
+	f := BindingRequiredFailure("bind oauth2/slack")
+	if f.Retriable() {
+		t.Error("BindingRequired must not be retriable until bound")
+	}
+}
+
+func TestBindingFailed_RetriableCallerChosen(t *testing.T) {
+	if !BindingFailedFailure("token refresh", true).Retriable() {
+		t.Error("BindingFailed retriable=true did not stick")
+	}
+	if BindingFailedFailure("revoked", false).Retriable() {
+		t.Error("BindingFailed retriable=false did not stick")
+	}
+}
+
+func TestHashMismatch_NotRetriable(t *testing.T) {
+	if HashMismatchFailure("sha mismatch").Retriable() {
+		t.Error("HashMismatch must not be retriable")
+	}
+}
+
+func TestSignatureFailure_NotRetriable(t *testing.T) {
+	if SignatureFailureFailure("bad sig").Retriable() {
+		t.Error("SignatureFailure must not be retriable")
+	}
+}
+
+func TestResourceLimit_NotRetriable(t *testing.T) {
+	f := ResourceLimitFailure("oom")
+	if f.Retriable() {
+		t.Error("ResourceLimitExceeded must not be retriable")
+	}
+	if f.Boundary() != Sandbox {
+		t.Errorf("boundary = %q, want sandbox", f.Boundary())
+	}
+}
+
+func TestConnectorRuntime_RetriableCallerChosen(t *testing.T) {
+	if ConnectorRuntime("panic", true).Retriable() != true {
+		t.Error("ConnectorRuntime retriable=true did not stick")
+	}
+	if ConnectorRuntime("contract", false).Retriable() {
+		t.Error("ConnectorRuntime retriable=false did not stick")
+	}
+}
+
+// Options.
+
+func TestWithDetails_AttachesAndOverwrites(t *testing.T) {
+	f := Network("x", WithDetails(map[string]any{"host": "api.example", "attempt": 1}))
+	if f.Details()["host"] != "api.example" {
+		t.Error("WithDetails didn't attach host")
+	}
+	if f.Details()["attempt"] != 1 {
+		t.Error("WithDetails didn't attach attempt")
+	}
+}
+
+func TestWithDetails_MergesWithExternalDefaults(t *testing.T) {
+	f := Upstream(503, "x", WithDetails(map[string]any{"retry_after_ms": 500}))
+	if f.Details()["status"] != 503 {
+		t.Error("External default detail status lost")
+	}
+	if f.Details()["retry_after_ms"] != 500 {
+		t.Error("WithDetails didn't merge")
+	}
+}
+
+func TestWithCause_Wraps(t *testing.T) {
+	cause := errors.New("dial: timeout")
+	f := Network("network failure", WithCause(cause))
+	if !errors.Is(f, cause) {
+		t.Errorf("errors.Is(f, cause) = false, want true")
+	}
+	if f.Unwrap() != cause {
+		t.Error("Unwrap() != cause")
+	}
+}
+
+func TestWithBoundary_OverridesDefault(t *testing.T) {
+	f := CapabilityDeniedAt(Sandbox, "x", WithBoundary(Action))
+	if f.Boundary() != Action {
+		t.Errorf("boundary = %q, want action (override)", f.Boundary())
+	}
+}
+
+// Error/Unwrap interface.
+
+func TestError_FormatsClassAndMessage(t *testing.T) {
+	f := Network("dial timeout")
+	got := f.Error()
+	if got != "network_error: dial timeout" {
+		t.Errorf("Error() = %q", got)
+	}
+}
+
+func TestError_FormatsCauseWhenPresent(t *testing.T) {
+	f := Network("dial timeout", WithCause(errors.New("broken pipe")))
+	got := f.Error()
+	if got != "network_error: dial timeout: broken pipe" {
+		t.Errorf("Error() = %q", got)
+	}
+}
+
+// SetAuditID, SetDetail mutators.
+
+func TestSetAuditID_Persists(t *testing.T) {
+	f := Network("x")
+	f.SetAuditID("audit-abc")
+	if f.AuditID() != "audit-abc" {
+		t.Errorf("AuditID = %q", f.AuditID())
+	}
+}
+
+func TestSetDetail_AttachesAndOverwrites(t *testing.T) {
+	f := Network("x")
+	f.SetDetail("retried", 3)
+	if f.Details()["retried"] != 3 {
+		t.Errorf("Details[retried] = %v", f.Details()["retried"])
+	}
+	f.SetDetail("retried", 5)
+	if f.Details()["retried"] != 5 {
+		t.Error("SetDetail did not overwrite")
+	}
+}
+
+// Envelope and HTTP.
+
+func TestToEnvelope_RoundTripsToJSON(t *testing.T) {
+	f := Upstream(503, "Slack 503", WithDetails(map[string]any{"host": "slack.com"}))
+	f.SetAuditID("audit-x")
+	body, err := json.Marshal(ToEnvelope(f))
+	if err != nil {
+		t.Fatalf("marshal: %v", err)
+	}
+	var got map[string]any
+	if err := json.Unmarshal(body, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	inner, _ := got["error"].(map[string]any)
+	if inner["class"] != "external_api_error" {
+		t.Errorf("class = %v", inner["class"])
+	}
+	if inner["retriable"] != true {
+		t.Errorf("retriable = %v", inner["retriable"])
+	}
+	if inner["audit_id"] != "audit-x" {
+		t.Errorf("audit_id = %v", inner["audit_id"])
+	}
+	d, _ := inner["details"].(map[string]any)
+	if d["status"].(float64) != 503 {
+		t.Errorf("details.status = %v", d["status"])
+	}
+}
+
+func TestHTTPStatus_PerClass(t *testing.T) {
+	cases := []struct {
+		f    *Failure
+		want int
+	}{
+		{CapabilityDeniedAt(Action, "x"), http.StatusForbidden},
+		{BindingRequiredFailure("x"), http.StatusPreconditionFailed},
+		{BindingFailedFailure("x", false), http.StatusPreconditionFailed},
+		{ResourceLimitFailure("x"), http.StatusInsufficientStorage},
+		{ConnectorRuntime("x", false), http.StatusInternalServerError},
+		{Network("x"), http.StatusBadGateway},
+		{Upstream(500, "x"), http.StatusBadGateway},
+		{HashMismatchFailure("x"), http.StatusUnprocessableEntity},
+		{SignatureFailureFailure("x"), http.StatusUnprocessableEntity},
+	}
+	for _, tc := range cases {
+		got := HTTPStatus(tc.f)
+		if got != tc.want {
+			t.Errorf("HTTPStatus(%s) = %d, want %d", tc.f.Class(), got, tc.want)
+		}
+	}
+}
+
+func TestWriteHTTP_WritesEnvelope(t *testing.T) {
+	w := httptest.NewRecorder()
+	WriteHTTP(w, Upstream(503, "upstream"))
+	if w.Code != http.StatusBadGateway {
+		t.Errorf("status = %d, want 502", w.Code)
+	}
+	if w.Header().Get("Content-Type") != "application/json" {
+		t.Errorf("Content-Type = %q", w.Header().Get("Content-Type"))
+	}
+	var got map[string]any
+	if err := json.Unmarshal(w.Body.Bytes(), &got); err != nil {
+		t.Fatalf("body not JSON: %v", err)
+	}
+	inner, _ := got["error"].(map[string]any)
+	if inner["class"] != "external_api_error" {
+		t.Errorf("class = %v", inner["class"])
+	}
+}
+
+// Tool-result mappers.
+
+func TestToOpenAIToolMessage_Shape(t *testing.T) {
+	f := Upstream(503, "upstream busy")
+	msg := ToOpenAIToolMessage(f, "call_1", "ship_update")
+	if msg["role"] != "tool" {
+		t.Errorf("role = %v", msg["role"])
+	}
+	if msg["tool_call_id"] != "call_1" {
+		t.Errorf("tool_call_id = %v", msg["tool_call_id"])
+	}
+	if msg["name"] != "ship_update" {
+		t.Errorf("name = %v", msg["name"])
+	}
+	content, _ := msg["content"].(string)
+	if content == "" {
+		t.Error("content empty")
+	}
+	var payload map[string]any
+	if err := json.Unmarshal([]byte(content), &payload); err != nil {
+		t.Fatalf("content not JSON: %v", err)
+	}
+	if payload["class"] != "external_api_error" {
+		t.Errorf("payload.class = %v", payload["class"])
+	}
+}
+
+func TestToAnthropicToolResult_SetsIsError(t *testing.T) {
+	f := Upstream(503, "upstream busy")
+	block := ToAnthropicToolResult(f, "tu_1")
+	if block["type"] != "tool_result" {
+		t.Errorf("type = %v", block["type"])
+	}
+	if block["tool_use_id"] != "tu_1" {
+		t.Errorf("tool_use_id = %v", block["tool_use_id"])
+	}
+	if block["is_error"] != true {
+		t.Errorf("is_error = %v, want true", block["is_error"])
+	}
+}

--- a/internal/intercept/anthropic.go
+++ b/internal/intercept/anthropic.go
@@ -11,6 +11,9 @@ import (
 	"strings"
 
 	"github.com/ALRubinger/aileron/internal/augment"
+	"github.com/ALRubinger/aileron/internal/failure"
+	"github.com/ALRubinger/aileron/internal/model"
+	"github.com/ALRubinger/aileron/internal/retry"
 )
 
 // HandleAnthropic mirrors HandleOpenAI for the Anthropic Messages
@@ -51,11 +54,12 @@ func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
 
 	ourNames := nameSet(aug.OurNames)
 
+	gatewayActor := model.ActorRef{ID: "aileron-gateway", Type: model.ActorTypeService}
+
 	for round := 0; round < maxRounds; round++ {
-		respStatus, respHeaders, respBody, err := e.sendAnthropic(r, currentBody)
-		if err != nil {
-			writeError(w, http.StatusBadGateway, "upstream_error",
-				"upstream Anthropic request failed: "+err.Error())
+		respStatus, respHeaders, respBody, sendFailure := e.sendAnthropicWithRetry(r, currentBody)
+		if sendFailure != nil {
+			writeFailure(r.Context(), w, e.recorder, sendFailure, gatewayActor)
 			return
 		}
 		if respStatus != http.StatusOK {
@@ -83,8 +87,11 @@ func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
 
 		toolResultBlocks, execErr := e.executeAnthropicToolUses(r.Context(), ours)
 		if execErr != nil {
-			writeError(w, http.StatusInternalServerError, "executor_error",
-				"action executor returned a fatal error: "+execErr.Error())
+			writeFailure(r.Context(), w, e.recorder,
+				failure.ConnectorRuntime("action executor fatal error: "+execErr.Error(), false,
+					failure.WithBoundary(failure.Runtime),
+					failure.WithCause(execErr)),
+				gatewayActor)
 			return
 		}
 
@@ -101,16 +108,47 @@ func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
 		"interception loop exceeded maximum rounds; aborting to avoid infinite cycle")
 }
 
+// sendAnthropicWithRetry runs sendAnthropic inside the engine's retry
+// policy. Mirror of sendOpenAIWithRetry.
+func (e *Engine) sendAnthropicWithRetry(orig *http.Request, body []byte) (int, http.Header, []byte, *failure.Failure) {
+	type result struct {
+		status  int
+		headers http.Header
+		body    []byte
+	}
+	out, f := retry.Do(orig.Context(), e.retryPolicy, e.clock,
+		func(ctx context.Context, _ int) (result, *failure.Failure) {
+			status, hdrs, body, err := e.sendAnthropic(ctx, orig, body)
+			if err != nil {
+				return result{}, failure.Network(
+					"upstream Anthropic request failed: "+err.Error(),
+					failure.WithCause(err),
+				)
+			}
+			if status == http.StatusTooManyRequests || (status >= 500 && status <= 599) {
+				return result{}, failure.Upstream(status,
+					fmt.Sprintf("upstream returned %d", status),
+					failure.WithDetails(map[string]any{"body": string(body)}),
+				)
+			}
+			return result{status: status, headers: hdrs, body: body}, nil
+		})
+	if f != nil {
+		return 0, nil, nil, f
+	}
+	return out.status, out.headers, out.body, nil
+}
+
 // sendAnthropic posts the body to the configured Anthropic upstream
 // and returns status, headers, and body.
-func (e *Engine) sendAnthropic(orig *http.Request, body []byte) (int, http.Header, []byte, error) {
+func (e *Engine) sendAnthropic(ctx context.Context, orig *http.Request, body []byte) (int, http.Header, []byte, error) {
 	target := *e.anthropicUpstream
 	if target.Path == "" || target.Path == "/" {
 		target.Path = "/v1/messages"
 	} else {
 		target.Path = strings.TrimRight(target.Path, "/") + "/v1/messages"
 	}
-	req, err := http.NewRequestWithContext(orig.Context(), http.MethodPost, target.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target.String(), bytes.NewReader(body))
 	if err != nil {
 		return 0, nil, nil, err
 	}
@@ -182,15 +220,17 @@ func (e *Engine) executeAnthropicToolUses(ctx context.Context, uses []map[string
 		if err != nil {
 			return nil, err
 		}
-		block := map[string]any{
+		if res.Failure != nil {
+			e.recorder.RecordFailure(ctx, res.Failure,
+				model.ActorRef{ID: name, Type: model.ActorTypeConnectorRuntime})
+			out = append(out, failure.ToAnthropicToolResult(res.Failure, id))
+			continue
+		}
+		out = append(out, map[string]any{
 			"type":        "tool_result",
 			"tool_use_id": id,
 			"content":     res.Content,
-		}
-		if res.IsError {
-			block["is_error"] = true
-		}
-		out = append(out, block)
+		})
 	}
 	return out, nil
 }

--- a/internal/intercept/helpers.go
+++ b/internal/intercept/helpers.go
@@ -1,8 +1,13 @@
 package intercept
 
 import (
+	"context"
 	"encoding/json"
 	"net/http"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/failure"
+	"github.com/ALRubinger/aileron/internal/model"
 )
 
 // nameSet builds a set lookup from a slice for O(1) membership tests.
@@ -100,11 +105,28 @@ type errorBodyInner struct {
 	Message string `json:"message"`
 }
 
-// writeError emits a structured JSON error matching the Aileron API
-// contract.
+// writeError emits a structured JSON error matching the Aileron
+// `api.Error` schema. Used for gateway-protocol errors (request
+// validation, configuration) that don't fit ADR-0010's runtime
+// failure taxonomy. Action-execution and upstream-call failures use
+// [writeFailure] instead, which writes the [failure.Envelope] shape.
 func writeError(w http.ResponseWriter, status int, code, message string) {
 	body, _ := json.Marshal(errorBody{Error: errorBodyInner{Code: code, Message: message}})
 	w.Header().Set("Content-Type", "application/json")
 	w.WriteHeader(status)
 	w.Write(body)
+}
+
+// writeFailure records the failure to the audit log and writes the
+// ADR-0010 envelope to the response. The audit_id stamped on the
+// failure is included in the envelope so callers can correlate.
+//
+// `actor` identifies who/what produced the failure for audit purposes.
+// Pass model.ActorRef{} when no concrete actor exists; the audit
+// store will record the failure under the unknown-actor namespace.
+func writeFailure(ctx context.Context, w http.ResponseWriter, recorder audit.Recorder, f *failure.Failure, actor model.ActorRef) {
+	if recorder != nil {
+		recorder.RecordFailure(ctx, f, actor)
+	}
+	failure.WriteHTTP(w, f)
 }

--- a/internal/intercept/intercept.go
+++ b/internal/intercept/intercept.go
@@ -18,7 +18,10 @@ import (
 	"net/url"
 
 	"github.com/ALRubinger/aileron/internal/action"
+	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/augment"
+	"github.com/ALRubinger/aileron/internal/clock"
+	"github.com/ALRubinger/aileron/internal/retry"
 )
 
 // maxRounds caps the number of intercept iterations a single agent
@@ -36,6 +39,9 @@ type Engine struct {
 	executor          action.Executor
 	httpClient        *http.Client
 	log               *slog.Logger
+	recorder          audit.Recorder
+	retryPolicy       retry.Policy
+	clock             clock.Clock
 }
 
 // Config groups the dependencies required to build an Engine. The
@@ -49,6 +55,19 @@ type Config struct {
 	Executor          action.Executor
 	HTTPClient        *http.Client // optional; defaults to http.DefaultClient
 	Log               *slog.Logger // optional; defaults to slog.Default()
+
+	// Recorder writes audit events for every failure surfaced through
+	// the gateway. Required — pass audit.NewRecorder(audit.NewMemStore(),
+	// nil, nil) for a default in-memory recorder.
+	Recorder audit.Recorder
+
+	// RetryPolicy governs upstream retries per ADR-0010. Optional;
+	// defaults to retry.DefaultPolicy().
+	RetryPolicy retry.Policy
+
+	// Clock is the time source used for retry backoff. Optional;
+	// defaults to clock.System{}.
+	Clock clock.Clock
 }
 
 // New builds an Engine from a Config.
@@ -59,6 +78,9 @@ func New(cfg Config) (*Engine, error) {
 	if cfg.Executor == nil {
 		return nil, errors.New("intercept: Executor is required")
 	}
+	if cfg.Recorder == nil {
+		return nil, errors.New("intercept: Recorder is required")
+	}
 	client := cfg.HTTPClient
 	if client == nil {
 		client = http.DefaultClient
@@ -67,6 +89,14 @@ func New(cfg Config) (*Engine, error) {
 	if log == nil {
 		log = slog.Default()
 	}
+	policy := cfg.RetryPolicy
+	if policy.MaxRetries == 0 && policy.BaseDelay == 0 && policy.Jitter == 0 {
+		policy = retry.DefaultPolicy()
+	}
+	clk := cfg.Clock
+	if clk == nil {
+		clk = clock.System{}
+	}
 	return &Engine{
 		openAIUpstream:    cfg.OpenAIUpstream,
 		anthropicUpstream: cfg.AnthropicUpstream,
@@ -74,6 +104,9 @@ func New(cfg Config) (*Engine, error) {
 		executor:          cfg.Executor,
 		httpClient:        client,
 		log:               log,
+		recorder:          cfg.Recorder,
+		retryPolicy:       policy,
+		clock:             clk,
 	}, nil
 }
 

--- a/internal/intercept/intercept_test.go
+++ b/internal/intercept/intercept_test.go
@@ -12,9 +12,14 @@ import (
 	"os"
 	"path/filepath"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 
 	"github.com/ALRubinger/aileron/internal/action"
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/failure"
+	"github.com/ALRubinger/aileron/internal/retry"
 )
 
 // Stage 4 contract (#370, ratified by ADR-0008):
@@ -195,11 +200,16 @@ func engineFor(t *testing.T, openAIURL, anthropicURL string, store *action.Store
 	if exec == nil {
 		exec = action.StubExecutor{}
 	}
+	// Tests use a tight retry policy so retried-network-error tests
+	// don't pay real-time backoff; the in-memory recorder lets tests
+	// query the audit log after the fact.
 	e, err := New(Config{
 		OpenAIUpstream:    oa,
 		AnthropicUpstream: an,
 		Actions:           store,
 		Executor:          exec,
+		Recorder:          audit.NewRecorder(audit.NewMemStore(), nil, nil),
+		RetryPolicy:       retry.Policy{MaxRetries: 0, BaseDelay: time.Millisecond, Jitter: 0},
 	})
 	if err != nil {
 		t.Fatalf("intercept.New: %v", err)
@@ -407,7 +417,7 @@ func TestHandleOpenAI_ActionErrorBecomesToolResultError(t *testing.T) {
 		`{"id":"r2","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Got an error from the action."}}]}`,
 	)
 	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
-	exec := &staticExecutor{result: action.Result{Content: "rate limited", IsError: true}}
+	exec := &staticExecutor{result: action.Result{Failure: failure.Upstream(429, "rate limited")}}
 	e := engineFor(t, upstream.URL, "", store, exec)
 
 	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
@@ -777,8 +787,8 @@ func TestHandleOpenAI_UpstreamUnreachable_Returns502(t *testing.T) {
 	if w.Code != http.StatusBadGateway {
 		t.Errorf("status = %d, want 502", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "upstream_error") {
-		t.Errorf("body = %s, want upstream_error code", w.Body.String())
+	if !strings.Contains(w.Body.String(), `"class":"network_error"`) {
+		t.Errorf("body = %s, want network_error class", w.Body.String())
 	}
 }
 
@@ -808,8 +818,8 @@ func TestHandleOpenAI_ExecutorFatalError_Returns500(t *testing.T) {
 	if w.Code != http.StatusInternalServerError {
 		t.Errorf("status = %d, want 500", w.Code)
 	}
-	if !strings.Contains(w.Body.String(), "executor_error") {
-		t.Errorf("body = %s, want executor_error code", w.Body.String())
+	if !strings.Contains(w.Body.String(), `"class":"connector_runtime_error"`) {
+		t.Errorf("body = %s, want connector_runtime_error class", w.Body.String())
 	}
 }
 
@@ -1122,7 +1132,7 @@ func TestHandleAnthropic_ActionErrorBecomesIsError(t *testing.T) {
 		`{"id":"m2","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"Got error."}],"stop_reason":"end_turn"}`,
 	)
 	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
-	exec := &staticExecutor{result: action.Result{Content: "rate limited", IsError: true}}
+	exec := &staticExecutor{result: action.Result{Failure: failure.Upstream(429, "rate limited")}}
 	e := engineFor(t, "", upstream.URL, store, exec)
 
 	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
@@ -1139,5 +1149,187 @@ func TestHandleAnthropic_ActionErrorBecomesIsError(t *testing.T) {
 	first := blocks[0].(map[string]any)
 	if first["is_error"] != true {
 		t.Errorf("tool_result.is_error = %v, want true", first["is_error"])
+	}
+}
+
+// =====================================================================
+// Stage 4 (#365, ratified by ADR-0010): retry + audit integration.
+//
+// These tests exercise the engine end-to-end with retry policy and a
+// recorder so we can assert that:
+//   - Network failures and upstream 5xx/429 retry per ADR-0010.
+//   - Final failures carry the retried count in details.
+//   - Failure responses to the agent embed an audit_id that resolves
+//     to a real recorded event.
+//   - Action-side failures (Result.Failure) flow back as tool-results
+//     with is_error / structured envelope content.
+// =====================================================================
+
+// engineWithRecorder builds an engine pointed at the given upstream
+// using a small retry policy (so retries don't pay real-time backoff)
+// and returns the engine + the audit store so tests can introspect
+// recorded events.
+func engineWithRecorder(t *testing.T, openAIURL, anthropicURL string, store *action.Store, exec action.Executor, policy retry.Policy) (*Engine, *audit.MemStore) {
+	t.Helper()
+	var oa, an *url.URL
+	if openAIURL != "" {
+		u, _ := url.Parse(openAIURL)
+		oa = u
+	}
+	if anthropicURL != "" {
+		u, _ := url.Parse(anthropicURL)
+		an = u
+	}
+	if exec == nil {
+		exec = action.StubExecutor{}
+	}
+	auditStore := audit.NewMemStore()
+	e, err := New(Config{
+		OpenAIUpstream:    oa,
+		AnthropicUpstream: an,
+		Actions:           store,
+		Executor:          exec,
+		Recorder:          audit.NewRecorder(auditStore, nil, nil),
+		RetryPolicy:       policy,
+	})
+	if err != nil {
+		t.Fatalf("intercept.New: %v", err)
+	}
+	return e, auditStore
+}
+
+// flakyUpstream returns 503 the first n times, then a real OpenAI
+// response. Counts requests for assertion.
+type flakyUpstream struct {
+	mu       sync.Mutex
+	failsLeft int
+	final    string
+	calls    int
+}
+
+func newFlakyUpstream(t *testing.T, failsLeft int, final string) (*httptest.Server, *flakyUpstream) {
+	t.Helper()
+	f := &flakyUpstream{failsLeft: failsLeft, final: final}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		f.mu.Lock()
+		f.calls++
+		left := f.failsLeft
+		if left > 0 {
+			f.failsLeft--
+		}
+		f.mu.Unlock()
+		if left > 0 {
+			w.Header().Set("Content-Type", "application/json")
+			w.WriteHeader(http.StatusServiceUnavailable)
+			w.Write([]byte(`{"error":"upstream busy"}`))
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(f.final))
+	}))
+	t.Cleanup(srv.Close)
+	return srv, f
+}
+
+func TestHandleOpenAI_RetriesUpstream5xxThenSucceeds(t *testing.T) {
+	upstream, flaky := newFlakyUpstream(t, 2,
+		`{"id":"ok","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"final"}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e, _ := engineWithRecorder(t, upstream.URL, "", store, nil,
+		retry.Policy{MaxRetries: 3, BaseDelay: time.Millisecond, Jitter: 0})
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if flaky.calls != 3 {
+		t.Errorf("upstream calls = %d, want 3 (2 retries + success)", flaky.calls)
+	}
+	if !strings.Contains(w.Body.String(), `"final"`) {
+		t.Errorf("body missing final content: %s", w.Body.String())
+	}
+}
+
+func TestHandleOpenAI_RetriesUpstream5xxThenFails_AuditIDResolvable(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusServiceUnavailable)
+		w.Write([]byte(`{"error":"persistent"}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e, auditStore := engineWithRecorder(t, srv.URL, "", store, nil,
+		retry.Policy{MaxRetries: 2, BaseDelay: time.Millisecond, Jitter: 0})
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", w.Code)
+	}
+	var resp map[string]any
+	json.Unmarshal(w.Body.Bytes(), &resp)
+	inner, _ := resp["error"].(map[string]any)
+	if inner["class"] != "external_api_error" {
+		t.Errorf("class = %v, want external_api_error", inner["class"])
+	}
+	auditID, _ := inner["audit_id"].(string)
+	if auditID == "" {
+		t.Fatal("audit_id missing in envelope")
+	}
+	if _, ok := auditStore.GetByEventID(auditID); !ok {
+		t.Errorf("audit_id %q does not resolve to a recorded event", auditID)
+	}
+	details, _ := inner["details"].(map[string]any)
+	if details["retried"] == nil {
+		t.Errorf("details.retried missing on exhausted retry; got details=%v", details)
+	}
+}
+
+func TestHandleOpenAI_ActionFailure_FlowsAsToolResult_AuditRecorded(t *testing.T) {
+	upstream, captured := newScriptedUpstream(t,
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"c","type":"function","function":{"name":"ship_update","arguments":"{}"}}]}}]}`,
+		`{"id":"r2","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"sorry"}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{result: action.Result{Failure: failure.CapabilityDeniedAt(failure.Action, "channel scope missing")}}
+	e, auditStore := engineWithRecorder(t, upstream.URL, "", store, exec, retry.DefaultPolicy())
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (action errors are tool-results)", w.Code)
+	}
+	// Continuation request's tool message carries the failure shape.
+	contMessages, _ := captured.captured[1]["messages"].([]any)
+	last := contMessages[len(contMessages)-1].(map[string]any)
+	content, _ := last["content"].(string)
+	if !strings.Contains(content, "capability_denied") {
+		t.Errorf("tool content missing class: %s", content)
+	}
+	// Audit log records the action-side failure too.
+	traces, _ := auditStore.ListTraces(context.Background(), audit.Filter{})
+	hasFailure := false
+	for _, tr := range traces {
+		for _, ev := range tr.Events {
+			if class, _ := ev.Payload["class"].(string); class == "capability_denied" {
+				hasFailure = true
+			}
+		}
+	}
+	if !hasFailure {
+		t.Error("audit log did not record the action-side capability_denied failure")
 	}
 }

--- a/internal/intercept/openai.go
+++ b/internal/intercept/openai.go
@@ -12,6 +12,9 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/action"
 	"github.com/ALRubinger/aileron/internal/augment"
+	"github.com/ALRubinger/aileron/internal/failure"
+	"github.com/ALRubinger/aileron/internal/model"
+	"github.com/ALRubinger/aileron/internal/retry"
 )
 
 // HandleOpenAI runs the augmentation + interception loop for an
@@ -69,11 +72,12 @@ func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
 
 	ourNames := nameSet(aug.OurNames)
 
+	gatewayActor := model.ActorRef{ID: "aileron-gateway", Type: model.ActorTypeService}
+
 	for round := 0; round < maxRounds; round++ {
-		respStatus, respHeaders, respBody, err := e.sendOpenAI(r, currentBody)
-		if err != nil {
-			writeError(w, http.StatusBadGateway, "upstream_error",
-				"upstream OpenAI request failed: "+err.Error())
+		respStatus, respHeaders, respBody, sendFailure := e.sendOpenAIWithRetry(r, currentBody)
+		if sendFailure != nil {
+			writeFailure(r.Context(), w, e.recorder, sendFailure, gatewayActor)
 			return
 		}
 		if respStatus != http.StatusOK {
@@ -103,8 +107,11 @@ func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
 
 		toolMessages, execErr := e.executeOpenAIToolCalls(r.Context(), ours)
 		if execErr != nil {
-			writeError(w, http.StatusInternalServerError, "executor_error",
-				"action executor returned a fatal error: "+execErr.Error())
+			writeFailure(r.Context(), w, e.recorder,
+				failure.ConnectorRuntime("action executor fatal error: "+execErr.Error(), false,
+					failure.WithBoundary(failure.Runtime),
+					failure.WithCause(execErr)),
+				gatewayActor)
 			return
 		}
 
@@ -121,20 +128,61 @@ func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
 		"interception loop exceeded maximum rounds; aborting to avoid infinite cycle")
 }
 
+// sendOpenAIWithRetry runs sendOpenAI inside the engine's retry
+// policy. Network errors and upstream 5xx/429 responses retry per
+// ADR-0010; everything else returns immediately. Non-retriable
+// upstream statuses (4xx) come back as a successful HTTP response
+// with the raw status — caller decides whether to passThrough.
+//
+// Returns:
+//   - status, headers, body for any HTTP response (2xx through 5xx);
+//   - or a *failure.Failure for transport-level failures (network
+//     errors, retried upstream 5xx that exhausted) that the caller
+//     should map to FailureEnvelope.
+func (e *Engine) sendOpenAIWithRetry(orig *http.Request, body []byte) (int, http.Header, []byte, *failure.Failure) {
+	type result struct {
+		status  int
+		headers http.Header
+		body    []byte
+	}
+	out, f := retry.Do(orig.Context(), e.retryPolicy, e.clock,
+		func(ctx context.Context, _ int) (result, *failure.Failure) {
+			status, hdrs, body, err := e.sendOpenAI(ctx, orig, body)
+			if err != nil {
+				return result{}, failure.Network(
+					"upstream OpenAI request failed: "+err.Error(),
+					failure.WithCause(err),
+				)
+			}
+			// 5xx and 429 → translate into a retriable Upstream failure
+			// so retry.Do can reattempt. Other statuses pass through
+			// the success path.
+			if status == http.StatusTooManyRequests || (status >= 500 && status <= 599) {
+				return result{}, failure.Upstream(status,
+					fmt.Sprintf("upstream returned %d", status),
+					failure.WithDetails(map[string]any{"body": string(body)}),
+				)
+			}
+			return result{status: status, headers: hdrs, body: body}, nil
+		})
+	if f != nil {
+		return 0, nil, nil, f
+	}
+	return out.status, out.headers, out.body, nil
+}
+
 // sendOpenAI POSTs the given body to the configured OpenAI upstream,
 // preserving auth-relevant request headers from the original request.
-// Returns status, response headers, and the full response body. The
-// caller is responsible for inspecting the status — non-200 responses
-// are returned without error so they can be propagated to the agent
-// unchanged.
-func (e *Engine) sendOpenAI(orig *http.Request, body []byte) (int, http.Header, []byte, error) {
+// Used inside [Engine.sendOpenAIWithRetry]; tests of the proxy seam
+// without retry call this directly.
+func (e *Engine) sendOpenAI(ctx context.Context, orig *http.Request, body []byte) (int, http.Header, []byte, error) {
 	target := *e.openAIUpstream
 	if target.Path == "" || target.Path == "/" {
 		target.Path = "/v1/chat/completions"
 	} else {
 		target.Path = strings.TrimRight(target.Path, "/") + "/v1/chat/completions"
 	}
-	req, err := http.NewRequestWithContext(orig.Context(), http.MethodPost, target.String(), bytes.NewReader(body))
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, target.String(), bytes.NewReader(body))
 	if err != nil {
 		return 0, nil, nil, err
 	}
@@ -226,15 +274,19 @@ func (e *Engine) executeOpenAIToolCalls(ctx context.Context, calls []map[string]
 		if err != nil {
 			return nil, err
 		}
-		content := res.Content
-		if res.IsError {
-			content = fmt.Sprintf(`{"error":true,"content":%s}`, jsonString(res.Content))
+		if res.Failure != nil {
+			// Audit-record the action-side failure so the audit_id is
+			// stamped onto the failure before it reaches the LLM.
+			e.recorder.RecordFailure(ctx, res.Failure,
+				model.ActorRef{ID: name, Type: model.ActorTypeConnectorRuntime})
+			out = append(out, failure.ToOpenAIToolMessage(res.Failure, id, name))
+			continue
 		}
 		out = append(out, map[string]any{
 			"role":         "tool",
 			"tool_call_id": id,
 			"name":         name,
-			"content":      content,
+			"content":      res.Content,
 		})
 	}
 	return out, nil

--- a/internal/retry/retry.go
+++ b/internal/retry/retry.go
@@ -1,0 +1,153 @@
+// Package retry implements ADR-0010's bounded-retry policy: at most
+// 3 retries with exponential backoff (1s/2s/4s + jitter) for failures
+// the [failure] package marks retriable. Network failures and
+// upstream 429/5xx responses are the canonical retriable classes;
+// everything else fails fast.
+//
+// The primitive is generic across return types so it can wrap both
+// the executor seam and HTTP upstream calls. Callers supply a
+// [Policy], a [clock.Clock], and an Op that returns either a value
+// or a *failure.Failure. retry.Do handles the loop, the backoff
+// scheduling, and the `details.retried = N` annotation on the final
+// failure.
+package retry
+
+import (
+	"context"
+	"errors"
+	"math/rand/v2"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/clock"
+	"github.com/ALRubinger/aileron/internal/failure"
+)
+
+// DefaultPolicy returns the v1 ADR-0010 default: 3 retries, 1s base
+// delay, 20% jitter. Most callers should pass this; a few might tune
+// jitter for deterministic tests.
+func DefaultPolicy() Policy {
+	return Policy{MaxRetries: 3, BaseDelay: time.Second, Jitter: 0.2}
+}
+
+// Policy controls how [Do] retries.
+type Policy struct {
+	// MaxRetries is the upper bound on additional attempts after
+	// the first one. ADR-0010 v1 default: 3.
+	MaxRetries int
+
+	// BaseDelay is the delay before the first retry. Subsequent
+	// retries double from there.
+	BaseDelay time.Duration
+
+	// Jitter is the fractional jitter applied to each delay
+	// (0.0 = none, 1.0 = up to 100% extra). Default: 0.2.
+	Jitter float64
+}
+
+// Op is the operation [Do] executes. attempt starts at 1 for the
+// first call and increments per retry; useful for callers that want
+// to observe the retry count for logging.
+type Op[T any] func(ctx context.Context, attempt int) (T, *failure.Failure)
+
+// Do runs op with the given retry policy. On a retriable failure it
+// sleeps `BaseDelay << (attempt-1)` (with jitter), up to MaxRetries
+// times, then returns the final failure with `details.retried = N`
+// stamped on. Non-retriable failures return immediately. Successes
+// return on the first non-failing attempt.
+//
+// retriable predicate: only NetworkError or ExternalAPIError failures
+// trip the retry path, and only when their Retriable() flag is true.
+// Other classes — even ones marked retriable in their constructor —
+// are left to the caller's policy. This keeps the retry surface
+// narrow per ADR-0010's "the runtime retries `retriable` errors"
+// language combined with the table that names the eligible classes.
+func Do[T any](ctx context.Context, p Policy, clk clock.Clock, op Op[T]) (T, *failure.Failure) {
+	if p.MaxRetries < 0 {
+		p.MaxRetries = 0
+	}
+	if p.BaseDelay <= 0 {
+		p.BaseDelay = time.Second
+	}
+	var zero T
+	var last *failure.Failure
+	for attempt := 1; attempt <= p.MaxRetries+1; attempt++ {
+		if err := ctx.Err(); err != nil {
+			return zero, ctxFailure(err)
+		}
+		v, f := op(ctx, attempt)
+		if f == nil {
+			return v, nil
+		}
+		last = f
+		if !shouldRetry(f) || attempt > p.MaxRetries {
+			break
+		}
+		// Sleep then retry.
+		delay := backoff(p, attempt)
+		select {
+		case <-ctx.Done():
+			return zero, ctxFailure(ctx.Err())
+		case <-clk.After(delay):
+		}
+	}
+	if last != nil {
+		// Stamp retried-count: number of retries actually performed
+		// equals attempts-minus-one capped at MaxRetries.
+		retries := p.MaxRetries
+		if !shouldRetry(last) {
+			retries = 0
+		}
+		if retries > 0 {
+			last.SetDetail("retried", retries)
+		}
+	}
+	return zero, last
+}
+
+// shouldRetry reports whether a failure is eligible per ADR-0010's
+// table: NetworkError always; ExternalAPIError only for 429 / 5xx
+// (which the failure constructor already encoded as Retriable()).
+func shouldRetry(f *failure.Failure) bool {
+	if f == nil || !f.Retriable() {
+		return false
+	}
+	switch f.Class() {
+	case failure.NetworkError, failure.ExternalAPIError:
+		return true
+	}
+	return false
+}
+
+// backoff returns the delay before retry n, capped to a sensible
+// upper bound and with random jitter applied.
+//
+//	n=1 → BaseDelay              (first retry)
+//	n=2 → BaseDelay * 2
+//	n=3 → BaseDelay * 4
+func backoff(p Policy, attempt int) time.Duration {
+	exponent := attempt - 1
+	if exponent < 0 {
+		exponent = 0
+	}
+	if exponent > 10 {
+		// Cap to avoid overflow in pathological tests.
+		exponent = 10
+	}
+	delay := p.BaseDelay << exponent
+	if p.Jitter > 0 {
+		// Multiply delay by a random factor in [1, 1+Jitter].
+		factor := 1 + rand.Float64()*p.Jitter
+		delay = time.Duration(float64(delay) * factor)
+	}
+	return delay
+}
+
+// ctxFailure wraps a context error as a NetworkError. Cancellation
+// during retry is treated as a network-side abort so the agent sees
+// a structured envelope rather than a raw Go error.
+func ctxFailure(err error) *failure.Failure {
+	if errors.Is(err, context.Canceled) {
+		return failure.Network("context canceled while retrying", failure.WithCause(err))
+	}
+	return failure.Network("context deadline exceeded while retrying", failure.WithCause(err))
+}

--- a/internal/retry/retry_test.go
+++ b/internal/retry/retry_test.go
@@ -1,0 +1,331 @@
+package retry
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/clock"
+	"github.com/ALRubinger/aileron/internal/failure"
+)
+
+// retry.Do contract:
+//   - Op called once on success; returns immediately.
+//   - Retriable failure (NetworkError or ExternalAPIError 5xx/429) is
+//     retried up to MaxRetries times; final failure carries
+//     details.retried = MaxRetries.
+//   - Non-retriable failure: no retry; details.retried not set.
+//   - Other classes (ConnectorRuntimeError etc.) even if marked
+//     retriable: not retried by this primitive.
+//   - Context cancellation aborts retry mid-sleep with a NetworkError
+//     wrapping the cancellation.
+
+func TestDo_SuccessOnFirstTry(t *testing.T) {
+	var calls int
+	v, f := Do(context.Background(), DefaultPolicy(), clock.System{}, func(_ context.Context, attempt int) (string, *failure.Failure) {
+		calls++
+		return "ok", nil
+	})
+	if f != nil {
+		t.Fatalf("Do returned failure: %v", f)
+	}
+	if v != "ok" {
+		t.Errorf("v = %q, want ok", v)
+	}
+	if calls != 1 {
+		t.Errorf("called %d times, want 1", calls)
+	}
+}
+
+func TestDo_RetriesNetworkErrorThenSucceeds(t *testing.T) {
+	c := clock.NewFake(time.Time{})
+	policy := Policy{MaxRetries: 3, BaseDelay: time.Second, Jitter: 0}
+	var calls int
+	op := func(_ context.Context, attempt int) (string, *failure.Failure) {
+		calls++
+		if calls < 3 {
+			return "", failure.Network("dial timeout")
+		}
+		return "ok", nil
+	}
+	// Run Do on a goroutine; Advance to release the fake's After channels.
+	resultCh := make(chan struct {
+		v string
+		f *failure.Failure
+	})
+	go func() {
+		v, f := Do(context.Background(), policy, c, op)
+		resultCh <- struct {
+			v string
+			f *failure.Failure
+		}{v, f}
+	}()
+	// First retry waits 1s; second retry waits 2s. Wait briefly between
+	// advances so the goroutine has a chance to schedule the next After.
+	for i := 0; i < 2; i++ {
+		waitForPending(t, c, 1)
+		c.Advance(10 * time.Second)
+	}
+	res := <-resultCh
+	if res.f != nil {
+		t.Fatalf("got failure: %v", res.f)
+	}
+	if res.v != "ok" {
+		t.Errorf("v = %q", res.v)
+	}
+	if calls != 3 {
+		t.Errorf("called %d times, want 3", calls)
+	}
+}
+
+func TestDo_RetriesUpstream5xxThenSucceeds(t *testing.T) {
+	c := clock.NewFake(time.Time{})
+	policy := Policy{MaxRetries: 3, BaseDelay: time.Second, Jitter: 0}
+	var calls int
+	op := func(_ context.Context, _ int) (int, *failure.Failure) {
+		calls++
+		if calls == 1 {
+			return 0, failure.Upstream(503, "service unavailable")
+		}
+		return 200, nil
+	}
+	resultCh := runAsync(c, policy, op)
+	waitForPending(t, c, 1)
+	c.Advance(2 * time.Second)
+	res := <-resultCh
+	if res.f != nil {
+		t.Fatalf("failure = %v", res.f)
+	}
+	if calls != 2 {
+		t.Errorf("calls = %d, want 2", calls)
+	}
+}
+
+func TestDo_DoesNotRetryNon4xx_5xx(t *testing.T) {
+	policy := Policy{MaxRetries: 3, BaseDelay: time.Second, Jitter: 0}
+	var calls int
+	op := func(_ context.Context, _ int) (int, *failure.Failure) {
+		calls++
+		return 0, failure.Upstream(404, "not found")
+	}
+	_, f := Do(context.Background(), policy, clock.System{}, op)
+	if f == nil {
+		t.Fatal("expected failure")
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (404 is not retriable)", calls)
+	}
+	if _, ok := f.Details()["retried"]; ok {
+		t.Error("details.retried set on a non-retried failure")
+	}
+}
+
+func TestDo_DoesNotRetryNonRetriableClasses(t *testing.T) {
+	policy := Policy{MaxRetries: 3, BaseDelay: time.Second, Jitter: 0}
+	cases := map[string]*failure.Failure{
+		"capability_denied":       failure.CapabilityDeniedAt(failure.Action, "denied"),
+		"binding_required":        failure.BindingRequiredFailure("bind"),
+		"resource_limit_exceeded": failure.ResourceLimitFailure("oom"),
+		"hash_mismatch":           failure.HashMismatchFailure("bad hash"),
+		"signature_failure":       failure.SignatureFailureFailure("bad sig"),
+		// connector_runtime_error marked retriable: still skipped by
+		// retry.Do because it's not network/external.
+		"connector_runtime_retriable": failure.ConnectorRuntime("transient", true),
+	}
+	for name, f := range cases {
+		t.Run(name, func(t *testing.T) {
+			var calls int
+			_, got := Do(context.Background(), policy, clock.System{}, func(_ context.Context, _ int) (any, *failure.Failure) {
+				calls++
+				return nil, f
+			})
+			if got != f {
+				t.Errorf("returned different failure: %v", got)
+			}
+			if calls != 1 {
+				t.Errorf("calls = %d, want 1 (class %q not retriable by retry.Do)", calls, f.Class())
+			}
+		})
+	}
+}
+
+func TestDo_StampsRetriedCountOnFinalFailure(t *testing.T) {
+	c := clock.NewFake(time.Time{})
+	policy := Policy{MaxRetries: 3, BaseDelay: time.Second, Jitter: 0}
+	op := func(_ context.Context, _ int) (any, *failure.Failure) {
+		return nil, failure.Network("always failing")
+	}
+	resultCh := runAsync(c, policy, op)
+	for i := 0; i < 3; i++ {
+		waitForPending(t, c, 1)
+		c.Advance(10 * time.Second)
+	}
+	res := <-resultCh
+	if res.f == nil {
+		t.Fatal("expected failure after exhausting retries")
+	}
+	got, ok := res.f.Details()["retried"].(int)
+	if !ok {
+		t.Fatalf("details.retried missing or wrong type: %v", res.f.Details()["retried"])
+	}
+	if got != 3 {
+		t.Errorf("details.retried = %d, want 3", got)
+	}
+}
+
+func TestDo_ContextCancelDuringSleep(t *testing.T) {
+	c := clock.NewFake(time.Time{})
+	policy := Policy{MaxRetries: 3, BaseDelay: time.Second, Jitter: 0}
+	ctx, cancel := context.WithCancel(context.Background())
+	op := func(_ context.Context, _ int) (any, *failure.Failure) {
+		return nil, failure.Network("flaky")
+	}
+	type result struct {
+		f *failure.Failure
+	}
+	out := make(chan result, 1)
+	go func() {
+		_, f := Do(ctx, policy, c, op)
+		out <- result{f}
+	}()
+	waitForPending(t, c, 1)
+	cancel()
+	res := <-out
+	if res.f == nil {
+		t.Fatal("expected failure on cancel")
+	}
+	if res.f.Class() != failure.NetworkError {
+		t.Errorf("class = %q, want network_error", res.f.Class())
+	}
+}
+
+func TestDo_ZeroMaxRetries_OnlyAttemptsOnce(t *testing.T) {
+	policy := Policy{MaxRetries: 0, BaseDelay: time.Second, Jitter: 0}
+	var calls int
+	_, f := Do(context.Background(), policy, clock.System{}, func(_ context.Context, _ int) (any, *failure.Failure) {
+		calls++
+		return nil, failure.Network("flaky")
+	})
+	if f == nil {
+		t.Fatal("expected failure")
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1", calls)
+	}
+}
+
+func TestBackoff_DoublesPerAttempt(t *testing.T) {
+	p := Policy{BaseDelay: time.Second, Jitter: 0}
+	cases := []struct {
+		attempt int
+		want    time.Duration
+	}{
+		{1, time.Second},
+		{2, 2 * time.Second},
+		{3, 4 * time.Second},
+		{4, 8 * time.Second},
+	}
+	for _, tc := range cases {
+		got := backoff(p, tc.attempt)
+		if got != tc.want {
+			t.Errorf("backoff(attempt=%d) = %v, want %v", tc.attempt, got, tc.want)
+		}
+	}
+}
+
+func TestBackoff_AppliesJitter(t *testing.T) {
+	p := Policy{BaseDelay: time.Second, Jitter: 0.5}
+	got := backoff(p, 1)
+	// Jitter expands the delay to [1, 1.5)s.
+	if got < time.Second || got >= time.Second*3/2 {
+		t.Errorf("jittered backoff out of range: %v", got)
+	}
+}
+
+func TestBackoff_CapsExponent(t *testing.T) {
+	p := Policy{BaseDelay: time.Second, Jitter: 0}
+	// attempt = 100 would normally overflow; the cap at 10 keeps it sane.
+	got := backoff(p, 100)
+	want := time.Second << 10
+	if got != want {
+		t.Errorf("backoff caps at 2^10 BaseDelay; got %v, want %v", got, want)
+	}
+}
+
+func TestBackoff_ZeroAttempt_TreatsAsFirst(t *testing.T) {
+	p := Policy{BaseDelay: time.Second, Jitter: 0}
+	got := backoff(p, 0)
+	if got != time.Second {
+		t.Errorf("backoff(0) = %v, want 1s", got)
+	}
+}
+
+func TestCtxFailure_DeadlineExceeded(t *testing.T) {
+	f := ctxFailure(context.DeadlineExceeded)
+	if f.Class() != failure.NetworkError {
+		t.Errorf("class = %q, want network_error", f.Class())
+	}
+}
+
+func TestDo_NormalisesNegativePolicy(t *testing.T) {
+	policy := Policy{MaxRetries: -5, BaseDelay: -time.Second, Jitter: 0}
+	var calls int
+	_, f := Do(context.Background(), policy, clock.System{}, func(_ context.Context, _ int) (int, *failure.Failure) {
+		calls++
+		return 0, failure.Network("flaky")
+	})
+	if f == nil {
+		t.Fatal("expected failure")
+	}
+	if calls != 1 {
+		t.Errorf("calls = %d, want 1 (negative MaxRetries clamped to 0)", calls)
+	}
+}
+
+func TestDefaultPolicy_MatchesADR0010(t *testing.T) {
+	p := DefaultPolicy()
+	if p.MaxRetries != 3 {
+		t.Errorf("MaxRetries = %d, want 3", p.MaxRetries)
+	}
+	if p.BaseDelay != time.Second {
+		t.Errorf("BaseDelay = %v, want 1s", p.BaseDelay)
+	}
+	if p.Jitter <= 0 || p.Jitter > 1 {
+		t.Errorf("Jitter = %v, want in (0,1]", p.Jitter)
+	}
+}
+
+// --- helpers ---
+
+type asyncResult[T any] struct {
+	v T
+	f *failure.Failure
+}
+
+// runAsync runs Do on a goroutine using the supplied clock and
+// returns a channel for the result. Tests advance the clock to
+// release retry sleeps.
+func runAsync[T any](c clock.Clock, policy Policy, op Op[T]) <-chan asyncResult[T] {
+	out := make(chan asyncResult[T], 1)
+	go func() {
+		v, f := Do(context.Background(), policy, c, op)
+		out <- asyncResult[T]{v, f}
+	}()
+	return out
+}
+
+// waitForPending busy-spins (with a timeout) until the fake clock
+// has at least n pending timers. Used to coordinate between the
+// goroutine running Do (which schedules After) and the test
+// (which advances the fake).
+func waitForPending(t *testing.T, c *clock.Fake, n int) {
+	t.Helper()
+	deadline := time.Now().Add(2 * time.Second)
+	for time.Now().Before(deadline) {
+		if c.Pending() >= n {
+			return
+		}
+		time.Sleep(time.Millisecond)
+	}
+	t.Fatalf("clock had %d pending timers, want ≥ %d (deadlocked?)", c.Pending(), n)
+}


### PR DESCRIPTION
## Summary

Implements [ADR-0010](https://docs.withaileron.ai/adr/0010-failure-handling) end-to-end (#365). One PR per the user's explicit direction; ~3.2k lines.

### New packages

- **`internal/clock`** (100% coverage) — minimal `Clock` interface + `System` real impl + `Fake` with `Advance(d)` / `Pending()` for deterministic retry tests.
- **`internal/failure`** (96.2%) — closed `FailureClass` (9 values) and `Boundary` (5 values) per ADR-0010. The `Failure` struct keeps `class` / `boundary` unexported so the only path to a valid value is through the per-class constructors (`Network`, `Upstream(status, ...)`, `CapabilityDeniedAt`, etc.). `Envelope` wire shape, `WriteHTTP` (status mapped per class), and protocol-shaped tool-result helpers (`ToOpenAIToolMessage`, `ToAnthropicToolResult`) for the agent-visible failure path. A drift test asserts the Go constants and the generated OpenAPI enum agree.
- **`internal/retry`** (97.7%) — generic `Do[T]` with the ADR's 1s/2s/4s + jitter schedule. Retries only `NetworkError` and `ExternalAPIError` (5xx/429); other classes — even when marked retriable — fall through. Stamps `details.retried` on the final failure when retries were attempted. Honours context cancellation.

### Audit recorder + in-memory store

The existing `internal/audit` SPI gains:
- `MemStore` satisfying `Store` for v1 dev/test (Postgres post-MVP).
- `Recorder` interface + impl that mints `audit-<uuid>` IDs and stamps them onto failures so the envelope returned to the agent carries a working back-reference. `RecordFailure` is best-effort per ADR-0010 — a failed audit write must not block the failure response.

### Connector manifest idempotency

`internal/cstore/manifest.go` gains `[connector.idempotency]` (`default = "idempotent" | "not_idempotent"`). `(m *Manifest).IsIdempotent()` is the predicate the retry layer will eventually consult to skip retry on side-effecting connectors.

### Executor API change

`action.Executor.Result` replaces `IsError + Content` with `Failure *failure.Failure + Content`. **This is a public-API break for the parallel WASM executor session.** Migration is one-line: `r.Failure = failure.Upstream(503, "...")` instead of `r.IsError = true; r.Content = "..."`.

### Intercept engine

Upstream LLM calls now wrap in `retry.Do` — network errors and 5xx/429 retry with exponential backoff. Final failures surface as `FailureEnvelope` responses. Action-side failures from the executor become tool-result messages the LLM can reason about, audit-recorded with the `audit_id` stamped before the response is written. `Engine.Config` gains `Recorder` (required), `RetryPolicy` (defaults to `retry.DefaultPolicy()`), and `Clock` (defaults to `clock.System{}`).

### OpenAPI spec

Gains `FailureEnvelope`, `FailureClass`, and `FailureBoundary` schemas plus a reusable `Failure` response. Gateway endpoints (`/v1/chat/completions`, `/v1/messages`) reference the new envelope on 4xx/5xx. **CRUD endpoints retain `api.Error`** per the ADR-scope decision: ADR-0010's runtime taxonomy doesn't fit auth/intent/approval CRUD failures, and forcing them in would expand the closed taxonomy beyond its semantic anchor.

### Auth normalisation

The 26 inline-JSON `http.Error` sites in `internal/auth/handler*.go` (which emitted `{"error": "<string>"}`) migrate to a local `writeError` helper emitting the standard `api.Error` shape. So the v1 server now emits exactly two stable envelopes — the gateway/action `FailureEnvelope` and the CRUD `api.Error`.

### ADR-0010 amendment

Amended in place (per the pre-MVP convention) to clarify scope (CRUD vs. action), name the auth normalisation, and link the new packages from Consequences.

## Test plan

- [x] `task generate:api` clean
- [x] `task lint:go` clean
- [x] `task build` succeeds (server, MCP, enclave, CLI, sh, UI, docs)
- [x] All internal package tests pass
- [x] New packages combined coverage: 94.0% (clock 100%, failure 96.2%, retry 97.7%, audit 90.7%)
- [x] Drift test asserts `failure.FailureClass` ↔ generated `api.FailureClass` enum
- [x] e2e tests through the engine: 503-503-200 retry-then-success; persistent 5xx with `audit_id` resolvable to a recorded event; action-side `CapabilityDenied` flowing as a tool-result with the audit log catching it; multi-turn intercept; agent-tool passthrough
- [x] Auth handler tests still pass after the shape migration

## Coordination note

`Result.IsError → Result.Failure` is the public-API break. The parallel WASM executor session needs to read `Result.Failure` instead of `Result.IsError`. The migration is mechanical — search for `IsError` in any in-progress executor branch and replace with the structured constructor.

Closes #365. Refs #335.

🤖 Generated with [Claude Code](https://claude.com/claude-code)