### PR TITLE
[codex] Add sandbox launch build policy

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -85,13 +85,14 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		launchFlags.SetOutput(stderr)
 		logLevel := launchFlags.String("log-level", "info", "Log level: trace, debug, info, warn, error")
 		sandboxRuntime := launchFlags.String("sandbox", "off", "Prepare sandbox image with runtime: off, auto, docker, or podman")
+		sandboxBuild := launchFlags.String("sandbox-build", "auto", "Sandbox build policy during launch: auto, always, or never")
 		if err := launchFlags.Parse(args[1:]); err != nil {
 			return 1
 		}
 		launchArgs := launchFlags.Args()
 
 		if len(launchArgs) < 1 {
-			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] [--sandbox=off|auto|docker|podman] <agent> [args...]")
+			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] [--sandbox=off|auto|docker|podman] [--sandbox-build=auto|always|never] <agent> [args...]")
 			fmt.Fprintf(stderr, "agents: %s\n", strings.Join(registry.Names(), ", "))
 			return 1
 		}
@@ -110,11 +111,12 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		cwd, _ := os.Getwd()
 
 		result, err := launchFn(context.Background(), launch.LaunchConfig{
-			Agent:          agent,
-			Args:           launchArgs[1:],
-			Dir:            cwd,
-			LogLevel:       launch.ParseLogLevel(*logLevel),
-			SandboxRuntime: *sandboxRuntime,
+			Agent:              agent,
+			Args:               launchArgs[1:],
+			Dir:                cwd,
+			LogLevel:           launch.ParseLogLevel(*logLevel),
+			SandboxRuntime:     *sandboxRuntime,
+			SandboxBuildPolicy: *sandboxBuild,
 		})
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %v\n", err)
@@ -168,7 +170,7 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "aileron — the execution layer for AI coding agents")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "usage:")
-	fmt.Fprintln(w, "  aileron launch [--sandbox=<runtime>] <agent> [args...]")
+	fmt.Fprintln(w, "  aileron launch [--sandbox=<runtime>] [--sandbox-build=<policy>] <agent> [args...]")
 	fmt.Fprintln(w, "                                      Launch an AI coding agent connected to the Aileron daemon")
 	fmt.Fprintln(w, "  aileron vault init                 Create the local encrypted vault with a passphrase")
 	fmt.Fprintln(w, "  aileron secret set <name>          Store a secret in the encrypted vault")

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -145,7 +145,7 @@ func TestRun_LaunchPopulatesWorkingDir(t *testing.T) {
 	}
 }
 
