### PR TITLE
docs(getting-started): liftoff polish — accordion preflight, restructure

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -1,60 +1,15 @@
 ---
 title: "Prepare for Liftoff"
-description: "Build Aileron from source, install the Google connector, bind a Google account via OAuth, and launch Claude Code with Gmail and Calendar actions wired in."
+description: "Build Aileron from source, install Gmail and Calendar actions, and launch Claude Code with everything wired in."
 order: 2
 ---
 
 import HighlightCard from '$lib/components/ui/highlight-card.svelte';
-import { PlatformTabs } from '$lib/components/ui/tabs/index.js';
+import LiftoffPreflight from '$lib/components/ui/liftoff-preflight.svelte';
 
-export const goInstall = [
-  { value: 'macos', label: 'macOS', lang: 'sh', code: 'brew install go' },
-  {
-    value: 'linux',
-    label: 'Linux',
-    lang: 'sh',
-    note: "Use your distro's package manager, or download the official tarball from go.dev/dl.",
-    code: '# Debian / Ubuntu (may lag behind upstream; check version)\nsudo apt-get install golang-go',
-  },
-  { value: 'windows', label: 'Windows', lang: 'powershell', code: 'winget install GoLang.Go' },
-];
+<HighlightCard>
 
-export const taskInstall = [
-  { value: 'macos', label: 'macOS', lang: 'sh', code: 'brew install go-task' },
-  {
-    value: 'linux',
-    label: 'Linux',
-    lang: 'sh',
-    code: 'sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin',
-  },
-  { value: 'windows', label: 'Windows', lang: 'powershell', code: 'scoop install task' },
-];
-
-export const nodeInstall = [
-  {
-    value: 'macos',
-    label: 'macOS',
-    lang: 'sh',
-    code: 'brew install node\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate',
-  },
-  {
-    value: 'linux',
-    label: 'Linux',
-    lang: 'sh',
-    note: 'Install nvm (https://github.com/nvm-sh/nvm), then run:',
-    code: 'nvm install 24\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate',
-  },
-  {
-    value: 'windows',
-    label: 'Windows',
-    lang: 'powershell',
-    code: 'winget install OpenJS.NodeJS\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate',
-  },
-];
-
-<HighlightCard title="Your first flight">
-
-Let's take your first flight with Aileron. In under 5 minutes, you'll be securely equipping Claude Code to use your real Gmail and Calendar account. Along the way we'll introduce Connectors and Actions, a joyful way to add powerful features to your agent. Your agent never sees the keys to your private services, and you always retain approval before taking an irreversible action like sending an email. Let's take off.
+We're about to take your first flight with Aileron. In under 5 minutes, you'll be securely equipping Claude Code to use your real Gmail and Calendar account. Along the way we'll introduce Connectors and Actions, a joyful way to add powerful features to your agent. Your agent never sees the keys to your private services, and you always retain approval before taking an irreversible action like sending an email. Let's take off.
 
 </HighlightCard>
 
@@ -64,29 +19,11 @@ Estimated time: 5 minutes. What happens: Summarize five most recent emails, draf
 
 </HighlightCard>
 
