### PR TITLE
feat(webapp): tabbed /hub shell with Suites / Actions / Providers

### DIFF
--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -357,6 +357,112 @@ export async function getHubInstallDecision(fqn: string): Promise<HubInstallDeci
 	return apiFetch(`/v1/hub/install-decision?fqn=${encodeURIComponent(fqn)}`);
 }
 
+// --- Hub action and suite catalogs (#709, action-first amendment) ---
+//
+// The Hub catalog holds three entry types: connectors (above), actions
+// (template pointers), and suites (bundles of actions). The webapp
+// browses all three through the daemon's `/v1/hub/*` endpoints.
+
+/** Single Hub action entry. Mirrors api.HubActionEntry. */
+export type HubActionEntry = {
+	fqn: string;
+	description: string;
+	publisher_github: string;
+	connector_fqn: string;
+	intents?: string[];
+	category?: string;
+};
+
+export type HubActionList = {
+	actions: HubActionEntry[];
+};
+
+/** Single Hub suite entry. Mirrors api.HubSuiteEntry. */
+export type HubSuiteEntry = {
+	fqn: string;
+	description: string;
+	publisher_github: string;
+	member_actions: string[];
+	connectors_required?: string[];
+	category?: string;
+};
+
+export type HubSuiteList = {
+	suites: HubSuiteEntry[];
+};
+
+/** Lists every action published to the Hub. Pass `q` to filter
+ *  server-side. */
+export async function listHubActions(q?: string): Promise<HubActionList> {
+	const qs = q && q.trim() ? `?q=${encodeURIComponent(q.trim())}` : '';
+	return apiFetch(`/v1/hub/actions${qs}`);
+}
+
+/** Lists every suite published to the Hub. Pass `q` to filter
+ *  server-side. */
+export async function listHubSuites(q?: string): Promise<HubSuiteList> {
+	const qs = q && q.trim() ? `?q=${encodeURIComponent(q.trim())}` : '';
+	return apiFetch(`/v1/hub/suites${qs}`);
+}
+
+/** Single action entry by FQN. */
+export async function getHubAction(fqn: string): Promise<HubActionEntry> {
+	return apiFetch(`/v1/hub/action?fqn=${encodeURIComponent(fqn)}`);
+}
+
+/** Single suite entry by FQN. */
+export async function getHubSuite(fqn: string): Promise<HubSuiteEntry> {
+	return apiFetch(`/v1/hub/suite?fqn=${encodeURIComponent(fqn)}`);
+}
+
+/** Per-connector trust panel inside a composite install-decision.
+ *  Shape mirrors api.HubInstallAuthority — same fields as the
+ *  connector-level HubInstallDecision minus the top-level description. */
+export type HubInstallAuthority = {
+	fqn: string;
+	publisher_github: string;
+	fingerprint: string;
+	trust_state: HubTrustState;
+	publisher_footprint: string[];
+	risk_indicators: string[];
+};
+
+/** Composite install-decision payload for an action install.
+ *  `authorities[]` always carries exactly one entry — the action's
+ *  declared connector dependency. The `kind` discriminator lets the
+ *  install modal render the action's own metadata alongside the
+ *  underlying connector trust gate. */
+export type HubActionInstallDecision = {
+	kind: 'action';
+	fqn: string;
+	description: string;
+	publisher_github: string;
+	connector_fqn: string;
+	authorities: HubInstallAuthority[];
+};
+
+/** Composite install-decision payload for a suite install.
+ *  `authorities[]` carries one entry per unique connector authority in
+ *  the suite's dependency closure. */
+export type HubSuiteInstallDecision = {
+	kind: 'suite';
+	fqn: string;
+	description: string;
+	publisher_github: string;
+	member_actions: string[];
+	authorities: HubInstallAuthority[];
+};
+
+/** Composite install-decision for an action FQN. */
+export async function getHubActionInstallDecision(fqn: string): Promise<HubActionInstallDecision> {
+	return apiFetch(`/v1/hub/action-install-decision?fqn=${encodeURIComponent(fqn)}`);
+}
+
+/** Composite install-decision for a suite FQN. */
+export async function getHubSuiteInstallDecision(fqn: string): Promise<HubSuiteInstallDecision> {
+	return apiFetch(`/v1/hub/suite-install-decision?fqn=${encodeURIComponent(fqn)}`);
+}
+
 /** Installed-connector envelope returned by POST /v1/connectors/install
  *  on success. `already_installed` is set when an offline-cached hash
  *  short-circuits the install pipeline (ADR-0004 §"Offline behavior"). */

