### PR TITLE
feat(daemon): bind ephemeral, publish discovery files, hold singleton lock

### DIFF
--- a/deploy/docker-compose.yml
+++ b/deploy/docker-compose.yml
@@ -44,7 +44,7 @@ services:
       enclave:
         condition: service_healthy
     environment:
-      AILERON_ADDR: ":8080"
+      AILERON_BIND: "0.0.0.0:8080"
       AILERON_DATABASE_URL: "postgres://aileron:aileron@postgres:5432/aileron?sslmode=disable"
       AILERON_JWT_SIGNING_KEY: "${AILERON_JWT_SIGNING_KEY}"
       AILERON_AUTO_VERIFY_EMAIL: "${AILERON_AUTO_VERIFY_EMAIL:-false}"

--- a/internal/server/entrypoint.sh
+++ b/internal/server/entrypoint.sh
@@ -11,4 +11,4 @@ if [ -n "$AILERON_DATABASE_URL" ]; then
   echo "Schema applied successfully."
 fi
 
-exec aileron-server
+exec aileron-server --bind "${AILERON_BIND:-0.0.0.0:8080}"

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -1,85 +1,202 @@
-// Package main is the entry point for the Aileron control plane server.
+// Package main is the entry point for the Aileron control plane daemon.
+//
+// Under ADR-0012 the daemon runs as one user-scoped long-lived process,
+// auto-spawned on first need by CLI / launch. By default it binds an
+// ephemeral port on 127.0.0.1 and advertises its URL via
+// `~/.aileron/daemon.json`; cloud / container deployments override the
+// bind address via `--bind`.
 package main
 
 import (
 	"context"
+	"errors"
+	"flag"
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"os/signal"
+	"path/filepath"
 	"syscall"
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/app"
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/vault"
+	"github.com/ALRubinger/aileron/internal/version"
 	"golang.org/x/term"
 )
 
 func main() {
-	level := slog.LevelInfo
-	if l := os.Getenv("AILERON_LOG_LEVEL"); l != "" {
-		switch l {
-		case "debug":
-			level = slog.LevelDebug
-		case "warn":
-			level = slog.LevelWarn
-		case "error":
-			level = slog.LevelError
-		}
-	}
-	log := slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: level}))
+	var bind string
+	flag.StringVar(&bind, "bind", "", "TCP bind address (default 127.0.0.1:0 ephemeral; cloud sets e.g. 0.0.0.0:8080)")
+	flag.Parse()
 
-	if err := run(log); err != nil {
-		log.Error("server exited with error", "error", err)
+	log := newLogger(os.Getenv("AILERON_LOG_LEVEL"))
+	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
+	defer stop()
+
+	if err := startDaemon(ctx, bind, log); err != nil {
+		log.Error("daemon exited with error", "error", err)
 		os.Exit(1)
 	}
 }
 
