### PR TITLE
feat(action): consume composite install-decision in action add

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -1577,6 +1577,28 @@ type hubInstallDecisionWire struct {
 	RiskIndicators     []string `json:"risk_indicators"`
 }
 
+// hubInstallAuthorityWire mirrors api.HubInstallAuthority — the
+// per-connector trust-panel element inside a composite install-decision.
+type hubInstallAuthorityWire struct {
+	Fqn                string   `json:"fqn"`
+	PublisherGithub    string   `json:"publisher_github"`
+	Fingerprint        string   `json:"fingerprint"`
+	TrustState         string   `json:"trust_state"`
+	PublisherFootprint []string `json:"publisher_footprint"`
+	RiskIndicators     []string `json:"risk_indicators"`
+}
+
+// hubActionInstallDecisionWire mirrors api.HubActionInstallDecision —
+// the composite payload returned by /v1/hub/action-install-decision.
+type hubActionInstallDecisionWire struct {
+	Kind            string                    `json:"kind"`
+	Fqn             string                    `json:"fqn"`
+	Description     string                    `json:"description"`
+	PublisherGithub string                    `json:"publisher_github"`
+	ConnectorFqn    string                    `json:"connector_fqn"`
+	Authorities     []hubInstallAuthorityWire `json:"authorities"`
+}
+
 // runConnectorInstall implements the consent flow per ADR-0007 with
 // the Hub install-decision layer added on top per ADR-0013 / #487:
 //
