### PR TITLE
feat(webapp): in-browser reauthorize for stale bindings in install modal

### DIFF
--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -568,3 +568,41 @@ export async function installAction(args: {
 		body: JSON.stringify(args)
 	});
 }
+
+/** Response from POST /v1/bindings/setup/oauth2/init. The caller
+ *  directs the browser to `authorize_url`; the daemon's callback
+ *  endpoint (#745) handles the rest when caller=daemon. */
+export type OAuth2InitResponse = {
+	session_id: string;
+	authorize_url: string;
+	redirect_uri: string;
+};
+
+/** Starts a reauthorize flow for an existing binding from the
+ *  webapp. Caller=daemon means the daemon's own listener at
+ *  /v1/bindings/setup/oauth2/callback receives the OAuth provider's
+ *  redirect (the webapp can't `bind()` a TCP port); after the daemon
+ *  completes the token exchange it 303s the browser to `return_to`
+ *  with a `#aileron_oauth=ok&binding=<name>` fragment.
+ *
+ *  The caller passes the binding's identifying tuple (connector FQN,
+ *  service, identity) — mirrors what `aileron binding reauthorize`
+ *  derives from a bare binding name on the CLI side. */
+export async function startReauthorize(args: {
+	connector_fqn: string;
+	identity: string;
+	service?: string;
+	return_to: string;
+}): Promise<OAuth2InitResponse> {
+	return apiFetch('/v1/bindings/setup/oauth2/init', {
+		method: 'POST',
+		body: JSON.stringify({
+			connector_fqn: args.connector_fqn,
+			identity: args.identity,
+			service: args.service,
+			purpose: 'reauthorize',
+			caller: 'daemon',
+			return_to: args.return_to
+		})
+	});
+}

--- a/webapp/src/lib/components/HubCompositeInstallModal.svelte
+++ b/webapp/src/lib/components/HubCompositeInstallModal.svelte
@@ -2,10 +2,12 @@
 	import * as Dialog from '$lib/components/ui/dialog';
 	import { Badge } from '$lib/components/ui/badge';
 	import { Button } from '$lib/components/ui/button';
+	import { onMount, onDestroy } from 'svelte';
 	import {
 		getHubActionInstallDecision,
 		getHubSuiteInstallDecision,
 		installAction,
+		startReauthorize,
 		type ConfirmedFingerprint,
 		type HubActionInstallDecision,
 		type HubSuiteInstallDecision,
@@ -58,6 +60,21 @@
 	let installResults = $state<InstalledActionResult[]>([]);
 	let installProgress = $state(''); // e.g. "Installing 2 of 5: <fqn>"
 
+	// Per-binding reauthorize state (#743 PR 3). The success panel
+	// renders a "Reauthorize" button per stale binding; clicking it
+	// opens the daemon-hosted OAuth flow (PR #745) in a popup. The
+	// popup ends on /oauth-callback-relay which postMessages this
+	// component with the result. Map is keyed by binding name; absent
+	// means idle.
+	type ReauthorizePhase = 'opening' | 'awaiting' | 'done' | 'failed';
+	type ReauthorizeRow = { phase: ReauthorizePhase; error?: string };
+	let reauthState = $state<Record<string, ReauthorizeRow>>({});
+	// Track open popups so we can refocus an existing one instead of
+	// opening a duplicate if the user clicks twice. Keyed by binding
+	// name; entries are cleared when the popup posts back or is
+	// otherwise observed closed.
+	let popups = new Map<string, Window>();
+
 	// Reset install state when the operator opens the modal for a
 	// different fqn — avoids surfacing the previous install's panel
 	// against a freshly-fetched decision.
@@ -69,6 +86,8 @@
 			installError = '';
 			installResults = [];
 			installProgress = '';
+			reauthState = {};
+			popups.clear();
 			return;
 		}
 		loading = true;
@@ -78,6 +97,8 @@
 		installError = '';
 		installResults = [];
 		installProgress = '';
+		reauthState = {};
+		popups.clear();
 		const target = fqn;
 		const targetKind = kind;
 		const fetcher =
@@ -200,6 +221,106 @@
 		}
 		return out;
 	});
