### PR TITLE
fix(server): default WebappURL to the daemon's bound URL

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -56,24 +56,23 @@ type Config struct {
 	// rather than in a process-lifetime memory vault.
 	Vault vault.Vault
 
-	// WebappURL is the base URL of the Aileron webapp the user opens to
-	// approve / deny gated actions (#418). When set, the action-approval
-	// notification's ReviewURL is built as
+	// WebappURL is the base URL the action-approval review surface is
+	// reachable at (#418). The notification's ReviewURL is built as
 	// `<WebappURL>/approvals?focus=<id>` so the terminal-printed block
-	// carries a per-approval deep link the operator can click or
-	// re-open via `aileron open approval <id>`.
+	// and agent-facing approval message carry a per-approval deep link
+	// the user can click or re-open via `aileron open approval <id>`.
 	//
-	// Empty falls back to the AILERON_WEBAPP_URL environment variable.
-	// Both empty means notifications fire with a generic prompt
-	// instead of a URL — the operator at least learns something needs
-	// attention.
+	// The daemon serves the webapp itself (see webapp_embed.go), so the
+	// natural default is the daemon's own bound URL. Production wiring
+	// (`internal/server`) sets that default after binding. This field
+	// and the `AILERON_WEBAPP_URL` environment variable are overrides
+	// for deployments where the daemon's bound URL is not what users
+	// hit: reverse-proxied installs, `--bind 0.0.0.0:...` containers, or
+	// a future split-origin webapp.
 	//
-	// Launch sets this to the embedded gateway's own URL so the
-	// notification points at the same daemon the agent is talking to.
-	// Once the daemon serves `ui/build` directly (post-MVP cleanup),
-	// that URL becomes the working webapp entry point automatically.
-	// Until then, users running the webapp dev server elsewhere can
-	// override via AILERON_WEBAPP_URL.
+	// Precedence: cfg.WebappURL (this field) → AILERON_WEBAPP_URL env →
+	// empty. Empty surfaces a generic prompt instead of a URL — the
+	// operator at least learns something needs attention.
 	WebappURL string
 
 	// Notifier overrides the default notification dispatcher (log +

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -237,6 +237,18 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 	}
 
 	url := "http://" + listener.Addr().String()
+
+	// The daemon serves the webapp itself (see internal/app/webapp_embed.go),
+	// so its own bound URL is the right default for the approval review URL
+	// surfaced in agent-facing messages. Operators running behind a reverse
+	// proxy or on a non-loopback bind (`--bind 0.0.0.0:...`) must override
+	// via `AILERON_WEBAPP_URL` so the message names the hostname users
+	// actually reach. Defaulting here means the common single-user local
+	// case works with no configuration.
+	if cfg.WebappURL == "" && os.Getenv("AILERON_WEBAPP_URL") == "" {
+		cfg.WebappURL = url
+	}
+
 	info := discovery.Info{
 		URL:       url,
 		PID:       os.Getpid(),

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"io"
 	"log/slog"
@@ -311,6 +312,109 @@ func TestRun_PublishesDiscoveryAndCleansUp(t *testing.T) {
 			t.Errorf("%s still exists after shutdown (err: %v)", name, err)
 		}
 	}
