### PR TITLE
feat(action): suite-level install consent — one prompt per suite

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -2065,6 +2065,14 @@ type actionAddOptions struct {
 	force   bool
 	yes     bool
 	noBind  bool
+	// suiteConsented is set by the suite-install path after the user
+	// has approved the suite-level consent screen. installOneAction
+	// then skips its own per-action Y/N prompt and the per-action
+	// preview render — both have already been surfaced at the suite
+	// level. Distinct from `yes` (which means "the operator passed
+	// --yes on the CLI; skip every interactive prompt including
+	// publisher trust") so each path can degrade independently.
+	suiteConsented bool
 	// outcome, when non-nil, is populated with a richer status code
 	// so the suite-install path can render a per-entry summary that
 	// distinguishes added / upgraded / already-installed / skipped /
@@ -2210,13 +2218,23 @@ func installOneAction(opts actionAddOptions, stdin io.Reader, stdout, stderr io.
 	// Step 2: render the consent prompt. Shows action metadata plus
 	// the connector deps split into "already installed" vs. "will
 	// be installed alongside this action".
-	renderActionPreview(stdout, &preview)
+	//
+	// Suite-consented installs skip this render: the suite preview
+	// already showed the operator what's coming. Per-action verbosity
+	// during the install loop would just repeat that for every entry.
+	if !opts.suiteConsented {
+		renderActionPreview(stdout, &preview)
+	}
 
 	// Step 2b (issue #563): for any connector dep that will be newly
 	// installed and whose authority differs from the action's,
 	// prompt to trust before the install consent. Already-installed
 	// deps are skipped — their authorities were trusted on the
 	// install that put them in the cstore.
+	//
+	// Suite-consented installs pre-resolve every dep authority in the
+	// preflight phase, so this loop sees trustState.ensure as a fast
+	// no-op (already-trusted short-circuit) and never prompts.
 	for _, dep := range preview.ConnectorDeps {
 		if dep.AlreadyInstalled {
 			continue
@@ -2233,10 +2251,19 @@ func installOneAction(opts actionAddOptions, stdin io.Reader, stdout, stderr io.
 		}
 	}
 
-	// Step 3: prompt unless --yes. Upgrades get a different prompt
-	// that names both versions so the operator can't miss that
-	// they're overwriting an existing install.
-	if !opts.yes {
+	// Step 3: prompt unless --yes or suite-consented. Upgrades get a
+	// different prompt that names both versions so the operator can't
+	// miss that they're overwriting an existing install.
+	switch {
+	case opts.yes, opts.suiteConsented:
+		// --yes implies consent to upgrade just like fresh install.
+		// suite-consented inherits the user's "install all" decision
+		// covering both shapes, so the same force-on-upgrade rule
+		// applies.
+		if upgrade {
+			forceForInstall = true
+		}
+	default:
 		var prompt string
 		if upgrade {
 			renderActionUpgradeBanner(stdout, &preview)
@@ -2260,10 +2287,6 @@ func installOneAction(opts actionAddOptions, stdin io.Reader, stdout, stderr io.
 		if upgrade {
 			forceForInstall = true
 		}
-	} else if upgrade {
-		// --yes implies consent to upgrade, mirroring how --yes
-		// implies consent to fresh install.
-		forceForInstall = true
 	}
 
 	// Step 4: install. The server walks the connector deps server-
@@ -2479,12 +2502,21 @@ func runActionAddSuiteRemote(source string, opts actionAddOptions, stdin *bufio.
 	return installSuiteEntries(manifest, refs, opts, stdin, stdout, stderr)
 }
 
-// installSuiteEntries is the shared per-entry loop + summary used
-// by both local and remote suite paths. Each entry installs via
-// installOneAction; one trustState threads through every call so
-// publisher prompts fire at most once per run. Per-entry failures
-// are captured for the final summary; the loop never aborts mid-
-// stream (failure-soft).
+// installSuiteEntries drives a suite install in three phases (#640):
+//
+//  1. Preflight: ensure publisher trust for every action authority,
+//     preview every ref against the daemon, ensure trust for every
+//     new connector-dep authority. Every prompt the run will issue
+//     happens here, before the user commits.
+//  2. Consent: render the collapsed suite preview (one line per
+//     action) and prompt once for the whole suite. --yes skips the
+//     prompt. All-already-installed skips the prompt. Decline marks
+//     every action as cancelled and exits 0.
+//  3. Install: call installOneAction per ref with suiteConsented=true.
+//     trustState is fully populated; per-action previews are silent
+//     (already shown in phase 2); no Y/N prompts fire. Per-action
+//     failures stay failure-soft; the summary at the end reports
+//     counts and a nonzero exit if anything failed.
 func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, opts actionAddOptions, stdin *bufio.Reader, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "Suite: %s\n", manifest.Name)
 	if manifest.Description != "" {
@@ -2493,31 +2525,328 @@ func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, opts actio
 	fmt.Fprintf(stdout, "  %d action(s) to install\n", len(refs))
 
 	trust := newTrustState()
-	type result struct {
-		ref     string
-		rc      int
-		outcome actionInstallStatus
+
+	// Phase 1a: trust action authorities up front so preview can
+	// verify signatures. Any decline here aborts the suite before
+	// the consent screen — the operator hasn't committed yet.
+	if rc := trustAuthoritiesForRefs(refs, opts.yes, trust, stdin, stdout, stderr); rc != 0 {
+		return rc
 	}
-	results := make([]result, 0, len(refs))
+
+	// Phase 1b: preview every ref. Per-ref preview failures land in
+	// the preflight result with a clear status so the consent screen
+	// surfaces them; the user can still install the healthy actions.
+	previews := previewSuiteRefs(refs, stdout)
+
+	// Phase 1c: trust new connector-dep authorities. Same abort-on-
+	// decline rule as 1a; the consent screen wouldn't render honest
+	// data with mixed trust state otherwise.
+	if rc := trustConnectorDepAuthorities(previews, opts.yes, trust, stdin, stdout, stderr); rc != 0 {
+		return rc
+	}
+
+	// Phase 2: collapsed consent screen + single Y/N.
+	plan := buildSuitePlan(refs, previews)
+	if plan.toInstall == 0 && plan.previewFailed == 0 {
+		fmt.Fprintln(stdout)
+		fmt.Fprintf(stdout, "All %d action(s) already installed; nothing to do.\n", len(refs))
+		return 0
+	}
+	cancelled := false
+	if !opts.yes {
+		renderSuitePreview(stdout, manifest, plan)
+		ans := strings.ToLower(strings.TrimSpace(promptLine(stdin, stdout, "Install? [y/N]: ")))
+		if ans != "y" && ans != "yes" {
+			cancelled = true
+		}
+	}
+
+	// Phase 3: install loop. Cancellation collapses every still-
+	// pending ref into actionInstallStatusCancelled; preview-failed
+	// refs stay failed regardless. The trustState carries the
+	// authorities resolved in phase 1.
+	results := runSuiteInstallLoop(refs, previews, opts, trust, cancelled, stdin, stdout, stderr)
+	return renderSuiteSummary(stdout, results)
+}
+
+// suiteRefPreview pairs a ref with its preview attempt. err is non-
+// nil when the daemon refused to preview the action; the consent
+// screen surfaces that explicitly and the install loop short-circuits
+// the ref as failed.
+type suiteRefPreview struct {
+	ref     cstore.Ref
+	preview *actionPreviewWire
+	err     error
+}
+
+// suitePlan is the per-ref classification the consent screen renders
+// and the install loop consults. Built once at the boundary between
+// preflight and consent so both paths see the same view.
+type suitePlan struct {
+	entries         []suitePlanEntry
+	toInstall       int
+	alreadyExisting int
+	previewFailed   int
+	hasUpgrade      bool
+	connectors      []suitePlanConnector
+}
+
+type suitePlanEntry struct {
+	ref             string
+	name            string
+	version         string
+	status          suitePlanStatus
+	existingVersion string // populated for statusUpgrade
+	previewErr      string // populated for statusPreviewFailed
+}
+
+type suitePlanStatus int
+
+const (
+	statusFresh suitePlanStatus = iota
+	statusUpgrade
+	statusAlreadyInstalled
+	statusPreviewFailed
+)
+
+type suitePlanConnector struct {
+	fqn              string
+	version          string
+	alreadyInstalled bool
+}
+
+func buildSuitePlan(refs []cstore.Ref, previews []suiteRefPreview) suitePlan {
+	plan := suitePlan{entries: make([]suitePlanEntry, 0, len(previews))}
+	seenConnectors := map[string]suitePlanConnector{}
+	for i, p := range previews {
+		entry := suitePlanEntry{ref: refs[i].String()}
+		switch {
+		case p.err != nil:
+			entry.status = statusPreviewFailed
+			entry.previewErr = p.err.Error()
+			plan.previewFailed++
+		case p.preview != nil && p.preview.AlreadyInstalled:
+			entry.name = p.preview.Name
+			entry.version = p.preview.Version
+			entry.status = statusAlreadyInstalled
+			plan.alreadyExisting++
+		case p.preview != nil && p.preview.Existing != nil:
+			entry.name = p.preview.Name
+			entry.version = p.preview.Version
+			entry.status = statusUpgrade
+			entry.existingVersion = p.preview.Existing.Version
+			plan.toInstall++
+			plan.hasUpgrade = true
+		case p.preview != nil:
+			entry.name = p.preview.Name
+			entry.version = p.preview.Version
+			entry.status = statusFresh
+			plan.toInstall++
+		}
+		plan.entries = append(plan.entries, entry)
+
+		// Aggregate connectors deduped by FQN+version. New (not yet
+		// installed) trumps already-installed when the same FQN
+		// shows up under multiple actions in either state.
+		if p.preview == nil {
+			continue
+		}
+		for _, dep := range p.preview.ConnectorDeps {
+			key := dep.Fqn + "@" + dep.Version
+			cur, exists := seenConnectors[key]
+			if !exists {
+				seenConnectors[key] = suitePlanConnector{
+					fqn: dep.Fqn, version: dep.Version, alreadyInstalled: dep.AlreadyInstalled,
+				}
+				continue
+			}
+			if cur.alreadyInstalled && !dep.AlreadyInstalled {
+				cur.alreadyInstalled = false
+				seenConnectors[key] = cur
+			}
+		}
+	}
+	plan.connectors = make([]suitePlanConnector, 0, len(seenConnectors))
+	for _, c := range seenConnectors {
+		plan.connectors = append(plan.connectors, c)
+	}
+	return plan
+}
+
+func renderSuitePreview(w io.Writer, manifest *suite.Manifest, plan suitePlan) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "\033[1mSuite install preview\033[0m")
+	fmt.Fprintln(w)
+	header := fmt.Sprintf("Install %d action(s) from this suite", plan.toInstall)
+	if plan.alreadyExisting > 0 {
+		header += fmt.Sprintf(" (%d already installed will be skipped)", plan.alreadyExisting)
+	}
+	if plan.previewFailed > 0 {
+		header += fmt.Sprintf(" (%d preview-failed will be marked failed)", plan.previewFailed)
+	}
+	fmt.Fprintln(w, header+":")
+	for _, e := range plan.entries {
+		switch e.status {
+		case statusFresh:
+			fmt.Fprintf(w, "  \033[32m+\033[0m %-30s v%s   (new)\n", e.name, e.version)
+		case statusUpgrade:
+			fmt.Fprintf(w, "  \033[33m↺\033[0m %-30s v%s   (upgrade from v%s)\n",
+				e.name, e.version, e.existingVersion)
+		case statusAlreadyInstalled:
+			fmt.Fprintf(w, "  \033[2m✓\033[0m \033[2m%-30s v%s   (already installed)\033[0m\n",
+				e.name, e.version)
+		case statusPreviewFailed:
+			fmt.Fprintf(w, "  \033[31m✗\033[0m %-30s        (preview failed: %s)\n",
+				e.ref, e.previewErr)
+		}
+	}
+	if len(plan.connectors) > 0 {
+		fmt.Fprintln(w)
+		fmt.Fprintln(w, "\033[1mConnectors:\033[0m")
+		for _, c := range plan.connectors {
+			if c.alreadyInstalled {
+				fmt.Fprintf(w, "  \033[2m✓ %s@%s   (already installed)\033[0m\n", c.fqn, c.version)
+			} else {
+				fmt.Fprintf(w, "  \033[32m+\033[0m %s@%s   (new)\n", c.fqn, c.version)
+			}
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+// trustAuthoritiesForRefs runs trust.ensure for every unique action
+// authority across the refs. Returns nonzero when any authority is
+// declined or the keyring write fails — the suite cannot proceed past
+// preview without trust, and per-issue #640 the suite is atomic at
+// the consent layer, so a partial set of trusted authorities does not
+// produce a partial install. Authorities the user already trusts in
+// this run short-circuit at trustState.ensure with no further prompt.
+func trustAuthoritiesForRefs(refs []cstore.Ref, autoYes bool, trust *trustState, stdin io.Reader, stdout, stderr io.Writer) int {
+	for _, ref := range refs {
+		// ref.FQN.Authority() is the canonical accessor; the FQN was
+		// already validated by suite.Resolve, so no parse error is
+		// expected here.
+		if err := trust.ensure(ref.FQN.Authority(), autoYes, stdin, stdout, stderr); err != nil {
+			fmt.Fprintf(stderr, "error: %v\n", err)
+			return 1
+		}
+	}
+	return 0
+}
+
+// previewSuiteRefs calls /actions/preview for every ref in declaration
+// order. Failures are captured per-entry rather than aborting the
+// loop; the consent screen surfaces them with their error so the
+// operator sees what went wrong.
+func previewSuiteRefs(refs []cstore.Ref, _ io.Writer) []suiteRefPreview {
+	out := make([]suiteRefPreview, 0, len(refs))
+	for _, ref := range refs {
+		fqnStr, version, _ := splitFQNVersion(ref.String(), "")
+		body, _ := json.Marshal(map[string]any{"fqn": fqnStr, "version": version})
+		status, raw, err := bindingDoRequest(http.MethodPost, "/actions/preview",
+			strings.NewReader(string(body)))
+		if err != nil {
+			out = append(out, suiteRefPreview{ref: ref, err: err})
+			continue
+		}
+		if status != http.StatusOK {
+			out = append(out, suiteRefPreview{ref: ref,
+				err: fmt.Errorf("daemon returned %d", status)})
+			continue
+		}
+		var preview actionPreviewWire
+		if err := json.Unmarshal(raw, &preview); err != nil {
+			out = append(out, suiteRefPreview{ref: ref, err: err})
+			continue
+		}
+		out = append(out, suiteRefPreview{ref: ref, preview: &preview})
+	}
+	return out
+}
+
+// trustConnectorDepAuthorities walks the preflight previews, collects
+// the unique authorities of every new (not-already-installed)
+// connector dep, and runs trust.ensure for each. Same atomic semantics
+// as trustAuthoritiesForRefs — any decline aborts before consent.
+func trustConnectorDepAuthorities(previews []suiteRefPreview, autoYes bool, trust *trustState, stdin io.Reader, stdout, stderr io.Writer) int {
+	for _, p := range previews {
+		if p.preview == nil {
+			continue
+		}
+		for _, dep := range p.preview.ConnectorDeps {
+			if dep.AlreadyInstalled {
+				continue
+			}
+			depFQN, perr := cstore.ParseFQN(dep.Fqn)
+			if perr != nil {
+				continue
+			}
+			if err := trust.ensure(depFQN.Authority(), autoYes, stdin, stdout, stderr); err != nil {
+				fmt.Fprintf(stderr, "error: %v\n", err)
+				return 1
+			}
+		}
+	}
+	return 0
+}
+
+// suiteInstallResult mirrors the per-ref slot of the pre-#640 anonymous
+// struct in installSuiteEntries; named here so the helper can return
+// a clean slice.
+type suiteInstallResult struct {
+	ref     string
+	rc      int
+	outcome actionInstallStatus
+}
+
+// runSuiteInstallLoop runs installOneAction per ref, threading the
+// already-populated trustState through. cancelled=true short-circuits
+// every ref into actionInstallStatusCancelled and skips the install
+// call entirely (this is what fires after the user says "n" at the
+// suite consent prompt).
+//
+// Preview-failed refs (from phase 1b) are reported as failed without
+// re-running installOneAction — the underlying preview call would
+// just fail again.
+func runSuiteInstallLoop(refs []cstore.Ref, previews []suiteRefPreview, opts actionAddOptions, trust *trustState, cancelled bool, stdin *bufio.Reader, stdout, stderr io.Writer) []suiteInstallResult {
+	results := make([]suiteInstallResult, 0, len(refs))
 	for i, ref := range refs {
 		fmt.Fprintln(stdout)
 		fmt.Fprintf(stdout, "── [%d/%d] %s\n", i+1, len(refs), ref.String())
+		if previews[i].err != nil {
+			fmt.Fprintf(stderr, "  preview failed earlier: %v\n", previews[i].err)
+			results = append(results, suiteInstallResult{ref: ref.String(), rc: 1, outcome: actionInstallStatusFailed})
+			continue
+		}
+		if cancelled {
+			results = append(results, suiteInstallResult{ref: ref.String(), rc: 0, outcome: actionInstallStatusCancelled})
+			continue
+		}
 		entryOpts := opts
 		entryOpts.fqn = ref.String()
+		entryOpts.suiteConsented = true
 		var outcome actionInstallOutcome
 		entryOpts.outcome = &outcome
 		rc := installOneAction(entryOpts, stdin, stdout, stderr, trust)
-		results = append(results, result{ref: ref.String(), rc: rc, outcome: outcome.status})
+		results = append(results, suiteInstallResult{ref: ref.String(), rc: rc, outcome: outcome.status})
 	}
+	return results
+}
 
-	fmt.Fprintln(stdout)
-	fmt.Fprintln(stdout, "Suite install summary:")
+// renderSuiteSummary prints the per-ref outcome list + the rolled-up
+// count line. Mirrors the pre-#640 trailing summary; returns the exit
+// code (nonzero if any ref failed). Cancellation counts toward the
+// summary; the user explicitly chose to cancel, so the run is "all
+// cancelled" rather than "0 added, 4 cancelled".
+func renderSuiteSummary(w io.Writer, results []suiteInstallResult) int {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "Suite install summary:")
 	var counts struct {
 		added, upgraded, alreadyInstalled, skipped, cancelled, failed int
 	}
 	for _, r := range results {
 		marker, label := summaryLine(r.outcome, r.rc)
-		fmt.Fprintf(stdout, "  %s %s%s\n", marker, r.ref, label)
+		fmt.Fprintf(w, "  %s %s%s\n", marker, r.ref, label)
 		switch r.outcome {
 		case actionInstallStatusAdded:
 			counts.added++
@@ -2532,9 +2861,6 @@ func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, opts actio
 		case actionInstallStatusFailed:
 			counts.failed++
 		default:
-			// Defensive: an unset outcome with rc=0 is treated as
-			// "added"; with rc!=0 as "failed". Keeps the summary sane
-			// if a future code path forgets to call setOutcome.
 			if r.rc == 0 {
 				counts.added++
 			} else {
@@ -2542,8 +2868,7 @@ func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, opts actio
 			}
 		}
 	}
-
-	fmt.Fprintln(stdout)
+	fmt.Fprintln(w)
 	parts := make([]string, 0, 6)
 	if counts.added > 0 {
 		parts = append(parts, fmt.Sprintf("%d added", counts.added))
@@ -2563,7 +2888,7 @@ func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, opts actio
 	if counts.failed > 0 {
 		parts = append(parts, fmt.Sprintf("%d failed", counts.failed))
 	}
-	fmt.Fprintf(stdout, "%d action(s): %s.\n", len(results), strings.Join(parts, ", "))
+	fmt.Fprintf(w, "%d action(s): %s.\n", len(results), strings.Join(parts, ", "))
 	if counts.failed > 0 {
 		return 1
 	}

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -4071,6 +4071,185 @@ actions = [
 	}
 }
 
+// TestRunActionAddSuite_PreviewFailureMarkedFailedInSummary: when
+// the daemon refuses to preview one ref (e.g. signature_failure on a
+// rotated key), the suite consent screen surfaces the failure with
+// the ✗ marker, the user can still install the healthy entries, and
+// the summary buckets the broken one as `failed` while reporting the
+// rest as added. Preview-failed entries never reach the install
+// endpoint.
+func TestRunActionAddSuite_PreviewFailureMarkedFailedInSummary(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+name = "preview-fail"
+description = "One bad apple; the rest install."
+
+actions = [
+  "github://acme/conn/actions/foo@0.1.0",
+  "github://acme/conn/actions/bar@0.1.0",
+  "github://acme/conn/actions/baz@0.1.0",
+]
+`)
+	installCalls := map[string]int{}
+	suiteInstallServer(t, []string{"github://acme/conn"},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			if strings.Contains(fqn, "/bar") {
+				// Simulate the daemon refusing to preview this ref
+				// (rotated signing key, missing keyring entry, etc.).
+				w.WriteHeader(http.StatusUnprocessableEntity)
+				_, _ = io.WriteString(w, `{"error":{"code":"signature_failure","message":"key not found"}}`)
+				return
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.1.0","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				fqn, lastSegment(fqn))
+		},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			installCalls[fqn]++
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.1.0","source":"x","path":"/p"}`, lastSegment(fqn), fqn)
+		},
+	)
+
+	stdin := strings.NewReader("y\n")
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{manifestPath}, stdin, &stdout, &stderr)
+	if code == 0 {
+		t.Errorf("expected nonzero exit when a preview fails; stderr=%s", stderr.String())
+	}
+	// The two healthy refs install; the broken one is never sent to
+	// /actions/install (it short-circuits as failed before the loop
+	// even runs the entry). Install endpoint receives the bare FQN
+	// (the @<version> rides in the request body, not the FQN field).
+	if installCalls["github://acme/conn/actions/bar"] != 0 {
+		t.Errorf("install endpoint hit for preview-failed ref; calls=%d",
+			installCalls["github://acme/conn/actions/bar"])
+	}
+	if installCalls["github://acme/conn/actions/foo"] != 1 ||
+		installCalls["github://acme/conn/actions/baz"] != 1 {
+		t.Errorf("expected healthy refs to install; calls=%+v", installCalls)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Suite install preview",
+		"(preview failed",
+		"actions/bar@0.1.0",
+		"actions/foo@0.1.0 (added)",
+		"actions/baz@0.1.0 (added)",
+		"3 action(s): 2 added, 1 failed.",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunActionAddSuite_YesFlagSkipsSuiteConsentPrompt: --yes is an
+// explicit "skip every prompt including the suite-level one". Pin
+// the contract: zero "Install?" prompts in the output regardless of
+// how many actions are in the suite.
+func TestRunActionAddSuite_YesFlagSkipsSuiteConsentPrompt(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+name = "yes-skips"
+description = "Four actions; --yes; zero prompts."
+
+actions = [
+  "github://acme/conn/actions/a1@0.1.0",
+  "github://acme/conn/actions/a2@0.1.0",
+  "github://acme/conn/actions/a3@0.1.0",
+  "github://acme/conn/actions/a4@0.1.0",
+]
+`)
+	installCalls := map[string]int{}
+	suiteInstallServer(t, []string{"github://acme/conn"}, nil,
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			installCalls[fqn]++
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.1.0","source":"x","path":"/p"}`, lastSegment(fqn), fqn)
+		},
+	)
+
+	// Empty stdin: if a prompt fires, the test deadlocks (the daemon
+	// is mocked but stdin is bounded). Asserting 0 prompts in stdout
+	// is the explicit contract.
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{"--yes", manifestPath}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if got := strings.Count(stdout.String(), "Install? [y/N]: "); got != 0 {
+		t.Errorf("--yes must suppress every consent prompt, got %d:\n%s", got, stdout.String())
+	}
+	if got := strings.Count(stdout.String(), "Suite install preview"); got != 0 {
+		t.Errorf("--yes must suppress the suite preview screen, got %d:\n%s", got, stdout.String())
+	}
+	if len(installCalls) != 4 {
+		t.Errorf("expected 4 install calls under --yes; got %d (%+v)", len(installCalls), installCalls)
+	}
+}
+
+// TestRunActionAddSuite_ConnectorDepsAggregatedAndDeduped: the suite
+// preview's "Connectors:" section lists every distinct dep once. Two
+// actions sharing a dep render that dep on one line; a third action
+// declaring a different dep adds a second line. Exercises
+// buildSuitePlan's dedup-by-FQN+version path.
+func TestRunActionAddSuite_ConnectorDepsAggregatedAndDeduped(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+name = "shared-deps"
+description = "Two share a connector dep; one is on its own."
+
+actions = [
+  "github://acme/conn/actions/foo@0.1.0",
+  "github://acme/conn/actions/bar@0.1.0",
+  "github://acme/conn/actions/baz@0.1.0",
+]
+`)
+	suiteInstallServer(t, []string{"github://acme/conn"},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			name := lastSegment(fqn)
+			// foo + bar share connector "google"; baz declares
+			// "calendar". Both are not-already-installed.
+			var deps string
+			switch name {
+			case "foo", "bar":
+				deps = `[{"fqn":"github://acme/google","version":"0.0.7","hash":"sha256:g","capabilities":["network"],"already_installed":false}]`
+			case "baz":
+				deps = `[{"fqn":"github://acme/calendar","version":"0.0.3","hash":"sha256:c","capabilities":["network"],"already_installed":false}]`
+			}
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.1.0","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":%s}`,
+				fqn, name, deps)
+		},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.1.0","source":"x","path":"/p"}`, lastSegment(fqn), fqn)
+		},
+	)
+	// Seed trust for both connector authorities so the preflight
+	// trust pass doesn't prompt; the test is about preview rendering.
+	withSeededKeyring(t, "github://acme/conn", "github://acme/google", "github://acme/calendar")
+
+	stdin := strings.NewReader("n\n") // decline to focus on the rendered preview
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{manifestPath}, stdin, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Connectors:",
+		"github://acme/google@0.0.7",
+		"github://acme/calendar@0.0.3",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("preview missing %q:\n%s", want, out)
+		}
+	}
+	// The shared dep must appear exactly once, not once per action.
+	if got := strings.Count(out, "github://acme/google@0.0.7"); got != 1 {
+		t.Errorf("shared connector listed %d times, want exactly 1:\n%s", got, out)
+	}
+}
+
 // TestRunActionAddSuite_MissingManifestFileExits1 surfaces a clear
 // error when the local source path doesn't exist.
 func TestRunActionAddSuite_MissingManifestFileExits1(t *testing.T) {

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -3793,10 +3793,12 @@ actions = [
 	}
 }
 
