### PR TITLE
feat(sandbox): add per-spawn CONNECT proxy enforcing capabilities.network

### DIFF
--- a/internal/sandbox/network.go
+++ b/internal/sandbox/network.go
@@ -83,6 +83,28 @@ func (p *HostPolicy) CheckURL(rawURL string) error {
 	return nil
 }
 
+// CheckHostPort verifies a `host:port` string is in the allowed
+// set. Mirrors [HostPolicy.CheckURL]'s contract for the spawn-proxy
+// path, where the proxy receives a host:port directly from the
+// CONNECT request and does not have a full URL to parse.
+//
+// Returns a structured `*Error` of class `capability_denied` and
+// boundary `sandbox` when the call is refused.
+func (p *HostPolicy) CheckHostPort(hostPort string) error {
+	candidate := normalizeHostPort(hostPort)
+	if _, ok := p.allowed[candidate]; !ok {
+		granted := make([]string, 0, len(p.allowed))
+		for h := range p.allowed {
+			granted = append(granted, h)
+		}
+		return newCapabilityDenied("host:port not in declared grant", map[string]any{
+			"requested": "network:" + candidate,
+			"granted":   prefixed(granted, "network:"),
+		})
+	}
+	return nil
+}
+
 // AllowedHosts returns a sorted-stable copy of the policy's grant for
 // auditing/error-detail purposes.
 func (p *HostPolicy) AllowedHosts() []string {

--- a/internal/sandbox/proxy.go
+++ b/internal/sandbox/proxy.go
@@ -1,0 +1,287 @@
+package sandbox
+
+import (
+	"bufio"
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"sync"
+	"sync/atomic"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+)
+
+// SpawnProxy is the per-invocation HTTP CONNECT proxy that mediates a
+// spawned subprocess's outbound network. The proxy is the single
+// enforcement seam for `[capabilities.network]` on spawn connectors
+// (per ADR-0014's "Network confinement: daemon-mediated proxy"
+// section). One proxy is created per spawn call, served on a
+// local-only listener the runtime hands in (TCP loopback on
+// macOS/Windows; Unix-domain socket on Linux), then closed when the
+// spawn completes.
+//
+// The proxy operates at the CONNECT method only. It does not
+// terminate TLS, so it sees host:port plus tunneled bytes but never
+// the request URL, headers, or body. Allowlist evaluation reuses
+// [HostPolicy] from the WASM network gate; both gates check against
+// the same `host:port` set.
+type SpawnProxy struct {
+	policy *HostPolicy
+	logger *slog.Logger
+	fqn    string
+
+	dial   func(ctx context.Context, network, addr string) (net.Conn, error)
+	closed atomic.Bool
+
+	mu sync.Mutex
+	ln net.Listener
+}
+
+// NewSpawnProxy constructs a proxy that enforces `policy` and emits
+// audit attributes naming `fqn`. The proxy is not started until
+// [SpawnProxy.Serve] is called. `logger` is optional; nil suppresses
+// audit emission (useful in tests).
+func NewSpawnProxy(policy *HostPolicy, logger *slog.Logger, fqn string) *SpawnProxy {
+	return &SpawnProxy{
+		policy: policy,
+		logger: logger,
+		fqn:    fqn,
+		dial:   defaultProxyDial,
+	}
+}
+
+// defaultProxyDial is the production dialer. Tests substitute a fake
+// via [SpawnProxy.SetDialer] so they can drive the proxy without
+// real upstream sockets.
+func defaultProxyDial(ctx context.Context, network, addr string) (net.Conn, error) {
+	var d net.Dialer
+	d.Timeout = 10 * time.Second
+	return d.DialContext(ctx, network, addr)
+}
+
+// SetDialer overrides the function the proxy uses to reach upstream
+// hosts. The runtime never calls this; tests inject fakes to avoid
+// dialing real network endpoints. Must be called before [Serve].
+func (p *SpawnProxy) SetDialer(dial func(ctx context.Context, network, addr string) (net.Conn, error)) {
+	p.dial = dial
+}
+
+// Serve accepts connections on `ln` until the listener returns
+// [net.ErrClosed] (typically via [SpawnProxy.Close]). Each accepted
+// connection is handled in its own goroutine. Serve blocks until the
+// listener is closed and all in-flight CONNECTs have drained.
+//
+// Returns nil on a clean shutdown via Close; returns the underlying
+// accept error otherwise.
+func (p *SpawnProxy) Serve(ctx context.Context, ln net.Listener) error {
+	p.mu.Lock()
+	if p.closed.Load() {
+		p.mu.Unlock()
+		ln.Close()
+		return nil
+	}
+	p.ln = ln
+	p.mu.Unlock()
+
+	var wg sync.WaitGroup
+	for {
+		conn, err := ln.Accept()
+		if err != nil {
+			if p.closed.Load() || errors.Is(err, net.ErrClosed) {
+				wg.Wait()
+				return nil
+			}
+			wg.Wait()
+			return err
+		}
+		wg.Add(1)
+		go func() {
+			defer wg.Done()
+			p.serveConn(ctx, conn)
+		}()
+	}
+}
+
+// Close shuts down the proxy. Outstanding CONNECTs are allowed to
+// finish; new accepts unblock with [net.ErrClosed]. Safe to call
+// from any goroutine. Idempotent.
+func (p *SpawnProxy) Close() error {
+	p.closed.Store(true)
+	p.mu.Lock()
+	ln := p.ln
+	p.mu.Unlock()
+	if ln == nil {
+		return nil
+	}
+	return ln.Close()
+}
+
+// serveConn handles a single client connection: read the CONNECT
+// line, check the allowlist, dial upstream, tunnel bytes both ways.
+//
+// On allowlist miss, returns `403 Forbidden`. On upstream-dial
+// failure, returns `502 Bad Gateway`. On non-CONNECT methods, returns
+// `405 Method Not Allowed`. Every decision (allow, deny, error)
+// emits one audit row.
+func (p *SpawnProxy) serveConn(ctx context.Context, client net.Conn) {
+	defer client.Close()
+	if dl, ok := ctx.Deadline(); ok {
+		client.SetDeadline(dl)
+	}
+
+	reader := bufio.NewReader(client)
+	req, err := http.ReadRequest(reader)
+	if err != nil {
+		p.emitAudit(ctx, "", "deny", "malformed_request")
+		return
+	}
+	defer func() {
+		// Drain the body so subsequent reads on the same connection
+		// (none in CONNECT, but http.Request reserves the body) don't
+		// hang.
+		_ = req.Body.Close()
+	}()
+
+	if req.Method != http.MethodConnect {
+		p.emitAudit(ctx, req.Host, "deny", "method_not_allowed")
+		writeStatus(client, http.StatusMethodNotAllowed, "CONNECT required")
+		return
+	}
+
+	target := req.Host
+	if target == "" {
+		p.emitAudit(ctx, "", "deny", "malformed_request")
+		writeStatus(client, http.StatusBadRequest, "missing host")
+		return
+	}
+
+	if err := p.policy.CheckHostPort(target); err != nil {
+		p.emitAudit(ctx, target, "deny", "capability_denied")
+		writeStatus(client, http.StatusForbidden, "host not in allowlist")
+		return
+	}
+
+	upstream, err := p.dial(ctx, "tcp", target)
+	if err != nil {
+		p.emitAudit(ctx, target, "deny", "upstream_unreachable")
+		writeStatus(client, http.StatusBadGateway, "upstream dial failed")
+		return
+	}
+	defer upstream.Close()
+
+	p.emitAudit(ctx, target, "allow", "")
+
+	if _, err := client.Write([]byte("HTTP/1.1 200 Connection established\r\n\r\n")); err != nil {
+		return
+	}
+
+	// Bidirectional tunnel. Drain whatever the client buffered into
+	// reader as part of the request parse; without this the first
+	// bytes of the TLS handshake would be stuck in the bufio buffer.
+	if n := reader.Buffered(); n > 0 {
+		buffered, _ := reader.Peek(n)
+		if _, err := upstream.Write(buffered); err != nil {
+			return
+		}
+		_, _ = reader.Discard(n)
+	}
+
+	done := make(chan struct{}, 2)
+	go func() {
+		_, _ = io.Copy(upstream, client)
+		// Half-close upstream so the upstream peer sees EOF and we
+		// don't leak goroutines on long-lived idle tunnels.
+		if cw, ok := upstream.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+		}
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(client, upstream)
+		if cw, ok := client.(interface{ CloseWrite() error }); ok {
+			_ = cw.CloseWrite()
+		}
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+}
+
+// emitAudit logs a structured `spawn_network` event per CONNECT
+// request: connector identity, target host:port, decision, deny class.
+// Mirrors emitSpawnAudit's shape so operators can correlate spawn
+// invocations with their network calls.
+func (p *SpawnProxy) emitAudit(ctx context.Context, target, decision, denyClass string) {
+	if p.logger == nil {
+		return
+	}
+	attrs := []slog.Attr{
+		slog.String("connector", p.fqn),
+		slog.String("host_port", target),
+		slog.String(audit.AttrPolicyDecision, decision),
+	}
+	if denyClass != "" {
+		attrs = append(attrs, slog.String("deny_class", denyClass))
+	}
+	p.logger.LogAttrs(ctx, slog.LevelInfo, "spawn_network", attrs...)
+}
+
+// writeStatus writes a minimal HTTP/1.1 response with the given
+// status code and a one-line reason phrase. The body is empty; the
+// reason phrase is informational only and not inspected by typical
+// HTTPS proxy clients.
+func writeStatus(w io.Writer, code int, reason string) {
+	statusLine := "HTTP/1.1 " + http.StatusText(code) + "\r\n"
+	if code != 0 {
+		statusLine = "HTTP/1.1 " + itoa(code) + " " + http.StatusText(code) + "\r\n"
+	}
+	_, _ = w.Write([]byte(statusLine + "Content-Length: 0\r\n\r\n"))
+	_ = reason // reserved for future structured response body
+}
+
+// startSpawnProxy stands up a per-spawn CONNECT proxy on host
+// loopback and returns the listener address callers should set as
+// `HTTPS_PROXY` on the subprocess. The returned `closeFn` tears the
+// proxy down (closes the listener, drains in-flight tunnels). Tests
+// substitute via WithSpawnProxyFactory.
+//
+// Errors construct-time setup only: a listener bind failure or an
+// invalid host policy. Per-CONNECT errors do not propagate here;
+// they emit audit rows and the subprocess sees an HTTP status.
+//
+// v1 binds on TCP loopback. The Linux UDS+shim path lives behind a
+// follow-up to ADR-0014's "Network confinement" section.
+var startSpawnProxy = defaultStartSpawnProxy
+
+func defaultStartSpawnProxy(ctx context.Context, policy *HostPolicy, logger *slog.Logger, fqn string) (*SpawnProxy, string, func(), error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, "", nil, err
+	}
+	proxy := NewSpawnProxy(policy, logger, fqn)
+	go func() {
+		// Serve blocks until Close is called or the listener errors.
+		// Per-connection errors are surfaced via audit emission inside
+		// serveConn; this goroutine's return value is intentionally
+		// dropped because Close is the normal termination path.
+		_ = proxy.Serve(ctx, ln)
+	}()
+	addr := ln.Addr().String()
+	closeFn := func() {
+		_ = proxy.Close()
+	}
+	return proxy, addr, closeFn, nil
+}
+
+// itoa avoids strconv just to keep the proxy's import surface small.
+// Status codes are always three ASCII digits in the supported range.
+func itoa(n int) string {
+	if n < 100 || n > 999 {
+		return "000"
+	}
+	return string([]byte{'0' + byte(n/100), '0' + byte((n/10)%10), '0' + byte(n%10)})
+}

