### PR TITLE
[codex] Run sandbox launch agents in containers

### DIFF
--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -72,7 +72,7 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 `aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is until runtime injection and launch-time validation land. Later launch work consumes the same composition contract and built image selection.
 
-`aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image before agent startup. This first launch integration makes image selection visible to the launcher and exports the prepared image metadata to the child process. It does not run the agent inside the container until the container execution slice lands.
+`aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image, then runs the agent command inside a one-shot Docker/Podman container. The project is mounted at `/home/agent/workspace` and used as the container working directory. Launch passes the session-scoped Aileron daemon env into the container and rewrites loopback daemon URLs to the runtime host alias (`host.docker.internal` for Docker, `host.containers.internal` for Podman).
 
 ## Consequences
 
@@ -80,7 +80,7 @@ Users with existing devcontainers get an upgrade path rather than a parallel Ail
 
 Aileron keeps a clear boundary: it owns mediation, credentials, approvals, audit, and runtime bootstrap; users own development tooling in the image.
 
-The first implementations can establish the contract and image-build substrate without also implementing runtime orchestration, watcher processes, shell interception, or proxy bootstrap. Those build on this substrate in later sandbox and shell-mediation work.
+The first implementations establish the contract, image-build substrate, and minimal container execution path without also implementing runtime injection, watcher processes, shell interception, or proxy bootstrap. Those build on this substrate in later sandbox and shell-mediation work.
 
 ## Alternatives Considered
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -14,7 +14,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 
 | Command | Purpose | Ratified by |
 |---|---|---|
-| `aileron launch [--sandbox=off\|auto\|docker\|podman]` | Launch an AI coding agent connected to the Aileron daemon. `--sandbox` prepares the project sandbox image for the session; container execution lands in follow-on sandbox runtime work. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron launch [--sandbox=off\|auto\|docker\|podman]` | Launch an AI coding agent connected to the Aileron daemon. `--sandbox` prepares the project sandbox image and runs the agent command inside it; `off` preserves direct host launch. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron status` | Report the running runtime: version, listen address, action count, connector count, binding count, vault state. Read-only; safe to run frequently. | — |
 
 ## Sandbox composition

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -6,7 +6,7 @@ order: 6
 
 Sandbox composition is the contract for deciding which container image an agent session runs in. It is defined by [ADR-0017](/adr/0017-sandbox-composition/) and implemented by the `aileron sandbox` CLI.
 
-This page covers the user-facing workflow. Runtime launch support is intentionally still staged: the current implementation can scaffold, inspect, build, and prepare sandbox images during `aileron launch`, while later work runs the agent inside the prepared container.
+This page covers the user-facing workflow. Runtime launch support is intentionally still staged: the current implementation can scaffold, inspect, build, and run the agent command in the prepared sandbox image, while later work adds runtime injection, discovery refresh, proxy bootstrap, and shell mediation.
 
 ## Choose a Composition Tier
 
@@ -106,9 +106,9 @@ Build behavior by tier:
 
 When building the base image outside the source tree, set `AILERON_SANDBOX_BASE_CONTEXT` to the directory containing the sandbox-base `Containerfile`.
 
-## Prepare During Launch
+## Run During Launch
 
-Use `--sandbox` on `aileron launch` to have launch prepare the composition-selected image before starting the agent:
+Use `--sandbox` on `aileron launch` to have launch prepare the composition-selected image and start the agent inside it:
 
 ```bash
 aileron launch --sandbox=auto claude
@@ -118,7 +118,9 @@ aileron launch --sandbox=podman goose
 
 `auto` detects Docker or Podman from `PATH`. `docker` and `podman` select a runtime explicitly. The default is `--sandbox=off`, which preserves the current direct host launch path.
 
-This slice prepares image selection only. Launch exports `AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, and, when a build ran, `AILERON_SANDBOX_RUNTIME` to the child process for the follow-on runtime path. It does not run the agent inside the container yet.
+The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
+
+The agent command must already exist in the selected image. For Tier 1, install the agent CLI in your devcontainer Dockerfile. Tier 2 uses the BYO image as supplied until runtime injection lands.
 
 ## Use a BYO Image
 
@@ -136,14 +138,14 @@ Set `customizations.aileron.image` when your team owns the complete image:
 }
 ```
 
