### PR TITLE
fix(wrap): underscore-translate dashed flag names; surface action load errors

### DIFF
--- a/cmd/aileron/action_state.go
+++ b/cmd/aileron/action_state.go
@@ -23,7 +23,22 @@ type actionListItem struct {
 }
 
 type actionListWireResponse struct {
-	Items []actionListItem `json:"items"`
+	Items      []actionListItem      `json:"items"`
+	LoadErrors []actionLoadErrorItem `json:"load_errors,omitempty"`
+}
+
+// actionLoadErrorItem mirrors the api.ActionLoadError shape the
+// daemon returns. Carried separately from the manifest items so
+// the table view can surface load failures without conflating them
+// with successful loads. Inline-decoded rather than imported from
+// internal/api/gen to keep the CLI binary's dep graph small (the
+// CLI talks to the daemon over HTTP and doesn't otherwise need the
+// generated client types).
+type actionLoadErrorItem struct {
+	Class   string `json:"class"`
+	Message string `json:"message"`
+	File    string `json:"file"`
+	Line    int    `json:"line,omitempty"`
 }
 
 // actionsHTTPClient is overridable in tests so they can exercise the
@@ -110,7 +125,7 @@ func runActionList(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	if len(out.Items) == 0 {
+	if len(out.Items) == 0 && len(out.LoadErrors) == 0 {
 		if *asJSON {
 			fmt.Fprintln(stdout, "[]")
 			return 0
@@ -131,25 +146,46 @@ func runActionList(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
-	fmt.Fprintln(tw, "NAME\tVERSION\tENABLED\tORIGIN\tSOURCE")
-	disabled := 0
-	for _, a := range out.Items {
-		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
-			a.Name,
-			a.Version,
-			actionEnabledLabel(a.Enabled),
-			originBadge(a.Source),
-			a.Source,
-		)
-		if a.Enabled != nil && !*a.Enabled {
-			disabled++
+	if len(out.Items) > 0 {
+		tw := tabwriter.NewWriter(stdout, 0, 0, 2, ' ', 0)
+		fmt.Fprintln(tw, "NAME\tVERSION\tENABLED\tORIGIN\tSOURCE")
+		disabled := 0
+		for _, a := range out.Items {
+			fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+				a.Name,
+				a.Version,
+				actionEnabledLabel(a.Enabled),
+				originBadge(a.Source),
+				a.Source,
+			)
+			if a.Enabled != nil && !*a.Enabled {
+				disabled++
+			}
+		}
+		tw.Flush()
+		if disabled > 0 {
+			fmt.Fprintln(stdout)
+			fmt.Fprintf(stdout, "%d action(s) currently disabled. Restart your MCP server after toggling to pick up changes.\n", disabled)
 		}
 	}
-	tw.Flush()
-	if disabled > 0 {
-		fmt.Fprintln(stdout)
-		fmt.Fprintf(stdout, "%d action(s) currently disabled. Restart your MCP server after toggling to pick up changes.\n", disabled)
+	// Surface per-file load failures on stderr so users see them
+	// immediately. Pre-fix, silent drops in the daemon's loader
+	// were invisible from the CLI — a wrap-emitted action with a
+	// validation error would be missing from `items` with no
+	// indication anything was wrong, and the user would only
+	// discover the gap when the agent couldn't find the tool.
+	if len(out.LoadErrors) > 0 {
+		if len(out.Items) > 0 {
+			fmt.Fprintln(stderr)
+		}
+		fmt.Fprintf(stderr, "%d action file(s) failed to load and are not callable:\n", len(out.LoadErrors))
+		for _, e := range out.LoadErrors {
+			loc := e.File
+			if e.Line > 0 {
+				loc = fmt.Sprintf("%s:%d", e.File, e.Line)
+			}
+			fmt.Fprintf(stderr, "  [%s] %s — %s\n", e.Class, loc, e.Message)
+		}
 	}
 	return 0
 }

--- a/cmd/aileron/action_state_test.go
+++ b/cmd/aileron/action_state_test.go
@@ -173,6 +173,57 @@ func TestRunActionList_DaemonErrorPropagates(t *testing.T) {
 	}
 }
 
+// TestRunActionList_SurfacesLoadErrorsOnStderr pins the visibility
+// fix for the dash-bug class of failures. Pre-fix, the daemon's
+// load_errors field was decoded into `_` and never rendered, so a
+// wrap-emitted action.md with a dashed input name (validation_error
+// from internal/action/validate.go's `^[a-z][a-z0-9_]*$` regex)
+// vanished from the table view with no indication anything was
+// wrong. The fix prints a structured summary to stderr that names
+// the failure class, the file, and the validator message so users
+// can act on it without curl detours.
+func TestRunActionList_SurfacesLoadErrorsOnStderr(t *testing.T) {
+	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		_ = json.NewEncoder(w).Encode(actionListWireResponse{
+			Items: []actionListItem{
+				{Name: "good-action", Version: "1.0.0", Source: "hub://x/y@1"},
+			},
+			LoadErrors: []actionLoadErrorItem{
+				{
+					Class:   "validation_error",
+					File:    "/Users/x/.aileron/actions/linear-foo.md",
+					Message: "inputs[1].name \"data-source\" must match ^[a-z][a-z0-9_]*$",
+				},
+				{
+					Class:   "parse_error",
+					File:    "/Users/x/.aileron/actions/broken.md",
+					Line:    7,
+					Message: "expected `+++` frontmatter delimiter",
+				},
+			},
+		})
+	})
+	setBindingBase(t, base)
+
+	var stdout, stderr bytes.Buffer
+	if code := runActionList(nil, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "good-action") {
+		t.Errorf("stdout missing valid row: %s", stdout.String())
+	}
+	errOut := stderr.String()
+	if !strings.Contains(errOut, "2 action file(s) failed to load") {
+		t.Errorf("stderr missing failure count: %s", errOut)
+	}
+	if !strings.Contains(errOut, "validation_error") || !strings.Contains(errOut, "data-source") {
+		t.Errorf("stderr missing first failure detail: %s", errOut)
+	}
+	if !strings.Contains(errOut, "parse_error") || !strings.Contains(errOut, "broken.md:7") {
+		t.Errorf("stderr missing line-numbered failure: %s", errOut)
+	}
+}
+
 // --- enable / disable ---
 
 func TestRunActionToggle_EnableSendsPatch(t *testing.T) {

--- a/internal/wrap/load.go
+++ b/internal/wrap/load.go
@@ -267,6 +267,14 @@ func walkSubcommand(ctx context.Context, runner HelpRunner, program string, path
 //	Name:        "issues-create"
 //	Argv:        "issues create --title {title} [--description {description}]"
 //	Params:      [{title, string, required}, {description, string, optional}]
+//
+// Flag names containing dashes (`--data-source`, `--group-by`) are
+// translated to underscore form (`data_source`, `group_by`) for the
+// action input name AND the argv placeholder, since action input
+// names are JSON Schema property names that must match
+// `[a-z][a-z0-9_]*` per the manifest validator. The argv *literal*
+// keeps the original spelling — that's what the wrapped CLI's
+// flag parser expects.
 func buildLeafSpec(path []string, description string, flags []flagSpec) SubcommandSpec {
 	name := strings.Join(path, "-")
 	var argv strings.Builder
@@ -292,26 +300,28 @@ func buildLeafSpec(path []string, description string, flags []flagSpec) Subcomma
 	}
 	var params []ParamSpec
 	for _, f := range required {
+		inputName := flagInputName(f.Name)
 		argv.WriteString(" --")
 		argv.WriteString(f.Name)
 		argv.WriteString(" {")
-		argv.WriteString(f.Name)
+		argv.WriteString(inputName)
 		argv.WriteString("}")
 		params = append(params, ParamSpec{
-			Name:        f.Name,
+			Name:        inputName,
 			Type:        inputType(f.Type),
 			Description: f.Description,
 			Required:    true,
 		})
 	}
 	for _, f := range optional {
+		inputName := flagInputName(f.Name)
 		argv.WriteString(" [--")
 		argv.WriteString(f.Name)
 		argv.WriteString(" {")
-		argv.WriteString(f.Name)
+		argv.WriteString(inputName)
 		argv.WriteString("}]")
 		params = append(params, ParamSpec{
-			Name:        f.Name,
+			Name:        inputName,
 			Type:        inputType(f.Type),
 			Description: f.Description,
 			Required:    false,
@@ -323,6 +333,25 @@ func buildLeafSpec(path []string, description string, flags []flagSpec) Subcomma
 		Argv:        argv.String(),
 		Params:      params,
 	}
+}
+
+// flagInputName translates a Cobra long-form flag name into the
+// shape an action-manifest input requires. The manifest validator
+// enforces `^[a-z][a-z0-9_]*$` on input names (JSON Schema property
+// shape, snake_case convention — `internal/action/validate.go`),
+// but Cobra flags conventionally use kebab-case (`--data-source`,
+// `--auth-set-api-key`). We translate dashes to underscores so the
+// emitted action.md validates while the argv literal — what the
+// wrapped CLI's flag parser actually reads — keeps the original
+// dashed spelling.
+//
+// This is a one-way translation; the agent's call carries
+// `data_source` as the input name and the spawn-pattern
+// placeholder also uses `data_source`. The connector never sees
+// the underscore form because the manifest's argv-template literal
+// is `--data-source`.
+func flagInputName(flagName string) string {
+	return strings.ReplaceAll(flagName, "-", "_")
 }
 
 // parseSubcommands extracts subcommands from a `--help` output. The

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -5,6 +5,7 @@ import (
 	"errors"
 	"os"
 	"path/filepath"
+	"regexp"
 	"strings"
 	"testing"
 
@@ -261,6 +262,127 @@ Usage:
 	wantArgv := "issues create --title {title} --team {team} [--description {description}] [--priority {priority}]"
 	if create.Argv != wantArgv {
 		t.Errorf("argv = %q\n  want = %q", create.Argv, wantArgv)
+	}
+}
+
+// TestBuildLeafSpec_TranslatesDashedFlagNamesToUnderscoreInputs pins the
+// load-bearing regression: Cobra long-form flag names with dashes
+// (`--data-source`, `--group-by`, `--auth-set-api-key`) must translate
+// to underscore form for the action-input `name` field and the
+// argv-pattern placeholder, since the action-manifest validator enforces
+// `^[a-z][a-z0-9_]*$` on input names. The argv *literal* keeps the
+// original dashed spelling — that's what the wrapped CLI parses.
+//
+// Without this translation, every leaf with a dashed flag would
+// silently fail to load (validation_error) at daemon startup and the
+// agent's tool catalog would be missing the action — the exact failure
+// mode that bit `aileron pp add linear` after #797 (linear-pp-cli's
+// 69 leaves carry globals like --data-source on every command).
+func TestBuildLeafSpec_TranslatesDashedFlagNamesToUnderscoreInputs(t *testing.T) {
+	rootHelp := `linear-pp-cli — Linear from the terminal.
+
+Available Commands:
+  cycles      Cycle operations
+`
+	leafHelp := `Compare cycles.
+
+Flags:
+      --data-source string   Data source: live, local, auto
+      --group-by string      Field to group by (required)
+`
+	runner := pathRunner(map[string]string{
+		"":               rootHelp,
+		"cycles":         leafHelp,
+	})
+	s, err := FromHelp(context.Background(), runner,
+		"github://aileron-test/linear-pp-cli", "1.0.0", "/usr/local/bin/linear-pp-cli")
+	if err != nil {
+		t.Fatalf("FromHelp: %v", err)
+	}
+	if len(s.Subcommands) != 1 {
+		t.Fatalf("subcommands = %d, want 1", len(s.Subcommands))
+	}
+	sub := s.Subcommands[0]
+	// Input names must be underscore-converted.
+	wantNames := map[string]bool{"group_by": true, "data_source": true}
+	for _, p := range sub.Params {
+		if !wantNames[p.Name] {
+			t.Errorf("param name = %q; want one of %v (dash-to-underscore translation regressed)", p.Name, wantNames)
+		}
+	}
+	// argv literal keeps the dashed spelling; placeholder uses underscores.
+	wantArgv := "cycles --group-by {group_by} [--data-source {data_source}]"
+	if sub.Argv != wantArgv {
+		t.Errorf("argv = %q\n  want = %q", sub.Argv, wantArgv)
+	}
+}
+
+// TestBuildLeafSpec_PreservesUnderscoreFlagNames covers the no-op path
+// — flag names that already use underscores (rare in Cobra but possible
+// elsewhere) pass through unchanged in both the input name and argv.
+func TestBuildLeafSpec_PreservesUnderscoreFlagNames(t *testing.T) {
+	leaf := buildLeafSpec(
+		[]string{"do"},
+		"Do a thing.",
+		[]flagSpec{
+			{Name: "snake_case_flag", Type: "string", Required: true},
+		},
+	)
+	if leaf.Params[0].Name != "snake_case_flag" {
+		t.Errorf("Name = %q, want snake_case_flag", leaf.Params[0].Name)
+	}
+	if leaf.Argv != "do --snake_case_flag {snake_case_flag}" {
+		t.Errorf("argv = %q", leaf.Argv)
+	}
+}
+
+// TestBuildLeafSpec_OutputValidatesAgainstActionManifest is the
+// belt-and-suspenders check: a Spec emitted from a realistic Cobra
+// leaf (dashed flags, mix of required/optional) must produce an
+// action.md that round-trips through internal/action.Validate without
+// surfacing any inputName regex failures. Catches the kind of
+// validation-error miss this PR fixes.
+func TestBuildLeafSpec_OutputValidatesAgainstActionManifest(t *testing.T) {
+	// End-to-end: build a Spec with dashed Cobra flag names, render
+	// it through the production emit path (RenderActionMD), parse
+	// it back via action.Parse, and run action.Validate against the
+	// result. This is the regression boundary for the dash-bug —
+	// before this PR, action.Validate rejected every leaf with a
+	// dashed flag (data-source, group-by, auth-set-api-key, ...)
+	// and the daemon silently dropped all 83 emitted linear-* files
+	// from its action store at load time.
+	leaf := buildLeafSpec(
+		[]string{"issues", "create"},
+		"Create a Linear issue",
+		[]flagSpec{
+			{Name: "title", Type: "string", Required: true},
+			{Name: "team", Type: "string", Required: true},
+			{Name: "data-source", Type: "string", Required: false},
+			{Name: "auth-set-api-key", Type: "string", Required: false},
+			{Name: "group-by", Type: "string", Required: false},
+		},
+	)
+	inputNameRe := `^[a-z][a-z0-9_]*$`
+	matcher := regexp.MustCompile(inputNameRe)
+	for _, p := range leaf.Params {
+		if !matcher.MatchString(p.Name) {
+			t.Errorf("param name %q does not match %s — would fail action.Validate", p.Name, inputNameRe)
+		}
+	}
+
+	spec := &Spec{
+		Connector:   ConnectorSpec{Name: "local://user/linear", Version: "0.0.1"},
+		Program:     ProgramSpec{Path: "/usr/local/bin/linear-pp-cli"},
+		Subcommands: []SubcommandSpec{leaf},
+	}
+	manifest := BuildManifest(spec)
+	md := RenderActionMD(spec, leaf, manifest, "sha256:bound-at-install")
+	parsed, err := action.Parse(ActionFileName(spec, leaf), []byte(md))
+	if err != nil {
+		t.Fatalf("emitted action.md does not parse: %v\n%s", err, md)
+	}
+	if err := action.Validate(parsed, ActionFileName(spec, leaf)); err != nil {
+		t.Fatalf("emitted action.md fails validation: %v\n%s", err, md)
 	}
 }
 


### PR DESCRIPTION
Fixes #798 (with corrected diagnosis — see [comment](https://github.com/ALRubinger/aileron/issues/798#issuecomment-4468463554)).

## Summary

PR #797's wrap heuristic emits Cobra long-form flag names verbatim into action.md `[[inputs]] name` fields. Cobra uses kebab-case (`--data-source`, `--group-by`, `--auth-set-api-key`); the action-manifest validator enforces `^[a-z][a-z0-9_]*$` on input names per `internal/action/validate.go:23`. **Every wrap-emitted linear-* leaf with a dashed flag silently failed `validation_error` at daemon load and was dropped from the in-memory action store**, so the agent saw none of them in its tool catalog and fell back to raw `http_request` (which fails on Linear's non-Bearer auth shape).

Two fixes:

**Wrap heuristic** (`internal/wrap/load.go`) — translate dashed flag names to underscore form for the action input `name` and the argv-pattern placeholder, while keeping the argv literal as the original dashed spelling (what the wrapped CLI parses). A flag declared `--data-source string` in Cobra now renders as input `data_source` with argv fragment `[--data-source {data_source}]`, which validates cleanly.

**CLI visibility** (`cmd/aileron/action_state.go`) — `aileron action list` now decodes the `load_errors` array from `GET /v1/actions` (which was always populated, just never rendered) and prints each failure on stderr with class, file path, and validator message. The silent-drop failure mode would have been caught much earlier with this affordance.

## Originally-filed-as-#798

I filed #798 today claiming the daemon doesn't auto-refresh actions written by `cli add` / `pp add` until a manual restart. **That was a misdiagnosis** — the `ListActions` handler (`internal/app/handlers.go:1256`) already calls `s.actions.Load()` on every `GET /v1/actions`, so the in-memory store is reloaded every time the CLI lists actions. The real bug is that wrap-emitted action.md files were failing validation 100% of the time on any leaf with a dashed flag, which is essentially every PrintingPress-shaped Cobra CLI (`--data-source`, `--rate-limit`, `--trust-mode`, `--pp-session`, ... are global flags on every linear-pp-cli leaf).

Closing #798 in favor of this PR.

## End-to-end verification

Before this PR (current `main`):
```
$ aileron cli refresh --yes linear
Refreshed linear. Operations: 83. Actions: 83.

$ aileron action list | grep linear
(nothing)

$ curl -s http://127.0.0.1:NNNN/v1/actions | jq '.load_errors | length'
83

$ curl -s http://127.0.0.1:NNNN/v1/actions | jq '.load_errors[0]'
{ "class": "validation_error",
  "file": "/Users/alr/.aileron/actions/linear-analytics.md",
  "message": "inputs[1].name \"group-by\" must match ^[a-z][a-z0-9_]*$" }
```

After this PR (will verify before merge): `aileron action list` shows 83 linear-* rows; agent picks `linear-issues-create` directly when asked to create a ticket; no `http_request` fallback.

## Test plan

- [x] `go test ./internal/wrap/... ./internal/action/... ./internal/cstore/... ./internal/sandbox/... ./internal/app/... ./cmd/aileron/...` — all green.
- [x] New `TestBuildLeafSpec_TranslatesDashedFlagNamesToUnderscoreInputs` — pins the dash→underscore translation.
- [x] New `TestBuildLeafSpec_PreservesUnderscoreFlagNames` — no-op path for already-underscore names.
- [x] Strengthened `TestBuildLeafSpec_OutputValidatesAgainstActionManifest` — round-trips through the production emit path (RenderActionMD), parses back via `action.Parse`, and runs `action.Validate` against a Spec with five dashed flag names. Catches any future regression on the dash boundary.
- [x] New `TestRunActionList_SurfacesLoadErrorsOnStderr` — pins the CLI visibility fix; verifies failure count + per-entry class/file/message are printed when the daemon returns `load_errors`.
- [ ] Smoke test after merge: `aileron daemon stop && task build && aileron daemon start && aileron cli refresh --yes linear && aileron action list | grep linear-issues` shows the leaves.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
