### PR TITLE
fix(wrap): action.md capabilities names the op, not 'spawn'

### DIFF
--- a/internal/wrap/credentials_test.go
+++ b/internal/wrap/credentials_test.go
@@ -194,12 +194,25 @@ func TestRenderActionMD_EmitsValidFrontmatter(t *testing.T) {
 		`[[requires.connectors]]`,
 		`name = "local://user/linear"`,
 		`hash = "sha256:bound-at-install"`,
+		// Capabilities array names the op the action invokes
+		// (per ADR-0003), not a generic "spawn" label. The
+		// action-boundary check at executor.go matches step.Op
+		// against this list — a wrapped CLI calling "issues"
+		// against an action declaring `capabilities = ["spawn"]`
+		// would get capability_denied.
+		`capabilities = ["issues"]`,
 		`[[execute]]`,
 		`op = "issues"`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("RenderActionMD output missing %q; got:\n%s", want, body)
 		}
+	}
+	// Negative: the legacy hardcoded ["spawn"] value must not
+	// appear. Pinned here so a future "let's normalize this
+	// back" patch doesn't silently regress.
+	if strings.Contains(body, `capabilities = ["spawn"]`) {
+		t.Errorf("RenderActionMD emitted the buggy capabilities = [\"spawn\"]; should name the op")
 	}
 }
 

--- a/internal/wrap/emit.go
+++ b/internal/wrap/emit.go
@@ -283,7 +283,17 @@ func renderActionMD(s *Spec, sub SubcommandSpec, _ *cstore.Manifest, connectorHa
 	fmt.Fprintf(&b, "name = %q\n", s.Connector.Name)
 	fmt.Fprintf(&b, "version = %q\n", s.Connector.Version)
 	fmt.Fprintf(&b, "hash = %q\n", hash)
-	fmt.Fprintln(&b, `capabilities = ["spawn"]`)
+	// Per ADR-0003 the action's capabilities array names each
+	// op the action's execute steps invoke. Wrap-generated
+	// action.md files have exactly one execute step (one
+	// subcommand per action), so the capabilities array is the
+	// single-element list of that op name. The earlier hardcoded
+	// ["spawn"] was a mis-encoding — the action-boundary check
+	// at executor.go's enforceCapabilityWithSpan compares
+	// step.Op against this list, so a wrapped CLI's op never
+	// matched and every action returned capability_denied
+	// before spawn could fire.
+	fmt.Fprintf(&b, "capabilities = [%q]\n", sub.Name)
 	fmt.Fprintln(&b)
 	if intent := actionIntent(sub); intent != "" {
 		fmt.Fprintln(&b, "[match]")


### PR DESCRIPTION
## Summary

User-reported via testing `aileron pp add linear`:

> the connector's declared capability subset is `["spawn"]` only, so the MCP wrappers return `capability_denied` before they can shell out.

Every wrap-emitted action.md hardcoded `capabilities = ["spawn"]`. Per ADR-0003 the action-boundary check at `executor.go:222` (`enforceCapabilityWithSpan`) matches `step.Op` against the action's `requires.connectors[N].capabilities` array. For a wrapped `linear-pp-cli issues` subcommand, `step.Op = "issues"` but the array is `["spawn"]` — so `EnforceCapability` returns `capability_denied` before the spawn primitive even runs.

This bug has been latent in every `aileron action wrap`-generated action since v2. The Linear install is the first known case where someone invoked a wrapped CLI through the full agent path; earlier wraps were exercised only through tests that called `Parse()` but never the executor.

## Fix

`wrap.renderActionMD` emits `capabilities = [<op-name>]` instead of `["spawn"]`. The action.md generated for a subcommand named `issues` now reads:

```toml
[[requires.connectors]]
name = "local://user/linear"
version = "0.0.1"
hash = "sha256:bound-at-install"
capabilities = ["issues"]
```

## Test

- `TestRenderActionMD_EmitsValidFrontmatter` updated to assert `capabilities = ["issues"]` for an `issues` subcommand.
- Plus a negative assert that the buggy `["spawn"]` value never reappears, so a future patch can't silently regress this.

Affects both `aileron action wrap` (manual) and BYOCLI (`aileron cli add` / `aileron pp add`) paths — they share `wrap.renderActionMD`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)