### PR TITLE
feat(sandbox): implement macOS spawn sandbox via sandbox-exec + SBPL

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -105,6 +105,46 @@ jobs:
         with:
           token: ${{ secrets.CODECOV_TOKEN }}
 
+  test-macos:
+    # Targeted macOS job: exercises the platform-specific spawn
+    # sandbox added in #721. The darwin-tagged code in
+    # internal/sandbox/spawn_sandbox_darwin.go generates the SBPL
+    # profile and shells out to /usr/bin/sandbox-exec, which only
+    # exists on macOS. The full test suite still runs on
+    # ubuntu-latest above; this job adds CI coverage for the
+    # //go:build darwin files that ubuntu-latest skips entirely.
+    #
+    # Scope is intentionally narrow to internal/sandbox/...: the
+    # darwin-tagged surface lives there, and broadening would
+    # double Codecov upload time without catching anything the
+    # ubuntu job doesn't already see.
+    name: Unit Tests (macOS)
+    runs-on: macos-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: internal/go.mod
+
+      - name: Run platform-specific sandbox tests
+        shell: bash
+        run: |
+          set -e
+          (cd internal && go test -race -coverprofile=coverage-darwin-internal.txt ./sandbox/...)
+
+      - name: Upload coverage reports to Codecov
+        uses: codecov/codecov-action@v6
+        with:
+          token: ${{ secrets.CODECOV_TOKEN }}
+          slug: ALRubinger/aileron
+          files: internal/coverage-darwin-internal.txt
+          # Merge with the Linux unit-test flag so codecov reports a
+          # single, combined "unit" coverage; macOS uploads add the
+          # *_darwin.go files that Linux runs cannot measure.
+          flags: unit
+
   test-windows:
     # Targeted Windows job: exercises the platform-specific lock and
     # process-detach primitives added for Windows support (#574) —

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,6 +128,20 @@ jobs:
           go-version: "1.26"
           cache-dependency-path: internal/go.mod
 
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build forwarder WASM
+        # The sandbox/forwarder tests load the embedded spawn-forwarder
+        # WASM bytes; without this build step those tests fail with
+        # "invalid magic number". The ubuntu Unit Tests job gets this
+        # automatically via `task test:go:ci`'s deps; this job runs a
+        # narrower target so it has to build the dep itself.
+        run: task build:forwarder
+
       - name: Run platform-specific sandbox tests
         shell: bash
         run: |

--- a/internal/sandbox/spawn.go
+++ b/internal/sandbox/spawn.go
@@ -83,11 +83,17 @@ type SpawnPolicy struct {
 	stderrCap int64
 }
 
