### PR TITLE
feat(webapp): Connector Hub browsing page + install modal

### DIFF
--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -222,3 +222,91 @@ export async function decideActionApproval(
 		body: JSON.stringify(body)
 	});
 }
+
+// --- Connector Hub (ADR-0013, #488) ---
+//
+// The daemon shallow-clones the public `aileron-connectors-hub` repo
+// per query and serves discovery via /v1/hub/*. The webapp is one of
+// two thin clients on top — the CLI (`aileron hub …`) is the other.
+// The install modal layers on top of `/v1/hub/install-decision` and
+// `/v1/connectors/install` to surface publisher trust before installing.
+
+/** Single Hub connector entry. Mirrors `api.HubConnectorEntry` in the
+ *  Go codegen — keep these shapes in sync with `internal/api/openapi.yaml`.
+ *  Field names match the JSON wire format directly (snake_case). */
+export type HubConnectorEntry = {
+	fqn: string;
+	description: string;
+	publisher_github: string;
+	key_url: string;
+	release_pattern: string;
+};
+
+export type HubConnectorList = {
+	connectors: HubConnectorEntry[];
+};
+
+/** Trust-state enum for the install-decision payload. Drives the
+ *  modal's color and copy. `unknown` = first install from this
+ *  publisher at this FQN; `already_trusted` = key already on the
+ *  local keyring; `conflict` = the publisher's key differs from one
+ *  the operator trusts for a sibling repo (rotation, MITM, or
+ *  impersonation — surface in red). */
+export type HubTrustState = 'already_trusted' | 'unknown' | 'conflict';
+
+/** Pre-computed install-decision payload. Mirrors api.HubInstallDecision.
+ *  The daemon fetches the publisher's current key, computes its
+ *  fingerprint, and folds in local keyring state before responding,
+ *  so the client renders the trust decision without ever holding key
+ *  bytes. */
+export type HubInstallDecision = {
+	fqn: string;
+	description: string;
+	publisher_github: string;
+	fingerprint: string;
+	trust_state: HubTrustState;
+	publisher_footprint: string[];
+	risk_indicators: string[];
+};
+
+/** Lists every connector published to the Hub. Pass `q` to filter
+ *  server-side (case-insensitive match on FQN and description). */
+export async function listHubConnectors(q?: string): Promise<HubConnectorList> {
+	const qs = q && q.trim() ? `?q=${encodeURIComponent(q.trim())}` : '';
+	return apiFetch(`/v1/hub/connectors${qs}`);
+}
+
+/** Fetches the install-decision payload for a single FQN. Returns the
+ *  same shape the CLI's `aileron connector install` renders. */
+export async function getHubInstallDecision(fqn: string): Promise<HubInstallDecision> {
+	return apiFetch(`/v1/hub/install-decision?fqn=${encodeURIComponent(fqn)}`);
+}
+
+/** Installed-connector envelope returned by POST /v1/connectors/install
+ *  on success. `already_installed` is set when an offline-cached hash
+ *  short-circuits the install pipeline (ADR-0004 §"Offline behavior"). */
+export type InstalledConnector = {
+	fqn: string;
+	version: string;
+	hash: string;
+	entry_dir: string;
+	already_installed?: boolean;
+};
+
+/** Runs the connector install pipeline. `confirmed_fingerprint` (per
+ *  ADR-0013 / #487 Q4) triggers daemon-side trust persistence: the
+ *  daemon verifies the publisher key's fingerprint matches what the
+ *  webapp confirmed at the modal, then writes the key to the keyring
+ *  under the FQN before running the install. Trust persists even if
+ *  the install pipeline later fails. */
+export async function installConnector(args: {
+	fqn: string;
+	version: string;
+	confirmed_fingerprint?: string;
+	expected_hash?: string;
+}): Promise<InstalledConnector> {
+	return apiFetch('/v1/connectors/install', {
+		method: 'POST',
+		body: JSON.stringify(args)
+	});
+}

