### PR TITLE
fix(vault): tolerate ErrVaultExists in concurrent first-run flow

### DIFF
--- a/cmd/aileron/vault_state.go
+++ b/cmd/aileron/vault_state.go
@@ -120,7 +120,16 @@ func promptCreateAndUnlock(vaultPath, passphraseFile string, stderr io.Writer) e
 			return errors.New("passphrases do not match")
 		}
 	}
-	if _, err := vaultInitFn(vaultPath, passphrase); err != nil {
+	// Tolerate ErrVaultExists: under concurrent first-run (e.g. ten
+	// parallel `aileron <cmd>` invocations sharing AILERON_VAULT_PASSPHRASE,
+	// per #454 Test 6), only one CLI's vault.Init wins; the others see
+	// the file already created and would otherwise fail with a confusing
+	// "creating vault: vault: already exists". The post-spawn unlock
+	// below then validates the passphrase against whatever was written —
+	// if the racing CLIs disagree, the losers get a 401 from /v1/vault/
+	// unlock and surface that, which is the correct shape for "you and
+	// another process picked different passphrases."
+	if _, err := vaultInitFn(vaultPath, passphrase); err != nil && !errors.Is(err, vault.ErrVaultExists) {
 		return fmt.Errorf("creating vault: %w", err)
 	}
 	url, err := spawnResolveCachedFn()

--- a/cmd/aileron/vault_state_test.go
+++ b/cmd/aileron/vault_state_test.go
@@ -623,6 +623,40 @@ func TestEnsureVaultUnlocked_StoppedMissing_InteractiveDriveSpawnAndUnlock(t *te
 	}
 }
 
+// TestEnsureVaultUnlocked_StoppedMissing_TolerateErrVaultExists pins
+// the concurrent first-run contract from #454 Test 6: multiple CLI
+// processes sharing AILERON_VAULT_PASSPHRASE may race on vault.Init,
+// and only one wins. The losers see the file already created and must
+// fall through to the spawn + unlock steps rather than aborting with
+// "creating vault: vault: already exists". The unlock POST is what
+// validates the passphrase end-to-end — a wrong passphrase still
+// surfaces as a 401, but a correct passphrase succeeds even though
+// vault.Init failed.
+func TestEnsureVaultUnlocked_StoppedMissing_TolerateErrVaultExists(t *testing.T) {
+	scopeHomeAndAPIURL(t)
+	t.Setenv(envVaultPassphrase, "shared-pass")
+
+	spawnFired, unlockFired := false, false
+	withVaultStateSeams(t, vaultStateFakes{
+		discoveryRead:   func(string) (discovery.Info, error) { return discovery.Info{}, discovery.ErrNotRunning },
+		vaultCheckState: func(string) (vault.State, error) { return vault.StateMissing, nil },
+		vaultInit: func(string, string) (vault.Vault, error) {
+			// Simulate a racing CLI having already created the vault
+			// between our CheckState and our Init call.
+			return nil, vault.ErrVaultExists
+		},
+		spawnResolve: func() (string, error) { spawnFired = true; return "http://x/v1", nil },
+		postUnlock:   func(string, string) error { unlockFired = true; return nil },
+	})
+
+	if err := ensureVaultUnlocked("", io.Discard); err != nil {
+		t.Fatalf("ensureVaultUnlocked: %v (ErrVaultExists must be tolerated)", err)
+	}
+	if !spawnFired || !unlockFired {
+		t.Errorf("spawn and unlock must still fire after ErrVaultExists; spawn=%v, unlock=%v", spawnFired, unlockFired)
+	}
+}
+
 // First-run + vault.Init failure: error wrapped, no spawn.
 func TestEnsureVaultUnlocked_StoppedMissing_VaultInitFailurePropagates(t *testing.T) {
 	scopeHomeAndAPIURL(t)


### PR DESCRIPTION
## Summary
Surfaced by readiness review for #454 Test 6 (concurrent first-run singleton). Ten parallel CLI processes sharing \`AILERON_VAULT_PASSPHRASE\` all enter \`promptCreateAndUnlock\`, but only one wins the \`vault.Init\` race. Pre-fix the losers aborted with \"creating vault: vault: already exists\" — confusing UX that doesn't match the test's expected contract (one daemon spawned, calls succeed).

## Fix
Treat \`vault.ErrVaultExists\` as success-ish in \`promptCreateAndUnlock\`: fall through to spawn + unlock with the passphrase the caller already has. The post-spawn \`/v1/vault/unlock\` validates the passphrase end-to-end — if the racing CLIs disagree, losers naturally surface a 401 (\"wrong passphrase — try again\"), which is the correct shape for \"you and another process picked different passphrases.\"

## Test plan
- [x] Regression test \`TestEnsureVaultUnlocked_StoppedMissing_TolerateErrVaultExists\` added; verified it fails before this fix (\"creating vault: vault: already exists\") and passes after.
- [x] \`go test ./cmd/aileron/...\` green.
- [x] Other state-machine tests untouched; single-CLI behavior unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)