### PR TITLE
feat(cli): add aileron keyring trust/list/revoke

### DIFF
--- a/cmd/aileron/keyring.go
+++ b/cmd/aileron/keyring.go
@@ -1,0 +1,240 @@
+package main
+
+import (
+	"crypto/ed25519"
+	"crypto/sha256"
+	"encoding/base64"
+	"errors"
+	"fmt"
+	"io"
+	"io/fs"
+	"os"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+// runKeyring dispatches `aileron keyring <subcommand>` to one of the
+// keyring management subcommands. The keyring is the v1 source of
+// trust for connector signature verification (per ADR-0002): every
+// `aileron connector install` checks the binary's signature against
+// keys registered for the FQN's authority. Without an entry, install
+// fails closed with class signature_failure.
+//
+// The keyring file lives at `~/.aileron/keyring.json`; users edit it
+// to authorize a publisher (or use these subcommands).
+func runKeyring(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: aileron keyring <trust|list|revoke> [args...]")
+		return 1
+	}
+	switch args[0] {
+	case "trust":
+		return runKeyringTrust(args[1:], stdout, stderr)
+	case "list":
+		return runKeyringList(args[1:], stdout, stderr)
+	case "revoke":
+		return runKeyringRevoke(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown keyring subcommand: %q\n", args[0])
+		fmt.Fprintln(stderr, "usage: aileron keyring <trust|list|revoke> [args...]")
+		return 1
+	}
+}
+
+// runKeyringTrust adds a publisher's ed25519 public key to the local
+// keyring. The key file may be a PEM-encoded SubjectPublicKeyInfo (as
+// produced by `openssl pkey -pubout`) or a raw 32-byte ed25519 public
+// key encoded in base64. Adding a key the keyring already trusts for
+// the same authority is a no-op (so re-running the command after a
+// non-rotation is safe).
+func runKeyringTrust(args []string, stdout, stderr io.Writer) int {
+	if len(args) != 2 {
+		fmt.Fprintln(stderr, "usage: aileron keyring trust <authority> <pubkey-file>")
+		fmt.Fprintln(stderr, "  authority: e.g. github://ALRubinger/aileron-connector-google")
+		fmt.Fprintln(stderr, "  pubkey-file: PEM (openssl pkey -pubout) or base64 raw key file")
+		return 1
+	}
+	authority := args[0]
+	if authority == "" {
+		fmt.Fprintln(stderr, "error: authority cannot be empty")
+		return 1
+	}
+
+	pub, err := readPublicKey(args[1])
+	if err != nil {
+		fmt.Fprintf(stderr, "error: read public key: %v\n", err)
+		return 1
+	}
+
+	path := cstore.DefaultKeyringPath()
+	if path == "" {
+		fmt.Fprintln(stderr, "error: cannot determine home directory; set $HOME or write ~/.aileron/keyring.json by hand")
+		return 1
+	}
+	keyring, err := cstore.LoadKeyring(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: load keyring %q: %v\n", path, err)
+		return 1
+	}
+
+	if keyring.HasKey(authority, pub) {
+		fmt.Fprintf(stdout, "Already trusted: %s\n", authority)
+		fmt.Fprintf(stdout, "  Fingerprint: %s\n", fingerprint(pub))
+		fmt.Fprintf(stdout, "  Keyring: %s\n", path)
+		return 0
+	}
+
+	keyring.Add(authority, pub)
+	if err := keyring.SaveKeyring(path); err != nil {
+		fmt.Fprintf(stderr, "error: save keyring: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "✓ Trusted publisher %s\n", authority)
+	fmt.Fprintf(stdout, "  Fingerprint: %s\n", fingerprint(pub))
+	fmt.Fprintf(stdout, "  Keyring: %s\n", path)
+	return 0
+}
+
+// runKeyringList prints the trusted publishers and a fingerprint per
+// registered key. Stable output order — authorities sorted, keys
+// printed in the order the keyring loaded them.
+func runKeyringList(args []string, stdout, stderr io.Writer) int {
+	if len(args) != 0 {
+		fmt.Fprintln(stderr, "usage: aileron keyring list")
+		return 1
+	}
+	path := cstore.DefaultKeyringPath()
+	if path == "" {
+		fmt.Fprintln(stderr, "error: cannot determine home directory")
+		return 1
+	}
+	keyring, err := cstore.LoadKeyring(path)
+	if err != nil {
+		// Missing file → empty keyring; LoadKeyring returns nil error.
+		// Anything else here is a real malformation.
+		fmt.Fprintf(stderr, "error: load keyring %q: %v\n", path, err)
+		return 1
+	}
+
+	authorities := keyring.Authorities()
+	if len(authorities) == 0 {
+		fmt.Fprintln(stdout, "No trusted publishers.")
+		fmt.Fprintf(stdout, "  Keyring: %s\n", path)
+		fmt.Fprintln(stdout, "  Add one with `aileron keyring trust <authority> <pubkey-file>`.")
+		return 0
+	}
+
+	fmt.Fprintf(stdout, "Trusted publishers (%d):\n", len(authorities))
+	for _, authority := range authorities {
+		keys := keyring.Keys(authority)
+		fmt.Fprintf(stdout, "  %s  (%d %s)\n", authority, len(keys), pluralKeys(len(keys)))
+		for _, key := range keys {
+			fmt.Fprintf(stdout, "    %s\n", fingerprint(key))
+		}
+	}
+	fmt.Fprintf(stdout, "\nKeyring: %s\n", path)
+	return 0
+}
+
+// runKeyringRevoke removes every key registered for a publisher.
+// Subsequent install attempts for that authority fail closed until
+// the publisher is re-trusted. There is no per-key revocation in v1 —
+// rotation under one authority is rare enough that the additional
+// flag space is not worth carrying.
+func runKeyringRevoke(args []string, stdout, stderr io.Writer) int {
+	if len(args) != 1 {
+		fmt.Fprintln(stderr, "usage: aileron keyring revoke <authority>")
+		return 1
+	}
+	authority := args[0]
+	path := cstore.DefaultKeyringPath()
+	if path == "" {
+		fmt.Fprintln(stderr, "error: cannot determine home directory")
+		return 1
+	}
+	keyring, err := cstore.LoadKeyring(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: load keyring %q: %v\n", path, err)
+		return 1
+	}
+	if !keyring.Remove(authority) {
+		fmt.Fprintf(stdout, "Not trusted: %s (no change)\n", authority)
+		return 0
+	}
+	if err := keyring.SaveKeyring(path); err != nil {
+		fmt.Fprintf(stderr, "error: save keyring: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "✓ Revoked publisher %s\n", authority)
+	fmt.Fprintf(stdout, "  Keyring: %s\n", path)
+	return 0
+}
+
+// readPublicKey decodes an ed25519 public key from a file. Tries PEM
+// first (the format `openssl pkey -pubout` produces); falls back to
+// trimming whitespace and treating the contents as a base64 raw key.
+// Either form is acceptable in v1 — connector authors typically ship
+// PEM as their `keys/publisher.pub`, but operators wiring up a
+// keyring from a recovery snippet often paste the raw base64.
+func readPublicKey(path string) (ed25519.PublicKey, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, fmt.Errorf("file not found: %s", path)
+		}
+		return nil, err
+	}
+	if pub, pemErr := cstore.ParsePEMPublicKey(data); pemErr == nil {
+		return pub, nil
+	}
+	// Fall back to base64 raw form: strip whitespace then decode.
+	trimmed := stripWhitespace(string(data))
+	for _, enc := range []*base64.Encoding{
+		base64.StdEncoding,
+		base64.RawStdEncoding,
+		base64.URLEncoding,
+		base64.RawURLEncoding,
+	} {
+		if raw, err := enc.DecodeString(trimmed); err == nil {
+			if len(raw) == ed25519.PublicKeySize {
+				return ed25519.PublicKey(raw), nil
+			}
+			return nil, fmt.Errorf("decoded %d bytes; ed25519 public key must be %d bytes",
+				len(raw), ed25519.PublicKeySize)
+		}
+	}
+	return nil, fmt.Errorf("file %q is neither PEM nor base64-encoded raw ed25519 public key", path)
+}
+
+// stripWhitespace removes ASCII whitespace from s. Used to tolerate
+// pasted keys with stray newlines / spaces.
+func stripWhitespace(s string) string {
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		switch s[i] {
+		case ' ', '\t', '\n', '\r':
+			continue
+		default:
+			out = append(out, s[i])
+		}
+	}
+	return string(out)
+}
+
+// fingerprint returns a short, stable identifier for a public key —
+// the first 16 hex characters of SHA-256(key). Long enough to
+// disambiguate keys at a glance, short enough to fit on a terminal
+// line without wrapping. Same shape of fingerprint as the canonical
+// ssh-keygen / git short-hash idioms.
+func fingerprint(pub ed25519.PublicKey) string {
+	sum := sha256.Sum256(pub)
+	return "sha256:" + base64.RawStdEncoding.EncodeToString(sum[:])[:22]
+}
+
+func pluralKeys(n int) string {
+	if n == 1 {
+		return "key"
+	}
+	return "keys"
+}

--- a/cmd/aileron/keyring_test.go
+++ b/cmd/aileron/keyring_test.go
@@ -1,0 +1,321 @@
+package main
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+// genTestKey returns a fresh ed25519 keypair plus its PEM-encoded
+// public key (the form `openssl pkey -pubout` produces).
+func genTestKey(t *testing.T) (ed25519.PublicKey, []byte) {
+	t.Helper()
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+	return pub, pemBytes
+}
+
+// writeKey writes data to a freshly-named temp file inside dir and
+// returns the path.
+func writeKey(t *testing.T, dir, name string, data []byte) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, data, 0o600); err != nil {
+		t.Fatalf("write %s: %v", path, err)
+	}
+	return path
+}
+
+// withTempHome points $HOME at a fresh temp dir for the test, so the
+// CLI's DefaultKeyringPath() lands inside the test's filesystem and
+// the test does not pollute the user's real ~/.aileron.
+func withTempHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	return dir
+}
+
+// --- readPublicKey ---
+
+func TestReadPublicKey_PEMHappyPath(t *testing.T) {
+	dir := t.TempDir()
+	pub, pemBytes := genTestKey(t)
+	path := writeKey(t, dir, "publisher.pub", pemBytes)
+
+	got, err := readPublicKey(path)
+	if err != nil {
+		t.Fatalf("readPublicKey: %v", err)
+	}
+	if !ed25519.PublicKey(got).Equal(pub) {
+		t.Errorf("returned key does not match generated public key")
+	}
+}
+
+func TestReadPublicKey_RawBase64(t *testing.T) {
+	dir := t.TempDir()
+	pub, _ := genTestKey(t)
+	encoded := base64.StdEncoding.EncodeToString(pub)
+	path := writeKey(t, dir, "publisher.b64", []byte(encoded+"\n"))
+
+	got, err := readPublicKey(path)
+	if err != nil {
+		t.Fatalf("readPublicKey: %v", err)
+	}
+	if !ed25519.PublicKey(got).Equal(pub) {
+		t.Errorf("returned key does not match generated public key")
+	}
+}
+
+func TestReadPublicKey_MissingFile(t *testing.T) {
+	if _, err := readPublicKey(filepath.Join(t.TempDir(), "nope.pub")); err == nil {
+		t.Fatal("expected error for missing file")
+	}
+}
+
+func TestReadPublicKey_GarbageContents(t *testing.T) {
+	dir := t.TempDir()
+	path := writeKey(t, dir, "garbage", []byte("not a key"))
+	if _, err := readPublicKey(path); err == nil {
+		t.Fatal("expected error for garbage file contents")
+	}
+}
+
+// --- keyring trust ---
+
+func TestKeyringTrust_AddsKeyAndPersists(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	keyPath := writeKey(t, t.TempDir(), "publisher.pub", pemBytes)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring(
+		[]string{"trust", "github://example/repo", keyPath},
+		stdout, stderr,
+	)
+	if rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Trusted publisher github://example/repo") {
+		t.Errorf("expected success message; got: %s", stdout.String())
+	}
+
+	// Reload from disk and verify the key is persisted.
+	keyringPath := filepath.Join(home, ".aileron", "keyring.json")
+	kr, err := cstore.LoadKeyring(keyringPath)
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !kr.HasKey("github://example/repo", pub) {
+		t.Errorf("keyring at %s does not contain the trusted key", keyringPath)
+	}
+}
+
+func TestKeyringTrust_DuplicateAddIsNoOp(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	keyPath := writeKey(t, t.TempDir(), "publisher.pub", pemBytes)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "github://example/repo", keyPath}, stdout, stderr); rc != 0 {
+		t.Fatalf("first trust: rc = %d; stderr = %s", rc, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	rc := runKeyring([]string{"trust", "github://example/repo", keyPath}, stdout, stderr)
+	if rc != 0 {
+		t.Fatalf("re-trust rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Already trusted") {
+		t.Errorf("expected duplicate-add to print 'Already trusted'; got: %s", stdout.String())
+	}
+}
+
+func TestKeyringTrust_RotationAddsAlongsideExisting(t *testing.T) {
+	home := withTempHome(t)
+	pub1, pem1 := genTestKey(t)
+	pub2, pem2 := genTestKey(t)
+	dir := t.TempDir()
+	key1 := writeKey(t, dir, "k1.pub", pem1)
+	key2 := writeKey(t, dir, "k2.pub", pem2)
+
+	for _, kp := range []string{key1, key2} {
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if rc := runKeyring([]string{"trust", "github://example/repo", kp}, stdout, stderr); rc != 0 {
+			t.Fatalf("trust %s: rc = %d; stderr = %s", kp, rc, stderr.String())
+		}
+	}
+
+	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !kr.HasKey("github://example/repo", pub1) {
+		t.Error("first key not preserved after second trust")
+	}
+	if !kr.HasKey("github://example/repo", pub2) {
+		t.Error("second key not added")
+	}
+	if got := len(kr.Keys("github://example/repo")); got != 2 {
+		t.Errorf("len(keys) = %d, want 2", got)
+	}
+}
+
+func TestKeyringTrust_RejectsEmptyAuthority(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	keyPath := writeKey(t, t.TempDir(), "publisher.pub", pemBytes)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "", keyPath}, stdout, stderr); rc == 0 {
+		t.Fatal("expected non-zero exit for empty authority")
+	}
+}
+
+func TestKeyringTrust_WrongArgCount(t *testing.T) {
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "only-one-arg"}, stdout, stderr); rc == 0 {
+		t.Fatal("expected non-zero exit for missing pubkey-file arg")
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("expected usage hint; got: %s", stderr.String())
+	}
+}
+
+// --- keyring list ---
+
+func TestKeyringList_EmptyKeyring(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"list"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No trusted publishers") {
+		t.Errorf("expected empty-state message; got: %s", stdout.String())
+	}
+}
+
+func TestKeyringList_PrintsTrustedAuthoritiesSorted(t *testing.T) {
+	withTempHome(t)
+	_, pem1 := genTestKey(t)
+	_, pem2 := genTestKey(t)
+	dir := t.TempDir()
+	for authority, body := range map[string][]byte{
+		"github://b/second": pem1,
+		"github://a/first":  pem2,
+	} {
+		path := writeKey(t, dir, strings.ReplaceAll(authority, "/", "_")+".pub", body)
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if rc := runKeyring([]string{"trust", authority, path}, stdout, stderr); rc != 0 {
+			t.Fatalf("seed %q: stderr = %s", authority, stderr.String())
+		}
+	}
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"list"}, stdout, stderr); rc != 0 {
+		t.Fatalf("list rc = %d; stderr = %s", rc, stderr.String())
+	}
+	out := stdout.String()
+	idxA := strings.Index(out, "github://a/first")
+	idxB := strings.Index(out, "github://b/second")
+	if idxA < 0 || idxB < 0 {
+		t.Fatalf("expected both authorities in output; got: %s", out)
+	}
+	if idxA > idxB {
+		t.Errorf("expected sorted order (a before b); got: %s", out)
+	}
+}
+
+// --- keyring revoke ---
+
+func TestKeyringRevoke_RemovesAuthority(t *testing.T) {
+	home := withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	keyPath := writeKey(t, t.TempDir(), "publisher.pub", pemBytes)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "github://example/repo", keyPath}, stdout, stderr); rc != 0 {
+		t.Fatalf("trust: rc = %d; stderr = %s", rc, stderr.String())
+	}
+
+	stdout.Reset()
+	stderr.Reset()
+	if rc := runKeyring([]string{"revoke", "github://example/repo"}, stdout, stderr); rc != 0 {
+		t.Fatalf("revoke rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Revoked publisher") {
+		t.Errorf("expected revoke success message; got: %s", stdout.String())
+	}
+
+	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if len(kr.Authorities()) != 0 {
+		t.Errorf("expected empty keyring after revoke; got authorities = %v", kr.Authorities())
+	}
+}
+
+func TestKeyringRevoke_AbsentAuthorityIsHarmless(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"revoke", "github://nope/nope"}, stdout, stderr); rc != 0 {
+		t.Fatalf("revoke of absent authority should succeed quietly; rc = %d, stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Not trusted") {
+		t.Errorf("expected 'Not trusted' message; got: %s", stdout.String())
+	}
+}
+
+// --- dispatch ---
+
+func TestRunKeyring_NoSubcommand(t *testing.T) {
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring(nil, stdout, stderr); rc == 0 {
+		t.Fatal("expected non-zero exit when no subcommand given")
+	}
+}
+
+func TestRunKeyring_UnknownSubcommand(t *testing.T) {
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"sniff"}, stdout, stderr); rc == 0 {
+		t.Fatal("expected non-zero exit for unknown subcommand")
+	}
+	if !strings.Contains(stderr.String(), "unknown keyring subcommand") {
+		t.Errorf("expected 'unknown keyring subcommand' message; got: %s", stderr.String())
+	}
+}
+
+// --- fingerprint helper ---
+
+func TestFingerprint_StableAndShort(t *testing.T) {
+	pub, _ := genTestKey(t)
+	a := fingerprint(pub)
+	b := fingerprint(pub)
+	if a != b {
+		t.Errorf("fingerprint not stable: %q vs %q", a, b)
+	}
+	if !strings.HasPrefix(a, "sha256:") {
+		t.Errorf("expected sha256: prefix; got %q", a)
+	}
+	if got := len(a); got > 32 {
+		t.Errorf("fingerprint too long for terminal display: %d chars (%q)", got, a)
+	}
+}

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -104,6 +104,8 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		return runConnector(args[1:], stdout, stderr)
 	case "action":
 		return runAction(args[1:], os.Stdin, stdout, stderr)
