### PR TITLE
fix(launch): enrich per-session log with audit-summary + audit-dir hint

### DIFF
--- a/internal/launch/export_test.go
+++ b/internal/launch/export_test.go
@@ -5,3 +5,9 @@ var OpenSessionLogger = openSessionLogger
 
 // SessionLogPath exposes sessionLogPath for testing.
 var SessionLogPath = sessionLogPath
+
+// SummarizeSessionShell exposes summarizeSessionShell for testing.
+var SummarizeSessionShell = summarizeSessionShell
+
+// LogSessionShellSummary exposes logSessionShellSummary for testing.
+var LogSessionShellSummary = logSessionShellSummary

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -203,6 +203,8 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		"dir", config.Dir,
 		"binary", agentPath,
 		"daemon_url", daemonURL,
+		"audit_dir", auditStateDir,
+		"daemon_log", filepath.Join(stateDir, "daemon.log"),
 	)
 
 	// Banner: probe the daemon's vault state so we can include the
@@ -228,7 +230,13 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 
 	sessionLog.Info("session ended", "exit_code", result.ExitCode)
 	if auditStateDir != "" {
-		PrintSessionSummary(os.Stderr, auditStateDir, sessionID)
+		// audit-*.jsonl files live in <auditStateDir>/audit/, not at
+		// the top level — pass the subdir so ReadShellEntriesFiltered
+		// finds the daily-rotated files.
+		auditDir := audit.DailyDir(auditStateDir)
+		shellSummary := summarizeSessionShell(auditDir, sessionID)
+		logSessionShellSummary(sessionLog, shellSummary)
+		PrintSessionSummary(os.Stderr, auditDir, sessionID)
 	}
 	return result, runErr
 }
@@ -425,43 +433,84 @@ func resolveAuditStateDir() string {
 	return filepath.Join(home, ".aileron")
 }
 
