### PR TITLE
feat(dev-run): add aileron-connector-dev-run harness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,6 +23,7 @@ jobs:
           cache-dependency-path: |
             internal/go.mod
             cmd/aileron/go.mod
+            cmd/aileron-connector-dev-run/go.mod
             cmd/aileron-enclave/go.mod
             cmd/aileron-mcp/go.mod
             cmd/aileron-sh/go.mod
@@ -74,6 +75,7 @@ jobs:
           cache-dependency-path: |
             internal/go.mod
             cmd/aileron/go.mod
+            cmd/aileron-connector-dev-run/go.mod
             cmd/aileron-enclave/go.mod
             cmd/aileron-mcp/go.mod
             cmd/aileron-sh/go.mod

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -104,6 +104,11 @@ tasks:
     cmds:
       - go build -o build/aileron-sh ./cmd/aileron-sh
 
+  build:connector-dev-run:
+    desc: Build the connector dev test harness (developer-only; not shipped)
+    cmds:
+      - go build -o build/aileron-connector-dev-run ./cmd/aileron-connector-dev-run
+
   build:ui:
     desc: Install UI dependencies and build
     dir: ui
@@ -180,7 +185,7 @@ tasks:
   lint:go:
     desc: Vet Go code
     cmds:
-      - go vet ./internal/... ./cmd/aileron/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./cmd/aileron-sh/...
+      - go vet ./internal/... ./cmd/aileron/... ./cmd/aileron-connector-dev-run/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./cmd/aileron-sh/...
 
   lint:ui:
     desc: Check the UI for type errors

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ vars:
   COMPOSE_FILE: deploy/docker-compose.yml
   # Single source of truth for Go test/vet package set, shared by local
   # (test:go, vet:go) and CI (test:go:ci) targets.
-  GO_TEST_PACKAGES: ./internal/... ./cmd/aileron/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./cmd/aileron-sh/... ./sdk/go/...
+  GO_TEST_PACKAGES: ./internal/... ./cmd/aileron/... ./cmd/aileron-connector-dev-run/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./cmd/aileron-sh/... ./sdk/go/...
 
 tasks:
   default:

--- a/cmd/aileron-connector-dev-run/go.mod
+++ b/cmd/aileron-connector-dev-run/go.mod
@@ -1,0 +1,10 @@
+module github.com/ALRubinger/aileron/cmd/aileron-connector-dev-run
+
+go 1.25.0
+
+require github.com/ALRubinger/aileron/internal v0.0.0
+
+replace (
+	github.com/ALRubinger/aileron/internal => ../../internal
+	github.com/ALRubinger/aileron/sdk/go => ../../sdk/go
+)

