### PR TITLE
fix(intercept): translate wire tool names back to manifest names

### DIFF
--- a/internal/augment/augment.go
+++ b/internal/augment/augment.go
@@ -33,6 +33,12 @@ type DerivedAction struct {
 	// manifest's kebab-case `name`).
 	Name string
 
+	// ManifestName is the original action manifest name (kebab-case,
+	// as it appears in the action store). The intercept layer uses
+	// this to reverse the wire-name mapping when invoking the
+	// executor, which is keyed by manifest name.
+	ManifestName string
+
 	// Description is the prose the LLM sees when choosing among tools —
 	// the action's Markdown body with a leading `# Heading` line
 	// stripped, falling back to `Match.Intent` if the body is empty.
@@ -49,9 +55,10 @@ type DerivedAction struct {
 func Derive(la action.LoadedAction) DerivedAction {
 	m := la.Manifest
 	return DerivedAction{
-		Name:        toolName(m.Name),
-		Description: deriveDescription(m),
-		Parameters:  deriveParameters(m),
+		Name:         toolName(m.Name),
+		ManifestName: m.Name,
+		Description:  deriveDescription(m),
+		Parameters:   deriveParameters(m),
 	}
 }
 
@@ -127,9 +134,17 @@ func deriveParameters(m *action.Manifest) map[string]any {
 // decide whether a tool call coming back from the upstream LLM should
 // be intercepted (Aileron-owned) or passed through unchanged
 // (agent-declared).
+//
+// Names maps each post-collision wire name to the original manifest
+// name. The intercept layer uses this to translate the LLM-emitted
+// tool name back to the manifest name the executor's store is keyed
+// by — a naive snake→kebab string replace would round-trip
+// incorrectly for any manifest that legitimately uses underscores or
+// any wire name renamed by the collision rules.
 type Augmented struct {
 	Body     []byte
 	OurNames []string
+	Names    map[string]string
 }
 
 // AugmentOpenAI parses an OpenAI Chat Completions request body, applies
@@ -153,12 +168,14 @@ func AugmentOpenAI(body []byte, actions []DerivedAction, log Logger) (Augmented,
 	declared := agentDeclaredOpenAI(tools, log)
 
 	ourNames := make([]string, 0, len(actions))
+	names := make(map[string]string, len(actions))
 	for _, a := range actions {
 		finalName := a.Name
 		if declared[finalName] {
 			finalName = "aileron." + finalName
 		}
 		ourNames = append(ourNames, finalName)
+		names[finalName] = a.ManifestName
 		tools = append(tools, map[string]any{
 			"type": "function",
 			"function": map[string]any{
@@ -173,7 +190,7 @@ func AugmentOpenAI(body []byte, actions []DerivedAction, log Logger) (Augmented,
 	if err != nil {
 		return Augmented{}, err
 	}
-	return Augmented{Body: out, OurNames: ourNames}, nil
+	return Augmented{Body: out, OurNames: ourNames, Names: names}, nil
 }
 
 // AugmentAnthropic parses an Anthropic Messages request body, applies
@@ -197,12 +214,14 @@ func AugmentAnthropic(body []byte, actions []DerivedAction, log Logger) (Augment
 	declared := agentDeclaredAnthropic(tools, log)
 
 	ourNames := make([]string, 0, len(actions))
+	names := make(map[string]string, len(actions))
 	for _, a := range actions {
 		finalName := a.Name
 		if declared[finalName] {
 			finalName = "aileron." + finalName
 		}
 		ourNames = append(ourNames, finalName)
+		names[finalName] = a.ManifestName
 		tools = append(tools, map[string]any{
 			"name":         finalName,
 			"description":  a.Description,
@@ -214,7 +233,7 @@ func AugmentAnthropic(body []byte, actions []DerivedAction, log Logger) (Augment
 	if err != nil {
 		return Augmented{}, err
 	}
-	return Augmented{Body: out, OurNames: ourNames}, nil
+	return Augmented{Body: out, OurNames: ourNames, Names: names}, nil
 }
 
 // agentDeclaredOpenAI walks the OpenAI-shape tools array, applies the

--- a/internal/augment/augment_test.go
+++ b/internal/augment/augment_test.go
@@ -66,6 +66,18 @@ func TestDerive_KebabToSnake(t *testing.T) {
 	}
 }
 
+func TestDerive_PreservesManifestName(t *testing.T) {
+	// Derive must keep the original kebab-case manifest name alongside
+	// the snake_case wire name. The intercept layer needs the original
+	// to look the action up in the executor's store, which is keyed by
+	// manifest name. Regression for #641.
+	la := loadedAction(t, "ship-update", "body", nil)
+	got := Derive(la)
+	if got.ManifestName != "ship-update" {
+		t.Errorf("ManifestName = %q, want ship-update", got.ManifestName)
+	}
+}
+
 func TestDerive_StripsLeadingHeading(t *testing.T) {
 	la := loadedAction(t, "x", "# Title\n\nThe real description.", nil)
 	got := Derive(la)
@@ -236,6 +248,49 @@ func TestAugmentOpenAI_NameCollision_RenamesAileronAction(t *testing.T) {
 	}
 	if len(got.OurNames) != 1 || got.OurNames[0] != "aileron.search" {
 		t.Errorf("OurNames = %v, want [aileron.search] (post-collision)", got.OurNames)
+	}
+}
+
+func TestAugmentOpenAI_NamesMapsWireNameToManifestName(t *testing.T) {
+	// Names is the inverse-lookup used by the intercept layer to find
+	// the executor's store key (the manifest name) from the wire name
+	// the LLM emitted. Critically, when the Aileron action is renamed
+	// because of a forward collision (gets the `aileron.` prefix), the
+	// map must still point at the unprefixed manifest name — that's
+	// the case a naive snake→kebab string replace gets wrong, and the
+	// motivating reason for using a map at all. Regression for #641.
+	body := []byte(`{"model":"gpt-4","messages":[],"tools":[{"type":"function","function":{"name":"search"}}]}`)
+	actions := []DerivedAction{
+		{Name: "ship_update", ManifestName: "ship-update", Description: "x", Parameters: map[string]any{"type": "object"}},
+		{Name: "search", ManifestName: "search", Description: "Aileron's", Parameters: map[string]any{"type": "object"}},
+	}
+	got, err := AugmentOpenAI(body, actions, nil)
+	if err != nil {
+		t.Fatalf("AugmentOpenAI: %v", err)
+	}
+	if got.Names["ship_update"] != "ship-update" {
+		t.Errorf("Names[ship_update] = %q, want ship-update", got.Names["ship_update"])
+	}
+	if got.Names["aileron.search"] != "search" {
+		t.Errorf("Names[aileron.search] = %q, want search (collision-renamed wire name must still point at unprefixed manifest)", got.Names["aileron.search"])
+	}
+}
+
+func TestAugmentAnthropic_NamesMapsWireNameToManifestName(t *testing.T) {
+	body := []byte(`{"model":"claude-sonnet-4-6","max_tokens":1,"messages":[],"tools":[{"name":"search","input_schema":{"type":"object"}}]}`)
+	actions := []DerivedAction{
+		{Name: "ship_update", ManifestName: "ship-update", Description: "x", Parameters: map[string]any{"type": "object"}},
+		{Name: "search", ManifestName: "search", Description: "Aileron's", Parameters: map[string]any{"type": "object"}},
+	}
+	got, err := AugmentAnthropic(body, actions, nil)
+	if err != nil {
+		t.Fatalf("AugmentAnthropic: %v", err)
+	}
+	if got.Names["ship_update"] != "ship-update" {
+		t.Errorf("Names[ship_update] = %q, want ship-update", got.Names["ship_update"])
+	}
+	if got.Names["aileron.search"] != "search" {
+		t.Errorf("Names[aileron.search] = %q, want search (collision-renamed wire name must still point at unprefixed manifest)", got.Names["aileron.search"])
 	}
 }
 

--- a/internal/intercept/anthropic.go
+++ b/internal/intercept/anthropic.go
@@ -136,7 +136,7 @@ func (e *Engine) HandleAnthropic(w http.ResponseWriter, r *http.Request) {
 		}
 		roundSpan.SetAttributes(attribute.Int("aileron.intercept.tool_calls_count", len(ours)))
 
-		toolResultBlocks, execErr := e.executeAnthropicToolUses(roundCtx, ours)
+		toolResultBlocks, execErr := e.executeAnthropicToolUses(roundCtx, ours, aug.Names)
 		if execErr != nil {
 			roundSpan.SetStatus(codes.Error, "executor fatal: "+execErr.Error())
 			roundSpan.End()
@@ -266,23 +266,38 @@ func classifyAnthropicToolUses(uses []map[string]any, ours map[string]bool) (min
 // executeAnthropicToolUses runs each Aileron tool_use block through
 // the engine's Executor and produces matching tool_result content
 // blocks for injection as a synthesized user message.
-func (e *Engine) executeAnthropicToolUses(ctx context.Context, uses []map[string]any) ([]map[string]any, error) {
+//
+// names maps the post-collision wire name (the LLM-facing identifier
+// that appears in the tool_use block) to the manifest name the
+// executor's store is keyed by. The mapping is built by the augment
+// layer at the same point the wire names are generated.
+func (e *Engine) executeAnthropicToolUses(ctx context.Context, uses []map[string]any, names map[string]string) ([]map[string]any, error) {
 	out := make([]map[string]any, 0, len(uses))
 	for _, u := range uses {
 		id, _ := u["id"].(string)
-		name, _ := u["name"].(string)
+		wireName, _ := u["name"].(string)
 		input, _ := u["input"].(map[string]any)
 		if input == nil {
 			input = map[string]any{}
 		}
 
-		res, err := e.executor.Execute(ctx, name, input)
+		manifestName, ok := names[wireName]
+		if !ok || manifestName == "" {
+			// The classifier should have filtered out anything not in
+			// OurNames; reaching here means augment/intercept have
+			// drifted out of sync. Fall back to the wire name so the
+			// executor produces a deterministic not-found error
+			// instead of silently misbehaving.
+			manifestName = wireName
+		}
+
+		res, err := e.executor.Execute(ctx, manifestName, input)
 		if err != nil {
 			return nil, err
 		}
 		if res.Failure != nil {
 			e.recorder.RecordFailure(ctx, res.Failure,
-				model.ActorRef{ID: name, Type: model.ActorTypeConnectorRuntime})
+				model.ActorRef{ID: manifestName, Type: model.ActorTypeConnectorRuntime})
 			out = append(out, failure.ToAnthropicToolResult(res.Failure, id))
 			continue
 		}

--- a/internal/intercept/intercept_test.go
+++ b/internal/intercept/intercept_test.go
@@ -315,8 +315,11 @@ func TestHandleOpenAI_InterceptsAileronToolCall(t *testing.T) {
 	if len(exec.calls) != 1 {
 		t.Fatalf("executor calls = %d, want 1", len(exec.calls))
 	}
-	if exec.calls[0].Name != "ship_update" {
-		t.Errorf("called name = %q, want ship_update", exec.calls[0].Name)
+	// Executor receives the manifest name (kebab-case), not the
+	// snake_case wire name the LLM sees — the intercept layer
+	// translates between them via aug.Names. Regression for #641.
+	if exec.calls[0].Name != "ship-update" {
+		t.Errorf("called name = %q, want ship-update", exec.calls[0].Name)
 	}
 	if exec.calls[0].Args["channel"] != "#engineering" {
 		t.Errorf("called args.channel = %v, want #engineering", exec.calls[0].Args["channel"])
@@ -600,6 +603,41 @@ func TestHandleAnthropic_InterceptsAileronToolUse(t *testing.T) {
 	contentBlocks := user["content"].([]any)
 	if contentBlocks[0].(map[string]any)["type"] != "tool_result" {
 		t.Errorf("expected tool_result block; got %v", contentBlocks[0])
+	}
+}
+
+// TestHandleAnthropic_CollisionRenamedActionInvokesManifestName
+// regresses #641 for the collision-rename path. An agent-declared
+// tool already named `ship_update` forces Aileron's matching action
+// to take the reserved-prefix wire name `aileron.ship_update`. When
+// the model calls back with that prefixed name, the intercept layer
+// must still hand the executor the original manifest name
+// (`ship-update`) — the case a naive snake→kebab string replace gets
+// wrong.
+func TestHandleAnthropic_CollisionRenamedActionInvokesManifestName(t *testing.T) {
+	upstream, _ := newScriptedUpstream(t,
+		`{"id":"msg1","type":"message","role":"assistant","model":"c","content":[{"type":"tool_use","id":"tu_1","name":"aileron.ship_update","input":{"channel":"#eng"}}],"stop_reason":"tool_use"}`,
+		`{"id":"msg2","type":"message","role":"assistant","model":"c","content":[{"type":"text","text":"Done."}],"stop_reason":"end_turn"}`,
+	)
+	store := loadStore(t, map[string]string{"ship-update.md": shipUpdateAction})
+	exec := &staticExecutor{result: action.Result{Content: `{"posted":true}`}}
+	e := engineFor(t, "", upstream.URL, store, exec)
+
+	// Agent declares a tool with the same name as Aileron's action,
+	// triggering the forward-collision rename.
+	r := httptest.NewRequest(http.MethodPost, "/v1/messages",
+		strings.NewReader(`{"model":"c","max_tokens":1024,"messages":[{"role":"user","content":"x"}],"tools":[{"name":"ship_update","description":"agent's","input_schema":{"type":"object"}}]}`))
+	w := httptest.NewRecorder()
+	e.HandleAnthropic(w, r)
+
+	if w.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", w.Code, w.Body.String())
+	}
+	if len(exec.calls) != 1 {
+		t.Fatalf("executor calls = %d, want 1", len(exec.calls))
+	}
+	if exec.calls[0].Name != "ship-update" {
+		t.Errorf("called name = %q, want ship-update (executor must see manifest name even when wire name is collision-prefixed)", exec.calls[0].Name)
 	}
 }
 

--- a/internal/intercept/openai.go
+++ b/internal/intercept/openai.go
@@ -153,7 +153,7 @@ func (e *Engine) HandleOpenAI(w http.ResponseWriter, r *http.Request) {
 		}
 		roundSpan.SetAttributes(attribute.Int("aileron.intercept.tool_calls_count", len(ours)))
 
-		toolMessages, execErr := e.executeOpenAIToolCalls(roundCtx, ours)
+		toolMessages, execErr := e.executeOpenAIToolCalls(roundCtx, ours, aug.Names)
 		if execErr != nil {
 			roundSpan.SetStatus(codes.Error, "executor fatal: "+execErr.Error())
 			roundSpan.End()
@@ -307,13 +307,25 @@ func classifyOpenAIToolCalls(calls []map[string]any, ours map[string]bool) (mine
 // executeOpenAIToolCalls runs each Aileron tool call through the
 // engine's Executor and produces the matching `tool` role messages
 // to inject into the continuation request.
-func (e *Engine) executeOpenAIToolCalls(ctx context.Context, calls []map[string]any) ([]map[string]any, error) {
+//
+// names maps the post-collision wire name (the LLM-facing identifier
+// that appears in the tool_call) to the manifest name the executor's
+// store is keyed by. The mapping is built by the augment layer at
+// the same point the wire names are generated. The `name` field
+// echoed back in the synthesized tool-role message stays as the wire
+// name, since the LLM called the tool by that name.
+func (e *Engine) executeOpenAIToolCalls(ctx context.Context, calls []map[string]any, names map[string]string) ([]map[string]any, error) {
 	out := make([]map[string]any, 0, len(calls))
 	for _, tc := range calls {
 		id, _ := tc["id"].(string)
 		fn, _ := tc["function"].(map[string]any)
-		name, _ := fn["name"].(string)
+		wireName, _ := fn["name"].(string)
 		argsRaw, _ := fn["arguments"].(string)
+
+		manifestName, ok := names[wireName]
+		if !ok || manifestName == "" {
+			manifestName = wireName
+		}
 
 		args := map[string]any{}
 		if argsRaw != "" {
@@ -321,13 +333,13 @@ func (e *Engine) executeOpenAIToolCalls(ctx context.Context, calls []map[string]
 				// LLM produced invalid JSON args. Surface this as a
 				// tool-result error so the LLM can correct, rather
 				// than failing the whole turn.
-				out = append(out, openAIErrorToolMessage(id, name,
+				out = append(out, openAIErrorToolMessage(id, wireName,
 					fmt.Sprintf("invalid JSON arguments: %s", err.Error())))
 				continue
 			}
 		}
 
-		res, err := e.executor.Execute(ctx, name, args)
+		res, err := e.executor.Execute(ctx, manifestName, args)
 		if err != nil {
 			return nil, err
 		}
@@ -335,14 +347,14 @@ func (e *Engine) executeOpenAIToolCalls(ctx context.Context, calls []map[string]
 			// Audit-record the action-side failure so the audit_id is
 			// stamped onto the failure before it reaches the LLM.
 			e.recorder.RecordFailure(ctx, res.Failure,
-				model.ActorRef{ID: name, Type: model.ActorTypeConnectorRuntime})
-			out = append(out, failure.ToOpenAIToolMessage(res.Failure, id, name))
+				model.ActorRef{ID: manifestName, Type: model.ActorTypeConnectorRuntime})
+			out = append(out, failure.ToOpenAIToolMessage(res.Failure, id, wireName))
 			continue
 		}
 		out = append(out, map[string]any{
 			"role":         "tool",
 			"tool_call_id": id,
-			"name":         name,
+			"name":         wireName,
 			"content":      res.Content,
 		})
 	}


### PR DESCRIPTION
## Summary

- Closes #641. Tool calls under `aileron launch` + Claude Code (or any Anthropic/OpenAI intercept consumer) were 500'ing with `action "list_upcoming_events" not found` because the intercept executors were handing the LLM-facing wire name straight to the action store, which is keyed by manifest name.
- Adds a wire→manifest name map (`augment.Augmented.Names`) populated at the same point the wire names are generated, mirroring the pattern the MCP server (`cmd/aileron-mcp/main.go`) already uses successfully.
- Anthropic and OpenAI executors translate through that map before `executor.Execute`. The OpenAI tool-result message still echoes the wire name in its `name` field (which is what the LLM called), but the executor receives the manifest name.

A naive `strings.ReplaceAll(name, "_", "-")` would *seem* to work for the simple kebab→snake case, but breaks for collision-renamed wire names (`aileron.<n>`), which is the path the new end-to-end regression test exercises.

## Test plan

- [x] `go test ./internal/augment/... ./internal/intercept/...` — passes; coverage at 98.2% / 91.1%
- [x] New `TestDerive_PreservesManifestName` — confirms `DerivedAction.ManifestName` round-trips.
- [x] New `TestAugmentOpenAI_NamesMapsWireNameToManifestName` and Anthropic counterpart — confirms `aileron.search` (collision-renamed) maps back to the unprefixed `search` manifest.
- [x] New `TestHandleAnthropic_CollisionRenamedActionInvokesManifestName` — drives the full Anthropic intercept path with an agent-declared collision and asserts the executor receives `ship-update`, not `aileron.ship_update` or `ship_update`.
- [x] Existing `TestHandleOpenAI_InterceptsAileronToolCall` updated to assert the executor sees the manifest name (`ship-update`) — the assertion that previously locked in the broken behavior.
- [ ] Manual: rerun `aileron launch` + Claude Code + Google Calendar `list-upcoming-events` and confirm the 500 is gone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)