### PR TITLE
feat(sandbox): scope BYOCLI sandbox decisions and add output caps

### DIFF
--- a/docs/src/content/docs/adr/0014-spawn-sandbox-technology.md
+++ b/docs/src/content/docs/adr/0014-spawn-sandbox-technology.md
@@ -8,8 +8,8 @@ order: 14
 <div class="meta">
 <table>
   <tr><th>Status</th><td>Accepted</td></tr>
-  <tr><th>Date</th><td>2026-05-10</td></tr>
-  <tr><th>Tracking</th><td><a href="https://github.com/ALRubinger/aileron/issues/508">#508</a></td></tr>
+  <tr><th>Date</th><td>2026-05-14</td></tr>
+  <tr><th>Tracking</th><td><a href="https://github.com/ALRubinger/aileron/issues/508">#508</a>, <a href="https://github.com/ALRubinger/aileron/issues/619">#619</a></td></tr>
 </table>
 </div>
 
@@ -25,7 +25,7 @@ The properties the spawn sandbox must enforce, derived from the manifest fields 
 
 1. **Filesystem scoping.** The subprocess can read files only within `fs_read` and write only within `fs_write`. No ambient access to the user's home directory, the runtime's working dir, or the rest of the filesystem.
 2. **Environment scoping.** The subprocess sees only the env keys in `env_passthrough`, plus credential env vars the runtime injects per [ADR-0002](/adr/0002-connector-model)'s credential-injection rule. Nothing from the host's ambient environment.
-3. **Network denial by default.** A subprocess spawned for a connector does not get network access via the spawn primitive. Network is the connector's own primitive ([ADR-0002](/adr/0002-connector-model) `[capabilities.network]`) and rides through the runtime's HTTP gate, not through the subprocess. Subprocess outbound network is denied at the sandbox boundary.
+3. **Network egress mediated by the daemon.** A subprocess reaches the network only through a daemon-run local proxy on loopback. The proxy enforces the connector's `[capabilities.network]` host:port allowlist ([ADR-0002](/adr/0002-connector-model)) and tunnels TLS via HTTP CONNECT. Direct egress to anything other than the daemon's proxy address is denied at the sandbox boundary. A connector that omits `[capabilities.network]` gets no network at all, same as v1.
 4. **Process scoping.** The subprocess cannot signal, ptrace, or otherwise interfere with the parent runtime, other subprocesses, or any unrelated host process. It receives its own session and a job-control boundary keyed to the runtime's lifetime.
 5. **No privilege escalation.** The subprocess runs at the host user's privilege level or lower. It cannot acquire capabilities the host user did not already have. On all platforms the runtime refuses to spawn setuid binaries.
 6. **Graceful unavailability.** If the chosen mechanism is unavailable on the running platform (kernel feature absent, OS version too old, capability missing), the runtime refuses to spawn with a structured error and emits an audit row. A missing sandbox is not silently permitted.
@@ -50,7 +50,7 @@ The runtime invokes the subprocess via `os/exec` with `SysProcAttr.Cloneflags` s
 1. **User namespace.** Maps the runtime's UID to a fresh nobody-equivalent inside the namespace. The subprocess cannot escalate to root within the namespace and cannot affect any host UID's resources.
 2. **Mount namespace.** The runtime constructs a private mount tree before exec'ing the subprocess: bind-mounts of each `fs_read` path read-only, bind-mounts of each `fs_write` path read-write, a tmpfs for `/tmp`, and a private `/proc`. Nothing outside `fs_read ∪ fs_write` is visible.
 3. **PID namespace.** The subprocess is PID 1 inside its namespace; it cannot see or signal host processes. Exit propagates cleanly back to the runtime.
-4. **Network namespace.** The new namespace has only a loopback interface and no routes. Outbound network calls fail at the kernel level. Network capability for a connector remains the runtime's own gate, not the subprocess's responsibility.
+4. **Network namespace.** The new namespace has only its own loopback interface and no routes to external networks. Outbound network calls fail at the kernel level. When the connector declares `[capabilities.network]`, the daemon's per-spawn CONNECT proxy listens on a Unix-domain socket that the runtime bind-mounts into the child's mount namespace; a small TCP-to-UDS shim runs as a sibling of the wrapped CLI inside the namespace and bridges `127.0.0.1:<port>` to that socket. The CLI honors the standard `HTTPS_PROXY` env var and reaches the daemon transparently. See "Network confinement" below for the full mechanism. When the connector omits `[capabilities.network]`, the namespace is fully isolated and the shim is not started.
 5. **Landlock (when available).** On Linux 5.13+, the runtime adds Landlock rules as a second filesystem layer, restricting reads and writes to the declared scopes even within the mount namespace. This is defense in depth. When Landlock is unavailable, the mount namespace alone is the enforcement.
 
 **Unprivileged user namespaces required.** On distributions or sysctl configurations that disable `kernel.unprivileged_userns_clone`, the runtime cannot create the user namespace and falls into the deny-spawn path with a structured error naming the missing capability. Users on such systems may enable the sysctl, switch distributions, or accept that spawn-using connectors will not run.
@@ -72,9 +72,10 @@ A typical generated profile:
 (allow file-read* (literal "/Users/alr/.gitconfig"))
 (allow file-write* (subpath "/Users/alr/.cache/aileron/gitcrawl"))
 (deny network*)
+(allow network* (remote tcp "localhost:54321"))
 ```
 
-Defaults deny everything. Each `fs_read` entry becomes one or more `file-read*` allow rules (literal for files, subpath for directories). Each `fs_write` entry becomes a `file-write*` allow rule. The declared `programs` list becomes `process-exec` literals. Network is denied wholesale.
+Defaults deny everything. Each `fs_read` entry becomes one or more `file-read*` allow rules (literal for files, subpath for directories). Each `fs_write` entry becomes a `file-write*` allow rule. The declared `programs` list becomes `process-exec` literals. Network is denied wholesale except for a single loopback exception to the daemon's per-spawn proxy port (the literal port number is bound by the daemon at spawn time and inlined into the generated profile). See "Network confinement" below for the proxy model.
 
 **`sandbox-exec` is deprecated.** Apple has carried the deprecation warning for years without removing the binary; it remains the only tool available to confine arbitrary subprocesses on macOS without code-signing entitlements. The underlying `sandbox_init` API is private and unstable. The runtime accepts the deprecation risk for v1 and tracks Apple's posture. When `sandbox-exec` is removed in a future macOS release, the spawn primitive on macOS will require either Apple's evolving alternative (currently `containerd`-style XPC-only sandboxing for App Store apps) or explicit deny-spawn until a replacement is ratified.
 
@@ -91,9 +92,50 @@ The runtime calls `CreateProcessAsUserW` with a token derived via `CreateRestric
 
 Filesystem scoping comes from the restricted token plus ACLs. The runtime adjusts ACLs on `fs_write` paths to grant write to the low-integrity token; everything else is denied by default to a Low-integrity caller. `fs_read` paths whose ACLs already grant read to `Everyone` need no adjustment. Paths with stricter ACLs that the connector needs to read are denied at the kernel level by the restricted token, which is the desired behavior.
 
-Network denial on Windows uses Windows Filtering Platform (WFP) rules applied to the subprocess's PID, or where unavailable a denylist at the firewall layer. Network capability remains the connector's own gate; the subprocess does not get its own network primitive.
+Network confinement on Windows uses Windows Filtering Platform (WFP) rules applied to the subprocess's PID. The default rule denies all outbound; when the connector declares `[capabilities.network]`, the runtime adds a second rule permitting outbound TCP to `127.0.0.1:<proxy-port>` for the spawn invocation's lifetime. See "Network confinement" below for the proxy model the rule connects to.
 
 **AppContainer deferred.** AppContainer would provide stronger guarantees (capability-token-based access to network, filesystem, and devices), but requires an Application Identity SID, an AppContainer profile registered with the OS, and significant manifest-side changes. The job-object plus restricted-token combination is the v1 mechanism. AppContainer is a future ADR.
