### PR TITLE
feat(wrap): recurse Cobra subcommands; expose per-leaf actions with optional flags

### DIFF
--- a/cmd/aileron/action_wrap_test.go
+++ b/cmd/aileron/action_wrap_test.go
@@ -99,17 +99,40 @@ func TestRunActionWrap_HelpMode_EmitsScaffoldFromFakeHelpRunner(t *testing.T) {
 	tmp := t.TempDir()
 	out := filepath.Join(tmp, "connector")
 
-	// Swap the help runner with a static fake. The runner returns
-	// a cobra-style subcommand list; the wrap loader scaffolds from
-	// it.
-	orig := actionWrapHelpRunner
-	actionWrapHelpRunner = func(_ context.Context, _ string, _ []string) (string, error) {
-		return `gh works with GitHub.
+	// Swap the help runner with a path-aware fake. Top-level returns
+	// a cobra subcommand list; each top-level subcommand returns a
+	// leaf-style help (no Available Commands) so the recursive walk
+	// terminates immediately and emits one operation per top-level
+	// name — `pr`, `issue`.
+	rootHelp := `gh works with GitHub.
 
 Available Commands:
   pr       Manage pull requests
   issue    Manage issues
-`, nil
+`
+	leafHelp := `Manage things.
+
+Usage:
+  thing <name>
+`
+	orig := actionWrapHelpRunner
+	actionWrapHelpRunner = func(_ context.Context, _ string, args []string) (string, error) {
+		key := ""
+		if n := len(args); n > 0 && args[n-1] == "--help" {
+			for _, a := range args[:n-1] {
+				if key != "" {
+					key += " "
+				}
+				key += a
+			}
+		}
+		switch key {
+		case "":
+			return rootHelp, nil
+		case "pr", "issue":
+			return leafHelp, nil
+		}
+		return "", nil
 	}
 	t.Cleanup(func() { actionWrapHelpRunner = orig })
 

--- a/cmd/aileron/cli_command.go
+++ b/cmd/aileron/cli_command.go
@@ -475,8 +475,13 @@ func validateConnectorName(name string) error {
 // merged help string. Many CLIs split --help between stdout and
 // stderr; the wrap parser is heuristic enough that handing it
 // both streams concatenated produces the same subcommand list.
-func runHelpSandboxed(ctx context.Context, programPath, cwd string) (string, error) {
-	res, err := sandbox.RunHelp(ctx, programPath, cwd)
+//
+// `subcommandPath` is the verb chain prepended before `--help`.
+// Nil/empty yields `<binary> --help`; `["issues", "create"]`
+// yields `<binary> issues create --help` so the wrap recursion
+// can walk Cobra-style nested verb trees.
+func runHelpSandboxed(ctx context.Context, programPath, cwd string, subcommandPath ...string) (string, error) {
+	res, err := sandbox.RunHelp(ctx, programPath, cwd, subcommandPath...)
 	if err != nil {
 		// Surface the captured output anyway — `curl --help`-style
 		// CLIs exit non-zero but still print usage.
@@ -487,16 +492,38 @@ func runHelpSandboxed(ctx context.Context, programPath, cwd string) (string, err
 	return string(res.Stdout) + string(res.Stderr), nil
 }
 
-// buildSpecFromHelp turns captured help text into a wrap.Spec.
-// Reuses wrap.FromHelp's subcommand parser via a static
-// HelpRunner so the introspection heuristic stays in one place.
-func buildSpecFromHelp(name, version, programPath, helpText string) (*wrap.Spec, error) {
+// buildSpecFromHelp turns the root --help text into a wrap.Spec
+// by handing wrap.FromHelp a sandboxed runner that re-invokes
+// `<binary> <subcommand path...> --help` for each subcommand the
+// recursion encounters.
+//
+// The root help text is pre-captured by the caller — re-invoking
+// the sandbox for it would be a wasted round trip — so the runner
+// short-circuits when the path is empty and returns the cached
+// text directly. Every nested path takes a fresh sandboxed call;
+// this is what makes the recursion's per-leaf flag extraction
+// faithful to the real CLI's verb tree (a static-text runner
+// would feed the root help back at every level and explode the
+// recursion against any non-trivial subcommand set, hence the
+// per-path-sandbox plumbing rather than the v0 single-shot
+// closure that lived here pre-#wrap-recurse-cobra).
+func buildSpecFromHelp(name, version, programPath, rootHelpText string) (*wrap.Spec, error) {
 	fqn, err := cstore.LocalFQN(name)
 	if err != nil {
 		return nil, err
 	}
-	runner := func(context.Context, string, []string) (string, error) {
-		return helpText, nil
+	cwd, _ := os.Getwd()
+	if cwd == "" {
+		cwd = "/"
+	}
+	runner := func(ctx context.Context, _ string, args []string) (string, error) {
+		// `args` is `<path...> --help`. The root invocation has
+		// args=["--help"]; everything else is a nested path.
+		if len(args) <= 1 {
+			return rootHelpText, nil
+		}
+		subPath := args[:len(args)-1] // drop the trailing "--help"
+		return runHelpSandboxed(ctx, programPath, cwd, subPath...)
 	}
 	spec, err := wrap.FromHelp(context.Background(), runner, fqn, version, programPath)
 	if err != nil {

--- a/internal/sandbox/run_help.go
+++ b/internal/sandbox/run_help.go
@@ -44,6 +44,14 @@ type RunHelpResult struct {
 //     and [cstore.DefaultMaxStderrBytes]; output beyond the cap
 //     is dropped with a structured truncation marker per ADR-0014.
 //
+// `subcommandPath` is the verb chain prepended before `--help`.
+// Nil/empty yields `<programPath> --help` (the root-help call);
+// `["issues", "create"]` yields `<programPath> issues create
+// --help` so the introspector can walk Cobra-style nested verb
+// trees. Each call is its own sandboxed invocation — callers
+// running many paths in sequence pay the per-call sandbox-startup
+// cost N times.
+//
 // `programPath` must be absolute. RunHelp returns the
 // [ErrSpawnUnavailable] wrapper from [SandboxAvailable] when the
 // host can't honor the confinement the docstring promises —
@@ -55,7 +63,7 @@ type RunHelpResult struct {
 // `--help` parser. Generalizable to any other one-shot sandboxed
 // invocation that doesn't need a fully-formed connector manifest
 // on disk first.
-func RunHelp(ctx context.Context, programPath, cwd string) (RunHelpResult, error) {
+func RunHelp(ctx context.Context, programPath, cwd string, subcommandPath ...string) (RunHelpResult, error) {
 	if err := SandboxAvailable(); err != nil {
 		return RunHelpResult{}, err
 	}
@@ -69,9 +77,13 @@ func RunHelp(ctx context.Context, programPath, cwd string) (RunHelpResult, error
 		return RunHelpResult{}, fmt.Errorf("run_help: cwd %q must be absolute", cwd)
 	}
 
+	argv := make([]string, 0, 2+len(subcommandPath))
+	argv = append(argv, filepath.Base(programPath))
+	argv = append(argv, subcommandPath...)
+	argv = append(argv, "--help")
 	envelope := SpawnEnvelope{
 		Program: programPath,
-		Argv:    []string{filepath.Base(programPath), "--help"},
+		Argv:    argv,
 		Cwd:     cwd,
 	}
 	// fs_read scope: the user's cwd (so the introspector can

--- a/internal/sandbox/spawn.go
+++ b/internal/sandbox/spawn.go
@@ -300,17 +300,38 @@ type SpawnResult struct {
 	Stderr   []byte
 }
 
-// argvPattern is a tokenized argv pattern with `{name}` placeholders.
-// A pattern matches an incoming argv when the lengths agree and each
-// token matches.
+// argvPattern is a tokenized argv pattern with `{name}` placeholders
+// and `[...]` optional groups.
+//
+// A pattern is a sequence of token *groups*. Most groups are a single
+// required token. An optional group is a `[...]`-wrapped run of one
+// or more whitespace-separated tokens; the whole group elides at
+// substitution time when every placeholder inside resolves to an
+// empty string (or is missing from `args`).
 //
 // A pattern token is a sequence of literal and placeholder segments.
 // `--since={since}` parses to two segments: literal `--since=` then a
 // placeholder. A whole-token placeholder `{name}` is a single
 // placeholder segment. Matching is greedy from left to right; literal
 // segments anchor the placeholder bounds.
+//
+// Optional-group rationale: PrintingPress-style CLIs expose verbs
+// with required + optional flags (e.g. `linear-pp-cli issues create
+// --title T --team K [--description D] [--priority N]`). Without
+// optional groups, every leaf would need a separate operation per
+// flag-combination (2^N — combinatorial explosion); with them, one
+// operation per leaf suffices and the matcher/substitutor admits or
+// elides each optional group independently.
 type argvPattern struct {
-	tokens [][]argvSegment
+	groups []argvGroup
+}
+
+// argvGroup is one token group in the pattern. A required group
+// carries exactly one token; an optional group (originally
+// `[tok1 tok2 ...]` in the manifest) may carry one or more.
+type argvGroup struct {
+	optional bool
+	tokens   [][]argvSegment
 }
 
 type argvSegment struct {
@@ -322,14 +343,67 @@ type argvSegment struct {
 	name string
 }
 
-// parseArgvPattern tokenizes a manifest argv pattern. Tokens are
-// whitespace-separated. Each token is split on `{name}` placeholders;
-// the resulting segments alternate literal / placeholder.
+// parseArgvPattern tokenizes a manifest argv pattern. The pattern is
+// a sequence of whitespace-separated tokens with two structural
+// extensions:
+//
+//   - `{name}` placeholders inside any token (substituted from
+//     `args` at call time).
+//   - `[tok1 tok2 ...]` optional groups (elided when every
+//     placeholder inside resolves to empty/missing).
+//
+// Optional groups must open and close at token boundaries; nesting
+// is not supported. An unmatched `[` or stray `]` is treated as a
+// literal so manifests with unintended brackets in argv literals
+// don't silently change semantics.
 func parseArgvPattern(pat string) argvPattern {
+	out := argvPattern{}
 	fields := strings.Fields(pat)
-	out := argvPattern{tokens: make([][]argvSegment, 0, len(fields))}
-	for _, f := range fields {
-		out.tokens = append(out.tokens, splitTokenSegments(f))
+	i := 0
+	for i < len(fields) {
+		f := fields[i]
+		// Optional-group opener: a token that starts with `[`. Walk
+		// forward until a token ends with `]`. The first/last
+		// tokens have their brackets stripped before segmentation.
+		if strings.HasPrefix(f, "[") {
+			groupTokens := [][]argvSegment{}
+			// Strip leading `[` from the first token.
+			first := strings.TrimPrefix(f, "[")
+			j := i
+			endFound := false
+			for ; j < len(fields); j++ {
+				cur := fields[j]
+				if j == i {
+					cur = first
+				}
+				if strings.HasSuffix(cur, "]") {
+					cur = strings.TrimSuffix(cur, "]")
+					if cur != "" {
+						groupTokens = append(groupTokens, splitTokenSegments(cur))
+					}
+					endFound = true
+					j++
+					break
+				}
+				if cur != "" {
+					groupTokens = append(groupTokens, splitTokenSegments(cur))
+				}
+			}
+			if !endFound {
+				// Unmatched `[` — fall back to literal-token treatment
+				// so a malformed manifest doesn't silently drop tokens.
+				out.groups = append(out.groups, argvGroup{tokens: [][]argvSegment{splitTokenSegments(f)}})
+				i++
+				continue
+			}
+			if len(groupTokens) > 0 {
+				out.groups = append(out.groups, argvGroup{optional: true, tokens: groupTokens})
+			}
+			i = j
+			continue
+		}
+		out.groups = append(out.groups, argvGroup{tokens: [][]argvSegment{splitTokenSegments(f)}})
+		i++
 	}
 	return out
 }
@@ -371,50 +445,135 @@ func splitTokenSegments(tok string) []argvSegment {
 // Substitute fills the placeholder segments of this pattern using
 // values from `args` and returns the substituted argv tokens. Returns
 // a structured *Error of class capability_denied (boundary=envelope)
-// when a placeholder has no matching arg.
+// when a required placeholder has no matching arg.
+//
+// Optional groups (`[...]` in the manifest) elide entirely when every
+// placeholder inside is missing from `args` or substitutes to an
+// empty string. If at least one placeholder in a group has a non-
+// empty value, the *whole* group renders — partial optional groups
+// are not supported because the manifest author chose to group these
+// tokens together as one logical "optional flag" unit.
 //
 // The resulting argv is whatever the pattern produced. The caller is
 // responsible for re-matching the substituted argv against the
 // pattern via SpawnPolicy.CheckSpawn — substitution does not bypass
 // the gate.
 func (p argvPattern) Substitute(args map[string]string) ([]string, *Error) {
-	out := make([]string, 0, len(p.tokens))
-	for _, segs := range p.tokens {
-		var b strings.Builder
-		for _, seg := range segs {
-			if !seg.isPlaceholder {
-				b.WriteString(seg.literal)
-				continue
-			}
-			v, ok := args[seg.name]
-			if !ok {
-				return nil, newCapabilityDenied(
-					"spawn_op: missing value for placeholder",
-					map[string]any{
-						"placeholder":     "{" + seg.name + "}",
-						"boundary_detail": "envelope",
-					})
-			}
-			b.WriteString(v)
+	out := make([]string, 0, len(p.groups))
+	for _, g := range p.groups {
+		if g.optional && optionalGroupElides(g, args) {
+			continue
 		}
-		out = append(out, b.String())
+		for _, segs := range g.tokens {
+			var b strings.Builder
+			for _, seg := range segs {
+				if !seg.isPlaceholder {
+					b.WriteString(seg.literal)
+					continue
+				}
+				v, ok := args[seg.name]
+				if !ok {
+					if g.optional {
+						// Optional groups tolerate missing
+						// placeholders only when *every* placeholder
+						// resolves empty/missing — that case is
+						// handled above. Reaching here means a peer
+						// placeholder had a value, so this one is
+						// genuinely required to render.
+						return nil, newCapabilityDenied(
+							"spawn_op: optional group has partial input",
+							map[string]any{
+								"placeholder":     "{" + seg.name + "}",
+								"boundary_detail": "envelope",
+							})
+					}
+					return nil, newCapabilityDenied(
+						"spawn_op: missing value for placeholder",
+						map[string]any{
+							"placeholder":     "{" + seg.name + "}",
+							"boundary_detail": "envelope",
+						})
+				}
+				b.WriteString(v)
+			}
+			out = append(out, b.String())
+		}
 	}
 	return out, nil
 }
 
-// matches reports whether `argv` matches this pattern. Token count
-// must agree exactly; each token's segments must consume its argv
-// element.
-func (p argvPattern) matches(argv []string) bool {
-	if len(argv) != len(p.tokens) {
-		return false
-	}
-	for i, segs := range p.tokens {
-		if !segmentsMatch(segs, argv[i]) {
-			return false
+// optionalGroupElides reports whether an optional group should be
+// omitted from the substituted argv. The rule: elide when every
+// placeholder in the group is either missing from `args` or
+// substitutes to an empty string. Groups containing only literals
+// (no placeholders) never elide — that would be a manifest mistake
+// (an "optional" group that always renders) but the gate doesn't
+// silently drop it.
+func optionalGroupElides(g argvGroup, args map[string]string) bool {
+	hasPlaceholder := false
+	for _, segs := range g.tokens {
+		for _, seg := range segs {
+			if !seg.isPlaceholder {
+				continue
+			}
+			hasPlaceholder = true
+			v, ok := args[seg.name]
+			if ok && v != "" {
+				return false
+			}
 		}
 	}
-	return true
+	return hasPlaceholder
+}
+
+// matches reports whether `argv` matches this pattern. Each required
+// group consumes one argv token; each optional group consumes its
+// token-count's worth or zero tokens (elided). The matcher walks
+// the argv and pattern in lockstep, trying both branches at each
+// optional group.
+func (p argvPattern) matches(argv []string) bool {
+	return matchGroups(p.groups, argv)
+}
+
+// matchGroups walks the pattern's group list against `argv`. For
+// required groups, the next argv token must consume the group's
+// single token's segments. For optional groups, the matcher tries
+// the "fully present" branch first (every group token consumed by
+// argv tokens in order) and, on failure, the "elided" branch (skip
+// the group entirely). Returns true when the full pattern consumes
+// the full argv.
+func matchGroups(groups []argvGroup, argv []string) bool {
+	if len(groups) == 0 {
+		return len(argv) == 0
+	}
+	g := groups[0]
+	rest := groups[1:]
+	if g.optional {
+		// Try with the group present first.
+		need := len(g.tokens)
+		if len(argv) >= need {
+			ok := true
+			for i, segs := range g.tokens {
+				if !segmentsMatch(segs, argv[i]) {
+					ok = false
+					break
+				}
+			}
+			if ok && matchGroups(rest, argv[need:]) {
+				return true
+			}
+		}
+		// Fall back to elided.
+		return matchGroups(rest, argv)
+	}
+	// Required group: exactly one token.
+	if len(argv) == 0 {
+		return false
+	}
+	if !segmentsMatch(g.tokens[0], argv[0]) {
+		return false
+	}
+	return matchGroups(rest, argv[1:])
 }
 
 // segmentsMatch reports whether `segs` consumes `s` end-to-end. The

--- a/internal/sandbox/spawn_test.go
+++ b/internal/sandbox/spawn_test.go
@@ -1308,6 +1308,130 @@ func TestArgvPattern_Substitute_PreservesLiteralTokens(t *testing.T) {
 	}
 }
 
+// Optional-group tests (`[...]` syntax). The wrap library targets
+// PrintingPress-style CLIs where leaves expose required + optional
+// flags; the pattern admits both fully-elided and fully-rendered
+// optional groups for the same operation.
+
+func TestArgvPattern_OptionalGroup_ElidesWhenInputMissing(t *testing.T) {
+	pat := parseArgvPattern("issues create --title {title} [--description {description}]")
+	got, err := pat.Substitute(map[string]string{"title": "Bug"})
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	want := []string{"issues", "create", "--title", "Bug"}
+	if !slicesEqualStrings(got, want) {
+		t.Errorf("Substitute = %v, want %v (optional --description should elide)", got, want)
+	}
+}
+
+func TestArgvPattern_OptionalGroup_ElidesWhenInputEmpty(t *testing.T) {
+	// Distinct from missing: the agent supplied the input but as an
+	// empty string. Treat empty same as missing — the manifest's
+	// optional-flag contract is "render only when there is a real
+	// value to pass."
+	pat := parseArgvPattern("issues create --title {title} [--description {description}]")
+	got, err := pat.Substitute(map[string]string{"title": "Bug", "description": ""})
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	want := []string{"issues", "create", "--title", "Bug"}
+	if !slicesEqualStrings(got, want) {
+		t.Errorf("Substitute = %v, want %v", got, want)
+	}
+}
+
+func TestArgvPattern_OptionalGroup_RendersWhenInputPresent(t *testing.T) {
+	pat := parseArgvPattern("issues create --title {title} [--description {description}]")
+	got, err := pat.Substitute(map[string]string{"title": "Bug", "description": "Body"})
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	want := []string{"issues", "create", "--title", "Bug", "--description", "Body"}
+	if !slicesEqualStrings(got, want) {
+		t.Errorf("Substitute = %v, want %v", got, want)
+	}
+}
+
+func TestArgvPattern_OptionalGroup_MultipleGroupsIndependentElision(t *testing.T) {
+	// Two optional groups; supply only the second. Each elides on its
+	// own — the renderer doesn't all-or-nothing across optional groups.
+	pat := parseArgvPattern("issues create --title {title} [--description {description}] [--priority {priority}]")
+	got, err := pat.Substitute(map[string]string{"title": "Bug", "priority": "1"})
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	want := []string{"issues", "create", "--title", "Bug", "--priority", "1"}
+	if !slicesEqualStrings(got, want) {
+		t.Errorf("Substitute = %v, want %v", got, want)
+	}
+}
+
+func TestArgvPattern_OptionalGroup_MatchesElidedArgv(t *testing.T) {
+	// The substituted argv (without the optional flag) must round-trip
+	// through .matches() so SpawnPolicy.CheckSpawn admits it.
+	pat := parseArgvPattern("issues create --title {title} [--description {description}]")
+	if !pat.matches([]string{"issues", "create", "--title", "Bug"}) {
+		t.Error("pattern should match an argv with optional flag absent")
+	}
+}
+
+func TestArgvPattern_OptionalGroup_MatchesRenderedArgv(t *testing.T) {
+	pat := parseArgvPattern("issues create --title {title} [--description {description}]")
+	if !pat.matches([]string{"issues", "create", "--title", "Bug", "--description", "Body"}) {
+		t.Error("pattern should match an argv with optional flag present")
+	}
+}
+
+func TestArgvPattern_OptionalGroup_RejectsPartialGroup(t *testing.T) {
+	// An optional group must be fully present or fully absent. An
+	// argv that includes the flag literal but not its value (or
+	// vice versa) should be rejected.
+	pat := parseArgvPattern("issues create --title {title} [--description {description}]")
+	if pat.matches([]string{"issues", "create", "--title", "Bug", "--description"}) {
+		t.Error("partial optional group should not match")
+	}
+}
+
+func TestArgvPattern_OptionalGroup_RejectsDifferentFlag(t *testing.T) {
+	// An argv that supplies an unrelated flag where the optional flag
+	// would appear must fail — the gate doesn't accept arbitrary tail
+	// tokens.
+	pat := parseArgvPattern("issues create --title {title} [--description {description}]")
+	if pat.matches([]string{"issues", "create", "--title", "Bug", "--priority", "1"}) {
+		t.Error("unknown flag where optional group would go must not match")
+	}
+}
+
+func TestParseArgvPattern_UnmatchedBracketTreatedAsLiteral(t *testing.T) {
+	// A pattern with an unmatched `[` is preserved verbatim so a
+	// manifest mistake doesn't silently drop tokens.
+	pat := parseArgvPattern("issues [create --title {title}")
+	// First group: "issues" required, second: "[create" treated as
+	// literal (unmatched bracket), third: "--title" with placeholder.
+	got, err := pat.Substitute(map[string]string{"title": "Bug"})
+	if err != nil {
+		t.Fatalf("Substitute: %v", err)
+	}
+	want := []string{"issues", "[create", "--title", "Bug"}
+	if !slicesEqualStrings(got, want) {
+		t.Errorf("Substitute = %v, want %v (unmatched [ should be literal)", got, want)
+	}
+}
+
+func TestArgvPattern_OptionalGroup_PartialInputErrors(t *testing.T) {
+	// Optional group with two placeholders: if the agent supplies
+	// one but not the other, the group's contract is broken —
+	// substitution rejects rather than silently omitting half.
+	// In practice the wrap heuristic emits one optional group per
+	// flag (single placeholder) so this is defense-in-depth.
+	pat := parseArgvPattern("foo [--a {a} --b {b}]")
+	_, err := pat.Substitute(map[string]string{"a": "x"}) // b absent
+	if err == nil {
+		t.Fatal("expected denial for partial optional-group input")
+	}
+}
+
 func TestHostSpawnOp_HappyPathRoutesThroughGate(t *testing.T) {
 	fake := &fakeExecutor{result: SpawnResult{ExitCode: 0, Stdout: []byte("commit-list")}}
 	state := &hostState{

--- a/internal/wrap/emit.go
+++ b/internal/wrap/emit.go
@@ -345,13 +345,25 @@ func renderActionMD(s *Spec, sub SubcommandSpec, _ *cstore.Manifest, connectorHa
 	fmt.Fprintf(&b, "id = %q\n", sub.Name)
 	fmt.Fprintf(&b, "connector = %q\n", s.Connector.Name)
 	fmt.Fprintf(&b, "op = %q\n", sub.Name)
-	if len(sub.Params) > 0 {
-		fmt.Fprintln(&b)
-		fmt.Fprintln(&b, "[execute.inputs]")
-		for _, p := range sub.Params {
-			fmt.Fprintf(&b, "%s = \"${args.%s}\"\n", p.Name, p.Name)
-		}
-	}
+	// Intentionally no `[execute.inputs]` block. The wrap-generated
+	// action's input names already match the argv-pattern placeholder
+	// names by construction (the wrap heuristic sets both from the
+	// Cobra flag's long-form), so the agent's call-time args flow
+	// directly to the connector through mergeArgs's args-iteration
+	// loop — no static interpolation needed.
+	//
+	// Critically, this is also the only correct shape for the optional-
+	// group argv extension introduced for this PR: emitting
+	// `description = "${args.description}"` here would, on an agent
+	// invocation that omits the optional `description` input, leave
+	// the literal token `${args.description}` in the merged args (per
+	// interpolateArgs's documented "leave-literal-for-unknown" policy
+	// in internal/action/executor.go). That non-empty literal would
+	// then defeat the optional-group elision in spawn.Substitute and
+	// the resulting argv would carry `--description ${args.description}`
+	// to the wrapped CLI. Skipping the block keeps optional-missing
+	// inputs absent from `args` entirely, which is exactly the
+	// pre-condition for elision.
 	fmt.Fprintln(&b, frontmatterDelim)
 	fmt.Fprintln(&b)
 	if sub.Description != "" {

--- a/internal/wrap/flags.go
+++ b/internal/wrap/flags.go
@@ -1,0 +1,196 @@
+package wrap
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+)
+
+// flagSpec is one parsed flag from a Cobra-style `--help` block. The
+// wrap heuristic emits one [ParamSpec] per exposed flag and one
+// argv-pattern token (or `[...]` optional group) per flag. Boolean
+// flags and repeatable-array flags are intentionally not modeled at
+// this layer — the parser skips them, so they never reach the
+// emitter.
+type flagSpec struct {
+	// Name is the long-form flag name without the leading `--`
+	// (e.g. "title"). Cobra's --help always lists the long form;
+	// the shorthand (`-h, --help`) is dropped by the parser.
+	Name string
+
+	// Type is the Cobra-declared type token: "string", "int",
+	// "int32", "int64", "float", "float32", "float64", "duration".
+	// Empty when no type token appears on the row (Cobra-boolean
+	// flags) — those are skipped by the parser and never reach the
+	// emitter, so the emitter does not have to model the no-type
+	// case.
+	Type string
+
+	// Description is the rest of the row after the type token,
+	// trimmed of trailing markers like `(required)`.
+	Description string
+
+	// Required is true when the description carried the literal
+	// `(required)` marker that Cobra appends for flags declared
+	// with cmd.MarkFlagRequired.
+	Required bool
+}
+
+// parseFlags reads a Cobra-style `--help` block and returns the
+// flag list aggregated from the "Flags:" and "Global Flags:"
+// sections. Both sections are emitted on every leaf — globals are
+// inherited by every callsite of the binary, so an agent invoking
+// the leaf may legitimately pass them.
+//
+// The parser is intentionally narrow: it recognizes Cobra's row
+// shape (`-x, --name <type> <description>`) and skips lines that
+// don't look like flag rows (section headers, blank lines, lines
+// without a `--` token). Repeatable flags (`stringSlice`, `strings`,
+// `stringArray`) and boolean flags (no type token) are dropped at
+// parse time — the argv-pattern model can't express them in v1, so
+// the emitter never has to filter again downstream.
+func parseFlags(help string) []flagSpec {
+	var out []flagSpec
+	scanner := bufio.NewScanner(strings.NewReader(help))
+	inFlagSection := false
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if isFlagSectionHeader(trimmed) {
+			inFlagSection = true
+			continue
+		}
+		if !inFlagSection {
+			continue
+		}
+		// Non-flag-row lines end the section. Cobra terminates the
+		// "Flags:" block with a blank line; a new section header
+		// (e.g. "Global Flags:") immediately restarts the parser.
+		if trimmed == "" {
+			inFlagSection = false
+			continue
+		}
+		// Flag rows are always indented in Cobra output. A non-
+		// indented line (e.g. "Use ..." or "Available Commands:")
+		// closes the section.
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			inFlagSection = false
+			// Re-check whether this line is itself a section header
+			// (e.g. immediately following "Flags:" with no blank).
+			if isFlagSectionHeader(trimmed) {
+				inFlagSection = true
+			}
+			continue
+		}
+		f, ok := parseFlagLine(trimmed)
+		if !ok {
+			continue
+		}
+		out = append(out, f)
+	}
+	return out
+}
+
+// isFlagSectionHeader recognizes Cobra's two flag-section headers.
+// urfave/cli uses "Options:" with the same row shape; supported as
+// a convenience even though PrintingPress's authoring convention
+// targets Cobra.
+func isFlagSectionHeader(line string) bool {
+	low := strings.ToLower(strings.TrimSuffix(line, ":"))
+	switch low {
+	case "flags", "global flags", "options", "global options":
+		return true
+	}
+	return false
+}
+
+// flagLineRe matches a Cobra flag row. The pattern captures:
+//
+//   - Optional shorthand block: `-x, ` (dropped).
+//   - Long form: `--name`.
+//   - Optional Cobra type token: `string`, `int`, `int32`, `int64`,
+//     `float`, `float32`, `float64`, `duration`. Boolean flags have
+//     no type token and the regex's type group stays empty.
+//     Repeatable-array types (`strings`, `stringSlice`, `stringArray`,
+//     `intSlice`) match here and are filtered out in parseFlagLine
+//     so the v1 emitter never sees them.
+//   - Description: the rest of the row.
+//
+// Cobra's column alignment puts at least two spaces between the
+// type (or long-form for booleans) and the description; the regex
+// allows one-or-more so handcrafted help text with single-space
+// gaps still parses.
+var flagLineRe = regexp.MustCompile(`^(?:-[a-zA-Z],\s+)?--([a-zA-Z][a-zA-Z0-9-]*)(?:\s+([a-zA-Z][a-zA-Z0-9]*))?\s+(.+?)\s*$`)
+
+// supportedFlagType reports whether a Cobra type token can be
+// represented in v1. String/numeric scalars are supported.
+// Repeatable types are not — modeling them would require the argv
+// pattern to repeat the flag N times, and the v1 grammar handles
+// at most one token per flag.
+func supportedFlagType(t string) bool {
+	switch t {
+	case "string", "int", "int32", "int64", "float", "float32", "float64", "duration":
+		return true
+	}
+	return false
+}
+
+// parseFlagLine matches one Cobra flag row. Returns the parsed
+// flagSpec on success, false when the line doesn't look like a
+// flag row OR when the flag is not representable in v1 (booleans,
+// repeatable arrays). Filtering at parse time keeps the emitter
+// from having to special-case the wrap layer's coverage choices.
+func parseFlagLine(line string) (flagSpec, bool) {
+	m := flagLineRe.FindStringSubmatch(line)
+	if m == nil {
+		return flagSpec{}, false
+	}
+	name := m[1]
+	typ := m[2]
+	desc := strings.TrimSpace(m[3])
+
+	// Skip `--help` — Cobra synthesizes it on every command. The
+	// agent surface never wants to call --help via an operation;
+	// it's a discovery affordance.
+	if name == "help" {
+		return flagSpec{}, false
+	}
+	if typ == "" {
+		// Cobra-boolean: not representable as a `[--flag {flag}]`
+		// optional group (the agent would have to supply "true" /
+		// "false" / "" as input strings, which is not how boolean
+		// flags work at the shell). Excluded in v1.
+		return flagSpec{}, false
+	}
+	if !supportedFlagType(typ) {
+		return flagSpec{}, false
+	}
+
+	required := false
+	if strings.HasSuffix(desc, "(required)") {
+		required = true
+		desc = strings.TrimSpace(strings.TrimSuffix(desc, "(required)"))
+	}
+
+	return flagSpec{
+		Name:        name,
+		Type:        typ,
+		Description: desc,
+		Required:    required,
+	}, true
+}
+
+// inputType maps a Cobra flag type to its action-manifest
+// [action.Input] type. Centralized so the emitter and tests agree
+// on the mapping without each holding its own switch.
+func inputType(cobraType string) string {
+	switch cobraType {
+	case "string", "duration":
+		return "string"
+	case "int", "int32", "int64":
+		return "integer"
+	case "float", "float32", "float64":
+		return "number"
+	}
+	return "string"
+}

--- a/internal/wrap/flags_test.go
+++ b/internal/wrap/flags_test.go
@@ -1,0 +1,218 @@
+package wrap
+
+import (
+	"testing"
+)
+
+// TestParseFlags_CobraIssuesCreateFixture is the load-bearing
+// regression: parse the actual --help shape `linear-pp-cli issues
+// create` emits. Title and team are required; the rest are
+// optional. Boolean and array-typed globals must be silently
+// dropped — v1 can't represent them in the argv pattern.
+func TestParseFlags_CobraIssuesCreateFixture(t *testing.T) {
+	help := `Create a Linear issue.
+
+Usage:
+  linear-pp-cli issues create [flags]
+
+Flags:
+      --assignee string      Assignee user UUID
+      --db string            Database path (for team-key resolution and pp_created ledger)
+      --description string   Issue description (markdown)
+  -h, --help                 help for create
+      --label strings        Label UUIDs (repeatable)
+      --priority int         Priority: 1=Urgent, 2=High, 3=Medium, 4=Low (0=None)
+      --project string       Project UUID
+      --state string         Workflow state UUID
+      --team string          Team key (e.g. ENG) or team UUID (required)
+      --title string         Issue title (required)
+
+Global Flags:
+      --agent                Set all agent-friendly defaults
+      --json                 Output as JSON
+      --config string        Config file path
+`
+	got := parseFlags(help)
+	want := map[string]struct {
+		typ      string
+		required bool
+	}{
+		"assignee":    {"string", false},
+		"db":          {"string", false},
+		"description": {"string", false},
+		"priority":    {"int", false},
+		"project":     {"string", false},
+		"state":       {"string", false},
+		"team":        {"string", true},
+		"title":       {"string", true},
+		"config":      {"string", false},
+	}
+	if len(got) != len(want) {
+		t.Errorf("got %d flags, want %d: %+v", len(got), len(want), got)
+	}
+	for _, f := range got {
+		exp, ok := want[f.Name]
+		if !ok {
+			t.Errorf("unexpected flag %q (boolean/array flags should drop)", f.Name)
+			continue
+		}
+		if f.Type != exp.typ {
+			t.Errorf("%s: type = %q, want %q", f.Name, f.Type, exp.typ)
+		}
+		if f.Required != exp.required {
+			t.Errorf("%s: required = %v, want %v", f.Name, f.Required, exp.required)
+		}
+	}
+}
+
+// TestParseFlags_SkipsBooleanFlags pins the v1 contract: boolean
+// flags (those without a Cobra type token) are not representable
+// in the argv pattern, so the parser drops them. A future PR can
+// add `[?{flag}:--flag]` syntax (or similar) and exercise this
+// path positively.
+func TestParseFlags_SkipsBooleanFlags(t *testing.T) {
+	help := `Flags:
+      --agent           Set all agent-friendly defaults
+      --json            Output as JSON
+      --csv             Output as CSV
+  -y, --yes             Skip the confirmation prompt
+      --title string    Issue title
+`
+	got := parseFlags(help)
+	if len(got) != 1 {
+		t.Fatalf("got %d flags, want 1 (only --title is non-boolean): %+v", len(got), got)
+	}
+	if got[0].Name != "title" {
+		t.Errorf("Name = %q, want title", got[0].Name)
+	}
+}
+
+// TestParseFlags_SkipsRepeatableArrayFlags pins the v1 contract:
+// `strings`, `stringSlice`, `stringArray`, `intSlice` flags need
+// argv repetition (--label foo --label bar), which the manifest
+// argv pattern can't model in a single optional group. Dropped at
+// parse time so the emitter doesn't have to special-case the
+// wrap-layer coverage choices downstream.
+func TestParseFlags_SkipsRepeatableArrayFlags(t *testing.T) {
+	help := `Flags:
+      --label strings       Label UUIDs (repeatable)
+      --tag stringSlice     Tag names
+      --port intSlice       Ports
+      --title string        Issue title
+`
+	got := parseFlags(help)
+	if len(got) != 1 || got[0].Name != "title" {
+		t.Errorf("got %+v, want only --title", got)
+	}
+}
+
+// TestParseFlags_GlobalFlagsBlock confirms the parser walks both
+// "Flags:" and "Global Flags:" sections and merges the entries.
+// Globals are inherited by every leaf, so an agent invoking the
+// leaf may legitimately pass them.
+func TestParseFlags_GlobalFlagsBlock(t *testing.T) {
+	help := `Flags:
+      --title string    Issue title (required)
+
+Global Flags:
+      --config string   Config file path
+`
+	got := parseFlags(help)
+	if len(got) != 2 {
+		t.Fatalf("got %d flags, want 2: %+v", len(got), got)
+	}
+	seen := map[string]bool{}
+	for _, f := range got {
+		seen[f.Name] = true
+	}
+	if !seen["title"] || !seen["config"] {
+		t.Errorf("missing flags: got %+v", seen)
+	}
+}
+
+// TestParseFlags_RequiredMarkerStrippedFromDescription confirms
+// the parser pulls `(required)` off the description text so the
+// emitted action.md doesn't surface the marker to the LLM (the
+// required-ness is already encoded in the input's `required`
+// field).
+func TestParseFlags_RequiredMarkerStrippedFromDescription(t *testing.T) {
+	help := `Flags:
+      --title string    Issue title (required)
+`
+	got := parseFlags(help)
+	if len(got) != 1 {
+		t.Fatalf("got %d flags, want 1", len(got))
+	}
+	if got[0].Description != "Issue title" {
+		t.Errorf("Description = %q, want %q", got[0].Description, "Issue title")
+	}
+	if !got[0].Required {
+		t.Error("Required = false, want true")
+	}
+}
+
+// TestParseFlags_IntegerType verifies the int type token maps to
+// the action manifest's "integer" input type (JSON Schema spelling).
+func TestParseFlags_IntegerType(t *testing.T) {
+	help := `Flags:
+      --priority int   Priority: 1=Urgent
+`
+	got := parseFlags(help)
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1", len(got))
+	}
+	if got[0].Type != "int" {
+		t.Errorf("Cobra Type = %q, want int", got[0].Type)
+	}
+	if inputType(got[0].Type) != "integer" {
+		t.Errorf("inputType(int) = %q, want integer", inputType(got[0].Type))
+	}
+}
+
+// TestParseFlags_HelpFlagDropped confirms `--help` is filtered.
+// Cobra synthesizes it on every command, but it isn't an
+// operation an agent should ever call through the wrap.
+func TestParseFlags_HelpFlagDropped(t *testing.T) {
+	help := `Flags:
+  -h, --help              help for create
+      --title string      Issue title
+`
+	got := parseFlags(help)
+	if len(got) != 1 || got[0].Name != "title" {
+		t.Errorf("got %+v, want only --title (no --help)", got)
+	}
+}
+
+// TestParseFlags_NoFlagSection returns no flags rather than
+// erroring. CLIs whose --help has no Flags: block (extremely rare,
+// but possible for unusually-shaped output) just produce a
+// flagless leaf.
+func TestParseFlags_NoFlagSection(t *testing.T) {
+	help := `Usage:
+  thing run
+`
+	got := parseFlags(help)
+	if len(got) != 0 {
+		t.Errorf("got %d flags, want 0", len(got))
+	}
+}
+
+func TestInputType_AllSupportedCobraTypes(t *testing.T) {
+	cases := map[string]string{
+		"string":   "string",
+		"duration": "string",
+		"int":      "integer",
+		"int32":    "integer",
+		"int64":    "integer",
+		"float":    "number",
+		"float32":  "number",
+		"float64":  "number",
+		"":         "string", // fallback for unknown
+	}
+	for in, want := range cases {
+		got := inputType(in)
+		if got != want {
+			t.Errorf("inputType(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/internal/wrap/load.go
+++ b/internal/wrap/load.go
@@ -114,45 +114,215 @@ func HelpRunnerExec(ctx context.Context, program string, args []string) (string,
 	return string(out), err
 }
 
-// FromHelp builds a Spec by invoking `<program> --help` and parsing
-// the output heuristically. The returned Spec is a scaffold the
-// connector author edits — the parser captures the top-level
-// subcommand list and a placeholder argv per subcommand. Per-flag
-// arity, parameter types, and descriptions need hand-editing in the
-// emitted YAML or directly in the manifest.
+// FromHelp builds a Spec by introspecting `<program> --help` and
+// every nested subcommand's `--help`. The output captures one
+// SubcommandSpec per *leaf* command (a command with no further
+// subcommands), with that leaf's required + optional flags as
+// declared inputs and an argv template that uses `[...]` optional
+// groups for the optional flags.
 //
-// `name` is the FQN to assign (`github://acme/foo`).
-// `version` is the connector's initial version (`0.0.1`).
+// For a Cobra CLI like linear-pp-cli:
+//
+//	linear-pp-cli                 (top-level)
+//	└── issues                    (namespace — has Available Commands)
+//	    ├── create                (leaf — has Flags only)   →  emits `issues-create`
+//	    └── list                  (leaf)                     →  emits `issues-list`
+//
+// Namespace commands (those that route to nested subcommands) are
+// not emitted as operations; only leaves are callable. This matches
+// how the agent thinks about tool calls: "create an issue", not
+// "navigate to the issues namespace and then create."
+//
+// `name` is the connector FQN to assign (`github://acme/foo` or
+// `local://user/foo`).
+// `version` is the connector's initial version.
 // `program` is the absolute path of the binary to wrap.
 // `runner` runs the help command; pass HelpRunnerExec in production.
+//
+// CLIs without any subcommands fall back to a single `run`
+// operation invoking the bare binary — same behavior as before the
+// recursion landed, so single-purpose wrapping paths are unchanged.
 func FromHelp(ctx context.Context, runner HelpRunner, name, version, program string) (*Spec, error) {
 	if !isAbsoluteOrTilde(program) {
 		return nil, fmt.Errorf("program path %q must be absolute or ~/-anchored", program)
 	}
-	help, err := runner(ctx, program, []string{"--help"})
+	rootHelp, err := runner(ctx, program, []string{"--help"})
 	if err != nil {
 		// Some programs exit non-zero on --help (notably curl). The
 		// captured output is still parseable; fall through.
-		if help == "" {
+		if rootHelp == "" {
 			return nil, fmt.Errorf("invoke %s --help: %w", program, err)
 		}
 	}
-	subs := parseSubcommands(help)
-	if len(subs) == 0 {
+	rootSubs := parseSubcommands(rootHelp)
+	if len(rootSubs) == 0 {
 		// CLIs without subcommands still get a single default
 		// operation that maps to the bare program invocation.
-		subs = []SubcommandSpec{{
-			Name:        "run",
-			Description: "Default invocation",
-			Argv:        baseName(program),
-		}}
+		return &Spec{
+			Connector: ConnectorSpec{Name: name, Version: version},
+			Program:   ProgramSpec{Path: program},
+			Subcommands: []SubcommandSpec{{
+				Name:        "run",
+				Description: "Default invocation",
+				Argv:        baseName(program),
+			}},
+		}, nil
 	}
-	prog := program
+
+	var leaves []SubcommandSpec
+	for _, rs := range rootSubs {
+		discovered, err := walkSubcommand(ctx, runner, program, []string{rs.Name}, rs.Description, 1)
+		if err != nil {
+			// A subcommand whose --help fails (rare, but happens on
+			// stub commands) drops out of the wrap rather than
+			// failing the whole install. The author can hand-add it
+			// later via the YAML path.
+			continue
+		}
+		leaves = append(leaves, discovered...)
+	}
+	if len(leaves) == 0 {
+		// Every recursive walk failed to surface a leaf. Fall back
+		// to the bare-subcommand emission so we don't ship a Spec
+		// with zero operations (cstore.ValidateManifest rejects that).
+		leaves = rootSubs
+	}
 	return &Spec{
 		Connector: ConnectorSpec{Name: name, Version: version},
-		Program:   ProgramSpec{Path: prog},
-		Subcommands: subs,
+		Program:   ProgramSpec{Path: program},
+		Subcommands: leaves,
 	}, nil
+}
+
+// maxSubcommandDepth caps how deep [walkSubcommand] recurses into a
+// subcommand tree. Cobra-shaped CLIs in PrintingPress's catalog top
+// out at depth 2 (`linear-pp-cli issues create`); gh/kubectl reach
+// 3 (`gh api graphql query`). Cap at 5 — anything deeper is either
+// a CLI authoring pathology or a runner that returns identical help
+// for every path (which the test fixtures used to do, and which
+// would otherwise spin forever). When the cap is hit the current
+// node is emitted as a leaf with whatever flags its help declares,
+// rather than continuing to recurse — the agent loses access to
+// genuinely-deep verbs, but the install completes.
+const maxSubcommandDepth = 5
+
+// walkSubcommand recursively explores a subcommand path. Returns
+// the leaf SubcommandSpecs discovered at this path (one when the
+// command is itself a leaf, many when it's a namespace whose
+// children are leaves, transitively).
+//
+// `path` is the chain of verbs from the root binary to this
+// subcommand (e.g. `["issues", "create"]`). The Cobra runtime
+// invokes `<binary> <path[0]> <path[1]> --help` to discover the
+// next layer.
+//
+// `description` is the line of prose the parent command's --help
+// associated with this subcommand. Plumbed down so leaves carry
+// the agent-facing prose from their parent's row when their own
+// --help body doesn't have a one-line summary at the top.
+//
+// `depth` is the current recursion depth (1 at the top-level
+// subcommand, 2 at its children, ...). Bounded by
+// [maxSubcommandDepth].
+func walkSubcommand(ctx context.Context, runner HelpRunner, program string, path []string, description string, depth int) ([]SubcommandSpec, error) {
+	args := append(append([]string(nil), path...), "--help")
+	help, err := runner(ctx, program, args)
+	if err != nil {
+		if help == "" {
+			return nil, fmt.Errorf("invoke %s %s: %w", program, strings.Join(args, " "), err)
+		}
+		// Tolerate non-zero exit when the output is still parseable.
+	}
+	subs := parseSubcommands(help)
+	if len(subs) > 0 && depth < maxSubcommandDepth {
+		// Namespace: recurse into each child. The namespace itself
+		// is not emitted as an operation — agents don't call
+		// "issues" without a verb; they call "issues create".
+		var out []SubcommandSpec
+		for _, s := range subs {
+			child := append(append([]string(nil), path...), s.Name)
+			discovered, err := walkSubcommand(ctx, runner, program, child, s.Description, depth+1)
+			if err != nil {
+				continue
+			}
+			out = append(out, discovered...)
+		}
+		return out, nil
+	}
+	// Leaf (or depth cap reached): parse flags + emit a SubcommandSpec.
+	flags := parseFlags(help)
+	leaf := buildLeafSpec(path, description, flags)
+	return []SubcommandSpec{leaf}, nil
+}
+
+// buildLeafSpec assembles a SubcommandSpec for a leaf command. The
+// operation name is the verb path joined by `-` (matches manifest
+// op-name shape `^[a-z][a-z0-9_-]*$`). The argv template uses the
+// verb path tokens unmodified, then required flags inline, then
+// each optional flag wrapped in `[...]`.
+//
+// Example for `linear-pp-cli issues create --title (required)
+// --description`:
+//
+//	Name:        "issues-create"
+//	Argv:        "issues create --title {title} [--description {description}]"
+//	Params:      [{title, string, required}, {description, string, optional}]
+func buildLeafSpec(path []string, description string, flags []flagSpec) SubcommandSpec {
+	name := strings.Join(path, "-")
+	var argv strings.Builder
+	for i, p := range path {
+		if i > 0 {
+			argv.WriteByte(' ')
+		}
+		argv.WriteString(p)
+	}
+	// Required flags first (stable order — order they appeared in
+	// the help, which Cobra alphabetizes). Then optional flags in
+	// the same order. The agent's tool catalog renders the JSON
+	// schema's `properties` map by declaration order; required-
+	// first keeps the call shape predictable.
+	required := make([]flagSpec, 0, len(flags))
+	optional := make([]flagSpec, 0, len(flags))
+	for _, f := range flags {
+		if f.Required {
+			required = append(required, f)
+		} else {
+			optional = append(optional, f)
+		}
+	}
+	var params []ParamSpec
+	for _, f := range required {
+		argv.WriteString(" --")
+		argv.WriteString(f.Name)
+		argv.WriteString(" {")
+		argv.WriteString(f.Name)
+		argv.WriteString("}")
+		params = append(params, ParamSpec{
+			Name:        f.Name,
+			Type:        inputType(f.Type),
+			Description: f.Description,
+			Required:    true,
+		})
+	}
+	for _, f := range optional {
+		argv.WriteString(" [--")
+		argv.WriteString(f.Name)
+		argv.WriteString(" {")
+		argv.WriteString(f.Name)
+		argv.WriteString("}]")
+		params = append(params, ParamSpec{
+			Name:        f.Name,
+			Type:        inputType(f.Type),
+			Description: f.Description,
+			Required:    false,
+		})
+	}
+	return SubcommandSpec{
+		Name:        name,
+		Description: description,
+		Argv:        argv.String(),
+		Params:      params,
+	}
 }
 
 // parseSubcommands extracts subcommands from a `--help` output. The

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -135,7 +135,7 @@ func TestLoadYAML_RejectsMalformedYAML(t *testing.T) {
 // --- --help parsing ---
 
 func TestFromHelp_ParsesCobraStyleSubcommandList(t *testing.T) {
-	help := `gh works with GitHub from the terminal.
+	rootHelp := `gh works with GitHub from the terminal.
 
 Available Commands:
   pr          Manage pull requests
@@ -147,7 +147,23 @@ Flags:
   -h, --help     Show help
   -v, --version  Show version
 `
-	s, err := FromHelp(context.Background(), staticRunner(help, nil),
+	// Each top-level subcommand resolves to a leaf with no further
+	// nesting in this fixture, so the recursion bottoms out
+	// immediately and emits one operation per top-level name —
+	// matching the v1 contract before the recursive walk landed.
+	leafHelp := `Manage things.
+
+Usage:
+  thing <subject>
+`
+	runner := pathRunner(map[string]string{
+		"":      rootHelp,
+		"pr":    leafHelp,
+		"issue": leafHelp,
+		"repo":  leafHelp,
+		"auth":  leafHelp,
+	})
+	s, err := FromHelp(context.Background(), runner,
 		"github://aileron-test/gh", "1.0.0", "/usr/bin/gh")
 	if err != nil {
 		t.Fatalf("FromHelp: %v", err)
@@ -159,8 +175,97 @@ Flags:
 	}
 }
 
+// TestFromHelp_RecursesIntoNamespacesAndEmitsLeafOperations is the
+// new-contract test: when a top-level subcommand is a namespace
+// (has its own Available Commands block), the walk recurses and
+// emits one operation per leaf — joined-by-dash for the op name.
+func TestFromHelp_RecursesIntoNamespacesAndEmitsLeafOperations(t *testing.T) {
+	rootHelp := `linear-pp-cli — Linear from the terminal.
+
+Available Commands:
+  issues      Get, list, or create Linear issues
+  teams       Manage teams
+`
+	issuesHelp := `Linear issue operations.
+
+Available Commands:
+  create      Create a new issue
+  list        List issues
+`
+	createHelp := `Create a new Linear issue.
+
+Flags:
+      --title string         Issue title (required)
+      --team string          Team key (required)
+      --description string   Issue description (markdown)
+      --priority int         Priority: 1=Urgent, 2=High
+`
+	listHelp := `List Linear issues.
+
+Flags:
+      --assignee string   Assignee user UUID
+      --state string      Workflow state UUID
+`
+	teamsHelp := `Manage teams.
+
+Usage:
+  linear-pp-cli teams [flags]
+`
+	runner := pathRunner(map[string]string{
+		"":              rootHelp,
+		"issues":        issuesHelp,
+		"issues create": createHelp,
+		"issues list":   listHelp,
+		"teams":         teamsHelp,
+	})
+	s, err := FromHelp(context.Background(), runner,
+		"github://aileron-test/linear-pp-cli", "1.0.0", "/usr/local/bin/linear-pp-cli")
+	if err != nil {
+		t.Fatalf("FromHelp: %v", err)
+	}
+	got := subcommandNames(s.Subcommands)
+	want := []string{"issues-create", "issues-list", "teams"}
+	if !slicesEqual(got, want) {
+		t.Fatalf("subcommands = %v, want %v", got, want)
+	}
+	// issues-create should carry the four parsed flags with title +
+	// team marked required, description + priority optional. Order
+	// follows required-first then optional, preserving Cobra's
+	// alphabetized listing within each group.
+	var create *SubcommandSpec
+	for i := range s.Subcommands {
+		if s.Subcommands[i].Name == "issues-create" {
+			create = &s.Subcommands[i]
+			break
+		}
+	}
+	if create == nil {
+		t.Fatal("issues-create not found")
+	}
+	wantParams := []ParamSpec{
+		{Name: "title", Type: "string", Required: true},
+		{Name: "team", Type: "string", Required: true},
+		{Name: "description", Type: "string"},
+		{Name: "priority", Type: "integer"},
+	}
+	if len(create.Params) != len(wantParams) {
+		t.Fatalf("issues-create params: got %d want %d (%+v)", len(create.Params), len(wantParams), create.Params)
+	}
+	for i, p := range create.Params {
+		if p.Name != wantParams[i].Name || p.Type != wantParams[i].Type || p.Required != wantParams[i].Required {
+			t.Errorf("param[%d]: got %+v, want name=%s type=%s required=%v",
+				i, p, wantParams[i].Name, wantParams[i].Type, wantParams[i].Required)
+		}
+	}
+	// argv should be `"issues create --title {title} --team {team} [--description {description}] [--priority {priority}]"`.
+	wantArgv := "issues create --title {title} --team {team} [--description {description}] [--priority {priority}]"
+	if create.Argv != wantArgv {
+		t.Errorf("argv = %q\n  want = %q", create.Argv, wantArgv)
+	}
+}
+
 func TestFromHelp_ParsesUrfaveStyleHeader(t *testing.T) {
-	help := `NAME:
+	rootHelp := `NAME:
    slackdump - Export Slack workspaces
 
 USAGE:
@@ -174,7 +279,20 @@ COMMANDS:
 GLOBAL OPTIONS:
    --help, -h     show help
 `
-	s, err := FromHelp(context.Background(), staticRunner(help, nil),
+	leafHelp := `Do the thing.
+
+Usage:
+  slackdump <action>
+`
+	runner := pathRunner(map[string]string{
+		"":       rootHelp,
+		"export": leafHelp,
+		"list":   leafHelp,
+		// "help" is filtered by parseSubcommands's name regex
+		// (lowercase + alphanumeric + dash); "help, h" was already
+		// dropped before the recursion, so we don't fixture it.
+	})
+	s, err := FromHelp(context.Background(), runner,
 		"github://aileron-test/slackdump", "1.0.0", "/usr/local/bin/slackdump")
 	if err != nil {
 		t.Fatalf("FromHelp: %v", err)
@@ -206,11 +324,27 @@ Usage: cat [OPTION]... [FILE]...
 func TestFromHelp_NonZeroExitWithOutputStillParses(t *testing.T) {
 	// curl exits non-zero on `--help` in some versions but still
 	// produces help on stdout; the parser tolerates that.
-	help := `Available Commands:
+	rootHelp := `Available Commands:
   one    First subcommand
   two    Second subcommand
 `
-	s, err := FromHelp(context.Background(), staticRunner(help, errors.New("non-zero")),
+	leafHelp := `Some leaf.
+
+Usage:
+  curl <thing>
+`
+	// pathRunner returns no error for known paths; the non-zero-exit
+	// case is exercised by wrapping the root response in a runner
+	// that yields output AND an error. We need the root invocation
+	// to error but the child invocations to succeed, so build a
+	// composite manually.
+	runner := func(_ context.Context, _ string, args []string) (string, error) {
+		if len(args) == 1 && args[0] == "--help" {
+			return rootHelp, errors.New("non-zero")
+		}
+		return leafHelp, nil
+	}
+	s, err := FromHelp(context.Background(), runner,
 		"github://aileron-test/curl", "1.0.0", "/usr/bin/curl")
 	if err != nil {
 		t.Fatalf("FromHelp: %v", err)
@@ -545,9 +679,44 @@ func TestSortedSubcommands_ReturnsAlphabeticalOrder(t *testing.T) {
 
 // staticRunner returns a HelpRunner that always yields the supplied
 // output and error.
+//
+// Tests that exercise the recursive --help walk should prefer
+// [pathRunner] instead — staticRunner returns the same body for
+// every subcommand path, so a multi-level walk against it would
+// either hit the depth cap or emit deeply-nested leaf names that
+// don't reflect a real CLI. staticRunner is still appropriate for
+// single-level tests (the CLI being wrapped has no nested verbs).
 func staticRunner(out string, err error) HelpRunner {
 	return func(_ context.Context, _ string, _ []string) (string, error) {
 		return out, err
+	}
+}
+
+// pathRunner returns a HelpRunner that yields different output per
+// subcommand path. The key is the space-separated verb path (`""`
+// for the bare program, `"pr"` for `<program> pr`, `"pr create"`
+// for `<program> pr create`), and the value is the body the
+// runner returns when `<program> <key> --help` is invoked.
+//
+// Paths absent from the map return an empty string + a synthetic
+// "no help" error — same shape a real CLI exit with no output
+// produces. The wrap walker treats that as a failed subcommand
+// and drops it from emission, mirroring production behavior.
+func pathRunner(byPath map[string]string) HelpRunner {
+	return func(_ context.Context, _ string, args []string) (string, error) {
+		// args carries `<path...> --help` — drop the trailing
+		// `--help` to build the key.
+		key := ""
+		if n := len(args); n > 0 && args[n-1] == "--help" {
+			key = strings.Join(args[:n-1], " ")
+		} else {
+			key = strings.Join(args, " ")
+		}
+		body, ok := byPath[key]
+		if !ok {
+			return "", errors.New("no help for path " + key)
+		}
+		return body, nil
 	}
 }
 

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -456,9 +456,14 @@ func TestEmit_ActionMDIsParseableByActionLoader(t *testing.T) {
 
 func TestEmit_ActionMDInputsLandWhenSpecDeclaresParams(t *testing.T) {
 	// The "log" subcommand in goodYAML has params (since, author);
-	// the emitted action.md should surface them as [[inputs]] entries
-	// with [execute.inputs] interpolation, so the agent can pass args
-	// through to the connector's spawn_op call.
+	// the emitted action.md surfaces them as [[inputs]] entries so
+	// the LLM tool catalog sees the parameter shape. The wrap
+	// emitter deliberately does NOT emit [execute.inputs] — the
+	// agent's call-time args flow directly to the connector through
+	// mergeArgs (the input names match the argv-pattern placeholder
+	// names by construction), and emitting `${args.X}` here would
+	// break optional-group elision for unsupplied inputs by leaving
+	// the literal token in the merged args map.
 	dir := t.TempDir()
 	s, _ := LoadYAML("a.yaml", []byte(goodYAML))
 	if err := Emit(s, dir, false); err != nil {
@@ -475,13 +480,15 @@ func TestEmit_ActionMDInputsLandWhenSpecDeclaresParams(t *testing.T) {
 	if len(manifest.Inputs) == 0 {
 		t.Fatal("expected [[inputs]] entries from spec params")
 	}
-	// Inputs flow into the [execute.inputs] interpolation map.
-	if len(manifest.Execute) != 1 || len(manifest.Execute[0].Inputs) == 0 {
-		t.Fatalf("execute.inputs missing: %+v", manifest.Execute)
+	// [execute.inputs] must be empty/absent — wrap-emitted actions
+	// rely on the args-iteration path in mergeArgs to deliver the
+	// agent's inputs to the connector.
+	if len(manifest.Execute) != 1 {
+		t.Fatalf("expected one execute step, got %d", len(manifest.Execute))
 	}
-	since, _ := manifest.Execute[0].Inputs["since"].(string)
-	if since != "${args.since}" {
-		t.Errorf("execute.inputs.since = %q, want ${args.since}", since)
+	if len(manifest.Execute[0].Inputs) != 0 {
+		t.Errorf("execute.inputs should be empty in wrap-emitted action.md; got %+v",
+			manifest.Execute[0].Inputs)
 	}
 }
 


### PR DESCRIPTION
## Summary

The BYOCLI wrap heuristic (`aileron cli add` / `aileron pp add`) previously parsed only the top-level subcommand list, emitting one bare-argv operation per top-level verb. For Cobra-shaped CLIs like `linear-pp-cli` whose verbs nest one level deeper (`issues create`, `issues list`, `teams update`, ...), this left the agent unable to do the actual work — `linear-issues` was registered as an action but the connector manifest mapped it to `argv = "issues"` with no parameter surface, so creating an issue, listing issues with filters, etc. all required either hand-editing the manifest or shelling out raw and defeating the credential seal.

This PR extends the wrap heuristic to recurse `<binary> <verb...> --help` to leaf commands and emit one action per leaf, with the leaf's Cobra-declared flags as typed inputs and an argv template that respects the required/optional distinction.

## Mechanism

**1. Optional `[...]` groups in argv patterns** (commit 1 — `internal/sandbox/spawn.go`)

The existing argv-pattern grammar required exact token-count matching, which made it impossible to model "optional flag" without 2^N operations. New syntax: `[--flag {flag}]` elides the entire group at substitution time when its placeholder resolves to empty/missing, and the matcher admits both fully-present and fully-elided argvs against the same pattern. Required flags use existing inline syntax (`--title {title}`); optional flags wrap in brackets.

**2. Recursive Cobra walk + flag parsing** (commit 2 — `internal/wrap/`)

`wrap.FromHelp` now invokes the runner with `<verb path...> --help` for every namespace command (one with its own `Available Commands:` block), walking to leaves bounded by `maxSubcommandDepth=5`. Each leaf's `Flags:` + `Global Flags:` sections are parsed into typed entries. The op name is the path joined by dash (`issues-create`, `workflow-status`), the argv lists the verb path then required flags inline then optional flags wrapped in `[...]`, and the inputs declare every flag with the correct type and required-ness.

v1 supports string / int / float / duration / int32-64 / float32-64 flag types. Boolean flags and repeatable arrays (`stringSlice`, `strings`, `intSlice`) are dropped at parse time — the argv grammar can't represent them, and re-introducing them in a follow-up is straightforward.

**3. Drop `[execute.inputs]` from wrap-emitted action.md** (commit 3 — `internal/wrap/emit.go`)

Wrap-emitted action.md files no longer carry `[execute.inputs]`. The wrap heuristic guarantees input names match argv-pattern placeholder names by construction, so the agent's call-time args flow directly through `mergeArgs`'s args-iteration loop. Critically, this is also the only correct shape for optional flags: emitting `description = "${args.description}"` would, when the agent omits the optional input, leave the literal token `${args.description}` in the merged args map (per `interpolateArgs`'s "leave-literal-for-unknown" policy), and that non-empty literal would defeat optional-group elision in `spawn.Substitute`.

**4. Production wiring** (commit 4 — `cmd/aileron/cli_command.go`)

`buildSpecFromHelp` previously handed `wrap.FromHelp` a static runner that returned the captured root help for every invocation. With recursion landed, that explodes (69-subcommands^5 = ~1.5B leaves before the depth cap). Fix: extend `sandbox.RunHelp` to accept a `subcommandPath` variadic, and replace the static runner with one that short-circuits the root call to the cached text and dispatches every nested path through a fresh sandboxed `--help` invocation.

## End-to-end verification

Ran `aileron cli refresh --yes linear` against the real `linear-pp-cli`:

- 83 leaf operations emitted (vs 69 bare-subcommand entries pre-recursion).
- `~/.aileron/actions/linear-issues-create.md` declares title + team as required string inputs and 16 optional inputs (description, priority as integer, assignee, db, project, session, state, plus globals like data-source, deliver, profile, rate-limit, timeout, trust-mode).
- Argv template: `issues create --team {team} --title {title} [--assignee {assignee}] [--db {db}] [--description {description}] [--priority {priority}] [--project {project}] [--session {session}] [--state {state}] [--config {config}] [--data-source {data-source}] [--deliver {deliver}] [--pp-session {pp-session}] [--profile {profile}] [--rate-limit {rate-limit}] [--select {select}] [--timeout {timeout}] [--trust-mode {trust-mode}]`.

Agent can now create issues through Aileron's sealed spawn path; no raw-shell fallback needed.

## Scope notes / follow-ups

- **Boolean flags** are dropped at parse time. The argv grammar would need a new conditional construct (e.g. `[?{flag}:--flag]` rendering as the literal `--flag` token when `flag` is truthy). Common case for PrintingPress CLIs is `--json` / `--agent` / `--no-color`; for now these stay at the wrapped CLI's defaults. Tracking as a follow-up.
- **Repeatable arrays** (`--label foo --label bar`) similarly need new grammar — the argv-pattern token list is fixed-length per group. Follow-up.
- **`aileron action wrap`** (the publisher path that emits a YAML scaffold for hand-edited connectors) still uses a single-shot help capture. Recursive emission there is straightforward but unscoped here since publisher-author UX is different from BYOCLI-install UX. Follow-up if useful.
- The running daemon caches actions at startup, so `aileron action list` shows pre-refresh state until the daemon restarts. Unrelated to this PR.

## Test plan

- [x] `go test ./internal/sandbox/... ./internal/wrap/... ./cmd/aileron/... ./internal/action/... ./internal/cstore/... ./internal/app/...` — all green.
- [x] New unit tests for `[...]` argv extension: elision-on-missing, elision-on-empty, render-when-present, multi-group independence, match-elided, match-rendered, reject-partial, unmatched-bracket-literal.
- [x] New unit tests for Cobra flag parser: required-flag marker, boolean skip, repeatable-array skip, global-flags merge, help-flag drop, integer-type mapping, no-flag-section tolerance.
- [x] New integration test `TestFromHelp_RecursesIntoNamespacesAndEmitsLeafOperations`: multi-level fake binary fixture, asserts op-name path-joining, argv shape, and input types/required.
- [x] Existing tests updated to use a path-aware `pathRunner` fixture instead of `staticRunner` (which now exists for single-level CLIs only).
- [x] `task build`; `aileron cli refresh --yes linear` end-to-end against real linear-pp-cli — 83 ops emitted with correct argv templates and input schemas.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
