### PR TITLE
docs(plans): mark slice 6 deny plan completed

### DIFF
--- a/docs/plans/2026-06-05-001-feat-sandbox-shell-deny-plan.md
+++ b/docs/plans/2026-06-05-001-feat-sandbox-shell-deny-plan.md
@@ -1,6 +1,6 @@
 ---
 title: "feat: deny semantics for sandbox shell mediation (#801 slice 6)"
-status: active
+status: completed
 created: 2026-06-05
 type: feat
 tracking: ["#801", "#747"]


### PR DESCRIPTION
## Summary

Tiny follow-up to #950: flips the slice 6 deny plan's frontmatter from `status: active` to `status: completed` per the ce-work shipping workflow. The plan body is unchanged.

## Test plan

- [x] Single-character metadata change in a markdown frontmatter field; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated internal plan documentation status.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->