### PR TITLE
feat(sandbox): aileron_host.spawn host function and SpawnPolicy gate

### DIFF
--- a/internal/sandbox/host.go
+++ b/internal/sandbox/host.go
@@ -67,11 +67,34 @@ type hostState struct {
 	// `binding_required` if the connector tries to use the path.
 	credentialResolver credential.Resolver
 
-	mu        sync.Mutex
-	logs      []LogLine
-	response  []byte
-	respCode  int
-	respErr   *Error // sticky: set when http_request itself was denied or failed
+	// spawnPolicy is the connector manifest's [capabilities.spawn]
+	// declaration in enforced form (per ADR-0002 spawn primitive,
+	// ADR-0014 sandbox tech). Nil when the connector did not declare
+	// spawn — every spawn host-function call then refuses with
+	// capability_denied.
+	spawnPolicy *SpawnPolicy
+
+	// spawnExecutor is the platform-specific subprocess executor.
+	// Defaults to defaultSpawnExecutor when the runtime was built
+	// without WithSpawnExecutor; tests inject fakes.
+	spawnExecutor SpawnExecutor
+
+	// actionSpawnGrant is the action manifest's declared subset of
+	// programs the connector may spawn. Empty means the action did
+	// not narrow the connector's grant. Non-empty entries act as the
+	// second-line gate alongside the connector manifest's policy.
+	actionSpawnGrant map[string]struct{}
+
+	mu             sync.Mutex
+	logs           []LogLine
+	response       []byte
+	respCode       int
+	respErr        *Error // sticky: set when http_request itself was denied or failed
+	spawnExitCode  int
+	spawnStdout    []byte
+	spawnStderr    []byte
+	spawnErr       *Error // sticky: set when spawn was denied or failed
+	spawnHasResult bool
 }
 
 // hostStateKey is the context key used to thread per-invocation state

--- a/internal/sandbox/sandbox.go
+++ b/internal/sandbox/sandbox.go
@@ -89,6 +89,14 @@ type Call struct {
 	Limits             Limits
 	AllowedAuthority   []string
 	CredentialResolver credential.Resolver
+
+	// AllowedSpawnPrograms is the action manifest's declared subset of
+	// programs the connector may invoke via aileron_host.spawn. Each
+	// entry is an absolute (or ~/-anchored) program path matching the
+	// connector manifest's [capabilities.spawn].programs declaration.
+	// Empty means the action did not narrow the connector's grant; the
+	// connector manifest's policy is the only spawn gate.
+	AllowedSpawnPrograms []string
 }
 
 // Result is what the sandbox produced. Successful runs surface their