+	case "keyring":
+		return runKeyring(args[1:], stdout, stderr)
 	case "status":
 		return runStatus(args[1:], stdout, stderr)
 	case "log":
@@ -131,6 +133,9 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron binding list               List credential bindings (metadata only — no unlock)")
 	fmt.Fprintln(w, "  aileron connector install <FQN>    Install a connector binary from its FQN")
 	fmt.Fprintln(w, "  aileron action add <FQN>           Install an action template from its FQN")
+	fmt.Fprintln(w, "  aileron keyring trust <auth> <key> Authorize a publisher's signing key for installs")
+	fmt.Fprintln(w, "  aileron keyring list               List trusted publishers and key fingerprints")
+	fmt.Fprintln(w, "  aileron keyring revoke <auth>      Remove a publisher's keys from the trust list")
 	fmt.Fprintln(w, "  aileron status [section]           Show merged config (policy, env, notifications, vault)")
 	fmt.Fprintln(w, "  aileron log [flags]                View the audit trail")
 	fmt.Fprintln(w, "  aileron version                    Print version information")

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -10,7 +10,6 @@ import (
 	"log/slog"
 	"net/http"
 	"os"
-	"path/filepath"
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/account"
@@ -614,7 +613,7 @@ func newConnectorInstaller(log *slog.Logger) *cstore.Installer {
 			"root", store.Root(), "error", err)
 		_ = store.RebuildIndex()
 	}
