### PR TITLE
Add sandbox proxy bootstrap env

### DIFF
--- a/docs/src/content/docs/adr/0019-v4-https-data-plane.md
+++ b/docs/src/content/docs/adr/0019-v4-https-data-plane.md
@@ -33,6 +33,8 @@ The current `AILERON_API_URL` shim dispatch path remains valid for explicit inst
 
 The first #896 implementation slice establishes the daemon-side connector-operation endpoint at `POST /v1/connector-operations/run`. Generated spec shims can reach this stable contract now; the daemon resolves installed spec metadata, audits recognized attempts, and fails closed with `501 not_implemented` until session CA bootstrap, `HTTPS_PROXY`, and credential injection are implemented behind the same contract.
 
+The second #896 slice adds an internal opt-in bootstrap mode for launch validation and follow-on implementation work. When `AILERON_SANDBOX_PROXY_BOOTSTRAP=1` is set for a sandboxed launch, Aileron generates a session-local CA under the daemon state directory, mounts the public CA into the container at `/etc/aileron/proxy/ca.pem`, and sets `HTTPS_PROXY`, `HTTP_PROXY`, and `NO_PROXY` for the agent container. This does not yet install the CA into the image trust store, run a credential-injecting proxy, or make credentialed HTTPS execution succeed; it only establishes the launch/session metadata boundary that the data plane will use.
+
 ## Consequences
 
 Images must be able to trust the session CA or fail before the agent starts. BYO images need documented trust-store requirements and actionable launch validation.

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -150,6 +150,8 @@ aileron launch --sandbox=podman --sandbox-build=never codex
 
 The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_API_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, discovery hints (`AILERON_TOOLS_FILE`, `AILERON_SHIMS_DIR`), and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). `AILERON_API_URL` points at the daemon's `/v1` API and is the stable endpoint for sandbox-side execution shims. For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
 
+An internal proxy-bootstrap mode is available for development of the #896 HTTPS data plane. When `AILERON_SANDBOX_PROXY_BOOTSTRAP=1` is set, sandbox launch generates a session-local CA, mounts the public CA at `/etc/aileron/proxy/ca.pem`, and sets standard proxy env (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`) plus Aileron metadata (`AILERON_SANDBOX_PROXY_MODE`, `AILERON_SANDBOX_PROXY_URL`, `AILERON_SANDBOX_PROXY_CA_FILE`). This mode is not yet a user-facing credential mediation feature: the CA is not installed into the image trust store, and credential injection at the proxy boundary remains follow-on #896 work.
+
 When installed action manifests or connector store metadata exist on the host, launch mounts them read-only under `/opt/aileron/manifests/actions` and `/opt/aileron/manifests/connectors`. Launch also generates a session-scoped static `/etc/aileron/tools.txt` manifest and read-only connector shim scripts under `/usr/local/bin` from two sources:
 
 - installed action manifests, which create shims that can execute an explicit installed action name through `AILERON_API_URL` with optional raw JSON args
