### PR TITLE
feat(intercept): emit aileron.gateway.* + aileron.intercept.round spans (#390)

### DIFF
--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -69,17 +69,18 @@ Tracing is independent of the audit log. The audit log answers *what was done*; 
 
 ### What gets emitted
 
-Today (as the Phase 7 emission integrations land slice by slice in [issue #390](https://github.com/ALRubinger/aileron/issues/390)):
+The Phase 7 emission integrations from [issue #390](https://github.com/ALRubinger/aileron/issues/390) are now complete:
 
-| Span name | Where it's emitted | Status |
-|---|---|---|
-| `aileron.mcp.tool.call` | `aileron-mcp` outbound to `/v1/actions/{name}/run` — typically the trace root under `aileron launch` | ✅ shipped |
-| `aileron.action.execute` | `SandboxExecutor.Execute` — root for an action invocation | ✅ shipped |
-| `aileron.connector.call` | per-step `conn.Invoke` inside the executor | ✅ shipped |
-| `aileron.capability.check` | per-step action-boundary capability enforcement (defense-in-depth, [ADR-0003](/adr/0003-action-model)) — first observability point on "how often does the sandbox say no?" | ✅ shipped |
-| `aileron.approval.wait` | the approval-queue blocking wait — covers the entire user-decision interval; `aileron.approval.decision` is `approved` / `denied` / `timeout` / `cancelled` | ✅ shipped |
-| HTTP server-root span | gateway and `/v1/actions/{name}/run` entry points | ✅ shipped |
-| `aileron.gateway.openai.chat` / `aileron.gateway.anthropic.messages` | LLM round-trip on the gateway | ⏳ pending |
+| Span name | Where it's emitted |
+|---|---|
+| `aileron.mcp.tool.call` | `aileron-mcp` outbound to `/v1/actions/{name}/run` — typically the trace root under `aileron launch` |
+| `aileron.gateway.openai.chat` / `aileron.gateway.anthropic.messages` | LLM round-trip on the gateway endpoints |
+| `aileron.intercept.round` | per round of the augmentation/interception loop when actions are installed; carries `aileron.intercept.{round_index,protocol,tool_calls_count,terminal}` |
+| `aileron.action.execute` | `SandboxExecutor.Execute` — root for an action invocation |
+| `aileron.capability.check` | per-step action-boundary capability enforcement (defense-in-depth, [ADR-0003](/adr/0003-action-model)) |
+| `aileron.connector.call` | per-step `conn.Invoke` inside the executor |
+| `aileron.approval.wait` | the approval-queue blocking wait — covers the entire user-decision interval; `aileron.approval.decision` is `approved` / `denied` / `timeout` / `cancelled` |
+| HTTP server-root span | other API entry points (`/v1/audit`, `/v1/bindings`, etc.) — generic "METHOD /path" naming |
 
 The file exporter is shipped — spans land in `~/.aileron/traces/spans-YYYY-MM-DD.jsonl`, sibling to the audit log's `~/.aileron/audit/audit-YYYY-MM-DD.jsonl`. Both surfaces share the path-naming convention via the `internal/dailypath` package, so retention and rotation are consistent across the two on-disk surfaces.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -718,20 +718,21 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 }
 
 // spanNameForRequest shapes server-root span names for the tracing
-// middleware. Default-style "METHOD /path" is fine for static paths
-// (`POST /v1/chat/completions`), but path-templated routes carrying
-// IDs (`POST /v1/actions/{name}/run`) blow up cardinality if the
-// raw URL is used as the span name. We collapse the two known
-// templated routes back to their template form so trace tooling
-// groups them correctly.
+// middleware. Static paths get "METHOD /path"; path-templated routes
+// carrying IDs (`POST /v1/actions/{name}/run`) collapse back to the
+// template form so trace tooling groups them correctly. The two
+// gateway endpoints get domain-shaped names (`aileron.gateway.openai.chat`,
+// `aileron.gateway.anthropic.messages`) so consumers can filter for
+// "all LLM round-trips" without grepping URL paths — they're the
+// secondary trace surface from issue #390 Phase 7.
 func spanNameForRequest(r *http.Request) string {
 	switch {
 	case r.Method == http.MethodPost && strings.HasPrefix(r.URL.Path, "/v1/actions/") && strings.HasSuffix(r.URL.Path, "/run"):
 		return "POST /v1/actions/{name}/run"
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/chat/completions":
-		return "POST /v1/chat/completions"
+		return "aileron.gateway.openai.chat"
 	case r.Method == http.MethodPost && r.URL.Path == "/v1/messages":
-		return "POST /v1/messages"
+		return "aileron.gateway.anthropic.messages"
 	}
 	return r.Method + " " + r.URL.Path
 }

--- a/internal/intercept/anthropic.go
+++ b/internal/intercept/anthropic.go
@@ -14,6 +14,10 @@ import (
 	"github.com/ALRubinger/aileron/internal/failure"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/retry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
 
 // HandleAnthropic mirrors HandleOpenAI for the Anthropic Messages
@@ -56,19 +60,33 @@ func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
 
 	gatewayActor := model.ActorRef{ID: "aileron-gateway", Type: model.ActorTypeService}
 
+	tracer := otel.GetTracerProvider().Tracer(tracerName)
 	for round := 0; round < maxRounds; round++ {
-		respStatus, respHeaders, respBody, sendFailure := e.sendAnthropicWithRetry(r, currentBody)
+		roundCtx, roundSpan := tracer.Start(r.Context(), "aileron.intercept.round",
+			trace.WithSpanKind(trace.SpanKindInternal),
+			trace.WithAttributes(
+				attribute.Int("aileron.intercept.round_index", round),
+				attribute.String("aileron.intercept.protocol", "anthropic"),
+			),
+		)
+		respStatus, respHeaders, respBody, sendFailure := e.sendAnthropicWithRetry(r.WithContext(roundCtx), currentBody)
 		if sendFailure != nil {
+			roundSpan.SetStatus(codes.Error, sendFailure.Message())
+			roundSpan.End()
 			writeFailure(r.Context(), w, e.recorder, sendFailure, gatewayActor)
 			return
 		}
 		if respStatus != http.StatusOK {
+			roundSpan.SetAttributes(attribute.Int("aileron.intercept.upstream_status", respStatus))
+			roundSpan.End()
 			passThrough(w, respStatus, respHeaders, respBody)
 			return
 		}
 
 		assistantContent, toolUses, err := parseAnthropicResponse(respBody)
 		if err != nil {
+			roundSpan.SetStatus(codes.Error, "parse upstream response: "+err.Error())
+			roundSpan.End()
 			passThrough(w, respStatus, respHeaders, respBody)
 			return
 		}
@@ -76,17 +94,24 @@ func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
 		ours, theirs := classifyAnthropicToolUses(toolUses, ourNames)
 
 		if len(ours) == 0 {
+			roundSpan.SetAttributes(attribute.Bool("aileron.intercept.terminal", true))
+			roundSpan.End()
 			emitAnthropicTerminal(w, respBody, wantStream)
 			return
 		}
 		if len(theirs) > 0 {
+			roundSpan.SetStatus(codes.Error, "mixed_tool_calls_unsupported")
+			roundSpan.End()
 			writeError(w, http.StatusBadGateway, "mixed_tool_calls_unsupported",
 				"the gateway does not yet support a single response that mixes Aileron tool calls with agent-declared tool calls")
 			return
 		}
+		roundSpan.SetAttributes(attribute.Int("aileron.intercept.tool_calls_count", len(ours)))
 
-		toolResultBlocks, execErr := e.executeAnthropicToolUses(r.Context(), ours)
+		toolResultBlocks, execErr := e.executeAnthropicToolUses(roundCtx, ours)
 		if execErr != nil {
+			roundSpan.SetStatus(codes.Error, "executor fatal: "+execErr.Error())
+			roundSpan.End()
 			writeFailure(r.Context(), w, e.recorder,
 				failure.ConnectorRuntime("action executor fatal error: "+execErr.Error(), false,
 					failure.WithBoundary(failure.Runtime),
@@ -97,11 +122,14 @@ func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
 
 		nextBody, err := appendAnthropicContinuation(currentBody, assistantContent, toolResultBlocks)
 		if err != nil {
+			roundSpan.SetStatus(codes.Error, "continuation: "+err.Error())
+			roundSpan.End()
 			writeError(w, http.StatusInternalServerError, "continuation_error",
 				"failed to build continuation request: "+err.Error())
 			return
 		}
 		currentBody = nextBody
+		roundSpan.End()
 	}
 
 	writeError(w, http.StatusBadGateway, "max_intercept_rounds",

--- a/internal/intercept/intercept_span_test.go
+++ b/internal/intercept/intercept_span_test.go
@@ -1,0 +1,184 @@
+package intercept
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/action"
+	"go.opentelemetry.io/otel"
+	sdktrace "go.opentelemetry.io/otel/sdk/trace"
+	"go.opentelemetry.io/otel/sdk/trace/tracetest"
+)
+
+// Span emission contract for the intercept loop:
+//
+//   - One aileron.intercept.round span per iteration of the loop.
+//     SpanKind=Internal. Round index attribute (0-based) tracks order.
+//   - Protocol attribute distinguishes openai vs anthropic.
+//   - Terminal round carries aileron.intercept.terminal=true.
+//   - Tool-bearing rounds carry aileron.intercept.tool_calls_count.
+//   - Failure paths set span status Error with a message.
+
+func withInMemoryExporter(t *testing.T) *tracetest.InMemoryExporter {
+	t.Helper()
+	exp := tracetest.NewInMemoryExporter()
+	tp := sdktrace.NewTracerProvider(sdktrace.WithSyncer(exp))
+	prev := otel.GetTracerProvider()
+	otel.SetTracerProvider(tp)
+	t.Cleanup(func() {
+		_ = tp.Shutdown(context.Background())
+		otel.SetTracerProvider(prev)
+	})
+	return exp
+}
+
+func roundSpans(spans []sdktrace.ReadOnlySpan) []sdktrace.ReadOnlySpan {
+	var out []sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		if s.Name() == "aileron.intercept.round" {
+			out = append(out, s)
+		}
+	}
+	return out
+}
+
+func attrInt(s sdktrace.ReadOnlySpan, key string) (int64, bool) {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsInt64(), true
+		}
+	}
+	return 0, false
+}
+
+func attrString(s sdktrace.ReadOnlySpan, key string) (string, bool) {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsString(), true
+		}
+	}
+	return "", false
+}
+
+func attrBool(s sdktrace.ReadOnlySpan, key string) (bool, bool) {
+	for _, a := range s.Attributes() {
+		if string(a.Key) == key {
+			return a.Value.AsBool(), true
+		}
+	}
+	return false, false
+}
+
+func TestHandleOpenAI_EmitsInterceptRoundSpans(t *testing.T) {
+	// Two-round flow: round 0 returns a tool call, round 1 returns
+	// the terminal text. We expect two intercept.round spans, the
+	// first carrying tool_calls_count=1, the second terminal=true.
+	exp := withInMemoryExporter(t)
+
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"tool_calls","message":{"role":"assistant","tool_calls":[{"id":"call_1","type":"function","function":{"name":"ship_update","arguments":"{\"channel\":\"#engineering\"}"}}]}}]}`,
+		`{"id":"r2","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"Posted."}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{result: action.Result{Content: `{"posted":true}`}}
+	e := engineFor(t, upstream.URL, "", store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"tell team I shipped"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	spans := roundSpans(exp.GetSpans().Snapshots())
+	if len(spans) != 2 {
+		t.Fatalf("got %d round spans, want 2", len(spans))
+	}
+
+	// Find by round_index — span end order isn't strictly guaranteed
+	// but in this synchronous flow it should be. Assert by attribute
+	// to be robust regardless.
+	var round0, round1 sdktrace.ReadOnlySpan
+	for _, s := range spans {
+		idx, _ := attrInt(s, "aileron.intercept.round_index")
+		switch idx {
+		case 0:
+			round0 = s
+		case 1:
+			round1 = s
+		}
+	}
+	if round0 == nil || round1 == nil {
+		t.Fatalf("expected spans for round_index 0 and 1; got: %+v", spans)
+	}
+
+	// Both spans carry the openai protocol attribute.
+	for i, s := range []sdktrace.ReadOnlySpan{round0, round1} {
+		if v, _ := attrString(s, "aileron.intercept.protocol"); v != "openai" {
+			t.Errorf("round %d protocol = %q, want openai", i, v)
+		}
+	}
+
+	// Round 0 had a tool call; round 1 was terminal.
+	if v, ok := attrInt(round0, "aileron.intercept.tool_calls_count"); !ok || v != 1 {
+		t.Errorf("round 0 tool_calls_count = %v (ok=%v), want 1", v, ok)
+	}
+	if v, ok := attrBool(round1, "aileron.intercept.terminal"); !ok || !v {
+		t.Errorf("round 1 terminal = %v (ok=%v), want true", v, ok)
+	}
+}
+
+func TestHandleAnthropic_EmitsInterceptRoundSpansWithProtocolLabel(t *testing.T) {
+	// Single terminal round on the Anthropic path: assert one
+	// intercept.round span with protocol=anthropic.
+	exp := withInMemoryExporter(t)
+
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"m1","type":"message","role":"assistant","model":"claude","content":[{"type":"text","text":"hello"}],"stop_reason":"end_turn"}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{}
+	e := engineFor(t, "", upstream.URL, store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"claude","messages":[{"role":"user","content":"hi"}],"max_tokens":1024}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+
+	spans := roundSpans(exp.GetSpans().Snapshots())
+	if len(spans) != 1 {
+		t.Fatalf("got %d round spans, want 1", len(spans))
+	}
+	if v, _ := attrString(spans[0], "aileron.intercept.protocol"); v != "anthropic" {
+		t.Errorf("protocol = %q, want anthropic", v)
+	}
+	if v, ok := attrBool(spans[0], "aileron.intercept.terminal"); !ok || !v {
+		t.Errorf("terminal = %v (ok=%v), want true", v, ok)
+	}
+}
+
+func TestHandleOpenAI_NoOpProviderDoesNotPanic(t *testing.T) {
+	// Default OTel global is no-op until daemon Init runs. The
+	// intercept loop must still work — span ops are no-ops.
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"r1","object":"chat.completion","model":"gpt-4","choices":[{"index":0,"finish_reason":"stop","message":{"role":"assistant","content":"hi"}}]}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{}
+	e := engineFor(t, upstream.URL, "", store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+	if w.Code != http.StatusOK {
+		t.Errorf("status = %d, want 200 with no-op tracer; body=%s", w.Code, w.Body.String())
+	}
+}

--- a/internal/intercept/openai.go
+++ b/internal/intercept/openai.go
@@ -15,7 +15,16 @@ import (
 	"github.com/ALRubinger/aileron/internal/failure"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/retry"
+	"go.opentelemetry.io/otel"
+	"go.opentelemetry.io/otel/attribute"
+	"go.opentelemetry.io/otel/codes"
+	"go.opentelemetry.io/otel/trace"
 )
+
+// tracerName names the OTel instrumentation library reported on
+// spans this package emits. Mirrors the convention used in
+// internal/action and internal/observability.
+const tracerName = "github.com/ALRubinger/aileron/internal/intercept"
 
 // HandleOpenAI runs the augmentation + interception loop for an
 // OpenAI Chat Completions request. The request body is read once,
@@ -74,19 +83,33 @@ func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
 
 	gatewayActor := model.ActorRef{ID: "aileron-gateway", Type: model.ActorTypeService}
 
+	tracer := otel.GetTracerProvider().Tracer(tracerName)
 	for round := 0; round < maxRounds; round++ {
-		respStatus, respHeaders, respBody, sendFailure := e.sendOpenAIWithRetry(r, currentBody)
+		roundCtx, roundSpan := tracer.Start(r.Context(), "aileron.intercept.round",
+			trace.WithSpanKind(trace.SpanKindInternal),
+			trace.WithAttributes(
+				attribute.Int("aileron.intercept.round_index", round),
+				attribute.String("aileron.intercept.protocol", "openai"),
+			),
+		)
+		respStatus, respHeaders, respBody, sendFailure := e.sendOpenAIWithRetry(r.WithContext(roundCtx), currentBody)
 		if sendFailure != nil {
+			roundSpan.SetStatus(codes.Error, sendFailure.Message())
+			roundSpan.End()
 			writeFailure(r.Context(), w, e.recorder, sendFailure, gatewayActor)
 			return
 		}
 		if respStatus != http.StatusOK {
+			roundSpan.SetAttributes(attribute.Int("aileron.intercept.upstream_status", respStatus))
+			roundSpan.End()
 			passThrough(w, respStatus, respHeaders, respBody)
 			return
 		}
 
 		assistantMsg, toolCalls, err := parseOpenAIChoice(respBody)
 		if err != nil {
+			roundSpan.SetStatus(codes.Error, "parse upstream response: "+err.Error())
+			roundSpan.End()
 			passThrough(w, respStatus, respHeaders, respBody)
 			return
 		}
@@ -96,17 +119,24 @@ func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
 		if len(ours) == 0 {
 			// No Aileron tool calls — terminal for this round.
 			// Either pure-text response or agent's tools to handle.
+			roundSpan.SetAttributes(attribute.Bool("aileron.intercept.terminal", true))
+			roundSpan.End()
 			emitOpenAITerminal(w, respBody, wantStream)
 			return
 		}
 		if len(theirs) > 0 {
+			roundSpan.SetStatus(codes.Error, "mixed_tool_calls_unsupported")
+			roundSpan.End()
 			writeError(w, http.StatusBadGateway, "mixed_tool_calls_unsupported",
 				"the gateway does not yet support a single response that mixes Aileron tool calls with agent-declared tool calls")
 			return
 		}
+		roundSpan.SetAttributes(attribute.Int("aileron.intercept.tool_calls_count", len(ours)))
 
-		toolMessages, execErr := e.executeOpenAIToolCalls(r.Context(), ours)
+		toolMessages, execErr := e.executeOpenAIToolCalls(roundCtx, ours)
 		if execErr != nil {
+			roundSpan.SetStatus(codes.Error, "executor fatal: "+execErr.Error())
+			roundSpan.End()
 			writeFailure(r.Context(), w, e.recorder,
 				failure.ConnectorRuntime("action executor fatal error: "+execErr.Error(), false,
 					failure.WithBoundary(failure.Runtime),
@@ -117,11 +147,14 @@ func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
 
 		nextBody, err := appendOpenAIContinuation(currentBody, assistantMsg, toolMessages)
 		if err != nil {
+			roundSpan.SetStatus(codes.Error, "continuation: "+err.Error())
+			roundSpan.End()
 			writeError(w, http.StatusInternalServerError, "continuation_error",
 				"failed to build continuation request: "+err.Error())
 			return
 		}
 		currentBody = nextBody
+		roundSpan.End()
 	}
 
 	writeError(w, http.StatusBadGateway, "max_intercept_rounds",


### PR DESCRIPTION
## Summary

Final Phase 7 emission slice for #390. With this in, every span family the issue called out is shipped.

### Two changes

**1. `spanNameForRequest` in `internal/app/app.go`**: rename gateway endpoint spans to their domain-shaped names.

| Before | After |
|---|---|
| `POST /v1/chat/completions` | `aileron.gateway.openai.chat` |
| `POST /v1/messages` | `aileron.gateway.anthropic.messages` |

Other API entry points keep their `METHOD /path` shape. Consumers can now filter for "all LLM round-trips" without grepping URL paths.

**2. `internal/intercept/openai.go` and `anthropic.go`**: wrap each iteration of the augmentation loop in an `aileron.intercept.round` span. Attributes:

- `aileron.intercept.round_index` — 0-based, monotonic per request
- `aileron.intercept.protocol` — `"openai"` or `"anthropic"`
- `aileron.intercept.tool_calls_count` — when Aileron tools are called
- `aileron.intercept.terminal` — `true` when the round produced the final assistant message
- `aileron.intercept.upstream_status` — when upstream returned a non-200

Failure paths set span status `Error` with a message describing which boundary failed (upstream, parse, executor, continuation).

### Trace tree (under `aileron launch`, intercept enabled)

```
aileron.mcp.tool.call                     (#464, root)
└── aileron.action.execute                (#461)
    ├── aileron.capability.check          (#466)
    └── aileron.connector.call            (#461)
```

### Trace tree (gateway with augmentation enabled, no MCP)

```
aileron.gateway.openai.chat               (this PR)
└── aileron.intercept.round (×N)          (this PR)
    └── aileron.action.execute            (#461)
        ├── aileron.capability.check      (#466)
        └── aileron.connector.call        (#461)
```

## Test plan

- [x] 3 new intercept span tests: openai two-round flow (`round_index=0` with `tool_calls_count`, `round_index=1` with `terminal=true`), anthropic single-round terminal, no-op tracer fallback
- [x] Coverage: `internal/intercept` 91.6%
- [x] Existing intercept suite (15 tests) green — span emission is purely additive
- [x] `go test ./...` — full internal-module sweep green
- [x] All four `cmd/*` modules build cleanly
- [x] `task build:docs` — 55 pages, no errors

Closes #390 once merged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
