### PR TITLE
feat(launch): per-agent AuthSpec for goose, opencode, pi

### DIFF
--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -12,12 +12,19 @@ This page is for operators and contributors. It documents the per-agent envelope
 
 Per-agent credentials live under the namespace `agents/<name>/<purpose>`:
 
-| Path                  | Owner | Envelope schema                                                                                |
-|-----------------------|-------|------------------------------------------------------------------------------------------------|
-| `agents/claude/oauth` | Claude Code  | `{"claudeAiOauth":{"accessToken":...,"refreshToken":...,"expiresAt":...,"scopes":[...]}}` |
-| `agents/codex/oauth`  | OpenAI Codex | `{"auth_mode":"chatgpt","tokens":{"access_token":...,"refresh_token":...,"id_token":...,"account_id":...},"last_refresh":"..."}` |
+| Path                    | Owner | Binding | Envelope / secret shape                                                                                |
+|-------------------------|-------|---------|--------------------------------------------------------------------------------------------------------|
+| `agents/claude/oauth`   | Claude Code  | FileBinding | `{"claudeAiOauth":{"accessToken":...,"refreshToken":...,"expiresAt":...,"scopes":[...]}}` |
+| `agents/codex/oauth`    | OpenAI Codex | FileBinding | `{"auth_mode":"chatgpt","tokens":{"access_token":...,"refresh_token":...,"id_token":...,"account_id":...},"last_refresh":"..."}` |
+| `agents/goose/oauth`    | Goose        | EnvBinding  | Raw provider API key (opaque bytes), rendered into `ANTHROPIC_API_KEY` |
+| `agents/opencode/oauth` | OpenCode     | FileBinding | `{"<provider>":{...credential...},...}` — `auth.json` keyed by provider name |
+| `agents/pi/oauth`       | Pi           | FileBinding | `{"<provider>":{"type":"api_key","key":...},...}` — `auth.json` keyed by provider name |
 