-func run(log *slog.Logger) error {
-	addr := os.Getenv("AILERON_ADDR")
-	if addr == "" {
-		addr = ":8080"
+// startDaemon resolves the production state directory + vault path and
+// drives [run] under the supplied context. Extracted from main so
+// tests can exercise the wiring with a cancellable ctx and a
+// HOME-overridden state directory.
+func startDaemon(ctx context.Context, bind string, log *slog.Logger) error {
+	stateDir, err := defaultStateDir()
+	if err != nil {
+		return err
 	}
+	return run(ctx, log, options{
+		BindAddr:  bind,
+		StateDir:  stateDir,
+		VaultPath: launch.DefaultVaultPath(),
+		IsTTY:     term.IsTerminal(int(os.Stdin.Fd())),
+		Stderr:    os.Stderr,
+	})
+}
 
-	cfg, err := selectVault(log, launch.DefaultVaultPath(), term.IsTerminal(int(os.Stdin.Fd())), nil, os.Stderr)
+// newLogger builds the daemon's structured JSON logger at the level
+// implied by env ("debug" / "warn" / "error"; anything else → info).
+func newLogger(env string) *slog.Logger {
+	return slog.New(slog.NewJSONHandler(os.Stdout, &slog.HandlerOptions{Level: parseLogLevel(env)}))
+}
+
+// parseLogLevel maps the AILERON_LOG_LEVEL env value to a slog.Level.
+func parseLogLevel(env string) slog.Level {
+	switch env {
+	case "debug":
+		return slog.LevelDebug
+	case "warn":
+		return slog.LevelWarn
+	case "error":
+		return slog.LevelError
+	default:
+		return slog.LevelInfo
+	}
+}
+
+// options holds the inputs run needs. Extracted so tests can construct
+// it with a t.TempDir()-scoped state directory.
+type options struct {
+	// BindAddr overrides the daemon's TCP bind address. Empty means
+	// "127.0.0.1:0" — an OS-assigned ephemeral port, the right choice
+	// for the local-daemon model where the URL is discovered via
+	// daemon.json rather than typed by users.
+	BindAddr string
+	// StateDir is the directory holding daemon.json, daemon.pid, and
+	// daemon.lock. ~/.aileron in production; t.TempDir() in tests.
+	StateDir string
+	// VaultPath is the file path for the persistent vault.
+	VaultPath string
+	// IsTTY controls whether the vault prompt may run interactively.
+	IsTTY bool
+	// Stderr is the stream selectVault uses for prompts. Set to
+	// os.Stderr in production; bytes.Buffer in tests.
+	Stderr io.Writer
+}
+
+// run owns the daemon lifecycle: acquire the singleton lock, bind,
+// publish discovery files, serve until ctx is canceled, then shut down
+// cleanly and remove the discovery files.
+//
+// Lock ordering is deliberate. Defers run LIFO, so the lock release
+// runs *after* discovery.Remove, ensuring no overlap window where a
+// fresh daemon could acquire the lock and observe stale daemon.json.
+func run(ctx context.Context, log *slog.Logger, opts options) error {
+	lockCtx, cancel := context.WithTimeout(ctx, 250*time.Millisecond)
+	defer cancel()
+	releaseLock, err := discovery.Lock(lockCtx, opts.StateDir)
+	if err != nil {
+		return fmt.Errorf("daemon already running, or could not acquire %s/%s: %w",
+			opts.StateDir, discovery.LockFile, err)
+	}
+	defer func() { _ = releaseLock() }()
+
+	cfg, err := selectVault(log, opts.VaultPath, opts.IsTTY, nil, opts.Stderr)
 	if err != nil {
 		return err
 	}
 
+	bindAddr := opts.BindAddr
+	if bindAddr == "" {
+		bindAddr = "127.0.0.1:0"
+	}
+	listener, err := net.Listen("tcp", bindAddr)
+	if err != nil {
+		return fmt.Errorf("listen %s: %w", bindAddr, err)
+	}
+
+	url := "http://" + listener.Addr().String()
+	info := discovery.Info{
+		URL:       url,
+		PID:       os.Getpid(),
+		Version:   version.Version,
+		StartedAt: time.Now().UTC(),
+	}
+	if err := discovery.Write(opts.StateDir, info); err != nil {
+		_ = listener.Close()
+		return fmt.Errorf("publish discovery: %w", err)
+	}
+	defer func() {
+		if err := discovery.Remove(opts.StateDir); err != nil {
+			log.Warn("removing discovery files", "error", err)
+		}
+	}()
+
 	handler, err := app.NewHandlerWithConfig(log, cfg)
 	if err != nil {
+		_ = listener.Close()
 		return err
 	}
 
 	srv := &http.Server{
-		Addr:         addr,
 		Handler:      handler,
 		ReadTimeout:  10 * time.Second,
 		WriteTimeout: 30 * time.Second,
 		IdleTimeout:  120 * time.Second,
 	}
 
-	// Graceful shutdown on SIGINT / SIGTERM.
-	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
-	defer stop()
-
+	serveErr := make(chan error, 1)
 	go func() {
-		log.Info("server listening", "addr", addr)
-		if err := srv.ListenAndServe(); err != nil && err != http.ErrServerClosed {
-			log.Error("listen error", "error", err)
+		log.Info("daemon listening", "url", url, "pid", info.PID, "version", info.Version)
+		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+			serveErr <- err
+			return
 		}
+		serveErr <- nil
 	}()
 
-	<-ctx.Done()
-	log.Info("shutting down")
+	select {
+	case <-ctx.Done():
+		log.Info("shutting down daemon", "url", url)
+	case err := <-serveErr:
+		if err != nil {
+			return fmt.Errorf("serve: %w", err)
+		}
+		return nil
+	}
 
-	shutdownCtx, cancel := context.WithTimeout(context.Background(), 30*time.Second)
-	defer cancel()
-
+	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 30*time.Second)
+	defer cancelShutdown()
 	return srv.Shutdown(shutdownCtx)
+}
+
+// defaultStateDir returns the canonical user state directory
+// (~/.aileron). The discovery file utilities create it on first write.
+func defaultStateDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("user home dir: %w", err)
+	}
+	return filepath.Join(home, ".aileron"), nil
 }
 
 // selectVault returns an [app.Config] with `Vault` set to a persistent

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -1,12 +1,18 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"io"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+	"time"
 
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
@@ -90,6 +96,312 @@ func TestSelectVault_CorruptFileFailsStartup(t *testing.T) {
 	if err == nil {
 		t.Fatal("selectVault: expected error for corrupt vault file, got nil")
 	}
+}
+
+// TestRun_PublishesDiscoveryAndCleansUp covers the daemon happy path:
+// run binds an ephemeral port, writes daemon.json with the URL/PID,
+// the URL is reachable for HTTP, and on context cancellation the
+// discovery files are removed and run returns cleanly.
+func TestRun_PublishesDiscoveryAndCleansUp(t *testing.T) {
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "127.0.0.1:0",
+		StateDir:  stateDir,
+		VaultPath: vaultPath,
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- run(ctx, log, opts) }()
+
+	info := waitForDaemon(t, stateDir, 3*time.Second)
+
+	if !strings.HasPrefix(info.URL, "http://127.0.0.1:") {
+		t.Errorf("URL = %q, want http://127.0.0.1:NNNN", info.URL)
+	}
+	if info.PID != os.Getpid() {
+		t.Errorf("PID = %d, want %d", info.PID, os.Getpid())
+	}
+	if info.Version == "" {
+		t.Error("Version is empty; expected build-injected or default 'dev'")
+	}
+
+	// URL is reachable: GET an endpoint that exists without auth setup.
+	resp, err := http.Get(info.URL + "/v1/vault/local/status")
+	if err != nil {
+		t.Fatalf("GET %s: %v", info.URL, err)
+	}
+	resp.Body.Close()
+	if resp.StatusCode == http.StatusInternalServerError {
+		t.Errorf("status = %d, expected non-5xx from a wired daemon", resp.StatusCode)
+	}
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("run returned error: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within timeout after cancel")
+	}
+
+	for _, name := range []string{discovery.InfoFile, discovery.PIDFile} {
+		if _, err := os.Stat(filepath.Join(stateDir, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("%s still exists after shutdown (err: %v)", name, err)
+		}
+	}
+}
+
+// TestRun_RefusesWhenAnotherDaemonHoldsLock asserts the singleton
+// invariant: a second daemon refuses to start while the first holds
+// daemon.lock. This is the core safety property — without it two
+// daemons could race to write daemon.json and clients would see only
+// the latest, while the other process keeps running invisibly.
+func TestRun_RefusesWhenAnotherDaemonHoldsLock(t *testing.T) {
+	stateDir := t.TempDir()
+
+	release, err := discovery.Lock(context.Background(), stateDir)
+	if err != nil {
+		t.Fatalf("manual Lock: %v", err)
+	}
+	defer release()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "127.0.0.1:0",
+		StateDir:  stateDir,
+		VaultPath: filepath.Join(t.TempDir(), "secrets.json"),
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	}
+
+	err = run(context.Background(), log, opts)
+	if err == nil {
+		t.Fatal("run should fail when daemon.lock is held by another process")
+	}
+}
+
+// TestRun_ListenFailureCleansUp verifies that when listen fails (e.g.
+// invalid bind address), no stale discovery files are left behind. The
+// daemon either succeeds and publishes, or fails and publishes nothing.
+func TestRun_ListenFailureCleansUp(t *testing.T) {
+	stateDir := t.TempDir()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "not-a-valid-address",
+		StateDir:  stateDir,
+		VaultPath: filepath.Join(t.TempDir(), "secrets.json"),
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	}
+
+	err := run(context.Background(), log, opts)
+	if err == nil {
+		t.Fatal("run should fail on invalid bind address")
+	}
+	for _, name := range []string{discovery.InfoFile, discovery.PIDFile} {
+		if _, err := os.Stat(filepath.Join(stateDir, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("%s exists after listen failure (err: %v)", name, err)
+		}
+	}
+}
+
+// TestRun_BindAddrEmptyMeansEphemeral verifies the local-daemon
+// default: empty BindAddr resolves to 127.0.0.1:0 (ephemeral port,
+// loopback only). Cloud overrides via --bind explicitly.
+func TestRun_BindAddrEmptyMeansEphemeral(t *testing.T) {
+	stateDir := t.TempDir()
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "",
+		StateDir:  stateDir,
+		VaultPath: filepath.Join(t.TempDir(), "secrets.json"),
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- run(ctx, log, opts) }()
+
+	info := waitForDaemon(t, stateDir, 3*time.Second)
+	if !strings.HasPrefix(info.URL, "http://127.0.0.1:") {
+		t.Errorf("URL = %q, want loopback ephemeral", info.URL)
+	}
+
+	cancel()
+	<-runErr
+}
+
+// TestRun_VaultErrorPropagates exercises the selectVault → run error
+// path: when the vault file is corrupt, run should return the vault
+// error and write no discovery files (the lock is acquired and
+// released cleanly via defer).
+func TestRun_RemoveWarnDoesNotFailShutdown(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod-based access denial is bypassed")
+	}
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "127.0.0.1:0",
+		StateDir:  stateDir,
+		VaultPath: vaultPath,
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- run(ctx, log, opts) }()
+	waitForDaemon(t, stateDir, 3*time.Second)
+
+	// Make stateDir read-only so discovery.Remove fails during shutdown.
+	// run should log a warning but still return cleanly.
+	if err := os.Chmod(stateDir, 0o500); err != nil {
+		t.Fatalf("chmod: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(stateDir, 0o700) })
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("run should swallow Remove failure as a warning: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("run did not return within timeout")
+	}
+}
+
+func TestRun_VaultErrorPropagates(t *testing.T) {
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+	if _, err := vault.Init(vaultPath, "passphrase"); err != nil {
+		t.Fatalf("vault.Init: %v", err)
+	}
+	tamper(t, vaultPath)
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "127.0.0.1:0",
+		StateDir:  stateDir,
+		VaultPath: vaultPath,
+		IsTTY:     true,
+		Stderr:    io.Discard,
+	}
+
+	err := run(context.Background(), log, opts)
+	if err == nil {
+		t.Fatal("run should fail when vault is corrupt")
+	}
+	for _, name := range []string{discovery.InfoFile, discovery.PIDFile} {
+		if _, err := os.Stat(filepath.Join(stateDir, name)); !errors.Is(err, os.ErrNotExist) {
+			t.Errorf("%s should not exist after vault error", name)
+		}
+	}
+}
+
+func TestParseLogLevel(t *testing.T) {
+	cases := map[string]slog.Level{
+		"debug":   slog.LevelDebug,
+		"warn":    slog.LevelWarn,
+		"error":   slog.LevelError,
+		"":        slog.LevelInfo,
+		"info":    slog.LevelInfo,
+		"unknown": slog.LevelInfo,
+	}
+	for env, want := range cases {
+		t.Run(env, func(t *testing.T) {
+			if got := parseLogLevel(env); got != want {
+				t.Errorf("parseLogLevel(%q) = %v, want %v", env, got, want)
+			}
+		})
+	}
+}
+
+func TestNewLogger(t *testing.T) {
+	if got := newLogger("debug"); got == nil {
+		t.Fatal("newLogger returned nil")
+	}
+}
+
+func TestStartDaemonHappyPath(t *testing.T) {
+	// HOME override redirects defaultStateDir at ~/.aileron into a temp
+	// dir so the test does not write to the user's actual home.
+	t.Setenv("HOME", t.TempDir())
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	runErr := make(chan error, 1)
+	go func() { runErr <- startDaemon(ctx, "127.0.0.1:0", log) }()
+
+	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+	waitForDaemon(t, stateDir, 3*time.Second)
+
+	cancel()
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("startDaemon: %v", err)
+		}
+	case <-time.After(5 * time.Second):
+		t.Fatal("startDaemon did not return within timeout")
+	}
+}
+
+func TestStartDaemonReturnsErrorFromRun(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	err := startDaemon(context.Background(), "not-a-valid-address", log)
+	if err == nil {
+		t.Fatal("startDaemon should propagate the listen error")
+	}
+}
+
+func TestDefaultStateDir(t *testing.T) {
+	dir, err := defaultStateDir()
+	if err != nil {
+		t.Fatalf("defaultStateDir: %v", err)
+	}
+	if !strings.HasSuffix(dir, ".aileron") {
+		t.Fatalf("dir = %q, want suffix .aileron", dir)
+	}
+}
+
+// waitForDaemon polls daemon.json with a short interval until it
+// appears or the deadline expires. Returns the parsed Info on success;
+// fails the test on timeout.
+func waitForDaemon(t *testing.T, stateDir string, timeout time.Duration) discovery.Info {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		info, err := discovery.Read(stateDir)
+		if err == nil {
+			return info
+		}
+		time.Sleep(20 * time.Millisecond)
+	}
+	t.Fatalf("daemon.json did not appear within %s", timeout)
+	return discovery.Info{}
 }
 
 // scriptedPrompter returns a PassphrasePrompter that always answers


