### PR TITLE
fix(cstore): reload keyring on every install instead of caching at startup

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -810,13 +810,18 @@ func registerProviders(
 
 // newConnectorInstaller wires the cstore install pipeline (ADR-0004) with
 // the v1 production defaults: HTTP fetcher, default per-scheme resolver,
-// and an empty Ed25519 keyring. The keyring is intentionally empty —
-// signing-keys-and-rotation is deferred per ADR-0002. The verifier is
-// loaded from `~/.aileron/keyring.json` (per the file-based scheme
-// introduced for #366); a missing or empty file means no publishers
-// are trusted, and the install pipeline fails closed on every call
-// (per ADR-0004's failure-modes table). Users opt in to a publisher
-// by adding its ed25519 public key to the keyring file.
+// and a ReloadingKeyring backed by `~/.aileron/keyring.json` (per the
+// file-based scheme introduced for #366). A missing or empty file means
+// no publishers are trusted, and the install pipeline fails closed on
+// every call (per ADR-0004's failure-modes table). Users opt in to a
+// publisher by adding its ed25519 public key to the keyring file via
+// `aileron keyring trust`.
+//
+// The verifier reloads the file on every install request so out-of-band
+// edits (the `aileron keyring trust` CLI writes the file directly,
+// bypassing the daemon) take effect immediately without a daemon
+// restart. Cost is one small JSON parse per install, which is dominated
+// by the network fetch in the same pipeline.
 //
 // The store root is `~/.aileron/store` per ADR-0004 §"Content-addressed
 // store layout"; tests substitute their own Installer on the apiServer
@@ -828,17 +833,10 @@ func newConnectorInstaller(log *slog.Logger) *cstore.Installer {
 			"root", store.Root(), "error", err)
 		_ = store.RebuildIndex()
 	}
-	keyringPath := cstore.DefaultKeyringPath()
-	keyring, err := cstore.LoadKeyring(keyringPath)
-	if err != nil {
-		log.Warn("failed to load keyring; falling back to empty (fail-closed)",
-			"path", keyringPath, "error", err)
-		keyring = cstore.NewEd25519Keyring()
-	}
 	return &cstore.Installer{
 		Resolver: cstore.DefaultResolver(),
 		Fetcher:  &cstore.HTTPFetcher{},
-		Verifier: keyring,
+		Verifier: &cstore.ReloadingKeyring{Path: cstore.DefaultKeyringPath()},
 		Store:    store,
 	}
 }

--- a/internal/cstore/verify.go
+++ b/internal/cstore/verify.go
@@ -93,3 +93,37 @@ type PermissiveVerifier struct{}
 
 // Verify implements Verifier — always returns nil.
 func (PermissiveVerifier) Verify(_ string, _, _, _ []byte) error { return nil }
+
+// ReloadingKeyring is a Verifier that re-reads its keyring from Path
+// on every Verify call. Use this when the daemon must observe
+// out-of-band keyring writes (e.g. `aileron keyring trust ...` writes
+// directly to ~/.aileron/keyring.json without notifying the daemon)
+// without needing a restart.
+//
+// Failure modes match LoadKeyring + Ed25519Keyring.Verify:
+//
+//   - Path missing → empty keyring → ClassSignatureFailure ("no
+//     signing key registered for authority …"). Same fail-closed
+//     behavior as a freshly started daemon with no keyring file.
+//   - Path malformed → ClassValidationError surfaced to the caller.
+//     The install pipeline turns this into a 422 with the parse
+//     error embedded, which is the right place for the user to see
+//     it (vs. silently falling back to empty and reporting "no
+//     signing key" for an authority they thought they had trusted).
+//
+// The file is small (a handful of KB even with many publishers) and
+// installs are infrequent, so re-parsing on every call is negligible.
+type ReloadingKeyring struct {
+	Path string
+}
+
+// Verify implements Verifier by loading the keyring at Path and
+// delegating to its Verify. See ReloadingKeyring docs for failure
+// modes.
+func (r *ReloadingKeyring) Verify(authority string, binary, manifest, signature []byte) error {
+	keyring, err := LoadKeyring(r.Path)
+	if err != nil {
+		return err
+	}
+	return keyring.Verify(authority, binary, manifest, signature)
+}

