### PR TITLE
fix(daemon): self-terminate on lock-file inode mismatch

### DIFF
--- a/internal/daemon/discovery/discovery.go
+++ b/internal/daemon/discovery/discovery.go
@@ -106,6 +106,35 @@ func Remove(stateDir string) error {
 	return nil
 }
 
+// LockFileInode returns the current inode of <stateDir>/daemon.lock.
+// Used by the daemon to capture the inode of its held flock at startup,
+// for periodic comparison against the current inode at the same path.
+//
+// The flock(2) primitive holds against an open file descriptor — i.e.
+// against an inode — not a path, so an external `rm -rf <stateDir>`
+// (or any other unlink + recreate at the same path) can leave a still-
+// running daemon flock'd against an orphaned inode while a fresh daemon
+// flock's a brand-new inode at the same path. Both processes hold valid
+// locks on different underlying inodes, breaking the singleton invariant.
+// A daemon that watches its lock-file inode can self-terminate when it
+// detects the mismatch (#528 finding 3b).
+//
+// Returns the wrapping os.ErrNotExist when the file has been unlinked
+// — callers can [errors.Is] against [os.ErrNotExist] to distinguish
+// "file gone" from other stat errors.
+func LockFileInode(stateDir string) (uint64, error) {
+	path := filepath.Join(stateDir, LockFile)
+	info, err := os.Stat(path)
+	if err != nil {
+		return 0, err
+	}
+	sys, ok := info.Sys().(*syscall.Stat_t)
+	if !ok {
+		return 0, fmt.Errorf("discovery: syscall.Stat_t unavailable for %s", path)
+	}
+	return uint64(sys.Ino), nil
+}
+
 // Lock takes an exclusive flock(2) on <stateDir>/daemon.lock, blocking
 // until the lock is acquired or ctx is canceled. Returns a release
 // function the caller must invoke (typically via defer) to release the

--- a/internal/daemon/discovery/discovery_test.go
+++ b/internal/daemon/discovery/discovery_test.go
@@ -337,3 +337,67 @@ func TestWriteFailsWhenStateDirIsFile(t *testing.T) {
 	}
 }
 
+// TestLockFileInode_StableThenChangesAfterUnlinkRecreate pins the
+// contract LockFileInode exposes to the daemon's inode-watch loop
+// (#528 finding 3b): repeated calls return the same inode while the
+// file is undisturbed; an unlink + recreate at the same path returns
+// a different inode (the failure mode the watcher detects).
+func TestLockFileInode_StableThenChangesAfterUnlinkRecreate(t *testing.T) {
+	dir := t.TempDir()
+
+	// Acquire a lock so daemon.lock exists with a stable inode.
+	release, err := discovery.Lock(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Lock: %v", err)
+	}
+
+	first, err := discovery.LockFileInode(dir)
+	if err != nil {
+		t.Fatalf("LockFileInode: %v", err)
+	}
+	if first == 0 {
+		t.Fatal("inode = 0; want a real inode")
+	}
+
+	// Repeated calls return the same inode.
+	second, err := discovery.LockFileInode(dir)
+	if err != nil {
+		t.Fatalf("LockFileInode (second call): %v", err)
+	}
+	if second != first {
+		t.Errorf("inode changed between calls: %d → %d", first, second)
+	}
+
+	// Release our flock and remove the lock file. (The release closes
+	// the fd; the held inode is freed once removed.)
+	if err := release(); err != nil {
+		t.Fatalf("release: %v", err)
+	}
+	if err := os.Remove(filepath.Join(dir, discovery.LockFile)); err != nil {
+		t.Fatalf("remove lock file: %v", err)
+	}
+
+	// File missing → error wrapping os.ErrNotExist.
+	if _, err := discovery.LockFileInode(dir); err == nil || !errors.Is(err, os.ErrNotExist) {
+		t.Fatalf("LockFileInode after remove: err = %v, want wrapped os.ErrNotExist", err)
+	}
+
+	// Acquire a fresh lock (creates daemon.lock anew) and verify the
+	// inode has changed. This is the empirical underpinning of finding
+	// 3b: a fresh inode at the same path is the signal a parallel
+	// daemon now owns the lock.
+	release2, err := discovery.Lock(context.Background(), dir)
+	if err != nil {
+		t.Fatalf("Lock (re-acquire): %v", err)
+	}
+	defer release2()
+
+	third, err := discovery.LockFileInode(dir)
+	if err != nil {
+		t.Fatalf("LockFileInode (post-recreate): %v", err)
+	}
+	if third == first {
+		t.Errorf("inode unchanged after unlink+recreate (got %d both times); the watcher cannot detect 3b", third)
+	}
+}
+