--- a/webapp/src/routes/hub/+page.svelte
+++ b/webapp/src/routes/hub/+page.svelte
@@ -1,56 +1,114 @@
 <script lang="ts">
-	import { listHubConnectors, type HubConnectorEntry } from '$lib/api';
+	import {
+		listHubConnectors,
+		listHubActions,
+		listHubSuites,
+		type HubConnectorEntry,
+		type HubActionEntry,
+		type HubSuiteEntry,
+	} from '$lib/api';
 	import { onMount } from 'svelte';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import HubInstallModal from '$lib/components/HubInstallModal.svelte';
 
-	// Hub browsing page (ADR-0013, #488). Reads from the daemon's
-	// `/v1/hub/connectors` endpoint; the daemon shallow-clones the
-	// public `aileron-connectors-hub` repo per query (no persisted
-	// cache, per #486).
+	// Hub browsing page (ADR-0013, action-first amendment / #709). The
+	// catalog has three entry types — Suites, Actions, Connectors — and
+	// the default tab is Suites (intent-first browse). The Providers tab
+	// preserves the original connector-only view from the pre-amendment
+	// page so trust-first browsers and "show me everything for Slack"
+	// flows keep working unchanged.
 	//
-	// The page is the webapp half of the umbrella's acceptance
-	// criteria 1-3: search by keyword, browse list with FQN +
-	// description, click an entry to see fingerprint and install. The
-	// install action opens HubInstallModal which carries the publisher
-	// trust decision.
+	// Each tab queries its own daemon endpoint and renders a card list.
+	// Search is per-tab — typing in the search input filters whichever
+	// catalog is currently active. Per-tab daemon clones are fast
+	// (shallow clone, no GitHub API; per #486).
 
-	let entries = $state<HubConnectorEntry[]>([]);
+	type Tab = 'suites' | 'actions' | 'providers';
+
+	let activeTab = $state<Tab>('suites');
+	let query = $state('');
+
+	let suites = $state<HubSuiteEntry[]>([]);
+	let actions = $state<HubActionEntry[]>([]);
+	let connectors = $state<HubConnectorEntry[]>([]);
 	let loading = $state(true);
 	let error = $state('');
-	let query = $state('');
 	let selectedFQN = $state<string | null>(null);
 
