### PR TITLE
Audit sandbox proxy mediation sources

### DIFF
--- a/docs/src/content/docs/adr/0019-v4-https-data-plane.md
+++ b/docs/src/content/docs/adr/0019-v4-https-data-plane.md
@@ -53,6 +53,8 @@ The tenth #896 slice proves the transparent proxy transport boundary. Authentica
 
 The eleventh #896 slice routes the first transparent proxy requests through the same credential-injection boundary. After authenticated `CONNECT` and TLS interception, the daemon matches the decrypted request by method, host, and path against installed connector specs. A unique match reuses the existing sandbox proxy executor to resolve the daemon-side credential binding, inject credentials, proxy the upstream request, and return the sanitized upstream response through the TLS tunnel. Missing or ambiguous matches, binding failures, invalid decrypted requests, and oversized request bodies fail closed. This still remains an internal proxy-bootstrap path pending broader client smoke coverage and final audit-schema work.
 
+The first #898 audit-schema slice distinguishes the HTTPS data-plane entry source in audit payloads. Connector-resolved proxy events now include `aileron.proxy.source` as `generated_connector_shim`, `daemon_request_boundary`, or `transparent_connect_tls`. Transparent proxy attempts that fail before a connector operation is uniquely resolved record `sandbox.proxy.rejected` with method, upstream scheme/host/path, session id, source, and rejection reason. These events continue to omit credential bytes, raw headers, request bodies, query strings, and full upstream URLs.
+
 ## Consequences
 
 Images must be able to trust the session CA or fail before the agent starts. BYO images need documented trust-store requirements and actionable launch validation.

--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -36,12 +36,13 @@ aileron audit list             # newest events first
 aileron audit get <audit-id>   # full event by id
 ```
 
-Today, four families of events land in the log:
+Today, five families of events land in the log:
 
 - **Install consent:** Every connector and action install records artifact FQN, version, hash, signature status, and the user's decision ([ADR-0007](/adr/0007-install-consent)).
 - **Action execution:** Every invocation records which connector it called, which capability it exercised, and which binding identity satisfied it ([ADR-0003](/adr/0003-action-model), [ADR-0011](/adr/0011-local-credential-vault)). Credential bytes are never recorded.
 - **Failure:** Every failure surfaces with a stable `class`, `boundary`, retry, and `audit_id` ([ADR-0010](/adr/0010-failure-handling)). The same `audit_id` is stamped onto the agent-visible tool-result envelope, so the LLM's "what went wrong?" reaction can be traced back to a specific event.
 - **Approval lifecycle:** Three event types: `approval.requested`, `approval.approved`, `approval.denied`. Each carries the same `aileron.approval.id` so a request and its decision are trivially correlated.
+- **Sandbox HTTPS data plane:** Generated connector shims and transparent sandbox proxy requests emit proxy audit events. `connector.proxy.proxied` and `connector.proxy.rejected` identify the resolved connector operation, upstream scheme/host/path, decision, proxy source, and response status or rejection reason. `sandbox.proxy.rejected` records transparent proxy attempts that fail before a connector operation is uniquely resolved. These events never record credential bytes, request bodies, raw headers, query strings, or full upstream URLs.
 
 The schema is durable. Every payload field uses the OpenTelemetry-namespaced key shape (`aileron.connector.fqn`, `aileron.binding.name`, `aileron.failure.class`, etc.). Consumers (log shippers, trace tools, custom queries) read the same vocabulary regardless of which surface they came in through.
 
@@ -157,6 +158,24 @@ Every span carries the OTel-namespaced shape locked in for the audit payload. Wh
 | `aileron.connector.fqn` | Fully-qualified connector identifier (e.g. `github://ALRubinger/aileron-connector-google`). |
 | `aileron.connector.op` | The connector operation name (e.g. `list_recent_emails`). |
 | `aileron.connector.hash` | The content-addressed hash of the connector binary. |
