### PR TITLE
docs(getting-started): liftoff iter — accordion animation, icon copy button, $ prompt

### DIFF
--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -43,39 +43,51 @@ const nav = navigation;
     <div class="flex min-h-screen pt-16">
       <Sidebar currentPath={currentPath} navigation={nav} client:load />
 
-      <div class="flex-1">
+      <!-- min-w-0 is load-bearing: a flex item's default min-width is
+           `auto`, which uses the intrinsic content width as a floor.
+           Long lines inside <pre> blocks would otherwise widen this
+           column past the viewport. With min-w-0, the column shrinks
+           and individual <pre> blocks scroll horizontally on their
+           own (they already have overflow-x: auto). -->
+      <div class="flex-1 min-w-0">
         <slot />
       </div>
     </div>
     <script>
-      // Wire up the "Copy" buttons injected by rehype-copy-button.
-      // Each button is a sibling of the <pre> inside .code-block-wrapper;
-      // we read textContent off the <pre> so we never copy the button's own
-      // label or any surrounding markup.
+      // Wire up the icon copy buttons. Two sources emit them with
+      // identical structure: rehype-copy-button.mjs at build time
+      // (prose code blocks) and code-block.svelte at runtime
+      // (PlatformTabs / accordion). Event delegation here covers
+      // both, including buttons that hydrate after this script runs.
+      // The button's `is-copied` class swaps the clipboard icon for
+      // the check icon via CSS — no textContent munging.
       (function () {
         const RESET_MS = 1500;
-        const buttons = document.querySelectorAll('button.code-copy-button');
-        buttons.forEach((btn) => {
-          btn.addEventListener('click', async () => {
-            const wrapper = btn.closest('.code-block-wrapper');
-            if (!wrapper) return;
-            const pre = wrapper.querySelector('pre');
-            if (!pre) return;
-            const text = pre.innerText;
-            const labelDefault = btn.getAttribute('data-copy-label') || 'Copy';
-            const labelCopied = btn.getAttribute('data-copy-label-copied') || 'Copied';
-            try {
-              await navigator.clipboard.writeText(text);
-              btn.textContent = labelCopied;
-              btn.classList.add('is-copied');
-            } catch {
-              btn.textContent = 'Copy failed';
-            }
-            setTimeout(() => {
-              btn.textContent = labelDefault;
-              btn.classList.remove('is-copied');
-            }, RESET_MS);
-          });
+        document.addEventListener('click', async (event) => {
+          const target = event.target;
+          if (!(target instanceof Element)) return;
+          const btn = target.closest('button.code-copy-button');
+          if (!btn) return;
+          const wrapper = btn.closest('.code-block-wrapper');
+          if (!wrapper) return;
+          const pre = wrapper.querySelector('pre');
+          if (!pre) return;
+          // `textContent` reads DOM-only and excludes ::before / ::after
+          // pseudo-elements (the `$` prompt). `innerText` may include
+          // them in some browsers, which would leak the prompt into
+          // the clipboard. Stick with textContent — for <pre>, the
+          // whitespace and newlines are preserved as-is.
+          try {
+            await navigator.clipboard.writeText(pre.textContent ?? '');
+            btn.classList.add('is-copied');
+            btn.setAttribute('aria-label', 'Code copied');
+          } catch {
+            btn.setAttribute('aria-label', 'Copy failed');
+          }
+          setTimeout(() => {
+            btn.classList.remove('is-copied');
+            btn.setAttribute('aria-label', 'Copy code to clipboard');
+          }, RESET_MS);
         });
       })();
     </script>

--- a/docs/src/lib/components/ui/code-block.svelte
+++ b/docs/src/lib/components/ui/code-block.svelte
@@ -1,0 +1,28 @@
+<script lang="ts">
+	import Clipboard from "@lucide/svelte/icons/clipboard";
+	import Check from "@lucide/svelte/icons/check";
+
+	let {
+		code,
+		lang,
+	}: {
+		code: string;
+		lang?: string;
+	} = $props();
+</script>
+
+<!--
+  Mirrors the structure rehype-copy-button.mjs emits at build time
+  (`.code-block-wrapper > button.code-copy-button + pre`). Used inside
+  Svelte islands (PlatformTabs, LiftoffPreflight) where MDX-time
+  rehype never runs. The click handler in BaseLayout.astro uses event
+  delegation so it picks up both static and dynamically-hydrated
+  buttons via the same code path.
+-->
+<div class="code-block-wrapper">
+	<button type="button" class="code-copy-button" aria-label="Copy code to clipboard">
+		<Clipboard size={16} class="icon-clipboard" aria-hidden="true" />
+		<Check size={16} class="icon-check" aria-hidden="true" />
+	</button>
+	<pre><code class={lang ? `language-${lang}` : undefined}>{code}</code></pre>
+</div>

--- a/docs/src/lib/components/ui/liftoff-preflight.svelte
+++ b/docs/src/lib/components/ui/liftoff-preflight.svelte
@@ -55,9 +55,11 @@
 		"[&[data-state=open]>svg]:rotate-180"
 	);
 	const itemClass = "border-b border-border";
+	// `cn-accordion-content` is the hook for the open/close height
+	// animation defined in global.css (driven by bits-ui's
+	// `--bits-accordion-content-height` CSS variable on data-state).
 	const contentClass = cn(
-		"overflow-hidden text-sm",
-		"data-[state=open]:pb-4 data-[state=closed]:pb-0",
+		"cn-accordion-content overflow-hidden pb-4 text-sm",
 		"[&_pre]:my-2"
 	);
 </script>

--- a/docs/src/lib/components/ui/tabs/platform-tabs.svelte
+++ b/docs/src/lib/components/ui/tabs/platform-tabs.svelte
@@ -2,6 +2,7 @@
 	import { Tabs as TabsPrimitive } from "bits-ui";
 	import { tabsListVariants } from "./tabs-list.svelte";
 	import { cn } from "$lib/utils.js";
+	import CodeBlock from "../code-block.svelte";
 
 	export type PlatformTabItem = {
 		value: string;
@@ -68,7 +69,7 @@
 			{#if item.note}
 				<p class="text-sm">{item.note}</p>
 			{/if}
-			<pre><code class={item.lang ? `language-${item.lang}` : undefined}>{item.code}</code></pre>
+			<CodeBlock code={item.code} lang={item.lang} />
 		</TabsPrimitive.Content>
 	{/each}
 </TabsPrimitive.Root>

--- a/docs/src/lib/rehype-copy-button.mjs
+++ b/docs/src/lib/rehype-copy-button.mjs
@@ -12,6 +12,60 @@
 
 import { visit } from 'unist-util-visit';
 
+// Lucide icon SVGs (16x16, currentColor stroke), inlined as hast nodes
+// so they ship in the static HTML next to the button. Kept in sync
+// with the lucide-svelte components used in code-block.svelte so both
+// sides of the runtime/build-time fence look identical.
+
+const SVG_BASE_PROPS = {
+  xmlns: 'http://www.w3.org/2000/svg',
+  width: 16,
+  height: 16,
+  viewBox: '0 0 24 24',
+  fill: 'none',
+  stroke: 'currentColor',
+  'stroke-width': 2,
+  'stroke-linecap': 'round',
+  'stroke-linejoin': 'round',
+  'aria-hidden': 'true',
+};
+
+const clipboardIcon = {
+  type: 'element',
+  tagName: 'svg',
+  properties: { ...SVG_BASE_PROPS, className: ['icon-clipboard'] },
+  children: [
+    {
+      type: 'element',
+      tagName: 'rect',
+      properties: { width: 8, height: 4, x: 8, y: 2, rx: 1, ry: 1 },
+      children: [],
+    },
+    {
+      type: 'element',
+      tagName: 'path',
+      properties: {
+        d: 'M16 4h2a2 2 0 0 1 2 2v14a2 2 0 0 1-2 2H6a2 2 0 0 1-2-2V6a2 2 0 0 1 2-2h2',
+      },
+      children: [],
+    },
+  ],
+};
+
+const checkIcon = {
+  type: 'element',
+  tagName: 'svg',
+  properties: { ...SVG_BASE_PROPS, className: ['icon-check'] },
+  children: [
+    {
+      type: 'element',
+      tagName: 'path',
+      properties: { d: 'M20 6 9 17l-5-5' },
+      children: [],
+    },
+  ],
+};
+
 /**
  * @returns {import('unified').Plugin}
  */
@@ -23,10 +77,46 @@ export default function rehypeCopyButton() {
 
       // Skip <pre> that doesn't wrap a <code> child (rare in markdown, but
       // possible in raw HTML).
-      const hasCodeChild = (node.children || []).some(
+      const codeChild = (node.children || []).find(
         (c) => c.type === 'element' && c.tagName === 'code',
       );
-      if (!hasCodeChild) return;
+      if (!codeChild) return;
+
+      // Skip code blocks with no language. Convention: a fenced block
+      // with a language (```sh, ```js, ...) is a command intended to
+      // be run, so it gets a copy button. A bare ``` block is a sample
+      // of console output / expected text, not something to copy and
+      // execute, so it stays unadorned.
+      //
+      // Two pipelines reach this plugin:
+      //   1. Plain remark-rehype puts the language as a class on
+      //      <code>: `<code class="language-sh">`.
+      //   2. Astro's Shiki highlighter (the project default) runs
+      //      before user rehype plugins and rewrites the structure:
+      //      it moves the language to a data attribute on <pre>
+      //      (`<pre data-language="sh" class="astro-code">`) and
+      //      strips `language-X` from <code>.
+      // Check both forms so the plugin works in either pipeline and
+      // remains correct if syntax highlighting is later disabled.
+      const preProps = node.properties || {};
+      const preDataLanguage =
+        preProps['data-language'] || preProps.dataLanguage;
+      const codeClass =
+        (codeChild.properties && codeChild.properties.className) || [];
+      const codeClasses = Array.isArray(codeClass)
+        ? codeClass
+        : String(codeClass).split(/\s+/);
+      const hasLanguageClass = codeClasses.some((c) =>
+        String(c).startsWith('language-'),
+      );
+      // Shiki labels unfenced ``` blocks `data-language="plaintext"`,
+      // not absent — treat plaintext as "no language" so console
+      // output samples stay unadorned.
+      const isPlaintext =
+        typeof preDataLanguage === 'string' &&
+        preDataLanguage.toLowerCase() === 'plaintext';
+      const hasLanguage = (!!preDataLanguage && !isPlaintext) || hasLanguageClass;
+      if (!hasLanguage) return;
 
       // Skip if we've already wrapped this <pre> (idempotency).
       const parentClass =
@@ -46,10 +136,12 @@ export default function rehypeCopyButton() {
           type: 'button',
           className: ['code-copy-button'],
           'aria-label': 'Copy code to clipboard',
-          'data-copy-label': 'Copy',
-          'data-copy-label-copied': 'Copied',
         },
-        children: [{ type: 'text', value: 'Copy' }],
+        children: [
+          // Deep-clone the icon nodes so the AST stays a tree, not a DAG.
+          JSON.parse(JSON.stringify(clipboardIcon)),
+          JSON.parse(JSON.stringify(checkIcon)),
+        ],
       };
 
       const wrapper = {

--- a/docs/src/lib/rehype-copy-button.test.mjs
+++ b/docs/src/lib/rehype-copy-button.test.mjs
@@ -16,7 +16,7 @@ function makeTree(children) {
   return { type: 'root', children };
 }
 
-function preWithCode(text) {
+function preWithCode(text, lang = 'sh') {
   return {
     type: 'element',
     tagName: 'pre',
@@ -25,7 +25,7 @@ function preWithCode(text) {
       {
         type: 'element',
         tagName: 'code',
-        properties: {},
+        properties: lang ? { className: [`language-${lang}`] } : {},
         children: [{ type: 'text', value: text }],
       },
     ],
@@ -53,6 +53,64 @@ test('wraps a <pre><code> in .code-block-wrapper with a copy button', () => {
   assert.equal(button.properties['aria-label'], 'Copy code to clipboard');
   assert.equal(pre.tagName, 'pre');
   assert.equal(pre.children[0].tagName, 'code');
+});
+
+test('wraps Shiki-shaped <pre data-language="sh"><code> (post-highlight)', () => {
+  // After Astro's Shiki transformer, the language has moved from
+  // <code class="language-sh"> to <pre data-language="sh" class="astro-code">.
+  const shikiPre = {
+    type: 'element',
+    tagName: 'pre',
+    properties: {
+      'data-language': 'sh',
+      className: ['astro-code'],
+    },
+    children: [
+      {
+        type: 'element',
+        tagName: 'code',
+        properties: {},
+        children: [{ type: 'text', value: 'aileron version' }],
+      },
+    ],
+  };
+  const tree = makeTree([shikiPre]);
+  run(tree);
+  assert.equal(tree.children.length, 1);
+  assert.equal(tree.children[0].tagName, 'div');
+  assert.deepEqual(tree.children[0].properties.className, ['code-block-wrapper']);
+});
+
+test('leaves a <pre><code> without language class alone (output sample, not a command)', () => {
+  const tree = makeTree([preWithCode('Output line 1\nOutput line 2', null)]);
+  run(tree);
+  assert.equal(tree.children.length, 1);
+  assert.equal(tree.children[0].tagName, 'pre');
+});
+
+test('leaves a Shiki <pre data-language="plaintext"> alone (unfenced ``` block)', () => {
+  // Shiki labels every unfenced ``` block `data-language="plaintext"`.
+  // We treat that as "no language" so console output stays unadorned.
+  const plaintextPre = {
+    type: 'element',
+    tagName: 'pre',
+    properties: {
+      'data-language': 'plaintext',
+      className: ['astro-code'],
+    },
+    children: [
+      {
+        type: 'element',
+        tagName: 'code',
+        properties: {},
+        children: [{ type: 'text', value: 'aileron dev (abc1234)' }],
+      },
+    ],
+  };
+  const tree = makeTree([plaintextPre]);
+  run(tree);
+  assert.equal(tree.children.length, 1);
+  assert.equal(tree.children[0].tagName, 'pre');
 });
 
 test('leaves a <pre> without <code> child alone', () => {

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -102,16 +102,46 @@
 /* Code-block copy button injected by rehype-copy-button.mjs.
  * The wrapper is positioned relative so the button can hover over the top-right
  * corner of the <pre>. The <pre>'s own bottom margin moves to the wrapper so
- * the layout stays identical to the un-wrapped version. */
+ * the layout stays identical to the un-wrapped version.
+ *
+ * Wrapped code blocks are commands (the language-fenced ones the
+ * plugin opted in). Style them with a left-border accent and a `$`
+ * prompt as a ::before pseudo-element so the visual cue says
+ * "this is meant to be typed/copy-pasted". The prompt is decorative-
+ * only — it lives outside DOM text, so `pre.textContent` (used by
+ * the copy handler) reads only the actual command bytes. */
 .prose .code-block-wrapper { position: relative; margin-bottom: 1.25rem; }
-.prose .code-block-wrapper > pre { margin-bottom: 0; }
+.prose .code-block-wrapper > pre {
+	position: relative;
+	margin-bottom: 0;
+	padding-left: 2.5rem;
+}
+.prose .code-block-wrapper > pre::before {
+	content: "$";
+	position: absolute;
+	top: 1rem;          /* match the <pre>'s padding-top */
+	left: 0.75rem;
+	color: var(--muted-foreground);
+	/* font-family / font-size / line-height intentionally omitted —
+	 * they inherit from <pre> so the `$` baseline lines up with the
+	 * first line of code text. */
+	user-select: none;
+	pointer-events: none;
+}
 .prose .code-copy-button {
 	position: absolute;
 	top: 0.5rem;
 	right: 0.5rem;
-	padding: 0.25rem 0.5rem;
-	font-size: 0.75rem;
-	font-family: inherit;
+	/* `<pre>` is now position: relative (for the $ prompt), which puts
+	 * it in the positioned-elements paint layer alongside this button.
+	 * Without z-index, the <pre> paints on top because it comes after
+	 * the button in document order. */
+	z-index: 1;
+	display: inline-flex;
+	align-items: center;
+	justify-content: center;
+	padding: 0.375rem;
+	line-height: 0;
 	color: var(--muted-foreground);
 	background: var(--background);
 	border: 1px solid var(--border);
@@ -125,6 +155,10 @@
 .prose .code-copy-button:focus-visible { opacity: 1; }
 .prose .code-copy-button:hover { color: var(--foreground); }
 .prose .code-copy-button.is-copied { color: var(--foreground); opacity: 1; }
+/* Toggle clipboard ↔ check icons via the .is-copied class. */
+.prose .code-copy-button .icon-check { display: none; }
+.prose .code-copy-button.is-copied .icon-clipboard { display: none; }
+.prose .code-copy-button.is-copied .icon-check { display: inline-block; }
 .prose blockquote { border-left: 4px solid var(--border); padding-left: 1rem; margin-left: 0; margin-right: 0; color: var(--muted-foreground); }
 .prose hr { border-color: var(--border); margin: 2rem 0; }
 .prose table { width: 100%; border-collapse: collapse; margin-bottom: 1.25rem; }
@@ -134,3 +168,24 @@
 .prose .meta table { width: auto; }
 .prose .meta th { font-weight: 500; background: none; white-space: nowrap; }
 .prose .meta td { color: var(--foreground); }
+
+/* Accordion open/close animation. bits-ui Accordion sets
+ * `--bits-accordion-content-height` on the Content element to its
+ * natural rendered height; we animate height from 0 ↔ that value
+ * keyed on bits-ui's `data-state` attribute. The Content needs
+ * `overflow: hidden` so clipping works while height is below the
+ * natural value — that's set on the component via Tailwind. */
+@keyframes accordion-down {
+	from { height: 0; }
+	to { height: var(--bits-accordion-content-height); }
+}
+@keyframes accordion-up {
+	from { height: var(--bits-accordion-content-height); }
+	to { height: 0; }
+}
+.cn-accordion-content[data-state="open"] {
+	animation: accordion-down 250ms ease-out forwards;
+}
+.cn-accordion-content[data-state="closed"] {
+	animation: accordion-up 250ms ease-in forwards;
+}


### PR DESCRIPTION
## Summary

A live-preview iteration pass on Prepare for Liftoff. Each change was authored against a running dev server with the user driving feedback.

### Accordion animation

The Preflight Checklist accordion now slides open and closed instead of snapping. Animation is keyed on bits-ui's `data-state` attribute and the `--bits-accordion-content-height` CSS variable bits-ui sets on the Content element. Asymmetric easing — `ease-out` opening, `ease-in` closing — at 250 ms each direction. The chevron rotation animates in sync with the existing `transition-transform`.

### Copy buttons inside accordions and tabs

The rehype plugin only sees code blocks rendered through the build-time MDX pipeline; `<pre>` blocks inside Svelte islands (PlatformTabs, accordion content) had no button. New `docs/src/lib/components/ui/code-block.svelte` component mirrors the rehype plugin's structure; PlatformTabs renders through it. Click handler in BaseLayout switched to `document.addEventListener` event delegation so dynamically-hydrated buttons inside Svelte islands are picked up.

### Icon copy button (clipboard ↔ check)

"Copy" text replaced with lucide clipboard / check icons. The rehype plugin emits SVG paths inline as deep-cloned hast nodes so the button ships in static HTML on first paint with no client-render flash; CodeBlock.svelte uses lucide-svelte for the same icons. The `is-copied` class swaps which icon is visible via CSS — no `textContent` munging on the button.

### Skip copy button on output samples

Convention: code blocks with a language fence are commands; bare ``` blocks are sample console output and stay unadorned. The plugin checks both `<code class="language-X">` (plain remark-rehype) and `<pre data-language="X">` (post-Shiki). Shiki labels unfenced blocks `data-language="plaintext"`, so plaintext is explicitly treated as "no language".

### Visual cue: \`$\` prompt on command blocks

Each command block gets a `$` prompt as a `::before` pseudo-element with `pointer-events: none` and `user-select: none`. The copy handler reads `pre.textContent` (DOM-only) instead of `pre.innerText`, so the prompt never leaks into the clipboard. Font-size and line-height inherit from `<pre>` so the prompt baseline aligns with the first line of code. The copy button gets `z-index: 1` because making `<pre>` `position: relative` (for the prompt's containing block) lifted it into the positioned-elements paint layer.

### Narrow-viewport overflow fix

The right column's `<div class="flex-1">` in BaseLayout had the default `min-width: auto`, which floors a flex item's width at its intrinsic content width. Long lines in `<pre>` blocks pushed the column past the viewport rather than letting the `<pre>`'s `overflow-x: auto` scroll horizontally. Adding `min-w-0` lets the column shrink with the viewport.

## Test plan

- [x] `node --test docs/src/lib/rehype-copy-button.test.mjs` — 8/8 green; 3 new cases (Shiki shape, no-language passthrough, plaintext passthrough)
- [x] `task build:docs` — 59 pages built clean
- [x] Manual: accordion items animate open/close with asymmetric easing
- [x] Manual: copy buttons appear on every command block (prose + accordion + tabs); none on output samples
- [x] Manual: icons swap clipboard ↔ check on click; aria-label updates for screen readers
- [x] Manual: `$` prompt visible, baseline-aligned with code; copy operation excludes the prompt
- [x] Manual: narrow-viewport down to ~360px keeps all content inside the column; long code lines scroll horizontally inside their `<pre>`

🤖 Generated with [Claude Code](https://claude.com/claude-code)