-	keyringPath := defaultKeyringPath()
+	keyringPath := cstore.DefaultKeyringPath()
 	keyring, err := cstore.LoadKeyring(keyringPath)
 	if err != nil {
 		log.Warn("failed to load keyring; falling back to empty (fail-closed)",
@@ -627,16 +626,4 @@ func newConnectorInstaller(log *slog.Logger) *cstore.Installer {
 		Verifier: keyring,
 		Store:    store,
 	}
-}
-
-// defaultKeyringPath returns the conventional path for the user's
-// publisher trust file: `$HOME/.aileron/keyring.json`. When the home
-// directory cannot be determined (test environments, edge cases),
-// returns an empty string — LoadKeyring treats that as a missing file.
-func defaultKeyringPath() string {
-	home, err := os.UserHomeDir()
-	if err != nil || home == "" {
-		return ""
-	}
-	return filepath.Join(home, ".aileron", "keyring.json")
 }

--- a/internal/cstore/keyring_config.go
+++ b/internal/cstore/keyring_config.go
@@ -2,12 +2,16 @@ package cstore
 
 import (
 	"crypto/ed25519"
+	"crypto/x509"
 	"encoding/base64"
 	"encoding/json"
+	"encoding/pem"
 	"errors"
 	"fmt"
 	"io/fs"
 	"os"
+	"path/filepath"
+	"sort"
 )
 
 // keyringFile is the JSON shape persisted at ~/.aileron/keyring.json
@@ -97,4 +101,137 @@ func decodeEd25519Pub(s string) (ed25519.PublicKey, error) {
 		return ed25519.PublicKey(bytes), nil
 	}
 	return nil, fmt.Errorf("not valid base64")
+}
+
+// SaveKeyring writes the keyring's current state to disk as the v1
+// JSON shape. Authorities are emitted in sorted order so successive
+// saves produce stable diffs. The file is written with mode 0600 to
+// match the surrounding ~/.aileron/ files (vault, secrets); parent
+// directories are created with 0700 if missing.
+//
+// Save is the inverse of LoadKeyring: a subsequent Load reads back an
+// equivalent keyring (modulo key ordering within each authority,
+// which the file format does not guarantee).
+func (k *Ed25519Keyring) SaveKeyring(path string) error {
+	k.mu.RLock()
+	doc := keyringFile{
+		Version:    1,
+		Publishers: make(map[string][]string, len(k.keys)),
+	}
+	for authority, pubs := range k.keys {
+		encoded := make([]string, 0, len(pubs))
+		for _, pub := range pubs {
+			encoded = append(encoded, base64.StdEncoding.EncodeToString(pub))
+		}
+		doc.Publishers[authority] = encoded
+	}
+	k.mu.RUnlock()
+
+	body, err := json.MarshalIndent(doc, "", "  ")
+	if err != nil {
+		return fmt.Errorf("marshal keyring: %w", err)
+	}
+	body = append(body, '\n')
+
+	if dir := filepath.Dir(path); dir != "" && dir != "." {
+		if err := os.MkdirAll(dir, 0o700); err != nil {
+			return fmt.Errorf("create keyring directory %q: %w", dir, err)
+		}
+	}
+	if err := os.WriteFile(path, body, 0o600); err != nil {
+		return fmt.Errorf("write keyring %q: %w", path, err)
+	}
+	return nil
+}
+
+// Authorities returns the authority strings the keyring has at least
+// one key registered for, in sorted order.
+func (k *Ed25519Keyring) Authorities() []string {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	out := make([]string, 0, len(k.keys))
+	for authority := range k.keys {
+		out = append(out, authority)
+	}
+	sort.Strings(out)
+	return out
+}
+
+// Keys returns a copy of the keys registered for an authority. Returns
+// nil if the authority is not present.
+func (k *Ed25519Keyring) Keys(authority string) []ed25519.PublicKey {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	src := k.keys[authority]
+	if src == nil {
+		return nil
+	}
+	out := make([]ed25519.PublicKey, len(src))
+	copy(out, src)
+	return out
+}
+
+// Remove drops every key registered for the authority. Returns true
+// when the authority was present (and its keys were removed), false
+// when the authority was not registered.
+func (k *Ed25519Keyring) Remove(authority string) bool {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	if _, ok := k.keys[authority]; !ok {
+		return false
+	}
+	delete(k.keys, authority)
+	return true
+}
+
+// HasKey reports whether the keyring already trusts the given public
+// key for the authority. Used by callers (e.g. `aileron keyring trust`)
+// to detect duplicate adds and avoid bloating the file with copies of
+// the same key on repeated invocation.
+func (k *Ed25519Keyring) HasKey(authority string, pub ed25519.PublicKey) bool {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	for _, existing := range k.keys[authority] {
+		if ed25519.PublicKey(existing).Equal(pub) {
+			return true
+		}
+	}
+	return false
+}
+
+// ParsePEMPublicKey decodes a PEM-encoded ed25519 public key
+// (SubjectPublicKeyInfo as produced by `openssl pkey -pubout`) into
+// the raw ed25519.PublicKey form Aileron's keyring stores. Returns
+// an error when the PEM block is missing, the algorithm is not
+// ed25519, or the encoded length is wrong.
+func ParsePEMPublicKey(pemBytes []byte) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("no PEM block found")
+	}
+	pub, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("parse PKIX public key: %w", err)
+	}
+	edPub, ok := pub.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("public key is not ed25519 (got %T)", pub)
+	}
+	if len(edPub) != ed25519.PublicKeySize {
+		return nil, fmt.Errorf("ed25519 public key has wrong length %d (want %d)",
+			len(edPub), ed25519.PublicKeySize)
+	}
+	return edPub, nil
+}
+
+// DefaultKeyringPath returns the conventional path
+// `$HOME/.aileron/keyring.json`. Returns "" when the user's home
+// directory cannot be determined; LoadKeyring treats that as a
+// missing file (empty keyring, fail-closed at install).
+func DefaultKeyringPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return filepath.Join(home, ".aileron", "keyring.json")
 }

