### PR TITLE
feat(ui): action-approvals surface on /approvals page

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -149,7 +149,16 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	}
 
 	// --- Notifier ---
-	notifier := notify.NewLogNotifier(log)
+	// Multi-notifier: log first (always works), desktop second (best-
+	// effort native OS notifications via osascript / notify-send). The
+	// desktop notifier is what nudges the user toward the webapp when
+	// an action-approval lands; the log notifier is the durable
+	// backstop. Slack / email notifiers (the existing rich-governance
+	// channels) compose into the same Multi when configured.
+	notifier := notify.NewMulti(
+		notify.NewLogNotifier(log),
+		notify.NewDesktopNotifier(log),
+	)
 
 	// --- LLM gateway (dual-protocol: OpenAI + Anthropic) ---
 	gatewayCfg, err := config.LoadGatewayConfig()
@@ -258,6 +267,25 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	// rich governance orchestrator above; converges with it post-MVP.
 	server.actionApprovals = approval.NewActionApprovalQueue(nil, nil)
 	server.actionApprovalTTL = 5 * time.Minute
+
+	// On Register, fire a notification so the user knows the agent is
+	// blocked. AILERON_WEBAPP_URL points at the webapp's /approvals
+	// page when set (typical: launch sets it after starting the
+	// gateway). When unset, the notification still fires but uses a
+	// fallback "Open the Aileron webapp" prompt — the operator at
+	// least sees that something is pending.
+	webappURL := os.Getenv("AILERON_WEBAPP_URL")
+	server.actionApprovals.SetOnRegister(func(a *approval.ActionApproval) {
+		summary := a.ActionName
+		if a.ConnectorFQN != "" {
+			summary = a.ActionName + " on " + a.ConnectorFQN
+		}
+		_ = notifier.Notify(context.Background(), notify.Notification{
+			ApprovalID: a.ID,
+			Summary:    summary,
+			ReviewURL:  webappURL,
+		})
+	})
 
 	// --- Intercept engine (stage 4) ---
 	// When augmentation is disabled (e.g. `aileron launch` with MCP as

--- a/internal/approval/action_queue.go
+++ b/internal/approval/action_queue.go
@@ -117,6 +117,19 @@ type ActionApprovalQueue struct {
 	// now returns "now" for RequestedAt and DecidedAt. Tests inject a
 	// fake clock.
 	now func() time.Time
+
+	// onRegister is invoked synchronously by Register after a new
+	// pending entry has been added. Production wiring fires a desktop
+	// notification + log line so the user knows to look at the webapp;
+	// tests inject a recorder. Nil = no-op.
+	//
+	// The callback runs on the Register caller's goroutine, so the
+	// runtime's RunAction is blocked behind it — it should be fast.
+	// Side-effects that may block (network, slow shell-out) should
+	// dispatch their own goroutine. Errors returned (or panics) are
+	// not propagated to Register's caller; this is a notification path,
+	// not a gating one.
+	onRegister func(*ActionApproval)
 }
 
 // NewActionApprovalQueue returns an empty queue using the supplied
@@ -136,11 +149,26 @@ func NewActionApprovalQueue(idGen func() string, now func() time.Time) *ActionAp
 	}
 }
 
-// Register creates and tracks a new pending approval. The returned
-// pointer is the caller's handle for [ActionApproval.Wait].
-func (q *ActionApprovalQueue) Register(actionName, connectorFQN, sessionID string, args map[string]any) *ActionApproval {
+// SetOnRegister installs a callback fired synchronously after each
+// successful Register. Pass nil to clear. Safe to call concurrently
+// with Register/List/Decide/Get; the swap is mutex-protected.
+//
+// Production wiring uses this to fire a desktop notification + log
+// line on each new pending approval so the user knows to look at the
+// webapp. Test code uses it to record call sequences.
+func (q *ActionApprovalQueue) SetOnRegister(fn func(*ActionApproval)) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
+	q.onRegister = fn
+}
+
+// Register creates and tracks a new pending approval. The returned
+// pointer is the caller's handle for [ActionApproval.Wait]. When an
+// onRegister callback has been installed via SetOnRegister, it is
+// invoked synchronously after the entry is in the map and before
+// Register returns. Callback errors / panics are not propagated.
+func (q *ActionApprovalQueue) Register(actionName, connectorFQN, sessionID string, args map[string]any) *ActionApproval {
+	q.mu.Lock()
 	a := &ActionApproval{
 		ID:           q.idGen(),
 		ActionName:   actionName,
@@ -151,6 +179,17 @@ func (q *ActionApprovalQueue) Register(actionName, connectorFQN, sessionID strin
 		decision:     make(chan ActionDecision, 1),
 	}
 	q.pending[a.ID] = a
+	cb := q.onRegister
+	q.mu.Unlock()
+	if cb != nil {
+		// Defer the panic recover so a misbehaving notifier never
+		// takes down RunAction. Notifications are nice-to-have; the
+		// queue's invariants must hold regardless.
+		func() {
+			defer func() { _ = recover() }()
+			cb(a)
+		}()
+	}
 	return a
 }
 

--- a/internal/approval/action_queue_test.go
+++ b/internal/approval/action_queue_test.go
@@ -188,6 +188,79 @@ func TestActionApprovalQueue_GetReturnsRegisteredEntry(t *testing.T) {
 	}
 }
 
