### PR TITLE
feat(cli): empty-state list outputs suggest next command (#492 item 1)

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -524,6 +524,7 @@ func runSecretList(stdout, stderr io.Writer) int {
 	names := fv.Names()
 	if len(names) == 0 {
 		fmt.Fprintln(stdout, "No secrets stored.")
+		fmt.Fprintln(stdout, "Run `aileron secret set <name>` to store one.")
 		return 0
 	}
 
@@ -746,7 +747,8 @@ func runBindingList(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if len(resp.Items) == 0 {
-		fmt.Fprintln(stdout, "No bindings.")
+		fmt.Fprintln(stdout, "No bindings configured.")
+		fmt.Fprintln(stdout, "Run `aileron binding setup <connector-FQN>` to add one.")
 		return 0
 	}
 	fmt.Fprintf(stdout, "%-40s  %-10s  %-30s  %s\n", "NAME", "KIND", "CONNECTOR", "STATUS")
@@ -1515,6 +1517,7 @@ func runConnectorCheck(args []string, stdout, stderr io.Writer) int {
 
 	if len(resp.Results) == 0 {
 		fmt.Fprintln(stdout, "No connectors installed.")
+		fmt.Fprintln(stdout, "Run `aileron connector install <FQN>` to add one.")
 		return 0
 	}
 

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -838,6 +838,9 @@ func TestRunSecret_ListEmpty(t *testing.T) {
 	if !strings.Contains(stdout.String(), "No secrets stored") {
 		t.Errorf("expected 'No secrets stored', got: %s", stdout.String())
 	}
+	if !strings.Contains(stdout.String(), "aileron secret set") {
+		t.Errorf("expected next-step hint mentioning `aileron secret set`, got: %s", stdout.String())
+	}
 }
 
 func TestRunSecret_ListWithSecrets(t *testing.T) {
@@ -891,8 +894,11 @@ func TestRunBinding_ListEmpty(t *testing.T) {
 	if code != 0 {
 		t.Errorf("exit code = %d; stderr = %s", code, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "No bindings.") {
+	if !strings.Contains(stdout.String(), "No bindings configured.") {
 		t.Errorf("output = %q", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "aileron binding setup") {
+		t.Errorf("expected next-step hint mentioning `aileron binding setup`, got: %s", stdout.String())
 	}
 }
 
@@ -2261,6 +2267,9 @@ func TestRunConnectorCheck_Empty(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "No connectors installed") {
 		t.Errorf("expected 'No connectors installed' in output; got: %s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "aileron connector install") {
+		t.Errorf("expected next-step hint mentioning `aileron connector install`, got: %s", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary
- `aileron binding list`, `aileron secret list`, `aileron connector check` now print a one-line hint pointing at the obvious next command on empty results — same pattern as `aileron sessions list` from #495.
- `aileron audit list` left as-is: no obvious next command for an empty audit feed.

## Test plan
- [x] Existing empty-state tests (`TestRunBinding_ListEmpty`, `TestRunSecret_ListEmpty`, `TestRunConnectorCheck_Empty`) extended to assert the next-step hint is present.
- [x] `go test ./cmd/aileron/...` green; coverage holds (85.8%).

Closes item #1 of #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)