+
+**Sandbox HTTPS data plane** (`connector.proxy.proxied`, `connector.proxy.rejected`, `sandbox.proxy.rejected` audit events):
+
+| Attribute | Description |
+|---|---|
+| `aileron.proxy.source` | Where the proxy attempt entered Aileron: `generated_connector_shim`, `daemon_request_boundary`, or `transparent_connect_tls`. |
+| `aileron.proxy.method` | HTTP method after daemon-side normalization. |
+| `aileron.proxy.upstream.scheme` | Upstream scheme. Currently `https` for mediated requests. |
+| `aileron.proxy.upstream.host` | Upstream host, including port when present. |
+| `aileron.proxy.upstream.path` | Upstream path only. Query strings are intentionally omitted. |
+| `aileron.proxy.upstream.status` | Upstream HTTP status for proxied requests. |
+| `aileron.proxy.reject_reason` | Rejection class for unresolved transparent proxy attempts. |
+| `aileron.connector.reject_reason` | Rejection class after a connector operation has been resolved. |
+| `aileron.connector.fqn` | Set on connector-resolved proxy events. |
+| `aileron.connector.tool` | Set on connector-resolved proxy events. |
+| `aileron.connector.operation` | Set on connector-resolved proxy events. |
+| `aileron.connector.credential` | Credential kind required by the spec, not the credential value. |
+| `aileron.session.id` | Launch session associated with the sandbox request when present. |
 
 **Approval wait** (`aileron.approval.wait`):
 

