### PR TITLE
fix(sandbox): ship Alpine-compatible scaffold snippets

### DIFF
--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -187,6 +187,17 @@ func TestInitWritesStarterDevcontainerAndDockerfile(t *testing.T) {
 	if !strings.Contains(string(dockerfile), "FROM aileron/sandbox-base:0.4.0") {
 		t.Fatalf("Dockerfile =\n%s", string(dockerfile))
 	}
+	for _, line := range strings.Split(string(dockerfile), "\n") {
+		trimmed := strings.TrimLeft(line, "# ")
+		if strings.HasPrefix(trimmed, "RUN ") && strings.Contains(trimmed, "apt-get") {
+			t.Fatalf("Dockerfile snippets must use apk against the Alpine base, not apt-get:\n%s", string(dockerfile))
+		}
+	}
+	for _, snippet := range []string{"--- Claude Code ---", "--- GitHub CLI ---", "--- Node.js ---", "--- Python ---", "--- kubectl ---", "--- Terraform ---"} {
+		if !strings.Contains(string(dockerfile), snippet) {
+			t.Fatalf("Dockerfile missing snippet %q:\n%s", snippet, string(dockerfile))
+		}
+	}
 }
 
 func TestInitDoesNotOverwriteWithoutForce(t *testing.T) {

--- a/internal/sandbox/composition/scaffold.go
+++ b/internal/sandbox/composition/scaffold.go
@@ -73,8 +73,9 @@ func starterDockerfile(version string) string {
 # Uncomment snippets below to add tools to the Aileron sandbox.
 # Keep rarely changing snippets earlier for better layer caching.
 #
-# Aileron's base image runs as the non-root "agent" user. Switch to root
-# before installing packages, then switch back to agent before launch.
+# Aileron's base image is Alpine-based and runs as the non-root "agent"
+# user. Switch to root before installing packages, then switch back to
+# agent before launch. All snippets use apk; do not use apt-get here.
 
 # USER root
 
@@ -83,30 +84,19 @@ func starterDockerfile(version string) string {
 #     npm install -g @anthropic-ai/claude-code
 
 # --- GitHub CLI ---
-# RUN apt-get update && apt-get install -y --no-install-recommends curl ca-certificates && \
-#     curl -fsSL https://github.com/cli/cli/releases/latest/download/gh_*_linux_amd64.tar.gz | \
-#       tar xz -C /usr/local --strip-components=1
+# RUN apk add --no-cache github-cli
 
-# --- Node.js (via fnm) ---
-# RUN curl -fsSL https://fnm.vercel.app/install | bash && \
-#     /root/.local/share/fnm/fnm install 20 && \
-#     ln -s /root/.local/share/fnm/aliases/default/bin/node /usr/local/bin/node && \
-#     ln -s /root/.local/share/fnm/aliases/default/bin/npm /usr/local/bin/npm
+# --- Node.js ---
+# RUN apk add --no-cache nodejs npm
 
-# --- Python (via mise) ---
-# RUN curl https://mise.run | sh && \
-#     /root/.local/bin/mise install python@3.11 && \
-#     ln -s /root/.local/share/mise/installs/python/3.11/bin/python /usr/local/bin/python
+# --- Python ---
+# RUN apk add --no-cache python3 py3-pip
 
 # --- kubectl ---
-# RUN curl -LO https://dl.k8s.io/release/v1.29.0/bin/linux/amd64/kubectl && \
-#     install -m 0755 kubectl /usr/local/bin/
+# RUN apk add --no-cache kubectl
 
 # --- Terraform ---
-# RUN apt-get update && apt-get install -y --no-install-recommends gnupg lsb-release curl ca-certificates && \
-#     curl -fsSL https://apt.releases.hashicorp.com/gpg | gpg --dearmor -o /usr/share/keyrings/hashicorp.gpg && \
-#     echo "deb [signed-by=/usr/share/keyrings/hashicorp.gpg] https://apt.releases.hashicorp.com $(lsb_release -cs) main" > /etc/apt/sources.list.d/hashicorp.list && \
-#     apt-get update && apt-get install -y --no-install-recommends terraform
+# RUN apk add --no-cache terraform
 
 # USER agent
 `, BaseImage(version))


### PR DESCRIPTION
## Summary

- `aileron sandbox init` scaffolded a `.devcontainer/Dockerfile` whose only working snippet was Claude Code. The GitHub CLI and Terraform snippets used `apt-get`; the Node.js / Python / kubectl snippets used Debian-flavored `curl` recipes. None of them work against the Alpine-based `aileron/sandbox-base` image, so uncommenting any of them produced a confusing `apk add` / `apt-get` exit-99 build failure (reported during #747 testing).
- Replace every snippet with the Alpine equivalent: `apk add` against packages in `main` or `community` (both enabled by default in `alpine:3.23`). The Claude Code snippet was already correct.
- Tighten the header comment so the file states up front that this is an Alpine base and `apt-get` is the wrong tool.
- Add a regression test that asserts no `RUN` line in the scaffolded Dockerfile invokes `apt-get` and that all six snippet markers (Claude Code, GitHub CLI, Node.js, Python, kubectl, Terraform) are present.

The scaffold is a menu where users uncomment what they want. Today, picking anything other than Claude Code means a broken build. After this PR every item on the menu works as-is.

## Test plan

- [x] `go test ./internal/sandbox/composition/...` — green; package coverage 88.5%
- [x] `go test ./internal/sandbox/... ./internal/launch/... ./cmd/aileron/...` — green
- [x] `coderabbit review` on the diff — no findings
- [x] Verified the rewritten packages exist in `alpine:3.23` (main: `git`, `nodejs`, `npm`, `python3`, `py3-pip`; community: `ripgrep`, `github-cli`, `kubectl`, `terraform`)
- [ ] End-to-end docker build of a scaffolded project with each snippet uncommented — not exercised in CI; the unit test pins the file contents and the Alpine package set is well-known. Reproducing the original failure manually (`aileron sandbox init`, uncomment GitHub CLI + `USER root`, `aileron sandbox build --runtime=docker`) now succeeds where it used to fail.

Surfaces under #747 (v4 sandbox foundation) as Tier 1 recipe quality. Does not close anything.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved sandbox devcontainer Dockerfile templates to use Alpine Linux package manager with correct installation examples for common development tools (GitHub CLI, Node.js, Python, kubectl, Terraform).

* **Tests**
  * Enhanced validation to ensure generated Dockerfiles follow Alpine-based image best practices and include expected tool configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->