### PR TITLE
feat(sandbox): Linux v3 — CLONE_NEWNET + UDS proxy + in-namespace shim

### DIFF
--- a/internal/sandbox/proxy.go
+++ b/internal/sandbox/proxy.go
@@ -243,39 +243,47 @@ func writeStatus(w io.Writer, code int, reason string) {
 	_ = reason // reserved for future structured response body
 }
 
-// startSpawnProxy stands up a per-spawn CONNECT proxy on host
-// loopback and returns the listener address callers should set as
-// `HTTPS_PROXY` on the subprocess. The returned `closeFn` tears the
-// proxy down (closes the listener, drains in-flight tunnels). Tests
-// substitute via WithSpawnProxyFactory.
+// ProxyEndpoint describes where a per-spawn CONNECT proxy is
+// listening. macOS and Windows ([SBPL] / [WFP]) permit the wrapped
+// CLI to reach a TCP loopback port directly, so [TCPAddr] is the
+// `HTTPS_PROXY` value the runtime sets on the subprocess. Linux
+// puts the wrapped CLI in a new network namespace under
+// `CLONE_NEWNET`, where the host's TCP loopback is unreachable;
+// the proxy binds on a Unix-domain socket whose path is in
+// [UDSPath], and the in-namespace spawn helper bridges TCP from
+// inside the namespace to that socket.
 //
