### PR TITLE
Validate sandbox shim HTTP client

### DIFF
--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -48,7 +48,7 @@ The Aileron extension block starts narrow:
 
 `image` selects the BYO-image tier. `mediation` and `approval_surface` are declared here so the config surface exists before shell mediation and the approval UI add the runtime behavior.
 
-The Aileron-owned base image contains only the runtime substrate: the `aileron` binary/shim entrypoints, discovery files, proxy/session bootstrap, CA installation hooks, and shell mediation files as those features land. It does not carry language runtimes or third-party development tools.
+The Aileron-owned base image contains only the runtime substrate: the `aileron` binary/shim entrypoints, discovery files, the minimal HTTP client used by generated connector shims, proxy/session bootstrap, CA installation hooks, and shell mediation files as those features land. It does not carry language runtimes or third-party development tools.
 
 ## Single-binary alignment
 
@@ -72,7 +72,7 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 `aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is; launch validates the minimal runtime contract before running the agent. Later launch work extends the initial runtime-injection substrate.
 
-`aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image, validates that it can execute `/bin/sh`, use a writable `/home/agent/workspace` mount, and resolve the agent command on `PATH`, then runs the agent command inside a one-shot Docker/Podman container. The project is mounted at `/home/agent/workspace` and used as the container working directory. Launch passes the session-scoped Aileron daemon env into the container, including `AILERON_API_URL` for the daemon `/v1` API used by sandbox-side execution shims, and rewrites loopback daemon URLs to the runtime host alias (`host.docker.internal` for Docker, `host.containers.internal` for Podman).
+`aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image, validates that it can execute `/bin/sh`, use a writable `/home/agent/workspace` mount, and resolve the agent command on `PATH`, then runs the agent command inside a one-shot Docker/Podman container. When generated connector shims are mounted, launch also validates that `wget` is available because those shims use it to reach `AILERON_API_URL`. The project is mounted at `/home/agent/workspace` and used as the container working directory. Launch passes the session-scoped Aileron daemon env into the container, including `AILERON_API_URL` for the daemon `/v1` API used by sandbox-side execution shims, and rewrites loopback daemon URLs to the runtime host alias (`host.docker.internal` for Docker, `host.containers.internal` for Podman).
 
 Launch build behavior is controlled by `--sandbox-build=auto|always|never`. `auto` is the default and builds Tier 0/Tier 1 images only when the selected local image is missing. `always` forces a rebuild. `never` fails if the selected image is not already present. The explicit `aileron sandbox build` command keeps its manual-build behavior.
 

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -139,7 +139,7 @@ aileron launch --sandbox=podman --sandbox-build=never codex
 
 The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_API_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). `AILERON_API_URL` points at the daemon's `/v1` API and is the stable endpoint for sandbox-side execution shims. For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
 
-When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. When installed actions declare connector dependencies, launch also generates a session-scoped static `/etc/aileron/tools.txt` manifest and read-only connector shim scripts under `/usr/local/bin`. These shims support `--help` for discovery and can execute an explicit installed action name through `AILERON_API_URL` with optional raw JSON args. Later runtime work adds live `tools.txt` refresh and the watcher process on top of these generated files.
+When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. When installed actions declare connector dependencies, launch also generates a session-scoped static `/etc/aileron/tools.txt` manifest and read-only connector shim scripts under `/usr/local/bin`. These shims support `--help` for discovery and can execute an explicit installed action name through `AILERON_API_URL` with optional raw JSON args. Generated connector shims require `wget`; Aileron's sandbox-base image includes it, and BYO/devcontainer images that receive shims are validated for it before agent startup. Later runtime work adds live `tools.txt` refresh and the watcher process on top of these generated files.
 
 Before registering the session, launch validates the selected image with the same mount/workdir shape it will use for the agent. The image must:
 
@@ -147,6 +147,7 @@ Before registering the session, launch validates the selected image with the sam
 - use `/home/agent/workspace` as the working directory
 - allow a temporary file to be written in the mounted workspace
 - resolve the agent command on `PATH`
+- provide `wget` when generated connector shims are mounted
 
 The agent command must already exist in the selected image. For Tier 1, install the agent CLI in your devcontainer Dockerfile. Tier 2 uses the BYO image as supplied while Aileron's runtime injection remains limited to session env, manifest mounts, `tools.txt`, and connector shims.
 

--- a/images/sandbox-base/Containerfile
+++ b/images/sandbox-base/Containerfile
@@ -13,7 +13,8 @@ RUN apk add --no-cache \
     grep \
     procps \
     sed \
-    tini
+    tini \
+    wget
 
 RUN addgroup -S agent && adduser -S -G agent -h /home/agent agent \
     && mkdir -p /etc/aileron /opt/aileron/manifests /home/agent/workspace \

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -285,6 +285,7 @@ func (b Builder) Validate(ctx context.Context, opts ValidateOptions) error {
 			validationScript,
 			"aileron-validate",
 			opts.Command[0],
+			boolArg(requiresShimHTTPClient(opts.Volumes)),
 		},
 	})
 	if err == nil {
@@ -313,7 +314,41 @@ if ! command -v "$1" >/dev/null 2>&1; then
   echo "install the agent CLI in the sandbox image or launch with --sandbox=off" >&2
   exit 127
 fi
+if [ "${2:-0}" = "1" ] && ! command -v wget >/dev/null 2>&1; then
+  echo "generated Aileron connector shims require wget in the sandbox image" >&2
+  echo "install wget in the sandbox image or launch with --sandbox=off" >&2
+  exit 127
+fi
+if [ "${2:-0}" = "1" ]; then
+  wget_help="$(wget --help 2>&1 || true)"
+  for flag in "--header" "--post-data" "-T" "-t" "-O"; do
+    case "$wget_help" in
+      *"$flag"*) ;;
+      *)
+        echo "generated Aileron connector shims require wget support for $flag" >&2
+        echo "install GNU wget or an equivalent wget implementation in the sandbox image" >&2
+        exit 127
+        ;;
+    esac
+  done
+fi
 `
