### PR TITLE
fix(launch): pre-allowlist Aileron MCP tools in Claude Code

### DIFF
--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -16,10 +16,23 @@ type Claude struct{}
 func (c Claude) Name() string          { return "claude" }
 func (c Claude) BinaryNames() []string { return []string{"claude"} }
 
-// Args tells Claude Code to auto-approve all Bash commands so that
-// Aileron is the single approval layer for shell execution.
+// Args tells Claude Code to auto-approve:
+//   - Bash, so Aileron's shell-policy + approval layer is the single
+//     arbiter of shell execution rather than Claude Code's per-command
+//     prompt.
+//   - The Aileron MCP server's tools (`mcp__<launch.MCPServerName>`),
+//     so Claude Code does not double-prompt for tools whose execution
+//     the daemon already mediates per ADR-0009/0010. Without this,
+//     each unique mcp__aileron__* tool fires a "Yes / Yes don't ask
+//     again / No" prompt the first time the agent calls it, doubling
+//     the trust surface and leading the user to vest trust decisions
+//     in the agent CLI rather than Aileron.
+//
+// `--allowedTools` accepts a single value with space-separated
+// patterns; the bare `mcp__<server>` form whitelists every tool from
+// that server (including ones registered later in the session).
 func (c Claude) Args() []string {
-	return []string{"--allowedTools", "Bash(*)"}
+	return []string{"--allowedTools", "Bash(*) mcp__" + launch.MCPServerName}
 }
 
 // Env returns Claude-specific environment variables. CLAUDE_CODE_SHELL

--- a/internal/launch/agents/claude_test.go
+++ b/internal/launch/agents/claude_test.go
@@ -6,6 +6,7 @@ import (
 	"strings"
 	"testing"
 
+	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/launch/agents"
 )
 
@@ -25,14 +26,27 @@ func TestClaude(t *testing.T) {
 	if len(args) < 2 {
 		t.Fatal("expected Args with --allowedTools")
 	}
-	found := false
+	var allowedToolsValue string
 	for i, a := range args {
-		if a == "--allowedTools" && i+1 < len(args) && args[i+1] == "Bash(*)" {
-			found = true
+		if a == "--allowedTools" && i+1 < len(args) {
+			allowedToolsValue = args[i+1]
+			break
 		}
 	}
-	if !found {
-		t.Errorf("expected --allowedTools Bash(*) in Args, got %v", args)
+	if allowedToolsValue == "" {
+		t.Fatalf("expected --allowedTools <value> in Args, got %v", args)
+	}
+	if !strings.Contains(allowedToolsValue, "Bash(*)") {
+		t.Errorf("expected Bash(*) in --allowedTools value, got %q", allowedToolsValue)
+	}
+	// Finding #6 of #532: the Aileron MCP server's tools must be
+	// pre-approved so Claude Code does not double-prompt for tools
+	// the daemon already gates. The bare `mcp__<server>` form covers
+	// every tool from that server.
+	wantMCP := "mcp__" + launch.MCPServerName
+	if !strings.Contains(allowedToolsValue, wantMCP) {
+		t.Errorf("expected %q in --allowedTools value to suppress per-tool prompts for Aileron MCP tools, got %q",
+			wantMCP, allowedToolsValue)
 	}
 
 	env := c.Env()

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -19,6 +19,15 @@ import (
 	launchpolicy "github.com/ALRubinger/aileron/internal/policy/launch"
 )
 
+// MCPServerName is the name Aileron registers itself under in
+// agents' MCP-server configs. The agent surfaces Aileron's tools as
+// `mcp__<MCPServerName>__<tool-name>`. Agent definitions reference
+// this when they wire host-level allowlists (e.g. Claude Code's
+// `--allowedTools mcp__aileron`) so Aileron remains the trust surface
+// per ADR-0009/0010 and the host doesn't double-prompt for tools the
+// daemon already gates.
+const MCPServerName = "aileron"
+
 // LaunchConfig holds the configuration for launching an agent.
 type LaunchConfig struct {
 	// Agent is the agent to launch.
@@ -181,8 +190,8 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		}
 		envJSON, _ := json.Marshal(mcpEnv)
 		mcpConfig := fmt.Sprintf(
-			`{"mcpServers":{"aileron":{"command":%q,"env":%s}}}`,
-			mcpBin, string(envJSON),
+			`{"mcpServers":{%q:{"command":%q,"env":%s}}}`,
+			MCPServerName, mcpBin, string(envJSON),
 		)
 		allArgs = append(allArgs, "--mcp-config", mcpConfig)
 	}


### PR DESCRIPTION
## Summary

- Add \`mcp__aileron\` to Claude Code's \`--allowedTools\` so every current and future Aileron-hosted tool is pre-approved in the host. Aileron remains the trust/approval surface per ADR-0009/0010; the daemon still gates every call.
- Introduce \`launch.MCPServerName\` so the literal "aileron" lives in one place — referenced from both the \`--mcp-config\` JSON the launcher writes and the Claude agent's \`--allowedTools\` value.
- \`Bash(*)\` stays. Non-Aileron tools (file edits, other MCP servers) keep their normal Claude Code prompts.

Resolves finding #6 of #532.

## Why

Claude Code's per-tool approval prompt fires once per unique \`mcp__aileron__*\` tool the agent calls:

\`\`\`
Tool use
   aileron - list_recent_emails(max_results: 5) (MCP)
   ...
 Do you want to proceed?
   1. Yes
 ❯ 2. Yes, and don't ask again for aileron - list_recent_emails commands in
      /Users/alr/git/...
\`\`\`

That asks the user to vest trust in the agent CLI surface, which the architecture explicitly says is not the trust boundary. It also doubles the friction: the user has to internalize that Claude Code's prompt is client-side noise and \`aileron approval list\` is the load-bearing gate. For new users it just looks like Aileron is over-prompty.

## Test plan

- [x] \`go test ./internal/launch/agents/... -count=1 -cover\` (92.1%)
- [x] Updated TestClaude asserts both \`Bash(*)\` and \`mcp__aileron\` appear in \`--allowedTools\`
- [x] Full \`internal/...\` test suite passes
- [ ] Manual: \`aileron launch claude\` then "Summarize my 5 most recent emails" — Aileron MCP tools execute without per-tool prompts; non-MCP tools still prompt as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)