### PR TITLE
feat(cstore): manifest schema for [capabilities.spawn]

### DIFF
--- a/internal/cstore/manifest.go
+++ b/internal/cstore/manifest.go
@@ -12,6 +12,7 @@
 package cstore
 
 import (
+	"regexp"
 	"strings"
 
 	"github.com/BurntSushi/toml"
@@ -95,6 +96,7 @@ type ManifestCapabilities struct {
 	Network    *ManifestNetwork    `toml:"network"`
 	Credential *ManifestCredential `toml:"credential"`
 	Runtime    *ManifestRuntime    `toml:"runtime"`
+	Spawn      *ManifestSpawn      `toml:"spawn"`
 }
 
 // ManifestNetwork is `[capabilities.network]` — declared outbound grants.
@@ -175,6 +177,63 @@ type ManifestRuntime struct {
 	Imports []string `toml:"imports"`
 }
 
+// ManifestSpawn is `[capabilities.spawn]` (per ADR-0002 spawn primitive,
+// ADR-0014 sandbox technology). Declares the connector's local subprocess
+// grants: which programs may be invoked, with which argv shapes, which
+// environment keys may be forwarded, and which filesystem scopes the
+// subprocess may read or write. Absent block means the connector may not
+// spawn anything.
+//
+// The runtime enforces this declaration at host-function call time via
+// HostPolicy.CheckSpawn, mirroring the network primitive's
+// HostPolicy.CheckURL.
+type ManifestSpawn struct {
+	// Programs lists allowed binaries. Each entry pins the binary by
+	// absolute filesystem path (or `~/`-anchored path) and optionally
+	// by content hash. The runtime resolves the path before exec and
+	// refuses spawn if it does not match an entry. When Hash is set,
+	// the runtime additionally verifies the binary's bytes.
+	Programs []ManifestSpawnProgram `toml:"programs"`
+
+	// ArgvPatterns is an allow-list of templated argv shapes the
+	// connector may invoke. Each pattern is a literal argv with
+	// `{name}` placeholders the connector fills at call time. An argv
+	// that does not match any pattern after substitution is denied.
+	ArgvPatterns []string `toml:"argv_patterns"`
+
+	// EnvPassthrough is the closed set of environment keys the runtime
+	// may set on the subprocess. The subprocess receives only declared
+	// keys; nothing is forwarded by default. Credential injection rides
+	// this channel (per ADR-0002 spawn-primitive credential rule).
+	EnvPassthrough []string `toml:"env_passthrough"`
+
+	// FSRead is the filesystem read scope. Each entry is an absolute
+	// path or `~/`-anchored path. The sandbox restricts subprocess
+	// reads to these paths.
+	FSRead []string `toml:"fs_read"`
+
+	// FSWrite is the filesystem write scope. Same shape as FSRead.
+	FSWrite []string `toml:"fs_write"`
+
+	// Cwd is the optional working-directory policy. When set, the
+	// runtime invokes the subprocess with this cwd; the cwd must be
+	// within FSRead. When unset, the runtime uses a per-invocation
+	// temporary directory.
+	Cwd string `toml:"cwd,omitempty"`
+}
+
+// ManifestSpawnProgram is one entry in [capabilities.spawn].programs:
+// a program path plus an optional content-hash pin.
+type ManifestSpawnProgram struct {
+	// Path is the absolute (or `~/`-anchored) filesystem path of the
+	// binary. The runtime resolves the path and compares before exec.
+	Path string `toml:"path"`
+
+	// Hash is the optional SHA-256 of the binary's bytes, prefixed
+	// with `sha256:`. When set, the runtime verifies on every call.
+	Hash string `toml:"hash,omitempty"`
+}
+
 // ManifestProvides is `[provides]` — discovery metadata. Not enforced by
 // the runtime; consumed by the Hub and by action authors.
 type ManifestProvides struct {
@@ -233,6 +292,11 @@ func ValidateManifest(m *Manifest, file string) error {
 	}
 	if cred := m.Capabilities.Credential; cred != nil {
 		if err := validateCredential(cred, file); err != nil {
+			return err
+		}
+	}
+	if sp := m.Capabilities.Spawn; sp != nil {
+		if err := validateSpawn(sp, file); err != nil {
 			return err
 		}
 	}
@@ -325,6 +389,101 @@ func validateOAuth2(o *ManifestOAuth2, file string) error {
 		}
 	}
 	return nil
+}
+
+// envKeyRe matches a POSIX-shape environment variable name: a leading
+// letter or underscore, followed by letters, digits, or underscores.
+var envKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
+
+// validateSpawn enforces the [capabilities.spawn] schema described in
+// ADR-0002's spawn-primitive section. See also ADR-0014 for the runtime
+// enforcement mechanism the declaration translates into.
+//
+// A spawn block is only meaningful when it grants at least one program;
+// an empty programs list is rejected so a connector cannot accidentally
+// ship an unenforceable spawn capability. All paths (program paths, FS
+// scopes, cwd) must be absolute or `~/`-anchored so the runtime can
+// resolve them portably across Linux, macOS, and Windows. Argv patterns
+// must each have at least one token. Environment keys must be valid
+// POSIX-shape identifiers.
+func validateSpawn(s *ManifestSpawn, file string) error {
+	if len(s.Programs) == 0 {
+		return newValidationErr(file,
+			"[capabilities.spawn].programs is required (at least one)")
+	}
+	for i, p := range s.Programs {
+		if strings.TrimSpace(p.Path) == "" {
+			return newValidationErr(file,
+				"[capabilities.spawn].programs[%d].path is required", i)
+		}
+		if !isAbsoluteOrTildePath(p.Path) {
+			return newValidationErr(file,
+				"[capabilities.spawn].programs[%d].path %q must be absolute (/...) or ~/-anchored",
+				i, p.Path)
+		}
+		if p.Hash != "" {
+			if !strings.HasPrefix(p.Hash, "sha256:") || len(p.Hash) <= len("sha256:") {
+				return newValidationErr(file,
+					"[capabilities.spawn].programs[%d].hash %q must be prefixed with sha256:",
+					i, p.Hash)
+			}
+		}
+	}
+	if len(s.ArgvPatterns) == 0 {
+		return newValidationErr(file,
+			"[capabilities.spawn].argv_patterns is required (at least one)")
+	}
+	for i, pat := range s.ArgvPatterns {
+		if strings.TrimSpace(pat) == "" {
+			return newValidationErr(file,
+				"[capabilities.spawn].argv_patterns[%d] is empty", i)
+		}
+	}
+	for i, k := range s.EnvPassthrough {
+		if !envKeyRe.MatchString(k) {
+			return newValidationErr(file,
+				"[capabilities.spawn].env_passthrough[%d] %q is not a valid environment variable name",
+				i, k)
+		}
+	}
+	for i, p := range s.FSRead {
+		if !isAbsoluteOrTildePath(p) {
+			return newValidationErr(file,
+				"[capabilities.spawn].fs_read[%d] %q must be absolute (/...) or ~/-anchored",
+				i, p)
+		}
+	}
+	for i, p := range s.FSWrite {
+		if !isAbsoluteOrTildePath(p) {
+			return newValidationErr(file,
+				"[capabilities.spawn].fs_write[%d] %q must be absolute (/...) or ~/-anchored",
+				i, p)
+		}
+	}
+	if s.Cwd != "" && !isAbsoluteOrTildePath(s.Cwd) {
+		return newValidationErr(file,
+			"[capabilities.spawn].cwd %q must be absolute (/...) or ~/-anchored",
+			s.Cwd)
+	}
+	return nil
+}
+
+// isAbsoluteOrTildePath reports whether p is either an absolute path
+// (`/...`) or a `~`-anchored path (`~`, `~/...`). Windows-style
+// drive-rooted paths (`C:\...`) are not accepted in the manifest
+// schema; per ADR-0014 the runtime translates `~/`-anchored paths to
+// the host's user profile on Windows.
+func isAbsoluteOrTildePath(p string) bool {
+	if p == "" {
+		return false
+	}
+	if strings.HasPrefix(p, "/") {
+		return true
+	}
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		return true
+	}
+	return false
 }
 
 // isAllowedOAuthURL reports whether s is an allowable OAuth provider