--- a/cmd/aileron-connector-dev-run/main.go
+++ b/cmd/aileron-connector-dev-run/main.go
@@ -1,0 +1,196 @@
+// Command aileron-connector-dev-run is a developer test harness for
+// running an Aileron WASM connector against real external APIs, without
+// going through the full install + binding + launch pipeline.
+//
+// Usage:
+//
+//	aileron-connector-dev-run \
+//	  --wasm     <path-to-connector.wasm> \
+//	  --manifest <path-to-connector/manifest.toml> \
+//	  --op       <op-name> \
+//	  --args     '<json-args>'
+//
+// The harness parses the manifest, builds the same Wazero-backed sandbox
+// runtime the production gateway uses, and invokes the connector with
+// the supplied op + args. The manifest's [capabilities.network] grant
+// is enforced exactly as in production. A stub credential resolver
+// returns the OAuth bearer token from the AILERON_DEV_TOKEN environment
+// variable; calls that mark themselves credential:"oauth2" get the
+// token injected at the network boundary just like a vault-bound
+// credential would.
+//
+// This binary is not installed alongside `aileron` for end users — it
+// lives in cmd/ so it can import internal/* packages directly. The
+// connector author runs it locally during connector development to
+// validate behavior against real APIs before tagging a release.
+//
+// Example (Gmail messages.list against a real account):
+//
+//	# Get a token from https://developers.google.com/oauthplayground
+//	# (gmail.readonly scope, exchange code for access token).
+//	export AILERON_DEV_TOKEN=ya29...
+//
+//	cd ~/git/ALRubinger/aileron-connector-google && task build
+//
+//	aileron-connector-dev-run \
+//	  --wasm     ~/git/ALRubinger/aileron-connector-google/connector.wasm \
+//	  --manifest ~/git/ALRubinger/aileron-connector-google/connector/manifest.toml \
+//	  --op       list_recent_emails \
+//	  --args     '{"query":"is:unread","max_results":3}'
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+
+	"github.com/ALRubinger/aileron/internal/credential"
+	"github.com/ALRubinger/aileron/internal/cstore"
+	"github.com/ALRubinger/aileron/internal/sandbox"
+)
+
+// tokenEnvVar names the env variable the harness reads to populate the
+// stub credential resolver. Any non-empty value is treated as the
+// bearer token to inject; the resolver does not interpret the value.
+const tokenEnvVar = "AILERON_DEV_TOKEN"
+
+func main() {
+	if err := run(context.Background(), os.Args[1:], os.Stdout, os.Stderr); err != nil {
+		fmt.Fprintf(os.Stderr, "aileron-connector-dev-run: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func run(ctx context.Context, args []string, stdout, stderr io.Writer) error {
+	fs := flag.NewFlagSet("aileron-connector-dev-run", flag.ContinueOnError)
+	fs.SetOutput(stderr)
+	wasmPath := fs.String("wasm", "", "path to connector.wasm")
+	manifestPath := fs.String("manifest", "", "path to connector/manifest.toml")
+	op := fs.String("op", "", "op name (matches the action's [[execute]].op)")
+	argsJSON := fs.String("args", "{}", "args as a JSON object")
+	verbose := fs.Bool("v", false, "print connector logs and resolver decisions to stderr")
+	fs.Usage = func() {
+		fmt.Fprintln(stderr, "usage: aileron-connector-dev-run --wasm <path> --manifest <path> --op <name> [--args <json>] [-v]")
+		fmt.Fprintln(stderr, "")
+		fmt.Fprintf(stderr, "  Env var %s carries the OAuth bearer token; the harness wires a\n", tokenEnvVar)
+		fmt.Fprintln(stderr, "  stub credential resolver that returns it as the bound credential.")
+		fmt.Fprintln(stderr, "  When unset, calls that mark themselves credential:\"oauth2\" return")
+		fmt.Fprintln(stderr, "  binding_required.")
+	}
+	if err := fs.Parse(args); err != nil {
+		return err
+	}
+	if *wasmPath == "" || *manifestPath == "" || *op == "" {
+		fs.Usage()
+		return errors.New("--wasm, --manifest, and --op are required")
+	}
+
+	wasmBytes, err := os.ReadFile(*wasmPath)
+	if err != nil {
+		return fmt.Errorf("read wasm: %w", err)
+	}
+	manifestBytes, err := os.ReadFile(*manifestPath)
+	if err != nil {
+		return fmt.Errorf("read manifest: %w", err)
+	}
+	manifest, err := cstore.ParseManifest(*manifestPath, manifestBytes)
+	if err != nil {
+		return fmt.Errorf("parse manifest: %w", err)
+	}
+	if err := cstore.ValidateManifest(manifest, *manifestPath); err != nil {
+		return fmt.Errorf("validate manifest: %w", err)
+	}
+
+	var opArgs map[string]any
+	if err := json.Unmarshal([]byte(*argsJSON), &opArgs); err != nil {
+		return fmt.Errorf("parse --args JSON: %w", err)
+	}
+
+	logLevel := slog.LevelWarn
+	if *verbose {
+		logLevel = slog.LevelDebug
+	}
+	log := slog.New(slog.NewTextHandler(stderr, &slog.HandlerOptions{Level: logLevel}))
+
+	rt, err := sandbox.NewWazeroRuntime(ctx, sandbox.WithLogger(log))
+	if err != nil {
+		return fmt.Errorf("init wazero runtime: %w", err)
+	}
+	defer func() { _ = rt.Close(ctx) }()
+
+	conn, err := rt.Compile(ctx, manifest, wasmBytes)
+	if err != nil {
+		return fmt.Errorf("compile connector: %w", err)
+	}
+	defer func() { _ = conn.Close(ctx) }()
+
+	resolver := newDevResolver(manifest, os.Getenv(tokenEnvVar))
+	if resolver.kind != "" && resolver.token == "" {
+		fmt.Fprintf(stderr, "note: %s not set; credential:%q calls return binding_required.\n",
+			tokenEnvVar, resolver.kind)
+	}
+
+	result, invokeErr := conn.Invoke(ctx, sandbox.Call{
+		Op:                 *op,
+		Args:               opArgs,
+		CredentialResolver: resolver,
+	})
+
+	for _, line := range result.Logs {
+		fmt.Fprintf(stderr, "[connector %s] %s\n", line.Level, line.Message)
+	}
+
+	if invokeErr != nil {
+		// Surface the structured error in the same shape the gateway
+		// would (ADR-0010 envelope); for a Go error without that shape,
+		// fall back to the prose Error() form.
+		_ = json.NewEncoder(stdout).Encode(envelope{Error: invokeErr.Error()})
+		return invokeErr
+	}
+
+	return json.NewEncoder(stdout).Encode(envelope{Output: result.Output})
+}
+
+// envelope is the JSON shape the harness emits on stdout. Mirrors the
+// connector ABI's input/output envelope (sandbox.testdata.echo.main.go)
+// so the dev-run output looks the same as what the production runtime
+// surfaces to the LLM.
+type envelope struct {
+	Output map[string]any `json:"output,omitempty"`
+	Error  string         `json:"error,omitempty"`
+}
+
+// devResolver is a stub credential.Resolver that returns a fixed bearer
+// token from the environment. Used in place of the production
+// vault-backed resolver so a connector author can exercise the
+// credential-mediation path against real APIs without binding setup.
+type devResolver struct {
+	kind  string
+	token string
+}
+
+func newDevResolver(m *cstore.Manifest, token string) *devResolver {
+	r := &devResolver{token: token}
+	if m != nil && m.Capabilities.Credential != nil {
+		r.kind = m.Capabilities.Credential.Kind
+	}
+	return r
+}
+
+func (r *devResolver) Resolve(_ context.Context) (credential.Credential, error) {
+	if r.kind == "" {
+		// Connector did not declare a credential capability; resolver
+		// shouldn't be called at all in that case. If we are called,
+		// surface the same error production would.
+		return credential.Credential{}, credential.ErrNoBindingResolver
+	}
+	if r.token == "" {
+		return credential.Credential{}, credential.ErrBindingMissing
+	}
+	return credential.Credential{Kind: r.kind, Value: []byte(r.token)}, nil
+}

--- a/cmd/aileron-connector-dev-run/main_test.go
+++ b/cmd/aileron-connector-dev-run/main_test.go
@@ -1,0 +1,66 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/credential"
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+func TestDevResolver_NoCredentialDeclaredReturnsNoBindingResolver(t *testing.T) {
+	r := newDevResolver(&cstore.Manifest{}, "tok")
+	_, err := r.Resolve(context.Background())
+	if !errors.Is(err, credential.ErrNoBindingResolver) {
+		t.Fatalf("got %v, want ErrNoBindingResolver", err)
+	}
+}
+
+func TestDevResolver_NoTokenReturnsBindingMissing(t *testing.T) {
+	m := &cstore.Manifest{}
+	m.Capabilities.Credential = &cstore.ManifestCredential{Kind: "oauth2"}
+	r := newDevResolver(m, "")
+	_, err := r.Resolve(context.Background())
+	if !errors.Is(err, credential.ErrBindingMissing) {
+		t.Fatalf("got %v, want ErrBindingMissing", err)
+	}
+}
+
+func TestDevResolver_HappyPathReturnsCredential(t *testing.T) {
+	m := &cstore.Manifest{}
+	m.Capabilities.Credential = &cstore.ManifestCredential{Kind: "oauth2"}
+	r := newDevResolver(m, "ya29.test-token")
+
+	cred, err := r.Resolve(context.Background())
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if cred.Kind != "oauth2" {
+		t.Errorf("Kind = %q, want oauth2", cred.Kind)
+	}
+	if string(cred.Value) != "ya29.test-token" {
+		t.Errorf("Value = %q, want ya29.test-token", string(cred.Value))
+	}
+}
+
+func TestEnvelope_OutputShape(t *testing.T) {
+	got, err := json.Marshal(envelope{Output: map[string]any{"k": "v"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `{"output":{"k":"v"}}` {
+		t.Errorf("got %s", got)
+	}
+}
+
+func TestEnvelope_ErrorShape(t *testing.T) {
+	got, err := json.Marshal(envelope{Error: "boom"})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != `{"error":"boom"}` {
+		t.Errorf("got %s", got)
+	}
+}

--- a/go.work
+++ b/go.work
@@ -2,6 +2,7 @@ go 1.25.0
 
 use (
 	./cmd/aileron
+	./cmd/aileron-connector-dev-run
 	./cmd/aileron-enclave
 	./cmd/aileron-mcp
 	./cmd/aileron-sh


### PR DESCRIPTION
## Summary

A developer-only CLI for running an Aileron WASM connector against real external APIs without the install/binding/launch round-trip. Spawned out of #402: connector authors need a fast iteration loop for `aileron-connector-google` and the connectors that follow.

## Usage

\`\`\`sh
task build:connector-dev-run

# Get an OAuth token (e.g. https://developers.google.com/oauthplayground for Google).
export AILERON_DEV_TOKEN=ya29...

./build/aileron-connector-dev-run \\
  --wasm     ~/git/ALRubinger/aileron-connector-google/connector.wasm \\
  --manifest ~/git/ALRubinger/aileron-connector-google/connector/manifest.toml \\
  --op       list_recent_emails \\
  --args     '{"query":"is:unread","max_results":3}'
\`\`\`

Output:
- Connector logs → stderr (\`[connector <level>] <msg>\`)
- Final result → stdout as \`{"output": {...}}\` or \`{"error": "..."}\` (mirrors the production tool-result envelope)

## What it does

- Reads \`connector.wasm\` + \`manifest.toml\` from disk.
- Parses + validates the manifest via \`internal/cstore\` — same path the production install pipeline uses.
- Spins up \`internal/sandbox\` (Wazero runtime) with the manifest's \`[capabilities.network]\` grant. **The network policy is enforced exactly as in production**; calls outside the grant deny with \`capability_denied\`.
- Wires a stub \`credential.Resolver\` that returns the bearer token from \`AILERON_DEV_TOKEN\` for calls referencing the connector's \`[capabilities.credential].kind\`. No vault, no binding setup, but the same credential-mediation code path runs.
- Invokes via \`Connector.Invoke\` and prints the result.

## What it deliberately does NOT do

- **Not installed alongside \`aileron\`.** Lives in \`cmd/\` so it can import \`internal/sandbox\` directly. Connector authors build it locally; end users never see it.
- **No vault, no binding store.** The whole point is to skip those for fast iteration. Production credentials still flow through the real path (\`aileron binding setup\` → vault → resolver) once the connector ships.
- **No action manifest involvement.** The harness invokes a connector op directly; the action layer is exercised by the existing E2E flow (\`aileron action add\` → MCP discovery → \`POST /v1/actions/{name}/run\`).

## Verifying with the Google connector

Smoke-tested locally against \`aileron-connector-google\`:

- Without \`AILERON_DEV_TOKEN\`: harness surfaces the structured envelope correctly (\`binding_required: credential: no binding for this capability (boundary=sandbox)\`). Confirms the credential-mediation path runs.
- Connector logs are captured on stderr with structured level prefix.
- The manifest loads + validates cleanly through \`cstore.ParseManifest\` + \`cstore.ValidateManifest\` (the same code the install pipeline runs against published tarballs).

A live API test against Gmail with a real token requires the publisher \`client_id\` (gating on Google Cloud Console registration in #402) — not on the critical path for landing this harness.

## Test plan

- [x] \`task lint:go\` clean
- [x] \`task build:connector-dev-run\` builds
- [x] \`go test ./...\` green for the new package
- [x] Manual smoke test against \`aileron-connector-google/connector.wasm\` confirms envelope shape, credential-mediation path, and connector-log capture
- [ ] Live Gmail API call with a real token (pending Google Cloud Console registration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)