### PR TITLE
fix(intercept): log upstream non-success and HTTP-200 error envelopes

### DIFF
--- a/internal/intercept/anthropic.go
+++ b/internal/intercept/anthropic.go
@@ -89,29 +89,30 @@ func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Anthropic occasionally surfaces upstream errors
-		// (overloaded_error, rate_limit_error, ...) inside an HTTP 200
-		// envelope. Logging here gives the operator a visible signal
-		// in daemon.log; without this the response looks indistin-
-		// guishable from a successful round and the agent's SDK retry
-		// (or 13-minute hang on stuttering streams) is the first sign
-		// anything is wrong. The body still flows through to the
-		// agent verbatim via parseAnthropicResponse → passThrough.
-		if errType, errMsg, ok := peekAnthropicError(respBody); ok {
-			e.log.Warn("upstream error in HTTP 200 envelope",
+		assistantContent, toolUses, err := parseAnthropicResponse(respBody)
+		if err != nil {
+			// Upstream returned HTTP 200 but the body isn't a usable
+			// message response. The two real-world cases:
+			//   1. An error envelope wrapped in a 200 (Anthropic's
+			//      `{"type":"error","error":{...}}` shape — overloaded
+			//      / rate-limit / etc. arriving inside an otherwise-
+			//      successful stream).
+			//   2. Genuinely malformed JSON.
+			// Either way the operator needs an in-band signal: without
+			// this, a 200 that took 72s looks identical to a slow-but-
+			// successful round in daemon.log, and the agent's SDK retry
+			// (or 13-minute hang on stuttering streams) is the first
+			// sign anything is wrong. The body preview carries the
+			// upstream error type for grep / `aileron sessions watch`
+			// without requiring provider-specific parsing here. The
+			// body still flows through to the agent verbatim.
+			e.log.Warn("upstream returned unparseable success body",
 				"protocol", "anthropic",
-				"upstream_error_type", errType,
-				"upstream_error_message", truncateForLog(errMsg, 256),
+				"parse_error", err.Error(),
+				"body_preview", truncateForLog(string(respBody), 512),
 				"request_id", respHeaders.Get("request-id"),
 				"round", round,
 			)
-			roundSpan.SetAttributes(
-				attribute.String("aileron.intercept.upstream_error_type", errType),
-			)
-		}
-
-		assistantContent, toolUses, err := parseAnthropicResponse(respBody)
-		if err != nil {
 			roundSpan.SetStatus(codes.Error, "parse upstream response: "+err.Error())
 			roundSpan.End()
 			passThrough(w, respStatus, respHeaders, respBody)

--- a/internal/intercept/anthropic.go
+++ b/internal/intercept/anthropic.go
@@ -77,10 +77,37 @@ func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if respStatus != http.StatusOK {
+			e.log.Warn("upstream non-success",
+				"protocol", "anthropic",
+				"upstream_status", respStatus,
+				"request_id", respHeaders.Get("request-id"),
+				"round", round,
+			)
 			roundSpan.SetAttributes(attribute.Int("aileron.intercept.upstream_status", respStatus))
 			roundSpan.End()
 			passThrough(w, respStatus, respHeaders, respBody)
 			return
+		}
+
+		// Anthropic occasionally surfaces upstream errors
+		// (overloaded_error, rate_limit_error, ...) inside an HTTP 200
+		// envelope. Logging here gives the operator a visible signal
+		// in daemon.log; without this the response looks indistin-
+		// guishable from a successful round and the agent's SDK retry
+		// (or 13-minute hang on stuttering streams) is the first sign
+		// anything is wrong. The body still flows through to the
+		// agent verbatim via parseAnthropicResponse → passThrough.
+		if errType, errMsg, ok := peekAnthropicError(respBody); ok {
+			e.log.Warn("upstream error in HTTP 200 envelope",
+				"protocol", "anthropic",
+				"upstream_error_type", errType,
+				"upstream_error_message", truncateForLog(errMsg, 256),
+				"request_id", respHeaders.Get("request-id"),
+				"round", round,
+			)
+			roundSpan.SetAttributes(
+				attribute.String("aileron.intercept.upstream_error_type", errType),
+			)
 		}
 
 		assistantContent, toolUses, err := parseAnthropicResponse(respBody)

--- a/internal/intercept/helpers.go
+++ b/internal/intercept/helpers.go
@@ -117,6 +117,86 @@ func writeError(w http.ResponseWriter, status int, code, message string) {
 	w.Write(body)
 }
 
+// peekAnthropicError returns the upstream error type and message
+// when body parses as an Anthropic error envelope —
+// `{"type":"error","error":{"type":"...","message":"..."}}` — and
+// (false) for valid messages or unparseable bodies.
+//
+// Anthropic surfaces some failure modes (overloaded_error,
+// rate_limit_error, …) inside an HTTP 200 response body when the
+// failure arrives mid-stream and the upstream wraps the streamed
+// error event into a single JSON document. Without an explicit
+// detection step the gateway sees a "successful" 200, the agent's
+// SDK retries silently on the inner error, and the operator gets no
+// visible signal that anything went wrong. peekAnthropicError gives
+// the gateway a place to log the upstream cause before passing the
+// envelope through to the agent.
+func peekAnthropicError(body []byte) (errType, message string, ok bool) {
+	var env struct {
+		Type  string `json:"type"`
+		Error struct {
+			Type    string `json:"type"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return "", "", false
+	}
+	if env.Type != "error" {
+		return "", "", false
+	}
+	return env.Error.Type, env.Error.Message, true
+}
+
+// peekOpenAIError returns the upstream error type/code/message when
+// body parses as an OpenAI error envelope —
+// `{"error":{"type":"...","code":"...","message":"..."}}` — and
+// (false) for valid completions or unparseable bodies.
+//
+// OpenAI primarily surfaces errors as HTTP 4xx/5xx, so this helper
+// exists mainly for symmetry with the Anthropic shape and for the
+// rare envelope-on-200 cases that arrive via streaming.
+func peekOpenAIError(body []byte) (errType, message string, ok bool) {
+	// Reject obvious successful completions before unmarshaling so
+	// we don't accidentally classify a `choices: [...]` body as an
+	// error just because its serialization happens to include an
+	// "error" key in some downstream content payload.
+	var env struct {
+		Choices []any `json:"choices"`
+		Error   struct {
+			Type    string `json:"type"`
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(body, &env); err != nil {
+		return "", "", false
+	}
+	if len(env.Choices) > 0 {
+		return "", "", false
+	}
+	if env.Error.Type == "" && env.Error.Code == "" && env.Error.Message == "" {
+		return "", "", false
+	}
+	t := env.Error.Type
+	if t == "" {
+		t = env.Error.Code
+	}
+	return t, env.Error.Message, true
+}
+
+// truncateForLog clips s to maxRunes runes, appending "…" when
+// truncation happened. Used to keep upstream-error messages short
+// enough that they don't blow up daemon.log when the upstream
+// returns a wall-of-text body (rare but observed).
+func truncateForLog(s string, maxRunes int) string {
+	r := []rune(s)
+	if len(r) <= maxRunes {
+		return s
+	}
+	return string(r[:maxRunes]) + "…"
+}
+
 // writeFailure records the failure to the audit log and writes the
 // ADR-0010 envelope to the response. The audit_id stamped on the
 // failure is included in the envelope so callers can correlate.

--- a/internal/intercept/helpers.go
+++ b/internal/intercept/helpers.go
@@ -117,78 +117,12 @@ func writeError(w http.ResponseWriter, status int, code, message string) {
 	w.Write(body)
 }
 
-// peekAnthropicError returns the upstream error type and message
-// when body parses as an Anthropic error envelope —
-// `{"type":"error","error":{"type":"...","message":"..."}}` — and
-// (false) for valid messages or unparseable bodies.
-//
-// Anthropic surfaces some failure modes (overloaded_error,
-// rate_limit_error, …) inside an HTTP 200 response body when the
-// failure arrives mid-stream and the upstream wraps the streamed
-// error event into a single JSON document. Without an explicit
-// detection step the gateway sees a "successful" 200, the agent's
-// SDK retries silently on the inner error, and the operator gets no
-// visible signal that anything went wrong. peekAnthropicError gives
-// the gateway a place to log the upstream cause before passing the
-// envelope through to the agent.
-func peekAnthropicError(body []byte) (errType, message string, ok bool) {
-	var env struct {
-		Type  string `json:"type"`
-		Error struct {
-			Type    string `json:"type"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
-	if err := json.Unmarshal(body, &env); err != nil {
-		return "", "", false
-	}
-	if env.Type != "error" {
-		return "", "", false
-	}
-	return env.Error.Type, env.Error.Message, true
-}
-
-// peekOpenAIError returns the upstream error type/code/message when
-// body parses as an OpenAI error envelope —
-// `{"error":{"type":"...","code":"...","message":"..."}}` — and
-// (false) for valid completions or unparseable bodies.
-//
-// OpenAI primarily surfaces errors as HTTP 4xx/5xx, so this helper
-// exists mainly for symmetry with the Anthropic shape and for the
-// rare envelope-on-200 cases that arrive via streaming.
-func peekOpenAIError(body []byte) (errType, message string, ok bool) {
-	// Reject obvious successful completions before unmarshaling so
-	// we don't accidentally classify a `choices: [...]` body as an
-	// error just because its serialization happens to include an
-	// "error" key in some downstream content payload.
-	var env struct {
-		Choices []any `json:"choices"`
-		Error   struct {
-			Type    string `json:"type"`
-			Code    string `json:"code"`
-			Message string `json:"message"`
-		} `json:"error"`
-	}
-	if err := json.Unmarshal(body, &env); err != nil {
-		return "", "", false
-	}
-	if len(env.Choices) > 0 {
-		return "", "", false
-	}
-	if env.Error.Type == "" && env.Error.Code == "" && env.Error.Message == "" {
-		return "", "", false
-	}
-	t := env.Error.Type
-	if t == "" {
-		t = env.Error.Code
-	}
-	return t, env.Error.Message, true
-}
-
 // truncateForLog clips s to maxRunes runes, appending "…" when
-// truncation happened. Used to keep upstream-error messages short
-// enough that they don't blow up daemon.log when the upstream
-// returns a wall-of-text body (rare but observed).
+// truncation happened. Used to bound upstream body previews in the
+// daemon log when an upstream returns a non-success body inside an
+// HTTP 200 envelope (e.g. Anthropic's overloaded_error wrapper) —
+// the body itself carries the operator-actionable signal but can be
+// arbitrarily large.
 func truncateForLog(s string, maxRunes int) string {
 	r := []rune(s)
 	if len(r) <= maxRunes {

--- a/internal/intercept/helpers_test.go
+++ b/internal/intercept/helpers_test.go
@@ -1,0 +1,245 @@
+package intercept
+
+import (
+	"bytes"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/action"
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/retry"
+)
+
+// --- peekAnthropicError contract (#532 finding 7b) ---
+
+func TestPeekAnthropicError_DetectsErrorEnvelope(t *testing.T) {
+	body := []byte(`{"type":"error","error":{"type":"overloaded_error","message":"API overloaded"}}`)
+	gotType, gotMsg, ok := peekAnthropicError(body)
+	if !ok {
+		t.Fatal("expected ok=true for valid Anthropic error envelope")
+	}
+	if gotType != "overloaded_error" {
+		t.Errorf("type = %q, want overloaded_error", gotType)
+	}
+	if gotMsg != "API overloaded" {
+		t.Errorf("message = %q, want %q", gotMsg, "API overloaded")
+	}
+}
+
+func TestPeekAnthropicError_RejectsValidMessage(t *testing.T) {
+	body := []byte(`{"id":"msg_1","type":"message","role":"assistant","content":[]}`)
+	if _, _, ok := peekAnthropicError(body); ok {
+		t.Error("peekAnthropicError accepted a valid message body — must only match type=error")
+	}
+}
+
+func TestPeekAnthropicError_RejectsUnparseable(t *testing.T) {
+	if _, _, ok := peekAnthropicError([]byte("not json")); ok {
+		t.Error("peekAnthropicError accepted unparseable body")
+	}
+}
+
+// --- peekOpenAIError contract ---
+
+func TestPeekOpenAIError_DetectsErrorEnvelope(t *testing.T) {
+	body := []byte(`{"error":{"type":"rate_limit_exceeded","code":"rate_limit","message":"Slow down"}}`)
+	gotType, gotMsg, ok := peekOpenAIError(body)
+	if !ok {
+		t.Fatal("expected ok=true for OpenAI error envelope")
+	}
+	if gotType != "rate_limit_exceeded" {
+		t.Errorf("type = %q, want rate_limit_exceeded", gotType)
+	}
+	if gotMsg != "Slow down" {
+		t.Errorf("message = %q", gotMsg)
+	}
+}
+
+func TestPeekOpenAIError_FallsBackToCode(t *testing.T) {
+	body := []byte(`{"error":{"code":"insufficient_quota","message":"out of credits"}}`)
+	gotType, _, ok := peekOpenAIError(body)
+	if !ok {
+		t.Fatal("expected ok=true")
+	}
+	if gotType != "insufficient_quota" {
+		t.Errorf("type = %q, want insufficient_quota (fell back to code)", gotType)
+	}
+}
+
+func TestPeekOpenAIError_RejectsValidChoices(t *testing.T) {
+	// A successful chat completion may legitimately mention "error" in
+	// content text or finish_reason metadata; the helper must not
+	// classify it as an error envelope.
+	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"no error here"}}]}`)
+	if _, _, ok := peekOpenAIError(body); ok {
+		t.Error("peekOpenAIError accepted a successful completion as an error")
+	}
+}
+
+func TestPeekOpenAIError_RejectsUnparseable(t *testing.T) {
+	if _, _, ok := peekOpenAIError([]byte("garbage")); ok {
+		t.Error("peekOpenAIError accepted unparseable body")
+	}
+}
+
+// --- truncateForLog ---
+
+func TestTruncateForLog_RespectsLimit(t *testing.T) {
+	got := truncateForLog("abcdefghij", 4)
+	if got != "abcd…" {
+		t.Errorf("got %q, want abcd…", got)
+	}
+}
+
+func TestTruncateForLog_PassesThroughShort(t *testing.T) {
+	if got := truncateForLog("abc", 10); got != "abc" {
+		t.Errorf("short string got truncated: %q", got)
+	}
+}
+
+// --- HandleAnthropic logs upstream-error envelope inside HTTP 200 ---
+
+// engineWithCapturedLogger builds an Engine wired to capture slog
+// output to buf, used for asserting on Warn-level events the
+// production handlers emit on upstream non-success and HTTP 200
+// error envelopes.
+func engineWithCapturedLogger(t *testing.T, openAIURL, anthropicURL string, store *action.Store, buf *bytes.Buffer) *Engine {
+	t.Helper()
+	var oa, an *url.URL
+	if openAIURL != "" {
+		u, _ := url.Parse(openAIURL)
+		oa = u
+	}
+	if anthropicURL != "" {
+		u, _ := url.Parse(anthropicURL)
+		an = u
+	}
+	logger := slog.New(slog.NewTextHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+	e, err := New(Config{
+		OpenAIUpstream:    oa,
+		AnthropicUpstream: an,
+		Actions:           store,
+		Executor:          action.StubExecutor{},
+		Recorder:          audit.NewRecorder(audit.NewMemStore(), nil, nil),
+		Log:               logger,
+		RetryPolicy:       retry.Policy{MaxRetries: 0, BaseDelay: time.Millisecond, Jitter: 0},
+	})
+	if err != nil {
+		t.Fatalf("intercept.New: %v", err)
+	}
+	return e
+}
+
+// TestHandleAnthropic_LogsUpstreamErrorEnvelopeOn200 pins finding #7b:
+// Anthropic's `{"type":"error","error":{...}}` body inside HTTP 200
+// must produce a WARN-level log event so the operator sees the
+// upstream cause in daemon.log instead of guessing from a 200-
+// looking request that took 72s.
+func TestHandleAnthropic_LogsUpstreamErrorEnvelopeOn200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("request-id", "req_test_42")
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusOK)
+		w.Write([]byte(`{"type":"error","error":{"type":"overloaded_error","message":"API overloaded"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+
+	var logs bytes.Buffer
+	e := engineWithCapturedLogger(t, "", srv.URL, store, &logs)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"claude-sonnet-4-6","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	out := logs.String()
+	for _, want := range []string{
+		"upstream error in HTTP 200 envelope",
+		"protocol=anthropic",
+		"upstream_error_type=overloaded_error",
+		"request_id=req_test_42",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in log, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestHandleAnthropic_LogsUpstreamNonSuccess pins the second half of
+// finding #7b: a non-200 upstream response must also surface as a
+// structured WARN event with status + request_id, not just an OTel
+// span attribute (operators without OTel enabled were getting no
+// in-band signal at all).
+//
+// Uses 401 because 429/5xx are retryable failures wrapped via
+// failure.Upstream and surfaced via writeFailure — the
+// "non-200 passthrough" branch exercised here is for 4xx non-429.
+func TestHandleAnthropic_LogsUpstreamNonSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("request-id", "req_test_401")
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"type":"error","error":{"type":"authentication_error","message":"bad key"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	var logs bytes.Buffer
+	e := engineWithCapturedLogger(t, "", srv.URL, store, &logs)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"claude-sonnet-4-6","max_tokens":1024,"messages":[{"role":"user","content":"hi"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	out := logs.String()
+	for _, want := range []string{
+		"upstream non-success",
+		"protocol=anthropic",
+		"upstream_status=401",
+		"request_id=req_test_401",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in log, got:\n%s", want, out)
+		}
+	}
+}
+
+// TestHandleOpenAI_LogsUpstreamNonSuccess mirrors the Anthropic
+// non-success-logging contract for the OpenAI path. Same operator-
+// visibility argument applies.
+func TestHandleOpenAI_LogsUpstreamNonSuccess(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("x-request-id", "req_oa_401")
+		w.WriteHeader(http.StatusUnauthorized)
+		w.Write([]byte(`{"error":{"message":"bad key"}}`))
+	}))
+	t.Cleanup(srv.Close)
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	var logs bytes.Buffer
+	e := engineWithCapturedLogger(t, srv.URL, "", store, &logs)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/chat/completions",
+		strings.NewReader(`{"model":"gpt-4","messages":[]}`))
+	w := httptest.NewRecorder()
+	e.HandleOpenAI(w, r)
+
+	out := logs.String()
+	for _, want := range []string{
+		"upstream non-success",
+		"protocol=openai",
+		"upstream_status=401",
+		"request_id=req_oa_401",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("expected %q in log, got:\n%s", want, out)
+		}
+	}
+}

--- a/internal/intercept/helpers_test.go
+++ b/internal/intercept/helpers_test.go
@@ -15,78 +15,6 @@ import (
 	"github.com/ALRubinger/aileron/internal/retry"
 )
 
-// --- peekAnthropicError contract (#532 finding 7b) ---
-
-func TestPeekAnthropicError_DetectsErrorEnvelope(t *testing.T) {
-	body := []byte(`{"type":"error","error":{"type":"overloaded_error","message":"API overloaded"}}`)
-	gotType, gotMsg, ok := peekAnthropicError(body)
-	if !ok {
-		t.Fatal("expected ok=true for valid Anthropic error envelope")
-	}
-	if gotType != "overloaded_error" {
-		t.Errorf("type = %q, want overloaded_error", gotType)
-	}
-	if gotMsg != "API overloaded" {
-		t.Errorf("message = %q, want %q", gotMsg, "API overloaded")
-	}
-}
-
-func TestPeekAnthropicError_RejectsValidMessage(t *testing.T) {
-	body := []byte(`{"id":"msg_1","type":"message","role":"assistant","content":[]}`)
-	if _, _, ok := peekAnthropicError(body); ok {
-		t.Error("peekAnthropicError accepted a valid message body — must only match type=error")
-	}
-}
-
-func TestPeekAnthropicError_RejectsUnparseable(t *testing.T) {
-	if _, _, ok := peekAnthropicError([]byte("not json")); ok {
-		t.Error("peekAnthropicError accepted unparseable body")
-	}
-}
-
-// --- peekOpenAIError contract ---
-
-func TestPeekOpenAIError_DetectsErrorEnvelope(t *testing.T) {
-	body := []byte(`{"error":{"type":"rate_limit_exceeded","code":"rate_limit","message":"Slow down"}}`)
-	gotType, gotMsg, ok := peekOpenAIError(body)
-	if !ok {
-		t.Fatal("expected ok=true for OpenAI error envelope")
-	}
-	if gotType != "rate_limit_exceeded" {
-		t.Errorf("type = %q, want rate_limit_exceeded", gotType)
-	}
-	if gotMsg != "Slow down" {
-		t.Errorf("message = %q", gotMsg)
-	}
-}
-
-func TestPeekOpenAIError_FallsBackToCode(t *testing.T) {
-	body := []byte(`{"error":{"code":"insufficient_quota","message":"out of credits"}}`)
-	gotType, _, ok := peekOpenAIError(body)
-	if !ok {
-		t.Fatal("expected ok=true")
-	}
-	if gotType != "insufficient_quota" {
-		t.Errorf("type = %q, want insufficient_quota (fell back to code)", gotType)
-	}
-}
-
-func TestPeekOpenAIError_RejectsValidChoices(t *testing.T) {
-	// A successful chat completion may legitimately mention "error" in
-	// content text or finish_reason metadata; the helper must not
-	// classify it as an error envelope.
-	body := []byte(`{"choices":[{"message":{"role":"assistant","content":"no error here"}}]}`)
-	if _, _, ok := peekOpenAIError(body); ok {
-		t.Error("peekOpenAIError accepted a successful completion as an error")
-	}
-}
-
-func TestPeekOpenAIError_RejectsUnparseable(t *testing.T) {
-	if _, _, ok := peekOpenAIError([]byte("garbage")); ok {
-		t.Error("peekOpenAIError accepted unparseable body")
-	}
-}
-
 // --- truncateForLog ---
 
 func TestTruncateForLog_RespectsLimit(t *testing.T) {
@@ -102,12 +30,12 @@ func TestTruncateForLog_PassesThroughShort(t *testing.T) {
 	}
 }
 
-// --- HandleAnthropic logs upstream-error envelope inside HTTP 200 ---
+// --- Upstream-visibility logging (#532 finding 7b) ---
 
 // engineWithCapturedLogger builds an Engine wired to capture slog
 // output to buf, used for asserting on Warn-level events the
-// production handlers emit on upstream non-success and HTTP 200
-// error envelopes.
+// production handlers emit on upstream non-success and unparseable-
+// 200 bodies.
 func engineWithCapturedLogger(t *testing.T, openAIURL, anthropicURL string, store *action.Store, buf *bytes.Buffer) *Engine {
 	t.Helper()
 	var oa, an *url.URL
@@ -135,12 +63,21 @@ func engineWithCapturedLogger(t *testing.T, openAIURL, anthropicURL string, stor
 	return e
 }
 
-// TestHandleAnthropic_LogsUpstreamErrorEnvelopeOn200 pins finding #7b:
-// Anthropic's `{"type":"error","error":{...}}` body inside HTTP 200
-// must produce a WARN-level log event so the operator sees the
-// upstream cause in daemon.log instead of guessing from a 200-
-// looking request that took 72s.
-func TestHandleAnthropic_LogsUpstreamErrorEnvelopeOn200(t *testing.T) {
+// TestHandleAnthropic_LogsUnparseable200Body pins finding #7b: when
+// upstream returns an HTTP 200 carrying a body that isn't a usable
+// message response — Anthropic's `{"type":"error","error":{...}}`
+// envelope is the motivating case (overloaded_error /
+// rate_limit_error inside an otherwise-successful stream) — the
+// gateway must log a WARN with the parse error and a body preview so
+// the operator sees the upstream cause in daemon.log. Without this
+// signal a 200 that took 72s looks identical to a slow-but-success-
+// ful round.
+//
+// The contract is provider-agnostic: any unparseable success body
+// (error envelope or genuinely malformed JSON) triggers the log.
+// This test pins the motivating shape; the handler does not depend
+// on it.
+func TestHandleAnthropic_LogsUnparseable200Body(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("request-id", "req_test_42")
 		w.Header().Set("Content-Type", "application/json")
@@ -161,10 +98,12 @@ func TestHandleAnthropic_LogsUpstreamErrorEnvelopeOn200(t *testing.T) {
 
 	out := logs.String()
 	for _, want := range []string{
-		"upstream error in HTTP 200 envelope",
+		"upstream returned unparseable success body",
 		"protocol=anthropic",
-		"upstream_error_type=overloaded_error",
 		"request_id=req_test_42",
+		// body preview must surface the upstream error type for grep
+		// without requiring the gateway to know Anthropic's shape:
+		"overloaded_error",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("expected %q in log, got:\n%s", want, out)

--- a/internal/intercept/openai.go
+++ b/internal/intercept/openai.go
@@ -100,10 +100,34 @@ func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 		if respStatus != http.StatusOK {
+			e.log.Warn("upstream non-success",
+				"protocol", "openai",
+				"upstream_status", respStatus,
+				"request_id", respHeaders.Get("x-request-id"),
+				"round", round,
+			)
 			roundSpan.SetAttributes(attribute.Int("aileron.intercept.upstream_status", respStatus))
 			roundSpan.End()
 			passThrough(w, respStatus, respHeaders, respBody)
 			return
+		}
+
+		// Mirror of the Anthropic path: log when an upstream error
+		// envelope arrives inside an HTTP 200 body. OpenAI usually
+		// returns errors as 4xx/5xx but streaming/edge cases can
+		// surface them in a 200 — same operator-visibility argument
+		// applies as for Anthropic.
+		if errType, errMsg, ok := peekOpenAIError(respBody); ok {
+			e.log.Warn("upstream error in HTTP 200 envelope",
+				"protocol", "openai",
+				"upstream_error_type", errType,
+				"upstream_error_message", truncateForLog(errMsg, 256),
+				"request_id", respHeaders.Get("x-request-id"),
+				"round", round,
+			)
+			roundSpan.SetAttributes(
+				attribute.String("aileron.intercept.upstream_error_type", errType),
+			)
 		}
 
 		assistantMsg, toolCalls, err := parseOpenAIChoice(respBody)

--- a/internal/intercept/openai.go
+++ b/internal/intercept/openai.go
@@ -112,26 +112,22 @@ func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 
-		// Mirror of the Anthropic path: log when an upstream error
-		// envelope arrives inside an HTTP 200 body. OpenAI usually
-		// returns errors as 4xx/5xx but streaming/edge cases can
-		// surface them in a 200 — same operator-visibility argument
-		// applies as for Anthropic.
-		if errType, errMsg, ok := peekOpenAIError(respBody); ok {
-			e.log.Warn("upstream error in HTTP 200 envelope",
+		assistantMsg, toolCalls, err := parseOpenAIChoice(respBody)
+		if err != nil {
+			// See the Anthropic handler for the full rationale: an
+			// HTTP 200 body that doesn't parse as a successful
+			// completion (error envelope or malformed JSON) needs an
+			// in-band log so the operator sees it in daemon.log
+			// instead of just an OTel span attribute. The body
+			// preview carries the upstream cause without provider-
+			// specific parsing here.
+			e.log.Warn("upstream returned unparseable success body",
 				"protocol", "openai",
-				"upstream_error_type", errType,
-				"upstream_error_message", truncateForLog(errMsg, 256),
+				"parse_error", err.Error(),
+				"body_preview", truncateForLog(string(respBody), 512),
 				"request_id", respHeaders.Get("x-request-id"),
 				"round", round,
 			)
-			roundSpan.SetAttributes(
-				attribute.String("aileron.intercept.upstream_error_type", errType),
-			)
-		}
-
-		assistantMsg, toolCalls, err := parseOpenAIChoice(respBody)
-		if err != nil {
 			roundSpan.SetStatus(codes.Error, "parse upstream response: "+err.Error())
 			roundSpan.End()
 			passThrough(w, respStatus, respHeaders, respBody)


### PR DESCRIPTION
## Summary

Two visibility gaps in the LLM gateway:

1. **Non-200 upstream responses** (4xx other than 429) used to pass through to the agent with no in-band log signal — only an OTel span attribute. Operators without OTel enabled saw nothing in daemon.log. Now emits a WARN with `protocol`, `upstream_status`, `request_id`, and the round index.

2. **HTTP 200 with an unparseable body.** Anthropic occasionally returns an HTTP 200 carrying `{"type":"error","error":{...}}` (overloaded_error, rate_limit_error, ...) — typically when a streamed error event gets wrapped into a single JSON document. Without an in-band log, a 200 that took 72s looks identical to a slow-but-successful round in daemon.log, and the agent's SDK retry (or 13-minute hang on stuttering streams) is the first sign anything is wrong.

   The fix piggybacks on the existing `parseAnthropicResponse` / `parseOpenAIChoice` error branch — those already reject error envelopes (`type != "message"` for Anthropic, "no choices" for OpenAI) and any genuinely malformed JSON. The handler now logs a WARN there with `protocol`, `parse_error` (the parser's own message), `body_preview` (truncated to 512 runes), `request_id`, and `round`. The body preview carries the upstream error type as ASCII for grep / future `aileron sessions watch` filtering, without the gateway needing to know provider-specific envelope shapes. Both providers benefit from a single code path.

The body still flows through to the agent verbatim in both cases.

Resolves finding #7b of #532. Pairs with #7a (#540) for end-of-session summaries and unblocks #7c (sessions watch).

## Test plan

- [x] `go test ./internal/intercept/... -count=1 -cover` (91.7%)
- [x] New tests:
  - `TestTruncateForLog_*` (limit + passthrough)
  - `TestHandleAnthropic_LogsUnparseable200Body` — Anthropic error envelope inside HTTP 200 produces a WARN whose body preview surfaces the upstream error type
  - `TestHandleAnthropic_LogsUpstreamNonSuccess` — 4xx non-429 produces a structured non-success WARN
  - `TestHandleOpenAI_LogsUpstreamNonSuccess` — same for the OpenAI path
- [x] Full `internal/...` test suite passes
- [ ] Manual: trigger a 401 from upstream and grep daemon.log for `upstream non-success`; trigger an Anthropic error envelope and grep for `unparseable success body`

🤖 Generated with [Claude Code](https://claude.com/claude-code)