### PR TITLE
chore(deps): add gomodTidy postUpdateOption to renovate config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -6,6 +6,7 @@
   "platformAutomerge": true,
   "automergeStrategy": "squash",
   "minimumReleaseAge": "3 days",
+  "postUpdateOptions": ["gomodTidy"],
   "packageRules": [
     {
       "matchUpdateTypes": ["minor", "patch", "pin", "digest"],


### PR DESCRIPTION
## Summary

- Adds `postUpdateOptions: ["gomodTidy"]` to renovate.json so Renovate runs `go mod tidy` after Go dependency bumps
- Fixes a recurring CI failure where Renovate bumps a single Go module's go.mod/go.sum but doesn't propagate transitive dep updates to other modules in this multi-module repo (e.g. `cmd/aileron-enclave/go.mod` referencing the old indirect version)
- Recent examples: PR #835 (google.golang.org/api), #854 (golang.org/x/crypto) — both failed the enclave build with `go mod tidy` needed errors

## Test plan

- [ ] Merge this PR
- [ ] Confirm Renovate's next Go-module bump PR has clean go.mod/go.sum across all modules in CI
