### PR TITLE
docs(mcp): clarify http_request only injects api_key bindings

### DIFF
--- a/cmd/aileron-mcp/main.go
+++ b/cmd/aileron-mcp/main.go
@@ -192,7 +192,7 @@ var draftReplyTool = toolDef{
 
 var httpRequestTool = toolDef{
 	Name:        "http_request",
-	Description: "Make an authenticated HTTP request. Aileron matches the URL against configured secrets and injects credentials. Requires human approval.",
+	Description: "Make an authenticated HTTP request to a URL covered by an api_key binding. Aileron matches the URL against configured api_key bindings (vault entries with kind=api_key and a url-pattern label) and injects the secret as a Bearer token. Does NOT inject OAuth credentials — OAuth bindings are scoped per-connector and reachable only via the bound connector's actions (see `aileron action add` for installed actions and `aileron binding list` for OAuth bindings). Requires human approval.",
 	InputSchema: schema{
 		Type: "object",
 		Properties: map[string]schemaProp{


### PR DESCRIPTION
## Summary
- Update the `http_request` tool description in `aileron-mcp` to spell out that it only injects **api_key** bindings (URL-pattern matched, Bearer-token injected) and explicitly does **not** inject OAuth credentials.
- Point agents at `aileron action add` / `aileron binding list` for the OAuth path, since OAuth bindings are scoped per-connector by ADR-0005's capability model.

## Why
Surfaced in the 2026-05-04 E2E demo: when a connector lacked a `send_email` action, the agent fell back to `http_request` against Gmail, hit a 401, and concluded the OAuth credential wasn't injected. That's a misdiagnosis — by design, OAuth bindings are not reachable from a generic `http_request`. The previous one-line description didn't disambiguate api_key vs oauth2 binding kinds, so the agent's reasoning was reasonable. The fix is a single description string.

Closes #416

## Test plan
- [x] `go build ./cmd/aileron-mcp/` succeeds
- [ ] Manual: run `aileron-mcp` and confirm the tool description in the MCP `tools/list` response matches the new wording

🤖 Generated with [Claude Code](https://claude.com/claude-code)