### PR TITLE
fix(launch): fail loud when aileron-mcp is not resolvable

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -64,6 +64,31 @@ func resolveSibling(selfPath, name string) (string, error) {
 	return exec.LookPath(name)
 }
 
+// resolveMCPBinary locates aileron-mcp. The MCP server is a required
+// runtime dependency of `aileron launch` per ADR-0015 — without it the
+// agent has no path to Aileron's tools, the vault, or the action-
+// approval surface. Missing aileron-mcp is a hard error with a
+// remediation hint, not a silent skip.
+//
+// Lookup order: next to the running aileron binary first (the shape
+// the Homebrew cask, deb/rpm/apk packages, and `task build:cli + task
+// build:mcp` all produce), then $PATH (covers `go install` users who
+// installed only the CLI or unusual layouts).
+func resolveMCPBinary(selfPath string) (string, error) {
+	mcpBin, err := resolveSibling(selfPath, "aileron-mcp")
+	if err == nil {
+		return mcpBin, nil
+	}
+	siblingDir := "<unknown>"
+	if selfPath != "" {
+		siblingDir = filepath.Dir(selfPath)
+	}
+	return "", fmt.Errorf(
+		"aileron-mcp not found next to %s/aileron or on PATH; reinstall aileron from the official packages, or build and place aileron-mcp alongside aileron (task build:mcp; cp build/aileron-mcp %s/)",
+		siblingDir, siblingDir,
+	)
+}
+
 // Launch starts the agent as a child process under Aileron's daemon.
 //
 // Per ADR-0015 the launcher is the daemon-connection + MCP-registration
@@ -97,16 +122,26 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	daemonURL = trimTrailingSlash(daemonURL)
 	client := newDaemonClient(daemonURL)
 
+	agentPath, err := ResolveBinary(config.Agent.BinaryNames())
+	if err != nil {
+		return LaunchResult{}, fmt.Errorf("agent %q: %w", config.Agent.Name(), err)
+	}
+
+	// Resolve aileron-mcp up front. Per ADR-0015 the MCP server is the
+	// runtime path for every Aileron tool the agent calls; running
+	// without it isn't running. Resolve before session registration so
+	// a missing binary fails before the daemon has anything to clean up.
+	selfPath, _ := os.Executable()
+	mcpBin, err := resolveMCPBinary(selfPath)
+	if err != nil {
+		return LaunchResult{}, err
+	}
+
 	regCtx, cancelReg := context.WithTimeout(ctx, daemonHTTPTimeout)
 	sessionID, err := client.RegisterSession(regCtx, config.Agent.Name(), config.Dir)
 	cancelReg()
 	if err != nil {
 		return LaunchResult{}, fmt.Errorf("register session: %w", err)
-	}
-
-	agentPath, err := ResolveBinary(config.Agent.BinaryNames())
-	if err != nil {
-		return LaunchResult{}, fmt.Errorf("agent %q: %w", config.Agent.Name(), err)
 	}
 
 	agentEnv := composeAgentEnv(config.Agent.Env(), config.Agent.LLMEndpointEnv(), daemonURL)
@@ -118,20 +153,17 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	// (Claude, Pi) or config-file (Codex, Goose, OpenCode). The env
 	// passed here ends up inside the MCP server process so it can
 	// reach the daemon's session-scoped surfaces.
