### PR TITLE
fix(daemon): exempt LLM gateway passthrough from daemon-token auth

### DIFF
--- a/internal/app/app_test.go
+++ b/internal/app/app_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -94,6 +95,114 @@ func TestNewHandler_LocalDaemonTokenProtectsV1(t *testing.T) {
 	_ = resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
 		t.Fatalf("status with token = %d, want 200", resp.StatusCode)
+	}
+}
+
+// TestNewHandler_LocalDaemonToken_ExemptsLLMGateway covers the
+// regression where the daemon's bearer-auth middleware was rejecting
+// requests to the LLM gateway (`/v1/messages`, `/v1/chat/completions`)
+// because the agent's own provider OAuth bearer in the Authorization
+// header didn't match the daemon's token. The gateway is a transparent
+// passthrough that forwards the agent's headers to upstream unchanged,
+// so daemon-token gating provides no security benefit and breaks every
+// in-container agent that uses subscription OAuth.
+//
+// The contract: a POST to a gateway endpoint must reach the reverse
+// proxy and be forwarded to upstream regardless of what the agent put
+// in the Authorization header. The middleware's 401 envelope (carrying
+// `code=unauthorized`, `message=missing or invalid daemon token`) must
+// not fire. Upstream behavior is irrelevant to this test — we run a
+// recording fake upstream and assert that the request reached it.
+func TestNewHandler_LocalDaemonToken_ExemptsLLMGateway(t *testing.T) {
+	// Recording fake upstream — every successful proxy pass lands here.
+	// 200 + no-op body keeps the response shape uninteresting; we only
+	// care that the request hit this handler (proves middleware bypass).
+	hits := make(chan *http.Request, 8)
+	upstream := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits <- r
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"ok":true}`))
+	}))
+	defer upstream.Close()
+
+	t.Setenv("AILERON_ANTHROPIC_BASE_URL", upstream.URL)
+	t.Setenv("AILERON_OPENAI_BASE_URL", upstream.URL)
+
+	log := slog.New(slog.NewJSONHandler(io.Discard, nil))
+	handler, err := NewHandlerWithConfig(log, Config{
+		Vault:            vault.NewMemVault(),
+		LocalDaemonToken: "tok_test",
+	})
+	if err != nil {
+		t.Fatalf("NewHandlerWithConfig: %v", err)
+	}
+	srv := httptest.NewServer(handler)
+	defer srv.Close()
+
+	cases := []struct {
+		path    string
+		auth    string // value for Authorization header; empty omits the header
+		comment string
+	}{
+		{"/v1/messages", "", "no auth (catches gateway-not-configured-style 401 from middleware)"},
+		{"/v1/messages", "Bearer sk-ant-oat01-fake-agent-oauth", "agent-supplied provider OAuth"},
+		{"/v1/chat/completions", "", "no auth"},
+		{"/v1/chat/completions", "Bearer sk-fake-openai-key", "agent-supplied provider key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.path+"/"+tc.comment, func(t *testing.T) {
+			req, err := http.NewRequest(http.MethodPost, srv.URL+tc.path,
+				strings.NewReader(`{"model":"x","messages":[]}`))
+			if err != nil {
+				t.Fatal(err)
+			}
+			req.Header.Set("Content-Type", "application/json")
+			if tc.auth != "" {
+				req.Header.Set("Authorization", tc.auth)
+			}
+			resp, err := http.DefaultClient.Do(req)
+			if err != nil {
+				t.Fatalf("POST %s: %v", tc.path, err)
+			}
+			body, _ := io.ReadAll(resp.Body)
+			_ = resp.Body.Close()
+			// The middleware's specific failure envelope must not appear,
+			// regardless of upstream behavior.
+			if bytes.Contains(body, []byte("missing or invalid daemon token")) {
+				t.Fatalf("middleware fired on %s (regression): body=%s", tc.path, string(body))
+			}
+			select {
+			case got := <-hits:
+				if got.URL.Path != tc.path {
+					t.Errorf("upstream received path %q, want %q", got.URL.Path, tc.path)
+				}
+				if tc.auth != "" && got.Header.Get("Authorization") != tc.auth {
+					t.Errorf("upstream Authorization = %q, want passthrough %q", got.Header.Get("Authorization"), tc.auth)
+				}
+			default:
+				t.Fatalf("upstream never received the request — middleware probably blocked %s (status=%d body=%s)", tc.path, resp.StatusCode, string(body))
+			}
+		})
+	}
+}
+
+// TestLocalDaemonAuthSkip_Contract pins the exact set of /v1/* paths
+// that bypass the daemon-token middleware: health, the cookie handshake,
+// and the two LLM gateway endpoints. Anything else under /v1/ requires
+// auth. A change here that adds a path needs a separate review of the
+// trust model.
+func TestLocalDaemonAuthSkip_Contract(t *testing.T) {
+	exempt := []string{"/v1/health", "/v1/auth/handshake", "/v1/messages", "/v1/chat/completions"}
+	for _, p := range exempt {
+		if !localDaemonAuthSkip(p) {
+			t.Errorf("%s must be exempt from daemon-token auth", p)
+		}
+	}
+	gated := []string{"/v1/status", "/v1/actions", "/v1/bindings", "/v1/messages/count_tokens", "/v1/audit"}
+	for _, p := range gated {
+		if localDaemonAuthSkip(p) {
+			t.Errorf("%s must require daemon-token auth", p)
+		}
 	}
 }
 

--- a/internal/app/middleware.go
+++ b/internal/app/middleware.go
@@ -149,6 +149,22 @@ func localDaemonAuthSkip(path string) bool {
 	switch path {
 	case "/v1/health", "/v1/auth/handshake":
 		return true
+	case "/v1/messages", "/v1/chat/completions":
+		// The LLM gateway is a transparent passthrough: the reverse
+		// proxy forwards the agent's own `x-api-key` /
+		// `Authorization` headers to upstream Anthropic / OpenAI
+		// unchanged (see newGatewayProxy in handlers_gateway.go), and
+		// the daemon never substitutes credentials of its own. Gating
+		// these paths on the daemon's bearer token would reject every
+		// in-container agent whose Authorization header carries its
+		// own provider OAuth token (the daemon would compare it to
+		// its own daemon token, see a mismatch, and 401 before the
+		// proxy ever runs). That 401 is also indistinguishable to the
+		// agent from an upstream auth failure, which sends users
+		// chasing the wrong root cause. The gateway adds no upstream
+		// credentials of its own, so daemon-token gating provides no
+		// security benefit here — exempt it.
+		return true
 	default:
 		return false
 	}


### PR DESCRIPTION
## Summary

`/v1/messages` (Anthropic) and `/v1/chat/completions` (OpenAI) on the daemon are transparent reverse proxies. `newGatewayProxy` (`internal/app/handlers_gateway.go:95-122`) forwards the agent's own `x-api-key` / `Authorization` headers to upstream **unchanged**; the daemon never substitutes credentials of its own.

Sitting behind `localDaemonAuthMiddleware` is wrong by design. Every in-container agent puts its own provider auth in the `Authorization` header — Claude Code's subscription OAuth bearer (`sk-ant-oat01-…`), OpenAI bearers, whatever. The middleware compares that header to Aileron's *own* daemon token, sees a mismatch, and returns `401 "missing or invalid daemon token"` before the proxy ever runs. Worst-of-both-worlds: the gate provides no security benefit (the daemon adds no upstream credentials of its own that a local attacker could exploit) and blocks the entire happy path.

User-visible symptom that surfaced this during #747 sandbox testing: every keystroke in Claude inside the sandbox produced *"Please run /login · API Error: 401 missing or invalid daemon token"*. The 401 was the daemon's middleware, not Anthropic. Claude (correctly) treated 401 as an auth failure and prompted to re-login, sending users chasing the wrong root cause.

## Fix

Add `/v1/messages` and `/v1/chat/completions` to `localDaemonAuthSkip` (`internal/app/middleware.go`). Inline comment explains the why so future readers don't accidentally pull them back into the gated set when adding new exemptions.

Coverage:

- **`TestLocalDaemonAuthSkip_Contract`** — pins the exact exempt set (`/v1/health`, `/v1/auth/handshake`, `/v1/messages`, `/v1/chat/completions`) and pins examples of paths that must remain gated (`/v1/status`, `/v1/actions`, `/v1/bindings`, `/v1/audit`, `/v1/messages/count_tokens`). Any future addition to the exempt list now requires deleting an assertion, which forces a review of the trust-model implication.
- **`TestNewHandler_LocalDaemonToken_ExemptsLLMGateway`** — end-to-end through `NewHandlerWithConfig` with `LocalDaemonToken="tok_test"` and a recording fake upstream. Verifies that POSTing to both gateway endpoints with (a) no `Authorization`, and (b) a deliberately wrong bearer (the shape of an agent's own provider OAuth) both reach the fake upstream and pass the `Authorization` header through unchanged. Also explicitly asserts the response body does not contain the middleware's `"missing or invalid daemon token"` string, so a regression where the gate sneaks back in fails loudly with that exact wording.

The existing `TestNewHandler_LocalDaemonTokenProtectsV1` continues to pass — non-gateway `/v1/*` paths still require the daemon token.

## What this PR doesn't fix

This unblocks gateway requests at the middleware layer. Anthropic upstream will still 401 if the agent has no valid provider credentials inside the container — the design conversation for getting those credentials in via vault injection is #969. After this PR, that's the only remaining blocker for end-to-end sandbox launch.

## Test plan

- [x] `go test ./internal/app/...` — full package green, ~13s
- [x] `go test ./internal/app/... -run "LocalDaemon|GatewayPassthrough|LocalDaemonAuthSkip" -v` — new tests pass; existing `TestNewHandler_LocalDaemonTokenProtectsV1` still pins the gated-by-default behavior for non-exempt paths
- [x] CodeRabbit review — no findings
- [ ] Manual: from inside the sandbox container, replicate the original failure (every keystroke → `"missing or invalid daemon token"`) on `main`, then rebuild with this PR and confirm the daemon-side gate no longer fires. The remaining failure (Anthropic upstream 401 because no provider credentials are injected) is expected and tracked in #969.

Related: #747 (v4 milestone), #964 + #966 (predecessor unblocks for sandbox launch), #969 (vault-backed credential injection — the post-this-PR remaining blocker).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * LLM gateway endpoints (`/v1/messages`, `/v1/chat/completions`) now bypass daemon-token authentication, allowing upstream authorization credentials to pass through unchanged.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->