+// TestActionApprovalQueue_OnRegisterCallbackFires asserts that the
+// hook installed via SetOnRegister is invoked for every Register, with
+// the exact pending entry as its argument. Production wiring uses this
+// to fire a desktop notification so the user knows the agent is
+// blocked; tests inject a recorder to drive the same path.
+func TestActionApprovalQueue_OnRegisterCallbackFires(t *testing.T) {
+	q := NewActionApprovalQueue(nil, nil)
+	var received []*ActionApproval
+	q.SetOnRegister(func(a *ActionApproval) {
+		received = append(received, a)
+	})
+
+	first := q.Register("send-email", "github://x/y", "sess-1", map[string]any{"to": "alice"})
+	second := q.Register("send-email", "github://x/y", "sess-2", nil)
+
+	if len(received) != 2 {
+		t.Fatalf("received len = %d, want 2", len(received))
+	}
+	if received[0].ID != first.ID || received[1].ID != second.ID {
+		t.Errorf("callback ids = [%s, %s], want [%s, %s]",
+			received[0].ID, received[1].ID, first.ID, second.ID)
+	}
+	// The callback gets the same pointer the caller does — the queue
+	// shouldn't be defensively copying. The webapp's notification
+	// payload reads ActionName / ConnectorFQN / Args directly off it.
+	if received[0].ActionName != "send-email" {
+		t.Errorf("callback received[0].ActionName = %q", received[0].ActionName)
+	}
+}
+
+// TestActionApprovalQueue_OnRegisterPanicDoesNotPropagate asserts the
+// fail-soft contract: a misbehaving callback (panic, slow, whatever)
+// does not break Register. The queue's invariants must hold regardless
+// of what the notifier does. Without this guarantee, a buggy notifier
+// would prevent the agent's tool call from registering — much worse
+// than no notification.
+func TestActionApprovalQueue_OnRegisterPanicDoesNotPropagate(t *testing.T) {
+	q := NewActionApprovalQueue(nil, nil)
+	q.SetOnRegister(func(_ *ActionApproval) {
+		panic("notifier blew up")
+	})
+
+	// If panic propagates, this Register call panics out of the test;
+	// the recover'd path returns normally.
+	a := q.Register("send-email", "github://x/y", "", nil)
+	if a == nil || a.ID == "" {
+		t.Fatal("Register returned nil despite recovered panic")
+	}
+	// Entry is still in the queue.
+	if got, ok := q.Get(a.ID); !ok || got.ID != a.ID {
+		t.Errorf("Get(%s) ok=%v, expected entry to be registered despite callback panic", a.ID, ok)
+	}
+}
+
+// TestActionApprovalQueue_SetOnRegisterClearsCallback covers the
+// SetOnRegister(nil) path: clearing the callback returns Register to
+// its no-op-on-side-effects behavior.
+func TestActionApprovalQueue_SetOnRegisterClearsCallback(t *testing.T) {
+	q := NewActionApprovalQueue(nil, nil)
+	called := 0
+	q.SetOnRegister(func(_ *ActionApproval) { called++ })
+	q.Register("a", "x", "", nil)
+	if called != 1 {
+		t.Fatalf("after first Register: called = %d, want 1", called)
+	}
+
+	q.SetOnRegister(nil)
+	q.Register("b", "x", "", nil)
+	if called != 1 {
+		t.Errorf("after SetOnRegister(nil) + Register: called = %d, want still 1", called)
+	}
+}
+
 // TestActionApprovalQueue_ConcurrentDecides verifies that Register +
 // Decide is safe under concurrent access. The queue lives in the
 // apiServer and is shared by every action-run handler; locking has

