### PR TITLE
feat(daemon): add discovery file utilities for daemon.json/pid/lock

### DIFF
--- a/internal/daemon/discovery/discovery.go
+++ b/internal/daemon/discovery/discovery.go
@@ -1,0 +1,181 @@
+// Package discovery manages the on-disk advertisement of the running
+// Aileron daemon. The daemon writes its URL, PID, version, and start
+// time to <stateDir>/daemon.json after binding its TCP listener; CLI
+// and launch read this file to find the daemon (with auto-spawn if
+// missing). A separate <stateDir>/daemon.pid sidecar exists so
+// `aileron stop` and shell tooling (`kill $(cat daemon.pid)`) can
+// find the process by PID without parsing JSON.
+//
+// A sidecar <stateDir>/daemon.lock is taken via flock(2) by clients
+// that race to spawn the daemon on first need; the holder spawns and
+// releases, and contenders re-check daemon.json after acquiring.
+//
+// All files are mode 0600 in a stateDir the caller is expected to
+// scope to the user's ~/.aileron/ (or t.TempDir() in tests).
+//
+// See ADR-0012.
+package discovery
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strconv"
+	"syscall"
+	"time"
+)
+
+// File names within stateDir.
+const (
+	InfoFile = "daemon.json"
+	PIDFile  = "daemon.pid"
+	LockFile = "daemon.lock"
+)
+
+// Info is the structured advertisement the daemon writes after binding.
+type Info struct {
+	URL       string    `json:"url"`
+	PID       int       `json:"pid"`
+	Version   string    `json:"version"`
+	StartedAt time.Time `json:"started_at"`
+}
+
+// ErrNotRunning is returned by Read when daemon.json does not exist.
+// Callers can use [errors.Is] against this sentinel; the underlying
+// cause is also wrapped so [errors.Is] against [os.ErrNotExist] works.
+var ErrNotRunning = errors.New("daemon is not running")
+
+// Read reads <stateDir>/daemon.json and returns the parsed Info.
+// Returns ErrNotRunning (also wrapping [os.ErrNotExist]) when the file
+// does not exist.
+func Read(stateDir string) (Info, error) {
+	path := filepath.Join(stateDir, InfoFile)
+	b, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return Info{}, fmt.Errorf("%w: %w", ErrNotRunning, err)
+		}
+		return Info{}, fmt.Errorf("discovery: read %s: %w", path, err)
+	}
+	var info Info
+	if err := json.Unmarshal(b, &info); err != nil {
+		return Info{}, fmt.Errorf("discovery: parse %s: %w", path, err)
+	}
+	return info, nil
+}
+
+// Write atomically replaces <stateDir>/daemon.json and <stateDir>/daemon.pid
+// with the supplied Info. The two files are written via temp + rename;
+// each rename is atomic on its own, but the pair is not — readers
+// should treat daemon.json as authoritative. Both files are mode 0600.
+//
+// stateDir is created (mode 0700) if it does not exist.
+func Write(stateDir string, info Info) error {
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return fmt.Errorf("discovery: mkdir %s: %w", stateDir, err)
+	}
+
+	b, err := json.Marshal(info)
+	if err != nil {
+		return fmt.Errorf("discovery: marshal: %w", err)
+	}
+	if err := writeAtomic(stateDir, InfoFile, b); err != nil {
+		return err
+	}
+
+	pidBytes := []byte(strconv.Itoa(info.PID) + "\n")
+	if err := writeAtomic(stateDir, PIDFile, pidBytes); err != nil {
+		return err
+	}
+	return nil
+}
+
+// Remove deletes daemon.json and daemon.pid from stateDir. Missing
+// files are not errors. The lock file is left in place — its presence
+// does not imply the daemon is running, and removing it could race
+// with a concurrent Lock acquisition.
+func Remove(stateDir string) error {
+	for _, name := range []string{InfoFile, PIDFile} {
+		if err := os.Remove(filepath.Join(stateDir, name)); err != nil && !errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("discovery: remove %s: %w", name, err)
+		}
+	}
+	return nil
+}
+
+// Lock takes an exclusive flock(2) on <stateDir>/daemon.lock, blocking
+// until the lock is acquired or ctx is canceled. Returns a release
+// function the caller must invoke (typically via defer) to release the
+// lock and close the file descriptor.
+//
+// Used by clients racing to spawn the daemon on first need: only the
+// holder spawns; contenders re-check daemon.json after acquiring.
+func Lock(ctx context.Context, stateDir string) (release func() error, err error) {
+	if err := os.MkdirAll(stateDir, 0o700); err != nil {
+		return nil, fmt.Errorf("discovery: mkdir %s: %w", stateDir, err)
+	}
+	path := filepath.Join(stateDir, LockFile)
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		return nil, fmt.Errorf("discovery: open lock: %w", err)
+	}
+
+	const pollInterval = 25 * time.Millisecond
+	for {
+		err := syscall.Flock(int(f.Fd()), syscall.LOCK_EX|syscall.LOCK_NB)
+		if err == nil {
+			return func() error {
+				_ = syscall.Flock(int(f.Fd()), syscall.LOCK_UN)
+				return f.Close()
+			}, nil
+		}
+		if !errors.Is(err, syscall.EWOULDBLOCK) {
+			_ = f.Close()
+			return nil, fmt.Errorf("discovery: flock: %w", err)
+		}
+		select {
+		case <-ctx.Done():
+			_ = f.Close()
+			return nil, ctx.Err()
+		case <-time.After(pollInterval):
+		}
+	}
+}
+
+// writeAtomic writes data to <stateDir>/<name> via a temp file and
+// rename(2). Mode is 0600. The rename is atomic on POSIX file systems.
+// On any error before the rename succeeds, the temp file is cleaned up.
+func writeAtomic(stateDir, name string, data []byte) error {
+	final := filepath.Join(stateDir, name)
+	tmp, err := os.CreateTemp(stateDir, name+".tmp.*")
+	if err != nil {
+		return fmt.Errorf("discovery: create temp for %s: %w", name, err)
+	}
+	tmpPath := tmp.Name()
+	keepTemp := false
+	defer func() {
+		if !keepTemp {
+			_ = os.Remove(tmpPath)
+		}
+	}()
+
+	if _, err := tmp.Write(data); err != nil {
+		_ = tmp.Close()
+		return fmt.Errorf("discovery: write %s: %w", name, err)
+	}
+	if err := tmp.Close(); err != nil {
+		return fmt.Errorf("discovery: close temp %s: %w", name, err)
+	}
+	if err := os.Chmod(tmpPath, 0o600); err != nil {
+		return fmt.Errorf("discovery: chmod %s: %w", name, err)
+	}
+	if err := os.Rename(tmpPath, final); err != nil {
+		return fmt.Errorf("discovery: rename %s: %w", name, err)
+	}
+	keepTemp = true
+	return nil
+}
+

