### PR TITLE
feat(sandbox): platform audit field + install-time SandboxAvailable probe

### DIFF
--- a/internal/sandbox/sandbox_available.go
+++ b/internal/sandbox/sandbox_available.go
@@ -1,0 +1,30 @@
+package sandbox
+
+// SandboxAvailable reports whether the spawn primitive's
+// platform sandbox is usable on this host. Returns nil when the
+// runtime can install the confinement layers ADR-0014 commits
+// to (FS scoping, network egress denial, process scoping);
+// returns a wrapped [ErrSpawnUnavailable] with an actionable
+// remediation hint otherwise.
+//
+// Intended for install-time use so a user installing a spawn-
+// using connector on a host without kernel-level confinement
+// gets a clear error before any binary is fetched or stored —
+// per ADR-0014's "Graceful unavailability" section and #719's
+// cross-platform checklist.
+//
+// Implementation lives in build-tagged sibling files: each
+// platform probes the OS-specific primitives the runtime would
+// need at spawn time:
+//
+//   - Linux: `unprivileged_userns_clone` sysctl.
+//   - macOS: presence of `/usr/bin/sandbox-exec`.
+//   - Windows: open + close a session handle on the Windows
+//     Filtering Platform engine (validates BFE is running and
+//     the daemon has the rights to install filters).
+//   - Other (BSD, illumos, etc.): the fallback returns
+//     [ErrSpawnUnavailable] unconditionally; ADR-0014 designates
+//     those platforms as deny-spawn.
+func SandboxAvailable() error {
+	return checkPlatformSandboxAvailable()
+}

--- a/internal/sandbox/sandbox_available_darwin.go
+++ b/internal/sandbox/sandbox_available_darwin.go
@@ -1,0 +1,19 @@
+//go:build darwin
+
+package sandbox
+
+import (
+	"fmt"
+	"os"
+)
+
+// checkPlatformSandboxAvailable probes the macOS sandbox primitive:
+// `/usr/bin/sandbox-exec` presence. The binary is part of the base
+// macOS install and has been since 10.5; absence indicates a
+// drastically non-standard system the runtime can't confine.
+func checkPlatformSandboxAvailable() error {
+	if _, err := os.Stat(sandboxExecPath); err != nil {
+		return fmt.Errorf("%w: sandbox-exec not present at %s", ErrSpawnUnavailable, sandboxExecPath)
+	}
+	return nil
+}

--- a/internal/sandbox/sandbox_available_linux.go
+++ b/internal/sandbox/sandbox_available_linux.go
@@ -1,0 +1,19 @@
+//go:build linux
+
+package sandbox
+
+// checkPlatformSandboxAvailable probes the Linux sandbox primitive:
+// `kernel.unprivileged_userns_clone` sysctl. See
+// [checkLinuxSandboxAvailable] for the full discussion of fallback
+// semantics on kernels that don't expose the knob.
+//
+// Landlock LSM is NOT probed here separately even though Linux v2
+// uses it: the helper applies Landlock at spawn time and emits a
+// structured error there if the kernel rejects the syscalls. A
+// host that has user namespaces but not Landlock can still run
+// connectors that omit fs_read / fs_write; the install-time probe
+// is intentionally permissive so the kernel-level enforcement
+// surface is the precise failure point.
+func checkPlatformSandboxAvailable() error {
+	return checkLinuxSandboxAvailable()
+}

--- a/internal/sandbox/sandbox_available_other.go
+++ b/internal/sandbox/sandbox_available_other.go
@@ -1,0 +1,11 @@
+//go:build !darwin && !linux && !windows
+
+package sandbox
+
+// checkPlatformSandboxAvailable on unsupported platforms (BSD,
+// illumos, etc.) returns [ErrSpawnUnavailable] unconditionally.
+// ADR-0014 designates these as deny-spawn at install time so the
+// user discovers the constraint before any binary is fetched.
+func checkPlatformSandboxAvailable() error {
+	return ErrSpawnUnavailable
+}

