### PR TITLE
docs(getting-started): rename to "Prepare for Liftoff" and add intro/expectations cards

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -4,29 +4,19 @@ description: "Build Aileron from source, install the Google connector, bind a Go
 order: 2
 ---
 
-import * as Card from '$lib/components/ui/card/index.js';
+import HighlightCard from '$lib/components/ui/highlight-card.svelte';
 
-<Card.Root class="my-8 border-l-4 border-l-primary text-base">
-<Card.Header>
-<Card.Title class="text-lg">Your first flight</Card.Title>
-</Card.Header>
-<Card.Content>
+<HighlightCard title="Your first flight">
 
 Let's take your first flight with Aileron. In under 5 minutes, you'll be securely equipping Claude Code to use your real Gmail and Calendar account. Along the way we'll introduce Connectors and Actions, a joyful way to add powerful features to your agent. Your agent never sees the keys to your private services, and you always retain approval before taking an irreversible action like sending an email. Let's take off.
 
-</Card.Content>
-</Card.Root>
+</HighlightCard>
 
-<Card.Root class="my-8 bg-muted/50 text-base">
-<Card.Header>
-<Card.Title class="text-lg">What to expect</Card.Title>
-</Card.Header>
-<Card.Content>
+<HighlightCard title="What to expect" variant="muted">
 
 Estimated time: 5 minutes. What happens: Summarize five most recent emails, draft an email, execute secured actions in a sandboxed environment, get proof of the audit trail for what was done — all without giving your agent or LLM direct access to your Google Account.
 
