### PR TITLE
chore: add CODEOWNERS for main branch review enforcement

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,0 +1,6 @@
+# Code Owners for aileron
+#
+# Every PR requires review from a code owner before merging to main.
+# See: https://docs.github.com/en/repositories/managing-your-repositorys-settings-and-security/customizing-your-repository/about-code-owners
+
+* @ALRubinger


### PR DESCRIPTION
## Summary
- Adds `.github/CODEOWNERS` with `* @ALRubinger` so every PR requires owner review.
- Pairs with the new **Protect main** ruleset (id 15801401) which enforces:
  - PR required, 1 approval, **Code Owner review required**, stale approvals dismissed on push
  - Required status checks: Lint & Verify, Unit Tests, Integration Tests (Go), Integration Tests (E2E), UI Tests, Docs
  - Block force-push and branch deletion
  - Bypass: repo admins (you) only, in `pull_request` mode — still must use a PR, no direct pushes

## Test plan
- [ ] Confirm ruleset visible at https://github.com/ALRubinger/aileron/rules/15801401
- [ ] Verify this PR shows "Review required from Code Owners" before merging
- [ ] Confirm required checks block merge until green

🤖 Generated with [Claude Code](https://claude.com/claude-code)