### PR TITLE
feat(sandbox): prepare images during launch

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -84,13 +84,14 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		launchFlags := flag.NewFlagSet("launch", flag.ContinueOnError)
 		launchFlags.SetOutput(stderr)
 		logLevel := launchFlags.String("log-level", "info", "Log level: trace, debug, info, warn, error")
+		sandboxRuntime := launchFlags.String("sandbox", "off", "Prepare sandbox image with runtime: off, auto, docker, or podman")
 		if err := launchFlags.Parse(args[1:]); err != nil {
 			return 1
 		}
 		launchArgs := launchFlags.Args()
 
 		if len(launchArgs) < 1 {
-			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] <agent> [args...]")
+			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] [--sandbox=off|auto|docker|podman] <agent> [args...]")
 			fmt.Fprintf(stderr, "agents: %s\n", strings.Join(registry.Names(), ", "))
 			return 1
 		}
@@ -109,10 +110,11 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		cwd, _ := os.Getwd()
 
 		result, err := launchFn(context.Background(), launch.LaunchConfig{
-			Agent:    agent,
-			Args:     launchArgs[1:],
-			Dir:      cwd,
-			LogLevel: launch.ParseLogLevel(*logLevel),
+			Agent:          agent,
+			Args:           launchArgs[1:],
+			Dir:            cwd,
+			LogLevel:       launch.ParseLogLevel(*logLevel),
+			SandboxRuntime: *sandboxRuntime,
 		})
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %v\n", err)
@@ -166,7 +168,8 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "aileron — the execution layer for AI coding agents")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "usage:")
-	fmt.Fprintln(w, "  aileron launch <agent> [args...]   Launch an AI coding agent connected to the Aileron daemon")
+	fmt.Fprintln(w, "  aileron launch [--sandbox=<runtime>] <agent> [args...]")
+	fmt.Fprintln(w, "                                      Launch an AI coding agent connected to the Aileron daemon")
 	fmt.Fprintln(w, "  aileron vault init                 Create the local encrypted vault with a passphrase")
 	fmt.Fprintln(w, "  aileron secret set <name>          Store a secret in the encrypted vault")
 	fmt.Fprintln(w, "  aileron secret list                List stored secret names")

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -145,6 +145,28 @@ func TestRun_LaunchPopulatesWorkingDir(t *testing.T) {
 	}
 }
 
+func TestRun_LaunchPassesSandboxRuntime(t *testing.T) {
+	origLaunch := launchFn
+	t.Cleanup(func() {
+		launchFn = origLaunch
+	})
+
+	var captured launch.LaunchConfig
+	launchFn = func(_ context.Context, cfg launch.LaunchConfig) (launch.LaunchResult, error) {
+		captured = cfg
+		return launch.LaunchResult{ExitCode: 0}, nil
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"launch", "--sandbox=docker", "claude"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, stderr.String())
+	}
+	if captured.SandboxRuntime != "docker" {
+		t.Errorf("LaunchConfig.SandboxRuntime = %q, want docker", captured.SandboxRuntime)
+	}
+}
+
 func TestRun_LaunchLogLevelNoAgent(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"launch", "--log-level=debug"}, newTestRegistry(), &stdout, &stderr)

--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -72,6 +72,8 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 `aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is until runtime injection and launch-time validation land. Later launch work consumes the same composition contract and built image selection.
 
+`aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image before agent startup. This first launch integration makes image selection visible to the launcher and exports the prepared image metadata to the child process. It does not run the agent inside the container until the container execution slice lands.
+
 ## Consequences
 
 Users with existing devcontainers get an upgrade path rather than a parallel Aileron-only config file.

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -14,7 +14,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 
 | Command | Purpose | Ratified by |
 |---|---|---|