--- a/internal/daemon/discovery/discovery_test.go
+++ b/internal/daemon/discovery/discovery_test.go
@@ -340,16 +340,28 @@ func TestWriteFailsWhenStateDirIsFile(t *testing.T) {
 // TestLockFileInode_StableThenChangesAfterUnlinkRecreate pins the
 // contract LockFileInode exposes to the daemon's inode-watch loop
 // (#528 finding 3b): repeated calls return the same inode while the
-// file is undisturbed; an unlink + recreate at the same path returns
-// a different inode (the failure mode the watcher detects).
+// file is undisturbed; an unlink + recreate at the same path while the
+// original lock fd is still held returns a different inode (the
+// failure mode the watcher detects).
+//
+// The fd-still-held detail matters: if the original fd is closed
+// before re-acquiring, Linux ext4 may reuse the now-free inode for
+// the new file, producing a false-negative inode comparison. The
+// real-world bug scenario keeps the original daemon's fd open
+// throughout (the daemon is still running), pinning the inode's
+// refcount > 0 so the kernel must allocate a fresh inode for the
+// fresh file. This test mirrors that — release1 fires only at
+// cleanup, after the second Lock has captured a comparison inode.
 func TestLockFileInode_StableThenChangesAfterUnlinkRecreate(t *testing.T) {
 	dir := t.TempDir()
 
-	// Acquire a lock so daemon.lock exists with a stable inode.
-	release, err := discovery.Lock(context.Background(), dir)
+	// Acquire a lock so daemon.lock exists. The fd is held until test
+	// cleanup — mimicking the original (still-running) daemon.
+	release1, err := discovery.Lock(context.Background(), dir)
 	if err != nil {
 		t.Fatalf("Lock: %v", err)
 	}
+	t.Cleanup(func() { _ = release1() })
 
 	first, err := discovery.LockFileInode(dir)
 	if err != nil {
@@ -368,36 +380,34 @@ func TestLockFileInode_StableThenChangesAfterUnlinkRecreate(t *testing.T) {
 		t.Errorf("inode changed between calls: %d → %d", first, second)
 	}
 
-	// Release our flock and remove the lock file. (The release closes
-	// the fd; the held inode is freed once removed.)
-	if err := release(); err != nil {
-		t.Fatalf("release: %v", err)
-	}
+	// External `rm -rf ~/.aileron`: unlink the lock file. Original
+	// fd still holds flock on the orphaned inode (refcount > 0), so
+	// the kernel cannot reuse that inode for whatever lands here next.
 	if err := os.Remove(filepath.Join(dir, discovery.LockFile)); err != nil {
 		t.Fatalf("remove lock file: %v", err)
 	}
 
-	// File missing → error wrapping os.ErrNotExist.
+	// Path missing → LockFileInode wraps os.ErrNotExist.
 	if _, err := discovery.LockFileInode(dir); err == nil || !errors.Is(err, os.ErrNotExist) {
 		t.Fatalf("LockFileInode after remove: err = %v, want wrapped os.ErrNotExist", err)
 	}
 
-	// Acquire a fresh lock (creates daemon.lock anew) and verify the
-	// inode has changed. This is the empirical underpinning of finding
-	// 3b: a fresh inode at the same path is the signal a parallel
-	// daemon now owns the lock.
+	// A "fresh daemon" comes up at the same path. discovery.Lock
+	// creates daemon.lock anew and flock's its fd — the original fd
+	// is on a different inode, so flock(LOCK_EX|LOCK_NB) succeeds
+	// without contention.
 	release2, err := discovery.Lock(context.Background(), dir)
 	if err != nil {
-		t.Fatalf("Lock (re-acquire): %v", err)
+		t.Fatalf("Lock (re-acquire while original fd still held): %v", err)
 	}
-	defer release2()
+	t.Cleanup(func() { _ = release2() })
 
 	third, err := discovery.LockFileInode(dir)
 	if err != nil {
 		t.Fatalf("LockFileInode (post-recreate): %v", err)
 	}
 	if third == first {
-		t.Errorf("inode unchanged after unlink+recreate (got %d both times); the watcher cannot detect 3b", third)
+		t.Errorf("inode unchanged after held-unlink-recreate (got %d both times); the watcher cannot detect 3b on this filesystem", third)
 	}
 }
 

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -19,6 +19,7 @@ import (
 	"os"
 	"os/signal"
 	"path/filepath"
+	"sync/atomic"
 	"syscall"
 	"time"
 
@@ -32,6 +33,12 @@ import (
 	"github.com/ALRubinger/aileron/internal/version"
 	"golang.org/x/term"
 )
+
+// lockInodeWatchInterval is how often the daemon stats <stateDir>/daemon.lock
+// to detect inode changes. Picked at 5s as a tradeoff: long enough to cost
+// nothing under steady-state, short enough that a duplicate-daemon situation
+// resolves quickly. Variable rather than const so tests can shorten it.
+var lockInodeWatchInterval = 5 * time.Second
 
 func main() {
 	var bind string
@@ -122,6 +129,18 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 			opts.StateDir, discovery.LockFile, err)
 	}
 	defer func() { _ = releaseLock() }()
+
+	// Capture the inode of daemon.lock at the moment we acquired its
+	// flock. The watcher goroutine below polls the same path and shuts
+	// us down if the inode changes — i.e. an external `rm -rf
+	// <stateDir>` (or any unlink-and-recreate) has orphaned our flock'd
+	// inode and a fresh daemon now owns the path. Without this watch a
+	// stranded daemon survives invisibly, breaking the singleton
+	// invariant (#528 finding 3b).
+	originalLockInode, err := discovery.LockFileInode(opts.StateDir)
+	if err != nil {
+		return fmt.Errorf("capture lock-file inode: %w", err)
+	}
 
 	cfg, err := selectVault(log, opts.VaultPath, opts.IsTTY, nil, opts.Stderr)
 	if err != nil {
@@ -228,7 +247,17 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 		_ = listener.Close()
 		return fmt.Errorf("publish discovery: %w", err)
 	}
+	// skipDiscoveryRemove gates the deferred discovery.Remove. The
+	// inode-watcher sets it on shutdown caused by lock-inode mismatch:
+	// at that point daemon.json/pid belong to the daemon that took
+	// over, and removing them would erase the surviving daemon's
+	// advertisement.
+	var skipDiscoveryRemove atomic.Bool
 	defer func() {
+		if skipDiscoveryRemove.Load() {
+			log.Info("inode-mismatch shutdown: leaving discovery files for the daemon that owns them")
+			return
+		}
 		if err := discovery.Remove(opts.StateDir); err != nil {
 			log.Warn("removing discovery files", "error", err)
 		}
@@ -257,9 +286,20 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 		serveErr <- nil
 	}()
 
+	// Lock-inode watcher. Closes inodeMismatch when the daemon.lock
+	// path's inode changes from originalLockInode (or the file is
+	// gone). See the originalLockInode capture above for the why.
+	inodeMismatch := make(chan struct{})
+	watchCtx, cancelWatch := context.WithCancel(ctx)
+	defer cancelWatch()
+	go watchLockInode(watchCtx, log, opts.StateDir, originalLockInode, inodeMismatch)
+
 	select {
 	case <-ctx.Done():
 		log.Info("shutting down daemon", "url", url)
+	case <-inodeMismatch:
+		log.Warn("daemon.lock inode changed; another daemon owns this path now — shutting down", "url", url)
+		skipDiscoveryRemove.Store(true)
 	case err := <-serveErr:
 		if err != nil {
 			return fmt.Errorf("serve: %w", err)
@@ -270,6 +310,43 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 	shutdownCtx, cancelShutdown := context.WithTimeout(context.Background(), 30*time.Second)
 	defer cancelShutdown()
 	return srv.Shutdown(shutdownCtx)
+}
+
+// watchLockInode polls daemon.lock at lockInodeWatchInterval and closes
+// trigger when the inode no longer matches original. Stops on ctx
+// cancellation. See run()'s originalLockInode capture for the why.
+//
+// "Inode changed" includes "file is gone": LockFileInode returns an
+// error wrapping os.ErrNotExist when daemon.lock has been unlinked,
+// which we treat the same as a mismatch. Other stat errors are logged
+// at warn but otherwise ignored — they're transient (e.g. fs hiccup)
+// and triggering shutdown on them would cause spurious daemon exits.
+func watchLockInode(ctx context.Context, log *slog.Logger, stateDir string, original uint64, trigger chan<- struct{}) {
+	ticker := time.NewTicker(lockInodeWatchInterval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			current, err := discovery.LockFileInode(stateDir)
+			if err != nil {
+				if errors.Is(err, os.ErrNotExist) {
+					log.Warn("daemon.lock disappeared", "stateDir", stateDir)
+					close(trigger)
+					return
+				}
+				log.Warn("statting daemon.lock", "error", err)
+				continue
+			}
+			if current != original {
+				log.Warn("daemon.lock inode changed",
+					"original", original, "current", current, "stateDir", stateDir)
+				close(trigger)
+				return
+			}
+		}
+	}
 }
 
 // defaultStateDir returns the canonical user state directory

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -344,6 +344,165 @@ func TestRun_RefusesWhenAnotherDaemonHoldsLock(t *testing.T) {
 	}
 }
 
+// TestRun_LockInodeMismatchTriggersShutdown regression-pins #528
+// finding 3b: when daemon.lock is unlinked-and-recreated while a daemon
+// is running (e.g. external `rm -rf ~/.aileron` followed by another
+// daemon spawning at the same path), the running daemon's flock is
+// orphaned on a now-unreferenced inode. Without the inode-watcher the
+// daemon would survive indefinitely alongside the new owner of the
+// path, breaking the singleton invariant.
+//
+// The watcher must:
+//   - detect the inode change,
+//   - exit run() cleanly (no error), and
+//   - leave daemon.json/daemon.pid intact (those belong to the daemon
+//     that took over; removing them would erase its advertisement).
+func TestRun_LockInodeMismatchTriggersShutdown(t *testing.T) {
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+	seedVault(t, vaultPath)
+
+	// Shorten the watch interval so the test doesn't wait the
+	// production 5s. Restored on cleanup.
+	prev := lockInodeWatchInterval
+	lockInodeWatchInterval = 50 * time.Millisecond
+	t.Cleanup(func() { lockInodeWatchInterval = prev })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "127.0.0.1:0",
+		StateDir:  stateDir,
+		VaultPath: vaultPath,
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- run(ctx, log, opts) }()
+
+	info := waitForDaemon(t, stateDir, 3*time.Second)
+	if info.URL == "" {
+		t.Fatal("daemon never published its URL")
+	}
+
+	// Simulate external "rm -rf <stateDir>/daemon.lock + new daemon
+	// recreates it." The daemon's flock-fd retains the original inode;
+	// our recreated file gets a fresh one.
+	lockPath := filepath.Join(stateDir, discovery.LockFile)
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove lock: %v", err)
+	}
+	f, err := os.OpenFile(lockPath, os.O_CREATE|os.O_RDWR, 0o600)
+	if err != nil {
+		t.Fatalf("recreate lock: %v", err)
+	}
+	_ = f.Close()
+
+	// Wait for the watcher to detect the mismatch and run() to return.
+	select {
+	case err := <-runErr:
+		if err != nil {
+			t.Fatalf("run returned error: %v (want nil — inode-mismatch is a clean shutdown)", err)
+		}
+	case <-time.After(3 * time.Second):
+		t.Fatal("run did not return after lock-file inode change; the watcher is not detecting the mismatch")
+	}
+
+	// daemon.json + daemon.pid must still exist: removing them would
+	// erase the surviving daemon's advertisement.
+	for _, name := range []string{discovery.InfoFile, discovery.PIDFile} {
+		if _, err := os.Stat(filepath.Join(stateDir, name)); err != nil {
+			t.Errorf("%s missing after inode-mismatch shutdown (err: %v); discovery files should be left for the daemon that took over", name, err)
+		}
+	}
+}
+
+// TestWatchLockInode_FileDisappeared covers the ENOENT branch: an
+// unlinked-but-not-recreated daemon.lock is the same shutdown signal
+// as a recreated one. Exercised as a unit test against watchLockInode
+// directly so we don't need to drive a full daemon.
+func TestWatchLockInode_FileDisappeared(t *testing.T) {
+	dir := t.TempDir()
+	lockPath := filepath.Join(dir, discovery.LockFile)
+	if err := os.WriteFile(lockPath, nil, 0o600); err != nil {
+		t.Fatalf("create lock: %v", err)
+	}
+	original, err := discovery.LockFileInode(dir)
+	if err != nil {
+		t.Fatalf("LockFileInode: %v", err)
+	}
+
+	prev := lockInodeWatchInterval
+	lockInodeWatchInterval = 25 * time.Millisecond
+	t.Cleanup(func() { lockInodeWatchInterval = prev })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	trigger := make(chan struct{})
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	go watchLockInode(ctx, log, dir, original, trigger)
+
+	// Unlink the lock file; do NOT recreate. The watcher should treat
+	// disappearance as a mismatch signal.
+	if err := os.Remove(lockPath); err != nil {
+		t.Fatalf("remove lock: %v", err)
+	}
+
+	select {
+	case <-trigger:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not signal on file-disappeared (ENOENT)")
+	}
+}
+
+// TestWatchLockInode_StopsOnContextCancel pins the watcher's clean-stop
+// behavior — the goroutine must exit when its context is canceled,
+// otherwise it leaks for the daemon's lifetime.
+func TestWatchLockInode_StopsOnContextCancel(t *testing.T) {
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, discovery.LockFile), nil, 0o600); err != nil {
+		t.Fatalf("create lock: %v", err)
+	}
+	original, err := discovery.LockFileInode(dir)
+	if err != nil {
+		t.Fatalf("LockFileInode: %v", err)
+	}
+
+	prev := lockInodeWatchInterval
+	lockInodeWatchInterval = 25 * time.Millisecond
+	t.Cleanup(func() { lockInodeWatchInterval = prev })
+
+	ctx, cancel := context.WithCancel(context.Background())
+	trigger := make(chan struct{})
+	done := make(chan struct{})
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	go func() {
+		watchLockInode(ctx, log, dir, original, trigger)
+		close(done)
+	}()
+
+	// Let the watcher run a couple of ticks, then cancel.
+	time.Sleep(75 * time.Millisecond)
+	cancel()
+
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("watcher did not return after context cancel")
+	}
+
+	// Trigger must not have fired — context cancel is a clean stop, not
+	// a mismatch signal.
+	select {
+	case <-trigger:
+		t.Fatal("trigger fired on context cancel; should only fire on inode change")
+	default:
+	}
+}
+
 // TestRun_ListenFailureCleansUp verifies that when listen fails (e.g.
 // invalid bind address), no stale discovery files are left behind. The
 // daemon either succeeds and publishes, or fails and publishes nothing.