+
+	// parseBindingName splits a canonical binding name (kind/service/
+	// identity) into its parts. Daemon-side binding.MakeName always
+	// emits this shape; reauthorize init needs the (service, identity)
+	// pair to find the existing binding.
+	function parseBindingName(name: string): { kind: string; service: string; identity: string } | null {
+		const parts = name.split('/');
+		if (parts.length !== 3 || parts.some((p) => p === '')) return null;
+		return { kind: parts[0], service: parts[1], identity: parts[2] };
+	}
+
+	// handleReauthorizeMessage receives the result postMessage from
+	// the OAuth callback relay popup. Validates origin + shape, then
+	// flips the matching row to done/failed.
+	function handleReauthorizeMessage(event: MessageEvent) {
+		// Same-origin only — defense in depth against a foreign tab
+		// shouting at this window. The relay always lives on the
+		// webapp's origin (loopback for v1).
+		if (event.origin !== window.location.origin) return;
+		const data = event.data;
+		if (!data || typeof data !== 'object') return;
+		if (data.type !== 'aileron-oauth-callback') return;
+		const binding = typeof data.binding === 'string' ? data.binding : '';
+		const status = typeof data.status === 'string' ? data.status : '';
+		if (!binding) return;
+		popups.delete(binding);
+		reauthState = {
+			...reauthState,
+			[binding]:
+				status === 'ok'
+					? { phase: 'done' }
+					: { phase: 'failed', error: 'Reauthorize was not completed.' }
+		};
+	}
+
+	onMount(() => {
+		window.addEventListener('message', handleReauthorizeMessage);
+	});
+
+	onDestroy(() => {
+		if (typeof window !== 'undefined') {
+			window.removeEventListener('message', handleReauthorizeMessage);
+		}
+	});
+
+	// runReauthorize handles a per-binding "Reauthorize" click. Drives
+	// the daemon-hosted OAuth flow (caller=daemon, from PR #745) in a
+	// popup so the modal's install context survives the OAuth dance —
+	// same-tab navigation would lose it. The popup ends on the
+	// /oauth-callback-relay route which postMessages this component.
+	async function runReauthorize(s: StaleBinding) {
+		const parts = parseBindingName(s.name);
+		if (!parts) {
+			reauthState = {
+				...reauthState,
+				[s.name]: { phase: 'failed', error: 'Malformed binding name.' }
+			};
+			return;
+		}
+		// Refocus an existing popup rather than spawning a duplicate.
+		const existing = popups.get(s.name);
+		if (existing && !existing.closed) {
+			existing.focus();
+			return;
+		}
+		reauthState = { ...reauthState, [s.name]: { phase: 'opening' } };
+		try {
+			const init = await startReauthorize({
+				connector_fqn: s.connector_fqn,
+				identity: parts.identity,
+				service: parts.service,
+				return_to: window.location.origin + '/oauth-callback-relay'
+			});
+			const popup = window.open(
+				init.authorize_url,
+				`aileron-oauth-${s.name}`,
+				'width=600,height=720,menubar=no,toolbar=no,location=yes'
+			);
+			if (!popup) {
+				reauthState = {
+					...reauthState,
+					[s.name]: {
+						phase: 'failed',
+						error: 'Popup blocked. Allow popups for this site and try again.'
+					}
+				};
+				return;
+			}
+			popups.set(s.name, popup);
+			reauthState = { ...reauthState, [s.name]: { phase: 'awaiting' } };
+		} catch (e: unknown) {
+			reauthState = {
+				...reauthState,
+				[s.name]: {
+					phase: 'failed',
+					error: e instanceof Error ? e.message : String(e)
+				}
+			};
+		}
+	}
 
 	// runInstall dispatches the install based on `kind`. Action: one
 	// /v1/actions/install call. Suite: loop through member_actions in
@@ -426,21 +547,67 @@
 									scope tracking). Reauthorize each binding before invoking
 									the action.
 								</p>
