### PR TITLE
fix(cli): print new-vault banner before first passphrase prompt

### DIFF
--- a/cmd/aileron/vault.go
+++ b/cmd/aileron/vault.go
@@ -67,6 +67,15 @@ func runVaultInit(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
+	// Print the new-vault banner BEFORE the first prompt so the user
+	// reads the irretrievable-passphrase warning before choosing one.
+	// File/env sources are non-interactive (CI, scripts) and don't need
+	// the warning — gate on willPromptInteractively, not on the source
+	// returned by readVaultPassphrase (which only resolves after the
+	// prompt fires).
+	if willPromptInteractively(*passphraseFile) {
+		printNewVaultBanner(stderr, vaultPath)
+	}
 	passphrase, source, err := readVaultPassphrase(*passphraseFile, "Vault passphrase: ", stderr)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
@@ -81,7 +90,6 @@ func runVaultInit(args []string, stdout, stderr io.Writer) int {
 	// passphrase comes from a file or env, re-reading the same source
 	// would just confirm itself, so we skip the second prompt.
 	if source == passphraseSourceInteractive {
-		printNewVaultBanner(stderr, vaultPath)
 		confirm, _, err := readVaultPassphrase("", "Confirm passphrase: ", stderr)
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %v\n", err)
@@ -140,6 +148,16 @@ func readVaultPassphrase(passphraseFile, prompt string, w io.Writer) (string, pa
 		return "", passphraseSourceInteractive, err
 	}
 	return pass, passphraseSourceInteractive, nil
+}
+
+// willPromptInteractively reports whether the next readVaultPassphrase
+// call would fall through to /dev/tty. Mirrors readVaultPassphrase's
+// dispatch order — file > env > interactive — so callers can decide
+// whether to print user-facing context (e.g. the new-vault banner)
+// BEFORE the prompt fires, instead of inferring interactivity from
+// the post-hoc passphraseSource return value.
+func willPromptInteractively(passphraseFile string) bool {
+	return passphraseFile == "" && os.Getenv(envVaultPassphrase) == ""
 }
 
 // printNewVaultBanner prints the irretrievable-passphrase warning. Same

--- a/cmd/aileron/vault_state.go
+++ b/cmd/aileron/vault_state.go
@@ -103,6 +103,13 @@ func promptAndUnlockRunning(daemonURL, passphraseFile string, stderr io.Writer) 
 // but folded into one prompt so a fresh user doesn't have to learn
 // three commands before their first action.
 func promptCreateAndUnlock(vaultPath, passphraseFile string, stderr io.Writer) error {
+	// Print the new-vault banner BEFORE the first prompt so the user
+	// reads the irretrievable-passphrase warning before choosing one.
+	// File/env sources skip the banner (non-interactive callers don't
+	// need the warning).
+	if willPromptInteractively(passphraseFile) {
+		printNewVaultBanner(stderr, vaultPath)
+	}
 	passphrase, source, err := readVaultPassphrase(passphraseFile, "Vault passphrase: ", stderr)
 	if err != nil {
 		return err
@@ -111,7 +118,6 @@ func promptCreateAndUnlock(vaultPath, passphraseFile string, stderr io.Writer) e
 		return errors.New("vault passphrase cannot be empty")
 	}
 	if source == passphraseSourceInteractive {
-		printNewVaultBanner(stderr, vaultPath)
 		confirm, _, err := readVaultPassphrase("", "Confirm passphrase: ", stderr)
 		if err != nil {
 			return err

--- a/cmd/aileron/vault_state_test.go
+++ b/cmd/aileron/vault_state_test.go
@@ -623,6 +623,54 @@ func TestEnsureVaultUnlocked_StoppedMissing_InteractiveDriveSpawnAndUnlock(t *te
 	}
 }
 
+// TestEnsureVaultUnlocked_StoppedMissing_BannerPrintsBeforeFirstPrompt
+// regression-pins #528 finding 1: on interactive first-run, the user
+// must see the irretrievable-passphrase warning BEFORE choosing a
+// passphrase, not after they've already typed one.
+//
+// The fake prompt writes its prompt string to the supplied writer,
+// mirroring defaultPromptPassphrase, so the test buffer captures the
+// natural ordering between banner output and prompt strings.
+func TestEnsureVaultUnlocked_StoppedMissing_BannerPrintsBeforeFirstPrompt(t *testing.T) {
+	scopeHomeAndAPIURL(t)
+	answers := []string{"new-pass", "new-pass"}
+	idx := 0
+	withVaultStateSeams(t, vaultStateFakes{
+		discoveryRead:   func(string) (discovery.Info, error) { return discovery.Info{}, discovery.ErrNotRunning },
+		vaultCheckState: func(string) (vault.State, error) { return vault.StateMissing, nil },
+		prompt: func(prompt string, w io.Writer) (string, error) {
+			if w != nil && prompt != "" {
+				_, _ = w.Write([]byte(prompt))
+			}
+			a := answers[idx]
+			idx++
+			return a, nil
+		},
+		vaultInit:    func(string, string) (vault.Vault, error) { return vault.NewMemVault(), nil },
+		spawnResolve: func() (string, error) { return "http://x/v1", nil },
+		postUnlock:   func(string, string) error { return nil },
+	})
+
+	var stderr bytes.Buffer
+	if err := ensureVaultUnlocked("", &stderr); err != nil {
+		t.Fatalf("ensureVaultUnlocked: %v", err)
+	}
+
+	out := stderr.String()
+	bannerAt := strings.Index(out, "Creating a new Aileron vault")
+	promptAt := strings.Index(out, "Vault passphrase:")
+	if bannerAt < 0 {
+		t.Fatalf("banner missing from stderr: %q", out)
+	}
+	if promptAt < 0 {
+		t.Fatalf("first prompt missing from stderr: %q", out)
+	}
+	if bannerAt > promptAt {
+		t.Errorf("banner must appear BEFORE first 'Vault passphrase:' prompt; banner@%d, prompt@%d\nstderr=%q",
+			bannerAt, promptAt, out)
+	}
+}
+
 // TestEnsureVaultUnlocked_StoppedMissing_TolerateErrVaultExists pins
 // the concurrent first-run contract from #454 Test 6: multiple CLI
 // processes sharing AILERON_VAULT_PASSPHRASE may race on vault.Init,

--- a/cmd/aileron/vault_test.go
+++ b/cmd/aileron/vault_test.go
@@ -229,6 +229,55 @@ func TestRunVaultInit_PassphraseFileTrimsTrailingNewline(t *testing.T) {
 	}
 }
 
+// TestRunVaultInit_BannerPrintsBeforeFirstPrompt regression-pins
+// #528 finding 1 (the `vault init` flow shares the same first-run
+// banner with the daemon-auto-spawn path; both must print the
+// irretrievable-passphrase warning BEFORE the user types a passphrase,
+// not between the two prompts).
+//
+// The scripted prompt writes its prompt string to the supplied writer
+// (mirroring defaultPromptPassphrase) so the captured stderr buffer
+// reflects natural ordering.
+func TestRunVaultInit_BannerPrintsBeforeFirstPrompt(t *testing.T) {
+	vaultPath := vaultInitTempHome(t)
+	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o700); err != nil {
+		t.Fatal(err)
+	}
+
+	answers := []string{"correct horse", "correct horse"}
+	idx := 0
+	prevPrompt := promptPassphrase
+	t.Cleanup(func() { promptPassphrase = prevPrompt })
+	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
+		if w != nil && prompt != "" {
+			_, _ = w.Write([]byte(prompt))
+		}
+		a := answers[idx]
+		idx++
+		return a, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"vault", "init"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+
+	out := stderr.String()
+	bannerAt := strings.Index(out, "Creating a new Aileron vault")
+	promptAt := strings.Index(out, "Vault passphrase:")
+	if bannerAt < 0 {
+		t.Fatalf("banner missing from stderr: %q", out)
+	}
+	if promptAt < 0 {
+		t.Fatalf("first prompt missing from stderr: %q", out)
+	}
+	if bannerAt > promptAt {
+		t.Errorf("banner must appear BEFORE first 'Vault passphrase:' prompt; banner@%d, prompt@%d\nstderr=%q",
+			bannerAt, promptAt, out)
+	}
+}
+
 func TestRunVaultInit_AppearsInHelp(t *testing.T) {
 	var stdout bytes.Buffer
 	usage(&stdout, newTestRegistry())

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -516,8 +516,12 @@ func EnvGlobMatch(pattern, name string) bool {
 	return pattern == name
 }
 
-// sessionLogPath returns the path to the session log file,
-// located alongside the audit log in .aileron/.
+// sessionLogPath returns the per-project session log path: the
+// .aileron/session.log next to the policy file (walking up from dir if
+// necessary) or, if no policy file exists, .aileron/session.log under
+// dir itself. The session log captures the launched agent's stdio and
+// is intentionally project-scoped — distinct from the audit log, which
+// is user-scoped at ~/.aileron/audit/.
 func sessionLogPath(dir string) string {
 	if dir == "" {
 		dir, _ = os.Getwd()


### PR DESCRIPTION
## Summary
Resolves findings 1 and 2 from #528 (manual acceptance testing of #454).

- **Finding 1 — banner ordering**: the "Creating a new Aileron vault" warning was printing *after* the user typed a passphrase, defeating the warning's purpose. Moved it ahead of the first prompt in both `promptCreateAndUnlock` (auto-spawn first-run) and `runVaultInit` (`aileron vault init`).
- **Finding 2 — stale comment**: `sessionLogPath`'s comment claimed the session log lives "alongside the audit log in `.aileron/`", but the audit log moved to `~/.aileron/audit/` per #454 step 5. Updated to describe what the function actually does.

## Approach
Added `willPromptInteractively(passphraseFile string) bool` next to `readVaultPassphrase` in `cmd/aileron/vault.go`. It mirrors the dispatch order (file > env > interactive) so callers can decide whether to print user-facing context **before** the prompt fires, instead of inferring interactivity from the post-hoc `passphraseSource` return value.

Both `promptCreateAndUnlock` and `runVaultInit` now print the banner conditionally on `willPromptInteractively`, then read the passphrase, then (if interactive) read the confirmation. File/env-sourced passphrases continue to skip the banner — non-interactive callers (CI, scripts) don't need the warning.

## Test plan
- [x] New regression test `TestEnsureVaultUnlocked_StoppedMissing_BannerPrintsBeforeFirstPrompt` asserts banner index < first-prompt index in stderr (mirrors the user-observed output from #454 Test 1).
- [x] New regression test `TestRunVaultInit_BannerPrintsBeforeFirstPrompt` covers the `vault init` path with the same ordering check.
- [x] Verified both new tests **fail** on the pre-fix code (banner@21, prompt@0) and pass after the fix.
- [x] `go test ./cmd/aileron/... ./internal/...` — all green.
- [x] Coverage: cmd/aileron 85.8%, internal/launch 87.4%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)