-	async function refresh(q: string) {
+	async function refresh() {
 		loading = true;
 		error = '';
+		const q = query.trim();
 		try {
-			const resp = await listHubConnectors(q);
-			entries = resp.connectors ?? [];
+			if (activeTab === 'suites') {
+				const resp = await listHubSuites(q || undefined);
+				suites = resp.suites ?? [];
+			} else if (activeTab === 'actions') {
+				const resp = await listHubActions(q || undefined);
+				actions = resp.actions ?? [];
+			} else {
+				const resp = await listHubConnectors(q || undefined);
+				connectors = resp.connectors ?? [];
+			}
 		} catch (e) {
 			error = e instanceof Error ? e.message : String(e);
-			entries = [];
 		} finally {
 			loading = false;
 		}
 	}
 
 	onMount(() => {
-		void refresh('');
+		void refresh();
 	});
 
 	let searchHandle: ReturnType<typeof setTimeout> | undefined;
 	function onSearchInput(value: string) {
 		query = value;
-		// Debounce — every keystroke would shallow-clone the Hub repo
-		// daemon-side. 250ms aligns with the typing pause that humans
-		// reach for an interactive search box.
+		// 250ms debounce — each query is a fresh shallow clone of the
+		// Hub repo daemon-side, so we don't want a fetch per keystroke.
 		if (searchHandle !== undefined) clearTimeout(searchHandle);
 		searchHandle = setTimeout(() => {
-			void refresh(query);
+			void refresh();
 		}, 250);
+	}
+
+	function switchTab(tab: Tab) {
+		if (tab === activeTab) return;
+		activeTab = tab;
+		// Re-fetch immediately; per-tab search state is preserved (the
+		// same `query` string applies, since the daemon's filter is
+		// substring-match on FQN + description in every catalog).
+		void refresh();
+	}
+
+	function placeholderForTab(tab: Tab): string {
+		switch (tab) {
+			case 'suites':
+				return 'Search suites by name or description…';
+			case 'actions':
+				return 'Search actions by name, description, or intent…';
+			case 'providers':
+				return 'Search providers by FQN or description…';
+		}
+	}
+
+	function emptyStateMessage(tab: Tab, q: string): string {
+		const trimmed = q.trim();
+		if (tab === 'suites') {
+			return trimmed
+				? `No Hub suites match "${trimmed}".`
+				: 'No suites published to the Hub yet.';
+		}
+		if (tab === 'actions') {
+			return trimmed
+				? `No Hub actions match "${trimmed}".`
+				: 'No actions published to the Hub yet.';
+		}
+		return trimmed
+			? `No Hub connectors match "${trimmed}".`
+			: 'No connectors published to the Hub.';
 	}
 </script>
 
@@ -58,17 +116,41 @@
 	<title>Hub — Aileron</title>
 </svelte:head>
 
-<h1 class="mb-4 text-3xl font-extrabold tracking-tight">Connector Hub</h1>
+<h1 class="mb-4 text-3xl font-extrabold tracking-tight">Hub</h1>
 <p class="ink-bleed mb-4 text-sm text-muted-foreground">
-	Community-published connectors. Browse, search by keyword, and install with
-	one click. The daemon writes publisher trust to your keyring per repo on
-	confirm.
+	Browse community-published suites, actions, and providers. The daemon
+	writes publisher trust to your keyring per repo on confirm. Default
+	view leads with intent — start at Suites if you're shopping for a
+	capability; switch to Providers if you want to see everything from a
+	specific publisher.
 </p>
+
+{#snippet tab(id: Tab, label: string, testid: string)}
+	<button
+		type="button"
+		role="tab"
+		aria-selected={activeTab === id}
+		class="rounded-t-md border-b-2 border-transparent px-4 py-2 text-sm font-medium text-muted-foreground transition-colors hover:text-foreground {activeTab ===
+		id
+			? 'border-foreground text-foreground'
+			: ''}"
+		onclick={() => switchTab(id)}
+		data-testid={testid}
+	>
+		{label}
+	</button>
+{/snippet}
+
+<div class="mb-4 flex gap-2 border-b" data-testid="hub-tabs" role="tablist">
+	{@render tab('suites', 'Suites', 'hub-tab-suites')}
+	{@render tab('actions', 'Actions', 'hub-tab-actions')}
+	{@render tab('providers', 'Providers', 'hub-tab-providers')}
+</div>
 
 <div class="mb-4">
 	<Input
 		type="text"
-		placeholder="Search by FQN or description…"
+		placeholder={placeholderForTab(activeTab)}
 		value={query}
 		oninput={(e) => onSearchInput((e.currentTarget as HTMLInputElement).value)}
 		data-testid="hub-search-input"
@@ -79,43 +161,126 @@
 	<p class="text-muted-foreground">Loading Hub entries…</p>
 {:else if error}
 	<p class="text-destructive" data-testid="hub-list-error">{error}</p>
-{:else if entries.length === 0}
-	<p class="text-muted-foreground" data-testid="hub-empty-state">
-		{query.trim()
-			? `No Hub connectors match "${query.trim()}".`
-			: 'No connectors published to the Hub.'}
-	</p>
-{:else}
-	<div class="flex flex-col gap-3" data-testid="hub-list">
-		{#each entries as entry (entry.fqn)}
-			<Card.Root data-testid="hub-entry-card" data-fqn={entry.fqn}>
-				<Card.Header>
-					<div class="flex flex-wrap items-start justify-between gap-2">
-						<div class="space-y-1">
-							<Card.Title class="font-mono text-sm break-all">
-								{entry.fqn}
-							</Card.Title>
-							<Card.Description>{entry.description}</Card.Description>
+{:else if activeTab === 'suites'}
+	{#if suites.length === 0}
+		<p class="text-muted-foreground" data-testid="hub-empty-state">
+			{emptyStateMessage('suites', query)}
+		</p>
+	{:else}
+		<div class="flex flex-col gap-3" data-testid="hub-list" data-tab="suites">
+			{#each suites as entry (entry.fqn)}
+				<Card.Root data-testid="hub-entry-card" data-fqn={entry.fqn}>
+					<Card.Header>
+						<div class="flex flex-wrap items-start justify-between gap-2">
+							<div class="space-y-1">
+								<Card.Title class="font-mono text-sm break-all">
+									{entry.fqn}
+								</Card.Title>
+								<Card.Description>{entry.description}</Card.Description>
+							</div>
+							<Button
+								variant="default"
+								onclick={() => (selectedFQN = entry.fqn)}
+								data-testid="hub-install-cta"
+							>
+								Install suite
+							</Button>
 						</div>
-						<Button
-							variant="default"
-							onclick={() => (selectedFQN = entry.fqn)}
-							data-testid="hub-install-cta"
-						>
-							Install
-						</Button>
-					</div>
-				</Card.Header>
-				<Card.Content class="text-xs text-muted-foreground">
-					<span>Publisher: {entry.publisher_github}</span>
-					<span class="ml-3">Release pattern: <code>{entry.release_pattern}</code></span>
-				</Card.Content>
-			</Card.Root>
-		{/each}
-	</div>
+					</Card.Header>
+					<Card.Content class="text-xs text-muted-foreground">
+						<span>Publisher: {entry.publisher_github}</span>
+						<span class="ml-3">
+							Actions: {entry.member_actions?.length ?? 0}
+						</span>
+						{#if entry.category}
+							<span class="ml-3">Category: {entry.category}</span>
+						{/if}
+					</Card.Content>
+				</Card.Root>
+			{/each}
+		</div>
+	{/if}
+{:else if activeTab === 'actions'}
+	{#if actions.length === 0}
+		<p class="text-muted-foreground" data-testid="hub-empty-state">
+			{emptyStateMessage('actions', query)}
+		</p>
+	{:else}
+		<div class="flex flex-col gap-3" data-testid="hub-list" data-tab="actions">
+			{#each actions as entry (entry.fqn)}
+				<Card.Root data-testid="hub-entry-card" data-fqn={entry.fqn}>
+					<Card.Header>
+						<div class="flex flex-wrap items-start justify-between gap-2">
+							<div class="space-y-1">
+								<Card.Title class="font-mono text-sm break-all">
+									{entry.fqn}
+								</Card.Title>
+								<Card.Description>{entry.description}</Card.Description>
+							</div>
+							<Button
+								variant="default"
+								onclick={() => (selectedFQN = entry.fqn)}
+								data-testid="hub-install-cta"
+							>
+								Install action
+							</Button>
+						</div>
+					</Card.Header>
+					<Card.Content class="text-xs text-muted-foreground">
+						<span>Publisher: {entry.publisher_github}</span>
+						<span class="ml-3">
+							Requires: <code>{entry.connector_fqn}</code>
+						</span>
+						{#if entry.category}
+							<span class="ml-3">Category: {entry.category}</span>
+						{/if}
+						{#if entry.intents && entry.intents.length > 0}
+							<div class="mt-1">
+								<span>Intents:</span>
+								{#each entry.intents as intent}
+									<code class="ml-1">{intent}</code>
+								{/each}
+							</div>
+						{/if}
+					</Card.Content>
+				</Card.Root>
+			{/each}
+		</div>
+	{/if}
+{:else}
+	{#if connectors.length === 0}
+		<p class="text-muted-foreground" data-testid="hub-empty-state">
+			{emptyStateMessage('providers', query)}
+		</p>
+	{:else}
+		<div class="flex flex-col gap-3" data-testid="hub-list" data-tab="providers">
+			{#each connectors as entry (entry.fqn)}
+				<Card.Root data-testid="hub-entry-card" data-fqn={entry.fqn}>
+					<Card.Header>
+						<div class="flex flex-wrap items-start justify-between gap-2">
+							<div class="space-y-1">
+								<Card.Title class="font-mono text-sm break-all">
+									{entry.fqn}
+								</Card.Title>
+								<Card.Description>{entry.description}</Card.Description>
+							</div>
+							<Button
+								variant="default"
+								onclick={() => (selectedFQN = entry.fqn)}
+								data-testid="hub-install-cta"
+							>
+								Install
+							</Button>
+						</div>
+					</Card.Header>
+					<Card.Content class="text-xs text-muted-foreground">
+						<span>Publisher: {entry.publisher_github}</span>
+						<span class="ml-3">Release pattern: <code>{entry.release_pattern}</code></span>
+					</Card.Content>
+				</Card.Root>
+			{/each}
+		</div>
+	{/if}
 {/if}
 
-<HubInstallModal
-	fqn={selectedFQN}
-	onClose={() => (selectedFQN = null)}
-/>
+<HubInstallModal fqn={selectedFQN} onClose={() => (selectedFQN = null)} />

--- a/webapp/src/routes/hub/page.test.ts
+++ b/webapp/src/routes/hub/page.test.ts
@@ -3,6 +3,8 @@ import { render, screen, waitFor, fireEvent } from '@testing-library/svelte';
 
 vi.mock('$lib/api', () => ({
 	listHubConnectors: vi.fn(),
+	listHubActions: vi.fn(),
+	listHubSuites: vi.fn(),
 	getHubInstallDecision: vi.fn(),
 	installConnector: vi.fn()
 }));
@@ -10,19 +12,23 @@ vi.mock('$lib/api', () => ({
 import Page from './+page.svelte';
 import {
 	listHubConnectors,
+	listHubActions,
+	listHubSuites,
 	getHubInstallDecision,
 	type HubConnectorEntry,
+	type HubActionEntry,
+	type HubSuiteEntry,
 	type HubInstallDecision
 } from '$lib/api';
 
-const aliceEntry: HubConnectorEntry = {
+const aliceConnector: HubConnectorEntry = {
 	fqn: 'github://alice/calendar',
 	description: 'Google Calendar connector',
 	publisher_github: 'alice',
 	key_url: 'https://example.com/alice.pub',
 	release_pattern: 'v*'
 };
-const bobEntry: HubConnectorEntry = {
+const bobConnector: HubConnectorEntry = {
 	fqn: 'github://bob/slack',
 	description: 'Slack messaging connector',
 	publisher_github: 'bob',
@@ -30,9 +36,30 @@ const bobEntry: HubConnectorEntry = {
 	release_pattern: 'v*'
 };
 
+const draftEmailAction: HubActionEntry = {
+	fqn: 'github://alice/conn-google/actions/draft-email',
+	description: 'Draft a Gmail message with subject, recipients, and body',
+	publisher_github: 'alice',
+	connector_fqn: 'github://alice/conn-google',
+	intents: ['draft email', 'compose gmail'],
+	category: 'communication'
+};
+
+const gmailSuite: HubSuiteEntry = {
+	fqn: 'github://alice/conn-google/suite',
+	description: 'Read and draft Gmail; read and create calendar events',
+	publisher_github: 'alice',
+	member_actions: [
+		'github://alice/conn-google/actions/list-recent-emails',
+		'github://alice/conn-google/actions/draft-email'
+	],
+	connectors_required: ['github://alice/conn-google'],
+	category: 'communication'
+};
+
 const aliceDecision: HubInstallDecision = {
-	fqn: aliceEntry.fqn,
-	description: aliceEntry.description,
+	fqn: aliceConnector.fqn,
+	description: aliceConnector.description,
 	publisher_github: 'alice',
 	fingerprint: 'sha256:aliceFingerprintAAAAAAA',
 	trust_state: 'unknown',
@@ -42,13 +69,96 @@ const aliceDecision: HubInstallDecision = {
 
 beforeEach(() => {
 	vi.mocked(listHubConnectors).mockReset();
+	vi.mocked(listHubActions).mockReset();
+	vi.mocked(listHubSuites).mockReset();
 	vi.mocked(getHubInstallDecision).mockReset();
+	// Sensible defaults: every tab returns empty unless overridden by
+	// the specific test. Avoids "function returned undefined" failures
+	// when a tab-switch test triggers a fetch the test didn't author.
+	vi.mocked(listHubConnectors).mockResolvedValue({ connectors: [] });
+	vi.mocked(listHubActions).mockResolvedValue({ actions: [] });
+	vi.mocked(listHubSuites).mockResolvedValue({ suites: [] });
 });
 
-describe('Hub page — list + search', () => {
-	it('renders an empty-state hint when the Hub is empty', async () => {
-		vi.mocked(listHubConnectors).mockResolvedValue({ connectors: [] });
+describe('Hub page — tab shell', () => {
+	it('lands on the Suites tab and queries /hub/suites first', async () => {
 		render(Page);
+		await waitFor(() => {
+			expect(listHubSuites).toHaveBeenCalledWith(undefined);
+		});
+		// Suites tab is the default per the action-first IA.
+		expect(screen.getByTestId('hub-tab-suites')).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+	});
+
+	it('renders Suite entries with action count and category', async () => {
+		vi.mocked(listHubSuites).mockResolvedValue({ suites: [gmailSuite] });
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByText(gmailSuite.fqn)).toBeInTheDocument();
+			expect(screen.getByText(gmailSuite.description)).toBeInTheDocument();
+			expect(screen.getByText(/Actions: 2/)).toBeInTheDocument();
+			expect(screen.getByText(/Category: communication/)).toBeInTheDocument();
+		});
+	});
+
+	it('switches to the Actions tab and fetches /hub/actions', async () => {
+		vi.mocked(listHubActions).mockResolvedValue({ actions: [draftEmailAction] });
+		render(Page);
+		await waitFor(() => {
+			expect(listHubSuites).toHaveBeenCalled();
+		});
+		await fireEvent.click(screen.getByTestId('hub-tab-actions'));
+		await waitFor(() => {
+			expect(listHubActions).toHaveBeenCalledWith(undefined);
+		});
+		expect(screen.getByTestId('hub-tab-actions')).toHaveAttribute(
+			'aria-selected',
+			'true'
+		);
+		expect(screen.getByText(draftEmailAction.fqn)).toBeInTheDocument();
+		expect(screen.getByText(/draft email/)).toBeInTheDocument();
+		expect(screen.getByText(/compose gmail/)).toBeInTheDocument();
+		expect(screen.getByText(/Requires:/)).toBeInTheDocument();
+	});
+
+	it('switches to the Providers tab and fetches /hub/connectors', async () => {
+		vi.mocked(listHubConnectors).mockResolvedValue({
+			connectors: [aliceConnector, bobConnector]
+		});
+		render(Page);
+		await waitFor(() => {
+			expect(listHubSuites).toHaveBeenCalled();
+		});
+		await fireEvent.click(screen.getByTestId('hub-tab-providers'));
+		await waitFor(() => {
+			expect(listHubConnectors).toHaveBeenCalledWith(undefined);
+		});
+		expect(screen.getByText('github://alice/calendar')).toBeInTheDocument();
+		expect(screen.getByText('github://bob/slack')).toBeInTheDocument();
+	});
+
+	it('clicking the active tab does not refetch', async () => {
+		render(Page);
+		await waitFor(() => {
+			expect(listHubSuites).toHaveBeenCalledTimes(1);
+		});
+		await fireEvent.click(screen.getByTestId('hub-tab-suites'));
+		// One additional event loop tick.
+		await Promise.resolve();
+		expect(listHubSuites).toHaveBeenCalledTimes(1);
+	});
+});
+
+describe('Hub page — Providers tab (legacy connector flow)', () => {
+	it('renders an empty-state hint when no connectors are published', async () => {
+		render(Page);
+		await waitFor(() => {
+			expect(listHubSuites).toHaveBeenCalled();
+		});
+		await fireEvent.click(screen.getByTestId('hub-tab-providers'));
 		await waitFor(() => {
 			expect(
 				screen.getByText(/No connectors published to the Hub/)
@@ -56,55 +166,72 @@ describe('Hub page — list + search', () => {
 		});
 	});
 
-	it('renders Hub entries returned by the API', async () => {
+	it('renders connector entries returned by the API', async () => {
 		vi.mocked(listHubConnectors).mockResolvedValue({
-			connectors: [aliceEntry, bobEntry]
+			connectors: [aliceConnector, bobConnector]
 		});
 		render(Page);
+		await waitFor(() => {
+			expect(listHubSuites).toHaveBeenCalled();
+		});
+		await fireEvent.click(screen.getByTestId('hub-tab-providers'));
 		await waitFor(() => {
 			expect(screen.getByText('github://alice/calendar')).toBeInTheDocument();
 			expect(screen.getByText('github://bob/slack')).toBeInTheDocument();
 			expect(screen.getByText('Google Calendar connector')).toBeInTheDocument();
 		});
-		expect(listHubConnectors).toHaveBeenCalledWith('');
 	});
 
 	it('surfaces an API error rather than silently rendering empty', async () => {
 		vi.mocked(listHubConnectors).mockRejectedValue(new Error('hub_unreachable'));
 		render(Page);
 		await waitFor(() => {
+			expect(listHubSuites).toHaveBeenCalled();
+		});
+		await fireEvent.click(screen.getByTestId('hub-tab-providers'));
+		await waitFor(() => {
 			expect(screen.getByTestId('hub-list-error')).toHaveTextContent(
 				'hub_unreachable'
 			);
 		});
 	});
+});
 
-	it('debounces search input and re-fetches with the query parameter', async () => {
+describe('Hub page — search (per-tab)', () => {
+	it('debounces search input and re-fetches with the query parameter on the active tab', async () => {
 		vi.useFakeTimers();
-		vi.mocked(listHubConnectors).mockResolvedValue({ connectors: [aliceEntry] });
+		vi.mocked(listHubSuites).mockResolvedValue({ suites: [gmailSuite] });
 		render(Page);
 		await vi.waitFor(() => {
-			expect(listHubConnectors).toHaveBeenCalledWith('');
+			expect(listHubSuites).toHaveBeenCalledWith(undefined);
 		});
 		const input = screen.getByTestId('hub-search-input');
 		await fireEvent.input(input, { target: { value: 'calendar' } });
-		// Debounce window is 250ms — advance the timer and let promises settle.
+		// Debounce window is 250ms.
 		await vi.advanceTimersByTimeAsync(300);
-		expect(listHubConnectors).toHaveBeenLastCalledWith('calendar');
+		expect(listHubSuites).toHaveBeenLastCalledWith('calendar');
 		vi.useRealTimers();
 	});
 
-	it('echoes the query in the no-match empty state', async () => {
+	it('echoes the query in the no-match empty state on every tab', async () => {
 		vi.useFakeTimers();
-		vi.mocked(listHubConnectors).mockResolvedValue({ connectors: [] });
 		render(Page);
 		await vi.waitFor(() => {
-			expect(listHubConnectors).toHaveBeenCalled();
+			expect(listHubSuites).toHaveBeenCalled();
 		});
+		// Default tab (Suites): empty + query echo.
 		await fireEvent.input(screen.getByTestId('hub-search-input'), {
 			target: { value: 'zzz' }
 		});
 		await vi.advanceTimersByTimeAsync(300);
+		await vi.waitFor(() => {
+			expect(screen.getByTestId('hub-empty-state')).toHaveTextContent('"zzz"');
+		});
+		// Switch tabs (search persists; re-fetches on the new tab).
+		await fireEvent.click(screen.getByTestId('hub-tab-providers'));
+		await vi.waitFor(() => {
+			expect(listHubConnectors).toHaveBeenCalledWith('zzz');
+		});
 		await vi.waitFor(() => {
 			expect(screen.getByTestId('hub-empty-state')).toHaveTextContent('"zzz"');
 		});
@@ -115,23 +242,27 @@ describe('Hub page — list + search', () => {
 describe('Hub page — install modal integration', () => {
 	it('opens the install modal with the clicked entry’s install-decision', async () => {
 		vi.mocked(listHubConnectors).mockResolvedValue({
-			connectors: [aliceEntry, bobEntry]
+			connectors: [aliceConnector, bobConnector]
 		});
 		vi.mocked(getHubInstallDecision).mockResolvedValue(aliceDecision);
 		render(Page);
+		await waitFor(() => {
+			expect(listHubSuites).toHaveBeenCalled();
+		});
+		await fireEvent.click(screen.getByTestId('hub-tab-providers'));
 		await waitFor(() => {
 			expect(screen.getByText('github://alice/calendar')).toBeInTheDocument();
 		});
 		const aliceCard = screen
 			.getAllByTestId('hub-entry-card')
-			.find((c) => c.getAttribute('data-fqn') === aliceEntry.fqn);
+			.find((c) => c.getAttribute('data-fqn') === aliceConnector.fqn);
 		expect(aliceCard).toBeDefined();
 		const installBtn = aliceCard!.querySelector(
 			'[data-testid="hub-install-cta"]'
 		) as HTMLButtonElement;
 		await fireEvent.click(installBtn);
 		await waitFor(() => {
-			expect(getHubInstallDecision).toHaveBeenCalledWith(aliceEntry.fqn);
+			expect(getHubInstallDecision).toHaveBeenCalledWith(aliceConnector.fqn);
 		});
 		await waitFor(() => {
 			expect(screen.getByTestId('hub-trust-state')).toHaveAttribute(


### PR DESCRIPTION
## Summary

- Extends `webapp/src/lib/api.ts` with type defs + fetchers for the action and suite catalogs and the composite install-decision payloads. Types mirror the daemon's OpenAPI shapes exactly.
- Refactors `webapp/src/routes/hub/+page.svelte` into a tabbed shell. Default tab is **Suites** (intent-first browse per ADR-0013's action-first amendment). Tab order is Suites → Actions → Providers — matching the CLI's `aileron hub list` rendering.
- Per-tab search: typing in the single search input re-fetches whichever catalog is active. Search state persists across tab switches.
- Card layouts:
  - Suites: FQN, description, publisher, action count, optional category
  - Actions: FQN, description, publisher, required connector, optional intents, optional category
  - Providers: existing connector card unchanged
- Existing `HubInstallModal` integration on the Providers tab is preserved; it continues to consume the connector-level `HubInstallDecision`. The composite install modal extension is a follow-up.

Detail pages (`/hub/actions/[fqn]`, `/hub/suites/[fqn]`) and the composite install modal are the remaining webapp items on #709.

Refs #709 (umbrella).

## Test plan

- [x] `svelte-check` clean.
- [x] `(cd webapp && pnpm exec vitest run)` green — 57 tests total, 11 in the hub page suite covering: default-tab Suites, switching to Actions / Providers, refetch behavior on switch, no-refetch when clicking active tab, per-tab empty state messages, API error surfacing on Providers, debounced search across tabs, search-query persistence on tab switch, and the existing install-modal integration on Providers.
- [x] Existing Providers tab behavior asserted as a strict subset of the prior connector-only page.
- [ ] CI green (full matrix).