### PR TITLE
feat(daemon): audit + session-log per-agent vault credential verbs

### DIFF
--- a/internal/app/handlers_local_vault_secrets.go
+++ b/internal/app/handlers_local_vault_secrets.go
@@ -1,13 +1,88 @@
 package app
 
 import (
+	"context"
 	"errors"
 	"net/http"
 	"strings"
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
+	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
+
+// vaultCredentialSessionHeader is the optional request header the
+// launcher may set to attribute a per-agent credential operation to a
+// specific launch session. When absent the requester is resolved to the
+// loopback service actor. This stays consistent with the
+// `X-Aileron-Session-Id` convention used by the connector-operations and
+// sandbox-proxy handlers, and requires no OpenAPI/wire-shape change.
+const vaultCredentialSessionHeader = "X-Aileron-Session-Id"
+
+// vaultCredentialLoopbackActorID is the actor ID used when no session
+// header is present. ADR-0011 per-agent credential verbs are reachable
+// only over the daemon loopback, so an unattributed request is recorded
+// as a loopback service actor rather than minting a new ActorType.
+const vaultCredentialLoopbackActorID = "loopback"
+
+// vaultCredentialActor resolves the requester for a per-agent
+// credential operation. When the optional session header is present it
+// attributes the operation to that launch session; otherwise it falls
+// back to the loopback service actor. The returned sessionID is empty
+// unless the header supplied one, so callers can decide whether to
+// stamp `aileron.session.id` into the payload.
+func vaultCredentialActor(r *http.Request) (actor model.ActorRef, sessionID string) {
+	if r != nil {
+		sessionID = strings.TrimSpace(r.Header.Get(vaultCredentialSessionHeader))
+	}
+	if sessionID != "" {
+		return model.ActorRef{Type: model.ActorTypeService, ID: sessionID}, sessionID
+	}
+	return model.ActorRef{Type: model.ActorTypeService, ID: vaultCredentialLoopbackActorID}, ""
+}
+
+// emitVaultCredentialEvent records an audit event and a session-log line
+// for a per-agent credential verb (ADR-0010 + ADR-0011). errClass is
+// empty on the success path and carries the handler's error code (e.g.
+// `vault_locked`, `vault_not_found`) on failure. The credential bytes
+// are never passed to this function, so they cannot reach the payload or
+// the log line. The audit call is a no-op when no recorder is wired, but
+// the slog line always fires so a nil-recorder daemon still leaves a
+// session-log signal.
+func (s *apiServer) emitVaultCredentialEvent(ctx context.Context, eventType model.EventType, name string, actor model.ActorRef, sessionID, errClass string) {
+	logArgs := []any{
+		"event", string(eventType),
+		"agent", name,
+		"actor", actor.ID,
+	}
+	if sessionID != "" {
+		logArgs = append(logArgs, "session", sessionID)
+	}
+	if errClass != "" {
+		logArgs = append(logArgs, "error_class", errClass)
+	}
+	if s.log != nil {
+		if errClass != "" {
+			s.log.Info("vault agent credential operation failed", logArgs...)
+		} else {
+			s.log.Info("vault agent credential operation", logArgs...)
+		}
+	}
+
+	if s.auditRecorder == nil {
+		return
+	}
+	payload := map[string]any{
+		"aileron.vault.agent": name,
+	}
+	if sessionID != "" {
+		payload["aileron.session.id"] = sessionID
+	}
+	if errClass != "" {
+		payload["aileron.failure.class"] = errClass
+	}
+	s.auditRecorder.RecordSuccess(ctx, eventType, actor, payload)
+}
 
 // agentCredentialVaultPath is the canonical vault path scheme for
 // per-agent OAuth/credential envelopes. The HTTP path uses the
@@ -49,32 +124,40 @@ func agentNameFromVaultPath(path string) (string, bool) {
 // future status-code change would not silently re-route the
 // fallthrough-to-in-container-login path documented in ADR-0025.
 func (s *apiServer) GetAgentCredentials(w http.ResponseWriter, r *http.Request, name string) {
+	ctx := r.Context()
+	actor, sessionID := vaultCredentialActor(r)
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "invalid_request", "agent name is required")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialRead, name, actor, sessionID, "invalid_request")
 		return
 	}
 	if s.vault == nil {
 		writeError(w, http.StatusServiceUnavailable, "no_local_vault",
 			"daemon is not configured with a vault")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialRead, name, actor, sessionID, "no_local_vault")
 		return
 	}
 
