### PR TITLE
feat(keyring): auto-fetch publisher key from convention path

### DIFF
--- a/cmd/aileron/keyring.go
+++ b/cmd/aileron/keyring.go
@@ -4,14 +4,28 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/base64"
-	"errors"
 	"fmt"
 	"io"
-	"io/fs"
-	"os"
+	"net/http"
+	"net/url"
+	"time"
 
 	"github.com/ALRubinger/aileron/internal/cstore"
 )
+
+// publisherKeyPath is the conventional location of a connector
+// publisher's ed25519 public key inside the source repo (per
+// ADR-0002). One arg `aileron keyring trust <authority>` fetches
+// `<raw-host>/<owner>/<repo>/HEAD/keys/publisher.pub`.
+const publisherKeyPath = "keys/publisher.pub"
+
+// rawGitHubBase is the base URL for fetching files at a ref from
+// public GitHub repositories. Overridable in tests.
+var rawGitHubBase = "https://raw.githubusercontent.com"
+
+// publisherKeyFetchTimeout caps the auto-fetch HTTP call so a stalled
+// network does not leave the user staring at a quiet terminal.
+const publisherKeyFetchTimeout = 15 * time.Second
 
 // runKeyring dispatches `aileron keyring <subcommand>` to one of the
 // keyring management subcommands. The keyring is the v1 source of
