### PR TITLE
test(e2e): gate connected-accounts test on a post-fetch state signal

### DIFF
--- a/ui/e2e-integration/connected-accounts.spec.ts
+++ b/ui/e2e-integration/connected-accounts.spec.ts
@@ -28,10 +28,14 @@ test.describe('Connected Accounts — Real API', () => {
 	test('available integrations shown or redirects to vault setup', async ({ authedPage: page }) => {
 		await page.goto('/settings/connected-accounts');
 
-		// Wait for the page to settle — either vault setup or connected accounts content
+		// Wait for a state signal that lands AFTER the GET /v1/connected-accounts
+		// fetch resolves — either the vault-setup redirect copy or the
+		// landed empty-state copy. The Connected Accounts card title
+		// renders before the fetch resolves, so gating on the title
+		// raced against the empty state and the providers list (#501).
 		const settled = page
 			.getByText('Secure your vault')
-			.or(page.locator('[data-slot="card-title"]', { hasText: 'Connected Accounts' }));
+			.or(page.getByText('No accounts connected yet.'));
 		await expect(settled).toBeVisible({ timeout: 15000 });
 
 		if (page.url().includes('/vault')) {
@@ -39,10 +43,10 @@ test.describe('Connected Accounts — Real API', () => {
 			return;
 		}
 
-		// Verify empty state
-		await expect(page.getByText('No accounts connected yet.')).toBeVisible();
-
-		// All four providers should be listed
+		// Empty state already verified by the `settled` matcher above —
+		// reaching this point means the fetch resolved and the page has
+		// rendered its post-fetch content. The provider list shares the
+		// same fetch, so the next assertions land deterministically.
 		await expect(page.getByText('Slack', { exact: true })).toBeVisible();
 		await expect(page.getByText('GitHub')).toBeVisible();
 		await expect(page.getByText('Gmail', { exact: true })).toBeVisible();


### PR DESCRIPTION
## Summary

Closes #501.

The `settled` matcher in the "available integrations shown or redirects to vault setup" test was satisfied as soon as the **Connected Accounts** card title appeared — which the page renders before the `GET /v1/connected-accounts` fetch resolves. Playwright's default 5s timeout on the very next assertion (`No accounts connected yet.`) could then fire before the fetch landed and the empty-state copy was painted, producing the intermittent failure observed on `2ef5436` (#495 push) and `1c5a0e5` (#500 head).

## Fix

Replace the title-branch in `settled` with the empty-state text. Both `or` branches now land **after** the API call resolves:

- `Secure your vault` is the redirect-target signal (vault-setup branch).
- `No accounts connected yet.` is the post-fetch landed-state signal (no-accounts branch).

The provider-name assertions that follow are guaranteed deterministic because they read from the same fetch's data — by the time we get past `settled`, the fetch has already populated the DOM.

## Test plan

- [x] Diff is a one-block spec edit; no production code changed.
- [ ] Five consecutive CI runs pass on this branch (the acceptance criterion in #501). Verifying via the PR's CI checks.

🤖 Generated with [Claude Code](https://claude.com/claude-code)