### PR TITLE
Record sandbox runtime cut line

### DIFF
--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -48,7 +48,7 @@ The Aileron extension block starts narrow:
 
 `image` selects the BYO-image tier. `mediation` and `approval_surface` are declared here so the config surface exists before shell mediation and the approval UI add the runtime behavior.
 
-The Aileron-owned base image contains only the runtime substrate: the `aileron` binary/shim entrypoints, discovery files, the minimal HTTP client used by generated connector shims, proxy/session bootstrap, CA installation hooks, and shell mediation files as those features land. It does not carry language runtimes or third-party development tools.
+The Aileron-owned base image contains only the runtime substrate: shell utilities, discovery files, and the minimal HTTP client used by generated connector shims. Proxy/session bootstrap, CA installation hooks, and shell mediation files layer onto this base as those features land. The base image does not carry language runtimes or third-party development tools.
 
 ## Single-binary alignment
 
@@ -57,7 +57,7 @@ This ADR follows the updated sandbox runtime direction:
 - Aileron uses one `aileron` binary with multiple modes.
 - This composition contract does not introduce an `aileron-mcp` image or launch path.
 - The canonical credentialed-action path is HTTPS through the Aileron proxy/data plane.
-- Runtime bootstrap supplies `HTTPS_PROXY` and `AILERON_TOKEN` when container/non-loopback daemon access is enabled.
+- Runtime bootstrap supplies `AILERON_API_URL`, `AILERON_TOKEN`, and launch session metadata for the current action-shim path. Later proxy work can add `HTTPS_PROXY` and session CA configuration without changing the composition tiers.
 
 ## CLI surface
 
@@ -70,13 +70,13 @@ The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented s
 
 `aileron sandbox plan` is an inspection helper that reports the normalized tier/image/dockerfile plan.
 
-`aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is; launch validates the minimal runtime contract before running the agent. Later launch work extends the initial runtime-injection substrate.
+`aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker or Podman. Tier 2 BYO images are selected as-is; launch validates the minimal runtime contract before running the agent.
 
 `aileron launch --sandbox=auto|docker|podman` consumes the same build path to prepare the selected image, validates that it can execute `/bin/sh`, use a writable `/home/agent/workspace` mount, and resolve the agent command on `PATH`, then runs the agent command inside a one-shot Docker/Podman container. When generated connector shims are mounted, launch also validates that `wget` is available because those shims use it to reach `AILERON_API_URL`. The project is mounted at `/home/agent/workspace` and used as the container working directory. Launch passes the session-scoped Aileron daemon env into the container, including `AILERON_API_URL` for the daemon `/v1` API used by sandbox-side execution shims, plus discovery hints `AILERON_TOOLS_FILE=/etc/aileron/tools.txt` and `AILERON_SHIMS_DIR=/usr/local/bin`. Local daemon URLs are rewritten to the runtime host alias (`host.docker.internal` for Docker, `host.containers.internal` for Podman).
 
 Launch build behavior is controlled by `--sandbox-build=auto|always|never`. `auto` is the default and builds Tier 0/Tier 1 images only when the selected local image is missing. `always` forces a rebuild. `never` fails if the selected image is not already present. The explicit `aileron sandbox build` command keeps its manual-build behavior.
 
-Sandbox launch also bind-mounts Aileron's installed action manifests and connector store metadata read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors` when the corresponding host directories exist. When installed action manifests declare connector dependencies, launch renders a session-scoped static `tools.txt` manifest and bind-mounts it read-only at `/etc/aileron/tools.txt`; it also renders read-only connector shim scripts under `/usr/local/bin` for `--help` discovery and explicit installed-action execution through `AILERON_API_URL`. Shim calls include the launch session id when `AILERON_SESSION_ID` is available so daemon-side approvals can retain session context. This is the first runtime-injection substrate for discovery and action dispatch; live `tools.txt` refresh and watcher processes remain follow-on work.
+Sandbox launch also bind-mounts Aileron's installed action manifests and connector store metadata read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors` when the corresponding host directories exist. When installed action manifests declare connector dependencies, launch renders a session-scoped static `tools.txt` manifest and bind-mounts it read-only at `/etc/aileron/tools.txt`; it also renders read-only connector shim scripts under `/usr/local/bin` for `--help` discovery and explicit installed-action execution through `AILERON_API_URL`. Shim calls include the launch session id when `AILERON_SESSION_ID` is available so daemon-side approvals can retain session context. This launch-scoped static discovery/action surface is the first complete sandbox runtime path for #796. Live `tools.txt` refresh and watcher processes are deferred until dynamic in-session connector install/update needs them.
 
 The sandbox-base image has a dedicated CI/publish workflow. Pull requests build the image for `linux/amd64` and `linux/arm64` without publishing. Release tags publish the same multi-arch image to GitHub Container Registry as `ghcr.io/alrubinger/aileron-sandbox-base:<version>`.
 
@@ -86,7 +86,7 @@ Users with existing devcontainers get an upgrade path rather than a parallel Ail
 
 Aileron keeps a clear boundary: it owns mediation, credentials, approvals, audit, and runtime bootstrap; users own development tooling in the image.
 
-The first implementations establish the contract, image-build substrate, minimal container execution path, and initial runtime-injection substrate. Live discovery refresh, watcher processes, shell interception, and proxy bootstrap build on this substrate in later sandbox and shell-mediation work.
+The first implementations establish the contract, image-build substrate, container execution path, validation, and launch-scoped discovery/action substrate. That is the #796 cut line before #801: live discovery refresh, watcher processes, shell interception, and proxy/session-CA bootstrap build on this substrate only when later runtime layers need them.
 
 ## Alternatives Considered
 

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -6,7 +6,7 @@ order: 6
 
 Sandbox composition is the contract for deciding which container image an agent session runs in. It is defined by [ADR-0017](/adr/0017-sandbox-composition/) and implemented by the `aileron sandbox` CLI.
 
