### PR TITLE
docs(guides): add Publishing a Connector to Guides nav

### DIFF
--- a/docs/src/content/docs/guides/authoring-a-connector.md
+++ b/docs/src/content/docs/guides/authoring-a-connector.md
@@ -5,7 +5,7 @@ description: "Write a connector from scratch: project layout, the JSON I/O envel
 
 This guide walks you from an empty directory to a working connector binary. By the end you will have a `wasip1` Go program that reads a JSON envelope from stdin, calls an external HTTP API through the runtime, and writes a JSON result to stdout.
 
-If you have not read it yet, start with [Connectors](/concepts/connectors/) for the model. This guide is the *how*; that page is the *what* and *why*. Once your connector compiles and behaves the way you want, [Publishing a connector](/connectors/publishing/) covers signing, tagging, and the keyring trust model.
+If you have not read it yet, start with [Connectors](/concepts/connectors/) for the model. This guide is the *how*; that page is the *what* and *why*. Once your connector compiles and behaves the way you want, [Publishing a connector](/guides/publishing-a-connector/) covers signing, tagging, and the keyring trust model.
 
 ## What you are building
 
@@ -279,7 +279,7 @@ A few non-obvious rules:
 - `kind` must match the kind on the user's binding. If your code passes `credential: "oauth2"` but the manifest declares `api_key`, the request is denied at the sandbox boundary even before the network gate fires.
 - `imports` lists the host functions you actually import. Declaring an import you never call is harmless; calling one you did not declare is a load-time failure.
 
-OAuth2 connectors need a `[capabilities.credential.oauth2]` block too — that part is covered in [Publishing a connector](/connectors/publishing/) since it's tied to OAuth-app registration with the upstream provider.
+OAuth2 connectors need a `[capabilities.credential.oauth2]` block too — that part is covered in [Publishing a connector](/guides/publishing-a-connector/) since it's tied to OAuth-app registration with the upstream provider.
 
 ## Limits
 
@@ -316,6 +316,6 @@ To smoke-test before publishing, install the unsigned binary into a local store 
 
 Once your connector behaves the way you want:
 
-- [Publishing a connector](/connectors/publishing/) — repo layout, signing, tag conventions, keyring trust, action templates.
+- [Publishing a connector](/guides/publishing-a-connector/) — repo layout, signing, tag conventions, keyring trust, action templates.
 - [ADR-0002: Connector Model](/adr/0002-connector-model/) — the design constraints behind everything in this guide.
 - [ADR-0005: Sandbox Choice](/adr/0005-sandbox-choice/) — why WASM, why these limits, why this ABI.

--- a/docs/src/content/docs/guides/authoring-an-action.md
+++ b/docs/src/content/docs/guides/authoring-an-action.md
@@ -17,7 +17,7 @@ This shapes how you author. The file is the artifact. There is nothing else.
 
 ## Project skeleton
 
-For an action template you are publishing, the file lives inside a connector repo per the layout in [Publishing a connector](/connectors/publishing/):
+For an action template you are publishing, the file lives inside a connector repo per the layout in [Publishing a connector](/guides/publishing-a-connector/):
 
 ```
 aileron-connector-slack/
@@ -284,7 +284,7 @@ To exercise the action end-to-end, drive it through `aileron launch` — the age
 ## Where to go next
 
 - [Authoring a Connector](/guides/authoring-a-connector/) — the connector your action depends on. Action capability subsets are meaningful only against a connector's declared capability set.
-- [Publishing a connector](/connectors/publishing/) — once you have an action template you want others to install, the same repo and signing flow applies. Action tarballs ship alongside the connector.
+- [Publishing a connector](/guides/publishing-a-connector/) — once you have an action template you want others to install, the same repo and signing flow applies. Action tarballs ship alongside the connector.
 - [ADR-0001: Manifest Format](/adr/0001-manifest-format/) — why TOML, why `+++`, why the frontmatter shape.
 - [ADR-0003: Action Model](/adr/0003-action-model/) — the design constraints behind everything in this guide.
 - [ADR-0010: Failure Handling](/adr/0010-failure-handling/) — first-failure-terminates, no auto-rollback, structured error envelopes.

--- a/docs/src/content/docs/guides/publishing-a-connector.md
+++ b/docs/src/content/docs/guides/publishing-a-connector.md
@@ -1,5 +1,5 @@
 ---
-title: "Publishing a connector"
+title: "Publishing a Connector"
 description: "How to author, sign, and release a connector + action templates that Aileron users can install via aileron connector install / aileron action add."
 ---
 

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -58,7 +58,8 @@ export const navigation: NavItem[] = [
     label: 'Guides',
     children: [
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },
-      { label: 'Authoring an Action', href: '/guides/authoring-an-action/' }
+      { label: 'Authoring an Action', href: '/guides/authoring-an-action/' },
+      { label: 'Publishing a Connector', href: '/connectors/publishing/' }
     ]
   },
   {

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -59,7 +59,7 @@ export const navigation: NavItem[] = [
     children: [
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },
       { label: 'Authoring an Action', href: '/guides/authoring-an-action/' },
-      { label: 'Publishing a Connector', href: '/connectors/publishing/' }
+      { label: 'Publishing a Connector', href: '/guides/publishing-a-connector/' }
     ]
   },
   {


### PR DESCRIPTION
## Summary

- Surfaces the Publishing a Connector guide under the Guides section (third entry, after the two Authoring guides). The section now presents the full author → ship arc.
- Relocates the page from `/connectors/publishing/` to `/guides/publishing-a-connector/` so the URL matches its sidebar grouping and is symmetric with the two Authoring guides. Updates the inbound cross-references from `authoring-a-connector` and `authoring-an-action`. Title-cased for consistency with the other Guides entries.
- The `connectors/` content directory is now empty and removed; everything connector-author-facing lives under `/guides/`.

## Commits

1. Add the nav entry pointing at the existing `/connectors/publishing/` URL.
2. Relocate the page under `/guides/publishing-a-connector/` and rewrite inbound links.

## Test plan

- [x] `task build:docs` succeeds; `/guides/publishing-a-connector/` is rendered; `/connectors/publishing/` is no longer in the build output.
- [x] Visual check: Publishing a Connector appears as the third entry under Guides; clicking lands on the new URL; cross-links from the Authoring guides resolve to the new URL.
- [x] If anything off-site links to the old `/connectors/publishing/` URL it will 404 — known and acceptable since the docs are pre-MVP.

🤖 Generated with [Claude Code](https://claude.com/claude-code)