### PR TITLE
fix(daemon): drop fixed write deadline that severed streaming responses

### DIFF
--- a/internal/app/handlers_gateway.go
+++ b/internal/app/handlers_gateway.go
@@ -1,10 +1,12 @@
 package app
 
 import (
+	"context"
 	"log/slog"
 	"net/http"
 	"net/http/httputil"
 	"net/url"
+	"time"
 
 	"github.com/ALRubinger/aileron/internal/failure"
 )
@@ -81,6 +83,15 @@ func writeVaultLocked(w http.ResponseWriter) {
 //
 // providerLabel is used for structured logs only; it does not affect
 // request routing.
+//
+// The returned handler wraps the proxy's ResponseWriter so a mid-
+// stream write failure (server-side deadline firing, agent
+// disconnecting partway through SSE) emits a single Warn log line
+// with the bytes-written / elapsed-ms / r.Context() error. The
+// proxy's own ErrorHandler only triggers for pre-response transport
+// failures; without this trap the request log shows status=200 even
+// when the stream got severed and the agent saw a "socket connection
+// was closed unexpectedly".
 func newGatewayProxy(upstream *url.URL, providerLabel string, log *slog.Logger) http.Handler {
 	rp := &httputil.ReverseProxy{
 		Rewrite: func(pr *httputil.ProxyRequest) {
@@ -97,5 +108,60 @@ func newGatewayProxy(upstream *url.URL, providerLabel string, log *slog.Logger) 
 				"upstream provider request failed: "+err.Error())
 		},
 	}
-	return rp
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sw := &streamWatchWriter{
+			ResponseWriter: w,
+			log:            log,
+			provider:       providerLabel,
+			upstream:       upstream.String(),
+			ctx:            r.Context(),
+			start:          time.Now(),
+		}
+		rp.ServeHTTP(sw, r)
+	})
+}
+
+// streamWatchWriter wraps an http.ResponseWriter to surface mid-
+// stream write failures into the daemon log. Once the upstream is
+// past response headers, httputil.ReverseProxy's ErrorHandler no
+// longer fires — any later write-side failure (the http.Server's
+// WriteTimeout firing, the agent dropping the socket, etc.) returns
+// up the response-copy loop and silently terminates the stream.
+// This wrapper logs once per request when that happens.
+type streamWatchWriter struct {
+	http.ResponseWriter
+	log      *slog.Logger
+	provider string
+	upstream string
+	ctx      context.Context
+	start    time.Time
+	bytes    int64
+	logged   bool
+}
+
+func (w *streamWatchWriter) Write(b []byte) (int, error) {
+	n, err := w.ResponseWriter.Write(b)
+	w.bytes += int64(n)
+	if err != nil && !w.logged {
+		w.logged = true
+		w.log.WarnContext(w.ctx, "gateway: response stream interrupted",
+			"provider", w.provider,
+			"upstream", w.upstream,
+			"bytes_written", w.bytes,
+			"elapsed_ms", time.Since(w.start).Milliseconds(),
+			"ctx_err", w.ctx.Err(),
+			"error", err)
+	}
+	return n, err
+}
+
+// Flush proxies through to the underlying ResponseWriter when it
+// implements http.Flusher. Required so httputil.ReverseProxy's
+// FlushInterval=-1 mode can flush SSE chunks through this wrapper —
+// without it, the proxy's type assertion fails and streaming
+// silently buffers until end-of-response.
+func (w *streamWatchWriter) Flush() {
+	if f, ok := w.ResponseWriter.(http.Flusher); ok {
+		f.Flush()
+	}
 }

