### PR TITLE
fix(intercept): decompress gzipped upstream response bodies

### DIFF
--- a/internal/intercept/anthropic.go
+++ b/internal/intercept/anthropic.go
@@ -221,7 +221,11 @@ func (e *Engine) sendAnthropic(ctx context.Context, orig *http.Request, body []b
 	if err != nil {
 		return 0, nil, nil, err
 	}
-	return resp.StatusCode, resp.Header.Clone(), respBody, nil
+	respBody, headers, err := decompressUpstreamBody(resp.Header.Clone(), respBody)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	return resp.StatusCode, headers, respBody, nil
 }
 
 // parseAnthropicResponse extracts the assistant content blocks and

--- a/internal/intercept/helpers.go
+++ b/internal/intercept/helpers.go
@@ -1,9 +1,15 @@
 package intercept
 
 import (
+	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
+	"fmt"
+	"io"
 	"net/http"
+	"strconv"
+	"strings"
 
 	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/failure"
@@ -91,6 +97,50 @@ func passThrough(w http.ResponseWriter, status int, headers http.Header, body []
 	}
 	w.WriteHeader(status)
 	w.Write(body)
+}
+
+// decompressUpstreamBody returns the body in its decoded form when
+// the upstream applied a Content-Encoding the gateway recognizes.
+// v1 supports `gzip` (the only encoding observed in the wild from
+// Anthropic and OpenAI), plus the no-op `identity` and absent header.
+//
+// The Claude / OpenAI SDKs send `Accept-Encoding: gzip` and
+// copyForwardableHeaders forwards it upstream verbatim. Go's
+// http.Transport only auto-decompresses when *it* added the header,
+// so when the agent's SDK sets it explicitly the response body comes
+// back compressed and io.ReadAll yields the raw gzipped bytes — which
+// then fails JSON parse and breaks the gateway's tool-call intercept
+// for that round.
+//
+// On a recognized encoding the returned headers strip Content-Encoding
+// and rewrite Content-Length so passThrough emits a coherent
+// uncompressed response to the agent. Unknown encodings (e.g. `br`,
+// `zstd`, `deflate`) and absent headers return the body and headers
+// unchanged — the parse path will still fail and log a body preview,
+// matching the pre-fix behavior for those cases.
+func decompressUpstreamBody(headers http.Header, body []byte) ([]byte, http.Header, error) {
+	enc := strings.TrimSpace(strings.ToLower(headers.Get("Content-Encoding")))
+	if enc == "" || enc == "identity" || enc != "gzip" {
+		return body, headers, nil
+	}
+	if len(body) == 0 {
+		// gzip.NewReader on an empty stream returns io.EOF; treat
+		// that as "nothing to decompress" rather than an error.
+		return body, headers, nil
+	}
+	gr, err := gzip.NewReader(bytes.NewReader(body))
+	if err != nil {
+		return nil, nil, fmt.Errorf("gzip reader: %w", err)
+	}
+	defer gr.Close()
+	decoded, err := io.ReadAll(gr)
+	if err != nil {
+		return nil, nil, fmt.Errorf("gzip read: %w", err)
+	}
+	out := headers.Clone()
+	out.Del("Content-Encoding")
+	out.Set("Content-Length", strconv.Itoa(len(decoded)))
+	return decoded, out, nil
 }
 
 // errorBody is the JSON shape this package writes for gateway-side