@@ -1826,6 +1848,142 @@ func renderHubInstallDecision(w io.Writer, d *hubInstallDecisionWire, verbose bo
 		fmt.Fprintln(w, "  \033[1mOther connectors by this publisher:\033[0m")
 		for _, fqn := range d.PublisherFootprint {
 			fmt.Fprintf(w, "    - %s\n", fqn)
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+// tryHubActionInstallDecisionFlow asks the daemon for the composite
+// install-decision payload for an action FQN. Returns:
+//
+//   - (true,  false, true)  → operator confirmed. Caller programmatically
+//     trusts each composite authority (`trust.ensure` with autoYes=true)
+//     so the existing per-authority prompt loop later in installOneAction
+//     becomes a no-op.
+//   - (false, true,  true)  → operator declined. Caller stops.
+//   - (false, false, false) → no Hub entry for the action (404), composite
+//     can't be precomputed (422 missing connector), or any other Hub
+//     error. Caller falls back to the existing per-authority trust flow.
+//
+// 404 and 422 fall through silently (these are legitimate non-Hub cases).
+// Other failure modes (5xx, parse errors) emit a one-line stderr note so
+// daemon-side Hub config issues are visible but don't block users with
+// pre-established trust from installing.
+//
+// `--yes` short-circuits the prompt and auto-confirms.
+//
+// The returned payload is non-nil whenever hubPath is true (whether
+// accepted or declined). Callers should walk payload.Authorities to
+// pre-trust each before running the install.
+func tryHubActionInstallDecisionFlow(actionFQN string, autoYes bool, stdin io.Reader, stdout, stderr io.Writer) (accepted, declined, hubPath bool, payload *hubActionInstallDecisionWire) {
+	q := url.Values{"fqn": []string{actionFQN}}.Encode()
+	status, body, err := bindingDoRequest(http.MethodGet, "/hub/action-install-decision?"+q, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "note: hub install-decision unavailable (%v); using local trust\n", err)
+		return false, false, false, nil
+	}
+	// 404: action not in the Hub catalog; legitimate non-Hub install.
+	// 422: action's declared connector_fqn isn't Hub-listed; install can
+	// still proceed via direct FQN resolution, but the Hub can't
+	// precompute the trust panel.
+	if status == http.StatusNotFound || status == http.StatusUnprocessableEntity {
+		return false, false, false, nil
+	}
+	if status != http.StatusOK {
+		fmt.Fprintf(stderr, "note: hub install-decision returned %d; using local trust\n", status)
+		return false, false, false, nil
+	}
+	var d hubActionInstallDecisionWire
+	if err := json.Unmarshal(body, &d); err != nil {
+		fmt.Fprintf(stderr, "note: could not parse hub install-decision (%v); using local trust\n", err)
+		return false, false, false, nil
+	}
+	// Empty payload (no FQN, no authorities) is a no-op. Treat it as a
+	// non-Hub case rather than rendering an empty trust panel — the
+	// composite endpoint should never legitimately return this, but
+	// downstream tests and mock daemons sometimes echo `{}` for catch-
+	// all 200 responses, and we don't want a blank panel to follow.
+	if d.Fqn == "" || len(d.Authorities) == 0 {
+		return false, false, false, nil
+	}
+
+	if autoYes {
+		return true, false, true, &d
+	}
+
+	// Wrap stdin once so the `d`-then-`y` two-line flow doesn't lose
+	// buffered bytes between iterations. promptLine builds its own
+	// bufio.Reader when handed a raw reader.
+	br, ok := stdin.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(stdin)
+	}
+
+	showDetails := false
+	for {
+		renderHubActionCompositeDecision(stdout, &d, showDetails)
+		var ans string
+		if showDetails {
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and install? [y/N]: ")))
+		} else {
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and install? [y/N/d=details]: ")))
+		}
+		switch ans {
+		case "y", "yes":
+			return true, false, true, &d
+		case "d", "details":
+			if showDetails {
+				fmt.Fprintln(stdout, "Cancelled.")
+				return false, true, true, &d
+			}
+			showDetails = true
+			continue
+		default:
+			fmt.Fprintln(stdout, "Cancelled.")
+			return false, true, true, &d
+		}
+	}
+}
+
+// renderHubActionCompositeDecision prints the composite trust panel for
+// an action install. Action-level metadata at the top, one panel per
+// connector authority below. Per-authority trust state and risks use
+// the same colorization as the connector-level install-decision render.
+//
+// `verbose` expands risk indicators (one per line; compact mode shows
+// the first only) and adds the per-authority publisher footprint.
+func renderHubActionCompositeDecision(w io.Writer, d *hubActionInstallDecisionWire, verbose bool) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "\033[1mHub install-decision (action)\033[0m")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  Action:    %s\n", d.Fqn)
+	if d.Description != "" {
+		fmt.Fprintf(w, "  Summary:   %s\n", d.Description)
+	}
+	fmt.Fprintf(w, "  Publisher: %s\n", d.PublisherGithub)
+	fmt.Fprintf(w, "  Connector: %s\n", d.ConnectorFqn)
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  \033[1mTrust gate(s): %d connector authority\033[0m\n", len(d.Authorities))
+	for _, auth := range d.Authorities {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  ● %s\n", auth.Fqn)
+		fmt.Fprintf(w, "      Publisher:   %s\n", auth.PublisherGithub)
+		fmt.Fprintf(w, "      Fingerprint: %s\n", auth.Fingerprint)
+		fmt.Fprintf(w, "      Trust:       %s\n", colorizeTrustState(auth.TrustState))
+		if len(auth.RiskIndicators) > 0 {
+			risks := auth.RiskIndicators
+			if !verbose && len(risks) > 1 {
+				risks = risks[:1]
+			}
+			for _, r := range risks {
+				fmt.Fprintf(w, "      Risk:        %s\n", colorizeRisk(auth.TrustState, r))
+			}
+		}
+		if verbose && len(auth.PublisherFootprint) > 0 {
+			fmt.Fprintln(w, "      Other connectors by this publisher:")
+			for _, fqn := range auth.PublisherFootprint {
+				fmt.Fprintf(w, "        - %s\n", fqn)
+			}
 		}
 	}
 	fmt.Fprintln(w)
@@ -2184,6 +2342,50 @@ func installOneAction(opts actionAddOptions, stdin io.Reader, stdout, stderr io.
 		setOutcome(actionInstallStatusFailed)
 		return 1
 	}
+
+	// Step 0a (ADR-0013 action-first amendment / #709): try the Hub
+	// composite install-decision flow. If the action is Hub-listed (200),
+	// render one trust panel grouping the action plus every connector
+	// authority it transitively depends on, and collapse trust consent
+	// into a single y/N. Suite-consented installs skip this — the suite-
+	// level composite (or the suite preflight) already covered consent.
+	if !opts.suiteConsented {
+		accepted, hubDeclined, hubPath, payload := tryHubActionInstallDecisionFlow(
+			resolvedFQN, opts.yes, stdin, stdout, stderr)
+		if hubDeclined {
+			setOutcome(actionInstallStatusCancelled)
+			return 0
+		}
+		if hubPath && accepted && payload != nil {
+			// Operator consented to the composite. Programmatically
+			// trust the action's own authority plus each connector
+			// authority surfaced by the composite. fetchPublisherKey
+			// re-fetches and re-fingerprints; a publisher who rotates
+			// between the composite call and this fetch is caught by
+			// the existing fingerprint check in keyring add — same code
+			// path as `aileron keyring trust`. Marking trustState
+			// suppresses the per-authority prompts that fire later in
+			// installOneAction.
+			if err := trust.ensure(actionFQN.Authority(), true, stdin, stdout, stderr); err != nil {
+				fmt.Fprintf(stderr, "error: %v\n", err)
+				setOutcome(actionInstallStatusFailed)
+				return 1
+			}
+			for _, auth := range payload.Authorities {
+				authFQN, parseErr := cstore.ParseFQN(auth.Fqn)
+				if parseErr != nil {
+					// Defensive: the daemon validated this already.
+					continue
+				}
+				if err := trust.ensure(authFQN.Authority(), true, stdin, stdout, stderr); err != nil {
+					fmt.Fprintf(stderr, "error: %v\n", err)
+					setOutcome(actionInstallStatusFailed)
+					return 1
+				}
+			}
+		}
+	}
+
 	if err := trust.ensure(actionFQN.Authority(), opts.yes, stdin, stdout, stderr); err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		setOutcome(actionInstallStatusFailed)

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -3653,6 +3653,137 @@ func TestRunActionAdd_HubCompositeDetailsExpandsAndAccepts(t *testing.T) {
 	}
 }
 
+// TestRunActionAdd_HubComposite503FallsThroughToLegacyWithNote: 503
+// from the daemon's composite endpoint surfaces a one-line stderr
+// note and falls through to the legacy trust flow. Operators with
+// broken daemon-side Hub config still install actions they've pre-
+// trusted.
+func TestRunActionAdd_HubComposite503FallsThroughToLegacyWithNote(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/action-install-decision":
+			w.WriteHeader(http.StatusServiceUnavailable)
+			_, _ = io.WriteString(w, `{"error":{"code":"hub_unreachable"}}`)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"fqn":"github://acme/conn/actions/run","version":"0.1.0","hash":"sha256:abc","name":"my-action","signature_status":"verified","connector_deps":[]}`)
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"name":"my-action","fqn":"github://acme/conn/actions/run","version":"0.1.0","source":"x","path":"/p"}`)
+		}
+	})
+
+	stdin := bufio.NewReader(strings.NewReader("y\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"github://acme/conn/actions/run@0.1.0"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "hub install-decision returned 503") {
+		t.Errorf("expected one-line stderr note on 503; got:\n%s", stderr.String())
+	}
+	// Legacy flow must still produce its trust prompt.
+	if !strings.Contains(stdout.String(), "Publisher github://acme/conn is not yet trusted") {
+		t.Errorf("legacy trust prompt should still fire after 503 fall-through:\n%s", stdout.String())
+	}
+}
+
+// TestRunActionAdd_HubCompositeMalformedJSONFallsThroughWithNote: 200
+// with un-parseable body surfaces a note and falls through. Guards
+// against a daemon shipping a wire-incompatible payload silently
+// blocking installs that the legacy path can complete.
+func TestRunActionAdd_HubCompositeMalformedJSONFallsThroughWithNote(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/action-install-decision":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `not valid json`)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"fqn":"github://acme/conn/actions/run","version":"0.1.0","hash":"sha256:abc","name":"my-action","signature_status":"verified","connector_deps":[]}`)
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"name":"my-action","fqn":"github://acme/conn/actions/run","version":"0.1.0","source":"x","path":"/p"}`)
+		}
+	})
+
+	stdin := bufio.NewReader(strings.NewReader("y\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"github://acme/conn/actions/run@0.1.0"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "could not parse hub install-decision") {
+		t.Errorf("expected parse-failure note; got:\n%s", stderr.String())
+	}
+}
+
+// TestRunActionAdd_HubCompositeDetailsTwiceTreatsAsDecline: typing `d`
+// twice expands the panel then declines (since the panel was already
+// in details mode, a second `d` is meaningless and counts as cancel).
+// Mirrors the connector-install composite contract.
+func TestRunActionAdd_HubCompositeDetailsTwiceTreatsAsDecline(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	previewCalled := false
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/action-install-decision":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"kind":"action","fqn":"github://acme/conn/actions/run",
+				"description":"x","publisher_github":"acme",
+				"connector_fqn":"github://acme/conn",
+				"authorities":[{
+					"fqn":"github://acme/conn","publisher_github":"acme",
+					"fingerprint":"sha256:any","trust_state":"unknown",
+					"publisher_footprint":[],"risk_indicators":["x"]
+				}]
+			}`)
+		case "/actions/preview":
+			previewCalled = true
+		}
+	})
+
+	stdin := bufio.NewReader(strings.NewReader("d\nd\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"github://acme/conn/actions/run@0.1.0"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Errorf("expected clean cancel exit 0, got %d", code)
+	}
+	if previewCalled {
+		t.Error("preview should not fire after second `d` treated as decline")
+	}
+	if !strings.Contains(stdout.String(), "Cancelled.") {
+		t.Errorf("expected 'Cancelled.' in output:\n%s", stdout.String())
+	}
+}
+
 // TestRunActionAdd_TrustDeclineAbortsBeforePreview asserts the cancel
 // path: typing "n" at the trust prompt aborts with a nonzero exit
 // code and never calls /actions/preview. The keyring stays empty.

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -2651,6 +2651,11 @@ func TestRunAction_AddAutoPromptsForUnboundCapabilities(t *testing.T) {
 			setupHits++
 			w.WriteHeader(http.StatusCreated)
 			_, _ = io.WriteString(w, `{"created":[{"name":"api_key/conn-a/work","kind":"api_key","service":"conn-a","identity":"work","connector_fqn":"github://x/conn-a","created_at":"2024-01-01T00:00:00Z"}]}`)
+		case "/hub/action-install-decision":
+			// Action isn't Hub-listed in this fixture; force the
+			// composite flow to fall through to the legacy path so this
+			// test continues to exercise its intended surface.
+			w.WriteHeader(http.StatusNotFound)
 		default:
 			t.Errorf("unexpected path %s", r.URL.Path)
 		}