--- a/internal/cstore/keyring_config_test.go
+++ b/internal/cstore/keyring_config_test.go
@@ -3,7 +3,9 @@ package cstore_test
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"crypto/x509"
 	"encoding/base64"
+	"encoding/pem"
 	"errors"
 	"os"
 	"path/filepath"
@@ -183,3 +185,237 @@ func TestLoadKeyring_RejectsEmptyAuthority(t *testing.T) {
 		t.Fatal("expected error on empty authority")
 	}
 }
+
+// --- SaveKeyring ---
+
+func TestSaveKeyring_RoundTripsEquivalentKeyring(t *testing.T) {
+	// Save → reload → verify the same keys come back. The file format
+	// guarantees authority equivalence; key order within an authority
+	// is order-of-insertion since that is what the keyringFile JSON
+	// preserves.
+	pubA, _, _ := ed25519.GenerateKey(rand.Reader)
+	pubB1, _, _ := ed25519.GenerateKey(rand.Reader)
+	pubB2, _, _ := ed25519.GenerateKey(rand.Reader)
+
+	kr := cstore.NewEd25519Keyring()
+	kr.Add("github://a/repo", pubA)
+	kr.Add("github://b/repo", pubB1)
+	kr.Add("github://b/repo", pubB2)
+
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	if err := kr.SaveKeyring(path); err != nil {
+		t.Fatalf("SaveKeyring: %v", err)
+	}
+
+	loaded, err := cstore.LoadKeyring(path)
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !loaded.HasKey("github://a/repo", pubA) {
+		t.Error("authority A's key not preserved")
+	}
+	if !loaded.HasKey("github://b/repo", pubB1) || !loaded.HasKey("github://b/repo", pubB2) {
+		t.Error("authority B's keys not preserved")
+	}
+}
+
+func TestSaveKeyring_CreatesParentDirectory(t *testing.T) {
+	// Save under a nested path that doesn't exist yet — should mkdir -p.
+	dir := t.TempDir()
+	path := filepath.Join(dir, "nested", ".aileron", "keyring.json")
+
+	kr := cstore.NewEd25519Keyring()
+	if err := kr.SaveKeyring(path); err != nil {
+		t.Fatalf("SaveKeyring should create parent dirs: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file not created: %v", err)
+	}
+}
+
+func TestSaveKeyring_FileMode0600(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	if err := cstore.NewEd25519Keyring().SaveKeyring(path); err != nil {
+		t.Fatalf("SaveKeyring: %v", err)
+	}
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	// We don't assert exact mode bits beyond the user-readable bit (umask
+	// can affect group/other on some platforms); the spec is "no
+	// world-readable trust file".
+	if info.Mode().Perm()&0o077 != 0 {
+		t.Errorf("file mode = %v; group/other bits should be unset", info.Mode().Perm())
+	}
+}
+
+// --- Authorities / Keys / Remove / HasKey ---
+
+func TestKeyringAuthorities_SortedAndDeduplicated(t *testing.T) {
+	pub1, _, _ := ed25519.GenerateKey(rand.Reader)
+	pub2, _, _ := ed25519.GenerateKey(rand.Reader)
+
+	kr := cstore.NewEd25519Keyring()
+	kr.Add("github://b/two", pub1)
+	kr.Add("github://a/one", pub2)
+	kr.Add("github://a/one", pub1) // second key under same authority
+
+	got := kr.Authorities()
+	want := []string{"github://a/one", "github://b/two"}
+	if len(got) != len(want) {
+		t.Fatalf("got %d authorities, want %d (%v)", len(got), len(want), got)
+	}
+	for i, w := range want {
+		if got[i] != w {
+			t.Errorf("Authorities[%d] = %q, want %q", i, got[i], w)
+		}
+	}
+}
+
+func TestKeyringKeys_ReturnsCopyNotOriginal(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	kr := cstore.NewEd25519Keyring()
+	kr.Add("github://x/y", pub)
+
+	keys := kr.Keys("github://x/y")
+	if len(keys) != 1 {
+		t.Fatalf("len(keys) = %d, want 1", len(keys))
+	}
+	keys[0] = ed25519.PublicKey(make([]byte, 32)) // mutate the copy
+
+	// Re-fetch and assert the original is untouched.
+	again := kr.Keys("github://x/y")
+	if !ed25519.PublicKey(again[0]).Equal(pub) {
+		t.Error("Keys() returned a slice aliased to the keyring's internal storage")
+	}
+}
+
+func TestKeyringKeys_UnknownAuthorityReturnsNil(t *testing.T) {
+	if got := cstore.NewEd25519Keyring().Keys("github://nope/nope"); got != nil {
+		t.Errorf("expected nil, got %v", got)
+	}
+}
+
+func TestKeyringRemove_ReturnsTrueOnHitFalseOnMiss(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	kr := cstore.NewEd25519Keyring()
+	kr.Add("github://x/y", pub)
+
+	if !kr.Remove("github://x/y") {
+		t.Error("Remove(present) = false; want true")
+	}
+	if kr.Remove("github://x/y") {
+		t.Error("Remove(absent after first remove) = true; want false")
+	}
+	if got := kr.Authorities(); len(got) != 0 {
+		t.Errorf("expected no authorities after Remove; got %v", got)
+	}
+}
+
+func TestKeyringHasKey_TrueOnlyForExactKey(t *testing.T) {
+	pub1, _, _ := ed25519.GenerateKey(rand.Reader)
+	pub2, _, _ := ed25519.GenerateKey(rand.Reader)
+	kr := cstore.NewEd25519Keyring()
+	kr.Add("github://x/y", pub1)
+
+	if !kr.HasKey("github://x/y", pub1) {
+		t.Error("HasKey should return true for added key")
+	}
+	if kr.HasKey("github://x/y", pub2) {
+		t.Error("HasKey should return false for a different key under same authority")
+	}
+	if kr.HasKey("github://other/repo", pub1) {
+		t.Error("HasKey should return false for a different authority")
+	}
+}
+
+// --- ParsePEMPublicKey ---
+
+func TestParsePEMPublicKey_HappyPath(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	pemBytes := makeTestPEM(t, pub)
+
+	got, err := cstore.ParsePEMPublicKey(pemBytes)
+	if err != nil {
+		t.Fatalf("ParsePEMPublicKey: %v", err)
+	}
+	if !ed25519.PublicKey(got).Equal(pub) {
+		t.Error("returned key does not match")
+	}
+}
+
+func TestParsePEMPublicKey_NoPEMBlock(t *testing.T) {
+	if _, err := cstore.ParsePEMPublicKey([]byte("not a pem block")); err == nil {
+		t.Fatal("expected error for non-PEM input")
+	}
+}
+
+func TestParsePEMPublicKey_GarbageDER(t *testing.T) {
+	// PEM block with non-DER contents.
+	bad := []byte("-----BEGIN PUBLIC KEY-----\nbm90LWRlcg==\n-----END PUBLIC KEY-----\n")
+	if _, err := cstore.ParsePEMPublicKey(bad); err == nil {
+		t.Fatal("expected error for non-DER PEM contents")
+	}
+}
+
+// --- DefaultKeyringPath ---
+
+func TestDefaultKeyringPath_FollowsHome(t *testing.T) {
+	t.Setenv("HOME", "/tmp/fake-home")
+	got := cstore.DefaultKeyringPath()
+	want := filepath.Join("/tmp/fake-home", ".aileron", "keyring.json")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDefaultKeyringPath_NoHomeReturnsEmpty(t *testing.T) {
+	// On unix-likes, unsetting HOME makes UserHomeDir return an error
+	// (no fallback). Skip the test on platforms where the runtime
+	// probes alternate sources (Windows looks at USERPROFILE etc.).
+	if _, err := os.UserHomeDir(); err == nil {
+		t.Setenv("HOME", "")
+		// Also clear the Windows fallback envs so the test is a real
+		// "no discoverable home" scenario across platforms.
+		t.Setenv("USERPROFILE", "")
+		t.Setenv("HOMEDRIVE", "")
+		t.Setenv("HOMEPATH", "")
+	}
+	if _, err := os.UserHomeDir(); err == nil {
+		t.Skip("UserHomeDir still resolves; can't simulate missing-home on this platform")
+	}
+	if got := cstore.DefaultKeyringPath(); got != "" {
+		t.Errorf("got %q; want empty when home is undiscoverable", got)
+	}
+}
+
+// --- LoadKeyring round-trip with tampered JSON ---
+
+func TestLoadKeyring_RetainsErrFromIO(t *testing.T) {
+	// Pass a directory path; ReadFile errors with EISDIR (or similar)
+	// — should not be a "missing file" no-op.
+	dir := t.TempDir()
+	if _, err := cstore.LoadKeyring(dir); err == nil {
+		t.Fatal("expected error when path is a directory")
+	}
+	// errors.Is(fs.ErrNotExist) must be false for this case.
+	if _, err := cstore.LoadKeyring(dir); errors.Is(err, os.ErrNotExist) {
+		t.Error("EISDIR was misinterpreted as missing file")
+	}
+}
+
+// makeTestPEM encodes the key's SubjectPublicKeyInfo as PEM. Mirrors
+// `openssl pkey -pubout` output, used to feed ParsePEMPublicKey.
+func makeTestPEM(t *testing.T, pub ed25519.PublicKey) []byte {
+	t.Helper()
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		t.Fatalf("MarshalPKIXPublicKey: %v", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der})
+}
+
+// _ silences an "unused import" warning when we strip the local
+// helpers in a future refactor; cheap insurance.
+var _ = base64.StdEncoding


