### PR TITLE
feat(daemon): add client-side auto-spawn helper

### DIFF
--- a/internal/daemon/spawn/spawn.go
+++ b/internal/daemon/spawn/spawn.go
@@ -1,0 +1,216 @@
+// Package spawn is the client-side helper for finding (or starting)
+// the Aileron daemon. CLI commands and `aileron launch` call
+// [Resolve] before they make any HTTP request; the helper either
+// returns an already-running daemon's URL or fork-execs a fresh
+// daemon and waits for its discovery file to appear.
+//
+// Concurrency invariant: multiple clients racing on first run all
+// observe a single spawn. The spawn-coordination uses
+// [discovery.Lock] held briefly across the SpawnFn call; the daemon's
+// own startup lock independently guards against duplicate daemons,
+// so even if two clients somehow trip the spawn at once only one
+// daemon survives.
+//
+// See ADR-0012.
+package spawn
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"net"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"syscall"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
+)
+
+// Options configures Resolve.
+type Options struct {
+	// StateDir holds discovery files (daemon.json, daemon.lock).
+	// Required.
+	StateDir string
+
+	// SpawnFn brings a daemon up. Defaults to fork-execing Binary
+	// (with BinaryArgs) detached from the parent. Tests substitute
+	// a function that synthetically writes daemon.json so the helper
+	// can be exercised without an OS process.
+	SpawnFn func(ctx context.Context, stateDir string) error
+
+	// Binary is the daemon binary path used by the default SpawnFn.
+	// Ignored when SpawnFn is set.
+	Binary string
+
+	// BinaryArgs are forwarded to Binary by the default SpawnFn.
+	BinaryArgs []string
+
+	// SpawnTimeout caps how long Resolve waits for daemon.json after
+	// triggering a spawn. Default 5s.
+	SpawnTimeout time.Duration
+
+	// PollInterval is how often Resolve polls daemon.json after
+	// spawning. Default 50ms.
+	PollInterval time.Duration
+
+	// LivenessTimeout caps the TCP-connect liveness probe per
+	// daemon.json read. Default 200ms.
+	LivenessTimeout time.Duration
+
+	// EnvLookup overrides os.Getenv. Tests inject this to drive the
+	// AILERON_API_URL fast path in isolation.
+	EnvLookup func(string) string
+}
+
+// ErrNoBinary is returned when SpawnFn is unset and Binary is empty —
+// the helper has nothing to fork-exec.
+var ErrNoBinary = errors.New("daemon binary path is empty (set Options.Binary)")
+
+// Resolve returns the URL of the running Aileron daemon, spawning
+// one if none is reachable. The fast path is one daemon.json read
+// plus a sub-millisecond TCP probe; the spawn path acquires a
+// singleton lock, runs SpawnFn, and polls daemon.json for the
+// configured SpawnTimeout.
+func Resolve(ctx context.Context, opts Options) (string, error) {
+	if opts.StateDir == "" {
+		return "", errors.New("spawn: StateDir is required")
+	}
+	if opts.EnvLookup == nil {
+		opts.EnvLookup = os.Getenv
+	}
+	if v := opts.EnvLookup("AILERON_API_URL"); v != "" {
+		return v, nil
+	}
+
+	if opts.SpawnTimeout <= 0 {
+		opts.SpawnTimeout = 5 * time.Second
+	}
+	if opts.PollInterval <= 0 {
+		opts.PollInterval = 50 * time.Millisecond
+	}
+	if opts.LivenessTimeout <= 0 {
+		opts.LivenessTimeout = 200 * time.Millisecond
+	}
+	if opts.SpawnFn == nil {
+		opts.SpawnFn = forkExec(opts.Binary, opts.BinaryArgs)
+	}
+
+	// Fast path: daemon already running and reachable.
+	if url, ok := readAlive(opts.StateDir, opts.LivenessTimeout); ok {
+		return url, nil
+	}
+
+	// Singleton spawn lock — at most one client triggers SpawnFn.
+	lockCtx, cancelLock := context.WithTimeout(ctx, 2*time.Second)
+	release, err := discovery.Lock(lockCtx, opts.StateDir)
+	cancelLock()
+	if err != nil {
+		return "", fmt.Errorf("spawn: acquire lock: %w", err)
+	}
+	// Release the lock as soon as SpawnFn returns and (in the default
+	// fork-exec case) the daemon's own startup lock takes over. We
+	// hold the lock through the polling loop too — clients that race
+	// past us will block on this lock and re-check daemon.json on
+	// acquire, avoiding redundant fork-execs.
+	defer func() { _ = release() }()
+
+	// Re-check after lock — another client may have spawned during
+	// our lock-acquire window.
+	if url, ok := readAlive(opts.StateDir, opts.LivenessTimeout); ok {
+		return url, nil
+	}
+
+	if err := opts.SpawnFn(ctx, opts.StateDir); err != nil {
+		return "", fmt.Errorf("spawn: %w", err)
+	}
+
+	return waitForDaemon(ctx, opts)
+}
+
+// waitForDaemon polls daemon.json until the daemon is reachable or
+// the SpawnTimeout deadline expires.
+func waitForDaemon(ctx context.Context, opts Options) (string, error) {
+	deadline := time.Now().Add(opts.SpawnTimeout)
+	for {
+		if url, ok := readAlive(opts.StateDir, opts.LivenessTimeout); ok {
+			return url, nil
+		}
+		if time.Now().After(deadline) {
+			return "", fmt.Errorf("spawn: daemon did not become ready within %s", opts.SpawnTimeout)
+		}
+		select {
+		case <-ctx.Done():
+			return "", ctx.Err()
+		case <-time.After(opts.PollInterval):
+		}
+	}
+}
+
+// readAlive reads daemon.json and TCP-probes the URL. Returns the
+// URL only when both succeed.
+func readAlive(stateDir string, livenessTimeout time.Duration) (string, bool) {
+	info, err := discovery.Read(stateDir)
+	if err != nil {
+		return "", false
+	}
+	addr, err := urlToHostPort(info.URL)
+	if err != nil {
+		return "", false
+	}
+	conn, err := net.DialTimeout("tcp", addr, livenessTimeout)
+	if err != nil {
+		return "", false
+	}
+	_ = conn.Close()
+	return info.URL, true
+}
+
+// urlToHostPort extracts host:port from `http://host:port` without
+// pulling in net/url. The daemon URL shape is fixed by ADR-0012.
+func urlToHostPort(u string) (string, error) {
+	const prefix = "http://"
+	if !strings.HasPrefix(u, prefix) {
+		return "", fmt.Errorf("expected http:// URL, got %q", u)
+	}
+	return u[len(prefix):], nil
+}
+
+// forkExec returns a SpawnFn that fork-execs binary with args. The
+// daemon's stdio is detached and redirected to <stateDir>/daemon.log
+// so it survives the parent's exit and produces a debuggable trail.
+//
+// Setsid puts the daemon in its own session so SIGHUP from the
+// parent's terminal does not propagate. The parent does not Wait on
+// the child; the daemon's lifetime is independent.
+func forkExec(binary string, args []string) func(context.Context, string) error {
+	return func(_ context.Context, stateDir string) error {
+		if binary == "" {
+			return ErrNoBinary
+		}
+		if err := os.MkdirAll(stateDir, 0o700); err != nil {
+			return fmt.Errorf("create state dir: %w", err)
+		}
+		cmd := exec.Command(binary, args...)
+		cmd.SysProcAttr = &syscall.SysProcAttr{Setsid: true}
+		cmd.Stdin = nil
+
+		logPath := filepath.Join(stateDir, "daemon.log")
+		f, err := os.OpenFile(logPath, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+		if err != nil {
+			return fmt.Errorf("open daemon log: %w", err)
+		}
+		cmd.Stdout = f
+		cmd.Stderr = f
+
+		if err := cmd.Start(); err != nil {
+			_ = f.Close()
+			return fmt.Errorf("start daemon: %w", err)
+		}
+		// Close our copy of the log FD; the child has its own.
+		_ = f.Close()
+		return nil
+	}
+}

--- a/internal/daemon/spawn/spawn_test.go
+++ b/internal/daemon/spawn/spawn_test.go
@@ -1,0 +1,299 @@
+package spawn_test
+
+import (
+	"context"
+	"errors"
+	"net"
+	"sync"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
+	"github.com/ALRubinger/aileron/internal/daemon/spawn"
+)
+
+// fakeDaemon binds an ephemeral port and writes daemon.json so
+// readAlive's TCP probe succeeds. The returned cleanup closes the
+// listener; tests defer it to avoid leaking sockets.
+func fakeDaemon(t *testing.T, stateDir string) (url string, cleanup func()) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	url = "http://" + ln.Addr().String()
+	if err := discovery.Write(stateDir, discovery.Info{
+		URL:       url,
+		PID:       12345,
+		Version:   "test",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		_ = ln.Close()
+		t.Fatalf("discovery.Write: %v", err)
+	}
+	return url, func() { _ = ln.Close() }
+}
+
+func TestResolve_AILERON_API_URL_BypassesEverything(t *testing.T) {
+	dir := t.TempDir() // empty — no daemon.json
+	got, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:  dir,
+		EnvLookup: func(k string) string { return map[string]string{"AILERON_API_URL": "http://override:9999"}[k] },
+		SpawnFn: func(context.Context, string) error {
+			t.Error("SpawnFn should not be called when AILERON_API_URL is set")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != "http://override:9999" {
+		t.Fatalf("got %q, want override URL", got)
+	}
+}
+
+func TestResolve_FastPathWhenDaemonAlive(t *testing.T) {
+	dir := t.TempDir()
+	want, cleanup := fakeDaemon(t, dir)
+	defer cleanup()
+
+	got, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:  dir,
+		EnvLookup: emptyEnv,
+		SpawnFn: func(context.Context, string) error {
+			t.Error("SpawnFn should not be called when daemon is already alive")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestResolve_SpawnsAndReturnsURL(t *testing.T) {
+	dir := t.TempDir()
+	var spawned atomic.Int32
+
+	got, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:     dir,
+		EnvLookup:    emptyEnv,
+		SpawnTimeout: 2 * time.Second,
+		SpawnFn: func(_ context.Context, stateDir string) error {
+			spawned.Add(1)
+			// Simulate the daemon publishing daemon.json after a short delay.
+			go func() {
+				time.Sleep(20 * time.Millisecond)
+				_, _ = fakeDaemon(t, stateDir)
+			}()
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got == "" {
+		t.Fatal("got empty URL")
+	}
+	if spawned.Load() != 1 {
+		t.Errorf("SpawnFn called %d times, want 1", spawned.Load())
+	}
+}
+
+func TestResolve_StaleDiscoveryTriggersRespawn(t *testing.T) {
+	dir := t.TempDir()
+	// Write daemon.json pointing at a port that nothing is listening on.
+	if err := discovery.Write(dir, discovery.Info{
+		URL:       "http://127.0.0.1:1", // port 1 — privileged, nothing answers
+		PID:       1,
+		Version:   "stale",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var spawned atomic.Int32
+	got, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:        dir,
+		EnvLookup:       emptyEnv,
+		LivenessTimeout: 50 * time.Millisecond,
+		SpawnTimeout:    2 * time.Second,
+		SpawnFn: func(_ context.Context, stateDir string) error {
+			spawned.Add(1)
+			_, _ = fakeDaemon(t, stateDir)
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got == "" {
+		t.Fatal("got empty URL")
+	}
+	if spawned.Load() != 1 {
+		t.Errorf("SpawnFn called %d times, want 1", spawned.Load())
+	}
+}
+
+// TestResolve_ConcurrentClientsSpawnExactlyOnce mimics the real
+// auto-spawn race: ten clients call Resolve simultaneously against
+// an empty state dir. The lock + recheck pattern must funnel all of
+// them through one SpawnFn call.
+func TestResolve_ConcurrentClientsSpawnExactlyOnce(t *testing.T) {
+	dir := t.TempDir()
+	var spawned atomic.Int32
+	var publishOnce sync.Once
+
+	const N = 10
+	results := make(chan string, N)
+	errs := make(chan error, N)
+	var wg sync.WaitGroup
+	wg.Add(N)
+	for i := 0; i < N; i++ {
+		go func() {
+			defer wg.Done()
+			got, err := spawn.Resolve(context.Background(), spawn.Options{
+				StateDir:     dir,
+				EnvLookup:    emptyEnv,
+				SpawnTimeout: 5 * time.Second,
+				SpawnFn: func(_ context.Context, stateDir string) error {
+					spawned.Add(1)
+					publishOnce.Do(func() { _, _ = fakeDaemon(t, stateDir) })
+					return nil
+				},
+			})
+			if err != nil {
+				errs <- err
+				return
+			}
+			results <- got
+		}()
+	}
+	wg.Wait()
+	close(results)
+	close(errs)
+
+	for err := range errs {
+		t.Fatalf("Resolve: %v", err)
+	}
+	var first string
+	count := 0
+	for got := range results {
+		if first == "" {
+			first = got
+		}
+		if got != first {
+			t.Fatalf("client got %q, expected the same %q", got, first)
+		}
+		count++
+	}
+	if count != N {
+		t.Fatalf("got %d successful results, want %d", count, N)
+	}
+	if got := spawned.Load(); got != 1 {
+		t.Fatalf("SpawnFn called %d times, want 1", got)
+	}
+}
+
+func TestResolve_TimeoutWhenDaemonNeverAppears(t *testing.T) {
+	dir := t.TempDir()
+	got, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:     dir,
+		EnvLookup:    emptyEnv,
+		SpawnTimeout: 200 * time.Millisecond,
+		PollInterval: 25 * time.Millisecond,
+		SpawnFn: func(context.Context, string) error {
+			return nil // intentionally do nothing — daemon.json never appears
+		},
+	})
+	if err == nil {
+		t.Fatalf("Resolve should time out, got URL %q", got)
+	}
+}
+
+func TestResolve_PropagatesSpawnError(t *testing.T) {
+	dir := t.TempDir()
+	wantErr := errors.New("spawn-failed-on-purpose")
+	_, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:  dir,
+		EnvLookup: emptyEnv,
+		SpawnFn:   func(context.Context, string) error { return wantErr },
+	})
+	if err == nil || !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v wrapped", err, wantErr)
+	}
+}
+
+func TestResolve_CtxCancellationDuringPoll(t *testing.T) {
+	dir := t.TempDir()
+	ctx, cancel := context.WithCancel(context.Background())
+
+	resultCh := make(chan error, 1)
+	go func() {
+		_, err := spawn.Resolve(ctx, spawn.Options{
+			StateDir:     dir,
+			EnvLookup:    emptyEnv,
+			SpawnTimeout: 5 * time.Second,
+			PollInterval: 25 * time.Millisecond,
+			SpawnFn:      func(context.Context, string) error { return nil },
+		})
+		resultCh <- err
+	}()
+
+	// Let Resolve enter the polling loop, then cancel.
+	time.Sleep(50 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-resultCh:
+		if !errors.Is(err, context.Canceled) {
+			t.Fatalf("got %v, want context.Canceled", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Resolve did not return after context cancel")
+	}
+}
+
+func TestResolve_RequiresStateDir(t *testing.T) {
+	_, err := spawn.Resolve(context.Background(), spawn.Options{StateDir: ""})
+	if err == nil {
+		t.Fatal("Resolve should fail when StateDir is empty")
+	}
+}
+
+func TestResolve_DefaultSpawnFnFailsWithEmptyBinary(t *testing.T) {
+	dir := t.TempDir()
+	_, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:     dir,
+		EnvLookup:    emptyEnv,
+		Binary:       "", // missing
+		SpawnTimeout: 100 * time.Millisecond,
+	})
+	if err == nil || !errors.Is(err, spawn.ErrNoBinary) {
+		t.Fatalf("got %v, want ErrNoBinary wrapped", err)
+	}
+}
+
+func TestResolve_DefaultSpawnFnForkExecsBinary(t *testing.T) {
+	dir := t.TempDir()
+	// Use /bin/true (exits 0 immediately) as the "daemon" binary —
+	// it won't write daemon.json, so Resolve will time out, but the
+	// fork-exec itself happens. Verifies the default SpawnFn wires
+	// the binary path through correctly without depending on a real
+	// daemon binary in tests.
+	_, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:     dir,
+		EnvLookup:    emptyEnv,
+		Binary:       "/bin/true",
+		SpawnTimeout: 200 * time.Millisecond,
+		PollInterval: 50 * time.Millisecond,
+	})
+	if err == nil {
+		t.Fatal("expected timeout because /bin/true does not write daemon.json")
+	}
+}
+
+func emptyEnv(string) string { return "" }


### PR DESCRIPTION
## Summary

Step 6 of #454. CLI commands and `aileron launch` will call `spawn.Resolve(ctx, opts)` before any HTTP request — the helper either returns the URL of an already-running daemon or fork-execs a fresh one and waits for its discovery file to appear.

This is the last invisible-plumbing step. Step 7 wires it into the CLI; step 8 wires it into launch; users see the change at that point.

## Surface

```go
spawn.Resolve(ctx context.Context, opts spawn.Options) (string, error)
```

- **`AILERON_API_URL`** env override → return immediately, no spawn (test/dev escape hatch).
- **Fast path:** `discovery.Read` + 200ms TCP probe. If the daemon is reachable, return its URL.
- **Spawn path:** acquire `discovery.Lock` (singleton invariant) → re-check `daemon.json` (race-collapse) → run `SpawnFn` → poll for `daemon.json` with 5s default timeout.
- **Default `SpawnFn`** fork-execs `Options.Binary` with `Setsid` (detached from the parent's terminal) and redirects stdio to `<stateDir>/daemon.log` for a debuggable trail. Tests substitute a callback that synthetically writes `daemon.json` so the helper is exercised without an OS process.

## Concurrency

`TestResolve_ConcurrentClientsSpawnExactlyOnce` races 10 goroutines against an empty state dir and asserts:

- All 10 receive the same URL.
- `SpawnFn` is invoked exactly once.

The lock is held through the polling loop, so clients that race past the first one block on lock acquisition and re-check `daemon.json` on entry — no redundant fork-execs.

## Test plan

- [x] `go test ./internal/daemon/spawn/... -race` is green.
- [x] `go vet ./internal/daemon/spawn/...` is clean.
- [x] Coverage 88.6%. Per-function: Resolve 92.9%, waitForDaemon 100%, readAlive 90.9%, urlToHostPort 75%, forkExec 78.9%.
- [x] Tests cover: AILERON_API_URL bypass, daemon-already-alive fast path, spawn-then-resolve happy path, stale-discovery triggers respawn, concurrent N=10 race produces exactly one spawn, timeout when SpawnFn never produces daemon.json, error propagation from SpawnFn, ctx cancellation during poll, missing StateDir, default SpawnFn ErrNoBinary, default SpawnFn fork-execs `/bin/true` (verifies wiring without a real daemon binary).

## Notes

- `Setsid` is unix-only. Per ADR-0012 the daemon is unix-only; Windows daemon support is deferred. Cloud Aileron (Docker) is the exposure path for non-unix.
- `<stateDir>/daemon.log` is single-file, no rotation. The audit log is daily-rotated (#468) but the daemon's own stderr is rare and small.

🤖 Generated with [Claude Code](https://claude.com/claude-code)