-In BYO-image mode, later runtime launch work will use the image as supplied and inject Aileron's runtime contract at launch: the `aileron` binary/shims, discovery files, proxy bootstrap, session CA, and shell mediation files.
+In BYO-image mode, launch currently uses the image as supplied. Later runtime launch work injects Aileron's runtime contract at launch: the `aileron` binary/shims, discovery files, proxy bootstrap, session CA, and shell mediation files.
 
 ## What Belongs in the Image
 
 Put ordinary project tooling in the devcontainer: language runtimes, CLIs, package managers, private CA bundles, and internal helper tools.
 
-Do not put Aileron credentials or user secrets in the image. Credentialed traffic is designed to flow through the Aileron HTTPS proxy/data plane. Runtime bootstrap supplies `HTTPS_PROXY` and `AILERON_TOKEN` when container launch support lands.
+Do not put Aileron credentials or user secrets in the image. Credentialed traffic is designed to flow through the Aileron HTTPS proxy/data plane. Runtime bootstrap supplies proxy configuration when that layer lands.
 
 ## What This Does Not Do Yet
 
-This slice does not run containers or inject runtime files into BYO images. Follow-on work runs agents inside the prepared image, adds BYO runtime injection and validation, and adds the discovery watcher. Shell-layer interception builds on top of that runtime substrate.
+This slice does not inject runtime files into BYO images, generate discovery shims, or mediate shell commands. Follow-on work adds BYO runtime injection and validation, the discovery watcher, proxy bootstrap, and shell-layer interception.

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -6,10 +6,13 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"net"
+	"net/url"
 	"os"
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"strings"
 	"syscall"
 	"time"
 
@@ -18,6 +21,7 @@ import (
 	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 	"github.com/ALRubinger/aileron/internal/version"
+	"golang.org/x/term"
 )
 
 // MCPServerName is the name Aileron registers itself under in agents'
@@ -39,11 +43,11 @@ type LaunchConfig struct {
 	Dir string
 	// LogLevel sets the session log verbosity (e.g. slog.LevelDebug).
 	LogLevel slog.Level
-	// SandboxRuntime selects the container runtime used to prepare the
-	// sandbox image for this launch. Empty or "off" preserves today's
-	// direct host launch path. "auto", "docker", and "podman" prepare
-	// the composition-selected image; container execution lands in a
-	// follow-on sandbox runtime slice.
+	// SandboxRuntime selects the container runtime used to run the
+	// agent in the prepared sandbox image. Empty or "off" preserves
+	// today's direct host launch path. "auto", "docker", and "podman"
+	// prepare the composition-selected image and execute the agent in a
+	// one-shot container.
 	SandboxRuntime string
 }
 
@@ -53,8 +57,8 @@ type LaunchResult struct {
 }
 
 // SandboxLaunchPlan is the sandbox image selected or prepared for a launch.
-// It is intentionally image-level only; container execution, runtime
-// injection, and network/proxy bootstrap are follow-on launch work.
+// Runtime injection, watcher refresh, and shell interception are follow-on
+// launch work.
 type SandboxLaunchPlan struct {
 	Runtime string
 	Image   string
@@ -145,9 +149,14 @@ func prepareSandbox(ctx context.Context, workDir, runtimeName string, stdout, st
 		Plan:    plan,
 	})
 	if errors.Is(err, sandboxcontainer.ErrNoBuildRequired) {
+		runtime, runtimeErr := sandboxcontainer.ResolveRuntime(runtimeName)
+		if runtimeErr != nil {
+			return SandboxLaunchPlan{}, runtimeErr
+		}
 		return SandboxLaunchPlan{
-			Image: result.Image,
-			Tier:  result.Tier,
+			Runtime: runtime,
+			Image:   result.Image,
+			Tier:    result.Tier,
 		}, nil
 	}
 	if err != nil {
@@ -203,23 +212,9 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	}
 	client := newDaemonClient(daemonURL, daemonToken)
 
