### PR TITLE
feat(action): consume composite install-decision in action add-suite

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -1615,6 +1615,17 @@ type hubActionInstallDecisionWire struct {
 	Authorities     []hubInstallAuthorityWire `json:"authorities"`
 }
 
+// hubSuiteInstallDecisionWire mirrors api.HubSuiteInstallDecision —
+// the composite payload returned by /v1/hub/suite-install-decision.
+type hubSuiteInstallDecisionWire struct {
+	Kind            string                    `json:"kind"`
+	Fqn             string                    `json:"fqn"`
+	Description     string                    `json:"description"`
+	PublisherGithub string                    `json:"publisher_github"`
+	MemberActions   []string                  `json:"member_actions"`
+	Authorities     []hubInstallAuthorityWire `json:"authorities"`
+}
+
 // runConnectorInstall implements the consent flow per ADR-0007 with
 // the Hub install-decision layer added on top per ADR-0013 / #487:
 //
@@ -2003,6 +2014,150 @@ func renderHubActionCompositeDecision(w io.Writer, d *hubActionInstallDecisionWi
 		}
 	}
 	fmt.Fprintln(w)
+}
+
+// tryHubSuiteInstallDecisionFlow is the suite-level counterpart to
+// tryHubActionInstallDecisionFlow. Asks the daemon for
+// /v1/hub/suite-install-decision and, when the suite is Hub-listed,
+// renders the composite trust panel (suite metadata + member actions
+// + per-authority trust gates) and collapses every per-authority
+// consent into a single y/N/d=details prompt.
+//
+// Fall-through, error-note, and empty-payload semantics match the
+// action variant.
+func tryHubSuiteInstallDecisionFlow(suiteFQN string, autoYes bool, stdin io.Reader, stdout, stderr io.Writer) (accepted, declined, hubPath bool, payload *hubSuiteInstallDecisionWire) {
+	q := url.Values{"fqn": []string{suiteFQN}}.Encode()
+	status, body, err := bindingDoRequest(http.MethodGet, "/hub/suite-install-decision?"+q, nil)
+	if err != nil {
+		fmt.Fprintf(stderr, "note: hub install-decision unavailable (%v); using local trust\n", err)
+		return false, false, false, nil
+	}
+	if status == http.StatusNotFound || status == http.StatusUnprocessableEntity {
+		return false, false, false, nil
+	}
+	if status != http.StatusOK {
+		fmt.Fprintf(stderr, "note: hub install-decision returned %d; using local trust\n", status)
+		return false, false, false, nil
+	}
+	var d hubSuiteInstallDecisionWire
+	if err := json.Unmarshal(body, &d); err != nil {
+		fmt.Fprintf(stderr, "note: could not parse hub install-decision (%v); using local trust\n", err)
+		return false, false, false, nil
+	}
+	if d.Fqn == "" || len(d.Authorities) == 0 {
+		return false, false, false, nil
+	}
+
+	if autoYes {
+		return true, false, true, &d
+	}
+
+	br, ok := stdin.(*bufio.Reader)
+	if !ok {
+		br = bufio.NewReader(stdin)
+	}
+
+	showDetails := false
+	for {
+		renderHubSuiteCompositeDecision(stdout, &d, showDetails)
+		var ans string
+		if showDetails {
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and continue? [y/N]: ")))
+		} else {
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and continue? [y/N/d=details]: ")))
+		}
+		switch ans {
+		case "y", "yes":
+			return true, false, true, &d
+		case "d", "details":
+			if showDetails {
+				fmt.Fprintln(stdout, "Cancelled.")
+				return false, true, true, &d
+			}
+			showDetails = true
+			continue
+		default:
+			fmt.Fprintln(stdout, "Cancelled.")
+			return false, true, true, &d
+		}
+	}
+}
+
+// renderHubSuiteCompositeDecision prints the composite trust panel for
+// a suite install. Suite-level metadata at the top, member actions in
+// the middle, one panel per connector authority below. Per-authority
+// trust state and risks use the same colorization as the connector and
+// action variants.
+//
+// `verbose` expands risk indicators (one per line; compact mode shows
+// the first only) and adds the per-authority publisher footprint.
+func renderHubSuiteCompositeDecision(w io.Writer, d *hubSuiteInstallDecisionWire, verbose bool) {
+	fmt.Fprintln(w)
+	fmt.Fprintln(w, "\033[1mHub install-decision (suite)\033[0m")
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  Suite:     %s\n", d.Fqn)
+	if d.Description != "" {
+		fmt.Fprintf(w, "  Summary:   %s\n", d.Description)
+	}
+	fmt.Fprintf(w, "  Publisher: %s\n", d.PublisherGithub)
+	if len(d.MemberActions) > 0 {
+		fmt.Fprintf(w, "  Actions:   %d\n", len(d.MemberActions))
+		for _, a := range d.MemberActions {
+			fmt.Fprintf(w, "    - %s\n", a)
+		}
+	}
+	fmt.Fprintln(w)
+	fmt.Fprintf(w, "  \033[1mTrust gate(s): %d connector authorit(y|ies)\033[0m\n", len(d.Authorities))
+	for _, auth := range d.Authorities {
+		fmt.Fprintln(w)
+		fmt.Fprintf(w, "  ● %s\n", auth.Fqn)
+		fmt.Fprintf(w, "      Publisher:   %s\n", auth.PublisherGithub)
+		fmt.Fprintf(w, "      Fingerprint: %s\n", auth.Fingerprint)
+		fmt.Fprintf(w, "      Trust:       %s\n", colorizeTrustState(auth.TrustState))
+		if len(auth.RiskIndicators) > 0 {
+			risks := auth.RiskIndicators
+			if !verbose && len(risks) > 1 {
+				risks = risks[:1]
+			}
+			for _, r := range risks {
+				fmt.Fprintf(w, "      Risk:        %s\n", colorizeRisk(auth.TrustState, r))
+			}
+		}
+		if verbose && len(auth.PublisherFootprint) > 0 {
+			fmt.Fprintln(w, "      Other connectors by this publisher:")
+			for _, fqn := range auth.PublisherFootprint {
+				fmt.Fprintf(w, "        - %s\n", fqn)
+			}
+		}
+	}
+	fmt.Fprintln(w)
+}
+
+// deriveHubSuiteFQN translates a remote suite source's parsed FQN into
+// the canonical Hub suite FQN. The Hub catalogs suites by
+// `<scheme>://<owner>/<repo>/<subpath-without-.toml>` while CLI users
+// type `<scheme>://<owner>/<repo>/<subpath>.toml@<ref>`.
+//
+// Returns an empty string when the source isn't shaped like a TOML
+// path under a git-host scheme — local sources and non-`.toml`
+// subpaths skip the Hub composite flow.
+func deriveHubSuiteFQN(parsed cstore.FQN) string {
+	if parsed.Scheme != "github" && parsed.Scheme != "gitlab" {
+		return ""
+	}
+	if parsed.Owner == "" || parsed.Repo == "" || parsed.Subpath == "" {
+		return ""
+	}
+	subpath := parsed.Subpath
+	const tomlExt = ".toml"
+	if !strings.HasSuffix(subpath, tomlExt) {
+		return ""
+	}
+	subpath = strings.TrimSuffix(subpath, tomlExt)
+	if subpath == "" {
+		return ""
+	}
+	return parsed.Scheme + "://" + parsed.Owner + "/" + parsed.Repo + "/" + subpath
 }
 
 // colorizeTrustState renders a trust-state label with ANSI color:
