### PR TITLE
style(docs): add sidebar texture, soften ink-bleed, apply to h1

### DIFF
--- a/design/build/output/tokens.generated.css
+++ b/design/build/output/tokens.generated.css
@@ -203,7 +203,8 @@
 	--z-modal: 1300;
 	--z-toast: 1400;
 	--pattern-page: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cg fill='%23000' fill-opacity='0.03'%3E%3Crect x='0' y='1' width='2' height='1'/%3E%3Crect x='2' y='3' width='2' height='1'/%3E%3Crect x='1' y='0' width='1' height='2'/%3E%3Crect x='3' y='2' width='1' height='2'/%3E%3C/g%3E%3C/svg%3E");
-	--effect-ink-bleed: drop-shadow(1px 0px 0px rgba(0, 0, 0, 0.10)) drop-shadow(-1px 0px 0px rgba(0, 0, 0, 0.10)) drop-shadow(0px 1px 0px rgba(0, 0, 0, 0.10)) drop-shadow(0px -1px 0px rgba(0, 0, 0, 0.10));
+	--pattern-sidebar: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cg fill='%23000' fill-opacity='0.1'%3E%3Crect x='0' y='1' width='2' height='1'/%3E%3Crect x='2' y='3' width='2' height='1'/%3E%3Crect x='1' y='0' width='1' height='2'/%3E%3Crect x='3' y='2' width='1' height='2'/%3E%3C/g%3E%3C/svg%3E");
+	--effect-ink-bleed: drop-shadow(1px 0px 0px rgba(0, 0, 0, 0.08)) drop-shadow(-1px 0px 0px rgba(0, 0, 0, 0.08)) drop-shadow(0px 1px 0px rgba(0, 0, 0, 0.08)) drop-shadow(0px -1px 0px rgba(0, 0, 0, 0.08));
 }
 
 .dark {

--- a/design/tokens.json
+++ b/design/tokens.json
@@ -196,7 +196,7 @@
     "$description": "Composite visual effects beyond single shadows or color values. Each entry is a complete CSS value that consuming code applies via the appropriate property (often `filter`).",
     "ink-bleed": {
       "$description": "Subtle halo around text glyphs, simulating ink bleeding into paper. Four 1px directional drop-shadows stacked into a single filter value, at 10% opacity each. Consumed by the `.ink-bleed` CSS utility class. Apply to a text element or a container (effect cascades to descendant text). Doesn't compose with `background-clip: text` — avoid on gradient-text headings.",
-      "$value": "drop-shadow(1px 0px 0px rgba(0, 0, 0, 0.10)) drop-shadow(-1px 0px 0px rgba(0, 0, 0, 0.10)) drop-shadow(0px 1px 0px rgba(0, 0, 0, 0.10)) drop-shadow(0px -1px 0px rgba(0, 0, 0, 0.10))",
+      "$value": "drop-shadow(1px 0px 0px rgba(0, 0, 0, 0.08)) drop-shadow(-1px 0px 0px rgba(0, 0, 0, 0.08)) drop-shadow(0px 1px 0px rgba(0, 0, 0, 0.08)) drop-shadow(0px -1px 0px rgba(0, 0, 0, 0.08))",
       "$type": "string"
     }
   },
@@ -243,6 +243,11 @@
     "page": {
       "$description": "Linen-weave texture. A 6x6 tile with interlocking horizontal and vertical thread segments. At 6px the tile is well below pixel-recognition distance and reads as a continuous textured surface. Adjust tile size for tightness (smaller = denser), rect dimensions for thread thickness, fill-opacity for visibility. Parallax behavior (texture scrolls slower than content) is wired by a small scroll handler in each stack, not by this token.",
       "$value": "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cg fill='%23000' fill-opacity='0.03'%3E%3Crect x='0' y='1' width='2' height='1'/%3E%3Crect x='2' y='3' width='2' height='1'/%3E%3Crect x='1' y='0' width='1' height='2'/%3E%3Crect x='3' y='2' width='1' height='2'/%3E%3C/g%3E%3C/svg%3E\")",
+      "$type": "string"
+    },
+    "sidebar": {
+      "$description": "Same linen-weave tile as `pattern.page`, but at fill-opacity 0.1 for a slightly heavier texture on the sidebar surface than the page background.",
+      "$value": "url(\"data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cg fill='%23000' fill-opacity='0.1'%3E%3Crect x='0' y='1' width='2' height='1'/%3E%3Crect x='2' y='3' width='2' height='1'/%3E%3Crect x='1' y='0' width='1' height='2'/%3E%3Crect x='3' y='2' width='1' height='2'/%3E%3C/g%3E%3C/svg%3E\")",
       "$type": "string"
     }
   }

--- a/docs/src/components/Sidebar.svelte
+++ b/docs/src/components/Sidebar.svelte
@@ -110,6 +110,7 @@
 <aside
   class="fixed top-16 left-0 z-40 h-[calc(100vh-4rem)] w-80 shrink-0 border-r border-border bg-muted shadow-low transition-transform duration-200
     {mobileOpen ? 'translate-x-0' : '-translate-x-full'} lg:translate-x-0 lg:sticky lg:top-16 lg:h-[calc(100vh-4rem)]"
+  style="background-image: var(--pattern-sidebar); background-repeat: repeat;"
 >
   <div class="p-4 flex flex-col h-full">
     <nav class="flex-1 min-h-0 overflow-y-auto pr-4 -mr-4 flex flex-col gap-4 {mounted ? 'visible' : 'invisible'}" aria-label="Documentation">

