### PR TITLE
feat(approval): emit audit events for action-approval lifecycle (#390)

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -390,6 +390,12 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 		server.actionApprovals = approval.NewActionApprovalQueue(nil, nil)
 	}
 	server.actionApprovalTTL = 5 * time.Minute
+	// Wire the audit recorder so approval.requested / approval.approved
+	// / approval.denied land in the audit log. Before this, the
+	// approval flow left no audit trail — the user could grant or
+	// deny consequential actions and a later "what did I approve
+	// today?" lookup would come back empty.
+	server.actionApprovals.SetAuditRecorder(recorder)
 
 	// On Register, fire a notification so the user knows the agent is
 	// blocked. The notification's ReviewURL points at the webapp's

--- a/internal/approval/action_queue.go
+++ b/internal/approval/action_queue.go
@@ -7,6 +7,9 @@ import (
 	"errors"
 	"sync"
 	"time"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/model"
 )
 
 // ApprovalKind discriminates the user-facing card layout the webapp
@@ -238,6 +241,21 @@ type ActionApprovalQueue struct {
 	// drops events past the buffer rather than back-pressuring Register
 	// or Decide.
 	subscribers map[chan ActionApprovalEvent]struct{}
+
+	// auditRec records approval lifecycle events to the audit log:
+	// approval.requested on Register, approval.approved /
+	// approval.denied on Decide. Nil disables emission — the queue
+	// still works, the audit trail just doesn't reflect approval
+	// flow. Set via [SetAuditRecorder] from the wiring site so
+	// production callers get a durable record without changing the
+	// queue's constructor signature.
+	//
+	// Attribute keys are the OTel-namespaced shape locked-in by
+	// PR #452 (`aileron.connector.fqn`, `aileron.approval.*`,
+	// `aileron.session.id`); when issue #390's span emission lands,
+	// the spans wrap these same events with identical attribute
+	// keys — single source of truth.
+	auditRec audit.Recorder
 }
 
 // NewActionApprovalQueue returns an empty queue using the supplied
@@ -269,6 +287,21 @@ func (q *ActionApprovalQueue) SetOnRegister(fn func(*ActionApproval)) {
 	q.mu.Lock()
 	defer q.mu.Unlock()
 	q.onRegister = fn
+}
+
+// SetAuditRecorder installs the audit.Recorder the queue calls into
+// on Register / Decide. Pass nil to disable emission. Safe to call
+// concurrently with the queue's other methods; the swap is mutex-
+// protected.
+//
+// Production wiring sets this once at daemon startup to the same
+// recorder the connector-install / binding-lifecycle paths use, so
+// the approval flow appears in `~/.aileron/audit.jsonl` alongside
+// every other significant event.
+func (q *ActionApprovalQueue) SetAuditRecorder(rec audit.Recorder) {
+	q.mu.Lock()
+	defer q.mu.Unlock()
+	q.auditRec = rec
 }
 
 // Subscribe registers a streaming consumer of queue events and
@@ -364,6 +397,7 @@ func (q *ActionApprovalQueue) RegisterKind(kind ApprovalKind, actionName, connec
 	}
 	q.pending[a.ID] = a
 	cb := q.onRegister
+	rec := q.auditRec
 	q.mu.Unlock()
 	if cb != nil {
 		// Defer the panic recover so a misbehaving notifier never
@@ -374,6 +408,7 @@ func (q *ActionApprovalQueue) RegisterKind(kind ApprovalKind, actionName, connec
 			cb(a)
 		}()
 	}
+	q.recordRequested(rec, a)
 	q.broadcast(ActionApprovalEvent{Type: ActionApprovalEventPending, Pending: a})
 	return a
 }
@@ -495,6 +530,7 @@ func (q *ActionApprovalQueue) Decide(id string, approved bool, reason string, ed
 	}
 	delete(q.pending, id)
 	kind := a.Kind
