### PR TITLE
[codex] Wire sandbox connector shim dispatch

### DIFF
--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -70,13 +70,13 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 `aileron sandbox plan` is an inspection helper that reports the normalized tier/image/dockerfile plan.
 
-`aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is; launch validates the minimal runtime contract before running the agent. Later launch work adds runtime injection.
+`aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is; launch validates the minimal runtime contract before running the agent. Later launch work extends the initial runtime-injection substrate.
 
 `aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image, validates that it can execute `/bin/sh`, use a writable `/home/agent/workspace` mount, and resolve the agent command on `PATH`, then runs the agent command inside a one-shot Docker/Podman container. The project is mounted at `/home/agent/workspace` and used as the container working directory. Launch passes the session-scoped Aileron daemon env into the container, including `AILERON_API_URL` for the daemon `/v1` API used by sandbox-side execution shims, and rewrites loopback daemon URLs to the runtime host alias (`host.docker.internal` for Docker, `host.containers.internal` for Podman).
 
 Launch build behavior is controlled by `--sandbox-build=auto|always|never`. `auto` is the default and builds Tier 0/Tier 1 images only when the selected local image is missing. `always` forces a rebuild. `never` fails if the selected image is not already present. The explicit `aileron sandbox build` command keeps its manual-build behavior.
 
-Sandbox launch also bind-mounts Aileron's installed action manifests and connector store metadata read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors` when the corresponding host directories exist. When installed action manifests declare connector dependencies, launch renders a session-scoped static `tools.txt` manifest and bind-mounts it read-only at `/etc/aileron/tools.txt`; it also renders read-only connector shim scripts under `/usr/local/bin` for `--help` discovery. The shims fail closed for execution until proxy-backed dispatch lands. This is the first runtime-injection substrate for discovery; live `tools.txt` refresh and watcher processes remain follow-on work.
+Sandbox launch also bind-mounts Aileron's installed action manifests and connector store metadata read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors` when the corresponding host directories exist. When installed action manifests declare connector dependencies, launch renders a session-scoped static `tools.txt` manifest and bind-mounts it read-only at `/etc/aileron/tools.txt`; it also renders read-only connector shim scripts under `/usr/local/bin` for `--help` discovery and explicit installed-action execution through `AILERON_API_URL`. This is the first runtime-injection substrate for discovery and action dispatch; live `tools.txt` refresh and watcher processes remain follow-on work.
 
 The sandbox-base image has a dedicated CI/publish workflow. Pull requests build the image for `linux/amd64` and `linux/arm64` without publishing. Release tags publish the same multi-arch image to GitHub Container Registry as `ghcr.io/alrubinger/aileron-sandbox-base:<version>`.
 
@@ -86,7 +86,7 @@ Users with existing devcontainers get an upgrade path rather than a parallel Ail
 
 Aileron keeps a clear boundary: it owns mediation, credentials, approvals, audit, and runtime bootstrap; users own development tooling in the image.
 
-The first implementations establish the contract, image-build substrate, and minimal container execution path without also implementing runtime injection, watcher processes, shell interception, or proxy bootstrap. Those build on this substrate in later sandbox and shell-mediation work.
+The first implementations establish the contract, image-build substrate, minimal container execution path, and initial runtime-injection substrate. Live discovery refresh, watcher processes, shell interception, and proxy bootstrap build on this substrate in later sandbox and shell-mediation work.
 
 ## Alternatives Considered
 

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -6,7 +6,7 @@ order: 6
 
 Sandbox composition is the contract for deciding which container image an agent session runs in. It is defined by [ADR-0017](/adr/0017-sandbox-composition/) and implemented by the `aileron sandbox` CLI.
 
-This page covers the user-facing workflow. Runtime launch support is intentionally still staged: the current implementation can scaffold, inspect, build, and run the agent command in the prepared sandbox image, while later work adds runtime injection, discovery refresh, proxy bootstrap, and shell mediation.
+This page covers the user-facing workflow. Runtime launch support is intentionally still staged: the current implementation can scaffold, inspect, build, run the agent command in the prepared sandbox image, and inject static discovery/action shims, while later work adds live discovery refresh, proxy bootstrap, and shell mediation.
 
 ## Choose a Composition Tier
 
