### PR TITLE
refactor(cli): drop legacy localhost:8721 fallback from bindingAPIBaseURL

### DIFF
--- a/cmd/aileron/approval.go
+++ b/cmd/aileron/approval.go
@@ -166,12 +166,15 @@ func runApprovalDecide(args []string, approved bool, stdout, stderr io.Writer) i
 // (`bindingAPIBaseURL` in main.go) so AILERON_API_URL overrides apply
 // uniformly across all subcommands.
 func approvalDoRequest(method, path string, body []byte) (*http.Response, error) {
-	url := bindingAPIBaseURL() + path
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return nil, err
+	}
 	var reader io.Reader
 	if body != nil {
 		reader = bytes.NewReader(body)
 	}
-	req, err := http.NewRequest(method, url, reader)
+	req, err := http.NewRequest(method, base+path, reader)
 	if err != nil {
 		return nil, err
 	}

--- a/cmd/aileron/daemon_cli_test.go
+++ b/cmd/aileron/daemon_cli_test.go
@@ -229,7 +229,10 @@ func TestRunDaemonStatus_WithVaultProbe(t *testing.T) {
 
 func TestBindingAPIBaseURL_RespectsAILERON_API_URL(t *testing.T) {
 	t.Setenv("AILERON_API_URL", "http://override.test:9999/v1/")
-	got := bindingAPIBaseURL()
+	got, err := bindingAPIBaseURL()
+	if err != nil {
+		t.Fatalf("override should not error: %v", err)
+	}
 	if got != "http://override.test:9999/v1" {
 		t.Errorf("got %q, want trimmed override URL", got)
 	}

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -593,7 +593,11 @@ const bindingUsage = `usage:
 // advertised in `~/.aileron/daemon.json`), and the doomed dial
 // produced a misleading second error line that obscured the real
 // spawn failure. Callers now surface the spawn error directly.
-func bindingAPIBaseURL() (string, error) {
+//
+// Declared as a `var` rather than `func` so tests can drive the
+// error-propagation path through every caller without going through
+// the spawn cache + daemon binary lookup.
+var bindingAPIBaseURL = func() (string, error) {
 	if u := os.Getenv("AILERON_API_URL"); u != "" {
 		return strings.TrimRight(u, "/"), nil
 	}

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -586,21 +586,18 @@ const bindingUsage = `usage:
 // resulting URL is cached for the lifetime of the CLI process so
 // repeat callers don't reprobe.
 //
-// On spawn failure (binary missing, daemon refuses to start) the
-// historical default `http://localhost:8721/v1` is returned so the
-// caller fails with the familiar "connection refused" rather than a
-// malformed URL. The error is logged to stderr so the operator sees
-// the real cause.
-func bindingAPIBaseURL() string {
+// Returns the spawn error verbatim on failure. Earlier versions
+// returned a hardcoded `http://localhost:8721/v1` fallback so the
+// caller would fail with "connection refused" — but the legacy port
+// has no meaning under ADR-0012 (the daemon binds an ephemeral port
+// advertised in `~/.aileron/daemon.json`), and the doomed dial
+// produced a misleading second error line that obscured the real
+// spawn failure. Callers now surface the spawn error directly.
+func bindingAPIBaseURL() (string, error) {
 	if u := os.Getenv("AILERON_API_URL"); u != "" {
-		return strings.TrimRight(u, "/")
+		return strings.TrimRight(u, "/"), nil
 	}
-	url, err := spawnResolveCached()
-	if err != nil {
-		fmt.Fprintf(os.Stderr, "aileron: could not resolve daemon URL: %v\n", err)
-		return "http://localhost:8721/v1"
-	}
-	return url
+	return spawnResolveCached()
 }
 
 var (
@@ -680,7 +677,11 @@ func daemonBinaryPath() (string, error) {
 // bindingDoRequest issues an HTTP request to the server and returns
 // the parsed body. Status codes are surfaced to callers.
 func bindingDoRequest(method, path string, body io.Reader) (int, []byte, error) {
-	req, err := http.NewRequest(method, bindingAPIBaseURL()+path, body)
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return 0, nil, err
+	}
+	req, err := http.NewRequest(method, base+path, body)
 	if err != nil {
 		return 0, nil, err
 	}
@@ -1175,8 +1176,12 @@ type runtimeStatus struct {
 // running — the CLI prints a "(daemon not reachable)" hint and moves
 // on rather than blocking the operator.
 func fetchRuntimeStatus() (*runtimeStatus, error) {
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return nil, err
+	}
 	client := &http.Client{Timeout: 2 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, bindingAPIBaseURL()+"/status", nil)
+	req, err := http.NewRequest(http.MethodGet, base+"/status", nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1200,8 +1205,8 @@ func showStatusRuntime(w io.Writer) {
 
 	rs, err := runtimeStatusFetcher()
 	if err != nil {
-		fmt.Fprintf(w, "  Daemon:            (not reachable at %s)\n", bindingAPIBaseURL())
-		fmt.Fprintln(w, "  Hint:              start the daemon with 'aileron launch <agent>' or 'aileron serve'.")
+		fmt.Fprintf(w, "  Daemon:            (not reachable: %v)\n", err)
+		fmt.Fprintln(w, "  Hint:              start the daemon with 'aileron daemon start' or run any 'aileron' command (auto-spawns).")
 		return
 	}
 
@@ -1457,8 +1462,12 @@ func fetchConnectorCheck(includePrerelease bool) (*connectorsCheckResponse, erro
 	if includePrerelease {
 		path += "?include_prerelease=true"
 	}
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return nil, err
+	}
 	client := &http.Client{Timeout: 30 * time.Second}
-	req, err := http.NewRequest(http.MethodGet, bindingAPIBaseURL()+path, nil)
+	req, err := http.NewRequest(http.MethodGet, base+path, nil)
 	if err != nil {
 		return nil, err
 	}
@@ -1592,9 +1601,13 @@ type unboundCapabilityWire struct {
 var syncFetcher = postSyncRequest
 
 func postSyncRequest(autoInstall bool) (*syncResult, error) {
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return nil, err
+	}
 	body, _ := json.Marshal(map[string]any{"auto_install": autoInstall})
 	client := &http.Client{Timeout: 5 * time.Minute}
-	req, err := http.NewRequest(http.MethodPost, bindingAPIBaseURL()+"/sync",
+	req, err := http.NewRequest(http.MethodPost, base+"/sync",
 		strings.NewReader(string(body)))
 	if err != nil {
 		return nil, err
@@ -2291,7 +2304,11 @@ type auditListQuery struct {
 }
 
 func fetchAuditList(q auditListQuery) (*auditListWire, error) {
-	u, err := url.Parse(bindingAPIBaseURL() + "/audit")
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return nil, err
+	}
+	u, err := url.Parse(base + "/audit")
 	if err != nil {
 		return nil, err
 	}
@@ -2330,8 +2347,12 @@ func fetchAuditList(q auditListQuery) (*auditListWire, error) {
 }
 
 func fetchAuditGet(auditID string) (*auditEventWire, int, error) {
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return nil, 0, err
+	}
 	client := &http.Client{Timeout: 10 * time.Second}
-	resp, err := client.Get(bindingAPIBaseURL() + "/audit/" + url.PathEscape(auditID))
+	resp, err := client.Get(base + "/audit/" + url.PathEscape(auditID))
 	if err != nil {
 		return nil, 0, err
 	}

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"bytes"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"net"
@@ -1284,6 +1285,95 @@ func TestBindingAPIBaseURL_OverrideTrimsTrailingSlash(t *testing.T) {
 	}
 	if got != "https://example.com/v1" {
 		t.Errorf("override = %q, want trimmed", got)
+	}
+}
+
+// TestBindingAPIBaseURL_PropagatesSpawnErrorThroughCallers locks in
+// the post-#490 contract: every helper that previously dialed the
+// hardcoded `localhost:8721` fallback now propagates the spawn
+// error from bindingAPIBaseURL instead. Stubs bindingAPIBaseURL to
+// return a sentinel error, then calls each helper and asserts the
+// sentinel reaches the caller.
+//
+// One test covers seven helpers because the error-propagation code
+// added at each call site is mechanical (early-return on
+// bindingAPIBaseURL error). Testing the contract once per helper
+// catches a future regression where someone forgets to plumb the
+// error through a new call site.
+func TestBindingAPIBaseURL_PropagatesSpawnErrorThroughCallers(t *testing.T) {
+	sentinel := errors.New("spawn unavailable for test")
+
+	// Stub the URL helper for the duration of the test. Restore on
+	// cleanup so other parallel-package tests aren't affected.
+	orig := bindingAPIBaseURL
+	bindingAPIBaseURL = func() (string, error) { return "", sentinel }
+	t.Cleanup(func() { bindingAPIBaseURL = orig })
+
+	cases := []struct {
+		name string
+		call func() error
+	}{
+		{
+			name: "bindingDoRequest",
+			call: func() error {
+				_, _, err := bindingDoRequest(http.MethodGet, "/bindings", nil)
+				return err
+			},
+		},
+		{
+			name: "fetchRuntimeStatus",
+			call: func() error {
+				_, err := fetchRuntimeStatus()
+				return err
+			},
+		},
+		{
+			name: "fetchConnectorCheck",
+			call: func() error {
+				_, err := fetchConnectorCheck(false)
+				return err
+			},
+		},
+		{
+			name: "postSyncRequest",
+			call: func() error {
+				_, err := postSyncRequest(false)
+				return err
+			},
+		},
+		{
+			name: "fetchAuditList",
+			call: func() error {
+				_, err := fetchAuditList(auditListQuery{})
+				return err
+			},
+		},
+		{
+			name: "fetchAuditGet",
+			call: func() error {
+				_, _, err := fetchAuditGet("audit-id")
+				return err
+			},
+		},
+		{
+			name: "approvalDoRequest",
+			call: func() error {
+				_, err := approvalDoRequest(http.MethodGet, "/approvals", nil)
+				return err
+			},
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			err := tc.call()
+			if err == nil {
+				t.Fatal("expected error from spawn failure to propagate")
+			}
+			if !errors.Is(err, sentinel) {
+				t.Errorf("got %v, want sentinel %v wrapped or returned", err, sentinel)
+			}
+		})
 	}
 }
 

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -677,14 +677,20 @@ func TestRunStatus_NotificationsNoPolicy(t *testing.T) {
 
 // TestRunStatus_RuntimeUnreachable covers the offline path: with no
 // daemon listening, `aileron status runtime` must exit cleanly and
-// surface a "(not reachable)" line. The CLI is a thin client; users
-// run it from arbitrary shells where the daemon may or may not be up.
+// surface a "(not reachable)" line that names the underlying error.
+// The CLI is a thin client; users run it from arbitrary shells where
+// the daemon may or may not be up.
+//
+// Locks in the post-#489 behavior: the unreachable line carries the
+// fetcher's error verbatim, not a hardcoded URL like the legacy
+// `http://localhost:8721/v1` fallback that `bindingAPIBaseURL` used
+// to return. The legacy port has no meaning under ADR-0012.
 func TestRunStatus_RuntimeUnreachable(t *testing.T) {
 	// Force the fetcher to fail so the test doesn't depend on the host
 	// having an actual server listening on the default port.
 	prev := runtimeStatusFetcher
 	runtimeStatusFetcher = func() (*runtimeStatus, error) {
-		return nil, fmt.Errorf("connection refused")
+		return nil, fmt.Errorf("daemon binary missing")
 	}
 	defer func() { runtimeStatusFetcher = prev }()
 
@@ -699,6 +705,15 @@ func TestRunStatus_RuntimeUnreachable(t *testing.T) {
 	}
 	if !strings.Contains(out, "not reachable") {
 		t.Errorf("expected 'not reachable' hint when daemon is down; got: %s", out)
+	}
+	if !strings.Contains(out, "daemon binary missing") {
+		t.Errorf("expected fetcher error to surface in output; got: %s", out)
+	}
+	if strings.Contains(out, "8721") {
+		t.Errorf("output should not name the legacy port 8721; got: %s", out)
+	}
+	if strings.Contains(out, "aileron serve") {
+		t.Errorf("output should not suggest 'aileron serve' (deprecated under ADR-0012); got: %s", out)
 	}
 }
 
@@ -1261,14 +1276,14 @@ func TestRunBinding_SetupParsesPartialResponse(t *testing.T) {
 	}
 }
 
-func TestBindingAPIBaseURL_DefaultAndOverride(t *testing.T) {
-	t.Setenv("AILERON_API_URL", "")
-	if got := bindingAPIBaseURL(); got != "http://localhost:8721/v1" {
-		t.Errorf("default = %q", got)
-	}
+func TestBindingAPIBaseURL_OverrideTrimsTrailingSlash(t *testing.T) {
 	t.Setenv("AILERON_API_URL", "https://example.com/v1/")
-	if got := bindingAPIBaseURL(); got != "https://example.com/v1" {
-		t.Errorf("override = %q", got)
+	got, err := bindingAPIBaseURL()
+	if err != nil {
+		t.Fatalf("override should not error: %v", err)
+	}
+	if got != "https://example.com/v1" {
+		t.Errorf("override = %q, want trimmed", got)
 	}
 }
 


### PR DESCRIPTION
## Summary

Follow-up to #489. Same bug report surfaced two error lines:

\`\`\`
aileron: could not resolve daemon URL: spawn: daemon did not become ready within 5s
error: Get \"http://localhost:8721/v1/bindings\": dial tcp [::1]:8721: connect: connection refused
\`\`\`

#489 fixes the first line (the actual deadlock). This PR fixes the second: \`bindingAPIBaseURL()\` was silently falling back to \`http://localhost:8721/v1\` on spawn failure, so callers dialed a port that has no meaning under ADR-0012 and got a misleading \"connection refused\" that obscured the truthful first line.

## Change

Refactor \`bindingAPIBaseURL()\` from \`() string\` to \`() (string, error)\` and propagate the spawn error through all 8 call sites (\`main.go\` + \`approval.go\`). The CLI now surfaces one truthful error and exits, instead of two errors where the second one lies.

While here:

- \`aileron status\` \"not reachable\" line names the underlying error (\"daemon binary missing\", \"spawn timeout\", etc.) instead of the misleading legacy URL.
- The \"not reachable\" hint stops suggesting \`aileron serve\` (deprecated under ADR-0012) in favor of \`aileron daemon start\`.

## Independence from #489

Different files, different concerns: #489 touches \`internal/daemon/spawn/\`, this PR touches \`cmd/aileron/\`. Both branch from the same main; either order merges cleanly.

## Test plan

- [x] \`go test -race ./cmd/aileron/...\` clean.
- [x] Updated \`TestRunStatus_RuntimeUnreachable\` to lock in the new contract: output names the actual error, never \`8721\`, never \`aileron serve\`.
- [x] Override-URL tests still pass with the new \`(string, error)\` signature.

🤖 Generated with [Claude Code](https://claude.com/claude-code)