### PR TITLE
ci(release): build .deb / .rpm / .apk packages via nfpm

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -106,6 +106,36 @@ archives:
 checksum:
   name_template: "checksums.txt"
 
+nfpms:
+  # Linux distro packages: .deb (Debian/Ubuntu), .rpm (RHEL/Fedora),
+  # .apk (Alpine). One bundled "aileron" package per format/arch
+  # contains the CLI, daemon, MCP server, and POSIX shell shim — all
+  # four binaries are versioned together.
+  #
+  # Install paths follow each distro's bin convention (/usr/bin). After
+  # install, `aileron version` works without further setup.
+  - id: aileron
+    package_name: aileron
+    ids:
+      - aileron
+      - aileron-server
+      - aileron-mcp
+      - aileron-sh
+    formats:
+      - deb
+      - rpm
+      - apk
+    vendor: Aileron
+    homepage: https://withaileron.ai
+    maintainer: Andrew Lee Rubinger <alr@alrubinger.com>
+    description: |-
+      Local LLM gateway giving AI agents the ability to take consequential
+      action on a user's behalf without ever holding their credentials in
+      the agent's process. Ships the CLI (aileron), daemon (aileron-server),
+      MCP server (aileron-mcp), and POSIX shell shim (aileron-sh).
+    license: Apache-2.0
+    bindir: /usr/bin
+
 signs:
   # Cosign keyless signing via GitHub Actions OIDC. Each artifact (archives,
   # checksums.txt, source) is signed; the bundle file pairs the signature with


### PR DESCRIPTION
## Summary

- Adds a goreleaser `nfpms:` block producing six Linux packages per release: `{deb,rpm,apk} × {amd64,arm64}`.
- Single bundled `aileron` package containing all four binaries (`aileron`, `aileron-server`, `aileron-mcp`, `aileron-sh`) installed to `/usr/bin/`.
- Packages will be attached to the GitHub Release alongside the existing tarballs and signed by the cosign step (`artifacts: all` already covers them).

After this lands and #572 cuts `v0.0.1`, the install path is one curl + one install:
```sh
# Debian/Ubuntu
curl -LO https://github.com/ALRubinger/aileron/releases/download/v0.0.1/aileron_0.0.1_linux_amd64.deb
sudo dpkg -i aileron_0.0.1_linux_amd64.deb

# RHEL/Fedora
sudo rpm -i aileron_0.0.1_linux_amd64.rpm

# Alpine
sudo apk add --allow-untrusted aileron_0.0.1_linux_amd64.apk
```

Hosted apt/yum/apk repos (so users can `apt-get install aileron` directly) remain out of scope per #572's acceptance — that's a follow-up if direct-download usage hits friction.

## Test plan

- [x] `goreleaser check` clean
- [x] `goreleaser release --snapshot --skip publish,sign --clean` produces all six packages
- [x] `ar t aileron_*.deb` shows expected internal structure (`debian-binary`, `control.tar.gz`, `data.tar.gz`)
- [x] `data.tar.gz` extracts to `./usr/bin/{aileron,aileron-mcp,aileron-server,aileron-sh}`
- [x] Control metadata verified: package name `aileron`, version, maintainer, homepage `https://withaileron.ai`, license `Apache-2.0`, full description
- [ ] Once merged: tag-triggered release uploads packages to GitHub Releases; manual install verified on at least one Debian-family + one RHEL-family distro

Refs #572