### PR TITLE
fix(pp): stash credentials via daemon; resolve local FQNs in binding setup

### DIFF
--- a/cmd/aileron/cli_command.go
+++ b/cmd/aileron/cli_command.go
@@ -4,11 +4,13 @@ import (
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
+	"encoding/json"
 	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"io/fs"
+	"net/http"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -20,11 +22,8 @@ import (
 	"github.com/BurntSushi/toml"
 
 	"github.com/ALRubinger/aileron/internal/action"
-	"github.com/ALRubinger/aileron/internal/binding"
 	"github.com/ALRubinger/aileron/internal/cstore"
-	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/sandbox"
-	"github.com/ALRubinger/aileron/internal/vault"
 	"github.com/ALRubinger/aileron/internal/wrap"
 )
 
@@ -89,7 +88,6 @@ func runCliAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	yes := flags.Bool("yes", false, "skip the confirmation prompt")
 	flags.BoolVar(yes, "y", false, "skip the confirmation prompt (alias for --yes)")
 	noCredentials := flags.Bool("no-credentials", false, "skip the credential-env-var heuristic + prompt; manifest stays credential-free")
-	passphraseFile := flags.String("passphrase-file", "", "read the vault passphrase from the named file (newline-terminated); only consulted when credentials are stashed")
 	var credentialOverrides stringList
 	flags.Var(&credentialOverrides, "credential", "explicit credential env-var name to stash (repeatable; supplements the heuristic)")
 	if err := flags.Parse(args); err != nil {
@@ -199,14 +197,25 @@ func runCliAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 
 	stashedCount := 0
+	var stashErr error
 	if len(credKeys) > 0 {
-		var stashErr error
 		stashedCount, stashErr = stashCredentialBindings(
 			manifest.Connector.Name, resolvedName, credKeys,
-			*passphraseFile, stdin, stdout, stderr,
+			stdin, stdout, stderr,
 		)
 		if stashErr != nil {
-			fmt.Fprintf(stderr, "warning: credential stash incomplete (%v); manifest is installed but bindings need `aileron cli refresh` or manual setup\n", stashErr)
+			// Loud failure: the manifest is installed but the
+			// binding never landed in the daemon's vault, so the
+			// runtime will deny every call to this connector with
+			// `binding_required` until the user re-runs the setup.
+			// A scroll-by warning is exactly how previous users
+			// (including the maintainer dogfooding `aileron pp add
+			// linear`) ended up with a connector whose every action
+			// 403'd. Surface it on stderr and exit non-zero so the
+			// shell prompt's exit-status indicator and any wrapping
+			// automation both notice.
+			fmt.Fprintf(stderr, "error: credential stash failed: %v\n", stashErr)
+			fmt.Fprintln(stderr, "       manifest is installed but no binding is stored; rerun `aileron binding setup "+manifest.Connector.Name+"` to recover")
 		}
 	}
 
@@ -218,6 +227,9 @@ func runCliAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	if len(credKeys) > 0 {
 		fmt.Fprintf(stdout, "  Credentials: %d declared, %d stashed in vault\n", len(credKeys), stashedCount)
+	}
+	if stashErr != nil {
+		return 1
 	}
 	return 0
 }
@@ -808,18 +820,22 @@ func applyCredentialsToSpec(spec *wrap.Spec, keys []string) {
 }
 
 // stashCredentialBindings prompts the user once for a credential
-// value, opens the local vault, and creates a single
-// `api_key/<connector-name>/default` binding holding that value.
-// The runtime injects the same credential into every env key
-// the manifest's [capabilities.spawn].credential_env_keys lists,
-// matching the existing publisher-signed forwarder behavior
-// (one credential, N alias env-var names).
+// value and dispatches the write to the daemon via
+// `POST /v1/bindings/setup`. The daemon already holds the
+// unlocked vault (the state machine guarantees this before any
+// dispatched handler runs), so we never re-prompt for a
+// passphrase here — eliminating the dual-prompt UX trap where
+// the credential-value prompt and the vault-passphrase prompt
+// looked identical and the user routinely missed the second
+// one, leaving the manifest installed but no binding written.
 //
-// Empty input skips the stash entirely — the manifest still
-// declares the env keys, but the runtime surfaces
-// `binding_required` until the user runs `aileron cli refresh`
-// or creates the binding through another path. Returns 1 when a
-// binding was written, 0 otherwise.
+// Returns 1 when the binding was created (or already existed
+// and was skipped), 0 with nil error when the user intentionally
+// left the value blank, and 0 with a non-nil error when the
+// daemon rejected the request. Callers surface the error
+// prominently — a silent "credential stash incomplete" warning
+// at the end of `pp add` is the exact failure mode this rewrite
+// is closing.
 //
 // v1 limitation: a connector that genuinely has multiple
 // distinct credentials (e.g. an API token and a separate webhook
@@ -827,7 +843,7 @@ func applyCredentialsToSpec(spec *wrap.Spec, keys []string) {
 // declared in EnvPassthrough so the user can set them in the
 // surrounding shell, but the vault doesn't hold them. Multi-
 // credential connectors fall back to the manual wrap path.
-func stashCredentialBindings(connectorFQN, connectorName string, keys []string, passphraseFile string, stdin io.Reader, stdout, stderr io.Writer) (int, error) {
+func stashCredentialBindings(connectorFQN, connectorName string, keys []string, stdin io.Reader, stdout, stderr io.Writer) (int, error) {
 	if len(keys) == 0 {
 		return 0, nil
 	}
@@ -850,66 +866,53 @@ func stashCredentialBindings(connectorFQN, connectorName string, keys []string, 
 		return 0, nil
 	}
 
-	vaultPath := launch.DefaultVaultPath()
-
-	// Prefer the passphrase the state machine just verified for
-	// this process (#783). On a fresh `~/.aileron` the state
-	// machine fires before runPpAdd / runCliAdd: it prints the
-	// Aileron banner + irretrievable-passphrase warning, asks the
-	// user to pick a passphrase, initializes the vault, and spawns
-	// the daemon — all *before* the catalog fetch. The cached
-	// value lets the binding write here reuse that passphrase
-	// without re-prompting. Empty string means the state machine
-	// took the no-prompt branch (daemon already running + vault
-	// unlocked) and we fall through to the standard resolution
-	// chain.
-	passphrase := recallVaultPassphrase()
-	if passphrase == "" {
-		var err error
-		passphrase, _, err = readVaultPassphrase(passphraseFile, "Vault passphrase: ", stderr)
-		if err != nil {
-			return 0, fmt.Errorf("read vault passphrase: %w", err)
-		}
-		if passphrase == "" {
-			return 0, errors.New("vault passphrase is required to stash credentials")
-		}
-	}
-
-	v, err := launch.OpenLocalVault(vaultPath, passphrase)
+	body, err := json.Marshal(map[string]any{
+		"connector_fqn": connectorFQN,
+		"bindings": []map[string]any{{
+			"identity": defaultBindingIdentity,
+			"source":   map[string]any{"kind": "api_key", "value": value},
+		}},
+	})
 	if err != nil {
-		return 0, fmt.Errorf("open vault: %w", err)
+		return 0, fmt.Errorf("marshal binding request: %w", err)
 	}
-
-	bindingName, err := binding.MakeName(
-		cstore.CredentialKindAPIKey,
-		connectorName,
-		"default",
-	)
+	status, respBody, err := bindingDoRequestFn(http.MethodPost, "/bindings/setup", strings.NewReader(string(body)))
 	if err != nil {
-		return 0, fmt.Errorf("make binding name for %s: %w", connectorName, err)
+		return 0, fmt.Errorf("post bindings/setup: %w", err)
 	}
-	b := binding.Binding{
-		Name:         bindingName,
-		Kind:         cstore.CredentialKindAPIKey,
-		Service:      connectorName,
-		Identity:     "default",
-		ConnectorFQN: connectorFQN,
-		Status:       binding.StatusActive,
-		CreatedAt:    timeNow(),
+	if status != http.StatusCreated {
+		return 0, fmt.Errorf("daemon rejected binding setup (HTTP %d): %s", status, strings.TrimSpace(string(respBody)))
 	}
-	store := &binding.VaultStore{Vault: v}
-	if err := store.Put(context.Background(), b, []byte(value), binding.PutUpsert); err != nil {
-		return 0, fmt.Errorf("put binding %s: %w", bindingName, err)
+	var resp struct {
+		Created []struct {
+			Name string `json:"name"`
+		} `json:"created"`
+		Skipped []string `json:"skipped"`
 	}
-	fmt.Fprintf(stdout, "  Stashed credential under binding %s\n", bindingName)
-	return 1, nil
+	if err := json.Unmarshal(respBody, &resp); err != nil {
+		return 0, fmt.Errorf("parse bindings/setup response: %w", err)
+	}
+	for _, b := range resp.Created {
+		fmt.Fprintf(stdout, "  Stashed credential under binding %s\n", b.Name)
+	}
+	for _, name := range resp.Skipped {
+		fmt.Fprintf(stdout, "  Binding %s already exists; left untouched\n", name)
+	}
+	return len(resp.Created) + len(resp.Skipped), nil
 }
 
-// Type-system gate: vault is used via the launch package's
-// OpenLocalVault helper; the explicit import keeps the linter
-// from suggesting deletion when the helper is the only call
-// site referenced here.
-var _ vault.Vault = (vault.Vault)(nil)
+// defaultBindingIdentity is the identity segment paired with
+// every credential `aileron pp add` / `aileron cli add` stashes.
+// Matches the historical local-vault binding name shape
+// `api_key/<connector-name>/default` so existing manifests and
+// the runtime credential resolver keep resolving the same key.
+const defaultBindingIdentity = "default"
+
+// bindingDoRequestFn is the HTTP seam tests swap with a fake
+// daemon transport. Production points at [bindingDoRequest] in
+// main.go, which resolves the daemon URL and submits a real
+// request.
+var bindingDoRequestFn = bindingDoRequest
 
 // timeNow is the wall clock the credential binding writes use
 // for CreatedAt stamps. Indirected as a package-level seam so

--- a/cmd/aileron/cli_command_credentials_test.go
+++ b/cmd/aileron/cli_command_credentials_test.go
@@ -436,6 +436,33 @@ func TestStashCredentialBindings_DaemonRejectionReturnsError(t *testing.T) {
 	}
 }
 
+func TestStashCredentialBindings_PrompterErrorPropagates(t *testing.T) {
+	// The credential-value prompt fails (e.g., /dev/tty unavailable
+	// in a non-interactive shell). stashCredentialBindings must
+	// wrap and return the error rather than swallowing it — a
+	// silent zero return would leave the install reporting
+	// "success" while the binding is missing, the exact failure
+	// mode this rewrite is closing.
+	prevPrompt := promptPassphrase
+	t.Cleanup(func() { promptPassphrase = prevPrompt })
+	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
+		return "", errors.New("tty unavailable")
+	}
+	withFakeBindingTransport(t, func(method, path string, body io.Reader) (int, []byte, error) {
+		return 0, nil, errors.New("transport should not be called when prompt fails")
+	})
+
+	var stdout, stderr bytes.Buffer
+	_, err := stashCredentialBindings(
+		"local://user/x", "x",
+		[]string{"X_API_KEY"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if err == nil || !strings.Contains(err.Error(), "tty unavailable") {
+		t.Errorf("err = %v, want underlying prompter error wrapped through", err)
+	}
+}
+
 func TestStashCredentialBindings_HTTPErrorPropagates(t *testing.T) {
 	// Transport error (e.g., daemon unreachable) must surface as a
 	// real error, not a silent zero return.

--- a/cmd/aileron/cli_command_credentials_test.go
+++ b/cmd/aileron/cli_command_credentials_test.go
@@ -11,9 +11,7 @@ import (
 	"testing"
 
 	"github.com/ALRubinger/aileron/internal/cstore"
-	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/sandbox/sandboxtest"
-	"github.com/ALRubinger/aileron/internal/vault"
 	"github.com/ALRubinger/aileron/internal/wrap"
 )
 
@@ -289,9 +287,17 @@ func contains(s []string, v string) bool {
 }
 
 func TestStashCredentialBindings_EmptyKeysIsNoOp(t *testing.T) {
+	// No credential env keys → no daemon round trip, no prompt.
+	// The fake transport stays untouched.
+	calls := 0
+	withFakeBindingTransport(t, func(method, path string, body io.Reader) (int, []byte, error) {
+		calls++
+		return 0, nil, errors.New("no transport call expected")
+	})
+
 	var stdout, stderr bytes.Buffer
 	written, err := stashCredentialBindings(
-		"local://user/x", "x", nil, "",
+		"local://user/x", "x", nil,
 		strings.NewReader(""), &stdout, &stderr,
 	)
 	if err != nil {
@@ -300,24 +306,31 @@ func TestStashCredentialBindings_EmptyKeysIsNoOp(t *testing.T) {
 	if written != 0 {
 		t.Errorf("written=%d want 0", written)
 	}
+	if calls != 0 {
+		t.Errorf("transport called %d times for empty keys; should not be called at all", calls)
+	}
 }
 
-func TestStashCredentialBindings_EmptyValueSkipsVaultWrite(t *testing.T) {
+func TestStashCredentialBindings_EmptyValueSkipsDaemonCall(t *testing.T) {
 	// User leaves the credential value blank (legitimate skip for
 	// connectors where the heuristic surfaced a false positive).
-	// stashCredentialBindings must return (0, nil) without touching
-	// the vault — proven by NOT setting up a vault passphrase.
+	// stashCredentialBindings must return (0, nil) without
+	// hitting the daemon — proven by failing the fake transport.
 	prevPrompt := promptPassphrase
 	t.Cleanup(func() { promptPassphrase = prevPrompt })
 	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
-		// Empty value → skip path.
-		return "", nil
+		return "", nil // empty value → skip path
 	}
+	transportCalls := 0
+	withFakeBindingTransport(t, func(method, path string, body io.Reader) (int, []byte, error) {
+		transportCalls++
+		return 0, nil, errors.New("no daemon call expected for empty-value skip")
+	})
 
 	var stdout, stderr bytes.Buffer
 	written, err := stashCredentialBindings(
 		"local://user/skipme", "skipme",
-		[]string{"SKIPME_API_TOKEN"}, "",
+		[]string{"SKIPME_API_TOKEN"},
 		strings.NewReader(""), &stdout, &stderr,
 	)
 	if err != nil {
@@ -326,37 +339,40 @@ func TestStashCredentialBindings_EmptyValueSkipsVaultWrite(t *testing.T) {
 	if written != 0 {
 		t.Errorf("written=%d want 0", written)
 	}
+	if transportCalls != 0 {
+		t.Errorf("daemon transport called %d times during empty-value skip; should be 0", transportCalls)
+	}
+	if !strings.Contains(stdout.String(), "no credential stashed") {
+		t.Errorf("stdout should explain the skip; got %q", stdout.String())
+	}
 }
 
-func TestStashCredentialBindings_WritesBindingToVault(t *testing.T) {
-	// End-to-end: the vault is pre-initialized (state machine's
-	// responsibility per #783), the cached passphrase lets the
-	// stash open the vault without prompting, and one binding
-	// lands. Verifies the binding-write half of the BYOCLI flow
-	// in isolation from the state machine.
-	fakeHome(t)
-	vaultPath := launch.DefaultVaultPath()
-	if _, err := vault.Init(vaultPath, "cached-passphrase"); err != nil {
-		t.Fatalf("vault.Init: %v", err)
-	}
-	rememberVaultPassphrase("cached-passphrase")
-	t.Cleanup(func() { rememberVaultPassphrase("") }) // clear for next test
-
+func TestStashCredentialBindings_PostsBindingToDaemon(t *testing.T) {
+	// Happy path: the user enters a value, stashCredentialBindings
+	// POSTs to /bindings/setup with the right body, and the
+	// daemon's `created` reply lands in stdout. No vault file is
+	// opened; no second prompt fires.
 	prevPrompt := promptPassphrase
 	t.Cleanup(func() { promptPassphrase = prevPrompt })
-	// Only the credential-value prompt fires — the passphrase
-	// comes from the cache. A second prompt here would mean the
-	// state-machine-cache path silently regressed.
-	calls := 0
+	promptCalls := 0
 	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
-		calls++
+		promptCalls++
 		return "super-secret-token-bytes", nil
 	}
+
+	var seenMethod, seenPath, seenBody string
+	withFakeBindingTransport(t, func(method, path string, body io.Reader) (int, []byte, error) {
+		seenMethod = method
+		seenPath = path
+		bs, _ := io.ReadAll(body)
+		seenBody = string(bs)
+		return 201, []byte(`{"created":[{"name":"api_key/linear/default"}],"skipped":[]}`), nil
+	})
 
 	var stdout, stderr bytes.Buffer
 	written, err := stashCredentialBindings(
 		"local://user/linear", "linear",
-		[]string{"LINEAR_API_TOKEN"}, "",
+		[]string{"LINEAR_API_TOKEN"},
 		strings.NewReader(""), &stdout, &stderr,
 	)
 	if err != nil {
@@ -365,124 +381,123 @@ func TestStashCredentialBindings_WritesBindingToVault(t *testing.T) {
 	if written != 1 {
 		t.Errorf("written=%d want 1", written)
 	}
-	if calls != 1 {
-		t.Errorf("expected only 1 prompt (credential value); the cached passphrase should skip the passphrase prompt — got %d prompts", calls)
+	if promptCalls != 1 {
+		t.Errorf("expected exactly 1 prompt (credential value); got %d. A second prompt means the dual-prompt UX trap regressed.", promptCalls)
+	}
+	if seenMethod != "POST" || seenPath != "/bindings/setup" {
+		t.Errorf("request: %s %s, want POST /bindings/setup", seenMethod, seenPath)
+	}
+	for _, want := range []string{
+		`"connector_fqn":"local://user/linear"`,
+		`"identity":"default"`,
+		`"kind":"api_key"`,
+		`"value":"super-secret-token-bytes"`,
+	} {
+		if !strings.Contains(seenBody, want) {
+			t.Errorf("request body missing %q; got %s", want, seenBody)
+		}
 	}
 	if !strings.Contains(stdout.String(), "Stashed credential under binding api_key/linear/default") {
 		t.Errorf("stdout missing success line: %q", stdout.String())
 	}
 }
 
-func TestStashCredentialBindings_FallsBackToPromptWhenCacheEmpty(t *testing.T) {
-	// When `pp add` / `cli add` is invoked while the daemon is
-	// already running and the vault is unlocked, the state
-	// machine's no-prompt branch fires and the cache stays empty.
-	// stashCredentialBindings must still resolve a passphrase —
-	// falling back to readVaultPassphrase (file/env/prompt).
-	fakeHome(t)
-	vaultPath := launch.DefaultVaultPath()
-	if _, err := vault.Init(vaultPath, "from-prompt"); err != nil {
-		t.Fatalf("vault.Init: %v", err)
-	}
-	rememberVaultPassphrase("") // ensure cache is clear
-	t.Cleanup(func() { rememberVaultPassphrase("") })
-
+func TestStashCredentialBindings_DaemonRejectionReturnsError(t *testing.T) {
+	// Daemon returns non-201 (e.g., the connector isn't installed
+	// — Bug B before the fix shipped). The caller must see a
+	// concrete error so the install can exit non-zero, never the
+	// silent-warning shape that produced the linear-auth bug.
 	prevPrompt := promptPassphrase
 	t.Cleanup(func() { promptPassphrase = prevPrompt })
-	calls := 0
-	canned := []string{
-		"credential-bytes", // credential value
-		"from-prompt",      // vault passphrase (matches Init)
-	}
 	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
-		v := canned[calls]
-		calls++
-		return v, nil
+		return "value", nil
 	}
+	withFakeBindingTransport(t, func(method, path string, body io.Reader) (int, []byte, error) {
+		return 404, []byte(`{"error":{"code":"connector_not_installed","message":"connector local://user/x is not installed"}}`), nil
+	})
 
 	var stdout, stderr bytes.Buffer
 	written, err := stashCredentialBindings(
-		"local://user/already", "already",
-		[]string{"ALREADY_API_KEY"}, "",
+		"local://user/x", "x",
+		[]string{"X_API_KEY"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if err == nil {
+		t.Fatalf("expected non-nil error on 404; stdout=%q", stdout.String())
+	}
+	if !strings.Contains(err.Error(), "HTTP 404") {
+		t.Errorf("err = %v, want status surfaced in message", err)
+	}
+	if !strings.Contains(err.Error(), "connector_not_installed") {
+		t.Errorf("err = %v, want daemon response body surfaced in message", err)
+	}
+	if written != 0 {
+		t.Errorf("written=%d want 0 on rejection", written)
+	}
+}
+
+func TestStashCredentialBindings_HTTPErrorPropagates(t *testing.T) {
+	// Transport error (e.g., daemon unreachable) must surface as a
+	// real error, not a silent zero return.
+	prevPrompt := promptPassphrase
+	t.Cleanup(func() { promptPassphrase = prevPrompt })
+	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
+		return "value", nil
+	}
+	withFakeBindingTransport(t, func(method, path string, body io.Reader) (int, []byte, error) {
+		return 0, nil, errors.New("connection refused")
+	})
+
+	var stdout, stderr bytes.Buffer
+	_, err := stashCredentialBindings(
+		"local://user/x", "x",
+		[]string{"X_API_KEY"},
+		strings.NewReader(""), &stdout, &stderr,
+	)
+	if err == nil || !strings.Contains(err.Error(), "connection refused") {
+		t.Errorf("err = %v, want transport error propagated", err)
+	}
+}
+
+func TestStashCredentialBindings_SkippedBindingsCountInReturn(t *testing.T) {
+	// Daemon reports the binding already exists (idempotent
+	// reinstall). That should count toward `written` so the caller
+	// reports a successful end-state and doesn't exit non-zero on
+	// a reinstall.
+	prevPrompt := promptPassphrase
+	t.Cleanup(func() { promptPassphrase = prevPrompt })
+	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
+		return "value", nil
+	}
+	withFakeBindingTransport(t, func(method, path string, body io.Reader) (int, []byte, error) {
+		return 201, []byte(`{"created":[],"skipped":["api_key/linear/default"]}`), nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	written, err := stashCredentialBindings(
+		"local://user/linear", "linear",
+		[]string{"LINEAR_API_TOKEN"},
 		strings.NewReader(""), &stdout, &stderr,
 	)
 	if err != nil {
 		t.Fatalf("stash: %v", err)
 	}
 	if written != 1 {
-		t.Errorf("written=%d want 1", written)
+		t.Errorf("written=%d want 1 (skipped == still-bound counts as a successful end-state)", written)
 	}
-	if calls != 2 {
-		t.Errorf("expected 2 prompts (credential + passphrase fallback), got %d", calls)
-	}
-}
-
-func TestStashCredentialBindings_EmptyPassphraseInFallbackRejected(t *testing.T) {
-	// Daemon-already-running branch: cache is cold so
-	// stashCredentialBindings falls back to readVaultPassphrase.
-	// An empty passphrase from the fallback must surface a clear
-	// error so the user knows the credential value was not
-	// written to the vault (rather than silently producing a 0
-	// return).
-	fakeHome(t)
-	rememberVaultPassphrase("")
-	t.Cleanup(func() { rememberVaultPassphrase("") })
-
-	prevPrompt := promptPassphrase
-	t.Cleanup(func() { promptPassphrase = prevPrompt })
-	calls := 0
-	canned := []string{
-		"credential-value", // credential
-		"",                 // empty vault passphrase
-	}
-	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
-		v := canned[calls]
-		calls++
-		return v, nil
-	}
-
-	var stdout, stderr bytes.Buffer
-	_, err := stashCredentialBindings(
-		"local://user/x", "x",
-		[]string{"X_API_KEY"}, "",
-		strings.NewReader(""), &stdout, &stderr,
-	)
-	if err == nil || !strings.Contains(err.Error(), "vault passphrase is required") {
-		t.Errorf("err = %v, want 'vault passphrase is required' wrap", err)
+	if !strings.Contains(stdout.String(), "already exists") {
+		t.Errorf("stdout should note the skip; got %q", stdout.String())
 	}
 }
 
-func TestStashCredentialBindings_PassphrasePrompterErrorPropagates(t *testing.T) {
-	// Daemon-already-running + cold cache + the passphrase prompt
-	// fails (e.g., /dev/tty unavailable in a CI container).
-	// stashCredentialBindings must wrap and surface the underlying
-	// error rather than swallowing it — otherwise the user sees a
-	// silent "0 stashed" success message with no indication of
-	// why the binding never lands.
-	fakeHome(t)
-	rememberVaultPassphrase("")
-	t.Cleanup(func() { rememberVaultPassphrase("") })
-
-	prevPrompt := promptPassphrase
-	t.Cleanup(func() { promptPassphrase = prevPrompt })
-	calls := 0
-	promptPassphrase = func(prompt string, w io.Writer) (string, error) {
-		calls++
-		if calls == 1 {
-			return "credential-value", nil // credential prompt succeeds
-		}
-		return "", errors.New("tty unavailable") // passphrase prompt fails
-	}
-
-	var stdout, stderr bytes.Buffer
-	_, err := stashCredentialBindings(
-		"local://user/y", "y",
-		[]string{"Y_API_KEY"}, "",
-		strings.NewReader(""), &stdout, &stderr,
-	)
-	if err == nil || !strings.Contains(err.Error(), "tty unavailable") {
-		t.Errorf("err = %v, want underlying prompter error wrapped through", err)
-	}
+// withFakeBindingTransport swaps bindingDoRequestFn for the
+// duration of a test. The restore handler runs through t.Cleanup
+// so test order doesn't affect the cached production value.
+func withFakeBindingTransport(t *testing.T, fn func(method, path string, body io.Reader) (int, []byte, error)) {
+	t.Helper()
+	prev := bindingDoRequestFn
+	t.Cleanup(func() { bindingDoRequestFn = prev })
+	bindingDoRequestFn = fn
 }
 
 func TestRememberRecallVaultPassphrase_RoundTrip(t *testing.T) {

--- a/cmd/aileron/pp_command.go
+++ b/cmd/aileron/pp_command.go
@@ -54,8 +54,7 @@ flags for ` + "`aileron pp add`" + `:
   --dry-run               Print the install plan and exit without running ` + "`go install`" + `
   --edit                  Open the inferred manifest in $EDITOR before confirmation
   -y, --yes               Skip the confirmation prompt
-  --no-credentials        Skip credential detection + prompt
-  --passphrase-file <p>   Read the vault passphrase from <p> (newline-terminated)`
+  --no-credentials        Skip credential detection + prompt`
 
 // runPpAdd implements `aileron pp add <name>`. The flow:
 //
@@ -89,7 +88,6 @@ func runPpAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	yes := flags.Bool("yes", false, "skip the confirmation prompt")
 	flags.BoolVar(yes, "y", false, "alias for --yes")
 	noCredentials := flags.Bool("no-credentials", false, "skip the credential prompt path entirely")
-	passphraseFile := flags.String("passphrase-file", "", "read the vault passphrase from this path")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
@@ -189,9 +187,6 @@ func runPpAdd(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 	if *noCredentials {
 		cliArgs = append(cliArgs, "--no-credentials")
-	}
-	if *passphraseFile != "" {
-		cliArgs = append(cliArgs, "--passphrase-file", *passphraseFile)
 	}
 	if entry.MCP != nil {
 		for _, envVar := range entry.MCP.EnvVars {

--- a/cmd/aileron/pp_command_test.go
+++ b/cmd/aileron/pp_command_test.go
@@ -468,52 +468,6 @@ func TestRunPpAdd_GoInstallFailureSurfacesError(t *testing.T) {
 	}
 }
 
-func TestRunPpAdd_PassphraseFileFlagFlowsThrough(t *testing.T) {
-	// The --passphrase-file flag must reach the cli-add handoff so
-	// users can do non-interactive installs (CI / config-as-code).
-	// Verify by setting up the full happy path and confirming the
-	// install succeeds with the flag — its presence on the
-	// generated cli-add args is what makes this path testable.
-	if runtime.GOOS == "windows" {
-		t.Skip("sandboxtest fake binary is POSIX-only")
-	}
-	startFixtureCatalog(t)
-	home := fakeHome(t)
-
-	prev := runGoInstall
-	t.Cleanup(func() { runGoInstall = prev })
-	runGoInstall = func(modulePath, gobin string, stdout, stderr io.Writer) error {
-		// Drop a non-trivial fake at the sandbox-bin path the
-		// installer just told the toolchain to write to.
-		const helpText = "Commands:\n  do  do thing\n"
-		body := "#!/bin/sh\nprintf '%s' '" + helpText + "'\n"
-		return os.WriteFile(filepath.Join(gobin, "linear-pp-cli"), []byte(body), 0o755)
-	}
-
-	// Even though we pass --no-credentials, the flag-parsing path
-	// for --passphrase-file still has to recognize the flag and
-	// thread it through.
-	passFile := filepath.Join(t.TempDir(), "phrase")
-	if err := os.WriteFile(passFile, []byte("ignored-by-no-credentials\n"), 0o600); err != nil {
-		t.Fatalf("write passfile: %v", err)
-	}
-
-	var stdout, stderr bytes.Buffer
-	code := runPpAdd(
-		[]string{"--yes", "--no-credentials", "--passphrase-file", passFile, "linear"},
-		strings.NewReader(""),
-		&stdout, &stderr,
-	)
-	if code != 0 {
-		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
-	}
-	// Manifest must exist under short name — proves cli add ran.
-	manifestPath := filepath.Join(home, ".aileron", "connectors", "local", "linear", "manifest.toml")
-	if _, err := os.Stat(manifestPath); err != nil {
-		t.Errorf("manifest missing after happy install: %v", err)
-	}
-}
-
 func TestRunGoInstall_FailsFastOnKnownBadModule(t *testing.T) {
 	// runGoInstall is the production exec.Command shell-out;
 	// tests normally mock the var to avoid forking `go`. This

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -467,8 +467,12 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 		// ~/.aileron/connectors/local. Set unconditionally; the
 		// executor tolerates a missing root and just resolves no
 		// local connectors for hosts that have never run
-		// `aileron cli add`.
-		sandboxExec.LocalStore = cstore.NewLocalStore(cstore.DefaultLocalRoot())
+		// `aileron cli add`. Stash the same instance on the
+		// apiServer so binding-setup handlers can resolve
+		// `local://` FQNs without re-walking the filesystem.
+		localStore := cstore.NewLocalStore(cstore.DefaultLocalRoot())
+		sandboxExec.LocalStore = localStore
+		server.localStore = localStore
 		executor = sandboxExec
 		server.sandboxRuntime = sandboxRT
 	}

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -92,6 +92,7 @@ type apiServer struct {
 	actionState        action.StateStore // per-action user preferences (enabled/disabled overlay); nil means defaults apply
 	executor           action.Executor   // synchronous action executor used by /v1/actions/{name}/run; nil falls back to stub
 	installer          *cstore.Installer    // connector install pipeline (ADR-0004); nil disables /v1/connectors/install
+	localStore         *cstore.LocalStore   // BYOCLI local-mode connectors under ~/.aileron/connectors/local (#749); nil disables local-FQN lookups in binding setup
 	versionLister      cstore.VersionLister // connector version source query (ADR-0004); nil falls back to cstore.DefaultVersionLister inside the check handler
 	sandboxRuntime     sandbox.Runtime   // WASM runtime for connector execution (ADR-0005); nil falls back to stub executor
 	actionApprovals    *approval.ActionApprovalQueue // pending action-level approvals (manifest [approval] required = true); RunAction blocks on Decide

--- a/internal/app/handlers_bindings.go
+++ b/internal/app/handlers_bindings.go
@@ -3,6 +3,7 @@ package app
 import (
 	"context"
 	"errors"
+	"io/fs"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -259,10 +260,37 @@ func (s *apiServer) RebindBinding(w http.ResponseWriter, r *http.Request, name a
 // trusts the cstore index plus the on-disk manifest. Returns the
 // canonicalised FQN string (so the audit/binding metadata always uses
 // the canonical form), the parsed manifest, and any error.
+//
+// Two stores are consulted in scheme order: `local://` FQNs resolve
+// against the BYOCLI [cstore.LocalStore] (#749); every other scheme
+// resolves against the hub [cstore.Installer.Store]. Wiring both
+// here lets `POST /v1/bindings/setup` create credential bindings for
+// connectors installed via `aileron pp add` / `aileron cli add`,
+// not just hub-published ones. Without this, the runtime accepts
+// `local://` invocations (executor.connectorForLocal reads
+// LocalStore directly) but the binding-setup path 404s, leaving the
+// user with an installed manifest the daemon won't credential.
 func (s *apiServer) lookupConnector(fqnStr string) (string, *cstore.Manifest, error) {
 	fqn, err := cstore.ParseFQN(fqnStr)
 	if err != nil {
 		return "", nil, err
+	}
+	if fqn.Scheme == "local" {
+		if s.localStore == nil {
+			return "", nil, errors.New("connector " + fqn.String() + " is not installed (local connector store not configured)")
+		}
+		name, err := cstore.LocalNameForFQN(fqn.String())
+		if err != nil {
+			return "", nil, err
+		}
+		cmf, err := s.localStore.Load(name)
+		if err != nil {
+			if errors.Is(err, fs.ErrNotExist) {
+				return "", nil, errors.New("connector " + fqn.String() + " is not installed")
+			}
+			return "", nil, err
+		}
+		return fqn.String(), cmf, nil
 	}
 	_, hash, ok := s.installer.Store.LookupAnyVersion(fqn)
 	if !ok {

--- a/internal/app/handlers_bindings_test.go
+++ b/internal/app/handlers_bindings_test.go
@@ -210,6 +210,112 @@ func TestSetupBindings_UninstalledConnectorIs404(t *testing.T) {
 	}
 }
 
+// TestSetupBindings_ResolvesLocalConnectorFQN regresses the
+// `aileron pp add linear` → `binding setup local://user/linear` flow.
+// Pre-fix, `lookupConnector` only consulted the hub installer
+// store, so any `local://` FQN 404'd with `connector_not_installed`
+// even though the manifest was on disk under
+// `~/.aileron/connectors/local/<name>/manifest.toml`. With the
+// local-store fallback wired, the same request lands a binding and
+// returns 201.
+func TestSetupBindings_ResolvesLocalConnectorFQN(t *testing.T) {
+	srv, _ := bindingTestServer(t)
+
+	// Seed a local manifest with a credential capability so the
+	// setup handler accepts the api_key source.
+	localRoot := t.TempDir()
+	localStore := cstore.NewLocalStore(localRoot)
+	localFQN, _ := cstore.LocalFQN("linear")
+	localManifest := &cstore.Manifest{
+		Connector: cstore.ManifestConnector{
+			Name:      localFQN,
+			Version:   "0.0.1",
+			Origin:    cstore.OriginLocal,
+			Forwarder: cstore.BuiltinForwarderSpawn,
+		},
+		Capabilities: cstore.ManifestCapabilities{
+			Spawn: &cstore.ManifestSpawn{
+				Programs:   []cstore.ManifestSpawnProgram{{Path: "/usr/local/bin/linear-pp-cli"}},
+				Operations: map[string]cstore.ManifestSpawnOperation{"me": {Argv: "me"}},
+			},
+			Credential: &cstore.ManifestCredential{Kind: cstore.CredentialKindAPIKey},
+		},
+	}
+	if _, err := localStore.Save("linear", localManifest); err != nil {
+		t.Fatalf("seed local manifest: %v", err)
+	}
+	srv.localStore = localStore
+
+	body := `{
+		"connector_fqn": "local://user/linear",
+		"bindings": [{"identity": "default", "source": {"kind": "api_key", "value": "lin_test_token"}}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/bindings/setup", strings.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	srv.SetupBindings(rec, req)
+	if rec.Code != http.StatusCreated {
+		t.Fatalf("status = %d, body = %s", rec.Code, rec.Body.String())
+	}
+	var got api.BindingSetupResponse
+	if err := json.NewDecoder(rec.Body).Decode(&got); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(got.Created) != 1 {
+		t.Fatalf("Created = %+v", got.Created)
+	}
+	b := got.Created[0]
+	if b.Name != "api_key/linear/default" {
+		t.Errorf("Name = %q, want api_key/linear/default", b.Name)
+	}
+	if b.ConnectorFqn != "local://user/linear" {
+		t.Errorf("ConnectorFqn = %q, want local://user/linear", b.ConnectorFqn)
+	}
+}
+
+// TestSetupBindings_LocalFQNWithoutLocalStoreIs404 documents the
+// failure mode for daemons started without the BYOCLI local store
+// wired (e.g., tests, embedded test servers, or a future
+// configuration that opts out). The handler must surface a
+// clear "not installed" 404 rather than panicking on a nil
+// dereference of s.localStore.
+func TestSetupBindings_LocalFQNWithoutLocalStoreIs404(t *testing.T) {
+	srv, _ := bindingTestServer(t)
+	// Deliberately leave srv.localStore nil.
+	body := `{
+		"connector_fqn": "local://user/linear",
+		"bindings": [{"identity": "default", "source": {"kind": "api_key", "value": "x"}}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/bindings/setup", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.SetupBindings(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+	if !strings.Contains(rec.Body.String(), "is not installed") {
+		t.Errorf("body should say not installed: %s", rec.Body.String())
+	}
+}
+
+// TestSetupBindings_UnknownLocalConnectorIs404 covers the case
+// where the FQN scheme is local but no entry exists under the
+// local store root. Distinguishes "scheme not supported" (nil
+// store) from "name not on disk" (store exists, manifest missing).
+func TestSetupBindings_UnknownLocalConnectorIs404(t *testing.T) {
+	srv, _ := bindingTestServer(t)
+	srv.localStore = cstore.NewLocalStore(t.TempDir())
+	body := `{
+		"connector_fqn": "local://user/never-installed",
+		"bindings": [{"identity": "default", "source": {"kind": "api_key", "value": "x"}}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/bindings/setup", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.SetupBindings(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404", rec.Code)
+	}
+}
+
 func TestSetupBindings_VaultLockedReturns423(t *testing.T) {
 	srv, _ := bindingTestServer(t, func(s *apiServer) { s.vaultLocked = true })
 	body := `{

--- a/internal/app/handlers_bindings_test.go
+++ b/internal/app/handlers_bindings_test.go
@@ -316,6 +316,26 @@ func TestSetupBindings_UnknownLocalConnectorIs404(t *testing.T) {
 	}
 }
 
+// TestSetupBindings_MalformedLocalFQNIs404 covers the
+// scheme-correct-but-rejected branch of LocalNameForFQN: an FQN
+// like `local://other/linear` parses as scheme=local but fails
+// the owner check (local connectors require owner="user"). The
+// handler must surface a clean error rather than crashing.
+func TestSetupBindings_MalformedLocalFQNIs404(t *testing.T) {
+	srv, _ := bindingTestServer(t)
+	srv.localStore = cstore.NewLocalStore(t.TempDir())
+	body := `{
+		"connector_fqn": "local://wrong-owner/linear",
+		"bindings": [{"identity": "default", "source": {"kind": "api_key", "value": "x"}}]
+	}`
+	req := httptest.NewRequest(http.MethodPost, "/v1/bindings/setup", strings.NewReader(body))
+	rec := httptest.NewRecorder()
+	srv.SetupBindings(rec, req)
+	if rec.Code != http.StatusNotFound {
+		t.Errorf("status = %d, want 404 (FQN malformed)", rec.Code)
+	}
+}
+
 func TestSetupBindings_VaultLockedReturns423(t *testing.T) {
 	srv, _ := bindingTestServer(t, func(s *apiServer) { s.vaultLocked = true })
 	body := `{


### PR DESCRIPTION
## Summary

`aileron pp add <name>` had two bugs that combined to leave Linear (and any other PrintingPress connector requiring an API key) installed but uncallable from the agent — every action denied with `binding_required`, no clear recovery path.

**Bug A — silent dual-prompt stash failure.** `stashCredentialBindings` opened the local vault file directly, which required a vault passphrase. With the daemon already running, the upstream `ensureVaultUnlocked` state machine short-circuits without caching the passphrase, so the stash fell through to a second hidden-input prompt right after the credential-value prompt. Two consecutive `***`-style prompts with no visual separation: easy to miss. A missed second prompt produced only a `warning: credential stash incomplete (...)` line that scrolled past, and the install reported success.

Rewritten to POST `/v1/bindings/setup`. The daemon already holds the unlocked vault, so the dual-prompt collapses to one (just the credential value), and any stash failure now surfaces as a stderr `error: credential stash failed: ...` line with a non-zero exit, plus a hint pointing at `aileron binding setup` for recovery.

**Bug B — `binding setup` rejected local FQNs.** `lookupConnector` only walked the hub installer store, so `aileron binding setup local://user/linear` 404'd with `connector_not_installed` even when the manifest was sitting under `~/.aileron/connectors/local/<name>/manifest.toml`. The runtime path already reads the LocalStore (`executor.connectorForLocal`), so the asymmetry was confusing: the agent could invoke a local connector but no recovery path existed for its credential.

`lookupConnector` now falls back to `apiServer.localStore` (the same `cstore.LocalStore` instance the sandbox executor uses for runtime resolution).

Together: `aileron pp add linear` ends with Linear callable from Claude, no manual recovery needed. And if the user does need recovery from a pre-fix broken install, `aileron binding setup local://user/linear` now works.

## Test plan

- [x] `go test ./cmd/aileron/... ./internal/app/...` — all green, 85.1% / 80.2% coverage.
- [x] Unit tests on `stashCredentialBindings`: empty keys (no-op), empty value (skip, no daemon call), happy path (POSTs correct body, single prompt), 404 daemon rejection (surfaces error), transport error (propagates), already-bound binding (counts in return).
- [x] Regression tests on `SetupBindings` handler: `local://` FQN resolves via LocalStore + creates binding; nil LocalStore returns 404; unknown local name returns 404.
- [x] Deleted obsolete tests covering the now-removed vault-direct-write code paths (`FallsBackToPromptWhenCacheEmpty`, `EmptyPassphraseInFallbackRejected`, `PassphrasePrompterErrorPropagates`, `PassphraseFileFlagFlowsThrough`).
- [x] `task build` succeeds; new daemon binary produced under `build/`.
- [ ] End-to-end smoke (deferred until merge): restart daemon with new binary, run `aileron cli remove linear && aileron pp add linear`, observe single credential prompt + working Linear actions in Claude.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
