### PR TITLE
docs(bluebubbles): rename connector FQN from imsg to bluebubbles

### DIFF
--- a/docs/src/content/docs/guides/setting-up-bluebubbles.md
+++ b/docs/src/content/docs/guides/setting-up-bluebubbles.md
@@ -50,7 +50,7 @@ If you changed the default port during setup, substitute that port number in the
 ## 4. Install Aileron's iMessage connector
 
 ```sh
-aileron connector install github://ALRubinger/aileron-connector-imsg@latest
+aileron connector install github://ALRubinger/aileron-connector-bluebubbles@latest
 ```
 
 Aileron prompts you for the BlueBubbles server password you set in step 1. Paste it in. The credential lands in your Aileron vault encrypted; Aileron's connector reads it only at call time, and the bytes never reach the agent.
@@ -62,7 +62,7 @@ If your BlueBubbles is on a non-default port, you'll see a follow-up prompt for 
 Install one of the iMessage actions, then ask your agent something simple:
 
 ```sh
-aileron action add github://ALRubinger/aileron-connector-imsg/actions/list-recent-chats@latest
+aileron action add github://ALRubinger/aileron-connector-bluebubbles/actions/list-recent-chats@latest
 aileron launch claude
 ```
 
@@ -76,7 +76,7 @@ The agent should return a list of recent chats. If you see a `bridge_unreachable
 
 **`permission_denied` or similar OS-level error**: You probably granted BlueBubbles Full Disk Access but not Automation (or vice versa). Re-check both *System Settings → Privacy & Security → Full Disk Access* and *Automation* per step 2, then relaunch BlueBubbles.
 
-**`unauthorized` from BlueBubbles**: The password Aileron is sending doesn't match the one BlueBubbles expects. Run `aileron binding setup github://ALRubinger/aileron-connector-imsg` to re-bind with the correct password.
+**`unauthorized` from BlueBubbles**: The password Aileron is sending doesn't match the one BlueBubbles expects. Run `aileron binding setup github://ALRubinger/aileron-connector-bluebubbles` to re-bind with the correct password.
 
 **Wrong port**: If you changed BlueBubbles' port during setup, Aileron needs to know. Update the URL by re-running `aileron binding setup` for the connector and providing the new URL when prompted.
 


### PR DESCRIPTION
## Summary

Small follow-up to [#606](https://github.com/ALRubinger/aileron/pull/606). Renames the three FQN references in the BlueBubbles setup guide from `aileron-connector-imsg` to `aileron-connector-bluebubbles` to match the actual connector repo.

## Why

The connector implementation is tightly bound to BlueBubbles: the manifest pins `localhost:1234`, the WASM code hits BlueBubbles-specific endpoints (`/api/v1/chat/query`, `/api/v1/message/text`), and the structured errors name BlueBubbles directly. Calling the FQN `connector-imsg` implied an iMessage abstraction the implementation does not deliver.

Per Aileron's connector-per-service model (ADR-0002), the connector now names what it is. A future iMessage bridge — Mautrix's BlueBubbles adapter, a hypothetical XPC-based local adapter, anything else — is a sibling connector that exposes actions with the same `[match].intent`. The "iMessage" abstraction lives at the action layer (each action's intent phrase), not at the FQN.

## What changes

Three line-level FQN substitutions in `docs/src/content/docs/guides/setting-up-bluebubbles.md`:
- `aileron connector install github://ALRubinger/aileron-connector-bluebubbles@latest`
- `aileron action add github://ALRubinger/aileron-connector-bluebubbles/actions/list-recent-chats@latest`
- `aileron binding setup github://ALRubinger/aileron-connector-bluebubbles` (troubleshooting section)

The new connector repo at `aileron-connector-bluebubbles` matches.

## Test plan

- [x] `pnpm build` in `docs/` clean (81 pages).
- [x] No `connector-imsg` references remain in the guide.

🤖 Generated with [Claude Code](https://claude.com/claude-code)