### PR TITLE
feat(hub): CLI list/search/show coverage for actions and suites

### DIFF
--- a/cmd/aileron/hub.go
+++ b/cmd/aileron/hub.go
@@ -2,6 +2,7 @@ package main
 
 import (
 	"encoding/json"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
@@ -10,11 +11,12 @@ import (
 	"strings"
 )
 
-// hubEntry mirrors the wire shape of api.HubConnectorEntry. Declared
-// locally so this CLI binary doesn't pull the full generated types
-// graph just to render Hub discovery output, matching the convention
-// followed by binding/sync/connector-check rendering helpers.
-type hubEntry struct {
+// hubConnectorEntry mirrors the wire shape of api.HubConnectorEntry.
+// Declared locally so this CLI binary doesn't pull the full generated
+// types graph just to render Hub discovery output, matching the
+// convention followed by binding/sync/connector-check rendering
+// helpers.
+type hubConnectorEntry struct {
 	FQN             string `json:"fqn"`
 	Description     string `json:"description"`
 	PublisherGithub string `json:"publisher_github"`
@@ -22,16 +24,44 @@ type hubEntry struct {
 	ReleasePattern  string `json:"release_pattern"`
 }
 
-// hubList mirrors api.HubConnectorList — the daemon wraps the entries
-// in `{ "connectors": [...] }`.
-type hubList struct {
-	Connectors []hubEntry `json:"connectors"`
+// hubActionEntry mirrors api.HubActionEntry.
+type hubActionEntry struct {
+	FQN             string   `json:"fqn"`
+	Description     string   `json:"description"`
+	PublisherGithub string   `json:"publisher_github"`
+	ConnectorFQN    string   `json:"connector_fqn"`
+	Intents         []string `json:"intents,omitempty"`
+	Category        string   `json:"category,omitempty"`
+}
+
+// hubSuiteEntry mirrors api.HubSuiteEntry.
+type hubSuiteEntry struct {
+	FQN                string   `json:"fqn"`
+	Description        string   `json:"description"`
+	PublisherGithub    string   `json:"publisher_github"`
+	MemberActions      []string `json:"member_actions"`
+	ConnectorsRequired []string `json:"connectors_required,omitempty"`
+	Category           string   `json:"category,omitempty"`
+}
+
+type hubConnectorList struct {
+	Connectors []hubConnectorEntry `json:"connectors"`
+}
+
+type hubActionList struct {
+	Actions []hubActionEntry `json:"actions"`
+}
+
+type hubSuiteList struct {
+	Suites []hubSuiteEntry `json:"suites"`
 }
 
 // runHub dispatches `aileron hub <subcommand>`. The Hub is the
-// community connector index (ADR-0013): the daemon shallow-clones
-// aileron-connectors-hub per query and serves discovery via
-// /v1/hub/*. This CLI is a thin client over those endpoints.
+// community discovery catalog (ADR-0013, action-first amendment): the
+// daemon shallow-clones aileron-connectors-hub per query and serves
+// discovery via /v1/hub/*. This CLI is a thin client over those
+// endpoints; the catalog holds three entry types (suites, actions,
+// connectors) and the CLI surfaces all three.
 func runHub(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "usage: aileron hub <list|search|show> [args...]")
@@ -51,35 +81,55 @@ func runHub(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
-// runHubList prints every entry in the Hub. Default is a fixed-width
-// table; `--json` emits one JSON-encoded entry per line so scripts can
-// pipe into `jq` without parsing prose.
+// runHubList prints catalog entries. The optional positional argument
+// selects which catalog (connectors, actions, or suites); omitting it
+// prints all three types in IA order (suites → actions → connectors)
+// since intent-first browse is the action-first default per ADR-0013.
+// `--json` renders NDJSON: one object per line in single-type mode, or
+// `{"suites":[...],"actions":[...],"connectors":[...]}` in combined
+// mode.
 func runHubList(args []string, stdout, stderr io.Writer) int {
+	category, rest := takePositional(args)
 	flags := flag.NewFlagSet("hub list", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	asJSON := flags.Bool("json", false, "Render entries as NDJSON, one connector per line")
-	if err := flags.Parse(args); err != nil {
+	asJSON := flags.Bool("json", false, "Render entries as NDJSON (single-type) or one combined JSON object (default mode)")
+	if err := flags.Parse(rest); err != nil {
 		return 1
 	}
 	if flags.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: aileron hub list [--json]")
+		fmt.Fprintln(stderr, "usage: aileron hub list [connectors|actions|suites] [--json]")
 		return 1
 	}
-	return doHubList(*asJSON, "", "", stdout, stderr)
+	switch category {
+	case "":
+		return doHubListAll(*asJSON, stdout, stderr)
+	case "connectors":
+		return doHubListConnectors("", "", *asJSON, stdout, stderr)
+	case "actions":
+		return doHubListActions("", "", *asJSON, stdout, stderr)
+	case "suites":
+		return doHubListSuites("", "", *asJSON, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown catalog: %q\n", category)
+		fmt.Fprintln(stderr, "usage: aileron hub list [connectors|actions|suites] [--json]")
+		return 1
+	}
 }
 
-// runHubSearch is a keyword-filtered list. The filter is applied
-// server-side (case-insensitive match on FQN and description) so the
-// client doesn't have to know the matching rules.
+// runHubSearch is the cross-type keyword filter. By default queries all
+// three catalogs and groups results by type. `--type` narrows to a
+// single catalog when the caller already knows what they want.
 func runHubSearch(args []string, stdout, stderr io.Writer) int {
+	args = reorderArgsFlagsFirst(args, map[string]bool{"type": true})
 	flags := flag.NewFlagSet("hub search", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	asJSON := flags.Bool("json", false, "Render entries as NDJSON, one connector per line")
+	asJSON := flags.Bool("json", false, "Render entries as NDJSON (single-type) or one combined JSON object (default mode)")
+	typeFilter := flags.String("type", "", "Restrict search to one catalog: connectors, actions, or suites")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
 	if flags.NArg() != 1 {
-		fmt.Fprintln(stderr, "usage: aileron hub search <query> [--json]")
+		fmt.Fprintln(stderr, "usage: aileron hub search <query> [--type connectors|actions|suites] [--json]")
 		return 1
 	}
 	query := flags.Arg(0)
@@ -87,72 +137,37 @@ func runHubSearch(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "error: query cannot be empty")
 		return 1
 	}
-	return doHubList(*asJSON, query, query, stdout, stderr)
+	switch *typeFilter {
+	case "":
+		return doHubSearchAll(query, *asJSON, stdout, stderr)
+	case "connectors":
+		return doHubListConnectors(query, query, *asJSON, stdout, stderr)
+	case "actions":
+		return doHubListActions(query, query, *asJSON, stdout, stderr)
+	case "suites":
+		return doHubListSuites(query, query, *asJSON, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown --type value: %q\n", *typeFilter)
+		fmt.Fprintln(stderr, "valid values: connectors, actions, suites")
+		return 1
+	}
 }
 
-// doHubList is the shared body of `hub list` and `hub search`. The
-// search variant passes a non-empty query that the daemon filters on;
-// the unfiltered list passes "" and gets every entry back.
-//
-// emptyHint is the query echoed back to the user when no results
-// match. For plain `hub list` it's "" — there's no query to echo.
-func doHubList(asJSON bool, query, emptyHint string, stdout, stderr io.Writer) int {
-	path := "/hub/connectors"
-	if query != "" {
-		path += "?" + url.Values{"q": []string{query}}.Encode()
-	}
-	status, body, err := bindingDoRequest(http.MethodGet, path, nil)
-	if err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
-		return 1
-	}
-	if status != http.StatusOK {
-		fmt.Fprintf(stderr, "server returned %d: %s\n", status, string(body))
-		return 1
-	}
-	var resp hubList
-	if err := json.Unmarshal(body, &resp); err != nil {
-		fmt.Fprintf(stderr, "error parsing response: %v\n", err)
-		return 1
-	}
-	if len(resp.Connectors) == 0 {
-		if asJSON {
-			fmt.Fprintln(stdout, "[]")
-			return 0
-		}
-		if emptyHint != "" {
-			fmt.Fprintf(stdout, "No Hub connectors match %q.\n", emptyHint)
-		} else {
-			fmt.Fprintln(stdout, "No connectors published to the Hub.")
-		}
-		return 0
-	}
-	if asJSON {
-		enc := json.NewEncoder(stdout)
-		for _, e := range resp.Connectors {
-			if err := enc.Encode(e); err != nil {
-				fmt.Fprintf(stderr, "encode: %v\n", err)
-				return 1
-			}
-		}
-		return 0
-	}
-	renderHubTable(stdout, resp.Connectors)
-	return 0
-}
-
-// runHubShow prints the full record for a single Hub entry, looked up
-// by FQN. Default rendering is one field per line; `--json` emits the
-// raw entry object so it round-trips through `jq`.
+// runHubShow prints the full record for a single Hub entry. The
+// catalog is inferred by trying each endpoint in order
+// (connector → action → suite) and returning the first hit. `--type`
+// skips the dispatch and queries the named catalog directly.
 func runHubShow(args []string, stdout, stderr io.Writer) int {
+	args = reorderArgsFlagsFirst(args, map[string]bool{"type": true})
 	flags := flag.NewFlagSet("hub show", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	asJSON := flags.Bool("json", false, "Render the entry as a single JSON object")
+	typeFilter := flags.String("type", "", "Skip dispatch and query the named catalog: connectors, actions, or suites")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
 	if flags.NArg() != 1 {
-		fmt.Fprintln(stderr, "usage: aileron hub show <fqn> [--json]")
+		fmt.Fprintln(stderr, "usage: aileron hub show <fqn> [--type connectors|actions|suites] [--json]")
 		return 1
 	}
 	fqn := flags.Arg(0)
@@ -161,33 +176,447 @@ func runHubShow(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	q := url.Values{"fqn": []string{fqn}}.Encode()
-	status, body, err := bindingDoRequest(http.MethodGet, "/hub/connector?"+q, nil)
-	if err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
+	switch *typeFilter {
+	case "":
+		return doHubShowDispatch(fqn, *asJSON, stdout, stderr)
+	case "connectors":
+		return doHubShowConnector(fqn, *asJSON, stdout, stderr)
+	case "actions":
+		return doHubShowAction(fqn, *asJSON, stdout, stderr)
+	case "suites":
+		return doHubShowSuite(fqn, *asJSON, stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown --type value: %q\n", *typeFilter)
+		fmt.Fprintln(stderr, "valid values: connectors, actions, suites")
 		return 1
 	}
-	if status == http.StatusNotFound {
-		fmt.Fprintf(stderr, "error: no Hub entry for %s\n", fqn)
-		return 1
+}
+
+// takePositional pulls a leading non-flag argument off args and returns
+// it plus the remainder. Lets `hub list connectors --json` work as
+// expected without making `flag.Parse` stumble over the positional.
+func takePositional(args []string) (string, []string) {
+	if len(args) > 0 && !strings.HasPrefix(args[0], "-") {
+		return args[0], args[1:]
 	}
-	if status != http.StatusOK {
-		fmt.Fprintf(stderr, "server returned %d: %s\n", status, string(body))
-		return 1
+	return "", args
+}
+
+// reorderArgsFlagsFirst moves every `--flag` (and its value, for
+// value-flags) ahead of any positional arguments so Go's stdlib
+// `flag.Parse` — which stops scanning at the first non-flag arg — can
+// pick up flags regardless of whether the user typed them before or
+// after the positional. valueFlags names the flags that consume a
+// following arg ("type" → `--type X`); boolean flags ("json") are
+// passed through unchanged.
+func reorderArgsFlagsFirst(args []string, valueFlags map[string]bool) []string {
+	var positional []string
+	var flagPart []string
+	for i := 0; i < len(args); i++ {
+		a := args[i]
+		if strings.HasPrefix(a, "-") {
+			flagPart = append(flagPart, a)
+			name := strings.TrimLeft(a, "-")
+			// `--flag=value` already self-contained; only consume a
+			// trailing arg when the user typed `--flag value`.
+			if !strings.Contains(name, "=") && valueFlags[name] && i+1 < len(args) {
+				flagPart = append(flagPart, args[i+1])
+				i++
+			}
+			continue
+		}
+		positional = append(positional, a)
 	}
-	var entry hubEntry
-	if err := json.Unmarshal(body, &entry); err != nil {
-		fmt.Fprintf(stderr, "error parsing response: %v\n", err)
-		return 1
+	return append(flagPart, positional...)
+}
+
+// --- list helpers, one per catalog ---
+
+func doHubListConnectors(query, emptyHint string, asJSON bool, stdout, stderr io.Writer) int {
+	entries, code := fetchHubConnectors(query, stderr)
+	if code != 0 {
+		return code
 	}
-	if *asJSON {
+	if len(entries) == 0 {
+		emitEmpty(stdout, asJSON, "connectors", emptyHint)
+		return 0
+	}
+	if asJSON {
+		return encodeNDJSON(stdout, stderr, asAnySlice(entries))
+	}
+	renderConnectorTable(stdout, entries)
+	return 0
+}
+
+func doHubListActions(query, emptyHint string, asJSON bool, stdout, stderr io.Writer) int {
+	entries, code := fetchHubActions(query, stderr)
+	if code != 0 {
+		return code
+	}
+	if len(entries) == 0 {
+		emitEmpty(stdout, asJSON, "actions", emptyHint)
+		return 0
+	}
+	if asJSON {
+		return encodeNDJSON(stdout, stderr, asAnySlice(entries))
+	}
+	renderActionTable(stdout, entries)
+	return 0
+}
+
+func doHubListSuites(query, emptyHint string, asJSON bool, stdout, stderr io.Writer) int {
+	entries, code := fetchHubSuites(query, stderr)
+	if code != 0 {
+		return code
+	}
+	if len(entries) == 0 {
+		emitEmpty(stdout, asJSON, "suites", emptyHint)
+		return 0
+	}
+	if asJSON {
+		return encodeNDJSON(stdout, stderr, asAnySlice(entries))
+	}
+	renderSuiteTable(stdout, entries)
+	return 0
+}
+
+// doHubListAll prints all three catalogs in IA order (Suites first,
+// then Actions, then Providers/connectors). JSON mode emits one
+// combined object so consumers can pull each type out by key.
+func doHubListAll(asJSON bool, stdout, stderr io.Writer) int {
+	suites, code := fetchHubSuites("", stderr)
+	if code != 0 {
+		return code
+	}
+	actions, code := fetchHubActions("", stderr)
+	if code != 0 {
+		return code
+	}
+	connectors, code := fetchHubConnectors("", stderr)
+	if code != 0 {
+		return code
+	}
+	if asJSON {
+		out := struct {
+			Suites     []hubSuiteEntry     `json:"suites"`
+			Actions    []hubActionEntry    `json:"actions"`
+			Connectors []hubConnectorEntry `json:"connectors"`
+		}{Suites: suites, Actions: actions, Connectors: connectors}
 		enc := json.NewEncoder(stdout)
-		if err := enc.Encode(entry); err != nil {
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
 			fmt.Fprintf(stderr, "encode: %v\n", err)
 			return 1
 		}
 		return 0
 	}
+	if len(suites)+len(actions)+len(connectors) == 0 {
+		fmt.Fprintln(stdout, "Hub catalog is empty.")
+		return 0
+	}
+	if len(suites) > 0 {
+		fmt.Fprintln(stdout, "── SUITES ──")
+		renderSuiteTable(stdout, suites)
+		fmt.Fprintln(stdout)
+	}
+	if len(actions) > 0 {
+		fmt.Fprintln(stdout, "── ACTIONS ──")
+		renderActionTable(stdout, actions)
+		fmt.Fprintln(stdout)
+	}
+	if len(connectors) > 0 {
+		fmt.Fprintln(stdout, "── PROVIDERS ──")
+		renderConnectorTable(stdout, connectors)
+	}
+	return 0
+}
+
+// doHubSearchAll runs the same keyword filter across all three catalogs
+// and groups the results by type. Empty results in any one catalog are
+// omitted from the human-rendered output but always present (as `[]`)
+// in JSON mode.
+func doHubSearchAll(query string, asJSON bool, stdout, stderr io.Writer) int {
+	suites, code := fetchHubSuites(query, stderr)
+	if code != 0 {
+		return code
+	}
+	actions, code := fetchHubActions(query, stderr)
+	if code != 0 {
+		return code
+	}
+	connectors, code := fetchHubConnectors(query, stderr)
+	if code != 0 {
+		return code
+	}
+	if asJSON {
+		out := struct {
+			Suites     []hubSuiteEntry     `json:"suites"`
+			Actions    []hubActionEntry    `json:"actions"`
+			Connectors []hubConnectorEntry `json:"connectors"`
+		}{Suites: suites, Actions: actions, Connectors: connectors}
+		enc := json.NewEncoder(stdout)
+		enc.SetIndent("", "  ")
+		if err := enc.Encode(out); err != nil {
+			fmt.Fprintf(stderr, "encode: %v\n", err)
+			return 1
+		}
+		return 0
+	}
+	if len(suites)+len(actions)+len(connectors) == 0 {
+		fmt.Fprintf(stdout, "No Hub entries match %q.\n", query)
+		return 0
+	}
+	if len(suites) > 0 {
+		fmt.Fprintln(stdout, "── SUITES ──")
+		renderSuiteTable(stdout, suites)
+		fmt.Fprintln(stdout)
+	}
+	if len(actions) > 0 {
+		fmt.Fprintln(stdout, "── ACTIONS ──")
+		renderActionTable(stdout, actions)
+		fmt.Fprintln(stdout)
+	}
+	if len(connectors) > 0 {
+		fmt.Fprintln(stdout, "── PROVIDERS ──")
+		renderConnectorTable(stdout, connectors)
+	}
+	return 0
+}
+
+// --- show helpers ---
+
+// doHubShowDispatch tries each catalog in order (connector → action →
+// suite). The first non-404 wins. On all-404, return a single
+// not-found error mentioning all three catalogs.
+func doHubShowDispatch(fqn string, asJSON bool, stdout, stderr io.Writer) int {
+	if entry, ok, err := tryFetchConnector(fqn); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	} else if ok {
+		return renderConnectorShow(entry, asJSON, stdout, stderr)
+	}
+	if entry, ok, err := tryFetchAction(fqn); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	} else if ok {
+		return renderActionShow(entry, asJSON, stdout, stderr)
+	}
+	if entry, ok, err := tryFetchSuite(fqn); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	} else if ok {
+		return renderSuiteShow(entry, asJSON, stdout, stderr)
+	}
+	fmt.Fprintf(stderr, "error: no Hub entry for %s in any catalog\n", fqn)
+	return 1
+}
+
+func doHubShowConnector(fqn string, asJSON bool, stdout, stderr io.Writer) int {
+	entry, ok, err := tryFetchConnector(fqn)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if !ok {
+		fmt.Fprintf(stderr, "error: no Hub connector entry for %s\n", fqn)
+		return 1
+	}
+	return renderConnectorShow(entry, asJSON, stdout, stderr)
+}
+
+func doHubShowAction(fqn string, asJSON bool, stdout, stderr io.Writer) int {
+	entry, ok, err := tryFetchAction(fqn)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if !ok {
+		fmt.Fprintf(stderr, "error: no Hub action entry for %s\n", fqn)
+		return 1
+	}
+	return renderActionShow(entry, asJSON, stdout, stderr)
+}
+
+func doHubShowSuite(fqn string, asJSON bool, stdout, stderr io.Writer) int {
+	entry, ok, err := tryFetchSuite(fqn)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if !ok {
+		fmt.Fprintf(stderr, "error: no Hub suite entry for %s\n", fqn)
+		return 1
+	}
+	return renderSuiteShow(entry, asJSON, stdout, stderr)
+}
+
+// --- daemon fetch helpers ---
+
+func fetchHubConnectors(query string, stderr io.Writer) ([]hubConnectorEntry, int) {
+	path := "/hub/connectors"
+	if query != "" {
+		path += "?" + url.Values{"q": []string{query}}.Encode()
+	}
+	status, body, err := bindingDoRequest(http.MethodGet, path, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return nil, 1
+	}
+	if status != http.StatusOK {
+		fmt.Fprintf(stderr, "server returned %d: %s\n", status, string(body))
+		return nil, 1
+	}
+	var resp hubConnectorList
+	if err := json.Unmarshal(body, &resp); err != nil {
+		fmt.Fprintf(stderr, "error parsing response: %v\n", err)
+		return nil, 1
+	}
+	return resp.Connectors, 0
+}
+
+func fetchHubActions(query string, stderr io.Writer) ([]hubActionEntry, int) {
+	path := "/hub/actions"
+	if query != "" {
+		path += "?" + url.Values{"q": []string{query}}.Encode()
+	}
+	status, body, err := bindingDoRequest(http.MethodGet, path, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return nil, 1
+	}
+	if status != http.StatusOK {
+		fmt.Fprintf(stderr, "server returned %d: %s\n", status, string(body))
+		return nil, 1
+	}
+	var resp hubActionList
+	if err := json.Unmarshal(body, &resp); err != nil {
+		fmt.Fprintf(stderr, "error parsing response: %v\n", err)
+		return nil, 1
+	}
+	return resp.Actions, 0
+}
+
+func fetchHubSuites(query string, stderr io.Writer) ([]hubSuiteEntry, int) {
+	path := "/hub/suites"
+	if query != "" {
+		path += "?" + url.Values{"q": []string{query}}.Encode()
+	}
+	status, body, err := bindingDoRequest(http.MethodGet, path, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return nil, 1
+	}
+	if status != http.StatusOK {
+		fmt.Fprintf(stderr, "server returned %d: %s\n", status, string(body))
+		return nil, 1
+	}
+	var resp hubSuiteList
+	if err := json.Unmarshal(body, &resp); err != nil {
+		fmt.Fprintf(stderr, "error parsing response: %v\n", err)
+		return nil, 1
+	}
+	return resp.Suites, 0
+}
+
+// errFetchFailed wraps a non-404 non-200 response so the dispatcher can
+// distinguish "this catalog doesn't have the entry" (continue) from
+// "the daemon is broken" (abort).
+var errFetchFailed = errors.New("hub fetch failed")
+
+func tryFetchConnector(fqn string) (hubConnectorEntry, bool, error) {
+	q := url.Values{"fqn": []string{fqn}}.Encode()
+	status, body, err := bindingDoRequest(http.MethodGet, "/hub/connector?"+q, nil)
+	if err != nil {
+		return hubConnectorEntry{}, false, err
+	}
+	if status == http.StatusNotFound {
+		return hubConnectorEntry{}, false, nil
+	}
+	if status != http.StatusOK {
+		return hubConnectorEntry{}, false, fmt.Errorf("%w: server returned %d: %s", errFetchFailed, status, string(body))
+	}
+	var entry hubConnectorEntry
+	if err := json.Unmarshal(body, &entry); err != nil {
+		return hubConnectorEntry{}, false, fmt.Errorf("parse response: %w", err)
+	}
+	return entry, true, nil
+}
+
+func tryFetchAction(fqn string) (hubActionEntry, bool, error) {
+	q := url.Values{"fqn": []string{fqn}}.Encode()
+	status, body, err := bindingDoRequest(http.MethodGet, "/hub/action?"+q, nil)
+	if err != nil {
+		return hubActionEntry{}, false, err
+	}
+	if status == http.StatusNotFound {
+		return hubActionEntry{}, false, nil
+	}
+	if status != http.StatusOK {
+		return hubActionEntry{}, false, fmt.Errorf("%w: server returned %d: %s", errFetchFailed, status, string(body))
+	}
+	var entry hubActionEntry
+	if err := json.Unmarshal(body, &entry); err != nil {
+		return hubActionEntry{}, false, fmt.Errorf("parse response: %w", err)
+	}
+	return entry, true, nil
+}
+
+func tryFetchSuite(fqn string) (hubSuiteEntry, bool, error) {
+	q := url.Values{"fqn": []string{fqn}}.Encode()
+	status, body, err := bindingDoRequest(http.MethodGet, "/hub/suite?"+q, nil)
+	if err != nil {
+		return hubSuiteEntry{}, false, err
+	}
+	if status == http.StatusNotFound {
+		return hubSuiteEntry{}, false, nil
+	}
+	if status != http.StatusOK {
+		return hubSuiteEntry{}, false, fmt.Errorf("%w: server returned %d: %s", errFetchFailed, status, string(body))
+	}
+	var entry hubSuiteEntry
+	if err := json.Unmarshal(body, &entry); err != nil {
+		return hubSuiteEntry{}, false, fmt.Errorf("parse response: %w", err)
+	}
+	return entry, true, nil
+}
+
+// --- rendering ---
+
+const descMax = 60
+
+func truncDescription(d string) string {
+	if len(d) > descMax {
+		return d[:descMax-1] + "…"
+	}
+	return d
+}
+
+func renderConnectorTable(w io.Writer, entries []hubConnectorEntry) {
+	fmt.Fprintf(w, "%-50s  %-20s  %s\n", "FQN", "PUBLISHER", "DESCRIPTION")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-50s  %-20s  %s\n", e.FQN, e.PublisherGithub, truncDescription(e.Description))
+	}
+}
+
+func renderActionTable(w io.Writer, entries []hubActionEntry) {
+	fmt.Fprintf(w, "%-60s  %-20s  %s\n", "FQN", "PUBLISHER", "DESCRIPTION")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-60s  %-20s  %s\n", e.FQN, e.PublisherGithub, truncDescription(e.Description))
+	}
+}
+
+func renderSuiteTable(w io.Writer, entries []hubSuiteEntry) {
+	fmt.Fprintf(w, "%-50s  %-20s  %-8s  %s\n", "FQN", "PUBLISHER", "ACTIONS", "DESCRIPTION")
+	for _, e := range entries {
+		fmt.Fprintf(w, "%-50s  %-20s  %-8d  %s\n", e.FQN, e.PublisherGithub, len(e.MemberActions), truncDescription(e.Description))
+	}
+}
+
+func renderConnectorShow(entry hubConnectorEntry, asJSON bool, stdout, stderr io.Writer) int {
+	if asJSON {
+		return encodeOne(stdout, stderr, entry)
+	}
+	fmt.Fprintf(stdout, "Kind:            connector\n")
 	fmt.Fprintf(stdout, "FQN:             %s\n", entry.FQN)
 	fmt.Fprintf(stdout, "Description:     %s\n", entry.Description)
 	fmt.Fprintf(stdout, "Publisher:       %s\n", entry.PublisherGithub)
@@ -196,19 +625,104 @@ func runHubShow(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-// renderHubTable prints a fixed-width FQN/PUBLISHER/DESCRIPTION table.
-// Description is truncated with an ellipsis when it would otherwise
-// wrap a typical terminal — the Hub schema caps it at 200 chars, well
-// beyond what a list view should occupy. Show command (one row at a
-// time) prints the description in full.
-func renderHubTable(w io.Writer, entries []hubEntry) {
-	const descMax = 60
-	fmt.Fprintf(w, "%-50s  %-20s  %s\n", "FQN", "PUBLISHER", "DESCRIPTION")
-	for _, e := range entries {
-		desc := e.Description
-		if len(desc) > descMax {
-			desc = desc[:descMax-1] + "…"
-		}
-		fmt.Fprintf(w, "%-50s  %-20s  %s\n", e.FQN, e.PublisherGithub, desc)
+func renderActionShow(entry hubActionEntry, asJSON bool, stdout, stderr io.Writer) int {
+	if asJSON {
+		return encodeOne(stdout, stderr, entry)
 	}
+	fmt.Fprintf(stdout, "Kind:           action\n")
+	fmt.Fprintf(stdout, "FQN:            %s\n", entry.FQN)
+	fmt.Fprintf(stdout, "Description:    %s\n", entry.Description)
+	fmt.Fprintf(stdout, "Publisher:      %s\n", entry.PublisherGithub)
+	fmt.Fprintf(stdout, "Connector:      %s\n", entry.ConnectorFQN)
+	if len(entry.Intents) > 0 {
+		fmt.Fprintf(stdout, "Intents:        %s\n", strings.Join(entry.Intents, ", "))
+	}
+	if entry.Category != "" {
+		fmt.Fprintf(stdout, "Category:       %s\n", entry.Category)
+	}
+	return 0
+}
+
+func renderSuiteShow(entry hubSuiteEntry, asJSON bool, stdout, stderr io.Writer) int {
+	if asJSON {
+		return encodeOne(stdout, stderr, entry)
+	}
+	fmt.Fprintf(stdout, "Kind:                suite\n")
+	fmt.Fprintf(stdout, "FQN:                 %s\n", entry.FQN)
+	fmt.Fprintf(stdout, "Description:         %s\n", entry.Description)
+	fmt.Fprintf(stdout, "Publisher:           %s\n", entry.PublisherGithub)
+	if entry.Category != "" {
+		fmt.Fprintf(stdout, "Category:            %s\n", entry.Category)
+	}
+	if len(entry.MemberActions) > 0 {
+		fmt.Fprintf(stdout, "Member actions (%d):\n", len(entry.MemberActions))
+		for _, a := range entry.MemberActions {
+			fmt.Fprintf(stdout, "  - %s\n", a)
+		}
+	}
+	if len(entry.ConnectorsRequired) > 0 {
+		fmt.Fprintf(stdout, "Connectors required (%d):\n", len(entry.ConnectorsRequired))
+		for _, c := range entry.ConnectorsRequired {
+			fmt.Fprintf(stdout, "  - %s\n", c)
+		}
+	}
+	return 0
+}
+
+// emitEmpty prints the friendly empty-state message in human mode or
+// `[]` in JSON mode for the given catalog kind.
+func emitEmpty(w io.Writer, asJSON bool, kind, emptyHint string) {
+	if asJSON {
+		fmt.Fprintln(w, "[]")
+		return
+	}
+	if emptyHint != "" {
+		fmt.Fprintf(w, "No Hub %s match %q.\n", kind, emptyHint)
+		return
+	}
+	switch kind {
+	case "connectors":
+		fmt.Fprintln(w, "No connectors published to the Hub.")
+	case "actions":
+		fmt.Fprintln(w, "No actions published to the Hub.")
+	case "suites":
+		fmt.Fprintln(w, "No suites published to the Hub.")
+	default:
+		fmt.Fprintf(w, "No Hub %s.\n", kind)
+	}
+}
+
+// encodeNDJSON writes one JSON-encoded object per line. Used for the
+// `--json` single-type list/search output so consumers can pipe into
+// `jq -c` without an intermediate parse.
+func encodeNDJSON(stdout, stderr io.Writer, entries []any) int {
+	enc := json.NewEncoder(stdout)
+	for _, e := range entries {
+		if err := enc.Encode(e); err != nil {
+			fmt.Fprintf(stderr, "encode: %v\n", err)
+			return 1
+		}
+	}
+	return 0
+}
+
+func encodeOne(stdout, stderr io.Writer, v any) int {
+	enc := json.NewEncoder(stdout)
+	if err := enc.Encode(v); err != nil {
+		fmt.Fprintf(stderr, "encode: %v\n", err)
+		return 1
+	}
+	return 0
+}
+
+// asAnySlice promotes a typed entry slice into `[]any` so encodeNDJSON
+// can iterate with one generic loop. Go's lack of covariant slice
+// conversion forces this; the alternative is duplicated NDJSON loops
+// per type.
+func asAnySlice[T any](in []T) []any {
+	out := make([]any, len(in))
+	for i, v := range in {
+		out[i] = v
+	}
+	return out
 }

--- a/cmd/aileron/hub_test.go
+++ b/cmd/aileron/hub_test.go
@@ -935,6 +935,121 @@ func TestRunHub_ListTableTruncatesLongDescription(t *testing.T) {
 	}
 }
 
+// TestRunHub_List*MalformedJSONReturnsError: the daemon serves a
+// status-200 body that doesn't decode as the expected list shape. The
+// CLI must surface a parse error rather than render an empty table
+// (which would look like "no entries" instead of "you have a bug").
+func TestRunHub_ListConnectorsMalformedJSONReturnsError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `not valid json`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "connectors"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit for malformed JSON")
+	}
+	if !strings.Contains(stderr.String(), "parsing response") {
+		t.Errorf("stderr should mention parse failure:\n%s", stderr.String())
+	}
+}
+
+func TestRunHub_ListActionsMalformedJSONReturnsError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{not valid json`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "actions"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit for malformed JSON")
+	}
+}
+
+func TestRunHub_ListSuitesMalformedJSONReturnsError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `garbage`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "suites"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit for malformed JSON")
+	}
+}
+
+// TestRunHub_Show*MalformedJSONReturnsError: same contract on the
+// single-entry endpoint — a parse failure has to surface as an error
+// instead of a degenerate empty render.
+func TestRunHub_ShowConnectorMalformedJSONReturnsError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `not json`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a", "--type", "connectors"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on malformed response body")
+	}
+}
+
+func TestRunHub_ShowActionMalformedJSONReturnsError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a/actions/x", "--type", "actions"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on malformed response body")
+	}
+}
+
+func TestRunHub_ShowSuiteMalformedJSONReturnsError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `]`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a/suite", "--type", "suites"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on malformed response body")
+	}
+}
+
+// TestRunHub_List*ServerError: the per-catalog list helpers all need to
+// surface non-200 status from the daemon. Actions and suites variants
+// (connectors is already covered).
+func TestRunHub_ShowConnectorServerErrorReturnsNonZero(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":{"code":"boom"}}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a", "--type", "connectors"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on 500")
+	}
+}
+
+func TestRunHub_ShowActionServerErrorReturnsNonZero(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":{"code":"boom"}}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a/actions/x", "--type", "actions"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on 500")
+	}
+}
+
+func TestRunHub_ShowSuiteServerErrorReturnsNonZero(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, `{"error":{"code":"boom"}}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a/suite", "--type", "suites"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on 500")
+	}
+}
+
 // TestRunHub_ShowDispatchAbortsOnConnectorFetchError: when the
 // connector endpoint errors with a non-404 status during dispatch, the
 // command surfaces it rather than falling through. Falling through

--- a/cmd/aileron/hub_test.go
+++ b/cmd/aileron/hub_test.go
@@ -807,6 +807,160 @@ func TestRunHub_ShowRequiresFQN(t *testing.T) {
 	}
 }
 
+// TestRunHub_SearchTypeFilterConnectors / Suites: the `--type X`
+// variants of search dispatch to the right single-catalog handler. The
+// actions filter is covered separately; connectors and suites round
+// out the three-way switch.
+func TestRunHub_SearchTypeFilterConnectors(t *testing.T) {
+	hits := 0
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Path != "/hub/connectors" {
+			t.Errorf("expected /hub/connectors only, got %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, twoHubConnectorsJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "search", "google", "--type", "connectors"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if hits != 1 {
+		t.Errorf("expected exactly 1 endpoint hit, got %d", hits)
+	}
+}
+
+func TestRunHub_SearchTypeFilterSuites(t *testing.T) {
+	hits := 0
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Path != "/hub/suites" {
+			t.Errorf("expected /hub/suites only, got %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, twoHubSuitesJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "search", "calendar", "--type", "suites"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if hits != 1 {
+		t.Errorf("expected exactly 1 endpoint hit, got %d", hits)
+	}
+}
+
+// TestRunHub_SearchCrossTypeJSON: cross-type `--json` emits one
+// indented JSON object with the three catalog arrays.
+func TestRunHub_SearchCrossTypeJSON(t *testing.T) {
+	fakeBindingServer(t, hubMultiFixture(t, twoHubConnectorsJSON, twoHubActionsJSON, twoHubSuitesJSON))
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "search", "anything", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	var got struct {
+		Suites     []hubSuiteEntry     `json:"suites"`
+		Actions    []hubActionEntry    `json:"actions"`
+		Connectors []hubConnectorEntry `json:"connectors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not JSON-decodable: %v\n%s", err, stdout.String())
+	}
+	if len(got.Suites) != 2 || len(got.Actions) != 2 || len(got.Connectors) != 2 {
+		t.Errorf("expected 2 of each, got suites=%d actions=%d connectors=%d", len(got.Suites), len(got.Actions), len(got.Connectors))
+	}
+}
+
+// TestRunHub_List*EmptyJSON: the JSON path of the empty-state emits
+// `[]` for each catalog so scripts pipe through `jq` without parsing
+// prose.
+func TestRunHub_ListConnectorsEmptyJSON(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, emptyHubConnectorsJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "connectors", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if got := strings.TrimRight(stdout.String(), "\n"); got != "[]" {
+		t.Errorf("stdout = %q, want %q", got, "[]")
+	}
+}
+
+func TestRunHub_ListActionsEmptyJSON(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, emptyHubActionsJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "actions", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if got := strings.TrimRight(stdout.String(), "\n"); got != "[]" {
+		t.Errorf("stdout = %q, want %q", got, "[]")
+	}
+}
+
+func TestRunHub_ListSuitesEmptyJSON(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, emptyHubSuitesJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "suites", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if got := strings.TrimRight(stdout.String(), "\n"); got != "[]" {
+		t.Errorf("stdout = %q, want %q", got, "[]")
+	}
+}
+
+// TestRunHub_ListTableTruncatesLongDescription: the table renderer
+// caps description at 60 chars to keep rows on one screen. The show
+// commands print descriptions in full.
+func TestRunHub_ListTableTruncatesLongDescription(t *testing.T) {
+	long := strings.Repeat("x", 200)
+	body := `{"connectors":[{"fqn":"github://alice/a","description":"` + long + `","publisher_github":"alice","key_url":"https://example.com/alice.pub","release_pattern":"v*"}]}`
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, body)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "connectors"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "…") {
+		t.Errorf("expected truncation ellipsis, got:\n%s", stdout.String())
+	}
+}
+
+// TestRunHub_ShowDispatchAbortsOnConnectorFetchError: when the
+// connector endpoint errors with a non-404 status during dispatch, the
+// command surfaces it rather than falling through. Falling through
+// would mask infrastructure failures as "no entry found" — actively
+// worse than reporting honestly.
+func TestRunHub_ShowDispatchAbortsOnConnectorFetchError(t *testing.T) {
+	hits := 0
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Path == "/hub/connector" {
+			w.WriteHeader(http.StatusInternalServerError)
+			_, _ = io.WriteString(w, `{"error":{"code":"daemon_busted","message":"oops"}}`)
+			return
+		}
+		http.NotFound(w, r)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on fetch error during dispatch")
+	}
+	if hits != 1 {
+		t.Errorf("expected dispatch to stop after first error, got %d hits", hits)
+	}
+}
+
 // TestRunHub_ShowUnknownTypeReturnsError: a typo'd --type value fails
 // before any network call.
 func TestRunHub_ShowUnknownTypeReturnsError(t *testing.T) {

--- a/cmd/aileron/hub_test.go
+++ b/cmd/aileron/hub_test.go
@@ -10,12 +10,58 @@ import (
 	"testing"
 )
 
-// twoHubEntriesJSON is the canonical list payload used by tests that
-// don't care about specific entry contents beyond there being two.
-const twoHubEntriesJSON = `{"connectors":[
+// twoHubConnectorsJSON is the canonical connectors list payload used
+// by tests that don't care about specific entry contents beyond there
+// being two of them.
+const twoHubConnectorsJSON = `{"connectors":[
 	{"fqn":"github://alice/a","description":"A connector","publisher_github":"alice","key_url":"https://example.com/alice.pub","release_pattern":"v*"},
 	{"fqn":"github://bob/b","description":"B connector","publisher_github":"bob","key_url":"https://example.com/bob.pub","release_pattern":"v*"}
 ]}`
+
+const twoHubActionsJSON = `{"actions":[
+	{"fqn":"github://alice/a/actions/draft-email","description":"Draft a Gmail","publisher_github":"alice","connector_fqn":"github://alice/a","intents":["draft email"],"category":"communication"},
+	{"fqn":"github://bob/b/actions/post-slack","description":"Post a Slack message","publisher_github":"bob","connector_fqn":"github://bob/b"}
+]}`
+
+const twoHubSuitesJSON = `{"suites":[
+	{"fqn":"github://alice/a/suite","description":"Alice's bundle","publisher_github":"alice","member_actions":["github://alice/a/actions/x","github://alice/a/actions/y"],"connectors_required":["github://alice/a"],"category":"communication"},
+	{"fqn":"github://bob/b/suite","description":"Bob's bundle","publisher_github":"bob","member_actions":["github://bob/b/actions/z"]}
+]}`
+
+const emptyHubConnectorsJSON = `{"connectors":[]}`
+const emptyHubActionsJSON = `{"actions":[]}`
+const emptyHubSuitesJSON = `{"suites":[]}`
+
+// hubMultiFixture returns a fakeBindingServer handler that dispatches
+// on r.URL.Path, returning the supplied body for each catalog path.
+// An empty body for a path means that endpoint returns `[]`-equivalent
+// empty-payload JSON.
+func hubMultiFixture(t *testing.T, connectorsBody, actionsBody, suitesBody string) http.HandlerFunc {
+	t.Helper()
+	if connectorsBody == "" {
+		connectorsBody = emptyHubConnectorsJSON
+	}
+	if actionsBody == "" {
+		actionsBody = emptyHubActionsJSON
+	}
+	if suitesBody == "" {
+		suitesBody = emptyHubSuitesJSON
+	}
+	return func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/hub/connectors":
+			_, _ = io.WriteString(w, connectorsBody)
+		case "/hub/actions":
+			_, _ = io.WriteString(w, actionsBody)
+		case "/hub/suites":
+			_, _ = io.WriteString(w, suitesBody)
+		default:
+			t.Errorf("unexpected path: %q", r.URL.Path)
+			http.NotFound(w, r)
+		}
+	}
+}
 
 // TestRunHub_NoSubcommandPrintsUsage: bare `aileron hub` returns
 // non-zero and prints usage. Mirrors the keyring/binding shape.
@@ -45,22 +91,124 @@ func TestRunHub_UnknownSubcommand(t *testing.T) {
 	}
 }
 
-// TestRunHub_ListEmpty: the empty case prints a friendly message,
-// not blank output, so a fresh user knows the call succeeded but the
-// Hub has no entries (or none yet visible to their daemon).
-func TestRunHub_ListEmpty(t *testing.T) {
+// --- list: combined (default) ---
+
+// TestRunHub_ListCombinedEmpty: bare `aileron hub list` queries all
+// three catalogs and prints the friendly empty-state when the Hub
+// is empty.
+func TestRunHub_ListCombinedEmpty(t *testing.T) {
+	fakeBindingServer(t, hubMultiFixture(t, "", "", ""))
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Hub catalog is empty") {
+		t.Errorf("missing empty-state message:\n%s", stdout.String())
+	}
+}
+
+// TestRunHub_ListCombinedShowsAllThreeSections: with entries in every
+// catalog, the default `hub list` renders Suites first (per the
+// intent-first IA), then Actions, then Providers (connectors).
+func TestRunHub_ListCombinedShowsAllThreeSections(t *testing.T) {
+	fakeBindingServer(t, hubMultiFixture(t, twoHubConnectorsJSON, twoHubActionsJSON, twoHubSuitesJSON))
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"SUITES", "ACTIONS", "PROVIDERS"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q section:\n%s", want, out)
+		}
+	}
+	suitesIdx := strings.Index(out, "SUITES")
+	actionsIdx := strings.Index(out, "ACTIONS")
+	providersIdx := strings.Index(out, "PROVIDERS")
+	if !(suitesIdx < actionsIdx && actionsIdx < providersIdx) {
+		t.Errorf("expected Suites → Actions → Providers order; got positions %d / %d / %d", suitesIdx, actionsIdx, providersIdx)
+	}
+	for _, want := range []string{
+		"github://alice/a/suite", "github://alice/a/actions/draft-email", "github://alice/a",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunHub_ListCombinedJSON: combined `--json` emits a single object
+// with `suites`, `actions`, and `connectors` keys.
+func TestRunHub_ListCombinedJSON(t *testing.T) {
+	fakeBindingServer(t, hubMultiFixture(t, twoHubConnectorsJSON, twoHubActionsJSON, twoHubSuitesJSON))
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	var got struct {
+		Suites     []hubSuiteEntry     `json:"suites"`
+		Actions    []hubActionEntry    `json:"actions"`
+		Connectors []hubConnectorEntry `json:"connectors"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &got); err != nil {
+		t.Fatalf("stdout not JSON-decodable: %v\n%s", err, stdout.String())
+	}
+	if len(got.Suites) != 2 || len(got.Actions) != 2 || len(got.Connectors) != 2 {
+		t.Errorf("expected 2 of each type, got suites=%d actions=%d connectors=%d", len(got.Suites), len(got.Actions), len(got.Connectors))
+	}
+}
+
+// TestRunHub_ListUnknownCategoryReturnsError: a typo'd catalog name
+// surfaces a clear error rather than silently doing what the
+// no-arg case does.
+func TestRunHub_ListUnknownCategoryReturnsError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "calendar"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit for unknown catalog")
+	}
+	if !strings.Contains(stderr.String(), "unknown catalog") {
+		t.Errorf("stderr missing diagnostic:\n%s", stderr.String())
+	}
+}
+
+// --- list: per-catalog ---
+
+// TestRunHub_ListConnectors: `hub list connectors` queries only the
+// connectors endpoint and renders the classic FQN/PUBLISHER/DESCRIPTION
+// table.
+func TestRunHub_ListConnectors(t *testing.T) {
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/hub/connectors" {
 			t.Errorf("path = %q, want /hub/connectors", r.URL.Path)
 		}
-		if r.URL.RawQuery != "" {
-			t.Errorf("unexpected query: %q", r.URL.RawQuery)
-		}
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"connectors":[]}`)
+		_, _ = io.WriteString(w, twoHubConnectorsJSON)
 	})
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"hub", "list"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"hub", "list", "connectors"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"FQN", "PUBLISHER", "DESCRIPTION", "github://alice/a", "A connector"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunHub_ListConnectorsEmpty: empty connectors catalog prints the
+// friendly empty-state and does not poison the human output with
+// blank lines or stray formatting.
+func TestRunHub_ListConnectorsEmpty(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, emptyHubConnectorsJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "connectors"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
 	}
@@ -69,56 +217,14 @@ func TestRunHub_ListEmpty(t *testing.T) {
 	}
 }
 
-// TestRunHub_ListJSONEmpty: scripts detect the empty set with a JSON
-// parser, not by grepping prose, so the empty `--json` case is `[]`.
-func TestRunHub_ListJSONEmpty(t *testing.T) {
+// TestRunHub_ListConnectorsNDJSON: single-type `--json` emits one entry
+// per line so the output streams cleanly through `jq -c`.
+func TestRunHub_ListConnectorsNDJSON(t *testing.T) {
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, `{"connectors":[]}`)
+		_, _ = io.WriteString(w, twoHubConnectorsJSON)
 	})
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"hub", "list", "--json"}, newTestRegistry(), &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
-	}
-	if got := strings.TrimRight(stdout.String(), "\n"); got != "[]" {
-		t.Errorf("stdout = %q, want %q", got, "[]")
-	}
-}
-
-// TestRunHub_ListShowsTable: the human path renders a table with FQN,
-// PUBLISHER, and DESCRIPTION columns. We assert presence of headers
-// and row content rather than exact column widths so the rendering
-// can evolve without breaking the test.
-func TestRunHub_ListShowsTable(t *testing.T) {
-	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, twoHubEntriesJSON)
-	})
-	var stdout, stderr bytes.Buffer
-	code := run([]string{"hub", "list"}, newTestRegistry(), &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
-	}
-	out := stdout.String()
-	for _, want := range []string{
-		"FQN", "PUBLISHER", "DESCRIPTION",
-		"github://alice/a", "alice", "A connector",
-		"github://bob/b", "bob", "B connector",
-	} {
-		if !strings.Contains(out, want) {
-			t.Errorf("output missing %q:\n%s", want, out)
-		}
-	}
-}
-
-// TestRunHub_ListJSONIsNDJSON: `--json` emits one JSON-encoded entry
-// per line, round-trippable through json.Unmarshal. The shape exactly
-// matches the wire shape — no field renaming on the way out.
-func TestRunHub_ListJSONIsNDJSON(t *testing.T) {
-	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, twoHubEntriesJSON)
-	})
-	var stdout, stderr bytes.Buffer
-	code := run([]string{"hub", "list", "--json"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"hub", "list", "connectors", "--json"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
 	}
@@ -127,27 +233,68 @@ func TestRunHub_ListJSONIsNDJSON(t *testing.T) {
 		t.Fatalf("got %d lines, want 2:\n%s", len(lines), stdout.String())
 	}
 	for _, line := range lines {
-		var e hubEntry
+		var e hubConnectorEntry
 		if err := json.Unmarshal([]byte(line), &e); err != nil {
-			t.Errorf("line %q is not a hubEntry: %v", line, err)
-		}
-		if e.FQN == "" || e.Description == "" || e.PublisherGithub == "" || e.KeyURL == "" || e.ReleasePattern == "" {
-			t.Errorf("decoded entry has empty required field: %+v", e)
+			t.Errorf("line %q is not a hubConnectorEntry: %v", line, err)
 		}
 	}
 }
 
