### PR TITLE
fix(cli): `pp add` must install <entry>/cmd/<name>-pp-cli, not module root

### DIFF
--- a/cmd/aileron/pp_command.go
+++ b/cmd/aileron/pp_command.go
@@ -106,12 +106,14 @@ func runPpAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	modulePath := ppModulePath(entry.Path)
+	packagePath := ppPackagePath(entry.Path, name)
 	sourceURL := ppSourceURL(entry.Path)
 	binaryName := name + "-pp-cli"
 
 	fmt.Fprintln(stdout)
 	fmt.Fprintf(stdout, "Install plan for %s:\n", name)
-	fmt.Fprintf(stdout, "  Module:   %s@latest\n", modulePath)
+	fmt.Fprintf(stdout, "  Module:   %s\n", modulePath)
+	fmt.Fprintf(stdout, "  Package:  %s@latest\n", packagePath)
 	fmt.Fprintf(stdout, "  Source:   %s\n", sourceURL)
 	fmt.Fprintf(stdout, "  Binary:   %s (installed to $GOBIN)\n", binaryName)
 	fmt.Fprintf(stdout, "  Wrap as:  local://user/%s\n", name)
@@ -130,8 +132,8 @@ func runPpAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 
-	fmt.Fprintf(stdout, "\nRunning `go install %s@latest`…\n", modulePath)
-	if err := runGoInstall(modulePath, stdout, stderr); err != nil {
+	fmt.Fprintf(stdout, "\nRunning `go install %s@latest`…\n", packagePath)
+	if err := runGoInstall(packagePath, stdout, stderr); err != nil {
 		fmt.Fprintf(stderr, "error: go install: %v\n", err)
 		return 1
 	}
@@ -265,12 +267,30 @@ func ppUnknownEntryError(name string, entries []ppEntry) error {
 }
 
 // ppModulePath derives the Go module path from a catalog entry's
-// `path` field. The convention is fixed: the library repo's own
-// path layout IS the module path. This function exists to
-// centralize the convention so a future catalog re-layout
-// touches one place.
+// `path` field. The convention is fixed: each catalog entry has
+// its own `go.mod` at `library/<category>/<name>/go.mod`, and
+// the module path declared there is the repo root plus the
+// entry's `path` field.
+//
+// Note: this is the *module* path, not the runnable *package*
+// path. The CLI binary lives at `<modulePath>/cmd/<name>-pp-cli`;
+// use [ppPackagePath] for the value passed to `go install`.
 func ppModulePath(entryPath string) string {
 	return "github.com/mvanhorn/printing-press-library/" + strings.TrimPrefix(entryPath, "/")
+}
+
+// ppPackagePath returns the import path of the CLI variant's
+// main package — the value passed to `go install`. Every
+// PrintingPress entry follows the `cmd/<name>-pp-cli` /
+// `cmd/<name>-pp-mcp` layout per their authoring convention;
+// BYOCLI wraps the `-pp-cli` variant (the agent calls it
+// through subcommands), not the `-pp-mcp` variant (which Aileron
+// would speak MCP to, a separate integration point).
+//
+// Centralizing the `cmd/<name>-pp-cli` suffix here keeps the
+// PrintingPress directory-layout assumption in one place.
+func ppPackagePath(entryPath, name string) string {
+	return ppModulePath(entryPath) + "/cmd/" + name + "-pp-cli"
 }
 
 // ppSourceURL renders a browser-friendly URL pointing at the

--- a/cmd/aileron/pp_command_test.go
+++ b/cmd/aileron/pp_command_test.go
@@ -176,6 +176,41 @@ func TestPPModulePath_StripsLeadingSlash(t *testing.T) {
 	}
 }
 
