### PR TITLE
docs: support draft pages, hide BlueBubbles/iMessage from prod

### DIFF
--- a/docs/src/content.config.ts
+++ b/docs/src/content.config.ts
@@ -7,7 +7,10 @@ const docs = defineCollection({
   schema: z.object({
     title: z.string(),
     description: z.string().optional(),
-    order: z.number().optional()
+    order: z.number().optional(),
+    // When true, the page is excluded from production builds (both as a route
+    // and from the sidebar). Visible in `astro dev` so authors can preview.
+    draft: z.boolean().default(false)
   })
 });
 

--- a/docs/src/content/docs/actions/imessage-via-bluebubbles.md
+++ b/docs/src/content/docs/actions/imessage-via-bluebubbles.md
@@ -2,6 +2,7 @@
 title: "iMessage via BlueBubbles"
 description: "Three actions for reading iMessage conversations and sending new ones through a local BlueBubbles bridge on macOS."
 order: 2
+draft: true
 ---
 
 The iMessage via BlueBubbles suite gives your agent three capabilities against the user's iMessage history: list recent conversations, read a single conversation, and send a new message. Send is gated by per-call user approval; reads run without prompting.

--- a/docs/src/content/docs/guides/setting-up-bluebubbles.md
+++ b/docs/src/content/docs/guides/setting-up-bluebubbles.md
@@ -1,6 +1,7 @@
 ---
 title: "Setting up BlueBubbles for Aileron"
 description: "Prerequisite for the iMessage connector: install BlueBubbles Server on your Mac, grant the OS permissions it needs, and verify Aileron can reach it."
+draft: true
 ---
 
 The Aileron iMessage connector doesn't touch your Mac's Messages app directly. Instead it talks to **BlueBubbles**, a free open-source server you run locally. BlueBubbles handles the platform-specific work (reading the iMessage history, sending new messages, listening for incoming ones) and exposes a simple HTTP API on your machine. Aileron talks to that API.

--- a/docs/src/content/docs/guides/wrapping-a-cli.md
+++ b/docs/src/content/docs/guides/wrapping-a-cli.md
@@ -12,8 +12,6 @@ Both paths produce the same shape: a connector manifest at `~/.aileron/connector
 
 This is the spawn primitive's payoff (per [ADR-0002](/adr/0002-connector-model)'s spawn-primitive section). Where [Authoring a Connector](/guides/authoring-a-connector/) is the path for new services that need their own WASM, this is the path for the long tail of existing CLIs (`gh`, `slackdump`, anything that already does the work you want the agent to compose with).
 
-> **Not for iMessage.** Apple's data model is locked down enough that there is no usable CLI to wrap. The iMessage connector takes a different path: it talks over HTTP to a local [BlueBubbles](https://bluebubbles.app/) bridge that holds the platform permissions instead. See [Setting up BlueBubbles for Aileron](/guides/setting-up-bluebubbles/).
-
 ## Quick start: PrintingPress
 
 ```sh
@@ -567,4 +565,3 @@ Reach for something other than wrapping when:
 - [ADR-0014: Spawn Sandbox Technology](/adr/0014-spawn-sandbox-technology) — what kernel mechanism confines the subprocess on each platform.
 - [Authoring a Connector](/guides/authoring-a-connector/) — for services that need their own WASM rather than a CLI wrap.
 - [Publishing a Connector](/guides/publishing-a-connector/) — if you want to publish your manifest under a stable FQN for others to install.
-- [Setting up BlueBubbles for Aileron](/guides/setting-up-bluebubbles/) — the iMessage path, which uses HTTP-to-a-local-bridge instead of a CLI wrap.

--- a/docs/src/content/docs/index.mdx
+++ b/docs/src/content/docs/index.mdx
@@ -39,7 +39,7 @@ Authorize Gmail and Calendar in your browser... done
 
 Claude Code now has six Gmail and Calendar capabilities in its catalog: list recent emails, list upcoming events, get an email, draft an email, send an email, and create a calendar event. The first four run silently when your agent reaches for them. The last two pause for your approval. Sent mail and a placed event aren't things you take back.
 
-Aileron ships connectors for Slack and iMessage today, and `aileron pp add <name>` or `aileron cli add <path>` turns any CLI you already use into a sandboxed capability your agent can call. Browse the full catalog in [Actions](/actions/gmail-and-google-calendar/).
+Aileron ships a Slack connector today, and `aileron pp add <name>` or `aileron cli add <path>` turns any CLI you already use into a sandboxed capability your agent can call. Browse the full catalog in [Actions](/actions/gmail-and-google-calendar/).
 
 ## Put first principles back into AI
 
