### PR TITLE
ci(release): cosign keyless signing of release artifacts

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -7,6 +7,7 @@ on:
 
 permissions:
   contents: write
+  id-token: write # cosign keyless signing via OIDC
 
 jobs:
   release:
@@ -46,6 +47,9 @@ jobs:
         # is gitignored except .gitkeep, so a fresh checkout has no assets — a
         # released binary built without this step would serve webappNotBuiltStub.
         run: task build:webapp
+
+      - name: Install cosign
+        uses: sigstore/cosign-installer@v4
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -75,36 +75,57 @@ builds:
 
 archives:
   - id: aileron
-    builds:
+    ids:
       - aileron
     name_template: "aileron_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
   - id: aileron-sh
-    builds:
+    ids:
       - aileron-sh
     name_template: "aileron-sh_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
 
   - id: aileron-server
-    builds:
+    ids:
       - aileron-server
     name_template: "aileron-server_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
   - id: aileron-mcp
-    builds:
+    ids:
       - aileron-mcp
     name_template: "aileron-mcp_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
-        format: zip
+        formats: [zip]
 
 checksum:
   name_template: "checksums.txt"
+
+signs:
+  # Cosign keyless signing via GitHub Actions OIDC. Each artifact (archives,
+  # checksums.txt, source) is signed; the bundle file pairs the signature with
+  # the Fulcio cert + Rekor log entry, so users verify with one command.
+  #
+  # Verify (replace ${ARTIFACT} with e.g. aileron_0.0.1_darwin_arm64.tar.gz):
+  #   cosign verify-blob \
+  #     --bundle ${ARTIFACT}.sigstore.json \
+  #     --certificate-identity-regexp 'https://github.com/ALRubinger/aileron/.github/workflows/release.yml@.*' \
+  #     --certificate-oidc-issuer https://token.actions.githubusercontent.com \
+  #     ${ARTIFACT}
+  - cmd: cosign
+    signature: "${artifact}.sigstore.json"
+    args:
+      - sign-blob
+      - "--bundle=${signature}"
+      - "${artifact}"
+      - "--yes"
+    artifacts: all
+    output: true
 
 changelog:
   sort: asc


### PR DESCRIPTION
## Summary

- Adds cosign keyless signing via GitHub Actions OIDC to the release pipeline. Every artifact (archives, `checksums.txt`, source) gets a sigstore bundle (`.sigstore.json`) that pairs the signature with the Fulcio cert + Rekor transparency log entry.
- Workflow gains `id-token: write` and a `sigstore/cosign-installer@v4` step before goreleaser.
- `.goreleaser.yml` `signs:` block follows the canonical pattern from [goreleaser/example-supply-chain](https://github.com/goreleaser/example-supply-chain). Verification command documented inline in the config and below.
- **Drive-by:** fixes two pre-existing goreleaser deprecations (`archives.builds` → `ids`; `format_overrides.format` → `formats: [list]`). Both surfaced when running `goreleaser check`. Config now validates clean.

## Verification command

After a release, users verify any artifact with:

```sh
cosign verify-blob \
  --bundle aileron_0.0.1_darwin_arm64.tar.gz.sigstore.json \
  --certificate-identity-regexp 'https://github.com/ALRubinger/aileron/.github/workflows/release.yml@.*' \
  --certificate-oidc-issuer https://token.actions.githubusercontent.com \
  aileron_0.0.1_darwin_arm64.tar.gz
```

## Test plan

- [x] `goreleaser check` passes clean against the new config
- [x] `goreleaser release --snapshot --skip publish,sign` builds the linux + darwin matrix successfully (Windows surfaces a pre-existing gap — see follow-up below)
- [ ] Once merged: a tag push triggers `release.yml` and produces signed artifacts; verification command above succeeds against a real release artifact

## Follow-up surfaced during validation

Local snapshot run found that **\`aileron\` and \`aileron-server\` don't currently compile on Windows** — `internal/daemon/discovery/discovery.go` uses POSIX-only syscalls (`syscall.Flock`, `syscall.Stat_t`, `LOCK_EX`, etc.). This is unrelated to cosign signing but **blocks cutting v0.0.1** with the current goreleaser matrix. Tracked in #574 with two proposed paths (drop Windows targets vs. add `_windows.go` implementations).

Refs #572, #574