### PR TITLE
fix(vault): sanitize untrusted session header in credential audit

### DIFF
--- a/internal/app/handlers_local_vault_secrets.go
+++ b/internal/app/handlers_local_vault_secrets.go
@@ -25,15 +25,61 @@ const vaultCredentialSessionHeader = "X-Aileron-Session-Id"
 // as a loopback service actor rather than minting a new ActorType.
 const vaultCredentialLoopbackActorID = "loopback"
 
+// maxSessionIDLen caps the length of an accepted X-Aileron-Session-Id
+// after sanitization. The header is untrusted (the loopback endpoint is
+// reachable by any local process, so the value can be forged), and it
+// flows into both the audit actor ID and the `aileron.session.id`
+// payload. A bound prevents an unbounded attacker-controlled string from
+// bloating audit records.
+const maxSessionIDLen = 128
+
+// sanitizeSessionID treats the X-Aileron-Session-Id header as untrusted
+// input. It trims surrounding whitespace, restricts the value to a safe
+// allow-list (ASCII alphanumerics plus `-`, `_`, `.`), and truncates to
+// maxSessionIDLen. Disallowed bytes — including CR/LF and other control
+// characters that could forge extra slog fields or audit-record lines —
+// are dropped. The result is empty when the input is absent or contains
+// no allow-listed characters, which the caller treats as "no session"
+// (falling back to the loopback service actor). Truncation happens after
+// filtering so a long run of disallowed bytes cannot crowd out the
+// allowed suffix.
+func sanitizeSessionID(raw string) string {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return ""
+	}
+	var b strings.Builder
+	for _, c := range raw {
+		if b.Len() >= maxSessionIDLen {
+			break
+		}
+		switch {
+		case c >= 'a' && c <= 'z',
+			c >= 'A' && c <= 'Z',
+			c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.':
+			b.WriteRune(c)
+		default:
+			// Drop anything else (whitespace, control bytes, punctuation,
+			// non-ASCII) so no CR/LF or other injection reaches the slog
+			// line or the audit payload.
+		}
+	}
+	return b.String()
+}
+
 // vaultCredentialActor resolves the requester for a per-agent
 // credential operation. When the optional session header is present it
 // attributes the operation to that launch session; otherwise it falls