--- a/internal/sandbox/sandbox_available_test.go
+++ b/internal/sandbox/sandbox_available_test.go
@@ -1,0 +1,28 @@
+package sandbox
+
+import (
+	"errors"
+	"runtime"
+	"testing"
+)
+
+func TestSandboxAvailable_ReturnsNilOnSupportedPlatformsByDefault(t *testing.T) {
+	// Contract: on the three supported platforms (linux, darwin,
+	// windows) SandboxAvailable returns nil on a healthy host.
+	// CI runners are healthy by construction; if the test fails
+	// the runner has a sandbox-disabling configuration the user
+	// would also hit at install time, which is the right signal.
+	err := SandboxAvailable()
+	switch runtime.GOOS {
+	case "linux", "darwin", "windows":
+		if err != nil {
+			t.Errorf("%s: SandboxAvailable returned %v on a supported platform", runtime.GOOS, err)
+		}
+	default:
+		// On unsupported platforms the contract is
+		// ErrSpawnUnavailable. Asserts the fallback wires through.
+		if !errors.Is(err, ErrSpawnUnavailable) {
+			t.Errorf("%s: expected wrapped ErrSpawnUnavailable, got %v", runtime.GOOS, err)
+		}
+	}
+}

--- a/internal/sandbox/sandbox_available_windows.go
+++ b/internal/sandbox/sandbox_available_windows.go
@@ -1,0 +1,26 @@
+//go:build windows
+
+package sandbox
+
+import "fmt"
+
+// checkPlatformSandboxAvailable probes the Windows sandbox
+// primitives: opens a session to the Windows Filtering Platform
+// engine (validates that the Base Filtering Engine service is
+// running and the daemon has access rights). Close on success.
+//
+// The restricted-token + job-object pieces from Windows v1
+// don't have a meaningful pre-spawn probe — they always
+// succeed on a healthy Windows install — so the WFP open is
+// the load-bearing check. A host where WFP is unreachable
+// would also reject the runtime's filter add at spawn time,
+// but failing at install time gives the operator a clearer
+// remediation step.
+func checkPlatformSandboxAvailable() error {
+	engine, err := openWFPEngine()
+	if err != nil {
+		return fmt.Errorf("%w: WFP engine probe: %v", ErrSpawnUnavailable, err)
+	}
+	_ = closeWFPEngine(engine)
+	return nil
+}