-// TestRunActionAddSuite_AlreadyInstalledIsLoggedAsSuccess: an
-// already-installed action counts as success — the suite intent
-// is satisfied.
-func TestRunActionAddSuite_AlreadyInstalledIsLoggedAsSuccess(t *testing.T) {
+// TestRunActionAddSuite_AlreadyInstalledShortCircuits: when every
+// action in the suite is already installed, the consent prompt is
+// suppressed and the run exits 0 with a single all-already-installed
+// message. Per #640, the suite-level consent screen is only shown
+// when there is install work to commit.
+func TestRunActionAddSuite_AlreadyInstalledShortCircuits(t *testing.T) {
 	manifestPath := writeSuiteManifest(t, `
 name = "rerun"
 description = "Re-running with everything already installed."
@@ -3817,17 +3819,20 @@ actions = [
 		},
 	)
 
+	// Empty stdin: the suite must not prompt — if the consent screen
+	// fired, the read would race and the test would be flaky.
 	var stdout, stderr bytes.Buffer
 	code := runActionAddSuite([]string{manifestPath}, strings.NewReader(""), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
 	}
 	out := stdout.String()
-	if strings.Count(out, "Already installed:") != 2 {
-		t.Errorf("expected 2 'Already installed' lines; got: %s", out)
+	if !strings.Contains(out, "All 2 action(s) already installed") {
+		t.Errorf("expected all-already-installed short-circuit: %s", out)
 	}
-	if !strings.Contains(out, "2 action(s): 2 already installed.") {
-		t.Errorf("summary should treat already-installed as success: %s", out)
+	// The interactive consent screen must not have rendered.
+	if strings.Contains(out, "Install?") {
+		t.Errorf("consent prompt should be suppressed when nothing to do:\n%s", out)
 	}
 }
 
@@ -3892,16 +3897,19 @@ actions = [
 	}
 }
 
-// TestRunActionAddSuite_DeclinedUpgradeIsSkippedNotFailed: when the
-// user declines the upgrade prompt for one entry mid-suite, the
-// summary buckets it as "skipped" (not failed) and the run exits 0.
-// This is the v2 fix for the bug where add-suite returned exit 1
-// because already-installed-with-different-bytes entries were treated
-// as 409 conflicts.
-func TestRunActionAddSuite_DeclinedUpgradeIsSkippedNotFailed(t *testing.T) {
+// TestRunActionAddSuite_DeclineCancelsEveryEntry: per #640, the
+// suite is atomic at the consent layer. One Y/N prompt covers the
+// whole suite (whether the entries are fresh, upgrades, or a mix);
+// "n" cancels every entry, no install endpoint is called, and the
+// run exits 0 with a summary that bucketed every entry as cancelled.
+//
+// Replaces the pre-#640 per-action upgrade-decline behavior that
+// allowed partial install when one entry of a multi-entry suite was
+// declined.
+func TestRunActionAddSuite_DeclineCancelsEveryEntry(t *testing.T) {
 	manifestPath := writeSuiteManifest(t, `
-name = "decline-upgrade"
-description = "User keeps the existing version of bar."
+name = "decline-suite"
+description = "Decline the suite; nothing installs."
 
 actions = [
   "github://acme/conn/actions/foo@0.2.0",
@@ -3913,13 +3921,11 @@ actions = [
 		func(fqn string, w http.ResponseWriter, r *http.Request) {
 			name := lastSegment(fqn)
 			if name == "bar" {
-				// Upgrade candidate.
 				w.WriteHeader(http.StatusOK)
 				fmt.Fprintf(w, `{"fqn":%q,"version":"0.2.0","hash":"sha256:new","name":%q,"signature_status":"verified","existing":{"version":"0.1.0","hash":"sha256:old","source":"github://acme/conn/actions/bar@0.1.0","path":"/p/bar.md"},"connector_deps":[]}`,
 					fqn, name)
 				return
 			}
-			// Fresh.
 			w.WriteHeader(http.StatusOK)
 			fmt.Fprintf(w, `{"fqn":%q,"version":"0.2.0","hash":"sha256:foo","name":%q,"signature_status":"verified","connector_deps":[]}`,
 				fqn, name)
@@ -3931,28 +3937,136 @@ actions = [
 		},
 	)
 
-	// Two prompts the suite will surface in order:
-	//   1. "Install? [y/N]" for foo (fresh) → "y"
-	//   2. "Replace v0.1.0 with v0.2.0?" for bar (upgrade) → "n"
-	stdin := strings.NewReader("y\nn\n")
+	// One suite-level prompt; "n" cancels everything.
+	stdin := strings.NewReader("n\n")
 	var stdout, stderr bytes.Buffer
 	code := runActionAddSuite([]string{manifestPath}, stdin, &stdout, &stderr)
 	if code != 0 {
-		t.Fatalf("declined upgrade should not fail the suite; exit=%d stderr=%s", code, stderr.String())
+		t.Fatalf("decline must not be a failure; exit=%d stderr=%s", code, stderr.String())
 	}
-	if installCalls["github://acme/conn/actions/bar@0.2.0"] != 0 {
-		t.Errorf("bar install must not be called when operator declines upgrade; calls=%d",
-			installCalls["github://acme/conn/actions/bar@0.2.0"])
+	if len(installCalls) > 0 {
+		t.Errorf("install endpoint must not be hit when suite is declined; calls=%+v", installCalls)
 	}
 	out := stdout.String()
+	// Exactly one consent prompt, regardless of fresh + upgrade mix.
+	if got := strings.Count(out, "Install? [y/N]: "); got != 1 {
+		t.Errorf("expected exactly 1 suite-level prompt, got %d:\n%s", got, out)
+	}
 	for _, want := range []string{
-		"Replace v0.1.0 with v0.2.0?",
-		"Skipped: bar (kept v0.1.0)",
-		"actions/bar@0.2.0 (skipped — kept existing version)",
-		"2 action(s): 1 added, 1 skipped.",
+		"Suite install preview",
+		"actions/foo@0.2.0 (cancelled)",
+		"actions/bar@0.2.0 (cancelled)",
+		"2 action(s): 2 cancelled.",
 	} {
 		if !strings.Contains(out, want) {
 			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunActionAddSuite_SingleConsentPromptForManyActions: the
+// headline #640 contract. A suite with N actions surfaces exactly one
+// "Install?" prompt under interactive mode. Pre-#640, each action got
+// its own prompt; for the Gmail+Calendar suite that was 6 prompts in
+// a row.
+func TestRunActionAddSuite_SingleConsentPromptForManyActions(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+name = "many"
+description = "Six actions; one prompt."
+
+actions = [
+  "github://acme/conn/actions/a1@0.1.0",
+  "github://acme/conn/actions/a2@0.1.0",
+  "github://acme/conn/actions/a3@0.1.0",
+  "github://acme/conn/actions/a4@0.1.0",
+  "github://acme/conn/actions/a5@0.1.0",
+  "github://acme/conn/actions/a6@0.1.0",
+]
+`)
+	installCalls := map[string]int{}
+	suiteInstallServer(t, []string{"github://acme/conn"},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.1.0","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				fqn, lastSegment(fqn))
+		},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			installCalls[fqn]++
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.1.0","source":"x","path":"/p"}`, lastSegment(fqn), fqn)
+		},
+	)
+
+	stdin := strings.NewReader("y\n")
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{manifestPath}, stdin, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if got := strings.Count(out, "Install? [y/N]: "); got != 1 {
+		t.Errorf("expected exactly 1 suite-level prompt for 6 actions, got %d:\n%s", got, out)
+	}
+	if len(installCalls) != 6 {
+		t.Errorf("expected install endpoint hit 6 times, got %d:\n%+v", len(installCalls), installCalls)
+	}
+}
+
+// TestRunActionAddSuite_MixedFreshAndUpgradeInPreview: the suite
+// preview labels each entry by status — fresh (+), upgrade (↺),
+// already installed (✓). Visual-regression test for the consent
+// screen #640 introduces.
+func TestRunActionAddSuite_MixedFreshAndUpgradeInPreview(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+name = "mixed-preview"
+description = "Fresh + upgrade + already-installed in one preview."
+
+actions = [
+  "github://acme/conn/actions/foo@0.2.0",
+  "github://acme/conn/actions/bar@0.2.0",
+  "github://acme/conn/actions/baz@0.2.0",
+]
+`)
+	suiteInstallServer(t, []string{"github://acme/conn"},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			name := lastSegment(fqn)
+			switch name {
+			case "foo":
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"fqn":%q,"version":"0.2.0","hash":"sha256:foo","name":%q,"signature_status":"verified","connector_deps":[]}`,
+					fqn, name)
+			case "bar":
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"fqn":%q,"version":"0.2.0","hash":"sha256:new","name":%q,"signature_status":"verified","existing":{"version":"0.1.0","hash":"sha256:old","source":"github://acme/conn/actions/bar@0.1.0","path":"/p/bar.md"},"connector_deps":[]}`,
+					fqn, name)
+			case "baz":
+				w.WriteHeader(http.StatusOK)
+				fmt.Fprintf(w, `{"fqn":%q,"version":"0.2.0","hash":"sha256:baz","name":%q,"already_installed":true,"connector_deps":[]}`,
+					fqn, name)
+			}
+		},
+		func(fqn string, w http.ResponseWriter, r *http.Request) {
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.2.0","source":"x","path":"/p"}`, lastSegment(fqn), fqn)
+		},
+	)
+
+	stdin := strings.NewReader("n\n") // decline so we only assert preview rendering.
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{manifestPath}, stdin, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Suite install preview",
+		"Install 2 action(s) from this suite (1 already installed will be skipped):",
+		"(new)",
+		"(upgrade from v0.1.0)",
+		"(already installed)",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("preview missing %q:\n%s", want, out)
 		}
 	}
 }
