### PR TITLE
fix(ci): cover cmd/aileron and cmd/aileron-sh in Go test workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,8 +22,10 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: |
             internal/go.mod
+            cmd/aileron/go.mod
             cmd/aileron-enclave/go.mod
             cmd/aileron-mcp/go.mod
+            cmd/aileron-sh/go.mod
             sdk/go/go.mod
             test/integration/go.mod
 
@@ -47,8 +49,14 @@ jobs:
         working-directory: ui
         run: pnpm install --frozen-lockfile
 
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
       - name: Go vet
-        run: go vet ./internal/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...
+        run: task vet:go
 
       - name: Svelte check
         working-directory: ui
@@ -65,20 +73,24 @@ jobs:
           go-version: "1.25"
           cache-dependency-path: |
             internal/go.mod
+            cmd/aileron/go.mod
+            cmd/aileron-enclave/go.mod
+            cmd/aileron-mcp/go.mod
+            cmd/aileron-sh/go.mod
             sdk/go/go.mod
             test/integration/go.mod
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Install gotestsum
         run: go install gotest.tools/gotestsum@latest
 
       - name: Run Go tests
-        run: |
-          gotestsum --junitfile junit.xml -- -race -coverprofile=coverage-raw.txt ./internal/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...
-          # Strip generated code (oapi-codegen) from the coverage profile.
-          # Codecov's ignore directive does not match paths under internal/,
-          # so we remove api/gen entries before upload.
-          grep -v '/api/gen/' coverage-raw.txt > coverage.txt
-          rm coverage-raw.txt
+        run: task test:go:ci
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v5

--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,11 @@ ui/.svelte-kit/
 ui/build/
 ui/node_modules/
 
+# Go test artifacts (task test:go:ci output)
+/junit.xml
+/coverage.txt
+/coverage-raw.txt
+
 # UI test artifacts
 ui/coverage/
 ui/coverage-e2e/

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -2,6 +2,9 @@ version: "3"
 
 vars:
   COMPOSE_FILE: deploy/docker-compose.yml
+  # Single source of truth for Go test/vet package set, shared by local
+  # (test:go, vet:go) and CI (test:go:ci) targets.
+  GO_TEST_PACKAGES: ./internal/... ./cmd/aileron/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./cmd/aileron-sh/... ./sdk/go/...
 
 tasks:
   default:
@@ -207,7 +210,22 @@ tasks:
   test:go:
     desc: Run Go tests
     cmds:
-      - go test ./internal/... ./cmd/aileron/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./cmd/aileron-sh/...
+      - go test {{.GO_TEST_PACKAGES}}
+
+  test:go:ci:
+    desc: Run Go tests with race, coverage, and JUnit output (used by CI)
+    cmds:
+      - gotestsum --junitfile junit.xml -- -race -coverprofile=coverage-raw.txt {{.GO_TEST_PACKAGES}}
+      # Strip generated code (oapi-codegen) from the coverage profile.
+      # Codecov's ignore directive does not match paths under internal/,
+      # so we remove api/gen entries before upload.
+      - grep -v '/api/gen/' coverage-raw.txt > coverage.txt
+      - rm coverage-raw.txt
+
+  vet:go:
+    desc: Run go vet over all Go packages
+    cmds:
+      - go vet {{.GO_TEST_PACKAGES}}
 
   test:integration:
     desc: Run integration tests against running services

--- a/cmd/aileron-sh/main_test.go
+++ b/cmd/aileron-sh/main_test.go
@@ -108,6 +108,8 @@ allow:
 }
 
 // TestShimPolicyDeny verifies that commands matching deny rules are blocked.
+// Uses a relative path so the project deny (rm -rf *) matches but the
+// built-in deny (rm -rf /*) does not, exercising the project rule directly.
 func TestShimPolicyDeny(t *testing.T) {
 	binary := buildShim(t)
 	dir := writePolicyDir(t, `
@@ -118,7 +120,7 @@ deny:
     description: "no recursive delete"
 `)
 
-	cmd := exec.Command(binary, "-c", "rm -rf /something")
+	cmd := exec.Command(binary, "-c", "rm -rf something")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "AILERON_REAL_SHELL=/bin/sh")
 	out, err := cmd.CombinedOutput()
@@ -141,7 +143,8 @@ deny:
 }
 
 // TestShimPolicyAskDeniesWithoutTTY verifies that ask commands default to