@@ -139,7 +139,7 @@ aileron launch --sandbox=podman --sandbox-build=never codex
 
 The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_API_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). `AILERON_API_URL` points at the daemon's `/v1` API and is the stable endpoint for sandbox-side execution shims. For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
 
-When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. When installed actions declare connector dependencies, launch also generates a session-scoped static `/etc/aileron/tools.txt` manifest and read-only connector shim scripts under `/usr/local/bin`. These shims support `--help` for discovery and fail closed for execution until proxy-backed shim dispatch lands. Later runtime work adds live `tools.txt` refresh and the watcher process on top of these generated files.
+When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. When installed actions declare connector dependencies, launch also generates a session-scoped static `/etc/aileron/tools.txt` manifest and read-only connector shim scripts under `/usr/local/bin`. These shims support `--help` for discovery and can execute an explicit installed action name through `AILERON_API_URL` with optional raw JSON args. Later runtime work adds live `tools.txt` refresh and the watcher process on top of these generated files.
 
 Before registering the session, launch validates the selected image with the same mount/workdir shape it will use for the agent. The image must:
 
@@ -148,7 +148,7 @@ Before registering the session, launch validates the selected image with the sam
 - allow a temporary file to be written in the mounted workspace
 - resolve the agent command on `PATH`
 
-The agent command must already exist in the selected image. For Tier 1, install the agent CLI in your devcontainer Dockerfile. Tier 2 uses the BYO image as supplied until runtime injection lands.
+The agent command must already exist in the selected image. For Tier 1, install the agent CLI in your devcontainer Dockerfile. Tier 2 uses the BYO image as supplied while Aileron's runtime injection remains limited to session env, manifest mounts, `tools.txt`, and connector shims.
 
 ## Use a BYO Image
 