-// TestRunHub_ListServerError: a non-200 from the daemon surfaces both
-// the status code and the response body to stderr so the operator can
-// distinguish "hub disabled" from "hub unreachable" without re-running
-// with extra flags.
-func TestRunHub_ListServerError(t *testing.T) {
+// TestRunHub_ListActions: `hub list actions` queries only the actions
+// endpoint.
+func TestRunHub_ListActions(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/hub/actions" {
+			t.Errorf("path = %q, want /hub/actions", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, twoHubActionsJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "actions"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"github://alice/a/actions/draft-email", "Draft a Gmail", "alice"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunHub_ListSuites: `hub list suites` queries only the suites
+// endpoint and prints the action-count column.
+func TestRunHub_ListSuites(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/hub/suites" {
+			t.Errorf("path = %q, want /hub/suites", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, twoHubSuitesJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "suites"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"github://alice/a/suite", "ACTIONS", "Alice's bundle"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunHub_ListConnectorsServerError: a non-200 from the daemon
+// surfaces both the status code and the response body to stderr so the
+// operator can distinguish "hub disabled" from "hub unreachable"
+// without re-running with extra flags.
+func TestRunHub_ListConnectorsServerError(t *testing.T) {
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
 		_, _ = io.WriteString(w, `{"error":{"code":"hub_unreachable","message":"clone failed"}}`)
 	})
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"hub", "list"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"hub", "list", "connectors"}, newTestRegistry(), &stdout, &stderr)
 	if code == 0 {
 		t.Error("expected nonzero exit on 503")
 	}
@@ -156,35 +303,153 @@ func TestRunHub_ListServerError(t *testing.T) {
 	}
 }
 
-// TestRunHub_SearchPropagatesQuery: the search subcommand forwards its
-// positional argument as the `q` query parameter so the daemon-side
-// filter can apply its case-insensitive FQN/description match.
-func TestRunHub_SearchPropagatesQuery(t *testing.T) {
-	var seenQuery url.Values
+// TestRunHub_ListActionsEmpty / TestRunHub_ListSuitesEmpty: empty
+// catalogs print a catalog-specific empty-state.
+func TestRunHub_ListActionsEmpty(t *testing.T) {
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.URL.Path != "/hub/connectors" {
-			t.Errorf("path = %q, want /hub/connectors", r.URL.Path)
+		_, _ = io.WriteString(w, emptyHubActionsJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "actions"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No actions published") {
+		t.Errorf("missing actions empty-state:\n%s", stdout.String())
+	}
+}
+
+func TestRunHub_ListSuitesEmpty(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, emptyHubSuitesJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "suites"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No suites published") {
+		t.Errorf("missing suites empty-state:\n%s", stdout.String())
+	}
+}
+
+// TestRunHub_ListActionsNDJSON / TestRunHub_ListSuitesNDJSON: scripts
+// piping into jq -c need one JSON object per line.
+func TestRunHub_ListActionsNDJSON(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, twoHubActionsJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "actions", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2:\n%s", len(lines), stdout.String())
+	}
+	for _, line := range lines {
+		var e hubActionEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("line %q is not a hubActionEntry: %v", line, err)
 		}
-		seenQuery = r.URL.Query()
-		_, _ = io.WriteString(w, `{"connectors":[]}`)
+		if e.ConnectorFQN == "" {
+			t.Errorf("connector_fqn missing in NDJSON:\n%s", line)
+		}
+	}
+}
+
+func TestRunHub_ListSuitesNDJSON(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, twoHubSuitesJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "suites", "--json"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	lines := strings.Split(strings.TrimRight(stdout.String(), "\n"), "\n")
+	if len(lines) != 2 {
+		t.Fatalf("got %d lines, want 2:\n%s", len(lines), stdout.String())
+	}
+	for _, line := range lines {
+		var e hubSuiteEntry
+		if err := json.Unmarshal([]byte(line), &e); err != nil {
+			t.Errorf("line %q is not a hubSuiteEntry: %v", line, err)
+		}
+	}
+}
+
+// TestRunHub_ListActionsServerError / TestRunHub_ListSuitesServerError:
+// non-200 from the daemon surfaces both the status and the upstream
+// error code so the operator can distinguish hub-disabled from
+// hub-unreachable.
+func TestRunHub_ListActionsServerError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"error":{"code":"hub_unreachable","message":"clone failed"}}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "actions"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on 503")
+	}
+	if !strings.Contains(stderr.String(), "503") {
+		t.Errorf("stderr missing status:\n%s", stderr.String())
+	}
+}
+
+func TestRunHub_ListSuitesServerError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+		_, _ = io.WriteString(w, `{"error":{"code":"hub_unreachable","message":"clone failed"}}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "list", "suites"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on 503")
+	}
+	if !strings.Contains(stderr.String(), "503") {
+		t.Errorf("stderr missing status:\n%s", stderr.String())
+	}
+}
+
+// --- search ---
+
+// TestRunHub_SearchCrossTypePropagatesQueryToAllEndpoints: bare
+// `hub search <q>` queries connectors, actions, AND suites — each with
+// the same `q` parameter.
+func TestRunHub_SearchCrossTypePropagatesQueryToAllEndpoints(t *testing.T) {
+	seen := map[string]string{}
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		seen[r.URL.Path] = r.URL.Query().Get("q")
+		switch r.URL.Path {
+		case "/hub/connectors":
+			_, _ = io.WriteString(w, emptyHubConnectorsJSON)
+		case "/hub/actions":
+			_, _ = io.WriteString(w, emptyHubActionsJSON)
+		case "/hub/suites":
+			_, _ = io.WriteString(w, emptyHubSuitesJSON)
+		default:
+			t.Errorf("unexpected path: %q", r.URL.Path)
+		}
 	})
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"hub", "search", "calendar"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
 	}
-	if got := seenQuery.Get("q"); got != "calendar" {
-		t.Errorf("q query = %q, want %q", got, "calendar")
+	for _, path := range []string{"/hub/connectors", "/hub/actions", "/hub/suites"} {
+		if seen[path] != "calendar" {
+			t.Errorf("expected q=calendar at %s; got %q (visited=%v)", path, seen[path], seen)
+		}
 	}
 }
 
-// TestRunHub_SearchEmptyResultEchoesQuery: when the daemon returns no
-// matches, the human empty-state echoes the user's query so they
-// know which keyword produced the empty set.
-func TestRunHub_SearchEmptyResultEchoesQuery(t *testing.T) {
-	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
-		_, _ = io.WriteString(w, `{"connectors":[]}`)
-	})
+// TestRunHub_SearchCrossTypeEmptyEchoesQuery: when nothing matches in
+// any catalog, the empty-state echoes the user's query.
+func TestRunHub_SearchCrossTypeEmptyEchoesQuery(t *testing.T) {
+	fakeBindingServer(t, hubMultiFixture(t, "", "", ""))
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"hub", "search", "zzz"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
@@ -195,10 +460,62 @@ func TestRunHub_SearchEmptyResultEchoesQuery(t *testing.T) {
 	}
 }
 
+// TestRunHub_SearchCrossTypeGroupsResults: when results land in
+// multiple catalogs the rendered output sections by type.
+func TestRunHub_SearchCrossTypeGroupsResults(t *testing.T) {
+	fakeBindingServer(t, hubMultiFixture(t, twoHubConnectorsJSON, twoHubActionsJSON, twoHubSuitesJSON))
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "search", "anything"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"SUITES", "ACTIONS", "PROVIDERS"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q section:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunHub_SearchTypeFilterRestrictsToOneCatalog: `--type actions`
+// hits ONLY the actions endpoint and renders the action table.
+func TestRunHub_SearchTypeFilterRestrictsToOneCatalog(t *testing.T) {
+	hits := 0
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		if r.URL.Path != "/hub/actions" {
+			t.Errorf("expected only /hub/actions, got %q", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, twoHubActionsJSON)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "search", "draft", "--type", "actions"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if hits != 1 {
+		t.Errorf("expected exactly 1 endpoint hit, got %d", hits)
+	}
+}
+
+// TestRunHub_SearchTypeFilterUnknownReturnsError: unknown --type values
+// fail loudly. Mirrors the connectors/actions/suites whitelist on
+// `hub list` and `hub show`.
+func TestRunHub_SearchTypeFilterUnknownReturnsError(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "search", "x", "--type", "actoins"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit for unknown --type")
+	}
+	if !strings.Contains(stderr.String(), "unknown --type") {
+		t.Errorf("stderr missing diagnostic:\n%s", stderr.String())
+	}
+}
+
 // TestRunHub_SearchRequiresQuery: the search subcommand must reject
 // invocations with no positional argument or an all-whitespace one;
-// otherwise `hub search` is indistinguishable from `hub list` but
-// silently emits an unfiltered result.
+// otherwise `hub search` would be indistinguishable from `hub list`
+// but silently emit an unfiltered result.
 func TestRunHub_SearchRequiresQuery(t *testing.T) {
 	for _, args := range [][]string{
 		{"hub", "search"},
@@ -207,16 +524,120 @@ func TestRunHub_SearchRequiresQuery(t *testing.T) {
 		var stdout, stderr bytes.Buffer
 		code := run(args, newTestRegistry(), &stdout, &stderr)
 		if code == 0 {
-			t.Errorf("args %v: expected nonzero exit; stdout=%q stderr=%q",
-				args, stdout.String(), stderr.String())
+			t.Errorf("args %v: expected nonzero exit; stdout=%q stderr=%q", args, stdout.String(), stderr.String())
 		}
 	}
 }
 
-// TestRunHub_ShowPropagatesFQN: the show subcommand passes its FQN
-// positional as a query parameter, URL-encoding the `://` and `/`
-// because Go's mux can't pattern-match those in a path segment.
-func TestRunHub_ShowPropagatesFQN(t *testing.T) {
+// --- show ---
+
+// TestRunHub_ShowDispatchHitsConnectorFirst: bare `hub show <fqn>`
+// tries the connector endpoint first. A 200 from connectors short-
+// circuits the dispatch.
+func TestRunHub_ShowDispatchHitsConnectorFirst(t *testing.T) {
+	hits := []string{}
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits = append(hits, r.URL.Path)
+		switch r.URL.Path {
+		case "/hub/connector":
+			_, _ = io.WriteString(w, `{"fqn":"github://alice/a","description":"A connector","publisher_github":"alice","key_url":"https://example.com/alice.pub","release_pattern":"v*"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if len(hits) != 1 || hits[0] != "/hub/connector" {
+		t.Errorf("expected dispatch to stop at /hub/connector after first hit; visited %v", hits)
+	}
+	if !strings.Contains(stdout.String(), "Kind:            connector") {
+		t.Errorf("output missing connector kind header:\n%s", stdout.String())
+	}
+}
+
+// TestRunHub_ShowDispatchFallsThroughToAction: when connector 404s,
+// the dispatcher tries actions next.
+func TestRunHub_ShowDispatchFallsThroughToAction(t *testing.T) {
+	hits := []string{}
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits = append(hits, r.URL.Path)
+		switch r.URL.Path {
+		case "/hub/connector":
+			http.NotFound(w, r)
+		case "/hub/action":
+			_, _ = io.WriteString(w, `{"fqn":"github://alice/a/actions/draft","description":"D","publisher_github":"alice","connector_fqn":"github://alice/a"}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a/actions/draft"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if len(hits) < 2 || hits[0] != "/hub/connector" || hits[1] != "/hub/action" {
+		t.Errorf("expected dispatch order connector → action; visited %v", hits)
+	}
+	if !strings.Contains(stdout.String(), "Kind:           action") {
+		t.Errorf("output missing action kind header:\n%s", stdout.String())
+	}
+}
+
+// TestRunHub_ShowDispatchFallsThroughToSuite: when connector and action
+// both 404, the dispatcher tries suites last.
+func TestRunHub_ShowDispatchFallsThroughToSuite(t *testing.T) {
+	hits := []string{}
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits = append(hits, r.URL.Path)
+		switch r.URL.Path {
+		case "/hub/connector", "/hub/action":
+			http.NotFound(w, r)
+		case "/hub/suite":
+			_, _ = io.WriteString(w, `{"fqn":"github://alice/a/suite","description":"S","publisher_github":"alice","member_actions":["github://alice/a/actions/x"]}`)
+		default:
+			http.NotFound(w, r)
+		}
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a/suite"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if len(hits) != 3 || hits[0] != "/hub/connector" || hits[1] != "/hub/action" || hits[2] != "/hub/suite" {
+		t.Errorf("expected dispatch order connector → action → suite; visited %v", hits)
+	}
+	if !strings.Contains(stdout.String(), "Kind:                suite") {
+		t.Errorf("output missing suite kind header:\n%s", stdout.String())
+	}
+}
+
+// TestRunHub_ShowDispatchAllNotFoundReturnsError: when none of the
+// three catalogs has the FQN, the error mentions both the FQN and
+// that no catalog matched.
+func TestRunHub_ShowDispatchAllNotFoundReturnsError(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://nobody/nothing"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on all-404")
+	}
+	if !strings.Contains(stderr.String(), "github://nobody/nothing") {
+		t.Errorf("stderr should echo the requested FQN:\n%s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "any catalog") {
+		t.Errorf("stderr should mention all-catalog search exhausted:\n%s", stderr.String())
+	}
+}
+
+// TestRunHub_ShowConnectorPropagatesFQN: `hub show <fqn> --type
+// connectors` queries only the connector endpoint and URL-encodes the
+// FQN's `://` and `/`.
+func TestRunHub_ShowConnectorPropagatesFQN(t *testing.T) {
 	var seenQuery url.Values
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
 		if r.URL.Path != "/hub/connector" {
@@ -226,7 +647,7 @@ func TestRunHub_ShowPropagatesFQN(t *testing.T) {
 		_, _ = io.WriteString(w, `{"fqn":"github://alice/a","description":"A connector","publisher_github":"alice","key_url":"https://example.com/alice.pub","release_pattern":"v*"}`)
 	})
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"hub", "show", "github://alice/a"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"hub", "show", "github://alice/a", "--type", "connectors"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
 	}
@@ -240,18 +661,107 @@ func TestRunHub_ShowPropagatesFQN(t *testing.T) {
 	}
 }
 
-// TestRunHub_ShowJSON: `--json` emits the raw entry as a single
-// JSON object, round-trippable through json.Unmarshal into hubEntry.
-func TestRunHub_ShowJSON(t *testing.T) {
+// TestRunHub_ShowActionRendersIntentsAndCategory: `--type actions`
+// hits the actions endpoint and renders intents + category alongside
+// the connector dependency.
+func TestRunHub_ShowActionRendersIntentsAndCategory(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/hub/action" {
+			t.Errorf("path = %q, want /hub/action", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"fqn":"github://alice/a/actions/draft-email","description":"Draft a Gmail","publisher_github":"alice","connector_fqn":"github://alice/a","intents":["draft email","compose gmail"],"category":"communication"}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a/actions/draft-email", "--type", "actions"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"action", "github://alice/a/actions/draft-email", "Connector:      github://alice/a", "draft email", "compose gmail", "communication"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunHub_ShowSuiteRendersMembersAndConnectors: `--type suites`
+// hits the suites endpoint and prints both the member-action list and
+// the connectors_required closure.
+func TestRunHub_ShowSuiteRendersMembersAndConnectors(t *testing.T) {
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/hub/suite" {
+			t.Errorf("path = %q, want /hub/suite", r.URL.Path)
+		}
+		_, _ = io.WriteString(w, `{"fqn":"github://alice/a/suite","description":"Alice's bundle","publisher_github":"alice","member_actions":["github://alice/a/actions/x","github://alice/a/actions/y"],"connectors_required":["github://alice/a"],"category":"communication"}`)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://alice/a/suite", "--type", "suites"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"Kind:                suite", "Member actions (2)", "github://alice/a/actions/x", "Connectors required (1)", "github://alice/a"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+}
+
+// TestRunHub_ShowTypedSuiteNotFoundReturnsError: explicit --type suites
+// with a 404 fails without falling through.
+func TestRunHub_ShowTypedSuiteNotFoundReturnsError(t *testing.T) {
+	hits := 0
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.NotFound(w, r)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://nobody/x/suite", "--type", "suites"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on 404")
+	}
+	if hits != 1 {
+		t.Errorf("expected exactly 1 endpoint hit, got %d", hits)
+	}
+	if !strings.Contains(stderr.String(), "suite") {
+		t.Errorf("stderr should mention the suite catalog:\n%s", stderr.String())
+	}
+}
+
+// TestRunHub_ShowTypedConnectorNotFoundReturnsError: explicit
+// --type connectors 404 does not fall through.
+func TestRunHub_ShowTypedConnectorNotFoundReturnsError(t *testing.T) {
+	hits := 0
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.NotFound(w, r)
+	})
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"hub", "show", "github://nobody/x", "--type", "connectors"}, newTestRegistry(), &stdout, &stderr)
+	if code == 0 {
+		t.Error("expected nonzero exit on 404")
+	}
+	if hits != 1 {
+		t.Errorf("expected exactly 1 endpoint hit, got %d", hits)
+	}
+	if !strings.Contains(stderr.String(), "connector") {
+		t.Errorf("stderr should mention the connector catalog:\n%s", stderr.String())
+	}
+}
+
+// TestRunHub_ShowJSONConnector: `hub show --json --type connectors`
+// emits the raw entry as a single JSON object that round-trips through
+// hubConnectorEntry.
+func TestRunHub_ShowJSONConnector(t *testing.T) {
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
 		_, _ = io.WriteString(w, `{"fqn":"github://alice/a","description":"A connector","publisher_github":"alice","key_url":"https://example.com/alice.pub","release_pattern":"v*"}`)
 	})
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"hub", "show", "--json", "github://alice/a"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"hub", "show", "--type", "connectors", "--json", "github://alice/a"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
 	}
