### PR TITLE
[codex] Mount sandbox tools manifest

### DIFF
--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -76,7 +76,7 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 Launch build behavior is controlled by `--sandbox-build=auto|always|never`. `auto` is the default and builds Tier 0/Tier 1 images only when the selected local image is missing. `always` forces a rebuild. `never` fails if the selected image is not already present. The explicit `aileron sandbox build` command keeps its manual-build behavior.
 
-Sandbox launch also bind-mounts Aileron's installed action manifests and connector store metadata read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors` when the corresponding host directories exist. This is the first runtime-injection substrate for discovery; generated shims, `tools.txt` refresh, and watcher processes remain follow-on work.
+Sandbox launch also bind-mounts Aileron's installed action manifests and connector store metadata read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors` when the corresponding host directories exist. When installed action manifests declare connector dependencies, launch renders a session-scoped static `tools.txt` manifest and bind-mounts it read-only at `/etc/aileron/tools.txt`. This is the first runtime-injection substrate for discovery; generated shims, live `tools.txt` refresh, and watcher processes remain follow-on work.
 
 The sandbox-base image has a dedicated CI/publish workflow. Pull requests build the image for `linux/amd64` and `linux/arm64` without publishing. Release tags publish the same multi-arch image to GitHub Container Registry as `ghcr.io/alrubinger/aileron-sandbox-base:<version>`.
 

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -139,7 +139,7 @@ aileron launch --sandbox=podman --sandbox-build=never codex
 
 The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
 
-When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. Later runtime work adds generated shims, `tools.txt` refresh, and the watcher process on top of these manifest mounts.
+When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. When installed actions declare connector dependencies, launch also generates a session-scoped static `/etc/aileron/tools.txt` manifest and mounts it read-only into the sandbox. Later runtime work adds generated shims, live `tools.txt` refresh, and the watcher process on top of these manifest mounts.
 
 Before registering the session, launch validates the selected image with the same mount/workdir shape it will use for the agent. The image must:
 
@@ -176,4 +176,4 @@ Do not put Aileron credentials or user secrets in the image. Credentialed traffi
 
 ## What This Does Not Do Yet
 
-This slice does not inject runtime files into BYO images, generate discovery shims, add proxy bootstrap, or mediate shell commands. Follow-on work adds runtime injection, the discovery watcher, proxy bootstrap, and shell-layer interception.
+This slice does not inject runtime files into BYO images, generate discovery shims, add live discovery refresh, add proxy bootstrap, or mediate shell commands. Follow-on work adds runtime injection, the discovery watcher, proxy bootstrap, and shell-layer interception.

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -22,6 +22,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/daemon/spawn"
 	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	sandboxdiscovery "github.com/ALRubinger/aileron/internal/sandbox/discovery"
 	"github.com/ALRubinger/aileron/internal/version"
 	"golang.org/x/term"
 )
@@ -199,6 +200,18 @@ func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchC
 	if commandName == "" {
 		return fmt.Errorf("agent %q has no container command", config.Agent.Name())
 	}
+	mounts, cleanupMounts, err := sandboxRuntimeMounts()
+	if err != nil {
+		return err
+	}
+	defer cleanupMounts()
+	if err := validateSandboxImageForLaunch(ctx, plan, config, mounts, commandName); err != nil {
+		return fmt.Errorf("sandbox image %s is not launchable for %s: %w", plan.Image, config.Agent.Name(), err)
+	}
+	return nil
+}
+
+func validateSandboxImage(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, mounts []sandboxcontainer.Volume, commandName string) error {
 	if err := (sandboxcontainer.Builder{
 		Runtime: plan.Runtime,
 		Stdout:  io.Discard,
@@ -206,14 +219,16 @@ func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchC
 		Runtime: plan.Runtime,
 		Image:   plan.Image,
 		WorkDir: config.Dir,
+		Volumes: mounts,
 		Command: []string{commandName},
 	}); err != nil {
-		return fmt.Errorf("sandbox image %s is not launchable for %s: %w", plan.Image, config.Agent.Name(), err)
+		return err
 	}
 	return nil
 }
 
 var validateSandboxForLaunch = validateSandbox