@@ -2668,6 +2823,9 @@ func runActionAddSuite(args []string, stdin io.Reader, stdout, stderr io.Writer)
 // runActionAddSuiteLocal handles a filesystem-path source: read,
 // parse, resolve with no inheritance context (path-form entries
 // in a local manifest are an error), then drive the shared loop.
+// Local sources never carry a Hub suite FQN, so the composite flow
+// is skipped — the install runs through the legacy per-authority
+// preflight unchanged.
 func runActionAddSuiteLocal(path string, opts actionAddOptions, stdin *bufio.Reader, stdout, stderr io.Writer) int {
 	data, err := os.ReadFile(path)
 	if err != nil {
@@ -2684,7 +2842,7 @@ func runActionAddSuiteLocal(path string, opts actionAddOptions, stdin *bufio.Rea
 		fmt.Fprintf(stderr, "error: %s: %v\n", path, err)
 		return 1
 	}
-	return installSuiteEntries(manifest, refs, opts, stdin, stdout, stderr)
+	return installSuiteEntries(manifest, refs, "", opts, stdin, stdout, stderr)
 }
 
 // runActionAddSuiteRemote handles an FQN-style source: parse the
@@ -2735,7 +2893,11 @@ func runActionAddSuiteRemote(source string, opts actionAddOptions, stdin *bufio.
 		fmt.Fprintf(stderr, "error: %s: %v\n", display, err)
 		return 1
 	}
-	return installSuiteEntries(manifest, refs, opts, stdin, stdout, stderr)
+	// Heuristic: a remote source ending in `.toml` maps to a Hub suite
+	// FQN by stripping the extension. The composite flow no-ops when
+	// the Hub doesn't list it (404 fall-through).
+	hubFQN := deriveHubSuiteFQN(suiteFQN)
+	return installSuiteEntries(manifest, refs, hubFQN, opts, stdin, stdout, stderr)
 }
 
 // installSuiteEntries drives a suite install in three phases (#640):