-// Errors construct-time setup only: a listener bind failure or an
-// invalid host policy. Per-CONNECT errors do not propagate here;
-// they emit audit rows and the subprocess sees an HTTP status.
-//
-// v1 binds on TCP loopback. The Linux UDS+shim path lives behind a
-// follow-up to ADR-0014's "Network confinement" section.
-var startSpawnProxy = defaultStartSpawnProxy
+// Exactly one of TCPAddr or UDSPath is populated for a given
+// platform. The runtime's [processSpawn] selects which to set
+// on the wrapped CLI's environment vs. on the helper request
+// based on which field is non-empty.
+type ProxyEndpoint struct {
+	// TCPAddr is the host:port the proxy is listening on for
+	// non-Linux platforms. Empty on Linux.
+	TCPAddr string
 
-func defaultStartSpawnProxy(ctx context.Context, policy *HostPolicy, logger *slog.Logger, fqn string) (*SpawnProxy, string, func(), error) {
-	ln, err := net.Listen("tcp", "127.0.0.1:0")
-	if err != nil {
-		return nil, "", nil, err
-	}
-	proxy := NewSpawnProxy(policy, logger, fqn)
-	go func() {
-		// Serve blocks until Close is called or the listener errors.
-		// Per-connection errors are surfaced via audit emission inside
-		// serveConn; this goroutine's return value is intentionally
-		// dropped because Close is the normal termination path.
-		_ = proxy.Serve(ctx, ln)
-	}()
-	addr := ln.Addr().String()
-	closeFn := func() {
-		_ = proxy.Close()
-	}
-	return proxy, addr, closeFn, nil
+	// UDSPath is the host filesystem path of the Unix-domain
+	// socket the proxy is listening on for Linux. Empty on
+	// non-Linux platforms.
+	UDSPath string
 }
+
+// startSpawnProxy stands up a per-spawn CONNECT proxy on the
+// platform-appropriate listener and returns a [ProxyEndpoint]
+// describing where the subprocess (or helper bridge) should
+// reach it. The returned `closeFn` tears the proxy down (closes
+// the listener, drains in-flight tunnels, removes the UDS file
+// when applicable). Tests substitute via overriding this var.
+//
+// Errors are construct-time setup only: a listener bind failure
+// or an invalid host policy. Per-CONNECT errors do not propagate
+// here; they emit audit rows and the subprocess sees an HTTP
+// status.
+//
+// Per-platform implementation lives in proxy_linux.go (UDS)
+// and proxy_other.go (TCP loopback). The var indirection is for
+// test injection.
+var startSpawnProxy = defaultStartSpawnProxy
 
 // itoa avoids strconv just to keep the proxy's import surface small.
 // Status codes are always three ASCII digits in the supported range.

--- a/internal/sandbox/proxy_linux.go
+++ b/internal/sandbox/proxy_linux.go
@@ -1,0 +1,91 @@
+//go:build linux
+
+package sandbox
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"net"
+	"os"
+	"path/filepath"
+)
+
+// defaultStartSpawnProxy on Linux binds the per-spawn CONNECT
+// proxy on a Unix-domain socket under `$XDG_RUNTIME_DIR` (or
+// `/tmp` when `$XDG_RUNTIME_DIR` is unset). The wrapped CLI runs
+// inside a network namespace (`CLONE_NEWNET`) where the host's
+// TCP loopback is unreachable; the in-namespace [spawnhelper.Run]
+// bridges from a namespace-local TCP loopback to this UDS via
+// [RunSpawnShim].
+//
+// Per-spawn UDS paths are removed when the proxy closes so the
+// socket file doesn't linger after the spawn completes.
+func defaultStartSpawnProxy(ctx context.Context, policy *HostPolicy, logger *slog.Logger, fqn string) (*SpawnProxy, ProxyEndpoint, func(), error) {
+	udsPath, err := makeProxyUDSPath()
+	if err != nil {
+		return nil, ProxyEndpoint{}, nil, fmt.Errorf("spawn proxy: pick UDS path: %w", err)
+	}
+	// Pre-emptively remove a stale socket if one exists; net.Listen
+	// fails with "address already in use" otherwise.
+	_ = os.Remove(udsPath)
+
+	ln, err := net.Listen("unix", udsPath)
+	if err != nil {
+		return nil, ProxyEndpoint{}, nil, fmt.Errorf("spawn proxy: listen unix %s: %w", udsPath, err)
+	}
+	// Permissions: only the daemon's user should reach the socket;
+	// the wrapped CLI runs as the same user inside the namespace
+	// so 0600 (or 0700 on the parent dir) is enough.
+	if err := os.Chmod(udsPath, 0o600); err != nil {
+		_ = ln.Close()
+		_ = os.Remove(udsPath)
+		return nil, ProxyEndpoint{}, nil, fmt.Errorf("spawn proxy: chmod UDS: %w", err)
+	}
+
+	proxy := NewSpawnProxy(policy, logger, fqn)
+	go func() {
+		_ = proxy.Serve(ctx, ln)
+	}()
+	endpoint := ProxyEndpoint{UDSPath: udsPath}
+	closeFn := func() {
+		_ = proxy.Close()
+		// Best-effort cleanup. If the daemon crashed between
+		// listener creation and CloseFn the socket file lingers;
+		// the next spawn picks a different ephemeral name so the
+		// stale file is harmless.
+		_ = os.Remove(udsPath)
+	}
+	return proxy, endpoint, closeFn, nil
+}
+
+// makeProxyUDSPath returns a path under the user's runtime dir
+// where the proxy can bind a per-spawn UDS. Prefers
+// `$XDG_RUNTIME_DIR` (typically `/run/user/<uid>` on systemd
+// hosts), falls back to `/tmp` so the path stays short enough
+// for sockaddr_un (108 chars on Linux).
+//
+// Path shape: `<dir>/aileron-proxy-<pid>-<random>.sock`. The
+// per-spawn random suffix avoids collisions when the daemon
+// runs concurrent invocations.
+func makeProxyUDSPath() (string, error) {
+	dir := os.Getenv("XDG_RUNTIME_DIR")
+	if dir == "" {
+		dir = "/tmp"
+	}
+	f, err := os.CreateTemp(dir, "aileron-proxy-*.sock")
+	if err != nil {
+		return "", fmt.Errorf("create temp in %s: %w", dir, err)
+	}
+	path := f.Name()
+	_ = f.Close()
+	// Remove the empty file; net.Listen creates the socket.
+	_ = os.Remove(path)
+	if got := len(path); got > 107 {
+		// Linux sockaddr_un.sun_path is 108 bytes including NUL.
+		// If our dir choice produces too long a path the listener
+		// will fail with EINVAL.
+		return "", fmt.Errorf("UDS path %q too long for sockaddr_un (108 bytes)", filepath.Base(path))
+	}
+	return path, nil
+}

--- a/internal/sandbox/proxy_other.go
+++ b/internal/sandbox/proxy_other.go
@@ -1,0 +1,38 @@
+//go:build !linux
+
+package sandbox
+
+import (
+	"context"
+	"log/slog"
+	"net"
+)
+
+// defaultStartSpawnProxy on non-Linux platforms binds the
+// per-spawn CONNECT proxy on TCP loopback. The platform sandbox
+// (macOS [SBPL] / Windows WFP) permits the wrapped CLI to reach
+// `127.0.0.1:<port>` directly, so the runtime sets `HTTPS_PROXY`
+// to the returned [ProxyEndpoint.TCPAddr] and the CLI dials
+// straight through.
+//
+// [SBPL]: see internal/sandbox/spawn_sandbox_darwin.go
+func defaultStartSpawnProxy(ctx context.Context, policy *HostPolicy, logger *slog.Logger, fqn string) (*SpawnProxy, ProxyEndpoint, func(), error) {
+	ln, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		return nil, ProxyEndpoint{}, nil, err
+	}
+	proxy := NewSpawnProxy(policy, logger, fqn)
+	go func() {
+		// Serve blocks until Close is called or the listener
+		// errors. Per-connection errors are surfaced via audit
+		// emission inside serveConn; this goroutine's return
+		// value is intentionally dropped because Close is the
+		// normal termination path.
+		_ = proxy.Serve(ctx, ln)
+	}()
+	endpoint := ProxyEndpoint{TCPAddr: ln.Addr().String()}
+	closeFn := func() {
+		_ = proxy.Close()
+	}
+	return proxy, endpoint, closeFn, nil
+}

