### PR TITLE
fix(cli): tcp-probe daemon url before treating daemon.json as live

### DIFF
--- a/cmd/aileron/vault_state.go
+++ b/cmd/aileron/vault_state.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"strings"
 	"sync"
@@ -43,14 +44,23 @@ func ensureVaultUnlocked(passphraseFile string, stderr io.Writer) error {
 	}
 
 	info, derr := discoveryReadFn(stateDir)
-	daemonRunning := derr == nil
+	// "Daemon running" requires both daemon.json present AND the URL
+	// reachable. A stale daemon.json from a prior crash (the daemon
+	// only removes it on clean shutdown) outlives the process; without
+	// the liveness check we'd misclassify that as "running", skip the
+	// passphrase prompt, and let spawn.Resolve below auto-spawn a
+	// vault-locked daemon — the first vault-touching call would then
+	// surface a confusing "vault locked" error instead of asking for
+	// the passphrase.
+	daemonRunning := derr == nil && daemonReachableFn(info.URL)
 
 	if daemonRunning {
 		locked, ok := probeLocalVaultLocked(info.URL)
 		if !ok {
-			// Daemon doesn't expose the local-vault surface (cloud-shape
-			// or older binary). Nothing to do — let the dispatched
-			// command try and surface whatever error it would naturally.
+			// Daemon is reachable but doesn't expose the local-vault
+			// surface (cloud-shape or older binary). Nothing to do —
+			// let the dispatched command try and surface whatever
+			// error it would naturally.
 			return nil
 		}
 		if !locked {
@@ -59,7 +69,9 @@ func ensureVaultUnlocked(passphraseFile string, stderr io.Writer) error {
 		return promptAndUnlockRunning(info.URL, passphraseFile, stderr)
 	}
 
-	// Daemon not running: classify by vault state.
+	// Daemon not running (or dead with stale discovery files): classify
+	// by vault state. promptAndSpawnUnlock drives spawn + unlock;
+	// spawn.Resolve overwrites stale discovery files via atomic rename.
 	vaultPath := launch.DefaultVaultPath()
 	state, err := vaultCheckStateFn(vaultPath)
 	if err != nil {
@@ -339,4 +351,36 @@ var (
 	vaultInitFn          = vault.Init
 	postVaultUnlockFn    = postVaultUnlock
 	spawnResolveCachedFn = spawnResolveCached
+	daemonReachableFn    = daemonURLReachable
 )
+
+// daemonReachableTimeout caps the TCP liveness probe used by
+// ensureVaultUnlocked. Matches the equivalent in internal/daemon/spawn
+// — a tight bound is safe because the daemon binds on loopback and any
+// healthy daemon answers a SYN within sub-millisecond latency. The
+// probe is best-effort context for state-machine classification, not
+// a strict deadline on the daemon.
+const daemonReachableTimeout = 200 * time.Millisecond
+
+// daemonURLReachable reports whether a TCP connection to baseURL's
+// host:port can be established within daemonReachableTimeout. Used by
+// ensureVaultUnlocked to distinguish a live (possibly cloud-shape)
+// daemon from a stale daemon.json left behind by a crashed daemon:
+// daemon.json survives a kill -9 or panic, but no process answers at
+// the recorded URL.
+//
+// A parse failure on baseURL returns false (treated as unreachable);
+// the spawn branch then heals the state by overwriting the stale
+// discovery files via atomic rename on next daemon start.
+func daemonURLReachable(baseURL string) bool {
+	const prefix = "http://"
+	if !strings.HasPrefix(baseURL, prefix) {
+		return false
+	}
+	conn, err := net.DialTimeout("tcp", baseURL[len(prefix):], daemonReachableTimeout)
+	if err != nil {
+		return false
+	}
+	_ = conn.Close()
+	return true
+}

--- a/cmd/aileron/vault_state_test.go
+++ b/cmd/aileron/vault_state_test.go
@@ -26,12 +26,13 @@ type vaultStateFakes struct {
 	postUnlock      func(string, string) error
 	prompt          func(string, io.Writer) (string, error)
 	spawnResolve    func() (string, error)
+	daemonReachable func(string) bool
 }
 
 func withVaultStateSeams(t *testing.T, fakes vaultStateFakes) {
 	t.Helper()
-	prevRead, prevCheck, prevInit, prevPost, prevPrompt, prevSpawn :=
-		discoveryReadFn, vaultCheckStateFn, vaultInitFn, postVaultUnlockFn, promptPassphrase, spawnResolveCachedFn
+	prevRead, prevCheck, prevInit, prevPost, prevPrompt, prevSpawn, prevReachable :=
+		discoveryReadFn, vaultCheckStateFn, vaultInitFn, postVaultUnlockFn, promptPassphrase, spawnResolveCachedFn, daemonReachableFn
 	t.Cleanup(func() {
 		discoveryReadFn = prevRead
 		vaultCheckStateFn = prevCheck
@@ -39,6 +40,7 @@ func withVaultStateSeams(t *testing.T, fakes vaultStateFakes) {
 		postVaultUnlockFn = prevPost
 		promptPassphrase = prevPrompt
 		spawnResolveCachedFn = prevSpawn
+		daemonReachableFn = prevReachable
 	})
 	if fakes.discoveryRead != nil {
 		discoveryReadFn = fakes.discoveryRead
@@ -57,6 +59,9 @@ func withVaultStateSeams(t *testing.T, fakes vaultStateFakes) {
 	}
 	if fakes.spawnResolve != nil {
 		spawnResolveCachedFn = fakes.spawnResolve
+	}
+	if fakes.daemonReachable != nil {
+		daemonReachableFn = fakes.daemonReachable
 	}
 }
 
@@ -779,6 +784,128 @@ func TestEnsureVaultUnlocked_ProbeUnsupported_NoOp(t *testing.T) {
 	}
 	if postCalled {
 		t.Error("postUnlock must not fire when probe is unsupported")
+	}
+}
+
+// --- ensureVaultUnlocked: stale daemon.json from crashed daemon ---
+
+// TestEnsureVaultUnlocked_StaleDaemonJSON_DrivesSpawnAndUnlock pins
+// recovery from a crashed daemon. The daemon writes daemon.json on
+// startup and only removes it on clean shutdown (SIGTERM via the
+// run() defer); a kill -9, OOM, or panic leaves the file behind
+// pointing at a URL nobody listens on anymore.
+//
+// Before the liveness check, ensureVaultUnlocked treated the stale
+// file as proof the daemon was running, probed /v1/vault/status, got
+// a connection error, misclassified that as "daemon doesn't expose
+// the local-vault surface" (cloud-shape / older binary), and silently
+// skipped the passphrase prompt. The dispatched command then auto-
+// spawned a vault-locked daemon and surfaced "vault locked" on its
+// first vault-touching call instead of asking the user for their
+// passphrase.
+//
+// After the fix, an unreachable daemon URL falls through to
+// promptAndSpawnUnlock just like a missing daemon.json would, and
+// spawn.Resolve overwrites the stale discovery files when the fresh
+// daemon comes up.
+func TestEnsureVaultUnlocked_StaleDaemonJSON_DrivesSpawnAndUnlock(t *testing.T) {
+	scopeHomeAndAPIURL(t)
+	t.Setenv(envVaultPassphrase, "stored-pass")
+
+	spawned := false
+	var unlockedAt, unlockedWith string
+	withVaultStateSeams(t, vaultStateFakes{
+		discoveryRead: func(string) (discovery.Info, error) {
+			// Stale daemon.json: file is present (no error) but the
+			// URL points at a dead process.
+			return discovery.Info{URL: "http://127.0.0.1:1"}, nil
+		},
+		daemonReachable: func(string) bool { return false },
+		vaultCheckState: func(string) (vault.State, error) { return vault.StateReady, nil },
+		spawnResolve: func() (string, error) {
+			spawned = true
+			return "http://127.0.0.1:54321/v1", nil
+		},
+		postUnlock: func(url, pass string) error {
+			unlockedAt, unlockedWith = url, pass
+			return nil
+		},
+	})
+
+	if err := ensureVaultUnlocked("", io.Discard); err != nil {
+		t.Fatalf("ensureVaultUnlocked: %v", err)
+	}
+	if !spawned {
+		t.Error("spawnResolveCached must fire when daemon.json is stale (URL unreachable)")
+	}
+	if unlockedAt != "http://127.0.0.1:54321" {
+		t.Errorf("postUnlock url = %q, want fresh daemon URL after spawn", unlockedAt)
+	}
+	if unlockedWith != "stored-pass" {
+		t.Errorf("postUnlock passphrase = %q, want %q", unlockedWith, "stored-pass")
+	}
+}
+
+// TestEnsureVaultUnlocked_StaleDaemonJSON_VaultMissing exercises the
+// less likely cousin: daemon.json is stale AND the vault file is
+// missing. Falls through to the first-run create branch.
+func TestEnsureVaultUnlocked_StaleDaemonJSON_VaultMissing(t *testing.T) {
+	scopeHomeAndAPIURL(t)
+	t.Setenv(envVaultPassphrase, "fresh-pass")
+
+	initFired, spawnFired, unlockFired := false, false, false
+	withVaultStateSeams(t, vaultStateFakes{
+		discoveryRead: func(string) (discovery.Info, error) {
+			return discovery.Info{URL: "http://127.0.0.1:1"}, nil
+		},
+		daemonReachable: func(string) bool { return false },
+		vaultCheckState: func(string) (vault.State, error) { return vault.StateMissing, nil },
+		vaultInit:       func(string, string) (vault.Vault, error) { initFired = true; return vault.NewMemVault(), nil },
+		spawnResolve:    func() (string, error) { spawnFired = true; return "http://x/v1", nil },
+		postUnlock:      func(string, string) error { unlockFired = true; return nil },
+	})
+
+	if err := ensureVaultUnlocked("", io.Discard); err != nil {
+		t.Fatalf("ensureVaultUnlocked: %v", err)
+	}
+	for name, ok := range map[string]bool{"vault.Init": initFired, "spawn": spawnFired, "postUnlock": unlockFired} {
+		if !ok {
+			t.Errorf("%s must fire when stale daemon.json + missing vault", name)
+		}
+	}
+}
+
+// --- daemonURLReachable: contract ---
+
+// TestDaemonURLReachable_Live confirms a live listener registers as
+// reachable. The httptest server gives us a known-bound port without
+// racing on system port allocation.
+func TestDaemonURLReachable_Live(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(http.ResponseWriter, *http.Request) {}))
+	t.Cleanup(srv.Close)
+	if !daemonURLReachable(srv.URL) {
+		t.Errorf("live httptest URL %q must be reachable", srv.URL)
+	}
+}
+
+// TestDaemonURLReachable_DeadURL confirms a URL nobody listens on
+// registers as unreachable within the bounded timeout. Port 1 is the
+// codebase's standard known-dead address (see TestPostVaultUnlock_NetworkError).
+func TestDaemonURLReachable_DeadURL(t *testing.T) {
+	if daemonURLReachable("http://127.0.0.1:1") {
+		t.Error("port 1 should not be reachable")
+	}
+}
+
+// TestDaemonURLReachable_BadScheme confirms a URL that isn't a plain
+// http:// host:port returns false. The daemon URL shape is fixed by
+// ADR-0012; anything else is treated as unreachable so the spawn
+// branch can heal the state.
+func TestDaemonURLReachable_BadScheme(t *testing.T) {
+	for _, u := range []string{"", "127.0.0.1:8080", "https://x", "ftp://x"} {
+		if daemonURLReachable(u) {
+			t.Errorf("daemonURLReachable(%q) = true, want false (non-http:// scheme)", u)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

`ensureVaultUnlocked` treated `daemon.json` existing as proof the daemon was running. The daemon only removes `daemon.json`/`daemon.pid` on clean shutdown (the deferred `discovery.Remove` in `internal/server/main.go`), so a crash, `kill -9`, OOM, or panic leaves stale files behind pointing at a URL nobody listens on anymore.

When a subsequent `aileron launch claude` (or any other vault-touching command) ran:

1. `discovery.Read` succeeded — file present → `daemonRunning = true`
2. `probeLocalVaultLocked` did its 1s HTTP probe to the dead URL → connection error → `ok=false`
3. The helper misclassified the unreachable daemon as **"cloud-shape or older binary"** and silently returned nil, **skipping the passphrase prompt entirely**
4. The dispatched command's `spawn.Resolve` did its own TCP liveness probe, correctly detected the stale state, and auto-spawned a fresh daemon — but that daemon comes up **vault-locked** (`selectVault`'s no-TTY auto-spawn branch)
5. The user got a confusing "vault locked" error instead of being asked for their passphrase

`spawn.Resolve` already self-heals the discovery files (atomic-rename overwrites the stale `daemon.json`/`daemon.pid` when the fresh daemon writes its own). The bug was purely in how `ensureVaultUnlocked` classified the state.

## Fix

Add a 200ms TCP liveness check (`daemonURLReachable`) and gate `daemonRunning` on both `daemon.json` presence AND URL reachability. An unreachable URL now falls through to `promptAndSpawnUnlock`, identical to the path a missing `daemon.json` would take.

The existing "cloud-shape / older binary" path is preserved: if the daemon URL **is** reachable but `/v1/vault/status` returns a non-200, the helper still returns nil and lets the dispatched command surface whatever error it would naturally.

## Test plan

- [x] New regression test `TestEnsureVaultUnlocked_StaleDaemonJSON_DrivesSpawnAndUnlock` pins the fix: `discoveryRead` returns Info with a dead URL, `daemonReachable` seam returns false, asserts spawn + unlock both fire with the stored passphrase.
- [x] Verified the regression test **fails on pre-fix code** (manually reverted the conditional, re-ran the test, observed failure) and **passes after the fix**.
- [x] Companion test `TestEnsureVaultUnlocked_StaleDaemonJSON_VaultMissing` covers the rare combo: stale `daemon.json` + missing vault → first-run create flow.
- [x] `TestDaemonURLReachable_Live` / `_DeadURL` / `_BadScheme` cover the helper contract (live httptest server, port 1, non-http schemes).
- [x] `daemonURLReachable` at 100% coverage, `ensureVaultUnlocked` at 94.7%.
- [x] All pre-existing tests in `cmd/aileron/` still pass — the "cloud-shape / older binary" path (`TestEnsureVaultUnlocked_ProbeUnsupported_NoOp`) is unchanged because its httptest server is TCP-reachable.
- [x] Full `./cmd/aileron/... ./internal/...` test suite green (one unrelated flake in `internal/sandbox/forwarder` that passes on re-run and is not touched by this change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