### PR DESCRIPTION
## Summary

Adds an `aileron keyring` CLI so trusting a connector publisher no longer means hand-editing `~/.aileron/keyring.json`. The keyring loader's own source flagged this as future work (`internal/cstore/keyring_config.go:27-28`):

> the file is the v1 source of trust — users edit it (or a future `aileron keyring add` command does) to authorize a publisher.

This PR is the command. Three subcommands:

```sh
aileron keyring trust github://ALRubinger/aileron-connector-google ./publisher.pub
# ✓ Trusted publisher github://ALRubinger/aileron-connector-google
#   Fingerprint: sha256:tvkJIZ72HffY0lIUS95OPc
#   Keyring: /Users/alr/.aileron/keyring.json

aileron keyring list
# Trusted publishers (1):
#   github://ALRubinger/aileron-connector-google  (1 key)
#     sha256:tvkJIZ72HffY0lIUS95OPc

aileron keyring revoke github://ALRubinger/aileron-connector-google
# ✓ Revoked publisher github://ALRubinger/aileron-connector-google
```

## Trust model: per-repo for v0.x

Authority is `<scheme>://<owner>/<repo>`. One trust action covers exactly one repo. This is the v0.x shape decided in #408 — schema versioning is already in place (`keyring_config.go:25,61` requires `version: 1` and rejects anything else), so future migrations to owner-level / hybrid trust ship as `version: 2` without invalidating v1 entries. Per-repo is fine for the demo path; the design conversation for v2 stays in #408 and is triggered by the second-publisher-connector arriving, Hub identity landing, or install-time TOFU UX work — none of which is urgent today.