@@ -2690,6 +2695,8 @@ func TestRunAction_AddDeclineDoesNotBindButPrintsHint(t *testing.T) {
 				"name":"echo","fqn":"x","version":"1.0.0","source":"x","path":"/p",
 				"unbound_capabilities":[{"connector_fqn":"github://x/conn-a","kind":"oauth2"}]
 			}`)
+		case "/hub/action-install-decision":
+			w.WriteHeader(http.StatusNotFound)
 		default:
 			t.Errorf("unexpected path %s", r.URL.Path)
 		}
@@ -2722,6 +2729,8 @@ func TestRunAction_AddNoBindFlagSkipsPrompt(t *testing.T) {
 				"name":"echo","fqn":"x","version":"1.0.0","source":"x","path":"/p",
 				"unbound_capabilities":[{"connector_fqn":"github://x/conn-a","kind":"api_key"}]
 			}`)
+		case "/hub/action-install-decision":
+			w.WriteHeader(http.StatusNotFound)
 		default:
 			t.Errorf("unexpected path with --no-bind: %s", r.URL.Path)
 		}
@@ -3316,6 +3325,331 @@ func TestRunActionAdd_AutoTrustPromptsAndInstalls(t *testing.T) {
 	}
 	if !kr.HasKey("github://acme/conn", pub) {
 		t.Error("keyring should contain trusted key after auto-trust")
+	}
+}
+
+// TestRunActionAdd_HubCompositeAcceptTrustsAuthoritiesAndInstalls is
+// the headline #709 acceptance test: when the action is Hub-listed,
+// the CLI renders a single composite trust panel covering the action
+// plus every connector authority it depends on. One "y" trusts every
+// surfaced authority and proceeds to preview + install. Per-authority
+// trust prompts are suppressed.
+func TestRunActionAdd_HubCompositeAcceptTrustsAuthoritiesAndInstalls(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	var hubCalled, previewCalled, installCalled bool
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/action-install-decision":
+			hubCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"kind":"action",
+				"fqn":"github://acme/conn/actions/run",
+				"description":"do the thing",
+				"publisher_github":"acme",
+				"connector_fqn":"github://acme/conn",
+				"authorities":[{
+					"fqn":"github://acme/conn",
+					"publisher_github":"acme",
+					"fingerprint":"sha256:i4l2kuD8q++d5b9v8/LLI1",
+					"trust_state":"unknown",
+					"publisher_footprint":[],
+					"risk_indicators":["First connector by this publisher you've installed"]
+				}]
+			}`)
+		case "/actions/preview":
+			previewCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"fqn":"github://acme/conn/actions/run","version":"0.1.0",
+				"hash":"sha256:abc","name":"my-action","signature_status":"verified",
+				"connector_deps":[]
+			}`)
+		case "/actions/install":
+			installCalled = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"name":"my-action","fqn":"github://acme/conn/actions/run","version":"0.1.0","source":"x","path":"/p"}`)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	// One y at the composite prompt; one y at the per-action install
+	// prompt. The per-authority trust prompts that the legacy flow
+	// would fire are suppressed because trustState records every
+	// composite authority as already trusted.
+	stdin := bufio.NewReader(strings.NewReader("y\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"github://acme/conn/actions/run@0.1.0"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr = %s", code, stderr.String())
+	}
+	if !hubCalled || !previewCalled || !installCalled {
+		t.Errorf("expected all three endpoints to fire; hub=%v preview=%v install=%v", hubCalled, previewCalled, installCalled)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Hub install-decision (action)",
+		"Action:    github://acme/conn/actions/run",
+		"Summary:   do the thing",
+		"Connector: github://acme/conn",
+		"sha256:i4l2kuD8q++d5b9v8/LLI1",
+		"Trust these publishers and install?",
+		"First connector by this publisher",
+		"Added: my-action",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// Per-authority "Publisher X is not yet trusted" lines MUST NOT
+	// fire — the composite consent already covered them. Their absence
+	// is the load-bearing UX promise of the composite flow.
+	if strings.Contains(out, "Publisher github://acme/conn is not yet trusted.\nAileron will fetch") {
+		t.Errorf("per-authority trust prompt fired after composite accept:\n%s", out)
+	}
+	// Trust persists post-install — composite y also wrote the keyring.
+	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !kr.HasKey("github://acme/conn", pub) {
+		t.Error("keyring should contain trusted key after composite accept")
+	}
+}
+
+// TestRunActionAdd_HubCompositeDeclineAbortsBeforePreview: declining at
+// the composite prompt aborts cleanly (exit 0, no preview/install
+// calls, keyring stays empty). Mirrors the legacy decline path but at
+// the new consent surface.
+func TestRunActionAdd_HubCompositeDeclineAbortsBeforePreview(t *testing.T) {
+	home := withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	previewCalled := false
+	installCalled := false
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/action-install-decision":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"kind":"action","fqn":"github://acme/conn/actions/run",
+				"description":"x","publisher_github":"acme",
+				"connector_fqn":"github://acme/conn",
+				"authorities":[{
+					"fqn":"github://acme/conn","publisher_github":"acme",
+					"fingerprint":"sha256:any","trust_state":"unknown",
+					"publisher_footprint":[],"risk_indicators":["x"]
+				}]
+			}`)
+		case "/actions/preview":
+			previewCalled = true
+		case "/actions/install":
+			installCalled = true
+		}
+	})
+
+	stdin := strings.NewReader("n\n")
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"github://acme/conn/actions/run@0.1.0"},
+		stdin, &stdout, &stderr,
+	)
+	// Composite decline is a clean cancel: exit 0, no install pipeline
+	// runs. The legacy decline-at-trust path historically exited
+	// nonzero; the action-first amendment treats decline as the
+	// operator's normal "no thanks" interaction.
+	if code != 0 {
+		t.Errorf("expected clean cancel exit 0, got %d; stderr=%s", code, stderr.String())
+	}
+	if previewCalled || installCalled {
+		t.Errorf("preview/install should not fire on decline; preview=%v install=%v", previewCalled, installCalled)
+	}
+	if !strings.Contains(stdout.String(), "Cancelled.") {
+		t.Errorf("expected 'Cancelled.' in output:\n%s", stdout.String())
+	}
+	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if kr != nil && len(kr.Keys("github://acme/conn")) != 0 {
+		t.Error("keyring should remain empty when composite declined")
+	}
+}
+
+// TestRunActionAdd_HubCompositeYesFlagAutoAccepts: --yes short-circuits
+// the composite prompt the same way it short-circuits the legacy
+// trust + install prompts. CI scripts and agent-driven installs stay
+// non-interactive.
+func TestRunActionAdd_HubCompositeYesFlagAutoAccepts(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	hubCalled := 0
+	installCalled := false
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/action-install-decision":
+			hubCalled++
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"kind":"action","fqn":"github://acme/conn/actions/run",
+				"description":"x","publisher_github":"acme",
+				"connector_fqn":"github://acme/conn",
+				"authorities":[{
+					"fqn":"github://acme/conn","publisher_github":"acme",
+					"fingerprint":"sha256:any","trust_state":"unknown",
+					"publisher_footprint":[],"risk_indicators":["x"]
+				}]
+			}`)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"fqn":"github://acme/conn/actions/run","version":"0.1.0","hash":"sha256:abc","name":"my-action","signature_status":"verified","connector_deps":[]}`)
+		case "/actions/install":
+			installCalled = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"name":"my-action","fqn":"github://acme/conn/actions/run","version":"0.1.0","source":"x","path":"/p"}`)
+		}
+	})
+
+	// No stdin reads — --yes must skip every prompt.
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"github://acme/conn/actions/run@0.1.0", "--yes"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if hubCalled != 1 || !installCalled {
+		t.Errorf("expected hub composite to fire once and install to run; hub=%d install=%v", hubCalled, installCalled)
+	}
+	// Composite panel must NOT be rendered when --yes is in effect —
+	// that would surface a wall of trust info before silent install,
+	// confusing for the script consumer.
+	if strings.Contains(stdout.String(), "Trust these publishers and install?") {
+		t.Errorf("composite prompt fired despite --yes:\n%s", stdout.String())
+	}
+}
+
+// TestRunActionAdd_HubComposite422FallsThroughToLegacy: when the
+// composite endpoint can't precompute the trust panel (e.g. action's
+// connector_fqn isn't Hub-listed), the CLI falls through to the
+// legacy per-authority trust + preview flow. Operators with Hub
+// configuration gaps still get their installs done.
+func TestRunActionAdd_HubComposite422FallsThroughToLegacy(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	hubCalled, previewCalled, installCalled := false, false, false
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/action-install-decision":
+			hubCalled = true
+			w.WriteHeader(http.StatusUnprocessableEntity)
+			_, _ = io.WriteString(w, `{"error":{"code":"missing_connector"}}`)
+		case "/actions/preview":
+			previewCalled = true
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"fqn":"github://acme/conn/actions/run","version":"0.1.0","hash":"sha256:abc","name":"my-action","signature_status":"verified","connector_deps":[]}`)
+		case "/actions/install":
+			installCalled = true
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"name":"my-action","fqn":"github://acme/conn/actions/run","version":"0.1.0","source":"x","path":"/p"}`)
+		}
+	})
+
+	stdin := bufio.NewReader(strings.NewReader("y\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"github://acme/conn/actions/run@0.1.0"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !hubCalled || !previewCalled || !installCalled {
+		t.Errorf("expected fall-through to legacy flow; hub=%v preview=%v install=%v", hubCalled, previewCalled, installCalled)
+	}
+	// Composite panel must NOT render when the endpoint 422s.
+	if strings.Contains(stdout.String(), "Hub install-decision (action)") {
+		t.Errorf("composite panel rendered on 422 fall-through:\n%s", stdout.String())
+	}
+	// Legacy per-authority trust prompt MUST render (operator typed y
+	// to accept it).
+	if !strings.Contains(stdout.String(), "Publisher github://acme/conn is not yet trusted") {
+		t.Errorf("legacy trust prompt should fire on fall-through:\n%s", stdout.String())
+	}
+}
+
+// TestRunActionAdd_HubCompositeDetailsExpandsAndAccepts: typing "d"
+// at the composite prompt expands the per-authority publisher_footprint
+// view; a subsequent "y" accepts. Validates the d=details → y two-step.
+func TestRunActionAdd_HubCompositeDetailsExpandsAndAccepts(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/conn/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/action-install-decision":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"kind":"action","fqn":"github://acme/conn/actions/run",
+				"description":"x","publisher_github":"acme",
+				"connector_fqn":"github://acme/conn",
+				"authorities":[{
+					"fqn":"github://acme/conn","publisher_github":"acme",
+					"fingerprint":"sha256:any","trust_state":"unknown",
+					"publisher_footprint":["github://acme/other-conn","github://acme/third-conn"],
+					"risk_indicators":["First connector by this publisher you've installed"]
+				}]
+			}`)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{"fqn":"github://acme/conn/actions/run","version":"0.1.0","hash":"sha256:abc","name":"my-action","signature_status":"verified","connector_deps":[]}`)
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			_, _ = io.WriteString(w, `{"name":"my-action","fqn":"github://acme/conn/actions/run","version":"0.1.0","source":"x","path":"/p"}`)
+		}
+	})
+
+	// d → details, y → accept composite, y → accept the action install
+	stdin := bufio.NewReader(strings.NewReader("d\ny\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAdd(
+		[]string{"github://acme/conn/actions/run@0.1.0"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	// Details expansion surfaces the publisher_footprint.
+	for _, want := range []string{
+		"Other connectors by this publisher",
+		"github://acme/other-conn",
+		"github://acme/third-conn",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("details mode missing %q:\n%s", want, out)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

- `aileron action add` now consults the Hub's composite install-decision endpoint (`/v1/hub/action-install-decision`) before running the legacy trust + preview flow. When the action is Hub-listed, the CLI renders one trust panel covering the action plus every connector authority in its dependency closure and prompts `y/N/d=details` once. On accept, each surfaced authority is programmatically trusted via the existing keyring path (`trust.ensure` with `autoYes=true`); the per-authority trust prompts later in `installOneAction` become no-ops because `trustState` already has them.
- 404 (action not in Hub catalog) and 422 (composite can't be precomputed — e.g. action's declared `connector_fqn` not Hub-listed) fall through silently to the existing per-authority trust flow. Empty `{}` responses fall through too, so legacy test fixtures that respond catch-all 200 OK don't accidentally trigger an empty trust panel.
- `--yes` short-circuits the composite prompt the same way it short-circuits every other consent prompt — non-interactive scripts stay non-interactive.
- `d=details` expands the per-authority `publisher_footprint` into the panel before re-prompting.
- Suite consumption (`action add-suite`) and the webapp install modal are follow-ups on the umbrella.

Refs #709 (umbrella).

## Test plan

- [x] `(cd cmd/aileron && go test -count=1 -cover ./...)` green; project coverage 85.9%.
- [x] New tests: composite accept happy path with keyring assertion; decline → clean exit-0 cancel; `--yes` skips prompt entirely; 422 fall-through preserves legacy trust prompt; `d` expansion + accept.
- [x] All pre-existing `TestRunActionAdd_*`, `TestRunAction_*`, and `TestInstallOneAction_*` tests still pass; affected strict-path fixtures updated to return 404 on the new endpoint so they continue exercising the legacy flow as intended.
- [x] Coverage on new code paths: `tryHubActionInstallDecisionFlow` 83.8%, `renderHubActionCompositeDecision` 96.3%.
- [ ] CI green (full matrix).