--- a/internal/daemon/discovery/discovery_test.go
+++ b/internal/daemon/discovery/discovery_test.go
@@ -1,0 +1,339 @@
+package discovery_test
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"strconv"
+	"strings"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
+)
+
+func TestWriteReadRoundTrip(t *testing.T) {
+	dir := t.TempDir()
+	want := discovery.Info{
+		URL:       "http://127.0.0.1:54321",
+		PID:       12345,
+		Version:   "0.0.7-dev+abc123",
+		StartedAt: time.Now().UTC().Truncate(time.Second),
+	}
+	if err := discovery.Write(dir, want); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+
+	got, err := discovery.Read(dir)
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if got.URL != want.URL || got.PID != want.PID || got.Version != want.Version {
+		t.Fatalf("round-trip mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+	if !got.StartedAt.Equal(want.StartedAt) {
+		t.Fatalf("StartedAt mismatch: got=%v want=%v", got.StartedAt, want.StartedAt)
+	}
+}
+
+func TestWriteCreatesStateDir(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "nested", "state")
+	info := discovery.Info{URL: "http://127.0.0.1:1", PID: 1, Version: "v", StartedAt: time.Now().UTC()}
+	if err := discovery.Write(dir, info); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dir, discovery.InfoFile)); err != nil {
+		t.Fatalf("Stat: %v", err)
+	}
+}
+
+func TestWriteSetsFileMode0600(t *testing.T) {
+	dir := t.TempDir()
+	info := discovery.Info{URL: "http://127.0.0.1:1", PID: 1, Version: "v", StartedAt: time.Now().UTC()}
+	if err := discovery.Write(dir, info); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	for _, name := range []string{discovery.InfoFile, discovery.PIDFile} {
+		fi, err := os.Stat(filepath.Join(dir, name))
+		if err != nil {
+			t.Fatalf("Stat %s: %v", name, err)
+		}
+		if mode := fi.Mode().Perm(); mode != 0o600 {
+			t.Fatalf("%s mode: want 0o600, got %o", name, mode)
+		}
+	}
+}
+
+func TestWritePIDFileContainsPID(t *testing.T) {
+	dir := t.TempDir()
+	info := discovery.Info{URL: "http://127.0.0.1:1", PID: 99887, Version: "v", StartedAt: time.Now().UTC()}
+	if err := discovery.Write(dir, info); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, discovery.PIDFile))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	pid, err := strconv.Atoi(strings.TrimSpace(string(b)))
+	if err != nil {
+		t.Fatalf("parse PID: %v", err)
+	}
+	if pid != info.PID {
+		t.Fatalf("got PID %d, want %d", pid, info.PID)
+	}
+}
+
+func TestReadMissingReturnsErrNotRunning(t *testing.T) {
+	dir := t.TempDir()
+	_, err := discovery.Read(dir)
+	if !errors.Is(err, discovery.ErrNotRunning) {
+		t.Fatalf("want ErrNotRunning, got %v", err)
+	}
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("ErrNotRunning should also wrap os.ErrNotExist; got %v", err)
+	}
+}
+
+func TestReadMalformedJSONFails(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, discovery.InfoFile), []byte("{not json"), 0o600); err != nil {
+		t.Fatalf("write garbage: %v", err)
+	}
+	_, err := discovery.Read(dir)
+	if err == nil {
+		t.Fatal("Read should fail on malformed JSON")
+	}
+	if errors.Is(err, discovery.ErrNotRunning) {
+		t.Fatalf("malformed JSON should not be reported as ErrNotRunning; got %v", err)
+	}
+}
+
+func TestRemoveDeletesBothFiles(t *testing.T) {
+	dir := t.TempDir()
+	info := discovery.Info{URL: "http://127.0.0.1:1", PID: 1, Version: "v", StartedAt: time.Now().UTC()}
+	if err := discovery.Write(dir, info); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	if err := discovery.Remove(dir); err != nil {
+		t.Fatalf("Remove: %v", err)
+	}
+	for _, name := range []string{discovery.InfoFile, discovery.PIDFile} {
+		if _, err := os.Stat(filepath.Join(dir, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Fatalf("%s still exists after Remove (err: %v)", name, err)
+		}
+	}
+}
+
+func TestRemoveIsIdempotent(t *testing.T) {
+	dir := t.TempDir()
+	if err := discovery.Remove(dir); err != nil {
+		t.Fatalf("Remove on empty dir: %v", err)
+	}
+	if err := discovery.Remove(dir); err != nil {
+		t.Fatalf("second Remove on empty dir: %v", err)
+	}
+}
+
+func TestLockIsExclusive(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	release1, err := discovery.Lock(ctx, dir)
+	if err != nil {
+		t.Fatalf("first Lock: %v", err)
+	}
+	defer release1()
+
+	// Second acquire with a short ctx must time out — first holder still has the lock.
+	ctx2, cancel := context.WithTimeout(ctx, 100*time.Millisecond)
+	defer cancel()
+	release2, err := discovery.Lock(ctx2, dir)
+	if err == nil {
+		release2()
+		t.Fatal("second Lock should not succeed while first is held")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Fatalf("want DeadlineExceeded, got %v", err)
+	}
+}
+
+func TestLockReleasePermitsReacquire(t *testing.T) {
+	dir := t.TempDir()
+	ctx := context.Background()
+
+	release1, err := discovery.Lock(ctx, dir)
+	if err != nil {
+		t.Fatalf("first Lock: %v", err)
+	}
+	if err := release1(); err != nil {
+		t.Fatalf("release1: %v", err)
+	}
+
+	release2, err := discovery.Lock(ctx, dir)
+	if err != nil {
+		t.Fatalf("second Lock after release: %v", err)
+	}
+	if err := release2(); err != nil {
+		t.Fatalf("release2: %v", err)
+	}
+}
+
+// TestLockSerializesContenders mimics the daemon-spawn race: many
+// goroutines try to acquire the lock; exactly one runs the protected
+// section at any time, and all of them eventually succeed.
+func TestLockSerializesContenders(t *testing.T) {
+	dir := t.TempDir()
+	const N = 8
+	var (
+		concurrent atomic.Int32
+		maxSeen    atomic.Int32
+		wg         sync.WaitGroup
+	)
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			ctx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+			defer cancel()
+			release, err := discovery.Lock(ctx, dir)
+			if err != nil {
+				t.Errorf("Lock: %v", err)
+				return
+			}
+			now := concurrent.Add(1)
+			for {
+				prev := maxSeen.Load()
+				if now <= prev || maxSeen.CompareAndSwap(prev, now) {
+					break
+				}
+			}
+			time.Sleep(5 * time.Millisecond)
+			concurrent.Add(-1)
+			if err := release(); err != nil {
+				t.Errorf("release: %v", err)
+			}
+		}()
+	}
+	wg.Wait()
+	if got := maxSeen.Load(); got != 1 {
+		t.Fatalf("max concurrent holders: want 1, got %d", got)
+	}
+}
+
+func TestLockCancelBeforeAcquire(t *testing.T) {
+	dir := t.TempDir()
+
+	// Hold the lock so the second Lock blocks.
+	hold, err := discovery.Lock(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("first Lock: %v", err)
+	}
+	defer hold()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // cancel immediately
+	_, err = discovery.Lock(ctx, dir)
+	if !errors.Is(err, context.Canceled) {
+		t.Fatalf("want Canceled, got %v", err)
+	}
+}
+
+func TestLockCreatesStateDir(t *testing.T) {
+	parent := t.TempDir()
+	dir := filepath.Join(parent, "nested")
+	release, err := discovery.Lock(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+	defer release()
+	if _, err := os.Stat(filepath.Join(dir, discovery.LockFile)); err != nil {
+		t.Fatalf("Stat lock file: %v", err)
+	}
+}
+
+// Compile-time assertion that discovery.Info JSON shape is what the
+// ADR documents — exact field names, lower-snake-case for started_at.
+func TestInfoJSONShape(t *testing.T) {
+	info := discovery.Info{
+		URL:       "http://127.0.0.1:54321",
+		PID:       42,
+		Version:   "v1",
+		StartedAt: time.Date(2026, 5, 5, 14, 22, 3, 0, time.UTC),
+	}
+	dir := t.TempDir()
+	if err := discovery.Write(dir, info); err != nil {
+		t.Fatalf("Write: %v", err)
+	}
+	b, err := os.ReadFile(filepath.Join(dir, discovery.InfoFile))
+	if err != nil {
+		t.Fatalf("ReadFile: %v", err)
+	}
+	want := `{"url":"http://127.0.0.1:54321","pid":42,"version":"v1","started_at":"2026-05-05T14:22:03Z"}`
+	if got := string(b); got != want {
+		t.Fatalf("json shape mismatch:\n got=%s\nwant=%s", got, want)
+	}
+}
+
+func TestWriteFailsOnReadOnlyStateDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod-based access denial is bypassed")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	err := discovery.Write(dir, discovery.Info{
+		URL: "u", PID: 1, Version: "v", StartedAt: time.Now().UTC(),
+	})
+	if err == nil {
+		t.Fatal("Write should fail when stateDir is read-only")
+	}
+}
+
+func TestLockFailsOnReadOnlyStateDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod-based access denial is bypassed")
+	}
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(dir, 0o700) })
+
+	_, err := discovery.Lock(context.Background(), dir)
+	if err == nil {
+		t.Fatal("Lock should fail when stateDir is read-only")
+	}
+}
+
+func TestLockMkdirFailsWhenParentIsFile(t *testing.T) {
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	_, err := discovery.Lock(context.Background(), filepath.Join(blocker, "sub"))
+	if err == nil {
+		t.Fatal("Lock should fail when parent is a regular file")
+	}
+}
+
+func TestWriteFailsWhenStateDirIsFile(t *testing.T) {
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatalf("write blocker: %v", err)
+	}
+	// stateDir = blocker, which is a regular file — MkdirAll should fail.
+	err := discovery.Write(blocker, discovery.Info{URL: "u", PID: 1, Version: "v", StartedAt: time.Now()})
+	if err == nil {
+		t.Fatal("Write should fail when stateDir is a regular file")
+	}
+}
+


