### PR TITLE
feat(action): `add-suite` subcommand + manifest v2 schema

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -1468,19 +1468,27 @@ const connectorUsage = `usage:
   aileron connector check [--include-prerelease] [--json]`
 
 const actionUsage = `usage:
-  aileron action add <FQN>     [--version=<v>] [--force] [--yes] [--no-bind]
-  aileron action add -f <path> [--force] [--yes] [--no-bind]
+  aileron action add <FQN>             [--version=<v>] [--force] [--yes] [--no-bind]
+  aileron action add-suite <SOURCE>    [--force] [--yes] [--no-bind]
 
 Single-action form: install one action by FQN. Trust + connector
 install are absorbed into this command (issue #563): on a fresh
 machine the CLI prompts to trust the publisher's signing key before
 preview, then prompts for the install consent.
 
-Suite form (issue #564): -f points at a TOML manifest listing a set
-of actions. The CLI installs each in order, sharing trust + connector
-state across the set so a publisher's prompt fires at most once per
-run. Per-action failures are surfaced in a final summary; the
-remaining actions still install (failure-soft).
+Suite form (issue #564): <SOURCE> is either:
+  - <scheme>://<owner>/<repo>/<file-path>@<ref>   (remote)
+  - <local-filesystem-path>                       (no scheme)
+
+Remote refs:
+  @latest     latest non-draft, non-prerelease release
+  @<tag>      a specific release tag (e.g. v0.0.6)
+  @<sha>      a specific commit SHA (40 hex chars)
+
+The CLI installs each action in declaration order, sharing trust +
+connector state across the set so a publisher's prompt fires at most
+once per run. Per-action failures are surfaced in a final summary;
+the remaining actions still install (failure-soft).
 
 Pass --yes to auto-accept all trust + consent prompts in
 non-interactive use.`
