### PR TITLE
feat(webapp): honor ?focus= on the approvals page

### DIFF
--- a/webapp/src/routes/approvals/+page.svelte
+++ b/webapp/src/routes/approvals/+page.svelte
@@ -39,6 +39,31 @@
 	let loading = $state(true);
 	let error = $state('');
 
+	// `?focus=<approval-id>` deep-link target, set by `aileron open
+	// approval <id>` (cmd/aileron/open.go) and by the terminal notifier.
+	// When the matching card renders, it's scrolled into view and gets a
+	// distinct ring so the operator can pick it out from sibling cards.
+	let focusedId = $state('');
+	let scrolledToFocused = false;
+
+	let focusedMissing = $derived(
+		!loading &&
+			!error &&
+			focusedId !== '' &&
+			!actionApprovals.some((a) => a.id === focusedId)
+	);
+
+	$effect(() => {
+		if (!focusedId || scrolledToFocused) return;
+		if (!actionApprovals.some((a) => a.id === focusedId)) return;
+		const el = document.querySelector(
+			`[data-approval-id="${CSS.escape(focusedId)}"]`
+		);
+		if (!el) return;
+		el.scrollIntoView({ behavior: 'smooth', block: 'center' });
+		scrolledToFocused = true;
+	});
+
 	// Action-level approvals stream live over SSE — no polling. The
 	// stream emits a `snapshot` on connect, then `pending` / `resolved`
 	// events as the queue mutates. The browser's EventSource handles