-</Card.Content>
-</Card.Root>
+</HighlightCard>
 
 This guide walks the full end-to-end flow on a fresh machine: build the binaries, trust a publisher, install the [`aileron-connector-google`](https://github.com/ALRubinger/aileron-connector-google) reference connector, bind a real Google account, and run [Claude Code](https://docs.claude.com/en/docs/claude-code) with Gmail and Calendar actions exposed via Aileron's MCP server.
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -1,8 +1,32 @@
 ---
-title: "Getting Started"
+title: "Prepare for Liftoff"
 description: "Build Aileron from source, install the Google connector, bind a Google account via OAuth, and launch Claude Code with Gmail and Calendar actions wired in."
 order: 2
 ---
+
+import * as Card from '$lib/components/ui/card/index.js';
+
+<Card.Root class="my-8 border-l-4 border-l-primary text-base">
+<Card.Header>
+<Card.Title class="text-lg">Your first flight</Card.Title>
+</Card.Header>
+<Card.Content>
+
+Let's take your first flight with Aileron. In under 5 minutes, you'll be securely equipping Claude Code to use your real Gmail and Calendar account. Along the way we'll introduce Connectors and Actions, a joyful way to add powerful features to your agent. Your agent never sees the keys to your private services, and you always retain approval before taking an irreversible action like sending an email. Let's take off.
+
+</Card.Content>
+</Card.Root>
+
+<Card.Root class="my-8 bg-muted/50 text-base">
+<Card.Header>
+<Card.Title class="text-lg">What to expect</Card.Title>
+</Card.Header>
+<Card.Content>
+
+Estimated time: 5 minutes. What happens: Summarize five most recent emails, draft an email, execute secured actions in a sandboxed environment, get proof of the audit trail for what was done — all without giving your agent or LLM direct access to your Google Account.
+
+</Card.Content>
+</Card.Root>
 
 This guide walks the full end-to-end flow on a fresh machine: build the binaries, trust a publisher, install the [`aileron-connector-google`](https://github.com/ALRubinger/aileron-connector-google) reference connector, bind a real Google account, and run [Claude Code](https://docs.claude.com/en/docs/claude-code) with Gmail and Calendar actions exposed via Aileron's MCP server.
 

--- a/docs/src/content/docs/privacy.mdx
+++ b/docs/src/content/docs/privacy.mdx
@@ -3,13 +3,9 @@ title: "Privacy Policy"
 description: "Aileron is open source and runs locally on your computer. We don't capture or store your data — and you can read the code to verify it."
 ---
 
-import * as Card from '$lib/components/ui/card/index.js';
+import HighlightCard from '$lib/components/ui/highlight-card.svelte';
 
-<Card.Root class="my-8 border-l-4 border-l-primary text-base">
-<Card.Header>
-<Card.Title class="text-lg">The short version</Card.Title>
-</Card.Header>
-<Card.Content>
+<HighlightCard title="The short version">
 
 Aileron is an open-source project, stewarded by its creator. No company or organization runs it. The purpose of Aileron is to give you security and confidence that no agent, no LLM, and not Aileron itself has direct access to your protected information beyond what you explicitly provide.
 
@@ -21,8 +17,7 @@ Aileron is an open-source project, stewarded by its creator. No company or organ
 - You are not the product.
 - The Aileron website and runtime use standard, anonymous web analytics. That's it.
 
-</Card.Content>
-</Card.Root>
+</HighlightCard>
 
 ## What this policy covers
 

--- a/docs/src/content/docs/terms.mdx
+++ b/docs/src/content/docs/terms.mdx
@@ -3,13 +3,9 @@ title: "Terms of Use"
 description: "Aileron is free, open-source software, offered as-is. These Terms cover what that means for both of us, in plain English."
 ---
 
-import * as Card from '$lib/components/ui/card/index.js';
+import HighlightCard from '$lib/components/ui/highlight-card.svelte';
 
-<Card.Root class="my-8 border-l-4 border-l-primary text-base">
-<Card.Header>
-<Card.Title class="text-lg">The short version</Card.Title>
-</Card.Header>
-<Card.Content>
+<HighlightCard title="The short version">
 
 Aileron is free, open-source software, offered as-is by its maintainer. These Terms cover what that means for both of us. You may use Aileron, and what you and your agent do with it is your responsibility.
 
@@ -19,8 +15,7 @@ Aileron is free, open-source software, offered as-is by its maintainer. These Te
 - Your use of those services (Gmail, Slack, the LLM provider you've chosen, and so on) is governed by their terms, not these.
 - Don't use Aileron for things that are illegal or that harm other people.
 
-</Card.Content>
-</Card.Root>
+</HighlightCard>
 
 ## What these Terms cover
 

--- a/docs/src/lib/components/ui/highlight-card.svelte
+++ b/docs/src/lib/components/ui/highlight-card.svelte
@@ -1,0 +1,45 @@
+<script lang="ts">
+  import type { Snippet } from 'svelte';
+  import * as Card from '$lib/components/ui/card/index.js';
+  import { cn } from '$lib/utils.js';
+
+  /**
+   * Aileron-custom HighlightCard — a prominent panel for in-page
+   * summaries / orientation callouts. Wraps shadcn-svelte's Card with
+   * the standardized "primary" (left-border accent) and "muted"
+   * (subtle background) styling reused across the privacy policy,
+   * terms of use, and Getting Started pages.
+   *
+   * Default variant matches the privacy/terms "short version" boxes;
+   * the muted variant reads as a softer, secondary callout that sits
+   * alongside a primary one (e.g. an "expectations" panel below an
+   * intro panel).
+   */
+  type Variant = 'primary' | 'muted';
+
+  let {
+    title,
+    variant = 'primary',
+    class: className,
+    children,
+  }: {
+    title: string;
+    variant?: Variant;
+    class?: string;
+    children: Snippet;
+  } = $props();
+
+  const variantClass: Record<Variant, string> = {
+    primary: 'border-l-4 border-l-primary',
+    muted: 'bg-muted/50',
+  };
+</script>
+
+<Card.Root class={cn('my-8 text-base', variantClass[variant], className)}>
+  <Card.Header>
+    <Card.Title class="text-lg">{title}</Card.Title>
+  </Card.Header>
+  <Card.Content>
+    {@render children()}
+  </Card.Content>
+</Card.Root>


### PR DESCRIPTION
## Summary

- Renames `docs/src/content/docs/getting-started.md` to `getting-started.mdx` and updates the frontmatter title to "Prepare for Liftoff" (description and order untouched).
- Adds a prominent intro card ("Your first flight") above the existing intro paragraph, reusing the same shadcn-svelte Card pattern (`border-l-4 border-l-primary text-base`) that `privacy.mdx` and `terms.mdx` already use for their "short version" panels.
- Adds a secondary expectations card ("What to expect") below the intro card, using `bg-muted/50` instead of the left-border accent so it reads as less prominent in the existing tailwind/shadcn-svelte conventions.

## Test plan

- [x] `task build:docs` succeeds (57 pages built, no errors).
- [x] Generated `docs/dist/getting-started/index.html` contains the new title "Prepare for Liftoff" and both card titles.
- [x] Generated HTML preserves the distinct card styling: `border-l-primary` on the intro card, `bg-muted/50` on the expectations card.
- [ ] Visual sanity check in `task dev:docs` — confirm intro card reads as primary and expectations card reads as secondary.
- [x] No other sections of `getting-started.mdx` are touched (sibling W3/W4/W5/W6 PRs own those).

Refs #550 (W2). One of several parallel PRs for the umbrella issue; expect to rebase on top of merged siblings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)