### PR TITLE
feat(audit): user-scope, daily-rotated audit log

### DIFF
--- a/cmd/aileron-sh/main.go
+++ b/cmd/aileron-sh/main.go
@@ -110,13 +110,17 @@ func writeDenyByUserMessage(command string) {
 	launch.WriteDenyByUser(os.Stderr, command)
 }
 
-// writeAuditEntry appends an entry to the audit log if configured.
+// writeAuditEntry appends an entry to today's daily-rotated audit log
+// under the state dir advertised via AILERON_AUDIT_DIR (set by
+// `aileron launch`). The file path is recomputed on every call so a
+// shell invocation that happens after midnight lands in the new day's
+// file. ADR-0012 specifies the user-scope, daily-rotated layout.
 func writeAuditEntry(command, disposition, ruleID string) {
-	path := os.Getenv("AILERON_AUDIT_LOG")
-	if path == "" {
+	stateDir := os.Getenv("AILERON_AUDIT_DIR")
+	if stateDir == "" {
 		return
 	}
-	audit.AppendShellEntry(path, audit.ShellEntry{
+	audit.AppendShellEntry(audit.DailyPath(stateDir), audit.ShellEntry{
 		Timestamp:   time.Now(),
 		SessionID:   os.Getenv("AILERON_SESSION_ID"),
 		Command:     command,

--- a/cmd/aileron-sh/main_test.go
+++ b/cmd/aileron-sh/main_test.go
@@ -7,6 +7,8 @@ import (
 	"path/filepath"
 	"strings"
 	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
 )
 
 // TestShimPassthrough verifies commands pass through without policy.
@@ -459,12 +461,13 @@ deny:
     description: "no recursive delete"
 `)
 
-	auditPath := filepath.Join(dir, "audit.jsonl")
+	stateDir := dir
+	auditPath := audit.DailyPath(stateDir)
 	cmd := exec.Command(binary, "-c", "rm -rf /something")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(),
 		"AILERON_REAL_SHELL=/bin/sh",
-		"AILERON_AUDIT_LOG="+auditPath,
+		"AILERON_AUDIT_DIR="+stateDir,
 		"AILERON_SESSION_ID=test-session",
 		"AILERON_AGENT=test",
 	)
@@ -493,12 +496,13 @@ version: 1
 default: ask
 `)
 
-	auditPath := filepath.Join(dir, "audit.jsonl")
+	stateDir := dir
+	auditPath := audit.DailyPath(stateDir)
 	cmd := exec.Command(binary, "-c", "docker run myimage")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(),
 		"AILERON_REAL_SHELL=/bin/sh",
-		"AILERON_AUDIT_LOG="+auditPath,
+		"AILERON_AUDIT_DIR="+stateDir,
 		"AILERON_SESSION_ID=test-session",
 	)
 	cmd.Run()
@@ -522,12 +526,13 @@ allow:
   - "echo *"
 `)
 
-	auditPath := filepath.Join(dir, "audit.jsonl")
+	stateDir := dir
+	auditPath := audit.DailyPath(stateDir)
 	cmd := exec.Command(binary, "-c", "echo audit-test")
 	cmd.Dir = dir
 	cmd.Env = append(os.Environ(),
 		"AILERON_REAL_SHELL=/bin/sh",
-		"AILERON_AUDIT_LOG="+auditPath,
+		"AILERON_AUDIT_DIR="+stateDir,
 		"AILERON_SESSION_ID=test-session",
 		"AILERON_AGENT=test",
 	)

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -1657,7 +1657,9 @@ func TestRunPolicySave_InvalidFlag(t *testing.T) {
 }
 
 func TestRunPolicySave_DefaultAuditLogPath(t *testing.T) {
-	// When --path is not given, runPolicySave uses ResolveAuditLogFromCwd.
+	// When --path is not given, runPolicySave uses ResolveAuditLogFromCwd
+	// which (post-ADR-0012) returns the user-scope audit state dir.
+	// Audit files live at <HOME>/.aileron/audit/audit-YYYY-MM-DD.jsonl.
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
 
@@ -1665,10 +1667,11 @@ func TestRunPolicySave_DefaultAuditLogPath(t *testing.T) {
 	os.Chdir(dir)
 	defer os.Chdir(oldWd)
 
-	// Create an audit file at the default location.
-	auditDir := filepath.Join(dir, ".aileron")
-	os.MkdirAll(auditDir, 0o755)
-	auditPath := filepath.Join(auditDir, "audit.jsonl")
+	// Create an audit file at today's daily-rotated location.
+	auditPath := audit.DailyPath(filepath.Join(dir, ".aileron"))
+	if err := os.MkdirAll(filepath.Dir(auditPath), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
 	audit.AppendShellEntry(auditPath, audit.ShellEntry{
 		SessionID: "s1", Command: "docker push myimage", Disposition: "ask_approved",
 	})

--- a/internal/app/handlers_status.go
+++ b/internal/app/handlers_status.go
@@ -119,39 +119,42 @@ func defaultVaultPath() string {
 	return filepath.Join(home, ".aileron", "secrets.json")
 }
 
-// resolveAuditPath returns the JSONL path the action-execution audit
-// store should write to, honoring AILERON_AUDIT_PATH.
+// resolveAuditStateDir returns the state directory the daily-rotated
+// audit log lives under, honoring AILERON_AUDIT_DIR.
 //
-//   - env unset → default `<home>/.aileron/audit.jsonl`
+//   - env unset → default `<home>/.aileron`
 //   - env explicitly empty → "" (caller falls back to in-memory store)
 //   - env set → that exact path
-func resolveAuditPath() string {
-	if p, ok := os.LookupEnv("AILERON_AUDIT_PATH"); ok {
+//
+// The audit JSONL files themselves live at
+// `<stateDir>/audit/audit-YYYY-MM-DD.jsonl` per ADR-0012.
+func resolveAuditStateDir() string {
+	if p, ok := os.LookupEnv("AILERON_AUDIT_DIR"); ok {
 		return p
 	}
 	home, err := os.UserHomeDir()
 	if err != nil {
-		return filepath.Join(".aileron", "audit.jsonl")
+		return ".aileron"
 	}
-	return filepath.Join(home, ".aileron", "audit.jsonl")
+	return filepath.Join(home, ".aileron")
 }
 
 // newAuditStore picks the audit-store implementation per
-// resolveAuditPath. A file-open failure logs a warning and falls back
-// to in-memory so the daemon still starts (degraded durability beats
-// no daemon).
+// resolveAuditStateDir. A directory-open failure logs a warning and
+// falls back to in-memory so the daemon still starts (degraded
+// durability beats no daemon).
 func newAuditStore(log *slog.Logger) audit.EventStore {
-	path := resolveAuditPath()
-	if path == "" {
-		log.Info("audit store: in-memory; events will not survive daemon restart (set AILERON_AUDIT_PATH to enable persistence)")
+	stateDir := resolveAuditStateDir()
+	if stateDir == "" {
+		log.Info("audit store: in-memory; events will not survive daemon restart (set AILERON_AUDIT_DIR to enable persistence)")
 		return audit.NewMemStore()
 	}
-	fs, err := audit.NewFileStore(path, log)
+	fs, err := audit.NewFileStore(stateDir, log)
 	if err != nil {
-		log.Warn("audit store: could not open file, falling back to in-memory",
-			"path", path, "error", err.Error())
+		log.Warn("audit store: could not open daily-rotated dir, falling back to in-memory",
+			"state_dir", stateDir, "error", err.Error())
 		return audit.NewMemStore()
 	}
-	log.Info("audit store: file-backed", "path", path)
+	log.Info("audit store: file-backed", "dir", audit.DailyDir(stateDir))
 	return fs
 }

--- a/internal/app/handlers_status_test.go
+++ b/internal/app/handlers_status_test.go
@@ -263,40 +263,40 @@ func TestDefaultVaultPath_FromHome(t *testing.T) {
 	}
 }
 
-// TestResolveAuditPath_DefaultsToHome asserts the env-unset path
-// lands at `<home>/.aileron/audit.jsonl`.
-func TestResolveAuditPath_DefaultsToHome(t *testing.T) {
+// TestResolveAuditStateDir_DefaultsToHome asserts the env-unset path
+// lands at `<home>/.aileron`.
+func TestResolveAuditStateDir_DefaultsToHome(t *testing.T) {
 	t.Setenv("HOME", "/test/home")
-	os.Unsetenv("AILERON_AUDIT_PATH")
-	got := resolveAuditPath()
-	want := filepath.Join("/test/home", ".aileron", "audit.jsonl")
+	os.Unsetenv("AILERON_AUDIT_DIR")
+	got := resolveAuditStateDir()
+	want := filepath.Join("/test/home", ".aileron")
 	if got != want {
-		t.Errorf("resolveAuditPath = %q, want %q", got, want)
+		t.Errorf("resolveAuditStateDir = %q, want %q", got, want)
 	}
 }
 
-// TestResolveAuditPath_RespectsEnvVar asserts that an explicit env
+// TestResolveAuditStateDir_RespectsEnvVar asserts that an explicit env
 // value (including an empty string for the in-memory opt-out)
 // supersedes the home-based default.
-func TestResolveAuditPath_RespectsEnvVar(t *testing.T) {
-	t.Setenv("AILERON_AUDIT_PATH", "/tmp/x/y/audit.jsonl")
-	if got := resolveAuditPath(); got != "/tmp/x/y/audit.jsonl" {
-		t.Errorf("resolveAuditPath = %q, want explicit", got)
+func TestResolveAuditStateDir_RespectsEnvVar(t *testing.T) {
+	t.Setenv("AILERON_AUDIT_DIR", "/tmp/x/y")
+	if got := resolveAuditStateDir(); got != "/tmp/x/y" {
+		t.Errorf("resolveAuditStateDir = %q, want explicit", got)
 	}
-	t.Setenv("AILERON_AUDIT_PATH", "")
-	if got := resolveAuditPath(); got != "" {
-		t.Errorf("resolveAuditPath with empty env = %q, want empty (memory opt-out)", got)
+	t.Setenv("AILERON_AUDIT_DIR", "")
+	if got := resolveAuditStateDir(); got != "" {
+		t.Errorf("resolveAuditStateDir with empty env = %q, want empty (memory opt-out)", got)
 	}
 }
 
 // TestNewAuditStore_FileBackedByDefault asserts that the wiring
-// chooses FileStore when AILERON_AUDIT_PATH points at a writable
-// path. Regression guard for the bug behind issue #412: events
-// recorded under aileron launch did not survive process exit.
+// chooses FileStore when AILERON_AUDIT_DIR points at a writable
+// directory, and that events round-trip through today's daily file.
+// Regression guard for the bug behind issue #412: events recorded
+// under aileron launch did not survive process exit.
 func TestNewAuditStore_FileBackedByDefault(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "audit.jsonl")
-	t.Setenv("AILERON_AUDIT_PATH", path)
+	t.Setenv("AILERON_AUDIT_DIR", dir)
 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	store := newAuditStore(log)
@@ -304,14 +304,14 @@ func TestNewAuditStore_FileBackedByDefault(t *testing.T) {
 		t.Fatalf("got %T, want *audit.FileStore", store)
 	}
 
-	// Round-trip through the file: append, then a fresh FileStore
+	// Round-trip through the daily file: append, then a fresh FileStore
 	// must surface the same event after replay.
 	if err := store.Append(context.Background(), audit.Event{
 		EventID: "wired", Timestamp: time.Now(),
 	}); err != nil {
 		t.Fatalf("Append: %v", err)
 	}
-	reopened, err := audit.NewFileStore(path, log)
+	reopened, err := audit.NewFileStore(dir, log)
 	if err != nil {
 		t.Fatalf("NewFileStore: %v", err)
 	}
@@ -322,12 +322,12 @@ func TestNewAuditStore_FileBackedByDefault(t *testing.T) {
 
 // TestNewAuditStore_FallsBackToMemoryWhenEnvEmpty asserts the explicit
 // in-memory opt-out path: tests and ephemeral contexts that set
-// `AILERON_AUDIT_PATH=` (empty) get a MemStore back.
+// `AILERON_AUDIT_DIR=` (empty) get a MemStore back.
 func TestNewAuditStore_FallsBackToMemoryWhenEnvEmpty(t *testing.T) {
-	t.Setenv("AILERON_AUDIT_PATH", "")
+	t.Setenv("AILERON_AUDIT_DIR", "")
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	store := newAuditStore(log)
 	if _, ok := store.(*audit.MemStore); !ok {
-		t.Errorf("got %T, want *audit.MemStore for empty AILERON_AUDIT_PATH", store)
+		t.Errorf("got %T, want *audit.MemStore for empty AILERON_AUDIT_DIR", store)
 	}
 }

--- a/internal/audit/dailypath.go
+++ b/internal/audit/dailypath.go
@@ -1,0 +1,32 @@
+package audit
+
+import (
+	"path/filepath"
+	"time"
+)
+
+// dailyDir is the subdirectory under a state dir that holds the
+// daily-rotated audit JSONL files.
+const dailyDir = "audit"
+
+// DailyPath returns today's audit JSONL file path inside stateDir,
+// using the local clock. The file is `<stateDir>/audit/audit-YYYY-MM-DD.jsonl`.
+//
+// Production callers compute the path on each write so a session that
+// crosses midnight rolls naturally to the next day's file.
+func DailyPath(stateDir string) string {
+	return DailyPathAt(stateDir, time.Now())
+}
+
+// DailyPathAt is the time-injectable variant of [DailyPath]. Tests use
+// it to drive midnight-rollover scenarios without sleeping.
+func DailyPathAt(stateDir string, t time.Time) string {
+	return filepath.Join(stateDir, dailyDir, "audit-"+t.Format("2006-01-02")+".jsonl")
+}
+
+// DailyDir returns the subdirectory path the daily files live in:
+// `<stateDir>/audit`. Useful for read-side callers that scan across
+// every daily file (e.g., `aileron policy save`).
+func DailyDir(stateDir string) string {
+	return filepath.Join(stateDir, dailyDir)
+}

--- a/internal/audit/dailypath_test.go
+++ b/internal/audit/dailypath_test.go
@@ -1,0 +1,45 @@
+package audit_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+)
+
+func TestDailyPathAt_FormatsYYYYMMDD(t *testing.T) {
+	stateDir := "/home/user/.aileron"
+	got := audit.DailyPathAt(stateDir, time.Date(2026, 5, 5, 14, 22, 3, 0, time.UTC))
+	want := filepath.Join(stateDir, "audit", "audit-2026-05-05.jsonl")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestDailyPathAt_RollsOverAtMidnight(t *testing.T) {
+	stateDir := "/x"
+	beforeMidnight := time.Date(2026, 5, 5, 23, 59, 59, 999_000_000, time.UTC)
+	afterMidnight := time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)
+
+	if a, b := audit.DailyPathAt(stateDir, beforeMidnight), audit.DailyPathAt(stateDir, afterMidnight); a == b {
+		t.Fatalf("daily path should differ across midnight; both = %q", a)
+	}
+}
+
+func TestDailyPath_UsesNowAndStateDir(t *testing.T) {
+	got := audit.DailyPath("/home/user/.aileron")
+	if !strings.HasPrefix(got, "/home/user/.aileron/audit/audit-") {
+		t.Fatalf("unexpected prefix: %q", got)
+	}
+	if !strings.HasSuffix(got, ".jsonl") {
+		t.Fatalf("missing .jsonl suffix: %q", got)
+	}
+}
+
+func TestDailyDir_IsAuditSubdir(t *testing.T) {
+	if got, want := audit.DailyDir("/x"), filepath.Join("/x", "audit"); got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}

--- a/internal/audit/file.go
+++ b/internal/audit/file.go
@@ -8,24 +8,26 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"sort"
 	"sync"
 
 	"github.com/ALRubinger/aileron/internal/model"
 )
 
 // FileStore is a JSONL-backed audit store: one event per line,
-// append-only, durable across daemon restarts. Reads are served
-// from an in-memory index rebuilt at startup, so the on-disk file is
-// authoritative and the in-memory copy is a cache.
+// daily-rotated under <stateDir>/audit/audit-YYYY-MM-DD.jsonl per
+// ADR-0012. Append computes today's path on every write; replay scans
+// every daily file in the directory at startup. Reads are served from
+// an in-memory index, so the on-disk files are authoritative and the
+// in-memory copy is a cache.
 //
 // Per ADR-0010 this is the v0.x persistence target — Postgres /
-// signed log are post-MVP and operate over the same SPI. Rotation,
-// retention, and dedup are deliberately not implemented.
+// signed log are post-MVP and operate over the same SPI.
 type FileStore struct {
-	path string
-	log  *slog.Logger
-	mu   sync.Mutex // serializes appends so file order matches mem order
-	mem  *MemStore  // hydrated from the file at New, then write-through
+	stateDir string
+	log      *slog.Logger
+	mu       sync.Mutex // serializes appends so file order matches mem order
+	mem      *MemStore  // hydrated from the daily files at New, then write-through
 }
 
 // fileLine is the on-disk JSONL shape: the SPI Event plus the
@@ -38,24 +40,24 @@ type fileLine struct {
 	Event       Event  `json:"event"`
 }
 
-// NewFileStore opens (or creates) a JSONL audit log at path and
-// returns a FileStore whose in-memory index is replayed from the
-// file. Malformed lines are skipped with a warning so a single
-// corrupt entry can't make the daemon refuse to start; the rest of
-// the file is still loaded.
+// NewFileStore opens (or creates) the daily-rotated audit log under
+// stateDir and returns a FileStore whose in-memory index is replayed
+// from every audit-*.jsonl file in <stateDir>/audit/. Malformed lines
+// are skipped with a warning so a single corrupt entry can't make the
+// daemon refuse to start; the rest of the file is still loaded.
 //
 // log may be nil; in that case warnings are routed to slog.Default.
-func NewFileStore(path string, log *slog.Logger) (*FileStore, error) {
+func NewFileStore(stateDir string, log *slog.Logger) (*FileStore, error) {
 	if log == nil {
 		log = slog.Default()
 	}
-	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
-		return nil, fmt.Errorf("creating audit log directory: %w", err)
+	if err := os.MkdirAll(DailyDir(stateDir), 0o755); err != nil {
+		return nil, fmt.Errorf("creating audit directory: %w", err)
 	}
 	fs := &FileStore{
-		path: path,
-		log:  log,
-		mem:  NewMemStore(),
+		stateDir: stateDir,
+		log:      log,
+		mem:      NewMemStore(),
 	}
 	if err := fs.replay(); err != nil {
 		return nil, err
@@ -63,22 +65,50 @@ func NewFileStore(path string, log *slog.Logger) (*FileStore, error) {
 	return fs, nil
 }
 
-// Path returns the JSONL file path the store is backed by. Useful
-// for status surfaces (e.g. `aileron status`) and tests.
-func (fs *FileStore) Path() string { return fs.path }
+// StateDir returns the state directory the daily files live under.
+// Useful for status surfaces (e.g. `aileron status`) and tests.
+func (fs *FileStore) StateDir() string { return fs.stateDir }
 
+// replay reads every audit-*.jsonl file in DailyDir(stateDir), sorted
+// by name (which is chronological since filenames embed YYYY-MM-DD),
+// and replays each into the in-memory index.
 func (fs *FileStore) replay() error {
-	f, err := os.Open(fs.path)
+	dir := DailyDir(fs.stateDir)
+	entries, err := os.ReadDir(dir)
 	if err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
-		return fmt.Errorf("opening audit log: %w", err)
+		return fmt.Errorf("listing audit directory: %w", err)
+	}
+	files := make([]string, 0, len(entries))
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			continue
+		}
+		// Match `audit-*.jsonl` only — ignore stray files.
+		if !isAuditFileName(name) {
+			continue
+		}
+		files = append(files, name)
+	}
+	sort.Strings(files)
+	for _, name := range files {
+		if err := fs.replayFile(filepath.Join(dir, name)); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+func (fs *FileStore) replayFile(path string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return fmt.Errorf("opening audit log %s: %w", path, err)
 	}
 	defer f.Close()
 	scanner := bufio.NewScanner(f)
-	// Default Scanner buffer is 64KiB; raise to handle large
-	// payloads (failure events with deep details). 1 MiB cap.
 	const maxLine = 1 << 20
 	scanner.Buffer(make([]byte, 0, 64<<10), maxLine)
 	lineNo := 0
@@ -93,7 +123,7 @@ func (fs *FileStore) replay() error {
 		if err := json.Unmarshal(raw, &line); err != nil {
 			bad++
 			fs.log.Warn("audit: skipped malformed line during replay",
-				"path", fs.path, "line", lineNo, "error", err.Error())
+				"path", path, "line", lineNo, "error", err.Error())
 			continue
 		}
 		if line.TraceID == "" && line.IntentID == "" && line.WorkspaceID == "" {
@@ -104,18 +134,18 @@ func (fs *FileStore) replay() error {
 		}
 	}
 	if err := scanner.Err(); err != nil {
-		return fmt.Errorf("scanning audit log: %w", err)
+		return fmt.Errorf("scanning audit log %s: %w", path, err)
 	}
 	if bad > 0 {
 		fs.log.Warn("audit: replay completed with skipped lines",
-			"path", fs.path, "skipped", bad, "loaded", lineNo-bad)
+			"path", path, "skipped", bad, "loaded", lineNo-bad)
 	}
 	return nil
 }
 
-// Append persists the event to the file and the in-memory index.
-// Both must succeed for Append to return nil; a write to disk that
-// fails surfaces to the recorder, which logs and continues per
+// Append persists the event to today's daily file and the in-memory
+// index. Both must succeed for Append to return nil; a write to disk
+// that fails surfaces to the recorder, which logs and continues per
 // ADR-0010's best-effort recording.
 func (fs *FileStore) Append(ctx context.Context, event Event) error {
 	fs.mu.Lock()
@@ -126,8 +156,8 @@ func (fs *FileStore) Append(ctx context.Context, event Event) error {
 	return fs.mem.Append(ctx, event)
 }
 
-// AppendToTrace persists the trace-correlated event to the file and
-// the in-memory index.
+// AppendToTrace persists the trace-correlated event to today's daily
+// file and the in-memory index.
 func (fs *FileStore) AppendToTrace(ctx context.Context, traceID, intentID, workspaceID string, event Event) error {
 	fs.mu.Lock()
 	defer fs.mu.Unlock()
@@ -143,9 +173,10 @@ func (fs *FileStore) AppendToTrace(ctx context.Context, traceID, intentID, works
 }
 
 func (fs *FileStore) writeLine(line fileLine) error {
-	f, err := os.OpenFile(fs.path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	path := DailyPath(fs.stateDir)
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
 	if err != nil {
-		return fmt.Errorf("opening audit log: %w", err)
+		return fmt.Errorf("opening audit log %s: %w", path, err)
 	}
 	defer f.Close()
 	data, err := json.Marshal(line)
@@ -177,6 +208,17 @@ func (fs *FileStore) ListTraces(ctx context.Context, filter Filter) ([]Trace, er
 // GetTrace delegates to the in-memory index.
 func (fs *FileStore) GetTrace(ctx context.Context, traceID string) (Trace, error) {
 	return fs.mem.GetTrace(ctx, traceID)
+}
+
+// isAuditFileName matches "audit-YYYY-MM-DD.jsonl" loosely — we
+// accept anything starting with "audit-" and ending in ".jsonl" so
+// future date formats don't break replay.
+func isAuditFileName(name string) bool {
+	const prefix = "audit-"
+	const suffix = ".jsonl"
+	return len(name) > len(prefix)+len(suffix) &&
+		name[:len(prefix)] == prefix &&
+		name[len(name)-len(suffix):] == suffix
 }
 
 // Compile-time check that FileStore satisfies the audit-store

--- a/internal/audit/file_extra_test.go
+++ b/internal/audit/file_extra_test.go
@@ -1,0 +1,119 @@
+package audit_test
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+)
+
+func TestNewFileStore_FailsWhenParentIsFile(t *testing.T) {
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Try to use a path under a regular file as the state dir —
+	// MkdirAll for <blocker>/sub/audit must fail.
+	_, err := audit.NewFileStore(filepath.Join(blocker, "sub"), slog.Default())
+	if err == nil {
+		t.Fatal("NewFileStore should fail when parent is a file")
+	}
+}
+
+func TestNewFileStore_FailsWhenReplayCannotOpen(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod-based access denial is bypassed")
+	}
+	dir := t.TempDir()
+	auditDir := audit.DailyDir(dir)
+	if err := os.MkdirAll(auditDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Seed a daily file then strip read perms — replay should error
+	// rather than silently skip the file (we'd lose history).
+	path := filepath.Join(auditDir, "audit-2026-05-04.jsonl")
+	if err := os.WriteFile(path, []byte(`{"event":{"EventID":"x","Timestamp":"2026-05-04T00:00:00Z"}}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	_, err := audit.NewFileStore(dir, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err == nil {
+		t.Fatal("NewFileStore should propagate replay open error")
+	}
+}
+
+func TestNewFileStore_FailsWhenAuditDirCannotBeListed(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod-based access denial is bypassed")
+	}
+	dir := t.TempDir()
+	auditDir := audit.DailyDir(dir)
+	if err := os.MkdirAll(auditDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// Make the audit dir unreadable so ReadDir during replay fails.
+	if err := os.Chmod(auditDir, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(auditDir, 0o755) })
+
+	_, err := audit.NewFileStore(dir, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err == nil {
+		t.Fatal("NewFileStore should propagate ReadDir failure")
+	}
+}
+
+func TestFileStore_AppendFailsOnReadOnlyAuditDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod-based access denial is bypassed")
+	}
+	dir := t.TempDir()
+	store, err := audit.NewFileStore(dir, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	// Lock the audit subdir so the per-write OpenFile in writeLine
+	// (O_CREATE) cannot create today's file.
+	auditDir := audit.DailyDir(dir)
+	if err := os.Chmod(auditDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(auditDir, 0o755) })
+
+	err = store.Append(context.Background(), audit.Event{EventID: "x", Timestamp: time.Now().UTC()})
+	if err == nil {
+		t.Fatal("Append should fail when writeLine cannot open the daily file")
+	}
+}
+
+func TestFileStore_AppendToTraceFailsOnReadOnlyAuditDir(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod-based access denial is bypassed")
+	}
+	dir := t.TempDir()
+	store, err := audit.NewFileStore(dir, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	auditDir := audit.DailyDir(dir)
+	if err := os.Chmod(auditDir, 0o500); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(auditDir, 0o755) })
+
+	err = store.AppendToTrace(context.Background(), "tid", "iid", "wid",
+		audit.Event{EventID: "x", Timestamp: time.Now().UTC()})
+	if err == nil {
+		t.Fatal("AppendToTrace should fail when writeLine cannot open the daily file")
+	}
+}