-	secret, err := s.vault.Get(r.Context(), agentCredentialVaultPath(name))
+	secret, err := s.vault.Get(ctx, agentCredentialVaultPath(name))
 	if vault.IsNotFound(err) {
 		writeError(w, http.StatusNotFound, "vault_not_found",
 			"no credential entry for agent "+name)
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialRead, name, actor, sessionID, "vault_not_found")
 		return
 	}
 	if errors.Is(err, vault.ErrCredentialUnavailable) {
 		writeError(w, http.StatusLocked, "vault_locked",
 			"unlock the vault before reading agent credentials")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialRead, name, actor, sessionID, "vault_locked")
 		return
 	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "vault_get_failed", err.Error())
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialRead, name, actor, sessionID, "vault_get_failed")
 		return
 	}
 
+	s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialRead, name, actor, sessionID, "")
 	writeJSON(w, http.StatusOK, agentCredentialsResponse(secret))
 }
 
@@ -84,39 +167,48 @@ func (s *apiServer) GetAgentCredentials(w http.ResponseWriter, r *http.Request, 
 // token against the vendor's auth server and persists the new
 // bundle before starting the container per AE6).
 func (s *apiServer) PutAgentCredentials(w http.ResponseWriter, r *http.Request, name string) {
+	ctx := r.Context()
+	actor, sessionID := vaultCredentialActor(r)
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "invalid_request", "agent name is required")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialWrite, name, actor, sessionID, "invalid_request")
 		return
 	}
 	if s.vault == nil {
 		writeError(w, http.StatusServiceUnavailable, "no_local_vault",
 			"daemon is not configured with a vault")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialWrite, name, actor, sessionID, "no_local_vault")
 		return
 	}
 
 	var req api.AgentCredentials
 	if err := decodeBody(r, &req); err != nil {
 		writeError(w, http.StatusBadRequest, "invalid_request", err.Error())
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialWrite, name, actor, sessionID, "invalid_request")
 		return
 	}
 	if len(req.Value) == 0 {
 		writeError(w, http.StatusBadRequest, "invalid_request",
 			"value is required and must be non-empty")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialWrite, name, actor, sessionID, "invalid_request")
 		return
 	}
 
 	meta := agentCredentialsMetadataFromRequest(req.Metadata)
-	err := s.vault.Put(r.Context(), agentCredentialVaultPath(name), req.Value, meta)
+	err := s.vault.Put(ctx, agentCredentialVaultPath(name), req.Value, meta)
 	if errors.Is(err, vault.ErrCredentialUnavailable) {
 		writeError(w, http.StatusLocked, "vault_locked",
 			"unlock the vault before writing agent credentials")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialWrite, name, actor, sessionID, "vault_locked")
 		return
 	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "vault_put_failed", err.Error())
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialWrite, name, actor, sessionID, "vault_put_failed")
 		return
 	}
 
+	s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialWrite, name, actor, sessionID, "")
 	w.WriteHeader(http.StatusNoContent)
 }
 
@@ -132,43 +224,53 @@ func (s *apiServer) PutAgentCredentials(w http.ResponseWriter, r *http.Request, 
 // existing store primitive. A locked vault makes Get return
 // ErrCredentialUnavailable, which yields 423 before any delete.
 func (s *apiServer) DeleteAgentCredentials(w http.ResponseWriter, r *http.Request, name string) {
+	ctx := r.Context()
+	actor, sessionID := vaultCredentialActor(r)
 	if name == "" {
 		writeError(w, http.StatusBadRequest, "invalid_request", "agent name is required")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialDelete, name, actor, sessionID, "invalid_request")
 		return
 	}
 	if s.vault == nil {
 		writeError(w, http.StatusServiceUnavailable, "no_local_vault",
 			"daemon is not configured with a vault")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialDelete, name, actor, sessionID, "no_local_vault")
 		return
 	}
 
 	path := agentCredentialVaultPath(name)