-	agentPath, err := ResolveBinary(config.Agent.BinaryNames())
-	if err != nil {
-		return LaunchResult{}, fmt.Errorf("agent %q: %w", config.Agent.Name(), err)
-	}
-
-	// Resolve aileron-mcp up front. Per ADR-0015 the MCP server is the
-	// runtime path for every Aileron tool the agent calls; running
-	// without it isn't running. Resolve before session registration so
-	// a missing binary fails before the daemon has anything to clean up.
-	selfPath, _ := os.Executable()
-	mcpBin, err := resolveMCPBinary(selfPath)
-	if err != nil {
-		return LaunchResult{}, err
-	}
-
+	sandboxEnabled := sandboxLaunchEnabled(config.SandboxRuntime)
 	var sandboxPlan SandboxLaunchPlan
-	if sandboxLaunchEnabled(config.SandboxRuntime) {
+	if sandboxEnabled {
 		plan, err := prepareSandboxForLaunch(ctx, config.Dir, config.SandboxRuntime, os.Stdout, os.Stderr)
 		if err != nil {
 			return LaunchResult{}, fmt.Errorf("prepare sandbox: %w", err)
@@ -233,7 +228,6 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 			fmt.Fprint(os.Stderr, ", built=true")
 		}
 		fmt.Fprintln(os.Stderr, ")")
-		fmt.Fprintln(os.Stderr, "aileron: container execution is not enabled yet; launching agent directly")
 	}
 
 	regCtx, cancelReg := context.WithTimeout(ctx, daemonHTTPTimeout)
@@ -243,7 +237,11 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		return LaunchResult{}, fmt.Errorf("register session: %w", err)
 	}
 
-	agentEnv := composeAgentEnv(config.Agent.Env(), config.Agent.LLMEndpointEnv(), daemonURL)
+	agentEndpointURL := daemonURL
+	if sandboxEnabled {
+		agentEndpointURL = containerURLForRuntime(daemonURL, sandboxPlan.Runtime)
+	}
+	agentEnv := composeAgentEnv(config.Agent.Env(), config.Agent.LLMEndpointEnv(), agentEndpointURL)
 	if sandboxPlan.Image != "" {
 		agentEnv["AILERON_SANDBOX_IMAGE"] = sandboxPlan.Image
 		agentEnv["AILERON_SANDBOX_TIER"] = string(sandboxPlan.Tier)
@@ -251,30 +249,14 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 			agentEnv["AILERON_SANDBOX_RUNTIME"] = sandboxPlan.Runtime
 		}
 	}