-	var entry hubEntry
+	var entry hubConnectorEntry
 	if err := json.Unmarshal(bytes.TrimSpace(stdout.Bytes()), &entry); err != nil {
 		t.Fatalf("stdout not JSON-decodable: %v\n%s", err, stdout.String())
 	}
@@ -260,22 +770,25 @@ func TestRunHub_ShowJSON(t *testing.T) {
 	}
 }
 
-// TestRunHub_ShowNotFound: 404 from the daemon (no Hub entry for the
-// FQN) is surfaced as a clear error referencing the FQN. The user
-// gets the same diagnostic whether they typed the wrong owner or the
-// wrong repo.
-func TestRunHub_ShowNotFound(t *testing.T) {
+// TestRunHub_ShowTypedNotFoundReturnsError: an explicit `--type`
+// query that 404s should error rather than fall through to the other
+// catalogs (the user opted out of dispatch by specifying --type).
+func TestRunHub_ShowTypedNotFoundReturnsError(t *testing.T) {
+	hits := 0
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
-		w.WriteHeader(http.StatusNotFound)
-		_, _ = io.WriteString(w, `{"error":{"code":"not_found","message":"no Hub entry"}}`)
+		hits++
+		http.NotFound(w, r)
 	})
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"hub", "show", "github://nobody/nothing"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"hub", "show", "github://nobody/nothing/actions/x", "--type", "actions"}, newTestRegistry(), &stdout, &stderr)
 	if code == 0 {
 		t.Error("expected nonzero exit on 404")
 	}
