### PR TITLE
chore(release): cleaner changelog buckets + drop deps/chore noise

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -193,21 +193,48 @@ signs:
 
 changelog:
   sort: asc
+  # Scope-class `[^)]+` is broader than the previous `[[:word:]]+`
+  # (which excluded hyphens and so dropped scopes like
+  # `feat(connector-install):` into Other). Conventional Commits is
+  # permissive about scope characters; the regex should be too.
+  #
+  # Order is load-bearing: the first matching group wins. Breaking
+  # Changes is at the top so `feat!:` / `fix!:` land there rather than
+  # in Features / Bug Fixes, which use overlapping regex.
   groups:
-    - title: Features
-      regexp: '^.*?feat(\([[:word:]]+\))??!?:.+$'
+    - title: 'Breaking Changes ⚠️'
+      regexp: '^.*?(feat|fix)(\([^)]+\))??!:.+$'
       order: 0
-    - title: Bug Fixes
-      regexp: '^.*?fix(\([[:word:]]+\))??!?:.+$'
+    - title: Features
+      regexp: '^.*?feat(\([^)]+\))??!?:.+$'
       order: 1
-    - title: Performance
-      regexp: '^.*?perf(\([[:word:]]+\))??!?:.+$'
+    - title: Bug Fixes
+      regexp: '^.*?fix(\([^)]+\))??!?:.+$'
       order: 2
-    - title: Documentation
-      regexp: '^.*?docs(\([[:word:]]+\))??!?:.+$'
+    - title: Performance
+      regexp: '^.*?perf(\([^)]+\))??!?:.+$'
       order: 3
+    - title: Documentation
+      regexp: '^.*?docs(\([^)]+\))??!?:.+$'
+      order: 4
     - title: Other
       order: 999
+  filters:
+    # Hide commit types that contribute no signal to a user-facing
+    # changelog. Conventional Commits keeps these in git history; the
+    # release notes call out what the user gets, not how the sausage
+    # got made. `fix(deps)` / `chore(deps)` / `build(deps)` are
+    # Renovate-style bumps; they'd otherwise dominate Bug Fixes and
+    # Other.
+    exclude:
+      - '^.*?chore(\([^)]+\))??!?:.+$'
+      - '^.*?style(\([^)]+\))??!?:.+$'
+      - '^.*?test(\([^)]+\))??!?:.+$'
+      - '^.*?refactor(\([^)]+\))??!?:.+$'
+      - '^.*?build(\([^)]+\))??!?:.+$'
+      - '^.*?ci(\([^)]+\))??!?:.+$'
+      - '^.*?revert(\([^)]+\))??!?:.+$'
+      - '^.*?(fix|chore|build)\(deps\)!?:.+$'
 
 release:
   github:


### PR DESCRIPTION
## Summary

You already had GoReleaser handling release notes on every ``v*`` tag push (``.goreleaser.yml`` lines 194-210). Three small fixes that materially improve the output:

- **Add ``Breaking Changes ⚠️`` group** at order 0, matching ``feat!:`` / ``fix!:``. PR #630 (``feat(launch)!: drop shell-shim``) would currently bury under Features; now it leads the notes.
- **Add ``filters.exclude``** for ``chore``, ``style``, ``test``, ``refactor``, ``build``, ``ci``, ``revert``, and Renovate's dependency bumps (``fix(deps)`` / ``chore(deps)`` / ``build(deps)``). Without filters the ~14 dep PRs in the v0.0.2..HEAD window dwarfed the real feature work.
- **Widen scope-class regex** from ``[[:word:]]+`` to ``[^)]+``. The old class excluded hyphens, so scopes like ``feat(connector-install):`` (PR #628) silently fell into Other. Conventional Commits is permissive about scope characters; the regex should be too.

## Preview

Manually running the new regex against ``git log v0.0.2..HEAD`` produces:

- **Breaking Changes (1):** PR #630
- **Features (11):** PRs #631, #628, #627, #617, #597, #596, #595, #594, #593, #590, #589, #588
- **Bug Fixes (3):** PRs #621, #612, #586
- **Documentation (11):** PRs #629, #613, #611, #610, #607, #606, #599, #598, #592, #587, #585
- **Excluded (14):** Renovate dep bumps + ``chore`` / ``build`` / ``test`` housekeeping

## Test plan

- [x] ``goreleaser check`` validates the new config
- [x] Manual regex pass against the v0.0.2..HEAD commit window: every PR lands in the expected bucket, including the previously-mis-bucketed ``feat(connector-install):``
- [x] No behavior change for the rest of the release pipeline (binaries, brews tap, cosign signing, Railway docs rebuild are all untouched)

To validate end-to-end before the next release, ``goreleaser release --snapshot --clean --skip=publish`` will dry-run the full pipeline locally and emit the rendered notes under ``dist/``.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>