### PR TITLE
[codex] add CLI action run command

### DIFF
--- a/cmd/aileron/action_state.go
+++ b/cmd/aileron/action_state.go
@@ -7,6 +7,8 @@ import (
 	"fmt"
 	"io"
 	"net/http"
+	"net/url"
+	"os"
 	"strings"
 	"text/tabwriter"
 	"time"
@@ -39,6 +41,30 @@ type actionLoadErrorItem struct {
 	Message string `json:"message"`
 	File    string `json:"file"`
 	Line    int    `json:"line,omitempty"`
+}
+
+type actionRunRequest struct {
+	Args map[string]any `json:"args"`
+}
+
+type actionRunResponse struct {
+	AuditID string  `json:"audit_id"`
+	Result  *string `json:"result,omitempty"`
+}
+
+type actionRunPendingResponse struct {
+	Status     string `json:"status"`
+	ApprovalID string `json:"approval_id"`
+	ReviewURL  string `json:"review_url,omitempty"`
+	Message    string `json:"message,omitempty"`
+}
+
+type actionRunFailureEnvelope struct {
+	Error struct {
+		Class   string `json:"class"`
+		Message string `json:"message"`
+		AuditID string `json:"audit_id,omitempty"`
+	} `json:"error"`
 }
 
 // actionsHTTPClient is overridable in tests so they can exercise the
@@ -166,6 +192,174 @@ func runActionList(args []string, stdout, stderr io.Writer) int {
 		}
 	}
 	return 0
+}
+
+type actionRunArgFlag struct {
+	values map[string]string
+	count  int
+}
+
+func (f *actionRunArgFlag) String() string {
+	if f == nil || len(f.values) == 0 {
+		return ""
+	}
+	body, _ := json.Marshal(f.values)
+	return string(body)
+}
+
+func (f *actionRunArgFlag) Set(value string) error {
+	key, val, ok := strings.Cut(value, "=")
+	if !ok || strings.TrimSpace(key) == "" {
+		return fmt.Errorf("--arg must be k=v")
+	}
+	if f.values == nil {
+		f.values = map[string]string{}
+	}
+	f.values[strings.TrimSpace(key)] = val
+	f.count++
+	return nil
+}
+
+// runActionRun implements `aileron action run <NAME>`. It is a thin
+// terminal-facing wrapper over the daemon's canonical
+// POST /v1/actions/{name}/run endpoint.
+func runActionRun(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("action run", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	var kvArgs actionRunArgFlag
+	flags.Var(&kvArgs, "arg", "Action argument as k=v; repeatable")
+	rawArgs := flags.String("args", "", "Raw JSON object for action args")
+	asJSON := flags.Bool("json", false, "Print the daemon response envelope verbatim")
+	auditIDOut := flags.String("audit-id-out", "", "Write the action audit_id to this path")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 1 || strings.TrimSpace(flags.Arg(0)) == "" {
+		fmt.Fprintln(stderr, "usage: aileron action run <NAME> [--arg k=v ...] [--args <json>] [--json] [--audit-id-out <path>]")
+		return 1
+	}
+	if kvArgs.count > 0 && strings.TrimSpace(*rawArgs) != "" {
+		fmt.Fprintln(stderr, "error: --arg and --args are mutually exclusive")
+		return 1
+	}
+
+	runArgs := map[string]any{}
+	if strings.TrimSpace(*rawArgs) != "" {
+		if err := json.Unmarshal([]byte(*rawArgs), &runArgs); err != nil {
+			fmt.Fprintf(stderr, "error: --args must be a JSON object: %v\n", err)
+			return 1
+		}
+		if runArgs == nil {
+			fmt.Fprintln(stderr, "error: --args must be a JSON object")
+			return 1
+		}
+	} else if kvArgs.count > 0 {
+		for k, v := range kvArgs.values {
+			runArgs[k] = v
+		}
+	}
+
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	name := strings.TrimSpace(flags.Arg(0))
+	body, _ := json.Marshal(actionRunRequest{Args: runArgs})
+	req, err := http.NewRequest(http.MethodPost, base+"/actions/"+url.PathEscape(name)+"/run", bytes.NewReader(body))
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	req.Header.Set("Content-Type", "application/json")
+	resp, err := actionsHTTPClient.Do(req)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	defer resp.Body.Close()
+	rawBody, err := io.ReadAll(resp.Body)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: reading response: %v\n", err)
+		return 1
+	}
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		if *auditIDOut != "" {
+			var out actionRunResponse
+			if err := json.Unmarshal(rawBody, &out); err != nil {
+				fmt.Fprintf(stderr, "decoding response: %v\n", err)
+				return 1
+			}
+			if err := writeAuditID(*auditIDOut, out.AuditID); err != nil {
+				fmt.Fprintf(stderr, "error: %v\n", err)
+				return 1
+			}
+		}
+		if *asJSON {
+			writeRawJSON(stdout, rawBody)
+			return 0
+		}
+		var out actionRunResponse
+		if err := json.Unmarshal(rawBody, &out); err != nil {
+			fmt.Fprintf(stderr, "decoding response: %v\n", err)
+			return 1
+		}
+		result := ""
+		if out.Result != nil {
+			result = *out.Result
+		}
+		fmt.Fprintln(stdout, "wrapped output:")
+		if result != "" {
+			fmt.Fprintln(stdout, result)
+		}
+		return 0
+	case http.StatusAccepted:
+		if *asJSON {
+			writeRawJSON(stdout, rawBody)
+			return 75
+		}
+		var pending actionRunPendingResponse
+		if err := json.Unmarshal(rawBody, &pending); err != nil {
+			fmt.Fprintf(stderr, "decoding pending response: %v\n", err)
+			return 1
+		}
+		if pending.ReviewURL != "" {
+			fmt.Fprintf(stderr, "approval pending; review at %s or run `aileron approval approve %s`\n", pending.ReviewURL, pending.ApprovalID)
+		} else {
+			fmt.Fprintf(stderr, "approval pending; run `aileron approval approve %s`\n", pending.ApprovalID)
+		}
+		return 75
+	default:
+		if env, ok := decodeActionRunFailure(rawBody); ok && env.Error.Class != "" {
+			fmt.Fprintf(stderr, "%s: %s\n", env.Error.Class, env.Error.Message)
+		}
+		fmt.Fprintf(stderr, "daemon returned %d: %s\n", resp.StatusCode, strings.TrimSpace(string(rawBody)))
+		return 1
+	}
+}
+
+func writeRawJSON(w io.Writer, raw []byte) {
+	_, _ = w.Write(raw)
+	if len(raw) == 0 || raw[len(raw)-1] != '\n' {
+		fmt.Fprintln(w)
+	}
+}
+
+func writeAuditID(path, auditID string) error {
+	if path == "" {
+		return nil
+	}
+	return os.WriteFile(path, []byte(auditID+"\n"), 0o600)
+}
+
+func decodeActionRunFailure(raw []byte) (actionRunFailureEnvelope, bool) {
+	var env actionRunFailureEnvelope
+	if err := json.Unmarshal(raw, &env); err != nil {
+		return env, false
+	}
+	return env, true
 }
 
 // runActionToggle implements `aileron action enable|disable <NAME>` by