--- a/internal/cstore/manifest_test.go
+++ b/internal/cstore/manifest_test.go
@@ -4,6 +4,8 @@ import (
 	"errors"
 	"strings"
 	"testing"
+
+	"github.com/BurntSushi/toml"
 )
 
 const validManifestTOML = `[connector]
@@ -410,6 +412,288 @@ func TestValidateManifest_AllowsLoopbackHTTPForLocalDev(t *testing.T) {
 				t.Errorf("loopback http should be allowed: %v", err)
 			}
 		})
+	}
+}
+
+// --- spawn capability validation (#509) ---
+
+func goodSpawn() *ManifestSpawn {
+	return &ManifestSpawn{
+		Programs:       []ManifestSpawnProgram{{Path: "/usr/bin/git"}},
+		ArgvPatterns:   []string{"git log --since={since} --author={author}"},
+		EnvPassthrough: []string{"GIT_AUTHOR_NAME"},
+		FSRead:         []string{"~/code/"},
+		FSWrite:        []string{"~/.cache/aileron/gitcrawl/"},
+	}
+}
+
+func TestValidateManifest_AcceptsFullSpawnBlock(t *testing.T) {
+	m := canonicalManifestForTest()
+	m.Capabilities.Spawn = goodSpawn()
+	m.Capabilities.Spawn.Cwd = "~/code/"
+	m.Capabilities.Spawn.Programs[0].Hash = "sha256:abc123"
+	if err := ValidateManifest(m, "ok.toml"); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+}
+
+func TestValidateManifest_AcceptsMinimalSpawnBlock(t *testing.T) {
+	// FSRead, FSWrite, EnvPassthrough are optional. The minimum is
+	// one program and one argv pattern.
+	m := canonicalManifestForTest()
+	m.Capabilities.Spawn = &ManifestSpawn{
+		Programs:     []ManifestSpawnProgram{{Path: "/usr/bin/git"}},
+		ArgvPatterns: []string{"git status"},
+	}
+	if err := ValidateManifest(m, "ok.toml"); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+}
+
+func TestValidateManifest_AcceptsAbsentSpawnBlock(t *testing.T) {
+	// The whole [capabilities.spawn] block is optional — connectors
+	// that do not spawn anything simply omit it.
+	m := canonicalManifestForTest()
+	if err := ValidateManifest(m, "ok.toml"); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+}
+
+func TestValidateManifest_RejectsBadSpawnFields(t *testing.T) {
+	cases := []struct {
+		name   string
+		mutate func(*ManifestSpawn)
+		want   string
+	}{
+		{"empty programs", func(s *ManifestSpawn) {
+			s.Programs = nil
+		}, "programs is required"},
+		{"empty program path", func(s *ManifestSpawn) {
+			s.Programs = []ManifestSpawnProgram{{Path: ""}}
+		}, "path is required"},
+		{"whitespace program path", func(s *ManifestSpawn) {
+			s.Programs = []ManifestSpawnProgram{{Path: "   "}}
+		}, "path is required"},
+		{"relative program path", func(s *ManifestSpawn) {
+			s.Programs = []ManifestSpawnProgram{{Path: "git"}}
+		}, "absolute"},
+		{"bad program hash prefix", func(s *ManifestSpawn) {
+			s.Programs = []ManifestSpawnProgram{{Path: "/usr/bin/git", Hash: "md5:abc"}}
+		}, "sha256:"},
+		{"hash prefix only", func(s *ManifestSpawn) {
+			s.Programs = []ManifestSpawnProgram{{Path: "/usr/bin/git", Hash: "sha256:"}}
+		}, "sha256:"},
+		{"empty argv_patterns", func(s *ManifestSpawn) {
+			s.ArgvPatterns = nil
+		}, "argv_patterns is required"},
+		{"blank argv pattern", func(s *ManifestSpawn) {
+			s.ArgvPatterns = []string{"   "}
+		}, "is empty"},
+		{"env key leading digit", func(s *ManifestSpawn) {
+			s.EnvPassthrough = []string{"1VAR"}
+		}, "valid environment variable"},
+		{"env key with dash", func(s *ManifestSpawn) {
+			s.EnvPassthrough = []string{"MY-VAR"}
+		}, "valid environment variable"},
+		{"env key empty", func(s *ManifestSpawn) {
+			s.EnvPassthrough = []string{""}
+		}, "valid environment variable"},
+		{"relative fs_read", func(s *ManifestSpawn) {
+			s.FSRead = []string{"code/"}
+		}, "absolute"},
+		{"relative fs_write", func(s *ManifestSpawn) {
+			s.FSWrite = []string{"cache/"}
+		}, "absolute"},
+		{"relative cwd", func(s *ManifestSpawn) {
+			s.Cwd = "code/"
+		}, "absolute"},
+		{"windows-style cwd", func(s *ManifestSpawn) {
+			s.Cwd = `C:\Users\me`
+		}, "absolute"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := canonicalManifestForTest()
+			sp := goodSpawn()
+			tc.mutate(sp)
+			m.Capabilities.Spawn = sp
+			err := ValidateManifest(m, "x.toml")
+			if err == nil {
+				t.Fatalf("Validate accepted; want error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q; want substring %q", err.Error(), tc.want)
+			}
+			var aerr *Error
+			if !errors.As(err, &aerr) || aerr.Class != ClassValidationError {
+				t.Errorf("expected ClassValidationError, got %v", err)
+			}
+		})
+	}
+}
+
+func TestValidateManifest_AcceptsTildeOnlyPath(t *testing.T) {
+	// `~` (no trailing slash) is the user's home directory; the
+	// validator accepts it as an anchored path.
+	m := canonicalManifestForTest()
+	sp := goodSpawn()
+	sp.FSRead = []string{"~"}
+	sp.Cwd = "~"
+	m.Capabilities.Spawn = sp
+	if err := ValidateManifest(m, "x.toml"); err != nil {
+		t.Errorf("`~` should be accepted: %v", err)
+	}
+}
+
+func TestValidateManifest_AcceptsAbsoluteUnixPaths(t *testing.T) {
+	m := canonicalManifestForTest()
+	sp := goodSpawn()
+	sp.FSRead = []string{"/var/spool/", "/etc/aileron/"}
+	sp.FSWrite = []string{"/tmp/aileron/"}
+	sp.Cwd = "/tmp/aileron/"
+	m.Capabilities.Spawn = sp
+	if err := ValidateManifest(m, "x.toml"); err != nil {
+		t.Errorf("absolute paths should be accepted: %v", err)
+	}
+}
+
+func TestParseManifest_AcceptsSpawnTOML(t *testing.T) {
+	body := []byte(`[connector]
+name = "github://acme/gitcrawl"
+version = "1.0.0"
+
+[capabilities.spawn]
+argv_patterns = ["git log --since={since}"]
+env_passthrough = ["GIT_AUTHOR_NAME"]
+fs_read = ["~/code/"]
+fs_write = ["~/.cache/aileron/gitcrawl/"]
+cwd = "~/code/"
+
+[[capabilities.spawn.programs]]
+path = "/usr/bin/git"
+hash = "sha256:abc123"
+`)
+	m, err := ParseManifest("x.toml", body)
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	sp := m.Capabilities.Spawn
+	if sp == nil {
+		t.Fatal("Spawn block not parsed")
+	}
+	if len(sp.Programs) != 1 || sp.Programs[0].Path != "/usr/bin/git" {
+		t.Errorf("Programs = %v", sp.Programs)
+	}
+	if sp.Programs[0].Hash != "sha256:abc123" {
+		t.Errorf("Programs[0].Hash = %q", sp.Programs[0].Hash)
+	}
+	if len(sp.ArgvPatterns) != 1 || sp.ArgvPatterns[0] != "git log --since={since}" {
+		t.Errorf("ArgvPatterns = %v", sp.ArgvPatterns)
+	}
+	if len(sp.EnvPassthrough) != 1 || sp.EnvPassthrough[0] != "GIT_AUTHOR_NAME" {
+		t.Errorf("EnvPassthrough = %v", sp.EnvPassthrough)
+	}
+	if sp.Cwd != "~/code/" {
+		t.Errorf("Cwd = %q", sp.Cwd)
+	}
+	if err := ValidateManifest(m, "x.toml"); err != nil {
+		t.Errorf("ValidateManifest after Parse: %v", err)
+	}
+}
+
+func TestParseManifest_SpawnRoundTrip(t *testing.T) {
+	// Round-trip property: a manifest with [capabilities.spawn] parses,
+	// validates, then re-encodes to TOML that parses back identically.
+	// Mirrors the parse/validate property expected of every capability
+	// block per issue #509's acceptance criterion.
+	body := []byte(`[connector]
+name = "github://acme/gitcrawl"
+version = "1.0.0"
+
+[capabilities.spawn]
+argv_patterns = ["git status", "git log --since={since}"]
+env_passthrough = ["GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL"]
+fs_read = ["~/code/", "~/.gitconfig"]
+fs_write = ["~/.cache/aileron/gitcrawl/"]
+
+[[capabilities.spawn.programs]]
+path = "/usr/bin/git"
+hash = "sha256:bd6e"
+`)
+	m1, err := ParseManifest("a.toml", body)
+	if err != nil {
+		t.Fatalf("first parse: %v", err)
+	}
+	if err := ValidateManifest(m1, "a.toml"); err != nil {
+		t.Fatalf("first validate: %v", err)
+	}
+	var buf strings.Builder
+	enc := toml.NewEncoder(&buf)
+	if err := enc.Encode(m1); err != nil {
+		t.Fatalf("encode: %v", err)
+	}
+	m2, err := ParseManifest("b.toml", []byte(buf.String()))
+	if err != nil {
+		t.Fatalf("second parse: %v\nencoded:\n%s", err, buf.String())
+	}
+	if err := ValidateManifest(m2, "b.toml"); err != nil {
+		t.Fatalf("second validate: %v", err)
+	}
+	if !spawnEqual(m1.Capabilities.Spawn, m2.Capabilities.Spawn) {
+		t.Errorf("round-trip diverged:\n  before: %+v\n  after:  %+v",
+			m1.Capabilities.Spawn, m2.Capabilities.Spawn)
+	}
+}
+
+func spawnEqual(a, b *ManifestSpawn) bool {
+	if a == nil || b == nil {
+		return a == b
+	}
+	if len(a.Programs) != len(b.Programs) {
+		return false
+	}
+	for i := range a.Programs {
+		if a.Programs[i] != b.Programs[i] {
+			return false
+		}
+	}
+	return stringSliceEqual(a.ArgvPatterns, b.ArgvPatterns) &&
+		stringSliceEqual(a.EnvPassthrough, b.EnvPassthrough) &&
+		stringSliceEqual(a.FSRead, b.FSRead) &&
+		stringSliceEqual(a.FSWrite, b.FSWrite) &&
+		a.Cwd == b.Cwd
+}
+
+func stringSliceEqual(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}
+
+func TestIsAbsoluteOrTildePath(t *testing.T) {
+	cases := map[string]bool{
+		"/usr/bin/git":         true,
+		"/":                    true,
+		"~":                    true,
+		"~/code":               true,
+		"~/code/":              true,
+		"":                     false,
+		"git":                  false,
+		"./bin/git":            false,
+		"../bin/git":           false,
+		`C:\Program Files\git`: false,
+		"~user/code":           false,
+	}
+	for p, want := range cases {
+		if got := isAbsoluteOrTildePath(p); got != want {
+			t.Errorf("isAbsoluteOrTildePath(%q) = %v, want %v", p, got, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Implements the manifest-side of the spawn primitive (#507's ADR amendment). Adds the `ManifestSpawn` struct, the `Spawn` field on `ManifestCapabilities`, and `validateSpawn` covering every field documented in ADR-0002's spawn-primitive section.

Validation rules:
- `programs` list is required (non-empty).
- Program `path` must be absolute or `~/`-anchored.
- Program `hash` (when set) must use the `sha256:` prefix.
- `argv_patterns` is required and each pattern must be non-empty.
- `env_passthrough` keys must match the POSIX env-name shape (`[A-Za-z_][A-Za-z0-9_]*`).
- `fs_read`, `fs_write`, and `cwd` (when set) must be absolute or `~/`-anchored.

The `[capabilities.spawn]` block is optional. Connectors that do not spawn anything simply omit it. Round-trip parse/validate/encode/parse property test in place.

## Closes

- Closes #509

## Test plan

- [x] `go test ./internal/cstore/...` passes with new tests.
- [x] `go tool cover -func` shows 100% coverage on `validateSpawn` and `isAbsoluteOrTildePath`.
- [x] Overall package coverage: 86.8% (above 80% bar).
- [x] `task lint:go` clean.
- [ ] Reviewer reads the `[capabilities.spawn]` example in `TestParseManifest_AcceptsSpawnTOML` to confirm the TOML shape matches the ADR.

## Notes

- Depends conceptually on #507 / #508 (PR #587) for the ADR design. Lands code only; the design is already PR'd.
- No changes to existing connector manifests. The block is purely additive.
- Sandbox enforcement (the runtime side) comes in the next PR for #510.

🤖 Generated with [Claude Code](https://claude.com/claude-code)