### PR TITLE
[codex] Add local daemon bearer auth

### DIFF
--- a/cmd/aileron/action_state.go
+++ b/cmd/aileron/action_state.go
@@ -112,6 +112,7 @@ func runActionList(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
+	setDaemonAuthorization(req)
 	resp, err := actionsHTTPClient.Do(req)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
@@ -388,6 +389,7 @@ func runActionToggle(args []string, enabled bool, stdout, stderr io.Writer) int 
 		return 1
 	}
 	req.Header.Set("Content-Type", "application/json")
+	setDaemonAuthorization(req)
 	resp, err := actionsHTTPClient.Do(req)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)

--- a/cmd/aileron/approval.go
+++ b/cmd/aileron/approval.go
@@ -181,5 +181,6 @@ func approvalDoRequest(method, path string, body []byte) (*http.Response, error)
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	setDaemonAuthorization(req)
 	return http.DefaultClient.Do(req)
 }

--- a/cmd/aileron/daemon_cli.go
+++ b/cmd/aileron/daemon_cli.go
@@ -144,7 +144,7 @@ func runDaemonStatus(_ []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "  Started:    %s\n", info.StartedAt.Local().Format(time.RFC3339))
 	fmt.Fprintf(stdout, "  State dir:  %s\n", stateDir)
 
