### PR TITLE
feat(audit): file-backed JSONL persistence for the action-execution log (#412)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -317,13 +317,15 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	}
 
 	// --- Audit log (ADR-0010) ---
-	// The in-memory store is sufficient for v1 dev/test; Postgres
-	// persistence is post-MVP. The recorder mints audit IDs and
-	// stamps them onto failures so the agent's response carries a
-	// working back-reference into the audit log. Built before the
-	// sandbox executor and binding store so each can emit lifecycle
-	// events through the same recorder.
-	auditStore := audit.NewMemStore()
+	// File-backed JSONL by default so events survive daemon restart;
+	// fall back to the in-memory store when no path is configured (the
+	// AILERON_AUDIT_PATH env var explicitly set to empty) or when the
+	// file path can't be opened. Postgres persistence is post-MVP. The
+	// recorder mints audit IDs and stamps them onto failures so the
+	// agent's response carries a working back-reference into the audit
+	// log. Built before the sandbox executor and binding store so each
+	// can emit lifecycle events through the same recorder.
+	auditStore := newAuditStore(log)
 	recorder := audit.NewRecorder(auditStore, nil, nil)
 	server.auditStore = auditStore
 	server.auditRecorder = recorder

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -99,7 +99,7 @@ type apiServer struct {
 	openAIProxy        http.Handler                // upstream proxy for /v1/chat/completions; nil disables the endpoint
 	anthropicProxy     http.Handler                // upstream proxy for /v1/messages; nil disables the endpoint
 	interceptEngine    interceptEngineHandle       // tool-call intercept engine; nil disables interception (proxy passthrough only)
-	auditStore         *audit.MemStore             // ADR-0010 audit store; in-memory for v1, Postgres post-MVP
+	auditStore         audit.EventStore            // ADR-0010 audit store; file-backed by default, MemStore in tests, Postgres post-MVP
 	auditRecorder      audit.Recorder              // ADR-0010 recorder; mints audit IDs and emits binding-lifecycle events
 	vaultLocked        bool                        // ADR-0011 gate: when true, gateway endpoints refuse to serve until the vault is unlocked
 	lockableVault      *vault.LockableVault        // wraps s.vault when the daemon runs with a deferred-unlock local vault (#429); nil otherwise

--- a/internal/app/handlers_bindings_test.go
+++ b/internal/app/handlers_bindings_test.go
@@ -740,8 +740,10 @@ func TestSetup_NoInstallerReturns503(t *testing.T) {
 
 // --- audit helpers ---
 
-// dumpEvents reads every recorded event from the in-memory audit store.
-func dumpEvents(t *testing.T, store *audit.MemStore) []audit.Event {
+// dumpEvents reads every recorded event from the audit store. Accepts
+// any EventStore so tests written against MemStore continue to work
+// after the production wiring switched to FileStore.
+func dumpEvents(t *testing.T, store audit.EventStore) []audit.Event {
 	t.Helper()
 	traces, err := store.ListTraces(context.Background(), audit.Filter{})
 	if err != nil {

--- a/internal/app/handlers_status.go
+++ b/internal/app/handlers_status.go
@@ -1,11 +1,13 @@
 package app
 
 import (
+	"log/slog"
 	"net/http"
 	"os"
 	"path/filepath"
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
+	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/vault"
 	"github.com/ALRubinger/aileron/internal/version"
 )
@@ -115,4 +117,41 @@ func defaultVaultPath() string {
 		return filepath.Join(".aileron", "secrets.json")
 	}
 	return filepath.Join(home, ".aileron", "secrets.json")
+}
+
+// resolveAuditPath returns the JSONL path the action-execution audit
+// store should write to, honoring AILERON_AUDIT_PATH.
+//
+//   - env unset → default `<home>/.aileron/audit.jsonl`
+//   - env explicitly empty → "" (caller falls back to in-memory store)
+//   - env set → that exact path
+func resolveAuditPath() string {
+	if p, ok := os.LookupEnv("AILERON_AUDIT_PATH"); ok {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".aileron", "audit.jsonl")
+	}
+	return filepath.Join(home, ".aileron", "audit.jsonl")
+}
+
+// newAuditStore picks the audit-store implementation per
+// resolveAuditPath. A file-open failure logs a warning and falls back
+// to in-memory so the daemon still starts (degraded durability beats
+// no daemon).
+func newAuditStore(log *slog.Logger) audit.EventStore {
+	path := resolveAuditPath()
+	if path == "" {
+		log.Info("audit store: in-memory; events will not survive daemon restart (set AILERON_AUDIT_PATH to enable persistence)")
+		return audit.NewMemStore()
+	}
+	fs, err := audit.NewFileStore(path, log)
+	if err != nil {
+		log.Warn("audit store: could not open file, falling back to in-memory",
+			"path", path, "error", err.Error())
+		return audit.NewMemStore()
+	}
+	log.Info("audit store: file-backed", "path", path)
+	return fs
 }

--- a/internal/app/handlers_status_test.go
+++ b/internal/app/handlers_status_test.go
@@ -3,13 +3,17 @@ package app
 import (
 	"context"
 	"encoding/json"
+	"io"
+	"log/slog"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
+	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/binding"
 	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/vault"
@@ -256,5 +260,74 @@ func TestDefaultVaultPath_FromHome(t *testing.T) {
 	want := filepath.Join("/test/home", ".aileron", "secrets.json")
 	if got != want {
 		t.Errorf("defaultVaultPath = %q, want %q", got, want)
+	}
+}
+
+// TestResolveAuditPath_DefaultsToHome asserts the env-unset path
+// lands at `<home>/.aileron/audit.jsonl`.
+func TestResolveAuditPath_DefaultsToHome(t *testing.T) {
+	t.Setenv("HOME", "/test/home")
+	os.Unsetenv("AILERON_AUDIT_PATH")
+	got := resolveAuditPath()
+	want := filepath.Join("/test/home", ".aileron", "audit.jsonl")
+	if got != want {
+		t.Errorf("resolveAuditPath = %q, want %q", got, want)
+	}
+}
+
+// TestResolveAuditPath_RespectsEnvVar asserts that an explicit env
+// value (including an empty string for the in-memory opt-out)
+// supersedes the home-based default.
+func TestResolveAuditPath_RespectsEnvVar(t *testing.T) {
+	t.Setenv("AILERON_AUDIT_PATH", "/tmp/x/y/audit.jsonl")
+	if got := resolveAuditPath(); got != "/tmp/x/y/audit.jsonl" {
+		t.Errorf("resolveAuditPath = %q, want explicit", got)
+	}
+	t.Setenv("AILERON_AUDIT_PATH", "")
+	if got := resolveAuditPath(); got != "" {
+		t.Errorf("resolveAuditPath with empty env = %q, want empty (memory opt-out)", got)
+	}
+}
+
+// TestNewAuditStore_FileBackedByDefault asserts that the wiring
+// chooses FileStore when AILERON_AUDIT_PATH points at a writable
+// path. Regression guard for the bug behind issue #412: events
+// recorded under aileron launch did not survive process exit.
+func TestNewAuditStore_FileBackedByDefault(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	t.Setenv("AILERON_AUDIT_PATH", path)
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := newAuditStore(log)
+	if _, ok := store.(*audit.FileStore); !ok {
+		t.Fatalf("got %T, want *audit.FileStore", store)
+	}
+
+	// Round-trip through the file: append, then a fresh FileStore
+	// must surface the same event after replay.
+	if err := store.Append(context.Background(), audit.Event{
+		EventID: "wired", Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	reopened, err := audit.NewFileStore(path, log)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if _, ok := reopened.GetByEventID("wired"); !ok {
+		t.Error("event 'wired' did not survive into a fresh reader")
+	}
+}
+
+// TestNewAuditStore_FallsBackToMemoryWhenEnvEmpty asserts the explicit
+// in-memory opt-out path: tests and ephemeral contexts that set
+// `AILERON_AUDIT_PATH=` (empty) get a MemStore back.
+func TestNewAuditStore_FallsBackToMemoryWhenEnvEmpty(t *testing.T) {
+	t.Setenv("AILERON_AUDIT_PATH", "")
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	store := newAuditStore(log)
+	if _, ok := store.(*audit.MemStore); !ok {
+		t.Errorf("got %T, want *audit.MemStore for empty AILERON_AUDIT_PATH", store)
 	}
 }

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -1,0 +1,193 @@
+package audit
+
+import (
+	"bufio"
+	"context"
+	"encoding/json"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"sync"
+
+	"github.com/ALRubinger/aileron/internal/model"
+)
+
+// FileStore is a JSONL-backed audit store: one event per line,
+// append-only, durable across daemon restarts. Reads are served
+// from an in-memory index rebuilt at startup, so the on-disk file is
+// authoritative and the in-memory copy is a cache.
+//
+// Per ADR-0010 this is the v0.x persistence target — Postgres /
+// signed log are post-MVP and operate over the same SPI. Rotation,
+// retention, and dedup are deliberately not implemented.
+type FileStore struct {
+	path string
+	log  *slog.Logger
+	mu   sync.Mutex // serializes appends so file order matches mem order
+	mem  *MemStore  // hydrated from the file at New, then write-through
+}
+
+// fileLine is the on-disk JSONL shape: the SPI Event plus the
+// optional trace-correlation fields. Mirroring [eventWithTrace] keeps
+// trace-aware Append lossless across restart.
+type fileLine struct {
+	TraceID     string `json:"trace_id,omitempty"`
+	IntentID    string `json:"intent_id,omitempty"`
+	WorkspaceID string `json:"workspace_id,omitempty"`
+	Event       Event  `json:"event"`
+}
+
+// NewFileStore opens (or creates) a JSONL audit log at path and
+// returns a FileStore whose in-memory index is replayed from the
+// file. Malformed lines are skipped with a warning so a single
+// corrupt entry can't make the daemon refuse to start; the rest of
+// the file is still loaded.
+//
+// log may be nil; in that case warnings are routed to slog.Default.
+func NewFileStore(path string, log *slog.Logger) (*FileStore, error) {
+	if log == nil {
+		log = slog.Default()
+	}
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, fmt.Errorf("creating audit log directory: %w", err)
+	}
+	fs := &FileStore{
+		path: path,
+		log:  log,
+		mem:  NewMemStore(),
+	}
+	if err := fs.replay(); err != nil {
+		return nil, err
+	}
+	return fs, nil
+}
+
+// Path returns the JSONL file path the store is backed by. Useful
+// for status surfaces (e.g. `aileron status`) and tests.
+func (fs *FileStore) Path() string { return fs.path }
+
+func (fs *FileStore) replay() error {
+	f, err := os.Open(fs.path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("opening audit log: %w", err)
+	}
+	defer f.Close()
+	scanner := bufio.NewScanner(f)
+	// Default Scanner buffer is 64KiB; raise to handle large
+	// payloads (failure events with deep details). 1 MiB cap.
+	const maxLine = 1 << 20
+	scanner.Buffer(make([]byte, 0, 64<<10), maxLine)
+	lineNo := 0
+	bad := 0
+	for scanner.Scan() {
+		lineNo++
+		raw := scanner.Bytes()
+		if len(raw) == 0 {
+			continue
+		}
+		var line fileLine
+		if err := json.Unmarshal(raw, &line); err != nil {
+			bad++
+			fs.log.Warn("audit: skipped malformed line during replay",
+				"path", fs.path, "line", lineNo, "error", err.Error())
+			continue
+		}
+		if line.TraceID == "" && line.IntentID == "" && line.WorkspaceID == "" {
+			_ = fs.mem.Append(context.Background(), line.Event)
+		} else {
+			_ = fs.mem.AppendToTrace(context.Background(),
+				line.TraceID, line.IntentID, line.WorkspaceID, line.Event)
+		}
+	}
+	if err := scanner.Err(); err != nil {
+		return fmt.Errorf("scanning audit log: %w", err)
+	}
+	if bad > 0 {
+		fs.log.Warn("audit: replay completed with skipped lines",
+			"path", fs.path, "skipped", bad, "loaded", lineNo-bad)
+	}
+	return nil
+}
+
+// Append persists the event to the file and the in-memory index.
+// Both must succeed for Append to return nil; a write to disk that
+// fails surfaces to the recorder, which logs and continues per
+// ADR-0010's best-effort recording.
+func (fs *FileStore) Append(ctx context.Context, event Event) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if err := fs.writeLine(fileLine{Event: event}); err != nil {
+		return err
+	}
+	return fs.mem.Append(ctx, event)
+}
+
+// AppendToTrace persists the trace-correlated event to the file and
+// the in-memory index.
+func (fs *FileStore) AppendToTrace(ctx context.Context, traceID, intentID, workspaceID string, event Event) error {
+	fs.mu.Lock()
+	defer fs.mu.Unlock()
+	if err := fs.writeLine(fileLine{
+		TraceID:     traceID,
+		IntentID:    intentID,
+		WorkspaceID: workspaceID,
+		Event:       event,
+	}); err != nil {
+		return err
+	}
+	return fs.mem.AppendToTrace(ctx, traceID, intentID, workspaceID, event)
+}
+
+func (fs *FileStore) writeLine(line fileLine) error {
+	f, err := os.OpenFile(fs.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening audit log: %w", err)
+	}
+	defer f.Close()
+	data, err := json.Marshal(line)
+	if err != nil {
+		return fmt.Errorf("encoding audit entry: %w", err)
+	}
+	data = append(data, '\n')
+	if _, err := f.Write(data); err != nil {
+		return fmt.Errorf("writing audit entry: %w", err)
+	}
+	return nil
+}
+
+// GetByEventID delegates to the in-memory index.
+func (fs *FileStore) GetByEventID(eventID string) (Event, bool) {
+	return fs.mem.GetByEventID(eventID)
+}
+
+// ListEvents delegates to the in-memory index.
+func (fs *FileStore) ListEvents(ctx context.Context, f EventFilter) ([]Event, error) {
+	return fs.mem.ListEvents(ctx, f)
+}
+
+// ListTraces delegates to the in-memory index.
+func (fs *FileStore) ListTraces(ctx context.Context, filter Filter) ([]Trace, error) {
+	return fs.mem.ListTraces(ctx, filter)
+}
+
+// GetTrace delegates to the in-memory index.
+func (fs *FileStore) GetTrace(ctx context.Context, traceID string) (Trace, error) {
+	return fs.mem.GetTrace(ctx, traceID)
+}
+
+// Compile-time check that FileStore satisfies the audit-store
+// surface. MemStore satisfies this implicitly today.
+var (
+	_ EventStore = (*FileStore)(nil)
+	_ EventStore = (*MemStore)(nil)
+	_ Store      = (*FileStore)(nil)
+
+	// helperEnsureModelImported keeps the model import live regardless
+	// of whether other callers in this package use it directly. Same
+	// purpose as the equivalent line in mem.go.
+	_ = model.ActorRef{}
+)

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -1,0 +1,288 @@
+package audit_test
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/model"
+)
+
+// FileStore contract:
+//   - Round-trip: Append → close → reopen → ListEvents / GetByEventID
+//     surfaces the same data the writer recorded.
+//   - Trace-aware Append (AppendToTrace) round-trips via ListTraces.
+//   - Concurrent appends from N goroutines all land — none are lost.
+//   - A malformed line in the file does not abort replay; remaining
+//     entries are loaded and the bad line is logged.
+//   - Filter/limit semantics match MemStore (delegation, but pinned).
+
+func newTestFileStore(t *testing.T) (*audit.FileStore, string) {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+	store, err := audit.NewFileStore(path, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	return store, path
+}
+
+func TestFileStore_AppendThenReopen_RoundTrip(t *testing.T) {
+	store, path := newTestFileStore(t)
+	t0 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	ev := audit.Event{
+		EventID:   "audit-xyz",
+		EventType: model.EventTypeActionInstalled,
+		Actor:     model.ActorRef{Type: model.ActorTypeHuman, ID: "user"},
+		Payload:   map[string]any{"name": "ship-update", "fqn": "github://aileron/slack"},
+		Timestamp: t0,
+	}
+	if err := store.Append(context.Background(), ev); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+
+	// Reopen — the new store must replay every appended entry.
+	reopened, err := audit.NewFileStore(path, slog.Default())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	got, ok := reopened.GetByEventID("audit-xyz")
+	if !ok {
+		t.Fatalf("event not found after reopen")
+	}
+	if got.EventID != "audit-xyz" || got.EventType != model.EventTypeActionInstalled {
+		t.Errorf("got = %+v", got)
+	}
+	if got.Payload["name"] != "ship-update" || got.Payload["fqn"] != "github://aileron/slack" {
+		t.Errorf("payload = %+v", got.Payload)
+	}
+	if !got.Timestamp.Equal(t0) {
+		t.Errorf("timestamp = %v, want %v", got.Timestamp, t0)
+	}
+	if got.Actor.Type != model.ActorTypeHuman || got.Actor.ID != "user" {
+		t.Errorf("actor = %+v", got.Actor)
+	}
+
+	listed, err := reopened.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(listed) != 1 || listed[0].EventID != "audit-xyz" {
+		t.Errorf("ListEvents = %+v, want one event xyz", listed)
+	}
+}
+
+func TestFileStore_AppendToTrace_RoundTrip(t *testing.T) {
+	store, path := newTestFileStore(t)
+	ctx := context.Background()
+	now := time.Now().UTC()
+	if err := store.AppendToTrace(ctx, "trace-1", "intent-1", "ws-1", audit.Event{
+		EventID:   "e-1",
+		EventType: model.EventTypeIntentSubmitted,
+		Actor:     model.ActorRef{ID: "u1"},
+		Timestamp: now,
+	}); err != nil {
+		t.Fatalf("AppendToTrace: %v", err)
+	}
+	if err := store.AppendToTrace(ctx, "trace-1", "intent-1", "ws-1", audit.Event{
+		EventID:   "e-2",
+		EventType: model.EventTypeExecutionSucceeded,
+		Actor:     model.ActorRef{ID: "agent-x"},
+		Timestamp: now.Add(time.Second),
+	}); err != nil {
+		t.Fatalf("AppendToTrace: %v", err)
+	}
+
+	reopened, err := audit.NewFileStore(path, slog.Default())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	traces, err := reopened.ListTraces(ctx, audit.Filter{IntentID: "intent-1"})
+	if err != nil {
+		t.Fatalf("ListTraces: %v", err)
+	}
+	if len(traces) != 1 {
+		t.Fatalf("traces = %d, want 1", len(traces))
+	}
+	if traces[0].WorkspaceID != "ws-1" || traces[0].IntentID != "intent-1" {
+		t.Errorf("trace meta = %+v", traces[0])
+	}
+	if len(traces[0].Events) != 2 {
+		t.Errorf("events = %d, want 2", len(traces[0].Events))
+	}
+
+	got, err := reopened.GetTrace(ctx, "trace-1")
+	if err != nil {
+		t.Fatalf("GetTrace: %v", err)
+	}
+	if got.WorkspaceID != "ws-1" {
+		t.Errorf("GetTrace = %+v", got)
+	}
+}
+
+func TestFileStore_ConcurrentAppends_AllLand(t *testing.T) {
+	store, path := newTestFileStore(t)
+	const writers = 8
+	const perWriter = 25
+	var wg sync.WaitGroup
+	for w := 0; w < writers; w++ {
+		wg.Add(1)
+		go func(w int) {
+			defer wg.Done()
+			for i := 0; i < perWriter; i++ {
+				id := fmt.Sprintf("w%d-i%d", w, i)
+				if err := store.Append(context.Background(), audit.Event{
+					EventID:   id,
+					Timestamp: time.Now().UTC(),
+					Payload:   map[string]any{"writer": w, "i": i},
+				}); err != nil {
+					t.Errorf("Append: %v", err)
+					return
+				}
+			}
+		}(w)
+	}
+	wg.Wait()
+
+	want := writers * perWriter
+	listed, err := store.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(listed) != want {
+		t.Errorf("in-memory count = %d, want %d", len(listed), want)
+	}
+
+	// Re-open: the file is the source of truth, so the same count
+	// must surface from a cold read.
+	reopened, err := audit.NewFileStore(path, slog.Default())
+	if err != nil {
+		t.Fatalf("reopen: %v", err)
+	}
+	relisted, _ := reopened.ListEvents(context.Background(), audit.EventFilter{})
+	if len(relisted) != want {
+		t.Errorf("reopened count = %d, want %d", len(relisted), want)
+	}
+
+	// Spot-check that every (writer, i) pair survived.
+	seen := map[string]bool{}
+	for _, e := range relisted {
+		seen[e.EventID] = true
+	}
+	for w := 0; w < writers; w++ {
+		for i := 0; i < perWriter; i++ {
+			id := fmt.Sprintf("w%d-i%d", w, i)
+			if !seen[id] {
+				t.Errorf("missing event %q after reopen", id)
+			}
+		}
+	}
+}
+
+func TestFileStore_MalformedLineSkippedWithWarning(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit.jsonl")
+
+	// Pre-seed the file: one good entry, one corrupt line, one good entry.
+	good1 := `{"event":{"EventID":"good-1","EventType":"action.installed","Actor":{"ID":"user","Type":"human"},"Payload":{"name":"ship-update"},"Timestamp":"2026-05-01T00:00:00Z"}}`
+	good2 := `{"event":{"EventID":"good-2","EventType":"action.installed","Actor":{"ID":"user","Type":"human"},"Payload":{"name":"send-email"},"Timestamp":"2026-05-01T00:01:00Z"}}`
+	corrupt := `{this is not json`
+	contents := strings.Join([]string{good1, corrupt, good2, ""}, "\n")
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatalf("seed file: %v", err)
+	}
+
+	var logBuf bytes.Buffer
+	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+	store, err := audit.NewFileStore(path, log)
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+
+	// Both good entries must have loaded; the corrupt line must not abort replay.
+	if _, ok := store.GetByEventID("good-1"); !ok {
+		t.Error("good-1 missing after replay")
+	}
+	if _, ok := store.GetByEventID("good-2"); !ok {
+		t.Error("good-2 missing after replay")
+	}
+	listed, _ := store.ListEvents(context.Background(), audit.EventFilter{})
+	if len(listed) != 2 {
+		t.Errorf("loaded = %d, want 2", len(listed))
+	}
+
+	// Warning must surface so operators can find the bad line.
+	logged := logBuf.String()
+	if !strings.Contains(logged, "malformed line") {
+		t.Errorf("expected 'malformed line' warning; got: %s", logged)
+	}
+	if !strings.Contains(logged, "skipped") {
+		t.Errorf("expected post-replay 'skipped' tally; got: %s", logged)
+	}
+}
+
+func TestFileStore_NewOnMissingFileIsEmpty(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "deeper", "audit.jsonl")
+	store, err := audit.NewFileStore(path, slog.Default())
+	if err != nil {
+		t.Fatalf("NewFileStore on missing path: %v", err)
+	}
+	listed, _ := store.ListEvents(context.Background(), audit.EventFilter{})
+	if len(listed) != 0 {
+		t.Errorf("listed = %d, want 0", len(listed))
+	}
+
+	// Append must create the file under the directory we asked for,
+	// proving MkdirAll happened in New.
+	if err := store.Append(context.Background(), audit.Event{
+		EventID: "after-mkdir", Timestamp: time.Now(),
+	}); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	if _, err := os.Stat(path); err != nil {
+		t.Errorf("file not created at %s: %v", path, err)
+	}
+}
+
+func TestFileStore_FilterAndLimitDelegateToMem(t *testing.T) {
+	// FileStore delegates ListEvents to MemStore — pin behavior so
+	// future refactors that re-implement the path don't silently drop
+	// filter semantics.
+	store, _ := newTestFileStore(t)
+	ctx := context.Background()
+	t0 := time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC)
+	for i := 0; i < 5; i++ {
+		_ = store.Append(ctx, audit.Event{
+			EventID:   string(rune('a' + i)),
+			Timestamp: t0.Add(time.Duration(i) * time.Hour),
+			Payload:   map[string]any{"class": "binding_required"},
+		})
+	}
+	got, err := store.ListEvents(ctx, audit.EventFilter{
+		Class: "binding_required",
+		Limit: 2,
+	})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(got) != 2 || got[0].EventID != "e" || got[1].EventID != "d" {
+		t.Errorf("got = %+v; want [e, d]", got)
+	}
+}
+
+func TestFileStore_PathReturnsConfiguredPath(t *testing.T) {
+	store, path := newTestFileStore(t)
+	if store.Path() != path {
+		t.Errorf("Path() = %q, want %q", store.Path(), path)
+	}
+}

--- a/internal/audit/spi.go
+++ b/internal/audit/spi.go
@@ -30,6 +30,27 @@ type Store interface {
 	GetTrace(ctx context.Context, traceID string) (Trace, error)
 }
 
+// EventStore is the audit-store surface the daemon and the
+// `/v1/audit` handlers depend on. It is the union of the trace-aware
+// [Store] SPI and the flat-event API the read endpoint uses, so the
+// in-memory and file-backed implementations are interchangeable at
+// the wiring site in `internal/app/app.go`.
+type EventStore interface {
+	Store
+
+	// AppendToTrace records an event scoped to a trace correlation
+	// (intent/workspace).
+	AppendToTrace(ctx context.Context, traceID, intentID, workspaceID string, event Event) error
+
+	// GetByEventID returns the recorded event with this id and
+	// reports whether one was found. Used by GET /v1/audit/{audit_id}.
+	GetByEventID(eventID string) (Event, bool)
+
+	// ListEvents returns flat events matching the filter, newest-first.
+	// Used by GET /v1/audit.
+	ListEvents(ctx context.Context, f EventFilter) ([]Event, error)
+}
+
 // Event is a single immutable audit record.
 type Event struct {
 	EventID   string


### PR DESCRIPTION
## Summary

Closes #412. The ADR-0010 audit recorder wrote to `audit.NewMemStore()` — an in-process map that disappeared on daemon exit. Under `aileron launch`, every action invocation got a stable `audit_id` back, but the lookup window was the launch session lifetime: shorter than the period during which a user might want to ask \"what did the agent do this morning?\" After PR #443 (the read API), this was the second half of the gap. This PR closes it.

## What ships

**Persistence (`internal/audit/file.go`)**

- `audit.FileStore` writes one event per line as JSONL with `O_APPEND|O_CREATE` semantics; trace metadata (`trace_id` / `intent_id` / `workspace_id`) is included so `AppendToTrace` round-trips losslessly across restart.
- Reads are served from an in-memory index hydrated at startup; the file is authoritative, the index is a cache. This lets the existing `MemStore` filter / lookup logic stay unchanged — `FileStore` delegates `ListEvents`, `GetByEventID`, `ListTraces`, `GetTrace` to a wrapped `MemStore`.
- Replay is tolerant of malformed lines: a single corrupt entry is skipped with a `warn` log line that names the path and line number, so the daemon can still start. A summary tally is logged when the replay completes with skipped lines.

**Interface (`internal/audit/spi.go`)**

- New `audit.EventStore` interface unions the trace-aware `Store` SPI with `AppendToTrace` / `GetByEventID` / `ListEvents`. Both `MemStore` and `FileStore` satisfy it; the field type in `apiServer` and the `dumpEvents` test helper are now interface-typed so test fixtures using `*MemStore` keep working.

**Wiring (`internal/app/`)**

- `resolveAuditPath()` honors `AILERON_AUDIT_PATH`: env unset → `<home>/.aileron/audit.jsonl`; env explicitly empty → in-memory opt-out; env set → that path.
- `newAuditStore()` picks `FileStore` by default; on file-open failure logs a warning and falls back to `MemStore` so the daemon still starts (degraded durability beats no daemon).

## Scope decisions

Per the issue's explicit out-of-scope list, this PR does **not** ship:

- Read API + CLI (→ #411 / shipped in #443).
- Signed audit log / hash chain (→ #398).
- Postgres backing (→ post-MVP per the existing comment at `handlers.go:102`).
- Rotation / retention policy (→ revisit when the file gets large enough to matter).

## Test plan

- [x] `go test ./internal/audit/ -run TestFileStore -v` — 7 tests covering: round-trip Append → reopen → Get/List, AppendToTrace round-trip via ListTraces, concurrent appends from 8 goroutines × 25 events with all 200 events present after reopen, malformed-line tolerance with warning, mkdir-on-New for missing intermediate directories, filter+limit delegation, and `Path()`.
- [x] `go test ./internal/app/ -run \"TestResolveAuditPath|TestNewAuditStore\" -v` — 4 wiring tests: default path, env override, env-empty opt-out, and the regression assertion that the daemon picks `*audit.FileStore` when `AILERON_AUDIT_PATH` points at a writable path (with a write→reopen→read assertion proving events survive).
- [x] Coverage: `internal/audit/file.go` 89.8% package; `replay` 89.7%, `Append/AppendToTrace` 80%, `Get/ListEvents/ListTraces/GetTrace` 100%. Wiring `resolveAuditPath` 83.3%, `newAuditStore` 80%. The dips are error-path branches (mkdir failure, marshal failure, file-open failure).
- [x] `go test ./internal/...` — full sweep green; existing tests using `*audit.MemStore` directly continue to pass via the new interface.
- [x] `go vet` clean across `internal/`, `cmd/aileron`, `cmd/aileron-mcp`.
- [x] `task build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)