### PR TITLE
feat(cli): add --json to list commands (#492 item 2)

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -438,7 +438,7 @@ func runSecret(args []string, stdout, stderr io.Writer) int {
 	case "set":
 		return runSecretSet(args[1:], stdout, stderr)
 	case "list":
-		return runSecretList(stdout, stderr)
+		return runSecretList(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown secret command: %q\n", args[0])
 		fmt.Fprintln(stderr, "usage: aileron secret <set|list>")
@@ -520,7 +520,14 @@ func runSecretSet(args []string, stdout, stderr io.Writer) int {
 }
 
 // runSecretList lists secret names in the vault.
-func runSecretList(stdout, stderr io.Writer) int {
+func runSecretList(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("secret list", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	asJSON := flags.Bool("json", false, "Render names as a JSON array")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
 	vaultPath := launch.DefaultVaultPath()
 	fv, err := vault.NewFileVault(vaultPath)
 	if err != nil {
@@ -530,8 +537,23 @@ func runSecretList(stdout, stderr io.Writer) int {
 
 	names := fv.Names()
 	if len(names) == 0 {
+		if *asJSON {
+			fmt.Fprintln(stdout, "[]")
+			return 0
+		}
 		fmt.Fprintln(stdout, "No secrets stored.")
 		fmt.Fprintln(stdout, "Run `aileron secret set <name>` to store one.")
+		return 0
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		for _, name := range names {
+			if err := enc.Encode(name); err != nil {
+				fmt.Fprintf(stderr, "encode: %v\n", err)
+				return 1
+			}
+		}
 		return 0
 	}
 
@@ -580,7 +602,7 @@ func runBinding(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 var bindingBrowser oauth.Opener = oauth.SystemBrowser{}
 
 const bindingUsage = `usage:
-  aileron binding list   [--connector FQN] [--kind KIND]
+  aileron binding list   [--connector FQN] [--kind KIND] [--json]
   aileron binding inspect <name>
   aileron binding setup  <connector-FQN>
   aileron binding rebind <name>
@@ -731,6 +753,7 @@ func runBindingList(args []string, stdout, stderr io.Writer) int {
 	flags.SetOutput(stderr)
 	connector := flags.String("connector", "", "filter by connector FQN")
 	kind := flags.String("kind", "", "filter by credential kind")
+	asJSON := flags.Bool("json", false, "Render rows as NDJSON, one binding per line")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -762,8 +785,22 @@ func runBindingList(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if len(resp.Items) == 0 {
+		if *asJSON {
+			fmt.Fprintln(stdout, "[]")
+			return 0
+		}
 		fmt.Fprintln(stdout, "No bindings configured.")
 		fmt.Fprintln(stdout, "Run `aileron binding setup <connector-FQN>` to add one.")
+		return 0
+	}
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		for _, b := range resp.Items {
+			if err := enc.Encode(b); err != nil {
+				fmt.Fprintf(stderr, "encode: %v\n", err)
+				return 1
+			}
+		}
 		return 0
 	}
 	fmt.Fprintf(stdout, "%-40s  %-10s  %-30s  %s\n", "NAME", "KIND", "CONNECTOR", "STATUS")
@@ -1437,7 +1474,7 @@ func resolveShim() (string, error) {
 
 const connectorUsage = `usage:
   aileron connector install <FQN> [--version=<v>] [--hash=<sha256:...>] [--yes]
-  aileron connector check [--include-prerelease]`
+  aileron connector check [--include-prerelease] [--json]`
 
 const actionUsage = `usage:
   aileron action add <FQN> [--version=<v>] [--force] [--yes] [--no-bind]`
@@ -1520,6 +1557,7 @@ func runConnectorCheck(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("connector check", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	includePrerelease := flags.Bool("include-prerelease", false, "include pre-release versions when computing the latest version")
+	asJSON := flags.Bool("json", false, "Render results as NDJSON, one connector per line")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -1531,8 +1569,23 @@ func runConnectorCheck(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if len(resp.Results) == 0 {
+		if *asJSON {
+			fmt.Fprintln(stdout, "[]")
+			return 0
+		}
 		fmt.Fprintln(stdout, "No connectors installed.")
 		fmt.Fprintln(stdout, "Run `aileron connector install <FQN>` to add one.")
+		return 0
+	}
+
+	if *asJSON {
+		enc := json.NewEncoder(stdout)
+		for _, r := range resp.Results {
+			if err := enc.Encode(r); err != nil {
+				fmt.Fprintf(stderr, "encode: %v\n", err)
+				return 1
+			}
+		}
 		return 0
 	}
 
@@ -2439,6 +2492,10 @@ func runAuditList(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 	if len(resp.Events) == 0 {
+		if *asJSON {
+			fmt.Fprintln(stdout, "[]")
+			return 0
+		}
 		fmt.Fprintln(stdout, "No audit events.")
 		return 0
 	}

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -523,7 +523,7 @@ func runSecretSet(args []string, stdout, stderr io.Writer) int {
 func runSecretList(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("secret list", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	asJSON := flags.Bool("json", false, "Render names as a JSON array")
+	asJSON := flags.Bool("json", false, "Render names as NDJSON, one name per line")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -1038,6 +1038,21 @@ func TestRunBinding_ListJSON_NDJSON(t *testing.T) {
 	}
 }
 
+// TestRunBinding_UsageAdvertisesJSON: bindingUsage gained `[--json]`
+// in #492 item 2; the user-discovery path is `aileron binding` with no
+// subcommand, which prints the usage to stderr. Pins the contract that
+// the flag is documented in that surface.
+func TestRunBinding_UsageAdvertisesJSON(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"binding"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit for no subcommand")
+	}
+	if !strings.Contains(stderr.String(), "--json") {
+		t.Errorf("usage missing `--json`:\n%s", stderr.String())
+	}
+}
+
 func TestRunBinding_ListShowsTable(t *testing.T) {
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -2455,6 +2470,21 @@ func TestRunConnectorCheck_JSON_NDJSON(t *testing.T) {
 		if err := json.Unmarshal([]byte(line), &r); err != nil {
 			t.Errorf("line %q is not JSON: %v", line, err)
 		}
+	}
+}
+
+// TestRunConnector_UsageAdvertisesJSON: connectorUsage gained `[--json]`
+// for `connector check` in #492 item 2. Pins that the flag is
+// documented in the surface a user reaches via `aileron connector`
+// with no subcommand.
+func TestRunConnector_UsageAdvertisesJSON(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"connector"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit for no subcommand")
+	}
+	if !strings.Contains(stderr.String(), "--json") {
+		t.Errorf("usage missing `--json`:\n%s", stderr.String())
 	}
 }
 

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -902,6 +902,61 @@ func TestRunSecret_ListWithSecrets(t *testing.T) {
 	}
 }
 
+// TestRunSecret_ListJSON_Empty: --json on an empty vault emits `[]`,
+// not the human-targeted prose. Lets scripts detect "nothing here yet"
+// without grepping for "No secrets stored".
+func TestRunSecret_ListJSON_Empty(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"secret", "list", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if got := strings.TrimRight(stdout.String(), "\n"); got != "[]" {
+		t.Errorf("stdout = %q, want %q", got, "[]")
+	}
+}
+
+// TestRunSecret_ListJSON_NDJSON: --json with secrets emits one
+// JSON-encoded name per line.
+func TestRunSecret_ListJSON_NDJSON(t *testing.T) {
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+
+	vaultPath := filepath.Join(dir, ".aileron", "secrets.json")
+	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(vaultPath, []byte(`{"salt":"AAAA","secrets":{"a":{"value":"ZW5j","metadata":{}},"b":{"value":"ZW5j","metadata":{}}}}`), 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"secret", "list", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2: %q", len(lines), stdout.String())
+	}
+	got := map[string]bool{}
+	for _, line := range lines {
+		var name string
+		if err := json.Unmarshal([]byte(line), &name); err != nil {
+			t.Errorf("line %q is not JSON: %v", line, err)
+		}
+		got[name] = true
+	}
+	for _, want := range []string{"a", "b"} {
+		if !got[want] {
+			t.Errorf("missing name %q in: %v", want, got)
+		}
+	}
+}
+
 // `aileron binding list` reads vault metadata without unlocking, per
 // ADR-0011 acceptance: metadata is plaintext on disk, so the user
 // can inspect what's bound before paying the passphrase prompt.
@@ -935,6 +990,51 @@ func TestRunBinding_ListEmpty(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "aileron binding setup") {
 		t.Errorf("expected next-step hint mentioning `aileron binding setup`, got: %s", stdout.String())
+	}
+}
+
+// TestRunBinding_ListJSON_Empty: --json on the empty case emits `[]`,
+// not the human "No bindings configured." text. Scripts can detect the
+// empty set with a JSON parser instead of grepping prose.
+func TestRunBinding_ListJSON_Empty(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items":[]}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"binding", "list", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if got := strings.TrimRight(stdout.String(), "\n"); got != "[]" {
+		t.Errorf("stdout = %q, want %q", got, "[]")
+	}
+}
+
+// TestRunBinding_ListJSON_NDJSON: --json with rows emits one
+// JSON-encoded binding per line, round-trippable through json.Decode.
+func TestRunBinding_ListJSON_NDJSON(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"items":[
+			{"name":"api_key/linear/team","kind":"api_key","service":"linear","identity":"team","connector_fqn":"github://aileron/linear","status":"active","created_at":"2024-01-01T00:00:00Z"},
+			{"name":"oauth2/slack/work","kind":"oauth2","service":"slack","identity":"work","connector_fqn":"github://aileron/slack","status":"active","created_at":"2024-01-01T00:00:00Z"}
+		]}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"binding", "list", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2: %q", len(lines), stdout.String())
+	}
+	for _, line := range lines {
+		var b bindingRow
+		if err := json.Unmarshal([]byte(line), &b); err != nil {
+			t.Errorf("line %q is not JSON: %v", line, err)
+		}
 	}
 }
 
@@ -2306,6 +2406,55 @@ func TestRunConnectorCheck_Empty(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "aileron connector install") {
 		t.Errorf("expected next-step hint mentioning `aileron connector install`, got: %s", stdout.String())
+	}
+}
+
+// TestRunConnectorCheck_JSON_Empty: --json on an empty install set emits
+// `[]`, so scripts can detect the bare-server case without grepping.
+func TestRunConnectorCheck_JSON_Empty(t *testing.T) {
+	prev := connectorCheckFetcher
+	connectorCheckFetcher = func(includePrerelease bool) (*connectorsCheckResponse, error) {
+		return &connectorsCheckResponse{Results: []connectorCheckResult{}}, nil
+	}
+	defer func() { connectorCheckFetcher = prev }()
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"connector", "check", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if got := strings.TrimRight(stdout.String(), "\n"); got != "[]" {
+		t.Errorf("stdout = %q, want %q", got, "[]")
+	}
+}
+
+// TestRunConnectorCheck_JSON_NDJSON: --json with results emits one
+// JSON-encoded connectorCheckResult per line.
+func TestRunConnectorCheck_JSON_NDJSON(t *testing.T) {
+	latest := "0.0.6"
+	prev := connectorCheckFetcher
+	connectorCheckFetcher = func(includePrerelease bool) (*connectorsCheckResponse, error) {
+		return &connectorsCheckResponse{Results: []connectorCheckResult{
+			{Fqn: "github://x/a", CurrentVersion: "0.0.5", LatestVersion: &latest, UpdateAvailable: true},
+			{Fqn: "github://x/b", CurrentVersion: "0.1.0", LatestVersion: &latest, UpdateAvailable: false},
+		}}, nil
+	}
+	defer func() { connectorCheckFetcher = prev }()
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"connector", "check", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2: %q", len(lines), stdout.String())
+	}
+	for _, line := range lines {
+		var r connectorCheckResult
+		if err := json.Unmarshal([]byte(line), &r); err != nil {
+			t.Errorf("line %q is not JSON: %v", line, err)
+		}
 	}
 }
 
@@ -3706,6 +3855,27 @@ func TestRunAudit_EmptyPrintsNoEntries(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "No audit events") {
 		t.Errorf("expected 'No audit events'; got: %s", stdout.String())
+	}
+}
+
+// TestRunAudit_EmptyJSONEmitsArray: regression for #492 item 2 — `--json`
+// on the empty case must emit `[]`, not the human "No audit events." line.
+// Before the fix, the empty branch ignored the flag and broke any script
+// that relied on parsing JSON from `aileron audit list --json`.
+func TestRunAudit_EmptyJSONEmitsArray(t *testing.T) {
+	prev := auditListFetcher
+	auditListFetcher = func(_ auditListQuery) (*auditListWire, error) {
+		return &auditListWire{Events: []auditEventWire{}}, nil
+	}
+	defer func() { auditListFetcher = prev }()
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"audit", "list", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if got := strings.TrimRight(stdout.String(), "\n"); got != "[]" {
+		t.Errorf("stdout = %q, want %q", got, "[]")
 	}
 }
 


### PR DESCRIPTION
## Summary
- Adds `--json` to `aileron binding list`, `aileron secret list`, and `aileron connector check`. Empty case emits `[]`; populated case emits NDJSON (one object per line). Matches the format already used by `aileron sessions list` (#495) and `aileron audit list`.
- Fixes a pre-existing bug in `aileron audit list --json`: the empty-case branch ignored the flag and printed the human "No audit events." line. Regression test included.

## Stacked on #498
This PR is based on `worktree-issue-492-item-1` (PR #498) because both branches touch `runBindingList` and `runConnectorCheck`. Once #498 lands, GitHub will offer to retarget to `main` (or merging #498 first will collapse the diff cleanly).

## Test plan
- [x] New tests cover the --json empty + NDJSON paths for binding, secret, and connector list commands.
- [x] `TestRunAudit_EmptyJSONEmitsArray` (regression for the audit empty-JSON bug) — fails before the fix, passes after.
- [x] `go test ./cmd/aileron/...` green; coverage holds (85.7%).
- [x] `bindingUsage` and `connectorUsage` strings updated to advertise `--json`.

Closes item #2 of #492.

🤖 Generated with [Claude Code](https://claude.com/claude-code)