### PR TITLE
refactor(sandbox-proxy): replace 501 stubs with structured rejections (#896 Section C)

### DIFF
--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -19,7 +19,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/sandbox/discovery"
 )
 
-const connectorOperationNotImplementedMessage = "connector operation dispatch is not implemented yet; mediated HTTPS data-plane execution is tracked by issue #896"
+const connectorOperationNotProxyableMessage = "connector operation is not proxyable through the daemon HTTPS data plane; the spec lacks a required field (method, hosts, path) or uses an unsupported HTTP method"
 const sandboxProxyMaxResponseBytes = 4 << 20
 
 const (
@@ -91,7 +91,7 @@ func (s *apiServer) RunConnectorOperation(w http.ResponseWriter, r *http.Request
 		ConnectorFqn: connectorFQN,
 		Tool:         toolName,
 		Operation:    operation.Name,
-		Message:      connectorOperationNotImplementedMessage,
+		Message:      connectorOperationNotProxyableMessage,
 	})
 }
 
@@ -539,7 +539,7 @@ func (s *apiServer) recordConnectorOperationRejected(r *http.Request, connectorF
 		"aileron.connector.boundary":      "daemon_operation_endpoint",
 		"aileron.connector.mediation":     "direct_shim_contract",
 		"aileron.connector.decision":      "rejected",
-		"aileron.connector.reject_reason": "data_plane_not_implemented",
+		"aileron.connector.reject_reason": "operation_not_proxyable",
 	}
 	if operation.Credential != "" {
 		payload["aileron.connector.credential_required"] = true

--- a/internal/app/handlers_connector_operations_test.go
+++ b/internal/app/handlers_connector_operations_test.go
@@ -152,7 +152,7 @@ func TestRunConnectorOperation_RecognizedOperationAuditsAndFailsClosed(t *testin
 	if payload["aileron.connector.credential"] != "oauth2" {
 		t.Errorf("credential kind payload = %v", payload["aileron.connector.credential"])
 	}
-	if payload["aileron.connector.reject_reason"] != "data_plane_not_implemented" {
+	if payload["aileron.connector.reject_reason"] != "operation_not_proxyable" {
 		t.Errorf("reject reason payload = %v", payload["aileron.connector.reject_reason"])
 	}
 	if payload["aileron.session.id"] != "session-123" {

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -57,8 +57,34 @@ func (s *apiServer) HandleSandboxForwardProxy(w http.ResponseWriter, r *http.Req
 		s.handleSandboxForwardProxyConnect(w, r, auth)
 		return
 	}
+	upstream := sandboxForwardProxyAbsoluteFormUpstream(r)
+	s.recordSandboxProxyUnresolvedRejected(r, sandboxProxySourceTransparentConnectTLS, r.Method, upstream, "non_connect_proxy_request_unsupported")
 	w.Header().Set("X-Aileron-Session-Id", auth.SessionID)
-	http.Error(w, "sandbox HTTPS forward proxy transport is not implemented yet; tracked by issue #896", http.StatusNotImplemented)
+	http.Error(w, "sandbox HTTPS forward proxy requires CONNECT for HTTPS interception; absolute-form proxy requests without CONNECT are not supported", http.StatusForbidden)
+}
+
+// sandboxForwardProxyAbsoluteFormUpstream returns a best-effort upstream
+// URL for audit emission on the non-CONNECT proxy path. Absolute-form
+// proxy requests carry the full URL on r.URL; relative-form requests
+// fall back to https://r.Host/r.URL.Path so the audit always has a
+// host and path to report.
+func sandboxForwardProxyAbsoluteFormUpstream(r *http.Request) *url.URL {
+	if r.URL != nil && r.URL.IsAbs() {
+		return r.URL
+	}
+	host := strings.TrimSpace(r.Host)
+	if host == "" && r.URL != nil {
+		host = r.URL.Host
+	}
+	path := "/"
+	if r.URL != nil && r.URL.Path != "" {
+		path = r.URL.Path
+	}
+	upstream, _ := parseSandboxProxyUpstreamURL("https://" + host + path)
+	if upstream == nil {
+		upstream = &url.URL{Scheme: "https", Host: host, Path: path}
+	}
+	return upstream
 }
 
 type sandboxForwardProxyConn struct {
@@ -81,8 +107,13 @@ func (s *apiServer) handleSandboxForwardProxyConnect(w http.ResponseWriter, r *h
 	}
 	cert, err := s.sandboxForwardProxyCertificate(auth.SessionID, targetHost)
 	if err != nil {
+		upstream, _ := parseSandboxProxyUpstreamURL("https://" + targetHost + "/")
+		if upstream == nil {
+			upstream = &url.URL{Scheme: "https", Host: targetHost, Path: "/"}
+		}
+		s.recordSandboxProxyUnresolvedRejected(r, sandboxProxySourceTransparentConnectTLS, r.Method, upstream, "session_ca_unavailable")
 		w.Header().Set("X-Aileron-Session-Id", auth.SessionID)
-		http.Error(w, "sandbox HTTPS forward proxy CONNECT transport is not available; tracked by issue #896", http.StatusNotImplemented)
+		http.Error(w, "sandbox proxy session CA is unavailable for this session; the launcher's session state directory may be missing or corrupted (see ADR-0019)", http.StatusInternalServerError)
 		return
 	}
 	hijacker, ok := w.(http.Hijacker)

--- a/internal/app/handlers_sandbox_forward_proxy_test.go
+++ b/internal/app/handlers_sandbox_forward_proxy_test.go
@@ -59,7 +59,7 @@ func TestSandboxForwardProxy_CONNECTRejectsInvalidToken(t *testing.T) {
 	}
 }
 
-func TestSandboxForwardProxy_CONNECTAuthenticatesAndFailsClosed(t *testing.T) {
+func TestSandboxForwardProxy_CONNECTAuthenticatesAndFailsClosedOnMissingSessionCA(t *testing.T) {
 	handler := newSandboxForwardProxyTestHandler(t, "daemon-token")
 	req := httptest.NewRequest(http.MethodConnect, "http://gmail.googleapis.com:443", nil)
 	req.Host = "gmail.googleapis.com:443"
@@ -68,14 +68,14 @@ func TestSandboxForwardProxy_CONNECTAuthenticatesAndFailsClosed(t *testing.T) {
 
 	handler.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusNotImplemented {
-		t.Fatalf("status = %d, want 501; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500; body=%s", rec.Code, rec.Body.String())
 	}
 	if got := rec.Header().Get("X-Aileron-Session-Id"); got != "session-123" {
 		t.Fatalf("X-Aileron-Session-Id = %q, want session-123", got)
 	}
-	if !strings.Contains(rec.Body.String(), "sandbox HTTPS forward proxy CONNECT transport is not available") {
-		t.Fatalf("body = %q", rec.Body.String())
+	if !strings.Contains(rec.Body.String(), "sandbox proxy session CA is unavailable") {
+		t.Fatalf("body = %q, want session CA unavailable message", rec.Body.String())
 	}
 }
 
@@ -671,7 +671,78 @@ func TestSignSandboxForwardProxyLeaf_IncludesIPSAN(t *testing.T) {
 	}
 }
 
-func TestSandboxForwardProxy_AbsoluteFormV1PathDoesNotHitDaemonAuth(t *testing.T) {
+func TestSandboxForwardProxy_NonCONNECTAuditsUnresolvedRejection(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		localDaemonToken: "daemon-token",
+		auditRecorder:    audit.NewRecorder(auditStore, nil, func() string { return "audit-non-connect" }),
+	}
+	handler := srv.sandboxForwardProxyMiddleware(http.NotFoundHandler())
+	req := httptest.NewRequest(http.MethodGet, "https://api.example.test/v1/resource", nil)
+	req.Header.Set("Proxy-Authorization", basicProxyAuth("session-123", "daemon-token"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
+	}
+
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyRejected {
+		t.Fatalf("event type = %q, want %q", events[0].EventType, model.EventTypeSandboxProxyRejected)
+	}
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != "non_connect_proxy_request_unsupported" {
+		t.Fatalf("reject reason = %v, want non_connect_proxy_request_unsupported", got)
+	}
+	if got := events[0].Payload["aileron.proxy.upstream.host"]; got != "api.example.test" {
+		t.Errorf("upstream host = %v, want api.example.test", got)
+	}
+}
+
+func TestSandboxForwardProxy_CONNECTSessionCAMissingAuditsUnresolvedRejection(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		localDaemonToken: "daemon-token",
+		auditRecorder:    audit.NewRecorder(auditStore, nil, func() string { return "audit-ca-missing" }),
+	}
+	handler := srv.sandboxForwardProxyMiddleware(http.NotFoundHandler())
+	req := httptest.NewRequest(http.MethodConnect, "http://gmail.googleapis.com:443", nil)
+	req.Host = "gmail.googleapis.com:443"
+	req.Header.Set("Proxy-Authorization", basicProxyAuth("session-123", "daemon-token"))
+	rec := httptest.NewRecorder()
+
+	handler.ServeHTTP(rec, req)
+
+	if rec.Code != http.StatusInternalServerError {
+		t.Fatalf("status = %d, want 500", rec.Code)
+	}
+
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyRejected {
+		t.Fatalf("event type = %q", events[0].EventType)
+	}
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != "session_ca_unavailable" {
+		t.Fatalf("reject reason = %v, want session_ca_unavailable", got)
+	}
+	if got := events[0].Payload["aileron.proxy.upstream.host"]; got != "gmail.googleapis.com" {
+		t.Errorf("upstream host = %v, want gmail.googleapis.com", got)
+	}
+}
+
+func TestSandboxForwardProxy_AbsoluteFormV1PathRejectsWithStructuredError(t *testing.T) {
 	handler := newSandboxForwardProxyTestHandler(t, "daemon-token")
 	req := httptest.NewRequest(http.MethodGet, "https://api.example.test/v1/resource", nil)
 	req.Header.Set("Proxy-Authorization", basicProxyAuth("session-123", "daemon-token"))
@@ -679,11 +750,14 @@ func TestSandboxForwardProxy_AbsoluteFormV1PathDoesNotHitDaemonAuth(t *testing.T
 
 	handler.ServeHTTP(rec, req)
 
-	if rec.Code != http.StatusNotImplemented {
-		t.Fatalf("status = %d, want 501; body=%s", rec.Code, rec.Body.String())
+	if rec.Code != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403; body=%s", rec.Code, rec.Body.String())
 	}
 	if got := rec.Header().Get("X-Aileron-Session-Id"); got != "session-123" {
 		t.Fatalf("X-Aileron-Session-Id = %q, want session-123", got)
+	}
+	if !strings.Contains(rec.Body.String(), "requires CONNECT for HTTPS interception") {
+		t.Fatalf("body = %q, want CONNECT-required message", rec.Body.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

Closes **Section C** of [#896](https://github.com/ALRubinger/aileron/issues/896) — the remaining three honest-stub 501 sites are replaced with structured rejection envelopes + audit events, and the `tracked by issue #896` strings are removed from production code.

### Three sites changed

| Site | Before | After |
|---|---|---|
| `HandleSandboxForwardProxy` non-CONNECT path (`handlers_sandbox_forward_proxy.go` line 61) | 501 with "tracked by issue #896" | **403** + actionable message "requires CONNECT for HTTPS interception"; emits `sandbox.proxy.rejected` with reason `non_connect_proxy_request_unsupported` via `recordSandboxProxyUnresolvedRejected` |
| `handleSandboxForwardProxyConnect` session CA missing (line 85) | 501 with "tracked by issue #896" | **500** + message pointing at ADR-0019; emits `sandbox.proxy.rejected` with reason `session_ca_unavailable` |
| `RunConnectorOperation` non-proxyable operation (line 22 const + 88-95 + 542 reject reason) | 501 with `connectorOperationNotImplementedMessage`, audit reason `data_plane_not_implemented` | **501** (unchanged — path is still reachable) with new `connectorOperationNotProxyableMessage`; audit reject_reason renamed to `operation_not_proxyable` |

### Why the third site keeps 501

The third site fires when a connector spec's operation lacks a required field (method, hosts, path) or uses an unsupported HTTP method — `canProxy` returns false in `connectorOperationRunProxyRequest`. This path remains reachable in the default-on world (a spec can ship with an unprojectable operation shape), so the right move is a *clearer name* (`operation_not_proxyable` instead of `data_plane_not_implemented`), not a deletion. The 501 status is kept to minimize client-side churn — generated shims key off `Status: "rejected"` in the JSON envelope, not the HTTP status.

### Tests

- `TestSandboxForwardProxy_AbsoluteFormV1PathRejectsWithStructuredError` — renamed from the old `…DoesNotHitDaemonAuth` test; asserts 403 + new message.
- `TestSandboxForwardProxy_CONNECTAuthenticatesAndFailsClosedOnMissingSessionCA` — renamed from `…AuthenticatesAndFailsClosed`; asserts 500 + session-CA-unavailable message.
- `TestSandboxForwardProxy_NonCONNECTAuditsUnresolvedRejection` (new) — verifies the audit event shape on the non-CONNECT path.
- `TestSandboxForwardProxy_CONNECTSessionCAMissingAuditsUnresolvedRejection` (new) — verifies the audit event shape on the missing-CA path.
- `TestRunConnectorOperation_RecognizedOperationAuditsAndFailsClosed` — assertion updated for the new reject reason.

### Verification

- [x] `go test ./internal/app/` — green.
- [x] `go test ./internal/app/ -cover` — 81.0% (above 80%).
- [x] `task vet:go` — clean.
- [x] `grep -rn "tracked by issue #896" internal/app/*.go | grep -v _test.go` — no production-code matches remain.

Covers requirements **R19, R20, R21**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Sandbox proxy error handling improved: now returns 403 Forbidden for unsupported HTTPS request formats and 500 Internal Server Error when session credentials are unavailable, with clearer explanatory messages for users.
  * Connector operation rejections now include more descriptive messaging to indicate when operations cannot be proxied.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->