-	env := buildEnv(agentEnv)
-
-	allArgs := append(config.Agent.Args(), config.Args...)
-
-	// MCP registration. The agent decides the wire shape: CLI flag
-	// (Claude, Pi) or config-file (Codex, Goose, OpenCode). The env
-	// passed here ends up inside the MCP server process so it can
-	// reach the daemon's session-scoped surfaces.
-	mcpEnv := map[string]string{
-		"AILERON_URL":          daemonURL,
-		"AILERON_COMMS_URL":    daemonURL,
-		"AILERON_SESSION_ID":   sessionID,
-		"AILERON_APPROVAL_URL": daemonURL + "/approvals",
-	}
-	extraArgs, mcpErr := config.Agent.ConfigureMCP(mcpBin, mcpEnv, config.Dir)
-	if mcpErr != nil {
-		return LaunchResult{}, fmt.Errorf("configuring MCP for %s: %w", config.Agent.Name(), mcpErr)
-	}
-	allArgs = append(allArgs, extraArgs...)
-
-	cmd := exec.CommandContext(ctx, agentPath, allArgs...)
-	cmd.Env = env
-	if config.Dir != "" {
-		cmd.Dir = config.Dir
+	if sandboxEnabled {
+		agentEnv["AILERON_URL"] = agentEndpointURL
+		agentEnv["AILERON_COMMS_URL"] = agentEndpointURL
+		agentEnv["AILERON_SESSION_ID"] = sessionID
+		agentEnv["AILERON_APPROVAL_URL"] = agentEndpointURL + "/approvals"
+		if daemonToken != "" {
+			agentEnv["AILERON_TOKEN"] = daemonToken
+		}
 	}
 
 	sessionLog, closeSessionLog := openSessionLogger(config.Dir, config.LogLevel)
@@ -285,7 +267,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		"agent", config.Agent.Name(),
 		"session_id", sessionID,
 		"dir", config.Dir,
-		"binary", agentPath,
+		"binary", firstAgentBinary(config.Agent),
 		"daemon_url", daemonURL,
 		"daemon_log", filepath.Join(stateDir, "daemon.log"),
 		"sandbox_image", sandboxPlan.Image,
@@ -298,7 +280,13 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	cancelProbe()
 	printStartupBanner(os.Stderr, daemonURL, sessionID, SessionLogPath(config.Dir), ok && locked)
 
-	result, runErr := launchDirect(cmd, config)
+	var result LaunchResult
+	var runErr error
+	if sandboxEnabled {
+		result, runErr = launchSandbox(ctx, sandboxPlan, config, agentEnv)
+	} else {
+		result, runErr = launchHost(ctx, config, daemonURL, sessionID, agentEnv)
+	}
 
 	endCtx, cancelEnd := context.WithTimeout(context.Background(), daemonHTTPTimeout)
 	exit := result.ExitCode
@@ -323,6 +311,46 @@ func composeAgentEnv(agentEnv map[string]string, endpointEnv, url string) map[st
 		merged[endpointEnv] = url
 	}
 	return merged
+}
+
+func firstAgentBinary(agent Agent) string {
+	names := agent.BinaryNames()
+	if len(names) == 0 {
+		return ""
+	}
+	return names[0]
+}
+
+func containerURLForRuntime(rawURL, runtimeName string) string {
+	parsed, err := url.Parse(rawURL)
+	if err != nil || parsed.Host == "" {
+		return rawURL
+	}
+	host, port, err := net.SplitHostPort(parsed.Host)
+	if err != nil {
+		host = parsed.Hostname()
+		port = parsed.Port()
+	}
+	if !isLoopbackHost(host) {
+		return rawURL
+	}
+	switch runtimeName {
+	case "podman":
+		host = "host.containers.internal"
+	default:
+		host = "host.docker.internal"
+	}
+	if port != "" {
+		parsed.Host = net.JoinHostPort(host, port)
+	} else {
+		parsed.Host = host
+	}
+	return parsed.String()
+}
+
+func isLoopbackHost(host string) bool {
+	host = strings.Trim(strings.ToLower(host), "[]")
+	return host == "localhost" || host == "127.0.0.1" || host == "::1"
 }
 
 // resolveStateDir returns ~/.aileron, the state directory the daemon
