### PR TITLE
fix(observability): proxy Flusher through HTTPMiddleware's statusRecorder

### DIFF
--- a/internal/app/handlers_action_approvals_test.go
+++ b/internal/app/handlers_action_approvals_test.go
@@ -14,6 +14,7 @@ import (
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/approval"
+	"github.com/ALRubinger/aileron/internal/observability"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
@@ -705,6 +706,55 @@ func TestWatchActionApprovals_ThroughLoggingMiddleware(t *testing.T) {
 	ev, err := readSSEEvent(r)
 	if err != nil {
 		t.Fatalf("read snapshot: %v (handler never flushed through the middleware)", err)
+	}
+	if ev.Event != "snapshot" {
+		t.Errorf("first event = %q, want snapshot", ev.Event)
+	}
+}
+
+// TestWatchActionApprovals_ThroughProductionMiddlewareChain is the
+// second-round regression for the same "Connecting to the approval
+// stream…" stall. The first round only chained loggingMiddleware and
+// missed that observability.HTTPMiddleware sits *between* logging and
+// the handler with its own ResponseWriter wrapper that also didn't
+// proxy Flush. The result: loggingMiddleware's statusWriter.Flush()
+// asserted `(http.Flusher)` against statusRecorder, which failed,
+// Flush became a no-op, bytes piled up in the http response buffer,
+// and the connection sat open with no bytes ever reaching the client
+// (no 500 this time — a silent stall).
+//
+// This test composes the chain in the same order as app.go's
+// `buildHandler`: HTTPMiddleware wrapped inside loggingMiddleware
+// wrapping the handler. Both wrappers must proxy Flush for the
+// snapshot to make it to the client.
+func TestWatchActionApprovals_ThroughProductionMiddlewareChain(t *testing.T) {
+	srv, q := newActionApprovalsTestServer(t)
+	q.Register("send-email", "github://x/y", "sess-1", map[string]any{"to": "alice"})
+
+	logger := slog.New(slog.NewTextHandler(&bytes.Buffer{}, nil))
+	var handler http.Handler = http.HandlerFunc(srv.WatchActionApprovals)
+	handler = loggingMiddleware(logger, handler)
+	handler = observability.HTTPMiddleware(nil)(handler)
+
+	httpSrv := httptest.NewServer(handler)
+	defer httpSrv.Close()
+
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Second)
+	defer cancel()
+	req, _ := http.NewRequestWithContext(ctx, http.MethodGet, httpSrv.URL, nil)
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("Do: %v (request timed out — handler never flushed bytes through the chain)", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	r := bufio.NewReader(resp.Body)
+	ev, err := readSSEEvent(r)
+	if err != nil {
+		t.Fatalf("read snapshot: %v (snapshot never reached the client — Flush was a no-op somewhere)", err)
 	}
 	if ev.Event != "snapshot" {
 		t.Errorf("first event = %q, want snapshot", ev.Event)

--- a/internal/observability/middleware.go
+++ b/internal/observability/middleware.go
@@ -99,3 +99,15 @@ func (s *statusRecorder) Write(b []byte) (int, error) {
 	}
 	return s.ResponseWriter.Write(b)
 }
+
+// Flush proxies through to the underlying ResponseWriter when it
+// implements http.Flusher. Required for SSE handlers downstream of
+// this middleware: without a Flush proxy on every wrapper in the
+// chain, the next-outer wrapper's Flush becomes a no-op against a
+// non-flushing wrapper, leaving bytes buffered and the client hung
+// on a silent connection.
+func (s *statusRecorder) Flush() {
+	if f, ok := s.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
+}

--- a/internal/observability/middleware_test.go
+++ b/internal/observability/middleware_test.go
@@ -202,6 +202,62 @@ func TestHTTPMiddleware_BodyOnlyWriteDefaultsToOK(t *testing.T) {
 	}
 }
 
+// TestHTTPMiddleware_PreservesFlusher is the unit-level regression
+// for the SSE stall on the `/approvals` page. The middleware's
+// statusRecorder wraps http.ResponseWriter; downstream SSE handlers
+// rely on `w.(http.Flusher)` succeeding and Flush actually reaching
+// the underlying writer. Without a Flush method on the wrapper, the
+// type assertion fails (or — if an outer wrapper has its own Flush
+// that delegates by interface assertion — silently no-ops), bytes
+// pile up in the response buffer, and the client sees a connection
+// that stays open with no events.
+//
+// Contract under test:
+//   - The writer the handler receives satisfies http.Flusher.
+//   - Calling Flush on that writer reaches the underlying
+//     ResponseWriter's Flush.
+func TestHTTPMiddleware_PreservesFlusher(t *testing.T) {
+	var sawFlusher bool
+	var flushedThrough bool
+
+	handler := http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		f, ok := w.(http.Flusher)
+		sawFlusher = ok
+		if ok {
+			f.Flush()
+		}
+	})
+	wrapped := HTTPMiddleware(nil)(handler)
+
+	underlying := &flushTrackingWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		onFlush:        func() { flushedThrough = true },
+	}
+	req := httptest.NewRequest(http.MethodGet, "/v1/anything", nil)
+	wrapped.ServeHTTP(underlying, req)
+
+	if !sawFlusher {
+		t.Error("handler's w.(http.Flusher) assertion failed — statusRecorder must implement Flush")
+	}
+	if !flushedThrough {
+		t.Error("Flush did not reach the underlying ResponseWriter — statusRecorder.Flush must proxy through")
+	}
+}
+
+// flushTrackingWriter is an http.ResponseWriter that records when its
+// Flush is invoked. Used to assert middleware wrappers proxy Flush
+// down the chain instead of swallowing it.
+type flushTrackingWriter struct {
+	http.ResponseWriter
+	onFlush func()
+}
+
+func (w *flushTrackingWriter) Flush() {
+	if w.onFlush != nil {
+		w.onFlush()
+	}
+}
+
 func TestHTTPMiddleware_DefaultSpanName(t *testing.T) {
 	// Internal helper, but worth a guard: the default name is the
 	// shape downstream operators search by in trace tools.


### PR DESCRIPTION
## Summary

- Second-round fix for the same "Connecting to the approval stream…" stall PR #653 attempted to resolve. #653 patched `loggingMiddleware`'s `statusWriter` but missed `observability.HTTPMiddleware`'s `statusRecorder`, which also wraps `http.ResponseWriter` without proxying `http.Flusher`.
- The production chain is `HTTPMiddleware (statusRecorder) → loggingMiddleware (statusWriter) → handler`. With #653 applied, `statusWriter.Flush()` did the right thing in isolation, but it asserts `(http.Flusher)` against the underlying writer — which is now `*statusRecorder`. The assertion failed silently, `statusWriter.Flush()` became a no-op, bytes piled up in Go's HTTP buffer, and the SSE stream sat open with no bytes ever reaching the client. No 500 this round, just a silent hang.
- Adds `Flush()` to `statusRecorder`. Every ResponseWriter wrapper in the middleware chain must proxy `http.Flusher`.

## Why #653's regression test missed it

`TestWatchActionApprovals_ThroughLoggingMiddleware` chained only one middleware. The new `TestWatchActionApprovals_ThroughProductionMiddlewareChain` composes both wrappers in the same order as `app.go:buildHandler` and asserts the snapshot reaches the client. Without this fix the request times out (silent stall, matching the user-reported bug); with it the snapshot arrives.

## How to verify

Before the fix, against the rebuilt daemon:

```
$ curl -sS -i -N --max-time 5 http://127.0.0.1:<port>/v1/action-approvals/watch
curl: (28) Operation timed out after 5006 milliseconds with 0 bytes received
```

After the fix, the same curl returns `200 OK` immediately with a `snapshot` event.

## Test plan

- [x] `go test ./internal/app/ -run TestWatchActionApprovals -count=1` passes; the new `TestWatchActionApprovals_ThroughProductionMiddlewareChain` fails on `main` (request times out) and passes on this branch.
- [x] `go test ./internal/observability/ -count=1` still passes.
- [ ] Rebuild (`task build:webapp && task build`), restart the daemon, trigger an approval-gated tool call, open the approvals page, and confirm the SSE stream connects and renders the card.

🤖 Generated with [Claude Code](https://claude.com/claude-code)