### PR TITLE
Test sandbox proxy launch token env

### DIFF
--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -260,6 +260,7 @@ func TestLaunch_SandboxBYOImageRunsContainer(t *testing.T) {
 func TestLaunch_SandboxProxyBootstrapEnvAndCAMount(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)
+	t.Setenv("AILERON_TOKEN", "daemon-token")
 	t.Setenv("AILERON_SANDBOX_PROXY_BOOTSTRAP", "1")
 
 	dir := t.TempDir()
@@ -299,11 +300,12 @@ func TestLaunch_SandboxProxyBootstrapEnvAndCAMount(t *testing.T) {
 	for _, want := range []string{
 		"--user\nroot\n",
 		"--volume\n" + caPath + ":/etc/aileron/proxy/ca.pem:ro\n",
+		"--env\nAILERON_TOKEN=daemon-token\n",
 		"--env\nAILERON_SANDBOX_PROXY_CA_FILE=/etc/aileron/proxy/ca.pem\n",
 		"--env\nAILERON_SANDBOX_PROXY_MODE=bootstrap\n",
-		"--env\nAILERON_SANDBOX_PROXY_URL=http://01HK0000000000000000000FAK@host.docker.internal:",
-		"--env\nHTTPS_PROXY=http://01HK0000000000000000000FAK@host.docker.internal:",
-		"--env\nHTTP_PROXY=http://01HK0000000000000000000FAK@host.docker.internal:",
+		"--env\nAILERON_SANDBOX_PROXY_URL=http://01HK0000000000000000000FAK:daemon-token@host.docker.internal:",
+		"--env\nHTTPS_PROXY=http://01HK0000000000000000000FAK:daemon-token@host.docker.internal:",
+		"--env\nHTTP_PROXY=http://01HK0000000000000000000FAK:daemon-token@host.docker.internal:",
 		"host.docker.internal",
 		"host.containers.internal",
 		"aileron-run-with-proxy-ca\ncodex\n",


### PR DESCRIPTION
## Summary
- extend the sandbox proxy-bootstrap launch smoke to set `AILERON_TOKEN`
- assert launch propagates `AILERON_TOKEN` into the container env
- assert `AILERON_SANDBOX_PROXY_URL`, `HTTPS_PROXY`, and `HTTP_PROXY` use the token-bearing standard proxy URL userinfo shape

## Verification
- `go test ./internal/launch -run TestLaunch_SandboxProxyBootstrapEnvAndCAMount`
- `go test ./internal/launch`
- `go test ./internal/launch/... ./internal/sandbox/...`
- `go test ./internal/...`
- `go test ./cmd/aileron/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...`
- `git diff --check`

Local `coderabbit` CLI is installed at 0.5.3 but not authenticated (`coderabbit auth status` reports not logged in), so the CodeRabbit CLI review could not run. Manual review found no actionable issues.

Refs #896
Refs #747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated test suite to validate proxy bootstrap functionality with token-based authentication.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->