@@ -41,17 +55,15 @@ func runKeyring(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
-// runKeyringTrust adds a publisher's ed25519 public key to the local
-// keyring. The key file may be a PEM-encoded SubjectPublicKeyInfo (as
-// produced by `openssl pkey -pubout`) or a raw 32-byte ed25519 public
-// key encoded in base64. Adding a key the keyring already trusts for
-// the same authority is a no-op (so re-running the command after a
-// non-rotation is safe).
+// runKeyringTrust fetches a publisher's ed25519 public key from the
+// conventional `keys/publisher.pub` path on the source repo's default
+// branch (per ADR-0002) and adds it to the local keyring. Adding a
+// key the keyring already trusts for the same authority is a no-op,
+// so re-running is safe.
 func runKeyringTrust(args []string, stdout, stderr io.Writer) int {
-	if len(args) != 2 {
-		fmt.Fprintln(stderr, "usage: aileron keyring trust <authority> <pubkey-file>")
+	if len(args) != 1 {
+		fmt.Fprintln(stderr, "usage: aileron keyring trust <authority>")
 		fmt.Fprintln(stderr, "  authority: e.g. github://ALRubinger/aileron-connector-google")
-		fmt.Fprintln(stderr, "  pubkey-file: PEM (openssl pkey -pubout) or base64 raw key file")
 		return 1
 	}
 	authority := args[0]
@@ -60,9 +72,9 @@ func runKeyringTrust(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	pub, err := readPublicKey(args[1])
+	pub, err := fetchPublisherKey(authority)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: read public key: %v\n", err)
+		fmt.Fprintf(stderr, "error: fetch publisher key for %s: %v\n", authority, err)
 		return 1
 	}
 
@@ -78,7 +90,7 @@ func runKeyringTrust(args []string, stdout, stderr io.Writer) int {
 	}
 
 	if keyring.HasKey(authority, pub) {
-		fmt.Fprintf(stdout, "Already trusted: %s\n", authority)
+		fmt.Fprintf(stdout, "Known publisher already trusted: %s\n", authority)
 		fmt.Fprintf(stdout, "  Fingerprint: %s\n", fingerprint(pub))
 		fmt.Fprintf(stdout, "  Keyring: %s\n", path)
 		return 0
@@ -94,6 +106,54 @@ func runKeyringTrust(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  Fingerprint: %s\n", fingerprint(pub))
 	fmt.Fprintf(stdout, "  Keyring: %s\n", path)
 	return 0
+}
+
+// fetchPublisherKey downloads the ed25519 public key a connector
+// publisher commits at `keys/publisher.pub` on the default branch
+// (per ADR-0002). v1 supports `github://` authorities only.
+//
+// The HTTP call is anonymous — the convention path is on the public
+// internet by definition, so no token plumbing is needed here.
+func fetchPublisherKey(authority string) (ed25519.PublicKey, error) {
+	fqn, err := cstore.ParseFQN(authority)
+	if err != nil {
+		return nil, fmt.Errorf("parse authority: %w", err)
+	}
+	if fqn.Scheme != "github" {
+		return nil, fmt.Errorf("auto-fetch supports github:// authorities only (got %s://)", fqn.Scheme)
+	}
+
+	// `HEAD` resolves to the repo's default branch on raw.githubusercontent.com,
+	// so we never have to ask the API "what's the default branch?" first.
+	keyURL := fmt.Sprintf("%s/%s/%s/HEAD/%s",
+		rawGitHubBase,
+		url.PathEscape(fqn.Owner),
+		url.PathEscape(fqn.Repo),
+		publisherKeyPath,
+	)
+
+	client := &http.Client{Timeout: publisherKeyFetchTimeout}
+	resp, err := client.Get(keyURL)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", keyURL, err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: HTTP %d (publisher must commit %s on the default branch)",
+			keyURL, resp.StatusCode, publisherKeyPath)
+	}
+
+	body, err := io.ReadAll(io.LimitReader(resp.Body, 64*1024))
+	if err != nil {
+		return nil, fmt.Errorf("read response: %w", err)
+	}
+
+	pub, err := decodePublicKey(body)
+	if err != nil {
+		return nil, fmt.Errorf("parse %s: %w", keyURL, err)
+	}
+	return pub, nil
 }
 
 // runKeyringList prints the trusted publishers and a fingerprint per
@@ -121,7 +181,7 @@ func runKeyringList(args []string, stdout, stderr io.Writer) int {
 	if len(authorities) == 0 {
 		fmt.Fprintln(stdout, "No trusted publishers.")
 		fmt.Fprintf(stdout, "  Keyring: %s\n", path)
-		fmt.Fprintln(stdout, "  Add one with `aileron keyring trust <authority> <pubkey-file>`.")
+		fmt.Fprintln(stdout, "  Add one with `aileron keyring trust <authority>`.")
 		return 0
 	}
 
@@ -171,20 +231,13 @@ func runKeyringRevoke(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-// readPublicKey decodes an ed25519 public key from a file. Tries PEM
-// first (the format `openssl pkey -pubout` produces); falls back to
-// trimming whitespace and treating the contents as a base64 raw key.
-// Either form is acceptable in v1 — connector authors typically ship
-// PEM as their `keys/publisher.pub`, but operators wiring up a
-// keyring from a recovery snippet often paste the raw base64.
-func readPublicKey(path string) (ed25519.PublicKey, error) {
-	data, err := os.ReadFile(path)
-	if err != nil {
-		if errors.Is(err, fs.ErrNotExist) {
-			return nil, fmt.Errorf("file not found: %s", path)
-		}
-		return nil, err
-	}
+// decodePublicKey decodes an ed25519 public key from raw bytes. Tries
+// PEM first (the format `openssl pkey -pubout` produces); falls back
+// to trimming whitespace and treating the contents as a base64 raw
+// key. Either form is acceptable in v1 — connector authors typically
+// commit PEM as their `keys/publisher.pub`, but raw base64 is also a
+// reasonable thing to find on the convention path.
+func decodePublicKey(data []byte) (ed25519.PublicKey, error) {
 	if pub, pemErr := cstore.ParsePEMPublicKey(data); pemErr == nil {
 		return pub, nil
 	}
@@ -204,7 +257,7 @@ func readPublicKey(path string) (ed25519.PublicKey, error) {
 				len(raw), ed25519.PublicKeySize)
 		}
 	}
-	return nil, fmt.Errorf("file %q is neither PEM nor base64-encoded raw ed25519 public key", path)
+	return nil, fmt.Errorf("not PEM and not base64-encoded raw ed25519 public key")
 }
 
 // stripWhitespace removes ASCII whitespace from s. Used to tolerate

--- a/cmd/aileron/keyring_test.go
+++ b/cmd/aileron/keyring_test.go
@@ -7,7 +7,8 @@ import (
 	"crypto/x509"
 	"encoding/base64"
 	"encoding/pem"
-	"os"
+	"net/http"
+	"net/http/httptest"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -31,17 +32,6 @@ func genTestKey(t *testing.T) (ed25519.PublicKey, []byte) {
 	return pub, pemBytes
 }
 
-// writeKey writes data to a freshly-named temp file inside dir and
-// returns the path.
-func writeKey(t *testing.T, dir, name string, data []byte) string {
-	t.Helper()
-	path := filepath.Join(dir, name)
-	if err := os.WriteFile(path, data, 0o600); err != nil {
-		t.Fatalf("write %s: %v", path, err)
-	}
-	return path
-}
-
 // withTempHome points $HOME at a fresh temp dir for the test, so the
 // CLI's DefaultKeyringPath() lands inside the test's filesystem and
 // the test does not pollute the user's real ~/.aileron.
@@ -52,48 +42,68 @@ func withTempHome(t *testing.T) string {
 	return dir
 }
 
-// --- readPublicKey ---
+// withMockGitHubRaw stands up an httptest server that mimics
+// raw.githubusercontent.com for one or more
+// `<owner>/<repo>/HEAD/keys/publisher.pub` paths and points the CLI
+// at it for the duration of the test. Returns a setter the test can
+// use to swap a path's body mid-test (e.g. to simulate publisher key
+// rotation between two `keyring trust` calls).
+func withMockGitHubRaw(t *testing.T, paths map[string][]byte) func(path string, body []byte) {
+	t.Helper()
 
-func TestReadPublicKey_PEMHappyPath(t *testing.T) {
-	dir := t.TempDir()
+	bodies := make(map[string][]byte, len(paths))
+	for k, v := range paths {
+		bodies[k] = v
+	}
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body, ok := bodies[r.URL.Path]
+		if !ok {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/octet-stream")
+		w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+
+	prev := rawGitHubBase
+	rawGitHubBase = srv.URL
+	t.Cleanup(func() { rawGitHubBase = prev })
+
+	return func(path string, body []byte) {
+		bodies[path] = body
+	}
+}
+
+// --- decodePublicKey ---
+
+func TestDecodePublicKey_PEMHappyPath(t *testing.T) {
 	pub, pemBytes := genTestKey(t)
-	path := writeKey(t, dir, "publisher.pub", pemBytes)
-
-	got, err := readPublicKey(path)
+	got, err := decodePublicKey(pemBytes)
 	if err != nil {
-		t.Fatalf("readPublicKey: %v", err)
+		t.Fatalf("decodePublicKey: %v", err)
 	}
 	if !ed25519.PublicKey(got).Equal(pub) {
 		t.Errorf("returned key does not match generated public key")
 	}
 }
 
-func TestReadPublicKey_RawBase64(t *testing.T) {
-	dir := t.TempDir()
+func TestDecodePublicKey_RawBase64(t *testing.T) {
 	pub, _ := genTestKey(t)
-	encoded := base64.StdEncoding.EncodeToString(pub)
-	path := writeKey(t, dir, "publisher.b64", []byte(encoded+"\n"))
-
-	got, err := readPublicKey(path)
+	encoded := base64.StdEncoding.EncodeToString(pub) + "\n"
+	got, err := decodePublicKey([]byte(encoded))
 	if err != nil {
-		t.Fatalf("readPublicKey: %v", err)
+		t.Fatalf("decodePublicKey: %v", err)
 	}
 	if !ed25519.PublicKey(got).Equal(pub) {
 		t.Errorf("returned key does not match generated public key")
 	}
 }
 
-func TestReadPublicKey_MissingFile(t *testing.T) {
-	if _, err := readPublicKey(filepath.Join(t.TempDir(), "nope.pub")); err == nil {
-		t.Fatal("expected error for missing file")
-	}
-}
-
-func TestReadPublicKey_GarbageContents(t *testing.T) {
-	dir := t.TempDir()
-	path := writeKey(t, dir, "garbage", []byte("not a key"))
-	if _, err := readPublicKey(path); err == nil {
-		t.Fatal("expected error for garbage file contents")
+func TestDecodePublicKey_GarbageContents(t *testing.T) {
+	if _, err := decodePublicKey([]byte("not a key")); err == nil {
+		t.Fatal("expected error for garbage contents")
 	}
 }
 
@@ -102,11 +112,13 @@ func TestReadPublicKey_GarbageContents(t *testing.T) {
 func TestKeyringTrust_AddsKeyAndPersists(t *testing.T) {
 	home := withTempHome(t)
 	pub, pemBytes := genTestKey(t)
-	keyPath := writeKey(t, t.TempDir(), "publisher.pub", pemBytes)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/example/repo/HEAD/keys/publisher.pub": pemBytes,
+	})
 
 	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
 	rc := runKeyring(
-		[]string{"trust", "github://example/repo", keyPath},
+		[]string{"trust", "github://example/repo"},
 		stdout, stderr,
 	)
 	if rc != 0 {
@@ -116,7 +128,6 @@ func TestKeyringTrust_AddsKeyAndPersists(t *testing.T) {
 		t.Errorf("expected success message; got: %s", stdout.String())
 	}
 
-	// Reload from disk and verify the key is persisted.
 	keyringPath := filepath.Join(home, ".aileron", "keyring.json")
 	kr, err := cstore.LoadKeyring(keyringPath)
 	if err != nil {
@@ -130,21 +141,26 @@ func TestKeyringTrust_AddsKeyAndPersists(t *testing.T) {
 func TestKeyringTrust_DuplicateAddIsNoOp(t *testing.T) {
 	withTempHome(t)
 	_, pemBytes := genTestKey(t)
-	keyPath := writeKey(t, t.TempDir(), "publisher.pub", pemBytes)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/example/repo/HEAD/keys/publisher.pub": pemBytes,
+	})
 
 	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
-	if rc := runKeyring([]string{"trust", "github://example/repo", keyPath}, stdout, stderr); rc != 0 {
+	if rc := runKeyring([]string{"trust", "github://example/repo"}, stdout, stderr); rc != 0 {
 		t.Fatalf("first trust: rc = %d; stderr = %s", rc, stderr.String())
 	}
 
 	stdout.Reset()
 	stderr.Reset()
-	rc := runKeyring([]string{"trust", "github://example/repo", keyPath}, stdout, stderr)
+	rc := runKeyring([]string{"trust", "github://example/repo"}, stdout, stderr)
 	if rc != 0 {
 		t.Fatalf("re-trust rc = %d; stderr = %s", rc, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Already trusted") {
-		t.Errorf("expected duplicate-add to print 'Already trusted'; got: %s", stdout.String())
+	if !strings.Contains(stdout.String(), "Known publisher already trusted") {
+		t.Errorf("expected duplicate-add to print 'Known publisher already trusted'; got: %s", stdout.String())
+	}
+	if strings.Contains(stdout.String(), "✓ Trusted publisher") {
+		t.Errorf("re-trust should not print success message; got: %s", stdout.String())
 	}
 }
 
@@ -152,15 +168,21 @@ func TestKeyringTrust_RotationAddsAlongsideExisting(t *testing.T) {
 	home := withTempHome(t)
 	pub1, pem1 := genTestKey(t)
 	pub2, pem2 := genTestKey(t)
-	dir := t.TempDir()
-	key1 := writeKey(t, dir, "k1.pub", pem1)
-	key2 := writeKey(t, dir, "k2.pub", pem2)
+	setBody := withMockGitHubRaw(t, map[string][]byte{
+		"/example/repo/HEAD/keys/publisher.pub": pem1,
+	})
 
-	for _, kp := range []string{key1, key2} {
-		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
-		if rc := runKeyring([]string{"trust", "github://example/repo", kp}, stdout, stderr); rc != 0 {
-			t.Fatalf("trust %s: rc = %d; stderr = %s", kp, rc, stderr.String())
-		}
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "github://example/repo"}, stdout, stderr); rc != 0 {
+		t.Fatalf("first trust: rc = %d; stderr = %s", rc, stderr.String())
+	}
+
+	// Publisher rotates: same convention path, new key bytes.
+	setBody("/example/repo/HEAD/keys/publisher.pub", pem2)
+	stdout.Reset()
+	stderr.Reset()
+	if rc := runKeyring([]string{"trust", "github://example/repo"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rotated trust: rc = %d; stderr = %s", rc, stderr.String())
 	}
 
 	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
@@ -168,10 +190,10 @@ func TestKeyringTrust_RotationAddsAlongsideExisting(t *testing.T) {
 		t.Fatalf("LoadKeyring: %v", err)
 	}
 	if !kr.HasKey("github://example/repo", pub1) {
-		t.Error("first key not preserved after second trust")
+		t.Error("first key not preserved after rotation")
 	}
 	if !kr.HasKey("github://example/repo", pub2) {
-		t.Error("second key not added")
+		t.Error("rotated key not added")
 	}
 	if got := len(kr.Keys("github://example/repo")); got != 2 {
 		t.Errorf("len(keys) = %d, want 2", got)
@@ -180,22 +202,77 @@ func TestKeyringTrust_RotationAddsAlongsideExisting(t *testing.T) {
 
 func TestKeyringTrust_RejectsEmptyAuthority(t *testing.T) {
 	withTempHome(t)
-	_, pemBytes := genTestKey(t)
-	keyPath := writeKey(t, t.TempDir(), "publisher.pub", pemBytes)
-
 	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
-	if rc := runKeyring([]string{"trust", "", keyPath}, stdout, stderr); rc == 0 {
+	if rc := runKeyring([]string{"trust", ""}, stdout, stderr); rc == 0 {
 		t.Fatal("expected non-zero exit for empty authority")
 	}
 }
 
 func TestKeyringTrust_WrongArgCount(t *testing.T) {
-	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
-	if rc := runKeyring([]string{"trust", "only-one-arg"}, stdout, stderr); rc == 0 {
-		t.Fatal("expected non-zero exit for missing pubkey-file arg")
+	cases := [][]string{
+		{"trust"},
+		{"trust", "github://example/repo", "extra-arg"},
 	}
-	if !strings.Contains(stderr.String(), "usage:") {
-		t.Errorf("expected usage hint; got: %s", stderr.String())
+	for _, args := range cases {
+		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+		if rc := runKeyring(args, stdout, stderr); rc == 0 {
+			t.Errorf("args=%v: expected non-zero exit", args)
+		}
+		if !strings.Contains(stderr.String(), "usage:") {
+			t.Errorf("args=%v: expected usage hint; got: %s", args, stderr.String())
+		}
+	}
+}
+
+func TestKeyringTrust_RejectsNonGitHubScheme(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "gitlab://example/repo"}, stdout, stderr)
+	if rc == 0 {
+		t.Fatal("expected non-zero exit for non-github scheme")
+	}
+	if !strings.Contains(stderr.String(), "github://") {
+		t.Errorf("expected error to point at github:// support; got: %s", stderr.String())
+	}
+}
+
+func TestKeyringTrust_InvalidAuthority(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "not-a-uri"}, stdout, stderr); rc == 0 {
+		t.Fatal("expected non-zero exit for malformed authority")
+	}
+	if !strings.Contains(stderr.String(), "fetch publisher key") {
+		t.Errorf("expected fetch error context; got: %s", stderr.String())
+	}
+}
+
+func TestKeyringTrust_MissingConventionPath(t *testing.T) {
+	withTempHome(t)
+	withMockGitHubRaw(t, map[string][]byte{}) // every path returns 404
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "github://nope/no-such-repo"}, stdout, stderr)
+	if rc == 0 {
+		t.Fatal("expected non-zero exit when convention path is absent")
+	}
+	if !strings.Contains(stderr.String(), "404") {
+		t.Errorf("expected 404 in error; got: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "keys/publisher.pub") {
+		t.Errorf("expected error to name the convention path; got: %s", stderr.String())
+	}
+}
+
+func TestKeyringTrust_GarbageBody(t *testing.T) {
+	withTempHome(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/owner/repo/HEAD/keys/publisher.pub": []byte("not a key"),
+	})
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "github://owner/repo"}, stdout, stderr); rc == 0 {
+		t.Fatal("expected non-zero exit for garbage body")
 	}
 }
 
@@ -216,14 +293,14 @@ func TestKeyringList_PrintsTrustedAuthoritiesSorted(t *testing.T) {
 	withTempHome(t)
 	_, pem1 := genTestKey(t)
 	_, pem2 := genTestKey(t)
-	dir := t.TempDir()
-	for authority, body := range map[string][]byte{
-		"github://b/second": pem1,
-		"github://a/first":  pem2,
-	} {
-		path := writeKey(t, dir, strings.ReplaceAll(authority, "/", "_")+".pub", body)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/b/second/HEAD/keys/publisher.pub": pem1,
+		"/a/first/HEAD/keys/publisher.pub":  pem2,
+	})
+
+	for _, authority := range []string{"github://b/second", "github://a/first"} {
 		stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
-		if rc := runKeyring([]string{"trust", authority, path}, stdout, stderr); rc != 0 {
+		if rc := runKeyring([]string{"trust", authority}, stdout, stderr); rc != 0 {
 			t.Fatalf("seed %q: stderr = %s", authority, stderr.String())
 		}
 	}
@@ -248,10 +325,12 @@ func TestKeyringList_PrintsTrustedAuthoritiesSorted(t *testing.T) {
 func TestKeyringRevoke_RemovesAuthority(t *testing.T) {
 	home := withTempHome(t)
 	_, pemBytes := genTestKey(t)
-	keyPath := writeKey(t, t.TempDir(), "publisher.pub", pemBytes)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/example/repo/HEAD/keys/publisher.pub": pemBytes,
+	})
 
 	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
-	if rc := runKeyring([]string{"trust", "github://example/repo", keyPath}, stdout, stderr); rc != 0 {
+	if rc := runKeyring([]string{"trust", "github://example/repo"}, stdout, stderr); rc != 0 {
 		t.Fatalf("trust: rc = %d; stderr = %s", rc, stderr.String())
 	}
 

--- a/docs/src/content/docs/adr/0002-connector-model.md
+++ b/docs/src/content/docs/adr/0002-connector-model.md
@@ -228,6 +228,8 @@ The mechanics of how the user binds an abstract capability to a concrete resourc
 
 The publisher is implicit in the FQN's authority — `github://acme/gmail` is published by the `acme` GitHub organization. Signing keys are associated with that authority through the publication channel's own conventions (e.g., signing keys configured in the source repo or via sigstore identities tied to the org).
 
+**Convention: a connector repo MUST publish its current ed25519 public key at `keys/publisher.pub` on the source repo's default branch.** This is the path `aileron keyring trust <authority>` reads from when the user trusts a publisher. The file is the PEM form (`openssl pkey -pubout`) or raw 32-byte ed25519 public key in base64; the install tooling accepts either. Publishers who rotate keys commit a new `keys/publisher.pub` and consumers re-run `aileron keyring trust` to pick up the new key alongside the existing one.
+
 Install tooling verifies the binary's signature against keys authorized for the FQN's authority. A connector named `github://acme/gmail` signed by a key not associated with `acme`'s GitHub org is rejected at install. The `provenance_hash` field in the manifest records the binary's content hash at publish time; the runtime checks this matches actual on-disk bytes before every execution.
 
 The runtime treats signature *presence* as information, not as authorization. A signed connector and an unsigned connector both go through the same install consent path; signature status is shown to the user (and the Hub may use it to organize browse views), but a valid signature does not bypass any capability check or skip the consent prompt.

--- a/docs/src/content/docs/adr/0013-connector-hub-and-trust-distribution.md
+++ b/docs/src/content/docs/adr/0013-connector-hub-and-trust-distribution.md
@@ -104,7 +104,7 @@ Rejected for v0.x. Hub-as-registry creates hosting and abuse-moderation responsi
 
 ### Per-publisher trust as v0.x default — rejected
 
-The keyring stores per-publisher entries from day one. `aileron keyring trust github://owner key.pub` covers any repo under that owner.
+The keyring stores per-publisher (owner-level, not per-repo) entries from day one. `aileron keyring trust github://owner` covers any repo under that owner.
 
 Rejected for v0.x. With one connector per publisher today, per-publisher trust without Hub-driven enumeration means the user trusts a key for a publisher they cannot enumerate. The Microsoft model needs a discovery layer to be coherent. Per-repo trust is the right answer until the Hub is real and a publisher ships a second connector.
 

--- a/docs/src/content/docs/getting-started.md
+++ b/docs/src/content/docs/getting-started.md
@@ -15,7 +15,6 @@ By the end you will have asked Claude Code "summarize my five most recent emails
 - **Node.js 24 or newer** and **pnpm 11.0.8 (within the 11.x line)**. The webapp and docs targets build through `pnpm`, so `task build` will fail without them. The simplest setup is `corepack enable` after installing Node, then `corepack prepare pnpm@11.0.8 --activate`.
 - **[Claude Code](https://docs.claude.com/en/docs/claude-code/setup) installed and configured** with an Anthropic API key in `ANTHROPIC_API_KEY`. Aileron's launcher routes Claude Code's LLM calls through the local Aileron daemon, but it does not supply or replace your API key.
 - **A Google account.** Gmail and Calendar must be enabled. The OAuth dance opens in your default browser.
-- **`jq` and `openssl`** for the one-liner that trusts the connector's signing key.
 
 There is no `brew install aileron` yet — for now you build from source. That is the path this guide follows.
 
@@ -80,11 +79,10 @@ You don't need to think about the daemon explicitly during this guide. If you wa
 
 Every connector install verifies an ed25519 signature against keys you have explicitly trusted (per [ADR-0002](/adr/0002-connector-model)). Without a trusted key for the publisher's authority, install fails closed before fetching anything.
 
-Download the `aileron-connector-google` publisher key and trust it:
+Trust the `aileron-connector-google` publisher — the CLI fetches the key from `keys/publisher.pub` on the repo's default branch:
 
 ```sh
-curl -fsSLO https://raw.githubusercontent.com/ALRubinger/aileron-connector-google/main/keys/publisher.pub
-aileron keyring trust github://ALRubinger/aileron-connector-google publisher.pub
+aileron keyring trust github://ALRubinger/aileron-connector-google
 ```
 
 You should see:

--- a/docs/src/content/docs/guides/publishing-a-connector.md
+++ b/docs/src/content/docs/guides/publishing-a-connector.md
@@ -233,30 +233,17 @@ Each `vX.Y.Z` push produces one connector release plus one per-action release, a
 
 ## How users trust your publisher
 
-Aileron ships with **no trusted publishers by default** — the keyring is fail-closed (`internal/cstore/keyring_config.go`). Users opt in to your publisher by adding the public key to `~/.aileron/keyring.json`:
-
-```json
-{
-  "version": 1,
-  "publishers": {
-    "github://ALRubinger/aileron-connector-google": [
-      "BASE64_ENCODED_RAW_ED25519_PUBLIC_KEY"
-    ]
-  }
-}
-```
-
-The authority key is the FQN base (`<scheme>://<owner>/<repo>`); the value is a list of public keys (a list to support key rotation — register the new key alongside the old, switch signing, drop the old).
-
-The keyring stores the **raw 32-byte ed25519 public key**, base64-encoded. `keys/publisher.pub` in your repo is the PEM form (a 44-byte SubjectPublicKeyInfo wrapping the same 32 raw bytes); consumers extract the raw form once with:
+Aileron ships with **no trusted publishers by default** — the keyring is fail-closed (`internal/cstore/keyring_config.go`). Users opt in to your publisher by running:
 
 ```sh
-PUB_KEY_RAW=$(openssl pkey -in keys/publisher.pub -pubin -outform DER | tail -c 32 | base64)
+aileron keyring trust github://<owner>/<repo>
 ```
 
-…then paste `$PUB_KEY_RAW` into the keyring entry above.
+The CLI fetches `keys/publisher.pub` from the default branch of your repo (the convention path ratified by [ADR-0002](/adr/0002-connector-model)), parses the key, and registers it under the authority `github://<owner>/<repo>`. **Committing `keys/publisher.pub` to your default branch is what makes that one-liner work** — the publisher key MUST be there, with that exact path, for users to trust you without manual ceremony.
 
-Document the extraction + registration steps in your connector's README so users know exactly what to copy into their keyring. Without an entry in the keyring for your authority, `aileron connector install` fails closed with `signature_failure` — unsigned or unverified binaries never reach disk.
+The keyring is a list per authority (to support rotation — register the new key alongside the old, switch signing, drop the old). Re-running `aileron keyring trust <authority>` after the publisher commits a new `keys/publisher.pub` adds the new key alongside the existing one; an already-trusted key is detected and reported as a no-op.
+
+Without an entry in the keyring for your authority, `aileron connector install` fails closed with `signature_failure` — unsigned or unverified binaries never reach disk.
 
 ## Action templates
 
@@ -302,14 +289,9 @@ Fetches a list of recent Gmail messages for the authenticated user.
 Once published, a user runs:
 
 ```sh
-# Trust the publisher (one-time per user)
-PUB_KEY_RAW=$(curl -fsSL https://raw.githubusercontent.com/ALRubinger/aileron-connector-google/main/keys/publisher.pub \
-  | openssl pkey -pubin -outform DER | tail -c 32 | base64)
-
-mkdir -p ~/.aileron
-jq -n --arg key "$PUB_KEY_RAW" \
-  '{version:1, publishers:{"github://ALRubinger/aileron-connector-google":[$key]}}' \
-  > ~/.aileron/keyring.json
+# Trust the publisher (one-time per user — fetches keys/publisher.pub
+# from the default branch of your repo).
+aileron keyring trust github://ALRubinger/aileron-connector-google
 
 # Install the connector at a specific tag
 aileron connector install github://ALRubinger/aileron-connector-google@0.0.1


### PR DESCRIPTION
## Summary

W1 of issue #550 (the precursor for parts of W3 and W6).

- `aileron keyring trust github://owner/repo` (one arg) now auto-fetches the publisher's ed25519 public key from `keys/publisher.pub` on the source repo's default branch and trusts it.
- Drops the previous `curl + jq + openssl` extraction users had to do before trusting a connector.
- The two-arg form (`aileron keyring trust <authority> <pubkey-file>`) is removed — the convention is the only path.
- Re-running with an already-trusted key prints `Known publisher already trusted: <authority>` and exits 0 (was `Already trusted`).
- Non-`github://` schemes get a clear error (`auto-fetch supports github:// authorities only`).

## Spec

- ADR-0002 ratifies the convention: a connector repo MUST publish its current ed25519 public key at `keys/publisher.pub` on the source repo's default branch.
- `publishing-a-connector.md` rewrites the "How users trust your publisher" section around the one-liner; the manual extraction snippet in the end-to-end install flow is replaced with `aileron keyring trust github://owner/repo`.
- ADR-0013's rejected-alternative snippet had a stale two-arg syntax — fixed.
- The current Getting Started guide's §3 collapses to the one-liner; `jq` and `openssl` prereqs (which only existed for that one snippet) drop.

## Test plan

- [x] `go test ./cmd/aileron/...` — green; package coverage 86.0% (`fetchPublisherKey` 90%, `decodePublicKey` 88.9%, `runKeyringTrust` 81.8%).
- [x] httptest-stubbed tests cover: happy path, key rotation (publisher commits new key, consumer re-runs), already-trusted no-op, non-github scheme rejection, malformed authority, missing convention path (404), garbage body.
- [x] All four module builds clean (`cmd/aileron`, `cmd/aileron-enclave`, `cmd/aileron-mcp`, `cmd/aileron-sh`, `internal`, `sdk/go`, `test/integration`).
- [ ] Reviewer: skim ADR-0002 convention paragraph and the publishing-a-connector "How users trust your publisher" rewrite for voice consistency.

Refs #550. Unblocks W3 (drop `jq`/`openssl` prereqs in the wider preflight rewrite) and W6 (vault prompt now triggers earlier on `keyring trust`, since auto-fetch is the first vault-touching step in the slim flow).

🤖 Generated with [Claude Code](https://claude.com/claude-code)