### PR TITLE
feat(launch): chown AuthSpec bind-mount to image agent UID on Linux

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -519,6 +519,19 @@ jobs:
           AILERON_API_URL: http://localhost:8080
           AILERON_UI_BASE_URL: http://localhost:3000
 
+      - name: Run AuthSpec bind-mount writability integration test (#988)
+        # The ubuntu runner has rootful Docker, where the host operator's
+        # UID owns the transient AuthSpec dir but the container runs as the
+        # image's non-root agent user — the exact environment where the
+        # writable bind mount fails with EPERM without the chown-to-agent-
+        # UID fix. The test self-skips on non-Linux / no-Docker hosts, so
+        # this is the acceptance environment. Additive step so a failure is
+        # attributable to this specific contract.
+        run: go test -tags=integration_sandbox -run TestAuthSpecBindMountWritable ./launch/...
+        working-directory: internal
+        env:
+          AILERON_SANDBOX_BASE_CONTEXT: ${{ github.workspace }}/images/sandbox-base
+
       - name: Stop server to flush coverage data
         if: ${{ !cancelled() }}
         run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml stop server

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -375,6 +375,15 @@ tasks:
     cmds:
       - go test -tags=integration_sandbox -race -run TestSandboxMCP ./internal/app/...
 
+  test:integration:authspec-bindmount:
+    desc: "Run the AuthSpec bind-mount writability integration test on a Linux Docker host (#988); self-skips on non-Linux or when no Docker runtime is on PATH"
+    dir: internal
+    cmds:
+      - go test -tags=integration_sandbox -run TestAuthSpecBindMountWritable ./launch/...
+    env:
+      AILERON_SANDBOX_BASE_CONTEXT:
+        sh: cd "{{.ROOT_DIR}}/images/sandbox-base" && pwd
+
   test:e2e:integration:
     desc: Run Playwright E2E tests against running services
     dir: ui

--- a/internal/launch/agent_uid.go
+++ b/internal/launch/agent_uid.go
@@ -63,6 +63,15 @@ func resolveAgentUIDCached(ctx context.Context, runner sandboxcontainer.Runner, 
 // agent owns both the mounted parent directory and the rendered
 // credential files, enabling the in-container tmpfile+rename rotation
 // over the writable bind mount.
+//
+// Note on capture-on-exit: after the agent rotates a credential
+// in-container, the resulting file is owned by the agent UID regardless
+// of this hook (the agent writes it). The host-side capture read is
+// therefore subject to the same ownership on rootful Docker whether or
+// not this chown ran; the hook does not introduce a new capture-read
+// failure mode for rotated files. An un-rotated seed file chowned here
+// is at worst re-readable only by root/agent, but its capture would
+// merely re-PUT identical bytes, so a skipped read is harmless.
 func newAgentDirChownHook(ctx context.Context, runner sandboxcontainer.Runner, runtime, image string) func(dir string) error {
 	if goruntime.GOOS != "linux" {
 		return nil

--- a/internal/launch/agent_uid.go
+++ b/internal/launch/agent_uid.go
@@ -1,0 +1,192 @@
+package launch
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io/fs"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strconv"
+	"strings"
+	"sync"
+
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// agentUIDCacheKey identifies a resolved UID lookup by runtime+image so
+// repeated launches against the same image pay the inspect/run cost at
+// most once per process.
+type agentUIDCacheKey struct {
+	runtime string
+	image   string
+}
+
+var (
+	agentUIDCacheMu sync.Mutex
+	agentUIDCache   = map[agentUIDCacheKey]int{}
+)
+
+// resolveAgentUIDCached wraps resolveAgentUID with a per-process cache
+// keyed on (runtime, image). Only successful resolutions are cached; a
+// failed lookup is retried on the next launch.
+func resolveAgentUIDCached(ctx context.Context, runner sandboxcontainer.Runner, runtime, image string) (int, error) {
+	key := agentUIDCacheKey{runtime: runtime, image: image}
+	agentUIDCacheMu.Lock()
+	if uid, ok := agentUIDCache[key]; ok {
+		agentUIDCacheMu.Unlock()
+		return uid, nil
+	}
+	agentUIDCacheMu.Unlock()
+
+	uid, err := resolveAgentUID(ctx, runner, runtime, image)
+	if err != nil {
+		return 0, err
+	}
+	agentUIDCacheMu.Lock()
+	agentUIDCache[key] = uid
+	agentUIDCacheMu.Unlock()
+	return uid, nil
+}
+
+// newAgentDirChownHook returns the chownTransientDir hook prepareAuthSpec
+// invokes after rendering the transient auth directory. The hook only
+// performs work on Linux: the macOS/Windows Docker Desktop file-sharing
+// shim translates UIDs at the boundary, so a host-side os.Chown to a
+// foreign in-container UID would be both pointless and (for a non-root
+// host user) likely to fail. On non-Linux hosts the returned hook is
+// nil and prepareAuthSpec skips the chown entirely.
+//
+// On Linux the hook resolves the image's agent UID (cached per
+// runtime+image) and recursively chowns the transient tree to it so the
+// agent owns both the mounted parent directory and the rendered
+// credential files, enabling the in-container tmpfile+rename rotation
+// over the writable bind mount.
+func newAgentDirChownHook(ctx context.Context, runner sandboxcontainer.Runner, runtime, image string) func(dir string) error {
+	if goruntime.GOOS != "linux" {
+		return nil
+	}
+	// Without a concrete runtime+image the resolver cannot inspect the
+	// image; returning nil avoids emitting a spurious per-launch warning
+	// on the rare path where sandbox prep left them unset.
+	if strings.TrimSpace(runtime) == "" || strings.TrimSpace(image) == "" {
+		return nil
+	}
+	return func(dir string) error {
+		uid, err := resolveAgentUIDCached(ctx, runner, runtime, image)
+		if err != nil {
+			return err
+		}
+		// Root (UID 0) already owns files created by a rootful host
+		// process; the recursive walk would be a no-op, so skip it.
+		if uid == 0 {
+			return nil
+		}
+		return chownTree(dir, uid)
+	}
+}
+
+// chownTree recursively changes the owning UID of dir and everything
+// beneath it to uid, leaving the GID (-1) and file modes untouched. It
+// mirrors the placement of the existing 0700 chmod on the transient
+// root in prepareAuthSpec.
+func chownTree(dir string, uid int) error {
+	return filepath.WalkDir(dir, func(path string, _ fs.DirEntry, walkErr error) error {
+		if walkErr != nil {
+			return walkErr
+		}
+		if err := os.Chown(path, uid, -1); err != nil {
+			return fmt.Errorf("chown %s to uid %d: %w", path, uid, err)
+		}
+		return nil
+	})
+}
+
+// resolveAgentUID returns the numeric UID of the container image's
+// configured USER for the given runtime+image. The UID is derived from
+// the image at launch time rather than hardcoded: the sandbox-base
+// Containerfile creates the `agent` user with BusyBox `adduser -S`,
+// which assigns the UID dynamically, so we cannot assume a fixed value
+// (and Tier-1/Tier-2 BYO images may differ again).
+//
+// Resolution proceeds in two steps:
+//
+//  1. Inspect the image config's User directive
+//     (`<runtime> image inspect --format '{{.Config.User}}'`). An empty
+//     result means the image runs as root, so the UID is 0. A numeric
+//     spec (`1000` or `1000:1000`) is parsed directly.
+//
+//  2. A named user (e.g. `agent`) is resolved to its numeric UID by
+//     running the image once with `id -u <name>`, which honors the
+//     name→UID mapping recorded in the image's /etc/passwd.
+//
+// The caller is expected to cache the result per (runtime, image) so a
+// launch pays the lookup at most once.
+func resolveAgentUID(ctx context.Context, runner sandboxcontainer.Runner, runtime, image string) (int, error) {
+	if runner == nil {
+		return 0, fmt.Errorf("resolve agent uid: runner is required")
+	}
+	if strings.TrimSpace(runtime) == "" {
+		return 0, fmt.Errorf("resolve agent uid: runtime is required")
+	}
+	if strings.TrimSpace(image) == "" {
+		return 0, fmt.Errorf("resolve agent uid: image is required")
+	}
+
+	var inspectOut bytes.Buffer
+	if err := runner.Run(ctx, runtime,
+		[]string{"image", "inspect", "--format", "{{.Config.User}}", image},
+		&inspectOut, &inspectOut); err != nil {
+		return 0, fmt.Errorf("resolve agent uid: inspect %s: %w (%s)",
+			image, err, strings.TrimSpace(inspectOut.String()))
+	}
+
+	userSpec := strings.TrimSpace(inspectOut.String())
+	// `docker image inspect` prints the literal "<no value>" when the
+	// template field is unset on some runtime/version combinations; treat
+	// it the same as an empty USER (image runs as root).
+	if userSpec == "" || userSpec == "<no value>" {
+		return 0, nil
+	}
+
+	// User specs may be `user`, `uid`, `user:group`, or `uid:gid`. Only
+	// the user component drives file ownership.
+	userPart := userSpec
+	if idx := strings.IndexByte(userSpec, ':'); idx >= 0 {
+		userPart = userSpec[:idx]
+	}
+	userPart = strings.TrimSpace(userPart)
+	if userPart == "" {
+		return 0, nil
+	}
+
+	// Numeric user component: parse directly, no second container run.
+	if uid, err := strconv.Atoi(userPart); err == nil {
+		if uid < 0 {
+			return 0, fmt.Errorf("resolve agent uid: image %s declares negative uid %d", image, uid)
+		}
+		return uid, nil
+	}
+
+	// Named user: resolve the name→UID mapping by running `id -u <name>`
+	// inside the image.
+	var idOut bytes.Buffer
+	if err := runner.Run(ctx, runtime,
+		[]string{"run", "--rm", image, "id", "-u", userPart},
+		&idOut, &idOut); err != nil {
+		return 0, fmt.Errorf("resolve agent uid: id -u %s in %s: %w (%s)",
+			userPart, image, err, strings.TrimSpace(idOut.String()))
+	}
+
+	idStr := strings.TrimSpace(idOut.String())
+	uid, err := strconv.Atoi(idStr)
+	if err != nil {
+		return 0, fmt.Errorf("resolve agent uid: parse `id -u %s` output %q from %s: %w",
+			userPart, idStr, image, err)
+	}
+	if uid < 0 {
+		return 0, fmt.Errorf("resolve agent uid: image %s resolved user %q to negative uid %d", image, userPart, uid)
+	}
+	return uid, nil
+}

--- a/internal/launch/agent_uid.go
+++ b/internal/launch/agent_uid.go
@@ -4,9 +4,6 @@ import (
 	"bytes"
 	"context"
 	"fmt"
-	"io/fs"
-	"os"
-	"path/filepath"
 	goruntime "runtime"
 	"strconv"
 	"strings"
@@ -53,16 +50,24 @@ func resolveAgentUIDCached(ctx context.Context, runner sandboxcontainer.Runner, 
 // newAgentDirChownHook returns the chownTransientDir hook prepareAuthSpec
 // invokes after rendering the transient auth directory. The hook only
 // performs work on Linux: the macOS/Windows Docker Desktop file-sharing
-// shim translates UIDs at the boundary, so a host-side os.Chown to a
-// foreign in-container UID would be both pointless and (for a non-root
-// host user) likely to fail. On non-Linux hosts the returned hook is
-// nil and prepareAuthSpec skips the chown entirely.
+// shim translates UIDs at the boundary, so chowning the host tree to a
+// foreign in-container UID would be both pointless and unnecessary. On
+// non-Linux hosts the returned hook is nil and prepareAuthSpec skips the
+// chown entirely.
 //
 // On Linux the hook resolves the image's agent UID (cached per
 // runtime+image) and recursively chowns the transient tree to it so the
 // agent owns both the mounted parent directory and the rendered
 // credential files, enabling the in-container tmpfile+rename rotation
 // over the writable bind mount.
+//
+// The chown runs through the container runtime as root, not via a
+// host-side os.Chown. `aileron launch` runs as the unprivileged host
+// operator, and changing a file's owner to a different UID requires
+// CAP_CHOWN; on rootful Docker a host-side chown to the agent UID fails
+// with EPERM. The chown is therefore delegated to a short-lived root
+// container that bind-mounts the tree, where the runtime daemon holds
+// the privilege. See chownTreeViaRuntime.
 //
 // Note on capture-on-exit: after the agent rotates a credential
 // in-container, the resulting file is owned by the agent UID regardless
@@ -88,28 +93,49 @@ func newAgentDirChownHook(ctx context.Context, runner sandboxcontainer.Runner, r
 			return err
 		}
 		// Root (UID 0) already owns files created by a rootful host
-		// process; the recursive walk would be a no-op, so skip it.
+		// process; the chown would be a no-op, so skip the container run.
 		if uid == 0 {
 			return nil
 		}
-		return chownTree(dir, uid)
+		return chownTreeViaRuntime(ctx, runner, runtime, image, dir, uid)
 	}
 }
 
-// chownTree recursively changes the owning UID of dir and everything
-// beneath it to uid, leaving the GID (-1) and file modes untouched. It
-// mirrors the placement of the existing 0700 chmod on the transient
-// root in prepareAuthSpec.
-func chownTree(dir string, uid int) error {
-	return filepath.WalkDir(dir, func(path string, _ fs.DirEntry, walkErr error) error {
-		if walkErr != nil {
-			return walkErr
-		}
-		if err := os.Chown(path, uid, -1); err != nil {
-			return fmt.Errorf("chown %s to uid %d: %w", path, uid, err)
-		}
-		return nil
-	})
+// chownTreeViaRuntime recursively changes the owning UID of dir (and
+// everything beneath it) to uid by running a short-lived root container
+// that bind-mounts dir at /mnt and invokes `chown -R <uid> /mnt`. The
+// GID and file modes are left untouched.
+//
+// This indirection exists because the host launcher is unprivileged:
+// os.Chown to a foreign UID needs CAP_CHOWN and fails with EPERM on
+// rootful Docker Linux. The container runtime daemon runs as root, so
+// the chown is delegated to it. The sandbox image doubles as the helper
+// image so no extra pull is needed, and --entrypoint overrides the
+// image's entrypoint with chown directly.
+func chownTreeViaRuntime(ctx context.Context, runner sandboxcontainer.Runner, runtime, image, dir string, uid int) error {
+	if runner == nil {
+		return fmt.Errorf("chown via runtime: runner is required")
+	}
+	if strings.TrimSpace(runtime) == "" {
+		return fmt.Errorf("chown via runtime: runtime is required")
+	}
+	if strings.TrimSpace(image) == "" {
+		return fmt.Errorf("chown via runtime: image is required")
+	}
+	var out bytes.Buffer
+	args := []string{
+		"run", "--rm",
+		"--user", "0",
+		"--entrypoint", "chown",
+		"--volume", dir + ":/mnt",
+		image,
+		"-R", strconv.Itoa(uid), "/mnt",
+	}
+	if err := runner.Run(ctx, runtime, args, &out, &out); err != nil {
+		return fmt.Errorf("chown %s to uid %d via %s root container: %w (%s)",
+			dir, uid, runtime, err, strings.TrimSpace(out.String()))
+	}
+	return nil
 }
 
 // resolveAgentUID returns the numeric UID of the container image's

--- a/internal/launch/agent_uid.go
+++ b/internal/launch/agent_uid.go
@@ -4,6 +4,7 @@ import (
 	"bytes"
 	"context"
 	"fmt"
+	"os"
 	goruntime "runtime"
 	"strconv"
 	"strings"
@@ -98,6 +99,32 @@ func newAgentDirChownHook(ctx context.Context, runner sandboxcontainer.Runner, r
 			return nil
 		}
 		return chownTreeViaRuntime(ctx, runner, runtime, image, dir, uid)
+	}
+}
+
+// newTransientReclaimHook returns the hook prepareAuthSpec invokes
+// before capture-on-exit reads the transient tree. It is the symmetric
+// counterpart to newAgentDirChownHook: that hook chowns the tree to the
+// agent UID so the in-container agent can rotate its credentials over
+// the writable bind mount; this hook chowns the tree back to the host
+// operator's UID once the container has exited, so the launcher (running
+// as that operator) can read the rotated file for the vault PUT.
+//
+// Without this reclaim, a rotated credential is left owned by the agent
+// UID with mode 0600 on rootful Docker Linux, and the host-side capture
+// read fails with EPERM — the rotation is silently dropped, defeating
+// the durability the AuthSpec lifecycle exists to provide. Like the
+// forward hook it is Linux-only and nil without a concrete runtime+image.
+func newTransientReclaimHook(ctx context.Context, runner sandboxcontainer.Runner, runtime, image string) func(dir string) error {
+	if goruntime.GOOS != "linux" {
+		return nil
+	}
+	if strings.TrimSpace(runtime) == "" || strings.TrimSpace(image) == "" {
+		return nil
+	}
+	hostUID := os.Getuid()
+	return func(dir string) error {
+		return chownTreeViaRuntime(ctx, runner, runtime, image, dir, hostUID)
 	}
 }
 

--- a/internal/launch/agent_uid_test.go
+++ b/internal/launch/agent_uid_test.go
@@ -4,8 +4,6 @@ import (
 	"context"
 	"errors"
 	"io"
-	"os"
-	"path/filepath"
 	goruntime "runtime"
 	"strings"
 	"testing"
@@ -233,26 +231,56 @@ func TestNewAgentDirChownHookNilOnNonLinux(t *testing.T) {
 	}
 }
 
-func TestChownTreeToOwnUIDIsNoOp(t *testing.T) {
-	// chownTree to the current process UID is a privilege-free no-op that
-	// still exercises the recursive walk and os.Chown call on every node.
-	root := t.TempDir()
-	sub := filepath.Join(root, "a", "b")
-	if err := os.MkdirAll(sub, 0o700); err != nil {
-		t.Fatalf("mkdir: %v", err)
+func TestChownTreeViaRuntimeRunsPrivilegedChown(t *testing.T) {
+	// The host launcher is unprivileged, so the chown is delegated to a
+	// root container that bind-mounts the tree. Assert the argv encodes
+	// that contract: a one-shot run as --user 0 with chown as the
+	// entrypoint and the tree mounted at /mnt.
+	runner := &fakeUIDRunner{}
+	if err := chownTreeViaRuntime(context.Background(), runner, "docker", "img:test", "/host/transient", 405); err != nil {
+		t.Fatalf("chownTreeViaRuntime: %v", err)
 	}
-	if err := os.WriteFile(filepath.Join(sub, "f"), []byte("x"), 0o600); err != nil {
-		t.Fatalf("write: %v", err)
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected exactly 1 runtime call, got %d: %v", len(runner.calls), runner.calls)
 	}
-	if err := chownTree(root, os.Getuid()); err != nil {
-		t.Fatalf("chownTree to own uid: %v", err)
+	got := strings.Join(runner.calls[0], " ")
+	for _, want := range []string{
+		"docker run --rm",
+		"--user 0",
+		"--entrypoint chown",
+		"--volume /host/transient:/mnt",
+		"img:test",
+		"-R 405 /mnt",
+	} {
+		if !strings.Contains(got, want) {
+			t.Errorf("chown argv missing %q; got %q", want, got)
+		}
 	}
 }
 
-func TestChownTreeMissingDirErrors(t *testing.T) {
-	err := chownTree(filepath.Join(t.TempDir(), "does-not-exist"), os.Getuid())
+func TestChownTreeViaRuntimeRunnerErrorPropagates(t *testing.T) {
+	runner := &fakeUIDRunner{
+		outputs: []string{"chown: /mnt: Operation not permitted\n"},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	err := chownTreeViaRuntime(context.Background(), runner, "docker", "img:test", "/host/transient", 405)
 	if err == nil {
-		t.Fatal("expected error walking a missing directory")
+		t.Fatal("expected error when the runtime chown fails")
+	}
+	if !strings.Contains(err.Error(), "chown") || !strings.Contains(err.Error(), "405") {
+		t.Fatalf("error should name the chown target uid, got %v", err)
+	}
+}
+
+func TestChownTreeViaRuntimeValidatesInputs(t *testing.T) {
+	if err := chownTreeViaRuntime(context.Background(), nil, "docker", "img", "/d", 1); err == nil {
+		t.Fatal("expected error for nil runner")
+	}
+	if err := chownTreeViaRuntime(context.Background(), &fakeUIDRunner{}, "", "img", "/d", 1); err == nil {
+		t.Fatal("expected error for empty runtime")
+	}
+	if err := chownTreeViaRuntime(context.Background(), &fakeUIDRunner{}, "docker", "", "/d", 1); err == nil {
+		t.Fatal("expected error for empty image")
 	}
 }
 

--- a/internal/launch/agent_uid_test.go
+++ b/internal/launch/agent_uid_test.go
@@ -3,7 +3,9 @@ package launch
 import (
 	"context"
 	"errors"
+	"fmt"
 	"io"
+	"os"
 	goruntime "runtime"
 	"strings"
 	"testing"
@@ -228,6 +230,85 @@ func TestNewAgentDirChownHookNilOnNonLinux(t *testing.T) {
 	}
 	if h := newAgentDirChownHook(context.Background(), &fakeUIDRunner{}, "docker", ""); h != nil {
 		t.Error("hook must be nil when image is empty")
+	}
+}
+
+func TestNewTransientReclaimHookNilConditions(t *testing.T) {
+	hook := newTransientReclaimHook(context.Background(), &fakeUIDRunner{}, "docker", "img")
+	if goruntime.GOOS == "linux" {
+		if hook == nil {
+			t.Fatal("reclaim hook must be non-nil on Linux for a concrete runtime+image")
+		}
+	} else if hook != nil {
+		t.Fatalf("reclaim hook must be nil on %s (the chown is only needed on Linux)", goruntime.GOOS)
+	}
+	if h := newTransientReclaimHook(context.Background(), &fakeUIDRunner{}, "", "img"); h != nil {
+		t.Error("reclaim hook must be nil when runtime is empty")
+	}
+	if h := newTransientReclaimHook(context.Background(), &fakeUIDRunner{}, "docker", ""); h != nil {
+		t.Error("reclaim hook must be nil when image is empty")
+	}
+}
+
+// TestChownHooksDelegateToRuntimeOnLinux drives both the forward chown
+// hook and the reclaim hook (Linux-only, where they are non-nil) and
+// asserts they delegate to the privileged runtime chown rather than a
+// host-side os.Chown — the whole point of the fix.
+func TestChownHooksDelegateToRuntimeOnLinux(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skipf("chown hooks are only non-nil on Linux; GOOS=%s", goruntime.GOOS)
+	}
+
+	// Forward hook: a numeric image user resolves without an id -u run,
+	// then the closure delegates the chown to the runtime as the agent UID.
+	img := "img:chownhook-" + t.Name()
+	t.Cleanup(func() {
+		agentUIDCacheMu.Lock()
+		delete(agentUIDCache, agentUIDCacheKey{runtime: "docker", image: img})
+		agentUIDCacheMu.Unlock()
+	})
+	runner := &fakeUIDRunner{outputs: []string{"1000\n"}}
+	hook := newAgentDirChownHook(context.Background(), runner, "docker", img)
+	if hook == nil {
+		t.Fatal("expected non-nil forward hook on Linux")
+	}
+	if err := hook("/host/transient"); err != nil {
+		t.Fatalf("forward chown hook: %v", err)
+	}
+	last := strings.Join(runner.calls[len(runner.calls)-1], " ")
+	if !strings.Contains(last, "--entrypoint chown") || !strings.Contains(last, "-R 1000 /mnt") {
+		t.Errorf("forward hook must delegate to the runtime chown as the agent UID; last call %q", last)
+	}
+
+	// A root image (empty USER) resolves to UID 0, so the chown is skipped
+	// entirely (root already owns host-created files) — no chown run.
+	rootImg := "img:roothook-" + t.Name()
+	t.Cleanup(func() {
+		agentUIDCacheMu.Lock()
+		delete(agentUIDCache, agentUIDCacheKey{runtime: "docker", image: rootImg})
+		agentUIDCacheMu.Unlock()
+	})
+	rootRunner := &fakeUIDRunner{outputs: []string{"\n"}}
+	rootHook := newAgentDirChownHook(context.Background(), rootRunner, "docker", rootImg)
+	if err := rootHook("/host/transient"); err != nil {
+		t.Fatalf("root-image chown hook: %v", err)
+	}
+	if len(rootRunner.calls) != 1 {
+		t.Errorf("root image must only inspect (UID 0 skips the chown), got %d calls: %v", len(rootRunner.calls), rootRunner.calls)
+	}
+
+	// Reclaim hook: chowns back to the host operator's UID via the runtime.
+	reclaimRunner := &fakeUIDRunner{}
+	reclaim := newTransientReclaimHook(context.Background(), reclaimRunner, "docker", img)
+	if reclaim == nil {
+		t.Fatal("expected non-nil reclaim hook on Linux")
+	}
+	if err := reclaim("/host/transient"); err != nil {
+		t.Fatalf("reclaim hook: %v", err)
+	}
+	rc := strings.Join(reclaimRunner.calls[0], " ")
+	if !strings.Contains(rc, "--entrypoint chown") || !strings.Contains(rc, fmt.Sprintf("-R %d /mnt", os.Getuid())) {
+		t.Errorf("reclaim hook must chown back to the host UID via the runtime; call %q", rc)
 	}
 }
 

--- a/internal/launch/agent_uid_test.go
+++ b/internal/launch/agent_uid_test.go
@@ -1,0 +1,269 @@
+package launch
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	goruntime "runtime"
+	"strings"
+	"testing"
+)
+
+// agent_uid.go contract (U1):
+//
+//   - A numeric Config.User ("1000") is parsed directly, no `id -u` run.
+//   - A "user:group" / "uid:gid" spec uses only the user component.
+//   - A named Config.User ("agent") triggers a second `id -u <name>`
+//     run whose integer output is the resolved UID.
+//   - An empty (or "<no value>") Config.User resolves to root (0).
+//   - An inspect command failure propagates as an error.
+//   - Non-integer `id -u` output is a parse error.
+
+// fakeUIDRunner records the argv of each Run call and returns canned
+// stdout per invocation, in order. It substitutes for Docker/Podman so
+// the resolver is testable without a container runtime.
+type fakeUIDRunner struct {
+	// outputs is consumed FIFO; each entry is the stdout written for the
+	// matching Run call.
+	outputs []string
+	// errs is consumed FIFO alongside outputs; a non-nil entry makes the
+	// matching Run call fail after writing its output.
+	errs []error
+
+	calls [][]string
+}
+
+func (f *fakeUIDRunner) Run(_ context.Context, name string, args []string, stdout, _ io.Writer) error {
+	argv := append([]string{name}, args...)
+	f.calls = append(f.calls, argv)
+	idx := len(f.calls) - 1
+	if idx < len(f.outputs) && f.outputs[idx] != "" {
+		_, _ = io.WriteString(stdout, f.outputs[idx])
+	}
+	if idx < len(f.errs) {
+		return f.errs[idx]
+	}
+	return nil
+}
+
+func TestResolveAgentUIDNumericUser(t *testing.T) {
+	runner := &fakeUIDRunner{outputs: []string{"1000\n"}}
+	uid, err := resolveAgentUID(context.Background(), runner, "docker", "img:test")
+	if err != nil {
+		t.Fatalf("resolveAgentUID: %v", err)
+	}
+	if uid != 1000 {
+		t.Fatalf("uid = %d, want 1000", uid)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected 1 run (inspect only), got %d: %v", len(runner.calls), runner.calls)
+	}
+	if got := strings.Join(runner.calls[0], " "); !strings.Contains(got, "image inspect") {
+		t.Fatalf("first call should be image inspect, got %q", got)
+	}
+}
+
+func TestResolveAgentUIDUserGroupForm(t *testing.T) {
+	runner := &fakeUIDRunner{outputs: []string{"1000:2000\n"}}
+	uid, err := resolveAgentUID(context.Background(), runner, "docker", "img:test")
+	if err != nil {
+		t.Fatalf("resolveAgentUID: %v", err)
+	}
+	if uid != 1000 {
+		t.Fatalf("uid = %d, want 1000 (user component of uid:gid)", uid)
+	}
+	if len(runner.calls) != 1 {
+		t.Fatalf("expected 1 run for numeric user:group, got %d", len(runner.calls))
+	}
+}
+
+func TestResolveAgentUIDNamedUser(t *testing.T) {
+	runner := &fakeUIDRunner{outputs: []string{"agent\n", "405\n"}}
+	uid, err := resolveAgentUID(context.Background(), runner, "podman", "img:test")
+	if err != nil {
+		t.Fatalf("resolveAgentUID: %v", err)
+	}
+	if uid != 405 {
+		t.Fatalf("uid = %d, want 405", uid)
+	}
+	if len(runner.calls) != 2 {
+		t.Fatalf("expected 2 runs (inspect + id -u), got %d: %v", len(runner.calls), runner.calls)
+	}
+	second := strings.Join(runner.calls[1], " ")
+	if !strings.Contains(second, "run --rm img:test id -u agent") {
+		t.Fatalf("second call should resolve the named user, got %q", second)
+	}
+}
+
+func TestResolveAgentUIDEmptyUserIsRoot(t *testing.T) {
+	for _, out := range []string{"\n", "<no value>\n", "  "} {
+		runner := &fakeUIDRunner{outputs: []string{out}}
+		uid, err := resolveAgentUID(context.Background(), runner, "docker", "img:test")
+		if err != nil {
+			t.Fatalf("resolveAgentUID(%q): %v", out, err)
+		}
+		if uid != 0 {
+			t.Fatalf("uid = %d for empty user %q, want 0 (root)", uid, out)
+		}
+		if len(runner.calls) != 1 {
+			t.Fatalf("empty user should not trigger id -u, got %d calls", len(runner.calls))
+		}
+	}
+}
+
+func TestResolveAgentUIDInspectErrorPropagates(t *testing.T) {
+	runner := &fakeUIDRunner{
+		outputs: []string{"no such image\n"},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	_, err := resolveAgentUID(context.Background(), runner, "docker", "missing:img")
+	if err == nil {
+		t.Fatal("expected error when inspect fails")
+	}
+	if !strings.Contains(err.Error(), "inspect") {
+		t.Fatalf("error should name the inspect step, got %v", err)
+	}
+}
+
+func TestResolveAgentUIDIDErrorPropagates(t *testing.T) {
+	runner := &fakeUIDRunner{
+		outputs: []string{"agent\n", "id: no such user\n"},
+		errs:    []error{nil, errors.New("exit status 1")},
+	}
+	_, err := resolveAgentUID(context.Background(), runner, "docker", "img:test")
+	if err == nil {
+		t.Fatal("expected error when id -u fails")
+	}
+	if !strings.Contains(err.Error(), "id -u") {
+		t.Fatalf("error should name the id -u step, got %v", err)
+	}
+}
+
+func TestResolveAgentUIDNonIntegerIDOutput(t *testing.T) {
+	runner := &fakeUIDRunner{outputs: []string{"agent\n", "not-a-number\n"}}
+	_, err := resolveAgentUID(context.Background(), runner, "docker", "img:test")
+	if err == nil {
+		t.Fatal("expected parse error for non-integer id -u output")
+	}
+	if !strings.Contains(err.Error(), "parse") {
+		t.Fatalf("error should mention parse failure, got %v", err)
+	}
+}
+
+func TestResolveAgentUIDCachedHitsCacheAfterFirstResolve(t *testing.T) {
+	// Use a unique image so this test never collides with the package-
+	// level cache populated by other tests.
+	img := "img:cache-" + t.Name()
+	t.Cleanup(func() {
+		agentUIDCacheMu.Lock()
+		delete(agentUIDCache, agentUIDCacheKey{runtime: "docker", image: img})
+		agentUIDCacheMu.Unlock()
+	})
+
+	runner := &fakeUIDRunner{outputs: []string{"1000\n"}}
+	uid, err := resolveAgentUIDCached(context.Background(), runner, "docker", img)
+	if err != nil || uid != 1000 {
+		t.Fatalf("first resolve: uid=%d err=%v", uid, err)
+	}
+	// Second call must hit the cache: a runner with no canned output
+	// would return an empty inspect (root, 0) on a cache miss, so a
+	// cached 1000 proves the cache served it without re-running.
+	empty := &fakeUIDRunner{}
+	uid, err = resolveAgentUIDCached(context.Background(), empty, "docker", img)
+	if err != nil {
+		t.Fatalf("cached resolve: %v", err)
+	}
+	if uid != 1000 {
+		t.Fatalf("cached uid = %d, want 1000 (served from cache, not re-resolved)", uid)
+	}
+	if len(empty.calls) != 0 {
+		t.Fatalf("cache hit must not invoke the runner, got %d calls", len(empty.calls))
+	}
+}
+
+func TestResolveAgentUIDCachedDoesNotCacheFailures(t *testing.T) {
+	img := "img:cache-fail-" + t.Name()
+	t.Cleanup(func() {
+		agentUIDCacheMu.Lock()
+		delete(agentUIDCache, agentUIDCacheKey{runtime: "docker", image: img})
+		agentUIDCacheMu.Unlock()
+	})
+
+	failing := &fakeUIDRunner{
+		outputs: []string{"boom\n"},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	if _, err := resolveAgentUIDCached(context.Background(), failing, "docker", img); err == nil {
+		t.Fatal("expected error from failing resolve")
+	}
+	// A failure must not be cached: a subsequent successful resolve must
+	// re-run and return the new value.
+	ok := &fakeUIDRunner{outputs: []string{"1000\n"}}
+	uid, err := resolveAgentUIDCached(context.Background(), ok, "docker", img)
+	if err != nil {
+		t.Fatalf("retry after failure: %v", err)
+	}
+	if uid != 1000 {
+		t.Fatalf("uid = %d, want 1000 (retry resolved fresh)", uid)
+	}
+	if len(ok.calls) == 0 {
+		t.Fatal("retry after a failed resolve must re-run the runner")
+	}
+}
+
+func TestNewAgentDirChownHookNilOnNonLinux(t *testing.T) {
+	hook := newAgentDirChownHook(context.Background(), &fakeUIDRunner{}, "docker", "img")
+	if goruntime.GOOS == "linux" {
+		if hook == nil {
+			t.Fatal("hook must be non-nil on Linux for a concrete runtime+image")
+		}
+	} else if hook != nil {
+		t.Fatalf("hook must be nil on %s (Docker Desktop shim translates UIDs)", goruntime.GOOS)
+	}
+
+	// Missing runtime/image yields a nil hook on every OS so launch does
+	// not emit a spurious chown warning when sandbox prep left them unset.
+	if h := newAgentDirChownHook(context.Background(), &fakeUIDRunner{}, "", "img"); h != nil {
+		t.Error("hook must be nil when runtime is empty")
+	}
+	if h := newAgentDirChownHook(context.Background(), &fakeUIDRunner{}, "docker", ""); h != nil {
+		t.Error("hook must be nil when image is empty")
+	}
+}
+
+func TestChownTreeToOwnUIDIsNoOp(t *testing.T) {
+	// chownTree to the current process UID is a privilege-free no-op that
+	// still exercises the recursive walk and os.Chown call on every node.
+	root := t.TempDir()
+	sub := filepath.Join(root, "a", "b")
+	if err := os.MkdirAll(sub, 0o700); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(sub, "f"), []byte("x"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	if err := chownTree(root, os.Getuid()); err != nil {
+		t.Fatalf("chownTree to own uid: %v", err)
+	}
+}
+
+func TestChownTreeMissingDirErrors(t *testing.T) {
+	err := chownTree(filepath.Join(t.TempDir(), "does-not-exist"), os.Getuid())
+	if err == nil {
+		t.Fatal("expected error walking a missing directory")
+	}
+}
+
+func TestResolveAgentUIDValidatesInputs(t *testing.T) {
+	if _, err := resolveAgentUID(context.Background(), nil, "docker", "img"); err == nil {
+		t.Fatal("expected error for nil runner")
+	}
+	if _, err := resolveAgentUID(context.Background(), &fakeUIDRunner{}, "", "img"); err == nil {
+		t.Fatal("expected error for empty runtime")
+	}
+	if _, err := resolveAgentUID(context.Background(), &fakeUIDRunner{}, "docker", ""); err == nil {
+		t.Fatal("expected error for empty image")
+	}
+}

--- a/internal/launch/authspec_bindmount_integration_test.go
+++ b/internal/launch/authspec_bindmount_integration_test.go
@@ -116,12 +116,6 @@ func TestAuthSpecBindMountWritable(t *testing.T) {
 		if err := chownTreeViaRuntime(ctx, runner, rt, authSpecBindMountTestImage, hostRoot, agentUID); err != nil {
 			t.Fatalf("apply chown fix (recursive chown to agent UID %d via runtime): %v", agentUID, err)
 		}
-		// The chown and the agent's in-container writes leave the tree owned
-		// by the agent UID; restore it to the test-runner UID (again via the
-		// privileged runtime path) so t.TempDir's cleanup can remove it.
-		t.Cleanup(func() {
-			_ = chownTreeViaRuntime(ctx, runner, rt, authSpecBindMountTestImage, hostRoot, os.Getuid())
-		})
 		stdout, stderr, runErr := runAsAgent(ctx, rt, hostRoot, containerParent, writeCmd)
 		if runErr != nil {
 			t.Fatalf("in-container write FAILED even WITH the chown-to-agent-UID fix (host UID %d, agent UID %d): %v\nstderr: %s\nThis is the regression #988 guards: the AuthSpec writable bind mount must be chowned to the resolved image agent UID so the agent can rotate credentials.", hostUID, agentUID, runErr, strings.TrimSpace(stderr))
@@ -129,12 +123,21 @@ func TestAuthSpecBindMountWritable(t *testing.T) {
 		if got := strings.TrimSpace(stdout); got != "rotated" {
 			t.Fatalf("in-container read-back = %q, want %q", got, "rotated")
 		}
+		// The agent rotated the file as the agent UID, so it is now owned by
+		// that UID (mode 0600). Reclaim ownership to the test-runner UID via
+		// the privileged runtime path, exactly as capture-on-exit does,
+		// before the host-side read. Without this the unprivileged read
+		// fails with EPERM and the rotation would be silently lost. This
+		// also restores ownership so t.TempDir's cleanup can remove the tree.
+		if err := chownTreeViaRuntime(ctx, runner, rt, authSpecBindMountTestImage, hostRoot, os.Getuid()); err != nil {
+			t.Fatalf("reclaim ownership to host UID %d before capture read: %v", os.Getuid(), err)
+		}
 		// Host-side file must reflect the in-container write so the
 		// launcher's capture-on-exit can snapshot it back to the vault.
 		hostFile := filepath.Join(hostRoot, filepath.Base(containerFile))
 		hostBytes, err := os.ReadFile(hostFile)
 		if err != nil {
-			t.Fatalf("read host-side file after in-container write: %v", err)
+			t.Fatalf("read host-side file after reclaim: %v", err)
 		}
 		if got := strings.TrimSpace(string(hostBytes)); got != "rotated" {
 			t.Fatalf("host-side file = %q after in-container rotation, want %q", got, "rotated")

--- a/internal/launch/authspec_bindmount_integration_test.go
+++ b/internal/launch/authspec_bindmount_integration_test.go
@@ -107,12 +107,21 @@ func TestAuthSpecBindMountWritable(t *testing.T) {
 	})
 
 	// Positive case: with the chown fix, the agent owns the tree and the
-	// write succeeds; the host-side file reflects it.
+	// write succeeds; the host-side file reflects it. The chown runs the
+	// same way production does (chownTreeViaRuntime): a root container
+	// bind-mounts the tree and chowns it, because the unprivileged
+	// test-runner UID cannot chown host files to the foreign agent UID.
 	t.Run("with_chown_fix_write_succeeds", func(t *testing.T) {
 		hostRoot := newTransientAuthDir(t, containerParent)
-		if err := chownTree(hostRoot, agentUID); err != nil {
-			t.Fatalf("apply chown fix (recursive chown to agent UID %d): %v", agentUID, err)
+		if err := chownTreeViaRuntime(ctx, runner, rt, authSpecBindMountTestImage, hostRoot, agentUID); err != nil {
+			t.Fatalf("apply chown fix (recursive chown to agent UID %d via runtime): %v", agentUID, err)
 		}
+		// The chown and the agent's in-container writes leave the tree owned
+		// by the agent UID; restore it to the test-runner UID (again via the
+		// privileged runtime path) so t.TempDir's cleanup can remove it.
+		t.Cleanup(func() {
+			_ = chownTreeViaRuntime(ctx, runner, rt, authSpecBindMountTestImage, hostRoot, os.Getuid())
+		})
 		stdout, stderr, runErr := runAsAgent(ctx, rt, hostRoot, containerParent, writeCmd)
 		if runErr != nil {
 			t.Fatalf("in-container write FAILED even WITH the chown-to-agent-UID fix (host UID %d, agent UID %d): %v\nstderr: %s\nThis is the regression #988 guards: the AuthSpec writable bind mount must be chowned to the resolved image agent UID so the agent can rotate credentials.", hostUID, agentUID, runErr, strings.TrimSpace(stderr))

--- a/internal/launch/authspec_bindmount_integration_test.go
+++ b/internal/launch/authspec_bindmount_integration_test.go
@@ -1,0 +1,207 @@
+//go:build integration_sandbox
+
+// AuthSpec bind-mount writability integration test (#988).
+//
+// This test exercises the load-bearing AuthSpec lifecycle contract on
+// the platform where it actually breaks: rootful-Docker Linux. The
+// launcher renders agent credentials into a transient host directory
+// (chmod 0700, owned by the host operator's UID), then bind-mounts that
+// directory WRITABLE into the sandbox container at the binding's parent
+// (e.g. /home/agent/.claude/). Claude rotates .credentials.json
+// mid-session by writing a tmpfile and renaming it over the original,
+// which requires the in-container agent user to own the mounted
+// directory and its files. The container runs as the image's `agent`
+// system user (created by BusyBox `adduser -S`, UID assigned
+// dynamically), not as the host operator's UID. A writable bind mount
+// preserves host ownership, so without the chown-to-agent-UID fix the
+// in-container write fails with EPERM.
+//
+// The test:
+//
+//   - Skips unless GOOS == linux and a Docker runtime is on PATH
+//     (macOS/Windows Docker Desktop translates UIDs via its file-sharing
+//     shim, so the bug does not reproduce there).
+//   - Builds the aileron/sandbox-base image (Tier base).
+//   - Creates a transient dir exactly as prepareAuthSpec does and seeds
+//     a credential file.
+//   - Negative control: WITHOUT the chown fix, an in-container write as
+//     the agent user must fail; on that failure the test surfaces the
+//     permanent diagnostic naming the UID mismatch and the chown fix.
+//   - Positive case: WITH the chown fix applied (resolveAgentUID +
+//     recursive chown), the same write succeeds (container exit 0) and
+//     the host-side file reflects the in-container write.
+//
+// Run with:
+//
+//	go test -tags=integration_sandbox -run TestAuthSpecBindMountWritable ./internal/launch/...
+package launch
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+const authSpecBindMountTestImage = "aileron/sandbox-base:authspec-bindmount-test"
+
+func TestAuthSpecBindMountWritable(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("AuthSpec bind-mount UID mismatch only reproduces on Linux; GOOS=%s translates UIDs via the Docker Desktop shim", runtime.GOOS)
+	}
+	rt, err := sandboxcontainer.ResolveRuntime("docker")
+	if err != nil {
+		t.Skipf("no docker runtime on PATH: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	buildAuthSpecBaseImage(ctx, t, rt)
+
+	runner := sandboxcontainer.DefaultRunner()
+	agentUID, err := resolveAgentUID(ctx, runner, rt, authSpecBindMountTestImage)
+	if err != nil {
+		t.Fatalf("resolve agent UID for %s: %v", authSpecBindMountTestImage, err)
+	}
+	if agentUID == 0 {
+		t.Fatalf("sandbox-base image resolved agent UID 0 (root); the image's USER directive should select the non-root `agent` user — the bind-mount writability contract is meaningless as root")
+	}
+	hostUID := os.Getuid()
+	if hostUID == agentUID {
+		t.Skipf("host UID %d equals container agent UID %d; the EPERM mismatch this test guards cannot occur in this environment", hostUID, agentUID)
+	}
+
+	// Container path mirrors prepareAuthSpec's mount target for Claude.
+	const containerParent = "/home/agent/.claude"
+	const containerFile = containerParent + "/.credentials.json"
+	// Reproduce Claude's mid-session rotation precisely: write a tmpfile
+	// in the mounted dir then rename it over .credentials.json. Both the
+	// tmpfile create and the rename require the agent to OWN the mounted
+	// directory (creating a new entry and unlinking the old one are
+	// directory operations), which is exactly what the chown fix grants.
+	// Read the rotated file back so a success path is observable.
+	const writeCmd = "echo rotated > " + containerParent + "/.credentials.json.tmp && " +
+		"mv " + containerParent + "/.credentials.json.tmp " + containerFile + " && " +
+		"cat " + containerFile
+
+	// Negative control: without the chown fix, the host operator owns the
+	// dir and the agent user cannot perform the tmpfile+rename rotation.
+	t.Run("negative_control_without_chown_fails", func(t *testing.T) {
+		hostRoot := newTransientAuthDir(t, containerParent)
+		stdout, stderr, runErr := runAsAgent(ctx, rt, hostRoot, containerParent, writeCmd)
+		if runErr == nil {
+			t.Fatalf("expected the in-container write to FAIL without the chown fix (host UID %d owns the dir, container runs as agent UID %d), but it succeeded; stdout=%q", hostUID, agentUID, stdout)
+		}
+		// Permanent diagnostic per #988 acceptance: name the UID mismatch
+		// and point at the chown-to-agent-UID fix.
+		t.Logf("negative control reproduced the EPERM the fix guards: host UID %d owns the AuthSpec bind-mount but the container runs as agent UID %d; the remedy is the chown-to-agent-UID fix applied before the writable mount. runtime stderr: %s", hostUID, agentUID, strings.TrimSpace(stderr))
+	})
+
+	// Positive case: with the chown fix, the agent owns the tree and the
+	// write succeeds; the host-side file reflects it.
+	t.Run("with_chown_fix_write_succeeds", func(t *testing.T) {
+		hostRoot := newTransientAuthDir(t, containerParent)
+		if err := chownTree(hostRoot, agentUID); err != nil {
+			t.Fatalf("apply chown fix (recursive chown to agent UID %d): %v", agentUID, err)
+		}
+		stdout, stderr, runErr := runAsAgent(ctx, rt, hostRoot, containerParent, writeCmd)
+		if runErr != nil {
+			t.Fatalf("in-container write FAILED even WITH the chown-to-agent-UID fix (host UID %d, agent UID %d): %v\nstderr: %s\nThis is the regression #988 guards: the AuthSpec writable bind mount must be chowned to the resolved image agent UID so the agent can rotate credentials.", hostUID, agentUID, runErr, strings.TrimSpace(stderr))
+		}
+		if got := strings.TrimSpace(stdout); got != "rotated" {
+			t.Fatalf("in-container read-back = %q, want %q", got, "rotated")
+		}
+		// Host-side file must reflect the in-container write so the
+		// launcher's capture-on-exit can snapshot it back to the vault.
+		hostFile := filepath.Join(hostRoot, filepath.Base(containerFile))
+		hostBytes, err := os.ReadFile(hostFile)
+		if err != nil {
+			t.Fatalf("read host-side file after in-container write: %v", err)
+		}
+		if got := strings.TrimSpace(string(hostBytes)); got != "rotated" {
+			t.Fatalf("host-side file = %q after in-container rotation, want %q", got, "rotated")
+		}
+	})
+}
+
+// buildAuthSpecBaseImage builds (or rebuilds) the sandbox-base image
+// under a dedicated test tag so the test never collides with a developer's
+// working image. AILERON_SANDBOX_BASE_CONTEXT may point at the
+// images/sandbox-base context; otherwise the Builder walks up from cwd.
+func buildAuthSpecBaseImage(ctx context.Context, t *testing.T, rt string) {
+	t.Helper()
+	builder := sandboxcontainer.Builder{
+		Runtime: rt,
+		Stdout:  testLogWriter{t},
+		Stderr:  testLogWriter{t},
+	}
+	plan := sandboxcomposition.Plan{
+		Tier:  sandboxcomposition.TierBase,
+		Image: authSpecBindMountTestImage,
+	}
+	if _, err := builder.Build(ctx, sandboxcontainer.BuildOptions{
+		Plan:   plan,
+		Tag:    authSpecBindMountTestImage,
+		Policy: sandboxcontainer.BuildPolicyAlways,
+	}); err != nil {
+		t.Fatalf("build sandbox-base test image: %v (set AILERON_SANDBOX_BASE_CONTEXT to images/sandbox-base if the context was not found)", err)
+	}
+}
+
+// newTransientAuthDir reproduces prepareAuthSpec's transient-dir setup:
+// a 0700 temp dir owned by the test-runner UID, with the container
+// parent's subdirectory mirrored beneath it and a seed file written.
+// It returns the host-side directory that maps to containerParent.
+func newTransientAuthDir(t *testing.T, containerParent string) string {
+	t.Helper()
+	root := t.TempDir()
+	if err := os.Chmod(root, 0o700); err != nil {
+		t.Fatalf("chmod transient root 0700: %v", err)
+	}
+	rel := strings.TrimLeft(containerParent, "/")
+	hostDir := filepath.Join(root, rel)
+	if err := os.MkdirAll(hostDir, 0o700); err != nil {
+		t.Fatalf("mkdir host group dir: %v", err)
+	}
+	// Seed a placeholder so the directory is non-empty, mirroring a
+	// pre-seeded credential the agent later rotates.
+	if err := os.WriteFile(filepath.Join(hostDir, ".credentials.json"), []byte("seed"), 0o600); err != nil {
+		t.Fatalf("seed credential file: %v", err)
+	}
+	return hostDir
+}
+
+// runAsAgent runs a one-shot container as the image's default (agent)
+// user with hostDir bind-mounted WRITABLE at containerParent, executing
+// cmd via /bin/sh -c. It returns stdout, stderr, and the run error.
+func runAsAgent(ctx context.Context, rt, hostDir, containerParent, cmd string) (string, string, error) {
+	args := []string{
+		"run", "--rm",
+		"--volume", hostDir + ":" + containerParent,
+		authSpecBindMountTestImage,
+		"/bin/sh", "-c", cmd,
+	}
+	var stdout, stderr bytes.Buffer
+	c := exec.CommandContext(ctx, rt, args...)
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	err := c.Run()
+	return stdout.String(), stderr.String(), err
+}
+
+// testLogWriter routes container build output to the test log.
+type testLogWriter struct{ t *testing.T }
+
+func (w testLogWriter) Write(p []byte) (int, error) {
+	w.t.Logf("%s", bytes.TrimRight(p, "\n"))
+	return len(p), nil
+}

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -132,6 +132,7 @@ func prepareAuthSpec(
 	sessionLog *slog.Logger,
 	stderr io.Writer,
 	chownTransientDir func(dir string) error,
+	reclaimTransientDir func(dir string) error,
 ) (authSpecPrep, error) {
 	prep := authSpecPrep{
 		EnvAdditions: map[string]string{},
@@ -420,6 +421,19 @@ func prepareAuthSpec(
 
 	if len(captureTargets) > 0 {
 		prep.CaptureFn = func(captureCtx context.Context) {
+			// The agent rotated its credentials in-container as the agent
+			// UID; reclaim ownership of the tree to the host operator
+			// before reading so the vault PUT can read the rotated file.
+			// On rootful Docker Linux the file is otherwise agent-owned
+			// and mode 0600, so a host-side read fails with EPERM and the
+			// rotation is lost. Non-fatal: warn and still attempt the
+			// reads (a same-UID environment needs no reclaim).
+			if reclaimTransientDir != nil {
+				if err := reclaimTransientDir(hostRoot); err != nil {
+					captureWarn(sessionLog, stderr, agentName, hostRoot,
+						fmt.Errorf("reclaim transient auth dir ownership to host UID before capture: %w; a credential the agent rotated as its own UID may be unreadable for the vault PUT", err))
+				}
+			}
 			for _, target := range captureTargets {
 				bytes, err := os.ReadFile(target.HostPath)
 				if err != nil {

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -107,6 +107,23 @@ type authSpecPrep struct {
 // refresh token survives the race because both writers exchanged
 // the same upstream token. A Fresher hook on FileBinding is a
 // clean follow-up if real users surface the concern.
+// chownTransientDir, when non-nil, is invoked once after every
+// FileBinding and StaticFile has been written to the transient host
+// directory and before the mount list is returned. It receives
+// hostRoot and is expected to recursively change ownership of the tree
+// to the resolved in-container agent UID. On rootful-Docker Linux the
+// host operator's UID owns the transient dir, but the container runs as
+// the image's `agent` system user; a writable bind mount preserves host
+// ownership, so the agent's mid-session credential rewrite (Claude's
+// tmpfile+rename of .credentials.json) fails with EPERM without this
+// chown. The launcher supplies a Linux-only closure; on macOS/Windows
+// (where the Docker Desktop file-sharing shim translates UIDs) it is
+// nil and the chown is skipped. A nil hook is a no-op.
+//
+// Resolver failures are surfaced as a non-fatal warning and launch
+// proceeds (the prior behavior); the hook returns an error only so the
+// launcher can decide warn-vs-abort. prepareAuthSpec treats a hook
+// error as non-fatal.
 func prepareAuthSpec(
 	ctx context.Context,
 	agentName string,
@@ -114,6 +131,7 @@ func prepareAuthSpec(
 	daemon authSpecDaemon,
 	sessionLog *slog.Logger,
 	stderr io.Writer,
+	chownTransientDir func(dir string) error,
 ) (authSpecPrep, error) {
 	prep := authSpecPrep{
 		EnvAdditions: map[string]string{},
@@ -347,6 +365,20 @@ func prepareAuthSpec(
 				Target:   sf.ContainerPath,
 				ReadOnly: true,
 			})
+		}
+	}
+
+	// Chown the transient tree to the in-container agent UID now that
+	// every file is written and before the dir is mounted. On Linux
+	// rootful Docker this is the fix that lets the agent rewrite its
+	// credentials through the writable bind mount; on other platforms
+	// the hook is nil. A resolver/chown failure is non-fatal: warn with
+	// a permanent diagnostic naming the UID mismatch and the chown fix,
+	// then proceed so a transient lookup hiccup never aborts a launch.
+	if chownTransientDir != nil {
+		if err := chownTransientDir(hostRoot); err != nil {
+			captureWarn(sessionLog, stderr, agentName, hostRoot,
+				fmt.Errorf("chown transient auth dir to image agent UID: %w; the agent runs as a non-root system user while the host operator owns this bind-mounted dir (host UID vs resolved agent UID mismatch), so in-container credential rotation may fail with EPERM — the remedy is the chown-to-agent-UID fix on the AuthSpec bind mount", err))
 		}
 	}
 

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -100,7 +100,7 @@ func newTestLogger() *slog.Logger {
 
 func TestPrepareAuthSpec_EmptySpecIsNoOp(t *testing.T) {
 	prep, err := prepareAuthSpec(context.Background(), "claude", AuthSpec{},
-		newFakeDaemon(), newTestLogger(), nil)
+		newFakeDaemon(), newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestPrepareAuthSpec_FileBindingRendersFromVault(t *testing.T) {
 		}},
 	}
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestPrepareAuthSpec_StaticFileLandsRegardlessOfVault(t *testing.T) {
 		}},
 	}
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestPrepareAuthSpec_RequiredVaultMissingFailsLaunch(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil)
+		newTestLogger(), nil, nil)
 	if err == nil {
 		t.Fatal("expected error for required+empty vault")
 	}
@@ -261,7 +261,7 @@ func TestPrepareAuthSpec_EmptyVaultOptionalBindingDoesNotRender(t *testing.T) {
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil)
+		newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestPrepareAuthSpec_CaptureOnCleanExitPersistsRotatedFile(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -338,7 +338,7 @@ func TestPrepareAuthSpec_CaptureSchemaFailureSkipsPut(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{}, errors.New("schema drift") },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -390,7 +390,7 @@ func TestPrepareAuthSpec_PreLaunchRefreshPersistsBeforeRender(t *testing.T) {
 			},
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil)
+	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -424,7 +424,7 @@ func TestPrepareAuthSpec_PreLaunchRefreshErrorAbortsLaunch(t *testing.T) {
 			},
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil)
+	_, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil)
 	if err == nil {
 		t.Fatal("expected error when PreLaunchRefresh fails")
 	}
@@ -441,7 +441,7 @@ func TestPrepareAuthSpec_CleanupRemovesTransientDir(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -469,7 +469,7 @@ func TestPrepareAuthSpec_EnvBindingMerges(t *testing.T) {
 			},
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil)
+	prep, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -493,7 +493,7 @@ func TestPrepareAuthSpec_CapturePutFailureSurfacesWarning(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -526,7 +526,7 @@ func TestPrepareAuthSpec_EnvBindingRequiredMissingErrors(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "example", spec, newFakeDaemon(),
-		newTestLogger(), nil)
+		newTestLogger(), nil, nil)
 	if err == nil {
 		t.Fatal("expected error on required env binding with empty vault")
 	}
@@ -546,7 +546,7 @@ func TestPrepareAuthSpec_EnvBindingOptionalMissingContinues(t *testing.T) {
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "example", spec, newFakeDaemon(),
-		newTestLogger(), nil)
+		newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -566,7 +566,7 @@ func TestPrepareAuthSpec_EnvBindingGetErrorPropagates(t *testing.T) {
 			Render:    func(s vault.Secret) (map[string]string, error) { return nil, nil },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil)
+	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil)
 	if err == nil {
 		t.Fatal("expected error when GET fails with non-NotFound")
 	}
@@ -585,7 +585,7 @@ func TestPrepareAuthSpec_EnvBindingRenderErrorPropagates(t *testing.T) {
 			Render:    func(s vault.Secret) (map[string]string, error) { return nil, errors.New("bad shape") },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil)
+	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil)
 	if err == nil {
 		t.Fatal("expected error when Render fails")
 	}
@@ -602,7 +602,7 @@ func TestPrepareAuthSpec_FileBindingRenderErrorPropagates(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil)
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
 	if err == nil {
 		t.Fatal("expected error when Render fails")
 	}
@@ -619,7 +619,7 @@ func TestPrepareAuthSpec_FileBindingGetErrorPropagates(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil)
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
 	if err == nil {
 		t.Fatal("expected error when GET fails with non-NotFound")
 	}
@@ -638,7 +638,7 @@ func TestPrepareAuthSpec_ValidationErrorReturnsBeforeFS(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil)
+		newTestLogger(), nil, nil)
 	if err == nil {
 		t.Fatal("expected validation error for nil Render")
 	}
@@ -666,7 +666,7 @@ func TestPrepareAuthSpec_EmptyVaultFirstLaunchProducesWritableParentMount(t *tes
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil)
+	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -712,7 +712,7 @@ func TestPrepareAuthSpec_RejectsNonConformingVaultPath(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "example", spec, newFakeDaemon(),
-		newTestLogger(), nil)
+		newTestLogger(), nil, nil)
 	if !errors.Is(err, ErrAuthSpecBadVaultPath) {
 		t.Fatalf("err = %v, want ErrAuthSpecBadVaultPath", err)
 	}
@@ -736,7 +736,7 @@ func TestPrepareAuthSpec_R30BootstrapLineFiresOnEmptyVault(t *testing.T) {
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil)
+		newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -760,7 +760,7 @@ func TestPrepareAuthSpec_RenderedAnyCredentialIsTrueOnHit(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -788,7 +788,7 @@ func TestPrepareAuthSpec_MountAsFileSkipsParentDirMount(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil)
+	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -799,6 +799,115 @@ func TestPrepareAuthSpec_MountAsFileSkipsParentDirMount(t *testing.T) {
 	}
 	if prep.Mounts[0].Target != "/home/agent/.codex/auth.json" {
 		t.Errorf("mount target = %q, want /home/agent/.codex/auth.json (file mount)", prep.Mounts[0].Target)
+	}
+}
+
+// claudeFileBindingSpec is a minimal AuthSpec that renders one file
+// binding into the transient dir, used by the chown-hook wiring tests.
+func claudeFileBindingSpec() AuthSpec {
+	return AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Mode:          0o600,
+			Required:      true,
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+		}},
+	}
+}
+
+func TestPrepareAuthSpec_ChownHookInvokedWithHostRootAfterFilesExist(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.seed("claude", []byte(`{"claudeAiOauth":{"accessToken":"tok"}}`))
+
+	var gotDir string
+	var sawFile bool
+	hook := func(dir string) error {
+		gotDir = dir
+		// The rendered credential file must already be on disk when the
+		// chown runs so the recursive chown covers it. The transient
+		// root mirrors the container parent path beneath it.
+		if _, err := os.Stat(filepath.Join(dir, "home", "agent", ".claude", ".credentials.json")); err == nil {
+			sawFile = true
+		}
+		return nil
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
+		daemon, newTestLogger(), nil, hook)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if gotDir == "" {
+		t.Fatal("chown hook was never invoked")
+	}
+	if len(prep.Mounts) == 0 {
+		t.Fatal("expected at least one mount")
+	}
+	// The hook must receive the transient root: the group dir mounted
+	// into the container lives under it, so a recursive chown of the
+	// root covers both the mounted parent and its rendered files.
+	mountSource := prep.Mounts[0].Source
+	rel, err := filepath.Rel(gotDir, mountSource)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		t.Errorf("hook dir %q is not an ancestor of mount source %q; the chown must cover the mounted dir", gotDir, mountSource)
+	}
+	if !sawFile {
+		t.Error("chown hook ran before the credential file was written; it must run after so the chown covers rendered files")
+	}
+}
+
+func TestPrepareAuthSpec_NilChownHookLeavesFilesIntact(t *testing.T) {
+	daemon := newFakeDaemon()
+	envelope := []byte(`{"claudeAiOauth":{"accessToken":"tok"}}`)
+	daemon.seed("claude", envelope)
+
+	// A nil hook is the non-Linux path: prep must still succeed and the
+	// rendered file must be present and unchanged.
+	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
+		daemon, newTestLogger(), nil, nil)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if len(prep.Mounts) != 1 {
+		t.Fatalf("Mounts = %d, want 1", len(prep.Mounts))
+	}
+	got, err := os.ReadFile(filepath.Join(prep.Mounts[0].Source, ".credentials.json"))
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+	if !bytes.Equal(got, envelope) {
+		t.Errorf("rendered bytes = %q, want %q", got, envelope)
+	}
+}
+
+func TestPrepareAuthSpec_ChownHookErrorIsNonFatal(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.seed("claude", []byte(`{"claudeAiOauth":{"accessToken":"tok"}}`))
+
+	stderr := &bytes.Buffer{}
+	hook := func(string) error { return errors.New("resolve agent uid: boom") }
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
+		daemon, newTestLogger(), stderr, hook)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec must not fail on chown hook error, got %v", err)
+	}
+	defer prep.Cleanup()
+
+	if len(prep.Mounts) != 1 {
+		t.Fatalf("Mounts = %d, want 1 (prep proceeds despite hook error)", len(prep.Mounts))
+	}
+	// The permanent diagnostic must name the UID mismatch and the
+	// chown-to-agent-UID remedy so a regression is attributable.
+	warned := stderr.String()
+	if !strings.Contains(warned, "chown") || !strings.Contains(warned, "UID") {
+		t.Errorf("warning %q must name the chown fix and UID mismatch", warned)
 	}
 }
 

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -100,7 +100,7 @@ func newTestLogger() *slog.Logger {
 
 func TestPrepareAuthSpec_EmptySpecIsNoOp(t *testing.T) {
 	prep, err := prepareAuthSpec(context.Background(), "claude", AuthSpec{},
-		newFakeDaemon(), newTestLogger(), nil, nil)
+		newFakeDaemon(), newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -136,7 +136,7 @@ func TestPrepareAuthSpec_FileBindingRendersFromVault(t *testing.T) {
 		}},
 	}
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -199,7 +199,7 @@ func TestPrepareAuthSpec_StaticFileLandsRegardlessOfVault(t *testing.T) {
 		}},
 	}
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -237,7 +237,7 @@ func TestPrepareAuthSpec_RequiredVaultMissingFailsLaunch(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil)
+		newTestLogger(), nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error for required+empty vault")
 	}
@@ -261,7 +261,7 @@ func TestPrepareAuthSpec_EmptyVaultOptionalBindingDoesNotRender(t *testing.T) {
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil)
+		newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -296,7 +296,7 @@ func TestPrepareAuthSpec_CaptureOnCleanExitPersistsRotatedFile(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -338,7 +338,7 @@ func TestPrepareAuthSpec_CaptureSchemaFailureSkipsPut(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{}, errors.New("schema drift") },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -390,7 +390,7 @@ func TestPrepareAuthSpec_PreLaunchRefreshPersistsBeforeRender(t *testing.T) {
 			},
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -424,7 +424,7 @@ func TestPrepareAuthSpec_PreLaunchRefreshErrorAbortsLaunch(t *testing.T) {
 			},
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when PreLaunchRefresh fails")
 	}
@@ -441,7 +441,7 @@ func TestPrepareAuthSpec_CleanupRemovesTransientDir(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -469,7 +469,7 @@ func TestPrepareAuthSpec_EnvBindingMerges(t *testing.T) {
 			},
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -493,7 +493,7 @@ func TestPrepareAuthSpec_CapturePutFailureSurfacesWarning(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -526,7 +526,7 @@ func TestPrepareAuthSpec_EnvBindingRequiredMissingErrors(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "example", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil)
+		newTestLogger(), nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error on required env binding with empty vault")
 	}
@@ -546,7 +546,7 @@ func TestPrepareAuthSpec_EnvBindingOptionalMissingContinues(t *testing.T) {
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "example", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil)
+		newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -566,7 +566,7 @@ func TestPrepareAuthSpec_EnvBindingGetErrorPropagates(t *testing.T) {
 			Render:    func(s vault.Secret) (map[string]string, error) { return nil, nil },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when GET fails with non-NotFound")
 	}
@@ -585,7 +585,7 @@ func TestPrepareAuthSpec_EnvBindingRenderErrorPropagates(t *testing.T) {
 			Render:    func(s vault.Secret) (map[string]string, error) { return nil, errors.New("bad shape") },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when Render fails")
 	}
@@ -602,7 +602,7 @@ func TestPrepareAuthSpec_FileBindingRenderErrorPropagates(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when Render fails")
 	}
@@ -619,7 +619,7 @@ func TestPrepareAuthSpec_FileBindingGetErrorPropagates(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error when GET fails with non-NotFound")
 	}
@@ -638,7 +638,7 @@ func TestPrepareAuthSpec_ValidationErrorReturnsBeforeFS(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil)
+		newTestLogger(), nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected validation error for nil Render")
 	}
@@ -666,7 +666,7 @@ func TestPrepareAuthSpec_EmptyVaultFirstLaunchProducesWritableParentMount(t *tes
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -712,7 +712,7 @@ func TestPrepareAuthSpec_RejectsNonConformingVaultPath(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "example", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil)
+		newTestLogger(), nil, nil, nil)
 	if !errors.Is(err, ErrAuthSpecBadVaultPath) {
 		t.Fatalf("err = %v, want ErrAuthSpecBadVaultPath", err)
 	}
@@ -736,7 +736,7 @@ func TestPrepareAuthSpec_R30BootstrapLineFiresOnEmptyVault(t *testing.T) {
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil)
+		newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -760,7 +760,7 @@ func TestPrepareAuthSpec_RenderedAnyCredentialIsTrueOnHit(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -788,7 +788,7 @@ func TestPrepareAuthSpec_MountAsFileSkipsParentDirMount(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -835,7 +835,7 @@ func TestPrepareAuthSpec_ChownHookInvokedWithHostRootAfterFilesExist(t *testing.
 	}
 
 	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
-		daemon, newTestLogger(), nil, hook)
+		daemon, newTestLogger(), nil, hook, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -868,7 +868,7 @@ func TestPrepareAuthSpec_NilChownHookLeavesFilesIntact(t *testing.T) {
 	// A nil hook is the non-Linux path: prep must still succeed and the
 	// rendered file must be present and unchanged.
 	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
-		daemon, newTestLogger(), nil, nil)
+		daemon, newTestLogger(), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -894,7 +894,7 @@ func TestPrepareAuthSpec_ChownHookErrorIsNonFatal(t *testing.T) {
 	hook := func(string) error { return errors.New("resolve agent uid: boom") }
 
 	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
-		daemon, newTestLogger(), stderr, hook)
+		daemon, newTestLogger(), stderr, hook, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec must not fail on chown hook error, got %v", err)
 	}
@@ -908,6 +908,73 @@ func TestPrepareAuthSpec_ChownHookErrorIsNonFatal(t *testing.T) {
 	warned := stderr.String()
 	if !strings.Contains(warned, "chown") || !strings.Contains(warned, "UID") {
 		t.Errorf("warning %q must name the chown fix and UID mismatch", warned)
+	}
+}
+
+func TestPrepareAuthSpec_ReclaimHookRunsBeforeCaptureRead(t *testing.T) {
+	envelope := []byte(`{"claudeAiOauth":{"accessToken":"old"}}`)
+	rotated := []byte(`{"claudeAiOauth":{"accessToken":"new"}}`)
+	daemon := newFakeDaemon()
+	daemon.seed("claude", envelope)
+
+	var reclaimedDir string
+	reclaim := func(dir string) error { reclaimedDir = dir; return nil }
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
+		daemon, newTestLogger(), nil, nil, reclaim)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	// Simulate the agent rotating the credential in-container.
+	hostPath := filepath.Join(prep.Mounts[0].Source, ".credentials.json")
+	if err := os.WriteFile(hostPath, rotated, 0o600); err != nil {
+		t.Fatalf("simulate rotation: %v", err)
+	}
+
+	prep.CaptureFn(context.Background())
+
+	if reclaimedDir == "" {
+		t.Fatal("reclaim hook was never invoked; capture must reclaim ownership before reading the rotated file")
+	}
+	// The reclaim must cover the mounted dir: its source lives under the
+	// transient root the hook received, so a recursive chown back to the
+	// host UID makes the rotated file readable for the PUT.
+	rel, err := filepath.Rel(reclaimedDir, prep.Mounts[0].Source)
+	if err != nil || strings.HasPrefix(rel, "..") {
+		t.Errorf("reclaim dir %q is not an ancestor of mount source %q", reclaimedDir, prep.Mounts[0].Source)
+	}
+	if len(daemon.puts) != 1 || !bytes.Equal(daemon.puts[0].Secret.Value, rotated) {
+		t.Fatalf("rotated bytes must be captured after reclaim; puts=%d", len(daemon.puts))
+	}
+}
+
+func TestPrepareAuthSpec_ReclaimHookErrorIsNonFatal(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.seed("claude", []byte(`{"claudeAiOauth":{"accessToken":"tok"}}`))
+
+	stderr := &bytes.Buffer{}
+	reclaim := func(string) error { return errors.New("chown via runtime: boom") }
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
+		daemon, newTestLogger(), stderr, nil, reclaim)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	// A reclaim failure must not abort capture: the read is still
+	// attempted (it succeeds here because the test owns the file), and the
+	// warning names the reclaim step so a regression is attributable.
+	prep.CaptureFn(context.Background())
+
+	warned := stderr.String()
+	if !strings.Contains(warned, "reclaim") {
+		t.Errorf("warning %q must name the reclaim step", warned)
+	}
+	if len(daemon.puts) != 1 {
+		t.Fatalf("capture must still attempt the PUT after a non-fatal reclaim error; puts=%d", len(daemon.puts))
 	}
 }
 

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -471,8 +471,17 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	// parity is a separate, smaller PR per the plan's scope boundary.
 	var authPrep authSpecPrep
 	if sandboxEnabled {
+		// On Linux the host operator (UID typically 1000) owns the
+		// transient auth dir, but the sandbox container runs as the
+		// image's `agent` system user, so writable bind-mounted
+		// credential files would be agent-unwritable. The hook chowns
+		// the transient tree to the image's resolved agent UID; it is
+		// nil on macOS/Windows where the Docker Desktop shim handles UID
+		// translation. See ADR-0025 and issue #988.
+		chownHook := newAgentDirChownHook(ctx, sandboxcontainer.DefaultRunner(),
+			sandboxPlan.Runtime, sandboxPlan.Image)
 		prep, err := prepareAuthSpec(ctx, config.Agent.Name(), config.Agent.AuthSpec(),
-			client, sessionLog, os.Stderr)
+			client, sessionLog, os.Stderr, chownHook)
 		if err != nil {
 			return LaunchResult{}, fmt.Errorf("prepare agent auth spec: %w", err)
 		}

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -480,8 +480,14 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		// translation. See ADR-0025 and issue #988.
 		chownHook := newAgentDirChownHook(ctx, sandboxcontainer.DefaultRunner(),
 			sandboxPlan.Runtime, sandboxPlan.Image)
+		// The symmetric counterpart: after the container exits, chown the
+		// transient tree back to the host operator so capture-on-exit can
+		// read a credential the agent rotated as the agent UID. Without it,
+		// rotations are silently dropped on rootful Docker Linux.
+		reclaimHook := newTransientReclaimHook(ctx, sandboxcontainer.DefaultRunner(),
+			sandboxPlan.Runtime, sandboxPlan.Image)
 		prep, err := prepareAuthSpec(ctx, config.Agent.Name(), config.Agent.AuthSpec(),
-			client, sessionLog, os.Stderr, chownHook)
+			client, sessionLog, os.Stderr, chownHook, reclaimHook)
 		if err != nil {
 			return LaunchResult{}, fmt.Errorf("prepare agent auth spec: %w", err)
 		}

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -43,6 +43,12 @@ type Runner interface {
 	Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error
 }
 
+// DefaultRunner returns the production Runner that shells out to the
+// container runtime executable (docker/podman). Callers outside this
+// package use it to drive runtime commands (e.g. image inspection)
+// through the same code path the Builder uses internally.
+func DefaultRunner() Runner { return execRunner{} }
+
 type execRunner struct{}
 
 func (execRunner) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {


### PR DESCRIPTION
## Summary

Fixes #988. On rootful-Docker Linux the AuthSpec lifecycle creates a transient host directory owned by the host operator's UID (typically 1000) and bind-mounts it **writable** into the sandbox at the binding's container parent (e.g. `/home/agent/.claude/`). The container runs as the image's non-root `agent` system user, and the writable bind mount preserves host ownership — so Claude's mid-session credential rotation (tmpfile + rename of `.credentials.json`) fails with `EPERM`. macOS/Windows Docker Desktop is unaffected (the file-sharing shim translates UIDs).

- **Agent UID is derived from the image, never hardcoded** (`internal/launch/agent_uid.go`): inspect `Config.User` via `image inspect`; a numeric spec is parsed directly, a named user (`agent`) is resolved by running `id -u <name>` once. Result is cached per `(runtime, image)`.
- **chown fix** (`internal/launch/authspec_runtime.go`): a Linux-only hook recursively chowns the transient tree to the resolved agent UID after files are written and before the mount is returned. It is nil on macOS/Windows. A resolver/chown failure is non-fatal and surfaces a **permanent diagnostic** naming the UID mismatch and the chown-to-agent-UID remedy (the regression tripwire).
- **Integration test** (`internal/launch/authspec_bindmount_integration_test.go`, build tag `integration_sandbox`): self-skips off Linux/Docker; reproduces the EPERM as a negative control and proves the tmpfile+rename rotation succeeds with the fix, then asserts the host-side file reflects the in-container write.
- **CI + Taskfile wiring**: extends the `integration-go` job (rootful-Docker ubuntu runner — the acceptance environment) and adds `task test:integration:authspec-bindmount`.

Scope held to the plan: no sandbox-base image/build change (UID derived by inspection), mount writability unchanged, host-launch parity out of scope, no OpenAPI change.

## Test plan

- [x] `go test ./internal/launch/...` — unit tests for the resolver (numeric/named/empty user, error paths), the cache (hit, no-cache-on-failure), `chownTree`, and the `prepareAuthSpec` hook wiring (invoked with the transient root after files exist, nil hook no-op, hook error non-fatal with diagnostic).
- [x] `go test ./internal/...` full module — green.
- [x] `go vet -tags=integration_sandbox ./internal/launch/...` and `./internal/app/...` — clean.
- [x] Integration test self-skips cleanly on darwin (verified locally).
- [ ] **Linux+Docker path runs only in CI** — the `integration-go` job exercises the negative control + fix on the ubuntu rootful-Docker runner where the bug reproduces. Cannot run locally (darwin). The Linux-only branch of `newAgentDirChownHook` is therefore uncovered by unit tests on this platform by design.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Sandbox launches on Linux now apply a best-effort ownership fix and reclaim ownership after container exit so bind-mounted credential directories are writable and rotated credentials are captured (non-fatal warning if fix fails).

* **Tests**
  * Added integration and unit tests validating bind-mount writability, chown delegation, hook ordering, and non-fatal failure handling.

* **Chores**
  * CI and task automation updated to run the new sandbox-specific integration test.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->