--- a/internal/sandbox/spawn.go
+++ b/internal/sandbox/spawn.go
@@ -1,0 +1,858 @@
+package sandbox
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"log/slog"
+	"os"
+	"os/exec"
+	"strings"
+	"sync"
+
+	"github.com/tetratelabs/wazero/api"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/credential"
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+// SpawnPolicy enforces a connector manifest's `[capabilities.spawn]`
+// declaration (per ADR-0002 spawn primitive, ADR-0014 sandbox tech).
+// Built once per connector and consulted on every spawn host-function
+// call before any process is created.
+//
+// SpawnPolicy is the gate; the platform sandbox in `spawnExecutor` is
+// the second-line enforcement. Both must agree for a call to proceed.
+type SpawnPolicy struct {
+	// programs maps an absolute program path to its declared optional
+	// content hash. An empty hash means "any bytes at this path are
+	// allowed"; a non-empty hash pins exact bytes.
+	programs map[string]string
+	// argvPatterns is the parsed allow-list of argv shapes. An incoming
+	// argv must match at least one pattern after placeholder substitution.
+	argvPatterns []argvPattern
+	// envAllowed is the closed set of environment keys the runtime is
+	// permitted to set on the subprocess. The connector cannot pass any
+	// other key.
+	envAllowed map[string]struct{}
+	// fsRead and fsWrite are the declared filesystem scopes the
+	// platform sandbox is expected to enforce. The gate rejects
+	// envelopes whose cwd falls outside fsRead.
+	fsRead  []string
+	fsWrite []string
+	// cwd is the optional manifest-declared cwd policy. When set, an
+	// envelope's cwd must match (or be empty, in which case the
+	// runtime substitutes this value).
+	cwd string
+}
+
+// NewSpawnPolicy builds a SpawnPolicy from a connector manifest. A nil
+// or absent `[capabilities.spawn]` block produces a deny-all policy:
+// the connector did not declare spawn and may not invoke a subprocess.
+func NewSpawnPolicy(m *cstore.Manifest) *SpawnPolicy {
+	p := &SpawnPolicy{
+		programs:   map[string]string{},
+		envAllowed: map[string]struct{}{},
+	}
+	if m == nil || m.Capabilities.Spawn == nil {
+		return p
+	}
+	s := m.Capabilities.Spawn
+	for _, prog := range s.Programs {
+		p.programs[prog.Path] = prog.Hash
+	}
+	for _, pat := range s.ArgvPatterns {
+		p.argvPatterns = append(p.argvPatterns, parseArgvPattern(pat))
+	}
+	for _, k := range s.EnvPassthrough {
+		p.envAllowed[k] = struct{}{}
+	}
+	p.fsRead = append(p.fsRead, s.FSRead...)
+	p.fsWrite = append(p.fsWrite, s.FSWrite...)
+	p.cwd = s.Cwd
+	return p
+}
+
+// SpawnEnvelope is the JSON shape connectors marshal as input to
+// `aileron_host.spawn`. Designed to be ergonomic across language ABIs;
+// the runtime parses it host-side.
+//
+// Fields:
+//
+//   - Program: absolute path or ~/-anchored path of the binary to invoke.
+//   - Argv: the full argument vector starting with argv[0]. The runtime
+//     compares the argv (after placeholder elision) against the
+//     manifest's argv_patterns.
+//   - Env: the environment to set on the subprocess. Each key must be
+//     in the manifest's env_passthrough; values are caller-supplied
+//     except for keys in CredentialEnvKeys, which the runtime
+//     resolves and injects.
+//   - Cwd: optional working directory. Must match the manifest's cwd
+//     (when set) and lie within fs_read.
+//   - Stdin: optional bytes piped to the subprocess on stdin.
+//   - CredentialEnvKeys: optional list of env keys whose values the
+//     runtime should resolve from the connector's bound credential and
+//     inject. The connector never holds the credential bytes.
+type SpawnEnvelope struct {
+	Program           string            `json:"program"`
+	Argv              []string          `json:"argv"`
+	Env               map[string]string `json:"env,omitempty"`
+	Cwd               string            `json:"cwd,omitempty"`
+	Stdin             string            `json:"stdin,omitempty"`
+	CredentialEnvKeys []string          `json:"credential_env_keys,omitempty"`
+}
+
+// SpawnResult is the captured outcome of a single subprocess invocation
+// returned to the connector through the host-function read path.
+type SpawnResult struct {
+	ExitCode int
+	Stdout   []byte
+	Stderr   []byte
+}
+
+// argvPattern is a tokenized argv pattern with `{name}` placeholders.
+// A pattern matches an incoming argv when the lengths agree and each
+// token matches.
+//
+// A pattern token is a sequence of literal and placeholder segments.
+// `--since={since}` parses to two segments: literal `--since=` then a
+// placeholder. A whole-token placeholder `{name}` is a single
+// placeholder segment. Matching is greedy from left to right; literal
+// segments anchor the placeholder bounds.
+type argvPattern struct {
+	tokens [][]argvSegment
+}
+
+type argvSegment struct {
+	literal       string
+	isPlaceholder bool
+}
+
+// parseArgvPattern tokenizes a manifest argv pattern. Tokens are
+// whitespace-separated. Each token is split on `{name}` placeholders;
+// the resulting segments alternate literal / placeholder.
+func parseArgvPattern(pat string) argvPattern {
+	fields := strings.Fields(pat)
+	out := argvPattern{tokens: make([][]argvSegment, 0, len(fields))}
+	for _, f := range fields {
+		out.tokens = append(out.tokens, splitTokenSegments(f))
+	}
+	return out
+}
+
+// splitTokenSegments breaks `tok` on each `{name}` placeholder. The
+// returned slice alternates literal / placeholder segments. Empty
+// literal segments are preserved so adjacent placeholders work.
+func splitTokenSegments(tok string) []argvSegment {
+	var out []argvSegment
+	for {
+		open := strings.Index(tok, "{")
+		if open < 0 {
+			if tok != "" {
+				out = append(out, argvSegment{literal: tok})
+			}
+			return out
+		}
+		close := strings.Index(tok[open:], "}")
+		if close < 0 {
+			// Unmatched `{` is treated as a literal.
+			out = append(out, argvSegment{literal: tok})
+			return out
+		}
+		close += open
+		if close == open+1 {
+			// `{}` is meaningless; treat as literal.
+			out = append(out, argvSegment{literal: tok[:close+1]})
+			tok = tok[close+1:]
+			continue
+		}
+		if open > 0 {
+			out = append(out, argvSegment{literal: tok[:open]})
+		}
+		out = append(out, argvSegment{isPlaceholder: true})
+		tok = tok[close+1:]
+	}
+}
+
+// matches reports whether `argv` matches this pattern. Token count
+// must agree exactly; each token's segments must consume its argv
+// element.
+func (p argvPattern) matches(argv []string) bool {
+	if len(argv) != len(p.tokens) {
+		return false
+	}
+	for i, segs := range p.tokens {
+		if !segmentsMatch(segs, argv[i]) {
+			return false
+		}
+	}
+	return true
+}
+
+// segmentsMatch reports whether `segs` consumes `s` end-to-end. The
+// algorithm walks segments left-to-right; literal segments must
+// appear at the current cursor (or, when preceded by a placeholder,
+// anywhere ahead and the placeholder consumes the gap).
+func segmentsMatch(segs []argvSegment, s string) bool {
+	if len(segs) == 0 {
+		return s == ""
+	}
+	cursor := 0
+	pendingPlaceholder := false
+	for i, seg := range segs {
+		if seg.isPlaceholder {
+			pendingPlaceholder = true
+			continue
+		}
+		// Literal segment.
+		if pendingPlaceholder {
+			idx := strings.Index(s[cursor:], seg.literal)
+			if idx < 0 {
+				return false
+			}
+			cursor += idx + len(seg.literal)
+			pendingPlaceholder = false
+			continue
+		}
+		// No placeholder pending: literal must match at cursor.
+		if !strings.HasPrefix(s[cursor:], seg.literal) {
+			return false
+		}
+		cursor += len(seg.literal)
+		_ = i
+	}
+	if pendingPlaceholder {
+		// Trailing placeholder consumes the remainder. Empty
+		// remainder is also acceptable when the placeholder name is
+		// non-empty (matches an empty interpolated arg).
+		return true
+	}
+	return cursor == len(s)
+}
+
+// CheckSpawn validates an incoming SpawnEnvelope against the connector
+// manifest's [capabilities.spawn] declaration. Returns a structured
+// *Error of class capability_denied (boundary=sandbox) when the
+// envelope falls outside the grant.
+//
+// The check is the first gate; the action-boundary subset (when
+// supplied) and the platform sandbox apply additional enforcement.
+// Mirrors HostPolicy.CheckURL's role for network capabilities.
+func (p *SpawnPolicy) CheckSpawn(env SpawnEnvelope) error {
+	if p == nil || len(p.programs) == 0 {
+		return newCapabilityDenied(
+			"spawn: connector did not declare [capabilities.spawn]",
+			map[string]any{
+				"requested":       "spawn:" + env.Program,
+				"boundary_detail": "connector_manifest",
+			})
+	}
+	if env.Program == "" {
+		return newCapabilityDenied("spawn: program is required",
+			map[string]any{"boundary_detail": "envelope"})
+	}
+	if _, ok := p.programs[env.Program]; !ok {
+		granted := make([]string, 0, len(p.programs))
+		for path := range p.programs {
+			granted = append(granted, path)
+		}
+		return newCapabilityDenied(
+			"spawn: program not in declared grant",
+			map[string]any{
+				"requested":       "spawn:" + env.Program,
+				"granted":         prefixed(granted, "spawn:"),
+				"boundary_detail": "connector_manifest",
+			})
+	}
+	if len(env.Argv) == 0 {
+		return newCapabilityDenied("spawn: argv is required",
+			map[string]any{"boundary_detail": "envelope"})
+	}
+	if !p.argvMatches(env.Argv) {
+		return newCapabilityDenied(
+			"spawn: argv does not match any declared pattern",
+			map[string]any{
+				"requested":       env.Argv,
+				"boundary_detail": "connector_manifest",
+			})
+	}
+	for k := range env.Env {
+		if _, ok := p.envAllowed[k]; !ok {
+			return newCapabilityDenied(
+				"spawn: env key not in declared passthrough",
+				map[string]any{
+					"requested":       "env:" + k,
+					"boundary_detail": "connector_manifest",
+				})
+		}
+	}
+	for _, k := range env.CredentialEnvKeys {
+		if _, ok := p.envAllowed[k]; !ok {
+			return newCapabilityDenied(
+				"spawn: credential env key not in declared passthrough",
+				map[string]any{
+					"requested":       "env:" + k,
+					"boundary_detail": "connector_manifest",
+				})
+		}
+	}
+	if env.Cwd != "" {
+		if p.cwd != "" && env.Cwd != p.cwd {
+			return newCapabilityDenied(
+				"spawn: cwd does not match declared policy",
+				map[string]any{
+					"requested":       env.Cwd,
+					"declared":        p.cwd,
+					"boundary_detail": "connector_manifest",
+				})
+		}
+		if !p.cwdWithinReadScope(env.Cwd) {
+			return newCapabilityDenied(
+				"spawn: cwd is outside declared fs_read",
+				map[string]any{
+					"requested":       env.Cwd,
+					"boundary_detail": "connector_manifest",
+				})
+		}
+	}
+	return nil
+}
+
+// argvMatches reports whether at least one declared argv pattern
+// accepts the incoming argv.
+func (p *SpawnPolicy) argvMatches(argv []string) bool {
+	for _, pat := range p.argvPatterns {
+		if pat.matches(argv) {
+			return true
+		}
+	}
+	return false
+}
+
+// cwdWithinReadScope reports whether `cwd` falls under any declared
+// fs_read scope. A scope of `~/code/` covers `~/code/aileron`; a scope
+// of `/var/spool/` covers `/var/spool/jobs`.
+func (p *SpawnPolicy) cwdWithinReadScope(cwd string) bool {
+	if len(p.fsRead) == 0 {
+		// No FS read scope declared; cwd cannot be outside what isn't
+		// declared, so accept.
+		return true
+	}
+	for _, scope := range p.fsRead {
+		if pathWithin(cwd, scope) {
+			return true
+		}
+	}
+	return false
+}
+
+// pathWithin reports whether `p` is the same as `scope` or lives under
+// it. Comparison is string-based on the manifest's declared form.
+// Trailing slash on `scope` is normalized so `~/code` and `~/code/`
+// are equivalent prefixes.
+func pathWithin(p, scope string) bool {
+	scope = strings.TrimRight(scope, "/")
+	if p == scope {
+		return true
+	}
+	return strings.HasPrefix(p, scope+"/")
+}
+
+// SpawnExecutor is the narrow surface the host functions use to
+// actually invoke a subprocess. Tests substitute fakes; the production
+// implementation forks an os/exec.Cmd with the platform's sandbox
+// applied (per ADR-0014).
+//
+// The executor is invoked only after CheckSpawn has approved. It is
+// responsible for the second-line enforcement (FS scoping, network
+// denial, process scoping) on the platforms it supports. On
+// unsupported platforms it returns ErrSpawnUnavailable so the host
+// function emits a structured spawn_sandbox_unavailable error.
+type SpawnExecutor interface {
+	Spawn(ctx context.Context, env SpawnEnvelope) (SpawnResult, error)
+}
+
+// ErrSpawnUnavailable is returned by SpawnExecutor.Spawn when the
+// running platform does not support the spawn primitive's enforcement
+// requirements. The host function translates this into a structured
+// spawn_sandbox_unavailable error class.
+var ErrSpawnUnavailable = errors.New("spawn: sandbox unavailable on this platform")
+
+// defaultSpawnExecutor is the production executor. It builds an
+// os/exec.Cmd with a bounded env, the manifest's cwd, and applies the
+// platform-specific sandbox in applyPlatformSandbox (build-tagged per
+// OS). Network denial is the platform sandbox's responsibility; the
+// executor's structural floor is the bounded env and cwd.
+type defaultSpawnExecutor struct{}
+
+// Spawn implements SpawnExecutor.
+func (defaultSpawnExecutor) Spawn(ctx context.Context, env SpawnEnvelope) (SpawnResult, error) {
+	if len(env.Argv) == 0 {
+		return SpawnResult{}, fmt.Errorf("spawn: empty argv")
+	}
+	cmd := exec.CommandContext(ctx, env.Program, env.Argv[1:]...)
+	cmd.Env = make([]string, 0, len(env.Env))
+	for k, v := range env.Env {
+		cmd.Env = append(cmd.Env, k+"="+v)
+	}
+	if env.Cwd != "" {
+		expanded, err := expandTilde(env.Cwd)
+		if err != nil {
+			return SpawnResult{}, fmt.Errorf("spawn: expand cwd: %w", err)
+		}
+		cmd.Dir = expanded
+	}
+	if env.Stdin != "" {
+		cmd.Stdin = strings.NewReader(env.Stdin)
+	}
+	if err := applyPlatformSandbox(cmd, env); err != nil {
+		return SpawnResult{}, err
+	}
+	stdout, stderr, runErr := runCaptured(cmd)
+	exitCode := 0
+	if runErr != nil {
+		var exitErr *exec.ExitError
+		if errors.As(runErr, &exitErr) {
+			exitCode = exitErr.ExitCode()
+		} else {
+			return SpawnResult{
+				ExitCode: -1,
+				Stdout:   stdout,
+				Stderr:   stderr,
+			}, runErr
+		}
+	}
+	return SpawnResult{
+		ExitCode: exitCode,
+		Stdout:   stdout,
+		Stderr:   stderr,
+	}, nil
+}
+
+// runCaptured runs `cmd` with stdout and stderr captured into separate
+// byte buffers. Returns the captured bytes plus any non-Exit error.
+func runCaptured(cmd *exec.Cmd) ([]byte, []byte, error) {
+	var stdout, stderr captureBuf
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	err := cmd.Run()
+	return stdout.Bytes(), stderr.Bytes(), err
+}
+
+// captureBuf is a minimal io.Writer with a thread-safe Bytes accessor.
+// os/exec writes from a goroutine in CommandContext; the buffer's
+// pointer is only read after Wait returns, but we still synchronize to
+// satisfy the race detector.
+type captureBuf struct {
+	mu  sync.Mutex
+	buf []byte
+}
+
+func (c *captureBuf) Write(p []byte) (int, error) {
+	c.mu.Lock()
+	c.buf = append(c.buf, p...)
+	c.mu.Unlock()
+	return len(p), nil
+}
+
+func (c *captureBuf) Bytes() []byte {
+	c.mu.Lock()
+	defer c.mu.Unlock()
+	out := make([]byte, len(c.buf))
+	copy(out, c.buf)
+	return out
+}
+
+// expandTilde resolves a leading `~/` or bare `~` against the user's
+// home directory. Absolute paths are returned unchanged.
+func expandTilde(p string) (string, error) {
+	if p == "~" || strings.HasPrefix(p, "~/") {
+		home, err := os.UserHomeDir()
+		if err != nil {
+			return "", err
+		}
+		if p == "~" {
+			return home, nil
+		}
+		return home + p[1:], nil
+	}
+	return p, nil
+}
+
+// hostSpawn implements `aileron_host.spawn(req_ptr, req_len) -> i32`.
+//
+// Returns:
+//
+//	 0  on success (output captured into per-invocation state)
+//	-1  on capability_denied or platform-sandbox refusal
+//	-2  on a malformed envelope
+//	-3  on spawn_sandbox_unavailable
+//
+// On any non-zero return, a structured *Error is stuck on
+// state.spawnErr so [Connector.Invoke] surfaces it instead of the
+// generic connector_runtime_error path.
+func hostSpawn(ctx context.Context, mod api.Module, reqPtr, reqLen uint32) int32 {
+	s := stateFromCtx(ctx)
+	if s == nil {
+		return -1
+	}
+	raw := readMemory(mod, reqPtr, reqLen)
+	if raw == nil {
+		s.mu.Lock()
+		s.spawnErr = newConnectorRuntimeError("spawn: invalid memory range")
+		s.mu.Unlock()
+		return -2
+	}
+	return processSpawn(ctx, s, raw)
+}
+
+// processSpawn is the memory-independent core of hostSpawn: it parses
+// the envelope, runs the gates, hands to the executor, captures
+// output, and emits audit. Exposed for tests so we can exercise the
+// gate and the host-function plumbing without going through wazero
+// linear memory.
+func processSpawn(ctx context.Context, s *hostState, raw []byte) int32 {
+	var env SpawnEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		s.mu.Lock()
+		s.spawnErr = newConnectorRuntimeError(fmt.Sprintf("spawn: invalid JSON envelope: %s", err.Error()))
+		s.mu.Unlock()
+		return -2
+	}
+	if s.spawnPolicy == nil {
+		s.mu.Lock()
+		s.spawnErr = newCapabilityDenied(
+			"spawn: connector did not declare [capabilities.spawn]",
+			map[string]any{
+				"requested":       "spawn:" + env.Program,
+				"connector":       s.connectorFQN,
+				"boundary_detail": "connector_manifest",
+			})
+		s.mu.Unlock()
+		emitSpawnAudit(ctx, s, env, "deny", -1, nil, nil, "capability_denied")
+		return -1
+	}
+
+	// First gate: connector manifest.
+	if err := s.spawnPolicy.CheckSpawn(env); err != nil {
+		s.mu.Lock()
+		s.spawnErr = err.(*Error)
+		s.mu.Unlock()
+		emitSpawnAudit(ctx, s, env, "deny", -1, nil, nil, "capability_denied")
+		return -1
+	}
+
+	// Second gate: action-boundary subset. The action declares which
+	// programs it allows the connector to spawn. When AllowedSpawnPrograms
+	// is non-empty, env.Program must appear in that subset; empty means
+	// the action did not narrow the connector's grant and the manifest
+	// gate above is the only check.
+	if len(s.actionSpawnGrant) > 0 {
+		if _, ok := s.actionSpawnGrant[env.Program]; !ok {
+			granted := make([]string, 0, len(s.actionSpawnGrant))
+			for k := range s.actionSpawnGrant {
+				granted = append(granted, k)
+			}
+			s.mu.Lock()
+			s.spawnErr = &Error{
+				Class:    ClassCapabilityDenied,
+				Boundary: BoundarySandbox,
+				Message:  "spawn: program not in action's declared capability subset",
+				Details: map[string]any{
+					"requested":       "spawn:" + env.Program,
+					"action_subset":   prefixed(granted, "spawn:"),
+					"boundary_detail": "action",
+				},
+			}
+			s.mu.Unlock()
+			emitSpawnAudit(ctx, s, env, "deny", -1, nil, nil, "capability_denied")
+			return -1
+		}
+	}
+
+	// Credential injection: never expose vault bytes to the connector.
+	if len(env.CredentialEnvKeys) > 0 {
+		injected, denyErr := injectSpawnCredentials(ctx, s, env)
+		if denyErr != nil {
+			s.mu.Lock()
+			s.spawnErr = denyErr
+			s.mu.Unlock()
+			emitSpawnAudit(ctx, s, env, "deny", -1, nil, nil, string(denyErr.Class))
+			return -1
+		}
+		if env.Env == nil {
+			env.Env = map[string]string{}
+		}
+		for k, v := range injected {
+			env.Env[k] = v
+		}
+	}
+
+	// Hand to the platform executor. Sandbox unavailability is
+	// translated into a distinct error class so operators can tell
+	// "rules were broken" from "platform cannot enforce rules".
+	executor := s.spawnExecutor
+	if executor == nil {
+		executor = defaultSpawnExecutor{}
+	}
+	res, runErr := executor.Spawn(ctx, env)
+	if runErr != nil {
+		if errors.Is(runErr, ErrSpawnUnavailable) {
+			s.mu.Lock()
+			s.spawnErr = newSpawnSandboxUnavailable(env.Program, runErr.Error())
+			s.mu.Unlock()
+			emitSpawnAudit(ctx, s, env, "deny", -1, nil, nil, "spawn_sandbox_unavailable")
+			return -3
+		}
+		s.mu.Lock()
+		s.spawnErr = newConnectorRuntimeError(fmt.Sprintf("spawn: %s", runErr.Error()))
+		s.mu.Unlock()
+		emitSpawnAudit(ctx, s, env, "error", res.ExitCode, res.Stdout, res.Stderr, "connector_runtime_error")
+		return -1
+	}
+
+	s.mu.Lock()
+	s.spawnExitCode = res.ExitCode
+	s.spawnStdout = res.Stdout
+	s.spawnStderr = res.Stderr
+	s.spawnErr = nil
+	s.spawnHasResult = true
+	s.mu.Unlock()
+	emitSpawnAudit(ctx, s, env, "allow", res.ExitCode, res.Stdout, res.Stderr, "")
+	return 0
+}
+
+// hostSpawnStatus implements `aileron_host.spawn_status() -> i32`.
+// Returns the most recent subprocess's exit code; -2 when no spawn
+// has been invoked yet on this connector instance. Real exit codes
+// (including negative ones from signal-killed processes) are not
+// confused with -2 because the connector must call spawn before
+// status, and a successful spawn sets spawnHasResult.
+func hostSpawnStatus(ctx context.Context) int32 {
+	s := stateFromCtx(ctx)
+	if s == nil {
+		return -1
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	if !s.spawnHasResult {
+		return -2
+	}
+	return int32(s.spawnExitCode)
+}
+
+// hostSpawnOutputSize implements
+// `aileron_host.spawn_output_size(which) -> i32`. `which`=0 reports
+// stdout size; `which`=1 reports stderr size. Returns -1 when no
+// subprocess output is buffered.
+func hostSpawnOutputSize(ctx context.Context, which uint32) int32 {
+	s := stateFromCtx(ctx)
+	if s == nil {
+		return -1
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	switch which {
+	case 0:
+		if s.spawnStdout == nil {
+			return -1
+		}
+		return int32(len(s.spawnStdout))
+	case 1:
+		if s.spawnStderr == nil {
+			return -1
+		}
+		return int32(len(s.spawnStderr))
+	default:
+		return -1
+	}
+}
+
+// hostSpawnOutputRead implements
+// `aileron_host.spawn_output_read(which, dst_ptr, dst_len) -> i32`.
+// Copies up to `dstLen` bytes of the named output (0=stdout, 1=stderr)
+// into module memory at `dstPtr`. Returns the number of bytes written;
+// -1 when no output is buffered or the destination range is invalid.
+func hostSpawnOutputRead(ctx context.Context, mod api.Module, which, dstPtr, dstLen uint32) int32 {
+	s := stateFromCtx(ctx)
+	if s == nil {
+		return -1
+	}
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	var src []byte
+	switch which {
+	case 0:
+		src = s.spawnStdout
+	case 1:
+		src = s.spawnStderr
+	default:
+		return -1
+	}
+	if src == nil {
+		return -1
+	}
+	n := uint32(len(src))
+	if n > dstLen {
+		n = dstLen
+	}
+	if n == 0 {
+		return 0
+	}
+	wrote := writeMemory(mod, dstPtr, src[:n])
+	if wrote == 0 {
+		return -1
+	}
+	return int32(wrote)
+}
+
+// injectSpawnCredentials resolves the connector's bound credential and
+// returns the env values to set for each requested credential env key.
+// Mirrors injectCredential's role for HTTP requests, with two
+// differences:
+//
+//  1. The credential is delivered as an environment variable on the
+//     subprocess rather than an HTTP Authorization header.
+//  2. Each entry in env.CredentialEnvKeys gets the same credential
+//     value; the connector composes which env key the subprocess
+//     expects (e.g. `GH_TOKEN` for the gh CLI, `SLACK_TOKEN` for
+//     slackdump).
+//
+// The credential bytes never leave this function except as the env
+// value the runtime sets on the os/exec.Cmd. The connector never
+// observes them.
+func injectSpawnCredentials(ctx context.Context, s *hostState, env SpawnEnvelope) (map[string]string, *Error) {
+	if s.expectedCredentialKind == "" {
+		return nil, newCapabilityDenied(
+			"spawn: connector did not declare [capabilities.credential]",
+			map[string]any{
+				"requested":       "credential_env",
+				"connector":       s.connectorFQN,
+				"boundary_detail": "connector_manifest",
+			})
+	}
+	if s.credentialResolver == nil {
+		return nil, newBindingRequired(
+			fmt.Sprintf(
+				"spawn: no credential binding found for connector %s (kind: %s); run `aileron binding setup %s` to create one",
+				s.connectorFQN, s.expectedCredentialKind, s.connectorFQN),
+			map[string]any{
+				"connector":       s.connectorFQN,
+				"capability_kind": s.expectedCredentialKind,
+				"boundary_detail": "action",
+			})
+	}
+	cred, resolveErr := s.credentialResolver.Resolve(ctx)
+	if resolveErr != nil {
+		switch {
+		case errors.Is(resolveErr, credential.ErrBindingMissing),
+			errors.Is(resolveErr, credential.ErrNoBindingResolver):
+			return nil, newBindingRequired(
+				resolveErr.Error(),
+				map[string]any{
+					"connector":       s.connectorFQN,
+					"capability_kind": s.expectedCredentialKind,
+					"boundary_detail": "action",
+				})
+		case errors.Is(resolveErr, credential.ErrCredentialKindMismatch):
+			return nil, newCapabilityDenied(
+				resolveErr.Error(),
+				map[string]any{
+					"connector":       s.connectorFQN,
+					"capability_kind": s.expectedCredentialKind,
+					"boundary_detail": "vault",
+				})
+		default:
+			return nil, newConnectorRuntimeError(fmt.Sprintf(
+				"spawn: resolve credential: %s", resolveErr.Error()))
+		}
+	}
+	out := make(map[string]string, len(env.CredentialEnvKeys))
+	for _, k := range env.CredentialEnvKeys {
+		out[k] = string(cred.Value)
+	}
+	return out, nil
+}
+
+// newSpawnSandboxUnavailable builds the spawn_sandbox_unavailable
+// error used when the platform cannot enforce the manifest's bounds.
+// Distinct from capability_denied: the rules were not broken by the
+// connector, the platform cannot enforce them. Operators read the
+// reason field to remediate (e.g. enable unprivileged user namespaces
+// on Linux).
+func newSpawnSandboxUnavailable(program, reason string) *Error {
+	return &Error{
+		Class:    "spawn_sandbox_unavailable",
+		Message:  "spawn: sandbox unavailable on this platform",
+		Boundary: BoundarySandbox,
+		Details: map[string]any{
+			"program": program,
+			"reason":  reason,
+		},
+	}
+}
+
+// emitSpawnAudit logs a structured audit event for one spawn
+// invocation. Captures connector identity, program, argv pattern (not
+// interpolated arguments, which may be sensitive), exit code, decision,
+// and content hashes of stdout and stderr.
+//
+// Uses audit.AttrPolicyDecision per the reservation in #480.
+func emitSpawnAudit(ctx context.Context, s *hostState, env SpawnEnvelope, decision string, exit int, stdout, stderr []byte, denyClass string) {
+	if s == nil || s.logger == nil {
+		return
+	}
+	attrs := []slog.Attr{
+		slog.String("connector", s.connectorFQN),
+		slog.String("program", env.Program),
+		slog.String("argv_shape", argvShape(env.Argv)),
+		slog.String(audit.AttrPolicyDecision, decision),
+		slog.Int("exit_code", exit),
+	}
+	if denyClass != "" {
+		attrs = append(attrs, slog.String("deny_class", denyClass))
+	}
+	if len(stdout) > 0 {
+		attrs = append(attrs, slog.String("stdout_sha256", hashHex(stdout)))
+		attrs = append(attrs, slog.Int("stdout_bytes", len(stdout)))
+	}
+	if len(stderr) > 0 {
+		attrs = append(attrs, slog.String("stderr_sha256", hashHex(stderr)))
+		attrs = append(attrs, slog.Int("stderr_bytes", len(stderr)))
+	}
+	s.logger.LogAttrs(ctx, slog.LevelInfo, "spawn", attrs...)
+}
+
+// argvShape produces a shape-only summary of an argv: argv[0] plus a
+// fixed-length tail summary (token count and a hash of the
+// remainder). Avoids leaking interpolated arguments while still giving
+// auditors a stable per-invocation correlation key.
+func argvShape(argv []string) string {
+	if len(argv) == 0 {
+		return ""
+	}
+	if len(argv) == 1 {
+		return argv[0]
+	}
+	rest := strings.Join(argv[1:], " ")
+	return fmt.Sprintf("%s[%d:%s]", argv[0], len(argv)-1, hashHex([]byte(rest))[:16])
+}
+
+// hashHex returns the hex-encoded SHA-256 of `b`.
+func hashHex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}
+
+// WithSpawnExecutor overrides the executor the runtime uses for
+// `aileron_host.spawn`. Defaults to the production
+// defaultSpawnExecutor; tests substitute fake executors to exercise
+// the gate and the host-function plumbing without forking real
+// processes.
+func WithSpawnExecutor(e SpawnExecutor) RuntimeOption {
+	return func(r *WazeroRuntime) { r.spawnExecutor = e }
+}

--- a/internal/sandbox/spawn_sandbox.go
+++ b/internal/sandbox/spawn_sandbox.go
@@ -1,0 +1,29 @@
+package sandbox
+
+import "os/exec"
+
+// applyPlatformSandbox is the per-OS hook that hardens a prepared
+// os/exec.Cmd before Run. Platform-specific implementations (Linux
+// namespaces + Landlock, macOS sandbox-exec, Windows job objects +
+// restricted token) live in build-tagged files.
+//
+// The default v1 implementation in this file is a no-op. The bounded
+// env and cwd that the executor sets on cmd are the structural floor;
+// the platform sandbox layered on top is what enforces filesystem
+// scoping, network denial, and process scoping per ADR-0014. The
+// per-platform tightening is a series of follow-ups that override
+// this default with cmd.SysProcAttr and friends.
+//
+// On platforms that ADR-0014 designates as unsupported (BSD, illumos,
+// any non-Linux/macOS/Windows OS), the platform-specific override
+// returns ErrSpawnUnavailable so hostSpawn translates that into a
+// spawn_sandbox_unavailable error.
+//
+// Unit tests substitute SpawnExecutor wholesale via WithSpawnExecutor
+// so the hook is not in the test path. It is the production runtime's
+// extension point.
+func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope) error {
+	_ = cmd
+	_ = env
+	return nil
+}