--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -22,6 +22,12 @@ import (
 const connectorOperationNotImplementedMessage = "connector operation dispatch is not implemented yet; mediated HTTPS data-plane execution is tracked by issue #896"
 const sandboxProxyMaxResponseBytes = 4 << 20
 
+const (
+	sandboxProxySourceGeneratedConnectorShim = "generated_connector_shim"
+	sandboxProxySourceDaemonRequestBoundary  = "daemon_request_boundary"
+	sandboxProxySourceTransparentConnectTLS  = "transparent_connect_tls"
+)
+
 var sandboxProxyDefaultClient = &http.Client{
 	Timeout:       30 * time.Second,
 	CheckRedirect: sandboxProxyRejectRedirect,
@@ -70,7 +76,7 @@ func (s *apiServer) RunConnectorOperation(w http.ResponseWriter, r *http.Request
 		return
 	}
 	if canProxy {
-		result, ok := s.executeSandboxProxyRequest(w, r, connectorFQN, toolName, proxyReq.method, proxyReq.upstream, operation, proxyReq.body, proxyReq.contentType)
+		result, ok := s.executeSandboxProxyRequest(w, r, sandboxProxySourceGeneratedConnectorShim, connectorFQN, toolName, proxyReq.method, proxyReq.upstream, operation, proxyReq.body, proxyReq.contentType)
 		if !ok {
 			return
 		}
@@ -139,7 +145,7 @@ func (s *apiServer) RecordSandboxProxyRequest(w http.ResponseWriter, r *http.Req
 		return
 	}
 
-	result, ok := s.executeSandboxProxyRequest(w, r, connectorFQN, toolName, method, upstream, operation, nil, "")
+	result, ok := s.executeSandboxProxyRequest(w, r, sandboxProxySourceDaemonRequestBoundary, connectorFQN, toolName, method, upstream, operation, nil, "")
 	if !ok {
 		return
 	}
@@ -326,14 +332,14 @@ func sandboxProxyHostWithDefaultPort(upstream *url.URL) string {
 	return strings.ToLower(upstream.Host)
 }
 
-func (s *apiServer) executeSandboxProxyRequest(w http.ResponseWriter, r *http.Request, connectorFQN, toolName, method string, upstream *url.URL, operation discovery.SpecOperationHelp, requestBody []byte, contentType string) (api.SandboxProxyResponse, bool) {
+func (s *apiServer) executeSandboxProxyRequest(w http.ResponseWriter, r *http.Request, source, connectorFQN, toolName, method string, upstream *url.URL, operation discovery.SpecOperationHelp, requestBody []byte, contentType string) (api.SandboxProxyResponse, bool) {
 	var reqBody io.Reader
 	if requestBody != nil {
 		reqBody = bytes.NewReader(requestBody)
 	}
 	req, err := http.NewRequestWithContext(r.Context(), method, upstream.String(), reqBody)
 	if err != nil {
-		auditID := s.recordSandboxProxyRejected(r, connectorFQN, toolName, method, upstream, operation, "invalid_upstream_request")
+		auditID := s.recordSandboxProxyRejected(r, source, connectorFQN, toolName, method, upstream, operation, "invalid_upstream_request")
 		writeJSON(w, http.StatusBadRequest, api.SandboxProxyRejectedResponse{
 			Status:       api.SandboxProxyRejectedResponseStatusRejected,
 			AuditId:      auditID,
@@ -350,7 +356,7 @@ func (s *apiServer) executeSandboxProxyRequest(w http.ResponseWriter, r *http.Re
 	}
 
 	if operation.Credential != "" {
-		if !s.injectSandboxProxyCredential(w, r, req, connectorFQN, toolName, method, upstream, operation) {
+		if !s.injectSandboxProxyCredential(w, r, req, source, connectorFQN, toolName, method, upstream, operation) {
 			return api.SandboxProxyResponse{}, false
 		}
 	}
@@ -358,7 +364,7 @@ func (s *apiServer) executeSandboxProxyRequest(w http.ResponseWriter, r *http.Re
 	client := sandboxProxyHTTPClient(s.sandboxProxyClient)
 	resp, err := client.Do(req)
 	if err != nil {
-		auditID := s.recordSandboxProxyRejected(r, connectorFQN, toolName, method, upstream, operation, "upstream_transport_failed")
+		auditID := s.recordSandboxProxyRejected(r, source, connectorFQN, toolName, method, upstream, operation, "upstream_transport_failed")
 		writeJSON(w, http.StatusBadGateway, api.SandboxProxyRejectedResponse{
 			Status:       api.SandboxProxyRejectedResponseStatusRejected,
 			AuditId:      auditID,
@@ -372,7 +378,7 @@ func (s *apiServer) executeSandboxProxyRequest(w http.ResponseWriter, r *http.Re
 	defer resp.Body.Close()
 	body, err := io.ReadAll(io.LimitReader(resp.Body, sandboxProxyMaxResponseBytes+1))
 	if err != nil {
-		auditID := s.recordSandboxProxyRejected(r, connectorFQN, toolName, method, upstream, operation, "upstream_read_failed")
+		auditID := s.recordSandboxProxyRejected(r, source, connectorFQN, toolName, method, upstream, operation, "upstream_read_failed")
 		writeJSON(w, http.StatusBadGateway, api.SandboxProxyRejectedResponse{
 			Status:       api.SandboxProxyRejectedResponseStatusRejected,
 			AuditId:      auditID,
@@ -384,7 +390,7 @@ func (s *apiServer) executeSandboxProxyRequest(w http.ResponseWriter, r *http.Re
 		return api.SandboxProxyResponse{}, false
 	}
 	if len(body) > sandboxProxyMaxResponseBytes {
-		auditID := s.recordSandboxProxyRejected(r, connectorFQN, toolName, method, upstream, operation, "upstream_response_too_large")
+		auditID := s.recordSandboxProxyRejected(r, source, connectorFQN, toolName, method, upstream, operation, "upstream_response_too_large")
 		writeJSON(w, http.StatusBadGateway, api.SandboxProxyRejectedResponse{
 			Status:       api.SandboxProxyRejectedResponseStatusRejected,
 			AuditId:      auditID,
@@ -396,7 +402,7 @@ func (s *apiServer) executeSandboxProxyRequest(w http.ResponseWriter, r *http.Re
 		return api.SandboxProxyResponse{}, false
 	}
 
-	auditID := s.recordSandboxProxyProxied(r, connectorFQN, toolName, method, upstream, operation, resp.StatusCode)
+	auditID := s.recordSandboxProxyProxied(r, source, connectorFQN, toolName, method, upstream, operation, resp.StatusCode)
 	return api.SandboxProxyResponse{
 		Status:         api.Proxied,
 		AuditId:        auditID,
@@ -425,9 +431,9 @@ func sandboxProxyHTTPClient(client *http.Client) *http.Client {
 	return &copy
 }
 
-func (s *apiServer) injectSandboxProxyCredential(w http.ResponseWriter, r *http.Request, req *http.Request, connectorFQN, toolName, method string, upstream *url.URL, operation discovery.SpecOperationHelp) bool {
+func (s *apiServer) injectSandboxProxyCredential(w http.ResponseWriter, r *http.Request, req *http.Request, source, connectorFQN, toolName, method string, upstream *url.URL, operation discovery.SpecOperationHelp) bool {
 	if s.bindings == nil {
-		auditID := s.recordSandboxProxyRejected(r, connectorFQN, toolName, method, upstream, operation, "binding_store_unavailable")
+		auditID := s.recordSandboxProxyRejected(r, source, connectorFQN, toolName, method, upstream, operation, "binding_store_unavailable")
 		writeJSON(w, http.StatusForbidden, api.SandboxProxyRejectedResponse{
 			Status:       api.SandboxProxyRejectedResponseStatusRejected,
 			AuditId:      auditID,
@@ -440,7 +446,7 @@ func (s *apiServer) injectSandboxProxyCredential(w http.ResponseWriter, r *http.
 	}
 	resolver := s.bindings.ResolverFor(r.Context(), connectorFQN, operation.Credential)
 	if resolver == nil {
-		auditID := s.recordSandboxProxyRejected(r, connectorFQN, toolName, method, upstream, operation, "binding_required")
+		auditID := s.recordSandboxProxyRejected(r, source, connectorFQN, toolName, method, upstream, operation, "binding_required")
 		writeJSON(w, http.StatusForbidden, api.SandboxProxyRejectedResponse{
 			Status:       api.SandboxProxyRejectedResponseStatusRejected,
 			AuditId:      auditID,
@@ -466,7 +472,7 @@ func (s *apiServer) injectSandboxProxyCredential(w http.ResponseWriter, r *http.
 			status = http.StatusForbidden
 			message = "sandbox proxy credential kind does not match connector spec"
 		}
-		auditID := s.recordSandboxProxyRejected(r, connectorFQN, toolName, method, upstream, operation, reason)
+		auditID := s.recordSandboxProxyRejected(r, source, connectorFQN, toolName, method, upstream, operation, reason)
 		writeJSON(w, status, api.SandboxProxyRejectedResponse{
 			Status:       api.SandboxProxyRejectedResponseStatusRejected,
 			AuditId:      auditID,
@@ -478,7 +484,7 @@ func (s *apiServer) injectSandboxProxyCredential(w http.ResponseWriter, r *http.
 		return false
 	}
 	if cred.Kind != operation.Credential {
-		auditID := s.recordSandboxProxyRejected(r, connectorFQN, toolName, method, upstream, operation, "credential_kind_mismatch")
+		auditID := s.recordSandboxProxyRejected(r, source, connectorFQN, toolName, method, upstream, operation, "credential_kind_mismatch")
 		writeJSON(w, http.StatusForbidden, api.SandboxProxyRejectedResponse{
 			Status:       api.SandboxProxyRejectedResponseStatusRejected,
 			AuditId:      auditID,
@@ -493,7 +499,7 @@ func (s *apiServer) injectSandboxProxyCredential(w http.ResponseWriter, r *http.
 	case "oauth2", "api_key":
 		req.Header.Set("Authorization", "Bearer "+string(cred.Value))
 	default:
-		auditID := s.recordSandboxProxyRejected(r, connectorFQN, toolName, method, upstream, operation, "unsupported_credential_kind")
+		auditID := s.recordSandboxProxyRejected(r, source, connectorFQN, toolName, method, upstream, operation, "unsupported_credential_kind")
 		writeJSON(w, http.StatusForbidden, api.SandboxProxyRejectedResponse{
 			Status:       api.SandboxProxyRejectedResponseStatusRejected,
 			AuditId:      auditID,
@@ -549,7 +555,7 @@ func (s *apiServer) recordConnectorOperationRejected(r *http.Request, connectorF
 	)
 }
 
-func (s *apiServer) recordSandboxProxyRejected(r *http.Request, connectorFQN, toolName, method string, upstream *url.URL, operation discovery.SpecOperationHelp, reason string) string {
+func (s *apiServer) recordSandboxProxyRejected(r *http.Request, source, connectorFQN, toolName, method string, upstream *url.URL, operation discovery.SpecOperationHelp, reason string) string {
 	if s.auditRecorder == nil {
 		if s.newID != nil {
 			return s.newID()
@@ -569,6 +575,7 @@ func (s *apiServer) recordSandboxProxyRejected(r *http.Request, connectorFQN, to
 		"aileron.connector.mediation":     "https_proxy",
 		"aileron.connector.decision":      "rejected",
 		"aileron.connector.reject_reason": reason,
+		"aileron.proxy.source":            source,
 		"aileron.proxy.method":            method,
 		"aileron.proxy.upstream.scheme":   upstream.Scheme,
 		"aileron.proxy.upstream.host":     upstream.Host,
@@ -588,7 +595,7 @@ func (s *apiServer) recordSandboxProxyRejected(r *http.Request, connectorFQN, to
 	)
 }
 
-func (s *apiServer) recordSandboxProxyProxied(r *http.Request, connectorFQN, toolName, method string, upstream *url.URL, operation discovery.SpecOperationHelp, upstreamStatus int) string {
+func (s *apiServer) recordSandboxProxyProxied(r *http.Request, source, connectorFQN, toolName, method string, upstream *url.URL, operation discovery.SpecOperationHelp, upstreamStatus int) string {
 	if s.auditRecorder == nil {
 		if s.newID != nil {
 			return s.newID()
@@ -607,6 +614,7 @@ func (s *apiServer) recordSandboxProxyProxied(r *http.Request, connectorFQN, too
 		"aileron.connector.boundary":    "https_proxy",
 		"aileron.connector.mediation":   "https_proxy",
 		"aileron.connector.decision":    "proxied",
+		"aileron.proxy.source":          source,
 		"aileron.proxy.method":          method,
 		"aileron.proxy.upstream.scheme": upstream.Scheme,
 		"aileron.proxy.upstream.host":   upstream.Host,
@@ -622,6 +630,35 @@ func (s *apiServer) recordSandboxProxyProxied(r *http.Request, connectorFQN, too
 	return s.auditRecorder.RecordSuccess(
 		r.Context(),
 		model.EventTypeConnectorProxyProxied,
+		model.ActorRef{Type: model.ActorTypeAgent, ID: "sandbox-proxy"},
+		payload,
+	)
+}
+
+func (s *apiServer) recordSandboxProxyUnresolvedRejected(r *http.Request, source, method string, upstream *url.URL, reason string) string {
+	if s.auditRecorder == nil {
+		if s.newID != nil {
+			return s.newID()
+		}
+		return audit.DefaultIDFn()
+	}
+	payload := map[string]any{
+		"aileron.proxy.boundary":        "https_proxy",
+		"aileron.proxy.mediation":       "https_proxy",
+		"aileron.proxy.decision":        "rejected",
+		"aileron.proxy.reject_reason":   reason,
+		"aileron.proxy.source":          source,
+		"aileron.proxy.method":          method,
+		"aileron.proxy.upstream.scheme": upstream.Scheme,
+		"aileron.proxy.upstream.host":   upstream.Host,
+		"aileron.proxy.upstream.path":   sandboxProxyUpstreamPath(upstream),
+	}
+	if sessionID := strings.TrimSpace(r.Header.Get("X-Aileron-Session-Id")); sessionID != "" {
+		payload["aileron.session.id"] = sessionID
+	}
+	return s.auditRecorder.RecordSuccess(
+		r.Context(),
+		model.EventTypeSandboxProxyRejected,
 		model.ActorRef{Type: model.ActorTypeAgent, ID: "sandbox-proxy"},
 		payload,
 	)

--- a/internal/app/handlers_connector_operations_test.go
+++ b/internal/app/handlers_connector_operations_test.go
@@ -252,6 +252,9 @@ func TestRunConnectorOperation_BodylessGETProxiesThroughSandboxDataPlane(t *test
 	if payload["aileron.connector.boundary"] != "https_proxy" {
 		t.Errorf("boundary payload = %v", payload["aileron.connector.boundary"])
 	}
+	if payload["aileron.proxy.source"] != sandboxProxySourceGeneratedConnectorShim {
+		t.Errorf("proxy source payload = %v", payload["aileron.proxy.source"])
+	}
 	if payload["aileron.session.id"] != "session-123" {
 		t.Errorf("session payload = %v", payload["aileron.session.id"])
 	}
@@ -733,7 +736,7 @@ func TestRecordSandboxProxyRequest_APIKeyCredentialInjectsBearerToken(t *testing
 		w.WriteHeader(http.StatusNoContent)
 	}))
 	defer upstream.Close()
-	srv, _ := newConnectorOperationTestServer([]connectorspec.Spec{
+	srv, auditStore := newConnectorOperationTestServer([]connectorspec.Spec{
 		{
 			SchemaVersion: connectorspec.SchemaVersion,
 			Connector:     connectorspec.Connector{FQN: connectorFQN},
@@ -765,6 +768,16 @@ func TestRecordSandboxProxyRequest_APIKeyCredentialInjectsBearerToken(t *testing
 	}
 	if resp.ContentType != nil {
 		t.Errorf("content type = %q, want nil", *resp.ContentType)
+	}
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if got := events[0].Payload["aileron.proxy.source"]; got != sandboxProxySourceDaemonRequestBoundary {
+		t.Errorf("proxy source = %v, want %q", got, sandboxProxySourceDaemonRequestBoundary)
 	}
 }
 
@@ -874,6 +887,9 @@ func TestRecordSandboxProxyRequest_CredentialFailuresRejectBeforeUpstream(t *tes
 			}
 			if got := events[0].Payload["aileron.connector.reject_reason"]; got != tt.wantReason {
 				t.Errorf("reject reason = %v, want %q", got, tt.wantReason)
+			}
+			if got := events[0].Payload["aileron.proxy.source"]; got != sandboxProxySourceDaemonRequestBoundary {
+				t.Errorf("proxy source = %v, want %q", got, sandboxProxySourceDaemonRequestBoundary)
 			}
 		})
 	}
@@ -1142,6 +1158,9 @@ func TestRecordSandboxProxyRequest_RootPathMatchesOperation(t *testing.T) {
 	}
 	if payload["aileron.proxy.upstream.path"] != "/" {
 		t.Errorf("path payload = %v", payload["aileron.proxy.upstream.path"])
+	}
+	if payload["aileron.proxy.source"] != sandboxProxySourceDaemonRequestBoundary {
+		t.Errorf("proxy source payload = %v", payload["aileron.proxy.source"])
 	}
 	if _, ok := payload["upstream_url"]; ok {
 		t.Errorf("raw upstream_url should not be audited: %v", payload["upstream_url"])

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -129,24 +129,28 @@ func (s *apiServer) handleSandboxForwardProxyDecrypted(conn io.Writer, decrypted
 	match, ok, err := s.matchSandboxForwardProxyOperation(decrypted.Method, upstream)
 	if err != nil {
 		if errors.Is(err, errSandboxForwardProxyAmbiguousOperation) {
+			s.recordSandboxProxyUnresolvedRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "ambiguous_operation_match")
 			writeSandboxForwardProxyError(conn, http.StatusForbidden, auth.SessionID, targetHost, err.Error())
 			return
 		}
+		s.recordSandboxProxyUnresolvedRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, sandboxForwardProxyMatchErrorReason(err))
 		writeSandboxForwardProxyError(conn, http.StatusInternalServerError, auth.SessionID, targetHost, err.Error())
 		return
 	}
 	if !ok {
+		s.recordSandboxProxyUnresolvedRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "operation_not_matched")
 		writeSandboxForwardProxyError(conn, http.StatusForbidden, auth.SessionID, targetHost, "sandbox proxy decrypted request did not match an installed connector operation")
 		return
 	}
 	body, contentType, err := readSandboxForwardProxyRequestBody(decrypted)
 	if err != nil {
+		s.recordSandboxProxyRejected(decrypted, sandboxProxySourceTransparentConnectTLS, match.connectorFQN, match.toolName, decrypted.Method, upstream, match.operation, sandboxForwardProxyBodyRejectReason(err))
 		writeSandboxForwardProxyError(conn, http.StatusRequestEntityTooLarge, auth.SessionID, targetHost, err.Error())
 		return
 	}
 
 	captured := newSandboxForwardProxyCapture()
-	result, ok := s.executeSandboxProxyRequest(captured, decrypted, match.connectorFQN, match.toolName, decrypted.Method, upstream, match.operation, body, contentType)
+	result, ok := s.executeSandboxProxyRequest(captured, decrypted, sandboxProxySourceTransparentConnectTLS, match.connectorFQN, match.toolName, decrypted.Method, upstream, match.operation, body, contentType)
 	if !ok {
 		writeSandboxForwardProxyCaptured(conn, auth.SessionID, targetHost, captured)
 		return
@@ -189,6 +193,24 @@ func (s *apiServer) matchSandboxForwardProxyOperation(method string, upstream *u
 		return sandboxForwardProxyOperationMatch{}, false, nil
 	}
 	return match, true, nil
+}
+
+func sandboxForwardProxyMatchErrorReason(err error) string {
+	switch {
+	case err == nil:
+		return ""
+	case strings.Contains(err.Error(), "invalid"):
+		return "connector_specs_invalid"
+	default:
+		return "connector_specs_unavailable"
+	}
+}
+
+func sandboxForwardProxyBodyRejectReason(err error) string {
+	if err != nil && strings.Contains(err.Error(), "read failed") {
+		return "request_body_read_failed"
+	}
+	return "request_body_too_large"
 }
 
 func sandboxForwardProxyUpstreamURL(targetHost string, decrypted *http.Request) (*url.URL, error) {

--- a/internal/app/handlers_sandbox_forward_proxy_test.go
+++ b/internal/app/handlers_sandbox_forward_proxy_test.go
@@ -2,12 +2,14 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
 	"crypto/x509"
 	"crypto/x509/pkix"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"io"
@@ -22,8 +24,10 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/internal/audit"
 	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
 	"github.com/ALRubinger/aileron/internal/credential"
+	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
@@ -110,10 +114,12 @@ func TestSandboxForwardProxy_CONNECTTerminatesTLSAndFailsClosedAfterDecryptedReq
 func TestSandboxForwardProxy_CONNECTRoutesMatchedDecryptedRequestThroughProxyBoundary(t *testing.T) {
 	stateDir := t.TempDir()
 	caPEM := writeSandboxProxyTestCA(t, stateDir, "session-123")
+	auditStore := audit.NewMemStore()
 	var upstreamMethod, upstreamURL, upstreamAuth string
 	srv := &apiServer{
 		localDaemonToken:     "daemon-token",
 		sandboxProxyStateDir: stateDir,
+		auditRecorder:        audit.NewRecorder(auditStore, nil, func() string { return "audit-transparent-proxy" }),
 		specLoader: func() ([]connectorspec.Spec, error) {
 			return []connectorspec.Spec{{
 				SchemaVersion: connectorspec.SchemaVersion,
@@ -182,6 +188,87 @@ func TestSandboxForwardProxy_CONNECTRoutesMatchedDecryptedRequestThroughProxyBou
 	}
 	if upstreamAuth != "Bearer lin_secret" {
 		t.Fatalf("upstream Authorization = %q, want bearer token", upstreamAuth)
+	}
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeConnectorProxyProxied {
+		t.Fatalf("event type = %q, want %q", events[0].EventType, model.EventTypeConnectorProxyProxied)
+	}
+	payload := events[0].Payload
+	if payload["aileron.proxy.source"] != sandboxProxySourceTransparentConnectTLS {
+		t.Errorf("proxy source = %v", payload["aileron.proxy.source"])
+	}
+	if payload["aileron.session.id"] != "session-123" {
+		t.Errorf("session id = %v", payload["aileron.session.id"])
+	}
+	payloadJSON, _ := json.Marshal(payload)
+	if strings.Contains(string(payloadJSON), "lin_secret") || strings.Contains(string(payloadJSON), "query=viewer") {
+		t.Fatalf("audit payload leaked credential or query string: %s", payloadJSON)
+	}
+}
+
+func TestSandboxForwardProxy_CONNECTNoMatchAuditsUnresolvedRejection(t *testing.T) {
+	stateDir := t.TempDir()
+	caPEM := writeSandboxProxyTestCA(t, stateDir, "session-123")
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		localDaemonToken:     "daemon-token",
+		sandboxProxyStateDir: stateDir,
+		auditRecorder:        audit.NewRecorder(auditStore, nil, func() string { return "audit-transparent-rejected" }),
+		specLoader: func() ([]connectorspec.Spec, error) {
+			return nil, nil
+		},
+	}
+	handler := srv.sandboxForwardProxyMiddleware(http.NotFoundHandler())
+	proxy := httptest.NewServer(handler)
+	defer proxy.Close()
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		t.Fatal("failed to append CA cert")
+	}
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	client := newSandboxForwardProxyClient(t, proxyURL, roots)
+	resp, err := client.Get("https://api.example.test/v1/resource?secret=not-audited")
+	if err != nil {
+		t.Fatalf("GET through sandbox forward proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyRejected {
+		t.Fatalf("event type = %q, want %q", events[0].EventType, model.EventTypeSandboxProxyRejected)
+	}
+	payload := events[0].Payload
+	if payload["aileron.proxy.source"] != sandboxProxySourceTransparentConnectTLS {
+		t.Errorf("proxy source = %v", payload["aileron.proxy.source"])
+	}
+	if payload["aileron.proxy.reject_reason"] != "operation_not_matched" {
+		t.Errorf("reject reason = %v", payload["aileron.proxy.reject_reason"])
+	}
+	if payload["aileron.proxy.upstream.path"] != "/v1/resource" {
+		t.Errorf("upstream path = %v", payload["aileron.proxy.upstream.path"])
+	}
+	payloadJSON, _ := json.Marshal(payload)
+	if strings.Contains(string(payloadJSON), "not-audited") {
+		t.Fatalf("audit payload leaked query string: %s", payloadJSON)
 	}
 }
 
@@ -414,6 +501,24 @@ func TestMatchSandboxForwardProxyOperationSpecErrors(t *testing.T) {
 	}}
 	if _, _, err := srv.matchSandboxForwardProxyOperation(http.MethodGet, upstream); err == nil || !strings.Contains(err.Error(), "connector specs invalid") {
 		t.Fatalf("invalid specs error = %v, want invalid", err)
+	}
+}
+
+func TestSandboxForwardProxyRejectReasonHelpers(t *testing.T) {
+	if got := sandboxForwardProxyMatchErrorReason(nil); got != "" {
+		t.Fatalf("nil match error reason = %q, want empty", got)
+	}
+	if got := sandboxForwardProxyMatchErrorReason(errors.New("connector specs invalid")); got != "connector_specs_invalid" {
+		t.Fatalf("invalid match error reason = %q", got)
+	}
+	if got := sandboxForwardProxyMatchErrorReason(errors.New("connector specs unavailable")); got != "connector_specs_unavailable" {
+		t.Fatalf("unavailable match error reason = %q", got)
+	}
+	if got := sandboxForwardProxyBodyRejectReason(errors.New("sandbox proxy decrypted request body read failed")); got != "request_body_read_failed" {
+		t.Fatalf("read failure reason = %q", got)
+	}
+	if got := sandboxForwardProxyBodyRejectReason(errors.New("sandbox proxy decrypted request body exceeded size limit")); got != "request_body_too_large" {
+		t.Fatalf("size failure reason = %q", got)
 	}
 }
 

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -301,4 +301,8 @@ const (
 	// never credential values.
 	EventTypeConnectorProxyRejected EventType = "connector.proxy.rejected"
 	EventTypeConnectorProxyProxied  EventType = "connector.proxy.proxied"
+
+	// Sandbox proxy event for HTTPS data-plane attempts rejected before
+	// a connector operation could be uniquely resolved.
+	EventTypeSandboxProxyRejected EventType = "sandbox.proxy.rejected"
 )


### PR DESCRIPTION
## Summary
- Add `aileron.proxy.source` to connector-resolved HTTPS proxy audit events so generated shims, the daemon request boundary, and transparent CONNECT/TLS can be distinguished.
- Add `sandbox.proxy.rejected` for transparent proxy attempts rejected before a connector operation is uniquely resolved.
- Document sandbox HTTPS data-plane audit attributes and redaction rules in the observability guide and ADR-0019.

## Verification
- `git diff --check`
- `go test ./internal/app -run 'TestRunConnectorOperation_BodylessGETProxies|TestRecordSandboxProxyRequest_APIKey|TestRecordSandboxProxyRequest_CredentialFailures|TestRecordSandboxProxyRequest_AuditsRootPath|TestSandboxForwardProxy' -count=1`
- `go test ./internal/app ./internal/audit ./internal/observability ./internal/server -coverprofile=/private/tmp/aileron-898.cover`
- `go test ./internal/...`
- `go test ./cmd/aileron/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...`
- docs `pnpm run check`
- `node design/build/generate-tokens.mjs`
- docs `pnpm run build`

Local CodeRabbit CLI note: `coderabbit --version` reports `0.5.3`; `coderabbit auth status --agent` reports not authenticated, so local CodeRabbit review could not run. I performed a manual review pass and fixed the docs event-family count before opening this PR.

Closes a narrow #898 slice. #898 should remain open for sandbox launch/container lifecycle, approval, and eventual shell-intercept audit shapes.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated observability guide with new sandbox HTTPS data-plane audit event families and attribute schema for proxy operations and rejections.
  * Added architectural decision record documenting HTTPS data-plane event sources in audit payloads.

* **New Features**
  * Enhanced audit logging for sandbox proxy rejections, now tracking proxy source and detailed rejection reasons before connector resolution.
  * Improved rejection reason classification for operation matching and request validation failures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->