--- a/internal/app/handlers_gateway_test.go
+++ b/internal/app/handlers_gateway_test.go
@@ -3,7 +3,9 @@ package app
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -386,6 +388,150 @@ func TestPostChatCompletions_UpstreamUnreachable_Returns502(t *testing.T) {
 	}
 	if apiErr.Error.Code != "upstream_error" {
 		t.Errorf("error.code = %q, want upstream_error", apiErr.Error.Code)
+	}
+}
+
+// ----------------------------------------------------------------------
+// Mid-stream interruption logging.
+//
+// httputil.ReverseProxy's ErrorHandler only fires for pre-response
+// transport failures. Once the upstream is past headers, any write-
+// side failure (the http.Server's WriteTimeout firing, the agent
+// dropping the socket mid-SSE, etc.) bubbles up through the
+// response-copy loop and silently terminates the stream — no daemon-
+// side log line, the agent just sees "socket connection was closed
+// unexpectedly". The gateway wraps the ResponseWriter to emit a Warn
+// describing how far the stream got before failure. These tests pin
+// that contract.
+// ----------------------------------------------------------------------
+
+// failingResponseWriter is a minimal ResponseWriter whose Write
+// returns errAfter bytes successfully (across calls), then errors
+// out. Models the "WriteTimeout fired mid-stream" scenario.
+type failingResponseWriter struct {
+	header     http.Header
+	written    *bytes.Buffer
+	failAfter  int
+	statusCode int
+	flushCalls int
+}
+
+func newFailingResponseWriter(failAfter int) *failingResponseWriter {
+	return &failingResponseWriter{header: http.Header{}, written: &bytes.Buffer{}, failAfter: failAfter}
+}
+
+func (w *failingResponseWriter) Header() http.Header { return w.header }
+func (w *failingResponseWriter) WriteHeader(code int) {
+	if w.statusCode == 0 {
+		w.statusCode = code
+	}
+}
+func (w *failingResponseWriter) Write(b []byte) (int, error) {
+	remaining := w.failAfter - w.written.Len()
+	if remaining <= 0 {
+		return 0, errors.New("write: broken pipe")
+	}
+	if remaining < len(b) {
+		w.written.Write(b[:remaining])
+		return remaining, errors.New("write: broken pipe")
+	}
+	w.written.Write(b)
+	return len(b), nil
+}
+func (w *failingResponseWriter) Flush() { w.flushCalls++ }
+
+func TestStreamWatchWriter_LogsOnceOnMidStreamFailure(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	failing := newFailingResponseWriter(8) // allow 8 bytes, then fail
+	w := &streamWatchWriter{
+		ResponseWriter: failing,
+		log:            log,
+		provider:       "anthropic",
+		upstream:       "https://api.anthropic.com",
+		ctx:            context.Background(),
+		start:          time.Now(),
+	}
+
+	// First write fits within failAfter — succeeds, no log.
+	if _, err := w.Write([]byte("hello")); err != nil {
+		t.Fatalf("first write: unexpected error %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Fatalf("first write logged unexpectedly: %s", buf.String())
+	}
+
+	// Second write straddles the failure boundary: 3 bytes succeed, then error.
+	n, err := w.Write([]byte("world!"))
+	if err == nil {
+		t.Fatal("second write: expected error, got nil")
+	}
+	if n != 3 {
+		t.Errorf("second write: n=%d, want 3 (8-byte cap minus 5 already written)", n)
+	}
+	if w.bytes != 8 {
+		t.Errorf("streamWatchWriter.bytes = %d, want 8 (total bytes successfully written)", w.bytes)
+	}
+	if buf.Len() == 0 {
+		t.Fatal("mid-stream failure produced no log line")
+	}
+
+	logLine := buf.String()
+	for _, want := range []string{
+		`"msg":"gateway: response stream interrupted"`,
+		`"provider":"anthropic"`,
+		`"bytes_written":8`,
+		`"error":"write: broken pipe"`,
+	} {
+		if !strings.Contains(logLine, want) {
+			t.Errorf("log missing %q\nlog: %s", want, logLine)
+		}
+	}
+
+	// Subsequent write failures must not log again — one line per
+	// request is the contract (otherwise a write-heavy proxy floods
+	// the log on a single dropped client).
+	buf.Reset()
+	if _, err := w.Write([]byte("more")); err == nil {
+		t.Fatal("third write: expected error, got nil")
+	}
+	if buf.Len() != 0 {
+		t.Errorf("second failure logged again: %s", buf.String())
+	}
+}
+
+func TestStreamWatchWriter_SilentOnSuccess(t *testing.T) {
+	var buf bytes.Buffer
+	log := slog.New(slog.NewJSONHandler(&buf, &slog.HandlerOptions{Level: slog.LevelWarn}))
+
+	w := &streamWatchWriter{
+		ResponseWriter: httptest.NewRecorder(),
+		log:            log,
+		provider:       "openai",
+		upstream:       "https://api.openai.com",
+		ctx:            context.Background(),
+		start:          time.Now(),
+	}
+	if _, err := w.Write([]byte("ok")); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("successful write produced log output: %s", buf.String())
+	}
+}
+
+func TestStreamWatchWriter_FlushProxiesThrough(t *testing.T) {
+	// httputil.ReverseProxy's FlushInterval=-1 mode asserts the
+	// wrapped writer implements http.Flusher. If the wrapper drops
+	// Flush, SSE streams silently buffer instead of flushing per
+	// chunk. The test fixture's Flush increments flushCalls so we
+	// can prove the wrapper forwards the call.
+	failing := newFailingResponseWriter(1024)
+	w := &streamWatchWriter{ResponseWriter: failing, log: slog.Default(), ctx: context.Background(), start: time.Now()}
+	w.Flush()
+	if failing.flushCalls != 1 {
+		t.Errorf("flushCalls = %d, want 1 (wrapper must proxy Flush)", failing.flushCalls)
 	}
 }
 

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -357,10 +357,18 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 	}
 
 	srv := &http.Server{
-		Handler:      handler,
-		ReadTimeout:  10 * time.Second,
-		WriteTimeout: 30 * time.Second,
-		IdleTimeout:  120 * time.Second,
+		Handler: handler,
+		// ReadHeaderTimeout bounds the request-header handshake against
+		// a slowloris-style stall. Body and response deadlines are *not*
+		// fixed here: the daemon serves long-lived streams (the
+		// `/v1/messages` Anthropic SSE proxy with extended thinking) and
+		// long-running synchronous actions (`/v1/actions/{name}/run`
+		// hitting slow upstream APIs like Google Docs). A non-zero
+		// http.Server.WriteTimeout would force-close those mid-flight,
+		// surfacing on the agent side as `socket connection was closed
+		// unexpectedly`. Per-request liveness rides on r.Context().
+		ReadHeaderTimeout: 10 * time.Second,
+		IdleTimeout:       120 * time.Second,
 	}
 
 	serveErr := make(chan error, 1)


