### PR TITLE
[codex] Mount sandbox runtime manifests

### DIFF
--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -76,6 +76,8 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 Launch build behavior is controlled by `--sandbox-build=auto|always|never`. `auto` is the default and builds Tier 0/Tier 1 images only when the selected local image is missing. `always` forces a rebuild. `never` fails if the selected image is not already present. The explicit `aileron sandbox build` command keeps its manual-build behavior.
 
+Sandbox launch also bind-mounts Aileron's installed action manifests and connector store metadata read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors` when the corresponding host directories exist. This is the first runtime-injection substrate for discovery; generated shims, `tools.txt` refresh, and watcher processes remain follow-on work.
+
 The sandbox-base image has a dedicated CI/publish workflow. Pull requests build the image for `linux/amd64` and `linux/arm64` without publishing. Release tags publish the same multi-arch image to GitHub Container Registry as `ghcr.io/alrubinger/aileron-sandbox-base:<version>`.
 
 ## Consequences

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -139,6 +139,8 @@ aileron launch --sandbox=podman --sandbox-build=never codex
 
 The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
 
+When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. Later runtime work adds generated shims, `tools.txt` refresh, and the watcher process on top of these manifest mounts.
+
 Before registering the session, launch validates the selected image with the same mount/workdir shape it will use for the agent. The image must:
 
 - execute `/bin/sh` commands through the selected container runtime

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -16,6 +16,8 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/ALRubinger/aileron/internal/action"
+	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/daemon/spawn"
 	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
@@ -489,6 +491,7 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 		Image:   plan.Image,
 		WorkDir: config.Dir,
 		Env:     agentEnv,
+		Volumes: sandboxRuntimeMounts(),
 		Command: command,
 		TTY:     term.IsTerminal(int(os.Stdin.Fd())),
 	})
@@ -496,6 +499,30 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 		return exitResult(err)
 	}
 	return LaunchResult{ExitCode: 0}, nil
+}
+
+func sandboxRuntimeMounts() []sandboxcontainer.Volume {
+	candidates := []sandboxcontainer.Volume{
+		{
+			Source:   action.DefaultDir(),
+			Target:   "/opt/aileron/manifests/actions",
+			ReadOnly: true,
+		},
+		{
+			Source:   filepath.Join(cstore.DefaultRoot(), "connectors"),
+			Target:   "/opt/aileron/manifests/connectors",
+			ReadOnly: true,
+		},
+	}
+	mounts := make([]sandboxcontainer.Volume, 0, len(candidates))
+	for _, candidate := range candidates {
+		info, err := os.Stat(candidate.Source)
+		if err != nil || !info.IsDir() {
+			continue
+		}
+		mounts = append(mounts, candidate)
+	}
+	return mounts
 }
 
 // launchDirect runs the agent with direct stdin/stdout/stderr passthrough.

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -1,6 +1,10 @@
 package launch
 
-import "testing"
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
 
 type emptyBinaryAgent struct{}
 
@@ -116,5 +120,35 @@ func TestNormalizeLaunchBuildPolicy(t *testing.T) {
 	}
 	if _, err := normalizeLaunchBuildPolicy("sometimes"); err == nil {
 		t.Fatal("expected unsupported build policy error")
+	}
+}
+
+func TestSandboxRuntimeMountsSkipsMissingStores(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	if got := sandboxRuntimeMounts(); len(got) != 0 {
+		t.Fatalf("sandboxRuntimeMounts = %#v, want no mounts", got)
+	}
+}
+
+func TestSandboxRuntimeMountsIncludesExistingStores(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	actionsDir := filepath.Join(home, ".aileron", "actions")
+	connectorsDir := filepath.Join(home, ".aileron", "store", "connectors")
+	for _, dir := range []string{actionsDir, connectorsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	mounts := sandboxRuntimeMounts()
+	if len(mounts) != 2 {
+		t.Fatalf("mounts = %#v, want two mounts", mounts)
+	}
+	if mounts[0].Source != actionsDir || mounts[0].Target != "/opt/aileron/manifests/actions" || !mounts[0].ReadOnly {
+		t.Fatalf("actions mount = %#v", mounts[0])
+	}
+	if mounts[1].Source != connectorsDir || mounts[1].Target != "/opt/aileron/manifests/connectors" || !mounts[1].ReadOnly {
+		t.Fatalf("connectors mount = %#v", mounts[1])
 	}
 }

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -244,6 +244,57 @@ func TestLaunch_SandboxBYOImageRunsContainer(t *testing.T) {
 	}
 }
 
