### PR TITLE
feat(action): emit aileron.capability.check span per execute step (#390)

### DIFF
--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -66,8 +66,8 @@ Today (as the Phase 7 emission integrations land slice by slice in [issue #390](
 | `aileron.mcp.tool.call` | `aileron-mcp` outbound to `/v1/actions/{name}/run` — typically the trace root under `aileron launch` | ✅ shipped |
 | `aileron.action.execute` | `SandboxExecutor.Execute` — root for an action invocation | ✅ shipped |
 | `aileron.connector.call` | per-step `conn.Invoke` inside the executor | ✅ shipped |
+| `aileron.capability.check` | per-step action-boundary capability enforcement (defense-in-depth, [ADR-0003](/adr/0003-action-model)) — first observability point on "how often does the sandbox say no?" | ✅ shipped |
 | HTTP server-root span | gateway and `/v1/actions/{name}/run` entry points | ✅ shipped |
-| `aileron.capability.check` | the action-boundary capability enforcement | ⏳ pending |
 | `aileron.approval.wait` | the approval-queue blocking wait | ⏳ pending |
 | `aileron.gateway.openai.chat` / `aileron.gateway.anthropic.messages` | LLM round-trip on the gateway | ⏳ pending |
 

--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -210,7 +210,7 @@ func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[str
 		// op name is treated as the capability string for v1 — the
 		// action's `capabilities = [...]` list must include the op
 		// the step invokes.
-		if capErr := EnforceCapability(manifest, step.Connector, step.Op); capErr != nil {
+		if capErr := enforceCapabilityWithSpan(ctx, manifest, step.Connector, step.Op); capErr != nil {
 			return errorResult(capErr), nil
 		}
 
@@ -267,6 +267,35 @@ func (e *SandboxExecutor) Execute(ctx context.Context, name string, args map[str
 	// Unreachable: every loop iteration either errors or, on the last
 	// iteration, returns the success result.
 	return Result{}, nil
+}
+
+// enforceCapabilityWithSpan wraps the action-boundary capability
+// check (ADR-0003 §"defense in depth") in an
+// `aileron.capability.check` span. Net-new emission point — until
+// this lands, "how often does the sandbox say no?" had no
+// observability surface. Attributes use the OTel-namespaced shape
+// shared with the audit log: aileron.connector.fqn,
+// aileron.capability.kind, aileron.action.name. Denial sets span
+// status Error with the *Error's message; success leaves status
+// Unset.
+func enforceCapabilityWithSpan(ctx context.Context, m *Manifest, connectorFQN, capability string) error {
+	tracer := otel.GetTracerProvider().Tracer(tracerName)
+	_, span := tracer.Start(ctx, "aileron.capability.check",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("aileron.connector.fqn", connectorFQN),
+			attribute.String("aileron.capability.kind", capability),
+		),
+	)
+	defer span.End()
+	if m != nil && m.Name != "" {
+		span.SetAttributes(attribute.String("aileron.action.name", m.Name))
+	}
+	if err := EnforceCapability(m, connectorFQN, capability); err != nil {
+		span.SetStatus(codes.Error, err.Error())
+		return err
+	}
+	return nil
 }
 
 // invokeWithSpan wraps a single connector.Invoke call in an

--- a/internal/action/executor_span_test.go
+++ b/internal/action/executor_span_test.go
@@ -235,6 +235,149 @@ func TestSandboxExecutor_Execute_ActionNotFoundMarksActionSpanError(t *testing.T
 	}
 }
 
+func TestSandboxExecutor_Execute_EmitsCapabilityCheckSpanPerStep(t *testing.T) {
+	// Defense-in-depth: every step's action-boundary check emits an
+	// aileron.capability.check span — child of action.execute,
+	// sibling of (and ordered before) the connector.call span when
+	// the check passes. Attributes follow the audit-log schema:
+	// aileron.connector.fqn, aileron.capability.kind,
+	// aileron.action.name.
+	exp := withInMemoryExporter(t)
+
+	cstoreDir := t.TempDir()
+	store := cstore.NewStore(cstoreDir)
+	hash := installFakeConnector(t, store, "github://test/echo", "1.0.0")
+	actions := installFakeAction(t, "github://test/echo", "1.0.0", hash, []string{"echo"}, []string{"echo"})
+
+	rt := &fakeRuntime{}
+	rt.connectors = map[string]*fakeConnector{"github://test/echo": {resp: map[string]any{"v": 1}}}
+
+	exec := NewSandboxExecutor(actions, store, rt, nil)
+	t.Cleanup(func() { _ = exec.Close(context.Background()) })
+
+	if _, err := exec.Execute(context.Background(), "test-action", nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	capSpan, ok := findSpan(spans, "aileron.capability.check")
+	if !ok {
+		t.Fatalf("aileron.capability.check span not emitted; got %d spans", len(spans))
+	}
+	if v, _ := attr(capSpan, "aileron.connector.fqn"); v != "github://test/echo" {
+		t.Errorf("aileron.connector.fqn = %v", v)
+	}
+	if v, _ := attr(capSpan, "aileron.capability.kind"); v != "echo" {
+		t.Errorf("aileron.capability.kind = %v, want echo", v)
+	}
+	if v, _ := attr(capSpan, "aileron.action.name"); v != "test-action" {
+		t.Errorf("aileron.action.name = %v, want test-action", v)
+	}
+
+	actSpan, _ := findSpan(spans, "aileron.action.execute")
+	if capSpan.Parent().SpanID() != actSpan.SpanContext().SpanID() {
+		t.Errorf("capability.check parent = %v, want action.execute span %v",
+			capSpan.Parent().SpanID(), actSpan.SpanContext().SpanID())
+	}
+}
+
+func TestSandboxExecutor_Execute_CapabilityCheckSpanMarksDeniedError(t *testing.T) {
+	// On denial: the capability.check span itself carries Error
+	// status with the denial message, distinct from the parent
+	// action.execute span (which also gets Error via the failure
+	// envelope on the result). Two spans showing Error means trace
+	// readers can pinpoint that *the capability check* was the
+	// failure point, not e.g. a downstream connector error.
+	exp := withInMemoryExporter(t)
+
+	cstoreDir := t.TempDir()
+	store := cstore.NewStore(cstoreDir)
+	hash := installFakeConnector(t, store, "github://test/echo", "1.0.0")
+	// Capabilities omit "echo" — the only execute step's op.
+	actions := installFakeAction(t, "github://test/echo", "1.0.0", hash, []string{"other_op"}, []string{"echo"})
+
+	rt := &fakeRuntime{}
+	rt.connectors = map[string]*fakeConnector{"github://test/echo": {resp: map[string]any{}}}
+
+	exec := NewSandboxExecutor(actions, store, rt, nil)
+	t.Cleanup(func() { _ = exec.Close(context.Background()) })
+
+	if _, err := exec.Execute(context.Background(), "test-action", nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	capSpan, ok := findSpan(spans, "aileron.capability.check")
+	if !ok {
+		t.Fatal("aileron.capability.check span not emitted")
+	}
+	if capSpan.Status().Code != 1 /* codes.Error */ {
+		t.Errorf("capability.check status = %v, want Error", capSpan.Status())
+	}
+	if !strings.Contains(capSpan.Status().Description, "capability_denied") &&
+		!strings.Contains(capSpan.Status().Description, "not in declared subset") {
+		t.Errorf("capability.check status description = %q, want denial message",
+			capSpan.Status().Description)
+	}
+}
+
+func TestSandboxExecutor_Execute_CapabilityCheckSpanPerStepUntilFirstDenial(t *testing.T) {
+	// Multi-step action where the second step is denied: the first
+	// step's capability.check passes (Ok), the second's fails (Error).
+	// First-failure-terminates per ADR-0010; no third span ever opens.
+	exp := withInMemoryExporter(t)
+
+	cstoreDir := t.TempDir()
+	store := cstore.NewStore(cstoreDir)
+	hash := installFakeConnector(t, store, "github://test/echo", "1.0.0")
+	// First step's op (echo) is in the capability list; second step's
+	// op (denied_op) is not.
+	actions := installFakeAction(t, "github://test/echo", "1.0.0", hash, []string{"echo"}, []string{"echo", "denied_op"})
+
+	rt := &fakeRuntime{}
+	rt.connectors = map[string]*fakeConnector{"github://test/echo": {resp: map[string]any{"v": 1}}}
+
+	exec := NewSandboxExecutor(actions, store, rt, nil)
+	t.Cleanup(func() { _ = exec.Close(context.Background()) })
+
+	if _, err := exec.Execute(context.Background(), "test-action", nil); err != nil {
+		t.Fatalf("Execute: %v", err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	var capSpans []sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if s.Name() == "aileron.capability.check" {
+			capSpans = append(capSpans, s)
+		}
+	}
+	if len(capSpans) != 2 {
+		t.Fatalf("got %d capability.check spans, want 2 (one per step until first denial)",
+			len(capSpans))
+	}
+	// Find the spans by their capability.kind attribute.
+	var firstStep, secondStep sdktrace.ReadOnlySpan
+	for _, s := range capSpans {
+		v, _ := attr(s, "aileron.capability.kind")
+		switch v {
+		case "echo":
+			firstStep = s
+		case "denied_op":
+			secondStep = s
+		}
+	}
+	if firstStep == nil || secondStep == nil {
+		t.Fatalf("expected both echo and denied_op spans; firstStep=%v secondStep=%v",
+			firstStep, secondStep)
+	}
+	if firstStep.Status().Code == 1 /* codes.Error */ {
+		t.Errorf("first-step capability.check status = Error, want Unset (op was allowed)")
+	}
+	if secondStep.Status().Code != 1 /* codes.Error */ {
+		t.Errorf("second-step capability.check status = %v, want Error", secondStep.Status())
+	}
+}
+
 func TestSandboxExecutor_Execute_NoOpProviderDoesNotCrash(t *testing.T) {
 	// With the OTel global at the no-op provider (the daemon startup
 	// default until AILERON_OTEL_ENABLED=true), Execute must still


### PR DESCRIPTION
## Summary

Net-new emission point. Until this lands, **"how often does the sandbox say no?"** had no observability surface — capability denials happened silently before any span boundary. With this PR, every action-boundary capability check ([ADR-0003](https://docs.withaileron.ai/adr/0003-action-model) §"defense in depth") emits an `aileron.capability.check` span with the OTel-namespaced shape shared with the audit log.

### Where it sits in the trace tree

```
aileron.mcp.tool.call            (cmd/aileron-mcp, #464)
└── aileron.action.execute       (#461)
    ├── aileron.capability.check (NEW — this PR, one per step)
    └── aileron.connector.call   (#461 — sibling, ordered after)
```

When the check passes, `connector.call` follows. When it fails, `connector.call` is never started (first-failure-terminates per ADR-0010), and *both* the `capability.check` span and the parent `action.execute` span carry `Error` — but the inner span pinpoints the *capability check itself* as the failure point, distinguishable from e.g. a downstream sandbox or connector failure.

### Implementation

`enforceCapabilityWithSpan` helper wraps the existing `EnforceCapability` without changing its signature (the function stays pure — no context coupling). Attributes follow the audit-log schema:

- `aileron.connector.fqn`
- `aileron.capability.kind`
- `aileron.action.name` (when manifest is in scope)

### Tests

3 new:
- **`EmitsCapabilityCheckSpanPerStep`** — happy path; parent/child relationship to `action.execute` verified
- **`CapabilityCheckSpanMarksDeniedError`** — denial sets span `Error` with the denial message
- **`CapabilityCheckSpanPerStepUntilFirstDenial`** — multi-step action emits one span per step until the first denial; downstream steps never run

### Docs

Moved `aileron.capability.check` from pending to shipped in the observability status table. Framed as "first observability point on capability enforcement" since it really is — there's nothing else.

## Test plan

- [x] `go test ./internal/action/...` — coverage 92.9% (no change); 3 new tests + 5 pre-existing span tests + the behavioral suite all pass
- [x] `go test ./...` — full internal-module sweep green
- [x] All four `cmd/*` modules build cleanly
- [x] `task build:docs` — 53 pages, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