-Other agents (Goose, OpenCode, Pi) ship a zero-value `AuthSpec{}` in v1: they continue to prompt for login on every sandbox launch. Per-agent specs for those three are tracked as follow-up issues.
+Two binding shapes appear in the table. A **FileBinding** backs a rotatable on-disk credential file: the launcher renders the vault bytes into the file before launch and snapshots the (possibly rotated) file back via Capture on clean exit. An **EnvBinding** backs a static credential read from the environment: the launcher renders the stored secret into one or more env vars at launch and has nothing to capture, because an env-key agent does not rewrite a credential file in-container.
+
+Goose authenticates with a provider API key (resolved from `<PROVIDER>_API_KEY` or its keyring), so its binding is an EnvBinding rendering the stored key into `ANTHROPIC_API_KEY` (Goose's default provider under launch; seed the matching key for a different provider). OpenCode and Pi each persist provider credentials in a standalone `auth.json` (OpenCode under `~/.local/share/opencode/`, Pi under `~/.pi/agent/`), so both use a byte-identity FileBinding. Pi's `auth.json` is the dedicated credential file, distinct from `settings.json`, so the binding never snapshots non-credential session state.
+
+The vault path's third segment is the literal `oauth` for every agent even when the stored secret is an API key, not an OAuth bundle. The daemon's per-agent endpoint and `vaultPathConforms` (in `internal/launch/authspec.go`) require exactly `agents/<name>/oauth`; any other shape fails launch validation.
 
 The daemon's HTTP surface scopes the path at the routing layer. `GET/PUT /v1/vault/agents/{name}/credentials` translates `{name}` internally to `agents/<name>/oauth`. Other vault paths are unreachable through this endpoint.
 
@@ -44,8 +51,12 @@ then starts the container with the bind-mount empty. The in-container agent perf
 
 - **Claude Code:** paste-the-code OAuth fallback in the terminal.
 - **Codex CLI:** device-auth flow against `auth.openai.com`.
+- **OpenCode:** `opencode auth login` writes `auth.json`.
+- **Pi:** `/login` writes `auth.json`.
 
 When the container exits cleanly, Capture reads the file the agent wrote and PUTs the bytes to the vault. Every later launch renders silently.
+
+Goose's EnvBinding has no Capture (there is no credential file to snapshot), so first-launch seeding for Goose is by manual `aileron vault put agents/goose/oauth` rather than by an in-container login that Capture stores.
 
 ## Manual seeding
 

--- a/internal/launch/agents/goose.go
+++ b/internal/launch/agents/goose.go
@@ -188,8 +188,20 @@ func gooseConfigDir() (string, error) {
 	return filepath.Join(home, ".config", "goose"), nil
 }
 
-// AuthSpec returns Goose's vault-backed credential descriptor.
-// Goose has no per-agent vault binding today, so it returns the
-// zero value; the launcher treats that as a no-op. A future v1.x
-// issue would fill this in for Goose sandbox launches.
-func (g Goose) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
+// AuthSpec returns Goose's vault-backed credential descriptor. Goose
+// authenticates with a provider API key (read from a `<PROVIDER>_API_KEY`
+// env var or its keyring), not a rotatable on-disk credential file, so
+// the binding is an EnvBinding: the stored key is rendered into the
+// container env at launch. There is no Capture (an env-key binding has
+// nothing to snapshot back) and no PreLaunchRefresh (a static API key
+// does not rotate). Required is false so an unseeded vault falls through
+// to Goose's normal provider-key resolution instead of hard-failing.
+func (g Goose) AuthSpec() launch.AuthSpec {
+	return launch.AuthSpec{
+		EnvBindings: []launch.EnvBinding{{
+			VaultPath: gooseVaultPath,
+			Required:  false,
+			Render:    gooseRender,
+		}},
+	}
+}

--- a/internal/launch/agents/goose_auth.go
+++ b/internal/launch/agents/goose_auth.go
@@ -1,0 +1,50 @@
+package agents
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// gooseVaultPath is the canonical vault namespace for Goose's
+// credential per ADR-0025's `agents/<name>/oauth` scheme. The third
+// segment is the literal `oauth` the daemon endpoint requires even
+// though Goose authenticates with a provider API key, not OAuth —
+// vaultPathConforms rejects any other shape (internal/launch/authspec.go).
+const gooseVaultPath = "agents/goose/oauth"
+
+// gooseAPIKeyEnv is the environment variable the in-container Goose
+// reads its LLM-provider credential from. Goose resolves provider
+// keys from `<PROVIDER>_API_KEY` env vars (or its keyring) rather
+// than a standalone on-disk credential file, so the natural vault
+// binding is an EnvBinding: a static API key rendered into the env.
+//
+// We bind ANTHROPIC_API_KEY because Goose's default provider in the
+// Aileron launch path is Anthropic. An operator running Goose against
+// a different provider seeds the matching key under the same vault
+// path and the in-container Goose still picks it up — the env var name
+// is the only provider-specific coupling, and it is documented here so
+// a future multi-provider binding has one place to change.
+const gooseAPIKeyEnv = "ANTHROPIC_API_KEY"
+
+// errGooseSecretEmpty is returned by gooseRender when the resolved
+// vault entry has no usable key. The launcher surfaces this to stderr
+// with the recovery hint per R13.
+var errGooseSecretEmpty = errors.New("goose: vault entry has empty API key")
+
+// gooseRender maps the vault secret to Goose's provider-API-key env
+// var. Goose's credential is a single opaque API key, so the vault
+// Value is the raw key bytes (no JSON envelope). We trim surrounding
+// whitespace (a key copied from another machine can carry a trailing
+// newline) and reject an empty value with a recovery hint, mirroring
+// claudeRender's empty-Value guard.
+func gooseRender(s vault.Secret) (map[string]string, error) {
+	key := strings.TrimSpace(string(s.Value))
+	if key == "" {
+		return nil, fmt.Errorf("%w (re-login or `aileron vault put %s` with the provider API key)",
+			errGooseSecretEmpty, gooseVaultPath)
+	}
+	return map[string]string{gooseAPIKeyEnv: key}, nil
+}

--- a/internal/launch/agents/goose_auth_test.go
+++ b/internal/launch/agents/goose_auth_test.go
@@ -1,0 +1,89 @@
+package agents_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// Goose AuthSpec contract (#982):
+//
+//   - AuthSpec ships one EnvBinding (provider API key) and no
+//     FileBindings or StaticFiles. Goose authenticates with a static
+//     provider API key, so there is nothing to Capture or refresh.
+//   - VaultPath is the canonical agents/goose/oauth.
+//   - Render maps a non-empty key to the provider env var, trimming
+//     surrounding whitespace.
+//   - Render rejects an empty/whitespace-only Value.
+
+func TestGoose_AuthSpec_Shape(t *testing.T) {
+	spec := agents.Goose{}.AuthSpec()
+	if len(spec.EnvBindings) != 1 {
+		t.Fatalf("EnvBindings = %d, want 1", len(spec.EnvBindings))
+	}
+	if len(spec.FileBindings) != 0 {
+		t.Errorf("FileBindings = %d, want 0 (env-key agent has no file)", len(spec.FileBindings))
+	}
+	if len(spec.StaticFiles) != 0 {
+		t.Errorf("StaticFiles = %d, want 0", len(spec.StaticFiles))
+	}
+
+	eb := spec.EnvBindings[0]
+	if eb.VaultPath != "agents/goose/oauth" {
+		t.Errorf("VaultPath = %q, want agents/goose/oauth", eb.VaultPath)
+	}
+	if eb.Required {
+		t.Errorf("Required = true; empty vault must fall through to Goose's own key resolution")
+	}
+	if eb.Render == nil {
+		t.Fatal("Render must be set")
+	}
+}
+
+func TestGoose_Render_MapsKeyToProviderEnv(t *testing.T) {
+	spec := agents.Goose{}.AuthSpec()
+	got, err := spec.EnvBindings[0].Render(vault.Secret{Value: []byte("sk-ant-test")})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if got["ANTHROPIC_API_KEY"] != "sk-ant-test" {
+		t.Errorf("Render = %v, want ANTHROPIC_API_KEY=sk-ant-test", got)
+	}
+	if len(got) != 1 {
+		t.Errorf("Render produced %d env vars, want 1", len(got))
+	}
+}
+
+func TestGoose_Render_TrimsWhitespace(t *testing.T) {
+	// A key copied from another machine can carry a trailing newline;
+	// Goose would reject the key with the newline embedded.
+	spec := agents.Goose{}.AuthSpec()
+	got, err := spec.EnvBindings[0].Render(vault.Secret{Value: []byte("  sk-ant-test\n")})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if got["ANTHROPIC_API_KEY"] != "sk-ant-test" {
+		t.Errorf("Render = %q, want trimmed sk-ant-test", got["ANTHROPIC_API_KEY"])
+	}
+}
+
+func TestGoose_Render_RejectsEmptyValue(t *testing.T) {
+	spec := agents.Goose{}.AuthSpec()
+	_, err := spec.EnvBindings[0].Render(vault.Secret{Value: nil})
+	if err == nil {
+		t.Fatal("expected error for empty Value")
+	}
+	if !strings.Contains(err.Error(), "empty API key") {
+		t.Errorf("err = %v, want mention of empty API key", err)
+	}
+}
+
+func TestGoose_Render_RejectsWhitespaceOnlyValue(t *testing.T) {
+	spec := agents.Goose{}.AuthSpec()
+	_, err := spec.EnvBindings[0].Render(vault.Secret{Value: []byte("   \n\t")})
+	if err == nil {
+		t.Fatal("expected error for whitespace-only Value")
+	}
+}

--- a/internal/launch/agents/opencode.go
+++ b/internal/launch/agents/opencode.go
@@ -83,7 +83,25 @@ func (o OpenCode) ConfigureMCP(mcpBin string, mcpEnv map[string]string, dir stri
 }
 
 // AuthSpec returns OpenCode's vault-backed credential descriptor.
-// OpenCode has no per-agent vault binding today, so it returns the
-// zero value; the launcher treats that as a no-op. A future v1.x
-// issue would fill this in for OpenCode sandbox launches.
-func (o OpenCode) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
+// OpenCode persists its provider credentials in a standalone
+// `auth.json` under the XDG data dir, written by `opencode auth login`
+// and loaded on startup. That is a rotatable on-disk credential file,
+// so the binding is a FileBinding with byte-identity Render/Capture.
+// Required is false so an unseeded vault falls through to OpenCode's
+// in-container `auth login` bootstrap, which Capture then snapshots on
+// clean exit. MountAsFile is false (the default): OpenCode's
+// ConfigureMCP writes a project-local `opencode.json` in the workspace
+// mount, not under the data dir, so no sibling mount needs to coexist
+// with auth.json.
+func (o OpenCode) AuthSpec() launch.AuthSpec {
+	return launch.AuthSpec{
+		FileBindings: []launch.FileBinding{{
+			VaultPath:     opencodeVaultPath,
+			ContainerPath: opencodeAuthContainerPath,
+			Mode:          0o600,
+			Required:      false,
+			Render:        opencodeRender,
+			Capture:       opencodeCapture,
+		}},
+	}
+}

--- a/internal/launch/agents/opencode_auth.go
+++ b/internal/launch/agents/opencode_auth.go
@@ -1,0 +1,82 @@
+package agents
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// opencodeAuthContainerPath is where the in-container OpenCode CLI
+// reads its provider credentials. OpenCode writes this file via
+// `opencode auth login` and loads it on startup; it lives under the
+// XDG data dir, not the config dir. ADR-0025.
+const opencodeAuthContainerPath = "/home/agent/.local/share/opencode/auth.json"
+
+// opencodeVaultPath is the canonical vault namespace for OpenCode's
+// credential per ADR-0025's `agents/<name>/oauth` scheme. The third
+// segment is the literal `oauth` the daemon endpoint requires even
+// when the stored providers are API keys rather than OAuth tokens —
+// vaultPathConforms rejects any other shape.
+const opencodeVaultPath = "agents/opencode/oauth"
+
+// errOpencodeEnvelopeMalformed is the sentinel returned when the
+// in-container auth.json does not parse as the documented envelope.
+// The launcher surfaces this to stderr with the file path and the
+// recovery options per R13.
+var errOpencodeEnvelopeMalformed = errors.New("opencode: auth envelope is malformed")
+
+// opencodeRender writes the vault's stored bytes into the in-container
+// auth.json verbatim. OpenCode's auth.json is a JSON object keyed by
+// provider name, each value carrying that provider's credential (an
+// API key or an OAuth bundle). We validate the envelope on the way
+// through so a vault holding non-OpenCode bytes (operator wrote the
+// wrong file) fails the launch with a clear error before the container
+// starts, mirroring claudeRender.
+func opencodeRender(s vault.Secret) ([]byte, error) {
+	if len(s.Value) == 0 {
+		return nil, fmt.Errorf("%w: vault entry has empty Value (re-login or `aileron vault put %s` with a real envelope)",
+			errOpencodeEnvelopeMalformed, opencodeVaultPath)
+	}
+	if err := validateOpencodeEnvelope(s.Value); err != nil {
+		return nil, err
+	}
+	// Byte-identity write: OpenCode reads the file directly and the
+	// round-trip property is the load-bearing contract for in-container
+	// rotation. Returning the bytes untouched makes that obvious.
+	return s.Value, nil
+}
+
+// opencodeCapture validates the post-run file bytes against the
+// envelope schema and produces a vault Secret. Bytes are byte-identity
+// over the in-container file so any provider OpenCode adds round-trips
+// cleanly. A partial-write or schema-drift session is skipped (error
+// returned) rather than overwriting the vault entry.
+func opencodeCapture(b []byte) (vault.Secret, error) {
+	if err := validateOpencodeEnvelope(b); err != nil {
+		return vault.Secret{}, err
+	}
+	return vault.Secret{
+		Value:    b,
+		Metadata: vault.Metadata{Type: "oauth_refresh_token"},
+	}, nil
+}
+
+// validateOpencodeEnvelope checks the bytes parse as a non-empty JSON
+// object. OpenCode's auth.json maps provider name to that provider's
+// credential entry; an empty object carries no usable credential and a
+// non-object (array, scalar) is not the documented shape. We tolerate
+// any provider keys and any per-provider sub-shape so a `brew upgrade
+// opencode` that adds a new provider or credential field does not break
+// the launch.
+func validateOpencodeEnvelope(b []byte) error {
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal(b, &env); err != nil {
+		return fmt.Errorf("%w: parse: %v", errOpencodeEnvelopeMalformed, err)
+	}
+	if len(env) == 0 {
+		return fmt.Errorf("%w: no provider entries", errOpencodeEnvelopeMalformed)
+	}
+	return nil
+}

--- a/internal/launch/agents/opencode_auth_test.go
+++ b/internal/launch/agents/opencode_auth_test.go
@@ -1,0 +1,146 @@
+package agents_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// OpenCode AuthSpec contract (#982):
+//
+//   - AuthSpec ships one FileBinding (auth.json) and no EnvBindings or
+//     StaticFiles.
+//   - VaultPath is the canonical agents/opencode/oauth; ContainerPath
+//     is the XDG data-dir auth.json; Mode 0600; not Required;
+//     MountAsFile false.
+//   - Render is byte-identity over a valid envelope and rejects an
+//     empty Value.
+//   - Capture is byte-identity, stamps Metadata.Type, and rejects a
+//     malformed envelope.
+
+func TestOpenCode_AuthSpec_Shape(t *testing.T) {
+	spec := agents.OpenCode{}.AuthSpec()
+	if len(spec.FileBindings) != 1 {
+		t.Fatalf("FileBindings = %d, want 1", len(spec.FileBindings))
+	}
+	if len(spec.EnvBindings) != 0 {
+		t.Errorf("EnvBindings = %d, want 0", len(spec.EnvBindings))
+	}
+	if len(spec.StaticFiles) != 0 {
+		t.Errorf("StaticFiles = %d, want 0", len(spec.StaticFiles))
+	}
+
+	fb := spec.FileBindings[0]
+	if fb.VaultPath != "agents/opencode/oauth" {
+		t.Errorf("VaultPath = %q, want agents/opencode/oauth", fb.VaultPath)
+	}
+	if fb.ContainerPath != "/home/agent/.local/share/opencode/auth.json" {
+		t.Errorf("ContainerPath = %q, want /home/agent/.local/share/opencode/auth.json", fb.ContainerPath)
+	}
+	if fb.Mode != 0o600 {
+		t.Errorf("Mode = %v, want 0600", fb.Mode)
+	}
+	if fb.Required {
+		t.Errorf("Required = true; empty vault must trigger in-container login fallthrough")
+	}
+	if fb.MountAsFile {
+		t.Errorf("MountAsFile = true; OpenCode has no sibling mount to coexist with")
+	}
+	if fb.Render == nil {
+		t.Error("Render must be set")
+	}
+	if fb.Capture == nil {
+		t.Error("Capture must be set")
+	}
+	if fb.PreLaunchRefresh != nil {
+		t.Error("PreLaunchRefresh must be nil; OpenCode has no refresh hook")
+	}
+}
+
+func TestOpenCode_Render_ByteIdentityOnValidEnvelope(t *testing.T) {
+	envelope := []byte(`{"anthropic":{"type":"api","key":"sk-ant-x"}}`)
+	spec := agents.OpenCode{}.AuthSpec()
+	got, err := spec.FileBindings[0].Render(vault.Secret{Value: envelope})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !bytes.Equal(got, envelope) {
+		t.Errorf("Render bytes = %q, want byte-identity %q", got, envelope)
+	}
+}
+
+func TestOpenCode_Render_RejectsEmptyValue(t *testing.T) {
+	spec := agents.OpenCode{}.AuthSpec()
+	_, err := spec.FileBindings[0].Render(vault.Secret{Value: nil})
+	if err == nil {
+		t.Fatal("expected error for empty Value")
+	}
+	if !strings.Contains(err.Error(), "empty Value") {
+		t.Errorf("err = %v, want mention of empty Value", err)
+	}
+}
+
+func TestOpenCode_Render_RejectsMalformedEnvelope(t *testing.T) {
+	spec := agents.OpenCode{}.AuthSpec()
+	_, err := spec.FileBindings[0].Render(vault.Secret{Value: []byte("not-json")})
+	if err == nil {
+		t.Fatal("expected error for malformed envelope")
+	}
+}
+
+func TestOpenCode_Render_RejectsEmptyObject(t *testing.T) {
+	// An empty object parses as JSON but carries no provider credential.
+	spec := agents.OpenCode{}.AuthSpec()
+	_, err := spec.FileBindings[0].Render(vault.Secret{Value: []byte("{}")})
+	if err == nil {
+		t.Fatal("expected error for empty object (no provider entries)")
+	}
+	if !strings.Contains(err.Error(), "no provider entries") {
+		t.Errorf("err = %v, want mention of no provider entries", err)
+	}
+}
+
+func TestOpenCode_Capture_RoundTripStampsOAuthRefreshToken(t *testing.T) {
+	envelope := []byte(`{"openai":{"type":"api","key":"sk-x"}}`)
+	spec := agents.OpenCode{}.AuthSpec()
+	got, err := spec.FileBindings[0].Capture(envelope)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if !bytes.Equal(got.Value, envelope) {
+		t.Errorf("Capture Value = %q, want byte-identity %q", got.Value, envelope)
+	}
+	if got.Metadata.Type != "oauth_refresh_token" {
+		t.Errorf("Metadata.Type = %q, want oauth_refresh_token", got.Metadata.Type)
+	}
+}
+
+func TestOpenCode_Capture_RejectsMalformedEnvelope(t *testing.T) {
+	spec := agents.OpenCode{}.AuthSpec()
+	_, err := spec.FileBindings[0].Capture([]byte("garbage bytes"))
+	if err == nil {
+		t.Fatal("expected error for non-JSON envelope")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("err = %v, want mention of parse failure", err)
+	}
+}
+
+func TestOpenCode_AuthSpec_RoundTrip(t *testing.T) {
+	envelope := []byte(`{"anthropic":{"type":"oauth","refresh":"r","access":"a"}}`)
+	spec := agents.OpenCode{}.AuthSpec()
+	rendered, err := spec.FileBindings[0].Render(vault.Secret{Value: envelope})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	captured, err := spec.FileBindings[0].Capture(rendered)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if !bytes.Equal(captured.Value, envelope) {
+		t.Errorf("round-trip drift: got %q want %q", captured.Value, envelope)
+	}
+}

--- a/internal/launch/agents/pi.go
+++ b/internal/launch/agents/pi.go
@@ -46,8 +46,25 @@ func (p Pi) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string, _ la
 	return []string{"--mcp-config", mcpConfig}, nil, nil
 }
 