+func TestLaunch_SandboxMountsAileronManifestStores(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	actionsDir := filepath.Join(home, ".aileron", "actions")
+	connectorsDir := filepath.Join(home, ".aileron", "store", "connectors")
+	for _, dir := range []string{actionsDir, connectorsDir} {
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+
+	dir := t.TempDir()
+	devcontainerDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(`{"customizations":{"aileron":{"image":"ghcr.io/acme/agent:latest"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	argsFile := filepath.Join(dir, "docker-args.txt")
+	docker := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+argsFile+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:          scriptAgent{script: "codex"},
+		Dir:            dir,
+		SandboxRuntime: "docker",
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read docker args: %v", err)
+	}
+	args := string(data)
+	for _, want := range []string{
+		"--volume\n" + actionsDir + ":/opt/aileron/manifests/actions:ro\n",
+		"--volume\n" + connectorsDir + ":/opt/aileron/manifests/connectors:ro\n",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("expected %q in docker args:\n%s", want, args)
+		}
+	}
+}
+
 func TestLaunch_SandboxBuildRunsPreparedImage(t *testing.T) {
 	dir := t.TempDir()
 	baseDir := filepath.Join(dir, "images", "sandbox-base")

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -75,8 +75,16 @@ type RunOptions struct {
 	Image   string
 	WorkDir string
 	Env     map[string]string
+	Volumes []Volume
 	Command []string
 	TTY     bool
+}
+
+// Volume describes an additional host bind mount for a sandbox container.
+type Volume struct {
+	Source   string
+	Target   string
+	ReadOnly bool
 }
 
 // RunResult reports the selected runtime after a sandbox container exits.
@@ -353,6 +361,20 @@ func runArgs(opts RunOptions) ([]string, error) {
 		"--workdir", WorkspacePath,
 		"--volume", absWorkDir+":"+WorkspacePath,
 	)
+	for _, volume := range opts.Volumes {
+		if strings.TrimSpace(volume.Source) == "" || strings.TrimSpace(volume.Target) == "" {
+			return nil, fmt.Errorf("sandbox volume source and target are required")
+		}
+		source, err := filepath.Abs(volume.Source)
+		if err != nil {
+			return nil, fmt.Errorf("resolve sandbox volume source: %w", err)
+		}
+		spec := source + ":" + volume.Target
+		if volume.ReadOnly {
+			spec += ":ro"
+		}
+		args = append(args, "--volume", spec)
+	}
 	keys := make([]string, 0, len(opts.Env))
 	for k := range opts.Env {
 		keys = append(keys, k)

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -474,6 +474,84 @@ func TestRunMountsWorkspaceAndExecutesCommand(t *testing.T) {
 	}
 }
 
+func TestRunMountsAdditionalReadOnlyVolumes(t *testing.T) {
+	dir := t.TempDir()
+	extra := filepath.Join(dir, "actions")
+	if err := os.MkdirAll(extra, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:   "aileron/sandbox-base:test",
+		WorkDir: dir,
+		Volumes: []Volume{{
+			Source:   extra,
+			Target:   "/opt/aileron/manifests/actions",
+			ReadOnly: true,
+		}},
+		Command: []string{"codex"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	absExtra, _ := filepath.Abs(extra)
+	want := []string{
+		"run", "--rm", "-i",
+		"--workdir", WorkspacePath,
+		"--volume", dir + ":" + WorkspacePath,
+		"--volume", absExtra + ":/opt/aileron/manifests/actions:ro",
+		"aileron/sandbox-base:test",
+		"codex",
+	}
+	if !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("args = %#v, want %#v", runner.args, want)
+	}
+}
+
+func TestRunMountsAdditionalReadWriteVolumes(t *testing.T) {
+	dir := t.TempDir()
+	extra := filepath.Join(dir, "connectors")
+	if err := os.MkdirAll(extra, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:   "aileron/sandbox-base:test",
+		WorkDir: dir,
+		Volumes: []Volume{{
+			Source: extra,
+			Target: "/opt/aileron/manifests/connectors",
+		}},
+		Command: []string{"codex"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	absExtra, _ := filepath.Abs(extra)
+	want := "--volume"
+	found := false
+	for i := 0; i < len(runner.args)-1; i++ {
+		if runner.args[i] == want && runner.args[i+1] == absExtra+":/opt/aileron/manifests/connectors" {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("read-write volume missing from args: %#v", runner.args)
+	}
+}
+
+func TestRunRejectsIncompleteAdditionalVolume(t *testing.T) {
+	_, err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Run(context.Background(), RunOptions{
+		Image:   "aileron/sandbox-base:test",
+		Volumes: []Volume{{Target: "/opt/aileron/manifests/actions"}},
+		Command: []string{"codex"},
+	})
+	if err == nil {
+		t.Fatal("expected incomplete volume error")
+	}
+}
+
 func TestRunAddsTTYWhenRequested(t *testing.T) {
 	runner := &recordingRunner{}
 	_, err := Builder{Runtime: "podman", Runner: runner}.Run(context.Background(), RunOptions{


### PR DESCRIPTION
## Summary\n- add a narrow extra-volume contract for sandbox container runs\n- mount installed action manifests and connector store metadata read-only under /opt/aileron/manifests when the host directories exist\n- document this as the static runtime-injection substrate for later shims/tools.txt watcher work\n\n## Scope\n- no generated shims\n- no tools.txt refresh or watcher process\n- no proxy bootstrap/session CA\n- no shell interception\n\n## Validation\n- go test ./internal/sandbox/container ./internal/launch\n- go test ./cmd/aileron ./internal/launch ./internal/sandbox/...\n- pnpm run check (docs)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox now automatically mounts action manifests and connector metadata directories from the host machine into the running container as read-only when available.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ALRubinger/aileron/pull/877?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->