### PR TITLE
docs: add v4 architecture page under Meet Aileron

### DIFF
--- a/docs/package.json
+++ b/docs/package.json
@@ -18,6 +18,7 @@
     "astro": "^6.1.6",
     "bits-ui": "^2.18.0",
     "clsx": "^2.1.1",
+    "mermaid": "^11.4.1",
     "rehype-external-links": "^3.0.0",
     "shiki": "^4.0.2",
     "svelte": "^5.55.4",

--- a/docs/pnpm-lock.yaml
+++ b/docs/pnpm-lock.yaml
@@ -26,6 +26,9 @@ importers:
       clsx:
         specifier: ^2.1.1
         version: 2.1.1
+      mermaid:
+        specifier: ^11.4.1
+        version: 11.15.0
       rehype-external-links:
         specifier: ^3.0.0
         version: 3.0.0
@@ -62,6 +65,9 @@ importers:
         version: 6.0.3
 
 packages:
+
+  '@antfu/install-pkg@1.1.0':
+    resolution: {integrity: sha512-MGQsmw10ZyI+EJo45CdSER4zEb+p31LpDAFp2Z3gkSd1yqVZGi0Ebx++YTEMonJy4oChEMLsxZ64j8FH6sSqtQ==}
 
   '@astrojs/check@0.9.9':
     resolution: {integrity: sha512-A5UW8uIuErLWEoRQvzgXpO1gTjUFtK8r7nU2Z7GewAMxUb7bPvpk11qaKKgxqXlHJWlAvaaxy+Xg28A6bmQ1Tg==}
@@ -135,9 +141,15 @@ packages:
     resolution: {integrity: sha512-LwdZHpScM4Qz8Xw2iKSzS+cfglZzJGvofQICy7W7v4caru4EaAmyUuO6BGrbyQ2mYV11W0U8j5mBhd14dd3B0A==}
     engines: {node: '>=6.9.0'}
 
+  '@braintree/sanitize-url@7.1.2':
+    resolution: {integrity: sha512-jigsZK+sMF/cuiB7sERuo9V7N9jx+dhmHHnQyDSVdpZwVutaBu7WvNYqMDLSgFgfB30n452TP3vjDAvFC973mA==}
+
   '@capsizecss/unpack@4.0.0':
     resolution: {integrity: sha512-VERIM64vtTP1C4mxQ5thVT9fK0apjPFobqybMtA1UdUujWka24ERHbRHFGmpbbhp73MhV+KSsHQH9C6uOTdEQA==}
     engines: {node: '>=18'}
+
+  '@chevrotain/types@11.1.2':
+    resolution: {integrity: sha512-U+HFai5+zmJCkK86QsaJtoITlboZHBqrVketcO2ROv865xfCMSFpELQoz1GkX5GzME8pTa+3kbKrZHQtI0gdbw==}
 
   '@clack/core@1.3.1':
     resolution: {integrity: sha512-fT1qHVGAag4IEkrupZ6lRRbNCs1vS9P01KB/sG8zKgvUztbYtFBtQpjSITNwooDZ83tpsPzP0mRNs1/KVszCRA==}
@@ -336,6 +348,12 @@ packages:
   '@floating-ui/utils@0.2.11':
     resolution: {integrity: sha512-RiB/yIh78pcIxl6lLMG0CgBXAZ2Y0eVHqMPYugu+9U0AeT6YBeiJpf7lbdJNIugFP5SIjwNRgo4DhR1Qxi26Gg==}
 
+  '@iconify/types@2.0.0':
+    resolution: {integrity: sha512-+wluvCrRhXrhyOmRDJ3q8mux9JkKy5SJ/v8ol2tu4FVjyYvtEzkc/3pK15ET6RKg4b4w4BmTk1+gsCUhf21Ykg==}
+
+  '@iconify/utils@3.1.3':
+    resolution: {integrity: sha512-LPKOXPn/zV+zis1oOfGWogaXVpqUybF3ZS6SCZIsz8vg0ivVp9+fVqyYB7xq0aiST/VhUQYGO1qo6uoYSiEJqw==}
+
   '@img/colour@1.1.0':
     resolution: {integrity: sha512-Td76q7j57o/tLVdgS746cYARfSyxk8iEfRxewL9h4OMzYhbW4TAcppl0mT4eyqXddh6L/jwoM75mo7ixa/pCeQ==}
     engines: {node: '>=18'}
@@ -515,6 +533,9 @@ packages:
 
   '@mdx-js/mdx@3.1.1':
     resolution: {integrity: sha512-f6ZO2ifpwAQIpzGWaBQT2TXxPv6z3RBzQKpVftEWN78Vl/YweF1uwussDx8ECAXVtr3Rs89fKyG9YlzUs9DyGQ==}
+
+  '@mermaid-js/parser@1.1.1':
+    resolution: {integrity: sha512-VuHdsYMK1bT6X2JbcAaWAhugTRvRBRyuZgd+c22swUeI9g/ntaxF7CY7dYarhZovofCbUNO0G7JesfmNtjYOCw==}
 
   '@oslojs/encoding@1.1.0':
     resolution: {integrity: sha512-70wQhgYmndg4GCPxPPxPGevRKqTIJ2Nh4OkiMWmDAVYsTQ+Ta7Sq+rPevXyXGdzr30/qZBnyOalCszoMxlyldQ==}
@@ -814,6 +835,99 @@ packages:
     peerDependencies:
       vite: ^5.2.0 || ^6 || ^7 || ^8
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.13':
     resolution: {integrity: sha512-KSVgmQmzMwPlmtljOomayoR89W4FynCAi3E8PPs7vmDVPe84hT+vGPKkJfThkmXs0x0jAaa9U8uW8bbfyS2fWw==}
 