### PR DESCRIPTION
## Summary

Step 3 of #454. The standalone server (`internal/server`) becomes the user-scoped local daemon described in ADR-0012.

What changes:

- **Default bind is `127.0.0.1:0`** (ephemeral, loopback only). Cloud / container deployments override via the new `--bind` flag.
- **`AILERON_ADDR` env is gone.** Replaced in `entrypoint.sh` by `AILERON_BIND` with a sane `0.0.0.0:8080` default. `deploy/docker-compose.yml` updated to match.
- **Singleton invariant** via `discovery.Lock` at startup: a second daemon refuses to start while the first is alive. The kernel drops the flock when a process dies, so crashed-daemon recovery is automatic on the next start — no PID-aliveness check, no stale-lock cleanup logic.
- **Publishes `daemon.json` + `daemon.pid`** after `Listen()` succeeds (capturing the actual ephemeral port), via `discovery.Write` from #459.
- **Cleans on shutdown.** `srv.Shutdown(30s)` then `discovery.Remove`. Defer ordering keeps the lock held through cleanup — no overlap window where a fresh daemon could observe stale `daemon.json`.

`run` is the testable entry point. `main` and `startDaemon` are thin shells around it (logger + flag wiring) so tests can drive `run` with a `t.TempDir()`-scoped state directory and a cancellable `context.Context`.

