### PR TITLE
feat(webapp): migrate shadcn-svelte primitives to nova style

### DIFF
--- a/webapp/components.json
+++ b/webapp/components.json
@@ -1,5 +1,6 @@
 {
 	"$schema": "https://shadcn-svelte.com/schema.json",
+	"style": "nova",
 	"tailwind": {
 		"css": "src/app.css",
 		"baseColor": "neutral"

--- a/webapp/package.json
+++ b/webapp/package.json
@@ -28,7 +28,8 @@
     "vite": "^6.0.0"
   },
   "devDependencies": {
-    "@lucide/svelte": "^1.7.0",
+    "@internationalized/date": "^3.12.1",
+    "@lucide/svelte": "^1.14.0",
     "@playwright/test": "^1.59.1",
     "@tailwindcss/vite": "^4.2.2",
     "@testing-library/jest-dom": "^6.9.1",

--- a/webapp/pnpm-lock.yaml
+++ b/webapp/pnpm-lock.yaml
@@ -39,8 +39,11 @@ importers:
         specifier: ^6.0.0
         version: 6.4.2(@types/node@24.12.4)(jiti@2.7.0)(lightningcss@1.32.0)
     devDependencies:
+      '@internationalized/date':
+        specifier: ^3.12.1
+        version: 3.12.1
       '@lucide/svelte':
-        specifier: ^1.7.0
+        specifier: ^1.14.0
         version: 1.14.0(svelte@5.55.5)
       '@playwright/test':
         specifier: ^1.59.1

--- a/webapp/src/lib/components/ui/dialog/dialog-close.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog-close.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		type = "button",
+		...restProps
+	}: DialogPrimitive.CloseProps = $props();
+</script>
+
+<DialogPrimitive.Close bind:ref data-slot="dialog-close" {type} {...restProps} />

--- a/webapp/src/lib/components/ui/dialog/dialog-content.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog-content.svelte
@@ -1,30 +1,48 @@
 <script lang="ts">
 	import { Dialog as DialogPrimitive } from "bits-ui";
-	import { cn } from "$lib/utils.js";
+	import DialogPortal from "./dialog-portal.svelte";
+	import type { Snippet } from "svelte";
+	import * as Dialog from "./index.js";
+	import { cn, type WithoutChildrenOrChild } from "$lib/utils.js";
+	import type { ComponentProps } from "svelte";
+	import { Button } from "$lib/components/ui/button/index.js";
+	import XIcon from '@lucide/svelte/icons/x';
 
 	let {
 		ref = $bindable(null),
 		class: className,
+		portalProps,
 		children,
+		showCloseButton = true,
 		...restProps
-	}: DialogPrimitive.ContentProps & { children?: import("svelte").Snippet } = $props();
+	}: WithoutChildrenOrChild<DialogPrimitive.ContentProps> & {
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof DialogPortal>>;
+		children: Snippet;
+		showCloseButton?: boolean;
+	} = $props();
 </script>
 
-<DialogPrimitive.Portal>
-	<DialogPrimitive.Overlay
-		class="fixed inset-0 z-50 bg-black/50 data-[state=open]:animate-in data-[state=closed]:animate-out data-[state=closed]:fade-out-0 data-[state=open]:fade-in-0"
-	/>
+<DialogPortal {...portalProps}>
+	<Dialog.Overlay />
 	<DialogPrimitive.Content
 		bind:ref
 		data-slot="dialog-content"
 		class={cn(
-			"fixed left-[50%] top-[50%] z-50 w-full max-w-lg translate-x-[-50%] translate-y-[-50%] rounded-lg border border-border bg-background p-6 shadow-lg",
+			"bg-popover text-popover-foreground data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 data-closed:zoom-out-95 data-open:zoom-in-95 ring-foreground/10 grid max-w-[calc(100%-2rem)] gap-4 rounded-xl p-4 text-sm ring-1 duration-100 sm:max-w-sm fixed top-1/2 left-1/2 z-50 w-full -translate-x-1/2 -translate-y-1/2 outline-none",
 			className
 		)}
 		{...restProps}
 	>
