### PR TITLE
refactor(dailypath): extract path-naming convention into shared package

### DIFF
--- a/internal/audit/dailypath.go
+++ b/internal/audit/dailypath.go
@@ -1,32 +1,38 @@
 package audit
 
 import (
-	"path/filepath"
 	"time"
+
+	"github.com/ALRubinger/aileron/internal/dailypath"
 )
 
-// dailyDir is the subdirectory under a state dir that holds the
-// daily-rotated audit JSONL files.
-const dailyDir = "audit"
+// auditSubdir / auditPrefix bind the audit log to a stable on-disk
+// shape: `<stateDir>/audit/audit-YYYY-MM-DD.jsonl`. The path
+// arithmetic itself lives in [dailypath]; this package owns the
+// binding so callers asking for "today's audit path" don't have to
+// know either name.
+const (
+	auditSubdir = "audit"
+	auditPrefix = "audit-"
+)
 
 // DailyPath returns today's audit JSONL file path inside stateDir,
-// using the local clock. The file is `<stateDir>/audit/audit-YYYY-MM-DD.jsonl`.
-//
-// Production callers compute the path on each write so a session that
-// crosses midnight rolls naturally to the next day's file.
+// using the local clock. Production callers compute the path on
+// each write so a session that crosses midnight rolls naturally to
+// the next day's file.
 func DailyPath(stateDir string) string {
-	return DailyPathAt(stateDir, time.Now())
+	return dailypath.Path(stateDir, auditSubdir, auditPrefix)
 }
 
-// DailyPathAt is the time-injectable variant of [DailyPath]. Tests use
-// it to drive midnight-rollover scenarios without sleeping.
+// DailyPathAt is the time-injectable variant of [DailyPath]. Tests
+// use it to drive midnight-rollover scenarios without sleeping.
 func DailyPathAt(stateDir string, t time.Time) string {
-	return filepath.Join(stateDir, dailyDir, "audit-"+t.Format("2006-01-02")+".jsonl")
+	return dailypath.PathAt(stateDir, auditSubdir, auditPrefix, t)
 }
 
 // DailyDir returns the subdirectory path the daily files live in:
 // `<stateDir>/audit`. Useful for read-side callers that scan across
 // every daily file (e.g., `aileron policy save`).
 func DailyDir(stateDir string) string {
-	return filepath.Join(stateDir, dailyDir)
+	return dailypath.Dir(stateDir, auditSubdir)
 }

--- a/internal/dailypath/dailypath.go
+++ b/internal/dailypath/dailypath.go
@@ -1,0 +1,52 @@
+// Package dailypath gives Aileron's on-disk JSONL surfaces a shared
+// path-naming convention: `<stateDir>/<subdir>/<prefix>YYYY-MM-DD.jsonl`.
+//
+// Two surfaces use it today: the audit log
+// (`~/.aileron/audit/audit-YYYY-MM-DD.jsonl`, ADR-0012) and the OTel
+// trace exporter (`~/.aileron/traces/spans-YYYY-MM-DD.jsonl`, issue
+// #390). Both rotate by local-clock day so a session that crosses
+// midnight rolls naturally to the next day's file. Filenames embed
+// the date so directory listings sort chronologically by name —
+// scanning for replay (audit) or for a date range (future trace
+// reader) is just `os.ReadDir` plus a sort by name.
+//
+// The package is deliberately tiny: just path arithmetic, no I/O.
+// File creation, locking, and replay live with each consumer because
+// the lifecycle needs differ — audit replays its files at startup to
+// rebuild the in-memory index; the OTel exporter doesn't, since
+// spans aren't queried by ID.
+package dailypath
+
+import (
+	"path/filepath"
+	"time"
+)
+
+// Path returns today's JSONL file path inside the supplied state
+// directory, using the local clock. The file is
+// `<stateDir>/<subdir>/<prefix>YYYY-MM-DD.jsonl`.
+//
+// Production callers compute the path on each write so a session
+// that crosses midnight rolls naturally to the next day's file.
+//
+// `subdir` and `prefix` are caller-owned: the audit store passes
+// `"audit"` / `"audit-"`; the trace exporter passes `"traces"` /
+// `"spans-"`. The function does not validate them — non-conforming
+// values produce non-conforming paths, which is the caller's
+// problem to surface.
+func Path(stateDir, subdir, prefix string) string {
+	return PathAt(stateDir, subdir, prefix, time.Now())
+}
+
+// PathAt is the time-injectable variant of [Path]. Tests use it to
+// drive midnight-rollover scenarios without sleeping.
+func PathAt(stateDir, subdir, prefix string, t time.Time) string {
+	return filepath.Join(stateDir, subdir, prefix+t.Format("2006-01-02")+".jsonl")
+}
+
+// Dir returns the subdirectory the daily files live in:
+// `<stateDir>/<subdir>`. Useful for read-side callers that scan
+// across every daily file (audit replay, future trace reader).
+func Dir(stateDir, subdir string) string {
+	return filepath.Join(stateDir, subdir)
+}

