### PR TITLE
docs(getting-started): condense section 1 and strip ADR references

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -86,29 +86,15 @@ By the end you will have asked Claude Code "summarize my five most recent emails
 
 - **A Google account.** Gmail and Calendar must be enabled. The OAuth dance opens in your default browser.
 
-There is no `brew install aileron` yet — for now you build from source. That is the path this guide follows.
-
 ## 1. Build the binaries
+
+> **Note:** there is no `brew install aileron` yet. This guide builds from source; package distribution is coming shortly.
 
 ```sh
 git clone https://github.com/ALRubinger/aileron.git && \
   cd aileron && \
-  task build:cli build:server build:mcp build:sh
-```
-
-This produces four binaries in `build/`:
-
-| Binary | Purpose |
-|---|---|
-| `aileron` | The CLI you use for install, binding, status, audit, launch, and `aileron daemon start/stop/status`. |
-| `server` | The user-scoped local daemon (per [ADR-0012](/adr/0012-local-daemon-architecture)). Auto-spawned by the CLI on first need; you don't run it directly during normal use. |
-| `aileron-mcp` | The MCP server that exposes installed actions to the agent. `aileron launch` resolves it as a sibling of the `aileron` binary. |
-| `aileron-sh` | The policy-enforced shell shim used by `aileron launch`. |
-
-Put the build directory on your `PATH` so the launcher can find `aileron-mcp` next to `aileron`:
-
-```sh
-export PATH="$PWD/build:$PATH"
+  task build:cli build:server build:mcp build:sh && \
+  export PATH="$PWD/build:$PATH"
 ```
 
 Verify:
@@ -117,9 +103,15 @@ Verify:
 aileron version
 ```
 
+You should see something like:
+
+```
+aileron dev (f66e51c)
+```
+
 ## 2. Trust the connector's publisher key
 
-Every connector install verifies an ed25519 signature against keys you have explicitly trusted (per [ADR-0002](/adr/0002-connector-model)). Without a trusted key for the publisher's authority, install fails closed before fetching anything.
+Every connector install verifies an ed25519 signature against keys you have explicitly trusted. Without a trusted key for the publisher's authority, install fails closed before fetching anything.
 
 Trust the `aileron-connector-google` publisher. The CLI fetches the key from `keys/publisher.pub` on the repo's default branch:
 
@@ -169,7 +161,7 @@ Pick the latest release tag from [the connector's releases page](https://github.
 aileron action add github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6
 ```
 
-Aileron resolves the action's connector dependency, fetches the connector tarball from the GitHub release, verifies the signature against your trusted key, computes the content hash, and walks you through a [consent prompt](/adr/0007-install-consent) for each new connector and the action itself. Confirm each step.
+Aileron resolves the action's connector dependency, fetches the connector tarball from the GitHub release, verifies the signature against your trusted key, computes the content hash, and walks you through a consent prompt for each new connector and the action itself. Confirm each step.
 
 When the install completes, the action file is at `~/.aileron/actions/list-recent-emails.md` (you own it — edit it freely) and the connector is in the content-addressed store at `~/.aileron/store/`.
 
@@ -275,7 +267,7 @@ aileron audit list           # action-execution audit log: every call, with inpu
 
 `aileron status` is configuration-shaped: what you've installed, what your policy says, where credentials live. `aileron daemon status` is process-shaped: which daemon process the CLI is talking to and whether its vault is unlocked. They overlap on vault state because both surface it for different reasons; the rest is disjoint.
 
-The audit log is the receipt for everything the agent did on your behalf. Each entry names the action, the connector version, the binding identity, the duration, and the disposition — recorded under `~/.aileron/audit/audit-YYYY-MM-DD.jsonl` (daily-rotated, user-scope per [ADR-0012](/adr/0012-local-daemon-architecture)). Combined with the install consent log, you can answer two questions for any action: "did I authorize this capability?" and "what did the agent actually do with it?"
+The audit log is the receipt for everything the agent did on your behalf. Each entry names the action, the connector version, the binding identity, the duration, and the disposition — recorded under `~/.aileron/audit/audit-YYYY-MM-DD.jsonl` (daily-rotated, user-scope). Combined with the install consent log, you can answer two questions for any action: "did I authorize this capability?" and "what did the agent actually do with it?"
 
 For end-to-end timing or correlation with the rest of your agent stack, Aileron also emits OpenTelemetry traces — opt-in via `AILERON_OTEL_ENABLED=true AILERON_OTEL_EXPORTER=stdout`. See [Observability](/guides/observability/) for what gets emitted, the span attribute schema, and the env vars that control both the audit and tracing surfaces.
 


### PR DESCRIPTION
## Summary

Final cleanup of the umbrella #550 acceptance criteria, combining **W5** (Section 1 condensation, four-binaries table removal) and the lingering ADR-reference cleanup into one PR.

### Section 1 (W5)

- Removed the four-binaries table (`aileron` / `server` / `aileron-mcp` / `aileron-sh`) and the "what each one does" prose.
- Inlined `export PATH="$PWD/build:$PATH"` into the build chain so the whole setup is one copy-pasteable block.
- Added the expected `aileron version` output (`aileron dev (f66e51c)`) so the reader can self-verify.
- Moved the "no `brew install aileron` yet" sentence into a Note callout, with the umbrella-spec framing ("this guide builds from source; package distribution is coming shortly").

### ADR cleanup

Stripped the four `[ADR-NNNN]` links the umbrella's "hide internal architecture" criterion was still violating after W1–W6 landed:

- §2 Trust: drop `(per [ADR-0002])` parenthetical.
- §3 Install: drop the link target on `consent prompt`; keep the text inline.
- §7 Inspect: drop `per [ADR-0012]` qualifier on the audit log path description.
- ADR-0012 in the four-binaries table dropped along with the table itself.

## #549 coordination

This PR strips the four-binaries table without picking a destination for the content. The table data is recoverable from git history (this commit's parent) and from the binary names themselves; when #549 lands a Development & Contribution section, the table can be restored there from the git record. The user explicitly authorized proceeding without waiting for #549.

## Out of scope (flagged for follow-up)

The umbrella's "no daemon mentions" criterion is partially still violated:

- §5's "What happened under the hood" bullet list leaks the daemon, `~/.aileron/daemon.json`, the `POST /v1/sessions` endpoint, ULID, `ANTHROPIC_BASE_URL`, and `aileron-mcp` internals.
- The Preflight Checklist's Claude Code prereq line names "the local Aileron daemon" while explaining the API key requirement.

These weren't part of W5 or the ADR-cleanup mandate. Suggested as a small standalone follow-up.

## Test plan

- [x] `task build:docs` green; 57 pages built.
- [x] Article body of `getting-started/index.html` confirmed clean of `ADR-`, `/adr/`, four-binaries table, and the `server` / `aileron-sh` binary names. Two `aileron-mcp` mentions remain in §5 (out-of-scope, flagged above).
- [x] Note callout renders; expected `aileron version` output line renders.
- [ ] Reviewer: read §1 top-to-bottom on a fresh machine; confirm one `task build:...` invocation produces a binary that responds to `aileron version`.

Closes #550 W5. Refs #549.

🤖 Generated with [Claude Code](https://claude.com/claude-code)