### PR TITLE
fix(wrap): wrapped CLIs see HOME + their own XDG dirs

### DIFF
--- a/cmd/aileron/cli_command.go
+++ b/cmd/aileron/cli_command.go
@@ -525,13 +525,42 @@ func buildSpecFromHelp(name, version, programPath, rootHelpText string) (*wrap.S
 		subPath := args[:len(args)-1] // drop the trailing "--help"
 		return runHelpSandboxed(ctx, programPath, cwd, subPath...)
 	}
-	spec, err := wrap.FromHelp(context.Background(), runner, fqn, version, programPath)
+	opts := wrap.FromHelpOptions{
+		AgentContext: captureAgentContext(context.Background(), programPath, cwd),
+	}
+	spec, err := wrap.FromHelpWithOptions(context.Background(), runner, fqn, version, programPath, opts)
 	if err != nil {
 		return nil, err
 	}
-	spec.FSRead = defaultFSReadScope(name)
-	spec.FSWrite = defaultFSWriteScope(name)
+	binaryName := filepath.Base(programPath)
+	spec.FSRead = defaultFSReadScope(name, binaryName)
+	spec.FSWrite = defaultFSWriteScope(name, binaryName)
+	spec.EnvPassthrough = mergeStringSets(spec.EnvPassthrough, defaultEnvPassthrough())
 	return spec, nil
+}
+
+// captureAgentContext attempts to run `<binary> agent-context` in
+// the same sandbox profile the --help introspection uses. Returns
+// nil whenever the call fails to produce parseable JSON — the
+// PrintingPress convention is opt-in, and most wrapped CLIs (gh,
+// kubectl, slackdump) don't implement it. The caller falls back
+// to --help-only positional parsing in that case, which is the
+// pre-#agent-context-positionals behavior.
+//
+// The capture runs under the same `fs_read = [cwd]`, no-network,
+// no-write, 5s-timeout profile as the --help walk, so even a
+// malicious binary that exists in the catalog can't read
+// `~/.ssh` or call out to the network from this step.
+func captureAgentContext(ctx context.Context, programPath, cwd string) *wrap.AgentContext {
+	res, err := sandbox.RunIntrospect(ctx, programPath, cwd, "agent-context")
+	if err != nil && len(res.Stdout) == 0 {
+		return nil
+	}
+	parsed, err := wrap.ParseAgentContext(res.Stdout)
+	if err != nil || parsed == nil {
+		return nil
+	}
+	return parsed
 }
 
 // defaultFSReadScope returns the default `[capabilities.spawn].fs_read`
