### PR TITLE
feat(webapp): apply design system to webapp UI (Stage 2 first pass)

### DIFF
--- a/webapp/src/lib/components/ui/card/card.svelte
+++ b/webapp/src/lib/components/ui/card/card.svelte
@@ -15,7 +15,7 @@
 	bind:this={ref}
 	data-slot="card"
 	data-size={size}
-	class={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col", className)}
+	class={cn("ring-foreground/10 bg-card text-card-foreground gap-4 overflow-hidden rounded-xl py-4 text-sm ring-1 shadow-low has-data-[slot=card-footer]:pb-0 has-[>img:first-child]:pt-0 data-[size=sm]:gap-3 data-[size=sm]:py-3 data-[size=sm]:has-data-[slot=card-footer]:pb-0 *:[img:first-child]:rounded-t-xl *:[img:last-child]:rounded-b-xl group/card flex flex-col", className)}
 	{...restProps}
 >
 	{@render children?.()}

--- a/webapp/src/routes/+layout.svelte
+++ b/webapp/src/routes/+layout.svelte
@@ -36,10 +36,15 @@
 	<title>Aileron</title>
 </svelte:head>
 
-<header class="border-b border-border bg-card">
+<header class="border-b border-border bg-card shadow-low">
 	<div class="mx-auto flex max-w-4xl items-center justify-between px-4 py-3">
-		<a href="/" class="text-sm font-semibold tracking-tight no-underline">
-			✈️ Aileron
+		<a
+			href="/"
+			class="text-foreground no-underline hover:text-foreground"
+		>
+			<span class="font-extrabold text-2xl tracking-tight">Aileron</span><span
+				class="font-normal text-2xl tracking-tight text-muted-foreground"
+			>ControlPlane</span>
 		</a>
 		<nav class="flex items-center gap-4 text-sm">
 			<span

--- a/webapp/src/routes/+page.svelte
+++ b/webapp/src/routes/+page.svelte
@@ -14,7 +14,7 @@
 </svelte:head>
 
 <div class="space-y-4">
-	<h1 class="text-2xl font-semibold tracking-tight">Aileron</h1>
+	<h1 class="mb-4 text-3xl font-extrabold tracking-tight">Aileron</h1>
 	<p class="text-muted-foreground">
 		The local webapp surfaced under <code>aileron launch</code>. Use it to review and decide on
 		action approvals the agent has paused on.

--- a/webapp/src/routes/actions/+page.svelte
+++ b/webapp/src/routes/actions/+page.svelte
@@ -64,7 +64,7 @@
 	<title>Actions — Aileron</title>
 </svelte:head>
 
-<h1 class="mb-4 text-xl font-semibold">Installed Actions</h1>
+<h1 class="mb-4 text-3xl font-extrabold tracking-tight">Installed Actions</h1>
 
 <p class="mb-3 text-sm text-muted-foreground">
 	Toggle which installed actions the agent's LLM can see. Disabling does

--- a/webapp/src/routes/approvals/+page.svelte
+++ b/webapp/src/routes/approvals/+page.svelte
@@ -185,7 +185,7 @@
 	<title>Approvals — Aileron</title>
 </svelte:head>
 
-<h1 class="mb-4 text-xl font-semibold">Approvals</h1>
+<h1 class="mb-4 text-3xl font-extrabold tracking-tight">Approvals</h1>
 
 <Tooltip.Provider>
 {#if loading}

--- a/webapp/src/routes/hub/+page.svelte
+++ b/webapp/src/routes/hub/+page.svelte
@@ -58,7 +58,7 @@
 	<title>Hub — Aileron</title>
 </svelte:head>
 
-<h1 class="mb-4 text-xl font-semibold">Connector Hub</h1>
+<h1 class="mb-4 text-3xl font-extrabold tracking-tight">Connector Hub</h1>
 <p class="mb-4 text-sm text-muted-foreground">
 	Community-published connectors. Browse, search by keyword, and install with
 	one click. The daemon writes publisher trust to your keyring per repo on


### PR DESCRIPTION
## Summary

First pass of Stage 2 (#692, part of #687). Extends the visual identity established in #689 into the webapp.

Tokens and Adobe Fonts were already wired in Stage 1 (`webapp/src/tokens.generated.css`, `webapp/src/app.html`). This PR adds the visual treatment that was missing on top of that foundation.

### Header (`+layout.svelte`)

- Aileron typeface treatment: "Aileron" in `font-extrabold` (Black, 800) + "ControlPlane" in `font-normal` (Regular, 400), both at `text-2xl tracking-tight`. Drops the ✈️ emoji.
- `shadow-low` on the header bar — 45° upper-left light direction matches docs.

### H1 standardization (all four routes)

`text-3xl font-extrabold tracking-tight` across `/`, `/actions`, `/approvals`, `/hub`. Previously the landing was `text-2xl font-semibold` and the others were `text-xl font-semibold`.

### Card primitive

Added `shadow-low` to the base class list of `lib/components/ui/card/card.svelte`, matching the same change made to docs' Card in #689.

## Deferred to follow-up commits within Stage 2

- **shadcn-svelte `style: nova` migration**: webapp's `components.json` lacks an explicit `style` field (defaults to `default`). Migrating requires updating the config and reinstalling each shadcn-svelte primitive (Card, Button, Badge, Dialog, Input, Select, Separator, Tooltip, Collapsible). That overwrites the `shadow-low` customization on Card and any other local edits, so it warrants its own commit + careful re-application of customizations.
- **`ink-bleed` on long-form webapp prose** where the surface warrants it (likely settings, approval-card explanations).
- **Webapp-specific pattern documentation** in `design/components.md` once those patterns settle.

## Test plan

- [ ] `task dev:webapp` renders the landing page with the new header treatment (Aileron Black + ControlPlane Regular at text-2xl, shadow-low on header)
- [ ] Page texture is visible and parallaxes (this was already wired in #689; verifies the foundation still works)
- [ ] All four routes' `<h1>` render at `text-3xl font-extrabold tracking-tight` — same visual weight across landing, /actions, /approvals, /hub
- [ ] Cards on the landing page show the 45° down-right drop shadow
- [ ] No regressions in `task test:webapp` or `task test:e2e:webapp`
- [ ] Side-by-side with docs: both surfaces feel like one product (same typeface, same header anchor pattern, same shadow direction)

Part of #692
Part of #687