### PR TITLE
feat(webapp): add Playwright E2E suite for approvals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -223,6 +223,117 @@ jobs:
           token: ${{ secrets.CODECOV_TOKEN }}
           files: ui/test-results/junit-vitest.xml,ui/test-results/junit-playwright.xml
 
+  test-webapp:
+    name: Webapp Tests
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 11.0.9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: webapp/pnpm-lock.yaml
+
+      - name: Install dependencies
+        working-directory: webapp
+        run: pnpm install --frozen-lockfile
+
+      - name: Run unit and component tests
+        working-directory: webapp
+        run: pnpm test
+
+      - name: Build for E2E
+        working-directory: webapp
+        run: pnpm build
+
+      - name: Install Playwright browsers
+        working-directory: webapp
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run E2E tests (mocked)
+        working-directory: webapp
+        run: pnpm test:e2e
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: webapp-playwright-report
+          path: webapp/playwright-report/
+          retention-days: 14
+
+      - name: Upload webapp test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: webapp/test-results/junit-vitest.xml,webapp/test-results/junit-playwright.xml
+
+  test-webapp-integration:
+    name: Webapp Integration E2E
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: |
+            internal/go.mod
+            cmd/aileron/go.mod
+
+      - uses: pnpm/action-setup@v5
+        with:
+          version: 11.0.9
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+          cache: pnpm
+          cache-dependency-path: webapp/pnpm-lock.yaml
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build daemon and CLI
+        run: |
+          task build:server
+          task build:cli
+
+      - name: Install webapp dependencies
+        working-directory: webapp
+        run: pnpm install --frozen-lockfile
+
+      - name: Install Playwright browsers
+        working-directory: webapp
+        run: pnpm exec playwright install --with-deps chromium
+
+      - name: Run integration E2E (real daemon + seed fixture)
+        run: webapp/scripts/run-integration-e2e.sh
+
+      - name: Upload Playwright report on failure
+        if: failure()
+        uses: actions/upload-artifact@v4
+        with:
+          name: webapp-integration-playwright-report
+          path: webapp/playwright-report/
+          retention-days: 14
+
+      - name: Upload integration test results to Codecov
+        if: ${{ !cancelled() }}
+        uses: codecov/test-results-action@v1
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          files: webapp/test-results/junit-playwright-integration.xml
+
   docs:
     name: Docs
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -237,11 +237,39 @@ tasks:
     desc: Run all tests
     cmds:
       - task: test:go
+      - task: test:webapp
       - task: test:ui
       - task: test:docs
 
+  test:webapp:
+    desc: Run local webapp unit tests (Vitest)
+    dir: webapp
+    cmds:
+      - pnpm install
+      - pnpm test
+
+  test:webapp:e2e:
+    desc: Run mocked-API Playwright E2E tests against the local webapp
+    deps:
+      - build:webapp
+    dir: webapp
+    cmds:
+      - pnpm install
+      - pnpm exec playwright install --with-deps chromium
+      - pnpm test:e2e
+
+  test:webapp:e2e:integration:
+    desc: Run Playwright E2E tests against a real daemon seeded with pending approvals
+    deps:
+      - build:server
+      - build:cli
+    cmds:
+      - cd webapp && pnpm install
+      - cd webapp && pnpm exec playwright install --with-deps chromium
+      - webapp/scripts/run-integration-e2e.sh
+
   test:ui:
-    desc: Run UI unit and component tests
+    desc: (Frozen) Run cloud-tier UI unit tests. Local webapp tests live in `test:webapp`.
     dir: ui
     cmds:
       - pnpm install

--- a/internal/approval/seed.go
+++ b/internal/approval/seed.go
@@ -1,0 +1,84 @@
+package approval
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+// SeedEntry is the JSON-deserialized shape consumed by the daemon's
+// `--dev-seed-approvals` flag. Each entry becomes a pending action
+// approval on queue startup so developer / Playwright integration
+// tests have something to list, approve, and deny without driving a
+// real agent through a policy-gated tool call.
+//
+// Not part of any production wire contract — exists strictly for the
+// developer-facing seed path. ID and RequestedAt are not user-supplied;
+// the queue mints them via the same path production registrations use.
+type SeedEntry struct {
+	Kind         ApprovalKind   `json:"kind"`
+	ActionName   string         `json:"action_name"`
+	ConnectorFQN string         `json:"connector_fqn,omitempty"`
+	Args         map[string]any `json:"args,omitempty"`
+	SessionID    string         `json:"session_id,omitempty"`
+}
+
+// LoadSeedFile reads the seed JSON from path and returns the validated
+// entries. The file may be either a top-level JSON array of entries or
+// an object with an `items` key holding the array — the latter matches
+// the shape `GET /v1/action-approvals` returns, so the same fixture
+// can be saved off a running daemon and replayed later.
+func LoadSeedFile(path string) ([]SeedEntry, error) {
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("read seed file: %w", err)
+	}
+	// Try {"items":[...]} first — that's the response shape from the
+	// list endpoint. Fall back to a bare array on failure.
+	var wrapped struct {
+		Items []SeedEntry `json:"items"`
+	}
+	if err := json.Unmarshal(raw, &wrapped); err == nil && wrapped.Items != nil {
+		return validateSeedEntries(wrapped.Items)
+	}
+	var arr []SeedEntry
+	if err := json.Unmarshal(raw, &arr); err != nil {
+		return nil, fmt.Errorf("seed file is neither a JSON array nor an object with an items array: %w", err)
+	}
+	return validateSeedEntries(arr)
+}
+
+// SeedQueue registers each entry on the queue using its kind-specific
+// Register* code path — the same one production callers go through.
+// Returns the minted approval IDs in input order so the seed caller
+// (and integration tests) can correlate input entries with the ids
+// the queue assigned.
+func SeedQueue(q *ActionApprovalQueue, entries []SeedEntry) []string {
+	ids := make([]string, 0, len(entries))
+	for _, e := range entries {
+		a := q.RegisterKind(e.Kind, e.ActionName, e.ConnectorFQN, e.SessionID, e.Args)
+		ids = append(ids, a.ID)
+	}
+	return ids
+}
+
+// validateSeedEntries rejects malformed entries before they hit the
+// queue. Anything that would silently produce a confusing empty card
+// in the webapp (missing action_name) or an unknown kind (typo in the
+// fixture file) is caught here so the seed-path failure mode is a
+// startup error with a line-number-able message rather than a runtime
+// surprise.
+func validateSeedEntries(entries []SeedEntry) ([]SeedEntry, error) {
+	for i, e := range entries {
+		if e.ActionName == "" {
+			return nil, fmt.Errorf("seed entry %d: action_name is required", i)
+		}
+		switch e.Kind {
+		case "", ApprovalKindAction, ApprovalKindCommsSend, ApprovalKindCommsDraft, ApprovalKindHTTPRequest:
+			// ok
+		default:
+			return nil, fmt.Errorf("seed entry %d: unknown kind %q (want one of: action, comms_send, comms_draft, http_request)", i, e.Kind)
+		}
+	}
+	return entries, nil
+}