## Test plan

- [x] `go test ./internal/server/... -race` is green.
- [x] `go vet ./internal/server/...` is clean.
- [x] Coverage on `internal/server` is 74.1% — `main()` is the only meaningful drag (4 lines of glue around `flag.Parse` / `signal.NotifyContext` / `os.Exit`); every helper and `run` path is covered. Diff coverage will land closer to the 80% target since most new lines are in tested helpers.
- [x] Tests cover: happy-path lifecycle (binds → `daemon.json` → reachable URL → cancel → cleanup), singleton refusal under held lock, invalid bind address, vault error propagation (corrupt vault file), `discovery.Remove` failure during shutdown logged but doesn't fail `run`, ephemeral default when `BindAddr=""`, `parseLogLevel`, `newLogger`, `defaultStateDir` shape, `startDaemon` happy path with `HOME` override, `startDaemon` error propagation.
- [x] Existing `selectVault` tests still pass unchanged.

## Notes

- Cloud Docker users moving from `AILERON_ADDR` need to set `AILERON_BIND` instead. Per the no-backwards-compat-before-release policy, no shim. The default in `entrypoint.sh` is `0.0.0.0:8080`, so existing setups that didn't override `AILERON_ADDR` continue to work without changes to `docker-compose.yml`.
- No CLI / launch integration yet. Auto-spawn (#454 step 6) and the `aileron daemon` subcommands (#454 step 7) consume this in follow-on PRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)