--- a/internal/dailypath/dailypath_test.go
+++ b/internal/dailypath/dailypath_test.go
@@ -1,0 +1,84 @@
+package dailypath_test
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/dailypath"
+)
+
+// PathAt contract:
+//   - Renders <stateDir>/<subdir>/<prefix>YYYY-MM-DD.jsonl exactly.
+//   - Date formatting is deterministic across timezones (the package
+//     uses the local clock; tests inject UTC for stability).
+//   - Different (subdir, prefix) combinations don't collide.
+//   - Path rolls over at midnight: the same stateDir+subdir+prefix
+//     yields different paths on consecutive days.
+
+func TestPathAt_RendersStateDirSubdirPrefixDate(t *testing.T) {
+	stateDir := "/home/user/.aileron"
+	got := dailypath.PathAt(stateDir, "audit", "audit-",
+		time.Date(2026, 5, 5, 14, 22, 3, 0, time.UTC))
+	want := filepath.Join(stateDir, "audit", "audit-2026-05-05.jsonl")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestPathAt_TraceExporterShape(t *testing.T) {
+	// The OTel trace exporter consumes this with subdir="traces"
+	// and prefix="spans-"; the resulting filename mirrors the
+	// audit shape but lands in its own directory.
+	stateDir := "/home/user/.aileron"
+	got := dailypath.PathAt(stateDir, "traces", "spans-",
+		time.Date(2026, 5, 5, 0, 0, 0, 0, time.UTC))
+	want := filepath.Join(stateDir, "traces", "spans-2026-05-05.jsonl")
+	if got != want {
+		t.Fatalf("got %q, want %q", got, want)
+	}
+}
+
+func TestPathAt_DifferentConsumersDontCollide(t *testing.T) {
+	t0 := time.Date(2026, 5, 5, 12, 0, 0, 0, time.UTC)
+	auditPath := dailypath.PathAt("/x", "audit", "audit-", t0)
+	tracePath := dailypath.PathAt("/x", "traces", "spans-", t0)
+	if auditPath == tracePath {
+		t.Fatalf("audit and traces paths must differ; both = %q", auditPath)
+	}
+	if filepath.Dir(auditPath) == filepath.Dir(tracePath) {
+		t.Errorf("audit and traces should live in different subdirs; both in %q", filepath.Dir(auditPath))
+	}
+}
+
+func TestPathAt_RollsOverAtMidnight(t *testing.T) {
+	stateDir := "/x"
+	beforeMidnight := time.Date(2026, 5, 5, 23, 59, 59, 999_000_000, time.UTC)
+	afterMidnight := time.Date(2026, 5, 6, 0, 0, 0, 0, time.UTC)
+	if a, b := dailypath.PathAt(stateDir, "audit", "audit-", beforeMidnight),
+		dailypath.PathAt(stateDir, "audit", "audit-", afterMidnight); a == b {
+		t.Fatalf("daily path should differ across midnight; both = %q", a)
+	}
+}
+
+func TestPath_UsesNow(t *testing.T) {
+	// Path is the live-clock convenience wrapper; assert the shape
+	// without pinning the date so the test stays deterministic.
+	got := dailypath.Path("/home/user/.aileron", "audit", "audit-")
+	if !strings.HasPrefix(got, "/home/user/.aileron/audit/audit-") {
+		t.Fatalf("unexpected prefix: %q", got)
+	}
+	if !strings.HasSuffix(got, ".jsonl") {
+		t.Fatalf("missing .jsonl suffix: %q", got)
+	}
+}
+
+func TestDir_StateDirSubdirJoin(t *testing.T) {
+	if got, want := dailypath.Dir("/x", "audit"), filepath.Join("/x", "audit"); got != want {
+		t.Fatalf("audit Dir = %q, want %q", got, want)
+	}
+	if got, want := dailypath.Dir("/x", "traces"), filepath.Join("/x", "traces"); got != want {
+		t.Fatalf("traces Dir = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Setup for the OTel trace file exporter (#390). The audit log shipped in #468 hardcoded its on-disk path-naming convention inline:

```
<stateDir>/audit/audit-YYYY-MM-DD.jsonl
```

The trace exporter wants the same shape with different `(subdir, prefix)` values:

```
<stateDir>/traces/spans-YYYY-MM-DD.jsonl
```

Pure refactor — no user-visible behavior change. Sharing keeps the convention guaranteed by code rather than guaranteed by coincidence, and gives both surfaces a tested foundation to land on.

### What changed

- **New `internal/dailypath` package** — `Path` / `PathAt` / `Dir`, all taking `(stateDir, subdir, prefix)`. 100% covered. Tests assert the audit shape, the trace shape, non-collision across consumers, and midnight rollover.
- **`internal/audit/dailypath.go`** — thin-wraps `dailypath` with `auditSubdir="audit"` / `auditPrefix="audit-"`. Preserves the audit-specific binding so the 5 callers don't change:
  - `internal/app/handlers_status.go`
  - `internal/launch/commsserver.go`
  - `internal/launch/launcher.go` (×2)
  - `cmd/aileron-sh/main.go`
  - `internal/audit/file.go`

The audit tests stay too. They're now **contract tests for the binding** ("audit path is in the audit subdir with audit- prefix"), complementing `dailypath`'s tests for the path arithmetic. Two layers of tests at the cost of ~50 lines, both independently exercisable.

### Why this shape

Considered three alternatives:

1. **Generic `jsonlrotate` package** — extract a full rotating writer (open-append-close, mutex, etc.) shared by audit and traces. Rejected: audit replays files at startup to rebuild an in-memory index; OTel exporter doesn't (spans aren't queried by ID). Forcing a shared lifecycle on consumers with genuinely different needs is the wrong shape.
2. **Don't share** — write a parallel 5-line `tracePath` helper in the observability package. Rejected: small duplication, but loses the "consistent path convention" guarantee and forfeits a clean independent test surface.
3. **Generalize the path arithmetic only** *(this PR)* — the genuinely shared concern, ~10 lines, independently testable. Each consumer keeps its own file mechanics.

## Test plan

- [x] `go test ./internal/dailypath/...` — coverage 100.0%; 6 tests including audit shape, trace shape, non-collision, and midnight rollover
- [x] `go test ./internal/audit/...` — green; the audit-specific binding tests still pass
- [x] `go test ./...` — full internal-module sweep green
- [x] All four `cmd/*` modules build cleanly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
