### PR TITLE
Add sandbox shell helper contract

### DIFF
--- a/docs/src/content/docs/adr/0021-v4-shell-layer-mediation.md
+++ b/docs/src/content/docs/adr/0021-v4-shell-layer-mediation.md
@@ -30,6 +30,8 @@ Shell-layer mediation is a container-only runtime layer tracked in #801:
 
 This layer builds on #796's container execution substrate and should share policy/audit concepts with the HTTPS data plane.
 
+The first #801 implementation slice establishes the image-side helper contract without enabling mediation. `aileron/sandbox-base` now includes `/usr/local/bin/aileron-shell-mediator` and `/etc/aileron/shell/aileron-bashrc`, and sandbox image validation has an opt-in probe for those files. Launch does not route `/bin/bash` or `/bin/sh` through the helper yet; later #801 slices wire shell routing, daemon decisions, approval result draining, bypass tests, and audit.
+
 ## Consequences
 
 Host launch remains governed by ADR-0015: Aileron audits Aileron actions, not arbitrary host commands.

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -86,3 +86,5 @@ aileron sandbox check --runtime=docker --build=never --agent=claude
 ## Current Limits
 
 The support matrix covers image contents only. It does not add shell mediation or live discovery refresh. Internal HTTPS proxy/session CA bootstrap work now expects images used for that development mode to provide `aileron-install-proxy-ca` and `aileron-run-with-proxy-ca`; the Aileron sandbox-base image includes both. Launch now authenticates standard proxy-shaped requests with proxy userinfo / `Proxy-Authorization`, but full forward-proxy transport remains tracked separately from the image support contract.