+var validateSandboxImageForLaunch = validateSandboxImage
 
 // Launch starts the agent as a child process under Aileron's daemon.
 //
@@ -480,9 +495,14 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 	if commandName == "" {
 		return LaunchResult{}, fmt.Errorf("agent %q has no container command", config.Agent.Name())
 	}
+	mounts, cleanupMounts, err := sandboxRuntimeMounts()
+	if err != nil {
+		return LaunchResult{}, err
+	}
+	defer cleanupMounts()
 	command := append([]string{commandName}, config.Agent.Args()...)
 	command = append(command, config.Args...)
-	_, err := sandboxcontainer.Builder{
+	_, err = sandboxcontainer.Builder{
 		Runtime: plan.Runtime,
 		Stdout:  os.Stdout,
 		Stderr:  os.Stderr,
@@ -491,7 +511,7 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 		Image:   plan.Image,
 		WorkDir: config.Dir,
 		Env:     agentEnv,
-		Volumes: sandboxRuntimeMounts(),
+		Volumes: mounts,
 		Command: command,
 		TTY:     term.IsTerminal(int(os.Stdin.Fd())),
 	})
@@ -501,7 +521,7 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 	return LaunchResult{ExitCode: 0}, nil
 }
 
-func sandboxRuntimeMounts() []sandboxcontainer.Volume {
+func sandboxRuntimeMounts() ([]sandboxcontainer.Volume, func(), error) {
 	candidates := []sandboxcontainer.Volume{
 		{
 			Source:   action.DefaultDir(),
@@ -522,7 +542,33 @@ func sandboxRuntimeMounts() []sandboxcontainer.Volume {
 		}
 		mounts = append(mounts, candidate)
 	}
-	return mounts
+	cleanup := func() {}
+	if toolsText := sandboxToolsText(); len(toolsText) > 0 {
+		dir, err := os.MkdirTemp("", "aileron-sandbox-discovery-*")
+		if err != nil {
+			return nil, cleanup, fmt.Errorf("create sandbox discovery tempdir: %w", err)
+		}
+		cleanup = func() { _ = os.RemoveAll(dir) }
+		path := filepath.Join(dir, "tools.txt")
+		if err := os.WriteFile(path, toolsText, 0o600); err != nil {
+			cleanup()
+			return nil, func() {}, fmt.Errorf("write sandbox tools manifest: %w", err)
+		}
+		mounts = append(mounts, sandboxcontainer.Volume{
+			Source:   path,
+			Target:   "/etc/aileron/tools.txt",
+			ReadOnly: true,
+		})
+	}
+	return mounts, cleanup, nil
+}
+
+func sandboxToolsText() []byte {
+	store := action.NewStore(action.DefaultDir())
+	if _, err := store.Load(); err != nil {
+		return nil
+	}
+	return sandboxdiscovery.ToolsText(store.List())
 }
 
 // launchDirect runs the agent with direct stdin/stdout/stderr passthrough.

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -1,9 +1,13 @@
 package launch
 
 import (
+	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
+
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 )
 
 type emptyBinaryAgent struct{}
@@ -102,6 +106,40 @@ func TestValidateSandboxRejectsAgentWithoutBinary(t *testing.T) {
 	}
 }
 
+func TestValidateSandboxPassesRuntimeMounts(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	actionsDir := filepath.Join(home, ".aileron", "actions")
+	if err := os.MkdirAll(actionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionsDir, "send-email.md"), []byte(validActionManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	orig := validateSandboxImageForLaunch
+	t.Cleanup(func() { validateSandboxImageForLaunch = orig })
+	var got []sandboxcontainer.Volume
+	validateSandboxImageForLaunch = func(_ context.Context, _ SandboxLaunchPlan, _ LaunchConfig, mounts []sandboxcontainer.Volume, commandName string) error {
+		got = append(got, mounts...)
+		if commandName != "codex" {
+			t.Fatalf("commandName = %q, want codex", commandName)
+		}
+		return nil
+	}
+
+	err := validateSandbox(context.Background(), SandboxLaunchPlan{Runtime: "docker", Image: "image:test"}, LaunchConfig{
+		Agent: namedBinaryAgent{name: "codex"},
+		Dir:   t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("validateSandbox: %v", err)
+	}
+	if !hasMountTarget(got, "/opt/aileron/manifests/actions") || !hasMountTarget(got, "/etc/aileron/tools.txt") {
+		t.Fatalf("validateSandbox mounts = %#v, want actions and tools.txt mounts", got)
+	}
+}
+
 func TestNormalizeLaunchBuildPolicy(t *testing.T) {
 	tests := map[string]string{
 		"":       "auto",
@@ -123,9 +161,40 @@ func TestNormalizeLaunchBuildPolicy(t *testing.T) {
 	}
 }
 
+func TestSandboxRuntimeMountsReportsToolsTempDirError(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	actionsDir := filepath.Join(home, ".aileron", "actions")
+	if err := os.MkdirAll(actionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(actionsDir, "send-email.md"), []byte(validActionManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	tmpFile := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(tmpFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("TMPDIR", tmpFile)
+
+	_, cleanup, err := sandboxRuntimeMounts()
+	defer cleanup()
+	if err == nil {
+		t.Fatal("expected tempdir error")
+	}
+	if !strings.Contains(err.Error(), "create sandbox discovery tempdir") {
+		t.Fatalf("error = %v, want discovery tempdir context", err)
+	}
+}
+
 func TestSandboxRuntimeMountsSkipsMissingStores(t *testing.T) {
 	t.Setenv("HOME", t.TempDir())
-	if got := sandboxRuntimeMounts(); len(got) != 0 {
+	got, cleanup, err := sandboxRuntimeMounts()
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("sandboxRuntimeMounts: %v", err)
+	}
+	if len(got) != 0 {
 		t.Fatalf("sandboxRuntimeMounts = %#v, want no mounts", got)
 	}
 }
@@ -141,7 +210,11 @@ func TestSandboxRuntimeMountsIncludesExistingStores(t *testing.T) {
 		}
 	}
 
-	mounts := sandboxRuntimeMounts()
+	mounts, cleanup, err := sandboxRuntimeMounts()
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("sandboxRuntimeMounts: %v", err)
+	}
 	if len(mounts) != 2 {
 		t.Fatalf("mounts = %#v, want two mounts", mounts)
 	}
@@ -152,3 +225,79 @@ func TestSandboxRuntimeMountsIncludesExistingStores(t *testing.T) {
 		t.Fatalf("connectors mount = %#v", mounts[1])
 	}
 }
+
+func TestSandboxRuntimeMountsIncludesGeneratedToolsText(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	actionsDir := filepath.Join(home, ".aileron", "actions")
+	if err := os.MkdirAll(actionsDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	actionPath := filepath.Join(actionsDir, "send-email.md")
+	if err := os.WriteFile(actionPath, []byte(validActionManifest), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	mounts, cleanup, err := sandboxRuntimeMounts()
+	defer cleanup()
+	if err != nil {
+		t.Fatalf("sandboxRuntimeMounts: %v", err)
+	}
+	var toolsMount *sandboxcontainer.Volume
+	for i := range mounts {
+		if mounts[i].Target == "/etc/aileron/tools.txt" {
+			toolsMount = &mounts[i]
+			break
+		}
+	}
+	if toolsMount == nil {
+		t.Fatalf("tools.txt mount missing from %#v", mounts)
+	}
+	if !toolsMount.ReadOnly {
+		t.Fatalf("tools.txt mount should be read-only: %#v", toolsMount)
+	}
+	data, err := os.ReadFile(toolsMount.Source)
+	if err != nil {
+		t.Fatalf("read tools.txt: %v", err)
+	}
+	if !strings.Contains(string(data), "google\tgithub://ALRubinger/aileron-connector-google") {
+		t.Fatalf("tools.txt did not include google connector:\n%s", data)
+	}
+}
+
+func hasMountTarget(mounts []sandboxcontainer.Volume, target string) bool {
+	for _, mount := range mounts {
+		if mount.Target == target {
+			return true
+		}
+	}
+	return false
+}
+
+const validActionManifest = `+++
+name = "send-email"
+version = "1.0.0"
+source = "hub://aileron/send-email@1.0.0"
+
+[[requires.connectors]]
+name = "github://ALRubinger/aileron-connector-google"
+version = "1.0.0"
+hash = "sha256:abc123"
+capabilities = ["send"]
+
+[match]
+intent = "send email"
+
+[[inputs]]
+name = "to"
+type = "string"
+description = "recipient"
+
+[[execute]]
+id = "send"
+connector = "github://ALRubinger/aileron-connector-google"
+op = "send_email"
++++
+
+# Send Email
+`

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -97,6 +97,7 @@ type ValidateOptions struct {
 	Runtime string
 	Image   string
 	WorkDir string
+	Volumes []Volume
 	Command []string
 }
 
@@ -277,6 +278,7 @@ func (b Builder) Validate(ctx context.Context, opts ValidateOptions) error {
 		Runtime: opts.Runtime,
 		Image:   opts.Image,
 		WorkDir: opts.WorkDir,
+		Volumes: opts.Volumes,
 		Command: []string{
 			"/bin/sh",
 			"-c",

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -587,10 +587,19 @@ func TestRunRejectsMissingCommand(t *testing.T) {
 
 func TestValidateRunsMinimalContractProbe(t *testing.T) {
 	dir := t.TempDir()
+	manifest := filepath.Join(t.TempDir(), "tools.txt")
+	if err := os.WriteFile(manifest, []byte("tool\tfqn\n"), 0o600); err != nil {
+		t.Fatal(err)
+	}
 	runner := &recordingRunner{}
 	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
 		Image:   "ghcr.io/acme/agent:latest",
 		WorkDir: dir,
+		Volumes: []Volume{{
+			Source:   manifest,
+			Target:   "/etc/aileron/tools.txt",
+			ReadOnly: true,
+		}},
 		Command: []string{"codex"},
 	})
 	if err != nil {
@@ -603,6 +612,7 @@ func TestValidateRunsMinimalContractProbe(t *testing.T) {
 		"run", "--rm", "-i",
 		"--workdir", WorkspacePath,
 		"--volume", dir + ":" + WorkspacePath,
+		"--volume", manifest + ":/etc/aileron/tools.txt:ro",
 		"ghcr.io/acme/agent:latest",
 		"/bin/sh", "-c",
 	}

--- a/internal/sandbox/discovery/tools.go
+++ b/internal/sandbox/discovery/tools.go
@@ -1,0 +1,107 @@
+// Package discovery renders the sandbox-side discovery surfaces agents read
+// inside container sessions.
+package discovery
+
+import (
+	"bytes"
+	"sort"
+	"strings"
+	"unicode"
+
+	"github.com/ALRubinger/aileron/internal/action"
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+// ToolsText renders /etc/aileron/tools.txt from installed action manifests.
+// The watcher added later can call the same renderer when manifests change.
+func ToolsText(actions []action.LoadedAction) []byte {
+	byConnector := map[string]map[string]bool{}
+	for _, loaded := range actions {
+		if loaded.Manifest == nil {
+			continue
+		}
+		actionName := strings.TrimSpace(loaded.Manifest.Name)
+		if actionName == "" {
+			continue
+		}
+		for _, connector := range loaded.Manifest.Requires.Connectors {
+			fqn := strings.TrimSpace(connector.Name)
+			if fqn == "" {
+				continue
+			}
+			if byConnector[fqn] == nil {
+				byConnector[fqn] = map[string]bool{}
+			}
+			byConnector[fqn][actionName] = true
+		}
+	}
+	if len(byConnector) == 0 {
+		return nil
+	}
+
+	fqns := make([]string, 0, len(byConnector))
+	for fqn := range byConnector {
+		fqns = append(fqns, fqn)
+	}
+	sort.Strings(fqns)
+
+	var out bytes.Buffer
+	for _, fqn := range fqns {
+		actions := sortedKeys(byConnector[fqn])
+		out.WriteString(toolName(fqn))
+		out.WriteString("\t")
+		out.WriteString(fqn)
+		out.WriteString(" -- installed Aileron connector used by actions: ")
+		out.WriteString(strings.Join(actions, ", "))
+		out.WriteString("\n")
+	}
+	return out.Bytes()
+}
+
+func sortedKeys(values map[string]bool) []string {
+	keys := make([]string, 0, len(values))
+	for key := range values {
+		keys = append(keys, key)
+	}
+	sort.Strings(keys)
+	return keys
+}
+
+func toolName(fqn string) string {
+	parsed, err := cstore.ParseFQN(fqn)
+	if err != nil {
+		return sanitizeToolName(fqn)
+	}
+	name := parsed.Repo
+	if parsed.Subpath != "" {
+		parts := strings.Split(parsed.Subpath, "/")
+		name = parts[len(parts)-1]
+	}
+	name = strings.TrimPrefix(name, "aileron-connector-")
+	name = strings.TrimPrefix(name, "connector-")
+	return sanitizeToolName(name)
+}
+
+func sanitizeToolName(name string) string {
+	name = strings.ToLower(strings.TrimSpace(name))
+	var out strings.Builder
+	lastDash := false
+	for _, r := range name {
+		switch {
+		case unicode.IsLetter(r), unicode.IsDigit(r), r == '_', r == '.':
+			out.WriteRune(r)
+			lastDash = false
+		case r == '-':
+			if !lastDash {
+				out.WriteByte('-')
+				lastDash = true
+			}
+		default:
+			if !lastDash {
+				out.WriteByte('-')
+				lastDash = true
+			}
+		}
+	}
+	return strings.Trim(out.String(), "-")
+}

--- a/internal/sandbox/discovery/tools_test.go
+++ b/internal/sandbox/discovery/tools_test.go
@@ -1,0 +1,57 @@
+package discovery
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/action"
+)
+
+func TestToolsTextRendersConnectorsFromActions(t *testing.T) {
+	got := string(ToolsText([]action.LoadedAction{
+		{Manifest: &action.Manifest{
+			Name: "send-email",
+			Requires: action.Requires{Connectors: []action.RequiresConnector{
+				{Name: "github://ALRubinger/aileron-connector-google"},
+			}},
+		}},
+		{Manifest: &action.Manifest{
+			Name: "move-file",
+			Requires: action.Requires{Connectors: []action.RequiresConnector{
+				{Name: "github://ALRubinger/aileron-connector-google"},
+				{Name: "hub://acme/internal/release-tool"},
+			}},
+		}},
+	}))
+
+	for _, want := range []string{
+		"google\tgithub://ALRubinger/aileron-connector-google -- installed Aileron connector used by actions: move-file, send-email\n",
+		"release-tool\thub://acme/internal/release-tool -- installed Aileron connector used by actions: move-file\n",
+	} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("tools.txt missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestToolsTextSkipsEmptyInputs(t *testing.T) {
+	got := ToolsText([]action.LoadedAction{
+		{},
+		{Manifest: &action.Manifest{Name: "no-connectors"}},
+		{Manifest: &action.Manifest{
+			Name: "blank-connector",
+			Requires: action.Requires{Connectors: []action.RequiresConnector{
+				{Name: " "},
+			}},
+		}},
+	})
+	if got != nil {
+		t.Fatalf("ToolsText = %q, want nil", got)
+	}
+}
+
+func TestToolNameSanitizesFallbackFQN(t *testing.T) {
+	if got := toolName("not a valid fqn"); got != "not-a-valid-fqn" {
+		t.Fatalf("toolName fallback = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary
- add a shared sandbox discovery renderer for static tools.txt content derived from installed action connector dependencies
- have sandbox launch generate a session-scoped tools.txt and mount it read-only at /etc/aileron/tools.txt when actions declare connector dependencies
- document the static discovery manifest while keeping watcher refresh, generated shims, proxy bootstrap, and shell mediation out of scope

## Validation
- go test ./internal/sandbox/discovery ./internal/launch ./internal/sandbox/container
- go test ./cmd/aileron ./internal/launch ./internal/sandbox/...
- pnpm run check

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox now automatically generates and includes a tools discovery manifest for installed actions and connectors.

* **Improvements**
  * Enhanced runtime mount handling with automatic cleanup of temporary resources and read-only bind-mounts for action and connector directories.

* **Documentation**
  * Updated sandbox composition documentation with details on mount configuration and generated tooling integration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ALRubinger/aileron/pull/878?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->