@@ -1635,6 +1643,8 @@ func runAction(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	switch args[0] {
 	case "add":
 		return runActionAdd(args[1:], br, stdout, stderr)
+	case "add-suite":
+		return runActionAddSuite(args[1:], br, stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown action command: %q\n", args[0])
 		fmt.Fprintln(stderr, actionUsage)
@@ -2161,22 +2171,10 @@ type actionAddOptions struct {
 	noBind  bool
 }
 
-// runActionAdd dispatches `aileron action add` to one of two paths:
-//
-//   - Suite form (`-f <path>`): parses the manifest at <path> and
-//     installs every action in it, sharing trust + connector state
-//     across the set (issue #564).
-//   - Single-action form (`<FQN>`): installs one action (issue #563
-//     auto-trust + connector install).
-//
-// Detection is pre-parse: scanning args for `-f` / `--file` so the
-// existing extractPositional path (which would otherwise treat the
-// suite path as a positional FQN) is bypassed cleanly.
+// runActionAdd installs a single action by FQN (issue #563
+// auto-trust + connector install). Suite installs go through the
+// peer subcommand `aileron action add-suite` (issue #564).
 func runActionAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
-	if hasFileFlag(args) {
-		return runActionAddSuite(args, stdin, stdout, stderr)
-	}
-
 	fqnArg, rest, ok := extractPositional(args)
 	if !ok {
 		fmt.Fprintln(stderr, actionUsage)
@@ -2199,22 +2197,6 @@ func runActionAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int 
 		noBind:  *noBind,
 	}
 	return installOneAction(opts, stdin, stdout, stderr, newTrustState())
-}
-
-// hasFileFlag reports whether args contain a `-f` / `--file`
-// invocation in any of the supported forms (`-f path`, `-f=path`,
-// `--file path`, `--file=path`). Used by runActionAdd to dispatch
-// to the suite-install path before the single-action path's
-// positional extractor (which doesn't know about value-taking
-// flags) gets confused by `-f path`.
-func hasFileFlag(args []string) bool {
-	for _, a := range args {
-		if a == "-f" || a == "--file" ||
-			strings.HasPrefix(a, "-f=") || strings.HasPrefix(a, "--file=") {
-			return true
-		}
-	}
-	return false
 }
 
 // installOneAction runs the full trust → preview → consent →
@@ -2397,45 +2379,59 @@ func installOneAction(opts actionAddOptions, stdin io.Reader, stdout, stderr io.
 	return 0
 }
 
-// runActionAddSuite implements `aileron action add -f <path>`
-// (issue #564). Parses the suite manifest at <path>, then installs
-// each action in declaration order via installOneAction, sharing a
-// single trustState so a publisher's prompt fires once per run
-// regardless of how many actions in the suite reference it.
+// runActionAddSuite implements `aileron action add-suite <SOURCE>`
+// (issue #564). Source is one of:
 //
-// Failure semantics are deliberately failure-soft: a per-action
-// install failure is captured in the final summary and the loop
-// continues with the next action. The CLI exits nonzero if any
-// action failed, so scripts can branch on the return code without
-// parsing the summary. Trust declines are treated like any other
-// per-action failure, but subsequent actions sharing the declined
-// authority skip silently (trustState.declined) so the user is not
-// re-prompted N-1 times for the same publisher.
+//   - Remote: `<scheme>://<owner>/<repo>/<file-path>@<ref>` — the
+//     CLI resolves the ref (latest / tag / sha), fetches the suite
+//     manifest from raw.githubusercontent.com, and uses the resolved
+//     ref to set the install version of path-form entries.
+//   - Local: any path without a `<scheme>://` prefix — the CLI
+//     reads the file from disk and installs entries that all carry
+//     explicit `<FQN>@<version>` (path-form requires a remote ref
+//     to inherit).
+//
+// Each action installs in declaration order via installOneAction,
+// sharing a single trustState so a publisher's prompt fires once
+// per run regardless of how many entries reference it. Failure
+// semantics are failure-soft (per-action failures captured in the
+// summary; loop continues; nonzero exit if any failed).
 func runActionAddSuite(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
-	flags := flag.NewFlagSet("action add -f", flag.ContinueOnError)
+	flags := flag.NewFlagSet("action add-suite", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	suitePath := flags.String("f", "", "path to a suite manifest TOML file")
-	suitePathLong := flags.String("file", "", "path to a suite manifest TOML file (alias for -f)")
 	force := flags.Bool("force", false, "overwrite existing actions with the same name")
 	noBind := flags.Bool("no-bind", false, "skip the auto-prompt for unbound credentials (use in scripts)")
 	yes := flags.Bool("yes", false, "skip the consent prompts and proceed without confirmation")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
-	if len(flags.Args()) > 0 {
-		fmt.Fprintln(stderr, "error: cannot combine -f with a positional FQN")
+	if len(flags.Args()) != 1 {
+		fmt.Fprintln(stderr, "error: add-suite takes exactly one source argument")
 		fmt.Fprintln(stderr, actionUsage)
 		return 1
 	}
-	path := *suitePath
-	if path == "" {
-		path = *suitePathLong
-	}
-	if path == "" {
-		fmt.Fprintln(stderr, "error: -f/--file requires a path to a suite manifest")
-		return 1
+	source := flags.Args()[0]
+
+	opts := actionAddOptions{force: *force, yes: *yes, noBind: *noBind}
+
+	// Buffered stdin so each prompt picks up where the previous
+	// left off — same reason runAction wraps stdin for the single-
+	// action path.
+	br, ok := stdin.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(stdin)
 	}
 
+	if strings.Contains(source, "://") {
+		return runActionAddSuiteRemote(source, opts, br, stdout, stderr)
+	}
+	return runActionAddSuiteLocal(source, opts, br, stdout, stderr)
+}
+
+// runActionAddSuiteLocal handles a filesystem-path source: read,
+// parse, resolve with no inheritance context (path-form entries
+// in a local manifest are an error), then drive the shared loop.
+func runActionAddSuiteLocal(path string, opts actionAddOptions, stdin *bufio.Reader, stdout, stderr io.Writer) int {
 	data, err := os.ReadFile(path)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: read suite manifest: %v\n", err)
@@ -2446,50 +2442,101 @@ func runActionAddSuite(args []string, stdin io.Reader, stdout, stderr io.Writer)
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
-
-	fmt.Fprintf(stdout, "Suite: %s\n", manifest.Suite.Name)
-	if manifest.Suite.Description != "" {
-		fmt.Fprintf(stdout, "  %s\n", manifest.Suite.Description)
+	refs, err := suite.Resolve(manifest, cstore.FQN{}, "")
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s: %v\n", path, err)
+		return 1
 	}
-	fmt.Fprintf(stdout, "  %d action(s) to install\n", len(manifest.Actions))
+	return installSuiteEntries(manifest, refs, opts, stdin, stdout, stderr)
+}
 
-	// Buffered stdin so each prompt picks up where the previous
-	// left off — same reason runAction wraps stdin for the single-
-	// action path. The trust + consent prompts within each
-	// installOneAction share this reader.
-	br, ok := stdin.(*bufio.Reader)
-	if !ok {
-		br = bufio.NewReader(stdin)
+// runActionAddSuiteRemote handles an FQN-style source: parse the
+// `<URL>@<ref>` shape, resolve `latest` to a concrete tag if needed,
+// fetch the suite manifest from raw.githubusercontent.com, and
+// drive the shared loop with the resolved ref's bare SemVer (when
+// applicable) as the inheritance version for path-form entries.
+func runActionAddSuiteRemote(source string, opts actionAddOptions, stdin *bufio.Reader, stdout, stderr io.Writer) int {
+	suiteFQN, ref, err := parseSuiteSource(source)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
 	}
+	ctx := context.Background()
+	resolvedRef := ref
+	if ref == "latest" {
+		fmt.Fprintf(stdout, "Resolving @latest for %s/%s …\n", suiteFQN.Owner, suiteFQN.Repo)
+		tag, rerr := resolveLatestRef(ctx, suiteFQN)
+		if rerr != nil {
+			fmt.Fprintf(stderr, "error: %v\n", rerr)
+			return 1
+		}
+		resolvedRef = tag
+		fmt.Fprintf(stdout, "  → %s\n", tag)
+	}
+
+	data, err := fetchSuiteTOML(ctx, suiteFQN, resolvedRef)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	display := source
+	manifest, err := suite.Parse(display, data)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	// Path-form entries inherit the suite's version. Strip the `v`
+	// prefix from a release tag to get bare SemVer; SHAs and other
+	// non-SemVer refs leave inheritVersion empty, which surfaces as
+	// a clear error from suite.Resolve when path-form entries are
+	// present.
+	inheritVersion, _ := suiteVersionFromRef(resolvedRef)
+
+	refs, err := suite.Resolve(manifest, suiteFQN, inheritVersion)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %s: %v\n", display, err)
+		return 1
+	}
+	return installSuiteEntries(manifest, refs, opts, stdin, stdout, stderr)
+}
+
+// installSuiteEntries is the shared per-entry loop + summary used
+// by both local and remote suite paths. Each entry installs via
+// installOneAction; one trustState threads through every call so
+// publisher prompts fire at most once per run. Per-entry failures
+// are captured for the final summary; the loop never aborts mid-
+// stream (failure-soft).
+func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, opts actionAddOptions, stdin *bufio.Reader, stdout, stderr io.Writer) int {
+	fmt.Fprintf(stdout, "Suite: %s\n", manifest.Name)
+	if manifest.Description != "" {
+		fmt.Fprintf(stdout, "  %s\n", manifest.Description)
+	}
+	fmt.Fprintf(stdout, "  %d action(s) to install\n", len(refs))
 
 	trust := newTrustState()
 	type result struct {
-		fqn  string
-		rc   int
+		ref string
+		rc  int
 	}
-	results := make([]result, 0, len(manifest.Actions))
-	for i, action := range manifest.Actions {
+	results := make([]result, 0, len(refs))
+	for i, ref := range refs {
 		fmt.Fprintln(stdout)
-		fmt.Fprintf(stdout, "── [%d/%d] %s\n", i+1, len(manifest.Actions), action.FQN)
-		opts := actionAddOptions{
-			fqn:    action.FQN,
-			force:  *force,
-			yes:    *yes,
-			noBind: *noBind,
-		}
-		rc := installOneAction(opts, br, stdout, stderr, trust)
-		results = append(results, result{fqn: action.FQN, rc: rc})
+		fmt.Fprintf(stdout, "── [%d/%d] %s\n", i+1, len(refs), ref.String())
+		entryOpts := opts
+		entryOpts.fqn = ref.String()
+		rc := installOneAction(entryOpts, stdin, stdout, stderr, trust)
+		results = append(results, result{ref: ref.String(), rc: rc})
 	}
 
-	// Final summary: one line per action with its outcome.
 	fmt.Fprintln(stdout)
 	fmt.Fprintln(stdout, "Suite install summary:")
 	failures := 0
 	for _, r := range results {
 		if r.rc == 0 {
-			fmt.Fprintf(stdout, "  \033[32m✓\033[0m %s\n", r.fqn)
+			fmt.Fprintf(stdout, "  \033[32m✓\033[0m %s\n", r.ref)
 		} else {
-			fmt.Fprintf(stdout, "  \033[31m✗\033[0m %s (exit %d)\n", r.fqn, r.rc)
+			fmt.Fprintf(stdout, "  \033[31m✗\033[0m %s (exit %d)\n", r.ref, r.rc)
 			failures++
 		}
 	}

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -4281,22 +4281,18 @@ func lastSegment(fqn string) string {
 }
 
 // TestRunActionAddSuite_HappyPathInstallsEveryAction is the headline
-// #564 test: a manifest with three actions installs all three and
-// the final summary lists them as added.
+// #564 test: a local v2 manifest with three actions installs all
+// three and the final summary lists them as added.
 func TestRunActionAddSuite_HappyPathInstallsEveryAction(t *testing.T) {
 	manifestPath := writeSuiteManifest(t, `
-[suite]
 name = "test-suite"
 description = "A test suite"
 
-[[actions]]
-fqn = "github://acme/conn/actions/foo@0.1.0"
-
-[[actions]]
-fqn = "github://acme/conn/actions/bar@0.1.0"
-
-[[actions]]
-fqn = "github://acme/conn/actions/baz@0.1.0"
+actions = [
+  "github://acme/conn/actions/foo@0.1.0",
+  "github://acme/conn/actions/bar@0.1.0",
+  "github://acme/conn/actions/baz@0.1.0",
+]
 `)
 	installed := map[string]int{}
 	suiteInstallServer(t, []string{"github://acme/conn"}, nil, func(fqn string, w http.ResponseWriter, r *http.Request) {
@@ -4307,7 +4303,7 @@ fqn = "github://acme/conn/actions/baz@0.1.0"
 	})
 
 	var stdout, stderr bytes.Buffer
-	code := runActionAdd([]string{"-f", manifestPath, "--yes"}, strings.NewReader(""), &stdout, &stderr)
+	code := runActionAddSuite([]string{"--yes", manifestPath}, strings.NewReader(""), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
 	}
@@ -4335,8 +4331,7 @@ fqn = "github://acme/conn/actions/baz@0.1.0"
 
 // TestRunActionAddSuite_SharesTrustPromptAcrossActions: when every
 // action in the suite shares an authority, the trust prompt fires
-// at most once per run. This is the "user doesn't see the same
-// trust prompt N times" guarantee from the acceptance criteria.
+// at most once per run.
 func TestRunActionAddSuite_SharesTrustPromptAcrossActions(t *testing.T) {
 	withTempHome(t)
 	_, pemBytes := genTestKey(t)
@@ -4345,18 +4340,14 @@ func TestRunActionAddSuite_SharesTrustPromptAcrossActions(t *testing.T) {
 	})
 
 	manifestPath := writeSuiteManifest(t, `
-[suite]
 name = "shared-trust"
 description = "Three actions, one publisher"
 
-[[actions]]
-fqn = "github://acme/conn/actions/foo@0.1.0"
-
-[[actions]]
-fqn = "github://acme/conn/actions/bar@0.1.0"
-
-[[actions]]
-fqn = "github://acme/conn/actions/baz@0.1.0"
+actions = [
+  "github://acme/conn/actions/foo@0.1.0",
+  "github://acme/conn/actions/bar@0.1.0",
+  "github://acme/conn/actions/baz@0.1.0",
+]
 `)
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
@@ -4375,35 +4366,29 @@ fqn = "github://acme/conn/actions/baz@0.1.0"
 	})
 
 	var stdout, stderr bytes.Buffer
-	code := runActionAdd([]string{"-f", manifestPath, "--yes"}, strings.NewReader(""), &stdout, &stderr)
+	code := runActionAddSuite([]string{"--yes", manifestPath}, strings.NewReader(""), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
 	}
-	// Trust prompt block lives in stdout. Count occurrences — must be 1.
 	count := strings.Count(stdout.String(), "Publisher github://acme/conn is not yet trusted")
 	if count != 1 {
 		t.Errorf("trust banner appeared %d times across the suite; want 1\nstdout:\n%s", count, stdout.String())
 	}
 }
 
-// TestRunActionAddSuite_FailureSoftContinuesAfterMidStreamFailure
-// asserts the documented failure semantics: when one action fails,
-// the loop continues with the rest, the summary lists each
-// outcome, and the exit code is nonzero.
+// TestRunActionAddSuite_FailureSoftContinuesAfterMidStreamFailure:
+// per-action failure → loop continues; summary lists each outcome;
+// nonzero exit.
 func TestRunActionAddSuite_FailureSoftContinuesAfterMidStreamFailure(t *testing.T) {
 	manifestPath := writeSuiteManifest(t, `
-[suite]
 name = "mixed"
 description = "First and third succeed; second fails."
 
-[[actions]]
-fqn = "github://acme/conn/actions/foo@0.1.0"
-
-[[actions]]
-fqn = "github://acme/conn/actions/bar@0.1.0"
-
-[[actions]]
-fqn = "github://acme/conn/actions/baz@0.1.0"
+actions = [
+  "github://acme/conn/actions/foo@0.1.0",
+  "github://acme/conn/actions/bar@0.1.0",
+  "github://acme/conn/actions/baz@0.1.0",
+]
 `)
 	suiteInstallServer(t, []string{"github://acme/conn"},
 		func(fqn string, w http.ResponseWriter, r *http.Request) {
@@ -4420,13 +4405,11 @@ fqn = "github://acme/conn/actions/baz@0.1.0"
 	)
 
 	var stdout, stderr bytes.Buffer
-	code := runActionAdd([]string{"-f", manifestPath, "--yes"}, strings.NewReader(""), &stdout, &stderr)
+	code := runActionAddSuite([]string{"--yes", manifestPath}, strings.NewReader(""), &stdout, &stderr)
 	if code == 0 {
 		t.Errorf("expected nonzero exit when an action fails; stderr=%s", stderr.String())
 	}
 	out := stdout.String()
-	// ANSI color codes wrap the ✓/✗ markers, so match the bare FQNs
-	// in the summary plus the failure-count footer.
 	for _, want := range []string{
 		"github://acme/conn/actions/foo@0.1.0",
 		"github://acme/conn/actions/bar@0.1.0",
@@ -4437,28 +4420,23 @@ fqn = "github://acme/conn/actions/baz@0.1.0"
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
 	}
-	// The bar entry must show as a failure (exit code suffix); the
-	// other two as ✓-prefixed entries.
 	if !strings.Contains(out, "actions/bar@0.1.0 (exit 1)") {
 		t.Errorf("bar entry should render with (exit N) suffix:\n%s", out)
 	}
 }
 
-// TestRunActionAddSuite_AlreadyInstalledIsLoggedAsSuccess: when an
-// action is already installed at the same content hash, it counts
-// as a success in the summary (the suite intent — "have these
-// actions installed" — is satisfied).
+// TestRunActionAddSuite_AlreadyInstalledIsLoggedAsSuccess: an
+// already-installed action counts as success — the suite intent
+// is satisfied.
 func TestRunActionAddSuite_AlreadyInstalledIsLoggedAsSuccess(t *testing.T) {
 	manifestPath := writeSuiteManifest(t, `
-[suite]
 name = "rerun"
 description = "Re-running with everything already installed."
 
-[[actions]]
-fqn = "github://acme/conn/actions/foo@0.1.0"
-
-[[actions]]
-fqn = "github://acme/conn/actions/bar@0.1.0"
+actions = [
+  "github://acme/conn/actions/foo@0.1.0",
+  "github://acme/conn/actions/bar@0.1.0",
+]
 `)
 	suiteInstallServer(t, []string{"github://acme/conn"},
 		func(fqn string, w http.ResponseWriter, r *http.Request) {
@@ -4472,7 +4450,7 @@ fqn = "github://acme/conn/actions/bar@0.1.0"
 	)
 
 	var stdout, stderr bytes.Buffer
-	code := runActionAdd([]string{"-f", manifestPath}, strings.NewReader(""), &stdout, &stderr)
+	code := runActionAddSuite([]string{manifestPath}, strings.NewReader(""), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
 	}
@@ -4486,13 +4464,12 @@ fqn = "github://acme/conn/actions/bar@0.1.0"
 }
 
 // TestRunActionAddSuite_MissingManifestFileExits1 surfaces a clear
-// error rather than a panic when the user points -f at a path that
-// doesn't exist.
+// error when the local source path doesn't exist.
 func TestRunActionAddSuite_MissingManifestFileExits1(t *testing.T) {
 	withSeededKeyring(t)
 	var stdout, stderr bytes.Buffer
-	code := runActionAdd(
-		[]string{"-f", "/no/such/file.toml"},
+	code := runActionAddSuite(
+		[]string{"/no/such/file.toml"},
 		strings.NewReader(""), &stdout, &stderr,
 	)
 	if code == 0 {
@@ -4503,35 +4480,54 @@ func TestRunActionAddSuite_MissingManifestFileExits1(t *testing.T) {
 	}
 }
 
-// TestRunActionAddSuite_RejectsCombinedPositionalAndFile: -f and
-// a positional FQN at the same time is ambiguous; surface it as
-// an error rather than picking one and ignoring the other.
-func TestRunActionAddSuite_RejectsCombinedPositionalAndFile(t *testing.T) {
+// TestRunActionAddSuite_RejectsExtraPositional: more than one
+// source argument is a usage error.
+func TestRunActionAddSuite_RejectsExtraPositional(t *testing.T) {
 	manifestPath := writeSuiteManifest(t, `
-[suite]
 name = "x"
 description = "x"
-[[actions]]
-fqn = "github://acme/conn/actions/foo@0.1.0"
+actions = ["github://acme/conn/actions/foo@0.1.0"]
 `)
 	withSeededKeyring(t)
 	var stdout, stderr bytes.Buffer
-	code := runActionAdd(
-		[]string{"-f", manifestPath, "github://acme/conn/actions/extra@0.1.0"},
+	code := runActionAddSuite(
+		[]string{manifestPath, "github://acme/conn/actions/extra@0.1.0"},
 		strings.NewReader(""), &stdout, &stderr,
 	)
 	if code == 0 {
-		t.Errorf("expected nonzero exit when -f combined with positional; stderr=%s", stderr.String())
+		t.Errorf("expected nonzero exit with extra positional; stderr=%s", stderr.String())
 	}
-	if !strings.Contains(stderr.String(), "cannot combine") {
-		t.Errorf("expected 'cannot combine' error; got: %s", stderr.String())
+	if !strings.Contains(stderr.String(), "exactly one source") {
+		t.Errorf("expected 'exactly one source' error; got: %s", stderr.String())
+	}
+}
+
+// TestRunActionAddSuite_PathFormInLocalManifestErrors: a local
+// manifest can't use path-form entries (no ref to inherit). Surface
+// the error, name the entry.
+func TestRunActionAddSuite_PathFormInLocalManifestErrors(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+name = "bad-local"
+description = "Path-form requires a remote ref."
+
+actions = [
+  "actions/foo",
+]
+`)
+	withSeededKeyring(t)
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{manifestPath}, strings.NewReader(""), &stdout, &stderr)
+	if code == 0 {
+		t.Errorf("expected nonzero exit for path-form in local manifest; stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "path-form") {
+		t.Errorf("error should explain path-form rule; got: %s", stderr.String())
 	}
 }
 
 // TestRunActionAddSuite_TrustDeclineSkipsRemainingSameAuthority:
-// when the user declines trust mid-suite, subsequent actions that
-// share the declined authority skip silently rather than re-
-// prompting. The user only sees the trust banner once.
+// trust decline mid-suite → remaining same-authority actions skip
+// without re-prompting.
 func TestRunActionAddSuite_TrustDeclineSkipsRemainingSameAuthority(t *testing.T) {
 	withTempHome(t)
 	_, pemBytes := genTestKey(t)
@@ -4540,18 +4536,14 @@ func TestRunActionAddSuite_TrustDeclineSkipsRemainingSameAuthority(t *testing.T)
 	})
 
 	manifestPath := writeSuiteManifest(t, `
-[suite]
 name = "decline-test"
 description = "Decline trust; remaining actions should skip."
 
-[[actions]]
-fqn = "github://acme/conn/actions/foo@0.1.0"
-
-[[actions]]
-fqn = "github://acme/conn/actions/bar@0.1.0"
-
-[[actions]]
-fqn = "github://acme/conn/actions/baz@0.1.0"
+actions = [
+  "github://acme/conn/actions/foo@0.1.0",
+  "github://acme/conn/actions/bar@0.1.0",
+  "github://acme/conn/actions/baz@0.1.0",
+]
 `)
 	previewHits := 0
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -4564,7 +4556,7 @@ fqn = "github://acme/conn/actions/baz@0.1.0"
 
 	stdin := bufio.NewReader(strings.NewReader("n\n"))
 	var stdout, stderr bytes.Buffer
-	code := runActionAdd([]string{"-f", manifestPath}, stdin, &stdout, &stderr)
+	code := runActionAddSuite([]string{manifestPath}, stdin, &stdout, &stderr)
 	if code == 0 {
 		t.Errorf("expected nonzero exit when trust declined; stderr=%s", stderr.String())
 	}
@@ -4576,6 +4568,263 @@ fqn = "github://acme/conn/actions/baz@0.1.0"
 	}
 	if !strings.Contains(stdout.String(), "1 of 3") && !strings.Contains(stdout.String(), "3 of 3") {
 		t.Errorf("summary should report failures; got: %s", stdout.String())
+	}
+}
+
+// --- runActionAddSuite: remote source (issue #564 phase 2) ---
+
+// remoteSuiteServer stands up two httptest servers (GitHub API for
+// resolveLatestRef + raw.githubusercontent.com for fetchSuiteTOML)
+// and points the CLI's globals at them. Returns nothing — the
+// fixtures register cleanup via t.Cleanup.
+//
+// suiteTOML is the body served at the raw URL; tagName is what
+// the releases-latest endpoint returns (empty → 404 to simulate
+// "no releases").
+func remoteSuiteServer(t *testing.T, owner, repo, filePath, tagName, suiteTOML string) {
+	t.Helper()
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/repos/" + owner + "/" + repo + "/releases/latest"
+		if r.URL.Path != want {
+			t.Errorf("unexpected api path: %s, want %s", r.URL.Path, want)
+		}
+		if tagName == "" {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"tag_name":%q}`, tagName)
+	}))
+	t.Cleanup(apiSrv.Close)
+
+	rawSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// raw.githubusercontent.com serves /<owner>/<repo>/<ref>/<path>.
+		// Tests register at one specific ref path; anything else 404s.
+		if !strings.HasSuffix(r.URL.Path, "/"+filePath) {
+			w.WriteHeader(http.StatusNotFound)
+			return
+		}
+		_, _ = w.Write([]byte(suiteTOML))
+	}))
+	t.Cleanup(rawSrv.Close)
+
+	prevAPI := githubAPIBase
+	githubAPIBase = apiSrv.URL
+	t.Cleanup(func() { githubAPIBase = prevAPI })
+
+	prevRaw := rawGitHubBase
+	rawGitHubBase = rawSrv.URL
+	t.Cleanup(func() { rawGitHubBase = prevRaw })
+}
+
+// TestRunActionAddSuiteRemote_LatestResolvesAndInstalls is the
+// headline remote test: @latest resolves via the releases API,
+// the fetched manifest's path-form entries inherit the resolved
+// release tag's bare SemVer as their install version.
+func TestRunActionAddSuiteRemote_LatestResolvesAndInstalls(t *testing.T) {
+	const suiteTOML = `
+name = "remote-suite"
+description = "Three actions, all path-form."
+
+actions = [
+  "actions/foo",
+  "actions/bar",
+  "actions/baz",
+]
+`
+	remoteSuiteServer(t, "acme", "conn", "suite.toml", "v0.0.6", suiteTOML)
+
+	installed := map[string]string{} // fqn -> version installed
+	suiteInstallServer(t, []string{"github://acme/conn"},
+		nil,
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				Version string `json:"version"`
+			}
+			_ = json.Unmarshal(body, &req)
+			installed[fqn] = req.Version
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":%q,"source":"x","path":"/p"}`,
+				lastSegment(fqn), fqn, req.Version)
+		},
+	)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"--yes", "github://acme/conn/suite.toml@latest"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	for _, fqn := range []string{
+		"github://acme/conn/actions/foo",
+		"github://acme/conn/actions/bar",
+		"github://acme/conn/actions/baz",
+	} {
+		if installed[fqn] != "0.0.6" {
+			t.Errorf("install of %s: version = %q, want 0.0.6", fqn, installed[fqn])
+		}
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Resolving @latest",
+		"→ v0.0.6",
+		"Suite: remote-suite",
+		"All 3 action(s) installed.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunActionAddSuiteRemote_PinnedTagSkipsAPI: an explicit
+// @<tag> ref doesn't hit the releases API.
+func TestRunActionAddSuiteRemote_PinnedTagSkipsAPI(t *testing.T) {
+	const suiteTOML = `
+name = "pinned"
+description = "Pinned to v0.0.6"
+
+actions = [
+  "actions/foo",
+]
+`
+	apiHits := 0
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		apiHits++
+		w.WriteHeader(http.StatusInternalServerError) // explode if hit
+	}))
+	defer apiSrv.Close()
+	prevAPI := githubAPIBase
+	githubAPIBase = apiSrv.URL
+	t.Cleanup(func() { githubAPIBase = prevAPI })
+
+	rawSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_, _ = w.Write([]byte(suiteTOML))
+	}))
+	defer rawSrv.Close()
+	prevRaw := rawGitHubBase
+	rawGitHubBase = rawSrv.URL
+	t.Cleanup(func() { rawGitHubBase = prevRaw })
+
+	suiteInstallServer(t, []string{"github://acme/conn"}, nil, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"--yes", "github://acme/conn/suite.toml@v0.0.6"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	if apiHits != 0 {
+		t.Errorf("releases API hit %d times for a pinned ref; want 0", apiHits)
+	}
+}
+
+// TestRunActionAddSuiteRemote_NoReleasesFailsCleanly: @latest
+// against a repo with no releases surfaces the actionable hint.
+func TestRunActionAddSuiteRemote_NoReleasesFailsCleanly(t *testing.T) {
+	remoteSuiteServer(t, "acme", "conn", "suite.toml", "", "")
+	withSeededKeyring(t)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"github://acme/conn/suite.toml@latest"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code == 0 {
+		t.Errorf("expected nonzero exit when no releases; stderr=%s", stderr.String())
+	}
+	for _, want := range []string{"@<release-tag>", "@<sha>"} {
+		if !strings.Contains(stderr.String(), want) {
+			t.Errorf("stderr should mention %q; got: %s", want, stderr.String())
+		}
+	}
+}
+
+// TestRunActionAddSuiteRemote_RawFetch404NamesURL: when the suite
+// manifest doesn't exist at the resolved ref, the user sees the
+// URL that was tried.
+func TestRunActionAddSuiteRemote_RawFetch404NamesURL(t *testing.T) {
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v0.0.6"}`))
+	}))
+	defer apiSrv.Close()
+	prevAPI := githubAPIBase
+	githubAPIBase = apiSrv.URL
+	t.Cleanup(func() { githubAPIBase = prevAPI })
+
+	rawSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer rawSrv.Close()
+	prevRaw := rawGitHubBase
+	rawGitHubBase = rawSrv.URL
+	t.Cleanup(func() { rawGitHubBase = prevRaw })
+
+	withSeededKeyring(t)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"github://acme/conn/missing.toml@latest"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code == 0 {
+		t.Errorf("expected nonzero exit; stderr=%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "missing.toml") {
+		t.Errorf("stderr should name the missing file; got: %s", stderr.String())
+	}
+}
+
+// TestRunActionAddSuiteRemote_MixedPathAndFQNEntries: a remote
+// manifest with one path-form entry (inherits ref) and one FQN-form
+// entry (explicit version) installs each at the right version.
+func TestRunActionAddSuiteRemote_MixedPathAndFQNEntries(t *testing.T) {
+	const suiteTOML = `
+name = "mixed"
+description = "Path-form inherits; FQN-form explicit."
+
+actions = [
+  "actions/foo",
+  "github://other/repo/actions/bar@1.0.0",
+]
+`
+	remoteSuiteServer(t, "acme", "conn", "suite.toml", "v0.0.6", suiteTOML)
+
+	installedVersions := map[string]string{}
+	suiteInstallServer(t, []string{"github://acme/conn", "github://other/repo"},
+		nil,
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			body, _ := io.ReadAll(r.Body)
+			var req struct {
+				Version string `json:"version"`
+			}
+			_ = json.Unmarshal(body, &req)
+			installedVersions[fqn] = req.Version
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":%q,"source":"x","path":"/p"}`,
+				lastSegment(fqn), fqn, req.Version)
+		},
+	)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"--yes", "github://acme/conn/suite.toml@latest"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	if got := installedVersions["github://acme/conn/actions/foo"]; got != "0.0.6" {
+		t.Errorf("path-form should inherit 0.0.6; got %q", got)
+	}
+	if got := installedVersions["github://other/repo/actions/bar"]; got != "1.0.0" {
+		t.Errorf("FQN-form should use 1.0.0; got %q", got)
 	}
 }
 