+
+The first shell-mediation image contract is also present in sandbox-base for #801 development: `/usr/local/bin/aileron-shell-mediator` and `/etc/aileron/shell/aileron-bashrc`. Launch does not enable shell mediation yet, and BYO images do not need those files unless a later shell-mediation mode explicitly validates them.

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -185,7 +185,7 @@ Set `customizations.aileron.image` when your team owns the complete image:
 }
 ```
 
-In BYO-image mode, launch uses the image as supplied and layers on Aileron's session env, manifest mounts, generated discovery files, and connector shims. Images that opt into internal proxy-bootstrap development must include `aileron-install-proxy-ca` and `aileron-run-with-proxy-ca` helpers compatible with the sandbox-base contract. Later runtime launch work can extend that contract with shell mediation files.
+In BYO-image mode, launch uses the image as supplied and layers on Aileron's session env, manifest mounts, generated discovery files, and connector shims. Images that opt into internal proxy-bootstrap development must include `aileron-install-proxy-ca` and `aileron-run-with-proxy-ca` helpers compatible with the sandbox-base contract. Sandbox-base now also carries the first #801 shell-mediation helper files (`aileron-shell-mediator` and `/etc/aileron/shell/aileron-bashrc`), but launch does not enable shell mediation or require those files for BYO images yet.
 
 ## What Belongs in the Image
 

--- a/images/sandbox-base/Containerfile
+++ b/images/sandbox-base/Containerfile
@@ -17,14 +17,17 @@ RUN apk add --no-cache \
     wget
 
 RUN addgroup -S agent && adduser -S -G agent -h /home/agent agent \
-    && mkdir -p /etc/aileron/proxy /opt/aileron/manifests /home/agent/workspace \
+    && mkdir -p /etc/aileron/proxy /etc/aileron/shell /opt/aileron/manifests /home/agent/workspace \
     && touch /etc/aileron/tools.txt \
     && chown -R agent:agent /home/agent
 
 COPY profile.d/aileron-tools.sh /etc/profile.d/aileron-tools.sh
+COPY shell/aileron-bashrc /etc/aileron/shell/aileron-bashrc
 COPY bin/aileron-install-proxy-ca /usr/local/bin/aileron-install-proxy-ca
 COPY bin/aileron-run-with-proxy-ca /usr/local/bin/aileron-run-with-proxy-ca
-RUN chmod 0755 /usr/local/bin/aileron-install-proxy-ca /usr/local/bin/aileron-run-with-proxy-ca
+COPY bin/aileron-shell-mediator /usr/local/bin/aileron-shell-mediator
+RUN chmod 0644 /etc/aileron/shell/aileron-bashrc \
+    && chmod 0755 /usr/local/bin/aileron-install-proxy-ca /usr/local/bin/aileron-run-with-proxy-ca /usr/local/bin/aileron-shell-mediator
 
 WORKDIR /home/agent/workspace
 USER agent

--- a/images/sandbox-base/bin/aileron-shell-mediator
+++ b/images/sandbox-base/bin/aileron-shell-mediator
@@ -1,0 +1,24 @@
+#!/bin/sh
+set -eu
+
+real_shell="${AILERON_REAL_SHELL:-/bin/bash}"
+aileron_bashrc="${AILERON_SHELL_RCFILE:-/etc/aileron/shell/aileron-bashrc}"
+
+if [ "${1:-}" = "--check" ]; then
+  if [ ! -x "$real_shell" ]; then
+    echo "sandbox shell mediation requires executable real shell at $real_shell" >&2
+    exit 127
+  fi
+  if [ ! -r "$aileron_bashrc" ]; then
+    echo "sandbox shell mediation requires readable rcfile at $aileron_bashrc" >&2
+    exit 127
+  fi
+  exit 0
+fi
+
+if [ "${AILERON_SANDBOX_SHELL_MEDIATION:-}" != "1" ]; then
+  exec "$real_shell" "$@"
+fi
+
+echo "sandbox shell mediation is not implemented in this image cut" >&2
+exit 127

--- a/images/sandbox-base/shell/aileron-bashrc
+++ b/images/sandbox-base/shell/aileron-bashrc
@@ -1,0 +1,10 @@
+# Aileron sandbox shell mediation rcfile.
+#
+# This file is intentionally inert until launch opts into shell mediation.
+# Later #801 slices install the DEBUG trap and result-drain hooks here.
+if [ "${AILERON_SANDBOX_SHELL_MEDIATION:-}" != "1" ]; then
+  return 0 2>/dev/null || exit 0
+fi
+
+echo "sandbox shell mediation rcfile loaded without an implemented trap" >&2
+return 127 2>/dev/null || exit 127

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -432,7 +432,7 @@ func TestLaunch_SandboxDiscoverySmokeMountsShimsForValidateAndRun(t *testing.T) 
 	if !strings.Contains(validateCall, "/bin/sh\n-c\n") {
 		t.Fatalf("validation call did not run contract probe:\n%s", validateCall)
 	}
-	if !strings.HasSuffix(strings.TrimSpace(validateCall), "\ncodex\n1\n0") {
+	if !strings.HasSuffix(strings.TrimSpace(validateCall), "\ncodex\n1\n0\n0") {
 		t.Fatalf("validation call did not enable shim HTTP-client validation:\n%s", validateCall)
 	}
 	if !regexp.MustCompile(`--env\nAILERON_API_URL=http://host\.docker\.internal:[0-9]+/v1\n`).MatchString(runCall) {

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -96,13 +96,14 @@ type RunResult struct {
 
 // ValidateOptions configures a launch-time sandbox image validation run.
 type ValidateOptions struct {
-	Runtime           string
-	Image             string
-	WorkDir           string
-	Env               map[string]string
-	Volumes           []Volume
-	Command           []string
-	RequireProxyTrust bool
+	Runtime               string
+	Image                 string
+	WorkDir               string
+	Env                   map[string]string
+	Volumes               []Volume
+	Command               []string
+	RequireProxyTrust     bool
+	RequireShellMediation bool
 }
 
 // Build builds the image for plan. Tier 0 builds Aileron's local sandbox-base
@@ -292,6 +293,7 @@ func (b Builder) Validate(ctx context.Context, opts ValidateOptions) error {
 			opts.Command[0],
 			boolArg(requiresShimHTTPClient(opts.Volumes)),
 			boolArg(opts.RequireProxyTrust),
+			boolArg(opts.RequireShellMediation),
 		},
 	})
 	if err == nil {
@@ -359,6 +361,14 @@ if [ "${3:-0}" = "1" ]; then
     exit 127
   fi
   aileron-install-proxy-ca --check "${AILERON_SANDBOX_PROXY_CA_FILE:-/etc/aileron/proxy/ca.pem}"
+fi
+if [ "${4:-0}" = "1" ]; then
+  if ! command -v aileron-shell-mediator >/dev/null 2>&1; then
+    echo "sandbox shell mediation requires aileron-shell-mediator in the sandbox image" >&2
+    echo "extend the current aileron/sandbox-base image or disable sandbox shell mediation" >&2
+    exit 127
+  fi
+  aileron-shell-mediator --check
 fi
 `
 

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -645,20 +645,23 @@ func TestValidateRunsMinimalContractProbe(t *testing.T) {
 		"ghcr.io/acme/agent:latest",
 		"/bin/sh", "-c",
 	}
-	if len(runner.args) < len(wantPrefix)+3 {
+	if len(runner.args) < len(wantPrefix)+4 {
 		t.Fatalf("args too short: %#v", runner.args)
 	}
 	if !reflect.DeepEqual(runner.args[:len(wantPrefix)], wantPrefix) {
 		t.Fatalf("args prefix = %#v, want %#v", runner.args[:len(wantPrefix)], wantPrefix)
 	}
-	if runner.args[len(runner.args)-3] != "codex" {
-		t.Fatalf("validation command = %q, want codex", runner.args[len(runner.args)-3])
+	if runner.args[len(runner.args)-4] != "codex" {
+		t.Fatalf("validation command = %q, want codex", runner.args[len(runner.args)-4])
+	}
+	if runner.args[len(runner.args)-3] != "0" {
+		t.Fatalf("shim validation flag = %q, want 0", runner.args[len(runner.args)-3])
 	}
 	if runner.args[len(runner.args)-2] != "0" {
-		t.Fatalf("shim validation flag = %q, want 0", runner.args[len(runner.args)-2])
+		t.Fatalf("proxy trust validation flag = %q, want 0", runner.args[len(runner.args)-2])
 	}
 	if runner.args[len(runner.args)-1] != "0" {
-		t.Fatalf("proxy trust validation flag = %q, want 0", runner.args[len(runner.args)-1])
+		t.Fatalf("shell mediation validation flag = %q, want 0", runner.args[len(runner.args)-1])
 	}
 }
 
@@ -682,13 +685,16 @@ func TestValidateRequiresWgetWhenShimsAreMounted(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
-	if runner.args[len(runner.args)-2] != "1" {
-		t.Fatalf("shim validation flag = %q, want 1", runner.args[len(runner.args)-2])
+	if runner.args[len(runner.args)-3] != "1" {
+		t.Fatalf("shim validation flag = %q, want 1", runner.args[len(runner.args)-3])
+	}
+	if runner.args[len(runner.args)-2] != "0" {
+		t.Fatalf("proxy trust validation flag = %q, want 0", runner.args[len(runner.args)-2])
 	}
 	if runner.args[len(runner.args)-1] != "0" {
-		t.Fatalf("proxy trust validation flag = %q, want 0", runner.args[len(runner.args)-1])
+		t.Fatalf("shell mediation validation flag = %q, want 0", runner.args[len(runner.args)-1])
 	}
-	script := runner.args[len(runner.args)-5]
+	script := runner.args[len(runner.args)-6]
 	if !strings.Contains(script, "generated Aileron connector shims require wget") {
 		t.Fatalf("validation script did not include wget requirement:\n%s", script)
 	}
@@ -722,21 +728,56 @@ func TestValidateRequiresProxyTrustHelperWhenRequested(t *testing.T) {
 	if err != nil {
 		t.Fatalf("Validate: %v", err)
 	}
-	if runner.args[len(runner.args)-3] != "codex" {
-		t.Fatalf("validation command = %q, want codex", runner.args[len(runner.args)-3])
+	if runner.args[len(runner.args)-4] != "codex" {
+		t.Fatalf("validation command = %q, want codex", runner.args[len(runner.args)-4])
 	}
-	if runner.args[len(runner.args)-2] != "0" {
-		t.Fatalf("shim validation flag = %q, want 0", runner.args[len(runner.args)-2])
+	if runner.args[len(runner.args)-3] != "0" {
+		t.Fatalf("shim validation flag = %q, want 0", runner.args[len(runner.args)-3])
 	}
-	if runner.args[len(runner.args)-1] != "1" {
-		t.Fatalf("proxy trust validation flag = %q, want 1", runner.args[len(runner.args)-1])
+	if runner.args[len(runner.args)-2] != "1" {
+		t.Fatalf("proxy trust validation flag = %q, want 1", runner.args[len(runner.args)-2])
 	}
-	script := runner.args[len(runner.args)-5]
+	if runner.args[len(runner.args)-1] != "0" {
+		t.Fatalf("shell mediation validation flag = %q, want 0", runner.args[len(runner.args)-1])
+	}
+	script := runner.args[len(runner.args)-6]
 	if !strings.Contains(script, "aileron-install-proxy-ca --check") {
 		t.Fatalf("validation script missing proxy trust helper check:\n%s", script)
 	}
 	if !strings.Contains(script, "command -v aileron-run-with-proxy-ca") {
 		t.Fatalf("validation script missing proxy wrapper check:\n%s", script)
+	}
+}
+
+func TestValidateRequiresShellMediationHelperWhenRequested(t *testing.T) {
+	runner := &recordingRunner{}
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Image:                 "ghcr.io/acme/agent:latest",
+		WorkDir:               t.TempDir(),
+		Command:               []string{"codex"},
+		RequireShellMediation: true,
+	})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	if runner.args[len(runner.args)-4] != "codex" {
+		t.Fatalf("validation command = %q, want codex", runner.args[len(runner.args)-4])
+	}
+	if runner.args[len(runner.args)-3] != "0" {
+		t.Fatalf("shim validation flag = %q, want 0", runner.args[len(runner.args)-3])
+	}
+	if runner.args[len(runner.args)-2] != "0" {
+		t.Fatalf("proxy trust validation flag = %q, want 0", runner.args[len(runner.args)-2])
+	}
+	if runner.args[len(runner.args)-1] != "1" {
+		t.Fatalf("shell mediation validation flag = %q, want 1", runner.args[len(runner.args)-1])
+	}
+	script := runner.args[len(runner.args)-6]
+	if !strings.Contains(script, "command -v aileron-shell-mediator") {
+		t.Fatalf("validation script missing shell mediation helper check:\n%s", script)
+	}
+	if !strings.Contains(script, "aileron-shell-mediator --check") {
+		t.Fatalf("validation script missing shell mediation contract check:\n%s", script)
 	}
 }
 


### PR DESCRIPTION
## Summary
- add the first #801 image-side shell mediation helper contract to sandbox-base
- add opt-in sandbox image validation for the shell mediation helper and rcfile
- document that launch does not enable shell mediation yet and BYO images are not required to provide these files until a later shell-mediation mode validates them

## Verification
- `AILERON_SHELL_RCFILE=images/sandbox-base/shell/aileron-bashrc AILERON_REAL_SHELL=/bin/bash sh images/sandbox-base/bin/aileron-shell-mediator --check`
- `go test ./internal/sandbox/container`
- `pnpm run check` in `docs/`
- `docker build -f images/sandbox-base/Containerfile -t aileron/sandbox-base:codex-shell-helper-test images/sandbox-base`
- `go test ./internal/sandbox/... ./internal/launch/...`
- `node design/build/generate-tokens.mjs`
- `docker run --rm aileron/sandbox-base:codex-shell-helper-test aileron-shell-mediator --check`
- `docker run --rm aileron/sandbox-base:codex-shell-helper-test aileron-shell-mediator -lc 'echo shell-pass-through'`\n- `docker run --rm --env AILERON_SANDBOX_SHELL_MEDIATION=1 aileron/sandbox-base:codex-shell-helper-test aileron-shell-mediator -lc 'echo should-not-run'` (expected exit 127 with fail-closed message)\n- `pnpm run build` in `docs/`\n- `go test ./internal/...`\n- `go test ./cmd/aileron/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...`\n- `git diff --check`\n\nLocal `coderabbit` CLI is installed at 0.5.3 but not authenticated (`coderabbit auth status` reports not logged in), so the CodeRabbit CLI review could not run. Manual review found no actionable issues.\n\nRefs #801\nRefs #747

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added shell mediation infrastructure to sandbox-base image, including a mediator binary and shell configuration files.

* **Documentation**
  * Updated documentation describing shell mediation components in sandbox-base and clarifying that launch does not yet enable mediation.

* **Tests**
  * Updated validation tests to support optional shell mediation helper verification.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->