--- a/internal/cstore/verify_test.go
+++ b/internal/cstore/verify_test.go
@@ -3,7 +3,10 @@ package cstore
 import (
 	"crypto/ed25519"
 	"crypto/rand"
+	"encoding/base64"
 	"errors"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -99,6 +102,116 @@ func TestEd25519Keyring_DifferentAuthorityIsDifferentTrustDomain(t *testing.T) {
 	err := ring.Verify("github://acme/slack", binary, manifest, sig)
 	if err == nil {
 		t.Fatal("Verify across authorities succeeded; want failure")
+	}
+}
+
+// TestReloadingKeyring_PicksUpFileChangesWithoutDaemonRestart pins the
+// fix for finding #4 of #532: when the user runs `aileron keyring trust
+// <authority> <pubkey>`, the CLI writes to ~/.aileron/keyring.json
+// directly and does not notify the daemon. With ReloadingKeyring as
+// the install pipeline's verifier, a subsequent `aileron action add`
+// must observe the new key on the next install — no `aileron stop`
+// required.
+//
+// Repro: write keyring with key A, Verify against a binary signed by
+// key B → ClassSignatureFailure ("no signing key registered" or
+// "signature does not verify"). Add key B to the file. Verify again
+// → must succeed without any explicit reload from the test.
+func TestReloadingKeyring_PicksUpFileChangesWithoutDaemonRestart(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyring.json")
+
+	binary := []byte("BIN")
+	manifest := []byte("MAN")
+	sig, pub := signedManifest(t, binary, manifest)
+	const authority = "github://acme/connector"
+
+	// Step 1: keyring file exists but does NOT trust the signing key.
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("keygen: %v", err)
+	}
+	writeKeyringFile(t, path, authority, []ed25519.PublicKey{otherPub})
+
+	v := &ReloadingKeyring{Path: path}
+	if err := v.Verify(authority, binary, manifest, sig); err == nil {
+		t.Fatal("Verify before adding pub should fail; got nil")
+	}
+
+	// Step 2: user runs `aileron keyring trust` — writes the pub to
+	// the file. The verifier must observe it on the next call without
+	// any explicit reload.
+	writeKeyringFile(t, path, authority, []ed25519.PublicKey{otherPub, pub})
+
+	if err := v.Verify(authority, binary, manifest, sig); err != nil {
+		t.Errorf("Verify after adding pub should succeed; got %v", err)
+	}
+}
+
+// TestReloadingKeyring_MissingFileFailsClosed pins the
+// no-trust-anchor case: when ~/.aileron/keyring.json does not exist,
+// Verify must reject every install with ClassSignatureFailure. This
+// matches the daemon-startup behavior LoadKeyring already implements
+// for missing files.
+func TestReloadingKeyring_MissingFileFailsClosed(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "does-not-exist.json")
+
+	v := &ReloadingKeyring{Path: path}
+	err := v.Verify("github://acme/connector", []byte("x"), []byte("y"), []byte("z"))
+	if err == nil {
+		t.Fatal("Verify with missing keyring file succeeded; want failure")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) || aerr.Class != ClassSignatureFailure {
+		t.Fatalf("err class = %v, want ClassSignatureFailure", aerr)
+	}
+}
+
+// TestReloadingKeyring_MalformedFileSurfacesError pins the
+// fail-closed-with-cause case: when the keyring file is unparseable,
+// Verify must surface the parse error rather than silently falling
+// back to an empty keyring (which would say "no signing key" — wrong
+// diagnosis for a syntax error in the file the user just edited).
+func TestReloadingKeyring_MalformedFileSurfacesError(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "keyring.json")
+	if err := os.WriteFile(path, []byte("{not valid json"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+
+	v := &ReloadingKeyring{Path: path}
+	err := v.Verify("github://acme/connector", []byte("x"), []byte("y"), []byte("z"))
+	if err == nil {
+		t.Fatal("Verify with malformed keyring succeeded; want failure")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) || aerr.Class != ClassValidationError {
+		t.Fatalf("err class = %v, want ClassValidationError (malformed JSON should surface, not fall back to empty)", aerr)
+	}
+}
+
+// writeKeyringFile is a test helper that writes a v1 keyring file
+// trusting `pubs` for `authority`. Distinct from Ed25519Keyring's
+// SaveKeyring so the test exercises the file format directly without
+// depending on Save's semantics.
+func writeKeyringFile(t *testing.T, path, authority string, pubs []ed25519.PublicKey) {
+	t.Helper()
+	encoded := make([]string, 0, len(pubs))
+	for _, p := range pubs {
+		encoded = append(encoded, base64.StdEncoding.EncodeToString(p))
+	}
+	body := `{"version":1,"publishers":{` +
+		`"` + authority + `":[`
+	for i, e := range encoded {
+		if i > 0 {
+			body += ","
+		}
+		body += `"` + e + `"`
+	}
+	body += `]}}`
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write keyring: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Daemon's connector installer used to load \`~/.aileron/keyring.json\` once at startup and cache the verifier. Since \`aileron keyring trust\` writes the file directly (no daemon RPC), newly trusted publishers were invisible until daemon restart.
- New \`cstore.ReloadingKeyring\` re-reads the file on every \`Verify\` call. \`newConnectorInstaller\` wires it as the install pipeline's verifier.
- Failure modes match the existing contract: missing file → fail-closed with "no signing key registered"; malformed JSON → \`ClassValidationError\` surfaced to the user instead of silently falling back to empty.

Resolves finding #4 of #532.

## Repro this fixes

```
$ aileron keyring trust github://ALRubinger/aileron-connector-google publisher.pub
✓ Trusted publisher ...
$ aileron action add github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6
server returned 422: {"error":{"code":"signature_failure","message":"no signing key registered for authority ..."}}
# (until \`aileron stop\` + retry)
```

After this PR the second command observes the freshly trusted publisher without the stop/restart workaround.

## Test plan

- [x] \`go test ./internal/cstore/... -count=1 -cover\` (86.2%)
- [x] New tests: file-change pickup without restart; missing file fail-closed; malformed file surfaces parse error
- [x] Full \`internal/...\` test suite passes
- [ ] Manual: \`aileron keyring trust ...\` then \`aileron action add ...\` succeeds without \`aileron stop\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)