### PR TITLE
docs(guides): ground all three guides in real aileron-connector-google

### DIFF
--- a/docs/src/content/docs/guides/authoring-a-connector.md
+++ b/docs/src/content/docs/guides/authoring-a-connector.md
@@ -5,7 +5,9 @@ description: "Write a connector from scratch: project layout, the JSON I/O envel
 
 This guide walks you from an empty directory to a working connector binary. By the end you will have a `wasip1` Go program that reads a JSON envelope from stdin, calls an external HTTP API through the runtime, and writes a JSON result to stdout.
 
-If you have not read it yet, start with [Connectors](/concepts/connectors/) for the model. This guide is the *how*; that page is the *what* and *why*. Once your connector compiles and behaves the way you want, [Publishing a connector](/guides/publishing-a-connector/) covers signing, tagging, and the keyring trust model.
+If you have not read it yet, start with [Connectors](/concepts/connectors/) for the model. This guide is the *how*; that page is the *what* and *why*. Once your connector compiles and behaves the way you want, [Publishing a Connector](/guides/publishing-a-connector/) covers signing, tagging, and the keyring trust model.
+
+The reference implementation throughout this guide is [`github.com/ALRubinger/aileron-connector-google`](https://github.com/ALRubinger/aileron-connector-google) — a real connector exposing six Gmail and Calendar ops. Snippets here are simplified for clarity; clone that repo when you want production-shape code to study.
 
 ## What you are building
 
@@ -20,15 +22,20 @@ You write Go that targets `GOOS=wasip1 GOARCH=wasm`. No goroutines that need a r
 
 ## Project skeleton
 
-The minimum:
+The minimum, mirroring the layout of the reference repo:
 
 ```
 my-connector/
 ├── connector/
-│   ├── main.go
+│   ├── main.go              # //go:build wasip1 — the WASM entry point
+│   ├── helpers.go           # untagged — pure helpers, host-testable
+│   ├── helpers_test.go      # standard go test, runs on the host
+│   ├── go.mod
 │   └── manifest.toml
-└── Taskfile.yml          # optional but recommended
+└── Taskfile.yml             # build wasm, smoke-compile wasip1, run unit tests
 ```
+
+Two source files instead of one is a deliberate split. `main.go` carries the `//go:build wasip1` tag because it imports the `aileron_host` host module — code Go can only compile when targeting the WASM runtime that supplies those imports. `helpers.go` has no build tag, so any pure logic that lives there (URL building, body encoding, attendee normalization) can be unit-tested with `go test` on your host platform without going through the WASM build at all.
 
 The publishing guide describes the full `aileron-connector-<service>` repo layout (action templates, signing keys, release tarball). For authoring, only `connector/` matters.
 
@@ -40,26 +47,29 @@ Every invocation reads one JSON object from stdin and writes one JSON object to 
 
 ```json
 {
-  "op": "list_channels",
-  "args": { "team_id": "T123" }
+  "op": "list_recent_emails",
+  "args": { "query": "is:unread", "max_results": 10 }
 }
 ```
 
 **Output (success):**
 
 ```json
-{ "output": { "channels": [...] } }
+{ "output": { "messages": [...], "resultSizeEstimate": 42 } }
 ```
 
 **Output (error):**
 
 ```json
-{ "error": { "class": "external_service_error", "message": "rate limited" } }
+{ "error": { "class": "external_api_error", "message": "Gmail API returned 429: rate limited" } }
 ```
 
-`op` is a string your connector dispatches on. `args` is an arbitrary JSON object — whatever the action template passed in. `output` is whatever you want to return; the runtime hands it back to the caller verbatim. `error.class` is a stable identifier the runtime maps onto its structured error model; `error.message` is a human-readable string.
+`op` is a string your connector dispatches on. `args` is an arbitrary JSON object — whatever the action template passed in. `output` is whatever you want to return; the runtime hands it back to the caller verbatim. `error.class` is one of the canonical failure classes the runtime understands; `error.message` is a human-readable string.
 
-The canonical reference is `internal/sandbox/testdata/echo/main.go` in the Aileron repo — every host function is exercised there, in isolation, against a real test harness.
+Two reference points worth bookmarking:
+
+- [`connector/main.go`](https://github.com/ALRubinger/aileron-connector-google/blob/main/connector/main.go) in `aileron-connector-google` is a complete production connector — six ops, four host functions, real Google API calls.
+- `internal/sandbox/testdata/echo/main.go` in the Aileron repo is the test fixture; it exercises every host function in isolation against a real test harness.
 
 ## A minimal main
 
@@ -94,12 +104,12 @@ type outputError struct {
 func main() {
 	raw, err := io.ReadAll(os.Stdin)
 	if err != nil {
-		writeError("read_stdin", err.Error())
+		writeError("connector_runtime_error", "read_stdin: "+err.Error())
 		os.Exit(1)
 	}
 	var in input
 	if err := json.Unmarshal(raw, &in); err != nil {
-		writeError("parse_input", err.Error())
+		writeError("connector_runtime_error", "parse_input: "+err.Error())
 		os.Exit(1)
 	}
 
@@ -107,7 +117,7 @@ func main() {
 	case "ping":
 		writeOutput(map[string]any{"ok": true})
 	default:
-		writeError("unknown_op", in.Op)
+		writeError("connector_runtime_error", "unknown op: "+in.Op)
 	}
 }
 
@@ -202,28 +212,38 @@ func doRequest(req httpRequest) (status int, body []byte, err error) {
 
 `rc` of `0` means success; `-1` means the request was denied (capability gate, build error, network failure) or otherwise failed; `-2` means your envelope was malformed JSON. On any non-zero `rc` the runtime has already attached a structured error to the call result — your connector cannot recover and should write a matching `outputError` and exit.
 
-Then dispatch a real op:
+Then dispatch a real op (this is the simplified shape of `list_recent_emails` from the reference repo):
 
 ```go
-case "list_channels":
+case "list_recent_emails":
+	q := url.Values{}
+	q.Set("maxResults", "10")
+	target := "https://gmail.googleapis.com/gmail/v1/users/me/messages?" + q.Encode()
+
 	status, body, err := doRequest(httpRequest{
 		Method:     "GET",
-		URL:        "https://slack.com/api/conversations.list",
+		URL:        target,
+		Headers:    map[string]string{"Accept": "application/json"},
 		Credential: "oauth2",
 	})
 	if err != nil {
-		writeError("connector_runtime_error", err.Error())
+		writeError("connector_runtime_error", "list_recent_emails: "+err.Error())
 		return
 	}
-	if status >= 400 {
-		writeError("external_service_error",
-			fmt.Sprintf("slack returned %d: %s", status, string(body)))
+	if status < 200 || status >= 300 {
+		writeError("external_api_error",
+			fmt.Sprintf("Gmail API returned %d: %s", status, string(body)))
 		return
 	}
 	var parsed map[string]any
-	json.Unmarshal(body, &parsed)
-	writeOutput(map[string]any{"channels": parsed["channels"]})
+	if err := json.Unmarshal(body, &parsed); err != nil {
+		writeError("connector_runtime_error", "list_recent_emails: parse: "+err.Error())
+		return
+	}
+	writeOutput(parsed)
 ```
+
+Two-status-class checks (`< 200 || >= 300`) instead of `>= 400` is the right shape: 3xx redirects still mean "didn't get the data".
 
 ## Credentials: the connector never sees the bytes
 
@@ -235,33 +255,39 @@ If the user has not bound a credential to your connector, the runtime returns `b
 
 ## Error classes
 
-The runtime recognizes these error classes from your output. Use them precisely; users see them in audit logs and `aileron launch` traces:
+The runtime defines a closed set of canonical failure classes in [`internal/failure/failure.go`](https://github.com/ALRubinger/aileron/blob/main/internal/failure/failure.go). Two are emitted by the connector itself:
 
 | Class | When |
 |---|---|
-| `bad_input` | The action passed `args` that violated your op's contract (missing fields, bad types). |
-| `external_service_error` | The remote API returned an error (4xx, 5xx, malformed response). |
-| `connector_runtime_error` | Something went wrong inside the connector itself — JSON parse failure, unexpected nil, an HTTP call that returned `rc != 0`. |
-| `unknown_op` | The action requested an op your connector does not implement. |
+| `external_api_error` | The remote API returned a non-2xx status, a malformed response, or otherwise indicated the call failed upstream. |
+| `connector_runtime_error` | Something went wrong inside the connector itself — bad input from the action (missing required arg, wrong type), JSON parse failure, an HTTP call that returned `rc != 0`, an unknown op. |
 
-If you write a class outside this set, it propagates verbatim — but stick to these unless you have a specific reason. Stable class names let action templates and the runtime treat failures uniformly.
+Two are emitted by the runtime *to* the connector (you observe them but don't write them yourself):
+
+- `capability_denied` — the call exceeded the connector's manifest grant or the action's declared capability subset.
+- `binding_required` — the connector requested a credential and no binding exists.
+
+Use `external_api_error` when the failure is on the other side of the network; use `connector_runtime_error` for everything else you originate. Stable class names let action templates and the runtime treat failures uniformly. If you write a class outside this set, it propagates verbatim, but the runtime's mapping logic will treat it as opaque.
 
 ## The manifest
 
-Declare exactly what the connector touches. Every field is enforced.
+Declare exactly what the connector touches. Every field is enforced. This is the manifest from `aileron-connector-google`, lightly trimmed:
 
 ```toml
 [connector]
-name = "github://acme/aileron-connector-slack"
-version = "0.1.0"
-publisher = "Acme"
+name = "github://ALRubinger/aileron-connector-google"
+version = "0.0.0-dev"   # CI substitutes the real version at release time
+publisher = "ALRubinger"
 
 [capabilities.network]
-hosts = ["slack.com:443"]
+hosts = [
+  "gmail.googleapis.com:443",
+  "www.googleapis.com:443",
+]
 
 [capabilities.credential]
 kind = "oauth2"
-scope = "Read channels and post messages"
+scope = "Read your Gmail messages and Calendar events; create drafts and calendar events"
 
 [capabilities.runtime]
 imports = [
@@ -277,9 +303,11 @@ A few non-obvious rules:
 
 - `hosts` is a closed list of `host:port` pairs. No wildcards. Forgetting `:443` is a common mistake — every entry needs an explicit port. The runtime denies any URL whose `host:port` is not on the list.
 - `kind` must match the kind on the user's binding. If your code passes `credential: "oauth2"` but the manifest declares `api_key`, the request is denied at the sandbox boundary even before the network gate fires.
+- `scope` here is **human-readable prose** — what the user sees in install consent prompts. It is *not* the OAuth scope list; that lives in the `[capabilities.credential.oauth2]` block (see below).
 - `imports` lists the host functions you actually import. Declaring an import you never call is harmless; calling one you did not declare is a load-time failure.
+- `version = "0.0.0-dev"` is intentional in source. The release workflow substitutes the real version (extracted from the pushed tag) into a build copy before signing — the publisher never hand-edits version fields. Same pattern applies to action manifests.
 
-OAuth2 connectors need a `[capabilities.credential.oauth2]` block too — that part is covered in [Publishing a connector](/guides/publishing-a-connector/) since it's tied to OAuth-app registration with the upstream provider.
+OAuth2 connectors need a `[capabilities.credential.oauth2]` block declaring the provider endpoints, client_id, and scope list. That block is covered in [Publishing a Connector](/guides/publishing-a-connector/) since it's tied to OAuth-app registration with the upstream provider — and, for some providers (notably Google), to a release-time `client_secret` substitution.
 
 ## Limits
 
@@ -292,17 +320,34 @@ If your connector needs more, request it in the manifest — the runtime clamps 
 
 The wall-time clock starts when `_start` runs and stops when it returns. There is no separate per-request budget; one slow upstream burns the whole budget.
 
+## Idempotency
+
+Mark every op as either idempotent or not in your head as you write it. Read ops (GETs) are idempotent by their HTTP shape. Write ops that mutate the world (`draft_email`, `send_email`, `create_calendar_event`) are typically not — repeating them creates duplicates. The action manifest declares this per step (`[[execute]].idempotent = false`), and the runtime's retry layer ([ADR-0010](/adr/0010-failure-handling/)) honors the declaration: idempotent ops can retry on transient failure; non-idempotent ops never auto-retry.
+
+This is not enforced at the connector boundary — it is a contract between the connector author (who knows whether the op is repeatable) and the action author (who declares the flag). Document idempotency for each op in your README and in the `main.go` doc comments so the action author knows what to declare.
+
 ## The build and iterate loop
 
 Build:
 
 ```sh
-GOOS=wasip1 GOARCH=wasm go build -trimpath -ldflags='-s -w' -o build/connector.wasm ./connector
+task build
+# or, equivalently:
+GOOS=wasip1 GOARCH=wasm go build -trimpath -ldflags='-s -w' -o connector.wasm ./connector
 ```
 
-`-trimpath` and `-ldflags='-s -w'` are not required for correctness, but they keep binaries reproducible and small (the resulting `.wasm` ends up content-addressed in the user's store, so smaller is faster to fetch).
+`-trimpath` and `-ldflags='-s -w'` keep binaries reproducible and small (the `.wasm` ends up content-addressed in the user's store, so smaller is faster to fetch).
 
-To smoke-test before publishing, install the unsigned binary into a local store and invoke it through `aileron launch`. The exact `aileron connector install --local <path>` flow lives with the CLI; iterate there.
+The reference repo's `Taskfile.yml` also has two test targets worth copying:
+
+```sh
+task test:unit     # runs go test against helpers.go on the host platform
+task test:wasip1   # GOOS=wasip1 GOARCH=wasm go build -o /dev/null . — catches host-import signature mismatches
+```
+
+Pure helpers (URL construction, body encoding, normalization) belong in `helpers.go` so `task test:unit` exercises them directly. Anything that calls `aileron_host.*` lives in `main.go` behind the `//go:build wasip1` tag.
+
+For end-to-end testing against real upstream APIs, point [`aileron-connector-dev-run`](https://github.com/ALRubinger/aileron/tree/main/cmd/aileron-connector-dev-run) at your `connector.wasm` + `manifest.toml` with a stub OAuth token (e.g. one minted via Google's OAuth Playground for a Google connector). It loads the binary into the production Wazero runtime, enforces the manifest's network grant, and invokes ops directly — validating credential mediation and the API call shape end-to-end without going through release / install / binding setup.
 
 ## Things that will trip you up
 

--- a/docs/src/content/docs/guides/authoring-an-action.md
+++ b/docs/src/content/docs/guides/authoring-an-action.md
@@ -7,6 +7,8 @@ This guide walks you from an empty file to a working, installable action. By the
 
 If you have not read it yet, start with [Actions](/concepts/actions/) for the model. This guide is the *how*; that page is the *what* and *why*. The companion guide is [Authoring a Connector](/guides/authoring-a-connector/) — actions exist to call connectors, so the two surfaces are designed in parallel.
 
+The reference templates throughout this guide are the [`actions/*/action.md`](https://github.com/ALRubinger/aileron-connector-google/tree/main/actions) files in `aileron-connector-google` — six real action templates spanning idempotent reads, non-idempotent writes, and per-call user approval.
+
 ## What you are building
 
 An action is a single Markdown file. There is no compiled artifact, no separate manifest, no bundled binary. The whole contract — what the action does, which connectors it touches, which capabilities it exercises, what arguments it accepts — lives in TOML frontmatter at the top of the file. The Markdown body is documentation that doubles as the description the LLM reads when deciding whether to invoke.
@@ -17,70 +19,72 @@ This shapes how you author. The file is the artifact. There is nothing else.
 
 ## Project skeleton
 
-For an action template you are publishing, the file lives inside a connector repo per the layout in [Publishing a connector](/guides/publishing-a-connector/):
+For an action template you are publishing, the file lives inside a connector repo per the layout in [Publishing a Connector](/guides/publishing-a-connector/):
 
 ```
-aileron-connector-slack/
+aileron-connector-google/
 └── actions/
-    └── ship-update/
+    └── list-recent-emails/
         └── action.md
 ```
 
-The file is named `action.md`; the directory name becomes the action handle (`ship-update` here). When a user runs `aileron action add github://acme/aileron-connector-slack/actions/ship-update@1.0.0`, the runtime fetches the tarball, verifies it, and writes the body to `~/.aileron/actions/ship-update.md`.
+The file is named `action.md`; the directory name becomes the action handle (`list-recent-emails` here). When a user runs `aileron action add github://ALRubinger/aileron-connector-google/actions/list-recent-emails@<version>`, the runtime fetches the tarball, verifies it, and writes the body to `~/.aileron/actions/list-recent-emails.md`.
 
 For an action you are writing for yourself — no template, no publishing — just create the file directly under `~/.aileron/actions/`. Same shape, same rules.
 
 ## The skeleton
 
-A complete, valid minimum:
+A complete, valid minimum, modeled on `list-recent-emails/action.md` from the reference repo:
 
 ```markdown
 +++
-name = "ship-update"
-version = "1.0.0"
-source = "hub://aileron/ship-update@1.0.0"
+name = "list-recent-emails"
+version = "0.0.0-dev"
+source = "github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.0-dev"
 
 [[requires.connectors]]
-name = "github://aileron/slack"
-version = "1.2.0"
-hash = "sha256:abc123..."
-capabilities = ["chat:write"]
+name = "github://ALRubinger/aileron-connector-google"
+version = "0.0.0-dev"
+hash = "sha256:bound-at-release"
+capabilities = ["list_recent_emails"]
 
 [match]
-intent = "tell team I shipped"
-
-[[inputs]]
-name = "channel"
-type = "string"
-description = "Slack channel to post to (e.g. '#engineering')."
-
-[[inputs]]
-name = "summary"
-type = "string"
-description = "What you shipped, in one or two sentences."
+intent = "list my recent Gmail messages"
 
 [[execute]]
-id = "post"
-connector = "github://aileron/slack"
-op = "post_message"
+id = "list"
+connector = "github://ALRubinger/aileron-connector-google"
+op = "list_recent_emails"
+idempotent = true
 
-[execute.inputs]
-channel = "${args.channel}"
-text = "${args.summary}"
+[[inputs]]
+name = "query"
+type = "string"
+description = "Optional Gmail search query, e.g. \"is:unread\" or \"from:alice@example.com\"."
+required = false
+
+[[inputs]]
+name = "max_results"
+type = "integer"
+description = "Maximum number of messages to return. Defaults to 10; capped at 100."
+required = false
 +++
 
-# Ship Update
+# List Recent Gmail Messages
 
-Posts a brief "shipped" announcement to a Slack channel.
+Fetches a list of recent Gmail messages for the authenticated user. Returns
+the raw `users.messages.list` response (a paginated list of `{id, threadId}`
+pairs); the agent or a downstream action resolves message bodies as needed.
 
-## When it fires
-
-- "tell the team I shipped the migration"
-- "post a ship update to #engineering"
-- "let everyone know I merged the PR"
+When it fires:
+- "summarize my unread emails from this week"
+- "show me messages from alice@example.com"
+- "what's in my inbox right now"
 ```
 
 That is everything. Open one of those `+++` blocks at the top; close it; write the body underneath.
+
+The `0.0.0-dev` and `sha256:bound-at-release` placeholders are *intentional* in source. The release workflow substitutes the real values at tag-push time. That pattern is covered in the [Identity](#identity) and [Connector dependencies](#connector-dependencies) sections below, and in detail in [Publishing a Connector](/guides/publishing-a-connector/).
 
 ## Frontmatter, field by field
 
@@ -89,9 +93,9 @@ Every field in the frontmatter is enforced. There is no "ignored if empty" — u
 ### Identity
 
 ```toml
-name    = "ship-update"
-version = "1.0.0"
-source  = "hub://aileron/ship-update@1.0.0"
+name    = "list-recent-emails"
+version = "0.0.0-dev"
+source  = "github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.0-dev"
 ```
 
 - `name` is the bare local handle. Lowercase, starts with a letter or digit, dashes/dots/underscores allowed (`^[a-z0-9][a-z0-9._-]*$`). It becomes the filename and the tool name the LLM sees.
@@ -100,29 +104,38 @@ source  = "hub://aileron/ship-update@1.0.0"
 
 The recognized FQN schemes are `github://`, `gitlab://`, and `hub://`. Anything else is a validation error.
 
+**Source-template convention:** in a published action template, both `version` and the version suffix in `source` are typically `0.0.0-dev`. The release workflow substitutes the real version (extracted from the pushed tag) into a build copy of the file before signing. The committed source intentionally stays a template, so the publisher pushes a tag and never edits version fields by hand. The shipped tarball — the file the user actually installs — carries the real values.
+
 ### Connector dependencies
 
 ```toml
 [[requires.connectors]]
-name         = "github://aileron/slack"
-version      = "1.2.0"
-hash         = "sha256:abc123..."
-capabilities = ["chat:write", "channels:read"]
+name         = "github://ALRubinger/aileron-connector-google"
+version      = "0.0.0-dev"
+hash         = "sha256:bound-at-release"
+capabilities = ["list_recent_emails"]
 ```
 
 This block does several jobs at once:
 
 - **Pins the connector.** `name` + `version` + `hash` together identify exactly one binary. The runtime refuses to execute an action whose pinned hash does not match what is in the content-addressed store. A connector publisher cannot ship a malicious update to your installed action — the action references a specific content hash, period.
-- **Declares the capability subset.** `capabilities` is what the action actually uses, not what the connector is capable of. The Slack connector might support `chat:write`, `chat:read`, `users:read`, `files:upload`; if your action only posts messages, you declare `chat:write` and that is the entire surface area.
+- **Declares the capability subset.** `capabilities` is what the action actually uses, not what the connector is capable of. The Google connector exposes `list_recent_emails`, `get_email`, `send_email`, `create_calendar_event`, etc.; an action that only lists messages declares `["list_recent_emails"]` and that is the entire surface area. The capability strings are typically the connector's op names, since each op corresponds to one external operation.
 - **Drives the audit story.** A reader of the file can tell at a glance what surface the action touches. If a future template update adds a new capability, it shows up as a TOML diff against the user's local copy and they can accept or reject it.
 
-You can declare multiple connectors. Compose them in your execute chain — one step pulls the recent merge from `git`, the next posts the announcement to `slack`.
+You can declare multiple connectors. Compose them in your execute chain — one step pulls a list of messages from `gmail`, the next creates a calendar event in `calendar`.
+
+**Placeholder convention:** as with `version`, the `0.0.0-dev` and `sha256:bound-at-release` placeholders are how a published template stays template-shaped. The release workflow substitutes both at tag-push time:
+
+- `0.0.0-dev` → the real version (taken from the pushed tag).
+- `sha256:bound-at-release` → the real connector content hash (computed after the connector tarball is built in the same workflow run).
+
+The committed source carries the placeholders; the published tarball carries the real values. This means every action in a connector repo automatically pins to the same connector hash, in the same release cohort, with no per-action commits per release.
 
 ### Intent matching
 
 ```toml
 [match]
-intent = "tell team I shipped"
+intent = "list my recent Gmail messages"
 ```
 
 `intent` is a canonical natural-language phrase the runtime uses to surface this action to the agent. The shape will grow as [ADR-0008](/adr/0008-intent-matching/) matures; in v1 it is one required string.
@@ -133,15 +146,16 @@ The intent string is *not* the only signal the LLM sees. The Markdown body's "Wh
 
 ```toml
 [[inputs]]
-name        = "channel"
+name        = "query"
 type        = "string"
-description = "Slack channel to post to (e.g. '#engineering')."
+description = "Optional Gmail search query, e.g. \"is:unread\" or \"from:alice@example.com\"."
+required    = false  # default is true; set false to mark optional
 
 [[inputs]]
-name        = "summary"
-type        = "string"
-description = "What you shipped, in one or two sentences."
-required    = false  # default is true; set false to mark optional
+name        = "max_results"
+type        = "integer"
+description = "Maximum number of messages to return. Defaults to 10; capped at 100."
+required    = false
 ```
 
 Inputs become the JSON Schema `parameters` object the LLM sees when Aileron exposes the action as a tool. The LLM uses `description` to decide what to pass. Write descriptions for the LLM — terse, concrete, with one example if format matters.
@@ -155,28 +169,27 @@ Inputs become the JSON Schema `parameters` object the LLM sees when Aileron expo
 
 ```toml
 [[execute]]
-id        = "recent_merge"
-connector = "github://aileron/git"
-op        = "read_recent_merge"
-
-[[execute]]
-id        = "post"
-connector = "github://aileron/slack"
-op        = "post_message"
+id         = "send"
+connector  = "github://ALRubinger/aileron-connector-google"
+op         = "send_email"
+idempotent = false
 
 [execute.inputs]
-channel = "${args.channel}"
-text    = "${args.summary}"
+to      = "${args.to}"
+subject = "${args.subject}"
+body    = "${args.body}"
 ```
 
 Steps run in declared order. Each step calls one connector op with one set of inputs. The runtime's contract:
 
 - **First failure terminates.** If step 2 fails, step 3 does not run. Per [ADR-0010](/adr/0010-failure-handling/), the action returns a Result whose `Failure` is the failing step's structured error.
-- **No auto-rollback.** Successful prior steps are not undone. If `recent_merge` succeeded and `post` failed, the merge fact is unchanged in the world (it was a read anyway, but the rule holds for writes too). If you need compensating actions, the agent composes them in conversation, not the action file.
+- **No auto-rollback.** Successful prior steps are not undone. If you need compensating actions, the agent composes them in conversation, not the action file.
 - **Each step ID is unique.** Step IDs are how prior outputs will be referenced once interpolation lands (see below).
 - **Each `connector` must appear in `[[requires.connectors]]`.** You cannot reference a connector you did not declare — validation fails before the action is installable.
 
 `[execute.inputs]` is a keyed map of arguments the runtime passes into the connector's op. Values can be literals or `${args.<name>}` interpolations referencing the call-time inputs you declared in `[[inputs]]`. The validator confirms every `${args.X}` reference matches a declared input.
+
+**`idempotent`** declares whether the gateway's retry layer ([ADR-0010](/adr/0010-failure-handling/)) is allowed to re-invoke this step on transient failure. Read ops (GETs) are typically `true`. Write ops that mutate the world (sending an email, creating a calendar event) MUST be `false` — repeating them produces duplicates. The connector's documentation tells you which ops are repeatable; the action manifest is where you record that decision.
 
 **v1 caveat on interpolation:** `${args.X}` works. `${step_id.field}` (referencing a prior step's output) is post-MVP. If your action genuinely needs to feed step 1's output into step 2's input, factor it into the connector for now — write a connector op that does both halves — rather than trying to chain steps in the action file.
 
@@ -189,7 +202,13 @@ required = true
 
 When `required = true`, the action does not run until the user explicitly approves the invocation in the Aileron webapp. The HTTP response from `POST /v1/actions/<name>/run` holds open while the approval is queued; on approve, the action runs and returns its normal result; on deny, the runtime returns a structured error with class `approval_denied`.
 
-Use approval for actions that touch the world in ways the user wants to confirm — sending an email, charging a card, deleting something. Skip it for read-only actions and low-stakes writes.
+Use approval for actions that touch the world in ways the user wants to confirm. The reference repo's three write actions illustrate the gating axis:
+
+- **`draft-email` — un-gated.** Drafts land in Gmail's Drafts folder and are fully reversible. The user already has a built-in human-in-the-loop step (clicking Send in Gmail), so a runtime prompt would duplicate that review without adding safety.
+- **`send-email` — gated.** Dispatched mail is not reversible. The approval step moves from Gmail's UI to Aileron's prompt; it does not disappear.
+- **`create-calendar-event` — gated.** Calendar's `events.insert` dispatches invitation emails to attendees as a side effect, and those notifications don't retract cleanly when the event is later deleted.
+
+Reversibility is the test. If the action's effect is recoverable by a normal user action (delete a draft, edit a doc), skip approval. If it isn't (mail dispatched, money moved, irreversible API call), gate it.
 
 The block is optional. Absent block ⇒ no approval needed.
 
@@ -225,8 +244,8 @@ Brief prose explanation of the steps. Mention any non-obvious behavior
 
 ## Inputs
 
-- `channel` — Slack channel to post to.
-- `summary` — One or two sentences about what shipped.
+- `query` — Optional Gmail search query.
+- `max_results` — Page size cap (default 10).
 ```
 
 Write the body for the LLM first. Trigger phrases and a tight one-paragraph description matter more than ASCII art. Avoid hedging language ("might", "sometimes", "depending on") — the LLM uses prose to predict the function's behavior, and uncertain prose makes it less likely to invoke when it should.
@@ -236,7 +255,7 @@ Write the body for the LLM first. Trigger phrases and a tight one-paragraph desc
 A few non-obvious behaviors worth knowing:
 
 - **Inputs from `[[inputs]]` are merged with `[execute.inputs]`.** v1 passes both through to the connector op. The connector receives the call-time args plus whatever the step declared.
-- **Connector ops get the JSON envelope shape from [Authoring a Connector](/guides/authoring-a-connector/)** — `{op: "post_message", args: {channel: "#engineering", text: "..."}}`. The action's job is to produce that shape; the connector's job is to dispatch on it.
+- **Connector ops get the JSON envelope shape from [Authoring a Connector](/guides/authoring-a-connector/)** — `{op: "list_recent_emails", args: {query: "is:unread", max_results: 10}}`. The action's job is to produce that shape; the connector's job is to dispatch on it.
 - **Step output becomes the action result.** When all steps succeed, the runtime aggregates them into the final result. v1 returns the last successful step's output as the primary content.
 - **Capability denial is sticky.** If a step tries a network call to a host outside the connector's manifest, or outside the action's declared capability subset, the call is denied at the sandbox boundary and the step fails. The runtime does not silently retry or substitute.
 
@@ -246,8 +265,8 @@ This is worth understanding because it shapes what `capabilities` should contain
 
 When a step runs:
 
-1. **Connector boundary.** The runtime checks the call against the connector's manifest. If the connector declared `chat:write` and the call is `chat:write`, fine. If the connector did not declare it, the call is denied.
-2. **Action boundary.** The runtime *also* checks the call against the action's declared capability subset. If the action declared `["chat:write"]` and the connector tries something else, the call is denied — even though the connector itself permits it.
+1. **Connector boundary.** The runtime checks the call against the connector's manifest. If the connector declared `gmail.googleapis.com:443` in `[capabilities.network].hosts` and the call dials that host, fine. If the connector tries to dial anywhere else, the call is denied.
+2. **Action boundary.** The runtime *also* checks the call against the action's declared capability subset. If the action declared `["list_recent_emails"]` and the step tries to invoke `send_email` instead, the call is denied — even though the connector itself permits it.
 
 Both gates fire on every call. Either denies and the step fails. The action's `capabilities` list is the second gate; declare the minimum subset you need so adding a new capability later is a visible TOML diff for the user, not a silent change in behavior.
 
@@ -256,25 +275,25 @@ Both gates fire on every call. Either denies and the step fails. The action's `c
 The fastest loop is to install a real template, edit the local file, and run it through the agent.
 
 ```sh
-# Install a template you'll modify
-$ aileron action add hub://aileron/ship-update@1.0.0
-✓ Action file written to ~/.aileron/actions/ship-update.md
+# Install a template you'll modify (replace <version> with a real tag)
+$ aileron action add github://ALRubinger/aileron-connector-google/actions/list-recent-emails@<version>
+✓ Action file written to ~/.aileron/actions/list-recent-emails.md
 
 # Edit the file
-$ $EDITOR ~/.aileron/actions/ship-update.md
+$ $EDITOR ~/.aileron/actions/list-recent-emails.md
 
 # Validation runs on every load — invalid frontmatter surfaces immediately
 $ aileron action list
-ship-update  1.0.0  hub://aileron/ship-update@1.0.0
+list-recent-emails  0.0.1  github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.1
 ```
 
-When you have written something the runtime does not like — missing field, malformed FQN, unknown frontmatter key — `aileron action list` and `aileron action show ship-update` surface the error with the file and (when known) the line. Fix it in place and try again.
+When you have written something the runtime does not like — missing field, malformed FQN, unknown frontmatter key — `aileron action list` and `aileron action show list-recent-emails` surface the error with the file and (when known) the line. Fix it in place and try again.
 
 To exercise the action end-to-end, drive it through `aileron launch` — the agent picks it up automatically once it is in the actions directory.
 
 ## Common authoring mistakes
 
-- **Forgetting `hash`.** The validator requires `sha256:<hex>` on every `[[requires.connectors]]` entry. Get it from the connector's release tarball or from `aileron connector show <FQN>` after install.
+- **Forgetting `hash`.** The validator requires `sha256:<hex>` on every `[[requires.connectors]]` entry. In a published template, the placeholder `sha256:bound-at-release` is what the source carries; CI substitutes the real hash at release time. If you are hand-writing an action against a connector you've already installed, get the hash from `aileron connector show <FQN>`.
 - **Listing more capabilities than you use.** The action boundary enforces the subset you declare; declaring more weakens the audit story. Strip capabilities aggressively.
 - **A `${args.X}` reference that does not match an input.** Validation catches this — the error names the offending step, key, and missing input.
 - **Multi-paragraph descriptions on inputs.** The LLM reads `description` as a single line. Keep it tight.

--- a/docs/src/content/docs/guides/publishing-a-connector.md
+++ b/docs/src/content/docs/guides/publishing-a-connector.md
@@ -3,32 +3,40 @@ title: "Publishing a Connector"
 description: "How to author, sign, and release a connector + action templates that Aileron users can install via aileron connector install / aileron action add."
 ---
 
-This guide walks through publishing a connector and its action templates so Aileron users can install them via `aileron connector install <FQN>` and `aileron action add <FQN>`. It documents the conventions Aileron's install pipeline expects: where the binary lives, how it's signed, how the user trusts your publisher key.
+This guide walks through publishing a connector and its action templates so Aileron users can install them via `aileron connector install <FQN>` and `aileron action add <FQN>`. It documents the conventions Aileron's install pipeline expects: where the binary lives, how it's signed, how the user trusts your publisher key, and how a single tag push produces every artifact in a release cohort.
 
-The reference implementation is `github.com/ALRubinger/aileron-connector-github` — a per-service connector exposing GitHub ops with action templates living alongside.
+The reference implementation is [`github.com/ALRubinger/aileron-connector-google`](https://github.com/ALRubinger/aileron-connector-google) — a per-service connector exposing six Gmail and Calendar ops with action templates living alongside. Snippets here mirror its layout; clone the repo when you want to see the full working setup.
 
-## The two-repo model
+## The one-repo-per-service model
 
-Per [ADR-0002](/adr/0002-connector-model), connectors are sandboxed binaries with their own publication identity and lifecycle. **A connector lives in its own repository, separate from Aileron itself.** A security fix to the GitHub connector should not require an Aileron release; Aileron's tag space should not be polluted with connector tags.
+Per [ADR-0002](/adr/0002-connector-model), connectors are sandboxed binaries with their own publication identity and lifecycle. **A connector lives in its own repository, separate from Aileron itself.** A security fix to the Google connector should not require an Aileron release; Aileron's tag space should not be polluted with connector tags.
 
-Convention: one repo per external service, named `aileron-connector-<service>` (e.g. `aileron-connector-github`, `aileron-connector-slack`). One connector binary per repo, exposing all of that service's ops. Action templates that exercise the connector live in the same repo at `actions/<name>/`. This matches the Terraform-provider pattern: one provider per service, dozens of resources inside.
+Convention: one repo per external service, named `aileron-connector-<service>` (e.g. `aileron-connector-google`, `aileron-connector-slack`). One connector binary per repo, exposing all of that service's ops. Action templates that exercise the connector live in the same repo at `actions/<name>/`. This matches the Terraform-provider pattern: one provider per service, dozens of resources inside.
 
 ## Repository layout
 
 ```
-aileron-connector-github/
+aileron-connector-google/
 ├── connector/
-│   ├── main.go              # wasip1 Go source
-│   ├── manifest.toml        # capability declarations
-│   └── README.md
+│   ├── main.go              # //go:build wasip1 — WASM entry, host-import calls
+│   ├── helpers.go           # untagged — host-testable pure helpers
+│   ├── helpers_test.go
+│   ├── go.mod
+│   └── manifest.toml        # capability declarations + OAuth provider config
 ├── actions/
-│   ├── list-recent-prs/
-│   │   └── action.md
-│   └── file-bug/
-│       └── action.md
-├── Taskfile.yml             # build, sign, package
-├── keys/                    # public keys committed; private keys NEVER committed
-│   └── publisher.pub
+│   ├── list-recent-emails/action.md
+│   ├── get-email/action.md
+│   ├── list-upcoming-events/action.md
+│   ├── draft-email/action.md
+│   ├── send-email/action.md
+│   └── create-calendar-event/action.md
+├── keys/
+│   ├── publisher.pub        # committed (PEM)
+│   └── README.md            # how consumers extract the raw key for their keyring
+├── Taskfile.yml             # build, pack, hash, test
+├── .github/workflows/
+│   ├── ci.yml
+│   └── release.yml          # one tag push → connector + every action tarball
 └── README.md
 ```
 
@@ -36,20 +44,22 @@ aileron-connector-github/
 
 ```toml
 [connector]
-name = "github://<owner>/aileron-connector-github"
-version = "0.1.0"
+name = "github://<owner>/aileron-connector-<service>"
+version = "0.0.0-dev"     # CI substitutes the real version at release time
 publisher = "Your Name"
 
 [capabilities.network]
-hosts = ["api.github.com:443"]
+hosts = ["api.example.com:443"]
 
 [capabilities.credential]
-kind = "api_key"
-scope = "repo:read"
+kind = "oauth2"
+scope = "Read messages and create events"   # human-readable; surfaced in CLI prompts
 
 [capabilities.runtime]
 imports = ["log", "http_request", "http_response_size", "http_response_status", "http_response_read"]
 ```
+
+`version = "0.0.0-dev"` is a deliberate placeholder. The release workflow substitutes the real version (extracted from the pushed tag) into a build copy of the manifest before signing — see [Releasing](#releasing) below. The committed source stays a template, so the publisher pushes a tag and never edits version fields by hand.
 
 ### OAuth2 connectors
 
@@ -58,21 +68,28 @@ A connector that needs OAuth2 access declares the OAuth provider config inside `
 ```toml
 [capabilities.credential]
 kind = "oauth2"
-scope = "Read your email and send messages"   # human-readable; surfaced in CLI prompts
+scope = "Read your Gmail messages and Calendar events; create drafts and calendar events"
 
 [capabilities.credential.oauth2]
 authorize_url = "https://accounts.google.com/o/oauth2/v2/auth"
 token_url     = "https://oauth2.googleapis.com/token"
-client_id     = "1234567890-xxxxxxx.apps.googleusercontent.com"
+client_id     = "298373247853-i63n2n3ghapvbsjn3ocb2jr6u9vkcmih.apps.googleusercontent.com"
+client_secret = "bound-at-release"
 scopes = [
-  "https://www.googleapis.com/auth/gmail.send",
+  "https://www.googleapis.com/auth/gmail.readonly",
+  "https://www.googleapis.com/auth/gmail.compose",
   "https://www.googleapis.com/auth/calendar.readonly",
+  "https://www.googleapis.com/auth/calendar.events",
 ]
 ```
 
 **Trust model: publishers register their own OAuth apps.** Each connector publisher creates an OAuth app on the target service (Google Cloud Console, Slack API dashboard, Notion integrations panel, etc.) and pastes the resulting `client_id` into the manifest. The user's consent screen names the publisher — *your* app name appears, not Aileron's. This is the load-bearing trust property of ADR-0002: the OAuth client is whoever wrote the code that will use the access.
 
-**No `client_secret` field.** v1 requires PKCE (S256) for installed-app flows. The "secret" most providers list for installed apps isn't actually secret per their own guidance — PKCE is the cryptographic protection. The manifest carries no secrets.
+**`client_secret` is sometimes required, and is bound at release time.** Aileron's OAuth dance uses PKCE (S256) per [ADR-0006](/adr/0006-capability-binding-ux/), but several providers — Google's "Desktop app" OAuth client type is the canonical example — still require `client_secret` on token-exchange and refresh requests. This is a provider quirk, not a spec requirement; PKCE is doing the cryptographic work, but the API rejects the call without the value present.
+
+For providers that demand it, the value ships in the connector binary the same way `gcloud` and `gh` ship their bundled secrets. **Never commit it to the repo** — GitHub's secret scanner forwards Google client secrets to Google, which auto-rotates them on detection. The committed source manifest carries `client_secret = "bound-at-release"` as a placeholder; the release workflow substitutes it from a repo secret (e.g. `GOOGLE_OAUTH_CLIENT_SECRET`) before signing and packing. The bound value lives only in the signed connector tarball.
+
+For providers that *don't* require `client_secret` (most non-Google OAuth servers), omit the field. The manifest validator allows omission.
 
 **Loopback redirect required.** When you register your OAuth app with the provider, register `http://localhost` (and/or `http://127.0.0.1`) as a valid redirect URI. The Aileron runtime allocates a free loopback port at bind time and serves the callback locally. Niche providers without loopback support are post-MVP.
 
@@ -98,91 +115,132 @@ Every field is enforced by the install pipeline:
 - `name` must match the FQN used at install time (no spoofing).
 - `version` is strict SemVer.
 - `[capabilities.network].hosts` is a closed list of `host:port` pairs (no wildcards). The runtime denies any outbound request not on the list.
-- `[capabilities.credential].kind` must equal the kind on the user's binding (`api_key` for v1; `oauth2` lands with [#388](https://github.com/ALRubinger/aileron/issues/388)).
+- `[capabilities.credential].kind` must equal the kind on the user's binding. v1 supports `api_key` and `oauth2`.
 
 ## WASM build
 
-The connector is a `wasip1` Go program that imports four host functions:
+The connector is a `wasip1` Go program — see [Authoring a Connector](/guides/authoring-a-connector/) for the full host-import ABI and source structure. Build via Taskfile from the repo root:
 
-```go
-//go:wasmimport aileron_host log
-func hostLog(...)
-
-//go:wasmimport aileron_host http_request
-func hostHTTPRequest(...) int32
-
-//go:wasmimport aileron_host http_response_size
-func hostHTTPResponseSize() int32
-
-//go:wasmimport aileron_host http_response_status
-func hostHTTPResponseStatus() int32
-
-//go:wasmimport aileron_host http_response_read
-func hostHTTPResponseRead(...) int32
+```sh
+task build
 ```
 
-The `internal/sandbox/testdata/echo/main.go` fixture in the Aileron repo is the canonical reference for the I/O envelope shape (JSON in on stdin, JSON out on stdout).
-
-Build with:
+…or directly:
 
 ```sh
 cd connector
-GOOS=wasip1 GOARCH=wasm go build -o ../build/connector.wasm .
+GOOS=wasip1 GOARCH=wasm go build -trimpath -ldflags='-s -w' -o ../connector.wasm .
 ```
+
+`-trimpath` and `-ldflags='-s -w'` keep the binary reproducible and small (the resulting `.wasm` ends up content-addressed in the user's store, so smaller is faster to fetch).
 
 ## Signing
 
 Aileron verifies every install with an ed25519 signature over `binary || manifest`. Publishers generate one keypair per repo (or per publisher identity), keep the private key out of the repo, and commit only the public key.
 
-Generate the keypair once:
+### Generate the keypair (one-time)
 
 ```sh
-go run github.com/ALRubinger/aileron/connectors/sign/keygen \
-  > keys/publisher.priv  # KEEP THIS OUT OF THE REPO
+# 1. Generate. Private key in /tmp briefly; public goes in the repo.
+openssl genpkey -algorithm ed25519 -out /tmp/publisher.key
+openssl pkey -in /tmp/publisher.key -pubout -out keys/publisher.pub
+
+# 2. Encode the private key for the GitHub Actions secret.
+#    macOS:
+base64 -i /tmp/publisher.key | pbcopy
+#    Linux:
+# base64 < /tmp/publisher.key | xclip -selection clipboard
+
+# 3. In GitHub: repo Settings → Secrets and variables → Actions →
+#    New repository secret. Name: AILERON_SIGNING_KEY. Value: paste.
+
+# 4. Save the PRIVATE key to a password manager, then delete the local copy:
+rm /tmp/publisher.key
+
+# 5. Commit the public key:
 git add keys/publisher.pub
+git commit -m "feat(keys): commit publisher signing public key"
+git push
 ```
 
-Sign the tarball at release time:
+### Sign at release time
+
+The CI release workflow does this for you (see [Releasing](#releasing)). For reference, the signing step is:
 
 ```sh
-go run github.com/ALRubinger/aileron/connectors/sign \
-  --priv keys/publisher.priv \
-  --binary build/connector.wasm \
-  --manifest connector/manifest.toml \
-  --out build/signature.sig
+# Hash input is the canonical concatenation: binary || manifest.
+cat connector.wasm connector/manifest.toml > /tmp/payload.bin
+
+# Sign with the ed25519 private key (rawin = sign the bytes, not a hash of them).
+openssl pkeyutl -sign -rawin -inkey /tmp/publisher.key \
+  -in /tmp/payload.bin -out signature.sig
+
+# Pack the flat archive Aileron's install pipeline expects.
+mkdir -p /tmp/pack
+cp connector.wasm           /tmp/pack/
+cp connector/manifest.toml  /tmp/pack/
+cp signature.sig            /tmp/pack/
+tar czf aileron.tar.gz -C /tmp/pack \
+  connector.wasm manifest.toml signature.sig
 ```
 
-Build the tarball:
+The tarball must be flat: exactly three files at the root (`connector.wasm`, `manifest.toml`, `signature.sig`), no `connector/` directory prefix. The Aileron install pipeline (`internal/cstore/tarball.go`) requires that exact shape.
+
+## Releasing
+
+**One tag, one workflow run, all artifacts.** The publisher pushes a `vX.Y.Z` tag; CI does the rest. There are no manifest edits before tagging — the source manifests are templates with placeholder versions and a placeholder connector hash, and CI substitutes the real values into build copies before signing and packing.
 
 ```sh
-tar czf build/aileron.tar.gz \
-  -C build connector.wasm signature.sig \
-  -C ../connector manifest.toml
+git tag vX.Y.Z
+git push origin vX.Y.Z
+# Wait ~2 minutes. Done — connector + every action tarball is published
+# at the per-FQN tag the install pipeline expects.
 ```
 
-## Release tag conventions
+The source manifests carry placeholders that CI binds at release time:
+
+- `version = "0.0.0-dev"` in `connector/manifest.toml` and every `actions/*/action.md` (also in each action's `source` URL and `[[requires.connectors]]` block). CI replaces `0.0.0-dev` with the version from the pushed tag.
+- `hash = "sha256:bound-at-release"` in every action manifest's `[[requires.connectors]]` block. CI replaces this with the connector tarball's real content hash, computed after the connector is built in the same workflow run.
+- `client_secret = "bound-at-release"` in the connector manifest, for OAuth providers that require it. CI replaces this from a repository secret.
+
+What CI does on each `vX.Y.Z` push (see [`release.yml`](https://github.com/ALRubinger/aileron-connector-google/blob/main/.github/workflows/release.yml) in the reference repo):
+
+1. Substitutes `0.0.0-dev` with the tag's version across every manifest in the working tree.
+2. Substitutes `client_secret = "bound-at-release"` with the repo secret value (OAuth providers that need it).
+3. Builds `connector.wasm` (wasip1).
+4. Computes `sha256(connector.wasm || manifest.toml)` — the canonical-hash input from ADR-0004.
+5. Signs the connector payload, packs `aileron.tar.gz`, publishes at tag `vX.Y.Z`.
+6. For each `actions/*/action.md`: substitutes `sha256:bound-at-release` with the real connector hash, signs the substituted manifest, packs `aileron.tar.gz`, publishes at tag `actions/<name>/vX.Y.Z`.
+
+All artifacts in a version cohort share provenance — every per-action release is created at the same commit the connector tag points at, with all action tarballs pinned to the same connector content hash.
+
+### Release tag conventions
 
 Aileron's resolver per [ADR-0004](/adr/0004-dependency-resolution) maps FQNs to GitHub release URLs:
 
-- **Single-artifact repo** (one connector at the root): tag `v<version>`.
-  - `github://acme/aileron-connector-foo@0.1.0` → tag `v0.1.0`.
-- **Monorepo subpath** (action templates living under the connector repo): tag `<subpath>/v<version>`.
-  - `github://acme/aileron-connector-foo/actions/list-prs@0.1.0` → tag `actions/list-prs/v0.1.0`.
+- **Connector** (one connector at the root of the repo): tag `v<version>`.
+  - `github://ALRubinger/aileron-connector-google@0.0.1` → tag `v0.0.1`.
+- **Action** (action templates under the connector repo): tag `actions/<name>/v<version>`.
+  - `github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.1` → tag `actions/list-recent-emails/v0.0.1`.
 
 The release asset must be named `aileron.tar.gz` for both connectors and actions.
 
-Action tarballs contain `action.md` and an optional `signature.sig` (signed over the action.md bytes alone). v1 keeps action signing optional; mandatory signing lands with the install consent flow ([#363](https://github.com/ALRubinger/aileron/issues/363)).
+Action tarballs contain `action.md` and `signature.sig` (signed over the substituted action.md bytes alone — the version and hash placeholders are replaced *before* signing).
+
+### What you see on the releases page
+
+Each `vX.Y.Z` push produces one connector release plus one per-action release, all from the same commit. The connector release (tagged `vX.Y.Z`) carries the **Latest** badge; the per-action releases (tagged `actions/<name>/vX.Y.Z`) are marked **Pre-release** so the page anchors visually on the connector. Per-action tags are how Aileron's resolver locates artifacts — they aren't subordinate releases despite their tag prefix; they're sibling artifacts in the same cohort, all pinned to the same connector content hash.
 
 ## How users trust your publisher
 
-Aileron ships with **no trusted publishers by default** — the keyring is fail-closed. Users opt in to your publisher by adding the public key to `~/.aileron/keyring.json`:
+Aileron ships with **no trusted publishers by default** — the keyring is fail-closed (`internal/cstore/keyring_config.go`). Users opt in to your publisher by adding the public key to `~/.aileron/keyring.json`:
 
 ```json
 {
   "version": 1,
   "publishers": {
-    "github://acme/aileron-connector-foo": [
-      "BASE64_ENCODED_ED25519_PUBLIC_KEY"
+    "github://ALRubinger/aileron-connector-google": [
+      "BASE64_ENCODED_RAW_ED25519_PUBLIC_KEY"
     ]
   }
 }
@@ -190,74 +248,80 @@ Aileron ships with **no trusted publishers by default** — the keyring is fail-
 
 The authority key is the FQN base (`<scheme>://<owner>/<repo>`); the value is a list of public keys (a list to support key rotation — register the new key alongside the old, switch signing, drop the old).
 
-Document the registration step in your connector's README so users know what to copy into their keyring.
+The keyring stores the **raw 32-byte ed25519 public key**, base64-encoded. `keys/publisher.pub` in your repo is the PEM form (a 44-byte SubjectPublicKeyInfo wrapping the same 32 raw bytes); consumers extract the raw form once with:
+
+```sh
+PUB_KEY_RAW=$(openssl pkey -in keys/publisher.pub -pubin -outform DER | tail -c 32 | base64)
+```
+
+…then paste `$PUB_KEY_RAW` into the keyring entry above.
+
+Document the extraction + registration steps in your connector's README so users know exactly what to copy into their keyring. Without an entry in the keyring for your authority, `aileron connector install` fails closed with `signature_failure` — unsigned or unverified binaries never reach disk.
 
 ## Action templates
 
-An action template is a Markdown file with TOML frontmatter that references your connector by FQN+version+hash:
+An action template is a Markdown file with TOML frontmatter that references your connector by FQN+version+hash. The full guide is [Authoring an Action](/guides/authoring-an-action/); from a publishing perspective the key point is the **placeholder convention**:
 
 ```markdown
 +++
-name = "list-recent-prs"
-version = "0.1.0"
-source = "github://acme/aileron-connector-foo/actions/list-recent-prs@0.1.0"
+name = "list-recent-emails"
+version = "0.0.0-dev"
+source = "github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.0-dev"
 
 [[requires.connectors]]
-name = "github://acme/aileron-connector-foo"
-version = "0.1.0"
-hash = "sha256:abc123..."          # paste the connector's canonical hash
-capabilities = ["list_prs"]        # subset the action exercises
+name = "github://ALRubinger/aileron-connector-google"
+version = "0.0.0-dev"
+hash = "sha256:bound-at-release"
+capabilities = ["list_recent_emails"]
 
 [match]
-intent = "list recent merged PRs"
-
-[[inputs]]
-name = "owner"
-type = "string"
-description = "Repository owner."
-
-[[inputs]]
-name = "repo"
-type = "string"
-description = "Repository name."
+intent = "list my recent Gmail messages"
 
 [[execute]]
 id = "list"
-connector = "github://acme/aileron-connector-foo"
-op = "list_prs"
+connector = "github://ALRubinger/aileron-connector-google"
+op = "list_recent_emails"
+idempotent = true
 
-[execute.inputs]
-owner = "${args.owner}"
-repo = "${args.repo}"
+[[inputs]]
+name = "query"
+type = "string"
+description = "Optional Gmail search query, e.g. \"is:unread\"."
+required = false
 +++
 
-# List recent PRs
+# List Recent Gmail Messages
 
-Lists recent merged PRs in a GitHub repository.
+Fetches a list of recent Gmail messages for the authenticated user.
 ```
 
-The Markdown body is the LLM-facing function description. Write tight prose — the LLM reads it to decide when to invoke the action.
+`0.0.0-dev` and `sha256:bound-at-release` stay in the committed source. The release workflow substitutes both into a build copy before signing, so every action in a cohort automatically pins to the same connector hash with no per-release commits. The Markdown body is the LLM-facing function description — write tight prose, the LLM reads it to decide when to invoke.
 
 ## End-to-end install flow
 
 Once published, a user runs:
 
 ```sh
-# Trust the publisher (one-time)
-echo '{"version":1,"publishers":{"github://acme/aileron-connector-foo":["BASE64..."]}}' \
+# Trust the publisher (one-time per user)
+PUB_KEY_RAW=$(curl -fsSL https://raw.githubusercontent.com/ALRubinger/aileron-connector-google/main/keys/publisher.pub \
+  | openssl pkey -pubin -outform DER | tail -c 32 | base64)
+
+mkdir -p ~/.aileron
+jq -n --arg key "$PUB_KEY_RAW" \
+  '{version:1, publishers:{"github://ALRubinger/aileron-connector-google":[$key]}}' \
   > ~/.aileron/keyring.json
 
-# Install the connector
-aileron connector install github://acme/aileron-connector-foo@0.1.0
+# Install the connector at a specific tag
+aileron connector install github://ALRubinger/aileron-connector-google@0.0.1
 
-# Install the action template
-aileron action add github://acme/aileron-connector-foo/actions/list-recent-prs@0.1.0
+# Install one of its action templates
+aileron action add github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.1
 
-# Bind the credential
-aileron binding setup github://acme/aileron-connector-foo
-# (CLI prompts for the api_key value)
+# Bind the credential — for OAuth2, drives the consent dance in the browser
+aileron binding setup github://ALRubinger/aileron-connector-google
 
 # Action is now available to the agent.
+aileron launch claude
 ```
 
 ## Versioning


### PR DESCRIPTION
## Summary

Audits the three Guides against [`github.com/ALRubinger/aileron-connector-google`](https://github.com/ALRubinger/aileron-connector-google) — the actual reference connector — and replaces invented examples, fictional tools, and incorrect facts with what the real repo does.

## What changed by guide

**Authoring a Connector**
- Replace fictional Slack examples with real Gmail (`list_recent_emails`) shape.
- Fix the error-class table: drop non-canonical `bad_input` / `external_service_error` / `unknown_op`; document the actual closed set from `internal/failure/failure.go` (`external_api_error`, `connector_runtime_error`, plus the runtime-emitted `capability_denied` / `binding_required`).
- Update manifest example to mirror the real Google manifest.
- Add the `helpers.go` (untagged) split — pattern for host-testable pure helpers separate from the wasip1-only `main.go`.
- Add an idempotency contract section (read ops vs write ops; coupling to the action manifest's `idempotent` flag).
- Replace the ad-hoc `aileron connector install --local` aside with the real `aileron-connector-dev-run` E2E path.

**Authoring an Action**
- Replace the fictional `ship-update` example with the real `list-recent-emails`.
- Document the `0.0.0-dev` / `sha256:bound-at-release` placeholder convention used in published source templates (and how CI substitutes both at tag-push time).
- Add the `idempotent` flag explanation under `[[execute]]` — was missing entirely.
- Strengthen the `[approval]` section with the real reversibility taxonomy (draft un-gated; send + create-event gated, with the rationale).
- Update the capability-gate example to use a real network host + op-name capability.

**Publishing a Connector**
- Replace fictional `aileron-connector-github` / `acme/aileron-connector-foo` with the real `aileron-connector-google` throughout.
- **MAJOR FIX:** `client_secret` is required by some providers (Google Desktop OAuth being the canonical case). The guide previously claimed the manifest carries no secrets, period — wrong. Documents the bound-at-release pattern with a repo secret (`GOOGLE_OAUTH_CLIENT_SECRET`) substituted by CI; clarifies that providers not requiring the field can omit it.
- Replace the fictional `go run github.com/ALRubinger/aileron/connectors/sign` tool (does not exist) with the real `openssl pkeyutl -sign -rawin` flow.
- Update repo layout to match the real one (`Taskfile.yml`, `.github/workflows/release.yml`, `keys/` with PEM `publisher.pub`).
- Add a full **Releasing** section describing the one-tag → (connector tarball + every action tarball) CI workflow with all three placeholder substitutions.
- Update the keyring extraction step to reflect the actual schema (raw 32-byte ed25519 key, `openssl` extraction from PEM).
- Update install flow with the real publisher key + FQN.

## Test plan

- [x] `task build:docs` succeeds; all three pages render.
- [x] Grep audit of guides finds zero residual `external_service_error`, `bad_input`, `aileron-connector-foo`, `aileron-connector-github`, `connectors/sign`, or `github://acme` references.
- [ ] Visual check: snippets compile mentally against the real `connector/main.go` and `actions/*/action.md` in `aileron-connector-google`.
- [ ] Sanity-check the OAuth `client_secret` paragraph — the guide now contradicts what it used to say, so future readers must come away with the correct mental model (PKCE is the cryptographic protection; `client_secret` for Desktop apps is a Google API quirk, value is bundled-not-secret, never committed to source).

🤖 Generated with [Claude Code](https://claude.com/claude-code)