--- a/cmd/aileron/suite_fetch.go
+++ b/cmd/aileron/suite_fetch.go
@@ -1,0 +1,224 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os"
+	"regexp"
+	"strings"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+// suite_fetch.go: helpers for `aileron action add-suite` against a
+// remote `<scheme>://<owner>/<repo>/<file-path>@<ref>` source. Local
+// (filesystem) manifests bypass everything here — see
+// runActionAddSuiteLocal in main.go.
+//
+// Three operations:
+//
+//   - parseSuiteSource splits the user's argument into FQN + raw ref
+//     and validates the ref shape.
+//   - resolveLatestRef turns a raw ref of "latest" into a concrete
+//     git tag via the GitHub releases API.
+//   - fetchSuiteTOML pulls the file's bytes from raw.githubusercontent.com.
+//
+// Test seams: rawGitHubBase (defined in keyring.go) and githubAPIBase
+// (defined here) are package-level vars so httptest servers can stub
+// either GitHub surface.
+
+// githubAPIBase is the base URL for GitHub's REST API. Overridable
+// in tests so resolveLatestRef can be exercised without hitting
+// production. Mirrors rawGitHubBase in keyring.go.
+var githubAPIBase = "https://api.github.com"
+
+// suiteFetchTimeout caps the per-request timeout for both the
+// releases API call and the raw TOML fetch. 15s matches the
+// publisherKeyFetchTimeout pattern: enough for slow networks,
+// short enough that a stalled host doesn't leave the user staring
+// at a quiet terminal.
+const suiteFetchTimeout = 15 * time.Second
+
+// suiteTOMLMaxBytes caps the suite manifest at 64 KB. Real suite
+// manifests are a few KB; the cap defends against a misconfigured
+// server returning megabytes. Mirrors fetchPublisherKey's 64 KB cap.
+const suiteTOMLMaxBytes = 64 * 1024
+
+// reSHA matches a 40-character lowercase hex SHA, the form
+// returned by `git rev-parse HEAD`. Short SHAs (7+ chars) are NOT
+// accepted — full SHAs are unambiguous, abbreviated ones can
+// collide between branches.
+var reSHA = regexp.MustCompile(`^[0-9a-f]{40}$`)
+
+// parseSuiteSource splits a user-supplied `<FQN-URL>@<ref>` into
+// the FQN half (file location) and the raw ref string. The split
+// is on the LAST `@` so tags containing `@` (rare but legal) survive,
+// the same way cstore.ParseRef does it.
+//
+// Validates that the FQN parses as an Aileron FQN and that the ref
+// is one of:
+//   - the literal `latest`
+//   - a 40-char lowercase hex SHA
+//   - any non-empty tag string
+//
+// The ref is NOT resolved here — `latest` survives as `latest` and
+// gets resolved by resolveLatestRef when the caller is ready.
+func parseSuiteSource(raw string) (cstore.FQN, string, error) {
+	at := strings.LastIndex(raw, "@")
+	if at < 0 {
+		return cstore.FQN{}, "", fmt.Errorf("source %q: missing @<ref> suffix (use @latest, @<release-tag>, or @<sha>)", raw)
+	}
+	fqnStr := raw[:at]
+	ref := raw[at+1:]
+	if ref == "" {
+		return cstore.FQN{}, "", fmt.Errorf("source %q: empty ref after @", raw)
+	}
+	fqn, err := cstore.ParseFQN(fqnStr)
+	if err != nil {
+		return cstore.FQN{}, "", fmt.Errorf("source %q: %w", raw, err)
+	}
+	if fqn.Subpath == "" {
+		return cstore.FQN{}, "", fmt.Errorf("source %q: missing file path after the repo (e.g. /suite.toml)", raw)
+	}
+	// Ref shape: latest, 40-hex SHA, or any non-empty tag. We don't
+	// reject "weird" tag names because GitHub allows a wide range
+	// (slashes, dots, dashes, underscores). The actual tag
+	// existence is verified by the raw fetch downstream.
+	if ref != "latest" && !reSHA.MatchString(ref) {
+		// Anything else is treated as a tag. No further validation.
+		_ = ref
+	}
+	return fqn, ref, nil
+}
+
+// resolveLatestRef calls GitHub's `releases/latest` endpoint and
+// returns the `tag_name`. This is the most-recent non-draft, non-
+// prerelease release; users who want prereleases pin via @<tag>.
+//
+// Honors GITHUB_TOKEN for higher rate limits; otherwise the call
+// is anonymous (60 req/hour/IP, plenty for casual use).
+//
+// Failure modes:
+//   - 404 (no releases or repo missing) → structured error pointing
+//     at the @<tag> / @<sha> alternatives.
+//   - 403 / 429 (rate-limited) → structured error suggesting
+//     GITHUB_TOKEN.
+//   - Network / decode failure → wrapped error.
+func resolveLatestRef(ctx context.Context, fqn cstore.FQN) (string, error) {
+	if fqn.Scheme != "github" {
+		return "", fmt.Errorf("@latest is only supported for github:// sources (got %s://)", fqn.Scheme)
+	}
+	endpoint := fmt.Sprintf("%s/repos/%s/%s/releases/latest",
+		strings.TrimRight(githubAPIBase, "/"),
+		url.PathEscape(fqn.Owner),
+		url.PathEscape(fqn.Repo),
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return "", fmt.Errorf("build request: %w", err)
+	}
+	req.Header.Set("Accept", "application/vnd.github+json")
+	req.Header.Set("X-GitHub-Api-Version", "2022-11-28")
+	if tok := os.Getenv("GITHUB_TOKEN"); tok != "" {
+		req.Header.Set("Authorization", "Bearer "+tok)
+	}
+	client := &http.Client{Timeout: suiteFetchTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", fmt.Errorf("GET %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+	switch resp.StatusCode {
+	case http.StatusOK:
+		// fall through
+	case http.StatusNotFound:
+		return "", fmt.Errorf("no published releases for %s/%s — pin with @<release-tag> or @<sha> instead of @latest",
+			fqn.Owner, fqn.Repo)
+	case http.StatusForbidden, http.StatusTooManyRequests:
+		return "", fmt.Errorf("github releases API rate-limited (HTTP %d) — set GITHUB_TOKEN to raise the limit",
+			resp.StatusCode)
+	default:
+		return "", fmt.Errorf("github releases API returned HTTP %d", resp.StatusCode)
+	}
+	var body struct {
+		TagName string `json:"tag_name"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		return "", fmt.Errorf("decode releases response: %w", err)
+	}
+	if body.TagName == "" {
+		return "", fmt.Errorf("github releases API returned empty tag_name")
+	}
+	return body.TagName, nil
+}
+
+// fetchSuiteTOML pulls the suite manifest's bytes from
+// raw.githubusercontent.com using the supplied (already-resolved)
+// ref. Caps the response at suiteTOMLMaxBytes; an oversize body
+// is treated as a malformed manifest.
+//
+// Anonymous fetch — public files don't need auth, and adding a
+// token here would surprise users who set GITHUB_TOKEN expecting
+// it to apply only to API calls.
+func fetchSuiteTOML(ctx context.Context, fqn cstore.FQN, ref string) ([]byte, error) {
+	if fqn.Scheme != "github" {
+		return nil, fmt.Errorf("remote suite fetch is only supported for github:// sources (got %s://)", fqn.Scheme)
+	}
+	endpoint := fmt.Sprintf("%s/%s/%s/%s/%s",
+		strings.TrimRight(rawGitHubBase, "/"),
+		url.PathEscape(fqn.Owner),
+		url.PathEscape(fqn.Repo),
+		url.PathEscape(ref),
+		fqn.Subpath, // intentionally NOT escaped: subpath includes legitimate `/`
+	)
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return nil, fmt.Errorf("build request: %w", err)
+	}
+	client := &http.Client{Timeout: suiteFetchTimeout}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("GET %s: %w", endpoint, err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode == http.StatusNotFound {
+		return nil, fmt.Errorf("no suite manifest at %s — check the file path and ref", endpoint)
+	}
+	if resp.StatusCode != http.StatusOK {
+		return nil, fmt.Errorf("GET %s: HTTP %d", endpoint, resp.StatusCode)
+	}
+	body, err := io.ReadAll(io.LimitReader(resp.Body, suiteTOMLMaxBytes+1))
+	if err != nil {
+		return nil, fmt.Errorf("read suite manifest: %w", err)
+	}
+	if len(body) > suiteTOMLMaxBytes {
+		return nil, fmt.Errorf("suite manifest at %s exceeds %d byte cap", endpoint, suiteTOMLMaxBytes)
+	}
+	return body, nil
+}
+
+// suiteVersionFromRef converts a resolved git ref (e.g. "v0.0.6")
+// into a bare SemVer string ("0.0.6") suitable for path-form
+// inheritance. Returns ok=false when the ref isn't a v-prefixed
+// SemVer — typical for raw SHAs, where path-form inheritance can't
+// happen.
+//
+// Single-artifact connectors release with `v<semver>` tags per
+// ADR-0004. Monorepo connectors with subpath-prefixed tags
+// (`<sub>/v<semver>`) are out of v1 scope; users on those layouts
+// pin with FQN-form entries.
+func suiteVersionFromRef(ref string) (string, bool) {
+	if !strings.HasPrefix(ref, "v") {
+		return "", false
+	}
+	bare := strings.TrimPrefix(ref, "v")
+	if !cstore.IsStrictSemver(bare) {
+		return "", false
+	}
+	return bare, true
+}

--- a/cmd/aileron/suite_fetch_test.go
+++ b/cmd/aileron/suite_fetch_test.go
@@ -1,0 +1,239 @@
+package main
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+// --- parseSuiteSource ---
+
+func TestParseSuiteSource_HappyPaths(t *testing.T) {
+	tests := []struct {
+		raw     string
+		wantFQN string
+		wantRef string
+	}{
+		{
+			raw:     "github://acme/conn/suite.toml@latest",
+			wantFQN: "github://acme/conn/suite.toml",
+			wantRef: "latest",
+		},
+		{
+			raw:     "github://acme/conn/suite.toml@v0.0.6",
+			wantFQN: "github://acme/conn/suite.toml",
+			wantRef: "v0.0.6",
+		},
+		{
+			raw:     "github://acme/conn/suites/full.toml@a1b2c3d4e5f6789012345678901234567890abcd",
+			wantFQN: "github://acme/conn/suites/full.toml",
+			wantRef: "a1b2c3d4e5f6789012345678901234567890abcd",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.raw, func(t *testing.T) {
+			fqn, ref, err := parseSuiteSource(tc.raw)
+			if err != nil {
+				t.Fatalf("parseSuiteSource(%q) error: %v", tc.raw, err)
+			}
+			if got := fqn.String(); got != tc.wantFQN {
+				t.Errorf("FQN = %q, want %q", got, tc.wantFQN)
+			}
+			if ref != tc.wantRef {
+				t.Errorf("ref = %q, want %q", ref, tc.wantRef)
+			}
+		})
+	}
+}
+
+func TestParseSuiteSource_RejectsMissingAtRef(t *testing.T) {
+	_, _, err := parseSuiteSource("github://acme/conn/suite.toml")
+	if err == nil {
+		t.Fatal("expected error for missing @<ref>")
+	}
+	if !strings.Contains(err.Error(), "@<ref>") {
+		t.Errorf("error should mention @<ref>; got: %v", err)
+	}
+}
+
+func TestParseSuiteSource_RejectsEmptyRef(t *testing.T) {
+	_, _, err := parseSuiteSource("github://acme/conn/suite.toml@")
+	if err == nil {
+		t.Fatal("expected error for empty ref")
+	}
+}
+
+func TestParseSuiteSource_RejectsMissingFilePath(t *testing.T) {
+	// github://owner/repo with no file path inside is meaningless
+	// for a suite source — there's nothing to fetch.
+	_, _, err := parseSuiteSource("github://acme/conn@latest")
+	if err == nil {
+		t.Fatal("expected error for missing file path")
+	}
+	if !strings.Contains(err.Error(), "file path") {
+		t.Errorf("error should mention file path; got: %v", err)
+	}
+}
+
+func TestParseSuiteSource_RejectsBadScheme(t *testing.T) {
+	_, _, err := parseSuiteSource("nope://acme/conn/suite.toml@latest")
+	if err == nil {
+		t.Fatal("expected error for bad scheme")
+	}
+}
+
+// --- resolveLatestRef ---
+
+// stubGitHubAPI swaps githubAPIBase for the test's lifetime, so
+// resolveLatestRef hits the supplied httptest server instead of
+// production.
+func stubGitHubAPI(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	prev := githubAPIBase
+	githubAPIBase = srv.URL
+	t.Cleanup(func() { githubAPIBase = prev })
+}
+
+func TestResolveLatestRef_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/repos/acme/conn/releases/latest" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"tag_name":"v0.0.6","name":"v0.0.6"}`))
+	}))
+	defer srv.Close()
+	stubGitHubAPI(t, srv)
+
+	ref, err := resolveLatestRef(context.Background(), cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn"})
+	if err != nil {
+		t.Fatalf("resolveLatestRef: %v", err)
+	}
+	if ref != "v0.0.6" {
+		t.Errorf("ref = %q, want v0.0.6", ref)
+	}
+}
+
+func TestResolveLatestRef_NoReleasesIsClearError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	stubGitHubAPI(t, srv)
+
+	_, err := resolveLatestRef(context.Background(), cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn"})
+	if err == nil {
+		t.Fatal("expected error when no releases")
+	}
+	for _, want := range []string{"@<release-tag>", "@<sha>"} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("error should mention %q; got: %v", want, err)
+		}
+	}
+}
+
+func TestResolveLatestRef_RateLimitedSuggestsToken(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusForbidden)
+	}))
+	defer srv.Close()
+	stubGitHubAPI(t, srv)
+
+	_, err := resolveLatestRef(context.Background(), cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn"})
+	if err == nil {
+		t.Fatal("expected error on 403")
+	}
+	if !strings.Contains(err.Error(), "GITHUB_TOKEN") {
+		t.Errorf("error should suggest GITHUB_TOKEN; got: %v", err)
+	}
+}
+
+func TestResolveLatestRef_RejectsNonGitHubScheme(t *testing.T) {
+	_, err := resolveLatestRef(context.Background(), cstore.FQN{Scheme: "gitlab", Owner: "acme", Repo: "conn"})
+	if err == nil {
+		t.Fatal("expected error on non-github scheme")
+	}
+}
+
+// --- fetchSuiteTOML ---
+
+// stubRawGitHub swaps rawGitHubBase for the test's lifetime so
+// fetchSuiteTOML hits the supplied httptest server. Mirrors the
+// pattern used by withMockGitHubRaw for keyring tests.
+func stubRawGitHub(t *testing.T, srv *httptest.Server) {
+	t.Helper()
+	prev := rawGitHubBase
+	rawGitHubBase = srv.URL
+	t.Cleanup(func() { rawGitHubBase = prev })
+}
+
+func TestFetchSuiteTOML_HappyPath(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/acme/conn/v0.0.6/suite.toml" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		_, _ = w.Write([]byte("name = \"x\"\n"))
+	}))
+	defer srv.Close()
+	stubRawGitHub(t, srv)
+
+	body, err := fetchSuiteTOML(context.Background(),
+		cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn", Subpath: "suite.toml"},
+		"v0.0.6",
+	)
+	if err != nil {
+		t.Fatalf("fetchSuiteTOML: %v", err)
+	}
+	if !strings.Contains(string(body), `name = "x"`) {
+		t.Errorf("body = %q", body)
+	}
+}
+
+func TestFetchSuiteTOML_404IsClearError(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	}))
+	defer srv.Close()
+	stubRawGitHub(t, srv)
+
+	_, err := fetchSuiteTOML(context.Background(),
+		cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn", Subpath: "suite.toml"},
+		"v0.0.6",
+	)
+	if err == nil {
+		t.Fatal("expected 404 error")
+	}
+	if !strings.Contains(err.Error(), "no suite manifest") {
+		t.Errorf("error should mention no suite manifest; got: %v", err)
+	}
+}
+
+// --- suiteVersionFromRef ---
+
+func TestSuiteVersionFromRef(t *testing.T) {
+	tests := []struct {
+		ref     string
+		want    string
+		wantOK  bool
+	}{
+		{"v0.0.6", "0.0.6", true},
+		{"v1.2.3-rc.1", "1.2.3-rc.1", true},
+		{"0.0.6", "", false},                                          // missing v prefix
+		{"v0.0", "", false},                                           // not strict semver (3 segments)
+		{"a1b2c3d4e5f6789012345678901234567890abcd", "", false},       // sha, not semver
+		{"main", "", false},                                           // branch name
+	}
+	for _, tc := range tests {
+		t.Run(tc.ref, func(t *testing.T) {
+			got, ok := suiteVersionFromRef(tc.ref)
+			if got != tc.want || ok != tc.wantOK {
+				t.Errorf("suiteVersionFromRef(%q) = (%q, %v), want (%q, %v)",
+					tc.ref, got, ok, tc.want, tc.wantOK)
+			}
+		})
+	}
+}

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -48,33 +48,13 @@ aileron dev (f66e51c)
 
 ## 2. Install Actions for Gmail and Calendar
 
