### PR TITLE
feat(cstore): install pipeline routing for shared-forwarder connectors

### DIFF
--- a/internal/action/executor.go
+++ b/internal/action/executor.go
@@ -14,6 +14,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/failure"
 	"github.com/ALRubinger/aileron/internal/sandbox"
+	"github.com/ALRubinger/aileron/internal/sandbox/forwarder"
 	"go.opentelemetry.io/otel"
 	"go.opentelemetry.io/otel/attribute"
 	"go.opentelemetry.io/otel/codes"
@@ -392,13 +393,9 @@ func (e *SandboxExecutor) connectorFor(ctx context.Context, m *Manifest, connect
 	if err != nil {
 		return nil, nil, "", err
 	}
-	binPath := filepath.Join(entryDir, "connector.wasm")
-	if _, statErr := os.Stat(binPath); errors.Is(statErr, os.ErrNotExist) {
-		binPath = filepath.Join(entryDir, "connector.wat")
-	}
-	binBytes, err := os.ReadFile(binPath)
+	binBytes, err := loadConnectorBytes(cmf, entryDir)
 	if err != nil {
-		return nil, nil, "", fmt.Errorf("read connector binary: %w", err)
+		return nil, nil, "", err
 	}
 	conn, err := e.Runtime.Compile(ctx, cmf, binBytes)
 	if err != nil {
@@ -408,6 +405,31 @@ func (e *SandboxExecutor) connectorFor(ctx context.Context, m *Manifest, connect
 	e.cache[dep.Hash] = cachedConnector{conn: conn, manifest: cmf}
 	e.mu.Unlock()
 	return conn, cmf, dep.Hash, nil
+}
+
+// loadConnectorBytes returns the WASM bytes the runtime should compile
+// for `cmf`. For forwarder-shaped connectors (those whose manifest
+// declares `connector.forwarder = "builtin://spawn-forwarder"`), the
+// bytes are the daemon-embedded forwarder; entryDir holds the manifest
+// only. For per-binary connectors, the bytes are read from disk under
+// entryDir as before.
+func loadConnectorBytes(cmf *cstore.Manifest, entryDir string) ([]byte, error) {
+	if cmf != nil && cmf.Connector.Forwarder == cstore.BuiltinForwarderSpawn {
+		// The forwarder bytes are part of the daemon binary; the
+		// manifest's content hash already includes them via
+		// cstore.ForwarderConnectorHash so the store does not need a
+		// copy on disk.
+		return forwarder.WASM, nil
+	}
+	binPath := filepath.Join(entryDir, "connector.wasm")
+	if _, statErr := os.Stat(binPath); errors.Is(statErr, os.ErrNotExist) {
+		binPath = filepath.Join(entryDir, "connector.wat")
+	}
+	binBytes, err := os.ReadFile(binPath)
+	if err != nil {
+		return nil, fmt.Errorf("read connector binary: %w", err)
+	}
+	return binBytes, nil
 }
 
 // resolverFor returns the credential.Resolver for the named connector,

--- a/internal/action/executor_forwarder_test.go
+++ b/internal/action/executor_forwarder_test.go
@@ -1,0 +1,96 @@
+package action
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+	"github.com/ALRubinger/aileron/internal/sandbox/forwarder"
+)
+
+// loadConnectorBytes is the single switch point that decides whether a
+// connector's bytes come from the embedded forwarder or from disk.
+// Regressions here would silently break every shared-forwarder wrap,
+// so the two paths are exercised directly here.
+
+func TestLoadConnectorBytes_ForwarderUsesEmbeddedWASM(t *testing.T) {
+	manifest := &cstore.Manifest{
+		Connector: cstore.ManifestConnector{
+			Name:      "github://acme/gitcrawl",
+			Version:   "0.0.1",
+			Forwarder: cstore.BuiltinForwarderSpawn,
+		},
+	}
+	// entryDir is intentionally non-existent: the load path must not
+	// consult the filesystem for forwarder connectors.
+	got, err := loadConnectorBytes(manifest, "/does/not/exist")
+	if err != nil {
+		t.Fatalf("loadConnectorBytes: %v", err)
+	}
+	if !bytes.Equal(got, forwarder.WASM) {
+		t.Errorf("forwarder path returned %d bytes; want forwarder.WASM (%d bytes)",
+			len(got), len(forwarder.WASM))
+	}
+}
+
+func TestLoadConnectorBytes_PerBinaryReadsFromDisk(t *testing.T) {
+	dir := t.TempDir()
+	want := []byte("PER-BINARY-WASM")
+	if err := os.WriteFile(filepath.Join(dir, "connector.wasm"), want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := &cstore.Manifest{
+		Connector: cstore.ManifestConnector{
+			Name:    "github://acme/slack-http",
+			Version: "1.0.0",
+			// No Forwarder — per-binary connector.
+		},
+	}
+	got, err := loadConnectorBytes(manifest, dir)
+	if err != nil {
+		t.Fatalf("loadConnectorBytes: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("per-binary read = %q, want %q", got, want)
+	}
+}
+
+func TestLoadConnectorBytes_PerBinaryFallsBackToConnectorWAT(t *testing.T) {
+	// The existing per-binary path tries connector.wasm first, then
+	// falls back to connector.wat (text format used by older test
+	// fixtures). Confirm the fallback path is intact for non-forwarder
+	// manifests so this PR doesn't accidentally regress it.
+	dir := t.TempDir()
+	want := []byte("(module)")
+	if err := os.WriteFile(filepath.Join(dir, "connector.wat"), want, 0o644); err != nil {
+		t.Fatal(err)
+	}
+	manifest := &cstore.Manifest{
+		Connector: cstore.ManifestConnector{
+			Name:    "github://acme/x",
+			Version: "0.1.0",
+		},
+	}
+	got, err := loadConnectorBytes(manifest, dir)
+	if err != nil {
+		t.Fatalf("loadConnectorBytes: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("wat fallback = %q, want %q", got, want)
+	}
+}
+
+func TestLoadConnectorBytes_PerBinaryMissingFileSurfacesError(t *testing.T) {
+	manifest := &cstore.Manifest{
+		Connector: cstore.ManifestConnector{
+			Name:    "github://acme/x",
+			Version: "0.1.0",
+		},
+	}
+	_, err := loadConnectorBytes(manifest, t.TempDir())
+	if err == nil {
+		t.Fatal("expected error when neither connector.wasm nor connector.wat exists")
+	}
+}

--- a/internal/cstore/install_forwarder_test.go
+++ b/internal/cstore/install_forwarder_test.go
@@ -1,0 +1,247 @@
+package cstore
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// forwarderManifestFor returns a minimal-valid forwarder-shaped
+// manifest for the given FQN/version. Used across the install tests.
+func forwarderManifestFor(fqn, version string) []byte {
+	return []byte(`[connector]
+name      = "` + fqn + `"
+version   = "` + version + `"
+publisher = "test"
+forwarder = "builtin://spawn-forwarder"
+
+[capabilities.spawn]
+
+[[capabilities.spawn.programs]]
+path = "/usr/bin/git"
+
+[capabilities.spawn.operations.status]
+argv = "git status"
+`)
+}
+
+func TestForwarderConnectorHash_IsCanonical(t *testing.T) {
+	// The hash is sha256(forwarder || manifest). Two independent
+	// invocations on the same inputs produce identical output; two
+	// invocations on different manifests do not.
+	fw := []byte("FORWARDER")
+	m1 := []byte("MANIFEST-1")
+	m2 := []byte("MANIFEST-2")
+	if ForwarderConnectorHash(fw, m1) != ForwarderConnectorHash(fw, m1) {
+		t.Error("hash is not deterministic")
+	}
+	if ForwarderConnectorHash(fw, m1) == ForwarderConnectorHash(fw, m2) {
+		t.Error("different manifests must produce different hashes")
+	}
+	sum := sha256.Sum256(append(fw, m1...))
+	want := "sha256:" + hex.EncodeToString(sum[:])
+	if got := ForwarderConnectorHash(fw, m1); got != want {
+		t.Errorf("hash = %q, want %q", got, want)
+	}
+}
+
+func TestInstallForwarderManifest_WritesManifestOnlyAtComputedHash(t *testing.T) {
+	store := NewStore(t.TempDir())
+	ref := mustRef(t, "github://acme/gitcrawl@0.0.1")
+	manifest := forwarderManifestFor(ref.FQN.String(), ref.Version)
+	forwarderBytes := []byte("FORWARDER-WASM")
+
+	res, err := store.InstallForwarderManifest(manifest, forwarderBytes, ref)
+	if err != nil {
+		t.Fatalf("InstallForwarderManifest: %v", err)
+	}
+	if res.AlreadyInstalled {
+		t.Error("first install reported AlreadyInstalled")
+	}
+	if want := ForwarderConnectorHash(forwarderBytes, manifest); res.Hash != want {
+		t.Errorf("Hash = %q, want %q", res.Hash, want)
+	}
+	if !filepath.IsAbs(res.EntryDir) {
+		t.Errorf("EntryDir not absolute: %q", res.EntryDir)
+	}
+
+	// The manifest is on disk; no connector.wasm or signature.sig was
+	// written. The store entry's identity is the manifest alone.
+	if _, err := os.Stat(filepath.Join(res.EntryDir, "manifest.toml")); err != nil {
+		t.Errorf("manifest.toml missing: %v", err)
+	}
+	for _, leftover := range []string{"connector.wasm", "connector.bin", "signature.sig"} {
+		if _, err := os.Stat(filepath.Join(res.EntryDir, leftover)); err == nil {
+			t.Errorf("forwarder install must not write %q", leftover)
+		}
+	}
+
+	if got, ok := store.Lookup(ref); !ok || got != res.Hash {
+		t.Errorf("Lookup after install = (%q, %v)", got, ok)
+	}
+}
+
+func TestInstallForwarderManifest_ReinstallSameBytesIsIdempotent(t *testing.T) {
+	store := NewStore(t.TempDir())
+	ref := mustRef(t, "github://acme/gitcrawl@0.0.1")
+	manifest := forwarderManifestFor(ref.FQN.String(), ref.Version)
+	fw := []byte("FORWARDER")
+
+	first, err := store.InstallForwarderManifest(manifest, fw, ref)
+	if err != nil {
+		t.Fatalf("first install: %v", err)
+	}
+	second, err := store.InstallForwarderManifest(manifest, fw, ref)
+	if err != nil {
+		t.Fatalf("second install: %v", err)
+	}
+	if !second.AlreadyInstalled {
+		t.Error("second install should report AlreadyInstalled")
+	}
+	if first.Hash != second.Hash {
+		t.Errorf("hashes diverged: %q vs %q", first.Hash, second.Hash)
+	}
+	if first.EntryDir != second.EntryDir {
+		t.Errorf("entry dirs diverged: %q vs %q", first.EntryDir, second.EntryDir)
+	}
+}
+
+func TestInstallForwarderManifest_DifferentForwarderProducesDifferentHash(t *testing.T) {
+	// This is the practically-important invariant for daemon upgrades:
+	// if the daemon ships new forwarder bytes, every wrap's hash
+	// changes — manifests get re-stored under the new hash, not
+	// silently confused with the old one.
+	store := NewStore(t.TempDir())
+	ref := mustRef(t, "github://acme/gitcrawl@0.0.1")
+	manifest := forwarderManifestFor(ref.FQN.String(), ref.Version)
+
+	v1, err := store.InstallForwarderManifest(manifest, []byte("FORWARDER-V1"), ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	v2, err := store.InstallForwarderManifest(manifest, []byte("FORWARDER-V2"), ref)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if v1.Hash == v2.Hash {
+		t.Error("different forwarder bytes must produce different store hashes")
+	}
+	if v1.EntryDir == v2.EntryDir {
+		t.Error("different hashes must land in different entry dirs")
+	}
+}
+
+func TestInstallForwarderManifest_RejectsNonForwarderManifest(t *testing.T) {
+	// A manifest that does not declare the builtin forwarder should
+	// not pass through this install path; the regular Installer.Install
+	// pipeline (with binary fetch + signature) is the right path for
+	// per-binary connectors.
+	store := NewStore(t.TempDir())
+	ref := mustRef(t, "github://acme/gitcrawl@0.0.1")
+	manifest := []byte(canonicalManifestFor(ref.FQN.String(), ref.Version))
+
+	_, err := store.InstallForwarderManifest(manifest, []byte("FW"), ref)
+	if err == nil {
+		t.Fatal("expected refusal of non-forwarder manifest")
+	}
+	if !strings.Contains(err.Error(), "shared forwarder") {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestInstallForwarderManifest_RejectsManifestFQNMismatch(t *testing.T) {
+	store := NewStore(t.TempDir())
+	ref := mustRef(t, "github://acme/gitcrawl@0.0.1")
+	// Manifest claims a different FQN than the install ref.
+	manifest := forwarderManifestFor("github://impostor/gitcrawl", "0.0.1")
+
+	_, err := store.InstallForwarderManifest(manifest, []byte("FW"), ref)
+	if err == nil {
+		t.Fatal("expected FQN-mismatch refusal")
+	}
+	var sErr *Error
+	if !errors_As(err, &sErr) || sErr.Class != ClassFQNMismatch {
+		t.Errorf("err = %v, want ClassFQNMismatch", err)
+	}
+}
+
+func TestInstallForwarderManifest_RejectsManifestVersionMismatch(t *testing.T) {
+	store := NewStore(t.TempDir())
+	ref := mustRef(t, "github://acme/gitcrawl@0.0.1")
+	// Manifest version differs from the install ref's version.
+	manifest := forwarderManifestFor(ref.FQN.String(), "9.9.9")
+
+	_, err := store.InstallForwarderManifest(manifest, []byte("FW"), ref)
+	if err == nil {
+		t.Fatal("expected version-mismatch refusal")
+	}
+	var sErr *Error
+	if !errors_As(err, &sErr) || sErr.Class != ClassFQNMismatch {
+		t.Errorf("err = %v", err)
+	}
+}
+
+func TestInstallForwarderManifest_RejectsMalformedTOML(t *testing.T) {
+	// The wrap tool emits TOML, but users hand-edit manifests too.
+	// Malformed input must surface as a parse error before any file
+	// is written.
+	store := NewStore(t.TempDir())
+	ref := mustRef(t, "github://acme/gitcrawl@0.0.1")
+	_, err := store.InstallForwarderManifest([]byte("name = ="), []byte("FW"), ref)
+	if err == nil {
+		t.Fatal("expected parse error for malformed TOML")
+	}
+	var sErr *Error
+	if !errors_As(err, &sErr) || sErr.Class != ClassParseError {
+		t.Errorf("err = %v, want ClassParseError", err)
+	}
+	// Confirm nothing was written.
+	entries, _ := os.ReadDir(filepath.Join(store.root, "connectors", "sha256"))
+	if len(entries) != 0 {
+		t.Errorf("store has %d entries after failed install; want 0", len(entries))
+	}
+}
+
+func TestInstallForwarderManifest_PropagatesValidationErrors(t *testing.T) {
+	// A manifest that fails ValidateManifest (e.g. missing required
+	// fields) should be rejected before any file is written.
+	store := NewStore(t.TempDir())
+	ref := mustRef(t, "github://acme/gitcrawl@0.0.1")
+	// Missing [capabilities.spawn.operations] is a validation failure.
+	bad := []byte(`[connector]
+name      = "github://acme/gitcrawl"
+version   = "0.0.1"
+forwarder = "builtin://spawn-forwarder"
+
+[capabilities.spawn]
+
+[[capabilities.spawn.programs]]
+path = "/usr/bin/git"
+`)
+	_, err := store.InstallForwarderManifest(bad, []byte("FW"), ref)
+	if err == nil {
+		t.Fatal("expected validation failure")
+	}
+}
+
+// errors_As wraps errors.As so the file does not need its own errors
+// import; tests already import errors transitively, but the helper
+// keeps the call site readable.
+func errors_As(err error, target **Error) bool {
+	for err != nil {
+		if e, ok := err.(*Error); ok {
+			*target = e
+			return true
+		}
+		type unwrapper interface{ Unwrap() error }
+		u, ok := err.(unwrapper)
+		if !ok {
+			return false
+		}
+		err = u.Unwrap()
+	}
+	return false
+}

--- a/internal/cstore/store.go
+++ b/internal/cstore/store.go
@@ -2,6 +2,7 @@ package cstore
 
 import (
 	"crypto/rand"
+	"crypto/sha256"
 	"encoding/hex"
 	"encoding/json"
 	"errors"
@@ -341,6 +342,136 @@ func (s *Store) commit(t *Tarball, ref Ref, hashHex string) error {
 		return wrapStoreErr(err)
 	}
 	return s.recordIndex(ref, "sha256:"+hashHex)
+}
+
+// ForwarderConnectorHash returns the canonical content hash for a
+// shared-forwarder connector (per ADR-0002's spawn-primitive section).
+// The connector binary is the daemon-embedded forwarder bytes; the
+// connector identity is the manifest. The hash is therefore
+// `sha256(forwarder_bytes || manifest_bytes)`, the same canonical
+// shape as the per-binary case but with the forwarder bytes
+// supplying the "binary" half.
+//
+// The returned value carries the `sha256:` prefix to match the
+// declared-hash format used elsewhere in cstore.
+func ForwarderConnectorHash(forwarderBytes, manifestBytes []byte) string {
+	h := sha256.New()
+	h.Write(forwarderBytes)
+	h.Write(manifestBytes)
+	return "sha256:" + hex.EncodeToString(h.Sum(nil))
+}
+
+// InstallForwarderManifest writes a forwarder-shaped manifest into the
+// content-addressed store. No binary fetch happens: forwarderBytes are
+// the daemon-embedded WASM the runtime supplies at execution time,
+// passed in here so cstore can compute the content hash without taking
+// a dependency on internal/sandbox/forwarder.
+//
+// The manifest must declare `connector.forwarder = "builtin://spawn-forwarder"`,
+// must parse and validate cleanly, and must agree with `ref` on FQN
+// and version. On success the manifest lives at
+// <root>/connectors/sha256/<hash>/manifest.toml; no connector.wasm or
+// signature.sig is written for the local-publisher case (the user is
+// the publisher and the manifest's content hash is the trust anchor).
+//
+// Returns the same shape as Installer.Install: hash + entry dir, plus
+// AlreadyInstalled when an entry with the matching hash existed before
+// this call.
+func (s *Store) InstallForwarderManifest(manifestBytes, forwarderBytes []byte, ref Ref) (*InstallResult, error) {
+	parsed, err := ParseManifest("", manifestBytes)
+	if err != nil {
+		return nil, err
+	}
+	if vErr := ValidateManifest(parsed, ""); vErr != nil {
+		return nil, vErr
+	}
+	if parsed.Connector.Forwarder != BuiltinForwarderSpawn {
+		return nil, &Error{
+			Class:    ClassValidationError,
+			Boundary: BoundaryRuntime,
+			Message:  "manifest does not opt into the shared forwarder",
+			Details: map[string]any{
+				"connector.forwarder": parsed.Connector.Forwarder,
+				"expected":            BuiltinForwarderSpawn,
+			},
+		}
+	}
+	if parsed.Connector.Name != ref.FQN.String() {
+		return nil, &Error{
+			Class:    ClassFQNMismatch,
+			Boundary: BoundaryRuntime,
+			Message:  "manifest FQN does not match install ref",
+			Details: map[string]any{
+				"requested_fqn": ref.FQN.String(),
+				"manifest_fqn":  parsed.Connector.Name,
+			},
+		}
+	}
+	if parsed.Connector.Version != ref.Version {
+		return nil, &Error{
+			Class:    ClassFQNMismatch,
+			Boundary: BoundaryRuntime,
+			Message:  "manifest version does not match install ref",
+			Details: map[string]any{
+				"requested_version": ref.Version,
+				"manifest_version":  parsed.Connector.Version,
+			},
+		}
+	}
+
+	hash := ForwarderConnectorHash(forwarderBytes, manifestBytes)
+	hashHex := strings.TrimPrefix(hash, "sha256:")
+
+	if err := os.MkdirAll(s.tmpRoot(), 0o755); err != nil {
+		return nil, wrapStoreErr(err)
+	}
+	if err := os.MkdirAll(s.sha256Root(), 0o755); err != nil {
+		return nil, wrapStoreErr(err)
+	}
+
+	dst := filepath.Join(s.sha256Root(), hashHex)
+	if _, err := os.Stat(dst); err == nil {
+		// Already-installed: identical manifest already in store at this
+		// hash (same forwarder bytes + same manifest bytes => same hash).
+		if err := s.recordIndex(ref, hash); err != nil {
+			return nil, err
+		}
+		return &InstallResult{
+			Hash:             hash,
+			EntryDir:         dst,
+			AlreadyInstalled: true,
+		}, nil
+	}
+
+	tmp, err := uniqueTempDir(s.tmpRoot())
+	if err != nil {
+		return nil, wrapStoreErr(err)
+	}
+	defer os.RemoveAll(tmp)
+
+	if err := writeFile(filepath.Join(tmp, tarManifestFile), manifestBytes, 0o644); err != nil {
+		return nil, wrapStoreErr(err)
+	}
+
+	if err := os.Rename(tmp, dst); err != nil {
+		// Concurrent install: re-stat and treat as no-op if dst now
+		// exists (mirrors Store.commit's race handling).
+		if _, sErr := os.Stat(dst); sErr == nil {
+			if err := s.recordIndex(ref, hash); err != nil {
+				return nil, err
+			}
+			return &InstallResult{
+				Hash:             hash,
+				EntryDir:         dst,
+				AlreadyInstalled: true,
+			}, nil
+		}
+		return nil, wrapStoreErr(err)
+	}
+	if err := s.recordIndex(ref, hash); err != nil {
+		return nil, err
+	}
+	return &InstallResult{Hash: hash, EntryDir: dst}, nil
 }
 
 // uniqueTempDir creates and returns a fresh subdirectory of parent.


### PR DESCRIPTION
## Summary

Fourth slice of the shared spawn-forwarder implementation. Closes the install loop: a forwarder-shaped manifest can now be written to the store *and* loaded by the action executor end-to-end. The remaining slice (#597 — \`aileron action wrap --install\`) lands directly on top of this primitive.

## What lands

**Install side (`internal/cstore`):**
- **`Store.InstallForwarderManifest(manifestBytes, forwarderBytes, ref)`** — writes a forwarder-shaped manifest into the content-addressed store *without* fetching a binary. Hash is `sha256(forwarderBytes || manifestBytes)` per ADR-0002. The entry contains only `manifest.toml`: no `connector.wasm`, no `signature.sig`, because the daemon-embedded forwarder is the binary half of the hash and the user is the local publisher.
- **`cstore.ForwarderConnectorHash(forwarderBytes, manifestBytes)`** — public primitive so the wrap tool and any future hub-distributed install path compute the same hash without duplicating logic.
- Validation refuses non-forwarder manifests, FQN/version mismatches against the install ref, malformed TOML, and anything that fails `ValidateManifest`.

**Load side (`internal/action/executor.go`):**
- **`loadConnectorBytes`** — new switch point. Manifests declaring `connector.forwarder = "builtin://spawn-forwarder"` get the embedded `forwarder.WASM` bytes without consulting the filesystem. Per-binary manifests fall back to the existing `connector.wasm` / `connector.wat` on-disk read. Wired into `connectorFor` so `Runtime.Compile` receives the right bytes.

## Closes

Implementation item 4 under #505 ("Install pipeline routing for forwarder connectors").

## Test plan

- [x] `go test ./internal/cstore` — 86.3% pkg coverage. \`ForwarderConnectorHash\` 100%, \`InstallForwarderManifest\` 70.3% with all load-bearing branches covered.
- [x] `go test ./internal/action` — 4 focused tests on \`loadConnectorBytes\` covering both forwarder and per-binary paths, the .wat fallback, and the missing-file error.
- [x] `task lint:go` clean.
- [x] Full sandbox + cstore + action test suites pass.

## Notes on coverage

Per direction, only added tests that strengthen Aileron. The uncovered 30% in `InstallForwarderManifest` is filesystem-error wrapping (\`wrapStoreErr\` calls for \`MkdirAll\` and \`writeFile\` failures) and concurrent-install race recovery — exercising them requires brittle fixtures (chmod hacks, goroutine races) that wouldn't catch real bugs. The behaviors mirror the existing \`Store.commit\` path which has the same coverage shape.

The genuinely user-facing edge cases (malformed TOML, FQN mismatch, version mismatch, validation failures, non-forwarder manifest refusal, reinstall idempotency, daemon-upgrade hash invalidation) are all covered.

## Up next

- **#597 — \`aileron action wrap\` retooling**: \`--install\` flag that calls \`Store.InstallForwarderManifest\` directly, plus dropping the Taskfile/release.yml scaffolding from the default output. This is the final slice — once it lands, \`aileron action wrap slackdump --install\` is the demo's wow moment.

🤖 Generated with [Claude Code](https://claude.com/claude-code)