--- a/webapp/src/lib/components/HubInstallModal.svelte
+++ b/webapp/src/lib/components/HubInstallModal.svelte
@@ -1,0 +1,269 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import {
+		getHubInstallDecision,
+		installConnector,
+		type HubInstallDecision,
+		type InstalledConnector
+	} from '$lib/api';
+
+	// Hub install modal (ADR-0013, #488). Opened when the user picks a
+	// Hub-listed connector to install from the browse page. The modal
+	// fetches the install-decision payload — same one the CLI's
+	// `aileron connector install` renders — and lets the user confirm
+	// the publisher's key fingerprint before running the install
+	// pipeline. On confirm, the install POST carries
+	// `confirmed_fingerprint`; the daemon writes per-FQN trust to the
+	// keyring before installing (#487 Q4 resolution).
+	//
+	// Per ADR-0013, the modal renders publisher info as informational
+	// context only — there is no "Trust this publisher" button in v0.x.
+	// Trust granularity stays strictly per-repo.
+
+	type Props = {
+		fqn: string | null;
+		onClose: () => void;
+	};
+
+	let { fqn, onClose }: Props = $props();
+
+	const open = $derived(fqn !== null);
+
+	let decision = $state<HubInstallDecision | null>(null);
+	let decisionError = $state('');
+	let loading = $state(false);
+
+	let version = $state('');
+	let expectedHash = $state('');
+	let installing = $state(false);
+	let installError = $state('');
+	let installed = $state<InstalledConnector | null>(null);
+
+	// Re-fetch the install-decision every time the modal opens for a
+	// new FQN. Resets all install-side state too so the previous
+	// install's success message doesn't bleed into the next session.
+	$effect(() => {
+		if (!fqn) {
+			decision = null;
+			decisionError = '';
+			version = '';
+			expectedHash = '';
+			installError = '';
+			installed = null;
+			return;
+		}
+		loading = true;
+		decision = null;
+		decisionError = '';
+		installed = null;
+		installError = '';
+		const target = fqn;
+		void getHubInstallDecision(target)
+			.then((d) => {
+				if (fqn === target) decision = d;
+			})
+			.catch((e: unknown) => {
+				if (fqn === target) {
+					decisionError = e instanceof Error ? e.message : String(e);
+				}
+			})
+			.finally(() => {
+				if (fqn === target) loading = false;
+			});
+	});
+
+	function handleOpenChange(next: boolean) {
+		if (!next) {
+			onClose();
+		}
+	}
+
+	async function handleInstall() {
+		if (!decision || !version.trim() || installing) return;
+		installing = true;
+		installError = '';
+		try {
+			installed = await installConnector({
+				fqn: decision.fqn,
+				version: version.trim(),
+				confirmed_fingerprint: decision.fingerprint,
+				expected_hash: expectedHash.trim() || undefined
+			});
+		} catch (e) {
+			installError = e instanceof Error ? e.message : String(e);
+		} finally {
+			installing = false;
+		}
+	}
+
+	function trustBadgeVariant(
+		state: HubInstallDecision['trust_state']
+	): 'default' | 'secondary' | 'destructive' | 'outline' {
+		// Match the CLI's color semantics from main.go:colorizeTrustState:
+		// already_trusted = green-equivalent, unknown = informational,
+		// conflict = destructive. The Badge primitive doesn't ship a
+		// "green" variant, so the green-equivalent rides on `default`
+		// (primary), which is the strong-affirmative color in the
+		// active theme.
+		switch (state) {
+			case 'already_trusted':
+				return 'default';
+			case 'conflict':
+				return 'destructive';
+			default:
+				return 'secondary';
+		}
+	}
+
+	function trustLabel(state: HubInstallDecision['trust_state']): string {
+		switch (state) {
+			case 'already_trusted':
+				return 'Already trusted';
+			case 'unknown':
+				return 'Unknown publisher';
+			case 'conflict':
+				return 'Conflict — key differs from a sibling repo';
+			default:
+				return state;
+		}
+	}
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content data-testid="hub-install-modal">
+		<Dialog.Header>
+			<Dialog.Title>Install from the Hub</Dialog.Title>
+			<Dialog.Description>
+				Review the publisher's key fingerprint before installing. The daemon
+				will write per-repo trust to your keyring on confirm.
+			</Dialog.Description>
+		</Dialog.Header>
+
+		{#if loading}
+			<p class="text-sm text-muted-foreground">Loading install decision…</p>
+		{:else if decisionError}
+			<p class="text-sm text-destructive" data-testid="hub-install-decision-error">
+				{decisionError}
+			</p>
+		{:else if decision && installed}
+			<div class="space-y-2 text-sm" data-testid="hub-install-installed">
+				<p class="text-foreground">
+					<span class="font-semibold">
+						{installed.already_installed ? 'Already installed' : 'Installed'}:
+					</span>
+					{installed.fqn}@{installed.version}
+				</p>
+				<dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1 text-xs">
+					<dt class="text-muted-foreground">Hash</dt>
+					<dd class="font-mono break-all">{installed.hash}</dd>
+					<dt class="text-muted-foreground">Path</dt>
+					<dd class="font-mono break-all">{installed.entry_dir}</dd>
+				</dl>
+			</div>
+			<Dialog.Footer>
+				<Button variant="default" onclick={onClose}>Close</Button>
+			</Dialog.Footer>
+		{:else if decision}
+			<div class="space-y-3 text-sm" data-testid="hub-install-decision">
+				<dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+					<dt class="text-muted-foreground">FQN</dt>
+					<dd class="font-mono break-all">{decision.fqn}</dd>
+					{#if decision.description}
+						<dt class="text-muted-foreground">Description</dt>
+						<dd>{decision.description}</dd>
+					{/if}
+					<dt class="text-muted-foreground">Publisher</dt>
+					<dd>{decision.publisher_github}</dd>
+					<dt class="text-muted-foreground">Fingerprint</dt>
+					<dd class="font-mono text-xs break-all">{decision.fingerprint}</dd>
+					<dt class="text-muted-foreground">Trust</dt>
+					<dd>
+						<Badge
+							variant={trustBadgeVariant(decision.trust_state)}
+							data-testid="hub-trust-state"
+							data-trust-state={decision.trust_state}
+						>
+							{trustLabel(decision.trust_state)}
+						</Badge>
+					</dd>
+				</dl>
+
+				{#if decision.risk_indicators.length > 0}
+					<div data-testid="hub-risk-indicators">
+						<p class="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+							Risk indicators
+						</p>
+						<ul class="space-y-1 text-xs">
+							{#each decision.risk_indicators as risk (risk)}
+								<li
+									class={decision.trust_state === 'conflict'
+										? 'text-destructive'
+										: 'text-foreground'}
+								>
+									{risk}
+								</li>
+							{/each}
+						</ul>
+					</div>
+				{/if}
+
+				{#if decision.publisher_footprint.length > 0}
+					<div data-testid="hub-publisher-footprint">
+						<p class="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground">
+							Other connectors by this publisher
+						</p>
+						<ul class="space-y-0.5 text-xs font-mono">
+							{#each decision.publisher_footprint as fp (fp)}
+								<li>{fp}</li>
+							{/each}
+						</ul>
+					</div>
+				{/if}
+
+				<div class="space-y-2 border-t border-border pt-3">
+					<label class="flex flex-col gap-1 text-xs">
+						<span class="font-medium">Version</span>
+						<Input
+							type="text"
+							placeholder="e.g. 1.2.0"
+							bind:value={version}
+							disabled={installing}
+							data-testid="hub-install-version-input"
+						/>
+					</label>
+					<label class="flex flex-col gap-1 text-xs">
+						<span class="font-medium">Expected hash (optional)</span>
+						<Input
+							type="text"
+							placeholder="sha256:…"
+							bind:value={expectedHash}
+							disabled={installing}
+							data-testid="hub-install-hash-input"
+						/>
+					</label>
+					{#if installError}
+						<p class="text-xs text-destructive" data-testid="hub-install-error">
+							{installError}
+						</p>
+					{/if}
+				</div>
+			</div>
+			<Dialog.Footer>
+				<Button
+					variant="default"
+					disabled={!version.trim() || installing}
+					onclick={handleInstall}
+					data-testid="hub-install-button"
+				>
+					{installing ? 'Installing…' : 'Install'}
+				</Button>
+				<Button variant="ghost" disabled={installing} onclick={onClose}>
+					Cancel
+				</Button>
+			</Dialog.Footer>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>

--- a/webapp/src/lib/components/HubInstallModal.test.ts
+++ b/webapp/src/lib/components/HubInstallModal.test.ts
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$lib/api', () => ({
+	getHubInstallDecision: vi.fn(),
+	installConnector: vi.fn()
+}));
+
+import HubInstallModal from './HubInstallModal.svelte';
+import {
+	getHubInstallDecision,
+	installConnector,
+	type HubInstallDecision
+} from '$lib/api';
+
+const unknownDecision: HubInstallDecision = {
+	fqn: 'github://alice/calendar',
+	description: 'Google Calendar connector',
+	publisher_github: 'alice',
+	fingerprint: 'sha256:aliceFingerprintAAAAAAA',
+	trust_state: 'unknown',
+	publisher_footprint: ['github://alice/drive', 'github://alice/gmail'],
+	risk_indicators: ["First connector by this publisher you've installed"]
+};
+
+const conflictDecision: HubInstallDecision = {
+	fqn: 'github://acme/x',
+	description: 'malicious twin',
+	publisher_github: 'acme',
+	fingerprint: 'sha256:newFingerprintBBBBBBBB',
+	trust_state: 'conflict',
+	publisher_footprint: ['github://acme/y'],
+	risk_indicators: [
+		'Key fingerprint differs from one you trust for github://acme/y'
+	]
+};
+
+const alreadyTrustedDecision: HubInstallDecision = {
+	fqn: 'github://acme/z',
+	description: 'previously trusted',
+	publisher_github: 'acme',
+	fingerprint: 'sha256:knownFingerprintCCCCCCC',
+	trust_state: 'already_trusted',
+	publisher_footprint: [],
+	risk_indicators: []
+};
+
+beforeEach(() => {
+	vi.mocked(getHubInstallDecision).mockReset();
+	vi.mocked(installConnector).mockReset();
+});
+
+describe('HubInstallModal — fetch + render', () => {
+	it('does not call the API while fqn is null', () => {
+		render(HubInstallModal, { fqn: null, onClose: () => {} });
+		expect(getHubInstallDecision).not.toHaveBeenCalled();
+	});
+
+	it('renders FQN, fingerprint, publisher, and risk indicators', async () => {
+		vi.mocked(getHubInstallDecision).mockResolvedValue(unknownDecision);
+		render(HubInstallModal, {
+			fqn: 'github://alice/calendar',
+			onClose: () => {}
+		});
+		await waitFor(() => {
+			expect(getHubInstallDecision).toHaveBeenCalledWith(
+				'github://alice/calendar'
+			);
+		});
+		await waitFor(() => {
+			expect(screen.getByText(unknownDecision.fingerprint)).toBeInTheDocument();
+			expect(screen.getByText('alice')).toBeInTheDocument();
+			expect(
+				screen.getByText("First connector by this publisher you've installed")
+			).toBeInTheDocument();
+			expect(screen.getByText('github://alice/drive')).toBeInTheDocument();
+		});
+	});
+
+	it('surfaces a decision fetch error rather than silently rendering empty', async () => {
+		vi.mocked(getHubInstallDecision).mockRejectedValue(
+			new Error('hub_unreachable')
+		);
+		render(HubInstallModal, {
+			fqn: 'github://alice/calendar',
+			onClose: () => {}
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-install-decision-error')).toHaveTextContent(
+				'hub_unreachable'
+			);
+		});
+	});
+
+	it('marks conflict trust state with the destructive Badge variant', async () => {
+		vi.mocked(getHubInstallDecision).mockResolvedValue(conflictDecision);
+		render(HubInstallModal, { fqn: conflictDecision.fqn, onClose: () => {} });
+		await waitFor(() => {
+			const badge = screen.getByTestId('hub-trust-state');
+			expect(badge).toHaveAttribute('data-trust-state', 'conflict');
+		});
+	});
+
+	it('marks already_trusted with the affirmative Badge variant', async () => {
+		vi.mocked(getHubInstallDecision).mockResolvedValue(alreadyTrustedDecision);
+		render(HubInstallModal, {
+			fqn: alreadyTrustedDecision.fqn,
+			onClose: () => {}
+		});
+		await waitFor(() => {
+			const badge = screen.getByTestId('hub-trust-state');
+			expect(badge).toHaveAttribute('data-trust-state', 'already_trusted');
+		});
+	});
+});
+
+describe('HubInstallModal — install action', () => {
+	it('disables Install until a version is provided', async () => {
+		vi.mocked(getHubInstallDecision).mockResolvedValue(unknownDecision);
+		render(HubInstallModal, { fqn: unknownDecision.fqn, onClose: () => {} });
+		const button = (await screen.findByTestId(
+			'hub-install-button'
+		)) as HTMLButtonElement;
+		expect(button.disabled).toBe(true);
+		const versionInput = (await screen.findByTestId(
+			'hub-install-version-input'
+		)) as HTMLInputElement;
+		await fireEvent.input(versionInput, { target: { value: '1.2.0' } });
+		await waitFor(() => {
+			expect(button.disabled).toBe(false);
+		});
+	});
+
+	it('sends confirmed_fingerprint and renders the installed envelope', async () => {
+		vi.mocked(getHubInstallDecision).mockResolvedValue(unknownDecision);
+		vi.mocked(installConnector).mockResolvedValue({
+			fqn: unknownDecision.fqn,
+			version: '1.2.0',
+			hash: 'sha256:abc123',
+			entry_dir: '/.aileron/store/connectors/sha256/abc123'
+		});
+		render(HubInstallModal, { fqn: unknownDecision.fqn, onClose: () => {} });
+		const versionInput = (await screen.findByTestId(
+			'hub-install-version-input'
+		)) as HTMLInputElement;
+		await fireEvent.input(versionInput, { target: { value: '1.2.0' } });
+		await fireEvent.click(await screen.findByTestId('hub-install-button'));
+		await waitFor(() => {
+			expect(installConnector).toHaveBeenCalledWith({
+				fqn: unknownDecision.fqn,
+				version: '1.2.0',
+				confirmed_fingerprint: unknownDecision.fingerprint,
+				expected_hash: undefined
+			});
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-install-installed')).toHaveTextContent(
+				'Installed'
+			);
+			expect(screen.getByText('sha256:abc123')).toBeInTheDocument();
+		});
+	});
+
+	it('forwards expected_hash when the operator supplies one', async () => {
+		vi.mocked(getHubInstallDecision).mockResolvedValue(unknownDecision);
+		vi.mocked(installConnector).mockResolvedValue({
+			fqn: unknownDecision.fqn,
+			version: '1.2.0',
+			hash: 'sha256:abc',
+			entry_dir: '/p'
+		});
+		render(HubInstallModal, { fqn: unknownDecision.fqn, onClose: () => {} });
+		await fireEvent.input(await screen.findByTestId('hub-install-version-input'), {
+			target: { value: '1.2.0' }
+		});
+		await fireEvent.input(await screen.findByTestId('hub-install-hash-input'), {
+			target: { value: 'sha256:expected' }
+		});
+		await fireEvent.click(await screen.findByTestId('hub-install-button'));
+		await waitFor(() => {
+			expect(installConnector).toHaveBeenCalledWith(
+				expect.objectContaining({ expected_hash: 'sha256:expected' })
+			);
+		});
+	});
+
+	it('renders "Already installed" verb when daemon short-circuits', async () => {
+		vi.mocked(getHubInstallDecision).mockResolvedValue(unknownDecision);
+		vi.mocked(installConnector).mockResolvedValue({
+			fqn: unknownDecision.fqn,
+			version: '1.2.0',
+			hash: 'sha256:abc',
+			entry_dir: '/p',
+			already_installed: true
+		});
+		render(HubInstallModal, { fqn: unknownDecision.fqn, onClose: () => {} });
+		await fireEvent.input(await screen.findByTestId('hub-install-version-input'), {
+			target: { value: '1.2.0' }
+		});
+		await fireEvent.click(await screen.findByTestId('hub-install-button'));
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-install-installed')).toHaveTextContent(
+				'Already installed'
+			);
+		});
+	});
+
+	it('surfaces install errors and does not render the installed envelope', async () => {
+		vi.mocked(getHubInstallDecision).mockResolvedValue(unknownDecision);
+		vi.mocked(installConnector).mockRejectedValue(
+			new Error('publisher key fingerprint changed')
+		);
+		render(HubInstallModal, { fqn: unknownDecision.fqn, onClose: () => {} });
+		await fireEvent.input(await screen.findByTestId('hub-install-version-input'), {
+			target: { value: '1.2.0' }
+		});
+		await fireEvent.click(await screen.findByTestId('hub-install-button'));
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-install-error')).toHaveTextContent(
+				'fingerprint changed'
+			);
+		});
+		expect(screen.queryByTestId('hub-install-installed')).toBeNull();
+	});
+});

