### PR TITLE
fix(sandbox): reword misleading binding_required error (#414)

### DIFF
--- a/internal/sandbox/host.go
+++ b/internal/sandbox/host.go
@@ -385,7 +385,9 @@ func injectCredential(ctx context.Context, s *hostState, req *http.Request, requ
 	}
 	if s.credentialResolver == nil {
 		return newBindingRequired(
-			"http_request: action declares no [[bindings]] entry for this connector",
+			fmt.Sprintf(
+				"http_request: no credential binding found for connector %s (kind: %s); run `aileron binding setup %s` to create one or `aileron binding list` to inspect existing bindings",
+				s.connectorFQN, s.expectedCredentialKind, s.connectorFQN),
 			map[string]any{
 				"connector":       s.connectorFQN,
 				"capability_kind": s.expectedCredentialKind,

--- a/internal/sandbox/host_credential_test.go
+++ b/internal/sandbox/host_credential_test.go
@@ -62,7 +62,12 @@ func TestInjectCredential_DeniedOnKindMismatchAgainstManifest(t *testing.T) {
 
 func TestInjectCredential_BindingRequiredWhenNoResolver(t *testing.T) {
 	// Manifest declared the kind, the connector emitted a credential
-	// reference, but the action declared no [[bindings]] entry — binding_required.
+	// reference, but no binding has been created for this connector —
+	// binding_required. The message must name the connector FQN, the
+	// credential kind, and point operators at `aileron binding setup`
+	// (regression test for #414: the old wording falsely blamed a
+	// "[[bindings]]" block in the action manifest, sending operators
+	// chasing a non-existent file edit).
 	st := &hostState{connectorFQN: "github://x/y", expectedCredentialKind: "oauth2"}
 	req, _ := http.NewRequest("GET", "https://example.com", nil)
 	err := injectCredential(context.Background(), st, req, "oauth2")
@@ -74,6 +79,14 @@ func TestInjectCredential_BindingRequiredWhenNoResolver(t *testing.T) {
 	}
 	if got, _ := err.Details["boundary_detail"].(string); got != "action" {
 		t.Errorf("boundary_detail = %q, want action", got)
+	}
+	if strings.Contains(err.Message, "[[bindings]]") {
+		t.Errorf("message still references [[bindings]] (the misleading wording from #414): %q", err.Message)
+	}
+	for _, want := range []string{"github://x/y", "oauth2", "aileron binding setup"} {
+		if !strings.Contains(err.Message, want) {
+			t.Errorf("message = %q, want substring %q", err.Message, want)
+		}
 	}
 }
 

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -97,9 +97,9 @@ func run(log *slog.Logger) error {
 //
 // Without this branch, the standalone server always took the in-memory
 // path, which silently dropped every credential binding the moment the
-// process exited — surfacing later as "action declares no [[bindings]]
-// entry for this connector" when the launch gateway tried to resolve
-// the same binding against the persistent file vault.
+// process exited — surfacing later as a `binding_required` error from
+// the credential mediation path when the launch gateway tried to
+// resolve the same binding against the persistent file vault.
 //
 // Extracted from `run` so unit tests can exercise the branching
 // without bringing up an HTTP server. `prompter` is forwarded to

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -52,7 +52,7 @@ func TestSelectVault_NonTTYFallsBackToMemoryEvenWithFile(t *testing.T) {
 // server always took the in-memory path, even when a persistent vault
 // file existed. That silently dropped every binding created via
 // `aileron binding setup` the moment the server process exited,
-// surfacing later as a "no [[bindings]] entry" error from the launch
+// surfacing later as a `binding_required` error from the launch
 // gateway. After this change the server unlocks the persistent vault
 // when conditions allow.
 func TestSelectVault_PresentFileAndTTYUnlocks(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes #414. The credential mediation path in `internal/sandbox/host.go` returned this message whenever `Bindings.ResolverFor()` returned nil:

> `http_request: action declares no [[bindings]] entry for this connector`

The wording falsely blamed a `[[bindings]]` block in the action manifest. There is no such block — bindings live in the vault and are looked up by `connectorFQN + kind` at execute time. The misdirection cost ~30 minutes per occurrence during the v0.0.6 E2E bring-up (3 hits in one day across 3 distinct root causes: vault wiring bug, never-completed OAuth setup, action↔connector hash mismatch).

## What changed

`internal/sandbox/host.go` (the only behavioral change). Old:

```
http_request: action declares no [[bindings]] entry for this connector
```

New:

```
http_request: no credential binding found for connector <FQN> (kind: <kind>);
run `aileron binding setup <FQN>` to create one or `aileron binding list`
to inspect existing bindings
```

Per the issue, the structured `details` (`connector`, `capability_kind`, `boundary_detail`) are unchanged — those were already correct; only the human-readable line needed replacing.

## Regression test

`TestInjectCredential_BindingRequiredWhenNoResolver` now asserts the new wording: must NOT contain `[[bindings]]`, must contain the connector FQN, the credential kind, and `aileron binding setup`. The test would have failed against the old message and passes against the new one.

## Comment sweep

Three comments quoted the old error string verbatim and would have rotted into out-of-date references:
- `internal/sandbox/host_credential_test.go` (test docstring)
- `internal/server/main.go:100` (regression-bug context for `selectVault`)
- `internal/server/main_test.go:55` (`TestSelectVault_PresentFileAndTTYUnlocks` docstring)

All three updated to refer to the `binding_required` error class instead of the literal string.

## What's NOT in this PR

Per the issue's "out of scope": no separate "ambiguous binding" message. The single `binding_required` class still covers both no-binding and ambiguous-binding; finer attribution stays in the audit-event details for now.

## Test plan

- [x] `go test ./internal/sandbox/ -run TestInjectCredential -v` — 9 tests pass, including the updated regression assertion.
- [x] `go test ./internal/sandbox/ ./internal/server/ ./internal/app/ ./internal/action/` — all green.
- [x] Coverage: `injectCredential` 100% line coverage; package overall 82.5%.
- [x] `go vet` clean across `internal/`, `cmd/aileron`, `cmd/aileron-mcp`.
- [x] `task build` green.
- [x] No other code or test in the tree references the old `[[bindings]]` wording (confirmed via `grep`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)