-This page covers the user-facing workflow. Runtime launch support is intentionally still staged: the current implementation can scaffold, inspect, build, run the agent command in the prepared sandbox image, and inject static discovery/action shims, while later work adds live discovery refresh, proxy bootstrap, and shell mediation.
+This page covers the user-facing workflow. Runtime launch support can scaffold, inspect, build, run the agent command in the prepared sandbox image, and inject static discovery/action shims. Live discovery refresh, proxy/session CA bootstrap, and shell mediation are follow-on runtime layers.
 
 ## Choose a Composition Tier
 
@@ -139,7 +139,7 @@ aileron launch --sandbox=podman --sandbox-build=never codex
 
 The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_API_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, discovery hints (`AILERON_TOOLS_FILE`, `AILERON_SHIMS_DIR`), and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). `AILERON_API_URL` points at the daemon's `/v1` API and is the stable endpoint for sandbox-side execution shims. For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
 
-When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. When installed actions declare connector dependencies, launch also generates a session-scoped static `/etc/aileron/tools.txt` manifest and read-only connector shim scripts under `/usr/local/bin`. These shims support `--help` for discovery and can execute an explicit installed action name through `AILERON_API_URL` with optional raw JSON args. Shim calls include the launch session id when `AILERON_SESSION_ID` is set, so daemon-side approval context stays tied to the sandbox session. Generated connector shims require `wget`; Aileron's sandbox-base image includes it, and BYO/devcontainer images that receive shims are validated for it before agent startup. Later runtime work adds live `tools.txt` refresh and the watcher process on top of these generated files.
+When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. When installed actions declare connector dependencies, launch also generates a session-scoped static `/etc/aileron/tools.txt` manifest and read-only connector shim scripts under `/usr/local/bin`. These shims support `--help` for discovery and can execute an explicit installed action name through `AILERON_API_URL` with optional raw JSON args. Shim calls include the launch session id when `AILERON_SESSION_ID` is set, so daemon-side approval context stays tied to the sandbox session. Generated connector shims require `wget`; Aileron's sandbox-base image includes it, and BYO/devcontainer images that receive shims are validated for it before agent startup. This static launch-scoped discovery/action surface is the current sandbox runtime contract. Live `tools.txt` refresh and watcher processes can layer on later when in-session connector changes need them.
 
 Before registering the session, launch validates the selected image with the same mount/workdir shape it will use for the agent. The image must:
 
@@ -167,14 +167,14 @@ Set `customizations.aileron.image` when your team owns the complete image:
 }
 ```
 
-In BYO-image mode, launch currently uses the image as supplied and layers on Aileron's session env, manifest mounts, generated discovery files, and connector shims. Later runtime launch work extends that contract with proxy bootstrap, session CA, and shell mediation files.
+In BYO-image mode, launch uses the image as supplied and layers on Aileron's session env, manifest mounts, generated discovery files, and connector shims. Later runtime launch work can extend that contract with proxy bootstrap, session CA, and shell mediation files.
 
 ## What Belongs in the Image
 
 Put ordinary project tooling in the devcontainer: language runtimes, CLIs, package managers, private CA bundles, and internal helper tools.
 
-Do not put Aileron credentials or user secrets in the image. Credentialed traffic is designed to flow through the Aileron HTTPS proxy/data plane. Runtime bootstrap supplies proxy configuration when that layer lands.
+Do not put Aileron credentials or user secrets in the image. Current generated action shims call the Aileron daemon API with the launch token and session context. Later credentialed network flows are designed to use the Aileron HTTPS proxy/data plane when that layer lands.
 
 ## What This Does Not Do Yet
 
-This slice does not add live discovery refresh, proxy bootstrap, or shell command mediation. Generated session-scoped `/etc/aileron/tools.txt` and read-only connector shims support `--help` discovery, and the shims can execute installed actions via `AILERON_API_URL` with optional raw JSON args. Follow-on work adds the discovery watcher, proxy bootstrap, and shell-layer interception.
+This runtime path does not add live discovery refresh, proxy bootstrap, or shell command mediation. Generated session-scoped `/etc/aileron/tools.txt` and read-only connector shims support `--help` discovery, and the shims can execute installed actions via `AILERON_API_URL` with optional raw JSON args. Follow-on work adds live discovery refresh only if dynamic in-session connector changes require it; proxy/session CA bootstrap and shell-layer interception are later runtime layers.


### PR DESCRIPTION
## Summary
- document launch-scoped static discovery/action shims as the current #796 sandbox runtime contract
- clarify that live discovery refresh, proxy/session CA bootstrap, and shell mediation are follow-on runtime layers rather than blockers for this cut
- align ADR-0017 and the sandbox composition guide with the runtime path now landed through #890

## Validation
- git diff --check
- pnpm run check (docs)
- coderabbit review --agent --base origin/main attempted; failed locally with auth startup error: Failed to start server. Is port 0 in use?
- code-review skill local pass: reviewed docs diff manually after CodeRabbit auth failure; no actionable findings

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sandbox composition documentation to clarify runtime workflow stages and current implementation scope
  * Enhanced user workflow documentation for sandbox build and launch operations  
  * Clarified runtime contract regarding environment variables, file mounts, and connector scripts

<!-- end of auto-generated comment: release notes by coderabbit.ai -->