### PR TITLE
feat(sandbox): Linux v2 — Landlock LSM via re-exec helper

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/launch/agents"
 	"github.com/ALRubinger/aileron/internal/oauth"
+	"github.com/ALRubinger/aileron/internal/sandbox/spawnhelper"
 	"github.com/ALRubinger/aileron/internal/suite"
 	"github.com/ALRubinger/aileron/internal/vault"
 	"github.com/ALRubinger/aileron/internal/version"
@@ -30,6 +31,21 @@ import (
 )
 
 func main() {
+	// Spawn-helper dispatch (ADR-0014, Linux platform sandbox).
+	// When the runtime re-execs into this binary with the hidden
+	// __spawn-helper marker, this process is acting as the in-namespace
+	// helper for a wrapped CLI: it applies Landlock restrictions and
+	// then `syscall.Exec`s into the wrapped program. Must run BEFORE
+	// any normal-CLI setup so the helper does not touch the vault,
+	// launcher registry, or any other host state that would leak
+	// across the namespace boundary.
+	if len(os.Args) >= 3 && os.Args[1] == spawnhelper.HelperArgvMarker {
+		spawnhelper.Run(os.Args[2])
+		// spawnhelper.Run never returns on success; if we reach
+		// here it has already exited with a structured error code.
+		return
+	}
+
 	registry := launch.NewRegistry()
 	registry.Register(agents.Claude{})
 	registry.Register(agents.Pi{})

--- a/internal/sandbox/spawn_sandbox_linux.go
+++ b/internal/sandbox/spawn_sandbox_linux.go
@@ -10,6 +10,8 @@ import (
 	"os/exec"
 	"strings"
 	"syscall"
+
+	"github.com/ALRubinger/aileron/internal/sandbox/spawnhelper"
 )
 
 // unprivilegedUserNSSysctl is the kernel knob distros sometimes
@@ -27,36 +29,51 @@ import (
 // [ADR-0014]: https://docs.withaileron.ai/adr/0014-spawn-sandbox-technology
 var unprivilegedUserNSSysctl = "/proc/sys/kernel/unprivileged_userns_clone"
 
+// osExecutable is the function the runtime calls to discover the
+// path of the daemon binary it should re-exec into for the
+// post-namespace helper. Declared as a var so tests can swap it
+// without needing to actually rename the test binary.
+var osExecutable = os.Executable
+
 // applyPlatformSandbox wires the wrapped subprocess to launch in a
 // fresh user + mount + PID namespace, providing process-level
-// isolation per ADR-0014's Linux section.
+// isolation per ADR-0014's Linux section. When the manifest
+// declares `fs_read` or `fs_write` scopes, the runtime also
+// re-execs into the daemon binary's [spawnhelper.Run] entry point
+// so Landlock LSM rules apply inside the namespace before the
+// wrapped CLI exec's.
 //
-// Scope of this implementation (Linux v1):
+// Scope of this implementation:
 //
-//   - **User namespace** maps the runtime's UID to UID 0 inside the
-//     namespace; the subprocess cannot escalate to host-root or
-//     affect any other UID's resources.
+//   - **User namespace** maps the runtime's UID to UID 0 inside
+//     the namespace; the subprocess cannot escalate to host-root
+//     or affect any other UID's resources.
 //   - **Mount namespace** is created (CLONE_NEWNS) so the
-//     subprocess's future mount operations cannot leak to the host.
-//     The mount tree itself is not rewritten in v1; a follow-up PR
-//     adds pivot_root + bind-mounted fs_read/fs_write scopes for
-//     real kernel-enforced FS confinement (paired with Landlock LSM
-//     on kernels that support it).
+//     subprocess's future mount operations cannot leak to the
+//     host. The mount tree itself is not rewritten yet; a future
+//     PR adds pivot_root + bind-mounted fs scopes if Landlock
+//     coverage proves insufficient.
 //   - **PID namespace** makes the subprocess PID 1 inside its
 //     namespace; it cannot see or signal host processes.
-//   - **Network namespace is NOT activated in v1** so the
-//     subprocess shares the host's network. The CONNECT proxy
-//     [#716] runs on host loopback, so HTTPS_PROXY injection
-//     works without additional shim plumbing. The trade-off: direct
-//     egress to non-allowlisted hosts is not kernel-enforced. A
-//     follow-up PR adds CLONE_NEWNET plus the in-namespace TCP-to-UDS
-//     shim ([#718]) for kernel-enforced egress confinement.
+//   - **Landlock LSM** is applied inside the helper (when
+//     `fs_read` or `fs_write` is declared) so the wrapped CLI
+//     cannot read or write outside the declared paths. This is
+//     the load-bearing kernel-enforced FS confinement; without
+//     it the namespace alone leaves the host filesystem
+//     reachable.
+//   - **Network namespace is NOT activated** so the subprocess
+//     shares the host's network. The CONNECT proxy runs on host
+//     loopback; the wrapped CLI honors `HTTPS_PROXY`. The
+//     trade-off: direct egress to non-allowlisted hosts is not
+//     kernel-enforced. A future PR adds `CLONE_NEWNET` +
+//     in-namespace TCP-to-UDS shim wiring ([#718]) for kernel-
+//     enforced egress.
 //
 // Returns [ErrSpawnUnavailable] when unprivileged user namespaces
-// are disabled at the sysctl level. Returns nil with no
-// modification to `cmd` when no manifest sandbox parameters were
-// declared (legacy path; pre-BYOCLI connectors continue to run
-// unchanged).
+// are disabled at the sysctl level or when the daemon binary
+// path cannot be discovered. Returns nil with no modification to
+// `cmd` when no manifest sandbox parameters were declared
+// (legacy path; pre-BYOCLI connectors continue to run unchanged).
 func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) (platformSandboxHooks, error) {
 	_ = env
 	if !limits.PlatformSandboxRequested() {
@@ -81,7 +98,53 @@ func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) 
 	// the gid_map is the kernel's required permission gate, and
 	// Go's exec package handles this when this flag is false.
 	cmd.SysProcAttr.GidMappingsEnableSetgroups = false
+
+	// When the manifest declares FS scopes, re-exec into the
+	// daemon binary's spawn-helper entry point so Landlock applies
+	// inside the namespace before the wrapped CLI starts. Network-
+	// only scoping (no fs_read / fs_write) keeps the v1 behavior
+	// where the wrapped CLI exec's directly.
+	if len(limits.FSRead) > 0 || len(limits.FSWrite) > 0 {
+		if err := rewireForHelper(cmd, limits); err != nil {
+			return platformSandboxHooks{}, err
+		}
+	}
+
 	return platformSandboxHooks{}, nil
+}
+
+// rewireForHelper captures the wrapped program from `cmd`,
+// encodes a [spawnhelper.Request] carrying it along with the
+// manifest's FS scopes, and rewires `cmd` so the kernel exec's
+// the daemon binary in helper mode instead. The helper applies
+// Landlock then `syscall.Exec`s the wrapped program — replacing
+// itself with the CLI under the configured confinement.
+func rewireForHelper(cmd *exec.Cmd, limits SpawnLimits) error {
+	helperPath, err := osExecutable()
+	if err != nil {
+		return fmt.Errorf("%w: locate daemon binary for spawn helper: %v", ErrSpawnUnavailable, err)
+	}
+
+	// Snapshot the wrapped invocation before reassigning cmd.Path
+	// and cmd.Args; the helper will use these for syscall.Exec.
+	req := spawnhelper.Request{
+		Program: cmd.Path,
+		Argv:    append([]string(nil), cmd.Args...),
+		Env:     append([]string(nil), cmd.Env...),
+		Cwd:     cmd.Dir,
+		FSRead:  append([]string(nil), limits.FSRead...),
+		FSWrite: append([]string(nil), limits.FSWrite...),
+	}
+	encoded, err := spawnhelper.EncodeRequest(req)
+	if err != nil {
+		return fmt.Errorf("%w: encode helper request: %v", ErrSpawnUnavailable, err)
+	}
+
+	cmd.Path = helperPath
+	cmd.Args = []string{"aileron", spawnhelper.HelperArgvMarker, encoded}
+	// cmd.Env and cmd.Dir carry through to the helper unchanged;
+	// the helper uses req.Env / req.Cwd for the wrapped exec.
+	return nil
 }
 
 // checkLinuxSandboxAvailable returns ErrSpawnUnavailable when the

--- a/internal/sandbox/spawn_sandbox_linux.go
+++ b/internal/sandbox/spawn_sandbox_linux.go
@@ -119,10 +119,23 @@ func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) 
 // the daemon binary in helper mode instead. The helper applies
 // Landlock then `syscall.Exec`s the wrapped program — replacing
 // itself with the CLI under the configured confinement.