-| `aileron launch` | Start the local Aileron server. Prompts for the vault passphrase if one is set; creates a vault on first run. Listens on `http://localhost:8721/v1` by default. | [ADR-0011](/adr/0011-local-credential-vault) |
+| `aileron launch [--sandbox=off\|auto\|docker\|podman]` | Launch an AI coding agent connected to the Aileron daemon. `--sandbox` prepares the project sandbox image for the session; container execution lands in follow-on sandbox runtime work. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron status` | Report the running runtime: version, listen address, action count, connector count, binding count, vault state. Read-only; safe to run frequently. | — |
 
 ## Sandbox composition

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -6,7 +6,7 @@ order: 6
 
 Sandbox composition is the contract for deciding which container image an agent session runs in. It is defined by [ADR-0017](/adr/0017-sandbox-composition/) and implemented by the `aileron sandbox` CLI.
 
-This page covers the user-facing workflow. Runtime launch support is intentionally still staged: the current implementation can scaffold, inspect, and build sandbox images, while later work wires those images into `aileron launch`.
+This page covers the user-facing workflow. Runtime launch support is intentionally still staged: the current implementation can scaffold, inspect, build, and prepare sandbox images during `aileron launch`, while later work runs the agent inside the prepared container.
 
 ## Choose a Composition Tier
 
@@ -106,6 +106,20 @@ Build behavior by tier:
 
 When building the base image outside the source tree, set `AILERON_SANDBOX_BASE_CONTEXT` to the directory containing the sandbox-base `Containerfile`.
 
+## Prepare During Launch
+
+Use `--sandbox` on `aileron launch` to have launch prepare the composition-selected image before starting the agent:
+
+```bash
+aileron launch --sandbox=auto claude
+aileron launch --sandbox=docker codex
+aileron launch --sandbox=podman goose
+```
+
+`auto` detects Docker or Podman from `PATH`. `docker` and `podman` select a runtime explicitly. The default is `--sandbox=off`, which preserves the current direct host launch path.
+
+This slice prepares image selection only. Launch exports `AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, and, when a build ran, `AILERON_SANDBOX_RUNTIME` to the child process for the follow-on runtime path. It does not run the agent inside the container yet.
+
 ## Use a BYO Image
 
 Set `customizations.aileron.image` when your team owns the complete image:
@@ -132,4 +146,4 @@ Do not put Aileron credentials or user secrets in the image. Credentialed traffi
 
 ## What This Does Not Do Yet
 
-This slice does not run containers or inject runtime files into BYO images. Follow-on work wires built images into launch, adds BYO runtime injection and validation, and adds the discovery watcher. Shell-layer interception builds on top of that runtime substrate.
+This slice does not run containers or inject runtime files into BYO images. Follow-on work runs agents inside the prepared image, adds BYO runtime injection and validation, and adds the discovery watcher. Shell-layer interception builds on top of that runtime substrate.

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -2,6 +2,7 @@ package launch
 
 import (
 	"context"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -14,6 +15,9 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/daemon/spawn"
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/version"
 )
 
 // MCPServerName is the name Aileron registers itself under in agents'
@@ -35,11 +39,27 @@ type LaunchConfig struct {
 	Dir string
 	// LogLevel sets the session log verbosity (e.g. slog.LevelDebug).
 	LogLevel slog.Level
+	// SandboxRuntime selects the container runtime used to prepare the
+	// sandbox image for this launch. Empty or "off" preserves today's
+	// direct host launch path. "auto", "docker", and "podman" prepare
+	// the composition-selected image; container execution lands in a
+	// follow-on sandbox runtime slice.
+	SandboxRuntime string
 }
 
 // LaunchResult holds the outcome of a launched agent process.
 type LaunchResult struct {
 	ExitCode int
+}
+
+// SandboxLaunchPlan is the sandbox image selected or prepared for a launch.
+// It is intentionally image-level only; container execution, runtime
+// injection, and network/proxy bootstrap are follow-on launch work.
+type SandboxLaunchPlan struct {
+	Runtime string
+	Image   string
+	Tier    sandboxcomposition.Tier
+	Built   bool
 }
 
 // ResolveBinary searches PATH for the first matching binary name from
@@ -89,6 +109,59 @@ func resolveMCPBinary(selfPath string) (string, error) {
 		siblingDir, siblingDir,
 	)
 }