@@ -2753,7 +2915,7 @@ func runActionAddSuiteRemote(source string, opts actionAddOptions, stdin *bufio.
 //     (already shown in phase 2); no Y/N prompts fire. Per-action
 //     failures stay failure-soft; the summary at the end reports
 //     counts and a nonzero exit if anything failed.
-func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, opts actionAddOptions, stdin *bufio.Reader, stdout, stderr io.Writer) int {
+func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, hubSuiteFQN string, opts actionAddOptions, stdin *bufio.Reader, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "Suite: %s\n", manifest.Name)
 	if manifest.Description != "" {
 		fmt.Fprintf(stdout, "  %s\n", manifest.Description)
@@ -2761,6 +2923,46 @@ func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, opts actio
 	fmt.Fprintf(stdout, "  %d action(s) to install\n", len(refs))
 
 	trust := newTrustState()
+
+	// Phase 0 (#709): when the suite is Hub-listed, render the composite
+	// trust panel covering every connector authority in the dependency
+	// closure and collapse per-authority consent into a single y/N.
+	// On accept, seed trustState so the legacy preflight prompts in
+	// phases 1a and 1c short-circuit; the operator sees one trust
+	// gate, not N.
+	if hubSuiteFQN != "" {
+		accepted, hubDeclined, hubPath, payload := tryHubSuiteInstallDecisionFlow(
+			hubSuiteFQN, opts.yes, stdin, stdout, stderr)
+		if hubDeclined {
+			return 0
+		}
+		if hubPath && accepted && payload != nil {
+			for _, auth := range payload.Authorities {
+				authFQN, parseErr := cstore.ParseFQN(auth.Fqn)
+				if parseErr != nil {
+					continue
+				}
+				if err := trust.ensure(authFQN.Authority(), true, stdin, stdout, stderr); err != nil {
+					fmt.Fprintf(stderr, "error: %v\n", err)
+					return 1
+				}
+			}
+			// Each member action's signing authority is what `aileron
+			// connector install` would sign against; phase 1a re-checks
+			// these so we pre-seed them here too. A typical same-
+			// publisher suite collapses to one trust.ensure call.
+			for _, a := range payload.MemberActions {
+				memberFQN, parseErr := cstore.ParseFQN(a)
+				if parseErr != nil {
+					continue
+				}
+				if err := trust.ensure(memberFQN.Authority(), true, stdin, stdout, stderr); err != nil {
+					fmt.Fprintf(stderr, "error: %v\n", err)
+					return 1
+				}
+			}
+		}
+	}
 
 	// Phase 1a: trust action authorities up front so preview can
 	// verify signatures. Any decline here aborts the suite before

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -5085,6 +5085,618 @@ actions = [
 	}
 }
 
