### PR TITLE
feat(action): emit aileron.action.execute + aileron.connector.call spans (#390)

### DIFF
--- a/docs/src/content/docs/concepts/observability.md
+++ b/docs/src/content/docs/concepts/observability.md
@@ -1,0 +1,101 @@
+---
+title: "Observability"
+description: "Aileron records every consequential decision in a local audit log and emits OpenTelemetry-compatible traces for action execution. This page covers what's emitted, how to enable trace export, and the env vars that control both surfaces."
+order: 6
+---
+
+Aileron emits two complementary surfaces of structured data: an **audit log** that's always on, and **OpenTelemetry traces** that are off by default and opt-in. They share attribute keys 1:1, so a span and an audit event for the same operation carry identical names — your trace tooling and your audit reader read the same vocabulary.
+
+The audit log is the *receipt*: durable, local, append-only JSONL on disk that answers "what did the agent do, with what authority, against which service?" The traces are the *flight recorder*: a per-request tree of timed spans that answers "where did latency go, where did errors originate, and how do these calls correlate with the rest of the agent stack?"
+
+If you only want a quick reference for env vars, jump to [Configuration](#configuration).
+
+## The audit log (always on)
+
+Every load-bearing decision in the runtime emits a structured audit record. This is not incidental logging — it's the contract that [Proof of Control](/concepts/proof-of-control/) builds on. The record lives at `~/.aileron/audit.jsonl` (one event per line) and is queryable through the CLI:
+
+```sh
+aileron audit list             # newest events first
+aileron audit get <audit-id>   # full event by id
+```
+
+Today, four families of events land in the log:
+
+- **Install consent** — every connector and action install records artifact FQN, version, hash, signature status, and the user's decision ([ADR-0007](/adr/0007-install-consent)).
+- **Action execution** — every invocation records which connector it called, which capability it exercised, and which binding identity satisfied it ([ADR-0003](/adr/0003-action-model), [ADR-0011](/adr/0011-local-credential-vault)). Credential bytes are never recorded.
+- **Failure** — every failure surfaces with a stable `class`, `boundary`, retry, and `audit_id` ([ADR-0010](/adr/0010-failure-handling)). The same `audit_id` is stamped onto the agent-visible tool-result envelope, so the LLM's "what went wrong?" reaction can be traced back to a specific event.
+- **Approval lifecycle** — `approval.requested`, `approval.approved`, `approval.denied`. Each carries the same `aileron.approval.id` so a request and its decision are trivially correlated.
+
+The schema is durable: every payload field uses the OpenTelemetry-namespaced key shape (`aileron.connector.fqn`, `aileron.binding.name`, `aileron.failure.class`, etc.) so consumers — log shippers, trace tools, custom queries — read the same vocabulary regardless of which surface they came in through.
+
+## OpenTelemetry traces (opt-in)
+
+When tracing is enabled, Aileron starts a server-root span on every request and child spans for the work inside. Spans propagate via [W3C TraceContext](https://www.w3.org/TR/trace-context/), so an inbound `traceparent` header from the calling agent makes Aileron's spans children of the agent's trace — your end-to-end view stays coherent.
+
+To turn it on for local development:
+
+```sh
+AILERON_OTEL_ENABLED=true \
+AILERON_OTEL_EXPORTER=stdout \
+aileron launch claude
+```
+
+Spans land on stderr as JSON-per-line. Pipe to `jq` to navigate them. With tracing off (the default), there's zero SDK overhead — the call sites resolve to no-op tracers.
+
+Tracing is independent of the audit log. The audit log answers *what was done*; the traces answer *how it ran*. Both are useful; neither replaces the other.
+
+### What gets emitted
+
+Today (as the Phase 7 emission integrations land slice by slice in [issue #390](https://github.com/ALRubinger/aileron/issues/390)):
+
+| Span name | Where it's emitted | Status |
+|---|---|---|
+| `aileron.action.execute` | `SandboxExecutor.Execute` — root for an action invocation | ✅ shipped |
+| `aileron.connector.call` | per-step `conn.Invoke` inside the executor | ✅ shipped |
+| HTTP server-root span | gateway and `/v1/actions/{name}/run` entry points | ✅ shipped (#457) |
+| `aileron.capability.check` | the action-boundary capability enforcement | ⏳ pending |
+| `aileron.approval.wait` | the approval-queue blocking wait | ⏳ pending |
+| `aileron.mcp.tool.call` | `aileron-mcp` outbound to `/v1/actions/{name}/run` | ⏳ pending |
+| `aileron.gateway.openai.chat` / `aileron.gateway.anthropic.messages` | LLM round-trip on the gateway | ⏳ pending |
+
+The file exporter (writing spans to `~/.aileron/traces/spans.jsonl` with date-based rotation) is also pending — it's gated on the parallel audit-log file rotation work so spans and audit events share a rotating writer with the same retention story.
+
+### Span attribute schema
+
+Every span carries the OTel-namespaced shape locked-in for the audit payload (PR #452). When you query traces by attribute, you query the same names you'd query the audit log by:
+
+| Attribute | On | Description |
+|---|---|---|
+| `aileron.action.name` | `aileron.action.execute` | The action manifest name being invoked |
+| `aileron.action.steps_count` | `aileron.action.execute` | Number of `[[execute]]` steps in the action |
+| `aileron.connector.fqn` | `aileron.connector.call` | Fully-qualified connector identifier (e.g. `github://ALRubinger/aileron-connector-google`) |
+| `aileron.connector.op` | `aileron.connector.call` | The connector operation name (e.g. `list_recent_emails`) |
+| `aileron.connector.hash` | `aileron.connector.call` | The content-addressed hash of the connector binary |
+| `aileron.failure.class` | error spans | Failure taxonomy class (`capability_denied`, `binding_required`, etc.) per [ADR-0010](/adr/0010-failure-handling) |
+| `aileron.failure.boundary` | error spans | Where the failure was detected (`action`, `sandbox`, `runtime`) |
+| `aileron.failure.retriable` | error spans | Whether the agent should retry |
+
+When a span fails, the OTel span status is also set to `Error` with the failure message — your tracing UI's red flags work without parsing attributes.
+
+## Configuration
+
+All knobs are environment variables read at daemon startup. Defaults reproduce the historic behavior — tracing off, audit on.
+
+| Env var | Default | Effect |
+|---|---|---|
+| `AILERON_OTEL_ENABLED` | `false` | Master switch for trace emission. When `false`, the SDK is never constructed; the call sites resolve to no-op. The W3C TraceContext propagator is registered regardless, so an inbound `traceparent` is parsed and propagated even without local emission. |
+| `AILERON_OTEL_SERVICE_NAME` | `aileron` | The OTel resource attribute `service.name` reported on every span. Set it to disambiguate Aileron from other services in your trace tooling. |
+| `AILERON_OTEL_EXPORTER` | `noop` | Exporter selection. `noop` drops spans (the default — same as `AILERON_OTEL_ENABLED=false`). `stdout` writes JSON-per-line to stderr for local development. The file exporter is pending. |
+| `AILERON_AUDIT_PATH` | `~/.aileron/audit.jsonl` | Override the audit log location. The default suits the personal-use case; environments with stricter filesystem layouts can point this elsewhere. |
+
+A misconfigured exporter — unknown name, or a known exporter whose construction fails — degrades gracefully to no-op rather than failing daemon startup. The Aileron HTTP server keeps serving when its telemetry sidecar is misconfigured; the failure is logged at warn level so you find it without it taking the daemon down.
+
+## Why both audit and traces
+
+It's a fair question: if attribute keys are identical, why ship two surfaces?
+
+The audit log is **structurally durable**: it's append-only on local disk, with no opt-in toggle, no exporter to misconfigure, and no in-memory batch processor that can drop events on shutdown. It's the *receipt* you can hand a compliance reviewer — and it's the substrate signed audit logs (a [Stage 1.5](/concepts/proof-of-control/) post-MVP item) will eventually live on.
+
+The OpenTelemetry surface is **structurally portable**: spans plug into existing observability infrastructure (Grafana, Datadog, OTLP collectors, etc.) without bespoke integration. When Aileron sits inside an otherwise instrumented agent stack, the trace tree connects across every hop your agent already exports.
+
+Both surfaces share keys precisely because the same operation should look the same regardless of where you read it from. When `aileron.connector.fqn` shows up in your trace tool, it shows up in `aileron audit list` filtered by the same name.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -186,6 +186,8 @@ aileron audit list           # action-execution audit log: every call, with inpu
 
 The audit log is the receipt for everything the agent did on your behalf. Each entry names the action, the connector version, the binding identity, the duration, and the disposition. Combined with the install consent log, you can answer two questions for any action: "did I authorize this capability?" and "what did the agent actually do with it?"
 
+For end-to-end timing or correlation with the rest of your agent stack, Aileron also emits OpenTelemetry traces — opt-in via `AILERON_OTEL_ENABLED=true AILERON_OTEL_EXPORTER=stdout`. See [Observability](/concepts/observability/) for what gets emitted, the span attribute schema, and the env vars that control both the audit and tracing surfaces.
+
 ## What you've built
 
 You ran a real LLM through a local proxy that augmented its tool catalog with installed actions, executed those actions inside a WASM sandbox, mediated OAuth tokens at the network boundary so the LLM never held a credential, and recorded every decision and execution in an audit log.

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -186,7 +186,7 @@ aileron audit list           # action-execution audit log: every call, with inpu
 
 The audit log is the receipt for everything the agent did on your behalf. Each entry names the action, the connector version, the binding identity, the duration, and the disposition. Combined with the install consent log, you can answer two questions for any action: "did I authorize this capability?" and "what did the agent actually do with it?"
 
-For end-to-end timing or correlation with the rest of your agent stack, Aileron also emits OpenTelemetry traces — opt-in via `AILERON_OTEL_ENABLED=true AILERON_OTEL_EXPORTER=stdout`. See [Observability](/concepts/observability/) for what gets emitted, the span attribute schema, and the env vars that control both the audit and tracing surfaces.
+For end-to-end timing or correlation with the rest of your agent stack, Aileron also emits OpenTelemetry traces — opt-in via `AILERON_OTEL_ENABLED=true AILERON_OTEL_EXPORTER=stdout`. See [Observability](/guides/observability/) for what gets emitted, the span attribute schema, and the env vars that control both the audit and tracing surfaces.
 
 ## What you've built
 

--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -29,6 +29,20 @@ The schema is durable: every payload field uses the OpenTelemetry-namespaced key
 
 ## OpenTelemetry traces (opt-in)
 
+### What this gives you
+
+[OpenTelemetry](https://opentelemetry.io/) (OTel) is the vendor-neutral industry standard for distributed tracing, metrics, and logs — the substrate Grafana, Datadog, Jaeger, Honeycomb, and most modern observability tools agree on. A *trace* is a tree of *spans*; each span is a timed unit of work with a name, attributes (key/value tags), a status, and a parent. The [W3C TraceContext](https://www.w3.org/TR/trace-context/) spec defines a `traceparent` HTTP header that carries the trace ID and parent span ID across service boundaries so a multi-service request stays connected end-to-end, regardless of which language or framework each service is written in.
+
+Aileron's role here is thin and consistent: when the agent calls Aileron, Aileron starts spans for the work it does (action execution, connector calls, capability checks, approval waits), parents them to the agent's incoming `traceparent` if one was passed, and emits them through a configurable exporter. The spans plug into your existing observability stack without bespoke integration — Aileron looks like any other instrumented service in the trace tree. If you don't have an observability practice yet, the **stdout exporter** described below works as a development aid: pipe the JSON-per-line output through `jq` to inspect what the runtime is doing.
+
+A few terms you'll see:
+
+- **Exporter** — the component that ships spans out of the process. Aileron currently supports `noop` (the default — drops spans, zero overhead) and `stdout` (writes JSON-per-line to stderr). A file exporter and an OTLP exporter are pending.
+- **OTLP** — the OpenTelemetry Protocol, the wire format collectors expect. When Aileron's OTLP exporter ships, you'll point it at an **OTel endpoint** — typically the URL of an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) deployed alongside your other services, which fans the spans out to whichever backend (Grafana, Datadog, etc.) you've configured.
+- **Span status** — `Ok` (default), `Error`, or `Unset`. Aileron sets `Error` on any span whose underlying operation failed, with the failure message as the status description.
+
+### Enabling tracing
+
 When tracing is enabled, Aileron starts a server-root span on every request and child spans for the work inside. Spans propagate via [W3C TraceContext](https://www.w3.org/TR/trace-context/), so an inbound `traceparent` header from the calling agent makes Aileron's spans children of the agent's trace — your end-to-end view stays coherent.
 
 To turn it on for local development:

--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -1,7 +1,6 @@
 ---
 title: "Observability"
 description: "Aileron records every consequential decision in a local audit log and emits OpenTelemetry-compatible traces for action execution. This page covers what's emitted, how to enable trace export, and the env vars that control both surfaces."
-order: 6
 ---
 
 Aileron emits two complementary surfaces of structured data: an **audit log** that's always on, and **OpenTelemetry traces** that are off by default and opt-in. They share attribute keys 1:1, so a span and an audit event for the same operation carry identical names — your trace tooling and your audit reader read the same vocabulary.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -52,7 +52,8 @@ export const navigation: NavItem[] = [
       { label: 'Actions', href: '/concepts/actions/' },
       { label: 'Connectors', href: '/concepts/connectors/' },
       { label: 'The Vault', href: '/concepts/the-vault/' },
-      { label: 'Proof of Control', href: '/concepts/proof-of-control/' }
+      { label: 'Proof of Control', href: '/concepts/proof-of-control/' },
+      { label: 'Observability', href: '/concepts/observability/' }
     ]
   },
   {

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -52,8 +52,7 @@ export const navigation: NavItem[] = [
       { label: 'Actions', href: '/concepts/actions/' },
       { label: 'Connectors', href: '/concepts/connectors/' },
       { label: 'The Vault', href: '/concepts/the-vault/' },
-      { label: 'Proof of Control', href: '/concepts/proof-of-control/' },
-      { label: 'Observability', href: '/concepts/observability/' }
+      { label: 'Proof of Control', href: '/concepts/proof-of-control/' }
     ]
   },
   {
@@ -61,7 +60,8 @@ export const navigation: NavItem[] = [
     children: [
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },
       { label: 'Authoring an Action', href: '/guides/authoring-an-action/' },
-      { label: 'Publishing a Connector', href: '/guides/publishing-a-connector/' }
+      { label: 'Publishing a Connector', href: '/guides/publishing-a-connector/' },
+      { label: 'Observability', href: '/guides/observability/' }
     ]
   },
   {

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -14,7 +14,18 @@ import (
 	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/failure"
 	"github.com/ALRubinger/aileron/internal/sandbox"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// tracerName names the OTel instrumentation library reported on
+// spans this package emits. Distinct from the resource service.name
+// (which identifies Aileron itself); per OTel conventions this names
+// the *instrumentation*, so traces carry a stable provenance for
+// the action-execution layer.
+const tracerName = "github.com/ALRubinger/aileron/internal/action"
 
 // Executor runs an installed action with the given call-time arguments
 // and returns a Result whose Content becomes the tool-result message
@@ -160,7 +171,20 @@ func (e *SandboxExecutor) Close(ctx context.Context) error {
 }
 
 // Execute implements [Executor].
-func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[string]any) (Result, error) {
+//
+// Emits an `aileron.action.execute` span around the full call and a
+// nested `aileron.connector.call` span around each step's
+// connector invocation. Span attributes use the OTel-namespaced shape
+// shared with the audit log (PR #452) so spans and audit events carry
+// identical keys — single source of truth.
+func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[string]any) (res Result, err error) {
+	tracer := otel.GetTracerProvider().Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "aileron.action.execute",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(attribute.String("aileron.action.name", name)),
+	)
+	defer func() { annotateActionSpan(span, res, err); span.End() }()
+
 	if e.Actions == nil || e.Store == nil || e.Runtime == nil {
 		return Result{}, fmt.Errorf("SandboxExecutor: Actions, Store, and Runtime are all required")
 	}
@@ -175,6 +199,7 @@ func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[str
 	if len(manifest.Execute) == 0 {
 		return Result{}, fmt.Errorf("action %q has no execute steps", name)
 	}
+	span.SetAttributes(attribute.Int("aileron.action.steps_count", len(manifest.Execute)))
 
 	// Build per-step output map keyed by step ID; later steps may
 	// reference prior outputs via interpolation. Interpolation itself
@@ -189,7 +214,7 @@ func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[str
 			return errorResult(capErr), nil
 		}
 
-		conn, connManifest, compileErr := e.connectorFor(ctx, manifest, step.Connector)
+		conn, connManifest, connHash, compileErr := e.connectorFor(ctx, manifest, step.Connector)
 		if compileErr != nil {
 			return errorResult(compileErr), nil
 		}
@@ -215,7 +240,7 @@ func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[str
 		resolver := e.resolverFor(ctx, connManifest, step.Connector)
 
 		allowed := allowedAuthorityFor(manifest, step.Connector)
-		res, invErr := conn.Invoke(ctx, sandbox.Call{
+		stepRes, invErr := e.invokeWithSpan(ctx, conn, step.Connector, step.Op, connHash, sandbox.Call{
 			Op:                 step.Op,
 			Args:               opArgs,
 			AllowedAuthority:   allowed,
@@ -224,13 +249,13 @@ func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[str
 		if invErr != nil {
 			return errorResult(invErr), nil
 		}
-		stepOutputs[step.ID] = res.Output
+		stepOutputs[step.ID] = stepRes.Output
 
 		// Last step's output is the action's output by convention.
 		if i == len(manifest.Execute)-1 {
 			body, mErr := json.Marshal(map[string]any{
 				"action": name,
-				"output": res.Output,
+				"output": stepRes.Output,
 				"steps":  stepOutputs,
 			})
 			if mErr != nil {
@@ -244,15 +269,69 @@ func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[str
 	return Result{}, nil
 }
 
-// connectorFor returns a compiled sandbox.Connector and the parsed
-// connector manifest for the connector FQN referenced by
-// `connectorFQN`. The connector is looked up in the action's
-// [[requires.connectors]] block (for hash + version), the matching
-// entry is fetched from the content-addressed store, and the binary
-// is compiled — cached by hash for subsequent calls. The connector
-// manifest is returned so the caller can read the connector's
-// declared `[capabilities.credential].kind` without re-parsing.
-func (e *SandboxExecutor) connectorFor(ctx context.Context, m *Manifest, connectorFQN string) (sandbox.Connector, *cstore.Manifest, error) {
+// invokeWithSpan wraps a single connector.Invoke call in an
+// `aileron.connector.call` span. Attributes follow the OTel-shaped
+// audit schema: aileron.connector.{fqn,op,hash}. Invoke errors mark
+// the span as Error; success leaves status Unset.
+func (e *SandboxExecutor) invokeWithSpan(ctx context.Context, conn sandbox.Connector, fqn, op, hash string, call sandbox.Call) (sandbox.Result, error) {
+	tracer := otel.GetTracerProvider().Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "aileron.connector.call",
+		trace.WithSpanKind(trace.SpanKindClient),
+		trace.WithAttributes(
+			attribute.String("aileron.connector.fqn", fqn),
+			attribute.String("aileron.connector.op", op),
+			attribute.String("aileron.connector.hash", hash),
+		),
+	)
+	defer span.End()
+	res, err := conn.Invoke(ctx, call)
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+	}
+	return res, err
+}
+
+// annotateActionSpan reflects the execute outcome onto the
+// aileron.action.execute span. Two failure modes per ADR-0010:
+//
+//   - Result.Failure non-nil: structured action-side failure
+//     (capability_denied, binding_required, etc.). The LLM sees
+//     these as tool results and can decide how to proceed; the span
+//     is still marked Error because the action's operation did fail
+//     in the OTel sense, with the failure attributes attached for
+//     filtering.
+//   - err non-nil: gateway-fatal Go error (executor misconfigured,
+//     action not found). Span Error with the err's message.
+func annotateActionSpan(span trace.Span, res Result, err error) {
+	if !span.IsRecording() {
+		return
+	}
+	if err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return
+	}
+	if res.Failure != nil {
+		span.SetStatus(codes.Error, res.Failure.Message())
+		span.SetAttributes(
+			attribute.String("aileron.failure.class", string(res.Failure.Class())),
+			attribute.String("aileron.failure.boundary", string(res.Failure.Boundary())),
+			attribute.Bool("aileron.failure.retriable", res.Failure.Retriable()),
+		)
+	}
+}
+
+// connectorFor returns a compiled sandbox.Connector, the parsed
+// connector manifest, and the resolved content hash for the
+// connector FQN referenced by `connectorFQN`. The connector is
+// looked up in the action's [[requires.connectors]] block (for hash
+// + version), the matching entry is fetched from the content-
+// addressed store, and the binary is compiled — cached by hash for
+// subsequent calls. The connector manifest is returned so the
+// caller can read the connector's declared
+// `[capabilities.credential].kind` without re-parsing; the hash is
+// returned so observability spans can attach `aileron.connector.hash`
+// without re-walking the manifest.
+func (e *SandboxExecutor) connectorFor(ctx context.Context, m *Manifest, connectorFQN string) (sandbox.Connector, *cstore.Manifest, string, error) {
 	// Find the [[requires.connectors]] entry that matches this FQN.
 	var dep *RequiresConnector
 	for i := range m.Requires.Connectors {
@@ -262,27 +341,27 @@ func (e *SandboxExecutor) connectorFor(ctx context.Context, m *Manifest, connect
 		}
 	}
 	if dep == nil {
-		return nil, nil, fmt.Errorf("action does not declare connector %q in [[requires.connectors]]", connectorFQN)
+		return nil, nil, "", fmt.Errorf("action does not declare connector %q in [[requires.connectors]]", connectorFQN)
 	}
 
 	e.mu.Lock()
 	if cached, ok := e.cache[dep.Hash]; ok {
 		e.mu.Unlock()
-		return cached.conn, cached.manifest, nil
+		return cached.conn, cached.manifest, dep.Hash, nil
 	}
 	e.mu.Unlock()
 
 	entryDir, err := e.Store.EntryDir(dep.Hash)
 	if err != nil {
-		return nil, nil, fmt.Errorf("connector %s: %w", connectorFQN, err)
+		return nil, nil, "", fmt.Errorf("connector %s: %w", connectorFQN, err)
 	}
 	manifestBytes, err := os.ReadFile(filepath.Join(entryDir, "manifest.toml"))
 	if err != nil {
-		return nil, nil, fmt.Errorf("read connector manifest: %w", err)
+		return nil, nil, "", fmt.Errorf("read connector manifest: %w", err)
 	}
 	cmf, err := cstore.ParseManifest(filepath.Join(entryDir, "manifest.toml"), manifestBytes)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	binPath := filepath.Join(entryDir, "connector.wasm")
 	if _, statErr := os.Stat(binPath); errors.Is(statErr, os.ErrNotExist) {
@@ -290,16 +369,16 @@ func (e *SandboxExecutor) connectorFor(ctx context.Context, m *Manifest, connect
 	}
 	binBytes, err := os.ReadFile(binPath)
 	if err != nil {
-		return nil, nil, fmt.Errorf("read connector binary: %w", err)
+		return nil, nil, "", fmt.Errorf("read connector binary: %w", err)
 	}
 	conn, err := e.Runtime.Compile(ctx, cmf, binBytes)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, "", err
 	}
 	e.mu.Lock()
 	e.cache[dep.Hash] = cachedConnector{conn: conn, manifest: cmf}
 	e.mu.Unlock()
-	return conn, cmf, nil
+	return conn, cmf, dep.Hash, nil
 }
 
 // resolverFor returns the credential.Resolver for the named connector,

--- a/internal/action/executor_span_test.go
+++ b/internal/action/executor_span_test.go
@@ -1,0 +1,261 @@
+package action
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+	"github.com/ALRubinger/aileron/internal/sandbox"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+	"go.opentelemetry.io/otel/trace/noop"
+)
+
+// Span emission contract for SandboxExecutor.Execute:
+//
+//   - aileron.action.execute span wraps the full call. Carries
+//     aileron.action.name and aileron.action.steps_count. On failure
+//     (Result.Failure non-nil OR returned err non-nil) the span
+//     status is Error and the OTel-shaped failure attributes are
+//     attached when there's a structured failure.
+//
+//   - aileron.connector.call span wraps each step's conn.Invoke.
+//     Child of action.execute. Carries aileron.connector.{fqn,op,hash}.
+//     Invoke errors mark the span Error.
+//
+//   - Capability denial short-circuits before the connector.call —
+//     the connector.call span is never started for denied steps.
+//
+// The audit-shape attribute keys here match PR #452's payload schema
+// 1:1 — span attributes and audit payload share a single source of
+// truth.
+
+// withInMemoryExporter installs a sync-flushed tracer provider whose
+// exported spans land in an in-memory collector. Returns the
+// collector and restores the previous global on cleanup.
+func withInMemoryExporter(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+	return exp
+}
+
+func findSpan(spans []sdktrace.ReadOnlySpan, name string) (sdktrace.ReadOnlySpan, bool) {
+	for _, s := range spans {
+		if s.Name() == name {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+func attr(s sdktrace.ReadOnlySpan, key string) (any, bool) {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsInterface(), true
+		}
+	}
+	return nil, false
+}
+
+func TestSandboxExecutor_Execute_EmitsActionAndConnectorSpans(t *testing.T) {
+	exp := withInMemoryExporter(t)
+
+	cstoreDir := t.TempDir()
+	store := cstore.NewStore(cstoreDir)
+	hash := installFakeConnector(t, store, "github://test/echo", "1.0.0")
+	actions := installFakeAction(t, "github://test/echo", "1.0.0", hash, []string{"echo"}, []string{"echo"})
+
+	rt := &fakeRuntime{}
+	rt.connectors = map[string]*fakeConnector{"github://test/echo": {resp: map[string]any{"value": "hi"}}}
+
+	exec := NewSandboxExecutor(actions, store, rt, nil)
+	t.Cleanup(func() { _ = exec.Close(context.Background()) })
+
+	if _, err := exec.Execute(context.Background(), "test-action", map[string]any{"value": "hi"}); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	actSpan, ok := findSpan(spans, "aileron.action.execute")
+	if !ok {
+		t.Fatalf("aileron.action.execute span not emitted; got %d spans", len(spans))
+	}
+	if v, _ := attr(actSpan, "aileron.action.name"); v != "test-action" {
+		t.Errorf("aileron.action.name = %v, want test-action", v)
+	}
+	if v, _ := attr(actSpan, "aileron.action.steps_count"); v != int64(1) {
+		t.Errorf("aileron.action.steps_count = %v, want 1", v)
+	}
+
+	connSpan, ok := findSpan(spans, "aileron.connector.call")
+	if !ok {
+		t.Fatal("aileron.connector.call span not emitted")
+	}
+	if v, _ := attr(connSpan, "aileron.connector.fqn"); v != "github://test/echo" {
+		t.Errorf("aileron.connector.fqn = %v", v)
+	}
+	if v, _ := attr(connSpan, "aileron.connector.op"); v != "echo" {
+		t.Errorf("aileron.connector.op = %v", v)
+	}
+	if v, _ := attr(connSpan, "aileron.connector.hash"); v != hash {
+		t.Errorf("aileron.connector.hash = %v, want %q", v, hash)
+	}
+
+	// Connector span must be a child of the action span.
+	if connSpan.Parent().SpanID() != actSpan.SpanContext().SpanID() {
+		t.Errorf("connector.call parent span = %v, want action.execute span %v",
+			connSpan.Parent().SpanID(), actSpan.SpanContext().SpanID())
+	}
+}
+
+func TestSandboxExecutor_Execute_CapabilityDeniedMarksSpanError(t *testing.T) {
+	// When the action-boundary check denies an op, no connector.call
+	// span is started; the action span captures the failure via
+	// Result.Failure, gets marked Error, and the OTel-shaped
+	// aileron.failure.* attributes attach.
+	exp := withInMemoryExporter(t)
+
+	cstoreDir := t.TempDir()
+	store := cstore.NewStore(cstoreDir)
+	hash := installFakeConnector(t, store, "github://test/echo", "1.0.0")
+	// Capability list omits "echo" — the only execute step's op.
+	actions := installFakeAction(t, "github://test/echo", "1.0.0", hash, []string{"other_op"}, []string{"echo"})
+
+	rt := &fakeRuntime{}
+	rt.connectors = map[string]*fakeConnector{"github://test/echo": {resp: map[string]any{"ok": true}}}
+
+	exec := NewSandboxExecutor(actions, store, rt, nil)
+	t.Cleanup(func() { _ = exec.Close(context.Background()) })
+
+	res, err := exec.Execute(context.Background(), "test-action", nil)
+	if err != nil {
+		t.Fatalf("Execute returned Go error: %v", err)
+	}
+	if res.Failure == nil {
+		t.Fatal("expected structured failure; got nil")
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	if _, ok := findSpan(spans, "aileron.connector.call"); ok {
+		t.Error("aileron.connector.call span should not be emitted on capability denial")
+	}
+	actSpan, ok := findSpan(spans, "aileron.action.execute")
+	if !ok {
+		t.Fatal("aileron.action.execute span not emitted")
+	}
+	if actSpan.Status().Code != 1 /* codes.Error */ {
+		t.Errorf("action.execute span status = %v, want Error", actSpan.Status())
+	}
+	if v, _ := attr(actSpan, "aileron.failure.class"); v == nil || v == "" {
+		t.Errorf("aileron.failure.class missing from action.execute span")
+	}
+	if v, _ := attr(actSpan, "aileron.failure.boundary"); v == nil || v == "" {
+		t.Errorf("aileron.failure.boundary missing from action.execute span")
+	}
+	if _, ok := attr(actSpan, "aileron.failure.retriable"); !ok {
+		t.Errorf("aileron.failure.retriable missing from action.execute span")
+	}
+}
+
+func TestSandboxExecutor_Execute_InvokeErrorMarksConnectorSpanError(t *testing.T) {
+	// A sandbox.Error returned from Invoke maps to a structured
+	// failure on the action span. The connector.call span itself is
+	// also marked Error so consumers filtering on span status can
+	// pinpoint the failing step.
+	exp := withInMemoryExporter(t)
+
+	cstoreDir := t.TempDir()
+	store := cstore.NewStore(cstoreDir)
+	hash := installFakeConnector(t, store, "github://test/echo", "1.0.0")
+	actions := installFakeAction(t, "github://test/echo", "1.0.0", hash, []string{"echo"}, []string{"echo"})
+
+	rt := &fakeRuntime{}
+	rt.connectors = map[string]*fakeConnector{"github://test/echo": {
+		err: &sandbox.Error{Class: sandbox.ClassCapabilityDenied, Message: "denied at sandbox boundary"},
+	}}
+
+	exec := NewSandboxExecutor(actions, store, rt, nil)
+	t.Cleanup(func() { _ = exec.Close(context.Background()) })
+
+	if _, err := exec.Execute(context.Background(), "test-action", nil); err != nil {
+		t.Fatalf("Execute returned Go error: %v", err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	connSpan, ok := findSpan(spans, "aileron.connector.call")
+	if !ok {
+		t.Fatal("connector.call span not emitted")
+	}
+	if connSpan.Status().Code != 1 /* codes.Error */ {
+		t.Errorf("connector.call status = %v, want Error", connSpan.Status())
+	}
+	if !strings.Contains(connSpan.Status().Description, "denied at sandbox boundary") {
+		t.Errorf("connector.call status description = %q, want containing %q",
+			connSpan.Status().Description, "denied at sandbox boundary")
+	}
+}
+
+func TestSandboxExecutor_Execute_ActionNotFoundMarksActionSpanError(t *testing.T) {
+	// Gateway-fatal Go error path: action lookup miss. The action
+	// span is the only span emitted; its status is Error with the
+	// Go error's message.
+	exp := withInMemoryExporter(t)
+
+	cstoreDir := t.TempDir()
+	store := cstore.NewStore(cstoreDir)
+	hash := installFakeConnector(t, store, "github://test/echo", "1.0.0")
+	actions := installFakeAction(t, "github://test/echo", "1.0.0", hash, []string{"echo"}, []string{"echo"})
+
+	exec := NewSandboxExecutor(actions, store, &fakeRuntime{}, nil)
+	t.Cleanup(func() { _ = exec.Close(context.Background()) })
+
+	if _, err := exec.Execute(context.Background(), "no-such-action", nil); err == nil {
+		t.Fatal("expected Go error for missing action")
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	actSpan, ok := findSpan(spans, "aileron.action.execute")
+	if !ok {
+		t.Fatal("aileron.action.execute span not emitted")
+	}
+	if actSpan.Status().Code != 1 /* codes.Error */ {
+		t.Errorf("action.execute status = %v, want Error", actSpan.Status())
+	}
+	if _, ok := findSpan(spans, "aileron.connector.call"); ok {
+		t.Error("aileron.connector.call span should not be emitted when no action found")
+	}
+}
+
+func TestSandboxExecutor_Execute_NoOpProviderDoesNotCrash(t *testing.T) {
+	// With the OTel global at the no-op provider (the daemon startup
+	// default until AILERON_OTEL_ENABLED=true), Execute must still
+	// work. Guards against accidental hard-dependencies on the SDK
+	// being installed.
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(noop.NewTracerProvider())
+	t.Cleanup(func() { otel.SetTracerProvider(prev) })
+
+	cstoreDir := t.TempDir()
+	store := cstore.NewStore(cstoreDir)
+	hash := installFakeConnector(t, store, "github://test/echo", "1.0.0")
+	actions := installFakeAction(t, "github://test/echo", "1.0.0", hash, []string{"echo"}, []string{"echo"})
+
+	rt := &fakeRuntime{}
+	rt.connectors = map[string]*fakeConnector{"github://test/echo": {resp: map[string]any{"v": 1}}}
+
+	exec := NewSandboxExecutor(actions, store, rt, nil)
+	t.Cleanup(func() { _ = exec.Close(context.Background()) })
+
+	if _, err := exec.Execute(context.Background(), "test-action", nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+}

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -13,6 +13,7 @@ require (
 	github.com/jackc/pgx/v5 v5.7.4
 	github.com/oapi-codegen/oapi-codegen/v2 v2.6.0
 	github.com/oapi-codegen/runtime v1.3.1
+	github.com/oklog/ulid/v2 v2.1.1
 	github.com/slack-go/slack v0.21.1
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.42.0
 	github.com/tetratelabs/wazero v1.11.0
@@ -81,7 +82,6 @@ require (
 	github.com/mohae/deepcopy v0.0.0-20170929034955-c48cc78d4826 // indirect
 	github.com/oasdiff/yaml v0.0.0-20250309154309-f31be36b4037 // indirect
 	github.com/oasdiff/yaml3 v0.0.0-20250309153720-d2182401db90 // indirect
-	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/opencontainers/go-digest v1.0.0 // indirect
 	github.com/opencontainers/image-spec v1.1.1 // indirect
 	github.com/perimeterx/marshmallow v1.1.5 // indirect


### PR DESCRIPTION
## Summary

Two-commit PR landing two halves of one slice:

1. **First commit** — wires `aileron.action.execute` + `aileron.connector.call` spans into `SandboxExecutor.Execute`. Foundation tracer provider was installed in #457; this is the first time spans are actually emitted from the action-execution path.
2. **Second commit** — adds **Concepts → Observability** docs page covering both the audit log and OTel surfaces, env var reference table, span attribute schema, and a current/pending status table for the rest of #390.

Independent of the file-rotation work — verifiable today with `AILERON_OTEL_EXPORTER=stdout`.

### Spans

- **`aileron.action.execute`** — wraps the full `Execute` call. Attributes: `aileron.action.name`, `aileron.action.steps_count`. On `Result.Failure` non-nil OR returned `err` non-nil, span status is Error and the OTel-shaped failure attributes (`aileron.failure.{class,boundary,retriable}`) attach for filtering.
- **`aileron.connector.call`** — wraps each step's `conn.Invoke`. Child of `action.execute`. Attributes: `aileron.connector.{fqn,op,hash}`. Invoke errors mark the span Error with the error's message as the status description.

### Docs

- New page at `/concepts/observability/` documenting both audit + traces, env vars, span schema, and which Phase 7 slices have shipped vs are pending.
- One-line pointer in step 8 of `getting-started.md` so the E2E walkthrough surfaces tracing.
- Sidebar entry added under Concepts.

### Notes

- Capability denial short-circuits **before** `connector.call` is started — the action-boundary check happens earlier in the loop. Failure attributes still attach to the parent `action.execute` span. The capability check itself becomes its own `aileron.capability.check` span in a follow-up slice.
- Connector hash plumbed through `connectorFor`'s return tuple (now 4 values: connector, manifest, hash, error) so the span attribute can attach without re-walking the action manifest.
- Attribute keys mirror PR #452's audit payload schema 1:1. Spans + audit events share a single source of truth; no schema drift risk when the rest of #390 lands.

## Test plan

- [x] `go test ./internal/action/...` — coverage 92.8%; 5 new span tests pass alongside the existing behavioral suite
- [x] `go test ./...` — full internal-module sweep green
- [x] All four `cmd/*` modules build cleanly
- [x] `task build:docs` — 51 pages, no errors; new page renders at `/concepts/observability/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)