### PR TITLE
feat(approval): emit aileron.approval.wait span around blocking wait (#390)

### DIFF
--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -67,8 +67,8 @@ Today (as the Phase 7 emission integrations land slice by slice in [issue #390](
 | `aileron.action.execute` | `SandboxExecutor.Execute` — root for an action invocation | ✅ shipped |
 | `aileron.connector.call` | per-step `conn.Invoke` inside the executor | ✅ shipped |
 | `aileron.capability.check` | per-step action-boundary capability enforcement (defense-in-depth, [ADR-0003](/adr/0003-action-model)) — first observability point on "how often does the sandbox say no?" | ✅ shipped |
+| `aileron.approval.wait` | the approval-queue blocking wait — covers the entire user-decision interval; `aileron.approval.decision` is `approved` / `denied` / `timeout` / `cancelled` | ✅ shipped |
 | HTTP server-root span | gateway and `/v1/actions/{name}/run` entry points | ✅ shipped |
-| `aileron.approval.wait` | the approval-queue blocking wait | ⏳ pending |
 | `aileron.gateway.openai.chat` / `aileron.gateway.anthropic.messages` | LLM round-trip on the gateway | ⏳ pending |
 
 The file exporter (writing spans to `~/.aileron/traces/spans.jsonl` with date-based rotation) is also pending — it's gated on the parallel audit-log file rotation work so spans and audit events share a rotating writer with the same retention story.

--- a/internal/approval/action_queue.go
+++ b/internal/approval/action_queue.go
@@ -10,7 +10,16 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/model"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// tracerName names the OTel instrumentation library reported on
+// spans this package emits. Mirrors the convention used in
+// internal/action and internal/observability.
+const tracerName = "github.com/ALRubinger/aileron/internal/approval"
 
 // ApprovalKind discriminates the user-facing card layout the webapp
 // renders for a queue entry. Defaults to [ApprovalKindAction] for
@@ -142,15 +151,51 @@ type ActionDecision struct {
 // held-open response. When this returns, the handler proceeds to
 // either execute the action (Approved) or write an `approval_denied`
 // failure envelope to the response.
+//
+// Emits an `aileron.approval.wait` span covering the blocked-on-user
+// interval. Span attribute keys mirror the audit-event keys emitted
+// by Register / Decide so consumers can correlate the queue's three
+// audit events with this span by `aileron.approval.id`. The span's
+// `aileron.approval.wait_ms` is computed identically to the
+// approved/denied audit event.
 func (a *ActionApproval) Wait(ctx context.Context, timeout time.Duration) (ActionDecision, error) {
+	tracer := otel.GetTracerProvider().Tracer(tracerName)
+	ctx, span := tracer.Start(ctx, "aileron.approval.wait",
+		trace.WithSpanKind(trace.SpanKindInternal),
+		trace.WithAttributes(
+			attribute.String("aileron.approval.id", a.ID),
+			attribute.String("aileron.approval.kind", string(a.Kind)),
+			attribute.String("aileron.approval.action", a.ActionName),
+		),
+	)
+	defer span.End()
+	if a.ConnectorFQN != "" {
+		span.SetAttributes(attribute.String("aileron.connector.fqn", a.ConnectorFQN))
+	}
+	if a.SessionID != "" {
+		span.SetAttributes(attribute.String("aileron.session.id", a.SessionID))
+	}
+
 	timer := time.NewTimer(timeout)
 	defer timer.Stop()
 	select {
 	case d := <-a.decision:
+		decision := "denied"
+		if d.Approved {
+			decision = "approved"
+		}
+		span.SetAttributes(
+			attribute.String("aileron.approval.decision", decision),
+			attribute.Int64("aileron.approval.wait_ms", d.DecidedAt.Sub(a.RequestedAt).Milliseconds()),
+		)
 		return d, nil
 	case <-timer.C:
+		span.SetAttributes(attribute.String("aileron.approval.decision", "timeout"))
+		span.SetStatus(codes.Error, ErrActionApprovalTimeout.Error())
 		return ActionDecision{}, ErrActionApprovalTimeout
 	case <-ctx.Done():
+		span.SetAttributes(attribute.String("aileron.approval.decision", "cancelled"))
+		span.SetStatus(codes.Error, ctx.Err().Error())
 		return ActionDecision{}, ctx.Err()
 	}
 }

--- a/internal/approval/action_queue_span_test.go
+++ b/internal/approval/action_queue_span_test.go
@@ -1,0 +1,221 @@
+package approval
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// Span emission contract for ActionApproval.Wait:
+//
+//   - Covers the blocked-on-user interval as aileron.approval.wait.
+//   - Attribute keys mirror the audit-event keys emitted by Register
+//     and Decide (PR #460) so consumers correlate the audit trail
+//     with the span by `aileron.approval.id`.
+//   - Approve / deny: span Ok (default), decision attribute set,
+//     wait_ms reflects RequestedAt → DecidedAt.
+//   - Timeout: span Error with the ErrActionApprovalTimeout message;
+//     decision = "timeout".
+//   - Caller-context cancel: span Error with ctx.Err() message;
+//     decision = "cancelled".
+
+func withInMemoryExporter(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+	return exp
+}
+
+func findSpan(spans []sdktrace.ReadOnlySpan, name string) (sdktrace.ReadOnlySpan, bool) {
+	for _, s := range spans {
+		if s.Name() == name {
+			return s, true
+		}
+	}
+	return nil, false
+}
+
+func attrString(s sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func attrInt64(s sdktrace.ReadOnlySpan, key string) (int64, bool) {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
+func TestWait_ApproveEmitsSpanOkWithDecisionAttrs(t *testing.T) {
+	exp := withInMemoryExporter(t)
+
+	q := NewActionApprovalQueue(nil, nil)
+	a := q.Register("send-email", "github://x/y", "sess-1", nil)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = a.Wait(context.Background(), time.Second)
+		close(done)
+	}()
+	if err := q.Decide(a.ID, true, "", nil); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	<-done
+
+	spans := exp.GetSpans().Snapshots()
+	got, ok := findSpan(spans, "aileron.approval.wait")
+	if !ok {
+		t.Fatalf("aileron.approval.wait span not emitted; got %d spans", len(spans))
+	}
+	if got.Status().Code != 0 /* codes.Unset */ {
+		t.Errorf("span status = %v, want Unset on approve", got.Status())
+	}
+	if v, _ := attrString(got, "aileron.approval.id"); v != a.ID {
+		t.Errorf("aileron.approval.id = %q, want %q", v, a.ID)
+	}
+	if v, _ := attrString(got, "aileron.approval.action"); v != "send-email" {
+		t.Errorf("aileron.approval.action = %q, want send-email", v)
+	}
+	if v, _ := attrString(got, "aileron.approval.kind"); v != string(ApprovalKindAction) {
+		t.Errorf("aileron.approval.kind = %q, want %q", v, ApprovalKindAction)
+	}
+	if v, _ := attrString(got, "aileron.connector.fqn"); v != "github://x/y" {
+		t.Errorf("aileron.connector.fqn = %q", v)
+	}
+	if v, _ := attrString(got, "aileron.session.id"); v != "sess-1" {
+		t.Errorf("aileron.session.id = %q", v)
+	}
+	if v, _ := attrString(got, "aileron.approval.decision"); v != "approved" {
+		t.Errorf("aileron.approval.decision = %q, want approved", v)
+	}
+	if _, ok := attrInt64(got, "aileron.approval.wait_ms"); !ok {
+		t.Errorf("aileron.approval.wait_ms missing from span")
+	}
+}
+
+func TestWait_DenyEmitsSpanOkWithDeniedDecision(t *testing.T) {
+	exp := withInMemoryExporter(t)
+
+	q := NewActionApprovalQueue(nil, nil)
+	a := q.Register("send-email", "", "", nil)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = a.Wait(context.Background(), time.Second)
+		close(done)
+	}()
+	if err := q.Decide(a.ID, false, "wrong recipient", nil); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	<-done
+
+	spans := exp.GetSpans().Snapshots()
+	got, ok := findSpan(spans, "aileron.approval.wait")
+	if !ok {
+		t.Fatal("aileron.approval.wait span not emitted")
+	}
+	// Deny is a deliberate user decision, not a system failure — span
+	// status stays Ok. The decision attribute carries the verdict.
+	if got.Status().Code != 0 /* codes.Unset */ {
+		t.Errorf("span status = %v, want Unset on deny (deny is a valid decision, not a span error)", got.Status())
+	}
+	if v, _ := attrString(got, "aileron.approval.decision"); v != "denied" {
+		t.Errorf("aileron.approval.decision = %q, want denied", v)
+	}
+	// Optional attrs absent when not set on Register.
+	if v, present := attrString(got, "aileron.connector.fqn"); present {
+		t.Errorf("aileron.connector.fqn should be absent when empty on Register; got %q", v)
+	}
+	if v, present := attrString(got, "aileron.session.id"); present {
+		t.Errorf("aileron.session.id should be absent when empty on Register; got %q", v)
+	}
+}
+
+func TestWait_TimeoutMarksSpanErrorWithTimeoutDecision(t *testing.T) {
+	exp := withInMemoryExporter(t)
+
+	q := NewActionApprovalQueue(nil, nil)
+	a := q.Register("send-email", "", "", nil)
+
+	_, err := a.Wait(context.Background(), 10*time.Millisecond)
+	if !errors.Is(err, ErrActionApprovalTimeout) {
+		t.Fatalf("Wait err = %v, want ErrActionApprovalTimeout", err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	got, ok := findSpan(spans, "aileron.approval.wait")
+	if !ok {
+		t.Fatal("aileron.approval.wait span not emitted")
+	}
+	if got.Status().Code != 1 /* codes.Error */ {
+		t.Errorf("span status = %v, want Error on timeout", got.Status())
+	}
+	if v, _ := attrString(got, "aileron.approval.decision"); v != "timeout" {
+		t.Errorf("aileron.approval.decision = %q, want timeout", v)
+	}
+}
+
+func TestWait_ContextCancelledMarksSpanErrorWithCancelledDecision(t *testing.T) {
+	exp := withInMemoryExporter(t)
+
+	q := NewActionApprovalQueue(nil, nil)
+	a := q.Register("send-email", "", "", nil)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan error, 1)
+	go func() {
+		_, err := a.Wait(ctx, time.Second)
+		done <- err
+	}()
+	cancel()
+	if err := <-done; !errors.Is(err, context.Canceled) {
+		t.Fatalf("Wait err = %v, want context.Canceled", err)
+	}
+
+	spans := exp.GetSpans().Snapshots()
+	got, ok := findSpan(spans, "aileron.approval.wait")
+	if !ok {
+		t.Fatal("aileron.approval.wait span not emitted")
+	}
+	if got.Status().Code != 1 /* codes.Error */ {
+		t.Errorf("span status = %v, want Error on ctx cancel", got.Status())
+	}
+	if v, _ := attrString(got, "aileron.approval.decision"); v != "cancelled" {
+		t.Errorf("aileron.approval.decision = %q, want cancelled", v)
+	}
+}
+
+func TestWait_NoOpProviderDoesNotPanic(t *testing.T) {
+	// Default OTel global is no-op until daemon Init runs. Wait must
+	// still work — span ops are no-ops.
+	q := NewActionApprovalQueue(nil, nil)
+	a := q.Register("send-email", "", "", nil)
+
+	done := make(chan struct{})
+	go func() {
+		_, _ = a.Wait(context.Background(), time.Second)
+		close(done)
+	}()
+	if err := q.Decide(a.ID, true, "", nil); err != nil {
+		t.Fatalf("Decide: %v", err)
+	}
+	<-done
+}


### PR DESCRIPTION
## Summary

Wraps `ActionApproval.Wait` in an `aileron.approval.wait` span covering the blocked-on-user interval. Pairs with the approval audit emission shipped in #460: the audit events fire on `Register` / `Decide`; this span covers the time-to-decision interval that connects them.

```
HTTP server-root span                 (#457)
├── aileron.approval.wait             ← NEW (this PR)
└── aileron.action.execute            (#461, runs after approval)
    ├── aileron.capability.check      (#466)
    └── aileron.connector.call        (#461)
```

### Attribute keys (audit-shape, single source of truth)

- `aileron.approval.id` — same id audit consumers use to correlate Register and Decide events
- `aileron.approval.kind` — `action` / `comms_send` / `comms_draft` / `http_request` / `shell`
- `aileron.approval.action` — the action-or-tool name the gate covers
- `aileron.connector.fqn` / `aileron.session.id` — when set on Register
- `aileron.approval.decision` — `approved` / `denied` / `timeout` / `cancelled`
- `aileron.approval.wait_ms` — `RequestedAt → DecidedAt` for resolved outcomes; computed identically to the audit event so both surfaces report the same number

The first two decision values come from `Decide` and align with the audit emission. The latter two (`timeout`, `cancelled`) are span-only outcomes — `Wait` can return without a `Decide` call when the timer fires or the caller's context cancels; the queue today doesn't emit audit events for those, by design (no decision was made).

### Span status semantics

- **approve / deny** — span `Ok` (Unset). Deny is a deliberate user decision, not a system failure.
- **timeout** — span `Error` with `ErrActionApprovalTimeout`'s message.
- **ctx cancel** — span `Error` with `ctx.Err()`'s message.

## Test plan

- [x] `go test ./internal/approval/...` — coverage 94.1%; 5 new span tests cover all four outcomes plus the no-op tracer fallback
- [x] `go test ./...` — full internal-module sweep green
- [x] All four `cmd/*` modules build cleanly
- [x] `task build:docs` — 55 pages, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
