### PR TITLE
feat(webapp): action and suite detail pages at /hub/{actions,suites}/[fqn]

### DIFF
--- a/webapp/src/routes/hub/+page.svelte
+++ b/webapp/src/routes/hub/+page.svelte
@@ -174,7 +174,13 @@
 						<div class="flex flex-wrap items-start justify-between gap-2">
 							<div class="space-y-1">
 								<Card.Title class="font-mono text-sm break-all">
-									{entry.fqn}
+									<a
+										href="/hub/suites/{encodeURIComponent(entry.fqn)}"
+										class="underline-offset-2 hover:underline"
+										data-testid="hub-entry-link"
+									>
+										{entry.fqn}
+									</a>
 								</Card.Title>
 								<Card.Description>{entry.description}</Card.Description>
 							</div>
@@ -213,7 +219,13 @@
 						<div class="flex flex-wrap items-start justify-between gap-2">
 							<div class="space-y-1">
 								<Card.Title class="font-mono text-sm break-all">
-									{entry.fqn}
+									<a
+										href="/hub/actions/{encodeURIComponent(entry.fqn)}"
+										class="underline-offset-2 hover:underline"
+										data-testid="hub-entry-link"
+									>
+										{entry.fqn}
+									</a>
 								</Card.Title>
 								<Card.Description>{entry.description}</Card.Description>
 							</div>