--- a/cmd/aileron/action_state_test.go
+++ b/cmd/aileron/action_state_test.go
@@ -7,6 +7,8 @@ import (
 	"io"
 	"net/http"
 	"net/http/httptest"
+	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 )
@@ -24,6 +26,8 @@ func newActionsFakeDaemon(t *testing.T, handler http.HandlerFunc) string {
 	t.Cleanup(srv.Close)
 	return srv.URL + "/v1"
 }
+
+func ptrString(s string) *string { return &s }
 
 // --- list ---
 
@@ -348,6 +352,163 @@ func TestRunActionList_EmptyJSONMode(t *testing.T) {
 	}
 }
 
+// --- run ---
+
+func TestRunActionRun_ArgFlagsSendArgsAndRenderResult(t *testing.T) {
+	var gotPath, gotMethod, gotContentType string
+	var gotBody []byte
+	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		gotMethod = r.Method
+		gotContentType = r.Header.Get("Content-Type")
+		gotBody, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(actionRunResponse{
+			AuditID: "audit-123",
+			Result:  ptrString(`{"ok":true}`),
+		})
+	})
+	setBindingBase(t, base)
+
+	auditPath := filepath.Join(t.TempDir(), "audit-id")
+	var stdout, stderr bytes.Buffer
+	code := runActionRun([]string{"--arg", "team=ENG", "--arg", "title=Smoke test", "--audit-id-out", auditPath, "linear-issues-create"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if gotMethod != http.MethodPost {
+		t.Errorf("method = %q", gotMethod)
+	}
+	if gotPath != "/v1/actions/linear-issues-create/run" {
+		t.Errorf("path = %q", gotPath)
+	}
+	if gotContentType != "application/json" {
+		t.Errorf("content-type = %q", gotContentType)
+	}
+	var parsed actionRunRequest
+	if err := json.Unmarshal(gotBody, &parsed); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	if parsed.Args["team"] != "ENG" || parsed.Args["title"] != "Smoke test" {
+		t.Errorf("args = %#v", parsed.Args)
+	}
+	if !strings.Contains(stdout.String(), "wrapped output:") || !strings.Contains(stdout.String(), `{"ok":true}`) {
+		t.Errorf("stdout missing rendered result: %s", stdout.String())
+	}
+	written, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit id: %v", err)
+	}
+	if string(written) != "audit-123\n" {
+		t.Errorf("audit id file = %q", string(written))
+	}
+}
+
+func TestRunActionRun_RawArgsJSONPassthrough(t *testing.T) {
+	var gotBody []byte
+	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		_ = json.NewEncoder(w).Encode(actionRunResponse{AuditID: "audit-raw"})
+	})
+	setBindingBase(t, base)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionRun([]string{"--args", `{"labels":["bug","triage"],"priority":2}`, "linear-issues-create"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	var parsed actionRunRequest
+	if err := json.Unmarshal(gotBody, &parsed); err != nil {
+		t.Fatalf("decode body: %v", err)
+	}
+	labels, ok := parsed.Args["labels"].([]any)
+	if !ok || len(labels) != 2 || labels[0] != "bug" || labels[1] != "triage" {
+		t.Errorf("labels = %#v", parsed.Args["labels"])
+	}
+	if parsed.Args["priority"] != float64(2) {
+		t.Errorf("priority = %#v", parsed.Args["priority"])
+	}
+}
+
+func TestRunActionRun_JSONModePrintsRawEnvelope(t *testing.T) {
+	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		_, _ = io.WriteString(w, `{"audit_id":"audit-json","result":"ok"}`)
+	})
+	setBindingBase(t, base)
+
+	auditPath := filepath.Join(t.TempDir(), "audit-id")
+	var stdout, stderr bytes.Buffer
+	code := runActionRun([]string{"--json", "--audit-id-out", auditPath, "ship-update"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.TrimSpace(stdout.String()) != `{"audit_id":"audit-json","result":"ok"}` {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+	written, err := os.ReadFile(auditPath)
+	if err != nil {
+		t.Fatalf("read audit id: %v", err)
+	}
+	if string(written) != "audit-json\n" {
+		t.Errorf("audit id file = %q", string(written))
+	}
+}
+
+func TestRunActionRun_PendingApprovalReturnsTempFail(t *testing.T) {
+	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		_ = json.NewEncoder(w).Encode(actionRunPendingResponse{
+			Status:     "pending_approval",
+			ApprovalID: "act-123",
+			ReviewURL:  "http://127.0.0.1:50419/approvals?focus=act-123",
+		})
+	})
+	setBindingBase(t, base)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionRun([]string{"send-draft"}, &stdout, &stderr)
+	if code != 75 {
+		t.Fatalf("exit = %d, want 75; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "approval pending") ||
+		!strings.Contains(stderr.String(), "http://127.0.0.1:50419/approvals?focus=act-123") ||
+		!strings.Contains(stderr.String(), "aileron approval approve act-123") {
+		t.Errorf("stderr missing approval guidance: %s", stderr.String())
+	}
+}
+
+func TestRunActionRun_SurfacesStructuredErrorClass(t *testing.T) {
+	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusPreconditionFailed)
+		_, _ = io.WriteString(w, `{"error":{"class":"binding_required","message":"vault is locked","boundary":"runtime","retriable":true}}`)
+	})
+	setBindingBase(t, base)
+
+	var stdout, stderr bytes.Buffer
+	code := runActionRun([]string{"ship-update"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("expected non-zero exit")
+	}
+	if !strings.Contains(stderr.String(), "binding_required: vault is locked") {
+		t.Errorf("stderr missing structured class: %s", stderr.String())
+	}
+}
+
+func TestRunActionRun_RejectsInvalidArgs(t *testing.T) {
+	cases := [][]string{
+		{"--arg", "missing-equals", "ship-update"},
+		{"--arg", "x=y", "--args", `{"x":"z"}`, "ship-update"},
+		{"--args", `[1,2]`, "ship-update"},
+	}
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			if code := runActionRun(args, &stdout, &stderr); code == 0 {
+				t.Fatalf("expected non-zero exit for args %v", args)
+			}
+		})
+	}
+}
+
 func TestRunActionToggle_BaseURLError(t *testing.T) {
 	orig := bindingAPIBaseURL
 	bindingAPIBaseURL = func() (string, error) { return "", fmt.Errorf("spawn boom") }
@@ -382,6 +543,24 @@ func TestRunAction_DispatchesList(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "No actions installed") {
 		t.Errorf("list dispatch did not call runActionList: %s", stdout.String())
+	}
+}
+
+func TestRunAction_DispatchesRun(t *testing.T) {
+	var gotPath string
+	base := newActionsFakeDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		gotPath = r.URL.Path
+		_ = json.NewEncoder(w).Encode(actionRunResponse{AuditID: "audit-run"})
+	})
+	setBindingBase(t, base)
+
+	var stdout, stderr bytes.Buffer
+	code := runAction([]string{"run", "ship-update"}, strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if gotPath != "/v1/actions/ship-update/run" {
+		t.Errorf("run dispatch path = %q", gotPath)
 	}
 }
 

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -171,6 +171,7 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron connector install <FQN>    Install a connector binary from its FQN")
 	fmt.Fprintln(w, "  aileron connector check            Check installed connectors for newer versions")
 	fmt.Fprintln(w, "  aileron action add <FQN>           Install an action template from its FQN")
