### PR TITLE
fix(launch): wire goose mcp via --with-extension, not config.yaml

### DIFF
--- a/internal/launch/agent.go
+++ b/internal/launch/agent.go
@@ -37,9 +37,9 @@ type Agent interface {
 	LLMEndpointEnv() string
 	// ConfigureMCP arranges for the agent to discover Aileron's MCP
 	// server. Agents that accept MCP wiring on the CLI (Claude Code's
-	// --mcp-config) return extra args; agents that read MCP server
-	// configuration from a config file (Codex's ~/.codex/config.toml,
-	// Goose's ~/.config/goose/config.yaml, OpenCode's opencode.json)
+	// --mcp-config, Goose's session --with-extension) return extra
+	// args; agents that read MCP server configuration from a config
+	// file (Codex's ~/.codex/config.toml, OpenCode's opencode.json)
 	// write the file and return nil args.
 	//
 	// mcpBin is the absolute path to the aileron-mcp binary.

--- a/internal/launch/agents/goose.go
+++ b/internal/launch/agents/goose.go
@@ -4,6 +4,8 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"sort"
+	"strings"
 
 	"gopkg.in/yaml.v3"
 
@@ -17,15 +19,24 @@ import (
 // (GOOSE_MODE=auto for autonomous; smart_approve/approve for prompted)
 // stays in charge.
 //
-// MCP wiring goes into `~/.config/goose/config.yaml`'s `extensions:`
-// block. Goose discovers MCP servers from this file at startup;
-// ConfigureMCP returns no extra args.
+// MCP wiring uses Goose's `session --with-extension` CLI flag rather
+// than writing into `~/.config/goose/config.yaml`. Goose v1.9.x
+// deserializes the `extensions:` block in one shot as a HashMap; if
+// any single entry fails the schema (e.g. a `type: platform` entry
+// written by a newer Goose version), the whole map silently becomes
+// empty and no extensions load. The `--with-extension` flag parses
+// directly into an ExtensionConfig::Stdio and bypasses that fragile
+// map decode.
 type Goose struct{}
 
 func (g Goose) Name() string          { return "goose" }
 func (g Goose) BinaryNames() []string { return []string{"goose"} }
 
-func (g Goose) Args() []string { return nil }
+// Args returns `["session"]` so the launcher invokes `goose session
+// --with-extension …`. `--with-extension` is a session-subcommand
+// flag in Goose's clap config; without an explicit subcommand the
+// flag isn't recognized.
+func (g Goose) Args() []string { return []string{"session"} }
 
 // Env sets GOOSE_MODE=auto so Goose runs without per-tool approval
 // prompts. Users who want Goose's own approval prompts can override
@@ -39,50 +50,112 @@ func (g Goose) Env() map[string]string {
 // Gateway routing for Goose is not available under launch today.
 func (g Goose) LLMEndpointEnv() string { return "" }
 
-// ConfigureMCP merges an `aileron` entry into the `extensions:` block
-// of `~/.config/goose/config.yaml`. Existing extensions and other
-// top-level keys are preserved. Goose's extension config is a YAML
-// object keyed by extension name; we use the `stdio` transport with
-// the aileron-mcp binary's absolute path.
+// ConfigureMCP returns CLI args that register aileron-mcp as a stdio
+// extension via Goose's `--with-extension` flag. The value format is
+// `ENV1=val1 ENV2=val2 cmd [args]` per Goose's parse_stdio_extension
+// parser. Values containing whitespace or shell metacharacters get
+// double-quoted.
 //
-// Returns nil args — Goose reads MCP servers from the config file, not
-// from CLI flags.
+// As a side effect this removes any stale `aileron` entry from
+// `~/.config/goose/config.yaml` left by prior launches that wrote
+// to the config file. Without cleanup, a future Goose version with
+// a fixed deserializer would load the stale config entry alongside
+// the live --with-extension one and spawn aileron-mcp twice (with
+// the wrong daemon URL and session ID from the stale entry).
 func (g Goose) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string) ([]string, error) {
+	if err := removeStaleAileronEntry(); err != nil {
+		return nil, fmt.Errorf("cleaning stale goose config entry: %w", err)
+	}
+	return []string{"--with-extension", encodeWithExtensionValue(mcpBin, mcpEnv)}, nil
+}
+
+// encodeWithExtensionValue builds the `ENV=val ENV=val cmd` string
+// Goose's parse_stdio_extension consumes. Env vars are emitted in
+// sorted order so the output is deterministic (Go map iteration is
+// otherwise randomized, which would make tests flaky and would
+// produce different cache keys for what is logically the same
+// invocation).
+func encodeWithExtensionValue(cmd string, envs map[string]string) string {
+	keys := make([]string, 0, len(envs))
+	for k := range envs {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	parts := make([]string, 0, len(keys)+1)
+	for _, k := range keys {
+		parts = append(parts, k+"="+shellQuoteIfNeeded(envs[k]))
+	}
+	parts = append(parts, shellQuoteIfNeeded(cmd))
+	return strings.Join(parts, " ")
+}
+
+// shellQuoteIfNeeded wraps s in double quotes (escaping any embedded
+// quotes and backslashes) when it contains whitespace or shell
+// metacharacters. Goose's split_quoted understands double-quoted
+// strings, so the round-trip is lossless for typical paths and env
+// values.
+func shellQuoteIfNeeded(s string) string {
+	if s == "" {
+		return `""`
+	}
+	if !strings.ContainsAny(s, " \t\n\"'\\$`") {
+		return s
+	}
+	var b strings.Builder
+	b.WriteByte('"')
+	for _, r := range s {
+		switch r {
+		case '"', '\\':
+			b.WriteByte('\\')
+		}
+		b.WriteRune(r)
+	}
+	b.WriteByte('"')
+	return b.String()
+}
+
+// removeStaleAileronEntry deletes any `extensions.aileron` block
+// from `~/.config/goose/config.yaml` (leaving the rest of the file
+// untouched). A missing config file is not an error — the user
+// just hasn't run Goose yet.
+func removeStaleAileronEntry() error {
 	configDir, err := gooseConfigDir()
 	if err != nil {
-		return nil, err
-	}
-	if err := os.MkdirAll(configDir, 0o755); err != nil {
-		return nil, fmt.Errorf("creating %s: %w", configDir, err)
+		return err
 	}
 	path := filepath.Join(configDir, "config.yaml")
-
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil
+		}
+		return fmt.Errorf("reading %s: %w", path, err)
+	}
 	root := map[string]any{}
-	if data, err := os.ReadFile(path); err == nil {
-		_ = yaml.Unmarshal(data, &root)
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		// Don't fail the launch over a malformed pre-existing
+		// config — leave it alone and let Goose itself surface
+		// any parse errors.
+		return nil
 	}
-
-	extensions, _ := root["extensions"].(map[string]any)
-	if extensions == nil {
-		extensions = map[string]any{}
+	extensions, ok := root["extensions"].(map[string]any)
+	if !ok {
+		return nil
 	}
-	extensions[launch.MCPServerName] = map[string]any{
-		"type":    "stdio",
-		"enabled": true,
-		"name":    launch.MCPServerName,
-		"cmd":     mcpBin,
-		"envs":    mcpEnv,
+	if _, present := extensions[launch.MCPServerName]; !present {
+		return nil
 	}
+	delete(extensions, launch.MCPServerName)
 	root["extensions"] = extensions
 
 	out, err := yaml.Marshal(root)
 	if err != nil {
-		return nil, fmt.Errorf("marshaling goose config: %w", err)
+		return fmt.Errorf("marshaling goose config: %w", err)
 	}
 	if err := os.WriteFile(path, out, 0o600); err != nil {
-		return nil, fmt.Errorf("writing %s: %w", path, err)
+		return fmt.Errorf("writing %s: %w", path, err)
 	}
-	return nil, nil
+	return nil
 }
 
 // gooseConfigDir returns Goose's per-user config directory:

--- a/internal/launch/agents/goose_test.go
+++ b/internal/launch/agents/goose_test.go
@@ -4,6 +4,7 @@ import (
 	"os"
 	"path/filepath"
 	"runtime"
+	"strings"
 	"testing"
 
 	"gopkg.in/yaml.v3"
@@ -31,7 +32,24 @@ func TestGoose_Env_ForcesAutonomousMode(t *testing.T) {
 	}
 }
 
-func TestGoose_ConfigureMCP_WritesConfigYAML(t *testing.T) {
+// TestGoose_Args_StartsSessionSubcommand pins the contract that
+// Aileron invokes `goose session …` rather than `goose` with no
+// subcommand. `--with-extension` is a session-subcommand flag in
+// Goose's clap config; without an explicit subcommand the flag
+// isn't recognized and our extension wiring silently disappears.
+func TestGoose_Args_StartsSessionSubcommand(t *testing.T) {
+	args := agents.Goose{}.Args()
+	if len(args) != 1 || args[0] != "session" {
+		t.Errorf("Args() = %v, want [\"session\"]", args)
+	}
+}
+
+// TestGoose_ConfigureMCP_ReturnsWithExtensionFlag verifies the
+// returned args are the `--with-extension <ENV=val ENV=val cmd>`
+// pair Goose's parse_stdio_extension consumes. We assert on the
+// shape rather than the exact string so future env-var additions
+// don't churn this test.
+func TestGoose_ConfigureMCP_ReturnsWithExtensionFlag(t *testing.T) {
 	if runtime.GOOS == "windows" {
 		t.Skip("XDG-based path test; Windows path resolution covered separately")
 	}
@@ -46,45 +64,62 @@ func TestGoose_ConfigureMCP_WritesConfigYAML(t *testing.T) {
 	if err != nil {
 		t.Fatalf("ConfigureMCP: %v", err)
 	}
-	if args != nil {
-		t.Errorf("Args = %v, want nil for Goose (config-file integration)", args)
+	if len(args) != 2 || args[0] != "--with-extension" {
+		t.Fatalf("Args = %v, want [\"--with-extension\", <value>]", args)
 	}
-
-	configPath := filepath.Join(home, ".config", "goose", "config.yaml")
-	data, err := os.ReadFile(configPath)
-	if err != nil {
-		t.Fatalf("config.yaml not written: %v", err)
+	value := args[1]
+	if !strings.HasSuffix(value, "/usr/local/bin/aileron-mcp") {
+		t.Errorf("--with-extension value = %q, want suffix \"/usr/local/bin/aileron-mcp\"", value)
 	}
-	var root map[string]any
-	if err := yaml.Unmarshal(data, &root); err != nil {
-		t.Fatalf("config.yaml not valid YAML: %v\n%s", err, data)
+	if !strings.Contains(value, "AILERON_URL=http://127.0.0.1:7000") {
+		t.Errorf("--with-extension value = %q, missing AILERON_URL", value)
 	}
-	extensions, _ := root["extensions"].(map[string]any)
-	if extensions == nil {
-		t.Fatalf("extensions key missing: %+v", root)
-	}
-	entry, _ := extensions["aileron"].(map[string]any)
-	if entry == nil {
-		t.Fatalf("extensions.aileron missing: %+v", extensions)
-	}
-	if entry["cmd"] != "/usr/local/bin/aileron-mcp" {
-		t.Errorf("extensions.aileron.cmd = %v, want /usr/local/bin/aileron-mcp", entry["cmd"])
-	}
-	if entry["type"] != "stdio" {
-		t.Errorf("extensions.aileron.type = %v, want \"stdio\"", entry["type"])
-	}
-	envs, _ := entry["envs"].(map[string]any)
-	if envs == nil {
-		t.Fatalf("extensions.aileron.envs missing: %+v", entry)
-	}
-	if envs["AILERON_URL"] != "http://127.0.0.1:7000" {
-		t.Errorf("envs.AILERON_URL = %v, want http://127.0.0.1:7000", envs["AILERON_URL"])
+	if !strings.Contains(value, "AILERON_SESSION_ID=sess-goose") {
+		t.Errorf("--with-extension value = %q, missing AILERON_SESSION_ID", value)
 	}
 }
 
-func TestGoose_ConfigureMCP_PreservesOtherExtensions(t *testing.T) {
+// TestGoose_ConfigureMCP_EnvVarOrderIsDeterministic prevents
+// flakiness from Go's randomized map iteration. The encoded value
+// must be stable across calls so test assertions and any cache
+// keys downstream don't churn.
+func TestGoose_ConfigureMCP_EnvVarOrderIsDeterministic(t *testing.T) {
 	if runtime.GOOS == "windows" {
-		t.Skip("XDG-based path test; Windows path resolution covered separately")
+		t.Skip("XDG-based path test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	envs := map[string]string{
+		"AILERON_URL":          "http://127.0.0.1:7000",
+		"AILERON_COMMS_URL":    "http://127.0.0.1:7000",
+		"AILERON_SESSION_ID":   "sess",
+		"AILERON_APPROVAL_URL": "http://127.0.0.1:7000/approvals",
+	}
+	first, err := agents.Goose{}.ConfigureMCP("/bin/aileron-mcp", envs, "")
+	if err != nil {
+		t.Fatalf("ConfigureMCP first: %v", err)
+	}
+	for i := 0; i < 20; i++ {
+		next, err := agents.Goose{}.ConfigureMCP("/bin/aileron-mcp", envs, "")
+		if err != nil {
+			t.Fatalf("ConfigureMCP repeat: %v", err)
+		}
+		if next[1] != first[1] {
+			t.Fatalf("--with-extension value not deterministic across calls\nfirst = %q\nrepeat = %q", first[1], next[1])
+		}
+	}
+}
+
+// TestGoose_ConfigureMCP_RemovesStaleAileronEntry covers the
+// cleanup of any pre-existing `extensions.aileron` block left by
+// older Aileron versions that wrote to config.yaml. The other
+// extensions and top-level keys must survive untouched — the user
+// (and Goose itself) may rely on them.
+func TestGoose_ConfigureMCP_RemovesStaleAileronEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG-based path test")
 	}
 	home := t.TempDir()
 	t.Setenv("HOME", home)
@@ -98,31 +133,87 @@ func TestGoose_ConfigureMCP_PreservesOtherExtensions(t *testing.T) {
 		"GOOSE_PROVIDER": "openai",
 		"extensions": map[string]any{
 			"developer": map[string]any{"enabled": true, "type": "builtin"},
-			"aileron":   map[string]any{"cmd": "/old/path"},
+			"aileron":   map[string]any{"cmd": "/old/path", "type": "stdio"},
 		},
 	}
 	seedYAML, _ := yaml.Marshal(seed)
-	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), seedYAML, 0o600); err != nil {
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, seedYAML, 0o600); err != nil {
 		t.Fatalf("seed: %v", err)
 	}
 
-	_, err := agents.Goose{}.ConfigureMCP("/new/path", map[string]string{}, "")
-	if err != nil {
+	if _, err := (agents.Goose{}).ConfigureMCP("/new/path", map[string]string{}, ""); err != nil {
 		t.Fatalf("ConfigureMCP: %v", err)
 	}
 
-	data, _ := os.ReadFile(filepath.Join(configDir, "config.yaml"))
+	data, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
 	var root map[string]any
-	_ = yaml.Unmarshal(data, &root)
+	if err := yaml.Unmarshal(data, &root); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
 	if root["GOOSE_PROVIDER"] != "openai" {
 		t.Error("top-level GOOSE_PROVIDER not preserved")
 	}
 	exts, _ := root["extensions"].(map[string]any)
+	if exts == nil {
+		t.Fatal("extensions block dropped")
+	}
 	if exts["developer"] == nil {
 		t.Error("developer extension not preserved")
 	}
-	aileronEntry, _ := exts["aileron"].(map[string]any)
-	if aileronEntry["cmd"] != "/new/path" {
-		t.Errorf("aileron extension not overwritten: %v", aileronEntry)
+	if _, present := exts["aileron"]; present {
+		t.Errorf("stale aileron entry should have been removed; got: %v", exts["aileron"])
+	}
+}
+
+// TestGoose_ConfigureMCP_NoConfigYAMLIsFine covers a fresh install
+// where the user has never run Goose. ConfigureMCP must succeed
+// without trying to create or modify any file in that case — the
+// `--with-extension` flag carries everything Goose needs.
+func TestGoose_ConfigureMCP_NoConfigYAMLIsFine(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG-based path test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	if _, err := (agents.Goose{}).ConfigureMCP("/bin/aileron-mcp", map[string]string{}, ""); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+	configPath := filepath.Join(home, ".config", "goose", "config.yaml")
+	if _, err := os.Stat(configPath); !os.IsNotExist(err) {
+		t.Errorf("ConfigureMCP should not create config.yaml when none exists; stat err = %v", err)
+	}
+}
+
+// TestGoose_ConfigureMCP_ShellQuotesValuesWithSpaces guards the
+// encoder against the case where a path or env value contains
+// whitespace — without quoting, Goose's split_quoted would slice
+// it in half and either point at a nonexistent binary or drop
+// half the value.
+func TestGoose_ConfigureMCP_ShellQuotesValuesWithSpaces(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG-based path test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	args, err := agents.Goose{}.ConfigureMCP("/Users/me/Application Support/aileron-mcp", map[string]string{
+		"WITH SPACE": "a b",
+	}, "")
+	if err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+	value := args[1]
+	if !strings.Contains(value, `"a b"`) {
+		t.Errorf("env value with space not quoted; value = %q", value)
+	}
+	if !strings.Contains(value, `"/Users/me/Application Support/aileron-mcp"`) {
+		t.Errorf("cmd path with space not quoted; value = %q", value)
 	}
 }

--- a/internal/launch/agents/goose_test.go
+++ b/internal/launch/agents/goose_test.go
@@ -217,3 +217,207 @@ func TestGoose_ConfigureMCP_ShellQuotesValuesWithSpaces(t *testing.T) {
 		t.Errorf("cmd path with space not quoted; value = %q", value)
 	}
 }
+
+// TestGoose_ConfigureMCP_QuotesEmptyEnvValues prevents an empty
+// env value from being emitted as bare `KEY=` followed by a
+// space — Goose's split_quoted would then consume the next
+// token as the value. `KEY=""` is the unambiguous form.
+func TestGoose_ConfigureMCP_QuotesEmptyEnvValues(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG-based path test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	args, err := agents.Goose{}.ConfigureMCP("/bin/aileron-mcp", map[string]string{
+		"EMPTY":  "",
+		"NORMAL": "value",
+	}, "")
+	if err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+	value := args[1]
+	if !strings.Contains(value, `EMPTY=""`) {
+		t.Errorf("empty env value not quoted as \"\"; value = %q", value)
+	}
+	if !strings.Contains(value, "NORMAL=value") {
+		t.Errorf("normal env value mangled; value = %q", value)
+	}
+}
+
+// TestGoose_ConfigureMCP_LeavesConfigUntouched_NoExtensionsKey
+// covers a config.yaml that exists but has no `extensions:`
+// block at all (older Goose installations, or users who never
+// added any). The cleanup must be a no-op — don't fabricate an
+// empty extensions key just to write one back.
+func TestGoose_ConfigureMCP_LeavesConfigUntouched_NoExtensionsKey(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG-based path test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	configDir := filepath.Join(home, ".config", "goose")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configPath := filepath.Join(configDir, "config.yaml")
+	original := []byte("GOOSE_PROVIDER: openai\nGOOSE_MODEL: gpt-4o\n")
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, err := (agents.Goose{}).ConfigureMCP("/bin/aileron-mcp", map[string]string{}, ""); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	got, err := os.ReadFile(configPath)
+	if err != nil {
+		t.Fatalf("re-read: %v", err)
+	}
+	if string(got) != string(original) {
+		t.Errorf("config.yaml mutated when no extensions key was present:\nwant: %q\ngot:  %q", original, got)
+	}
+}
+
+// TestGoose_ConfigureMCP_TolratesMalformedConfigYAML pins the
+// design decision that a pre-existing malformed config.yaml
+// must NOT fail the launch. The user's config is theirs to
+// manage; Goose itself will surface the parse error. Aileron's
+// MCP wiring still has to go through.
+func TestGoose_ConfigureMCP_ToleratesMalformedConfigYAML(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG-based path test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	configDir := filepath.Join(home, ".config", "goose")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// `:`-prefixed value at top level isn't valid YAML.
+	bad := []byte("extensions:\n  aileron:\n    cmd: :::not yaml\n  : whoops\n")
+	if err := os.WriteFile(filepath.Join(configDir, "config.yaml"), bad, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	args, err := (agents.Goose{}).ConfigureMCP("/bin/aileron-mcp", map[string]string{"AILERON_URL": "http://x"}, "")
+	if err != nil {
+		t.Fatalf("ConfigureMCP should tolerate malformed user config, got: %v", err)
+	}
+	if len(args) != 2 || args[0] != "--with-extension" {
+		t.Errorf("Args = %v, want [\"--with-extension\", <value>]", args)
+	}
+}
+
+// TestGoose_ConfigureMCP_EscapesQuotesAndBackslashes covers
+// the inner switch in the quoter — values containing a literal
+// double-quote or backslash need to be escaped, not just
+// wrapped. An unescaped `"` would terminate the quoted string
+// early and Goose's split_quoted would consume the rest as a
+// separate token (silently losing data); an unescaped `\` could
+// be interpreted as an escape introducer.
+func TestGoose_ConfigureMCP_EscapesQuotesAndBackslashes(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG-based path test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	args, err := agents.Goose{}.ConfigureMCP("/bin/aileron-mcp", map[string]string{
+		"QUOTE": `a"b`,
+		"SLASH": `a\b`,
+	}, "")
+	if err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+	value := args[1]
+	if !strings.Contains(value, `QUOTE="a\"b"`) {
+		t.Errorf("double-quote not escaped; value = %q", value)
+	}
+	if !strings.Contains(value, `SLASH="a\\b"`) {
+		t.Errorf("backslash not escaped; value = %q", value)
+	}
+}
+
+// TestGoose_ConfigureMCP_PreservesOtherExtensionsWhenNoAileronEntry
+// covers the cleanup's early-return when an existing config has
+// other extensions but no `aileron` key. The file must not be
+// rewritten — that would churn formatting/comments unnecessarily
+// for every launch.
+func TestGoose_ConfigureMCP_PreservesOtherExtensionsWhenNoAileronEntry(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG-based path test")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("XDG_CONFIG_HOME", "")
+
+	configDir := filepath.Join(home, ".config", "goose")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	configPath := filepath.Join(configDir, "config.yaml")
+	original := []byte("extensions:\n  developer:\n    enabled: true\n    type: builtin\n")
+	if err := os.WriteFile(configPath, original, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	beforeMtime, _ := os.Stat(configPath)
+
+	if _, err := (agents.Goose{}).ConfigureMCP("/bin/aileron-mcp", map[string]string{}, ""); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	afterMtime, _ := os.Stat(configPath)
+	if !afterMtime.ModTime().Equal(beforeMtime.ModTime()) {
+		// File was rewritten despite having nothing to clean — a
+		// no-op cleanup should not touch the file.
+		got, _ := os.ReadFile(configPath)
+		t.Errorf("config.yaml rewritten when no aileron entry existed to clean\nbefore: %q\nafter:  %q", original, got)
+	}
+}
+
+// TestGoose_ConfigureMCP_HonorsXDGConfigHome covers the
+// non-default XDG path. Users with a custom XDG_CONFIG_HOME
+// (common on Linux setups) need the cleanup to target their
+// actual config directory, not the implicit ~/.config fallback.
+func TestGoose_ConfigureMCP_HonorsXDGConfigHome(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("XDG-based path test")
+	}
+	xdg := t.TempDir()
+	t.Setenv("XDG_CONFIG_HOME", xdg)
+	t.Setenv("HOME", t.TempDir())
+
+	configDir := filepath.Join(xdg, "goose")
+	if err := os.MkdirAll(configDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	seed := map[string]any{
+		"extensions": map[string]any{
+			"aileron": map[string]any{"cmd": "/old/path", "type": "stdio"},
+		},
+	}
+	seedYAML, _ := yaml.Marshal(seed)
+	configPath := filepath.Join(configDir, "config.yaml")
+	if err := os.WriteFile(configPath, seedYAML, 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+
+	if _, err := (agents.Goose{}).ConfigureMCP("/new/path", map[string]string{}, ""); err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+
+	data, _ := os.ReadFile(configPath)
+	var root map[string]any
+	_ = yaml.Unmarshal(data, &root)
+	exts, _ := root["extensions"].(map[string]any)
+	if _, present := exts["aileron"]; present {
+		t.Errorf("stale aileron entry under XDG_CONFIG_HOME not cleaned up: %v", exts)
+	}
+}


### PR DESCRIPTION
## Summary

- `aileron launch goose` was silently failing to expose Aileron's MCP tools to the agent. Reproduced with `aileron pp add sentry` followed by `aileron launch goose` — the model reported "no Sentry-related extensions enabled," and the daemon log showed Goose never requested `/v1/actions`.
- Root cause: Goose v1.9.x deserializes the whole `~/.config/goose/config.yaml` `extensions:` block as a single `HashMap<String, ExtensionEntry>` and swallows decode errors via `unwrap_or_else(|_| HashMap::new())`. Any entry that fails the schema — e.g. a `type: platform` entry written by a newer Goose version — silently wipes ALL extensions. The user's config had 9 `type: platform` entries (the v1.9.2 enum has no Platform variant), so the aileron stdio entry never loaded.
- Fix: stop writing into Goose's config file. Use `goose session --with-extension <ENV=val cmd>` instead, which parses directly into an `ExtensionConfig::Stdio` via Goose's `parse_stdio_extension` and bypasses the fragile map decode.
- Also drop any pre-existing `aileron` entry from `~/.config/goose/config.yaml` so a future Goose with a per-entry deserializer (already on `main`) doesn't double-spawn aileron-mcp from both the stale config and the live `--with-extension` flag.

## What changed

| File | Change |
|---|---|
| `internal/launch/agents/goose.go` | `Args()` now returns `["session"]` (subcommand needed for `--with-extension` to parse). `ConfigureMCP` returns `["--with-extension", "<encoded value>"]` and cleans up any prior `aileron` entry instead of writing one. New helper `encodeWithExtensionValue` emits envs in sorted order; `shellQuoteIfNeeded` handles values with whitespace or shell metacharacters. |
| `internal/launch/agents/goose_test.go` | Replaced the "writes config.yaml" tests with: `Args()` returns `[session]`; `ConfigureMCP` returns `--with-extension`-shaped args containing the env vars and cmd; env order is deterministic across calls; stale `aileron` entry is removed while other extensions and top-level keys survive; absence of a pre-existing config.yaml is fine; values with spaces are shell-quoted. |
| `internal/launch/agent.go` | Doc comment on `ConfigureMCP` updated — Goose is now in the CLI-arg camp alongside Claude/Pi, not the config-file camp. |

## Test plan

- [x] `go test ./internal/launch/...` — both packages green, coverage 83.7% (agents) / 84.2% (launch).
- [x] End-to-end with rebuilt binary against the user's actual platform-polluted config: `goose session --with-extension '...'` produced a fresh `/v1/actions` hit in `~/.aileron/daemon.log`, despite 9 `type: platform` entries still in `~/.config/goose/config.yaml`.
- [x] `goose run --no-session --with-extension '... aileron-mcp' -t 'one-word: is there a tool with sentry in its name?'` → model answered "yes".
- [ ] CI build + cross-platform tests.

## Follow-up

Goose-side bug worth reporting against v1.9.x: extension-map deserialization should be per-entry with a logged warning, not whole-map with swallowed error. `block/goose@main` already does this (`crates/goose/src/config/extensions.rs:get_extensions_map_with_config`), but v1.9.2 and v1.9.3 still have the silent failure. Will file separately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)