### PR TITLE
[codex] Validate sandbox launch images

### DIFF
--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -70,9 +70,9 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 `aileron sandbox plan` is an inspection helper that reports the normalized tier/image/dockerfile plan.
 
-`aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is until runtime injection and launch-time validation land. Later launch work consumes the same composition contract and built image selection.
+`aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is; launch validates the minimal runtime contract before running the agent. Later launch work adds runtime injection.
 
-`aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image, then runs the agent command inside a one-shot Docker/Podman container. The project is mounted at `/home/agent/workspace` and used as the container working directory. Launch passes the session-scoped Aileron daemon env into the container and rewrites loopback daemon URLs to the runtime host alias (`host.docker.internal` for Docker, `host.containers.internal` for Podman).
+`aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image, validates that it can execute `/bin/sh`, use a writable `/home/agent/workspace` mount, and resolve the agent command on `PATH`, then runs the agent command inside a one-shot Docker/Podman container. The project is mounted at `/home/agent/workspace` and used as the container working directory. Launch passes the session-scoped Aileron daemon env into the container and rewrites loopback daemon URLs to the runtime host alias (`host.docker.internal` for Docker, `host.containers.internal` for Podman).
 
 ## Consequences
 

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -102,7 +102,7 @@ Build behavior by tier:
 |---|---|
 | Tier 0 | Builds the local `images/sandbox-base/Containerfile` as `aileron/sandbox-base:<version>`. |
 | Tier 1 | Builds the devcontainer Dockerfile and tags it as a deterministic local `aileron/sandbox-project:<hash>` image unless `--tag` is supplied. |
-| Tier 2 | Does not build. The BYO image is reported as-is; runtime injection and launch-time validation land later. |
+| Tier 2 | Does not build. The BYO image is reported as-is; launch validates it before agent startup. |
 
 When building the base image outside the source tree, set `AILERON_SANDBOX_BASE_CONTEXT` to the directory containing the sandbox-base `Containerfile`.
 
@@ -119,6 +119,13 @@ aileron launch --sandbox=podman goose
 `auto` detects Docker or Podman from `PATH`. `docker` and `podman` select a runtime explicitly. The default is `--sandbox=off`, which preserves the current direct host launch path.
 
 The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
+
+Before registering the session, launch validates the selected image with the same mount/workdir shape it will use for the agent. The image must:
+
+- execute `/bin/sh` commands through the selected container runtime
+- use `/home/agent/workspace` as the working directory
+- allow a temporary file to be written in the mounted workspace
+- resolve the agent command on `PATH`
 
 The agent command must already exist in the selected image. For Tier 1, install the agent CLI in your devcontainer Dockerfile. Tier 2 uses the BYO image as supplied until runtime injection lands.
 
@@ -148,4 +155,4 @@ Do not put Aileron credentials or user secrets in the image. Credentialed traffi
 
 ## What This Does Not Do Yet
 
-This slice does not inject runtime files into BYO images, generate discovery shims, or mediate shell commands. Follow-on work adds BYO runtime injection and validation, the discovery watcher, proxy bootstrap, and shell-layer interception.
+This slice does not inject runtime files into BYO images, generate discovery shims, add proxy bootstrap, or mediate shell commands. Follow-on work adds runtime injection, the discovery watcher, proxy bootstrap, and shell-layer interception.

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -172,6 +172,27 @@ func prepareSandbox(ctx context.Context, workDir, runtimeName string, stdout, st
 
 var prepareSandboxForLaunch = prepareSandbox
 
+func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig) error {
+	commandName := firstAgentBinary(config.Agent)
+	if commandName == "" {
+		return fmt.Errorf("agent %q has no container command", config.Agent.Name())
+	}
+	if err := (sandboxcontainer.Builder{
+		Runtime: plan.Runtime,
+		Stdout:  io.Discard,
+	}).Validate(ctx, sandboxcontainer.ValidateOptions{
+		Runtime: plan.Runtime,
+		Image:   plan.Image,
+		WorkDir: config.Dir,
+		Command: []string{commandName},
+	}); err != nil {
+		return fmt.Errorf("sandbox image %s is not launchable for %s: %w", plan.Image, config.Agent.Name(), err)
+	}
+	return nil
+}
+
+var validateSandboxForLaunch = validateSandbox
+
 // Launch starts the agent as a child process under Aileron's daemon.
 //
 // Per ADR-0015 the launcher is the daemon-connection + MCP-registration
@@ -228,6 +249,9 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 			fmt.Fprint(os.Stderr, ", built=true")
 		}
 		fmt.Fprintln(os.Stderr, ")")
+		if err := validateSandboxForLaunch(ctx, sandboxPlan, config); err != nil {
+			return LaunchResult{}, err
+		}
 	}
 
 	regCtx, cancelReg := context.WithTimeout(ctx, daemonHTTPTimeout)

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -88,3 +88,12 @@ func TestLaunchSandboxRejectsAgentWithoutBinary(t *testing.T) {
 		t.Fatal("expected missing container command error")
 	}
 }