+
+func boolArg(value bool) string {
+	if value {
+		return "1"
+	}
+	return "0"
+}
+
+func requiresShimHTTPClient(volumes []Volume) bool {
+	for _, volume := range volumes {
+		if strings.HasPrefix(volume.Target, "/usr/local/bin/") {
+			return true
+		}
+	}
+	return false
+}
 
 // ResolveRuntime returns the container runtime executable to use.
 func ResolveRuntime(name string) (string, error) {

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -622,8 +622,42 @@ func TestValidateRunsMinimalContractProbe(t *testing.T) {
 	if !reflect.DeepEqual(runner.args[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("args prefix = %#v, want %#v", runner.args[:len(wantPrefix)], wantPrefix)
 	}
-	if runner.args[len(runner.args)-1] != "codex" {
-		t.Fatalf("validation command = %q, want codex", runner.args[len(runner.args)-1])
+	if runner.args[len(runner.args)-2] != "codex" {
+		t.Fatalf("validation command = %q, want codex", runner.args[len(runner.args)-2])
+	}
+	if runner.args[len(runner.args)-1] != "0" {
+		t.Fatalf("shim validation flag = %q, want 0", runner.args[len(runner.args)-1])
+	}
+}
+
+func TestValidateRequiresWgetWhenShimsAreMounted(t *testing.T) {
+	dir := t.TempDir()
+	shim := filepath.Join(t.TempDir(), "google")
+	if err := os.WriteFile(shim, []byte("#!/bin/sh\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	runner := &recordingRunner{}
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Image:   "ghcr.io/acme/agent:latest",
+		WorkDir: dir,
+		Volumes: []Volume{{
+			Source:   shim,
+			Target:   "/usr/local/bin/google",
+			ReadOnly: true,
+		}},
+		Command: []string{"codex"},
+	})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if runner.args[len(runner.args)-1] != "1" {
+		t.Fatalf("shim validation flag = %q, want 1", runner.args[len(runner.args)-1])
+	}
+	if !strings.Contains(runner.args[len(runner.args)-4], "generated Aileron connector shims require wget") {
+		t.Fatalf("validation script did not include wget requirement:\n%s", runner.args[len(runner.args)-4])
+	}
+	if !strings.Contains(runner.args[len(runner.args)-4], `"--post-data"`) {
+		t.Fatalf("validation script did not include wget flag probe:\n%s", runner.args[len(runner.args)-4])
 	}
 }
 
@@ -644,6 +678,62 @@ func TestValidateReportsActionableRuntimeFailure(t *testing.T) {
 	for _, want := range []string{
 		"validate sandbox image ghcr.io/acme/agent:latest",
 		"agent command not found in sandbox image: codex",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestValidateReportsMissingWgetForShimImages(t *testing.T) {
+	runner := runnerFunc(func(_ context.Context, _ string, _ []string, _, stderr io.Writer) error {
+		_, _ = stderr.Write([]byte("generated Aileron connector shims require wget in the sandbox image\n"))
+		return errors.New("exit status 127")
+	})
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Image:   "ghcr.io/acme/agent:latest",
+		WorkDir: t.TempDir(),
+		Volumes: []Volume{{
+			Source: filepath.Join(t.TempDir(), "google"),
+			Target: "/usr/local/bin/google",
+		}},
+		Command: []string{"codex"},
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"validate sandbox image ghcr.io/acme/agent:latest",
+		"generated Aileron connector shims require wget in the sandbox image",
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+}
+
+func TestValidateReportsUnsupportedWgetForShimImages(t *testing.T) {
+	runner := runnerFunc(func(_ context.Context, _ string, _ []string, _, stderr io.Writer) error {
+		_, _ = stderr.Write([]byte("generated Aileron connector shims require wget support for --post-data\n"))
+		return errors.New("exit status 127")
+	})
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Image:   "ghcr.io/acme/agent:latest",
+		WorkDir: t.TempDir(),
+		Volumes: []Volume{{
+			Source: filepath.Join(t.TempDir(), "google"),
+			Target: "/usr/local/bin/google",
+		}},
+		Command: []string{"codex"},
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"validate sandbox image ghcr.io/acme/agent:latest",
+		"generated Aileron connector shims require wget support for --post-data",
 	} {
 		if !strings.Contains(msg, want) {
 			t.Fatalf("error %q does not contain %q", msg, want)


### PR DESCRIPTION
## Summary
- install wget in the sandbox-base image so generated connector shims can dispatch through AILERON_API_URL
- validate BYO/devcontainer images for wget only when generated connector shims are mounted
- document the shim HTTP-client requirement in ADR-0017 and sandbox composition docs

## Validation
- git diff --check
- go test ./internal/sandbox/container
- go test ./cmd/aileron ./internal/launch ./internal/sandbox/...
- pnpm run check (docs)
- docker build -t aileron/sandbox-base:codex-wget-validation-test -f images/sandbox-base/Containerfile images/sandbox-base

## Local review
- coderabbit --version: 0.5.2
- coderabbit auth status: not logged in
- coderabbit review --agent --base origin/main: failed during auth startup with `Failed to start server. Is port 0 in use?`
- Manual local review completed after the CodeRabbit CLI auth failure

Refs #796


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Enhanced sandbox launch validation to check for HTTP client support when connector shims are present; base sandbox image now includes wget so shims work out of the box.

* **Documentation**
  * Clarified sandbox composition docs and ADR to document the wget requirement, launch validation behavior, and how session-scoped daemon environment and loopback URLs are handled.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->