--- a/internal/sandbox/spawn_test.go
+++ b/internal/sandbox/spawn_test.go
@@ -1,0 +1,886 @@
+package sandbox
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"log/slog"
+	"os"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/credential"
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+// All gate-side assertions in this file cite the ADR clause they
+// enforce so refactors that preserve the contract leave them green.
+
+// goodSpawnManifest builds a connector manifest with a typical
+// [capabilities.spawn] declaration the gate tests mutate.
+func goodSpawnManifest() *cstore.Manifest {
+	return &cstore.Manifest{
+		Connector: cstore.ManifestConnector{
+			Name:    "github://aileron-test/gitcrawl",
+			Version: "1.0.0",
+		},
+		Capabilities: cstore.ManifestCapabilities{
+			Spawn: &cstore.ManifestSpawn{
+				Programs: []cstore.ManifestSpawnProgram{
+					{Path: "/usr/bin/git"},
+				},
+				ArgvPatterns: []string{
+					"git log --since={since}",
+					"git status",
+				},
+				EnvPassthrough: []string{"GIT_AUTHOR_NAME", "GH_TOKEN"},
+				FSRead:         []string{"~/code/"},
+				FSWrite:        []string{"~/.cache/aileron/gitcrawl/"},
+			},
+		},
+	}
+}
+
+func TestSpawnPolicy_DefaultDenyWhenNoSpawnBlock(t *testing.T) {
+	// ADR-0002 §"Each capability section is enumerable and bounded.
+	// There is no `*` and no implicit grant. A connector that did not
+	// declare network access cannot dial out, period." — applies
+	// equally to spawn.
+	policy := NewSpawnPolicy(&cstore.Manifest{})
+	err := policy.CheckSpawn(SpawnEnvelope{Program: "/usr/bin/git", Argv: []string{"git", "status"}})
+	if err == nil {
+		t.Fatal("expected denial when no spawn block was declared")
+	}
+	var serr *Error
+	if !errors.As(err, &serr) || serr.Class != ClassCapabilityDenied || serr.Boundary != BoundarySandbox {
+		t.Errorf("err = %v; want capability_denied/sandbox", err)
+	}
+}
+
+func TestSpawnPolicy_AllowsDeclaredArgvPattern(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	if err := policy.CheckSpawn(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+	}); err != nil {
+		t.Errorf("matching argv should be allowed: %v", err)
+	}
+	if err := policy.CheckSpawn(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "log", "--since=2026-01-01"},
+	}); err != nil {
+		t.Errorf("placeholder match should be allowed: %v", err)
+	}
+}
+
+func TestSpawnPolicy_DeniesUndeclaredProgram(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	err := policy.CheckSpawn(SpawnEnvelope{
+		Program: "/usr/bin/curl",
+		Argv:    []string{"curl", "https://evil.example.com"},
+	})
+	if err == nil {
+		t.Fatal("expected denial for undeclared program")
+	}
+	var serr *Error
+	if !errors.As(err, &serr) || serr.Class != ClassCapabilityDenied {
+		t.Fatalf("err class = %v, want capability_denied", err)
+	}
+	if got, _ := serr.Details["requested"].(string); got != "spawn:/usr/bin/curl" {
+		t.Errorf("details.requested = %q", got)
+	}
+	granted, _ := serr.Details["granted"].([]string)
+	sort.Strings(granted)
+	if len(granted) != 1 || granted[0] != "spawn:/usr/bin/git" {
+		t.Errorf("details.granted = %v", granted)
+	}
+}
+
+func TestSpawnPolicy_DeniesUndeclaredArgvShape(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	err := policy.CheckSpawn(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "push", "--force"},
+	})
+	if err == nil {
+		t.Fatal("expected denial for argv shape outside grant")
+	}
+	var serr *Error
+	if !errors.As(err, &serr) || serr.Class != ClassCapabilityDenied {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestSpawnPolicy_DeniesUndeclaredEnvKey(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	err := policy.CheckSpawn(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+		Env:     map[string]string{"AWS_SECRET_KEY": "leaked"},
+	})
+	if err == nil {
+		t.Fatal("expected denial for env key not in passthrough")
+	}
+	var serr *Error
+	if !errors.As(err, &serr) || serr.Class != ClassCapabilityDenied {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestSpawnPolicy_AllowsDeclaredEnvKey(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	if err := policy.CheckSpawn(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+		Env:     map[string]string{"GIT_AUTHOR_NAME": "alr"},
+	}); err != nil {
+		t.Errorf("declared env key should be allowed: %v", err)
+	}
+}
+
+func TestSpawnPolicy_DeniesUndeclaredCredentialEnvKey(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	err := policy.CheckSpawn(SpawnEnvelope{
+		Program:           "/usr/bin/git",
+		Argv:              []string{"git", "status"},
+		CredentialEnvKeys: []string{"NOT_DECLARED"},
+	})
+	if err == nil {
+		t.Fatal("expected denial for credential env key outside passthrough")
+	}
+}
+
+func TestSpawnPolicy_DeniesCwdOutsideReadScope(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	err := policy.CheckSpawn(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+		Cwd:     "~/other/path",
+	})
+	if err == nil {
+		t.Fatal("expected denial for cwd outside fs_read")
+	}
+}
+
+func TestSpawnPolicy_DeniesCwdMismatchingDeclaredPolicy(t *testing.T) {
+	m := goodSpawnManifest()
+	m.Capabilities.Spawn.Cwd = "~/code/aileron"
+	policy := NewSpawnPolicy(m)
+	err := policy.CheckSpawn(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+		Cwd:     "~/code/elsewhere",
+	})
+	if err == nil {
+		t.Fatal("expected denial when cwd does not match declared policy")
+	}
+}
+
+func TestSpawnPolicy_AllowsCwdWithinReadScope(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	if err := policy.CheckSpawn(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+		Cwd:     "~/code/aileron",
+	}); err != nil {
+		t.Errorf("cwd within fs_read should be allowed: %v", err)
+	}
+}
+
+func TestSpawnPolicy_RejectsEmptyProgram(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	if err := policy.CheckSpawn(SpawnEnvelope{Argv: []string{"git", "status"}}); err == nil {
+		t.Fatal("expected denial for empty program")
+	}
+}
+
+func TestSpawnPolicy_RejectsEmptyArgv(t *testing.T) {
+	policy := NewSpawnPolicy(goodSpawnManifest())
+	if err := policy.CheckSpawn(SpawnEnvelope{Program: "/usr/bin/git"}); err == nil {
+		t.Fatal("expected denial for empty argv")
+	}
+}
+
+// --- argvPattern matching ---
+
+func TestArgvPattern_LiteralOnly(t *testing.T) {
+	pat := parseArgvPattern("git status")
+	if !pat.matches([]string{"git", "status"}) {
+		t.Error("exact match should succeed")
+	}
+	if pat.matches([]string{"git", "log"}) {
+		t.Error("non-matching literal should be rejected")
+	}
+	if pat.matches([]string{"git"}) {
+		t.Error("length mismatch should be rejected")
+	}
+}
+
+func TestArgvPattern_PlaceholderMatchesAnything(t *testing.T) {
+	pat := parseArgvPattern("git log --since={date} --author={who}")
+	if !pat.matches([]string{"git", "log", "--since=2026-01-01", "--author=alr"}) {
+		t.Error("placeholders should match arbitrary values")
+	}
+}
+
+// --- pathWithin ---
+
+func TestPathWithin(t *testing.T) {
+	cases := []struct {
+		path, scope string
+		want        bool
+	}{
+		{"~/code/aileron", "~/code/", true},
+		{"~/code/aileron", "~/code", true},
+		{"~/code", "~/code/", true},
+		{"~/other", "~/code/", false},
+		{"/var/spool/jobs", "/var/spool", true},
+		{"/var", "/var/spool", false},
+	}
+	for _, tc := range cases {
+		if got := pathWithin(tc.path, tc.scope); got != tc.want {
+			t.Errorf("pathWithin(%q, %q) = %v, want %v", tc.path, tc.scope, got, tc.want)
+		}
+	}
+}
+
+// --- Host-function plumbing tests via fake SpawnExecutor ---
+//
+// The runtime's spawn host functions are registered once at
+// installHostModule time; per-call state is threaded via context.
+// The integration here is the whole flow from a connector calling
+// `aileron_host.spawn` to the captured output coming back through
+// `spawn_output_*`. The end-to-end WASM-fixture test lives in
+// internal/sandbox/wazero_spawn_test.go (added with #512's fixture
+// regen). Here we exercise the host-function plumbing directly with a
+// fake executor.
+
+// fakeExecutor records the envelope it was given and produces a
+// scripted result. Implements SpawnExecutor.
+type fakeExecutor struct {
+	gotEnv SpawnEnvelope
+	result SpawnResult
+	err    error
+}
+
+func (f *fakeExecutor) Spawn(_ context.Context, env SpawnEnvelope) (SpawnResult, error) {
+	f.gotEnv = env
+	return f.result, f.err
+}
+
+// fakeResolver implements credential.Resolver for the credential-injection tests.
+type fakeResolver struct {
+	cred credential.Credential
+	err  error
+}
+
+func (f *fakeResolver) Resolve(_ context.Context) (credential.Credential, error) {
+	return f.cred, f.err
+}
+
+func TestSpawn_HostFunctions_HappyPath(t *testing.T) {
+	fake := &fakeExecutor{result: SpawnResult{ExitCode: 0, Stdout: []byte("hello\n"), Stderr: nil}}
+	state := &hostState{
+		spawnPolicy:   NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor: fake,
+		connectorFQN:  "github://aileron-test/gitcrawl",
+	}
+	ctx := ctxWithState(context.Background(), state)
+
+	envBytes := mustJSON(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc != 0 {
+		t.Fatalf("processSpawn rc = %d (err: %v)", rc, state.spawnErr)
+	}
+	if !state.spawnHasResult {
+		t.Error("spawnHasResult should be true after a successful spawn")
+	}
+	if state.spawnExitCode != 0 {
+		t.Errorf("exit = %d", state.spawnExitCode)
+	}
+	if string(state.spawnStdout) != "hello\n" {
+		t.Errorf("stdout = %q", string(state.spawnStdout))
+	}
+	if !envvarsMatch(fake.gotEnv.Argv, []string{"git", "status"}) {
+		t.Errorf("executor saw argv %v", fake.gotEnv.Argv)
+	}
+}
+
+func TestSpawn_HostFunctions_DenyOnUndeclaredProgram(t *testing.T) {
+	fake := &fakeExecutor{}
+	state := &hostState{
+		spawnPolicy:   NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor: fake,
+		connectorFQN:  "github://aileron-test/gitcrawl",
+	}
+	ctx := ctxWithState(context.Background(), state)
+
+	envBytes := mustJSON(SpawnEnvelope{
+		Program: "/usr/bin/curl",
+		Argv:    []string{"curl", "https://evil.example.com"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc == 0 {
+		t.Fatal("processSpawn should refuse undeclared program")
+	}
+	if state.spawnErr == nil || state.spawnErr.Class != ClassCapabilityDenied {
+		t.Errorf("expected capability_denied, got %v", state.spawnErr)
+	}
+	if fake.gotEnv.Program != "" {
+		t.Error("executor must not run when gate denies")
+	}
+}
+
+func TestSpawn_HostFunctions_RefusesWhenNoManifest(t *testing.T) {
+	state := &hostState{
+		// no spawnPolicy — connector did not declare spawn
+		connectorFQN: "github://aileron-test/gitcrawl",
+	}
+	ctx := ctxWithState(context.Background(), state)
+
+	envBytes := mustJSON(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc == 0 {
+		t.Fatal("processSpawn should refuse when policy is nil")
+	}
+	if state.spawnErr == nil || state.spawnErr.Class != ClassCapabilityDenied {
+		t.Errorf("expected capability_denied, got %v", state.spawnErr)
+	}
+}
+
+func TestSpawn_HostFunctions_ActionBoundarySubsetEnforced(t *testing.T) {
+	state := &hostState{
+		spawnPolicy:      NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor:    &fakeExecutor{result: SpawnResult{}},
+		actionSpawnGrant: map[string]struct{}{"/usr/bin/other": {}},
+		connectorFQN:     "github://aileron-test/gitcrawl",
+	}
+	ctx := ctxWithState(context.Background(), state)
+	envBytes := mustJSON(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc == 0 {
+		t.Fatal("expected denial when program not in action subset")
+	}
+	if state.spawnErr == nil || state.spawnErr.Class != ClassCapabilityDenied {
+		t.Errorf("expected capability_denied, got %v", state.spawnErr)
+	}
+	detail, _ := state.spawnErr.Details["boundary_detail"].(string)
+	if detail != "action" {
+		t.Errorf("boundary_detail = %q, want action", detail)
+	}
+}
+
+func TestSpawn_HostFunctions_SandboxUnavailable(t *testing.T) {
+	fake := &fakeExecutor{err: ErrSpawnUnavailable}
+	state := &hostState{
+		spawnPolicy:   NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor: fake,
+		connectorFQN:  "github://aileron-test/gitcrawl",
+	}
+	ctx := ctxWithState(context.Background(), state)
+	envBytes := mustJSON(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc != -3 {
+		t.Errorf("rc = %d, want -3 (spawn_sandbox_unavailable)", rc)
+	}
+	if state.spawnErr == nil || string(state.spawnErr.Class) != "spawn_sandbox_unavailable" {
+		t.Errorf("err class = %v, want spawn_sandbox_unavailable", state.spawnErr)
+	}
+}
+
+func TestSpawn_HostFunctions_CredentialInjection(t *testing.T) {
+	fake := &fakeExecutor{result: SpawnResult{ExitCode: 0, Stdout: []byte("ok")}}
+	state := &hostState{
+		spawnPolicy:            NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor:          fake,
+		connectorFQN:           "github://aileron-test/gitcrawl",
+		expectedCredentialKind: "api_key",
+		credentialResolver: &fakeResolver{
+			cred: credential.Credential{Kind: "api_key", Value: []byte("ghs_secret123")},
+		},
+	}
+	ctx := ctxWithState(context.Background(), state)
+
+	envBytes := mustJSON(SpawnEnvelope{
+		Program:           "/usr/bin/git",
+		Argv:              []string{"git", "status"},
+		CredentialEnvKeys: []string{"GH_TOKEN"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc != 0 {
+		t.Fatalf("processSpawn rc = %d (err: %v)", rc, state.spawnErr)
+	}
+	got := fake.gotEnv.Env["GH_TOKEN"]
+	if got != "ghs_secret123" {
+		t.Errorf("GH_TOKEN = %q, want injected credential", got)
+	}
+}
+
+func TestSpawn_HostFunctions_CredentialBindingMissing(t *testing.T) {
+	fake := &fakeExecutor{}
+	state := &hostState{
+		spawnPolicy:            NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor:          fake,
+		connectorFQN:           "github://aileron-test/gitcrawl",
+		expectedCredentialKind: "api_key",
+		// no resolver wired
+	}
+	ctx := ctxWithState(context.Background(), state)
+
+	envBytes := mustJSON(SpawnEnvelope{
+		Program:           "/usr/bin/git",
+		Argv:              []string{"git", "status"},
+		CredentialEnvKeys: []string{"GH_TOKEN"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc == 0 {
+		t.Fatal("expected denial when binding is missing")
+	}
+	if state.spawnErr == nil || state.spawnErr.Class != ClassBindingRequired {
+		t.Errorf("expected binding_required, got %v", state.spawnErr)
+	}
+}
+
+func TestSpawnStatus_NoResultReturnsSentinel(t *testing.T) {
+	state := &hostState{}
+	ctx := ctxWithState(context.Background(), state)
+	if got := hostSpawnStatus(ctx); got != -2 {
+		t.Errorf("hostSpawnStatus before spawn = %d, want -2", got)
+	}
+}
+
+func TestSpawnOutputSize_NoResultReturnsMinusOne(t *testing.T) {
+	state := &hostState{}
+	ctx := ctxWithState(context.Background(), state)
+	if got := hostSpawnOutputSize(ctx, 0); got != -1 {
+		t.Errorf("stdout size before spawn = %d, want -1", got)
+	}
+	if got := hostSpawnOutputSize(ctx, 1); got != -1 {
+		t.Errorf("stderr size before spawn = %d, want -1", got)
+	}
+	if got := hostSpawnOutputSize(ctx, 99); got != -1 {
+		t.Errorf("invalid which = %d, want -1", got)
+	}
+}
+
+func TestSpawnExecutor_DefaultRunsRealBinary(t *testing.T) {
+	// The default executor is a thin os/exec wrapper. Hit it once
+	// against a binary that should exist on every supported test
+	// platform: /bin/echo on macOS / Linux. Windows CI substitutes
+	// cmd.exe; this test is gated on POSIX.
+	if !commandExists("/bin/echo") {
+		t.Skip("/bin/echo not present; skipping default executor smoke test")
+	}
+	res, err := defaultSpawnExecutor{}.Spawn(context.Background(), SpawnEnvelope{
+		Program: "/bin/echo",
+		Argv:    []string{"echo", "hello"},
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if res.ExitCode != 0 {
+		t.Errorf("exit = %d", res.ExitCode)
+	}
+	if !strings.Contains(string(res.Stdout), "hello") {
+		t.Errorf("stdout = %q, want to contain 'hello'", string(res.Stdout))
+	}
+}
+
+func TestExpandTilde(t *testing.T) {
+	got, err := expandTilde("~")
+	if err != nil {
+		t.Fatalf("expandTilde(~): %v", err)
+	}
+	if got == "~" {
+		t.Errorf("~ was not expanded: %q", got)
+	}
+	got2, err := expandTilde("~/code")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if !strings.HasSuffix(got2, "/code") {
+		t.Errorf("~/code expansion = %q", got2)
+	}
+	if got3, _ := expandTilde("/abs"); got3 != "/abs" {
+		t.Errorf("absolute path mutated: %q", got3)
+	}
+}
+
+func TestArgvShape_StableForSameInputs(t *testing.T) {
+	a := argvShape([]string{"git", "log", "--since=2026-01-01"})
+	b := argvShape([]string{"git", "log", "--since=2026-01-01"})
+	if a != b {
+		t.Errorf("argvShape not stable: %q vs %q", a, b)
+	}
+	c := argvShape([]string{"git", "log", "--since=2026-02-01"})
+	if a == c {
+		t.Errorf("argvShape should differ when interpolated arg differs")
+	}
+}
+
+// --- helpers ---
+
+func mustJSON(v any) []byte {
+	b, err := json.Marshal(v)
+	if err != nil {
+		panic(err)
+	}
+	return b
+}
+
+// commandExists reports whether the named binary is present on the
+// host's filesystem.
+func commandExists(p string) bool {
+	if p == "" {
+		return false
+	}
+	if _, err := os.Stat(p); err != nil {
+		return false
+	}
+	return true
+}
+
+func TestWithSpawnExecutor_WiresExecutorIntoRuntime(t *testing.T) {
+	fake := &fakeExecutor{result: SpawnResult{ExitCode: 0, Stdout: []byte("from-fake")}}
+	rt, err := NewWazeroRuntime(context.Background(), WithSpawnExecutor(fake))
+	if err != nil {
+		t.Fatalf("NewWazeroRuntime: %v", err)
+	}
+	t.Cleanup(func() { _ = rt.Close(context.Background()) })
+	if rt.spawnExecutor != fake {
+		t.Errorf("spawnExecutor = %v, want our fake", rt.spawnExecutor)
+	}
+}
+
+// recordingHandler is a slog.Handler that records every log Record's
+// attribute map for assertion.
+type recordingHandler struct {
+	records []map[string]any
+}
+
+func (h *recordingHandler) Enabled(_ context.Context, _ slog.Level) bool { return true }
+func (h *recordingHandler) Handle(_ context.Context, r slog.Record) error {
+	rec := map[string]any{"msg": r.Message}
+	r.Attrs(func(a slog.Attr) bool {
+		rec[a.Key] = a.Value.Any()
+		return true
+	})
+	h.records = append(h.records, rec)
+	return nil
+}
+func (h *recordingHandler) WithAttrs(_ []slog.Attr) slog.Handler { return h }
+func (h *recordingHandler) WithGroup(_ string) slog.Handler      { return h }
+
+func TestEmitSpawnAudit_AllowDecisionEmitsExpectedAttributes(t *testing.T) {
+	h := &recordingHandler{}
+	state := &hostState{
+		connectorFQN: "github://aileron-test/gitcrawl",
+		logger:       slog.New(h),
+	}
+	emitSpawnAudit(context.Background(), state,
+		SpawnEnvelope{Program: "/usr/bin/git", Argv: []string{"git", "status"}},
+		"allow", 0, []byte("hello"), nil, "")
+	if len(h.records) != 1 {
+		t.Fatalf("expected one audit record, got %d", len(h.records))
+	}
+	rec := h.records[0]
+	if rec["aileron.policy.decision"] != "allow" {
+		t.Errorf("policy decision = %v", rec["aileron.policy.decision"])
+	}
+	if rec["program"] != "/usr/bin/git" {
+		t.Errorf("program = %v", rec["program"])
+	}
+	if rec["stdout_sha256"] == nil {
+		t.Error("stdout_sha256 missing")
+	}
+	if rec["stderr_sha256"] != nil {
+		t.Error("stderr_sha256 should be absent for empty stderr")
+	}
+}
+
+func TestEmitSpawnAudit_DenyClassPropagated(t *testing.T) {
+	h := &recordingHandler{}
+	state := &hostState{
+		connectorFQN: "github://aileron-test/gitcrawl",
+		logger:       slog.New(h),
+	}
+	emitSpawnAudit(context.Background(), state,
+		SpawnEnvelope{Program: "/usr/bin/git", Argv: []string{"git", "status"}},
+		"deny", -1, nil, []byte("permission denied"), "capability_denied")
+	if len(h.records) != 1 {
+		t.Fatalf("got %d records", len(h.records))
+	}
+	if h.records[0]["deny_class"] != "capability_denied" {
+		t.Errorf("deny_class = %v", h.records[0]["deny_class"])
+	}
+}
+
+func TestSpawnExecutor_DefaultPropagatesNonZeroExit(t *testing.T) {
+	if !commandExists("/usr/bin/false") && !commandExists("/bin/false") {
+		t.Skip("/bin/false not present")
+	}
+	prog := "/usr/bin/false"
+	if !commandExists(prog) {
+		prog = "/bin/false"
+	}
+	res, err := defaultSpawnExecutor{}.Spawn(context.Background(), SpawnEnvelope{
+		Program: prog,
+		Argv:    []string{"false"},
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if res.ExitCode == 0 {
+		t.Error("expected non-zero exit from /bin/false")
+	}
+}
+
+func TestSpawnExecutor_DefaultRejectsEmptyArgv(t *testing.T) {
+	_, err := defaultSpawnExecutor{}.Spawn(context.Background(), SpawnEnvelope{
+		Program: "/bin/echo",
+	})
+	if err == nil {
+		t.Error("expected error on empty argv")
+	}
+}
+
+func TestSpawnExecutor_DefaultRunsWithStdin(t *testing.T) {
+	if !commandExists("/bin/cat") {
+		t.Skip("/bin/cat not present")
+	}
+	res, err := defaultSpawnExecutor{}.Spawn(context.Background(), SpawnEnvelope{
+		Program: "/bin/cat",
+		Argv:    []string{"cat"},
+		Stdin:   "echoed-stdin",
+	})
+	if err != nil {
+		t.Fatalf("Spawn: %v", err)
+	}
+	if string(res.Stdout) != "echoed-stdin" {
+		t.Errorf("stdout = %q, want echoed input", string(res.Stdout))
+	}
+}
+
+func TestSplitTokenSegments_UnmatchedBraceTreatedAsLiteral(t *testing.T) {
+	segs := splitTokenSegments("--since={oops")
+	// Unmatched `{` falls back to a single literal segment.
+	if len(segs) != 1 || segs[0].isPlaceholder || segs[0].literal != "--since={oops" {
+		t.Errorf("segments = %+v", segs)
+	}
+}
+
+func TestSplitTokenSegments_EmptyBracesAreLiteral(t *testing.T) {
+	segs := splitTokenSegments("--{}-x")
+	// `{}` has zero placeholder name; treated as literal in the token.
+	for _, s := range segs {
+		if s.isPlaceholder {
+			t.Errorf("`{}` should not be a placeholder: %+v", segs)
+		}
+	}
+}
+
+func TestSpawn_HostFunctions_NilStateReturnsMinusOne(t *testing.T) {
+	if got := hostSpawnStatus(context.Background()); got != -1 {
+		t.Errorf("hostSpawnStatus(no state) = %d, want -1", got)
+	}
+	if got := hostSpawnOutputSize(context.Background(), 0); got != -1 {
+		t.Errorf("hostSpawnOutputSize(no state) = %d, want -1", got)
+	}
+	if got := hostSpawnOutputRead(context.Background(), nil, 0, 0, 0); got != -1 {
+		t.Errorf("hostSpawnOutputRead(no state) = %d, want -1", got)
+	}
+}
+
+func TestSpawn_HostFunctions_OutputReadWithNoBuffer(t *testing.T) {
+	// State with no spawn result: read should return -1 from each
+	// branch (stdout, stderr, invalid which).
+	state := &hostState{}
+	ctx := ctxWithState(context.Background(), state)
+	if got := hostSpawnOutputRead(ctx, nil, 0, 0, 16); got != -1 {
+		t.Errorf("stdout read with no buffer = %d", got)
+	}
+	if got := hostSpawnOutputRead(ctx, nil, 1, 0, 16); got != -1 {
+		t.Errorf("stderr read with no buffer = %d", got)
+	}
+	if got := hostSpawnOutputRead(ctx, nil, 99, 0, 16); got != -1 {
+		t.Errorf("invalid which = %d", got)
+	}
+}
+
+func TestSpawn_HostFunctions_OutputReadEmptyBufferReturnsZero(t *testing.T) {
+	// dst_len=0 short-circuits before any memory write.
+	state := &hostState{spawnStdout: []byte("hi"), spawnStderr: []byte("err")}
+	ctx := ctxWithState(context.Background(), state)
+	if got := hostSpawnOutputRead(ctx, nil, 0, 0, 0); got != 0 {
+		t.Errorf("zero-length stdout read = %d, want 0", got)
+	}
+	if got := hostSpawnOutputRead(ctx, nil, 1, 0, 0); got != 0 {
+		t.Errorf("zero-length stderr read = %d, want 0", got)
+	}
+}
+
+// noKindResolver returns ErrCredentialKindMismatch on Resolve.
+type noKindResolver struct{}
+
+func (noKindResolver) Resolve(_ context.Context) (credential.Credential, error) {
+	return credential.Credential{}, credential.ErrCredentialKindMismatch
+}
+
+func TestSpawn_HostFunctions_CredentialKindMismatch(t *testing.T) {
+	state := &hostState{
+		spawnPolicy:            NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor:          &fakeExecutor{},
+		connectorFQN:           "github://aileron-test/gitcrawl",
+		expectedCredentialKind: "api_key",
+		credentialResolver:     noKindResolver{},
+	}
+	ctx := ctxWithState(context.Background(), state)
+	envBytes := mustJSON(SpawnEnvelope{
+		Program:           "/usr/bin/git",
+		Argv:              []string{"git", "status"},
+		CredentialEnvKeys: []string{"GH_TOKEN"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc == 0 {
+		t.Fatal("expected denial for kind mismatch")
+	}
+	if state.spawnErr == nil || state.spawnErr.Class != ClassCapabilityDenied {
+		t.Errorf("expected capability_denied, got %v", state.spawnErr)
+	}
+	detail, _ := state.spawnErr.Details["boundary_detail"].(string)
+	if detail != "vault" {
+		t.Errorf("boundary_detail = %q, want vault", detail)
+	}
+}
+
+// genericErrResolver returns an unclassified error.
+type genericErrResolver struct{}
+
+func (genericErrResolver) Resolve(_ context.Context) (credential.Credential, error) {
+	return credential.Credential{}, errors.New("network broke")
+}
+
+func TestSpawn_HostFunctions_CredentialResolveGenericError(t *testing.T) {
+	state := &hostState{
+		spawnPolicy:            NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor:          &fakeExecutor{},
+		connectorFQN:           "github://aileron-test/gitcrawl",
+		expectedCredentialKind: "api_key",
+		credentialResolver:     genericErrResolver{},
+	}
+	ctx := ctxWithState(context.Background(), state)
+	envBytes := mustJSON(SpawnEnvelope{
+		Program:           "/usr/bin/git",
+		Argv:              []string{"git", "status"},
+		CredentialEnvKeys: []string{"GH_TOKEN"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc == 0 {
+		t.Fatal("expected error for generic resolve failure")
+	}
+	if state.spawnErr == nil || state.spawnErr.Class != ClassConnectorRuntimeError {
+		t.Errorf("expected connector_runtime_error, got %v", state.spawnErr)
+	}
+}
+
+func TestSpawn_HostFunctions_NoCredentialDeclaration(t *testing.T) {
+	// Connector did not declare a credential capability but the spawn
+	// envelope requests credential injection. Expect capability_denied.
+	state := &hostState{
+		spawnPolicy:   NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor: &fakeExecutor{},
+		connectorFQN:  "github://aileron-test/gitcrawl",
+		// expectedCredentialKind is empty
+	}
+	ctx := ctxWithState(context.Background(), state)
+	envBytes := mustJSON(SpawnEnvelope{
+		Program:           "/usr/bin/git",
+		Argv:              []string{"git", "status"},
+		CredentialEnvKeys: []string{"GH_TOKEN"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc == 0 {
+		t.Fatal("expected denial when no credential declared")
+	}
+	if state.spawnErr == nil || state.spawnErr.Class != ClassCapabilityDenied {
+		t.Errorf("expected capability_denied, got %v", state.spawnErr)
+	}
+}
+
+func TestSpawn_HostFunctions_MalformedJSONEnvelope(t *testing.T) {
+	state := &hostState{spawnPolicy: NewSpawnPolicy(goodSpawnManifest())}
+	ctx := ctxWithState(context.Background(), state)
+	if rc := processSpawn(ctx, state, []byte("not json")); rc != -2 {
+		t.Errorf("rc = %d, want -2 (malformed envelope)", rc)
+	}
+	if state.spawnErr == nil || state.spawnErr.Class != ClassConnectorRuntimeError {
+		t.Errorf("err = %v", state.spawnErr)
+	}
+}
+
+// fakeExecutorErr returns an arbitrary non-sandbox-unavailable error.
+type fakeExecutorErr struct{ err error }
+
+func (f fakeExecutorErr) Spawn(_ context.Context, _ SpawnEnvelope) (SpawnResult, error) {
+	return SpawnResult{}, f.err
+}
+
+func TestSpawn_HostFunctions_ExecutorRunErrorPropagates(t *testing.T) {
+	state := &hostState{
+		spawnPolicy:   NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor: fakeExecutorErr{err: errors.New("fork failed")},
+		connectorFQN:  "github://aileron-test/gitcrawl",
+	}
+	ctx := ctxWithState(context.Background(), state)
+	envBytes := mustJSON(SpawnEnvelope{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "status"},
+	})
+	rc := processSpawn(ctx, state, envBytes)
+	if rc == 0 {
+		t.Fatal("expected non-zero rc on executor error")
+	}
+	if state.spawnErr == nil || state.spawnErr.Class != ClassConnectorRuntimeError {
+		t.Errorf("err = %v", state.spawnErr)
+	}
+}
+
+func TestArgvShape_EmptyAndSingleToken(t *testing.T) {
+	if got := argvShape(nil); got != "" {
+		t.Errorf("argvShape(nil) = %q", got)
+	}
+	if got := argvShape([]string{"only"}); got != "only" {
+		t.Errorf("argvShape(single) = %q", got)
+	}
+}
+
+func TestPathWithin_TrailingSlashEdgeCases(t *testing.T) {
+	if !pathWithin("~/code/", "~/code/") {
+		t.Error("identical with trailing slash should match")
+	}
+}
+
+func envvarsMatch(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sandbox/wazero.go
+++ b/internal/sandbox/wazero.go
@@ -28,9 +28,10 @@ import (
 // instance down — the per-invocation isolation required by ADR-0005's
 // acceptance criterion #8.
 type WazeroRuntime struct {
-	rt   wazero.Runtime
-	doer HTTPDoer
-	log  *slog.Logger
+	rt            wazero.Runtime
+	doer          HTTPDoer
+	log           *slog.Logger
+	spawnExecutor SpawnExecutor
 
 	// hostMu guards host-module installation so concurrent Compile
 	// calls do not race the WASI registration.
@@ -83,11 +84,15 @@ func NewWazeroRuntime(ctx context.Context, opts ...RuntimeOption) (*WazeroRuntim
 	return w, nil
 }
 
-// installHostModule registers the four Aileron host functions
-// (`log`, `http_request`, `http_response_size`, `http_response_status`,
-// `http_response_read`) under the `aileron_host` module name. The
-// per-invocation state is threaded through context.Context so the
-// module can be installed once and reused.
+// installHostModule registers the Aileron host functions under the
+// `aileron_host` module name. Per-invocation state is threaded through
+// context.Context so the module can be installed once and reused.
+//
+// HTTP-side imports: `log`, `http_request`, `http_response_size`,
+// `http_response_status`, `http_response_read`.
+//
+// Spawn-side imports (per ADR-0002 spawn primitive): `spawn`,
+// `spawn_status`, `spawn_output_size`, `spawn_output_read`.
 func (w *WazeroRuntime) installHostModule(ctx context.Context) error {
 	w.hostMu.Lock()
 	defer w.hostMu.Unlock()
@@ -108,6 +113,18 @@ func (w *WazeroRuntime) installHostModule(ctx context.Context) error {
 		NewFunctionBuilder().
 		WithFunc(hostHTTPResponseRead).
 		Export("http_response_read").
+		NewFunctionBuilder().
+		WithFunc(hostSpawn).
+		Export("spawn").
+		NewFunctionBuilder().
+		WithFunc(hostSpawnStatus).
+		Export("spawn_status").
+		NewFunctionBuilder().
+		WithFunc(hostSpawnOutputSize).
+		Export("spawn_output_size").
+		NewFunctionBuilder().
+		WithFunc(hostSpawnOutputRead).
+		Export("spawn_output_read").
 		Instantiate(ctx)
 	return err
 }
@@ -131,21 +148,22 @@ func (w *WazeroRuntime) Compile(ctx context.Context, manifest *cstore.Manifest, 
 		return nil, newConnectorLoadFailed(fmt.Sprintf("compile WASM: %s", err.Error()))
 	}
 	return &wazeroConnector{
-		runtime:  w,
-		manifest: manifest,
-		compiled: compiled,
-		policy:   NewHostPolicy(manifest),
+		runtime:     w,
+		manifest:    manifest,
+		compiled:    compiled,
+		policy:      NewHostPolicy(manifest),
+		spawnPolicy: NewSpawnPolicy(manifest),
 	}, nil
 }
 
 // wazeroConnector is the per-binary handle: caches the compiled module
-// and the parsed network policy so repeated invocations don't redo
-// either.
+// and the parsed policies so repeated invocations don't redo either.
 type wazeroConnector struct {
-	runtime  *WazeroRuntime
-	manifest *cstore.Manifest
-	compiled wazero.CompiledModule
-	policy   *HostPolicy
+	runtime     *WazeroRuntime
+	manifest    *cstore.Manifest
+	compiled    wazero.CompiledModule
+	policy      *HostPolicy
+	spawnPolicy *SpawnPolicy
 }
 
 // Close implements [Connector]. Releases the cached compiled module.
@@ -178,6 +196,9 @@ func (c *wazeroConnector) Invoke(ctx context.Context, call Call) (Result, error)
 		connectorFQN:           manifestFQN(c.manifest),
 		expectedCredentialKind: manifestCredentialKind(c.manifest),
 		credentialResolver:     call.CredentialResolver,
+		spawnPolicy:            c.spawnPolicy,
+		spawnExecutor:          c.runtime.spawnExecutor,
+		actionSpawnGrant:       toSet(call.AllowedSpawnPrograms),
 	}
 	callCtx = ctxWithState(callCtx, state)
 


### PR DESCRIPTION
## Summary

Runtime side of the spawn capability primitive (ADR-0002, ADR-0014). When a WASM connector calls `aileron_host.spawn`, the runtime validates the envelope against the manifest's `[capabilities.spawn]` declaration and the action-boundary subset, applies the platform sandbox, runs the subprocess, captures output, and emits an audit row.

### What lands

- **`SpawnPolicy.CheckSpawn`** — connector-manifest gate that mirrors `HostPolicy.CheckURL` at `internal/sandbox/network.go:43-84`. Validates program path, argv pattern (whole-token *and* embedded `--since={since}` placeholders), env keys, credential env keys, and cwd scope. `capability_denied` on any mismatch.
- **Four host functions registered in `aileron_host`**: `spawn`, `spawn_status`, `spawn_output_size`, `spawn_output_read`. Output retrieval mirrors the existing `http_response_*` pattern.
- **`SpawnExecutor` interface + `defaultSpawnExecutor`** wrapping `os/exec`. `WithSpawnExecutor` RuntimeOption substitutes test fakes.
- **Credential injection via env var**: vault bytes never reach the connector; the runtime resolves the binding and sets the env on the `os/exec.Cmd` only.
- **`emitSpawnAudit`** logs every allow/deny/error using `audit.AttrPolicyDecision` (the key reserved in #480) plus argv shape, exit code, and SHA-256 of captured output.
- **`applyPlatformSandbox`** — build-tagged hook for per-OS isolation. Default is a no-op floor; per-platform hardening (Linux namespaces+Landlock, macOS sandbox-exec, Windows job objects) lands as follow-ups under ADR-0014.
- **`ErrSpawnUnavailable`** surfaces as a distinct `spawn_sandbox_unavailable` error class so operators distinguish "rules broken" from "platform cannot enforce".
- **`Call.AllowedSpawnPrograms`** — action-boundary subset, checked alongside the connector manifest at host-call time.

## Closes

- Closes #510

## Test plan

- [x] `go test ./internal/sandbox` passes (full suite, including the existing tests).
- [x] `go test -race` clean.
- [x] Coverage 85.5% on the package (above the 80% bar).
- [x] `task lint:go` clean.
- [x] Argv pattern matcher supports both `git status` (whole-token) and `git log --since={since}` (embedded placeholder) shapes.
- [ ] Reviewer confirms the gate's denial classes line up with ADR-0002's spawn-primitive section.

## Notes for review

- The host functions are registered in `installHostModule` alongside the existing `http_*` set. No change to the existing http surface.
- `processSpawn` is the memory-independent core; `hostSpawn` is a thin wrapper that reads memory then delegates. Tests exercise `processSpawn` directly so they don't need a real WASM module.
- The end-to-end WASM-fixture test (echo connector calling `aileron_host.spawn` against a fake binary) lands with #512's test harness — split because that issue productizes the fake-binary helper, and rebuilding the embedded `.wasm` fixture is its own concern.
- Per-platform sandbox enforcement is intentionally a no-op floor here. ADR-0014 mandates the mechanism; the hook's signature is in place so the Linux/macOS/Windows implementations can plug in without ABI changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)