### PR TITLE
[codex] Expose sandbox image build command

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -188,7 +188,7 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron sync [--bind-all] [--yes]  Reconcile installed actions: install missing connectors; report unbound capabilities")
 	fmt.Fprintln(w, "  aileron audit [list|show]          View the action-execution audit log (ADR-0010)")
 	fmt.Fprintln(w, "  aileron sessions [list|get]        View `aileron launch` session records (ADR-0012)")
-	fmt.Fprintln(w, "  aileron sandbox [init|plan]        Scaffold or inspect sandbox composition")
+	fmt.Fprintln(w, "  aileron sandbox [init|plan|build]  Scaffold, inspect, or build sandbox images")
 	fmt.Fprintln(w, "  aileron daemon start|stop|status   Manage the local Aileron daemon (auto-spawned on demand)")
 	fmt.Fprintln(w, "  aileron stop                       Alias for 'aileron daemon stop'")
 	fmt.Fprintln(w, "  aileron open [approvals|approval <id>]  Open the Aileron webapp (default: root) in your browser")

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/launch/agents"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 )
 
 // init bypasses the CLI vault state machine for the bulk of tests.
@@ -260,6 +261,179 @@ func TestRunSandboxPlanRejectsExtraArgs(t *testing.T) {
 		t.Fatalf("expected exit code 1, got %d", code)
 	}
 	if !strings.Contains(stderr.String(), "usage: aileron sandbox plan") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunSandboxBuildRejectsExtraArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sandbox", "build", "extra"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "usage: aileron sandbox build") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunSandboxBuildRejectsInvalidFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sandbox", "build", "--bogus"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "flag provided but not defined") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunSandboxBuildReportsComplete(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	origBuild := sandboxBuildFn
+	t.Cleanup(func() { sandboxBuildFn = origBuild })
+	sandboxBuildFn = func(_ context.Context, runtimeName string, buildStdout, _ io.Writer, opts sandboxcontainer.BuildOptions) (sandboxcontainer.BuildResult, error) {
+		if runtimeName != "podman" {
+			t.Fatalf("runtimeName = %q, want podman", runtimeName)
+		}
+		if opts.Tag != "ghcr.io/acme/sandbox:test" {
+			t.Fatalf("Tag = %q", opts.Tag)
+		}
+		if opts.Plan.Tier != "base" {
+			t.Fatalf("Plan.Tier = %q, want base", opts.Plan.Tier)
+		}
+		if _, ok := buildStdout.(*bytes.Buffer); !ok {
+			t.Fatalf("stdout writer = %T, want *bytes.Buffer", buildStdout)
+		}
+		return sandboxcontainer.BuildResult{
+			Runtime: runtimeName,
+			Image:   opts.Tag,
+			Built:   true,
+			Tier:    opts.Plan.Tier,
+		}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sandbox", "build", "--runtime=podman", "--tag=ghcr.io/acme/sandbox:test"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	for _, want := range []string{"tier: base", "runtime: podman", "image: ghcr.io/acme/sandbox:test", "build: complete"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("stdout = %q, missing %q", out, want)
+		}
+	}
+}
+
+func TestRunSandboxBuildReportsNoBuildRequired(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.MkdirAll(filepath.Join(dir, ".devcontainer"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".devcontainer", "devcontainer.json"), []byte(`{"customizations":{"aileron":{"image":"ghcr.io/acme/agent:latest"}}}`), 0o644); err != nil {
+		t.Fatalf("write devcontainer: %v", err)
+	}
+
+	origBuild := sandboxBuildFn
+	t.Cleanup(func() { sandboxBuildFn = origBuild })
+	sandboxBuildFn = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.BuildOptions) (sandboxcontainer.BuildResult, error) {
+		return sandboxcontainer.BuildResult{
+			Image: opts.Plan.Image,
+			Tier:  opts.Plan.Tier,
+		}, sandboxcontainer.ErrNoBuildRequired
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sandbox", "build"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "tier: byo_image") || !strings.Contains(out, "image: ghcr.io/acme/agent:latest") || !strings.Contains(out, "build: not required") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestRunSandboxBuildWithDefaultBuilderReportsNoBuildRequired(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.MkdirAll(filepath.Join(dir, ".devcontainer"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".devcontainer", "devcontainer.json"), []byte(`{"customizations":{"aileron":{"image":"ghcr.io/acme/agent:latest"}}}`), 0o644); err != nil {
+		t.Fatalf("write devcontainer: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sandbox", "build"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d; stderr=%q", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "tier: byo_image") || !strings.Contains(out, "image: ghcr.io/acme/agent:latest") || !strings.Contains(out, "build: not required") {
+		t.Fatalf("stdout = %q", out)
+	}
+}
+
+func TestRunSandboxBuildSurfacesBuildError(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	origBuild := sandboxBuildFn
+	t.Cleanup(func() { sandboxBuildFn = origBuild })
+	sandboxBuildFn = func(context.Context, string, io.Writer, io.Writer, sandboxcontainer.BuildOptions) (sandboxcontainer.BuildResult, error) {
+		return sandboxcontainer.BuildResult{}, errors.New("runtime unavailable")
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sandbox", "build"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "runtime unavailable") {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunSandboxBuildSurfacesParseError(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+	if err := os.MkdirAll(filepath.Join(dir, ".devcontainer"), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, ".devcontainer", "devcontainer.json"), []byte(`{"customizations":{"aileron":{"approval_surface":"sms"}}}`), 0o644); err != nil {
+		t.Fatalf("write devcontainer: %v", err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sandbox", "build"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "approval_surface") {
 		t.Fatalf("stderr = %q", stderr.String())
 	}
 }

--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -1,18 +1,21 @@
 package main
 
 import (
+	"context"
+	"errors"
 	"flag"
 	"fmt"
 	"io"
 	"os"
 
 	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 	"github.com/ALRubinger/aileron/internal/version"
 )
 
 func runSandbox(args []string, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan>")
+		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build>")
 		return 1
 	}
 	switch args[0] {
@@ -20,9 +23,11 @@ func runSandbox(args []string, stdout, stderr io.Writer) int {
 		return runSandboxInit(args[1:], stdout, stderr)
 	case "plan":
 		return runSandboxPlan(args[1:], stdout, stderr)
+	case "build":
+		return runSandboxBuild(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown sandbox command: %q\n", args[0])
-		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan>")
+		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build>")
 		return 1
 	}
 }
@@ -86,4 +91,56 @@ func runSandboxPlan(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stdout, "dockerfile: %s\n", plan.DockerfilePath)
 	}
 	return 0
+}
+
+func runSandboxBuild(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("sandbox build", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	runtimeName := flags.String("runtime", sandboxcontainer.DefaultRuntime, "Container runtime: auto, docker, or podman")
+	tag := flags.String("tag", "", "Override the image tag to build")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: aileron sandbox build [--runtime=auto|docker|podman] [--tag=<image>]")
+		return 1
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	plan, err := sandboxcomposition.Discover(cwd, version.Version)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	result, err := sandboxBuildFn(context.Background(), *runtimeName, stdout, stderr, sandboxcontainer.BuildOptions{
+		WorkDir: cwd,
+		Plan:    plan,
+		Tag:     *tag,
+	})
+	if errors.Is(err, sandboxcontainer.ErrNoBuildRequired) {
+		fmt.Fprintf(stdout, "tier: %s\n", result.Tier)
+		fmt.Fprintf(stdout, "image: %s\n", result.Image)
+		fmt.Fprintln(stdout, "build: not required")
+		return 0
+	}
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "tier: %s\n", result.Tier)
+	fmt.Fprintf(stdout, "runtime: %s\n", result.Runtime)
+	fmt.Fprintf(stdout, "image: %s\n", result.Image)
+	fmt.Fprintln(stdout, "build: complete")
+	return 0
+}
+
+var sandboxBuildFn = func(ctx context.Context, runtimeName string, stdout, stderr io.Writer, opts sandboxcontainer.BuildOptions) (sandboxcontainer.BuildResult, error) {
+	return sandboxcontainer.Builder{
+		Runtime: runtimeName,
+		Stdout:  stdout,
+		Stderr:  stderr,
+	}.Build(ctx, opts)
 }

