### PR TITLE
fix(docs): make prose fluid below lg, snap only when sidebar is in flow

### DIFF
--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -110,9 +110,13 @@ This is a deliberate rule. Fluid scaling (`clamp(min, vw, max)`) shifts wrap poi
 Applies to:
 
 - `h1` page title — three sizes (small/medium/large) at `< sm`, `sm`–`lg`, `lg+`
-- `.prose` max-width — six steps at `360`, `480`, `640`, `1024`, `1280`, `1536`
+- `.prose` max-width — three snap steps at `lg` (1024), `xl` (1280), `2xl` (1536)
 
-The `.prose` width ladder accounts for layout changes at each breakpoint (left sidebar entering the flow at `lg`, right TOC entering at `xl`).
+Below `lg` (mobile, sm, md — anywhere the left sidebar is *not* in the layout) the prose deliberately does *not* snap. Snap widths at those viewports are narrower than the available container, which wastes horizontal space without benefit. The prose uses `max-width: 100%` so it fills the container at whatever the viewport happens to be.
+
+The rule: **snap only when there's other layout chrome competing for horizontal space** (left sidebar from `lg`, right TOC from `xl`). When content is the whole viewport, let it use the whole viewport.
+
+The `.prose` width ladder accounts for layout changes at each snap breakpoint (left sidebar entering at `lg`, right TOC entering at `xl`).
 
 ### Display heading gradient
 

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -115,9 +115,6 @@
 		line-height: 1.75;
 		max-width: 100%;
 	}
-	@media (min-width: 360px)  { :where(.prose) { max-width: 18rem; } }
-	@media (min-width: 480px)  { :where(.prose) { max-width: 26rem; } }
-	@media (min-width: 640px)  { :where(.prose) { max-width: 32rem; } }
 	@media (min-width: 1024px) { :where(.prose) { max-width: 38rem; } }
 	@media (min-width: 1280px) { :where(.prose) { max-width: 38rem; } }
 	@media (min-width: 1536px) { :where(.prose) { max-width: 46rem; } }


### PR DESCRIPTION
## Summary

Post-foundation polish to the prose width ladder set up in #689 and refined in #693.

The previous ladder snapped from 360px upward, with narrow caps (18rem, 26rem, 32rem) on small viewports. Those caps were narrower than the available container width, which constrained prose unnecessarily on every viewport below `lg` — where the left sidebar isn't yet in the layout.

This PR changes the rule: **snap only when there's other layout chrome competing for horizontal space.** The left sidebar enters at `lg` (1024px); the TOC enters at `xl` (1280px). Below `lg`, prose has the whole viewport, so it fills the container instead of snapping into a narrow column.

## New ladder

| Viewport | `.prose` max-width | What's in flow |
|---|---|---|
| < 1024 (mobile, sm, md) | **100% of container** | Content only |
| 1024–1279 (`lg`) | 38rem (608px) | Left sidebar enters |
| 1280–1535 (`xl`) | 38rem (608px) | Sidebar + TOC |
| 1536+ (`2xl`) | 46rem (736px) | More viewport, content can breathe |

## Spec change

`DESIGN.md` "Step-snap responsive sizing" section updated to capture the rule explicitly: snap when there's layout chrome, fluid when content has the whole viewport. The three remaining snap breakpoints (lg, xl, 2xl) align with the points where the layout adds chrome.

## Test plan

- [ ] At viewports 320–1023px, prose fills the available container width with comfortable padding (no narrow column)
- [ ] At 1024+ (lg), prose snaps to 38rem and the left sidebar appears
- [ ] No regressions at xl/2xl
- [ ] No regressions in any other docs page rendering