-// deny when there is no controlling terminal.
+// deny when there is no controlling terminal. Uses "docker" because it is
+// not on the built-in allow list, so default:ask actually applies.
 func TestShimPolicyAskDeniesWithoutTTY(t *testing.T) {
 	binary := buildShim(t)
 	dir := writePolicyDir(t, `
@@ -149,7 +152,7 @@ version: 1
 default: ask
 `)
 
-	cmd := exec.Command(binary, "-c", "git push origin main")
+	cmd := exec.Command(binary, "-c", "docker run myimage")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "AILERON_REAL_SHELL=/bin/sh")
 	err := cmd.Run()
@@ -325,8 +328,10 @@ deny:
     description: "no recursive delete"
 `)
 
-	// Simulate the exact wrapper Claude Code sends.
-	wrapped := "shopt -u extglob 2>/dev/null || true && eval 'rm -rf /tmp/test' < /dev/null && pwd -P >| /tmp/claude-test-cwd"
+	// Simulate the exact wrapper Claude Code sends. Inner command uses a
+	// relative path so the project deny ("rm -rf *") matches and the built-in
+	// deny ("rm -rf /*") does not.
+	wrapped := "shopt -u extglob 2>/dev/null || true && eval 'rm -rf tmp/test' < /dev/null && pwd -P >| /tmp/claude-test-cwd"
 	cmd := exec.Command(binary, "-c", "-l", wrapped)
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "AILERON_REAL_SHELL=/bin/bash", "AILERON_AGENT=claude")
@@ -424,7 +429,7 @@ deny:
     description: "no recursive delete"
 `)
 
-	cmd := exec.Command(binary, "-c", "rm -rf /something")
+	cmd := exec.Command(binary, "-c", "rm -rf something")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(), "AILERON_REAL_SHELL=/bin/sh")
 	var stderr bytes.Buffer
@@ -479,7 +484,8 @@ deny:
 }
 
 // TestShimAskDeniesWithoutTTYAudit verifies that ask commands that
-// auto-deny (no tty) write an audit entry.
+// auto-deny (no tty) write an audit entry. Uses "docker" because it is
+// not on the built-in allow list, so default:ask actually applies.
 func TestShimAskDeniesWithoutTTYAudit(t *testing.T) {
 	binary := buildShim(t)
 	dir := writePolicyDir(t, `
@@ -488,7 +494,7 @@ default: ask
 `)
 
 	auditPath := filepath.Join(dir, "audit.jsonl")
-	cmd := exec.Command(binary, "-c", "git push origin main")
+	cmd := exec.Command(binary, "-c", "docker run myimage")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(),
 		"AILERON_REAL_SHELL=/bin/sh",


### PR DESCRIPTION
## Summary

Closes #330.

- Fix 5 `cmd/aileron-sh` test failures that were invisible in CI because the workflow's vet/test jobs omitted `cmd/aileron` and `cmd/aileron-sh` (only `task test:go` ran them locally).
- Wire CI through Taskfile targets so the local and CI package lists can't drift again.

## Why the tests were failing

All 5 failures were the same root cause: built-in defaults shadowed the test's project policy.

- `rm -rf /something` matched the built-in deny `rm -rf /*` (more specific) before the test's user-defined `rm -rf *` rule, so the assertion on the user description (`"no recursive delete"`) saw the built-in's description (`"block recursive delete at filesystem root"`) instead.
- `git push origin main` matched the built-in allow `git *`, so a project policy of `default: ask` never applied — the command was allowed and exited 128 (git error) instead of 1 (policy deny).

Fix: change the test commands to forms that don't collide with built-in defaults (`rm -rf something`, `docker run myimage`). Each test's contract is preserved.

## Why CI didn't catch them

`.github/workflows/ci.yml` ran vet/test on `./internal/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...` — `cmd/aileron-sh` (and `cmd/aileron`) were missing.

## Workflow change

- Introduced `GO_TEST_PACKAGES` as a Taskfile var — the single source of truth for both vet and test.
- Added `test:go:ci` (race + coverage + JUnit, with the existing `/api/gen/` coverage strip) and `vet:go`.
- CI now runs `task vet:go` and `task test:go:ci`. Any package added to the Taskfile is automatically covered in CI.
- Added `cmd/aileron/go.mod` and `cmd/aileron-sh/go.mod` to the cache deps so module downloads stay deterministic.
- `task test:go` (local) is unchanged in behavior — fast, no race/coverage instrumentation — but now also covers the broader package set.

## Test plan

- [x] `task vet:go` passes
- [x] `task test:go:ci` passes (2639 tests, produces `junit.xml` + `coverage.txt`)
- [x] `task test:go` passes
- [ ] CI job is green on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)