### PR TITLE
docs(getting-started): lead with prebuilt binary install paths

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -77,17 +77,22 @@ jobs:
         # Railway only auto-rebuilds on push-to-main; a release tag
         # alone doesn't move main, so the docs would otherwise stay
         # frozen at the previous release until the next code push.
-        # Hit Railway's deploy hook to force a rebuild.
         #
-        # If RAILWAY_DOCS_DEPLOY_HOOK isn't configured, skip silently
-        # — the docs will catch up on the next push to main.
+        # Railway has no built-in deploy webhook, so use the Railway
+        # CLI with a project-scoped token. Create the token in Railway
+        # dashboard → project → Settings → Tokens → Create, then add
+        # it as the RAILWAY_TOKEN repo secret. If the token isn't
+        # configured, skip silently — docs catch up on next push.
+        #
+        # The --service value must match the docs service name in the
+        # Railway project; adjust if it ever differs from "docs".
         if: success()
         run: |
-          if [ -z "${RAILWAY_DOCS_DEPLOY_HOOK}" ]; then
-            echo "RAILWAY_DOCS_DEPLOY_HOOK not configured; skipping docs rebuild trigger"
+          if [ -z "${RAILWAY_TOKEN}" ]; then
+            echo "RAILWAY_TOKEN not configured; skipping docs rebuild"
             exit 0
           fi
-          curl -fsSL -X POST "${RAILWAY_DOCS_DEPLOY_HOOK}"
+          npx -y @railway/cli redeploy --service docs --yes
           echo "Triggered Railway docs rebuild"
         env:
-          RAILWAY_DOCS_DEPLOY_HOOK: ${{ secrets.RAILWAY_DOCS_DEPLOY_HOOK }}
+          RAILWAY_TOKEN: ${{ secrets.RAILWAY_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,3 +69,25 @@ jobs:
           # across repos. Configure as a repo secret before tagging
           # the first release.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+
+      - name: Trigger docs site rebuild
+        # The docs site's `$lib/data/release.ts` fetches the latest
+        # release tag from GitHub at build time, so install URLs and
+        # version text in getting-started reflect whatever's current.
+        # Railway only auto-rebuilds on push-to-main; a release tag
+        # alone doesn't move main, so the docs would otherwise stay
+        # frozen at the previous release until the next code push.
+        # Hit Railway's deploy hook to force a rebuild.
+        #
+        # If RAILWAY_DOCS_DEPLOY_HOOK isn't configured, skip silently
+        # — the docs will catch up on the next push to main.
+        if: success()
+        run: |
+          if [ -z "${RAILWAY_DOCS_DEPLOY_HOOK}" ]; then
+            echo "RAILWAY_DOCS_DEPLOY_HOOK not configured; skipping docs rebuild trigger"
+            exit 0
+          fi
+          curl -fsSL -X POST "${RAILWAY_DOCS_DEPLOY_HOOK}"
+          echo "Triggered Railway docs rebuild"
+        env:
+          RAILWAY_DOCS_DEPLOY_HOOK: ${{ secrets.RAILWAY_DOCS_DEPLOY_HOOK }}

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -1,11 +1,12 @@
 ---
 title: "Prepare for Liftoff"
-description: "Build Aileron from source, install Gmail and Calendar actions, and launch Claude Code with everything wired in."
+description: "Install Aileron, install Gmail and Calendar actions, and launch Claude Code with everything wired in."
 order: 2
 ---
 
 import HighlightCard from '$lib/components/ui/highlight-card.svelte';
 import LiftoffPreflight from '$lib/components/ui/liftoff-preflight.svelte';
+import PlatformTabs from '$lib/components/ui/tabs/platform-tabs.svelte';
 
 <HighlightCard>
 
@@ -23,16 +24,30 @@ Estimated time: 5 minutes. What happens: Summarize five most recent emails, draf
 
 <LiftoffPreflight client:load />
 
-## 1. Build Aileron
+## 1. Install Aileron
 
-> **Note:** there is no `brew install aileron` yet. This guide builds from source; package distribution is coming shortly.
-
-```sh
-git clone https://github.com/ALRubinger/aileron.git && \
-  cd aileron && \
-  task build:cli build:server build:mcp build:sh && \
-  export PATH="$PWD/build:$PATH"
-```
+<PlatformTabs items={[
+  {
+    value: "macos",
+    label: "macOS",
+    lang: "sh",
+    code: "brew tap ALRubinger/aileron\nbrew install aileron",
+  },
+  {
+    value: "linux",
+    label: "Linux",
+    lang: "sh",
+    note: "Debian/Ubuntu shown; .rpm and .apk packages are attached to every release alongside .deb.",
+    code: "curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_linux_amd64.deb\nsudo dpkg -i aileron_0.0.2_linux_amd64.deb",
+  },
+  {
+    value: "windows",
+    label: "Windows",
+    lang: "powershell",
+    note: "Extract the zip and add the directory to PATH.",
+    code: "Invoke-WebRequest -Uri https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_windows_amd64.zip -OutFile aileron.zip\nExpand-Archive aileron.zip -DestinationPath $env:USERPROFILE\\aileron",
+  },
+]} client:load />
 
 Verify:
 
@@ -43,8 +58,10 @@ aileron version
 You should see something like:
 
 ```
-aileron dev (f66e51c)
+aileron 0.0.2 (697521b)
 ```
+
+> Want to build from source? Clone [the repo](https://github.com/ALRubinger/aileron) and follow the README. The prebuilt path above is the standard install for everyone else.
 
 ## 2. Install Actions for Gmail and Calendar
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -74,7 +74,7 @@ Estimated time: 5 minutes. What happens: Summarize five most recent emails, draf
   {
     value: "source",
     label: "Build from source",
-    note: 'Requires Go 1.25, Task, Node.js 24, and pnpm 11.0.8 on PATH. See the <a href="https://github.com/ALRubinger/aileron#building-from-source">repo README</a> for prerequisite install commands.',
+    note: "Expand each prerequisite for per-OS install commands, then run the build:",
     lang: "sh",
     code: "git clone https://github.com/ALRubinger/aileron.git\ncd aileron\ntask build:cli build:server build:mcp build:sh\nexport PATH=\"$PWD/build:$PATH\"",
   },

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -7,6 +7,7 @@ order: 2
 import HighlightCard from '$lib/components/ui/highlight-card.svelte';
 import LiftoffPreflight from '$lib/components/ui/liftoff-preflight.svelte';
 import InstallTabs from '$lib/components/ui/tabs/install-tabs.svelte';
+import { latestRelease } from '$lib/data/release';
 
 <HighlightCard>
 
@@ -46,19 +47,19 @@ Estimated time: 5 minutes. What happens: Summarize five most recent emails, draf
             value: "deb",
             label: "Debian / Ubuntu (.deb)",
             lang: "sh",
-            code: "curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_linux_amd64.deb\nsudo dpkg -i aileron_0.0.2_linux_amd64.deb",
+            code: `curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_${latestRelease.version}_linux_amd64.deb\nsudo dpkg -i aileron_${latestRelease.version}_linux_amd64.deb`,
           },
           {
             value: "rpm",
             label: "RHEL / Fedora (.rpm)",
             lang: "sh",
-            code: "curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_linux_amd64.rpm\nsudo rpm -i aileron_0.0.2_linux_amd64.rpm",
+            code: `curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_${latestRelease.version}_linux_amd64.rpm\nsudo rpm -i aileron_${latestRelease.version}_linux_amd64.rpm`,
           },
           {
             value: "apk",
             label: "Alpine (.apk)",
             lang: "sh",
-            code: "curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_linux_amd64.apk\nsudo apk add --allow-untrusted aileron_0.0.2_linux_amd64.apk",
+            code: `curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_${latestRelease.version}_linux_amd64.apk\nsudo apk add --allow-untrusted aileron_${latestRelease.version}_linux_amd64.apk`,
           },
         ],
       },