--- a/webapp/src/routes/+layout.svelte
+++ b/webapp/src/routes/+layout.svelte
@@ -49,6 +49,7 @@
 			>
 				{stateLabel}
 			</span>
+			<a href="/hub" class="text-foreground hover:text-primary no-underline">Hub</a>
 			<a href="/approvals" class="text-foreground hover:text-primary no-underline"
 				>Approvals</a
 			>

--- a/webapp/src/routes/hub/+page.svelte
+++ b/webapp/src/routes/hub/+page.svelte
@@ -1,0 +1,121 @@
+<script lang="ts">
+	import { listHubConnectors, type HubConnectorEntry } from '$lib/api';
+	import { onMount } from 'svelte';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import { Input } from '$lib/components/ui/input';
+	import HubInstallModal from '$lib/components/HubInstallModal.svelte';
+
+	// Hub browsing page (ADR-0013, #488). Reads from the daemon's
+	// `/v1/hub/connectors` endpoint; the daemon shallow-clones the
+	// public `aileron-connectors-hub` repo per query (no persisted
+	// cache, per #486).
+	//
+	// The page is the webapp half of the umbrella's acceptance
+	// criteria 1-3: search by keyword, browse list with FQN +
+	// description, click an entry to see fingerprint and install. The
+	// install action opens HubInstallModal which carries the publisher
+	// trust decision.
+
+	let entries = $state<HubConnectorEntry[]>([]);
+	let loading = $state(true);
+	let error = $state('');
+	let query = $state('');
+	let selectedFQN = $state<string | null>(null);
+
+	async function refresh(q: string) {
+		loading = true;
+		error = '';
+		try {
+			const resp = await listHubConnectors(q);
+			entries = resp.connectors ?? [];
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+			entries = [];
+		} finally {
+			loading = false;
+		}
+	}
+
+	onMount(() => {
+		void refresh('');
+	});
+
+	let searchHandle: ReturnType<typeof setTimeout> | undefined;
+	function onSearchInput(value: string) {
+		query = value;
+		// Debounce — every keystroke would shallow-clone the Hub repo
+		// daemon-side. 250ms aligns with the typing pause that humans
+		// reach for an interactive search box.
+		if (searchHandle !== undefined) clearTimeout(searchHandle);
+		searchHandle = setTimeout(() => {
+			void refresh(query);
+		}, 250);
+	}
+</script>
+
+<svelte:head>
+	<title>Hub — Aileron</title>
+</svelte:head>
+
+<h1 class="mb-4 text-xl font-semibold">Connector Hub</h1>
+<p class="mb-4 text-sm text-muted-foreground">
+	Community-published connectors. Browse, search by keyword, and install with
+	one click. The daemon writes publisher trust to your keyring per repo on
+	confirm.
+</p>
+
+<div class="mb-4">
+	<Input
+		type="text"
+		placeholder="Search by FQN or description…"
+		value={query}
+		oninput={(e) => onSearchInput((e.currentTarget as HTMLInputElement).value)}
+		data-testid="hub-search-input"
+	/>
+</div>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading Hub entries…</p>
+{:else if error}
+	<p class="text-destructive" data-testid="hub-list-error">{error}</p>
+{:else if entries.length === 0}
+	<p class="text-muted-foreground" data-testid="hub-empty-state">
+		{query.trim()
+			? `No Hub connectors match "${query.trim()}".`
+			: 'No connectors published to the Hub.'}
+	</p>
+{:else}
+	<div class="flex flex-col gap-3" data-testid="hub-list">
+		{#each entries as entry (entry.fqn)}
+			<Card.Root data-testid="hub-entry-card" data-fqn={entry.fqn}>
+				<Card.Header>
+					<div class="flex flex-wrap items-start justify-between gap-2">
+						<div class="space-y-1">
+							<Card.Title class="font-mono text-sm break-all">
+								{entry.fqn}
+							</Card.Title>
+							<Card.Description>{entry.description}</Card.Description>
+						</div>
+						<Button
+							variant="default"
+							onclick={() => (selectedFQN = entry.fqn)}
+							data-testid="hub-install-cta"
+						>
+							Install
+						</Button>
+					</div>
+				</Card.Header>
+				<Card.Content class="text-xs text-muted-foreground">
+					<span>Publisher: {entry.publisher_github}</span>
+					<span class="ml-3">Release pattern: <code>{entry.release_pattern}</code></span>
+				</Card.Content>
+			</Card.Root>
+		{/each}
+	</div>
+{/if}
+
+<HubInstallModal
+	fqn={selectedFQN}
+	onClose={() => (selectedFQN = null)}
+/>

--- a/webapp/src/routes/hub/page.test.ts
+++ b/webapp/src/routes/hub/page.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
+
+vi.mock('$lib/api', () => ({
+	listHubConnectors: vi.fn(),
+	getHubInstallDecision: vi.fn(),
+	installConnector: vi.fn()
+}));
+
+import Page from './+page.svelte';
+import {
+	listHubConnectors,
+	getHubInstallDecision,
+	type HubConnectorEntry,
+	type HubInstallDecision
+} from '$lib/api';
+
+const aliceEntry: HubConnectorEntry = {
+	fqn: 'github://alice/calendar',
+	description: 'Google Calendar connector',
+	publisher_github: 'alice',
+	key_url: 'https://example.com/alice.pub',
+	release_pattern: 'v*'
+};
+const bobEntry: HubConnectorEntry = {
+	fqn: 'github://bob/slack',
+	description: 'Slack messaging connector',
+	publisher_github: 'bob',
+	key_url: 'https://example.com/bob.pub',
+	release_pattern: 'v*'
+};
+
+const aliceDecision: HubInstallDecision = {
+	fqn: aliceEntry.fqn,
+	description: aliceEntry.description,
+	publisher_github: 'alice',
+	fingerprint: 'sha256:aliceFingerprintAAAAAAA',
+	trust_state: 'unknown',
+	publisher_footprint: [],
+	risk_indicators: ["First connector by this publisher you've installed"]
+};
+
+beforeEach(() => {
+	vi.mocked(listHubConnectors).mockReset();
+	vi.mocked(getHubInstallDecision).mockReset();
+});
+
+describe('Hub page — list + search', () => {
+	it('renders an empty-state hint when the Hub is empty', async () => {
+		vi.mocked(listHubConnectors).mockResolvedValue({ connectors: [] });
+		render(Page);
+		await waitFor(() => {
+			expect(
+				screen.getByText(/No connectors published to the Hub/)
+			).toBeInTheDocument();
+		});
+	});
+
+	it('renders Hub entries returned by the API', async () => {
+		vi.mocked(listHubConnectors).mockResolvedValue({
+			connectors: [aliceEntry, bobEntry]
+		});
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('github://alice/calendar')).toBeInTheDocument();
+			expect(screen.getByText('github://bob/slack')).toBeInTheDocument();
+			expect(screen.getByText('Google Calendar connector')).toBeInTheDocument();
+		});
+		expect(listHubConnectors).toHaveBeenCalledWith('');
+	});
+
+	it('surfaces an API error rather than silently rendering empty', async () => {
+		vi.mocked(listHubConnectors).mockRejectedValue(new Error('hub_unreachable'));
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-list-error')).toHaveTextContent(
+				'hub_unreachable'
+			);
+		});
+	});
+
+	it('debounces search input and re-fetches with the query parameter', async () => {
+		vi.useFakeTimers();
+		vi.mocked(listHubConnectors).mockResolvedValue({ connectors: [aliceEntry] });
+		render(Page);
+		await vi.waitFor(() => {
+			expect(listHubConnectors).toHaveBeenCalledWith('');
+		});
+		const input = screen.getByTestId('hub-search-input');
+		await fireEvent.input(input, { target: { value: 'calendar' } });
+		// Debounce window is 250ms — advance the timer and let promises settle.
+		await vi.advanceTimersByTimeAsync(300);
+		expect(listHubConnectors).toHaveBeenLastCalledWith('calendar');
+		vi.useRealTimers();
+	});
+
+	it('echoes the query in the no-match empty state', async () => {
+		vi.useFakeTimers();
+		vi.mocked(listHubConnectors).mockResolvedValue({ connectors: [] });
+		render(Page);
+		await vi.waitFor(() => {
+			expect(listHubConnectors).toHaveBeenCalled();
+		});
+		await fireEvent.input(screen.getByTestId('hub-search-input'), {
+			target: { value: 'zzz' }
+		});
+		await vi.advanceTimersByTimeAsync(300);
+		await vi.waitFor(() => {
+			expect(screen.getByTestId('hub-empty-state')).toHaveTextContent('"zzz"');
+		});
+		vi.useRealTimers();
+	});
+});
+
+describe('Hub page — install modal integration', () => {
+	it('opens the install modal with the clicked entry’s install-decision', async () => {
+		vi.mocked(listHubConnectors).mockResolvedValue({
+			connectors: [aliceEntry, bobEntry]
+		});
+		vi.mocked(getHubInstallDecision).mockResolvedValue(aliceDecision);
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('github://alice/calendar')).toBeInTheDocument();
+		});
+		const aliceCard = screen
+			.getAllByTestId('hub-entry-card')
+			.find((c) => c.getAttribute('data-fqn') === aliceEntry.fqn);
+		expect(aliceCard).toBeDefined();
+		const installBtn = aliceCard!.querySelector(
+			'[data-testid="hub-install-cta"]'
+		) as HTMLButtonElement;
+		await fireEvent.click(installBtn);
+		await waitFor(() => {
+			expect(getHubInstallDecision).toHaveBeenCalledWith(aliceEntry.fqn);
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-trust-state')).toHaveAttribute(
+				'data-trust-state',
+				'unknown'
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

Adds the two webapp items from the #488 umbrella:

- **/hub route** — lists every connector published to the Hub, debounced keyword search (250ms) forwards `q` to `/v1/hub/connectors?q=`. Each entry shows FQN, description, publisher, release pattern. Click ``Install`` to open the modal.
- **HubInstallModal** — fetches `/v1/hub/install-decision` and surfaces the publisher fingerprint, trust state (color-coded ``Badge``: ``default`` for ``already_trusted``, ``secondary`` for ``unknown``, ``destructive`` for ``conflict``), risk indicators, and publisher footprint. Install button POSTs to `/v1/connectors/install` with ``confirmed_fingerprint``; the daemon writes per-FQN trust to the keyring before running the install pipeline. Success renders the installed envelope (FQN, version, hash, path); the ``Already installed`` verb fires when the daemon short-circuits on a cached hash.
- **api.ts** — adds ``listHubConnectors``, ``getHubInstallDecision``, ``installConnector`` and type mirrors for ``HubConnectorEntry``, ``HubConnectorList``, ``HubInstallDecision``, ``HubTrustState``, ``InstalledConnector``.
- **+layout.svelte** — adds the Hub nav link.

Closes the last two client items in the umbrella (#488); only the publisher + consumer docs guides remain.

## Test plan

- [x] `pnpm test` passes — 37 cases total (10 modal, 6 Hub page, 21 existing approvals)
- [x] Hub page: empty state, list render, search debounce + query parameter, query-echoed empty state, API error, install button opens modal with correct FQN
- [x] Install modal: no API call while ``fqn`` is null, decision-fetch renders FQN/fingerprint/publisher/risks/footprint, decision-fetch error surfaced, ``conflict`` -> destructive Badge variant, ``already_trusted`` -> default Badge variant, Install disabled without version, install POST forwards ``confirmed_fingerprint``, ``expected_hash`` forwarded when supplied, ``already_installed`` -> "Already installed" verb, install error surfaced
- [x] ``pnpm check`` (svelte-check): 0 errors / 0 warnings
- [x] ``task build:webapp`` succeeds; static output embedded into ``internal/app/webapp_dist/``

Coverage on new files: ``HubInstallModal.svelte`` 98.07% / ``routes/hub/+page.svelte`` 97.18%. ``api.ts`` reads 0% because the tests mock it (intentional — unit tests don't hit live HTTP).

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>