### PR TITLE
feat(observability): file exporter for OTel spans (#390)

### DIFF
--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -37,7 +37,7 @@ Aileron's role here is thin and consistent: when the agent calls Aileron, Ailero
 
 A few terms you'll see:
 
-- **Exporter** — the component that ships spans out of the process. Aileron currently supports `noop` (the default — drops spans, zero overhead) and `stdout` (writes JSON-per-line to stderr). A file exporter and an OTLP exporter are pending.
+- **Exporter** — the component that ships spans out of the process. Aileron supports `noop` (the default — drops spans, zero overhead), `stdout` (writes JSON-per-line to stderr for local development), and `file` (writes JSON-per-line to a daily-rotated file under `~/.aileron/traces/`, sibling to the audit log). An OTLP exporter is pending.
 - **OTLP** — the OpenTelemetry Protocol, the wire format collectors expect. When Aileron's OTLP exporter ships, you'll point it at an **OTel endpoint** — typically the URL of an [OpenTelemetry Collector](https://opentelemetry.io/docs/collector/) deployed alongside your other services, which fans the spans out to whichever backend (Grafana, Datadog, etc.) you've configured.
 - **Span status** — `Ok` (default), `Error`, or `Unset`. Aileron sets `Error` on any span whose underlying operation failed, with the failure message as the status description.
 
@@ -55,6 +55,16 @@ aileron launch claude
 
 Spans land on stderr as JSON-per-line. Pipe to `jq` to navigate them. With tracing off (the default), there's zero SDK overhead — the call sites resolve to no-op tracers.
 
+For durable retention across sessions, use the **file** exporter — spans land in a daily-rotated file under `~/.aileron/traces/`, mirroring the audit log's `~/.aileron/audit/` layout:
+
+```sh
+AILERON_OTEL_ENABLED=true \
+AILERON_OTEL_EXPORTER=file \
+aileron launch claude
+```
+
+A new file is created per local-clock day (`spans-YYYY-MM-DD.jsonl`); a session that crosses midnight rolls naturally to the next day's file. `AILERON_TRACES_DIR` overrides the state directory; the default (`~/.aileron`) keeps audit and traces side-by-side.
+
 Tracing is independent of the audit log. The audit log answers *what was done*; the traces answer *how it ran*. Both are useful; neither replaces the other.
 
 ### What gets emitted
@@ -71,7 +81,7 @@ Today (as the Phase 7 emission integrations land slice by slice in [issue #390](
 | HTTP server-root span | gateway and `/v1/actions/{name}/run` entry points | ✅ shipped |
 | `aileron.gateway.openai.chat` / `aileron.gateway.anthropic.messages` | LLM round-trip on the gateway | ⏳ pending |
 
-The file exporter (writing spans to `~/.aileron/traces/spans.jsonl` with date-based rotation) is also pending — it's gated on the parallel audit-log file rotation work so spans and audit events share a rotating writer with the same retention story.
+The file exporter is shipped — spans land in `~/.aileron/traces/spans-YYYY-MM-DD.jsonl`, sibling to the audit log's `~/.aileron/audit/audit-YYYY-MM-DD.jsonl`. Both surfaces share the path-naming convention via the `internal/dailypath` package, so retention and rotation are consistent across the two on-disk surfaces.
 
 ### Span attribute schema
 
@@ -98,8 +108,9 @@ All knobs are environment variables read at daemon startup. Defaults reproduce t
 |---|---|---|
 | `AILERON_OTEL_ENABLED` | `false` | Master switch for trace emission. When `false`, the SDK is never constructed; the call sites resolve to no-op. The W3C TraceContext propagator is registered regardless, so an inbound `traceparent` is parsed and propagated even without local emission. |
 | `AILERON_OTEL_SERVICE_NAME` | `aileron` | The OTel resource attribute `service.name` reported on every span. Set it to disambiguate Aileron from other services in your trace tooling. |
-| `AILERON_OTEL_EXPORTER` | `noop` | Exporter selection. `noop` drops spans (the default — same as `AILERON_OTEL_ENABLED=false`). `stdout` writes JSON-per-line to stderr for local development. The file exporter is pending. |
-| `AILERON_AUDIT_PATH` | `~/.aileron/audit.jsonl` | Override the audit log location. The default suits the personal-use case; environments with stricter filesystem layouts can point this elsewhere. |
+| `AILERON_OTEL_EXPORTER` | `noop` | Exporter selection. `noop` drops spans (the default — same as `AILERON_OTEL_ENABLED=false`). `stdout` writes JSON-per-line to stderr for local development. `file` writes JSON-per-line to a daily-rotated file under `AILERON_TRACES_DIR`. |
+| `AILERON_TRACES_DIR` | `~/.aileron` | State directory for the `file` exporter. Spans land at `<dir>/traces/spans-YYYY-MM-DD.jsonl`. The default keeps traces and the audit log side-by-side under `~/.aileron/`. Setting this to an explicit empty string disables the file exporter (degrades to no-op). |
+| `AILERON_AUDIT_DIR` | `~/.aileron` | State directory for the audit log. Audit events land at `<dir>/audit/audit-YYYY-MM-DD.jsonl`. The default keeps the audit log alongside traces. Setting this to an explicit empty string falls back to the in-memory store (events lost on daemon restart). |
 
 A misconfigured exporter — unknown name, or a known exporter whose construction fails — degrades gracefully to no-op rather than failing daemon startup. The Aileron HTTP server keeps serving when its telemetry sidecar is misconfigured; the failure is logged at warn level so you find it without it taking the daemon down.
 

--- a/internal/config/observability.go
+++ b/internal/config/observability.go
@@ -2,16 +2,16 @@ package config
 
 import (
 	"fmt"
+	"os"
+	"path/filepath"
 	"strconv"
 )
 
 // ObservabilityConfig holds the knobs that control OpenTelemetry
 // emission. Issue #390 Phase 7 ships this as foundation: the SDK
 // bootstrap and traceparent extraction land here so external callers
-// can correlate end-to-end. Span emission at action / connector /
-// capability / approval boundaries lands in follow-up PRs once the
-// audit-log file rotation work converges and we can share the
-// rotating writer between audit and traces.
+// can correlate end-to-end. Span emission integrations and the file
+// exporter ride on top.
 type ObservabilityConfig struct {
 	// OTelEnabled is the master switch. When false, the bootstrap
 	// installs a no-op tracer provider and tracing is effectively
@@ -27,16 +27,28 @@ type ObservabilityConfig struct {
 
 	// Exporter selects how spans leave the process. "noop" drops
 	// every span (the default; matches OTelEnabled=false). "stdout"
-	// writes JSON-per-line to stderr for local development. The
-	// file/OTLP exporters land in follow-up PRs.
+	// writes JSON-per-line to stderr for local development. "file"
+	// writes JSON-per-line to a daily-rotated file under TracesDir
+	// (path: <TracesDir>/traces/spans-YYYY-MM-DD.jsonl).
 	// Env: AILERON_OTEL_EXPORTER (default: "noop")
 	Exporter string
+
+	// TracesDir is the state directory under which the file exporter
+	// writes its daily-rotated spans file. The file itself lives at
+	// `<TracesDir>/traces/spans-YYYY-MM-DD.jsonl`, sibling to the
+	// audit log's `<TracesDir>/audit/audit-YYYY-MM-DD.jsonl` when
+	// the two share a state dir. Only consulted when Exporter ==
+	// "file"; the field is populated regardless so wiring code can
+	// inspect the resolved path without re-reading env vars.
+	// Env: AILERON_TRACES_DIR (default: <home>/.aileron)
+	TracesDir string
 }
 
 // Exporter values recognised by LoadObservabilityConfig.
 const (
 	ExporterNoop   = "noop"
 	ExporterStdout = "stdout"
+	ExporterFile   = "file"
 )
 
 const (
@@ -61,15 +73,38 @@ func LoadObservabilityConfig() (*ObservabilityConfig, error) {
 
 	exporter := envOrDefault("AILERON_OTEL_EXPORTER", defaultOTelExporter)
 	switch exporter {
-	case ExporterNoop, ExporterStdout:
+	case ExporterNoop, ExporterStdout, ExporterFile:
 	default:
-		return nil, fmt.Errorf("AILERON_OTEL_EXPORTER: unknown exporter %q (want %q or %q)",
-			exporter, ExporterNoop, ExporterStdout)
+		return nil, fmt.Errorf("AILERON_OTEL_EXPORTER: unknown exporter %q (want %q, %q, or %q)",
+			exporter, ExporterNoop, ExporterStdout, ExporterFile)
 	}
 
 	return &ObservabilityConfig{
 		OTelEnabled: enabled,
 		ServiceName: envOrDefault("AILERON_OTEL_SERVICE_NAME", defaultOTelServiceName),
 		Exporter:    exporter,
+		TracesDir:   resolveTracesDir(),
 	}, nil
+}
+
+// resolveTracesDir returns the state directory the file exporter
+// writes under. Mirrors the audit store's resolveAuditStateDir
+// behavior:
+//
+//   - env unset → default `<home>/.aileron`
+//   - env explicitly empty → "" (caller falls back to no-op)
+//   - env set → that exact path
+//
+// When UserHomeDir fails, fall back to ".aileron" (relative) so the
+// daemon still starts; the file exporter's MkdirAll will create the
+// dir relative to whatever directory the daemon was launched from.
+func resolveTracesDir() string {
+	if p, ok := os.LookupEnv("AILERON_TRACES_DIR"); ok {
+		return p
+	}
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return ".aileron"
+	}
+	return filepath.Join(home, ".aileron")
 }

--- a/internal/config/observability_test.go
+++ b/internal/config/observability_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"os"
+	"strings"
 	"testing"
 )
 
@@ -70,5 +72,61 @@ func TestLoadObservabilityConfig_TrimsServiceName(t *testing.T) {
 	}
 	if got, want := cfg.ServiceName, "aileron-staging"; got != want {
 		t.Errorf("ServiceName = %q, want %q", got, want)
+	}
+}
+
+func TestLoadObservabilityConfig_AcceptsFileExporter(t *testing.T) {
+	t.Setenv("AILERON_OTEL_ENABLED", "true")
+	t.Setenv("AILERON_OTEL_EXPORTER", "file")
+	cfg, err := LoadObservabilityConfig()
+	if err != nil {
+		t.Fatalf("LoadObservabilityConfig: %v", err)
+	}
+	if got, want := cfg.Exporter, ExporterFile; got != want {
+		t.Errorf("Exporter = %q, want %q", got, want)
+	}
+}
+
+func TestLoadObservabilityConfig_TracesDirHonorsEnv(t *testing.T) {
+	t.Setenv("AILERON_TRACES_DIR", "/var/lib/aileron/x")
+	cfg, err := LoadObservabilityConfig()
+	if err != nil {
+		t.Fatalf("LoadObservabilityConfig: %v", err)
+	}
+	if got, want := cfg.TracesDir, "/var/lib/aileron/x"; got != want {
+		t.Errorf("TracesDir = %q, want %q", got, want)
+	}
+}
+
+func TestLoadObservabilityConfig_TracesDirEmptyEnvIsExplicitlyEmpty(t *testing.T) {
+	// Symmetric to the audit store's resolveAuditStateDir: an
+	// explicit empty env var means "don't write to disk", as
+	// distinct from "use the default location."
+	t.Setenv("AILERON_TRACES_DIR", "")
+	cfg, err := LoadObservabilityConfig()
+	if err != nil {
+		t.Fatalf("LoadObservabilityConfig: %v", err)
+	}
+	if cfg.TracesDir != "" {
+		t.Errorf("TracesDir = %q, want empty", cfg.TracesDir)
+	}
+}
+
+func TestLoadObservabilityConfig_TracesDirDefaultsUnderHome(t *testing.T) {
+	// When no env var is set, TracesDir resolves to <home>/.aileron.
+	// We don't pin the exact value since the home dir varies per
+	// machine; assert it ends with the expected suffix.
+	if err := os.Unsetenv("AILERON_TRACES_DIR"); err != nil {
+		t.Fatalf("Unsetenv: %v", err)
+	}
+	cfg, err := LoadObservabilityConfig()
+	if err != nil {
+		t.Fatalf("LoadObservabilityConfig: %v", err)
+	}
+	if cfg.TracesDir == "" {
+		t.Fatal("expected non-empty TracesDir default; got empty")
+	}
+	if !strings.HasSuffix(cfg.TracesDir, ".aileron") {
+		t.Errorf("TracesDir = %q, want suffix .aileron", cfg.TracesDir)
 	}
 }

--- a/internal/observability/file_exporter.go
+++ b/internal/observability/file_exporter.go
@@ -1,0 +1,97 @@
+package observability
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"sync"
+
+	"github.com/ALRubinger/aileron/internal/dailypath"
+	"go.opentelemetry.io/otel/exporters/stdout/stdouttrace"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// fileExporter writes OTel spans as JSON-per-line to a daily-rotated
+// file under `<stateDir>/traces/spans-YYYY-MM-DD.jsonl`. The path
+// convention is shared with the audit log (`<stateDir>/audit/...`)
+// via the [dailypath] package, so a `~/.aileron` directory contains
+// both surfaces side-by-side and rotates them together.
+//
+// The exporter does not hold a file handle across calls. Each
+// ExportSpans opens today's path with O_APPEND|O_CREATE, writes the
+// batch, and closes — same shape the audit FileStore uses for its
+// writes (#468). Crossing midnight mid-batch is safe: the next call
+// computes a fresh path against the new local date.
+//
+// Span serialization piggy-backs on stdouttrace's compact-JSON
+// emitter — a fresh stdouttrace.Exporter is constructed per call,
+// pointed at the open file, then discarded. This avoids hand-rolling
+// JSON for every OTel span field; the tradeoff (allocating an
+// exporter struct per batch) is trivial since stdouttrace.New does
+// no I/O of its own.
+type fileExporter struct {
+	stateDir string
+
+	mu sync.Mutex
+}
+
+// newFileExporter ensures the traces subdirectory exists and returns
+// the exporter. Returns an error if the directory cannot be created
+// (permissions, disk full); the caller in [Init] surfaces the error
+// as a warn-log and degrades to no-op rather than failing daemon
+// startup.
+func newFileExporter(stateDir string) (*fileExporter, error) {
+	if stateDir == "" {
+		return nil, fmt.Errorf("traces state dir is empty")
+	}
+	if err := os.MkdirAll(dailypath.Dir(stateDir, tracesSubdir), 0o755); err != nil {
+		return nil, fmt.Errorf("creating traces directory: %w", err)
+	}
+	return &fileExporter{stateDir: stateDir}, nil
+}
+
+// tracesSubdir / tracesPrefix bind the trace exporter to its on-disk
+// shape: `<stateDir>/traces/spans-YYYY-MM-DD.jsonl`. Symmetric to
+// the auditSubdir / auditPrefix binding in internal/audit.
+const (
+	tracesSubdir = "traces"
+	tracesPrefix = "spans-"
+)
+
+// ExportSpans appends each span as one JSON line to today's traces
+// file. Concurrency-safe: the OTel SDK's batch processor serializes
+// calls upstream, but the mutex defends against multiple processors
+// or unusual configurations.
+func (e *fileExporter) ExportSpans(ctx context.Context, spans []sdktrace.ReadOnlySpan) error {
+	if len(spans) == 0 {
+		return nil
+	}
+	path := dailypath.Path(e.stateDir, tracesSubdir, tracesPrefix)
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	f, err := os.OpenFile(path, os.O_APPEND|os.O_CREATE|os.O_WRONLY, 0o600)
+	if err != nil {
+		return fmt.Errorf("opening traces file %s: %w", path, err)
+	}
+	defer f.Close()
+
+	// stdouttrace emits compact JSON-per-line by default (PrettyPrint
+	// is opt-in), which is exactly the shape jq-friendly tooling
+	// expects for the file at rest.
+	inner, err := stdouttrace.New(stdouttrace.WithWriter(f))
+	if err != nil {
+		return fmt.Errorf("constructing inner serializer: %w", err)
+	}
+	return inner.ExportSpans(ctx, spans)
+}
+
+// Shutdown is a no-op: the exporter holds no file handle, no
+// goroutine, no batched-but-unflushed state across calls. Each
+// ExportSpans is self-contained.
+func (e *fileExporter) Shutdown(_ context.Context) error {
+	return nil
+}
+
+// Compile-time check that fileExporter satisfies the SDK's
+// SpanExporter contract.
+var _ sdktrace.SpanExporter = (*fileExporter)(nil)

--- a/internal/observability/file_exporter_test.go
+++ b/internal/observability/file_exporter_test.go
@@ -1,0 +1,175 @@
+package observability
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/config"
+	"github.com/ALRubinger/aileron/internal/dailypath"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+)
+
+// File exporter contract:
+//   - Writes spans to <stateDir>/traces/spans-YYYY-MM-DD.jsonl,
+//     using the dailypath convention shared with the audit log.
+//   - Empty batches are a no-op (don't create empty files).
+//   - Each span emerges as one JSON line; the file is parseable by
+//     standard JSONL tooling.
+//   - Multiple ExportSpans calls append (don't overwrite).
+//   - Empty stateDir is rejected at construction time.
+//   - Shutdown is a no-op (no held file handle to flush).
+
+func TestNewFileExporter_RejectsEmptyStateDir(t *testing.T) {
+	if _, err := newFileExporter(""); err == nil {
+		t.Fatal("expected error for empty stateDir")
+	}
+}
+
+func TestNewFileExporter_CreatesTracesSubdir(t *testing.T) {
+	stateDir := t.TempDir()
+	if _, err := newFileExporter(stateDir); err != nil {
+		t.Fatalf("newFileExporter: %v", err)
+	}
+	tracesDir := dailypath.Dir(stateDir, tracesSubdir)
+	if info, err := os.Stat(tracesDir); err != nil || !info.IsDir() {
+		t.Fatalf("expected traces subdir at %s; err=%v", tracesDir, err)
+	}
+}
+
+func TestFileExporter_WritesSpansToTodaysFile(t *testing.T) {
+	stateDir := t.TempDir()
+	exp, err := newFileExporter(stateDir)
+	if err != nil {
+		t.Fatalf("newFileExporter: %v", err)
+	}
+
+	// Drive a span through a synchronous SDK provider configured to
+	// export to our file exporter.
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+	tracer := tp.Tracer("test")
+	_, span := tracer.Start(context.Background(), "exported-span")
+	span.End()
+	if err := tp.ForceFlush(context.Background()); err != nil {
+		t.Fatalf("ForceFlush: %v", err)
+	}
+
+	wantPath := dailypath.PathAt(stateDir, tracesSubdir, tracesPrefix, time.Now())
+	contents, err := os.ReadFile(wantPath)
+	if err != nil {
+		t.Fatalf("reading traces file %s: %v", wantPath, err)
+	}
+	body := string(contents)
+	if !strings.Contains(body, "exported-span") {
+		t.Errorf("expected span name in file; got %q", body)
+	}
+	// Sanity-check the file is JSONL: at least one non-empty line
+	// must parse as valid JSON.
+	parsedAny := false
+	for _, line := range strings.Split(body, "\n") {
+		line = strings.TrimSpace(line)
+		if line == "" {
+			continue
+		}
+		var record map[string]any
+		if err := json.Unmarshal([]byte(line), &record); err != nil {
+			t.Errorf("file contains non-JSON line: %q (%v)", line, err)
+			continue
+		}
+		parsedAny = true
+	}
+	if !parsedAny {
+		t.Errorf("expected at least one parseable JSON line in %q", body)
+	}
+}
+
+func TestFileExporter_EmptyBatchIsNoOp(t *testing.T) {
+	stateDir := t.TempDir()
+	exp, err := newFileExporter(stateDir)
+	if err != nil {
+		t.Fatalf("newFileExporter: %v", err)
+	}
+	// Pass nil; ExportSpans must early-return without I/O.
+	if err := exp.ExportSpans(context.Background(), nil); err != nil {
+		t.Errorf("ExportSpans on empty batch returned error: %v", err)
+	}
+	// The file must not have been created — empty batches mustn't
+	// produce empty files (which would make grep tooling miss
+	// something / nothing in the absence of meaningful events).
+	wantPath := dailypath.PathAt(stateDir, tracesSubdir, tracesPrefix, time.Now())
+	if _, err := os.Stat(wantPath); !os.IsNotExist(err) {
+		t.Errorf("traces file should not exist for empty batch; stat err=%v", err)
+	}
+}
+
+func TestFileExporter_SubsequentCallsAppend(t *testing.T) {
+	stateDir := t.TempDir()
+	exp, err := newFileExporter(stateDir)
+	if err != nil {
+		t.Fatalf("newFileExporter: %v", err)
+	}
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	t.Cleanup(func() { _ = tp.Shutdown(context.Background()) })
+
+	tracer := tp.Tracer("test")
+	for _, name := range []string{"first-span", "second-span", "third-span"} {
+		_, span := tracer.Start(context.Background(), name)
+		span.End()
+	}
+	if err := tp.ForceFlush(context.Background()); err != nil {
+		t.Fatalf("ForceFlush: %v", err)
+	}
+
+	contents, err := os.ReadFile(filepath.Join(stateDir, "traces", "spans-"+time.Now().Format("2006-01-02")+".jsonl"))
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	body := string(contents)
+	for _, name := range []string{"first-span", "second-span", "third-span"} {
+		if !strings.Contains(body, name) {
+			t.Errorf("expected %q in appended file; got %q", name, body)
+		}
+	}
+}
+
+func TestFileExporter_ShutdownIsNoOp(t *testing.T) {
+	stateDir := t.TempDir()
+	exp, err := newFileExporter(stateDir)
+	if err != nil {
+		t.Fatalf("newFileExporter: %v", err)
+	}
+	if err := exp.Shutdown(context.Background()); err != nil {
+		t.Errorf("Shutdown returned error: %v", err)
+	}
+	// Shutdown is idempotent — multiple calls are fine.
+	if err := exp.Shutdown(context.Background()); err != nil {
+		t.Errorf("second Shutdown returned error: %v", err)
+	}
+}
+
+func TestNewExporter_DispatchesFileByConfig(t *testing.T) {
+	// The newExporter dispatch in tracing.go must route Exporter=file
+	// through to newFileExporter with the configured TracesDir. This
+	// is what wires the config-driven choice into the global Init
+	// code path.
+	stateDir := t.TempDir()
+	cfg := &config.ObservabilityConfig{
+		Exporter:  config.ExporterFile,
+		TracesDir: stateDir,
+	}
+	exp, err := newExporter(cfg, nil /* stdoutW unused for file */)
+	if err != nil {
+		t.Fatalf("newExporter(file): %v", err)
+	}
+	if exp == nil {
+		t.Fatal("expected file exporter, got nil")
+	}
+	if info, err := os.Stat(filepath.Join(stateDir, "traces")); err != nil || !info.IsDir() {
+		t.Errorf("traces subdir not created at construction; err=%v", err)
+	}
+}

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -99,7 +99,7 @@ func TestHTTPMiddleware_MalformedTraceparentStartsFreshTrace(t *testing.T) {
 
 func TestHTTPMiddleware_ExportsSpanWithStatus5xxAsError(t *testing.T) {
 	var buf bytes.Buffer
-	exp, err := newExporter(config.ExporterStdout, &buf)
+	exp, err := newExporter(&config.ObservabilityConfig{Exporter: config.ExporterStdout}, &buf)
 	if err != nil {
 		t.Fatalf("newExporter: %v", err)
 	}

--- a/internal/observability/tracing.go
+++ b/internal/observability/tracing.go
@@ -90,7 +90,7 @@ func Init(cfg *config.ObservabilityConfig, log *slog.Logger) *Provider {
 		return &Provider{TracerProvider: p}
 	}
 
-	exporter, err := newExporter(cfg.Exporter, os.Stderr)
+	exporter, err := newExporter(cfg, os.Stderr)
 	if err != nil {
 		log.Warn("observability: exporter construction failed; tracing disabled",
 			"exporter", cfg.Exporter, "error", err.Error())
@@ -135,18 +135,21 @@ func Init(cfg *config.ObservabilityConfig, log *slog.Logger) *Provider {
 // Returns (nil, nil) for the no-op case so the caller can short-
 // circuit to a no-op provider without constructing the SDK.
 //
-// w is the writer the stdout exporter targets — taken as a parameter
-// so tests can capture span output without race conditions on
-// os.Stderr.
-func newExporter(name string, w io.Writer) (sdktrace.SpanExporter, error) {
-	switch name {
+// stdoutW is the writer the stdout exporter targets — taken as a
+// parameter so tests can capture span output without race
+// conditions on os.Stderr. The file exporter uses cfg.TracesDir
+// directly; the writer parameter does not apply.
+func newExporter(cfg *config.ObservabilityConfig, stdoutW io.Writer) (sdktrace.SpanExporter, error) {
+	switch cfg.Exporter {
 	case config.ExporterNoop, "":
 		return nil, nil
 	case config.ExporterStdout:
 		// PrettyPrint is intentionally off: jq-friendly JSON-per-line
 		// is what humans want when piping through standard tooling.
-		return stdouttrace.New(stdouttrace.WithWriter(w))
+		return stdouttrace.New(stdouttrace.WithWriter(stdoutW))
+	case config.ExporterFile:
+		return newFileExporter(cfg.TracesDir)
 	default:
-		return nil, fmt.Errorf("unknown exporter %q", name)
+		return nil, fmt.Errorf("unknown exporter %q", cfg.Exporter)
 	}
 }

--- a/internal/observability/tracing_test.go
+++ b/internal/observability/tracing_test.go
@@ -84,7 +84,7 @@ func TestInit_StdoutExporterEmitsSpan(t *testing.T) {
 	// this test asserts the exporter contract — given a span, write a
 	// JSON line — which is the part that matters for downstream tooling.
 	var buf bytes.Buffer
-	exp, err := newExporter(cfg.Exporter, &buf)
+	exp, err := newExporter(cfg, &buf)
 	if err != nil {
 		t.Fatalf("newExporter: %v", err)
 	}


### PR DESCRIPTION
## Summary

Closes the original file-rotation gate on #390. Spans now have a durable destination: `<stateDir>/traces/spans-YYYY-MM-DD.jsonl`, sibling to the audit log's `<stateDir>/audit/audit-YYYY-MM-DD.jsonl`. Both surfaces share the path-naming convention via `internal/dailypath` (merged in #471), so retention and rotation are consistent across the two on-disk surfaces.

```
~/.aileron/
├── audit/
│   ├── audit-2026-05-04.jsonl
│   └── audit-2026-05-05.jsonl
└── traces/
    ├── spans-2026-05-04.jsonl
    └── spans-2026-05-05.jsonl
```

### Implementation

`internal/observability/file_exporter.go`:
- `newFileExporter` eagerly creates the traces subdirectory so dir-permission failures surface at startup, not on first emission.
- `ExportSpans` opens today's path with `O_APPEND|O_CREATE` per call, computes the path freshly each time so a session crossing midnight rolls naturally to the next day's file. No file handle held across calls.
- Span serialization piggy-backs on `stdouttrace`'s compact-JSON emitter — a fresh `stdouttrace.Exporter` per call, pointed at the open file, then discarded. Avoids hand-rolling JSON for every OTel span field.
- Empty batches are a no-op: don't create empty files (which would be misleading to grep tooling looking for "anything happened").

### Configuration

- New `ExporterFile = "file"` joins `ExporterNoop` / `ExporterStdout`.
- New `TracesDir` field on `ObservabilityConfig`, populated from `AILERON_TRACES_DIR` (default: `~/.aileron`). Mirrors the audit store's `resolveAuditStateDir` behavior — explicit empty env var means "no file exporter, degrade to no-op."
- `newExporter` dispatch now takes `*ObservabilityConfig` instead of just the exporter name, so it can read `TracesDir` for the file case.

### Usage

```sh
AILERON_OTEL_ENABLED=true \
AILERON_OTEL_EXPORTER=file \
aileron launch claude
```

## Test plan

- [x] 7 new file-exporter tests: rejects empty stateDir, creates traces subdir at construction, writes spans to today's file, empty batch is no-op (no empty file created), subsequent calls append, `Shutdown` is idempotent, dispatch via config routes correctly
- [x] 4 new config tests: file exporter accepted, `TracesDir` honors env, empty env is explicitly empty (not the default), default suffix is `.aileron`
- [x] Existing tests updated for the `newExporter` signature change
- [x] Coverage: `internal/observability` 90.5%, `internal/config` 96.1%
- [x] `go test ./...` — full internal-module sweep green
- [x] All four `cmd/*` modules build cleanly
- [x] `task build:docs` — 55 pages, no errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)