-// back to the loopback service actor. The returned sessionID is empty
-// unless the header supplied one, so callers can decide whether to
-// stamp `aileron.session.id` into the payload.
+// back to the loopback service actor. The header is untrusted, so it is
+// sanitized at this single read site (the only place it enters the audit
+// surface); both the actor ID and the returned sessionID derive from the
+// already-bounded value. The returned sessionID is empty unless the
+// header supplied an allow-listed value, so callers can decide whether
+// to stamp `aileron.session.id` into the payload.
 func vaultCredentialActor(r *http.Request) (actor model.ActorRef, sessionID string) {
 	if r != nil {
-		sessionID = strings.TrimSpace(r.Header.Get(vaultCredentialSessionHeader))
+		sessionID = sanitizeSessionID(r.Header.Get(vaultCredentialSessionHeader))
 	}
 	if sessionID != "" {
 		return model.ActorRef{Type: model.ActorTypeService, ID: sessionID}, sessionID
@@ -239,6 +285,12 @@ func (s *apiServer) DeleteAgentCredentials(w http.ResponseWriter, r *http.Reques
 	}
 
 	path := agentCredentialVaultPath(name)
+	// The existence check decrypts the stored credential, but the secret
+	// is intentionally discarded with `_`: DELETE binds only the agent
+	// name, never the loaded value. emitVaultCredentialEvent takes only
+	// `name`, so the decrypted bytes can never reach an audit payload or
+	// session-log line (ADR-0011: no plaintext credential in any record).
+	// Do not bind or log this Get result.
 	_, err := s.vault.Get(ctx, path)
 	if vault.IsNotFound(err) {
 		writeError(w, http.StatusNotFound, "vault_not_found",

--- a/internal/app/handlers_local_vault_secrets_test.go
+++ b/internal/app/handlers_local_vault_secrets_test.go
@@ -822,3 +822,167 @@ func assertFailureClass(t *testing.T, e audit.Event, want string) {
 		t.Errorf("aileron.failure.class = %v, want %q", got, want)
 	}
 }
+
+// X-Aileron-Session-Id is untrusted (the loopback endpoint is reachable
+// by any local process). The handler must sanitize it before it reaches
+// the audit actor ID, the `aileron.session.id` payload, or the slog
+// line: bound the length, restrict to a safe charset, and strip control
+// bytes so a forged header cannot inject extra log fields or bloat the
+// record. When sanitization empties the value, the actor falls back to
+// the loopback service ref.
+
+func putWithSessionHeader(t *testing.T, s *apiServer, name, header string) {
+	t.Helper()
+	body := api.AgentCredentials{Value: []byte(vaultCredentialSecret)}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/v1/vault/agents/"+name+"/credentials",
+		bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Aileron-Session-Id", header)
+	rec := httptest.NewRecorder()
+	s.PutAgentCredentials(rec, req, name)
+	assertStatus(t, rec, http.StatusNoContent)
+}
+
+func TestSanitizeSessionID(t *testing.T) {
+	long := strings.Repeat("a", maxSessionIDLen+50)
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"empty", "", ""},
+		{"whitespace only", "   \t\n", ""},
+		{"normal value unchanged", "sess-123", "sess-123"},
+		{"allowed punctuation kept", "a-b_c.d", "a-b_c.d"},
+		{"trims surrounding space", "  sess-123  ", "sess-123"},
+		{"strips CR/LF injection", "sess-123\r\nactor=admin", "sess-123actoradmin"},
+		{"strips control bytes", "se\x00ss\x07", "sess"},
+		{"strips disallowed punctuation", "a=b c/d", "abcd"},
+		{"only-disallowed becomes empty", "=/ \t\n@", ""},
+		{"truncates to cap", long, strings.Repeat("a", maxSessionIDLen)},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := sanitizeSessionID(c.in); got != c.want {
+				t.Errorf("sanitizeSessionID(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
+func TestVaultCredentials_ForgedSessionHeaderIsSanitized(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	// A forged header injects a CR/LF plus a fake log field. After
+	// sanitization only the allow-listed bytes survive, concatenated.
+	putWithSessionHeader(t, s, "claude", "sess-1\r\nactor=admin")
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialWrite)
+	const wantID = "sess-1actoradmin"
+	if ev.Actor.ID != wantID {
+		t.Errorf("actor ID = %q, want %q", ev.Actor.ID, wantID)
+	}
+	if ev.Payload["aileron.session.id"] != wantID {
+		t.Errorf("session id = %v, want %q", ev.Payload["aileron.session.id"], wantID)
+	}
+	// No raw CR/LF or a second forged log line reached the buffer/payload.
+	if strings.Contains(logBuf.String(), "\nactor=admin") {
+		t.Errorf("slog buffer contains an injected log line: %q", logBuf.String())
+	}
+	raw, err := json.Marshal(ev.Payload)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.ContainsAny(string(raw), "\r\n") {
+		t.Errorf("audit payload contains raw control bytes: %s", string(raw))
+	}
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestVaultCredentials_OverLengthSessionHeaderTruncated(t *testing.T) {
+	s, store, _ := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	header := strings.Repeat("x", maxSessionIDLen+25)
+	putWithSessionHeader(t, s, "claude", header)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialWrite)
+	want := strings.Repeat("x", maxSessionIDLen)
+	if ev.Actor.ID != want {
+		t.Errorf("actor ID len = %d, want %d", len(ev.Actor.ID), maxSessionIDLen)
+	}
+	if ev.Payload["aileron.session.id"] != want {
+		t.Errorf("session id len = %d, want %d", len(ev.Payload["aileron.session.id"].(string)), maxSessionIDLen)
+	}
+}
+
+func TestVaultCredentials_AllDisallowedSessionHeaderFallsBackToLoopback(t *testing.T) {
+	s, store, _ := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	// Header of only-disallowed chars sanitizes to empty -> loopback.
+	putWithSessionHeader(t, s, "claude", "=/@ \t")
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialWrite)
+	if ev.Actor.Type != model.ActorTypeService || ev.Actor.ID != "loopback" {
+		t.Errorf("actor = %+v, want service/loopback", ev.Actor)
+	}
+	if _, ok := ev.Payload["aileron.session.id"]; ok {
+		t.Errorf("sanitized-empty header must omit aileron.session.id: %v", ev.Payload)
+	}
+}
+
+// DELETE existence-check guard (acceptance item 2): the secret loaded by
+// the existence Get is discarded and must never surface in the audit
+// payload or session log, even though it is decrypted in memory.
+
+func TestDeleteAgentCredentials_LoadedSecretNeverLogged(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, vault.NewMemVault())
+	putAuditableCredential(t, s, "claude")
+
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/vault/agents/claude/credentials", nil)
+	s.DeleteAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusNoContent)
+
+	events := listVaultCredentialEvents(t, store)
+	requireSingleEvent(t, events, model.EventTypeVaultCredentialDelete)
+	// The existence Get decrypted the stored secret; assert that none of
+	// its bytes reached either surface even though it was loaded.
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+// DELETE 500-branch auditing (acceptance items 1 & 3): both 500 branches
+// emit a failure event with the right class and never leak credential
+// bytes to the payload or slog.
+
+func TestDeleteAgentCredentials_GetErrorEmitsFailureEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, getErrVault{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/vault/agents/claude/credentials", nil)
+	s.DeleteAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusInternalServerError)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialDelete)
+	assertFailureClass(t, ev, "vault_get_failed")
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
+func TestDeleteAgentCredentials_DeleteErrorEmitsFailureEvent(t *testing.T) {
+	// deleteErrVault.Get returns a secret value before Delete fails, so
+	// this also reinforces the Unit 2 guard: the loaded secret must not
+	// leak on the vault_delete_failed path.
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, deleteErrVault{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodDelete, "/v1/vault/agents/claude/credentials", nil)
+	s.DeleteAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusInternalServerError)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialDelete)
+	assertFailureClass(t, ev, "vault_delete_failed")
+	assertNoCredentialLeak(t, events, logBuf)
+}


