### PR TITLE
fix(app): proxy Flusher through loggingMiddleware so SSE streams work

### DIFF
--- a/internal/app/handlers_action_approvals_test.go
+++ b/internal/app/handlers_action_approvals_test.go
@@ -669,6 +669,48 @@ func TestWatchActionApprovals_DisabledReturns503(t *testing.T) {
 	}
 }
 
+// TestWatchActionApprovals_ThroughLoggingMiddleware is the regression
+// test for the SSE stream stalling at "Connecting to the approval
+// stream…" in the webapp. The handler asserts `w.(http.Flusher)`; an
+// earlier statusWriter wrapper in loggingMiddleware did not proxy
+// Flush, so the assertion failed and the handler returned 500
+// streaming_unsupported. The webapp's onError path doesn't clear its
+// loading flag, so the page sat on the placeholder forever.
+//
+// The contract the SSE handler depends on is: any ResponseWriter
+// wrapper in the middleware chain MUST preserve http.Flusher when
+// the underlying writer supports it. This test exercises the handler
+// through loggingMiddleware end-to-end and asserts the snapshot event
+// is delivered with a 200 — which only happens if Flush proxies
+// through the wrapper.
+func TestWatchActionApprovals_ThroughLoggingMiddleware(t *testing.T) {
+	srv, q := newActionApprovalsTestServer(t)
+	q.Register("send-email", "github://x/y", "sess-1", map[string]any{"to": "alice"})
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	wrapped := loggingMiddleware(logger, http.HandlerFunc(srv.WatchActionApprovals))
+	httpSrv := httptest.NewServer(wrapped)
+	defer httpSrv.Close()
+
+	resp, err := http.Get(httpSrv.URL)
+	if err != nil {
+		t.Fatalf("Get: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200 (SSE handler must work through loggingMiddleware)", resp.StatusCode)
+	}
+
+	r := bufio.NewReader(resp.Body)
+	ev, err := readSSEEvent(r)
+	if err != nil {
+		t.Fatalf("read snapshot: %v (handler never flushed through the middleware)", err)
+	}
+	if ev.Event != "snapshot" {
+		t.Errorf("first event = %q, want snapshot", ev.Event)
+	}
+}
+
 // TestWatchActionApprovals_ClientDisconnectReleases asserts the
 // handler returns when the client disconnects. Without proper
 // context handling, every closed tab would leak a goroutine

--- a/internal/app/middleware.go
+++ b/internal/app/middleware.go
@@ -71,6 +71,16 @@ func (w *statusWriter) Write(b []byte) (int, error) {
 	return w.ResponseWriter.Write(b)
 }
 
+// Flush proxies through to the underlying ResponseWriter when it
+// implements http.Flusher. Required for SSE handlers that assert
+// `w.(http.Flusher)` — without this, the type assertion fails on the
+// wrapped writer and the stream never starts.
+func (w *statusWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}
+
 // corsMiddleware adds CORS headers, echoing the request Origin so that
 // credentialed (cookie-based) requests work. The wildcard "*" is not
 // allowed when credentials: "include" is used by the browser.

--- a/webapp/src/routes/approvals/+page.svelte
+++ b/webapp/src/routes/approvals/+page.svelte
@@ -135,7 +135,13 @@
 			onPending: applyPending,
 			onResolved: (r) => applyResolved(r.id),
 			onError: (e) => {
+				// Surface the failure instead of leaving the page on the
+				// "Connecting…" placeholder forever. `loading` is also
+				// cleared here so the error branch renders — the SSE
+				// stream may never deliver a snapshot if the browser gave
+				// up (readyState === CLOSED).
 				error = e instanceof Error ? e.message : String(e);
+				loading = false;
 			}
 		});
 		return () => {

--- a/webapp/src/routes/approvals/page.test.ts
+++ b/webapp/src/routes/approvals/page.test.ts
@@ -219,6 +219,22 @@ describe('Approvals page — action approvals (#418)', () => {
 		});
 	});
 
+	it('shows the SSE error message instead of the "Connecting…" placeholder when the stream fails', async () => {
+		// Regression: when the SSE handler fails (e.g. 500
+		// streaming_unsupported from a missing Flush in middleware),
+		// the page must surface the error rather than sit on the
+		// "Connecting to the approval stream…" placeholder forever.
+		vi.mocked(watchActionApprovals).mockImplementation((sub) => {
+			queueMicrotask(() => sub.onError?.(new Error('stream closed: 500')));
+			return () => {};
+		});
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText('stream closed: 500')).toBeInTheDocument();
+		});
+		expect(screen.queryByText(/Connecting to the approval stream/)).not.toBeInTheDocument();
+	});
+
 	it('surfaces server errors from decideActionApproval', async () => {
 		setupWatcher([
 			{


### PR DESCRIPTION
## Summary

- The `/v1/action-approvals/watch` SSE endpoint was returning 500 `streaming_unsupported` in production because `loggingMiddleware`'s `statusWriter` wraps `http.ResponseWriter` without proxying `http.Flusher` — the handler's `w.(http.Flusher)` assertion failed before it could send the snapshot.
- The webapp's `/approvals` page sat on "Connecting to the approval stream…" forever — both because the server never sent a snapshot AND because the page only cleared `loading` on snapshot, never on error.
- Fix the middleware to proxy `Flush()` through to the underlying writer, and fix the page to surface the error instead of the placeholder when the stream fails.

## Why it slipped past CI

The existing `WatchActionApprovals` tests bound the handler directly to `httptest.NewServer`, bypassing `loggingMiddleware`. The new regression test `TestWatchActionApprovals_ThroughLoggingMiddleware` exercises the production path.

## How to verify

Reproducer before the fix:

```
$ curl -sS -i -N http://127.0.0.1:<port>/v1/action-approvals/watch
HTTP/1.1 500 Internal Server Error
...
{"error":{"code":"streaming_unsupported","message":"response writer does not support flushing"}}
```

After the fix, the same curl returns `200 OK` with `Content-Type: text/event-stream` and a `snapshot` event.

## Test plan

- [x] `go test ./internal/app/ -run TestWatchActionApprovals -count=1` passes; the new `TestWatchActionApprovals_ThroughLoggingMiddleware` fails on `main` and passes on this branch.
- [x] `pnpm vitest run src/routes/approvals/page.test.ts` passes (15/15); the new "shows the SSE error message instead of the Connecting placeholder" test fails on `main` and passes on this branch.
- [ ] Rebuild (`task build:webapp && task build`), restart the daemon, trigger an approval-gated tool call, open the approvals page, and confirm the SSE stream connects and renders the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)