+// suiteAndKeyRawServer is a combined stand-in for raw.githubusercontent.com
+// that serves BOTH the suite manifest (at the convention path) AND the
+// publisher key (at /<owner>/<repo>/HEAD/keys/publisher.pub). The two
+// existing helpers (`remoteSuiteServer` + `withMockGitHubRaw`) each
+// rewrite `rawGitHubBase`, so combining them in the same test would
+// race; the last one wins and the other endpoint 404s. This helper
+// avoids that by routing both paths through one server.
+//
+// Also stands up the releases API mock at `/repos/<owner>/<repo>/releases/latest`
+// returning the given tagName, so @latest resolves cleanly.
+func suiteAndKeyRawServer(t *testing.T, owner, repo, filePath, tagName, suiteTOML string, publisherPEM []byte) {
+	t.Helper()
+	apiSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		want := "/repos/" + owner + "/" + repo + "/releases/latest"
+		if r.URL.Path != want {
+			t.Errorf("unexpected api path: %s, want %s", r.URL.Path, want)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		fmt.Fprintf(w, `{"tag_name":%q}`, tagName)
+	}))
+	t.Cleanup(apiSrv.Close)
+
+	keyPath := "/" + owner + "/" + repo + "/HEAD/keys/publisher.pub"
+	rawSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == keyPath {
+			w.Header().Set("Content-Type", "application/octet-stream")
+			_, _ = w.Write(publisherPEM)
+			return
+		}
+		if strings.HasSuffix(r.URL.Path, "/"+filePath) {
+			_, _ = w.Write([]byte(suiteTOML))
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(rawSrv.Close)
+
+	prevAPI := githubAPIBase
+	githubAPIBase = apiSrv.URL
+	t.Cleanup(func() { githubAPIBase = prevAPI })
+
+	prevRaw := rawGitHubBase
+	rawGitHubBase = rawSrv.URL
+	t.Cleanup(func() { rawGitHubBase = prevRaw })
+}
+
+// --- suite composite install-decision (#709 / #725 sibling) ---
+
+// TestRunActionAddSuiteRemote_HubCompositeAcceptSeedsTrust is the
+// headline #709 suite test: when the suite's source maps to a Hub-
+// listed suite FQN, the CLI renders one composite trust panel covering
+// every connector authority in the dependency closure and one y/N. On
+// accept, trust is seeded for every surfaced authority plus every
+// member-action authority. The legacy per-authority preflight prompts
+// in installSuiteEntries short-circuit because trustState already
+// has them.
+func TestRunActionAddSuiteRemote_HubCompositeAcceptSeedsTrust(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	const suiteTOML = `
+name = "hub-suite"
+description = "Three actions"
+
+actions = [
+  "actions/foo",
+  "actions/bar",
+]
+`
+	suiteAndKeyRawServer(t, "acme", "conn", "suite.toml", "v0.0.6", suiteTOML, pemBytes)
+
+	hubCalled := 0
+	installed := map[string]int{}
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			FQN string `json:"fqn"`
+		}
+		_ = json.Unmarshal(body, &req)
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		switch r.URL.Path {
+		case "/hub/suite-install-decision":
+			hubCalled++
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"kind":"suite",
+				"fqn":"github://acme/conn/suite",
+				"description":"Three actions",
+				"publisher_github":"acme",
+				"member_actions":["github://acme/conn/actions/foo","github://acme/conn/actions/bar"],
+				"authorities":[{
+					"fqn":"github://acme/conn","publisher_github":"acme",
+					"fingerprint":"sha256:any","trust_state":"unknown",
+					"publisher_footprint":[],"risk_indicators":["First connector by this publisher you've installed"]
+				}]
+			}`)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.0.6","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			installed[req.FQN]++
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.0.6","source":"x","path":"/p"}`,
+				lastSegment(req.FQN), req.FQN)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	// One y at the composite prompt, one y at the suite-install consent.
+	// Legacy per-authority "Publisher is not yet trusted" prompts MUST
+	// NOT fire — the composite covered them.
+	stdin := bufio.NewReader(strings.NewReader("y\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"github://acme/conn/suite.toml@v0.0.6"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if hubCalled != 1 {
+		t.Errorf("composite endpoint should fire exactly once, got %d", hubCalled)
+	}
+	if installed["github://acme/conn/actions/foo"] != 1 || installed["github://acme/conn/actions/bar"] != 1 {
+		t.Errorf("expected both actions installed; got %v", installed)
+	}
+	out := stdout.String()
+	for _, want := range []string{
+		"Hub install-decision (suite)",
+		"Suite:     github://acme/conn/suite",
+		"Actions:   2",
+		"github://acme/conn/actions/foo",
+		"Trust these publishers and continue?",
+	} {
+		if !strings.Contains(out, want) {
+			t.Errorf("output missing %q:\n%s", want, out)
+		}
+	}
+	// Per-authority y/N trust prompts MUST NOT fire — the composite
+	// covered them. The "Publisher X is not yet trusted" informational
+	// line still prints (ensureAuthorityTrusted always announces what
+	// it's about to do), but no interactive prompt follows because the
+	// composite-accept seeds trust with autoYes=true.
+	if strings.Contains(out, "Trust publisher github://acme/conn?") {
+		t.Errorf("legacy per-authority y/N prompt fired after composite accept:\n%s", out)
+	}
+	// Trust must persist to the keyring — both the connector authority
+	// and the action authorities (same authority in this same-publisher
+	// suite) are now trusted via the composite-accept seed.
+	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !kr.HasKey("github://acme/conn", pub) {
+		t.Error("keyring should contain trusted key after composite accept")
+	}
+}
+
+// TestRunActionAddSuiteRemote_HubCompositeDeclineAborts: declining the
+// composite trust prompt aborts the suite install cleanly (exit 0,
+// no preview/install calls, keyring stays empty).
+func TestRunActionAddSuiteRemote_HubCompositeDeclineAborts(t *testing.T) {
+	home := withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	const suiteTOML = `
+name = "hub-suite"
+description = "x"
+actions = ["actions/foo"]
+`
+	suiteAndKeyRawServer(t, "acme", "conn", "suite.toml", "v0.0.6", suiteTOML, pemBytes)
+
+	previewCalled, installCalled := false, false
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		switch r.URL.Path {
+		case "/hub/suite-install-decision":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"kind":"suite","fqn":"github://acme/conn/suite",
+				"description":"x","publisher_github":"acme",
+				"member_actions":["github://acme/conn/actions/foo"],
+				"authorities":[{
+					"fqn":"github://acme/conn","publisher_github":"acme",
+					"fingerprint":"sha256:any","trust_state":"unknown",
+					"publisher_footprint":[],"risk_indicators":["x"]
+				}]
+			}`)
+		case "/actions/preview":
+			previewCalled = true
+		case "/actions/install":
+			installCalled = true
+		}
+	})
+
+	stdin := strings.NewReader("n\n")
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"github://acme/conn/suite.toml@v0.0.6"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Errorf("expected clean cancel exit 0, got %d; stderr=%s", code, stderr.String())
+	}
+	if previewCalled || installCalled {
+		t.Errorf("decline should short-circuit; preview=%v install=%v", previewCalled, installCalled)
+	}
+	if !strings.Contains(stdout.String(), "Cancelled.") {
+		t.Errorf("expected 'Cancelled.':\n%s", stdout.String())
+	}
+	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if kr != nil && len(kr.Keys("github://acme/conn")) != 0 {
+		t.Error("keyring should remain empty when composite declined")
+	}
+}
+
+// TestRunActionAddSuiteRemote_HubComposite404FallsThroughToLegacy:
+// when the suite isn't Hub-listed, the composite endpoint 404s and
+// the legacy per-authority preflight runs as before.
+func TestRunActionAddSuiteRemote_HubComposite404FallsThroughToLegacy(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	const suiteTOML = `
+name = "legacy-suite"
+description = "x"
+actions = ["actions/foo"]
+`
+	suiteAndKeyRawServer(t, "acme", "conn", "suite.toml", "v0.0.6", suiteTOML, pemBytes)
+
+	hubCalled, previewCalled, installCalled := false, false, false
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			FQN string `json:"fqn"`
+		}
+		_ = json.Unmarshal(body, &req)
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		switch r.URL.Path {
+		case "/hub/suite-install-decision":
+			hubCalled = true
+			w.WriteHeader(http.StatusNotFound)
+		case "/actions/preview":
+			previewCalled = true
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.0.6","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			installCalled = true
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.0.6","source":"x","path":"/p"}`,
+				lastSegment(req.FQN), req.FQN)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	// One y to legacy trust prompt, one y to suite consent.
+	stdin := bufio.NewReader(strings.NewReader("y\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"github://acme/conn/suite.toml@v0.0.6"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !hubCalled || !previewCalled || !installCalled {
+		t.Errorf("expected fall-through to legacy; hub=%v preview=%v install=%v", hubCalled, previewCalled, installCalled)
+	}
+	if strings.Contains(stdout.String(), "Hub install-decision (suite)") {
+		t.Errorf("composite panel rendered on 404 fall-through:\n%s", stdout.String())
+	}
+	if !strings.Contains(stdout.String(), "Publisher github://acme/conn is not yet trusted") {
+		t.Errorf("legacy trust prompt should fire on fall-through:\n%s", stdout.String())
+	}
+}
+
+// TestRunActionAddSuite_LocalSourceSkipsHubComposite: local file
+// sources never carry a Hub suite FQN, so the composite endpoint is
+// not consulted. The legacy preflight runs unchanged.
+func TestRunActionAddSuite_LocalSourceSkipsHubComposite(t *testing.T) {
+	manifestPath := writeSuiteManifest(t, `
+name = "local-suite"
+description = "x"
+
+actions = [
+  "github://acme/conn/actions/foo@0.1.0",
+]
+`)
+	hubCalled := false
+	suiteInstallServer(t, []string{"github://acme/conn"}, nil, nil)
+	// Wrap the binding server with a sniffer that fails if the composite
+	// endpoint fires. suiteInstallServer already attached a handler;
+	// re-attach by replacing the AILERON_API_URL with a wrapper proxy
+	// is too invasive — instead, assert through path-tracking on the
+	// existing server by registering a custom handler.
+	prevURL := os.Getenv("AILERON_API_URL")
+	t.Setenv("AILERON_API_URL", prevURL) // no-op, just records intent
+	// Replace the existing handler: re-create one that tracks hub calls.
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			FQN string `json:"fqn"`
+		}
+		_ = json.Unmarshal(body, &req)
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		switch r.URL.Path {
+		case "/hub/suite-install-decision", "/hub/action-install-decision":
+			hubCalled = true
+			w.WriteHeader(http.StatusNotFound)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.1.0","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.1.0","source":"x","path":"/p"}`,
+				lastSegment(req.FQN), req.FQN)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite([]string{"--yes", manifestPath}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if hubCalled {
+		t.Error("local-source install should NOT consult the Hub suite-install-decision endpoint")
+	}
+}
+
+// TestRunActionAddSuiteRemote_HubCompositeYesFlagAutoAccepts: --yes
+// short-circuits the composite prompt, just like its action sibling.
+func TestRunActionAddSuiteRemote_HubCompositeYesFlagAutoAccepts(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	const suiteTOML = `
+name = "hub-suite"
+description = "x"
+actions = ["actions/foo"]
+`
+	suiteAndKeyRawServer(t, "acme", "conn", "suite.toml", "v0.0.6", suiteTOML, pemBytes)
+
+	hubHits := 0
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			FQN string `json:"fqn"`
+		}
+		_ = json.Unmarshal(body, &req)
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		switch r.URL.Path {
+		case "/hub/suite-install-decision":
+			hubHits++
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"kind":"suite","fqn":"github://acme/conn/suite",
+				"description":"x","publisher_github":"acme",
+				"member_actions":["github://acme/conn/actions/foo"],
+				"authorities":[{
+					"fqn":"github://acme/conn","publisher_github":"acme",
+					"fingerprint":"sha256:any","trust_state":"unknown",
+					"publisher_footprint":[],"risk_indicators":["x"]
+				}]
+			}`)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.0.6","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.0.6","source":"x","path":"/p"}`,
+				lastSegment(req.FQN), req.FQN)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"--yes", "github://acme/conn/suite.toml@v0.0.6"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if hubHits != 1 {
+		t.Errorf("composite should fire exactly once, got %d", hubHits)
+	}
+	// Composite prompt MUST NOT render when --yes is in effect.
+	if strings.Contains(stdout.String(), "Trust these publishers and continue?") {
+		t.Errorf("composite prompt fired despite --yes:\n%s", stdout.String())
+	}
+}
+
+// TestRunActionAddSuiteRemote_HubCompositeMalformedJSONFallsThrough:
+// malformed payload from the composite endpoint surfaces a one-line
+// stderr note and proceeds with the legacy preflight.
+func TestRunActionAddSuiteRemote_HubCompositeMalformedJSONFallsThrough(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	const suiteTOML = `
+name = "legacy"
+description = "x"
+actions = ["actions/foo"]
+`
+	suiteAndKeyRawServer(t, "acme", "conn", "suite.toml", "v0.0.6", suiteTOML, pemBytes)
+
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			FQN string `json:"fqn"`
+		}
+		_ = json.Unmarshal(body, &req)
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		switch r.URL.Path {
+		case "/hub/suite-install-decision":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `not json`)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.0.6","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.0.6","source":"x","path":"/p"}`,
+				lastSegment(req.FQN), req.FQN)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	stdin := bufio.NewReader(strings.NewReader("y\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"github://acme/conn/suite.toml@v0.0.6"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "could not parse hub install-decision") {
+		t.Errorf("expected parse-failure note; stderr=%s", stderr.String())
+	}
+}
+
+// TestRunActionAddSuiteRemote_HubComposite503FallsThrough: 503 from
+// the composite endpoint surfaces a one-line stderr note and falls
+// through to the legacy preflight.
+func TestRunActionAddSuiteRemote_HubComposite503FallsThrough(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	const suiteTOML = `
+name = "legacy"
+description = "x"
+actions = ["actions/foo"]
+`
+	suiteAndKeyRawServer(t, "acme", "conn", "suite.toml", "v0.0.6", suiteTOML, pemBytes)
+
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			FQN string `json:"fqn"`
+		}
+		_ = json.Unmarshal(body, &req)
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		switch r.URL.Path {
+		case "/hub/suite-install-decision":
+			w.WriteHeader(http.StatusServiceUnavailable)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.0.6","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.0.6","source":"x","path":"/p"}`,
+				lastSegment(req.FQN), req.FQN)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	stdin := bufio.NewReader(strings.NewReader("y\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"github://acme/conn/suite.toml@v0.0.6"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "hub install-decision returned 503") {
+		t.Errorf("expected 503 note; stderr=%s", stderr.String())
+	}
+}
+
+// TestRunActionAddSuiteRemote_HubCompositeDetailsExpandsAndAccepts:
+// d→details, then y accepts. Validates the d=details two-step on the
+// suite-composite prompt.
+func TestRunActionAddSuiteRemote_HubCompositeDetailsExpandsAndAccepts(t *testing.T) {
+	withTempHome(t)
+	_, pemBytes := genTestKey(t)
+	const suiteTOML = `
+name = "hub-suite"
+description = "x"
+actions = ["actions/foo"]
+`
+	suiteAndKeyRawServer(t, "acme", "conn", "suite.toml", "v0.0.6", suiteTOML, pemBytes)
+
+	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
+		body, _ := io.ReadAll(r.Body)
+		var req struct {
+			FQN string `json:"fqn"`
+		}
+		_ = json.Unmarshal(body, &req)
+		r.Body = io.NopCloser(strings.NewReader(string(body)))
+		switch r.URL.Path {
+		case "/hub/suite-install-decision":
+			w.WriteHeader(http.StatusOK)
+			_, _ = io.WriteString(w, `{
+				"kind":"suite","fqn":"github://acme/conn/suite",
+				"description":"x","publisher_github":"acme",
+				"member_actions":["github://acme/conn/actions/foo"],
+				"authorities":[{
+					"fqn":"github://acme/conn","publisher_github":"acme",
+					"fingerprint":"sha256:any","trust_state":"unknown",
+					"publisher_footprint":["github://acme/other-conn"],
+					"risk_indicators":["First connector by this publisher"]
+				}]
+			}`)
+		case "/actions/preview":
+			w.WriteHeader(http.StatusOK)
+			fmt.Fprintf(w, `{"fqn":%q,"version":"0.0.6","hash":"sha256:abc","name":%q,"signature_status":"verified","connector_deps":[]}`,
+				req.FQN, lastSegment(req.FQN))
+		case "/actions/install":
+			w.WriteHeader(http.StatusCreated)
+			fmt.Fprintf(w, `{"name":%q,"fqn":%q,"version":"0.0.6","source":"x","path":"/p"}`,
+				lastSegment(req.FQN), req.FQN)
+		default:
+			w.WriteHeader(http.StatusNotFound)
+		}
+	})
+
+	// d → details, y → accept composite, y → accept the suite install.
+	stdin := bufio.NewReader(strings.NewReader("d\ny\ny\n"))
+	var stdout, stderr bytes.Buffer
+	code := runActionAddSuite(
+		[]string{"github://acme/conn/suite.toml@v0.0.6"},
+		stdin, &stdout, &stderr,
+	)
+	if code != 0 {
+		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Other connectors by this publisher") {
+		t.Errorf("expected publisher_footprint in details mode:\n%s", stdout.String())
+	}
+}
+
+// --- deriveHubSuiteFQN unit ---
+
+func TestDeriveHubSuiteFQN(t *testing.T) {
+	cases := []struct {
+		name string
+		in   cstore.FQN
+		want string
+	}{
+		{
+			name: "github single-suite repo",
+			in:   cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn", Subpath: "suite.toml"},
+			want: "github://acme/conn/suite",
+		},
+		{
+			name: "github nested suite",
+			in:   cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn", Subpath: "suites/gmail.toml"},
+			want: "github://acme/conn/suites/gmail",
+		},
+		{
+			name: "gitlab same shape",
+			in:   cstore.FQN{Scheme: "gitlab", Owner: "acme", Repo: "conn", Subpath: "suite.toml"},
+			want: "gitlab://acme/conn/suite",
+		},
+		{
+			name: "hub scheme skipped (no .toml suffix story here)",
+			in:   cstore.FQN{Scheme: "hub", Owner: "acme", Repo: "conn", Subpath: "suite.toml"},
+			want: "",
+		},
+		{
+			name: "missing subpath",
+			in:   cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn"},
+			want: "",
+		},
+		{
+			name: "non-toml subpath",
+			in:   cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn", Subpath: "config.yaml"},
+			want: "",
+		},
+		{
+			name: "bare .toml (would resolve to empty after strip)",
+			in:   cstore.FQN{Scheme: "github", Owner: "acme", Repo: "conn", Subpath: ".toml"},
+			want: "",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := deriveHubSuiteFQN(tc.in); got != tc.want {
+				t.Errorf("deriveHubSuiteFQN(%+v) = %q, want %q", tc.in, got, tc.want)
+			}
+		})
+	}
+}
+
 // --- aileron audit ---
 
 // TestRunAudit_EmptyPrintsNoEntries: with no events the CLI prints a


