### PR TITLE
fix(launch): cross-compile aileron-mcp for the sandbox container on non-Linux hosts

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -69,13 +69,25 @@ tasks:
       - go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron-server ./internal/server
 
   build:mcp:
-    desc: Build the Aileron MCP server binary locally
+    desc: Build the Aileron MCP server binary locally (plus a Linux variant on macOS/Windows hosts so `aileron launch --sandbox=docker` can bind-mount it into the container)
     vars:
       VERSION: dev
       COMMIT:
         sh: git rev-parse --short HEAD
+      HOST_GOOS:
+        sh: go env GOOS
+      HOST_GOARCH:
+        sh: go env GOARCH
     cmds:
       - go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron-mcp ./cmd/aileron-mcp
+      # Sandbox launch bind-mounts aileron-mcp into a Linux container. On
+      # non-Linux hosts the host-arch Mach-O / PE binary above fails with
+      # exec format error; this second build produces a sibling the
+      # launcher's resolveSandboxMCPBinary prefers for the sandbox path.
+      - |
+        if [ "{{.HOST_GOOS}}" != "linux" ]; then
+          GOOS=linux GOARCH={{.HOST_GOARCH}} go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron-mcp-linux-{{.HOST_GOARCH}} ./cmd/aileron-mcp
+        fi
 
   build:enclave:
     desc: Build the enclave binary locally

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -12,6 +12,7 @@ import (
 	"os/exec"
 	"os/signal"
 	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"syscall"
@@ -135,6 +136,34 @@ func resolveMCPBinary(selfPath string) (string, error) {
 	)
 }
 