-// AuthSpec returns Pi's vault-backed credential descriptor. Pi has
-// no per-agent vault binding today, so it returns the zero value;
-// the launcher treats that as a no-op. A future v1.x issue would
-// fill this in for Pi sandbox launches.
-func (p Pi) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
+// AuthSpec returns Pi's vault-backed credential descriptor. Pi keeps
+// its provider credentials in a dedicated `auth.json` under
+// `~/.pi/agent/`, written by `/login` and loaded on startup. That is a
+// rotatable on-disk credential file (separate from settings.json), so
+// the binding is a FileBinding with byte-identity Render/Capture.
+// Required is false so an unseeded vault falls through to Pi's
+// in-container `/login` bootstrap, which Capture then snapshots on
+// clean exit. MountAsFile is false (the default): Pi's ConfigureMCP
+// passes MCP config via a CLI flag, not a file mount, so no sibling
+// mount needs to coexist with auth.json.
+func (p Pi) AuthSpec() launch.AuthSpec {
+	return launch.AuthSpec{
+		FileBindings: []launch.FileBinding{{
+			VaultPath:     piVaultPath,
+			ContainerPath: piAuthContainerPath,
+			Mode:          0o600,
+			Required:      false,
+			Render:        piRender,
+			Capture:       piCapture,
+		}},
+	}
+}