--- a/internal/sandbox/spawn.go
+++ b/internal/sandbox/spawn.go
@@ -120,10 +120,22 @@ type SpawnLimits struct {
 
 	// ProxyAddr is the per-invocation proxy endpoint the platform
 	// sandbox permits loopback access to. Empty when the connector
-	// did not declare `[capabilities.network]`; in that case the
-	// platform sandbox denies all network. Format is `host:port`,
-	// typically `127.0.0.1:<ephemeral>`.
+	// did not declare `[capabilities.network]` or when the proxy
+	// is reachable only via [ProxyUDSPath] (Linux + helper bridge).
+	// Format is `host:port`, typically `127.0.0.1:<ephemeral>`.
+	// macOS reads this for the SBPL `(allow network*)` rule;
+	// Windows for the WFP filter.
 	ProxyAddr string
+
+	// ProxyUDSPath is the host-filesystem path of a Unix-domain
+	// socket the per-invocation CONNECT proxy is listening on.
+	// Linux populates this when the wrapped CLI runs inside a
+	// `CLONE_NEWNET` namespace where the host's TCP loopback is
+	// unreachable; the in-namespace spawn helper bridges from a
+	// namespace-local TCP loopback to this socket via
+	// [RunSpawnShim]. Empty on macOS, Windows, and on Linux for
+	// connectors that don't trigger the helper rewire.
+	ProxyUDSPath string
 }
 
 // PlatformSandboxRequested reports whether the manifest carried any