@@ -540,6 +569,16 @@ func buildSpecFromHelp(name, version, programPath, rootHelpText string) (*wrap.S
 // `$XDG_CACHE_HOME/<name>` — so modern CLIs that store config,
 // sync DBs / SQLite caches, and ephemeral scratch in their
 // conventional XDG dirs install working out of the box.
+//
+// `connectorName` is the on-disk connector name (e.g. `linear`);
+// `binaryName` is the actual binary filename (e.g. `linear-pp-cli`).
+// Both are included so that `aileron pp add` — which mints a short
+// connector name distinct from the binary name — covers the dirs
+// the wrapped CLI actually writes to. Most wrapped CLIs use their
+// own filename as the XDG subdir (`linear-pp-cli` →
+// `~/.local/share/linear-pp-cli/`). When the two match (the common
+// `aileron cli add /usr/local/bin/gh` case), the duplicate is
+// folded out.
 //
 // The original #619 scope (config-only) under-served service-bound
 // CLIs whose data layer lives in `~/.local/share/<name>`
@@ -551,12 +590,8 @@ func buildSpecFromHelp(name, version, programPath, rootHelpText string) (*wrap.S
 // (BYOCLI) wrap default" section for the model.
 //
 // [ADR-0014]: /adr/0014-spawn-sandbox-technology
-func defaultFSReadScope(name string) []string {
-	return []string{
-		filepath.Join(xdgConfigHome(), name),
-		filepath.Join(xdgDataHome(), name),
-		filepath.Join(xdgCacheHome(), name),
-	}
+func defaultFSReadScope(connectorName, binaryName string) []string {
+	return xdgScopeFor(connectorName, binaryName)
 }
 
 // defaultFSWriteScope mirrors defaultFSReadScope. Writes follow the
@@ -565,11 +600,68 @@ func defaultFSReadScope(name string) []string {
 // rotation of cached responses), and splitting read vs. write
 // scopes here would block the common case for marginal additional
 // confinement.
-func defaultFSWriteScope(name string) []string {
+func defaultFSWriteScope(connectorName, binaryName string) []string {
+	return xdgScopeFor(connectorName, binaryName)
+}
+
+// xdgScopeFor builds the XDG triad for every distinct app-dir name
+// (connector name + binary name when they differ). The order is
+// stable: connector-name triad first, then binary-name triad,
+// duplicates removed — so an emitter that re-wraps the same binary
+// produces a byte-identical manifest.
+func xdgScopeFor(connectorName, binaryName string) []string {
+	names := []string{connectorName}
+	if binaryName != "" && binaryName != connectorName {
+		names = append(names, binaryName)
+	}
+	out := make([]string, 0, 3*len(names))
+	seen := make(map[string]struct{}, 3*len(names))
+	for _, n := range names {
+		for _, root := range []string{xdgConfigHome(), xdgDataHome(), xdgCacheHome()} {
+			p := filepath.Join(root, n)
+			if _, ok := seen[p]; ok {
+				continue
+			}
+			seen[p] = struct{}{}
+			out = append(out, p)
+		}
+	}
+	return out
+}
+
+// defaultEnvPassthrough returns the env keys every wrap-emitted
+// local connector inherits by default. These are the non-secret
+// environment knobs nearly every Unix CLI needs to resolve its own
+// state dirs and find sibling executables; without them, a
+// sandboxed subprocess sees an empty environment and computes
+// relative paths like `.local/share/<app>/data.db` that the
+// platform sandbox rejects (the EPERM mkdir failure that surfaced
+// `aileron pp add linear` on first try).
+//
+// The set is intentionally narrow:
+//
+//   - HOME: required for `os.UserHomeDir()` and every `~/`-anchored
+//     path the CLI computes (config files, cache dirs, sync stores).
+//   - PATH: required for any CLI that shells out to a sibling
+//     binary (git wrappers, kubectl plugins, common-case
+//     compose).
+//   - XDG_CONFIG_HOME / XDG_DATA_HOME / XDG_CACHE_HOME: respected
+//     by modern Cobra/clap CLIs to pick app-state roots. Unset on
+//     most macOS shells, set on Linux desktops; passing through
+//     when present lets the CLI follow the user's XDG override.
+//
+// All five are non-secret and present in the daemon's own
+// environment; the spawn envelope builder pulls their live values
+// from `os.Getenv` at invocation time. Credential env vars
+// (`LINEAR_API_KEY`, `GH_TOKEN`) are added separately by the
+// credential-detection heuristic and never flow through this list.
+func defaultEnvPassthrough() []string {
 	return []string{
-		filepath.Join(xdgConfigHome(), name),
-		filepath.Join(xdgDataHome(), name),
-		filepath.Join(xdgCacheHome(), name),
+		"HOME",
+		"PATH",
+		"XDG_CACHE_HOME",
+		"XDG_CONFIG_HOME",
+		"XDG_DATA_HOME",
 	}
 }
 

--- a/cmd/aileron/cli_command_test.go
+++ b/cmd/aileron/cli_command_test.go
@@ -331,7 +331,7 @@ func TestDefaultFSReadScope_CoversXDGTriad(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
 	t.Setenv("XDG_DATA_HOME", "/custom/data")
 	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
-	got := defaultFSReadScope("mycli")
+	got := defaultFSReadScope("mycli", "mycli")
 	want := []string{
 		"/custom/config/mycli",
 		"/custom/data/mycli",
@@ -353,7 +353,7 @@ func TestDefaultFSWriteScope_CoversXDGTriad(t *testing.T) {
 	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
 	t.Setenv("XDG_DATA_HOME", "/custom/data")
 	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
-	got := defaultFSWriteScope("mycli")
+	got := defaultFSWriteScope("mycli", "mycli")
 	want := []string{
 		"/custom/config/mycli",
 		"/custom/data/mycli",
@@ -366,6 +366,69 @@ func TestDefaultFSWriteScope_CoversXDGTriad(t *testing.T) {
 		if got[i] != want[i] {
 			t.Errorf("scope[%d]=%q, want %q", i, got[i], want[i])
 		}
+	}
+}
+
+// TestDefaultFSScope_CoversBothConnectorAndBinaryNames pins the
+// behavior that drove `aileron pp add linear` to install broken:
+// the binary `linear-pp-cli` writes to `~/.local/share/linear-pp-cli`,
+// but the on-disk connector name `pp add` mints is the bare `linear`.
+// Both XDG triads must appear so the sandbox doesn't EPERM the first
+// `sync` write.
+func TestDefaultFSScope_CoversBothConnectorAndBinaryNames(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
+	t.Setenv("XDG_DATA_HOME", "/custom/data")
+	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
+	for label, got := range map[string][]string{
+		"fs_read":  defaultFSReadScope("linear", "linear-pp-cli"),
+		"fs_write": defaultFSWriteScope("linear", "linear-pp-cli"),
+	} {
+		want := []string{
+			"/custom/config/linear",
+			"/custom/data/linear",
+			"/custom/cache/linear",
+			"/custom/config/linear-pp-cli",
+			"/custom/data/linear-pp-cli",
+			"/custom/cache/linear-pp-cli",
+		}
+		if len(got) != len(want) {
+			t.Fatalf("%s: scope=%v, want %v", label, got, want)
+		}
+		for i := range want {
+			if got[i] != want[i] {
+				t.Errorf("%s: scope[%d]=%q, want %q", label, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestDefaultEnvPassthrough_IncludesHomeAndXDG pins the set of
+// non-secret env keys every wrap-emitted local connector forwards
+// to its subprocess. Without HOME, Go's `os.UserHomeDir()` returns
+// "" and CLIs fall back to relative paths like `.local/share/...`
+// that the platform sandbox rejects with EPERM (the failure mode
+// that surfaced on `aileron pp add linear`'s first sync). XDG_*
+// support the user override; PATH covers shell-out cases.
+func TestDefaultEnvPassthrough_IncludesHomeAndXDG(t *testing.T) {
+	got := defaultEnvPassthrough()
+	want := map[string]bool{
+		"HOME":            true,
+		"PATH":            true,
+		"XDG_CACHE_HOME":  true,
+		"XDG_CONFIG_HOME": true,
+		"XDG_DATA_HOME":   true,
+	}
+	if len(got) != len(want) {
+		t.Errorf("defaultEnvPassthrough returned %d keys, want %d; got=%v", len(got), len(want), got)
+	}
+	for _, k := range got {
+		if !want[k] {
+			t.Errorf("defaultEnvPassthrough returned unexpected key %q", k)
+		}
+		delete(want, k)
+	}
+	for k := range want {
+		t.Errorf("defaultEnvPassthrough missing key %q", k)
 	}
 }
 

--- a/internal/sandbox/run_help.go
+++ b/internal/sandbox/run_help.go
@@ -64,6 +64,33 @@ type RunHelpResult struct {
 // invocation that doesn't need a fully-formed connector manifest
 // on disk first.
 func RunHelp(ctx context.Context, programPath, cwd string, subcommandPath ...string) (RunHelpResult, error) {
+	args := append(append([]string(nil), subcommandPath...), "--help")
+	return RunIntrospect(ctx, programPath, cwd, args...)
+}
+
+// RunIntrospect runs `<programPath> args...` under the same
+// sandbox profile [RunHelp] uses, with the same timeout, fs scope,
+// and output caps. It exists for one-shot introspection calls
+// whose final argument isn't `--help` — most notably the
+// PrintingPress `agent-context` convention, where the CLI emits
+// a machine-readable JSON description of its commands when
+// invoked with `agent-context` (no `--help`). Sharing the
+// sandbox profile with [RunHelp] means an introspection-time
+// call cannot reach `$HOME`, the network, or write anywhere on
+// disk even when the binary is malicious or buggy.
+//
+// `args` is the full argument tail after the binary basename
+// (which the function supplies as argv[0] itself). Callers pass
+// `[]string{"agent-context"}` for the PP convention, or any
+// other read-only metadata command the binary documents.
+//
+// Returns the same [RunHelpResult] shape as [RunHelp]. A
+// non-zero ExitCode is not an error — the caller decides what
+// to do with the captured streams (PP binaries that don't
+// implement `agent-context` typically exit non-zero with a
+// "unknown command" message that callers should treat as
+// "feature absent," not "install broken").
+func RunIntrospect(ctx context.Context, programPath, cwd string, args ...string) (RunHelpResult, error) {
 	if err := SandboxAvailable(); err != nil {
 		return RunHelpResult{}, err
 	}
@@ -77,10 +104,9 @@ func RunHelp(ctx context.Context, programPath, cwd string, subcommandPath ...str
 		return RunHelpResult{}, fmt.Errorf("run_help: cwd %q must be absolute", cwd)
 	}
 
-	argv := make([]string, 0, 2+len(subcommandPath))
+	argv := make([]string, 0, 1+len(args))
 	argv = append(argv, filepath.Base(programPath))
-	argv = append(argv, subcommandPath...)
-	argv = append(argv, "--help")
+	argv = append(argv, args...)
 	envelope := SpawnEnvelope{
 		Program: programPath,
 		Argv:    argv,

--- a/internal/wrap/agent_context.go
+++ b/internal/wrap/agent_context.go
@@ -1,0 +1,158 @@
+package wrap
+
+import (
+	"encoding/json"
+	"strings"
+)
+
+// AgentContext is the subset of the PrintingPress `agent-context`
+// JSON envelope the wrap heuristic consults to recover positional
+// arguments that a CLI's Cobra `--help` Usage block hides. The full
+// schema (versioned by `schema_version`) carries flag types,
+// defaults, pp:endpoint annotations, and auth metadata — none of
+// which the introspector needs in v1, so the decoder ignores them.
+//
+// Why a separate source: Cobra's "shortcut" convention emits a
+// Usage line that elides the positional even when the underlying
+// command requires one (linear-pp-cli's `attachments` is a
+// shortcut for `attachments get <id>`, but `--help` shows
+// `attachments <id> [flags]` only for the leaf — the shortcut
+// row in `agent-context` is what reliably carries the `<id>`).
+// Preferring the `use` string when present means a PP-style CLI
+// that documents its positionals in agent-context produces a
+// working wrap even when its `--help` output is ambiguous.
+//
+// Schema reference: github.com/mvanhorn/printing-press-library
+// (the catalog the `aileron pp add` installer reads from).
+type AgentContext struct {
+	SchemaVersion string         `json:"schema_version"`
+	Commands      []AgentCommand `json:"commands"`
+}
+
+// AgentCommand is one entry in the agent-context `commands` /
+// `subcommands` tree. Recursive — namespace commands carry a
+// `subcommands` array, leaves don't.
+type AgentCommand struct {
+	Name        string         `json:"name"`
+	Use         string         `json:"use"`
+	Short       string         `json:"short"`
+	Subcommands []AgentCommand `json:"subcommands,omitempty"`
+}
+
+// ParseAgentContext decodes the captured `agent-context` stdout
+// into the [AgentContext] subset the wrap heuristic uses. Returns
+// nil with no error when `data` is empty (the binary doesn't
+// implement the agent-context convention; callers should fall
+// back to `--help` parsing). Returns an error only for malformed
+// JSON — every other defect (missing fields, unknown schema
+// version) decodes to zero values and the caller continues.
+func ParseAgentContext(data []byte) (*AgentContext, error) {
+	if len(data) == 0 {
+		return nil, nil
+	}
+	// Tolerate leading whitespace / BOM that some CLIs emit. The
+	// JSON object itself starts at the first `{`.
+	trimmed := stripUntilJSON(data)
+	if len(trimmed) == 0 {
+		return nil, nil
+	}
+	var ctx AgentContext
+	if err := json.Unmarshal(trimmed, &ctx); err != nil {
+		return nil, err
+	}
+	return &ctx, nil
+}
+
+// stripUntilJSON trims bytes preceding the first `{` so a CLI
+// that prefixes its JSON with a banner or progress line still
+// parses. Returns the byte slice from `{` onward, or nil if no
+// `{` is present.
+func stripUntilJSON(data []byte) []byte {
+	for i, b := range data {
+		if b == '{' {
+			return data[i:]
+		}
+	}
+	return nil
+}
+
+// PositionalsByPath returns a map from verb-path (joined by " ")
+// to the positionals declared in each command's `use` string.
+// Empty when the context is nil or carries no commands.
+//
+// Example: linear-pp-cli's agent-context describes an
+// `attachments` command with `"use": "attachments <id>"` →
+// PositionalsByPath returns `{"attachments": [{Name:"id",
+// Required:true}]}`. The `--help` parser found nothing for the
+// same path because the Usage line was `attachments [flags]` (the
+// shortcut convention); the wrap emitter then prefers this
+// positional set.
+//
+// Variadic positionals (`<ARGS...>` / `[ARGS...]`) are skipped to
+// match parsePositionals — the argv-pattern grammar doesn't
+// represent variadic slots in v1.
+func PositionalsByPath(ctx *AgentContext) map[string][]positionalSpec {
+	if ctx == nil || len(ctx.Commands) == 0 {
+		return nil
+	}
+	out := map[string][]positionalSpec{}
+	for _, c := range ctx.Commands {
+		walkAgentCommands(out, nil, c)
+	}
+	if len(out) == 0 {
+		return nil
+	}
+	return out
+}
+
+// walkAgentCommands recursively flattens an [AgentCommand] tree
+// into a verb-path → positionals map. `parent` is the chain of
+// verbs accumulated above this node (e.g. `["issues"]` when
+// visiting `issues.create`). Empty parent + cmd.Name "attachments"
+// yields the key "attachments"; parent `["issues"]` + cmd.Name
+// "create" yields "issues create".
+func walkAgentCommands(out map[string][]positionalSpec, parent []string, cmd AgentCommand) {
+	if cmd.Name == "" {
+		return
+	}
+	path := append(append([]string(nil), parent...), cmd.Name)
+	key := strings.Join(path, " ")
+	if positionals := positionalsFromUse(cmd.Use, cmd.Name); len(positionals) > 0 {
+		out[key] = positionals
+	}
+	for _, sub := range cmd.Subcommands {
+		walkAgentCommands(out, path, sub)
+	}
+}
+
+// positionalsFromUse parses an agent-context `use` string into the
+// positionals it declares. The `use` field is a single line with
+// the same `[ARG]` / `<ARG>` markers Cobra's Usage block uses, but
+// without the binary prefix and the trailing `[flags]` token.
+//
+// Examples:
+//
+//	"attachments <id>"            → [{Name:"id", Required:true}]
+//	"issues [ID]"                 → [{Name:"id", Required:false}]
+//	"create"                      → nil
+//	""                            → nil
+//
+// `verbName` is the leaf verb's own name (e.g. "attachments") so
+// the parser can skip it as the leading non-marker token rather
+// than mistaking a literal positional.
+func positionalsFromUse(use, verbName string) []positionalSpec {
+	use = strings.TrimSpace(use)
+	if use == "" {
+		return nil
+	}
+	// Strip the leading verb name so the bracket-marker extractor
+	// doesn't have to know about it. `extractPositionalsFromUsageLine`
+	// only looks at `[...]` and `<...>` shapes; any leading literal
+	// tokens are ignored by that pass, so this trim is belt-and-
+	// suspenders for shapes like `<verb> <ID>` where the verb might
+	// resemble a positional.
+	if verbName != "" && strings.HasPrefix(use, verbName) {
+		use = strings.TrimSpace(use[len(verbName):])
+	}
+	return extractPositionalsFromUsageLine(use)
+}

--- a/internal/wrap/agent_context_test.go
+++ b/internal/wrap/agent_context_test.go
@@ -1,0 +1,270 @@
+package wrap
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+// TestParseAgentContext_DecodesPPCatalogShape exercises the subset
+// of the PrintingPress agent-context schema the wrap heuristic
+// reads. Fields the parser doesn't consult (schema_version-only
+// shape, auth blocks, flag metadata) are still required to decode
+// without erroring — the struct uses json tags that ignore them.
+func TestParseAgentContext_DecodesPPCatalogShape(t *testing.T) {
+	in := `{
+		"schema_version": "3",
+		"cli": {"name": "linear-pp-cli", "version": "1.0.0"},
+		"commands": [
+			{
+				"name": "attachments",
+				"use": "attachments <id>",
+				"short": "Get a single attachment"
+			},
+			{
+				"name": "issues",
+				"use": "issues [ID]",
+				"subcommands": [
+					{"name": "create", "use": "create"},
+					{"name": "list", "use": "list"}
+				]
+			}
+		]
+	}`
+	got, err := ParseAgentContext([]byte(in))
+	if err != nil {
+		t.Fatalf("ParseAgentContext: %v", err)
+	}
+	if got == nil {
+		t.Fatal("ParseAgentContext returned nil")
+	}
+	if got.SchemaVersion != "3" {
+		t.Errorf("SchemaVersion = %q, want %q", got.SchemaVersion, "3")
+	}
+	if len(got.Commands) != 2 {
+		t.Fatalf("Commands len = %d, want 2", len(got.Commands))
+	}
+	if got.Commands[0].Use != "attachments <id>" {
+		t.Errorf("Commands[0].Use = %q", got.Commands[0].Use)
+	}
+	if len(got.Commands[1].Subcommands) != 2 {
+		t.Errorf("issues.Subcommands len = %d, want 2", len(got.Commands[1].Subcommands))
+	}
+}
+
+// TestParseAgentContext_EmptyInputReturnsNil pins the convention:
+// an empty body means "binary doesn't implement agent-context";
+// callers fall back to --help-only parsing. Returning nil instead
+// of an error keeps the call site terse.
+func TestParseAgentContext_EmptyInputReturnsNil(t *testing.T) {
+	for _, in := range [][]byte{nil, {}, []byte("   \n")} {
+		got, err := ParseAgentContext(in)
+		if err != nil {
+			t.Errorf("ParseAgentContext(%q): err = %v, want nil", in, err)
+		}
+		if got != nil {
+			t.Errorf("ParseAgentContext(%q): got = %+v, want nil", in, got)
+		}
+	}
+}
+
+// TestParseAgentContext_TolerateLeadingBanner covers the wild
+// case where a CLI prints a one-line banner before the JSON. The
+// parser strips up to the first `{` so a stray progress line or
+// shell-color reset doesn't fail the whole introspection.
+func TestParseAgentContext_TolerateLeadingBanner(t *testing.T) {
+	in := "warming up...\n{\"schema_version\": \"3\", \"commands\": []}"
+	got, err := ParseAgentContext([]byte(in))
+	if err != nil {
+		t.Fatalf("ParseAgentContext: %v", err)
+	}
+	if got == nil || got.SchemaVersion != "3" {
+		t.Errorf("got = %+v, want SchemaVersion=3", got)
+	}
+}
+
+// TestParseAgentContext_MalformedJSONErrors keeps the error path
+// honest — a non-empty body that isn't JSON returns an error
+// rather than nil, so the caller sees the problem rather than
+// silently degrading to --help-only.
+func TestParseAgentContext_MalformedJSONErrors(t *testing.T) {
+	_, err := ParseAgentContext([]byte("{not json"))
+	if err == nil {
+		t.Errorf("ParseAgentContext on malformed input returned nil error")
+	}
+}
+
+// TestPositionalsByPath_FlattenedKeyShape pins the verb-path
+// shape walkSubcommand uses to look up overrides — space-joined,
+// no binary prefix. Without this stability guarantee, a refactor
+// of the path representation would silently disconnect the
+// override path from the lookup path.
+func TestPositionalsByPath_FlattenedKeyShape(t *testing.T) {
+	ctx := &AgentContext{
+		Commands: []AgentCommand{
+			{
+				Name: "attachments",
+				Use:  "attachments <id>",
+			},
+			{
+				Name: "issues",
+				Use:  "issues [ID]",
+				Subcommands: []AgentCommand{
+					{Name: "create", Use: "create"},
+					{Name: "get", Use: "get <issue_id>"},
+				},
+			},
+		},
+	}
+	got := PositionalsByPath(ctx)
+	if got == nil {
+		t.Fatal("PositionalsByPath returned nil")
+	}
+	// "attachments" → [{id, required}]
+	if specs, ok := got["attachments"]; !ok || len(specs) != 1 || specs[0].Name != "id" || !specs[0].Required {
+		t.Errorf("attachments override = %+v; want [{id, required}]", specs)
+	}
+	// "issues" → [{id, optional}] (square brackets)
+	if specs, ok := got["issues"]; !ok || len(specs) != 1 || specs[0].Name != "id" || specs[0].Required {
+		t.Errorf("issues override = %+v; want [{id, optional}]", specs)
+	}
+	// "issues get" → [{issue_id, required}]
+	if specs, ok := got["issues get"]; !ok || len(specs) != 1 || specs[0].Name != "issue_id" || !specs[0].Required {
+		t.Errorf("issues get override = %+v; want [{issue_id, required}]", specs)
+	}
+	// "issues create" has no positional in its use string; the
+	// PP convention puts flags in the separate `flags` array, not
+	// inline in `use`. The override map should therefore not
+	// carry an entry for this path — its absence is what tells
+	// walkSubcommand to keep using the --help-derived positionals
+	// (which for a flags-only leaf are empty).
+	if _, ok := got["issues create"]; ok {
+		t.Errorf("issues create unexpectedly has positional override; verb-only `use` should not register an entry")
+	}
+}
+
+// TestPositionalsByPath_NilContextReturnsNil pins the no-op path:
+// callers can pass nil (e.g. when the binary doesn't implement
+// agent-context) and the lookup is a no-op rather than a nil
+// dereference.
+func TestPositionalsByPath_NilContextReturnsNil(t *testing.T) {
+	if got := PositionalsByPath(nil); got != nil {
+		t.Errorf("PositionalsByPath(nil) = %v, want nil", got)
+	}
+	if got := PositionalsByPath(&AgentContext{}); got != nil {
+		t.Errorf("PositionalsByPath(empty) = %v, want nil", got)
+	}
+}
+
+// TestFromHelpWithOptions_AgentContextRecoversHiddenPositional is
+// the load-bearing test for `aileron pp add linear`: linear-pp-cli's
+// `attachments --help` Usage line is `attachments [flags]` (the
+// shortcut convention drops the `<id>` positional), but the
+// agent-context output declares it explicitly. Without the
+// override path, the wrap emits `linear-pp-cli attachments` with
+// no input — and the Linear API rejects the malformed GraphQL
+// query with a 400 CSRF response that looks like an auth failure
+// to the agent. With the override, the leaf gets the `{id}`
+// placeholder.
+func TestFromHelpWithOptions_AgentContextRecoversHiddenPositional(t *testing.T) {
+	rootHelp := `linear-pp-cli — Linear from the terminal.
+
+Available Commands:
+  attachments   Get a single attachment
+`
+	// The shortcut convention: Usage line elides the positional.
+	leafHelp := `Shortcut for 'attachments get'. Get a single attachment
+
+Usage:
+  linear-pp-cli attachments [flags]
+`
+	runner := pathRunner(map[string]string{
+		"":            rootHelp,
+		"attachments": leafHelp,
+	})
+	agentCtx := &AgentContext{
+		Commands: []AgentCommand{
+			{Name: "attachments", Use: "attachments <id>"},
+		},
+	}
+	s, err := FromHelpWithOptions(context.Background(), runner,
+		"local://user/linear", "0.0.1", "/usr/local/bin/linear-pp-cli",
+		FromHelpOptions{AgentContext: agentCtx})
+	if err != nil {
+		t.Fatalf("FromHelpWithOptions: %v", err)
+	}
+	if len(s.Subcommands) != 1 {
+		t.Fatalf("subcommands = %d, want 1", len(s.Subcommands))
+	}
+	leaf := s.Subcommands[0]
+	if !strings.Contains(leaf.Argv, "{id}") {
+		t.Errorf("argv = %q; expected {id} positional (recovered from agent-context)", leaf.Argv)
+	}
+	if len(leaf.Params) != 1 || leaf.Params[0].Name != "id" || !leaf.Params[0].Required {
+		t.Errorf("params = %+v; want one required `id` input", leaf.Params)
+	}
+}
+
+// TestFromHelpWithOptions_AgentContextOverridesHelpPositional pins
+// the precedence: when both --help and agent-context declare
+// positionals, agent-context wins. The structured source is
+// authoritative; --help parsing is a heuristic fallback.
+func TestFromHelpWithOptions_AgentContextOverridesHelpPositional(t *testing.T) {
+	rootHelp := `Available Commands:
+  fetch   Fetch a resource
+`
+	// --help declares one optional positional.
+	leafHelp := `Fetch a resource.
+
+Usage:
+  mycli fetch [URL] [flags]
+`
+	runner := pathRunner(map[string]string{
+		"":      rootHelp,
+		"fetch": leafHelp,
+	})
+	// agent-context declares it as REQUIRED with a different name.
+	agentCtx := &AgentContext{
+		Commands: []AgentCommand{
+			{Name: "fetch", Use: "fetch <target_url>"},
+		},
+	}
+	s, err := FromHelpWithOptions(context.Background(), runner,
+		"local://user/mycli", "0.0.1", "/usr/local/bin/mycli",
+		FromHelpOptions{AgentContext: agentCtx})
+	if err != nil {
+		t.Fatalf("FromHelpWithOptions: %v", err)
+	}
+	leaf := s.Subcommands[0]
+	if len(leaf.Params) != 1 || leaf.Params[0].Name != "target_url" || !leaf.Params[0].Required {
+		t.Errorf("params = %+v; agent-context should override --help (want required target_url)", leaf.Params)
+	}
+}
+
+// TestFromHelp_NoAgentContextPreservesHelpParsing pins the
+// backwards-compatibility floor: callers using bare FromHelp (no
+// agent-context) get exactly the pre-#agent-context behavior. A
+// shortcut-style binary still ends up with an empty positional
+// list — the bug stays as it was, but only for connectors that
+// can't supply agent-context.
+func TestFromHelp_NoAgentContextPreservesHelpParsing(t *testing.T) {
+	rootHelp := `Available Commands:
+  attachments   Get a single attachment
+`
+	leafHelp := `Usage:
+  mycli attachments [flags]
+`
+	runner := pathRunner(map[string]string{
+		"":            rootHelp,
+		"attachments": leafHelp,
+	})
+	s, err := FromHelp(context.Background(), runner,
+		"local://user/mycli", "0.0.1", "/usr/local/bin/mycli")
+	if err != nil {
+		t.Fatalf("FromHelp: %v", err)
+	}
+	leaf := s.Subcommands[0]
+	if len(leaf.Params) != 0 {
+		t.Errorf("params = %+v; bare FromHelp must not synthesize positionals", leaf.Params)
+	}
+}

--- a/internal/wrap/load.go
+++ b/internal/wrap/load.go
@@ -114,6 +114,21 @@ func HelpRunnerExec(ctx context.Context, program string, args []string) (string,
 	return string(out), err
 }
 
+// FromHelpOptions carries optional inputs to [FromHelpWithOptions].
+// Zero value matches the behavior of [FromHelp]; populated fields
+// enrich the wrap with metadata the bare `--help` parser can't
+// recover.
+type FromHelpOptions struct {
+	// AgentContext is the parsed PrintingPress `agent-context`
+	// JSON, when the wrapped binary supports the convention. Used
+	// to recover positionals that the Cobra `--help` Usage line
+	// hides (e.g. `linear-pp-cli teams` is documented as
+	// `teams <id>` in agent-context but as `teams [flags]` in
+	// --help). When nil, FromHelp parses positionals from --help
+	// alone — the pre-agent-context behavior.
+	AgentContext *AgentContext
+}
+
 // FromHelp builds a Spec by introspecting `<program> --help` and
 // every nested subcommand's `--help`. The output captures one
 // SubcommandSpec per *leaf* command (a command with no further
@@ -143,6 +158,15 @@ func HelpRunnerExec(ctx context.Context, program string, args []string) (string,
 // operation invoking the bare binary — same behavior as before the
 // recursion landed, so single-purpose wrapping paths are unchanged.
 func FromHelp(ctx context.Context, runner HelpRunner, name, version, program string) (*Spec, error) {
+	return FromHelpWithOptions(ctx, runner, name, version, program, FromHelpOptions{})
+}
+
+// FromHelpWithOptions is the option-bearing variant of [FromHelp].
+// Callers that have already captured the binary's `agent-context`
+// output (via [sandbox.RunIntrospect] + [ParseAgentContext]) pass
+// it here so the wrap heuristic can prefer the structured
+// positional declarations over `--help`-line parsing.
+func FromHelpWithOptions(ctx context.Context, runner HelpRunner, name, version, program string, opts FromHelpOptions) (*Spec, error) {
 	if !isAbsoluteOrTilde(program) {
 		return nil, fmt.Errorf("program path %q must be absolute or ~/-anchored", program)
 	}
@@ -154,6 +178,7 @@ func FromHelp(ctx context.Context, runner HelpRunner, name, version, program str
 			return nil, fmt.Errorf("invoke %s --help: %w", program, err)
 		}
 	}
+	positionalOverrides := PositionalsByPath(opts.AgentContext)
 	rootSubs := parseSubcommands(rootHelp)
 	if len(rootSubs) == 0 {
 		// CLIs without subcommands still get a single default
@@ -172,7 +197,7 @@ func FromHelp(ctx context.Context, runner HelpRunner, name, version, program str
 	progBase := baseName(program)
 	var leaves []SubcommandSpec
 	for _, rs := range rootSubs {
-		discovered, err := walkSubcommand(ctx, runner, program, progBase, []string{rs.Name}, rs.Description, 1)
+		discovered, err := walkSubcommand(ctx, runner, program, progBase, []string{rs.Name}, rs.Description, 1, positionalOverrides)
 		if err != nil {
 			// A subcommand whose --help fails (rare, but happens on
 			// stub commands) drops out of the wrap rather than
@@ -236,7 +261,7 @@ const maxSubcommandDepth = 5
 // `depth` is the current recursion depth (1 at the top-level
 // subcommand, 2 at its children, ...). Bounded by
 // [maxSubcommandDepth].
-func walkSubcommand(ctx context.Context, runner HelpRunner, program, progBase string, path []string, description string, depth int) ([]SubcommandSpec, error) {
+func walkSubcommand(ctx context.Context, runner HelpRunner, program, progBase string, path []string, description string, depth int, positionalOverrides map[string][]positionalSpec) ([]SubcommandSpec, error) {
 	args := append(append([]string(nil), path...), "--help")
 	help, err := runner(ctx, program, args)
 	if err != nil {
@@ -253,7 +278,7 @@ func walkSubcommand(ctx context.Context, runner HelpRunner, program, progBase st
 		var out []SubcommandSpec
 		for _, s := range subs {
 			child := append(append([]string(nil), path...), s.Name)
-			discovered, err := walkSubcommand(ctx, runner, program, progBase, child, s.Description, depth+1)
+			discovered, err := walkSubcommand(ctx, runner, program, progBase, child, s.Description, depth+1, positionalOverrides)
 			if err != nil {
 				continue
 			}
@@ -265,7 +290,16 @@ func walkSubcommand(ctx context.Context, runner HelpRunner, program, progBase st
 	// emit a SubcommandSpec. Positionals come from the Usage block
 	// (`<binary> verb [POS] [flags]`); flags from the Flags + Global
 	// Flags sections.
+	//
+	// Agent-context overrides win when present, even if --help
+	// already parsed positionals — the structured source is more
+	// reliable than free-form Usage scraping when the CLI provides
+	// it. CLIs without agent-context fall back to the --help
+	// parser as before.
 	positionals := parsePositionals(help)
+	if override, ok := positionalOverrides[strings.Join(path, " ")]; ok && len(override) > 0 {
+		positionals = override
+	}
 	flags := parseFlags(help)
 	leaf := buildLeafSpec(progBase, path, description, positionals, flags)
 	return []SubcommandSpec{leaf}, nil


### PR DESCRIPTION
## Summary

`aileron pp add linear` installed a connector that couldn't read or write its own state. The wrap heuristic produced a manifest that:

- Forwarded only `LINEAR_API_KEY` to the subprocess — no `HOME`, no `XDG_*`, no `PATH`. With `HOME=""`, `os.UserHomeDir()` returns the empty string and `linear-pp-cli sync` tries `mkdir .local` in the daemon's cwd. The platform sandbox EPERMs it.
- Scoped fs_read/fs_write to `~/.config/linear` / `~/.local/share/linear` / `~/.cache/linear`, but the binary writes to `~/.local/share/linear-pp-cli/...` (its own basename, not the connector short name). Even with `HOME` set, the write was outside the scope.
- Built argv patterns from `--help` Usage lines only, missing positionals that PrintingPress CLIs document in their structured `agent-context` output (`"use": "attachments <id>"`).

Three coordinated fixes:

- **`defaultEnvPassthrough`** declares `HOME`, `PATH`, and the three `XDG_*_HOME` keys for every wrap. Live values flow through `os.Getenv` at envelope-build time.
- **`defaultFSReadScope` / `defaultFSWriteScope`** now take both the connector short name AND the binary basename, emitting one XDG triad per name (deduped when they match).
- **`wrap.FromHelpWithOptions`** + **`wrap.ParseAgentContext`** + **`sandbox.RunIntrospect`**: the wrap heuristic captures `<binary> agent-context` under the same sandbox profile the `--help` walk uses, and prefers its `use` strings for positionals when present. Bare `wrap.FromHelp` is unchanged for callers that don't supply agent-context.

After this change, `aileron pp add linear` produces a manifest where `linear-sync` hydrates the local DB, `linear-issues-list` returns rows, and `linear-issues-create` writes to Linear with a real team key.

## Test plan

- [x] `task test:go` — full Go suite green
- [x] New tests in `internal/wrap/agent_context_test.go` (8 cases) covering ParseAgentContext shape, banner tolerance, malformed-JSON error path, PositionalsByPath flattening, and end-to-end `FromHelpWithOptions` recovery / override / no-context fallback
- [x] New tests in `cmd/aileron/cli_command_test.go` for `defaultEnvPassthrough` and the dual-name fs scope (connector-name + binary-name triads)
- [x] Coverage: `internal/wrap` 89.2%, `internal/sandbox` 86.4%, `cmd/aileron` 85.2%
- [x] Manual reproduction with hand-patched manifest: `linear-sync` now creates `~/.local/share/linear-pp-cli/store.db` instead of EPERMing on relative `.local`
- [ ] One known upstream limitation: `linear-pp-cli teams` is documented in agent-context as `"use": "teams"` (no positional) even though it's a shortcut for `teams get <id>`. That action remains broken until linear-pp-cli's agent-context output declares the positional; nothing the wrap can recover. The catalog of every other linear-pp-cli subcommand (`attachments`, `users`, `projects`, …) works correctly because their agent-context entries are well-formed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