### PR DESCRIPTION
## Summary

Suite-level counterpart to #725. `aileron action add-suite <remote>` now consults the daemon's `/v1/hub/suite-install-decision` endpoint before the legacy preflight when the source URL maps to a Hub-listed suite FQN.

- **Hub FQN derivation**: heuristic strips trailing `.toml` from the suite source's subpath. `github://acme/conn/suite.toml@v1.0.0` → `github://acme/conn/suite`. Nested suites work too (`suites/gmail.toml` → `suites/gmail`). Local file sources and non-`.toml` subpaths skip the composite entirely.
- **One trust gate**: when the suite is Hub-listed, the CLI renders one composite trust panel (suite metadata + member-action list + per-authority trust gates) and collapses every per-authority consent into a single y/N/d=details prompt. On accept, every authority in the composite plus every member-action authority is programmatically trusted via `trust.ensure(autoYes=true)`. The legacy per-authority prompts in `installSuiteEntries` phases 1a and 1c short-circuit because `trustState` already has them.
- **Fall-through paths**: 404 (suite not Hub-listed), 422 (closure missing connector), parse errors, and empty payloads all fall through to the legacy preflight. 5xx surfaces a one-line stderr note. `--yes` auto-accepts without rendering the panel. `d=details` expands per-authority `publisher_footprint`.

Refs #709 (umbrella).

## Test plan

- [x] `(cd cmd/aileron && go test -count=1 -cover ./...)` green.
- [x] New tests: composite accept seeds trust + installs both actions; decline → clean exit-0; 404 fall-through preserves legacy prompts; local-file source skips Hub; --yes auto-accept; 503 / malformed JSON fall-through with note; `d` expansion + accept; `deriveHubSuiteFQN` unit table (7 cases).
- [x] Existing remote-suite, local-suite, and per-action tests all still pass without changes (404 from the new endpoint is the natural fall-through for fixtures that don't model it).
- [x] Coverage: `tryHubSuiteInstallDecisionFlow` 83.8%, `renderHubSuiteCompositeDecision` 96.7%, `deriveHubSuiteFQN` 100%, `installSuiteEntries` 83.3%.
- [ ] CI green (full matrix).