-								<ul class="mt-1 space-y-1">
+								<ul class="mt-2 space-y-2">
 									{#each aggregatedStale as s (s.name)}
-										<li>
-											<span class="font-mono break-all">{s.name}</span>
-											{#if s.service}<span class="text-muted-foreground"> ({s.service})</span>{/if}
+										{@const row = reauthState[s.name]}
+										<li
+											class="rounded border border-yellow-500/30 bg-background p-2"
+											data-testid="hub-composite-stale-row"
+											data-binding={s.name}
+										>
+											<div class="flex flex-wrap items-center justify-between gap-2">
+												<div class="min-w-0">
+													<span class="font-mono break-all">{s.name}</span>
+													{#if s.service}<span class="text-muted-foreground"> ({s.service})</span>{/if}
+												</div>
+												<div class="flex items-center gap-2">
+													{#if row?.phase === 'done'}
+														<Badge variant="default" data-testid="hub-composite-stale-status">
+															Reauthorized
+														</Badge>
+													{:else}
+														<Button
+															variant="outline"
+															size="sm"
+															disabled={row?.phase === 'opening' || row?.phase === 'awaiting'}
+															onclick={() => runReauthorize(s)}
+															data-testid="hub-composite-reauthorize-button"
+															data-binding={s.name}
+														>
+															{#if row?.phase === 'opening'}
+																Opening…
+															{:else if row?.phase === 'awaiting'}
+																Waiting for browser…
+															{:else if row?.phase === 'failed'}
+																Retry reauthorize
+															{:else}
+																Reauthorize
+															{/if}
+														</Button>
+													{/if}
+												</div>
+											</div>
 											{#if s.stale_reason === 'scope_drift' && s.missing_scopes && s.missing_scopes.length > 0}
-												<div class="ml-4 text-muted-foreground">
+												<div class="mt-1 ml-1 text-muted-foreground">
 													Missing: {s.missing_scopes.join(', ')}
 												</div>
 											{:else if s.stale_reason === 'no_grant_record'}
-												<div class="ml-4 text-muted-foreground">
+												<div class="mt-1 ml-1 text-muted-foreground">
 													Predates scope tracking; one-time reauthorize needed.
 												</div>
 											{/if}
-											<code class="ml-4 font-mono">aileron binding reauthorize {s.name}</code>
+											{#if row?.phase === 'failed' && row.error}
+												<div
+													class="mt-1 text-destructive"
+													data-testid="hub-composite-reauthorize-error"
+												>
+													{row.error}
+												</div>
+											{/if}
+											<details class="mt-1 ml-1 text-muted-foreground">
+												<summary class="cursor-pointer">Or copy the CLI command</summary>
+												<code class="mt-1 block font-mono">aileron binding reauthorize {s.name}</code>
+											</details>
 										</li>
 									{/each}
 								</ul>

--- a/webapp/src/lib/components/HubCompositeInstallModal.test.ts
+++ b/webapp/src/lib/components/HubCompositeInstallModal.test.ts
@@ -5,7 +5,8 @@ import userEvent from '@testing-library/user-event';
 vi.mock('$lib/api', () => ({
 	getHubActionInstallDecision: vi.fn(),
 	getHubSuiteInstallDecision: vi.fn(),
-	installAction: vi.fn()
+	installAction: vi.fn(),
+	startReauthorize: vi.fn()
 }));
 
 import Modal from './HubCompositeInstallModal.svelte';
@@ -13,6 +14,7 @@ import {
 	getHubActionInstallDecision,
 	getHubSuiteInstallDecision,
 	installAction,
+	startReauthorize,
 	type HubActionInstallDecision,
 	type HubSuiteInstallDecision,
 	type InstalledActionResult
@@ -71,6 +73,7 @@ beforeEach(() => {
 	vi.mocked(getHubActionInstallDecision).mockReset();
 	vi.mocked(getHubSuiteInstallDecision).mockReset();
 	vi.mocked(installAction).mockReset();
+	vi.mocked(startReauthorize).mockReset();
 });
 
 describe('HubCompositeInstallModal — action', () => {
@@ -423,5 +426,193 @@ describe('HubCompositeInstallModal — install (suite)', () => {
 		});
 		const btn = await screen.findByTestId('hub-composite-install-button');
 		expect(btn).toHaveTextContent(`Install suite (${suiteDecision.member_actions.length})`);
+	});
+});
+
+// --- #743 PR 3: in-browser reauthorize for stale bindings ---
+
+// reauthorizeFlow installs the action then surfaces a stale binding
+// the user can click Reauthorize on. Shared setup across the
+// reauthorize tests so each test only encodes its own assertion.
+async function reauthorizeFlow(staleName = 'oauth2/google/work') {
+	vi.mocked(getHubActionInstallDecision).mockResolvedValue(actionDecision);
+	vi.mocked(installAction).mockResolvedValue(
+		actionResult('draft-email', {
+			newly_stale_bindings: [
+				{
+					name: staleName,
+					connector_fqn: 'github://alice/conn-google',
+					stale_reason: 'scope_drift',
+					missing_scopes: ['drive'],
+					service: 'google'
+				}
+			]
+		})
+	);
+	const user = userEvent.setup();
+	render(Modal, {
+		props: { fqn: actionDecision.fqn, kind: 'action', onClose: () => {} }
+	});
+	await user.click(await screen.findByTestId('hub-composite-install-button'));
+	await waitFor(() => {
+		expect(screen.getByTestId('hub-composite-stale')).toBeInTheDocument();
+	});
+	return user;
+}
+
+describe('HubCompositeInstallModal — reauthorize (PR 3)', () => {
+	it('clicking Reauthorize calls startReauthorize with the binding tuple + caller=daemon implied', async () => {
+		const fakePopup = { focus: vi.fn(), closed: false } as unknown as Window;
+		vi.spyOn(window, 'open').mockReturnValue(fakePopup);
+		vi.mocked(startReauthorize).mockResolvedValue({
+			session_id: 's',
+			authorize_url: 'https://provider.test/authorize?state=abc',
+			redirect_uri: 'http://127.0.0.1:9999/v1/bindings/setup/oauth2/callback'
+		});
+		const user = await reauthorizeFlow();
+
+		await user.click(screen.getByTestId('hub-composite-reauthorize-button'));
+
+		await waitFor(() => expect(startReauthorize).toHaveBeenCalledTimes(1));
+		expect(startReauthorize).toHaveBeenCalledWith({
+			connector_fqn: 'github://alice/conn-google',
+			identity: 'work',
+			service: 'google',
+			return_to: window.location.origin + '/oauth-callback-relay'
+		});
+		// Popup opened with the daemon-supplied authorize URL.
+		expect(window.open).toHaveBeenCalledWith(
+			'https://provider.test/authorize?state=abc',
+			expect.stringContaining('aileron-oauth-'),
+			expect.any(String)
+		);
+	});
+
+	it('renders the awaiting state after the popup opens', async () => {
+		const fakePopup = { focus: vi.fn(), closed: false } as unknown as Window;
+		vi.spyOn(window, 'open').mockReturnValue(fakePopup);
+		vi.mocked(startReauthorize).mockResolvedValue({
+			session_id: 's',
+			authorize_url: 'https://provider.test/authorize',
+			redirect_uri: 'x'
+		});
+		const user = await reauthorizeFlow();
+		await user.click(screen.getByTestId('hub-composite-reauthorize-button'));
+
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-composite-reauthorize-button')).toHaveTextContent(
+				'Waiting for browser…'
+			);
+		});
+	});
+
+	it('flips the row to Reauthorized when the relay posts ok', async () => {
+		const fakePopup = { focus: vi.fn(), closed: false } as unknown as Window;
+		vi.spyOn(window, 'open').mockReturnValue(fakePopup);
+		vi.mocked(startReauthorize).mockResolvedValue({
+			session_id: 's',
+			authorize_url: 'https://provider.test/authorize',
+			redirect_uri: 'x'
+		});
+		const user = await reauthorizeFlow();
+		await user.click(screen.getByTestId('hub-composite-reauthorize-button'));
+		await waitFor(() => expect(startReauthorize).toHaveBeenCalled());
+
+		// Simulate the relay popup posting back the success message.
+		window.dispatchEvent(
+			new MessageEvent('message', {
+				data: {
+					type: 'aileron-oauth-callback',
+					status: 'ok',
+					binding: 'oauth2/google/work'
+				},
+				origin: window.location.origin
+			})
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-composite-stale-status')).toHaveTextContent('Reauthorized');
+		});
+	});
+
+	it('surfaces a popup-blocked failure when window.open returns null', async () => {
+		vi.spyOn(window, 'open').mockReturnValue(null);
+		vi.mocked(startReauthorize).mockResolvedValue({
+			session_id: 's',
+			authorize_url: 'https://provider.test/authorize',
+			redirect_uri: 'x'
+		});
+		const user = await reauthorizeFlow();
+		await user.click(screen.getByTestId('hub-composite-reauthorize-button'));
+
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-composite-reauthorize-error')).toHaveTextContent(
+				'Popup blocked'
+			);
+		});
+		expect(screen.getByTestId('hub-composite-reauthorize-button')).toHaveTextContent(
+			'Retry reauthorize'
+		);
+	});
+
+	it('ignores postMessage from a foreign origin', async () => {
+		const fakePopup = { focus: vi.fn(), closed: false } as unknown as Window;
+		vi.spyOn(window, 'open').mockReturnValue(fakePopup);
+		vi.mocked(startReauthorize).mockResolvedValue({
+			session_id: 's',
+			authorize_url: 'https://provider.test/authorize',
+			redirect_uri: 'x'
+		});
+		const user = await reauthorizeFlow();
+		await user.click(screen.getByTestId('hub-composite-reauthorize-button'));
+		await waitFor(() => expect(startReauthorize).toHaveBeenCalled());
+
+		// Hostile message from another origin — modal must ignore it.
+		window.dispatchEvent(
+			new MessageEvent('message', {
+				data: {
+					type: 'aileron-oauth-callback',
+					status: 'ok',
+					binding: 'oauth2/google/work'
+				},
+				origin: 'https://attacker.example'
+			})
+		);
+
+		// Give the event loop a tick so a buggy handler would have run.
+		await new Promise((resolve) => setTimeout(resolve, 10));
+		expect(screen.queryByTestId('hub-composite-stale-status')).not.toBeInTheDocument();
+	});
+
+	it('reports a status=error postMessage as a retryable failure', async () => {
+		const fakePopup = { focus: vi.fn(), closed: false } as unknown as Window;
+		vi.spyOn(window, 'open').mockReturnValue(fakePopup);
+		vi.mocked(startReauthorize).mockResolvedValue({
+			session_id: 's',
+			authorize_url: 'https://provider.test/authorize',
+			redirect_uri: 'x'
+		});
+		const user = await reauthorizeFlow();
+		await user.click(screen.getByTestId('hub-composite-reauthorize-button'));
+		await waitFor(() => expect(startReauthorize).toHaveBeenCalled());
+
+		window.dispatchEvent(
+			new MessageEvent('message', {
+				data: {
+					type: 'aileron-oauth-callback',
+					status: 'error',
+					binding: 'oauth2/google/work'
+				},
+				origin: window.location.origin
+			})
+		);
+
+		await waitFor(() => {
+			expect(screen.getByTestId('hub-composite-reauthorize-error')).toHaveTextContent(
+				'Reauthorize was not completed'
+			);
+		});
+		// And the row's NOT marked done.
+		expect(screen.queryByTestId('hub-composite-stale-status')).not.toBeInTheDocument();
 	});
 });

