### PR TITLE
feat(design): step header wordmark down by one size below lg

### DIFF
--- a/design/DESIGN.md
+++ b/design/DESIGN.md
@@ -111,10 +111,13 @@ Applies to:
 
 - `h1` page title — three sizes (small/medium/large) at `< sm`, `sm`–`lg`, `lg+`
 - `.prose` max-width — three snap steps at `lg` (1024), `xl` (1280), `2xl` (1536)
+- **Brand wordmark in the page header** — one Tailwind step smaller below `lg` than at `lg+` (docs: `text-2xl` → `text-3xl`; webapp: `text-xl` → `text-2xl`)
 
 Below `lg` (mobile, sm, md — anywhere the left sidebar is *not* in the layout) the prose deliberately does *not* snap. Snap widths at those viewports are narrower than the available container, which wastes horizontal space without benefit. The prose uses `max-width: 100%` so it fills the container at whatever the viewport happens to be.
 
-The rule: **snap only when there's other layout chrome competing for horizontal space** (left sidebar from `lg`, right TOC from `xl`). When content is the whole viewport, let it use the whole viewport.
+The brand wordmark steps down for the same reason: at `lg+` the page has chrome (sidebar, TOC) framing the content, and a large wordmark anchors the experience. Below `lg` the viewport is content-only — a smaller wordmark leaves more room for the actual page and feels proportional to the simpler layout.
+
+The rule: **scale display elements with available chrome.** When the viewport has layout chrome competing for space (sidebar from `lg`, TOC from `xl`), display elements are bigger and content is snapped to a stable column. When content owns the viewport, display elements step down and content goes fluid.
 
 The `.prose` width ladder accounts for layout changes at each snap breakpoint (left sidebar entering at `lg`, right TOC entering at `xl`).
 

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -38,10 +38,10 @@ const nav = navigation;
   </head>
   <body>
     <header class="fixed top-0 left-0 right-0 z-50 h-16 flex items-center pl-16 pr-6 lg:px-6 border-b border-border bg-background transition-[padding] duration-200">
-      <a href="/" class="font-extrabold text-3xl text-foreground no-underline hover:text-foreground">
+      <a href="/" class="font-extrabold text-2xl lg:text-3xl text-foreground no-underline hover:text-foreground">
         Aileron
       </a>
-      <span class="font-normal text-3xl text-muted-foreground">ControlPlane</span>
+      <span class="font-normal text-2xl lg:text-3xl text-muted-foreground">ControlPlane</span>
       <a
         href="https://github.com/ALRubinger/aileron"
         target="_blank"

--- a/webapp/src/routes/+layout.svelte
+++ b/webapp/src/routes/+layout.svelte
@@ -42,8 +42,8 @@
 			href="/"
 			class="text-foreground no-underline hover:text-foreground"
 		>
-			<span class="font-extrabold text-2xl tracking-tight">Aileron</span><span
-				class="font-normal text-2xl tracking-tight text-muted-foreground"
+			<span class="font-extrabold text-xl lg:text-2xl tracking-tight">Aileron</span><span
+				class="font-normal text-xl lg:text-2xl tracking-tight text-muted-foreground"
 			>ControlPlane</span>
 		</a>
 		<nav class="flex items-center gap-4 text-sm">


### PR DESCRIPTION
## Summary

Generalizes the prose-snap rule established in #699 into a broader principle and applies it to the page header brand wordmark.

The wordmark in both stacks previously rendered at the same Tailwind size at every viewport. Below `lg` (mobile, sm, md — no sidebar in the layout) the wordmark felt oversized relative to the simpler content-only layout.

This PR steps the wordmark down by one Tailwind size below `lg`:

- **Docs**: `text-2xl` (24px) below lg, `text-3xl` (30px) at lg+
- **Webapp**: `text-xl` (20px) below lg, `text-2xl` (24px) at lg+

## Generalized principle

The "snap below lg, fluid above" rule for prose has the same underlying logic as this header treatment: **scale display elements with available chrome.**

- Viewport has chrome (sidebar from `lg`, TOC from `xl`) → display elements are bigger, content snaps to a stable column
- Viewport is content-only (below `lg`) → display elements step down, content goes fluid

`DESIGN.md` "Step-snap responsive sizing" section updated to capture this as a named principle, and the header wordmark added to the applies-to list.

## Test plan

- [ ] Resize docs from 1024 → 1023: Aileron wordmark snaps from 30px → 24px
- [ ] Resize webapp same: Aileron wordmark snaps from 24px → 20px
- [ ] No regressions in either stack's existing header layout (vault chip, nav links, GitHub icon on docs)