### PR DESCRIPTION
## Summary
Resolves finding 3b from #528 — the singleton-invariant violation observed during #454 Test 6 (three concurrently-running daemons each holding flock on a different inode).

`flock(2)` is held against an open file descriptor, which pins the inode — not the path. An external `rm -rf ~/.aileron` (or any unlink + recreate at the same path) leaves a running daemon flock'd against an orphaned inode while a fresh daemon flock's a brand-new inode at the same path. Both processes hold valid locks on different underlying inodes and neither knows the other exists.

## Approach
1. **Capture the inode** of `daemon.lock` at startup, immediately after `discovery.Lock` returns (`internal/server/main.go`).
2. **Watcher goroutine** stats the path every `lockInodeWatchInterval` (5 s in production, overrideable for tests). When the inode changes — or the file is unlinked — it closes a `inodeMismatch` channel. The daemon's main `select` picks up the signal and initiates clean shutdown.
3. **Skip `discovery.Remove`** on the inode-mismatch shutdown path: `daemon.json` and `daemon.pid` now belong to the daemon that took over, and removing them would erase its advertisement. Tracked via an `atomic.Bool` set just before shutdown.

New helper: `discovery.LockFileInode(stateDir) (uint64, error)` — wraps `os.Stat` + `syscall.Stat_t.Ino` so the daemon can probe the path without exposing platform internals at the call site. Returns the wrapping `os.ErrNotExist` when the file has been unlinked.