+
+func sandboxLaunchEnabled(runtimeName string) bool {
+	switch runtimeName {
+	case "", "off":
+		return false
+	default:
+		return true
+	}
+}
+
+func validateSandboxRuntime(runtimeName string) error {
+	switch runtimeName {
+	case "", "off", sandboxcontainer.DefaultRuntime, "docker", "podman":
+		return nil
+	default:
+		return fmt.Errorf("unsupported sandbox runtime %q (want off, auto, docker, or podman)", runtimeName)
+	}
+}
+
+func prepareSandbox(ctx context.Context, workDir, runtimeName string, stdout, stderr io.Writer) (SandboxLaunchPlan, error) {
+	if err := validateSandboxRuntime(runtimeName); err != nil {
+		return SandboxLaunchPlan{}, err
+	}
+	plan, err := sandboxcomposition.Discover(workDir, version.Version)
+	if err != nil {
+		return SandboxLaunchPlan{}, err
+	}
+	result, err := sandboxcontainer.Builder{
+		Runtime: runtimeName,
+		Stdout:  stdout,
+		Stderr:  stderr,
+	}.Build(ctx, sandboxcontainer.BuildOptions{
+		WorkDir: workDir,
+		Plan:    plan,
+	})
+	if errors.Is(err, sandboxcontainer.ErrNoBuildRequired) {
+		return SandboxLaunchPlan{
+			Image: result.Image,
+			Tier:  result.Tier,
+		}, nil
+	}
+	if err != nil {
+		return SandboxLaunchPlan{}, err
+	}
+	return SandboxLaunchPlan{
+		Runtime: result.Runtime,
+		Image:   result.Image,
+		Tier:    result.Tier,
+		Built:   result.Built,
+	}, nil
+}
+
+var prepareSandboxForLaunch = prepareSandbox
 
 // Launch starts the agent as a child process under Aileron's daemon.
 //
@@ -145,6 +218,24 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		return LaunchResult{}, err
 	}
 
+	var sandboxPlan SandboxLaunchPlan
+	if sandboxLaunchEnabled(config.SandboxRuntime) {
+		plan, err := prepareSandboxForLaunch(ctx, config.Dir, config.SandboxRuntime, os.Stdout, os.Stderr)
+		if err != nil {
+			return LaunchResult{}, fmt.Errorf("prepare sandbox: %w", err)
+		}
+		sandboxPlan = plan
+		fmt.Fprintf(os.Stderr, "aileron: sandbox image %s ready (tier=%s", sandboxPlan.Image, sandboxPlan.Tier)
+		if sandboxPlan.Runtime != "" {
+			fmt.Fprintf(os.Stderr, ", runtime=%s", sandboxPlan.Runtime)
+		}
+		if sandboxPlan.Built {
+			fmt.Fprint(os.Stderr, ", built=true")
+		}
+		fmt.Fprintln(os.Stderr, ")")
+		fmt.Fprintln(os.Stderr, "aileron: container execution is not enabled yet; launching agent directly")
+	}
+
 	regCtx, cancelReg := context.WithTimeout(ctx, daemonHTTPTimeout)
 	sessionID, err := client.RegisterSession(regCtx, config.Agent.Name(), config.Dir)
 	cancelReg()
@@ -153,6 +244,13 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	}
 
 	agentEnv := composeAgentEnv(config.Agent.Env(), config.Agent.LLMEndpointEnv(), daemonURL)
+	if sandboxPlan.Image != "" {
+		agentEnv["AILERON_SANDBOX_IMAGE"] = sandboxPlan.Image
+		agentEnv["AILERON_SANDBOX_TIER"] = string(sandboxPlan.Tier)
+		if sandboxPlan.Runtime != "" {
+			agentEnv["AILERON_SANDBOX_RUNTIME"] = sandboxPlan.Runtime
+		}
+	}
 	env := buildEnv(agentEnv)
 
 	allArgs := append(config.Agent.Args(), config.Args...)
@@ -190,6 +288,9 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		"binary", agentPath,
 		"daemon_url", daemonURL,
 		"daemon_log", filepath.Join(stateDir, "daemon.log"),
+		"sandbox_image", sandboxPlan.Image,
+		"sandbox_tier", sandboxPlan.Tier,
+		"sandbox_runtime", sandboxPlan.Runtime,
 	)
 
 	probeCtx, cancelProbe := context.WithTimeout(ctx, daemonHTTPTimeout)

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -46,11 +46,11 @@ type scriptAgent struct {
 	mcpArgs  []string
 }
 
-func (a scriptAgent) Name() string                                  { return "test-script" }
-func (a scriptAgent) BinaryNames() []string                         { return []string{a.script} }
-func (a scriptAgent) Args() []string                                { return nil }
-func (a scriptAgent) Env() map[string]string                        { return a.extraEnv }
-func (a scriptAgent) LLMEndpointEnv() string                        { return "" }
+func (a scriptAgent) Name() string           { return "test-script" }
+func (a scriptAgent) BinaryNames() []string  { return []string{a.script} }
+func (a scriptAgent) Args() []string         { return nil }
+func (a scriptAgent) Env() map[string]string { return a.extraEnv }
+func (a scriptAgent) LLMEndpointEnv() string { return "" }
 func (a scriptAgent) ConfigureMCP(string, map[string]string, string) ([]string, error) {
 	return a.mcpArgs, nil
 }
