### PR TITLE
feat(cstore): operations table + forwarder field for spawn primitive

### DIFF
--- a/internal/cstore/manifest.go
+++ b/internal/cstore/manifest.go
@@ -65,6 +65,14 @@ type ManifestConnector struct {
 	// install consent UI. Not load-bearing; provenance lives in the FQN.
 	Publisher string `toml:"publisher"`
 
+	// Forwarder, when set, opts the connector into the daemon-embedded
+	// shared spawn-forwarder WASM (per ADR-0002's spawn-primitive
+	// section). The only allowed value in v1 is "builtin://spawn-forwarder".
+	// When set, the install pipeline routes around the per-connector
+	// WASM fetch; the daemon supplies the forwarder bytes at execution
+	// time and the manifest is the connector's complete identity.
+	Forwarder string `toml:"forwarder,omitempty"`
+
 	// Idempotency is the optional `[connector.idempotency]` block per
 	// ADR-0010. Absent → idempotent default; present → must declare
 	// `default = "idempotent" | "not_idempotent"`. The retry primitive
@@ -72,6 +80,11 @@ type ManifestConnector struct {
 	// retry a failed call.
 	Idempotency *ManifestIdempotency `toml:"idempotency"`
 }
+
+// BuiltinForwarderSpawn is the reserved FQN for the daemon-embedded
+// spawn-forwarder. The only allowed value of ManifestConnector.Forwarder
+// in v1; new builtin:// shapes require an ADR amendment.
+const BuiltinForwarderSpawn = "builtin://spawn-forwarder"
 
 // ManifestIdempotency is `[connector.idempotency]` — the connector's
 // declaration of whether a retry could double-send a side effect.
@@ -195,11 +208,18 @@ type ManifestSpawn struct {
 	// the runtime additionally verifies the binary's bytes.
 	Programs []ManifestSpawnProgram `toml:"programs"`
 
-	// ArgvPatterns is an allow-list of templated argv shapes the
-	// connector may invoke. Each pattern is a literal argv with
-	// `{name}` placeholders the connector fills at call time. An argv
-	// that does not match any pattern after substitution is denied.
-	ArgvPatterns []string `toml:"argv_patterns"`
+	// Operations is the closed map of operations the connector exposes.
+	// Each entry is keyed by op name (matched at call time against the
+	// agent's tool-call op) and carries an argv pattern with `{name}`
+	// placeholders the runtime substitutes from the agent's args. The
+	// gate's argv allow-list is derived from operations[*].argv.
+	//
+	// An incoming op whose name is not in this map is denied with
+	// capability_denied. The forwarder WASM consumes this table via the
+	// aileron_host.spawn_op host function; per-binary connectors using
+	// the low-level aileron_host.spawn can also read it from the runtime
+	// gate.
+	Operations map[string]ManifestSpawnOperation `toml:"operations"`
 
 	// EnvPassthrough is the closed set of environment keys the runtime
 	// may set on the subprocess. The subprocess receives only declared
@@ -220,6 +240,36 @@ type ManifestSpawn struct {
 	// within FSRead. When unset, the runtime uses a per-invocation
 	// temporary directory.
 	Cwd string `toml:"cwd,omitempty"`
+}
+
+// ManifestSpawnOperation is one entry in [capabilities.spawn.operations]:
+// an argv template the runtime substitutes from the agent's args plus
+// optional human-readable description for action.md generation.
+type ManifestSpawnOperation struct {
+	// Argv is the templated argv shape. Tokens are whitespace-separated;
+	// each token may contain `{name}` placeholders that bind to the
+	// agent's args at call time. The runtime validates the substituted
+	// argv against this pattern and refuses any envelope whose argv
+	// doesn't match.
+	Argv string `toml:"argv"`
+
+	// Description is a one-line human-readable summary. Surfaced in the
+	// agent's tool list and the wrap tool's generated action.md.
+	Description string `toml:"description,omitempty"`
+}
+
+// ArgvPatterns returns the flat list of argv templates derived from the
+// manifest's operations map. The sandbox gate (SpawnPolicy.CheckSpawn)
+// consumes this list as its argv allow-list.
+func (s *ManifestSpawn) ArgvPatterns() []string {
+	if s == nil || len(s.Operations) == 0 {
+		return nil
+	}
+	out := make([]string, 0, len(s.Operations))
+	for _, op := range s.Operations {
+		out = append(out, op.Argv)
+	}
+	return out
 }
 
 // ManifestSpawnProgram is one entry in [capabilities.spawn].programs:
@@ -281,6 +331,17 @@ func ValidateManifest(m *Manifest, file string) error {
 	if m.Connector.ProvenanceHash != "" {
 		if !strings.HasPrefix(m.Connector.ProvenanceHash, "sha256:") || len(m.Connector.ProvenanceHash) <= len("sha256:") {
 			return newValidationErr(file, "[connector].provenance_hash %q must be prefixed with sha256:", m.Connector.ProvenanceHash)
+		}
+	}
+	if m.Connector.Forwarder != "" {
+		if m.Connector.Forwarder != BuiltinForwarderSpawn {
+			return newValidationErr(file,
+				"[connector].forwarder %q is not recognized; v1 supports only %q",
+				m.Connector.Forwarder, BuiltinForwarderSpawn)
+		}
+		if m.Capabilities.Spawn == nil {
+			return newValidationErr(file,
+				"[connector].forwarder is set but [capabilities.spawn] is absent; the forwarder requires a spawn capability to drive")
 		}
 	}
 	if m.Capabilities.Network != nil {
@@ -395,6 +456,12 @@ func validateOAuth2(o *ManifestOAuth2, file string) error {
 // letter or underscore, followed by letters, digits, or underscores.
 var envKeyRe = regexp.MustCompile(`^[A-Za-z_][A-Za-z0-9_]*$`)
 
+// opNameRe matches an operation name in [capabilities.spawn.operations].
+// Lowercase, alphanumeric, underscores, and hyphens; must begin with a
+// letter. Names appear in action.md filenames and in the agent's tool
+// surface, so the shape is conservative.
+var opNameRe = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
+
 // validateSpawn enforces the [capabilities.spawn] schema described in
 // ADR-0002's spawn-primitive section. See also ADR-0014 for the runtime
 // enforcement mechanism the declaration translates into.
@@ -429,14 +496,19 @@ func validateSpawn(s *ManifestSpawn, file string) error {
 			}
 		}
 	}
-	if len(s.ArgvPatterns) == 0 {
+	if len(s.Operations) == 0 {
 		return newValidationErr(file,
-			"[capabilities.spawn].argv_patterns is required (at least one)")
+			"[capabilities.spawn.operations] is required (at least one operation)")
 	}
-	for i, pat := range s.ArgvPatterns {
-		if strings.TrimSpace(pat) == "" {
+	for name, op := range s.Operations {
+		if !opNameRe.MatchString(name) {
 			return newValidationErr(file,
-				"[capabilities.spawn].argv_patterns[%d] is empty", i)
+				"[capabilities.spawn.operations].%q name must match %s",
+				name, opNameRe.String())
+		}
+		if strings.TrimSpace(op.Argv) == "" {
+			return newValidationErr(file,
+				"[capabilities.spawn.operations].%q.argv is required", name)
 		}
 	}
 	for i, k := range s.EnvPassthrough {

--- a/internal/cstore/manifest_test.go
+++ b/internal/cstore/manifest_test.go
@@ -419,8 +419,10 @@ func TestValidateManifest_AllowsLoopbackHTTPForLocalDev(t *testing.T) {
 
 func goodSpawn() *ManifestSpawn {
 	return &ManifestSpawn{
-		Programs:       []ManifestSpawnProgram{{Path: "/usr/bin/git"}},
-		ArgvPatterns:   []string{"git log --since={since} --author={author}"},
+		Programs: []ManifestSpawnProgram{{Path: "/usr/bin/git"}},
+		Operations: map[string]ManifestSpawnOperation{
+			"log": {Argv: "git log --since={since} --author={author}"},
+		},
 		EnvPassthrough: []string{"GIT_AUTHOR_NAME"},
 		FSRead:         []string{"~/code/"},
 		FSWrite:        []string{"~/.cache/aileron/gitcrawl/"},
@@ -439,11 +441,13 @@ func TestValidateManifest_AcceptsFullSpawnBlock(t *testing.T) {
 
 func TestValidateManifest_AcceptsMinimalSpawnBlock(t *testing.T) {
 	// FSRead, FSWrite, EnvPassthrough are optional. The minimum is
-	// one program and one argv pattern.
+	// one program and one operation.
 	m := canonicalManifestForTest()
 	m.Capabilities.Spawn = &ManifestSpawn{
-		Programs:     []ManifestSpawnProgram{{Path: "/usr/bin/git"}},
-		ArgvPatterns: []string{"git status"},
+		Programs: []ManifestSpawnProgram{{Path: "/usr/bin/git"}},
+		Operations: map[string]ManifestSpawnOperation{
+			"status": {Argv: "git status"},
+		},
 	}
 	if err := ValidateManifest(m, "ok.toml"); err != nil {
 		t.Errorf("Validate() = %v", err)
@@ -483,12 +487,15 @@ func TestValidateManifest_RejectsBadSpawnFields(t *testing.T) {
 		{"hash prefix only", func(s *ManifestSpawn) {
 			s.Programs = []ManifestSpawnProgram{{Path: "/usr/bin/git", Hash: "sha256:"}}
 		}, "sha256:"},
-		{"empty argv_patterns", func(s *ManifestSpawn) {
-			s.ArgvPatterns = nil
-		}, "argv_patterns is required"},
-		{"blank argv pattern", func(s *ManifestSpawn) {
-			s.ArgvPatterns = []string{"   "}
-		}, "is empty"},
+		{"empty operations", func(s *ManifestSpawn) {
+			s.Operations = nil
+		}, "operations] is required"},
+		{"blank operation argv", func(s *ManifestSpawn) {
+			s.Operations = map[string]ManifestSpawnOperation{"x": {Argv: "   "}}
+		}, "argv is required"},
+		{"invalid op name", func(s *ManifestSpawn) {
+			s.Operations = map[string]ManifestSpawnOperation{"BadName": {Argv: "git status"}}
+		}, "name must match"},
 		{"env key leading digit", func(s *ManifestSpawn) {
 			s.EnvPassthrough = []string{"1VAR"}
 		}, "valid environment variable"},
@@ -532,6 +539,102 @@ func TestValidateManifest_RejectsBadSpawnFields(t *testing.T) {
 	}
 }
 
+func TestValidateManifest_AcceptsForwarderConnector(t *testing.T) {
+	// A connector that opts into the daemon-embedded forwarder declares
+	// connector.forwarder plus a normal spawn block. Validation accepts.
+	m := canonicalManifestForTest()
+	m.Connector.Forwarder = BuiltinForwarderSpawn
+	m.Capabilities.Spawn = goodSpawn()
+	if err := ValidateManifest(m, "ok.toml"); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+}
+
+func TestValidateManifest_RejectsUnknownForwarder(t *testing.T) {
+	m := canonicalManifestForTest()
+	m.Connector.Forwarder = "builtin://something-else"
+	m.Capabilities.Spawn = goodSpawn()
+	err := ValidateManifest(m, "ok.toml")
+	if err == nil {
+		t.Fatal("expected error for unknown forwarder")
+	}
+	if !strings.Contains(err.Error(), "not recognized") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestValidateManifest_RejectsForwarderWithoutSpawn(t *testing.T) {
+	// The forwarder needs a spawn capability to drive; setting it
+	// without [capabilities.spawn] is meaningless.
+	m := canonicalManifestForTest()
+	m.Connector.Forwarder = BuiltinForwarderSpawn
+	err := ValidateManifest(m, "ok.toml")
+	if err == nil {
+		t.Fatal("expected error when forwarder is set but no spawn block")
+	}
+	if !strings.Contains(err.Error(), "[capabilities.spawn]") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestValidateManifest_AcceptsForwarderFreeSpawnConnector(t *testing.T) {
+	// A connector can use spawn without opting into the forwarder
+	// (e.g. a custom WASM body that calls aileron_host.spawn directly).
+	m := canonicalManifestForTest()
+	m.Capabilities.Spawn = goodSpawn()
+	// Forwarder field intentionally absent.
+	if err := ValidateManifest(m, "ok.toml"); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+}
+
+func TestManifestSpawn_ArgvPatternsDerivedFromOperations(t *testing.T) {
+	s := &ManifestSpawn{
+		Operations: map[string]ManifestSpawnOperation{
+			"log":    {Argv: "git log --since={since}"},
+			"status": {Argv: "git status"},
+		},
+	}
+	got := s.ArgvPatterns()
+	if len(got) != 2 {
+		t.Fatalf("ArgvPatterns() len = %d, want 2", len(got))
+	}
+	// Map iteration order is unstable; assert both entries appear.
+	seen := map[string]bool{}
+	for _, p := range got {
+		seen[p] = true
+	}
+	if !seen["git log --since={since}"] || !seen["git status"] {
+		t.Errorf("ArgvPatterns() = %v; want both entries", got)
+	}
+}
+
+func TestManifestSpawn_ArgvPatternsHandlesNil(t *testing.T) {
+	var s *ManifestSpawn
+	if got := s.ArgvPatterns(); got != nil {
+		t.Errorf("nil receiver should return nil; got %v", got)
+	}
+	empty := &ManifestSpawn{}
+	if got := empty.ArgvPatterns(); got != nil {
+		t.Errorf("empty Operations should return nil; got %v", got)
+	}
+}
+
+func TestOpNameRegex_AcceptsValidNames(t *testing.T) {
+	good := []string{"log", "list", "list_recent", "send-msg", "x1"}
+	for _, n := range good {
+		if !opNameRe.MatchString(n) {
+			t.Errorf("opNameRe rejected valid name %q", n)
+		}
+	}
+	bad := []string{"", "Log", "1log", "log!", "_internal", "Send-Msg"}
+	for _, n := range bad {
+		if opNameRe.MatchString(n) {
+			t.Errorf("opNameRe accepted invalid name %q", n)
+		}
+	}
+}
+
 func TestValidateManifest_AcceptsTildeOnlyPath(t *testing.T) {
 	// `~` (no trailing slash) is the user's home directory; the
 	// validator accepts it as an anchored path.
@@ -563,7 +666,6 @@ name = "github://acme/gitcrawl"
 version = "1.0.0"
 
 [capabilities.spawn]
-argv_patterns = ["git log --since={since}"]
 env_passthrough = ["GIT_AUTHOR_NAME"]
 fs_read = ["~/code/"]
 fs_write = ["~/.cache/aileron/gitcrawl/"]
@@ -572,6 +674,10 @@ cwd = "~/code/"
 [[capabilities.spawn.programs]]
 path = "/usr/bin/git"
 hash = "sha256:abc123"
+
+[capabilities.spawn.operations.log]
+argv = "git log --since={since}"
+description = "List commits since a date"
 `)
 	m, err := ParseManifest("x.toml", body)
 	if err != nil {
@@ -587,8 +693,15 @@ hash = "sha256:abc123"
 	if sp.Programs[0].Hash != "sha256:abc123" {
 		t.Errorf("Programs[0].Hash = %q", sp.Programs[0].Hash)
 	}
-	if len(sp.ArgvPatterns) != 1 || sp.ArgvPatterns[0] != "git log --since={since}" {
-		t.Errorf("ArgvPatterns = %v", sp.ArgvPatterns)
+	logOp, ok := sp.Operations["log"]
+	if !ok {
+		t.Fatalf("Operations missing 'log': %v", sp.Operations)
+	}
+	if logOp.Argv != "git log --since={since}" {
+		t.Errorf("Operations.log.argv = %q", logOp.Argv)
+	}
+	if logOp.Description != "List commits since a date" {
+		t.Errorf("Operations.log.description = %q", logOp.Description)
 	}
 	if len(sp.EnvPassthrough) != 1 || sp.EnvPassthrough[0] != "GIT_AUTHOR_NAME" {
 		t.Errorf("EnvPassthrough = %v", sp.EnvPassthrough)
@@ -611,7 +724,6 @@ name = "github://acme/gitcrawl"
 version = "1.0.0"
 
 [capabilities.spawn]
-argv_patterns = ["git status", "git log --since={since}"]
 env_passthrough = ["GIT_AUTHOR_NAME", "GIT_AUTHOR_EMAIL"]
 fs_read = ["~/code/", "~/.gitconfig"]
 fs_write = ["~/.cache/aileron/gitcrawl/"]
@@ -619,6 +731,12 @@ fs_write = ["~/.cache/aileron/gitcrawl/"]
 [[capabilities.spawn.programs]]
 path = "/usr/bin/git"
 hash = "sha256:bd6e"
+
+[capabilities.spawn.operations.log]
+argv = "git log --since={since}"
+
+[capabilities.spawn.operations.status]
+argv = "git status"
 `)
 	m1, err := ParseManifest("a.toml", body)
 	if err != nil {
@@ -657,8 +775,16 @@ func spawnEqual(a, b *ManifestSpawn) bool {
 			return false
 		}
 	}
-	return stringSliceEqual(a.ArgvPatterns, b.ArgvPatterns) &&
-		stringSliceEqual(a.EnvPassthrough, b.EnvPassthrough) &&
+	if len(a.Operations) != len(b.Operations) {
+		return false
+	}
+	for name, opA := range a.Operations {
+		opB, ok := b.Operations[name]
+		if !ok || opA != opB {
+			return false
+		}
+	}
+	return stringSliceEqual(a.EnvPassthrough, b.EnvPassthrough) &&
 		stringSliceEqual(a.FSRead, b.FSRead) &&
 		stringSliceEqual(a.FSWrite, b.FSWrite) &&
 		a.Cwd == b.Cwd

--- a/internal/sandbox/spawn.go
+++ b/internal/sandbox/spawn.go
@@ -65,7 +65,7 @@ func NewSpawnPolicy(m *cstore.Manifest) *SpawnPolicy {
 	for _, prog := range s.Programs {
 		p.programs[prog.Path] = prog.Hash
 	}
-	for _, pat := range s.ArgvPatterns {
+	for _, pat := range s.ArgvPatterns() {
 		p.argvPatterns = append(p.argvPatterns, parseArgvPattern(pat))
 	}
 	for _, k := range s.EnvPassthrough {

--- a/internal/sandbox/spawn_test.go
+++ b/internal/sandbox/spawn_test.go
@@ -30,9 +30,9 @@ func goodSpawnManifest() *cstore.Manifest {
 				Programs: []cstore.ManifestSpawnProgram{
 					{Path: "/usr/bin/git"},
 				},
-				ArgvPatterns: []string{
-					"git log --since={since}",
-					"git status",
+				Operations: map[string]cstore.ManifestSpawnOperation{
+					"log":    {Argv: "git log --since={since}"},
+					"status": {Argv: "git status"},
 				},
 				EnvPassthrough: []string{"GIT_AUTHOR_NAME", "GH_TOKEN"},
 				FSRead:         []string{"~/code/"},

--- a/internal/wrap/emit.go
+++ b/internal/wrap/emit.go
@@ -62,6 +62,7 @@ func BuildManifest(s *Spec) *cstore.Manifest {
 			Name:      s.Connector.Name,
 			Version:   s.Connector.Version,
 			Publisher: s.Connector.Publisher,
+			Forwarder: cstore.BuiltinForwarderSpawn,
 		},
 	}
 	if s.Credential != nil {
@@ -78,9 +79,13 @@ func BuildManifest(s *Spec) *cstore.Manifest {
 		FSRead:         append([]string(nil), s.FSRead...),
 		FSWrite:        append([]string(nil), s.FSWrite...),
 		Cwd:            s.Cwd,
+		Operations:     map[string]cstore.ManifestSpawnOperation{},
 	}
 	for _, sub := range s.Subcommands {
-		spawn.ArgvPatterns = append(spawn.ArgvPatterns, sub.Argv)
+		spawn.Operations[sub.Name] = cstore.ManifestSpawnOperation{
+			Argv:        sub.Argv,
+			Description: sub.Description,
+		}
 	}
 	m.Capabilities.Spawn = spawn
 	return m

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -273,8 +273,8 @@ func TestEmit_ProducesValidManifest(t *testing.T) {
 	if m.Capabilities.Spawn == nil {
 		t.Fatal("manifest is missing [capabilities.spawn]")
 	}
-	if got, want := len(m.Capabilities.Spawn.ArgvPatterns), 2; got != want {
-		t.Errorf("argv_patterns count = %d, want %d", got, want)
+	if got, want := len(m.Capabilities.Spawn.Operations), 2; got != want {
+		t.Errorf("operations count = %d, want %d", got, want)
 	}
 }
 


### PR DESCRIPTION
## Summary

First implementation slice of the shared spawn-forwarder design from [#592](https://github.com/ALRubinger/aileron/pull/592). Updates the manifest schema; downstream sub-PRs add the host function, embed the WASM, route the install pipeline, and retool \`aileron action wrap\`.

### What changes in the schema

- **\`ManifestSpawn.ArgvPatterns []string\`** → **\`Operations map[string]ManifestSpawnOperation\`**. Operation entries bind an op name (matched against the agent's tool-call op at runtime) to an argv template plus a one-line description. The flat argv-pattern allow-list that the sandbox gate consumes is now derived from \`operations[*].argv\` via the new \`ManifestSpawn.ArgvPatterns()\` method.
- **\`ManifestConnector.Forwarder\` (new)**. Opts the connector into the daemon-embedded shared forwarder. Only allowed value in v1 is \`builtin://spawn-forwarder\` (constant \`cstore.BuiltinForwarderSpawn\`).
- **\`opNameRe\`** validates op names: lowercase letter-prefixed, alphanumeric + underscore + hyphen. Conservative because op names appear in \`action.md\` filenames and on the agent's tool surface.

### Downstream consumers

- \`internal/sandbox/spawn.go\` — \`NewSpawnPolicy\` now calls \`s.ArgvPatterns()\` instead of reading the (removed) slice field.
- \`internal/wrap/emit.go\` — \`BuildManifest\` emits the operations map keyed by subcommand name and sets \`connector.forwarder\` so wrap output is forwarder-shaped by default. Full retooling (drop Taskfile/release.yml from default output, add \`--install\` flag) is a follow-up under #505.

Pre-MVP, no migration shim per the no-backwards-compat-before-release convention.

## Closes

Part of [#505](https://github.com/ALRubinger/aileron/issues/505) — implementation section 2, item 1.

## Test plan

- [x] \`go test ./internal/cstore\` — 87.0% coverage; 100% on \`validateSpawn\`, \`ValidateManifest\`, \`ArgvPatterns()\`, \`opNameRe\`. Round-trip parse/encode property test updated.
- [x] \`go test ./internal/sandbox\` — fixtures migrated; all pre-existing spawn tests still pass.
- [x] \`go test ./internal/wrap\` — fixtures migrated; emit/validate round-trip still passes.
- [x] \`go test ./cmd/aileron\` — wrap CLI tests still pass.
- [x] \`task lint:go\` clean.
- [ ] Reviewer reads \`ManifestSpawn.Operations\` shape against ADR-0002's \`[capabilities.spawn.operations]\` description.

## Notes for review

- Pre-existing failure on \`TestResolveShim_NotFound\` is unrelated (confirmed on main before this branch).
- Wrap-emitted manifests now default to \`connector.forwarder = "builtin://spawn-forwarder"\`. This means the next slice (host function \`spawn_op\`) and the install pipeline routing will need to land before wrapped CLIs install end-to-end; until then a wrap-emitted manifest will validate but not yet be installable. That's expected mid-stack; the PRs land in dependency order.

🤖 Generated with [Claude Code](https://claude.com/claude-code)