--- a/internal/notify/desktop.go
+++ b/internal/notify/desktop.go
@@ -1,0 +1,171 @@
+package notify
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"os/exec"
+	"runtime"
+	"strings"
+)
+
+// DesktopNotifier delivers approval requests as native operating-system
+// notifications (macOS Notification Center, Linux notify-send). The
+// surface is best-effort and fails open: when the platform isn't
+// supported, the underlying binary is missing, or the shell-out
+// errors, the notifier logs a warning and returns nil. Notifications
+// are a nice-to-have to nudge the user toward the webapp — if they
+// don't fire, the queue still works, the user can still discover
+// pending entries by visiting /approvals directly.
+//
+// Per-platform behavior:
+//
+//   - darwin: shells out to `osascript -e 'display notification ...'`.
+//     Always available on macOS; no install required. Title appears
+//     in bold; subtitle below; body in the click-through area.
+//   - linux: shells out to `notify-send`. Requires the libnotify
+//     bin/devel package (e.g. `apt install libnotify-bin`); we don't
+//     install it for the user.
+//   - other (windows, freebsd, etc.): no-op. Logged once per Notify
+//     call so the operator can see why notifications aren't appearing.
+//
+// Defense in depth: we never accept arbitrary shell input — every
+// argument crosses the boundary as exec.Command argv, never via
+// `sh -c`, so an attacker-controlled action name in the Summary can't
+// shell-inject. The osascript path passes a single AppleScript
+// literal that we sanitize for embedded double quotes, the only
+// character that can break the literal.
+type DesktopNotifier struct {
+	log *slog.Logger
+	// runner is the exec hook. Tests inject a fake; production uses
+	// runReal which calls exec.CommandContext.
+	runner func(ctx context.Context, name string, args ...string) error
+	// goos is the platform string used for dispatch. Defaults to
+	// runtime.GOOS in NewDesktopNotifier; tests override it directly
+	// so every branch is reachable on any host without skip-on-GOOS.
+	goos string
+}
+
+// NewDesktopNotifier returns a DesktopNotifier wired to real `os/exec`
+// and the host's runtime.GOOS for platform dispatch. Pass a nil logger
+// to use slog.Default.
+func NewDesktopNotifier(log *slog.Logger) *DesktopNotifier {
+	if log == nil {
+		log = slog.Default()
+	}
+	return &DesktopNotifier{
+		log:    log,
+		runner: runReal,
+		goos:   runtime.GOOS,
+	}
+}
+
+// Notify implements [Notifier]. The Summary becomes the notification
+// body; ReviewURL is appended so the user has a clickable target.
+// Approvers and IntentID are unused on this surface — the desktop
+// notifier is the single-user case (#418) where the rich governance
+// fields don't apply.
+func (n *DesktopNotifier) Notify(ctx context.Context, notif Notification) error {
+	switch n.goos {
+	case "darwin":
+		return n.notifyDarwin(ctx, notif)
+	case "linux":
+		return n.notifyLinux(ctx, notif)
+	default:
+		n.log.Warn("desktop notifications not supported on this platform",
+			"goos", n.goos,
+			"approval_id", notif.ApprovalID,
+			"summary", notif.Summary,
+		)
+		return nil
+	}
+}
+
+// notifyDarwin invokes osascript with a single `display notification`
+// command. Format:
+//
+//	osascript -e 'display notification "BODY" with title "TITLE" subtitle "SUB"'
+//
+// Apple's display-notification command takes literal strings; we
+// quote-escape any double quotes in the input fields so the literal
+// closes correctly. AppleScript has no shell-style command injection
+// here because the whole thing crosses as one argv element.
+func (n *DesktopNotifier) notifyDarwin(ctx context.Context, notif Notification) error {
+	title := "Aileron approval"
+	subtitle := truncate(notif.Summary, 80)
+	body := notif.ReviewURL
+	if body == "" {
+		body = "Open the Aileron webapp to approve or deny."
+	}
+	script := fmt.Sprintf(
+		`display notification "%s" with title "%s" subtitle "%s"`,
+		escapeAppleScript(body),
+		escapeAppleScript(title),
+		escapeAppleScript(subtitle),
+	)
+	if err := n.runner(ctx, "osascript", "-e", script); err != nil {
+		n.log.Warn("desktop notification failed (osascript)",
+			"error", err,
+			"approval_id", notif.ApprovalID,
+		)
+		return nil
+	}
+	return nil
+}
+
+// notifyLinux invokes notify-send with the standard summary + body
+// argument shape. When the binary isn't installed, exec.Command
+// returns an error which we swallow with a logged warning.
+func (n *DesktopNotifier) notifyLinux(ctx context.Context, notif Notification) error {
+	title := "Aileron approval"
+	summary := truncate(notif.Summary, 80)
+	body := notif.ReviewURL
+	if body == "" {
+		body = "Open the Aileron webapp to approve or deny."
+	}
+	combined := summary
+	if body != "" {
+		combined = summary + "\n" + body
+	}
+	if err := n.runner(ctx, "notify-send", "-a", "Aileron", title, combined); err != nil {
+		n.log.Warn("desktop notification failed (notify-send)",
+			"error", err,
+			"approval_id", notif.ApprovalID,
+			"hint", "install libnotify-bin if missing",
+		)
+		return nil
+	}
+	return nil
+}
+
+// runReal is the production exec hook. Tests inject a fake to assert
+// the right commands are invoked without actually shelling out.
+func runReal(ctx context.Context, name string, args ...string) error {
+	cmd := exec.CommandContext(ctx, name, args...)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		return fmt.Errorf("%s: %w (output: %s)", name, err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// escapeAppleScript escapes the only AppleScript literal-breaking
+// character relevant for notification text: double quotes. Backslashes
+// are literal in AppleScript strings (no escape sequences), so this
+// is a single-character pass.
+func escapeAppleScript(s string) string {
+	return strings.ReplaceAll(s, `"`, `\"`)
+}
+
+// truncate caps a notification field at n characters. Both macOS and
+// Linux truncate longer strings anyway, but they do it ungracefully —
+// we'd rather control the cutoff than have the OS clip mid-word.
+func truncate(s string, n int) string {
+	if len(s) <= n {
+		return s
+	}
+	if n <= 1 {
+		return s[:n]
+	}
+	return s[:n-1] + "…"
+}

--- a/internal/notify/desktop_test.go
+++ b/internal/notify/desktop_test.go
@@ -1,0 +1,291 @@
+package notify
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"runtime"
+	"strings"
+	"testing"
+)
+
+// recordingRunner is a fake exec hook used by the tests below to
+// capture argv without shelling out. cmds is the sequence of recorded
+// invocations (one entry per Run call); err is what each call returns.
+type recordingRunner struct {
+	cmds [][]string
+	err  error
+}
+
+func (r *recordingRunner) run(_ context.Context, name string, args ...string) error {
+	r.cmds = append(r.cmds, append([]string{name}, args...))
+	return r.err
+}
+
+// newTestNotifier returns a DesktopNotifier with the supplied exec
+// runner and platform string. Driving the platform dispatch via the
+// `goos` field — rather than runtime.GOOS — lets every branch run on
+// any host without skip-on-GOOS (which would leak coverage on CI
+// systems that don't have one of the platforms).
+func newTestNotifier(goos string, runner func(ctx context.Context, name string, args ...string) error) *DesktopNotifier {
+	return &DesktopNotifier{
+		log:    slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		runner: runner,
+		goos:   goos,
+	}
+}
+
+// TestNewDesktopNotifier_DefaultsToHostGOOS covers the constructor:
+// production wiring should pick up the host's runtime.GOOS so the
+// dispatch picks the right platform branch without any extra config.
+func TestNewDesktopNotifier_DefaultsToHostGOOS(t *testing.T) {
+	n := NewDesktopNotifier(slog.New(slog.NewJSONHandler(io.Discard, nil)))
+	if n.goos != runtime.GOOS {
+		t.Errorf("goos = %q, want %q", n.goos, runtime.GOOS)
+	}
+	if n.runner == nil {
+		t.Error("runner is nil; constructor must wire runReal")
+	}
+}
+
+// TestNewDesktopNotifier_NilLoggerUsesDefault asserts the constructor
+// gracefully handles a nil logger argument (production wiring may not
+// always have a slog.Logger handy at construction time).
+func TestNewDesktopNotifier_NilLoggerUsesDefault(t *testing.T) {
+	n := NewDesktopNotifier(nil)
+	if n.log == nil {
+		t.Error("log is nil after NewDesktopNotifier(nil); want slog.Default")
+	}
+}
+
+// TestDesktopNotifier_DarwinShellsOutToOSAScript covers the macOS
+// path. Every branch runs on every host because we drive `goos`
+// directly rather than skipping on runtime.GOOS.
+func TestDesktopNotifier_DarwinShellsOutToOSAScript(t *testing.T) {
+	rec := &recordingRunner{}
+	n := newTestNotifier("darwin", rec.run)
+
+	err := n.Notify(context.Background(), Notification{
+		ApprovalID: "act-1",
+		Summary:    "send-email on github://x/y",
+		ReviewURL:  "http://127.0.0.1:5173/approvals",
+	})
+	if err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if len(rec.cmds) != 1 {
+		t.Fatalf("got %d cmds, want 1: %+v", len(rec.cmds), rec.cmds)
+	}
+	cmd := rec.cmds[0]
+	if cmd[0] != "osascript" {
+		t.Errorf("argv[0] = %q, want osascript", cmd[0])
+	}
+	if len(cmd) != 3 || cmd[1] != "-e" {
+		t.Fatalf("argv = %v, want [osascript -e <script>]", cmd)
+	}
+	script := cmd[2]
+	for _, want := range []string{
+		`display notification "http://127.0.0.1:5173/approvals"`,
+		`with title "Aileron approval"`,
+		`subtitle "send-email on github://x/y"`,
+	} {
+		if !strings.Contains(script, want) {
+			t.Errorf("script missing %q\nfull:\n%s", want, script)
+		}
+	}
+}
+
+// TestDesktopNotifier_LinuxShellsOutToNotifySend mirrors the macOS
+// test for the Linux path. notify-send takes a separate `-a` for the
+// app name and a `<title>` `<body>` pair, with the body containing
+// summary + URL on separate lines.
+func TestDesktopNotifier_LinuxShellsOutToNotifySend(t *testing.T) {
+	rec := &recordingRunner{}
+	n := newTestNotifier("linux", rec.run)
+
+	err := n.Notify(context.Background(), Notification{
+		ApprovalID: "act-1",
+		Summary:    "send-email",
+		ReviewURL:  "http://127.0.0.1:5173/approvals",
+	})
+	if err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if len(rec.cmds) != 1 {
+		t.Fatalf("got %d cmds, want 1: %+v", len(rec.cmds), rec.cmds)
+	}
+	cmd := rec.cmds[0]
+	if cmd[0] != "notify-send" {
+		t.Errorf("argv[0] = %q, want notify-send", cmd[0])
+	}
+	if len(cmd) < 5 {
+		t.Fatalf("argv = %v, want at least [notify-send -a Aileron <title> <body>]", cmd)
+	}
+	if cmd[1] != "-a" || cmd[2] != "Aileron" {
+		t.Errorf("argv[1:3] = %v, want [-a Aileron]", cmd[1:3])
+	}
+	if cmd[3] != "Aileron approval" {
+		t.Errorf("title = %q, want Aileron approval", cmd[3])
+	}
+	body := cmd[4]
+	if !strings.Contains(body, "send-email") {
+		t.Errorf("body missing summary; got %q", body)
+	}
+	if !strings.Contains(body, "http://127.0.0.1:5173/approvals") {
+		t.Errorf("body missing URL; got %q", body)
+	}
+}
+
+// TestDesktopNotifier_DarwinFailureReturnsNilAndLogs asserts the
+// fail-soft contract on darwin's path: when osascript errors (e.g.
+// silently denied by user-config), Notify returns nil. Notifications
+// are best-effort; the queue's invariants don't depend on them firing.
+func TestDesktopNotifier_DarwinFailureReturnsNilAndLogs(t *testing.T) {
+	rec := &recordingRunner{err: errors.New("simulated osascript failure")}
+	n := newTestNotifier("darwin", rec.run)
+	err := n.Notify(context.Background(), Notification{
+		ApprovalID: "act-1", Summary: "send-email", ReviewURL: "http://example.com",
+	})
+	if err != nil {
+		t.Errorf("Notify err = %v, want nil (fail-soft)", err)
+	}
+}
+
+// TestDesktopNotifier_LinuxFailureReturnsNilAndLogs covers the
+// missing-binary case on Linux: notify-send not installed → exec
+// returns an error → we swallow with a logged warning.
+func TestDesktopNotifier_LinuxFailureReturnsNilAndLogs(t *testing.T) {
+	rec := &recordingRunner{err: errors.New("notify-send: command not found")}
+	n := newTestNotifier("linux", rec.run)
+	err := n.Notify(context.Background(), Notification{
+		ApprovalID: "act-1", Summary: "send-email", ReviewURL: "http://example.com",
+	})
+	if err != nil {
+		t.Errorf("Notify err = %v, want nil (fail-soft)", err)
+	}
+}
+
+// TestDesktopNotifier_UnsupportedPlatformIsNoOp asserts that platforms
+// without a desktop-notification path return nil without invoking the
+// runner. The runner's recording stays empty.
+func TestDesktopNotifier_UnsupportedPlatformIsNoOp(t *testing.T) {
+	rec := &recordingRunner{}
+	n := newTestNotifier("plan9", rec.run)
+	if err := n.Notify(context.Background(), Notification{
+		ApprovalID: "act-1",
+		Summary:    "send-email",
+	}); err != nil {
+		t.Errorf("Notify err = %v, want nil", err)
+	}
+	if len(rec.cmds) != 0 {
+		t.Errorf("recorded %d cmds, want 0 on unsupported platform", len(rec.cmds))
+	}
+}
+
+// TestDesktopNotifier_DarwinFallbackBodyWhenURLEmpty covers the case
+// where AILERON_WEBAPP_URL isn't configured: the notification still
+// fires with a fallback prompt rather than dropping the URL silently.
+// Same fallback applies on linux; this test asserts the darwin
+// branch's behavior.
+func TestDesktopNotifier_DarwinFallbackBodyWhenURLEmpty(t *testing.T) {
+	rec := &recordingRunner{}
+	n := newTestNotifier("darwin", rec.run)
+	if err := n.Notify(context.Background(), Notification{
+		ApprovalID: "act-1", Summary: "send-email", ReviewURL: "",
+	}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if len(rec.cmds) != 1 {
+		t.Fatalf("cmds = %v", rec.cmds)
+	}
+	combined := strings.Join(rec.cmds[0], " ")
+	if !strings.Contains(combined, "Open the Aileron webapp") {
+		t.Errorf("expected fallback prompt; got %q", combined)
+	}
+}
+
+// TestDesktopNotifier_LinuxFallbackBodyWhenURLEmpty mirrors the
+// darwin fallback test for linux's notify-send path.
+func TestDesktopNotifier_LinuxFallbackBodyWhenURLEmpty(t *testing.T) {
+	rec := &recordingRunner{}
+	n := newTestNotifier("linux", rec.run)
+	if err := n.Notify(context.Background(), Notification{
+		ApprovalID: "act-1", Summary: "send-email", ReviewURL: "",
+	}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if len(rec.cmds) != 1 {
+		t.Fatalf("cmds = %v", rec.cmds)
+	}
+	combined := strings.Join(rec.cmds[0], " ")
+	if !strings.Contains(combined, "Open the Aileron webapp") {
+		t.Errorf("expected fallback prompt; got %q", combined)
+	}
+}
+
+// TestDesktopNotifier_EscapesAppleScriptDoubleQuotes verifies that an
+// action name carrying double quotes (e.g. `send "weekly recap"`)
+// can't break the AppleScript literal — the `\"` escape closes the
+// string cleanly. AppleScript has no shell-meta interpretation here
+// (the whole script is one argv element), so this is just literal-
+// breaking, not an injection vector — but it would still produce a
+// non-firing notification without the escape.
+func TestDesktopNotifier_EscapesAppleScriptDoubleQuotes(t *testing.T) {
+	rec := &recordingRunner{}
+	n := newTestNotifier("darwin", rec.run)
+	_ = n.Notify(context.Background(), Notification{
+		ApprovalID: "act-1",
+		Summary:    `send "weekly recap"`,
+		ReviewURL:  "http://example.com",
+	})
+	if len(rec.cmds) != 1 {
+		t.Fatalf("cmds = %v", rec.cmds)
+	}
+	script := rec.cmds[0][2]
+	if !strings.Contains(script, `subtitle "send \"weekly recap\""`) {
+		t.Errorf("expected escaped quotes in subtitle; got %q", script)
+	}
+}
+
+// TestEscapeAppleScript covers the helper directly: backslashes are
+// literal in AppleScript strings (no escape sequences), so the only
+// character to escape is a double quote.
+func TestEscapeAppleScript(t *testing.T) {
+	cases := []struct{ in, want string }{
+		{"plain", "plain"},
+		{`with "quote"`, `with \"quote\"`},
+		{`backslash \ stays`, `backslash \ stays`},
+		{"", ""},
+	}
+	for _, c := range cases {
+		if got := escapeAppleScript(c.in); got != c.want {
+			t.Errorf("escapeAppleScript(%q) = %q, want %q", c.in, got, c.want)
+		}
+	}
+}
+
+// TestTruncate covers the cap helper: under-cap stays as-is; at-cap
+// stays as-is; over-cap gets truncated with an ellipsis to indicate
+// the cut. The n=1 / n=0 edge cases trip up naive implementations
+// (subtracting `n-1` for the ellipsis would underflow); the helper
+// hard-cuts at byte boundaries instead.
+func TestTruncate(t *testing.T) {
+	cases := []struct {
+		in   string
+		n    int
+		want string
+	}{
+		{"short", 10, "short"},
+		{"exact-len", 9, "exact-len"},
+		{"this is a long string", 10, "this is a…"},
+		{"", 5, ""},
+		{"abc", 1, "a"},  // n=1: ellipsis would leave nothing; hard-cut.
+		{"abc", 0, ""},   // n=0: nothing fits.
+	}
+	for _, c := range cases {
+		if got := truncate(c.in, c.n); got != c.want {
+			t.Errorf("truncate(%q, %d) = %q, want %q", c.in, c.n, got, c.want)
+		}
+	}
+}

--- a/internal/notify/log_test.go
+++ b/internal/notify/log_test.go
@@ -1,0 +1,129 @@
+package notify
+
+import (
+	"bytes"
+	"context"
+	"log/slog"
+	"strings"
+	"testing"
+)
+
+// TestLogNotifier_NotifyEmitsStructuredFields verifies that the
+// LogNotifier carries every field a downstream log scraper would
+// want to filter on. Approval id and the review URL are the
+// load-bearing ones — without them the log line tells the operator
+// "something happened" but not which approval or where to act.
+func TestLogNotifier_NotifyEmitsStructuredFields(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	n := NewLogNotifier(log)
+
+	err := n.Notify(context.Background(), Notification{
+		ApprovalID:  "act-1",
+		IntentID:    "int-1",
+		WorkspaceID: "ws-1",
+		Summary:     "send-email on github://x/y",
+		ReviewURL:   "http://127.0.0.1:5173/approvals",
+		Approvers: []Approver{
+			{PrincipalID: "user:alr", DisplayName: "Andrew", Contact: "alr@example.com"},
+		},
+	})
+	if err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	out := buf.String()
+	for _, want := range []string{
+		`"approval_id":"act-1"`,
+		`"intent_id":"int-1"`,
+		`"summary":"send-email on github://x/y"`,
+		`"review_url":"http://127.0.0.1:5173/approvals"`,
+		`"approvers":1`,
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("log line missing %q\nfull:\n%s", want, out)
+		}
+	}
+}
+
+// TestNewLogNotifier_NonNilLogger covers the constructor's basic
+// contract: pass a logger, get a notifier wired to it.
+func TestNewLogNotifier_NonNilLogger(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, nil))
+	n := NewLogNotifier(log)
+	if n == nil {
+		t.Fatal("NewLogNotifier returned nil")
+	}
+	if n.log != log {
+		t.Error("logger not stored on notifier")
+	}
+}
+
+// TestMulti_NotifyDispatchesToAll asserts that NewMulti sends a single
+// Notification to every wrapped notifier, in order. Used by the app
+// wiring to compose log + desktop (and future Slack / email).
+func TestMulti_NotifyDispatchesToAll(t *testing.T) {
+	calls := 0
+	notif := &recordingNotifier{onNotify: func(_ Notification) error {
+		calls++
+		return nil
+	}}
+	m := NewMulti(notif, notif, notif)
+	if err := m.Notify(context.Background(), Notification{ApprovalID: "act-1"}); err != nil {
+		t.Fatalf("Notify: %v", err)
+	}
+	if calls != 3 {
+		t.Errorf("calls = %d, want 3", calls)
+	}
+}
+
+// TestMulti_NotifyCollectsErrors asserts that errors from individual
+// notifiers don't stop dispatch to subsequent ones, but are returned
+// to the caller as a MultiError. Important so an unreliable Slack
+// webhook can't silently break the always-works log notifier in the
+// same chain.
+func TestMulti_NotifyCollectsErrors(t *testing.T) {
+	good := &recordingNotifier{onNotify: func(_ Notification) error { return nil }}
+	bad := &recordingNotifier{onNotify: func(_ Notification) error {
+		return &MultiError{Errors: []error{simpleErr("boom")}}
+	}}
+	m := NewMulti(good, bad, good)
+	err := m.Notify(context.Background(), Notification{ApprovalID: "act-1"})
+	if err == nil {
+		t.Fatal("Notify err = nil, want MultiError")
+	}
+	merr, ok := err.(*MultiError)
+	if !ok {
+		t.Fatalf("err type = %T, want *MultiError", err)
+	}
+	if len(merr.Errors) != 1 {
+		t.Errorf("collected %d errors, want 1", len(merr.Errors))
+	}
+	if !strings.Contains(merr.Error(), "boom") {
+		t.Errorf("MultiError.Error() = %q, missing root cause", merr.Error())
+	}
+	// All three notifiers should have been called despite the middle one erroring.
+	if good.callCount+bad.callCount != 3 {
+		t.Errorf("total notifier calls = %d (good=%d, bad=%d), want 3",
+			good.callCount+bad.callCount, good.callCount, bad.callCount)
+	}
+}
+
+// recordingNotifier is a minimal Notifier implementation for tests:
+// counts calls and forwards to a hook.
+type recordingNotifier struct {
+	callCount int
+	onNotify  func(Notification) error
+}
+
+func (r *recordingNotifier) Notify(_ context.Context, n Notification) error {
+	r.callCount++
+	if r.onNotify != nil {
+		return r.onNotify(n)
+	}
+	return nil
+}
+
+type simpleErr string
+
+func (e simpleErr) Error() string { return string(e) }

