### PR TITLE
fix(ci): pin cosign-installer to v4.1.2

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,11 @@ jobs:
         run: task build:webapp
 
       - name: Install cosign
-        uses: sigstore/cosign-installer@v4
+        # Pinned to v4.1.2 (the latest v4.x at time of pinning). The
+        # repo doesn't publish a moving `v4` major-version tag — only
+        # specific patch tags within v4.x and a moving `v3`. Bump the
+        # pin when newer v4.x or v5 tags ship.
+        uses: sigstore/cosign-installer@v4.1.2
 
       - name: Run GoReleaser
         uses: goreleaser/goreleaser-action@v6


### PR DESCRIPTION
## Summary

Release workflow failed at the very first step on \`v0.0.2\`:

\`\`\`
##[error]Unable to resolve action \`sigstore/cosign-installer@v4\`, unable to find version \`v4\`
\`\`\`

Root cause: \`sigstore/cosign-installer\` doesn't publish a moving \`v4\` major-version tag. Only specific patch tags exist (\`v4.0.0\`, \`v4.1.0\`, \`v4.1.1\`, \`v4.1.2\`). They DO maintain a moving \`v3\`, but not yet \`v4\`. My initial pin to \`@v4\` was based on the latest release being \`v4.1.2\` — I incorrectly assumed a moving major tag existed.

Fix: pin to \`@v4.1.2\` (the latest v4.x). Comment in the workflow notes the pinning policy so future bumps are intentional.

## After this merges

Delete the failed \`v0.0.2\` tag and re-cut:

\`\`\`sh
git tag -d v0.0.2
git push origin :refs/tags/v0.0.2
git pull --rebase origin main
git tag -a v0.0.2 -m "v0.0.2"
git push origin v0.0.2
\`\`\`

## Failure run

https://github.com/ALRubinger/aileron/actions/runs/25615285474

Refs #572