### PR TITLE
feat(sandbox): scaffold a ready-to-build Dockerfile for the chosen agent

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -146,7 +146,7 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 	case "sessions":
 		return runSessions(args[1:], stdout, stderr)
 	case "sandbox":
-		return runSandbox(args[1:], stdout, stderr)
+		return runSandbox(args[1:], registry, stdout, stderr)
 	case "vault":
 		return runVault(args[1:], stdout, stderr)
 	case "daemon":

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -246,6 +246,58 @@ func TestRunSandboxRequiresSubcommand(t *testing.T) {
 	}
 }
 
+func TestRunSandboxInitAgentFlagSelectsRecipe(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	reg := newTestRegistry()
+	reg.Register(agents.Codex{})
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sandbox", "init", "--agent=codex"}, reg, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("expected exit code 0, got %d; stderr=%q", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "agent: codex") {
+		t.Fatalf("stdout missing agent line: %q", stdout.String())
+	}
+	body, err := os.ReadFile(filepath.Join(dir, ".devcontainer", "Dockerfile"))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	if !strings.Contains(string(body), "TODO: install the codex CLI") {
+		t.Fatalf("Dockerfile missing codex TODO stub:\n%s", string(body))
+	}
+}
+
+func TestRunSandboxInitAgentFlagRejectsUnknownAgent(t *testing.T) {
+	dir := t.TempDir()
+	oldWd, _ := os.Getwd()
+	if err := os.Chdir(dir); err != nil {
+		t.Fatalf("chdir: %v", err)
+	}
+	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"sandbox", "init", "--agent=bogus"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("expected exit code 1, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), `unknown agent: "bogus"`) {
+		t.Fatalf("stderr = %q", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "available agents:") {
+		t.Fatalf("stderr missing agent list: %q", stderr.String())
+	}
+	if _, err := os.Stat(filepath.Join(dir, ".devcontainer")); !os.IsNotExist(err) {
+		t.Fatalf("scaffold should not be written for unknown agent: stat err = %v", err)
+	}
+}
+
 func TestRunSandboxInitRejectsExtraArgs(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"sandbox", "init", "extra"}, newTestRegistry(), &stdout, &stderr)

--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -9,19 +9,20 @@ import (
 	"os"
 	"strings"
 
+	"github.com/ALRubinger/aileron/internal/launch"
 	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 	"github.com/ALRubinger/aileron/internal/version"
 )
 