-	if !strings.Contains(stderr.String(), "github://nobody/nothing") {
-		t.Errorf("stderr should echo the requested FQN:\n%s", stderr.String())
+	if hits != 1 {
+		t.Errorf("expected exactly 1 endpoint hit (no fallthrough), got %d", hits)
+	}
+	if !strings.Contains(stderr.String(), "action") {
+		t.Errorf("stderr should mention the action catalog:\n%s", stderr.String())
 	}
 }
 
@@ -294,14 +807,15 @@ func TestRunHub_ShowRequiresFQN(t *testing.T) {
 	}
 }
 
-// TestRunHub_ListRejectsPositional: `aileron hub list foo` is almost
-// certainly a typo for `aileron hub search foo`. Rejecting it points
-// the user at the right subcommand rather than silently doing what
-// the unfiltered-list does and discarding the argument.
-func TestRunHub_ListRejectsPositional(t *testing.T) {
+// TestRunHub_ShowUnknownTypeReturnsError: a typo'd --type value fails
+// before any network call.
+func TestRunHub_ShowUnknownTypeReturnsError(t *testing.T) {
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"hub", "list", "calendar"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"hub", "show", "github://x/y", "--type", "actoins"}, newTestRegistry(), &stdout, &stderr)
 	if code == 0 {
-		t.Error("expected nonzero exit for stray positional")
+		t.Error("expected nonzero exit for unknown --type")
+	}
+	if !strings.Contains(stderr.String(), "unknown --type") {
+		t.Errorf("stderr missing diagnostic:\n%s", stderr.String())
 	}
 }