--- a/docs/src/styles/global.css
+++ b/docs/src/styles/global.css
@@ -129,12 +129,8 @@
 		letter-spacing: var(--role-display-tracking);
 		margin-top: 0;
 		margin-bottom: 1.5rem;
-		background: linear-gradient(to right,
-			var(--foreground) 0%,
-			color-mix(in oklch, var(--foreground) 70%, transparent) 100%);
-		-webkit-background-clip: text;
-		background-clip: text;
-		color: transparent;
+		color: var(--foreground);
+		filter: var(--effect-ink-bleed);
 	}
 	@media (min-width: 640px)  { :where(.prose) h1 { font-size: 3rem; } }
 	@media (min-width: 1024px) { :where(.prose) h1 { font-size: var(--role-display-size); } }

--- a/docs/src/styles/tokens.generated.css
+++ b/docs/src/styles/tokens.generated.css
@@ -203,7 +203,8 @@
 	--z-modal: 1300;
 	--z-toast: 1400;
 	--pattern-page: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cg fill='%23000' fill-opacity='0.03'%3E%3Crect x='0' y='1' width='2' height='1'/%3E%3Crect x='2' y='3' width='2' height='1'/%3E%3Crect x='1' y='0' width='1' height='2'/%3E%3Crect x='3' y='2' width='1' height='2'/%3E%3C/g%3E%3C/svg%3E");
-	--effect-ink-bleed: drop-shadow(1px 0px 0px rgba(0, 0, 0, 0.10)) drop-shadow(-1px 0px 0px rgba(0, 0, 0, 0.10)) drop-shadow(0px 1px 0px rgba(0, 0, 0, 0.10)) drop-shadow(0px -1px 0px rgba(0, 0, 0, 0.10));
+	--pattern-sidebar: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cg fill='%23000' fill-opacity='0.1'%3E%3Crect x='0' y='1' width='2' height='1'/%3E%3Crect x='2' y='3' width='2' height='1'/%3E%3Crect x='1' y='0' width='1' height='2'/%3E%3Crect x='3' y='2' width='1' height='2'/%3E%3C/g%3E%3C/svg%3E");
+	--effect-ink-bleed: drop-shadow(1px 0px 0px rgba(0, 0, 0, 0.08)) drop-shadow(-1px 0px 0px rgba(0, 0, 0, 0.08)) drop-shadow(0px 1px 0px rgba(0, 0, 0, 0.08)) drop-shadow(0px -1px 0px rgba(0, 0, 0, 0.08));
 }
 
 .dark {

--- a/webapp/src/tokens.generated.css
+++ b/webapp/src/tokens.generated.css
@@ -203,7 +203,8 @@
 	--z-modal: 1300;
 	--z-toast: 1400;
 	--pattern-page: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cg fill='%23000' fill-opacity='0.03'%3E%3Crect x='0' y='1' width='2' height='1'/%3E%3Crect x='2' y='3' width='2' height='1'/%3E%3Crect x='1' y='0' width='1' height='2'/%3E%3Crect x='3' y='2' width='1' height='2'/%3E%3C/g%3E%3C/svg%3E");
-	--effect-ink-bleed: drop-shadow(1px 0px 0px rgba(0, 0, 0, 0.10)) drop-shadow(-1px 0px 0px rgba(0, 0, 0, 0.10)) drop-shadow(0px 1px 0px rgba(0, 0, 0, 0.10)) drop-shadow(0px -1px 0px rgba(0, 0, 0, 0.10));
+	--pattern-sidebar: url("data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' width='4' height='4' viewBox='0 0 4 4'%3E%3Cg fill='%23000' fill-opacity='0.1'%3E%3Crect x='0' y='1' width='2' height='1'/%3E%3Crect x='2' y='3' width='2' height='1'/%3E%3Crect x='1' y='0' width='1' height='2'/%3E%3Crect x='3' y='2' width='1' height='2'/%3E%3C/g%3E%3C/svg%3E");
+	--effect-ink-bleed: drop-shadow(1px 0px 0px rgba(0, 0, 0, 0.08)) drop-shadow(-1px 0px 0px rgba(0, 0, 0, 0.08)) drop-shadow(0px 1px 0px rgba(0, 0, 0, 0.08)) drop-shadow(0px -1px 0px rgba(0, 0, 0, 0.08));
 }
 
 .dark {


### PR DESCRIPTION
## Summary

- New `pattern.sidebar` design token (linen-weave SVG at `fill-opacity='0.1'`); applied to the docs `<aside>` as a background texture overlaying `bg-muted`.
- Softens `effect.ink-bleed` from alpha `0.10` → `0.08` across all four directional drop-shadows.
- Drops the gradient on `:where(.prose) h1` (`background-clip: text` + `color: transparent`) and applies `filter: var(--effect-ink-bleed)` directly. The gradient + transparent text prevented the ink-bleed halo from rendering at all — the token's own description already calls this out as an anti-pattern.

Tokens edited at the source (`design/tokens.json`); generated files regenerated via `node design/build/generate-tokens.mjs` into the three downstream `tokens.generated.css` outputs.

## Test plan

- [ ] Visit any docs page — sidebar shows a subtle linen-weave texture on top of `bg-muted`
- [ ] Page h1 (e.g. page title) renders in solid foreground with a soft per-glyph halo (no more gradient)
- [ ] Section h2/h3/p/list text still shows the ink-bleed halo at the lowered `0.08` alpha (slightly softer than before)
- [ ] Light + dark mode both render correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)