+func TestPPPackagePath_AppendsCmdSubdirAndPpCliSuffix(t *testing.T) {
+	// The actual binary lives at `<modulePath>/cmd/<name>-pp-cli`
+	// in every PrintingPress entry (their authoring tooling
+	// emits that layout). Pin the convention here so a future
+	// `go install` regression doesn't ship a path that resolves
+	// to the module root and fails with "found, but does not
+	// contain package."
+	cases := []struct {
+		entry string
+		name  string
+		want  string
+	}{
+		{
+			entry: "library/project-management/linear",
+			name:  "linear",
+			want:  "github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli",
+		},
+		{
+			entry: "library/marketing/ahrefs",
+			name:  "ahrefs",
+			want:  "github.com/mvanhorn/printing-press-library/library/marketing/ahrefs/cmd/ahrefs-pp-cli",
+		},
+		{
+			entry: "/library/social/linkedin",
+			name:  "linkedin",
+			want:  "github.com/mvanhorn/printing-press-library/library/social/linkedin/cmd/linkedin-pp-cli",
+		},
+	}
+	for _, c := range cases {
+		if got := ppPackagePath(c.entry, c.name); got != c.want {
+			t.Errorf("ppPackagePath(%q, %q)=%q want %q", c.entry, c.name, got, c.want)
+		}
+	}
+}
+
 func TestPPSourceURL_StripsLeadingSlash(t *testing.T) {
 	if got := ppSourceURL("/library/x/y"); got != "https://github.com/mvanhorn/printing-press-library/tree/main/library/x/y" {
 		t.Errorf("ppSourceURL=%q", got)
@@ -263,8 +298,8 @@ func TestRunPpAdd_DryRunDoesNotInstall(t *testing.T) {
 		t.Error("--dry-run should not invoke go install")
 	}
 	out := stdout.String()
-	if !strings.Contains(out, "github.com/mvanhorn/printing-press-library/library/project-management/linear") {
-		t.Errorf("install plan should show module path: %q", out)
+	if !strings.Contains(out, "github.com/mvanhorn/printing-press-library/library/project-management/linear/cmd/linear-pp-cli") {
+		t.Errorf("install plan should show the cmd/-pp-cli package path: %q", out)
 	}
 	if !strings.Contains(out, "dry-run") {
 		t.Errorf("dry-run notice missing: %q", out)


### PR DESCRIPTION
## Summary

Reported by user: `aileron pp add linear` fails with

```
go: github.com/mvanhorn/printing-press-library/library/project-management/linear@latest:
module github.com/mvanhorn/printing-press-library/library/project-management/linear@latest
found (v0.0.0-20260515233152-31406a121c08), but does not contain package
github.com/mvanhorn/printing-press-library/library/project-management/linear
error: go install: exit status 1
```

PrintingPress entries declare a Go module at the entry directory (`library/project-management/linear/go.mod` with `module github.com/mvanhorn/printing-press-library/library/project-management/linear`) but the runnable CLI binary lives at `<entry>/cmd/<name>-pp-cli`. `go install`ing the module root resolves the module but finds no main package.

## Fix

Split the catalog-derived module path from the import path `go install` actually consumes:

- `ppModulePath(entry.Path)` — module root, used for display and to derive other paths.
- `ppPackagePath(entry.Path, name)` — adds `/cmd/<name>-pp-cli`; this is the value passed to `runGoInstall`.

The install plan now surfaces both lines (`Module:` and `Package:`) so the user audits the exact path `go install` sees.

The `cmd/<name>-pp-cli` suffix is a PrintingPress directory-layout assumption — pinned to one place (`ppPackagePath`) so a future restructure has one site to update.

## Test plan

- [x] `TestPPPackagePath_AppendsCmdSubdirAndPpCliSuffix` — new test pinning the convention across linear / ahrefs / linkedin entry shapes.
- [x] Existing `TestRunPpAdd_DryRunDoesNotInstall` updated to expect the `cmd/<name>-pp-cli` path in the install plan.
- [x] `TestRunPpAdd_HappyPathHandsOffToCliAdd` already mocks `runGoInstall`; still green with the new path.
- [ ] Real-CLI smoke test (`aileron pp add linear` end-to-end) — reviewer should re-verify after merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
