### PR TITLE
[codex] Publish sandbox base image

### DIFF
--- a/.github/workflows/sandbox-base.yml
+++ b/.github/workflows/sandbox-base.yml
@@ -1,0 +1,65 @@
+name: Sandbox Base Image
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/sandbox-base.yml"
+      - "images/sandbox-base/**"
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: sandbox-base-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  IMAGE_NAME: ghcr.io/alrubinger/aileron-sandbox-base
+
+jobs:
+  build:
+    name: Build sandbox-base
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v3
+
+      - uses: docker/setup-buildx-action@v3
+
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=tag
+            type=sha,prefix=git-
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=Aileron sandbox base
+            org.opencontainers.image.description=Minimal sandbox substrate for Aileron-managed agent containers.
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        uses: docker/login-action@v3
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Build image
+        uses: docker/build-push-action@v6
+        with:
+          context: images/sandbox-base
+          file: images/sandbox-base/Containerfile
+          platforms: linux/amd64,linux/arm64
+          push: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}

--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -76,6 +76,8 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 Launch build behavior is controlled by `--sandbox-build=auto|always|never`. `auto` is the default and builds Tier 0/Tier 1 images only when the selected local image is missing. `always` forces a rebuild. `never` fails if the selected image is not already present. The explicit `aileron sandbox build` command keeps its manual-build behavior.
 
+The sandbox-base image has a dedicated CI/publish workflow. Pull requests build the image for `linux/amd64` and `linux/arm64` without publishing. Release tags publish the same multi-arch image to GitHub Container Registry as `ghcr.io/alrubinger/aileron-sandbox-base:<version>`.
+
 ## Consequences
 
 Users with existing devcontainers get an upgrade path rather than a parallel Aileron-only config file.

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -106,6 +106,8 @@ Build behavior by tier:
 
 When building the base image outside the source tree, set `AILERON_SANDBOX_BASE_CONTEXT` to the directory containing the sandbox-base `Containerfile`.
 
+Release tags also build the sandbox-base image for `linux/amd64` and `linux/arm64` and publish it to GitHub Container Registry as `ghcr.io/alrubinger/aileron-sandbox-base:<version>`. Pull-request runs build both platforms without publishing, so image regressions are caught before release.
+
 ## Run During Launch
 
 Use `--sandbox` on `aileron launch` to have launch prepare the composition-selected image and start the agent inside it:


### PR DESCRIPTION
## Summary\n- add a dedicated sandbox-base image workflow\n- build the image for linux/amd64 and linux/arm64 on pull requests without publishing\n- publish release-tag and workflow-dispatch builds to GitHub Container Registry as ghcr.io/alrubinger/aileron-sandbox-base\n- document the release image path in the sandbox composition docs and ADR-0017\n\n## Scope\n- keeps launch behavior unchanged\n- does not add BYO runtime injection, discovery watchers, proxy bootstrap, or shell interception\n\n## Validation\n- pnpm run check (docs)\n- docker build -t aileron/sandbox-base:codex-publish-test -f images/sandbox-base/Containerfile images/sandbox-base\n- ruby YAML parse for .github/workflows/sandbox-base.yml

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Automated Docker image builds supporting multiple platforms, published to GitHub Container Registry with version tagging

* **Documentation**
  * Updated documentation with details on multi-platform builds and container registry publishing

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ALRubinger/aileron/pull/875?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->