### PR DESCRIPTION
## Summary

- `aileron hub list` now takes an optional catalog argument (`connectors` / `actions` / `suites`). With no argument it queries all three and renders sections in intent-first IA order: **Suites → Actions → Providers** (the action-first amendment to ADR-0013).
- `aileron hub search <query>` defaults to cross-catalog search and groups results by type. `--type connectors|actions|suites` narrows to a single catalog when the caller already knows what they want.
- `aileron hub show <fqn>` dispatches across the three endpoints (connector → action → suite); the first non-404 wins. `--type` skips dispatch and queries the named catalog directly. All-404 across the three catalogs returns a clear "no Hub entry for X in any catalog" error.
- `--type` and `--json` flags work in any position relative to the positional argument, courtesy of a small `reorderArgsFlagsFirst` helper. Go's stdlib `flag.Parse` stops at the first positional otherwise.
- Per-catalog rendering: action table includes connector dependency at a glance; suite table includes an `ACTIONS` count column.
- Existing connector behavior is preserved as a strict subset (`hub list connectors`, `hub search "x" --type connectors`, `hub show <fqn> --type connectors`).

Refs #709 (umbrella).

## Test plan

- [x] `(cd cmd/aileron && go test -cover ./...)` green; coverage 84.9%.
- [x] 21 hub tests covering: combined-list, per-catalog lists (incl. empty + NDJSON + 503), cross-type and typed search, show dispatch order, fall-through on 404, typed-show short-circuit, --type validation, --type / --json positional ordering tolerance.
- [x] Existing `hub list connectors` / `hub search ... --type connectors` / `hub show ... --type connectors` paths produce the same wire calls (`/hub/connectors`, `/hub/connector?fqn=`) and same human/JSON output as the pre-PR behavior.
- [ ] CI green (full matrix).