### PR TITLE
docs(guides): add install guides; surface suite guide in nav

### DIFF
--- a/docs/src/content/docs/guides/authoring-an-action-suite.md
+++ b/docs/src/content/docs/guides/authoring-an-action-suite.md
@@ -17,7 +17,7 @@ Once committed at the root of your connector repo, users install everything you 
 aileron action add-suite github://you/your-connector/suite.toml@latest
 ```
 
-The trust prompt fires once for your publisher key. The connector tarball is fetched once and reused. OAuth consent (if your connector needs it) pops up once on the first action and binds for all of them. The CLI prints a per-action summary at the end.
+Per-run, the trust prompt fires once for your publisher key. The connector tarball is fetched once and reused. OAuth consent (if your connector needs it) pops up once on the first action and the resulting binding is reused for the rest. Per-action failures don't abort the run — they surface in a final summary, the remaining actions still install, and the command exits non-zero if any failed.
 
 ## When to publish a suite
 
@@ -130,11 +130,19 @@ Three ref forms cover the common patterns:
 
 | Form | When to use |
 |------|-------------|
-| `@latest` | The user wants whatever the connector's most recent release ships. The CLI hits `api.github.com/repos/<owner>/<repo>/releases/latest` and uses the returned `tag_name` as the suite's ref. |
+| `@latest` | The user wants whatever the connector's most recent release ships. The CLI hits `api.github.com/repos/<owner>/<repo>/releases/latest` and uses the returned `tag_name` as the suite's ref. Honors `GITHUB_TOKEN` for higher rate limits. |
 | `@<tag>` (e.g. `@v0.0.6`) | The user wants a specific release. The CLI uses the tag verbatim. |
-| `@<sha>` (40 hex chars) | The user wants a specific commit. The CLI uses the SHA verbatim. **Caveat:** path-form entries can't inherit a SHA as their install version (actions install by SemVer release tag, not by SHA). A `@<sha>` source must use FQN-form entries throughout. |
+| `@<sha>` (40 hex chars) | The user wants a specific commit. The CLI uses the SHA verbatim. **Caveat:** path-form entries can't inherit a SHA as their install version (actions install by SemVer release tag, not by SHA). A `@<sha>` source must use FQN-form entries throughout. Path-form inheritance also requires a `v`-prefixed SemVer tag (`v0.0.6`); other tag shapes leave nothing for path-form entries to inherit and surface the same error. |
 
 The `@<ref>` is required. There is no implicit "default branch HEAD" — that would silently shift what users install between days, breaking reproducibility.
+
+The same flags `aileron action add` accepts apply to the suite form:
+
+| Flag | Effect |
+|------|--------|
+| `--yes` | Auto-accept every trust and consent prompt across the run. Use in CI or scripted installs. Does not bypass server-side signature verification. |
+| `--force` | Overwrite existing actions with the same name. Without it, an entry whose name + hash already match the installed version is reported as already-installed and skipped. |
+| `--no-bind` | Skip the post-install auto-prompt to bind unbound credential capabilities. Useful when a script will run `aileron binding setup` separately. |
 
 ## Validation rules
 

--- a/docs/src/content/docs/guides/installing-a-connector.md
+++ b/docs/src/content/docs/guides/installing-a-connector.md
@@ -1,0 +1,168 @@
+---
+title: "Installing a Connector"
+description: "Install a connector binary directly: keyring trust, the install consent prompt, capability preview, content-addressed storage, and credential binding."
+---
+
+This guide is for users installing a connector binary on its own, separate from any action that depends on it. It walks through `aileron keyring trust`, `aileron connector install`, the preview-and-consent flow, where the binary lands on disk, and the binding step that follows. By the end you will have a verified, sandboxed connector under `~/.aileron/store/connectors/sha256/<hash>/` and a credential bound (or queued for binding) against it.
+
+If you have not read it yet, start with [Connectors](/concepts/connectors/) for the model. The companion authoring guide is [Authoring a Connector](/guides/authoring-a-connector/), and [Publishing a Connector](/guides/publishing-a-connector/) covers the publisher side of the contract this guide consumes.
+
+## When to install a connector standalone
+
+Most users don't run this command directly. `aileron action add <action-FQN>` walks the action's connector dependencies and installs every missing connector transitively, in the same atomic flow. The standalone command exists for three cases:
+
+1. **You want the connector but no actions yet.** You're building your own actions against it, or you want to drive the binding setup before any action template lands.
+2. **You're pinning a specific connector hash.** `--hash=sha256:<hex>` aborts the install if the computed hash doesn't match, useful for reproducible deployments.
+3. **You're scripting against a connector check.** `aileron connector check` reports newer versions; `aileron connector install` is how you upgrade.
+
+If you're starting from an action template, [Installing an Action](/guides/installing-an-action/) is the more direct path.
+
+## Trust the publisher first
+
+Connector install verifies the binary's signature against keys registered for the FQN's authority. Without an entry, the install fails closed with `signature_failure` before anything reaches disk.
+
+```sh
+aileron keyring trust github://ALRubinger/aileron-connector-google
+```
+
+The CLI fetches `keys/publisher.pub` from the publisher's default branch on `raw.githubusercontent.com`, parses the ed25519 public key, and adds it under the authority `github://ALRubinger/aileron-connector-google` in `~/.aileron/keyring.json`. Output looks like:
+
+```
+✓ Trusted publisher github://ALRubinger/aileron-connector-google
+  Fingerprint: sha256:nXKt8AfDQH5jL2pM1RvB9w
+  Keyring: /Users/you/.aileron/keyring.json
+```
+
+Re-running the command after the publisher rotates their key adds the new key alongside the old (rotation support, per [ADR-0002](/adr/0002-connector-model/)). Re-running with no rotation reports the existing fingerprint and exits zero.
+
+The keyring is fail-closed by default. There are no pre-trusted publishers shipped with Aileron; every publisher you install from has to be explicitly added.
+
+> **Note on auto-trust:** `aileron action add` auto-prompts to trust an action's publisher (and any new connector dep publishers) before the install. Standalone `aileron connector install` does not — run `aileron keyring trust` first.
+
+## Preview and install
+
+```sh
+aileron connector install github://ALRubinger/aileron-connector-google@0.0.6
+```
+
+The version is required. Either suffix the FQN with `@<version>` or pass `--version=<v>` separately.
+
+The CLI runs a two-phase flow per [ADR-0007](/adr/0007-install-consent/):
+
+1. **Preview.** The server fetches the tarball, verifies the signature against your keyring, parses the manifest, and returns the metadata. Signature failure or hash mismatch aborts here, before any prompt.
+2. **Render the preview** for you to review:
+
+   ```
+   Connector install preview
+
+     FQN:        github://ALRubinger/aileron-connector-google
+     Version:    0.0.6
+     Hash:       sha256:a1b2c3d4e5f6…
+     Publisher:  Andrew Lee Rubinger
+     Signature:  verified
+
+     Network access:
+       - gmail.googleapis.com:443
+       - www.googleapis.com:443
+
+     Credential required:
+       kind:  oauth2
+       scope: Read your Gmail messages and Calendar events; create drafts and calendar events
+   ```
+
+   The capabilities section is the closed list of hosts the connector can reach plus the credential kind it needs. Anything not on the list is denied at the sandbox boundary at runtime.
+
+3. **Consent prompt** (`Install? [y/N]:`). On `y`, the server runs the install pipeline a second time and writes the verified tarball to disk:
+
+   ```
+   Installed: github://ALRubinger/aileron-connector-google@0.0.6
+     hash: sha256:a1b2c3d4e5f6…
+     path: /Users/you/.aileron/store/connectors/sha256/a1b2c3d4e5f6…
+   ```
+
+The store is content-addressed. Two installs that resolve to the same `binary || manifest` hash share the same on-disk directory, regardless of FQN or version label.
+
+### Already-installed short-circuit
+
+If the preview reports the same FQN + version + hash as an existing entry, the CLI prints `Already installed: <FQN>@<version>` and exits zero without prompting. There is no work to do.
+
+## Flags
+
+| Flag | Effect |
+|------|--------|
+| `--version=<v>` | Strict SemVer version to install. Required if the FQN has no `@<version>` suffix. |
+| `--hash=sha256:<hex>` | Expected content hash. The install aborts if the computed hash doesn't match. Use this when you want byte-level reproducibility, e.g. in deployment scripts. |
+| `--yes` | Skip the consent prompt. Does not bypass signature verification (the server still checks the keyring). |
+
+## Bind the credential
+
+Most connectors need a credential to do anything useful. After the connector installs, drop into the binding setup:
+
+```sh
+aileron binding setup github://ALRubinger/aileron-connector-google
+```
+
+The CLI prompts for an identity (`work`, `personal`, etc. — a label so you can have multiple bindings against the same connector), then dispatches by the connector's declared credential kind:
+
+- **OAuth2.** The CLI POSTs to `/v1/bindings/setup/oauth2/init`, opens your browser to the publisher's `authorize_url`, listens on a loopback port for the redirect, and exchanges the code for tokens. The publisher's app name appears on the consent screen, not Aileron's. The bound `{access_token, refresh_token}` envelope is encrypted at rest in your vault; tokens are refreshed transparently when they near expiry.
+- **API key.** The CLI prompts for the key value inline, encrypts it, and stores it in the vault.
+
+Until at least one binding exists for a connector's credential capability, actions that need it fail with `binding_required` at invocation time. `aileron binding list` shows the metadata for every binding (no secret bytes, ever).
+
+## Checking for updates
+
+```sh
+aileron connector check
+```
+
+Walks every installed connector, queries the publisher's source for newer versions per [ADR-0004](/adr/0004-dependency-resolution/), and reports a per-connector status:
+
+```
+  github://ALRubinger/aileron-connector-google@0.0.5 → 0.0.6 (update available)
+  github://OtherPub/another-connector@1.0.0 (up to date)
+
+1 update(s) available; 2 connector(s) checked.
+```
+
+Pass `--include-prerelease` to surface non-stable releases. Pass `--json` for NDJSON output (one connector per line) for scripting.
+
+To install the new version, run `aileron connector install <FQN>@<new-version>`. There is no automatic upgrade in v1; the install consent prompt fires for every upgrade so you see the new capability surface before agreeing to it.
+
+## What lands on disk
+
+```
+~/.aileron/
+├── store/
+│   └── connectors/
+│       └── sha256/
+│           ├── a1b2c3d4e5f6…/                  # one connector tarball, content-addressed
+│           │   ├── connector.wasm
+│           │   ├── manifest.toml
+│           │   └── signature.sig
+│           └── …
+├── keyring.json                                # trusted publisher keys
+└── secrets.json                                # encrypted vault — bindings live here
+```
+
+The connector binary is sandboxed at runtime. Per the manifest's declared capabilities, it can reach only the hosts on its allow-list and request only the credential kind it declared at install time. The capability gates fire at every outbound call; nothing the binary does at runtime can widen the surface you reviewed at install.
+
+## What you can't do yet
+
+There are no `aileron connector list` / `show` / `remove` subcommands in v1. `aileron status` reports the installed-connector count, and `aileron connector check` enumerates each one. To remove a connector, delete its directory under `~/.aileron/store/connectors/sha256/` (only safe if no installed action pins that hash — verify with `aileron sync` first).
+
+## Common errors
+
+- **`signature_failure`** — the connector's authority isn't in your keyring, or the publisher rotated their key. Run `aileron keyring trust <authority>` to fetch the current key. Without a trusted key, no install proceeds.
+- **`hash mismatch`** — `--hash=...` was supplied and the computed hash doesn't match. Either the publisher republished under the same version (which they shouldn't do), or you have the wrong expected hash.
+- **`version is required`** — neither the FQN nor `--version` carried a SemVer. Add `@<version>` to the FQN or pass `--version=<v>`.
+- **`binding_required` (at action runtime)** — the connector installed fine but no binding exists for its credential capability. Run `aileron binding setup <connector-FQN>`.
+
+## Companion reading
+
+- [Installing an Action](/guides/installing-an-action/) — the more common entry point; `action add` walks connector deps for you.
+- [Authoring a Connector](/guides/authoring-a-connector/) — write the WASM binary this guide installs.
+- [Publishing a Connector](/guides/publishing-a-connector/) — sign and release a connector users can install.
+- [ADR-0002: Connector Model](/adr/0002-connector-model/) — sandboxing, signing, and the trust model.
+- [ADR-0004: Dependency Resolution](/adr/0004-dependency-resolution/) — how FQNs map to release artifacts.
+- [ADR-0006: Capability Binding UX](/adr/0006-capability-binding-ux/) — the design behind `aileron binding setup`.
+- [ADR-0007: Install Consent](/adr/0007-install-consent/) — why the preview/prompt flow looks the way it does.