--- a/webapp/src/routes/hub/actions/[fqn]/+page.svelte
+++ b/webapp/src/routes/hub/actions/[fqn]/+page.svelte
@@ -1,0 +1,112 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { getHubAction, type HubActionEntry } from '$lib/api';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import HubInstallModal from '$lib/components/HubInstallModal.svelte';
+
+	// Detail page for a single Hub action entry (#709). The route param
+	// `[fqn]` carries the action FQN URL-encoded; SvelteKit decodes once
+	// before handing it to us, so `page.params.fqn` is the canonical
+	// string like `github://acme/conn-google/actions/draft-email`.
+	//
+	// Rendered alongside the connector dependency, intents, and category.
+	// The Install button opens the existing HubInstallModal targeted at
+	// the action's own FQN; the modal will fetch the composite action
+	// install-decision when its composite extension lands.
+
+	let entry = $state<HubActionEntry | null>(null);
+	let loading = $state(true);
+	let error = $state('');
+	let installFqn = $state<string | null>(null);
+
+	const fqn = $derived(page.params.fqn ?? '');
+
+	onMount(async () => {
+		try {
+			entry = await getHubAction(fqn);
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>{entry?.fqn ?? 'Action'} — Hub — Aileron</title>
+</svelte:head>
+
+<div class="mb-4">
+	<Button
+		variant="ghost"
+		onclick={() => goto('/hub')}
+		data-testid="hub-detail-back"
+	>
+		← Back to Hub
+	</Button>
+</div>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading action…</p>
+{:else if error}
+	<p class="text-destructive" data-testid="hub-detail-error">{error}</p>
+{:else if entry}
+	<h1 class="mb-2 font-mono text-2xl font-bold break-all">{entry.fqn}</h1>
+	<p class="ink-bleed mb-6 text-base text-muted-foreground">
+		{entry.description}
+	</p>
+
+	<Card.Root class="mb-4">
+		<Card.Header>
+			<Card.Title>Action metadata</Card.Title>
+		</Card.Header>
+		<Card.Content class="space-y-2 text-sm">
+			<div>
+				<span class="font-medium">Publisher:</span>
+				<span class="ml-2 font-mono">{entry.publisher_github}</span>
+			</div>
+			<div>
+				<span class="font-medium">Required connector:</span>
+				<a
+					href="/hub/connectors/{encodeURIComponent(entry.connector_fqn)}"
+					class="ml-2 font-mono underline-offset-2 hover:underline"
+					data-testid="hub-detail-connector-link"
+				>
+					{entry.connector_fqn}
+				</a>
+			</div>
+			{#if entry.category}
+				<div>
+					<span class="font-medium">Category:</span>
+					<span class="ml-2">{entry.category}</span>
+				</div>
+			{/if}
+			{#if entry.intents && entry.intents.length > 0}
+				<div>
+					<span class="font-medium">Intents:</span>
+					<ul
+						class="mt-1 ml-2 list-disc pl-4"
+						data-testid="hub-detail-intents"
+					>
+						{#each entry.intents as intent}
+							<li><code>{intent}</code></li>
+						{/each}
+					</ul>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Button
+		variant="default"
+		onclick={() => (installFqn = entry!.fqn)}
+		data-testid="hub-detail-install-cta"
+	>
+		Install action
+	</Button>
+
+	<HubInstallModal fqn={installFqn} onClose={() => (installFqn = null)} />
+{/if}

--- a/webapp/src/routes/hub/actions/[fqn]/page.test.ts
+++ b/webapp/src/routes/hub/actions/[fqn]/page.test.ts
@@ -1,0 +1,85 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+
+vi.mock('$lib/api', () => ({
+	getHubAction: vi.fn(),
+	getHubInstallDecision: vi.fn(),
+	installConnector: vi.fn()
+}));
+
+vi.mock('$app/state', () => ({
+	page: { params: { fqn: 'github://alice/conn-google/actions/draft-email' } }
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+import Page from './+page.svelte';
+import { getHubAction, type HubActionEntry } from '$lib/api';
+
+const draftEmail: HubActionEntry = {
+	fqn: 'github://alice/conn-google/actions/draft-email',
+	description: 'Draft a Gmail message with subject, recipients, and body',
+	publisher_github: 'alice',
+	connector_fqn: 'github://alice/conn-google',
+	intents: ['draft email', 'compose gmail'],
+	category: 'communication'
+};
+
+beforeEach(() => {
+	vi.mocked(getHubAction).mockReset();
+});
+
+describe('Hub action detail page', () => {
+	it('fetches the action by FQN and renders metadata', async () => {
+		vi.mocked(getHubAction).mockResolvedValue(draftEmail);
+		render(Page);
+		await waitFor(() => {
+			expect(getHubAction).toHaveBeenCalledWith(draftEmail.fqn);
+		});
+		expect(screen.getByText(draftEmail.fqn)).toBeInTheDocument();
+		expect(screen.getByText(draftEmail.description)).toBeInTheDocument();
+		expect(screen.getByText('alice')).toBeInTheDocument();
+		expect(screen.getByText(draftEmail.connector_fqn)).toBeInTheDocument();
+		expect(screen.getByText('communication')).toBeInTheDocument();
+		// Intents render as a list.
+		const intents = screen.getByTestId('hub-detail-intents');
+		expect(intents).toHaveTextContent('draft email');
+		expect(intents).toHaveTextContent('compose gmail');
+	});
+
+	it('renders the connector dependency as a link to the connector detail', async () => {
+		vi.mocked(getHubAction).mockResolvedValue(draftEmail);
+		render(Page);
+		await waitFor(() => {
+			expect(getHubAction).toHaveBeenCalled();
+		});
+		const link = screen.getByTestId('hub-detail-connector-link') as HTMLAnchorElement;
+		expect(link).toHaveAttribute(
+			'href',
+			'/hub/connectors/' + encodeURIComponent(draftEmail.connector_fqn)
+		);
+	});
+
+	it('surfaces a fetch error rather than rendering a partial UI', async () => {
+		vi.mocked(getHubAction).mockRejectedValue(new Error('not_found'));
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-detail-error')).toHaveTextContent(
+				'not_found'
+			);
+		});
+	});
+
+	it('does not render the install CTA before the entry has loaded', async () => {
+		// Reject so the entry never loads — the install CTA must not
+		// render because the modal requires entry.fqn to target.
+		vi.mocked(getHubAction).mockRejectedValue(new Error('boom'));
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-detail-error')).toBeInTheDocument();
+		});
+		expect(screen.queryByTestId('hub-detail-install-cta')).toBeNull();
+	});
+});

--- a/webapp/src/routes/hub/suites/[fqn]/+page.svelte
+++ b/webapp/src/routes/hub/suites/[fqn]/+page.svelte
@@ -1,0 +1,125 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+	import { page } from '$app/state';
+	import { goto } from '$app/navigation';
+	import { getHubSuite, type HubSuiteEntry } from '$lib/api';
+	import * as Card from '$lib/components/ui/card';
+	import { Button } from '$lib/components/ui/button';
+	import HubInstallModal from '$lib/components/HubInstallModal.svelte';
+
+	// Detail page for a single Hub suite entry (#709). Same routing
+	// pattern as the action detail page: `[fqn]` is URL-encoded in the
+	// link and SvelteKit decodes once. Renders the member-action list
+	// and the connectors_required closure so the operator can see what
+	// the suite will install before clicking through.
+
+	let entry = $state<HubSuiteEntry | null>(null);
+	let loading = $state(true);
+	let error = $state('');
+	let installFqn = $state<string | null>(null);
+
+	const fqn = $derived(page.params.fqn ?? '');
+
+	onMount(async () => {
+		try {
+			entry = await getHubSuite(fqn);
+		} catch (e) {
+			error = e instanceof Error ? e.message : String(e);
+		} finally {
+			loading = false;
+		}
+	});
+</script>
+
+<svelte:head>
+	<title>{entry?.fqn ?? 'Suite'} — Hub — Aileron</title>
+</svelte:head>
+
+<div class="mb-4">
+	<Button
+		variant="ghost"
+		onclick={() => goto('/hub')}
+		data-testid="hub-detail-back"
+	>
+		← Back to Hub
+	</Button>
+</div>
+
+{#if loading}
+	<p class="text-muted-foreground">Loading suite…</p>
+{:else if error}
+	<p class="text-destructive" data-testid="hub-detail-error">{error}</p>
+{:else if entry}
+	<h1 class="mb-2 font-mono text-2xl font-bold break-all">{entry.fqn}</h1>
+	<p class="ink-bleed mb-6 text-base text-muted-foreground">
+		{entry.description}
+	</p>
+
+	<Card.Root class="mb-4">
+		<Card.Header>
+			<Card.Title>Suite metadata</Card.Title>
+		</Card.Header>
+		<Card.Content class="space-y-2 text-sm">
+			<div>
+				<span class="font-medium">Publisher:</span>
+				<span class="ml-2 font-mono">{entry.publisher_github}</span>
+			</div>
+			{#if entry.category}
+				<div>
+					<span class="font-medium">Category:</span>
+					<span class="ml-2">{entry.category}</span>
+				</div>
+			{/if}
+			<div>
+				<span class="font-medium">Member actions ({entry.member_actions.length}):</span>
+				<ul
+					class="mt-1 ml-2 list-disc pl-4"
+					data-testid="hub-detail-members"
+				>
+					{#each entry.member_actions as action}
+						<li>
+							<a
+								href="/hub/actions/{encodeURIComponent(action)}"
+								class="font-mono underline-offset-2 hover:underline"
+							>
+								{action}
+							</a>
+						</li>
+					{/each}
+				</ul>
+			</div>
+			{#if entry.connectors_required && entry.connectors_required.length > 0}
+				<div>
+					<span class="font-medium">
+						Connectors required ({entry.connectors_required.length}):
+					</span>
+					<ul
+						class="mt-1 ml-2 list-disc pl-4"
+						data-testid="hub-detail-connectors"
+					>
+						{#each entry.connectors_required as conn}
+							<li>
+								<a
+									href="/hub/connectors/{encodeURIComponent(conn)}"
+									class="font-mono underline-offset-2 hover:underline"
+								>
+									{conn}
+								</a>
+							</li>
+						{/each}
+					</ul>
+				</div>
+			{/if}
+		</Card.Content>
+	</Card.Root>
+
+	<Button
+		variant="default"
+		onclick={() => (installFqn = entry!.fqn)}
+		data-testid="hub-detail-install-cta"
+	>
+		Install suite
+	</Button>
+
+	<HubInstallModal fqn={installFqn} onClose={() => (installFqn = null)} />
+{/if}

--- a/webapp/src/routes/hub/suites/[fqn]/page.test.ts
+++ b/webapp/src/routes/hub/suites/[fqn]/page.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+
+vi.mock('$lib/api', () => ({
+	getHubSuite: vi.fn(),
+	getHubInstallDecision: vi.fn(),
+	installConnector: vi.fn()
+}));
+
+vi.mock('$app/state', () => ({
+	page: { params: { fqn: 'github://alice/conn-google/suite' } }
+}));
+
+vi.mock('$app/navigation', () => ({
+	goto: vi.fn()
+}));
+
+import Page from './+page.svelte';
+import { getHubSuite, type HubSuiteEntry } from '$lib/api';
+
+const gmailSuite: HubSuiteEntry = {
+	fqn: 'github://alice/conn-google/suite',
+	description: 'Read and draft Gmail; read and create calendar events',
+	publisher_github: 'alice',
+	member_actions: [
+		'github://alice/conn-google/actions/list-recent-emails',
+		'github://alice/conn-google/actions/draft-email'
+	],
+	connectors_required: ['github://alice/conn-google'],
+	category: 'communication'
+};
+
+beforeEach(() => {
+	vi.mocked(getHubSuite).mockReset();
+});
+
+describe('Hub suite detail page', () => {
+	it('fetches the suite by FQN and renders metadata', async () => {
+		vi.mocked(getHubSuite).mockResolvedValue(gmailSuite);
+		render(Page);
+		await waitFor(() => {
+			expect(getHubSuite).toHaveBeenCalledWith(gmailSuite.fqn);
+		});
+		expect(screen.getByText(gmailSuite.fqn)).toBeInTheDocument();
+		expect(screen.getByText(gmailSuite.description)).toBeInTheDocument();
+		expect(screen.getByText('alice')).toBeInTheDocument();
+		expect(screen.getByText('communication')).toBeInTheDocument();
+	});
+
+	it('renders each member action as a link to the action detail', async () => {
+		vi.mocked(getHubSuite).mockResolvedValue(gmailSuite);
+		render(Page);
+		await waitFor(() => {
+			expect(getHubSuite).toHaveBeenCalled();
+		});
+		const members = screen.getByTestId('hub-detail-members');
+		for (const action of gmailSuite.member_actions) {
+			const link = members.querySelector(`a[href="/hub/actions/${encodeURIComponent(action)}"]`);
+			expect(link, `expected member-action link for ${action}`).not.toBeNull();
+		}
+	});
+
+	it('renders the connectors_required list when present', async () => {
+		vi.mocked(getHubSuite).mockResolvedValue(gmailSuite);
+		render(Page);
+		await waitFor(() => {
+			expect(getHubSuite).toHaveBeenCalled();
+		});
+		const list = screen.getByTestId('hub-detail-connectors');
+		expect(list).toHaveTextContent('github://alice/conn-google');
+	});
+
+	it('omits the connectors_required block when the suite does not declare one', async () => {
+		const minimalSuite: HubSuiteEntry = {
+			fqn: 'github://alice/x/suite',
+			description: 'minimal',
+			publisher_github: 'alice',
+			member_actions: ['github://alice/x/actions/foo']
+			// no connectors_required
+		};
+		vi.mocked(getHubSuite).mockResolvedValue(minimalSuite);
+		render(Page);
+		await waitFor(() => {
+			expect(getHubSuite).toHaveBeenCalled();
+		});
+		expect(screen.queryByTestId('hub-detail-connectors')).toBeNull();
+	});
+
+	it('surfaces a fetch error rather than rendering a partial UI', async () => {
+		vi.mocked(getHubSuite).mockRejectedValue(new Error('not_found'));
+		render(Page);
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-detail-error')).toHaveTextContent(
+				'not_found'
+			);
+		});
+	});
+});


### PR DESCRIPTION
## Summary

- Adds `/hub/actions/[fqn]` and `/hub/suites/[fqn]` detail routes. Each fetches a single Hub entry via the daemon's existing per-type endpoints (`/v1/hub/action`, `/v1/hub/suite`) and renders the full record.
- Action detail: FQN, description, publisher, required connector (linked to its connector detail), optional intents list, optional category.
- Suite detail: FQN, description, publisher, optional category, member-actions list (each linked to its action detail page), `connectors_required` closure (linked to connector detail) when declared.
- Both pages include an Install button that opens the existing `HubInstallModal` targeted at the entry's own FQN. The composite extension of the modal that renders per-authority panels is the next webapp PR.
- Main `/hub` page: Suite and Action card titles now wrap their FQN in a link to the detail page. Providers tab unchanged — the existing connector card already linked to `/hub/connectors/<fqn>` tooling.

Routing note: SvelteKit's `[fqn]` dynamic param decodes once. Links use `encodeURIComponent(fqn)`; the page reads `page.params.fqn` as the canonical FQN string. Browser URL shows the encoded form (ugly but functional and bookmark-able).

Refs #709 (umbrella).

## Test plan

- [x] `svelte-check` clean.
- [x] `(cd webapp && pnpm exec vitest run)` green — 20 hub-route tests in three files.
  - Action detail: fetches by FQN, renders metadata, connector link href shape, fetch-error surfaces, install CTA absent until entry loads.
  - Suite detail: fetches by FQN, renders metadata, each member-action rendered as link to action detail, `connectors_required` rendered when present and omitted when absent, fetch-error surfaces.
  - Existing main-`/hub` tests still pass — new card-title links don't disrupt the install-button flow.
- [ ] CI green (full matrix).