### PR TITLE
ci: shard Linux Go unit tests into sandbox + rest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -63,8 +63,18 @@ jobs:
         run: pnpm check
 
   test:
-    name: Unit Tests
+    # Sharded Linux Go unit tests. The single-shot equivalent is
+    # `task test:go:ci`; CI splits it into two matrix shards because
+    # internal/sandbox/... accounts for ~44% of total Go test wall
+    # time. Two parallel shards cut Unit Tests wall from ~5m → ~2m30s.
+    # Both shards upload coverage under the `unit` flag; Codecov
+    # merges by file.
+    name: Unit Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        shard: [sandbox, rest]
     steps:
       - uses: actions/checkout@v6
 
@@ -90,7 +100,7 @@ jobs:
         run: go install gotest.tools/gotestsum@latest
 
       - name: Run Go tests
-        run: task test:go:ci
+        run: task test:go:ci:${{ matrix.shard }}
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -300,7 +300,7 @@ tasks:
       - go tool cover -func=coverage.txt | tail -1
 
   test:go:ci:
-    desc: Run Go tests with race, coverage, and JUnit output (used by CI)
+    desc: Run Go tests with race, coverage, and JUnit output (single-shot; local equivalent of the CI shards combined)
     deps:
       - build:forwarder
     cmds:
@@ -312,6 +312,37 @@ tasks:
       # mismatch. Belt-and-suspenders alongside codecov.yml's ignore
       # directive so local `go tool cover` summaries agree with
       # Codecov reports.
+      - grep -v -E '/(api/gen|sessions/sessionstest)/' coverage-raw.txt > coverage.txt
+      - rm coverage-raw.txt
+
+  test:go:ci:sandbox:
+    # Sandbox shard of the CI Go test suite. Paired with
+    # test:go:ci:rest; together they cover the same package set as
+    # test:go:ci. Split because internal/sandbox/... accounts for ~44%
+    # of total Go test wall time, so isolating it gives a roughly
+    # balanced 2-shard matrix.
+    desc: Run CI Go tests for the internal/sandbox/... shard
+    deps:
+      - build:forwarder
+    cmds:
+      - gotestsum --junitfile junit.xml -- -race -coverprofile=coverage-raw.txt ./internal/sandbox/...
+      - grep -v -E '/(api/gen|sessions/sessionstest)/' coverage-raw.txt > coverage.txt
+      - rm coverage-raw.txt
+
+  test:go:ci:rest:
+    # Non-sandbox shard. Computes the package list at runtime as
+    # "everything in GO_TEST_PACKAGES minus internal/sandbox/...";
+    # using `go list | grep` keeps the source-of-truth in
+    # GO_TEST_PACKAGES so newly added packages flow into the right
+    # shard automatically.
+    desc: Run CI Go tests for everything except internal/sandbox/...
+    deps:
+      - build:forwarder
+    cmds:
+      - |
+        set -euo pipefail
+        pkgs=$(go list {{.GO_TEST_PACKAGES}} | grep -vE '/sandbox(/|$)' | tr '\n' ' ')
+        gotestsum --junitfile junit.xml -- -race -coverprofile=coverage-raw.txt $pkgs
       - grep -v -E '/(api/gen|sessions/sessionstest)/' coverage-raw.txt > coverage.txt
       - rm coverage-raw.txt
 


### PR DESCRIPTION
## Summary

Profiling `task test:go:ci` (429 CPU-s total) showed `internal/sandbox/...` accounting for ~44% of total Go test wall time. Splitting the Linux Unit Tests job into two parallel matrix shards cuts its critical-path wall from ~5:04 → ~2:30.

**Per-package timing (top 6 of 414s in `internal/`):**

| Package | CPU-s | Share |
|---|---|---|
| `internal/sandbox` | 131 | 31% |
| `internal/app` | 55 | 13% |
| `internal/sandbox/forwarder` | 51 | 12% |
| `internal/server` | 18 | 4% |
| `internal/launch` | 17 | 4% |
| `internal/vault` | 14 | 3% |

The natural shard seam is `internal/sandbox/...` vs everything else (45% vs 55% by CPU-seconds).

**Changes:**
- New Taskfile targets: `test:go:ci:sandbox` and `test:go:ci:rest`. The rest shard computes its package list at runtime via `go list ... | grep -vE '/sandbox(/|$)'` so the source of truth stays in `GO_TEST_PACKAGES` and newly added packages flow into the right shard automatically.
- `.github/workflows/ci.yml` `test` job becomes a matrix on `shard: [sandbox, rest]`. `fail-fast: false` so one shard failure doesn't cancel the other.
- Both shards upload coverage under the `unit` flag. The package sets are disjoint, so Codecov merges cleanly by file. `codecov.yml` needs no changes.
- `task test:go:ci` (single-shot) preserved for local use; docs in `docs/src/content/docs/development/{running-tests,submitting-changes}.md` continue to reference it.

**Local verification** (darwin/arm64, cache cleared):

```
sandbox: 2:09 wall / 177 tests / coverage.txt + junit.xml produced
rest:    1:00 wall / 3,397 tests / coverage.txt + junit.xml produced
```

CI parallelism is lower (4 vCPU vs 8), so the rest shard will be longer in CI; projected `max(sandbox, rest)` ≈ 2:30 + ~25s setup.

## Test plan

- [ ] Both shards pass green on this PR
- [ ] Codecov reports unit coverage merged across `sandbox` + `rest` (+ existing macOS, Windows uploads) — patch coverage should match pre-shard behavior since the package sets are disjoint and complete
- [ ] `task test:go:ci` still works locally for single-shot runs
- [ ] No drop in Codecov unit % vs `main`

## Out of scope

- Sandbox tests are still the hot path on macOS and Windows jobs too; further wins (in-package `t.Parallel()` audit, optional `-race`-off PR runs) tracked as a follow-up.
- Docker layer caching for the integration jobs (separate ~3 min of duplicated `docker compose --build` per run) tracked separately.
- The `cache-dependency-path` references `cmd/aileron-sh/go.mod` which no longer exists; pre-existing, not addressed here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)