### PR TITLE
fix(server): use persistent vault when one exists at the canonical path

### DIFF
--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -3,6 +3,8 @@ package main
 
 import (
 	"context"
+	"fmt"
+	"io"
 	"log/slog"
 	"net/http"
 	"os"
@@ -11,6 +13,9 @@ import (
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/app"
+	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/vault"
+	"golang.org/x/term"
 )
 
 func main() {
@@ -39,7 +44,12 @@ func run(log *slog.Logger) error {
 		addr = ":8080"
 	}
 
-	handler, err := app.NewHandler(log)
+	cfg, err := selectVault(log, launch.DefaultVaultPath(), term.IsTerminal(int(os.Stdin.Fd())), nil, os.Stderr)
+	if err != nil {
+		return err
+	}
+
+	handler, err := app.NewHandlerWithConfig(log, cfg)
 	if err != nil {
 		return err
 	}
@@ -70,4 +80,54 @@ func run(log *slog.Logger) error {
 	defer cancel()
 
 	return srv.Shutdown(shutdownCtx)
+}
+
+// selectVault returns an [app.Config] with `Vault` set to a persistent
+// file vault unlocked from `vaultPath` when both conditions hold:
+//
+//  1. A vault file already exists at `vaultPath` (i.e. the user ran
+//     `aileron launch` or `aileron binding setup` previously and
+//     created one), and
+//  2. `isTTY` is true — needed so the passphrase prompt has somewhere
+//     to read from.
+//
+// Otherwise the returned config has `Vault: nil`, and
+// [app.NewHandlerWithConfig] falls back to its in-memory dev vault per
+// the comment in `internal/app/app.go`.
+//
+// Without this branch, the standalone server always took the in-memory
+// path, which silently dropped every credential binding the moment the
+// process exited — surfacing later as "action declares no [[bindings]]
+// entry for this connector" when the launch gateway tried to resolve
+// the same binding against the persistent file vault.
+//
+// Extracted from `run` so unit tests can exercise the branching
+// without bringing up an HTTP server. `prompter` is forwarded to
+// [launch.EnsureVault]; nil means use the package default which reads
+// from `/dev/tty`.
+func selectVault(log *slog.Logger, vaultPath string, isTTY bool, prompter launch.PassphrasePrompter, w io.Writer) (app.Config, error) {
+	state, err := vault.CheckState(vaultPath)
+	if err != nil {
+		// A vault file exists but is unreadable. This is a security
+		// signal (tamper or corruption) — fail-loud rather than
+		// silently dropping back to the in-memory dev vault, which
+		// would mask the issue and hide whatever bindings the user
+		// thought they had. Operators who want a clean memory-mode
+		// start can `rm` the file themselves.
+		return app.Config{}, fmt.Errorf("checking vault %q: %w", vaultPath, err)
+	}
+	if state == vault.StateMissing {
+		log.Info("no persistent vault found; using in-memory dev vault", "path", vaultPath)
+		return app.Config{}, nil
+	}
+	if !isTTY {
+		log.Info("no controlling tty; using in-memory dev vault", "path", vaultPath)
+		return app.Config{}, nil
+	}
+	log.Info("unlocking persistent vault", "path", vaultPath)
+	v, vErr := launch.EnsureVault(vaultPath, prompter, w, 3)
+	if vErr != nil {
+		return app.Config{}, vErr
+	}
+	return app.Config{Vault: v}, nil
 }

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -1,0 +1,127 @@
+package main
+
+import (
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// TestSelectVault_NoFileFallsBackToMemory verifies that the standalone
+// server uses the in-memory dev vault when no vault file exists at
+// the path. Other modes are gated on this state — if the file is
+// missing, the server should not attempt to prompt the user.
+func TestSelectVault_NoFileFallsBackToMemory(t *testing.T) {
+	dir := t.TempDir()
+	cfg, err := selectVault(slog.Default(), filepath.Join(dir, "secrets.json"), true, refusePrompter(t), io.Discard)
+	if err != nil {
+		t.Fatalf("selectVault: %v", err)
+	}
+	if cfg.Vault != nil {
+		t.Errorf("cfg.Vault = %v, want nil (in-memory fallback)", cfg.Vault)
+	}
+}
+
+// TestSelectVault_NonTTYFallsBackToMemoryEvenWithFile asserts that the
+// server does not attempt to unlock a persistent vault in headless
+// contexts (Docker, CI, systemd) — there is nowhere to prompt the
+// passphrase. Without this guard the server would block on read from
+// /dev/tty during startup.
+func TestSelectVault_NonTTYFallsBackToMemoryEvenWithFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	if _, err := vault.Init(path, "passphrase"); err != nil {
+		t.Fatalf("vault.Init: %v", err)
+	}
+
+	cfg, err := selectVault(slog.Default(), path, false /* isTTY */, refusePrompter(t), io.Discard)
+	if err != nil {
+		t.Fatalf("selectVault: %v", err)
+	}
+	if cfg.Vault != nil {
+		t.Errorf("cfg.Vault = %v, want nil (non-TTY should never unlock)", cfg.Vault)
+	}
+}
+
+// TestSelectVault_PresentFileAndTTYUnlocks is the regression test for
+// the bug this commit fixes: prior to this change the standalone
+// server always took the in-memory path, even when a persistent vault
+// file existed. That silently dropped every binding created via
+// `aileron binding setup` the moment the server process exited,
+// surfacing later as a "no [[bindings]] entry" error from the launch
+// gateway. After this change the server unlocks the persistent vault
+// when conditions allow.
+func TestSelectVault_PresentFileAndTTYUnlocks(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	const passphrase = "correct-horse-battery-staple"
+	if _, err := vault.Init(path, passphrase); err != nil {
+		t.Fatalf("vault.Init: %v", err)
+	}
+
+	cfg, err := selectVault(slog.Default(), path, true, scriptedPrompter(passphrase), io.Discard)
+	if err != nil {
+		t.Fatalf("selectVault: %v", err)
+	}
+	if cfg.Vault == nil {
+		t.Fatal("cfg.Vault is nil; expected the persistent vault to be unlocked and used")
+	}
+}
+
+// TestSelectVault_CorruptFileFailsStartup ensures the server start
+// fails loudly when a vault file exists but is unparseable, rather
+// than silently falling back to the in-memory dev vault. Falling
+// back would mask a security signal (the file may have been
+// tampered with) AND would orphan whatever bindings the user thought
+// they had — both worse outcomes than refusing to start.
+func TestSelectVault_CorruptFileFailsStartup(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "secrets.json")
+	if _, err := vault.Init(path, "p"); err != nil {
+		t.Fatalf("vault.Init: %v", err)
+	}
+	tamper(t, path)
+
+	_, err := selectVault(slog.Default(), path, true, refusePrompter(t), io.Discard)
+	if err == nil {
+		t.Fatal("selectVault: expected error for corrupt vault file, got nil")
+	}
+}
+
+// scriptedPrompter returns a PassphrasePrompter that always answers
+// with the given passphrase. Used to drive the unlock path in tests
+// without touching /dev/tty.
+func scriptedPrompter(passphrase string) launch.PassphrasePrompter {
+	return func(_ string, _ io.Writer) (string, error) {
+		return passphrase, nil
+	}
+}
+
+// refusePrompter returns a PassphrasePrompter that fails the test if
+// it is called. Used in cases where the path-under-test should never
+// reach the prompt step — calling the prompter is the test failure.
+func refusePrompter(t *testing.T) launch.PassphrasePrompter {
+	t.Helper()
+	return func(_ string, _ io.Writer) (string, error) {
+		t.Errorf("prompter was called; expected to short-circuit before prompting")
+		return "", nil
+	}
+}
+
+// tamper corrupts the vault file at `path` by overwriting its first
+// byte. Any subsequent vault.Unlock call returns vault.ErrVaultTampered.
+func tamper(t *testing.T, path string) {
+	t.Helper()
+	f, err := os.OpenFile(path, os.O_WRONLY, 0o600)
+	if err != nil {
+		t.Fatalf("open vault for tampering: %v", err)
+	}
+	defer f.Close()
+	if _, err := f.Write([]byte{0xff}); err != nil {
+		t.Fatalf("tamper write: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

The standalone server (`./build/server`, used by the install + binding CLI) always took the in-memory dev-mode vault — even when a persistent vault file existed at `~/.aileron/secrets.json`. Every credential binding written via `aileron binding setup` against the standalone server lived only in process memory and disappeared the moment the server exited, surfacing later as a misleading runtime error from the launch gateway:

```
the google connector action declares no [[bindings]] entry for the OAuth2 capability
```

The two halves of the system silently disagreed on which vault was authoritative.

## Repro

1. `./build/server &` (or `task build && ./build/server &`)
2. `./build/aileron connector install github://.../@vX.Y.Z`
3. `./build/aileron action add github://.../actions/.../@vX.Y.Z` — accept the OAuth prompt → complete consent → "Bound: oauth2/.../work"
4. `./build/aileron binding list` → shows the binding ✓
5. `pkill -f 'build/server' && ./build/aileron launch claude`
6. In Claude: invoke the action → `binding_required: action declares no [[bindings]] entry`

The binding never made it to disk because the standalone server was holding it in a process-local memory vault. Launch's embedded gateway uses `~/.aileron/secrets.json`. The two saw different state.

## Fix

At server startup, when a vault file exists at the canonical path AND we have a controlling TTY, call `launch.EnsureVault` to prompt for the passphrase and pass the unlocked vault into `app.NewHandlerWithConfig`. Bindings now persist across server restarts and are visible to the launch gateway, which has been using the same file all along.

The dev-mode in-memory fallback still kicks in for headless contexts (Docker, CI, tests) and when no vault file exists — that path is unchanged.

Corrupt or unreadable vault files now fail server startup loudly rather than silently dropping back to memory mode. Falling back would mask a security signal AND orphan whatever bindings the operator believed were persisted.

## Behavior matrix

| Vault file at `DefaultVaultPath()` | TTY | Behavior |
|---|---|---|
| Missing | * | In-memory dev vault (unchanged from before) |
| Present, valid | yes | Prompt for passphrase, unlock, use persistent vault |
| Present, valid | no  | In-memory dev vault (headless contexts) |
| Present, corrupt | * | Server fails to start; operator investigates |

## Why this lived

The bug was hidden by the test surface: existing E2E tests in `internal/app/handlers_install_e2e_test.go` build synthetic in-test vaults and never touch the standalone-server-vs-launch crossover. Bringing the v0.0.4 release of `aileron-connector-google` into Aileron exposed it for the first time.

## Test plan

- [x] `go test github.com/ALRubinger/aileron/internal/...` green; new `internal/server` package goes from 0 tests to 4 covering all branches
- [x] `selectVault` (the extracted helper) at 92.9% statement coverage
- [x] Existing `internal/launch` and `internal/app` tests unaffected (they don't share state with `selectVault`)
- [ ] After merge: bind via standalone server → kill server → `aileron launch claude` → invoke action → resolves binding ✓

## Followup (out of scope)

`launch.EnsureVault` and `launch.DefaultVaultPath` arguably belong in `internal/vault` since both server and launch consume them. Cross-package import (`server → launch`) works but inverts the conceptual dependency direction. Worth extracting to `internal/vault/unlock.go` in a separate PR — pure refactor, no behavior change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
