### PR TITLE
docs: BlueBubbles setup guide + Wrapping a CLI correction (closes #514)

### DIFF
--- a/docs/src/content/docs/guides/setting-up-bluebubbles.md
+++ b/docs/src/content/docs/guides/setting-up-bluebubbles.md
@@ -1,0 +1,105 @@
+---
+title: "Setting up BlueBubbles for Aileron"
+description: "Prerequisite for the iMessage connector: install BlueBubbles Server on your Mac, grant the OS permissions it needs, and verify Aileron can reach it."
+---
+
+The Aileron iMessage connector doesn't touch your Mac's Messages app directly. Instead it talks to **BlueBubbles**, a free open-source server you run locally. BlueBubbles handles the platform-specific work (reading the iMessage history, sending new messages, listening for incoming ones) and exposes a simple HTTP API on your machine. Aileron talks to that API.
+
+This separation matters in two ways. First, **you grant macOS permissions to BlueBubbles, not to Aileron**. BlueBubbles is purpose-built for this; Aileron stays out of the operating system's privileged surface. Second, **if Apple ever changes how iMessage data is stored**, BlueBubbles' maintainers handle that — Aileron's connector keeps working without changes.
+
+You only need to do this setup once per Mac.
+
+## Before you start
+
+- A Mac that's already signed in to iMessage and receiving messages normally.
+- About 5 minutes.
+- You'll create one password during this setup. Pick something memorable; you'll give it to Aileron later as a credential.
+
+## 1. Install BlueBubbles Server
+
+Download the Mac app from [bluebubbles.app](https://bluebubbles.app/downloads/) and drag it to your Applications folder. Launch it from there (not from the downloads folder, so macOS treats it as a normal app).
+
+On first launch, BlueBubbles walks you through a setup wizard. You only need the first two steps for Aileron's purposes:
+
+1. **Set a server password.** Choose something strong; this is the only thing standing between anyone on your local network and your iMessage history. Save it in your password manager.
+2. **Skip the Firebase / Google setup** unless you separately want BlueBubbles' phone-app features. Aileron doesn't use them.
+
+Leave BlueBubbles Server running. It lives in your menu bar.
+
+## 2. Grant the macOS permissions BlueBubbles needs
+
+BlueBubbles needs two macOS permissions to do its work. macOS prompts for both the first time BlueBubbles needs them; if you missed the prompt, you can grant them by hand:
+
+- **Full Disk Access**. Open *System Settings → Privacy & Security → Full Disk Access*. Toggle BlueBubbles Server **on**. This lets BlueBubbles read your iMessage database.
+- **Automation**. Open *System Settings → Privacy & Security → Automation*. Find BlueBubbles Server in the list and check the box next to **Messages**. This lets BlueBubbles send new messages on your behalf.
+
+Quit and relaunch BlueBubbles Server after granting either of these. macOS is picky about when permission changes take effect.
+
+## 3. Confirm BlueBubbles is reachable
+
+BlueBubbles Server runs an HTTP API on `localhost:1234` by default. Open a terminal and ask it for its status:
+
+```sh
+curl http://localhost:1234/api/v1/server/info?password=YOUR_BLUEBUBBLES_PASSWORD
+```
+
+If the response is a JSON object describing your server (version, OS, iMessage status), you're done. If you get a connection error, BlueBubbles isn't running; relaunch it from Applications.
+
+If you changed the default port during setup, substitute that port number in the URL above and remember it for the next step.
+
+## 4. Install Aileron's iMessage connector
+
+```sh
+aileron connector install github://ALRubinger/aileron-connector-imsg@latest
+```
+
+Aileron prompts you for the BlueBubbles server password you set in step 1. Paste it in. The credential lands in your Aileron vault encrypted; Aileron's connector reads it only at call time, and the bytes never reach the agent.
+
+If your BlueBubbles is on a non-default port, you'll see a follow-up prompt for the URL. Otherwise the default `http://localhost:1234` is used.
+
+## 5. Try it
+
+Install one of the iMessage actions, then ask your agent something simple:
+
+```sh
+aileron action add github://ALRubinger/aileron-connector-imsg/actions/list-recent-chats@latest
+aileron launch claude
+```
+
+> *"List the iMessage conversations I've had in the last week."*
+
+The agent should return a list of recent chats. If you see a `bridge_unreachable` error, jump to the troubleshooting section below.
+
+## Troubleshooting
+
+**`bridge_unreachable`**: BlueBubbles Server isn't running. Open Applications and relaunch it. Confirm the menu bar icon is present and that `curl http://localhost:1234/api/v1/server/info?password=...` returns JSON.
+
+**`permission_denied` or similar OS-level error**: You probably granted BlueBubbles Full Disk Access but not Automation (or vice versa). Re-check both *System Settings → Privacy & Security → Full Disk Access* and *Automation* per step 2, then relaunch BlueBubbles.
+
+**`unauthorized` from BlueBubbles**: The password Aileron is sending doesn't match the one BlueBubbles expects. Run `aileron binding setup github://ALRubinger/aileron-connector-imsg` to re-bind with the correct password.
+
+**Wrong port**: If you changed BlueBubbles' port during setup, Aileron needs to know. Update the URL by re-running `aileron binding setup` for the connector and providing the new URL when prompted.
+
+## What this gives the agent
+
+With this setup, your agent can:
+
+- **Read** recent iMessage conversations and individual messages.
+- **Send** new iMessages to existing chats.
+- **List** the chats you're part of.
+
+Every send goes through Aileron's standard approval gate; you confirm the recipient and message body before BlueBubbles actually delivers it. Reads happen without prompting because they're scoped to your own message history.
+
+The full set of operations the connector exposes is listed in its [hub entry](https://hub.aileron.dev/imsg).
+
+## What this does *not* do
+
+- **Not a phone bridge.** You can use BlueBubbles' own iOS/Android app features alongside this if you want, but Aileron doesn't need them. Skip Firebase / Google during BlueBubbles' setup wizard.
+- **Not for received-message webhooks.** v1 of Aileron's iMessage connector is pull-only. Reacting to new incoming messages in real time is a v3 conversation.
+- **Not a Mac-less option.** BlueBubbles needs the Mac to be running and signed in to iMessage. There is no way around this; iMessage is Apple-only by design.
+
+## See also
+
+- [BlueBubbles documentation](https://bluebubbles.app/docs/)
+- [Installing a Connector](/guides/installing-a-connector/)
+- [Wrapping a CLI](/guides/wrapping-a-cli/) — for the spawn-primitive pattern used by other connectors (not this one; iMessage uses HTTP instead).

--- a/docs/src/content/docs/guides/wrapping-a-cli.md
+++ b/docs/src/content/docs/guides/wrapping-a-cli.md
@@ -5,7 +5,9 @@ description: "Turn a local CLI into an Aileron action surface with one command. 
 
 If you have a CLI installed on your machine, you can give your agent access to it under Aileron's capability bounds without writing or building a connector. The `aileron action wrap` command does the work: it generates a manifest, lands it in the daemon's connector store, writes action files under `~/.aileron/actions/`, and the wrapped subcommands become tool calls the agent can invoke.
 
-This is the spawn primitive's payoff (per [ADR-0002](/adr/0002-connector-model)'s spawn-primitive section). Where [Authoring a Connector](/guides/authoring-a-connector/) is the path for new services that need their own WASM, this guide is the path for the long tail of existing CLIs (`git`, `gh`, `slackdump`, `imsg`, anything POSIX) that already do the work you want the agent to compose with.
+This is the spawn primitive's payoff (per [ADR-0002](/adr/0002-connector-model)'s spawn-primitive section). Where [Authoring a Connector](/guides/authoring-a-connector/) is the path for new services that need their own WASM, this guide is the path for the long tail of existing CLIs (`git`, `gh`, `slackdump`, anything POSIX) that already do the work you want the agent to compose with.
+
+> **Not for iMessage.** Apple's data model is locked down enough that there is no usable CLI to wrap. The iMessage connector takes a different path: it talks over HTTP to a local [BlueBubbles](https://bluebubbles.app/) bridge that holds the platform permissions instead. See [Setting up BlueBubbles for Aileron](/guides/setting-up-bluebubbles/).
 
 ## What you get
 
@@ -252,3 +254,4 @@ The daemon rebuilds its index on next start. A more polished `aileron connector 
 - [ADR-0014: Spawn Sandbox Technology](/adr/0014-spawn-sandbox-technology) — what kernel mechanism confines the subprocess on each platform.
 - [Authoring a Connector](/guides/authoring-a-connector/) — for services that need their own WASM rather than a CLI wrap.
 - [Publishing a Connector](/guides/publishing-a-connector/) — if you want to publish your manifest under a stable FQN for others to install.
+- [Setting up BlueBubbles for Aileron](/guides/setting-up-bluebubbles/) — the iMessage path, which uses HTTP-to-a-local-bridge instead of a CLI wrap.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -62,6 +62,7 @@ export const navigation: NavItem[] = [
       { label: 'Installing an Action', href: '/guides/installing-an-action/' },
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },
       { label: 'Wrapping a CLI', href: '/guides/wrapping-a-cli/' },
+      { label: 'Setting up BlueBubbles for Aileron', href: '/guides/setting-up-bluebubbles/' },
       { label: 'Authoring an Action', href: '/guides/authoring-an-action/' },
       { label: 'Authoring an Action Suite', href: '/guides/authoring-an-action-suite/' },
       { label: 'Publishing a Connector', href: '/guides/publishing-a-connector/' },


### PR DESCRIPTION
## Summary

Lands the docs decisions from the resolution of #514. The iMessage connector will use [BlueBubbles](https://bluebubbles.app/) as a local HTTP bridge rather than touching Messages.app directly; this PR ships the prerequisite setup guide that users follow once per Mac and corrects the Wrapping a CLI guide where it implied imsg was a spawn-wrap candidate.

## Closes

- Closes #514 (decision posted as a comment on the issue and the issue is closed).

## What lands

- **New guide: `/guides/setting-up-bluebubbles/`** — a five-minute, one-time prereq covering BlueBubbles Server install, the macOS permission grants (Full Disk Access + Automation on BlueBubbles, **not** on Aileron), the localhost reachability check via `curl`, the Aileron connector install + credential binding, and a troubleshooting block keyed to the structured error codes the connector will surface (`bridge_unreachable`, `unauthorized`, `permission_denied`, wrong port).
- **Wrapping a CLI guide correction** — drops `imsg` from the "long tail of CLIs" intro list and adds a callout pointing readers to the BlueBubbles guide for the iMessage case. iMessage is decisively *not* a spawn-wrap candidate; the wrap guide should not suggest otherwise.
- **Sidebar nav** — new entry under Guides immediately after "Wrapping a CLI" so the BlueBubbles page is discoverable alongside other connector-onboarding material.

## Decision context (also at issue #514)

The full write-up is in [the #514 comment](https://github.com/ALRubinger/aileron/issues/514#issuecomment-4419292965). Short version:

1. **Architectural fit** — the iMessage connector is a v1-shape HTTP connector: `[capabilities.network]` for `localhost:1234`, `[capabilities.credential]` for the BlueBubbles password. No spawn primitive, no AppleScript.
2. **ToS posture moves off Aileron** — BlueBubbles is the entity touching Messages.app; Aileron is an HTTP client talking to a localhost server it didn't write.
3. **Permissions surface stays small** — the user grants Full Disk Access + Automation to BlueBubbles, not Aileron's daemon.
4. **Generalizable** — bridge-daemon-plus-localhost-HTTP fits other locked-down platforms (WhatsApp via matrix-appservice-whatsapp, Signal via signald, on-prem corporate chat relays). v2's iMessage case prototypes the v3+ bridged-services category.

## Test plan

- [x] `pnpm build` in `docs/` clean (81 pages, +1 from new guide).
- [x] Cross-links resolve: setup guide ↔ wrap guide ↔ Installing a Connector.
- [ ] Reviewer: tone-check the setup guide for user-friendliness; troubleshooting block matches the structured error codes the connector will eventually emit.

## Up next (outside this PR)

- The actual `aileron-connector-imsg` repo is external, parallel to #513 (Slack HTTP). Both follow the v1 connector model.
- A future PR can add a hub entry linking back to the setup guide once the connector ships.

🤖 Generated with [Claude Code](https://claude.com/claude-code)