### PR TITLE
fix(release): point Railway docs trigger at backboard graphql endpoint

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -104,7 +104,7 @@ jobs:
             echo "RAILWAY_TOKEN not configured; skipping docs rebuild"
             exit 0
           fi
-          curl -fsSL -X POST https://api.railway.app/graphql \
+          curl -fsSL -X POST https://backboard.railway.app/graphql/v2 \
             -H "Authorization: Bearer ${RAILWAY_TOKEN}" \
             -H "Content-Type: application/json" \
             -d '{


### PR DESCRIPTION
## Summary

- The v0.0.3 release job [failed at the trailing "Trigger docs site rebuild" step](https://github.com/ALRubinger/aileron/actions/runs/26069998870/job/76649181879) with `curl: (22) The requested URL returned error: 404`.
- The release artifacts themselves published fine (24 assets, signed, Homebrew tap pushed). Only the post-release docs-rebuild trigger was broken.
- Root cause: PR #586 wired the trigger to `https://api.railway.app/graphql`, which is Railway's **REST** host (the root page literally banners "Home of the Railway API"). It returns 404 for `/graphql`. Railway's GraphQL endpoint is `https://backboard.railway.app/graphql/v2` — confirmed with a no-auth introspection (`{ __typename }` → HTTP 200).
- v0.0.2 ran ~8 hours before #586 merged, so this step has never executed on a successful release — the bug sat dormant until v0.0.3.

## Test plan

- [x] `curl -X POST https://backboard.railway.app/graphql/v2 -d '{"query":"{ __typename }"}'` returns HTTP 200
- [x] `curl -X POST https://api.railway.app/graphql` returns HTTP 404 (current behavior)
- [ ] Merging this PR pushes to main, which triggers Railway's auto-deploy and rebuilds the docs site — picking up v0.0.3 in `$lib/data/release.ts` as a side effect.
- [ ] Next release tag (whenever) exercises the corrected trigger end-to-end.
