### PR TITLE
ci: cache Playwright browsers across four jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -258,6 +258,12 @@ jobs:
         working-directory: ui
         run: E2E_COVERAGE=1 pnpm build
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-ui-${{ hashFiles('ui/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
         working-directory: ui
         run: pnpm exec playwright install --with-deps chromium
@@ -333,6 +339,12 @@ jobs:
         working-directory: webapp
         run: pnpm build
 
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-webapp-${{ hashFiles('webapp/pnpm-lock.yaml') }}
+
       - name: Install Playwright browsers
         working-directory: webapp
         run: pnpm exec playwright install --with-deps chromium
@@ -393,6 +405,12 @@ jobs:
       - name: Install webapp dependencies
         working-directory: webapp
         run: pnpm install --frozen-lockfile
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-webapp-${{ hashFiles('webapp/pnpm-lock.yaml') }}
 
       - name: Install Playwright browsers
         working-directory: webapp
@@ -594,6 +612,12 @@ jobs:
           node-version: 24
           cache: pnpm
           cache-dependency-path: ui/pnpm-lock.yaml
+
+      - name: Cache Playwright browsers
+        uses: actions/cache@v4
+        with:
+          path: ~/.cache/ms-playwright
+          key: ${{ runner.os }}-playwright-ui-${{ hashFiles('ui/pnpm-lock.yaml') }}
 
       - name: Install Playwright dependencies
         working-directory: ui


### PR DESCRIPTION
## Summary

Four jobs (UI Tests, Webapp Tests, Webapp Integration E2E, Integration Tests E2E) each download Playwright/Chromium fresh every run, spending ~22–26s × 4 = **~95s of duplicated work per CI run**.

Adds \`actions/cache@v4\` for \`~/.cache/ms-playwright\` keyed on the relevant pnpm-lock.yaml hash. \`playwright install --with-deps chromium\` is still invoked after the cache restore — Playwright detects the existing binaries and skips the download, while the apt-get system-dep step (cheap on GHA's ubuntu-latest image, most deps pre-installed) runs as before.

## Scope details

- **Two cache keys:** \`playwright-ui-<lockhash>\` for the two ui-dir jobs, \`playwright-webapp-<lockhash>\` for the two webapp-dir jobs. Lockfile churn in one app doesn't invalidate the other.
- **No conditional install** — let Playwright's idempotency handle it. Cleaner than \`if: steps.cache.outputs.cache-hit\` branching.

## Expected impact

Pure **metered-compute** win — none of these jobs are on the wall-clock critical path (Unit Tests Windows at ~3:00 is the floor). Projected savings: ~15s per job × 4 jobs ≈ **~60s of metered compute per warm CI run**. Free on public repos; worth doing because the wasted-electricity aesthetics matter and the change is tiny.

## Test plan

- [ ] Cold run passes (cache miss, browsers downloaded as before; cache written for next time)
- [ ] Second run (after another commit on this PR or post-merge) shows the four jobs' Install Playwright steps drop from ~25s to ~5s
- [ ] No new flakes in any Playwright job

## Out of scope

- Caching apt-get deps (would need to install via different mechanism; deps are already mostly pre-installed on GHA runners — not worth the complexity).
- Sharing one cache between ui and webapp (they currently use the same Playwright version, but cache key per app dir is safer against drift).

🤖 Generated with [Claude Code](https://claude.com/claude-code)