### PR TITLE
feat(cli): aileron sessions watch — tail a launch session's log live

### DIFF
--- a/cmd/aileron/sessions.go
+++ b/cmd/aileron/sessions.go
@@ -23,8 +23,9 @@ var (
 )
 
 const sessionsUsage = `usage:
-  aileron sessions list [--active] [--agent NAME] [--since RFC3339] [--limit N] [--json]
-  aileron sessions get  <session-id> [--json]`
+  aileron sessions list  [--active] [--agent NAME] [--since RFC3339] [--limit N] [--json]
+  aileron sessions get   <session-id> [--json]
+  aileron sessions watch <session-id> [--no-follow]`
 
 // sessionsListQuery mirrors the four query parameters supported by
 // `GET /v1/sessions`. Empty / zero values are not sent.
@@ -48,6 +49,8 @@ func runSessions(args []string, stdout, stderr io.Writer) int {
 		return runSessionsList(args[1:], stdout, stderr)
 	case "get":
 		return runSessionsGet(args[1:], stdout, stderr)
+	case "watch":
+		return runSessionsWatch(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown sessions command: %q\n", args[0])
 		fmt.Fprintln(stderr, sessionsUsage)

--- a/cmd/aileron/sessions_watch.go
+++ b/cmd/aileron/sessions_watch.go
@@ -68,11 +68,16 @@ func runSessionsWatch(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	logPath := launch.SessionLogPath(s.WorkingDir)
-	if logPath == "" {
-		fmt.Fprintln(stderr, "error: could not resolve session log path (no working_dir on session record)")
+	if s.WorkingDir == "" {
+		// SessionLogPath falls back to cwd for empty input, which
+		// would silently watch the wrong project's session.log.
+		// A session record without a working_dir is malformed (the
+		// daemon stamps it at registration); fail fast rather than
+		// guess.
+		fmt.Fprintf(stderr, "error: session %q has no working_dir recorded; cannot locate session log\n", sessionID)
 		return 1
 	}
+	logPath := launch.SessionLogPath(s.WorkingDir)
 
 	ctx, stop := signal.NotifyContext(context.Background(), sessionsWatchSignals...)
 	defer stop()

--- a/cmd/aileron/sessions_watch.go
+++ b/cmd/aileron/sessions_watch.go
@@ -1,0 +1,166 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"os/signal"
+	"syscall"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/launch"
+)
+
+// sessionsWatchTailInterval is how often the watch loop polls the
+// session log file for new bytes when following. 200ms is the same
+// order of magnitude as `tail -F` and feels live for an interactive
+// command without spinning the CPU.
+//
+// Replaceable in tests so they don't pay real-time waits.
+var sessionsWatchTailInterval = 200 * time.Millisecond
+
+// sessionsWatchSignals is the set of signals that gracefully end the
+// watch loop. Replaceable in tests where signal.Notify on SIGINT is
+// hostile (it interferes with `go test`'s own signal handling).
+var sessionsWatchSignals = []os.Signal{syscall.SIGINT, syscall.SIGTERM}
+
+// runSessionsWatch follows the per-session log written by `aileron
+// launch` for sessionID, printing existing content first, then
+// streaming new bytes as they appear. Resolves session → working_dir
+// via GET /v1/sessions/{id} so the working_dir lookup matches what
+// the launcher recorded; computes the on-disk path via
+// [launch.SessionLogPath] so the resolution rules (policy-file walk,
+// fallback to .aileron/session.log under dir) stay in lockstep.
+//
+// Exits when the user sends SIGINT/SIGTERM, or — when --no-follow is
+// set — after printing the file's existing content. An ended session
+// is followed identically to a running one (no special-case): if the
+// file is static the loop just sleeps. The user picks the right
+// stopping point with Ctrl-C.
+//
+// Resolves finding #7c of #532 — `kubectl logs -f`-style visibility
+// into a launch session.
+func runSessionsWatch(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("sessions watch", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	noFollow := flags.Bool("no-follow", false, "Print the existing content and exit; do not stream new lines")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	rest := flags.Args()
+	if len(rest) != 1 {
+		fmt.Fprintln(stderr, "usage: aileron sessions watch <session-id> [--no-follow]")
+		return 1
+	}
+	sessionID := rest[0]
+
+	s, status, err := sessionsGetFetcher(sessionID)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if status == http.StatusNotFound {
+		fmt.Fprintf(stderr, "session %q not found\n", sessionID)
+		return 1
+	}
+
+	logPath := launch.SessionLogPath(s.WorkingDir)
+	if logPath == "" {
+		fmt.Fprintln(stderr, "error: could not resolve session log path (no working_dir on session record)")
+		return 1
+	}
+
+	ctx, stop := signal.NotifyContext(context.Background(), sessionsWatchSignals...)
+	defer stop()
+
+	if err := tailSessionLog(ctx, stdout, logPath, *noFollow); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// tailSessionLog opens path, copies existing content to w, and (when
+// follow is true) keeps appending new bytes as they're written by the
+// launcher. Returns nil on graceful end (ctx cancel for follow=true,
+// EOF for follow=false). Returns an error only on unrecoverable I/O
+// failure — a missing file at start is treated as "not yet" and
+// polled for, since the watch command may legitimately race the
+// launcher creating session.log on first write.
+//
+// Split out from runSessionsWatch so the loop is testable without a
+// running daemon.
+func tailSessionLog(ctx context.Context, w io.Writer, path string, noFollow bool) error {
+	f, err := openSessionLogPolling(ctx, path)
+	if err != nil {
+		return err
+	}
+	defer func() { _ = f.Close() }()
+
+	// Seek to start; the contract is "print existing content first."
+	if _, err := f.Seek(0, io.SeekStart); err != nil {
+		return fmt.Errorf("seek session log: %w", err)
+	}
+
+	// Copy whatever is in the file right now.
+	if _, err := io.Copy(w, f); err != nil {
+		return fmt.Errorf("read session log: %w", err)
+	}
+
+	if noFollow {
+		return nil
+	}
+
+	// Follow loop: poll for new bytes appended after our current
+	// offset. ENOSYS-clean implementation — works on every platform
+	// where os.File supports Seek + Read at an offset.
+	buf := make([]byte, 4096)
+	for {
+		n, readErr := f.Read(buf)
+		if n > 0 {
+			if _, werr := w.Write(buf[:n]); werr != nil {
+				return werr
+			}
+		}
+		if readErr != nil && !errors.Is(readErr, io.EOF) {
+			return readErr
+		}
+		if n > 0 {
+			// Got data — try to drain immediately rather than sleep.
+			continue
+		}
+		select {
+		case <-ctx.Done():
+			return nil
+		case <-time.After(sessionsWatchTailInterval):
+		}
+	}
+}
+
+// openSessionLogPolling opens path for reading, polling at
+// sessionsWatchTailInterval if the file does not yet exist. Returns
+// when the file appears or ctx is cancelled. The poll handles the
+// race where the user runs `aileron sessions watch <id>` immediately
+// after `aileron launch <agent>` and beats the launcher to writing
+// session.log.
+func openSessionLogPolling(ctx context.Context, path string) (*os.File, error) {
+	for {
+		f, err := os.Open(path)
+		if err == nil {
+			return f, nil
+		}
+		if !errors.Is(err, os.ErrNotExist) {
+			return nil, fmt.Errorf("open session log %q: %w", path, err)
+		}
+		select {
+		case <-ctx.Done():
+			return nil, ctx.Err()
+		case <-time.After(sessionsWatchTailInterval):
+		}
+	}
+}
+

--- a/cmd/aileron/sessions_watch_test.go
+++ b/cmd/aileron/sessions_watch_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	api "github.com/ALRubinger/aileron/internal/api/gen"
+)
+
+// /v1/sessions watch CLI contract (#532 finding 7c):
+//
+//   - `aileron sessions watch <id>` resolves the session to its
+//     working_dir via GET /v1/sessions/{id}, computes the per-project
+//     session.log path, and tails it. Existing content prints first;
+//     new lines stream until SIGINT/SIGTERM.
+//   - 404 surfaces as "session ... not found" on stderr with exit 1.
+//   - `--no-follow` prints existing content and exits.
+//   - A missing session.log at start is polled for, not an error —
+//     the watcher may legitimately race the launcher creating the file.
+
+// --- runSessionsWatch ---
+
+func TestRunSessionsWatch_NotFoundExitsOne(t *testing.T) {
+	withSessionsFetchers(t, nil,
+		func(string) (*api.Session, int, error) {
+			return nil, http.StatusNotFound, nil
+		})
+
+	var stdout, stderr bytes.Buffer
+	code := runSessionsWatch([]string{"missing"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), `session "missing" not found`) {
+		t.Errorf("stderr = %q, want session-not-found message", stderr.String())
+	}
+}
+
+func TestRunSessionsWatch_RequiresSessionID(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runSessionsWatch(nil, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 for missing id", code)
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("stderr = %q, want usage line", stderr.String())
+	}
+}
+
+func TestRunSessionsWatch_NoFollowPrintsExistingAndExits(t *testing.T) {
+	dir := t.TempDir()
+	logPath := filepath.Join(dir, ".aileron", "session.log")
+	if err := os.MkdirAll(filepath.Dir(logPath), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(logPath, []byte("line1\nline2\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	withSessionsFetchers(t, nil,
+		func(id string) (*api.Session, int, error) {
+			return &api.Session{Id: id, WorkingDir: dir, Agent: "claude"}, http.StatusOK, nil
+		})
+
+	var stdout, stderr bytes.Buffer
+	code := runSessionsWatch([]string{"--no-follow", "abc123"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr = %s", code, stderr.String())
+	}
+	if got := stdout.String(); got != "line1\nline2\n" {
+		t.Errorf("stdout = %q, want existing log content verbatim", got)
+	}
+}
+
+// --- tailSessionLog ---
+
+func TestTailSessionLog_PrintsExistingThenAppends(t *testing.T) {
+	withFastTailInterval(t)
+
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.log")
+	if err := os.WriteFile(path, []byte("first\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out lockingBuffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- tailSessionLog(ctx, &out, path, false) }()
+
+	// Wait for the existing content to be printed.
+	waitForOutput(t, &out, "first\n")
+
+	// Append new bytes; the follow loop should pick them up.
+	f, err := os.OpenFile(path, os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if _, err := f.WriteString("second\n"); err != nil {
+		t.Fatal(err)
+	}
+	_ = f.Close()
+	waitForOutput(t, &out, "second\n")
+
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("tailSessionLog returned err = %v, want nil after ctx cancel", err)
+	}
+}
+
+func TestTailSessionLog_NoFollowReturnsAfterExisting(t *testing.T) {
+	withFastTailInterval(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.log")
+	if err := os.WriteFile(path, []byte("only line\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out lockingBuffer
+	if err := tailSessionLog(context.Background(), &out, path, true); err != nil {
+		t.Fatalf("tailSessionLog: %v", err)
+	}
+	if got := out.String(); got != "only line\n" {
+		t.Errorf("got %q, want %q", got, "only line\n")
+	}
+}
+
+func TestTailSessionLog_PollsForFileCreation(t *testing.T) {
+	withFastTailInterval(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.log")
+	// File does not exist yet — the watch must poll, not error.
+
+	var out lockingBuffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- tailSessionLog(ctx, &out, path, false) }()
+
+	// Race the watcher: create the file shortly after the call.
+	time.Sleep(40 * time.Millisecond)
+	if err := os.WriteFile(path, []byte("appeared\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	waitForOutput(t, &out, "appeared\n")
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("tailSessionLog returned err = %v, want nil after ctx cancel", err)
+	}
+}
+
+func TestTailSessionLog_OpenFailureSurfaced(t *testing.T) {
+	withFastTailInterval(t)
+	// A path under a non-readable parent yields a non-ErrNotExist
+	// open error; tailSessionLog must surface it rather than
+	// retrying forever.
+	dir := t.TempDir()
+	parent := filepath.Join(dir, "noperm")
+	if err := os.Mkdir(parent, 0o000); err != nil {
+		t.Fatal(err)
+	}
+	t.Cleanup(func() { _ = os.Chmod(parent, 0o755) }) // let TempDir clean up
+	path := filepath.Join(parent, "session.log")
+
+	if os.Geteuid() == 0 {
+		t.Skip("root bypasses 0o000 — skipping")
+	}
+
+	var out lockingBuffer
+	err := tailSessionLog(context.Background(), &out, path, true)
+	if err == nil {
+		t.Fatal("expected error from unreadable parent dir, got nil")
+	}
+}
+
+// --- helpers ---
+
+// withFastTailInterval shortens the tail polling interval for the
+// duration of the test so the suite finishes promptly. Restores on
+// cleanup.
+func withFastTailInterval(t *testing.T) {
+	t.Helper()
+	orig := sessionsWatchTailInterval
+	sessionsWatchTailInterval = 5 * time.Millisecond
+	t.Cleanup(func() { sessionsWatchTailInterval = orig })
+}
+
+// lockingBuffer is a goroutine-safe bytes.Buffer; the tail loop
+// writes to it from a goroutine while the test reads it.
+type lockingBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *lockingBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *lockingBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// waitForOutput polls the buffer up to 1.5s for substr to appear,
+// failing the test if it doesn't. Replaces sleep+assert which would
+// either be racy (too short) or slow (too long).
+func waitForOutput(t *testing.T, out *lockingBuffer, substr string) {
+	t.Helper()
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if strings.Contains(out.String(), substr) {
+			return
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	t.Fatalf("output never contained %q; got:\n%s", substr, out.String())
+}

--- a/cmd/aileron/sessions_watch_test.go
+++ b/cmd/aileron/sessions_watch_test.go
@@ -79,6 +79,46 @@ func TestRunSessionsWatch_NoFollowPrintsExistingAndExits(t *testing.T) {
 	}
 }
 
+func TestRunSessionsWatch_FetcherTransportErrorExitsOne(t *testing.T) {
+	// A transport / spawn failure surfaces as a non-nil error from the
+	// fetcher, distinct from a structured 404. The CLI must exit 1
+	// with the underlying error on stderr — this is the daemon-down
+	// path users hit when AILERON_API_URL is misconfigured or the
+	// daemon binary cannot be located.
+	withSessionsFetchers(t, nil,
+		func(string) (*api.Session, int, error) {
+			return nil, 0, errStub("daemon: no such host")
+		})
+
+	var stdout, stderr bytes.Buffer
+	code := runSessionsWatch([]string{"abc"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "daemon: no such host") {
+		t.Errorf("stderr = %q, want underlying transport error", stderr.String())
+	}
+}
+
+func TestRunSessionsWatch_EmptyWorkingDirExitsOne(t *testing.T) {
+	// A session record without a working_dir would let SessionLogPath
+	// fall back to cwd and silently tail the wrong project's log.
+	// Fail fast with a clear error instead.
+	withSessionsFetchers(t, nil,
+		func(id string) (*api.Session, int, error) {
+			return &api.Session{Id: id, Agent: "claude" /* WorkingDir intentionally empty */}, http.StatusOK, nil
+		})
+
+	var stdout, stderr bytes.Buffer
+	code := runSessionsWatch([]string{"abc"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "no working_dir recorded") {
+		t.Errorf("stderr = %q, want explanatory error", stderr.String())
+	}
+}
+
 // --- tailSessionLog ---
 
 func TestTailSessionLog_PrintsExistingThenAppends(t *testing.T) {
@@ -160,6 +200,83 @@ func TestTailSessionLog_PollsForFileCreation(t *testing.T) {
 	}
 }
 
+// TestTailSessionLog_LargeContentDrainsAcrossReads pins that the
+// follow loop drains content larger than its 4 KiB read buffer in
+// one logical "burst" — without this, a session that emits a big
+// startup banner or summary would print only the first 4 KiB and
+// then sleep until the next poll tick, fragmenting the output the
+// operator sees in real time.
+func TestTailSessionLog_LargeContentDrainsAcrossReads(t *testing.T) {
+	withFastTailInterval(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "session.log")
+
+	// Build a payload that crosses the read buffer (4096) plus some
+	// margin so we exercise multiple Read iterations.
+	const payloadSize = 12000
+	payload := make([]byte, payloadSize)
+	for i := range payload {
+		payload[i] = byte('a' + (i % 26))
+	}
+	if err := os.WriteFile(path, payload, 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var out lockingBuffer
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+
+	done := make(chan error, 1)
+	go func() { done <- tailSessionLog(ctx, &out, path, false) }()
+
+	// Wait for the full existing payload to land.
+	deadline := time.Now().Add(1500 * time.Millisecond)
+	for time.Now().Before(deadline) {
+		if len(out.String()) >= payloadSize {
+			break
+		}
+		time.Sleep(5 * time.Millisecond)
+	}
+	if got := out.String(); len(got) != payloadSize {
+		t.Fatalf("got %d bytes, want %d (multi-Read drain)", len(got), payloadSize)
+	}
+	cancel()
+	if err := <-done; err != nil {
+		t.Errorf("tailSessionLog returned err = %v after ctx cancel", err)
+	}
+}
+
+// TestTailSessionLog_CancelDuringFilePolling pins that ctx
+// cancellation breaks the open-file polling loop. Without this, a
+// `aileron sessions watch <id>` against a session that never writes
+// (immediate-exit launches) would block forever — the SIGINT path
+// in runSessionsWatch threads ctx through, so the polling loop is
+// the actual cancellation respondent.
+func TestTailSessionLog_CancelDuringFilePolling(t *testing.T) {
+	withFastTailInterval(t)
+	dir := t.TempDir()
+	path := filepath.Join(dir, "never-appears.log")
+
+	ctx, cancel := context.WithCancel(context.Background())
+
+	var out lockingBuffer
+	done := make(chan error, 1)
+	go func() { done <- tailSessionLog(ctx, &out, path, false) }()
+
+	// Give the loop time to enter polling, then cancel.
+	time.Sleep(30 * time.Millisecond)
+	cancel()
+
+	select {
+	case err := <-done:
+		if err == nil || !strings.Contains(err.Error(), "context canceled") {
+			t.Errorf("err = %v, want wrapped context.Canceled", err)
+		}
+	case <-time.After(1 * time.Second):
+		t.Fatal("tailSessionLog did not return after ctx cancel during file polling")
+	}
+}
+
 func TestTailSessionLog_OpenFailureSurfaced(t *testing.T) {
 	withFastTailInterval(t)
 	// A path under a non-readable parent yields a non-ErrNotExist
@@ -214,6 +331,12 @@ func (b *lockingBuffer) String() string {
 	defer b.mu.Unlock()
 	return b.buf.String()
 }
+
+// errStub is the smallest possible error type for fetcher stubs;
+// avoids dragging fmt.Errorf into the test surface.
+type errStub string
+
+func (e errStub) Error() string { return string(e) }
 
 // waitForOutput polls the buffer up to 1.5s for substr to appear,
 // failing the test if it doesn't. Replaces sleep+assert which would

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -207,6 +207,7 @@ In a separate terminal — the daemon is still running, so any CLI call connects
 aileron status               # what's configured: action/connector/binding counts, policy, env, vault state
 aileron daemon status        # what's running: daemon URL, PID, version, started_at, locked/unlocked vault
 aileron sessions list        # every aileron launch, with status (running / ended / orphaned) and exit code
+aileron sessions watch <id>  # tail the per-session log live (Ctrl-C to stop; --no-follow for one-shot)
 aileron action audit         # every installed action and the capabilities it can exercise
 aileron binding list         # bound credentials with their last-used timestamp
 aileron audit list           # action-execution audit log: every call, with inputs and outcome

--- a/internal/launch/export_test.go
+++ b/internal/launch/export_test.go
@@ -3,9 +3,6 @@ package launch
 // OpenSessionLogger exposes openSessionLogger for testing.
 var OpenSessionLogger = openSessionLogger
 
-// SessionLogPath exposes sessionLogPath for testing.
-var SessionLogPath = sessionLogPath
-
 // SummarizeSessionShell exposes summarizeSessionShell for testing.
 var SummarizeSessionShell = summarizeSessionShell
 

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -204,7 +204,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 
 	sessionLog, closeSessionLog := openSessionLogger(config.Dir, config.LogLevel)
 	defer closeSessionLog()
-	fmt.Fprintf(os.Stderr, "aileron: session log → %s\n", sessionLogPath(config.Dir))
+	fmt.Fprintf(os.Stderr, "aileron: session log → %s\n", SessionLogPath(config.Dir))
 
 	sessionLog.Info("session started",
 		"agent", config.Agent.Name(),
@@ -222,7 +222,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	probeCtx, cancelProbe := context.WithTimeout(ctx, daemonHTTPTimeout)
 	locked, ok := client.LocalVaultLocked(probeCtx)
 	cancelProbe()
-	printStartupBanner(os.Stderr, daemonURL, sessionID, sessionLogPath(config.Dir), ok && locked)
+	printStartupBanner(os.Stderr, daemonURL, sessionID, SessionLogPath(config.Dir), ok && locked)
 
 	result, runErr := launchDirect(cmd, config)
 
@@ -574,13 +574,17 @@ func EnvGlobMatch(pattern, name string) bool {
 	return pattern == name
 }
 
-// sessionLogPath returns the per-project session log path: the
+// SessionLogPath returns the per-project session log path: the
 // .aileron/session.log next to the policy file (walking up from dir if
 // necessary) or, if no policy file exists, .aileron/session.log under
 // dir itself. The session log captures the launched agent's stdio and
 // is intentionally project-scoped — distinct from the audit log, which
 // is user-scoped at ~/.aileron/audit/.
-func sessionLogPath(dir string) string {
+//
+// Exported so `aileron sessions watch <id>` can resolve the same path
+// the launcher writes to, without re-implementing the policy-file
+// walk.
+func SessionLogPath(dir string) string {
 	if dir == "" {
 		dir, _ = os.Getwd()
 	}
@@ -596,7 +600,7 @@ func sessionLogPath(dir string) string {
 // cleanup function to close the file. If the file cannot be created,
 // returns a discard logger so callers never receive nil.
 func openSessionLogger(dir string, level slog.Level) (*slog.Logger, func()) {
-	path := sessionLogPath(dir)
+	path := SessionLogPath(dir)
 	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
 		return slog.New(slog.NewTextHandler(io.Discard, nil)), func() {}
 	}


### PR DESCRIPTION
## Summary

\`aileron launch\` writes per-project session logs at \`<project>/.aileron/session.log\`; the launcher and gateway both emit structured events there (session start/end + audit-dir hints from #540, upstream-error envelopes via daemon.log from #541). Until now there was no first-class way to follow that stream while a launch was running.

\`aileron sessions watch <session-id>\`:

- Fetches the session record via \`GET /v1/sessions/{id}\` so working_dir is authoritative.
- Resolves the on-disk log path via the newly-exported \`launch.SessionLogPath\`, keeping the resolution rules (policy-file walk, fallback to \`<dir>/.aileron/session.log\`) in lockstep with the writer.
- Prints existing content, then streams new bytes as they appear. \`--no-follow\` exits after the existing content (for scripts).
- Polls for the file appearing if the watch starts before the launcher's first write (common when racing \`aileron launch\` in one terminal and \`aileron sessions watch\` in another).
- Exits cleanly on SIGINT/SIGTERM.

Resolves finding #7c of #532. Closes the issue (all in-scope findings landed: #1 #533, #2+#5 #539, #4 #534, #6 #535, #7a #540, #7b #541; #3 documented non-goal).

## Test plan

- [x] \`go test ./cmd/aileron/... -count=1 -cover\` (85.6%)
- [x] New tests:
  - \`TestRunSessionsWatch_NotFoundExitsOne\` / \`...RequiresSessionID\` / \`...NoFollowPrintsExistingAndExits\`
  - \`TestTailSessionLog_PrintsExistingThenAppends\` (existing content + appended bytes streamed)
  - \`TestTailSessionLog_NoFollowReturnsAfterExisting\`
  - \`TestTailSessionLog_PollsForFileCreation\` (race with launcher creating session.log)
  - \`TestTailSessionLog_OpenFailureSurfaced\` (non-ErrNotExist open errors propagate)
- [x] Full \`internal/...\` test suite passes; \`task lint:docs\` clean
- [ ] Manual: \`aileron launch claude\` in one terminal, \`aileron sessions watch <id>\` in another — see "session started" land first, then live events

🤖 Generated with [Claude Code](https://claude.com/claude-code)