### PR TITLE
fix(wrap): emit XDG fs scopes as directory subpaths, not literal files

### DIFF
--- a/cmd/aileron/cli_command.go
+++ b/cmd/aileron/cli_command.go
@@ -609,6 +609,18 @@ func defaultFSWriteScope(connectorName, binaryName string) []string {
 // stable: connector-name triad first, then binary-name triad,
 // duplicates removed — so an emitter that re-wraps the same binary
 // produces a byte-identical manifest.
+//
+// Each emitted path carries a trailing slash. The manifest fs_read/
+// fs_write contract treats trailing-slash paths as directory scopes
+// (every file beneath the path is in scope); slashless paths denote
+// a single-file scope. The wrap emitter always produces directory
+// scopes — config/data/cache roots are never single files — so the
+// trailing slash is required for the platform sandbox to translate
+// these into `subpath` (macOS SBPL) / path-beneath (Linux Landlock)
+// allow rules. Without it, macOS sandbox-exec emits `literal` rules
+// that permit opening only the directory inode itself, and any file
+// the wrapped CLI writes underneath (`data.db`, lockfiles, journal
+// files) faults with SQLITE_CANTOPEN / EPERM.
 func xdgScopeFor(connectorName, binaryName string) []string {
 	names := []string{connectorName}
 	if binaryName != "" && binaryName != connectorName {
@@ -618,7 +630,7 @@ func xdgScopeFor(connectorName, binaryName string) []string {
 	seen := make(map[string]struct{}, 3*len(names))
 	for _, n := range names {
 		for _, root := range []string{xdgConfigHome(), xdgDataHome(), xdgCacheHome()} {
-			p := filepath.Join(root, n)
+			p := filepath.Join(root, n) + "/"
 			if _, ok := seen[p]; ok {
 				continue
 			}

--- a/cmd/aileron/cli_command_test.go
+++ b/cmd/aileron/cli_command_test.go
@@ -327,15 +327,19 @@ func TestDefaultFSReadScope_CoversXDGTriad(t *testing.T) {
 	// Wrap-emitted local connectors get fs_read on the full XDG
 	// triad (config + data + cache) so modern CLIs that store
 	// sync DBs or caches outside $XDG_CONFIG_HOME install working.
+	// Trailing slashes mark each entry as a directory scope per the
+	// manifest contract — the SBPL emitter promotes these to
+	// `subpath` rules; slashless entries would become `literal` rules
+	// and EPERM the first file write under the dir.
 	// See ADR-0014's "Local-origin (BYOCLI) wrap default" section.
 	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
 	t.Setenv("XDG_DATA_HOME", "/custom/data")
 	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
 	got := defaultFSReadScope("mycli", "mycli")
 	want := []string{
-		"/custom/config/mycli",
-		"/custom/data/mycli",
-		"/custom/cache/mycli",
+		"/custom/config/mycli/",
+		"/custom/data/mycli/",
+		"/custom/cache/mycli/",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("scope=%v, want %v", got, want)
@@ -355,9 +359,9 @@ func TestDefaultFSWriteScope_CoversXDGTriad(t *testing.T) {
 	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
 	got := defaultFSWriteScope("mycli", "mycli")
 	want := []string{
-		"/custom/config/mycli",
-		"/custom/data/mycli",
-		"/custom/cache/mycli",
+		"/custom/config/mycli/",
+		"/custom/data/mycli/",
+		"/custom/cache/mycli/",
 	}
 	if len(got) != len(want) {
 		t.Fatalf("scope=%v, want %v", got, want)
@@ -384,12 +388,12 @@ func TestDefaultFSScope_CoversBothConnectorAndBinaryNames(t *testing.T) {
 		"fs_write": defaultFSWriteScope("linear", "linear-pp-cli"),
 	} {
 		want := []string{
-			"/custom/config/linear",
-			"/custom/data/linear",
-			"/custom/cache/linear",
-			"/custom/config/linear-pp-cli",
-			"/custom/data/linear-pp-cli",
-			"/custom/cache/linear-pp-cli",
+			"/custom/config/linear/",
+			"/custom/data/linear/",
+			"/custom/cache/linear/",
+			"/custom/config/linear-pp-cli/",
+			"/custom/data/linear-pp-cli/",
+			"/custom/cache/linear-pp-cli/",
 		}
 		if len(got) != len(want) {
 			t.Fatalf("%s: scope=%v, want %v", label, got, want)
@@ -397,6 +401,42 @@ func TestDefaultFSScope_CoversBothConnectorAndBinaryNames(t *testing.T) {
 		for i := range want {
 			if got[i] != want[i] {
 				t.Errorf("%s: scope[%d]=%q, want %q", label, i, got[i], want[i])
+			}
+		}
+	}
+}
+
+// TestDefaultFSScope_PathsAreDirectoryScopes pins the manifest-
+// schema invariant the macOS sandbox depends on: every wrap-emitted
+// fs_read/fs_write entry must end with `/` so the SBPL emitter
+// translates it to a `subpath` rule. The slashless form becomes a
+// `literal` rule that permits opening only the directory inode
+// itself — every file the wrapped CLI writes underneath (sync DBs,
+// lockfiles, journal files) then faults with EPERM /
+// SQLITE_CANTOPEN. This was the breakage path on `aileron pp add
+// linear` even after #806 expanded the XDG triad and #825 added the
+// binary-basename triad: the paths reached the sandbox but
+// `(allow file-write* (literal ...))` denied data.db on first sync.
+//
+// Independently of any specific path layout, this test asserts the
+// contract directly so a future refactor of xdgScopeFor that drops
+// trailing slashes regresses the macOS run.
+func TestDefaultFSScope_PathsAreDirectoryScopes(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/custom/config")
+	t.Setenv("XDG_DATA_HOME", "/custom/data")
+	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
+	for label, paths := range map[string][]string{
+		"fs_read same-name":  defaultFSReadScope("mycli", "mycli"),
+		"fs_write same-name": defaultFSWriteScope("mycli", "mycli"),
+		"fs_read split":      defaultFSReadScope("linear", "linear-pp-cli"),
+		"fs_write split":     defaultFSWriteScope("linear", "linear-pp-cli"),
+	} {
+		if len(paths) == 0 {
+			t.Errorf("%s: scope is empty; expected at least one entry", label)
+		}
+		for _, p := range paths {
+			if !strings.HasSuffix(p, "/") {
+				t.Errorf("%s: scope entry %q must end with `/` so the SBPL emitter writes a subpath rule, not a literal", label, p)
 			}
 		}
 	}


### PR DESCRIPTION
## Summary

`aileron pp add linear` (and every wrap-emitted connector on macOS) was declaring its `fs_read`/`fs_write` scopes via `filepath.Join`, which strips trailing slashes. The manifest contract treats slashless paths as **single-file scopes**; the macOS SBPL emitter dutifully translated them into `(allow file-write* (literal "/Users/alr/.local/share/linear-pp-cli"))` — permitting only the directory inode itself.

End-to-end: the wrapped CLI ran, reached its data dir, and faulted on the first write *underneath* the directory. `linear-pp-cli sync` surfaced this as `SQLITE_CANTOPEN (14)` opening `data.db`; other operations crashed inside the sandbox with empty stderr and the daemon reported `connector exited 1; stderr: ; boundary: sandbox`. The XDG triad expansion from #806 and the binary-basename triad from #825 both put the right directories in the manifest, but the slashless form meant the SBPL allow rule covered none of the files inside them.

**Fix:** append `/` to every path `xdgScopeFor` emits. The SBPL emitter already treats trailing-slash paths as `subpath` (whole-subtree) allows. Linux Landlock is unaffected — path-beneath rules are inherently subtree-scoped regardless of the trailing slash.

Existing on-disk manifests will continue to fault until regenerated — `aileron pp add <name>` re-emits the manifest. Until then, hand-editing `manifest.toml` to add trailing slashes to the `fs_read`/`fs_write` entries works as a workaround.

## Test plan

- [x] `go test ./cmd/aileron/ -run "TestDefaultFS|TestDefaultEnvPassthrough" -v` — three updated XDG-triad tests now assert trailing-slash form; new `TestDefaultFSScope_PathsAreDirectoryScopes` pins the schema invariant directly so a future refactor of `xdgScopeFor` that drops trailing slashes regresses the macOS path.
- [x] `go test ./internal/sandbox/ -run TestBuildSBPL` — existing SBPL `subpath` vs `literal` translation tests still pass (no behavior change in the emitter).
- [x] `go test ./cmd/aileron/ ./internal/sandbox/ ./internal/wrap/` — no regressions across the touched surface.
- [ ] Maintainer smoke after merge: `aileron pp add linear` regenerates manifest → `aileron action run linear-sync` succeeds (currently EPERMs writing `data.db`). Out of scope for this PR's CI since it requires an unlocked vault and a running daemon.

## Out of scope

The user-reported Linear API CSRF error (`GET /graphql` rejected by Linear's anti-CSRF) is a bug in upstream `linear-pp-cli`, not Aileron. The user's local-store fallback errors and empty-stderr crashes both trace to this sandbox issue and should clear after manifest regeneration.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