+// resolveSandboxMCPBinary locates an aileron-mcp binary suitable for
+// bind-mounting into a Linux sandbox container.
+//
+// The host aileron-mcp produced by `task build:mcp` (or the official
+// packages) is built for the host OS/arch. On Linux/<arch>, that binary
+// runs unchanged inside a matching-arch container. On macOS or Windows
+// hosts, mounting a Mach-O / PE binary into a Linux container produces
+// `exec format error` at validate time (see runtime.go's "arch mismatch
+// or corrupt mount" path), even when the container's arch matches the
+// host's. To make sandbox launch work off Linux without per-user manual
+// cross-compilation, `task build:mcp` also produces a Linux variant
+// suffixed with the host GOARCH (e.g. `aileron-mcp-linux-arm64`); this
+// resolver prefers that sibling when it exists and falls back to the
+// host-arch binary otherwise.
+//
+// Container platform != host GOARCH (e.g. user passes
+// `DOCKER_DEFAULT_PLATFORM=linux/amd64` on an arm64 host) remains a hard
+// error at validate time; cross-architecture launch is out of scope for
+// the local dev build path and is handled by the published per-agent
+// images on the v4 roadmap.
+func resolveSandboxMCPBinary(selfPath string) (string, error) {
+	suffixed := "aileron-mcp-linux-" + runtime.GOARCH
+	if bin, err := resolveSibling(selfPath, suffixed); err == nil {
+		return bin, nil
+	}
+	return resolveMCPBinary(selfPath)
+}
+
 func sandboxLaunchEnabled(runtimeName string) bool {
 	switch runtimeName {
 	case "", "off":
@@ -222,9 +251,11 @@ func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchC
 	defer cleanupMounts()
 	mounts = append(mounts, extraMounts...)
 	// Resolve aileron-mcp and append its mount so the validate step
-	// can smoke-check the binary inside the container (ADR-0024).
+	// can smoke-check the binary inside the container (ADR-0024). Prefer
+	// the cross-compiled Linux variant when present so this works off a
+	// macOS/Windows host.
 	selfPath, _ := os.Executable()
-	mcpBinHost, err := resolveMCPBinary(selfPath)
+	mcpBinHost, err := resolveSandboxMCPBinary(selfPath)
 	if err != nil {
 		return err
 	}
@@ -573,8 +604,11 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 	// container's well-known MCP binary path. Matches the resolution
 	// shape host launch uses and the host-mount pattern
 	// sandboxDiscoveryMounts uses for tools.txt and shims (ADR-0024).
+	// Sandbox-flavored lookup picks the cross-compiled Linux variant
+	// when present so this path works off macOS/Windows hosts without
+	// per-user cross-compilation.
 	selfPath, _ := os.Executable()
-	mcpBinHost, err := resolveMCPBinary(selfPath)
+	mcpBinHost, err := resolveSandboxMCPBinary(selfPath)
 	if err != nil {
 		return LaunchResult{}, err
 	}

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"runtime"
 	"strings"
 	"testing"
 
@@ -478,3 +479,81 @@ op = "send_email"
 
 # Send Email
 `
+
+// TestResolveSandboxMCPBinary_PrefersLinuxSibling locks in the
+// precedence the launcher relies on under --sandbox=docker|podman: when
+// `task build:mcp` on a non-Linux host produces both `aileron-mcp`
+// (host arch, unrunnable in a Linux container) and
+// `aileron-mcp-linux-<arch>` (cross-compiled), the sandbox-flavored
+// lookup must pick the Linux variant, even when both exist. This is the
+// fix for the "aileron-mcp on PATH but not executable in this container
+// (arch mismatch or corrupt mount)" failure mode.
+func TestResolveSandboxMCPBinary_PrefersLinuxSibling(t *testing.T) {
+	dir := t.TempDir()
+	selfPath := filepath.Join(dir, "aileron")
+	if err := os.WriteFile(selfPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hostBin := filepath.Join(dir, "aileron-mcp")
+	if err := os.WriteFile(hostBin, []byte("host-arch binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	linuxBin := filepath.Join(dir, "aileron-mcp-linux-"+runtime.GOARCH)
+	if err := os.WriteFile(linuxBin, []byte("linux/"+runtime.GOARCH+" binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveSandboxMCPBinary(selfPath)
+	if err != nil {
+		t.Fatalf("resolveSandboxMCPBinary: %v", err)
+	}
+	want, _ := filepath.Abs(linuxBin)
+	if got != want {
+		t.Fatalf("got %q, want %q (the Linux-suffixed sibling)", got, want)
+	}
+}
+
+// TestResolveSandboxMCPBinary_FallsBackToHostBinary covers the Linux
+// host case: `task build:mcp` only produces the plain binary because it
+// is already a Linux binary; the sandbox-flavored lookup must accept it.
+func TestResolveSandboxMCPBinary_FallsBackToHostBinary(t *testing.T) {
+	dir := t.TempDir()
+	selfPath := filepath.Join(dir, "aileron")
+	if err := os.WriteFile(selfPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	hostBin := filepath.Join(dir, "aileron-mcp")
+	if err := os.WriteFile(hostBin, []byte("host arch is linux"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveSandboxMCPBinary(selfPath)
+	if err != nil {
+		t.Fatalf("resolveSandboxMCPBinary: %v", err)
+	}
+	want, _ := filepath.Abs(hostBin)
+	if got != want {
+		t.Fatalf("got %q, want %q (fallback to plain aileron-mcp)", got, want)
+	}
+}
+
+// TestResolveSandboxMCPBinary_PropagatesMissingError ensures the
+// "aileron-mcp not found" remediation hint surfaces even on the
+// sandbox-flavored lookup, so users on a fresh checkout get the same
+// `task build:mcp` pointer the host path already gives them.
+func TestResolveSandboxMCPBinary_PropagatesMissingError(t *testing.T) {
+	dir := t.TempDir()
+	selfPath := filepath.Join(dir, "aileron")
+	if err := os.WriteFile(selfPath, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", "")
+
+	_, err := resolveSandboxMCPBinary(selfPath)
+	if err == nil {
+		t.Fatal("expected error when neither variant exists")
+	}
+	if !strings.Contains(err.Error(), "aileron-mcp not found") || !strings.Contains(err.Error(), "task build:mcp") {
+		t.Fatalf("error message lost the remediation hint: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

`aileron launch --sandbox=docker claude` failed at validate time on macOS hosts with:

> error: ... aileron-mcp on PATH but not executable in this container (arch mismatch or corrupt mount); sandbox MCP wiring failed: exit status 127

Reported during #747 testing right after #964 unblocked the Dockerfile flow.

**Root cause.** `task build:mcp` (Taskfile.yml:78) did a plain `go build` with no `GOOS/GOARCH`, so on macOS / Windows hosts the produced `aileron-mcp` was Mach-O / PE. The sandbox launcher bind-mounts that binary read-only at `/usr/local/bin/aileron-mcp` and the validation script (`internal/sandbox/container/runtime.go:382`) runs `aileron-mcp --version`. Linux cannot execute a Mach-O binary → exec format error → exit 127. The error message even named "arch mismatch" as the likely cause; the build pipeline just had no way to produce the right binary.

## Fix

- **Taskfile** — on non-Linux hosts, `task build:mcp` now runs a second `GOOS=linux GOARCH=$(go env GOARCH) go build` and produces `build/aileron-mcp-linux-<arch>` next to the host binary. On Linux hosts the existing plain build is already a Linux binary, no extra step.
- **Launcher** — new `resolveSandboxMCPBinary` (`internal/launch/launcher.go`) prefers `aileron-mcp-linux-<runtime.GOARCH>` next to the running `aileron` binary when present, falls back to the plain `aileron-mcp` otherwise. Both sandbox call sites — `validateSandbox` (preflight) and `launchSandbox` (run) — use the new resolver. The host-launch path continues to use `resolveMCPBinary` unchanged so host MCP workflows keep their Mach-O / PE binary.
- The missing-binary error still recommends `task build:mcp` so the remediation hint remains correct.

After this PR:

```bash
task build:mcp   # produces build/aileron-mcp (Mach-O on macOS) AND build/aileron-mcp-linux-arm64 (ELF)
./build/aileron launch --sandbox=docker claude
# launcher bind-mounts build/aileron-mcp-linux-arm64 into the container -> --version smoke passes
```

## Scope boundaries (deferred)

- Container-arch != host-arch (e.g. `DOCKER_DEFAULT_PLATFORM=linux/amd64` on an arm64 host) remains a hard error at validate time. The `resolveSandboxMCPBinary` shape leaves room for an arch override but adding one requires plumbing the container's actual platform through the launcher, which is out of scope for this fix. Cross-arch is properly addressed by the per-agent published images tracked in #965.

## Test plan

- [x] `go test ./internal/launch/...` — green; package coverage 87.4%
- [x] `go test ./internal/sandbox/... ./cmd/aileron/...` — green
- [x] New unit tests for the resolver in `internal/launch/launcher_internal_test.go`:
  - `TestResolveSandboxMCPBinary_PrefersLinuxSibling` — when both `aileron-mcp` and `aileron-mcp-linux-<arch>` exist next to the running binary, the sandbox path picks the Linux variant
  - `TestResolveSandboxMCPBinary_FallsBackToHostBinary` — when only the plain `aileron-mcp` exists (Linux-host case), it's used as-is
  - `TestResolveSandboxMCPBinary_PropagatesMissingError` — when nothing matches, the error still says `aileron-mcp not found` and points at `task build:mcp`
- [x] CodeRabbit review — no findings
- [x] Manual: `task build:mcp` on darwin/arm64 produces both `build/aileron-mcp` (`Mach-O 64-bit executable arm64`) and `build/aileron-mcp-linux-arm64` (`ELF 64-bit LSB executable, ARM aarch64`)
- [ ] End-to-end `aileron launch --sandbox=docker claude` against a real Linux container — not in CI; the unit tests pin the resolver precedence and the file-format mismatch was the failure mode being fixed. Will be re-exercised by the original reporter on their next test run.

Related: #747 (v4 milestone), #964 (the earlier PR that unblocked the Dockerfile path and surfaced this), #965 (per-agent published images that eventually replace the host-mount path), [ADR-0024](https://docs.withaileron.ai/adr/0024-sandbox-mcp-parity/) (sandbox MCP parity).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved Linux sandbox compatibility for macOS and Windows. The build system now automatically generates platform-specific binaries to support containerized execution without requiring manual cross-compilation setup.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->