### PR TITLE
fix(pp): install wrapped binaries under sandbox-bin, not GOBIN (#780)

### DIFF
--- a/cmd/aileron/pp_command.go
+++ b/cmd/aileron/pp_command.go
@@ -13,6 +13,8 @@ import (
 	"path/filepath"
 	"strings"
 	"time"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
 )
 
 // runPp dispatches `aileron pp <subcommand>`. The `pp` namespace
@@ -67,10 +69,16 @@ flags for ` + "`aileron pp add`" + `:
 //     `github.com/mvanhorn/printing-press-library/<path>`.
 //  5. Print the install plan (module + source URL + binary name)
 //     and require confirmation (unless --yes).
-//  6. Run `go install <module>@latest`. Output streams to the
-//     user's stdout/stderr so they see the toolchain's progress.
-//  7. Locate the installed binary at $GOBIN/<name>-pp-cli (with
-//     fallbacks).
+//  6. Run `go install <module>@latest` with `GOBIN` overridden to
+//     the per-connector sandbox-bin directory
+//     (~/.aileron/connectors/local/<name>/bin) so the binary
+//     never lands on the user's `$PATH`. Closes the credential-
+//     sealing bypass that let agents reach the wrapped CLI via
+//     raw shell (#780). Output streams to the user's stdout/
+//     stderr so they see the toolchain's progress.
+//  7. The binary path is deterministic — `<sandbox-bin>/<binary>`
+//     — so the post-install resolution is a single fileExists
+//     check rather than a GOBIN/GOPATH/$PATH walk.
 //  8. Hand off to runCliAdd against that binary. The introspector
 //     + credential capture from #755 + #759 do the rest.
 func runPpAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
@@ -109,13 +117,16 @@ func runPpAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	packagePath := ppPackagePath(entry.Path, name)
 	sourceURL := ppSourceURL(entry.Path)
 	binaryName := name + "-pp-cli"
+	sandboxBinDir := cstore.LocalConnectorBinDir(name)
+	binPath := filepath.Join(sandboxBinDir, binaryName)
 
 	fmt.Fprintln(stdout)
 	fmt.Fprintf(stdout, "Install plan for %s:\n", name)
 	fmt.Fprintf(stdout, "  Module:   %s\n", modulePath)
 	fmt.Fprintf(stdout, "  Package:  %s@latest\n", packagePath)
 	fmt.Fprintf(stdout, "  Source:   %s\n", sourceURL)
-	fmt.Fprintf(stdout, "  Binary:   %s (installed to $GOBIN)\n", binaryName)
+	fmt.Fprintf(stdout, "  Binary:   %s\n", binaryName)
+	fmt.Fprintf(stdout, "  Install:  %s (not on $PATH; reached via Aileron's spawn primitive)\n", binPath)
 	fmt.Fprintf(stdout, "  Wrap as:  local://user/%s\n", name)
 	if entry.MCP != nil && len(entry.MCP.EnvVars) > 0 {
 		fmt.Fprintf(stdout, "  Creds:    %s (catalog-declared; prompted after install)\n", strings.Join(entry.MCP.EnvVars, ", "))
@@ -135,16 +146,25 @@ func runPpAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		}
 	}
 