-// SpawnLimits carries the runtime-decided byte caps applied to a
-// single spawn invocation's captured output. The runtime resolves
-// these from the manifest (per [cstore.ManifestSpawnLimits]) and
-// passes them to the [SpawnExecutor]; connectors do not control
-// their own caps.
+// SpawnLimits carries the runtime-decided per-invocation parameters
+// the executor needs in addition to the connector-supplied envelope.
+// Originally just byte caps for captured output, the struct now
+// carries the resolved filesystem scopes and proxy endpoint the
+// platform sandbox uses to construct its per-OS confinement
+// (per ADR-0014's "Network confinement: daemon-mediated proxy" and
+// the per-platform sandbox sections).
+//
+// The runtime resolves every field from the manifest plus
+// per-spawn state (proxy port) before calling the executor.
+// Connectors never set these directly.
 type SpawnLimits struct {
 	// MaxStdoutBytes caps the bytes the executor returns in
 	// [SpawnResult.Stdout]. Output past this point is dropped and
@@ -99,6 +105,35 @@ type SpawnLimits struct {
 	// [SpawnResult.Stderr]. Same truncation semantics as
 	// MaxStdoutBytes.
 	MaxStderrBytes int64
+
+	// FSRead is the manifest's declared read-scope (per
+	// [cstore.ManifestSpawn.FSRead]). The platform sandbox
+	// translates these into kernel-enforced filesystem confinement
+	// (Linux Landlock + mount namespace, macOS SBPL `file-read*`
+	// rules, Windows ACL adjustments).
+	FSRead []string
+
+	// FSWrite is the manifest's declared write-scope (per
+	// [cstore.ManifestSpawn.FSWrite]). Same role as FSRead but
+	// for writes.
+	FSWrite []string
+
+	// ProxyAddr is the per-invocation proxy endpoint the platform
+	// sandbox permits loopback access to. Empty when the connector
+	// did not declare `[capabilities.network]`; in that case the
+	// platform sandbox denies all network. Format is `host:port`,
+	// typically `127.0.0.1:<ephemeral>`.
+	ProxyAddr string
+}
+
+// PlatformSandboxRequested reports whether the manifest carried any
+// platform-sandbox-relevant declaration (FS scope, network proxy).
+// Used by each platform's [applyPlatformSandbox] to decide whether
+// to engage the OS-level confinement. A zero-value SpawnLimits
+// (legacy spawn with no manifest scopes) returns false so tests and
+// pre-sandbox callers keep running unchanged.
+func (l SpawnLimits) PlatformSandboxRequested() bool {
+	return len(l.FSRead) > 0 || len(l.FSWrite) > 0 || l.ProxyAddr != ""
 }
 
 // StdoutCap returns the resolved stdout byte cap. Always positive
@@ -587,7 +622,7 @@ func (defaultSpawnExecutor) Spawn(ctx context.Context, env SpawnEnvelope, limits
 	if env.Stdin != "" {
 		cmd.Stdin = strings.NewReader(env.Stdin)
 	}
-	if err := applyPlatformSandbox(cmd, env); err != nil {
+	if err := applyPlatformSandbox(cmd, env, limits); err != nil {
 		return SpawnResult{}, err
 	}
 	stdout, stderr, runErr := runCaptured(cmd, limits)
@@ -912,8 +947,9 @@ func processSpawn(ctx context.Context, s *hostState, raw []byte) int32 {
 	// returns. Connectors that omit [capabilities.network] get no
 	// proxy and no HTTPS_PROXY env; the platform sandbox denies all
 	// outbound at the kernel boundary.
+	var proxyAddr string
 	if s.policy != nil && len(s.policy.AllowedHosts()) > 0 {
-		proxy, proxyAddr, proxyClose, err := startSpawnProxy(ctx, s.policy, s.logger, s.connectorFQN)
+		proxy, addr, proxyClose, err := startSpawnProxy(ctx, s.policy, s.logger, s.connectorFQN)
 		if err != nil {
 			s.mu.Lock()
 			s.spawnErr = newConnectorRuntimeError(fmt.Sprintf("spawn: start network proxy: %s", err.Error()))
@@ -926,8 +962,9 @@ func processSpawn(ctx context.Context, s *hostState, raw []byte) int32 {
 		if env.Env == nil {
 			env.Env = map[string]string{}
 		}
-		env.Env["HTTPS_PROXY"] = "http://" + proxyAddr
-		env.Env["HTTP_PROXY"] = "http://" + proxyAddr
+		env.Env["HTTPS_PROXY"] = "http://" + addr
+		env.Env["HTTP_PROXY"] = "http://" + addr
+		proxyAddr = addr
 	}
 
 	// Hand to the platform executor. Sandbox unavailability is
@@ -940,6 +977,9 @@ func processSpawn(ctx context.Context, s *hostState, raw []byte) int32 {
 	limits := SpawnLimits{
 		MaxStdoutBytes: s.spawnPolicy.stdoutCap,
 		MaxStderrBytes: s.spawnPolicy.stderrCap,
+		FSRead:         append([]string(nil), s.spawnPolicy.fsRead...),
+		FSWrite:        append([]string(nil), s.spawnPolicy.fsWrite...),
+		ProxyAddr:      proxyAddr,
 	}
 	res, runErr := executor.Spawn(ctx, env, limits)
 	if runErr != nil {

--- a/internal/sandbox/spawn_sandbox.go
+++ b/internal/sandbox/spawn_sandbox.go
@@ -1,29 +1,33 @@
+//go:build !darwin && !linux && !windows
+
 package sandbox
 
 import "os/exec"
 
 // applyPlatformSandbox is the per-OS hook that hardens a prepared
-// os/exec.Cmd before Run. Platform-specific implementations (Linux
-// namespaces + Landlock, macOS sandbox-exec, Windows job objects +
-// restricted token) live in build-tagged files.
+// os/exec.Cmd before Run. The platform-specific implementations
+// (Linux namespaces + Landlock, macOS sandbox-exec, Windows job
+// objects + restricted token) live in build-tagged sibling files.
 //
-// The default v1 implementation in this file is a no-op. The bounded
-// env and cwd that the executor sets on cmd are the structural floor;
-// the platform sandbox layered on top is what enforces filesystem
-// scoping, network denial, and process scoping per ADR-0014. The
-// per-platform tightening is a series of follow-ups that override
-// this default with cmd.SysProcAttr and friends.
+// This fallback implementation runs on platforms ADR-0014 designates
+// as unsupported (BSD, illumos, any non-Linux/macOS/Windows OS).
+// Per ADR-0014's "Graceful unavailability" section, the runtime
+// refuses to spawn rather than spawn unconfined: the function
+// returns [ErrSpawnUnavailable] when the manifest declares any
+// sandbox parameters, which hostSpawn translates into a structured
+// `spawn_sandbox_unavailable` error.
 //
-// On platforms that ADR-0014 designates as unsupported (BSD, illumos,
-// any non-Linux/macOS/Windows OS), the platform-specific override
-// returns ErrSpawnUnavailable so hostSpawn translates that into a
-// spawn_sandbox_unavailable error.
-//
-// Unit tests substitute SpawnExecutor wholesale via WithSpawnExecutor
-// so the hook is not in the test path. It is the production runtime's
-// extension point.
-func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope) error {
+// A manifest that declares no FS scopes, no network, and no proxy
+// address (`limits` zero-value) gets the legacy no-op behavior so
+// pre-sandbox connectors continue to function for tests and
+// internal smoke checks. Production BYOCLI connectors always
+// declare at least an FS scope and therefore land in the
+// unavailable path on these OSes.
+func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) error {
 	_ = cmd
 	_ = env
+	if limits.PlatformSandboxRequested() {
+		return ErrSpawnUnavailable
+	}
 	return nil
 }

--- a/internal/sandbox/spawn_sandbox_darwin.go
+++ b/internal/sandbox/spawn_sandbox_darwin.go
@@ -1,0 +1,176 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+// sandboxExecPath is the macOS-bundled binary the runtime invokes
+// to apply a generated SBPL profile to a subprocess. Per
+// [ADR-0014]'s macOS section, `sandbox-exec` is Apple's
+// long-deprecated-but-still-shipped tool for applying ad-hoc
+// sandbox profiles to arbitrary commands; the deprecation has been
+// in place for years without removal and the binary remains the
+// only documented mechanism that does not require code-signing
+// entitlements.
+//
+// [ADR-0014]: https://docs.withaileron.ai/adr/0014-spawn-sandbox-technology
+const sandboxExecPath = "/usr/bin/sandbox-exec"
+
+// applyPlatformSandbox wraps `cmd` so it executes under a
+// `sandbox-exec` profile generated from the connector manifest's
+// declared scopes plus the runtime-decided proxy endpoint.
+//
+// The Sandbox Profile Language (SBPL) string is passed inline via
+// `-p` to avoid the per-invocation tempfile lifecycle issues
+// `-f` would impose. SBPL is documented at a basic level in
+// Apple's `man sandbox-exec(1)` and `man sandbox(7)`; the runtime's
+// generator uses the small subset of forms ADR-0014 commits to.
+//
+// Returns [ErrSpawnUnavailable] when `sandbox-exec` is missing
+// (impossible on a healthy macOS install but the runtime fails
+// closed rather than spawn unconfined). Returns nil with no
+// modification to `cmd` when no manifest sandbox parameters were
+// declared (legacy path; pre-BYOCLI connectors continue to run
+// unchanged).
+func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) error {
+	if !limits.PlatformSandboxRequested() {
+		return nil
+	}
+	if _, err := os.Stat(sandboxExecPath); err != nil {
+		return fmt.Errorf("%w: sandbox-exec not present at %s", ErrSpawnUnavailable, sandboxExecPath)
+	}
+
+	profile := buildSBPLProfile(env, limits)
+
+	// Rewire cmd so the kernel exec's sandbox-exec, which in turn
+	// applies the profile and exec's the wrapped program. cmd.Args
+	// must include sandbox-exec's argv[0] plus its flags plus the
+	// wrapped program and its arguments.
+	origPath := cmd.Path
+	origArgs := cmd.Args
+	cmd.Path = sandboxExecPath
+	cmd.Args = append([]string{"sandbox-exec", "-p", profile, origPath}, origArgs[1:]...)
+	return nil
+}
+
+// buildSBPLProfile renders the SBPL profile for a single spawn
+// invocation. The shape follows the macOS App Sandbox pattern:
+// permissive baseline so arbitrary Mach-O binaries can start (a
+// strict `(deny default)` requires opting back in to dozens of
+// private Apple operations like `mach-bootstrap`, `syscall*`,
+// `file-map-executable` for every framework, and is brittle across
+// macOS versions), then surgical denies on the operations that
+// carry the BYOCLI threat model:
+//
+//   - **File reads under user-private paths.** `/Users`, `/Volumes`,
+//     and user-scoped `/private/var/folders` are denied by default;
+//     the manifest's `fs_read` scopes re-allow specific subtrees.
+//     This is the load-bearing defense against user-secret
+//     exfiltration (`~/.ssh`, `~/.aws`, browser profiles).
+//   - **File writes anywhere.** Denied by default; the manifest's
+//     `fs_write` scopes re-allow specific subtrees, plus `/dev/null`
+//     and the sandbox-exec-managed temp area.
+//   - **Network egress.** Denied wholesale; when the connector
+//     declared `[capabilities.network]` a single allow rule names
+//     the daemon's proxy endpoint on loopback (per ADR-0014's
+//     "Network confinement: daemon-mediated proxy").
+//
+// Reads of `/etc`, `/opt`, `/usr/local`, and other system paths
+// outside `/Users` and `/Volumes` are allowed by the permissive
+// baseline. This matches the BYOCLI threat model (which targets
+// user-secret exfiltration, not OS-file reads) and aligns with
+// what `brew install`-style CLIs already see when run bare from
+// the shell. A future tightening can move toward `(deny default)`
+// with explicit allows once the system-essentials set has been
+// empirically validated across macOS releases.
+//
+// The profile is regenerated per spawn invocation because the
+// proxy port is ephemeral. Concurrent spawns from the same
+// connector each get their own port and profile.
+func buildSBPLProfile(env SpawnEnvelope, limits SpawnLimits) string {
+	var b strings.Builder
+	b.WriteString("(version 1)\n")
+	b.WriteString("(allow default)\n")
+
+	// File-write: deny everywhere; re-allow the manifest scope plus
+	// platform-essential write destinations.
+	b.WriteString("(deny file-write*)\n")
+	b.WriteString("(allow file-write* (literal \"/dev/null\"))\n")
+	// sandbox-exec stages internal state in /private/var/folders; the
+	// wrapped process needs write access for its own ephemeral
+	// scratch space (Foundation/NSTemporaryDirectory uses this tree).
+	b.WriteString("(allow file-write* (subpath \"/private/var/folders\"))\n")
+	for _, p := range limits.FSWrite {
+		writeSBPLPathRule(&b, "file-write*", p)
+	}
+
+	// File-read: deny user-private paths; re-allow manifest scopes.
+	// /Users and /Volumes are the load-bearing denies; everything
+	// else stays permissive per the comment above.
+	b.WriteString("(deny file-read* (subpath \"/Users\"))\n")
+	b.WriteString("(deny file-read* (subpath \"/Volumes\"))\n")
+	for _, p := range limits.FSRead {
+		writeSBPLPathRule(&b, "file-read*", p)
+	}
+
+	// Network: deny outbound; re-allow the proxy endpoint when set.
+	b.WriteString("(deny network*)\n")
+	if limits.ProxyAddr != "" {
+		fmt.Fprintf(&b, "(allow network* (remote tcp %s))\n", sbplQuote(limits.ProxyAddr))
+	}
+
+	// Record the wrapped program in the profile as a comment so
+	// post-hoc inspection of a generated profile names the
+	// connector's intended binary. Not a rule; SBPL ignores `;` to
+	// end of line.
+	fmt.Fprintf(&b, "; wrapped program: %s\n", env.Program)
+
+	return b.String()
+}
+
+// writeSBPLPathRule emits a single `file-read*` or `file-write*`
+// allow rule for a manifest-declared path. Trailing-slash paths
+// become `subpath` rules (entire directory tree); slashless paths
+// become `literal` rules (exact file match). `~/`-anchored paths
+// are expanded to the user's home directory before emission since
+// SBPL has no shell-style expansion.
+func writeSBPLPathRule(b *strings.Builder, op, manifestPath string) {
+	expanded, err := expandTilde(manifestPath)
+	if err != nil {
+		// expandTilde only fails when os.UserHomeDir errors, which
+		// on macOS is essentially never. Skip the rule rather than
+		// emit a broken one; the spawn will fail at first access
+		// inside the scope.
+		return
+	}
+	if strings.HasSuffix(expanded, "/") {
+		fmt.Fprintf(b, "(allow %s (subpath %s))\n", op, sbplQuote(strings.TrimRight(expanded, "/")))
+		return
+	}
+	fmt.Fprintf(b, "(allow %s (literal %s))\n", op, sbplQuote(expanded))
+}
+
+// sbplQuote returns an SBPL string literal: a double-quoted form
+// with backslashes and double-quotes escaped. SBPL has no other
+// metacharacters inside string literals.
+func sbplQuote(s string) string {
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '\\':
+			b.WriteString(`\\`)
+		case '"':
+			b.WriteString(`\"`)
+		default:
+			b.WriteRune(r)
+		}
+	}
+	b.WriteByte('"')
+	return b.String()
+}

--- a/internal/sandbox/spawn_sandbox_darwin_test.go
+++ b/internal/sandbox/spawn_sandbox_darwin_test.go
@@ -1,0 +1,290 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"context"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// Each test below cites the ADR-0014 clause or the macOS SBPL
+// property it enforces so refactors that preserve the contract
+// leave the test green.
+
+func TestApplyPlatformSandbox_Darwin_NoOpWhenNoParamsDeclared(t *testing.T) {
+	// Contract (ADR-0014 graceful unavailability + legacy compat):
+	// when the manifest declares nothing platform-sandbox-relevant
+	// the function returns nil and leaves cmd untouched. This
+	// preserves the executor's pre-sandbox behavior for tests that
+	// don't exercise the sandbox.
+	cmd := exec.CommandContext(context.Background(), "/bin/echo", "hello")
+	origPath := cmd.Path
+	origArgs := append([]string(nil), cmd.Args...)
+
+	if err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/echo"}, SpawnLimits{}); err != nil {
+		t.Fatalf("expected nil with empty limits, got %v", err)
+	}
+	if cmd.Path != origPath {
+		t.Errorf("cmd.Path mutated: %q -> %q", origPath, cmd.Path)
+	}
+	if !sliceEq(cmd.Args, origArgs) {
+		t.Errorf("cmd.Args mutated: %v -> %v", origArgs, cmd.Args)
+	}
+}
+
+func TestApplyPlatformSandbox_Darwin_WrapsCmdWhenParamsDeclared(t *testing.T) {
+	// Contract: when the manifest declares scopes, cmd is rewired
+	// so the kernel exec's sandbox-exec, which applies the profile
+	// and exec's the wrapped program.
+	cmd := exec.CommandContext(context.Background(), "/bin/echo", "hello")
+	limits := SpawnLimits{FSRead: []string{"~/code/"}}
+	if err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/echo"}, limits); err != nil {
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	if cmd.Path != sandboxExecPath {
+		t.Errorf("cmd.Path = %q, want %q", cmd.Path, sandboxExecPath)
+	}
+	if len(cmd.Args) < 4 {
+		t.Fatalf("cmd.Args too short: %v", cmd.Args)
+	}
+	if cmd.Args[0] != "sandbox-exec" {
+		t.Errorf("argv[0] = %q, want sandbox-exec", cmd.Args[0])
+	}
+	if cmd.Args[1] != "-p" {
+		t.Errorf("argv[1] = %q, want -p", cmd.Args[1])
+	}
+	// Profile is argv[2]; wrapped program is argv[3]; wrapped argv
+	// tail is argv[4..]
+	if cmd.Args[3] != "/bin/echo" {
+		t.Errorf("wrapped program = %q, want /bin/echo", cmd.Args[3])
+	}
+	if cmd.Args[4] != "hello" {
+		t.Errorf("wrapped arg = %q, want hello", cmd.Args[4])
+	}
+}
+
+func TestBuildSBPLProfile_HasPermissiveBaselineWithUserDenies(t *testing.T) {
+	// Contract: per the BYOCLI threat model in ADR-0014's macOS
+	// section, the profile uses an `(allow default)` baseline plus
+	// surgical denies on user-private paths and writes. The wrapped
+	// program name appears as a trailing comment for post-hoc
+	// inspection.
+	env := SpawnEnvelope{Program: "/usr/bin/git"}
+	profile := buildSBPLProfile(env, SpawnLimits{FSRead: []string{"~/code/"}})
+	mustContain(t, profile,
+		"(version 1)",
+		"(allow default)",
+		"(deny file-write*)",
+		`(deny file-read* (subpath "/Users"))`,
+		`(deny file-read* (subpath "/Volumes"))`,
+		"(deny network*)",
+		"; wrapped program: /usr/bin/git",
+	)
+}
+
+func TestBuildSBPLProfile_TranslatesFSScopes(t *testing.T) {
+	// Contract: trailing-slash manifest paths become subpath rules;
+	// slashless paths become literal rules. Tilde expands to the
+	// home directory at profile-generation time. Manifest scopes
+	// appear AFTER the user-path denies so the SBPL evaluator
+	// reinstates allow for the specific subtree.
+	limits := SpawnLimits{
+		FSRead:  []string{"~/code/", "/etc/passwd", "/private/etc/", "/usr/local/share/data.json"},
+		FSWrite: []string{"~/.cache/aileron/"},
+	}
+	profile := buildSBPLProfile(SpawnEnvelope{Program: "/usr/bin/git"}, limits)
+	mustContain(t, profile,
+		`(allow file-read* (literal "/etc/passwd"))`,
+		`(allow file-read* (subpath "/private/etc"))`,
+		`(allow file-read* (literal "/usr/local/share/data.json"))`,
+	)
+	if !strings.Contains(profile, "file-write*") {
+		t.Errorf("profile missing file-write* rule: %s", profile)
+	}
+
+	// Manifest read scopes must appear after the /Users deny so the
+	// rule ordering reinstates the allow for the specific subtree.
+	idxDeny := strings.Index(profile, `(deny file-read* (subpath "/Users"))`)
+	// We don't know the user's home directory in this test
+	// environment, so we just check that *some* manifest-scope
+	// re-allow appears after the /Users deny.
+	idxAllow := strings.Index(profile[idxDeny:], `(allow file-read* `)
+	if idxAllow < 0 {
+		t.Errorf("expected at least one (allow file-read* ...) after the /Users deny:\n%s", profile)
+	}
+}
+
+func TestBuildSBPLProfile_NetworkDeniedByDefaultButProxyAllowed(t *testing.T) {
+	// Contract (ADR-0014 network confinement): without a proxy
+	// address, network is denied wholesale; with one, exactly one
+	// allow rule names the proxy endpoint.
+	env := SpawnEnvelope{Program: "/usr/bin/git"}
+
+	noNet := buildSBPLProfile(env, SpawnLimits{FSRead: []string{"~/code/"}})
+	if !strings.Contains(noNet, "(deny network*)") {
+		t.Errorf("no-network profile missing deny network*: %s", noNet)
+	}
+	if strings.Contains(noNet, "(allow network*") {
+		t.Errorf("no-network profile unexpectedly allows network: %s", noNet)
+	}
+
+	withNet := buildSBPLProfile(env, SpawnLimits{
+		FSRead:    []string{"~/code/"},
+		ProxyAddr: "127.0.0.1:54321",
+	})
+	mustContain(t, withNet,
+		"(deny network*)",
+		`(allow network* (remote tcp "127.0.0.1:54321"))`,
+	)
+}
+
+func TestApplyPlatformSandbox_Darwin_RunsRealBinaryUnderSandbox(t *testing.T) {
+	// End-to-end smoke: /bin/echo runs under the generated profile,
+	// the sandbox permits the system essentials, the wrapped binary
+	// exits 0 and produces its expected output. Asserts that the
+	// system-essentials read set is wide enough for at least a
+	// trivial Mach-O binary.
+	cmd := exec.CommandContext(context.Background(), "/bin/echo", "sandboxed")
+	limits := SpawnLimits{FSRead: []string{"~/code/"}}
+	if err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/echo"}, limits); err != nil {
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("sandboxed /bin/echo failed: %v (cmd=%v)", err, cmd.Args)
+	}
+	if !strings.Contains(string(out), "sandboxed") {
+		t.Errorf("output = %q, want to contain 'sandboxed'", string(out))
+	}
+}
+
+func TestApplyPlatformSandbox_Darwin_BlocksUserHomeReadOutsideScope(t *testing.T) {
+	// Contract (BYOCLI threat model): a binary spawned under a
+	// profile whose fs_read does not cover a path under /Users
+	// cannot read that path. The kernel sandbox kext rejects the
+	// open, the binary errors. This is the load-bearing defense
+	// against user-secret exfiltration. /bin/cat is a small Mach-O
+	// to use as a probe.
+	//
+	// Write a sentinel file outside the manifest's scope, then
+	// declare an fs_read that does not cover it, then run cat on
+	// it and expect failure.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	allowedDir := filepath.Join(home, "aileron-sandbox-test-allowed")
+	deniedDir := filepath.Join(home, "aileron-sandbox-test-denied")
+	if err := os.MkdirAll(allowedDir, 0o755); err != nil {
+		t.Fatalf("mkdir allowed: %v", err)
+	}
+	if err := os.MkdirAll(deniedDir, 0o755); err != nil {
+		t.Fatalf("mkdir denied: %v", err)
+	}
+	defer os.RemoveAll(allowedDir)
+	defer os.RemoveAll(deniedDir)
+	sentinel := filepath.Join(deniedDir, "secret.txt")
+	if err := os.WriteFile(sentinel, []byte("don't read me"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "/bin/cat", sentinel)
+	limits := SpawnLimits{FSRead: []string{allowedDir + "/"}}
+	if err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/cat"}, limits); err != nil {
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Fatalf("expected /bin/cat to fail reading %s under sandbox; succeeded with output %q",
+			sentinel, string(out))
+	}
+	// On macOS the sandbox kext makes the read fail with EPERM,
+	// which cat reports and exits non-zero. The exact exit code
+	// and stderr shape are not part of the contract, only the
+	// non-zero exit.
+	var exitErr *exec.ExitError
+	if !errors.As(runErr, &exitErr) {
+		t.Fatalf("expected exec.ExitError, got %v", runErr)
+	}
+	if exitErr.ExitCode() == 0 {
+		t.Errorf("expected non-zero exit, got %d", exitErr.ExitCode())
+	}
+}
+
+func TestApplyPlatformSandbox_Darwin_AllowsUserHomeReadInsideScope(t *testing.T) {
+	// Contract (complement of the above): a path under /Users that
+	// IS within the declared fs_read scope is readable. The kernel
+	// permits the open and cat succeeds.
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	allowedDir := filepath.Join(home, "aileron-sandbox-test-allowed-read")
+	if err := os.MkdirAll(allowedDir, 0o755); err != nil {
+		t.Fatalf("mkdir allowed: %v", err)
+	}
+	defer os.RemoveAll(allowedDir)
+	sentinel := filepath.Join(allowedDir, "data.txt")
+	if err := os.WriteFile(sentinel, []byte("hello-from-sandbox"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "/bin/cat", sentinel)
+	limits := SpawnLimits{FSRead: []string{allowedDir + "/"}}
+	if err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/cat"}, limits); err != nil {
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("sandboxed cat failed inside declared scope: %v", err)
+	}
+	if !strings.Contains(string(out), "hello-from-sandbox") {
+		t.Errorf("output = %q, want to contain sentinel", string(out))
+	}
+}
+
+func TestSBPLQuote_EscapesSpecialChars(t *testing.T) {
+	// Contract: backslash and double-quote are escaped; everything
+	// else passes through unchanged.
+	cases := []struct {
+		in, want string
+	}{
+		{`/usr/bin/git`, `"/usr/bin/git"`},
+		{`/path with spaces`, `"/path with spaces"`},
+		{`/has"quote`, `"/has\"quote"`},
+		{`/has\backslash`, `"/has\\backslash"`},
+	}
+	for _, tc := range cases {
+		if got := sbplQuote(tc.in); got != tc.want {
+			t.Errorf("sbplQuote(%q) = %q, want %q", tc.in, got, tc.want)
+		}
+	}
+}
+
+// --- helpers ---
+
+func mustContain(t *testing.T, haystack string, needles ...string) {
+	t.Helper()
+	for _, n := range needles {
+		if !strings.Contains(haystack, n) {
+			t.Errorf("expected substring %q in:\n%s", n, haystack)
+		}
+	}
+}
+
+func sliceEq(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sandbox/spawn_sandbox_linux.go
+++ b/internal/sandbox/spawn_sandbox_linux.go
@@ -1,0 +1,32 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// applyPlatformSandbox is the Linux placeholder until the
+// namespace + Landlock implementation lands (tracked under
+// the platform-sandbox umbrella; see [ADR-0014]'s Linux
+// section and the in-namespace TCP-to-UDS shim in
+// [spawn_shim.go]).
+//
+// Per ADR-0014's "Graceful unavailability" principle, the
+// runtime refuses to spawn rather than spawn unconfined.
+// When the manifest declares any sandbox parameters the
+// function returns [ErrSpawnUnavailable]; legacy callers
+// that pass an empty SpawnLimits get the existing no-op
+// behavior so pre-sandbox connectors and tests keep
+// working.
+//
+// [ADR-0014]: https://docs.withaileron.ai/adr/0014-spawn-sandbox-technology
+func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) error {
+	_ = cmd
+	_ = env
+	if limits.PlatformSandboxRequested() {
+		return fmt.Errorf("%w: Linux platform sandbox not yet implemented (see ADR-0014)", ErrSpawnUnavailable)
+	}
+	return nil
+}

--- a/internal/sandbox/spawn_sandbox_windows.go
+++ b/internal/sandbox/spawn_sandbox_windows.go
@@ -1,0 +1,31 @@
+//go:build windows
+
+package sandbox
+
+import (
+	"fmt"
+	"os/exec"
+)
+
+// applyPlatformSandbox is the Windows placeholder until the
+// job-object + restricted-token + WFP implementation lands
+// (tracked under the platform-sandbox umbrella; see
+// [ADR-0014]'s Windows section).
+//
+// Per ADR-0014's "Graceful unavailability" principle, the
+// runtime refuses to spawn rather than spawn unconfined.
+// When the manifest declares any sandbox parameters the
+// function returns [ErrSpawnUnavailable]; legacy callers
+// that pass an empty SpawnLimits get the existing no-op
+// behavior so pre-sandbox connectors and tests keep
+// working.
+//
+// [ADR-0014]: https://docs.withaileron.ai/adr/0014-spawn-sandbox-technology
+func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) error {
+	_ = cmd
+	_ = env
+	if limits.PlatformSandboxRequested() {
+		return fmt.Errorf("%w: Windows platform sandbox not yet implemented (see ADR-0014)", ErrSpawnUnavailable)
+	}
+	return nil
+}


### PR DESCRIPTION
## Summary

First real platform-sandbox implementation under [#719](https://github.com/ALRubinger/aileron/issues/719). Turns `applyPlatformSandbox` on macOS from a no-op into a kernel-enforced sandbox via `/usr/bin/sandbox-exec` plus a generated Sandbox Profile Language (SBPL) string. The CONNECT proxy ([#716](https://github.com/ALRubinger/aileron/issues/716)) and the spawn primitive's filesystem confinement claim become real on macOS.

### Profile shape

Follows the macOS App Sandbox pattern: permissive `(allow default)` baseline so arbitrary Mach-O binaries can start without per-OS-version SBPL maintenance, then surgical denies on the operations carrying the BYOCLI threat model:

- **File reads under `/Users` and `/Volumes`** denied; manifest `fs_read` scopes re-allow specific subtrees. Load-bearing defense against user-secret exfiltration (`~/.ssh`, `~/.aws`, browser profiles).
- **File writes anywhere** denied; manifest `fs_write` scopes plus `/dev/null` and `/private/var/folders` (where Foundation/`NSTemporaryDirectory` stages scratch) re-allowed.
- **Network egress** denied wholesale; when the connector declared `[capabilities.network]`, a single `(allow network* (remote tcp "127.0.0.1:<proxy-port>"))` rule names the daemon's proxy endpoint.

A `(deny default)` profile is the tighter eventual goal but it would require opting back into dozens of private Apple operations (`mach-bootstrap`, `syscall*`, `file-map-executable` per framework) and is brittle across macOS releases. The permissive baseline is documented as a deliberate v1 choice with a path to tightening in `buildSBPLProfile`'s doc comment.

### Interface changes

- `SpawnLimits` extended with `FSRead`, `FSWrite`, `ProxyAddr` fields populated in `processSpawn` from the resolved `SpawnPolicy` plus the proxy startup. Docstring updated to reflect the broader role (runtime-decided per-spawn parameters, not just byte caps).
- `applyPlatformSandbox(cmd, env, limits)` — new third parameter so platform impls have the manifest's scopes.
- `SpawnLimits.PlatformSandboxRequested()` — the gate every platform impl uses to decide "activate the sandbox?". A zero-value limits keeps the legacy no-op behavior so pre-sandbox tests and callers run unchanged.
- Linux and Windows files are placeholders returning `ErrSpawnUnavailable` when the manifest declares sandbox params, preserving ADR-0014's graceful-unavailability principle until their real impls land.

### End-to-end proof

The integration tests demonstrate the kernel actually enforces the profile, not just that the profile is well-formed:

- `TestApplyPlatformSandbox_Darwin_RunsRealBinaryUnderSandbox` — `/bin/echo` runs cleanly under the sandbox (the permissive baseline is wide enough).
- `TestApplyPlatformSandbox_Darwin_BlocksUserHomeReadOutsideScope` — `/bin/cat` reading a file under `/Users` outside the declared `fs_read` scope fails with non-zero exit. The kernel sandbox kext rejects the open, not the test framework.
- `TestApplyPlatformSandbox_Darwin_AllowsUserHomeReadInsideScope` — `/bin/cat` reading inside the declared scope succeeds. The complement of the above proves the rule re-allow ordering works.

Plus SBPL structure tests, quote-escaping tests, no-op-when-no-params tests, and a cmd-rewiring test.

Coverage on the new file: `applyPlatformSandbox` 90%, `buildSBPLProfile` 100%, `writeSBPLPathRule` 85.7%, `sbplQuote` 100%. Full `internal/sandbox` 85.5%.

## Test plan

- [x] Profile structure (permissive baseline, user denies, write deny, network deny, wrapped-program comment)
- [x] FS scope translation (subpath for trailing slash, literal otherwise, tilde expansion)
- [x] Network rule generation (deny default + proxy allow when set)
- [x] SBPL string quoting (backslash + double-quote escaping)
- [x] Cmd rewiring (sandbox-exec path, argv shape)
- [x] No-op when params not declared
- [x] End-to-end: real binary runs under the sandbox
- [x] End-to-end: kernel blocks user-home read outside scope
- [x] End-to-end: kernel allows user-home read inside scope
- [x] Full `./...` test sweep green; cross-compile clean on linux/windows
- [x] Race-detector run on sandbox: green

## Out of scope, follow-up

- **Linux implementation.** Placeholder returns `ErrSpawnUnavailable` when sandbox params declared. Real impl pairs with the [#718](https://github.com/ALRubinger/aileron/issues/718) shim and lands in a follow-up PR.
- **Windows implementation.** Placeholder pattern same as Linux. Real impl lands in a follow-up PR.
- **`(deny default)` tightening on macOS.** Documented in `buildSBPLProfile`'s comment as the future-direction goal. Requires empirical validation of the system-essentials set across macOS releases.
- **Sandbox-available probe at install time.** [#719](https://github.com/ALRubinger/aileron/issues/719) calls for the probe to run at `aileron action install` and `aileron cli add` time; currently runs only at first spawn. Small follow-up; lands when [#580](https://github.com/ALRubinger/aileron/issues/580) adds the `cli add` command.