### PR TITLE
test(audit): pin sandbox.proxy.disabled + cross-family no-leak sweep (#898)

### DIFF
--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -196,6 +196,20 @@ Migration note: operators who previously queried `sandbox.proxy.rejected` with r
 
 The event is emitted once per launch session by the `aileron launch` CLI through the daemon's `POST /v1/sandbox-proxy/disabled` endpoint. It never records credential bytes, environment variables, the BYO image's contents, or shell history. See [ADR-0019](/adr/0019-v4-https-data-plane/) for the v4 HTTPS data plane decision and the `--sandbox-proxy` flag semantics.
 
+#### Redaction rules
+
+Every sandbox HTTPS data-plane audit event is built from a fixed field set. The recorders copy only the fields named in the tables above into the payload. The following inputs are never recorded in any event family, and the no-leak invariant is enforced in code, not by convention alone.
+
+| Redacted input | Rule | Rationale |
+|---|---|---|
+| Credential bytes | The resolved secret for any binding kind (`oauth2`, `api_key`, or any future kind) is injected at the TLS boundary and never enters an audit payload. The event records `aileron.connector.credential`, the credential *kind*, never the value. | The credential-sealing claim depends on the agent and the audit log never seeing the secret. |
+| `Authorization:` header values | Inbound request headers are read only for `X-Aileron-Session-Id`. The `Authorization` header, and any other request header, is never copied into a payload. | The daemon injects `Authorization: Bearer <token>` on the *outbound* request; that header must not echo back into the log. |
+| Query strings | `aileron.proxy.upstream.path` carries the upstream path only. The `?...` query is dropped by `sandboxProxyUpstreamPath`, which returns `EscapedPath()`. | Query strings routinely carry tokens (`?token=...`, `?api_key=...`); recording them would defeat credential sealing. |
+| Full upstream URLs | An event records the upstream scheme, host, and path as separate fields. It never records the assembled URL. | The host and path are operationally useful and contain no secret; the assembled URL would reintroduce the query string. |
+| Request and response bodies, raw headers | Neither the request body nor the upstream response body is recorded. Only `aileron.proxy.upstream.status` captures the response. | Bodies and raw headers carry user data and credentials with no audit value. |
+
+This redaction contract is pinned in code by the cross-family no-leak sweep in [`internal/app/sandbox_proxy_audit_shape_test.go`](https://github.com/ALRubinger/aileron/blob/main/internal/app/sandbox_proxy_audit_shape_test.go) (`TestSandboxProxyAuditShape_NoCredentialLeakAcrossFamilies`). The sweep drives every emitter with credential-shaped inputs (an `Authorization: Bearer` header, a secret-shaped header, and a query string on the upstream URL) and asserts no serialized payload contains them. That test is the authoritative definition of the no-leak rule; this prose summarizes it.
+
 **Approval wait** (`aileron.approval.wait`):
 
 | Attribute | Description |

--- a/internal/app/sandbox_proxy_audit_shape_test.go
+++ b/internal/app/sandbox_proxy_audit_shape_test.go
@@ -1,6 +1,7 @@
 package app
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"net/http"
@@ -9,6 +10,7 @@ import (
 	"strings"
 	"testing"
 
+	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/audit"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/sandbox/discovery"
@@ -66,10 +68,6 @@ func (s sandboxProxyEventShape) validate(t *testing.T, payload map[string]any) {
 // plane" section. When that documentation changes, this struct must
 // change with it. The accompanying tests below stress every emission
 // site by name.
-//
-// The sandbox.proxy.disabled shape lands in a follow-up once the
-// new daemon endpoint from PR #970 (issue #896 Section B) is on main;
-// the documentation already describes it.
 var (
 	connectorProxyProxiedShape = sandboxProxyEventShape{
 		eventType: "connector.proxy.proxied",
@@ -172,6 +170,24 @@ var (
 			"lin_secret", "Bearer ", "Authorization",
 		},
 	}
+
+	sandboxProxyDisabledShape = sandboxProxyEventShape{
+		eventType: "sandbox.proxy.disabled",
+		requiredFields: []string{
+			"aileron.proxy.source",
+			"aileron.proxy.boundary",
+			"aileron.proxy.decision",
+			"aileron.proxy.disabled_reason",
+			"aileron.sandbox.mode",
+			"aileron.session.id",
+		},
+		allowedFields: []string{
+			"aileron.sandbox.image",
+		},
+		forbiddenSubstrs: []string{
+			"lin_secret", "Bearer ", "Authorization",
+		},
+	}
 )
 
 func TestSandboxProxyAuditShape_ConnectorProxyProxiedConforms(t *testing.T) {
@@ -254,4 +270,128 @@ func TestSandboxProxyAuditShape_SandboxProxyPassthroughConforms(t *testing.T) {
 		t.Fatalf("event type = %q", events[0].EventType)
 	}
 	sandboxProxyPassthroughShape.validate(t, events[0].Payload)
+}
+
+// TestSandboxProxyAuditShape_SandboxProxyDisabledConforms pins the
+// sandbox.proxy.disabled family (gate A). RecordSandboxProxyDisabled is
+// the daemon endpoint the launcher posts to once per launch session
+// when the v4 HTTPS proxy is not in force. Each disabled_reason enum is
+// exercised as a subtest; every emission must conform to the documented
+// field contract.
+func TestSandboxProxyAuditShape_SandboxProxyDisabledConforms(t *testing.T) {
+	reasons := []api.SandboxProxyDisabledRequestReason{
+		api.UserOptOut,
+		api.PreflightFailed,
+		api.UnsupportedSandboxMode,
+	}
+	for _, reason := range reasons {
+		t.Run(string(reason), func(t *testing.T) {
+			auditStore := audit.NewMemStore()
+			srv := &apiServer{
+				auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-shape-disabled" }),
+			}
+			mode := "docker"
+			image := "ghcr.io/acme/sandbox:latest"
+			body, err := json.Marshal(api.SandboxProxyDisabledRequest{
+				Reason:       reason,
+				SessionId:    "session-shape-test",
+				SandboxMode:  &mode,
+				SandboxImage: &image,
+			})
+			if err != nil {
+				t.Fatalf("marshal request: %v", err)
+			}
+			req := httptest.NewRequest(http.MethodPost, "/v1/sandbox-proxy/disabled", bytes.NewReader(body))
+			rec := httptest.NewRecorder()
+			srv.RecordSandboxProxyDisabled(rec, req)
+			if rec.Code != http.StatusNoContent {
+				t.Fatalf("status = %d, want 204", rec.Code)
+			}
+			events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+			if len(events) != 1 {
+				t.Fatalf("events = %d, want 1", len(events))
+			}
+			if events[0].EventType != model.EventTypeSandboxProxyDisabled {
+				t.Fatalf("event type = %q", events[0].EventType)
+			}
+			sandboxProxyDisabledShape.validate(t, events[0].Payload)
+			if got := events[0].Payload["aileron.proxy.disabled_reason"]; got != string(reason) {
+				t.Errorf("disabled_reason = %v, want %q", got, reason)
+			}
+		})
+	}
+}
+
+// TestSandboxProxyAuditShape_NoCredentialLeakAcrossFamilies is the
+// cross-family no-credential-leak sweep (gate E): the single most
+// load-bearing invariant for the credential-sealing claim. It drives
+// every sandbox/data-plane audit emitter with inputs that carry
+// credential-shaped substrings — an Authorization: Bearer header, a
+// secret-shaped header, and a query string on the upstream URL — and
+// asserts no emitter's serialized payload echoes any of them. Host and
+// path are surfaced; query strings, headers, and credential bytes are
+// not.
+func TestSandboxProxyAuditShape_NoCredentialLeakAcrossFamilies(t *testing.T) {
+	const (
+		bearer    = "Bearer test-token"
+		linSecret = "lin_secret_xyz"
+		query     = "token=value"
+	)
+	forbidden := []string{bearer, linSecret, query, "?" + query, "test-token"}
+
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-leak-sweep" }),
+	}
+
+	poison := func(req *http.Request) *http.Request {
+		req.Header.Set("X-Aileron-Session-Id", "session-leak-sweep")
+		req.Header.Set("Authorization", bearer)
+		req.Header.Set("X-Aileron-Upstream-Secret", linSecret)
+		return req
+	}
+
+	// Upstream URL carries credential-shaped query parameters; the
+	// recorders must surface host + path only, never the raw query.
+	upstream, err := url.Parse("https://api.example.test/v1/resource?" + query + "&secret=" + linSecret)
+	if err != nil {
+		t.Fatalf("parse upstream: %v", err)
+	}
+	op := discovery.SpecOperationHelp{
+		Name: "viewer.get", Method: "GET", Path: "/v1/resource", Credential: "api_key",
+		Hosts: []string{"api.example.test"},
+	}
+	const fqn = "github://acme/aileron-connector-linear"
+
+	proxyReq := poison(httptest.NewRequest(http.MethodConnect, "/", nil))
+	srv.recordSandboxProxyProxied(proxyReq, sandboxProxySourceTransparentConnectTLS, fqn, "linear", "GET", upstream, op, 200)
+	srv.recordSandboxProxyRejected(proxyReq, sandboxProxySourceTransparentConnectTLS, fqn, "linear", "GET", upstream, op, "upstream_transport_failed")
+	srv.recordSandboxProxyProtocolRejected(proxyReq, sandboxProxySourceTransparentConnectTLS, "GET", upstream, "session_ca_unavailable")
+	srv.recordSandboxProxyPassthrough(proxyReq, sandboxProxySourceTransparentConnectTLS, "GET", upstream, 200)
+	srv.recordConnectorOperationRejected(proxyReq, fqn, "linear", op)
+
+	mode := "docker"
+	disabledBody, err := json.Marshal(api.SandboxProxyDisabledRequest{
+		Reason:      api.UserOptOut,
+		SessionId:   "session-leak-sweep",
+		SandboxMode: &mode,
+	})
+	if err != nil {
+		t.Fatalf("marshal disabled request: %v", err)
+	}
+	disabledReq := poison(httptest.NewRequest(http.MethodPost, "/v1/sandbox-proxy/disabled", bytes.NewReader(disabledBody)))
+	srv.RecordSandboxProxyDisabled(httptest.NewRecorder(), disabledReq)
+
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 6 {
+		t.Fatalf("events = %d, want 6 (one per emitter)", len(events))
+	}
+	for _, ev := range events {
+		payloadJSON, _ := json.Marshal(ev.Payload)
+		for _, f := range forbidden {
+			if strings.Contains(string(payloadJSON), f) {
+				t.Errorf("[%s] payload leaks credential-shaped substring %q: %s", ev.EventType, f, string(payloadJSON))
+			}
+		}
+	}
 }


### PR DESCRIPTION
## Summary

Closes the remaining active gates (A, E, F) on the narrowed **898N** scope of #898 (v4 runtime audit schema for sandbox/data-plane flows). No production code changes — this pins already-shipped event families with conformance tests and documents the redaction contract.

- **Gate A** — `sandbox.proxy.disabled` conformance test. Adds `sandboxProxyDisabledShape` and `TestSandboxProxyAuditShape_SandboxProxyDisabledConforms`, exercising `RecordSandboxProxyDisabled` across all three `disabled_reason` enums (`user_opt_out`, `preflight_failed`, `unsupported_sandbox_mode`) via subtests.
- **Gate E** — cross-family no-credential-leak sweep. Adds `TestSandboxProxyAuditShape_NoCredentialLeakAcrossFamilies`, the single most load-bearing invariant for the credential-sealing claim. It drives every sandbox/data-plane emitter (`recordSandboxProxyProxied`, `recordSandboxProxyRejected`, `recordSandboxProxyProtocolRejected`, `recordSandboxProxyPassthrough`, `RecordSandboxProxyDisabled`, `recordConnectorOperationRejected`) with credential-shaped inputs (`Authorization: Bearer test-token` header, a secret-shaped header, and a `?token=value&secret=lin_secret_xyz` query on the upstream URL) and asserts no serialized payload echoes any of them.
- **Gate F** — redaction rules in prose. New "Redaction rules" subsection in `docs/.../guides/observability.md` enumerating credential bytes (per binding kind), `Authorization:` header values, query strings, and full upstream URLs, with host + path allowed and query forbidden. Links the gate-E sweep as the authoritative pinning.

Documented-defer decisions B and C are satisfied by the issue body itself; former gate D (canonical schema doc) remains deferred.

## Test plan

- [x] `go test ./internal/app/ -run TestSandboxProxyAuditShape -v` — all shape tests pass, including the new disabled (3 subtests) and no-leak sweep.
- [x] `task vet:go` clean.
- [x] `task test:go` — full Go suite green (58 packages ok, exit 0).
- [x] `internal/app` coverage 81.9% (≥80% bar holds; test-only + docs change).
- [x] CodeRabbit review on uncommitted changes — no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated observability guide with explicit redaction rules for audit events, clarifying that sensitive data—including credentials, authorization headers, query strings, URLs, and request/response bodies—are never recorded in sandbox HTTPS data-plane audit events.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->