### PR TITLE
fix(cli): initialize vault when first credential lands via `pp/cli add`

### DIFF
--- a/cmd/aileron/cli_command.go
+++ b/cmd/aileron/cli_command.go
@@ -851,13 +851,56 @@ func stashCredentialBindings(connectorFQN, connectorName string, keys []string, 
 	}
 
 	vaultPath := launch.DefaultVaultPath()
-	passphrase, _, err := readVaultPassphrase(passphraseFile, "Vault passphrase: ", stderr)
+
+	// Detect whether this is a fresh vault so we can print the
+	// irretrievable-passphrase banner before the user picks a
+	// passphrase. Mirrors the contract `aileron vault init` and
+	// `aileron secret set` establish — `cli add` / `pp add` are
+	// often the user's first vault-touching command (a brand-new
+	// laptop running `aileron pp add linear`), and a passphrase
+	// prompt without the new-vault context is alarming.
+	isNewVault := true
+	if fv, openErr := vault.NewFileVault(vaultPath); openErr == nil {
+		isNewVault = !fv.HasContents()
+	}
+	if isNewVault && willPromptInteractively(passphraseFile) {
+		printNewVaultBanner(stderr, vaultPath)
+	}
+
+	passphrase, source, err := readVaultPassphrase(passphraseFile, "Vault passphrase: ", stderr)
 	if err != nil {
 		return 0, fmt.Errorf("read vault passphrase: %w", err)
 	}
 	if passphrase == "" {
 		return 0, errors.New("vault passphrase is required to stash credentials")
 	}