@@ -825,6 +939,9 @@ packages:
 
   '@types/estree@1.0.9':
     resolution: {integrity: sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@3.0.4':
     resolution: {integrity: sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ==}
@@ -852,6 +969,9 @@ packages:
 
   '@ungap/structured-clone@1.3.1':
     resolution: {integrity: sha512-mUFwbeTqrVgDQxFveS+df2yfap6iuP20NAKAsBt5jDEoOTDew+zwLAOilHCeQJOVSvmgCX4ogqIrA0mnyr08yQ==}
+
+  '@upsetjs/venn.js@2.0.0':
+    resolution: {integrity: sha512-WbBhLrooyePuQ1VZxrJjtLvTc4NVfpOyKx0sKqioq9bX1C1m7Jgykkn8gLrtwumBioXIqam8DLxp88Adbue6Hw==}
 
   '@volar/kit@2.4.28':
     resolution: {integrity: sha512-cKX4vK9dtZvDRaAzeoUdaAJEew6IdxHNCRrdp5Kvcl6zZOqb6jTOfk3kXkIkG3T7oTFXguEMt5+9ptyqYR84Pg==}
@@ -1004,6 +1124,14 @@ packages:
     resolution: {integrity: sha512-yPVavfyCcRhmorC7rWlkHn15b4wDVgVmBA7kV4QVBsF7kv/9TKJAbAXVTxvTnwP8HHKjRCJDClKbciiYS7p0DQ==}
     engines: {node: '>=16'}
 
+  commander@7.2.0:
+    resolution: {integrity: sha512-QrWXB+ZQSVPmIWIhtEO9H+gwHaMGYiF5ChvoJ+K9ZGHG/sVsa6yiesAD1GC/x46sET00Xlwo1u49RVVVzvcSkw==}
+    engines: {node: '>= 10'}
+
+  commander@8.3.0:
+    resolution: {integrity: sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww==}
+    engines: {node: '>= 12'}
+
   common-ancestor-path@2.0.0:
     resolution: {integrity: sha512-dnN3ibLeoRf2HNC+OlCiNc5d2zxbLJXOtiZUudNFSXZrNSydxcCsSpRzXwfu7BBWCIfHPw+xTayeBvJCP/D8Ng==}
     engines: {node: '>= 18'}
@@ -1014,6 +1142,12 @@ packages:
   cookie@1.1.1:
     resolution: {integrity: sha512-ei8Aos7ja0weRpFzJnEA9UHJ/7XQmqglbRwnf2ATjcB9Wq874VKH9kfjjirM6UhU2/E5fFYadylyhFldcqSidQ==}
     engines: {node: '>=18'}
+
+  cose-base@1.0.3:
+    resolution: {integrity: sha512-s9whTXInMSgAp/NVXVNuVxVKzGH2qck3aQlVHxDCdAEPgtMKwc4Wq6/QKhgdEdgbLSi9rBTAcPoRa6JpiG4ksg==}
+
+  cose-base@2.2.0:
+    resolution: {integrity: sha512-AzlgcsCbUMymkADOJtQm3wO9S3ltPfYOFD5033keQn9NJzIbtnZj+UdBJe7DYml/8TdbtHJW3j58SOnKhWY/5g==}
 
   crossws@0.3.5:
     resolution: {integrity: sha512-ojKiDvcmByhwa8YYqbQI/hg7MEU0NC03+pSdEq4ZUnZR9xXpwk7E43SMNGkn+JxJGPFtNvQ48+vV2p+P1ml5PA==}
@@ -1037,6 +1171,165 @@ packages:
     resolution: {integrity: sha512-0LrrStPOdJj+SPCCrGhzryycLjwcgUSHBtxNA8aIDxf0GLsRh1cKYhB00Gd1lDOS4yGH69+SNn13+TWbVHETFQ==}
     engines: {node: ^10 || ^12.20.0 || ^14.13.0 || >=15.0.0, npm: '>=7.0.0'}
 
+  cytoscape-cose-bilkent@4.1.0:
+    resolution: {integrity: sha512-wgQlVIUJF13Quxiv5e1gstZ08rnZj2XaLHGoFMYXz7SkNfCDOOteKBE6SYRfA9WxxI/iBc3ajfDoc6hb/MRAHQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape-fcose@2.2.0:
+    resolution: {integrity: sha512-ki1/VuRIHFCzxWNrsshHYPs6L7TvLu3DL+TyIGEsRcvVERmxokbf5Gdk7mFxZnTdiGtnA4cfSmjZJMviqSuZrQ==}
+    peerDependencies:
+      cytoscape: ^3.2.0
+
+  cytoscape@3.33.4:
+    resolution: {integrity: sha512-HIN5Pmd9MrX9BkV7tDwnOcEJCSFvCpc8X97h3f508J6I5FsqAY65wKOCvgH2CuP42CaahWaz4tuh32SOOIH7ww==}
+    engines: {node: '>=0.10'}
+
+  d3-array@2.12.1:
+    resolution: {integrity: sha512-B0ErZK/66mHtEsR1TkPEEkwdy+WDesimkM5gpZr5Dsg54BiTA5RXtYW5qTLIAcekaS9xfZrzBLF/OAkB3Qn1YQ==}
+
+  d3-array@3.2.4:
+    resolution: {integrity: sha512-tdQAmyA18i4J7wprpYq8ClcxZy3SC31QMeByyCFyRt7BVHdREQZ5lpzoe5mFEYZUWe+oq8HBvk9JjpibyEV4Jg==}
+    engines: {node: '>=12'}
+
+  d3-axis@3.0.0:
+    resolution: {integrity: sha512-IH5tgjV4jE/GhHkRV0HiVYPDtvfjHQlQfJHs0usq7M30XcSBvOotpmH1IgkcXsO/5gEQZD43B//fc7SRT5S+xw==}
+    engines: {node: '>=12'}
+
+  d3-brush@3.0.0:
+    resolution: {integrity: sha512-ALnjWlVYkXsVIGlOsuWH1+3udkYFI48Ljihfnh8FZPF2QS9o+PzGLBslO0PjzVoHLZ2KCVgAM8NVkXPJB2aNnQ==}
+    engines: {node: '>=12'}
+
+  d3-chord@3.0.1:
+    resolution: {integrity: sha512-VE5S6TNa+j8msksl7HwjxMHDM2yNK3XCkusIlpX5kwauBfXuyLAtNg9jCp/iHH61tgI4sb6R/EIMWCqEIdjT/g==}
+    engines: {node: '>=12'}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-contour@4.0.2:
+    resolution: {integrity: sha512-4EzFTRIikzs47RGmdxbeUvLWtGedDUNkTcmzoeyg4sP/dvCexO47AaQL7VKy/gul85TOxw+IBgA8US2xwbToNA==}
+    engines: {node: '>=12'}
+
+  d3-delaunay@6.0.4:
+    resolution: {integrity: sha512-mdjtIZ1XLAM8bm/hx3WwjfHt6Sggek7qH043O8KEjDXN40xi3vx/6pYSVTwLjEgiXQTbvaouWKynLBiUZ6SK6A==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-dsv@3.0.1:
+    resolution: {integrity: sha512-UG6OvdI5afDIFP9w4G0mNq50dSOsXHJaRE8arAS5o9ApWnIElp8GZw1Dun8vP8OyHOZ/QJUKUJwxiiCCnUwm+Q==}
+    engines: {node: '>=12'}
+    hasBin: true
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-fetch@3.0.1:
+    resolution: {integrity: sha512-kpkQIM20n3oLVBKGg6oHrUchHM3xODkTzjMoj7aWQFq5QEM+R6E4WkzT5+tojDY7yjez8KgCBRoj4aEr99Fdqw==}
+    engines: {node: '>=12'}
+
+  d3-force@3.0.0:
+    resolution: {integrity: sha512-zxV/SsA+U4yte8051P4ECydjD/S+qeYtnaIyAs9tgHCqfguma/aAQDjo85A9Z6EKhBirHRJHXIgJUlffT4wdLg==}
+    engines: {node: '>=12'}
+
+  d3-format@3.1.2:
+    resolution: {integrity: sha512-AJDdYOdnyRDV5b6ArilzCPPwc1ejkHcoyFarqlPqT7zRYjhavcT3uSrqcMvsgh2CgoPbK3RCwyHaVyxYcP2Arg==}
+    engines: {node: '>=12'}
+
+  d3-geo@3.1.1:
+    resolution: {integrity: sha512-637ln3gXKXOwhalDzinUgY83KzNWZRKbYubaG+fGVuc/dxO64RRljtCTnf5ecMyE1RIdtqpkVcq0IbtU2S8j2Q==}
+    engines: {node: '>=12'}
+
+  d3-hierarchy@3.1.2:
+    resolution: {integrity: sha512-FX/9frcub54beBdugHjDCdikxThEqjnR93Qt7PvQTOHxyiNCAlvMrHhclk3cD5VeAaq9fxmfRp+CnWw9rEMBuA==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-path@1.0.9:
+    resolution: {integrity: sha512-VLaYcn81dtHVTjEHd8B+pbe9yHWpXKZUC87PzoFmsFrJqgFwDe/qxfp5MlfsfM1V5E/iVt0MmEbWQ7FVIXh/bg==}
+
+  d3-path@3.1.0:
+    resolution: {integrity: sha512-p3KP5HCf/bvjBSSKuXid6Zqijx7wIfNW+J/maPs+iwR35at5JCbLUT0LzF1cnjbCHWhqzQTIN2Jpe8pRebIEFQ==}
+    engines: {node: '>=12'}
+
+  d3-polygon@3.0.1:
+    resolution: {integrity: sha512-3vbA7vXYwfe1SYhED++fPUQlWSYTTGmFmQiany/gdbiWgU/iEyQzyymwL9SkJjFFuCS4902BSzewVGsHHmHtXg==}
+    engines: {node: '>=12'}
+
+  d3-quadtree@3.0.1:
+    resolution: {integrity: sha512-04xDrxQTDTCFwP5H6hRhsRcb9xxv2RzkcsygFzmkSIOJy3PeRJP7sNk3VRIbKXcog561P9oU0/rVH6vDROAgUw==}
+    engines: {node: '>=12'}
+
+  d3-random@3.0.1:
+    resolution: {integrity: sha512-FXMe9GfxTxqd5D6jFsQ+DJ8BJS4E/fT5mqqdjovykEB2oFbTMDVdg1MGFxfQW+FBOGoB++k8swBrgwSHT1cUXQ==}
+    engines: {node: '>=12'}
+
+  d3-sankey@0.12.3:
+    resolution: {integrity: sha512-nQhsBRmM19Ax5xEIPLMY9ZmJ/cDvd1BG3UVvt5h3WRxKg5zGRbvnteTyWAbzeSvlh3tW7ZEmq4VwR5mB3tutmQ==}
+
+  d3-scale-chromatic@3.1.0:
+    resolution: {integrity: sha512-A3s5PWiZ9YCXFye1o246KoscMWqf8BsD9eRiJ3He7C9OBaxKhAd5TFCdEx/7VbKtxxTsu//1mMJFrEt572cEyQ==}
+    engines: {node: '>=12'}
+
+  d3-scale@4.0.2:
+    resolution: {integrity: sha512-GZW464g1SH7ag3Y7hXjf8RoUuAFIqklOAq3MRl4OaWabTFJY9PN/E1YklhXLh+OQ3fM9yS2nOkCoS+WLZ6kvxQ==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-shape@1.3.7:
+    resolution: {integrity: sha512-EUkvKjqPFUAZyOlhY5gzCxCeI0Aep04LwIRpsZ/mLFelJiUfnK56jo5JMDSE7yyP2kLSb6LtF+S5chMk7uqPqw==}
+
+  d3-shape@3.2.0:
+    resolution: {integrity: sha512-SaLBuwGm3MOViRq2ABk3eLoxwZELpH6zhl3FbAoJ7Vm1gofKx6El1Ib5z23NUEhF9AsGl7y+dzLe5Cw2AArGTA==}
+    engines: {node: '>=12'}
+
+  d3-time-format@4.1.0:
+    resolution: {integrity: sha512-dJxPBlzC7NugB2PDLwo9Q8JiTR3M3e4/XANkreKSUxF8vvXKqm1Yfq4Q5dl8budlunRVlUUaDUgFt7eA8D6NLg==}
+    engines: {node: '>=12'}
+
+  d3-time@3.1.0:
+    resolution: {integrity: sha512-VqKjzBLejbSMT4IgbmVgDjpkYrNWUYJnbCGo874u7MMKIWsILRX+OpX/gTk8MqjpT1A/c6HY2dCA77ZN0lkQ2Q==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
+
+  d3@7.9.0:
+    resolution: {integrity: sha512-e1U46jVP+w7Iut8Jt8ri1YsPOvFpg46k+K8TpCb0P+zjCkjkPnV7WzfDJzMHy1LnA+wj5pLT1wjO901gLXeEhA==}
+    engines: {node: '>=12'}
+
+  dagre-d3-es@7.0.14:
+    resolution: {integrity: sha512-P4rFMVq9ESWqmOgK+dlXvOtLwYg0i7u0HBGJER0LZDJT2VHIPAMZ/riPxqJceWMStH5+E61QxFra9kIS3AqdMg==}
+
+  dayjs@1.11.20:
+    resolution: {integrity: sha512-YbwwqR/uYpeoP4pu043q+LTDLFBLApUP6VxRihdfNTqu4ubqMlGDLd6ErXhEgsyvY0K6nCs7nggYumAN+9uEuQ==}
+
   debug@4.4.3:
     resolution: {integrity: sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==}
     engines: {node: '>=6.0'}
@@ -1058,6 +1351,9 @@ packages:
 
   defu@6.1.7:
     resolution: {integrity: sha512-7z22QmUWiQ/2d0KkdYmANbRUVABpZ9SNYyH5vx6PZ+nE5bcC0l7uFvEfHlyld/HcGBFTL536ClDt3DEcSlEJAQ==}
+
+  delaunator@5.1.0:
+    resolution: {integrity: sha512-AGrQ4QSgssa1NGmWmLPqN5NY2KajF5MqxetNEO+o0n3ZwZZeTmt7bBnvzHWrmkZFxGgr4HdyFgelzgi06otLuQ==}
 
   dequal@2.0.3:
     resolution: {integrity: sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==}
@@ -1090,6 +1386,9 @@ packages:
     resolution: {integrity: sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w==}
     engines: {node: '>= 4'}
 
+  dompurify@3.4.5:
+    resolution: {integrity: sha512-OrwIBKsdNSVEeubdJ1HBv/wNENRM9ytAVCv7YXt//A3vPdVMNuACRqK9mXCGCBW2ln7BT/A4X0jXHo2Gu89miA==}
+
   domutils@3.2.2:
     resolution: {integrity: sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw==}
 
@@ -1117,6 +1416,9 @@ packages:
 
   es-module-lexer@2.1.0:
     resolution: {integrity: sha512-n27zTYMjYu1aj4MjCWzSP7G9r75utsaoc8m61weK+W8JMBGGQybd43GstCXZ3WNmSFtGT9wi59qQTW6mhTR5LQ==}
+
+  es-toolkit@1.46.1:
+    resolution: {integrity: sha512-5eNtXOs3tbfxXOj04tjjseeWkRWaoCjdEI+96DgwzZoe6c9juL49pXlzAFTI72aWC9Y8p7168g6XIKjh7k6pyQ==}
 
   esast-util-from-estree@2.0.0:
     resolution: {integrity: sha512-4CyanoAudUSBAn5K13H4JhsMH6L9ZP7XbLVe/dKybkxMO7eDyLsT8UHl9TRNrU2Gr9nz+FovfSIjuXWJ81uVwQ==}
@@ -1235,6 +1537,9 @@ packages:
   h3@1.15.11:
     resolution: {integrity: sha512-L3THSe2MPeBwgIZVSH5zLdBBU90TOxarvhK9d04IDY2AmVS8j2Jz2LIWtwsGOU3lu2I5jCN7FNvVfY2+XyF+mg==}
 
+  hachure-fill@0.5.2:
+    resolution: {integrity: sha512-3GKBOn+m2LX9iq+JC1064cSFprJY4jL1jCXTcpnfER5HYE2l/4EfWSGzkPa/ZDBmYI0ZOEj5VHV/eKnPGkHuOg==}
+
   hast-util-from-html@2.0.3:
     resolution: {integrity: sha512-CUSRHXyKjzHov8yKsQjGOElXy/3EKpyX56ELnkHH34vDVw1N1XSQ1ZcAvTyAPtGqLTuKP/uxM+aLkSPqF/EtMw==}
 
@@ -1280,8 +1585,22 @@ packages:
   http-cache-semantics@4.2.0:
     resolution: {integrity: sha512-dTxcvPXqPvXBQpq5dUr6mEMJX4oIEFv6bwom3FDwKRDsuIjjJGANqhBuoAn9c1RQJIdAKav33ED65E2ys+87QQ==}
 
+  iconv-lite@0.6.3:
+    resolution: {integrity: sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==}
+    engines: {node: '>=0.10.0'}
+
+  import-meta-resolve@4.2.0:
+    resolution: {integrity: sha512-Iqv2fzaTQN28s/FwZAoFq0ZSs/7hMAHJVX+w8PZl3cY19Pxk6jFFalxQoIfW2826i/fDLXv8IiEZRIT0lDuWcg==}
+
   inline-style-parser@0.2.7:
     resolution: {integrity: sha512-Nb2ctOyNR8DqQoR0OwRG95uNWIC0C1lCgf5Naz5H6Ji72KZ8OcFZLz2P5sNgwlyoJ8Yif11oMuYs5pBQa86csA==}
+
+  internmap@1.0.1:
+    resolution: {integrity: sha512-lDB5YccMydFBtasVtxnZ3MRBHuaoE8GKsppq+EchKL2U4nK/DmEpPHNH8MZe5HkMtpSiTSOZwfN0tzYjO/lJEw==}
+
+  internmap@2.0.3:
+    resolution: {integrity: sha512-5Hh7Y1wQbvY5ooGgPbDaL5iYLAPzMTUrjMulskHLH6wnv/A+1q5rgEaiuqEjB+oxGXIVZs1FF+R/KPN3ZSQYYg==}
+    engines: {node: '>=12'}
 
   iron-webcrypto@1.2.1:
     resolution: {integrity: sha512-feOM6FaSr6rEABp/eDfVseKyTMDt+KGpeB35SkVn9Tyn0CqvVsY3EwI0v5i8nMHyJnzCIQf7nsy3p41TPkJZhg==}
@@ -1349,9 +1668,22 @@ packages:
   jsonc-parser@3.3.1:
     resolution: {integrity: sha512-HUgH65KyejrUFPvHFPbqOY0rsFip3Bo5wb4ngvdi1EpCYWUQDC5V+Y7mZws+DLkr4M//zQJoanu1SP+87Dv1oQ==}
 
+  katex@0.16.47:
+    resolution: {integrity: sha512-Eeo8Ys1doU1z+x8AZsPpQu+p/QcZBI5PeOo7QGQdy2x2m0MU/hYagBbGOmXwr5KVbEfVuWv9LpnQWeehogurjg==}
+    hasBin: true
+
+  khroma@2.1.0:
+    resolution: {integrity: sha512-Ls993zuzfayK269Svk9hzpeGUKob/sIgZzyHYdjQoAdQetRKpOLj+k/QQQ/6Qi0Yz65mlROrfd+Ev+1+7dz9Kw==}
+
   kleur@4.1.5:
     resolution: {integrity: sha512-o+NO+8WrRiQEE4/7nwRJhN1HWpVmJm511pBHUxPLtp0BUISzlBplORYSmTclCnJvQq2tKu/sgl3xVpkc7ZWuQQ==}
     engines: {node: '>=6'}
+
+  layout-base@1.0.2:
+    resolution: {integrity: sha512-8h2oVEZNktL4BH2JCOI90iD1yXwL6iNW7KcCKT2QZgQJR2vbqDsldCTPRU9NifTCqHZci57XvQQ15YTu+sTYPg==}
+
+  layout-base@2.0.1:
+    resolution: {integrity: sha512-dp3s92+uNI1hWIpPGH3jK2kxE2lMjdXdr+DH8ynZHpd6PUlH6x6cbuXnoMmiNumznqaNO31xu9e79F0uuZ0JFg==}
 
   lightningcss-android-arm64@1.32.0:
     resolution: {integrity: sha512-YK7/ClTt4kAK0vo6w3X+Pnm0D2cf2vPHbhOXdoNti1Ga0al1P4TBZhwjATvjNwLEBCnKvjJc2jQgHXH0NEwlAg==}
@@ -1430,6 +1762,9 @@ packages:
   locate-character@3.0.0:
     resolution: {integrity: sha512-SW13ws7BjaeJ6p7Q6CO2nchbYEc3X3J6WrmTTDto7yMPqVSZTUyY5Tjbid+Ab8gLnATtygYtiDIJGQRRn2ZOiA==}
 
+  lodash-es@4.18.1:
+    resolution: {integrity: sha512-J8xewKD/Gk22OZbhpOVSwcs60zhd95ESDwezOFuA3/099925PdHJ7OFHNTGtajL3AlZkykD32HykiMo+BIBI8A==}
+
   longest-streak@3.1.0:
     resolution: {integrity: sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==}
 
@@ -1453,6 +1788,11 @@ packages:
 
   markdown-table@3.0.4:
     resolution: {integrity: sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==}
+
+  marked@16.4.2:
+    resolution: {integrity: sha512-TI3V8YYWvkVf3KJe1dRkpnjs68JUPyEa5vjKrp1XEEJUAOaQc+Qj+L1qWbPd0SJuAdQkFU0h73sXXqwDYxsiDA==}
+    engines: {node: '>= 20'}
+    hasBin: true
 
   mdast-util-definitions@6.0.0:
     resolution: {integrity: sha512-scTllyX6pnYNZH/AIp/0ePz6s4cZtARxImwoPJ7kS42n+MnVsI4XbnG6d4ibehRIldYMWM2LD7ImQblVhUejVQ==}
@@ -1510,6 +1850,9 @@ packages:
 
   mdn-data@2.27.1:
     resolution: {integrity: sha512-9Yubnt3e8A0OKwxYSXyhLymGW4sCufcLG6VdiDdUGVkPhpqLxlvP5vl1983gQjJl3tqbrM731mjaZaP68AgosQ==}
+
+  mermaid@11.15.0:
+    resolution: {integrity: sha512-pTMbcf3rWdtLiYGpmoTjHEpeY8seiy6sR+9nD7LOs8KfUbHE4lOUAprTRqRAcWSQ6MQpdX+YEsxShtGsINtPtw==}
 
   micromark-core-commonmark@2.0.3:
     resolution: {integrity: sha512-RDBrHEMSxVFLg6xvnXmb1Ayr2WzLAWjeSATAoxwKYJV94TeNavgoIdA0a9ytzDSVzBy2YKFK+emCPOEibLeCrg==}
@@ -1693,6 +2036,9 @@ packages:
   path-browserify@1.0.1:
     resolution: {integrity: sha512-b7uo2UCUOYZcnF/3ID0lulOJi/bafxa1xPe7ZPsammBSpjSWQkjNxlt635YGS2MiR9GjvuXCtz2emr3jbsz98g==}
 
+  path-data-parser@0.1.0:
+    resolution: {integrity: sha512-NOnmBpt5Y2RWbuv0LMzsayp3lVylAHLPUTut412ZA3l+C4uw4ZVkQbjShYCQ8TCpUMdPapr4YjUqLYD6v68j+w==}
+
   piccolore@0.1.3:
     resolution: {integrity: sha512-o8bTeDWjE086iwKrROaDf31K0qC/BENdm15/uH9usSC/uZjJOKb2YGiVHfLY4GhwsERiPI1jmwI2XrA7ACOxVw==}
 
@@ -1706,6 +2052,12 @@ packages:
   picomatch@4.0.4:
     resolution: {integrity: sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A==}
     engines: {node: '>=12'}
+
+  points-on-curve@0.2.0:
+    resolution: {integrity: sha512-0mYKnYYe9ZcqMCWhUjItv/oHjvgEsfKvnUTg8sAtnHr3GVy7rGkXCb6d5cSyqrWqL4k81b9CPg3urd+T7aop3A==}
+
+  points-on-path@0.2.1:
+    resolution: {integrity: sha512-25ClnWWuw7JbWZcgqY/gJ4FQWadKxGWk+3kR/7kD0tCaDtPPMj7oHu2ToLaVhfpnHrZzYby2w6tUA0eOIuUg8g==}
 
   postcss@8.5.14:
     resolution: {integrity: sha512-SoSL4+OSEtR99LHFZQiJLkT59C5B1amGO1NzTwj7TT1qCUgUO6hxOvzkOYxD+vMrXBM3XJIKzokoERdqQq/Zmg==}
@@ -1823,10 +2175,16 @@ packages:
   retext@9.0.0:
     resolution: {integrity: sha512-sbMDcpHCNjvlheSgMfEcVrZko3cDzdbe1x/e7G66dFp0Ff7Mldvi2uv6JkJQzdRcvLYE8CA8Oe8siQx8ZOgTcA==}
 
+  robust-predicates@3.0.3:
+    resolution: {integrity: sha512-NS3levdsRIUOmiJ8FZWCP7LG3QpJyrs/TE0Zpf1yvZu8cAJJ6QMW92H1c7kWpdIHo8RvmLxN/o2JXTKHp74lUA==}
+
   rollup@4.60.3:
     resolution: {integrity: sha512-pAQK9HalE84QSm4Po3EmWIZPd3FnjkShVkiMlz1iligWYkWQ7wHYd1PF/T7QZ5TVSD6uSTon5gBVMSM4JfBV+A==}
     engines: {node: '>=18.0.0', npm: '>=8.0.0'}
     hasBin: true
+
+  roughjs@4.6.6:
+    resolution: {integrity: sha512-ZUz/69+SYpFN/g/lUlo2FXcIjRkSu3nDarreVdGGndHEBJ6cXPdKguS8JGxwj5HA5xIbVKSmLgr5b3AWxtRfvQ==}
 
   runed@0.35.1:
     resolution: {integrity: sha512-2F4Q/FZzbeJTFdIS/PuOoPRSm92sA2LhzTnv6FXhCoENb3huf5+fDuNOg1LNvGOouy3u/225qxmuJvcV3IZK5Q==}
@@ -1836,6 +2194,12 @@ packages:
     peerDependenciesMeta:
       '@sveltejs/kit':
         optional: true
+
+  rw@1.3.3:
+    resolution: {integrity: sha512-PdhdWy89SiZogBLaw42zdeqtRJ//zFd2PgQavcICDUgJT5oW10QCRKbJ6bg4r0/UY2M6BWd5tkxuGFRvCkgfHQ==}
+
+  safer-buffer@2.1.2:
+    resolution: {integrity: sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==}
 
   sax@1.6.0:
     resolution: {integrity: sha512-6R3J5M4AcbtLUdZmRv2SygeVaM7IhrLXu9BmnOGmmACak8fiUtOsYNWUS4uK7upbmHIBbLBeFeI//477BKLBzA==}
@@ -1891,6 +2255,9 @@ packages:
 
   style-to-object@1.0.14:
     resolution: {integrity: sha512-LIN7rULI0jBscWQYaSswptyderlarFkjQ+t79nzty8tcIAceVomEVlLzH5VP4Cmsv6MtKhs7qaAiwlcp+Mgaxw==}
+
+  stylis@4.4.0:
+    resolution: {integrity: sha512-5Z9ZpRzfuH6l/UAvCPAPUo3665Nk2wLaZU3x+TLHKVzIz33+sbJqbtrYoC3KD4/uVOr2Zp+L0LySezP9OHV9yA==}
 
   svelte-toolbelt@0.10.6:
     resolution: {integrity: sha512-YWuX+RE+CnWYx09yseAe4ZVMM7e7GRFZM6OYWpBKOb++s+SQ8RBIMMe+Bs/CznBMc0QPLjr+vDBxTAkozXsFXQ==}
@@ -1956,6 +2323,10 @@ packages:
 
   trough@2.2.0:
     resolution: {integrity: sha512-tmMpK00BjZiUyVyvrBK7knerNgmgvcV/KLVyuma/SC+TQN167GrMRciANTz09+k3zW8L8t60jWO1GpfkZdjTaw==}
+
+  ts-dedent@2.2.0:
+    resolution: {integrity: sha512-q5W7tVM71e2xjHZTlgfTDoPF/SmqKG5hddq9SzR49CH2hayqRKJtQ4mtRlSxKaJlR/+9rEM+mnBHf7I2/BQcpQ==}
+    engines: {node: '>=6.10'}
 
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
@@ -2077,6 +2448,10 @@ packages:
         optional: true
       uploadthing:
         optional: true
+
+  uuid@14.0.0:
+    resolution: {integrity: sha512-Qo+uWgilfSmAhXCMav1uYFynlQO7fMFiMVZsQqZRMIXp0O7rR7qjkj+cPvBHLgBqi960QCoo/PH2/6ZtVqKvrg==}
+    hasBin: true
 
   vfile-location@5.0.3:
     resolution: {integrity: sha512-5yXvWDEgqeiYiBe1lbxYF7UMAIm/IcopxMHrMQDq3nvKcjPKIhZklUKL+AE7J7uApI4kwe2snsK+eI6UTj9EHg==}
@@ -2286,6 +2661,11 @@ packages:
 
 snapshots:
 
+  '@antfu/install-pkg@1.1.0':
+    dependencies:
+      package-manager-detector: 1.6.0
+      tinyexec: 1.1.2
+
   '@astrojs/check@0.9.9(prettier@3.8.3)(typescript@6.0.3)':
     dependencies:
       '@astrojs/language-server': 2.16.7(prettier@3.8.3)(typescript@6.0.3)
@@ -2426,9 +2806,13 @@ snapshots:
       '@babel/helper-string-parser': 7.27.1
       '@babel/helper-validator-identifier': 7.28.5
 
+  '@braintree/sanitize-url@7.1.2': {}
+
   '@capsizecss/unpack@4.0.0':
     dependencies:
       fontkitten: 1.0.3
+
+  '@chevrotain/types@11.1.2': {}
 
   '@clack/core@1.3.1':
     dependencies:
@@ -2558,6 +2942,14 @@ snapshots:
       '@floating-ui/utils': 0.2.11
 
   '@floating-ui/utils@0.2.11': {}
+
+  '@iconify/types@2.0.0': {}
+
+  '@iconify/utils@3.1.3':
+    dependencies:
+      '@antfu/install-pkg': 1.1.0
+      '@iconify/types': 2.0.0
+      import-meta-resolve: 4.2.0
 
   '@img/colour@1.1.0':
     optional: true
@@ -2712,6 +3104,10 @@ snapshots:
       vfile: 6.0.3
     transitivePeerDependencies:
       - supports-color
+
+  '@mermaid-js/parser@1.1.1':
+    dependencies:
+      '@chevrotain/types': 11.1.2
 
   '@oslojs/encoding@1.1.0': {}
 
@@ -2931,6 +3327,123 @@ snapshots:
       tailwindcss: 4.3.0
       vite: 7.3.3(jiti@2.7.0)(lightningcss@1.32.0)(yaml@2.8.4)
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.13':
     dependencies:
       '@types/ms': 2.1.0
@@ -2942,6 +3455,8 @@ snapshots:
   '@types/estree@1.0.8': {}
 
   '@types/estree@1.0.9': {}
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@3.0.4':
     dependencies:
@@ -2966,6 +3481,11 @@ snapshots:
   '@types/unist@3.0.3': {}
 
   '@ungap/structured-clone@1.3.1': {}
+
+  '@upsetjs/venn.js@2.0.0':
+    optionalDependencies:
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   '@volar/kit@2.4.28(typescript@6.0.3)':
     dependencies:
@@ -3207,11 +3727,23 @@ snapshots:
 
   commander@11.1.0: {}
 
+  commander@7.2.0: {}
+
+  commander@8.3.0: {}
+
   common-ancestor-path@2.0.0: {}
 
   cookie-es@1.2.3: {}
 
   cookie@1.1.1: {}
+
+  cose-base@1.0.3:
+    dependencies:
+      layout-base: 1.0.2
+
+  cose-base@2.2.0:
+    dependencies:
+      layout-base: 2.0.1
 
   crossws@0.3.5:
     dependencies:
@@ -3241,6 +3773,192 @@ snapshots:
     dependencies:
       css-tree: 2.2.1
 
+  cytoscape-cose-bilkent@4.1.0(cytoscape@3.33.4):
+    dependencies:
+      cose-base: 1.0.3
+      cytoscape: 3.33.4
+
+  cytoscape-fcose@2.2.0(cytoscape@3.33.4):
+    dependencies:
+      cose-base: 2.2.0
+      cytoscape: 3.33.4
+
+  cytoscape@3.33.4: {}
+
+  d3-array@2.12.1:
+    dependencies:
+      internmap: 1.0.1
+
+  d3-array@3.2.4:
+    dependencies:
+      internmap: 2.0.3
+
+  d3-axis@3.0.0: {}
+
+  d3-brush@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3-chord@3.0.1:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-color@3.1.0: {}
+
+  d3-contour@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-delaunay@6.0.4:
+    dependencies:
+      delaunator: 5.1.0
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-dsv@3.0.1:
+    dependencies:
+      commander: 7.2.0
+      iconv-lite: 0.6.3
+      rw: 1.3.3
+
+  d3-ease@3.0.1: {}
+
+  d3-fetch@3.0.1:
+    dependencies:
+      d3-dsv: 3.0.1
+
+  d3-force@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-timer: 3.0.1
+
+  d3-format@3.1.2: {}
+
+  d3-geo@3.1.1:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-hierarchy@3.1.2: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-path@1.0.9: {}
+
+  d3-path@3.1.0: {}
+
+  d3-polygon@3.0.1: {}
+
+  d3-quadtree@3.0.1: {}
+
+  d3-random@3.0.1: {}
+
+  d3-sankey@0.12.3:
+    dependencies:
+      d3-array: 2.12.1
+      d3-shape: 1.3.7
+
+  d3-scale-chromatic@3.1.0:
+    dependencies:
+      d3-color: 3.1.0
+      d3-interpolate: 3.0.1
+
+  d3-scale@4.0.2:
+    dependencies:
+      d3-array: 3.2.4
+      d3-format: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-shape@1.3.7:
+    dependencies:
+      d3-path: 1.0.9
+
+  d3-shape@3.2.0:
+    dependencies:
+      d3-path: 3.1.0
+
+  d3-time-format@4.1.0:
+    dependencies:
+      d3-time: 3.1.0
+
+  d3-time@3.1.0:
+    dependencies:
+      d3-array: 3.2.4
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+
+  d3@7.9.0:
+    dependencies:
+      d3-array: 3.2.4
+      d3-axis: 3.0.0
+      d3-brush: 3.0.0
+      d3-chord: 3.0.1
+      d3-color: 3.1.0
+      d3-contour: 4.0.2
+      d3-delaunay: 6.0.4
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-dsv: 3.0.1
+      d3-ease: 3.0.1
+      d3-fetch: 3.0.1
+      d3-force: 3.0.0
+      d3-format: 3.1.2
+      d3-geo: 3.1.1
+      d3-hierarchy: 3.1.2
+      d3-interpolate: 3.0.1
+      d3-path: 3.1.0
+      d3-polygon: 3.0.1
+      d3-quadtree: 3.0.1
+      d3-random: 3.0.1
+      d3-scale: 4.0.2
+      d3-scale-chromatic: 3.1.0
+      d3-selection: 3.0.0
+      d3-shape: 3.2.0
+      d3-time: 3.1.0
+      d3-time-format: 4.1.0
+      d3-timer: 3.0.1
+      d3-transition: 3.0.1(d3-selection@3.0.0)
+      d3-zoom: 3.0.0
+
+  dagre-d3-es@7.0.14:
+    dependencies:
+      d3: 7.9.0
+      lodash-es: 4.18.1
+
+  dayjs@1.11.20: {}
+
   debug@4.4.3:
     dependencies:
       ms: 2.1.3
@@ -3254,6 +3972,10 @@ snapshots:
   deepmerge@4.3.1: {}
 
   defu@6.1.7: {}
+
+  delaunator@5.1.0:
+    dependencies:
+      robust-predicates: 3.0.3
 
   dequal@2.0.3: {}
 
@@ -3281,6 +4003,10 @@ snapshots:
     dependencies:
       domelementtype: 2.3.0
 
+  dompurify@3.4.5:
+    optionalDependencies:
+      '@types/trusted-types': 2.0.7
+
   domutils@3.2.2:
     dependencies:
       dom-serializer: 2.0.0
@@ -3306,6 +4032,8 @@ snapshots:
   entities@6.0.1: {}
 
   es-module-lexer@2.1.0: {}
+
+  es-toolkit@1.46.1: {}
 
   esast-util-from-estree@2.0.0:
     dependencies:
@@ -3452,6 +4180,8 @@ snapshots:
       ufo: 1.6.4
       uncrypto: 0.1.3
 
+  hachure-fill@0.5.2: {}
+
   hast-util-from-html@2.0.3:
     dependencies:
       '@types/hast': 3.0.4
@@ -3586,7 +4316,17 @@ snapshots:
 
   http-cache-semantics@4.2.0: {}
 
+  iconv-lite@0.6.3:
+    dependencies:
+      safer-buffer: 2.1.2
+
+  import-meta-resolve@4.2.0: {}
+
   inline-style-parser@0.2.7: {}
+
+  internmap@1.0.1: {}
+
+  internmap@2.0.3: {}
 
   iron-webcrypto@1.2.1: {}
 
@@ -3635,7 +4375,17 @@ snapshots:
 
   jsonc-parser@3.3.1: {}
 
+  katex@0.16.47:
+    dependencies:
+      commander: 8.3.0
+
+  khroma@2.1.0: {}
+
   kleur@4.1.5: {}
+
+  layout-base@1.0.2: {}
+
+  layout-base@2.0.1: {}
 
   lightningcss-android-arm64@1.32.0:
     optional: true
@@ -3688,6 +4438,8 @@ snapshots:
 
   locate-character@3.0.0: {}
 
+  lodash-es@4.18.1: {}
+
   longest-streak@3.1.0: {}
 
   lru-cache@11.3.6: {}
@@ -3707,6 +4459,8 @@ snapshots:
   markdown-extensions@2.0.0: {}
 
   markdown-table@3.0.4: {}
+
+  marked@16.4.2: {}
 
   mdast-util-definitions@6.0.0:
     dependencies:
@@ -3880,6 +4634,30 @@ snapshots:
   mdn-data@2.0.28: {}
 
   mdn-data@2.27.1: {}
+
+  mermaid@11.15.0:
+    dependencies:
+      '@braintree/sanitize-url': 7.1.2
+      '@iconify/utils': 3.1.3
+      '@mermaid-js/parser': 1.1.1
+      '@types/d3': 7.4.3
+      '@upsetjs/venn.js': 2.0.0
+      cytoscape: 3.33.4
+      cytoscape-cose-bilkent: 4.1.0(cytoscape@3.33.4)
+      cytoscape-fcose: 2.2.0(cytoscape@3.33.4)
+      d3: 7.9.0
+      d3-sankey: 0.12.3
+      dagre-d3-es: 7.0.14
+      dayjs: 1.11.20
+      dompurify: 3.4.5
+      es-toolkit: 1.46.1
+      katex: 0.16.47
+      khroma: 2.1.0
+      marked: 16.4.2
+      roughjs: 4.6.6
+      stylis: 4.4.0
+      ts-dedent: 2.2.0
+      uuid: 14.0.0
 
   micromark-core-commonmark@2.0.3:
     dependencies:
@@ -4225,6 +5003,8 @@ snapshots:
 
   path-browserify@1.0.1: {}
 
+  path-data-parser@0.1.0: {}
+
   piccolore@0.1.3: {}
 
   picocolors@1.1.1: {}
@@ -4232,6 +5012,13 @@ snapshots:
   picomatch@2.3.2: {}
 
   picomatch@4.0.4: {}
+
+  points-on-curve@0.2.0: {}
+
+  points-on-path@0.2.1:
+    dependencies:
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
 
   postcss@8.5.14:
     dependencies:
@@ -4415,6 +5202,8 @@ snapshots:
       retext-stringify: 4.0.0
       unified: 11.0.5
 
+  robust-predicates@3.0.3: {}
+
   rollup@4.60.3:
     dependencies:
       '@types/estree': 1.0.8
@@ -4446,12 +5235,23 @@ snapshots:
       '@rollup/rollup-win32-x64-msvc': 4.60.3
       fsevents: 2.3.3
 
+  roughjs@4.6.6:
+    dependencies:
+      hachure-fill: 0.5.2
+      path-data-parser: 0.1.0
+      points-on-curve: 0.2.0
+      points-on-path: 0.2.1
+
   runed@0.35.1(svelte@5.55.5):
     dependencies:
       dequal: 2.0.3
       esm-env: 1.2.2
       lz-string: 1.5.0
       svelte: 5.55.5
+
+  rw@1.3.3: {}
+
+  safer-buffer@2.1.2: {}
 
   sax@1.6.0: {}
 
@@ -4535,6 +5335,8 @@ snapshots:
     dependencies:
       inline-style-parser: 0.2.7
 
+  stylis@4.4.0: {}
+
   svelte-toolbelt@0.10.6(svelte@5.55.5):
     dependencies:
       clsx: 2.1.1
@@ -4610,6 +5412,8 @@ snapshots:
   trim-lines@3.0.1: {}
 
   trough@2.2.0: {}
+
+  ts-dedent@2.2.0: {}
 
   tslib@2.8.1: {}
 
@@ -4699,6 +5503,8 @@ snapshots:
       node-fetch-native: 1.6.7
       ofetch: 1.5.1
       ufo: 1.6.4
+
+  uuid@14.0.0: {}
 
   vfile-location@5.0.3:
     dependencies:

--- a/docs/src/content/docs/meet-aileron/v4.mdx
+++ b/docs/src/content/docs/meet-aileron/v4.mdx
@@ -1,0 +1,571 @@
+---
+title: "Aileron v4"
+description: "Aileron is the execution layer for AI-core organizations. The v4 architecture: identity, policy, approvals, audit, and runtime boundaries applied uniformly to every AI agent in the company."
+order: 3
+---
+
+import MermaidDiagram from '$lib/components/ui/mermaid-diagram.svelte';
+import Feature from '$lib/components/ui/feature.svelte';
+import * as Alert from '$lib/components/ui/alert/index.js';
+import KeyRound from '@lucide/svelte/icons/key-round';
+import Database from '@lucide/svelte/icons/database';
+import Lock from '@lucide/svelte/icons/lock';
+import Bot from '@lucide/svelte/icons/bot';
+
+<div class="not-prose mb-10">
+  <h2 class="text-4xl font-bold leading-tight tracking-tight text-slate-900 dark:text-slate-50 mb-5">
+    Aileron is the execution layer for AI-core organizations.
+  </h2>
+  <p class="text-xl text-slate-700 dark:text-slate-300 leading-relaxed">
+    Identity, policy, approvals, audit, and runtime boundaries applied uniformly to every AI agent in the organization.
+  </p>
+</div>
+
+<div class="not-prose my-10 rounded-lg bg-slate-900 p-7 text-slate-100">
+  <div class="text-xs uppercase tracking-widest text-slate-400 mb-3">The pitch</div>
+  <p class="text-lg leading-relaxed mb-3">
+    A decade ago, every company became a software company. That transition required new infrastructure: cloud platforms, deployment pipelines, observability stacks, identity and access management. The companies that built on it rebuilt how they operated. The infrastructure layer captured a generation of value.
+  </p>
+  <p class="text-lg leading-relaxed mb-3">
+    Every company is now becoming an AI company. The work humans did against software is shifting to AI agents doing that work, across every function: engineering, support, sales, operations, research, compliance. That transition needs its own infrastructure layer: identity, policy, approvals, audit, and runtime boundaries that apply uniformly to every agent in the company.
+  </p>
+  <p class="text-lg leading-relaxed mb-4">
+    Aileron is that infrastructure. The execution layer for AI-core organizations.
+  </p>
+  <p class="text-xl font-semibold text-white">
+    Run AI the way you run everything else.
+  </p>
+</div>
+
+## What this makes possible
+
+Concrete scenarios teams and organizations can run on Aileron:
+
+- An agent reads a Slack support thread, opens a Linear bug ticket, runs a GitHub Actions deploy of the fix, and updates the affected customer's Stripe record. The deploy and the Stripe write require human approval. The full trail is auditable to a specific engineer.
+- A new engineer joins, gets an Aileron account, and runs their first session with the team's curated connectors already provisioned (Linear, Slack, internal services). Credentials live in the team vault, rotated centrally. No per-laptop setup.
+- The platform team rolls out an internal-tools agent across engineering, support, and sales. Every team's agent uses the same Aileron substrate, the same policy framework, the same audit destination. One operating model across the company, not one custom integration per team.
+- A production-touching agent runs overnight with confidence that the agent cannot bypass approval gates, exfiltrate credentials, or escape its container's blast radius. Engineers wake up to a queue of completed actions and any rejected pending requests.
+- Leadership asks for AI spend visibility across the company. Aileron shows LLM-token consumption per agent, per team, per project, alongside which actions ran, which were approved, and which upstream systems were touched.
+- A compliance review for AI-mediated production access points at integrated action-level audit, approval workflows, RBAC, and (in v5 SaaS) TEE-attested credential isolation. The audit shape matches what SOC 2 or HIPAA controls already require.
+- The platform team migrates from "agents on developer laptops" to "agents as a managed platform service" without rewriting any agent code. Same connectors, same policy, same audit. The deployment topology shifts; the architecture does not.
+
+## What teams and organizations gain
+
+Capabilities that compound across every agent and every team:
+
+- **One substrate for every agent.** Whatever model (Claude, GPT, Gemini, open-weights), whatever framework, whatever team: every agent runs through the same Aileron runtime, with the same policy, approvals, audit, and credential boundary.
+- **Identity at the agentic layer.** Per-user authentication, per-team vaults, RBAC on credentials and actions. Every agentic action is attributed to a human, not to "the agent."
+- **Action-level policy** declared per connector and enforced at the proxy. Idempotency, approval requirements, and audit shape are uniform across every invocation.
+- **Human-in-the-loop approval** as a first-class primitive. Irreversible actions pause; approvers grant or reject; agents continue.
+- **Action-attributed audit** with user identity, parsed arguments, approval decision, and outcome. The audit trail compliance review actually uses.
+- **A curated connector ecosystem.** Installing a connector package gives the organization a typed action surface with policy declared. New systems light up across all teams at once.
+- **Fleet visibility.** Aileron is the single point every agentic action passes through. That makes it the natural place to report LLM spend, tool usage, approval latency, and error rates across teams, agents, and projects.
+- **Bounded agent runtime.** Container-level isolation, shell-layer mediation, PTY-owned approvals, restricted network egress. The agent's blast radius is bounded by construction.
+- **One operating model, three deployment topologies.** Customer-operated today, BYOC Enterprise next, multi-tenant SaaS with TEE-attested credential isolation later. The architecture follows the organization from a single team's pilot to a company-wide platform.
+
+## Thesis
+
+Aileron's product is the runtime. The runtime is a containerized service customers operate, with a deployment topology that evolves across milestones: v4 customer-operated → v4.x BYOC Enterprise → v5 multi-tenant SaaS.
+
+The agent runs inside a container bounded by the Aileron Way (shell mediation, PTY-owned approvals, host isolation, bypass-prevention). The container's `HTTPS_PROXY` points at Aileron's credential mediation proxy. Every credentialed operation flows through the same path: Aileron-curated connector shims, the agent's LLM API calls, and third-party CLIs that respect `HTTPS_PROXY` all hit the proxy. The proxy identifies the request, evaluates policy, gates approval if required, injects the real credential at the TLS boundary, and forwards upstream. The agent never holds plaintext credentials.
+
+One mediation path, one credential injection mechanism, one audit point. Process count scales with throughput, not user count.
+
+## Trust zones
+
+Every component falls into one of these zones based on its relationship to plaintext credentials.
+
+<div class="not-prose grid gap-4 md:grid-cols-2 my-6">
+
+<Feature icon={KeyRound} title="User-side, key custody">
+The user's CLI on their laptop or the user's browser. Holds the master key briefly during launch. Delivers the key to the credential service over a local secure channel (v4) or an attested channel (v5). Does not persist the key.
+</Feature>
+
+<Feature icon={Database} title="Control plane (never plaintext)">
+Sessions, user CLI requests, policy storage, audit storage, approval orchestration, the encrypted credential store. Authenticates users, surfaces approvals, holds encrypted blobs. Cannot decrypt anything.
+</Feature>
+
+<Feature icon={Lock} title="Credential mediation (trusted, narrow surface)">
+The HTTPS proxy and the credential service. The proxy terminates TLS from container traffic, matches requests against connector specs, evaluates policy, calls the credential service for decryption, injects credentials, re-establishes TLS upstream. The credential service holds session keys in memory. Together they are the data plane. **In v5 SaaS, TEE attestation encloses both.**
+</Feature>
+
+<Feature icon={Bot} title="Agent runtime (untrusted with credentials)">
+The agent container. Bounded by the Aileron Way at the OS layer. Hosts the agent, bash, the `aileron` CLI, Aileron-curated connector shims, and user-installed tools. `HTTPS_PROXY` set to the credential mediation proxy. The trusted CA cert for the proxy is installed at session start.
+</Feature>
+
+</div>
+
+## Components shipped in v4
+
+The v4 binary set is small: one `aileron` binary, plus connector packages (each a thin shim and its OpenAPI spec). No separate sidecar, no MCP server from Aileron, no proxy worker binary.
+
+### aileron (single multi-modal binary)
+
+One binary, multiple modes selected by subcommand:
+
+- `aileron launch <agent>`: starts a session. Transient. Holds the master key briefly during launch, then exits.
+- `aileron service`: the long-lived runtime backend. Hosts the management plane (sessions, audit, policy, approvals) and the data plane (HTTPS proxy + credential service) as logical components. Single-user v4 colocates them all in one process; v4.x and v5 split.
+- `aileron status`, `aileron approval list`, `aileron audit query`, `aileron actions list`, `aileron secret list`, `aileron session info`: user-facing CLI subcommands. Talk to the management plane over HTTPS with the session token.
+
+### Connector packages (one per integrated system)
+
+Each connector ships two things:
+
+- **Connector spec** (OpenAPI definition or equivalent). Declares the upstream API surface, the curated subset Aileron exposes as actions, idempotency and approval requirements per action. Used by the proxy at runtime to match HTTPS requests to action identities and apply policy.
+- **Connector shim** (one binary in `$PATH`: `linear`, `slack`, `github`). Generated from the spec. Parses argv into the upstream HTTPS request, makes the call (which routes through `HTTPS_PROXY`), prints the response. No credential handling.
+
+### Encrypted credential store
+
+Storage layer accessed by the management plane. Vault-centric schema: each vault has its own random vault key; credentials inside are encrypted with that vault key; the vault key is wrapped (encrypted) once per authorized member. Personal vault is the trivial case of a one-member vault. File-backed in v4 (`~/.aileron/store/vaults/{vault_id}/...`); Postgres + blob storage in v4.x and v5.
+
+### Management plane (logical component inside aileron service)
+
+The control plane. Sessions (start, validate, end). User CLI requests. Policy storage and lookup. Approval orchestration (surface to user via TUI, webapp, mobile; collect responses). Audit log storage. Multi-user-aware from day one. Never sees plaintext credentials.
+
+### Credential mediation: proxy + credential service (the data plane)
+
+Together they handle all credentialed traffic. Both run inside the TEE in v5.
+
+- **HTTPS proxy.** Accepts `HTTPS_PROXY` connections from the agent container. Terminates TLS using a session-local CA installed in the container. Matches each request against the relevant connector spec to identify the action. Asks the management plane for policy and approval. Asks the credential service for the credential to inject. Strips whatever auth the agent attached, injects the real credential, re-establishes TLS upstream. Plaintext credential lives in proxy memory for a single request, zeroed after.
+- **Credential service.** Holds session-keyed material in memory keyed by session ID: master key, unwrapped vault keys cached for the session. Memory footprint per session is small (~KB). Provides decrypt operations to the proxy.
+
+In v4 these are colocated with the management plane in one `aileron service` process. In v4.x and v5 they split: proxy workers autoscale to traffic, credential service shards by tenant.
+
+### Agent container (docker sandbox microVM)
+
+The Aileron Way environment. Contents:
+
+- The agent (Claude Code or other), configured to use `HTTPS_PROXY` for all outbound HTTPS, including LLM API calls.
+- A locked-down bash with a DEBUG trap for shell-layer policy mediation (non-credential).
+- The `aileron` CLI for status queries, audit, approvals, and action manifest browsing.
+- Connector shims in `$PATH` for the team's installed connectors.
+- The action catalog manifest at `/etc/aileron/actions.json`.
+- The proxy's CA certificate installed in the system trust store.
+- Placeholder auth configs for supported third-party CLIs (e.g., a dummy `~/.config/gh/hosts.yml`).
+- Any user-installed third-party tools brought in via devcontainer.json.
+
+<Alert.Root class="my-6">
+  <Alert.Title>What is not in v4</Alert.Title>
+  <Alert.Description>
+    No <code>aileron-mcp</code> binary, no per-session sidecar process, no separate action-executor binary, no internal RPC path from shims. The agent's tool schema from Aileron is empty (bash plus any user-MCPs only). Aileron-specific functionality is reached via the <code>aileron</code> CLI and connector shims, all reachable through bash.
+  </Alert.Description>
+</Alert.Root>
+
+## Network policy
+
+Agents need productive direct egress (read docs, install packages, fetch public data) alongside the mediated credentialed path. v4 ships a tiered model that balances both.
+
+| Tier | What it covers | How it works |
+|---|---|---|
+| **Aileron-mediated HTTPS** | Connector shim calls, agent's LLM API, third-party CLI calls to known-credentialed destinations | Flow through `HTTPS_PROXY`. Proxy matches request to action, enforces policy, gates approval, injects credentials, audits. |
+| **Direct uncredentialed egress** | Public documentation, package registries (npm, pypi, brew, apt), public APIs, uncredentialed search | Routes through the proxy by default (logged, not injected). Customers can configure default-deny + allowlist for stricter posture. |
+| **Private network ranges** | `127.0.0.0/8`, `192.168.0.0/16` | Docker sandbox denies by default, with explicit bypass only for the loopback path to the Aileron proxy. |
+| **Non-HTTPS egress** | SSH, database connections, custom protocols | Outside the proxy's scope. Docker sandbox network policy handles allow/deny. v4 does not credential-mediate non-HTTPS. |
+
+<Alert.Root class="my-6">
+  <Alert.Title>Residual exfil risk</Alert.Title>
+  <Alert.Description>
+    With permissive uncredentialed egress, a compromised agent could send context data (user prompts, tool results, files it has read) to attacker-controlled endpoints. Mitigated by audit, approval gating on the actions that introduce sensitive data, and network-layer destination categorization. Credentials cannot be exfiltrated regardless because they never enter the container; only context-data exfil is residual, and that is fundamentally an agent-policy concern, not a network-policy one.
+  </Alert.Description>
+</Alert.Root>
+
+## Vault model: shared by design
+
+A user's "vault" at runtime is not a single storage unit. It is a view: the union of their personal vault and every shared vault they have been granted access to. v4 ships a vault-centric schema where the personal vault is the trivial case of a one-member shared vault.
+
+Shared vaults are **out of scope** as a v4 user feature (no team-grant UX, no member-management endpoints). The storage and encryption shape supports them from day one so that v4.x can add the feature without restructuring the data layer.
+
+### Encryption model (1Password / Bitwarden pattern)
+
+- Each vault has a randomly-generated **vault key**.
+- All credentials inside the vault are encrypted with that vault key.
+- The vault key is wrapped (encrypted) once per authorized member, using each member's key.
+- To decrypt a credential: fetch the member's wrapping → unwrap with user's master key → use vault key to decrypt the credential.
+- Personal vault is a vault where `type=personal` and `members` has exactly one entry.
+
+### Storage schema
+
+```
+vaults/
+  {vault_id}/
+    meta.json
+      # name, type (personal|shared), owner, created_at
+    members.json
+      # member list with roles (owner|contributor|reader)
+    key_wrappings/
+      {user_id}.wrap
+      # vault key wrapped with user's key, one per member
+    credentials/
+      {credential_id}.enc       # encrypted with vault key
+      {credential_id}.meta.json # name, type, action bindings
+```
+
+### Grant and revoke (v4.x scope, mechanics established in v4)
+
+- **Grant access to a new member.** An existing member with the grant role unwraps the vault key with their own key, re-wraps it with the new member's key, stores `{new_user_id}.wrap`, updates `members.json`. No credential ciphertexts are touched.
+- **Revoke access (rotate).** Generate a new vault key. Re-encrypt every credential. Re-wrap for every remaining member. Delete the revoked member's wrapping. Revocation prevents new decryptions; it does not retroactively invalidate credentials already decrypted in memory.
+
+## Tool discoverability
+
+The agent must find and correctly invoke Aileron-curated connector shims. The shims are not third-party CLIs the LLM knows from training; they are Aileron's curated action surface generated from connector specs.
+
+v4 uses **lazy structured discovery**: a short system prompt hint, a static manifest file the LLM can read, and per-shim `--help` output. The LLM does not get all actions advertised in its MCP tool schema (which would scale poorly with the connector catalog).
+
+<div class="not-prose grid gap-4 md:grid-cols-3 my-6">
+
+<Feature title="System prompt hint">
+Aileron prefixes the agent's system prompt with one short paragraph telling it where Aileron connectors live in `$PATH`, where the action catalog is, and how to use `--help` for details. Roughly 150 tokens, paid once per inference.
+</Feature>
+
+<Feature title="Manifest at /etc/aileron/actions.json">
+Structured JSON listing every action: connector, action name, description, argument schema, idempotency declaration, approval requirement. The LLM reads it proactively when the user's intent suggests an Aileron-mediated action.
+</Feature>
+
+<Feature title="Per-shim --help">
+Shell-native discovery as the LLM's fallback. `linear --help` lists actions with descriptions. `linear create-issue --help` prints the action's argument schema.
+</Feature>
+
+</div>
+
+<Alert.Root class="my-6">
+  <Alert.Title>Empirical caveat</Alert.Title>
+  <Alert.Description>
+    Whether the LLM reliably finds and correctly invokes Aileron shims with only this much guidance is something to measure during the v4 beta. Modern LLMs are good at exploring unknown CLIs via <code>--help</code>, but if hit rate is low, fallbacks include promoting frequently-used actions into a small MCP tool schema, expanding the system prompt, or improving manifest descriptions.
+  </Alert.Description>
+</Alert.Root>
+
+## Steady-state architecture
+
+Mid-session on a developer's laptop in v4. The `aileron service` process hosts the management plane plus the data plane (HTTPS proxy + credential service) as logical components. The agent container's `HTTPS_PROXY` points at the data plane.
+
+<MermaidDiagram client:load graph={`graph TB
+    subgraph laptop["💻 User's Laptop"]
+      direction TB
+
+      subgraph user_side["User-side"]
+        CLI["aileron launch (transient at start)"]
+      end
+
+      subgraph runtime_backend["aileron service (long-lived process)"]
+        direction TB
+        subgraph mgmt["Management plane"]
+          Mgmt["Sessions, policy, approvals, audit"]
+          Store[("Encrypted Store")]
+          Mgmt --> Store
+        end
+        subgraph data_plane["Data plane (credential mediation)"]
+          Proxy["HTTPS proxy"]
+          CredSvc["Credential service (session keys)"]
+          Proxy <-->|"decrypt"| CredSvc
+        end
+        Mgmt <-->|"policy, approvals"| Proxy
+        CredSvc -->|"fetch blobs"| Store
+      end
+
+      subgraph agent_zone["Agent runtime"]
+        AgentContainer["Agent container (docker sandbox)"]
+        Agent["Agent: Claude Code"]
+        Bash["bash (DEBUG trap)"]
+        AileronCli["aileron CLI"]
+        Shims["Connector shims (linear, slack, ...)"]
+        AgentContainer --- Agent
+        AgentContainer --- Bash
+        AgentContainer --- AileronCli
+        AgentContainer --- Shims
+      end
+    end
+
+    External["External APIs"]
+
+    CLI -.->|"key"| CredSvc
+    CLI -->|"session bootstrap"| Mgmt
+    Agent -->|"HTTPS_PROXY"| Proxy
+    Shims -->|"HTTPS_PROXY"| Proxy
+    AileronCli -->|"queries"| Mgmt
+    Proxy -->|"injects, TLS upstream"| External
+
+    classDef purple fill:#f3e8ff,stroke:#9333ea,color:#581c87
+    classDef blue fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+    classDef green fill:#dcfce7,stroke:#16a34a,color:#14532d
+    classDef amber fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef red fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+
+    class CLI purple
+    class Mgmt,Store blue
+    class Proxy,CredSvc green
+    class AgentContainer,Agent,Bash,AileronCli,Shims amber
+    class External red
+`} />
+
+The agent container has one mediated egress, `HTTPS_PROXY` pointing at the data plane. All credentialed traffic (connector shims, third-party CLIs, the agent's LLM API call) flows through the same proxy. The data plane is the only outbound point to external systems.
+
+## Startup sequence
+
+What happens between `aileron launch claude "..."` being typed and the agent beginning work.
+
+<MermaidDiagram client:load graph={`sequenceDiagram
+    autonumber
+    actor User
+    participant CLI as aileron launch
+    participant Mgmt as Management plane
+    participant CredSvc as Credential service
+    participant Container as Agent container
+
+    User->>CLI: aileron launch claude "..."
+    CLI->>CLI: Check ~/.aileron/service.json
+    alt Backend not running
+      CLI->>Mgmt: Auto-spawn aileron service
+      Mgmt->>Mgmt: Bind localhost, write service.json
+    end
+    CLI->>User: Prompt for master key
+    User->>CLI: Master key
+    CLI->>Mgmt: Start session for user X
+    Mgmt->>CLI: session_id, session bearer, HTTPS_PROXY URL, CA cert
+    CLI->>CredSvc: Deliver master key (local secure channel)
+    CredSvc->>CredSvc: Store session entry: session_id → master_key
+    CLI->>Container: docker sandbox create + run<br/>(HTTPS_PROXY, session token,<br/>CA cert installed,<br/>placeholder auth configs,<br/>system prompt hint)
+    Container->>Container: Agent starts (no master key, no plaintext)
+    CLI->>CLI: Exit (key zeroes from CLI memory)
+    Container->>User: Agent begins work
+`} />
+
+## Credentialed action flow
+
+Mid-session, the agent invokes a connector shim (e.g., `linear create-issue --title "x"`). Same flow applies to third-party CLIs like `gh issue create` and to the agent's LLM API call. Single mediation path.
+
+<MermaidDiagram client:load graph={`sequenceDiagram
+    autonumber
+    participant Agent
+    participant Shim as linear (shim)
+    participant Proxy as HTTPS proxy
+    participant Mgmt as Management plane
+    participant CredSvc as Credential service
+    participant Store as Encrypted Store
+    participant Linear as api.linear.app
+
+    Agent->>Shim: linear create-issue --title "x"
+    Shim->>Proxy: CONNECT api.linear.app:443 (via HTTPS_PROXY)
+    Proxy->>Proxy: Authenticate (session token)
+    Shim->>Proxy: POST /issues with placeholder auth (TLS terminated)
+    Proxy->>Proxy: Match request → action: linear.create_issue
+    Proxy->>Mgmt: Evaluate policy
+    Mgmt-->>Proxy: Approval required
+    Proxy->>Mgmt: Post approval request
+    Mgmt->>User: Render approval (TUI / webapp / mobile)
+    User-->>Mgmt: Approve
+    Mgmt-->>Proxy: Approval token
+    Proxy->>CredSvc: Decrypt Linear credential for session
+    CredSvc->>Store: Fetch wrapped vault key (if not cached)
+    Store-->>CredSvc: Wrapped vault key
+    CredSvc->>CredSvc: Unwrap with master key (cache for session)
+    CredSvc->>Store: Fetch encrypted Linear credential
+    Store-->>CredSvc: Ciphertext
+    CredSvc->>CredSvc: Decrypt with vault key
+    CredSvc-->>Proxy: Plaintext credential
+    Proxy->>Proxy: Strip placeholder auth, inject real bearer
+    Proxy->>Linear: POST /issues (new TLS upstream)
+    Linear-->>Proxy: 201 Created
+    Proxy->>Proxy: Zero plaintext credential
+    Proxy->>Mgmt: Audit: action completed
+    Proxy-->>Shim: 201 Created
+    Shim-->>Agent: stdout: created issue #123
+`} />
+
+The plaintext credential never enters the agent container, never appears in any tool's memory, never appears in any logged request body the operator sees. Audit captures the action with attribution to the user.
+
+## Deployment topology evolution
+
+Same architecture, three milestones. What changes is where each logical component runs and how it scales.
+
+### v4 — Customer-operated (~6 months)
+
+Single developer or team on their own machine. `aileron service` hosts the management plane and the data plane in one process. Encrypted store is file-backed locally. Agent container's `HTTPS_PROXY` points at the local process.
+
+<MermaidDiagram client:load graph={`graph LR
+    subgraph laptop["💻 Developer's laptop"]
+      CLI["aileron CLI"]
+      subgraph backend["aileron service (one process)"]
+        Mgmt["Mgmt plane"]
+        Proxy["HTTPS proxy"]
+        CredSvc["Cred svc"]
+      end
+      Store[("~/.aileron/store")]
+      Container["Agent container"]
+      Mgmt --> Store
+      CredSvc --> Store
+      Proxy <--> CredSvc
+      Proxy <--> Mgmt
+      CLI -.->|"key"| CredSvc
+      Container -->|"HTTPS_PROXY"| Proxy
+    end
+    External["External APIs"]
+    Proxy --> External
+
+    classDef purple fill:#f3e8ff,stroke:#9333ea,color:#581c87
+    classDef blue fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+    classDef green fill:#dcfce7,stroke:#16a34a,color:#14532d
+    classDef amber fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef red fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+
+    class CLI purple
+    class Mgmt,Store blue
+    class Proxy,CredSvc green
+    class Container amber
+    class External red
+`} />
+
+### v4.x — BYOC Enterprise (~6 to 12 months)
+
+Customer deploys the runtime backend into their own cloud account. Management plane and data plane split. Proxy workers autoscale to traffic. Credential service shards by team if needed.
+
+<MermaidDiagram client:load graph={`graph LR
+    subgraph cloud["☁️ Customer's cloud account"]
+      Mgmt["Management plane (multi-user)"]
+      Proxy["HTTPS proxy (autoscaled)"]
+      CredSvc["Credential service (session keys)"]
+      Store[("Postgres + S3")]
+      Mgmt --> Store
+      CredSvc --> Store
+      Proxy <--> CredSvc
+      Proxy <--> Mgmt
+    end
+
+    subgraph laptop_a["💻 User A"]
+      CLI_A["aileron CLI"]
+      Container_A["Agent container"]
+    end
+
+    subgraph laptop_b["💻 User B"]
+      CLI_B["aileron CLI"]
+      Container_B["Agent container"]
+    end
+
+    External["External APIs"]
+    CLI_A -.->|"key"| CredSvc
+    CLI_B -.->|"key"| CredSvc
+    Container_A -->|"HTTPS_PROXY"| Proxy
+    Container_B -->|"HTTPS_PROXY"| Proxy
+    Proxy --> External
+
+    classDef purple fill:#f3e8ff,stroke:#9333ea,color:#581c87
+    classDef blue fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+    classDef green fill:#dcfce7,stroke:#16a34a,color:#14532d
+    classDef amber fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef red fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+
+    class CLI_A,CLI_B purple
+    class Mgmt,Store blue
+    class Proxy,CredSvc green
+    class Container_A,Container_B amber
+    class External red
+`} />
+
+### v5 — Multi-tenant SaaS (~12 to 24 months)
+
+Aileron operates the runtime backend. Management plane is multi-tenant. **Both the HTTPS proxy and the credential service run inside Trusted Execution Environments**; together they form the data plane enclave. Master key flows through an attested channel from the user's device. Plaintext never leaves the TEE boundary.
+
+<MermaidDiagram client:load graph={`graph LR
+    subgraph aileron_cloud["☁️ Aileron multi-tenant cloud"]
+      Mgmt["Management plane (tenant-aware)"]
+      Store[("Postgres + blob (per-tenant)")]
+      Mgmt --> Store
+
+      subgraph tee["🔒 TEE (attested) — data plane enclave"]
+        Proxy["HTTPS proxy (Confidential VMs)"]
+        CredSvc["Credential service (sharded by tenant)"]
+        Proxy <--> CredSvc
+      end
+
+      CredSvc --> Store
+      Mgmt <--> Proxy
+      Container["Agent container"]
+    end
+
+    User["💻 User's browser / laptop"]
+    External["External APIs"]
+
+    User -.->|"key via attested channel"| CredSvc
+    User --> Mgmt
+    Container -->|"HTTPS_PROXY"| Proxy
+    Proxy --> External
+
+    classDef purple fill:#f3e8ff,stroke:#9333ea,color:#581c87
+    classDef blue fill:#dbeafe,stroke:#2563eb,color:#1e3a8a
+    classDef green fill:#dcfce7,stroke:#16a34a,color:#14532d
+    classDef amber fill:#fef3c7,stroke:#d97706,color:#78350f
+    classDef red fill:#fee2e2,stroke:#dc2626,color:#7f1d1d
+
+    class User purple
+    class Mgmt,Store blue
+    class Proxy,CredSvc green
+    class Container amber
+    class External red
+`} />
+
+### What lives where
+
+| Component | v4 | v4.x | v5 |
+|---|---|---|---|
+| Management plane | Colocated in `aileron service` on user's laptop | Separate service in customer cloud | Aileron's cloud, multi-tenant |
+| HTTPS proxy | Colocated in `aileron service` | Autoscaled worker pool in customer cloud | Inside TEE, each in Confidential VM |
+| Credential service | Colocated in `aileron service` | Separate service in customer cloud | Inside TEE alongside proxy, sharded by tenant |
+| Encrypted store | Local files in `~/.aileron/store/vaults/` | Customer's Postgres + blob storage | Aileron's Postgres + object storage, per-tenant prefixed |
+| Master key custody | User's laptop (briefly) → credential service | User's device → credential service in customer cloud | User's device → TEE via attested channel |
+| Agent container | User's laptop (docker sandbox) | User's laptop or customer cloud workspace | User's laptop or Aileron cloud |
+| Audit destination | Local audit log | Customer-configured SIEM | Customer-configured SIEM (export from Aileron) |
+
+## Zero-knowledge enforcement in v5 SaaS
+
+The TEE encloses the entire data plane: the HTTPS proxy and the credential service. Plaintext credentials, master keys, and unwrapped vault keys never exist outside the TEE boundary. This is what makes the zero-knowledge promise enforceable against Aileron as operator, not just asserted.
+
+**An Aileron operator with full infrastructure access CAN see:**
+
+- Encrypted blob storage contents (ciphertext only)
+- Network traffic between components (all TLS-encrypted)
+- TLS SNI showing upstream destinations (api.linear.app, anthropic.com, etc.)
+- Audit log entries (who performed what action, when)
+- Management plane state (sessions, policies, approvals, RBAC)
+- Agent container execution (filesystem, processes, stdout)
+- Attestation reports proving the TEE is running expected code
+
+**An Aileron operator CANNOT see:**
+
+- Master keys (live only inside TEE memory)
+- Unwrapped vault keys (live only inside TEE memory)
+- Decrypted credentials at any moment (TEE memory only)
+- Request bodies after TLS termination at the proxy (decrypted inside TEE)
+- Upstream HTTPS payloads (decrypted inside TEE)
+- The plaintext credential injection step (happens inside TEE)
+- Anything else inside TEE memory pages
+
+Customers verify the enforcement via TEE attestation at session start and on a continuous basis. Attestation is cryptographic proof that the TEE is running the audited, signed Aileron data plane code without modification. An operator cannot patch the TEE to leak secrets without breaking attestation and being detected.
+
+<Alert.Root class="my-6">
+  <Alert.Title>Threat model boundaries</Alert.Title>
+  <Alert.Description>
+    The TEE protects against passive observation, root access on the host VM, and most insider-threat scenarios. It does not protect against side-channel attacks on the TEE silicon (an active research area), supply-chain compromise of the Aileron-signed TEE image (mitigated via reproducible builds and customer-verified attestation), or the LLM provider seeing prompts and tool results.
+  </Alert.Description>
+</Alert.Root>
+
+## Open architectural decisions
+
+Decisions taken in the current design that are still open for refinement. "(chosen)" means a default position has been taken pending pushback.
+
+1. **One mediation path: HTTPS proxy for everything.** Aileron-curated connector shims, third-party CLIs, and the agent's LLM API call all route through the same proxy via `HTTPS_PROXY`. Connector specs drive request-to-action matching, policy enforcement, and credential routing. (chosen)
+2. **One binary, multiple modes.** `aileron` hosts the CLI subcommands and the long-lived service mode. Connector shims are spec-generated thin HTTPS clients shipped per connector package. No separate sidecar, proxy worker, MCP server, or action-executor binary. (chosen)
+3. **Management plane and data plane colocate in v4, split in v4.x.** Interface boundaries are network-call shape from day one so v4.x can deploy them separately without code change. (chosen)
+4. **Network policy is tiered.** Container's `HTTPS_PROXY` routes credentialed traffic through Aileron mediation. Uncredentialed direct egress is allowed by default for productivity (with audit). Customers can tighten to default-deny + allowlist for regulated deployments. (chosen)
+5. **Placeholder auth configs for supported third-party CLIs.** Aileron pre-populates each supported third-party CLI's local auth config at session start. (chosen)
+6. **Connector specs are mandatory.** Every Aileron connector ships an OpenAPI spec used by the proxy for request-to-action matching. (chosen)
+7. **Credential service is stateful, narrow.** Holds session-scoped material keyed by session ID. In v5, runs inside TEE with attestation. (chosen)
+8. **v5 TEE scope:** both HTTPS proxy and credential service run inside the TEE boundary; together they form the data plane enclave. Plaintext never exits the TEE. (chosen)
+9. **Master key delivery:** local secure channel in v4 (chosen); attested channel into TEE in v5. Mechanism in v4.x BYOC TBD.
+10. **Tool discoverability: lazy structured discovery.** System prompt hint plus `/etc/aileron/actions.json` manifest plus per-shim `--help`. No Aileron MCP server in v4. (chosen)
+11. **User-MCPs allowed via devcontainer.** Users add their own MCP servers in `customizations.aileron.mcps`. Aileron does not provide its own MCP server in v4. (chosen)
+12. **Credential lifecycle:** session keys cached in the credential service for the session's lifetime; plaintext credentials decrypted just-in-time per HTTPS request, zeroed after. (chosen)
+
+## References
+
+The HTTPS forward proxy with credential injection at the TLS boundary is the architecture Infisical published as [Agent Vault](https://infisical.com/blog/agent-vault-the-open-source-credential-proxy-and-vault-for-agents) (2026-04-22), and the same convergence Anthropic Managed Agents and Browser Use have reached. Aileron incorporates the pattern (not a code dependency in v4) and integrates with its own policy, audit, vault, and approval systems.
+
+Tracked in GitHub umbrella issue #747, sub-issues #796, #801, #802, #827, #828.

--- a/docs/src/lib/components/ui/mermaid-diagram.svelte
+++ b/docs/src/lib/components/ui/mermaid-diagram.svelte
@@ -1,0 +1,57 @@
+<script lang="ts">
+  import { onMount } from 'svelte';
+
+  /**
+   * Renders a Mermaid diagram from a graph definition string.
+   * Loads mermaid from CDN on mount so no build-time dependency is required.
+   * Used by docs pages that include architecture or sequence diagrams.
+   */
+  let {
+    graph,
+    class: className = ''
+  }: {
+    graph: string;
+    class?: string;
+  } = $props();
+
+  let container: HTMLDivElement;
+  let error = $state<string | null>(null);
+
+  onMount(async () => {
+    try {
+      // Dynamic import keeps mermaid out of the SSR bundle (it requires DOM globals).
+      const mod = await import('mermaid');
+      const mermaid = mod.default;
+      mermaid.initialize({
+        startOnLoad: false,
+        theme: 'base',
+        themeVariables: {
+          primaryColor: '#f1f5f9',
+          primaryTextColor: '#0f172a',
+          primaryBorderColor: '#475569',
+          lineColor: '#475569',
+          secondaryColor: '#dbeafe',
+          tertiaryColor: '#fef3c7',
+          fontFamily: 'ui-sans-serif, system-ui, sans-serif',
+          fontSize: '14px'
+        },
+        flowchart: { curve: 'basis', padding: 20 },
+        sequence: { actorMargin: 60, boxMargin: 10, messageMargin: 35 }
+      });
+      const id = `mermaid-${Math.random().toString(36).slice(2)}`;
+      const { svg } = await mermaid.render(id, graph);
+      if (container) container.innerHTML = svg;
+    } catch (e) {
+      error = (e as Error)?.message ?? 'Failed to render diagram';
+    }
+  });
+</script>
+
+<div
+  bind:this={container}
+  class="mermaid-diagram not-prose flex justify-center overflow-x-auto rounded-lg border border-slate-200 bg-white p-4 {className}"
+>
+  {#if error}
+    <pre class="text-sm text-red-600">Diagram failed to render: {error}</pre>
+  {/if}
+</div>

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -42,7 +42,8 @@ export const navigation: NavItem[] = [
     label: 'Meet Aileron',
     children: [
       { label: 'Overview', href: '/' },
-      { label: 'Liftoff in 5 Minutes', href: '/getting-started/' }
+      { label: 'Liftoff in 5 Minutes', href: '/getting-started/' },
+      { label: 'v4', href: '/meet-aileron/v4/' }
     ]
   },
   {


### PR DESCRIPTION
## Summary

- New docs page at `/meet-aileron/v4/` describing the v4 architecture: execution layer for AI-core organizations, unified HTTPS-proxy mediation, vault-centric storage, tiered network policy, and topology evolution across v4 / v4.x / v5.
- New `MermaidDiagram` Svelte component at `src/lib/components/ui/mermaid-diagram.svelte`. Loads mermaid dynamically inside `onMount` (kept out of the SSR bundle since mermaid needs DOM globals). Used by the v4 page for the steady-state, startup, action-flow, and three topology diagrams.
- Adds `mermaid` ^11.4.1 as a runtime dependency in `docs/package.json`.
- Adds the v4 entry to sidebar navigation under "Meet Aileron".

## Test plan

- [x] `task build:docs` completes successfully; `/meet-aileron/v4/index.html` is in the build output.
- [ ] Run `pnpm dev` from `docs/` and visit `http://localhost:4321/meet-aileron/v4/` to verify all six mermaid diagrams render (steady-state, startup sequence, action flow, v4 / v4.x / v5 topologies).
- [ ] Sidebar shows the new "v4" entry under Meet Aileron.
- [ ] Page renders in both light and dark mode without layout issues.

🤖 Generated with [Claude Code](https://claude.com/claude-code)