### PR TITLE
ci: cache docs image layers via buildx GHA cache

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -422,8 +422,22 @@ jobs:
     steps:
       - uses: actions/checkout@v6
 
+      - uses: docker/setup-buildx-action@v3
+
       - name: Build docs image
-        run: docker build -t aileron-docs -f docs/Dockerfile .
+        # GHA layer cache for the docs image. The same pattern was
+        # tried for the integration jobs but did not produce a wall-
+        # time win there: `load: true` + multi-stage Go builds add
+        # ~90s of image-load overhead that swamps the cache savings,
+        # and those jobs aren't on the critical path anyway.
+        uses: docker/build-push-action@v6
+        with:
+          context: .
+          file: docs/Dockerfile
+          tags: aileron-docs
+          load: true
+          cache-from: type=gha,scope=docs
+          cache-to: type=gha,mode=max,scope=docs
 
       - name: Start docs container
         run: docker run -d --name docs -p 3001:3000 aileron-docs


### PR DESCRIPTION
## Summary

Third in the CI speedup series, scoped down from the original attempt.

Adds GHA-backed BuildKit layer caching to the docs job's image build (`docker/build-push-action@v6`, `cache-to/from type=gha,scope=docs`). Warm-cache runs drop the build step from ~30s to ~5s.

## Why only docs (and not the integration jobs)

The original version of this PR (force-pushed away) also added bake-based caching to \`integration-go\` and \`integration-e2e\`. That part didn't produce a wall-time win:

- **Cache contention.** The two integration jobs build the \`server\` image with different \`COVERAGE\` build args. When they share a cache scope, whichever finishes last overwrites the manifest, so the other's warm run cache-misses on the server image.
- **\`load: true\` overhead is structural.** Even on a perfect cache hit, BuildKit has to extract three multi-stage Go/Node images and load them into the local Docker daemon. That's ~30s × 3 = ~90s of overhead per warm run that swamps the cache savings.
- **Not on the critical path.** After #758 + #761, Unit Tests (Windows) at ~3:00 is the wall floor. Even ideal integration caching (each job ~1:30) wouldn't move it. Metered-compute savings only matter on private repos.

The docs image is simple (single-stage astro build), so its load is fast and the cache savings translate cleanly to wall-time.

## Expected impact

| | Before | Cold (cache write) | Warm (cache hit) |
|---|---|---|---|
| Docs | 0:31 | ~1:10 | **~0:17** |

Off the critical path either way, but the warm-cache savings are a clean -14s of metered compute per CI run.

## Test plan

- [ ] First CI run passes (cold)
- [ ] Second CI run (after another small commit) shows the warm-cache Docs job at ~0:17
- [ ] No other jobs affected

## Out of scope

- Integration job caching — investigated, doesn't pay off (see above).
- Registry-push caching pattern (would avoid \`load: true\` overhead) — bigger refactor, only worth doing if/when integration jobs become critical path or compute cost matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)