@@ -4019,10 +4133,13 @@ actions = [
 	}
 }
 
-// TestRunActionAddSuite_TrustDeclineSkipsRemainingSameAuthority:
-// trust decline mid-suite → remaining same-authority actions skip
-// without re-prompting.
-func TestRunActionAddSuite_TrustDeclineSkipsRemainingSameAuthority(t *testing.T) {
+// TestRunActionAddSuite_TrustDeclineAbortsBeforeConsent: per #640's
+// atomic-at-consent rule, trust prompts happen up front during the
+// preflight phase. Declining trust for the suite's publisher aborts
+// the run cleanly: no /actions/preview calls, no consent screen, no
+// install attempt — and exits non-zero so a script that ran the
+// suite install sees the failure.
+func TestRunActionAddSuite_TrustDeclineAbortsBeforeConsent(t *testing.T) {
 	withTempHome(t)
 	_, pemBytes := genTestKey(t)
 	withMockGitHubRaw(t, map[string][]byte{
@@ -4031,7 +4148,7 @@ func TestRunActionAddSuite_TrustDeclineSkipsRemainingSameAuthority(t *testing.T)
 
 	manifestPath := writeSuiteManifest(t, `
 name = "decline-test"
-description = "Decline trust; remaining actions should skip."
+description = "Decline trust; the run aborts before consent."
 
 actions = [
   "github://acme/conn/actions/foo@0.1.0",
@@ -4060,8 +4177,10 @@ actions = [
 	if strings.Count(stdout.String(), "Publisher github://acme/conn is not yet trusted") != 1 {
 		t.Errorf("trust banner should fire once across the suite, not per action:\n%s", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "failed.") {
-		t.Errorf("summary should report failures; got: %s", stdout.String())
+	// The interactive consent screen must not have rendered — the
+	// run aborted before reaching it.
+	if strings.Contains(stdout.String(), "Suite install preview") {
+		t.Errorf("consent screen should not render after trust decline:\n%s", stdout.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

`aileron action add-suite` used to prompt for install consent per action. A 6-action suite produced 6 `Install? [y/N]:` prompts in sequence. The user asked to install a suite — they should consent at the suite level, once, atomically.

Refactor `installSuiteEntries` into three phases: preflight (trust + preview), suite-level consent, install loop with consent already given.

Closes #640.

## Sample run (after this change)

```
Suite: aileron-connector-google
  Curated Gmail + Calendar actions.
  4 action(s) to install

Suite install preview

Install 3 action(s) from this suite (1 already installed will be skipped):
  + draft-email                  v0.0.7   (new)
  + send-email                   v0.0.7   (new)
  ↺ create-calendar-event        v0.0.7   (upgrade from v0.0.6)
  ✓ list-upcoming-events         v0.0.7   (already installed)

Connectors:
  ✓ github://ALRubinger/aileron-connector-google@0.0.7   (already installed)

Install? [y/N]:
```

One prompt covers the whole suite.

## Phases

1. **Preflight** — `trustAuthoritiesForRefs` ensures publisher trust for every unique action authority across the refs. `previewSuiteRefs` calls `/actions/preview` per ref and captures results (including failures). `trustConnectorDepAuthorities` resolves trust for any new connector-dep authorities discovered in the previews. Every prompt the run will issue happens here, before the user commits.
2. **Consent** — `buildSuitePlan` rolls the previews into a typed plan (fresh/upgrade/already-installed/preview-failed). `renderSuitePreview` shows the collapsed view. One Y/N prompt. `--yes` skips it; all-already-installed short-circuits; decline marks every action as cancelled with exit 0.
3. **Install** — `runSuiteInstallLoop` calls `installOneAction` per ref with the new `suiteConsented` flag. `installOneAction` skips the per-action preview render and Y/N prompt when `suiteConsented` is set; trust prompts no-op (`trustState` already populated); per-action failures stay failure-soft.

## Decisions baked in (from #640)

| Question | Decision |
|---|---|
| Detail level in the preview | Collapsed-by-default: one line per action with `+`/`↺`/`✓`/`✗` marker + version + status. |
| Per-action skip after suite consent | All-or-nothing. The user asked to install a suite. `aileron action add <FQN>` remains for surgical single-action work. |
| Per-action failure | Failure-soft; the summary at the end reports `M added, N upgraded, P already installed, Q failed`. |

## Test plan

- [x] `go test -count=1 ./cmd/aileron/...` — clean
- [x] Coverage on `cmd/aileron`: 84.4%
- [x] **New tests cleanly fail against the pre-#640 code and pass against the new code** (verified with `git stash` of `main.go`):
  - `TestRunActionAddSuite_SingleConsentPromptForManyActions` — 6 actions, 1 prompt
  - `TestRunActionAddSuite_DeclineCancelsEveryEntry` — single \"n\" cancels every action
  - `TestRunActionAddSuite_AlreadyInstalledShortCircuits` — all-already-installed message, no prompt
  - `TestRunActionAddSuite_MixedFreshAndUpgradeInPreview` — preview labels each entry correctly
  - `TestRunActionAddSuite_TrustDeclineAbortsBeforeConsent` — trust decline aborts before any preview / consent
- [ ] Manual smoke: `aileron action add-suite github://ALRubinger/aileron-connector-google/suite.toml@latest` against a fresh `~/.aileron`; confirm one consent prompt, one trust prompt, then the install loop runs without further interruption.

## Behavior changes worth knowing

- **All-already-installed run.** Used to print 6× `Already installed: <name>` lines + the summary. Now prints `All N action(s) already installed; nothing to do.` and exits 0. Cleaner; same exit code.
- **Per-action upgrade decline.** Pre-#640, the suite paused at each upgrade prompt and a per-action `n` was bucketed as `skipped`. Now the suite is atomic — the consent prompt covers fresh + upgrade together. Surgical upgrades stay available via `aileron action add <FQN>`.
- **Trust decline.** Pre-#640, trust decline mid-suite continued silently (subsequent same-authority actions were skipped). Now the suite aborts before consent renders — the user resolves trust first, then runs the suite again.

🤖 Generated with [Claude Code](https://claude.com/claude-code)