-	_, err := s.vault.Get(r.Context(), path)
+	_, err := s.vault.Get(ctx, path)
 	if vault.IsNotFound(err) {
 		writeError(w, http.StatusNotFound, "vault_not_found",
 			"no credential entry for agent "+name)
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialDelete, name, actor, sessionID, "vault_not_found")
 		return
 	}
 	if errors.Is(err, vault.ErrCredentialUnavailable) {
 		writeError(w, http.StatusLocked, "vault_locked",
 			"unlock the vault before deleting agent credentials")
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialDelete, name, actor, sessionID, "vault_locked")
 		return
 	}
 	if err != nil {
 		writeError(w, http.StatusInternalServerError, "vault_get_failed", err.Error())
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialDelete, name, actor, sessionID, "vault_get_failed")
 		return
 	}
 
-	if err := s.vault.Delete(r.Context(), path); err != nil {
+	if err := s.vault.Delete(ctx, path); err != nil {
 		if errors.Is(err, vault.ErrCredentialUnavailable) {
 			writeError(w, http.StatusLocked, "vault_locked",
 				"unlock the vault before deleting agent credentials")
+			s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialDelete, name, actor, sessionID, "vault_locked")
 			return
 		}
 		writeError(w, http.StatusInternalServerError, "vault_delete_failed", err.Error())
+		s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialDelete, name, actor, sessionID, "vault_delete_failed")
 		return
 	}
 
+	s.emitVaultCredentialEvent(ctx, model.EventTypeVaultCredentialDelete, name, actor, sessionID, "")
 	w.WriteHeader(http.StatusNoContent)
 }
 

