### PR TITLE
refactor(audit): rename audit payload keys to OTel span-attribute conventions

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -2325,17 +2325,19 @@ func runAuditShow(args []string, stdout, stderr io.Writer) int {
 
 // auditPayloadSummary renders a one-line, human-readable hint about
 // the event. Pulls the most identifying fields from each event shape
-// the recorder emits today.
+// the recorder emits today. Payload field names follow the
+// OTel-namespaced audit schema (issue #390 Phase 6.5).
 func auditPayloadSummary(e auditEventWire) string {
 	if e.EventType == "execution.failed" {
-		class, _ := e.Payload["class"].(string)
+		class, _ := e.Payload["aileron.failure.class"].(string)
 		conn := payloadConnector(e.Payload)
 		if conn != "" {
 			return fmt.Sprintf("class=%s connector=%s", class, conn)
 		}
 		return "class=" + class
 	}
-	if name, _ := e.Payload["name"].(string); name != "" {
+	name := payloadName(e.Payload)
+	if name != "" {
 		conn := payloadConnector(e.Payload)
 		if conn != "" {
 			return fmt.Sprintf("name=%s connector=%s", name, conn)
@@ -2348,14 +2350,27 @@ func auditPayloadSummary(e auditEventWire) string {
 	return ""
 }
 
+// payloadName pulls a human-identifying name from the namespaced
+// audit payload. Action and binding events surface different keys;
+// either resolves to the same single-line summary slot.
+func payloadName(p map[string]any) string {
+	if s, _ := p["aileron.action.name"].(string); s != "" {
+		return s
+	}
+	if s, _ := p["aileron.binding.name"].(string); s != "" {
+		return s
+	}
+	return ""
+}
+
 func payloadConnector(p map[string]any) string {
-	if s, _ := p["connector_fqn"].(string); s != "" {
+	if s, _ := p["aileron.connector.fqn"].(string); s != "" {
 		return s
 	}
-	if s, _ := p["fqn"].(string); s != "" {
+	if s, _ := p["aileron.action.fqn"].(string); s != "" {
 		return s
 	}
-	if d, ok := p["details"].(map[string]any); ok {
+	if d, ok := p["aileron.failure.details"].(map[string]any); ok {
 		if s, _ := d["connector"].(string); s != "" {
 			return s
 		}

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -3565,8 +3565,8 @@ func TestRunAudit_TabularRendersTimestampIDTypeAndSummary(t *testing.T) {
 			EventType: "execution.failed",
 			Timestamp: time.Date(2026, 5, 1, 12, 30, 0, 0, time.UTC),
 			Payload: map[string]any{
-				"class":   "binding_required",
-				"details": map[string]any{"connector": "github://aileron/slack"},
+				"aileron.failure.class":   "binding_required",
+				"aileron.failure.details": map[string]any{"connector": "github://aileron/slack"},
 			},
 		}}}, nil
 	}
@@ -3801,9 +3801,10 @@ func TestFetchAuditGet_HitsCorrectURL(t *testing.T) {
 }
 
 // TestAuditPayloadSummary_PerEventShape exercises the renderer
-// branches the tabular tests don't reach: action-installed (name
-// + fqn), binding event (connector_fqn only), and an event with
-// no useful keys.
+// branches the tabular tests don't reach: action-installed (action
+// name + FQN), binding event (connector FQN only), and an event with
+// no useful keys. Payload field names follow the OTel-namespaced
+// audit schema (issue #390 Phase 6.5).
 func TestAuditPayloadSummary_PerEventShape(t *testing.T) {
 	cases := []struct {
 		name string
@@ -3815,8 +3816,8 @@ func TestAuditPayloadSummary_PerEventShape(t *testing.T) {
 			in: auditEventWire{
 				EventType: "action.installed",
 				Payload: map[string]any{
-					"name": "ship-update",
-					"fqn":  "github://aileron/ship-update",
+					"aileron.action.name": "ship-update",
+					"aileron.action.fqn":  "github://aileron/ship-update",
 				},
 			},
 			want: "name=ship-update connector=github://aileron/ship-update",
@@ -3825,7 +3826,7 @@ func TestAuditPayloadSummary_PerEventShape(t *testing.T) {
 			name: "binding-created",
 			in: auditEventWire{
 				EventType: "binding.created",
-				Payload:   map[string]any{"connector_fqn": "github://aileron/slack"},
+				Payload:   map[string]any{"aileron.connector.fqn": "github://aileron/slack"},
 			},
 			want: "connector=github://aileron/slack",
 		},

--- a/docs/src/content/docs/adr/0010-failure-handling.md
+++ b/docs/src/content/docs/adr/0010-failure-handling.md
@@ -236,7 +236,7 @@ Rejected because it imposes a class-hierarchy ceremony that doesn't pay off in t
 - The runtime implements bounded retry with exponential backoff for `retriable: true` errors. v1 default: 3 retries; uniform across actions. Implementation lives in [`internal/retry`](https://github.com/ALRubinger/aileron/blob/main/internal/retry); the [`internal/clock`](https://github.com/ALRubinger/aileron/blob/main/internal/clock) abstraction makes retry tests deterministic.
 - Idempotency is checked at the runtime/connector boundary; the runtime trusts the connector's `[connector.idempotency]` declaration but enforces the default-on-retry policy.
 - The structured error envelope is constructed at the boundary that produced the error and passed through unchanged. Boundaries don't rewrap each other's errors. The closed taxonomy lives in [`internal/failure`](https://github.com/ALRubinger/aileron/blob/main/internal/failure); only the package's per-class constructors can produce a valid Failure value, so handlers cannot synthesize an arbitrary class string.
-- Audit logging records every failure with full context: class, message, boundary, retried-count, actor identity, time, audit ID. Implementation lives in [`internal/audit`](https://github.com/ALRubinger/aileron/blob/main/internal/audit) on top of the existing `Store` SPI; v1 ships an in-memory implementation, with Postgres persistence post-MVP.
+- Audit logging records every failure with full context: class, message, boundary, retried-count, actor identity, time, audit ID. Implementation lives in [`internal/audit`](https://github.com/ALRubinger/aileron/blob/main/internal/audit) on top of the existing `Store` SPI; v1 ships an in-memory implementation, with Postgres persistence post-MVP. Audit-log payload field names follow OTel span-attribute conventions (`aileron.failure.class`, `aileron.failure.boundary`, `aileron.failure.retriable`, `aileron.failure.message`, `aileron.failure.details`) — see [the audit-vs-wire split below](#audit-payload-vs-wire-envelope) for why the audit log diverges from the wire envelope shape.
 
 ### Scope: which envelope applies where
 
@@ -245,6 +245,17 @@ The ADR-0010 envelope applies to **errors returned to the calling action and thr
 Other API endpoints (intents, approvals, policies, accounts, auth) retain the existing `api.Error` envelope (`{error: {code, message, details, request_id}}`). Those errors are CRUD-shaped and don't fit ADR-0010's runtime taxonomy of `network_error` / `capability_denied` / etc. Forcing them in would either expand the closed taxonomy beyond its semantic anchor or drop fidelity. Consumers that want a single unified shape can layer one in their own client; the server emits two stable envelopes by design.
 
 The `internal/auth` package was previously emitting a third, ad-hoc shape (`{"error": "<string>"}`). Stage 5 of #356 normalised those handlers to the standard `api.Error` shape so the v1 server emits exactly two envelope shapes — the gateway/action `FailureEnvelope` and the CRUD `api.Error`.
+
+### Audit payload vs wire envelope
+
+The wire failure envelope and the audit-log record describe the same underlying failure but live on two surfaces with two different conventions:
+
+- **Wire envelope** (HTTP error response body): flat REST/JSON keys — `class`, `message`, `retriable`, `boundary`, `audit_id`, `details` — as documented above. Stable contract for agents and action authors.
+- **Audit-log payload** (`audit.Event.Payload`): the same fields under OTel span-attribute names — `aileron.failure.class`, `aileron.failure.message`, `aileron.failure.retriable`, `aileron.failure.boundary`, `aileron.failure.details`. The OTel `aileron.` prefix scopes the attributes for vendor ownership when audit events are exported as spans (see [#390](https://github.com/ALRubinger/aileron/issues/390) Phase 6.5 schema alignment).
+
+The recorder in [`internal/audit/record.go`](https://github.com/ALRubinger/aileron/blob/main/internal/audit/record.go) translates the wire envelope into the audit shape at write time. Other audit events (binding lifecycle, install consent, etc.) follow the same OTel-namespaced convention — `aileron.binding.name`, `aileron.connector.fqn`, `aileron.capability.kind`, `aileron.action.fqn`, `aileron.signature.status`, `aileron.consent.decision`, etc. The split is deliberate: the wire envelope is part of an HTTP API contract that uses standard REST conventions; the audit payload is a telemetry record whose field names need to survive co-existing in a span/trace alongside attributes from any other instrumented library, which is what OTel's prefix convention exists to handle.
+
+Phase 7 (post-MVP) wires the actual OTLP exporter and `traceparent` propagation per [#390](https://github.com/ALRubinger/aileron/issues/390); the names are pre-aligned so that emission becomes a wiring change, not a schema break.
 
 ### For users
 

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -1096,12 +1096,12 @@ func (s *apiServer) recordConnectorInstalled(ctx context.Context, ref cstore.Ref
 	s.auditRecorder.RecordSuccess(ctx, model.EventTypeConnectorInstalled,
 		model.ActorRef{Type: model.ActorTypeHuman, ID: "user"},
 		map[string]any{
-			"fqn":               ref.FQN.String(),
-			"version":           ref.Version,
-			"hash":              res.Hash,
-			"signature_status":  "verified",
-			"decision":          "approved",
-			"already_installed": res.AlreadyInstalled,
+			"aileron.connector.fqn":             ref.FQN.String(),
+			"aileron.connector.version":         ref.Version,
+			"aileron.connector.hash":            res.Hash,
+			"aileron.signature.status":          "verified",
+			"aileron.consent.decision":          "approved",
+			"aileron.install.already_installed": res.AlreadyInstalled,
 		})
 }
 

--- a/internal/app/handlers_audit_test.go
+++ b/internal/app/handlers_audit_test.go
@@ -85,8 +85,8 @@ func TestListAudit_FiltersForwardedToStore(t *testing.T) {
 			EventID:   "match",
 			EventType: model.EventTypeExecutionFailed,
 			Payload: map[string]any{
-				"class":   "binding_required",
-				"details": map[string]any{"connector": fqn},
+				"aileron.failure.class":   "binding_required",
+				"aileron.failure.details": map[string]any{"connector": fqn},
 			},
 			Timestamp: time.Now(),
 		},
@@ -94,8 +94,8 @@ func TestListAudit_FiltersForwardedToStore(t *testing.T) {
 			EventID:   "wrong-class",
 			EventType: model.EventTypeExecutionFailed,
 			Payload: map[string]any{
-				"class":   "policy_denied",
-				"details": map[string]any{"connector": fqn},
+				"aileron.failure.class":   "policy_denied",
+				"aileron.failure.details": map[string]any{"connector": fqn},
 			},
 			Timestamp: time.Now(),
 		},
@@ -138,7 +138,7 @@ func TestGetAudit_FoundReturnsEvent(t *testing.T) {
 			EventID:   "audit-xyz",
 			EventType: model.EventTypeActionInstalled,
 			Actor:     model.ActorRef{Type: model.ActorTypeHuman, ID: "user"},
-			Payload:   map[string]any{"name": "ship-update"},
+			Payload:   map[string]any{"aileron.action.name": "ship-update"},
 			Timestamp: time.Date(2026, 5, 1, 0, 0, 0, 0, time.UTC),
 		},
 	)
@@ -160,8 +160,8 @@ func TestGetAudit_FoundReturnsEvent(t *testing.T) {
 	if got.Actor.Id != "user" || got.Actor.Type != string(model.ActorTypeHuman) {
 		t.Errorf("Actor = %+v", got.Actor)
 	}
-	if got.Payload["name"] != "ship-update" {
-		t.Errorf("Payload.name = %v", got.Payload["name"])
+	if got.Payload["aileron.action.name"] != "ship-update" {
+		t.Errorf("Payload[aileron.action.name] = %v", got.Payload["aileron.action.name"])
 	}
 }
 

--- a/internal/app/handlers_bindings.go
+++ b/internal/app/handlers_bindings.go
@@ -284,17 +284,19 @@ func (s *apiServer) lookupConnector(fqnStr string) (string, *cstore.Manifest, er
 }
 
 // recordBindingEvent persists an audit event for a binding lifecycle
-// transition. Payload deliberately excludes credential bytes.
+// transition. Payload deliberately excludes credential bytes. Field
+// names follow the OTel-namespaced audit schema (issue #390 Phase
+// 6.5) so Phase 7 emission can map them straight to span attributes.
 func (s *apiServer) recordBindingEvent(ctx context.Context, evt model.EventType, name, connectorFQN, kind string) {
 	if s.auditRecorder == nil {
 		return
 	}
-	payload := map[string]any{"name": name}
+	payload := map[string]any{"aileron.binding.name": name}
 	if connectorFQN != "" {
-		payload["connector_fqn"] = connectorFQN
+		payload["aileron.connector.fqn"] = connectorFQN
 	}
 	if kind != "" {
-		payload["kind"] = kind
+		payload["aileron.capability.kind"] = kind
 	}
 	s.auditRecorder.RecordSuccess(ctx, evt, model.ActorRef{Type: model.ActorTypeHuman, ID: "user"}, payload)
 }

--- a/internal/app/handlers_install_actions.go
+++ b/internal/app/handlers_install_actions.go
@@ -399,27 +399,27 @@ func (s *apiServer) runInstallAction(ctx context.Context, ref cstore.Ref, force,
 		manifestHashHex := sha256.Sum256(tb.Manifest)
 		deps := make([]map[string]any, 0, len(manifest.Requires.Connectors))
 		for _, c := range manifest.Requires.Connectors {
-			dep := map[string]any{"name": c.Name}
+			dep := map[string]any{"aileron.connector.fqn": c.Name}
 			if c.Version != "" {
-				dep["version"] = c.Version
+				dep["aileron.connector.version"] = c.Version
 			}
 			if c.Hash != "" {
-				dep["hash"] = c.Hash
+				dep["aileron.connector.hash"] = c.Hash
 			}
 			deps = append(deps, dep)
 		}
 		s.auditRecorder.RecordSuccess(ctx, model.EventTypeActionInstalled,
 			model.ActorRef{Type: model.ActorTypeHuman, ID: "user"},
 			map[string]any{
-				"name":             manifest.Name,
-				"fqn":              ref.FQN.String(),
-				"version":          ref.Version,
-				"hash":             "sha256:" + hex.EncodeToString(manifestHashHex[:]),
-				"signature_status": signatureStatus,
-				"decision":         "approved",
-				"source":           manifest.Source,
-				"path":             dest,
-				"dependencies":     deps,
+				"aileron.action.name":          manifest.Name,
+				"aileron.action.fqn":           ref.FQN.String(),
+				"aileron.action.version":       ref.Version,
+				"aileron.action.hash":          "sha256:" + hex.EncodeToString(manifestHashHex[:]),
+				"aileron.signature.status":     signatureStatus,
+				"aileron.consent.decision":     "approved",
+				"aileron.action.source":        manifest.Source,
+				"aileron.action.path":          dest,
+				"aileron.action.dependencies":  deps,
 			})
 	}
 

--- a/internal/app/handlers_install_actions_test.go
+++ b/internal/app/handlers_install_actions_test.go
@@ -425,33 +425,42 @@ func TestInstallAction_ContextCarriesAuditPayload(t *testing.T) {
 				continue
 			}
 			found = true
-			for _, key := range []string{"name", "fqn", "version", "hash", "signature_status", "decision", "path", "dependencies"} {
+			for _, key := range []string{
+				"aileron.action.name",
+				"aileron.action.fqn",
+				"aileron.action.version",
+				"aileron.action.hash",
+				"aileron.signature.status",
+				"aileron.consent.decision",
+				"aileron.action.path",
+				"aileron.action.dependencies",
+			} {
 				if _, ok := e.Payload[key]; !ok {
 					t.Errorf("payload missing %q", key)
 				}
 			}
-			if got, _ := e.Payload["signature_status"].(string); got != "verified" {
-				t.Errorf("signature_status = %q, want \"verified\"", got)
+			if got, _ := e.Payload["aileron.signature.status"].(string); got != "verified" {
+				t.Errorf("aileron.signature.status = %q, want \"verified\"", got)
 			}
-			if got, _ := e.Payload["decision"].(string); got != "approved" {
-				t.Errorf("decision = %q, want \"approved\"", got)
+			if got, _ := e.Payload["aileron.consent.decision"].(string); got != "approved" {
+				t.Errorf("aileron.consent.decision = %q, want \"approved\"", got)
 			}
-			hash, _ := e.Payload["hash"].(string)
+			hash, _ := e.Payload["aileron.action.hash"].(string)
 			if !strings.HasPrefix(hash, "sha256:") || len(hash) != len("sha256:")+64 {
-				t.Errorf("hash = %q, want sha256:<64 hex>", hash)
+				t.Errorf("aileron.action.hash = %q, want sha256:<64 hex>", hash)
 			}
-			deps, ok := e.Payload["dependencies"].([]map[string]any)
+			deps, ok := e.Payload["aileron.action.dependencies"].([]map[string]any)
 			if !ok || len(deps) != 1 {
-				t.Errorf("dependencies = %#v, want one entry", e.Payload["dependencies"])
+				t.Errorf("aileron.action.dependencies = %#v, want one entry", e.Payload["aileron.action.dependencies"])
 			} else {
-				if deps[0]["name"] != depFQN {
-					t.Errorf("dependencies[0].name = %v, want %q", deps[0]["name"], depFQN)
+				if deps[0]["aileron.connector.fqn"] != depFQN {
+					t.Errorf("dep[0].aileron.connector.fqn = %v, want %q", deps[0]["aileron.connector.fqn"], depFQN)
 				}
-				if deps[0]["version"] != "1.0.0" {
-					t.Errorf("dependencies[0].version = %v, want \"1.0.0\"", deps[0]["version"])
+				if deps[0]["aileron.connector.version"] != "1.0.0" {
+					t.Errorf("dep[0].aileron.connector.version = %v, want \"1.0.0\"", deps[0]["aileron.connector.version"])
 				}
-				if deps[0]["hash"] != depHash {
-					t.Errorf("dependencies[0].hash = %v, want %q", deps[0]["hash"], depHash)
+				if deps[0]["aileron.connector.hash"] != depHash {
+					t.Errorf("dep[0].aileron.connector.hash = %v, want %q", deps[0]["aileron.connector.hash"], depHash)
 				}
 			}
 		}
@@ -484,8 +493,8 @@ func TestInstallAction_AuditUnsignedTarball(t *testing.T) {
 	if got == nil {
 		t.Fatal("expected an action.installed event")
 	}
-	if status, _ := got.Payload["signature_status"].(string); status != "unsigned" {
-		t.Errorf("signature_status = %q, want \"unsigned\"", status)
+	if status, _ := got.Payload["aileron.signature.status"].(string); status != "unsigned" {
+		t.Errorf("aileron.signature.status = %q, want \"unsigned\"", status)
 	}
 }
 

--- a/internal/app/handlers_install_test.go
+++ b/internal/app/handlers_install_test.go
@@ -177,23 +177,23 @@ func TestInstallConnector_AuditPayloadHasConsentFields(t *testing.T) {
 	if got == nil {
 		t.Fatalf("expected a connector.installed event; got %d events", len(events))
 	}
-	if got.Payload["fqn"] != "github://aileron/slack" {
-		t.Errorf("fqn = %v", got.Payload["fqn"])
+	if got.Payload["aileron.connector.fqn"] != "github://aileron/slack" {
+		t.Errorf("aileron.connector.fqn = %v", got.Payload["aileron.connector.fqn"])
 	}
-	if got.Payload["version"] != "1.2.0" {
-		t.Errorf("version = %v", got.Payload["version"])
+	if got.Payload["aileron.connector.version"] != "1.2.0" {
+		t.Errorf("aileron.connector.version = %v", got.Payload["aileron.connector.version"])
 	}
-	if got.Payload["hash"] != expectedHash {
-		t.Errorf("hash = %v, want %q", got.Payload["hash"], expectedHash)
+	if got.Payload["aileron.connector.hash"] != expectedHash {
+		t.Errorf("aileron.connector.hash = %v, want %q", got.Payload["aileron.connector.hash"], expectedHash)
 	}
-	if got.Payload["signature_status"] != "verified" {
-		t.Errorf("signature_status = %v, want \"verified\"", got.Payload["signature_status"])
+	if got.Payload["aileron.signature.status"] != "verified" {
+		t.Errorf("aileron.signature.status = %v, want \"verified\"", got.Payload["aileron.signature.status"])
 	}
-	if got.Payload["decision"] != "approved" {
-		t.Errorf("decision = %v, want \"approved\"", got.Payload["decision"])
+	if got.Payload["aileron.consent.decision"] != "approved" {
+		t.Errorf("aileron.consent.decision = %v, want \"approved\"", got.Payload["aileron.consent.decision"])
 	}
-	if got.Payload["already_installed"] != false {
-		t.Errorf("already_installed = %v, want false", got.Payload["already_installed"])
+	if got.Payload["aileron.install.already_installed"] != false {
+		t.Errorf("aileron.install.already_installed = %v, want false", got.Payload["aileron.install.already_installed"])
 	}
 }
 
@@ -221,7 +221,7 @@ func TestInstallConnector_AuditOnOfflineReinstall(t *testing.T) {
 			continue
 		}
 		count++
-		if v, _ := events[i].Payload["already_installed"].(bool); v {
+		if v, _ := events[i].Payload["aileron.install.already_installed"].(bool); v {
 			reinstall = &events[i]
 		}
 	}

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -43,7 +43,7 @@ func TestFileStore_AppendThenReopen_RoundTrip(t *testing.T) {
 		EventID:   "audit-xyz",
 		EventType: model.EventTypeActionInstalled,
 		Actor:     model.ActorRef{Type: model.ActorTypeHuman, ID: "user"},
-		Payload:   map[string]any{"name": "ship-update", "fqn": "github://aileron/slack"},
+		Payload:   map[string]any{"aileron.action.name": "ship-update", "aileron.action.fqn": "github://aileron/slack"},
 		Timestamp: t0,
 	}
 	if err := store.Append(context.Background(), ev); err != nil {
@@ -62,7 +62,7 @@ func TestFileStore_AppendThenReopen_RoundTrip(t *testing.T) {
 	if got.EventID != "audit-xyz" || got.EventType != model.EventTypeActionInstalled {
 		t.Errorf("got = %+v", got)
 	}
-	if got.Payload["name"] != "ship-update" || got.Payload["fqn"] != "github://aileron/slack" {
+	if got.Payload["aileron.action.name"] != "ship-update" || got.Payload["aileron.action.fqn"] != "github://aileron/slack" {
 		t.Errorf("payload = %+v", got.Payload)
 	}
 	if !got.Timestamp.Equal(t0) {
@@ -265,7 +265,7 @@ func TestFileStore_FilterAndLimitDelegateToMem(t *testing.T) {
 		_ = store.Append(ctx, audit.Event{
 			EventID:   string(rune('a' + i)),
 			Timestamp: t0.Add(time.Duration(i) * time.Hour),
-			Payload:   map[string]any{"class": "binding_required"},
+			Payload:   map[string]any{"aileron.failure.class": "binding_required"},
 		})
 	}
 	got, err := store.ListEvents(ctx, audit.EventFilter{

--- a/internal/audit/mem.go
+++ b/internal/audit/mem.go
@@ -23,12 +23,14 @@ type EventFilter struct {
 	EventID string
 	// ConnectorFQN, when non-empty, matches events whose payload
 	// references this FQN under any of the recorder's connector
-	// keys: top-level `connector_fqn`, top-level `fqn` (action
-	// install events), or `details.connector` (failure events).
+	// keys: `aileron.connector.fqn` (binding lifecycle and
+	// connector install events), `aileron.action.fqn` (action
+	// install events — when filtering by the action's own FQN),
+	// or `aileron.failure.details.connector` (failure events).
 	ConnectorFQN string
 	// Class, when non-empty, matches events whose payload carries
 	// this failure class. Has no effect on success events (they
-	// don't record `class`), so a Class filter naturally narrows
+	// don't record a class), so a Class filter naturally narrows
 	// to failures.
 	Class string
 	// Limit caps the number of events returned. <=0 means no cap.
@@ -69,7 +71,7 @@ func matchEventFilter(ev Event, f EventFilter) bool {
 		return false
 	}
 	if f.Class != "" {
-		got, _ := ev.Payload["class"].(string)
+		got, _ := ev.Payload["aileron.failure.class"].(string)
 		if got != f.Class {
 			return false
 		}
@@ -81,18 +83,22 @@ func matchEventFilter(ev Event, f EventFilter) bool {
 }
 
 // payloadMatchesConnector returns true when the payload carries the
-// given connector FQN under any of the keys the recorder uses today:
-//   - `connector_fqn` (binding lifecycle events)
-//   - `fqn`           (action.installed events)
-//   - `details.connector` (failure events)
+// given connector FQN under any of the namespaced keys the recorder
+// uses today:
+//   - `aileron.connector.fqn` (binding lifecycle, connector install)
+//   - `aileron.action.fqn`    (action install — matches when the user
+//     filters by the action's own FQN, since actions are addressed
+//     under the same FQN namespace as connectors)
+//   - `aileron.failure.details.connector` (failure events that
+//     surface a connector identity in nested details)
 func payloadMatchesConnector(p map[string]any, fqn string) bool {
-	if got, _ := p["connector_fqn"].(string); got == fqn {
+	if got, _ := p["aileron.connector.fqn"].(string); got == fqn {
 		return true
 	}
-	if got, _ := p["fqn"].(string); got == fqn {
+	if got, _ := p["aileron.action.fqn"].(string); got == fqn {
 		return true
 	}
-	if details, ok := p["details"].(map[string]any); ok {
+	if details, ok := p["aileron.failure.details"].(map[string]any); ok {
 		if got, _ := details["connector"].(string); got == fqn {
 			return true
 		}

--- a/internal/audit/mem_events_test.go
+++ b/internal/audit/mem_events_test.go
@@ -85,20 +85,20 @@ func TestListEvents_FilterByClassMatchesFailures(t *testing.T) {
 		audit.Event{
 			EventID:   "fail-1",
 			EventType: model.EventTypeExecutionFailed,
-			Payload:   map[string]any{"class": "binding_required"},
+			Payload:   map[string]any{"aileron.failure.class": "binding_required"},
 			Timestamp: time.Now(),
 		},
 		audit.Event{
 			EventID:   "fail-2",
 			EventType: model.EventTypeExecutionFailed,
-			Payload:   map[string]any{"class": "policy_denied"},
+			Payload:   map[string]any{"aileron.failure.class": "policy_denied"},
 			Timestamp: time.Now(),
 		},
 		audit.Event{
-			// Success event has no `class` — must be filtered out.
+			// Success event carries no failure class — must be filtered out.
 			EventID:   "ok",
 			EventType: model.EventTypeActionInstalled,
-			Payload:   map[string]any{"name": "ship-update"},
+			Payload:   map[string]any{"aileron.action.name": "ship-update"},
 			Timestamp: time.Now(),
 		},
 	)
@@ -114,28 +114,28 @@ func TestListEvents_FilterByConnectorFQNAcrossKnownKeys(t *testing.T) {
 		// Binding-lifecycle event
 		audit.Event{
 			EventID:   "bind",
-			Payload:   map[string]any{"connector_fqn": fqn},
+			Payload:   map[string]any{"aileron.connector.fqn": fqn},
 			Timestamp: time.Now(),
 		},
-		// Action-installed event
+		// Action-installed event keyed on the action's own FQN
 		audit.Event{
 			EventID:   "act",
-			Payload:   map[string]any{"fqn": fqn},
+			Payload:   map[string]any{"aileron.action.fqn": fqn},
 			Timestamp: time.Now(),
 		},
-		// Failure event with details.connector
+		// Failure event with nested details.connector
 		audit.Event{
 			EventID: "fail",
 			Payload: map[string]any{
-				"class":   "binding_required",
-				"details": map[string]any{"connector": fqn},
+				"aileron.failure.class":   "binding_required",
+				"aileron.failure.details": map[string]any{"connector": fqn},
 			},
 			Timestamp: time.Now(),
 		},
 		// Unrelated event
 		audit.Event{
 			EventID:   "other",
-			Payload:   map[string]any{"connector_fqn": "github://x/y"},
+			Payload:   map[string]any{"aileron.connector.fqn": "github://x/y"},
 			Timestamp: time.Now(),
 		},
 	)
@@ -186,19 +186,19 @@ func TestListEvents_FiltersCompose(t *testing.T) {
 		// Match: right class, right connector, after Since.
 		audit.Event{
 			EventID:   "want",
-			Payload:   map[string]any{"class": "binding_required", "details": map[string]any{"connector": fqn}},
+			Payload:   map[string]any{"aileron.failure.class": "binding_required", "aileron.failure.details": map[string]any{"connector": fqn}},
 			Timestamp: t0.Add(time.Hour),
 		},
 		// Right class + connector, but BEFORE Since.
 		audit.Event{
 			EventID:   "too-old",
-			Payload:   map[string]any{"class": "binding_required", "details": map[string]any{"connector": fqn}},
+			Payload:   map[string]any{"aileron.failure.class": "binding_required", "aileron.failure.details": map[string]any{"connector": fqn}},
 			Timestamp: t0.Add(-time.Hour),
 		},
 		// Right class + Since, but different connector.
 		audit.Event{
 			EventID:   "wrong-fqn",
-			Payload:   map[string]any{"class": "binding_required", "details": map[string]any{"connector": "github://x/y"}},
+			Payload:   map[string]any{"aileron.failure.class": "binding_required", "aileron.failure.details": map[string]any{"connector": "github://x/y"}},
 			Timestamp: t0.Add(time.Hour),
 		},
 	)

--- a/internal/audit/record.go
+++ b/internal/audit/record.go
@@ -76,14 +76,20 @@ func (r *recorder) RecordFailure(ctx context.Context, f *failure.Failure, actor 
 	if f != nil {
 		f.SetAuditID(id)
 	}
+	// Audit-log payload uses OTel-namespaced field names per the
+	// Phase 6.5 schema alignment for issue #390. The wire error
+	// envelope keeps its flat REST-style keys (`class`, `boundary`,
+	// …) per ADR-0010; the recorder translates between the two
+	// surfaces at write time. `details` stays nested for now —
+	// flattening into indexed attributes is deferred to Phase 7.
 	payload := map[string]any{}
 	if f != nil {
-		payload["class"] = string(f.Class())
-		payload["boundary"] = string(f.Boundary())
-		payload["retriable"] = f.Retriable()
-		payload["message"] = f.Message()
+		payload["aileron.failure.class"] = string(f.Class())
+		payload["aileron.failure.boundary"] = string(f.Boundary())
+		payload["aileron.failure.retriable"] = f.Retriable()
+		payload["aileron.failure.message"] = f.Message()
 		if d := f.Details(); len(d) > 0 {
-			payload["details"] = d
+			payload["aileron.failure.details"] = d
 		}
 	}
 	_ = r.store.Append(ctx, Event{

--- a/internal/audit/record_test.go
+++ b/internal/audit/record_test.go
@@ -13,7 +13,10 @@ import (
 // Recorder contract:
 //   - RecordFailure mints an audit_id, stamps it on the failure, and
 //     appends an EventTypeExecutionFailed event whose payload carries
-//     class/boundary/retriable/message/details.
+//     the namespaced failure attributes (aileron.failure.class,
+//     aileron.failure.boundary, aileron.failure.retriable,
+//     aileron.failure.message, aileron.failure.details) per the
+//     OTel-aligned audit schema (issue #390 Phase 6.5).
 //   - RecordSuccess appends an event with the given type/payload.
 //   - Clock and idFn are injectable for deterministic tests.
 //   - Store.Append errors are swallowed (best-effort audit per ADR-0010).
@@ -53,17 +56,17 @@ func TestRecordFailure_StampsAuditIDAndAppends(t *testing.T) {
 	if ev.EventType != model.EventTypeExecutionFailed {
 		t.Errorf("event type = %q, want execution.failed", ev.EventType)
 	}
-	if ev.Payload["class"] != string(failure.ExternalAPIError) {
-		t.Errorf("payload.class = %v", ev.Payload["class"])
+	if ev.Payload["aileron.failure.class"] != string(failure.ExternalAPIError) {
+		t.Errorf("payload[aileron.failure.class] = %v", ev.Payload["aileron.failure.class"])
 	}
-	if ev.Payload["retriable"] != true {
-		t.Errorf("payload.retriable = %v", ev.Payload["retriable"])
+	if ev.Payload["aileron.failure.retriable"] != true {
+		t.Errorf("payload[aileron.failure.retriable] = %v", ev.Payload["aileron.failure.retriable"])
 	}
-	if ev.Payload["message"] != "service unavailable" {
-		t.Errorf("payload.message = %v", ev.Payload["message"])
+	if ev.Payload["aileron.failure.message"] != "service unavailable" {
+		t.Errorf("payload[aileron.failure.message] = %v", ev.Payload["aileron.failure.message"])
 	}
-	if d, ok := ev.Payload["details"].(map[string]any); !ok || d["retried"] != 2 {
-		t.Errorf("payload.details = %v", ev.Payload["details"])
+	if d, ok := ev.Payload["aileron.failure.details"].(map[string]any); !ok || d["retried"] != 2 {
+		t.Errorf("payload[aileron.failure.details] = %v", ev.Payload["aileron.failure.details"])
 	}
 	if ev.Actor.ID != "agent-1" {
 		t.Errorf("actor.id = %q", ev.Actor.ID)

--- a/internal/intercept/intercept_test.go
+++ b/internal/intercept/intercept_test.go
@@ -1324,7 +1324,7 @@ func TestHandleOpenAI_ActionFailure_FlowsAsToolResult_AuditRecorded(t *testing.T
 	hasFailure := false
 	for _, tr := range traces {
 		for _, ev := range tr.Events {
-			if class, _ := ev.Payload["class"].(string); class == "capability_denied" {
+			if class, _ := ev.Payload["aileron.failure.class"].(string); class == "capability_denied" {
 				hasFailure = true
 			}
 		}


### PR DESCRIPTION
## Summary

Issue #390 Phase 6.5 schema alignment: every audit-event payload field name is renamed to the OTel-namespaced form so Phase 7 OTLP emission can map them straight to span attributes without a breaking schema change after publishers depend on the format.

**Audit-log payload only** — the wire failure envelope keeps its flat REST keys (`class`, `boundary`, `retriable`, `message`, `details`). The recorder translates between the two surfaces at write time. ADR-0010 is amended with a new \"Audit payload vs wire envelope\" section that documents the split and points forward to Phase 7.

## Renames

| Event family | Before | After |
|---|---|---|
| failure | `class`, `boundary`, `retriable`, `message`, `details` | `aileron.failure.{class,boundary,retriable,message,details}` |
| binding | `name`, `connector_fqn`, `kind` | `aileron.binding.name`, `aileron.connector.fqn`, `aileron.capability.kind` |
| connector install | `fqn`, `version`, `hash`, `signature_status`, `decision`, `already_installed` | `aileron.connector.{fqn,version,hash}`, `aileron.signature.status`, `aileron.consent.decision`, `aileron.install.already_installed` |
| action install | `name`, `fqn`, `version`, `hash`, `signature_status`, `decision`, `source`, `path`, `dependencies` | `aileron.action.{name,fqn,version,hash,source,path,dependencies}`, `aileron.signature.status`, `aileron.consent.decision`; inner deps use `aileron.connector.{fqn,version,hash}` |

## Why namespacing

OTel attribute conventions reserve generic names (`name`, `version`, `class`, …) for semantic-convention namespaces (`http.*`, `db.*`, `service.*`, …) and require vendor-owned attributes to use a vendor-specific prefix. Without the `aileron.` prefix:
- An audit span carrying `name` would collide with attributes from any co-instrumented library (HTTP middleware, DB drivers, SDKs, …) — backends can't disambiguate.
- Auto-derived metrics/labels in Datadog, Grafana, etc. need the prefix to scope filters to Aileron's audit data.
- The prefix signals provenance and ownership.

## Why the wire envelope keeps the flat names

The wire envelope is part of an HTTP API contract that follows REST/JSON conventions; real APIs don't return `{\"aileron.failure.class\": \"...\"}` in error bodies. The OTel prefix exists specifically to scope attributes inside a multi-source span/trace, not inside a response that's already URL-scoped. The recorder's translation in `internal/audit/record.go` is small and isolated, and ADR-0010 already distinguishes its envelope from the CRUD `api.Error` shape — renaming the wire too would just add a third convention without getting to \"one shape everywhere.\"

## Test plan

- [x] `go test ./internal/... ./cmd/aileron/...` green — every audit-payload-asserting test updated to the namespaced keys
- [x] Filter logic (`internal/audit/mem.go`) updated to read `aileron.connector.fqn` / `aileron.action.fqn` / `aileron.failure.details.connector` and `aileron.failure.class`; the `--connector` and `--class` CLI filters work unchanged
- [x] CLI summary (`auditPayloadSummary`, `payloadConnector`, new `payloadName`) reads the namespaced keys; `aileron audit list` output format is unchanged
- [x] ADR-0010 amended with the audit-vs-wire split section
- [x] Coverage: audit 89.8%, app 79.6% (no regression)

🤖 Generated with [Claude Code](https://claude.com/claude-code)