### PR TITLE
feat(cli): add aileron sessions list / get subcommands

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -122,6 +122,8 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		return runLog(args[1:], stdout, stderr)
 	case "audit":
 		return runAudit(args[1:], stdout, stderr)
+	case "sessions":
+		return runSessions(args[1:], stdout, stderr)
 	case "daemon":
 		return runDaemon(args[1:], stdout, stderr)
 	case "stop":
@@ -161,6 +163,7 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron sync [--bind-all] [--yes]  Reconcile installed actions: install missing connectors; report unbound capabilities")
 	fmt.Fprintln(w, "  aileron log [flags]                View the shell-policy log")
 	fmt.Fprintln(w, "  aileron audit [list|show]          View the action-execution audit log (ADR-0010)")
+	fmt.Fprintln(w, "  aileron sessions [list|get]        View `aileron launch` session records (ADR-0012)")
 	fmt.Fprintln(w, "  aileron daemon start|stop|status   Manage the local Aileron daemon (auto-spawned on demand)")
 	fmt.Fprintln(w, "  aileron stop                       Alias for 'aileron daemon stop'")
 	fmt.Fprintln(w, "  aileron version                    Print version information")

--- a/cmd/aileron/sessions.go
+++ b/cmd/aileron/sessions.go
@@ -1,0 +1,251 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strconv"
+	"time"
+
+	api "github.com/ALRubinger/aileron/internal/api/gen"
+)
+
+// sessionsListFetcher and sessionsGetFetcher are the HTTP clients for
+// the daemon's `/v1/sessions` endpoints. Replaceable in tests so they
+// don't depend on a running daemon (mirrors auditListFetcher /
+// auditGetFetcher). Keep at package scope so tests can swap them.
+var (
+	sessionsListFetcher = fetchSessionsList
+	sessionsGetFetcher  = fetchSessionsGet
+)
+
+const sessionsUsage = `usage:
+  aileron sessions list [--active] [--agent NAME] [--since RFC3339] [--limit N] [--json]
+  aileron sessions get  <session-id> [--json]`
+
+// sessionsListQuery mirrors the four query parameters supported by
+// `GET /v1/sessions`. Empty / zero values are not sent.
+type sessionsListQuery struct {
+	activeOnly bool
+	agent      string
+	since      string
+	limit      int
+}
+
+// runSessions dispatches `aileron sessions <subcommand>`. With no
+// subcommand it lists, mirroring `aileron audit`'s shape — the most
+// common interactive use is "what did I run today?" which a bare
+// `aileron sessions` should answer without ceremony.
+func runSessions(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		return runSessionsList(nil, stdout, stderr)
+	}
+	switch args[0] {
+	case "list":
+		return runSessionsList(args[1:], stdout, stderr)
+	case "get":
+		return runSessionsGet(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown sessions command: %q\n", args[0])
+		fmt.Fprintln(stderr, sessionsUsage)
+		return 1
+	}
+}
+
+// runSessionsList renders the user's launch sessions as a fixed-width
+// table. The render layout mirrors `aileron audit list`: timestamp,
+// id, status, summary. The status column carries the three-state
+// vocabulary the OpenAPI spec defines:
+//   - "running"     — ended_at is null
+//   - "ended"       — ended_at + exit_code present
+//   - "orphaned"    — ended_at present, exit_code null
+//
+// "orphaned" is the honest signal for a session whose daemon was
+// killed mid-flight: the orphan-reaper stamps ended_at on next
+// daemon start without fabricating an exit code (per ADR-0012).
+func runSessionsList(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("sessions list", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	activeOnly := flags.Bool("active", false, "Only sessions still running (ended_at is null)")
+	agent := flags.String("agent", "", "Filter by agent name (e.g. claude, pi)")
+	since := flags.String("since", "", "Lower-bound on started_at (RFC 3339, e.g. 2026-05-01T00:00:00Z)")
+	limit := flags.Int("limit", 0, "Maximum sessions to return (default: server returns all)")
+	asJSON := flags.Bool("json", false, "Emit one JSON-encoded session per line")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	resp, err := sessionsListFetcher(sessionsListQuery{
+		activeOnly: *activeOnly,
+		agent:      *agent,
+		since:      *since,
+		limit:      *limit,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if len(resp.Items) == 0 {
+		if *asJSON {
+			fmt.Fprintln(stdout, "[]")
+			return 0
+		}
+		fmt.Fprintln(stdout, "No sessions.")
+		fmt.Fprintln(stdout, "Run `aileron launch <agent>` to start one.")
+		return 0
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		for _, s := range resp.Items {
+			if err := enc.Encode(s); err != nil {
+				fmt.Fprintf(stderr, "encode: %v\n", err)
+				return 1
+			}
+		}
+		return 0
+	}
+	for _, s := range resp.Items {
+		ts := s.StartedAt.Local().Format("2006-01-02 15:04:05")
+		fmt.Fprintf(stdout, "%s  %-26s  %-9s  %-8s  %s\n",
+			ts, s.Id, sessionStatus(s), s.Agent, sessionSummary(s))
+	}
+	return 0
+}
+
+// runSessionsGet fetches a single session by id and emits it as
+// indented JSON. Always JSON: the wire shape is small (8 fields)
+// and a "show" command is expected to be machine-readable for
+// scripts that need the full record.
+func runSessionsGet(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("sessions get", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	rest := flags.Args()
+	if len(rest) != 1 {
+		fmt.Fprintln(stderr, "usage: aileron sessions get <session-id>")
+		return 1
+	}
+	s, status, err := sessionsGetFetcher(rest[0])
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if status == http.StatusNotFound {
+		fmt.Fprintf(stderr, "session %q not found\n", rest[0])
+		return 1
+	}
+	enc := json.NewEncoder(stdout)
+	enc.SetIndent("", "  ")
+	if err := enc.Encode(s); err != nil {
+		fmt.Fprintf(stderr, "encode: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// sessionStatus collapses the (EndedAt, ExitCode) tuple to the wire
+// vocabulary defined in the OpenAPI Session schema. The three states
+// are mutually exclusive; ExitCode without EndedAt is impossible by
+// construction.
+func sessionStatus(s api.Session) string {
+	if s.EndedAt == nil {
+		return "running"
+	}
+	if s.ExitCode == nil {
+		return "orphaned"
+	}
+	return "ended"
+}
+
+// sessionSummary formats the trailing column of `sessions list`. For
+// ended sessions it shows the exit code and a duration; for running
+// sessions, the working directory; for orphans, just the working dir
+// (their duration is meaningless — the daemon-restart timestamp).
+func sessionSummary(s api.Session) string {
+	switch sessionStatus(s) {
+	case "ended":
+		dur := s.EndedAt.Sub(s.StartedAt)
+		return fmt.Sprintf("exit=%d  in %s  cwd=%s", *s.ExitCode, dur.Round(time.Second), s.WorkingDir)
+	case "orphaned":
+		return fmt.Sprintf("cwd=%s", s.WorkingDir)
+	default: // running
+		return fmt.Sprintf("cwd=%s", s.WorkingDir)
+	}
+}
+
+// fetchSessionsList issues `GET /v1/sessions` and decodes the body.
+// Empty query parameters are not sent — the daemon's defaults apply
+// (no filter, return all matching).
+func fetchSessionsList(q sessionsListQuery) (*api.SessionListResponse, error) {
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return nil, err
+	}
+	u, err := url.Parse(base + "/sessions")
+	if err != nil {
+		return nil, err
+	}
+	qs := u.Query()
+	if q.activeOnly {
+		qs.Set("active_only", "true")
+	}
+	if q.agent != "" {
+		qs.Set("agent", q.agent)
+	}
+	if q.since != "" {
+		qs.Set("since", q.since)
+	}
+	if q.limit > 0 {
+		qs.Set("limit", strconv.Itoa(q.limit))
+	}
+	u.RawQuery = qs.Encode()
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(u.String())
+	if err != nil {
+		return nil, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(raw))
+	}
+	var out api.SessionListResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("decoding response: %w", err)
+	}
+	return &out, nil
+}
+
+// fetchSessionsGet issues `GET /v1/sessions/{id}` and returns the
+// session record plus the HTTP status. 404 is surfaced via the
+// status int so callers can distinguish "not found" from a transport
+// error without parsing strings.
+func fetchSessionsGet(sessionID string) (*api.Session, int, error) {
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return nil, 0, err
+	}
+	client := &http.Client{Timeout: 10 * time.Second}
+	resp, err := client.Get(base + "/sessions/" + url.PathEscape(sessionID))
+	if err != nil {
+		return nil, 0, err
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, http.StatusNotFound, nil
+	}
+	if resp.StatusCode != http.StatusOK {
+		raw, _ := io.ReadAll(resp.Body)
+		return nil, resp.StatusCode, fmt.Errorf("daemon returned %d: %s", resp.StatusCode, string(raw))
+	}
+	var s api.Session
+	if err := json.NewDecoder(resp.Body).Decode(&s); err != nil {
+		return nil, resp.StatusCode, fmt.Errorf("decoding response: %w", err)
+	}
+	return &s, resp.StatusCode, nil
+}

--- a/cmd/aileron/sessions_test.go
+++ b/cmd/aileron/sessions_test.go
@@ -1,0 +1,499 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	api "github.com/ALRubinger/aileron/internal/api/gen"
+)
+
+// /v1/sessions CLI contract:
+//
+//   - `aileron sessions` and `aileron sessions list` both list sessions
+//     (mirroring `aileron audit`'s no-subcommand-means-list shape).
+//   - List renders a fixed-width table by default; `--json` emits one
+//     JSON object per session. Empty sets render "No sessions." in
+//     human mode and `[]` in JSON mode.
+//   - Status column maps (EndedAt, ExitCode) to "running" / "ended" /
+//     "orphaned" per the OpenAPI Session schema.
+//   - `aileron sessions get <id>` emits indented JSON; 404 surfaces as
+//     "session ... not found" on stderr with exit code 1.
+//   - Filter flags (--active, --agent, --since, --limit) flow through
+//     to the wire query parameters.
+//   - Error from the fetcher (typically a spawn / daemon failure) is
+//     surfaced verbatim with exit code 1.
+
+// withSessionsFetchers swaps the package-level fetcher seams for the
+// duration of a test, restoring on cleanup. Mirrors the pattern used
+// by audit / runtimeStatus tests.
+func withSessionsFetchers(t *testing.T,
+	list func(sessionsListQuery) (*api.SessionListResponse, error),
+	get func(string) (*api.Session, int, error),
+) {
+	t.Helper()
+	if list != nil {
+		origList := sessionsListFetcher
+		sessionsListFetcher = list
+		t.Cleanup(func() { sessionsListFetcher = origList })
+	}
+	if get != nil {
+		origGet := sessionsGetFetcher
+		sessionsGetFetcher = get
+		t.Cleanup(func() { sessionsGetFetcher = origGet })
+	}
+}
+
+// --- list rendering ---
+
+func TestRunSessions_NoSubcommandListsByDefault(t *testing.T) {
+	withSessionsFetchers(t,
+		func(sessionsListQuery) (*api.SessionListResponse, error) {
+			return &api.SessionListResponse{Items: []api.Session{}}, nil
+		},
+		nil,
+	)
+	var stdout, stderr bytes.Buffer
+	code := runSessions(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No sessions") {
+		t.Errorf("bare `aileron sessions` should list (got %q)", stdout.String())
+	}
+}
+
+func TestRunSessionsList_EmptyRendersHumanMessageAndHint(t *testing.T) {
+	withSessionsFetchers(t,
+		func(sessionsListQuery) (*api.SessionListResponse, error) {
+			return &api.SessionListResponse{}, nil
+		},
+		nil,
+	)
+	var stdout, stderr bytes.Buffer
+	code := runSessionsList(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "No sessions.") {
+		t.Errorf("missing empty-state message; got %q", out)
+	}
+	if !strings.Contains(out, "aileron launch") {
+		t.Errorf("empty-state should hint at `aileron launch`; got %q", out)
+	}
+}
+
+func TestRunSessionsList_EmptyJSONRendersBracketBracket(t *testing.T) {
+	withSessionsFetchers(t,
+		func(sessionsListQuery) (*api.SessionListResponse, error) {
+			return &api.SessionListResponse{}, nil
+		},
+		nil,
+	)
+	var stdout bytes.Buffer
+	code := runSessionsList([]string{"--json"}, &stdout, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatal("expected exit 0")
+	}
+	if got := strings.TrimSpace(stdout.String()); got != "[]" {
+		t.Errorf("empty --json should be []; got %q", got)
+	}
+}
+
+func TestRunSessionsList_RendersTableRowPerSession(t *testing.T) {
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	exit := 0
+	end := now.Add(45 * time.Second)
+	withSessionsFetchers(t,
+		func(sessionsListQuery) (*api.SessionListResponse, error) {
+			return &api.SessionListResponse{Items: []api.Session{
+				{Id: "01ABC", Agent: "claude", StartedAt: now, EndedAt: &end, ExitCode: &exit, WorkingDir: "/proj"},
+				{Id: "01DEF", Agent: "pi", StartedAt: now}, // running
+			}}, nil
+		},
+		nil,
+	)
+	var stdout bytes.Buffer
+	code := runSessionsList(nil, &stdout, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatal("expected exit 0")
+	}
+	out := stdout.String()
+	for _, want := range []string{"01ABC", "01DEF", "claude", "pi", "ended", "running", "exit=0", "/proj"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in output; got:\n%s", want, out)
+		}
+	}
+}
+
+func TestRunSessionsList_StatusForOrphan(t *testing.T) {
+	// EndedAt set + ExitCode nil = orphaned (daemon-restart signal).
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	end := now.Add(45 * time.Second)
+	withSessionsFetchers(t,
+		func(sessionsListQuery) (*api.SessionListResponse, error) {
+			return &api.SessionListResponse{Items: []api.Session{
+				{Id: "01ORPH", Agent: "claude", StartedAt: now, EndedAt: &end},
+			}}, nil
+		},
+		nil,
+	)
+	var stdout bytes.Buffer
+	code := runSessionsList(nil, &stdout, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatal("expected exit 0")
+	}
+	if !strings.Contains(stdout.String(), "orphaned") {
+		t.Errorf("orphan should render with status=orphaned; got %q", stdout.String())
+	}
+}
+
+func TestRunSessionsList_JSONOneObjectPerLine(t *testing.T) {
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	exit := 0
+	end := now.Add(time.Second)
+	withSessionsFetchers(t,
+		func(sessionsListQuery) (*api.SessionListResponse, error) {
+			return &api.SessionListResponse{Items: []api.Session{
+				{Id: "01ABC", Agent: "claude", StartedAt: now, EndedAt: &end, ExitCode: &exit},
+				{Id: "01DEF", Agent: "pi", StartedAt: now},
+			}}, nil
+		},
+		nil,
+	)
+	var stdout bytes.Buffer
+	code := runSessionsList([]string{"--json"}, &stdout, &bytes.Buffer{})
+	if code != 0 {
+		t.Fatal("expected exit 0")
+	}
+	lines := strings.Split(strings.TrimSpace(stdout.String()), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("expected 2 JSON lines, got %d:\n%s", len(lines), stdout.String())
+	}
+	for i, line := range lines {
+		var s api.Session
+		if err := json.Unmarshal([]byte(line), &s); err != nil {
+			t.Errorf("line %d not valid JSON: %v (%s)", i, err, line)
+		}
+	}
+}
+
+// --- filter flags flow through to the query ---
+
+func TestRunSessionsList_FlagsFlowToQuery(t *testing.T) {
+	var got sessionsListQuery
+	withSessionsFetchers(t,
+		func(q sessionsListQuery) (*api.SessionListResponse, error) {
+			got = q
+			return &api.SessionListResponse{}, nil
+		},
+		nil,
+	)
+	code := runSessionsList(
+		[]string{"--active", "--agent", "claude", "--since", "2026-05-01T00:00:00Z", "--limit", "5"},
+		&bytes.Buffer{}, &bytes.Buffer{},
+	)
+	if code != 0 {
+		t.Fatal("expected exit 0")
+	}
+	if !got.activeOnly {
+		t.Error("--active should set activeOnly")
+	}
+	if got.agent != "claude" {
+		t.Errorf("agent = %q, want claude", got.agent)
+	}
+	if got.since != "2026-05-01T00:00:00Z" {
+		t.Errorf("since = %q", got.since)
+	}
+	if got.limit != 5 {
+		t.Errorf("limit = %d, want 5", got.limit)
+	}
+}
+
+// --- error propagation ---
+
+func TestRunSessionsList_FetcherErrorReturnsNonZero(t *testing.T) {
+	withSessionsFetchers(t,
+		func(sessionsListQuery) (*api.SessionListResponse, error) {
+			return nil, fmt.Errorf("daemon unreachable")
+		},
+		nil,
+	)
+	var stdout, stderr bytes.Buffer
+	code := runSessionsList(nil, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit on fetcher error")
+	}
+	if !strings.Contains(stderr.String(), "daemon unreachable") {
+		t.Errorf("expected error in stderr; got %q", stderr.String())
+	}
+}
+
+// --- get ---
+
+func TestRunSessionsGet_RendersIndentedJSON(t *testing.T) {
+	exit := 0
+	end := time.Now().UTC()
+	withSessionsFetchers(t, nil,
+		func(id string) (*api.Session, int, error) {
+			if id != "01ABC" {
+				t.Errorf("id = %q, want 01ABC", id)
+			}
+			return &api.Session{
+				Id: "01ABC", Agent: "claude", StartedAt: end, EndedAt: &end, ExitCode: &exit,
+			}, http.StatusOK, nil
+		},
+	)
+	var stdout, stderr bytes.Buffer
+	code := runSessionsGet([]string{"01ABC"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	// Indented JSON has two-space indentation on every property line.
+	if !strings.Contains(out, `  "id": "01ABC"`) {
+		t.Errorf("expected indented JSON; got %q", out)
+	}
+}
+
+func TestRunSessionsGet_NotFoundReturnsNonZero(t *testing.T) {
+	withSessionsFetchers(t, nil,
+		func(string) (*api.Session, int, error) {
+			return nil, http.StatusNotFound, nil
+		},
+	)
+	var stdout, stderr bytes.Buffer
+	code := runSessionsGet([]string{"missing"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for 404")
+	}
+	if !strings.Contains(stderr.String(), "not found") {
+		t.Errorf("expected 'not found' on stderr; got %q", stderr.String())
+	}
+}
+
+func TestRunSessionsGet_MissingIDReturnsUsage(t *testing.T) {
+	withSessionsFetchers(t, nil,
+		func(string) (*api.Session, int, error) {
+			t.Fatal("fetcher should not be called when id is missing")
+			return nil, 0, nil
+		},
+	)
+	var stderr bytes.Buffer
+	code := runSessionsGet(nil, &bytes.Buffer{}, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit when id is missing")
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("expected usage on stderr; got %q", stderr.String())
+	}
+}
+
+// --- dispatch ---
+
+func TestRunSessions_UnknownSubcommandReturnsUsage(t *testing.T) {
+	var stderr bytes.Buffer
+	code := runSessions([]string{"frobnicate"}, &bytes.Buffer{}, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit for unknown subcommand")
+	}
+	if !strings.Contains(stderr.String(), "unknown sessions command") {
+		t.Errorf("expected unknown-command message; got %q", stderr.String())
+	}
+}
+
+// --- sessionStatus / sessionSummary helpers ---
+
+func TestSessionStatus(t *testing.T) {
+	now := time.Now()
+	end := now.Add(time.Second)
+	exit := 0
+
+	cases := []struct {
+		name string
+		s    api.Session
+		want string
+	}{
+		{"running", api.Session{StartedAt: now}, "running"},
+		{"ended", api.Session{StartedAt: now, EndedAt: &end, ExitCode: &exit}, "ended"},
+		{"orphaned", api.Session{StartedAt: now, EndedAt: &end}, "orphaned"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := sessionStatus(tc.s); got != tc.want {
+				t.Errorf("sessionStatus = %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestSessionSummary_EndedHasExitAndDuration(t *testing.T) {
+	start := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	end := start.Add(2 * time.Minute)
+	exit := 42
+	got := sessionSummary(api.Session{StartedAt: start, EndedAt: &end, ExitCode: &exit, WorkingDir: "/proj"})
+	for _, want := range []string{"exit=42", "2m0s", "/proj"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("missing %q in summary %q", want, got)
+		}
+	}
+}
+
+// --- HTTP fetchers against a fake daemon ---
+
+// fetchSessionsList / fetchSessionsGet are the only places in the
+// sessions surface that talk to the wire. The fetcher seam is
+// stubbed in the runner tests above; these tests exercise the
+// real fetchers against an httptest server so the URL shape, query
+// string, and decode path get end-to-end coverage.
+
+func TestFetchSessionsList_BuildsQueryAndDecodes(t *testing.T) {
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	exit := 0
+	end := now.Add(time.Second)
+	gotPath := make(chan string, 1)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotPath <- r.URL.Path + "?" + r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(api.SessionListResponse{Items: []api.Session{
+			{Id: "01ABC", Agent: "claude", StartedAt: now, EndedAt: &end, ExitCode: &exit},
+		}})
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	resp, err := fetchSessionsList(sessionsListQuery{
+		activeOnly: true,
+		agent:      "claude",
+		since:      "2026-05-01T00:00:00Z",
+		limit:      10,
+	})
+	if err != nil {
+		t.Fatalf("fetchSessionsList: %v", err)
+	}
+
+	pathQuery := <-gotPath
+	if !strings.HasPrefix(pathQuery, "/v1/sessions?") {
+		t.Errorf("expected /v1/sessions path; got %q", pathQuery)
+	}
+	for _, want := range []string{"active_only=true", "agent=claude", "since=2026-05-01", "limit=10"} {
+		if !strings.Contains(pathQuery, want) {
+			t.Errorf("expected %q in query; got %q", want, pathQuery)
+		}
+	}
+	if len(resp.Items) != 1 || resp.Items[0].Id != "01ABC" {
+		t.Errorf("decoded body wrong: %+v", resp)
+	}
+}
+
+func TestFetchSessionsList_EmptyQueryWhenNoFilters(t *testing.T) {
+	gotQuery := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotQuery <- r.URL.RawQuery
+		_ = json.NewEncoder(w).Encode(api.SessionListResponse{})
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	if _, err := fetchSessionsList(sessionsListQuery{}); err != nil {
+		t.Fatal(err)
+	}
+	if got := <-gotQuery; got != "" {
+		t.Errorf("expected no query string, got %q", got)
+	}
+}
+
+func TestFetchSessionsList_Non200SurfacesError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	_, err := fetchSessionsList(sessionsListQuery{})
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if !strings.Contains(err.Error(), "500") {
+		t.Errorf("expected status code in error; got %v", err)
+	}
+}
+
+func TestFetchSessionsGet_Decodes(t *testing.T) {
+	now := time.Date(2026, 5, 6, 12, 0, 0, 0, time.UTC)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if !strings.HasSuffix(r.URL.Path, "/sessions/01ABC") {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		_ = json.NewEncoder(w).Encode(api.Session{Id: "01ABC", Agent: "claude", StartedAt: now})
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	s, status, err := fetchSessionsGet("01ABC")
+	if err != nil {
+		t.Fatalf("fetchSessionsGet: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Errorf("status = %d, want 200", status)
+	}
+	if s.Id != "01ABC" {
+		t.Errorf("id = %q, want 01ABC", s.Id)
+	}
+}
+
+func TestFetchSessionsGet_404SurfacesViaStatus(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "not found", http.StatusNotFound)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	s, status, err := fetchSessionsGet("missing")
+	if err != nil {
+		t.Fatalf("404 should not be a transport error: %v", err)
+	}
+	if status != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", status)
+	}
+	if s != nil {
+		t.Errorf("session = %+v, want nil on 404", s)
+	}
+}
+
+func TestFetchSessionsGet_Non200Non404IsError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		http.Error(w, "boom", http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	_, _, err := fetchSessionsGet("01ABC")
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+}
+
+func TestFetchSessionsList_PropagatesBaseURLError(t *testing.T) {
+	// When AILERON_API_URL isn't set, bindingAPIBaseURL goes through
+	// the spawn path. Stub that path to return a sentinel error and
+	// verify it propagates.
+	t.Setenv("AILERON_API_URL", "")
+	sentinel := fmt.Errorf("spawn boom")
+	orig := bindingAPIBaseURL
+	bindingAPIBaseURL = func() (string, error) { return "", sentinel }
+	t.Cleanup(func() { bindingAPIBaseURL = orig })
+
+	if _, err := fetchSessionsList(sessionsListQuery{}); err == nil {
+		t.Fatal("expected error from bindingAPIBaseURL")
+	}
+	if _, _, err := fetchSessionsGet("x"); err == nil {
+		t.Fatal("expected error from bindingAPIBaseURL")
+	}
+}


### PR DESCRIPTION
## Summary

Surfaced during issue #454's manual acceptance testing: tests 3, 4, 5, and 8 all reference `aileron sessions list` to verify session lifecycle, but the CLI surface was never wired. The daemon-side endpoints (`/v1/sessions`, `/v1/sessions/{id}`) exist — per umbrella step #4 / PR #465 — only the CLI client was missing. Half of the umbrella's user-visible deliverable for sessions was unreachable.

This PR closes that gap; addresses item (7) of #492.

## Behavior

```
$ aileron sessions list
2026-05-06 22:10:01  01KR0DFHNXKNDGC0NJ5ZP3W7VM  ended      claude    exit=0  in 0s  cwd=/proj
2026-05-06 22:02:07  01KR0D12J69KMCCVXQGAKEM626  ended      claude    exit=0  in 0s  cwd=/proj

$ aileron sessions list --json
{\"agent\":\"claude\",\"ended_at\":\"...\",\"exit_code\":0,\"id\":\"01KR0DFHNXKNDGC0NJ5ZP3W7VM\",...}

$ aileron sessions list --agent=nonsense
No sessions.
Run `aileron launch <agent>` to start one.

$ aileron sessions get 01KR0DFHNXKNDGC0NJ5ZP3W7VM
{
  \"agent\": \"claude\",
  \"ended_at\": \"...\",
  ...
}
```

The Status column maps the (EndedAt, ExitCode) tuple per the OpenAPI Session schema: `running` / `ended` / `orphaned` (the honest "daemon was killed mid-flight" signal — no fabricated exit code).

## Implementation

- Mirrors the existing `audit list` / `audit show` shape: a fetcher seam at package scope (`sessionsListFetcher`, `sessionsGetFetcher`) so tests don't depend on a running daemon.
- Filter flags (`--active`, `--agent`, `--since`, `--limit`) flow to the wire query parameters.
- Empty-set rendering follows item (1) of #492: human format prints a discoverable hint, JSON prints `[]`.
- Wired into dispatch + help in `main.go`.

## Test plan

- [x] 12 runner tests + 6 HTTP-fetcher tests (httptest fake daemon) covering: dispatch, table render, status mapping for all three states, JSON output (incl. empty), filter flag flow, fetcher error propagation, get/404, base-URL error propagation.
- [x] `go test -race ./cmd/aileron/` clean.
- [x] Coverage: every function in `sessions.go` between 75-100%.
- [x] Manual smoke against a live daemon: `list`, `list --json`, `get <id>`, `get nope`, `list --agent=nonsense`, `list --agent=nonsense --json` all behave correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
