### PR TITLE
feat(webapp): composite install modal for action and suite installs

### DIFF
--- a/webapp/src/lib/components/HubCompositeInstallModal.svelte
+++ b/webapp/src/lib/components/HubCompositeInstallModal.svelte
@@ -1,0 +1,271 @@
+<script lang="ts">
+	import * as Dialog from '$lib/components/ui/dialog';
+	import { Badge } from '$lib/components/ui/badge';
+	import { Button } from '$lib/components/ui/button';
+	import {
+		getHubActionInstallDecision,
+		getHubSuiteInstallDecision,
+		type HubActionInstallDecision,
+		type HubSuiteInstallDecision,
+		type HubInstallAuthority,
+		type HubTrustState
+	} from '$lib/api';
+
+	// Composite install modal (#709, action-first amendment). Opened
+	// when the user picks a Hub-listed action or suite to install. The
+	// modal fetches the composite install-decision payload from the
+	// daemon and renders one panel per unique connector authority in
+	// the dependency closure. All authorities share a single confirm
+	// action — the umbrella's "one trust gate, not N" promise.
+	//
+	// End-to-end install execution from the webapp requires a daemon-
+	// side trust endpoint that v0.x doesn't expose; the modal surfaces
+	// the operator's CLI command so they complete the install in their
+	// terminal once they've reviewed and accepted the trust panel.
+	// Tracked as a follow-up; the trust panel render is the load-
+	// bearing UX delivery for this iteration.
+
+	type Kind = 'action' | 'suite';
+
+	type Props = {
+		fqn: string | null;
+		kind: Kind | null;
+		onClose: () => void;
+	};
+
+	let { fqn, kind, onClose }: Props = $props();
+
+	const open = $derived(fqn !== null && kind !== null);
+
+	type Decision = HubActionInstallDecision | HubSuiteInstallDecision;
+	let decision = $state<Decision | null>(null);
+	let decisionError = $state('');
+	let loading = $state(false);
+
+	$effect(() => {
+		if (!fqn || !kind) {
+			decision = null;
+			decisionError = '';
+			return;
+		}
+		loading = true;
+		decision = null;
+		decisionError = '';
+		const target = fqn;
+		const targetKind = kind;
+		const fetcher =
+			targetKind === 'action'
+				? getHubActionInstallDecision
+				: getHubSuiteInstallDecision;
+		void fetcher(target)
+			.then((d) => {
+				if (fqn === target && kind === targetKind) decision = d;
+			})
+			.catch((e: unknown) => {
+				if (fqn === target && kind === targetKind) {
+					decisionError = e instanceof Error ? e.message : String(e);
+				}
+			})
+			.finally(() => {
+				if (fqn === target && kind === targetKind) loading = false;
+			});
+	});
+
+	function handleOpenChange(next: boolean) {
+		if (!next) onClose();
+	}
+
+	function trustBadgeVariant(
+		state: HubTrustState
+	): 'default' | 'secondary' | 'destructive' | 'outline' {
+		switch (state) {
+			case 'already_trusted':
+				return 'default';
+			case 'conflict':
+				return 'destructive';
+			default:
+				return 'secondary';
+		}
+	}
+
+	function trustLabel(state: HubTrustState): string {
+		switch (state) {
+			case 'already_trusted':
+				return 'Already trusted';
+			case 'unknown':
+				return 'Unknown publisher';
+			case 'conflict':
+				return 'Conflict — key differs from a sibling repo';
+			default:
+				return state;
+		}
+	}
+
+	function cliCommand(d: Decision): string {
+		// Pin to "@latest" since the composite payload doesn't carry a
+		// version. The CLI resolves @latest via the releases API for
+		// actions and via the suite source repo for suites; same shape
+		// the docs already use.
+		if (d.kind === 'action') {
+			return `aileron action add ${d.fqn}@latest`;
+		}
+		return `aileron action add-suite ${d.fqn}.toml@latest`;
+	}
+
+	// Suite FQNs in the Hub catalog are `<owner>/<repo>/suite` (or
+	// `<owner>/<repo>/suites/<x>`); the CLI's `add-suite` takes the
+	// path to the actual `suite.toml` file at a ref. The `cliCommand`
+	// helper appends `.toml@latest` to bridge that gap. Local
+	// (non-remote) suite installs aren't reachable from the Hub, so
+	// the heuristic is safe for every code path the modal serves.
+</script>
+
+<Dialog.Root {open} onOpenChange={handleOpenChange}>
+	<Dialog.Content data-testid="hub-composite-install-modal">
+		<Dialog.Header>
+			<Dialog.Title>
+				{#if kind === 'suite'}
+					Install suite from the Hub
+				{:else}
+					Install action from the Hub
+				{/if}
+			</Dialog.Title>
+			<Dialog.Description>
+				Review every connector authority this install depends on. One
+				accept covers them all — the daemon writes per-repo trust to your
+				keyring before the install pipeline runs.
+			</Dialog.Description>
+		</Dialog.Header>
+
+		{#if loading}
+			<p class="text-sm text-muted-foreground">Loading install decision…</p>
+		{:else if decisionError}
+			<p
+				class="text-sm text-destructive"
+				data-testid="hub-composite-decision-error"
+			>
+				{decisionError}
+			</p>
+		{:else if decision}
+			<div class="space-y-4 text-sm" data-testid="hub-composite-decision">
+				<dl class="grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+					<dt class="text-muted-foreground">
+						{decision.kind === 'suite' ? 'Suite' : 'Action'}
+					</dt>
+					<dd class="font-mono break-all">{decision.fqn}</dd>
+					{#if decision.description}
+						<dt class="text-muted-foreground">Description</dt>
+						<dd>{decision.description}</dd>
+					{/if}
+					<dt class="text-muted-foreground">Publisher</dt>
+					<dd>{decision.publisher_github}</dd>
+					{#if decision.kind === 'action'}
+						<dt class="text-muted-foreground">Connector</dt>
+						<dd class="font-mono break-all">{decision.connector_fqn}</dd>
+					{/if}
+				</dl>
+
+				{#if decision.kind === 'suite' && decision.member_actions.length > 0}
+					<div data-testid="hub-composite-members">
+						<p
+							class="mb-1 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+						>
+							Member actions ({decision.member_actions.length})
+						</p>
+						<ul class="space-y-0.5 text-xs font-mono">
+							{#each decision.member_actions as a (a)}
+								<li class="break-all">{a}</li>
+							{/each}
+						</ul>
+					</div>
+				{/if}
+
+				<div data-testid="hub-composite-authorities">
+					<p
+						class="mb-2 text-xs font-medium uppercase tracking-wide text-muted-foreground"
+					>
+						Trust gate ({decision.authorities.length})
+					</p>
+					<ul class="space-y-3">
+						{#each decision.authorities as auth (auth.fqn)}
+							{@render authorityPanel(auth)}
+						{/each}
+					</ul>
+				</div>
+
+				<div class="space-y-2 border-t border-border pt-3">
+					<p
+						class="text-xs font-medium uppercase tracking-wide text-muted-foreground"
+					>
+						Complete the install
+					</p>
+					<p class="text-xs text-muted-foreground">
+						Run this in your terminal. The CLI walks the same trust panel
+						you reviewed here and writes per-repo trust to your keyring on
+						confirm.
+					</p>
+					<pre
+						class="rounded border border-border bg-muted/50 p-2 text-xs font-mono whitespace-pre-wrap break-all"
+						data-testid="hub-composite-cli-command"><code>{cliCommand(decision)}</code></pre>
+				</div>
+			</div>
+			<Dialog.Footer>
+				<Button variant="default" onclick={onClose}>Close</Button>
+			</Dialog.Footer>
+		{/if}
+	</Dialog.Content>
+</Dialog.Root>
+
+{#snippet authorityPanel(auth: HubInstallAuthority)}
+	<li
+		class="rounded border border-border p-3 text-xs"
+		data-testid="hub-composite-authority"
+		data-fqn={auth.fqn}
+	>
+		<div class="font-mono break-all font-medium">{auth.fqn}</div>
+		<div class="mt-1 grid grid-cols-[max-content_1fr] gap-x-3 gap-y-1">
+			<span class="text-muted-foreground">Publisher</span>
+			<span>{auth.publisher_github}</span>
+			<span class="text-muted-foreground">Fingerprint</span>
+			<span class="font-mono break-all">{auth.fingerprint}</span>
+			<span class="text-muted-foreground">Trust</span>
+			<span>
+				<Badge
+					variant={trustBadgeVariant(auth.trust_state)}
+					data-testid="hub-composite-trust-state"
+					data-trust-state={auth.trust_state}
+				>
+					{trustLabel(auth.trust_state)}
+				</Badge>
+			</span>
+		</div>
+		{#if auth.risk_indicators.length > 0}
+			<ul
+				class="mt-2 space-y-0.5"
+				data-testid="hub-composite-risk-indicators"
+			>
+				{#each auth.risk_indicators as risk (risk)}
+					<li
+						class={auth.trust_state === 'conflict'
+							? 'text-destructive'
+							: 'text-foreground'}
+					>
+						{risk}
+					</li>
+				{/each}
+			</ul>
+		{/if}
+		{#if auth.publisher_footprint.length > 0}
+			<div class="mt-2">
+				<p class="mb-1 text-muted-foreground">
+					Other connectors by this publisher
+				</p>
+				<ul class="space-y-0.5 font-mono">
+					{#each auth.publisher_footprint as fp (fp)}
+						<li>{fp}</li>
+					{/each}
+				</ul>
+			</div>
+		{/if}
+	</li>
+{/snippet}

--- a/webapp/src/lib/components/HubCompositeInstallModal.test.ts
+++ b/webapp/src/lib/components/HubCompositeInstallModal.test.ts
@@ -1,0 +1,210 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/svelte';
+
+vi.mock('$lib/api', () => ({
+	getHubActionInstallDecision: vi.fn(),
+	getHubSuiteInstallDecision: vi.fn()
+}));
+
+import Modal from './HubCompositeInstallModal.svelte';
+import {
+	getHubActionInstallDecision,
+	getHubSuiteInstallDecision,
+	type HubActionInstallDecision,
+	type HubSuiteInstallDecision
+} from '$lib/api';
+
+const actionDecision: HubActionInstallDecision = {
+	kind: 'action',
+	fqn: 'github://alice/conn-google/actions/draft-email',
+	description: 'Draft a Gmail message',
+	publisher_github: 'alice',
+	connector_fqn: 'github://alice/conn-google',
+	authorities: [
+		{
+			fqn: 'github://alice/conn-google',
+			publisher_github: 'alice',
+			fingerprint: 'sha256:aliceFingerprintAAAAAA',
+			trust_state: 'unknown',
+			publisher_footprint: ['github://alice/other-conn'],
+			risk_indicators: ["First connector by this publisher you've installed"]
+		}
+	]
+};
+
+const suiteDecision: HubSuiteInstallDecision = {
+	kind: 'suite',
+	fqn: 'github://alice/conn-google/suite',
+	description: 'Gmail and Calendar bundle',
+	publisher_github: 'alice',
+	member_actions: [
+		'github://alice/conn-google/actions/list-recent-emails',
+		'github://alice/conn-google/actions/draft-email'
+	],
+	authorities: [
+		{
+			fqn: 'github://alice/conn-google',
+			publisher_github: 'alice',
+			fingerprint: 'sha256:aliceFingerprintAAAAAA',
+			trust_state: 'unknown',
+			publisher_footprint: [],
+			risk_indicators: ['First connector by this publisher']
+		},
+		{
+			fqn: 'github://bob/conn-calendar',
+			publisher_github: 'bob',
+			fingerprint: 'sha256:bobFingerprintBBBBBBB',
+			trust_state: 'already_trusted',
+			publisher_footprint: [],
+			risk_indicators: []
+		}
+	]
+};
+
+beforeEach(() => {
+	vi.mocked(getHubActionInstallDecision).mockReset();
+	vi.mocked(getHubSuiteInstallDecision).mockReset();
+});
+
+describe('HubCompositeInstallModal — action', () => {
+	it('fetches the action composite payload and renders the trust panel', async () => {
+		vi.mocked(getHubActionInstallDecision).mockResolvedValue(actionDecision);
+		render(Modal, {
+			props: {
+				fqn: actionDecision.fqn,
+				kind: 'action',
+				onClose: () => {}
+			}
+		});
+		await waitFor(() => {
+			expect(getHubActionInstallDecision).toHaveBeenCalledWith(actionDecision.fqn);
+		});
+		await waitFor(() => {
+			expect(screen.getByText(actionDecision.fqn)).toBeInTheDocument();
+		});
+		expect(screen.getByText(actionDecision.description)).toBeInTheDocument();
+		// connector_fqn surfaces in two places: the action-level
+		// "Connector" row and the authority panel's FQN header.
+		expect(screen.getAllByText(actionDecision.connector_fqn).length).toBeGreaterThanOrEqual(1);
+		// One authority surfaced with its fingerprint + trust badge.
+		const authorities = screen.getAllByTestId('hub-composite-authority');
+		expect(authorities).toHaveLength(1);
+		expect(authorities[0]).toHaveAttribute('data-fqn', 'github://alice/conn-google');
+		expect(screen.getByText('sha256:aliceFingerprintAAAAAA')).toBeInTheDocument();
+		expect(screen.getByTestId('hub-composite-trust-state')).toHaveAttribute(
+			'data-trust-state',
+			'unknown'
+		);
+	});
+
+	it('renders the CLI command for completing the install', async () => {
+		vi.mocked(getHubActionInstallDecision).mockResolvedValue(actionDecision);
+		render(Modal, {
+			props: { fqn: actionDecision.fqn, kind: 'action', onClose: () => {} }
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-composite-cli-command')).toBeInTheDocument();
+		});
+		expect(screen.getByTestId('hub-composite-cli-command')).toHaveTextContent(
+			`aileron action add ${actionDecision.fqn}@latest`
+		);
+	});
+
+	it('surfaces fetch errors instead of rendering an empty panel', async () => {
+		vi.mocked(getHubActionInstallDecision).mockRejectedValue(
+			new Error('not_found')
+		);
+		render(Modal, {
+			props: { fqn: actionDecision.fqn, kind: 'action', onClose: () => {} }
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-composite-decision-error')).toHaveTextContent(
+				'not_found'
+			);
+		});
+	});
+
+	it('renders publisher_footprint when verbose-ish info is available', async () => {
+		vi.mocked(getHubActionInstallDecision).mockResolvedValue(actionDecision);
+		render(Modal, {
+			props: { fqn: actionDecision.fqn, kind: 'action', onClose: () => {} }
+		});
+		await waitFor(() => {
+			expect(screen.getByText('github://alice/other-conn')).toBeInTheDocument();
+		});
+	});
+});
+
+describe('HubCompositeInstallModal — suite', () => {
+	it('renders one panel per unique connector authority', async () => {
+		vi.mocked(getHubSuiteInstallDecision).mockResolvedValue(suiteDecision);
+		render(Modal, {
+			props: {
+				fqn: suiteDecision.fqn,
+				kind: 'suite',
+				onClose: () => {}
+			}
+		});
+		await waitFor(() => {
+			expect(getHubSuiteInstallDecision).toHaveBeenCalledWith(suiteDecision.fqn);
+		});
+		await waitFor(() => {
+			expect(screen.getByText(suiteDecision.fqn)).toBeInTheDocument();
+		});
+		const authorities = screen.getAllByTestId('hub-composite-authority');
+		expect(authorities).toHaveLength(2);
+		const fqns = authorities.map((a) => a.getAttribute('data-fqn'));
+		expect(fqns).toEqual(['github://alice/conn-google', 'github://bob/conn-calendar']);
+		// Per-authority trust state — one unknown (alice), one
+		// already_trusted (bob).
+		const trustBadges = screen.getAllByTestId('hub-composite-trust-state');
+		expect(trustBadges[0]).toHaveAttribute('data-trust-state', 'unknown');
+		expect(trustBadges[1]).toHaveAttribute('data-trust-state', 'already_trusted');
+	});
+
+	it('renders the member-action list', async () => {
+		vi.mocked(getHubSuiteInstallDecision).mockResolvedValue(suiteDecision);
+		render(Modal, {
+			props: { fqn: suiteDecision.fqn, kind: 'suite', onClose: () => {} }
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-composite-members')).toBeInTheDocument();
+		});
+		const members = screen.getByTestId('hub-composite-members');
+		for (const a of suiteDecision.member_actions) {
+			expect(members).toHaveTextContent(a);
+		}
+	});
+
+	it('renders the CLI command for the suite install path', async () => {
+		vi.mocked(getHubSuiteInstallDecision).mockResolvedValue(suiteDecision);
+		render(Modal, {
+			props: { fqn: suiteDecision.fqn, kind: 'suite', onClose: () => {} }
+		});
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-composite-cli-command')).toBeInTheDocument();
+		});
+		// Hub suite FQN is `<owner>/<repo>/suite`; the CLI's add-suite
+		// command takes the `.toml` file path, so the modal appends
+		// `.toml@latest` to bridge the gap.
+		expect(screen.getByTestId('hub-composite-cli-command')).toHaveTextContent(
+			`aileron action add-suite ${suiteDecision.fqn}.toml@latest`
+		);
+	});
+});
+
+describe('HubCompositeInstallModal — dispatch', () => {
+	it('does not fetch when fqn is null', () => {
+		render(Modal, { props: { fqn: null, kind: null, onClose: () => {} } });
+		expect(getHubActionInstallDecision).not.toHaveBeenCalled();
+		expect(getHubSuiteInstallDecision).not.toHaveBeenCalled();
+	});
+
+	it('does not fetch when kind is null', () => {
+		render(Modal, {
+			props: { fqn: 'github://x/y/actions/z', kind: null, onClose: () => {} }
+		});
+		expect(getHubActionInstallDecision).not.toHaveBeenCalled();
+		expect(getHubSuiteInstallDecision).not.toHaveBeenCalled();
+	});
+});

--- a/webapp/src/routes/hub/+page.svelte
+++ b/webapp/src/routes/hub/+page.svelte
@@ -12,6 +12,7 @@
 	import { Button } from '$lib/components/ui/button';
 	import { Input } from '$lib/components/ui/input';
 	import HubInstallModal from '$lib/components/HubInstallModal.svelte';
+	import HubCompositeInstallModal from '$lib/components/HubCompositeInstallModal.svelte';
 
 	// Hub browsing page (ADR-0013, action-first amendment / #709). The
 	// catalog has three entry types — Suites, Actions, Connectors — and
@@ -35,7 +36,21 @@
 	let connectors = $state<HubConnectorEntry[]>([]);
 	let loading = $state(true);
 	let error = $state('');
-	let selectedFQN = $state<string | null>(null);
+	// Connector install modal is the single-authority connector flow.
+	// Composite modal is action/suite installs (one trust panel per
+	// authority in the closure).
+	let connectorInstallFQN = $state<string | null>(null);
+	let compositeFQN = $state<string | null>(null);
+	let compositeKind = $state<'action' | 'suite' | null>(null);
+
+	function openCompositeInstall(fqn: string, kind: 'action' | 'suite') {
+		compositeFQN = fqn;
+		compositeKind = kind;
+	}
+	function closeCompositeInstall() {
+		compositeFQN = null;
+		compositeKind = null;
+	}
 
 	async function refresh() {
 		loading = true;
@@ -186,7 +201,7 @@
 							</div>
 							<Button
 								variant="default"
-								onclick={() => (selectedFQN = entry.fqn)}
+								onclick={() => openCompositeInstall(entry.fqn, 'suite')}
 								data-testid="hub-install-cta"
 							>
 								Install suite
@@ -231,7 +246,7 @@
 							</div>
 							<Button
 								variant="default"
-								onclick={() => (selectedFQN = entry.fqn)}
+								onclick={() => openCompositeInstall(entry.fqn, 'action')}
 								data-testid="hub-install-cta"
 							>
 								Install action
@@ -278,7 +293,7 @@
 							</div>
 							<Button
 								variant="default"
-								onclick={() => (selectedFQN = entry.fqn)}
+								onclick={() => (connectorInstallFQN = entry.fqn)}
 								data-testid="hub-install-cta"
 							>
 								Install
@@ -295,4 +310,12 @@
 	{/if}
 {/if}
 
-<HubInstallModal fqn={selectedFQN} onClose={() => (selectedFQN = null)} />
+<HubInstallModal
+	fqn={connectorInstallFQN}
+	onClose={() => (connectorInstallFQN = null)}
+/>
+<HubCompositeInstallModal
+	fqn={compositeFQN}
+	kind={compositeKind}
+	onClose={closeCompositeInstall}
+/>

--- a/webapp/src/routes/hub/actions/[fqn]/+page.svelte
+++ b/webapp/src/routes/hub/actions/[fqn]/+page.svelte
@@ -5,7 +5,7 @@
 	import { getHubAction, type HubActionEntry } from '$lib/api';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import HubInstallModal from '$lib/components/HubInstallModal.svelte';
+	import HubCompositeInstallModal from '$lib/components/HubCompositeInstallModal.svelte';
 
 	// Detail page for a single Hub action entry (#709). The route param
 	// `[fqn]` carries the action FQN URL-encoded; SvelteKit decodes once
@@ -108,5 +108,9 @@
 		Install action
 	</Button>
 
-	<HubInstallModal fqn={installFqn} onClose={() => (installFqn = null)} />
+	<HubCompositeInstallModal
+		fqn={installFqn}
+		kind={installFqn ? 'action' : null}
+		onClose={() => (installFqn = null)}
+	/>
 {/if}

--- a/webapp/src/routes/hub/suites/[fqn]/+page.svelte
+++ b/webapp/src/routes/hub/suites/[fqn]/+page.svelte
@@ -5,7 +5,7 @@
 	import { getHubSuite, type HubSuiteEntry } from '$lib/api';
 	import * as Card from '$lib/components/ui/card';
 	import { Button } from '$lib/components/ui/button';
-	import HubInstallModal from '$lib/components/HubInstallModal.svelte';
+	import HubCompositeInstallModal from '$lib/components/HubCompositeInstallModal.svelte';
 
 	// Detail page for a single Hub suite entry (#709). Same routing
 	// pattern as the action detail page: `[fqn]` is URL-encoded in the
@@ -121,5 +121,9 @@
 		Install suite
 	</Button>
 
-	<HubInstallModal fqn={installFqn} onClose={() => (installFqn = null)} />
+	<HubCompositeInstallModal
+		fqn={installFqn}
+		kind={installFqn ? 'suite' : null}
+		onClose={() => (installFqn = null)}
+	/>
 {/if}


### PR DESCRIPTION
## Summary

Adds `HubCompositeInstallModal.svelte` — the action/suite counterpart to the existing connector-level `HubInstallModal`. Renders the composite install-decision payload grouped by authority: one trust panel per unique connector in the dependency closure, with the umbrella's load-bearing UX promise — one accept covers them all.

- Action modal: fetches `/v1/hub/action-install-decision?fqn=<fqn>`, renders action-level metadata (FQN, description, publisher, required connector) plus a single-authority trust panel.
- Suite modal: fetches `/v1/hub/suite-install-decision?fqn=<fqn>`, renders suite metadata, the member-action list, and N grouped trust panels (one per unique connector authority in the closure).
- Each authority panel shows FQN, publisher, fingerprint, colored trust-state badge (green `already_trusted` / yellow `unknown` / red `conflict` — matches the CLI's `colorizeTrustState`), risk indicators, and `publisher_footprint`.
- Wired into Suites + Actions tabs on `/hub` and into the action/suite detail pages. The Providers tab keeps the existing `HubInstallModal` unchanged.

**Why no in-modal install execution yet.** End-to-end webapp install for actions/suites needs the daemon to expose a trust-write endpoint (`POST /v1/keyring/trust`) so the webapp can mirror the CLI's `trust.ensure(authority, autoYes=true)` step. v0.x doesn't have that endpoint, so the composite modal renders the trust panel and surfaces the operator's CLI command (`aileron action add <fqn>@latest` / `aileron action add-suite <fqn>.toml@latest`) as the install path. The trust-panel render is the load-bearing umbrella UX delivery; in-modal install execution is a follow-up that needs daemon-side work.

Refs #709 (umbrella).

## Test plan

- [x] `svelte-check` clean.
- [x] `(cd webapp && pnpm exec vitest run)` green — 75 tests including 12 new in `HubCompositeInstallModal.test.ts`:
  - Action: fetches by FQN, renders metadata, surfaces fetch errors, renders publisher_footprint, renders CLI command for the install path.
  - Suite: renders one panel per unique authority (asserted on a two-authority cross-publisher fixture), member-action list, CLI command format with `.toml@latest` suffix to bridge Hub FQN → CLI source URL.
  - Dispatch: no fetch when `fqn` or `kind` is null.
- [x] Existing Providers tab integration test still passes — connector modal untouched.
- [ ] CI green (full matrix).