### PR TITLE
test: scrub last connectors/local path in sandbox test fixture

### DIFF
--- a/internal/sandbox/spawn_sandbox_darwin_test.go
+++ b/internal/sandbox/spawn_sandbox_darwin_test.go
@@ -93,16 +93,16 @@ func TestBuildSBPLProfile_AllowsReadOnSpawnedBinaryDir(t *testing.T) {
 	// binary's parent directory and that allow MUST appear after
 	// the /Users deny so the SBPL evaluator reinstates it. Without
 	// this, macOS Security framework's `SecPolicyCreateSSL` fails
-	// for any Go binary installed under /Users (the default
-	// `aileron pp add` layout), breaking every HTTPS call.
+	// for any Go binary installed under /Users, breaking every
+	// HTTPS call.
 	//
 	// `subpath` is required: a `literal` rule on the binary file
 	// alone does not satisfy Security framework, which also stats
 	// the surrounding directory while determining code-signing
 	// identity for keychain access scoping.
-	env := SpawnEnvelope{Program: "/Users/someone/.aileron/connectors/local/foo/bin/foo-cli"}
+	env := SpawnEnvelope{Program: "/Users/someone/.aileron/store/connectors/sha256/abc123/bin/foo-cli"}
 	profile := buildSBPLProfile(env, SpawnLimits{FSRead: []string{"~/code/"}})
-	wantRule := `(allow file-read* (subpath "/Users/someone/.aileron/connectors/local/foo/bin"))`
+	wantRule := `(allow file-read* (subpath "/Users/someone/.aileron/store/connectors/sha256/abc123/bin"))`
 	if !strings.Contains(profile, wantRule) {
 		t.Errorf("profile missing binary-dir allow rule %q:\n%s", wantRule, profile)
 	}


### PR DESCRIPTION
## Summary

Step 10 of the BYOCLI removal (#840). The umbrella's acceptance test grepped for `connectors/local` and expected zero hits across the repo. Two leftover mentions remained in `internal/sandbox/spawn_sandbox_darwin_test.go` where the test fixture used a BYOCLI install path as the example program under `/Users`.

The test itself is generic — it verifies the sandbox profile auto-allows `file-read*` on the spawned binary's parent directory regardless of where the binary lives — so update the fixture to use a content-addressed store path (`~/.aileron/store/connectors/sha256/<hash>/bin/`) which is the layout hub-installed connectors actually use.

With this, the umbrella's final acceptance grep returns zero across the repo.

## Test plan

- [x] `task test:go` passes (sandbox tests confirm the contract).
- [x] `grep -r "connectors/local"` across all source extensions returns zero hits.
- [x] `grep -r -i "BYOCLI\\|byocli\\|PrintingPress\\|printingpress\\|local://\\|OriginLocal"` across `*.go`, `*.md`, `*.yaml`, `*.yml` returns zero hits.

## Refs

- Umbrella: #840 (this closes it)
- Predecessors: #841, #842, #843, #844, #845, #846, #847, #848 (all merged)