### PR DESCRIPTION
## Summary

The daemon's `http.Server` carried `WriteTimeout: 30 * time.Second`, which closes the TCP connection 30 seconds after request headers are read — regardless of what the handler is doing. That fired on the two long-tailed daemon endpoints:

- `POST /v1/messages` — Anthropic SSE proxy. With extended thinking and a large conversation context (which builds up after the agent calls a few tools), streaming responses routinely exceed 30s.
- `POST /v1/actions/{name}/run` — synchronous action execution. Google Docs `create-doc` with `body` content does two API hits (`documents.create` + `documents.batchUpdate`) and refetches the full document; comparable latency on other connectors.

When the deadline fired mid-stream the agent (Claude Code via undici) surfaced:

> API Error: The socket connection was closed unexpectedly. For more information, pass `verbose: true` in the second argument to fetch()

The daemon log was silent: `httputil.ReverseProxy`'s `ErrorHandler` only triggers for pre-response transport failures, and the request log line showed status=200 / duration<30s because the response *headers* had succeeded.

### Reproduction signal in the wild

`~/.aileron/daemon.log` already shows `/v1/messages` durations of 13.7s, 21.4s, **22.7s** — all under 30s but trending toward the ceiling. Anything that crossed 30s was killed silently.

### Fix

`internal/server/main.go`:
- Replace `ReadTimeout: 10s` / `WriteTimeout: 30s` with `ReadHeaderTimeout: 10s` only. Header handshake still gets a slowloris guard; body and response deadlines come from `r.Context()` (which the client controls).
- Keep `IdleTimeout: 120s` for the keep-alive ceiling.

`internal/app/handlers_gateway.go`:
- Wrap the reverse-proxy ResponseWriter with `streamWatchWriter` so any future mid-stream write failure (server timeout, agent disconnect, etc.) emits one `gateway: response stream interrupted` Warn line carrying `provider`, `bytes_written`, `elapsed_ms`, `ctx_err`, and the underlying `error`. Forwards `Flush()` through so the proxy's `FlushInterval=-1` SSE flushing still works.

## Test plan

- [x] `go test ./internal/app/ -count=1` — passes (12.8s)
- [x] `go test ./internal/server/ -count=1` — passes (2.2s)
- [x] New unit tests in `handlers_gateway_test.go`:
  - `TestStreamWatchWriter_LogsOnceOnMidStreamFailure` — straddling-boundary write fails, log line carries provider + bytes + error, second failure does not re-log
  - `TestStreamWatchWriter_SilentOnSuccess` — no log on clean stream
  - `TestStreamWatchWriter_FlushProxiesThrough` — wrapper forwards `http.Flusher` (required for SSE)
- [x] Pre-existing gateway streaming / pass-through tests still pass with the wrapper in place
- [ ] After merge: rebuild `build/server` (`task build:server`), restart the daemon, repeat a Gmail send / Google Doc create flow that previously failed at ~30s and confirm it completes

🤖 Generated with [Claude Code](https://claude.com/claude-code)