--- a/internal/audit/file_test.go
+++ b/internal/audit/file_test.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"io"
 	"log/slog"
 	"os"
 	"path/filepath"
@@ -25,15 +26,17 @@ import (
 //     entries are loaded and the bad line is logged.
 //   - Filter/limit semantics match MemStore (delegation, but pinned).
 
+// newTestFileStore returns a FileStore rooted at a fresh tempdir.
+// The second return is the state dir (so callers wanting to verify
+// today's daily file path can compute audit.DailyPath(dir)).
 func newTestFileStore(t *testing.T) (*audit.FileStore, string) {
 	t.Helper()
 	dir := t.TempDir()
-	path := filepath.Join(dir, "audit.jsonl")
-	store, err := audit.NewFileStore(path, slog.New(slog.NewTextHandler(os.Stderr, nil)))
+	store, err := audit.NewFileStore(dir, slog.New(slog.NewTextHandler(os.Stderr, nil)))
 	if err != nil {
 		t.Fatalf("NewFileStore: %v", err)
 	}
-	return store, path
+	return store, dir
 }
 
 func TestFileStore_AppendThenReopen_RoundTrip(t *testing.T) {
@@ -190,9 +193,11 @@ func TestFileStore_ConcurrentAppends_AllLand(t *testing.T) {
 
 func TestFileStore_MalformedLineSkippedWithWarning(t *testing.T) {
 	dir := t.TempDir()
-	path := filepath.Join(dir, "audit.jsonl")
-
-	// Pre-seed the file: one good entry, one corrupt line, one good entry.
+	// Pre-seed today's daily file: one good entry, one corrupt line, one good entry.
+	path := audit.DailyPath(dir)
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
 	good1 := `{"event":{"EventID":"good-1","EventType":"action.installed","Actor":{"ID":"user","Type":"human"},"Payload":{"name":"ship-update"},"Timestamp":"2026-05-01T00:00:00Z"}}`
 	good2 := `{"event":{"EventID":"good-2","EventType":"action.installed","Actor":{"ID":"user","Type":"human"},"Payload":{"name":"send-email"},"Timestamp":"2026-05-01T00:01:00Z"}}`
 	corrupt := `{this is not json`
@@ -203,7 +208,7 @@ func TestFileStore_MalformedLineSkippedWithWarning(t *testing.T) {
 
 	var logBuf bytes.Buffer
 	log := slog.New(slog.NewTextHandler(&logBuf, &slog.HandlerOptions{Level: slog.LevelWarn}))
-	store, err := audit.NewFileStore(path, log)
+	store, err := audit.NewFileStore(dir, log)
 	if err != nil {
 		t.Fatalf("NewFileStore: %v", err)
 	}
@@ -280,9 +285,60 @@ func TestFileStore_FilterAndLimitDelegateToMem(t *testing.T) {
 	}
 }
 
-func TestFileStore_PathReturnsConfiguredPath(t *testing.T) {
-	store, path := newTestFileStore(t)
-	if store.Path() != path {
-		t.Errorf("Path() = %q, want %q", store.Path(), path)
+func TestFileStore_StateDirReturnsConfiguredDir(t *testing.T) {
+	store, dir := newTestFileStore(t)
+	if store.StateDir() != dir {
+		t.Errorf("StateDir() = %q, want %q", store.StateDir(), dir)
+	}
+}
+
+// TestFileStore_ReplaysAcrossDailyFiles seeds two distinct audit-*.jsonl
+// files (older + newer) in <stateDir>/audit/ and asserts that opening
+// a fresh FileStore replays both, in chronological order.
+func TestFileStore_ReplaysAcrossDailyFiles(t *testing.T) {
+	dir := t.TempDir()
+	auditDir := audit.DailyDir(dir)
+	if err := os.MkdirAll(auditDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+
+	yesterday := `{"event":{"EventID":"yday","EventType":"action.installed","Actor":{"ID":"u","Type":"human"},"Payload":{},"Timestamp":"2026-05-04T10:00:00Z"}}` + "\n"
+	today := `{"event":{"EventID":"today","EventType":"action.installed","Actor":{"ID":"u","Type":"human"},"Payload":{},"Timestamp":"2026-05-05T10:00:00Z"}}` + "\n"
+
+	if err := os.WriteFile(filepath.Join(auditDir, "audit-2026-05-04.jsonl"), []byte(yesterday), 0o600); err != nil {
+		t.Fatalf("seed yesterday: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(auditDir, "audit-2026-05-05.jsonl"), []byte(today), 0o600); err != nil {
+		t.Fatalf("seed today: %v", err)
+	}
+	// A non-audit file in the same dir is ignored, not parsed.
+	if err := os.WriteFile(filepath.Join(auditDir, "README.txt"), []byte("ignore me"), 0o600); err != nil {
+		t.Fatalf("seed noise: %v", err)
+	}
+
+	store, err := audit.NewFileStore(dir, slog.New(slog.NewTextHandler(io.Discard, nil)))
+	if err != nil {
+		t.Fatalf("NewFileStore: %v", err)
+	}
+	if _, ok := store.GetByEventID("yday"); !ok {
+		t.Error("yesterday's event missing after replay")
+	}
+	if _, ok := store.GetByEventID("today"); !ok {
+		t.Error("today's event missing after replay")
+	}
+}
+
+// TestFileStore_AppendCreatesDailyFile asserts that an Append after a
+// fresh open creates today's audit-YYYY-MM-DD.jsonl file in
+// <stateDir>/audit/, not a flat file at the root.
+func TestFileStore_AppendCreatesDailyFile(t *testing.T) {
+	store, dir := newTestFileStore(t)
+	ev := audit.Event{EventID: "ping", Timestamp: time.Now().UTC()}
+	if err := store.Append(context.Background(), ev); err != nil {
+		t.Fatalf("Append: %v", err)
+	}
+	wantPath := audit.DailyPath(dir)
+	if _, err := os.Stat(wantPath); err != nil {
+		t.Fatalf("expected daily file at %s, got: %v", wantPath, err)
 	}
 }

--- a/internal/audit/local.go
+++ b/internal/audit/local.go
@@ -6,6 +6,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
 	"strings"
 	"time"
 )
@@ -47,7 +48,28 @@ func AppendShellEntry(path string, entry ShellEntry) error {
 
 // ReadShellEntries reads all JSONL entries from the audit log.
 // Malformed lines are silently skipped.
+//
+// path may be either a single JSONL file (legacy / test use) or the
+// daily-rotated directory `<stateDir>/audit/`. When it's a directory,
+// every `audit-*.jsonl` file inside is read, sorted by name (which is
+// chronological since filenames embed the date).
 func ReadShellEntries(path string) ([]ShellEntry, error) {
+	files, err := resolveAuditFiles(path)
+	if err != nil {
+		return nil, err
+	}
+	var entries []ShellEntry
+	for _, p := range files {
+		got, err := readShellEntriesFromFile(p)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, got...)
+	}
+	return entries, nil
+}
+
+func readShellEntriesFromFile(path string) ([]ShellEntry, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err
@@ -68,6 +90,42 @@ func ReadShellEntries(path string) ([]ShellEntry, error) {
 		entries = append(entries, entry)
 	}
 	return entries, scanner.Err()
+}
+
+// resolveAuditFiles returns the list of files to read for `path`.
+// If path is a directory, lists every `audit-*.jsonl` file inside,
+// sorted by name. If path is a file (or does not exist), returns
+// just that path.
+func resolveAuditFiles(path string) ([]string, error) {
+	info, err := os.Stat(path)
+	if err != nil {
+		// Caller-friendly: a missing file is an error from the
+		// stat below in readShellEntriesFromFile, not here.
+		if os.IsNotExist(err) {
+			return []string{path}, nil
+		}
+		return nil, err
+	}
+	if !info.IsDir() {
+		return []string{path}, nil
+	}
+	entries, err := os.ReadDir(path)
+	if err != nil {
+		return nil, err
+	}
+	var files []string
+	for _, e := range entries {
+		name := e.Name()
+		if e.IsDir() {
+			continue
+		}
+		if !isAuditFileName(name) {
+			continue
+		}
+		files = append(files, filepath.Join(path, name))
+	}
+	sort.Strings(files)
+	return files, nil
 }
 
 // ShellFilter specifies criteria for filtering audit entries.
@@ -113,7 +171,25 @@ func AppendMessageEntry(path string, entry MessageEntry) error {
 
 // ReadMessageEntries reads all message JSONL entries from the audit log.
 // Only entries with an "event" field are returned (shell entries are skipped).
+//
+// path follows the same dir-or-file rule as [ReadShellEntries].
 func ReadMessageEntries(path string) ([]MessageEntry, error) {
+	files, err := resolveAuditFiles(path)
+	if err != nil {
+		return nil, err
+	}
+	var entries []MessageEntry
+	for _, p := range files {
+		got, err := readMessageEntriesFromFile(p)
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, got...)
+	}
+	return entries, nil
+}
+
+func readMessageEntriesFromFile(path string) ([]MessageEntry, error) {
 	f, err := os.Open(path)
 	if err != nil {
 		return nil, err

--- a/internal/audit/local_extra_test.go
+++ b/internal/audit/local_extra_test.go
@@ -1,0 +1,199 @@
+package audit_test
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+)
+
+// ReadShellEntries / ReadMessageEntries delegate to resolveAuditFiles
+// for the dir-vs-file decision. These tests exercise that decision tree
+// through the public API.
+
+func TestReadShellEntries_DirectoryScansAuditFiles(t *testing.T) {
+	dir := t.TempDir()
+	// Two daily files plus a file that should be ignored (not "audit-...jsonl").
+	good1 := filepath.Join(dir, "audit-2026-05-04.jsonl")
+	good2 := filepath.Join(dir, "audit-2026-05-05.jsonl")
+	junk := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(good1, []byte(`{"session_id":"s1","disposition":"deny"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(good2, []byte(`{"session_id":"s2","disposition":"allow"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(junk, []byte("ignore me"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// A subdirectory in the same place should not crash the scan.
+	if err := os.MkdirAll(filepath.Join(dir, "subdir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := audit.ReadShellEntries(dir)
+	if err != nil {
+		t.Fatalf("ReadShellEntries: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+	// Sorted by name → 2026-05-04 first, 2026-05-05 second.
+	if entries[0].SessionID != "s1" || entries[1].SessionID != "s2" {
+		t.Errorf("entries out of order: %+v", entries)
+	}
+}
+
+func TestReadShellEntries_NonExistentPathReturnsErrorOnOpen(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "nope.jsonl")
+	_, err := audit.ReadShellEntries(missing)
+	if !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("want os.ErrNotExist, got %v", err)
+	}
+}
+
+func TestReadShellEntries_EmptyDirectoryReturnsEmpty(t *testing.T) {
+	entries, err := audit.ReadShellEntries(t.TempDir())
+	if err != nil {
+		t.Fatalf("ReadShellEntries: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Fatalf("got %d entries, want 0", len(entries))
+	}
+}
+
+func TestReadMessageEntries_DirectoryScans(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit-2026-05-05.jsonl")
+	// Mix message entries (have "event") and shell entries (no "event") in one file.
+	contents := strings.Join([]string{
+		`{"session_id":"s","event":"message_received","service":"slack","channel":"#x"}`,
+		`{"session_id":"s","disposition":"allow"}`,
+		`{"session_id":"s","event":"draft_requested","service":"slack","channel":"#x"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	entries, err := audit.ReadMessageEntries(dir)
+	if err != nil {
+		t.Fatalf("ReadMessageEntries: %v", err)
+	}
+	// Only the two with event should be returned.
+	if len(entries) != 2 {
+		t.Fatalf("got %d entries, want 2", len(entries))
+	}
+}
+
+func TestAppendShellEntry_FailsWhenParentIsFile(t *testing.T) {
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// path's parent (`blocker/sub`) cannot be created because `blocker` is a file.
+	err := audit.AppendShellEntry(filepath.Join(blocker, "sub", "audit.jsonl"), audit.ShellEntry{
+		Timestamp:   time.Now(),
+		SessionID:   "s",
+		Command:     "echo",
+		Disposition: "allow",
+	})
+	if err == nil {
+		t.Fatal("AppendShellEntry should fail when parent dir cannot be created")
+	}
+}
+
+func TestAppendMessageEntry_FailsWhenParentIsFile(t *testing.T) {
+	parent := t.TempDir()
+	blocker := filepath.Join(parent, "blocker")
+	if err := os.WriteFile(blocker, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := audit.AppendMessageEntry(filepath.Join(blocker, "sub", "audit.jsonl"), audit.MessageEntry{
+		Timestamp: time.Now(),
+		SessionID: "s",
+		Event:     "message_received",
+		Service:   "slack",
+		Channel:   "#x",
+	})
+	if err == nil {
+		t.Fatal("AppendMessageEntry should fail when parent dir cannot be created")
+	}
+}
+
+func TestAppendShellEntry_FailsWhenPathIsDirectory(t *testing.T) {
+	dir := t.TempDir() // existing directory; OpenFile with O_WRONLY fails
+	err := audit.AppendShellEntry(dir, audit.ShellEntry{
+		Timestamp:   time.Now(),
+		SessionID:   "s",
+		Command:     "echo",
+		Disposition: "allow",
+	})
+	if err == nil {
+		t.Fatal("AppendShellEntry should fail when path resolves to a directory")
+	}
+}
+
+func TestAppendMessageEntry_FailsWhenPathIsDirectory(t *testing.T) {
+	dir := t.TempDir()
+	err := audit.AppendMessageEntry(dir, audit.MessageEntry{
+		Timestamp: time.Now(),
+		SessionID: "s",
+		Event:     "message_received",
+		Service:   "slack",
+		Channel:   "#x",
+	})
+	if err == nil {
+		t.Fatal("AppendMessageEntry should fail when path resolves to a directory")
+	}
+}
+
+func TestReadShellEntriesFiltered_DirectoryAndFilters(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit-2026-05-05.jsonl")
+	contents := strings.Join([]string{
+		`{"session_id":"s1","command":"git push origin main","disposition":"deny","rule_id":"never-push-main"}`,
+		`{"session_id":"s2","command":"echo hi","disposition":"allow"}`,
+		`{"session_id":"s1","command":"echo bye","disposition":"allow"}`,
+	}, "\n") + "\n"
+	if err := os.WriteFile(path, []byte(contents), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := audit.ReadShellEntriesFiltered(dir, audit.ShellFilter{
+		SessionID:      "s1",
+		CommandPattern: "echo",
+	})
+	if err != nil {
+		t.Fatalf("ReadShellEntriesFiltered: %v", err)
+	}
+	if len(got) != 1 || got[0].Command != "echo bye" {
+		t.Fatalf("got %+v; want one entry: echo bye", got)
+	}
+}
+
+func TestReadShellEntries_DirectoryWithUnreadableEntryReturnsError(t *testing.T) {
+	if os.Getuid() == 0 {
+		t.Skip("running as root; chmod-based access denial is bypassed")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "audit-2026-05-05.jsonl")
+	if err := os.WriteFile(path, []byte(`{"session_id":"s"}`+"\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	// Strip read permission from the file; ReadShellEntries should
+	// surface the open error rather than silently succeed.
+	if err := os.Chmod(path, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(path, 0o600) })
+
+	_, err := audit.ReadShellEntries(dir)
+	if err == nil {
+		t.Fatal("expected error reading unreadable file")
+	}
+}

--- a/internal/launch/commsserver.go
+++ b/internal/launch/commsserver.go
@@ -71,7 +71,7 @@ type CommsServer struct {
 	listener    net.Listener
 	queue       *NotifyQueue
 	senders     map[string]comms.Listener
-	auditLog    string
+	auditStateDir    string
 	sessionID   string
 	secrets     launchpolicy.SecretsConfig
 	vault       vault.Vault
@@ -91,7 +91,7 @@ type CommsServer struct {
 // specific entries here and wait for the user to decide via the
 // webapp. Pass nil for the legacy fail-closed behaviour preserved
 // for callers that don't yet route through the queue.
-func NewCommsServer(socketPath string, queue *NotifyQueue, senders []comms.Listener, auditLog, sessionID string, approvals *approval.ActionApprovalQueue) (*CommsServer, error) {
+func NewCommsServer(socketPath string, queue *NotifyQueue, senders []comms.Listener, auditStateDir, sessionID string, approvals *approval.ActionApprovalQueue) (*CommsServer, error) {
 	os.Remove(socketPath)
 
 	ln, err := net.Listen("unix", socketPath)
@@ -109,7 +109,7 @@ func NewCommsServer(socketPath string, queue *NotifyQueue, senders []comms.Liste
 		listener:    ln,
 		queue:       queue,
 		senders:     senderMap,
-		auditLog:    auditLog,
+		auditStateDir:    auditStateDir,
 		sessionID:   sessionID,
 		approvals:   approvals,
 		approvalTTL: defaultCommsApprovalTimeout,
@@ -516,10 +516,10 @@ func RequestComms(socketPath string, req CommsRequest) CommsResponse {
 }
 
 func (cs *CommsServer) logMessage(event, service, channel, author, body, inReplyTo string) {
-	if cs.auditLog == "" {
+	if cs.auditStateDir == "" {
 		return
 	}
-	audit.AppendMessageEntry(cs.auditLog, audit.MessageEntry{
+	audit.AppendMessageEntry(audit.DailyPath(cs.auditStateDir), audit.MessageEntry{
 		Timestamp: time.Now(),
 		SessionID: cs.sessionID,
 		Event:     event,

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -151,13 +151,13 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	}
 
 	sessionID := generateSessionID()
-	auditLog := resolveAuditLog(config.Dir)
+	auditStateDir := resolveAuditStateDir()
 	envConfig := loadEnvConfig(config.Dir)
 	approvalSocket := filepath.Join(os.TempDir(), "ai-"+sessionID+".sock")
 	commsSocket := filepath.Join(os.TempDir(), "ai-comms-"+sessionID+".sock")
 
 	agentEnv := composeAgentEnv(config.Agent.Env(), config.Agent.LLMEndpointEnv(), gatewayURL(gateway))
-	env := buildEnv(config.ShellShim, config.Agent.Name(), sessionID, auditLog, envConfig, agentEnv)
+	env := buildEnv(config.ShellShim, config.Agent.Name(), sessionID, auditStateDir, envConfig, agentEnv)
 	env = append(env, "AILERON_APPROVAL_SOCKET="+approvalSocket)
 	env = append(env, "AILERON_COMMS_SOCKET="+commsSocket)
 
@@ -218,7 +218,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	// `read_messages` MCP tool. The webapp surface for surfacing
 	// these messages is a future addition (#418's followups);
 	// today the agent reads them via `aileron-mcp`.
-	listeners := startCommsListeners(ctx, config.Dir, queue, auditLog, sessionID, sessionLog)
+	listeners := startCommsListeners(ctx, config.Dir, queue, auditStateDir, sessionID, sessionLog)
 	defer stopCommsListeners(listeners)
 
 	// Comms server: same socket the pre-#419 launch exposed to
@@ -226,7 +226,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	// paths fail-closed under the new launch (no in-pty approval
 	// surface; webapp wire-through pending) — see commsserver.go for
 	// the regression detail.
-	commsSrv, err := NewCommsServer(commsSocket, queue, listeners, auditLog, sessionID, approvalQueue)
+	commsSrv, err := NewCommsServer(commsSocket, queue, listeners, auditStateDir, sessionID, approvalQueue)
 	if err != nil {
 		return LaunchResult{}, fmt.Errorf("starting comms server: %w", err)
 	}
@@ -261,8 +261,8 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	result, err := launchDirect(cmd, config)
 
 	sessionLog.Info("session ended", "exit_code", result.ExitCode)
-	if auditLog != "" {
-		PrintSessionSummary(os.Stderr, auditLog, sessionID)
+	if auditStateDir != "" {
+		PrintSessionSummary(os.Stderr, auditStateDir, sessionID)
 	}
 	return result, err
 }
@@ -335,7 +335,7 @@ func exitResult(err error) (LaunchResult, error) {
 //   - Replaces SHELL with the shim path
 //   - Sets AILERON_REAL_SHELL to the original SHELL value
 //   - Merges any agent-specific env vars (including agent-specific vars like CLAUDE_CODE_SHELL)
-func buildEnv(shimPath, agentName, sessionID, auditLog string, envConfig *launchpolicy.EnvConfig, agentEnv map[string]string) []string {
+func buildEnv(shimPath, agentName, sessionID, auditStateDir string, envConfig *launchpolicy.EnvConfig, agentEnv map[string]string) []string {
 	origShell := os.Getenv("SHELL")
 	if origShell == "" {
 		origShell = "/bin/sh"
@@ -355,7 +355,7 @@ func buildEnv(shimPath, agentName, sessionID, auditLog string, envConfig *launch
 		"AILERON_REAL_SHELL": true,
 		"AILERON_AGENT":      true,
 		"AILERON_SESSION_ID": true,
-		"AILERON_AUDIT_LOG":  true,
+		"AILERON_AUDIT_DIR":  true,
 	}
 	for k := range agentEnv {
 		managed[k] = true
@@ -383,8 +383,8 @@ func buildEnv(shimPath, agentName, sessionID, auditLog string, envConfig *launch
 	filtered = append(filtered, "AILERON_REAL_SHELL="+realShell)
 	filtered = append(filtered, "AILERON_AGENT="+agentName)
 	filtered = append(filtered, "AILERON_SESSION_ID="+sessionID)
-	if auditLog != "" {
-		filtered = append(filtered, "AILERON_AUDIT_LOG="+auditLog)
+	if auditStateDir != "" {
+		filtered = append(filtered, "AILERON_AUDIT_DIR="+auditStateDir)
 	}
 	for k, v := range agentEnv {
 		if k == "AILERON_REAL_SHELL" {
@@ -404,37 +404,29 @@ func generateSessionID() string {
 	return fmt.Sprintf("%x", b)
 }
 
-// ResolveAuditLogFromCwd resolves the audit log path from the current
-// working directory.
+// ResolveAuditLogFromCwd returns the audit subdirectory the
+// daily-rotated JSONL files live in (`~/.aileron/audit`). Pre-ADR-0012
+// this resolved per-project under the working directory and honored an
+// `aileron.yaml` `Settings.AuditLog` override; ADR-0012 centralizes
+// audit at user scope so all callers get the same path.
+//
+// The function name is kept for callers (`aileron policy save` etc.)
+// that read the audit log via the file system; under ADR-0012 it is
+// effectively a constant. Read helpers like
+// [audit.ReadShellEntriesFiltered] accept a directory and scan every
+// `audit-*.jsonl` file inside.
 func ResolveAuditLogFromCwd() string {
-	return resolveAuditLog("")
+	return audit.DailyDir(resolveAuditStateDir())
 }
 
-// resolveAuditLog determines the audit log path. It looks for
-// aileron.yaml in the given directory (or cwd) and reads its
-// Settings.AuditLog field. Falls back to .aileron/audit.jsonl
-// relative to the policy file's directory.
-func resolveAuditLog(dir string) string {
-	if dir == "" {
-		dir, _ = os.Getwd()
+// resolveAuditStateDir returns `~/.aileron`. The audit JSONL files
+// themselves live under `audit/audit-YYYY-MM-DD.jsonl` inside.
+func resolveAuditStateDir() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".aileron"
 	}
-	policyPath := FindPolicyFile(dir)
-	if policyPath == "" {
-		// No policy file — use cwd/.aileron/audit.jsonl.
-		return filepath.Join(dir, ".aileron", "audit.jsonl")
-	}
-
-	policyDir := filepath.Dir(policyPath)
-
-	pf := loadPolicyFileFrom(policyPath)
-	if pf.Settings != nil && pf.Settings.AuditLog != "" {
-		p := pf.Settings.AuditLog
-		if !filepath.IsAbs(p) {
-			p = filepath.Join(policyDir, p)
-		}
-		return p
-	}
-	return filepath.Join(policyDir, ".aileron", "audit.jsonl")
+	return filepath.Join(home, ".aileron")
 }
 
 // PrintSessionSummary reads the audit log for the given session and
@@ -630,7 +622,7 @@ func prepareCommsConfig(dir string, sessionLog *slog.Logger) *commsSetup {
 
 // startCommsWithVault resolves tokens (using the provided vault, which
 // may be nil), creates listeners, and starts them.
-func startCommsWithVault(ctx context.Context, setup *commsSetup, v vault.Vault, queue *NotifyQueue, auditLog, sessionID string) []comms.Listener {
+func startCommsWithVault(ctx context.Context, setup *commsSetup, v vault.Vault, queue *NotifyQueue, auditStateDir, sessionID string) []comms.Listener {
 	if setup == nil {
 		return nil
 	}
@@ -696,13 +688,13 @@ func startCommsWithVault(ctx context.Context, setup *commsSetup, v vault.Vault, 
 		created = append(created, dl)
 	}
 
-	return StartListeners(ctx, created, queue, os.Stderr, autoDraft, priority, auditLog, sessionID, sessionLog)
+	return StartListeners(ctx, created, queue, os.Stderr, autoDraft, priority, auditStateDir, sessionID, sessionLog)
 }
 
 // startCommsListeners is the legacy convenience wrapper that prepares
 // config, opens the vault via the old tty prompt, and starts listeners.
 // Used by the non-pty (direct) launch path.
-func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, auditLog, sessionID string, sessionLog *slog.Logger) []comms.Listener {
+func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, auditStateDir, sessionID string, sessionLog *slog.Logger) []comms.Listener {
 	setup := prepareCommsConfig(dir, sessionLog)
 	if setup == nil {
 		return nil
@@ -719,7 +711,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 		}
 	}
 
-	return startCommsWithVault(ctx, setup, v, queue, auditLog, sessionID)
+	return startCommsWithVault(ctx, setup, v, queue, auditStateDir, sessionID)
 }
 
 // StartListeners connects and starts each listener, bridging incoming
@@ -727,7 +719,7 @@ func startCommsListeners(ctx context.Context, dir string, queue *NotifyQueue, au
 // trigger automatic draft replies. The priority map controls the
 // priority level ("normal", "high") per channel. Returns the
 // successfully started listeners. Errors are written to w.
-func StartListeners(ctx context.Context, listeners []comms.Listener, queue *NotifyQueue, w io.Writer, autoDraft map[string]bool, priority map[string]string, auditLog, sessionID string, log *slog.Logger) []comms.Listener {
+func StartListeners(ctx context.Context, listeners []comms.Listener, queue *NotifyQueue, w io.Writer, autoDraft map[string]bool, priority map[string]string, auditStateDir, sessionID string, log *slog.Logger) []comms.Listener {
 	var started []comms.Listener
 	for _, l := range listeners {
 		if err := l.Connect(ctx); err != nil {
@@ -743,7 +735,7 @@ func StartListeners(ctx context.Context, listeners []comms.Listener, queue *Noti
 		}
 		log.Info("listener started", "service", l.Service())
 		started = append(started, l)
-		go BridgeMessages(msgs, queue, autoDraft, priority, auditLog, sessionID, log)
+		go BridgeMessages(msgs, queue, autoDraft, priority, auditStateDir, sessionID, log)
 	}
 	return started
 }
@@ -752,7 +744,7 @@ func StartListeners(ctx context.Context, listeners []comms.Listener, queue *Noti
 // into the NotifyQueue. The autoDraft map controls which channels trigger
 // automatic draft replies. The priority map sets the priority level per
 // channel. Exported for testing.
-func BridgeMessages(msgs <-chan comms.IncomingMessage, queue *NotifyQueue, autoDraft map[string]bool, priority map[string]string, auditLog, sessionID string, log *slog.Logger) {
+func BridgeMessages(msgs <-chan comms.IncomingMessage, queue *NotifyQueue, autoDraft map[string]bool, priority map[string]string, auditStateDir, sessionID string, log *slog.Logger) {
 	for msg := range msgs {
 		preview := msg.Body
 		if len(preview) > 80 {
@@ -780,8 +772,8 @@ func BridgeMessages(msgs <-chan comms.IncomingMessage, queue *NotifyQueue, autoD
 			AutoDraft: autoDraft[msg.Channel],
 			Priority:  pri,
 		})
-		if auditLog != "" {
-			audit.AppendMessageEntry(auditLog, audit.MessageEntry{
+		if auditStateDir != "" {
+			audit.AppendMessageEntry(audit.DailyPath(auditStateDir), audit.MessageEntry{
 				Timestamp: msg.Timestamp,
 				SessionID: sessionID,
 				Event:     "message_received",

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -418,48 +418,12 @@ env:
 
 func TestResolveAuditLogFromCwd(t *testing.T) {
 	dir := t.TempDir()
-	// No aileron.yaml → falls back to cwd/.aileron/audit.jsonl.
-	oldWd, _ := os.Getwd()
-	os.Chdir(dir)
-	defer os.Chdir(oldWd)
-
-	path := launch.ResolveAuditLogFromCwd()
-	if !strings.HasSuffix(path, filepath.Join(".aileron", "audit.jsonl")) {
-		t.Errorf("expected .aileron/audit.jsonl suffix, got %q", path)
-	}
-}
-
-func TestResolveAuditLogFromCwd_WithPolicy(t *testing.T) {
-	dir := t.TempDir()
 	t.Setenv("HOME", dir)
-	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte(`
-version: 1
-settings:
-  audit_log: custom/audit.log
-`), 0o644)
 
-	oldWd, _ := os.Getwd()
-	os.Chdir(dir)
-	defer os.Chdir(oldWd)
-
-	path := launch.ResolveAuditLogFromCwd()
-	if !strings.HasSuffix(path, filepath.Join("custom", "audit.log")) {
-		t.Errorf("expected custom/audit.log, got %q", path)
-	}
-}
-
-func TestResolveAuditLogFromCwd_DefaultWithPolicy(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	os.WriteFile(filepath.Join(dir, "aileron.yaml"), []byte("version: 1\n"), 0o644)
-
-	oldWd, _ := os.Getwd()
-	os.Chdir(dir)
-	defer os.Chdir(oldWd)
-
-	path := launch.ResolveAuditLogFromCwd()
-	if !strings.HasSuffix(path, filepath.Join(".aileron", "audit.jsonl")) {
-		t.Errorf("expected .aileron/audit.jsonl, got %q", path)
+	got := launch.ResolveAuditLogFromCwd()
+	want := filepath.Join(dir, ".aileron", "audit")
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
 	}
 }
 
@@ -844,18 +808,19 @@ notifications:
 }
 
 func TestBridgeMessages_AuditLog(t *testing.T) {
-	auditPath := filepath.Join(t.TempDir(), "audit.jsonl")
+	stateDir := t.TempDir()
 	queue := launch.NewNotifyQueue(10, nil)
 	msgs := make(chan comms.IncomingMessage, 2)
 
-	go launch.BridgeMessages(msgs, queue, nil, nil, auditPath, "test-session", nopLogger())
+	go launch.BridgeMessages(msgs, queue, nil, nil, stateDir, "test-session", nopLogger())
 
 	msgs <- comms.IncomingMessage{ID: "1", Service: "slack", Channel: "#backend", Author: "Alice", Body: "hello", Timestamp: time.Now()}
 	msgs <- comms.IncomingMessage{ID: "2", Service: "discord", Channel: "dev-chat", Author: "Bob", Body: "hi", Timestamp: time.Now()}
 	close(msgs)
 	time.Sleep(50 * time.Millisecond)
 
-	entries, err := audit.ReadMessageEntries(auditPath)
+	// Reader sees the daily-rotated layout: scan <stateDir>/audit/.
+	entries, err := audit.ReadMessageEntries(audit.DailyDir(stateDir))
 	if err != nil {
 		t.Fatal(err)
 	}

--- a/internal/policy/launch/loader.go
+++ b/internal/policy/launch/loader.go
@@ -158,9 +158,6 @@ func Merge(base, overlay *PolicyFile) *PolicyFile {
 		if overlay.Settings.AskMode != "" {
 			merged.AskMode = overlay.Settings.AskMode
 		}
-		if overlay.Settings.AuditLog != "" {
-			merged.AuditLog = overlay.Settings.AuditLog
-		}
 		if overlay.Settings.Timeout != 0 {
 			merged.Timeout = overlay.Settings.Timeout
 		}

--- a/internal/policy/launch/schema.go
+++ b/internal/policy/launch/schema.go
@@ -33,9 +33,8 @@ type SecretDef struct {
 
 // Settings holds launch session configuration.
 type Settings struct {
-	AskMode  string `yaml:"ask_mode,omitempty"`  // "terminal" or "ui"
-	AuditLog string `yaml:"audit_log,omitempty"` // path to audit log file
-	Timeout  int    `yaml:"timeout,omitempty"`   // seconds to wait for human response
+	AskMode string `yaml:"ask_mode,omitempty"` // "terminal" or "ui"
+	Timeout int    `yaml:"timeout,omitempty"`  // seconds to wait for human response
 }
 
 // NotifyConfig holds notification channel configuration for Slack and Discord.

--- a/internal/policy/launch/testdata/basic.yaml
+++ b/internal/policy/launch/testdata/basic.yaml
@@ -3,7 +3,6 @@ default: ask
 
 settings:
   ask_mode: terminal
-  audit_log: .aileron/audit.jsonl
   timeout: 30
 
 env:


### PR DESCRIPTION
## Summary

Step 5 of #454. Centralizes the audit log at `~/.aileron/audit/audit-YYYY-MM-DD.jsonl` per ADR-0012. Two existing locations collapse:

- `<cwd>/.aileron/audit.jsonl` (per-project) — gone.
- `~/.aileron/audit.jsonl` (single user-scope file added in #446) — gone.

Both replaced by the daily-rotated layout. Same data model, same EventStore SPI; only the layout and resolution paths change.

## Changes

- **`audit.DailyPath(stateDir)`** computes today's file. **`DailyDir(stateDir)`** is the audit subdirectory readers scan. **`DailyPathAt(stateDir, t)`** is the time-injectable variant tests use for midnight-rollover scenarios.
- **`FileStore` is daily-rotated:** constructor takes a state dir, `Append` opens today's file per write (no long-lived FD), `replay` scans every `audit-*.jsonl` in `<stateDir>/audit/` at startup. `Path()` → `StateDir()`. The EventStore interface is unchanged so `/v1/audit` reads work transparently.
- **Shell/message writers** (`aileron-sh`, `launcher`, `commsserver`) compute today's path via `audit.DailyPath(stateDir)` on every call so a session that crosses midnight rolls naturally.
- **Read API** (`ReadShellEntries`, `ReadMessageEntries`, `ReadShellEntriesFiltered`) accepts either a single file path or a directory of daily files via a new `resolveAuditFiles` helper.
- **`launch.ResolveAuditLogFromCwd`** returns `~/.aileron/audit` (the daily-files subdir). Stops reading `aileron.yaml`'s `Settings.AuditLog`; that field is removed from the schema and from any test fixtures.
- **Daemon env:** `AILERON_AUDIT_PATH` (file) → `AILERON_AUDIT_DIR` (state dir). Matches launch's `AILERON_AUDIT_DIR` so the two writers point at the same root.

## Test plan

- [x] `go test ./internal/audit/... ./internal/launch/... ./internal/policy/... ./internal/app/... ./cmd/aileron-sh/... ./cmd/aileron/... -race` is green.
- [x] `go vet ./...` is clean.
- [x] `task test:go:cover` total: 81.6%. Audit package per-function coverage 62-100% (the lower numbers are structural error paths in `NewFileStore` / `writeLine` that aren't worth fault injection).
- [x] Daily-rotation tests cover: `DailyPathAt` formats `YYYY-MM-DD`, rolls across midnight, `DailyDir` is the `audit/` subdir; `FileStore` replays across multiple daily files; `Append` creates today's file in the daily layout.
- [x] Existing audit handler tests (`/v1/audit`, `/v1/audit/{id}`) unchanged and green — they read through the EventStore SPI which doesn't change shape.

## Notes

- No backwards compat for old paths. Per the no-backwards-compat-before-release policy and ADR-0012, anyone with an existing `~/.aileron/audit.jsonl` won't have it migrated; the file is just ignored. Documentation calls this out.
- `Settings.AuditLog` removal touches `internal/policy/launch/schema.go` + `loader.go` + the `testdata/basic.yaml` fixture. No production users since the project hasn't shipped.
- The `aileron.yaml` `audit_log` field was the only audit-path knob users ever had. Going forward there's `AILERON_AUDIT_DIR` for tests/dev overrides; production is constant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)