--- a/ui/src/lib/api.ts
+++ b/ui/src/lib/api.ts
@@ -72,6 +72,53 @@ export async function denyRequest(approvalId: string, reason: string, comment?: 
 	});
 }
 
+// --- Action-level approvals (#418) ---
+//
+// Distinct from the rich governance flow above (`/v1/approvals` with
+// intents and multi-approver workflows). The action-approval queue is
+// the runtime-blocking shape: one entry per held-open
+// `POST /v1/actions/{name}/run` waiting for a single yes/no decision.
+// Per the launch path, the agent surfaces the approval URL to the
+// user via templated MCP tool descriptions; the user decides here.
+
+export type PendingActionApproval = {
+	id: string;
+	action_name: string;
+	connector_fqn?: string;
+	args?: Record<string, unknown>;
+	session_id?: string;
+	requested_at: string;
+};
+
+export type ActionApprovalListResponse = {
+	items: PendingActionApproval[];
+};
+
+/** Returns the queue of pending action-level approvals. The webapp polls
+ *  this every few seconds while open; the backend is in-memory per-process,
+ *  so an empty list after the daemon restarts is normal (#412 will give
+ *  this persistence later). */
+export async function listActionApprovals(): Promise<ActionApprovalListResponse> {
+	return apiFetch('/v1/action-approvals');
+}
+
+/** Resolves a pending action-approval. The runtime's blocked
+ *  `RunAction` unblocks on the next tick; on `approved=true` the action
+ *  proceeds normally, on `approved=false` it returns an
+ *  `approval_denied` failure envelope to the agent with `reason` in the
+ *  message body. Returns null on success (server replies 200 with empty
+ *  body); throws on 404 (already resolved) or other non-2xx. */
+export async function decideActionApproval(
+	approvalId: string,
+	approved: boolean,
+	reason?: string
+): Promise<null> {
+	return apiFetch(`/v1/action-approvals/${approvalId}/decide`, {
+		method: 'POST',
+		body: JSON.stringify({ approved, reason: reason ?? '' })
+	});
+}
+
 export async function getIntent(intentId: string) {
 	return apiFetch(`/v1/intents/${intentId}`);
 }