@@ -133,7 +145,7 @@ type SpawnLimits struct {
 // (legacy spawn with no manifest scopes) returns false so tests and
 // pre-sandbox callers keep running unchanged.
 func (l SpawnLimits) PlatformSandboxRequested() bool {
-	return len(l.FSRead) > 0 || len(l.FSWrite) > 0 || l.ProxyAddr != ""
+	return len(l.FSRead) > 0 || len(l.FSWrite) > 0 || l.ProxyAddr != "" || l.ProxyUDSPath != ""
 }
 
 // StdoutCap returns the resolved stdout byte cap. Always positive
@@ -997,9 +1009,10 @@ func processSpawn(ctx context.Context, s *hostState, raw []byte) int32 {
 	// returns. Connectors that omit [capabilities.network] get no
 	// proxy and no HTTPS_PROXY env; the platform sandbox denies all
 	// outbound at the kernel boundary.
-	var proxyAddr string
+	var proxyTCPAddr string
+	var proxyUDSPath string
 	if s.policy != nil && len(s.policy.AllowedHosts()) > 0 {
-		proxy, addr, proxyClose, err := startSpawnProxy(ctx, s.policy, s.logger, s.connectorFQN)
+		proxy, endpoint, proxyClose, err := startSpawnProxy(ctx, s.policy, s.logger, s.connectorFQN)
 		if err != nil {
 			s.mu.Lock()
 			s.spawnErr = newConnectorRuntimeError(fmt.Sprintf("spawn: start network proxy: %s", err.Error()))
@@ -1009,12 +1022,27 @@ func processSpawn(ctx context.Context, s *hostState, raw []byte) int32 {
 		}
 		_ = proxy // retain for future per-spawn audit context attach
 		defer proxyClose()
-		if env.Env == nil {
-			env.Env = map[string]string{}
+
+		if endpoint.TCPAddr != "" {
+			// macOS / Windows path: the wrapped CLI dials the
+			// proxy directly via host loopback (the platform
+			// sandbox permits exactly this address).
+			if env.Env == nil {
+				env.Env = map[string]string{}
+			}
+			env.Env["HTTPS_PROXY"] = "http://" + endpoint.TCPAddr
+			env.Env["HTTP_PROXY"] = "http://" + endpoint.TCPAddr
+			proxyTCPAddr = endpoint.TCPAddr
 		}
-		env.Env["HTTPS_PROXY"] = "http://" + addr
-		env.Env["HTTP_PROXY"] = "http://" + addr
-		proxyAddr = addr
+		if endpoint.UDSPath != "" {
+			// Linux path: the wrapped CLI runs inside a
+			// CLONE_NEWNET namespace where the host's TCP
+			// loopback is unreachable. The in-namespace helper
+			// bridges from a namespace-local TCP loopback to
+			// this UDS via RunSpawnShim and injects HTTPS_PROXY
+			// itself before exec'ing the wrapped CLI.
+			proxyUDSPath = endpoint.UDSPath
+		}
 	}
 
 	// Hand to the platform executor. Sandbox unavailability is
@@ -1029,7 +1057,8 @@ func processSpawn(ctx context.Context, s *hostState, raw []byte) int32 {
 		MaxStderrBytes: s.spawnPolicy.stderrCap,
 		FSRead:         append([]string(nil), s.spawnPolicy.fsRead...),
 		FSWrite:        append([]string(nil), s.spawnPolicy.fsWrite...),
-		ProxyAddr:      proxyAddr,
+		ProxyAddr:      proxyTCPAddr,
+		ProxyUDSPath:   proxyUDSPath,
 	}
 	res, runErr := executor.Spawn(ctx, env, limits)
 	if runErr != nil {

--- a/internal/sandbox/spawn_sandbox_linux.go
+++ b/internal/sandbox/spawn_sandbox_linux.go
@@ -99,12 +99,23 @@ func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) 
 	// Go's exec package handles this when this flag is false.
 	cmd.SysProcAttr.GidMappingsEnableSetgroups = false
 
-	// When the manifest declares FS scopes, re-exec into the
-	// daemon binary's spawn-helper entry point so Landlock applies
-	// inside the namespace before the wrapped CLI starts. Network-
-	// only scoping (no fs_read / fs_write) keeps the v1 behavior
-	// where the wrapped CLI exec's directly.
-	if len(limits.FSRead) > 0 || len(limits.FSWrite) > 0 {
+	// When the manifest declares [capabilities.network], add
+	// CLONE_NEWNET so direct egress is kernel-blocked. The
+	// in-namespace helper bridges to the daemon's UDS proxy via
+	// RunSpawnShim; the wrapped CLI's HTTPS_PROXY is set by the
+	// helper post-shim-startup.
+	if limits.ProxyUDSPath != "" {
+		cmd.SysProcAttr.Cloneflags |= syscall.CLONE_NEWNET
+	}
+
+	// When the manifest declares any sandbox parameter the helper
+	// needs to mediate (FS scopes for Landlock, or network for
+	// shim bridging), re-exec into the daemon's spawn-helper
+	// entry point. The kernel forks into the namespaces per the
+	// Cloneflags above; the helper runs as PID 1 inside the
+	// namespace, applies Landlock, optionally starts the network
+	// shim, then exec's the wrapped CLI.
+	if len(limits.FSRead) > 0 || len(limits.FSWrite) > 0 || limits.ProxyUDSPath != "" {
 		if err := rewireForHelper(cmd, limits); err != nil {
 			return platformSandboxHooks{}, err
 		}
@@ -141,12 +152,13 @@ func rewireForHelper(cmd *exec.Cmd, limits SpawnLimits) error {
 	// Snapshot the wrapped invocation before reassigning cmd.Path
 	// and cmd.Args; the helper will use these for syscall.Exec.
 	req := spawnhelper.Request{
-		Program: cmd.Path,
-		Argv:    append([]string(nil), cmd.Args...),
-		Env:     append([]string(nil), cmd.Env...),
-		Cwd:     cmd.Dir,
-		FSRead:  fsRead,
-		FSWrite: fsWrite,
+		Program:      cmd.Path,
+		Argv:         append([]string(nil), cmd.Args...),
+		Env:          append([]string(nil), cmd.Env...),
+		Cwd:          cmd.Dir,
+		FSRead:       fsRead,
+		FSWrite:      fsWrite,
+		ProxyUDSPath: limits.ProxyUDSPath,
 	}
 	encoded, err := spawnhelper.EncodeRequest(req)
 	if err != nil {

--- a/internal/sandbox/spawn_sandbox_linux_test.go
+++ b/internal/sandbox/spawn_sandbox_linux_test.go
@@ -135,6 +135,45 @@ func TestApplyPlatformSandbox_Linux_RewiresIntoHelperWhenFSScopesDeclared(t *tes
 	}
 }
 
+func TestApplyPlatformSandbox_Linux_RewiresAndActivatesNetNSWhenProxyUDSDeclared(t *testing.T) {
+	// Contract (v3): when network is declared on Linux, the proxy
+	// binds on UDS and the runtime sets ProxyUDSPath. The platform
+	// sandbox responds by activating CLONE_NEWNET (so direct egress
+	// is kernel-blocked) and rewiring cmd into the helper (which
+	// bridges via RunSpawnShim).
+	origExec := osExecutable
+	defer func() { osExecutable = origExec }()
+	osExecutable = func() (string, error) { return "/usr/local/bin/aileron-fake", nil }
+
+	cmd := exec.CommandContext(context.Background(), "/usr/bin/git", "log")
+	limits := SpawnLimits{ProxyUDSPath: "/tmp/aileron-proxy-12345.sock"}
+	if _, err := applyPlatformSandbox(cmd, SpawnEnvelope{Program: "/usr/bin/git"}, limits); err != nil {
+		if strings.Contains(err.Error(), "spawn_sandbox_unavailable") {
+			t.Skip("sandbox unavailable on this runner")
+		}
+		t.Fatalf("applyPlatformSandbox: %v", err)
+	}
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr nil")
+	}
+	if cmd.SysProcAttr.Cloneflags&syscall.CLONE_NEWNET == 0 {
+		t.Error("CLONE_NEWNET should be set when ProxyUDSPath declared")
+	}
+	if cmd.Path != "/usr/local/bin/aileron-fake" {
+		t.Errorf("cmd.Path = %q, want helper rewire to daemon binary", cmd.Path)
+	}
+	if len(cmd.Args) < 3 || cmd.Args[1] != spawnhelper.HelperArgvMarker {
+		t.Errorf("cmd.Args = %v, want helper-marker rewire", cmd.Args)
+	}
+	req, err := spawnhelper.DecodeRequest(cmd.Args[2])
+	if err != nil {
+		t.Fatalf("decode rewired request: %v", err)
+	}
+	if req.ProxyUDSPath != "/tmp/aileron-proxy-12345.sock" {
+		t.Errorf("req.ProxyUDSPath = %q, want manifest UDS path", req.ProxyUDSPath)
+	}
+}
+
 func TestApplyPlatformSandbox_Linux_NoRewireWhenOnlyProxyAddrDeclared(t *testing.T) {
 	// Contract: when only network is declared (no fs_read/fs_write),
 	// the wrapped CLI execs directly. Landlock doesn't govern

--- a/internal/sandbox/spawn_test.go
+++ b/internal/sandbox/spawn_test.go
@@ -8,6 +8,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"runtime"
 	"sort"
 	"strings"
 	"testing"
@@ -753,12 +754,16 @@ func TestRunCaptured_EnforcesLimits(t *testing.T) {
 	}
 }
 
-func TestSpawn_HostFunctions_InjectsProxyEnvWhenNetworkDeclared(t *testing.T) {
+func TestSpawn_HostFunctions_RoutesProxyPerPlatformWhenNetworkDeclared(t *testing.T) {
 	// Contract: when the connector manifest carries
-	// [capabilities.network] hosts, the runtime stands up a per-spawn
-	// proxy on loopback and injects HTTPS_PROXY/HTTP_PROXY on the
-	// subprocess's env before the executor sees it. The proxy is
-	// torn down after Spawn returns.
+	// [capabilities.network] hosts, the runtime stands up a
+	// per-spawn proxy and routes it differently per platform:
+	//   - macOS / Windows: HTTPS_PROXY/HTTP_PROXY injected on the
+	//     subprocess's env (it dials the host TCP proxy directly).
+	//   - Linux: the proxy binds on a UDS and the runtime passes
+	//     the path through SpawnLimits.ProxyUDSPath; the
+	//     in-namespace helper bridges and injects HTTPS_PROXY
+	//     post-fork, so the env at this layer carries neither.
 	fake := &fakeExecutor{result: SpawnResult{ExitCode: 0}}
 	m := goodSpawnManifest()
 	m.Capabilities.Network = &cstore.ManifestNetwork{
@@ -775,6 +780,19 @@ func TestSpawn_HostFunctions_InjectsProxyEnvWhenNetworkDeclared(t *testing.T) {
 	if rc := processSpawn(ctx, state, envBytes); rc != 0 {
 		t.Fatalf("processSpawn rc=%d err=%v", rc, state.spawnErr)
 	}
+
+	if runtime.GOOS == "linux" {
+		// Linux: proxy on UDS, helper injects HTTPS_PROXY.
+		if fake.gotLimits.ProxyUDSPath == "" {
+			t.Errorf("ProxyUDSPath empty; want UDS-bound proxy on Linux. limits=%+v", fake.gotLimits)
+		}
+		if _, ok := fake.gotEnv.Env["HTTPS_PROXY"]; ok {
+			t.Errorf("HTTPS_PROXY injected by runtime on Linux; expected helper to inject post-fork. env=%v", fake.gotEnv.Env)
+		}
+		return
+	}
+
+	// macOS / Windows: proxy on TCP, env injected by runtime.
 	httpsProxy, ok := fake.gotEnv.Env["HTTPS_PROXY"]
 	if !ok {
 		t.Errorf("HTTPS_PROXY missing from injected env; got %v", fake.gotEnv.Env)
@@ -787,10 +805,11 @@ func TestSpawn_HostFunctions_InjectsProxyEnvWhenNetworkDeclared(t *testing.T) {
 	}
 }
 
-func TestSpawn_HostFunctions_NoProxyEnvWhenNetworkAbsent(t *testing.T) {
+func TestSpawn_HostFunctions_NoProxyRoutingWhenNetworkAbsent(t *testing.T) {
 	// Contract: a spawn connector that omits [capabilities.network]
-	// gets no HTTPS_PROXY injection. The subprocess will have no
-	// network path at all (the platform sandbox denies all egress).
+	// gets no proxy routing on any platform — no HTTPS_PROXY env,
+	// no ProxyUDSPath, no ProxyAddr. The subprocess will have no
+	// network path at all once the platform sandbox engages.
 	fake := &fakeExecutor{result: SpawnResult{ExitCode: 0}}
 	m := goodSpawnManifest()
 	state := &hostState{
@@ -809,6 +828,9 @@ func TestSpawn_HostFunctions_NoProxyEnvWhenNetworkAbsent(t *testing.T) {
 	}
 	if _, ok := fake.gotEnv.Env["HTTP_PROXY"]; ok {
 		t.Errorf("HTTP_PROXY injected despite no [capabilities.network]")
+	}
+	if fake.gotLimits.ProxyAddr != "" || fake.gotLimits.ProxyUDSPath != "" {
+		t.Errorf("limits carry proxy routing despite no network: %+v", fake.gotLimits)
 	}
 }
 

--- a/internal/sandbox/spawnhelper/request.go
+++ b/internal/sandbox/spawnhelper/request.go
@@ -64,6 +64,17 @@ type Request struct {
 	// rules apply to subtrees regardless.
 	FSRead  []string `json:"fs_read,omitempty"`
 	FSWrite []string `json:"fs_write,omitempty"`
+
+	// ProxyUDSPath, when non-empty, is the host-filesystem path
+	// of the daemon's per-spawn CONNECT proxy. The helper runs
+	// [internal/sandbox.RunSpawnShim] on the namespace-local TCP
+	// loopback and bridges accepted connections to this socket;
+	// it injects `HTTPS_PROXY` / `HTTP_PROXY` on the wrapped
+	// CLI's env to point at the in-namespace TCP listener. Empty
+	// when the connector did not declare `[capabilities.network]`
+	// or when the platform's network confinement does not need
+	// the helper bridge (macOS / Windows).
+	ProxyUDSPath string `json:"proxy_uds_path,omitempty"`
 }
 
 // HelperArgvMarker is the first argv element the runtime passes

--- a/internal/sandbox/spawnhelper/run_linux.go
+++ b/internal/sandbox/spawnhelper/run_linux.go
@@ -3,24 +3,35 @@
 package spawnhelper
 
 import (
+	"context"
+	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"syscall"
 )
 
 // Run is the entry point the daemon's main() dispatches to when
 // it sees [HelperArgvMarker] as its first argv. The function
 // parses the request, applies Landlock filesystem restrictions,
-// optionally chdir's, and then `syscall.Exec`s into the wrapped
-// program — replacing this helper process with the CLI under
-// the configured confinement.
+// optionally starts the [RunSpawnShim] network bridge, then
+// either:
 //
-// Never returns on success; the Exec syscall replaces the
-// process image. On any failure (malformed request, Landlock
-// unavailable, Exec failure) writes a structured error message
-// to stderr and exits with code 1 so the runtime audit row
-// records a sandbox-setup failure rather than a silently
-// unconfined spawn.
+//   - `syscall.Exec`s into the wrapped program (no network shim
+//     needed; helper becomes the CLI), or
+//   - forks the wrapped CLI as a child and waits while the shim
+//     goroutine serves connections from inside the namespace
+//     (network shim needed; helper stays alive to host the
+//     shim, exits with the CLI's status when it finishes).
+//
+// Never returns on success in the no-shim path; replaces the
+// process via syscall.Exec. In the shim path returns after the
+// wrapped CLI exits with the CLI's exit code. On any failure
+// (malformed request, Landlock unavailable, shim startup error,
+// exec failure) writes a structured error message to stderr
+// and exits with code 1 so the runtime audit row records a
+// sandbox-setup failure rather than a silently unconfined
+// spawn.
 func Run(encodedReq string) {
 	req, err := DecodeRequest(encodedReq)
 	if err != nil {
@@ -31,24 +42,140 @@ func Run(encodedReq string) {
 		failHelper("apply Landlock: %v", err)
 	}
 
-	if req.Cwd != "" {
-		if err := os.Chdir(req.Cwd); err != nil {
-			failHelper("chdir %s: %v", req.Cwd, err)
-		}
-	}
-
-	// syscall.Exec replaces this process with the wrapped CLI.
-	// The Env defaults to os.Environ() when the request didn't
-	// carry one; the runtime always provides Env in production
-	// but the fallback keeps the helper testable in isolation.
+	// Default env is os.Environ() when the request didn't carry
+	// one; the runtime always provides Env in production but the
+	// fallback keeps the helper testable in isolation.
 	env := req.Env
 	if env == nil {
 		env = os.Environ()
 	}
-	if err := syscall.Exec(req.Program, req.Argv, env); err != nil {
-		// Exec only returns on failure.
-		failHelper("exec %s: %v", req.Program, err)
+
+	if req.ProxyUDSPath == "" {
+		// No network shim: syscall.Exec replaces this process
+		// with the wrapped CLI.
+		if req.Cwd != "" {
+			if err := os.Chdir(req.Cwd); err != nil {
+				failHelper("chdir %s: %v", req.Cwd, err)
+			}
+		}
+		if err := syscall.Exec(req.Program, req.Argv, env); err != nil {
+			failHelper("exec %s: %v", req.Program, err)
+		}
+		return // unreachable
 	}
+
+	// Network shim: start RunSpawnShim on a namespace-local
+	// loopback port, then fork the wrapped CLI as a child of
+	// this helper process. The shim and the CLI become siblings
+	// inside the namespace; when the CLI exits we cancel the
+	// shim and propagate the CLI's exit code.
+	runWithShim(req, env)
+}
+
+// runWithShim implements the network-mediated spawn path. The
+// helper retains its PID-1 role inside the namespace, hosts the
+// shim goroutine, forks the wrapped CLI as a child, and exits
+// with the child's status once it terminates.
+//
+// Lifecycle:
+//
+//  1. Listen on `127.0.0.1:0` inside the namespace (the
+//     CLONE_NEWNET sets up an isolated loopback the kernel
+//     auto-brings-up).
+//  2. Shim goroutine bridges accepted connections to the host
+//     UDS via filesystem path. (CLONE_NEWNS does not isolate
+//     filesystem access by default; the daemon's UDS is reachable.)
+//  3. Inject `HTTPS_PROXY` / `HTTP_PROXY` into the wrapped CLI's
+//     env pointing at the in-namespace loopback port.
+//  4. Start the wrapped CLI as a child via `exec.Cmd`.
+//  5. Wait for the child to exit; cancel the shim context.
+//  6. Exit with the child's exit code (preserves non-zero
+//     statuses up to the runtime).
+func runWithShim(req Request, env []string) {
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	ready := make(chan string, 1)
+	shimErr := make(chan error, 1)
+	go func() {
+		shimErr <- RunSpawnShim(ctx, "127.0.0.1:0", req.ProxyUDSPath, ready)
+	}()
+
+	var shimAddr string
+	select {
+	case shimAddr = <-ready:
+	case err := <-shimErr:
+		// Shim failed before publishing its ready address; abort.
+		failHelper("network shim startup: %v", err)
+	}
+
+	// Inject the proxy env into the wrapped CLI's env. Replace
+	// any pre-existing HTTPS_PROXY/HTTP_PROXY values the runtime
+	// may have set on the cmd before deciding the helper was
+	// needed (defensive; production processSpawn doesn't set
+	// these on Linux when UDS path is in the limits).
+	env = removeProxyEnv(env)
+	env = append(env,
+		"HTTPS_PROXY=http://"+shimAddr,
+		"HTTP_PROXY=http://"+shimAddr,
+	)
+
+	cmd := exec.Command(req.Program)
+	cmd.Args = req.Argv
+	cmd.Env = env
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if req.Cwd != "" {
+		cmd.Dir = req.Cwd
+	}
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			cancel()
+			<-shimErr // drain
+			os.Exit(exitErr.ExitCode())
+		}
+		failHelper("run wrapped CLI: %v", err)
+	}
+	cancel()
+	<-shimErr
+}
+
+// removeProxyEnv strips any HTTPS_PROXY / HTTP_PROXY keys from
+// the env slice. Returns a new slice. Used to clear pre-existing
+// proxy hints before the helper sets its own.
+func removeProxyEnv(env []string) []string {
+	out := make([]string, 0, len(env))
+	for _, kv := range env {
+		if hasPrefixCI(kv, "HTTPS_PROXY=") || hasPrefixCI(kv, "HTTP_PROXY=") {
+			continue
+		}
+		out = append(out, kv)
+	}
+	return out
+}
+
+// hasPrefixCI reports whether s starts with prefix, case-insensitively
+// on ASCII letters. The proxy env vars are conventionally upper-case
+// but some CLIs honor lowercase variants; treat both alike.
+func hasPrefixCI(s, prefix string) bool {
+	if len(s) < len(prefix) {
+		return false
+	}
+	for i := 0; i < len(prefix); i++ {
+		a, b := s[i], prefix[i]
+		if a >= 'A' && a <= 'Z' {
+			a += 'a' - 'A'
+		}
+		if b >= 'A' && b <= 'Z' {
+			b += 'a' - 'A'
+		}
+		if a != b {
+			return false
+		}
+	}
+	return true
 }
 
 // failHelper writes a `spawn-helper: <msg>` line to stderr and

--- a/internal/sandbox/spawnhelper/shim.go
+++ b/internal/sandbox/spawnhelper/shim.go
@@ -1,4 +1,4 @@
-package sandbox
+package spawnhelper
 
 import (
 	"context"

--- a/internal/sandbox/spawnhelper/shim_test.go
+++ b/internal/sandbox/spawnhelper/shim_test.go
@@ -1,6 +1,6 @@
 //go:build !windows
 
-package sandbox
+package spawnhelper
 
 import (
 	"context"


### PR DESCRIPTION
## Summary

Final piece of [#719](https://github.com/ALRubinger/aileron/issues/719)'s Linux platform sandbox: kernel-enforced egress denial. Combines with [#723](https://github.com/ALRubinger/aileron/pull/723) (namespaces) and [#727](https://github.com/ALRubinger/aileron/pull/727) (Landlock) to make Linux deliver the BYOCLI threat model in full.

### What changes

When a connector declares `[capabilities.network]` on Linux:

- **Proxy binds on Unix-domain socket** under `$XDG_RUNTIME_DIR` (or `/tmp`) instead of TCP loopback. Build-tagged `proxy_linux.go` vs `proxy_other.go`. macOS/Windows keep TCP since their platform sandboxes can permit loopback to a TCP port directly.
- **`CLONE_NEWNET` activates** alongside user+mount+PID namespaces. The wrapped CLI sees only an isolated loopback interface with no routes — direct egress is kernel-blocked.
- **In-namespace shim** (`RunSpawnShim`, moved into the `spawnhelper` package from #718) listens on the namespace's loopback and bridges to the host UDS via filesystem path. `CLONE_NEWNS` doesn't isolate file access by default, so the daemon's UDS is reachable through the namespace.
- **Helper forks the wrapped CLI instead of `syscall.Exec`**. The helper stays alive as PID 1 to host the shim goroutine; the CLI runs as PID 2 child. When the CLI exits, the helper cancels the shim, drains, and exits with the CLI's status. `syscall.Exec` would kill the shim goroutine since it replaces the process image entirely.
- **`HTTPS_PROXY` injection moves**: on Linux + network the helper sets it post-shim-startup (it's the only thing that knows the in-namespace listener port). On macOS/Windows the runtime keeps the pre-fork injection (CLI dials host TCP loopback directly).

### Architecture cleanup

- `ProxyEndpoint` struct replaces the single-string `addr` return from `startSpawnProxy`. Cleaner field shape: `TCPAddr` (macOS/Windows) or `UDSPath` (Linux), exactly one populated per platform.
- `internal/sandbox/spawn_shim.go` moves into `internal/sandbox/spawnhelper/shim.go` so the helper can call `RunSpawnShim` without a circular dep. Test file moves alongside.

## Test plan

- [x] `Request` round-trip handles `ProxyUDSPath`
- [x] `TestApplyPlatformSandbox_Linux_RewiresAndActivatesNetNSWhenProxyUDSDeclared` — verifies `CLONE_NEWNET` activates, cmd rewires into helper, the encoded request carries the UDS path
- [x] Existing v1 + v2 tests on Linux still pass (FS-only path unchanged)
- [x] Existing macOS / Windows tests unchanged (proxy_other.go preserves TCP behavior)
- [x] Cross-compile clean on all three platforms

The load-bearing end-to-end test for v3 — wrap CLI tries to reach a non-allowlisted host, kernel blocks it via the network namespace — is harder to author without a working CLI that uses `HTTPS_PROXY`. The v2 Landlock end-to-end test ([#727](https://github.com/ALRubinger/aileron/pull/727)) proves the helper rewire works; the v3 additions are kernel-mechanism (`CLONE_NEWNET`) + wiring (shim goroutine + UDS path passing). The shim itself has comprehensive tests from [#718](https://github.com/ALRubinger/aileron/pull/718).

## Out of scope (follow-ups)

- **End-to-end network egress test on Linux** — wrap a real http-client CLI, configure allowlist, verify allowed hosts succeed and disallowed hosts fail with `network_unreachable`. Lands cleanest paired with the malicious-CLI integration fixture from [#719](https://github.com/ALRubinger/aileron/issues/719)'s cross-platform checklist.
- **Pivot_root + bind-mount tree** — Landlock + namespace is the FS confinement today; pivot_root adds defense-in-depth but isn't load-bearing once Landlock is in place. Punt unless a real connector demands it.

#719 closes after this lands plus the malicious-CLI integration fixture; Windows v2 (WFP) and cross-platform finishing items remain.

Refs [#619](https://github.com/ALRubinger/aileron/issues/619) [#719](https://github.com/ALRubinger/aileron/issues/719).