### PR TITLE
fix(spawn): release lock before waitForDaemon so the daemon can start

### DIFF
--- a/internal/daemon/spawn/spawn.go
+++ b/internal/daemon/spawn/spawn.go
@@ -110,22 +110,31 @@ func Resolve(ctx context.Context, opts Options) (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("spawn: acquire lock: %w", err)
 	}
-	// Release the lock as soon as SpawnFn returns and (in the default
-	// fork-exec case) the daemon's own startup lock takes over. We
-	// hold the lock through the polling loop too — clients that race
-	// past us will block on this lock and re-check daemon.json on
-	// acquire, avoiding redundant fork-execs.
-	defer func() { _ = release() }()
 
 	// Re-check after lock — another client may have spawned during
 	// our lock-acquire window.
 	if url, ok := readAlive(opts.StateDir, opts.LivenessTimeout); ok {
+		_ = release()
 		return url, nil
 	}
 
 	if err := opts.SpawnFn(ctx, opts.StateDir); err != nil {
+		_ = release()
 		return "", fmt.Errorf("spawn: %w", err)
 	}
+
+	// Release before waitForDaemon. The daemon's own startup-lock
+	// acquisition (`internal/server.run`) takes over as the singleton
+	// check; holding the lock through the polling loop would deadlock
+	// against it — the daemon would time out, exit, and never write
+	// daemon.json, leaving the helper to time out at SpawnTimeout.
+	//
+	// Concurrent clients that race past us during waitForDaemon either
+	// observe the daemon's daemon.json once it lands (fast-path return)
+	// or fork a redundant daemon — the daemon's own lock then
+	// guarantees only one survives, so the worst case is a few wasted
+	// process starts, not duplicated daemons.
+	_ = release()
 
 	return waitForDaemon(ctx, opts)
 }

--- a/internal/daemon/spawn/spawn_test.go
+++ b/internal/daemon/spawn/spawn_test.go
@@ -296,4 +296,83 @@ func TestResolve_DefaultSpawnFnForkExecsBinary(t *testing.T) {
 	}
 }
 
+// TestResolve_ReleasesLockBeforeWaitForDaemon is the regression test
+// for the spawn/daemon deadlock that surfaced while running the
+// ADR-0012 manual acceptance tests on a fresh machine.
+//
+// The bug: the helper held [discovery.Lock] through both SpawnFn and
+// the subsequent waitForDaemon polling loop. The daemon child (in
+// `internal/server.run`) tries to acquire the same lock for its own
+// singleton check with a 250ms timeout. Holding the lock through
+// waitForDaemon caused the daemon to time out, exit, and never
+// publish daemon.json — the helper then timed out at SpawnTimeout
+// with the misleading "daemon did not become ready within Ns".
+//
+// The contract the daemon depends on: by the time waitForDaemon is
+// polling, the spawn helper has released the lock so the daemon can
+// take it for itself. This test asserts that contract by attempting
+// to acquire the same lock from a goroutine started during SpawnFn
+// — which mirrors what the real daemon does at startup.
+func TestResolve_ReleasesLockBeforeWaitForDaemon(t *testing.T) {
+	dir := t.TempDir()
+
+	// Synthetic "daemon" goroutine: tries to grab the lock (the way
+	// the real daemon does), then writes daemon.json so Resolve's
+	// polling completes.
+	daemonStarted := make(chan struct{})
+	daemonLockErr := make(chan error, 1)
+
+	spawnFn := func(_ context.Context, stateDir string) error {
+		go func() {
+			// Wait for the helper to enter waitForDaemon. A small
+			// delay is enough — the helper releases the lock between
+			// SpawnFn returning and the first poll iteration.
+			time.Sleep(50 * time.Millisecond)
+			lockCtx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+			defer cancel()
+			release, err := discovery.Lock(lockCtx, stateDir)
+			daemonLockErr <- err
+			if err != nil {
+				return
+			}
+			defer func() { _ = release() }()
+			// Stand in for the daemon's listen + discovery.Write.
+			_, _ = fakeDaemon(t, stateDir)
+			close(daemonStarted)
+		}()
+		return nil
+	}
+
+	got, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:     dir,
+		EnvLookup:    emptyEnv,
+		SpawnTimeout: 3 * time.Second,
+		PollInterval: 25 * time.Millisecond,
+		SpawnFn:      spawnFn,
+	})
+
+	// Whether Resolve returns success or not, the daemon's lock attempt
+	// must succeed — that's the contract under test.
+	select {
+	case lockErr := <-daemonLockErr:
+		if lockErr != nil {
+			t.Fatalf("daemon-side Lock acquisition failed (spawn helper still holding it?): %v", lockErr)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("daemon goroutine never reported its lock attempt — Resolve probably blocked forever")
+	}
+
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got == "" {
+		t.Fatal("got empty URL")
+	}
+	select {
+	case <-daemonStarted:
+	default:
+		t.Error("daemon goroutine never wrote daemon.json — Resolve returned but the synthetic daemon didn't run")
+	}
+}
+
 func emptyEnv(string) string { return "" }