@@ -193,6 +193,145 @@ func TestLaunch_AgentMCPArgs_Appended(t *testing.T) {
 		if !found {
 			t.Errorf("expected arg %q in child argv, got %v", w, args)
 		}
+	}
+}
+
+func TestLaunch_SandboxBYOImageEnvVarsFlowThrough(t *testing.T) {
+	dir := t.TempDir()
+	devcontainerDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(`{"customizations":{"aileron":{"image":"ghcr.io/acme/agent:latest"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	outFile := filepath.Join(dir, "env.txt")
+	script := filepath.Join(dir, "capture.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nenv > "+outFile+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:          scriptAgent{script: script},
+		Dir:            dir,
+		SandboxRuntime: "auto",
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read env: %v", err)
+	}
+	env := string(data)
+	for _, want := range []string{
+		"AILERON_SANDBOX_IMAGE=ghcr.io/acme/agent:latest",
+		"AILERON_SANDBOX_TIER=byo_image",
+	} {
+		if !strings.Contains(env, want) {
+			t.Errorf("expected %q in child env:\n%s", want, env)
+		}
+	}
+	if strings.Contains(env, "AILERON_SANDBOX_RUNTIME=") {
+		t.Errorf("BYO image should not report a build runtime:\n%s", env)
+	}
+}
+
+func TestLaunch_SandboxBuildEnvVarsFlowThrough(t *testing.T) {
+	dir := t.TempDir()
+	baseDir := filepath.Join(dir, "images", "sandbox-base")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "Containerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	docker := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	outFile := filepath.Join(dir, "env.txt")
+	script := filepath.Join(dir, "capture.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\nenv > "+outFile+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:          scriptAgent{script: script},
+		Dir:            dir,
+		SandboxRuntime: "docker",
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	data, err := os.ReadFile(outFile)
+	if err != nil {
+		t.Fatalf("read env: %v", err)
+	}
+	env := string(data)
+	for _, want := range []string{
+		"AILERON_SANDBOX_IMAGE=aileron/sandbox-base:latest",
+		"AILERON_SANDBOX_TIER=base",
+		"AILERON_SANDBOX_RUNTIME=docker",
+	} {
+		if !strings.Contains(env, want) {
+			t.Errorf("expected %q in child env:\n%s", want, env)
+		}
+	}
+}
+
+func TestLaunch_SandboxBuildFailureFailsBeforeAgentStart(t *testing.T) {
+	dir := t.TempDir()
+	baseDir := filepath.Join(dir, "images", "sandbox-base")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "Containerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	docker := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nexit 7\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	outFile := filepath.Join(dir, "agent-started")
+	script := filepath.Join(dir, "capture.sh")
+	if err := os.WriteFile(script, []byte("#!/bin/sh\ntouch "+outFile+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:          scriptAgent{script: script},
+		Dir:            dir,
+		SandboxRuntime: "docker",
+	})
+	if err == nil {
+		t.Fatal("expected sandbox build failure")
+	}
+	if !strings.Contains(err.Error(), "prepare sandbox") {
+		t.Fatalf("error = %v", err)
+	}
+	if _, statErr := os.Stat(outFile); !os.IsNotExist(statErr) {
+		t.Fatalf("agent started despite build failure; stat err=%v", statErr)
+	}
+}
+
+func TestLaunch_SandboxInvalidRuntimeFails(t *testing.T) {
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:          scriptAgent{script: "/bin/sh"},
+		SandboxRuntime: "containerd",
+	})
+	if err == nil {
+		t.Fatal("expected invalid sandbox runtime error")
+	}
+	if !strings.Contains(err.Error(), "unsupported sandbox runtime") {
+		t.Fatalf("error = %v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add `aileron launch --sandbox=off|auto|docker|podman` and pass the selected runtime into launch config
- prepare the sandbox composition image during launch through the existing Docker/Podman build substrate
- expose prepared image metadata to the child process via `AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, and build runtime when applicable
- update sandbox CLI/docs/ADR text without user-facing v4 wording

## Scope
- #796 only
- prepares/selects/builds sandbox images during launch
- does not run the agent inside the container yet
- does not add BYO runtime injection, discovery watcher refresh, or shell interception (#801)
- keeps the single `aileron` CLI surface

## Validation
- `go test ./cmd/aileron ./internal/launch ./internal/sandbox/...`
- `pnpm run check`
- attempted `go test ./...`, but the repo root is a Go workspace wrapper and that pattern is invalid: `directory prefix . does not contain modules listed in go.work`