--- a/internal/approval/seed_test.go
+++ b/internal/approval/seed_test.go
@@ -1,0 +1,173 @@
+package approval
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// TestLoadSeedFile_BareArray verifies the seed loader accepts a top-
+// level JSON array. This is the canonical fixture shape.
+func TestLoadSeedFile_BareArray(t *testing.T) {
+	path := writeSeedFile(t, `[
+		{"kind":"action","action_name":"send-email","connector_fqn":"github://x/y","args":{"to":"a@b.com"}}
+	]`)
+	entries, err := LoadSeedFile(path)
+	if err != nil {
+		t.Fatalf("LoadSeedFile: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len=%d want 1", len(entries))
+	}
+	if entries[0].Kind != ApprovalKindAction {
+		t.Errorf("kind=%q want action", entries[0].Kind)
+	}
+	if entries[0].ActionName != "send-email" {
+		t.Errorf("action_name=%q", entries[0].ActionName)
+	}
+	if entries[0].ConnectorFQN != "github://x/y" {
+		t.Errorf("connector_fqn=%q", entries[0].ConnectorFQN)
+	}
+	if got, want := entries[0].Args["to"], "a@b.com"; got != want {
+		t.Errorf("args.to=%v want %q", got, want)
+	}
+}
+
+// TestLoadSeedFile_ItemsWrapper verifies the seed loader also accepts
+// the {"items":[...]} shape so a fixture captured directly from
+// `GET /v1/action-approvals` can be replayed.
+func TestLoadSeedFile_ItemsWrapper(t *testing.T) {
+	path := writeSeedFile(t, `{"items":[
+		{"kind":"comms_send","action_name":"send_message","args":{"service":"slack","channel":"#dev","body":"hi"}}
+	]}`)
+	entries, err := LoadSeedFile(path)
+	if err != nil {
+		t.Fatalf("LoadSeedFile: %v", err)
+	}
+	if len(entries) != 1 {
+		t.Fatalf("len=%d want 1", len(entries))
+	}
+	if entries[0].Kind != ApprovalKindCommsSend {
+		t.Errorf("kind=%q want comms_send", entries[0].Kind)
+	}
+}
+
+// TestLoadSeedFile_MissingActionName rejects entries without an
+// action_name — those would render as blank cards in the webapp.
+func TestLoadSeedFile_MissingActionName(t *testing.T) {
+	path := writeSeedFile(t, `[{"kind":"action"}]`)
+	_, err := LoadSeedFile(path)
+	if err == nil {
+		t.Fatal("LoadSeedFile: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "action_name is required") {
+		t.Errorf("error=%v want mention of action_name", err)
+	}
+}
+
+// TestLoadSeedFile_UnknownKind rejects typo'd kinds at load time —
+// the seed-path failure mode is a startup error, not a runtime
+// surprise once the daemon is already running.
+func TestLoadSeedFile_UnknownKind(t *testing.T) {
+	path := writeSeedFile(t, `[{"kind":"approve_everything","action_name":"x"}]`)
+	_, err := LoadSeedFile(path)
+	if err == nil {
+		t.Fatal("LoadSeedFile: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unknown kind") {
+		t.Errorf("error=%v want mention of unknown kind", err)
+	}
+}
+
+// TestLoadSeedFile_MissingFile surfaces a useful filesystem error
+// rather than a confusing unmarshal error.
+func TestLoadSeedFile_MissingFile(t *testing.T) {
+	_, err := LoadSeedFile(filepath.Join(t.TempDir(), "does-not-exist.json"))
+	if err == nil {
+		t.Fatal("LoadSeedFile: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "read seed file") {
+		t.Errorf("error=%v want mention of read seed file", err)
+	}
+}
+
+// TestLoadSeedFile_InvalidJSON rejects garbage. Verifies the
+// fall-through error mentions both shape options so an operator
+// debugging the failure knows what's expected.
+func TestLoadSeedFile_InvalidJSON(t *testing.T) {
+	path := writeSeedFile(t, `not even close to JSON`)
+	_, err := LoadSeedFile(path)
+	if err == nil {
+		t.Fatal("LoadSeedFile: want error, got nil")
+	}
+	if !strings.Contains(err.Error(), "neither a JSON array nor an object") {
+		t.Errorf("error=%v want a shape-hint message", err)
+	}
+}
+
+// TestSeedQueue_RegistersAllEntries verifies SeedQueue puts each
+// entry on the queue in input order and returns the minted ids,
+// exercising the same Register code path production uses.
+func TestSeedQueue_RegistersAllEntries(t *testing.T) {
+	q := NewActionApprovalQueue(nil, nil)
+	entries := []SeedEntry{
+		{Kind: ApprovalKindAction, ActionName: "send-email", Args: map[string]any{"to": "a@b"}},
+		{Kind: ApprovalKindCommsSend, ActionName: "send_message", Args: map[string]any{"service": "slack"}},
+		{Kind: ApprovalKindHTTPRequest, ActionName: "http_request", Args: map[string]any{"method": "GET", "url": "http://x"}},
+	}
+
+	ids := SeedQueue(q, entries)
+
+	if len(ids) != 3 {
+		t.Fatalf("len(ids)=%d want 3", len(ids))
+	}
+	pending := q.List()
+	if len(pending) != 3 {
+		t.Fatalf("queue.List len=%d want 3", len(pending))
+	}
+	// All seeded entries must be retrievable by their returned id.
+	for _, id := range ids {
+		if _, ok := q.Get(id); !ok {
+			t.Errorf("Get(%q) not found", id)
+		}
+	}
+	// Kinds round-trip — the queue's RegisterKind preserves what
+	// the seed handed it.
+	gotKinds := map[ApprovalKind]int{}
+	for _, p := range pending {
+		gotKinds[p.Kind]++
+	}
+	for _, k := range []ApprovalKind{ApprovalKindAction, ApprovalKindCommsSend, ApprovalKindHTTPRequest} {
+		if gotKinds[k] != 1 {
+			t.Errorf("kind %q count=%d want 1", k, gotKinds[k])
+		}
+	}
+}
+
+// TestSeedQueue_EmptyKindDefaultsToAction mirrors the queue's own
+// behavior — an unset kind in the JSON becomes ApprovalKindAction
+// rather than failing — so fixtures written before #428 (or by
+// hand without a kind field) still seed successfully.
+func TestSeedQueue_EmptyKindDefaultsToAction(t *testing.T) {
+	q := NewActionApprovalQueue(nil, nil)
+	ids := SeedQueue(q, []SeedEntry{
+		{ActionName: "legacy-action"},
+	})
+	if len(ids) != 1 {
+		t.Fatalf("len(ids)=%d", len(ids))
+	}
+	a, _ := q.Get(ids[0])
+	if a.Kind != ApprovalKindAction {
+		t.Errorf("kind=%q want %q", a.Kind, ApprovalKindAction)
+	}
+}
+
+func writeSeedFile(t *testing.T, body string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "seed.json")
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+	return path
+}

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -24,6 +24,7 @@ import (
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/app"
+	"github.com/ALRubinger/aileron/internal/approval"
 	"github.com/ALRubinger/aileron/internal/comms"
 	"github.com/ALRubinger/aileron/internal/config"
 	"github.com/ALRubinger/aileron/internal/daemon/discovery"
@@ -42,14 +43,16 @@ var lockInodeWatchInterval = 5 * time.Second
 
 func main() {
 	var bind string
+	var seedApprovalsPath string
 	flag.StringVar(&bind, "bind", "", "TCP bind address (default 127.0.0.1:0 ephemeral; cloud sets e.g. 0.0.0.0:8080)")
+	flag.StringVar(&seedApprovalsPath, "dev-seed-approvals", "", "Dev-only: path to a JSON file of pending action approvals to seed at startup. Refused unless the bind address is loopback.")
 	flag.Parse()
 
 	log := newLogger(os.Getenv("AILERON_LOG_LEVEL"))
 	ctx, stop := signal.NotifyContext(context.Background(), syscall.SIGINT, syscall.SIGTERM)
 	defer stop()
 
-	if err := startDaemon(ctx, bind, log); err != nil {
+	if err := startDaemon(ctx, bind, seedApprovalsPath, log); err != nil {
 		log.Error("daemon exited with error", "error", err)
 		os.Exit(1)
 	}
@@ -59,17 +62,18 @@ func main() {
 // drives [run] under the supplied context. Extracted from main so
 // tests can exercise the wiring with a cancellable ctx and a
 // HOME-overridden state directory.
-func startDaemon(ctx context.Context, bind string, log *slog.Logger) error {
+func startDaemon(ctx context.Context, bind, seedApprovalsPath string, log *slog.Logger) error {
 	stateDir, err := defaultStateDir()
 	if err != nil {
 		return err
 	}
 	return run(ctx, log, options{
-		BindAddr:  bind,
-		StateDir:  stateDir,
-		VaultPath: launch.DefaultVaultPath(),
-		IsTTY:     term.IsTerminal(int(os.Stdin.Fd())),
-		Stderr:    os.Stderr,
+		BindAddr:          bind,
+		StateDir:          stateDir,
+		VaultPath:         launch.DefaultVaultPath(),
+		IsTTY:             term.IsTerminal(int(os.Stdin.Fd())),
+		Stderr:            os.Stderr,
+		SeedApprovalsPath: seedApprovalsPath,
 	})
 }
 
@@ -111,6 +115,13 @@ type options struct {
 	// Stderr is the stream selectVault uses for prompts. Set to
 	// os.Stderr in production; bytes.Buffer in tests.
 	Stderr io.Writer
+	// SeedApprovalsPath, when set, points at a JSON file of pending
+	// action approvals to register on the queue at startup. Developer-
+	// only — Playwright integration tests drive this so the approvals
+	// page has something to list/approve/deny without standing up a
+	// real agent. Refused unless BindAddr resolves to a loopback
+	// address.
+	SeedApprovalsPath string
 }
 
 // run owns the daemon lifecycle: acquire the singleton lock, bind,
@@ -231,6 +242,27 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 	if bindAddr == "" {
 		bindAddr = "127.0.0.1:0"
 	}
+
+	// --dev-seed-approvals: developer-only path to a JSON fixture of
+	// pending action approvals. Wired in before the handler is built so
+	// the seeded queue is the one cfg.ActionApprovals carries.
+	// Loopback-only: refusing on a non-loopback bind keeps a careless
+	// `aileron --bind 0.0.0.0 --dev-seed-approvals=...` from exposing a
+	// pre-populated approval surface to the network.
+	if opts.SeedApprovalsPath != "" {
+		if !isLoopbackBind(bindAddr) {
+			return fmt.Errorf("--dev-seed-approvals requires a loopback bind address (got %q)", bindAddr)
+		}
+		entries, err := approval.LoadSeedFile(opts.SeedApprovalsPath)
+		if err != nil {
+			return fmt.Errorf("load seed approvals: %w", err)
+		}
+		queue := approval.NewActionApprovalQueue(nil, nil)
+		ids := approval.SeedQueue(queue, entries)
+		cfg.ActionApprovals = queue
+		log.Info("seeded action approvals", "count", len(ids), "ids", ids)
+	}
+
 	listener, err := net.Listen("tcp", bindAddr)
 	if err != nil {
 		return fmt.Errorf("listen %s: %w", bindAddr, err)
@@ -369,6 +401,28 @@ func defaultStateDir() (string, error) {
 		return "", fmt.Errorf("user home dir: %w", err)
 	}
 	return filepath.Join(home, ".aileron"), nil
+}
+
+// isLoopbackBind reports whether bindAddr ("host:port" form) resolves
+// to a loopback IP. Used by the --dev-seed-approvals guard so the
+// developer-only seed surface can never accompany a public bind.
+//
+// Conservative on parse failure (returns false): unparseable bind
+// addresses don't get the benefit of the doubt — better to reject the
+// seed than silently expose it on an unintended interface.
+func isLoopbackBind(bindAddr string) bool {
+	host, _, err := net.SplitHostPort(bindAddr)
+	if err != nil {
+		return false
+	}
+	if host == "" || host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	if ip == nil {
+		return false
+	}
+	return ip.IsLoopback()
 }
 
 // selectVault decides how the daemon should access the local file vault

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -784,7 +784,7 @@ func TestStartDaemonHappyPath(t *testing.T) {
 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
 	runErr := make(chan error, 1)
-	go func() { runErr <- startDaemon(ctx, "127.0.0.1:0", log) }()
+	go func() { runErr <- startDaemon(ctx, "127.0.0.1:0", "", log) }()
 
 	waitForDaemon(t, stateDir, 3*time.Second)
 
@@ -807,7 +807,7 @@ func TestStartDaemonReturnsErrorFromRun(t *testing.T) {
 	seedVault(t, launch.DefaultVaultPath())
 
 	log := slog.New(slog.NewTextHandler(io.Discard, nil))
-	err := startDaemon(context.Background(), "not-a-valid-address", log)
+	err := startDaemon(context.Background(), "not-a-valid-address", "", log)
 	if err == nil {
 		t.Fatal("startDaemon should propagate the listen error")
 	}
@@ -857,6 +857,170 @@ func refusePrompter(t *testing.T) launch.PassphrasePrompter {
 	return func(_ string, _ io.Writer) (string, error) {
 		t.Errorf("prompter was called; expected to short-circuit before prompting")
 		return "", nil
+	}
+}
+
+// TestIsLoopbackBind covers the bind-address classifier the
+// --dev-seed-approvals guard depends on. Each case is one row in the
+// guard's truth table; rejecting parse failures is the conservative
+// default per the function's contract.
+func TestIsLoopbackBind(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{"127.0.0.1:0", true},
+		{"127.0.0.1:8080", true},
+		{"localhost:8080", true},
+		{":8080", true}, // empty host = bind on all loopback interfaces in tests
+		{"[::1]:0", true},
+		{"0.0.0.0:8080", false},
+		{"192.168.1.5:0", false},
+		{"example.com:80", false}, // hostname; doesn't resolve to loopback
+		{"not-a-valid-address", false},
+	}
+	for _, c := range cases {
+		t.Run(c.addr, func(t *testing.T) {
+			if got := isLoopbackBind(c.addr); got != c.want {
+				t.Errorf("isLoopbackBind(%q) = %v, want %v", c.addr, got, c.want)
+			}
+		})
+	}
+}
+
+// TestRun_SeedApprovals_PopulatesQueue verifies the --dev-seed-approvals
+// path end-to-end against a real daemon: the JSON fixture is loaded,
+// each entry is registered on the action-approval queue, and the
+// queue's pending entries surface via the public list endpoint.
+//
+// This is the contract Playwright's tier-2 integration spec depends
+// on. Without it, the spec would have nothing to list/approve.
+func TestRun_SeedApprovals_PopulatesQueue(t *testing.T) {
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+	seedVault(t, vaultPath)
+	seedFile := filepath.Join(t.TempDir(), "approvals.json")
+	body := `[
+		{"kind":"action","action_name":"send-email","connector_fqn":"github://x/y","args":{"to":"a@b.com"}},
+		{"kind":"comms_send","action_name":"send_message","args":{"service":"slack","channel":"#dev","body":"deploy"}}
+	]`
+	if err := os.WriteFile(seedFile, []byte(body), 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:          "127.0.0.1:0",
+		StateDir:          stateDir,
+		VaultPath:         vaultPath,
+		IsTTY:             false,
+		Stderr:            io.Discard,
+		SeedApprovalsPath: seedFile,
+	}
+	runErr := make(chan error, 1)
+	go func() { runErr <- run(ctx, log, opts) }()
+	info := waitForDaemon(t, stateDir, 3*time.Second)
+	defer func() {
+		cancel()
+		select {
+		case <-runErr:
+		case <-time.After(5 * time.Second):
+			t.Fatal("run did not return within timeout")
+		}
+	}()
+
+	resp, err := http.Get(info.URL + "/v1/action-approvals")
+	if err != nil {
+		t.Fatalf("GET /v1/action-approvals: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	var listResp struct {
+		Items []struct {
+			ID         string `json:"id"`
+			Kind       string `json:"kind"`
+			ActionName string `json:"action_name"`
+		} `json:"items"`
+	}
+	if err := json.NewDecoder(resp.Body).Decode(&listResp); err != nil {
+		t.Fatalf("decode list: %v", err)
+	}
+	if len(listResp.Items) != 2 {
+		t.Fatalf("len(items)=%d want 2 — seed entries should be surfaced via /v1/action-approvals", len(listResp.Items))
+	}
+	kinds := map[string]bool{}
+	for _, it := range listResp.Items {
+		kinds[it.Kind] = true
+		if it.ID == "" || it.ActionName == "" {
+			t.Errorf("entry missing id or action_name: %+v", it)
+		}
+	}
+	if !kinds["action"] || !kinds["comms_send"] {
+		t.Errorf("kinds=%v want action and comms_send", kinds)
+	}
+}
+
+// TestRun_SeedApprovals_RejectsNonLoopbackBind verifies the guard
+// short-circuits BEFORE binding when --dev-seed-approvals is paired
+// with a public bind. Failing fast keeps a careless invocation from
+// briefly exposing the seeded queue to the network.
+func TestRun_SeedApprovals_RejectsNonLoopbackBind(t *testing.T) {
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+	seedVault(t, vaultPath)
+	seedFile := filepath.Join(t.TempDir(), "approvals.json")
+	if err := os.WriteFile(seedFile, []byte(`[]`), 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	err := run(context.Background(), log, options{
+		BindAddr:          "0.0.0.0:0",
+		StateDir:          stateDir,
+		VaultPath:         vaultPath,
+		IsTTY:             false,
+		Stderr:            io.Discard,
+		SeedApprovalsPath: seedFile,
+	})
+	if err == nil {
+		t.Fatal("run should reject --dev-seed-approvals on a non-loopback bind")
+	}
+	if !strings.Contains(err.Error(), "loopback") {
+		t.Errorf("err=%v want mention of loopback", err)
+	}
+}
+
+// TestRun_SeedApprovals_PropagatesLoadErrors covers the failure mode
+// where the seed file is malformed. The startup error should be
+// surfaced rather than swallowed — Playwright's job runner needs to
+// fail fast on a broken fixture.
+func TestRun_SeedApprovals_PropagatesLoadErrors(t *testing.T) {
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+	seedVault(t, vaultPath)
+	seedFile := filepath.Join(t.TempDir(), "broken.json")
+	if err := os.WriteFile(seedFile, []byte(`{not json at all`), 0o600); err != nil {
+		t.Fatalf("write seed: %v", err)
+	}
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	err := run(context.Background(), log, options{
+		BindAddr:          "127.0.0.1:0",
+		StateDir:          stateDir,
+		VaultPath:         vaultPath,
+		IsTTY:             false,
+		Stderr:            io.Discard,
+		SeedApprovalsPath: seedFile,
+	})
+	if err == nil {
+		t.Fatal("run should surface seed-load errors")
+	}
+	if !strings.Contains(err.Error(), "load seed approvals") {
+		t.Errorf("err=%v want 'load seed approvals' prefix", err)
 	}
 }
 

--- a/test/fixtures/action-approvals/basic.json
+++ b/test/fixtures/action-approvals/basic.json
@@ -1,0 +1,31 @@
+[
+  {
+    "kind": "action",
+    "action_name": "send-email",
+    "connector_fqn": "github://aileron/aileron-connector-google",
+    "args": {
+      "to": "alice@example.com",
+      "subject": "release notes",
+      "body": "v0.0.7 is cut"
+    }
+  },
+  {
+    "kind": "comms_send",
+    "action_name": "send_message",
+    "args": {
+      "service": "slack",
+      "channel": "#deploys",
+      "body": "Deploying main to prod"
+    }
+  },
+  {
+    "kind": "http_request",
+    "action_name": "http_request",
+    "args": {
+      "method": "POST",
+      "url": "https://api.example.com/widgets",
+      "body": "{\"name\":\"new\"}",
+      "secret_name": "example_api_key"
+    }
+  }
+]

--- a/webapp/.gitignore
+++ b/webapp/.gitignore
@@ -4,3 +4,5 @@ build/
 .DS_Store
 test-results/
 coverage/
+playwright-report/
+playwright/.cache/

--- a/webapp/e2e-integration/approvals-lifecycle.spec.ts
+++ b/webapp/e2e-integration/approvals-lifecycle.spec.ts
@@ -1,0 +1,114 @@
+import { test, expect, type Page } from '@playwright/test';
+
+// Real-daemon integration test for the /approvals page.
+//
+// Setup expectation: an `aileron` daemon is already running with the
+// `test/fixtures/action-approvals/basic.json` seed loaded (three
+// pending entries: `action`, `comms_send`, `http_request`) and its
+// bound URL is in `AILERON_WEBAPP_URL`. The Taskfile target
+// `test:webapp:e2e:integration` is responsible for that wiring.
+//
+// The tests share a single daemon and the daemon's queue is mutable
+// state. They run sequentially (workers=1 in playwright.integration.config.ts)
+// and each test draws down a different entry from the seed so they
+// don't trip over each other. Re-running the suite without restarting
+// the daemon would fail the second run — that's a feature, not a bug:
+// the seed represents a known starting state.
+
+test.beforeAll(async () => {
+	if (!process.env.AILERON_WEBAPP_URL) {
+		throw new Error(
+			'AILERON_WEBAPP_URL is not set. Run via `task test:webapp:e2e:integration` so the orchestration script starts the daemon and exports the URL.'
+		);
+	}
+});
+
+test('lists the seeded pending approvals', async ({ page }) => {
+	await page.goto('/approvals');
+
+	// Three cards from the seed fixture, no mocks.
+	await expect(page.getByTestId('action-approval-card')).toHaveCount(3, {
+		timeout: 10_000
+	});
+	const kinds = await page
+		.getByTestId('action-approval-card')
+		.evaluateAll((els) => els.map((e) => (e as HTMLElement).dataset.approvalKind));
+	expect(kinds).toEqual(expect.arrayContaining(['action', 'comms_send', 'http_request']));
+});
+
+test('approving the action kind removes its card and clears it from the server queue', async ({
+	page
+}) => {
+	await page.goto('/approvals');
+	const card = firstCardByKind(page, 'action');
+	await expect(card).toBeVisible();
+	const approvalId = await card.getAttribute('data-approval-id');
+	if (!approvalId) throw new Error('action card missing data-approval-id');
+
+	await card.getByTestId('approve-button').click();
+
+	// Optimistic removal on the client.
+	await expect(card).toHaveCount(0);
+
+	// Server-side state agrees: the entry no longer appears in the
+	// pending list.
+	const remaining = await fetchPendingIds(page);
+	expect(remaining).not.toContain(approvalId);
+});
+
+test('denying the comms_send kind with a reason persists the reason on the server', async ({
+	page
+}) => {
+	await page.goto('/approvals');
+	const card = firstCardByKind(page, 'comms_send');
+	await expect(card).toBeVisible();
+	const approvalId = await card.getAttribute('data-approval-id');
+	if (!approvalId) throw new Error('comms_send card missing data-approval-id');
+
+	await card.getByTestId('deny-reason-input').fill('wrong channel');
+	await card.getByTestId('deny-button').click();
+
+	await expect(card).toHaveCount(0);
+
+	// The decided entry is retained in the queue's outcome map; poll
+	// the result endpoint to confirm the deny reason round-tripped.
+	const result = await fetchResult(page, approvalId);
+	expect(result.status).toBe('denied');
+	expect(result.reason).toBe('wrong channel');
+});
+
+test('approving the http_request kind drains the remaining card and shows the empty state', async ({
+	page
+}) => {
+	await page.goto('/approvals');
+	const card = firstCardByKind(page, 'http_request');
+	await expect(card).toBeVisible();
+
+	await card.getByTestId('approve-button').click();
+	await expect(card).toHaveCount(0);
+
+	// Empty state renders once the queue drains.
+	await expect(page.getByText(/No pending approvals/i)).toBeVisible();
+});
+
+function firstCardByKind(page: Page, kind: string) {
+	return page.locator(`[data-approval-kind="${kind}"]`).first();
+}
+
+async function fetchPendingIds(page: Page): Promise<string[]> {
+	const resp = await page.request.get('/v1/action-approvals');
+	expect(resp.ok()).toBe(true);
+	const body = (await resp.json()) as {
+		items: Array<{ id: string }>;
+	};
+	return body.items.map((i) => i.id);
+}
+
+async function fetchResult(
+	page: Page,
+	id: string
+): Promise<{ status: string; reason?: string }> {
+	const resp = await page.request.get(`/v1/action-approvals/${id}/result`);
+	expect(resp.ok()).toBe(true);
+	return resp.json();
+}

--- a/webapp/e2e/approvals-approve.spec.ts
+++ b/webapp/e2e/approvals-approve.spec.ts
@@ -1,0 +1,123 @@
+import { test, expect, fixture } from './fixtures/approvals';
+
+test.describe('Approvals page — approving', () => {
+	test('action kind: clicking Approve posts {approved: true} for the right id', async ({
+		page,
+		approvalsMock
+	}) => {
+		const item = fixture.action();
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([item]);
+
+		await expect(
+			page.locator(`[data-approval-id="${item.id}"]`)
+		).toBeVisible();
+
+		const card = page.locator(`[data-approval-id="${item.id}"]`);
+		await card.getByTestId('approve-button').click();
+
+		// One decide POST landed against the right id with approved=true.
+		// reason is empty on approve per +page.svelte:70.
+		await expect.poll(() => approvalsMock.decides.posts.length).toBe(1);
+		const post = approvalsMock.decides.posts[0];
+		expect(post.approvalId).toBe(item.id);
+		expect(post.body.approved).toBe(true);
+		expect(post.body.reason).toBe('');
+		expect(post.body.edited_payload).toBeUndefined();
+
+		// Optimistic removal: the card disappears immediately on click
+		// (page applies resolved synchronously). No SSE push needed.
+		await expect(
+			page.locator(`[data-approval-id="${item.id}"]`)
+		).toHaveCount(0);
+	});
+
+	test('comms_send kind: card shows service/channel/body, Approve posts approved=true', async ({
+		page,
+		approvalsMock
+	}) => {
+		const item = fixture.commsSend();
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([item]);
+
+		const card = page.locator(`[data-approval-id="${item.id}"]`);
+		const summary = card.getByTestId('comms-send-summary');
+		await expect(summary).toContainText('slack');
+		await expect(summary).toContainText('#general');
+		await expect(card.getByTestId('comms-send-body')).toContainText(
+			'Deploying main to prod'
+		);
+
+		await card.getByTestId('approve-button').click();
+
+		await expect.poll(() => approvalsMock.decides.posts.length).toBe(1);
+		expect(approvalsMock.decides.posts[0].approvalId).toBe(item.id);
+		expect(approvalsMock.decides.posts[0].body.approved).toBe(true);
+	});
+
+	test('http_request kind: card shows method + URL + credential, Approve posts approved=true', async ({
+		page,
+		approvalsMock
+	}) => {
+		const item = fixture.httpRequest();
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([item]);
+
+		const card = page.locator(`[data-approval-id="${item.id}"]`);
+		const summary = card.getByTestId('http-request-summary');
+		await expect(summary).toContainText('POST');
+		await expect(summary).toContainText('https://api.example.com/widgets');
+		// secret_name should appear (without ever exposing the value).
+		await expect(summary).toContainText('example_api_key');
+
+		await card.getByTestId('approve-button').click();
+
+		await expect.poll(() => approvalsMock.decides.posts.length).toBe(1);
+		expect(approvalsMock.decides.posts[0].approvalId).toBe(item.id);
+		expect(approvalsMock.decides.posts[0].body.approved).toBe(true);
+	});
+
+	test('http_request without a matching secret surfaces the unauthenticated hint', async ({
+		page,
+		approvalsMock
+	}) => {
+		const item = fixture.httpRequest({
+			id: 'act-http-no-cred',
+			args: {
+				method: 'GET',
+				url: 'https://api.example.com/public',
+				body: '',
+				secret_name: ''
+			}
+		});
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([item]);
+
+		await expect(
+			page.locator(`[data-approval-id="${item.id}"]`).getByText(/No matching api_key binding/i)
+		).toBeVisible();
+	});
+
+	test('approving one of several entries leaves the others in place', async ({
+		page,
+		approvalsMock
+	}) => {
+		const a = fixture.action();
+		const b = fixture.commsSend();
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([a, b]);
+
+		await page
+			.locator(`[data-approval-id="${a.id}"]`)
+			.getByTestId('approve-button')
+			.click();
+
+		await expect.poll(() => approvalsMock.decides.posts.length).toBe(1);
+		await expect(
+			page.locator(`[data-approval-id="${a.id}"]`)
+		).toHaveCount(0);
+		await expect(
+			page.locator(`[data-approval-id="${b.id}"]`)
+		).toBeVisible();
+	});
+});

--- a/webapp/e2e/approvals-deny.spec.ts
+++ b/webapp/e2e/approvals-deny.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, fixture } from './fixtures/approvals';
+
+test.describe('Approvals page — denying', () => {
+	test('Deny with no reason posts {approved: false, reason: ""}', async ({
+		page,
+		approvalsMock
+	}) => {
+		// Per webapp/src/routes/approvals/+page.svelte:70 the reason
+		// field is optional on deny — the page forwards "" verbatim
+		// rather than blocking submit. The runtime forwards "" to the
+		// agent which reads it as a bare "user denied".
+		const item = fixture.action();
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([item]);
+
+		await page
+			.locator(`[data-approval-id="${item.id}"]`)
+			.getByTestId('deny-button')
+			.click();
+
+		await expect.poll(() => approvalsMock.decides.posts.length).toBe(1);
+		const post = approvalsMock.decides.posts[0];
+		expect(post.approvalId).toBe(item.id);
+		expect(post.body.approved).toBe(false);
+		expect(post.body.reason).toBe('');
+
+		await expect(
+			page.locator(`[data-approval-id="${item.id}"]`)
+		).toHaveCount(0);
+	});
+
+	test('Deny with a typed reason ships the reason on the POST', async ({
+		page,
+		approvalsMock
+	}) => {
+		const item = fixture.commsSend();
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([item]);
+
+		const card = page.locator(`[data-approval-id="${item.id}"]`);
+		await card.getByTestId('deny-reason-input').fill('wrong channel');
+		await card.getByTestId('deny-button').click();
+
+		await expect.poll(() => approvalsMock.decides.posts.length).toBe(1);
+		const post = approvalsMock.decides.posts[0];
+		expect(post.approvalId).toBe(item.id);
+		expect(post.body.approved).toBe(false);
+		expect(post.body.reason).toBe('wrong channel');
+	});
+
+	test('Approve ignores whatever is in the reason input', async ({
+		page,
+		approvalsMock
+	}) => {
+		// The input is shared between approve and deny; the page
+		// snapshots reason='' on approve so a stray typed value doesn't
+		// leak into an approval audit event.
+		const item = fixture.action();
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([item]);
+
+		const card = page.locator(`[data-approval-id="${item.id}"]`);
+		await card.getByTestId('deny-reason-input').fill('this should not ship');
+		await card.getByTestId('approve-button').click();
+
+		await expect.poll(() => approvalsMock.decides.posts.length).toBe(1);
+		expect(approvalsMock.decides.posts[0].body.approved).toBe(true);
+		expect(approvalsMock.decides.posts[0].body.reason).toBe('');
+	});
+
+	test('denying one entry leaves the others in place', async ({
+		page,
+		approvalsMock
+	}) => {
+		const a = fixture.action();
+		const b = fixture.httpRequest();
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([a, b]);
+
+		await page
+			.locator(`[data-approval-id="${b.id}"]`)
+			.getByTestId('deny-button')
+			.click();
+
+		await expect.poll(() => approvalsMock.decides.posts.length).toBe(1);
+		expect(approvalsMock.decides.posts[0].approvalId).toBe(b.id);
+		await expect(
+			page.locator(`[data-approval-id="${a.id}"]`)
+		).toBeVisible();
+		await expect(
+			page.locator(`[data-approval-id="${b.id}"]`)
+		).toHaveCount(0);
+	});
+});

--- a/webapp/e2e/approvals-list.spec.ts
+++ b/webapp/e2e/approvals-list.spec.ts
@@ -1,0 +1,94 @@
+import { test, expect, fixture } from './fixtures/approvals';
+
+test.describe('Approvals page — listing', () => {
+	test('shows the empty-state hint when the snapshot is empty', async ({
+		page,
+		approvalsMock
+	}) => {
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([]);
+		await expect(
+			page.getByText(/No pending approvals/i)
+		).toBeVisible();
+	});
+
+	test('renders a populated snapshot — one card per pending entry', async ({
+		page,
+		approvalsMock
+	}) => {
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([
+			fixture.action(),
+			fixture.commsSend(),
+			fixture.httpRequest()
+		]);
+
+		const cards = page.getByTestId('action-approval-card');
+		await expect(cards).toHaveCount(3);
+		await expect(
+			page.locator('[data-approval-id="act-action-1"]')
+		).toBeVisible();
+		await expect(
+			page.locator('[data-approval-id="act-comms-send-1"]')
+		).toBeVisible();
+		await expect(
+			page.locator('[data-approval-id="act-http-1"]')
+		).toBeVisible();
+	});
+
+	test('appends a card when a pending event arrives after load', async ({
+		page,
+		approvalsMock
+	}) => {
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([fixture.action()]);
+		await expect(page.getByTestId('action-approval-card')).toHaveCount(1);
+
+		await approvalsMock.sse.pushPending(
+			fixture.commsSend({ id: 'act-late-arrival' })
+		);
+
+		await expect(page.getByTestId('action-approval-card')).toHaveCount(2);
+		await expect(
+			page.locator('[data-approval-id="act-late-arrival"]')
+		).toBeVisible();
+	});
+
+	test('removes a card when a resolved event arrives for that id', async ({
+		page,
+		approvalsMock
+	}) => {
+		// A `resolved` event the user did NOT trigger themselves —
+		// simulates a second tab (or the CLI) deciding the approval.
+		// The page must drop the matching card on receipt.
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([
+			fixture.action(),
+			fixture.commsSend()
+		]);
+		await expect(page.getByTestId('action-approval-card')).toHaveCount(2);
+
+		await approvalsMock.sse.pushResolved(
+			fixture.resolved('act-action-1', true)
+		);
+
+		await expect(page.getByTestId('action-approval-card')).toHaveCount(1);
+		await expect(
+			page.locator('[data-approval-id="act-action-1"]')
+		).toHaveCount(0);
+	});
+
+	test('de-dupes a `pending` event for an id already in the snapshot', async ({
+		page,
+		approvalsMock
+	}) => {
+		// SSE reconnect can replay a snapshot whose ids overlap with
+		// recently-delivered `pending` events. The page must not double
+		// the cards.
+		await page.goto('/approvals');
+		await approvalsMock.sse.pushSnapshot([fixture.action()]);
+		await approvalsMock.sse.pushPending(fixture.action());
+
+		await expect(page.getByTestId('action-approval-card')).toHaveCount(1);
+	});
+});

--- a/webapp/e2e/fixtures/approvals.ts
+++ b/webapp/e2e/fixtures/approvals.ts
@@ -1,0 +1,292 @@
+import { expect, test as base, type Page, type Request } from '@playwright/test';
+
+/**
+ * Mocked-API fixture for the /approvals page.
+ *
+ * The page consumes two endpoint families:
+ *
+ *   - GET /v1/action-approvals/watch  — Server-Sent Events feed of the
+ *     pending queue (snapshot + pending + resolved frames). The page
+ *     opens this via `new EventSource(...)` on mount.
+ *   - POST /v1/action-approvals/{id}/decide  — user verdict. Plain
+ *     fetch; returns 200 with an empty body on success.
+ *
+ * Playwright's `route.fulfill()` buffers the body, so streamed SSE is
+ * not directly forwardable through `page.route()`. Instead, this
+ * fixture overrides `window.EventSource` with a test-only class whose
+ * frames are pushed from Node via `page.evaluate()`. The override is
+ * installed via `addInitScript()` and so applies to every navigation in
+ * the test's page context.
+ *
+ * The decide endpoint is mocked through `page.route()` and exposes the
+ * captured request bodies for assertion. The decide-resolved
+ * round-trip is decoupled: tests push the `resolved` SSE frame
+ * themselves after asserting the decide POST, mirroring how the real
+ * daemon broadcasts to all subscribers.
+ */
+
+import type {
+	PendingActionApproval,
+	ResolvedActionApproval
+} from '../../src/lib/api';
+
+const WATCH_URL_PATH = '/v1/action-approvals/watch';
+
+/**
+ * Bag of recorded decide-POST requests. Tests assert against this
+ * (e.g. "the approve button POSTed with approved=true and the right id").
+ * Cleared between tests by the fixture.
+ */
+export type DecideRecorder = {
+	posts: Array<{ approvalId: string; body: DecideBody }>;
+};
+
+export type DecideBody = {
+	approved: boolean;
+	reason: string;
+	edited_payload?: Record<string, unknown>;
+};
+
+/**
+ * Live handle to the mocked SSE stream. Tests push frames; the page's
+ * EventSource subscriber dispatches them as if they came from the
+ * daemon.
+ */
+export type SSEController = {
+	/**
+	 * Replace the snapshot — useful when the test mounts the page and
+	 * wants a non-empty initial state. Pushes an `event: snapshot`
+	 * frame. Safe to call before navigation; the override buffers
+	 * frames until the page constructs the EventSource.
+	 */
+	pushSnapshot: (items: PendingActionApproval[]) => Promise<void>;
+	/** Push a `pending` frame — appears live in the page. */
+	pushPending: (item: PendingActionApproval) => Promise<void>;
+	/** Push a `resolved` frame — page removes the matching card. */
+	pushResolved: (resolved: ResolvedActionApproval) => Promise<void>;
+};
+
+type ApprovalsFixtures = {
+	approvalsMock: {
+		sse: SSEController;
+		decides: DecideRecorder;
+	};
+};
+
+export const test = base.extend<ApprovalsFixtures>({
+	approvalsMock: async ({ page }, use) => {
+		await installEventSourceMock(page);
+		const decides: DecideRecorder = { posts: [] };
+		await installDecideMock(page, decides);
+
+		const sse: SSEController = {
+			pushSnapshot: (items) => emit(page, 'snapshot', { items }),
+			pushPending: (item) => emit(page, 'pending', item),
+			pushResolved: (resolved) => emit(page, 'resolved', resolved)
+		};
+
+		await use({ sse, decides });
+	}
+});
+
+export { expect };
+
+async function installEventSourceMock(page: Page): Promise<void> {
+	await page.addInitScript(({ watchPath }) => {
+		const inbox: Array<{ event: string; data: unknown }> = [];
+		// One channel per EventSource — keyed by the resolved URL so a
+		// test that navigates between pages doesn't cross frames.
+		const channels = new Map<
+			string,
+			{
+				dispatch: (event: string, data: unknown) => void;
+				close: () => void;
+			}
+		>();
+
+		(window as unknown as { __sseChannels__: typeof channels }).__sseChannels__ = channels;
+		(window as unknown as { __sseInbox__: typeof inbox }).__sseInbox__ = inbox;
+
+		class MockEventSource extends EventTarget {
+			static readonly CONNECTING = 0;
+			static readonly OPEN = 1;
+			static readonly CLOSED = 2;
+			readonly CONNECTING = 0;
+			readonly OPEN = 1;
+			readonly CLOSED = 2;
+			readyState = 1;
+			withCredentials = false;
+			url: string;
+			onopen: ((this: EventSource, ev: Event) => unknown) | null = null;
+			onmessage: ((this: EventSource, ev: MessageEvent) => unknown) | null = null;
+			onerror: ((this: EventSource, ev: Event) => unknown) | null = null;
+
+			constructor(url: string | URL) {
+				super();
+				this.url =
+					typeof url === 'string'
+						? new URL(url, location.origin).pathname + new URL(url, location.origin).search
+						: url.pathname + url.search;
+
+				const dispatch = (event: string, data: unknown) => {
+					if (this.readyState === 2) return;
+					const ev = new MessageEvent(event, { data: JSON.stringify(data) });
+					this.dispatchEvent(ev);
+				};
+				const close = () => {
+					this.readyState = 2;
+				};
+
+				channels.set(this.url, { dispatch, close });
+
+				// Drain any frames queued before the page constructed the
+				// EventSource. The order of evaluate() vs onMount is not
+				// strictly deterministic across runs, so this buffer keeps
+				// pushSnapshot-before-navigate safe.
+				if (this.url === watchPath) {
+					queueMicrotask(() => {
+						while (inbox.length > 0) {
+							const f = inbox.shift();
+							if (f) dispatch(f.event, f.data);
+						}
+					});
+				}
+			}
+
+			close() {
+				this.readyState = 2;
+				channels.delete(this.url);
+			}
+		}
+
+		// Replace the constructor in place. EventSource is a structural
+		// type on window for our purposes — the page's api.ts only uses
+		// addEventListener / close / readyState.
+		(window as unknown as { EventSource: typeof MockEventSource }).EventSource = MockEventSource;
+	}, { watchPath: WATCH_URL_PATH });
+}
+
+async function emit(page: Page, event: string, data: unknown): Promise<void> {
+	await page.evaluate(
+		({ event, data, watchPath }) => {
+			const channels = (window as unknown as {
+				__sseChannels__?: Map<
+					string,
+					{ dispatch: (e: string, d: unknown) => void }
+				>;
+			}).__sseChannels__;
+			const inbox = (window as unknown as {
+				__sseInbox__?: Array<{ event: string; data: unknown }>;
+			}).__sseInbox__;
+			const ch = channels?.get(watchPath);
+			if (ch) {
+				ch.dispatch(event, data);
+			} else if (inbox) {
+				// EventSource not yet constructed (test pushed snapshot
+				// before navigation). Buffer for delivery on construct.
+				inbox.push({ event, data });
+			}
+		},
+		{ event, data, watchPath: WATCH_URL_PATH }
+	);
+}
+
+async function installDecideMock(page: Page, decides: DecideRecorder): Promise<void> {
+	await page.route('**/v1/action-approvals/*/decide', async (route) => {
+		const req: Request = route.request();
+		const url = new URL(req.url());
+		const segments = url.pathname.split('/');
+		// path: /v1/action-approvals/{id}/decide
+		const approvalId = segments[segments.length - 2];
+		const body = (await safeJSON(req.postData())) as DecideBody;
+		decides.posts.push({ approvalId, body });
+		// Match the daemon's wire contract (#655): decide returns 204
+		// No Content. apiFetch's 204 branch returns null cleanly;
+		// returning 200 with an empty body would trip the json-parse
+		// catch in the page and surface a spurious error.
+		await route.fulfill({ status: 204 });
+	});
+
+	// The page also calls GET /v1/action-approvals on reconnect; mock
+	// it as empty by default so a tab-level reload doesn't surprise the
+	// test with a real-network attempt.
+	await page.route('**/v1/action-approvals', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ items: [] })
+		});
+	});
+
+	// The root layout calls /v1/vault/status on mount (vault.svelte.ts).
+	// Mock it as `unlocked` so the passphrase modal stays closed; the
+	// real daemon under `aileron launch` typically reports the same
+	// state for an already-decrypted vault.
+	await page.route('**/v1/vault/status', async (route) => {
+		await route.fulfill({
+			status: 200,
+			contentType: 'application/json',
+			body: JSON.stringify({ locked: false, state: 'unlocked' })
+		});
+	});
+}
+
+function safeJSON(s: string | null): Record<string, unknown> {
+	if (!s) return {};
+	try {
+		return JSON.parse(s);
+	} catch {
+		return {};
+	}
+}
+
+/**
+ * Builders for the three in-scope kinds — keeps specs from re-asserting
+ * the wire shape. Mirrors `internal/approval/action_queue.go:36-58` and
+ * the openapi spec's `args` schema descriptions.
+ */
+export const fixture = {
+	action: (overrides?: Partial<PendingActionApproval>): PendingActionApproval => ({
+		id: 'act-action-1',
+		kind: 'action',
+		action_name: 'send-email',
+		connector_fqn: 'github://aileron/aileron-connector-google',
+		args: { to: 'alice@example.com', subject: 'hi' },
+		session_id: 'session-42',
+		requested_at: '2026-05-04T12:00:00Z',
+		...overrides
+	}),
+	commsSend: (overrides?: Partial<PendingActionApproval>): PendingActionApproval => ({
+		id: 'act-comms-send-1',
+		kind: 'comms_send',
+		action_name: 'send_message',
+		args: {
+			service: 'slack',
+			channel: '#general',
+			body: 'Deploying main to prod'
+		},
+		session_id: 'session-42',
+		requested_at: '2026-05-04T12:01:00Z',
+		...overrides
+	}),
+	httpRequest: (overrides?: Partial<PendingActionApproval>): PendingActionApproval => ({
+		id: 'act-http-1',
+		kind: 'http_request',
+		action_name: 'http_request',
+		args: {
+			method: 'POST',
+			url: 'https://api.example.com/widgets',
+			body: '{"name":"new"}',
+			secret_name: 'example_api_key'
+		},
+		session_id: 'session-42',
+		requested_at: '2026-05-04T12:02:00Z',
+		...overrides
+	}),
+	resolved: (id: string, approved: boolean, reason = ''): ResolvedActionApproval => ({
+		id,
+		approved,
+		reason,
+		decided_at: '2026-05-04T12:05:00Z'
+	})
+};

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -10,7 +10,10 @@
     "preview": "vite preview",
     "check": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json",
     "check:watch": "svelte-kit sync && svelte-check --tsconfig ./tsconfig.json --watch",
-    "test": "vitest run"
+    "test": "vitest run",
+    "test:e2e": "playwright test",
+    "test:e2e:integration": "playwright test --config=playwright.integration.config.ts",
+    "test:e2e:install": "playwright install --with-deps chromium"
   },
   "dependencies": {
     "@sveltejs/adapter-static": "^3.0.0",
@@ -26,6 +29,7 @@
   },
   "devDependencies": {
     "@lucide/svelte": "^1.7.0",
+    "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.2",
     "@types/node": "^22.0.0",
     "@testing-library/jest-dom": "^6.9.1",

--- a/webapp/playwright.config.ts
+++ b/webapp/playwright.config.ts
@@ -1,0 +1,31 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Mocked-API E2E config. The webServer runs `pnpm preview` against the
+// already-built static output in `build/`; every `/v1/*` request the
+// page makes is intercepted by `page.route()` inside the specs. Pair
+// with `playwright.integration.config.ts` for the real-daemon tier.
+//
+// Run `task build:webapp` (or `pnpm build` inside this directory) before
+// invoking Playwright — `pnpm preview` will 404 without a fresh build.
+export default defineConfig({
+	testDir: 'e2e',
+	fullyParallel: true,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: process.env.CI ? 1 : undefined,
+	reporter: process.env.CI
+		? [['github'], ['junit', { outputFile: 'test-results/junit-playwright.xml' }]]
+		: 'html',
+	use: {
+		baseURL: 'http://localhost:4173',
+		trace: 'on-first-retry'
+	},
+	projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }],
+	webServer: {
+		command: 'pnpm preview --port 4173 --strictPort',
+		port: 4173,
+		reuseExistingServer: !process.env.CI,
+		stdout: 'pipe',
+		stderr: 'pipe'
+	}
+});

--- a/webapp/playwright.integration.config.ts
+++ b/webapp/playwright.integration.config.ts
@@ -1,0 +1,33 @@
+import { defineConfig, devices } from '@playwright/test';
+
+// Real-daemon integration config. The daemon is expected to be running
+// already, started with `--dev-seed-approvals=test/fixtures/action-approvals/basic.json`
+// and its bound URL exposed via the `AILERON_WEBAPP_URL` env var. The
+// repo's `task test:webapp:e2e:integration` Taskfile target wires
+// everything up; see `webapp/scripts/run-integration-e2e.sh` for the
+// startup/teardown sequence.
+//
+// Tests run sequentially with one worker because the daemon's queue is
+// shared mutable state — each test approves or denies from a common
+// initial seed.
+export default defineConfig({
+	testDir: 'e2e-integration',
+	fullyParallel: false,
+	forbidOnly: !!process.env.CI,
+	retries: process.env.CI ? 2 : 0,
+	workers: 1,
+	reporter: process.env.CI
+		? [
+				['github'],
+				[
+					'junit',
+					{ outputFile: 'test-results/junit-playwright-integration.xml' }
+				]
+			]
+		: 'html',
+	use: {
+		baseURL: process.env.AILERON_WEBAPP_URL,
+		trace: 'on-first-retry'
+	},
+	projects: [{ name: 'chromium', use: { ...devices['Desktop Chrome'] } }]
+});

--- a/webapp/pnpm-lock.yaml
+++ b/webapp/pnpm-lock.yaml
@@ -42,6 +42,9 @@ importers:
       '@lucide/svelte':
         specifier: ^1.7.0
         version: 1.14.0(svelte@5.55.5)
+      '@playwright/test':
+        specifier: ^1.59.1
+        version: 1.59.1
       '@tailwindcss/vite':
         specifier: ^4.2.2
         version: 4.3.0(vite@6.4.2(@types/node@22.19.18)(jiti@2.7.0)(lightningcss@1.32.0))
@@ -362,6 +365,11 @@ packages:
     resolution: {integrity: sha512-MVuP5VRCBQa2OaIpaRbuEV4k5OV2dy9MyxA6Tf4Sz/IN0v3zzUU72ObHc9r2Zn/wSMXDg6lLrHrczqI7w7gCzQ==}
     peerDependencies:
       svelte: ^5
+
+  '@playwright/test@1.59.1':
+    resolution: {integrity: sha512-PG6q63nQg5c9rIi4/Z5lR5IVF7yU5MqmKaPOe0HSc0O2cX1fPi96sUQu5j7eo4gKCkB2AnNGoWt7y4/Xx3Kcqg==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   '@polka/url@1.0.0-next.29':
     resolution: {integrity: sha512-wwQAWhWSuHaag8c4q/KN/vCoeOJYshAIvMQwD4GpSb3OiZklFfvAgmj0VCBBImRpuF/aFgIRzllXlVX93Jevww==}
@@ -888,6 +896,11 @@ packages:
       picomatch:
         optional: true
 
+  fsevents@2.3.2:
+    resolution: {integrity: sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==}
+    engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
+    os: [darwin]
+
   fsevents@2.3.3:
     resolution: {integrity: sha512-5xoDfX+fL7faATnagmWPpbFtwh/R77WmMMqqHGS65C3vvB0YHrgF+B1YmZ3441tMj5n63k0212XNoJwzlhffQw==}
     engines: {node: ^8.16.0 || ^10.6.0 || >=11.0.0}
@@ -1088,6 +1101,16 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  playwright-core@1.59.1:
+    resolution: {integrity: sha512-HBV/RJg81z5BiiZ9yPzIiClYV/QMsDCKUyogwH9p3MCP6IYjUFu/MActgYAvK0oWyV9NlwM3GLBjADyWgydVyg==}
+    engines: {node: '>=18'}
+    hasBin: true
+
+  playwright@1.59.1:
+    resolution: {integrity: sha512-C8oWjPR3F81yljW9o5OxcWzfh6avkVwDD2VYdwIGqTkl+OGFISgypqzfu7dOe4QNLL2aqcWBmI3PMtLIK233lw==}
+    engines: {node: '>=18'}
+    hasBin: true
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
@@ -1583,6 +1606,10 @@ snapshots:
     dependencies:
       svelte: 5.55.5
 
+  '@playwright/test@1.59.1':
+    dependencies:
+      playwright: 1.59.1
+
   '@polka/url@1.0.0-next.29': {}
 
   '@rollup/rollup-android-arm-eabi@4.60.3':
@@ -2034,6 +2061,9 @@ snapshots:
     optionalDependencies:
       picomatch: 4.0.4
 
+  fsevents@2.3.2:
+    optional: true
+
   fsevents@2.3.3:
     optional: true
 
@@ -2198,6 +2228,14 @@ snapshots:
   picocolors@1.1.1: {}
 
   picomatch@4.0.4: {}
+
+  playwright-core@1.59.1: {}
+
+  playwright@1.59.1:
+    dependencies:
+      playwright-core: 1.59.1
+    optionalDependencies:
+      fsevents: 2.3.2
 
   postcss@8.5.14:
     dependencies:

--- a/webapp/scripts/run-integration-e2e.sh
+++ b/webapp/scripts/run-integration-e2e.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+#
+# Orchestrates the tier-2 (real-daemon) Playwright integration suite.
+#
+# - Builds the daemon (or assumes a fresh `build/server` from task deps).
+# - Creates an isolated state dir + vault file under a temporary HOME.
+# - Starts the daemon with the basic.json seed fixture on an ephemeral
+#   loopback port.
+# - Waits for the daemon to publish its URL via daemon.json.
+# - Runs Playwright with AILERON_WEBAPP_URL pointed at the daemon.
+# - Tears the daemon down on any exit path (success, failure, signal).
+#
+# Run via `task test:webapp:e2e:integration` from the repo root.
+
+set -euo pipefail
+
+# Resolve repo root from this script's location, so the target works
+# regardless of where Task chose to run it.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
+
+SERVER_BIN="${REPO_ROOT}/build/server"
+AILERON_BIN="${REPO_ROOT}/build/aileron"
+SEED_FILE="${REPO_ROOT}/test/fixtures/action-approvals/basic.json"
+WEBAPP_DIR="${REPO_ROOT}/webapp"
+
+if [[ ! -x "${SERVER_BIN}" ]]; then
+  echo "error: ${SERVER_BIN} not found — run 'task build:server' first" >&2
+  exit 1
+fi
+if [[ ! -x "${AILERON_BIN}" ]]; then
+  echo "error: ${AILERON_BIN} not found — run 'task build:cli' first" >&2
+  exit 1
+fi
+if [[ ! -f "${SEED_FILE}" ]]; then
+  echo "error: seed fixture missing at ${SEED_FILE}" >&2
+  exit 1
+fi
+
+TMP_HOME="$(mktemp -d -t aileron-e2e-XXXXXX)"
+mkdir -p "${TMP_HOME}/.aileron"
+
+cleanup() {
+  if [[ -n "${DAEMON_PID:-}" ]] && kill -0 "${DAEMON_PID}" 2>/dev/null; then
+    kill "${DAEMON_PID}" 2>/dev/null || true
+    # Give the daemon up to 5s to shut down cleanly.
+    for _ in $(seq 1 25); do
+      if ! kill -0 "${DAEMON_PID}" 2>/dev/null; then
+        break
+      fi
+      sleep 0.2
+    done
+    kill -9 "${DAEMON_PID}" 2>/dev/null || true
+  fi
+  rm -rf "${TMP_HOME}"
+}
+trap cleanup EXIT INT TERM
+
+# Initialize a vault under TMP_HOME so the daemon can start. The
+# passphrase doesn't matter — none of the approvals endpoints need to
+# read credentials, so the daemon stays vault-locked for the duration
+# of the run.
+HOME="${TMP_HOME}" AILERON_VAULT_PASSPHRASE=test-passphrase \
+  "${AILERON_BIN}" vault init >/dev/null
+
+# Start the daemon. --bind 127.0.0.1:0 picks an ephemeral port; the
+# daemon writes the chosen URL to daemon.json which we read below.
+HOME="${TMP_HOME}" "${SERVER_BIN}" \
+  --bind 127.0.0.1:0 \
+  --dev-seed-approvals "${SEED_FILE}" \
+  >"${TMP_HOME}/server.log" 2>&1 &
+DAEMON_PID=$!
+
+# Poll daemon.json for up to 10s waiting for the URL to appear.
+DAEMON_URL=""
+for _ in $(seq 1 50); do
+  if [[ -f "${TMP_HOME}/.aileron/daemon.json" ]]; then
+    DAEMON_URL="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["url"])' "${TMP_HOME}/.aileron/daemon.json" 2>/dev/null || true)"
+    if [[ -n "${DAEMON_URL}" ]]; then
+      break
+    fi
+  fi
+  sleep 0.2
+done
+if [[ -z "${DAEMON_URL}" ]]; then
+  echo "error: daemon did not publish daemon.json within 10s" >&2
+  echo "--- daemon log ---" >&2
+  cat "${TMP_HOME}/server.log" >&2 || true
+  exit 1
+fi
+
+# Confirm reachability before handing off to Playwright.
+if ! curl -fsS "${DAEMON_URL}/v1/action-approvals" >/dev/null; then
+  echo "error: daemon at ${DAEMON_URL} not reachable" >&2
+  echo "--- daemon log ---" >&2
+  cat "${TMP_HOME}/server.log" >&2 || true
+  exit 1
+fi
+
+# Unlock the vault. Otherwise the webapp's layout opens the passphrase
+# modal on every page load, and the modal's full-screen overlay
+# intercepts clicks on the approval cards. The approvals endpoints
+# themselves don't read credentials, so this is purely a UI-layer
+# concern — but Playwright sees real DOM, so we have to clear it.
+if ! curl -fsS -X POST -H 'Content-Type: application/json' \
+  -d '{"passphrase":"test-passphrase"}' \
+  "${DAEMON_URL}/v1/vault/unlock" >/dev/null; then
+  echo "error: vault unlock failed" >&2
+  echo "--- daemon log ---" >&2
+  cat "${TMP_HOME}/server.log" >&2 || true
+  exit 1
+fi
+
+echo "daemon listening at ${DAEMON_URL} (pid ${DAEMON_PID})"
+
+cd "${WEBAPP_DIR}"
+AILERON_WEBAPP_URL="${DAEMON_URL}" \
+  pnpm exec playwright test --config=playwright.integration.config.ts "$@"


### PR DESCRIPTION
## Summary

- Two tiers of Playwright coverage for the `/approvals` page: mocked-API (`webapp/e2e/`) and real-daemon integration (`webapp/e2e-integration/`).
- New developer-only daemon flag `--dev-seed-approvals=<file.json>` registers seed approvals at startup (loopback bind only). Used by the integration tier.
- Two production bug fixes uncovered while writing the tests (see Bug fixes below).
- New CI jobs `test-webapp` (mocked) and `test-webapp-integration` (real daemon) paralleling `test-ui` / `integration-e2e`.

## Coverage

| Kind | Listing | Approve | Deny |
|---|---|---|---|
| `action` | ✓ | ✓ | ✓ |
| `comms_send` | ✓ | ✓ | ✓ |
| `http_request` | ✓ | ✓ | ✓ |

`comms_draft` (editable body branch) is deferred — re-evaluate after this lands.

## Bug fixes

Discovered while writing the tests; both have regression tests in this PR:

1. **`webapp/src/lib/api.ts`** — `apiFetch` could not handle a 200 response with an empty body. The daemon's action-approval decide endpoint returns 200 with no payload; `res.json()` rejected on empty body, the page's error branch fired, and the entire cards section disappeared after every approve/deny click. Now treats empty bodies as `null` (same as 204).
2. **`internal/observability/middleware.go`** — `statusRecorder` did not proxy `Flush()`. Companion to #653's `loggingMiddleware` Flusher fix: observability wraps outside logging, so its recorder also has to preserve `http.Flusher` or SSE handlers further down the chain silently buffer until the connection closes.

## Approach for the SSE mock (tier 1)

Playwright's `route.fulfill()` buffers the body, so streaming SSE through `page.route()` doesn't work. Instead `webapp/e2e/fixtures/approvals.ts` overrides `window.EventSource` via `addInitScript` with a test-only class that the spec pushes frames into through `page.evaluate()`. The decide endpoint is mocked through `page.route()` as a plain HTTP call.

## Approach for the integration tier

`webapp/scripts/run-integration-e2e.sh` orchestrates the lifecycle:

1. Builds and isolates a temporary HOME with a fresh vault.
2. Starts the daemon with `--bind 127.0.0.1:0 --dev-seed-approvals=test/fixtures/action-approvals/basic.json`.
3. Reads the bound URL from `daemon.json`.
4. Unlocks the vault (otherwise the layout's passphrase modal blocks clicks).
5. Runs Playwright with `AILERON_WEBAPP_URL` pointed at the daemon.
6. Tears the daemon down on any exit.

## Test plan

- [x] `task test:webapp` — 31 Vitest pass
- [x] `task test:webapp:e2e` — 14 Playwright (mocked) pass
- [x] `task test:webapp:e2e:integration` — 4 Playwright (real daemon) pass
- [x] `cd internal && go test ./...` — all green
- [x] Falsification check: removed deny-reason logic from `+page.svelte` and confirmed `approvals-deny.spec.ts` fails (then reverted)
- [ ] CI `test-webapp` job green
- [ ] CI `test-webapp-integration` job green

🤖 Generated with [Claude Code](https://claude.com/claude-code)