--- a/internal/intercept/helpers_test.go
+++ b/internal/intercept/helpers_test.go
@@ -2,6 +2,7 @@ package intercept
 
 import (
 	"bytes"
+	"compress/gzip"
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
@@ -14,6 +15,138 @@ import (
 	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/retry"
 )
+
+// gzipBytes returns the gzip-compressed encoding of s — used by tests
+// that simulate an upstream that honored `Accept-Encoding: gzip`.
+func gzipBytes(t *testing.T, s string) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gw := gzip.NewWriter(&buf)
+	if _, err := gw.Write([]byte(s)); err != nil {
+		t.Fatalf("gzip write: %v", err)
+	}
+	if err := gw.Close(); err != nil {
+		t.Fatalf("gzip close: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// --- decompressUpstreamBody ---
+
+func TestDecompressUpstreamBody_GzipDecodesAndStripsHeader(t *testing.T) {
+	plain := `{"type":"message","content":[]}`
+	encoded := gzipBytes(t, plain)
+	in := http.Header{}
+	in.Set("Content-Encoding", "gzip")
+	in.Set("Content-Length", "999")
+	in.Set("X-Pass-Through", "keep")
+
+	body, headers, err := decompressUpstreamBody(in, encoded)
+	if err != nil {
+		t.Fatalf("decompressUpstreamBody: %v", err)
+	}
+	if string(body) != plain {
+		t.Errorf("body = %q, want %q", body, plain)
+	}
+	if got := headers.Get("Content-Encoding"); got != "" {
+		t.Errorf("Content-Encoding still present: %q", got)
+	}
+	if got := headers.Get("Content-Length"); got != "31" {
+		t.Errorf("Content-Length = %q, want %d", got, len(plain))
+	}
+	if got := headers.Get("X-Pass-Through"); got != "keep" {
+		t.Errorf("unrelated header dropped; X-Pass-Through = %q", got)
+	}
+	// Helper must not mutate the caller's input headers.
+	if in.Get("Content-Encoding") != "gzip" {
+		t.Error("input headers mutated")
+	}
+}
+
+func TestDecompressUpstreamBody_IdentityPassThrough(t *testing.T) {
+	plain := []byte(`{"type":"message"}`)
+	in := http.Header{}
+	in.Set("Content-Encoding", "identity")
+
+	body, headers, err := decompressUpstreamBody(in, plain)
+	if err != nil {
+		t.Fatalf("decompressUpstreamBody: %v", err)
+	}
+	if !bytes.Equal(body, plain) {
+		t.Errorf("body changed; got %q", body)
+	}
+	if headers.Get("Content-Encoding") != "identity" {
+		t.Error("identity header should be preserved when unchanged")
+	}
+}
+
+func TestDecompressUpstreamBody_NoEncodingHeader(t *testing.T) {
+	plain := []byte(`{"type":"message"}`)
+	body, _, err := decompressUpstreamBody(http.Header{}, plain)
+	if err != nil {
+		t.Fatalf("decompressUpstreamBody: %v", err)
+	}
+	if !bytes.Equal(body, plain) {
+		t.Errorf("body changed; got %q", body)
+	}
+}
+
+func TestDecompressUpstreamBody_UnknownEncodingPassThrough(t *testing.T) {
+	// Brotli / zstd / deflate aren't supported. We pass through
+	// unchanged so the existing parse-failure path logs and the
+	// agent's SDK can still try to decode if it knows the encoding.
+	in := http.Header{}
+	in.Set("Content-Encoding", "br")
+	original := []byte("opaque-brotli-bytes")
+
+	body, headers, err := decompressUpstreamBody(in, original)
+	if err != nil {
+		t.Fatalf("decompressUpstreamBody: %v", err)
+	}
+	if !bytes.Equal(body, original) {
+		t.Error("body changed for unknown encoding")
+	}
+	if headers.Get("Content-Encoding") != "br" {
+		t.Error("Content-Encoding stripped for unknown encoding")
+	}
+}
+
+func TestDecompressUpstreamBody_GzipMixedCaseAndWhitespace(t *testing.T) {
+	plain := `{"ok":true}`
+	in := http.Header{}
+	in.Set("Content-Encoding", "  GZIP  ")
+
+	body, _, err := decompressUpstreamBody(in, gzipBytes(t, plain))
+	if err != nil {
+		t.Fatalf("decompressUpstreamBody: %v", err)
+	}
+	if string(body) != plain {
+		t.Errorf("body = %q, want %q", body, plain)
+	}
+}
+
+func TestDecompressUpstreamBody_GzipEmptyBodyIsNoOp(t *testing.T) {
+	in := http.Header{}
+	in.Set("Content-Encoding", "gzip")
+	body, headers, err := decompressUpstreamBody(in, nil)
+	if err != nil {
+		t.Fatalf("expected no error on empty gzip body; got %v", err)
+	}
+	if len(body) != 0 {
+		t.Errorf("body = %q, want empty", body)
+	}
+	if headers.Get("Content-Encoding") != "gzip" {
+		t.Error("empty-body short-circuit should not strip headers")
+	}
+}
+
+func TestDecompressUpstreamBody_GzipMalformedReturnsError(t *testing.T) {
+	in := http.Header{}
+	in.Set("Content-Encoding", "gzip")
+	if _, _, err := decompressUpstreamBody(in, []byte("not-actually-gzip")); err == nil {
+		t.Fatal("expected error on malformed gzip body")
+	}
+}
 
 // --- truncateForLog ---
 

--- a/internal/intercept/intercept_test.go
+++ b/internal/intercept/intercept_test.go
@@ -2,6 +2,7 @@ package intercept
 
 import (
 	"bytes"
+	"compress/gzip"
 	"context"
 	"encoding/json"
 	"fmt"
@@ -599,6 +600,59 @@ func TestHandleAnthropic_InterceptsAileronToolUse(t *testing.T) {
 	contentBlocks := user["content"].([]any)
 	if contentBlocks[0].(map[string]any)["type"] != "tool_result" {
 		t.Errorf("expected tool_result block; got %v", contentBlocks[0])
+	}
+}
+
+// --- Anthropic: gzipped upstream still intercepts tool_use ---
+
+// TestHandleAnthropic_GzippedUpstreamIntercepted regresses a real-
+// world stall: the Claude SDK forwards `Accept-Encoding: gzip`,
+// Anthropic returns gzipped bodies, and pre-fix the gateway
+// io.ReadAll'd the raw gzipped bytes and JSON-parse-failed every
+// round, breaking tool-call interception and forcing the agent
+// onto its much slower MCP fallback path. Drafting a single email
+// went from seconds to multi-minute stalls.
+func TestHandleAnthropic_GzippedUpstreamIntercepted(t *testing.T) {
+	calls := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		body := `{"id":"msg2","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"Sent."}],"stop_reason":"end_turn"}`
+		if calls == 0 {
+			body = `{"id":"msg1","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"tu_1","name":"ship_update","input":{"channel":"#eng"}}],"stop_reason":"tool_use"}`
+		}
+		calls++
+		var buf bytes.Buffer
+		gw := gzip.NewWriter(&buf)
+		gw.Write([]byte(body))
+		gw.Close()
+		w.Header().Set("Content-Type", "application/json")
+		w.Header().Set("Content-Encoding", "gzip")
+		w.WriteHeader(http.StatusOK)
+		w.Write(buf.Bytes())
+	}))
+	t.Cleanup(srv.Close)
+
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{result: action.Result{Content: `{"posted":true}`}}
+	e := engineFor(t, "", srv.URL, store, exec)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1024,"messages":[{"role":"user","content":"ship"}]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if len(exec.calls) != 1 {
+		t.Errorf("executor calls = %d; want 1 — gateway failed to parse the gzipped tool_use response", len(exec.calls))
+	}
+	if !strings.Contains(w.Body.String(), `"text":"Sent."`) {
+		t.Errorf("agent didn't see final text: %s", w.Body.String())
+	}
+	// passThrough must have stripped Content-Encoding, since the body
+	// we just emitted to the agent is the decompressed form.
+	if got := w.Header().Get("Content-Encoding"); got != "" {
+		t.Errorf("Content-Encoding leaked to agent: %q", got)
 	}
 }
 

--- a/internal/intercept/openai.go
+++ b/internal/intercept/openai.go
@@ -252,7 +252,11 @@ func (e *Engine) sendOpenAI(ctx context.Context, orig *http.Request, body []byte
 	if err != nil {
 		return 0, nil, nil, err
 	}
-	return resp.StatusCode, resp.Header.Clone(), respBody, nil
+	respBody, headers, err := decompressUpstreamBody(resp.Header.Clone(), respBody)
+	if err != nil {
+		return 0, nil, nil, err
+	}
+	return resp.StatusCode, headers, respBody, nil
 }
 
 // parseOpenAIChoice extracts the first choice's assistant message and


### PR DESCRIPTION
## Summary

Fixes the multi-minute stall when an agent under `aileron launch` makes tool-using LLM calls (most visible: drafting emails through Claude).

The gateway's intercept layer was reading upstream response bodies via `io.ReadAll(resp.Body)` and JSON-parsing them. The Claude / OpenAI SDKs send `Accept-Encoding: gzip`; `copyForwardableHeaders` forwarded it verbatim; Go's `http.Transport` only auto-decompresses when *it* added that header, so the bytes came back gzip-compressed (`\x1f\x8b\x08...`). Every round, the parse failed, the gateway logged `upstream returned unparseable success body`, and `passThrough` sent the gzipped bytes to the agent.

The agent's SDK still decoded them, so calls eventually completed, but the gateway was blind to tool calls. Tool dispatch fell back to the agent's MCP roundtrip path, doubling every tool invocation. A single email draft hit ~40 parse failures and accumulated to multi-minute stalls.

## Fix

Add `decompressUpstreamBody` to `internal/intercept/helpers.go`. When the upstream response carries `Content-Encoding: gzip`, decompress the body, strip the encoding header, rewrite `Content-Length`, and hand the decoded bytes to the parser. Wired into both `sendAnthropic` and `sendOpenAI`.

- **Identity / absent encoding**: passthrough unchanged.
- **Unknown encodings** (`br`, `zstd`, `deflate`): passthrough unchanged. The existing parse-failure log keeps catching those, matching pre-fix behavior. Adding brotli or zstd is a future enhancement; gzip is the only encoding observed in the wild from Anthropic and OpenAI.
- **Empty gzip body**: short-circuit (gzip.NewReader returns io.EOF on an empty stream).

## Test plan

- [x] `go test ./intercept/...` — green; package coverage 91.5% (was ~89%).
- [x] 7 unit tests on `decompressUpstreamBody`: gzip decode + header rewrite, identity passthrough, no-encoding passthrough, unknown-encoding (br) passthrough, mixed-case + whitespace tolerance, empty-body short-circuit, malformed-gzip error.
- [x] 1 integration regression test (`TestHandleAnthropic_GzippedUpstreamIntercepted`): full intercept flow against a scripted upstream returning a `tool_use` response with `Content-Encoding: gzip`. Asserts (a) the executor was invoked exactly once (proving the gateway parsed the gzipped tool_use), and (b) the re-emitted response to the agent has no `Content-Encoding` header.
- [x] Build clean across all modules.

## How this was caught

Diagnosed live from a stalled `aileron launch claude` session by reading `~/.aileron/daemon.log`: 39 `upstream returned unparseable success body` entries in 4 minutes, all with `body_preview` starting with the gzip magic number `\x1f\x8b\x08`. PR #541's logging change (which added body previews on parse failure) was load-bearing for the diagnosis.

🤖 Generated with [Claude Code](https://claude.com/claude-code)