### PR TITLE
feat(sandbox): Linux spawn sandbox v1 — user+mount+PID namespaces

### DIFF
--- a/internal/sandbox/spawn_sandbox_linux.go
+++ b/internal/sandbox/spawn_sandbox_linux.go
@@ -19,8 +19,13 @@ import (
 // `unshare(CLONE_NEWUSER)`, which makes [ADR-0014]'s Linux spawn
 // sandbox unavailable.
 //
+// Declared as a var (not const) so tests can swap it to a tempfile
+// with controlled contents and exercise the disabled-sysctl and
+// IO-error paths that the production kernel won't reproduce on a
+// healthy CI runner.
+//
 // [ADR-0014]: https://docs.withaileron.ai/adr/0014-spawn-sandbox-technology
-const unprivilegedUserNSSysctl = "/proc/sys/kernel/unprivileged_userns_clone"
+var unprivilegedUserNSSysctl = "/proc/sys/kernel/unprivileged_userns_clone"
 
 // applyPlatformSandbox wires the wrapped subprocess to launch in a
 // fresh user + mount + PID namespace, providing process-level

--- a/internal/sandbox/spawn_sandbox_linux.go
+++ b/internal/sandbox/spawn_sandbox_linux.go
@@ -3,30 +3,110 @@
 package sandbox
 
 import (
+	"errors"
 	"fmt"
+	"io/fs"
+	"os"
 	"os/exec"
+	"strings"
+	"syscall"
 )
 
-// applyPlatformSandbox is the Linux placeholder until the
-// namespace + Landlock implementation lands (tracked under
-// the platform-sandbox umbrella; see [ADR-0014]'s Linux
-// section and the in-namespace TCP-to-UDS shim in
-// [spawn_shim.go]).
-//
-// Per ADR-0014's "Graceful unavailability" principle, the
-// runtime refuses to spawn rather than spawn unconfined.
-// When the manifest declares any sandbox parameters the
-// function returns [ErrSpawnUnavailable]; legacy callers
-// that pass an empty SpawnLimits get the existing no-op
-// behavior so pre-sandbox connectors and tests keep
-// working.
+// unprivilegedUserNSSysctl is the kernel knob distros sometimes
+// disable for hardening (notably old Debian / Ubuntu LTS releases
+// and some grsecurity-patched kernels). When set to 0, an
+// unprivileged process cannot create a user namespace via
+// `unshare(CLONE_NEWUSER)`, which makes [ADR-0014]'s Linux spawn
+// sandbox unavailable.
 //
 // [ADR-0014]: https://docs.withaileron.ai/adr/0014-spawn-sandbox-technology
+const unprivilegedUserNSSysctl = "/proc/sys/kernel/unprivileged_userns_clone"
+
+// applyPlatformSandbox wires the wrapped subprocess to launch in a
+// fresh user + mount + PID namespace, providing process-level
+// isolation per ADR-0014's Linux section.
+//
+// Scope of this implementation (Linux v1):
+//
+//   - **User namespace** maps the runtime's UID to UID 0 inside the
+//     namespace; the subprocess cannot escalate to host-root or
+//     affect any other UID's resources.
+//   - **Mount namespace** is created (CLONE_NEWNS) so the
+//     subprocess's future mount operations cannot leak to the host.
+//     The mount tree itself is not rewritten in v1; a follow-up PR
+//     adds pivot_root + bind-mounted fs_read/fs_write scopes for
+//     real kernel-enforced FS confinement (paired with Landlock LSM
+//     on kernels that support it).
+//   - **PID namespace** makes the subprocess PID 1 inside its
+//     namespace; it cannot see or signal host processes.
+//   - **Network namespace is NOT activated in v1** so the
+//     subprocess shares the host's network. The CONNECT proxy
+//     [#716] runs on host loopback, so HTTPS_PROXY injection
+//     works without additional shim plumbing. The trade-off: direct
+//     egress to non-allowlisted hosts is not kernel-enforced. A
+//     follow-up PR adds CLONE_NEWNET plus the in-namespace TCP-to-UDS
+//     shim ([#718]) for kernel-enforced egress confinement.
+//
+// Returns [ErrSpawnUnavailable] when unprivileged user namespaces
+// are disabled at the sysctl level. Returns nil with no
+// modification to `cmd` when no manifest sandbox parameters were
+// declared (legacy path; pre-BYOCLI connectors continue to run
+// unchanged).
 func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) error {
-	_ = cmd
 	_ = env
-	if limits.PlatformSandboxRequested() {
-		return fmt.Errorf("%w: Linux platform sandbox not yet implemented (see ADR-0014)", ErrSpawnUnavailable)
+	if !limits.PlatformSandboxRequested() {
+		return nil
 	}
+	if err := checkLinuxSandboxAvailable(); err != nil {
+		return err
+	}
+
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS | syscall.CLONE_NEWPID
+	cmd.SysProcAttr.UidMappings = []syscall.SysProcIDMap{
+		{ContainerID: 0, HostID: os.Getuid(), Size: 1},
+	}
+	cmd.SysProcAttr.GidMappings = []syscall.SysProcIDMap{
+		{ContainerID: 0, HostID: os.Getgid(), Size: 1},
+	}
+	// GidMappingsEnableSetgroups must be false for an unprivileged
+	// user-namespace clone: writing to /proc/<pid>/setgroups before
+	// the gid_map is the kernel's required permission gate, and
+	// Go's exec package handles this when this flag is false.
+	cmd.SysProcAttr.GidMappingsEnableSetgroups = false
 	return nil
+}
+
+// checkLinuxSandboxAvailable returns ErrSpawnUnavailable when the
+// running kernel disables unprivileged user namespaces. Older
+// kernels that don't expose the sysctl at all are assumed
+// permissive (the namespace API has been GA since 3.8, and the
+// sysctl is a Debian/Ubuntu-ism rather than a kernel default).
+//
+// Returns nil on systems where the spawn primitive can run.
+// Returns ErrSpawnUnavailable with a remediation hint in the
+// error message when the sysctl reports unavailability so the
+// host function emits a structured `spawn_sandbox_unavailable`
+// error with actionable text.
+func checkLinuxSandboxAvailable() error {
+	raw, err := os.ReadFile(unprivilegedUserNSSysctl)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			// Sysctl absent: kernel doesn't expose this knob.
+			// Assume namespaces are available; the clone() will
+			// fail at exec time with EPERM if it isn't.
+			return nil
+		}
+		// Read error other than absence: surface as unavailable
+		// since we cannot determine the state.
+		return fmt.Errorf("%w: could not read %s: %v", ErrSpawnUnavailable, unprivilegedUserNSSysctl, err)
+	}
+	val := strings.TrimSpace(string(raw))
+	if val == "1" {
+		return nil
+	}
+	return fmt.Errorf("%w: unprivileged user namespaces disabled (kernel.unprivileged_userns_clone=%s); enable with `sudo sysctl -w kernel.unprivileged_userns_clone=1`",
+		ErrSpawnUnavailable, val)
 }

