### PR TITLE
docs(actions/slack): add workspace install prerequisite

### DIFF
--- a/docs/src/content/docs/actions/slack.md
+++ b/docs/src/content/docs/actions/slack.md
@@ -12,11 +12,11 @@ Posts are made with the authorizing user's token, not as a bot. Messages appear 
 
 ## Prerequisite
 
-The Aileron Slack app must be installed into your workspace before OAuth consent can complete. For most workspaces this happens automatically as part of `aileron binding setup`: the first authorization from a workspace installs the app there as a side effect of the OAuth dance, and subsequent users in the same workspace skip straight to the consent screen.
+The Aileron Slack app must be installed into your workspace. `aileron action add` (and `add-suite`) handles this for you: the CLI opens Slack's consent screen in your browser, and clicking Allow installs the app and authorizes your user in one step.
 
-If your workspace gates third-party apps behind admin approval (Settings → Permissions → "Require App Approval"), the OAuth flow offers to send an install request to a workspace admin instead of completing authorization. Ask an admin to approve the request, then re-run `aileron binding setup`. The four scopes the admin sees during approval are the same ones listed in [Scopes the consent screen asks for](#scopes-the-consent-screen-asks-for) below; nothing additional is requested.
+If your workspace requires admin approval for third-party apps, Slack shows a "Request to install" button instead of Allow. A workspace admin approves the request, then you re-run the same `aileron action add` command.
 
-Workspaces that disable third-party apps entirely cannot use this connector. The Aileron Slack app is registered by the connector publisher (`ALRubinger`); your workspace admin chooses whether to allow it. No part of `aileron-connector-slack` can bypass that choice.
+The Aileron Slack app is not on the Slack Marketplace, so there's no App Directory page to install from. The CLI is the install path.
 
 ## Install
 

--- a/docs/src/content/docs/actions/slack.md
+++ b/docs/src/content/docs/actions/slack.md
@@ -10,6 +10,14 @@ The suite is published from the [`aileron-connector-slack`](https://github.com/A
 
 Posts are made with the authorizing user's token, not as a bot. Messages appear in Slack authored by the user. This is the right shape for the Monday catch-up demo and for power-user automation generally; it is the wrong shape if you want a dedicated app identity for posts.
 
+## Prerequisite
+
+The Aileron Slack app must be installed into your workspace before OAuth consent can complete. For most workspaces this happens automatically as part of `aileron binding setup`: the first authorization from a workspace installs the app there as a side effect of the OAuth dance, and subsequent users in the same workspace skip straight to the consent screen.
+
+If your workspace gates third-party apps behind admin approval (Settings → Permissions → "Require App Approval"), the OAuth flow offers to send an install request to a workspace admin instead of completing authorization. Ask an admin to approve the request, then re-run `aileron binding setup`. The four scopes the admin sees during approval are the same ones listed in [Scopes the consent screen asks for](#scopes-the-consent-screen-asks-for) below; nothing additional is requested.
+
+Workspaces that disable third-party apps entirely cannot use this connector. The Aileron Slack app is registered by the connector publisher (`ALRubinger`); your workspace admin chooses whether to allow it. No part of `aileron-connector-slack` can bypass that choice.
+
 ## Install
 
 ### Whole suite (recommended)


### PR DESCRIPTION
## Summary

The Slack action page (added in #611) didn't say that the Aileron Slack app must be installed into the user's workspace before OAuth consent can complete. Adds a Prerequisite section covering the three cases:

- **Most workspaces**: install happens automatically as a side effect of the first user's OAuth dance.
- **Workspaces with \"Require App Approval\"**: OAuth flow sends an install request to a workspace admin; the user re-runs \`aileron binding setup\` after approval. Pointer to the existing scope list (same scopes the admin sees).
- **Workspaces with third-party apps fully disabled**: can't use the connector. Explicit language that the connector cannot bypass workspace policy.

## Test plan

- [x] \`task build:docs\` clean.
- [x] Rendered \`<h2 id=\"prerequisite\">\` plus three paragraphs verified in \`docs/dist/actions/slack/index.html\`.
- [x] Auto-anchor link \`#scopes-the-consent-screen-asks-for\` resolves to the existing section.
- [ ] After merge, click through on the live site and confirm the new section reads correctly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)