### PR TITLE
feat(auth): aileron auth <agent> --import-from-host vault seeding

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -146,7 +146,11 @@ jobs:
         shell: bash
         run: |
           set -e
-          (cd internal && go test -race -coverprofile=coverage-darwin-internal.txt ./sandbox/...)
+          # launch/hostimport carries the darwin-tagged Keychain shell-out
+          # (keychain_darwin.go) for `aileron auth <agent> --import-from-host`
+          # (#986). It only compiles and runs on macOS, so it joins the
+          # sandbox package in this job's glob to get real CI coverage.
+          (cd internal && go test -race -coverprofile=coverage-darwin-internal.txt ./sandbox/... ./launch/hostimport/...)
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v6
@@ -196,7 +200,11 @@ jobs:
           # test broke. Without it, `go test` only reports `FAIL pkg`
           # at the package level when no test prints anything, which
           # hides syscall-level hangs that don't produce stdout.
-          (cd internal && go test -v -race -coverprofile=coverage-windows-internal.txt ./daemon/discovery/... ./daemon/spawn/... ./sandbox/...)
+          # launch/hostimport's file_other.go is the Windows credential-file
+          # read for `aileron auth <agent> --import-from-host` (#986). The
+          # file-mode test runs here so %USERPROFILE% path resolution is
+          # verified on a real Windows runner.
+          (cd internal && go test -v -race -coverprofile=coverage-windows-internal.txt ./daemon/discovery/... ./daemon/spawn/... ./sandbox/... ./launch/hostimport/...)
           # cmd/aileron's full suite is gated behind #577 on Windows.
           # Run only the helpers with a Windows-specific implementation.
           (cd cmd/aileron && go test -race -coverprofile=coverage-windows-aileron.txt -run 'TestSignalDaemonStop' .)

--- a/cmd/aileron/auth.go
+++ b/cmd/aileron/auth.go
@@ -65,15 +65,15 @@ func runAuthImport(agentName string, registry *launch.Registry, stdout, stderr i
 
 	raw, err := hostimport.Extract(agentName, hostimport.Options{})
 	if err != nil {
-		switch {
-		case errors.Is(err, hostimport.ErrNotAuthenticated):
+		if errors.Is(err, hostimport.ErrNotAuthenticated) {
 			fmt.Fprintf(stderr, "error: no host credentials found for %s\n", agentName)
 			fmt.Fprintf(stderr, "log in first, then re-run; or use interactive in-container login: aileron launch %s --sandbox=docker\n", agentName)
-		case errors.Is(err, hostimport.ErrLinuxKeyringUnsupported):
-			fmt.Fprintf(stderr, "error: %v\n", err)
-		default:
-			fmt.Fprintf(stderr, "error reading host credentials: %v\n", err)
+			return 1
 		}
+		// Any other extraction error (including the Linux-keyring
+		// deferral, whose message already names the recovery paths) is
+		// surfaced verbatim.
+		fmt.Fprintf(stderr, "error reading host credentials: %v\n", err)
 		return 1
 	}
 

--- a/cmd/aileron/auth.go
+++ b/cmd/aileron/auth.go
@@ -86,11 +86,9 @@ func runAuthImport(agentName string, registry *launch.Registry, stdout, stderr i
 		return 1
 	}
 
-	body, err := json.Marshal(agentCredentialsBody{Value: secret.Value})
-	if err != nil {
-		fmt.Fprintf(stderr, "error: %v\n", err)
-		return 1
-	}
+	// Marshaling a struct with a single []byte field cannot fail, so the
+	// error is discarded here (matching runBindingSetup's precedent).
+	body, _ := json.Marshal(agentCredentialsBody{Value: secret.Value})
 	status, respBody, err := vaultDoRequest(http.MethodPut,
 		"/vault/agents/"+agentName+"/credentials", body)
 	if err != nil {

--- a/cmd/aileron/auth.go
+++ b/cmd/aileron/auth.go
@@ -1,0 +1,144 @@
+package main
+
+import (
+	"encoding/json"
+	"errors"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/launch/hostimport"
+)
+
+const authUsage = `usage:
+  aileron auth <agent> --import-from-host
+
+Seed the vault from an already-authenticated host install.
+<agent> must be claude or codex.`
+
+// runAuth dispatches `aileron auth <agent> ...`. The only verb in v1 is
+// `--import-from-host`, which reads an already-authenticated host
+// install's credential state for claude or codex, validates it against
+// the same schema the agent's AuthSpec Capture enforces, and PUTs it to
+// the vault through the daemon at agents/<name>/oauth.
+//
+// The auth namespace is reserved to later grow --status / --logout;
+// those are out of scope for #986.
+func runAuth(args []string, registry *launch.Registry, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, authUsage)
+		return 1
+	}
+
+	// Require <agent> as the first positional so the flag parser does
+	// not have to reorder. Flags follow the agent name.
+	agentName := args[0]
+	flags := flag.NewFlagSet("auth", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	importFromHost := flags.Bool("import-from-host", false,
+		"Read the host install's credential state and seed the vault")
+	if err := flags.Parse(args[1:]); err != nil {
+		return 1
+	}
+	if !*importFromHost {
+		fmt.Fprintln(stderr, "error: --import-from-host is required (the only auth mode in v1)")
+		fmt.Fprintln(stderr, authUsage)
+		return 1
+	}
+
+	return runAuthImport(agentName, registry, stdout, stderr)
+}
+
+// runAuthImport executes the host-import flow for one agent.
+func runAuthImport(agentName string, registry *launch.Registry, stdout, stderr io.Writer) int {
+	// Resolve the agent and its credential FileBinding so we validate
+	// host bytes through the exact Capture the launcher uses. This is
+	// also where we reject unsupported agents: only claude and codex
+	// have a host install hostimport can read.
+	binding, err := agentOAuthBinding(registry, agentName)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	raw, err := hostimport.Extract(agentName, hostimport.Options{})
+	if err != nil {
+		switch {
+		case errors.Is(err, hostimport.ErrNotAuthenticated):
+			fmt.Fprintf(stderr, "error: no host credentials found for %s\n", agentName)
+			fmt.Fprintf(stderr, "log in first, then re-run; or use interactive in-container login: aileron launch %s --sandbox=docker\n", agentName)
+		case errors.Is(err, hostimport.ErrLinuxKeyringUnsupported):
+			fmt.Fprintf(stderr, "error: %v\n", err)
+		default:
+			fmt.Fprintf(stderr, "error reading host credentials: %v\n", err)
+		}
+		return 1
+	}
+
+	// Validate via the agent's Capture — identical to the launcher's
+	// clean-exit capture. Capture returns a vault.Secret whose Value is
+	// the validated bytes; we PUT those bytes byte-verbatim.
+	secret, err := binding.Capture(raw)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: host credentials for %s are not a valid envelope: %v\n", agentName, err)
+		return 1
+	}
+
+	body, err := json.Marshal(agentCredentialsBody{Value: secret.Value})
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	status, respBody, err := vaultDoRequest(http.MethodPut,
+		"/vault/agents/"+agentName+"/credentials", body)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	switch status {
+	case http.StatusNoContent:
+		fmt.Fprintf(stdout, "Imported host credentials to agents/%s/oauth\n", agentName)
+		return 0
+	case http.StatusLocked:
+		fmt.Fprintln(stderr, "error: vault is locked; unlock it first")
+		return 1
+	case http.StatusServiceUnavailable:
+		fmt.Fprintln(stderr, "error: daemon is not configured with a vault")
+		return 1
+	default:
+		fmt.Fprintf(stderr, "server returned %d: %s\n", status, string(respBody))
+		return 1
+	}
+}
+
+// agentOAuthBinding resolves the agent's credential FileBinding — the
+// one whose VaultPath is agents/<name>/oauth — so the caller can run
+// host bytes through its Capture. It returns a clear unsupported-agent
+// error for any agent hostimport cannot read (goose/opencode/pi) and
+// for unknown names.
+func agentOAuthBinding(registry *launch.Registry, agentName string) (launch.FileBinding, error) {
+	switch agentName {
+	case hostimport.AgentClaude, hostimport.AgentCodex:
+		// supported
+	default:
+		return launch.FileBinding{}, fmt.Errorf("host import is not supported for %q (supported: %s, %s)",
+			agentName, hostimport.AgentClaude, hostimport.AgentCodex)
+	}
+
+	agent, ok := registry.Get(agentName)
+	if !ok {
+		return launch.FileBinding{}, fmt.Errorf("unknown agent: %q", agentName)
+	}
+	want := "agents/" + agentName + "/oauth"
+	for _, fb := range agent.AuthSpec().FileBindings {
+		if fb.VaultPath == want {
+			if fb.Capture == nil {
+				return launch.FileBinding{}, fmt.Errorf("agent %q binding %s has no Capture validator", agentName, want)
+			}
+			return fb, nil
+		}
+	}
+	return launch.FileBinding{}, fmt.Errorf("agent %q has no credential binding at %s", agentName, want)
+}

--- a/cmd/aileron/auth_test.go
+++ b/cmd/aileron/auth_test.go
@@ -214,6 +214,99 @@ func TestRunAuth_DaemonLocked(t *testing.T) {
 	}
 }
 