@@ -166,7 +166,7 @@ Set `customizations.aileron.image` when your team owns the complete image:
 }
 ```
 
-In BYO-image mode, launch currently uses the image as supplied. Later runtime launch work injects Aileron's runtime contract at launch: the `aileron` binary/shims, discovery files, proxy bootstrap, session CA, and shell mediation files.
+In BYO-image mode, launch currently uses the image as supplied and layers on Aileron's session env, manifest mounts, generated discovery files, and connector shims. Later runtime launch work extends that contract with proxy bootstrap, session CA, and shell mediation files.
 
 ## What Belongs in the Image
 
@@ -176,4 +176,4 @@ Do not put Aileron credentials or user secrets in the image. Credentialed traffi
 
 ## What This Does Not Do Yet
 
-This slice does not execute connector shims, add live discovery refresh, add proxy bootstrap, or mediate shell commands. Follow-on work adds proxy-backed shim dispatch, the discovery watcher, proxy bootstrap, and shell-layer interception.
+This slice does not add live discovery refresh, proxy bootstrap, or shell command mediation. Generated session-scoped `/etc/aileron/tools.txt` and read-only connector shims support `--help` discovery, and the shims can execute installed actions via `AILERON_API_URL` with optional raw JSON args. Follow-on work adds the discovery watcher, proxy bootstrap, and shell-layer interception.

--- a/internal/sandbox/discovery/tools.go
+++ b/internal/sandbox/discovery/tools.go
@@ -61,8 +61,6 @@ func ToolsText(actions []action.LoadedAction) []byte {
 }
 
 // ShimScripts renders static connector shim scripts keyed by command name.
-// These scripts are a discovery surface only until proxy-backed shim dispatch
-// lands; they support --help and fail closed for execution attempts.
 func ShimScripts(actions []action.LoadedAction) map[string][]byte {
 	tools := ConnectorTools(actions)
 	if len(tools) == 0 {
@@ -237,10 +235,11 @@ func shimScript(tool ConnectorTool) []byte {
 			}
 		}
 	}
-	fmt.Fprintf(&help, "\nExecution is not wired in this sandbox slice yet; proxy-backed shim dispatch lands in a follow-on #796 PR.\n")
+	fmt.Fprintf(&help, "\nRun `%s <action-name> --args '<json-object>'` to execute an installed action through the Aileron daemon API.\n", tool.Name)
 
 	var out bytes.Buffer
 	out.WriteString("#!/bin/sh\n")
+	out.WriteString("set -u\n")
 	out.WriteString("case \"${1:-}\" in\n")
 	out.WriteString("  \"\"|\"-h\"|\"--help\"|\"help\")\n")
 	out.WriteString("    cat <<'AILERON_HELP'\n")
@@ -249,10 +248,66 @@ func shimScript(tool ConnectorTool) []byte {
 	out.WriteString("    exit 0\n")
 	out.WriteString("    ;;\n")
 	out.WriteString("esac\n")
-	out.WriteString("cat >&2 <<'AILERON_ERROR'\n")
-	fmt.Fprintf(&out, "Aileron connector shim %q is installed for discovery, but execution is not wired yet.\n", tool.Name)
-	out.WriteString("Run with --help to inspect installed actions. Proxy-backed shim dispatch lands in a follow-on #796 PR.\n")
-	out.WriteString("AILERON_ERROR\n")
-	out.WriteString("exit 64\n")
+	out.WriteString("action_name=$1\n")
+	out.WriteString("shift\n")
+	out.WriteString("case \"$action_name\" in\n")
+	for _, action := range tool.Actions {
+		fmt.Fprintf(&out, "  %s)\n", shellQuote(action.Name))
+		out.WriteString("    ;;\n")
+	}
+	out.WriteString("  *)\n")
+	fmt.Fprintf(&out, "    echo 'Unknown action for %s: '\"$action_name\" >&2\n", shellSingleQuote(tool.Name))
+	out.WriteString("    echo 'Run with --help to list installed actions.' >&2\n")
+	out.WriteString("    exit 64\n")
+	out.WriteString("    ;;\n")
+	out.WriteString("esac\n")
+	out.WriteString("args_json='{}'\n")
+	out.WriteString("while [ \"$#\" -gt 0 ]; do\n")
+	out.WriteString("  case \"$1\" in\n")
+	out.WriteString("    --args)\n")
+	out.WriteString("      shift\n")
+	out.WriteString("      if [ \"$#\" -eq 0 ]; then\n")
+	out.WriteString("        echo 'Missing value for --args' >&2\n")
+	out.WriteString("        exit 64\n")
+	out.WriteString("      fi\n")
+	out.WriteString("      args_json=$1\n")
+	out.WriteString("      ;;\n")
+	out.WriteString("    --json)\n")
+	out.WriteString("      ;;\n")
+	out.WriteString("    -h|--help|help)\n")
+	out.WriteString("      exec \"$0\" --help\n")
+	out.WriteString("      ;;\n")
+	out.WriteString("    *)\n")
+	out.WriteString("      echo 'Unsupported argument: '\"$1\" >&2\n")
+	out.WriteString("      echo 'Usage: ")
+	out.WriteString(shellSingleQuote(tool.Name))
+	out.WriteString(" <action-name> [--args <json-object>] [--json]' >&2\n")
+	out.WriteString("      exit 64\n")
+	out.WriteString("      ;;\n")
+	out.WriteString("  esac\n")
+	out.WriteString("  shift\n")
+	out.WriteString("done\n")
+	out.WriteString("if [ -z \"${AILERON_API_URL:-}\" ]; then\n")
+	out.WriteString("  echo 'AILERON_API_URL is not set; cannot reach the Aileron daemon API.' >&2\n")
+	out.WriteString("  exit 69\n")
+	out.WriteString("fi\n")
+	out.WriteString("if ! command -v wget >/dev/null 2>&1; then\n")
+	out.WriteString("  echo 'wget is required for Aileron connector shims in this sandbox image.' >&2\n")
+	out.WriteString("  exit 69\n")
+	out.WriteString("fi\n")
+	out.WriteString("body='{\"args\":'\"$args_json\"'}'\n")
+	out.WriteString("url=${AILERON_API_URL%/}/actions/$action_name/run\n")
+	out.WriteString("if [ -n \"${AILERON_TOKEN:-}\" ]; then\n")
+	out.WriteString("  exec wget -T 30 -t 3 -q -O - --header 'Content-Type: application/json' --header \"Authorization: Bearer $AILERON_TOKEN\" --post-data \"$body\" \"$url\"\n")
+	out.WriteString("fi\n")
+	out.WriteString("exec wget -T 30 -t 3 -q -O - --header 'Content-Type: application/json' --post-data \"$body\" \"$url\"\n")
 	return out.Bytes()
+}
+
+func shellQuote(value string) string {
+	return "'" + shellSingleQuote(value) + "'"
+}
+
+func shellSingleQuote(value string) string {
+	return strings.ReplaceAll(value, "'", "'\"'\"'")
 }

--- a/internal/sandbox/discovery/tools_test.go
+++ b/internal/sandbox/discovery/tools_test.go
@@ -1,6 +1,10 @@
 package discovery
 
 import (
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -37,7 +41,7 @@ func TestConnectorToolsRendersActionHelp(t *testing.T) {
 	}
 }
 
-func TestShimScriptsRenderHelpAndFailClosed(t *testing.T) {
+func TestShimScriptsRenderHelpAndDispatch(t *testing.T) {
 	scripts := ShimScripts(testActions())
 	script := string(scripts["google"])
 	for _, want := range []string{
@@ -45,12 +49,137 @@ func TestShimScriptsRenderHelpAndFailClosed(t *testing.T) {
 		"Aileron connector shim: google\n",
 		"send-email - send email\n",
 		"--to <string> (required) - recipient\n",
-		"execution is not wired yet",
-		"exit 64\n",
+		"Run `google <action-name> --args '<json-object>'`",
+		"--post-data \"$body\" \"$url\"",
 	} {
 		if !strings.Contains(script, want) {
 			t.Fatalf("shim script missing %q:\n%s", want, script)
 		}
+	}
+}
+
+func TestShimScriptExecutesInstalledActionThroughDaemonAPI(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generated shim execution is POSIX shell behavior")
+	}
+	scripts := ShimScripts(testActions())
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, "google")
+	if err := os.WriteFile(shimPath, scripts["google"], 0o755); err != nil {
+		t.Fatal(err)
+	}
+	capturePath := filepath.Join(dir, "wget-args.txt")
+	wgetPath := filepath.Join(dir, "wget")
+	if err := os.WriteFile(wgetPath, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+capturePath+"\nprintf '{\"ok\":true}\\n'\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	cmd := exec.Command("/bin/sh", shimPath, "send-email", "--args", `{"to":"a@example.com"}`, "--json")
+	cmd.Env = append(os.Environ(),
+		"PATH="+dir+string(os.PathListSeparator)+os.Getenv("PATH"),
+		"AILERON_API_URL=http://host.docker.internal:48123/v1",
+		"AILERON_TOKEN=test-token",
+	)
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("shim execution failed: %v\n%s", err, out)
+	}
+	if got := string(out); got != "{\"ok\":true}\n" {
+		t.Fatalf("shim output = %q", got)
+	}
+	captured, err := os.ReadFile(capturePath)
+	if err != nil {
+		t.Fatal(err)
+	}
+	args := string(captured)
+	for _, want := range []string{
+		"--header\nContent-Type: application/json\n",
+		"--header\nAuthorization: Bearer test-token\n",
+		"--post-data\n{\"args\":{\"to\":\"a@example.com\"}}\n",
+		"http://host.docker.internal:48123/v1/actions/send-email/run\n",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("wget args missing %q:\n%s", want, args)
+		}
+	}
+}
+
+func TestShimScriptRejectsUnknownAction(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generated shim execution is POSIX shell behavior")
+	}
+	scripts := ShimScripts(testActions())
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, "google")
+	if err := os.WriteFile(shimPath, scripts["google"], 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", shimPath, "missing-action")
+	cmd.Env = append(os.Environ(), "AILERON_API_URL=http://host.docker.internal:48123/v1")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("shim succeeded unexpectedly:\n%s", out)
+	}
+	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 64 {
+		t.Fatalf("shim exit = %v, want 64; output:\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "Unknown action for google: missing-action") {
+		t.Fatalf("unknown action output = %s", out)
+	}
+}
+
+func TestShimScriptFailsWithoutAILERONAPIURL(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generated shim execution is POSIX shell behavior")
+	}
+	scripts := ShimScripts(testActions())
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, "google")
+	if err := os.WriteFile(shimPath, scripts["google"], 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", shimPath, "send-email")
+	cmd.Env = append(os.Environ(), "AILERON_API_URL=")
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("shim succeeded unexpectedly:\n%s", out)
+	}
+	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 69 {
+		t.Fatalf("shim exit = %v, want 69; output:\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "AILERON_API_URL") {
+		t.Fatalf("missing API URL output = %s", out)
+	}
+}
+
+func TestShimScriptFailsWithoutWget(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("generated shim execution is POSIX shell behavior")
+	}
+	scripts := ShimScripts(testActions())
+	dir := t.TempDir()
+	shimPath := filepath.Join(dir, "google")
+	if err := os.WriteFile(shimPath, scripts["google"], 0o755); err != nil {
+		t.Fatal(err)
+	}
+	emptyPathDir := filepath.Join(dir, "empty-path")
+	if err := os.Mkdir(emptyPathDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	cmd := exec.Command("/bin/sh", shimPath, "send-email")
+	cmd.Env = append(os.Environ(),
+		"PATH="+emptyPathDir,
+		"AILERON_API_URL=http://host.docker.internal:48123/v1",
+	)
+	out, err := cmd.CombinedOutput()
+	if err == nil {
+		t.Fatalf("shim succeeded unexpectedly:\n%s", out)
+	}
+	if exitErr, ok := err.(*exec.ExitError); !ok || exitErr.ExitCode() != 69 {
+		t.Fatalf("shim exit = %v, want 69; output:\n%s", err, out)
+	}
+	if !strings.Contains(string(out), "wget") {
+		t.Fatalf("missing wget output = %s", out)
 	}
 }
 


### PR DESCRIPTION
## Summary

- Wire generated sandbox connector shims to execute explicit installed action names through `AILERON_API_URL`.
- Keep `--help` local and fail closed for unknown actions, missing `AILERON_API_URL`, or missing `wget`.
- Support the narrow initial invocation shape: `<tool> <action-name> [--args <json-object>] [--json]`.
- Update sandbox docs and ADR-0017 to reflect action dispatch while keeping shell interception and live discovery refresh out of scope.

## Review

- CodeRabbit CLI 0.5.2 is installed locally, but `coderabbit review --agent --base origin/main` could not complete because the CLI is unauthenticated and failed auth startup: `Failed to start server. Is port 0 in use?`
- Local code-review skill workflow was followed up to the same authentication blocker.
- Manual review verified action names are already constrained by action manifest validation to portable URL-path-safe handles.

## Validation

- `git diff --check`
- `go test ./internal/sandbox/discovery`
- `go test ./cmd/aileron ./internal/launch ./internal/sandbox/...`
- `pnpm run check`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Documentation**
  * Updated sandbox composition and launch docs to reflect that connector shims are injected at runtime, support discovery and explicit execution via the daemon API, and note remaining follow-on work (live refresh, watcher, proxy bootstrap).

* **New Features**
  * Connector shim scripts can execute installed actions through the daemon API using AILERON_API_URL, accept optional JSON args, and include an Authorization header when a token is set.

* **Tests**
  * Expanded shim-script tests for help/usage, successful dispatch, unknown-action rejection, and failure cases (missing AILERON_API_URL or wget).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/ALRubinger/aileron/pull/886?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->