--- a/webapp/src/routes/oauth-callback-relay/+page.svelte
+++ b/webapp/src/routes/oauth-callback-relay/+page.svelte
@@ -1,0 +1,98 @@
+<script lang="ts">
+	import { onMount } from 'svelte';
+
+	// OAuth callback relay (#743 PR 3). The daemon-hosted callback
+	// (PR #745, internal/app/handlers_bindings_oauth2.go) writes the
+	// binding then 303s the user's browser to a loopback-only
+	// return_to URL with a fragment of the form
+	//   #aileron_oauth=ok&binding=<urlencoded binding name>
+	// or
+	//   #aileron_oauth=error
+	//
+	// The webapp's stale-binding panel runs the reauthorize flow in a
+	// popup (so the install modal's state survives the OAuth dance).
+	// The popup ends up here on completion. This page parses the
+	// fragment, posts the result to the opener via postMessage, and
+	// closes itself. The opener listens for the message and updates
+	// the corresponding stale-binding row.
+	//
+	// All work happens client-side — the daemon's callback already
+	// committed the binding before the redirect landed.
+
+	let parsed = $state<{ status: string; binding: string } | null>(null);
+	let postedToOpener = $state(false);
+	let closingSelf = $state(false);
+	let manualClose = $state(false);
+
+	function parseFragment(hash: string): { status: string; binding: string } {
+		// Strip the leading "#"; the daemon-side appender builds the
+		// fragment shape so this parser only needs to handle k=v&k=v.
+		const trimmed = hash.replace(/^#/, '');
+		const params = new URLSearchParams(trimmed);
+		return {
+			status: params.get('aileron_oauth') ?? '',
+			binding: params.get('binding') ?? ''
+		};
+	}
+
+	onMount(() => {
+		parsed = parseFragment(window.location.hash);
+		const opener = window.opener;
+		if (!opener) {
+			// User landed here without an opener — surface the result
+			// in-page instead of leaving them on a blank screen. Same
+			// content the popup path would have posted; the opener-
+			// recovery story is "click the modal again", same as a
+			// CLI session restart.
+			manualClose = true;
+			return;
+		}
+		try {
+			// Targeting the same-origin opener; the daemon validated
+			// return_to as loopback-only at init time, and the relay
+			// only ever lands on the webapp's own origin.
+			opener.postMessage(
+				{
+					type: 'aileron-oauth-callback',
+					status: parsed.status,
+					binding: parsed.binding
+				},
+				window.location.origin
+			);
+			postedToOpener = true;
+		} catch {
+			// postMessage failed (cross-origin, opener crashed, etc.)
+			// — keep the page rendered so the user has something to
+			// read rather than a blank flash before close.
+			manualClose = true;
+			return;
+		}
+		closingSelf = true;
+		// Give the postMessage event loop a tick to flush before the
+		// window closes. 50ms is invisible to the user and reliably
+		// avoids dropping the message in slow tabs.
+		setTimeout(() => window.close(), 50);
+	});
+</script>
+
+<svelte:head>
+	<title>Aileron OAuth callback</title>
+</svelte:head>
+
+<main class="mx-auto max-w-md p-6 text-sm font-sans">
+	{#if !parsed}
+		<p>Completing OAuth callback…</p>
+	{:else if closingSelf}
+		<p>OAuth callback received. Closing this window…</p>
+	{:else if manualClose}
+		{#if parsed.status === 'ok'}
+			<h1 class="mb-2 text-base font-medium">Reauthorized {parsed.binding || 'binding'}.</h1>
+			<p>You can close this tab and return to Aileron.</p>
+		{:else}
+			<h1 class="mb-2 text-base font-medium">Reauthorize was not completed.</h1>
+			<p>Close this tab and try again from the Aileron install modal.</p>
+		{/if}
+	{:else}
+		<p>OAuth callback received.</p>
+	{/if}
+</main>

--- a/webapp/src/routes/oauth-callback-relay/page.test.ts
+++ b/webapp/src/routes/oauth-callback-relay/page.test.ts
@@ -1,0 +1,65 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { render } from '@testing-library/svelte';
+
+import Relay from './+page.svelte';
+
+// The relay page (#743 PR 3) is the popup landing page after the
+// daemon-hosted OAuth callback writes the binding. It reads the
+// fragment, postMessages the opener, and closes itself. These tests
+// stub window.opener / window.close and observe the postMessage
+// call shape.
+
+beforeEach(() => {
+	// Default to an empty hash; individual tests override.
+	window.location.hash = '';
+});
+
+afterEach(() => {
+	window.location.hash = '';
+});
+
+describe('oauth-callback-relay', () => {
+	it('postMessages the opener with parsed fragment + closes', async () => {
+		window.location.hash = '#aileron_oauth=ok&binding=oauth2%2Fgoogle%2Fwork';
+		const postMessage = vi.fn();
+		const opener = { postMessage } as unknown as Window;
+		Object.defineProperty(window, 'opener', { value: opener, configurable: true });
+		const close = vi.spyOn(window, 'close').mockImplementation(() => {});
+
+		render(Relay);
+		// onMount + the deferred close timer (50ms) need to flush.
+		await new Promise((resolve) => setTimeout(resolve, 100));
+
+		expect(postMessage).toHaveBeenCalledWith(
+			{
+				type: 'aileron-oauth-callback',
+				status: 'ok',
+				binding: 'oauth2/google/work'
+			},
+			window.location.origin
+		);
+		expect(close).toHaveBeenCalled();
+	});
+
+	it('still works when opener is null — renders a manual-close hint', async () => {
+		window.location.hash = '#aileron_oauth=ok&binding=oauth2%2Fgoogle%2Fwork';
+		Object.defineProperty(window, 'opener', { value: null, configurable: true });
+		const close = vi.spyOn(window, 'close').mockImplementation(() => {});
+
+		const { getByText } = render(Relay);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(getByText(/Reauthorized/)).toBeInTheDocument();
+		expect(close).not.toHaveBeenCalled();
+	});
+
+	it('surfaces error status when opener is absent', async () => {
+		window.location.hash = '#aileron_oauth=error';
+		Object.defineProperty(window, 'opener', { value: null, configurable: true });
+
+		const { getByText } = render(Relay);
+		await new Promise((resolve) => setTimeout(resolve, 50));
+
+		expect(getByText(/Reauthorize was not completed/)).toBeInTheDocument();
+	});
+});


### PR DESCRIPTION
## Summary

Third and final PR under #743. Closes the loop on webapp parity with the CLI: after this lands, the webapp can both **install** and **reauthorize stale bindings** without leaving the browser.

- **`HubCompositeInstallModal` success panel:** each `newly_stale_bindings` row now exposes a **Reauthorize** button. Clicking it drives the daemon-hosted OAuth flow (`caller=daemon` from PR #745) in a popup, so the install modal's state survives the consent dance.
- **`/oauth-callback-relay`** route is the popup's landing page after the daemon-side callback writes the binding. It parses the `#aileron_oauth=ok&binding=<name>` fragment the daemon appends, postMessages the opener, and closes itself.
- **`startReauthorize()`** in `$lib/api` wraps `POST /v1/bindings/setup/oauth2/init` with the right knobs (`purpose=reauthorize`, `caller=daemon`, `return_to`).

## Flow

```
Reauthorize click
  → POST /v1/bindings/setup/oauth2/init  (purpose=reauthorize, caller=daemon)
  → window.open(authorize_url, popup)
  → OAuth provider consent
  → daemon callback writes the binding
  → 303 to /oauth-callback-relay#aileron_oauth=ok&binding=<name>
  → relay postMessages opener, closes
  → modal flips the row to "Reauthorized"
```

Same-tab navigation was considered and rejected — it loses the modal's install context, forcing a rebuild from URL fragments + sessionStorage. The popup is the only shape that keeps the success panel coherent through the OAuth dance.

## Security

- **Origin checks both sides.** The relay only postMessages `window.location.origin`; the modal ignores messages from any other origin (test pinned).
- **No new server endpoint.** All server work landed in PR #745. The flow re-uses `oauth2/init` and the daemon-hosted callback verbatim.
- **State validated by daemon.** The CSRF `state` value is generated by the daemon at init, embedded in the authorize URL, and consumed by the callback (PR #745 covered this); the webapp never sees it.

## Test plan

- [x] **Modal tests (6 new, 24 total):** click dispatches `startReauthorize` with the parsed binding tuple (`kind/service/identity` → service+identity, plus the connector_fqn from the stale row); popup `window.open` observed; awaiting state renders; postMessage from same-origin flips row to Reauthorized; foreign-origin postMessage is ignored; popup-blocked path surfaces "Popup blocked" + Retry button; `status=error` postMessage shows the error message and keeps the button (no Reauthorized badge).
- [x] **Relay tests (3 new):** success postMessage shape, manual-close fallback when `window.opener` is null, error-status rendering for orphaned tabs.
- [x] All 93 webapp tests pass (was 84 pre-PR; +9 from this change).
- [x] `task lint:webapp` clean, `task build:webapp` clean.
- [x] Verified: empty/null `newly_stale_bindings` still hides the panel (no regression to PR 2 success path).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
