### PR TITLE
fix(docs): collapse brew tap + install into one command

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -37,7 +37,7 @@ Estimated time: 5 minutes. What happens: Summarize five most recent emails, draf
         label: "macOS",
         lang: "sh",
         note: 'Uses <a href="https://brew.sh">Homebrew</a>. Don\'t have it yet? Install it first.',
-        code: "brew tap ALRubinger/aileron\nbrew install aileron",
+        code: "brew install --cask ALRubinger/aileron/aileron",
       },
       {
         value: "linux",

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -22,7 +22,7 @@ import EyeOff from '@lucide/svelte/icons/eye-off';
 You'd never hand an agent the keys to your email, your calendar, your messaging services. You don't have to.
 
 ```sh
-$ brew install aileron
+$ brew install --cask ALRubinger/aileron/aileron
 $ aileron launch
 
   First launch — let's configure your upstream LLM.


### PR DESCRIPTION
## Summary

`brew install <user>/<tap-suffix>/<cask>` auto-taps the source repo on first use, so the documented two-step install collapses to a single command:

\`\`\`sh
brew install --cask ALRubinger/aileron/aileron
\`\`\`

\`--cask\` is the canonical, future-proof form for cask installs (the tap-qualified triple would also work today without \`--cask\` because the tap only contains casks, but explicit is better).

## Changes

- \`docs/src/content/docs/getting-started.mdx:40\` — the install tab's macOS code block.
- \`docs/src/content/docs/index.mdx:25\` — the homepage hero snippet was \`brew install aileron\`, which fails on a fresh machine because the tap isn't present yet.

## Test plan

- [x] \`task build:docs\` clean.
- [x] Rendered HTML in \`docs/dist/getting-started/\` and \`docs/dist/index.html\` shows the new command.
- [ ] After merge, click through on the live site to verify both code blocks render and copy correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)