+	rec := q.auditRec
 	q.mu.Unlock()
 	decidedAt := q.now()
 	a.decision <- ActionDecision{
@@ -503,6 +539,7 @@ func (q *ActionApprovalQueue) Decide(id string, approved bool, reason string, ed
 		EditedPayload: editedPayload,
 		DecidedAt:     decidedAt,
 	}
+	q.recordDecided(rec, a, approved, reason, editedPayload != nil, decidedAt)
 	q.broadcast(ActionApprovalEvent{
 		Type: ActionApprovalEventResolved,
 		Resolved: &ResolvedActionApproval{
@@ -514,6 +551,72 @@ func (q *ActionApprovalQueue) Decide(id string, approved bool, reason string, ed
 		},
 	})
 	return nil
+}
+
+// recordRequested emits an approval.requested audit event. Best-
+// effort: a nil recorder is a no-op; the recorder itself swallows
+// store errors per ADR-0010 (audit must not block the runtime).
+//
+// Actor is the agent — the agent's tool call is what triggered the
+// gate, even though the runtime is the caller doing the registration.
+// Attributes use the OTel-namespaced shape locked-in by PR #452.
+func (q *ActionApprovalQueue) recordRequested(rec audit.Recorder, a *ActionApproval) {
+	if rec == nil {
+		return
+	}
+	payload := map[string]any{
+		"aileron.approval.id":     a.ID,
+		"aileron.approval.kind":   string(a.Kind),
+		"aileron.approval.action": a.ActionName,
+	}
+	if a.ConnectorFQN != "" {
+		payload["aileron.connector.fqn"] = a.ConnectorFQN
+	}
+	if a.SessionID != "" {
+		payload["aileron.session.id"] = a.SessionID
+	}
+	rec.RecordSuccess(context.Background(),
+		model.EventTypeApprovalRequested,
+		model.ActorRef{Type: model.ActorTypeAgent, ID: "agent"},
+		payload)
+}
+
+// recordDecided emits approval.approved or approval.denied. Carries
+// the same approval.id as the requested event so the two are
+// trivially correlated by audit consumers. wait_ms is the time
+// between Register and Decide — a useful production signal (slow
+// human responses block the agent).
+func (q *ActionApprovalQueue) recordDecided(rec audit.Recorder, a *ActionApproval, approved bool, reason string, edited bool, decidedAt time.Time) {
+	if rec == nil {
+		return
+	}
+	decision := "denied"
+	evt := model.EventTypeApprovalDenied
+	if approved {
+		decision = "approved"
+		evt = model.EventTypeApprovalApproved
+	}
+	payload := map[string]any{
+		"aileron.approval.id":       a.ID,
+		"aileron.approval.kind":     string(a.Kind),
+		"aileron.approval.action":   a.ActionName,
+		"aileron.approval.decision": decision,
+		"aileron.approval.edited":   edited,
+		"aileron.approval.wait_ms":  decidedAt.Sub(a.RequestedAt).Milliseconds(),
+	}
+	if a.ConnectorFQN != "" {
+		payload["aileron.connector.fqn"] = a.ConnectorFQN
+	}
+	if a.SessionID != "" {
+		payload["aileron.session.id"] = a.SessionID
+	}
+	if reason != "" {
+		payload["aileron.approval.reason"] = reason
+	}
+	rec.RecordSuccess(context.Background(),
+		evt,
+		model.ActorRef{Type: model.ActorTypeHuman, ID: "user"},
+		payload)
 }
 
 // defaultActionApprovalID returns an opaque identifier suitable for

--- a/internal/approval/action_queue_audit_test.go
+++ b/internal/approval/action_queue_audit_test.go
@@ -1,0 +1,228 @@
+package approval
+
+import (
+	"context"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/model"
+)
+
+// Audit-emission contract for the queue:
+//   - Register fires an approval.requested event with the OTel-shaped
+//     attribute keys (`aileron.approval.id`, `aileron.approval.kind`,
+//     `aileron.approval.action`, plus connector / session when present).
+//     Actor is the agent — the agent is what triggered the gate.
+//   - Decide(approved=true) fires approval.approved; Decide(approved=false)
+//     fires approval.denied. The approval.id matches the requested event
+//     so consumers can correlate the two; wait_ms reflects request → decide.
+//     Actor is the human user who decided.
+//   - When EditedPayload is non-nil on Decide, the resolved event carries
+//     `aileron.approval.edited = true`.
+//   - SetAuditRecorder(nil) disables emission without breaking the queue.
+
+func newRecorderWithStore(t *testing.T) (audit.Recorder, *audit.MemStore) {
+	t.Helper()
+	store := audit.NewMemStore()
+	rec := audit.NewRecorder(store, nil, nil)
+	return rec, store
+}
+
+func eventByType(events []audit.Event, evt model.EventType) (audit.Event, bool) {
+	for _, e := range events {
+		if e.EventType == evt {
+			return e, true
+		}
+	}
+	return audit.Event{}, false
+}
+
+func TestActionApprovalQueue_RegisterEmitsApprovalRequested(t *testing.T) {
+	rec, store := newRecorderWithStore(t)
+	q := NewActionApprovalQueue(nil, nil)
+	q.SetAuditRecorder(rec)
+
+	a := q.Register("send-email", "github://x/aileron-connector-google", "sess-42", map[string]any{"to": "alice"})
+
+	events, err := store.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	got, ok := eventByType(events, model.EventTypeApprovalRequested)
+	if !ok {
+		t.Fatalf("expected approval.requested event; got %d events", len(events))
+	}
+	if got.Actor.Type != model.ActorTypeAgent {
+		t.Errorf("Actor.Type = %q, want %q", got.Actor.Type, model.ActorTypeAgent)
+	}
+	if got.Payload["aileron.approval.id"] != a.ID {
+		t.Errorf("aileron.approval.id = %v, want %q", got.Payload["aileron.approval.id"], a.ID)
+	}
+	if got.Payload["aileron.approval.action"] != "send-email" {
+		t.Errorf("aileron.approval.action = %v, want send-email", got.Payload["aileron.approval.action"])
+	}
+	if got.Payload["aileron.approval.kind"] != string(ApprovalKindAction) {
+		t.Errorf("aileron.approval.kind = %v, want %q", got.Payload["aileron.approval.kind"], ApprovalKindAction)
+	}
+	if got.Payload["aileron.connector.fqn"] != "github://x/aileron-connector-google" {
+		t.Errorf("aileron.connector.fqn = %v", got.Payload["aileron.connector.fqn"])
+	}
+	if got.Payload["aileron.session.id"] != "sess-42" {
+		t.Errorf("aileron.session.id = %v, want sess-42", got.Payload["aileron.session.id"])
+	}
+}
+
+func TestActionApprovalQueue_RegisterOmitsAbsentOptionalAttrs(t *testing.T) {
+	// When ConnectorFQN / SessionID are empty, the corresponding
+	// attribute keys must not appear — empty strings on a span /
+	// audit event are noise that downstream tooling has to filter out.
+	rec, store := newRecorderWithStore(t)
+	q := NewActionApprovalQueue(nil, nil)
+	q.SetAuditRecorder(rec)
+
+	q.Register("send-email", "", "", nil)
+
+	events, _ := store.ListEvents(context.Background(), audit.EventFilter{})
+	got, ok := eventByType(events, model.EventTypeApprovalRequested)
+	if !ok {
+		t.Fatal("expected approval.requested event")
+	}
+	if _, present := got.Payload["aileron.connector.fqn"]; present {
+		t.Errorf("aileron.connector.fqn should be absent when empty; got %v", got.Payload["aileron.connector.fqn"])
+	}
+	if _, present := got.Payload["aileron.session.id"]; present {
+		t.Errorf("aileron.session.id should be absent when empty; got %v", got.Payload["aileron.session.id"])
+	}
+}
+
+func TestActionApprovalQueue_ApproveEmitsApprovalApproved(t *testing.T) {
+	rec, store := newRecorderWithStore(t)
+	q := NewActionApprovalQueue(nil, nil)
+	q.SetAuditRecorder(rec)
+
+	a := q.Register("send-email", "github://x/y", "sess-1", nil)
+	if err := q.Decide(a.ID, true, "", nil); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	events, _ := store.ListEvents(context.Background(), audit.EventFilter{})
+	got, ok := eventByType(events, model.EventTypeApprovalApproved)
+	if !ok {
+		t.Fatalf("expected approval.approved event; events=%d", len(events))
+	}
+	if got.Actor.Type != model.ActorTypeHuman {
+		t.Errorf("Actor.Type = %q, want %q", got.Actor.Type, model.ActorTypeHuman)
+	}
+	if got.Payload["aileron.approval.id"] != a.ID {
+		t.Errorf("aileron.approval.id = %v, want %q (must match the requested event)", got.Payload["aileron.approval.id"], a.ID)
+	}
+	if got.Payload["aileron.approval.decision"] != "approved" {
+		t.Errorf("aileron.approval.decision = %v, want approved", got.Payload["aileron.approval.decision"])
+	}
+	if got.Payload["aileron.approval.edited"] != false {
+		t.Errorf("aileron.approval.edited = %v, want false", got.Payload["aileron.approval.edited"])
+	}
+}
+
+func TestActionApprovalQueue_DenyEmitsApprovalDenied(t *testing.T) {
+	rec, store := newRecorderWithStore(t)
+	q := NewActionApprovalQueue(nil, nil)
+	q.SetAuditRecorder(rec)
+
+	a := q.Register("send-email", "github://x/y", "", nil)
+	if err := q.Decide(a.ID, false, "wrong recipient", nil); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	events, _ := store.ListEvents(context.Background(), audit.EventFilter{})
+	got, ok := eventByType(events, model.EventTypeApprovalDenied)
+	if !ok {
+		t.Fatal("expected approval.denied event")
+	}
+	if got.Payload["aileron.approval.decision"] != "denied" {
+		t.Errorf("aileron.approval.decision = %v, want denied", got.Payload["aileron.approval.decision"])
+	}
+	if got.Payload["aileron.approval.reason"] != "wrong recipient" {
+		t.Errorf("aileron.approval.reason = %v, want %q", got.Payload["aileron.approval.reason"], "wrong recipient")
+	}
+}
+
+func TestActionApprovalQueue_EditedDecisionFlagsEdited(t *testing.T) {
+	rec, store := newRecorderWithStore(t)
+	q := NewActionApprovalQueue(nil, nil)
+	q.SetAuditRecorder(rec)
+
+	a := q.RegisterCommsDraft("slack", "C123", "alice", "ping?", "pong", "ts-1", "")
+	if err := q.Decide(a.ID, true, "", map[string]any{"body": "pong (edited)"}); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	events, _ := store.ListEvents(context.Background(), audit.EventFilter{})
+	got, ok := eventByType(events, model.EventTypeApprovalApproved)
+	if !ok {
+		t.Fatal("expected approval.approved event")
+	}
+	if got.Payload["aileron.approval.edited"] != true {
+		t.Errorf("aileron.approval.edited = %v, want true", got.Payload["aileron.approval.edited"])
+	}
+	if got.Payload["aileron.approval.kind"] != string(ApprovalKindCommsDraft) {
+		t.Errorf("aileron.approval.kind = %v, want %q", got.Payload["aileron.approval.kind"], ApprovalKindCommsDraft)
+	}
+}
+
+func TestActionApprovalQueue_WaitMsReflectsRegisterToDecide(t *testing.T) {
+	// Inject a clock that advances by a known delta between register
+	// and decide so we can assert wait_ms is computed from those
+	// timestamps, not from wall time.
+	t0 := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	calls := 0
+	now := func() time.Time {
+		// First call: register. Second call: decide, 250ms later.
+		t := t0
+		if calls > 0 {
+			t = t0.Add(250 * time.Millisecond)
+		}
+		calls++
+		return t
+	}
+	rec, store := newRecorderWithStore(t)
+	q := NewActionApprovalQueue(nil, now)
+	q.SetAuditRecorder(rec)
+
+	a := q.Register("send-email", "", "", nil)
+	if err := q.Decide(a.ID, true, "", nil); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+
+	events, _ := store.ListEvents(context.Background(), audit.EventFilter{})
+	got, ok := eventByType(events, model.EventTypeApprovalApproved)
+	if !ok {
+		t.Fatal("expected approval.approved event")
+	}
+	if got.Payload["aileron.approval.wait_ms"] != int64(250) {
+		t.Errorf("aileron.approval.wait_ms = %v, want 250", got.Payload["aileron.approval.wait_ms"])
+	}
+}
+
+func TestActionApprovalQueue_NilRecorderEmitsNothing(t *testing.T) {
+	// SetAuditRecorder(nil) should not break the queue's invariants.
+	// The decide path must still unblock waiters and broadcast the
+	// resolved event to subscribers.
+	q := NewActionApprovalQueue(nil, nil)
+	q.SetAuditRecorder(nil) // explicit no-op
+
+	a := q.Register("send-email", "", "", nil)
+	if err := q.Decide(a.ID, true, "", nil); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+}
+
+func TestActionApprovalQueue_NoRecorderConfiguredEmitsNothing(t *testing.T) {
+	// Default state — recorder never set. Same expectation as above.
+	q := NewActionApprovalQueue(nil, nil)
+	a := q.Register("send-email", "", "", nil)
+	if err := q.Decide(a.ID, true, "", nil); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fills a real gap in the audit log: the action-approval flow currently emits **zero** audit events. A user grants or denies consequential actions and a later "what did the agent ask me about today?" lookup comes back empty. This wires `audit.Recorder` through the `ActionApprovalQueue` so the three lifecycle events (`approval.requested`, `approval.approved`, `approval.denied`) land in `~/.aileron/audit.jsonl` alongside every other significant event.

Slice of #390 — independent of the OTel emission integrations (no rotation dependency). Attribute keys follow the OTel-namespaced shape locked-in by PR #452, so when span emission lands the spans wrap these same events with identical attribute keys — single source of truth.

### What's emitted

- **`approval.requested`** — fires from `RegisterKind`. Actor: agent. Attributes: `aileron.approval.{id,kind,action}`, plus `aileron.connector.fqn` / `aileron.session.id` when present.
- **`approval.approved`** / **`approval.denied`** — fire from `Decide`. Actor: human user. Same `aileron.approval.id` as the requested event so consumers can pair the two trivially. Attributes: `aileron.approval.{decision,edited,wait_ms}` plus `aileron.approval.reason` on denials.

### Wiring

- New `SetAuditRecorder(rec)` on `ActionApprovalQueue` (mirrors the existing `SetOnRegister` pattern — backward-compatible, additive).
- Wired once at daemon startup in `NewHandlerWithConfig` to the same recorder the connector-install / binding-lifecycle paths use.
- Queues without a recorder configured continue working as before; emission is purely additive.

### Out of scope (deliberately)

- `approval.expired` — would require queue-side timeout detection (today the entry stays "pending" forever after `Wait` times out). Separate change.
- Span emission around the approval flow — comes with the rest of #390 Phase 7 once the rotating writer for the file exporter lands.

## Test plan

- [x] `go test ./internal/approval/...` — 12 tests, all pass; coverage 93.7%
- [x] `go test ./internal/app/...` — full app suite green (no regression in handler wiring)
- [x] `go test ./...` — full internal-module sweep green
- [x] Behavioural tests (register-decide-unblocks-waiter, deny-carries-reason, etc.) unchanged — emission is purely additive
- [x] Specific assertions: actor types (agent for requested, human for decided), attribute keys present/absent, `wait_ms` reflects `RequestedAt → DecidedAt`, `edited=true` when `EditedPayload` non-nil

🤖 Generated with [Claude Code](https://claude.com/claude-code)
