### PR TITLE
fix(intercept): emit content_block_delta events in reconstructed SSE

### DIFF
--- a/internal/intercept/anthropic.go
+++ b/internal/intercept/anthropic.go
@@ -360,10 +360,31 @@ type anthropicEvent struct {
 }
 
 // anthropicEventsFromMessage converts a non-streamed Anthropic
-// Messages response into a minimal event sequence: message_start,
-// then per-content-block start/delta/stop, then message_delta and
-// message_stop. Sufficient for a simple agent that just needs the
-// final assistant message.
+// Messages response into the SSE event sequence Anthropic clients
+// expect when streaming: message_start, then per-content-block
+// start / delta(s) / stop, then message_delta and message_stop.
+//
+// Each block type has its own delta wire shape per the Anthropic
+// streaming protocol:
+//
+//   - text: start carries an empty text; text_delta delivers the
+//     content.
+//   - thinking: start carries empty thinking + empty signature;
+//     thinking_delta delivers the reasoning text; signature_delta
+//     delivers the model's signature (required when the conversation
+//     involves tool use — the API rejects thinking blocks in
+//     subsequent turns whose signature does not match).
+//   - tool_use: start carries id + name + empty input; input_json_delta
+//     delivers the input JSON.
+//   - redacted_thinking: no deltas — the opaque `data` field rides on
+//     the start event since it is not progressively streamed.
+//
+// Skipping the deltas (Aileron's pre-#638 behavior of stuffing the
+// full block into content_block_start) breaks clients that accumulate
+// content from delta events — Claude Code's session ends up with
+// thinking blocks whose `thinking` field is empty, and the API
+// rejects the next turn with "each thinking block must contain
+// thinking" (#638).
 func anthropicEventsFromMessage(body []byte) ([]anthropicEvent, error) {
 	var msg map[string]any
 	if err := json.Unmarshal(body, &msg); err != nil {
@@ -385,19 +406,7 @@ func anthropicEventsFromMessage(body []byte) ([]anthropicEvent, error) {
 		if bm == nil {
 			continue
 		}
-		startBlockData, _ := json.Marshal(map[string]any{
-			"type":          "content_block_start",
-			"index":         i,
-			"content_block": bm,
-		})
-		stopBlockData, _ := json.Marshal(map[string]any{
-			"type":  "content_block_stop",
-			"index": i,
-		})
-		events = append(events,
-			anthropicEvent{Name: "content_block_start", Data: string(startBlockData)},
-			anthropicEvent{Name: "content_block_stop", Data: string(stopBlockData)},
-		)
+		events = append(events, anthropicEventsForBlock(i, bm)...)
 	}
 
 	deltaData, _ := json.Marshal(map[string]any{
@@ -411,4 +420,110 @@ func anthropicEventsFromMessage(body []byte) ([]anthropicEvent, error) {
 		anthropicEvent{Name: "message_stop", Data: string(stopData)},
 	)
 	return events, nil
+}
+
+// anthropicEventsForBlock produces the SSE event sequence for one
+// content block: a metadata-only content_block_start, zero or more
+// content_block_delta events carrying the content fields, and a
+// content_block_stop. The split between start and deltas matches
+// Anthropic's real streaming protocol — clients accumulate content
+// from deltas, not from the start event.
+//
+// Unknown block types fall back to the pre-#638 behavior (stuff the
+// whole block into the start event, no deltas) on the principle that
+// emitting something the client can ignore is better than dropping a
+// block entirely. Future-protocol blocks land here.
+func anthropicEventsForBlock(index int, bm map[string]any) []anthropicEvent {
+	blockType, _ := bm["type"].(string)
+
+	startBlock := map[string]any{"type": blockType}
+	var deltas []map[string]any
+
+	switch blockType {
+	case "text":
+		startBlock["text"] = ""
+		if text, ok := bm["text"].(string); ok && text != "" {
+			deltas = append(deltas, map[string]any{
+				"type": "text_delta",
+				"text": text,
+			})
+		}
+	case "thinking":
+		// start: empty thinking + empty signature placeholder.
+		// thinking_delta: the reasoning text.
+		// signature_delta: the model-issued signature (required for
+		// thinking blocks that participate in a tool-use turn).
+		startBlock["thinking"] = ""
+		startBlock["signature"] = ""
+		if thinking, ok := bm["thinking"].(string); ok && thinking != "" {
+			deltas = append(deltas, map[string]any{
+				"type":     "thinking_delta",
+				"thinking": thinking,
+			})
+		}
+		if sig, ok := bm["signature"].(string); ok && sig != "" {
+			deltas = append(deltas, map[string]any{
+				"type":      "signature_delta",
+				"signature": sig,
+			})
+		}
+	case "tool_use":
+		// start: id + name + empty input. input_json_delta carries the
+		// serialized input JSON in one chunk (Anthropic's real stream
+		// would chunk it; one chunk is a valid sequence).
+		if id, ok := bm["id"].(string); ok {
+			startBlock["id"] = id
+		}
+		if name, ok := bm["name"].(string); ok {
+			startBlock["name"] = name
+		}
+		startBlock["input"] = map[string]any{}
+		input, hasInput := bm["input"]
+		if hasInput {
+			inputJSON, err := json.Marshal(input)
+			if err == nil && len(inputJSON) > 0 && string(inputJSON) != "null" && string(inputJSON) != "{}" {
+				deltas = append(deltas, map[string]any{
+					"type":         "input_json_delta",
+					"partial_json": string(inputJSON),
+				})
+			}
+		}
+	case "redacted_thinking":
+		// The opaque `data` field is not progressively streamed;
+		// Anthropic ships it on the start event. No deltas.
+		if data, ok := bm["data"].(string); ok {
+			startBlock["data"] = data
+		}
+	default:
+		// Unknown block type. Preserve the full block in the start
+		// event so the client at least sees its content; future
+		// protocol blocks land here without breaking the gateway.
+		startBlock = bm
+	}
+
+	startData, _ := json.Marshal(map[string]any{
+		"type":          "content_block_start",
+		"index":         index,
+		"content_block": startBlock,
+	})
+	events := []anthropicEvent{{Name: "content_block_start", Data: string(startData)}}
+
+	for _, d := range deltas {
+		deltaData, _ := json.Marshal(map[string]any{
+			"type":  "content_block_delta",
+			"index": index,
+			"delta": d,
+		})
+		events = append(events, anthropicEvent{
+			Name: "content_block_delta",
+			Data: string(deltaData),
+		})
+	}
+
+	stopData, _ := json.Marshal(map[string]any{
+		"type":  "content_block_stop",
+		"index": index,
+	})
+	events = append(events, anthropicEvent{Name: "content_block_stop", Data: string(stopData)})
+	return events
 }

--- a/internal/intercept/intercept_test.go
+++ b/internal/intercept/intercept_test.go
@@ -682,6 +682,239 @@ func TestHandleAnthropic_StreamingEmittedAsSSE(t *testing.T) {
 	}
 }
 
+// Regression test for #638: when Aileron rebuilds an SSE stream from a
+// non-streamed upstream response, every content block's content fields
+// must arrive via content_block_delta events (not be embedded in
+// content_block_start). Anthropic SDK clients — Claude Code included
+// — accumulate content from deltas; if Aileron stuffs the full block
+// into content_block_start, the client's accumulator stays empty,
+// thinking/text/tool_use content gets lost mid-flight, and the next
+// turn fails with "messages.N.content.M.thinking: each thinking block
+// must contain thinking".
+//
+// Contract under test: for each content block type the engine emits,
+// reading the delta events back must reconstruct the original
+// content. content_block_start carries only the block's metadata
+// fields (type, id, name, signature shape) — never the content.
+func TestHandleAnthropic_StreamingRebuild_DeltasAccumulateToOriginalContent(t *testing.T) {
+	// Upstream returns a multi-block assistant response: thinking
+	// (the case that surfaced #638) + text. tool_use is exercised by
+	// the existing interception tests; here the goal is the terminal
+	// emit path that runs when no Aileron tool_use is present.
+	upstream, _ := newScriptedUpstream(t, `{
+		"id":"msg_x","type":"message","role":"assistant","model":"c",
+		"content":[
+			{"type":"thinking","thinking":"Let me reason about this carefully.","signature":"sig_abc123"},
+			{"type":"text","text":"Hello, world!"}
+		],
+		"stop_reason":"end_turn"
+	}`)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", upstream.URL, store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1024,"messages":[],"stream":true}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	events := parseSSEEvents(t, w.Body.String())
+
+	// Block 0 (thinking): start with empty fields, thinking_delta
+	// carrying the reasoning, signature_delta carrying the signature,
+	// then stop.
+	thinkingStart := findBlockEvent(t, events, "content_block_start", 0)
+	startBlock0, _ := thinkingStart["content_block"].(map[string]any)
+	if startBlock0["type"] != "thinking" {
+		t.Errorf("block 0 start type = %v, want thinking", startBlock0["type"])
+	}
+	if startBlock0["thinking"] != "" {
+		t.Errorf("block 0 start.thinking = %q, want empty (content rides on deltas)", startBlock0["thinking"])
+	}
+
+	thinkingDeltas := findBlockEvents(events, "content_block_delta", 0)
+	gotThinking := accumulateDeltaField(thinkingDeltas, "thinking_delta", "thinking")
+	if gotThinking != "Let me reason about this carefully." {
+		t.Errorf("accumulated thinking = %q, want original; deltas = %+v", gotThinking, thinkingDeltas)
+	}
+	gotSig := accumulateDeltaField(thinkingDeltas, "signature_delta", "signature")
+	if gotSig != "sig_abc123" {
+		t.Errorf("accumulated signature = %q, want sig_abc123", gotSig)
+	}
+
+	// Block 1 (text): start with empty text, text_delta carrying the
+	// content, then stop.
+	textStart := findBlockEvent(t, events, "content_block_start", 1)
+	startBlock1, _ := textStart["content_block"].(map[string]any)
+	if startBlock1["type"] != "text" {
+		t.Errorf("block 1 start type = %v, want text", startBlock1["type"])
+	}
+	if startBlock1["text"] != "" {
+		t.Errorf("block 1 start.text = %q, want empty", startBlock1["text"])
+	}
+
+	textDeltas := findBlockEvents(events, "content_block_delta", 1)
+	gotText := accumulateDeltaField(textDeltas, "text_delta", "text")
+	if gotText != "Hello, world!" {
+		t.Errorf("accumulated text = %q, want original; deltas = %+v", gotText, textDeltas)
+	}
+
+	// Each block must have its content_block_stop with the matching index.
+	for i := 0; i < 2; i++ {
+		stop := findBlockEvent(t, events, "content_block_stop", i)
+		if int(stop["index"].(float64)) != i {
+			t.Errorf("stop event %d has index %v", i, stop["index"])
+		}
+	}
+}
+
+func TestHandleAnthropic_StreamingRebuild_ToolUseInputArrivesAsDelta(t *testing.T) {
+	// Terminal response from upstream where the model called an
+	// agent-declared tool (not an Aileron tool — that path would
+	// continue the loop). Aileron rebuilds SSE; the input must ride
+	// in input_json_delta, with the start event carrying id/name and
+	// an empty input.
+	upstream, _ := newScriptedUpstream(t, `{
+		"id":"msg_x","type":"message","role":"assistant","model":"c",
+		"content":[
+			{"type":"tool_use","id":"tu_1","name":"agent_tool","input":{"x":42,"y":"hello"}}
+		],
+		"stop_reason":"tool_use"
+	}`)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	e := engineFor(t, "", upstream.URL, store, nil)
+
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1024,"messages":[],"stream":true}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", w.Code)
+	}
+	events := parseSSEEvents(t, w.Body.String())
+
+	start := findBlockEvent(t, events, "content_block_start", 0)
+	startBlock, _ := start["content_block"].(map[string]any)
+	if startBlock["type"] != "tool_use" {
+		t.Errorf("start.type = %v, want tool_use", startBlock["type"])
+	}
+	if startBlock["id"] != "tu_1" || startBlock["name"] != "agent_tool" {
+		t.Errorf("start missing id/name: %+v", startBlock)
+	}
+	input, _ := startBlock["input"].(map[string]any)
+	if len(input) != 0 {
+		t.Errorf("start.input = %+v, want empty (rides on delta)", input)
+	}
+
+	deltas := findBlockEvents(events, "content_block_delta", 0)
+	gotJSON := accumulateDeltaField(deltas, "input_json_delta", "partial_json")
+	if gotJSON == "" {
+		t.Fatalf("input_json_delta missing; deltas = %+v", deltas)
+	}
+	var parsed map[string]any
+	if err := json.Unmarshal([]byte(gotJSON), &parsed); err != nil {
+		t.Fatalf("partial_json not valid JSON: %v\n%s", err, gotJSON)
+	}
+	if parsed["x"].(float64) != 42 || parsed["y"] != "hello" {
+		t.Errorf("decoded input = %+v, want {x:42, y:hello}", parsed)
+	}
+}
+
+// parseSSEEvents parses an SSE stream into a slice of
+// {event, data-map} entries. Order is preserved. Only events with a
+// JSON-decodable data field land in the slice — any other lines (e.g.
+// comments) are ignored.
+func parseSSEEvents(t *testing.T, body string) []map[string]any {
+	t.Helper()
+	var events []map[string]any
+	for _, block := range strings.Split(body, "\n\n") {
+		block = strings.TrimSpace(block)
+		if block == "" {
+			continue
+		}
+		var eventName, dataLine string
+		for _, line := range strings.Split(block, "\n") {
+			switch {
+			case strings.HasPrefix(line, "event: "):
+				eventName = strings.TrimPrefix(line, "event: ")
+			case strings.HasPrefix(line, "data: "):
+				dataLine = strings.TrimPrefix(line, "data: ")
+			}
+		}
+		if eventName == "" || dataLine == "" {
+			continue
+		}
+		var data map[string]any
+		if err := json.Unmarshal([]byte(dataLine), &data); err != nil {
+			t.Fatalf("SSE data line is not JSON: %v\nline=%s", err, dataLine)
+		}
+		data["__event"] = eventName
+		events = append(events, data)
+	}
+	return events
+}
+
+// findBlockEvent returns the first event with the given name whose
+// `index` field matches blockIndex. Fails the test if no such event
+// exists.
+func findBlockEvent(t *testing.T, events []map[string]any, name string, blockIndex int) map[string]any {
+	t.Helper()
+	for _, e := range events {
+		if e["__event"] != name {
+			continue
+		}
+		idx, ok := e["index"].(float64)
+		if !ok {
+			continue
+		}
+		if int(idx) == blockIndex {
+			return e
+		}
+	}
+	t.Fatalf("no %s event with index %d in: %+v", name, blockIndex, events)
+	return nil
+}
+
+// findBlockEvents returns every event with the given name whose
+// `index` matches blockIndex.
+func findBlockEvents(events []map[string]any, name string, blockIndex int) []map[string]any {
+	var out []map[string]any
+	for _, e := range events {
+		if e["__event"] != name {
+			continue
+		}
+		idx, ok := e["index"].(float64)
+		if !ok {
+			continue
+		}
+		if int(idx) == blockIndex {
+			out = append(out, e)
+		}
+	}
+	return out
+}
+
+// accumulateDeltaField walks a slice of content_block_delta event
+// payloads and concatenates the named field from every delta of the
+// matching type. Mirrors how a real Anthropic SDK client builds the
+// final block content from its delta stream.
+func accumulateDeltaField(events []map[string]any, deltaType, field string) string {
+	var out strings.Builder
+	for _, e := range events {
+		d, ok := e["delta"].(map[string]any)
+		if !ok || d["type"] != deltaType {
+			continue
+		}
+		if s, ok := d[field].(string); ok {
+			out.WriteString(s)
+		}
+	}
+	return out.String()
+}
+
 // --- OpenAI: invalid LLM JSON args become tool-result errors ---
 
 func TestHandleOpenAI_InvalidArgsJSON_BecomesToolResultError(t *testing.T) {


### PR DESCRIPTION
## Summary

When the intercept engine rebuilds an Anthropic SSE event stream from a non-streamed upstream response, it must emit `content_block_delta` events between `content_block_start` and `content_block_stop` for each content block. Anthropic SDK clients — Claude Code included — accumulate content from those delta events. The pre-#638 implementation stuffed the entire block into `content_block_start` and skipped deltas; the client's accumulator stayed empty, thinking content was lost, and the next-turn request was rejected by Anthropic.

Closes #638.

## What was wrong

`anthropicEventsFromMessage` (`internal/intercept/anthropic.go`) emitted only `content_block_start` + `content_block_stop` per block:

```go
startBlockData, _ := json.Marshal(map[string]any{
    "type":          "content_block_start",
    "index":         i,
    "content_block": bm,  // entire block, including content
})
// ... immediately followed by content_block_stop, no deltas
```

Claude Code's session accumulator works off `content_block_delta` events, not `content_block_start`. With deltas missing, thinking blocks landed in the session with `signature` set and `thinking` empty. Next turn → `messages.N.content.M.thinking: each thinking block must contain thinking` from Anthropic.

## What changed

`anthropicEventsFromMessage` now delegates per-block to a new `anthropicEventsForBlock` helper that emits the protocol-correct sequence per block type:

| Block type | `content_block_start` carries | `content_block_delta` carries |
|---|---|---|
| `text` | `{type:"text", text:""}` | `{type:"text_delta", text:"…"}` |
| `thinking` | `{type:"thinking", thinking:"", signature:""}` | `{type:"thinking_delta", thinking:"…"}` then `{type:"signature_delta", signature:"…"}` |
| `tool_use` | `{type:"tool_use", id, name, input:{}}` | `{type:"input_json_delta", partial_json:"…"}` |
| `redacted_thinking` | `{type:"redacted_thinking", data:"…"}` | (no deltas — opaque data ships on start) |
| unknown | full block (pre-fix shape) | (no deltas) |

The fall-through for unknown block types preserves graceful behavior for future protocol additions — emitting something the client can ignore beats dropping a block entirely.

## Regression tests

Two new tests in `internal/intercept/intercept_test.go`:

- `TestHandleAnthropic_StreamingRebuild_DeltasAccumulateToOriginalContent` — upstream returns a `thinking` + `text` response; the test parses the emitted SSE, walks the deltas the way an SDK accumulator would, and asserts the recovered content equals the original.
- `TestHandleAnthropic_StreamingRebuild_ToolUseInputArrivesAsDelta` — same shape for `tool_use`: id/name on the start, input JSON on the delta.

Test helpers (`parseSSEEvents`, `findBlockEvent`, `findBlockEvents`, `accumulateDeltaField`) added inline; they assert against the protocol contract, so the tests survive future refactors of `anthropicEventsForBlock` as long as the wire shape stays correct.

**Verified the tests catch the original bug.** Stashed the production fix, re-ran — both tests cleanly fail with messages naming the exact symptom (thinking field on start instead of in delta; deltas list empty). Restored the fix; both pass.

## Test plan

- [x] `go test -count=1 ./internal/intercept/...` clean (existing tests + 2 new)
- [x] `go test -count=1 ./internal/app/...` clean (gateway handler unchanged)
- [x] Coverage on `internal/intercept`: 91.4% (was 90.7% before this PR — net +0.7%)
- [x] Tests fail against the pre-fix code, pass against the fix
- [ ] Manual smoke: `aileron launch claude` against a thinking-enabled Claude model with the Gmail+Calendar action suite installed; ask a multi-turn question; confirm no 400 from Anthropic

## Out of scope

- Streaming upstream-response → client directly instead of reconstructing from a non-streamed body. That's a larger refactor and `setStream(aug.Body, false)` is load-bearing for the tool-call interception loop. Reconstructed-SSE remains the right shape for v1; the goal here was to make the reconstruction correct.
- OpenAI Chat Completions parity. The OpenAI streaming protocol is different and doesn't have the same thinking-block trap. If a parallel bug exists, it's its own issue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)