-The `aileron-connector-google` connector ships several action templates: read Gmail, draft an email, read your calendar, create an event. Install them as a suite by pointing `aileron action add` at a TOML manifest.
-
-Save this as `gmail-and-calendar.toml`. Pick the latest release tag from [the connector's releases page](https://github.com/ALRubinger/aileron-connector-google/releases) and substitute it for `0.0.6`:
-
-```toml
-[suite]
-name = "gmail-and-calendar"
-description = "Read and draft Gmail; read and create calendar events"
-
-[[actions]]
-fqn = "github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6"
-
-[[actions]]
-fqn = "github://ALRubinger/aileron-connector-google/actions/get-email@0.0.6"
-
-[[actions]]
-fqn = "github://ALRubinger/aileron-connector-google/actions/list-upcoming-events@0.0.6"
-
-[[actions]]
-fqn = "github://ALRubinger/aileron-connector-google/actions/draft-email@0.0.6"
-```
-
-Then run:
+The `aileron-connector-google` connector publishes a curated suite of Gmail and Calendar actions. Install them all in one command:
 
 ```sh
-aileron action add -f gmail-and-calendar.toml
+aileron action add-suite github://ALRubinger/aileron-connector-google/suite.toml@latest
 ```
+
+`@latest` resolves to the connector's most recent release. Pin to a specific version with `@v0.0.6`, or to a git commit with `@<sha>`.
 
 This is the first command that touches your local secret store, so Aileron walks you through creating one before recording trust. You'll see this prompt now:
 
@@ -108,11 +88,11 @@ Trust publisher github://ALRubinger/aileron-connector-google? [y/N]: y
   Keyring: /Users/you/.aileron/keyring.json
 ```
 
-The trust prompt fires once for the publisher and applies to every action in the suite. Aileron then walks each action through preview and install in declaration order. The connector tarball is fetched once and reused. Google's OAuth consent screen pops up on the first action, and the credential binds for all four. The CLI prints a per-action summary at the end.
+The trust prompt fires once for the publisher and applies to every action in the suite. Aileron then walks each action through preview and install in declaration order. The connector tarball is fetched once and reused. Google's OAuth consent screen pops up on the first action, and the bound credential is reused for the rest. The CLI prints a per-action summary at the end.
 
 The connector's publisher already shipped a Desktop OAuth `client_id` and `client_secret` bound at release time, so there's no Google Cloud Console setup on your end. The token bytes are encrypted at rest; Aileron refreshes them transparently when they near expiry, and the connector never sees the credential.
 
-If you'd rather drive each step yourself, the single-action form `aileron action add <action-FQN>` still works, and `aileron keyring trust <authority>` runs the trust step on its own. The suite manifest is the default flow because it names the set as a single intent.
+If you'd rather drive each step yourself, the single-action form `aileron action add <action-FQN>` still works, and `aileron keyring trust <authority>` runs the trust step on its own. If you maintain a connector and want to publish your own suite, see [Authoring an Action Suite](/guides/authoring-an-action-suite/).
 
 ## 3. Launch Claude Code through Aileron
 

--- a/docs/src/content/docs/guides/authoring-an-action-suite.md
+++ b/docs/src/content/docs/guides/authoring-an-action-suite.md
@@ -1,0 +1,186 @@
+---
+title: "Authoring an Action Suite"
+description: "Publish a curated bundle of actions in a single TOML manifest so users can install your full surface with one command."
+---
+
+This guide walks you from an empty file to a published `suite.toml` that any user can install with one CLI command. By the end you will have a manifest in your connector repo that names every action you ship, plus a clear understanding of how the path-form vs. FQN-form rule works.
+
+If you have not read it yet, start with [Actions](/concepts/actions/) for the model and [Authoring an Action](/guides/authoring-an-action/) for how individual action templates are built. A suite is a thin layer on top: the actions you wrote already work standalone; the suite manifest just gives users one command instead of N.
+
+## What you are building
+
+An action suite is a single TOML file. There is no compiled artifact, no schema migration, no daemon plumbing. The whole contract is a `name`, a `description`, and a flat list of action references the user wants installed together.
+
+Once committed at the root of your connector repo, users install everything you ship in one shot:
+
+```sh
+aileron action add-suite github://you/your-connector/suite.toml@latest
+```
+
+The trust prompt fires once for your publisher key. The connector tarball is fetched once and reused. OAuth consent (if your connector needs it) pops up once on the first action and binds for all of them. The CLI prints a per-action summary at the end.
+
+## When to publish a suite
+
+Publish a `suite.toml` when your connector ships more than one action that users typically install together. Examples:
+
+- A Google connector with read-Gmail, draft-Gmail, read-Calendar, create-Calendar actions: shipping a suite means a user gets the whole "Gmail-and-Calendar" surface in one command instead of six.
+- A Slack connector with read-channel, post-message, list-users actions: a suite frames the bundle as the user's intent ("I want my agent to do Slack") rather than its implementation detail.
+
+Skip the suite if you ship a single action — the existing `aileron action add <FQN>@<version>` form is already one command.
+
+## File location
+
+The convention is one `suite.toml` at the **repo root**:
+
+```
+your-connector/
+├── actions/
+│   ├── action-one/
+│   ├── action-two/
+│   └── action-three/
+├── connector.toml
+├── keys/
+│   └── publisher.pub
+└── suite.toml          ← publish here
+```
+
+A user typing `aileron action add-suite github://you/your-connector/suite.toml@latest` resolves `@latest` via the GitHub releases API, fetches `suite.toml` at that release tag from `raw.githubusercontent.com`, and walks every entry.
+
+If you ship multiple themed bundles (rare), put them under `suites/` and users name them explicitly:
+
+```
+your-connector/suites/gmail-only.toml
+your-connector/suites/calendar-only.toml
+```
+
+```sh
+aileron action add-suite github://you/your-connector/suites/gmail-only.toml@latest
+```
+
+The CLI doesn't care which path you choose; the URL just points at whatever file you committed.
+
+## Schema
+
+A `suite.toml` has three top-level keys. No `[suite]` table, no `[[actions]]` array of tables — just flat top-level keys.
+
+```toml
+name = "gmail-and-calendar"
+description = "Read and draft Gmail; read and create calendar events"
+
+actions = [
+  "actions/list-recent-emails",
+  "actions/get-email",
+  "actions/list-upcoming-events",
+  "actions/draft-email",
+]
+```
+
+### `name` (required)
+
+A short, human-readable identifier shown in the install summary. Pick something that names the user's intent (`"gmail-and-calendar"`), not the implementation (`"connector-google-action-bundle"`).
+
+### `description` (required, non-empty)
+
+A one-line summary of what the suite does. Strict-mode validation rejects an empty string so published manifests always carry useful metadata.
+
+### `actions` (required, non-empty)
+
+A flat array of strings. Each entry is one of two forms.
+
+**Path form** (`"actions/<name>"`) is the common case. It is interpreted as a path relative to the suite manifest's repo. The CLI inherits the version from the ref the suite was fetched at — so if the user runs `add-suite ...@v0.0.6`, every path-form entry installs at version `0.0.6`. Leading `/` is normalized away (`"/actions/foo"` and `"actions/foo"` are equivalent).
+
+**FQN form** (`"<scheme>://<owner>/<repo>/<subpath>@<version>"`) is for cross-publisher entries — actions that live in a different repo than the suite. The version is required and must be strict SemVer. Use this only when you actually need to bundle an action you didn't publish; same-repo entries are clearer as path-form.
+
+```toml
+actions = [
+  "actions/list-recent-emails",                              # same repo, inherits ref
+  "github://other-pub/other-repo/actions/foo@1.2.3",         # cross-publisher, explicit
+]
+```
+
+## A worked example
+
+[`aileron-connector-google`](https://github.com/ALRubinger/aileron-connector-google) ships six actions. Its `suite.toml` is:
+
+```toml
+name = "aileron-connector-google"
+description = "Read and draft Gmail; read and create calendar events; send mail and create events with per-call approval."
+
+actions = [
+  "actions/list-recent-emails",
+  "actions/get-email",
+  "actions/list-upcoming-events",
+  "actions/draft-email",
+  "actions/send-email",
+  "actions/create-calendar-event",
+]
+```
+
+Users type one command:
+
+```sh
+aileron action add-suite github://ALRubinger/aileron-connector-google/suite.toml@latest
+```
+
+…and end up with all six actions installed at the latest release version, OAuth bound, ready to invoke.
+
+## How users invoke a suite
+
+Three ref forms cover the common patterns:
+
+| Form | When to use |
+|------|-------------|
+| `@latest` | The user wants whatever the connector's most recent release ships. The CLI hits `api.github.com/repos/<owner>/<repo>/releases/latest` and uses the returned `tag_name` as the suite's ref. |
+| `@<tag>` (e.g. `@v0.0.6`) | The user wants a specific release. The CLI uses the tag verbatim. |
+| `@<sha>` (40 hex chars) | The user wants a specific commit. The CLI uses the SHA verbatim. **Caveat:** path-form entries can't inherit a SHA as their install version (actions install by SemVer release tag, not by SHA). A `@<sha>` source must use FQN-form entries throughout. |
+
+The `@<ref>` is required. There is no implicit "default branch HEAD" — that would silently shift what users install between days, breaking reproducibility.
+
+## Validation rules
+
+The parser is strict. Authors who break these rules see an error before users do; users who hit a malformed manifest see the same error inline.
+
+- Unknown top-level keys → error. A typo at the top level fails fast rather than silently installing the wrong thing.
+- Missing or empty `name` / `description` → error.
+- Empty `actions` array → error.
+- An empty string in the array → error.
+- A path-form entry in a *local* manifest (loaded via filesystem path rather than a remote URL) → error. There's no ref to inherit. Rewrite the entry as FQN-form with explicit `@<version>`.
+- An FQN-form entry without `@<version>` → error. Strict SemVer is enforced — same rule the single-action `aileron action add <FQN>` uses.
+
+## Releasing a suite update
+
+A `suite.toml` is content like any other file in your repo. To roll out a new bundle composition:
+
+1. Edit `suite.toml` on `main`.
+2. Cut a release as you would for an action change. The release tag (`v<semver>`) becomes the ref users see at `@latest`.
+
+Path-form entries automatically resolve to the same release tag, so you don't have to bump versions inside the manifest.
+
+## For self-curated bundles
+
+The same command accepts a local filesystem path:
+
+```sh
+aileron action add-suite ./my-bundle.toml
+```
+
+Local manifests can't use path-form entries (no ref to inherit), so every entry must be a full FQN with explicit `@<version>`:
+
+```toml
+name = "my-bundle"
+description = "Personal bundle for this project"
+
+actions = [
+  "github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6",
+  "github://OtherPublisher/another-connector/actions/foo@1.0.0",
+]
+```
+
+Useful for project-scoped bundles ("for this repo, install these five actions") that don't belong in any one connector's published suite.
+
+## Companion reading
+
+- [Concepts → Actions](/concepts/actions/) — the model behind what you're bundling.
+- [Authoring an Action](/guides/authoring-an-action/) — how to write the action templates a suite references.
+- [Authoring a Connector](/guides/authoring-a-connector/) — connectors and actions are designed in parallel.
+- [Publishing a Connector](/guides/publishing-a-connector/) — signing, tagging, and the keyring trust model that the per-action verification rides on.

--- a/internal/cstore/fqn.go
+++ b/internal/cstore/fqn.go
@@ -72,6 +72,15 @@ var fqnSchemes = map[string]bool{
 // semverRe matches strict SemVer 2.0.0 per ADR-0002.
 var semverRe = regexp.MustCompile(`^(0|[1-9]\d*)\.(0|[1-9]\d*)\.(0|[1-9]\d*)(?:-[0-9A-Za-z.-]+)?(?:\+[0-9A-Za-z.-]+)?$`)
 
+// IsStrictSemver reports whether v matches Aileron's strict SemVer
+// rule (the same rule ParseRef enforces on `@<version>` suffixes).
+// Exported so callers outside this package — e.g. the suite fetch
+// path that strips a `v` prefix from a release tag — can validate
+// the result without re-implementing the regex.
+func IsStrictSemver(v string) bool {
+	return semverRe.MatchString(v)
+}
+
 // ParseFQN parses an FQN string. Returns an error when the scheme is
 // unknown, the owner/repo segments are missing, or the URI is malformed.
 // Does NOT accept `@<version>` suffixes — those are stripped by ParseRef.

--- a/internal/suite/manifest.go
+++ b/internal/suite/manifest.go
@@ -1,14 +1,19 @@
 // Package suite parses Aileron action-suite manifests — the
 // "group install" primitive from issue #564. A suite manifest names
 // a set of actions that get installed together via
-// `aileron action add -f <path>`, sharing connector resolution and
-// trust prompts across the whole set.
+// `aileron action add-suite <source>`, sharing connector resolution
+// and trust prompts across the whole set.
 //
-// v1 supports local files only. The parser is closed: unknown
-// top-level keys, unknown per-action keys, missing required fields,
-// and an empty `[[actions]]` array all surface as errors. The aim
-// is to fail loudly when a typo would otherwise silently install a
-// different set than the user expected.
+// The parser is closed: unknown top-level keys, missing required
+// fields, and an empty `actions` list all surface as errors. The
+// aim is to fail loudly when a typo would otherwise silently install
+// a different set than the user expected.
+//
+// Schema v2 (post-#564 follow-up): top-level keys, no `[suite]`
+// table; `actions` is a flat array of strings. Each entry is either
+// a path (relative to the suite's repo, version inherited from the
+// fetched ref) or a full FQN with explicit `@<version>`. See the
+// authoring guide for the definitive reference.
 package suite
 
 import (
@@ -16,70 +21,63 @@ import (
 	"strings"
 
 	"github.com/BurntSushi/toml"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
 )
 
 // Manifest is the parsed form of a suite TOML file.
 //
-// Example:
+// Example (remote, the common case):
 //
-//	[suite]
 //	name = "gmail-and-calendar"
 //	description = "Read and draft Gmail; read and create calendar events"
 //
-//	[[actions]]
-//	fqn = "github://owner/repo/actions/list-recent-emails@0.0.6"
+//	actions = [
+//	  "actions/list-recent-emails",
+//	  "actions/get-email",
+//	]
 //
-//	[[actions]]
-//	fqn = "github://owner/repo/actions/get-email@0.0.6"
+// Example (local, all entries explicit):
+//
+//	name = "my-bundle"
+//	description = "Personal bundle"
+//
+//	actions = [
+//	  "github://acme/conn/actions/foo@0.0.6",
+//	  "github://other/repo/actions/bar@1.0.0",
+//	]
 type Manifest struct {
-	// Suite is the manifest's metadata block. Required.
-	Suite Suite `toml:"suite"`
+	// Name is the suite's identifier, shown in the install summary.
+	// Required and non-empty.
+	Name string `toml:"name"`
 
-	// Actions is the ordered list of actions to install. Required and
-	// non-empty: a suite with zero actions has no semantic meaning.
-	Actions []Action `toml:"actions"`
-}
-
-// Suite carries the human-readable identity of the manifest. Both
-// fields are required so users (and any future Hub publish path)
-// can render a suite without falling back to "untitled".
-type Suite struct {
-	Name        string `toml:"name"`
+	// Description is a one-line human-readable summary. Required
+	// and non-empty so published manifests always carry useful
+	// metadata; the strict-mode rule is the cheapest way to keep
+	// that habit.
 	Description string `toml:"description"`
-}
 
-// Action is one entry in the suite's install list. Each FQN must
-// embed an `@<version>` suffix; v1 doesn't support floating versions
-// in suite manifests because the same source could resolve to
-// different bytes on different days, breaking reproducibility.
-type Action struct {
-	// FQN is the fully-qualified `<scheme>://<owner>/<repo>/<subpath>@<version>`
-	// reference — same form `aileron action add <FQN>@<version>`
-	// accepts on the command line.
-	FQN string `toml:"fqn"`
+	// Actions is the ordered list of action references to install.
+	// Each entry is either a path-form string ("actions/<name>" —
+	// version inherited from the suite's fetch ref) or an FQN-form
+	// string ("<scheme>://<owner>/<repo>/.../<name>@<version>").
+	// Required and non-empty.
+	Actions []string `toml:"actions"`
 }
 
 // Parse reads suite TOML from data, validates structurally, and
 // returns the populated Manifest. `file` is included in error
 // messages so users can map the failure back to the source file.
 //
-// Strict-mode rules:
-//   - Unknown top-level keys → error.
-//   - Unknown keys inside `[suite]` or each `[[actions]]` → error.
-//   - Missing `[suite].name` or `[suite].description` → error.
-//   - Empty `[[actions]]` → error.
-//   - Each action's `fqn` must be non-empty and contain `@<version>`.
-//
-// The parser does NOT validate FQN syntax beyond the `@<version>`
-// presence check — that's the install pipeline's job (and runs the
-// same `cstore.ParseRef` the single-action path uses).
+// Does NOT classify entries (path-form vs FQN-form) — that's
+// `Resolve`'s job. Parse keeps to syntactic validation: required
+// fields present, no unknown keys, no empty entries.
 func Parse(file string, data []byte) (*Manifest, error) {
 	var m Manifest
 	meta, err := toml.Decode(string(data), &m)
 	if err != nil {
 		return nil, fmt.Errorf("parse %q: %w", file, err)
 	}
-
 	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
 		keys := make([]string, 0, len(undecoded))
 		for _, k := range undecoded {
@@ -87,23 +85,65 @@ func Parse(file string, data []byte) (*Manifest, error) {
 		}
 		return nil, fmt.Errorf("parse %q: unknown key(s): %s", file, strings.Join(keys, ", "))
 	}
-
-	if m.Suite.Name == "" {
-		return nil, fmt.Errorf("parse %q: [suite].name is required", file)
+	if m.Name == "" {
+		return nil, fmt.Errorf("parse %q: name is required", file)
 	}
-	if m.Suite.Description == "" {
-		return nil, fmt.Errorf("parse %q: [suite].description is required", file)
+	if m.Description == "" {
+		return nil, fmt.Errorf("parse %q: description is required", file)
 	}
 	if len(m.Actions) == 0 {
-		return nil, fmt.Errorf("parse %q: at least one [[actions]] entry is required", file)
+		return nil, fmt.Errorf("parse %q: at least one entry in actions is required", file)
 	}
-	for i, a := range m.Actions {
-		if a.FQN == "" {
-			return nil, fmt.Errorf("parse %q: actions[%d].fqn is required", file, i)
-		}
-		if !strings.Contains(a.FQN, "@") {
-			return nil, fmt.Errorf("parse %q: actions[%d].fqn %q must include @<version>", file, i, a.FQN)
+	for i, raw := range m.Actions {
+		if strings.TrimSpace(raw) == "" {
+			return nil, fmt.Errorf("parse %q: actions[%d] is empty", file, i)
 		}
 	}
 	return &m, nil
+}
+
+// Resolve composes a `cstore.Ref` per `actions` entry, applying
+// the path-form vs. FQN-form rule:
+//
+//   - Path form (no `<scheme>://` prefix): the entry is treated
+//     as a subpath relative to suiteFQN. The action installs at
+//     suiteVersion. Both must be non-zero, otherwise the entry has
+//     no version to inherit (the local-manifest case where path-
+//     form entries aren't valid).
+//   - FQN form (has `<scheme>://` prefix): parsed via
+//     cstore.ParseRef, which enforces strict SemVer on the
+//     `@<version>` suffix. The entry MUST include `@<version>`.
+//
+// The returned slice mirrors the input order. The first error
+// encountered aborts; callers wrap it with the source file name.
+func Resolve(m *Manifest, suiteFQN cstore.FQN, suiteVersion string) ([]cstore.Ref, error) {
+	out := make([]cstore.Ref, 0, len(m.Actions))
+	for i, raw := range m.Actions {
+		entry := strings.TrimSpace(raw)
+		if strings.Contains(entry, "://") {
+			ref, err := cstore.ParseRef(entry)
+			if err != nil {
+				return nil, fmt.Errorf("actions[%d] %q: %w", i, raw, err)
+			}
+			out = append(out, ref)
+			continue
+		}
+		// Path form. Both the suite's authority and an inheritable
+		// version are required.
+		if suiteFQN.Scheme == "" || suiteVersion == "" {
+			return nil, fmt.Errorf("actions[%d] %q: path-form entries require a remote suite manifest with @<release-tag>; rewrite this entry as a full FQN with explicit @<version>", i, raw)
+		}
+		path := strings.TrimPrefix(entry, "/")
+		if path == "" {
+			return nil, fmt.Errorf("actions[%d] %q: empty path", i, raw)
+		}
+		fqn := cstore.FQN{
+			Scheme:  suiteFQN.Scheme,
+			Owner:   suiteFQN.Owner,
+			Repo:    suiteFQN.Repo,
+			Subpath: path,
+		}
+		out = append(out, cstore.Ref{FQN: fqn, Version: suiteVersion})
+	}
+	return out, nil
 }

--- a/internal/suite/manifest_test.go
+++ b/internal/suite/manifest_test.go
@@ -3,38 +3,40 @@ package suite
 import (
 	"strings"
 	"testing"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
 )
 
-// TestParse_HappyPath verifies a well-formed manifest decodes to the
-// expected struct shape. This is the contract the CLI's `-f` path
-// reads against.
+// --- Parse ---
+
+// TestParse_HappyPath verifies a well-formed v2 manifest decodes to
+// the expected struct shape. This is the contract the CLI's
+// `add-suite` paths read against.
 func TestParse_HappyPath(t *testing.T) {
 	data := []byte(`
-[suite]
 name = "gmail-and-calendar"
 description = "Read and draft Gmail; read and create calendar events"
 
-[[actions]]
-fqn = "github://owner/repo/actions/list-recent-emails@0.0.6"
-
-[[actions]]
-fqn = "github://owner/repo/actions/get-email@0.0.6"
+actions = [
+  "actions/list-recent-emails",
+  "actions/get-email",
+]
 `)
 	m, err := Parse("test.toml", data)
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	if m.Suite.Name != "gmail-and-calendar" {
-		t.Errorf("Suite.Name = %q", m.Suite.Name)
+	if m.Name != "gmail-and-calendar" {
+		t.Errorf("Name = %q", m.Name)
 	}
-	if m.Suite.Description == "" {
-		t.Error("Suite.Description should be set")
+	if m.Description == "" {
+		t.Error("Description should be set")
 	}
 	if len(m.Actions) != 2 {
 		t.Fatalf("len(Actions) = %d, want 2", len(m.Actions))
 	}
-	if m.Actions[0].FQN != "github://owner/repo/actions/list-recent-emails@0.0.6" {
-		t.Errorf("Actions[0].FQN = %q", m.Actions[0].FQN)
+	if m.Actions[0] != "actions/list-recent-emails" {
+		t.Errorf("Actions[0] = %q", m.Actions[0])
 	}
 }
 
@@ -43,15 +45,11 @@ fqn = "github://owner/repo/actions/get-email@0.0.6"
 // the wrong thing.
 func TestParse_RejectsUnknownTopLevelKey(t *testing.T) {
 	data := []byte(`
-[suite]
 name = "x"
 description = "x"
+maintainer = "alice"
 
-[bogus]
-key = "value"
-
-[[actions]]
-fqn = "github://owner/repo/actions/foo@1.0.0"
+actions = ["actions/foo"]
 `)
 	_, err := Parse("test.toml", data)
 	if err == nil {
@@ -62,82 +60,53 @@ fqn = "github://owner/repo/actions/foo@1.0.0"
 	}
 }
 
-// TestParse_RejectsUnknownActionKey: per-action keys are equally
-// closed. A user who types `name = "x"` (instead of editing the
-// FQN) should see an error, not a silently-misnamed install.
-func TestParse_RejectsUnknownActionKey(t *testing.T) {
+// TestParse_RejectsLegacySuiteTable: v1's `[suite]` block is no
+// longer accepted. Surface it as an unknown key so authors who
+// migrate get a clear "remove the table" signal.
+func TestParse_RejectsLegacySuiteTable(t *testing.T) {
 	data := []byte(`
 [suite]
 name = "x"
 description = "x"
 
-[[actions]]
-fqn = "github://owner/repo/actions/foo@1.0.0"
-nickname = "foo-action"
+actions = ["actions/foo"]
 `)
 	_, err := Parse("test.toml", data)
 	if err == nil {
-		t.Fatal("expected error for unknown action key")
+		t.Fatal("expected error for legacy [suite] table")
 	}
 	if !strings.Contains(err.Error(), "unknown key") {
-		t.Errorf("error should mention unknown key; got: %v", err)
+		t.Errorf("error should mention unknown key for [suite]; got: %v", err)
 	}
 }
 
-// TestParse_RejectsUnknownSuiteKey: same closed-schema rule for the
-// [suite] table itself.
-func TestParse_RejectsUnknownSuiteKey(t *testing.T) {
+// TestParse_RequiresName: missing required metadata fails.
+func TestParse_RequiresName(t *testing.T) {
 	data := []byte(`
-[suite]
-name = "x"
 description = "x"
-maintainer = "alice"
-
-[[actions]]
-fqn = "github://owner/repo/actions/foo@1.0.0"
+actions = ["actions/foo"]
 `)
 	_, err := Parse("test.toml", data)
 	if err == nil {
-		t.Fatal("expected error for unknown suite key")
+		t.Fatal("expected error for missing name")
 	}
-	if !strings.Contains(err.Error(), "unknown key") {
-		t.Errorf("error should mention unknown key; got: %v", err)
-	}
-}
-
-// TestParse_RequiresSuiteName: missing required metadata fails.
-func TestParse_RequiresSuiteName(t *testing.T) {
-	data := []byte(`
-[suite]
-description = "x"
-
-[[actions]]
-fqn = "github://owner/repo/actions/foo@1.0.0"
-`)
-	_, err := Parse("test.toml", data)
-	if err == nil {
-		t.Fatal("expected error for missing suite.name")
-	}
-	if !strings.Contains(err.Error(), "[suite].name") {
-		t.Errorf("error should mention [suite].name; got: %v", err)
+	if !strings.Contains(err.Error(), "name is required") {
+		t.Errorf("error should mention name; got: %v", err)
 	}
 }
 
-// TestParse_RequiresSuiteDescription: same for description.
-func TestParse_RequiresSuiteDescription(t *testing.T) {
+// TestParse_RequiresDescription: same for description.
+func TestParse_RequiresDescription(t *testing.T) {
 	data := []byte(`
-[suite]
 name = "x"
-
-[[actions]]
-fqn = "github://owner/repo/actions/foo@1.0.0"
+actions = ["actions/foo"]
 `)
 	_, err := Parse("test.toml", data)
 	if err == nil {
-		t.Fatal("expected error for missing suite.description")
+		t.Fatal("expected error for missing description")
 	}
-	if !strings.Contains(err.Error(), "[suite].description") {
-		t.Errorf("error should mention [suite].description; got: %v", err)
+	if !strings.Contains(err.Error(), "description is required") {
+		t.Errorf("error should mention description; got: %v", err)
 	}
 }
 
@@ -145,65 +114,41 @@ fqn = "github://owner/repo/actions/foo@1.0.0"
 // semantic meaning; surface it loudly.
 func TestParse_RejectsEmptyActions(t *testing.T) {
 	data := []byte(`
-[suite]
 name = "x"
 description = "x"
+actions = []
 `)
 	_, err := Parse("test.toml", data)
 	if err == nil {
 		t.Fatal("expected error for empty actions")
 	}
-	if !strings.Contains(err.Error(), "[[actions]]") {
-		t.Errorf("error should mention [[actions]]; got: %v", err)
+	if !strings.Contains(err.Error(), "actions") {
+		t.Errorf("error should mention actions; got: %v", err)
 	}
 }
 
-// TestParse_RejectsActionWithoutVersion: floating versions break
-// reproducibility — the same source could resolve to different
-// bytes on different days. v1 requires `@<version>`.
-func TestParse_RejectsActionWithoutVersion(t *testing.T) {
+// TestParse_RejectsEmptyEntry: a blank string in the array is a
+// misconfigured manifest.
+func TestParse_RejectsEmptyEntry(t *testing.T) {
 	data := []byte(`
-[suite]
 name = "x"
 description = "x"
-
-[[actions]]
-fqn = "github://owner/repo/actions/foo"
+actions = ["actions/foo", "  "]
 `)
 	_, err := Parse("test.toml", data)
 	if err == nil {
-		t.Fatal("expected error for action without @<version>")
+		t.Fatal("expected error for empty entry")
 	}
-	if !strings.Contains(err.Error(), "@<version>") {
-		t.Errorf("error should mention @<version>; got: %v", err)
-	}
-}
-
-// TestParse_RejectsEmptyActionFQN: an action entry with an explicit
-// empty fqn is a misconfigured manifest.
-func TestParse_RejectsEmptyActionFQN(t *testing.T) {
-	data := []byte(`
-[suite]
-name = "x"
-description = "x"
-
-[[actions]]
-fqn = ""
-`)
-	_, err := Parse("test.toml", data)
-	if err == nil {
-		t.Fatal("expected error for empty action fqn")
-	}
-	if !strings.Contains(err.Error(), "fqn is required") {
-		t.Errorf("error should mention fqn required; got: %v", err)
+	if !strings.Contains(err.Error(), "actions[1]") {
+		t.Errorf("error should name actions[1]; got: %v", err)
 	}
 }
 
 // TestParse_RejectsMalformedTOML: surface TOML decode errors
 // faithfully so users can locate the bad line.
 func TestParse_RejectsMalformedTOML(t *testing.T) {
-	data := []byte(`[suite
-name = "x"`)
+	data := []byte(`name =
+`)
 	_, err := Parse("test.toml", data)
 	if err == nil {
 		t.Fatal("expected error for malformed TOML")
@@ -214,27 +159,140 @@ name = "x"`)
 // in declaration order. Verify the parser keeps that order.
 func TestParse_PreservesActionOrder(t *testing.T) {
 	data := []byte(`
-[suite]
 name = "x"
 description = "x"
 
-[[actions]]
-fqn = "github://owner/repo/actions/aaa@1.0.0"
-
-[[actions]]
-fqn = "github://owner/repo/actions/bbb@1.0.0"
-
-[[actions]]
-fqn = "github://owner/repo/actions/ccc@1.0.0"
+actions = [
+  "actions/aaa",
+  "actions/bbb",
+  "actions/ccc",
+]
 `)
 	m, err := Parse("test.toml", data)
 	if err != nil {
 		t.Fatalf("Parse: %v", err)
 	}
-	want := []string{"aaa", "bbb", "ccc"}
+	want := []string{"actions/aaa", "actions/bbb", "actions/ccc"}
 	for i, w := range want {
-		if !strings.Contains(m.Actions[i].FQN, w) {
-			t.Errorf("Actions[%d].FQN = %q, want substring %q", i, m.Actions[i].FQN, w)
+		if m.Actions[i] != w {
+			t.Errorf("Actions[%d] = %q, want %q", i, m.Actions[i], w)
 		}
+	}
+}
+
+// --- Resolve ---
+
+// TestResolve_PathFormInherits the suite's repo and version; the
+// composed Ref points at <suiteFQN.Authority()>/<path>@<suiteVersion>.
+// This is the headline ergonomic of v2.
+func TestResolve_PathFormInheritsSuiteRefAndRepo(t *testing.T) {
+	m := &Manifest{
+		Name: "x", Description: "x",
+		Actions: []string{"actions/foo", "actions/bar"},
+	}
+	suiteFQN := cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn"}
+	refs, err := Resolve(m, suiteFQN, "0.0.6")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if len(refs) != 2 {
+		t.Fatalf("len(refs) = %d, want 2", len(refs))
+	}
+	if got := refs[0].FQN.String(); got != "github://acme/conn/actions/foo" {
+		t.Errorf("refs[0].FQN = %q", got)
+	}
+	if refs[0].Version != "0.0.6" {
+		t.Errorf("refs[0].Version = %q, want 0.0.6", refs[0].Version)
+	}
+}
+
+// TestResolve_FQNFormUnchanged: an FQN-form entry skips the
+// inheritance machinery entirely; cstore.ParseRef does the work.
+func TestResolve_FQNFormUnchanged(t *testing.T) {
+	m := &Manifest{
+		Name: "x", Description: "x",
+		Actions: []string{"github://other/repo/actions/foo@1.2.3"},
+	}
+	refs, err := Resolve(m, cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn"}, "0.0.6")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := refs[0].FQN.String(); got != "github://other/repo/actions/foo" {
+		t.Errorf("refs[0].FQN = %q", got)
+	}
+	if refs[0].Version != "1.2.3" {
+		t.Errorf("refs[0].Version = %q, want 1.2.3", refs[0].Version)
+	}
+}
+
+// TestResolve_MixedEntries: path-form and FQN-form coexist in one
+// manifest. Path form inherits; FQN form uses its own version.
+func TestResolve_MixedEntries(t *testing.T) {
+	m := &Manifest{
+		Name: "x", Description: "x",
+		Actions: []string{
+			"actions/foo",
+			"github://other/repo/actions/bar@1.0.0",
+		},
+	}
+	suiteFQN := cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn"}
+	refs, err := Resolve(m, suiteFQN, "0.0.6")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if refs[0].Version != "0.0.6" {
+		t.Errorf("path-form should inherit 0.0.6; got %q", refs[0].Version)
+	}
+	if refs[1].Version != "1.0.0" {
+		t.Errorf("FQN-form should use 1.0.0; got %q", refs[1].Version)
+	}
+}
+
+// TestResolve_PathFormRequiresSuiteContext: a path-form entry in a
+// local manifest (zero suiteFQN/version) is a hard error so the
+// user sees the actual problem rather than installing under the
+// wrong publisher.
+func TestResolve_PathFormRequiresSuiteContext(t *testing.T) {
+	m := &Manifest{
+		Name: "x", Description: "x",
+		Actions: []string{"actions/foo"},
+	}
+	_, err := Resolve(m, cstore.FQN{}, "")
+	if err == nil {
+		t.Fatal("expected error for path-form in local mode")
+	}
+	if !strings.Contains(err.Error(), "path-form") {
+		t.Errorf("error should mention path-form; got: %v", err)
+	}
+}
+
+// TestResolve_FQNFormWithoutVersionErrors: matches cstore.ParseRef's
+// strict-SemVer rule. A v2 manifest can't omit @<version> on FQN-
+// form entries.
+func TestResolve_FQNFormWithoutVersionErrors(t *testing.T) {
+	m := &Manifest{
+		Name: "x", Description: "x",
+		Actions: []string{"github://acme/conn/actions/foo"},
+	}
+	_, err := Resolve(m, cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn"}, "0.0.6")
+	if err == nil {
+		t.Fatal("expected error for FQN without @<version>")
+	}
+}
+
+// TestResolve_PathFormStripsLeadingSlash: be forgiving of "/actions/foo"
+// vs. "actions/foo"; both compose to the same result.
+func TestResolve_PathFormStripsLeadingSlash(t *testing.T) {
+	m := &Manifest{
+		Name: "x", Description: "x",
+		Actions: []string{"/actions/foo"},
+	}
+	suiteFQN := cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn"}
+	refs, err := Resolve(m, suiteFQN, "0.0.6")
+	if err != nil {
+		t.Fatalf("Resolve: %v", err)
+	}
+	if got := refs[0].FQN.Subpath; got != "actions/foo" {
+		t.Errorf("subpath = %q, want actions/foo", got)
 	}
 }


### PR DESCRIPTION
## Summary

Replaces PR #567's `aileron action add -f <local-path>` with a peer subcommand `aileron action add-suite <SOURCE>` that installs from either a local file or a remote `<scheme>://<owner>/<repo>/<file-path>@<ref>` URL. Adds a v2 manifest schema with top-level keys, a flat string list, and path-form entries that inherit the suite's release ref. Closes the option-2 deferral from #564.

## Command shape

```sh
aileron action add-suite <SOURCE> [--force] [--yes] [--no-bind]
```

Remote refs: `@latest` / `@<tag>` / `@<sha>`. The Liftoff command becomes:

```sh
aileron action add-suite github://ALRubinger/aileron-connector-google/suite.toml@latest
```

Per the no-backwards-compat rule, the `-f` flag and the v1 schema are removed rather than deprecated.

## Manifest v2

```toml
name = "gmail-and-calendar"
description = "Read and draft Gmail; read and create calendar events"

actions = [
  "actions/list-recent-emails",                          # path form
  "github://other-pub/other-repo/actions/foo@1.2.3",     # FQN form
]
```

Top-level keys (no `[suite]` table). `actions` is a flat array of strings. Path-form entries inherit the suite's resolved ref as their install version; FQN-form entries are explicit and required when no ref is inheritable (i.e. local manifests).

## Test plan

- [x] `go test ./internal/suite/...` — 14 tests cover parse + resolve, including path-form inheritance, mixed entries, leading-slash normalization, legacy `[suite]` rejection, and path-form-in-local-manifest error. 97.2% coverage.
- [x] `go test ./cmd/aileron/... -run TestParseSuiteSource|TestResolveLatestRef|TestFetchSuiteTOML|TestSuiteVersionFromRef` — unit tests for the fetch helpers against `httptest.NewServer` with `githubAPIBase` / `rawGitHubBase` overridden.
- [x] `go test ./cmd/aileron/... -run TestRunActionAddSuite` — 7 local-path tests rewritten for v2 schema, plus 5 new remote-path tests:
  - `_LatestResolvesAndInstalls` — `@latest` → releases API → `tag_name=v0.0.6` → install loop with version=0.0.6
  - `_PinnedTagSkipsAPI` — `@v0.0.6` should not call releases API
  - `_NoReleasesFailsCleanly` — 404 from releases API surfaces actionable hint
  - `_RawFetch404NamesURL` — missing manifest at the resolved ref names the URL
  - `_MixedPathAndFQNEntries` — path-form + FQN-form coexist; each installs at the right version
- [x] `task test` — full workspace green
- [x] `task lint:go` and `task lint:docs` — clean
- [x] Coverage: `internal/suite` 97.2%, `installSuiteEntries` 100%, all new fetch helpers ≥71%.

## Docs

- New guide: `docs/.../guides/authoring-an-action-suite.md`. Sibling to `authoring-an-action.md` and `authoring-a-connector.md`. Walks through file location convention, the v2 schema, ref forms, validation rules, and self-curated bundles.
- Liftoff §2 collapses to a single `add-suite ...@latest` call. The inline TOML manifest block from PR #567 is gone.

## Connector-repo coordination

The Liftoff command points at `ALRubinger/aileron-connector-google`'s `suite.toml`, which doesn't exist yet. Tracking issue filed at [aileron-connector-google#13](https://github.com/ALRubinger/aileron-connector-google/issues/13). Cutting a release after that PR merges makes `@latest` resolve to a tag containing `suite.toml`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)