--- a/internal/sandbox/spawn_sandbox_linux_test.go
+++ b/internal/sandbox/spawn_sandbox_linux_test.go
@@ -1,0 +1,160 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"strings"
+	"syscall"
+	"testing"
+)
+
+// Each test below cites the ADR-0014 clause or the Linux namespace
+// property it enforces so refactors that preserve the contract
+// leave the test green.
+
+func TestApplyPlatformSandbox_Linux_NoOpWhenNoParamsDeclared(t *testing.T) {
+	// Contract (ADR-0014 graceful unavailability + legacy compat):
+	// when the manifest declares nothing platform-sandbox-relevant
+	// the function returns nil and leaves cmd untouched. This
+	// preserves the executor's pre-sandbox behavior for tests that
+	// don't exercise the sandbox.
+	cmd := exec.CommandContext(context.Background(), "/bin/echo", "hello")
+	if err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/echo"}, SpawnLimits{}); err != nil {
+		t.Fatalf("expected nil with empty limits, got %v", err)
+	}
+	if cmd.SysProcAttr != nil && cmd.SysProcAttr.Cloneflags != 0 {
+		t.Errorf("expected Cloneflags untouched with empty limits, got %#x", cmd.SysProcAttr.Cloneflags)
+	}
+}
+
+func TestApplyPlatformSandbox_Linux_SetsCloneflagsAndIDMappings(t *testing.T) {
+	// Contract: when the manifest declares scopes, the runtime
+	// configures SysProcAttr so the kernel forks into a new
+	// user+mount+PID namespace with the runtime's UID mapped to
+	// 0 inside.
+	cmd := exec.CommandContext(context.Background(), "/bin/echo", "hello")
+	limits := SpawnLimits{FSRead: []string{"~/code/"}}
+	if err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/echo"}, limits); err != nil {
+		// Sandbox-available probe may fail on hardened runners; the
+		// gate test below covers that path.
+		if strings.Contains(err.Error(), "spawn_sandbox_unavailable") || strings.Contains(err.Error(), "unprivileged_userns") {
+			t.Skip("sandbox unavailable on this runner; tested separately")
+		}
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr nil after sandbox setup")
+	}
+	wantFlags := uintptr(syscall.CLONE_NEWUSER | syscall.CLONE_NEWNS | syscall.CLONE_NEWPID)
+	if cmd.SysProcAttr.Cloneflags&wantFlags != wantFlags {
+		t.Errorf("Cloneflags = %#x, want bits %#x set", cmd.SysProcAttr.Cloneflags, wantFlags)
+	}
+	if cmd.SysProcAttr.Cloneflags&syscall.CLONE_NEWNET != 0 {
+		t.Error("CLONE_NEWNET should NOT be set in v1 (HTTPS_PROXY cooperation only; tracked separately)")
+	}
+	if len(cmd.SysProcAttr.UidMappings) != 1 {
+		t.Fatalf("UidMappings = %v, want 1 entry", cmd.SysProcAttr.UidMappings)
+	}
+	m := cmd.SysProcAttr.UidMappings[0]
+	if m.ContainerID != 0 || m.HostID != os.Getuid() || m.Size != 1 {
+		t.Errorf("UidMappings[0] = %+v, want {0, %d, 1}", m, os.Getuid())
+	}
+	if len(cmd.SysProcAttr.GidMappings) != 1 {
+		t.Fatalf("GidMappings = %v, want 1 entry", cmd.SysProcAttr.GidMappings)
+	}
+	gm := cmd.SysProcAttr.GidMappings[0]
+	if gm.ContainerID != 0 || gm.HostID != os.Getgid() || gm.Size != 1 {
+		t.Errorf("GidMappings[0] = %+v, want {0, %d, 1}", gm, os.Getgid())
+	}
+	if cmd.SysProcAttr.GidMappingsEnableSetgroups {
+		t.Error("GidMappingsEnableSetgroups must be false for unprivileged user-namespace clones")
+	}
+}
+
+func TestApplyPlatformSandbox_Linux_RunsRealBinaryUnderSandbox(t *testing.T) {
+	// End-to-end: a wrapped binary boots inside the namespace, sees
+	// its own PID 1 (itself), and exits cleanly. /bin/sh is widely
+	// available; we ask it to print the PID of the only process it
+	// sees, which inside a PID namespace is its own PID 1.
+	if _, err := os.Stat("/bin/sh"); err != nil {
+		t.Skip("/bin/sh not present")
+	}
+	if err := checkLinuxSandboxAvailable(); err != nil {
+		t.Skipf("sandbox unavailable: %v", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", "echo PID=$$")
+	limits := SpawnLimits{FSRead: []string{"~/code/"}}
+	if err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/sh"}, limits); err != nil {
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	var stdout bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stdout
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("sandboxed /bin/sh failed: %v (output: %s)", err, stdout.String())
+	}
+	// Inside the new PID namespace the shell sees itself as PID 1
+	// (or PID 2 if Go's exec inserts an init helper). Either way,
+	// the visible PID should be in the single digits and never
+	// match the actual host PID.
+	out := strings.TrimSpace(stdout.String())
+	if !strings.HasPrefix(out, "PID=") {
+		t.Fatalf("output = %q, want PID=...", out)
+	}
+	visiblePID := strings.TrimPrefix(out, "PID=")
+	// The host PID of this test process is unlikely to be in 1..10.
+	// A successful PID-namespace setup gives the child a small PID.
+	if len(visiblePID) > 2 {
+		t.Errorf("expected small PID (PID-namespaced); got %q", visiblePID)
+	}
+}
+
+func TestApplyPlatformSandbox_Linux_NoSandboxSetupWhenUnavailable(t *testing.T) {
+	// Contract: when the sysctl reports namespaces are unavailable,
+	// applyPlatformSandbox returns ErrSpawnUnavailable and does not
+	// modify cmd. The host function translates the error class into
+	// `spawn_sandbox_unavailable` so the user sees an actionable
+	// message instead of a cryptic clone() failure at runtime.
+	//
+	// We can't toggle the sysctl from a test, so this test only
+	// exercises the path when the sysctl reports `0`. In CI the
+	// sysctl is typically `1`, so the test skips.
+	raw, err := os.ReadFile(unprivilegedUserNSSysctl)
+	if err != nil {
+		t.Skip("sysctl file absent; cannot test unavailable path on this runner")
+	}
+	if strings.TrimSpace(string(raw)) == "1" {
+		t.Skip("unprivileged user namespaces enabled on this runner; cannot test unavailable path")
+	}
+	cmd := exec.CommandContext(context.Background(), "/bin/echo")
+	limits := SpawnLimits{FSRead: []string{"~/code/"}}
+	err = applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/echo"}, limits)
+	if err == nil {
+		t.Fatal("expected ErrSpawnUnavailable on locked-down runner")
+	}
+	if !strings.Contains(err.Error(), "spawn_sandbox_unavailable") &&
+		!strings.Contains(err.Error(), "sandbox unavailable") {
+		t.Errorf("error %v does not mention sandbox unavailability", err)
+	}
+}
+
+func TestCheckLinuxSandboxAvailable_AcceptsEnabled(t *testing.T) {
+	// On the CI ubuntu runner the sysctl is enabled (=1) by default.
+	// When absent or 1, the check returns nil.
+	err := checkLinuxSandboxAvailable()
+	// Either nil (sysctl enabled or absent) or a sandbox-unavailable
+	// error is acceptable — we can't control the runner's sysctl
+	// state. We just assert the return shape: either nil or
+	// wraps ErrSpawnUnavailable.
+	if err != nil {
+		if !strings.Contains(err.Error(), "spawn_sandbox_unavailable") &&
+			!strings.Contains(err.Error(), "sandbox unavailable") {
+			t.Errorf("non-nil error does not mention sandbox unavailability: %v", err)
+		}
+	}
+}

--- a/internal/sandbox/spawn_sandbox_linux_test.go
+++ b/internal/sandbox/spawn_sandbox_linux_test.go
@@ -5,8 +5,10 @@ package sandbox
 import (
 	"bytes"
 	"context"
+	"errors"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"strings"
 	"syscall"
 	"testing"
@@ -114,47 +116,105 @@ func TestApplyPlatformSandbox_Linux_RunsRealBinaryUnderSandbox(t *testing.T) {
 	}
 }
 
-func TestApplyPlatformSandbox_Linux_NoSandboxSetupWhenUnavailable(t *testing.T) {
-	// Contract: when the sysctl reports namespaces are unavailable,
-	// applyPlatformSandbox returns ErrSpawnUnavailable and does not
-	// modify cmd. The host function translates the error class into
-	// `spawn_sandbox_unavailable` so the user sees an actionable
-	// message instead of a cryptic clone() failure at runtime.
-	//
-	// We can't toggle the sysctl from a test, so this test only
-	// exercises the path when the sysctl reports `0`. In CI the
-	// sysctl is typically `1`, so the test skips.
-	raw, err := os.ReadFile(unprivilegedUserNSSysctl)
-	if err != nil {
-		t.Skip("sysctl file absent; cannot test unavailable path on this runner")
-	}
-	if strings.TrimSpace(string(raw)) == "1" {
-		t.Skip("unprivileged user namespaces enabled on this runner; cannot test unavailable path")
-	}
-	cmd := exec.CommandContext(context.Background(), "/bin/echo")
-	limits := SpawnLimits{FSRead: []string{"~/code/"}}
-	err = applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/echo"}, limits)
-	if err == nil {
-		t.Fatal("expected ErrSpawnUnavailable on locked-down runner")
-	}
-	if !strings.Contains(err.Error(), "spawn_sandbox_unavailable") &&
-		!strings.Contains(err.Error(), "sandbox unavailable") {
-		t.Errorf("error %v does not mention sandbox unavailability", err)
+func TestCheckLinuxSandboxAvailable_AcceptsEnabled(t *testing.T) {
+	// Contract: sysctl reports "1" → namespaces available, return nil.
+	swapped := withSysctlContent(t, "1\n")
+	defer swapped()
+	if err := checkLinuxSandboxAvailable(); err != nil {
+		t.Errorf("expected nil with sysctl=1, got %v", err)
 	}
 }
 
-func TestCheckLinuxSandboxAvailable_AcceptsEnabled(t *testing.T) {
-	// On the CI ubuntu runner the sysctl is enabled (=1) by default.
-	// When absent or 1, the check returns nil.
-	err := checkLinuxSandboxAvailable()
-	// Either nil (sysctl enabled or absent) or a sandbox-unavailable
-	// error is acceptable — we can't control the runner's sysctl
-	// state. We just assert the return shape: either nil or
-	// wraps ErrSpawnUnavailable.
-	if err != nil {
-		if !strings.Contains(err.Error(), "spawn_sandbox_unavailable") &&
-			!strings.Contains(err.Error(), "sandbox unavailable") {
-			t.Errorf("non-nil error does not mention sandbox unavailability: %v", err)
-		}
+func TestCheckLinuxSandboxAvailable_AcceptsAbsent(t *testing.T) {
+	// Contract: sysctl absent → kernel doesn't expose the knob, assume
+	// permissive. Older kernels predate the knob; the namespace API
+	// has been GA since 3.8.
+	defer swapSysctl(t, "/nonexistent/never-exists-aileron-test")()
+	if err := checkLinuxSandboxAvailable(); err != nil {
+		t.Errorf("expected nil when sysctl absent, got %v", err)
 	}
+}
+
+func TestCheckLinuxSandboxAvailable_RejectsDisabled(t *testing.T) {
+	// Contract: sysctl reports "0" → return ErrSpawnUnavailable with
+	// an actionable remediation hint. The host function translates
+	// the wrapped error into a structured `spawn_sandbox_unavailable`
+	// class so operators see the sysctl name and the fix command.
+	swapped := withSysctlContent(t, "0\n")
+	defer swapped()
+	err := checkLinuxSandboxAvailable()
+	if err == nil {
+		t.Fatal("expected ErrSpawnUnavailable with sysctl=0")
+	}
+	if !errors.Is(err, ErrSpawnUnavailable) {
+		t.Errorf("error does not wrap ErrSpawnUnavailable: %v", err)
+	}
+	if !strings.Contains(err.Error(), "unprivileged_userns_clone") {
+		t.Errorf("error %v does not name the sysctl", err)
+	}
+	if !strings.Contains(err.Error(), "sysctl") {
+		t.Errorf("error %v does not include remediation hint", err)
+	}
+}
+
+func TestCheckLinuxSandboxAvailable_RejectsUnreadable(t *testing.T) {
+	// Contract: any read error other than ErrNotExist (e.g., a
+	// permissions-restricted /proc) is treated as unavailable since
+	// the runtime cannot determine the state. Fail closed.
+	dir := t.TempDir()
+	unreadable := filepath.Join(dir, "unreadable")
+	if err := os.WriteFile(unreadable, []byte("1"), 0o000); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	if os.Getuid() == 0 {
+		t.Skip("running as root; can't simulate read-permission failure")
+	}
+	defer swapSysctl(t, unreadable)()
+	err := checkLinuxSandboxAvailable()
+	if err == nil {
+		t.Fatal("expected ErrSpawnUnavailable for unreadable sysctl")
+	}
+	if !errors.Is(err, ErrSpawnUnavailable) {
+		t.Errorf("error does not wrap ErrSpawnUnavailable: %v", err)
+	}
+}
+
+func TestApplyPlatformSandbox_Linux_ReturnsUnavailableWhenSysctlDisabled(t *testing.T) {
+	// Contract: when the sandbox-available probe rejects, the
+	// function does not touch cmd.SysProcAttr and surfaces the
+	// wrapped ErrSpawnUnavailable. The host function turns this
+	// into `spawn_sandbox_unavailable` for the caller.
+	swapped := withSysctlContent(t, "0\n")
+	defer swapped()
+	cmd := exec.CommandContext(context.Background(), "/bin/echo")
+	limits := SpawnLimits{FSRead: []string{"~/code/"}}
+	err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/echo"}, limits)
+	if !errors.Is(err, ErrSpawnUnavailable) {
+		t.Fatalf("expected wrapped ErrSpawnUnavailable, got %v", err)
+	}
+	if cmd.SysProcAttr != nil && cmd.SysProcAttr.Cloneflags != 0 {
+		t.Errorf("cmd.SysProcAttr.Cloneflags should be untouched, got %#x", cmd.SysProcAttr.Cloneflags)
+	}
+}
+
+// withSysctlContent writes `content` to a tempfile and points
+// unprivilegedUserNSSysctl at it for the duration of the returned
+// cleanup. Use with `defer`.
+func withSysctlContent(t *testing.T, content string) func() {
+	t.Helper()
+	dir := t.TempDir()
+	path := filepath.Join(dir, "sysctl")
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		t.Fatalf("WriteFile: %v", err)
+	}
+	return swapSysctl(t, path)
+}
+
+// swapSysctl points unprivilegedUserNSSysctl at `path` and returns
+// a function that restores the original. Use with `defer`.
+func swapSysctl(t *testing.T, path string) func() {
+	t.Helper()
+	orig := unprivilegedUserNSSysctl
+	unprivilegedUserNSSysctl = path
+	return func() { unprivilegedUserNSSysctl = orig }
 }


### PR DESCRIPTION
## Summary

First Linux platform-sandbox PR under [#719](https://github.com/ALRubinger/aileron/issues/719). Turns `applyPlatformSandbox` on Linux from "return `ErrSpawnUnavailable` when manifest declares scopes" into real namespace-based process isolation. The wrapped subprocess launches inside a fresh **user + mount + PID** namespace via `SysProcAttr.Cloneflags`, with the runtime's UID/GID mapped to 0 inside.

### Scope

This is **Linux v1**, not the full kernel-enforced confinement ADR-0014 commits to. The file header documents what's delivered and what's intentionally deferred:

**Delivered:**
- **Process isolation** — subprocess sees its own PID tree (PID 1 in namespace), cannot signal or observe host processes.
- **User isolation** — runtime UID maps to 0 inside the namespace; subprocess has no caps on host-side resources.
- **Mount namespace** — created so future mounts don't leak to the host. Tree itself stays as-is in v1.
- **Sandbox-available probe** — reads `/proc/sys/kernel/unprivileged_userns_clone`. When disabled (some Debian/Ubuntu LTS hardening, grsecurity kernels), returns `ErrSpawnUnavailable` with a `sudo sysctl` remediation hint.

**Intentionally deferred to follow-ups:**
- **`CLONE_NEWNET` + in-namespace shim wiring** — would activate the kernel-enforced egress denial, but requires bind-mounting the proxy UDS into the child's view and forking [`RunSpawnShim`](https://github.com/ALRubinger/aileron/issues/718) inside the namespace. Until then, host network is shared and `HTTPS_PROXY` cooperation is the egress confinement mechanism. Direct egress to non-allowlisted hosts is **not kernel-blocked** on Linux v1.
- **Landlock LSM + pivot_root with bind-mounted fs scopes** — kernel-grade FS confinement (read scopes per `fs_read`, write scopes per `fs_write`). Needs a re-exec helper pattern so the rules are applied inside the child before exec; the daemon entry point grows a `--spawn-helper` dispatch in that PR.

The trade-off is honest: Linux v1 ships process/PID isolation today, full kernel-enforced FS+network confinement lands in PRs 2 and 3 under [#719](https://github.com/ALRubinger/aileron/issues/719). The alternative (block everything until the full stack lands) keeps Linux users on `ErrSpawnUnavailable` indefinitely.

### Implementation notes

- `Cloneflags |= CLONE_NEWUSER | CLONE_NEWNS | CLONE_NEWPID` (not `CLONE_NEWNET` per scope above).
- `UidMappings`/`GidMappings`: map runtime UID/GID → 0 inside namespace.
- `GidMappingsEnableSetgroups = false` per the kernel's permission gate for unprivileged user-namespace clones (the kernel requires `/proc/<pid>/setgroups` to be set to `deny` before `gid_map` can be written by an unprivileged caller; Go's exec package handles this when the flag is false).
- Empty-`SpawnLimits` legacy path returns nil and leaves cmd untouched.

## Test plan

Tests run on the existing `ubuntu-latest` Unit Tests job (Linux is its default build tag — no CI config change needed for this PR).

- [x] `TestApplyPlatformSandbox_Linux_NoOpWhenNoParamsDeclared` — empty limits leave SysProcAttr untouched
- [x] `TestApplyPlatformSandbox_Linux_SetsCloneflagsAndIDMappings` — verifies Cloneflags include user/mount/PID, NOT NET; UidMappings/GidMappings shape; setgroups=false
- [x] `TestApplyPlatformSandbox_Linux_RunsRealBinaryUnderSandbox` — end-to-end `/bin/sh -c "echo PID=$$"` asserts subprocess sees a small PID (PID-namespace boundary), not the host PID
- [x] `TestApplyPlatformSandbox_Linux_NoSandboxSetupWhenUnavailable` — skips on typical CI runner (sysctl enabled); exercises the locked-down path when sysctl is `0`
- [x] `TestCheckLinuxSandboxAvailable_AcceptsEnabled` — sysctl-read smoke
- [x] Cross-compile clean on darwin and windows (`GOOS=darwin/windows go build`)

If the ubuntu CI runner has the sysctl disabled or the kernel rejects the clone for any other reason, the smoke test will fail and surface what GitHub-hosted runners support.

## Out of scope (follow-ups)

- PR-2: re-exec helper for Landlock LSM + pivot_root bind-mount tree (kernel-enforced FS confinement).
- PR-3: `CLONE_NEWNET` activation + bind-mounted UDS proxy + in-namespace `RunSpawnShim` invocation (kernel-enforced egress confinement).
- Cross-platform: install-time sandbox-available probe (lands with [#580](https://github.com/ALRubinger/aileron/issues/580)).
- Cross-platform: audit `platform` field on every spawn row.
- Cross-platform: malicious-CLI integration test fixture run on each runner.