### PR TITLE
docs: brand homepage as Aileron (drop "Docs") and add maintainer line

### DIFF
--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -137,7 +137,9 @@ Aileron doesn't replace Tool Calling or MCP — it complements them. Each layer 
 
 Your agent's existing MCP servers keep exposing tools the same way. The LLM still uses Tool Calling to express intent. Aileron is the layer that runs underneath — making the execution of those tool calls safe to use against your real systems.
 
-## Project
+## About
+
+Aileron is an open-source project, stewarded by Andrew Lee Rubinger. Contact: [fly@withaileron.ai](mailto:fly@withaileron.ai).
 
 [![Static Badge](https://img.shields.io/badge/github-repo-blue?style=for-the-badge&logo=github&label=ALRubinger%2Faileron)](https://github.com/ALRubinger/aileron)
 ![GitHub License](https://img.shields.io/github/license/ALRubinger/aileron?style=for-the-badge)

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -23,7 +23,7 @@ const nav = navigation;
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <meta name="slack-app-id" content="A0ATKS91VPW" />
-    <title>{title} - Aileron Docs</title>
+    <title>{title === 'Aileron' ? 'Aileron' : `${title} - Aileron`}</title>
     <script is:inline>
       !function(t,e){var o,n,p,r;e.__SV||(window.posthog && window.posthog.__loaded)||(window.posthog=e,e._i=[],e.init=function(i,s,a){function g(t,e){var o=e.split(".");2==o.length&&(t=t[o[0]],e=o[1]),t[e]=function(){t.push([e].concat(Array.prototype.slice.call(arguments,0)))}}(p=t.createElement("script")).type="text/javascript",p.crossOrigin="anonymous",p.async=!0,p.src=s.api_host.replace(".i.posthog.com","-assets.i.posthog.com")+"/static/array.js",(r=t.getElementsByTagName("script")[0]).parentNode.insertBefore(p,r);var u=e;for(void 0!==a?u=e[a]=[]:a="posthog",u.people=u.people||[],u.toString=function(t){var e="posthog";return"posthog"!==a&&(e+="."+a),t||(e+=" (stub)"),e},u.people.toString=function(){return u.toString(1)+".people (stub)"},o="init Dr qr Ci Br Zr Pr capture calculateEventProperties Ur register register_once register_for_session unregister unregister_for_session Xr getFeatureFlag getFeatureFlagPayload getFeatureFlagResult isFeatureEnabled reloadFeatureFlags updateFlags updateEarlyAccessFeatureEnrollment getEarlyAccessFeatures on onFeatureFlags onSurveysLoaded onSessionId getSurveys getActiveMatchingSurveys renderSurvey displaySurvey cancelPendingSurvey canRenderSurvey canRenderSurveyAsync Jr identify setPersonProperties group resetGroups setPersonPropertiesForFlags resetPersonPropertiesForFlags setGroupPropertiesForFlags resetGroupPropertiesForFlags reset setIdentity clearIdentity get_distinct_id getGroups get_session_id get_session_replay_url alias set_config startSessionRecording stopSessionRecording sessionRecordingStarted captureException captureLog startExceptionAutocapture stopExceptionAutocapture loadToolbar get_property getSessionProperty Gr Hr createPersonProfile setInternalOrTestUser Wr Fr tn opt_in_capturing opt_out_capturing has_opted_in_capturing has_opted_out_capturing get_explicit_consent_status is_capturing clear_opt_in_out_capturing $r debug ki Yr getPageViewId captureTraceFeedback captureTraceMetric Rr".split(" "),n=0;n<o.length;n++)g(u,o[n]);e._i.push([i,s,a])},e.__SV=1)}(document,window.posthog||[]);
       posthog.init('phc_CQuEfquiVnj6iEDdSy9RV2T63kBTuPz7V3dJysGZrAiA', {
@@ -37,7 +37,7 @@ const nav = navigation;
   <body>
     <header class="fixed top-0 left-0 right-0 z-50 h-16 flex items-center pl-16 pr-6 lg:px-6 border-b border-border bg-background transition-[padding] duration-200">
       <a href="/" class="font-bold text-lg text-foreground no-underline hover:text-foreground">
-        Aileron Docs
+        Aileron
       </a>
     </header>
     <div class="flex min-h-screen pt-16">


### PR DESCRIPTION
## Summary

Two small homepage changes ahead of Google OAuth verification ([#196](https://github.com/ALRubinger/aileron/issues/196) — Phase 1, application homepage requirement). Audit on the prior PR identified that `withaileron.ai` read as a docs sub-site rather than the app's homepage, and that the maintainer / contact identity wasn't surfaced anywhere on the landing page itself.

- **`BaseLayout.astro`** — brand and `<title>` template change from "Aileron Docs" to "Aileron". The site is the whole web presence (landing + docs), so framing it as "Docs" understates what users land on. Title template guards the homepage case so the tab reads `Aileron` instead of `Aileron - Aileron`.
- **`index.mdx`** — rename "Project" section to "About" and add a one-line maintainer + contact statement, mirroring the language in the privacy policy and terms.

## Test plan

- [x] `task lint:docs` passes
- [x] `task build:docs` succeeds
- [ ] Visual check — header reads `Aileron`; homepage tab title is `Aileron`; sub-page tab titles read `<page> - Aileron`; About section has the maintainer line above the badges

🤖 Generated with [Claude Code](https://claude.com/claude-code)