--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -68,7 +68,9 @@ This ADR follows the updated sandbox runtime direction:
 
 The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented snippets for common tools. The snippets are guidance, not a runtime resolver. Users own their container contents using normal Docker/devcontainer workflows.
 
-`aileron sandbox plan` is an inspection helper that reports the normalized tier/image/dockerfile plan. Later launch work consumes the same composition contract and built image selection.
+`aileron sandbox plan` is an inspection helper that reports the normalized tier/image/dockerfile plan.
+
+`aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is until runtime injection and launch-time validation land. Later launch work consumes the same composition contract and built image selection.
 
 ## Consequences
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -23,6 +23,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 |---|---|---|
 | `aileron sandbox init` | Scaffold `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile` for sandbox composition. The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented tool snippets. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox plan` | Inspect the normalized composition tier and image Aileron infers from the current project. | [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron sandbox build` | Build the Tier 0 sandbox-base image or Tier 1 devcontainer image with Docker or Podman. Tier 2 BYO images are reported without build or injection. | [ADR-0017](/adr/0017-sandbox-composition) |
 
 See [Sandbox Composition](/development/sandbox-composition/) for the full workflow and examples.
 

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -6,7 +6,7 @@ order: 6
 
 Sandbox composition is the contract for deciding which container image an agent session runs in. It is defined by [ADR-0017](/adr/0017-sandbox-composition/) and implemented by the `aileron sandbox` CLI.
 
-This page covers the user-facing workflow. Runtime launch support is intentionally still staged: the current implementation can scaffold and inspect the composition plan, while later work wires that plan into container build and `aileron launch`.
+This page covers the user-facing workflow. Runtime launch support is intentionally still staged: the current implementation can scaffold, inspect, and build sandbox images, while later work wires those images into `aileron launch`.
 
 ## Choose a Composition Tier
 
@@ -81,6 +81,31 @@ devcontainer: .devcontainer/devcontainer.json
 dockerfile: Dockerfile
 ```
 
+## Build the Image
+
+Use `sandbox build` to build the image selected by the plan:
+
+```bash
+aileron sandbox build
+```
+
+Aileron detects Docker or Podman from `PATH`. You can choose explicitly:
+
+```bash
+aileron sandbox build --runtime=podman
+aileron sandbox build --runtime=docker --tag=ghcr.io/acme/agent-dev:local
+```
+
+Build behavior by tier:
+
+| Tier | Build behavior |
+|---|---|
+| Tier 0 | Builds the local `images/sandbox-base/Containerfile` as `aileron/sandbox-base:<version>`. |
+| Tier 1 | Builds the devcontainer Dockerfile and tags it as a deterministic local `aileron/sandbox-project:<hash>` image unless `--tag` is supplied. |
+| Tier 2 | Does not build. The BYO image is reported as-is; runtime injection and launch-time validation land later. |
+
+When building the base image outside the source tree, set `AILERON_SANDBOX_BASE_CONTEXT` to the directory containing the sandbox-base `Containerfile`.
+
 ## Use a BYO Image
 
 Set `customizations.aileron.image` when your team owns the complete image:
@@ -107,4 +132,4 @@ Do not put Aileron credentials or user secrets in the image. Credentialed traffi
 
 ## What This Does Not Do Yet
 
-This slice does not run containers or inject runtime files into BYO images. Follow-on work wires image builds into launch, adds BYO runtime injection and validation, and adds the discovery watcher. Shell-layer interception builds on top of that runtime substrate.
+This slice does not run containers or inject runtime files into BYO images. Follow-on work wires built images into launch, adds BYO runtime injection and validation, and adds the discovery watcher. Shell-layer interception builds on top of that runtime substrate.


### PR DESCRIPTION
## Summary

- Adds `aileron sandbox build` as the first user-facing consumer of the sandbox image build substrate.
- Supports `--runtime=auto|docker|podman` and `--tag=<image>` while reusing the existing composition plan.
- Reports no-build selections for Tier 2/BYO and image-only devcontainers instead of requiring a container runtime.
- Documents build behavior for Tier 0, Tier 1, and Tier 2 without introducing launch wiring or shell interception.

## Scope

This stays inside #796. It exposes image building only; it does not run containers, wire sandbox images into `aileron launch`, perform BYO runtime injection, add discovery watching, or start shell interception.

Refs #796
Refs #747

## Validation

- `go test ./cmd/aileron ./internal/sandbox/...`
- `go test ./cmd/aileron -run TestRunSandbox -coverprofile=/tmp/sandbox-cmd-cover.out`
- `pnpm run check` in `docs/`
- `go run ./cmd/aileron sandbox build --runtime=docker --tag aileron/sandbox-base:codex-cli-test`