-	selfPath, _ := os.Executable()
-	if mcpBin, err := resolveSibling(selfPath, "aileron-mcp"); err == nil {
-		mcpEnv := map[string]string{
-			"AILERON_URL":          daemonURL,
-			"AILERON_COMMS_URL":    daemonURL,
-			"AILERON_SESSION_ID":   sessionID,
-			"AILERON_APPROVAL_URL": daemonURL + "/approvals",
-		}
-		extraArgs, mcpErr := config.Agent.ConfigureMCP(mcpBin, mcpEnv, config.Dir)
-		if mcpErr != nil {
-			return LaunchResult{}, fmt.Errorf("configuring MCP for %s: %w", config.Agent.Name(), mcpErr)
-		}
-		allArgs = append(allArgs, extraArgs...)
+	mcpEnv := map[string]string{
+		"AILERON_URL":          daemonURL,
+		"AILERON_COMMS_URL":    daemonURL,
+		"AILERON_SESSION_ID":   sessionID,
+		"AILERON_APPROVAL_URL": daemonURL + "/approvals",
 	}
+	extraArgs, mcpErr := config.Agent.ConfigureMCP(mcpBin, mcpEnv, config.Dir)
+	if mcpErr != nil {
+		return LaunchResult{}, fmt.Errorf("configuring MCP for %s: %w", config.Agent.Name(), mcpErr)
+	}
+	allArgs = append(allArgs, extraArgs...)
 
 	cmd := exec.CommandContext(ctx, agentPath, allArgs...)
 	cmd.Env = env

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -159,6 +159,8 @@ func TestLaunch_WorkingDirectory(t *testing.T) {
 }
 
 func TestLaunch_AgentMCPArgs_Appended(t *testing.T) {
+	// aileron-mcp resolution is handled package-wide by TestMain
+	// (a fake binary is on PATH for every test).
 	dir := t.TempDir()
 	outFile := filepath.Join(dir, "args.txt")
 	// Capture argv as one line per argument so we can assert presence.
@@ -166,18 +168,6 @@ func TestLaunch_AgentMCPArgs_Appended(t *testing.T) {
 	if err := os.WriteFile(script, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+outFile+"\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
-
-	// The launcher only calls ConfigureMCP when aileron-mcp resolves
-	// (next to the test binary or on PATH). Without that, MCP wiring is
-	// silently skipped and the assertions below would fail with no signal
-	// about why. Pin a fake aileron-mcp at the head of PATH so the
-	// resolution succeeds in every environment (CI, fresh checkouts).
-	mcpDir := t.TempDir()
-	mcpBin := filepath.Join(mcpDir, "aileron-mcp")
-	if err := os.WriteFile(mcpBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", mcpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
 		Agent: scriptAgent{
@@ -203,6 +193,31 @@ func TestLaunch_AgentMCPArgs_Appended(t *testing.T) {
 		if !found {
 			t.Errorf("expected arg %q in child argv, got %v", w, args)
 		}
+	}
+}
+
+func TestLaunch_AileronMCPMissing_FailsLoud(t *testing.T) {
+	// Strip the package-wide fake aileron-mcp from PATH and point HOME
+	// at a tempdir so resolveSibling has no chance of finding one.
+	// Launch should fail with a structured error before session
+	// registration happens.
+	t.Setenv("PATH", "")
+	t.Setenv("HOME", t.TempDir())
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent: scriptAgent{script: "/bin/sh"},
+	})
+	if err == nil {
+		t.Fatal("expected error when aileron-mcp is unresolvable, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "aileron-mcp") {
+		t.Errorf("error message does not mention aileron-mcp: %q", msg)
+	}
+	// The message should point the user at the lookup paths it tried so
+	// they can debug installation issues without diving into source.
+	if !strings.Contains(msg, "PATH") {
+		t.Errorf("error message does not mention PATH: %q", msg)
 	}
 }
 

--- a/internal/launch/testmain_test.go
+++ b/internal/launch/testmain_test.go
@@ -5,25 +5,33 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
 )
 
-// TestMain spins up a fake daemon and points AILERON_API_URL at it
-// for every test in this package. spawn.Resolve honors the env var
-// and returns the URL immediately without trying to fork-exec a real
-// daemon binary — so tests don't need `server` on PATH.
+// TestMain spins up a fake daemon, points AILERON_API_URL at it, and
+// installs a fake aileron-mcp on PATH for every test in this package.
 //
-// The fake handles the three endpoints Launch hits:
+// Fake daemon (AILERON_API_URL): spawn.Resolve honors the env var and
+// returns the URL immediately without trying to fork-exec a real
+// daemon binary. The fake handles the endpoints Launch hits:
 //
 //   - POST /v1/sessions          mints a stable test session id
 //   - POST /v1/sessions/{id}/end accepts and returns the record
 //   - GET  /v1/vault/local/status reports unlocked
 //
-// Tests that need a different fake (e.g., to assert the request body
-// or simulate a locked vault) can set AILERON_API_URL themselves to
-// override the package-wide one.
+// Fake aileron-mcp: per ADR-0015, Launch requires aileron-mcp to be
+// resolvable (next to the running binary or on PATH). Production
+// always satisfies this; the test binary doesn't, so we plant a
+// no-op shell script in a tempdir and prepend that dir to PATH. The
+// MCP server never runs in these tests — Launch only resolves the
+// path to hand to the agent's ConfigureMCP method.
+//
+// Tests that need a different fake (e.g., to assert the request body,
+// simulate a locked vault, or exercise the missing-aileron-mcp error
+// path) can override the relevant env vars themselves.
 func TestMain(m *testing.M) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
@@ -52,5 +60,17 @@ func TestMain(m *testing.M) {
 	}))
 	defer srv.Close()
 	_ = os.Setenv("AILERON_API_URL", srv.URL)
+
+	mcpDir, err := os.MkdirTemp("", "aileron-mcp-fake-")
+	if err != nil {
+		panic("creating fake aileron-mcp dir: " + err.Error())
+	}
+	defer os.RemoveAll(mcpDir)
+	mcpBin := filepath.Join(mcpDir, "aileron-mcp")
+	if err := os.WriteFile(mcpBin, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		panic("writing fake aileron-mcp: " + err.Error())
+	}
+	_ = os.Setenv("PATH", mcpDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
 	os.Exit(m.Run())
 }


### PR DESCRIPTION
## Summary

Per [ADR-0015](https://docs.withaileron.ai/adr/0015-launch-audit-scope/), the MCP server is the runtime path for every Aileron tool the agent calls. The launcher previously wrapped MCP resolution in `if err == nil { ... }`, silently skipping registration when `aileron-mcp` couldn't be found next to the running binary or on PATH. The agent launched, the gateway routed, the session was recorded — but `mcp__aileron__*` tools were invisible, the vault was unreachable, and the action-approval flow was gone. No error, no warning, no audit signal.

Closes #633.

## What changes

- New `resolveMCPBinary(selfPath)` helper. Looks up `aileron-mcp` next to the running `aileron` binary first, then `$PATH`. On failure returns a structured error naming both lookup paths and pointing at remediation (`task build:mcp` + copy alongside `aileron`).
- `Launch` calls it up front (before session registration), so a missing binary fails before the daemon mutates state. The old `if … == nil` wrapper around MCP wiring is gone; the wiring now always runs.
- `TestMain` installs a fake `aileron-mcp` on PATH for the whole package. Production always satisfies this; the test binary doesn't. Removes a hack in `TestLaunch_AgentMCPArgs_Appended` that did the same thing per-test (introduced in PR #630's CI fix, ` 8108e56`).
- New `TestLaunch_AileronMCPMissing_FailsLoud` — strips PATH + HOME so neither lookup path can hit; asserts the structured error mentions `aileron-mcp` and `PATH`.

## Sample error (after this change)

```
$ aileron launch claude
aileron-mcp not found next to /usr/local/bin/aileron or on PATH; \
reinstall aileron from the official packages, or build and place \
aileron-mcp alongside aileron (task build:mcp; cp build/aileron-mcp /usr/local/bin/)
```

## Test plan

- [x] `go test ./internal/launch/...` — all pass; new failure-mode test passes
- [x] `go test ./internal/... ./cmd/aileron/... ./cmd/aileron-mcp/... ./cmd/aileron-enclave/...` — clean (after `task build:forwarder` for the pre-existing WASM-not-built failure mode in `internal/sandbox/forwarder` — unrelated to this change)
- [x] Coverage: `internal/launch` 84.2% (up from 83.7%)
- [ ] Manual smoke: `mv ~/.aileron/bin/aileron-mcp /tmp/ && aileron launch claude` — should print the structured error and exit non-zero before any session is registered

🤖 Generated with [Claude Code](https://claude.com/claude-code)