+
+	// First-touch vault: require interactive confirmation so a
+	// typo doesn't lock the user out of their own credential
+	// forever. Skipped for file/env passphrase sources (CI,
+	// scripts) since re-reading the same source would just
+	// confirm itself.
+	if isNewVault && source == passphraseSourceInteractive {
+		confirm, _, confErr := readVaultPassphrase("", "Confirm passphrase: ", stderr)
+		if confErr != nil {
+			return 0, fmt.Errorf("read confirmation passphrase: %w", confErr)
+		}
+		if confirm != passphrase {
+			return 0, errors.New("passphrases do not match; aborting credential stash")
+		}
+	}
+
+	// Initialize the vault file if this is the first write. The
+	// vault file has to exist with a verification blob keyed to
+	// the passphrase before OpenLocalVault accepts it; without
+	// this `pp add` against a fresh ~/.aileron would error out
+	// of the open call with "no verification blob."
+	if isNewVault {
+		if _, initErr := vault.Init(vaultPath, passphrase); initErr != nil && !errors.Is(initErr, vault.ErrVaultExists) {
+			return 0, fmt.Errorf("create vault at %s: %w", vaultPath, initErr)
+		}
+	}
+
 	v, err := launch.OpenLocalVault(vaultPath, passphrase)
 	if err != nil {
 		return 0, fmt.Errorf("open vault: %w", err)

--- a/cmd/aileron/cli_command_credentials_test.go
+++ b/cmd/aileron/cli_command_credentials_test.go
@@ -334,9 +334,16 @@ func TestStashCredentialBindings_WritesBindingToVault(t *testing.T) {
 
 	prevPrompt := promptPassphrase
 	t.Cleanup(func() { promptPassphrase = prevPrompt })
-	// First call: credential value. Second call: passphrase.
+	// Prompt sequence for a fresh vault:
+	//   1. credential value
+	//   2. vault passphrase
+	//   3. confirm passphrase (new-vault interactive flow)
 	calls := 0
-	canned := []string{"super-secret-token-bytes", "vault-passphrase-1"}
+	canned := []string{
+		"super-secret-token-bytes",
+		"vault-passphrase-1",
+		"vault-passphrase-1",
+	}
 	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
 		v := canned[calls]
 		calls++
@@ -357,6 +364,78 @@ func TestStashCredentialBindings_WritesBindingToVault(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "Stashed credential under binding api_key/linear/default") {
 		t.Errorf("stdout missing success line: %q", stdout.String())
+	}
+}
+
+func TestStashCredentialBindings_NewVaultPromptsConfirmAndShowsBanner(t *testing.T) {
+	// Reported by user: aileron pp add against a fresh ~/.aileron
+	// asked for a passphrase with no context about creating a new
+	// vault, and didn't ask for confirmation — a typo would lock
+	// the user out of the credential they just typed. Verify the
+	// fresh-vault path now (a) prints the new-vault banner and
+	// (b) prompts twice (passphrase + confirm) before stashing.
+	home := fakeHome(t)
+	_ = home
+
+	prevPrompt := promptPassphrase
+	t.Cleanup(func() { promptPassphrase = prevPrompt })
+	calls := 0
+	canned := []string{
+		"sekrit-value",  // credential
+		"pass",          // passphrase
+		"pass",          // confirm
+	}
+	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
+		v := canned[calls]
+		calls++
+		return v, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	written, err := stashCredentialBindings(
+		"local://user/freshcli", "freshcli",
+		[]string{"FRESHCLI_API_KEY"}, "",
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if err != nil {
+		t.Fatalf("stash: %v", err)
+	}
+	if written != 1 {
+		t.Errorf("written=%d want 1", written)
+	}
+	if !strings.Contains(stderr.String(), "Vault") && !strings.Contains(stderr.String(), "vault") {
+		t.Errorf("expected new-vault banner on stderr; got: %q", stderr.String())
+	}
+	if calls != 3 {
+		t.Errorf("expected 3 prompts (credential + passphrase + confirm), got %d", calls)
+	}
+}
+
+func TestStashCredentialBindings_NewVaultMismatchedConfirm(t *testing.T) {
+	// Typo on confirm must reject the stash so the user doesn't
+	// lock themselves out of the credential they just typed.
+	fakeHome(t)
+	prevPrompt := promptPassphrase
+	t.Cleanup(func() { promptPassphrase = prevPrompt })
+	calls := 0
+	canned := []string{"value", "pass-one", "pass-two"} // confirm differs
+	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
+		v := canned[calls]
+		calls++
+		return v, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	_, err := stashCredentialBindings(
+		"local://user/typo", "typo",
+		[]string{"TYPO_API_KEY"}, "",
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if err == nil {
+		t.Fatal("expected error when confirm doesn't match")
+	}
+	if !strings.Contains(err.Error(), "do not match") {
+		t.Errorf("error should mention passphrase mismatch: %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Reported by user:

> When aileron daemon is not running, and with a deleted ~/.aileron, running "aileron pp add linear" asks me for my vault passphrase — but there's no vault! I don't see how it could possibly be adding the LINEAR_API_KEY to the vault when the "pp" command doesn't ask me to create/open the vault before it starts.

Right — `stashCredentialBindings` was missing the new-vault detection + banner + confirmation idiom that `aileron vault init` and `aileron secret set` follow. On a fresh `~/.aileron`, `pp add` prompted "Vault passphrase:" with no context, didn't confirm, and `launch.OpenLocalVault` errored out because no verification blob existed yet. A typo would silently lock the user out of the credential they just typed.

## Fix

Four things added to `stashCredentialBindings`, mirroring `aileron vault init` / `aileron secret set`:

1. **New-vault detection** — open the vault file (or absent file) and check `HasContents()`.
2. **New-vault banner** — print the irretrievable-passphrase warning before prompt fires when the vault is fresh AND the prompt is interactive (gated on `willPromptInteractively` so `--passphrase-file` scripts skip the banner).
3. **Confirmation prompt** — for interactive entry on a fresh vault, re-prompt for the passphrase and reject on mismatch.
4. **Vault initialization** — call `vault.Init` explicitly when the file doesn't yet exist; without this, `OpenLocalVault` on a missing verification blob errors out and the credential never lands.

## Tests

- `TestStashCredentialBindings_NewVaultPromptsConfirmAndShowsBanner` — pins the three-prompt sequence (credential + passphrase + confirm) and asserts the new-vault banner appears.
- `TestStashCredentialBindings_NewVaultMismatchedConfirm` — pins the rejection path on typo so a future refactor can't quietly drop confirmation.
- Existing `TestStashCredentialBindings_WritesBindingToVault` updated to feed three canned values instead of two.

🤖 Generated with [Claude Code](https://claude.com/claude-code)