## Behavior

- `trust` accepts **PEM** (the form `openssl pkey -pubout` produces, what publishers commit to `keys/publisher.pub`) or a file containing a **base64-encoded raw 32-byte ed25519 public key** (the format the keyring file actually stores). Operators pasting a recovery snippet are not blocked by format mismatch.
- Adding a key the keyring already trusts under the same authority is a no-op — re-running is safe.
- New keys append rather than replace — supports key rotation per the `Ed25519Keyring` design (verifier accepts any registered key for the authority).
- `revoke` removes all keys for a given authority. Per-key revocation is deferred — rotation under one authority is rare enough that the extra flag space isn't worth carrying yet.
- Fingerprints are short (`sha256:` + first 22 base64 chars of SHA-256) — long enough to disambiguate, short enough to fit on a terminal line.

## Implementation

- `internal/cstore/keyring_config.go`: new methods on `Ed25519Keyring` (`SaveKeyring`, `Authorities`, `Keys`, `Remove`, `HasKey`) and package-level helpers (`ParsePEMPublicKey`, `DefaultKeyringPath`). The new API is the inverse of `LoadKeyring` — a save/load round-trip preserves the keyring. `SaveKeyring` writes `0600` and creates parent dirs with `0700`, matching the surrounding `~/.aileron/` files.
- `internal/app/app.go`: replaces the duplicated lowercase `defaultKeyringPath` helper with `cstore.DefaultKeyringPath`. Runtime and CLI now share one source of truth for the path.
- `cmd/aileron/keyring.go`: subcommand dispatch + the three operations.
- `cmd/aileron/main.go`: wires `case "keyring":` and updates `aileron help`.

