### PR TITLE
ci(renovate): enable platform auto-merge for minor and patch updates

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -2,5 +2,13 @@
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
     "config:recommended"
+  ],
+  "platformAutomerge": true,
+  "automergeStrategy": "squash",
+  "packageRules": [
+    {
+      "matchUpdateTypes": ["minor", "patch", "pin", "digest"],
+      "automerge": true
+    }
   ]
 }


### PR DESCRIPTION
## Summary

- Opt minor, patch, pin, and digest dependency updates into GitHub's native auto-merge (`platformAutomerge: true`) so Renovate PRs land automatically once the required status checks pass.
- Use squash as the auto-merge strategy, matching the aileron-family convention.
- Major version bumps still require manual review.

## Companion changes (already applied directly)

- Repo setting `allow_auto_merge` flipped on; `delete_branch_on_merge` flipped on.
- `main` ruleset required-checks updated: replaced stale `Unit Tests` entry with the four matrix names (Windows/macOS/rest/sandbox); added Webapp Tests, Webapp Integration E2E, and both Socket Security checks. Codecov intentionally left out — patch coverage isn't a useful gate on dep bumps.

## Test plan

- [x] Verify the new ruleset lists all expected required checks: `gh api repos/ALRubinger/aileron/rulesets/15801401 --jq '.rules[]|select(.type=="required_status_checks").parameters.required_status_checks[].context'`
- [ ] After merge, watch the next Renovate PR (#792 or #793 are open): confirm it self-enables auto-merge and lands when checks go green.
- [ ] Confirm a major-version Renovate PR (when one appears) does NOT auto-merge.