+func TestRunAuth_DaemonUnexpectedStatus(t *testing.T) {
+	// An unexpected daemon status maps to the default "server returned"
+	// branch with the body echoed for diagnosis.
+	seedHostCredential(t, "codex", []byte(`{"auth_mode":"chatgpt","tokens":{"refresh_token":"r"}}`))
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte("boom"))
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"codex", "--import-from-host"}, authTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "server returned 500") || !strings.Contains(stderr.String(), "boom") {
+		t.Errorf("stderr = %q, want server-returned-500 with body", stderr.String())
+	}
+}
+
+// fakeAuthAgent is a stand-in registered under a supported name so the
+// command's defensive AuthSpec guards (missing binding, nil Capture)
+// can be exercised without depending on the real agent definitions
+// staying misconfigured.
+type fakeAuthAgent struct {
+	name string
+	spec launch.AuthSpec
+}
+
+func (f fakeAuthAgent) Name() string          { return f.name }
+func (f fakeAuthAgent) BinaryNames() []string { return []string{f.name} }
+func (f fakeAuthAgent) Args() []string        { return nil }
+func (f fakeAuthAgent) Env() map[string]string {
+	return nil
+}
+func (f fakeAuthAgent) LLMEndpointEnv() string { return "" }
+func (f fakeAuthAgent) ConfigureMCP(string, map[string]string, string, launch.Mode) ([]string, []launch.MCPMount, error) {
+	return nil, nil, nil
+}
+func (f fakeAuthAgent) AuthSpec() launch.AuthSpec { return f.spec }
+
+// TestRunAuth_BindingMissingCapture covers the defensive guard that
+// rejects an agent whose oauth FileBinding declares no Capture
+// validator, rather than nil-dereferencing it.
+func TestRunAuth_BindingMissingCapture(t *testing.T) {
+	r := launch.NewRegistry()
+	r.Register(fakeAuthAgent{
+		name: "claude",
+		spec: launch.AuthSpec{FileBindings: []launch.FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/x",
+			Capture:       nil,
+		}}},
+	})
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"claude", "--import-from-host"}, r, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "no Capture validator") {
+		t.Errorf("stderr = %q, want nil-Capture guard", stderr.String())
+	}
+}
+
+// TestRunAuth_BindingPathMissing covers the guard that fires when a
+// supported, registered agent has no binding at agents/<name>/oauth.
+func TestRunAuth_BindingPathMissing(t *testing.T) {
+	r := launch.NewRegistry()
+	r.Register(fakeAuthAgent{name: "codex", spec: launch.AuthSpec{}})
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"codex", "--import-from-host"}, r, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "no credential binding at agents/codex/oauth") {
+		t.Errorf("stderr = %q, want missing-binding guard", stderr.String())
+	}
+}
+
+// TestRunAuth_UnknownAgentNotRegistered exercises the registry-miss
+// branch: a supported name (codex) that is nonetheless absent from the
+// registry surfaces a clear "unknown agent" error before any host read.
+func TestRunAuth_UnknownAgentNotRegistered(t *testing.T) {
+	empty := launch.NewRegistry() // codex not registered
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"codex", "--import-from-host"}, empty, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown agent") {
+		t.Errorf("stderr = %q, want unknown-agent error", stderr.String())
+	}
+}
+
 func TestRunAuth_DaemonNoVault(t *testing.T) {
 	seedHostCredential(t, "codex", []byte(`{"auth_mode":"chatgpt","tokens":{"refresh_token":"r"}}`))
 	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {

--- a/cmd/aileron/auth_test.go
+++ b/cmd/aileron/auth_test.go
@@ -1,0 +1,231 @@
+package main
+
+import (
+	"bytes"
+	"encoding/json"
+	"net/http"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+)
+
+// skipIfClaudeKeychainOnly skips a Claude file-fixture test on macOS,
+// where Claude credentials live in the Keychain rather than a file the
+// HOME-redirect fixture can seed. Reading the real Keychain item in a
+// test is forbidden, so the authoritative coverage for the Claude
+// file-mode path is the ubuntu CI shard (cmd/aileron's full suite runs
+// there). Codex-based tests cover the daemon-side behavior on every OS
+// because Codex prefers its auth.json file on macOS too.
+func skipIfClaudeKeychainOnly(t *testing.T) {
+	t.Helper()
+	if runtime.GOOS == "darwin" {
+		t.Skip("Claude is Keychain-only on macOS; file-fixture path is covered on the ubuntu CI shard")
+	}
+}
+
+// authTestRegistry builds a registry holding the agents host-import
+// cares about plus an unsupported one, mirroring main()'s wiring.
+func authTestRegistry() *launch.Registry {
+	r := launch.NewRegistry()
+	r.Register(agents.Claude{})
+	r.Register(agents.Codex{})
+	r.Register(agents.Goose{})
+	return r
+}
+
+// seedHostCredential writes a fixture credential file under a redirected
+// HOME so hostimport's file-mode extractor reads it. Returns nothing;
+// the test asserts on the daemon PUT body. These cmd/aileron tests run
+// on the ubuntu shards where file mode is the extraction path.
+func seedHostCredential(t *testing.T, agent string, content []byte) {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	var rel string
+	switch agent {
+	case "claude":
+		rel = filepath.Join(".claude", ".credentials.json")
+	case "codex":
+		rel = filepath.Join(".codex", "auth.json")
+	default:
+		t.Fatalf("unsupported agent in fixture: %s", agent)
+	}
+	path := filepath.Join(home, rel)
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, content, 0o600); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunAuth_ImportClaudeHappyPath(t *testing.T) {
+	skipIfClaudeKeychainOnly(t)
+	envelope := []byte(`{"claudeAiOauth":{"accessToken":"tok","refreshToken":"r","scopes":["x"]}}`)
+	seedHostCredential(t, "claude", envelope)
+
+	var received []byte
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodPut || r.URL.Path != "/vault/agents/claude/credentials" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		var body agentCredentialsBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode: %v", err)
+		}
+		received = body.Value
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"claude", "--import-from-host"}, authTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !bytes.Equal(received, envelope) {
+		t.Errorf("PUT body = %q, want %q (byte-verbatim)", received, envelope)
+	}
+	if !strings.Contains(stdout.String(), "Imported host credentials to agents/claude/oauth") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRunAuth_ImportCodexHappyPath(t *testing.T) {
+	envelope := []byte(`{"auth_mode":"chatgpt","tokens":{"access_token":"a","refresh_token":"r"}}`)
+	seedHostCredential(t, "codex", envelope)
+
+	var received []byte
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/vault/agents/codex/credentials" {
+			t.Errorf("unexpected path: %s", r.URL.Path)
+		}
+		var body agentCredentialsBody
+		_ = json.NewDecoder(r.Body).Decode(&body)
+		received = body.Value
+		w.WriteHeader(http.StatusNoContent)
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"codex", "--import-from-host"}, authTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !bytes.Equal(received, envelope) {
+		t.Errorf("PUT body = %q, want %q", received, envelope)
+	}
+}
+
+func TestRunAuth_UnsupportedAgent(t *testing.T) {
+	// No HTTP server: an unsupported agent must fail before any extract
+	// or daemon call.
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"goose", "--import-from-host"}, authTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "not supported for") {
+		t.Errorf("stderr = %q, want unsupported message", stderr.String())
+	}
+}
+
+func TestRunAuth_MissingImportFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"claude"}, authTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "--import-from-host is required") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunAuth_NoArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runAuth(nil, authTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunAuth_HostNotAuthenticated(t *testing.T) {
+	// On macOS an absent Codex file would fall back to the real "Codex
+	// Auth" Keychain item, which a test must not touch; Claude is
+	// keychain-only there. Run the file-absence assertion on the ubuntu
+	// shard via the skip guard.
+	skipIfClaudeKeychainOnly(t)
+
+	// Redirect HOME to an empty dir so no credential file exists.
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"claude", "--import-from-host"}, authTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	msg := stderr.String()
+	if !strings.Contains(msg, "no host credentials found") {
+		t.Errorf("stderr = %q, want not-authenticated message", msg)
+	}
+	if !strings.Contains(msg, "--sandbox=docker") {
+		t.Errorf("stderr = %q, want in-container recovery path", msg)
+	}
+}
+
+func TestRunAuth_MalformedEnvelope(t *testing.T) {
+	// A file present but failing the agent's Capture (Codex envelope
+	// missing the required refresh_token). Codex reads its file on every
+	// OS, so this exercises the Capture-rejection path cross-platform.
+	seedHostCredential(t, "codex", []byte(`{"auth_mode":"chatgpt","tokens":{}}`))
+
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"codex", "--import-from-host"}, authTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "not a valid envelope") {
+		t.Errorf("stderr = %q, want malformed-envelope message", stderr.String())
+	}
+}
+
+func TestRunAuth_DaemonLocked(t *testing.T) {
+	seedHostCredential(t, "codex", []byte(`{"auth_mode":"chatgpt","tokens":{"refresh_token":"r"}}`))
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusLocked)
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"codex", "--import-from-host"}, authTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "locked") {
+		t.Errorf("stderr = %q, want locked message", stderr.String())
+	}
+}
+
+func TestRunAuth_DaemonNoVault(t *testing.T) {
+	seedHostCredential(t, "codex", []byte(`{"auth_mode":"chatgpt","tokens":{"refresh_token":"r"}}`))
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusServiceUnavailable)
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"codex", "--import-from-host"}, authTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "not configured with a vault") {
+		t.Errorf("stderr = %q, want no-vault message", stderr.String())
+	}
+}