-func runSandbox(args []string, stdout, stderr io.Writer) int {
+func runSandbox(args []string, registry *launch.Registry, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check>")
 		return 1
 	}
 	switch args[0] {
 	case "init":
-		return runSandboxInit(args[1:], stdout, stderr)
+		return runSandboxInit(args[1:], registry, stdout, stderr)
 	case "plan":
 		return runSandboxPlan(args[1:], stdout, stderr)
 	case "build":
@@ -35,15 +36,21 @@ func runSandbox(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
-func runSandboxInit(args []string, stdout, stderr io.Writer) int {
+func runSandboxInit(args []string, registry *launch.Registry, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("sandbox init", flag.ContinueOnError)
 	flags.SetOutput(stderr)
 	force := flags.Bool("force", false, "Overwrite existing .devcontainer files")
+	agent := flags.String("agent", sandboxcomposition.DefaultAgent, "Agent CLI to scaffold the install recipe for")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
 	if flags.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: aileron sandbox init [--force]")
+		fmt.Fprintln(stderr, "usage: aileron sandbox init [--force] [--agent=<name>]")
+		return 1
+	}
+	if _, ok := registry.Get(*agent); !ok {
+		fmt.Fprintf(stderr, "unknown agent: %q\n", *agent)
+		fmt.Fprintf(stderr, "available agents: %s\n", strings.Join(registry.Names(), ", "))
 		return 1
 	}
 	cwd, err := os.Getwd()
@@ -55,6 +62,7 @@ func runSandboxInit(args []string, stdout, stderr io.Writer) int {
 		WorkDir: cwd,
 		Version: version.Version,
 		Force:   *force,
+		Agent:   *agent,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
@@ -62,6 +70,7 @@ func runSandboxInit(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "created %s\n", result.DevcontainerPath)
 	fmt.Fprintf(stdout, "created %s\n", result.DockerfilePath)
+	fmt.Fprintf(stdout, "agent: %s\n", *agent)
 	return 0
 }
 

--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -66,7 +66,7 @@ This ADR follows the updated sandbox runtime direction:
 - `.devcontainer/devcontainer.json`
 - `.devcontainer/Dockerfile`
 
-The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented snippets for common tools. The snippets are guidance, not a runtime resolver. Users own their container contents using normal Docker/devcontainer workflows.
+The Dockerfile extends `aileron/sandbox-base:<version>`, pre-fills the install recipe for the agent named in `--agent` (default `claude`), and ships additional tool snippets (GitHub CLI, Node.js, Python, kubectl, Terraform) commented out for users to enable as needed. The snippets are guidance, not a runtime resolver. Users own their container contents using normal Docker/devcontainer workflows.
 
 `aileron sandbox plan` is an inspection helper that reports the normalized tier/image/dockerfile plan.
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -21,7 +21,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 
 | Command | Purpose | Ratified by |
 |---|---|---|
-| `aileron sandbox init` | Scaffold `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile` for sandbox composition. The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented tool snippets. | [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron sandbox init [--agent=<name>] [--force]` | Scaffold `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile` for sandbox composition. The Dockerfile extends `aileron/sandbox-base:<version>`, pre-fills the install recipe for `--agent` (defaults to `claude`), and ships additional tool snippets commented out. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox plan` | Inspect the normalized composition tier and image Aileron infers from the current project. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox build` | Build the Tier 0 sandbox-base image or Tier 1 devcontainer image with Docker or Podman. Tier 2 BYO images are reported without build or injection. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox check [--runtime=auto\|docker\|podman] [--build=auto\|always\|never] --agent=<command>` | Validate that the selected sandbox image can launch an agent command before starting a session. | [ADR-0017](/adr/0017-sandbox-composition) |

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -32,27 +32,10 @@ Tier 0 `aileron/sandbox-base` intentionally does not include agent CLIs. Use Tie
 
 ## Claude Code Recipe
 
-Start with the standard scaffold:
+`aileron sandbox init` scaffolds for Claude Code by default — the generated `.devcontainer/Dockerfile` already extends `aileron/sandbox-base`, switches to `USER root`, runs the Claude install, and switches back to `USER agent`. No edits required:
 
 ```bash
 aileron sandbox init
-```
-
-Edit `.devcontainer/Dockerfile`:
-
-```dockerfile
-FROM aileron/sandbox-base:latest
-
-USER root
-
-RUN apk add --no-cache \
-    git \
-    nodejs \
-    npm \
-    ripgrep \
-    && npm install -g @anthropic-ai/claude-code
-
-USER agent
 ```
 
 Build and validate:

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -49,7 +49,13 @@ The generated `devcontainer.json` is deliberately small:
 }
 ```
 
-The generated Dockerfile starts from `aileron/sandbox-base:<version>` and includes commented recipes for common tools such as GitHub CLI, Node.js, Python, kubectl, and Terraform. Uncomment and edit the snippets your project needs.
+The generated Dockerfile starts from `aileron/sandbox-base:<version>`, switches to `USER root` for installs, and switches back to `USER agent` before launch. The chosen agent's install recipe is pre-filled and ready to build; additional tool snippets (GitHub CLI, Node.js, Python, kubectl, Terraform) ship commented out for you to enable as needed.
+
+By default `aileron sandbox init` scaffolds for Claude Code. Pass `--agent=<name>` to scaffold for a different agent — Aileron writes a ready-to-build recipe when one is documented, or a `TODO` install stub otherwise:
+
+```bash
+aileron sandbox init --agent=codex
+```
 
 Use `--force` only when you intentionally want to replace the existing scaffold:
 

--- a/docs/src/content/docs/meet-aileron/v4.mdx
+++ b/docs/src/content/docs/meet-aileron/v4.mdx
@@ -164,7 +164,7 @@ v4 uses `.devcontainer/devcontainer.json` as the project-local composition subst
 
 `customizations.aileron.image` selects the BYO-image tier, where Aileron uses the image as supplied and injects the runtime contract at launch: the `aileron` binary/shims, discovery files, proxy bootstrap, session CA, and shell mediation files. Runtime bootstrap supplies `HTTPS_PROXY` and `AILERON_TOKEN`; non-loopback/container daemon binds are intentionally not protected until that explicit token path exists.
 
-`aileron sandbox init` scaffolds the starter `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile`. The Dockerfile extends `aileron/sandbox-base:<version>` and includes commented snippets for common tools. Tool installation remains standard container work; Aileron does not maintain an `aileron.yaml` tool resolver.
+`aileron sandbox init` scaffolds the starter `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile`. The Dockerfile extends `aileron/sandbox-base:<version>`, pre-fills the install recipe for the agent named in `--agent` (defaults to `claude`), and ships additional tool snippets commented out for you to enable as needed. Tool installation remains standard container work; Aileron does not maintain an `aileron.yaml` tool resolver.
 
 <Alert.Root class="my-6">
   <Alert.Title>What is not in v4</Alert.Title>

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -193,10 +193,64 @@ func TestInitWritesStarterDevcontainerAndDockerfile(t *testing.T) {
 			t.Fatalf("Dockerfile snippets must use apk against the Alpine base, not apt-get:\n%s", string(dockerfile))
 		}
 	}
-	for _, snippet := range []string{"--- Claude Code ---", "--- GitHub CLI ---", "--- Node.js ---", "--- Python ---", "--- kubectl ---", "--- Terraform ---"} {
+	for _, snippet := range []string{"--- GitHub CLI ---", "--- Node.js ---", "--- Python ---", "--- kubectl ---", "--- Terraform ---"} {
 		if !strings.Contains(string(dockerfile), snippet) {
-			t.Fatalf("Dockerfile missing snippet %q:\n%s", snippet, string(dockerfile))
+			t.Fatalf("Dockerfile missing menu snippet %q:\n%s", snippet, string(dockerfile))
 		}
+	}
+}
+
+func TestInitDefaultsToClaudeRecipeReadyToBuild(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Init(InitOptions{WorkDir: dir, Version: "0.4.0"}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	dockerfile, err := os.ReadFile(filepath.Join(dir, DefaultDockerfilePath))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	body := string(dockerfile)
+	for _, want := range []string{
+		"\nUSER root\n",
+		"\nUSER agent\n",
+		"--- Claude Code ---",
+		"npm install -g @anthropic-ai/claude-code",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("default Dockerfile missing %q:\n%s", want, body)
+		}
+	}
+	// The Claude install RUN must NOT be commented out — that was the
+	// pre-#963 footgun.
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, "@anthropic-ai/claude-code") && strings.HasPrefix(strings.TrimSpace(line), "#") {
+			t.Fatalf("Claude install RUN should be uncommented:\n%s", body)
+		}
+	}
+}
+
+func TestInitWithUnknownAgentEmitsTODOStub(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Init(InitOptions{WorkDir: dir, Version: "0.4.0", Agent: "codex"}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	dockerfile, err := os.ReadFile(filepath.Join(dir, DefaultDockerfilePath))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	body := string(dockerfile)
+	for _, want := range []string{
+		"\nUSER root\n",
+		"\nUSER agent\n",
+		"TODO: install the codex CLI",
+		"sandbox-agent-images",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("codex Dockerfile missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "@anthropic-ai/claude-code") {
+		t.Fatalf("codex Dockerfile should not include the Claude recipe:\n%s", body)
 	}
 }
 

--- a/internal/sandbox/composition/scaffold.go
+++ b/internal/sandbox/composition/scaffold.go
@@ -7,11 +7,18 @@ import (
 	"path/filepath"
 )
 
+// DefaultAgent is the agent the scaffold targets when --agent is omitted.
+// Claude Code is the only agent with a documented Tier 1 install recipe
+// today (see docs/development/sandbox-agent-images.md); other agents emit
+// a structurally correct Dockerfile with a TODO install stub.
+const DefaultAgent = "claude"
+
 // InitOptions configures the sandbox scaffold operation.
 type InitOptions struct {
 	WorkDir string
 	Version string
 	Force   bool
+	Agent   string
 }
 
 // InitResult reports which files were written.
@@ -42,7 +49,11 @@ func Init(opts InitOptions) (InitResult, error) {
 	if err := os.WriteFile(devcontainerPath, []byte(starterDevcontainer()), 0o644); err != nil {
 		return InitResult{}, fmt.Errorf("write %s: %w", devcontainerPath, err)
 	}
-	if err := os.WriteFile(dockerfilePath, []byte(starterDockerfile(opts.Version)), 0o644); err != nil {
+	agent := opts.Agent
+	if agent == "" {
+		agent = DefaultAgent
+	}
+	if err := os.WriteFile(dockerfilePath, []byte(starterDockerfile(opts.Version, agent)), 0o644); err != nil {
 		return InitResult{}, fmt.Errorf("write %s: %w", dockerfilePath, err)
 	}
 	return InitResult{
@@ -67,37 +78,55 @@ func starterDevcontainer() string {
 `
 }
 
-func starterDockerfile(version string) string {
+func starterDockerfile(version, agent string) string {
 	return fmt.Sprintf(`FROM %s
 
-# Uncomment snippets below to add tools to the Aileron sandbox.
-# Keep rarely changing snippets earlier for better layer caching.
-#
 # Aileron's base image is Alpine-based and runs as the non-root "agent"
-# user. Switch to root before installing packages, then switch back to
-# agent before launch. All snippets use apk; do not use apt-get here.
+# user. Switch to root to install tools, then switch back to agent before
+# launch. All install snippets use apk; do not use apt-get here.
 
-# USER root
+USER root
 
-# --- Claude Code ---
-# RUN apk add --no-cache git nodejs npm ripgrep && \
-#     npm install -g @anthropic-ai/claude-code
+%s
 
-# --- GitHub CLI ---
+# Uncomment additional tool snippets below as needed. Keep rarely
+# changing snippets earlier for better layer caching.
+#
+# # --- GitHub CLI ---
 # RUN apk add --no-cache github-cli
-
-# --- Node.js ---
+#
+# # --- Node.js ---
 # RUN apk add --no-cache nodejs npm
-
-# --- Python ---
+#
+# # --- Python ---
 # RUN apk add --no-cache python3 py3-pip
-
-# --- kubectl ---
+#
+# # --- kubectl ---
 # RUN apk add --no-cache kubectl
-
-# --- Terraform ---
+#
+# # --- Terraform ---
 # RUN apk add --no-cache terraform
 
-# USER agent
-`, BaseImage(version))
+USER agent
+`, BaseImage(version), agentInstallSnippet(agent))
+}
+
+// agentInstallSnippet returns the install recipe for agent. Agents with
+// a documented Tier 1 recipe are pre-filled and uncommented; agents
+// without one get a TODO stub that still produces a buildable Dockerfile
+// once the user fills it in.
+func agentInstallSnippet(agent string) string {
+	switch agent {
+	case "claude":
+		return `# --- Claude Code ---
+RUN apk add --no-cache git nodejs npm ripgrep && \
+    npm install -g @anthropic-ai/claude-code`
+	default:
+		return fmt.Sprintf(`# --- TODO: install the %s CLI ---
+# Aileron does not yet ship a verified install recipe for %s.
+# Replace this stub with an install that puts %q on PATH and uses apk
+# against the Alpine base. See:
+#   https://docs.withaileron.ai/development/sandbox-agent-images/
+# RUN apk add --no-cache ...`, agent, agent, agent)
+	}
 }


### PR DESCRIPTION
## Summary

`aileron sandbox init` previously shipped a Dockerfile where every useful line — including the `USER root` / `USER agent` directives that gate `apk` from working — was commented out. Following the documented Tier 1 recipe hit an exit-99 build failure unless the user knew to uncomment the right `USER` lines too. That bug is the one that triggered #963 and the conversation that produced this PR.

This change:

- Adds `--agent=<name>` to `aileron sandbox init`, validated against the launch registry. Default is `claude` (the only agent with a documented Tier 1 recipe today; tracked in #747).
- Rewrites the scaffold so the `USER root` → install → `USER agent` flow is uncommented and correctly placed. For `claude`, the install line is pre-filled and ready to build. For agents without a verified recipe (`codex`, `goose`, `opencode`, `pi`), it emits a `TODO: install the <name> CLI` stub plus a pointer to `docs/development/sandbox-agent-images/`, so the USER-directive footgun is gone even when the user still owns the install command itself.
- Tightens docs (`cli/index.md`, `development/sandbox-composition.md`, `development/sandbox-agent-images.md`, `meet-aileron/v4.mdx`, ADR-0017) to describe the new behavior. The Claude recipe walkthrough in `sandbox-agent-images.md` becomes `init && build && check && launch` with no Dockerfile editing.

End-to-end for the happy path:

```bash
aileron sandbox init                 # writes a ready-to-build Dockerfile for claude
aileron sandbox build --runtime=docker
aileron sandbox check --runtime=docker --agent=claude
aileron launch --sandbox=docker claude
```

A follow-up issue ([#965](https://github.com/ALRubinger/aileron/issues/965)) tracks publishing per-agent Tier 1 images (`aileron/sandbox-claude:<version>`) so even this Dockerfile goes away and `init` writes a Tier 2 BYO-image devcontainer instead.

## Test plan

- [x] `go test ./internal/sandbox/composition/...` — green; package coverage 89.1%
- [x] `go test ./cmd/aileron/...` — green; package coverage 85.4%
- [x] `go test ./internal/sandbox/... ./internal/launch/... ./cmd/aileron/...` — green
- [x] New unit tests: default scaffold is ready-to-build for claude (`TestInitDefaultsToClaudeRecipeReadyToBuild`), non-claude agents get a TODO stub (`TestInitWithUnknownAgentEmitsTODOStub`), CLI flag is validated against the registry (`TestRunSandboxInitAgentFlagSelectsRecipe`, `TestRunSandboxInitAgentFlagRejectsUnknownAgent`)
- [x] Pre-#963 regression assertion (no `RUN apt-get` in scaffolded output) still holds against the new template
- [x] CodeRabbit review — no findings
- [x] Manual eyeball of `init` and `init --agent=codex` output — USER directives correctly placed, claude install uncommented, codex emits TODO stub
- [ ] End-to-end docker build of the scaffolded Dockerfile — not exercised locally; the install line is the same `apk add ... && npm install -g @anthropic-ai/claude-code` that was already working in user testing once `USER root` was set, and the unit tests pin the file contents.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * `aileron sandbox init` now supports `--agent` flag to specify which agent to pre-configure (defaults to `claude`).
  * Generated Dockerfile pre-fills the installation recipe for the selected agent.
  * Agent validation with helpful error messages for unknown agents.

* **Documentation**
  * Updated CLI reference and development guides for the new `--agent` option and Dockerfile scaffolding behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->