### PR TITLE
docs(adr): record sandbox-only host-launch parity decision for AuthSpec

### DIFF
--- a/docs/src/content/docs/adr/0025-vault-backed-agent-auth.md
+++ b/docs/src/content/docs/adr/0025-vault-backed-agent-auth.md
@@ -8,7 +8,7 @@ order: 25
 <table>
   <tr><th>Status</th><td>Accepted</td></tr>
   <tr><th>Date</th><td>2026-06-10</td></tr>
-  <tr><th>Tracking</th><td><a href="https://github.com/ALRubinger/aileron/issues/969">#969</a>, <a href="https://github.com/ALRubinger/aileron/issues/747">#747</a></td></tr>
+  <tr><th>Tracking</th><td><a href="https://github.com/ALRubinger/aileron/issues/969">#969</a>, <a href="https://github.com/ALRubinger/aileron/issues/747">#747</a>, <a href="https://github.com/ALRubinger/aileron/issues/983">#983</a></td></tr>
 </table>
 </div>
 
@@ -46,7 +46,7 @@ The daemon's new endpoints are namespace-scoped at the routing layer: `{name}` t
 
 **Seeding is exclusively in-container in v1.** First launch with an empty vault prints `[launcher] no credentials in vault for <agent>. agent will prompt for login` to stderr and starts the container with the writable bind-mount empty. The in-container agent performs its normal interactive login (paste-the-code OAuth fallback for Claude, device-auth for Codex). Capture on clean exit seeds the vault. Every subsequent launch renders silently. Host-side credential import is deferred to a follow-up; the brainstorm closes that scope in v1.
 
-**Sandbox-only in v1.** Host-launch parity for `AuthSpec` is architecturally clean to extend later. It is not part of this decision.
+**Sandbox-only in v1.** Host launch (`aileron launch <agent>` with no sandbox flag) is deliberately not vault-backed. Host launch already resolves a working install's credentials from the host user's own `~/.claude/` and `~/.codex/`. `prepareAuthSpec` runs only on the sandbox path and is intentionally not wired into host launch. Intervening on the host path risks breaking a working install, so the host path stays untouched in v1. Vault-backed host auth would render vault entries into host paths and capture rotations back to the vault. That work warrants a separate PR with explicit user testing, and is deferred. The host-parity question was evaluated under issue [#983](https://github.com/ALRubinger/aileron/issues/983): three options were weighed, extending `AuthSpec` to host launch, a hybrid, and documenting the sandbox-only stance. Documenting the sandbox-only stance was chosen for v1. Host-launch parity for `AuthSpec` stays architecturally clean to extend later, and is not part of this decision.
 
 ## Consequences
 
@@ -70,6 +70,7 @@ The daemon's new endpoints are namespace-scoped at the routing layer: `{name}` t
 
 - The vault entry holds a usable OAuth credential. The daemon already protects this surface per [ADR-0011](/adr/0011-local-credential-vault); the new endpoints inherit the same posture without widening it.
 - The writable host-side transient directory is chmod 0700, so OAuth bytes do not leak through a shared host's default umask. The launcher removes it on Launch exit.
+- Host launch's credentials stay entirely host-resolved and are untouched by the vault path. The vault-to-container conduit exists only on the sandbox path, so a host launch reads the same `~/.claude/` and `~/.codex/` files it always has.
 
 ## Alternatives Considered
 

--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -8,6 +8,10 @@ order: 10
 
 This page is for operators and contributors. It documents the per-agent envelope schemas, the seeding paths, and the recovery commands.
 
+## Host launch is not vault-backed in v1
+
+Vault-backed credential injection applies only to `aileron launch <agent> --sandbox=docker` (and `--sandbox=podman`). A plain `aileron launch <agent>` host launch is not vault-backed in v1. Host launch lets the agent find its own credentials in the host user's home directory (`~/.claude/`, `~/.codex/`). `prepareAuthSpec` does not run on the host path, so the `AuthSpec` lifecycle is sandbox-only. Host-side vault-backed auth is a deliberately deferred follow-up that needs its own PR and explicit user testing. See [ADR-0025](/adr/0025-vault-backed-agent-auth) for the decision record.
+
 ## Vault path scheme
 
 Per-agent credentials live under the namespace `agents/<name>/<purpose>`:


### PR DESCRIPTION
## Summary

Documents Option 3 from issue #983: the `AuthSpec` vault-backed credential pipeline stays sandbox-only in v1, and host launch (`aileron launch <agent>` with no sandbox flag) keeps resolving the host user's own `~/.claude/` and `~/.codex/` credentials. This is a deliberate, durable decision recorded in docs. No code change.

- **ADR-0025**: expands the terse "Sandbox-only in v1" note into an explicit record that the host-parity question was evaluated (three options weighed) and resolved to a deliberate no-op for v1, with rationale; adds `#983` to the Tracking table; adds a trust-model bullet clarifying host launch credentials stay host-resolved.
- **`development/sandbox-agent-auth.md`**: adds a "Host launch is not vault-backed in v1" scoping section after the opening, stating vault injection applies only to `--sandbox=docker`/`--sandbox=podman`, that `prepareAuthSpec` does not run on the host path, and that host-side vault auth is a deferred follow-up.

Closes #983.

## Test plan

This is a docs-only change. There is no code test, and the absence of one is an accepted, expected gap rather than a coverage miss. Verification is by review:

- [x] `task lint:docs` (astro check) passes with 0 errors / 0 warnings / 0 hints.
- [x] `git diff --name-only` lists exactly the two doc files; nothing under `internal/`, `cmd/`, or `*_test.go`.
- [x] No em-dashes in any added line.
- [x] No sibling content reverted; edits confined to the expanded Decision note, the trust-model bullet, the tracking-table cell, and the new dev-doc scoping section.
- [x] Front-matter intact on both files; ADR Status stays Accepted, Date stays 2026-06-10.
- [x] ADR amended in place per pre-MVP convention (no superseding ADR).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated vault-backed agent authentication documentation with clarifications on supported launch modes.
  * Clarified that vault-backed credential injection applies only to sandbox deployments in v1, with host-launch support deferred to a future release.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->