@@ -183,7 +185,7 @@ Set `customizations.aileron.image` when your team owns the complete image:
 }
 ```
 
-In BYO-image mode, launch uses the image as supplied and layers on Aileron's session env, manifest mounts, generated discovery files, and connector shims. Later runtime launch work can extend that contract with proxy bootstrap, session CA, and shell mediation files.
+In BYO-image mode, launch uses the image as supplied and layers on Aileron's session env, manifest mounts, generated discovery files, and connector shims. Later runtime launch work can extend that contract with trusted proxy bootstrap, session CA installation, and shell mediation files.
 
 ## What Belongs in the Image
 
@@ -193,4 +195,4 @@ Do not put Aileron credentials or user secrets in the image. Current generated a
 
 ## What This Does Not Do Yet
 
-This runtime path does not add live discovery refresh, proxy bootstrap, or shell command mediation. Generated session-scoped `/etc/aileron/tools.txt` and read-only connector shims support `--help` discovery; action shims can execute installed actions via `AILERON_API_URL`, and spec-backed operation shims call the stable `/connector-operations/run` daemon API contract. Follow-on work adds the mediated execution path behind connector-operation shims ([#896](https://github.com/ALRubinger/aileron/issues/896)), live discovery refresh only if dynamic in-session connector changes require it ([#897](https://github.com/ALRubinger/aileron/issues/897)), proxy/session CA bootstrap and credentialed HTTPS data-plane mediation ([ADR-0019](/adr/0019-v4-https-data-plane/)), and shell-layer interception ([#801](https://github.com/ALRubinger/aileron/issues/801), [ADR-0021](/adr/0021-v4-shell-layer-mediation/)).
+This runtime path does not add live discovery refresh, trusted proxy execution, or shell command mediation. Generated session-scoped `/etc/aileron/tools.txt` and read-only connector shims support `--help` discovery; action shims can execute installed actions via `AILERON_API_URL`, and spec-backed operation shims call the stable `/connector-operations/run` daemon API contract. Follow-on work adds the mediated execution path behind connector-operation shims ([#896](https://github.com/ALRubinger/aileron/issues/896)), live discovery refresh only if dynamic in-session connector changes require it ([#897](https://github.com/ALRubinger/aileron/issues/897)), session CA trust-store installation and credentialed HTTPS data-plane mediation ([ADR-0019](/adr/0019-v4-https-data-plane/)), and shell-layer interception ([#801](https://github.com/ALRubinger/aileron/issues/801), [ADR-0021](/adr/0021-v4-shell-layer-mediation/)).

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -203,7 +203,7 @@ func prepareSandbox(ctx context.Context, workDir, runtimeName, buildPolicy strin
 
 var prepareSandboxForLaunch = prepareSandbox
 
-func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig) error {
+func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, agentEnv map[string]string, extraMounts ...sandboxcontainer.Volume) error {
 	commandName := firstAgentBinary(config.Agent)
 	if commandName == "" {
 		return fmt.Errorf("agent %q has no container command", config.Agent.Name())
@@ -213,13 +213,14 @@ func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchC
 		return err
 	}
 	defer cleanupMounts()
-	if err := validateSandboxImageForLaunch(ctx, plan, config, mounts, commandName); err != nil {
+	mounts = append(mounts, extraMounts...)
+	if err := validateSandboxImageForLaunch(ctx, plan, config, agentEnv, mounts, commandName); err != nil {
 		return fmt.Errorf("sandbox image %s is not launchable for %s: %w", plan.Image, config.Agent.Name(), err)
 	}
 	return nil
 }
 
-func validateSandboxImage(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, mounts []sandboxcontainer.Volume, commandName string) error {
+func validateSandboxImage(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, agentEnv map[string]string, mounts []sandboxcontainer.Volume, commandName string) error {
 	if err := (sandboxcontainer.Builder{
 		Runtime: plan.Runtime,
 		Stdout:  io.Discard,
@@ -227,6 +228,7 @@ func validateSandboxImage(ctx context.Context, plan SandboxLaunchPlan, config La
 		Runtime: plan.Runtime,
 		Image:   plan.Image,
 		WorkDir: config.Dir,
+		Env:     agentEnv,
 		Volumes: mounts,
 		Command: []string{commandName},
 	}); err != nil {
@@ -294,9 +296,6 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 			fmt.Fprint(os.Stderr, ", built=true")
 		}
 		fmt.Fprintln(os.Stderr, ")")
-		if err := validateSandboxForLaunch(ctx, sandboxPlan, config); err != nil {
-			return LaunchResult{}, err
-		}
 	}
 
 	regCtx, cancelReg := context.WithTimeout(ctx, daemonHTTPTimeout)
@@ -305,6 +304,15 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	if err != nil {
 		return LaunchResult{}, fmt.Errorf("register session: %w", err)
 	}
+	sessionClosed := false
+	defer func() {
+		if sessionClosed {
+			return
+		}
+		endCtx, cancelEnd := context.WithTimeout(context.Background(), daemonHTTPTimeout)
+		_ = client.EndSession(endCtx, sessionID, nil)
+		cancelEnd()
+	}()
 
 	agentEndpointURL := daemonURL
 	if sandboxEnabled {
@@ -335,6 +343,11 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 			return LaunchResult{}, fmt.Errorf("prepare sandbox proxy bootstrap: %w", err)
 		}
 		applySandboxProxyBootstrapEnv(agentEnv, proxyBootstrap)
+	}
+	if sandboxEnabled {
+		if err := validateSandboxForLaunch(ctx, sandboxPlan, config, agentEnv, proxyBootstrap.Mounts...); err != nil {
+			return LaunchResult{}, err
+		}
 	}
 
 	sessionLog, closeSessionLog := openSessionLogger(config.Dir, config.LogLevel)
@@ -375,6 +388,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		sessionLog.Warn("end session", "error", endErr)
 	}
 	cancelEnd()
+	sessionClosed = true
 
 	sessionLog.Info("session ended", "exit_code", result.ExitCode)
 	return result, runErr

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -40,6 +40,7 @@ const MCPServerName = "aileron"
 const (
 	sandboxToolsFilePath = "/etc/aileron/tools.txt"
 	sandboxShimsDirPath  = "/usr/local/bin"
+	sandboxProxyCAPath   = "/etc/aileron/proxy/ca.pem"
 )
 
 // LaunchConfig holds the configuration for launching an agent.
@@ -310,6 +311,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		agentEndpointURL = containerURLForRuntime(daemonURL, sandboxPlan.Runtime)
 	}
 	agentEnv := composeAgentEnv(config.Agent.Env(), config.Agent.LLMEndpointEnv(), agentEndpointURL)
+	var proxyBootstrap sandboxProxyBootstrap
 	if sandboxPlan.Image != "" {
 		agentEnv["AILERON_SANDBOX_IMAGE"] = sandboxPlan.Image
 		agentEnv["AILERON_SANDBOX_TIER"] = string(sandboxPlan.Tier)
@@ -328,6 +330,11 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		if daemonToken != "" {
 			agentEnv["AILERON_TOKEN"] = daemonToken
 		}
+		proxyBootstrap, err = prepareSandboxProxyBootstrap(stateDir, sessionID, agentEndpointURL)
+		if err != nil {
+			return LaunchResult{}, fmt.Errorf("prepare sandbox proxy bootstrap: %w", err)
+		}
+		applySandboxProxyBootstrapEnv(agentEnv, proxyBootstrap)
 	}
 
 	sessionLog, closeSessionLog := openSessionLogger(config.Dir, config.LogLevel)
@@ -344,6 +351,9 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		"sandbox_image", sandboxPlan.Image,
 		"sandbox_tier", sandboxPlan.Tier,
 		"sandbox_runtime", sandboxPlan.Runtime,
+		"sandbox_proxy_mode", proxyBootstrap.Mode,
+		"sandbox_proxy_url", proxyBootstrap.ProxyURL,
+		"sandbox_proxy_ca_path", proxyBootstrap.CAPath,
 	)
 
 	probeCtx, cancelProbe := context.WithTimeout(ctx, daemonHTTPTimeout)
@@ -354,7 +364,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	var result LaunchResult
 	var runErr error
 	if sandboxEnabled {
-		result, runErr = launchSandbox(ctx, sandboxPlan, config, agentEnv)
+		result, runErr = launchSandbox(ctx, sandboxPlan, config, agentEnv, proxyBootstrap.Mounts...)
 	} else {
 		result, runErr = launchHost(ctx, config, daemonURL, sessionID, agentEnv)
 	}
@@ -504,7 +514,7 @@ func launchHost(ctx context.Context, config LaunchConfig, daemonURL, sessionID s
 	return launchDirect(cmd, config)
 }
 
-func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, agentEnv map[string]string) (LaunchResult, error) {
+func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, agentEnv map[string]string, extraMounts ...sandboxcontainer.Volume) (LaunchResult, error) {
 	commandName := firstAgentBinary(config.Agent)
 	if commandName == "" {
 		return LaunchResult{}, fmt.Errorf("agent %q has no container command", config.Agent.Name())
@@ -514,6 +524,7 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 		return LaunchResult{}, err
 	}
 	defer cleanupMounts()
+	mounts = append(mounts, extraMounts...)
 	command := append([]string{commandName}, config.Agent.Args()...)
 	command = append(command, config.Args...)
 	_, err = sandboxcontainer.Builder{

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -154,7 +154,7 @@ func TestLaunchSandboxRejectsAgentWithoutBinary(t *testing.T) {
 func TestValidateSandboxRejectsAgentWithoutBinary(t *testing.T) {
 	err := validateSandbox(nil, SandboxLaunchPlan{Runtime: "docker", Image: "image:test"}, LaunchConfig{
 		Agent: emptyBinaryAgent{},
-	})
+	}, nil)
 	if err == nil {
 		t.Fatal("expected missing container command error")
 	}
@@ -174,7 +174,7 @@ func TestValidateSandboxPassesRuntimeMounts(t *testing.T) {
 	orig := validateSandboxImageForLaunch
 	t.Cleanup(func() { validateSandboxImageForLaunch = orig })
 	var got []sandboxcontainer.Volume
-	validateSandboxImageForLaunch = func(_ context.Context, _ SandboxLaunchPlan, _ LaunchConfig, mounts []sandboxcontainer.Volume, commandName string) error {
+	validateSandboxImageForLaunch = func(_ context.Context, _ SandboxLaunchPlan, _ LaunchConfig, _ map[string]string, mounts []sandboxcontainer.Volume, commandName string) error {
 		got = append(got, mounts...)
 		if commandName != "codex" {
 			t.Fatalf("commandName = %q, want codex", commandName)
@@ -185,7 +185,7 @@ func TestValidateSandboxPassesRuntimeMounts(t *testing.T) {
 	err := validateSandbox(context.Background(), SandboxLaunchPlan{Runtime: "docker", Image: "image:test"}, LaunchConfig{
 		Agent: namedBinaryAgent{name: "codex"},
 		Dir:   t.TempDir(),
-	})
+	}, nil)
 	if err != nil {
 		t.Fatalf("validateSandbox: %v", err)
 	}
@@ -193,6 +193,41 @@ func TestValidateSandboxPassesRuntimeMounts(t *testing.T) {
 		if !hasMountTarget(got, target) {
 			t.Fatalf("validateSandbox mounts = %#v, want target %s", got, target)
 		}
+	}
+}
+
+func TestValidateSandboxPassesExtraMountsAndEnv(t *testing.T) {
+	orig := validateSandboxImageForLaunch
+	t.Cleanup(func() { validateSandboxImageForLaunch = orig })
+	agentEnv := map[string]string{"HTTPS_PROXY": "http://host.docker.internal:48123"}
+	extraMount := sandboxcontainer.Volume{
+		Source:   filepath.Join(t.TempDir(), "ca.pem"),
+		Target:   sandboxProxyCAPath,
+		ReadOnly: true,
+	}
+	var gotEnv map[string]string
+	var gotMounts []sandboxcontainer.Volume
+	validateSandboxImageForLaunch = func(_ context.Context, _ SandboxLaunchPlan, _ LaunchConfig, env map[string]string, mounts []sandboxcontainer.Volume, commandName string) error {
+		gotEnv = env
+		gotMounts = append(gotMounts, mounts...)
+		if commandName != "codex" {
+			t.Fatalf("commandName = %q, want codex", commandName)
+		}
+		return nil
+	}
+
+	err := validateSandbox(context.Background(), SandboxLaunchPlan{Runtime: "docker", Image: "image:test"}, LaunchConfig{
+		Agent: namedBinaryAgent{name: "codex"},
+		Dir:   t.TempDir(),
+	}, agentEnv, extraMount)
+	if err != nil {
+		t.Fatalf("validateSandbox: %v", err)
+	}
+	if gotEnv["HTTPS_PROXY"] != "http://host.docker.internal:48123" {
+		t.Fatalf("validation env = %#v", gotEnv)
+	}
+	if !hasMountTarget(gotMounts, sandboxProxyCAPath) {
+		t.Fatalf("validation mounts = %#v, missing %s", gotMounts, sandboxProxyCAPath)
 	}
 }
 

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -250,6 +250,66 @@ func TestLaunch_SandboxBYOImageRunsContainer(t *testing.T) {
 	if !regexp.MustCompile(`--env\nAILERON_API_URL=http://host\.docker\.internal:[0-9]+/v1\n`).MatchString(args) {
 		t.Errorf("expected container AILERON_API_URL /v1 env in docker args:\n%s", args)
 	}