--- a/cmd/aileron/auth_test.go
+++ b/cmd/aileron/auth_test.go
@@ -182,6 +182,40 @@ func TestRunAuth_HostNotAuthenticated(t *testing.T) {
 	}
 }
 
+// TestRunAuth_ExtractError covers the non-ErrNotAuthenticated extract
+// failure branch: a credential file that exists but is unreadable
+// surfaces the underlying read error rather than the login-recovery
+// message. Skipped when running as root (chmod 000 does not deny root)
+// and on Windows (POSIX perms do not apply).
+func TestRunAuth_ExtractError(t *testing.T) {
+	skipIfClaudeKeychainOnly(t) // darwin Claude path ignores the HOME fixture
+	if runtime.GOOS == "windows" {
+		t.Skip("POSIX file permissions do not gate reads on Windows")
+	}
+	if os.Geteuid() == 0 {
+		t.Skip("chmod 000 does not deny root")
+	}
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home)
+	path := filepath.Join(home, ".claude", ".credentials.json")
+	if err := os.MkdirAll(filepath.Dir(path), 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(path, []byte(`{"claudeAiOauth":{"accessToken":"t"}}`), 0o000); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runAuth([]string{"claude", "--import-from-host"}, authTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "error reading host credentials") {
+		t.Errorf("stderr = %q, want extract-error message", stderr.String())
+	}
+}
+
 func TestRunAuth_MalformedEnvelope(t *testing.T) {
 	// A file present but failing the agent's Capture (Codex envelope
 	// missing the required refresh_token). Codex reads its file on every

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -151,6 +151,8 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		return runSandbox(args[1:], registry, stdout, stderr)
 	case "vault":
 		return runVault(args[1:], os.Stdin, stdout, stderr)
+	case "auth":
+		return runAuth(args[1:], registry, stdout, stderr)
 	case "daemon":
 		return runDaemon(args[1:], stdout, stderr)
 	case "stop":
@@ -175,6 +177,7 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron launch [--sandbox=<runtime>] [--sandbox-build=<policy>] <agent> [args...]")
 	fmt.Fprintln(w, "                                      Launch an AI coding agent connected to the Aileron daemon")
 	fmt.Fprintln(w, "  aileron vault init                 Create the local encrypted vault with a passphrase")
+	fmt.Fprintln(w, "  aileron auth <agent> --import-from-host  Seed the vault from an authenticated host install (claude|codex)")
 	fmt.Fprintln(w, "  aileron secret set <name>          Store a secret in the encrypted vault")
 	fmt.Fprintln(w, "  aileron secret list                List stored secret names")
 	fmt.Fprintln(w, "  aileron binding list               List credential bindings (metadata only — no unlock)")

--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -87,7 +87,7 @@ aileron vault list
 
 `aileron auth <agent> --import-from-host` seeds the vault from an already-authenticated host install. It reads the host `claude` or `codex` credential state, validates it against the same schema the launcher's Capture pass enforces, and writes it through the daemon to `agents/<agent>/oauth`. Operators who already ran `claude` or `codex` login on the host skip the per-machine in-container login.
 
-```
+```bash
 aileron auth claude --import-from-host
 aileron auth codex --import-from-host
 ```

--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -85,7 +85,22 @@ The bytes must match the envelope schema in the table above when set manually. R
 aileron vault list
 ```
 
-The `aileron auth <agent> --import-from-host` subcommand is intentionally not in v1. The host-import surface (Linux file read, macOS Keychain shell-out, Windows file read) is deferred to a follow-up. The in-container login path covers bootstrap.
+`aileron auth <agent> --import-from-host` seeds the vault from an already-authenticated host install. It reads the host `claude` or `codex` credential state, validates it against the same schema the launcher's Capture pass enforces, and writes it through the daemon to `agents/<agent>/oauth`. Operators who already ran `claude` or `codex` login on the host skip the per-machine in-container login.
+
+```
+aileron auth claude --import-from-host
+aileron auth codex --import-from-host
+```
+
+The command reads the credential from the location each agent's CLI writes per operating system.
+
+- Linux. Claude reads `~/.claude/.credentials.json`. Codex reads `~/.codex/auth.json`. A Linux keyring install (libsecret) is not supported in v1; the command returns a clear error naming the file-mode and interactive-login recovery paths.
+- macOS. Claude reads the Keychain item under the `Claude Code-credentials` service. Codex prefers `~/.codex/auth.json` when it exists and otherwise reads the `Codex Auth` Keychain service. The first real Keychain read shows a macOS access dialog; approve it once so the command can read the item.
+- Windows. Claude reads `%USERPROFILE%\.claude\.credentials.json`. Codex reads `%USERPROFILE%\.codex\auth.json`.
+
+Only `claude` and `codex` accept `--import-from-host`. Other agents return a clear unsupported error. The bytes are read verbatim and validated through the agent's Capture before the PUT, so a malformed or partial envelope fails with the same error the launcher reports rather than landing a broken credential in the vault.
+
+When the host install is not authenticated (the file is absent or empty, or the Keychain item is missing), the command reports that no host credentials were found and names the recovery path: log in on the host first, or run the interactive in-container login with `aileron launch <agent> --sandbox=docker`.
 
 ## Recovery
 

--- a/internal/launch/hostimport/file_other.go
+++ b/internal/launch/hostimport/file_other.go
@@ -1,0 +1,33 @@
+//go:build !darwin
+
+package hostimport
+
+// extract resolves the host credential bytes on non-macOS platforms
+// (Linux and Windows) by reading the agent's credential file. Both
+// supported agents store their credential in a file under the user's
+// home directory:
+//
+//	Claude:  ~/.claude/.credentials.json  (%USERPROFILE%\.claude\... on Windows)
+//	Codex:   ~/.codex/auth.json           (%USERPROFILE%\.codex\... on Windows)
+//
+// A FilePathOverride wins over the default so tests read a fixture.
+//
+// On Linux the agent CLI may instead store the credential in a keyring
+// (libsecret/secret-tool). hostimport does not implement keyring
+// extraction in v1; when the file is absent the caller sees
+// ErrNotAuthenticated, whose recovery text covers both re-running login
+// so the file is written and the interactive in-container path. The
+// dedicated ErrLinuxKeyringUnsupported sentinel exists for callers that
+// want to detect a keyring-only install explicitly once that detection
+// lands; v1 maps file-absence to ErrNotAuthenticated.
+func extract(agent string, opts Options) ([]byte, error) {
+	path := opts.FilePathOverride
+	if path == "" {
+		p, err := defaultCredentialPath(agent)
+		if err != nil {
+			return nil, err
+		}
+		path = p
+	}
+	return readCredentialFile(path)
+}

--- a/internal/launch/hostimport/file_other_test.go
+++ b/internal/launch/hostimport/file_other_test.go
@@ -1,0 +1,87 @@
+//go:build !darwin
+
+package hostimport
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+// TestExtract_FileModeReturnsBytesVerbatim confirms the file-mode
+// extractor (Linux/Windows) reads the credential file byte-for-byte,
+// including a trailing newline, since agent credential files are
+// exact-byte artifacts. Runs on ubuntu shards and on windows-latest CI
+// (the build tag selects this file on both).
+func TestExtract_FileModeReturnsBytesVerbatim(t *testing.T) {
+	want := []byte("{\"claudeAiOauth\":{\"accessToken\":\"tok\"}}\n")
+	dir := t.TempDir()
+	path := filepath.Join(dir, "creds.json")
+	if err := os.WriteFile(path, want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Extract(AgentClaude, Options{FilePathOverride: path})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Extract = %q, want %q (verbatim)", got, want)
+	}
+}
+
+// TestExtract_FileModeMissingFile maps an absent credential file to
+// ErrNotAuthenticated so the CLI surfaces the in-container login
+// recovery path.
+func TestExtract_FileModeMissingFile(t *testing.T) {
+	missing := filepath.Join(t.TempDir(), "absent.json")
+	_, err := Extract(AgentCodex, Options{FilePathOverride: missing})
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("Extract(missing): err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+// TestExtract_FileModeEmptyFile maps a zero-byte credential file to
+// ErrNotAuthenticated: an empty credential is as useless as a missing
+// one.
+func TestExtract_FileModeEmptyFile(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "empty.json")
+	if err := os.WriteFile(path, nil, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, err := Extract(AgentClaude, Options{FilePathOverride: path})
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("Extract(empty): err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+// TestExtract_FileModeDefaultPath confirms that with no override the
+// extractor resolves the agent's default path under the user's home
+// directory. We redirect HOME (and USERPROFILE on Windows) to a temp
+// dir and seed the canonical layout so the test never reads the
+// developer's real install.
+func TestExtract_FileModeDefaultPath(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	t.Setenv("USERPROFILE", home) // Windows home resolution
+
+	want := []byte(`{"auth_mode":"chatgpt","tokens":{"refresh_token":"r"}}`)
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Extract(AgentCodex, Options{})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Extract = %q, want %q", got, want)
+	}
+}

--- a/internal/launch/hostimport/hostimport.go
+++ b/internal/launch/hostimport/hostimport.go
@@ -1,0 +1,120 @@
+// Package hostimport reads an already-authenticated host install's
+// credential state for a supported coding agent so the bytes can be
+// seeded into the Aileron vault.
+//
+// The package is the extraction half of `aileron auth <agent>
+// --import-from-host` (issue #986). It resolves the raw credential
+// bytes for an agent from whichever host location that agent's CLI
+// writes — a file under the user's home directory on Linux/Windows, or
+// the macOS Keychain via `security find-generic-password`. It performs
+// no validation of the envelope: the caller validates by running the
+// bytes through the agent's AuthSpec FileBinding Capture, which is the
+// same validation the launcher performs on a clean-exit capture. This
+// keeps the validation logic in one place (the agent definitions) and
+// makes hostimport a pure byte-extraction surface.
+//
+// The package is split across build-tagged files so the macOS Keychain
+// shell-out (keychain_darwin.go) and the Linux/Windows file read
+// (file_other.go) each live where they compile and run. Platform-gated
+// CI jobs run the matching tests on the runner where the platform
+// exists; see .github/workflows/ci.yml.
+//
+// Extraction matrix (authoritative; ADR-0025):
+//
+//	Claude — Linux:    ~/.claude/.credentials.json
+//	         macOS:    security -s "Claude Code-credentials" -w
+//	         Windows:  %USERPROFILE%\.claude\.credentials.json
+//	Codex  — Linux:    ~/.codex/auth.json
+//	         macOS:    ~/.codex/auth.json (preferred), else "Codex Auth" keyring
+//	         Windows:  %USERPROFILE%\.codex\auth.json
+//
+// The Linux keyring (libsecret/secret-tool) path is deliberately
+// unsupported in v1: it returns ErrLinuxKeyringUnsupported naming the
+// file-mode and interactive-login recovery paths.
+package hostimport
+
+import (
+	"errors"
+	"fmt"
+)
+
+// Agent identifiers hostimport recognizes. Only these two have a host
+// install whose credential state hostimport knows how to read; every
+// other registry agent is rejected with ErrUnsupportedAgent.
+const (
+	AgentClaude = "claude"
+	AgentCodex  = "codex"
+)
+
+// Default keychain/service names the macOS `security` shell-out queries.
+// They mirror the service names Claude Code and Codex CLI register their
+// generic-password items under. Tests override them via Options so reads
+// never touch the operator's real Keychain items.
+const (
+	// DefaultClaudeKeychainService is the generic-password service name
+	// Claude Code stores its credentials under on macOS.
+	DefaultClaudeKeychainService = "Claude Code-credentials"
+	// DefaultCodexKeychainService is the generic-password service name
+	// Codex CLI stores its credentials under on macOS keyring mode.
+	DefaultCodexKeychainService = "Codex Auth"
+)
+
+// ErrUnsupportedAgent is returned by Extract when the agent name is not
+// claude or codex. Other registry agents (goose, opencode, pi) have no
+// host-import support in v1.
+var ErrUnsupportedAgent = errors.New("hostimport: agent does not support host import")
+
+// ErrNotAuthenticated is returned when the host install has no usable
+// credential state: the credential file is absent or empty, or the
+// macOS Keychain item does not exist. The CLI surfaces this with the
+// in-container interactive-login recovery path.
+var ErrNotAuthenticated = errors.New("hostimport: host install is not authenticated")
+
+// ErrLinuxKeyringUnsupported is returned when a Linux host stores the
+// agent credential in a keyring (libsecret/secret-tool) rather than the
+// file location hostimport reads. v1 does not implement keyring
+// extraction; the error names the file-mode and interactive-login
+// recovery paths.
+var ErrLinuxKeyringUnsupported = errors.New("hostimport: Linux keyring extraction is not supported in v1; use file mode (re-run the agent's login so it writes the credential file) or interactive in-container login (aileron launch <agent> --sandbox=docker)")
+
+// Options carries the test seams that let extraction target fixtures
+// instead of the operator's real host install. Production callers pass
+// the zero value, which resolves the real default file paths and
+// keychain service names.
+type Options struct {
+	// FilePathOverride, when non-empty, is the exact path the file-mode
+	// extractor reads instead of the agent's default
+	// (~/.claude/.credentials.json or ~/.codex/auth.json). Tests point
+	// this at a fixture under t.TempDir().
+	FilePathOverride string
+
+	// KeychainService, when non-empty, overrides the macOS Keychain
+	// service name the `security` shell-out queries. Tests set this to a
+	// throwaway service so reads never touch the real Claude/Codex items.
+	KeychainService string
+
+	// KeychainPath, when non-empty, appends a keychain argument to the
+	// `security` invocation so reads target a throwaway test keychain
+	// rather than the user's login keychain. Production leaves this
+	// empty (security searches the default search list).
+	KeychainPath string
+}
+
+// Extract reads the raw host credential bytes for the given agent. It
+// returns the bytes verbatim with no validation or munging; the caller
+// validates by running them through the agent's Capture. The agent must
+// be AgentClaude or AgentCodex; any other name returns ErrUnsupportedAgent.
+//
+// The concrete extraction is platform-specific: on macOS it shells out
+// to `security` (with a file-mode fallback for Codex); on Linux/Windows
+// it reads the credential file. A missing/empty source maps to
+// ErrNotAuthenticated.
+func Extract(agent string, opts Options) ([]byte, error) {
+	switch agent {
+	case AgentClaude, AgentCodex:
+		return extract(agent, opts)
+	default:
+		return nil, fmt.Errorf("%w: %q (supported: %s, %s)",
+			ErrUnsupportedAgent, agent, AgentClaude, AgentCodex)
+	}
+}

--- a/internal/launch/hostimport/hostimport_test.go
+++ b/internal/launch/hostimport/hostimport_test.go
@@ -1,0 +1,58 @@
+package hostimport
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// TestExtract_UnknownAgentRejected pins the contract that only claude
+// and codex are supported; every other registry agent is rejected with
+// ErrUnsupportedAgent before any host read happens.
+func TestExtract_UnknownAgentRejected(t *testing.T) {
+	for _, agent := range []string{"goose", "opencode", "pi", "", "Claude", "CODEX"} {
+		_, err := Extract(agent, Options{})
+		if !errors.Is(err, ErrUnsupportedAgent) {
+			t.Errorf("Extract(%q): err = %v, want ErrUnsupportedAgent", agent, err)
+		}
+	}
+}
+
+// TestErrLinuxKeyringUnsupported_NamesRecovery pins that the deferral
+// sentinel's message names both recovery paths (file mode + interactive
+// in-container login) so the CLI can surface it verbatim.
+func TestErrLinuxKeyringUnsupported_NamesRecovery(t *testing.T) {
+	msg := ErrLinuxKeyringUnsupported.Error()
+	if !strings.Contains(msg, "file mode") {
+		t.Errorf("ErrLinuxKeyringUnsupported = %q, want it to name file mode", msg)
+	}
+	if !strings.Contains(msg, "--sandbox=docker") {
+		t.Errorf("ErrLinuxKeyringUnsupported = %q, want it to name interactive in-container login", msg)
+	}
+}
+
+// TestErrNotAuthenticated_Distinct guards that the sentinels are
+// distinct errors, so callers can branch on them independently.
+func TestErrNotAuthenticated_Distinct(t *testing.T) {
+	if errors.Is(ErrNotAuthenticated, ErrUnsupportedAgent) ||
+		errors.Is(ErrUnsupportedAgent, ErrLinuxKeyringUnsupported) ||
+		errors.Is(ErrNotAuthenticated, ErrLinuxKeyringUnsupported) {
+		t.Fatal("sentinels must be distinct errors")
+	}
+}
+
+// TestExtract_SupportedAgentsReadHost confirms the supported agents
+// reach the platform extractor. With no real host install and no
+// fixture override, the extractor surfaces ErrNotAuthenticated (file
+// absent / keychain item missing) rather than ErrUnsupportedAgent. The
+// override points at a guaranteed-absent path so the test does not
+// depend on the developer's actual ~/.claude or ~/.codex.
+func TestExtract_SupportedAgentsReadHost(t *testing.T) {
+	missing := t.TempDir() + "/does-not-exist.json"
+	for _, agent := range []string{AgentClaude, AgentCodex} {
+		_, err := Extract(agent, Options{FilePathOverride: missing})
+		if !errors.Is(err, ErrNotAuthenticated) {
+			t.Errorf("Extract(%q, missing override): err = %v, want ErrNotAuthenticated", agent, err)
+		}
+	}
+}

--- a/internal/launch/hostimport/keychain.go
+++ b/internal/launch/hostimport/keychain.go
@@ -24,9 +24,37 @@ func runSecurity(args ...string) ([]byte, error) {
 	cmd.Stdout = &stdout
 	cmd.Stderr = &stderr
 	if err := cmd.Run(); err != nil {
+		// Surface the captured stderr on the ExitError so callers can
+		// distinguish "item not found" from other access failures.
+		// cmd.Run leaves ExitError.Stderr nil when cmd.Stderr is set, so
+		// we attach it here.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			exitErr.Stderr = stderr.Bytes()
+		}
 		return nil, err
 	}
 	return stdout.Bytes(), nil
+}
+
+// keychainItemNotFoundExit is the exit code `security
+// find-generic-password` returns when the requested item does not exist
+// (errSecItemNotFound surfaces as exit 44). It is the single exit code
+// that means "the credential is simply absent" as opposed to a real
+// keychain access failure.
+const keychainItemNotFoundExit = 44
+
+// isKeychainItemNotFound reports whether a `security` ExitError means
+// the item was absent (exit 44) rather than a genuine access failure
+// such as a locked keychain or permission denial. It also accepts the
+// "could not be found" stderr substring when present, so a future
+// security release that changes the exit code still maps a clear
+// not-found message to ErrNotAuthenticated.
+func isKeychainItemNotFound(exitErr *exec.ExitError) bool {
+	if exitErr.ExitCode() == keychainItemNotFoundExit {
+		return true
+	}
+	return bytes.Contains(exitErr.Stderr, []byte("could not be found"))
 }
 
 // readKeychain reads a generic-password item's bytes via the injected
@@ -48,11 +76,14 @@ func readKeychain(service, keychainPath string) ([]byte, error) {
 	}
 	out, err := securityRunner(args...)
 	if err != nil {
-		// security exits non-zero when the item is absent. Treat any
-		// non-zero exit as "no usable credential" so the caller surfaces
-		// the recovery path rather than a raw exec error.
+		// `security` exits 44 ("could not be found") when the item is
+		// absent; that is the only case that means "not authenticated".
+		// Other non-zero exits (locked keychain, permission denied,
+		// corrupted database) are real failures the operator must see,
+		// so they propagate with the security stderr rather than being
+		// masked as a missing credential.
 		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
+		if errors.As(err, &exitErr) && isKeychainItemNotFound(exitErr) {
 			return nil, ErrNotAuthenticated
 		}
 		return nil, err

--- a/internal/launch/hostimport/keychain.go
+++ b/internal/launch/hostimport/keychain.go
@@ -1,0 +1,65 @@
+package hostimport
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+)
+
+// securityRunner runs the macOS `security` tool and returns its stdout.
+// It is a package var so tests on every platform can stub the
+// shell-out and exercise the output-parsing logic in readKeychain
+// without a real Keychain (the GitHub macOS runner cannot grant the
+// non-interactive Keychain access these reads require). Production binds
+// it to runSecurity, which execs /usr/bin/security.
+var securityRunner = runSecurity
+
+// runSecurity execs `/usr/bin/security <args...>` and returns its
+// stdout. A non-zero exit (the item is absent: security exits 44,
+// "could not be found") is reported as an error the caller maps to
+// ErrNotAuthenticated.
+func runSecurity(args ...string) ([]byte, error) {
+	cmd := exec.Command("/usr/bin/security", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, err
+	}
+	return stdout.Bytes(), nil
+}
+
+// readKeychain reads a generic-password item's bytes via the injected
+// securityRunner. keychainPath, when non-empty, is appended so the read
+// targets a throwaway test keychain rather than the login keychain.
+//
+// The `-w` flag prints the password followed by a single trailing
+// newline; that newline is trimmed so the stored credential bytes are
+// exact. A non-zero `security` exit (absent item) maps to
+// ErrNotAuthenticated, as does an empty password.
+//
+// readKeychain has no build tag so the parsing/error-mapping logic is
+// unit-testable on every platform through the securityRunner seam; the
+// real exec (runSecurity) only ever fires on darwin via keychain_darwin.go.
+func readKeychain(service, keychainPath string) ([]byte, error) {
+	args := []string{"find-generic-password", "-s", service, "-w"}
+	if keychainPath != "" {
+		args = append(args, keychainPath)
+	}
+	out, err := securityRunner(args...)
+	if err != nil {
+		// security exits non-zero when the item is absent. Treat any
+		// non-zero exit as "no usable credential" so the caller surfaces
+		// the recovery path rather than a raw exec error.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, ErrNotAuthenticated
+		}
+		return nil, err
+	}
+	trimmed := bytes.TrimSuffix(out, []byte("\n"))
+	if len(trimmed) == 0 {
+		return nil, ErrNotAuthenticated
+	}
+	return trimmed, nil
+}

--- a/internal/launch/hostimport/keychain_darwin.go
+++ b/internal/launch/hostimport/keychain_darwin.go
@@ -3,9 +3,7 @@
 package hostimport
 
 import (
-	"bytes"
 	"errors"
-	"os/exec"
 )
 
 // extract resolves the host credential bytes on macOS.
@@ -66,44 +64,4 @@ func extract(agent string, opts Options) ([]byte, error) {
 	default:
 		return nil, ErrNotAuthenticated
 	}
-}
-
-// readKeychain shells out to `security find-generic-password -s
-// <service> -w` to read a generic-password item's password bytes. When
-// keychainPath is non-empty it is appended so the read targets a
-// throwaway test keychain rather than the login keychain.
-//
-// The -w flag prints the password followed by a trailing newline; the
-// stored credential bytes must not carry that newline, so it is
-// trimmed. A missing item exits non-zero (the password "could not be
-// found"); that maps to ErrNotAuthenticated. An empty password maps to
-// ErrNotAuthenticated for the same reason a zero-byte file does.
-func readKeychain(service, keychainPath string) ([]byte, error) {
-	args := []string{"find-generic-password", "-s", service, "-w"}
-	if keychainPath != "" {
-		args = append(args, keychainPath)
-	}
-	cmd := exec.Command("/usr/bin/security", args...)
-	var stdout, stderr bytes.Buffer
-	cmd.Stdout = &stdout
-	cmd.Stderr = &stderr
-	if err := cmd.Run(); err != nil {
-		// security exits non-zero when the item is absent (exit 44,
-		// "could not be found"). Treat any non-zero exit as "no usable
-		// credential" so the caller surfaces the recovery path rather
-		// than a raw exec error.
-		var exitErr *exec.ExitError
-		if errors.As(err, &exitErr) {
-			return nil, ErrNotAuthenticated
-		}
-		return nil, err
-	}
-	// -w appends a single trailing newline after the password. Trim only
-	// that trailing newline; the credential JSON itself never ends in a
-	// bare \n the keychain added, and inner newlines are preserved.
-	out := bytes.TrimSuffix(stdout.Bytes(), []byte("\n"))
-	if len(out) == 0 {
-		return nil, ErrNotAuthenticated
-	}
-	return out, nil
 }

--- a/internal/launch/hostimport/keychain_darwin.go
+++ b/internal/launch/hostimport/keychain_darwin.go
@@ -1,0 +1,101 @@
+//go:build darwin
+
+package hostimport
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+)
+
+// extract resolves the host credential bytes on macOS.
+//
+// Claude is keychain-only: Claude Code stores .credentials.json content
+// in the macOS Keychain under the "Claude Code-credentials" service, so
+// hostimport reads it with `security find-generic-password -w`.
+//
+// Codex supports both modes. The Codex CLI writes ~/.codex/auth.json in
+// the common case, and only falls back to the Keychain ("Codex Auth"
+// service) when configured for keyring storage. hostimport prefers the
+// file when it exists (it is the cheaper, non-interactive read) and
+// falls back to the Keychain otherwise. A FilePathOverride forces the
+// file path regardless of agent.
+//
+// The first real Keychain read prompts the user with a macOS access
+// dialog; the operator approves it once. Tests never hit that dialog:
+// they point KeychainPath at a throwaway keychain pre-populated with
+// set-key-partition-list so the read is non-interactive.
+func extract(agent string, opts Options) ([]byte, error) {
+	if opts.FilePathOverride != "" {
+		return readCredentialFile(opts.FilePathOverride)
+	}
+
+	switch agent {
+	case AgentClaude:
+		service := opts.KeychainService
+		if service == "" {
+			service = DefaultClaudeKeychainService
+		}
+		return readKeychain(service, opts.KeychainPath)
+	case AgentCodex:
+		// Prefer the file when the Codex CLI wrote one; fall back to the
+		// keyring service only when the file is absent.
+		path, err := defaultCredentialPath(agent)
+		if err != nil {
+			return nil, err
+		}
+		if path != "" {
+			if _, statErr := os.Stat(path); statErr == nil {
+				return readCredentialFile(path)
+			}
+		}
+		service := opts.KeychainService
+		if service == "" {
+			service = DefaultCodexKeychainService
+		}
+		return readKeychain(service, opts.KeychainPath)
+	default:
+		return nil, ErrNotAuthenticated
+	}
+}
+
+// readKeychain shells out to `security find-generic-password -s
+// <service> -w` to read a generic-password item's password bytes. When
+// keychainPath is non-empty it is appended so the read targets a
+// throwaway test keychain rather than the login keychain.
+//
+// The -w flag prints the password followed by a trailing newline; the
+// stored credential bytes must not carry that newline, so it is
+// trimmed. A missing item exits non-zero (the password "could not be
+// found"); that maps to ErrNotAuthenticated. An empty password maps to
+// ErrNotAuthenticated for the same reason a zero-byte file does.
+func readKeychain(service, keychainPath string) ([]byte, error) {
+	args := []string{"find-generic-password", "-s", service, "-w"}
+	if keychainPath != "" {
+		args = append(args, keychainPath)
+	}
+	cmd := exec.Command("/usr/bin/security", args...)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		// security exits non-zero when the item is absent (exit 44,
+		// "could not be found"). Treat any non-zero exit as "no usable
+		// credential" so the caller surfaces the recovery path rather
+		// than a raw exec error.
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil, ErrNotAuthenticated
+		}
+		return nil, err
+	}
+	// -w appends a single trailing newline after the password. Trim only
+	// that trailing newline; the credential JSON itself never ends in a
+	// bare \n the keychain added, and inner newlines are preserved.
+	out := bytes.TrimSuffix(stdout.Bytes(), []byte("\n"))
+	if len(out) == 0 {
+		return nil, ErrNotAuthenticated
+	}
+	return out, nil
+}

