### PR TITLE
fix(cli): surface daemon error body on suite preview failures

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -2752,6 +2752,32 @@ func trustAuthoritiesForRefs(refs []cstore.Ref, autoYes bool, trust *trustState,
 	return 0
 }
 
+// daemonErrText extracts a human-readable summary from a daemon error
+// response body. The daemon returns errors as the api.Error envelope
+// (`{"error":{"code":"...","message":"..."}}`); when that parses, we
+// render `code: message` so the operator sees the underlying cause
+// (e.g. `fetch_failed: 404 (tag or release not found)`) instead of a
+// bare HTTP status. Falls back to the raw body for anything that
+// doesn't match the envelope, and to `<no body>` for empty responses.
+func daemonErrText(raw []byte) string {
+	if len(raw) == 0 {
+		return "<no body>"
+	}
+	var env struct {
+		Error struct {
+			Code    string `json:"code"`
+			Message string `json:"message"`
+		} `json:"error"`
+	}
+	if err := json.Unmarshal(raw, &env); err == nil && env.Error.Code != "" {
+		if env.Error.Message != "" {
+			return env.Error.Code + ": " + env.Error.Message
+		}
+		return env.Error.Code
+	}
+	return string(raw)
+}
+
 // previewSuiteRefs calls /actions/preview for every ref in declaration
 // order. Failures are captured per-entry rather than aborting the
 // loop; the consent screen surfaces them with their error so the
@@ -2769,7 +2795,7 @@ func previewSuiteRefs(refs []cstore.Ref, _ io.Writer) []suiteRefPreview {
 		}
 		if status != http.StatusOK {
 			out = append(out, suiteRefPreview{ref: ref,
-				err: fmt.Errorf("daemon returned %d", status)})
+				err: fmt.Errorf("daemon returned %d: %s", status, daemonErrText(raw))})
 			continue
 		}
 		var preview actionPreviewWire

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -4989,3 +4989,85 @@ func TestFetchAuditList_BuildsURL(t *testing.T) {
 		}
 	}
 }
+
+// TestDaemonErrText covers the parser for the daemon's api.Error
+// envelope. Contract:
+//   - Empty body → "<no body>".
+//   - Envelope with code + message → "code: message" so the operator
+//     sees the underlying classification (e.g. fetch_failed) and the
+//     human detail rather than a bare HTTP status.
+//   - Envelope with code only → "code" alone.
+//   - Anything that doesn't parse as the envelope (legacy daemons,
+//     proxies, raw 500s) → the raw body verbatim so no detail is lost.
+func TestDaemonErrText(t *testing.T) {
+	tests := []struct {
+		name string
+		raw  string
+		want string
+	}{
+		{"empty", "", "<no body>"},
+		{
+			"envelope_with_code_and_message",
+			`{"error":{"code":"fetch_failed","message":"404 (tag or release not found)"}}`,
+			"fetch_failed: 404 (tag or release not found)",
+		},
+		{
+			"envelope_with_code_only",
+			`{"error":{"code":"invalid_fqn"}}`,
+			"invalid_fqn",
+		},
+		{
+			"non_envelope_passthrough",
+			`<html>504 Gateway Timeout</html>`,
+			`<html>504 Gateway Timeout</html>`,
+		},
+		{
+			"envelope_missing_code_falls_through",
+			`{"error":{"message":"oops"}}`,
+			`{"error":{"message":"oops"}}`,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := daemonErrText([]byte(tc.raw)); got != tc.want {
+				t.Errorf("daemonErrText(%q) = %q, want %q", tc.raw, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestPreviewSuiteRefs_NonOKSurfacesDaemonError is the regression test
+// for the friction documented in the daemon-error-passthrough fix: a
+// 422 from /actions/preview used to surface as "daemon returned 422"
+// with no reason, hiding the actual classification (e.g. fetch_failed)
+// from the operator. After the fix, the error message must include
+// the daemon's code + message so the suite consent screen tells the
+// user what actually went wrong.
+func TestPreviewSuiteRefs_NonOKSurfacesDaemonError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/actions/preview" {
+			t.Errorf("path = %q", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusUnprocessableEntity)
+		_, _ = io.WriteString(w, `{"error":{"code":"fetch_failed","message":"404 (tag or release not found)"}}`)
+	})
+
+	ref, err := cstore.ParseRef("github://ALRubinger/aileron-connector-github/actions/list-recent-prs@9.9.9")
+	if err != nil {
+		t.Fatalf("ParseRef: %v", err)
+	}
+	previews := previewSuiteRefs([]cstore.Ref{ref}, io.Discard)
+	if len(previews) != 1 {
+		t.Fatalf("len(previews) = %d, want 1", len(previews))
+	}
+	if previews[0].err == nil {
+		t.Fatalf("previews[0].err = nil, want non-nil")
+	}
+	got := previews[0].err.Error()
+	for _, want := range []string{"422", "fetch_failed", "404 (tag or release not found)"} {
+		if !strings.Contains(got, want) {
+			t.Errorf("err = %q, want substring %q", got, want)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

- `previewSuiteRefs` swallowed the daemon's `api.Error` envelope on non-200 responses from `/actions/preview`, so operators saw a bare `daemon returned 422` with no reason. A typo in a tag (which the daemon classifies as `fetch_failed: 404 (tag or release not found)`) looked like a daemon bug.
- Added a small `daemonErrText` helper in `cmd/aileron/main.go` that parses the standard `{"error":{"code","message"}}` envelope to `code: message`, falling back to the raw body for anything that doesn't match. Wired it through the non-OK branch of `previewSuiteRefs`.
- Added unit tests covering each envelope shape (empty body, code+message, code-only, non-envelope passthrough, missing-code fallback) and a regression test that drives `previewSuiteRefs` through an `httptest` server returning a real 422 envelope.

## Test plan

- [x] `go test ./cmd/aileron/ -run 'TestDaemonErrText|TestPreviewSuiteRefs_NonOKSurfacesDaemonError' -v` — passes after the fix.
- [x] Sanity-checked the regression test fails before the fix (reverted the production change locally, ran the test, confirmed `err = "daemon returned 422"` lacking `fetch_failed`).
- [x] `task test` — full repo suite green.
- [x] `go test ./cmd/aileron/ -cover` reports 85.3% statement coverage for the CLI package.

🤖 Generated with [Claude Code](https://claude.com/claude-code)