## Test plan

- [x] `task lint:go` clean
- [x] `task test:go` green; `cmd/aileron` at 86.4%, `internal/cstore` at 87.2%
- [x] All new functions individually >80% coverage:
  - `SaveKeyring` 83.3%, `Authorities` 100%, `Keys` 100%, `Remove` 100%, `HasKey` 100%, `ParsePEMPublicKey` 83.3%, `DefaultKeyringPath` 100%
- [x] Smoke-tested end-to-end against a freshly-generated ed25519 keypair: trust → list → duplicate-trust (no-op) → revoke → list (empty). Verified `~/.aileron/keyring.json` schema matches the loader's expectations after each operation.
- [x] Used in the v0.0.4 E2E run with `aileron-connector-google`: `aileron keyring trust github://ALRubinger/aileron-connector-google ./keys/publisher.pub` → `aileron connector install ...@0.0.4` → signature verified → install succeeded. Same for the action tarball.

## Out of scope (followups, all gated on #408)

- **Auto-fetch via `aileron keyring trust github://...`** (without a local file argument). Would resolve the FQN to the publisher's `keys/publisher.pub` in their repo's `main` branch (raw URL or release artifact), download, present the fingerprint, prompt to confirm, then add. Higher-leverage UX but introduces a TOFU step worth designing once #408 settles the granularity question.
- **In-line trust prompt at `aileron connector install`** — when install hits an unknown authority, prompt "Trust this publisher? Show fingerprint, [y/N]". Best built on top of the auto-fetch above.
- **Per-key revocation** (`aileron keyring revoke <auth> <fingerprint>`). Marginal until rotation actually happens in the wild.
- **Owner-level / hybrid trust** — the granularity question itself. Lives in #408.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