-func TestRun_LaunchPassesSandboxRuntime(t *testing.T) {
+func TestRun_LaunchPassesSandboxOptions(t *testing.T) {
 	origLaunch := launchFn
 	t.Cleanup(func() {
 		launchFn = origLaunch
@@ -158,12 +158,15 @@ func TestRun_LaunchPassesSandboxRuntime(t *testing.T) {
 	}
 
 	var stdout, stderr bytes.Buffer
-	code := run([]string{"launch", "--sandbox=docker", "claude"}, newTestRegistry(), &stdout, &stderr)
+	code := run([]string{"launch", "--sandbox=docker", "--sandbox-build=never", "claude"}, newTestRegistry(), &stdout, &stderr)
 	if code != 0 {
 		t.Fatalf("expected exit code 0, got %d (stderr=%q)", code, stderr.String())
 	}
 	if captured.SandboxRuntime != "docker" {
 		t.Errorf("LaunchConfig.SandboxRuntime = %q, want docker", captured.SandboxRuntime)
+	}
+	if captured.SandboxBuildPolicy != "never" {
+		t.Errorf("LaunchConfig.SandboxBuildPolicy = %q, want never", captured.SandboxBuildPolicy)
 	}
 }
 

--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -74,6 +74,8 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 `aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image, validates that it can execute `/bin/sh`, use a writable `/home/agent/workspace` mount, and resolve the agent command on `PATH`, then runs the agent command inside a one-shot Docker/Podman container. The project is mounted at `/home/agent/workspace` and used as the container working directory. Launch passes the session-scoped Aileron daemon env into the container and rewrites loopback daemon URLs to the runtime host alias (`host.docker.internal` for Docker, `host.containers.internal` for Podman).
 
+Launch build behavior is controlled by `--sandbox-build=auto|always|never`. `auto` is the default and builds Tier 0/Tier 1 images only when the selected local image is missing. `always` forces a rebuild. `never` fails if the selected image is not already present. The explicit `aileron sandbox build` command keeps its manual-build behavior.
+
 ## Consequences
 
 Users with existing devcontainers get an upgrade path rather than a parallel Aileron-only config file.

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -14,7 +14,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 
 | Command | Purpose | Ratified by |
 |---|---|---|
-| `aileron launch [--sandbox=off\|auto\|docker\|podman]` | Launch an AI coding agent connected to the Aileron daemon. `--sandbox` prepares the project sandbox image and runs the agent command inside it; `off` preserves direct host launch. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron launch [--sandbox=off\|auto\|docker\|podman] [--sandbox-build=auto\|always\|never]` | Launch an AI coding agent connected to the Aileron daemon. `--sandbox` prepares the project sandbox image and runs the agent command inside it; `off` preserves direct host launch. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron status` | Report the running runtime: version, listen address, action count, connector count, binding count, vault state. Read-only; safe to run frequently. | — |
 
 ## Sandbox composition

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -118,6 +118,23 @@ aileron launch --sandbox=podman goose
 
 `auto` detects Docker or Podman from `PATH`. `docker` and `podman` select a runtime explicitly. The default is `--sandbox=off`, which preserves the current direct host launch path.
 
+Launch uses `--sandbox-build=auto` by default. Build policy options are:
+
+| Policy | Behavior |
+|---|---|
+| `auto` | Use the selected image if it already exists locally; build Tier 0/Tier 1 images only when missing. |
+| `always` | Rebuild Tier 0/Tier 1 images before validation and launch. |
+| `never` | Do not build; fail with an actionable error if the selected image is missing locally. |
+
+Examples:
+
+```bash
+aileron launch --sandbox=docker --sandbox-build=always claude
+aileron launch --sandbox=podman --sandbox-build=never codex
+```
+
+`aileron sandbox build` remains the explicit manual build command and always invokes the selected runtime build for Tier 0/Tier 1.
+
 The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
 
 Before registering the session, launch validates the selected image with the same mount/workdir shape it will use for the agent. The image must:

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -49,6 +49,9 @@ type LaunchConfig struct {
 	// prepare the composition-selected image and execute the agent in a
 	// one-shot container.
 	SandboxRuntime string
+	// SandboxBuildPolicy controls launch-time builds for buildable
+	// sandbox tiers. Empty defaults to auto for launch.
+	SandboxBuildPolicy string
 }
 
 // LaunchResult holds the outcome of a launched agent process.
@@ -132,8 +135,24 @@ func validateSandboxRuntime(runtimeName string) error {
 	}
 }
 
-func prepareSandbox(ctx context.Context, workDir, runtimeName string, stdout, stderr io.Writer) (SandboxLaunchPlan, error) {
+func normalizeLaunchBuildPolicy(policy string) (string, error) {
+	normalized := strings.TrimSpace(policy)
+	switch normalized {
+	case "":
+		return sandboxcontainer.BuildPolicyAuto, nil
+	case sandboxcontainer.BuildPolicyAuto, sandboxcontainer.BuildPolicyAlways, sandboxcontainer.BuildPolicyNever:
+		return normalized, nil
+	default:
+		return "", fmt.Errorf("unsupported sandbox build policy %q (want auto, always, or never)", normalized)
+	}
+}
+
+func prepareSandbox(ctx context.Context, workDir, runtimeName, buildPolicy string, stdout, stderr io.Writer) (SandboxLaunchPlan, error) {
 	if err := validateSandboxRuntime(runtimeName); err != nil {
+		return SandboxLaunchPlan{}, err
+	}
+	policy, err := normalizeLaunchBuildPolicy(buildPolicy)
+	if err != nil {
 		return SandboxLaunchPlan{}, err
 	}
 	plan, err := sandboxcomposition.Discover(workDir, version.Version)
@@ -147,6 +166,7 @@ func prepareSandbox(ctx context.Context, workDir, runtimeName string, stdout, st
 	}.Build(ctx, sandboxcontainer.BuildOptions{
 		WorkDir: workDir,
 		Plan:    plan,
+		Policy:  policy,
 	})
 	if errors.Is(err, sandboxcontainer.ErrNoBuildRequired) {
 		runtime, runtimeErr := sandboxcontainer.ResolveRuntime(runtimeName)
@@ -236,7 +256,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	sandboxEnabled := sandboxLaunchEnabled(config.SandboxRuntime)
 	var sandboxPlan SandboxLaunchPlan
 	if sandboxEnabled {
-		plan, err := prepareSandboxForLaunch(ctx, config.Dir, config.SandboxRuntime, os.Stdout, os.Stderr)
+		plan, err := prepareSandboxForLaunch(ctx, config.Dir, config.SandboxRuntime, config.SandboxBuildPolicy, os.Stdout, os.Stderr)
 		if err != nil {
 			return LaunchResult{}, fmt.Errorf("prepare sandbox: %w", err)
 		}

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -97,3 +97,24 @@ func TestValidateSandboxRejectsAgentWithoutBinary(t *testing.T) {
 		t.Fatal("expected missing container command error")
 	}
 }
+
+func TestNormalizeLaunchBuildPolicy(t *testing.T) {
+	tests := map[string]string{
+		"":       "auto",
+		" auto ": "auto",
+		"always": "always",
+		"never":  "never",
+	}
+	for input, want := range tests {
+		got, err := normalizeLaunchBuildPolicy(input)
+		if err != nil {
+			t.Fatalf("normalizeLaunchBuildPolicy(%q): %v", input, err)
+		}
+		if got != want {
+			t.Fatalf("normalizeLaunchBuildPolicy(%q) = %q, want %q", input, got, want)
+		}
+	}
+	if _, err := normalizeLaunchBuildPolicy("sometimes"); err == nil {
+		t.Fatal("expected unsupported build policy error")
+	}
+}

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -262,10 +262,11 @@ func TestLaunch_SandboxBuildRunsPreparedImage(t *testing.T) {
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
-		Agent:          scriptAgent{script: "claude"},
-		Dir:            dir,
-		Args:           []string{"--dangerously-skip-permissions"},
-		SandboxRuntime: "docker",
+		Agent:              scriptAgent{script: "claude"},
+		Dir:                dir,
+		Args:               []string{"--dangerously-skip-permissions"},
+		SandboxRuntime:     "docker",
+		SandboxBuildPolicy: "always",
 	})
 	if err != nil {
 		t.Fatalf("launch: %v", err)
@@ -312,9 +313,10 @@ func TestLaunch_SandboxBuildFailureFailsBeforeAgentStart(t *testing.T) {
 	}
 
 	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
-		Agent:          scriptAgent{script: script},
-		Dir:            dir,
-		SandboxRuntime: "docker",
+		Agent:              scriptAgent{script: script},
+		Dir:                dir,
+		SandboxRuntime:     "docker",
+		SandboxBuildPolicy: "always",
 	})
 	if err == nil {
 		t.Fatal("expected sandbox build failure")
@@ -324,6 +326,36 @@ func TestLaunch_SandboxBuildFailureFailsBeforeAgentStart(t *testing.T) {
 	}
 	if _, statErr := os.Stat(outFile); !os.IsNotExist(statErr) {
 		t.Fatalf("agent started despite build failure; stat err=%v", statErr)
+	}
+}
+
+func TestLaunch_SandboxBuildNeverFailsBeforeAgentStart(t *testing.T) {
+	dir := t.TempDir()
+	baseDir := filepath.Join(dir, "images", "sandbox-base")
+	if err := os.MkdirAll(baseDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(baseDir, "Containerfile"), []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	binDir := t.TempDir()
+	docker := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nexit 1\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:              scriptAgent{script: "claude"},
+		Dir:                dir,
+		SandboxRuntime:     "docker",
+		SandboxBuildPolicy: "never",
+	})
+	if err == nil {
+		t.Fatal("expected missing image failure")
+	}
+	if !strings.Contains(err.Error(), "sandbox build policy is never") {
+		t.Fatalf("error = %v", err)
 	}
 }
 

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -23,6 +23,12 @@ const WorkspacePath = "/home/agent/workspace"
 
 var ErrNoBuildRequired = errors.New("sandbox image does not require a build")
 
+const (
+	BuildPolicyAlways = "always"
+	BuildPolicyAuto   = "auto"
+	BuildPolicyNever  = "never"
+)
+
 // Runner executes a container runtime command. It exists so build planning can
 // be tested without Docker or Podman on the host.
 type Runner interface {
@@ -52,6 +58,7 @@ type BuildOptions struct {
 	WorkDir string
 	Plan    composition.Plan
 	Tag     string
+	Policy  string
 }
 
 // BuildResult reports the image selected or built for launch.
@@ -111,6 +118,10 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 		image = opts.Plan.Image
 	}
 	result := BuildResult{Image: image, Tier: opts.Plan.Tier}
+	policy, err := normalizeBuildPolicy(opts.Policy)
+	if err != nil {
+		return BuildResult{}, err
+	}
 	switch opts.Plan.Tier {
 	case composition.TierBase:
 		runtimeName, err := resolveRuntime(b.Runtime, b.Runner == nil)
@@ -118,6 +129,13 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 			return BuildResult{}, err
 		}
 		result.Runtime = runtimeName
+		shouldBuild, err := b.shouldBuild(ctx, runner, runtimeName, image, policy)
+		if err != nil {
+			return BuildResult{}, err
+		}
+		if !shouldBuild {
+			return result, nil
+		}
 		args, err := baseBuildArgs(workDir, image)
 		if err != nil {
 			return BuildResult{}, err
@@ -140,6 +158,13 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 		if opts.Tag == "" {
 			result.Image = ProjectImageTag(workDir)
 		}
+		shouldBuild, err := b.shouldBuild(ctx, runner, runtimeName, result.Image, policy)
+		if err != nil {
+			return BuildResult{}, err
+		}
+		if !shouldBuild {
+			return result, nil
+		}
 		args, err := devcontainerBuildArgs(workDir, opts.Plan, result.Image)
 		if err != nil {
 			return BuildResult{}, err
@@ -155,6 +180,40 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 	default:
 		return BuildResult{}, fmt.Errorf("unsupported sandbox composition tier %q", opts.Plan.Tier)
 	}
+}
+
+func normalizeBuildPolicy(policy string) (string, error) {
+	normalized := strings.TrimSpace(policy)
+	switch normalized {
+	case "", BuildPolicyAlways:
+		return BuildPolicyAlways, nil
+	case BuildPolicyAuto:
+		return BuildPolicyAuto, nil
+	case BuildPolicyNever:
+		return BuildPolicyNever, nil
+	default:
+		return "", fmt.Errorf("unsupported sandbox build policy %q (want auto, always, or never)", normalized)
+	}
+}
+
+func (b Builder) shouldBuild(ctx context.Context, runner Runner, runtimeName, image, policy string) (bool, error) {
+	switch policy {
+	case BuildPolicyAlways:
+		return true, nil
+	case BuildPolicyAuto:
+		return !b.imageExists(ctx, runner, runtimeName, image), nil
+	case BuildPolicyNever:
+		if b.imageExists(ctx, runner, runtimeName, image) {
+			return false, nil
+		}
+		return false, fmt.Errorf("sandbox image %s not found locally and sandbox build policy is never; run `aileron sandbox build --runtime=%s` or use --sandbox-build=auto|always", image, runtimeName)
+	default:
+		return false, fmt.Errorf("unsupported sandbox build policy %q (want auto, always, or never)", policy)
+	}
+}
+
+func (b Builder) imageExists(ctx context.Context, runner Runner, runtimeName, image string) bool {
+	return runner.Run(ctx, runtimeName, []string{"image", "inspect", image}, io.Discard, io.Discard) == nil
 }
 
 // Run starts a one-shot sandbox container for an agent command.

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -26,6 +26,26 @@ func (r *recordingRunner) Run(_ context.Context, name string, args []string, _, 
 	return nil
 }
 
+type callRecordingRunner struct {
+	calls []runnerCall
+	errs  []error
+}
+
+type runnerCall struct {
+	name string
+	args []string
+}
+
+func (r *callRecordingRunner) Run(_ context.Context, name string, args []string, _, _ io.Writer) error {
+	r.calls = append(r.calls, runnerCall{name: name, args: append([]string(nil), args...)})
+	if len(r.errs) == 0 {
+		return nil
+	}
+	err := r.errs[0]
+	r.errs = r.errs[1:]
+	return err
+}
+
 func TestBuildBaseImageUsesLocalContainerfile(t *testing.T) {
 	dir := t.TempDir()
 	containerfile := filepath.Join(dir, "images", "sandbox-base", "Containerfile")
@@ -83,6 +103,130 @@ func TestBuildDevcontainerUsesProjectTagAndBuildArgs(t *testing.T) {
 	want := []string{"build", "-t", wantTag, "-f", dockerfile, "--build-arg", "A=first", "--build-arg", "Z=last", dir}
 	if !reflect.DeepEqual(runner.args, want) {
 		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestBuildBaseImageAutoSkipsExistingImage(t *testing.T) {
+	dir := t.TempDir()
+	containerfile := filepath.Join(dir, "images", "sandbox-base", "Containerfile")
+	if err := os.MkdirAll(filepath.Dir(containerfile), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(containerfile, []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Containerfile: %v", err)
+	}
+	runner := &callRecordingRunner{}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: dir,
+		Policy:  BuildPolicyAuto,
+		Plan: composition.Plan{
+			Tier:  composition.TierBase,
+			Image: "aileron/sandbox-base:test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if result.Built {
+		t.Fatalf("result.Built = true, want false")
+	}
+	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", "aileron/sandbox-base:test"}}}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestBuildBaseImageAutoBuildsMissingImage(t *testing.T) {
+	dir := t.TempDir()
+	containerfile := filepath.Join(dir, "images", "sandbox-base", "Containerfile")
+	if err := os.MkdirAll(filepath.Dir(containerfile), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(containerfile, []byte("FROM scratch\n"), 0o644); err != nil {
+		t.Fatalf("write Containerfile: %v", err)
+	}
+	runner := &callRecordingRunner{errs: []error{errors.New("missing"), nil}}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: dir,
+		Policy:  BuildPolicyAuto,
+		Plan: composition.Plan{
+			Tier:  composition.TierBase,
+			Image: "aileron/sandbox-base:test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if !result.Built {
+		t.Fatalf("result.Built = false, want true")
+	}
+	want := []runnerCall{
+		{name: "docker", args: []string{"image", "inspect", "aileron/sandbox-base:test"}},
+		{name: "docker", args: []string{"build", "-t", "aileron/sandbox-base:test", "-f", containerfile, filepath.Dir(containerfile)}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestBuildBaseImageNeverRequiresExistingImage(t *testing.T) {
+	runner := &callRecordingRunner{errs: []error{errors.New("missing")}}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: t.TempDir(),
+		Policy:  BuildPolicyNever,
+		Plan: composition.Plan{
+			Tier:  composition.TierBase,
+			Image: "aileron/sandbox-base:test",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected missing image error")
+	}
+	if !strings.Contains(err.Error(), "sandbox build policy is never") {
+		t.Fatalf("error = %v", err)
+	}
+}
+
+func TestBuildBaseImageNeverSkipsExistingImage(t *testing.T) {
+	runner := &callRecordingRunner{}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: t.TempDir(),
+		Policy:  BuildPolicyNever,
+		Plan: composition.Plan{
+			Tier:  composition.TierBase,
+			Image: "aileron/sandbox-base:test",
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if result.Built {
+		t.Fatalf("result.Built = true, want false")
+	}
+	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", "aileron/sandbox-base:test"}}}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestBuildRejectsUnsupportedPolicy(t *testing.T) {
+	_, err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Build(context.Background(), BuildOptions{
+		WorkDir: t.TempDir(),
+		Policy:  "sometimes",
+		Plan: composition.Plan{
+			Tier:  composition.TierBase,
+			Image: "aileron/sandbox-base:test",
+		},
+	})
+	if err == nil {
+		t.Fatal("expected unsupported policy error")
+	}
+}
+
+func TestShouldBuildRejectsUnsupportedPolicy(t *testing.T) {
+	_, err := (Builder{}).shouldBuild(context.Background(), &recordingRunner{}, "docker", "image:test", "sometimes")
+	if err == nil {
+		t.Fatal("expected unsupported policy error")
 	}
 }
 


### PR DESCRIPTION
## Summary

Continues #796 after PR #871 by making launch-time sandbox image build behavior explicit and predictable.

This PR keeps `aileron sandbox build` as the explicit manual build command, while adding launch policy for `aileron launch --sandbox=...`:

- adds `--sandbox-build=auto|always|never` to `aileron launch`
- defaults launch to `auto`, which uses an existing local Tier 0/Tier 1 image and builds only when missing
- supports `always` to force rebuild before validation and launch
- supports `never` to skip builds and fail early if the selected image is missing locally
- preserves existing direct host launch behavior for `--sandbox=off`
- updates docs, CLI reference, and ADR-0017

Out of scope here:

- BYO runtime file injection
- discovery watcher / `tools.txt` refresh
- proxy bootstrap and session CA wiring
- shell interception (#801)

## Validation

- `go test ./cmd/aileron ./internal/launch ./internal/sandbox/...`
- `pnpm run check` in `docs/`
- local coverage spot-check for new policy helpers via `go test ./internal/launch ./internal/sandbox/container -coverprofile=/tmp/build-policy-cover.out`

## Follow-on work

Still remaining for #796 before #801:

- runtime injection for BYO images
- discovery watcher and `/etc/aileron/tools.txt` refresh
- proxy bootstrap/session CA wiring
- multi-arch `aileron/sandbox-base:<version>` publishing