### PR TITLE
chore: scrub remaining BYOCLI references in sandbox + test comments

### DIFF
--- a/cmd/aileron/connector_install_hub_test.go
+++ b/cmd/aileron/connector_install_hub_test.go
@@ -259,8 +259,8 @@ func TestRunConnectorInstall_HubFlowAlreadyTrustedRendersGreen(t *testing.T) {
 // TestRunConnectorInstall_HubMissingFallsBackToPreview: a 404 from
 // /v1/hub/install-decision means the FQN is not in the Hub. The CLI
 // falls back to the legacy preview-then-install flow without surfacing
-// any error — pre-Hub connectors (private repos, BYOCLI wrappers) keep
-// working the same way they did before #488.
+// any error — pre-Hub connectors (private repos) keep working the same
+// way they did before #488.
 func TestRunConnectorInstall_HubMissingFallsBackToPreview(t *testing.T) {
 	var previewCalled, installCalled bool
 	hubInstallServer(t,

--- a/cmd/aileron/vault_state_test.go
+++ b/cmd/aileron/vault_state_test.go
@@ -118,14 +118,6 @@ func TestBypassesVault(t *testing.T) {
 		{"sync", []string{"sync"}, false},
 		{"audit list", []string{"audit", "list"}, false},
 		{"sessions list", []string{"sessions", "list"}, false},
-		// Per #783, BYOCLI commands now go through the state machine
-		// so first-run onboarding (banner + ASCII art + vault init)
-		// fires *before* the catalog fetch / go install. The cached
-		// passphrase covers the subsequent binding write without re-
-		// prompting the user.
-		{"pp add", []string{"pp", "add", "linear"}, false},
-		{"cli add", []string{"cli", "add", "/usr/local/bin/gh"}, false},
-		{"cli refresh", []string{"cli", "refresh", "linear"}, false},
 		{"unknown command", []string{"bogus"}, false},
 	}
 	for _, tc := range cases {

--- a/internal/sandbox/spawn.go
+++ b/internal/sandbox/spawn.go
@@ -315,12 +315,12 @@ type SpawnResult struct {
 // placeholder segment. Matching is greedy from left to right; literal
 // segments anchor the placeholder bounds.
 //
-// Optional-group rationale: PrintingPress-style CLIs expose verbs
-// with required + optional flags (e.g. `linear-pp-cli issues create
-// --title T --team K [--description D] [--priority N]`). Without
-// optional groups, every leaf would need a separate operation per
-// flag-combination (2^N — combinatorial explosion); with them, one
-// operation per leaf suffices and the matcher/substitutor admits or
+// Optional-group rationale: CLIs commonly expose verbs with
+// required + optional flags (e.g. `gh issue create --title T
+// --body B [--milestone M] [--label L]`). Without optional
+// groups, every leaf would need a separate operation per
+// flag-combination (2^N — combinatorial explosion); with them,
+// one operation per leaf suffices and the matcher/substitutor admits or
 // elides each optional group independently.
 type argvPattern struct {
 	groups []argvGroup

--- a/internal/sandbox/spawn_sandbox_common.go
+++ b/internal/sandbox/spawn_sandbox_common.go
@@ -12,9 +12,8 @@ package sandbox
 // A manifest that declares no FS scopes, no network, and no proxy
 // address (zero-value SpawnLimits) gets the legacy no-op behavior
 // so pre-sandbox tests and internal smoke checks continue to
-// function. Production BYOCLI connectors always declare at least
-// an FS scope and therefore land in the unavailable path on
-// unsupported OSes.
+// function. Connectors that declare any sandbox-relevant scope
+// land in the unavailable path on unsupported OSes.
 //
 // Lives in a non-build-tagged file so every supported platform's
 // CI run measures it. The build-tagged entry point in

--- a/internal/sandbox/spawn_sandbox_darwin.go
+++ b/internal/sandbox/spawn_sandbox_darwin.go
@@ -36,8 +36,7 @@ const sandboxExecPath = "/usr/bin/sandbox-exec"
 // (impossible on a healthy macOS install but the runtime fails
 // closed rather than spawn unconfined). Returns nil with no
 // modification to `cmd` when no manifest sandbox parameters were
-// declared (legacy path; pre-BYOCLI connectors continue to run
-// unchanged).
+// declared.
 func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) (platformSandboxHooks, error) {
 	if !limits.PlatformSandboxRequested() {
 		return platformSandboxHooks{}, nil
@@ -66,7 +65,7 @@ func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) 
 // private Apple operations like `mach-bootstrap`, `syscall*`,
 // `file-map-executable` for every framework, and is brittle across
 // macOS versions), then surgical denies on the operations that
-// carry the BYOCLI threat model:
+// carry the threat model:
 //
 //   - **File reads under user-private paths.** `/Users`, `/Volumes`,
 //     and user-scoped `/private/var/folders` are denied by default;
@@ -83,10 +82,10 @@ func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) 
 //
 // Reads of `/etc`, `/opt`, `/usr/local`, and other system paths
 // outside `/Users` and `/Volumes` are allowed by the permissive
-// baseline. This matches the BYOCLI threat model (which targets
-// user-secret exfiltration, not OS-file reads) and aligns with
-// what `brew install`-style CLIs already see when run bare from
-// the shell. A future tightening can move toward `(deny default)`
+// baseline. The threat model targets user-secret exfiltration,
+// not OS-file reads, and the permissive baseline aligns with what
+// `brew install`-style CLIs already see when run bare from the
+// shell. A future tightening can move toward `(deny default)`
 // with explicit allows once the system-essentials set has been
 // empirically validated across macOS releases.
 //
@@ -121,16 +120,14 @@ func buildSBPLProfile(env SpawnEnvelope, limits SpawnLimits) string {
 	// a profile that denies the path, `SecPolicyCreateSSL` returns
 	// NULL and Go's TLS stack surfaces it as
 	// `tls: failed to verify certificate: SecPolicyCreateSSL error: 0`
-	// on every HTTPS call. This affects every Go-on-darwin spawn
-	// connector installed under /Users (the default `aileron pp add`
-	// layout puts them under `~/.aileron/connectors/...`).
+	// on every HTTPS call.
 	//
 	// `subpath` is required, not `literal`: Security stats the
 	// surrounding directory in addition to mapping the Mach-O,
 	// so a literal-file allow alone does not suffice. This grant
-	// does not widen the BYOCLI threat model — the binary is
-	// already trusted to execute under this profile; reading its
-	// own resting directory adds no exfiltration surface.
+	// does not widen the threat model — the binary is already
+	// trusted to execute under this profile; reading its own
+	// resting directory adds no exfiltration surface.
 	if env.Program != "" {
 		if expanded, err := expandTilde(env.Program); err == nil {
 			fmt.Fprintf(&b, "(allow file-read* (subpath %s))\n", sbplQuote(filepath.Dir(expanded)))

--- a/internal/sandbox/spawn_sandbox_darwin_test.go
+++ b/internal/sandbox/spawn_sandbox_darwin_test.go
@@ -71,11 +71,10 @@ func TestApplyPlatformSandbox_Darwin_WrapsCmdWhenParamsDeclared(t *testing.T) {
 }
 
 func TestBuildSBPLProfile_HasPermissiveBaselineWithUserDenies(t *testing.T) {
-	// Contract: per the BYOCLI threat model in ADR-0014's macOS
-	// section, the profile uses an `(allow default)` baseline plus
-	// surgical denies on user-private paths and writes. The wrapped
-	// program name appears as a trailing comment for post-hoc
-	// inspection.
+	// Contract: per ADR-0014's macOS section, the profile uses an
+	// `(allow default)` baseline plus surgical denies on user-private
+	// paths and writes. The wrapped program name appears as a
+	// trailing comment for post-hoc inspection.
 	env := SpawnEnvelope{Program: "/usr/bin/git"}
 	profile := buildSBPLProfile(env, SpawnLimits{FSRead: []string{"~/code/"}})
 	mustContain(t, profile,
@@ -246,12 +245,11 @@ func TestApplyPlatformSandbox_Darwin_RunsRealBinaryUnderSandbox(t *testing.T) {
 }
 
 func TestApplyPlatformSandbox_Darwin_BlocksUserHomeReadOutsideScope(t *testing.T) {
-	// Contract (BYOCLI threat model): a binary spawned under a
-	// profile whose fs_read does not cover a path under /Users
-	// cannot read that path. The kernel sandbox kext rejects the
-	// open, the binary errors. This is the load-bearing defense
-	// against user-secret exfiltration. /bin/cat is a small Mach-O
-	// to use as a probe.
+	// Contract: a binary spawned under a profile whose fs_read does
+	// not cover a path under /Users cannot read that path. The kernel
+	// sandbox kext rejects the open, the binary errors. This is the
+	// load-bearing defense against user-secret exfiltration.
+	// /bin/cat is a small Mach-O to use as a probe.
 	//
 	// Write a sentinel file outside the manifest's scope, then
 	// declare an fs_read that does not cover it, then run cat on

--- a/internal/sandbox/spawn_sandbox_linux.go
+++ b/internal/sandbox/spawn_sandbox_linux.go
@@ -72,8 +72,7 @@ var osExecutable = os.Executable
 // Returns [ErrSpawnUnavailable] when unprivileged user namespaces
 // are disabled at the sysctl level or when the daemon binary
 // path cannot be discovered. Returns nil with no modification to
-// `cmd` when no manifest sandbox parameters were declared
-// (legacy path; pre-BYOCLI connectors continue to run unchanged).
+// `cmd` when no manifest sandbox parameters were declared.
 func applyPlatformSandbox(cmd *exec.Cmd, env SpawnEnvelope, limits SpawnLimits) (platformSandboxHooks, error) {
 	_ = env
 	if !limits.PlatformSandboxRequested() {

--- a/internal/sandbox/spawn_sandbox_linux_test.go
+++ b/internal/sandbox/spawn_sandbox_linux_test.go
@@ -196,12 +196,12 @@ func TestApplyPlatformSandbox_Linux_NoRewireWhenOnlyProxyAddrDeclared(t *testing
 }
 
 func TestApplyPlatformSandbox_Linux_HelperEnforcesLandlockReadScope(t *testing.T) {
-	// End-to-end (BYOCLI threat model): a wrapped CLI cannot read
-	// outside its declared fs_read scope. The test binary acts as
-	// the daemon: when the runtime re-execs into the helper marker
-	// (via TestMain dispatch), Landlock is applied and cat is
-	// exec'd; cat reading a sentinel outside the scope fails with
-	// EPERM/EACCES at the kernel boundary.
+	// End-to-end: a wrapped CLI cannot read outside its declared
+	// fs_read scope. The test binary acts as the daemon: when the
+	// runtime re-execs into the helper marker (via TestMain
+	// dispatch), Landlock is applied and cat is exec'd; cat
+	// reading a sentinel outside the scope fails with EPERM/EACCES
+	// at the kernel boundary.
 	if _, err := os.Stat("/bin/cat"); err != nil {
 		t.Skip("/bin/cat not present")
 	}

--- a/internal/sandbox/spawn_sandbox_windows.go
+++ b/internal/sandbox/spawn_sandbox_windows.go
@@ -46,7 +46,7 @@ var (
 // The disable/delete/restrict lists are all nil for v1 (we rely on
 // DISABLE_MAX_PRIVILEGE | LUA_TOKEN to do the work). Plumbing them
 // through is a v2 hardening: explicit SIDs-to-restrict tightens the
-// trust further but isn't load-bearing for the BYOCLI threat model.
+// trust further but isn't load-bearing for the current threat model.
 func createRestrictedToken(existing windows.Token, flags uint32) (windows.Token, error) {
 	var newToken windows.Token
 	r1, _, e1 := procCreateRestrictedToken.Call(
@@ -90,8 +90,8 @@ func createRestrictedToken(existing windows.Token, flags uint32) (windows.Token,
 // What this does NOT yet deliver:
 //
 //   - Read confinement. Low integrity blocks writes, not reads.
-//     The BYOCLI threat model's "no ~/.ssh exfiltration" claim
-//     requires AppContainer (ADR-0014 defers).
+//     The "no ~/.ssh exfiltration" claim requires AppContainer
+//     (ADR-0014 defers).
 //   - ACL adjustments on fs_write paths. Low integrity is coarse;
 //     per-path ACLs giving the low-integrity token write access
 //     to declared scopes are a follow-up.
@@ -326,8 +326,8 @@ func createSpawnJobObject() (windows.Handle, error) {
 // Between exec.Cmd.Start and this call the subprocess is live
 // but unjobbed for a few microseconds. The window is a known
 // trade-off versus CREATE_SUSPENDED + manual ResumeThread which
-// Go's os/exec does not directly expose. For the BYOCLI threat
-// model the brief unjobbed window is acceptable; documented in
+// Go's os/exec does not directly expose. The brief unjobbed
+// window is acceptable for the threat model; documented in
 // ADR-0014's Windows section.
 func assignProcessToSpawnJob(job windows.Handle, p *os.Process) error {
 	procHandle, err := windows.OpenProcess(

--- a/internal/sandbox/spawn_test.go
+++ b/internal/sandbox/spawn_test.go
@@ -1308,10 +1308,10 @@ func TestArgvPattern_Substitute_PreservesLiteralTokens(t *testing.T) {
 	}
 }
 
-// Optional-group tests (`[...]` syntax). The wrap library targets
-// PrintingPress-style CLIs where leaves expose required + optional
-// flags; the pattern admits both fully-elided and fully-rendered
-// optional groups for the same operation.
+// Optional-group tests (`[...]` syntax). Pattern admits both
+// fully-elided and fully-rendered optional groups for the same
+// operation, supporting CLIs whose leaves expose required +
+// optional flags.
 
 func TestArgvPattern_OptionalGroup_ElidesWhenInputMissing(t *testing.T) {
 	pat := parseArgvPattern("issues create --title {title} [--description {description}]")

--- a/internal/sandbox/testdata/fakebinary/main.go
+++ b/internal/sandbox/testdata/fakebinary/main.go
@@ -1,7 +1,7 @@
 // Package main is the test-only fake binary the runtime's
 // integration tests wrap to prove the platform sandbox enforces
-// the BYOCLI threat model. The same source is compiled and
-// invoked on every CI runner (linux, macOS, Windows), so the
+// the spawn-primitive threat model. The same source is compiled
+// and invoked on every CI runner (linux, macOS, Windows), so the
 // assertions across the matrix exercise identical attack
 // scenarios and the test surface stays portable.
 //


### PR DESCRIPTION
## Summary

Step 6 of the BYOCLI removal (#840). All functional local-mode code is gone after #841–#845; what remained were narrative comments and a few stale test entries. This PR cleans them up so the codebase reads as if BYOCLI never existed.

## Changes

- `internal/sandbox/spawn.go`, `spawn_test.go`, `spawn_sandbox_common.go`, `spawn_sandbox_darwin.go`, `spawn_sandbox_darwin_test.go`, `spawn_sandbox_linux.go`, `spawn_sandbox_linux_test.go`, `spawn_sandbox_windows.go`: rewrite comments that framed the sandbox contract as the "BYOCLI threat model" or referenced "pre-BYOCLI connectors." The technical narrative stays — only the BYOCLI framing is removed.
- `internal/sandbox/testdata/fakebinary/main.go`: rebrand from "BYOCLI threat model" to "spawn-primitive threat model." The binary itself stays — it's a generic sandbox-enforcement probe.
- `cmd/aileron/connector_install_hub_test.go`: drop the "BYOCLI wrappers" example from the hub-fallback test comment.
- `cmd/aileron/vault_state_test.go`: drop the three test-table entries (`pp add`, `cli add`, `cli refresh`) testing state-machine behavior for commands that no longer exist.

## Test plan

- [x] `task test:go` passes.
- [x] `grep -rn "BYOCLI\\|byocli\\|PrintingPress\\|printingpress\\|pre-BYOCLI\\|local://" --include="*.go"` returns zero hits.
- [x] `grep -rn "internal/wrap\\|internal/sandbox/run_help" --include="*.go"` returns zero hits.

## Refs

- Umbrella: #840
- Predecessors: #841, #842, #843, #844, #845 (all merged)
