### PR TITLE
fix(ui): resolve connected-accounts test race via load-time redirect

### DIFF
--- a/ui/src/routes/+layout.svelte
+++ b/ui/src/routes/+layout.svelte
@@ -5,17 +5,15 @@
 	import { goto } from '$app/navigation';
 	import { Button } from '$lib/components/ui/button';
 	import { Separator } from '$lib/components/ui/separator';
-	import { initAuth, isAuthenticated, getUser, logout } from '$lib/auth.svelte.js';
+	import { isAuthenticated, getUser, logout } from '$lib/auth.svelte.js';
 	import { initPosthog, posthog } from '$lib/posthog.js';
 	import PassphraseModal from '$lib/components/PassphraseModal.svelte';
 	import { sessionExpiresAt, setSessionExpiresAt } from '$lib/vault.svelte.js';
-	import { lockVault, getVaultStatus } from '$lib/api';
+	import { lockVault } from '$lib/api';
 
 	let { children } = $props();
 	let mounted = $state(false);
 	let menuOpen = $state(false);
-
-	const publicPaths = ['/login', '/signup', '/verify-email', '/auth/callback'];
 
 	let vaultTimeRemaining = $state('');
 
@@ -36,7 +34,6 @@
 	}
 
 	onMount(() => {
-		initAuth();
 		initPosthog();
 		mounted = true;
 
@@ -51,34 +48,6 @@
 		if (mounted) {
 			posthog.capture('$pageview', { $current_url: page.url.href });
 		}
-	});
-
-	$effect(() => {
-		if (!mounted) return;
-		const path = page.url.pathname;
-		const isPublic = publicPaths.some((p) => path.startsWith(p));
-		if (!isPublic && !isAuthenticated()) {
-			const redirect = path === '/' ? '' : `?redirectTo=${encodeURIComponent(path)}`;
-			goto(`/login${redirect}`);
-		}
-	});
-
-	// Redirect to vault setup if authenticated but no passphrase set.
-	let vaultChecked = $state(false);
-	$effect(() => {
-		if (!mounted || !isAuthenticated() || vaultChecked) return;
-		const path = page.url.pathname;
-		if (path === '/vault') return;
-		vaultChecked = true;
-		getVaultStatus()
-			.then((status) => {
-				if (!status.has_passphrase) {
-					goto('/vault');
-				}
-			})
-			.catch(() => {
-				// Vault status unavailable — don't block.
-			});
 	});
 
 	// Close menu when clicking outside.

--- a/ui/src/routes/+layout.ts
+++ b/ui/src/routes/+layout.ts
@@ -1,0 +1,31 @@
+import { redirect, isRedirect } from '@sveltejs/kit';
+import { browser } from '$app/environment';
+import { initAuth, isAuthenticated } from '$lib/auth.svelte.js';
+import { getVaultStatus } from '$lib/api';
+
+const PUBLIC_PATHS = ['/login', '/signup', '/verify-email', '/auth/callback'];
+
+export const load = async ({ url }) => {
+	if (!browser) return;
+
+	const path = url.pathname;
+	const isPublic = PUBLIC_PATHS.some((p) => path.startsWith(p));
+
+	initAuth();
+
+	if (!isPublic && !isAuthenticated()) {
+		const params = path === '/' ? '' : `?redirectTo=${encodeURIComponent(path)}`;
+		throw redirect(303, `/login${params}`);
+	}
+
+	if (isPublic || !isAuthenticated() || path === '/vault') return;
+
+	try {
+		const status = await getVaultStatus();
+		if (!status.has_passphrase) {
+			throw redirect(303, '/vault');
+		}
+	} catch (err) {
+		if (isRedirect(err)) throw err;
+	}
+};


### PR DESCRIPTION
## Summary

- The connected-accounts E2E test (`available integrations shown or redirects to vault setup`) has been intermittently failing across multiple unrelated PRs (#674, #700, #706, and several rerun-to-green attempts) with `getByText('Slack') ... element(s) not found`.
- Root cause: the auth and vault redirects in `+layout.svelte` were post-mount `$effect`s that raced with the connected-accounts page's own `onMount` fetch. The page rendered "No accounts connected yet." and the provider list, the test caught it, then the layout's redirect fired during the Slack assertion's retry window.
- Fix: move the redirects into a SvelteKit `load()` in `+layout.ts`. `load` runs before the page component mounts and `throw redirect(303, ...)` short-circuits navigation deterministically — the connected-accounts page never renders providers when the user is destined for `/vault`.

## Test plan
- [x] `pnpm check` — 0 errors
- [x] `pnpm test` — 71 passed (includes 17 in `connected-accounts/page.test.ts`)
- [ ] CI integration E2E green for `connected-accounts.spec.ts:28` (the previously flaky test) and `vault-setup.spec.ts` (which already tested the redirect path explicitly)
- [ ] No regression in `settings.spec.ts` (its `gotoSettings` helper already handles the race, will be a no-op after fix)