### PR DESCRIPTION
## Summary

Step 2 of #454. Adds `internal/daemon/discovery/` — the on-disk advertisement layer the daemon writes after binding its TCP listener and the flock-based singleton clients use to race for first-spawn rights.

Surface:

- `Info{URL, PID, Version, StartedAt}` ↔ `<stateDir>/daemon.json` (mode `0600`).
- Sidecar `<stateDir>/daemon.pid` so shell tooling (`kill $(cat ~/.aileron/daemon.pid)`) and `aileron stop` can find the process by PID without parsing JSON.
- `Read` returns `ErrNotRunning` (also wrapping `os.ErrNotExist`) when daemon.json is absent; clients use this as the "no daemon yet, time to spawn" signal.
- `Write` atomically replaces both files via temp + rename. Each rename is atomic on POSIX; the pair is not — daemon.json is authoritative.
- `Remove` is idempotent and leaves the lock file in place (removing it could race with a concurrent acquire).
- `Lock(ctx, stateDir)` takes a blocking exclusive `flock(2)` on `<stateDir>/daemon.lock`, with context cancellation via short-poll. Returns a release function the caller invokes (typically via defer).

`stateDir` is a parameter (not hardcoded to `~/.aileron/`) so tests use `t.TempDir()` and the caller resolves the user's state directory. The package creates `stateDir` at mode `0700` if it does not exist.

