### PR TITLE
fix(cli): populate LaunchConfig.Dir at launch call site (#492 item 9)

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -72,16 +72,23 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 			return 1
 		}
 
-		shimPath, err := resolveShim()
+		shimPath, err := resolveShimFn()
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %v\n", err)
 			return 1
 		}
 
-		result, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		// Capture cwd so the daemon's session record carries working_dir
+		// (rendered by `aileron sessions list`). os.Getwd basically never
+		// errors in practice; on the rare case it does, fall through with
+		// Dir="" — the launcher and daemon already tolerate that.
+		cwd, _ := os.Getwd()
+
+		result, err := launchFn(context.Background(), launch.LaunchConfig{
 			Agent:     agent,
 			ShellShim: shimPath,
 			Args:      launchArgs[1:],
+			Dir:       cwd,
 			LogLevel:  launch.ParseLogLevel(*logLevel),
 		})
 		if err != nil {
@@ -616,6 +623,14 @@ var (
 // spawnResolveFn is the seam that lets tests substitute spawn.Resolve
 // without fork-execing a real daemon binary.
 var spawnResolveFn = spawn.Resolve
+
+// launchFn / resolveShimFn are package-level seams so tests can assert on
+// the LaunchConfig the CLI builds without depending on a real shim or a
+// running daemon.
+var (
+	launchFn      = launch.Launch
+	resolveShimFn = resolveShim
+)
 
 // spawnResolveCached calls spawnResolveOnce at most once per CLI
 // process and caches the result. The cache is intentionally

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -111,6 +112,41 @@ func TestRun_LaunchUnknownAgent(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "claude") {
 		t.Error("expected available agents list in stderr")
+	}
+}
+
+// Regression test for issue #492 item 9: the CLI must populate
+// LaunchConfig.Dir from os.Getwd() so the daemon's session record carries
+// working_dir. Before the fix, Dir was the empty string at the call site,
+// and every `aileron sessions list` row showed cwd="".
+func TestRun_LaunchPopulatesWorkingDir(t *testing.T) {
+	origShim := resolveShimFn
+	origLaunch := launchFn
+	t.Cleanup(func() {
+		resolveShimFn = origShim
+		launchFn = origLaunch
+	})
+
+	resolveShimFn = func() (string, error) { return "/fake/aileron-sh", nil }
+
+	var captured launch.LaunchConfig
+	launchFn = func(_ context.Context, cfg launch.LaunchConfig) (launch.LaunchResult, error) {
+		captured = cfg
+		return launch.LaunchResult{ExitCode: 0}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"launch", "claude"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, stderr.String())
+	}
+
+	cwd, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("os.Getwd: %v", err)
+	}
+	if captured.Dir != cwd {
+		t.Errorf("LaunchConfig.Dir = %q, want %q (cwd)", captured.Dir, cwd)
 	}
 }
 
@@ -3205,12 +3241,12 @@ func TestRunBinding_SetupOAuth2_InitErrorIsExit1(t *testing.T) {
 
 func TestPortFromRedirectURI(t *testing.T) {
 	cases := map[string]int{
-		"http://127.0.0.1:54321/callback":   54321,
-		"http://localhost:8080/x":           8080,
-		"http://127.0.0.1/callback":         0, // no port
-		"https://accounts.google.com/auth":  0, // standard port omitted
-		"":                                  0,
-		"not a url":                         0,
+		"http://127.0.0.1:54321/callback":  54321,
+		"http://localhost:8080/x":          8080,
+		"http://127.0.0.1/callback":        0, // no port
+		"https://accounts.google.com/auth": 0, // standard port omitted
+		"":                                 0,
+		"not a url":                        0,
 	}
 	for in, want := range cases {
 		if got := portFromRedirectURI(in); got != want {


### PR DESCRIPTION
## Summary
- `aileron launch` never set `Dir` on `LaunchConfig`, so the daemon's session record carried `working_dir=""` for every launch — defeating `aileron sessions list`'s `cwd` column.
- Capture `os.Getwd()` at the CLI call site and pass it through. Existing rows with empty `working_dir` are accepted as historical artifacts.

## Test plan
- [x] `TestRun_LaunchPopulatesWorkingDir` (new) — injects a fake launcher, asserts captured `LaunchConfig.Dir == os.Getwd()`. Fails before this commit, passes after.
- [x] Existing `TestRun_Launch*` tests still pass (use the same `resolveShimFn` seam, default to real `resolveShim`).
- [x] `go vet ./cmd/aileron/...` clean; `cmd/aileron` coverage stays at 86%.

Closes item #9 of #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)