-	if locked, ok := probeLocalVaultLocked(info.URL); ok {
+	if locked, ok := probeLocalVaultLocked(info.URL, info.Token); ok {
 		state := "unlocked"
 		if locked {
 			state = "locked"
@@ -158,9 +158,16 @@ func runDaemonStatus(_ []string, stdout, stderr io.Writer) int {
 // locked. Returns (locked, true) on a successful probe; (_, false)
 // when the daemon doesn't respond or doesn't expose the endpoint
 // (e.g. cloud-shaped deployment without a local vault).
-func probeLocalVaultLocked(baseURL string) (bool, bool) {
+func probeLocalVaultLocked(baseURL, token string) (bool, bool) {
 	client := &http.Client{Timeout: 1 * time.Second}
-	resp, err := client.Get(baseURL + "/v1/vault/status")
+	req, err := http.NewRequest(http.MethodGet, baseURL+"/v1/vault/status", nil)
+	if err != nil {
+		return false, false
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
 	if err != nil {
 		return false, false
 	}

--- a/cmd/aileron/daemon_cli_test.go
+++ b/cmd/aileron/daemon_cli_test.go
@@ -148,7 +148,7 @@ func TestProbeLocalVaultLocked_LockedTrue(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	locked, ok := probeLocalVaultLocked(srv.URL)
+	locked, ok := probeLocalVaultLocked(srv.URL, "")
 	if !ok {
 		t.Fatal("ok should be true on a 200 response")
 	}
@@ -163,7 +163,7 @@ func TestProbeLocalVaultLocked_UnlockedFalse(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	locked, ok := probeLocalVaultLocked(srv.URL)
+	locked, ok := probeLocalVaultLocked(srv.URL, "")
 	if !ok {
 		t.Fatal("ok should be true on a 200 response")
 	}
@@ -174,7 +174,7 @@ func TestProbeLocalVaultLocked_UnlockedFalse(t *testing.T) {
 
 func TestProbeLocalVaultLocked_NoServer(t *testing.T) {
 	// Port 1 is privileged + nothing listens — connect refused / timeout.
-	_, ok := probeLocalVaultLocked("http://127.0.0.1:1")
+	_, ok := probeLocalVaultLocked("http://127.0.0.1:1", "")
 	if ok {
 		t.Fatal("ok should be false when the daemon isn't reachable")
 	}
@@ -186,7 +186,7 @@ func TestProbeLocalVaultLocked_Non200(t *testing.T) {
 	}))
 	defer srv.Close()
 
-	_, ok := probeLocalVaultLocked(srv.URL)
+	_, ok := probeLocalVaultLocked(srv.URL, "")
 	if ok {
 		t.Fatal("ok should be false on non-200")
 	}

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/config"
 	"github.com/ALRubinger/aileron/internal/cstore"
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/daemon/spawn"
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/launch/agents"
@@ -508,6 +509,7 @@ func bindingDoRequest(method, path string, body io.Reader) (int, []byte, error) 
 	if body != nil {
 		req.Header.Set("Content-Type", "application/json")
 	}
+	setDaemonAuthorization(req)
 	resp, err := http.DefaultClient.Do(req)
 	if err != nil {
 		return 0, nil, err
@@ -518,6 +520,27 @@ func bindingDoRequest(method, path string, body io.Reader) (int, []byte, error) 
 		return resp.StatusCode, nil, err
 	}
 	return resp.StatusCode, out, nil
+}
+
+func setDaemonAuthorization(req *http.Request) {
+	if token := daemonAuthToken(); token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+}
+
+func daemonAuthToken() string {
+	if token := os.Getenv("AILERON_TOKEN"); token != "" {
+		return token
+	}
+	stateDir, err := defaultStateDir()
+	if err != nil {
+		return ""
+	}
+	info, err := discovery.Read(stateDir)
+	if err != nil {
+		return ""
+	}
+	return info.Token
 }
 
 // runBindingList renders the user's bindings as a fixed-width table.
@@ -1153,6 +1176,7 @@ func fetchRuntimeStatus() (*runtimeStatus, error) {
 	if err != nil {
 		return nil, err
 	}
+	setDaemonAuthorization(req)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -1350,6 +1374,7 @@ func fetchConnectorCheck(includePrerelease bool) (*connectorsCheckResponse, erro
 	if err != nil {
 		return nil, err
 	}
+	setDaemonAuthorization(req)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err
@@ -1468,12 +1493,12 @@ func runAction(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 // locally so the CLI binary doesn't pull the full generated types
 // graph just to render this surface.
 type syncResult struct {
-	ActionsSeen      int                       `json:"actions_seen"`
-	Required         []connectorRefWire        `json:"required"`
-	Installed        []installedConnectorWire  `json:"installed"`
-	AlreadyInstalled []connectorRefWire        `json:"already_installed"`
-	InstallFailures  []connectorFailureWire    `json:"install_failures"`
-	Unbound          []unboundCapabilityWire   `json:"unbound"`
+	ActionsSeen      int                      `json:"actions_seen"`
+	Required         []connectorRefWire       `json:"required"`
+	Installed        []installedConnectorWire `json:"installed"`
+	AlreadyInstalled []connectorRefWire       `json:"already_installed"`
+	InstallFailures  []connectorFailureWire   `json:"install_failures"`
+	Unbound          []unboundCapabilityWire  `json:"unbound"`
 }
 
 type connectorRefWire struct {
@@ -1482,11 +1507,11 @@ type connectorRefWire struct {
 }
 
 type installedConnectorWire struct {
-	Fqn              string  `json:"fqn"`
-	Version          string  `json:"version"`
-	Hash             string  `json:"hash"`
-	EntryDir         string  `json:"entry_dir"`
-	AlreadyInstalled *bool   `json:"already_installed,omitempty"`
+	Fqn              string `json:"fqn"`
+	Version          string `json:"version"`
+	Hash             string `json:"hash"`
+	EntryDir         string `json:"entry_dir"`
+	AlreadyInstalled *bool  `json:"already_installed,omitempty"`
 }
 
 type connectorFailureWire struct {
@@ -1519,6 +1544,7 @@ func postSyncRequest(autoInstall bool) (*syncResult, error) {
 		return nil, err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	setDaemonAuthorization(req)
 	resp, err := client.Do(req)
 	if err != nil {
 		return nil, err

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -19,6 +19,7 @@ import (
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/cstore"
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/launch/agents"
 )
@@ -154,20 +155,6 @@ func TestRun_LaunchLogLevelNoAgent(t *testing.T) {
 	}
 }
 
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 func TestRunStatus_All(t *testing.T) {
 	dir := t.TempDir()
 	t.Setenv("HOME", dir)
@@ -191,8 +178,6 @@ func TestRunStatus_All(t *testing.T) {
 		t.Error("expected Vault section")
 	}
 }
-
-
 
 func TestRunStatus_Notifications(t *testing.T) {
 	dir := t.TempDir()
@@ -280,9 +265,6 @@ func TestRunStatus_InHelp(t *testing.T) {
 		t.Error("expected 'aileron status' in help output")
 	}
 }
-
-
-
 
 // TestRunStatus_RuntimeUnreachable covers the offline path: with no
 // daemon listening, `aileron status runtime` must exit cleanly and
@@ -392,7 +374,6 @@ func TestRunStatus_RuntimeIncludedInDefault(t *testing.T) {
 		t.Error("expected daemon version in default status output")
 	}
 }
-
 
 func TestRunSecret_NoSubcommand(t *testing.T) {
 	var stdout, stderr bytes.Buffer
@@ -1010,6 +991,63 @@ func TestBindingAPIBaseURL_OverrideTrimsTrailingSlash(t *testing.T) {
 	}
 }
 
+func TestDaemonAuthTokenPrefersEnvironment(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AILERON_TOKEN", "tok_env")
+	if got := daemonAuthToken(); got != "tok_env" {
+		t.Fatalf("daemonAuthToken = %q, want tok_env", got)
+	}
+}
+
+func TestDaemonAuthTokenReadsDiscovery(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+	if err := discovery.Write(stateDir, discovery.Info{
+		URL:   "http://127.0.0.1:8721",
+		Token: "tok_file",
+	}); err != nil {
+		t.Fatalf("write discovery: %v", err)
+	}
+	if got := daemonAuthToken(); got != "tok_file" {
+		t.Fatalf("daemonAuthToken = %q, want tok_file", got)
+	}
+}
+
+func TestSetDaemonAuthorization(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	t.Setenv("AILERON_TOKEN", "tok_req")
+	req := httptest.NewRequest(http.MethodGet, "http://daemon.test/v1/status", nil)
+
+	setDaemonAuthorization(req)
+
+	if got := req.Header.Get("Authorization"); got != "Bearer tok_req" {
+		t.Fatalf("Authorization = %q, want bearer token", got)
+	}
+}
+
+func TestBindingDoRequestSendsDaemonAuthorization(t *testing.T) {
+	t.Setenv("AILERON_TOKEN", "tok_binding")
+	var sawAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{}`)
+	}))
+	defer srv.Close()
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	status, _, err := bindingDoRequest(http.MethodGet, "/bindings", nil)
+	if err != nil {
+		t.Fatalf("bindingDoRequest: %v", err)
+	}
+	if status != http.StatusOK {
+		t.Fatalf("status = %d, want 200", status)
+	}
+	if sawAuth != "Bearer tok_binding" {
+		t.Fatalf("Authorization = %q, want bearer token", sawAuth)
+	}
+}
+
 // TestBindingAPIBaseURL_PropagatesSpawnErrorThroughCallers locks in
 // the post-#490 contract: every helper that previously dialed the
 // hardcoded `localhost:8721` fallback now propagates the spawn
@@ -1131,23 +1169,6 @@ func TestRunBinding_UnknownSubcommand(t *testing.T) {
 		t.Error("expected nonzero exit code for unknown subcommand")
 	}
 }
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
-
 
 func TestRunSecret_InHelp(t *testing.T) {
 	var stdout bytes.Buffer
@@ -4610,7 +4631,9 @@ actions = [
 `)
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
 		body, _ := io.ReadAll(r.Body)
-		var req struct{ FQN string `json:"fqn"` }
+		var req struct {
+			FQN string `json:"fqn"`
+		}
 		_ = json.Unmarshal(body, &req)
 		switch r.URL.Path {
 		case "/actions/preview":

--- a/cmd/aileron/vault_state.go
+++ b/cmd/aileron/vault_state.go
@@ -54,7 +54,7 @@ func ensureVaultUnlocked(passphraseFile string, stderr io.Writer) error {
 	daemonRunning := derr == nil && daemonReachableFn(info.URL)
 
 	if daemonRunning {
-		locked, ok := probeLocalVaultLocked(info.URL)
+		locked, ok := probeLocalVaultLocked(info.URL, info.Token)
 		if !ok {
 			// Daemon is reachable but doesn't expose the local-vault
 			// surface (cloud-shape or older binary). Nothing to do —
@@ -213,6 +213,7 @@ func postVaultUnlock(daemonURL, passphrase string) error {
 		return fmt.Errorf("build unlock request: %w", err)
 	}
 	req.Header.Set("Content-Type", "application/json")
+	setDaemonAuthorization(req)
 
 	client := &http.Client{Timeout: 10 * time.Second}
 	resp, err := client.Do(req)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -16,23 +16,23 @@ import (
 	"github.com/ALRubinger/aileron/internal/account"
 	"github.com/ALRubinger/aileron/internal/action"
 	api "github.com/ALRubinger/aileron/internal/api/gen"
-	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/approval"
+	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/auth"
 	githubauth "github.com/ALRubinger/aileron/internal/auth/github"
 	googleauth "github.com/ALRubinger/aileron/internal/auth/google"
-	"github.com/ALRubinger/aileron/internal/config"
-	"github.com/ALRubinger/aileron/internal/connector"
-	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/binding"
 	"github.com/ALRubinger/aileron/internal/comms"
+	"github.com/ALRubinger/aileron/internal/config"
+	"github.com/ALRubinger/aileron/internal/connector"
+	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/draft"
 	"github.com/ALRubinger/aileron/internal/enclave"
 	"github.com/ALRubinger/aileron/internal/hub"
-	"github.com/ALRubinger/aileron/internal/sandbox"
 	"github.com/ALRubinger/aileron/internal/notify"
 	"github.com/ALRubinger/aileron/internal/observability"
 	"github.com/ALRubinger/aileron/internal/policy"
+	"github.com/ALRubinger/aileron/internal/sandbox"
 	"github.com/ALRubinger/aileron/internal/sessions"
 	"github.com/ALRubinger/aileron/internal/source"
 	calendarsource "github.com/ALRubinger/aileron/internal/source/calendar"
@@ -74,6 +74,13 @@ type Config struct {
 	// empty. Empty surfaces a generic prompt instead of a URL — the
 	// operator at least learns something needs attention.
 	WebappURL string
+
+	// LocalDaemonToken enables always-on bearer authentication for the
+	// local daemon's /v1/* surface. CLI and in-container clients read
+	// the token from daemon.json and send Authorization: Bearer <token>.
+	// The local webapp obtains an HttpOnly same-origin cookie through
+	// GET /v1/auth/handshake so EventSource can authenticate too.
+	LocalDaemonToken string
 
 	// Notifier overrides the default notification dispatcher (log +
 	// terminal multi). Production wiring leaves this nil; tests inject
@@ -407,6 +414,7 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 		grantCapabilityKey: grantCapabilityKey,
 		openAIProxy:        openAIProxy,
 		anthropicProxy:     anthropicProxy,
+		localDaemonToken:   cfg.LocalDaemonToken,
 		newID:              idGen,
 		actions:            action.NewStore(action.DefaultDir()),
 		actionState:        newActionStateStore(log),
@@ -589,6 +597,7 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	if teeCfg.TEEEnabled() {
 		server.teeState = newTeeState()
 	}
+	mux.HandleFunc("GET /v1/auth/handshake", server.handleLocalAuthHandshake)
 	api.HandlerFromMux(server, mux)
 
 	// Source connector tools API (read-only context retrieval).
@@ -646,6 +655,7 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 
 	// Middleware chain: CORS -> request ID -> logging -> [auth] -> routes.
 	var handler http.Handler = mux
+	handler = localDaemonAuthMiddleware(cfg.LocalDaemonToken, handler)
 
 	if authCfg.AuthEnabled() {
 		db, err := postgres.NewDB(ctx, authCfg.DatabaseURL)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -144,6 +144,45 @@ func TestNewHandler_LocalDaemonHandshakeSetsCookie(t *testing.T) {
 	}
 }
 
+func TestNewHandler_LocalDaemonHandshakeDisabled(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	handler, err := NewHandlerWithConfig(log, Config{Vault: vault.NewMemVault()})
+	if err != nil {
+		t.Fatalf("NewHandlerWithConfig: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/auth/handshake", nil)
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("handshake status = %d, want 204", rr.Code)
+	}
+	if got := rr.Result().Cookies(); len(got) != 0 {
+		t.Fatalf("cookies = %#v, want none", got)
+	}
+}
+
+func TestNewHandler_LocalDaemonHandshakeRejectsAbsoluteHostMismatch(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	handler, err := NewHandlerWithConfig(log, Config{
+		Vault:            vault.NewMemVault(),
+		LocalDaemonToken: "tok_cookie",
+	})
+	if err != nil {
+		t.Fatalf("NewHandlerWithConfig: %v", err)
+	}
+
+	rr := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "http://daemon.test/v1/auth/handshake", nil)
+	req.Host = "other.test"
+	handler.ServeHTTP(rr, req)
+
+	if rr.Code != http.StatusForbidden {
+		t.Fatalf("handshake status = %d, want 403", rr.Code)
+	}
+}
+
 func TestNewHandler_CreateIntentAndPolicyEvaluation(t *testing.T) {
 	handler := newTestHandler(t)
 	srv := httptest.NewServer(handler)

--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -61,6 +61,89 @@ func TestNewHandler_HealthEndpoint(t *testing.T) {
 	}
 }
 
+func TestNewHandler_LocalDaemonTokenProtectsV1(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	handler, err := NewHandlerWithConfig(log, Config{
+		Vault:            vault.NewMemVault(),
+		LocalDaemonToken: "tok_test",
+	})
+	if err != nil {
+		t.Fatalf("NewHandlerWithConfig: %v", err)
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	resp, err := http.Get(srv.URL + "/v1/status")
+	if err != nil {
+		t.Fatalf("GET /v1/status: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusUnauthorized {
+		t.Fatalf("status without token = %d, want 401", resp.StatusCode)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.Header.Set("Authorization", "Bearer tok_test")
+	resp, err = http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET /v1/status with token: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status with token = %d, want 200", resp.StatusCode)
+	}
+}
+
+func TestNewHandler_LocalDaemonHandshakeSetsCookie(t *testing.T) {
+	log := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	handler, err := NewHandlerWithConfig(log, Config{
+		Vault:            vault.NewMemVault(),
+		LocalDaemonToken: "tok_cookie",
+	})
+	if err != nil {
+		t.Fatalf("NewHandlerWithConfig: %v", err)
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	client := &http.Client{}
+	resp, err := client.Get(srv.URL + "/v1/auth/handshake")
+	if err != nil {
+		t.Fatalf("GET /v1/auth/handshake: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("handshake status = %d, want 200", resp.StatusCode)
+	}
+	var cookie *http.Cookie
+	for _, c := range resp.Cookies() {
+		if c.Name == localDaemonTokenCookie {
+			cookie = c
+			break
+		}
+	}
+	if cookie == nil || cookie.Value != "tok_cookie" {
+		t.Fatalf("daemon token cookie = %#v, want tok_cookie", cookie)
+	}
+
+	req, err := http.NewRequest(http.MethodGet, srv.URL+"/v1/status", nil)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req.AddCookie(cookie)
+	resp, err = client.Do(req)
+	if err != nil {
+		t.Fatalf("GET /v1/status with cookie: %v", err)
+	}
+	_ = resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status with cookie = %d, want 200", resp.StatusCode)
+	}
+}
+
 func TestNewHandler_CreateIntentAndPolicyEvaluation(t *testing.T) {
 	handler := newTestHandler(t)
 	srv := httptest.NewServer(handler)

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -13,23 +13,23 @@ import (
 	"github.com/ALRubinger/aileron/internal/account"
 	"github.com/ALRubinger/aileron/internal/action"
 	api "github.com/ALRubinger/aileron/internal/api/gen"
-	"github.com/ALRubinger/aileron/internal/cstore"
-	"github.com/ALRubinger/aileron/internal/sandbox"
 	"github.com/ALRubinger/aileron/internal/approval"
 	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/auth"
 	"github.com/ALRubinger/aileron/internal/binding"
 	"github.com/ALRubinger/aileron/internal/comms"
-	"github.com/ALRubinger/aileron/internal/hub"
 	"github.com/ALRubinger/aileron/internal/config"
 	connectorpkg "github.com/ALRubinger/aileron/internal/connector"
 	"github.com/ALRubinger/aileron/internal/crypto"
+	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/draft"
 	"github.com/ALRubinger/aileron/internal/enclave"
 	"github.com/ALRubinger/aileron/internal/failure"
+	"github.com/ALRubinger/aileron/internal/hub"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/notify"
 	"github.com/ALRubinger/aileron/internal/policy"
+	"github.com/ALRubinger/aileron/internal/sandbox"
 	"github.com/ALRubinger/aileron/internal/sessions"
 	"github.com/ALRubinger/aileron/internal/source"
 	"github.com/ALRubinger/aileron/internal/store"
@@ -88,29 +88,30 @@ type apiServer struct {
 	localVaultMu       sync.Mutex                  // serializes /v1/vault/unlock so concurrent submits don't both call vault.Unlock
 	vaultUnlockedCh    chan struct{}               // closed on the first successful unlock; nil when daemon started already-unlocked. Used by respawned approval executors to park until the user unlocks the vault (#649).
 	newID              func() string
-	actions            *action.Store     // installed actions in ~/.aileron/actions/ (ADR-0003)
-	actionState        action.StateStore // per-action user preferences (enabled/disabled overlay); nil means defaults apply
-	executor           action.Executor   // synchronous action executor used by /v1/actions/{name}/run; nil falls back to stub
-	installer          *cstore.Installer    // connector install pipeline (ADR-0004); nil disables /v1/connectors/install
-	versionLister      cstore.VersionLister // connector version source query (ADR-0004); nil falls back to cstore.DefaultVersionLister inside the check handler
-	sandboxRuntime     sandbox.Runtime   // WASM runtime for connector execution (ADR-0005); nil falls back to stub executor
+	actions            *action.Store                 // installed actions in ~/.aileron/actions/ (ADR-0003)
+	actionState        action.StateStore             // per-action user preferences (enabled/disabled overlay); nil means defaults apply
+	executor           action.Executor               // synchronous action executor used by /v1/actions/{name}/run; nil falls back to stub
+	installer          *cstore.Installer             // connector install pipeline (ADR-0004); nil disables /v1/connectors/install
+	versionLister      cstore.VersionLister          // connector version source query (ADR-0004); nil falls back to cstore.DefaultVersionLister inside the check handler
+	sandboxRuntime     sandbox.Runtime               // WASM runtime for connector execution (ADR-0005); nil falls back to stub executor
 	actionApprovals    *approval.ActionApprovalQueue // pending action-level approvals (manifest [approval] required = true); RunAction blocks on Decide
 	sessions           sessions.Store                // ADR-0012: persistent launch-session records; nil → /v1/sessions endpoints return 503
 	webappURL          string                        // base URL the webapp is served at; surfaces in /v1/status (#364) and the approval-notification ReviewURL
+	localDaemonToken   string                        // local-daemon bearer token; empty disables local bearer auth
 	actionApprovalTTL  time.Duration                 // how long RunAction holds the response open before timing out; default 5m, configurable for tests
-	bindings           binding.Store     // capability bindings (ADR-0006); nil when no vault is wired
-	oauth2Sessions     *oauth2Sessions   // ADR-0006 server-driven OAuth dance state; lazy-initialized on first use
-	oauth2HTTPClient   *http.Client      // for OAuth token exchanges; nil → http.DefaultClient
+	bindings           binding.Store                 // capability bindings (ADR-0006); nil when no vault is wired
+	oauth2Sessions     *oauth2Sessions               // ADR-0006 server-driven OAuth dance state; lazy-initialized on first use
+	oauth2HTTPClient   *http.Client                  // for OAuth token exchanges; nil → http.DefaultClient
 
 	// --- Hub (ADR-0013, #486, #487) ---
-	hub          *hub.Client // connector-discovery Hub client; nil disables /v1/hub/* endpoints
-	keyringPath  string      // path to ~/.aileron/keyring.json for install-decision trust state; "" falls back to cstore.DefaultKeyringPath()
+	hub         *hub.Client // connector-discovery Hub client; nil disables /v1/hub/* endpoints
+	keyringPath string      // path to ~/.aileron/keyring.json for install-decision trust state; "" falls back to cstore.DefaultKeyringPath()
 
 	// --- Comms (ADR-0012 step 9B-2) ---
-	notifyQueue   *comms.NotifyQueue        // daemon-wide inbound messages; nil disables /comms/* endpoints
-	listeners     *comms.ListenerRegistry   // registered channel listeners; populated by the vault-unlock callback
-	onVaultUnlock func(vault.Vault)         // fires after POST /v1/vault/unlock so listener startup can resolve tokens
-	auditStateDir string                    // scopes message-event audit log writes; "" disables audit emission for /comms/*
+	notifyQueue     *comms.NotifyQueue      // daemon-wide inbound messages; nil disables /comms/* endpoints
+	listeners       *comms.ListenerRegistry // registered channel listeners; populated by the vault-unlock callback
+	onVaultUnlock   func(vault.Vault)       // fires after POST /v1/vault/unlock so listener startup can resolve tokens
+	auditStateDir   string                  // scopes message-event audit log writes; "" disables audit emission for /comms/*
 	commsHTTPClient *http.Client            // outbound client for /comms/http; nil falls back to http.DefaultClient
 }
 
@@ -178,6 +179,31 @@ func (s *apiServer) GetHealth(w http.ResponseWriter, r *http.Request) {
 		Version:   version.Version,
 		Timestamp: time.Now().UTC(),
 	})
+}
+
+func (s *apiServer) handleLocalAuthHandshake(w http.ResponseWriter, r *http.Request) {
+	if s.localDaemonToken == "" {
+		w.WriteHeader(http.StatusNoContent)
+		return
+	}
+	if r.Host == "" || r.Host != r.URL.Host {
+		// For ordinary origin-form browser requests r.URL.Host is empty;
+		// reconstruct the effective request origin from Host. The
+		// explicit comparison below is only meaningful for absolute-form
+		// requests, which local browsers should not send.
+		if r.URL.Host != "" {
+			writeError(w, http.StatusForbidden, "host_mismatch", "request host does not match daemon origin")
+			return
+		}
+	}
+	http.SetCookie(w, &http.Cookie{
+		Name:     localDaemonTokenCookie,
+		Value:    s.localDaemonToken,
+		Path:     "/v1",
+		HttpOnly: true,
+		SameSite: http.SameSiteStrictMode,
+	})
+	writeJSON(w, http.StatusOK, map[string]bool{"ok": true})
 }
 
 // --- Intents ---
@@ -1725,7 +1751,6 @@ func buildPendingApprovalResponse(approvalID, actionName, connFQN, reviewURL str
 		Message:    msg,
 	}
 }
-
 
 func manifestToAPI(la action.LoadedAction, enabled bool) api.Action {
 	m := la.Manifest

--- a/internal/app/middleware.go
+++ b/internal/app/middleware.go
@@ -3,9 +3,11 @@ package app
 import (
 	"context"
 	"crypto/rand"
+	"crypto/subtle"
 	"encoding/hex"
 	"log/slog"
 	"net/http"
+	"strings"
 	"time"
 )
 
@@ -102,6 +104,53 @@ func corsMiddleware(next http.Handler) http.Handler {
 		}
 		next.ServeHTTP(w, r)
 	})
+}
+
+const localDaemonTokenCookie = "aileron_daemon_token"
+
+// localDaemonAuthMiddleware protects the local daemon's /v1/* surface
+// with the token advertised in daemon.json. CLI/shim clients send it as
+// Authorization: Bearer <token>; the same-origin webapp gets a cookie
+// through /v1/auth/handshake so browser EventSource can authenticate.
+func localDaemonAuthMiddleware(token string, next http.Handler) http.Handler {
+	if token == "" {
+		return next
+	}
+	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodOptions || !strings.HasPrefix(r.URL.Path, "/v1/") || localDaemonAuthSkip(r.URL.Path) {
+			next.ServeHTTP(w, r)
+			return
+		}
+		got := bearerToken(r)
+		if got == "" {
+			if c, err := r.Cookie(localDaemonTokenCookie); err == nil {
+				got = c.Value
+			}
+		}
+		if subtle.ConstantTimeCompare([]byte(got), []byte(token)) != 1 {
+			writeError(w, http.StatusUnauthorized, "unauthorized", "missing or invalid daemon token")
+			return
+		}
+		next.ServeHTTP(w, r)
+	})
+}
+
+func localDaemonAuthSkip(path string) bool {
+	switch path {
+	case "/v1/health", "/v1/auth/handshake":
+		return true
+	default:
+		return false
+	}
+}
+
+func bearerToken(r *http.Request) string {
+	const prefix = "Bearer "
+	h := r.Header.Get("Authorization")
+	if !strings.HasPrefix(h, prefix) {
+		return ""
+	}
+	return strings.TrimSpace(strings.TrimPrefix(h, prefix))
 }
 
 func generateID() string {

--- a/internal/daemon/discovery/discovery.go
+++ b/internal/daemon/discovery/discovery.go
@@ -44,6 +44,7 @@ type Info struct {
 	PID       int       `json:"pid"`
 	Version   string    `json:"version"`
 	StartedAt time.Time `json:"started_at"`
+	Token     string    `json:"token,omitempty"`
 }
 
 // ErrNotRunning is returned by Read when daemon.json does not exist.

--- a/internal/daemon/discovery/discovery_test.go
+++ b/internal/daemon/discovery/discovery_test.go
@@ -22,6 +22,7 @@ func TestWriteReadRoundTrip(t *testing.T) {
 		PID:       12345,
 		Version:   "0.0.7-dev+abc123",
 		StartedAt: time.Now().UTC().Truncate(time.Second),
+		Token:     "tok_test",
 	}
 	if err := discovery.Write(dir, want); err != nil {
 		t.Fatalf("Write: %v", err)
@@ -31,7 +32,7 @@ func TestWriteReadRoundTrip(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Read: %v", err)
 	}
-	if got.URL != want.URL || got.PID != want.PID || got.Version != want.Version {
+	if got.URL != want.URL || got.PID != want.PID || got.Version != want.Version || got.Token != want.Token {
 		t.Fatalf("round-trip mismatch:\n got=%+v\nwant=%+v", got, want)
 	}
 	if !got.StartedAt.Equal(want.StartedAt) {
@@ -285,5 +286,3 @@ func TestWriteFailsWhenStateDirIsFile(t *testing.T) {
 		t.Fatal("Write should fail when stateDir is a regular file")
 	}
 }
-
-

--- a/internal/launch/daemon_client.go
+++ b/internal/launch/daemon_client.go
@@ -22,15 +22,21 @@ const daemonHTTPTimeout = 5 * time.Second
 // one per Launch invocation.
 type daemonClient struct {
 	baseURL string
+	token   string
 	client  *http.Client
 }
 
 // newDaemonClient wraps the daemon's URL (e.g. "http://127.0.0.1:54321")
 // in a thin HTTP client. baseURL has any trailing slash trimmed and
 // is treated as the root the /v1 paths attach to.
-func newDaemonClient(baseURL string) *daemonClient {
+func newDaemonClient(baseURL string, token ...string) *daemonClient {
+	var tok string
+	if len(token) > 0 {
+		tok = token[0]
+	}
 	return &daemonClient{
 		baseURL: trimTrailingSlash(baseURL),
+		token:   tok,
 		client:  &http.Client{Timeout: daemonHTTPTimeout},
 	}
 }
@@ -51,6 +57,7 @@ func (c *daemonClient) RegisterSession(ctx context.Context, agent, workingDir st
 		return "", err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	c.authorize(req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return "", fmt.Errorf("post /v1/sessions: %w", err)
@@ -86,6 +93,7 @@ func (c *daemonClient) EndSession(ctx context.Context, sessionID string, exitCod
 		return err
 	}
 	req.Header.Set("Content-Type", "application/json")
+	c.authorize(req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return fmt.Errorf("post end-session: %w", err)
@@ -107,6 +115,7 @@ func (c *daemonClient) LocalVaultLocked(ctx context.Context) (locked bool, ok bo
 	if err != nil {
 		return false, false
 	}
+	c.authorize(req)
 	resp, err := c.client.Do(req)
 	if err != nil {
 		return false, false
@@ -122,6 +131,12 @@ func (c *daemonClient) LocalVaultLocked(ctx context.Context) (locked bool, ok bo
 		return false, false
 	}
 	return body.Locked, true
+}
+
+func (c *daemonClient) authorize(req *http.Request) {
+	if c.token != "" {
+		req.Header.Set("Authorization", "Bearer "+c.token)
+	}
 }
 
 // httpStatusError reads the response body and returns a human-friendly
@@ -150,4 +165,3 @@ func trimTrailingSlash(u string) string {
 	}
 	return u
 }
-

--- a/internal/launch/daemon_client_test.go
+++ b/internal/launch/daemon_client_test.go
@@ -43,6 +43,23 @@ func TestDaemonClient_RegisterSession_Success(t *testing.T) {
 	}
 }
 
+func TestDaemonClient_SendsBearerToken(t *testing.T) {
+	seen := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(map[string]any{"id": "01HK00000000000000000XYZAB"})
+	}))
+	defer srv.Close()
+
+	c := newDaemonClient(srv.URL, "tok_launch")
+	if _, err := c.RegisterSession(context.Background(), "claude", "/work"); err != nil {
+		t.Fatalf("RegisterSession: %v", err)
+	}
+	if got := <-seen; got != "Bearer tok_launch" {
+		t.Fatalf("Authorization = %q, want bearer token", got)
+	}
+}
+
 func TestDaemonClient_RegisterSession_NonOK_ReturnsStatusError(t *testing.T) {
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusServiceUnavailable)
@@ -205,13 +222,13 @@ func TestDaemonClient_LocalVaultLocked_GarbageBodyReturnsNotOK(t *testing.T) {
 
 func TestTrimTrailingSlash(t *testing.T) {
 	cases := map[string]string{
-		"":                     "",
-		"http://x":             "http://x",
-		"http://x/":            "http://x",
-		"http://x///":          "http://x",
-		"/":                    "/", // single-char "/" is preserved
-		"/v1":                  "/v1",
-		"/v1/":                 "/v1",
+		"":            "",
+		"http://x":    "http://x",
+		"http://x/":   "http://x",
+		"http://x///": "http://x",
+		"/":           "/", // single-char "/" is preserved
+		"/v1":         "/v1",
+		"/v1/":        "/v1",
 	}
 	for in, want := range cases {
 		if got := trimTrailingSlash(in); got != want {

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -12,6 +12,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/daemon/spawn"
 )
 
@@ -120,7 +121,14 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		return LaunchResult{}, fmt.Errorf("daemon: %w", err)
 	}
 	daemonURL = trimTrailingSlash(daemonURL)
-	client := newDaemonClient(daemonURL)
+	var daemonToken string
+	if info, err := discovery.Read(stateDir); err == nil && trimTrailingSlash(info.URL) == daemonURL {
+		daemonToken = info.Token
+	}
+	if daemonToken == "" {
+		daemonToken = os.Getenv("AILERON_TOKEN")
+	}
+	client := newDaemonClient(daemonURL, daemonToken)
 
 	agentPath, err := ResolveBinary(config.Agent.BinaryNames())
 	if err != nil {

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -9,6 +9,8 @@ package main
 
 import (
 	"context"
+	"crypto/rand"
+	"encoding/hex"
 	"errors"
 	"flag"
 	"fmt"
@@ -25,11 +27,11 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/app"
 	"github.com/ALRubinger/aileron/internal/approval"
+	approvaljsonl "github.com/ALRubinger/aileron/internal/approval/jsonl"
 	"github.com/ALRubinger/aileron/internal/comms"
 	"github.com/ALRubinger/aileron/internal/config"
 	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/launch"
-	approvaljsonl "github.com/ALRubinger/aileron/internal/approval/jsonl"
 	"github.com/ALRubinger/aileron/internal/sessions/jsonl"
 	"github.com/ALRubinger/aileron/internal/vault"
 	"github.com/ALRubinger/aileron/internal/version"
@@ -96,6 +98,14 @@ func parseLogLevel(env string) slog.Level {
 	default:
 		return slog.LevelInfo
 	}
+}
+
+func generateDaemonToken() (string, error) {
+	var b [32]byte
+	if _, err := rand.Read(b[:]); err != nil {
+		return "", err
+	}
+	return hex.EncodeToString(b[:]), nil
 }
 
 // options holds the inputs run needs. Extracted so tests can construct
@@ -312,6 +322,12 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 	}
 
 	url := "http://" + listener.Addr().String()
+	daemonToken, err := generateDaemonToken()
+	if err != nil {
+		_ = listener.Close()
+		return fmt.Errorf("generate daemon token: %w", err)
+	}
+	cfg.LocalDaemonToken = daemonToken
 
 	// The daemon serves the webapp itself (see internal/app/webapp_embed.go),
 	// so its own bound URL is the right default for the approval review URL
@@ -329,6 +345,7 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 		PID:       os.Getpid(),
 		Version:   version.Version,
 		StartedAt: time.Now().UTC(),
+		Token:     daemonToken,
 	}
 	if err := discovery.Write(opts.StateDir, info); err != nil {
 		_ = listener.Close()

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -108,6 +108,18 @@ func generateDaemonToken() (string, error) {
 	return hex.EncodeToString(b[:]), nil
 }
 
+func shouldProtectLocalDaemon(addr net.Addr) bool {
+	host, _, err := net.SplitHostPort(addr.String())
+	if err != nil {
+		return false
+	}
+	if host == "localhost" {
+		return true
+	}
+	ip := net.ParseIP(host)
+	return ip != nil && ip.IsLoopback()
+}
+
 // options holds the inputs run needs. Extracted so tests can construct
 // it with a t.TempDir()-scoped state directory.
 type options struct {
@@ -322,12 +334,15 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 	}
 
 	url := "http://" + listener.Addr().String()
-	daemonToken, err := generateDaemonToken()
-	if err != nil {
-		_ = listener.Close()
-		return fmt.Errorf("generate daemon token: %w", err)
+	var daemonToken string
+	if shouldProtectLocalDaemon(listener.Addr()) {
+		daemonToken, err = generateDaemonToken()
+		if err != nil {
+			_ = listener.Close()
+			return fmt.Errorf("generate daemon token: %w", err)
+		}
+		cfg.LocalDaemonToken = daemonToken
 	}
-	cfg.LocalDaemonToken = daemonToken
 
 	// The daemon serves the webapp itself (see internal/app/webapp_embed.go),
 	// so its own bound URL is the right default for the approval review URL

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -6,6 +6,7 @@ import (
 	"errors"
 	"io"
 	"log/slog"
+	"net"
 	"net/http"
 	"os"
 	"path/filepath"
@@ -124,6 +125,57 @@ func TestSelectVault_CorruptFileFailsStartup(t *testing.T) {
 	if err == nil {
 		t.Fatal("selectVault: expected error for corrupt vault file, got nil")
 	}
+}
+
+func TestShouldProtectLocalDaemon(t *testing.T) {
+	cases := []struct {
+		addr string
+		want bool
+	}{
+		{addr: "127.0.0.1:8721", want: true},
+		{addr: "[::1]:8721", want: true},
+		{addr: "localhost:8721", want: true},
+		{addr: "0.0.0.0:8080", want: false},
+		{addr: "[::]:8080", want: false},
+		{addr: "10.0.0.5:8080", want: false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.addr, func(t *testing.T) {
+			got := shouldProtectLocalDaemon(&net.TCPAddr{IP: parseTestIP(t, tc.addr), Port: parseTestPort(t, tc.addr)})
+			if strings.HasPrefix(tc.addr, "localhost:") {
+				got = shouldProtectLocalDaemon(stringAddr(tc.addr))
+			}
+			if got != tc.want {
+				t.Fatalf("shouldProtectLocalDaemon(%q) = %v, want %v", tc.addr, got, tc.want)
+			}
+		})
+	}
+}
+
+type stringAddr string
+
+func (a stringAddr) Network() string { return "tcp" }
+func (a stringAddr) String() string  { return string(a) }
+
+func parseTestIP(t *testing.T, addr string) net.IP {
+	t.Helper()
+	host, _, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	return net.ParseIP(host)
+}
+
+func parseTestPort(t *testing.T, addr string) int {
+	t.Helper()
+	_, port, err := net.SplitHostPort(addr)
+	if err != nil {
+		t.Fatalf("SplitHostPort(%q): %v", addr, err)
+	}
+	if port == "8721" {
+		return 8721
+	}
+	return 8080
 }
 
 // seedVault creates a passphrase-protected vault file at path, so the

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -176,10 +176,7 @@ func TestRun_NoTTYDaemonHonorsVaultUnlock(t *testing.T) {
 
 	// Pre-unlock the vault should report locked. (Empty cfg.Vault +
 	// LocalVaultPath set → LockableVault wrap → vaultLocked = true.)
-	statusResp, err := http.Get(info.URL + "/v1/vault/status")
-	if err != nil {
-		t.Fatalf("GET /v1/vault/status: %v", err)
-	}
+	statusResp := doDaemonRequest(t, http.MethodGet, info.URL+"/v1/vault/status", info.Token, "")
 	defer statusResp.Body.Close()
 	statusBody, _ := io.ReadAll(statusResp.Body)
 	if !strings.Contains(string(statusBody), `"locked":true`) {
@@ -187,11 +184,7 @@ func TestRun_NoTTYDaemonHonorsVaultUnlock(t *testing.T) {
 	}
 
 	// Drive the unlock with the right passphrase.
-	unlockBody := strings.NewReader(`{"passphrase":"` + passphrase + `"}`)
-	unlockResp, err := http.Post(info.URL+"/v1/vault/unlock", "application/json", unlockBody)
-	if err != nil {
-		t.Fatalf("POST /v1/vault/unlock: %v", err)
-	}
+	unlockResp := doDaemonRequest(t, http.MethodPost, info.URL+"/v1/vault/unlock", info.Token, `{"passphrase":"`+passphrase+`"}`)
 	defer unlockResp.Body.Close()
 	if unlockResp.StatusCode != http.StatusOK {
 		body, _ := io.ReadAll(unlockResp.Body)
@@ -199,10 +192,7 @@ func TestRun_NoTTYDaemonHonorsVaultUnlock(t *testing.T) {
 	}
 
 	// Status after unlock: locked:false.
-	statusResp2, err := http.Get(info.URL + "/v1/vault/status")
-	if err != nil {
-		t.Fatalf("GET /v1/vault/status (post-unlock): %v", err)
-	}
+	statusResp2 := doDaemonRequest(t, http.MethodGet, info.URL+"/v1/vault/status", info.Token, "")
 	defer statusResp2.Body.Close()
 	statusBody2, _ := io.ReadAll(statusResp2.Body)
 	if !strings.Contains(string(statusBody2), `"locked":false`) {
@@ -237,11 +227,7 @@ func TestRun_NoTTYDaemonRejectsWrongPassphrase(t *testing.T) {
 	go func() { runErr <- run(ctx, log, opts) }()
 	info := waitForDaemon(t, stateDir, 3*time.Second)
 
-	resp, err := http.Post(info.URL+"/v1/vault/unlock", "application/json",
-		strings.NewReader(`{"passphrase":"wrong"}`))
-	if err != nil {
-		t.Fatalf("POST /v1/vault/unlock: %v", err)
-	}
+	resp := doDaemonRequest(t, http.MethodPost, info.URL+"/v1/vault/unlock", info.Token, `{"passphrase":"wrong"}`)
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusUnauthorized {
 		t.Errorf("status = %d, want 401 for wrong passphrase", resp.StatusCode)
@@ -288,10 +274,7 @@ func TestRun_PublishesDiscoveryAndCleansUp(t *testing.T) {
 	}
 
 	// URL is reachable: GET an endpoint that exists without auth setup.
-	resp, err := http.Get(info.URL + "/v1/vault/status")
-	if err != nil {
-		t.Fatalf("GET %s: %v", info.URL, err)
-	}
+	resp := doDaemonRequest(t, http.MethodGet, info.URL+"/v1/vault/status", info.Token, "")
 	resp.Body.Close()
 	if resp.StatusCode == http.StatusInternalServerError {
 		t.Errorf("status = %d, expected non-5xx from a wired daemon", resp.StatusCode)
@@ -349,7 +332,7 @@ func TestRun_WebappURL_DefaultsToBoundURL(t *testing.T) {
 
 	info := waitForDaemon(t, stateDir, 3*time.Second)
 
-	got := fetchStatusGatewayURL(t, info.URL)
+	got := fetchStatusGatewayURL(t, info.URL, info.Token)
 	if got != info.URL {
 		t.Errorf("gateway_url = %q, want %q (the daemon's own bound URL)", got, info.URL)
 	}
@@ -386,7 +369,7 @@ func TestRun_WebappURL_EnvOverrides(t *testing.T) {
 
 	info := waitForDaemon(t, stateDir, 3*time.Second)
 
-	got := fetchStatusGatewayURL(t, info.URL)
+	got := fetchStatusGatewayURL(t, info.URL, info.Token)
 	if got != override {
 		t.Errorf("gateway_url = %q, want %q (env override wins over bound URL)", got, override)
 	}
@@ -398,12 +381,9 @@ func TestRun_WebappURL_EnvOverrides(t *testing.T) {
 // fetchStatusGatewayURL hits the daemon's `/v1/status` endpoint and
 // returns the `gateway_url` field (which surfaces `s.webappURL` per
 // handlers_status.go). Empty string when the field is absent.
-func fetchStatusGatewayURL(t *testing.T, daemonURL string) string {
+func fetchStatusGatewayURL(t *testing.T, daemonURL, token string) string {
 	t.Helper()
-	resp, err := http.Get(daemonURL + "/v1/status")
-	if err != nil {
-		t.Fatalf("GET /v1/status: %v", err)
-	}
+	resp := doDaemonRequest(t, http.MethodGet, daemonURL+"/v1/status", token, "")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("GET /v1/status status = %d, want 200", resp.StatusCode)
@@ -415,6 +395,29 @@ func fetchStatusGatewayURL(t *testing.T, daemonURL string) string {
 		t.Fatalf("decode status: %v", err)
 	}
 	return body.GatewayURL
+}
+
+func doDaemonRequest(t *testing.T, method, url, token, body string) *http.Response {
+	t.Helper()
+	var reader io.Reader
+	if body != "" {
+		reader = strings.NewReader(body)
+	}
+	req, err := http.NewRequest(method, url, reader)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	if body != "" {
+		req.Header.Set("Content-Type", "application/json")
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("%s %s: %v", method, url, err)
+	}
+	return resp
 }
 
 // TestRun_RefusesWhenAnotherDaemonHoldsLock asserts the singleton
@@ -931,10 +934,7 @@ func TestRun_SeedApprovals_PopulatesQueue(t *testing.T) {
 		}
 	}()
 
-	resp, err := http.Get(info.URL + "/v1/action-approvals")
-	if err != nil {
-		t.Fatalf("GET /v1/action-approvals: %v", err)
-	}
+	resp := doDaemonRequest(t, http.MethodGet, info.URL+"/v1/action-approvals", info.Token, "")
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status = %d, want 200", resp.StatusCode)

--- a/webapp/e2e-integration/approvals-lifecycle.spec.ts
+++ b/webapp/e2e-integration/approvals-lifecycle.spec.ts
@@ -96,7 +96,6 @@ function firstCardByKind(page: Page, kind: string) {
 }
 
 async function fetchPendingIds(page: Page): Promise<string[]> {
-	await ensureDaemonAuth(page);
 	const resp = await page.request.get('/v1/action-approvals');
 	expect(resp.ok()).toBe(true);
 	const body = (await resp.json()) as {
@@ -109,13 +108,7 @@ async function fetchResult(
 	page: Page,
 	id: string
 ): Promise<{ status: string; reason?: string }> {
-	await ensureDaemonAuth(page);
 	const resp = await page.request.get(`/v1/action-approvals/${id}/result`);
 	expect(resp.ok()).toBe(true);
 	return resp.json();
-}
-
-async function ensureDaemonAuth(page: Page): Promise<void> {
-	const resp = await page.request.get('/v1/auth/handshake');
-	expect([200, 204]).toContain(resp.status());
 }

--- a/webapp/e2e-integration/approvals-lifecycle.spec.ts
+++ b/webapp/e2e-integration/approvals-lifecycle.spec.ts
@@ -96,6 +96,7 @@ function firstCardByKind(page: Page, kind: string) {
 }
 
 async function fetchPendingIds(page: Page): Promise<string[]> {
+	await ensureDaemonAuth(page);
 	const resp = await page.request.get('/v1/action-approvals');
 	expect(resp.ok()).toBe(true);
 	const body = (await resp.json()) as {
@@ -108,7 +109,13 @@ async function fetchResult(
 	page: Page,
 	id: string
 ): Promise<{ status: string; reason?: string }> {
+	await ensureDaemonAuth(page);
 	const resp = await page.request.get(`/v1/action-approvals/${id}/result`);
 	expect(resp.ok()).toBe(true);
 	return resp.json();
+}
+
+async function ensureDaemonAuth(page: Page): Promise<void> {
+	const resp = await page.request.get('/v1/auth/handshake');
+	expect([200, 204]).toContain(resp.status());
 }

--- a/webapp/e2e/fixtures/approvals.ts
+++ b/webapp/e2e/fixtures/approvals.ts
@@ -194,6 +194,13 @@ async function emit(page: Page, event: string, data: unknown): Promise<void> {
 }
 
 async function installDecideMock(page: Page, decides: DecideRecorder): Promise<void> {
+	// The local-daemon client performs a same-origin auth handshake before
+	// API fetches and EventSource setup. Mocked E2E does not run a daemon,
+	// so acknowledge the handshake without setting a cookie.
+	await page.route('**/v1/auth/handshake', async (route) => {
+		await route.fulfill({ status: 204 });
+	});
+
 	await page.route('**/v1/action-approvals/*/decide', async (route) => {
 		const req: Request = route.request();
 		const url = new URL(req.url());

--- a/webapp/scripts/run-integration-e2e.sh
+++ b/webapp/scripts/run-integration-e2e.sh
@@ -71,26 +71,29 @@ HOME="${TMP_HOME}" "${SERVER_BIN}" \
   >"${TMP_HOME}/server.log" 2>&1 &
 DAEMON_PID=$!
 
-# Poll daemon.json for up to 10s waiting for the URL to appear.
+# Poll daemon.json for up to 10s waiting for the URL and bearer token to appear.
 DAEMON_URL=""
+DAEMON_TOKEN=""
 for _ in $(seq 1 50); do
   if [[ -f "${TMP_HOME}/.aileron/daemon.json" ]]; then
     DAEMON_URL="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1]))["url"])' "${TMP_HOME}/.aileron/daemon.json" 2>/dev/null || true)"
-    if [[ -n "${DAEMON_URL}" ]]; then
+    DAEMON_TOKEN="$(python3 -c 'import json,sys; print(json.load(open(sys.argv[1])).get("token", ""))' "${TMP_HOME}/.aileron/daemon.json" 2>/dev/null || true)"
+    if [[ -n "${DAEMON_URL}" && -n "${DAEMON_TOKEN}" ]]; then
       break
     fi
   fi
   sleep 0.2
 done
-if [[ -z "${DAEMON_URL}" ]]; then
-  echo "error: daemon did not publish daemon.json within 10s" >&2
+if [[ -z "${DAEMON_URL}" || -z "${DAEMON_TOKEN}" ]]; then
+  echo "error: daemon did not publish daemon.json URL and token within 10s" >&2
   echo "--- daemon log ---" >&2
   cat "${TMP_HOME}/server.log" >&2 || true
   exit 1
 fi
 
 # Confirm reachability before handing off to Playwright.
-if ! curl -fsS "${DAEMON_URL}/v1/action-approvals" >/dev/null; then
+AUTH_HEADER="Authorization: Bearer ${DAEMON_TOKEN}"
+if ! curl -fsS -H "${AUTH_HEADER}" "${DAEMON_URL}/v1/action-approvals" >/dev/null; then
   echo "error: daemon at ${DAEMON_URL} not reachable" >&2
   echo "--- daemon log ---" >&2
   cat "${TMP_HOME}/server.log" >&2 || true
@@ -102,7 +105,7 @@ fi
 # intercepts clicks on the approval cards. The approvals endpoints
 # themselves don't read credentials, so this is purely a UI-layer
 # concern — but Playwright sees real DOM, so we have to clear it.
-if ! curl -fsS -X POST -H 'Content-Type: application/json' \
+if ! curl -fsS -X POST -H 'Content-Type: application/json' -H "${AUTH_HEADER}" \
   -d '{"passphrase":"test-passphrase"}' \
   "${DAEMON_URL}/v1/vault/unlock" >/dev/null; then
   echo "error: vault unlock failed" >&2

--- a/webapp/src/lib/api.ts
+++ b/webapp/src/lib/api.ts
@@ -1,12 +1,13 @@
 // Local-webapp API client.
 //
 // The daemon serves this webapp at the same origin it serves the
-// `/v1/*` API. No JWT, no token refresh — there's no multi-user auth
-// boundary on the local surface. The one cross-cutting concern is
-// vault-locked handling: under `aileron launch` the daemon may start
-// vault-locked and refuse vault-needing endpoints with 423; the
-// passphrase modal (#429) opens, the user unlocks, and the original
-// request is retried.
+// `/v1/*` API. The local daemon uses a single same-origin handshake to
+// set an HttpOnly daemon-token cookie; there is no multi-user login,
+// JWT refresh, or organization selector. The other cross-cutting
+// concern is vault-locked handling: under `aileron launch` the daemon
+// may start vault-locked and refuse vault-needing endpoints with 423;
+// the passphrase modal (#429) opens, the user unlocks, and the
+// original request is retried.
 //
 // See ../../../ui/src/lib/api.ts for the cloud-tier reference client
 // (frozen). The shape is deliberately pared-down here — only what
@@ -15,8 +16,21 @@
 import { onVaultLocked } from './vault.svelte';
 
 const API_BASE = '';
+let daemonHandshake: Promise<void> | null = null;
+
+async function ensureDaemonHandshake(): Promise<void> {
+	if (!daemonHandshake) {
+		daemonHandshake = fetch(`${API_BASE}/v1/auth/handshake`).then((res) => {
+			if (!res.ok && res.status !== 204) {
+				throw new Error(`daemon auth handshake: ${res.statusText}`);
+			}
+		});
+	}
+	return daemonHandshake;
+}
 
 async function apiFetch<T>(path: string, init?: RequestInit): Promise<T> {
+	await ensureDaemonHandshake();
 	const res = await fetch(`${API_BASE}${path}`, {
 		...init,
 		headers: {
@@ -51,6 +65,7 @@ export type LocalVaultStatus = {
  *  load so it can open the modal even if the user hasn't yet
  *  triggered a vault-needing call. */
 export async function getLocalVaultStatus(): Promise<LocalVaultStatus> {
+	await ensureDaemonHandshake();
 	const res = await fetch(`${API_BASE}/v1/vault/status`);
 	if (!res.ok) {
 		throw new Error(`vault status: ${res.statusText}`);
@@ -62,6 +77,7 @@ export async function getLocalVaultStatus(): Promise<LocalVaultStatus> {
  *  with a recognisable message on 401 (wrong passphrase) so the modal
  *  can keep the field open and let the user retry. */
 export async function unlockLocalVault(passphrase: string): Promise<LocalVaultStatus> {
+	await ensureDaemonHandshake();
 	const res = await fetch(`${API_BASE}/v1/vault/unlock`, {
 		method: 'POST',
 		headers: { 'Content-Type': 'application/json' },
@@ -187,40 +203,51 @@ export type ActionApprovalSubscriber = {
  *  expected to refetch via [listActionApprovals]. */
 export function watchActionApprovals(sub: ActionApprovalSubscriber): () => void {
 	const url = `${API_BASE}/v1/action-approvals/watch`;
-	const es = new EventSource(url);
+	let es: EventSource | null = null;
+	let closed = false;
 
-	es.addEventListener('snapshot', (e: MessageEvent) => {
-		try {
-			const payload = JSON.parse(e.data);
-			sub.onSnapshot(payload.items ?? []);
-		} catch (err) {
-			sub.onError?.(err);
-		}
-	});
-	es.addEventListener('pending', (e: MessageEvent) => {
-		try {
-			sub.onPending(JSON.parse(e.data));
-		} catch (err) {
-			sub.onError?.(err);
-		}
-	});
-	es.addEventListener('resolved', (e: MessageEvent) => {
-		try {
-			sub.onResolved(JSON.parse(e.data));
-		} catch (err) {
-			sub.onError?.(err);
-		}
-	});
-	es.addEventListener('error', (e) => {
-		// EventSource auto-reconnects on transient failure. We only
-		// surface the error once per disconnect — readyState === CLOSED
-		// means the browser gave up; CONNECTING means it'll retry.
-		if (es.readyState === EventSource.CLOSED) {
-			sub.onError?.(e);
-		}
-	});
+	void ensureDaemonHandshake()
+		.then(() => {
+			if (closed) return;
+			es = new EventSource(url);
 
-	return () => es.close();
+			es.addEventListener('snapshot', (e: MessageEvent) => {
+				try {
+					const payload = JSON.parse(e.data);
+					sub.onSnapshot(payload.items ?? []);
+				} catch (err) {
+					sub.onError?.(err);
+				}
+			});
+			es.addEventListener('pending', (e: MessageEvent) => {
+				try {
+					sub.onPending(JSON.parse(e.data));
+				} catch (err) {
+					sub.onError?.(err);
+				}
+			});
+			es.addEventListener('resolved', (e: MessageEvent) => {
+				try {
+					sub.onResolved(JSON.parse(e.data));
+				} catch (err) {
+					sub.onError?.(err);
+				}
+			});
+			es.addEventListener('error', (e) => {
+				// EventSource auto-reconnects on transient failure. We only
+				// surface the error once per disconnect — readyState === CLOSED
+				// means the browser gave up; CONNECTING means it'll retry.
+				if (es?.readyState === EventSource.CLOSED) {
+					sub.onError?.(e);
+				}
+			});
+		})
+		.catch((err) => sub.onError?.(err));
+
+	return () => {
+		closed = true;
+		es?.close();
+	};
 }
 
 /** Resolves a pending action-approval. The runtime's blocked


### PR DESCRIPTION
## Summary

Implements the first v4 Phase 1 bearer-auth slice for the local daemon. The daemon now mints a per-start token, publishes it in `daemon.json` for loopback binds, and requires daemon-token auth for local `/v1/*` routes except health and the local webapp handshake.

## What changed

- Add token support to daemon discovery info and mint it at daemon bind time for loopback/local daemon listeners.
- Protect local `/v1/*` requests with bearer or same-origin cookie auth.
- Add `/v1/auth/handshake` so the embedded webapp can authenticate browser fetches and EventSource.
- Teach CLI, launch daemon clients, integration setup, and webapp tests to send or mock the daemon auth path.
- Keep container/non-loopback binds unprotected so full-stack container E2E and remote runtime models are not forced through local-daemon auth.
- Update server, app, CLI, launch, discovery, and webapp tests around the protected local daemon surface.

## Validation

- `go test ./cmd/aileron ./internal/app ./internal/server`
- `go test -coverprofile=/tmp/aileron-cover.out ./cmd/aileron ./internal/app ./internal/server ./internal/launch ./internal/daemon/discovery`
- `pnpm run check` in `webapp`
- `pnpm test:e2e` in `webapp`
- `webapp/scripts/run-integration-e2e.sh`
- `git diff --check`
- GitHub Actions: full PR suite green on PR #862

## Notes

Root `go test ./...` is not valid with this `go.work` layout, so Go all-package validation was run per relevant module/package set.