-// PrintSessionSummary reads the audit log for the given session and
-// prints a summary of what happened.
-func PrintSessionSummary(w io.Writer, auditPath, sessionID string) {
+// SessionShellSummary is the aggregate count of shell-policy
+// dispositions emitted by aileron-sh for one launch session. Empty
+// (zero counts, Total == 0) means either the session ran no shell
+// commands or its audit entries are unreadable — the difference does
+// not matter to the operator opening the session log.
+type SessionShellSummary struct {
+	Total      int
+	Allowed    int // policy: allow
+	Denied     int // policy: deny
+	Approved   int // ask, user approved
+	UserDenied int // ask, user denied
+}
+
+// summarizeSessionShell reads the audit log entries for sessionID and
+// returns aggregate counts. Errors and missing files are flattened to
+// a zero summary — this powers operator-visible output where partial
+// data (or no data) is the normal case for early-exit launches.
+func summarizeSessionShell(auditPath, sessionID string) SessionShellSummary {
 	entries, err := audit.ReadShellEntriesFiltered(auditPath, audit.ShellFilter{
 		SessionID: sessionID,
 	})
 	if err != nil || len(entries) == 0 {
-		return
+		return SessionShellSummary{}
 	}
-
-	var allowed, denied, approved, userDenied int
+	var s SessionShellSummary
 	for _, e := range entries {
+		s.Total++
 		switch e.Disposition {
 		case "allow":
-			allowed++
+			s.Allowed++
 		case "deny":
-			denied++
+			s.Denied++
 		case "ask_approved":
-			approved++
+			s.Approved++
 		case "ask_denied":
-			userDenied++
+			s.UserDenied++
 		}
 	}
+	return s
+}
 
+// PrintSessionSummary reads the audit log for the given session and
+// prints a colorized summary of what happened. Used at end-of-launch
+// to give the operator a one-glance receipt on stderr; the structured
+// equivalent lands in the session log via [logSessionShellSummary].
+func PrintSessionSummary(w io.Writer, auditPath, sessionID string) {
+	s := summarizeSessionShell(auditPath, sessionID)
+	if s.Total == 0 {
+		return
+	}
 	fmt.Fprintf(w, "\n\033[1maileron session summary:\033[0m\n")
-	if allowed > 0 {
-		fmt.Fprintf(w, "  %d command(s) allowed by policy\n", allowed)
+	if s.Allowed > 0 {
+		fmt.Fprintf(w, "  %d command(s) allowed by policy\n", s.Allowed)
 	}
-	if denied > 0 {
-		fmt.Fprintf(w, "  %d command(s) denied by policy\n", denied)
+	if s.Denied > 0 {
+		fmt.Fprintf(w, "  %d command(s) denied by policy\n", s.Denied)
 	}
-	if approved > 0 {
-		fmt.Fprintf(w, "  %d command(s) approved by user\n", approved)
+	if s.Approved > 0 {
+		fmt.Fprintf(w, "  %d command(s) approved by user\n", s.Approved)
 	}
-	if userDenied > 0 {
-		fmt.Fprintf(w, "  %d command(s) denied by user\n", userDenied)
+	if s.UserDenied > 0 {
+		fmt.Fprintf(w, "  %d command(s) denied by user\n", s.UserDenied)
 	}
+}
+
+// logSessionShellSummary writes the structured shell-summary as a
+// single slog event so it lands in the per-session log alongside
+// "session started" / "session ended" — the operator's first stop
+// when a launch goes wrong. Always emits an event (including when
+// Total == 0) so the absence of activity is itself recorded.
+func logSessionShellSummary(log *slog.Logger, s SessionShellSummary) {
+	log.Info("session shell summary",
+		"total", s.Total,
+		"allowed", s.Allowed,
+		"denied", s.Denied,
+		"approved", s.Approved,
+		"user_denied", s.UserDenied,
+	)
 }
 
 // loadEnvConfig loads the merged policy's EnvConfig for env scrubbing.

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -478,6 +478,90 @@ func TestPrintSessionSummary_EmptySession(t *testing.T) {
 	}
 }
 
+// TestSummarizeSessionShell_ProducesAggregateCounts pins finding #7a
+// of #532: end-of-session shell-policy counts must be available as
+// structured data so the launcher can both print colorized stderr
+// AND emit a single slog event into the per-session log. The session
+// log is the operator's first stop when a launch goes wrong; the
+// counts let them tell at a glance whether the agent ran shell calls
+// and whether any were denied.
+func TestSummarizeSessionShell_ProducesAggregateCounts(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "audit.jsonl")
+	for _, e := range []struct{ disp string }{
+		{"allow"}, {"allow"}, {"allow"},
+		{"deny"},
+		{"ask_approved"}, {"ask_approved"},
+		{"ask_denied"},
+	} {
+		audit.AppendShellEntry(path, audit.ShellEntry{
+			SessionID:   "abc",
+			Command:     "x",
+			Disposition: e.disp,
+		})
+	}
+
+	got := launch.SummarizeSessionShell(path, "abc")
+	want := launch.SessionShellSummary{
+		Total:      7,
+		Allowed:    3,
+		Denied:     1,
+		Approved:   2,
+		UserDenied: 1,
+	}
+	if got != want {
+		t.Errorf("got %+v, want %+v", got, want)
+	}
+}
+
+func TestSummarizeSessionShell_ZeroOnMissingFile(t *testing.T) {
+	got := launch.SummarizeSessionShell("/nonexistent/audit.jsonl", "any")
+	if (got != launch.SessionShellSummary{}) {
+		t.Errorf("expected zero summary for missing file, got %+v", got)
+	}
+}
+
+// TestLogSessionShellSummary_EmitsStructuredEvent pins the contract
+// that the per-session log gets a structured slog event with all
+// counters, even when totals are zero. "Zero activity" is itself a
+// signal — a launch that fired no shell commands tells the operator
+// the agent isn't using the shell, and silence in the log would not.
+func TestLogSessionShellSummary_EmitsStructuredEvent(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	launch.LogSessionShellSummary(logger, launch.SessionShellSummary{
+		Total: 4, Allowed: 2, Denied: 1, Approved: 1, UserDenied: 0,
+	})
+
+	out := buf.String()
+	for _, want := range []string{
+		`msg="session shell summary"`,
+		"total=4",
+		"allowed=2",
+		"denied=1",
+		"approved=1",
+		"user_denied=0",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in slog output, got:\n%s", want, out)
+		}
+	}
+}
+
+func TestLogSessionShellSummary_EmitsZeroSummary(t *testing.T) {
+	var buf strings.Builder
+	logger := slog.New(slog.NewTextHandler(&buf, &slog.HandlerOptions{Level: slog.LevelInfo}))
+
+	launch.LogSessionShellSummary(logger, launch.SessionShellSummary{})
+	out := buf.String()
+	if !strings.Contains(out, `msg="session shell summary"`) {
+		t.Errorf("expected zero-summary event to still be emitted, got:\n%s", out)
+	}
+	if !strings.Contains(out, "total=0") {
+		t.Errorf("expected total=0 in output, got:\n%s", out)
+	}
+}
+
 func TestEnvGlobMatch(t *testing.T) {
 	tests := []struct {
 		pattern string


### PR DESCRIPTION
## Summary

- Per-session \`session.log\` used to carry two events ("session started" / "session ended") and nothing else. After this PR it also gets a structured \`session shell summary\` event with Total/Allowed/Denied/Approved/UserDenied counts pulled from the audit log.
- "session started" event now includes \`audit_dir\` and \`daemon_log\` paths so the operator opening session.log knows where to look next without guessing.
- Fixes an underlying bug in the existing \`PrintSessionSummary\` call site: \`auditStateDir\` is \`~/.aileron\`, not \`~/.aileron/audit\`, so the scan was finding zero entries on production. Switched to \`audit.DailyDir(auditStateDir)\`.

Resolves finding #7a of #532. Real-time per-event capture (gateway / action calls) lands via #7b/#7c.

## Test plan

- [x] \`go test ./internal/launch/... -count=1 -cover\` (87.6%)
- [x] New tests:
  - \`TestSummarizeSessionShell_ProducesAggregateCounts\`
  - \`TestSummarizeSessionShell_ZeroOnMissingFile\`
  - \`TestLogSessionShellSummary_EmitsStructuredEvent\`
  - \`TestLogSessionShellSummary_EmitsZeroSummary\`
- [x] Existing \`TestPrintSessionSummary\` still passes (refactor preserved its colorized output)
- [ ] Manual: \`aileron launch claude\`, run a few shell calls, exit, then \`cat <project>/.aileron/session.log\` — expect the structured summary line

🤖 Generated with [Claude Code](https://claude.com/claude-code)