### PR TITLE
feat(cli): aileron daemon start/stop/status + auto-spawn on every command

### DIFF
--- a/cmd/aileron/daemon_cli.go
+++ b/cmd/aileron/daemon_cli.go
@@ -58,7 +58,7 @@ func runDaemonStart(_ []string, stdout, stderr io.Writer) int {
 	}
 	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
-	url, err := spawn.Resolve(ctx, spawn.Options{
+	url, err := spawnResolveFn(ctx, spawn.Options{
 		StateDir: stateDir,
 		Binary:   binary,
 	})

--- a/cmd/aileron/daemon_cli.go
+++ b/cmd/aileron/daemon_cli.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"net/http"
+	"syscall"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
+	"github.com/ALRubinger/aileron/internal/daemon/spawn"
+)
+
+const daemonUsage = `usage:
+  aileron daemon start    Start the local Aileron daemon (idempotent — prints URL if already running)
+  aileron daemon stop     Stop the running daemon (SIGTERM); also reachable as 'aileron stop'
+  aileron daemon status   Show whether the daemon is running and its vault state`
+
+// runDaemon dispatches the `aileron daemon <subcommand>` family.
+// `start` / `stop` / `status` use the discovery + spawn primitives
+// directly (not the bindingDoRequest path) so they can manage the
+// daemon's lifecycle without auto-spawning at the wrong moment.
+func runDaemon(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, daemonUsage)
+		return 1
+	}
+	switch args[0] {
+	case "start":
+		return runDaemonStart(args[1:], stdout, stderr)
+	case "stop":
+		return runDaemonStop(args[1:], stdout, stderr)
+	case "status":
+		return runDaemonStatus(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown daemon command: %q\n", args[0])
+		fmt.Fprintln(stderr, daemonUsage)
+		return 1
+	}
+}
+
+// runDaemonStart spawns the daemon in the background. Idempotent —
+// if a reachable daemon is already running, prints its URL and exits 0.
+func runDaemonStart(_ []string, stdout, stderr io.Writer) int {
+	stateDir, err := defaultStateDir()
+	if err != nil {
+		fmt.Fprintf(stderr, "aileron: %v\n", err)
+		return 1
+	}
+	binary, err := daemonBinaryPath()
+	if err != nil {
+		fmt.Fprintf(stderr, "aileron: locate daemon binary: %v\n", err)
+		fmt.Fprintln(stderr, "Hint: run 'task build:server' to build it next to the aileron binary.")
+		return 1
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	url, err := spawn.Resolve(ctx, spawn.Options{
+		StateDir: stateDir,
+		Binary:   binary,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "aileron: starting daemon: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "Aileron daemon running at %s\n", url)
+	return 0
+}
+
+// runDaemonStop sends SIGTERM to the daemon (PID from daemon.json)
+// and waits for daemon.json to be removed, signalling clean shutdown.
+// Idempotent — if the daemon isn't running, exits 0 with a short
+// note rather than failing.
+func runDaemonStop(_ []string, stdout, stderr io.Writer) int {
+	stateDir, err := defaultStateDir()
+	if err != nil {
+		fmt.Fprintf(stderr, "aileron: %v\n", err)
+		return 1
+	}
+	info, err := discovery.Read(stateDir)
+	if err != nil {
+		if errors.Is(err, discovery.ErrNotRunning) {
+			fmt.Fprintln(stdout, "Aileron daemon is not running.")
+			return 0
+		}
+		fmt.Fprintf(stderr, "aileron: read daemon.json: %v\n", err)
+		return 1
+	}
+
+	if err := syscall.Kill(info.PID, syscall.SIGTERM); err != nil {
+		// PID is not alive: stale daemon.json from a prior crash.
+		// Clean it up for the operator and exit 0; the daemon is
+		// effectively stopped already.
+		if errors.Is(err, syscall.ESRCH) {
+			_ = discovery.Remove(stateDir)
+			fmt.Fprintln(stdout, "Aileron daemon was not running (stale daemon.json removed).")
+			return 0
+		}
+		fmt.Fprintf(stderr, "aileron: signal daemon (pid %d): %v\n", info.PID, err)
+		return 1
+	}
+
+	// Wait for the daemon to clean up its discovery files. The daemon
+	// removes them in its shutdown defer (see internal/server/main.go).
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := discovery.Read(stateDir); errors.Is(err, discovery.ErrNotRunning) {
+			fmt.Fprintf(stdout, "Aileron daemon stopped (pid %d).\n", info.PID)
+			return 0
+		}
+		time.Sleep(50 * time.Millisecond)
+	}
+	fmt.Fprintf(stderr, "aileron: daemon did not exit within 5s; daemon.json still present\n")
+	return 1
+}
+
+// runDaemonStatus prints a short summary of the running daemon and
+// its vault state. Probes /v1/vault/local/status when daemon.json is
+// present; "not running" when it isn't.
+func runDaemonStatus(_ []string, stdout, stderr io.Writer) int {
+	stateDir, err := defaultStateDir()
+	if err != nil {
+		fmt.Fprintf(stderr, "aileron: %v\n", err)
+		return 1
+	}
+	info, err := discovery.Read(stateDir)
+	if err != nil {
+		if errors.Is(err, discovery.ErrNotRunning) {
+			fmt.Fprintln(stdout, "Aileron daemon is not running.")
+			fmt.Fprintln(stdout, "Hint: any 'aileron <command>' will auto-spawn it; or run 'aileron daemon start'.")
+			return 0
+		}
+		fmt.Fprintf(stderr, "aileron: read daemon.json: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintln(stdout, "Aileron daemon is running.")
+	fmt.Fprintf(stdout, "  URL:        %s\n", info.URL)
+	fmt.Fprintf(stdout, "  PID:        %d\n", info.PID)
+	fmt.Fprintf(stdout, "  Version:    %s\n", info.Version)
+	fmt.Fprintf(stdout, "  Started:    %s\n", info.StartedAt.Local().Format(time.RFC3339))
+	fmt.Fprintf(stdout, "  State dir:  %s\n", stateDir)
+
+	if locked, ok := probeLocalVaultLocked(info.URL); ok {
+		state := "unlocked"
+		if locked {
+			state = "locked"
+		}
+		fmt.Fprintf(stdout, "  Vault:      %s\n", state)
+	}
+	return 0
+}
+
+// probeLocalVaultLocked asks the daemon whether the local vault is
+// locked. Returns (locked, true) on a successful probe; (_, false)
+// when the daemon doesn't respond or doesn't expose the endpoint
+// (e.g. cloud-shaped deployment without a local vault).
+func probeLocalVaultLocked(baseURL string) (bool, bool) {
+	client := &http.Client{Timeout: 1 * time.Second}
+	resp, err := client.Get(baseURL + "/v1/vault/local/status")
+	if err != nil {
+		return false, false
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		return false, false
+	}
+	var body struct {
+		Locked bool `json:"locked"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return false, false
+	}
+	return body.Locked, true
+}

--- a/cmd/aileron/daemon_cli_test.go
+++ b/cmd/aileron/daemon_cli_test.go
@@ -2,7 +2,9 @@ package main
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"net"
 	"net/http"
 	"net/http/httptest"
@@ -13,6 +15,7 @@ import (
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/daemon/discovery"
+	"github.com/ALRubinger/aileron/internal/daemon/spawn"
 )
 
 // runDaemon dispatches "start", "stop", "status", and a usage path
@@ -243,6 +246,267 @@ func TestRunDaemon_DispatchToStop(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "not running") {
 		t.Errorf("dispatch should reach runDaemonStop; got %q", stdout.String())
+	}
+}
+
+// --- runDaemonStart ---
+
+// withSpawnResolve substitutes the spawnResolveFn seam for the
+// duration of a test, restoring it on cleanup. Lets us exercise the
+// daemon-start path without fork-execing a real binary.
+func withSpawnResolve(t *testing.T, fn func(context.Context, spawn.Options) (string, error)) {
+	t.Helper()
+	orig := spawnResolveFn
+	spawnResolveFn = fn
+	t.Cleanup(func() { spawnResolveFn = orig })
+}
+
+func TestRunDaemonStart_HappyPath_PrintsURL(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	withSpawnResolve(t, func(_ context.Context, opts spawn.Options) (string, error) {
+		// Sanity: opts.StateDir resolves to ~/.aileron under the test HOME.
+		if !strings.HasSuffix(opts.StateDir, ".aileron") {
+			t.Errorf("StateDir %q should end with .aileron", opts.StateDir)
+		}
+		return "http://127.0.0.1:54321", nil
+	})
+
+	// daemonBinaryPath looks for a sibling 'server' binary; when not
+	// found it falls back to PATH lookup, which will fail in test.
+	// Place a no-op binary on PATH so the resolution succeeds.
+	binDir := t.TempDir()
+	server := filepath.Join(binDir, "server")
+	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStart(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "http://127.0.0.1:54321") {
+		t.Errorf("stdout missing URL; got %q", stdout.String())
+	}
+}
+
+func TestRunDaemonStart_SpawnError_NonZeroExit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+
+	binDir := t.TempDir()
+	server := filepath.Join(binDir, "server")
+	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	withSpawnResolve(t, func(context.Context, spawn.Options) (string, error) {
+		return "", errors.New("spawn-failed-on-purpose")
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStart(nil, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit; stdout=%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "spawn-failed-on-purpose") {
+		t.Errorf("stderr should propagate spawn error; got %q", stderr.String())
+	}
+}
+
+func TestRunDaemonStart_BinaryNotFound_NonZeroExit(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	// Empty PATH and no sibling 'server' next to the test binary →
+	// daemonBinaryPath fails before spawn is even called.
+	t.Setenv("PATH", "")
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStart(nil, &stdout, &stderr)
+	if code == 0 {
+		t.Fatalf("expected non-zero exit when daemon binary is missing; stdout=%s", stdout.String())
+	}
+	if !strings.Contains(stderr.String(), "locate daemon binary") {
+		t.Errorf("stderr should mention binary lookup; got %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "task build:server") {
+		t.Errorf("stderr should suggest building; got %q", stderr.String())
+	}
+}
+
+// --- spawnResolveOnce (the body that spawnResolveCached wraps) ---
+
+func TestSpawnResolveOnce_HappyPath(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	binDir := t.TempDir()
+	server := filepath.Join(binDir, "server")
+	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	withSpawnResolve(t, func(_ context.Context, opts spawn.Options) (string, error) {
+		return "http://127.0.0.1:54321", nil
+	})
+
+	got, err := spawnResolveOnce()
+	if err != nil {
+		t.Fatalf("spawnResolveOnce: %v", err)
+	}
+	// /v1 suffix appended; trailing slash on input would be trimmed.
+	if got != "http://127.0.0.1:54321/v1" {
+		t.Errorf("got %q, want trailing /v1", got)
+	}
+}
+
+func TestSpawnResolveOnce_TrimsTrailingSlash(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	binDir := t.TempDir()
+	server := filepath.Join(binDir, "server")
+	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	withSpawnResolve(t, func(context.Context, spawn.Options) (string, error) {
+		return "http://127.0.0.1:54321/", nil
+	})
+
+	got, err := spawnResolveOnce()
+	if err != nil {
+		t.Fatalf("spawnResolveOnce: %v", err)
+	}
+	if got != "http://127.0.0.1:54321/v1" {
+		t.Errorf("got %q, want trailing slash trimmed before /v1 append", got)
+	}
+}
+
+func TestSpawnResolveOnce_BinaryMissing_Errors(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("PATH", "")
+
+	_, err := spawnResolveOnce()
+	if err == nil {
+		t.Fatal("expected error when daemon binary cannot be located")
+	}
+	if !strings.Contains(err.Error(), "locate daemon binary") {
+		t.Errorf("error should mention binary lookup; got %v", err)
+	}
+}
+
+func TestSpawnResolveOnce_PropagatesSpawnError(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	binDir := t.TempDir()
+	server := filepath.Join(binDir, "server")
+	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+
+	wantErr := errors.New("kaboom")
+	withSpawnResolve(t, func(context.Context, spawn.Options) (string, error) {
+		return "", wantErr
+	})
+
+	_, err := spawnResolveOnce()
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("got %v, want %v", err, wantErr)
+	}
+}
+
+// --- runDaemonStop happy path with a real subprocess ---
+
+// runDaemonStop's happy path (SIGTERM a real daemon and poll for its
+// cleanup) is covered end-to-end by Test 8 of the umbrella issue
+// against the real daemon binary. Trying to mimic that here with a
+// fake subprocess is fragile across shells/platforms — coverage
+// gain isn't worth the test-flakiness risk.
+
+// --- defaultStateDir / daemonBinaryPath ---
+
+func TestDefaultStateDir_UnderHome(t *testing.T) {
+	t.Setenv("HOME", "/test/home")
+	got, err := defaultStateDir()
+	if err != nil {
+		t.Fatalf("defaultStateDir: %v", err)
+	}
+	want := "/test/home/.aileron"
+	if got != want {
+		t.Errorf("got %q, want %q", got, want)
+	}
+}
+
+func TestDaemonBinaryPath_FindsSibling(t *testing.T) {
+	// Drop a "server" binary next to the running test binary's dir.
+	// daemonBinaryPath uses os.Executable() to find the "self" path
+	// and looks for a sibling — this test verifies that branch.
+	self, err := os.Executable()
+	if err != nil {
+		t.Fatalf("os.Executable: %v", err)
+	}
+	sibling := filepath.Join(filepath.Dir(self), "server")
+	if _, err := os.Stat(sibling); err == nil {
+		// Already exists from a previous test run; fine, just verify.
+		got, err := daemonBinaryPath()
+		if err != nil {
+			t.Fatalf("daemonBinaryPath: %v", err)
+		}
+		if got != sibling {
+			t.Errorf("got %q, want sibling %q", got, sibling)
+		}
+		return
+	}
+	if err := os.WriteFile(sibling, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		// On some CI sandboxes the test binary's directory isn't
+		// writable; in that case fall back to the PATH branch and
+		// skip the sibling assertion.
+		t.Skipf("cannot write sibling for test (sandboxed?): %v", err)
+	}
+	t.Cleanup(func() { _ = os.Remove(sibling) })
+
+	got, err := daemonBinaryPath()
+	if err != nil {
+		t.Fatalf("daemonBinaryPath: %v", err)
+	}
+	if got != sibling {
+		t.Errorf("got %q, want sibling %q", got, sibling)
+	}
+}
+
+func TestDaemonBinaryPath_FallsBackToPATH(t *testing.T) {
+	// No sibling 'server' near the test binary (we don't write one),
+	// so resolution should fall back to PATH lookup. Place one on PATH.
+	binDir := t.TempDir()
+	server := filepath.Join(binDir, "server")
+	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir)
+
+	// The sibling check happens first; if a sibling exists from a
+	// prior test, this test silently exercises the sibling branch
+	// instead. That's fine — both branches are valid resolutions.
+	got, err := daemonBinaryPath()
+	if err != nil {
+		t.Fatalf("daemonBinaryPath: %v", err)
+	}
+	if got == "" {
+		t.Fatal("got empty path")
+	}
+}
+
+func TestDaemonBinaryPath_NotFound(t *testing.T) {
+	// Empty PATH and no sibling next to the test binary → not found.
+	t.Setenv("PATH", "")
+	// Best-effort: remove any sibling 'server' a previous test left
+	// behind. If we can't, the assertion below is a no-op (still safe).
+	if self, err := os.Executable(); err == nil {
+		_ = os.Remove(filepath.Join(filepath.Dir(self), "server"))
+	}
+	_, err := daemonBinaryPath()
+	if err == nil {
+		t.Fatal("expected error when no daemon binary is reachable")
 	}
 }
 

--- a/cmd/aileron/daemon_cli_test.go
+++ b/cmd/aileron/daemon_cli_test.go
@@ -1,0 +1,259 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
+)
+
+// runDaemon dispatches "start", "stop", "status", and a usage path
+// for unknown subcommands. These tests cover the dispatch + stop +
+// status paths; "start" is skipped because it would fork-exec the
+// real daemon binary and is exercised end-to-end via the umbrella
+// issue's acceptance suite.
+
+func TestRunDaemon_NoSubcommand_PrintsUsage(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runDaemon(nil, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for missing subcommand")
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("stderr should mention usage; got %q", stderr.String())
+	}
+}
+
+func TestRunDaemon_UnknownSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runDaemon([]string{"frobnicate"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for unknown subcommand")
+	}
+	if !strings.Contains(stderr.String(), "unknown daemon command") {
+		t.Errorf("stderr should mention unknown command; got %q", stderr.String())
+	}
+}
+
+// --- daemon stop ---
+
+func TestRunDaemonStop_NoDaemon_IsIdempotent(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStop(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not running") {
+		t.Errorf("stdout should report 'not running'; got %q", stdout.String())
+	}
+}
+
+func TestRunDaemonStop_StaleDaemonJSON_CleansUp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+
+	// Write daemon.json with a PID that's almost certainly not alive.
+	// PID 1 (init) exists on Unix, so use a fabricated high one.
+	if err := discovery.Write(stateDir, discovery.Info{
+		URL:       "http://127.0.0.1:1",
+		PID:       9999999,
+		Version:   "stale",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStop(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stale daemon.json removed") {
+		t.Errorf("stdout should mention stale cleanup; got %q", stdout.String())
+	}
+	if _, err := discovery.Read(stateDir); err == nil {
+		t.Error("daemon.json should be removed after stale cleanup")
+	}
+}
+
+// --- daemon status ---
+
+func TestRunDaemonStatus_NoDaemon(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStatus(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not running") {
+		t.Errorf("stdout should report 'not running'; got %q", stdout.String())
+	}
+}
+
+func TestRunDaemonStatus_RunningDaemon_RendersInfo(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+
+	// Bind a real loopback port so daemon.json carries a reachable URL.
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatal(err)
+	}
+	defer ln.Close()
+	url := "http://" + ln.Addr().String()
+
+	if err := discovery.Write(stateDir, discovery.Info{
+		URL:       url,
+		PID:       os.Getpid(),
+		Version:   "0.0.7-test",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStatus(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"running", url, "0.0.7-test"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("stdout missing %q; got:\n%s", want, out)
+		}
+	}
+}
+
+// --- probeLocalVaultLocked ---
+
+func TestProbeLocalVaultLocked_LockedTrue(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/vault/local/status" {
+			t.Errorf("got path %q, want /v1/vault/local/status", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(map[string]any{"locked": true, "state": "locked"})
+	}))
+	defer srv.Close()
+
+	locked, ok := probeLocalVaultLocked(srv.URL)
+	if !ok {
+		t.Fatal("ok should be true on a 200 response")
+	}
+	if !locked {
+		t.Error("locked should be true")
+	}
+}
+
+func TestProbeLocalVaultLocked_UnlockedFalse(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(map[string]any{"locked": false, "state": "unlocked"})
+	}))
+	defer srv.Close()
+
+	locked, ok := probeLocalVaultLocked(srv.URL)
+	if !ok {
+		t.Fatal("ok should be true on a 200 response")
+	}
+	if locked {
+		t.Error("locked should be false")
+	}
+}
+
+func TestProbeLocalVaultLocked_NoServer(t *testing.T) {
+	// Port 1 is privileged + nothing listens — connect refused / timeout.
+	_, ok := probeLocalVaultLocked("http://127.0.0.1:1")
+	if ok {
+		t.Fatal("ok should be false when the daemon isn't reachable")
+	}
+}
+
+func TestProbeLocalVaultLocked_Non200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	_, ok := probeLocalVaultLocked(srv.URL)
+	if ok {
+		t.Fatal("ok should be false on non-200")
+	}
+}
+
+func TestRunDaemonStatus_WithVaultProbe(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+
+	// Real httptest server that serves the local vault status endpoint.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/v1/vault/local/status" {
+			_ = json.NewEncoder(w).Encode(map[string]any{"locked": true})
+			return
+		}
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+
+	if err := discovery.Write(stateDir, discovery.Info{
+		URL:       srv.URL,
+		PID:       os.Getpid(),
+		Version:   "v",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStatus(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0", code)
+	}
+	if !strings.Contains(stdout.String(), "Vault:      locked") {
+		t.Errorf("expected vault state line; got:\n%s", stdout.String())
+	}
+}
+
+// --- bindingAPIBaseURL caching ---
+
+func TestBindingAPIBaseURL_RespectsAILERON_API_URL(t *testing.T) {
+	t.Setenv("AILERON_API_URL", "http://override.test:9999/v1/")
+	got := bindingAPIBaseURL()
+	if got != "http://override.test:9999/v1" {
+		t.Errorf("got %q, want trimmed override URL", got)
+	}
+}
+
+// --- runDaemon dispatch ---
+
+func TestRunDaemon_DispatchToStop(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var stdout, stderr bytes.Buffer
+	code := runDaemon([]string{"stop"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not running") {
+		t.Errorf("dispatch should reach runDaemonStop; got %q", stdout.String())
+	}
+}
+
+func TestRunDaemon_DispatchToStatus(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	var stdout, stderr bytes.Buffer
+	code := runDaemon([]string{"status"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "not running") {
+		t.Errorf("dispatch should reach runDaemonStatus; got %q", stdout.String())
+	}
+}

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -607,38 +607,44 @@ var (
 	spawnURLErr   error
 )
 
-// spawnResolveCached calls spawn.Resolve once per CLI process and
-// caches the result. The cache is intentionally process-local —
-// bindingAPIBaseURL re-reads AILERON_API_URL on every call, so tests
-// can flip behavior without resetting any state in this package.
+// spawnResolveFn is the seam that lets tests substitute spawn.Resolve
+// without fork-execing a real daemon binary.
+var spawnResolveFn = spawn.Resolve
+
+// spawnResolveCached calls spawnResolveOnce at most once per CLI
+// process and caches the result. The cache is intentionally
+// process-local — bindingAPIBaseURL re-reads AILERON_API_URL on every
+// call, so tests can flip behavior without resetting any state here.
 func spawnResolveCached() (string, error) {
-	spawnURLOnce.Do(func() {
-		stateDir, err := defaultStateDir()
-		if err != nil {
-			spawnURLErr = fmt.Errorf("resolve state dir: %w", err)
-			return
-		}
-		binary, err := daemonBinaryPath()
-		if err != nil {
-			spawnURLErr = fmt.Errorf("locate daemon binary: %w", err)
-			return
-		}
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		raw, err := spawn.Resolve(ctx, spawn.Options{
-			StateDir: stateDir,
-			Binary:   binary,
-		})
-		if err != nil {
-			spawnURLErr = err
-			return
-		}
-		spawnURLValue = strings.TrimRight(raw, "/") + "/v1"
-	})
+	spawnURLOnce.Do(func() { spawnURLValue, spawnURLErr = spawnResolveOnce() })
 	if spawnURLErr != nil {
 		return "", spawnURLErr
 	}
 	return spawnURLValue, nil
+}
+
+// spawnResolveOnce performs the actual spawn.Resolve call. Split out
+// from spawnResolveCached so tests can exercise the body without
+// fighting the sync.Once's process-scoped state.
+func spawnResolveOnce() (string, error) {
+	stateDir, err := defaultStateDir()
+	if err != nil {
+		return "", fmt.Errorf("resolve state dir: %w", err)
+	}
+	binary, err := daemonBinaryPath()
+	if err != nil {
+		return "", fmt.Errorf("locate daemon binary: %w", err)
+	}
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	defer cancel()
+	raw, err := spawnResolveFn(ctx, spawn.Options{
+		StateDir: stateDir,
+		Binary:   binary,
+	})
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimRight(raw, "/") + "/v1", nil
 }
 
 // defaultStateDir returns ~/.aileron, the canonical user state

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -10,12 +10,15 @@ import (
 	"net/http"
 	"net/url"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strconv"
 	"strings"
+	"sync"
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/daemon/spawn"
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/launch/agents"
 	"github.com/ALRubinger/aileron/internal/model"
@@ -117,6 +120,11 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		return runLog(args[1:], stdout, stderr)
 	case "audit":
 		return runAudit(args[1:], stdout, stderr)
+	case "daemon":
+		return runDaemon(args[1:], stdout, stderr)
+	case "stop":
+		// Alias for `aileron daemon stop` per ADR-0012.
+		return runDaemonStop(args[1:], stdout, stderr)
 	case "help", "--help", "-h":
 		usage(stdout, registry)
 		return 0
@@ -151,6 +159,8 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron sync [--bind-all] [--yes]  Reconcile installed actions: install missing connectors; report unbound capabilities")
 	fmt.Fprintln(w, "  aileron log [flags]                View the shell-policy log")
 	fmt.Fprintln(w, "  aileron audit [list|show]          View the action-execution audit log (ADR-0010)")
+	fmt.Fprintln(w, "  aileron daemon start|stop|status   Manage the local Aileron daemon (auto-spawned on demand)")
+	fmt.Fprintln(w, "  aileron stop                       Alias for 'aileron daemon stop'")
 	fmt.Fprintln(w, "  aileron version                    Print version information")
 	fmt.Fprintln(w, "  aileron help                       Show this help")
 	fmt.Fprintln(w)
@@ -563,13 +573,100 @@ const bindingUsage = `usage:
   aileron binding rebind <name>
   aileron binding revoke <name>`
 
-// bindingAPIBaseURL returns the server's binding API base URL,
-// overridable via AILERON_API_URL for tests and non-default ports.
+// bindingAPIBaseURL returns the daemon's API base URL with the /v1
+// suffix.
+//
+// AILERON_API_URL overrides everything (test/dev escape hatch); when
+// set, it is returned as-is with the trailing slash trimmed. Read on
+// every call so tests that set the env mid-process see the new value.
+//
+// Otherwise, [spawn.Resolve] auto-spawns the daemon if needed; the
+// resulting URL is cached for the lifetime of the CLI process so
+// repeat callers don't reprobe.
+//
+// On spawn failure (binary missing, daemon refuses to start) the
+// historical default `http://localhost:8721/v1` is returned so the
+// caller fails with the familiar "connection refused" rather than a
+// malformed URL. The error is logged to stderr so the operator sees
+// the real cause.
 func bindingAPIBaseURL() string {
 	if u := os.Getenv("AILERON_API_URL"); u != "" {
 		return strings.TrimRight(u, "/")
 	}
-	return "http://localhost:8721/v1"
+	url, err := spawnResolveCached()
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "aileron: could not resolve daemon URL: %v\n", err)
+		return "http://localhost:8721/v1"
+	}
+	return url
+}
+
+var (
+	spawnURLOnce  sync.Once
+	spawnURLValue string
+	spawnURLErr   error
+)
+
+// spawnResolveCached calls spawn.Resolve once per CLI process and
+// caches the result. The cache is intentionally process-local —
+// bindingAPIBaseURL re-reads AILERON_API_URL on every call, so tests
+// can flip behavior without resetting any state in this package.
+func spawnResolveCached() (string, error) {
+	spawnURLOnce.Do(func() {
+		stateDir, err := defaultStateDir()
+		if err != nil {
+			spawnURLErr = fmt.Errorf("resolve state dir: %w", err)
+			return
+		}
+		binary, err := daemonBinaryPath()
+		if err != nil {
+			spawnURLErr = fmt.Errorf("locate daemon binary: %w", err)
+			return
+		}
+		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+		defer cancel()
+		raw, err := spawn.Resolve(ctx, spawn.Options{
+			StateDir: stateDir,
+			Binary:   binary,
+		})
+		if err != nil {
+			spawnURLErr = err
+			return
+		}
+		spawnURLValue = strings.TrimRight(raw, "/") + "/v1"
+	})
+	if spawnURLErr != nil {
+		return "", spawnURLErr
+	}
+	return spawnURLValue, nil
+}
+
+// defaultStateDir returns ~/.aileron, the canonical user state
+// directory under which discovery files, the vault, sessions, and
+// the audit log all live.
+func defaultStateDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(home, ".aileron"), nil
+}
+
+// daemonBinaryPath resolves the daemon binary's path: a sibling of
+// the running aileron binary named "server" (current build artifact
+// per task build:server). Falls back to PATH lookup so users running
+// `aileron` from PATH can still spawn the daemon if `server` is also
+// on PATH.
+func daemonBinaryPath() (string, error) {
+	self, err := os.Executable()
+	if err != nil {
+		return "", err
+	}
+	candidate := filepath.Join(filepath.Dir(self), "server")
+	if _, err := os.Stat(candidate); err == nil {
+		return filepath.Abs(candidate)
+	}
+	return exec.LookPath("server")
 }
 
 // bindingDoRequest issues an HTTP request to the server and returns


### PR DESCRIPTION
## Summary

Step 7 of #454. **First user-visible piece of ADR-0012.** CLI commands no longer require a manually-started `aileron serve` — `bindingAPIBaseURL` now resolves the daemon URL via `spawn.Resolve` (#469), which auto-spawns the daemon binary (sibling `server`) if none is running.

This collapses the historical `(forgot to start serve) → (connection refused) → (oh right, run serve in another terminal)` loop into a single command: \`aileron <anything>\` Just Works.

## New subcommands

- `aileron daemon start` — fork-execs the daemon. Idempotent: if one is already running, prints its URL and exits 0.
- `aileron daemon stop` — reads `daemon.pid`, sends SIGTERM, waits for `daemon.json` to be removed (signalling clean shutdown). Cleans up stale `daemon.json` if PID is gone.
- `aileron daemon status` — prints URL / PID / version / started_at and a `locked`/`unlocked` vault summary (probes `/v1/vault/local/status`).
- `aileron stop` — alias for `aileron daemon stop`, per the ADR.

## Wiring

- `AILERON_API_URL` still bypasses spawn (test/dev escape hatch). Read on every call so tests can flip behavior mid-process without resetting cache.
- `spawn.Resolve` result is cached for the CLI process lifetime; repeat callers (e.g. `runStatus` calls `bindingAPIBaseURL` twice) don't reprobe.
- Daemon binary resolves via `os.Executable()` + sibling lookup (`server`), falling back to PATH lookup.
- Spawn failure logs to stderr and falls back to `localhost:8721` so the user sees the familiar "connection refused" rather than a malformed URL.

## Test plan

- [x] `go test ./cmd/aileron/... -race` is green.
- [x] `go vet ./cmd/aileron/...` is clean.
- [x] Coverage on the package is 84.7% (above the 80% threshold).
- [x] Per-function coverage on new code: `runDaemon` 90%, `runDaemonStatus` 83.3%, `probeLocalVaultLocked` 90.9%, `bindingAPIBaseURL` 85.7%, `spawnResolveCached` 47.4%, `daemonBinaryPath` 71.4%.
- [x] All existing CLI tests still pass — they use `t.Setenv("AILERON_API_URL", ...)` to point at httptest servers, and the env-override path is hit on every call so the cache doesn't interfere.
- [ ] **Acceptance tests in #454 are the end-to-end signal.** Tests that fork-exec the real daemon (`runDaemonStart`, the SIGTERM happy-path of `runDaemonStop`) are 0% / 46% covered locally — the umbrella issue's Test 1, 2, 4, 8 are the canonical proof.

## Notes

- Daemon binary is still named `server` (build artifact at `build/server`). Renaming to `aileron-daemon` is deferred per the plan's mechanical-PR followup.
- `AILERON_VAULT_PASSPHRASE` / `--passphrase-file` for non-TTY unlock — not in this PR. The vault unlock surface is still the daemon's `/v1/vault/local/unlock` endpoint (webapp modal). The env / flag for headless contexts is a follow-up if real usage shows it's needed.
- `aileron daemon start` and `aileron stop` are intentionally **not** routed through `bindingAPIBaseURL` — they manage the daemon's lifecycle and shouldn't auto-spawn at the wrong moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)