--- a/internal/launch/hostimport/keychain_darwin.go
+++ b/internal/launch/hostimport/keychain_darwin.go
@@ -5,7 +5,6 @@ package hostimport
 import (
 	"bytes"
 	"errors"
-	"os"
 	"os/exec"
 )
 
@@ -40,14 +39,23 @@ func extract(agent string, opts Options) ([]byte, error) {
 		return readKeychain(service, opts.KeychainPath)
 	case AgentCodex:
 		// Prefer the file when the Codex CLI wrote one; fall back to the
-		// keyring service only when the file is absent.
+		// keyring service only when the file is absent. Read directly
+		// rather than stat-then-read so a file that exists but is
+		// unreadable surfaces its real error instead of silently falling
+		// back to the keychain (and so there is no TOCTOU window).
 		path, err := defaultCredentialPath(agent)
 		if err != nil {
 			return nil, err
 		}
 		if path != "" {
-			if _, statErr := os.Stat(path); statErr == nil {
-				return readCredentialFile(path)
+			data, readErr := readCredentialFile(path)
+			if readErr == nil {
+				return data, nil
+			}
+			// Only the absent/empty case (ErrNotAuthenticated) falls
+			// through to the keychain; any other read error propagates.
+			if !errors.Is(readErr, ErrNotAuthenticated) {
+				return nil, readErr
 			}
 		}
 		service := opts.KeychainService

--- a/internal/launch/hostimport/keychain_darwin_test.go
+++ b/internal/launch/hostimport/keychain_darwin_test.go
@@ -73,6 +73,61 @@ func TestExtract_KeychainReturnsBytes(t *testing.T) {
 	}
 }
 
+// TestExtract_ClaudeDefaultServiceName exercises the default-service
+// branch: when Options.KeychainService is empty, Claude reads the
+// DefaultClaudeKeychainService name. The read still targets the
+// throwaway keychain (KeychainPath set), so the real login-keychain
+// item is never touched — we seed the throwaway keychain under the
+// default service name.
+func TestExtract_ClaudeDefaultServiceName(t *testing.T) {
+	keychain := newTestKeychain(t)
+	want := []byte(`{"claudeAiOauth":{"accessToken":"tok"}}`)
+	addGenericPassword(t, keychain, DefaultClaudeKeychainService, want)
+
+	got, err := Extract(AgentClaude, Options{KeychainPath: keychain})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Extract = %q, want %q", got, want)
+	}
+}
+
+// TestExtract_CodexDefaultServiceName exercises the Codex
+// default-service branch the same way, with an empty HOME so the file
+// is absent and the keyring fallback fires.
+func TestExtract_CodexDefaultServiceName(t *testing.T) {
+	t.Setenv("HOME", t.TempDir()) // no ~/.codex/auth.json
+	keychain := newTestKeychain(t)
+	want := []byte(`{"auth_mode":"chatgpt","tokens":{"refresh_token":"r"}}`)
+	addGenericPassword(t, keychain, DefaultCodexKeychainService, want)
+
+	got, err := Extract(AgentCodex, Options{KeychainPath: keychain})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Extract = %q, want %q", got, want)
+	}
+}
+
+// TestExtract_KeychainEmptyPassword maps a stored-but-empty keychain
+// item to ErrNotAuthenticated, covering the empty-output guard in
+// readKeychain.
+func TestExtract_KeychainEmptyPassword(t *testing.T) {
+	keychain := newTestKeychain(t)
+	const service = "hostimport-test-empty"
+	addGenericPassword(t, keychain, service, []byte(""))
+
+	_, err := Extract(AgentClaude, Options{
+		KeychainService: service,
+		KeychainPath:    keychain,
+	})
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("Extract(empty password): err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
 // TestExtract_KeychainMissingItem maps an absent keychain item to
 // ErrNotAuthenticated.
 func TestExtract_KeychainMissingItem(t *testing.T) {

--- a/internal/launch/hostimport/keychain_darwin_test.go
+++ b/internal/launch/hostimport/keychain_darwin_test.go
@@ -1,0 +1,137 @@
+//go:build darwin
+
+package hostimport
+
+import (
+	"bytes"
+	"errors"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"testing"
+)
+
+// newTestKeychain creates a throwaway, password-protected keychain
+// under t.TempDir(), unlocks it, and registers cleanup. The real
+// "Claude Code-credentials" / "Codex Auth" items in the user's login
+// keychain are never touched: every read in this file targets this
+// throwaway keychain via Options.KeychainPath.
+func newTestKeychain(t *testing.T) string {
+	t.Helper()
+	if _, err := exec.LookPath("/usr/bin/security"); err != nil {
+		t.Skipf("/usr/bin/security unavailable: %v", err)
+	}
+	path := filepath.Join(t.TempDir(), "hostimport-test.keychain-db")
+	const pw = "hostimport-test"
+	if out, err := exec.Command("/usr/bin/security", "create-keychain", "-p", pw, path).CombinedOutput(); err != nil {
+		t.Skipf("create-keychain: %v: %s", err, out)
+	}
+	t.Cleanup(func() {
+		_ = exec.Command("/usr/bin/security", "delete-keychain", path).Run()
+	})
+	if out, err := exec.Command("/usr/bin/security", "unlock-keychain", "-p", pw, path).CombinedOutput(); err != nil {
+		t.Fatalf("unlock-keychain: %v: %s", err, out)
+	}
+	return path
+}
+
+// addGenericPassword stores fixture bytes under a service in the test
+// keychain and makes the read non-interactive via set-key-partition-list
+// so cmd.Run() does not block on a Keychain access dialog in CI.
+func addGenericPassword(t *testing.T, keychain, service string, value []byte) {
+	t.Helper()
+	const pw = "hostimport-test"
+	if out, err := exec.Command("/usr/bin/security", "add-generic-password",
+		"-a", "hostimport", "-s", service, "-w", string(value), keychain).CombinedOutput(); err != nil {
+		t.Fatalf("add-generic-password: %v: %s", err, out)
+	}
+	// Allow the security tool itself to read the item without prompting.
+	if out, err := exec.Command("/usr/bin/security", "set-key-partition-list",
+		"-S", "apple-tool:,apple:", "-s", "-k", pw, keychain).CombinedOutput(); err != nil {
+		t.Skipf("set-key-partition-list (non-interactive read unavailable): %v: %s", err, out)
+	}
+}
+
+// TestExtract_KeychainReturnsBytes confirms Claude's macOS path reads
+// the generic-password item via `security -w` and returns the stored
+// bytes with the -w trailing newline trimmed.
+func TestExtract_KeychainReturnsBytes(t *testing.T) {
+	keychain := newTestKeychain(t)
+	const service = "hostimport-test-claude"
+	want := []byte(`{"claudeAiOauth":{"accessToken":"tok"}}`)
+	addGenericPassword(t, keychain, service, want)
+
+	got, err := Extract(AgentClaude, Options{
+		KeychainService: service,
+		KeychainPath:    keychain,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Extract = %q, want %q (no trailing newline)", got, want)
+	}
+}
+
+// TestExtract_KeychainMissingItem maps an absent keychain item to
+// ErrNotAuthenticated.
+func TestExtract_KeychainMissingItem(t *testing.T) {
+	keychain := newTestKeychain(t)
+	_, err := Extract(AgentClaude, Options{
+		KeychainService: "hostimport-test-absent",
+		KeychainPath:    keychain,
+	})
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("Extract(missing item): err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+// TestExtract_CodexPrefersFileOverKeychain confirms the Codex macOS
+// precedence: when ~/.codex/auth.json exists, the file wins over the
+// keyring. We redirect HOME to a temp dir, seed the file, and assert
+// the file bytes come back even though no keychain item is registered.
+func TestExtract_CodexPrefersFileOverKeychain(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	want := []byte(`{"auth_mode":"chatgpt","tokens":{"refresh_token":"r"}}`)
+	codexDir := filepath.Join(home, ".codex")
+	if err := os.MkdirAll(codexDir, 0o700); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(codexDir, "auth.json"), want, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := Extract(AgentCodex, Options{
+		KeychainService: "hostimport-test-absent",
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Extract = %q, want file bytes %q", got, want)
+	}
+}
+
+// TestExtract_CodexFallsBackToKeychain confirms that when no
+// ~/.codex/auth.json exists, the Codex macOS path falls back to the
+// keyring service.
+func TestExtract_CodexFallsBackToKeychain(t *testing.T) {
+	home := t.TempDir() // empty home: no ~/.codex/auth.json
+	t.Setenv("HOME", home)
+	keychain := newTestKeychain(t)
+	const service = "hostimport-test-codex"
+	want := []byte(`{"auth_mode":"chatgpt","tokens":{"refresh_token":"r"}}`)
+	addGenericPassword(t, keychain, service, want)
+
+	got, err := Extract(AgentCodex, Options{
+		KeychainService: service,
+		KeychainPath:    keychain,
+	})
+	if err != nil {
+		t.Fatalf("Extract: %v", err)
+	}
+	if !bytes.Equal(got, want) {
+		t.Errorf("Extract = %q, want %q", got, want)
+	}
+}

--- a/internal/launch/hostimport/keychain_test.go
+++ b/internal/launch/hostimport/keychain_test.go
@@ -1,0 +1,113 @@
+package hostimport
+
+import (
+	"bytes"
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+// stubSecurity swaps securityRunner for the duration of a test and
+// restores it afterward, so the keychain output-parsing logic can be
+// exercised on every platform without a real macOS Keychain (the CI
+// macOS runner cannot grant the non-interactive Keychain access a real
+// read requires).
+func stubSecurity(t *testing.T, fn func(args ...string) ([]byte, error)) {
+	t.Helper()
+	prev := securityRunner
+	securityRunner = fn
+	t.Cleanup(func() { securityRunner = prev })
+}
+
+// TestReadKeychain_TrimsTrailingNewline confirms the single trailing
+// newline `security -w` appends is stripped while inner bytes are
+// preserved verbatim.
+func TestReadKeychain_TrimsTrailingNewline(t *testing.T) {
+	payload := []byte(`{"claudeAiOauth":{"accessToken":"tok"}}`)
+	var gotArgs []string
+	stubSecurity(t, func(args ...string) ([]byte, error) {
+		gotArgs = args
+		return append(append([]byte{}, payload...), '\n'), nil
+	})
+
+	got, err := readKeychain("svc", "")
+	if err != nil {
+		t.Fatalf("readKeychain: %v", err)
+	}
+	if !bytes.Equal(got, payload) {
+		t.Errorf("readKeychain = %q, want %q (one trailing \\n trimmed)", got, payload)
+	}
+	want := []string{"find-generic-password", "-s", "svc", "-w"}
+	if len(gotArgs) != len(want) {
+		t.Fatalf("args = %v, want %v", gotArgs, want)
+	}
+	for i := range want {
+		if gotArgs[i] != want[i] {
+			t.Fatalf("args = %v, want %v", gotArgs, want)
+		}
+	}
+}
+
+// TestReadKeychain_AppendsKeychainPath confirms a non-empty keychain
+// path is appended so reads target a throwaway keychain.
+func TestReadKeychain_AppendsKeychainPath(t *testing.T) {
+	var gotArgs []string
+	stubSecurity(t, func(args ...string) ([]byte, error) {
+		gotArgs = args
+		return []byte("x\n"), nil
+	})
+	if _, err := readKeychain("svc", "/tmp/test.keychain"); err != nil {
+		t.Fatalf("readKeychain: %v", err)
+	}
+	if len(gotArgs) == 0 || gotArgs[len(gotArgs)-1] != "/tmp/test.keychain" {
+		t.Errorf("args = %v, want keychain path appended last", gotArgs)
+	}
+}
+
+// TestReadKeychain_NonZeroExitIsNotAuthenticated maps a `security`
+// non-zero exit (absent item) to ErrNotAuthenticated.
+func TestReadKeychain_NonZeroExitIsNotAuthenticated(t *testing.T) {
+	// A real *exec.ExitError from a guaranteed-failing command.
+	exitErr := exec.Command("/usr/bin/false").Run()
+	if exitErr == nil {
+		// /usr/bin/false missing (unusual); synthesize via a command
+		// that exits non-zero.
+		exitErr = exec.Command("/bin/sh", "-c", "exit 44").Run()
+	}
+	stubSecurity(t, func(args ...string) ([]byte, error) {
+		return nil, exitErr
+	})
+	_, err := readKeychain("svc", "")
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("readKeychain (exit err): err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+// TestReadKeychain_NonExitErrorPropagates confirms a non-exit error
+// (e.g. the security binary missing) propagates rather than being
+// masked as ErrNotAuthenticated.
+func TestReadKeychain_NonExitErrorPropagates(t *testing.T) {
+	sentinel := errors.New("exec failed: file not found")
+	stubSecurity(t, func(args ...string) ([]byte, error) {
+		return nil, sentinel
+	})
+	_, err := readKeychain("svc", "")
+	if !errors.Is(err, sentinel) {
+		t.Errorf("readKeychain = %v, want the wrapped exec error", err)
+	}
+	if errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("readKeychain masked a non-exit error as ErrNotAuthenticated")
+	}
+}
+
+// TestReadKeychain_EmptyOutputIsNotAuthenticated maps an empty (or
+// newline-only) password to ErrNotAuthenticated.
+func TestReadKeychain_EmptyOutputIsNotAuthenticated(t *testing.T) {
+	stubSecurity(t, func(args ...string) ([]byte, error) {
+		return []byte("\n"), nil
+	})
+	_, err := readKeychain("svc", "")
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("readKeychain (empty): err = %v, want ErrNotAuthenticated", err)
+	}
+}

--- a/internal/launch/hostimport/keychain_test.go
+++ b/internal/launch/hostimport/keychain_test.go
@@ -5,26 +5,27 @@ import (
 	"errors"
 	"os/exec"
 	"runtime"
+	"strconv"
 	"testing"
 )
 
-// nonZeroExitError returns a real *exec.ExitError from a command that
-// exits non-zero, portably across Unix and Windows. readKeychain maps
-// such errors to ErrNotAuthenticated.
-func nonZeroExitError(t *testing.T) error {
+// exitWithCode returns a real *exec.ExitError for the given exit code,
+// portably across Unix and Windows, so tests can drive readKeychain's
+// exit-code branch without a real `security` binary.
+func exitWithCode(t *testing.T, code int) *exec.ExitError {
 	t.Helper()
 	var cmd *exec.Cmd
 	if runtime.GOOS == "windows" {
-		cmd = exec.Command("cmd", "/c", "exit 44")
+		cmd = exec.Command("cmd", "/c", "exit "+strconv.Itoa(code))
 	} else {
-		cmd = exec.Command("sh", "-c", "exit 44")
+		cmd = exec.Command("sh", "-c", "exit "+strconv.Itoa(code))
 	}
 	err := cmd.Run()
 	var exitErr *exec.ExitError
 	if !errors.As(err, &exitErr) {
 		t.Skipf("could not produce an *exec.ExitError on %s: %v", runtime.GOOS, err)
 	}
-	return err
+	return exitErr
 }
 
 // stubSecurity swaps securityRunner for the duration of a test and
@@ -84,16 +85,49 @@ func TestReadKeychain_AppendsKeychainPath(t *testing.T) {
 	}
 }
 
-// TestReadKeychain_NonZeroExitIsNotAuthenticated maps a `security`
-// non-zero exit (absent item) to ErrNotAuthenticated.
-func TestReadKeychain_NonZeroExitIsNotAuthenticated(t *testing.T) {
-	exitErr := nonZeroExitError(t)
+// TestReadKeychain_ItemNotFoundIsNotAuthenticated maps the absent-item
+// exit code (44) to ErrNotAuthenticated.
+func TestReadKeychain_ItemNotFoundIsNotAuthenticated(t *testing.T) {
+	exitErr := exitWithCode(t, keychainItemNotFoundExit)
 	stubSecurity(t, func(args ...string) ([]byte, error) {
 		return nil, exitErr
 	})
 	_, err := readKeychain("svc", "")
 	if !errors.Is(err, ErrNotAuthenticated) {
-		t.Errorf("readKeychain (exit err): err = %v, want ErrNotAuthenticated", err)
+		t.Errorf("readKeychain (exit 44): err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+// TestReadKeychain_NotFoundStderrIsNotAuthenticated maps a non-44 exit
+// whose stderr says the item "could not be found" to ErrNotAuthenticated,
+// covering the stderr-substring fallback.
+func TestReadKeychain_NotFoundStderrIsNotAuthenticated(t *testing.T) {
+	exitErr := exitWithCode(t, 1)
+	exitErr.Stderr = []byte("security: SecKeychainSearchCopyNext: The specified item could not be found in the keychain.")
+	stubSecurity(t, func(args ...string) ([]byte, error) {
+		return nil, exitErr
+	})
+	_, err := readKeychain("svc", "")
+	if !errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("readKeychain (not-found stderr): err = %v, want ErrNotAuthenticated", err)
+	}
+}
+
+// TestReadKeychain_OtherExitPropagates confirms a non-44 exit without a
+// not-found stderr (e.g. a locked keychain or permission denial) is NOT
+// masked as ErrNotAuthenticated; the operator must see the real failure.
+func TestReadKeychain_OtherExitPropagates(t *testing.T) {
+	exitErr := exitWithCode(t, 51) // errSecInteractionNotAllowed-style failure
+	exitErr.Stderr = []byte("security: User interaction is not allowed.")
+	stubSecurity(t, func(args ...string) ([]byte, error) {
+		return nil, exitErr
+	})
+	_, err := readKeychain("svc", "")
+	if errors.Is(err, ErrNotAuthenticated) {
+		t.Errorf("readKeychain masked a non-not-found exit as ErrNotAuthenticated: %v", err)
+	}
+	if err == nil {
+		t.Error("readKeychain: want the real exit error, got nil")
 	}
 }
 

--- a/internal/launch/hostimport/keychain_test.go
+++ b/internal/launch/hostimport/keychain_test.go
@@ -4,8 +4,28 @@ import (
 	"bytes"
 	"errors"
 	"os/exec"
+	"runtime"
 	"testing"
 )
+
+// nonZeroExitError returns a real *exec.ExitError from a command that
+// exits non-zero, portably across Unix and Windows. readKeychain maps
+// such errors to ErrNotAuthenticated.
+func nonZeroExitError(t *testing.T) error {
+	t.Helper()
+	var cmd *exec.Cmd
+	if runtime.GOOS == "windows" {
+		cmd = exec.Command("cmd", "/c", "exit 44")
+	} else {
+		cmd = exec.Command("sh", "-c", "exit 44")
+	}
+	err := cmd.Run()
+	var exitErr *exec.ExitError
+	if !errors.As(err, &exitErr) {
+		t.Skipf("could not produce an *exec.ExitError on %s: %v", runtime.GOOS, err)
+	}
+	return err
+}
 
 // stubSecurity swaps securityRunner for the duration of a test and
 // restores it afterward, so the keychain output-parsing logic can be
@@ -67,13 +87,7 @@ func TestReadKeychain_AppendsKeychainPath(t *testing.T) {
 // TestReadKeychain_NonZeroExitIsNotAuthenticated maps a `security`
 // non-zero exit (absent item) to ErrNotAuthenticated.
 func TestReadKeychain_NonZeroExitIsNotAuthenticated(t *testing.T) {
-	// A real *exec.ExitError from a guaranteed-failing command.
-	exitErr := exec.Command("/usr/bin/false").Run()
-	if exitErr == nil {
-		// /usr/bin/false missing (unusual); synthesize via a command
-		// that exits non-zero.
-		exitErr = exec.Command("/bin/sh", "-c", "exit 44").Run()
-	}
+	exitErr := nonZeroExitError(t)
 	stubSecurity(t, func(args ...string) ([]byte, error) {
 		return nil, exitErr
 	})

--- a/internal/launch/hostimport/paths.go
+++ b/internal/launch/hostimport/paths.go
@@ -1,0 +1,56 @@
+package hostimport
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// defaultCredentialPath returns the host file path the agent's CLI
+// writes its credential to, resolved from the user's home directory.
+// os.UserHomeDir resolves $HOME on Linux/macOS and %USERPROFILE% on
+// Windows, so the same logic yields the right path on every OS.
+//
+// Claude:  ~/.claude/.credentials.json
+// Codex:   ~/.codex/auth.json
+//
+// The agent has already been validated as claude or codex by Extract,
+// so the default branch is unreachable in practice; it returns an empty
+// path which the caller maps to ErrNotAuthenticated.
+func defaultCredentialPath(agent string) (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", err
+	}
+	switch agent {
+	case AgentClaude:
+		return filepath.Join(home, ".claude", ".credentials.json"), nil
+	case AgentCodex:
+		return filepath.Join(home, ".codex", "auth.json"), nil
+	default:
+		return "", nil
+	}
+}
+
+// readCredentialFile reads the credential file at path verbatim. An
+// absent file or an empty file both map to ErrNotAuthenticated: a
+// zero-byte credential is as useless as a missing one and the recovery
+// path is identical. Any other read error (permission denied, IO
+// failure) is returned wrapped so the operator sees the underlying
+// cause.
+//
+// The bytes are returned whole-file with no trailing-newline munging,
+// mirroring runVaultPut's --from-file semantics: agent credential files
+// are exact-byte artifacts.
+func readCredentialFile(path string) ([]byte, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, ErrNotAuthenticated
+		}
+		return nil, err
+	}
+	if len(data) == 0 {
+		return nil, ErrNotAuthenticated
+	}
+	return data, nil
+}


### PR DESCRIPTION
## Summary

Adds the daemon-backed CLI verb `aileron auth <agent> --import-from-host` (#986). It reads an already-authenticated host `claude`/`codex` install, validates the credential envelope through the agent's existing `AuthSpec` FileBinding `Capture`, and PUTs it byte-verbatim to `agents/<name>/oauth` via the existing daemon endpoint `PUT /v1/vault/agents/{name}/credentials`. Operators who already ran `claude`/`codex` login on the host skip the per-machine in-container login.

- New platform-tagged package `internal/launch/hostimport` does the extraction with injectable seams (file-path + keychain-service/path overrides) so tests never touch the real install:
  - macOS (`keychain_darwin.go`): `security find-generic-password -s <service> -w`; Claude is keychain-only, Codex prefers `~/.codex/auth.json` then falls back to the `Codex Auth` keyring.
  - Linux/Windows (`file_other.go`): whole-file read of `~/.claude/.credentials.json` / `~/.codex/auth.json`, honoring `%USERPROFILE%` on Windows.
  - Linux keyring (libsecret) is a deliberate v1 stub returning `ErrLinuxKeyringUnsupported` with the file-mode + interactive-login recovery text.
- `cmd/aileron/auth.go` wires the verb: resolves the agent's `agents/<name>/oauth` FileBinding, extracts, validates via `Capture`, and maps the daemon `204/423/503/default` status codes exactly like `vault put`. Only `claude`/`codex` are accepted; other agents return a clear unsupported error.
- No OpenAPI/daemon changes: this is a new client of an existing endpoint, so no approval-gating/idempotency work.
- CI: the macOS and Windows jobs' test globs now include `./launch/hostimport/...` so the Keychain and `%USERPROFILE%` file-mode paths actually run on the matching runner. The ubuntu shards pick the package up automatically via `GO_TEST_PACKAGES`.
- Dev doc `sandbox-agent-auth.md` replaces the "intentionally not in v1" prose with the new command, the per-OS extraction matrix, the macOS Keychain access-dialog note, and the error/recovery UX.

## Test plan

- [x] `cd internal && go test -race ./launch/hostimport/...` (darwin local: keychain create/add/set-partition-list against a throwaway keychain, missing-item, codex file-vs-keyring precedence; never touches the real items).
- [x] `cd cmd/aileron && go test -race .` (full suite, darwin local). Claude file-fixture tests skip on darwin because Claude is keychain-only there; the ubuntu CI shard is authoritative for the Claude file-mode path. Codex-based daemon tests (happy/malformed/locked/no-vault) run on every OS.
- [x] `go vet` clean; cross-build + cross-vet for `GOOS=linux` and `GOOS=windows`.
- [x] `coderabbit review --base main` returned zero findings on this diff.
- [ ] Windows file-mode correctness is confirmed only by the `windows-latest` CI job (cannot be run on this macOS dev machine; simple file I/O, low risk).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a top-level CLI command to import existing host credentials for Claude and Codex (macOS Keychain + file-based on other platforms); CLI help updated.

* **Documentation**
  * Documented the auth-import workflow, platform-specific credential sources, supported agents, and recovery/error behaviors.

* **Tests**
  * Expanded cross-platform tests covering host-import, keychain/file reads, auth flows, and daemon error paths.

* **Chores**
  * CI updated to run expanded unit tests on macOS and Windows covering host-import paths.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->