@@ -67,7 +68,7 @@ Estimated time: 5 minutes. What happens: Summarize five most recent emails, draf
         label: "Windows",
         lang: "powershell",
         note: "Extract the zip and add the directory to PATH.",
-        code: "Invoke-WebRequest -Uri https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_windows_amd64.zip -OutFile aileron.zip\nExpand-Archive aileron.zip -DestinationPath $env:USERPROFILE\\aileron",
+        code: `Invoke-WebRequest -Uri https://github.com/ALRubinger/aileron/releases/latest/download/aileron_${latestRelease.version}_windows_amd64.zip -OutFile aileron.zip\nExpand-Archive aileron.zip -DestinationPath $env:USERPROFILE\\aileron`,
       },
     ],
   },
@@ -86,11 +87,9 @@ Verify:
 aileron version
 ```
 
-You should see something like:
+You should see the installed version:
 
-```
-aileron 0.0.2 (697521b)
-```
+<pre><code>{`aileron ${latestRelease.version}`}</code></pre>
 
 ## 2. Install Actions for Gmail and Calendar
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -76,7 +76,7 @@ Estimated time: 5 minutes. What happens: Summarize five most recent emails, draf
     label: "Build from source",
     note: "Expand each prerequisite for per-OS install commands, then run the build:",
     lang: "sh",
-    code: "git clone https://github.com/ALRubinger/aileron.git\ncd aileron\ntask build:cli build:server build:mcp build:sh\nexport PATH=\"$PWD/build:$PATH\"",
+    code: "git clone https://github.com/ALRubinger/aileron.git && \\\n  cd aileron && \\\n  task build:cli build:server build:mcp build:sh && \\\n  export PATH=\"$PWD/build:$PATH\"",
   },
 ]} client:load />
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -6,7 +6,7 @@ order: 2
 
 import HighlightCard from '$lib/components/ui/highlight-card.svelte';
 import LiftoffPreflight from '$lib/components/ui/liftoff-preflight.svelte';
-import PlatformTabs from '$lib/components/ui/tabs/platform-tabs.svelte';
+import InstallTabs from '$lib/components/ui/tabs/install-tabs.svelte';
 
 <HighlightCard>
 
@@ -26,26 +26,57 @@ Estimated time: 5 minutes. What happens: Summarize five most recent emails, draf
 
 ## 1. Install Aileron
 
-<PlatformTabs items={[
+<InstallTabs methods={[
   {
-    value: "macos",
-    label: "macOS",
-    lang: "sh",
-    code: "brew tap ALRubinger/aileron\nbrew install aileron",
+    value: "install",
+    label: "Install",
+    platforms: [
+      {
+        value: "macos",
+        label: "macOS",
+        lang: "sh",
+        note: 'Uses <a href="https://brew.sh">Homebrew</a>. Don\'t have it yet? Install it first.',
+        code: "brew tap ALRubinger/aileron\nbrew install aileron",
+      },
+      {
+        value: "linux",
+        label: "Linux",
+        variants: [
+          {
+            value: "deb",
+            label: "Debian / Ubuntu (.deb)",
+            lang: "sh",
+            code: "curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_linux_amd64.deb\nsudo dpkg -i aileron_0.0.2_linux_amd64.deb",
+          },
+          {
+            value: "rpm",
+            label: "RHEL / Fedora (.rpm)",
+            lang: "sh",
+            code: "curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_linux_amd64.rpm\nsudo rpm -i aileron_0.0.2_linux_amd64.rpm",
+          },
+          {
+            value: "apk",
+            label: "Alpine (.apk)",
+            lang: "sh",
+            code: "curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_linux_amd64.apk\nsudo apk add --allow-untrusted aileron_0.0.2_linux_amd64.apk",
+          },
+        ],
+      },
+      {
+        value: "windows",
+        label: "Windows",
+        lang: "powershell",
+        note: "Extract the zip and add the directory to PATH.",
+        code: "Invoke-WebRequest -Uri https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_windows_amd64.zip -OutFile aileron.zip\nExpand-Archive aileron.zip -DestinationPath $env:USERPROFILE\\aileron",
+      },
+    ],
   },
   {
-    value: "linux",
-    label: "Linux",
+    value: "source",
+    label: "Build from source",
+    note: 'Requires Go 1.25, Task, Node.js 24, and pnpm 11.0.8 on PATH. See the <a href="https://github.com/ALRubinger/aileron#building-from-source">repo README</a> for prerequisite install commands.',
     lang: "sh",
-    note: "Debian/Ubuntu shown; .rpm and .apk packages are attached to every release alongside .deb.",
-    code: "curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_linux_amd64.deb\nsudo dpkg -i aileron_0.0.2_linux_amd64.deb",
-  },
-  {
-    value: "windows",
-    label: "Windows",
-    lang: "powershell",
-    note: "Extract the zip and add the directory to PATH.",
-    code: "Invoke-WebRequest -Uri https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_windows_amd64.zip -OutFile aileron.zip\nExpand-Archive aileron.zip -DestinationPath $env:USERPROFILE\\aileron",
+    code: "git clone https://github.com/ALRubinger/aileron.git\ncd aileron\ntask build:cli build:server build:mcp build:sh\nexport PATH=\"$PWD/build:$PATH\"",
   },
 ]} client:load />
 
@@ -60,8 +91,6 @@ You should see something like:
 ```
 aileron 0.0.2 (697521b)
 ```
-
-> Want to build from source? Clone [the repo](https://github.com/ALRubinger/aileron) and follow the README. The prebuilt path above is the standard install for everyone else.
 
 ## 2. Install Actions for Gmail and Calendar
 

--- a/docs/src/lib/components/ui/build-prereqs.svelte
+++ b/docs/src/lib/components/ui/build-prereqs.svelte
@@ -1,0 +1,119 @@
+<script lang="ts">
+	import { Accordion as AccordionPrimitive } from "bits-ui";
+	import ChevronDown from "@lucide/svelte/icons/chevron-down";
+	import { cn } from "$lib/utils.js";
+	import PlatformTabs, { type PlatformTabItem } from "./tabs/platform-tabs.svelte";
+
+	const goInstall: PlatformTabItem[] = [
+		{ value: "macos", label: "macOS", lang: "sh", code: "brew install go" },
+		{
+			value: "linux",
+			label: "Linux",
+			lang: "sh",
+			note: "Use your distro's package manager, or download the official tarball from go.dev/dl.",
+			code: "# Debian / Ubuntu (may lag behind upstream; check version)\nsudo apt-get install golang-go",
+		},
+		{ value: "windows", label: "Windows", lang: "powershell", code: "winget install GoLang.Go" },
+	];
+
+	const taskInstall: PlatformTabItem[] = [
+		{ value: "macos", label: "macOS", lang: "sh", code: "brew install go-task" },
+		{
+			value: "linux",
+			label: "Linux",
+			lang: "sh",
+			code: 'sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin',
+		},
+		{ value: "windows", label: "Windows", lang: "powershell", code: "scoop install task" },
+	];
+
+	const nodeInstall: PlatformTabItem[] = [
+		{
+			value: "macos",
+			label: "macOS",
+			lang: "sh",
+			code: "brew install node\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate",
+		},
+		{
+			value: "linux",
+			label: "Linux",
+			lang: "sh",
+			note: "Install nvm (https://github.com/nvm-sh/nvm), then run:",
+			code: "nvm install 24\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate",
+		},
+		{
+			value: "windows",
+			label: "Windows",
+			lang: "powershell",
+			code: "winget install OpenJS.NodeJS\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate",
+		},
+	];
+
+	const triggerClass = cn(
+		"flex w-full items-center justify-between py-3 text-left text-sm font-medium",
+		"hover:underline focus-visible:outline-1 focus-visible:outline-ring",
+		"[&[data-state=open]>svg]:rotate-180"
+	);
+	const itemClass = "border-b border-border";
+	const contentClass = cn(
+		"cn-accordion-content overflow-hidden pb-4 text-sm",
+		"[&_pre]:my-2"
+	);
+</script>
+
+<!--
+  BuildPrereqs is the dev-toolchain accordion shown under the "Build
+  from source" method tab in InstallTabs. Single Svelte component
+  owning the Accordion primitives directly so bits-ui's accordion
+  context stays intact (the same constraint that Tabs has).
+-->
+<AccordionPrimitive.Root type="multiple" class="cn-build-prereqs my-2 w-full">
+	<AccordionPrimitive.Item value="go" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>Go 1.25 or newer</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content class={contentClass}>
+			<p>
+				Aileron's modules require it. <code>go version</code> should report at least
+				<code>go1.25.0</code>.
+			</p>
+			<PlatformTabs items={goInstall} />
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+
+	<AccordionPrimitive.Item value="task" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>Task</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content class={contentClass}>
+			<p>
+				All build commands go through <code>task</code>. See
+				<a href="https://taskfile.dev/installation/">taskfile.dev</a> for other install options.
+			</p>
+			<PlatformTabs items={taskInstall} />
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+
+	<AccordionPrimitive.Item value="node" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>Node.js 24 + pnpm 11.0.8</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content class={contentClass}>
+			<p>
+				The webapp and docs targets build through <code>pnpm</code>, so <code>task build</code> will
+				fail without them. The simplest setup is <code>corepack enable</code> after installing Node,
+				then <code>corepack prepare pnpm@11.0.8 --activate</code>.
+			</p>
+			<PlatformTabs items={nodeInstall} />
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+</AccordionPrimitive.Root>

--- a/docs/src/lib/components/ui/liftoff-preflight.svelte
+++ b/docs/src/lib/components/ui/liftoff-preflight.svelte
@@ -2,52 +2,6 @@
 	import { Accordion as AccordionPrimitive } from "bits-ui";
 	import ChevronDown from "@lucide/svelte/icons/chevron-down";
 	import { cn } from "$lib/utils.js";
-	import PlatformTabs, { type PlatformTabItem } from "./tabs/platform-tabs.svelte";
-
-	const goInstall: PlatformTabItem[] = [
-		{ value: "macos", label: "macOS", lang: "sh", code: "brew install go" },
-		{
-			value: "linux",
-			label: "Linux",
-			lang: "sh",
-			note: "Use your distro's package manager, or download the official tarball from go.dev/dl.",
-			code: "# Debian / Ubuntu (may lag behind upstream; check version)\nsudo apt-get install golang-go",
-		},
-		{ value: "windows", label: "Windows", lang: "powershell", code: "winget install GoLang.Go" },
-	];
-
-	const taskInstall: PlatformTabItem[] = [
-		{ value: "macos", label: "macOS", lang: "sh", code: "brew install go-task" },
-		{
-			value: "linux",
-			label: "Linux",
-			lang: "sh",
-			code: 'sh -c "$(curl --location https://taskfile.dev/install.sh)" -- -d -b ~/.local/bin',
-		},
-		{ value: "windows", label: "Windows", lang: "powershell", code: "scoop install task" },
-	];
-
-	const nodeInstall: PlatformTabItem[] = [
-		{
-			value: "macos",
-			label: "macOS",
-			lang: "sh",
-			code: "brew install node\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate",
-		},
-		{
-			value: "linux",
-			label: "Linux",
-			lang: "sh",
-			note: "Install nvm (https://github.com/nvm-sh/nvm), then run:",
-			code: "nvm install 24\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate",
-		},
-		{
-			value: "windows",
-			label: "Windows",
-			lang: "powershell",
-			code: "winget install OpenJS.NodeJS\ncorepack enable\ncorepack prepare pnpm@11.0.8 --activate",
-		},
-	];
 
 	const triggerClass = cn(
 		"flex w-full items-center justify-between py-3 text-left text-sm font-medium",
@@ -65,65 +19,14 @@
 </script>
 
 <!--
-  LiftoffPreflight is a single Svelte island that owns the entire
-  "Liftoff in 5 Minutes" preflight checklist: an accordion of bits-ui
-  Accordion items, three of which embed a PlatformTabs component for
-  per-OS install commands. Splitting Accordion primitives across MDX
+  LiftoffPreflight owns the "Liftoff in 5 Minutes" preflight checklist
+  as a single Svelte island. Splitting Accordion primitives across MDX
   references would sever bits-ui's context (see the comment on
   platform-tabs.svelte). Page-specific by design — the prose lives
   here so the data and presentation stay together for content that
   only ships on this one page.
 -->
 <AccordionPrimitive.Root type="multiple" class="cn-preflight my-6 w-full">
-	<AccordionPrimitive.Item value="go" class={itemClass}>
-		<AccordionPrimitive.Header>
-			<AccordionPrimitive.Trigger class={triggerClass}>
-				<span>Go 1.25 or newer</span>
-				<ChevronDown size={16} class="shrink-0 transition-transform" />
-			</AccordionPrimitive.Trigger>
-		</AccordionPrimitive.Header>
-		<AccordionPrimitive.Content class={contentClass}>
-			<p>
-				Aileron's modules require it. <code>go version</code> should report at least
-				<code>go1.25.0</code>.
-			</p>
-			<PlatformTabs items={goInstall} />
-		</AccordionPrimitive.Content>
-	</AccordionPrimitive.Item>
-
-	<AccordionPrimitive.Item value="task" class={itemClass}>
-		<AccordionPrimitive.Header>
-			<AccordionPrimitive.Trigger class={triggerClass}>
-				<span>Task</span>
-				<ChevronDown size={16} class="shrink-0 transition-transform" />
-			</AccordionPrimitive.Trigger>
-		</AccordionPrimitive.Header>
-		<AccordionPrimitive.Content class={contentClass}>
-			<p>
-				All build commands go through <code>task</code>. See
-				<a href="https://taskfile.dev/installation/">taskfile.dev</a> for other install options.
-			</p>
-			<PlatformTabs items={taskInstall} />
-		</AccordionPrimitive.Content>
-	</AccordionPrimitive.Item>
-
-	<AccordionPrimitive.Item value="node" class={itemClass}>
-		<AccordionPrimitive.Header>
-			<AccordionPrimitive.Trigger class={triggerClass}>
-				<span>Node.js 24 + pnpm 11.0.8</span>
-				<ChevronDown size={16} class="shrink-0 transition-transform" />
-			</AccordionPrimitive.Trigger>
-		</AccordionPrimitive.Header>
-		<AccordionPrimitive.Content class={contentClass}>
-			<p>
-				The webapp and docs targets build through <code>pnpm</code>, so <code>task build</code> will
-				fail without them. The simplest setup is <code>corepack enable</code> after installing Node,
-				then <code>corepack prepare pnpm@11.0.8 --activate</code>.
-			</p>
-			<PlatformTabs items={nodeInstall} />
-		</AccordionPrimitive.Content>
-	</AccordionPrimitive.Item>
-
 	<AccordionPrimitive.Item value="claude-code" class={itemClass}>
 		<AccordionPrimitive.Header>
 			<AccordionPrimitive.Trigger class={triggerClass}>

--- a/docs/src/lib/components/ui/tabs/index.ts
+++ b/docs/src/lib/components/ui/tabs/index.ts
@@ -3,6 +3,11 @@ import Content from "./tabs-content.svelte";
 import List, { tabsListVariants, type TabsListVariant } from "./tabs-list.svelte";
 import Trigger from "./tabs-trigger.svelte";
 import PlatformTabs, { type PlatformTabItem } from "./platform-tabs.svelte";
+import InstallTabs, {
+	type InstallMethod,
+	type InstallPlatform,
+	type InstallVariant,
+} from "./install-tabs.svelte";
 
 export {
 	Root,
@@ -19,4 +24,9 @@ export {
 	//
 	PlatformTabs,
 	type PlatformTabItem,
+	//
+	InstallTabs,
+	type InstallMethod,
+	type InstallPlatform,
+	type InstallVariant,
 };

--- a/docs/src/lib/components/ui/tabs/install-tabs.svelte
+++ b/docs/src/lib/components/ui/tabs/install-tabs.svelte
@@ -1,0 +1,202 @@
+<script lang="ts" module>
+	import { Tabs as TabsPrimitive } from "bits-ui";
+	import { tabsListVariants } from "./tabs-list.svelte";
+	import { cn } from "$lib/utils.js";
+	import CodeBlock from "../code-block.svelte";
+
+	export type InstallVariant = {
+		value: string;
+		label: string;
+		lang?: string;
+		code: string;
+		note?: string;
+	};
+
+	export type InstallPlatform = {
+		value: string;
+		label: string;
+		// Either a single code view (lang/code/note here) OR a list of
+		// variants rendered as a third level of sub-tabs (e.g. Linux's
+		// deb/rpm/apk). Mutually exclusive in practice; if both are set,
+		// `variants` wins.
+		lang?: string;
+		code?: string;
+		note?: string;
+		variants?: InstallVariant[];
+	};
+
+	export type InstallMethod = {
+		value: string;
+		label: string;
+		// Either a flat single-block method (e.g. "Build from source"
+		// with one cross-platform command) or a per-platform method
+		// (e.g. "Install" with macOS/Linux/Windows tabs). If both are
+		// set, `platforms` wins.
+		lang?: string;
+		code?: string;
+		note?: string;
+		platforms?: InstallPlatform[];
+	};
+</script>
+
+<script lang="ts">
+	let {
+		methods,
+		defaultMethod,
+		defaultPlatform,
+		class: className,
+	}: {
+		methods: InstallMethod[];
+		defaultMethod?: string;
+		defaultPlatform?: string;
+		class?: string;
+	} = $props();
+
+	let methodValue = $state(defaultMethod ?? methods[0]?.value ?? "");
+	// Per-method active platform/variant state, keyed by method value
+	// so switching methods doesn't lose your sub-selection. Initialized
+	// lazily inside reactive blocks.
+	let platformValue = $state<Record<string, string>>({});
+	let variantValue = $state<Record<string, string>>({});
+
+	function platformFor(method: InstallMethod): string {
+		const cached = platformValue[method.value];
+		if (cached) return cached;
+		const fallback = defaultPlatform ?? method.platforms?.[0]?.value ?? "";
+		return fallback;
+	}
+
+	function variantFor(method: InstallMethod, platform: InstallPlatform): string {
+		const key = `${method.value}/${platform.value}`;
+		const cached = variantValue[key];
+		if (cached) return cached;
+		return platform.variants?.[0]?.value ?? "";
+	}
+
+	function setPlatform(methodKey: string, value: string) {
+		platformValue = { ...platformValue, [methodKey]: value };
+	}
+
+	function setVariant(methodKey: string, platformKey: string, value: string) {
+		variantValue = { ...variantValue, [`${methodKey}/${platformKey}`]: value };
+	}
+
+	const triggerClass = cn(
+		"cn-tabs-trigger relative inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1 text-sm transition-all",
+		"text-foreground/60 hover:text-foreground",
+		"data-active:bg-background data-active:text-foreground data-active:shadow-sm",
+		"focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50"
+	);
+
+	// Notes are author-controlled markup in the page that includes this
+	// component (currently getting-started.mdx). Treat note strings as
+	// trusted HTML so anchors and emphasis render — never bind to user
+	// input here.
+</script>
+
+<!--
+  InstallTabs owns three nested Tabs.Root layers (method → platform →
+  variant) in a single Svelte island. Splitting any of the layers
+  across separate components would sever bits-ui's tabs context (see
+  the comment on platform-tabs.svelte for the same constraint at one
+  level). Page-specific by design — the install matrix on the
+  getting-started page is the only consumer.
+-->
+<TabsPrimitive.Root
+	bind:value={methodValue}
+	data-slot="tabs"
+	class={cn("cn-tabs install-tabs group/tabs flex flex-col my-3", className)}
+>
+	<TabsPrimitive.List
+		data-slot="tabs-list"
+		data-variant="default"
+		class={cn(tabsListVariants({ variant: "default" }), "rounded-md p-1")}
+	>
+		{#each methods as method (method.value)}
+			<TabsPrimitive.Trigger
+				value={method.value}
+				data-slot="tabs-trigger"
+				class={triggerClass}
+			>
+				{method.label}
+			</TabsPrimitive.Trigger>
+		{/each}
+	</TabsPrimitive.List>
+
+	{#each methods as method (method.value)}
+		<TabsPrimitive.Content
+			value={method.value}
+			data-slot="tabs-content"
+			class={cn("cn-tabs-content flex-1 outline-none mt-2")}
+		>
+			{#if method.note}
+				<p class="text-sm">{@html method.note}</p>
+			{/if}
+
+			{#if method.platforms && method.platforms.length > 0}
+				<TabsPrimitive.Root
+					value={platformFor(method)}
+					onValueChange={(v) => setPlatform(method.value, v)}
+					class="cn-tabs flex flex-col mt-2"
+				>
+					<TabsPrimitive.List
+						data-variant="default"
+						class={cn(tabsListVariants({ variant: "default" }), "rounded-md p-1")}
+					>
+						{#each method.platforms as platform (platform.value)}
+							<TabsPrimitive.Trigger value={platform.value} class={triggerClass}>
+								{platform.label}
+							</TabsPrimitive.Trigger>
+						{/each}
+					</TabsPrimitive.List>
+
+					{#each method.platforms as platform (platform.value)}
+						<TabsPrimitive.Content
+							value={platform.value}
+							class={cn("cn-tabs-content flex-1 outline-none mt-2")}
+						>
+							{#if platform.note}
+								<p class="text-sm">{@html platform.note}</p>
+							{/if}
+
+							{#if platform.variants && platform.variants.length > 0}
+								<TabsPrimitive.Root
+									value={variantFor(method, platform)}
+									onValueChange={(v) => setVariant(method.value, platform.value, v)}
+									class="cn-tabs flex flex-col mt-2"
+								>
+									<TabsPrimitive.List
+										data-variant="default"
+										class={cn(tabsListVariants({ variant: "default" }), "rounded-md p-1")}
+									>
+										{#each platform.variants as variant (variant.value)}
+											<TabsPrimitive.Trigger value={variant.value} class={triggerClass}>
+												{variant.label}
+											</TabsPrimitive.Trigger>
+										{/each}
+									</TabsPrimitive.List>
+
+									{#each platform.variants as variant (variant.value)}
+										<TabsPrimitive.Content
+											value={variant.value}
+											class={cn("cn-tabs-content flex-1 outline-none mt-2")}
+										>
+											{#if variant.note}
+												<p class="text-sm">{@html variant.note}</p>
+											{/if}
+											<CodeBlock code={variant.code} lang={variant.lang} />
+										</TabsPrimitive.Content>
+									{/each}
+								</TabsPrimitive.Root>
+							{:else if platform.code}
+								<CodeBlock code={platform.code} lang={platform.lang} />
+							{/if}
+						</TabsPrimitive.Content>
+					{/each}
+				</TabsPrimitive.Root>
+			{:else if method.code}
+				<CodeBlock code={method.code} lang={method.lang} />
+			{/if}
+		</TabsPrimitive.Content>
+	{/each}
+</TabsPrimitive.Root>

--- a/docs/src/lib/components/ui/tabs/install-tabs.svelte
+++ b/docs/src/lib/components/ui/tabs/install-tabs.svelte
@@ -3,6 +3,7 @@
 	import { tabsListVariants } from "./tabs-list.svelte";
 	import { cn } from "$lib/utils.js";
 	import CodeBlock from "../code-block.svelte";
+	import BuildPrereqs from "../build-prereqs.svelte";
 
 	export type InstallVariant = {
 		value: string;
@@ -81,10 +82,29 @@
 		variantValue = { ...variantValue, [`${methodKey}/${platformKey}`]: value };
 	}
 
-	const triggerClass = cn(
+	// Visual hierarchy: each tab level gets a distinct trigger size +
+	// list style so the user reads "Install vs Build from source" as
+	// the major decision, "macOS / Linux / Windows" as the platform
+	// pivot, and "deb / rpm / apk" as the smaller package-format
+	// pivot. Without this differentiation all three rows look like
+	// equally-weighted choices.
+	const methodTriggerClass = cn(
+		"cn-tabs-trigger relative inline-flex items-center justify-center whitespace-nowrap rounded-md px-4 py-1.5 text-base font-medium transition-all",
+		"text-foreground/60 hover:text-foreground",
+		"data-active:bg-background data-active:text-foreground data-active:shadow-sm",
+		"focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50"
+	);
+	const platformTriggerClass = cn(
 		"cn-tabs-trigger relative inline-flex items-center justify-center whitespace-nowrap rounded-sm px-3 py-1 text-sm transition-all",
 		"text-foreground/60 hover:text-foreground",
 		"data-active:bg-background data-active:text-foreground data-active:shadow-sm",
+		"focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50"
+	);
+	const variantTriggerClass = cn(
+		"cn-tabs-trigger relative inline-flex items-center justify-center whitespace-nowrap px-2 py-0.5 text-xs transition-colors",
+		"text-foreground/50 hover:text-foreground/80",
+		"border-b-2 border-transparent",
+		"data-active:text-foreground data-active:border-foreground",
 		"focus-visible:outline-1 focus-visible:outline-ring disabled:pointer-events-none disabled:opacity-50"
 	);
 
@@ -110,13 +130,13 @@
 	<TabsPrimitive.List
 		data-slot="tabs-list"
 		data-variant="default"
-		class={cn(tabsListVariants({ variant: "default" }), "rounded-md p-1")}
+		class={cn(tabsListVariants({ variant: "default" }), "rounded-lg p-1")}
 	>
 		{#each methods as method (method.value)}
 			<TabsPrimitive.Trigger
 				value={method.value}
 				data-slot="tabs-trigger"
-				class={triggerClass}
+				class={methodTriggerClass}
 			>
 				{method.label}
 			</TabsPrimitive.Trigger>
@@ -127,10 +147,14 @@
 		<TabsPrimitive.Content
 			value={method.value}
 			data-slot="tabs-content"
-			class={cn("cn-tabs-content flex-1 outline-none mt-2")}
+			class={cn("cn-tabs-content flex-1 outline-none mt-4")}
 		>
 			{#if method.note}
 				<p class="text-sm">{@html method.note}</p>
+			{/if}
+
+			{#if method.value === "source"}
+				<BuildPrereqs />
 			{/if}
 
 			{#if method.platforms && method.platforms.length > 0}
@@ -144,7 +168,7 @@
 						class={cn(tabsListVariants({ variant: "default" }), "rounded-md p-1")}
 					>
 						{#each method.platforms as platform (platform.value)}
-							<TabsPrimitive.Trigger value={platform.value} class={triggerClass}>
+							<TabsPrimitive.Trigger value={platform.value} class={platformTriggerClass}>
 								{platform.label}
 							</TabsPrimitive.Trigger>
 						{/each}
@@ -153,7 +177,7 @@
 					{#each method.platforms as platform (platform.value)}
 						<TabsPrimitive.Content
 							value={platform.value}
-							class={cn("cn-tabs-content flex-1 outline-none mt-2")}
+							class={cn("cn-tabs-content flex-1 outline-none mt-3")}
 						>
 							{#if platform.note}
 								<p class="text-sm">{@html platform.note}</p>
@@ -166,11 +190,11 @@
 									class="cn-tabs flex flex-col mt-2"
 								>
 									<TabsPrimitive.List
-										data-variant="default"
-										class={cn(tabsListVariants({ variant: "default" }), "rounded-md p-1")}
+										data-variant="line"
+										class={cn(tabsListVariants({ variant: "line" }), "border-b border-border")}
 									>
 										{#each platform.variants as variant (variant.value)}
-											<TabsPrimitive.Trigger value={variant.value} class={triggerClass}>
+											<TabsPrimitive.Trigger value={variant.value} class={variantTriggerClass}>
 												{variant.label}
 											</TabsPrimitive.Trigger>
 										{/each}

--- a/docs/src/lib/data/release.ts
+++ b/docs/src/lib/data/release.ts
@@ -1,0 +1,70 @@
+// Latest released Aileron version, fetched from the GitHub API at
+// build time. Imported by getting-started.mdx (and any future install
+// surfaces) so download URLs and version-text in docs always reflect
+// the most recent published release without a manual docs bump.
+//
+// On a successful release, the release workflow triggers a Railway
+// redeploy of the docs site so this module re-evaluates against the
+// fresh /releases/latest endpoint. See .github/workflows/release.yml.
+//
+// Top-level await runs once per build at module-load time. Astro's
+// static output captures the resulting `latestRelease` constant into
+// the rendered HTML — no runtime fetch hits browsers.
+
+export type LatestRelease = {
+	/** Bare version, e.g. "0.0.2" — matches goreleaser's name_template. */
+	version: string;
+	/** Full git tag, e.g. "v0.0.2" — matches the GitHub Release tag. */
+	tag: string;
+};
+
+// Fallback used only when the GitHub API call fails at build time
+// (rate limit, transient outage, no network on the build host). Bump
+// this in tandem with each release as a belt-and-suspenders measure;
+// in normal builds the live fetch overrides it.
+const FALLBACK: LatestRelease = {
+	version: "0.0.2",
+	tag: "v0.0.2",
+};
+
+const API_URL = "https://api.github.com/repos/ALRubinger/aileron/releases/latest";
+const TIMEOUT_MS = 10_000;
+
+async function fetchLatest(): Promise<LatestRelease> {
+	// One unauthenticated fetch per docs build is well inside GitHub's
+	// 60 req/hr unauth limit. If the build cadence ever climbs (e.g.
+	// per-PR preview deploys), pass a token via Authorization header.
+	const headers: Record<string, string> = {
+		Accept: "application/vnd.github+json",
+		"User-Agent": "aileron-docs-build",
+		"X-GitHub-Api-Version": "2022-11-28",
+	};
+
+	const controller = new AbortController();
+	const timer = setTimeout(() => controller.abort(), TIMEOUT_MS);
+	try {
+		const res = await fetch(API_URL, { headers, signal: controller.signal });
+		if (!res.ok) {
+			console.warn(
+				`[release.ts] GitHub API ${res.status} ${res.statusText}; using fallback ${FALLBACK.tag}`,
+			);
+			return FALLBACK;
+		}
+		const data = (await res.json()) as { tag_name?: string };
+		const tag = data.tag_name;
+		if (!tag || typeof tag !== "string") {
+			console.warn(`[release.ts] GitHub API missing tag_name; using fallback ${FALLBACK.tag}`);
+			return FALLBACK;
+		}
+		const version = tag.startsWith("v") ? tag.slice(1) : tag;
+		return { version, tag };
+	} catch (err) {
+		const message = err instanceof Error ? err.message : String(err);
+		console.warn(`[release.ts] GitHub API fetch failed (${message}); using fallback ${FALLBACK.tag}`);
+		return FALLBACK;
+	} finally {
+		clearTimeout(timer);
+	}
+}
+
+export const latestRelease = await fetchLatest();


### PR DESCRIPTION
## Summary

The last #572 acceptance item — "Getting Started rewritten to lead with prebuilt-binary install paths."

- Replaces the section 1 build-from-source block with platform-tabbed install commands: \`brew\` on macOS, \`dpkg\` on Linux, \`Invoke-WebRequest + Expand-Archive\` on Windows. Drops the "no brew install yet" note (#572 made that no longer true).
- Adds a one-line pointer to the README for contributors who want to build from source.
- \`LiftoffPreflight\` slims down — Go / Task / Node + pnpm accordion items are gone since prebuilt binaries don't need them. Only Claude Code + Google account remain.
- \`PlatformTabs\` import moves to the MDX page (the preflight no longer uses it).
- Frontmatter description updated.

## Test plan

- [x] \`pnpm check\` clean (0 errors / 0 warnings)
- [x] \`pnpm build\` produces all 63 pages
- [ ] **Smoke test on a clean macOS machine**: copy/paste the macOS tab's commands; \`aileron version\` succeeds
- [ ] **Smoke test on a clean Linux/Debian VM**: copy/paste the Linux tab's commands; \`aileron version\` succeeds
- [ ] Per #572's acceptance: each install path manually verified before merge

## Trade-off — version drift in URLs

Download URLs and the example version output hardcode \`v0.0.2\` literally:

\`\`\`sh
curl -LO https://github.com/ALRubinger/aileron/releases/latest/download/aileron_0.0.2_linux_amd64.deb
\`\`\`

GitHub's \`releases/latest/download/<asset>\` redirect requires the asset name to match the latest release exactly. Our archives are named \`aileron_<version>_<os>_<arch>\`, so the URL works only for the version it knows about. Each release tag will need a small docs bump (sed-able).

Two cleaner paths for a follow-up:
1. Add stable-named asset copies in \`release.yml\` (e.g. \`aileron_linux_amd64.deb\` alongside \`aileron_0.0.2_linux_amd64.deb\`)
2. Automate the docs version bump on tag (small action that opens a PR)

Either is small scope; tracked as a follow-up rather than blocking this rewrite.

## Refs

- Distribution umbrella: #572
- Smoke-tested install paths so far: macOS arm64 via Homebrew (\`v0.0.2\` clean post-#582 quarantine fix)