No callers wire this in yet. The daemon main loop (#454 step 3) and the client auto-spawn helper (#454 step 6) consume it in follow-on PRs.

## Test plan

- [x] `go test ./internal/daemon/... -race` is green.
- [x] `go vet ./internal/daemon/...` is clean.
- [x] Coverage on `internal/daemon/discovery` is 81.2% (over the 80% project threshold).
- [x] Tests cover: round-trip Write/Read, JSON shape exactness (`url`/`pid`/`version`/`started_at` snake_case), file mode `0o600`, missing-file → `ErrNotRunning` + `os.ErrNotExist`, malformed JSON failure, Remove idempotence, parent-as-file failure, read-only-stateDir failure paths for both Write and Lock.
- [x] Lock tests cover: exclusivity (second acquire times out), release-then-reacquire, contention serialization across 8 goroutines (max-concurrent-holders == 1), context cancellation before acquire, mkdir-on-acquire when stateDir doesn't exist.

## Notes

- Used `syscall.Flock` (stdlib, unix-only) over `golang.org/x/sys/unix` since the daemon is unix-only per ADR-0012 (Windows daemon support is deferred). No new dep.
- `Lock` polls every 25ms when contended rather than calling blocking `flock(...)` in a goroutine, so context cancellation is responsive without leaking a stuck syscall.

🤖 Generated with [Claude Code](https://claude.com/claude-code)