--- a/internal/sandbox/proxy_test.go
+++ b/internal/sandbox/proxy_test.go
@@ -1,0 +1,274 @@
+package sandbox
+
+import (
+	"bufio"
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net"
+	"net/http"
+	"strings"
+	"sync"
+	"testing"
+	"time"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+// The contract tests below validate the proxy against ADR-0014's
+// "Network confinement: daemon-mediated proxy" section. Each test
+// states the property it enforces in a comment so a refactor that
+// preserves the contract leaves the test green.
+
+func TestSpawnProxy_TunnelsAllowedHost(t *testing.T) {
+	// Contract: a CONNECT request to a host in [capabilities.network]
+	// receives 200 Connection established and the bytes flow through.
+	policy := policyForHosts(t, "allowed.test:443")
+
+	// Fake upstream: echoes what it reads.
+	upstream, upstreamReady := newEchoServer(t)
+	defer upstream.Close()
+
+	proxy := NewSpawnProxy(policy, nil, "github://aileron-test/x")
+	proxy.SetDialer(func(ctx context.Context, network, addr string) (net.Conn, error) {
+		// The proxy dials "allowed.test:443"; redirect to our fake echo server.
+		if addr != "allowed.test:443" {
+			return nil, fmt.Errorf("unexpected dial: %q", addr)
+		}
+		return net.Dial("tcp", upstream.Addr().String())
+	})
+
+	ln, addr := newLoopbackListener(t)
+	go proxy.Serve(context.Background(), ln)
+	defer proxy.Close()
+
+	<-upstreamReady
+
+	client, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer client.Close()
+	client.SetDeadline(time.Now().Add(2 * time.Second))
+
+	fmt.Fprintf(client, "CONNECT allowed.test:443 HTTP/1.1\r\nHost: allowed.test:443\r\n\r\n")
+	br := bufio.NewReader(client)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+
+	// Tunnel works: send a sentinel, read it back from echo upstream.
+	if _, err := client.Write([]byte("ping")); err != nil {
+		t.Fatalf("write through tunnel: %v", err)
+	}
+	got := make([]byte, 4)
+	if _, err := io.ReadFull(br, got); err != nil {
+		t.Fatalf("read echo: %v", err)
+	}
+	if string(got) != "ping" {
+		t.Errorf("echo = %q, want %q", got, "ping")
+	}
+}
+
+func TestSpawnProxy_DeniesDisallowedHost(t *testing.T) {
+	// Contract: a CONNECT request to a host outside
+	// [capabilities.network] returns 403 and the audit row carries
+	// `capability_denied`.
+	policy := policyForHosts(t, "allowed.test:443")
+	logBuf, logger := newCapturingLogger()
+	proxy := NewSpawnProxy(policy, logger, "github://aileron-test/x")
+	dialed := false
+	proxy.SetDialer(func(ctx context.Context, network, addr string) (net.Conn, error) {
+		dialed = true
+		return nil, errors.New("should not have dialed")
+	})
+
+	ln, addr := newLoopbackListener(t)
+	go proxy.Serve(context.Background(), ln)
+	defer proxy.Close()
+
+	client, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial: %v", err)
+	}
+	defer client.Close()
+	client.SetDeadline(time.Now().Add(2 * time.Second))
+
+	fmt.Fprintf(client, "CONNECT denied.test:443 HTTP/1.1\r\nHost: denied.test:443\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(client), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != 403 {
+		t.Errorf("status = %d, want 403", resp.StatusCode)
+	}
+	if dialed {
+		t.Error("proxy dialed upstream despite policy miss")
+	}
+	auditOut := logBuf.String()
+	if !strings.Contains(auditOut, "spawn_network") {
+		t.Errorf("audit log missing spawn_network: %s", auditOut)
+	}
+	if !strings.Contains(auditOut, "capability_denied") {
+		t.Errorf("audit log missing capability_denied class: %s", auditOut)
+	}
+	if !strings.Contains(auditOut, "denied.test:443") {
+		t.Errorf("audit log missing target host_port: %s", auditOut)
+	}
+}
+
+func TestSpawnProxy_RejectsNonConnectMethod(t *testing.T) {
+	// Contract: only CONNECT is honored. Plain GET (an agent sending
+	// a regular HTTP request through the proxy) fails closed.
+	policy := policyForHosts(t, "allowed.test:443")
+	proxy := NewSpawnProxy(policy, nil, "x")
+	ln, addr := newLoopbackListener(t)
+	go proxy.Serve(context.Background(), ln)
+	defer proxy.Close()
+
+	client, _ := net.Dial("tcp", addr)
+	defer client.Close()
+	client.SetDeadline(time.Now().Add(2 * time.Second))
+	fmt.Fprintf(client, "GET http://allowed.test/ HTTP/1.1\r\nHost: allowed.test\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(client), nil)
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != 405 {
+		t.Errorf("status = %d, want 405", resp.StatusCode)
+	}
+}
+
+func TestSpawnProxy_BadGatewayOnUpstreamFailure(t *testing.T) {
+	// Contract: an allowlist-permitted host that cannot be reached
+	// yields 502 with a structured audit row, not 403 (the connector
+	// did not break the rules; the network broke).
+	policy := policyForHosts(t, "allowed.test:443")
+	logBuf, logger := newCapturingLogger()
+	proxy := NewSpawnProxy(policy, logger, "x")
+	proxy.SetDialer(func(ctx context.Context, network, addr string) (net.Conn, error) {
+		return nil, errors.New("simulated upstream failure")
+	})
+
+	ln, addr := newLoopbackListener(t)
+	go proxy.Serve(context.Background(), ln)
+	defer proxy.Close()
+
+	client, _ := net.Dial("tcp", addr)
+	defer client.Close()
+	client.SetDeadline(time.Now().Add(2 * time.Second))
+	fmt.Fprintf(client, "CONNECT allowed.test:443 HTTP/1.1\r\nHost: allowed.test:443\r\n\r\n")
+	resp, err := http.ReadResponse(bufio.NewReader(client), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != 502 {
+		t.Errorf("status = %d, want 502", resp.StatusCode)
+	}
+	if !strings.Contains(logBuf.String(), "upstream_unreachable") {
+		t.Errorf("audit missing upstream_unreachable: %s", logBuf.String())
+	}
+}
+
+func TestSpawnProxy_CloseStopsServing(t *testing.T) {
+	// Contract: Close unblocks Serve and is idempotent.
+	policy := policyForHosts(t)
+	proxy := NewSpawnProxy(policy, nil, "x")
+	ln, _ := newLoopbackListener(t)
+	done := make(chan error, 1)
+	go func() { done <- proxy.Serve(context.Background(), ln) }()
+	if err := proxy.Close(); err != nil {
+		t.Fatalf("first Close: %v", err)
+	}
+	if err := proxy.Close(); err != nil {
+		t.Fatalf("second Close: %v", err)
+	}
+	select {
+	case err := <-done:
+		if err != nil {
+			t.Errorf("Serve returned %v on Close", err)
+		}
+	case <-time.After(2 * time.Second):
+		t.Fatal("Serve did not return after Close")
+	}
+}
+
+// --- helpers ---
+
+func policyForHosts(t *testing.T, hosts ...string) *HostPolicy {
+	t.Helper()
+	m := &cstore.Manifest{
+		Capabilities: cstore.ManifestCapabilities{
+			Network: &cstore.ManifestNetwork{Hosts: hosts},
+		},
+	}
+	return NewHostPolicy(m)
+}
+
+func newLoopbackListener(t *testing.T) (net.Listener, string) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen: %v", err)
+	}
+	return ln, ln.Addr().String()
+}
+
+// newEchoServer returns a TCP server that echoes whatever bytes a
+// connection writes to it. The returned channel is closed once the
+// server is accepting connections.
+func newEchoServer(t *testing.T) (net.Listener, <-chan struct{}) {
+	t.Helper()
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("listen echo: %v", err)
+	}
+	ready := make(chan struct{})
+	close(ready)
+	go func() {
+		for {
+			c, err := ln.Accept()
+			if err != nil {
+				return
+			}
+			go func(c net.Conn) {
+				defer c.Close()
+				_, _ = io.Copy(c, c)
+			}(c)
+		}
+	}()
+	return ln, ready
+}
+
+// newCapturingLogger returns an slog.Logger that writes JSON records
+// to an in-memory buffer the test can inspect.
+func newCapturingLogger() (*syncBuf, *slog.Logger) {
+	buf := &syncBuf{}
+	handler := slog.NewJSONHandler(buf, &slog.HandlerOptions{Level: slog.LevelDebug})
+	return buf, slog.New(handler)
+}
+
+// syncBuf is a thread-safe bytes.Buffer wrapper for the test logger.
+type syncBuf struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (s *syncBuf) Write(p []byte) (int, error) {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.Write(p)
+}
+
+func (s *syncBuf) String() string {
+	s.mu.Lock()
+	defer s.mu.Unlock()
+	return s.buf.String()
+}