+
+### Network confinement: daemon-mediated proxy
+
+Spawn connectors that need outbound network declare it via the connector's existing `[capabilities.network]` block ([ADR-0002](/adr/0002-connector-model)). The block's shape is unchanged from WASM connectors: a closed list of `host:port` pairs, no wildcards. What changes is the enforcement seam. WASM connectors call the runtime's HTTP host function and the runtime checks each URL before dialing. Native subprocesses cannot be intercepted at the function-call layer; the runtime instead constrains the network paths the subprocess can reach so that every outbound flow is forced through a daemon-controlled proxy where the same allowlist is checked.
+
+The flow is the same conceptually on all three platforms; only the substrate between the CLI and the proxy differs.
+
+1. At spawn time, the daemon binds an HTTP CONNECT proxy on a per-invocation local endpoint. On macOS and Windows the endpoint is an ephemeral TCP port on `127.0.0.1`; on Linux it is a Unix-domain socket file under `$XDG_RUNTIME_DIR` (the namespace barrier prevents a host-loopback TCP listener from being reachable). Neither endpoint is exposed to any non-local interface.
+2. The runtime sets `HTTPS_PROXY` and `HTTP_PROXY` on the subprocess's environment to point at `http://127.0.0.1:<port>`. On Linux that port lives on the namespace's own loopback and is served by an in-namespace shim that bridges to the UDS; on macOS and Windows it is the daemon's proxy port directly. Both env keys are added to the closed `env_passthrough` set automatically when the connector declares `[capabilities.network]`; the connector author does not declare them.
+3. The OS sandbox permits exactly one outbound network operation: TCP to the configured loopback port. On macOS and Windows that's the daemon's host-loopback port; on Linux it's the in-namespace loopback the shim listens on. Everything else is denied at the platform mechanism (the per-platform rules above).
+4. For each CONNECT request the proxy receives, it parses the target host:port, checks it against the connector's `[capabilities.network].hosts` allowlist (the same `internal/sandbox.HostPolicy` used by the WASM HTTP gate), tunnels the bytes through to the destination on a match, or returns `403 Forbidden` and emits a `capability_denied` audit row on a miss.
+
+The proxy is the single enforcement seam for the host:port allowlist across all platforms. The match logic lives in Go in the daemon. Per-platform glue is uniform from the CLI's point of view: `HTTPS_PROXY` points at a loopback TCP address, and only that address is reachable.
+
+**CONNECT, not MITM.** The proxy operates at the CONNECT method only; it does not terminate TLS. The proxy sees host:port and the encrypted bytes; it does not see request URLs, headers, or bodies. The trade-off is intentional. No CA certificate gets installed in the subprocess's trust store, no TLS interception complications, no per-CLI quirks around certificate handling. The cost is audit granularity: spawn audit rows record `host:port` per CONNECT, not full request URLs. For deeper observability the connector author can use a WASM connector instead, where the HTTP gate sees the full request shape.
+
+**Linux: in-namespace TCP-to-UDS shim.** On macOS and Windows, the platform sandbox can selectively permit loopback to one TCP port without granting any other network access to the subprocess. Linux's mechanism in this ADR (a private network namespace) gives the subprocess its own loopback, which is not connected to the host's loopback where a TCP listener would naturally bind. Bridging the two without `CAP_NET_ADMIN` on the host (which the unprivileged user-namespace path does not have) requires moving the path between subprocess and proxy off TCP and onto a substrate that crosses the namespace boundary cleanly. That substrate is a Unix-domain socket file plus a tiny in-namespace shim that translates between the CLI's expected `127.0.0.1:<port>` and the socket.
+
+The mechanism, end to end:
+
+1. Before forking, the daemon binds its per-spawn CONNECT proxy on a Unix-domain socket at `$XDG_RUNTIME_DIR/aileron-proxy-<spawn-id>.sock`. The socket lives on the host filesystem under the daemon's user.
+2. The runtime constructs the child's mount namespace (already required for `fs_read` / `fs_write`) and **bind-mounts the socket file** into the child's view at a fixed path (`/run/aileron-proxy.sock`). Bind-mounting inside the runtime's own user+mount namespace is permitted to unprivileged user-namespace processes; no `CAP_NET_ADMIN` is involved.
+3. The runtime forks once more inside the new namespace. The forked child immediately exec's the wrapped CLI with `HTTPS_PROXY=http://127.0.0.1:<port>` set. The forked parent (also inside the namespace) runs a tiny **TCP-to-UDS shim**: it listens on `127.0.0.1:<port>` on the namespace's own loopback, and for each accepted connection it dials `/run/aileron-proxy.sock` and `io.Copy`s bytes in both directions.
+4. When the CLI exits, the shim observes the SIGCHLD and exits too. The namespace tears down. The socket file is cleaned up by the daemon.
+
+The shim is part of the daemon binary (re-exec'd with a `--spawn-shim` flag, or a goroutine in the post-fork parent before its own exit). No separate binary, no external dependency. Implementation lives in `internal/sandbox/spawn_shim_linux.go`.
+
+Why this is privilege-free:
+
+- Every step happens inside the unprivileged user+mount+net namespace the runtime already creates per ADR-0014's existing Linux mechanism.
+- Bind-mounting a host file (`...aileron-proxy-<id>.sock`) into the child's mount namespace is permitted to unprivileged user-namespace processes for files the runtime already has read+write access to.
+- The shim listens on the namespace's own loopback, which is brought up by default for new network namespaces. No interface configuration, no routing rules, no eBPF.
+- The CLI's only network path is the in-namespace loopback (the shim) because the namespace has no external interface. Direct egress to anywhere else fails at the kernel level.
+
+The cost is one extra goroutine and two-way `io.Copy` per CONNECT request. Negligible at the byte volumes spawn connectors realistically push. For CLIs that ignore `HTTPS_PROXY`, the failure mode is `network_unreachable` (no other network path exists), which is the same failure-closed posture as the other platforms.
+
+A future optimization: when the daemon runs with `CAP_NET_ADMIN` (operator-deployed configurations, not the user-laptop default), the runtime can skip the shim and instead share the host's network namespace with the subprocess plus an nftables cgroup rule that drops all egress except to the proxy port on host loopback. The ADR commits to the shim as the baseline; the nftables path is a perf optimization that can ship later without affecting the manifest contract.
+
+**CLIs that ignore `HTTPS_PROXY`.** Even with kernel enforcement, the proxy model only delivers usable network to a CLI when the CLI actually routes through the proxy. CLIs that build their own HTTP clients and ignore the standard proxy env vars cannot reach the network because direct egress is denied. The failure is structured (`network_unreachable`, distinct from `capability_denied`) and the audit row notes the proxy was untouched. Documenting the requirement at install time is the introspector's job (see the BYOCLI sandbox tightening tracked in [#619](https://github.com/ALRubinger/aileron/issues/619)). The trade-off is acceptable: the alternative is permitting unmediated egress, which collapses the spawn primitive's network confinement property.
+
+**Per-invocation lifetime.** The proxy listener and any associated platform rules (SBPL `(allow network*)` line, WFP allow rule, nftables/cgroup binding) live for the duration of a single spawn invocation. The runtime tears them down after `Wait()` returns. Audit rows record proxy decisions correlated with the spawn invocation's audit id. Across invocations of the same connector, each spawn gets a fresh ephemeral port and a fresh proxy goroutine.
 
 ### Cross-platform manifest implications
 
@@ -157,6 +199,14 @@ Ship the spawn primitive's manifest schema and host function but leave the enfor
 
 Rejected because the spawn primitive's security property is its enforcement. Shipping the schema without the mechanism would be a promise the runtime cannot keep. Connector authors writing against `[capabilities.spawn]` need to know that the declared scope is actually the scope the subprocess runs in. A deferred decision here is a silent unsafe default.
 
+### Per-host network filtering at the OS layer (rejected)
+
+Enforce the connector's `[capabilities.network]` host:port allowlist directly in the per-platform sandbox mechanism: macOS SBPL `(allow network* (remote tcp "api.linear.app:443"))` rules per allowed host, Windows WFP rules per host, Linux nftables rules per host. No daemon-side proxy involved.
+
+Rejected for three reasons. First, the allowlist matching logic would be duplicated across three platform implementations and three rule languages; a bug in one would not be a bug in the others, and per-platform debugging multiplies. Second, hostname-to-IP resolution in the OS rules is brittle: SBPL allowlists on macOS evaluate against the resolved IP at rule-application time, not at connect time, so DNS rotation breaks the rule; WFP and nftables have similar limitations. Third, audit emission would split across platform mechanisms, leaving the daemon without a single source of truth for "what network calls did this spawn make."
+
+The daemon-mediated proxy collapses these problems into one Go implementation of the allowlist check, sees every CONNECT request with its current hostname, and emits a single audit stream. The OS sandbox's only network task is "permit loopback to one port" which is uniform across platforms.
+
 ## Consequences
 
 ### For connector authors
@@ -165,6 +215,7 @@ Rejected because the spawn primitive's security property is its enforcement. Shi
 - Path declarations must be Unix-style or `~/`-anchored. Windows paths are computed by the runtime at install/run time.
 - `programs` entries that do not resolve on a target platform cause install to fail on that platform. The connector author either accepts the platform constraint or extends the schema in a future ADR.
 - A connector that declares `[capabilities.spawn]` is unavailable on BSDs, illumos, and any other non-supported OS. The runtime refuses install with a structured error naming the missing platform.
+- A spawn connector that needs outbound network declares `[capabilities.network]` with the same `host:port` allowlist shape WASM connectors use. The runtime injects `HTTPS_PROXY` and `HTTP_PROXY` automatically; the connector author does not declare those env keys. CLIs that ignore standard proxy env vars cannot make outbound calls.
 
 ### For the runtime
 
@@ -172,7 +223,8 @@ Rejected because the spawn primitive's security property is its enforcement. Shi
 - The Linux implementation uses `golang.org/x/sys/unix` and direct `syscall` calls; no external binary dependencies.
 - The macOS implementation invokes `/usr/bin/sandbox-exec`; an installed macOS always has it. Absence is a structured error.
 - The Windows implementation uses `golang.org/x/sys/windows` for token manipulation, job objects, and WFP rules.
-- The runtime maintains a per-platform "sandbox available" probe, run at startup and at install of spawn-using connectors. The result feeds the structured `spawn_sandbox_unavailable` error.
+- The runtime maintains a per-platform "sandbox available" probe, run at startup and at install of spawn-using connectors. The result feeds the structured `spawn_sandbox_unavailable` error. The probe runs at `aileron action install` time and at `aileron cli add` time (for BYOCLI per [#580](https://github.com/ALRubinger/aileron/issues/580)) so the user sees unavailability before any binary is fetched or stored.
+- The proxy implementation lives in `internal/sandbox/proxy.go` and is shared across platforms. It reuses `internal/sandbox.HostPolicy` for the host:port allowlist check. On Linux, the per-spawn proxy binds on a Unix-domain socket under `$XDG_RUNTIME_DIR` rather than on TCP; the runtime bind-mounts the socket into the child's view and starts a TCP-to-UDS shim (`internal/sandbox/spawn_shim_linux.go`) inside the namespace.
 
 ### For testing
 
@@ -184,6 +236,8 @@ Rejected because the spawn primitive's security property is its enforcement. Shi
 - Every spawn call emits an audit event identifying the connector, the program, the argv pattern, the exit code, and the content hashes of stdout and stderr. The audit row is identical across platforms; the underlying mechanism is not exposed in the audit.
 - Sandbox-unavailability denials emit a distinct audit class (`spawn_sandbox_unavailable`) so an operator can distinguish "the subprocess broke the rules" from "the platform cannot enforce the rules."
 - The audit record persists the platform identifier so post-hoc analysis of a multi-platform deployment can distinguish per-OS behavior.
+- The daemon's spawn proxy emits a `spawn_network` audit event per CONNECT request: connector identity, requested host:port, decision (allow / capability_denied), and the spawn invocation's audit id for correlation. CONNECT does not terminate TLS, so the audit captures host:port granularity only, not full request URLs.
+- The runtime caps stdout and stderr at the manifest-declared `[capabilities.spawn.limits]` byte counts (defaults: 1 MiB stdout, 256 KiB stderr) and inserts a structured truncation marker when a stream exceeds its cap. The marker is part of the captured bytes the connector reads back, ensuring downstream consumers see truncation rather than assuming completeness.
 
 ### Open implementation questions (deferred)
 
@@ -206,8 +260,12 @@ runtime calls clone(CLONE_NEWUSER|CLONE_NEWNS|CLONE_NEWPID|CLONE_NEWNET, ...)
       /Users/alr/code            (bind, read-only)        # fs_read
       /Users/alr/.cache/aileron  (bind, read-write)       # fs_write
     apply Landlock ruleset: read /Users/alr/code, write /Users/alr/.cache/aileron, deny everything else
+    bind-mount /run/user/1000/aileron-proxy-<spawn-id>.sock -> /run/aileron-proxy.sock
     setenv only declared keys plus injected credentials
-    exec("/usr/bin/git", argv...)
+    setenv HTTPS_PROXY=http://127.0.0.1:54321 HTTP_PROXY=http://127.0.0.1:54321
+    fork:
+      parent:  spawn-shim listens on 127.0.0.1:54321, bridges to /run/aileron-proxy.sock
+      child:   exec("/usr/bin/git", argv...)
 ```
 
 ### macOS: generated SBPL profile
@@ -221,9 +279,10 @@ runtime calls clone(CLONE_NEWUSER|CLONE_NEWNS|CLONE_NEWPID|CLONE_NEWNET, ...)
 (allow file-read* (literal "/Users/alr/.gitconfig"))
 (allow file-write* (subpath "/Users/alr/.cache/aileron/gitcrawl"))
 (deny network*)
+(allow network* (remote tcp "localhost:54321"))
 ```
 
-The runtime writes the profile to a tempfile and invokes `/usr/bin/sandbox-exec -f <tempfile> /usr/bin/git ...`.
+The runtime writes the profile to a tempfile and invokes `/usr/bin/sandbox-exec -f <tempfile> /usr/bin/git ...`. The loopback allow rule names the daemon's per-spawn proxy port. When the connector declares `[capabilities.network]`, the runtime also injects `HTTPS_PROXY` and `HTTP_PROXY` into the subprocess's environment pointing at the same address.
 
 ### Windows: restricted token plus job object
 
@@ -233,6 +292,8 @@ SetTokenInformation(hToken, TokenIntegrityLevel, LOW_INTEGRITY_SID)
 hJob   = CreateJobObjectW(...); set KILL_ON_JOB_CLOSE, UILIMIT_HANDLES, BREAKAWAY_OK=false
 CreateProcessAsUserW(hToken, "C:\\Program Files\\Git\\bin\\git.exe", argv, ..., CREATE_SUSPENDED)
 AssignProcessToJobObject(hJob, hProcess)
+add WFP filter: deny outbound TCP for this PID except 127.0.0.1:54321
+setenv HTTPS_PROXY=http://127.0.0.1:54321 HTTP_PROXY=http://127.0.0.1:54321
 ResumeThread(hThread)
 ```
 

--- a/docs/src/content/docs/guides/wrapping-a-cli.md
+++ b/docs/src/content/docs/guides/wrapping-a-cli.md
@@ -327,6 +327,9 @@ The runtime reads each declared key from its own environment (the daemon's, whic
 | `fs_read` | no | Filesystem read scopes (absolute or `~/`-anchored paths). The sandbox restricts subprocess reads to these. |
 | `fs_write` | no | Filesystem write scopes. Same shape as `fs_read`. |
 | `cwd` | no | Optional working-directory policy. When set, must be within `fs_read` or `fs_write`. |
+| `network.hosts` | no | Outbound network allowlist as `host:port` pairs. The runtime injects `HTTPS_PROXY` and `HTTP_PROXY` and tunnels CONNECTs through a daemon-mediated proxy that enforces the list (per [ADR-0014](/adr/0014-spawn-sandbox-technology)'s network-confinement section). Omit to deny all outbound. |
+| `limits.max_stdout_bytes` | no | Byte cap on captured subprocess stdout. Defaults to 1 MiB. Output past the cap is truncated with a structured marker. |
+| `limits.max_stderr_bytes` | no | Byte cap on captured subprocess stderr. Defaults to 256 KiB. Same truncation semantics. |
 
 A complete reference manifest is in [ADR-0002](/adr/0002-connector-model)'s "Implementation details" subsection.
 
@@ -354,6 +357,117 @@ rm -rf ~/.aileron/store/connectors/sha256/<hash> # remove the manifest entry
 ```
 
 The daemon rebuilds its index on next start. A more polished `aileron connector remove` is a future ergonomic improvement; for now, manual file removal is the path.
+
+## Network access for spawned CLIs
+
+A wrapped CLI that needs to make outbound HTTPS calls (Linear, Sentry, the GitHub API, anything that hits a remote service) declares the hosts it talks to. The runtime injects standard `HTTPS_PROXY` and `HTTP_PROXY` env vars on the subprocess and points them at a local proxy the daemon runs for the duration of the call. The proxy enforces the host:port allowlist; everything outside the list is denied. Direct egress that bypasses the proxy is denied at the kernel level by the platform sandbox.
+
+```yaml
+network:
+  hosts:
+    - api.linear.app:443
+    - api.github.com:443
+```
+
+The shape mirrors `[capabilities.network]` for WASM connectors. Hosts are pinned to `host:port` pairs; no wildcards. Omit the block to deny all outbound network from the subprocess.
+
+What the proxy sees and audits: the requested host:port per CONNECT request, and the bytes tunneled through. TLS is end-to-end between the subprocess and the remote, so the proxy does not see request URLs, headers, or bodies. Audit granularity is per host:port per request, correlated with the spawn invocation's audit id.
+
+What the CLI must do: honor `HTTPS_PROXY` / `HTTP_PROXY`. Most Go CLIs and anything built on `curl` or `requests` do this by default. CLIs that build their own HTTP clients and ignore standard proxy env vars cannot reach the network through Aileron because the sandbox denies direct egress. The failure surfaces as a structured `network_unreachable` error on the first outbound call.
+
+See [ADR-0014](/adr/0014-spawn-sandbox-technology)'s "Network confinement: daemon-mediated proxy" section for the per-platform mechanism.
+
+## Output caps
+
+The runtime caps the bytes it captures from a subprocess's stdout and stderr. Defaults are 1 MiB stdout and 256 KiB stderr. Output past the cap is truncated and a structured marker (`[aileron: output truncated, N bytes dropped]`) is appended to the captured slice the connector reads back.
+
+Override the defaults per CLI when you need more or less headroom:
+
+```yaml
+limits:
+  max_stdout_bytes: 4194304  # 4 MiB
+  max_stderr_bytes: 131072   # 128 KiB
+```
+
+The caps cannot be disabled. Unbounded output is a load-bearing problem rather than a convenience one: a wrapped CLI's stdout flows back into the connector and ultimately into the agent's LLM context, and the agent treats it as data to consider. A subprocess that emits an arbitrary volume of attacker-chosen bytes is an attempt to overwhelm the agent's prompt. The cap bounds that side channel's blast radius. The schema rejects values past 64 MiB or values of zero (omit the field to use the default).
+
+## What `aileron cli add` shows you
+
+When [Milestone v3](https://github.com/ALRubinger/aileron/issues/584) ships the BYOCLI flow ([#580](https://github.com/ALRubinger/aileron/issues/580)), the install command will show the full inferred capability block before fetching the binary. The user makes two trust decisions at once: that the catalog and the upstream module are OK to install, and that the binary should have access to the listed scopes.
+
+The shape the runtime presents at install time:
+
+```sh
+$ aileron cli add linear
+
+Tap:          printingpress (registry pinned at sha256:b3d4e2…)
+Module:       github.com/printing-press/linear-cli@v1.4.0
+Install:      go install github.com/printing-press/linear-cli@v1.4.0
+
+This connector will be granted:
+  Filesystem read:   ~/.config/linear/                  [scope-default]
+  Filesystem write:  ~/.cache/linear/                   [scope-default]
+  Network hosts:     api.linear.app:443                 [from --help]
+  Environment vars:  LINEAR_API_TOKEN                   [credential-injected]
+  Output caps:       1 MiB stdout, 256 KiB stderr        [defaults]
+
+Proceed?  [y] yes  [e] edit  [n] no  [d] dry-run
+```
+
+The display surfaces every grant the runtime will give the wrapped CLI. Two flags refine the flow:
+
+- `aileron cli add --dry-run <cli>` prints the manifest the introspector would emit and exits without fetching the binary. Useful for reviewing what the introspector inferred from `--help` before any install side effects occur.
+- `aileron cli add --edit <cli>` opens the inferred manifest in `$EDITOR` so you can narrow scopes or tweak operations before confirming. The runtime re-validates the edited manifest before continuing.
+
+Broad scopes (filesystem scope of `$HOME`, unrestricted network) are highlighted in the install-time display. The introspector defaults to the narrowest possible scope (`$XDG_CONFIG_HOME/<cli>` for FS, the hosts mentioned in `--help` for network); when the heuristic can't infer a narrow scope, it prompts rather than expanding silently.
+
+This UX spec is the contract; the implementation lands with [#580](https://github.com/ALRubinger/aileron/issues/580).
+
+## Threat model
+
+What BYOCLI defends against, and what it does not. Reading this honestly is part of using it well.
+
+### Compared to running the CLI bare in your shell
+
+Running a CLI bare from your shell:
+
+- The CLI runs with your user's full filesystem access. It can read SSH keys, browser profiles, `.env` files in any project, shell history.
+- The CLI inherits your shell's environment. Any credential set in your shell (`AWS_ACCESS_KEY_ID`, ambient `GITHUB_TOKEN`, IDE-injected secrets) is visible to it.
+- The CLI's network egress is unrestricted. It can reach any host on the public internet.
+- The CLI's stdout / stderr ends up wherever you piped it. Nothing limits the volume or scrutinizes the content.
+
+Wrapping the same CLI through Aileron's spawn primitive:
+
+- The CLI's filesystem reach is bound by `fs_read` and `fs_write`. The kernel enforces the bound (per [ADR-0014](/adr/0014-spawn-sandbox-technology)) via Linux namespaces plus Landlock, macOS `sandbox-exec`, or Windows job objects plus restricted tokens. Files outside the declared scopes are not visible to the subprocess.
+- The CLI sees only the env keys in `env_passthrough`. Credentials it needs are injected from the vault at spawn time and never live in your shell. The connector itself does not see the credential bytes either.
+- The CLI's network egress is denied except to the hosts in `network.hosts`, enforced by the daemon-mediated proxy. Hosts outside the allowlist are refused with an audit row, not just a network error.
+- The CLI's stdout / stderr is captured against a byte cap. Output past the cap is truncated with a marker; the agent never sees an unbounded volume of subprocess-chosen bytes.
+- Every spawn invocation emits an audit event: connector identity, argv shape, exit code, output hashes, network decisions.
+
+The agent calling the wrapped CLI through Aileron gets less surface than calling the same CLI through your shell. Wrapping is a strict narrowing.
+
+### What wrapping does not defend against
+
+- **What's in the binary.** Aileron does not analyze the CLI's syscalls, infer behavior, or otherwise vet the binary's contents. The trust anchor is "you installed this binary yourself" (or "the catalog you tapped vouches for it"). A malicious binary can do anything the declared scopes permit. The kernel-enforced sandbox bounds *what* it can touch, not *whether* what it touches is what you wanted.
+- **The LLM provider sees prompts and tool results.** A wrapped CLI's stdout flows back to the agent and into the LLM's context. The credential bytes do not leave your machine, but the data the CLI returns does. Wrap CLIs whose output you would be comfortable sharing with your LLM provider.
+- **stdout as a side channel.** A wrapped CLI can, within its filesystem scope, read declared files and write their contents to stdout. That stdout becomes LLM context. A malicious CLI granted read access to `~/code/` could exfiltrate code via its stdout response to an unrelated query. The output cap bounds the volume; it does not prevent the channel. Treat the stdout cap as a blast-radius bound, not a confidentiality guarantee.
+- **CLIs that bypass `HTTPS_PROXY`.** The network confinement relies on the CLI honoring standard proxy env vars. CLIs that don't honor them cannot reach the network at all (the sandbox denies direct egress); they fail rather than bypass. But the failure mode is "the CLI doesn't work," not "the CLI works and leaks." When a wrapped CLI fails with `network_unreachable` on first call, suspect a proxy-ignoring HTTP client and either patch the CLI or use a different wrap.
+- **Binary integrity after install.** The manifest records the binary's SHA-256 hash at install time and the runtime rechecks on every spawn. This defends against a later `go install` of a malicious version of the same module: the hash mismatches and the spawn refuses. It does not defend against compromise *at the moment of original install*. If the upstream was malicious when you ran `cli add`, you wrapped a malicious binary and pinned its hash.
+- **Unsupported platforms.** The kernel-enforced sandbox runs on Linux, macOS, and Windows only. On BSDs, illumos, and other Unix-likes, spawn-using connectors refuse to install with a structured `spawn_sandbox_unavailable` error. The CLI cannot be wrapped on those platforms in v3; there is no fallback to "wrap unconfined." Failure is closed.
+
+### Disposition for sensitive workflows
+
+Use wrapping when:
+
+- You want an agent to compose with a CLI's specific operations under bounds you control.
+- You are comfortable with the CLI's stdout being readable by your LLM provider.
+- The CLI honors standard proxy env vars (or it has no network needs at all).
+
+Reach for something other than wrapping when:
+
+- The CLI emits secrets in stdout that should not flow into the LLM context. Wrapping won't filter those.
+- The CLI's behavior is poorly understood and the threat model assumptions ("it only reads its config dir") cannot be validated. Spend time understanding the binary first.
+- The use case wants stronger boundaries than file-system-and-network scoping. The connector model (authored WASM, [Authoring a Connector](/guides/authoring-a-connector/)) gives finer-grained host-function-level control at the cost of writing code rather than declaring a manifest.
 
 ## See also
 

--- a/internal/cstore/manifest.go
+++ b/internal/cstore/manifest.go
@@ -247,6 +247,79 @@ type ManifestSpawn struct {
 	// within FSRead. When unset, the runtime uses a per-invocation
 	// temporary directory.
 	Cwd string `toml:"cwd,omitempty"`
+
+	// Limits is the optional `[capabilities.spawn.limits]` block. When
+	// absent, the runtime applies [DefaultMaxStdoutBytes] and
+	// [DefaultMaxStderrBytes]. When present, the declared values
+	// override the defaults; either field may be omitted to use the
+	// default for that stream alone. The caps bound the bytes the
+	// runtime captures from the subprocess; output past the cap is
+	// truncated and a structured marker appended.
+	//
+	// Caps are part of the security model: stdout is read back into
+	// the connector and ultimately the agent's LLM context, so an
+	// unbounded subprocess can be coerced into producing an arbitrary
+	// volume of attacker-chosen bytes. A finite cap bounds the side
+	// channel's blast radius.
+	Limits *ManifestSpawnLimits `toml:"limits,omitempty"`
+}
+
+// ManifestSpawnLimits is `[capabilities.spawn.limits]` — per-stream
+// byte caps on the subprocess's captured output. Values are absolute
+// byte counts. A nil pointer means "use the default for both
+// streams"; a partially-set struct (one field nil) means "default
+// for the unset stream."
+type ManifestSpawnLimits struct {
+	// MaxStdoutBytes caps the bytes the runtime captures from the
+	// subprocess's stdout. When the subprocess produces more, the
+	// extra bytes are dropped and a structured truncation marker is
+	// appended to the captured slice. nil means "use [DefaultMaxStdoutBytes]."
+	MaxStdoutBytes *int64 `toml:"max_stdout_bytes,omitempty"`
+
+	// MaxStderrBytes caps the bytes the runtime captures from the
+	// subprocess's stderr. Same truncation semantics as
+	// MaxStdoutBytes. nil means "use [DefaultMaxStderrBytes]."
+	MaxStderrBytes *int64 `toml:"max_stderr_bytes,omitempty"`
+}
+
+// Spawn output cap defaults and upper bound. Per ADR-0014's
+// network-confinement and output-cap consequences, the runtime
+// enforces these even when the manifest omits the limits block.
+const (
+	// DefaultMaxStdoutBytes is 1 MiB — large enough for typical
+	// structured CLI output (JSON dumps, log tails), small enough
+	// to bound the side channel through the agent's LLM context.
+	DefaultMaxStdoutBytes int64 = 1 << 20
+
+	// DefaultMaxStderrBytes is 256 KiB — diagnostic messages on
+	// failure rarely need more.
+	DefaultMaxStderrBytes int64 = 256 << 10
+
+	// MaxSpawnOutputCap is the absolute ceiling the runtime will
+	// honor for either stream's cap. Beyond this, the manifest
+	// should be expressing "write to a file" via `fs_write` rather
+	// than holding bytes in memory.
+	MaxSpawnOutputCap int64 = 64 << 20
+)
+
+// StdoutCap returns the byte cap the runtime applies to subprocess
+// stdout. Resolves the manifest's declared value when present, falls
+// back to [DefaultMaxStdoutBytes] otherwise.
+func (s *ManifestSpawn) StdoutCap() int64 {
+	if s == nil || s.Limits == nil || s.Limits.MaxStdoutBytes == nil {
+		return DefaultMaxStdoutBytes
+	}
+	return *s.Limits.MaxStdoutBytes
+}
+
+// StderrCap returns the byte cap the runtime applies to subprocess
+// stderr. Resolves the manifest's declared value when present, falls
+// back to [DefaultMaxStderrBytes] otherwise.
+func (s *ManifestSpawn) StderrCap() int64 {
+	if s == nil || s.Limits == nil || s.Limits.MaxStderrBytes == nil {
+		return DefaultMaxStderrBytes
+	}
+	return *s.Limits.MaxStderrBytes
 }
 
 // ManifestSpawnOperation is one entry in [capabilities.spawn.operations]:
@@ -557,6 +630,43 @@ func validateSpawn(s *ManifestSpawn, file string) error {
 		return newValidationErr(file,
 			"[capabilities.spawn].cwd %q must be absolute (/...) or ~/-anchored",
 			s.Cwd)
+	}
+	if s.Limits != nil {
+		if err := validateSpawnLimits(s.Limits, file); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// validateSpawnLimits enforces the [capabilities.spawn.limits]
+// schema: each declared cap must be positive (zero is reserved for
+// "the default" by omitting the field, not by setting it to zero)
+// and at most [MaxSpawnOutputCap]. The runtime treats unbounded
+// output as a security risk per ADR-0014; the manifest cannot
+// express it.
+func validateSpawnLimits(l *ManifestSpawnLimits, file string) error {
+	if l.MaxStdoutBytes != nil {
+		v := *l.MaxStdoutBytes
+		if v <= 0 {
+			return newValidationErr(file,
+				"[capabilities.spawn.limits].max_stdout_bytes %d must be positive (omit the field to use the default)", v)
+		}
+		if v > MaxSpawnOutputCap {
+			return newValidationErr(file,
+				"[capabilities.spawn.limits].max_stdout_bytes %d exceeds the maximum permitted value %d", v, MaxSpawnOutputCap)
+		}
+	}
+	if l.MaxStderrBytes != nil {
+		v := *l.MaxStderrBytes
+		if v <= 0 {
+			return newValidationErr(file,
+				"[capabilities.spawn.limits].max_stderr_bytes %d must be positive (omit the field to use the default)", v)
+		}
+		if v > MaxSpawnOutputCap {
+			return newValidationErr(file,
+				"[capabilities.spawn.limits].max_stderr_bytes %d exceeds the maximum permitted value %d", v, MaxSpawnOutputCap)
+		}
 	}
 	return nil
 }

--- a/internal/cstore/manifest_test.go
+++ b/internal/cstore/manifest_test.go
@@ -539,6 +539,127 @@ func TestValidateManifest_RejectsBadSpawnFields(t *testing.T) {
 	}
 }
 
+func TestValidateManifest_AcceptsSpawnLimits(t *testing.T) {
+	m := canonicalManifestForTest()
+	sp := goodSpawn()
+	stdoutCap := int64(2 << 20) // 2 MiB
+	stderrCap := int64(64 << 10)
+	sp.Limits = &ManifestSpawnLimits{
+		MaxStdoutBytes: &stdoutCap,
+		MaxStderrBytes: &stderrCap,
+	}
+	m.Capabilities.Spawn = sp
+	if err := ValidateManifest(m, "ok.toml"); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+	if got := sp.StdoutCap(); got != stdoutCap {
+		t.Errorf("StdoutCap() = %d, want %d", got, stdoutCap)
+	}
+	if got := sp.StderrCap(); got != stderrCap {
+		t.Errorf("StderrCap() = %d, want %d", got, stderrCap)
+	}
+}
+
+func TestSpawnCapsFallBackToDefaultsWhenLimitsAbsent(t *testing.T) {
+	// Contract: when no limits block is declared, the runtime applies
+	// the default caps (per ADR-0014).
+	sp := goodSpawn()
+	if got := sp.StdoutCap(); got != DefaultMaxStdoutBytes {
+		t.Errorf("StdoutCap() = %d, want default %d", got, DefaultMaxStdoutBytes)
+	}
+	if got := sp.StderrCap(); got != DefaultMaxStderrBytes {
+		t.Errorf("StderrCap() = %d, want default %d", got, DefaultMaxStderrBytes)
+	}
+}
+
+func TestSpawnCapsFallBackPerStreamWhenOneOmitted(t *testing.T) {
+	// Contract: declaring one stream's cap does not affect the other,
+	// which falls back to its default.
+	sp := goodSpawn()
+	stdoutCap := int64(4 << 20)
+	sp.Limits = &ManifestSpawnLimits{MaxStdoutBytes: &stdoutCap}
+	if got := sp.StdoutCap(); got != stdoutCap {
+		t.Errorf("StdoutCap() = %d, want %d", got, stdoutCap)
+	}
+	if got := sp.StderrCap(); got != DefaultMaxStderrBytes {
+		t.Errorf("StderrCap() = %d, want default %d", got, DefaultMaxStderrBytes)
+	}
+}
+
+func TestValidateManifest_RejectsBadSpawnLimits(t *testing.T) {
+	zero := int64(0)
+	negative := int64(-1)
+	overCap := MaxSpawnOutputCap + 1
+	cases := []struct {
+		name   string
+		limits ManifestSpawnLimits
+		want   string
+	}{
+		{"stdout zero", ManifestSpawnLimits{MaxStdoutBytes: &zero}, "max_stdout_bytes"},
+		{"stdout negative", ManifestSpawnLimits{MaxStdoutBytes: &negative}, "max_stdout_bytes"},
+		{"stdout over cap", ManifestSpawnLimits{MaxStdoutBytes: &overCap}, "exceeds the maximum"},
+		{"stderr zero", ManifestSpawnLimits{MaxStderrBytes: &zero}, "max_stderr_bytes"},
+		{"stderr negative", ManifestSpawnLimits{MaxStderrBytes: &negative}, "max_stderr_bytes"},
+		{"stderr over cap", ManifestSpawnLimits{MaxStderrBytes: &overCap}, "exceeds the maximum"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := canonicalManifestForTest()
+			sp := goodSpawn()
+			lim := tc.limits
+			sp.Limits = &lim
+			m.Capabilities.Spawn = sp
+			err := ValidateManifest(m, "x.toml")
+			if err == nil {
+				t.Fatalf("Validate accepted; want error containing %q", tc.want)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %q; want substring %q", err.Error(), tc.want)
+			}
+			var aerr *Error
+			if !errors.As(err, &aerr) || aerr.Class != ClassValidationError {
+				t.Errorf("expected ClassValidationError, got %v", err)
+			}
+		})
+	}
+}
+
+func TestParseManifest_AcceptsSpawnLimitsTOML(t *testing.T) {
+	body := []byte(`[connector]
+name = "github://acme/gitcrawl"
+version = "1.0.0"
+
+[capabilities.spawn]
+
+[[capabilities.spawn.programs]]
+path = "/usr/bin/git"
+
+[capabilities.spawn.operations.log]
+argv = "git log"
+
+[capabilities.spawn.limits]
+max_stdout_bytes = 2097152
+max_stderr_bytes = 65536
+`)
+	m, err := ParseManifest("x.toml", body)
+	if err != nil {
+		t.Fatalf("ParseManifest: %v", err)
+	}
+	if err := ValidateManifest(m, "x.toml"); err != nil {
+		t.Fatalf("ValidateManifest: %v", err)
+	}
+	sp := m.Capabilities.Spawn
+	if sp.Limits == nil {
+		t.Fatal("Limits block not parsed")
+	}
+	if sp.StdoutCap() != 2<<20 {
+		t.Errorf("StdoutCap() = %d, want %d", sp.StdoutCap(), 2<<20)
+	}
+	if sp.StderrCap() != 64<<10 {
+		t.Errorf("StderrCap() = %d, want %d", sp.StderrCap(), 64<<10)
+	}
+}
+
 func TestValidateManifest_AcceptsCredentialEnvKeys(t *testing.T) {
 	m := canonicalManifestForTest()
 	sp := goodSpawn()

--- a/internal/sandbox/sandboxtest/recording_executor.go
+++ b/internal/sandbox/sandboxtest/recording_executor.go
@@ -30,14 +30,29 @@ type RecordingExecutor struct {
 	Err    error
 	Hook   func(env sandbox.SpawnEnvelope) (sandbox.SpawnResult, error)
 
-	mu    sync.Mutex
-	calls []sandbox.SpawnEnvelope
+	mu     sync.Mutex
+	calls  []sandbox.SpawnEnvelope
+	limits []sandbox.SpawnLimits
+}
+
+// LastLimits returns the [sandbox.SpawnLimits] passed alongside the
+// most recent Spawn call, or the zero value when no Spawn has been
+// invoked. Convenience for tests that need to assert on the resolved
+// caps the runtime supplied.
+func (r *RecordingExecutor) LastLimits() sandbox.SpawnLimits {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	if len(r.limits) == 0 {
+		return sandbox.SpawnLimits{}
+	}
+	return r.limits[len(r.limits)-1]
 }
 
 // Spawn implements sandbox.SpawnExecutor.
-func (r *RecordingExecutor) Spawn(_ context.Context, env sandbox.SpawnEnvelope) (sandbox.SpawnResult, error) {
+func (r *RecordingExecutor) Spawn(_ context.Context, env sandbox.SpawnEnvelope, limits sandbox.SpawnLimits) (sandbox.SpawnResult, error) {
 	r.mu.Lock()
 	r.calls = append(r.calls, env)
+	r.limits = append(r.limits, limits)
 	r.mu.Unlock()
 	if r.Hook != nil {
 		return r.Hook(env)
@@ -80,6 +95,7 @@ func (r *RecordingExecutor) Reset() {
 	r.mu.Lock()
 	defer r.mu.Unlock()
 	r.calls = nil
+	r.limits = nil
 	r.Result = sandbox.SpawnResult{}
 	r.Err = nil
 	r.Hook = nil

--- a/internal/sandbox/sandboxtest/sandboxtest_test.go
+++ b/internal/sandbox/sandboxtest/sandboxtest_test.go
@@ -23,7 +23,7 @@ func TestRecordingExecutor_RecordsEnvelope(t *testing.T) {
 		Program: "/usr/bin/git",
 		Argv:    []string{"git", "status"},
 	}
-	res, err := r.Spawn(context.Background(), env)
+	res, err := r.Spawn(context.Background(), env, sandbox.SpawnLimits{})
 	if err != nil {
 		t.Fatalf("Spawn: %v", err)
 	}
@@ -52,8 +52,8 @@ func TestRecordingExecutor_HookOverridesScriptedResult(t *testing.T) {
 			return sandbox.SpawnResult{ExitCode: 0, Stdout: []byte("status")}, nil
 		},
 	}
-	res1, _ := r.Spawn(context.Background(), sandbox.SpawnEnvelope{Argv: []string{"git", "log"}})
-	res2, _ := r.Spawn(context.Background(), sandbox.SpawnEnvelope{Argv: []string{"git", "status"}})
+	res1, _ := r.Spawn(context.Background(), sandbox.SpawnEnvelope{Argv: []string{"git", "log"}}, sandbox.SpawnLimits{})
+	res2, _ := r.Spawn(context.Background(), sandbox.SpawnEnvelope{Argv: []string{"git", "status"}}, sandbox.SpawnLimits{})
 	if string(res1.Stdout) != "commits" {
 		t.Errorf("res1 = %q", string(res1.Stdout))
 	}
@@ -64,7 +64,7 @@ func TestRecordingExecutor_HookOverridesScriptedResult(t *testing.T) {
 
 func TestRecordingExecutor_PropagatesError(t *testing.T) {
 	r := &sandboxtest.RecordingExecutor{Err: sandbox.ErrSpawnUnavailable}
-	_, err := r.Spawn(context.Background(), sandbox.SpawnEnvelope{Program: "/usr/bin/git", Argv: []string{"git"}})
+	_, err := r.Spawn(context.Background(), sandbox.SpawnEnvelope{Program: "/usr/bin/git", Argv: []string{"git"}}, sandbox.SpawnLimits{})
 	if !errors.Is(err, sandbox.ErrSpawnUnavailable) {
 		t.Errorf("err = %v, want ErrSpawnUnavailable", err)
 	}
@@ -81,12 +81,12 @@ func TestRecordingExecutor_ResetClearsState(t *testing.T) {
 	r := &sandboxtest.RecordingExecutor{
 		Result: sandbox.SpawnResult{ExitCode: 7},
 	}
-	_, _ = r.Spawn(context.Background(), sandbox.SpawnEnvelope{Argv: []string{"x"}})
+	_, _ = r.Spawn(context.Background(), sandbox.SpawnEnvelope{Argv: []string{"x"}}, sandbox.SpawnLimits{})
 	r.Reset()
 	if r.CallCount() != 0 {
 		t.Errorf("CallCount after Reset = %d", r.CallCount())
 	}
-	res, _ := r.Spawn(context.Background(), sandbox.SpawnEnvelope{Argv: []string{"x"}})
+	res, _ := r.Spawn(context.Background(), sandbox.SpawnEnvelope{Argv: []string{"x"}}, sandbox.SpawnLimits{})
 	if res.ExitCode != 0 {
 		t.Errorf("Result was not cleared: %+v", res)
 	}

--- a/internal/sandbox/spawn.go
+++ b/internal/sandbox/spawn.go
@@ -27,6 +27,12 @@ import (
 //
 // SpawnPolicy is the gate; the platform sandbox in `spawnExecutor` is
 // the second-line enforcement. Both must agree for a call to proceed.
+//
+// The policy also carries the per-stream output caps the runtime
+// applies to subprocess stdout and stderr (per [cstore.ManifestSpawnLimits]
+// and ADR-0014's output-cap consequences). The caps are derived once
+// from the manifest at policy construction and consulted on every
+// spawn invocation.
 type SpawnPolicy struct {
 	// programs maps an absolute program path to its declared optional
 	// content hash. An empty hash means "any bytes at this path are
@@ -68,7 +74,39 @@ type SpawnPolicy struct {
 	// envelope's cwd must match (or be empty, in which case the
 	// runtime substitutes this value).
 	cwd string
+	// stdoutCap and stderrCap are the resolved byte caps the runtime
+	// applies when capturing subprocess output. Resolved from the
+	// manifest's [capabilities.spawn.limits] block at construction;
+	// fall back to [cstore.DefaultMaxStdoutBytes] and
+	// [cstore.DefaultMaxStderrBytes] when unset.
+	stdoutCap int64
+	stderrCap int64
 }
+
+// SpawnLimits carries the runtime-decided byte caps applied to a
+// single spawn invocation's captured output. The runtime resolves
+// these from the manifest (per [cstore.ManifestSpawnLimits]) and
+// passes them to the [SpawnExecutor]; connectors do not control
+// their own caps.
+type SpawnLimits struct {
+	// MaxStdoutBytes caps the bytes the executor returns in
+	// [SpawnResult.Stdout]. Output past this point is dropped and
+	// a structured truncation marker is appended to the captured
+	// bytes.
+	MaxStdoutBytes int64
+
+	// MaxStderrBytes caps the bytes the executor returns in
+	// [SpawnResult.Stderr]. Same truncation semantics as
+	// MaxStdoutBytes.
+	MaxStderrBytes int64
+}
+
+// StdoutCap returns the resolved stdout byte cap. Always positive
+// when the policy was constructed from a valid manifest.
+func (p *SpawnPolicy) StdoutCap() int64 { return p.stdoutCap }
+
+// StderrCap returns the resolved stderr byte cap.
+func (p *SpawnPolicy) StderrCap() int64 { return p.stderrCap }
 
 // NewSpawnPolicy builds a SpawnPolicy from a connector manifest. A nil
 // or absent `[capabilities.spawn]` block produces a deny-all policy:
@@ -78,6 +116,8 @@ func NewSpawnPolicy(m *cstore.Manifest) *SpawnPolicy {
 		programs:   map[string]string{},
 		envAllowed: map[string]struct{}{},
 		operations: map[string]argvPattern{},
+		stdoutCap:  cstore.DefaultMaxStdoutBytes,
+		stderrCap:  cstore.DefaultMaxStderrBytes,
 	}
 	if m == nil || m.Capabilities.Spawn == nil {
 		return p
@@ -102,6 +142,8 @@ func NewSpawnPolicy(m *cstore.Manifest) *SpawnPolicy {
 	p.fsRead = append(p.fsRead, s.FSRead...)
 	p.fsWrite = append(p.fsWrite, s.FSWrite...)
 	p.cwd = s.Cwd
+	p.stdoutCap = s.StdoutCap()
+	p.stderrCap = s.StderrCap()
 	return p
 }
 
@@ -503,11 +545,13 @@ func pathWithin(p, scope string) bool {
 //
 // The executor is invoked only after CheckSpawn has approved. It is
 // responsible for the second-line enforcement (FS scoping, network
-// denial, process scoping) on the platforms it supports. On
-// unsupported platforms it returns ErrSpawnUnavailable so the host
-// function emits a structured spawn_sandbox_unavailable error.
+// denial, process scoping) on the platforms it supports, and for
+// honoring the runtime-supplied [SpawnLimits] when capturing the
+// subprocess's stdout and stderr. On unsupported platforms it
+// returns ErrSpawnUnavailable so the host function emits a
+// structured spawn_sandbox_unavailable error.
 type SpawnExecutor interface {
-	Spawn(ctx context.Context, env SpawnEnvelope) (SpawnResult, error)
+	Spawn(ctx context.Context, env SpawnEnvelope, limits SpawnLimits) (SpawnResult, error)
 }
 
 // ErrSpawnUnavailable is returned by SpawnExecutor.Spawn when the
@@ -524,7 +568,7 @@ var ErrSpawnUnavailable = errors.New("spawn: sandbox unavailable on this platfor
 type defaultSpawnExecutor struct{}
 
 // Spawn implements SpawnExecutor.
-func (defaultSpawnExecutor) Spawn(ctx context.Context, env SpawnEnvelope) (SpawnResult, error) {
+func (defaultSpawnExecutor) Spawn(ctx context.Context, env SpawnEnvelope, limits SpawnLimits) (SpawnResult, error) {
 	if len(env.Argv) == 0 {
 		return SpawnResult{}, fmt.Errorf("spawn: empty argv")
 	}
@@ -546,7 +590,7 @@ func (defaultSpawnExecutor) Spawn(ctx context.Context, env SpawnEnvelope) (Spawn
 	if err := applyPlatformSandbox(cmd, env); err != nil {
 		return SpawnResult{}, err
 	}
-	stdout, stderr, runErr := runCaptured(cmd)
+	stdout, stderr, runErr := runCaptured(cmd, limits)
 	exitCode := 0
 	if runErr != nil {
 		var exitErr *exec.ExitError
@@ -567,39 +611,89 @@ func (defaultSpawnExecutor) Spawn(ctx context.Context, env SpawnEnvelope) (Spawn
 	}, nil
 }
 
-// runCaptured runs `cmd` with stdout and stderr captured into separate
+// runCaptured runs `cmd` with stdout and stderr captured into capped
 // byte buffers. Returns the captured bytes plus any non-Exit error.
-func runCaptured(cmd *exec.Cmd) ([]byte, []byte, error) {
-	var stdout, stderr captureBuf
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
+// Output beyond the configured cap is dropped at the writer; a
+// truncation marker is appended to the returned slice when a stream
+// exceeded its cap.
+func runCaptured(cmd *exec.Cmd, limits SpawnLimits) ([]byte, []byte, error) {
+	stdout := newCaptureBuf(limits.MaxStdoutBytes)
+	stderr := newCaptureBuf(limits.MaxStderrBytes)
+	cmd.Stdout = stdout
+	cmd.Stderr = stderr
 	err := cmd.Run()
-	return stdout.Bytes(), stderr.Bytes(), err
+	return stdout.Captured(), stderr.Captured(), err
 }
 
-// captureBuf is a minimal io.Writer with a thread-safe Bytes accessor.
-// os/exec writes from a goroutine in CommandContext; the buffer's
-// pointer is only read after Wait returns, but we still synchronize to
-// satisfy the race detector.
+// captureBuf is a bounded io.Writer with a thread-safe accessor.
+// os/exec writes from a goroutine in CommandContext; the buffer is
+// only read after Wait returns, but we still synchronize to satisfy
+// the race detector.
+//
+// captureBuf caps the bytes it stores at `cap`. Writes past `cap`
+// are accepted (so the subprocess sees no I/O error and continues
+// normally) but the trailing bytes are dropped. When at least one
+// byte was dropped, Captured() appends a structured truncation
+// marker to the returned slice.
+//
+// A cap <= 0 is treated as unbounded for tests; production code
+// constructs the buffer through [newCaptureBuf] which sanitizes the
+// cap to a positive value.
 type captureBuf struct {
-	mu  sync.Mutex
-	buf []byte
+	mu       sync.Mutex
+	buf      []byte
+	cap      int64
+	dropped  int64 // count of bytes received past the cap
+}
+
+// newCaptureBuf returns a capture buffer with the given byte cap. A
+// non-positive cap falls back to [cstore.DefaultMaxStdoutBytes] as a
+// defensive default; callers should pass a sane positive value from
+// the resolved manifest limits.
+func newCaptureBuf(cap int64) *captureBuf {
+	if cap <= 0 {
+		cap = cstore.DefaultMaxStdoutBytes
+	}
+	return &captureBuf{cap: cap}
 }
 
 func (c *captureBuf) Write(p []byte) (int, error) {
 	c.mu.Lock()
-	c.buf = append(c.buf, p...)
-	c.mu.Unlock()
+	defer c.mu.Unlock()
+	remaining := c.cap - int64(len(c.buf))
+	if remaining <= 0 {
+		c.dropped += int64(len(p))
+		return len(p), nil
+	}
+	if int64(len(p)) <= remaining {
+		c.buf = append(c.buf, p...)
+		return len(p), nil
+	}
+	c.buf = append(c.buf, p[:remaining]...)
+	c.dropped += int64(len(p)) - remaining
 	return len(p), nil
 }
 
-func (c *captureBuf) Bytes() []byte {
+// Captured returns a copy of the captured bytes with a structured
+// truncation marker appended when at least one byte was dropped past
+// the cap. The marker is part of the returned slice so downstream
+// consumers see truncation even when they cannot inspect the buffer's
+// internal state.
+func (c *captureBuf) Captured() []byte {
 	c.mu.Lock()
 	defer c.mu.Unlock()
-	out := make([]byte, len(c.buf))
-	copy(out, c.buf)
+	out := make([]byte, 0, len(c.buf)+truncationMarkerMaxLen)
+	out = append(out, c.buf...)
+	if c.dropped > 0 {
+		out = append(out, fmt.Sprintf("\n[aileron: output truncated, %d bytes dropped]\n", c.dropped)...)
+	}
 	return out
 }
+
+// truncationMarkerMaxLen is a hint at the marker's worst-case length
+// so the initial allocation in Captured fits without a reallocation
+// for typical drop counts. Not a hard bound.
+const truncationMarkerMaxLen = 64
 
 // expandTilde resolves a leading `~/` or bare `~` against the user's
 // home directory. Absolute paths are returned unchanged.
@@ -816,7 +910,11 @@ func processSpawn(ctx context.Context, s *hostState, raw []byte) int32 {
 	if executor == nil {
 		executor = defaultSpawnExecutor{}
 	}
-	res, runErr := executor.Spawn(ctx, env)
+	limits := SpawnLimits{
+		MaxStdoutBytes: s.spawnPolicy.stdoutCap,
+		MaxStderrBytes: s.spawnPolicy.stderrCap,
+	}
+	res, runErr := executor.Spawn(ctx, env, limits)
 	if runErr != nil {
 		if errors.Is(runErr, ErrSpawnUnavailable) {
 			s.mu.Lock()

--- a/internal/sandbox/spawn_test.go
+++ b/internal/sandbox/spawn_test.go
@@ -1,11 +1,13 @@
 package sandbox
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
 	"log/slog"
 	"os"
+	"os/exec"
 	"sort"
 	"strings"
 	"testing"
@@ -259,13 +261,15 @@ func TestPathWithin(t *testing.T) {
 // fakeExecutor records the envelope it was given and produces a
 // scripted result. Implements SpawnExecutor.
 type fakeExecutor struct {
-	gotEnv SpawnEnvelope
-	result SpawnResult
-	err    error
+	gotEnv    SpawnEnvelope
+	gotLimits SpawnLimits
+	result    SpawnResult
+	err       error
 }
 
-func (f *fakeExecutor) Spawn(_ context.Context, env SpawnEnvelope) (SpawnResult, error) {
+func (f *fakeExecutor) Spawn(_ context.Context, env SpawnEnvelope, limits SpawnLimits) (SpawnResult, error) {
 	f.gotEnv = env
+	f.gotLimits = limits
 	return f.result, f.err
 }
 
@@ -487,7 +491,7 @@ func TestSpawnExecutor_DefaultRunsRealBinary(t *testing.T) {
 	res, err := defaultSpawnExecutor{}.Spawn(context.Background(), SpawnEnvelope{
 		Program: "/bin/echo",
 		Argv:    []string{"echo", "hello"},
-	})
+	}, defaultTestLimits())
 	if err != nil {
 		t.Fatalf("Spawn: %v", err)
 	}
@@ -639,7 +643,7 @@ func TestSpawnExecutor_DefaultPropagatesNonZeroExit(t *testing.T) {
 	res, err := defaultSpawnExecutor{}.Spawn(context.Background(), SpawnEnvelope{
 		Program: prog,
 		Argv:    []string{"false"},
-	})
+	}, defaultTestLimits())
 	if err != nil {
 		t.Fatalf("Spawn: %v", err)
 	}
@@ -651,7 +655,7 @@ func TestSpawnExecutor_DefaultPropagatesNonZeroExit(t *testing.T) {
 func TestSpawnExecutor_DefaultRejectsEmptyArgv(t *testing.T) {
 	_, err := defaultSpawnExecutor{}.Spawn(context.Background(), SpawnEnvelope{
 		Program: "/bin/echo",
-	})
+	}, defaultTestLimits())
 	if err == nil {
 		t.Error("expected error on empty argv")
 	}
@@ -665,12 +669,109 @@ func TestSpawnExecutor_DefaultRunsWithStdin(t *testing.T) {
 		Program: "/bin/cat",
 		Argv:    []string{"cat"},
 		Stdin:   "echoed-stdin",
-	})
+	}, defaultTestLimits())
 	if err != nil {
 		t.Fatalf("Spawn: %v", err)
 	}
 	if string(res.Stdout) != "echoed-stdin" {
 		t.Errorf("stdout = %q, want echoed input", string(res.Stdout))
+	}
+}
+
+func TestCaptureBuf_CapsAndAppendsTruncationMarker(t *testing.T) {
+	// Contract: writes past the cap are accepted (no I/O error) but the
+	// bytes are dropped; Captured returns at most cap+marker bytes; the
+	// marker is present when at least one byte was dropped.
+	cb := newCaptureBuf(10)
+	n, err := cb.Write([]byte("0123456789"))
+	if err != nil || n != 10 {
+		t.Fatalf("first write: n=%d err=%v", n, err)
+	}
+	n, err = cb.Write([]byte("OVERFLOW"))
+	if err != nil || n != len("OVERFLOW") {
+		t.Fatalf("second write: n=%d err=%v", n, err)
+	}
+	captured := cb.Captured()
+	prefix := []byte("0123456789")
+	if !bytes.HasPrefix(captured, prefix) {
+		t.Fatalf("captured prefix = %q, want %q", captured[:10], prefix)
+	}
+	if !bytes.Contains(captured, []byte("truncated")) {
+		t.Errorf("captured = %q, want truncation marker", string(captured))
+	}
+	if !bytes.Contains(captured, []byte("8 bytes dropped")) {
+		t.Errorf("captured = %q, want dropped-byte count", string(captured))
+	}
+}
+
+func TestCaptureBuf_NoMarkerWhenWithinCap(t *testing.T) {
+	cb := newCaptureBuf(10)
+	cb.Write([]byte("hello"))
+	captured := cb.Captured()
+	if string(captured) != "hello" {
+		t.Errorf("captured = %q, want %q (no marker for under-cap writes)", string(captured), "hello")
+	}
+}
+
+func TestCaptureBuf_PartialFinalWrite(t *testing.T) {
+	// Contract: when a single write straddles the cap, the cap-fitting
+	// prefix is stored and the rest is counted as dropped.
+	cb := newCaptureBuf(5)
+	cb.Write([]byte("hello-world"))
+	captured := cb.Captured()
+	if !bytes.HasPrefix(captured, []byte("hello")) {
+		t.Errorf("captured prefix = %q, want %q", captured, "hello")
+	}
+	if !bytes.Contains(captured, []byte("6 bytes dropped")) {
+		t.Errorf("captured = %q, want '6 bytes dropped'", string(captured))
+	}
+}
+
+func TestRunCaptured_EnforcesLimits(t *testing.T) {
+	// Contract: the executor's runCaptured caps each stream independently
+	// at the supplied SpawnLimits. Output past the cap appears truncated
+	// in the returned slice; counts in the marker are accurate.
+	if !commandExists("/bin/sh") {
+		t.Skip("/bin/sh not present; runCaptured smoke test relies on shell")
+	}
+	cmd := exec.Command("/bin/sh", "-c", `printf 'aaaaaaaaaa' && printf 'eeee' >&2`)
+	stdout, stderr, err := runCaptured(cmd, SpawnLimits{MaxStdoutBytes: 4, MaxStderrBytes: 2})
+	if err != nil {
+		t.Fatalf("runCaptured: %v", err)
+	}
+	if !bytes.HasPrefix(stdout, []byte("aaaa")) {
+		t.Errorf("stdout prefix = %q, want %q", stdout, "aaaa")
+	}
+	if !bytes.Contains(stdout, []byte("truncated")) {
+		t.Errorf("stdout = %q, want truncation marker", string(stdout))
+	}
+	if !bytes.HasPrefix(stderr, []byte("ee")) {
+		t.Errorf("stderr prefix = %q, want %q", stderr, "ee")
+	}
+	if !bytes.Contains(stderr, []byte("truncated")) {
+		t.Errorf("stderr = %q, want truncation marker", string(stderr))
+	}
+}
+
+func TestSpawnPolicy_PassesResolvedLimitsToExecutor(t *testing.T) {
+	// Contract: processSpawn supplies the executor with the limits
+	// derived from the connector's manifest (or defaults when absent).
+	fake := &fakeExecutor{result: SpawnResult{ExitCode: 0}}
+	state := &hostState{
+		spawnPolicy:   NewSpawnPolicy(goodSpawnManifest()),
+		spawnExecutor: fake,
+		connectorFQN:  "github://aileron-test/gitcrawl",
+	}
+	ctx := ctxWithState(context.Background(), state)
+	envBytes := mustJSON(SpawnEnvelope{Program: "/usr/bin/git", Argv: []string{"git", "status"}})
+	if rc := processSpawn(ctx, state, envBytes); rc != 0 {
+		t.Fatalf("processSpawn rc=%d err=%v", rc, state.spawnErr)
+	}
+	if fake.gotLimits.MaxStdoutBytes != cstore.DefaultMaxStdoutBytes {
+		t.Errorf("stdout cap = %d, want default %d", fake.gotLimits.MaxStdoutBytes, cstore.DefaultMaxStdoutBytes)
+	}
+	if fake.gotLimits.MaxStderrBytes != cstore.DefaultMaxStderrBytes {
+		t.Errorf("stderr cap = %d, want default %d", fake.gotLimits.MaxStderrBytes, cstore.DefaultMaxStderrBytes)
 	}
 }
 
@@ -831,10 +932,20 @@ func TestSpawn_HostFunctions_MalformedJSONEnvelope(t *testing.T) {
 	}
 }
 
+// defaultTestLimits returns SpawnLimits populated from the manifest
+// schema defaults; the runtime applies these when no per-connector
+// override exists.
+func defaultTestLimits() SpawnLimits {
+	return SpawnLimits{
+		MaxStdoutBytes: cstore.DefaultMaxStdoutBytes,
+		MaxStderrBytes: cstore.DefaultMaxStderrBytes,
+	}
+}
+
 // fakeExecutorErr returns an arbitrary non-sandbox-unavailable error.
 type fakeExecutorErr struct{ err error }
 
-func (f fakeExecutorErr) Spawn(_ context.Context, _ SpawnEnvelope) (SpawnResult, error) {
+func (f fakeExecutorErr) Spawn(_ context.Context, _ SpawnEnvelope, _ SpawnLimits) (SpawnResult, error) {
 	return SpawnResult{}, f.err
 }
 


### PR DESCRIPTION
## Summary

Resolves the scoping half of #619 — the six open BYOCLI sandbox questions (FS scope defaults, network confinement, install-time visibility, unsupported platforms, stdout cap, binary integrity) — and ships the one piece that doesn't have to wait for #580: the runtime-enforced output cap with structured truncation.

The implementation half of #619 (the CONNECT proxy + Linux in-namespace TCP-to-UDS shim ADR-0014 now commits to) is the natural follow-up PR.

- **ADR-0014 amended** for the daemon-mediated CONNECT proxy model. Linux is privilege-free out of the box via a Unix-domain socket + in-namespace shim; macOS/Windows use SBPL and WFP rules to permit loopback to one port. New "Per-host network filtering at the OS layer" rejected-alternative explains why allowlist enforcement lives in the daemon, not in three different per-OS rule languages.
- **`[capabilities.spawn.limits]` schema** in `internal/cstore` with `max_stdout_bytes` and `max_stderr_bytes` (`*int64` so absent vs zero is distinguishable). Defaults 1 MiB stdout / 256 KiB stderr; absolute ceiling 64 MiB; values of zero or negative are rejected.
- **Output cap enforced** in `internal/sandbox.captureBuf`. Writes past the cap are accepted (subprocess sees no I/O error) but bytes are dropped; `Captured()` returns the bounded slice with a structured truncation marker `[aileron: output truncated, N bytes dropped]` appended when at least one byte was dropped.
- **`SpawnExecutor.Spawn` signature** now takes `SpawnLimits`. The recording executor in `sandboxtest` and the spawn fakes are updated; `LastLimits()` accessor added for tests that need to assert on the resolved caps.
- **Wrapping a CLI guide** carries a threat-model section (honest vs-running-bare comparison, what it doesn't defend against, disposition guidance), a network section describing the proxy and `HTTPS_PROXY` cooperation, an output-caps section, and a forward-looking spec for the `aileron cli add` install-time confirmation UX. The `cli add` implementation is scoped to #580.

Tests cover the cap contract end-to-end: `TestCaptureBuf_CapsAndAppendsTruncationMarker`, `_NoMarkerWhenWithinCap`, `_PartialFinalWrite`, `TestRunCaptured_EnforcesLimits` (real `/bin/sh` smoke), `TestSpawnPolicy_PassesResolvedLimitsToExecutor`, plus per-stream-default fallback and parse/round-trip tests in `cstore`.

Coverage on the affected packages: `internal/sandbox` 84.2%, `internal/cstore` 86.7%.

## Test plan

- [x] `go test ./...` green in `internal/` (all 40+ packages)
- [x] New cap tests pass: `TestCaptureBuf_*`, `TestRunCaptured_EnforcesLimits`, `TestSpawnPolicy_PassesResolvedLimitsToExecutor`
- [x] Manifest validation: positive cap accepted, zero/negative/over-ceiling rejected with `ClassValidationError`
- [x] Round-trip TOML parse/encode preserves the `[capabilities.spawn.limits]` block
- [x] `defaultTestLimits()` smoke test against real `/bin/echo`, `/bin/false`, `/bin/cat` (POSIX guard)
- [x] No new em-dashes in modified prose (per docs writing voice)
- [x] All ADR cross-references are hyperlinks (per ADR convention)

## Out of scope for this PR

- The CONNECT proxy + Linux shim implementation — follow-up PR for #619.
- The `aileron cli add` command + introspector — #580.
- BSD/illumos `spawn_sandbox_unavailable` test runner — coverage-impractical without a CI matrix that includes those OSes; the structured error class is already tested for Linux's `unprivileged_userns_clone` case.