@@ -60,7 +60,7 @@ Aileron adds three fundamentals of quality software to your agent.
 </Feature>
 
 <Feature icon={KeyRound} title="Security">
-  Your keys never reach the LLM. Gmail, Slack, iMessage, and every other service live in a vault Aileron alone uses. The LLM sees results, not secrets.
+  Your keys never reach the LLM. Gmail, Slack, and every other service live in a vault Aileron alone uses. The LLM sees results, not secrets.
 </Feature>
 
 </div>
@@ -71,7 +71,7 @@ The result: AI and traditional software each do what they're best at, in the sam
 
 A few ideas that map to what Aileron ships today.
 
-<div class="not-prose grid gap-4 md:grid-cols-3 my-6">
+<div class="not-prose grid gap-4 md:grid-cols-2 my-6">
 
 <Card.Root>
   <Card.Header>
@@ -82,19 +82,6 @@ A few ideas that map to what Aileron ships today.
 _"Summarize what I missed over the weekend in `#engineering` and draft a reply to the thread about the migration."_
 
 The agent calls `search-messages` and `list-channels` from the [Slack connector](/actions/slack/), synthesizes a summary, then proposes a reply. The approval card surfaces in your local webapp. You tap approve and Aileron posts as you through `send-message`.
-
-  </Card.Content>
-</Card.Root>
-
-<Card.Root>
-  <Card.Header>
-    <Card.Title>iMessage from your inbox</Card.Title>
-  </Card.Header>
-  <Card.Content class="text-muted-foreground space-y-3">
-
-_"When the Amazon delivery email arrives, text my partner."_
-
-The agent watches Gmail through `list-recent-emails`, spots the delivery confirmation, drafts the message, and surfaces it for your approval. You tap approve and Aileron sends through [iMessage via BlueBubbles](/actions/imessage-via-bluebubbles/).
 
   </Card.Content>
 </Card.Root>