@@ -121,6 +146,9 @@
 	}
 
 	onMount(() => {
+		const params = new URLSearchParams(window.location.search);
+		focusedId = params.get('focus') ?? '';
+
 		const closeStream = watchActionApprovals({
 			onSnapshot: (items) => {
 				actionApprovals = items;
@@ -161,6 +189,14 @@
 {:else if error}
 	<p class="text-destructive">{error}</p>
 {:else if actionApprovals.length === 0}
+	{#if focusedMissing}
+		<p
+			class="mb-3 rounded border border-border bg-muted/40 p-2 text-sm text-muted-foreground"
+			data-testid="focused-missing-banner"
+		>
+			Approval <code class="rounded bg-muted px-1">{focusedId}</code> is no longer pending.
+		</p>
+	{/if}
 	<p class="text-muted-foreground">
 		No pending approvals. The agent's blocked tool calls (if any) will appear here.
 	</p>
@@ -169,13 +205,24 @@
 		<p class="mb-3 text-sm text-muted-foreground">
 			The agent is blocked on these tool calls until you approve or deny.
 		</p>
+		{#if focusedMissing}
+			<p
+				class="mb-3 rounded border border-border bg-muted/40 p-2 text-sm text-muted-foreground"
+				data-testid="focused-missing-banner"
+			>
+				Approval <code class="rounded bg-muted px-1">{focusedId}</code> is no longer pending.
+			</p>
+		{/if}
 		<div class="flex flex-col gap-3">
 			{#each actionApprovals as approval (approval.id)}
 				{@const kind = entryKind(approval)}
+				{@const isFocused = approval.id === focusedId}
 				<Card.Root
 					data-testid="action-approval-card"
 					data-approval-id={approval.id}
 					data-approval-kind={kind}
+					data-focused={isFocused ? 'true' : 'false'}
+					class={isFocused ? 'ring-2 ring-primary' : ''}
 				>
 					<Card.Header>
 						<div class="flex items-center justify-between">

--- a/webapp/src/routes/approvals/page.test.ts
+++ b/webapp/src/routes/approvals/page.test.ts
@@ -1,4 +1,4 @@
-import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { describe, it, expect, vi, beforeAll, beforeEach } from 'vitest';
 import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
 
 vi.mock('$lib/api', () => ({
@@ -38,6 +38,10 @@ beforeEach(() => {
 	captured = null;
 	vi.mocked(decideActionApproval).mockResolvedValue(null);
 	setupWatcher();
+	// Clear any ?focus= left over from a prior test — the page reads
+	// window.location.search on mount, so a leak would silently break
+	// unrelated cases.
+	window.history.replaceState({}, '', '/approvals');
 });
 
 describe('Approvals page — empty state', () => {
@@ -391,6 +395,149 @@ describe('Approvals page — comms-MCP kinds (#428)', () => {
 				screen.getByText(/No matching api_key binding/)
 			).toBeInTheDocument();
 		});
+	});
+});
+
+describe('Approvals page — ?focus deep-link highlight', () => {
+	beforeAll(() => {
+		// jsdom doesn't implement scrollIntoView; the production code
+		// calls it whenever a focused card lands in the DOM, so install a
+		// stub at the prototype level so neither the spy nor the effect
+		// itself blow up.
+		if (!('scrollIntoView' in Element.prototype)) {
+			(Element.prototype as unknown as { scrollIntoView: () => void }).scrollIntoView =
+				() => {};
+		}
+	});
+
+	it('highlights and scrolls to the focused approval card', async () => {
+		const scrollSpy = vi
+			.spyOn(Element.prototype, 'scrollIntoView')
+			.mockImplementation(() => {});
+		window.history.replaceState({}, '', '/approvals?focus=act-focus-1');
+		setupWatcher([
+			{
+				id: 'act-other',
+				kind: 'action' as const,
+				action_name: 'noop',
+				requested_at: '2026-05-04T12:00:00Z'
+			},
+			{
+				id: 'act-focus-1',
+				kind: 'action' as const,
+				action_name: 'send-email',
+				requested_at: '2026-05-04T12:00:01Z'
+			}
+		]);
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByText('send-email')).toBeInTheDocument();
+		});
+
+		const cards = await screen.findAllByTestId('action-approval-card');
+		const focused = cards.find(
+			(c) => c.getAttribute('data-approval-id') === 'act-focus-1'
+		);
+		const other = cards.find(
+			(c) => c.getAttribute('data-approval-id') === 'act-other'
+		);
+		expect(focused).toBeDefined();
+		expect(other).toBeDefined();
+		expect(focused!.getAttribute('data-focused')).toBe('true');
+		expect(other!.getAttribute('data-focused')).toBe('false');
+		expect(focused!.className).toContain('ring-2');
+		expect(other!.className).not.toContain('ring-2 ring-primary');
+		await waitFor(() => {
+			expect(scrollSpy).toHaveBeenCalled();
+		});
+
+		scrollSpy.mockRestore();
+	});
+
+	it('shows a banner when the focused id is not in the pending list', async () => {
+		window.history.replaceState({}, '', '/approvals?focus=act-missing');
+		setupWatcher([
+			{
+				id: 'act-other',
+				kind: 'action' as const,
+				action_name: 'send-email',
+				requested_at: '2026-05-04T12:00:00Z'
+			}
+		]);
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('focused-missing-banner')).toBeInTheDocument();
+		});
+		expect(screen.getByTestId('focused-missing-banner').textContent).toContain(
+			'act-missing'
+		);
+	});
+
+	it('shows the missing banner alongside the empty-state hint when no approvals are pending', async () => {
+		window.history.replaceState({}, '', '/approvals?focus=act-gone');
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('focused-missing-banner')).toBeInTheDocument();
+		});
+		expect(
+			screen.getByText(/No pending approvals\. The agent's blocked tool calls/)
+		).toBeInTheDocument();
+	});
+
+	it('clears the missing banner once the focused approval arrives via SSE', async () => {
+		window.history.replaceState({}, '', '/approvals?focus=act-late');
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('focused-missing-banner')).toBeInTheDocument();
+		});
+
+		captured!.onPending({
+			id: 'act-late',
+			kind: 'action' as const,
+			action_name: 'send-email',
+			requested_at: '2026-05-04T12:00:05Z'
+		});
+
+		await waitFor(() => {
+			expect(
+				screen.queryByTestId('focused-missing-banner')
+			).not.toBeInTheDocument();
+		});
+		const card = (await screen.findAllByTestId('action-approval-card')).find(
+			(c) => c.getAttribute('data-approval-id') === 'act-late'
+		);
+		expect(card!.getAttribute('data-focused')).toBe('true');
+	});
+
+	it('does not highlight anything when no ?focus param is set', async () => {
+		setupWatcher([
+			{
+				id: 'act-1',
+				kind: 'action' as const,
+				action_name: 'send-email',
+				requested_at: '2026-05-04T12:00:00Z'
+			}
+		]);
+
+		render(Page);
+
+		await waitFor(() => {
+			expect(screen.getByText('send-email')).toBeInTheDocument();
+		});
+
+		const card = screen.getByTestId('action-approval-card');
+		expect(card.getAttribute('data-focused')).toBe('false');
+		expect(
+			screen.queryByTestId('focused-missing-banner')
+		).not.toBeInTheDocument();
 	});
 });
 


### PR DESCRIPTION
## Summary

`aileron open approval <id>` and the terminal notifier both link to `/approvals?focus=<id>`, but the page was ignoring the query parameter — with two or more pending approvals on screen, nothing was visually called out, so the operator had to eyeball which card the agent was actually blocked on.

This change wires up the parameter:

- Reads `focus` on mount.
- Adds a `ring-2 ring-primary` outline + `data-focused="true"` to the matching card.
- Scrolls the focused card into view once it lands in the DOM (works for both snapshot delivery and a late-arriving `pending` SSE event).
- Renders a `data-testid="focused-missing-banner"` callout when the id isn't in the current pending list (already resolved, or stale paste of an old `aileron open approval` command). The banner clears automatically if the matching `pending` event arrives.

## Test plan

- [x] `task test:webapp` — Vitest, 47 tests pass (5 new specs cover: focused card highlight + scroll, banner when missing, banner alongside empty-state, banner clears on late `pending`, no highlight without `?focus=`).
- [x] `pnpm check` — svelte-check clean (0 errors, 0 warnings).
- [x] `pnpm test:e2e` — Playwright mocked suite (18 specs) still passes, no regression in approve/deny/list/preview flows.
- [ ] Manual: run `aileron launch`, queue two pending approvals, then `aileron open approval <one-of-them>` — confirm the targeted card is ringed and scrolled to.