@@ -363,6 +391,67 @@ func printStartupBanner(w io.Writer, daemonURL, sessionID, logPath string, vault
 	if vaultLocked {
 		fmt.Fprintf(w, "✈️  Vault locked — open %s and enter your passphrase to unlock.\n", daemonURL)
 	}
+}
+
+func launchHost(ctx context.Context, config LaunchConfig, daemonURL, sessionID string, agentEnv map[string]string) (LaunchResult, error) {
+	agentPath, err := ResolveBinary(config.Agent.BinaryNames())
+	if err != nil {
+		return LaunchResult{}, fmt.Errorf("agent %q: %w", config.Agent.Name(), err)
+	}
+
+	// Resolve aileron-mcp up front for the host launch path. Sandbox
+	// launch does not revive aileron-mcp as the container runtime model;
+	// container-side shims/proxy bootstrap land in later #796/#801 slices.
+	selfPath, _ := os.Executable()
+	mcpBin, err := resolveMCPBinary(selfPath)
+	if err != nil {
+		return LaunchResult{}, err
+	}
+
+	allArgs := append(config.Agent.Args(), config.Args...)
+	mcpEnv := map[string]string{
+		"AILERON_URL":          daemonURL,
+		"AILERON_COMMS_URL":    daemonURL,
+		"AILERON_SESSION_ID":   sessionID,
+		"AILERON_APPROVAL_URL": daemonURL + "/approvals",
+	}
+	extraArgs, mcpErr := config.Agent.ConfigureMCP(mcpBin, mcpEnv, config.Dir)
+	if mcpErr != nil {
+		return LaunchResult{}, fmt.Errorf("configuring MCP for %s: %w", config.Agent.Name(), mcpErr)
+	}
+	allArgs = append(allArgs, extraArgs...)
+
+	cmd := exec.CommandContext(ctx, agentPath, allArgs...)
+	cmd.Env = buildEnv(agentEnv)
+	if config.Dir != "" {
+		cmd.Dir = config.Dir
+	}
+	return launchDirect(cmd, config)
+}
+
+func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, agentEnv map[string]string) (LaunchResult, error) {
+	commandName := firstAgentBinary(config.Agent)
+	if commandName == "" {
+		return LaunchResult{}, fmt.Errorf("agent %q has no container command", config.Agent.Name())
+	}
+	command := append([]string{commandName}, config.Agent.Args()...)
+	command = append(command, config.Args...)
+	_, err := sandboxcontainer.Builder{
+		Runtime: plan.Runtime,
+		Stdout:  os.Stdout,
+		Stderr:  os.Stderr,
+	}.Run(ctx, sandboxcontainer.RunOptions{
+		Runtime: plan.Runtime,
+		Image:   plan.Image,
+		WorkDir: config.Dir,
+		Env:     agentEnv,
+		Command: command,
+		TTY:     term.IsTerminal(int(os.Stdin.Fd())),
+	})
+	if err != nil {
+		return exitResult(err)
+	}
+	return LaunchResult{ExitCode: 0}, nil
 }
 
 // launchDirect runs the agent with direct stdin/stdout/stderr passthrough.

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -1,0 +1,90 @@
+package launch
+
+import "testing"
+
+type emptyBinaryAgent struct{}
+
+func (emptyBinaryAgent) Name() string           { return "empty" }
+func (emptyBinaryAgent) BinaryNames() []string  { return nil }
+func (emptyBinaryAgent) Args() []string         { return nil }
+func (emptyBinaryAgent) Env() map[string]string { return nil }
+func (emptyBinaryAgent) LLMEndpointEnv() string { return "" }
+func (emptyBinaryAgent) ConfigureMCP(string, map[string]string, string) ([]string, error) {
+	return nil, nil
+}
+
+type namedBinaryAgent struct{ name string }
+
+func (a namedBinaryAgent) Name() string           { return "named" }
+func (a namedBinaryAgent) BinaryNames() []string  { return []string{a.name} }
+func (a namedBinaryAgent) Args() []string         { return nil }
+func (a namedBinaryAgent) Env() map[string]string { return nil }
+func (a namedBinaryAgent) LLMEndpointEnv() string { return "" }
+func (a namedBinaryAgent) ConfigureMCP(string, map[string]string, string) ([]string, error) {
+	return nil, nil
+}
+
+func TestFirstAgentBinaryHandlesEmptyAgent(t *testing.T) {
+	if got := firstAgentBinary(emptyBinaryAgent{}); got != "" {
+		t.Fatalf("firstAgentBinary = %q, want empty", got)
+	}
+	if got := firstAgentBinary(namedBinaryAgent{name: "codex"}); got != "codex" {
+		t.Fatalf("firstAgentBinary = %q, want codex", got)
+	}
+}
+
+func TestContainerURLForRuntimeRewritesLoopbackAliases(t *testing.T) {
+	tests := []struct {
+		name    string
+		rawURL  string
+		runtime string
+		want    string
+	}{
+		{
+			name:    "docker localhost",
+			rawURL:  "http://localhost:48123",
+			runtime: "docker",
+			want:    "http://host.docker.internal:48123",
+		},
+		{
+			name:    "podman localhost",
+			rawURL:  "http://127.0.0.1:48123",
+			runtime: "podman",
+			want:    "http://host.containers.internal:48123",
+		},
+		{
+			name:    "non-loopback unchanged",
+			rawURL:  "http://10.0.0.5:48123",
+			runtime: "docker",
+			want:    "http://10.0.0.5:48123",
+		},
+		{
+			name:    "localhost without port",
+			rawURL:  "http://localhost",
+			runtime: "docker",
+			want:    "http://host.docker.internal",
+		},
+		{
+			name:    "invalid unchanged",
+			rawURL:  "://not-a-url",
+			runtime: "docker",
+			want:    "://not-a-url",
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := containerURLForRuntime(tt.rawURL, tt.runtime); got != tt.want {
+				t.Fatalf("containerURLForRuntime(%q, %q) = %q, want %q", tt.rawURL, tt.runtime, got, tt.want)
+			}
+		})
+	}
+}
+
+func TestLaunchSandboxRejectsAgentWithoutBinary(t *testing.T) {
+	_, err := launchSandbox(nil, SandboxLaunchPlan{Runtime: "docker", Image: "image:test"}, LaunchConfig{
+		Agent: emptyBinaryAgent{},
+	}, nil)
+	if err == nil {
+		t.Fatal("expected missing container command error")
+	}
+}

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -196,7 +196,7 @@ func TestLaunch_AgentMCPArgs_Appended(t *testing.T) {
 	}
 }
 
