### PR TITLE
ci(release): build webapp before goreleaser

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -25,6 +25,28 @@ jobs:
             cmd/aileron-mcp/go.mod
             sdk/go/go.mod
 
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 11.0.8
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: webapp/pnpm-lock.yaml
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build webapp for embed
+        # aileron-server embeds internal/app/webapp_dist/ via go:embed. The dir
+        # is gitignored except .gitkeep, so a fresh checkout has no assets — a
+        # released binary built without this step would serve webappNotBuiltStub.
+        run: task build:webapp
+
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6
         with:


### PR DESCRIPTION
## Summary

- `aileron-server` embeds `internal/app/webapp_dist/` via `go:embed`. The dir is gitignored except `.gitkeep`, so a fresh CI checkout has no assets — `release.yml` previously skipped the webapp build, which would have produced a binary serving the `webappNotBuiltStub` handler instead of the real UI.
- Adds Node 24 + pnpm 11.0.8 + Task setup, then runs `task build:webapp` before goreleaser so the released `aileron-server` archive contains the real Svelte build.

This is the pre-blocker called out in #572's "Pre-blocker" section. No release has been cut yet, so this is forward-fix only — no migration concerns.

## Test plan

Manual local validation (CI run will follow on the next tag push):

- [x] `task build:webapp` populates `internal/app/webapp_dist/` with `_app/` + `index.html`
- [x] `task build:server` produces a 47M binary; `strings` confirms embedded SvelteKit HTML body, hashed JS chunks, and `data-sveltekit-preload-data` markers
- [ ] Once merged: tag `v0.0.1` (or a `v0.0.0-test` snapshot) and confirm GoReleaser run uploads `aileron-server_*` archives whose extracted binary serves the real webapp at `/`

Refs #572