### PR TITLE
feat(wrap): support Cobra positionals; prepend binary basename to argv

### DIFF
--- a/internal/wrap/load.go
+++ b/internal/wrap/load.go
@@ -169,9 +169,10 @@ func FromHelp(ctx context.Context, runner HelpRunner, name, version, program str
 		}, nil
 	}
 
+	progBase := baseName(program)
 	var leaves []SubcommandSpec
 	for _, rs := range rootSubs {
-		discovered, err := walkSubcommand(ctx, runner, program, []string{rs.Name}, rs.Description, 1)
+		discovered, err := walkSubcommand(ctx, runner, program, progBase, []string{rs.Name}, rs.Description, 1)
 		if err != nil {
 			// A subcommand whose --help fails (rare, but happens on
 			// stub commands) drops out of the wrap rather than
@@ -185,7 +186,18 @@ func FromHelp(ctx context.Context, runner HelpRunner, name, version, program str
 		// Every recursive walk failed to surface a leaf. Fall back
 		// to the bare-subcommand emission so we don't ship a Spec
 		// with zero operations (cstore.ValidateManifest rejects that).
-		leaves = rootSubs
+		// Prepend the binary basename so each fallback op invokes
+		// the wrapped CLI correctly (without this, argv[0] eats
+		// the subcommand token at exec time and the wrapped CLI
+		// runs as if called bare).
+		leaves = make([]SubcommandSpec, len(rootSubs))
+		for i, rs := range rootSubs {
+			leaves[i] = SubcommandSpec{
+				Name:        rs.Name,
+				Description: rs.Description,
+				Argv:        progBase + " " + rs.Name,
+			}
+		}
 	}
 	return &Spec{
 		Connector: ConnectorSpec{Name: name, Version: version},
@@ -224,7 +236,7 @@ const maxSubcommandDepth = 5
 // `depth` is the current recursion depth (1 at the top-level
 // subcommand, 2 at its children, ...). Bounded by
 // [maxSubcommandDepth].
-func walkSubcommand(ctx context.Context, runner HelpRunner, program string, path []string, description string, depth int) ([]SubcommandSpec, error) {
+func walkSubcommand(ctx context.Context, runner HelpRunner, program, progBase string, path []string, description string, depth int) ([]SubcommandSpec, error) {
 	args := append(append([]string(nil), path...), "--help")
 	help, err := runner(ctx, program, args)
 	if err != nil {
@@ -241,7 +253,7 @@ func walkSubcommand(ctx context.Context, runner HelpRunner, program string, path
 		var out []SubcommandSpec
 		for _, s := range subs {
 			child := append(append([]string(nil), path...), s.Name)
-			discovered, err := walkSubcommand(ctx, runner, program, child, s.Description, depth+1)
+			discovered, err := walkSubcommand(ctx, runner, program, progBase, child, s.Description, depth+1)
 			if err != nil {
 				continue
 			}
@@ -249,41 +261,83 @@ func walkSubcommand(ctx context.Context, runner HelpRunner, program string, path
 		}
 		return out, nil
 	}
-	// Leaf (or depth cap reached): parse flags + emit a SubcommandSpec.
+	// Leaf (or depth cap reached): parse positionals + flags and
+	// emit a SubcommandSpec. Positionals come from the Usage block
+	// (`<binary> verb [POS] [flags]`); flags from the Flags + Global
+	// Flags sections.
+	positionals := parsePositionals(help)
 	flags := parseFlags(help)
-	leaf := buildLeafSpec(path, description, flags)
+	leaf := buildLeafSpec(progBase, path, description, positionals, flags)
 	return []SubcommandSpec{leaf}, nil
 }
 
 // buildLeafSpec assembles a SubcommandSpec for a leaf command. The
 // operation name is the verb path joined by `-` (matches manifest
-// op-name shape `^[a-z][a-z0-9_-]*$`). The argv template uses the
-// verb path tokens unmodified, then required flags inline, then
-// each optional flag wrapped in `[...]`.
+// op-name shape `^[a-z][a-z0-9_-]*$`). The argv template lays out
+// the leaf invocation in the order Cobra expects it on the
+// command line:
 //
-// Example for `linear-pp-cli issues create --title (required)
-// --description`:
+//   - binary basename as argv[0] (the runtime exec uses
+//     `Argv[1:]` as the subprocess args, treating Argv[0] as the
+//     conventional binary-name slot — see
+//     `internal/sandbox/spawn.go`'s `exec.CommandContext(ctx,
+//     env.Program, env.Argv[1:]...)`. Omitting the basename here
+//     would cause the first verb token to be eaten by argv[0] and
+//     the wrapped CLI would run as if called bare)
+//   - verb path tokens (literals)
+//   - required positionals as bare placeholders `{name}`
+//   - optional positionals wrapped in `[{name}]` optional groups
+//   - required flags as `--flag {name}`
+//   - optional flags wrapped in `[--flag {name}]` optional groups
 //
-//	Name:        "issues-create"
-//	Argv:        "issues create --title {title} [--description {description}]"
-//	Params:      [{title, string, required}, {description, string, optional}]
+// Example for `linear-pp-cli sql [SQL] [flags]` with a `--rate-limit`
+// optional flag, wrapped as `linear-pp-cli`:
 //
-// Flag names containing dashes (`--data-source`, `--group-by`) are
-// translated to underscore form (`data_source`, `group_by`) for the
-// action input name AND the argv placeholder, since action input
-// names are JSON Schema property names that must match
-// `[a-z][a-z0-9_]*` per the manifest validator. The argv *literal*
-// keeps the original spelling — that's what the wrapped CLI's
-// flag parser expects.
-func buildLeafSpec(path []string, description string, flags []flagSpec) SubcommandSpec {
+//	Name:        "sql"
+//	Argv:        "linear-pp-cli sql [{sql}] [--rate-limit {rate_limit}]"
+//	Params:      [{sql, string, optional}, {rate_limit, number, optional}]
+//
+// Flag and positional names containing dashes (`--data-source`,
+// `<FILE-PATH>`) are translated to underscore form (`data_source`,
+// `file_path`) for the action input name AND the argv placeholder,
+// since action input names are JSON Schema property names that
+// must match `[a-z][a-z0-9_]*` per the manifest validator. The
+// argv *literal* for flag names keeps the original spelling — that's
+// what the wrapped CLI's flag parser expects.
+func buildLeafSpec(progBase string, path []string, description string, positionals []positionalSpec, flags []flagSpec) SubcommandSpec {
 	name := strings.Join(path, "-")
 	var argv strings.Builder
-	for i, p := range path {
-		if i > 0 {
-			argv.WriteByte(' ')
-		}
+	argv.WriteString(progBase)
+	for _, p := range path {
+		argv.WriteByte(' ')
 		argv.WriteString(p)
 	}
+
+	// Positionals follow Cobra ordering: they appear before flags
+	// on the command line. Required positionals are bare
+	// placeholders; optional positionals get the `[...]` group
+	// treatment so the agent can omit them and still produce a
+	// valid argv (the bare-invocation behavior Cobra preserves
+	// for `[ARG]`-shaped slots).
+	var params []ParamSpec
+	for _, p := range positionals {
+		if p.Required {
+			argv.WriteString(" {")
+			argv.WriteString(p.Name)
+			argv.WriteString("}")
+		} else {
+			argv.WriteString(" [{")
+			argv.WriteString(p.Name)
+			argv.WriteString("}]")
+		}
+		params = append(params, ParamSpec{
+			Name:        p.Name,
+			Type:        "string",
+			Description: positionalDescription(p),
+			Required:    p.Required,
+		})
+	}
+
 	// Required flags first (stable order — order they appeared in
 	// the help, which Cobra alphabetizes). Then optional flags in
 	// the same order. The agent's tool catalog renders the JSON
@@ -298,7 +352,6 @@ func buildLeafSpec(path []string, description string, flags []flagSpec) Subcomma
 			optional = append(optional, f)
 		}
 	}
-	var params []ParamSpec
 	for _, f := range required {
 		inputName := flagInputName(f.Name)
 		argv.WriteString(" --")
@@ -333,6 +386,19 @@ func buildLeafSpec(path []string, description string, flags []flagSpec) Subcomma
 		Argv:        argv.String(),
 		Params:      params,
 	}
+}
+
+// positionalDescription returns a human-readable description for a
+// positional input. Cobra's --help doesn't carry per-positional
+// prose the way it does for flags (`--flag string  Description`),
+// so we synthesize a minimal description from the positional's
+// name and required-ness. The author can hand-edit it later via
+// `--edit`.
+func positionalDescription(p positionalSpec) string {
+	if p.Required {
+		return "Positional argument: " + p.Name + " (required)"
+	}
+	return "Positional argument: " + p.Name + " (optional)"
 }
 
 // flagInputName translates a Cobra long-form flag name into the

--- a/internal/wrap/load_test.go
+++ b/internal/wrap/load_test.go
@@ -259,9 +259,50 @@ Usage:
 		}
 	}
 	// argv should be `"issues create --title {title} --team {team} [--description {description}] [--priority {priority}]"`.
-	wantArgv := "issues create --title {title} --team {team} [--description {description}] [--priority {priority}]"
+	wantArgv := "linear-pp-cli issues create --title {title} --team {team} [--description {description}] [--priority {priority}]"
 	if create.Argv != wantArgv {
 		t.Errorf("argv = %q\n  want = %q", create.Argv, wantArgv)
+	}
+}
+
+// TestFromHelp_PlumbsPositionalsThroughLeafSpec confirms that
+// positional arguments declared in a leaf's Usage block flow
+// through the full FromHelp → walkSubcommand → buildLeafSpec
+// pipeline. The leaf's argv pattern must contain the positional
+// placeholder; the leaf's Params slice must contain the input.
+func TestFromHelp_PlumbsPositionalsThroughLeafSpec(t *testing.T) {
+	rootHelp := `linear-pp-cli — Linear from the terminal.
+
+Available Commands:
+  sql      Run SQL against the local store
+`
+	leafHelp := `Run a SQL query against the local store.
+
+Usage:
+  linear-pp-cli sql [SQL] [flags]
+
+Flags:
+      --json   Output as JSON
+`
+	runner := pathRunner(map[string]string{
+		"":    rootHelp,
+		"sql": leafHelp,
+	})
+	s, err := FromHelp(context.Background(), runner,
+		"github://aileron-test/linear-pp-cli", "1.0.0", "/usr/local/bin/linear-pp-cli")
+	if err != nil {
+		t.Fatalf("FromHelp: %v", err)
+	}
+	if len(s.Subcommands) != 1 {
+		t.Fatalf("subcommands = %d, want 1", len(s.Subcommands))
+	}
+	leaf := s.Subcommands[0]
+	wantArgv := "linear-pp-cli sql [{sql}]"
+	if leaf.Argv != wantArgv {
+		t.Errorf("argv = %q\n  want = %q (--json is boolean and dropped per v1)", leaf.Argv, wantArgv)
+	}
+	if len(leaf.Params) != 1 || leaf.Params[0].Name != "sql" || leaf.Params[0].Required {
+		t.Errorf("params = %+v; want one optional `sql` input", leaf.Params)
 	}
 }
 
@@ -311,7 +352,7 @@ Flags:
 		}
 	}
 	// argv literal keeps the dashed spelling; placeholder uses underscores.
-	wantArgv := "cycles --group-by {group_by} [--data-source {data_source}]"
+	wantArgv := "linear-pp-cli cycles --group-by {group_by} [--data-source {data_source}]"
 	if sub.Argv != wantArgv {
 		t.Errorf("argv = %q\n  want = %q", sub.Argv, wantArgv)
 	}
@@ -322,8 +363,10 @@ Flags:
 // elsewhere) pass through unchanged in both the input name and argv.
 func TestBuildLeafSpec_PreservesUnderscoreFlagNames(t *testing.T) {
 	leaf := buildLeafSpec(
+		"mycli",
 		[]string{"do"},
 		"Do a thing.",
+		nil,
 		[]flagSpec{
 			{Name: "snake_case_flag", Type: "string", Required: true},
 		},
@@ -331,7 +374,7 @@ func TestBuildLeafSpec_PreservesUnderscoreFlagNames(t *testing.T) {
 	if leaf.Params[0].Name != "snake_case_flag" {
 		t.Errorf("Name = %q, want snake_case_flag", leaf.Params[0].Name)
 	}
-	if leaf.Argv != "do --snake_case_flag {snake_case_flag}" {
+	if leaf.Argv != "mycli do --snake_case_flag {snake_case_flag}" {
 		t.Errorf("argv = %q", leaf.Argv)
 	}
 }
@@ -352,8 +395,10 @@ func TestBuildLeafSpec_OutputValidatesAgainstActionManifest(t *testing.T) {
 	// and the daemon silently dropped all 83 emitted linear-* files
 	// from its action store at load time.
 	leaf := buildLeafSpec(
+		"linear-pp-cli",
 		[]string{"issues", "create"},
 		"Create a Linear issue",
+		nil,
 		[]flagSpec{
 			{Name: "title", Type: "string", Required: true},
 			{Name: "team", Type: "string", Required: true},

--- a/internal/wrap/positionals.go
+++ b/internal/wrap/positionals.go
@@ -1,0 +1,196 @@
+package wrap
+
+import (
+	"bufio"
+	"regexp"
+	"strings"
+)
+
+// positionalSpec is one parsed positional argument from a
+// Cobra-style `--help` Usage block. The wrap heuristic emits one
+// [ParamSpec] per positional and one argv-pattern token (or
+// `[{name}]` optional group for Cobra's `[ARG]` shape) per
+// positional.
+//
+// Variadic positionals (`[ARGS...]` / `<ARGS...>`) are not modeled
+// in v1 — the argv-pattern grammar matches token-for-token and
+// can't expand a single placeholder into many output tokens. The
+// parser skips variadic forms so the emitter never sees them.
+type positionalSpec struct {
+	// Name is the lowercased + underscore-normalized identifier
+	// derived from the Cobra positional marker. `[SQL]` → `sql`;
+	// `<FILE-PATH>` → `file_path`. Must satisfy the action input
+	// regex `^[a-z][a-z0-9_]*$` — positionals whose normalized
+	// name doesn't (e.g. leading digit) are dropped at parse time.
+	Name string
+
+	// Required is true when the Cobra marker used angle brackets
+	// (`<ARG>`); false for square brackets (`[ARG]`). Mirrors
+	// Cobra's convention — square brackets are "optional," angle
+	// brackets are "required." CLIs that don't follow the
+	// convention (some use only `[ARG]` regardless of
+	// requiredness) end up with everything optional; the agent can
+	// still pass values but its tool schema won't mark them
+	// required. Acceptable v1 trade-off.
+	Required bool
+}
+
+// parsePositionals reads a Cobra-style `--help` block and extracts
+// the leaf command's positional arguments from its Usage section.
+//
+// Cobra emits one or more Usage lines after the "Usage:" header.
+// For a leaf, the line takes the shape:
+//
+//	binary <verb...> <REQ_POS> [OPT_POS] [flags]
+//
+// Lines whose tail token is `[command]` describe the namespace
+// invocation form for a non-leaf command and are ignored. Tokens
+// inside square or angle brackets that match reserved Cobra
+// markers (`flags`, `command`, `options`, `args` —
+// case-insensitive) are not positionals and are filtered out.
+// Everything else inside `[...]` or `<...>` is treated as a
+// positional with the appropriate required-ness.
+//
+// The order in the returned slice matches the order positionals
+// appear in the first parseable Usage line; if multiple lines
+// declare different positional sets (Cobra allows this for
+// commands that overload), the first one wins and the rest are
+// ignored. Duplicates across lines are not collected — each
+// positional appears once.
+func parsePositionals(help string) []positionalSpec {
+	scanner := bufio.NewScanner(strings.NewReader(help))
+	inUsage := false
+	var out []positionalSpec
+	seen := map[string]bool{}
+	for scanner.Scan() {
+		line := scanner.Text()
+		trimmed := strings.TrimSpace(line)
+		if !inUsage {
+			if isUsageHeader(trimmed) {
+				inUsage = true
+			}
+			continue
+		}
+		// Blank line ends the section.
+		if trimmed == "" {
+			if len(out) > 0 {
+				return out
+			}
+			continue
+		}
+		// Non-indented line means we've left the Usage block.
+		if !strings.HasPrefix(line, " ") && !strings.HasPrefix(line, "\t") {
+			return out
+		}
+		// The `<binary> <verbs...> [command]` line describes the
+		// namespace-pivot invocation form; the leaf positional
+		// shape lives on a sibling line, so skip this one.
+		if strings.HasSuffix(trimmed, "[command]") {
+			continue
+		}
+		for _, p := range extractPositionalsFromUsageLine(trimmed) {
+			if seen[p.Name] {
+				continue
+			}
+			seen[p.Name] = true
+			out = append(out, p)
+		}
+		// One leaf-shape line is enough; subsequent overload
+		// lines would only confuse the emitter (e.g. a leaf that
+		// accepts EITHER one positional OR zero, depending on
+		// flags). Bail after the first line that yielded
+		// positionals so the wrap stays deterministic.
+		if len(out) > 0 {
+			return out
+		}
+	}
+	return out
+}
+
+// isUsageHeader recognizes the "Usage:" section header that Cobra
+// emits at the top of any --help block. urfave/cli uses "USAGE:"
+// (uppercase) with a similar single-line shape; supported for
+// parity with parseSubcommands' urfave handling.
+func isUsageHeader(line string) bool {
+	low := strings.ToLower(strings.TrimSuffix(line, ":"))
+	return low == "usage"
+}
+
+// usageMarkerRe matches one `[...]` or `<...>` token. The body is
+// captured for filtering. Variadic markers (trailing `...` inside
+// the brackets) are recognized but the body matcher excludes them
+// — see extractPositionalsFromUsageLine.
+var usageMarkerRe = regexp.MustCompile(`(?:\[([^\[\]]+)\]|<([^<>]+)>)`)
+
+// reservedUsageMarkers names the Cobra/urfave-style tokens that
+// appear inside `[...]` in a Usage line but are NOT positional
+// args. They describe slots for flags / subcommands / option
+// blocks, not named positional values.
+var reservedUsageMarkers = map[string]bool{
+	"flags":   true,
+	"command": true,
+	"options": true,
+	"args":    true,
+}
+
+// extractPositionalsFromUsageLine returns the positional specs
+// declared on a single Usage line, in the order they appear. The
+// caller filters duplicates and limits to the first leaf-shape
+// line.
+func extractPositionalsFromUsageLine(line string) []positionalSpec {
+	matches := usageMarkerRe.FindAllStringSubmatch(line, -1)
+	out := make([]positionalSpec, 0, len(matches))
+	for _, m := range matches {
+		var body string
+		var required bool
+		switch {
+		case m[1] != "":
+			body = m[1]
+			required = false
+		case m[2] != "":
+			body = m[2]
+			required = true
+		default:
+			continue
+		}
+		// Variadic forms (`[ARGS...]`, `<FILES...>`) aren't
+		// representable in the v1 argv-pattern grammar — drop
+		// them so the emitter doesn't get a placeholder it can't
+		// honor at substitution time. Tracked for the same
+		// follow-up that covers repeatable flag arrays.
+		if strings.HasSuffix(body, "...") {
+			continue
+		}
+		// Reserved markers are not positionals — they're Cobra's
+		// shorthand for "flags can go here," etc.
+		if reservedUsageMarkers[strings.ToLower(body)] {
+			continue
+		}
+		name := positionalInputName(body)
+		if name == "" {
+			continue
+		}
+		out = append(out, positionalSpec{Name: name, Required: required})
+	}
+	return out
+}
+
+// positionalInputName normalizes a Cobra positional marker into
+// an action-manifest input name. Lowercases and translates dashes
+// to underscores to satisfy the input regex `^[a-z][a-z0-9_]*$`
+// (`internal/action/validate.go`). Returns the empty string when
+// the normalized result wouldn't validate (e.g. leading digit,
+// empty body, non-ASCII chars) — callers drop those positionals
+// rather than emit an action.md that would fail validation.
+func positionalInputName(marker string) string {
+	name := strings.ToLower(strings.ReplaceAll(marker, "-", "_"))
+	if !positionalNameRe.MatchString(name) {
+		return ""
+	}
+	return name
+}
+
+// positionalNameRe matches the action-input name shape (same as
+// the validator's `inputNameRe`). Pinned locally so the emitter
+// can drop positionals before they reach `action.Validate`.
+var positionalNameRe = regexp.MustCompile(`^[a-z][a-z0-9_]*$`)

--- a/internal/wrap/positionals_test.go
+++ b/internal/wrap/positionals_test.go
@@ -1,0 +1,286 @@
+package wrap
+
+import (
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/action"
+)
+
+// TestParsePositionals_OptionalSquareBrackets pins the canonical
+// Cobra leaf shape `<binary> verb [POS] [flags]`. Square brackets
+// mark the positional as optional — the parser must record it so
+// the wrap emitter can wrap it in an `[{name}]` argv group.
+func TestParsePositionals_OptionalSquareBrackets(t *testing.T) {
+	help := `Run a SQL query against the local store.
+
+Usage:
+  linear-pp-cli sql [SQL] [flags]
+
+Flags:
+      --json   Output as JSON
+`
+	got := parsePositionals(help)
+	if len(got) != 1 {
+		t.Fatalf("got %d positionals, want 1: %+v", len(got), got)
+	}
+	if got[0].Name != "sql" {
+		t.Errorf("name = %q, want sql", got[0].Name)
+	}
+	if got[0].Required {
+		t.Errorf("required = true; square-bracket markers are optional")
+	}
+}
+
+// TestParsePositionals_RequiredAngleBrackets covers the convention
+// some CLIs use for required positionals (`<ARG>`). Required-ness
+// flows through to the action input's `required` field.
+func TestParsePositionals_RequiredAngleBrackets(t *testing.T) {
+	help := `Get one issue by id.
+
+Usage:
+  linear-pp-cli issue get <ID> [flags]
+`
+	got := parsePositionals(help)
+	if len(got) != 1 {
+		t.Fatalf("got %d, want 1", len(got))
+	}
+	if got[0].Name != "id" {
+		t.Errorf("name = %q, want id", got[0].Name)
+	}
+	if !got[0].Required {
+		t.Errorf("required = false; angle-bracket markers are required")
+	}
+}
+
+// TestParsePositionals_FiltersReservedMarkers ensures `[flags]`,
+// `[command]`, `[options]`, and `[args]` are not mistaken for
+// positional arguments. These are Cobra/urfave structural
+// markers, not named positional slots.
+func TestParsePositionals_FiltersReservedMarkers(t *testing.T) {
+	help := `Usage:
+  cmd verb [flags] [options] [command] [args]
+`
+	got := parsePositionals(help)
+	if len(got) != 0 {
+		t.Errorf("got %+v; reserved markers should not become positionals", got)
+	}
+}
+
+// TestParsePositionals_MultiplePositionalsPreserveOrder confirms
+// the argv-render order matches the Usage-line order (Cobra
+// preserves command-line position via the marker order).
+func TestParsePositionals_MultiplePositionalsPreserveOrder(t *testing.T) {
+	help := `Move a file.
+
+Usage:
+  cmd move <SOURCE> <DEST> [flags]
+`
+	got := parsePositionals(help)
+	if len(got) != 2 {
+		t.Fatalf("got %d, want 2: %+v", len(got), got)
+	}
+	if got[0].Name != "source" || got[1].Name != "dest" {
+		t.Errorf("order/names wrong: %+v", got)
+	}
+}
+
+// TestParsePositionals_SkipsCommandLine confirms the
+// `<binary> verb [command]` Usage line — Cobra emits this on
+// namespace commands to advertise the subcommand pivot — does
+// not contribute a `command` positional.
+func TestParsePositionals_SkipsCommandLine(t *testing.T) {
+	help := `Usage:
+  cmd verb [SQL] [flags]
+  cmd verb [command]
+`
+	got := parsePositionals(help)
+	if len(got) != 1 || got[0].Name != "sql" {
+		t.Errorf("got %+v; should keep [SQL] and skip the [command] line", got)
+	}
+}
+
+// TestParsePositionals_VariadicDropped covers the v1 limitation:
+// `[ARGS...]` / `<FILES...>` aren't representable in the argv-
+// pattern grammar (single placeholder, fixed token count). The
+// parser drops them so the emitter never sees them. Tracked for
+// the same follow-up that covers repeatable flag arrays.
+func TestParsePositionals_VariadicDropped(t *testing.T) {
+	help := `Usage:
+  cmd batch <FILES...> [flags]
+`
+	got := parsePositionals(help)
+	if len(got) != 0 {
+		t.Errorf("got %+v; variadic positionals should be dropped in v1", got)
+	}
+}
+
+// TestParsePositionals_DashedMarkerNamesNormalized confirms the
+// same dash-to-underscore translation applied to flag names is
+// applied to positional marker names too (`<FILE-PATH>` →
+// `file_path`). Keeps the action-input regex satisfied.
+func TestParsePositionals_DashedMarkerNamesNormalized(t *testing.T) {
+	help := `Usage:
+  cmd open <FILE-PATH> [flags]
+`
+	got := parsePositionals(help)
+	if len(got) != 1 || got[0].Name != "file_path" {
+		t.Errorf("got %+v; want file_path (dash normalized to underscore)", got)
+	}
+}
+
+// TestParsePositionals_LowercaseMarkerNames accepts CLIs that
+// follow a `[file-path]` lowercase convention rather than the
+// uppercase Cobra default.
+func TestParsePositionals_LowercaseMarkerNames(t *testing.T) {
+	help := `Usage:
+  cmd open [file-path] [flags]
+`
+	got := parsePositionals(help)
+	if len(got) != 1 || got[0].Name != "file_path" {
+		t.Errorf("got %+v; want file_path", got)
+	}
+}
+
+// TestParsePositionals_LeadingDigitDropped covers the
+// regex-compliance fallback: a positional whose normalized name
+// starts with a digit (e.g. `[2FA_CODE]`) can't be an action
+// input — the validator's `^[a-z][a-z0-9_]*$` rejects leading
+// digits. The parser drops these rather than emit an action.md
+// that would fail validation downstream.
+func TestParsePositionals_LeadingDigitDropped(t *testing.T) {
+	help := `Usage:
+  cmd login <2FA_CODE> [flags]
+`
+	got := parsePositionals(help)
+	if len(got) != 0 {
+		t.Errorf("got %+v; leading-digit names should drop", got)
+	}
+}
+
+// TestParsePositionals_OverloadedUsageLinesFirstWins covers the
+// edge case where Cobra emits multiple Usage lines (one with
+// positionals, one without). The parser takes the first leaf-
+// shape line that yields positionals so emission stays
+// deterministic.
+func TestParsePositionals_OverloadedUsageLinesFirstWins(t *testing.T) {
+	help := `Usage:
+  cmd issues [ID] [flags]
+  cmd issues --interactive
+`
+	got := parsePositionals(help)
+	if len(got) != 1 || got[0].Name != "id" {
+		t.Errorf("got %+v; want one positional from first leaf line", got)
+	}
+}
+
+// TestParsePositionals_NoUsageBlockReturnsNil tolerates --help
+// output that lacks a Usage block (rare but possible). No
+// positionals → no error.
+func TestParsePositionals_NoUsageBlockReturnsNil(t *testing.T) {
+	help := `Just some prose.
+
+Flags:
+  --json   Output as JSON
+`
+	got := parsePositionals(help)
+	if len(got) != 0 {
+		t.Errorf("got %+v; want none", got)
+	}
+}
+
+// --- buildLeafSpec integration ---
+
+// TestBuildLeafSpec_PositionalRequiredRendersInline confirms a
+// required positional becomes a bare `{name}` placeholder in the
+// argv (no brackets), positioned before any flags. The action
+// input is marked required.
+func TestBuildLeafSpec_PositionalRequiredRendersInline(t *testing.T) {
+	leaf := buildLeafSpec(
+		"linear-pp-cli",
+		[]string{"issue", "get"},
+		"Get one issue",
+		[]positionalSpec{{Name: "id", Required: true}},
+		nil,
+	)
+	wantArgv := "linear-pp-cli issue get {id}"
+	if leaf.Argv != wantArgv {
+		t.Errorf("argv = %q\n  want = %q", leaf.Argv, wantArgv)
+	}
+	if len(leaf.Params) != 1 || leaf.Params[0].Name != "id" || !leaf.Params[0].Required {
+		t.Errorf("params = %+v; want id required=true", leaf.Params)
+	}
+}
+
+// TestBuildLeafSpec_PositionalOptionalWrapsInOptionalGroup checks
+// that `[ARG]`-shaped (optional) positionals end up in the same
+// `[...]` optional-group syntax used for optional flags. Lets the
+// agent omit the positional and Cobra still accepts the bare
+// invocation.
+func TestBuildLeafSpec_PositionalOptionalWrapsInOptionalGroup(t *testing.T) {
+	leaf := buildLeafSpec(
+		"linear-pp-cli",
+		[]string{"sql"},
+		"Run SQL",
+		[]positionalSpec{{Name: "sql", Required: false}},
+		[]flagSpec{{Name: "rate-limit", Type: "float", Required: false}},
+	)
+	wantArgv := "linear-pp-cli sql [{sql}] [--rate-limit {rate_limit}]"
+	if leaf.Argv != wantArgv {
+		t.Errorf("argv = %q\n  want = %q", leaf.Argv, wantArgv)
+	}
+	// Both inputs surface as optional.
+	for _, p := range leaf.Params {
+		if p.Required {
+			t.Errorf("param %q should be optional", p.Name)
+		}
+	}
+}
+
+// TestBuildLeafSpec_PositionalsBeforeFlags pins the argv ordering
+// contract: Cobra expects positionals before flags on the command
+// line. The emitter must follow that order so the substituted
+// argv parses correctly when the wrapped CLI re-tokenizes it.
+func TestBuildLeafSpec_PositionalsBeforeFlags(t *testing.T) {
+	leaf := buildLeafSpec(
+		"mycli",
+		[]string{"do"},
+		"Do a thing",
+		[]positionalSpec{{Name: "thing", Required: true}},
+		[]flagSpec{
+			{Name: "force", Type: "string", Required: true},
+			{Name: "config", Type: "string", Required: false},
+		},
+	)
+	wantArgv := "mycli do {thing} --force {force} [--config {config}]"
+	if leaf.Argv != wantArgv {
+		t.Errorf("argv = %q\n  want = %q", leaf.Argv, wantArgv)
+	}
+}
+
+// TestBuildLeafSpec_PositionalOutputValidates is the boundary
+// check: an emitted action.md with positional inputs must parse
+// and validate against internal/action's loader. Catches the same
+// shape of bug that PR #800 fixed for dashed flag names.
+func TestBuildLeafSpec_PositionalOutputValidates(t *testing.T) {
+	leaf := buildLeafSpec(
+		"linear-pp-cli",
+		[]string{"sql"},
+		"Run SQL against the local store",
+		[]positionalSpec{{Name: "sql", Required: false}},
+		nil,
+	)
+	spec := &Spec{
+		Connector:   ConnectorSpec{Name: "local://user/linear", Version: "0.0.1"},
+		Program:     ProgramSpec{Path: "/usr/local/bin/linear-pp-cli"},
+		Subcommands: []SubcommandSpec{leaf},
+	}
+	manifest := BuildManifest(spec)
+	md := RenderActionMD(spec, leaf, manifest, "sha256:bound-at-install")
+	parsed, err := action.Parse(ActionFileName(spec, leaf), []byte(md))
+	if err != nil {
+		t.Fatalf("emitted action.md does not parse: %v\n%s", err, md)
+	}
+	if err := action.Validate(parsed, ActionFileName(spec, leaf)); err != nil {
+		t.Fatalf("emitted action.md fails validation: %v\n%s", err, md)
+	}
+}


### PR DESCRIPTION
Follow-up to #797 / #800. Closes the two end-to-end failure modes that surfaced once `aileron pp add linear` actually invoked wrapped operations.

## Summary

**Positional arguments are now supported.** The wrap heuristic walks the Cobra `Usage:` block and extracts named positional markers — `[ARG]` for optional, `<ARG>` for required — alongside the existing `Flags:` / `Global Flags:` parsing. They become typed inputs on the emitted action.md and bare/optional-group placeholders in the argv pattern. Required positionals render inline (`{name}`); optional positionals use the same `[{name}]` optional-group syntax as optional flags.

**Binary basename now lands as argv[0].** The runtime executor at `internal/sandbox/spawn.go:782` invokes the wrapped binary via `exec.CommandContext(ctx, env.Program, env.Argv[1:]...)` — it treats `Argv[0]` as the conventional binary-name slot and only passes `Argv[1:]` as subprocess args. The wrap-emitted argv patterns never included the basename as their first token, so an argv like `["sql", "<query>"]` became `linear-pp-cli <query>` at exec time — the `sql` subcommand was consumed by argv[0]. Cobra received the SQL string as "unknown command" instead of `sql <SQL>`. This affected **every** wrap-emitted operation since #797 landed.

## Why this matters

Without these two fixes, `aileron pp add linear` registered 83 callable actions but every invocation through the agent either returned Cobra usage text (no subcommand, because basename ate it) or "unknown command" (positional payload misinterpreted as the next subcommand name). The user couldn't ask Claude to create a Linear ticket without manually walking it through `linear-teams-list` → `linear-issues-create` flag-by-flag — exactly the UX the wrap was supposed to eliminate.

## End-to-end verification against the real linear-pp-cli

Refreshed the local Linear connector against this branch's binary, then exercised two leaves through the daemon:

```
$ aileron action run linear-doctor
  OK Config: ok
  OK Auth: configured
  auth_source: env:LINEAR_API_KEY
  base_url: https://api.linear.app/graphql

$ aileron action run linear-sql --args query="SELECT id, name FROM teams LIMIT 3"
# argv assembled correctly: linear-pp-cli sql "SELECT id, name FROM teams LIMIT 3"
# (Subsequent runtime failure is a sandbox fs_write scope issue
# for the sync DB — separate from this PR.)
```

The doctor result confirms credential injection works end-to-end (`auth_source: env:LINEAR_API_KEY`) and the binary is being invoked correctly (it can read its config). The sql failure is now at the sandbox layer, not the argv assembly layer.

## Scope notes (follow-ups)

- **Sandbox `fs_write` scope.** linear-pp-cli writes its sync DB to `~/.local/share/linear-pp-cli/` (XDG_DATA_HOME); the wrap's default `fs_write` is `~/.config/<name>` only. The connector's sync/sql/analytics operations fail with `mkdir .local: operation not permitted` until the wrap emits broader XDG defaults or the user hand-edits the manifest.
- **Sandbox `[capabilities.network]` scope.** The wrap doesn't infer outbound host requirements from `--help`. For Linear, the manifest needs `api.linear.app:443` (and probably the connector's GraphQL host) in `hosts`.
- **Boolean flags / repeatable arrays / variadic positionals.** Same v1 limitations as #797 — argv-pattern grammar can't represent them yet. Tracked.

## Test plan

- [x] `go test ./internal/wrap/... ./cmd/aileron/... ./internal/sandbox/... ./internal/action/... ./internal/cstore/... ./internal/app/...` — all green.
- [x] New positional-parser unit tests cover: optional/required brackets, reserved-marker filtering, multiple positionals, variadic dropping, dashed names normalized, lowercase names accepted, leading-digit dropped, overloaded usage lines, missing Usage block, the `[command]` line filtered.
- [x] New `buildLeafSpec` tests cover: required-positional inline, optional-positional in optional group, positionals-before-flags ordering, basename-prepending, full round-trip through `action.Parse` + `action.Validate`.
- [x] Updated `FromHelp` recursion test asserts the basename is included in the leaf argv.
- [x] End-to-end smoke against linear-pp-cli: `linear-doctor` exits clean with credential injected; `linear-sql` reaches the wrapped binary with the correct argv (the only remaining failure is sandbox-scope, not argv).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