### PR DESCRIPTION
## Summary

Review-residual hardening for #985 (per-agent vault credential audit logging). PR #1001 already merged the bulk of the audit emitter, shared leak-scan assertion, and per-verb failure events. This closes the remaining gaps from the brief.

- **Sanitize the untrusted `X-Aileron-Session-Id` header (the real open gap).** The loopback endpoint is reachable by any local process, so the header is forgeable. It previously flowed in raw (only `TrimSpace`) into the audit actor ID, the `aileron.session.id` payload, and the slog line — a log-injection / unbounded-id exposure. New `sanitizeSessionID` (called at the single read site in `vaultCredentialActor`) trims, restricts to an ASCII allow-list (`A-Za-z0-9`, `-`, `_`, `.`), drops CR/LF and other control bytes, and caps at `maxSessionIDLen = 128`. A sanitized-to-empty value falls back to the loopback service actor exactly as the empty-header path does today.
- **Explicit guard on the DELETE existence-Get.** The decrypted secret is discarded with `_` and a load-bearing comment now states the intent (ADR-0011: no plaintext credential in any record). The emitter signature still takes only `name`.
- **Close the two DELETE 500-branch auditing gaps.** New auditing-server tests prove `vault_get_failed` and `vault_delete_failed` each emit one failure event with the right `aileron.failure.class` and never leak credential bytes.

### Decisions / non-changes (for the reviewer)

- **No switch from `RecordSuccess` to `RecordFailure`.** The brief only requires failure events be *emitted* with the error class, which the merged emitter already does via `RecordSuccess` + `aileron.failure.class`. `RecordFailure` would force `EventTypeExecutionFailed` and alter EventType semantics — not requested.
- **No OpenAPI / generated-code change.** `X-Aileron-Session-Id` is an optional, undeclared convention header (it is not in `internal/api/openapi.yaml`); this work adds no endpoint/schema/parameter.
- **Scope is `handlers_local_vault_secrets.go` only.** The identical untrusted-header read in `handlers_connector_operations.go` and `handlers_sandbox_proxy_disabled.go` is out of scope per the brief. **Follow-up candidate:** factor the sanitization into a shared helper and apply it at those two read sites too.

## Test plan

- [x] `go test ./internal/app/ -run 'TestVaultCredentials|TestSanitizeSessionID|TestDeleteAgentCredentials'` green, including:
  - `TestSanitizeSessionID` table (empty, whitespace-only, normal, allowed punctuation, CR/LF injection, control bytes, only-disallowed -> empty, truncation)
  - `TestVaultCredentials_ForgedSessionHeaderIsSanitized` (no injected log line / raw control bytes in slog buffer or payload)
  - `TestVaultCredentials_OverLengthSessionHeaderTruncated`
  - `TestVaultCredentials_AllDisallowedSessionHeaderFallsBackToLoopback`
  - `TestDeleteAgentCredentials_LoadedSecretNeverLogged` (decrypted-then-discarded secret absent from both surfaces)
  - `TestDeleteAgentCredentials_GetErrorEmitsFailureEvent` / `..._DeleteErrorEmitsFailureEvent`
- [x] Full `go test ./internal/app/ -cover` green at 82.0%; `sanitizeSessionID` and `vaultCredentialActor` at 100%.
- [x] `gofmt`, `go vet ./internal/app/`, `go build ./internal/...` clean.

Closes #998

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced session identifier validation with whitespace trimming, character filtering, and length enforcement.
  * Reinforced credential protection mechanisms to prevent plaintext credentials from appearing in audit records.

* **Tests**
  * Expanded test coverage for session identifier sanitization across various invalid input scenarios.
  * Added tests verifying credentials are protected throughout audit and error logging paths.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->