### PR TITLE
feat(audit): reserve aileron.signing.key_id + aileron.policy.decision

### DIFF
--- a/docs/src/content/docs/adr/0010-failure-handling.md
+++ b/docs/src/content/docs/adr/0010-failure-handling.md
@@ -257,6 +257,17 @@ The recorder in [`internal/audit/record.go`](https://github.com/ALRubinger/ailer
 
 Phase 7 (post-MVP) wires the actual OTLP exporter and `traceparent` propagation per [#390](https://github.com/ALRubinger/aileron/issues/390); the names are pre-aligned so that emission becomes a wiring change, not a schema break.
 
+#### Reserved keys (declared, not yet emitted)
+
+Two attribute keys are declared in the audit payload schema but not populated by any recorder today. They are reserved so future features can adopt them without forcing a downstream-visible rename once consumers depend on the format. Constants live in `internal/audit/keys.go`.
+
+| Key | Reserved for | Issue |
+|---|---|---|
+| `aileron.signing.key_id` | The public-key fingerprint that signed an audit event under the Stage-1.5 hash-chained audit log. | [#398](https://github.com/ALRubinger/aileron/issues/398) |
+| `aileron.policy.decision` | The verdict a pre-execution policy hook returned for the action that produced this event: `allow`, `deny`, `require_approval`, or an opaque decision-source reference. | [#396](https://github.com/ALRubinger/aileron/issues/396), [#399](https://github.com/ALRubinger/aileron/issues/399) |
+
+Consumers reading the audit log MUST tolerate these keys appearing as empty / absent today and as populated values once the corresponding features ship. Reading code that names them by string literal should switch to the `audit.AttrSigningKeyID` and `audit.AttrPolicyDecision` constants so a future spelling refinement (which would itself require migration coordination) has a single point of change.
+
 ### For users
 
 - Failures are surfaced. The user sees the agent's chat say "I tried to post the update but Slack returned an error — would you like me to try again with a different channel?" rather than the agent claiming success and the message never arriving.

--- a/internal/audit/keys.go
+++ b/internal/audit/keys.go
@@ -1,0 +1,33 @@
+package audit
+
+// Reserved attribute keys for the audit-event payload.
+//
+// These names are declared as part of the ADR-0010 schema but no
+// recorder emits them yet. They exist so future implementations of
+// signed audit logs (#398) and the external policy hook (#396, #399)
+// pick up the same spelling rather than choosing alternates that
+// would force a downstream-visible rename later.
+//
+// Both names follow the OTel-namespaced convention shared with the
+// rest of the audit payload (#390 Phase 6.5). When the corresponding
+// features ship, recorders import these constants instead of writing
+// the string literally.
+//
+// Reservations were committed in #404's "Schema lock-in" track and
+// in the per-issue Phase 6.5 commitments on #398 and #399. The
+// rename portion of Phase 6.5 shipped in #452; this file is the
+// reservation portion.
+const (
+	// AttrSigningKeyID is the public-key fingerprint that signed an
+	// audit event under the Stage-1.5 hash-chained audit log (#398).
+	// Empty / absent on every event today; populated when signing
+	// lands.
+	AttrSigningKeyID = "aileron.signing.key_id"
+
+	// AttrPolicyDecision is the verdict a pre-execution policy hook
+	// returned for the action that produced this event: "allow",
+	// "deny", "require_approval", or an opaque decision-source
+	// reference (#396, #399). Empty / absent on every event today;
+	// populated when the policy hook lands.
+	AttrPolicyDecision = "aileron.policy.decision"
+)

--- a/internal/audit/keys_test.go
+++ b/internal/audit/keys_test.go
@@ -1,0 +1,22 @@
+package audit
+
+import "testing"
+
+// The reserved keys aren't behavior, they're contract. The contract
+// is that these specific spellings are stable. The test guards the
+// spellings against accidental rename. When a recorder eventually
+// emits one of these, change it here AND in any consumer reading the
+// audit log; this test is the single point of truth for the wire
+// strings.
+
+func TestAttrSigningKeyIDSpelling(t *testing.T) {
+	if got, want := AttrSigningKeyID, "aileron.signing.key_id"; got != want {
+		t.Errorf("AttrSigningKeyID = %q, want %q", got, want)
+	}
+}
+
+func TestAttrPolicyDecisionSpelling(t *testing.T) {
+	if got, want := AttrPolicyDecision, "aileron.policy.decision"; got != want {
+		t.Errorf("AttrPolicyDecision = %q, want %q", got, want)
+	}
+}


### PR DESCRIPTION
## Summary

Closes the second half of the Phase 6.5 commitment that was tracked under #404 but never picked up in code.

PR #452 delivered the OTel-namespacing rename. The **reserved-fields** portion of Phase 6.5 (committed across #398 and #399, tracked on #404 as the unchecked "Reserved audit envelope fields" line) has been sitting open since 2026-05-01. This commit pays that debt down.

### What's reserved

Two attribute keys declared in `internal/audit/keys.go` and documented in [ADR-0010](https://docs.withaileron.ai/adr/0010-failure-handling/):

| Key | Reserved for |
|---|---|
| `aileron.signing.key_id` | Public-key fingerprint that will sign audit events under the Stage-1.5 hash-chained audit log (#398). |
| `aileron.policy.decision` | Verdict from a pre-execution policy hook: `allow` / `deny` / `require_approval` / opaque source ref (#396, #399). |

Both follow the OTel-namespaced convention shared with the rest of the audit payload. Neither is emitted by any recorder today; they'll be picked up by the Stage-1.5 signing implementation and the policy-hook implementation respectively.

### Why constants, not just docs

Future implementers import one name. Without constants, `signed_audit_logs.go` and `policy_hook.go` (whoever writes them, whenever) might independently choose `signature_key_id`, `signing_key`, `audit_signing_key`, etc. The constants pin the spelling at the substrate layer where it has to be stable.

Two trivial spelling-guard tests exist so a future rename trips a compile failure plus a test failure rather than silently breaking external audit-log consumers.

### Why this slipped

The Phase 6.5 commitment had two deliverables tracked across different threads:

- **#390** committed to renaming audit fields to OTel-namespaced keys.
- **#398** and **#399** committed to reserving `signing_key_id` and `policy_decision` as open optional fields.

The umbrella #404 tracked both correctly as separate bullets. PR #452 delivered the first. The second was never picked up. When #390 closed, the closeout comment overclaimed by saying "Phase 6.5 shipped in PR #452" without distinguishing that this was one of two deliverables.

This PR completes the original commitment and ticks the second box on #404.

## Test plan

- [x] `go test ./internal/audit/...` clean
- [x] `task build:docs` clean (ADR amendment renders correctly)
- [x] No code-behavior change; constants and ADR text only

🤖 Generated with [Claude Code](https://claude.com/claude-code)
