### PR TITLE
fix(wrap): namespace local action names by connector leaf (#781)

### DIFF
--- a/internal/wrap/credentials_test.go
+++ b/internal/wrap/credentials_test.go
@@ -189,7 +189,10 @@ func TestRenderActionMD_EmitsValidFrontmatter(t *testing.T) {
 	body := RenderActionMD(spec, sub, nil, "")
 	for _, want := range []string{
 		"+++",
-		`name = "issues"`,
+		// Action name is namespaced by connector leaf per #781
+		// so the action store doesn't silently collide two
+		// wraps sharing the same op name.
+		`name = "linear-issues"`,
 		`version = "0.0.1"`,
 		`[[requires.connectors]]`,
 		`name = "local://user/linear"`,
@@ -229,6 +232,60 @@ func TestRenderActionMD_HonorsExplicitHash(t *testing.T) {
 	}
 	if strings.Contains(body, "bound-at-install") {
 		t.Errorf("placeholder should not appear when explicit hash supplied: %s", body)
+	}
+}
+
+func TestActionName_NamespacedByConnectorLeaf(t *testing.T) {
+	// Regression for #781: the action.md `name` field must agree
+	// with the filename so the daemon's action-store map (keyed
+	// on `name`) doesn't silently collide when two wraps share
+	// an op (e.g. `linear-pp-cli`'s `auth` vs. a hypothetical
+	// `sentry-pp-cli`'s `auth`).
+	cases := []struct {
+		fqn  string
+		op   string
+		want string
+	}{
+		{"local://user/linear", "issues", "linear-issues"},
+		{"github://acme/gitcrawl", "log", "gitcrawl-log"},
+		{"github://acme/integrations/connectors/imsg", "send", "imsg-send"},
+		// FQN without a leaf segment falls through to the bare
+		// op — defensive only; production FQNs are parsed first.
+		{"barename", "do", "do"},
+	}
+	for _, c := range cases {
+		s := &Spec{Connector: ConnectorSpec{Name: c.fqn}}
+		if got := ActionName(s, SubcommandSpec{Name: c.op}); got != c.want {
+			t.Errorf("ActionName(%q, %q) = %q, want %q", c.fqn, c.op, got, c.want)
+		}
+	}
+}
+
+func TestRenderActionMD_NoCollisionBetweenWrapsSharingAnOp(t *testing.T) {
+	// Concretely: install two distinct wraps whose subcommand sets
+	// overlap on `auth`. Pre-#781 the rendered action.md files both
+	// declared `name = "auth"` and the second load would stomp the
+	// first in the action store. With the namespacing fix, the
+	// rendered names diverge (`linear-auth`, `sentry-auth`) and
+	// both coexist.
+	linear := &Spec{
+		Connector:   ConnectorSpec{Name: "local://user/linear", Version: "0.0.1"},
+		Subcommands: []SubcommandSpec{{Name: "auth"}},
+	}
+	sentry := &Spec{
+		Connector:   ConnectorSpec{Name: "local://user/sentry", Version: "0.0.1"},
+		Subcommands: []SubcommandSpec{{Name: "auth"}},
+	}
+	linearBody := RenderActionMD(linear, linear.Subcommands[0], nil, "")
+	sentryBody := RenderActionMD(sentry, sentry.Subcommands[0], nil, "")
+	if !strings.Contains(linearBody, `name = "linear-auth"`) {
+		t.Errorf("linear action.md missing namespaced name; got:\n%s", linearBody)
+	}
+	if !strings.Contains(sentryBody, `name = "sentry-auth"`) {
+		t.Errorf("sentry action.md missing namespaced name; got:\n%s", sentryBody)
+	}
+	if strings.Contains(linearBody, `name = "auth"`+"\n") {
+		t.Errorf("linear action.md still declares bare `auth` name; the action store would collide with sentry")
 	}
 }
 

--- a/internal/wrap/emit.go
+++ b/internal/wrap/emit.go
@@ -155,11 +155,27 @@ func ActionFileName(s *Spec, sub SubcommandSpec) string {
 }
 
 func actionFileName(s *Spec, sub SubcommandSpec) string {
+	return ActionName(s, sub) + ".md"
+}
+
+// ActionName returns the registered action name for a wrapped
+// subcommand: `<connector-leaf>-<op>` when the FQN has a leaf
+// segment, or the bare op otherwise. The action store keys on
+// this value, so namespacing it by connector prevents silent
+// collisions between wraps with overlapping op names (e.g. two
+// CLIs both exposing an "auth" op).
+//
+// Action filenames already followed this convention via
+// [ActionFileName]; pre-#781 the filename and the action.md's
+// `name` field disagreed (filename namespaced, name bare), which
+// let two wraps stomp each other in the action store's
+// name-keyed map.
+func ActionName(s *Spec, sub SubcommandSpec) string {
 	prefix := connectorLeaf(s.Connector.Name)
 	if prefix == "" {
-		return sub.Name + ".md"
+		return sub.Name
 	}
-	return prefix + "-" + sub.Name + ".md"
+	return prefix + "-" + sub.Name
 }
 
 // connectorLeaf returns the last `/`-separated path segment of the
@@ -275,7 +291,14 @@ func renderActionMD(s *Spec, sub SubcommandSpec, _ *cstore.Manifest, connectorHa
 	}
 	var b strings.Builder
 	fmt.Fprintln(&b, frontmatterDelim)
-	fmt.Fprintf(&b, "name = %q\n", sub.Name)
+	// Top-level action name is namespaced by connector leaf
+	// (`<leaf>-<op>`) so the daemon's action-store name-keyed map
+	// doesn't silently overwrite when two wraps share an op (e.g.
+	// two CLIs both with `auth`). The action's filename has used
+	// this convention since the wrap package's introduction;
+	// before #781 the `name` field disagreed with the filename,
+	// which is what let the collision through.
+	fmt.Fprintf(&b, "name = %q\n", ActionName(s, sub))
 	fmt.Fprintf(&b, "version = %q\n", s.Connector.Version)
 	fmt.Fprintf(&b, "source = %q\n", actionSource(s, sub))
 	fmt.Fprintln(&b)

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -300,8 +300,11 @@ func TestEmit_ActionMDIsParseableByActionLoader(t *testing.T) {
 	if parseErr != nil {
 		t.Fatalf("emitted action.md does not parse: %v\n%s", parseErr, body)
 	}
-	if manifest.Name != "log" {
-		t.Errorf("manifest.Name = %q, want log", manifest.Name)
+	// Per #781 the rendered name is namespaced by the connector
+	// leaf so two wraps with overlapping op names don't collide
+	// in the action store's name-keyed map.
+	if manifest.Name != "gitcrawl-log" {
+		t.Errorf("manifest.Name = %q, want gitcrawl-log", manifest.Name)
 	}
 	if got := len(manifest.Requires.Connectors); got != 1 {
 		t.Fatalf("requires.connectors len = %d, want 1", got)


### PR DESCRIPTION
## Summary

Closes #781. Sub-PR for umbrella #786.

The action.md `name` field rendered by `wrap.renderActionMD` was the bare op (`issues`, `auth`, `teams`). Filenames were already prefixed (`linear-issues.md`) via `actionFileName`, but the action store keys on `name`, so two wrapped CLIs with overlapping ops (e.g. Linear's `auth` vs. a hypothetical Sentry's `auth`) silently overwrote each other in the name-keyed map.

After this change:

- Action.md `name` field: `<connector-leaf>-<op>` (e.g. `linear-issues`, `sentry-auth`)
- `[[execute]] op` and `capabilities`: still the bare op — the action-boundary check at `internal/action/executor.go:enforceCapabilityWithSpan` compares `step.Op` against `c.Capabilities` and the spawn forwarder routes on the bare op.

Adds an `ActionName` helper exported alongside `ActionFileName` so callers can derive the registered name without re-implementing the leaf-prefix rule.

## Test plan

- [x] `go test ./internal/wrap/...` — new regression `TestRenderActionMD_NoCollisionBetweenWrapsSharingAnOp` exercises two wraps sharing `auth` and asserts distinct rendered names.
- [x] `go test ./internal/wrap/...` — coverage 88.8%.
- [x] `go test ./cmd/aileron/...` — no regressions in BYOCLI install paths.
- [x] Updated `TestRenderActionMD_EmitsValidFrontmatter` and `TestEmit_ActionMDIsParseableByActionLoader` to assert on the namespaced shape; both pass.

🤖 Generated with [Claude Code](https://claude.com/claude-code)