-		{#if children}
-			{@render children()}
+		{@render children?.()}
+		{#if showCloseButton}
+			<DialogPrimitive.Close data-slot="dialog-close">
+				{#snippet child({ props })}
+					<Button variant="ghost" class="absolute top-2 right-2" size="icon-sm" {...props}>
+						<XIcon  />
+						<span class="sr-only">Close</span>
+					</Button>
+				{/snippet}
+			</DialogPrimitive.Close>
 		{/if}
 	</DialogPrimitive.Content>
-</DialogPrimitive.Portal>
+</DialogPortal>

--- a/webapp/src/lib/components/ui/dialog/dialog-description.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog-description.svelte
@@ -12,6 +12,6 @@
 <DialogPrimitive.Description
 	bind:ref
 	data-slot="dialog-description"
-	class={cn("text-sm text-muted-foreground", className)}
+	class={cn("text-muted-foreground *:[a]:hover:text-foreground text-sm *:[a]:underline *:[a]:underline-offset-3", className)}
 	{...restProps}
 />

--- a/webapp/src/lib/components/ui/dialog/dialog-footer.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog-footer.svelte
@@ -1,20 +1,32 @@
 <script lang="ts">
-	import { cn } from "$lib/utils.js";
+	import { cn, type WithElementRef } from "$lib/utils.js";
 	import type { HTMLAttributes } from "svelte/elements";
+	import { Dialog as DialogPrimitive } from "bits-ui";
+	import { Button } from "$lib/components/ui/button/index.js";
 
 	let {
+		ref = $bindable(null),
 		class: className,
 		children,
+		showCloseButton = false,
 		...restProps
-	}: HTMLAttributes<HTMLDivElement> & { children?: import("svelte").Snippet } = $props();
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> & {
+		showCloseButton?: boolean;
+	} = $props();
 </script>
 
 <div
+	bind:this={ref}
 	data-slot="dialog-footer"
-	class={cn("flex flex-col-reverse sm:flex-row sm:justify-end gap-2", className)}
+	class={cn("bg-muted/50 -mx-4 -mb-4 rounded-b-xl border-t p-4 flex flex-col-reverse gap-2 sm:flex-row sm:justify-end", className)}
 	{...restProps}
 >
-	{#if children}
-		{@render children()}
+	{@render children?.()}
+	{#if showCloseButton}
+		<DialogPrimitive.Close>
+			{#snippet child({ props })}
+				<Button variant="outline" {...props}>Close</Button>
+			{/snippet}
+		</DialogPrimitive.Close>
 	{/if}
 </div>

--- a/webapp/src/lib/components/ui/dialog/dialog-header.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog-header.svelte
@@ -1,20 +1,20 @@
 <script lang="ts">
-	import { cn } from "$lib/utils.js";
 	import type { HTMLAttributes } from "svelte/elements";
+	import { cn, type WithElementRef } from "$lib/utils.js";
 
 	let {
+		ref = $bindable(null),
 		class: className,
 		children,
 		...restProps
-	}: HTMLAttributes<HTMLDivElement> & { children?: import("svelte").Snippet } = $props();
+	}: WithElementRef<HTMLAttributes<HTMLDivElement>> = $props();
 </script>
 
 <div
+	bind:this={ref}
 	data-slot="dialog-header"
-	class={cn("flex flex-col gap-1.5 text-center sm:text-left", className)}
+	class={cn("gap-2 flex flex-col", className)}
 	{...restProps}
 >
-	{#if children}
-		{@render children()}
-	{/if}
+	{@render children?.()}
 </div>

--- a/webapp/src/lib/components/ui/dialog/dialog-overlay.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog-overlay.svelte
@@ -1,0 +1,17 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+
+	let {
+		ref = $bindable(null),
+		class: className,
+		...restProps
+	}: DialogPrimitive.OverlayProps = $props();
+</script>
+
+<DialogPrimitive.Overlay
+	bind:ref
+	data-slot="dialog-overlay"
+	class={cn("data-open:animate-in data-closed:animate-out data-closed:fade-out-0 data-open:fade-in-0 bg-black/10 duration-100 supports-backdrop-filter:backdrop-blur-xs fixed inset-0 isolate z-50", className)}
+	{...restProps}
+/>

--- a/webapp/src/lib/components/ui/dialog/dialog-portal.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from "bits-ui";
+
+	let { ...restProps }: DialogPrimitive.PortalProps = $props();
+</script>
+
+<DialogPrimitive.Portal {...restProps} />

--- a/webapp/src/lib/components/ui/dialog/dialog-title.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog-title.svelte
@@ -12,6 +12,6 @@
 <DialogPrimitive.Title
 	bind:ref
 	data-slot="dialog-title"
-	class={cn("text-lg font-semibold leading-none tracking-tight", className)}
+	class={cn("text-base leading-none font-medium", className)}
 	{...restProps}
 />

--- a/webapp/src/lib/components/ui/dialog/dialog-trigger.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog-trigger.svelte
@@ -1,0 +1,11 @@
+<script lang="ts">
+	import { Dialog as DialogPrimitive } from "bits-ui";
+
+	let {
+		ref = $bindable(null),
+		type = "button",
+		...restProps
+	}: DialogPrimitive.TriggerProps = $props();
+</script>
+
+<DialogPrimitive.Trigger bind:ref data-slot="dialog-trigger" {type} {...restProps} />

--- a/webapp/src/lib/components/ui/dialog/dialog.svelte
+++ b/webapp/src/lib/components/ui/dialog/dialog.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
 	import { Dialog as DialogPrimitive } from "bits-ui";
 
-	let {
-		open = $bindable(false),
-		...restProps
-	}: DialogPrimitive.RootProps = $props();
+	let { open = $bindable(false), ...restProps }: DialogPrimitive.RootProps = $props();
 </script>
 
 <DialogPrimitive.Root bind:open {...restProps} />

--- a/webapp/src/lib/components/ui/dialog/index.ts
+++ b/webapp/src/lib/components/ui/dialog/index.ts
@@ -1,22 +1,34 @@
 import Root from "./dialog.svelte";
-import Content from "./dialog-content.svelte";
-import Header from "./dialog-header.svelte";
-import Footer from "./dialog-footer.svelte";
+import Portal from "./dialog-portal.svelte";
 import Title from "./dialog-title.svelte";
+import Footer from "./dialog-footer.svelte";
+import Header from "./dialog-header.svelte";
+import Overlay from "./dialog-overlay.svelte";
+import Content from "./dialog-content.svelte";
 import Description from "./dialog-description.svelte";
+import Trigger from "./dialog-trigger.svelte";
+import Close from "./dialog-close.svelte";
 
 export {
 	Root,
-	Content,
-	Header,
-	Footer,
 	Title,
+	Portal,
+	Footer,
+	Header,
+	Trigger,
+	Overlay,
+	Content,
 	Description,
+	Close,
 	//
 	Root as Dialog,
-	Content as DialogContent,
-	Header as DialogHeader,
-	Footer as DialogFooter,
 	Title as DialogTitle,
+	Portal as DialogPortal,
+	Footer as DialogFooter,
+	Header as DialogHeader,
+	Trigger as DialogTrigger,
+	Overlay as DialogOverlay,
+	Content as DialogContent,
 	Description as DialogDescription,
+	Close as DialogClose,
 };

--- a/webapp/src/lib/components/ui/tooltip/index.ts
+++ b/webapp/src/lib/components/ui/tooltip/index.ts
@@ -1,16 +1,19 @@
-import Root from './tooltip.svelte';
-import Trigger from './tooltip-trigger.svelte';
-import Content from './tooltip-content.svelte';
-import Provider from './tooltip-provider.svelte';
+import Root from "./tooltip.svelte";
+import Trigger from "./tooltip-trigger.svelte";
+import Content from "./tooltip-content.svelte";
+import Provider from "./tooltip-provider.svelte";
+import Portal from "./tooltip-portal.svelte";
 
 export {
 	Root,
-	Content,
 	Trigger,
+	Content,
 	Provider,
+	Portal,
 	//
 	Root as Tooltip,
 	Content as TooltipContent,
 	Trigger as TooltipTrigger,
-	Provider as TooltipProvider
+	Provider as TooltipProvider,
+	Portal as TooltipPortal,
 };

--- a/webapp/src/lib/components/ui/tooltip/tooltip-content.svelte
+++ b/webapp/src/lib/components/ui/tooltip/tooltip-content.svelte
@@ -1,22 +1,52 @@
 <script lang="ts">
-	import { Tooltip as TooltipPrimitive } from 'bits-ui';
-	import { cn } from '$lib/utils';
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+	import { cn } from "$lib/utils.js";
+	import TooltipPortal from "./tooltip-portal.svelte";
+	import type { ComponentProps } from "svelte";
+	import type { WithoutChildrenOrChild } from "$lib/utils.js";
 
 	let {
 		ref = $bindable(null),
 		class: className,
-		sideOffset = 6,
+		sideOffset = 0,
+		side = "top",
+		children,
+		arrowClasses,
+		portalProps,
 		...restProps
-	}: TooltipPrimitive.ContentProps = $props();
+	}: TooltipPrimitive.ContentProps & {
+		arrowClasses?: string;
+		portalProps?: WithoutChildrenOrChild<ComponentProps<typeof TooltipPortal>>;
+	} = $props();
 </script>
 
-<TooltipPrimitive.Content
-	bind:ref
-	data-slot="tooltip-content"
-	{sideOffset}
-	class={cn(
-		'z-50 max-w-xs rounded-md border border-border bg-popover px-3 py-1.5 text-xs text-popover-foreground shadow-md',
-		className
-	)}
-	{...restProps}
-/>
+<TooltipPortal {...portalProps}>
+	<TooltipPrimitive.Content
+		bind:ref
+		data-slot="tooltip-content"
+		{sideOffset}
+		{side}
+		class={cn(
+			"data-open:animate-in data-open:fade-in-0 data-open:zoom-in-95 data-[state=delayed-open]:animate-in data-[state=delayed-open]:fade-in-0 data-[state=delayed-open]:zoom-in-95 data-closed:animate-out data-closed:fade-out-0 data-closed:zoom-out-95 data-[side=bottom]:slide-in-from-top-2 data-[side=left]:slide-in-from-right-2 data-[side=right]:slide-in-from-left-2 data-[side=top]:slide-in-from-bottom-2 inline-flex items-center gap-1.5 rounded-md px-3 py-1.5 text-xs has-data-[slot=kbd]:pr-1.5 **:data-[slot=kbd]:relative **:data-[slot=kbd]:isolate **:data-[slot=kbd]:z-50 **:data-[slot=kbd]:rounded-sm bg-foreground text-background z-50 w-fit max-w-xs origin-(--bits-tooltip-content-transform-origin)",
+			className
+		)}
+		{...restProps}
+	>
+		{@render children?.()}
+		<TooltipPrimitive.Arrow>
+			{#snippet child({ props })}
+				<div
+					class={cn(
+						"size-2.5 translate-y-[calc(-50%-2px)] rotate-45 rounded-[2px] bg-foreground fill-foreground z-50",
+						"data-[side=top]:translate-x-1/2 data-[side=top]:translate-y-[calc(-50%+2px)]",
+						"data-[side=bottom]:-translate-x-1/2 data-[side=bottom]:-translate-y-[calc(-50%+1px)]",
+						"data-[side=right]:translate-x-[calc(50%+2px)] data-[side=right]:translate-y-1/2",
+						"data-[side=left]:-translate-y-[calc(50%-3px)]",
+						arrowClasses
+					)}
+					{...props}
+				></div>
+			{/snippet}
+		</TooltipPrimitive.Arrow>
+	</TooltipPrimitive.Content>
+</TooltipPortal>

--- a/webapp/src/lib/components/ui/tooltip/tooltip-portal.svelte
+++ b/webapp/src/lib/components/ui/tooltip/tooltip-portal.svelte
@@ -1,0 +1,7 @@
+<script lang="ts">
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
+
+	let { ...restProps }: TooltipPrimitive.PortalProps = $props();
+</script>
+
+<TooltipPrimitive.Portal {...restProps} />

--- a/webapp/src/lib/components/ui/tooltip/tooltip-provider.svelte
+++ b/webapp/src/lib/components/ui/tooltip/tooltip-provider.svelte
@@ -1,13 +1,7 @@
 <script lang="ts">
-	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
 
-	let {
-		delayDuration = 200,
-		children,
-		...restProps
-	}: TooltipPrimitive.ProviderProps = $props();
+	let { delayDuration = 0, ...restProps }: TooltipPrimitive.ProviderProps = $props();
 </script>
 
-<TooltipPrimitive.Provider {delayDuration} {...restProps}>
-	{@render children?.()}
-</TooltipPrimitive.Provider>
+<TooltipPrimitive.Provider {delayDuration} {...restProps} />

--- a/webapp/src/lib/components/ui/tooltip/tooltip-trigger.svelte
+++ b/webapp/src/lib/components/ui/tooltip/tooltip-trigger.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
 
 	let { ref = $bindable(null), ...restProps }: TooltipPrimitive.TriggerProps = $props();
 </script>

--- a/webapp/src/lib/components/ui/tooltip/tooltip.svelte
+++ b/webapp/src/lib/components/ui/tooltip/tooltip.svelte
@@ -1,10 +1,7 @@
 <script lang="ts">
-	import { Tooltip as TooltipPrimitive } from 'bits-ui';
+	import { Tooltip as TooltipPrimitive } from "bits-ui";
 
-	let {
-		open = $bindable(false),
-		...restProps
-	}: TooltipPrimitive.RootProps = $props();
+	let { open = $bindable(false), ...restProps }: TooltipPrimitive.RootProps = $props();
 </script>
 
 <TooltipPrimitive.Root bind:open {...restProps} />


### PR DESCRIPTION
## Summary

Part of #692 (Stage 2 of #687).

Aligns the webapp's shadcn-svelte primitives with the `nova` style that docs has been using since #689. With this PR both stacks render shadcn primitives identically.

## What changed

- `components.json`: added `"style": "nova"`
- All nine existing shadcn-svelte primitives reinstalled via `pnpm dlx shadcn-svelte@latest add ... --overwrite --yes`: `badge`, `button`, `card`, `collapsible`, `dialog`, `input`, `select`, `separator`, `tooltip`
- `package.json`: `@lucide/svelte` bumped `1.7.0` → `1.14.0`, adds `@internationalized/date` (transitive for nova's date components, even though we don't use them yet)

## What's actually different between default and nova

Most primitives are byte-identical between styles. `card`, `button`, `badge`, `collapsible`, `input`, `select`, `separator` rendered identically on disk after the reinstall (their files were overwritten by the CLI but the content didn't change).

The two primitives that **do** differ structurally between styles:

- **`dialog/`**: nova decomposes the dialog into more granular components. New files added: `dialog-close.svelte`, `dialog-overlay.svelte`, `dialog-portal.svelte`, `dialog-trigger.svelte`. Previously these were inline inside `dialog.svelte`.
- **`tooltip/`**: similar decomposition. `tooltip-portal.svelte` added.

The `index.ts` exports in both folders are updated to surface the new pieces. Consumers using `import * as Dialog from "$lib/components/ui/dialog"` are unaffected.

## Customizations preserved

The `shadow-low` class on `card.svelte` (added in #693) was stripped by the CLI overwrite. Manually re-added so `card.svelte` matches what's on main.

## Verification

- `pnpm check` → 876 files, 0 errors, 0 warnings
- `pnpm test` → 52 tests passing across 5 test files
- Visual sanity: all four routes still render with the design language we landed in #693

## Test plan

- [ ] `task dev:webapp` renders correctly (header, h1, cards, dialogs, tooltips)
- [ ] Approvals page (which uses Dialog/Tooltip primitives heavily) still works end-to-end
- [ ] `task test:webapp` and `task test:e2e:webapp` pass in CI

Part of #692
Part of #687