-This guide walks the full end-to-end flow on a fresh machine: build the binaries, trust a publisher, install the [`aileron-connector-google`](https://github.com/ALRubinger/aileron-connector-google) reference connector, bind a real Google account, and run [Claude Code](https://docs.claude.com/en/docs/claude-code) with Gmail and Calendar actions exposed via Aileron's MCP server.
-
-By the end you will have asked Claude Code "summarize my five most recent emails", watched it pick a Gmail tool Aileron published, and seen Aileron execute it inside the WASM sandbox against the real Google API — all without Claude ever holding your OAuth token.
-
 ## Preflight Checklist
 
-- **Go 1.25 or newer.** Aileron's modules require it. `go version` should report at least `go1.25.0`. Install instructions vary by platform.
+<LiftoffPreflight client:load />
 
-  <PlatformTabs items={goInstall} client:load />
-
-- **[Task](https://taskfile.dev/installation/).** All build commands go through `task`.
-
-  <PlatformTabs items={taskInstall} client:load />
-
-- **Node.js 24 or newer** and **pnpm 11.0.8 (within the 11.x line).** The webapp and docs targets build through `pnpm`, so `task build` will fail without them. The simplest setup is `corepack enable` after installing Node, then `corepack prepare pnpm@11.0.8 --activate`.
-
-  <PlatformTabs items={nodeInstall} client:load />
-
-- **[Claude Code](https://docs.claude.com/en/docs/claude-code/setup) installed and configured** with an Anthropic API key in `ANTHROPIC_API_KEY`. Aileron's launcher routes Claude Code's LLM calls through the local Aileron daemon. It does not supply or replace your API key.
-
-- **A Google account.** Gmail and Calendar must be enabled. The OAuth dance opens in your default browser.
-
-## 1. Build the binaries
+## 1. Build Aileron
 
 > **Note:** there is no `brew install aileron` yet. This guide builds from source; package distribution is coming shortly.
 
@@ -109,11 +46,9 @@ You should see something like:
 aileron dev (f66e51c)
 ```
 
-## 2. Trust the connector's publisher key
+## 2. Install Actions for Gmail and Calendar
 
-Every connector install verifies an ed25519 signature against keys you have explicitly trusted. Without a trusted key for the publisher's authority, install fails closed before fetching anything.
-
-Trust the `aileron-connector-google` publisher. The CLI fetches the key from `keys/publisher.pub` on the repo's default branch:
+Every connector install verifies an ed25519 signature against keys you have explicitly trusted. Without a trusted key for the publisher's authority, install fails closed before fetching anything. Trust the `aileron-connector-google` publisher; the CLI fetches the key from `keys/publisher.pub` on the repo's default branch:
 
 ```sh
 aileron keyring trust github://ALRubinger/aileron-connector-google
@@ -147,63 +82,20 @@ After the passphrase is set, the trust command finishes:
   Keyring: /Users/you/.aileron/keyring.json
 ```
 
-Confirm it landed:
+Now add the Gmail and Calendar actions. Pick the latest release tag from [the connector's releases page](https://github.com/ALRubinger/aileron-connector-google/releases) and substitute it for `0.0.6` below.
 
 ```sh
-aileron keyring list
+aileron action add github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6 && \
+  aileron action add github://ALRubinger/aileron-connector-google/actions/get-email@0.0.6 && \
+  aileron action add github://ALRubinger/aileron-connector-google/actions/list-upcoming-events@0.0.6 && \
+  aileron action add github://ALRubinger/aileron-connector-google/actions/draft-email@0.0.6
 ```
 
-## 3. Install an action
+The first `action add` resolves the action's connector dependency, fetches the connector tarball from the GitHub release, verifies the signature against your trusted key, computes the content hash, and walks you through Google's OAuth consent screen to bind a credential. Confirm each step. Subsequent action installs reuse the connector and the binding.
 
-Pick the latest release tag from [the connector's releases page](https://github.com/ALRubinger/aileron-connector-google/releases) and install one of its action templates. Versions in this guide use `0.0.6` — substitute the current tag.
+The connector's publisher already shipped a Desktop OAuth `client_id` and `client_secret` bound at release time, so there's no Google Cloud Console setup on your end. The token bytes are encrypted at rest; Aileron refreshes them transparently when they near expiry, and the connector never sees the credential.
 
-```sh
-aileron action add github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6
-```
-
-Aileron resolves the action's connector dependency, fetches the connector tarball from the GitHub release, verifies the signature against your trusted key, computes the content hash, and walks you through a consent prompt for each new connector and the action itself. Confirm each step.
-
-When the install completes, the action file is at `~/.aileron/actions/list-recent-emails.md` (you own it — edit it freely) and the connector is in the content-addressed store at `~/.aileron/store/`.
-
-Add a couple more so the agent has room to compose:
-
-```sh
-aileron action add github://ALRubinger/aileron-connector-google/actions/get-email@0.0.6
-aileron action add github://ALRubinger/aileron-connector-google/actions/list-upcoming-events@0.0.6
-aileron action add github://ALRubinger/aileron-connector-google/actions/draft-email@0.0.6
-```
-
-The connector is fetched once; subsequent action installs reuse it.
-
-## 4. Confirm your Google binding
-
-Action templates declare *what* credential they need; binding is how you tell Aileron *which* one of your accounts to use. The Google connector declares an OAuth2 capability with read+compose scopes for Gmail and read+events scopes for Calendar.
-
-By the time you reach this step, `aileron action add` should already have walked you through Google's OAuth consent screen and bound a credential — you can see it now:
-
-```sh
-aileron binding list
-```
-
-You should see something like:
-
-```
-oauth2/aileron-connector-google/personal  oauth2  google  ...
-```
-
-The connector's publisher already shipped a Desktop OAuth `client_id` and `client_secret` bound at release time, so there's no Google Cloud Console setup on your end. The token bytes are encrypted at rest; Aileron refreshes them transparently when they near expiry, and the connector never sees the credential. See [The Vault](/concepts/the-vault/) for how the credential travels at execution time.
-
-### If you skipped consent during install
-
-If you declined the consent prompt during `aileron action add`, or your terminal session ended before consent completed, run the binding step explicitly:
-
-```sh
-aileron binding setup github://ALRubinger/aileron-connector-google
-```
-
-You'll be asked for an identity (e.g. `personal`, `work`) — this is just a label that disambiguates multiple accounts you might bind under the same connector. Aileron then opens your browser to Google's OAuth consent screen. Approve, and Google redirects to a loopback URL Aileron is listening on. The CLI captures the code, exchanges it for a refresh token server-side, and stores the result in your vault. Re-run `aileron binding list` to confirm.
-
-## 5. Launch Claude Code through Aileron
+## 3. Launch Claude Code through Aileron
 
 ```sh
 aileron launch claude
@@ -212,32 +104,18 @@ aileron launch claude
 You'll see a banner like:
 
 ```
-✈️  Aileron — webapp http://127.0.0.1:54321 — session 01HK6... — log ~/.aileron/logs/...
+✈️  Aileron — webapp http://127.0.0.1:54321 — session 01HK6...
 ```
 
-If the vault happens to be locked at this moment, a follow-up line points you at the unlock surface:
+Claude Code is now a normal Claude Code session, with a tool catalog that includes the actions you just installed.
 
-```
-✈️  Vault locked — open http://127.0.0.1:54321 and enter your passphrase to unlock.
-```
-
-What happened under the hood:
-
-- The CLI resolved the daemon URL via `~/.aileron/daemon.json` (auto-spawning the daemon on first need).
-- It registered the launch session by `POST /v1/sessions`; the daemon minted a [ULID](https://github.com/ulid/spec) session ID and stamped its start time.
-- It set `ANTHROPIC_BASE_URL` to the daemon URL so Claude Code's LLM calls flow through Aileron.
-- It registered `aileron-mcp` as an MCP server for the session. On startup, `aileron-mcp` queries the daemon's `/v1/actions` and generates one MCP tool per installed action — `list_recent_emails`, `get_email`, `list_upcoming_events`, `draft_email`.
-- The vault binding you set up in step 4 is in scope because the daemon is the same process the CLI used to register the binding.
-
-The daemon URL is **stable across launches** — bookmark it once and it stays reachable until you `aileron stop`. Claude Code is now a normal Claude Code session, with a tool catalog that includes the actions Aileron published.
-
-## 6. Drive the actions from the agent
+## 4. Drive the actions from the agent
 
 In the Claude Code prompt, try:
 
 > Summarize my five most recent emails.
 
-Claude picks `list_recent_emails` (it sees one tool per installed action thanks to MCP discovery), Aileron executes it inside the WASM sandbox against `gmail.googleapis.com`, returns `{id, threadId}` pairs, Claude fans out parallel `get_email` calls for the metadata, and you get a summary.
+Claude picks `list_recent_emails`, Aileron executes it inside the WASM sandbox against `gmail.googleapis.com`, returns `{id, threadId}` pairs, Claude fans out parallel `get_email` calls for the metadata, and you get a summary.
 
 A few more prompts to exercise the rest of the surface:
 
@@ -247,17 +125,16 @@ Routes to `list_upcoming_events`.
 
 > Draft a reply to the last email from Andrew thanking him and confirming Tuesday.
 
-Routes to `get_email` (to read context) then `draft_email` — which lands a draft in your Gmail Drafts folder. Drafts are reversible, so this action is not gated; the existing manual "click Send in Gmail" step is the human review.
+Routes to `get_email` (to read context) then `draft_email`, which lands a draft in your Gmail Drafts folder. Drafts are reversible, so this action is not gated; the existing manual "click Send in Gmail" step is the human review.
 
-`send-email` and `create-calendar-event` are gated for per-call approval because their effects are not reversible (see [the connector's README](https://github.com/ALRubinger/aileron-connector-google#what-it-ships) for why). When Claude proposes one of those, the approval lands on the daemon's `/approvals` page (the same URL printed in the launch banner above), and Claude's tool call blocks until you click Approve or Deny.
+`send-email` and `create-calendar-event` are gated for per-call approval because their effects are not reversible (see [the connector's README](https://github.com/ALRubinger/aileron-connector-google#what-it-ships) for why). When Claude proposes one of those, the approval lands on the webapp URL printed in the launch banner above, and Claude's tool call blocks until you click Approve or Deny.
 
-## 7. Inspect what happened
+## 5. Inspect what happened
 
-In a separate terminal — the daemon is still running, so any CLI call connects to the same process — see what the runtime knows:
+In a separate terminal, see what the runtime knows:
 
 ```sh
 aileron status               # what's configured: action/connector/binding counts, policy, env, vault state
-aileron daemon status        # what's running: daemon URL, PID, version, started_at, locked/unlocked vault
 aileron sessions list        # every aileron launch, with status (running / ended / orphaned) and exit code
 aileron sessions watch <id>  # tail the per-session log live (Ctrl-C to stop; --no-follow for one-shot)
 aileron action audit         # every installed action and the capabilities it can exercise
@@ -265,11 +142,9 @@ aileron binding list         # bound credentials with their last-used timestamp
 aileron audit list           # action-execution audit log: every call, with inputs and outcome
 ```
 
-`aileron status` is configuration-shaped: what you've installed, what your policy says, where credentials live. `aileron daemon status` is process-shaped: which daemon process the CLI is talking to and whether its vault is unlocked. They overlap on vault state because both surface it for different reasons; the rest is disjoint.
+The audit log is the receipt for everything the agent did on your behalf. Each entry names the action, the connector version, the binding identity, the duration, and the disposition, recorded under `~/.aileron/audit/audit-YYYY-MM-DD.jsonl` (daily-rotated, user-scope). Combined with the install consent log, you can answer two questions for any action: "did I authorize this capability?" and "what did the agent actually do with it?"
 
-The audit log is the receipt for everything the agent did on your behalf. Each entry names the action, the connector version, the binding identity, the duration, and the disposition — recorded under `~/.aileron/audit/audit-YYYY-MM-DD.jsonl` (daily-rotated, user-scope). Combined with the install consent log, you can answer two questions for any action: "did I authorize this capability?" and "what did the agent actually do with it?"
-
-For end-to-end timing or correlation with the rest of your agent stack, Aileron also emits OpenTelemetry traces — opt-in via `AILERON_OTEL_ENABLED=true AILERON_OTEL_EXPORTER=stdout`. See [Observability](/guides/observability/) for what gets emitted, the span attribute schema, and the env vars that control both the audit and tracing surfaces.
+For end-to-end timing or correlation with the rest of your agent stack, Aileron also emits OpenTelemetry traces, opt-in via `AILERON_OTEL_ENABLED=true AILERON_OTEL_EXPORTER=stdout`. See [Observability](/guides/observability/) for what gets emitted, the span attribute schema, and the env vars that control both the audit and tracing surfaces.
 
 ## What you've built
 
@@ -281,4 +156,4 @@ This is the loop the rest of the docs builds on. From here:
 - [Concepts → Actions](/concepts/actions/) and [Connectors](/concepts/connectors/) — the model behind what you just installed.
 - [Guides → Authoring an Action](/guides/authoring-an-action/) — write your own action template against an existing connector.
 - [Guides → Authoring a Connector](/guides/authoring-a-connector/) — ship a connector for a service Aileron does not yet have.
-- [CLI Reference](/cli/) — every command grouped by concern, each linked to the ADR that ratifies its behavior.
+- [CLI Reference](/cli/) — every command grouped by concern.

--- a/docs/src/lib/components/ui/highlight-card.svelte
+++ b/docs/src/lib/components/ui/highlight-card.svelte
@@ -23,7 +23,7 @@
     class: className,
     children,
   }: {
-    title: string;
+    title?: string;
     variant?: Variant;
     class?: string;
     children: Snippet;
@@ -36,9 +36,11 @@
 </script>
 
 <Card.Root class={cn('my-8 text-base', variantClass[variant], className)}>
-  <Card.Header>
-    <Card.Title class="text-lg">{title}</Card.Title>
-  </Card.Header>
+  {#if title}
+    <Card.Header>
+      <Card.Title class="text-lg">{title}</Card.Title>
+    </Card.Header>
+  {/if}
   <Card.Content>
     {@render children()}
   </Card.Content>

--- a/docs/src/lib/components/ui/liftoff-preflight.svelte
+++ b/docs/src/lib/components/ui/liftoff-preflight.svelte
@@ -1,0 +1,153 @@
+<script lang="ts">
+	import { Accordion as AccordionPrimitive } from "bits-ui";
+	import ChevronDown from "@lucide/svelte/icons/chevron-down";
+	import { cn } from "$lib/utils.js";
+	import PlatformTabs, { type PlatformTabItem } from "./tabs/platform-tabs.svelte";
+
+	const goInstall: PlatformTabItem[] = [
+		{ value: "macos", label: "macOS", lang: "sh", code: "brew install go" },
+		{
+			value: "linux",
+			label: "Linux",
+			lang: "sh",
+			note: "Use your distro's package manager, or download the official tarball from go.dev/dl.",
+			code: "# Debian / Ubuntu (may lag behind upstream; check version)\nsudo apt-get install golang-go",
+		},
+		{ value: "windows", label: "Windows", lang: "powershell", code: "winget install GoLang.Go" },
+	];
+
+	const taskInstall: PlatformTabItem[] = [
+		{ value: "macos", label: "macOS", lang: "sh", code: "brew install go-task" },
+		{
+			value: "linux",
+			label: "Linux",
+			lang: "sh",
+			code: 'sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin',
+		},
+		{ value: "windows", label: "Windows", lang: "powershell", code: "scoop install task" },
+	];
+
+	const nodeInstall: PlatformTabItem[] = [
+		{
+			value: "macos",
+			label: "macOS",
+			lang: "sh",
+			code: "brew install node\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate",
+		},
+		{
+			value: "linux",
+			label: "Linux",
+			lang: "sh",
+			note: "Install nvm (https://github.com/nvm-sh/nvm), then run:",
+			code: "nvm install 24\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate",
+		},
+		{
+			value: "windows",
+			label: "Windows",
+			lang: "powershell",
+			code: "winget install OpenJS.NodeJS\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate",
+		},
+	];
+
+	const triggerClass = cn(
+		"flex w-full items-center justify-between py-3 text-left text-sm font-medium",
+		"hover:underline focus-visible:outline-1 focus-visible:outline-ring",
+		"[&[data-state=open]>svg]:rotate-180"
+	);
+	const itemClass = "border-b border-border";
+	const contentClass = cn(
+		"overflow-hidden text-sm",
+		"data-[state=open]:pb-4 data-[state=closed]:pb-0",
+		"[&_pre]:my-2"
+	);
+</script>
+
+<!--
+  LiftoffPreflight is a single Svelte island that owns the entire
+  "Liftoff in 5 Minutes" preflight checklist: an accordion of bits-ui
+  Accordion items, three of which embed a PlatformTabs component for
+  per-OS install commands. Splitting Accordion primitives across MDX
+  references would sever bits-ui's context (see the comment on
+  platform-tabs.svelte). Page-specific by design — the prose lives
+  here so the data and presentation stay together for content that
+  only ships on this one page.
+-->
+<AccordionPrimitive.Root type="multiple" class="cn-preflight my-6 w-full">
+	<AccordionPrimitive.Item value="go" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>Go 1.25 or newer</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content class={contentClass}>
+			<p>
+				Aileron's modules require it. <code>go version</code> should report at least
+				<code>go1.25.0</code>.
+			</p>
+			<PlatformTabs items={goInstall} />
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+
+	<AccordionPrimitive.Item value="task" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>Task</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content class={contentClass}>
+			<p>
+				All build commands go through <code>task</code>. See
+				<a href="https://taskfile.dev/installation/">taskfile.dev</a> for other install options.
+			</p>
+			<PlatformTabs items={taskInstall} />
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+
+	<AccordionPrimitive.Item value="node" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>Node.js 24 + pnpm 11.0.8</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content class={contentClass}>
+			<p>
+				The webapp and docs targets build through <code>pnpm</code>, so <code>task build</code> will
+				fail without them. The simplest setup is <code>corepack enable</code> after installing Node,
+				then <code>corepack prepare pnpm@11.0.8 --activate</code>.
+			</p>
+			<PlatformTabs items={nodeInstall} />
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+
+	<AccordionPrimitive.Item value="claude-code" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>Claude Code</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content class={contentClass}>
+			<p>
+				Install and configure
+				<a href="https://docs.claude.com/en/docs/claude-code/setup">Claude Code</a> with an
+				Anthropic API key in <code>ANTHROPIC_API_KEY</code>. Aileron's launcher routes Claude
+				Code's LLM calls through Aileron locally. It does not supply or replace your API key.
+			</p>
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+
+	<AccordionPrimitive.Item value="google" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>A Google account</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content class={contentClass}>
+			<p>Gmail and Calendar must be enabled. The OAuth dance opens in your default browser.</p>
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+</AccordionPrimitive.Root>

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -42,7 +42,7 @@ export const navigation: NavItem[] = [
     label: 'Meet Aileron',
     children: [
       { label: 'Overview', href: '/' },
-      { label: 'Getting Started', href: '/getting-started/' }
+      { label: 'Liftoff in 5 Minutes', href: '/getting-started/' }
     ]
   },
   {


### PR DESCRIPTION
## Summary

Round-2 polish on the Liftoff guide, following the round-1 umbrella (#550).

### Changes

- **Sidebar nav** renamed "Getting Started" → "Liftoff in 5 Minutes" in \`docs/src/lib/navigation.ts\`.
- **Intro card** drops the "Your first flight" title (it was redundant with the body's opening sentence). \`HighlightCard.title\` is now optional; when omitted, the Card.Header is skipped entirely. Privacy / terms "short version" cards still pass titles.
- **First sentence** rewritten from "Let's take your first flight" → "We're about to take your first flight" (anticipatory tone, lands cleaner against the closing "Let's take off").
- **Preflight Checklist as accordion**. New \`docs/src/lib/components/ui/liftoff-preflight.svelte\` — single Svelte island wrapping bits-ui Accordion + the existing PlatformTabs component. Five collapsed headlines ("Go 1.25 or newer", "Task", "Node.js 24 + pnpm 11.0.8", "Claude Code", "A Google account"); platform install tabs only render when expanded. Same single-island pattern W3 used for tabs to keep bits-ui context inside one hydration boundary.
- **§1** "Build the binaries" → **"Build Aileron"**.
- **§2 + §3 merged** into **"Install Actions for Gmail and Calendar"**. Trust step still appears as a precondition; the four \`action add\` calls chain with \`&&\` into one copy-pasteable block.
- **§4 "Confirm your Google binding" removed** entirely. Diagnostics belong elsewhere; a first-flight guide shouldn't walk the user through introspection.
- **§5 → §3** "Launch Claude Code through Aileron". Dropped the "What happened under the hood" bullet list — that was the remaining \`daemon\` / \`daemon.json\` / \`POST /v1/sessions\` / \`ULID\` / \`ANTHROPIC_BASE_URL\` / \`aileron-mcp\` leak flagged in the W5+ADR PR body (#560). The Claude Code prereq inside the accordion also no longer mentions "the local Aileron daemon".
- **§6 → §4**, **§7 → §5**. Light prose trims.

### Net result

The umbrella's "hide internal architecture" acceptance criterion is now fully met for this page: no ADR references, no daemon mentions, no four-binaries breakdown, no vault file paths in prose.

### Filed for follow-up

- **#563** — \`aileron action add\` should auto-prompt to trust the publisher and auto-install the connector. When this lands, §2 collapses from "trust + four adds" to a single command.
- **#564** — \`aileron action add -f <suite-manifest>\` for installing an action suite in one operation. When this lands, §2 collapses further to one suite-install line.

## Test plan

- [x] \`task build:docs\` green; 57 pages built.
- [x] Rendered article body of \`/getting-started/\`: intro card has no title, first sentence reads "We're about to take your first flight", section headings are exactly Preflight / 1 Build Aileron / 2 Install Actions for Gmail and Calendar / 3 Launch / 4 Drive / 5 Inspect / What you've built.
- [x] LiftoffPreflight renders with 5 accordion triggers in expected order; PlatformTabs embed inside Go / Task / Node items only.
- [x] Sidebar shows "Liftoff in 5 Minutes" (×2 — page sidebar + mobile nav).
- [ ] Reviewer: click each accordion item on the rendered page and confirm tabs work inside the expanded Go/Task/Node items.

Refs #550. Closes #563-blocking-language for §2 (will land independently). Filed #563 + #564.

🤖 Generated with [Claude Code](https://claude.com/claude-code)