--- a/internal/sandbox/proxy_test.go
+++ b/internal/sandbox/proxy_test.go
@@ -177,6 +177,81 @@ func TestSpawnProxy_BadGatewayOnUpstreamFailure(t *testing.T) {
 	}
 }
 
+func TestSpawnProxy_TunnelsWithDefaultDialer(t *testing.T) {
+	// Contract: the production dialer (defaultProxyDial) actually
+	// reaches the resolved host:port. Covers the dial path the
+	// fake-dialer tests skip.
+	upstream, _ := newEchoServer(t)
+	defer upstream.Close()
+	host, port, err := net.SplitHostPort(upstream.Addr().String())
+	if err != nil {
+		t.Fatalf("split echo addr: %v", err)
+	}
+	policy := policyForHosts(t, host+":"+port)
+
+	proxy := NewSpawnProxy(policy, nil, "x")
+	ln, addr := newLoopbackListener(t)
+	go proxy.Serve(context.Background(), ln)
+	defer proxy.Close()
+
+	client, err := net.Dial("tcp", addr)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	defer client.Close()
+	client.SetDeadline(time.Now().Add(2 * time.Second))
+
+	fmt.Fprintf(client, "CONNECT %s:%s HTTP/1.1\r\nHost: %s:%s\r\n\r\n", host, port, host, port)
+	resp, err := http.ReadResponse(bufio.NewReader(client), &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		t.Fatalf("read response: %v", err)
+	}
+	if resp.StatusCode != 200 {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestSpawnProxy_RejectsMalformedRequest(t *testing.T) {
+	// Contract: garbage on the wire fails closed without dialing.
+	// Audit records `malformed_request`.
+	policy := policyForHosts(t, "allowed.test:443")
+	logBuf, logger := newCapturingLogger()
+	proxy := NewSpawnProxy(policy, logger, "x")
+	ln, addr := newLoopbackListener(t)
+	go proxy.Serve(context.Background(), ln)
+	defer proxy.Close()
+
+	client, _ := net.Dial("tcp", addr)
+	defer client.Close()
+	client.SetDeadline(time.Now().Add(2 * time.Second))
+	client.Write([]byte("\x00\x01\x02not-an-http-request\r\n\r\n"))
+	_, _ = io.Copy(io.Discard, client)
+
+	time.Sleep(50 * time.Millisecond)
+	if !strings.Contains(logBuf.String(), "malformed_request") {
+		t.Errorf("audit missing malformed_request: %s", logBuf.String())
+	}
+}
+
+func TestSpawnProxy_ItoaCoversStatusRange(t *testing.T) {
+	// Contract: status codes outside 100..999 are clamped to "000".
+	cases := []struct {
+		in   int
+		want string
+	}{
+		{200, "200"},
+		{403, "403"},
+		{502, "502"},
+		{50, "000"},
+		{1000, "000"},
+	}
+	for _, tc := range cases {
+		if got := itoa(tc.in); got != tc.want {
+			t.Errorf("itoa(%d) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
 func TestSpawnProxy_CloseStopsServing(t *testing.T) {
 	// Contract: Close unblocks Serve and is idempotent.
 	policy := policyForHosts(t)

--- a/internal/sandbox/spawn.go
+++ b/internal/sandbox/spawn.go
@@ -903,6 +903,33 @@ func processSpawn(ctx context.Context, s *hostState, raw []byte) int32 {
 		}
 	}
 
+	// Network proxy: when the connector declares [capabilities.network],
+	// the runtime stands up a per-spawn CONNECT proxy on host loopback
+	// and injects HTTPS_PROXY/HTTP_PROXY into the subprocess's env
+	// (per ADR-0014's "Network confinement: daemon-mediated proxy").
+	// The allowlist match logic lives in s.policy, reused from the WASM
+	// HTTP gate. The proxy goroutine is torn down when this function
+	// returns. Connectors that omit [capabilities.network] get no
+	// proxy and no HTTPS_PROXY env; the platform sandbox denies all
+	// outbound at the kernel boundary.
+	if s.policy != nil && len(s.policy.AllowedHosts()) > 0 {
+		proxy, proxyAddr, proxyClose, err := startSpawnProxy(ctx, s.policy, s.logger, s.connectorFQN)
+		if err != nil {
+			s.mu.Lock()
+			s.spawnErr = newConnectorRuntimeError(fmt.Sprintf("spawn: start network proxy: %s", err.Error()))
+			s.mu.Unlock()
+			emitSpawnAudit(ctx, s, env, "error", -1, nil, nil, "connector_runtime_error")
+			return -1
+		}
+		_ = proxy // retain for future per-spawn audit context attach
+		defer proxyClose()
+		if env.Env == nil {
+			env.Env = map[string]string{}
+		}
+		env.Env["HTTPS_PROXY"] = "http://" + proxyAddr
+		env.Env["HTTP_PROXY"] = "http://" + proxyAddr
+	}
+
 	// Hand to the platform executor. Sandbox unavailability is
 	// translated into a distinct error class so operators can tell
 	// "rules were broken" from "platform cannot enforce rules".

--- a/internal/sandbox/spawn_test.go
+++ b/internal/sandbox/spawn_test.go
@@ -753,6 +753,65 @@ func TestRunCaptured_EnforcesLimits(t *testing.T) {
 	}
 }
 
+func TestSpawn_HostFunctions_InjectsProxyEnvWhenNetworkDeclared(t *testing.T) {
+	// Contract: when the connector manifest carries
+	// [capabilities.network] hosts, the runtime stands up a per-spawn
+	// proxy on loopback and injects HTTPS_PROXY/HTTP_PROXY on the
+	// subprocess's env before the executor sees it. The proxy is
+	// torn down after Spawn returns.
+	fake := &fakeExecutor{result: SpawnResult{ExitCode: 0}}
+	m := goodSpawnManifest()
+	m.Capabilities.Network = &cstore.ManifestNetwork{
+		Hosts: []string{"api.linear.app:443"},
+	}
+	state := &hostState{
+		spawnPolicy:   NewSpawnPolicy(m),
+		spawnExecutor: fake,
+		connectorFQN:  "github://aileron-test/x",
+		policy:        NewHostPolicy(m),
+	}
+	ctx := ctxWithState(context.Background(), state)
+	envBytes := mustJSON(SpawnEnvelope{Program: "/usr/bin/git", Argv: []string{"git", "status"}})
+	if rc := processSpawn(ctx, state, envBytes); rc != 0 {
+		t.Fatalf("processSpawn rc=%d err=%v", rc, state.spawnErr)
+	}
+	httpsProxy, ok := fake.gotEnv.Env["HTTPS_PROXY"]
+	if !ok {
+		t.Errorf("HTTPS_PROXY missing from injected env; got %v", fake.gotEnv.Env)
+	}
+	if !strings.HasPrefix(httpsProxy, "http://127.0.0.1:") {
+		t.Errorf("HTTPS_PROXY = %q, want http://127.0.0.1:<port>", httpsProxy)
+	}
+	if got := fake.gotEnv.Env["HTTP_PROXY"]; got != httpsProxy {
+		t.Errorf("HTTP_PROXY = %q, want %q", got, httpsProxy)
+	}
+}
+
+func TestSpawn_HostFunctions_NoProxyEnvWhenNetworkAbsent(t *testing.T) {
+	// Contract: a spawn connector that omits [capabilities.network]
+	// gets no HTTPS_PROXY injection. The subprocess will have no
+	// network path at all (the platform sandbox denies all egress).
+	fake := &fakeExecutor{result: SpawnResult{ExitCode: 0}}
+	m := goodSpawnManifest()
+	state := &hostState{
+		spawnPolicy:   NewSpawnPolicy(m),
+		spawnExecutor: fake,
+		connectorFQN:  "github://aileron-test/x",
+		policy:        NewHostPolicy(m), // no [capabilities.network]
+	}
+	ctx := ctxWithState(context.Background(), state)
+	envBytes := mustJSON(SpawnEnvelope{Program: "/usr/bin/git", Argv: []string{"git", "status"}})
+	if rc := processSpawn(ctx, state, envBytes); rc != 0 {
+		t.Fatalf("processSpawn rc=%d err=%v", rc, state.spawnErr)
+	}
+	if _, ok := fake.gotEnv.Env["HTTPS_PROXY"]; ok {
+		t.Errorf("HTTPS_PROXY injected despite no [capabilities.network]")
+	}
+	if _, ok := fake.gotEnv.Env["HTTP_PROXY"]; ok {
+		t.Errorf("HTTP_PROXY injected despite no [capabilities.network]")
+	}
+}
+
 func TestSpawnPolicy_PassesResolvedLimitsToExecutor(t *testing.T) {
 	// Contract: processSpawn supplies the executor with the limits
 	// derived from the connector's manifest (or defaults when absent).


### PR DESCRIPTION
## Summary

Builds the daemon-mediated CONNECT proxy ADR-0014 commits to (in #715) for spawn-connector outbound network. This is the implementation half of #619's network-confinement decision.

- **`internal/sandbox/proxy.go`** — per-invocation HTTP CONNECT proxy. Reads the CONNECT line, checks the target against the connector's `[capabilities.network]` allowlist via `HostPolicy.CheckHostPort` (new method, mirrors `CheckURL`), tunnels TLS bytes on a match or returns `403 Forbidden` on a miss. The allowlist match logic lives in one place: `HostPolicy`, reused from the WASM HTTP gate.
- **`processSpawn` wire-in** — when the connector manifest carries `[capabilities.network]`, the runtime stands up the proxy on host loopback before invoking the executor, injects `HTTPS_PROXY` and `HTTP_PROXY` into the subprocess's env (post-`CheckSpawn` so the connector author doesn't have to declare them in `env_passthrough`), and tears the proxy down after `Spawn` returns.
- **`spawn_network` audit event** — one row per CONNECT request: connector identity, requested host:port, decision (allow / deny), deny class (`capability_denied`, `upstream_unreachable`, `method_not_allowed`, `malformed_request`). Same `audit.AttrPolicyDecision` shape spawn invocations already use.
- **CONNECT, not MITM** — proxy sees host:port and tunneled bytes but never request URLs, headers, or bodies. No CA cert install in the subprocess's trust store. Audit granularity is per CONNECT per host:port. Trade-off documented in ADR-0014.

Tests cover the contract end-to-end: tunneled-allowed-host, denied-disallowed-host (with audit assertion), non-CONNECT method rejected, upstream-unreachable returns 502, Close-stops-Serve idempotent. Plus two integration tests asserting the wire-in injects `HTTPS_PROXY` when network is declared and does not inject when it's absent.

Coverage on `internal/sandbox`: 83.8%.

## Test plan

- [x] `TestSpawnProxy_TunnelsAllowedHost` — CONNECT to allowlisted host returns 200, bytes echo back through the tunnel
- [x] `TestSpawnProxy_DeniesDisallowedHost` — CONNECT to non-allowlisted host returns 403, audit emits `capability_denied`, no upstream dial
- [x] `TestSpawnProxy_RejectsNonConnectMethod` — plain `GET` through the proxy returns 405
- [x] `TestSpawnProxy_BadGatewayOnUpstreamFailure` — allowlisted host with unreachable upstream returns 502, audit emits `upstream_unreachable`
- [x] `TestSpawnProxy_CloseStopsServing` — Close unblocks Serve, idempotent
- [x] `TestSpawn_HostFunctions_InjectsProxyEnvWhenNetworkDeclared` — runtime sets `HTTPS_PROXY=http://127.0.0.1:<port>` on the executor's env when manifest has `[capabilities.network]`
- [x] `TestSpawn_HostFunctions_NoProxyEnvWhenNetworkAbsent` — no `HTTPS_PROXY` injection when manifest omits network
- [x] Race-detector run: green
- [x] Full `./...` test sweep: green

## Out of scope, follow-up

- **Linux UDS proxy + in-namespace TCP-to-UDS shim.** ADR-0014's "Network confinement" section commits to UDS + shim on Linux for the privilege-free path. Implementing it requires the broader Linux platform sandbox (`applyPlatformSandbox` namespace setup) to land first so the shim has a context to run in. The proxy binds on TCP loopback on every platform today; on Linux without enforced namespace isolation that's adequate but doesn't deliver kernel-grade egress confinement.
- **Per-platform OS sandbox rule injection.** macOS SBPL `(allow network* (remote tcp "localhost:<port>"))`, Windows WFP allow-loopback, Linux nftables/eBPF. These plug into `applyPlatformSandbox`, which is a no-op in v1. Without them the proxy is "polite" — CLIs that honor `HTTPS_PROXY` route through it, CLIs that ignore it can still egress directly. Tracked under the broader v3 platform-sandbox follow-up.
- **`aileron cli add`** — the BYOCLI command + introspector that exercises this proxy end-to-end. Tracked in #580.

The current state is honest: the proxy is the right abstraction and the wire-in works. Kernel-level enforcement of "only loopback to proxy" lands when the platform sandboxes do.