+}
+
+// TestRun_WebappURL_DefaultsToBoundURL pins the contract that the
+// daemon's own bound URL becomes the default WebappURL surfaced in
+// agent-facing approval messages. Without this default, an
+// approval-gated action's review URL is rendered as "Visit  to
+// approve" — empty between "Visit" and "to" — because
+// `buildPendingApprovalResponse` interpolates `s.webappURL` directly.
+// The daemon serves the webapp itself (see internal/app/webapp_embed.go),
+// so its own URL is the right out-of-the-box answer for the common
+// local case.
+//
+// `AILERON_WEBAPP_URL` (covered by [TestRun_WebappURL_EnvOverrides])
+// remains an operator override for reverse-proxied deployments.
+func TestRun_WebappURL_DefaultsToBoundURL(t *testing.T) {
+	t.Setenv("AILERON_WEBAPP_URL", "")
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+	seedVault(t, vaultPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "127.0.0.1:0",
+		StateDir:  stateDir,
+		VaultPath: vaultPath,
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- run(ctx, log, opts) }()
+
+	info := waitForDaemon(t, stateDir, 3*time.Second)
+
+	got := fetchStatusGatewayURL(t, info.URL)
+	if got != info.URL {
+		t.Errorf("gateway_url = %q, want %q (the daemon's own bound URL)", got, info.URL)
+	}
+
+	cancel()
+	<-runErr
+}
+
+// TestRun_WebappURL_EnvOverrides asserts that `AILERON_WEBAPP_URL`,
+// when set, takes precedence over the bound-URL default. This is the
+// escape hatch for reverse-proxied or `--bind 0.0.0.0:...` deployments
+// where the bound URL is not what users see.
+func TestRun_WebappURL_EnvOverrides(t *testing.T) {
+	const override = "https://aileron.example.com"
+	t.Setenv("AILERON_WEBAPP_URL", override)
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+	seedVault(t, vaultPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "127.0.0.1:0",
+		StateDir:  stateDir,
+		VaultPath: vaultPath,
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- run(ctx, log, opts) }()
+
+	info := waitForDaemon(t, stateDir, 3*time.Second)
+
+	got := fetchStatusGatewayURL(t, info.URL)
+	if got != override {
+		t.Errorf("gateway_url = %q, want %q (env override wins over bound URL)", got, override)
+	}
+
+	cancel()
+	<-runErr
+}
+
+// fetchStatusGatewayURL hits the daemon's `/v1/status` endpoint and
+// returns the `gateway_url` field (which surfaces `s.webappURL` per
+// handlers_status.go). Empty string when the field is absent.
+func fetchStatusGatewayURL(t *testing.T, daemonURL string) string {
+	t.Helper()
+	resp, err := http.Get(daemonURL + "/v1/status")
+	if err != nil {
+		t.Fatalf("GET /v1/status: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("GET /v1/status status = %d, want 200", resp.StatusCode)
+	}
+	var body struct {
+		GatewayURL string `json:"gateway_url"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+		t.Fatalf("decode status: %v", err)
+	}
+	return body.GatewayURL
 }
 
 // TestRun_RefusesWhenAnotherDaemonHoldsLock asserts the singleton


### PR DESCRIPTION
## Summary

- The daemon serves the webapp itself (`internal/app/webapp_embed.go` embeds the SvelteKit build, `internal/app/app.go:537` mounts it at `/`). Its own bound URL is the natural default for the per-approval review link surfaced in agent-facing messages.
- Before: `cfg.WebappURL` defaulted to empty, producing approval messages like `"Visit  to approve"` with a missing URL — observed in a real `aileron launch claude` run.
- After: `cfg.WebappURL` defaults to `http://<bind>:<port>` when neither the cfg field nor `AILERON_WEBAPP_URL` is set. The env var stays as the escape hatch for reverse-proxied or `--bind 0.0.0.0:...` deployments.

## Precedence

`cfg.WebappURL` (field) → `AILERON_WEBAPP_URL` (env) → bound-URL default → empty.

## Documentation reframe

`Config.WebappURL`'s godoc now describes the field and env var as **operator overrides** for non-default deployments, not required settings. The common single-user local case is no-config.

## Regression tests

`internal/server/main_test.go`:
- `TestRun_WebappURL_DefaultsToBoundURL` — verifies `/v1/status`'s `gateway_url` equals the daemon's bound URL when no env override.
- `TestRun_WebappURL_EnvOverrides` — verifies the env override wins over the bound-URL default.

Both tests use `/v1/status` as the observation surface since that's where `apiServer.webappURL` is exposed (`handlers_status.go:36-39`).

## Test plan

- [x] `go test ./server/ ./app/ -count=1` — all green
- [x] New regression tests cover both branches (default + override)
- [ ] Manual: `aileron launch claude` → ask for a `send-email` → confirm the surfaced approval message now reads `"Visit http://127.0.0.1:NNNN/approvals?focus=... to approve"` instead of `"Visit  to approve"`

🤖 Generated with [Claude Code](https://claude.com/claude-code)