@@ -143,7 +130,7 @@ Your agent's existing MCP servers keep exposing tools the same way. The LLM stil
 The architecture above is real, shipped, and runs against real APIs. Three milestones anchor it:
 
 - **[Milestone v1](https://github.com/ALRubinger/aileron/issues/493)** — First end-to-end install-and-execute path. A signed reference connector ([`aileron-connector-google`](https://github.com/ALRubinger/aileron-connector-google)) is installed by FQN, six Gmail and Calendar actions are bound to OAuth credentials in the local vault, and `aileron launch claude` runs the whole loop with sealed credentials, capability bounds, and audit emission. Ratified by 11 ADRs at [docs.withaileron.ai/adr](/adr/).
-- **[Milestone v2](https://github.com/ALRubinger/aileron/issues/505)** — Personal-context demo for power users. Adds the spawn capability primitive ([ADR-0002](/adr/0002-connector-model/), [ADR-0014](/adr/0014-spawn-sandbox-technology/)) so sandboxed connectors can request the host to run a bounded local CLI subprocess. The shared spawn-forwarder lets you wrap any CLI with a manifest, no per-tool WASM build. Native HTTP connectors for [Slack](/actions/slack/) and [iMessage via BlueBubbles](/actions/imessage-via-bluebubbles/) ship alongside the [Wrapping a CLI](/guides/wrapping-a-cli/) guide.
+- **[Milestone v2](https://github.com/ALRubinger/aileron/issues/505)** — Personal-context demo for power users. Adds the spawn capability primitive ([ADR-0002](/adr/0002-connector-model/), [ADR-0014](/adr/0014-spawn-sandbox-technology/)) so sandboxed connectors can request the host to run a bounded local CLI subprocess. The shared spawn-forwarder lets you wrap any CLI with a manifest, no per-tool WASM build. A native HTTP [Slack connector](/actions/slack/) ships alongside the [Wrapping a CLI](/guides/wrapping-a-cli/) guide.
 - **[Milestone v3](https://github.com/ALRubinger/aileron/issues/584)** — BYOCLI: one-command CLI wrapping. `aileron cli add <path>` introspects an installed binary's `--help` inside the spawn sandbox, generates the connector manifest, prompts once for any credential env var, and writes a vault binding. `aileron pp add <name>` does the same starting from the [PrintingPress](https://printingpress.dev/) catalog — fetches the live `registry.json`, runs `go install`, hands off to the introspector. Closes the gap between "I have a CLI on my laptop" and "my agent can call it sandboxed and audited" to one command.
 
 The [ADR index](/adr/) is the canonical record of every architectural decision that got us here.

--- a/docs/src/layouts/BaseLayout.astro
+++ b/docs/src/layouts/BaseLayout.astro
@@ -1,6 +1,7 @@
 ---
+import { getCollection } from 'astro:content';
 import Sidebar from '../components/Sidebar.svelte';
-import { navigation } from '../lib/navigation';
+import { navigation, isSection, type NavItem } from '../lib/navigation';
 import '../styles/global.css';
 
 interface Props {
@@ -10,11 +11,28 @@ interface Props {
 const { title } = Astro.props;
 const currentPath = Astro.url.pathname;
 
-// Navigation is currently a flat structure (homepage only).
-// Historical content lives in `docs/archive/` off-site; nav will be rebuilt as
-// new pages are written. ADR auto-injection from content collections has been
-// removed since both `adr/` and `archived-adr/` are now archived off-site.
-const nav = navigation;
+// In production, hide nav entries pointing at pages marked `draft: true` in
+// frontmatter. Sections that become empty after filtering are dropped too.
+// In dev, the full nav is shown so authors can navigate to drafts.
+const draftEntries = await getCollection('docs', ({ data }) => data.draft === true);
+const draftHrefs = new Set(
+  draftEntries.map((e) => (e.id === 'index' ? '/' : `/${e.id}/`))
+);
+
+function filterNav(items: NavItem[]): NavItem[] {
+  const result: NavItem[] = [];
+  for (const item of items) {
+    if (isSection(item)) {
+      const children = filterNav(item.children);
+      if (children.length > 0) result.push({ ...item, children });
+    } else if (!draftHrefs.has(item.href)) {
+      result.push(item);
+    }
+  }
+  return result;
+}
+
+const nav = import.meta.env.PROD ? filterNav(navigation) : navigation;
 ---
 
 <!doctype html>

--- a/docs/src/pages/[...slug].astro
+++ b/docs/src/pages/[...slug].astro
@@ -5,7 +5,9 @@ import SectionBreak from '../lib/components/section-break.astro';
 import SectionResume from '../lib/components/section-resume.astro';
 
 export async function getStaticPaths() {
-  const docs = await getCollection('docs');
+  const docs = await getCollection('docs', ({ data }) =>
+    !import.meta.env.PROD || !data.draft
+  );
   return docs.map((entry) => ({
     params: { slug: entry.id === 'index' ? undefined : entry.id },
     props: { entry }

--- a/docs/src/pages/raw/[...slug].astro
+++ b/docs/src/pages/raw/[...slug].astro
@@ -3,7 +3,9 @@ import { getCollection } from 'astro:content';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 
 export async function getStaticPaths() {
-  const docs = await getCollection('docs');
+  const docs = await getCollection('docs', ({ data }) =>
+    !import.meta.env.PROD || !data.draft
+  );
   return docs.map((entry) => ({
     params: { slug: entry.id === 'index' ? undefined : entry.id },
     props: { entry }


### PR DESCRIPTION
## Summary

- Adds a `draft: boolean` field (default `false`) to the docs content schema. In `astro build` (prod), draft pages are excluded from `getStaticPaths` for both the formatted and `/raw/` routes, and the sidebar filter in `BaseLayout.astro` strips matching nav entries (and any sections that empty out as a result). In `astro dev`, drafts render normally so authors can preview locally.
- Marks two pages as `draft: true`: `actions/imessage-via-bluebubbles.md` and `guides/setting-up-bluebubbles.md`.
- Removes the inbound promotional links and surrounding context from non-draft pages so prod has no references to the connector:
  - `index.mdx` — drops "and iMessage" from the connectors blurb, drops "iMessage" from the security feature card, removes the "iMessage from your inbox" use-case card (and switches the surrounding grid to `md:grid-cols-2` so the remaining two cards lay out cleanly), and trims the iMessage half from the Milestone v2 bullet
  - `guides/wrapping-a-cli.md` — removes the "Not for iMessage" blockquote callout and the BlueBubbles bullet from "See also"

Prod build went from 95 → 93 pages; `grep -ril 'bluebubbles\|imessage' docs/dist/` returns nothing.

## Test plan

- [x] `pnpm run build` succeeds and produces 93 pages
- [x] No files matching `*bluebubbles*` or `*imessage*` are emitted under `docs/dist/`
- [x] Sidebar in built `getting-started/index.html` has zero matches for either string (only inbound mentions remain in body content of pages where they were intentional)
- [ ] Local `astro dev` preview shows both draft pages in the sidebar and serves their routes (manual preview before merge)

🤖 Generated with [Claude Code](https://claude.com/claude-code)