### PR TITLE
fix(launch): look up daemon binary as aileron-server, not server

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -53,7 +53,7 @@ tasks:
       COMMIT:
         sh: git rev-parse --short HEAD
     cmds:
-      - go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/server ./internal/server
+      - go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron-server ./internal/server
 
   build:mcp:
     desc: Build the Aileron MCP server binary locally

--- a/cmd/aileron/daemon_cli_test.go
+++ b/cmd/aileron/daemon_cli_test.go
@@ -275,11 +275,11 @@ func TestRunDaemonStart_HappyPath_PrintsURL(t *testing.T) {
 		return "http://127.0.0.1:54321", nil
 	})
 
-	// daemonBinaryPath looks for a sibling 'server' binary; when not
-	// found it falls back to PATH lookup, which will fail in test.
-	// Place a no-op binary on PATH so the resolution succeeds.
+	// daemonBinaryPath looks for a sibling 'aileron-server' binary;
+	// when not found it falls back to PATH lookup, which will fail in
+	// test. Place a no-op binary on PATH so the resolution succeeds.
 	binDir := t.TempDir()
-	server := filepath.Join(binDir, "server")
+	server := filepath.Join(binDir, "aileron-server")
 	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -299,7 +299,7 @@ func TestRunDaemonStart_SpawnError_NonZeroExit(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 
 	binDir := t.TempDir()
-	server := filepath.Join(binDir, "server")
+	server := filepath.Join(binDir, "aileron-server")
 	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -321,8 +321,8 @@ func TestRunDaemonStart_SpawnError_NonZeroExit(t *testing.T) {
 
 func TestRunDaemonStart_BinaryNotFound_NonZeroExit(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	// Empty PATH and no sibling 'server' next to the test binary →
-	// daemonBinaryPath fails before spawn is even called.
+	// Empty PATH and no sibling 'aileron-server' next to the test
+	// binary → daemonBinaryPath fails before spawn is even called.
 	t.Setenv("PATH", "")
 
 	var stdout, stderr bytes.Buffer
@@ -343,7 +343,7 @@ func TestRunDaemonStart_BinaryNotFound_NonZeroExit(t *testing.T) {
 func TestSpawnResolveOnce_HappyPath(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	binDir := t.TempDir()
-	server := filepath.Join(binDir, "server")
+	server := filepath.Join(binDir, "aileron-server")
 	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -366,7 +366,7 @@ func TestSpawnResolveOnce_HappyPath(t *testing.T) {
 func TestSpawnResolveOnce_TrimsTrailingSlash(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	binDir := t.TempDir()
-	server := filepath.Join(binDir, "server")
+	server := filepath.Join(binDir, "aileron-server")
 	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -401,7 +401,7 @@ func TestSpawnResolveOnce_BinaryMissing_Errors(t *testing.T) {
 func TestSpawnResolveOnce_PropagatesSpawnError(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
 	binDir := t.TempDir()
-	server := filepath.Join(binDir, "server")
+	server := filepath.Join(binDir, "aileron-server")
 	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -462,14 +462,14 @@ func TestDefaultStateDir_UnderHome(t *testing.T) {
 }
 
 func TestDaemonBinaryPath_FindsSibling(t *testing.T) {
-	// Drop a "server" binary next to the running test binary's dir.
-	// daemonBinaryPath uses os.Executable() to find the "self" path
+	// Drop an "aileron-server" binary next to the running test binary's
+	// dir. daemonBinaryPath uses os.Executable() to find the "self" path
 	// and looks for a sibling — this test verifies that branch.
 	self, err := os.Executable()
 	if err != nil {
 		t.Fatalf("os.Executable: %v", err)
 	}
-	sibling := filepath.Join(filepath.Dir(self), "server")
+	sibling := filepath.Join(filepath.Dir(self), "aileron-server")
 	if _, err := os.Stat(sibling); err == nil {
 		// Already exists from a previous test run; fine, just verify.
 		got, err := daemonBinaryPath()
@@ -499,10 +499,11 @@ func TestDaemonBinaryPath_FindsSibling(t *testing.T) {
 }
 
 func TestDaemonBinaryPath_FallsBackToPATH(t *testing.T) {
-	// No sibling 'server' near the test binary (we don't write one),
-	// so resolution should fall back to PATH lookup. Place one on PATH.
+	// No sibling 'aileron-server' near the test binary (we don't write
+	// one), so resolution should fall back to PATH lookup. Place one
+	// on PATH — mirrors the Homebrew install layout.
 	binDir := t.TempDir()
-	server := filepath.Join(binDir, "server")
+	server := filepath.Join(binDir, "aileron-server")
 	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -523,10 +524,10 @@ func TestDaemonBinaryPath_FallsBackToPATH(t *testing.T) {
 func TestDaemonBinaryPath_NotFound(t *testing.T) {
 	// Empty PATH and no sibling next to the test binary → not found.
 	t.Setenv("PATH", "")
-	// Best-effort: remove any sibling 'server' a previous test left
-	// behind. If we can't, the assertion below is a no-op (still safe).
+	// Best-effort: remove any sibling 'aileron-server' a previous test
+	// left behind. If we can't, the assertion below is a no-op (safe).
 	if self, err := os.Executable(); err == nil {
-		_ = os.Remove(filepath.Join(filepath.Dir(self), "server"))
+		_ = os.Remove(filepath.Join(filepath.Dir(self), "aileron-server"))
 	}
 	_, err := daemonBinaryPath()
 	if err == nil {

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -485,20 +485,20 @@ func defaultStateDir() (string, error) {
 }
 
 // daemonBinaryPath resolves the daemon binary's path: a sibling of
-// the running aileron binary named "server" (current build artifact
-// per task build:server). Falls back to PATH lookup so users running
-// `aileron` from PATH can still spawn the daemon if `server` is also
-// on PATH.
+// the running aileron binary named "aileron-server" — the name used
+// by `task build:server` and the goreleaser/Homebrew bundle. Falls
+// back to PATH lookup for layouts where os.Executable does not point
+// at the same directory the daemon is installed into.
 func daemonBinaryPath() (string, error) {
 	self, err := os.Executable()
 	if err != nil {
 		return "", err
 	}
-	candidate := filepath.Join(filepath.Dir(self), "server")
+	candidate := filepath.Join(filepath.Dir(self), "aileron-server")
 	if _, err := os.Stat(candidate); err == nil {
 		return filepath.Abs(candidate)
 	}
-	return exec.LookPath("server")
+	return exec.LookPath("aileron-server")
 }
 
 // bindingDoRequest issues an HTTP request to the server and returns

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -227,17 +227,19 @@ func resolveStateDir() (string, error) {
 }
 
 // resolveDaemonBinary locates the daemon binary — a sibling of the
-// running aileron binary named "server" — and falls back to PATH.
+// running aileron binary named "aileron-server" — and falls back to
+// PATH. The name matches the goreleaser/Homebrew artifact so installs
+// from a packaged distribution work without further setup.
 func resolveDaemonBinary() (string, error) {
 	self, err := os.Executable()
 	if err != nil {
 		return "", err
 	}
-	candidate := filepath.Join(filepath.Dir(self), "server")
+	candidate := filepath.Join(filepath.Dir(self), "aileron-server")
 	if _, err := os.Stat(candidate); err == nil {
 		return filepath.Abs(candidate)
 	}
-	return exec.LookPath("server")
+	return exec.LookPath("aileron-server")
 }
 
 // printStartupBanner writes a single line on stderr before exec'ing the

--- a/internal/launch/launcher_extra_test.go
+++ b/internal/launch/launcher_extra_test.go
@@ -7,16 +7,19 @@ import (
 )
 
 // resolveDaemonBinary contract:
-//   - sibling 'server' next to the running test binary takes priority
+//   - sibling 'aileron-server' next to the running test binary takes priority
 //   - falls back to PATH lookup when no sibling exists
 //   - returns an error when neither is reachable
+//
+// The literal name 'aileron-server' must match the goreleaser/Homebrew
+// artifact name; mismatch broke `aileron launch` for Homebrew installs.
 
 func TestResolveDaemonBinary_FindsSibling(t *testing.T) {
 	self, err := os.Executable()
 	if err != nil {
 		t.Fatalf("os.Executable: %v", err)
 	}
-	sibling := filepath.Join(filepath.Dir(self), "server")
+	sibling := filepath.Join(filepath.Dir(self), "aileron-server")
 	created := false
 	if _, err := os.Stat(sibling); err != nil {
 		if err := os.WriteFile(sibling, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
@@ -39,10 +42,10 @@ func TestResolveDaemonBinary_FindsSibling(t *testing.T) {
 func TestResolveDaemonBinary_FallsBackToPATH(t *testing.T) {
 	// Make sure no sibling is in the way (best effort).
 	if self, err := os.Executable(); err == nil {
-		_ = os.Remove(filepath.Join(filepath.Dir(self), "server"))
+		_ = os.Remove(filepath.Join(filepath.Dir(self), "aileron-server"))
 	}
 	binDir := t.TempDir()
-	server := filepath.Join(binDir, "server")
+	server := filepath.Join(binDir, "aileron-server")
 	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -59,7 +62,7 @@ func TestResolveDaemonBinary_FallsBackToPATH(t *testing.T) {
 
 func TestResolveDaemonBinary_NotFound(t *testing.T) {
 	if self, err := os.Executable(); err == nil {
-		_ = os.Remove(filepath.Join(filepath.Dir(self), "server"))
+		_ = os.Remove(filepath.Join(filepath.Dir(self), "aileron-server"))
 	}
 	t.Setenv("PATH", "")
 	if _, err := resolveDaemonBinary(); err == nil {

--- a/webapp/scripts/run-integration-e2e.sh
+++ b/webapp/scripts/run-integration-e2e.sh
@@ -2,7 +2,7 @@
 #
 # Orchestrates the tier-2 (real-daemon) Playwright integration suite.
 #
-# - Builds the daemon (or assumes a fresh `build/server` from task deps).
+# - Builds the daemon (or assumes a fresh `build/aileron-server` from task deps).
 # - Creates an isolated state dir + vault file under a temporary HOME.
 # - Starts the daemon with the basic.json seed fixture on an ephemeral
 #   loopback port.
@@ -19,7 +19,7 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 REPO_ROOT="$(cd "${SCRIPT_DIR}/../.." && pwd)"
 
-SERVER_BIN="${REPO_ROOT}/build/server"
+SERVER_BIN="${REPO_ROOT}/build/aileron-server"
 AILERON_BIN="${REPO_ROOT}/build/aileron"
 SEED_FILE="${REPO_ROOT}/test/fixtures/action-approvals/basic.json"
 WEBAPP_DIR="${REPO_ROOT}/webapp"


### PR DESCRIPTION
## Summary

- `aileron launch` (and any other auto-spawn path) failed on Homebrew installs with `locate daemon binary: exec: "server": executable file not found in $PATH`. The CLI's daemon-binary lookup searched for a binary named `server`, but the goreleaser/Homebrew bundle ships the daemon as `aileron-server`.
- Rename the local build artifact from `build/server` to `build/aileron-server` so Taskfile output matches the released name, and update both `daemonBinaryPath` (cmd/aileron) and `resolveDaemonBinary` (internal/launch) to search for `aileron-server` as sibling and on PATH.
- The existing fallback tests already covered the lookup-by-name contract; renaming the literal to `aileron-server` turns them into the regression test for this exact bug — an `aileron-server` binary on PATH (Homebrew layout) is now found.

## Test plan
- [x] `go test ./cmd/aileron/... ./internal/launch/...` passes (coverage 85.2% / 84.2%).
- [x] `go vet ./internal/... ./cmd/aileron/...` clean.
- [x] Built `task build:cli build:server`, dropped both binaries in a temp `bin/` directory mimicking Homebrew, ran `aileron daemon start` and `aileron launch claude` from an `env -i PATH=$BIN`. The original "locate daemon binary" error is gone; downstream behaviour (vault-init prompt) is reached as designed.
- [ ] CI green on this branch (release build, integration suite, codecov).

🤖 Generated with [Claude Code](https://claude.com/claude-code)