### PR TITLE
fix(cli): clean up Hub install-decision render and prompts

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -1780,7 +1780,7 @@ type hubSuiteInstallDecisionWire struct {
 //
 //  1. GET /v1/hub/install-decision?fqn=<fqn>. If the FQN is in the Hub
 //     (200), render the publisher / fingerprint / trust-state / risks
-//     and prompt y/N/d=details. On confirm, call install with
+//     and prompt y/n/d=details. On confirm, call install with
 //     `confirmed_fingerprint`; the daemon writes per-FQN trust to the
 //     keyring before running the install pipeline (#487 Q4).
 //
@@ -1879,7 +1879,7 @@ func runConnectorInstall(args []string, stdin io.Reader, stdout, stderr io.Write
 
 	// Step 3: prompt unless --yes.
 	if !*yes {
-		answer := strings.ToLower(strings.TrimSpace(promptLine(stdin, stdout, "Install? [y/N]: ")))
+		answer := strings.ToLower(strings.TrimSpace(promptLine(stdin, stdout, "Install? [y/n]: ")))
 		if answer != "y" && answer != "yes" {
 			fmt.Fprintln(stdout, "Cancelled.")
 			return 0
@@ -1965,9 +1965,9 @@ func tryHubInstallDecisionFlow(fqn string, autoYes bool, stdin io.Reader, stdout
 		renderHubInstallDecision(stdout, &d, showDetails)
 		var ans string
 		if showDetails {
-			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Install? [y/N]: ")))
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Install? [y/n]: ")))
 		} else {
-			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Install? [y/N/d=details]: ")))
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Install? [y/n/d=details]: ")))
 		}
 		switch ans {
 		case "y", "yes":
@@ -2100,9 +2100,9 @@ func tryHubActionInstallDecisionFlow(actionFQN string, autoYes bool, stdin io.Re
 		renderHubActionCompositeDecision(stdout, &d, showDetails)
 		var ans string
 		if showDetails {
-			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and install? [y/N]: ")))
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and install? [y/n]: ")))
 		} else {
-			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and install? [y/N/d=details]: ")))
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and install? [y/n/d=details]: ")))
 		}
 		switch ans {
 		case "y", "yes":
@@ -2138,8 +2138,6 @@ func renderHubActionCompositeDecision(w io.Writer, d *hubActionInstallDecisionWi
 	}
 	fmt.Fprintf(w, "  Publisher: %s\n", d.PublisherGithub)
 	fmt.Fprintf(w, "  Connector: %s\n", d.ConnectorFqn)
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  \033[1mTrust gate(s): %d connector authority\033[0m\n", len(d.Authorities))
 	for _, auth := range d.Authorities {
 		fmt.Fprintln(w)
 		fmt.Fprintf(w, "  ● %s\n", auth.Fqn)
@@ -2170,7 +2168,7 @@ func renderHubActionCompositeDecision(w io.Writer, d *hubActionInstallDecisionWi
 // /v1/hub/suite-install-decision and, when the suite is Hub-listed,
 // renders the composite trust panel (suite metadata + member actions
 // + per-authority trust gates) and collapses every per-authority
-// consent into a single y/N/d=details prompt.
+// consent into a single y/n/d=details prompt.
 //
 // Fall-through, error-note, and empty-payload semantics match the
 // action variant.
@@ -2211,9 +2209,9 @@ func tryHubSuiteInstallDecisionFlow(suiteFQN string, autoYes bool, stdin io.Read
 		renderHubSuiteCompositeDecision(stdout, &d, showDetails)
 		var ans string
 		if showDetails {
-			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and continue? [y/N]: ")))
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and continue? [y/n]: ")))
 		} else {
-			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and continue? [y/N/d=details]: ")))
+			ans = strings.ToLower(strings.TrimSpace(promptLine(br, stdout, "Trust these publishers and continue? [y/n/d=details]: ")))
 		}
 		switch ans {
 		case "y", "yes":
@@ -2255,8 +2253,6 @@ func renderHubSuiteCompositeDecision(w io.Writer, d *hubSuiteInstallDecisionWire
 			fmt.Fprintf(w, "    - %s\n", a)
 		}
 	}
-	fmt.Fprintln(w)
-	fmt.Fprintf(w, "  \033[1mTrust gate(s): %d connector authorit(y|ies)\033[0m\n", len(d.Authorities))
 	for _, auth := range d.Authorities {
 		fmt.Fprintln(w)
 		fmt.Fprintf(w, "  ● %s\n", auth.Fqn)
@@ -2830,10 +2826,10 @@ func installOneAction(opts actionAddOptions, stdin io.Reader, stdout, stderr io.
 		var prompt string
 		if upgrade {
 			renderActionUpgradeBanner(stdout, &preview)
-			prompt = fmt.Sprintf("Replace v%s with v%s? [y/N]: ",
+			prompt = fmt.Sprintf("Replace v%s with v%s? [y/n]: ",
 				preview.Existing.Version, preview.Version)
 		} else {
-			prompt = "Install? [y/N]: "
+			prompt = "Install? [y/n]: "
 		}
 		answer := strings.ToLower(strings.TrimSpace(promptLine(stdin, stdout, prompt)))
 		if answer != "y" && answer != "yes" {
@@ -3287,7 +3283,7 @@ func installSuiteEntries(manifest *suite.Manifest, refs []cstore.Ref, hubSuiteFQ
 	cancelled := false
 	if !opts.yes {
 		renderSuitePreview(stdout, manifest, plan)
-		ans := strings.ToLower(strings.TrimSpace(promptLine(stdin, stdout, "Install? [y/N]: ")))
+		ans := strings.ToLower(strings.TrimSpace(promptLine(stdin, stdout, "Install? [y/n]: ")))
 		if ans != "y" && ans != "yes" {
 			cancelled = true
 		}

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -1478,7 +1478,7 @@ func TestRunConnector_InstallPromptYesProceeds(t *testing.T) {
 	if !installCalled {
 		t.Error("install endpoint not called after 'y' confirmation")
 	}
-	if !strings.Contains(stdout.String(), "Install? [y/N]:") {
+	if !strings.Contains(stdout.String(), "Install? [y/n]:") {
 		t.Errorf("expected prompt in stdout; got: %s", stdout.String())
 	}
 	_ = r // silence unused if compiler complains
@@ -3389,7 +3389,7 @@ func TestRunActionAdd_PreviewThenInstallOnYes(t *testing.T) {
 		"Connectors that will be installed",
 		"github://acme/conn@1.0.0",
 		"op_a",
-		"Install? [y/N]:",
+		"Install? [y/n]:",
 		"Added: my-action",
 	} {
 		if !strings.Contains(out, want) {
@@ -3737,7 +3737,7 @@ func TestRunActionAdd_AutoTrustPromptsAndInstalls(t *testing.T) {
 		"Trust publisher github://acme/conn?",
 		"✓ Trusted publisher github://acme/conn",
 		"Action install preview",
-		"Install? [y/N]:",
+		"Install? [y/n]:",
 		"Added: my-action",
 	} {
 		if !strings.Contains(out, want) {
@@ -4840,7 +4840,7 @@ actions = [
 	}
 	out := stdout.String()
 	// Exactly one consent prompt, regardless of fresh + upgrade mix.
-	if got := strings.Count(out, "Install? [y/N]: "); got != 1 {
+	if got := strings.Count(out, "Install? [y/n]: "); got != 1 {
 		t.Errorf("expected exactly 1 suite-level prompt, got %d:\n%s", got, out)
 	}
 	for _, want := range []string{
@@ -4895,7 +4895,7 @@ actions = [
 		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
 	}
 	out := stdout.String()
-	if got := strings.Count(out, "Install? [y/N]: "); got != 1 {
+	if got := strings.Count(out, "Install? [y/n]: "); got != 1 {
 		t.Errorf("expected exactly 1 suite-level prompt for 6 actions, got %d:\n%s", got, out)
 	}
 	if len(installCalls) != 6 {
@@ -5067,7 +5067,7 @@ actions = [
 	if code != 0 {
 		t.Fatalf("exit = %d; stderr=%s", code, stderr.String())
 	}
-	if got := strings.Count(stdout.String(), "Install? [y/N]: "); got != 0 {
+	if got := strings.Count(stdout.String(), "Install? [y/n]: "); got != 0 {
 		t.Errorf("--yes must suppress every consent prompt, got %d:\n%s", got, stdout.String())
 	}
 	if got := strings.Count(stdout.String(), "Suite install preview"); got != 0 {

--- a/internal/app/handlers_hub.go
+++ b/internal/app/handlers_hub.go
@@ -194,6 +194,14 @@ func buildRiskIndicators(kr *cstore.Ed25519Keyring, footprint []string, trustSta
 	switch {
 	case trustState == api.HubTrustStateConflict:
 		risks = append(risks, "Key fingerprint differs from one you trust for a sibling repo ("+conflictFQN+")")
+	case trustState == api.HubTrustStateAlreadyTrusted:
+		// Already trusted at this FQN: the "first install" framing would
+		// be a lie (the user has this exact connector). Surface sibling
+		// trust as informational context, otherwise emit nothing — the
+		// already_trusted state itself carries the reassurance.
+		if trustedSiblings > 0 {
+			risks = append(risks, pluralizeTrustedSiblings(trustedSiblings))
+		}
 	case trustedSiblings == 0:
 		risks = append(risks, "First connector by this publisher you've installed")
 	default:

--- a/internal/app/handlers_hub_test.go
+++ b/internal/app/handlers_hub_test.go
@@ -177,6 +177,62 @@ func TestGetHubInstallDecision_AlreadyTrustedWhenKeyringMatches(t *testing.T) {
 	if got.TrustState != api.HubTrustStateAlreadyTrusted {
 		t.Fatalf("trust_state = %s, want already_trusted", got.TrustState)
 	}
+	// Already-trusted with no sibling footprint must not surface the
+	// "First connector by this publisher you've installed" line — the
+	// user has this exact connector trusted, so that framing is wrong.
+	for _, r := range got.RiskIndicators {
+		if strings.Contains(r, "First connector by this publisher") {
+			t.Errorf("already_trusted should not emit first-connector risk; got %q", r)
+		}
+	}
+}
+
+// TestGetHubInstallDecision_AlreadyTrustedWithTrustedSibling: when the
+// keyring already trusts this FQN AND a sibling repo by the same
+// publisher, surface the sibling-trust line as informational context.
+// Reupgrade flow: don't claim "First connector"; do say "Publisher has
+// N other connectors you already trust" when truthy.
+func TestGetHubInstallDecision_AlreadyTrustedWithTrustedSibling(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	keyServer := httpKeyServer(t, pub)
+	defer keyServer.Close()
+
+	url := makeHubFixture(t, map[string]string{
+		"alice_a.yaml": entryYAML("github://alice/a", "A", "alice", keyServer.URL+"/publisher.pub"),
+		"alice_b.yaml": entryYAML("github://alice/b", "B", "alice", "https://example.com/b.pub"),
+	})
+	keyringPath := writeKeyring(t, map[string][]ed25519.PublicKey{
+		"github://alice/a": {pub},
+		"github://alice/b": {pub},
+	})
+	srv := &apiServer{
+		log:         slog.Default(),
+		hub:         &hub.Client{URL: url, HTTP: keyServer.Client()},
+		keyringPath: keyringPath,
+	}
+	rec := httptest.NewRecorder()
+	srv.GetHubInstallDecision(rec, httptest.NewRequest(http.MethodGet, "/v1/hub/install-decision?fqn=github://alice/a", nil), api.GetHubInstallDecisionParams{Fqn: "github://alice/a"})
+
+	if rec.Code != http.StatusOK {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got api.HubInstallDecision
+	_ = json.NewDecoder(rec.Body).Decode(&got)
+	if got.TrustState != api.HubTrustStateAlreadyTrusted {
+		t.Fatalf("trust_state = %s, want already_trusted", got.TrustState)
+	}
+	foundSiblingIndicator := false
+	for _, r := range got.RiskIndicators {
+		if strings.Contains(r, "First connector by this publisher") {
+			t.Errorf("already_trusted should not emit first-connector risk; got %q", r)
+		}
+		if strings.Contains(r, "other connector") {
+			foundSiblingIndicator = true
+		}
+	}
+	if !foundSiblingIndicator {
+		t.Errorf("expected trusted-sibling indicator, got %v", got.RiskIndicators)
+	}
 }
 
 func TestGetHubInstallDecision_ConflictWhenSiblingHasDifferentKey(t *testing.T) {


### PR DESCRIPTION
## Summary

UX polish on the terminal trust panel shown during `aileron action add` / `aileron suite install` / `aileron connector install`.

- **Removed `Trust gate(s): N connector authorit(y|ies)` header.** The per-authority `●` bullet already separates the section; the lazy pluralization read as a placeholder.
- **Fixed bogus "First connector by this publisher you've installed" risk on upgrades.** When the FQN is already trusted (re-install / version bump), the old switch still fell into the "first install" arm, contradicting the `Trust: already trusted` line right above it. New behavior: emit the trusted-sibling line if applicable, otherwise no risk line — `already_trusted` carries its own reassurance.
- **Lowercased the install/composite prompts** to `[y/n/d=details]` and `[y/n]`. Anything other than `y`/`yes` still cancels. Left the destructive `binding revoke` prompt as `[y/N]` because uppercase-default is a real safety signal for irreversible ops.

### Before vs After (already-trusted upgrade)

```
Hub install-decision (suite)
  ...
  Actions:   3
    - ...
                                                            <-- old: empty line
  Trust gate(s): 1 connector authorit(y|ies)                <-- old: header gone

  ● github://ALRubinger/aileron-connector-google
      Publisher:   ALRubinger
      Fingerprint: sha256:...
      Trust:       already trusted
      Risk:        • First connector by this publisher...   <-- old: bogus line gone

Trust these publishers and continue? [y/n/d=details]:        <-- old: [y/N/d=details]
```

## Test plan

- [x] `go test ./cmd/aileron/ ./internal/app/` — green
- [x] New regression: `TestGetHubInstallDecision_AlreadyTrustedWithTrustedSibling` asserts (a) no "First connector" risk on already-trusted and (b) sibling-trust line is surfaced when applicable
- [x] Existing `TestGetHubInstallDecision_AlreadyTrustedWhenKeyringMatches` extended to assert "First connector" is absent
- [x] Coverage: cmd/aileron 84.9%, internal/app 80.2%
- [x] Existing Hub install / composite tests (action + suite + connector) all still pass with the lowercase prompts

🤖 Generated with [Claude Code](https://claude.com/claude-code)