--- a/internal/app/handlers_local_vault_secrets_test.go
+++ b/internal/app/handlers_local_vault_secrets_test.go
@@ -538,7 +538,10 @@ func newAuditingAgentCredentialsServer(t *testing.T, v vault.Vault) (*apiServer,
 func assertNoCredentialLeak(t *testing.T, events []audit.Event, logBuf *bytes.Buffer) {
 	t.Helper()
 	for _, e := range events {
-		raw, _ := json.Marshal(e.Payload)
+		raw, err := json.Marshal(e.Payload)
+		if err != nil {
+			t.Fatalf("marshal event payload: %v", err)
+		}
 		for _, forbidden := range vaultCredentialForbidden {
 			if strings.Contains(string(raw), forbidden) {
 				t.Errorf("audit payload leaked %q: %s", forbidden, string(raw))
@@ -639,6 +642,19 @@ func TestGetAgentCredentials_MissingEntryEmitsFailureEvent(t *testing.T) {
 	events := listVaultCredentialEvents(t, store)
 	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialRead)
 	assertFailureClass(t, ev, "vault_not_found")
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestGetAgentCredentials_LockedVaultEmitsFailureEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewLockableVault())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/agents/codex/credentials", nil)
+	s.GetAgentCredentials(rec, req, "codex")
+	assertStatus(t, rec, http.StatusLocked)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialRead)
+	assertFailureClass(t, ev, "vault_locked")
 	assertNoCredentialLeak(t, events, logBuf)
 }
 

--- a/internal/app/handlers_local_vault_secrets_test.go
+++ b/internal/app/handlers_local_vault_secrets_test.go
@@ -11,6 +11,8 @@ import (
 	"testing"
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
@@ -495,3 +497,312 @@ func TestAgentNameFromVaultPath(t *testing.T) {
 }
 
 func strPtr(s string) *string { return &s }
+
+// Audit + session-log contract for the per-agent credential verbs
+// (#985, ADR-0010 + ADR-0011):
+//
+//   - GET/PUT/DELETE each emit one audit event with the verb's
+//     EventType, carrying `aileron.vault.agent` and never the bytes.
+//   - The success path emits no `aileron.failure.class`; each error
+//     branch emits the verb's EventType plus the error-code class.
+//   - The credential value never appears in the audit payload JSON or
+//     the captured slog buffer (the core leak-prevention assertion).
+//   - A nil recorder never panics and still fires the slog line.
+//   - The optional X-Aileron-Session-Id header attributes the operation
+//     to that session; absent, the actor is the loopback service ref.
+
+// vaultCredentialSecret is the credential body the audit tests PUT. The
+// distinctive substrings below must never surface in any audit payload
+// or session log line.
+const vaultCredentialSecret = `{"claudeAiOauth":{"accessToken":"tok-SUPERSECRET","refreshToken":"rt-SUPERSECRET"}}`
+
+var vaultCredentialForbidden = []string{"tok-SUPERSECRET", "rt-SUPERSECRET", "accessToken"}
+
+// newAuditingAgentCredentialsServer builds a server with a real
+// in-memory audit store and a slog logger that writes into logBuf, so a
+// test can assert on both the recorded events and the session log.
+func newAuditingAgentCredentialsServer(t *testing.T, v vault.Vault) (*apiServer, *audit.MemStore, *bytes.Buffer) {
+	t.Helper()
+	store := audit.NewMemStore()
+	logBuf := &bytes.Buffer{}
+	s := &apiServer{
+		log:           slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug})),
+		vault:         v,
+		auditRecorder: audit.NewRecorder(store, nil, func() string { return "vault-cred-audit-id" }),
+	}
+	return s, store, logBuf
+}
+
+// assertNoCredentialLeak fails if any forbidden substring appears in the
+// marshaled event payloads or the captured session log.
+func assertNoCredentialLeak(t *testing.T, events []audit.Event, logBuf *bytes.Buffer) {
+	t.Helper()
+	for _, e := range events {
+		raw, _ := json.Marshal(e.Payload)
+		for _, forbidden := range vaultCredentialForbidden {
+			if strings.Contains(string(raw), forbidden) {
+				t.Errorf("audit payload leaked %q: %s", forbidden, string(raw))
+			}
+		}
+	}
+	logStr := logBuf.String()
+	for _, forbidden := range vaultCredentialForbidden {
+		if strings.Contains(logStr, forbidden) {
+			t.Errorf("session log leaked %q: %s", forbidden, logStr)
+		}
+	}
+}
+
+// putAuditableCredential PUTs the distinctive secret for agent name.
+func putAuditableCredential(t *testing.T, s *apiServer, name string) {
+	t.Helper()
+	body := api.AgentCredentials{Value: []byte(vaultCredentialSecret)}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/v1/vault/agents/"+name+"/credentials",
+		bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	rec := httptest.NewRecorder()
+	s.PutAgentCredentials(rec, req, name)
+	assertStatus(t, rec, http.StatusNoContent)
+}
+
+func listVaultCredentialEvents(t *testing.T, store *audit.MemStore) []audit.Event {
+	t.Helper()
+	events, err := store.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	return events
+}
+
+func TestGetAgentCredentials_SuccessEmitsReadEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	putAuditableCredential(t, s, "claude")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/agents/claude/credentials", nil)
+	s.GetAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusOK)
+
+	events := listVaultCredentialEvents(t, store)
+	read := requireSingleEvent(t, events, model.EventTypeVaultCredentialRead)
+	if read.Payload["aileron.vault.agent"] != "claude" {
+		t.Errorf("agent = %v, want claude", read.Payload["aileron.vault.agent"])
+	}
+	if _, ok := read.Payload["aileron.failure.class"]; ok {
+		t.Errorf("success event must not carry aileron.failure.class: %v", read.Payload)
+	}
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestPutAgentCredentials_SuccessEmitsWriteEventWithoutSecret(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	putAuditableCredential(t, s, "claude")
+
+	events := listVaultCredentialEvents(t, store)
+	write := requireSingleEvent(t, events, model.EventTypeVaultCredentialWrite)
+	if write.Payload["aileron.vault.agent"] != "claude" {
+		t.Errorf("agent = %v, want claude", write.Payload["aileron.vault.agent"])
+	}
+	// Core leak-prevention assertion: the PUT body never reaches audit
+	// or the session log.
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestDeleteAgentCredentials_SuccessEmitsDeleteEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	putAuditableCredential(t, s, "claude")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/vault/agents/claude/credentials", nil)
+	s.DeleteAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusNoContent)
+
+	events := listVaultCredentialEvents(t, store)
+	del := requireSingleEvent(t, events, model.EventTypeVaultCredentialDelete)
+	if del.Payload["aileron.vault.agent"] != "claude" {
+		t.Errorf("agent = %v, want claude", del.Payload["aileron.vault.agent"])
+	}
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestGetAgentCredentials_MissingEntryEmitsFailureEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/agents/claude/credentials", nil)
+	s.GetAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusNotFound)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialRead)
+	assertFailureClass(t, ev, "vault_not_found")
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestPutAgentCredentials_LockedVaultEmitsFailureEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewLockableVault())
+	body := api.AgentCredentials{Value: []byte(vaultCredentialSecret)}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/v1/vault/agents/claude/credentials",
+		bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	s.PutAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusLocked)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialWrite)
+	assertFailureClass(t, ev, "vault_locked")
+	// Even a rejected PUT must not leak the body it tried to store.
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestDeleteAgentCredentials_LockedVaultEmitsFailureEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewLockableVault())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/vault/agents/codex/credentials", nil)
+	s.DeleteAgentCredentials(rec, req, "codex")
+	assertStatus(t, rec, http.StatusLocked)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialDelete)
+	assertFailureClass(t, ev, "vault_locked")
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestDeleteAgentCredentials_MissingEntryEmitsFailureEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/vault/agents/claude/credentials", nil)
+	s.DeleteAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusNotFound)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialDelete)
+	assertFailureClass(t, ev, "vault_not_found")
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestVaultCredentials_NilRecorderDoesNotPanic(t *testing.T) {
+	// newAgentCredentialsServer leaves auditRecorder nil. Every verb
+	// must still return the correct status and fire the slog line.
+	v := vault.NewMemVault()
+	s := newAgentCredentialsServer(t, v)
+	logBuf := &bytes.Buffer{}
+	s.log = slog.New(slog.NewTextHandler(logBuf, &slog.HandlerOptions{Level: slog.LevelDebug}))
+
+	putAuditableCredential(t, s, "claude")
+
+	getRec := httptest.NewRecorder()
+	getReq := httptest.NewRequest(http.MethodGet, "/v1/vault/agents/claude/credentials", nil)
+	s.GetAgentCredentials(getRec, getReq, "claude")
+	assertStatus(t, getRec, http.StatusOK)
+
+	delRec := httptest.NewRecorder()
+	delReq := httptest.NewRequest(http.MethodDelete, "/v1/vault/agents/claude/credentials", nil)
+	s.DeleteAgentCredentials(delRec, delReq, "claude")
+	assertStatus(t, delRec, http.StatusNoContent)
+
+	// The slog line fired even with no recorder, and never leaked.
+	if !strings.Contains(logBuf.String(), "vault.credential.read") {
+		t.Errorf("expected a read session-log line; got %s", logBuf.String())
+	}
+	assertNoCredentialLeak(t, nil, logBuf)
+}
+
+func TestVaultCredentials_SessionHeaderAttributesActor(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+
+	body := api.AgentCredentials{Value: []byte(vaultCredentialSecret)}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/v1/vault/agents/claude/credentials",
+		bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Aileron-Session-Id", "sess-123")
+	rec := httptest.NewRecorder()
+	s.PutAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusNoContent)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialWrite)
+	if ev.Actor.Type != model.ActorTypeService || ev.Actor.ID != "sess-123" {
+		t.Errorf("actor = %+v, want service/sess-123", ev.Actor)
+	}
+	if ev.Payload["aileron.session.id"] != "sess-123" {
+		t.Errorf("session id = %v, want sess-123", ev.Payload["aileron.session.id"])
+	}
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestVaultCredentials_NoSessionHeaderUsesLoopbackActor(t *testing.T) {
+	s, store, _ := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	putAuditableCredential(t, s, "claude")
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialWrite)
+	if ev.Actor.Type != model.ActorTypeService || ev.Actor.ID != "loopback" {
+		t.Errorf("actor = %+v, want service/loopback", ev.Actor)
+	}
+	if _, ok := ev.Payload["aileron.session.id"]; ok {
+		t.Errorf("no session header => payload must omit aileron.session.id: %v", ev.Payload)
+	}
+}
+
+// requireSingleEvent asserts exactly one event of the given type is
+// present and returns it.
+func requireSingleEvent(t *testing.T, events []audit.Event, want model.EventType) audit.Event {
+	t.Helper()
+	var matches []audit.Event
+	for _, e := range events {
+		if e.EventType == want {
+			matches = append(matches, e)
+		}
+	}
+	if len(matches) != 1 {
+		t.Fatalf("events of type %q = %d, want 1 (all events: %+v)", want, len(matches), events)
+	}
+	return matches[0]
+}
+
+// putErrVault fails Put with a generic (non-Unavailable) error so the
+// PutAgentCredentials vault_put_failed 500 branch — and its failure
+// emission — is exercised.
+type putErrVault struct{ vault.Vault }
+
+func (putErrVault) Put(context.Context, string, []byte, vault.Metadata) error { return errGeneric }
+
+func TestPutAgentCredentials_PutErrorEmitsFailureEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, putErrVault{})
+	body := api.AgentCredentials{Value: []byte(vaultCredentialSecret)}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodPut, "/v1/vault/agents/claude/credentials",
+		bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	s.PutAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusInternalServerError)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialWrite)
+	assertFailureClass(t, ev, "vault_put_failed")
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func assertFailureClass(t *testing.T, e audit.Event, want string) {
+	t.Helper()
+	if got := e.Payload["aileron.failure.class"]; got != want {
+		t.Errorf("aileron.failure.class = %v, want %q", got, want)
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -322,4 +322,15 @@ const (
 	// launcher when proxy bootstrap is opted out, preflight fails, or
 	// the sandbox mode does not support bootstrap.
 	EventTypeSandboxProxyDisabled EventType = "sandbox.proxy.disabled"
+
+	// Per-agent vault credential events (ADR-0010 + ADR-0011). Emitted
+	// on each verb at /v1/vault/agents/{name}/credentials so a loopback
+	// process that reads, overwrites, or removes an OAuth bundle leaves
+	// an audit signal. The payload carries the agent name, the requester
+	// actor, a recorder-stamped timestamp, and on failure an
+	// `aileron.failure.class` error class. The credential bytes NEVER
+	// appear in the payload — only metadata about the operation.
+	EventTypeVaultCredentialRead   EventType = "vault.credential.read"
+	EventTypeVaultCredentialWrite  EventType = "vault.credential.write"
+	EventTypeVaultCredentialDelete EventType = "vault.credential.delete"
 )


### PR DESCRIPTION
## Summary
- Emit an `audit.Recorder` event and a `slog.Info` session-log line on each per-agent credential verb (GET/PUT/DELETE) at `/v1/vault/agents/{name}/credentials`, closing the gap where a loopback process could read, overwrite, or remove an OAuth bundle with no audit signal (closes #985, implements ADR-0010 + ADR-0011).
- Adds three `model.EventType` constants: `vault.credential.read`, `vault.credential.write`, `vault.credential.delete`. The payload carries `aileron.vault.agent`, the requester actor, a recorder-stamped timestamp, and on failure `aileron.failure.class`. The credential bytes never reach the payload or the log line.
- Resolves the requester from the optional `X-Aileron-Session-Id` header (consistent with the connector-operations / sandbox-proxy handlers, no OpenAPI change); when absent, attributes the operation to a `service`/`loopback` actor. Nil-recorder daemons still fire the slog line.

## Deliberate deviation (flagged for reviewer)
Failures are recorded via the verb's own `EventType` + an `aileron.failure.class` field rather than `RecordFailure(*failure.Failure, …)`. These handlers emit error *codes* (`vault_locked`, `vault_not_found`, …), not `*failure.Failure` envelopes; synthesizing one would distort the audit shape and stamp spurious audit IDs onto a response that has none. This mirrors the established `emitActionExecutionFailure` / `emitActionExecutorError` convention in `handlers.go`.

## Scope
- In scope: the three credential verbs, the three new EventType constants, tests. `ListAgentCredentials` is out of scope (returns no credential bytes; #985 enumerates only GET/PUT/DELETE).
- Not touched: OpenAPI spec, generated server, approval-gating / idempotency manifests, the `audit` package internals.

## Test plan
- [x] `task test:go` — all Go packages pass.
- [x] `go test ./internal/app/... ./internal/model/...` pass; package coverage 81.9% (above the 80% bar).
- [x] Audit-shape tests assert: success events carry agent name and omit `aileron.failure.class`; each error branch emits the verb's EventType + the right error class; the credential value (`tok-SUPERSECRET`, `rt-SUPERSECRET`, `accessToken`) is absent from every payload JSON and the captured slog buffer.
- [x] Nil-recorder path returns correct status and still logs without panicking.
- [x] Session-header propagation: `X-Aileron-Session-Id` -> `service`/`<session>` actor + `aileron.session.id`; absent -> `service`/`loopback`, no session field.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Credential operations (read, write, delete) now emit new audit events with optional session attribution via a request header; events include operation metadata, agent identifier, timestamp, and error classification for failures

* **Tests**
  * Added comprehensive tests validating audit event emission, session/header attribution, failure classifications, nil-recorder behavior, and that secret bytes never appear in logs
<!-- end of auto-generated comment: release notes by coderabbit.ai -->