### PR TITLE
fix(wrap): single-space help columns + skip malformed subcommand names

### DIFF
--- a/internal/wrap/credentials_test.go
+++ b/internal/wrap/credentials_test.go
@@ -251,6 +251,100 @@ func TestActionSource_LocalFQNNoDoublePrefix(t *testing.T) {
 	}
 }
 
+func TestParseSubcommands_SingleSpaceColumns(t *testing.T) {
+	// Some CLIs (Linear's reflection-based linear-pp-cli is the
+	// reported case) format `--help` with a single space between
+	// the subcommand name and its description. Before this fix
+	// the splitter treated 2+ spaces as the column separator,
+	// which made the whole row a single "name" token — failing
+	// the manifest schema's `[a-z][a-z0-9_-]*` rule and aborting
+	// the entire `aileron pp add` install. Verify single-space
+	// rows now parse correctly.
+	help := `Usage: foo [command]
+
+Commands:
+  list List things
+  authentication-session-responses Get a single auth session response
+  do-work Run a job
+`
+	subs := parseSubcommands(help)
+	got := map[string]string{}
+	for _, s := range subs {
+		got[s.Name] = s.Description
+	}
+	for _, name := range []string{"list", "authentication-session-responses", "do-work"} {
+		if _, ok := got[name]; !ok {
+			t.Errorf("missing subcommand %q in single-space-column help; got %v", name, got)
+		}
+	}
+	if got["list"] != "List things" {
+		t.Errorf("list desc=%q want %q", got["list"], "List things")
+	}
+}
+
+func TestParseSubcommands_StillHandlesCobraStyleMultiSpace(t *testing.T) {
+	// Regression check: relaxing the splitter to any whitespace
+	// must not break the cobra/urfave-style 2+-space layout that
+	// most CLIs use. The descriptions get a trailing-whitespace
+	// trim from splitSubcommandLine, so both styles read clean.
+	help := `Usage: foo
+
+Commands:
+  list      List things
+  show      Show one
+`
+	subs := parseSubcommands(help)
+	if len(subs) != 2 {
+		t.Fatalf("got %d subcommands, want 2: %v", len(subs), subs)
+	}
+	if subs[0].Name != "list" || subs[0].Description != "List things" {
+		t.Errorf("cobra-style row[0] mismatched: %+v", subs[0])
+	}
+	if subs[1].Name != "show" || subs[1].Description != "Show one" {
+		t.Errorf("cobra-style row[1] mismatched: %+v", subs[1])
+	}
+}
+
+func TestParseSubcommands_SkipsMalformedNames(t *testing.T) {
+	// Defense in depth: a name that survives the splitter but
+	// doesn't match the manifest's POSIX-shape rule is dropped
+	// rather than failing the whole install. Without this, a
+	// single rogue row in a CLI's `--help` would block users
+	// from wrapping the rest of it.
+	help := `Commands:
+  list List things
+  3invalid Number-led so the manifest rejects it
+  Bad-Caps Uppercase not allowed in operation names
+  has_underscore Permitted
+`
+	subs := parseSubcommands(help)
+	names := make([]string, 0, len(subs))
+	for _, s := range subs {
+		names = append(names, s.Name)
+	}
+	wantPresent := []string{"list", "has_underscore"}
+	wantAbsent := []string{"3invalid", "Bad-Caps"}
+	for _, n := range wantPresent {
+		found := false
+		for _, got := range names {
+			if got == n {
+				found = true
+				break
+			}
+		}
+		if !found {
+			t.Errorf("expected %q in %v", n, names)
+		}
+	}
+	for _, n := range wantAbsent {
+		for _, got := range names {
+			if got == n {
+				t.Errorf("malformed name %q should have been dropped; got %v", n, names)
+			}
+		}
+	}
+}
+
 // wantContains asserts the slice contains all expected values.
 func wantContains(t *testing.T, got []string, want string) {
 	t.Helper()

--- a/internal/wrap/load.go
+++ b/internal/wrap/load.go
@@ -196,6 +196,17 @@ func parseSubcommands(help string) []SubcommandSpec {
 		if name == "" {
 			continue
 		}
+		// Defense in depth against parser surprises: skip names
+		// that won't survive the manifest schema's POSIX-shape
+		// rule. The introspector should never emit a bad name
+		// after the splitter relaxation below, but a row whose
+		// "name" column happens to contain a number-led token
+		// or punctuation the regex rejects would otherwise fail
+		// the entire install rather than just dropping the
+		// outlier subcommand.
+		if !subcommandNameRe.MatchString(name) {
+			continue
+		}
 		out = append(out, SubcommandSpec{
 			Name:        name,
 			Description: desc,
@@ -204,6 +215,13 @@ func parseSubcommands(help string) []SubcommandSpec {
 	}
 	return out
 }
+
+// subcommandNameRe matches the operation-name shape the manifest
+// schema accepts (`^[a-z][a-z0-9_-]*$` per [cstore.ValidateManifest]).
+// Centralized here so the heuristic parser can drop malformed
+// rows before they reach the manifest validator and fail the
+// whole install.
+var subcommandNameRe = regexp.MustCompile(`^[a-z][a-z0-9_-]*$`)
 
 // isSubcommandHeader recognizes the section headers cobra,
 // urfave/cli, and clap-rs typically emit.
@@ -216,13 +234,19 @@ func isSubcommandHeader(line string) bool {
 	return false
 }
 
-// splitSubcommandLine splits a `name  description` row into its two
-// halves. Whitespace runs of two or more separate the name from the
-// description.
-var twoOrMoreSpaces = regexp.MustCompile(`\s{2,}`)
+// splitSubcommandLine splits a `name <gap> description` row into
+// its two halves. Cobra and urfave/cli space the columns with
+// two or more characters; some other generators (the Linear
+// CLI's reflection-based runtime, for example) use a single
+// space. The splitter treats any run of whitespace as the
+// column separator — operation names are constrained to
+// `[a-z][a-z0-9_-]*` by the manifest schema, so they never
+// contain internal whitespace, and a single-space gap can't
+// occur inside a real name.
+var splitterRe = regexp.MustCompile(`\s+`)
 
 func splitSubcommandLine(line string) (name, desc string) {
-	parts := twoOrMoreSpaces.Split(line, 2)
+	parts := splitterRe.Split(line, 2)
 	switch len(parts) {
 	case 0:
 		return "", ""


### PR DESCRIPTION
## Summary

Reported by user after running `aileron pp add linear` (post-#774 install-path fix):

```
error: emitted manifest does not validate: validation_error: [capabilities.spawn.operations]."authentication-session-responses Get a single authenticationsessionresponse" name must match ^[a-z][a-z0-9_-]*$ (manifest.toml)
```

Two bugs in the introspector heuristic, both surface from the same `linear-pp-cli --help` output:

### 1. Splitter required 2+ spaces between name and description

The previous `\s{2,}` regex matched cobra / urfave style help formatting where descriptions are aligned in a second column with 2+ spaces of padding. Linear's `linear-pp-cli` uses a reflection-based help formatter that single-spaces the columns — so the whole `name desc` row became one token, ended up as the op name, and failed the manifest schema's `^[a-z][a-z0-9_-]*$` rule.

**Fix:** relax the splitter to `\s+`. Operation names are constrained to `[a-z][a-z0-9_-]*` by the manifest schema and never contain internal whitespace, so any single-space gap inside a row is a column separator.

### 2. `parseSubcommands` accepted malformed names

A single rogue `--help` row (a leading-digit token, an uppercase column header, a stray dash, etc.) would propagate to the manifest validator and abort the entire install. Defense in depth: parse-time validation drops malformed rows so the rest of the CLI wraps cleanly.

## Tests

- `TestParseSubcommands_SingleSpaceColumns` — pins the Linear shape including the long `authentication-session-responses` name from the bug report.
- `TestParseSubcommands_StillHandlesCobraStyleMultiSpace` — regression check that the splitter relaxation doesn't break the 2+-space layout most CLIs use.
- `TestParseSubcommands_SkipsMalformedNames` — pins the defense-in-depth filter (`3invalid`, `Bad-Caps` dropped; `list`, `has_underscore` kept).

## Test plan

- [x] `go test ./internal/wrap/ ./cmd/aileron/` — green locally.
- [ ] Reviewer re-runs `aileron pp add linear` end-to-end to confirm.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
