### PR TITLE
fix(release): strip quarantine xattr in Homebrew cask postflight

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -126,6 +126,19 @@ homebrew_casks:
       - aileron-server
       - aileron-mcp
       - aileron-sh
+    # macOS Gatekeeper blocks first-run of unsigned/non-notarized
+    # binaries with "Apple could not verify ... is free of malware."
+    # Until we set up Apple Developer ID notarization (needs $99/yr
+    # enrollment + macOS runner + notarytool), strip the quarantine
+    # xattr at install time. The user already trusted the cask by
+    # `brew install`-ing it; getting hit by Gatekeeper after that is
+    # bad UX and the cosign signature is the real trust signal.
+    hooks:
+      post:
+        install: |
+          if OS.mac?
+            system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", staged_path]
+          end
 
 nfpms:
   # Linux distro packages: .deb (Debian/Ubuntu), .rpm (RHEL/Fedora),


### PR DESCRIPTION
## Summary

User report: after \`brew install aileron\` from the new tap, running \`aileron version\` was blocked by macOS Gatekeeper with:

> Apple could not verify "aileron" is free of malware that may harm your Mac or compromise your privacy.

Our binaries aren't Apple-notarized — that needs a \$99/yr Apple Developer ID, a macOS runner in the release workflow, and \`notarytool\`/\`codesign\` integration. Out of scope for v0.0.x; tracked separately as a follow-up.

The pragmatic fix until notarization lands: strip the \`com.apple.quarantine\` xattr in a cask postflight hook. The user already trusted the cask by \`brew install\`-ing it from a tap they explicitly added; the cosign signature is the real trust signal we ship today.

## What changes

\`.goreleaser.yml\` adds a \`hooks.post.install\` to the \`homebrew_casks\` block. Goreleaser renders this as a \`postflight do ... end\` Ruby block in the generated cask:

\`\`\`ruby
postflight do
  if OS.mac?
    system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", staged_path]
  end
end
\`\`\`

Pattern is per goreleaser docs — they don't expose a \`no_quarantine\` flag directly, but recommend this hook for non-notarized binaries.

## Test plan

- [x] \`goreleaser check\` clean
- [x] \`goreleaser release --snapshot --skip publish,sign --clean\` produces \`dist/homebrew/Casks/aileron.rb\` with the postflight block
- [ ] After merge: cut \`v0.0.2\`, update tap, \`brew install aileron\` on a clean macOS — verify Gatekeeper does not block

## Existing v0.0.1 installs

The new postflight runs on **install**, not on existing installs. Anyone already on v0.0.1 needs a one-time manual fix:

\`\`\`sh
sudo xattr -dr com.apple.quarantine "\$(brew --prefix aileron)"
\`\`\`

…or they reinstall after v0.0.2 ships (\`brew uninstall aileron && brew install aileron\`).

## Follow-up

Apple notarization is the right long-term fix. Worth a tracking issue when distribution scope grows. For now, cosign + Sigstore transparency log is the trust story.

Refs #572