-func TestLaunch_SandboxBYOImageEnvVarsFlowThrough(t *testing.T) {
+func TestLaunch_SandboxBYOImageRunsContainer(t *testing.T) {
 	dir := t.TempDir()
 	devcontainerDir := filepath.Join(dir, ".devcontainer")
 	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
@@ -206,39 +206,45 @@ func TestLaunch_SandboxBYOImageEnvVarsFlowThrough(t *testing.T) {
 		t.Fatal(err)
 	}
 
-	outFile := filepath.Join(dir, "env.txt")
-	script := filepath.Join(dir, "capture.sh")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\nenv > "+outFile+"\n"), 0o755); err != nil {
+	binDir := t.TempDir()
+	argsFile := filepath.Join(dir, "docker-args.txt")
+	docker := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+argsFile+"\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
-		Agent:          scriptAgent{script: script},
+		Agent:          scriptAgent{script: "codex"},
 		Dir:            dir,
+		Args:           []string{"--ask-for-approval", "never"},
 		SandboxRuntime: "auto",
 	})
 	if err != nil {
 		t.Fatalf("launch: %v", err)
 	}
-	data, err := os.ReadFile(outFile)
+	data, err := os.ReadFile(argsFile)
 	if err != nil {
-		t.Fatalf("read env: %v", err)
+		t.Fatalf("read docker args: %v", err)
 	}
-	env := string(data)
+	args := string(data)
 	for _, want := range []string{
-		"AILERON_SANDBOX_IMAGE=ghcr.io/acme/agent:latest",
-		"AILERON_SANDBOX_TIER=byo_image",
+		"run\n",
+		"--workdir\n/home/agent/workspace\n",
+		"--volume\n" + dir + ":/home/agent/workspace\n",
+		"--env\nAILERON_SANDBOX_IMAGE=ghcr.io/acme/agent:latest\n",
+		"--env\nAILERON_SANDBOX_TIER=byo_image\n",
+		"--env\nAILERON_SANDBOX_RUNTIME=docker\n",
+		"--env\nAILERON_URL=http://host.docker.internal:",
+		"ghcr.io/acme/agent:latest\ncodex\n--ask-for-approval\nnever\n",
 	} {
-		if !strings.Contains(env, want) {
-			t.Errorf("expected %q in child env:\n%s", want, env)
+		if !strings.Contains(args, want) {
+			t.Errorf("expected %q in docker args:\n%s", want, args)
 		}
-	}
-	if strings.Contains(env, "AILERON_SANDBOX_RUNTIME=") {
-		t.Errorf("BYO image should not report a build runtime:\n%s", env)
 	}
 }
 
