### PR TITLE
ci(codecov): wait for 5 builds before computing coverage status

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,6 +1,6 @@
 codecov:
   notify:
-    after_n_builds: 4
+    after_n_builds: 5
 
 coverage:
   status:
@@ -8,7 +8,7 @@ coverage:
       default:
         target: auto
         threshold: 2%
-        after_n_builds: 4
+        after_n_builds: 5
       ui:
         target: auto
         threshold: 5%
@@ -18,7 +18,7 @@ coverage:
       default:
         target: 80%
         threshold: 2%
-        after_n_builds: 4
+        after_n_builds: 5
 
 flags:
   unit:


### PR DESCRIPTION
## Summary

- Bump all three `after_n_builds` thresholds from 4 → 5 to match the actual number of coverage uploads per PR after #576 added Windows unit tests.

## Background

The coverage upload count went from 4 → 5 when #576 (2026-05-08) added the Windows unit-tests job, but `codecov.yml`'s `after_n_builds: 4` (last touched 2026-05-05) was not bumped to match. Result: codecov fires its status check as soon as 4 uploads land. The Linux unit-tests job is typically the slowest single suite, so on PRs that change `internal/` it finishes after codecov has already computed status — and the headline `internal/` coverage never makes it into the patch + project numbers.

You can see this on #647: codecov posted `head sessions: 2` / `head coverage: 15.48%` even though Unit Tests (Linux) successfully uploaded its 448KB coverage file shortly after the status was posted. Reproduces on any PR with substantial `internal/` changes.

## Test plan

- [ ] Watch this PR's `codecov/patch` + `codecov/project` checks — they should wait for all five uploads before computing and reflect the real coverage.
- [ ] After this merges, recheck #647's codecov status — re-running its CI should now produce accurate numbers.

🤖 Generated with [Claude Code](https://claude.com/claude-code)