### PR TITLE
fix(launch): default --log-level to info so session.log is useful

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -53,7 +53,7 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		// Parse aileron-level flags before the agent name.
 		launchFlags := flag.NewFlagSet("launch", flag.ContinueOnError)
 		launchFlags.SetOutput(stderr)
-		logLevel := launchFlags.String("log-level", "warn", "Log level: trace, debug, info, warn, error")
+		logLevel := launchFlags.String("log-level", "info", "Log level: trace, debug, info, warn, error")
 		if err := launchFlags.Parse(args[1:]); err != nil {
 			return 1
 		}


### PR DESCRIPTION
## Summary

The launcher writes session-start and session-end records via slog at INFO level. The `aileron launch --log-level` default was `warn`, which filtered those records out — producing an empty `~/.aileron/session.log` file the user can't use to diagnose anything.

Surfaced while debugging Test 3 of #454: I asked the user to share `~/.aileron/session.log` to figure out why a stub `claude` exited quickly, and the log was zero bytes despite a successful launch.

## Why INFO is the right level for these lines

- "session started" and "session ended" are routine operational events, exactly INFO.
- WARN is reserved for surprises; ERROR for failures the operator must act on.
- The daemon already defaults to INFO via `parseLogLevel` in `internal/server/main.go`. This aligns the launcher with that convention.

The fix is the default level, not the level of the lines.

## Independence

One-line change. No conflict with any open PR.

## Test plan

- [x] `go test -race ./cmd/aileron/` clean.
- [x] Existing `--log-level=debug` flag tests still pass (they pin a specific level, not the default).
- [x] `internal/launch/loglevel.go`'s typo-fallback to WARN is intentionally untouched — that's a separate concern (an invalid `--log-level=foobar` should arguably be a hard error, but that's not this PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)