### PR TITLE
feat(sync): honor --bind-all with interactive credential prompts (#437)

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -112,7 +112,7 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 	case "status":
 		return runStatus(args[1:], stdout, stderr)
 	case "sync":
-		return runSync(args[1:], stdout, stderr)
+		return runSync(args[1:], os.Stdin, stdout, stderr)
 	case "log":
 		return runLog(args[1:], stdout, stderr)
 	case "audit":
@@ -1501,19 +1501,19 @@ func postSyncRequest(autoInstall bool) (*syncResult, error) {
 // `/v1/sync`, prints a per-section report, and surfaces unbound
 // capabilities so the operator knows what to bind next.
 //
-// `--bind-all` is parsed but not yet honored: pre-binding requires
-// credential values that have to come from somewhere (interactive
-// prompt for api_key, OAuth dance for oauth2). For v1 this CLI flag
-// is documented as a TODO, the unbound list serves as the operator's
-// next-step guide. Filed as a follow-up — see issue #364.
+// `--bind-all` walks the unbound list and prompts interactively to
+// create a binding per entry — api_key kinds prompt for the value
+// inline, oauth2 kinds drive the server-side OAuth dance through the
+// same code path as `aileron binding setup`. Failures don't abort
+// the loop; a final summary reports bound vs failed.
 //
-// `--yes` is also accepted but has no effect today: the install
-// pipeline is unconditional in v1 (no consent prompt). The flag is
-// honored on the wire so adding consent later doesn't break callers.
-func runSync(args []string, stdout, stderr io.Writer) int {
+// `--yes` is accepted but has no effect today: the install pipeline
+// is unconditional in v1 (no consent prompt). The flag is honored on
+// the wire so adding consent later doesn't break callers.
+func runSync(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("sync", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	bindAll := flags.Bool("bind-all", false, "(not yet implemented) pre-bind every required capability before exiting")
+	bindAll := flags.Bool("bind-all", false, "after sync, prompt to create a binding for each unbound capability")
 	yes := flags.Bool("yes", false, "auto-approve install consent for new connectors (no-op in v1; install is unconditional)")
 	if err := flags.Parse(args); err != nil {
 		return 1
@@ -1570,9 +1570,19 @@ func runSync(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stdout, "  Bind each with: aileron binding setup <FQN>")
 	}
 
-	if *bindAll {
+	if *bindAll && len(resp.Unbound) > 0 {
 		fmt.Fprintln(stdout)
-		fmt.Fprintln(stderr, "warning: --bind-all is not yet implemented in v1; run 'aileron binding setup <FQN>' for each unbound capability listed above.")
+		fmt.Fprintf(stdout, "Binding %d capability(s)...\n", len(resp.Unbound))
+		bound, failed := bindAllUnbound(resp.Unbound, stdin, stdout, stderr)
+		fmt.Fprintln(stdout)
+		fmt.Fprintf(stdout, "Bound %d of %d capability(s)", bound, len(resp.Unbound))
+		if failed > 0 {
+			fmt.Fprintf(stdout, " (%d failed)", failed)
+		}
+		fmt.Fprintln(stdout, ".")
+		if failed > 0 {
+			return 1
+		}
 	}
 
 	// Exit non-zero on install failures so operators wiring sync
@@ -1581,6 +1591,71 @@ func runSync(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	return 0
+}
+
+// bindAllUnbound walks the unbound list returned by /v1/sync and
+// dispatches by credential kind. It returns (bound, failed) counts.
+// Failures don't abort the loop — partial binding is more useful
+// than nothing.
+func bindAllUnbound(unbound []unboundCapabilityWire, stdin io.Reader, stdout, stderr io.Writer) (bound, failed int) {
+	br := bufio.NewReader(stdin)
+	for _, u := range unbound {
+		fmt.Fprintln(stdout)
+		scope := ""
+		if u.Scope != nil && *u.Scope != "" {
+			scope = " — " + *u.Scope
+		}
+		fmt.Fprintf(stdout, "→ %s [%s]%s\n", u.ConnectorFqn, u.Kind, scope)
+
+		identity := promptLine(br, stdout, "  Identity (e.g. work, personal): ")
+		if identity == "" {
+			fmt.Fprintln(stderr, "  identity is required; skipping")
+			failed++
+			continue
+		}
+
+		var rc int
+		switch u.Kind {
+		case "oauth2":
+			rc = bindOneOAuth2(u.ConnectorFqn, identity, stdout, stderr)
+		case "api_key":
+			rc = runBindingSetupAPIKey(u.ConnectorFqn, identity, br, stdout, stderr)
+		default:
+			fmt.Fprintf(stderr, "  unsupported credential kind %q for %s; skipping\n", u.Kind, u.ConnectorFqn)
+			failed++
+			continue
+		}
+		if rc == 0 {
+			bound++
+		} else {
+			failed++
+		}
+	}
+	return bound, failed
+}
+
+// bindOneOAuth2 drives the server-side OAuth dance for a single
+// (connector, identity). It is the bind-all counterpart to the OAuth
+// branch of `runBindingSetup`: the kind is known up front (from the
+// sync response), so we POST init unconditionally and treat anything
+// other than 200 as a hard error rather than falling through to
+// api_key. The post-init flow shares `runBindingSetupOAuth2Finish`.
+func bindOneOAuth2(connectorFQN, identity string, stdout, stderr io.Writer) int {
+	initBody, _ := json.Marshal(map[string]any{
+		"connector_fqn": connectorFQN,
+		"identity":      identity,
+	})
+	initStatus, initRespBody, err := bindingDoRequest(http.MethodPost,
+		"/bindings/setup/oauth2/init", strings.NewReader(string(initBody)))
+	if err != nil {
+		fmt.Fprintf(stderr, "  error: %v\n", err)
+		return 1
+	}
+	if initStatus != http.StatusOK {
+		fmt.Fprintf(stderr, "  server returned %d: %s\n", initStatus, string(initRespBody))
+		return 1
+	}
+	return runBindingSetupOAuth2Finish(initRespBody, stdout, stderr)
 }
 
 // connectorPreviewWire mirrors the JSON shape of api.ConnectorPreview

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -2413,12 +2413,38 @@ func TestRunSync_InstallFailureExits1(t *testing.T) {
 	}
 }
 
-// TestRunSync_BindAllWarns asserts that --bind-all prints a clear
-// "not yet implemented" warning so operators learn the limitation
-// without filing a "broken" bug. When --bind-all lands as a real
-// feature, this test will be replaced.
-func TestRunSync_BindAllWarns(t *testing.T) {
-	scope := "test"
+// TestRunSync_BindAllNoUnboundIsNoop asserts that --bind-all with no
+// unbound capabilities is a clean no-op: no prompts, no summary line,
+// no stderr noise. The earlier "not yet implemented" stderr warning
+// is gone.
+func TestRunSync_BindAllNoUnboundIsNoop(t *testing.T) {
+	prev := syncFetcher
+	syncFetcher = func(autoInstall bool) (*syncResult, error) {
+		return &syncResult{ActionsSeen: 1}, nil
+	}
+	defer func() { syncFetcher = prev }()
+
+	stdin := strings.NewReader("")
+	var stdout, stderr bytes.Buffer
+	code := runSync([]string{"--bind-all"}, stdin, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "not yet implemented") {
+		t.Errorf("legacy 'not yet implemented' warning leaked into stderr: %s", stderr.String())
+	}
+	if strings.Contains(stdout.String(), "Binding ") {
+		t.Errorf("did not expect binding loop output with no unbound; got: %s", stdout.String())
+	}
+}
+
+// TestRunSync_BindAllAPIKeyHappyPath asserts the canonical flow: one
+// unbound api_key capability → operator types identity + key → CLI
+// POSTs /v1/bindings/setup with the right body → CLI prints
+// "Created" and a summary, exits 0. Mocks the daemon at the HTTP
+// boundary via httptest so the test runs without a real server.
+func TestRunSync_BindAllAPIKeyHappyPath(t *testing.T) {
+	scope := "secret_key"
 	prev := syncFetcher
 	syncFetcher = func(autoInstall bool) (*syncResult, error) {
 		return &syncResult{
@@ -2429,10 +2455,208 @@ func TestRunSync_BindAllWarns(t *testing.T) {
 	}
 	defer func() { syncFetcher = prev }()
 
+	var seenBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/bindings/setup" || r.Method != http.MethodPost {
+			t.Errorf("unexpected daemon call: %s %s", r.Method, r.URL.Path)
+			http.NotFound(w, r)
+			return
+		}
+		seenBody, _ = io.ReadAll(r.Body)
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"created":[{"name":"github://acme/widget/work"}],"skipped":[]}`)
+	}))
+	defer srv.Close()
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	stdin := strings.NewReader("work\nsk-live-1234\n")
 	var stdout, stderr bytes.Buffer
-	run([]string{"sync", "--bind-all"}, newTestRegistry(), &stdout, &stderr)
-	if !strings.Contains(stderr.String(), "not yet implemented") {
-		t.Errorf("expected '--bind-all not yet implemented' warning; got stderr: %s", stderr.String())
+	code := runSync([]string{"--bind-all"}, stdin, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	out := stdout.String()
+	for _, want := range []string{
+		"github://acme/widget [api_key]",
+		"secret_key",
+		"Created: github://acme/widget/work",
+		"Bound 1 of 1",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in stdout; got: %s", want, out)
+		}
+	}
+
+	// Wire body must carry FQN + the identity + value the user typed.
+	body := string(seenBody)
+	for _, want := range []string{
+		`"connector_fqn":"github://acme/widget"`,
+		`"identity":"work"`,
+		`"kind":"api_key"`,
+		`"value":"sk-live-1234"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %q in POST body; got: %s", want, body)
+		}
+	}
+}
+
+// TestRunSync_BindAllOAuth2InitPosted asserts that an oauth2 unbound
+// entry triggers POST /v1/bindings/setup/oauth2/init with the right
+// body. The full dance (browser open, callback listener, finish POST)
+// is out of scope for a unit test; this pins the boundary the issue
+// asks for ("OAuth path mocked at the binding-setup-oauth2 boundary").
+// The test makes the init endpoint return an error so the loop
+// terminates without trying to bind a real loopback listener.
+func TestRunSync_BindAllOAuth2InitPosted(t *testing.T) {
+	prev := syncFetcher
+	syncFetcher = func(autoInstall bool) (*syncResult, error) {
+		return &syncResult{
+			Unbound: []unboundCapabilityWire{
+				{ConnectorFqn: "github://acme/oauth-widget", Kind: "oauth2"},
+			},
+		}, nil
+	}
+	defer func() { syncFetcher = prev }()
+
+	var seenPath string
+	var seenBody []byte
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seenPath = r.URL.Path
+		seenBody, _ = io.ReadAll(r.Body)
+		// Surface as a 500 so the loop counts a failure and exits
+		// cleanly without trying to listen for a callback.
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":"upstream provider down"}`)
+	}))
+	defer srv.Close()
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	stdin := strings.NewReader("personal\n")
+	var stdout, stderr bytes.Buffer
+	code := runSync([]string{"--bind-all"}, stdin, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("exit = %d, want 1 on bind failure", code)
+	}
+
+	if seenPath != "/v1/bindings/setup/oauth2/init" {
+		t.Errorf("path = %q, want /v1/bindings/setup/oauth2/init", seenPath)
+	}
+	body := string(seenBody)
+	for _, want := range []string{
+		`"connector_fqn":"github://acme/oauth-widget"`,
+		`"identity":"personal"`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("expected %q in init body; got: %s", want, body)
+		}
+	}
+
+	if !strings.Contains(stdout.String(), "Bound 0 of 1 capability(s) (1 failed)") {
+		t.Errorf("expected '0 of 1 (1 failed)' summary; got: %s", stdout.String())
+	}
+}
+
+// TestRunSync_BindAllPartialFailureContinues asserts that a single
+// failing binding doesn't abort the loop: the next unbound entry is
+// still attempted, and the summary line tallies correctly.
+func TestRunSync_BindAllPartialFailureContinues(t *testing.T) {
+	prev := syncFetcher
+	syncFetcher = func(autoInstall bool) (*syncResult, error) {
+		return &syncResult{
+			Unbound: []unboundCapabilityWire{
+				{ConnectorFqn: "github://acme/first", Kind: "api_key"},
+				{ConnectorFqn: "github://acme/second", Kind: "api_key"},
+			},
+		}, nil
+	}
+	defer func() { syncFetcher = prev }()
+
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		if calls == 1 {
+			// First binding fails on the daemon side.
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"error":"vault locked"}`)
+			return
+		}
+		// Second binding succeeds.
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusCreated)
+		_, _ = io.WriteString(w, `{"created":[{"name":"github://acme/second/work"}]}`)
+	}))
+	defer srv.Close()
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	stdin := strings.NewReader("work\nbad-key\nwork\ngood-key\n")
+	var stdout, stderr bytes.Buffer
+	code := runSync([]string{"--bind-all"}, stdin, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("exit = %d, want 1 (partial failure)", code)
+	}
+	if calls != 2 {
+		t.Errorf("daemon calls = %d, want 2 (loop must continue past the first failure)", calls)
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Bound 1 of 2 capability(s) (1 failed)") {
+		t.Errorf("expected '1 of 2 (1 failed)' summary; got: %s", out)
+	}
+}
+
+// TestRunSync_BindAllUnsupportedKindContinues asserts that an
+// unrecognized credential kind logs to stderr and is counted as a
+// failure, but doesn't crash or short-circuit the loop.
+func TestRunSync_BindAllUnsupportedKindContinues(t *testing.T) {
+	prev := syncFetcher
+	syncFetcher = func(autoInstall bool) (*syncResult, error) {
+		return &syncResult{
+			Unbound: []unboundCapabilityWire{
+				{ConnectorFqn: "github://acme/weird", Kind: "future_kind"},
+			},
+		}, nil
+	}
+	defer func() { syncFetcher = prev }()
+
+	stdin := strings.NewReader("work\n")
+	var stdout, stderr bytes.Buffer
+	code := runSync([]string{"--bind-all"}, stdin, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("exit = %d, want 1 on unsupported kind", code)
+	}
+	if !strings.Contains(stderr.String(), `unsupported credential kind "future_kind"`) {
+		t.Errorf("expected unsupported-kind message in stderr; got: %s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Bound 0 of 1 capability(s) (1 failed)") {
+		t.Errorf("expected '0 of 1 (1 failed)' summary; got: %s", stdout.String())
+	}
+}
+
+// TestRunSync_BindAllEmptyIdentitySkips asserts that pressing return
+// at the identity prompt skips that entry (counted as failed) and
+// the loop continues to the next.
+func TestRunSync_BindAllEmptyIdentitySkips(t *testing.T) {
+	prev := syncFetcher
+	syncFetcher = func(autoInstall bool) (*syncResult, error) {
+		return &syncResult{
+			Unbound: []unboundCapabilityWire{
+				{ConnectorFqn: "github://acme/widget", Kind: "api_key"},
+			},
+		}, nil
+	}
+	defer func() { syncFetcher = prev }()
+
+	// Empty identity (just a newline).
+	stdin := strings.NewReader("\n")
+	var stdout, stderr bytes.Buffer
+	code := runSync([]string{"--bind-all"}, stdin, &stdout, &stderr)
+	if code != 1 {
+		t.Errorf("exit = %d, want 1 when binding skipped", code)
+	}
+	if !strings.Contains(stderr.String(), "identity is required") {
+		t.Errorf("expected 'identity is required' in stderr; got: %s", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes #437. PR #434 shipped `aileron sync` with `--bind-all` parsed but not honored — the CLI printed `warning: --bind-all is not yet implemented in v1; run 'aileron binding setup <FQN>' for each unbound capability listed above.` and exited. Per ADR-0004's acceptance, `--bind-all` should pre-bind every required capability before exiting. This PR delivers that.

## What changed

After the existing sync output, when `--bind-all` is set and the unbound list is non-empty, the CLI walks each entry and dispatches by `kind`:

- **`api_key`** — prompts for identity + key value inline, POSTs `/v1/bindings/setup` with the same wire shape as `aileron binding setup`'s api_key path.
- **`oauth2`** — prompts for identity, POSTs `/v1/bindings/setup/oauth2/init`, then drives the existing `runBindingSetupOAuth2Finish` flow (browser open, loopback callback, finish POST). The init→detect-then-fall-through round trip that single-FQN `binding setup` does is unnecessary here because the kind is already on the sync response.
- **unsupported kinds** — log to stderr (`unsupported credential kind "future_kind" for <FQN>; skipping`) and count as failed; the loop continues.

Failures don't abort the loop. A final summary line reports bound vs failed:

```
Bound 1 of 2 capability(s) (1 failed).
```

`--bind-all` exits 1 if anything failed so shell scripts can branch on it. The bare-`sync` path is unchanged: same output, same exit code.

## Scope decisions per the issue

- **In scope:** interactive prompts for `api_key`; OAuth dance for `oauth2`; per-capability looping over the unbound list returned by `/v1/sync`.
- **Explicitly out of scope:** non-interactive batch binding from a config file (use `aileron secret set` + per-FQN `binding setup` for that); vault unlock (assumes the daemon vault is already unlocked when sync runs).

## Test plan

- [x] `go test -run TestRunSync_BindAll -v` — 6 new tests:
  - `NoUnboundIsNoop` — `--bind-all` with empty unbound list is a clean no-op (no prompts, no summary, no stderr noise; legacy "not yet implemented" warning gone).
  - `APIKeyHappyPath` — one unbound api_key → identity + key typed → CLI POSTs `/v1/bindings/setup` with `connector_fqn` + `identity` + `kind:api_key` + `value` in the body; "Created" line and `Bound 1 of 1` summary appear; exit 0.
  - `OAuth2InitPosted` — one unbound oauth2 → CLI POSTs `/v1/bindings/setup/oauth2/init` with the right body. Pins the boundary the issue calls out; daemon returns 500 so the test doesn't try to bind a real loopback listener. Exit 1, `Bound 0 of 1 (1 failed)` summary.
  - `PartialFailureContinues` — two unbound entries, first fails, second succeeds. Confirms the loop doesn't short-circuit; daemon called twice; summary `1 of 2 (1 failed)`; exit 1.
  - `UnsupportedKindContinues` — unknown `kind` → stderr message + counted failed; exit 1.
  - `EmptyIdentitySkips` — empty input at the identity prompt → "identity is required" + skipped; exit 1.
- [x] `go test -count=1 ./...` (cmd/aileron) — full suite green; existing sync tests untouched.
- [x] `go test ./internal/... -count=1` — full sweep green; the daemon endpoints (`/v1/bindings/setup`, `/v1/bindings/setup/oauth2/{init,finish}`) are unchanged.
- [x] Coverage: `bindAllUnbound` 100%, `bindOneOAuth2` 66.7% (the dip is the success-path branch — full happy path needs a real loopback listener). `runSync` 64.8% overall.
- [x] `go vet` clean across `internal/`, `cmd/aileron`, `cmd/aileron-mcp`.
- [x] `task build` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)