--- a/internal/launch/agents/pi_auth.go
+++ b/internal/launch/agents/pi_auth.go
@@ -1,0 +1,82 @@
+package agents
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// piAuthContainerPath is where the in-container Pi CLI reads its
+// provider credentials. Pi keeps its credential entries in a dedicated
+// `auth.json` under `~/.pi/agent/`, separate from `settings.json`
+// (which holds non-credential state). Binding the dedicated auth.json
+// — not settings.json — avoids snapshotting non-credential session
+// state into the vault. ADR-0025.
+const piAuthContainerPath = "/home/agent/.pi/agent/auth.json"
+
+// piVaultPath is the canonical vault namespace for Pi's credential per
+// ADR-0025's `agents/<name>/oauth` scheme. The third segment is the
+// literal `oauth` the daemon endpoint requires even when the stored
+// providers are API keys rather than OAuth bundles — vaultPathConforms
+// rejects any other shape.
+const piVaultPath = "agents/pi/oauth"
+
+// errPiEnvelopeMalformed is the sentinel returned when the in-container
+// auth.json does not parse as the documented envelope. The launcher
+// surfaces this to stderr with the file path and recovery options per
+// R13.
+var errPiEnvelopeMalformed = errors.New("pi: auth envelope is malformed")
+
+// piRender writes the vault's stored bytes into the in-container
+// auth.json verbatim. Pi's auth.json is a JSON object keyed by provider
+// name, each value an entry like {"type":"api_key","key":"..."} (OAuth
+// credentials land here too after `/login`). We validate the envelope
+// on the way through so a vault holding non-Pi bytes (operator wrote
+// the wrong file) fails the launch with a clear error before the
+// container starts, mirroring claudeRender.
+func piRender(s vault.Secret) ([]byte, error) {
+	if len(s.Value) == 0 {
+		return nil, fmt.Errorf("%w: vault entry has empty Value (re-login or `aileron vault put %s` with a real envelope)",
+			errPiEnvelopeMalformed, piVaultPath)
+	}
+	if err := validatePiEnvelope(s.Value); err != nil {
+		return nil, err
+	}
+	// Byte-identity write: Pi reads the file directly; round-trip
+	// identity is the load-bearing contract for in-container rotation.
+	return s.Value, nil
+}
+
+// piCapture validates the post-run file bytes against the envelope
+// schema and produces a vault Secret. Bytes are byte-identity over the
+// in-container file so any provider or credential field Pi adds
+// round-trips cleanly. A partial-write or schema-drift session is
+// skipped (error returned) rather than overwriting the vault entry.
+func piCapture(b []byte) (vault.Secret, error) {
+	if err := validatePiEnvelope(b); err != nil {
+		return vault.Secret{}, err
+	}
+	return vault.Secret{
+		Value:    b,
+		Metadata: vault.Metadata{Type: "oauth_refresh_token"},
+	}, nil
+}
+
+// validatePiEnvelope checks the bytes parse as a non-empty JSON object.
+// Pi's auth.json maps provider name to a credential entry; an empty
+// object carries no usable credential and a non-object is not the
+// documented shape. We tolerate any provider keys and any per-provider
+// sub-shape so a Pi upgrade that adds providers or fields does not
+// break the launch.
+func validatePiEnvelope(b []byte) error {
+	var env map[string]json.RawMessage
+	if err := json.Unmarshal(b, &env); err != nil {
+		return fmt.Errorf("%w: parse: %v", errPiEnvelopeMalformed, err)
+	}
+	if len(env) == 0 {
+		return fmt.Errorf("%w: no provider entries", errPiEnvelopeMalformed)
+	}
+	return nil
+}