+	for _, unwanted := range []string{"HTTPS_PROXY=", "HTTP_PROXY=", "AILERON_SANDBOX_PROXY_MODE="} {
+		if strings.Contains(args, unwanted) {
+			t.Errorf("did not expect proxy bootstrap env %q by default:\n%s", unwanted, args)
+		}
+	}
+}
+
+func TestLaunch_SandboxProxyBootstrapEnvAndCAMount(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("AILERON_SANDBOX_PROXY_BOOTSTRAP", "1")
+
+	dir := t.TempDir()
+	devcontainerDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(`{"customizations":{"aileron":{"image":"ghcr.io/acme/agent:latest"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	argsFile := filepath.Join(dir, "docker-args.txt")
+	docker := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" > "+argsFile+"\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:          scriptAgent{script: "codex"},
+		Dir:            dir,
+		SandboxRuntime: "docker",
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read docker args: %v", err)
+	}
+	args := string(data)
+	caPath := filepath.Join(home, ".aileron", "sessions", "01HK0000000000000000000FAK", "sandbox-proxy", "ca.pem")
+	if _, err := os.Stat(caPath); err != nil {
+		t.Fatalf("stat generated CA: %v", err)
+	}
+	for _, want := range []string{
+		"--volume\n" + caPath + ":/etc/aileron/proxy/ca.pem:ro\n",
+		"--env\nAILERON_SANDBOX_PROXY_CA_FILE=/etc/aileron/proxy/ca.pem\n",
+		"--env\nAILERON_SANDBOX_PROXY_MODE=bootstrap\n",
+		"--env\nAILERON_SANDBOX_PROXY_URL=http://host.docker.internal:",
+		"--env\nHTTPS_PROXY=http://host.docker.internal:",
+		"--env\nHTTP_PROXY=http://host.docker.internal:",
+		"host.docker.internal",
+		"host.containers.internal",
+	} {
+		if !strings.Contains(args, want) {
+			t.Fatalf("run call missing %q:\n%s", want, args)
+		}
+	}
 }
 
 func TestLaunch_SandboxMountsAileronManifestStores(t *testing.T) {

--- a/internal/launch/proxy_bootstrap.go
+++ b/internal/launch/proxy_bootstrap.go
@@ -35,6 +35,9 @@ func prepareSandboxProxyBootstrap(stateDir, sessionID, agentEndpointURL string) 
 	if strings.TrimSpace(sessionID) == "" {
 		return sandboxProxyBootstrap{}, fmt.Errorf("session id is required")
 	}
+	if err := validateProxyBootstrapSessionID(sessionID); err != nil {
+		return sandboxProxyBootstrap{}, err
+	}
 	proxyURL := strings.TrimRight(agentEndpointURL, "/")
 	if proxyURL == "" {
 		return sandboxProxyBootstrap{}, fmt.Errorf("agent endpoint URL is required")
@@ -56,6 +59,16 @@ func prepareSandboxProxyBootstrap(stateDir, sessionID, agentEndpointURL string) 
 			ReadOnly: true,
 		}},
 	}, nil
+}
+
+func validateProxyBootstrapSessionID(sessionID string) error {
+	if sessionID != strings.TrimSpace(sessionID) {
+		return fmt.Errorf("session id must not contain surrounding whitespace")
+	}
+	if sessionID == "." || sessionID == ".." || filepath.Clean(sessionID) != sessionID || filepath.Base(sessionID) != sessionID || strings.ContainsAny(sessionID, `/\`) {
+		return fmt.Errorf("session id %q is not a safe path segment", sessionID)
+	}
+	return nil
 }
 
 func sandboxProxyBootstrapEnabled() bool {

--- a/internal/launch/proxy_bootstrap.go
+++ b/internal/launch/proxy_bootstrap.go
@@ -1,0 +1,151 @@
+package launch
+
+import (
+	"crypto/rand"
+	"crypto/rsa"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"fmt"
+	"math/big"
+	"net"
+	"net/url"
+	"os"
+	"path/filepath"
+	"strings"
+	"time"
+
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+const sandboxProxyBootstrapEnv = "AILERON_SANDBOX_PROXY_BOOTSTRAP"
+
+type sandboxProxyBootstrap struct {
+	Mode     string
+	ProxyURL string
+	CAPath   string
+	KeyPath  string
+	Mounts   []sandboxcontainer.Volume
+}
+
+func prepareSandboxProxyBootstrap(stateDir, sessionID, agentEndpointURL string) (sandboxProxyBootstrap, error) {
+	if !sandboxProxyBootstrapEnabled() {
+		return sandboxProxyBootstrap{}, nil
+	}
+	if strings.TrimSpace(sessionID) == "" {
+		return sandboxProxyBootstrap{}, fmt.Errorf("session id is required")
+	}
+	proxyURL := strings.TrimRight(agentEndpointURL, "/")
+	if proxyURL == "" {
+		return sandboxProxyBootstrap{}, fmt.Errorf("agent endpoint URL is required")
+	}
+	root := filepath.Join(stateDir, "sessions", sessionID, "sandbox-proxy")
+	caPath := filepath.Join(root, "ca.pem")
+	keyPath := filepath.Join(root, "ca.key")
+	if err := writeSessionCA(caPath, keyPath, sessionID); err != nil {
+		return sandboxProxyBootstrap{}, err
+	}
+	return sandboxProxyBootstrap{
+		Mode:     "bootstrap",
+		ProxyURL: proxyURL,
+		CAPath:   caPath,
+		KeyPath:  keyPath,
+		Mounts: []sandboxcontainer.Volume{{
+			Source:   caPath,
+			Target:   sandboxProxyCAPath,
+			ReadOnly: true,
+		}},
+	}, nil
+}
+
+func sandboxProxyBootstrapEnabled() bool {
+	switch strings.ToLower(strings.TrimSpace(os.Getenv(sandboxProxyBootstrapEnv))) {
+	case "1", "true", "yes", "on", "bootstrap":
+		return true
+	default:
+		return false
+	}
+}
+
+func applySandboxProxyBootstrapEnv(agentEnv map[string]string, bootstrap sandboxProxyBootstrap) {
+	if bootstrap.Mode == "" {
+		return
+	}
+	agentEnv["AILERON_SANDBOX_PROXY_MODE"] = bootstrap.Mode
+	agentEnv["AILERON_SANDBOX_PROXY_URL"] = bootstrap.ProxyURL
+	agentEnv["AILERON_SANDBOX_PROXY_CA_FILE"] = sandboxProxyCAPath
+	agentEnv["HTTPS_PROXY"] = bootstrap.ProxyURL
+	agentEnv["HTTP_PROXY"] = bootstrap.ProxyURL
+	agentEnv["NO_PROXY"] = mergeNoProxy(agentEnv["NO_PROXY"], bootstrap.ProxyURL)
+}
+
+func mergeNoProxy(existing, proxyURL string) string {
+	entries := []string{}
+	seen := map[string]struct{}{}
+	add := func(value string) {
+		value = strings.TrimSpace(value)
+		if value == "" {
+			return
+		}
+		if _, ok := seen[value]; ok {
+			return
+		}
+		seen[value] = struct{}{}
+		entries = append(entries, value)
+	}
+	for _, value := range strings.Split(existing, ",") {
+		add(value)
+	}
+	for _, value := range []string{"localhost", "127.0.0.1", "::1", "host.docker.internal", "host.containers.internal"} {
+		add(value)
+	}
+	if parsed, err := url.Parse(proxyURL); err == nil {
+		host := parsed.Hostname()
+		add(host)
+		if ip := net.ParseIP(host); ip != nil {
+			add(ip.String())
+		}
+	}
+	return strings.Join(entries, ",")
+}
+
+func writeSessionCA(caPath, keyPath, sessionID string) error {
+	if err := os.MkdirAll(filepath.Dir(caPath), 0o700); err != nil {
+		return fmt.Errorf("create sandbox proxy CA dir: %w", err)
+	}
+	key, err := rsa.GenerateKey(rand.Reader, 2048)
+	if err != nil {
+		return fmt.Errorf("generate sandbox proxy CA key: %w", err)
+	}
+	serialLimit := new(big.Int).Lsh(big.NewInt(1), 128)
+	serial, err := rand.Int(rand.Reader, serialLimit)
+	if err != nil {
+		return fmt.Errorf("generate sandbox proxy CA serial: %w", err)
+	}
+	now := time.Now().UTC()
+	template := x509.Certificate{
+		SerialNumber: serial,
+		Subject: pkix.Name{
+			CommonName:   "Aileron sandbox session CA",
+			Organization: []string{"Aileron"},
+		},
+		NotBefore:             now.Add(-time.Minute),
+		NotAfter:              now.Add(12 * time.Hour),
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+		BasicConstraintsValid: true,
+		IsCA:                  true,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, &template, &template, &key.PublicKey, key)
+	if err != nil {
+		return fmt.Errorf("create sandbox proxy CA cert: %w", err)
+	}
+	certPEM := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(caPath, certPEM, 0o644); err != nil {
+		return fmt.Errorf("write sandbox proxy CA cert: %w", err)
+	}
+	keyPEM := pem.EncodeToMemory(&pem.Block{Type: "RSA PRIVATE KEY", Bytes: x509.MarshalPKCS1PrivateKey(key)})
+	if err := os.WriteFile(keyPath, keyPEM, 0o600); err != nil {
+		return fmt.Errorf("write sandbox proxy CA key: %w", err)
+	}
+	return nil
+}

--- a/internal/launch/proxy_bootstrap_test.go
+++ b/internal/launch/proxy_bootstrap_test.go
@@ -64,6 +64,37 @@ func TestPrepareSandboxProxyBootstrap_GeneratesSessionCAAndMount(t *testing.T) {
 	}
 }
 
+func TestPrepareSandboxProxyBootstrap_RejectsUnsafeSessionID(t *testing.T) {
+	t.Setenv(sandboxProxyBootstrapEnv, "1")
+	for _, sessionID := range []string{"../escape", "nested/session", `nested\session`, " session-123", "session-123 ", ".", ".."} {
+		t.Run(sessionID, func(t *testing.T) {
+			_, err := prepareSandboxProxyBootstrap(t.TempDir(), sessionID, "http://host.docker.internal:48123")
+			if err == nil {
+				t.Fatal("expected unsafe session id error")
+			}
+		})
+	}
+}
+
+func TestPrepareSandboxProxyBootstrap_RequiresAgentEndpointURL(t *testing.T) {
+	t.Setenv(sandboxProxyBootstrapEnv, "1")
+	_, err := prepareSandboxProxyBootstrap(t.TempDir(), "session-123", "")
+	if err == nil {
+		t.Fatal("expected agent endpoint URL error")
+	}
+}
+
+func TestWriteSessionCA_ReturnsCreateDirError(t *testing.T) {
+	parentFile := filepath.Join(t.TempDir(), "not-a-dir")
+	if err := os.WriteFile(parentFile, []byte("x"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	err := writeSessionCA(filepath.Join(parentFile, "ca.pem"), filepath.Join(parentFile, "ca.key"), "session-123")
+	if err == nil {
+		t.Fatal("expected create dir error")
+	}
+}
+
 func TestApplySandboxProxyBootstrapEnv(t *testing.T) {
 	env := map[string]string{"NO_PROXY": "internal.example"}
 	applySandboxProxyBootstrapEnv(env, sandboxProxyBootstrap{

--- a/internal/launch/proxy_bootstrap_test.go
+++ b/internal/launch/proxy_bootstrap_test.go
@@ -1,0 +1,90 @@
+package launch
+
+import (
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestPrepareSandboxProxyBootstrap_DefaultOff(t *testing.T) {
+	t.Setenv(sandboxProxyBootstrapEnv, "")
+	got, err := prepareSandboxProxyBootstrap(t.TempDir(), "session-123", "http://host.docker.internal:48123")
+	if err != nil {
+		t.Fatalf("prepareSandboxProxyBootstrap: %v", err)
+	}
+	if got.Mode != "" || got.ProxyURL != "" || len(got.Mounts) != 0 {
+		t.Fatalf("bootstrap = %+v, want zero value", got)
+	}
+}
+
+func TestPrepareSandboxProxyBootstrap_GeneratesSessionCAAndMount(t *testing.T) {
+	t.Setenv(sandboxProxyBootstrapEnv, "1")
+	stateDir := t.TempDir()
+	got, err := prepareSandboxProxyBootstrap(stateDir, "session-123", "http://host.docker.internal:48123/")
+	if err != nil {
+		t.Fatalf("prepareSandboxProxyBootstrap: %v", err)
+	}
+	if got.Mode != "bootstrap" {
+		t.Fatalf("Mode = %q, want bootstrap", got.Mode)
+	}
+	if got.ProxyURL != "http://host.docker.internal:48123" {
+		t.Fatalf("ProxyURL = %q", got.ProxyURL)
+	}
+	wantCAPath := filepath.Join(stateDir, "sessions", "session-123", "sandbox-proxy", "ca.pem")
+	if got.CAPath != wantCAPath {
+		t.Fatalf("CAPath = %q, want %q", got.CAPath, wantCAPath)
+	}
+	if len(got.Mounts) != 1 {
+		t.Fatalf("mounts = %+v, want one", got.Mounts)
+	}
+	if got.Mounts[0].Source != got.CAPath || got.Mounts[0].Target != sandboxProxyCAPath || !got.Mounts[0].ReadOnly {
+		t.Fatalf("mount = %+v", got.Mounts[0])
+	}
+
+	data, err := os.ReadFile(got.CAPath)
+	if err != nil {
+		t.Fatalf("read CA: %v", err)
+	}
+	block, _ := pem.Decode(data)
+	if block == nil || block.Type != "CERTIFICATE" {
+		t.Fatalf("CA PEM block = %#v", block)
+	}
+	cert, err := x509.ParseCertificate(block.Bytes)
+	if err != nil {
+		t.Fatalf("parse CA: %v", err)
+	}
+	if !cert.IsCA {
+		t.Fatal("generated certificate is not a CA")
+	}
+	if _, err := os.Stat(got.KeyPath); err != nil {
+		t.Fatalf("stat CA key: %v", err)
+	}
+}
+
+func TestApplySandboxProxyBootstrapEnv(t *testing.T) {
+	env := map[string]string{"NO_PROXY": "internal.example"}
+	applySandboxProxyBootstrapEnv(env, sandboxProxyBootstrap{
+		Mode:     "bootstrap",
+		ProxyURL: "http://host.docker.internal:48123",
+	})
+
+	for key, want := range map[string]string{
+		"AILERON_SANDBOX_PROXY_MODE":    "bootstrap",
+		"AILERON_SANDBOX_PROXY_URL":     "http://host.docker.internal:48123",
+		"AILERON_SANDBOX_PROXY_CA_FILE": sandboxProxyCAPath,
+		"HTTPS_PROXY":                   "http://host.docker.internal:48123",
+		"HTTP_PROXY":                    "http://host.docker.internal:48123",
+	} {
+		if got := env[key]; got != want {
+			t.Fatalf("%s = %q, want %q", key, got, want)
+		}
+	}
+	for _, want := range []string{"internal.example", "localhost", "127.0.0.1", "::1", "host.docker.internal", "host.containers.internal"} {
+		if !strings.Contains(env["NO_PROXY"], want) {
+			t.Fatalf("NO_PROXY = %q, missing %q", env["NO_PROXY"], want)
+		}
+	}
+}

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -98,6 +98,7 @@ type ValidateOptions struct {
 	Runtime string
 	Image   string
 	WorkDir string
+	Env     map[string]string
 	Volumes []Volume
 	Command []string
 }
@@ -279,6 +280,7 @@ func (b Builder) Validate(ctx context.Context, opts ValidateOptions) error {
 		Runtime: opts.Runtime,
 		Image:   opts.Image,
 		WorkDir: opts.WorkDir,
+		Env:     opts.Env,
 		Volumes: opts.Volumes,
 		Command: []string{
 			"/bin/sh",

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -595,6 +595,9 @@ func TestValidateRunsMinimalContractProbe(t *testing.T) {
 	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
 		Image:   "ghcr.io/acme/agent:latest",
 		WorkDir: dir,
+		Env: map[string]string{
+			"HTTPS_PROXY": "http://host.docker.internal:48123",
+		},
 		Volumes: []Volume{{
 			Source:   manifest,
 			Target:   "/etc/aileron/tools.txt",
@@ -613,6 +616,7 @@ func TestValidateRunsMinimalContractProbe(t *testing.T) {
 		"--workdir", WorkspacePath,
 		"--volume", dir + ":" + WorkspacePath,
 		"--volume", manifest + ":/etc/aileron/tools.txt:ro",
+		"--env", "HTTPS_PROXY=http://host.docker.internal:48123",
 		"ghcr.io/acme/agent:latest",
 		"/bin/sh", "-c",
 	}


### PR DESCRIPTION
## Summary
- add an internal opt-in sandbox proxy bootstrap mode via AILERON_SANDBOX_PROXY_BOOTSTRAP=1
- generate a session-local CA/key, mount the public CA into sandboxed launches, and set proxy env/metadata
- document the #896 bootstrap boundary while keeping credential injection and trusted proxy execution as follow-on work

## Scope
This does not install the CA into image trust stores, run a credential-injecting proxy, or enable successful credentialed HTTPS mediation. It only establishes the launch/session metadata and mount boundary for the next #896 data-plane slice.

Refs #896
Refs #747

## Verification
- go test ./internal/launch ./internal/sandbox/container
- go test ./cmd/aileron/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./internal/... ./sdk/go/... ./test/integration/... (integration glob matched no packages)
- pnpm run check (docs)
- node design/build/generate-tokens.mjs, then pnpm run build (docs)
- git diff --check

## Local review
- coderabbit --version: 0.5.2
- coderabbit auth status --agent: not_authenticated, so CodeRabbit-backed local review could not run in this environment

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added an opt-in sandbox "proxy bootstrap" mode that generates a session-local CA, mounts the CA into sandboxed runs, and configures proxy-related environment variables for the agent.

* **Documentation**
  * Updated ADR and sandbox composition docs to describe the proxy bootstrap behavior and clarify what it does and does not enable.

* **Tests**
  * Added comprehensive unit and integration tests covering bootstrap, CA generation, mounts, env wiring, and validation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->