+
+func TestValidateSandboxRejectsAgentWithoutBinary(t *testing.T) {
+	err := validateSandbox(nil, SandboxLaunchPlan{Runtime: "docker", Image: "image:test"}, LaunchConfig{
+		Agent: emptyBinaryAgent{},
+	})
+	if err == nil {
+		t.Fatal("expected missing container command error")
+	}
+}

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -327,6 +327,51 @@ func TestLaunch_SandboxBuildFailureFailsBeforeAgentStart(t *testing.T) {
 	}
 }
 
+func TestLaunch_SandboxValidationFailureFailsBeforeAgentRun(t *testing.T) {
+	dir := t.TempDir()
+	devcontainerDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(`{"customizations":{"aileron":{"image":"ghcr.io/acme/agent:latest"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	argsFile := filepath.Join(dir, "docker-args.txt")
+	docker := filepath.Join(binDir, "docker")
+	script := "#!/bin/sh\nprintf '%s\\n' \"$@\" > " + argsFile + "\necho 'agent command not found in sandbox image: codex' >&2\nexit 127\n"
+	if err := os.WriteFile(docker, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:          scriptAgent{script: "codex"},
+		Dir:            dir,
+		SandboxRuntime: "docker",
+	})
+	if err == nil {
+		t.Fatal("expected sandbox validation failure")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"sandbox image ghcr.io/acme/agent:latest is not launchable for test-script",
+		"agent command not found in sandbox image: codex",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+	data, readErr := os.ReadFile(argsFile)
+	if readErr != nil {
+		t.Fatalf("read docker args: %v", readErr)
+	}
+	if strings.Contains(string(data), "ghcr.io/acme/agent:latest\ncodex\n") {
+		t.Fatalf("agent run happened despite validation failure:\n%s", data)
+	}
+}
+
 func TestLaunch_SandboxInvalidRuntimeFails(t *testing.T) {
 	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
 		Agent:          scriptAgent{script: "/bin/sh"},

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -2,6 +2,7 @@
 package container
 
 import (
+	"bytes"
 	"context"
 	"crypto/sha256"
 	"encoding/hex"
@@ -74,6 +75,14 @@ type RunOptions struct {
 // RunResult reports the selected runtime after a sandbox container exits.
 type RunResult struct {
 	Runtime string
+}
+
+// ValidateOptions configures a launch-time sandbox image validation run.
+type ValidateOptions struct {
+	Runtime string
+	Image   string
+	WorkDir string
+	Command []string
 }
 
 // Build builds the image for plan. Tier 0 builds Aileron's local sandbox-base
@@ -181,6 +190,61 @@ func (b Builder) Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 	}
 	return RunResult{Runtime: runtimeName}, nil
 }
+
+// Validate checks that an image can satisfy the minimal launch-time sandbox
+// runtime contract: shell command execution, the mounted workspace as CWD, a
+// writable workspace mount, and the requested agent command on PATH.
+func (b Builder) Validate(ctx context.Context, opts ValidateOptions) error {
+	if opts.Image == "" {
+		return fmt.Errorf("sandbox image is required")
+	}
+	if len(opts.Command) == 0 || strings.TrimSpace(opts.Command[0]) == "" {
+		return fmt.Errorf("sandbox command is required")
+	}
+	var stderr bytes.Buffer
+	builder := b
+	if builder.Stderr == nil {
+		builder.Stderr = &stderr
+	}
+	_, err := builder.Run(ctx, RunOptions{
+		Runtime: opts.Runtime,
+		Image:   opts.Image,
+		WorkDir: opts.WorkDir,
+		Command: []string{
+			"/bin/sh",
+			"-c",
+			validationScript,
+			"aileron-validate",
+			opts.Command[0],
+		},
+	})
+	if err == nil {
+		return nil
+	}
+	detail := strings.TrimSpace(stderr.String())
+	if detail != "" {
+		return fmt.Errorf("validate sandbox image %s: %s: %w", opts.Image, detail, err)
+	}
+	return fmt.Errorf("validate sandbox image %s: image must support /bin/sh command execution, a writable %s workspace mount, and agent command %q on PATH: %w", opts.Image, WorkspacePath, opts.Command[0], err)
+}
+
+const validationScript = `
+if [ "$(pwd)" != "` + WorkspacePath + `" ]; then
+  echo "sandbox working directory is $(pwd), want ` + WorkspacePath + `" >&2
+  exit 2
+fi
+probe=".aileron-sandbox-validate-$$"
+if ! ( : > "$probe" ) 2>/dev/null; then
+  echo "sandbox workspace is not writable at ` + WorkspacePath + `" >&2
+  exit 3
+fi
+rm -f "$probe"
+if ! command -v "$1" >/dev/null 2>&1; then
+  echo "agent command not found in sandbox image: $1" >&2
+  echo "install the agent CLI in the sandbox image or launch with --sandbox=off" >&2
+  exit 127
+fi
+`
 
 // ResolveRuntime returns the container runtime executable to use.
 func ResolveRuntime(name string) (string, error) {

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -3,11 +3,13 @@ package container
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
 	"os"
 	"path/filepath"
 	"reflect"
 	"runtime"
+	"strings"
 	"testing"
 
 	"github.com/ALRubinger/aileron/internal/sandbox/composition"
@@ -358,6 +360,107 @@ func TestRunRejectsMissingCommand(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatal("expected missing command error")
+	}
+}
+
+func TestValidateRunsMinimalContractProbe(t *testing.T) {
+	dir := t.TempDir()
+	runner := &recordingRunner{}
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Image:   "ghcr.io/acme/agent:latest",
+		WorkDir: dir,
+		Command: []string{"codex"},
+	})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if runner.name != "docker" {
+		t.Fatalf("runtime = %q, want docker", runner.name)
+	}
+	wantPrefix := []string{
+		"run", "--rm", "-i",
+		"--workdir", WorkspacePath,
+		"--volume", dir + ":" + WorkspacePath,
+		"ghcr.io/acme/agent:latest",
+		"/bin/sh", "-c",
+	}
+	if len(runner.args) < len(wantPrefix)+2 {
+		t.Fatalf("args too short: %#v", runner.args)
+	}
+	if !reflect.DeepEqual(runner.args[:len(wantPrefix)], wantPrefix) {
+		t.Fatalf("args prefix = %#v, want %#v", runner.args[:len(wantPrefix)], wantPrefix)
+	}
+	if runner.args[len(runner.args)-1] != "codex" {
+		t.Fatalf("validation command = %q, want codex", runner.args[len(runner.args)-1])
+	}
+}
+
+func TestValidateReportsActionableRuntimeFailure(t *testing.T) {
+	runner := runnerFunc(func(_ context.Context, _ string, _ []string, _, stderr io.Writer) error {
+		_, _ = stderr.Write([]byte("agent command not found in sandbox image: codex\n"))
+		return errors.New("exit status 127")
+	})
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Image:   "ghcr.io/acme/agent:latest",
+		WorkDir: t.TempDir(),
+		Command: []string{"codex"},
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"validate sandbox image ghcr.io/acme/agent:latest",
+		"agent command not found in sandbox image: codex",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestValidateRejectsMissingImage(t *testing.T) {
+	err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Validate(context.Background(), ValidateOptions{
+		Command: []string{"codex"},
+	})
+	if err == nil {
+		t.Fatal("expected missing image error")
+	}
+}
+
+func TestValidateRejectsMissingCommand(t *testing.T) {
+	err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Validate(context.Background(), ValidateOptions{
+		Image: "ghcr.io/acme/agent:latest",
+	})
+	if err == nil {
+		t.Fatal("expected missing command error")
+	}
+}
+
+func TestValidateReportsFallbackWhenRuntimeHasNoDetail(t *testing.T) {
+	runner := runnerFunc(func(context.Context, string, []string, io.Writer, io.Writer) error {
+		return errors.New("exit status 126")
+	})
+	err := Builder{
+		Runtime: "docker",
+		Runner:  runner,
+		Stderr:  io.Discard,
+	}.Validate(context.Background(), ValidateOptions{
+		Image:   "ghcr.io/acme/agent:latest",
+		WorkDir: t.TempDir(),
+		Command: []string{"codex"},
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"image must support /bin/sh command execution",
+		"agent command \"codex\" on PATH",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary

Continues #796 after PR #870 by adding launch-time validation for the minimal sandbox runtime contract before Aileron starts the agent container.

This PR keeps scope narrow:

- adds `internal/sandbox/container` validation that runs through the selected Docker/Podman runtime
- validates `/bin/sh` command execution, `/home/agent/workspace` as CWD, a writable workspace mount, and the requested agent command on `PATH`
- runs validation after image preparation and before session registration / agent startup
- returns actionable errors for non-launchable BYO or devcontainer images
- updates sandbox docs and ADR-0017 to describe current validation behavior

Out of scope here:

- BYO runtime file injection
- discovery watcher / `tools.txt` refresh
- proxy bootstrap and session CA wiring
- shell interception (#801)

## Validation

- `go test ./internal/sandbox/container`
- `go test ./internal/launch`
- `go test ./cmd/aileron ./internal/launch ./internal/sandbox/...`
- `pnpm run check` in `docs/`

## Follow-on work

Still remaining for #796 before #801:

- runtime injection for BYO images
- discovery watcher and `/etc/aileron/tools.txt` refresh
- cache/rebuild policy around launch consumption
- proxy bootstrap/session CA wiring
- multi-arch `aileron/sandbox-base:<version>` publishing