--- a/internal/launch/agents/pi_auth_test.go
+++ b/internal/launch/agents/pi_auth_test.go
@@ -1,0 +1,145 @@
+package agents_test
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// Pi AuthSpec contract (#982):
+//
+//   - AuthSpec ships one FileBinding (auth.json) and no EnvBindings or
+//     StaticFiles.
+//   - VaultPath is the canonical agents/pi/oauth; ContainerPath is the
+//     dedicated ~/.pi/agent/auth.json; Mode 0600; not Required;
+//     MountAsFile false.
+//   - Render is byte-identity over a valid envelope and rejects an
+//     empty Value.
+//   - Capture is byte-identity, stamps Metadata.Type, and rejects a
+//     malformed envelope.
+
+func TestPi_AuthSpec_Shape(t *testing.T) {
+	spec := agents.Pi{}.AuthSpec()
+	if len(spec.FileBindings) != 1 {
+		t.Fatalf("FileBindings = %d, want 1", len(spec.FileBindings))
+	}
+	if len(spec.EnvBindings) != 0 {
+		t.Errorf("EnvBindings = %d, want 0", len(spec.EnvBindings))
+	}
+	if len(spec.StaticFiles) != 0 {
+		t.Errorf("StaticFiles = %d, want 0", len(spec.StaticFiles))
+	}
+
+	fb := spec.FileBindings[0]
+	if fb.VaultPath != "agents/pi/oauth" {
+		t.Errorf("VaultPath = %q, want agents/pi/oauth", fb.VaultPath)
+	}
+	if fb.ContainerPath != "/home/agent/.pi/agent/auth.json" {
+		t.Errorf("ContainerPath = %q, want /home/agent/.pi/agent/auth.json", fb.ContainerPath)
+	}
+	if fb.Mode != 0o600 {
+		t.Errorf("Mode = %v, want 0600", fb.Mode)
+	}
+	if fb.Required {
+		t.Errorf("Required = true; empty vault must trigger in-container login fallthrough")
+	}
+	if fb.MountAsFile {
+		t.Errorf("MountAsFile = true; Pi passes MCP config via a flag, no sibling mount")
+	}
+	if fb.Render == nil {
+		t.Error("Render must be set")
+	}
+	if fb.Capture == nil {
+		t.Error("Capture must be set")
+	}
+	if fb.PreLaunchRefresh != nil {
+		t.Error("PreLaunchRefresh must be nil; Pi has no launcher refresh hook")
+	}
+}
+
+func TestPi_Render_ByteIdentityOnValidEnvelope(t *testing.T) {
+	envelope := []byte(`{"anthropic":{"type":"api_key","key":"sk-ant-x"}}`)
+	spec := agents.Pi{}.AuthSpec()
+	got, err := spec.FileBindings[0].Render(vault.Secret{Value: envelope})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	if !bytes.Equal(got, envelope) {
+		t.Errorf("Render bytes = %q, want byte-identity %q", got, envelope)
+	}
+}
+
+func TestPi_Render_RejectsEmptyValue(t *testing.T) {
+	spec := agents.Pi{}.AuthSpec()
+	_, err := spec.FileBindings[0].Render(vault.Secret{Value: nil})
+	if err == nil {
+		t.Fatal("expected error for empty Value")
+	}
+	if !strings.Contains(err.Error(), "empty Value") {
+		t.Errorf("err = %v, want mention of empty Value", err)
+	}
+}
+
+func TestPi_Render_RejectsMalformedEnvelope(t *testing.T) {
+	spec := agents.Pi{}.AuthSpec()
+	_, err := spec.FileBindings[0].Render(vault.Secret{Value: []byte("not-json")})
+	if err == nil {
+		t.Fatal("expected error for malformed envelope")
+	}
+}
+
+func TestPi_Render_RejectsEmptyObject(t *testing.T) {
+	spec := agents.Pi{}.AuthSpec()
+	_, err := spec.FileBindings[0].Render(vault.Secret{Value: []byte("{}")})
+	if err == nil {
+		t.Fatal("expected error for empty object (no provider entries)")
+	}
+	if !strings.Contains(err.Error(), "no provider entries") {
+		t.Errorf("err = %v, want mention of no provider entries", err)
+	}
+}
+
+func TestPi_Capture_RoundTripStampsOAuthRefreshToken(t *testing.T) {
+	envelope := []byte(`{"openai":{"type":"api_key","key":"sk-x"}}`)
+	spec := agents.Pi{}.AuthSpec()
+	got, err := spec.FileBindings[0].Capture(envelope)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if !bytes.Equal(got.Value, envelope) {
+		t.Errorf("Capture Value = %q, want byte-identity %q", got.Value, envelope)
+	}
+	if got.Metadata.Type != "oauth_refresh_token" {
+		t.Errorf("Metadata.Type = %q, want oauth_refresh_token", got.Metadata.Type)
+	}
+}
+
+func TestPi_Capture_RejectsMalformedEnvelope(t *testing.T) {
+	spec := agents.Pi{}.AuthSpec()
+	_, err := spec.FileBindings[0].Capture([]byte("garbage bytes"))
+	if err == nil {
+		t.Fatal("expected error for non-JSON envelope")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Errorf("err = %v, want mention of parse failure", err)
+	}
+}
+
+func TestPi_AuthSpec_RoundTrip(t *testing.T) {
+	envelope := []byte(`{"anthropic":{"type":"api_key","key":"k"},"openai":{"type":"api_key","key":"o"}}`)
+	spec := agents.Pi{}.AuthSpec()
+	rendered, err := spec.FileBindings[0].Render(vault.Secret{Value: envelope})
+	if err != nil {
+		t.Fatalf("Render: %v", err)
+	}
+	captured, err := spec.FileBindings[0].Capture(rendered)
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if !bytes.Equal(captured.Value, envelope) {
+		t.Errorf("round-trip drift: got %q want %q", captured.Value, envelope)
+	}
+}