-func TestLaunch_SandboxBuildEnvVarsFlowThrough(t *testing.T) {
+func TestLaunch_SandboxBuildRunsPreparedImage(t *testing.T) {
 	dir := t.TempDir()
 	baseDir := filepath.Join(dir, "images", "sandbox-base")
 	if err := os.MkdirAll(baseDir, 0o755); err != nil {
@@ -248,38 +254,37 @@ func TestLaunch_SandboxBuildEnvVarsFlowThrough(t *testing.T) {
 		t.Fatal(err)
 	}
 	binDir := t.TempDir()
+	argsFile := filepath.Join(dir, "docker-args.txt")
 	docker := filepath.Join(binDir, "docker")
-	if err := os.WriteFile(docker, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" >> "+argsFile+"\nprintf '%s\\n' --- >> "+argsFile+"\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
-	outFile := filepath.Join(dir, "env.txt")
-	script := filepath.Join(dir, "capture.sh")
-	if err := os.WriteFile(script, []byte("#!/bin/sh\nenv > "+outFile+"\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-
 	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
-		Agent:          scriptAgent{script: script},
+		Agent:          scriptAgent{script: "claude"},
 		Dir:            dir,
+		Args:           []string{"--dangerously-skip-permissions"},
 		SandboxRuntime: "docker",
 	})
 	if err != nil {
 		t.Fatalf("launch: %v", err)
 	}
-	data, err := os.ReadFile(outFile)
+	data, err := os.ReadFile(argsFile)
 	if err != nil {
-		t.Fatalf("read env: %v", err)
+		t.Fatalf("read docker args: %v", err)
 	}
-	env := string(data)
+	args := string(data)
 	for _, want := range []string{
-		"AILERON_SANDBOX_IMAGE=aileron/sandbox-base:latest",
-		"AILERON_SANDBOX_TIER=base",
-		"AILERON_SANDBOX_RUNTIME=docker",
+		"build\n-t\naileron/sandbox-base:latest\n",
+		"run\n--rm\n-i\n",
+		"--env\nAILERON_SANDBOX_IMAGE=aileron/sandbox-base:latest\n",
+		"--env\nAILERON_SANDBOX_TIER=base\n",
+		"--env\nAILERON_SANDBOX_RUNTIME=docker\n",
+		"aileron/sandbox-base:latest\nclaude\n--dangerously-skip-permissions\n",
 	} {
-		if !strings.Contains(env, want) {
-			t.Errorf("expected %q in child env:\n%s", want, env)
+		if !strings.Contains(args, want) {
+			t.Errorf("expected %q in docker args:\n%s", want, args)
 		}
 	}
 }

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -1,4 +1,4 @@
-// Package container builds sandbox container images from composition plans.
+// Package container builds and runs sandbox container images from composition plans.
 package container
 
 import (
@@ -18,6 +18,7 @@ import (
 )
 
 const DefaultRuntime = "auto"
+const WorkspacePath = "/home/agent/workspace"
 
 var ErrNoBuildRequired = errors.New("sandbox image does not require a build")
 
@@ -31,6 +32,7 @@ type execRunner struct{}
 
 func (execRunner) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
 	cmd := exec.CommandContext(ctx, name, args...)
+	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
 	return cmd.Run()
@@ -57,6 +59,21 @@ type BuildResult struct {
 	Image   string
 	Built   bool
 	Tier    composition.Tier
+}
+
+// RunOptions configures one sandbox container execution.
+type RunOptions struct {
+	Runtime string
+	Image   string
+	WorkDir string
+	Env     map[string]string
+	Command []string
+	TTY     bool
+}
+
+// RunResult reports the selected runtime after a sandbox container exits.
+type RunResult struct {
+	Runtime string
 }
 
 // Build builds the image for plan. Tier 0 builds Aileron's local sandbox-base
@@ -131,6 +148,40 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 	}
 }
 
+// Run starts a one-shot sandbox container for an agent command.
+func (b Builder) Run(ctx context.Context, opts RunOptions) (RunResult, error) {
+	if opts.Image == "" {
+		return RunResult{}, fmt.Errorf("sandbox image is required")
+	}
+	if len(opts.Command) == 0 || strings.TrimSpace(opts.Command[0]) == "" {
+		return RunResult{}, fmt.Errorf("sandbox command is required")
+	}
+	runner := b.Runner
+	if runner == nil {
+		runner = execRunner{}
+	}
+	stdout := b.Stdout
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	stderr := b.Stderr
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	runtimeName, err := resolveRuntime(firstNonEmpty(opts.Runtime, b.Runtime), b.Runner == nil)
+	if err != nil {
+		return RunResult{}, err
+	}
+	args, err := runArgs(opts)
+	if err != nil {
+		return RunResult{}, err
+	}
+	if err := runner.Run(ctx, runtimeName, args, stdout, stderr); err != nil {
+		return RunResult{}, err
+	}
+	return RunResult{Runtime: runtimeName}, nil
+}
+
 // ResolveRuntime returns the container runtime executable to use.
 func ResolveRuntime(name string) (string, error) {
 	return resolveRuntime(name, true)
@@ -160,6 +211,45 @@ func resolveRuntime(name string, checkPath bool) (string, error) {
 		}
 		return "", fmt.Errorf("unsupported sandbox runtime %q (want auto, docker, or podman)", name)
 	}
+}
+
+func runArgs(opts RunOptions) ([]string, error) {
+	workDir := opts.WorkDir
+	if workDir == "" {
+		workDir = "."
+	}
+	absWorkDir, err := filepath.Abs(workDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox workdir: %w", err)
+	}
+	args := []string{"run", "--rm", "-i"}
+	if opts.TTY {
+		args = append(args, "-t")
+	}
+	args = append(args,
+		"--workdir", WorkspacePath,
+		"--volume", absWorkDir+":"+WorkspacePath,
+	)
+	keys := make([]string, 0, len(opts.Env))
+	for k := range opts.Env {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	for _, k := range keys {
+		args = append(args, "--env", k+"="+opts.Env[k])
+	}
+	args = append(args, opts.Image)
+	args = append(args, opts.Command...)
+	return args, nil
+}
+
+func firstNonEmpty(values ...string) string {
+	for _, value := range values {
+		if strings.TrimSpace(value) != "" {
+			return value
+		}
+	}
+	return ""
 }
 
 // ProjectImageTag returns the deterministic local image tag for a project.

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -296,6 +296,71 @@ func TestBuilderStreamsRuntimeOutput(t *testing.T) {
 	}
 }
 
+func TestRunMountsWorkspaceAndExecutesCommand(t *testing.T) {
+	dir := t.TempDir()
+	runner := &recordingRunner{}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:   "aileron/sandbox-base:test",
+		WorkDir: dir,
+		Env: map[string]string{
+			"Z_VAR": "last",
+			"A_VAR": "first",
+		},
+		Command: []string{"codex", "--model", "gpt-5"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if result.Runtime != "docker" {
+		t.Fatalf("runtime = %q, want docker", result.Runtime)
+	}
+	want := []string{
+		"run", "--rm", "-i",
+		"--workdir", WorkspacePath,
+		"--volume", dir + ":" + WorkspacePath,
+		"--env", "A_VAR=first",
+		"--env", "Z_VAR=last",
+		"aileron/sandbox-base:test",
+		"codex", "--model", "gpt-5",
+	}
+	if runner.name != "docker" || !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("runner = %s %#v, want docker %#v", runner.name, runner.args, want)
+	}
+}
+
+func TestRunAddsTTYWhenRequested(t *testing.T) {
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "podman", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:   "aileron/sandbox-base:test",
+		Command: []string{"claude"},
+		TTY:     true,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if !reflect.DeepEqual(runner.args[:4], []string{"run", "--rm", "-i", "-t"}) {
+		t.Fatalf("args prefix = %#v, want tty run prefix", runner.args[:4])
+	}
+}
+
+func TestRunRejectsMissingImage(t *testing.T) {
+	_, err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Run(context.Background(), RunOptions{
+		Command: []string{"codex"},
+	})
+	if err == nil {
+		t.Fatal("expected missing image error")
+	}
+}
+
+func TestRunRejectsMissingCommand(t *testing.T) {
+	_, err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Run(context.Background(), RunOptions{
+		Image: "aileron/sandbox-base:test",
+	})
+	if err == nil {
+		t.Fatal("expected missing command error")
+	}
+}
+
 type runnerFunc func(context.Context, string, []string, io.Writer, io.Writer) error
 
 func (f runnerFunc) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {


### PR DESCRIPTION
## Summary

Continues #796 after PR #869 by making `aileron launch --sandbox=auto|docker|podman` consume the prepared sandbox image for actual container execution.

This PR adds the narrow runtime execution contract needed for the next sandbox slice:

- adds a testable Docker/Podman `run` path in `internal/sandbox/container`
- mounts the project at `/home/agent/workspace` and uses that as the container working directory
- runs the agent command inside the selected image for sandbox launches
- preserves the existing direct host launch path for `--sandbox=off`
- passes session-scoped Aileron env into the container and rewrites loopback daemon URLs to the runtime host alias
- keeps sandbox launch off the old `aileron-mcp` host-launch model; runtime injection, discovery watcher, proxy bootstrap, and shell interception remain follow-on work
- updates ADR/docs/CLI reference to describe the new minimal execution path

## Validation

- `go test ./internal/sandbox/container`
- `go test ./internal/launch`
- `go test ./cmd/aileron ./internal/launch ./internal/sandbox/...`
- `pnpm run check` in `docs/`

## Follow-on work

Still remaining in #796 before #801:

- BYO runtime injection and launch-time validation
- discovery watcher and `tools.txt` refresh
- cache/rebuild policy around launch consumption
- proxy bootstrap/session CA wiring
- multi-arch `aileron/sandbox-base:<version>` publishing