### PR TITLE
Wire sandbox shell launch opt-in

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -41,7 +41,10 @@ const (
 	sandboxToolsFilePath = "/etc/aileron/tools.txt"
 	sandboxShimsDirPath  = "/usr/local/bin"
 	sandboxProxyCAPath   = "/etc/aileron/proxy/ca.pem"
+	sandboxShellRCPath   = "/etc/aileron/shell/aileron-bashrc"
 )
+
+const sandboxShellMediationEnv = "AILERON_SANDBOX_SHELL_MEDIATION"
 
 // LaunchConfig holds the configuration for launching an agent.
 type LaunchConfig struct {
@@ -225,13 +228,14 @@ func validateSandboxImage(ctx context.Context, plan SandboxLaunchPlan, config La
 		Runtime: plan.Runtime,
 		Stdout:  io.Discard,
 	}).Validate(ctx, sandboxcontainer.ValidateOptions{
-		Runtime:           plan.Runtime,
-		Image:             plan.Image,
-		WorkDir:           config.Dir,
-		Env:               agentEnv,
-		Volumes:           mounts,
-		Command:           []string{commandName},
-		RequireProxyTrust: agentEnv["AILERON_SANDBOX_PROXY_MODE"] != "",
+		Runtime:               plan.Runtime,
+		Image:                 plan.Image,
+		WorkDir:               config.Dir,
+		Env:                   agentEnv,
+		Volumes:               mounts,
+		Command:               []string{commandName},
+		RequireProxyTrust:     agentEnv["AILERON_SANDBOX_PROXY_MODE"] != "",
+		RequireShellMediation: agentEnv[sandboxShellMediationEnv] == "1",
 	}); err != nil {
 		return err
 	}
@@ -336,6 +340,11 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		agentEnv["AILERON_APPROVAL_URL"] = agentEndpointURL + "/approvals"
 		agentEnv["AILERON_TOOLS_FILE"] = sandboxToolsFilePath
 		agentEnv["AILERON_SHIMS_DIR"] = sandboxShimsDirPath
+		if sandboxShellMediationEnabled() {
+			agentEnv[sandboxShellMediationEnv] = "1"
+			agentEnv["AILERON_SHELL_RCFILE"] = sandboxShellRCPath
+			agentEnv["AILERON_REAL_SHELL"] = "/bin/bash"
+		}
 		if daemonToken != "" {
 			agentEnv["AILERON_TOKEN"] = daemonToken
 		}
@@ -393,6 +402,10 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 
 	sessionLog.Info("session ended", "exit_code", result.ExitCode)
 	return result, runErr
+}
+
+func sandboxShellMediationEnabled() bool {
+	return os.Getenv(sandboxShellMediationEnv) == "1"
 }
 
 // composeAgentEnv merges the agent's env map with the LLM-endpoint

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -316,6 +316,67 @@ func TestLaunch_SandboxProxyBootstrapEnvAndCAMount(t *testing.T) {
 	}
 }
 
+func TestLaunch_SandboxShellMediationOptInValidatesAndPassesEnv(t *testing.T) {
+	t.Setenv("AILERON_SANDBOX_SHELL_MEDIATION", "1")
+
+	dir := t.TempDir()
+	devcontainerDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(devcontainerDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(devcontainerDir, "devcontainer.json"), []byte(`{"customizations":{"aileron":{"image":"ghcr.io/acme/agent:latest"}}}`), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	binDir := t.TempDir()
+	argsFile := filepath.Join(dir, "docker-args.txt")
+	docker := filepath.Join(binDir, "docker")
+	script := "#!/bin/sh\nprintf '%s\\n' '---' >> " + argsFile + "\nprintf '%s\\n' \"$@\" >> " + argsFile + "\n"
+	if err := os.WriteFile(docker, []byte(script), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:          scriptAgent{script: "codex"},
+		Dir:            dir,
+		SandboxRuntime: "docker",
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read docker args: %v", err)
+	}
+	calls := strings.Split(strings.TrimPrefix(string(data), "---\n"), "\n---\n")
+	if len(calls) != 2 {
+		t.Fatalf("docker calls = %d, want validate and run:\n%s", len(calls), data)
+	}
+	validateCall, runCall := calls[0], calls[1]
+	validateArgs := strings.Split(strings.TrimSpace(validateCall), "\n")
+	if len(validateArgs) < 5 {
+		t.Fatalf("validation call too short:\n%s", validateCall)
+	}
+	validateArgs = validateArgs[len(validateArgs)-5:]
+	if validateArgs[0] != "aileron-validate" || validateArgs[1] != "codex" || validateArgs[4] != "1" {
+		t.Fatalf("validation call did not require shell mediation helper:\n%s", validateCall)
+	}
+	for _, want := range []string{
+		"--env\nAILERON_SANDBOX_SHELL_MEDIATION=1\n",
+		"--env\nAILERON_SHELL_RCFILE=/etc/aileron/shell/aileron-bashrc\n",
+		"--env\nAILERON_REAL_SHELL=/bin/bash\n",
+		"ghcr.io/acme/agent:latest\ncodex\n",
+	} {
+		if !strings.Contains(runCall, want) {
+			t.Fatalf("run call missing %q:\n%s", want, runCall)
+		}
+	}
+	if strings.Contains(runCall, "aileron-shell-mediator\ncodex\n") {
+		t.Fatalf("launch should not wrap the agent command yet:\n%s", runCall)
+	}
+}
+
 func TestLaunch_SandboxMountsAileronManifestStores(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)


### PR DESCRIPTION
## Summary
- gate sandbox shell mediation behind the existing internal AILERON_SANDBOX_SHELL_MEDIATION=1 opt-in
- pass shell mediation env into containerized launches only when that opt-in is set
- require image validation to find aileron-shell-mediator before launch when the opt-in is set
- keep the agent command unwrapped in this slice

## Tests
- go test ./internal/launch -run TestLaunch_SandboxShellMediationOptInValidatesAndPassesEnv
- go test ./internal/launch
- go test ./internal/launch/... ./internal/sandbox/...
- go test ./internal/...
- go test ./cmd/aileron/... ./cmd/aileron-enclave/... ./cmd/aileron-mcp/... ./sdk/go/...
- git diff --check

Local CodeRabbit CLI is installed but not authenticated, so the local CLI review could not run.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Optional sandbox shell mediation can be enabled via an environment flag; when enabled, additional mediation-related environment variables are propagated to sandboxed launches.

* **Tests**
  * Added test coverage to validate the opt-in sandbox shell mediation flow, including validation and run phases and the propagated environment variables.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->