+//
+// Tilde-anchored manifest paths (`~/code/`) are expanded to
+// absolute paths before encoding; the helper opens them via
+// `unix.Open` which has no shell-style expansion.
 func rewireForHelper(cmd *exec.Cmd, limits SpawnLimits) error {
 	helperPath, err := osExecutable()
 	if err != nil {
 		return fmt.Errorf("%w: locate daemon binary for spawn helper: %v", ErrSpawnUnavailable, err)
+	}
+
+	fsRead, err := expandPaths(limits.FSRead)
+	if err != nil {
+		return fmt.Errorf("%w: expand fs_read: %v", ErrSpawnUnavailable, err)
+	}
+	fsWrite, err := expandPaths(limits.FSWrite)
+	if err != nil {
+		return fmt.Errorf("%w: expand fs_write: %v", ErrSpawnUnavailable, err)
 	}
 
 	// Snapshot the wrapped invocation before reassigning cmd.Path
@@ -132,8 +145,8 @@ func rewireForHelper(cmd *exec.Cmd, limits SpawnLimits) error {
 		Argv:    append([]string(nil), cmd.Args...),
 		Env:     append([]string(nil), cmd.Env...),
 		Cwd:     cmd.Dir,
-		FSRead:  append([]string(nil), limits.FSRead...),
-		FSWrite: append([]string(nil), limits.FSWrite...),
+		FSRead:  fsRead,
+		FSWrite: fsWrite,
 	}
 	encoded, err := spawnhelper.EncodeRequest(req)
 	if err != nil {
@@ -145,6 +158,22 @@ func rewireForHelper(cmd *exec.Cmd, limits SpawnLimits) error {
 	// cmd.Env and cmd.Dir carry through to the helper unchanged;
 	// the helper uses req.Env / req.Cwd for the wrapped exec.
 	return nil
+}
+
+// expandPaths resolves any `~/`-anchored manifest paths to
+// absolute host paths via [expandTilde]. The helper's Landlock
+// setup opens each scope via `unix.Open` which has no shell-
+// style expansion, so the runtime expands here.
+func expandPaths(in []string) ([]string, error) {
+	out := make([]string, 0, len(in))
+	for _, p := range in {
+		expanded, err := expandTilde(p)
+		if err != nil {
+			return nil, fmt.Errorf("expand %q: %w", p, err)
+		}
+		out = append(out, expanded)
+	}
+	return out, nil
 }
 
 // checkLinuxSandboxAvailable returns ErrSpawnUnavailable when the

--- a/internal/sandbox/spawn_sandbox_linux_test.go
+++ b/internal/sandbox/spawn_sandbox_linux_test.go
@@ -289,7 +289,17 @@ func TestApplyPlatformSandbox_Linux_RunsRealBinaryUnderSandbox(t *testing.T) {
 	}
 
 	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", "echo PID=$$")
-	limits := SpawnLimits{FSRead: []string{"~/code/"}}
+	// Declare /tmp as the read scope so Landlock's path-open
+	// succeeds; the test only cares about the PID-namespace
+	// boundary, not the FS confinement. /tmp exists on every
+	// POSIX host. The system-essentials (/lib, /lib64, /usr,
+	// /bin, /etc) are needed for /bin/sh's dyld to start.
+	limits := SpawnLimits{FSRead: []string{"/tmp"}}
+	for _, sys := range []string{"/lib", "/lib64", "/usr", "/etc", "/bin"} {
+		if _, err := os.Stat(sys); err == nil {
+			limits.FSRead = append(limits.FSRead, sys)
+		}
+	}
 	if _, err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/sh"}, limits); err != nil {
 		t.Fatalf("applyPlatformSandbox: %v", err)
 	}

--- a/internal/sandbox/spawn_sandbox_linux_test.go
+++ b/internal/sandbox/spawn_sandbox_linux_test.go
@@ -12,7 +12,23 @@ import (
 	"strings"
 	"syscall"
 	"testing"
+
+	"github.com/ALRubinger/aileron/internal/sandbox/spawnhelper"
 )
+
+// TestMain intercepts the spawn-helper re-exec on Linux test runs.
+// The runtime calls os.Executable() to discover the daemon binary
+// for the helper re-exec; in tests that returns the test binary
+// itself. Without this dispatch, the helper invocation would
+// re-run the entire test suite recursively. With it, the test
+// binary acts as both the test driver and the helper.
+func TestMain(m *testing.M) {
+	if len(os.Args) >= 3 && os.Args[1] == spawnhelper.HelperArgvMarker {
+		spawnhelper.Run(os.Args[2])
+		return // unreachable in practice; Run never returns on success
+	}
+	os.Exit(m.Run())
+}
 
 // Each test below cites the ADR-0014 clause or the Linux namespace
 // property it enforces so refactors that preserve the contract
@@ -75,6 +91,189 @@ func TestApplyPlatformSandbox_Linux_SetsCloneflagsAndIDMappings(t *testing.T) {
 	if cmd.SysProcAttr.GidMappingsEnableSetgroups {
 		t.Error("GidMappingsEnableSetgroups must be false for unprivileged user-namespace clones")
 	}
+}
+
+func TestApplyPlatformSandbox_Linux_RewiresIntoHelperWhenFSScopesDeclared(t *testing.T) {
+	// Contract: when fs_read or fs_write is declared, the runtime
+	// rewires cmd to re-exec the daemon binary in helper mode.
+	// cmd.Path becomes the daemon path; cmd.Args[1] is the
+	// __spawn-helper marker; cmd.Args[2] is the encoded request
+	// that decodes to the original Program/Argv.
+	origExec := osExecutable
+	defer func() { osExecutable = origExec }()
+	osExecutable = func() (string, error) { return "/usr/local/bin/aileron-fake", nil }
+
+	cmd := exec.CommandContext(context.Background(), "/usr/bin/git", "log", "--since=2026-01-01")
+	limits := SpawnLimits{FSRead: []string{"/Users/alr/code/"}}
+	if _, err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/usr/bin/git"}, limits); err != nil {
+		if strings.Contains(err.Error(), "spawn_sandbox_unavailable") {
+			t.Skip("sandbox unavailable on this runner")
+		}
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	if cmd.Path != "/usr/local/bin/aileron-fake" {
+		t.Errorf("cmd.Path = %q, want daemon binary path", cmd.Path)
+	}
+	if len(cmd.Args) != 3 {
+		t.Fatalf("cmd.Args = %v, want [aileron, __spawn-helper, <encoded>]", cmd.Args)
+	}
+	if cmd.Args[1] != spawnhelper.HelperArgvMarker {
+		t.Errorf("cmd.Args[1] = %q, want %q", cmd.Args[1], spawnhelper.HelperArgvMarker)
+	}
+	req, err := spawnhelper.DecodeRequest(cmd.Args[2])
+	if err != nil {
+		t.Fatalf("decode rewired request: %v", err)
+	}
+	if req.Program != "/usr/bin/git" {
+		t.Errorf("req.Program = %q, want /usr/bin/git", req.Program)
+	}
+	if !equalSlice(req.Argv, []string{"/usr/bin/git", "log", "--since=2026-01-01"}) {
+		t.Errorf("req.Argv = %v, want wrapped git argv", req.Argv)
+	}
+	if !equalSlice(req.FSRead, []string{"/Users/alr/code/"}) {
+		t.Errorf("req.FSRead = %v, want manifest scope", req.FSRead)
+	}
+}
+
+func TestApplyPlatformSandbox_Linux_NoRewireWhenOnlyProxyAddrDeclared(t *testing.T) {
+	// Contract: when only network is declared (no fs_read/fs_write),
+	// the wrapped CLI execs directly. Landlock doesn't govern
+	// network, so re-execing through the helper would add a
+	// process layer for no gain. v3's CLONE_NEWNET + shim work
+	// changes this; until then the wrapped CLI is the direct
+	// exec target.
+	cmd := exec.CommandContext(context.Background(), "/bin/echo", "hi")
+	origPath := cmd.Path
+	limits := SpawnLimits{ProxyAddr: "127.0.0.1:54321"}
+	if _, err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/echo"}, limits); err != nil {
+		if strings.Contains(err.Error(), "spawn_sandbox_unavailable") {
+			t.Skip("sandbox unavailable on this runner")
+		}
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	if cmd.Path != origPath {
+		t.Errorf("cmd.Path = %q; want unchanged %q (no helper rewire when only network declared)", cmd.Path, origPath)
+	}
+}
+
+func TestApplyPlatformSandbox_Linux_HelperEnforcesLandlockReadScope(t *testing.T) {
+	// End-to-end (BYOCLI threat model): a wrapped CLI cannot read
+	// outside its declared fs_read scope. The test binary acts as
+	// the daemon: when the runtime re-execs into the helper marker
+	// (via TestMain dispatch), Landlock is applied and cat is
+	// exec'd; cat reading a sentinel outside the scope fails with
+	// EPERM/EACCES at the kernel boundary.
+	if _, err := os.Stat("/bin/cat"); err != nil {
+		t.Skip("/bin/cat not present")
+	}
+	if err := checkLinuxSandboxAvailable(); err != nil {
+		t.Skipf("sandbox unavailable: %v", err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	allowedDir := filepath.Join(home, "aileron-linux-v2-test-allowed")
+	deniedDir := filepath.Join(home, "aileron-linux-v2-test-denied")
+	if err := os.MkdirAll(allowedDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.MkdirAll(deniedDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(allowedDir)
+	defer os.RemoveAll(deniedDir)
+	sentinel := filepath.Join(deniedDir, "secret.txt")
+	if err := os.WriteFile(sentinel, []byte("don't read me"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "/bin/cat", sentinel)
+	limits := SpawnLimits{
+		FSRead: []string{allowedDir},
+		// Also allow read of /lib, /lib64, /usr (dyld needs them
+		// to start /bin/cat). On the helper Landlock is the only
+		// FS constraint, so these system paths must be in fs_read.
+		// In production this widening is handled by the introspector
+		// at `aileron cli add` time.
+	}
+	// Append system-essentials so /bin/cat can dynamic-link.
+	for _, sys := range []string{"/lib", "/lib64", "/usr", "/etc", "/bin"} {
+		if _, err := os.Stat(sys); err == nil {
+			limits.FSRead = append(limits.FSRead, sys)
+		}
+	}
+	if _, err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/cat"}, limits); err != nil {
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	out, runErr := cmd.CombinedOutput()
+	if runErr == nil {
+		t.Fatalf("expected /bin/cat to fail reading sentinel under Landlock; got success with output %q", string(out))
+	}
+	// The exact exit shape varies but a non-zero exit is the
+	// contract. Cat reports "Permission denied" when it hits
+	// EACCES from the kernel.
+	if !strings.Contains(string(out), "Permission denied") &&
+		!strings.Contains(string(out), "permission denied") {
+		t.Logf("note: cat output did not contain 'Permission denied' but exited non-zero: %q", string(out))
+	}
+}
+
+func TestApplyPlatformSandbox_Linux_HelperAllowsReadInsideScope(t *testing.T) {
+	// Complement: a read INSIDE the declared scope succeeds. Proves
+	// Landlock's allow rule for the manifest scope is actually
+	// applied (not just denying everything wholesale).
+	if _, err := os.Stat("/bin/cat"); err != nil {
+		t.Skip("/bin/cat not present")
+	}
+	if err := checkLinuxSandboxAvailable(); err != nil {
+		t.Skipf("sandbox unavailable: %v", err)
+	}
+
+	home, err := os.UserHomeDir()
+	if err != nil {
+		t.Skip("no home dir")
+	}
+	allowedDir := filepath.Join(home, "aileron-linux-v2-test-allow-read")
+	if err := os.MkdirAll(allowedDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	defer os.RemoveAll(allowedDir)
+	sentinel := filepath.Join(allowedDir, "data.txt")
+	if err := os.WriteFile(sentinel, []byte("hello-from-landlock"), 0o600); err != nil {
+		t.Fatalf("write sentinel: %v", err)
+	}
+
+	cmd := exec.CommandContext(context.Background(), "/bin/cat", sentinel)
+	limits := SpawnLimits{FSRead: []string{allowedDir}}
+	for _, sys := range []string{"/lib", "/lib64", "/usr", "/etc", "/bin"} {
+		if _, err := os.Stat(sys); err == nil {
+			limits.FSRead = append(limits.FSRead, sys)
+		}
+	}
+	if _, err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/bin/cat"}, limits); err != nil {
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("sandboxed cat failed inside declared scope: %v", err)
+	}
+	if !strings.Contains(string(out), "hello-from-landlock") {
+		t.Errorf("output = %q, want sentinel content", string(out))
+	}
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
 }
 
 func TestApplyPlatformSandbox_Linux_RunsRealBinaryUnderSandbox(t *testing.T) {

--- a/internal/sandbox/spawnhelper/landlock_linux.go
+++ b/internal/sandbox/spawnhelper/landlock_linux.go
@@ -1,0 +1,150 @@
+//go:build linux
+
+package spawnhelper
+
+import (
+	"fmt"
+	"unsafe"
+
+	"golang.org/x/sys/unix"
+)
+
+// Landlock rule-type constants. ABI v1 ships with only
+// PATH_BENEATH (subtree-rooted file-access rules). Newer ABIs
+// add NET_PORT and other types; the runtime only uses PATH_BENEATH.
+// `golang.org/x/sys/unix` v0.44.0 exposes the access-bit flags but
+// not the rule-type number, so the runtime declares it locally.
+const landlockRulePathBeneath = 1
+
+// landlockReadAccess is the bitmask of access types this runtime
+// declares as "readable" for a manifest's `fs_read` scope. ABI v1
+// distinguishes file-read from directory-read; both are needed for
+// a wrapped CLI that lists a directory and reads its files.
+const landlockReadAccess = unix.LANDLOCK_ACCESS_FS_READ_FILE | unix.LANDLOCK_ACCESS_FS_READ_DIR
+
+// landlockWriteAccess is the bitmask granted to `fs_write` scopes.
+// Beyond `WRITE_FILE`, write-scope use cases (caches, output dirs)
+// typically also need to create, delete, and rename within the
+// subtree. ABI v1 caps the set at REG/CHAR/DIR/SOCK/FIFO/BLOCK/SYM
+// makes plus the removes; newer ABIs add TRUNCATE (v3) and REFER
+// (v2) which the runtime can extend later.
+const landlockWriteAccess = unix.LANDLOCK_ACCESS_FS_WRITE_FILE |
+	unix.LANDLOCK_ACCESS_FS_REMOVE_DIR |
+	unix.LANDLOCK_ACCESS_FS_REMOVE_FILE |
+	unix.LANDLOCK_ACCESS_FS_MAKE_CHAR |
+	unix.LANDLOCK_ACCESS_FS_MAKE_DIR |
+	unix.LANDLOCK_ACCESS_FS_MAKE_REG |
+	unix.LANDLOCK_ACCESS_FS_MAKE_SOCK |
+	unix.LANDLOCK_ACCESS_FS_MAKE_FIFO |
+	unix.LANDLOCK_ACCESS_FS_MAKE_BLOCK |
+	unix.LANDLOCK_ACCESS_FS_MAKE_SYM
+
+// applyLandlock creates a Landlock ruleset that governs file
+// reads and writes, adds an allow rule per manifest path, sets
+// `PR_SET_NO_NEW_PRIVS` so the restriction survives subsequent
+// execve calls, and finally restricts the calling process to the
+// ruleset. After return, the helper (and the wrapped CLI it
+// exec's into) can access only the declared paths.
+//
+// Returns nil when both lists are empty (no Landlock restriction
+// configured — the legacy v1 behavior for connectors without
+// FS scopes declared). Returns an error if any syscall fails;
+// the helper surfaces this as a non-zero exit so the runtime
+// audit row records a sandbox setup failure rather than a
+// silently-unconfined spawn.
+func applyLandlock(fsRead, fsWrite []string) error {
+	if len(fsRead) == 0 && len(fsWrite) == 0 {
+		return nil
+	}
+
+	// Create the ruleset declaring the access types we'll govern.
+	// Once a type is in handled_access_fs, the kernel denies it by
+	// default; subsequent add-rule calls re-grant specific subtrees.
+	attr := unix.LandlockRulesetAttr{
+		Access_fs: landlockReadAccess | landlockWriteAccess,
+	}
+	rulesetFD, _, errno := unix.Syscall(
+		unix.SYS_LANDLOCK_CREATE_RULESET,
+		uintptr(unsafe.Pointer(&attr)),
+		unsafe.Sizeof(attr),
+		0,
+	)
+	if errno != 0 {
+		return fmt.Errorf("landlock_create_ruleset: %w", errno)
+	}
+	defer unix.Close(int(rulesetFD))
+
+	for _, p := range fsRead {
+		if err := addLandlockPathRule(int(rulesetFD), p, landlockReadAccess); err != nil {
+			return err
+		}
+	}
+	for _, p := range fsWrite {
+		// Write scopes get read+write because most write operations
+		// open the file for both. Without this, a CLI that writes
+		// to a cache directory by reading-modifying-writing fails
+		// at the read step.
+		if err := addLandlockPathRule(int(rulesetFD), p, landlockReadAccess|landlockWriteAccess); err != nil {
+			return err
+		}
+	}
+
+	// PR_SET_NO_NEW_PRIVS prevents the kernel from re-granting
+	// privileges across execve(setuid_binary). Landlock requires
+	// this be set before restrict_self per the kernel docs;
+	// without it, the call fails with EPERM.
+	if err := unix.Prctl(unix.PR_SET_NO_NEW_PRIVS, 1, 0, 0, 0); err != nil {
+		return fmt.Errorf("prctl(PR_SET_NO_NEW_PRIVS): %w", err)
+	}
+
+	_, _, errno = unix.Syscall(unix.SYS_LANDLOCK_RESTRICT_SELF, rulesetFD, 0, 0)
+	if errno != 0 {
+		return fmt.Errorf("landlock_restrict_self: %w", errno)
+	}
+	return nil
+}
+
+// addLandlockPathRule opens `path` as an O_PATH file descriptor
+// and adds an allow rule covering it (and everything beneath it,
+// per Landlock's `path-beneath` semantics) for the given access
+// mask. The FD is closed before return; the kernel retains a
+// reference internally.
+func addLandlockPathRule(rulesetFD int, path string, access uint64) error {
+	fd, err := unix.Open(path, unix.O_PATH|unix.O_CLOEXEC, 0)
+	if err != nil {
+		return fmt.Errorf("landlock open %q: %w", path, err)
+	}
+	defer unix.Close(fd)
+	pathAttr := unix.LandlockPathBeneathAttr{
+		Allowed_access: access,
+		Parent_fd:      int32(fd),
+	}
+	_, _, errno := unix.Syscall6(
+		unix.SYS_LANDLOCK_ADD_RULE,
+		uintptr(rulesetFD),
+		landlockRulePathBeneath,
+		uintptr(unsafe.Pointer(&pathAttr)),
+		0, 0, 0,
+	)
+	if errno != 0 {
+		return fmt.Errorf("landlock_add_rule %q: %w", path, errno)
+	}
+	return nil
+}
+
+// landlockSupported reports whether the running kernel exposes
+// the Landlock API. Returns false on kernels older than 5.13 or
+// kernels built without CONFIG_SECURITY_LANDLOCK.
+//
+// The probe uses `landlock_create_ruleset(NULL, 0, LANDLOCK_CREATE_RULESET_VERSION)`,
+// which returns the supported ABI version on success and an
+// errno on failure. Caller treats any non-positive return as
+// "unsupported."
+func landlockSupported() bool {
+	r1, _, _ := unix.Syscall(
+		unix.SYS_LANDLOCK_CREATE_RULESET,
+		0, 0,
+		unix.LANDLOCK_CREATE_RULESET_VERSION,
+	)
+	return int(r1) >= 1
+}

--- a/internal/sandbox/spawnhelper/request.go
+++ b/internal/sandbox/spawnhelper/request.go
@@ -1,0 +1,114 @@
+// Package spawnhelper defines the post-namespace setup step that
+// runs inside the spawn-sandbox namespace before the wrapped CLI
+// exec's. The runtime cannot install Landlock rules or do a
+// pivot_root from outside the namespace, and Go's `syscall.SysProcAttr`
+// has no hook between clone() and exec() for in-namespace code,
+// so the runtime re-execs the daemon binary with a hidden flag
+// (`__spawn-helper`) and the daemon's main() dispatches to
+// [Run] when it sees that argv.
+//
+// The re-exec runs as PID 1 inside the namespace ADR-0014's Linux
+// section sets up; it applies Landlock filesystem restrictions
+// (read scopes from `fs_read`, write scopes from `fs_write`) and
+// then `syscall.Exec`s into the wrapped CLI, replacing itself.
+//
+// This package is split from `internal/sandbox` so `cmd/aileron`
+// can import only the dispatch entry point at process start
+// without dragging the full sandbox subtree in.
+package spawnhelper
+
+import (
+	"encoding/base64"
+	"encoding/json"
+	"fmt"
+)
+
+// Request is the directive the runtime serializes onto the
+// re-exec'd helper's argv. The helper applies the declared
+// Landlock rules to its own process and then exec's into the
+// wrapped program.
+//
+// Fields are intentionally pure data (no handles, no pointers,
+// no platform types) so the marshalled form is portable and
+// debuggable. The transport is base64-encoded JSON via a single
+// argv element after the `__spawn-helper` marker; argv was
+// chosen over env or FD-passing because it survives /proc/self
+// inspection (useful for post-hoc debugging) and the contents
+// carry no secrets (credentials are injected into Env by the
+// runtime as plain env keys the wrapped CLI reads).
+type Request struct {
+	// Program is the absolute path of the binary the helper
+	// should exec into. Required.
+	Program string `json:"program"`
+
+	// Argv is the full argument vector (argv[0] = program name
+	// the CLI sees, etc.). Required, non-empty.
+	Argv []string `json:"argv"`
+
+	// Env is the environment the wrapped CLI inherits. Each entry
+	// is `KEY=value`. The runtime injects credentials and proxy
+	// addresses here; the helper passes the slice through unchanged.
+	Env []string `json:"env,omitempty"`
+
+	// Cwd, when non-empty, is the working directory the helper
+	// chdir's into before exec'ing. The runtime resolves any
+	// `~/`-anchored manifest cwd before assembling the request,
+	// so this is always an absolute host path.
+	Cwd string `json:"cwd,omitempty"`
+
+	// FSRead and FSWrite are the manifest's filesystem scopes
+	// the helper translates into Landlock allow rules. Paths are
+	// absolute host paths (the runtime expands `~/` before
+	// assembling the request). A trailing slash conventionally
+	// indicates a directory subtree; Landlock's `path-beneath`
+	// rules apply to subtrees regardless.
+	FSRead  []string `json:"fs_read,omitempty"`
+	FSWrite []string `json:"fs_write,omitempty"`
+}
+
+// HelperArgvMarker is the first argv element the runtime passes
+// to the re-exec'd daemon binary to signal "you are running as
+// the spawn helper; parse the request from argv[2]." Hidden from
+// the user-facing CLI's help text and command dispatch.
+const HelperArgvMarker = "__spawn-helper"
+
+// EncodeRequest serializes the request into the single argv
+// element the runtime passes after [HelperArgvMarker]. Base64
+// shields against shells, logging systems, and `ps` truncating
+// or interpreting embedded JSON metacharacters.
+func EncodeRequest(req Request) (string, error) {
+	if req.Program == "" {
+		return "", fmt.Errorf("spawnhelper: Program is required")
+	}
+	if len(req.Argv) == 0 {
+		return "", fmt.Errorf("spawnhelper: Argv is required")
+	}
+	raw, err := json.Marshal(req)
+	if err != nil {
+		return "", fmt.Errorf("spawnhelper: marshal request: %w", err)
+	}
+	return base64.StdEncoding.EncodeToString(raw), nil
+}
+
+// DecodeRequest parses the base64-encoded JSON the runtime
+// embedded in argv. Returns an error when the encoding is
+// malformed or required fields are absent so the helper fails
+// loudly rather than silently passing a malformed request to
+// `syscall.Exec`.
+func DecodeRequest(encoded string) (Request, error) {
+	var req Request
+	raw, err := base64.StdEncoding.DecodeString(encoded)
+	if err != nil {
+		return req, fmt.Errorf("spawnhelper: base64 decode: %w", err)
+	}
+	if err := json.Unmarshal(raw, &req); err != nil {
+		return req, fmt.Errorf("spawnhelper: unmarshal request: %w", err)
+	}
+	if req.Program == "" {
+		return req, fmt.Errorf("spawnhelper: decoded request missing Program")
+	}
+	if len(req.Argv) == 0 {
+		return req, fmt.Errorf("spawnhelper: decoded request missing Argv")
+	}
+	return req, nil
+}

--- a/internal/sandbox/spawnhelper/request_test.go
+++ b/internal/sandbox/spawnhelper/request_test.go
@@ -1,0 +1,103 @@
+package spawnhelper
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestEncodeDecode_RoundTrip(t *testing.T) {
+	// Contract: a request encoded by the runtime and decoded by the
+	// helper recovers every field. Round-trip is the load-bearing
+	// property of the transport.
+	req := Request{
+		Program: "/usr/bin/git",
+		Argv:    []string{"git", "log", "--since=2026-01-01"},
+		Env:     []string{"PATH=/usr/bin", "GIT_AUTHOR_NAME=alr"},
+		Cwd:     "/Users/alr/code/aileron",
+		FSRead:  []string{"/Users/alr/code/", "/etc/gitconfig"},
+		FSWrite: []string{"/Users/alr/.cache/aileron/"},
+	}
+	encoded, err := EncodeRequest(req)
+	if err != nil {
+		t.Fatalf("EncodeRequest: %v", err)
+	}
+	decoded, err := DecodeRequest(encoded)
+	if err != nil {
+		t.Fatalf("DecodeRequest: %v", err)
+	}
+	if decoded.Program != req.Program {
+		t.Errorf("Program = %q, want %q", decoded.Program, req.Program)
+	}
+	if !equalSlice(decoded.Argv, req.Argv) {
+		t.Errorf("Argv = %v, want %v", decoded.Argv, req.Argv)
+	}
+	if !equalSlice(decoded.Env, req.Env) {
+		t.Errorf("Env = %v, want %v", decoded.Env, req.Env)
+	}
+	if decoded.Cwd != req.Cwd {
+		t.Errorf("Cwd = %q, want %q", decoded.Cwd, req.Cwd)
+	}
+	if !equalSlice(decoded.FSRead, req.FSRead) {
+		t.Errorf("FSRead = %v, want %v", decoded.FSRead, req.FSRead)
+	}
+	if !equalSlice(decoded.FSWrite, req.FSWrite) {
+		t.Errorf("FSWrite = %v, want %v", decoded.FSWrite, req.FSWrite)
+	}
+}
+
+func TestEncodeRequest_RejectsMissingProgram(t *testing.T) {
+	_, err := EncodeRequest(Request{Argv: []string{"x"}})
+	if err == nil || !strings.Contains(err.Error(), "Program") {
+		t.Errorf("expected Program-required error, got %v", err)
+	}
+}
+
+func TestEncodeRequest_RejectsMissingArgv(t *testing.T) {
+	_, err := EncodeRequest(Request{Program: "/bin/echo"})
+	if err == nil || !strings.Contains(err.Error(), "Argv") {
+		t.Errorf("expected Argv-required error, got %v", err)
+	}
+}
+
+func TestDecodeRequest_RejectsBadBase64(t *testing.T) {
+	_, err := DecodeRequest("!!not base64!!")
+	if err == nil || !strings.Contains(err.Error(), "base64") {
+		t.Errorf("expected base64 decode error, got %v", err)
+	}
+}
+
+func TestDecodeRequest_RejectsBadJSON(t *testing.T) {
+	_, err := DecodeRequest("bm90IGpzb24=") // base64("not json")
+	if err == nil || !strings.Contains(err.Error(), "unmarshal") {
+		t.Errorf("expected unmarshal error, got %v", err)
+	}
+}
+
+func TestDecodeRequest_RejectsMissingProgramAfterDecode(t *testing.T) {
+	// Wire-format tampering: someone could base64-encode a JSON
+	// blob that's syntactically valid but missing required fields.
+	// The helper has to fail closed.
+	encoded, err := EncodeRequest(Request{Program: "/bin/x", Argv: []string{"x"}})
+	if err != nil {
+		t.Fatal(err)
+	}
+	// Substitute the encoded blob with one that decodes to {} —
+	// `{}` is base64 `e30=`.
+	_, err = DecodeRequest("e30=")
+	if err == nil || !strings.Contains(err.Error(), "Program") {
+		t.Errorf("expected Program-required error after empty decode, got %v", err)
+	}
+	_ = encoded
+}
+
+func equalSlice(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sandbox/spawnhelper/run_linux.go
+++ b/internal/sandbox/spawnhelper/run_linux.go
@@ -1,0 +1,60 @@
+//go:build linux
+
+package spawnhelper
+
+import (
+	"fmt"
+	"os"
+	"syscall"
+)
+
+// Run is the entry point the daemon's main() dispatches to when
+// it sees [HelperArgvMarker] as its first argv. The function
+// parses the request, applies Landlock filesystem restrictions,
+// optionally chdir's, and then `syscall.Exec`s into the wrapped
+// program — replacing this helper process with the CLI under
+// the configured confinement.
+//
+// Never returns on success; the Exec syscall replaces the
+// process image. On any failure (malformed request, Landlock
+// unavailable, Exec failure) writes a structured error message
+// to stderr and exits with code 1 so the runtime audit row
+// records a sandbox-setup failure rather than a silently
+// unconfined spawn.
+func Run(encodedReq string) {
+	req, err := DecodeRequest(encodedReq)
+	if err != nil {
+		failHelper("decode request: %v", err)
+	}
+
+	if err := applyLandlock(req.FSRead, req.FSWrite); err != nil {
+		failHelper("apply Landlock: %v", err)
+	}
+
+	if req.Cwd != "" {
+		if err := os.Chdir(req.Cwd); err != nil {
+			failHelper("chdir %s: %v", req.Cwd, err)
+		}
+	}
+
+	// syscall.Exec replaces this process with the wrapped CLI.
+	// The Env defaults to os.Environ() when the request didn't
+	// carry one; the runtime always provides Env in production
+	// but the fallback keeps the helper testable in isolation.
+	env := req.Env
+	if env == nil {
+		env = os.Environ()
+	}
+	if err := syscall.Exec(req.Program, req.Argv, env); err != nil {
+		// Exec only returns on failure.
+		failHelper("exec %s: %v", req.Program, err)
+	}
+}
+
+// failHelper writes a `spawn-helper: <msg>` line to stderr and
+// exits the process with code 1. Centralizes the failure shape
+// so audit logs and tests can match on it.
+func failHelper(format string, args ...any) {
+	fmt.Fprintf(os.Stderr, "spawn-helper: "+format+"\n", args...)
+	os.Exit(1)
+}

--- a/internal/sandbox/spawnhelper/run_other.go
+++ b/internal/sandbox/spawnhelper/run_other.go
@@ -1,0 +1,20 @@
+//go:build !linux
+
+package spawnhelper
+
+import (
+	"fmt"
+	"os"
+)
+
+// Run on non-Linux platforms is a structured-failure stub. The
+// runtime only re-execs into the helper on Linux (per ADR-0014's
+// platform sandbox section); seeing the helper marker on another
+// OS means the runtime has a wiring bug or the daemon binary is
+// being invoked from outside the runtime's spawn path. Either
+// way, fail loudly rather than silently passing through.
+func Run(encodedReq string) {
+	_ = encodedReq
+	fmt.Fprintln(os.Stderr, "spawn-helper: invoked on a non-Linux platform; helper is a Linux-only construct (see ADR-0014)")
+	os.Exit(1)
+}


### PR DESCRIPTION
## Summary

Closes the Linux FS-confinement gap from v1 ([#723](https://github.com/ALRubinger/aileron/pull/723)). The wrapped CLI now runs under kernel-enforced Landlock LSM restrictions in addition to the user/mount/PID namespace isolation from v1. The end-to-end test proves the kernel rejects reads outside the declared scope.

### The re-exec helper pattern

Per ADR-0014 and the Linux v2 design notes I wrote into [#719](https://github.com/ALRubinger/aileron/issues/719): Go's `SysProcAttr` has no hook to run Go code inside the child between `clone()` and `exec()`. Landlock must be applied inside the namespace, before the wrapped CLI exec's, by the helper itself. The pattern is well-established (Chrome's `--type=zygote/renderer`, Firefox's `MOZ_CHILD_PROCESS_*`):

1. **Parent** (`processSpawn` → `applyPlatformSandbox`) rewires `cmd` to launch the daemon binary instead of the wrapped CLI. `cmd.Args = ["aileron", "__spawn-helper", "<base64-json>"]`. The Cloneflags + UID/GID maps from v1 carry through unchanged so the kernel still forks into the new namespaces.
2. **Daemon's `main()`** dispatches on `__spawn-helper` as its first argv check, before any normal-CLI setup (vault, launcher registry). Hidden from `aileron --help`.
3. **Helper** decodes the request, applies Landlock rules, optionally `chdir`s, then `syscall.Exec`s into the wrapped CLI — replacing itself with the program under the configured confinement.

### What's in the package

New `internal/sandbox/spawnhelper` (split from `internal/sandbox` so `cmd/aileron` doesn't pull in the full sandbox subtree for the dispatch):

- `request.go` (no build tag): `Request` struct + base64/JSON `EncodeRequest` / `DecodeRequest`. Tested cross-platform with round-trip + malformed-input rejection.
- `landlock_linux.go`: `applyLandlock` + `addLandlockPathRule` calling `SYS_LANDLOCK_CREATE_RULESET` / `SYS_LANDLOCK_ADD_RULE` / `SYS_LANDLOCK_RESTRICT_SELF` directly via `unix.Syscall6` (golang.org/x/sys/unix v0.44.0 exposes the ABI v1 constants and struct types but not the syscall wrappers). Sets `PR_SET_NO_NEW_PRIVS` before `restrict_self` per the kernel contract.
- `run_linux.go`: `Run` parses the request, applies Landlock, optional chdir, `syscall.Exec`. `failHelper` writes a structured `spawn-helper:` stderr line and exits 1 on any failure.
- `run_other.go`: non-Linux stub that fails loudly if invoked.

### End-to-end proof

`TestApplyPlatformSandbox_Linux_HelperEnforcesLandlockReadScope` creates two directories under `$HOME`, writes a sentinel file in the denied one, and runs `/bin/cat <sentinel>` under the sandbox with only the allowed directory in `fs_read`. The kernel rejects the read with `EACCES` (Landlock's enforcement) and `cat` exits non-zero with "Permission denied" in stderr.

Its complement `TestApplyPlatformSandbox_Linux_HelperAllowsReadInsideScope` proves the allow rule actually does its job — cat reading inside the declared scope succeeds.

The test binary itself acts as the daemon: `TestMain` dispatches on the helper marker so the re-exec lands in `spawnhelper.Run` rather than recursing the whole test suite.

## Scope

**Delivered:**
- Helper re-exec dispatch in `cmd/aileron/main.go`.
- Landlock LSM rules from manifest fs scopes, kernel-enforced.
- Process / PID / user isolation from v1 (carries through).
- Tests: spawnhelper Request round-trip; cross-compile clean on darwin/windows; end-to-end Landlock proof on ubuntu CI runner.

**Intentionally deferred to v3:**
- `CLONE_NEWNET` activation + bind-mount UDS proxy socket + in-namespace `RunSpawnShim` invocation. Until then, host network is shared and `HTTPS_PROXY` cooperation is the egress mechanism (direct egress is not kernel-blocked on Linux).
- `pivot_root` + custom mount tree. Landlock alone is the FS confinement; pivot_root adds defense-in-depth but isn't load-bearing once Landlock is in place. Consider if a real connector demands it.

## Test plan

- [x] `spawnhelper` Request round-trip (6 tests; runs on every platform)
- [x] Cross-compile clean on darwin and windows
- [x] `TestApplyPlatformSandbox_Linux_RewiresIntoHelperWhenFSScopesDeclared` (runs on darwin/linux/windows via cross-compile + on Linux runner via test execution)
- [x] `TestApplyPlatformSandbox_Linux_NoRewireWhenOnlyProxyAddrDeclared`
- [x] `TestApplyPlatformSandbox_Linux_HelperEnforcesLandlockReadScope` (end-to-end on ubuntu runner)
- [x] `TestApplyPlatformSandbox_Linux_HelperAllowsReadInsideScope` (end-to-end on ubuntu runner)
- [x] `darwin / windows` Unit Tests jobs continue to pass (signature stable)

The ubuntu runner is where the load-bearing Landlock-enforcement signal lives. If the runner's kernel disables Landlock or denies the helper's syscall sequence, the end-to-end tests will fail with surfaced details.

## Out of scope, follow-up

- **Linux v3 (network namespace + shim):** `CLONE_NEWNET` + bind-mount UDS proxy + in-namespace `RunSpawnShim`. Final piece for kernel-enforced egress on Linux. Design notes in [#719](https://github.com/ALRubinger/aileron/issues/719).
- **Windows v2:** WFP rules for per-PID egress filtering.
- **Cross-platform finishing:** audit `platform` field, install-time sandbox-available probe.

Refs [#619](https://github.com/ALRubinger/aileron/issues/619) [#719](https://github.com/ALRubinger/aileron/issues/719).