--- a/ui/src/routes/approvals/+page.svelte
+++ b/ui/src/routes/approvals/+page.svelte
@@ -1,21 +1,90 @@
 <script lang="ts">
-	import { listApprovals } from '$lib/api';
+	import {
+		listApprovals,
+		listActionApprovals,
+		decideActionApproval,
+		type PendingActionApproval
+	} from '$lib/api';
 	import { onMount } from 'svelte';
 	import { approvalStatusColor } from '$lib/colors';
 	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
 
-	let approvals = $state<any[]>([]);
+	// Rich-governance approvals (intents + multi-approver). Existing
+	// surface — kept here so the page stays the single "things waiting
+	// for a decision" entry point for the user.
+	// eslint-disable-next-line @typescript-eslint/no-explicit-any
+	let governanceApprovals = $state<any[]>([]);
+
+	// Action-level approvals (#418): runtime-blocking yes/no for actions
+	// whose manifest declared `[approval] required = true`. Each entry
+	// represents one held-open `RunAction` HTTP response.
+	let actionApprovals = $state<PendingActionApproval[]>([]);
+
+	// Per-id deny-reason state. Surfaced inline next to the action's
+	// args so the user types their reason where they're looking, rather
+	// than navigating to a detail view. Empty string is fine — the
+	// runtime forwards "" verbatim and the agent reads "user denied"
+	// without commentary.
+	let denyReasons = $state<Record<string, string>>({});
+
+	// Per-id pending-decide flag so we can disable the buttons during
+	// the in-flight POST. Without this, double-click during latency
+	// produces a "404 already resolved" race the user can't interpret.
+	let deciding = $state<Record<string, boolean>>({});
+
 	let loading = $state(true);
 	let error = $state('');
 
 	async function load() {
 		try {
-			const data = await listApprovals();
-			approvals = data.items || [];
-		} catch (e: any) {
-			error = e.message;
+			const [g, a] = await Promise.all([
+				listApprovals().catch(() => ({ items: [] })),
+				listActionApprovals().catch(() => ({ items: [] }))
+			]);
+			governanceApprovals = g.items || [];
+			actionApprovals = a.items || [];
+			error = '';
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
 		} finally {
 			loading = false;
+		}
+	}
+
+	async function decide(id: string, approved: boolean) {
+		// Snapshot the reason at click-time so a concurrent typing
+		// keystroke doesn't change what gets sent. Empty for approve.
+		const reason = approved ? '' : (denyReasons[id] ?? '');
+		deciding[id] = true;
+		try {
+			await decideActionApproval(id, approved, reason);
+			// Optimistically drop the entry rather than waiting for the
+			// next poll cycle. The next `load()` will reconcile if the
+			// server view differs.
+			actionApprovals = actionApprovals.filter((a) => a.id !== id);
+			delete denyReasons[id];
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			deciding[id] = false;
+		}
+	}
+
+	function formatRequestedAt(ts: string): string {
+		try {
+			return new Date(ts).toLocaleString();
+		} catch {
+			return ts;
+		}
+	}
+
+	function formatArgs(args: Record<string, unknown> | undefined): string {
+		if (!args || Object.keys(args).length === 0) return '(no args)';
+		try {
+			return JSON.stringify(args, null, 2);
+		} catch {
+			return String(args);
 		}
 	}
 