### PR DESCRIPTION
## Summary

Surfaced while running issue #454's manual acceptance tests (Test 1: \`aileron binding list\` on a fresh machine):

\`\`\`
aileron: could not resolve daemon URL: spawn: daemon did not become ready within 5s
error: Get \"http://localhost:8721/v1/bindings\": dial tcp [::1]:8721: connect: connection refused
\`\`\`

## Root cause

The spawn helper in \`internal/daemon/spawn/spawn.go\` held \`discovery.Lock\` through both \`SpawnFn\` AND the subsequent \`waitForDaemon\` polling loop. The daemon child (\`internal/server.run\`) tries to acquire the same lock for its own singleton check with a 250ms timeout — held the lock means the daemon times out, exits, and never publishes \`daemon.json\`. The helper then times out at \`SpawnTimeout\` (5s default) with the misleading \"daemon did not become ready\".

The freshly-failed daemon log nailed it:

\`\`\`
{\"level\":\"ERROR\",\"msg\":\"daemon exited with error\",\"error\":\"daemon already running, or could not acquire ~/.aileron/daemon.lock: context deadline exceeded\"}
\`\`\`

The function's own comment even described the intended design — *\"Release the lock as soon as SpawnFn returns and the daemon's own startup lock takes over\"* — but the deferred release fired only after \`waitForDaemon\`.

## Fix

Move the release to happen explicitly between \`SpawnFn\` returning and \`waitForDaemon\` starting. The daemon's own startup-lock acquisition becomes the singleton check; concurrent clients racing past us during \`waitForDaemon\` either observe \`daemon.json\` (fast-path return) or fork a redundant daemon process that the daemon's own lock then rejects.

## Verification

End-to-end on the same fresh state that triggered the bug:

\`\`\`
$ rm -rf ~/.aileron
$ build/aileron binding list
No bindings.

$ cat ~/.aileron/daemon.log
{\"msg\":\"daemon listening\",\"url\":\"http://127.0.0.1:58737\",\"pid\":87011,\"version\":\"dev\"}
{\"msg\":\"request\",\"method\":\"GET\",\"path\":\"/v1/bindings\",\"status\":200,\"duration_ms\":0}

$ build/aileron binding list   # second call: same daemon
No bindings.
$ pgrep -f build/server | wc -l
       1
\`\`\`

That covers umbrella tests 1 + 2.

## Regression test

\`TestResolve_ReleasesLockBeforeWaitForDaemon\` asserts the lock contract by attempting acquisition from a goroutine started during \`SpawnFn\` — which mirrors what the real daemon does at startup. Confirmed:

- **Old code:** test fails with \`context deadline exceeded\` (the exact production symptom).
- **New code:** test passes.

## Known follow-up not in this PR

When spawn fails for any reason, \`bindingAPIBaseURL\` falls back to \`http://localhost:8721/v1\` — a port that has no meaning under ADR-0012, which produced the misleading second error line in the original report. After this fix, the deadlock no longer triggers the fallback on the happy path, but the fallback itself is still misleading when spawn fails for unrelated reasons (binary missing, daemon crashes during startup). Worth a separate PR; tagging it on if the user agrees.

## Test plan

- [x] \`go test -race ./internal/daemon/...\` clean.
- [x] Manual: \`rm -rf ~/.aileron && aileron binding list\` succeeds on a fresh machine.
- [x] Manual: second call reuses the same daemon (umbrella test 2).
- [x] Regression test fails on old code, passes on fix.

🤖 Generated with [Claude Code](https://claude.com/claude-code)