--- a/internal/sandbox/spawn.go
+++ b/internal/sandbox/spawn.go
@@ -10,6 +10,7 @@ import (
 	"log/slog"
 	"os"
 	"os/exec"
+	"runtime"
 	"strings"
 	"sync"
 
@@ -1260,7 +1261,9 @@ func newSpawnSandboxUnavailable(program, reason string) *Error {
 // emitSpawnAudit logs a structured audit event for one spawn
 // invocation. Captures connector identity, program, argv pattern (not
 // interpolated arguments, which may be sensitive), exit code, decision,
-// and content hashes of stdout and stderr.
+// content hashes of stdout and stderr, and the platform identifier so
+// multi-platform deployments can distinguish per-OS behavior in
+// post-hoc analysis.
 //
 // Uses audit.AttrPolicyDecision per the reservation in #480.
 func emitSpawnAudit(ctx context.Context, s *hostState, env SpawnEnvelope, decision string, exit int, stdout, stderr []byte, denyClass string) {
@@ -1271,6 +1274,7 @@ func emitSpawnAudit(ctx context.Context, s *hostState, env SpawnEnvelope, decisi
 		slog.String("connector", s.connectorFQN),
 		slog.String("program", env.Program),
 		slog.String("argv_shape", argvShape(env.Argv)),
+		slog.String("platform", runtime.GOOS),
 		slog.String(audit.AttrPolicyDecision, decision),
 		slog.Int("exit_code", exit),
 	}

--- a/internal/sandbox/spawn_test.go
+++ b/internal/sandbox/spawn_test.go
@@ -616,6 +616,32 @@ func TestEmitSpawnAudit_AllowDecisionEmitsExpectedAttributes(t *testing.T) {
 	}
 }
 
+func TestEmitSpawnAudit_PlatformFieldCarriesGOOS(t *testing.T) {
+	// Contract (#719 cross-platform finishing): every spawn
+	// audit row carries the runtime.GOOS value so post-hoc
+	// analysis of a multi-platform deployment can distinguish
+	// per-OS behavior without relying on derived signals like
+	// argv0's path style.
+	h := &recordingHandler{}
+	state := &hostState{
+		connectorFQN: "github://aileron-test/gitcrawl",
+		logger:       slog.New(h),
+	}
+	emitSpawnAudit(context.Background(), state,
+		SpawnEnvelope{Program: "/usr/bin/git", Argv: []string{"git", "status"}},
+		"allow", 0, nil, nil, "")
+	if len(h.records) != 1 {
+		t.Fatalf("expected one record, got %d", len(h.records))
+	}
+	got, ok := h.records[0]["platform"].(string)
+	if !ok || got == "" {
+		t.Errorf("platform field missing or empty: %v", h.records[0]["platform"])
+	}
+	if got != runtime.GOOS {
+		t.Errorf("platform = %q, want %q", got, runtime.GOOS)
+	}
+}
+
 func TestEmitSpawnAudit_DenyClassPropagated(t *testing.T) {
 	h := &recordingHandler{}
 	state := &hostState{


### PR DESCRIPTION
## Summary

Cross-platform finishing items from [#719](https://github.com/ALRubinger/aileron/issues/719). Two small surfaces, both shippable independently.

### 1. `platform` field on spawn audit rows

Every `emitSpawnAudit` emission now carries `slog.String("platform", runtime.GOOS)`. Post-hoc analysis of multi-platform deployments can distinguish per-OS behavior without relying on derived signals (path style on argv, exit-code conventions, etc.).

### 2. `sandbox.SandboxAvailable() error`

Exported function that probes the platform-specific sandbox primitives before the runtime needs them. Build-tagged per-OS:

- **Linux** — reuses the existing `checkLinuxSandboxAvailable` (`unprivileged_userns_clone` sysctl).
- **macOS** — `/usr/bin/sandbox-exec` presence check.
- **Windows** — opens + closes a WFP engine handle. Validates that the Base Filtering Engine service is running and the daemon has filter-install rights. Failure here means a spawn-connector install would fail at first spawn; surfacing at install time is the contract.
- **Fallback** (BSD, illumos, etc.) — returns `ErrSpawnUnavailable` per ADR-0014's deny-spawn designation.

Intended call site is the connector-install path: `aileron action add` today, plus the `aileron cli add` flow [#580](https://github.com/ALRubinger/aileron/issues/580) introduces. Wire-up into either is a separate, minimal change; this PR delivers the function so those callers have something to call.

## Test plan

- [x] `TestSandboxAvailable_ReturnsNilOnSupportedPlatformsByDefault` — runs on all three runners and the fallback path
- [x] `TestEmitSpawnAudit_PlatformFieldCarriesGOOS` — `platform` field present and matches `runtime.GOOS`
- [x] Existing audit tests still pass (platform field is additive)
- [x] Cross-compile clean on darwin / linux / windows / fallback build tags

## What remains on #719

After this lands, the only outstanding #719 item is the **malicious-CLI integration fixture** — a fake binary that tries to read `~/.ssh/id_rsa`, dial `evil.example.com`, write to `/etc/passwd` etc., run on every CI runner, with assertions that each attempt fails at the kernel boundary. Each platform's PR already has equivalent end-to-end assertions for the load-bearing properties; the unified fixture is a cleaner story but not a security-critical gap.

Refs [#619](https://github.com/ALRubinger/aileron/issues/619) [#719](https://github.com/ALRubinger/aileron/issues/719).