## Test plan
- [x] `discovery.TestLockFileInode_StableThenChangesAfterUnlinkRecreate` — pins the inode contract: stable across calls; ENOENT after unlink; fresh inode after re-creation. This is the empirical underpinning of 3b.
- [x] `server.TestRun_LockInodeMismatchTriggersShutdown` — end-to-end: daemon starts, external `rm` + recreate of `daemon.lock`, watcher detects within ~50 ms (test interval), `run()` returns nil, `daemon.json`/`daemon.pid` are intact.
- [x] `server.TestWatchLockInode_FileDisappeared` — ENOENT branch: unlink-but-no-recreate also triggers shutdown.
- [x] `server.TestWatchLockInode_StopsOnContextCancel` — leak prevention: watcher exits cleanly on ctx cancel and does not falsely fire the trigger.
- [x] All existing server / discovery / spawn tests still pass.
- [x] Coverage on `watchLockInode`: 88.2% (only uncovered: transient stat-error fallthrough, `log.Warn + continue`).

## Notes
- 5 s poll is conservative; the failure mode (concurrent daemons) is hours-long, so a 5 s detection window is plenty fast and costs ~one stat per tick under steady-state.
- This is the second of two PRs against #528 finding 3 (lock-related concurrency). Finding 3a (client-side retry on lock-acquire timeout) is in #530.

🤖 Generated with [Claude Code](https://claude.com/claude-code)