### PR TITLE
ci(release): Homebrew cask via auto-published tap

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -59,3 +59,9 @@ jobs:
           args: release --clean
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # PAT with contents:write on ALRubinger/homebrew-aileron, used
+          # by goreleaser's brews step to commit Formula/aileron.rb.
+          # GITHUB_TOKEN scopes to this repo only and can't write
+          # across repos. Configure as a repo secret before tagging
+          # the first release.
+          HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -74,37 +74,58 @@ builds:
       - arm64
 
 archives:
+  # One bundled archive per platform contains all four binaries
+  # (aileron, aileron-server, aileron-mcp, aileron-sh) versioned
+  # together. Matches the Linux nfpm package shape and the Homebrew
+  # formula install. Windows archives omit aileron-sh (POSIX-only).
   - id: aileron
     ids:
       - aileron
-    name_template: "aileron_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format_overrides:
-      - goos: windows
-        formats: [zip]
-
-  - id: aileron-sh
-    ids:
-      - aileron-sh
-    name_template: "aileron-sh_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-
-  - id: aileron-server
-    ids:
       - aileron-server
-    name_template: "aileron-server_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
-    format_overrides:
-      - goos: windows
-        formats: [zip]
-
-  - id: aileron-mcp
-    ids:
       - aileron-mcp
-    name_template: "aileron-mcp_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
+      - aileron-sh
+    # Windows archives omit aileron-sh (POSIX-only) — fewer binaries
+    # than linux/darwin. Goreleaser flags this as a confusion risk by
+    # default; explicit acknowledgement here.
+    allow_different_binary_count: true
+    name_template: "aileron_{{ .Version }}_{{ .Os }}_{{ .Arch }}"
     format_overrides:
       - goos: windows
         formats: [zip]
 
 checksum:
   name_template: "checksums.txt"
+
+homebrew_casks:
+  # Homebrew cask auto-published to the homebrew-aileron tap on each
+  # release. After release, users install with:
+  #   brew tap ALRubinger/aileron
+  #   brew install aileron
+  #
+  # Uses goreleaser's homebrew_casks (the brews field is deprecated as
+  # of v2; casks are the modern path for pre-compiled binaries).
+  #
+  # The tap is a separate GitHub repo (homebrew-aileron); goreleaser
+  # commits the cask there using HOMEBREW_TAP_GITHUB_TOKEN — a PAT
+  # with contents:write scope on the tap repo, set as a secret in this
+  # repo. Default GITHUB_TOKEN can't write across repos.
+  - name: aileron
+    ids:
+      - aileron # the bundled archive id above (all four binaries)
+    repository:
+      owner: ALRubinger
+      name: homebrew-aileron
+      branch: main
+      token: "{{ .Env.HOMEBREW_TAP_GITHUB_TOKEN }}"
+    homepage: https://withaileron.ai
+    description: Local LLM gateway for AI agents to take consequential action without holding credentials
+    license: Apache-2.0
+    # All four binaries from the bundled archive land on PATH.
+    binaries:
+      - aileron
+      - aileron-server
+      - aileron-mcp
+      - aileron-sh
 
 nfpms:
   # Linux distro packages: .deb (Debian/Ubuntu), .rpm (RHEL/Fedora),


### PR DESCRIPTION
## Summary

- Adds goreleaser `homebrew_casks:` block that publishes a cask to the new [`ALRubinger/homebrew-aileron`](https://github.com/ALRubinger/homebrew-aileron) tap on each release.
- After this lands + #578 + v0.0.1 cut, macOS + Linuxbrew users install with:
  ```sh
  brew tap ALRubinger/aileron
  brew install aileron
  ```
- The cask installs all four binaries (`aileron`, `aileron-server`, `aileron-mcp`, `aileron-sh`) for darwin arm64/amd64 + linux arm64/amd64.

## Collateral changes

**1. Archives consolidated.** The four per-binary archives collapse into a single bundled archive `aileron_<version>_<os>_<arch>.tar.gz` (or `.zip` on Windows) containing all four binaries — matches #578's nfpm shape and gives the Homebrew cask a single archive to point at. `allow_different_binary_count: true` acknowledges that Windows archives omit `aileron-sh` (POSIX-only).

**2. `release.yml` gains `HOMEBREW_TAP_GITHUB_TOKEN` env.** Default `GITHUB_TOKEN` scopes to this repo only and can't push to `homebrew-aileron`. **Action required before first release tag**: configure repo secret `HOMEBREW_TAP_GITHUB_TOKEN` with a PAT that has `contents: write` on `ALRubinger/homebrew-aileron`.

## brews → homebrew_casks migration

`goreleaser check` flagged the `brews` field as deprecated in v2 ("phased out in favor of homebrew_casks"). Migrated. Casks are the modern path for pre-compiled binaries; same install UX (`brew install aileron`).

## Test plan

- [x] `goreleaser check` clean
- [x] `HOMEBREW_TAP_GITHUB_TOKEN=dummy goreleaser release --snapshot --skip publish,sign --clean` produces:
  - 5 bundled archives (linux × {amd64,arm64}, darwin × {amd64,arm64}, windows amd64)
  - `dist/homebrew/Casks/aileron.rb` with per-platform URL + sha256, all four binaries declared
- [x] Archive contents verified: linux/darwin tarball contains 4 binaries; windows zip contains 3 (no aileron-sh)
- [x] **Pre-merge action required**: configure `HOMEBREW_TAP_GITHUB_TOKEN` repo secret
- [ ] Once merged + v0.0.1 cut: `brew tap ALRubinger/aileron && brew install aileron` works on a clean macOS arm64

## Sequencing

This PR is independent of #578 (Linux packages). Either can land first; both reference build IDs but no archive IDs in common, and the bundled archive consolidation here is needed for Homebrew specifically.

Refs #572