### PR TITLE
docs(guides): Hub publisher + consumer guides

### DIFF
--- a/docs/src/content/docs/guides/discovering-connectors.md
+++ b/docs/src/content/docs/guides/discovering-connectors.md
@@ -1,0 +1,141 @@
+---
+title: "Discovering Connectors"
+description: "Browse and install community-published connectors via the Aileron Connector Hub. Covers aileron hub search/show, the webapp Hub page, and the install-decision trust prompt."
+---
+
+This guide is for users who want to find and install community-published connectors. The Aileron Connector Hub is a public discovery index: a list of connectors that publishers have opted into making findable. Discovery is decoupled from trust. Appearing in the Hub is not an Aileron endorsement. You still confirm the publisher's signing key fingerprint before installing.
+
+The Hub itself is the GitHub repo [`aileron-connectors-hub`](https://github.com/ALRubinger/aileron-connectors-hub). Each entry is one YAML file pointing at a connector's canonical `github://owner/repo` FQN. The Hub holds no binaries. Install artifacts still come from the publisher's source repository.
+
+For the install pipeline that runs under all this, see [Installing a Connector](/guides/installing-a-connector/). The Hub layers discovery and a per-FQN trust prompt on top of that pipeline.
+
+## Quick tour
+
+```sh
+# List every connector in the Hub.
+aileron hub list
+
+# Search by keyword (matches FQN and description).
+aileron hub search calendar
+
+# Show a single entry's metadata.
+aileron hub show github://ALRubinger/aileron-connector-google
+```
+
+The same data is browseable in the webapp: under `aileron launch`, visit `/hub` for a searchable list with one-click install.
+
+## How the daemon talks to the Hub
+
+The daemon shallow-clones `aileron-connectors-hub` on every query and parses the entries on the fly. There is no persisted cache and no GitHub API call (per [ADR-0013](/adr/0013-connector-hub-and-trust-distribution/) and the resolution of issue #486). Each `aileron hub` invocation pays one shallow git clone of a small repo. The CLI is the same shape as any other Aileron subcommand: it talks to the local daemon over `/v1/hub/*`, the daemon does the work.
+
+The webapp's `/hub` page reads the same endpoints. CLI and webapp render the same data in different shapes.
+
+## `aileron hub` CLI
+
+### `list`
+
+Prints every Hub entry as a fixed-width table:
+
+```
+FQN                                                 PUBLISHER             DESCRIPTION
+github://ALRubinger/aileron-connector-google        ALRubinger            Google Workspace connector (Calendar, Drive, Gmail)
+github://alice/aileron-connector-slack              alice                 Slack messaging connector
+```
+
+Pass `--json` for NDJSON output (one JSON-encoded entry per line) when scripting.
+
+### `search <query>`
+
+Case-insensitive substring match on FQN and description. Server-side filter, so the daemon handles the matching rules.
+
+```sh
+aileron hub search slack
+```
+
+### `show <fqn>`
+
+Prints the full record for one entry:
+
+```
+FQN:             github://ALRubinger/aileron-connector-google
+Description:     Google Workspace connector (Calendar, Drive, Gmail)
+Publisher:       ALRubinger
+Key URL:         https://raw.githubusercontent.com/ALRubinger/aileron-connector-google/main/keys/publisher.pub
+Release pattern: v*
+```
+
+The `Key URL` is where the daemon will fetch the publisher's signing key during install. The `Release pattern` is a glob the publisher commits to (e.g. `v*` means versioned releases at tags starting with `v`).
+
+## The install-decision prompt
+
+When you run `aileron connector install <FQN>` on a Hub-listed connector, the CLI does not jump straight to the preview flow. It first fetches an install-decision payload from the daemon, which:
+
+1. Looks up the Hub entry.
+2. Fetches the publisher's current public key from `key_url`.
+3. Computes the key's fingerprint.
+4. Compares against your local keyring to determine trust state.
+
+You see something like this:
+
+```
+Hub install-decision
+
+  FQN:         github://ALRubinger/aileron-connector-google
+  Description: Google Workspace connector (Calendar, Drive, Gmail)
+  Publisher:   ALRubinger
+  Fingerprint: sha256:nXKt8AfDQH5jL2pM1RvB9w
+  Trust:       unknown (first install)
+
+  Risk indicators:
+    • First connector by this publisher you've installed
+
+Install? [y/N/d=details]:
+```
+
+Three answers are accepted:
+
+- **`y`** confirms. The daemon writes the publisher key to your keyring under this FQN, then runs the install pipeline. Trust persists on disk even if the install pipeline later fails. Re-running the install does not re-prompt.
+- **`N`** (or any unrecognized answer) cancels. Nothing is written. The daemon does not run the install pipeline.
+- **`d`** shows full details: the complete list of risk indicators, every other connector the same publisher has listed in the Hub. The prompt then asks again with `y/N`.
+
+### Trust states and colors
+
+The `Trust:` line picks one of three labels, color-coded so the unusual states stand out:
+
+| State | Color | Meaning |
+|---|---|---|
+| `already trusted` | green | The publisher's current key is already on your keyring at this FQN. The install proceeds without trust-write work. |
+| `unknown (first install)` | yellow | The keyring has no trusted key for this FQN. Confirming will register the publisher's current key. |
+| `conflict — key differs from a trusted sibling repo` | red | A different connector by the same publisher (per `publisher_github`) carries a key you trust, and the key at this FQN's `key_url` doesn't match. Possible explanations are key rotation, MITM, or impersonation. Worth a closer look before confirming. |
+
+The `conflict` state is rare and intentional. v0.x trust is strictly per-repo (per FQN), so one publisher with two connectors can carry two different keys without anything being wrong. The conflict surface flags the case so you notice. Run `aileron keyring list` to see what's currently trusted, compare fingerprints with the publisher's release notes or commits to `keys/publisher.pub` in their repo, then make a call.
+
+## The webapp's Hub page
+
+Under `aileron launch`, the daemon serves a static webapp at `http://127.0.0.1:<port>/`. The `/hub` page renders the same entries the CLI lists, with a debounced search box and a per-card **Install** button.
+
+Clicking **Install** opens a modal showing the same install-decision payload the CLI renders: FQN, publisher, fingerprint, trust-state badge, risk indicators, the publisher's other Hub entries. A version input (required) and an optional expected-hash input let you pin the install. On confirm, the modal POSTs to the same `/v1/connectors/install` endpoint the CLI uses, with the same `confirmed_fingerprint` payload. Daemon-side behavior is identical to the CLI flow.
+
+The modal renders the publisher footprint as informational context. There is no "Trust this publisher" button. v0.x trust is per-repo, and the design is deliberately careful not to invite users into a wider trust grant.
+
+## What the Hub does not do
+
+| What | Why not |
+|---|---|
+| Vet publishers | Anyone with a GitHub account can open a PR adding their connector to the Hub. Aileron does not review submissions for quality, security, or claims made in the description. The Hub is a discovery surface, not an editorial one. |
+| Host binaries | Install artifacts live at `github://owner/repo`. The Hub entry is one YAML file pointing at the canonical FQN. If a publisher takes their repo down, the Hub entry breaks; Aileron stores nothing on the publisher's behalf. |
+| Show popularity signals | No stars, no last-commit timestamps, no download counts in v0.x. Surfacing those would force every user's daemon to call `api.github.com` (60/hr unauthenticated ceiling) on every Hub page load. A server-side metadata service that amortizes those calls is tracked in [issue #614](https://github.com/ALRubinger/aileron/issues/614). |
+| Phone home | No telemetry. The daemon does not report which connectors you browsed, which you installed, or which Hub entries you opened. The discovery surface and the install pipeline both run locally. |
+
+## Common errors
+
+- **`hub_unreachable`**: the daemon couldn't clone the Hub repo. Check that the daemon has network access to `github.com`. The same error wraps any non-404 git clone failure.
+- **`not_found`** at install time: you supplied a `confirmed_fingerprint` (i.e. you went through the install-decision flow), but the FQN is not in the Hub. The daemon and the CLI are out of sync on what's installable, probably because the Hub PR for the entry hasn't merged yet. Workaround: install with pre-established trust via `aileron keyring trust <FQN>` followed by `aileron connector install <FQN>@<version>`, which uses the legacy flow.
+- **`fingerprint_mismatch`**: between rendering the install-decision and confirming, the publisher's key at `key_url` changed. The daemon refuses to install rather than silently trusting a different key. Re-run the install command to see the new fingerprint, compare against the publisher's release notes, and decide.
+
+## See also
+
+- [Installing a Connector](/guides/installing-a-connector/): the install pipeline that runs after the install-decision prompt.
+- [Publishing to the Hub](/guides/publishing-to-the-hub/): the publisher side of this surface.
+- [ADR-0013: Connector Hub and Trust Distribution](/adr/0013-connector-hub-and-trust-distribution/): design rationale for the Hub.
+- [ADR-0002: Connector Model](/adr/0002-connector-model/): the FQN authority and keyring trust model the Hub layers on top of.

--- a/docs/src/content/docs/guides/publishing-to-the-hub.md
+++ b/docs/src/content/docs/guides/publishing-to-the-hub.md
@@ -1,0 +1,131 @@
+---
+title: "Publishing to the Hub"
+description: "Submit your connector to the Aileron Connector Hub so users can discover it via aileron hub search and the webapp Hub page. Covers the YAML entry shape, the schema, the PR workflow, and what changes after merge."
+---
+
+This guide is for publishers who have already shipped a connector and want users to discover it through the Aileron Connector Hub. The Hub is a public GitHub repo, [`aileron-connectors-hub`](https://github.com/ALRubinger/aileron-connectors-hub), that maintains one YAML entry per community-published connector. Adding your entry makes you findable through `aileron hub search`, the webapp's `/hub` page, and the install-decision prompt that fires on `aileron connector install`.
+
+This is a discovery decision, not a release decision. Releasing a new version of your connector is unchanged: you push a tag, CI publishes the tarball at `github://<owner>/<repo>`. The Hub entry is one YAML file pointing at that FQN. Versions are not part of the entry.
+
+If you have not shipped your connector yet, start with [Publishing a Connector](/guides/publishing-a-connector/). That guide covers the binary, the signing key, the release workflow, and the trust contract Aileron's install pipeline expects. The Hub builds on top of that. Without a signed release at a `github://` FQN, there is nothing to discover.
+
+## When to submit a Hub entry
+
+The Hub is optional. Connectors install fine without an entry. The question is whether you want users to find your connector through Aileron's discovery surface.
+
+| Situation | Submit? |
+|---|---|
+| You want users to discover your connector through `aileron hub search` or the webapp `/hub` page | Yes |
+| The connector is private, internal to your team, or you distribute the FQN out-of-band | No |
+| You're shipping a one-off CLI wrapper for personal use | No |
+| You want the install-decision trust prompt to fire (yellow banner, fingerprint comparison, key persists on confirm) when users `aileron connector install` your FQN | Yes |
+
+Inclusion in the Hub is not an endorsement. Aileron does not vet what you publish. Maintainers of the Hub repo confirm that the entry's schema is valid and that it points at a real `github://` FQN. They do not audit your binary or your `keys/publisher.pub`. That contract is between you and the consumers who confirm your fingerprint at install time.
+
+## The entry shape
+
+Each entry is one YAML file under `connectors/`. The recommended naming convention is `<scheme>_<owner>_<repo>.yaml`, lowercased, dots replaced with dashes, to keep the directory listing scannable.
+
+A complete entry:
+
+```yaml
+fqn: github://ALRubinger/aileron-connector-google
+description: Google Workspace connector (Calendar, Drive, Gmail)
+publisher_github: ALRubinger
+key_url: https://raw.githubusercontent.com/ALRubinger/aileron-connector-google/main/keys/publisher.pub
+release_pattern: v*
+```
+
+All five fields are required. The JSON Schema at [`schema/connector-entry.schema.json`](https://github.com/ALRubinger/aileron-connectors-hub/blob/main/schema/connector-entry.schema.json) is the authoritative spec. The Hub repo's CI validates every PR against it.
+
+### `fqn`
+
+The canonical FQN for your connector. Must match `^github://[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?/[A-Za-z0-9._-]+$`. In v0.x this is always a GitHub URL of the form `github://<owner>/<repo>`. No subpaths, no scheme other than `github`. Aileron's resolver maps this FQN to release artifacts at `https://github.com/<owner>/<repo>/releases`.
+
+### `description`
+
+A one-line summary, 1 to 200 characters. Shown next to the FQN in `aileron hub list` and in the webapp's `/hub` cards. Write it for the user searching for "calendar" or "slack", not for the LLM. Action-template Markdown bodies carry the LLM-facing description.
+
+### `publisher_github`
+
+Your GitHub username or organization, exactly as it appears on github.com. Must match `^[A-Za-z0-9](?:[A-Za-z0-9-]*[A-Za-z0-9])?$`. This is used to compute the install-decision flow's publisher footprint: when a user installs your connector, the daemon scans the Hub for other entries with the same `publisher_github` and surfaces them as context.
+
+Two publishers can ship a connector at the same name (`github://alice/aileron-connector-slack` and `github://bob/aileron-connector-slack` coexist in the Hub). The FQN owner disambiguates. There is no namespace collision.
+
+### `key_url`
+
+Direct URL to the PEM-encoded ed25519 public key that signs your releases. Must start with `https://`. The conventional location, ratified by [ADR-0002](/adr/0002-connector-model/), is `keys/publisher.pub` on the default branch of your connector repo:
+
+```
+https://raw.githubusercontent.com/<owner>/<repo>/main/keys/publisher.pub
+```
+
+Use `main` (or your repo's actual default branch) rather than a tag. The daemon fetches this URL during the install-decision flow to compute the fingerprint the user sees. Pinning to a tag would mean that updating your entry to point at a new key requires a new Hub PR even when the key is committed in your repo.
+
+The Hub does not host your key. It records the URL where your key lives, and your repo is the authoritative source.
+
+### `release_pattern`
+
+A glob describing your release tag convention. Must be at least one character. v0.x supports a small set of patterns:
+
+- `v*`: versioned tags like `v1.2.3` (the convention this guide and Aileron's reference connectors use).
+- `release-*`: tags like `release-2025.01`.
+- `*`: any tag. Rare. Useful for connectors that don't use semantic versioning.
+
+The pattern is informational in v0.x. The install pipeline locates artifacts via the [ADR-0004](/adr/0004-dependency-resolution/) resolver, not via the Hub entry. Future work, [issue #614](https://github.com/ALRubinger/aileron/issues/614), may use `release_pattern` to drive a server-side "latest stable version" surface.
+
+## The PR workflow
+
+The Hub is GitHub-native. There is no upload form, no review committee, no Aileron review.
+
+1. Fork [`aileron-connectors-hub`](https://github.com/ALRubinger/aileron-connectors-hub).
+2. Add one YAML file under `connectors/`. Filename does not have to match `fqn` (the daemon reads `fqn` from the file contents), but follow the `<scheme>_<owner>_<repo>.yaml` convention.
+3. Open a PR. The Hub repo's CI runs JSON Schema validation against `schema/connector-entry.schema.json` (see [PR #1](https://github.com/ALRubinger/aileron-connectors-hub/pull/1)). A green check means the YAML is well-formed, the required fields are present, and the patterns hold.
+4. A maintainer of the Hub repo merges. The merge does not require Aileron-org membership. See [`CONTRIBUTING.md`](https://github.com/ALRubinger/aileron-connectors-hub/blob/main/CONTRIBUTING.md) for the maintainer rotation and review SLA.
+
+The maintainer review is light: that the FQN resolves to a real GitHub repo, that `key_url` returns a parseable PEM ed25519 public key, that the entry is not a duplicate of an existing one. Maintainers do not run your binary, audit your code, or grade your description.
+
+A typical PR is one file added under `connectors/`. Touching `schema/`, `CONTRIBUTING.md`, or the workflow files needs a separate PR with a different review bar.
+
+## What changes after merge
+
+Once your PR merges to `main`, the Hub entry is live immediately. The daemon shallow-clones the Hub repo per query, so the next time any user runs `aileron hub list` or visits `/hub` in the webapp, your entry shows up. There is no cache to invalidate.
+
+Three things start happening:
+
+- **Discovery.** Users searching for keywords in your description find your connector. `aileron hub search calendar` matches every entry whose FQN or description contains "calendar" case-insensitively.
+- **Install-decision prompt.** When a user runs `aileron connector install <your-FQN>`, the CLI fetches the install-decision payload before the install pipeline runs. They see your fingerprint, the trust state (almost always `unknown (first install)` for a new publisher), and a yellow risk indicator noting it's their first connector from you. On confirm, the daemon writes your key to their keyring under your FQN and runs the install. See [Discovering Connectors](/guides/discovering-connectors/) for the user-side flow.
+- **Publisher footprint.** If you list a second connector in the Hub later, users installing either will see the other as informational context: "Publisher has 1 other connector you already trust" or similar.
+
+The webapp `/hub` page shows your entry under the same discovery surface, with a one-click Install button that opens the install-decision modal.
+
+## Updating your entry
+
+Edit your entry by opening a PR that modifies the YAML file. The schema validator runs on every PR. The same maintainer review process applies.
+
+| You want to | Steps |
+|---|---|
+| Change your description | One-line edit to `description`. Schema validates length 1 to 200. |
+| Change your key URL (e.g. branch rename from `main` to `default`) | Edit `key_url`. Make sure the new URL returns the same PEM bytes; otherwise the install-decision flow's fingerprint surface will pick up the change. |
+| Rotate your signing key | Commit the new `keys/publisher.pub` to your repo first. The `key_url` already points at the default branch, so no Hub edit is needed. Users who already trust the old key see `conflict` on their next install of the same FQN, with the new fingerprint shown for comparison. |
+| Move your repo to a new owner | The FQN changes. Open a Hub PR adding a new entry at the new FQN. Keep the old entry in place for a release cycle so users on the old FQN keep finding the connector. Then open a second PR removing the old entry. |
+| Withdraw your connector | Open a PR deleting the YAML file. The discovery surface drops it on next daemon clone. Already-installed connectors keep working. Their trust state in users' keyrings persists. |
+
+There is no "version" of a Hub entry. The Hub does not track release-by-release; that's the job of your repo's tags and the install pipeline.
+
+## What the Hub does not require
+
+| Not required | Why |
+|---|---|
+| Aileron-org GitHub membership | Anyone can open a PR. Maintainership of the Hub is intentionally lighter-touch than maintainership of the Aileron daemon repo. |
+| Sigstore signing or transparency log entries | Long-lived static keys remain in v0.x. The three known limitations (leaked keys retroactively compromise past versions, no transparency log means undetected backdated signatures, weak identity binding) are accepted per [ADR-0013](/adr/0013-connector-hub-and-trust-distribution/). Revisit when v1 stability work begins. |
+| A "verified publisher" badge | The Hub does not have publisher tiers. Every entry is equal, every user makes their own trust decision at install time. |
+| OAuth provider registration | The Hub entry is about discovery. If your connector uses OAuth2, that's declared in your connector's `manifest.toml` per [Publishing a Connector](/guides/publishing-a-connector/), not in the Hub entry. |
+
+## See also
+
+- [Publishing a Connector](/guides/publishing-a-connector/): the connector lifecycle the Hub entry layers on top of: signing keys, release workflow, capability manifests.
+- [Discovering Connectors](/guides/discovering-connectors/): the user side of this surface.
+- [ADR-0013: Connector Hub and Trust Distribution](/adr/0013-connector-hub-and-trust-distribution/): design rationale for the Hub, the Hub-as-pointer (vs. Hub-as-registry) decision, and what was deferred.
+- [ADR-0002: Connector Model](/adr/0002-connector-model/): the FQN authority + keyring trust model.
+- [`aileron-connectors-hub` on GitHub](https://github.com/ALRubinger/aileron-connectors-hub): the repo itself.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -66,6 +66,7 @@ export const navigation: NavItem[] = [
   {
     label: 'Guides',
     children: [
+      { label: 'Discovering Connectors', href: '/guides/discovering-connectors/' },
       { label: 'Installing a Connector', href: '/guides/installing-a-connector/' },
       { label: 'Installing an Action', href: '/guides/installing-an-action/' },
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },
@@ -74,6 +75,7 @@ export const navigation: NavItem[] = [
       { label: 'Authoring an Action', href: '/guides/authoring-an-action/' },
       { label: 'Authoring an Action Suite', href: '/guides/authoring-an-action-suite/' },
       { label: 'Publishing a Connector', href: '/guides/publishing-a-connector/' },
+      { label: 'Publishing to the Hub', href: '/guides/publishing-to-the-hub/' },
       { label: 'Observability', href: '/guides/observability/' }
     ]
   },


### PR DESCRIPTION
## Summary

Two new guides closing the last umbrella items in #488:

- **[Discovering Connectors](https://github.com/ALRubinger/aileron/blob/docs/hub-guides/docs/src/content/docs/guides/discovering-connectors.md)** (user side): ``aileron hub list / search / show``, the webapp ``/hub`` page, the install-decision prompt (trust states, fingerprint, y/N/d=details, color semantics), and the no-vetting / no-binary / no-popularity-signals / no-telemetry posture.
- **[Publishing to the Hub](https://github.com/ALRubinger/aileron/blob/docs/hub-guides/docs/src/content/docs/guides/publishing-to-the-hub.md)** (publisher side): when a Hub entry makes sense, the five required YAML fields with schema patterns, the GitHub-native PR workflow against ``aileron-connectors-hub``, what changes after merge, and how to update an entry without re-publishing the connector.

Both guides link back to the existing Installing / Publishing a Connector pages for the install pipeline they layer on top of, and to ADR-0013 for the design rationale.

Sidebar nav (``docs/src/lib/navigation.ts``) gets two new entries under Guides.

## Test plan

- [x] ``task build:docs`` succeeds; both new pages built (``/guides/discovering-connectors/`` and ``/guides/publishing-to-the-hub/``)
- [x] All internal cross-links resolve to existing pages (manually verified against the Astro build output)
- [x] Writing-voice scan: no em-dashes in prose (the one remaining em-dash is inside the literal daemon UI string ``conflict — key differs from a trusted sibling repo``, quoted verbatim); no "not just X, it's Y" constructions

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>