+	fmt.Fprintln(w, "  aileron action run <NAME>          Invoke an installed action directly")
 	fmt.Fprintln(w, "  aileron keyring trust <auth> <key> Authorize a publisher's signing key for installs")
 	fmt.Fprintln(w, "  aileron keyring list               List trusted publishers and key fingerprints")
 	fmt.Fprintln(w, "  aileron keyring revoke <auth>      Remove a publisher's keys from the trust list")
@@ -1262,6 +1263,7 @@ const connectorUsage = `usage:
 
 const actionUsage = `usage:
   aileron action list                  [--json]
+  aileron action run <NAME>            [--arg k=v ...] [--args <json>] [--json] [--audit-id-out <path>]
   aileron action enable <NAME>
   aileron action disable <NAME>
   aileron action add <FQN>             [--version=<v>] [--force] [--yes] [--no-bind]
@@ -1449,6 +1451,8 @@ func runAction(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 		return runActionAddSuite(args[1:], br, stdout, stderr)
 	case "list":
 		return runActionList(args[1:], stdout, stderr)
+	case "run":
+		return runActionRun(args[1:], stdout, stderr)
 	case "enable":
 		return runActionToggle(args[1:], true, stdout, stderr)
 	case "disable":

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -24,7 +24,40 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 | `aileron action add <FQN>@<version>` | Fetch an action template from the named source and copy it into `~/.aileron/actions/`. Walks declared connector dependencies and prompts for each. | [ADR-0003](/adr/0003-action-model), [ADR-0007](/adr/0007-install-consent) |
 | `aileron action update <name>` | Fetch the latest version of an installed action's template; show a diff against the local file; apply on confirmation. | [ADR-0003](/adr/0003-action-model) |
 | `aileron action list` | List every action in `~/.aileron/actions/` with its source FQN, version, and connector dependencies. | [ADR-0003](/adr/0003-action-model) |
+| `aileron action run <name>` | Invoke an installed action directly from the terminal through the same daemon endpoint used by the agent-facing MCP server. Useful for smoke tests, connector diagnostics, and scripts. | [ADR-0003](/adr/0003-action-model), [ADR-0008](/adr/0008-intent-matching), [ADR-0009](/adr/0009-user-channel) |
 | `aileron action remove <name>` | Delete an installed action file. Connectors no longer referenced are *not* automatically removed; use `aileron connector gc`. | [ADR-0003](/adr/0003-action-model) |
+
+### `aileron action run`
+
+```bash
+aileron action run <name> [--arg k=v ...] [--args <json>] [--json] [--audit-id-out <path>]
+```
+
+`<name>` is the installed action name shown by `aileron action list`, such as `sentry-organizations-list` or `linear-issues-create`. The CLI posts to `POST /v1/actions/{name}/run`; there is no separate execution path or weaker approval path for terminal invocations.
+
+Arguments can be supplied in either of two mutually exclusive forms:
+
+```bash
+aileron action run linear-issues-create \
+  --arg team=ENG \
+  --arg title='Smoke test'
+
+aileron action run linear-issues-create \
+  --args '{"labels":["bug","triage"],"priority":2}'
+```
+
+`--arg k=v` is repeatable and sends string values. `--args <json>` sends a raw JSON object for nested values, arrays, numbers, or booleans.
+
+By default, successful calls print:
+
+```text
+wrapped output:
+<result>
+```
+
+Use `--json` to print the daemon response envelope exactly as returned, including `audit_id` and `result`. Use `--audit-id-out <path>` to write the successful execution's `audit_id` to a file for follow-up audit-log tooling.
+
+Approval-gated actions return an approval-pending message instead of running immediately. The CLI prints the review URL or `aileron approval approve <id>` command and exits with code `75` (`EX_TEMPFAIL`) so scripts can distinguish "approval needed" from ordinary failures.
 
 ## Connectors
 


### PR DESCRIPTION
## Summary
- Add `aileron action run <name>` for direct terminal invocation of installed actions.
- Support repeatable `--arg k=v`, raw JSON `--args`, raw daemon envelope output via `--json`, and `--audit-id-out` for scripts.
- Document the command in the docs CLI reference.

## Validation
- `go test ./...` from `cmd/aileron`
- `pnpm run check` from `docs`
- `pnpm run build` from `docs`

Refs #811