### PR TITLE
feat(webapp): apply ink-bleed to page-level description prose

### DIFF
--- a/webapp/src/routes/+page.svelte
+++ b/webapp/src/routes/+page.svelte
@@ -15,7 +15,7 @@
 
 <div class="space-y-4">
 	<h1 class="mb-4 text-3xl font-extrabold tracking-tight">Aileron</h1>
-	<p class="text-muted-foreground">
+	<p class="ink-bleed text-muted-foreground">
 		The local webapp surfaced under <code>aileron launch</code>. Use it to review and decide on
 		action approvals the agent has paused on.
 	</p>

--- a/webapp/src/routes/actions/+page.svelte
+++ b/webapp/src/routes/actions/+page.svelte
@@ -66,7 +66,7 @@
 
 <h1 class="mb-4 text-3xl font-extrabold tracking-tight">Installed Actions</h1>
 
-<p class="mb-3 text-sm text-muted-foreground">
+<p class="ink-bleed mb-3 text-sm text-muted-foreground">
 	Toggle which installed actions the agent's LLM can see. Disabling does
 	not uninstall — the action's manifest file stays in place and re-enabling
 	restores it. Restart your MCP server after toggling so the LLM picks up

--- a/webapp/src/routes/approvals/+page.svelte
+++ b/webapp/src/routes/approvals/+page.svelte
@@ -206,7 +206,7 @@
 	</p>
 {:else}
 	<section data-testid="action-approvals-section">
-		<p class="mb-3 text-sm text-muted-foreground">
+		<p class="ink-bleed mb-3 text-sm text-muted-foreground">
 			The agent is blocked on these tool calls until you approve or deny.
 		</p>
 		{#if focusedMissing}

--- a/webapp/src/routes/hub/+page.svelte
+++ b/webapp/src/routes/hub/+page.svelte
@@ -59,7 +59,7 @@
 </svelte:head>
 
 <h1 class="mb-4 text-3xl font-extrabold tracking-tight">Connector Hub</h1>
-<p class="mb-4 text-sm text-muted-foreground">
+<p class="ink-bleed mb-4 text-sm text-muted-foreground">
 	Community-published connectors. Browse, search by keyword, and install with
 	one click. The daemon writes publisher trust to your keyring per repo on
 	confirm.


### PR DESCRIPTION
## Summary

Part of #692 (Stage 2 of #687).

Adds the `ink-bleed` utility class (defined in #689 via `effect.ink-bleed` token + `.ink-bleed` CSS rule) to the descriptive paragraphs at the top of each main webapp route.

The effect (four 1px directional `drop-shadow` filters at 10% opacity, applied per-glyph) gives longer prose a tactile, paper-grain quality that matches how the docs site reads inside `.prose-section` cards.

## Applied to

- `/+page.svelte`: intro paragraph "The local webapp surfaced under…"
- `/actions/+page.svelte`: "Toggle which installed actions…" (multi-line)
- `/approvals/+page.svelte`: "The agent is blocked on these tool calls…"
- `/hub/+page.svelte`: "Community-published connectors…" (multi-line)

## Not applied to

- Short status messages (loading states, errors, empty states) — benefit from crisp readability
- Inline metadata (version chips, source paths) — too small/dense for the bleed to read as intentional
- Approval card body content — defer until those surfaces get a broader pattern pass

## Verification

- `pnpm check`: 876 files, 0 errors, 0 warnings
- 4 small markup-only changes (1 class addition per file)

## Test plan

- [ ] `task dev:webapp` shows the subtle ink-bleed halo on the description prose of each route at viewing distance
- [ ] No regression in existing tests
- [ ] Short prose (status messages, empty states) remains crisp without bleed

Part of #692
Part of #687