### PR TITLE
test(sandbox): mark wazero/forwarder integration tests as t.Parallel

### DIFF
--- a/internal/sandbox/credential_integration_test.go
+++ b/internal/sandbox/credential_integration_test.go
@@ -36,6 +36,7 @@ func oauthEchoManifest(host string) *cstore.Manifest {
 // Bearer test-token` on the actual outbound request. The connector
 // never touches the bytes.
 func TestCredentialMediation_EndToEnd_InjectsBearerHeader(t *testing.T) {
+	t.Parallel()
 	var seenAuth string
 	var seenURL string
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -109,6 +110,7 @@ func TestCredentialMediation_EndToEnd_InjectsBearerHeader(t *testing.T) {
 // reference time; the connector receives a binding_required
 // structured error.
 func TestCredentialMediation_BindingMissing_ReturnsBindingRequired(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Error("upstream should not have been dialed")
 		w.WriteHeader(http.StatusOK)
@@ -154,6 +156,7 @@ func TestCredentialMediation_BindingMissing_ReturnsBindingRequired(t *testing.T)
 // disagrees with its own manifest's declared kind. Refused at the
 // connector-manifest boundary.
 func TestCredentialMediation_KindMismatch_ReturnsCapabilityDenied(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		t.Error("upstream should not have been dialed")
 		w.WriteHeader(http.StatusOK)

--- a/internal/sandbox/forwarder/forwarder_test.go
+++ b/internal/sandbox/forwarder/forwarder_test.go
@@ -54,6 +54,7 @@ func TestWASM_Embedded(t *testing.T) {
 }
 
 func TestForwarder_DispatchesToSpawnOp(t *testing.T) {
+	t.Parallel()
 	// End-to-end: compile the embedded forwarder, invoke it with a
 	// {op, args} envelope on stdin, verify the runtime's spawn host
 	// function received the manifest-derived spawn envelope.
@@ -101,6 +102,7 @@ func TestForwarder_DispatchesToSpawnOp(t *testing.T) {
 }
 
 func TestForwarder_UndeclaredOpDenied(t *testing.T) {
+	t.Parallel()
 	exec := &sandboxtest.RecordingExecutor{}
 	rt, err := sandbox.NewWazeroRuntime(context.Background(), sandbox.WithSpawnExecutor(exec))
 	if err != nil {
@@ -131,6 +133,7 @@ func TestForwarder_UndeclaredOpDenied(t *testing.T) {
 }
 
 func TestForwarder_MissingPlaceholderDenied(t *testing.T) {
+	t.Parallel()
 	exec := &sandboxtest.RecordingExecutor{}
 	rt, _ := sandbox.NewWazeroRuntime(context.Background(), sandbox.WithSpawnExecutor(exec))
 	t.Cleanup(func() { _ = rt.Close(context.Background()) })
@@ -154,6 +157,7 @@ func TestForwarder_MissingPlaceholderDenied(t *testing.T) {
 }
 
 func TestForwarder_StableOperationsAcrossInvocations(t *testing.T) {
+	t.Parallel()
 	// One forwarder instance, two invocations of different operations.
 	// Each invocation must independently lookup its op against the
 	// manifest; state from the first call must not leak into the

--- a/internal/sandbox/internal_test.go
+++ b/internal/sandbox/internal_test.go
@@ -10,6 +10,7 @@ import (
 )
 
 func TestSandboxExecutor_ActionBoundary_DeniesURLOutsideSubset(t *testing.T) {
+	t.Parallel()
 	// Issue #359 acceptance #7: the action's declared capability
 	// subset is enforced *in addition to* the connector manifest's
 	// grant. Even when the connector manifest grants two hosts, an
@@ -54,6 +55,7 @@ func TestSandboxExecutor_ActionBoundary_DeniesURLOutsideSubset(t *testing.T) {
 }
 
 func TestSandboxExecutor_ActionBoundary_AllowsURLInSubset(t *testing.T) {
+	t.Parallel()
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.WriteHeader(http.StatusOK)
 		_, _ = w.Write([]byte("ok"))

--- a/internal/sandbox/wazero_test.go
+++ b/internal/sandbox/wazero_test.go
@@ -49,6 +49,7 @@ func newTestRuntime(t *testing.T, doer HTTPDoer) Runtime {
 }
 
 func TestWazeroRuntime_PerCallInstantiation_HappyPathRoundTrip(t *testing.T) {
+	t.Parallel()
 	// ADR-0005 acceptance #1: per-call connector instantiation works.
 	// AC #8: connector instances are scoped to a single invocation
 	// and torn down on completion. Two invocations produce independent
@@ -85,6 +86,7 @@ func TestWazeroRuntime_PerCallInstantiation_HappyPathRoundTrip(t *testing.T) {
 }
 
 func TestWazeroRuntime_AileronLog_CapturedAsLogLines(t *testing.T) {
+	t.Parallel()
 	// The connector calls aileron_host.log to emit a log line; the
 	// runtime captures those into Result.Logs. This is the seam
 	// audit emission will use post-MVP (#365).
@@ -105,6 +107,7 @@ func TestWazeroRuntime_AileronLog_CapturedAsLogLines(t *testing.T) {
 }
 
 func TestWazeroRuntime_HTTPRequestAllowedHostSucceeds(t *testing.T) {
+	t.Parallel()
 	// ADR-0005 acceptance #3: network access is gated by
 	// [capabilities.network]. A URL whose host:port is in the grant
 	// reaches the host's HTTP doer and the response flows back to
@@ -138,6 +141,7 @@ func TestWazeroRuntime_HTTPRequestAllowedHostSucceeds(t *testing.T) {
 }
 
 func TestWazeroRuntime_HTTPRequestDeniedHostReturnsCapabilityDenied(t *testing.T) {
+	t.Parallel()
 	// ADR-0005 example "Capability denial at the WASM sandbox boundary":
 	// the runtime refuses outbound calls to hosts not in the grant.
 	// The error class is capability_denied with boundary=sandbox; the
@@ -173,6 +177,7 @@ func TestWazeroRuntime_HTTPRequestDeniedHostReturnsCapabilityDenied(t *testing.T
 }
 
 func TestWazeroRuntime_WallTimeLimitTerminatesAndNamesLimit(t *testing.T) {
+	t.Parallel()
 	// ADR-0005 §"Resource limits": hitting a limit terminates the
 	// instance and surfaces a structured error to the calling action.
 	// AC #6: terminations produce class=resource_limit_exceeded with
@@ -211,6 +216,7 @@ func TestWazeroRuntime_WallTimeLimitTerminatesAndNamesLimit(t *testing.T) {
 }
 
 func TestWazeroRuntime_ConnectorPanicSurfacesAsRuntimeError(t *testing.T) {
+	t.Parallel()
 	// A connector that exits non-zero produces a connector_runtime_error.
 	// The class lets the LLM (and audit log) reason about the failure
 	// without parsing prose; the message is bounded so an enormous
@@ -236,6 +242,7 @@ func TestWazeroRuntime_ConnectorPanicSurfacesAsRuntimeError(t *testing.T) {
 }
 
 func TestWazeroRuntime_MalformedBinaryFailsCompile(t *testing.T) {
+	t.Parallel()
 	// ADR-0005 acceptance #2: out-of-grant imports refuse at
 	// instantiation. Malformed binaries fail at compile, which is
 	// the earlier failure mode. Both produce connector_load_failed.
@@ -251,6 +258,7 @@ func TestWazeroRuntime_MalformedBinaryFailsCompile(t *testing.T) {
 }
 
 func TestWazeroRuntime_NilManifestRejected(t *testing.T) {
+	t.Parallel()
 	rt := newTestRuntime(t, http.DefaultClient)
 	if _, err := rt.Compile(context.Background(), nil, echoWASM); err == nil {
 		t.Fatal("expected error for nil manifest")


### PR DESCRIPTION
## Summary

Follow-up to #758. After sharding Unit Tests on Linux, the new critical path became Windows Unit Tests at ~4 min — bottlenecked by the same sandbox tests that dominate every platform.

Profiling `internal/sandbox` with `-race -json -v` showed **15 of its tests cost ~11s each**, totaling ~165s out of ~170s. The 11-second uniformity is the per-test cost of instantiating a fresh wazero runtime and compiling `echoWASM` / `forwarder.WASM`. Each test owns its runtime, httptest server, vault, and recording executor — no shared mutable state — so they can run concurrently.

## Changes

Added `t.Parallel()` to 17 tests across 4 files:
- `internal/sandbox/wazero_test.go` (8 tests, the heavy ones)
- `internal/sandbox/credential_integration_test.go` (3 tests)
- `internal/sandbox/internal_test.go` (2 ActionBoundary tests)
- `internal/sandbox/forwarder/forwarder_test.go` (4 tests)

The Linux-only `osExecutable`-patching tests in `spawn_sandbox_linux_test.go` are **not** parallelized — they swap a package global and must stay serial. Go's test runner correctly runs serial tests first, then parallel ones, so this co-exists cleanly.

## Local timing (darwin/arm64, `-race -coverprofile`)

| | Before | After |
|---|---|---|
| `internal/sandbox` | 2:09 (128s) | **0:36 (36s)** |
| `internal/sandbox/forwarder` | 0:48 | **0:22** |
| Whole sandbox shard wall | 2:09 | **0:38** |

3.4× speedup on 8-core arm64. CI's 4-vCPU runners get less parallel headroom, but all three Unit Tests jobs (Linux sandbox shard, macOS, Windows) run subsets of these tests, so all three benefit.

Coverage preserved: sandbox 85.3%, forwarder 100%, sandboxtest 87.5%, spawnhelper 88.1%.

## Test plan

- [ ] All sandbox tests pass on Linux/macOS/Windows under `-race`
- [ ] No new test flakes when run with `-count=2`
- [ ] Codecov reports the same coverage % for the sandbox packages
- [ ] Unit Tests (sandbox) shard wall on CI noticeably faster (target: ~1:30 from current ~3:33)
- [ ] Unit Tests (macOS) and Unit Tests (Windows) walls drop proportionally

Verified locally with `go test -race -count=2 ./internal/sandbox/...` (66s for two full runs).

## Out of scope

- Caching the compiled wazero module inside the runtime so each test pays the compile cost only once — a separate, larger optimization that touches production code.
- Docker layer caching for the integration jobs — tracked separately; after this PR it becomes the next critical-path candidate (~2:55 wall).

🤖 Generated with [Claude Code](https://claude.com/claude-code)