### PR TITLE
fix(spawn): retry readAlive on lock-acquire timeout

### DIFF
--- a/internal/daemon/spawn/spawn.go
+++ b/internal/daemon/spawn/spawn.go
@@ -108,6 +108,17 @@ func Resolve(ctx context.Context, opts Options) (string, error) {
 	release, err := discovery.Lock(lockCtx, opts.StateDir)
 	cancelLock()
 	if err != nil {
+		// Lock-acquire timed out. The most common cause is that a
+		// surviving daemon already grabbed the lock and is holding
+		// it for its lifetime (`internal/server.run`'s `defer
+		// releaseLock`), so no client can ever acquire it again.
+		// In that case the daemon is up — retry readAlive once
+		// before surfacing the error. (#528 finding 3a)
+		if errors.Is(err, context.DeadlineExceeded) {
+			if url, ok := readAlive(opts.StateDir, opts.LivenessTimeout); ok {
+				return url, nil
+			}
+		}
 		return "", fmt.Errorf("spawn: acquire lock: %w", err)
 	}
 

--- a/internal/daemon/spawn/spawn_test.go
+++ b/internal/daemon/spawn/spawn_test.go
@@ -376,3 +376,130 @@ func TestResolve_ReleasesLockBeforeWaitForDaemon(t *testing.T) {
 }
 
 func emptyEnv(string) string { return "" }
+
+// TestResolve_RetriesReadAliveOnLockTimeout regression-pins #528
+// finding 3a: when the spawn lock is held forever (the surviving
+// daemon owns it for its lifetime), a client that arrives during the
+// daemon's bind window must not return "spawn: acquire lock: context
+// deadline exceeded". Instead, it should retry readAlive once after
+// the lock-acquire timeout and pick up the now-bound daemon.
+//
+// Scenario: external goroutine takes daemon.lock and holds it. After
+// a short delay, it stands up a fake daemon (TCP listener + daemon.json).
+// Resolve is called with a short ctx so the lock acquire fails quickly.
+// The fix's post-timeout readAlive retry is what lets Resolve return
+// the URL successfully despite the lock being held.
+func TestResolve_RetriesReadAliveOnLockTimeout(t *testing.T) {
+	dir := t.TempDir()
+
+	// Hold daemon.lock for the duration of the test, mimicking the
+	// surviving daemon's lifetime-long flock.
+	lockHeld := make(chan struct{})
+	releaseLockOnExit := make(chan struct{})
+	go func() {
+		lockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		release, err := discovery.Lock(lockCtx, dir)
+		if err != nil {
+			t.Errorf("external lock acquire: %v", err)
+			close(lockHeld)
+			return
+		}
+		close(lockHeld)
+		<-releaseLockOnExit
+		_ = release()
+	}()
+	t.Cleanup(func() { close(releaseLockOnExit) })
+	<-lockHeld
+
+	// After Resolve enters its lock-acquire wait, write daemon.json +
+	// bind a listener. The 100ms delay is enough that Resolve has
+	// passed its fast-path readAlive (which would otherwise short-
+	// circuit before the lock attempt) and is blocked in discovery.Lock.
+	bindDone := make(chan string, 1)
+	var listenerCloser func()
+	go func() {
+		time.Sleep(100 * time.Millisecond)
+		url, cleanup := fakeDaemon(t, dir)
+		listenerCloser = cleanup
+		bindDone <- url
+	}()
+	t.Cleanup(func() {
+		if listenerCloser != nil {
+			listenerCloser()
+		}
+	})
+
+	// 400ms ctx caps the lock-acquire timeout (it would otherwise be
+	// 2s). Bound by 100ms-bind + slack for the retry to fire.
+	ctx, cancel := context.WithTimeout(context.Background(), 400*time.Millisecond)
+	defer cancel()
+
+	got, err := spawn.Resolve(ctx, spawn.Options{
+		StateDir:        dir,
+		EnvLookup:       emptyEnv,
+		SpawnTimeout:    1 * time.Second,
+		PollInterval:    25 * time.Millisecond,
+		LivenessTimeout: 200 * time.Millisecond,
+		SpawnFn: func(context.Context, string) error {
+			t.Error("SpawnFn must not be called: lock-acquire-timeout retry should pick up the existing daemon")
+			return nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve: %v (expected the post-timeout readAlive retry to return the daemon URL)", err)
+	}
+	want := <-bindDone
+	if got != want {
+		t.Errorf("got URL %q, want %q", got, want)
+	}
+}
+
+// TestResolve_LockTimeoutSurfacedWhenNoDaemon pins the negative case
+// for #528 finding 3a: if the lock truly cannot be acquired AND no
+// daemon is reachable, the lock-acquire error must still propagate.
+// Otherwise the fix would mask all lock-acquire errors as silent
+// successes against a nonexistent daemon.
+func TestResolve_LockTimeoutSurfacedWhenNoDaemon(t *testing.T) {
+	dir := t.TempDir()
+
+	// Hold the lock; never write daemon.json or bind a listener.
+	lockHeld := make(chan struct{})
+	releaseLockOnExit := make(chan struct{})
+	go func() {
+		lockCtx, cancel := context.WithTimeout(context.Background(), 5*time.Second)
+		defer cancel()
+		release, err := discovery.Lock(lockCtx, dir)
+		if err != nil {
+			t.Errorf("external lock acquire: %v", err)
+			close(lockHeld)
+			return
+		}
+		close(lockHeld)
+		<-releaseLockOnExit
+		_ = release()
+	}()
+	t.Cleanup(func() { close(releaseLockOnExit) })
+	<-lockHeld
+
+	ctx, cancel := context.WithTimeout(context.Background(), 300*time.Millisecond)
+	defer cancel()
+
+	_, err := spawn.Resolve(ctx, spawn.Options{
+		StateDir:        dir,
+		EnvLookup:       emptyEnv,
+		SpawnTimeout:    1 * time.Second,
+		PollInterval:    25 * time.Millisecond,
+		LivenessTimeout: 50 * time.Millisecond,
+		SpawnFn: func(context.Context, string) error {
+			t.Error("SpawnFn must not be called when lock acquire times out")
+			return nil
+		},
+	})
+	if err == nil {
+		t.Fatal("expected lock-acquire error when no daemon is reachable, got nil")
+	}
+	if !errors.Is(err, context.DeadlineExceeded) {
+		t.Errorf("err = %v, want wrapped context.DeadlineExceeded", err)
+	}
+}


### PR DESCRIPTION
## Summary
Resolves finding 3a from #528 — concurrent first-run hard-failures observed at a 4/10 rate during #454 Test 6.

When the surviving daemon takes `daemon.lock`, it holds it for its entire lifetime (`internal/server.run`'s `defer releaseLock`). Other clients that arrive during the daemon's bind window (after the parent client released the spawn lock but before the daemon binds its TCP port) hit `discovery.Lock` and spin until the 2 s ctx timeout, then return `spawn: acquire lock: context deadline exceeded` — even though the daemon is right there, just slightly slow to come up.

Fix: after `discovery.Lock` returns `context.DeadlineExceeded`, retry `readAlive` once. By the time 2 s has elapsed, any daemon racing for the lock has either bound its port (so the retry returns its URL) or genuinely failed (in which case the lock-acquire error still propagates).

## Test plan
- [x] `TestResolve_RetriesReadAliveOnLockTimeout` — external goroutine takes `daemon.lock` and holds it for the duration; a second goroutine writes `daemon.json` + binds a listener after 100 ms; `Resolve` is called with a 400 ms ctx so its lock acquire fails. With the fix, the retry returns the URL; without it, Resolve hard-fails with `spawn: acquire lock: context deadline exceeded` (verified via stash + rerun).
- [x] `TestResolve_LockTimeoutSurfacedWhenNoDaemon` — negative case: lock held, no daemon ever appears. Confirms the lock-acquire error still propagates so the fix doesn't silently mask all timeouts.
- [x] All existing spawn tests still pass.
- [x] Coverage: `internal/daemon/spawn` 90.5%.

## Notes
This addresses 3a only. Finding 3b (singleton invariant breaks across `rm -rf` while a daemon survives) is a separate bug with a different fix shape — tracked for a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)