--- a/internal/launch/authspec_test.go
+++ b/internal/launch/authspec_test.go
@@ -10,9 +10,9 @@ import (
 
 // TestAuthSpec_ZeroValueIsValid pins the no-op-agent contract: the
 // zero-value AuthSpec is a legal return from Agent.AuthSpec() and
-// must not panic on field access. Goose, Pi, and OpenCode all ship
-// with this shape in v1, so the contract is load-bearing for the
-// launcher's default code path.
+// must not panic on field access. An agent with no bindable
+// credential ships this shape, so the contract is load-bearing for
+// the launcher's default code path.
 func TestAuthSpec_ZeroValueIsValid(t *testing.T) {
 	spec := AuthSpec{}
 	if len(spec.EnvBindings) != 0 {


### PR DESCRIPTION
## Summary

Replaces the zero-value `launch.AuthSpec{}` returned by `Goose.AuthSpec()`, `OpenCode.AuthSpec()`, and `Pi.AuthSpec()` with vault-backed credential descriptors, so `aileron launch <agent> --sandbox=docker` renders stored credentials into the container instead of prompting for login every run. Mirrors the Claude/Codex bindings shipped in #979. Single PR for all three agents (operator override of the issue's one-PR-per-agent AC).

Per-agent binding shape was chosen from the agent's actual on-disk auth model:

- **Goose** — `EnvBinding`. Goose authenticates with a provider API key resolved from `<PROVIDER>_API_KEY` (or its keyring), not a rotatable credential file. The stored key renders into `ANTHROPIC_API_KEY` (Goose's default provider under launch). No `Capture` (nothing to snapshot) and no `PreLaunchRefresh` (a static key does not rotate).
- **OpenCode** — `FileBinding` over `~/.local/share/opencode/auth.json` (written by `opencode auth login`, loaded on startup). Byte-identity `Render`/`Capture`.
- **Pi** — `FileBinding` over the dedicated `~/.pi/agent/auth.json` (separate from `settings.json`, so no non-credential state is captured). Byte-identity `Render`/`Capture`.

All three use the canonical `agents/<name>/oauth` vault path required by `vaultPathConforms`. No spec/API surface change; no edits to `authspec.go`/`authspec_runtime.go` or Claude/Codex auth files. Dev doc `sandbox-agent-auth.md` updated with the new vault-path table rows, binding-shape explanation, and first-launch flows.

## Test plan

- [x] `go test ./internal/launch/... -cover` green (launch 87.3%, agents 90.2%; new auth functions 100%).
- [x] Per-agent `*_auth_test.go`: shape assertion (binding count/type, vault path, container path, mode, MountAsFile, nil refresh hook), Render valid/empty/malformed, and for the FileBinding agents Capture round-trip byte-identity + `Metadata.Type` stamp + malformed rejection.
- [x] `go vet ./internal/launch/...` clean; `cmd/aileron` builds (agents are registered there).
- [x] CodeRabbit review: no findings.

Resolves #982

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented vault-backed credential binding for Goose (environment variable), OpenCode and Pi (file-based), enabling secure credential storage and retrieval with fallback to native authentication methods.

* **Documentation**
  * Expanded agent credential documentation with complete per-agent vault path configurations, binding types, and in-container login/seeding workflows.

* **Tests**
  * Added comprehensive test coverage validating agent authentication specs, credential rendering, capture operations, and round-trip envelope handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->