@@ -30,39 +99,119 @@
 	<title>Approvals - Aileron</title>
 </svelte:head>
 
-<h1 class="text-xl font-semibold mb-4">Approvals</h1>
+<h1 class="mb-4 text-xl font-semibold">Approvals</h1>
 
 {#if loading}
 	<p class="text-muted-foreground">Loading...</p>
 {:else if error}
 	<p class="text-destructive">{error}</p>
-{:else if approvals.length === 0}
-	<p class="text-muted-foreground">No approval requests yet. Submit an intent via the API or MCP server.</p>
+{:else if actionApprovals.length === 0 && governanceApprovals.length === 0}
+	<p class="text-muted-foreground">
+		No pending approvals. The agent's blocked tool calls (if any) will appear here.
+	</p>
 {:else}
-	<div class="flex flex-col gap-3">
-		{#each approvals as approval}
-			<a href="/approvals/{approval.approval_id}" class="no-underline text-foreground">
-				<Card.Root class="hover:bg-muted/50 transition-colors">
-					<Card.Header>
-						<div class="flex justify-between items-center">
-							<div>
-								<span class="font-semibold">{approval.approval_id}</span>
-								{#if approval.rationale}
-									<span class="text-muted-foreground ml-3 text-sm">{approval.rationale}</span>
-								{/if}
+	{#if actionApprovals.length > 0}
+		<section class="mb-6" data-testid="action-approvals-section">
+			<h2 class="mb-2 text-base font-semibold">Action approvals</h2>
+			<p class="mb-3 text-sm text-muted-foreground">
+				The agent is blocked on these tool calls until you approve or deny.
+			</p>
+			<div class="flex flex-col gap-3">
+				{#each actionApprovals as approval (approval.id)}
+					<Card.Root data-testid="action-approval-card" data-approval-id={approval.id}>
+						<Card.Header>
+							<div class="flex items-center justify-between">
+								<div>
+									<span class="font-semibold">{approval.action_name}</span>
+									{#if approval.connector_fqn}
+										<span class="ml-3 text-sm text-muted-foreground">
+											via {approval.connector_fqn}
+										</span>
+									{/if}
+								</div>
+								<span class="text-xs text-muted-foreground">
+									{formatRequestedAt(approval.requested_at)}
+								</span>
 							</div>
-							<span class="font-semibold text-sm uppercase" style="color: {approvalStatusColor(approval.status)}">
-								{approval.status}
-							</span>
-						</div>
-					</Card.Header>
-					<Card.Content>
-						<div class="text-xs text-muted-foreground">
-							Intent: {approval.intent_id} | Requested: {new Date(approval.requested_at).toLocaleString()}
-						</div>
-					</Card.Content>
-				</Card.Root>
-			</a>
-		{/each}
-	</div>
+						</Card.Header>
+						<Card.Content class="flex flex-col gap-3">
+							<pre
+								class="overflow-x-auto rounded bg-muted p-3 text-xs"
+								data-testid="approval-args">{formatArgs(approval.args)}</pre>
+							<div class="flex items-center gap-2">
+								<input
+									type="text"
+									placeholder="Optional reason (deny only)"
+									class="flex-1 rounded border border-input bg-background px-2 py-1 text-sm"
+									bind:value={denyReasons[approval.id]}
+									disabled={deciding[approval.id]}
+									data-testid="deny-reason-input"
+								/>
+								<Button
+									variant="default"
+									disabled={deciding[approval.id]}
+									data-testid="approve-button"
+									onclick={() => decide(approval.id, true)}
+								>
+									Approve
+								</Button>
+								<Button
+									variant="destructive"
+									disabled={deciding[approval.id]}
+									data-testid="deny-button"
+									onclick={() => decide(approval.id, false)}
+								>
+									Deny
+								</Button>
+							</div>
+							{#if approval.session_id}
+								<div class="text-xs text-muted-foreground">
+									Session: {approval.session_id}
+								</div>
+							{/if}
+						</Card.Content>
+					</Card.Root>
+				{/each}
+			</div>
+		</section>
+	{/if}
+
+	{#if governanceApprovals.length > 0}
+		<section data-testid="governance-approvals-section">
+			<h2 class="mb-2 text-base font-semibold">Governance approvals</h2>
+			<div class="flex flex-col gap-3">
+				{#each governanceApprovals as approval (approval.approval_id)}
+					<a href="/approvals/{approval.approval_id}" class="text-foreground no-underline">
+						<Card.Root class="transition-colors hover:bg-muted/50">
+							<Card.Header>
+								<div class="flex items-center justify-between">
+									<div>
+										<span class="font-semibold">{approval.approval_id}</span>
+										{#if approval.rationale}
+											<span class="ml-3 text-sm text-muted-foreground"
+												>{approval.rationale}</span
+											>
+										{/if}
+									</div>
+									<span
+										class="text-sm font-semibold uppercase"
+										style="color: {approvalStatusColor(approval.status)}"
+									>
+										{approval.status}
+									</span>
+								</div>
+							</Card.Header>
+							<Card.Content>
+								<div class="text-xs text-muted-foreground">
+									Intent: {approval.intent_id} | Requested: {formatRequestedAt(
+										approval.requested_at
+									)}
+								</div>
+							</Card.Content>
+						</Card.Root>
+					</a>
+				{/each}
+			</div>
+		</section>
+	{/if}
 {/if}

--- a/ui/src/routes/approvals/page.test.ts
+++ b/ui/src/routes/approvals/page.test.ts
@@ -1,0 +1,166 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$lib/api', () => ({
+	listApprovals: vi.fn(),
+	listActionApprovals: vi.fn(),
+	decideActionApproval: vi.fn()
+}));
+
+import Page from './+page.svelte';
+import { listApprovals, listActionApprovals, decideActionApproval } from '$lib/api';
+
+beforeEach(() => {
+	vi.mocked(listApprovals).mockResolvedValue({ items: [] });
+	vi.mocked(listActionApprovals).mockResolvedValue({ items: [] });
+	vi.mocked(decideActionApproval).mockResolvedValue(null);
+});
+
+describe('Approvals page — empty state', () => {
+	it('shows the empty-state hint when no approvals are pending', async () => {
+		render(Page);
+		await waitFor(() => {
+			expect(
+				screen.getByText(/No pending approvals\. The agent's blocked tool calls/)
+			).toBeInTheDocument();
+		});
+	});
+});
+
+describe('Approvals page — action approvals (#418)', () => {
+	it('renders pending action approvals with action name, connector, and args', async () => {
+		vi.mocked(listActionApprovals).mockResolvedValue({
+			items: [
+				{
+					id: 'act-test-1',
+					action_name: 'send-email',
+					connector_fqn: 'github://x/aileron-connector-google',
+					args: { to: 'alice@example.com', subject: 'hi' },
+					session_id: 'session-42',
+					requested_at: '2026-05-04T12:00:00Z'
+				}
+			]
+		});
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByText('send-email')).toBeInTheDocument();
+		});
+		expect(screen.getByText(/github:\/\/x\/aileron-connector-google/)).toBeInTheDocument();
+		// Args are rendered as JSON; recipient and subject must both appear in
+		// the rendered <pre> so the user can review what would be sent.
+		const argsBlock = screen.getByTestId('approval-args');
+		expect(argsBlock.textContent).toContain('alice@example.com');
+		expect(argsBlock.textContent).toContain('subject');
+		// Session id is surfaced verbatim.
+		expect(screen.getByText(/Session: session-42/)).toBeInTheDocument();
+	});
+
+	it('does not render the args block when an entry has no args', async () => {
+		vi.mocked(listActionApprovals).mockResolvedValue({
+			items: [
+				{
+					id: 'act-test-1',
+					action_name: 'noop',
+					requested_at: '2026-05-04T12:00:00Z'
+				}
+			]
+		});
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('noop')).toBeInTheDocument();
+		});
+		// `(no args)` placeholder keeps the layout stable rather than
+		// collapsing the args row entirely — easier to scan a list.
+		expect(screen.getByTestId('approval-args').textContent).toBe('(no args)');
+	});
+
+	it('approves an action and removes it from the list optimistically', async () => {
+		vi.mocked(listActionApprovals).mockResolvedValue({
+			items: [
+				{
+					id: 'act-test-1',
+					action_name: 'send-email',
+					requested_at: '2026-05-04T12:00:00Z'
+				}
+			]
+		});
+
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('send-email')).toBeInTheDocument();
+		});
+
+		const approveButton = screen.getByTestId('approve-button');
+		await fireEvent.click(approveButton);
+
+		await waitFor(() => {
+			expect(decideActionApproval).toHaveBeenCalledWith('act-test-1', true, '');
+		});
+		// After resolution, the card disappears even before the next poll
+		// — this is the optimistic-update path the user perceives as
+		// instant feedback. Reconciliation happens on the next interval tick.
+		await waitFor(() => {
+			expect(screen.queryByText('send-email')).not.toBeInTheDocument();
+		});
+	});
+
+	it('denies an action with the typed reason', async () => {
+		vi.mocked(listActionApprovals).mockResolvedValue({
+			items: [
+				{
+					id: 'act-test-1',
+					action_name: 'send-email',
+					requested_at: '2026-05-04T12:00:00Z'
+				}
+			]
+		});
+
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('send-email')).toBeInTheDocument();
+		});
+
+		const reasonInput = screen.getByTestId('deny-reason-input') as HTMLInputElement;
+		await fireEvent.input(reasonInput, { target: { value: 'wrong recipient' } });
+		const denyButton = screen.getByTestId('deny-button');
+		await fireEvent.click(denyButton);
+
+		await waitFor(() => {
+			expect(decideActionApproval).toHaveBeenCalledWith(
+				'act-test-1',
+				false,
+				'wrong recipient'
+			);
+		});
+	});
+
+	it('surfaces server errors from decideActionApproval', async () => {
+		vi.mocked(listActionApprovals).mockResolvedValue({
+			items: [
+				{
+					id: 'act-test-1',
+					action_name: 'send-email',
+					requested_at: '2026-05-04T12:00:00Z'
+				}
+			]
+		});
+		vi.mocked(decideActionApproval).mockRejectedValue(
+			new Error('approval is unknown or already resolved')
+		);
+
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('send-email')).toBeInTheDocument();
+		});
+
+		await fireEvent.click(screen.getByTestId('approve-button'));
+
+		await waitFor(() => {
+			expect(
+				screen.getByText('approval is unknown or already resolved')
+			).toBeInTheDocument();
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds the webapp surface for action-level approvals, delivering the first half of #418. The runtime side shipped in #421; until now the only way to decide on a pending entry was the `aileron approval` CLI. With this PR the user clicks approve or deny on a card.

| Before | After |
|---|---|
| Runtime blocks; user runs `aileron approval list` in another terminal; copies an id; runs `aileron approval approve <id>` | Runtime blocks; user opens `/approvals`; clicks Approve or Deny |

## What's on the page

- **Action approvals** section at the top. Each card carries the action name, connector FQN, JSON-formatted args (so the user can review what would actually be sent), the requesting session, and the requested-at timestamp.
- An inline reason input next to Approve / Deny — empty for approve, optional commentary for deny that gets forwarded to the agent.
- Optimistic removal on decide. The card disappears immediately; the next poll-cycle reconciles if the server view differs.
- Per-id "deciding" flag disables the buttons during the in-flight POST. Heads off the double-click → 404 race.
- **Governance approvals** section below — the existing `/v1/approvals` rich-workflow surface, unchanged.

The page polls every 5s alongside the existing governance-approval poll.

## What this does *not* do (scoped for follow-ups on #418)

- **System notification firing** on `Register`. The user still has to know to look at the page. OS-level notification wiring lands separately via the existing `internal/notify` package.
- **Static-asset serving** of `ui/build` from the daemon. For now the user runs `task dev:ui` and points `PUBLIC_API_BASE` at the embedded gateway. Bundling the webapp into the daemon binary is a separate concern.
- **`AILERON_APPROVAL_URL` refinement** in launch — currently points at `<gateway>/approvals`. Once the daemon serves the webapp this still works because the gateway can proxy through; refining the URL comes with the static-asset change.
- **SSE / WebSocket** push for live updates. Polling at 5s is sufficient for v0.x; upgrade if the shape stops scaling.

## Test plan

- [x] `task lint:ui` — 0 errors, 0 warnings, 0 files with problems
- [x] `pnpm exec vitest run` — 68/68 tests pass (6 new in `src/routes/approvals/page.test.ts`)
- [x] New tests cover: empty state, populated render with every field surfaced, no-args fallback, approve flow with optimistic removal, deny flow with reason forwarding, server-error surfacing
- [ ] After merge: install an action with `[approval] required = true`, run `aileron launch claude`, ask Claude to use it, see Claude tell the user to approve at the URL, click Approve in the webapp at `/approvals`, observe Claude's tool call return and the agent continue.

## Demo path post-merge

```sh
# In the connector repo, mark an action [approval] required = true.
# (Or use a test fixture if no real connector ships one yet — the
#  send-email connector action #415 is the natural target once it lands.)

# Terminal 1:
task build && task dev:ui   # webapp on http://localhost:5173

# Terminal 2:
./build/aileron launch claude

# Terminal 3 (Claude Code session inside launch): ask the agent to use
# the gated action. Tool call blocks. Claude tells the user the
# AILERON_APPROVAL_URL.

# Browser: open http://localhost:5173/approvals.
# See the pending request. Click Approve.

# Back in Claude: tool call returns; agent continues.
```

Cross-references: #421 (runtime + CLI shipped), #418 (this issue), #419 (pty removal — depends on this), #394 (Imran's per-invocation-approval framing — webapp is the consent-surface choice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