-	fmt.Fprintf(stdout, "\nRunning `go install %s@latest`…\n", packagePath)
-	if err := runGoInstall(packagePath, stdout, stderr); err != nil {
+	// Create the per-connector sandbox-bin directory before
+	// invoking `go install`; the toolchain refuses to write to a
+	// nonexistent GOBIN. Mode 0o755 matches DefaultLocalRoot's
+	// directory mode so the daemon's connector loader can stat
+	// the path without permission surprises.
+	if err := os.MkdirAll(sandboxBinDir, 0o755); err != nil {
+		fmt.Fprintf(stderr, "error: create sandbox bin dir %s: %v\n", sandboxBinDir, err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "\nRunning `GOBIN=%s go install %s@latest`…\n", sandboxBinDir, packagePath)
+	if err := runGoInstall(packagePath, sandboxBinDir, stdout, stderr); err != nil {
 		fmt.Fprintf(stderr, "error: go install: %v\n", err)
 		return 1
 	}
 
-	binPath, err := resolveInstalledBinary(binaryName)
-	if err != nil {
-		fmt.Fprintf(stderr, "error: locate installed binary: %v\n", err)
-		fmt.Fprintln(stderr, "Check that $GOBIN (or $(go env GOPATH)/bin) is on your $PATH.")
+	if !fileExists(binPath) {
+		fmt.Fprintf(stderr, "error: expected binary at %s after go install but the file is missing\n", binPath)
+		fmt.Fprintln(stderr, "This usually means the package's main binary name differs from `<name>-pp-cli`. Check the catalog entry.")
 		return 1
 	}
 
@@ -352,50 +372,32 @@ func requireGoOnPath() error {
 }
 
 // runGoInstall shells out to `go install <module>@latest` with
-// the user's full environment, streaming output to the caller's
-// stdout/stderr. The user sees the toolchain's progress and any
-// build error directly. Per family rule "trust internal code,"
-// the function relies on exec.LookPath having already verified
-// `go` is present.
+// GOBIN overridden to the per-connector sandbox-bin directory,
+// streaming output to the caller's stdout/stderr. The user sees
+// the toolchain's progress and any build error directly. Per
+// family rule "trust internal code," the function relies on
+// exec.LookPath having already verified `go` is present.
+//
+// `gobin` is the absolute path the toolchain writes the resulting
+// binary to. Pinning GOBIN per-install (rather than relying on
+// whatever GOBIN/GOPATH the user has globally) is the load-bearing
+// piece of #780's credential-sealing fix — without it the binary
+// lands on `$PATH` and any shell-capable agent can bypass
+// Aileron's vault-mediated credential injection.
 //
 // Indirected through a package-level var so tests can swap in a
 // fake without forking a real `go` process.
-var runGoInstall = func(modulePath string, stdout, stderr io.Writer) error {
+var runGoInstall = func(modulePath, gobin string, stdout, stderr io.Writer) error {
 	cmd := exec.Command("go", "install", modulePath+"@latest")
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
-	cmd.Env = os.Environ()
+	// Appending after os.Environ() lets our GOBIN override any
+	// pre-existing GOBIN the user set in their shell — the Go
+	// toolchain reads `os.Getenv("GOBIN")` which returns the last
+	// duplicate. Same idiom as exec/cmd.Run's documented append-
+	// to-override.
+	cmd.Env = append(os.Environ(), "GOBIN="+gobin)
 	return cmd.Run()
-}
-
-// resolveInstalledBinary returns the absolute path of the
-// just-installed binary. Walks the precedence Go's install
-// pipeline writes to:
-//
-//  1. $GOBIN (set explicitly by user)
-//  2. $(go env GOPATH)/bin (the default install destination)
-//  3. exec.LookPath fallback ($PATH lookup)
-//
-// Returns an error when none of the three locations contain the
-// expected binary, so the caller can surface a remediation hint
-// rather than handing a malformed path to the wrapper.
-func resolveInstalledBinary(binaryName string) (string, error) {
-	if bin := os.Getenv("GOBIN"); bin != "" {
-		path := filepath.Join(bin, binaryName)
-		if fileExists(path) {
-			return path, nil
-		}
-	}
-	if gopath, err := goEnvGOPATH(); err == nil && gopath != "" {
-		path := filepath.Join(gopath, "bin", binaryName)
-		if fileExists(path) {
-			return path, nil
-		}
-	}
-	if path, err := exec.LookPath(binaryName); err == nil {
-		return path, nil
-	}
-	return "", fmt.Errorf("binary %q not found in $GOBIN, $(go env GOPATH)/bin, or $PATH after install", binaryName)
 }
 
 // fileExists is a stat-and-discard helper. Doesn't distinguish
@@ -404,16 +406,4 @@ func resolveInstalledBinary(binaryName string) (string, error) {
 func fileExists(path string) bool {
 	_, err := os.Stat(path)
 	return err == nil
-}
-
-// goEnvGOPATH returns the Go toolchain's reported GOPATH, the
-// fallback location `go install` writes to when GOBIN is unset.
-// Indirected so tests can mock without forking `go env`.
-var goEnvGOPATH = func() (string, error) {
-	cmd := exec.Command("go", "env", "GOPATH")
-	out, err := cmd.Output()
-	if err != nil {
-		return "", err
-	}
-	return strings.TrimSpace(string(out)), nil
 }

--- a/cmd/aileron/pp_command_test.go
+++ b/cmd/aileron/pp_command_test.go
@@ -280,7 +280,7 @@ func TestRunPpAdd_DryRunDoesNotInstall(t *testing.T) {
 	called := false
 	prev := runGoInstall
 	t.Cleanup(func() { runGoInstall = prev })
-	runGoInstall = func(modulePath string, stdout, stderr io.Writer) error {
+	runGoInstall = func(modulePath, gobin string, stdout, stderr io.Writer) error {
 		called = true
 		return nil
 	}
@@ -303,6 +303,16 @@ func TestRunPpAdd_DryRunDoesNotInstall(t *testing.T) {
 	}
 	if !strings.Contains(out, "dry-run") {
 		t.Errorf("dry-run notice missing: %q", out)
+	}
+	// Install plan must advertise the sandbox-bin path so users
+	// see where the binary will land before they confirm. Per
+	// #780 this is the credential-sealing fix's user-facing
+	// signal — the binary is *not* on $PATH.
+	if !strings.Contains(out, filepath.Join(".aileron", "connectors", "local", "linear", "bin", "linear-pp-cli")) {
+		t.Errorf("install plan should advertise sandbox-bin path: %q", out)
+	}
+	if !strings.Contains(out, "not on $PATH") {
+		t.Errorf("install plan should call out the not-on-$PATH guarantee: %q", out)
 	}
 }
 
@@ -341,52 +351,6 @@ func TestRunPpAdd_GoMissingFailsLoud(t *testing.T) {
 	}
 }
 
-func TestResolveInstalledBinary_FindsGOBIN(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("GOBIN", dir)
-	target := filepath.Join(dir, "fakecli-pp-cli")
-	if err := os.WriteFile(target, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-	got, err := resolveInstalledBinary("fakecli-pp-cli")
-	if err != nil {
-		t.Fatalf("resolve: %v", err)
-	}
-	if got != target {
-		t.Errorf("got %q want %q", got, target)
-	}
-}
-
-func TestResolveInstalledBinary_FallsBackToGOPATHBin(t *testing.T) {
-	// GOBIN unset, GOPATH custom. Drop the binary in $GOPATH/bin
-	// and verify the fallback finds it.
-	if runtime.GOOS == "windows" {
-		t.Skip("PATHEXT semantics differ on Windows; covered separately")
-	}
-	t.Setenv("GOBIN", "")
-	gopath := t.TempDir()
-	prev := goEnvGOPATH
-	goEnvGOPATH = func() (string, error) { return gopath, nil }
-	t.Cleanup(func() { goEnvGOPATH = prev })
-
-	bindir := filepath.Join(gopath, "bin")
-	if err := os.MkdirAll(bindir, 0o755); err != nil {
-		t.Fatalf("mkdir: %v", err)
-	}
-	target := filepath.Join(bindir, "fallbackcli-pp-cli")
-	if err := os.WriteFile(target, []byte("#!/bin/sh\n"), 0o755); err != nil {
-		t.Fatalf("write: %v", err)
-	}
-
-	got, err := resolveInstalledBinary("fallbackcli-pp-cli")
-	if err != nil {
-		t.Fatalf("resolve: %v", err)
-	}
-	if got != target {
-		t.Errorf("got %q want %q", got, target)
-	}
-}
-
 func TestRunPpAdd_PassesCatalogEnvVarsAsCredentialOverrides(t *testing.T) {
 	// linear-pp-cli's --help doesn't mention LINEAR_API_KEY by
 	// name, so the wrap heuristic alone would skip the credential
@@ -397,7 +361,6 @@ func TestRunPpAdd_PassesCatalogEnvVarsAsCredentialOverrides(t *testing.T) {
 	// (--dry-run) so the test doesn't have to set up the vault.
 	startFixtureCatalog(t)
 	fakeHome(t)
-	t.Setenv("GOBIN", t.TempDir())
 
 	var stdout, stderr bytes.Buffer
 	if code := runPpAdd(
@@ -415,25 +378,29 @@ func TestRunPpAdd_PassesCatalogEnvVarsAsCredentialOverrides(t *testing.T) {
 
 func TestRunPpAdd_HappyPathHandsOffToCliAdd(t *testing.T) {
 	// End-to-end happy path with `go install` mocked. The mock
-	// writes a sandboxtest.FakeBinary to GOBIN/<name>-pp-cli so
-	// the cli-add handoff has a real binary to introspect.
+	// writes a fake binary into the sandbox-bin directory the
+	// installer hands the toolchain via GOBIN — the same path
+	// the cli-add handoff will introspect.
 	// Verifies: catalog lookup → install plan → mocked install
-	// → binary resolution → cli add manifest write.
+	// → sandbox-bin path resolution → cli add manifest write.
 	if runtime.GOOS == "windows" {
 		t.Skip("sandboxtest.FakeBinary is POSIX-only")
 	}
 	startFixtureCatalog(t)
 	home := fakeHome(t)
-	gobin := filepath.Join(t.TempDir(), "gobin")
-	if err := os.MkdirAll(gobin, 0o755); err != nil {
-		t.Fatalf("mkdir gobin: %v", err)
-	}
-	t.Setenv("GOBIN", gobin)
+	sandboxBin := filepath.Join(home, ".aileron", "connectors", "local", "linear", "bin")
 
-	// Mock `go install` to drop a fake binary at the expected path.
+	// Mock `go install` to drop a fake binary at the sandbox-bin
+	// path the installer just told the toolchain to write to.
+	// `gobin` is the GOBIN override the installer set; the mock
+	// honors it so the resulting path matches what the installer
+	// then looks for.
 	prevInstall := runGoInstall
 	t.Cleanup(func() { runGoInstall = prevInstall })
-	runGoInstall = func(modulePath string, stdout, stderr io.Writer) error {
+	runGoInstall = func(modulePath, gobin string, stdout, stderr io.Writer) error {
+		if gobin != sandboxBin {
+			t.Errorf("runGoInstall received GOBIN=%q, want %q (sandbox-bin path under fake home)", gobin, sandboxBin)
+		}
 		const helpText = "linear-pp-cli - Linear CLI\n\nUsage: linear-pp-cli [command]\n\nCommands:\n  issues   List issues\n  create   Create issue\n"
 		path := filepath.Join(gobin, "linear-pp-cli")
 		if err := os.WriteFile(path, []byte("#!/bin/sh\nprintf '%s' '"+helpText+"'\n"), 0o755); err != nil {
@@ -458,6 +425,19 @@ func TestRunPpAdd_HappyPathHandsOffToCliAdd(t *testing.T) {
 	if _, err := os.Stat(manifestPath); err != nil {
 		t.Fatalf("local manifest missing: %v", err)
 	}
+
+	// The manifest's program path must point at the sandbox-bin
+	// install location — not GOBIN/GOPATH/$PATH. This is the
+	// load-bearing #780 assertion: the binary lives where only
+	// Aileron's spawn primitive can find it.
+	manifestBytes, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read manifest: %v", err)
+	}
+	wantProgram := filepath.Join(sandboxBin, "linear-pp-cli")
+	if !strings.Contains(string(manifestBytes), wantProgram) {
+		t.Errorf("manifest does not record sandbox-bin program path %q:\n%s", wantProgram, manifestBytes)
+	}
 }
 
 func TestRunPpAdd_GoInstallFailureSurfacesError(t *testing.T) {
@@ -467,11 +447,10 @@ func TestRunPpAdd_GoInstallFailureSurfacesError(t *testing.T) {
 	// touching the local connector store.
 	startFixtureCatalog(t)
 	fakeHome(t)
-	t.Setenv("GOBIN", t.TempDir())
 
 	prev := runGoInstall
 	t.Cleanup(func() { runGoInstall = prev })
-	runGoInstall = func(modulePath string, stdout, stderr io.Writer) error {
+	runGoInstall = func(modulePath, gobin string, stdout, stderr io.Writer) error {
 		return errors.New("simulated build failure")
 	}
 
@@ -500,16 +479,12 @@ func TestRunPpAdd_PassphraseFileFlagFlowsThrough(t *testing.T) {
 	}
 	startFixtureCatalog(t)
 	home := fakeHome(t)
-	gobin := filepath.Join(t.TempDir(), "gobin")
-	if err := os.MkdirAll(gobin, 0o755); err != nil {
-		t.Fatalf("mkdir gobin: %v", err)
-	}
-	t.Setenv("GOBIN", gobin)
 
 	prev := runGoInstall
 	t.Cleanup(func() { runGoInstall = prev })
-	runGoInstall = func(modulePath string, stdout, stderr io.Writer) error {
-		// Drop a non-trivial fake at the expected path.
+	runGoInstall = func(modulePath, gobin string, stdout, stderr io.Writer) error {
+		// Drop a non-trivial fake at the sandbox-bin path the
+		// installer just told the toolchain to write to.
 		const helpText = "Commands:\n  do  do thing\n"
 		body := "#!/bin/sh\nprintf '%s' '" + helpText + "'\n"
 		return os.WriteFile(filepath.Join(gobin, "linear-pp-cli"), []byte(body), 0o755)
@@ -546,12 +521,13 @@ func TestRunGoInstall_FailsFastOnKnownBadModule(t *testing.T) {
 	// invalid module path so `go install` fails fast (bad module
 	// shape, no network resolution attempted). Exercises every
 	// line of the function body without actually installing
-	// anything — verifies env/stdout/stderr wiring is correct.
+	// anything — verifies env/stdout/stderr/GOBIN wiring is
+	// correct.
 	if _, err := exec.LookPath("go"); err != nil {
 		t.Skip("`go` toolchain not on $PATH; cannot exercise runGoInstall body")
 	}
 	var stdout, stderr bytes.Buffer
-	err := runGoInstall("not-a-valid/module path/with spaces", &stdout, &stderr)
+	err := runGoInstall("not-a-valid/module path/with spaces", t.TempDir(), &stdout, &stderr)
 	if err == nil {
 		t.Fatal("expected go install to fail on a malformed module path")
 	}
@@ -563,34 +539,34 @@ func TestRunGoInstall_FailsFastOnKnownBadModule(t *testing.T) {
 	}
 }
 
-func TestGoEnvGOPATH_ReturnsToolchainGOPATH(t *testing.T) {
-	// Companion smoke-test for the goEnvGOPATH test seam — runs
-	// the real `go env GOPATH` shell-out and verifies it returns
-	// a non-empty absolute-looking path. Covers the seam's body
-	// (4 lines) without mocking.
-	if _, err := exec.LookPath("go"); err != nil {
-		t.Skip("`go` not on $PATH")
-	}
-	got, err := goEnvGOPATH()
-	if err != nil {
-		t.Fatalf("goEnvGOPATH: %v", err)
-	}
-	if got == "" {
-		t.Errorf("goEnvGOPATH returned empty string")
-	}
-}
+func TestRunPpAdd_BinaryMissingAfterInstallSurfacesError(t *testing.T) {
+	// Regression for #780: if `go install` succeeds but the
+	// binary isn't at the expected sandbox-bin path (e.g. the
+	// upstream package's main binary name differs from the
+	// `<name>-pp-cli` convention), the installer must bail with
+	// a clear error rather than handing a phantom path to the
+	// cli-add handoff.
+	startFixtureCatalog(t)
+	fakeHome(t)
 
-func TestResolveInstalledBinary_MissingErrors(t *testing.T) {
-	t.Setenv("GOBIN", t.TempDir())
-	prev := goEnvGOPATH
-	goEnvGOPATH = func() (string, error) { return t.TempDir(), nil }
-	t.Cleanup(func() { goEnvGOPATH = prev })
-	// Empty PATH so the LookPath fallback doesn't accidentally
-	// find a real binary on the host.
-	t.Setenv("PATH", "")
+	prev := runGoInstall
+	t.Cleanup(func() { runGoInstall = prev })
+	runGoInstall = func(modulePath, gobin string, stdout, stderr io.Writer) error {
+		// Pretend the toolchain succeeded but wrote nothing —
+		// the only way the post-install check fires.
+		return nil
+	}
 
-	_, err := resolveInstalledBinary("absolutely-nonexistent-pp-cli")
-	if err == nil {
-		t.Fatal("expected error for missing binary")
+	var stdout, stderr bytes.Buffer
+	code := runPpAdd(
+		[]string{"--yes", "--no-credentials", "linear"},
+		strings.NewReader(""),
+		&stdout, &stderr,
+	)
+	if code == 0 {
+		t.Fatal("expected nonzero exit when the binary is missing post-install")
+	}
+	if !strings.Contains(stderr.String(), "expected binary at") {
+		t.Errorf("stderr should explain the missing-binary failure: %q", stderr.String())
 	}
 }

--- a/internal/cstore/local_store.go
+++ b/internal/cstore/local_store.go
@@ -63,6 +63,19 @@ func DefaultLocalRoot() string {
 	return filepath.Join(".aileron", "connectors", "local")
 }
 
+// LocalConnectorBinDir returns the sandboxed install directory for
+// a local connector's wrapped binaries — `<root>/<name>/bin`. The
+// `pp add` installer overrides `GOBIN` to this path so the wrapped
+// CLI never lands on the user's `$PATH`, closing the bypass that
+// let an agent's `Bash` tool reach the binary directly and skip
+// vault-mediated credential injection (#780). Aileron's spawn
+// primitive resolves the binary path from the manifest's
+// `programs[].path` field, so the binary doesn't need `$PATH`
+// reachability for the runtime itself.
+func LocalConnectorBinDir(name string) string {
+	return filepath.Join(DefaultLocalRoot(), name, "bin")
+}
+
 // localManifestFile is the single manifest filename a local
 // connector directory holds. Matches the hub store's
 // [tarManifestFile] so manifest parsers see the same byte layout

--- a/internal/cstore/local_store_test.go
+++ b/internal/cstore/local_store_test.go
@@ -268,6 +268,20 @@ func TestDefaultLocalRoot_IncludesAileronSubdir(t *testing.T) {
 	}
 }
 
+func TestLocalConnectorBinDir_IsUnderLocalRoot(t *testing.T) {
+	// #780 contract: the sandbox-bin path is per-connector, lives
+	// under DefaultLocalRoot, and is *not* on $PATH. The agent's
+	// shell tool can't find binaries here, which closes the BYOCLI
+	// credential-sealing bypass.
+	got := LocalConnectorBinDir("linear")
+	if !strings.HasPrefix(got, DefaultLocalRoot()) {
+		t.Errorf("LocalConnectorBinDir(%q)=%q should be under DefaultLocalRoot %q", "linear", got, DefaultLocalRoot())
+	}
+	if !strings.HasSuffix(got, "linear/bin") && !strings.HasSuffix(got, "linear\\bin") {
+		t.Errorf("LocalConnectorBinDir(%q)=%q should end with linear/bin", "linear", got)
+	}
+}
+
 func TestLocalFQN_RejectsInvalidName(t *testing.T) {
 	for _, bad := range []string{"", "Bad-Caps", "with space", "../escape", ".hidden"} {
 		if _, err := LocalFQN(bad); err == nil {


### PR DESCRIPTION
## Summary

Closes #780. Sub-PR for umbrella #786.

\`aileron pp add <name>\` ran \`go install\` against the user's ambient \`GOBIN\`/\`GOPATH\`, dropping the wrapped CLI on \`\$PATH\`. Real-world failure (2026-05-15): \`aileron launch claude\` gave the agent both Aileron MCP tools and a \`Bash\` tool; Claude shelled out to \`linear-pp-cli\` directly, bypassing Aileron's vault-mediated credential injection. The CLI saw no \`LINEAR_API_KEY\` and returned 401.

Override \`GOBIN\` for the install to \`~/.aileron/connectors/local/<name>/bin/\`. The binary is reachable only via the manifest's \`programs[].path\` field — Aileron's spawn primitive resolves the absolute path at runtime, so the binary doesn't need \`\$PATH\` reachability for Aileron itself, but any shell-capable agent that tries \`linear-pp-cli\` raw will get "command not found".

Adds \`cstore.LocalConnectorBinDir(name)\` so daemon loaders and future \`cli refresh\` upgrades derive the same path without duplicating the convention.

### Scope

- **In scope**: \`aileron pp add\` install path.
- **Out of scope**: \`aileron cli add <path>\` (the user already chose the binary's location there; copying or symlinking would complicate upgrades and the residual bypass is acknowledged for the manual path).
- The post-install lookup is now a deterministic single-file check; \`resolveInstalledBinary\` and \`goEnvGOPATH\` are removed along with their tests since the GOBIN/GOPATH fallback walks no longer apply.

## Test plan

- [x] \`go test ./cmd/aileron/...\` — coverage 85.1%.
- [x] \`go test ./internal/cstore/...\` — coverage 85.0%. New test \`TestLocalConnectorBinDir_IsUnderLocalRoot\`.
- [x] New regression \`TestRunPpAdd_HappyPathHandsOffToCliAdd\` asserts \`runGoInstall\` receives the sandbox-bin path as \`GOBIN\` and the resulting manifest records that path in \`programs[].path\`.
- [x] New regression \`TestRunPpAdd_BinaryMissingAfterInstallSurfacesError\` covers the post-install file-existence guard.
- [x] Manual verification path documented in the umbrella's End-to-end demo bullet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)