### PR TITLE
feat(action): suite install via `aileron action add -f <manifest>` (#564)

### DIFF
--- a/cmd/aileron/keyring.go
+++ b/cmd/aileron/keyring.go
@@ -157,6 +157,50 @@ func fetchPublisherKey(authority string) (ed25519.PublicKey, error) {
 	return pub, nil
 }
 
+// trustState tracks per-run trust decisions across one CLI
+// invocation. Suite installs (#564) thread the same state through
+// every action so a publisher's prompt fires at most once per run.
+// Both maps key on FQN authority strings (`<scheme>://<owner>/<repo>`).
+//
+//   - trusted:  authorities that have been (or already were) trusted
+//               this run. A second prompt is suppressed.
+//   - declined: authorities the user said "no" to (or fetch failed
+//               for) this run. Subsequent actions whose authority is
+//               in declined skip silently with a one-line summary
+//               line. A re-run of the command clears the state.
+type trustState struct {
+	trusted  map[string]bool
+	declined map[string]bool
+}
+
+func newTrustState() *trustState {
+	return &trustState{
+		trusted:  map[string]bool{},
+		declined: map[string]bool{},
+	}
+}
+
+// ensure is the suite-aware wrapper around ensureAuthorityTrusted.
+// It short-circuits when the authority has already been resolved
+// (trusted or declined) earlier in the same run, otherwise it falls
+// through to the prompt. Any failure marks the authority declined
+// so subsequent same-authority actions in the suite skip without
+// re-prompting.
+func (s *trustState) ensure(authority string, autoYes bool, stdin io.Reader, stdout, stderr io.Writer) error {
+	if s.declined[authority] {
+		return fmt.Errorf("publisher %s trust previously declined this run; skipping", authority)
+	}
+	if s.trusted[authority] {
+		return nil
+	}
+	if err := ensureAuthorityTrusted(authority, autoYes, stdin, stdout, stderr); err != nil {
+		s.declined[authority] = true
+		return err
+	}
+	s.trusted[authority] = true
+	return nil
+}
+
 // ensureAuthorityTrusted is the install-time bridge to the keyring:
 // it checks whether the supplied authority has any keys registered
 // and, if not, prompts the operator (or proceeds when autoYes=true)
@@ -169,6 +213,10 @@ func fetchPublisherKey(authority string) (ed25519.PublicKey, error) {
 // install flow per issue #563. Same fetch + verify path as the
 // standalone trust subcommand — re-uses fetchPublisherKey and the
 // keyring helpers so the policy stays in one place.
+//
+// Single-action callers can use this directly. Suite callers should
+// thread a *trustState through trustState.ensure so the same
+// authority isn't prompted twice across the suite.
 func ensureAuthorityTrusted(authority string, autoYes bool, stdin io.Reader, stdout, stderr io.Writer) error {
 	path := cstore.DefaultKeyringPath()
 	if path == "" {

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -26,6 +26,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/oauth"
 	launchpolicy "github.com/ALRubinger/aileron/internal/policy/launch"
+	"github.com/ALRubinger/aileron/internal/suite"
 	"github.com/ALRubinger/aileron/internal/vault"
 	"github.com/ALRubinger/aileron/internal/version"
 	"golang.org/x/term"
@@ -1467,12 +1468,22 @@ const connectorUsage = `usage:
   aileron connector check [--include-prerelease] [--json]`
 
 const actionUsage = `usage:
-  aileron action add <FQN> [--version=<v>] [--force] [--yes] [--no-bind]
+  aileron action add <FQN>     [--version=<v>] [--force] [--yes] [--no-bind]
+  aileron action add -f <path> [--force] [--yes] [--no-bind]
 
-Trust + connector install are absorbed into this command (issue #563):
-on a fresh machine, the CLI prompts to trust the publisher's signing
-key before preview, then prompts for the action install consent. Pass
---yes to auto-accept both prompts in non-interactive use.`
+Single-action form: install one action by FQN. Trust + connector
+install are absorbed into this command (issue #563): on a fresh
+machine the CLI prompts to trust the publisher's signing key before
+preview, then prompts for the install consent.
+
+Suite form (issue #564): -f points at a TOML manifest listing a set
+of actions. The CLI installs each in order, sharing trust + connector
+state across the set so a publisher's prompt fires at most once per
+run. Per-action failures are surfaced in a final summary; the
+remaining actions still install (failure-soft).
+
+Pass --yes to auto-accept all trust + consent prompts in
+non-interactive use.`
 
 // runConnector dispatches `aileron connector <subcommand>`.
 func runConnector(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
@@ -2138,18 +2149,34 @@ func shortHash(h string) string {
 	return h
 }
 
-// runActionAdd posts to /v1/actions/install, renders the envelope,
-// and (per ADR-0006 v1 UX) prompts the user to drop into the binding
-// setup flow for any unbound credential capabilities the action's
-// connectors declare. The user stays in the CLI surface throughout —
-// avoids the hit-binding_required-at-agent-invocation friction.
+// actionAddOptions carries the per-install knobs that drive
+// installOneAction. Both the single-action and suite paths build
+// one of these per action; the only difference is the source
+// (CLI argv vs. suite manifest entry).
+type actionAddOptions struct {
+	fqn     string // raw FQN; may include @<version>
+	version string // optional separate version flag
+	force   bool
+	yes     bool
+	noBind  bool
+}
+
+// runActionAdd dispatches `aileron action add` to one of two paths:
 //
-// When the server returns `connectors_missing` (issue #413), the CLI
-// shows the resolved FQN, version, and hash for each missing
-// connector and prompts the user; on confirmation it retries the
-// install with `auto_install_connectors=true` so the server runs the
-// connector pipeline transparently.
+//   - Suite form (`-f <path>`): parses the manifest at <path> and
+//     installs every action in it, sharing trust + connector state
+//     across the set (issue #564).
+//   - Single-action form (`<FQN>`): installs one action (issue #563
+//     auto-trust + connector install).
+//
+// Detection is pre-parse: scanning args for `-f` / `--file` so the
+// existing extractPositional path (which would otherwise treat the
+// suite path as a positional FQN) is bypassed cleanly.
 func runActionAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	if hasFileFlag(args) {
+		return runActionAddSuite(args, stdin, stdout, stderr)
+	}
+
 	fqnArg, rest, ok := extractPositional(args)
 	if !ok {
 		fmt.Fprintln(stderr, actionUsage)
@@ -2164,7 +2191,49 @@ func runActionAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 	if err := flags.Parse(rest); err != nil {
 		return 1
 	}
-	resolvedFQN, resolvedVersion, perr := splitFQNVersion(fqnArg, *version)
+	opts := actionAddOptions{
+		fqn:     fqnArg,
+		version: *version,
+		force:   *force,
+		yes:     *yes,
+		noBind:  *noBind,
+	}
+	return installOneAction(opts, stdin, stdout, stderr, newTrustState())
+}
+
+// hasFileFlag reports whether args contain a `-f` / `--file`
+// invocation in any of the supported forms (`-f path`, `-f=path`,
+// `--file path`, `--file=path`). Used by runActionAdd to dispatch
+// to the suite-install path before the single-action path's
+// positional extractor (which doesn't know about value-taking
+// flags) gets confused by `-f path`.
+func hasFileFlag(args []string) bool {
+	for _, a := range args {
+		if a == "-f" || a == "--file" ||
+			strings.HasPrefix(a, "-f=") || strings.HasPrefix(a, "--file=") {
+			return true
+		}
+	}
+	return false
+}
+
+// installOneAction runs the full trust → preview → consent →
+// install → auto-bind flow for a single action. The trust state is
+// passed in so suite installs can share it across actions; a
+// single-action invocation passes a fresh state.
+//
+// Per ADR-0006 v1 UX, on success it prompts the user to drop into
+// the binding setup flow for any unbound credential capabilities
+// the action's connectors declare. The user stays in the CLI
+// surface throughout, which avoids the
+// hit-binding_required-at-agent-invocation friction.
+//
+// When the server returns `connectors_missing` (issue #413), the
+// CLI shows the resolved FQN, version, and hash for each missing
+// connector and retries the install with `auto_install_connectors=true`
+// so the server runs the connector pipeline transparently.
+func installOneAction(opts actionAddOptions, stdin io.Reader, stdout, stderr io.Writer, trust *trustState) int {
+	resolvedFQN, resolvedVersion, perr := splitFQNVersion(opts.fqn, opts.version)
 	if perr != nil {
 		fmt.Fprintf(stderr, "%v\n", perr)
 		return 1
@@ -2173,21 +2242,16 @@ func runActionAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 	// Step 0 (issue #563): ensure the action's authority is trusted.
 	// Preview verifies the action signature against this authority's
 	// keys; without one, the daemon would fail with `signature_failure`
-	// before we ever rendered the consent prompt. Track which
-	// authorities we've already prompted for in this invocation so
-	// connector deps that share the action's authority don't double-
-	// prompt below.
+	// before we ever rendered the consent prompt.
 	actionFQN, perr := cstore.ParseFQN(resolvedFQN)
 	if perr != nil {
 		fmt.Fprintf(stderr, "error: %v\n", perr)
 		return 1
 	}
-	trustedThisRun := map[string]bool{}
-	if err := ensureAuthorityTrusted(actionFQN.Authority(), *yes, stdin, stdout, stderr); err != nil {
+	if err := trust.ensure(actionFQN.Authority(), opts.yes, stdin, stdout, stderr); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
-	trustedThisRun[actionFQN.Authority()] = true
 
 	// Step 1: preview. Fetches + parses the action manifest plus
 	// enumerates connector deps with their already-installed status.
@@ -2237,19 +2301,14 @@ func runActionAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 			// The daemon already validated this — defensive skip.
 			continue
 		}
-		auth := depFQN.Authority()
-		if trustedThisRun[auth] {
-			continue
-		}
-		if err := ensureAuthorityTrusted(auth, *yes, stdin, stdout, stderr); err != nil {
+		if err := trust.ensure(depFQN.Authority(), opts.yes, stdin, stdout, stderr); err != nil {
 			fmt.Fprintf(stderr, "error: %v\n", err)
 			return 1
 		}
-		trustedThisRun[auth] = true
 	}
 
 	// Step 3: prompt unless --yes.
-	if !*yes {
+	if !opts.yes {
 		answer := strings.ToLower(strings.TrimSpace(promptLine(stdin, stdout, "Install? [y/N]: ")))
 		if answer != "y" && answer != "yes" {
 			fmt.Fprintln(stdout, "Cancelled.")
@@ -2265,7 +2324,7 @@ func runActionAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 		"version":                 resolvedVersion,
 		"auto_install_connectors": true,
 	}
-	if *force {
+	if opts.force {
 		body["force"] = true
 	}
 	bodyJSON, _ := json.Marshal(body)
@@ -2303,7 +2362,7 @@ func runActionAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 	fmt.Fprintf(stdout, "%s: %s\n  source: %s\n  path: %s\n",
 		verb, resp.Name, resp.Source, resp.Path)
 
-	if *noBind || len(resp.UnboundCapabilities) == 0 {
+	if opts.noBind || len(resp.UnboundCapabilities) == 0 {
 		if len(resp.UnboundCapabilities) > 0 {
 			fmt.Fprintln(stdout, "")
 			fmt.Fprintln(stdout, "Action has unbound credential capabilities:")
@@ -2335,6 +2394,110 @@ func runActionAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 			// one later.
 		}
 	}
+	return 0
+}
+
+// runActionAddSuite implements `aileron action add -f <path>`
+// (issue #564). Parses the suite manifest at <path>, then installs
+// each action in declaration order via installOneAction, sharing a
+// single trustState so a publisher's prompt fires once per run
+// regardless of how many actions in the suite reference it.
+//
+// Failure semantics are deliberately failure-soft: a per-action
+// install failure is captured in the final summary and the loop
+// continues with the next action. The CLI exits nonzero if any
+// action failed, so scripts can branch on the return code without
+// parsing the summary. Trust declines are treated like any other
+// per-action failure, but subsequent actions sharing the declined
+// authority skip silently (trustState.declined) so the user is not
+// re-prompted N-1 times for the same publisher.
+func runActionAddSuite(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("action add -f", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	suitePath := flags.String("f", "", "path to a suite manifest TOML file")
+	suitePathLong := flags.String("file", "", "path to a suite manifest TOML file (alias for -f)")
+	force := flags.Bool("force", false, "overwrite existing actions with the same name")
+	noBind := flags.Bool("no-bind", false, "skip the auto-prompt for unbound credentials (use in scripts)")
+	yes := flags.Bool("yes", false, "skip the consent prompts and proceed without confirmation")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if len(flags.Args()) > 0 {
+		fmt.Fprintln(stderr, "error: cannot combine -f with a positional FQN")
+		fmt.Fprintln(stderr, actionUsage)
+		return 1
+	}
+	path := *suitePath
+	if path == "" {
+		path = *suitePathLong
+	}
+	if path == "" {
+		fmt.Fprintln(stderr, "error: -f/--file requires a path to a suite manifest")
+		return 1
+	}
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: read suite manifest: %v\n", err)
+		return 1
+	}
+	manifest, err := suite.Parse(path, data)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Suite: %s\n", manifest.Suite.Name)
+	if manifest.Suite.Description != "" {
+		fmt.Fprintf(stdout, "  %s\n", manifest.Suite.Description)
+	}
+	fmt.Fprintf(stdout, "  %d action(s) to install\n", len(manifest.Actions))
+
+	// Buffered stdin so each prompt picks up where the previous
+	// left off — same reason runAction wraps stdin for the single-
+	// action path. The trust + consent prompts within each
+	// installOneAction share this reader.
+	br, ok := stdin.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(stdin)
+	}
+
+	trust := newTrustState()
+	type result struct {
+		fqn  string
+		rc   int
+	}
+	results := make([]result, 0, len(manifest.Actions))
+	for i, action := range manifest.Actions {
+		fmt.Fprintln(stdout)
+		fmt.Fprintf(stdout, "── [%d/%d] %s\n", i+1, len(manifest.Actions), action.FQN)
+		opts := actionAddOptions{
+			fqn:    action.FQN,
+			force:  *force,
+			yes:    *yes,
+			noBind: *noBind,
+		}
+		rc := installOneAction(opts, br, stdout, stderr, trust)
+		results = append(results, result{fqn: action.FQN, rc: rc})
+	}
+
+	// Final summary: one line per action with its outcome.
+	fmt.Fprintln(stdout)
+	fmt.Fprintln(stdout, "Suite install summary:")
+	failures := 0
+	for _, r := range results {
+		if r.rc == 0 {
+			fmt.Fprintf(stdout, "  \033[32m✓\033[0m %s\n", r.fqn)
+		} else {
+			fmt.Fprintf(stdout, "  \033[31m✗\033[0m %s (exit %d)\n", r.fqn, r.rc)
+			failures++
+		}
+	}
+	if failures > 0 {
+		fmt.Fprintf(stdout, "\n%d of %d action(s) failed.\n", failures, len(results))
+		return 1
+	}
+	fmt.Fprintf(stdout, "\nAll %d action(s) installed.\n", len(results))
 	return 0
 }
 

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -4208,6 +4208,377 @@ func TestRunActionAdd_PublisherKeyFetchFailureExits1(t *testing.T) {
 	}
 }
 
+// --- runActionAddSuite: -f manifest install (issue #564) ---
+
+// writeSuiteManifest writes a TOML suite manifest to a temp file
+// and returns the path. The caller can then point `aileron action
+// add -f` at it. Inline TOML keeps the test self-contained.
+func writeSuiteManifest(t *testing.T, body string) string {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "suite.toml")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write suite manifest: %v", err)
+	}
+	return path
+}
+
+// suiteInstallServer is the suite-test analogue of
+// actionInstallServer. It seeds the keyring and stands up a fake
+// daemon that records (preview, install) hits per FQN so tests can
+// assert which actions made it through. Each handler may be nil to
+// fall through to a default success response.
+//
+// per-FQN handlers receive the action FQN extracted from the
+// request body (without @<version>) so the test can match on a
+// specific entry.
+func suiteInstallServer(
+	t *testing.T,
+	authorities []string,
+	onPreview func(fqn string, w http.ResponseWriter, r *http.Request),
+	onInstall func(fqn string, w http.ResponseWriter, r *http.Request),
+) *httptest.Server {
+	t.Helper()
+	withSeededKeyring(t, authorities...)
+	return fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			FQN string `json:"fqn"`
+		}
+		_ = json.Unmarshal(body, &req)
+		// Restore body so handlers can re-read if they want.
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		switch r.URL.Path {
+		case "/actions/preview":
+			if onPreview != nil {
+				onPreview(req.FQN, w, r)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.1.0","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			if onInstall != nil {
+				onInstall(req.FQN, w, r)
+				return
+			}
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.1.0","source":%q,"path":"/p"}`,
+				lastSegment(req.FQN), req.FQN, req.FQN+"@0.1.0")
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+}
+
+// lastSegment returns the slug after the last `/` in an FQN,
+// suitable as a synthetic action `name` in test responses.
+func lastSegment(fqn string) string {
+	if i := strings.LastIndex(fqn, "/"); i >= 0 {
+		return fqn[i+1:]
+	}
+	return fqn
+}
+
+// TestRunActionAddSuite_HappyPathInstallsEveryAction is the headline
+// #564 test: a manifest with three actions installs all three and
+// the final summary lists them as added.
+func TestRunActionAddSuite_HappyPathInstallsEveryAction(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+[suite]
+name = "test-suite"
+description = "A test suite"
+
+[[actions]]
+fqn = "github://acme/conn/actions/foo@0.1.0"
+
+[[actions]]
+fqn = "github://acme/conn/actions/bar@0.1.0"
+
+[[actions]]
+fqn = "github://acme/conn/actions/baz@0.1.0"
+`)
+	installed := map[string]int{}
+	suiteInstallServer(t, []string{"github://acme/conn"}, nil, func(fqn string, w http.ResponseWriter, r *http.Request) {
+		installed[fqn]++
+		w.WriteHeader(http.StatusCreated)
+		fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.1.0","source":"x","path":"/p"}`,
+			lastSegment(fqn), fqn)
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd([]string{"-f", manifestPath, "--yes"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	for _, want := range []string{
+		"github://acme/conn/actions/foo",
+		"github://acme/conn/actions/bar",
+		"github://acme/conn/actions/baz",
+	} {
+		if installed[want] != 1 {
+			t.Errorf("install for %s: hits = %d, want 1", want, installed[want])
+		}
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Suite: test-suite",
+		"3 action(s) to install",
+		"Suite install summary:",
+		"All 3 action(s) installed.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunActionAddSuite_SharesTrustPromptAcrossActions: when every
+// action in the suite shares an authority, the trust prompt fires
+// at most once per run. This is the "user doesn't see the same
+// trust prompt N times" guarantee from the acceptance criteria.
+func TestRunActionAddSuite_SharesTrustPromptAcrossActions(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	manifestPath := writeSuiteManifest(t, `
+[suite]
+name = "shared-trust"
+description = "Three actions, one publisher"
+
+[[actions]]
+fqn = "github://acme/conn/actions/foo@0.1.0"
+
+[[actions]]
+fqn = "github://acme/conn/actions/bar@0.1.0"
+
+[[actions]]
+fqn = "github://acme/conn/actions/baz@0.1.0"
+`)
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct{ FQN string `json:"fqn"` }
+		_ = json.Unmarshal(body, &req)
+		switch r.URL.Path {
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.1.0","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.1.0","source":"x","path":"/p"}`,
+				lastSegment(req.FQN), req.FQN)
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd([]string{"-f", manifestPath, "--yes"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	// Trust prompt block lives in stdout. Count occurrences — must be 1.
+	count := strings.Count(stdout.String(), "Publisher github://acme/conn is not yet trusted")
+	if count != 1 {
+		t.Errorf("trust banner appeared %d times across the suite; want 1\nstdout:\n%s", count, stdout.String())
+	}
+}
+
+// TestRunActionAddSuite_FailureSoftContinuesAfterMidStreamFailure
+// asserts the documented failure semantics: when one action fails,
+// the loop continues with the rest, the summary lists each
+// outcome, and the exit code is nonzero.
+func TestRunActionAddSuite_FailureSoftContinuesAfterMidStreamFailure(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+[suite]
+name = "mixed"
+description = "First and third succeed; second fails."
+
+[[actions]]
+fqn = "github://acme/conn/actions/foo@0.1.0"
+
+[[actions]]
+fqn = "github://acme/conn/actions/bar@0.1.0"
+
+[[actions]]
+fqn = "github://acme/conn/actions/baz@0.1.0"
+`)
+	suiteInstallServer(t, []string{"github://acme/conn"},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(fqn, "/bar") {
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = io.WriteString(w, `{"error":{"code":"signature_failure","message":"bad signature"}}`)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.1.0","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				fqn, lastSegment(fqn))
+		},
+		nil,
+	)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd([]string{"-f", manifestPath, "--yes"}, strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Errorf("expected nonzero exit when an action fails; stderr=%s", stderr.String())
+	}
+	out := stdout.String()
+	// ANSI color codes wrap the ✓/✗ markers, so match the bare FQNs
+	// in the summary plus the failure-count footer.
+	for _, want := range []string{
+		"github://acme/conn/actions/foo@0.1.0",
+		"github://acme/conn/actions/bar@0.1.0",
+		"github://acme/conn/actions/baz@0.1.0",
+		"1 of 3 action(s) failed.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// The bar entry must show as a failure (exit code suffix); the
+	// other two as ✓-prefixed entries.
+	if !strings.Contains(out, "actions/bar@0.1.0 (exit 1)") {
+		t.Errorf("bar entry should render with (exit N) suffix:\n%s", out)
+	}
+}
+
+// TestRunActionAddSuite_AlreadyInstalledIsLoggedAsSuccess: when an
+// action is already installed at the same content hash, it counts
+// as a success in the summary (the suite intent — "have these
+// actions installed" — is satisfied).
+func TestRunActionAddSuite_AlreadyInstalledIsLoggedAsSuccess(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+[suite]
+name = "rerun"
+description = "Re-running with everything already installed."
+
+[[actions]]
+fqn = "github://acme/conn/actions/foo@0.1.0"
+
+[[actions]]
+fqn = "github://acme/conn/actions/bar@0.1.0"
+`)
+	suiteInstallServer(t, []string{"github://acme/conn"},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.1.0","hash":"sha256:abc","name":%q,"already_installed":true,"connector_deps":[]}`,
+				fqn, lastSegment(fqn))
+		},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			t.Errorf("install endpoint should not be hit for already_installed entries (fqn=%s)", fqn)
+		},
+	)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd([]string{"-f", manifestPath}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	out := stdout.String()
+	if strings.Count(out, "Already installed:") != 2 {
+		t.Errorf("expected 2 'Already installed' lines; got: %s", out)
+	}
+	if !strings.Contains(out, "All 2 action(s) installed.") {
+		t.Errorf("summary should treat already-installed as success: %s", out)
+	}
+}
+
+// TestRunActionAddSuite_MissingManifestFileExits1 surfaces a clear
+// error rather than a panic when the user points -f at a path that
+// doesn't exist.
+func TestRunActionAddSuite_MissingManifestFileExits1(t *testing.T) {
+	withSeededKeyring(t)
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"-f", "/no/such/file.toml"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code == 0 {
+		t.Errorf("expected nonzero exit; stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "read suite manifest") {
+		t.Errorf("expected read-error in stderr; got: %s", stderr.String())
+	}
+}
+
+// TestRunActionAddSuite_RejectsCombinedPositionalAndFile: -f and
+// a positional FQN at the same time is ambiguous; surface it as
+// an error rather than picking one and ignoring the other.
+func TestRunActionAddSuite_RejectsCombinedPositionalAndFile(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+[suite]
+name = "x"
+description = "x"
+[[actions]]
+fqn = "github://acme/conn/actions/foo@0.1.0"
+`)
+	withSeededKeyring(t)
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"-f", manifestPath, "github://acme/conn/actions/extra@0.1.0"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code == 0 {
+		t.Errorf("expected nonzero exit when -f combined with positional; stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "cannot combine") {
+		t.Errorf("expected 'cannot combine' error; got: %s", stderr.String())
+	}
+}
+
+// TestRunActionAddSuite_TrustDeclineSkipsRemainingSameAuthority:
+// when the user declines trust mid-suite, subsequent actions that
+// share the declined authority skip silently rather than re-
+// prompting. The user only sees the trust banner once.
+func TestRunActionAddSuite_TrustDeclineSkipsRemainingSameAuthority(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	manifestPath := writeSuiteManifest(t, `
+[suite]
+name = "decline-test"
+description = "Decline trust; remaining actions should skip."
+
+[[actions]]
+fqn = "github://acme/conn/actions/foo@0.1.0"
+
+[[actions]]
+fqn = "github://acme/conn/actions/bar@0.1.0"
+
+[[actions]]
+fqn = "github://acme/conn/actions/baz@0.1.0"
+`)
+	previewHits := 0
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/actions/preview" {
+			previewHits++
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = io.WriteString(w, `{}`)
+	})
+
+	stdin := bufio.NewReader(strings.NewReader("n\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd([]string{"-f", manifestPath}, stdin, &stdout, &stderr)
+	if code == 0 {
+		t.Errorf("expected nonzero exit when trust declined; stderr=%s", stderr.String())
+	}
+	if previewHits != 0 {
+		t.Errorf("preview hit %d times after trust decline; want 0", previewHits)
+	}
+	if strings.Count(stdout.String(), "Publisher github://acme/conn is not yet trusted") != 1 {
+		t.Errorf("trust banner should fire once across the suite, not per action:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "1 of 3") && !strings.Contains(stdout.String(), "3 of 3") {
+		t.Errorf("summary should report failures; got: %s", stdout.String())
+	}
+}
+
 // --- aileron audit ---
 
 // TestRunAudit_EmptyPrintsNoEntries: with no events the CLI prints a

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -48,15 +48,32 @@ aileron dev (f66e51c)
 
 ## 2. Install Actions for Gmail and Calendar
 
-`aileron action add` is the one command you need. On a fresh machine, the first invocation prompts to trust the publisher's signing key, installs the action's connector dependency, and walks you through Google's OAuth consent screen to bind a credential. Subsequent installs reuse the trust, the connector, and the binding.
+The `aileron-connector-google` connector ships several action templates: read Gmail, draft an email, read your calendar, create an event. Install them as a suite by pointing `aileron action add` at a TOML manifest.
 
-Pick the latest release tag from [the connector's releases page](https://github.com/ALRubinger/aileron-connector-google/releases) and substitute it for `0.0.6` below.
+Save this as `gmail-and-calendar.toml`. Pick the latest release tag from [the connector's releases page](https://github.com/ALRubinger/aileron-connector-google/releases) and substitute it for `0.0.6`:
+
+```toml
+[suite]
+name = "gmail-and-calendar"
+description = "Read and draft Gmail; read and create calendar events"
+
+[[actions]]
+fqn = "github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6"
+
+[[actions]]
+fqn = "github://ALRubinger/aileron-connector-google/actions/get-email@0.0.6"
+
+[[actions]]
+fqn = "github://ALRubinger/aileron-connector-google/actions/list-upcoming-events@0.0.6"
+
+[[actions]]
+fqn = "github://ALRubinger/aileron-connector-google/actions/draft-email@0.0.6"
+```
+
+Then run:
 
 ```sh
-aileron action add github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6 && \
-  aileron action add github://ALRubinger/aileron-connector-google/actions/get-email@0.0.6 && \
-  aileron action add github://ALRubinger/aileron-connector-google/actions/list-upcoming-events@0.0.6 && \
-  aileron action add github://ALRubinger/aileron-connector-google/actions/draft-email@0.0.6
+aileron action add -f gmail-and-calendar.toml
 ```
 
 This is the first command that touches your local secret store, so Aileron walks you through creating one before recording trust. You'll see this prompt now:
@@ -91,11 +108,11 @@ Trust publisher github://ALRubinger/aileron-connector-google? [y/N]: y
   Keyring: /Users/you/.aileron/keyring.json
 ```
 
-The first `action add` then resolves the action's connector dependency, fetches the connector tarball from the GitHub release, verifies the signature against the trusted key, computes the content hash, and walks you through Google's OAuth consent screen to bind a credential. Confirm each step. Subsequent installs in the chain reuse the trust, the connector, and the binding.
+The trust prompt fires once for the publisher and applies to every action in the suite. Aileron then walks each action through preview and install in declaration order. The connector tarball is fetched once and reused. Google's OAuth consent screen pops up on the first action, and the credential binds for all four. The CLI prints a per-action summary at the end.
 
 The connector's publisher already shipped a Desktop OAuth `client_id` and `client_secret` bound at release time, so there's no Google Cloud Console setup on your end. The token bytes are encrypted at rest; Aileron refreshes them transparently when they near expiry, and the connector never sees the credential.
 
-If you prefer to manage trust separately from install, run `aileron keyring trust <authority>` before `aileron action add`. Either path works; the unified flow is just the default.
+If you'd rather drive each step yourself, the single-action form `aileron action add <action-FQN>` still works, and `aileron keyring trust <authority>` runs the trust step on its own. The suite manifest is the default flow because it names the set as a single intent.
 
 ## 3. Launch Claude Code through Aileron
 

--- a/internal/suite/manifest.go
+++ b/internal/suite/manifest.go
@@ -1,0 +1,109 @@
+// Package suite parses Aileron action-suite manifests — the
+// "group install" primitive from issue #564. A suite manifest names
+// a set of actions that get installed together via
+// `aileron action add -f <path>`, sharing connector resolution and
+// trust prompts across the whole set.
+//
+// v1 supports local files only. The parser is closed: unknown
+// top-level keys, unknown per-action keys, missing required fields,
+// and an empty `[[actions]]` array all surface as errors. The aim
+// is to fail loudly when a typo would otherwise silently install a
+// different set than the user expected.
+package suite
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/BurntSushi/toml"
+)
+
+// Manifest is the parsed form of a suite TOML file.
+//
+// Example:
+//
+//	[suite]
+//	name = "gmail-and-calendar"
+//	description = "Read and draft Gmail; read and create calendar events"
+//
+//	[[actions]]
+//	fqn = "github://owner/repo/actions/list-recent-emails@0.0.6"
+//
+//	[[actions]]
+//	fqn = "github://owner/repo/actions/get-email@0.0.6"
+type Manifest struct {
+	// Suite is the manifest's metadata block. Required.
+	Suite Suite `toml:"suite"`
+
+	// Actions is the ordered list of actions to install. Required and
+	// non-empty: a suite with zero actions has no semantic meaning.
+	Actions []Action `toml:"actions"`
+}
+
+// Suite carries the human-readable identity of the manifest. Both
+// fields are required so users (and any future Hub publish path)
+// can render a suite without falling back to "untitled".
+type Suite struct {
+	Name        string `toml:"name"`
+	Description string `toml:"description"`
+}
+
+// Action is one entry in the suite's install list. Each FQN must
+// embed an `@<version>` suffix; v1 doesn't support floating versions
+// in suite manifests because the same source could resolve to
+// different bytes on different days, breaking reproducibility.
+type Action struct {
+	// FQN is the fully-qualified `<scheme>://<owner>/<repo>/<subpath>@<version>`
+	// reference — same form `aileron action add <FQN>@<version>`
+	// accepts on the command line.
+	FQN string `toml:"fqn"`
+}
+
+// Parse reads suite TOML from data, validates structurally, and
+// returns the populated Manifest. `file` is included in error
+// messages so users can map the failure back to the source file.
+//
+// Strict-mode rules:
+//   - Unknown top-level keys → error.
+//   - Unknown keys inside `[suite]` or each `[[actions]]` → error.
+//   - Missing `[suite].name` or `[suite].description` → error.
+//   - Empty `[[actions]]` → error.
+//   - Each action's `fqn` must be non-empty and contain `@<version>`.
+//
+// The parser does NOT validate FQN syntax beyond the `@<version>`
+// presence check — that's the install pipeline's job (and runs the
+// same `cstore.ParseRef` the single-action path uses).
+func Parse(file string, data []byte) (*Manifest, error) {
+	var m Manifest
+	meta, err := toml.Decode(string(data), &m)
+	if err != nil {
+		return nil, fmt.Errorf("parse %q: %w", file, err)
+	}
+
+	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+		keys := make([]string, 0, len(undecoded))
+		for _, k := range undecoded {
+			keys = append(keys, k.String())
+		}
+		return nil, fmt.Errorf("parse %q: unknown key(s): %s", file, strings.Join(keys, ", "))
+	}
+
+	if m.Suite.Name == "" {
+		return nil, fmt.Errorf("parse %q: [suite].name is required", file)
+	}
+	if m.Suite.Description == "" {
+		return nil, fmt.Errorf("parse %q: [suite].description is required", file)
+	}
+	if len(m.Actions) == 0 {
+		return nil, fmt.Errorf("parse %q: at least one [[actions]] entry is required", file)
+	}
+	for i, a := range m.Actions {
+		if a.FQN == "" {
+			return nil, fmt.Errorf("parse %q: actions[%d].fqn is required", file, i)
+		}
+		if !strings.Contains(a.FQN, "@") {
+			return nil, fmt.Errorf("parse %q: actions[%d].fqn %q must include @<version>", file, i, a.FQN)
+		}
+	}
+	return &m, nil
+}

--- a/internal/suite/manifest_test.go
+++ b/internal/suite/manifest_test.go
@@ -1,0 +1,240 @@
+package suite
+
+import (
+	"strings"
+	"testing"
+)
+
+// TestParse_HappyPath verifies a well-formed manifest decodes to the
+// expected struct shape. This is the contract the CLI's `-f` path
+// reads against.
+func TestParse_HappyPath(t *testing.T) {
+	data := []byte(`
+[suite]
+name = "gmail-and-calendar"
+description = "Read and draft Gmail; read and create calendar events"
+
+[[actions]]
+fqn = "github://owner/repo/actions/list-recent-emails@0.0.6"
+
+[[actions]]
+fqn = "github://owner/repo/actions/get-email@0.0.6"
+`)
+	m, err := Parse("test.toml", data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if m.Suite.Name != "gmail-and-calendar" {
+		t.Errorf("Suite.Name = %q", m.Suite.Name)
+	}
+	if m.Suite.Description == "" {
+		t.Error("Suite.Description should be set")
+	}
+	if len(m.Actions) != 2 {
+		t.Fatalf("len(Actions) = %d, want 2", len(m.Actions))
+	}
+	if m.Actions[0].FQN != "github://owner/repo/actions/list-recent-emails@0.0.6" {
+		t.Errorf("Actions[0].FQN = %q", m.Actions[0].FQN)
+	}
+}
+
+// TestParse_RejectsUnknownTopLevelKey is the strict-mode contract:
+// a typo at the top level fails fast rather than silently installing
+// the wrong thing.
+func TestParse_RejectsUnknownTopLevelKey(t *testing.T) {
+	data := []byte(`
+[suite]
+name = "x"
+description = "x"
+
+[bogus]
+key = "value"
+
+[[actions]]
+fqn = "github://owner/repo/actions/foo@1.0.0"
+`)
+	_, err := Parse("test.toml", data)
+	if err == nil {
+		t.Fatal("expected error for unknown top-level key")
+	}
+	if !strings.Contains(err.Error(), "unknown key") {
+		t.Errorf("error should mention unknown key; got: %v", err)
+	}
+}
+
+// TestParse_RejectsUnknownActionKey: per-action keys are equally
+// closed. A user who types `name = "x"` (instead of editing the
+// FQN) should see an error, not a silently-misnamed install.
+func TestParse_RejectsUnknownActionKey(t *testing.T) {
+	data := []byte(`
+[suite]
+name = "x"
+description = "x"
+
+[[actions]]
+fqn = "github://owner/repo/actions/foo@1.0.0"
+nickname = "foo-action"
+`)
+	_, err := Parse("test.toml", data)
+	if err == nil {
+		t.Fatal("expected error for unknown action key")
+	}
+	if !strings.Contains(err.Error(), "unknown key") {
+		t.Errorf("error should mention unknown key; got: %v", err)
+	}
+}
+
+// TestParse_RejectsUnknownSuiteKey: same closed-schema rule for the
+// [suite] table itself.
+func TestParse_RejectsUnknownSuiteKey(t *testing.T) {
+	data := []byte(`
+[suite]
+name = "x"
+description = "x"
+maintainer = "alice"
+
+[[actions]]
+fqn = "github://owner/repo/actions/foo@1.0.0"
+`)
+	_, err := Parse("test.toml", data)
+	if err == nil {
+		t.Fatal("expected error for unknown suite key")
+	}
+	if !strings.Contains(err.Error(), "unknown key") {
+		t.Errorf("error should mention unknown key; got: %v", err)
+	}
+}
+
+// TestParse_RequiresSuiteName: missing required metadata fails.
+func TestParse_RequiresSuiteName(t *testing.T) {
+	data := []byte(`
+[suite]
+description = "x"
+
+[[actions]]
+fqn = "github://owner/repo/actions/foo@1.0.0"
+`)
+	_, err := Parse("test.toml", data)
+	if err == nil {
+		t.Fatal("expected error for missing suite.name")
+	}
+	if !strings.Contains(err.Error(), "[suite].name") {
+		t.Errorf("error should mention [suite].name; got: %v", err)
+	}
+}
+
+// TestParse_RequiresSuiteDescription: same for description.
+func TestParse_RequiresSuiteDescription(t *testing.T) {
+	data := []byte(`
+[suite]
+name = "x"
+
+[[actions]]
+fqn = "github://owner/repo/actions/foo@1.0.0"
+`)
+	_, err := Parse("test.toml", data)
+	if err == nil {
+		t.Fatal("expected error for missing suite.description")
+	}
+	if !strings.Contains(err.Error(), "[suite].description") {
+		t.Errorf("error should mention [suite].description; got: %v", err)
+	}
+}
+
+// TestParse_RejectsEmptyActions: a suite with zero actions has no
+// semantic meaning; surface it loudly.
+func TestParse_RejectsEmptyActions(t *testing.T) {
+	data := []byte(`
+[suite]
+name = "x"
+description = "x"
+`)
+	_, err := Parse("test.toml", data)
+	if err == nil {
+		t.Fatal("expected error for empty actions")
+	}
+	if !strings.Contains(err.Error(), "[[actions]]") {
+		t.Errorf("error should mention [[actions]]; got: %v", err)
+	}
+}
+
+// TestParse_RejectsActionWithoutVersion: floating versions break
+// reproducibility — the same source could resolve to different
+// bytes on different days. v1 requires `@<version>`.
+func TestParse_RejectsActionWithoutVersion(t *testing.T) {
+	data := []byte(`
+[suite]
+name = "x"
+description = "x"
+
+[[actions]]
+fqn = "github://owner/repo/actions/foo"
+`)
+	_, err := Parse("test.toml", data)
+	if err == nil {
+		t.Fatal("expected error for action without @<version>")
+	}
+	if !strings.Contains(err.Error(), "@<version>") {
+		t.Errorf("error should mention @<version>; got: %v", err)
+	}
+}
+
+// TestParse_RejectsEmptyActionFQN: an action entry with an explicit
+// empty fqn is a misconfigured manifest.
+func TestParse_RejectsEmptyActionFQN(t *testing.T) {
+	data := []byte(`
+[suite]
+name = "x"
+description = "x"
+
+[[actions]]
+fqn = ""
+`)
+	_, err := Parse("test.toml", data)
+	if err == nil {
+		t.Fatal("expected error for empty action fqn")
+	}
+	if !strings.Contains(err.Error(), "fqn is required") {
+		t.Errorf("error should mention fqn required; got: %v", err)
+	}
+}
+
+// TestParse_RejectsMalformedTOML: surface TOML decode errors
+// faithfully so users can locate the bad line.
+func TestParse_RejectsMalformedTOML(t *testing.T) {
+	data := []byte(`[suite
+name = "x"`)
+	_, err := Parse("test.toml", data)
+	if err == nil {
+		t.Fatal("expected error for malformed TOML")
+	}
+}
+
+// TestParse_PreservesActionOrder: the install loop walks the list
+// in declaration order. Verify the parser keeps that order.
+func TestParse_PreservesActionOrder(t *testing.T) {
+	data := []byte(`
+[suite]
+name = "x"
+description = "x"
+
+[[actions]]
+fqn = "github://owner/repo/actions/aaa@1.0.0"
+
+[[actions]]
+fqn = "github://owner/repo/actions/bbb@1.0.0"
+
+[[actions]]
+fqn = "github://owner/repo/actions/ccc@1.0.0"
+`)
+	m, err := Parse("test.toml", data)
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	want := []string{"aaa", "bbb", "ccc"}
+	for i, w := range want {
+		if !strings.Contains(m.Actions[i].FQN, w) {
+			t.Errorf("Actions[%d].FQN = %q, want substring %q", i, m.Actions[i].FQN, w)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Adds a "group install" primitive analogous to `dnf groupinstall`. A TOML suite manifest names a set of actions to install together; `aileron action add -f <path>` installs them all in one operation, sharing trust prompts, connector resolution, and binding state across the whole set. Closes #564.

- New `internal/suite` package parses manifests strictly (closed schema; unknown fields are an error). Each entry's FQN must include `@<version>` so the suite is reproducible.
- `runActionAdd` now dispatches to a suite path when `-f` / `--file` is present, otherwise runs the existing single-action path. Detection is pre-parse so `extractPositional` doesn't mistake the suite path for a positional FQN.
- Extracted `installOneAction` from the original `runActionAdd` body. Both single-action and suite callers reuse it. Suite mode threads one `trustState` through every entry so a publisher's prompt fires at most once per run, even across N actions.
- `trustState` tracks both trusted and declined authorities. Declined authorities short-circuit subsequent same-authority actions with a skip message rather than re-prompting.
- Suite loop is failure-soft: a per-action failure is captured in the final summary; the loop continues with the next action; the CLI exits nonzero if any action failed.
- Liftoff guide §2 collapses the four chained `action add` calls into a single `gmail-and-calendar.toml` manifest plus `aileron action add -f gmail-and-calendar.toml`. Single-action form documented as fallback.

## Manifest schema

```toml
[suite]
name = "gmail-and-calendar"
description = "Read and draft Gmail; read and create calendar events"

[[actions]]
fqn = "github://owner/repo/actions/<name>@<version>"
```

## Test plan

- [x] `go test ./internal/suite/...` — 11 tests cover happy path, strict-mode rejection of unknown keys (top-level, `[suite]`, per-action), required-field enforcement, missing `@<version>`, malformed TOML, declaration-order preservation. 100% coverage on the package.
- [x] `go test ./cmd/aileron/... -run TestRunActionAddSuite` — 7 tests:
  - `_HappyPathInstallsEveryAction` — 3-action manifest, all install
  - `_SharesTrustPromptAcrossActions` — trust banner appears once across the suite
  - `_FailureSoftContinuesAfterMidStreamFailure` — action 2 fails, action 3 still installs, summary lists each
  - `_AlreadyInstalledIsLoggedAsSuccess` — re-running with everything installed is a no-op
  - `_MissingManifestFileExits1` — clean error on bad path
  - `_RejectsCombinedPositionalAndFile` — `-f` + positional FQN errors
  - `_TrustDeclineSkipsRemainingSameAuthority` — declining trust mid-suite skips remaining same-authority actions silently
- [x] All existing `TestRunAction*` tests still pass after the dispatcher refactor.
- [x] `task test` — full workspace green
- [x] `task lint:go` and `task lint:docs` — clean
- [x] Coverage: `runActionAddSuite` 89.3%; `installOneAction` 79% (unchanged from pre-refactor `runActionAdd`); `internal/suite` 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)