--- a/docs/src/content/docs/guides/installing-an-action.md
+++ b/docs/src/content/docs/guides/installing-an-action.md
@@ -1,0 +1,169 @@
+---
+title: "Installing an Action"
+description: "Install action templates from a published source: single-action add, suite installs, trust prompts, OAuth binding, and what lands on disk."
+---
+
+This guide is for users adding actions to their local Aileron install. It walks through `aileron action add` for a single action, `aileron action add-suite` for a curated bundle, the trust prompt that fires on first install from a new publisher, and the auto-bind step that hands off to OAuth or API-key setup. By the end you will have one or more action templates installed under `~/.aileron/actions/` and credentials bound for any connector they need.
+
+If you have not read it yet, start with [Actions](/concepts/actions/) for the model and [Connectors](/concepts/connectors/) for the surface actions invoke. The companion authoring guides are [Authoring an Action](/guides/authoring-an-action/) and [Authoring an Action Suite](/guides/authoring-an-action-suite/).
+
+## What gets installed
+
+An action is a single Markdown file with TOML frontmatter. `aileron action add` resolves the action's FQN, fetches its tarball, verifies the signature against your local keyring, walks any connector dependencies the action declares, and writes the body to `~/.aileron/actions/<name>.md`. The user owns the file from that point — edit the trigger phrases, retitle the action, swap connector pins, all without anyone's permission.
+
+A suite is a TOML manifest naming several actions to install together. `aileron action add-suite` runs the same flow once per entry, sharing trust state and connector installs across the set so prompts fire at most once per publisher.
+
+## Installing a single action
+
+```sh
+aileron action add github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6
+```
+
+The version is required. Either suffix the FQN with `@<version>` or pass `--version=<v>` separately; supplying both is an error if they conflict.
+
+On a fresh machine the CLI runs three things in order before installing:
+
+1. **Trust prompt** for the action's authority (the `<scheme>://<owner>/<repo>` part of its FQN). Aileron fetches `keys/publisher.pub` from the publisher's default branch, prints the fingerprint, and asks for confirmation. Subsequent installs from the same publisher skip this prompt because the key is already in `~/.aileron/keyring.json`.
+2. **Preview** of the action's metadata: name, version, source, hash, intent, and the connector dependencies it declares, split into "already installed" vs "will be installed alongside this action". Signature failure or parse errors abort here, before any consent prompt.
+3. **Trust prompt** for any *new* connector dependency whose authority differs from the action's. Same fetch + register flow as step 1.
+
+After all trust is established and the preview renders, the CLI prompts `Install? [y/N]:`. On `y`, the server runs the install pipeline (action + every missing connector, atomically) and prints the resulting path:
+
+```
+Added: list-recent-emails
+  source: github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6
+  path:   /Users/you/.aileron/actions/list-recent-emails.md
+```
+
+Connector binaries land under `~/.aileron/store/connectors/sha256/<hash>/`, content-addressed by the same hash the action's frontmatter pins. Two actions that pin the same connector hash share the same on-disk binary.
+
+### Re-installing the same version
+
+If the action and connector hashes the server resolves match what's already installed, the CLI short-circuits with `Already installed: <name>` and exits zero. No prompt, no rewrite. Pass `--force` to overwrite an existing action of the same name with a different hash.
+
+## Installing a suite
+
+A suite manifest is a single TOML file at the root of a connector repo (or anywhere reachable). It names several actions to install together:
+
+```sh
+aileron action add-suite github://ALRubinger/aileron-connector-google/suite.toml@latest
+```
+
+The CLI resolves the ref, fetches the manifest from `raw.githubusercontent.com`, parses it, and walks each entry through the same install flow as `action add`. Trust state is shared across the run, so the publisher prompt fires at most once even when ten actions reference the same authority. Per-action failures don't abort the run; the CLI prints a final summary and exits non-zero if any failed.
+
+```
+Suite: aileron-connector-google
+  Read and draft Gmail; read and create calendar events; send mail and create events with per-call approval.
+  6 action(s) to install
+
+── [1/6] github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6
+…
+
+Suite install summary:
+  ✓ github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6
+  ✓ github://ALRubinger/aileron-connector-google/actions/get-email@0.0.6
+  …
+
+All 6 action(s) installed.
+```
+
+### Ref forms
+
+Three ref forms cover the common patterns. The `@<ref>` suffix is required — there is no implicit "default branch HEAD."
+
+| Form | What happens |
+|------|--------------|
+| `@latest` | The CLI calls `api.github.com/repos/<owner>/<repo>/releases/latest` and uses the returned `tag_name`. Set `GITHUB_TOKEN` to raise the anonymous 60 req/hour rate limit. |
+| `@<tag>` (e.g. `@v0.0.6`) | The CLI uses the tag verbatim. |
+| `@<sha>` (40 hex chars) | The CLI uses the commit SHA verbatim. Path-form entries inside the suite can't inherit a SHA as their install version (actions install by SemVer release tag), so a `@<sha>` source must use FQN-form entries throughout. |
+
+### Local suite manifests
+
+The same command accepts a filesystem path:
+
+```sh
+aileron action add-suite ./my-bundle.toml
+```
+
+Local manifests can't use path-form entries because there is no ref to inherit from. Every entry must be a full FQN with explicit `@<version>`:
+
+```toml
+name = "my-bundle"
+description = "Personal bundle for this project"
+
+actions = [
+  "github://ALRubinger/aileron-connector-google/actions/list-recent-emails@0.0.6",
+  "github://OtherPublisher/another-connector/actions/foo@1.0.0",
+]
+```
+
+Use this for project-scoped bundles that don't belong in any one connector's published suite. See [Authoring an Action Suite](/guides/authoring-an-action-suite/) for the full schema.
+
+## The auto-bind step
+
+If an action's connector declares a credential capability (OAuth2 or API key) and you don't already have a binding for it, the CLI prompts to set one up immediately after the install lands:
+
+```
+This action needs oauth2 — Read your Gmail messages and Calendar events; create drafts and calendar events
+access for github://ALRubinger/aileron-connector-google. Set up now? [Y/n]:
+```
+
+On `y`, the CLI drives the same flow `aileron binding setup <connector-FQN>` runs:
+
+- **OAuth2 connectors** open your browser to the publisher's authorize URL, capture the code via a local loopback callback, exchange it for tokens, and store the result in your encrypted vault. The publisher's app name appears on the consent screen, not Aileron's. Tokens are refreshed transparently when they near expiry; the connector never sees them.
+- **API key connectors** prompt for the value inline and store it in the vault.
+
+You can decline a per-action bind with `n` and run `aileron binding setup <connector-FQN>` later. Pass `--no-bind` to suppress the prompt entirely (useful in scripts).
+
+## Flags
+
+The same flags apply to both `action add` and `action add-suite`:
+
+| Flag | Effect |
+|------|--------|
+| `--yes` | Auto-accept trust and consent prompts. Does not bypass server-side signature verification — an unsigned or unverifiable artifact still fails closed. |
+| `--force` | Overwrite an existing action with the same name. |
+| `--no-bind` | Skip the post-install auto-bind prompt. The action installs; unbound capabilities are listed in the output and you bind them later with `aileron binding setup`. |
+
+`action add` also accepts `--version=<v>` for cases where the FQN has no `@<version>` suffix.
+
+## What lands on disk
+
+```
+~/.aileron/
+├── actions/                              # one .md per installed action
+│   ├── list-recent-emails.md
+│   └── …
+├── store/
+│   └── connectors/
+│       └── sha256/
+│           └── <hash>/                   # content-addressed connector binaries
+│               ├── connector.wasm
+│               ├── manifest.toml
+│               └── signature.sig
+├── keyring.json                          # trusted publisher keys
+├── secrets.json                          # encrypted vault (Argon2id)
+└── audit/                                # daily-rotated audit log
+```
+
+Actions are user-owned files. Frontmatter validation runs on every load, so an edit that breaks the schema surfaces immediately the next time the daemon walks the directory.
+
+## What you can't do yet
+
+There are no `aileron action list` / `show` / `remove` subcommands in v1. To remove an installed action, delete the file at `~/.aileron/actions/<name>.md`. To audit what's installed, list the directory or use `aileron sync` (which walks the actions and reports their connector dependencies).
+
+## Common errors
+
+- **`signature_failure`** — the action's authority isn't in your keyring, or the publisher rotated their key without re-running `aileron keyring trust`. Run `aileron keyring trust <authority>` to add the new key, or accept the auto-trust prompt on the next install.
+- **`no published releases for <owner>/<repo> — pin with @<release-tag> or @<sha> instead of @latest`** — the repo has no GitHub release. Either the publisher hasn't cut one yet, or you have the wrong repo. Pin a specific tag or SHA.
+- **`actions[N] "..." path-form entries require a remote suite manifest with @<release-tag>`** — a local suite manifest used path-form (`actions/<name>`) entries. Rewrite each as a full FQN with explicit `@<version>`.
+- **`FQN already includes @<v>; --version=<v> conflicts`** — the FQN suffix and `--version` flag disagree. Use one or the other.
+
+## Companion reading
+
+- [Authoring an Action](/guides/authoring-an-action/) — write the templates this guide installs.
+- [Authoring an Action Suite](/guides/authoring-an-action-suite/) — author the bundles `add-suite` consumes.
+- [Installing a Connector](/guides/installing-a-connector/) — for connectors you want to install standalone, before any action references them.
+- [ADR-0004: Dependency Resolution](/adr/0004-dependency-resolution/) — how FQNs map to GitHub release URLs.
+- [ADR-0006: Capability Binding UX](/adr/0006-capability-binding-ux/) — the design behind the auto-bind step.
+- [ADR-0007: Install Consent](/adr/0007-install-consent/) — why the preview/prompt flow looks the way it does.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -58,8 +58,11 @@ export const navigation: NavItem[] = [
   {
     label: 'Guides',
     children: [
+      { label: 'Installing a Connector', href: '/guides/installing-a-connector/' },
+      { label: 'Installing an Action', href: '/guides/installing-an-action/' },
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },
       { label: 'Authoring an Action', href: '/guides/authoring-an-action/' },
+      { label: 'Authoring an Action Suite', href: '/guides/authoring-an-action-suite/' },
       { label: 'Publishing a Connector', href: '/guides/publishing-a-connector/' },
       { label: 'Observability', href: '/guides/observability/' }
     ]


### PR DESCRIPTION
## Summary

- New guide: **Installing an Action** — `aileron action add` and `aileron action add-suite`, ref forms (`@latest` / `@tag` / `@sha`), trust auto-prompt, install consent + preview, post-install auto-bind, on-disk layout, common errors.
- New guide: **Installing a Connector** — `aileron keyring trust` + `aileron connector install`, capability preview, content-addressed store, `aileron connector check` for upgrades, then binding setup.
- Wires both into the **Guides** sidebar in `docs/src/lib/navigation.ts`, plus the existing **Authoring an Action Suite** entry that was missing from nav.
- Light update to the suite authoring guide: flags section (`--yes` / `--force` / `--no-bind`) and a clarification that the trust prompt fires once per run, not once forever.

Both new guides were grounded in actual code (`cmd/aileron/main.go`, `cmd/aileron/keyring.go`, `cmd/aileron/suite_fetch.go`, `internal/suite/manifest.go`) — not invented behavior. Where the CLI doesn't yet have a feature (no `action list` / `action remove` / `connector list` / `connector remove`), the guides say so explicitly and point at the manual fallback.

## Test plan

- [x] `task lint:docs` passes (0 errors / 0 warnings / 0 hints across 18 files).
- [x] Local Astro dev server (`pnpm exec astro dev`) returns 200 for `/guides/installing-an-action/`, `/guides/installing-a-connector/`, and `/guides/authoring-an-action-suite/`.
- [x] All three new sidebar entries render in the page HTML.
- [ ] Visual review on the staging deploy: nav order under Guides, page formatting (tables, fenced code, headings).
- [ ] Click-through every internal link (Concepts, ADRs, sibling guides) — none should 404.

🤖 Generated with [Claude Code](https://claude.com/claude-code)