### PR TITLE
fix(sandbox): isolate runtime child pgrp and harden SIGINT salvage

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -773,9 +773,23 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 	// stops the named container with a bounded grace window then runs
 	// the same captureOnce the clean-exit gate uses. SIGKILL stays
 	// uncatchable and intentionally bypasses this path.
+	//
+	// Cleanup discipline is borrowed from launchDirect (signal.Stop +
+	// close + drain) — but NOT its signal-*forwarding* behavior.
+	// launchDirect forwards the caught signal to the child
+	// (cmd.Process.Signal(sig)); the salvage path does the opposite,
+	// catching the signal and issuing a graceful stop itself, so the
+	// forward-to-child loop is intentionally not reused here.
 	sigCh := make(chan os.Signal, 1)
 	sandboxSignalNotify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	salvageDone := make(chan struct{})
+	// signalFired records whether the goroutine read a real signal (vs.
+	// observing the clean-exit close below). It makes the "the drain
+	// below only blocks on salvage when a signal actually fired" intent
+	// explicit: on a clean exit the goroutine takes the channel-closed
+	// branch and returns immediately, so <-salvageDone is bounded and
+	// never waits on Capture.
+	var signalFired bool
 	go func() {
 		defer close(salvageDone)
 		sig, ok := <-sigCh
@@ -783,8 +797,10 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 			// Channel closed by the clean-exit path below; no signal
 			// arrived. The container exited on its own and the clean-
 			// exit gate owns Capture, so there is nothing to salvage.
+			// signalFired stays false; the drain returns at once.
 			return
 		}
+		signalFired = true
 		// A SIGINT/SIGTERM is tearing the foreground container down
 		// before the clean-exit Capture gate can run. Best-effort stop
 		// the named container with a bounded grace window, then salvage
@@ -809,13 +825,22 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 
 	// Stop signal delivery and drain the salvage goroutine before
 	// returning so no post-return signal is caught and no goroutine
-	// leaks (mirrors launchDirect's signal.Stop discipline). Closing
-	// sigCh unblocks the goroutine on the clean-exit path; if a signal
-	// already landed the goroutine is mid-salvage and salvageDone closes
-	// once Capture completes.
+	// leaks (mirrors launchDirect's signal.Stop discipline — only the
+	// cleanup shape transfers, not launchDirect's forward-to-child
+	// behavior). The drain is bounded: closing sigCh unblocks the
+	// goroutine on the clean-exit path (signalFired stays false) and it
+	// returns without running salvage, so <-salvageDone completes at
+	// once. Only when a signal actually fired (signalFired true) does the
+	// drain wait, and only until the goroutine's stop+Capture finish — so
+	// no truncated-mid-PUT race and no hang on the clean path.
 	sandboxSignalStop(sigCh)
 	close(sigCh)
 	<-salvageDone
+	// Reading signalFired here is safe: the goroutine's only write to it
+	// happens-before it closes salvageDone, which this receive observes.
+	if signalFired && sessionLog != nil {
+		sessionLog.Info("sandbox salvage completed", "container", containerName)
+	}
 
 	if err != nil {
 		return exitResult(err)
@@ -1055,6 +1080,12 @@ func launchDirect(cmd *exec.Cmd, config LaunchConfig) (LaunchResult, error) {
 		return LaunchResult{}, fmt.Errorf("failed to start %s: %w", config.Agent.Name(), err)
 	}
 
+	// Host launch FORWARDS the caught signal to the child so the agent's
+	// own Ctrl-C handling runs unchanged. This is the opposite of the
+	// sandbox salvage path (launchSandbox), which CATCHES the signal and
+	// issues a graceful `docker stop` itself. Only launchDirect's cleanup
+	// discipline (signal.Stop + close) is reused there, never this
+	// forward-to-child loop. See ADR-0025 and issue #999.
 	sigCh := make(chan os.Signal, 1)
 	signal.Notify(sigCh, syscall.SIGINT, syscall.SIGTERM)
 	go func() {

--- a/internal/launch/launcher_signal_test.go
+++ b/internal/launch/launcher_signal_test.go
@@ -1,11 +1,13 @@
 package launch
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"io"
 	"log/slog"
 	"os"
+	"path/filepath"
 	"sync"
 	"sync/atomic"
 	"syscall"
@@ -13,6 +15,7 @@ import (
 	"time"
 
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/vault"
 )
 
 // signalTestHarness swaps the launchSandbox test seams for fakes and
@@ -241,6 +244,126 @@ func TestNewSalvageCaptureFiresOnce(t *testing.T) {
 	once()
 	if n.Load() != 1 {
 		t.Fatalf("CaptureFn fired %d times, want exactly 1", n.Load())
+	}
+}
+
+// buildSalvageCaptureFn constructs a CaptureFn shaped exactly like the
+// one prepareAuthSpec produces: it reclaims the transient dir ownership
+// (recording the call order), reads the host-side credential file, and
+// PUTs the bytes to the daemon. This lets the salvage regression assert
+// the real flush behavior — reclaim-before-read plus an end-to-end PUT —
+// without re-running prepareAuthSpec's full machinery.
+func buildSalvageCaptureFn(daemon authSpecDaemon, hostPath, vaultName string, order *[]string) func(context.Context) {
+	// reclaim mirrors prepareAuthSpec's reclaimTransientDir hook (#1005):
+	// ownership is reclaimed to the host operator before the read so the
+	// vault PUT can read a file the agent rotated as the agent UID.
+	reclaim := func(string) {
+		*order = append(*order, "reclaim")
+	}
+	return func(ctx context.Context) {
+		reclaim(filepath.Dir(hostPath))
+		b, err := os.ReadFile(hostPath)
+		if err != nil {
+			return
+		}
+		*order = append(*order, "read")
+		_ = daemon.PutAgentCredentials(ctx, vaultName, vault.Secret{
+			Value:    b,
+			Metadata: vault.Metadata{Type: "oauth_refresh_token"},
+		})
+	}
+}
+
+// TestLaunchSandboxSignalFlushesCaptureToVault is the end-to-end salvage
+// regression: a mid-session SIGINT must land the agent's rotated
+// credential in the vault, not merely run a closure. It writes a host
+// credential file (models the in-container rotation landing on the bind
+// mount), wraps a prepareAuthSpec-shaped CaptureFn in newSalvageCapture,
+// drives launchSandbox through the signal harness, delivers a synthetic
+// SIGINT, and asserts the fake daemon received exactly one PUT carrying
+// the file's bytes — with reclaim run before the read.
+func TestLaunchSandboxSignalFlushesCaptureToVault(t *testing.T) {
+	hostDir := t.TempDir()
+	hostPath := filepath.Join(hostDir, ".credentials.json")
+	want := []byte(`{"access_token":"rotated-by-agent","refresh_token":"r2"}`)
+	if err := os.WriteFile(hostPath, want, 0o600); err != nil {
+		t.Fatalf("seed host credential: %v", err)
+	}
+
+	daemon := newFakeDaemon()
+	var order []string
+	captureFn := buildSalvageCaptureFn(daemon, hostPath, "claude", &order)
+	once := newSalvageCapture(captureFn)
+
+	h := newSignalTestHarness(t)
+	go h.deliverSignal()
+	_, err := runSalvageLaunchSandbox(t, once)
+	if err == nil {
+		t.Fatal("expected non-nil run error after force-kill")
+	}
+
+	if h.stopCalls.Load() != 1 {
+		t.Fatalf("stop issued %d times, want 1", h.stopCalls.Load())
+	}
+	if name, _ := h.stopName.Load().(string); name != "aileron-sbx-test" {
+		t.Fatalf("stop targeted %q, want aileron-sbx-test", name)
+	}
+
+	daemon.mu.Lock()
+	puts := append([]putRecord(nil), daemon.puts...)
+	daemon.mu.Unlock()
+	if len(puts) != 1 {
+		t.Fatalf("daemon received %d PUTs, want exactly 1", len(puts))
+	}
+	if puts[0].Name != "claude" {
+		t.Fatalf("PUT name = %q, want claude", puts[0].Name)
+	}
+	if !bytes.Equal(puts[0].Secret.Value, want) {
+		t.Fatalf("PUT bytes = %q, want %q", puts[0].Secret.Value, want)
+	}
+	// Reclaim-before-read invariant (#1005): the salvage path's
+	// captureOnce must reclaim ownership before reading the host file.
+	if len(order) < 2 || order[0] != "reclaim" || order[1] != "read" {
+		t.Fatalf("call order = %v, want reclaim before read", order)
+	}
+}
+
+// TestLaunchSandboxCleanExitFlushesCaptureOnce verifies the clean-exit
+// path flushes the rotated credential exactly once through the caller's
+// gate (newSalvageCapture), and the salvage path does not double-fire
+// it. launchSandbox itself must not Capture on a clean exit; the caller
+// invokes once() after a nil run error.
+func TestLaunchSandboxCleanExitFlushesCaptureOnce(t *testing.T) {
+	hostDir := t.TempDir()
+	hostPath := filepath.Join(hostDir, ".credentials.json")
+	want := []byte(`{"access_token":"clean-exit","refresh_token":"r3"}`)
+	if err := os.WriteFile(hostPath, want, 0o600); err != nil {
+		t.Fatalf("seed host credential: %v", err)
+	}
+
+	daemon := newFakeDaemon()
+	var order []string
+	once := newSalvageCapture(buildSalvageCaptureFn(daemon, hostPath, "claude", &order))
+
+	h := newSignalTestHarness(t)
+	go h.cleanExit()
+	if _, err := runSalvageLaunchSandbox(t, once); err != nil {
+		t.Fatalf("clean exit returned error: %v", err)
+	}
+	// launchSandbox must not have Captured on clean exit.
+	daemon.mu.Lock()
+	if n := len(daemon.puts); n != 0 {
+		daemon.mu.Unlock()
+		t.Fatalf("launchSandbox PUT %d times on clean exit; the caller's gate owns it", n)
+	}
+	daemon.mu.Unlock()
+	// The caller's clean-exit gate fires the same wrapper.
+	once()
+	daemon.mu.Lock()
+	puts := len(daemon.puts)
+	daemon.mu.Unlock()
+	if puts != 1 {
+		t.Fatalf("daemon received %d PUTs after caller gate, want exactly 1", puts)
 	}
 }
 

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -56,6 +56,14 @@ func (execRunner) Run(ctx context.Context, name string, args []string, stdout, s
 	cmd.Stdin = os.Stdin
 	cmd.Stdout = stdout
 	cmd.Stderr = stderr
+	// Put the runtime child in its own process group so a terminal
+	// Ctrl-C (SIGINT to the foreground process group) reaches only
+	// aileron, not `docker`/`podman` directly. This keeps aileron's
+	// AuthSpec salvage handler the sole owner of teardown — an orderly
+	// `docker stop --time` followed by Capture — instead of racing a
+	// concurrent runtime-initiated kill. No-op on Windows. See ADR-0025
+	// and issue #999.
+	setRuntimeChildPgid(cmd)
 	return cmd.Run()
 }
 
@@ -295,8 +303,17 @@ func (b Builder) Run(ctx context.Context, opts RunOptions) (RunResult, error) {
 // the runtime's own SIGTERM-to-SIGKILL grace window. An empty name is a
 // no-op so callers never have to special-case an anonymous container,
 // and a nil runner falls back to the real runtime so the launcher path
-// works without wiring. The runner's error is returned verbatim; the
-// caller treats a stop failure as non-fatal and proceeds to Capture.
+// works without wiring.
+//
+// On a normal Ctrl-C the launcher runs containers with `--rm`, so the
+// runtime often auto-removes the container before this salvage stop
+// runs. The resulting "No such container" / "is not running" stop error
+// is benign: the container is already gone, which is exactly what the
+// stop wanted. To avoid alarming the user with a spurious warning on the
+// common clean-Ctrl-C path, StopContainer tees the runtime's stderr into
+// a buffer and treats an already-gone signature as success (returns
+// nil). Genuine errors (permission denied, daemon unreachable) are
+// returned verbatim so the caller can still warn.
 func StopContainer(ctx context.Context, runner Runner, runtimeName, name string, graceSeconds int, stdout, stderr io.Writer) error {
 	if strings.TrimSpace(name) == "" {
 		return nil
@@ -310,8 +327,34 @@ func StopContainer(ctx context.Context, runner Runner, runtimeName, name string,
 	if stderr == nil {
 		stderr = io.Discard
 	}
+	var stderrBuf bytes.Buffer
+	teedStderr := io.MultiWriter(stderr, &stderrBuf)
 	args := []string{"stop", "--time", strconv.Itoa(graceSeconds), name}
-	return runner.Run(ctx, runtimeName, args, stdout, stderr)
+	err := runner.Run(ctx, runtimeName, args, stdout, teedStderr)
+	if err != nil && isContainerAlreadyGone(stderrBuf.String()) {
+		return nil
+	}
+	return err
+}
+
+// isContainerAlreadyGone reports whether a container-runtime stop error's
+// stderr indicates the target container was already removed or stopped.
+// Matched case-insensitively against the signatures Docker and Podman
+// emit for a missing or non-running container, so the `--rm`
+// auto-removal race on a clean Ctrl-C does not surface as a warning. See
+// StopContainer and issue #999.
+func isContainerAlreadyGone(stderr string) bool {
+	lowered := strings.ToLower(stderr)
+	for _, signature := range []string{
+		"no such container",
+		"is not running",
+		"already stopped",
+	} {
+		if strings.Contains(lowered, signature) {
+			return true
+		}
+	}
+	return false
 }
 
 // Validate checks that an image can satisfy the minimal launch-time sandbox

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -994,11 +994,66 @@ func TestStopContainerIssuesStopWithGrace(t *testing.T) {
 }
 
 func TestStopContainerReturnsRunnerErrorVerbatim(t *testing.T) {
-	wantErr := errors.New("no such container")
+	// A genuine error whose stderr does not match the already-gone
+	// signature is returned verbatim — only the auto-removal race is
+	// suppressed, not real failures.
+	wantErr := errors.New("permission denied")
 	runner := &callRecordingRunner{errs: []error{wantErr}}
 	err := StopContainer(context.Background(), runner, "podman", "aileron-sbx-y", 10, io.Discard, io.Discard)
 	if !errors.Is(err, wantErr) {
 		t.Fatalf("StopContainer error = %v, want %v", err, wantErr)
+	}
+}
+
+// stderrWritingRunner writes a fixed string to the stderr writer and
+// then returns errReturn, modeling a container runtime that prints a
+// diagnostic to stderr and exits non-zero.
+type stderrWritingRunner struct {
+	stderrText string
+	errReturn  error
+}
+
+func (r *stderrWritingRunner) Run(_ context.Context, _ string, _ []string, _, stderr io.Writer) error {
+	_, _ = io.WriteString(stderr, r.stderrText)
+	return r.errReturn
+}
+
+func TestStopContainerSuppressesAlreadyGone(t *testing.T) {
+	cases := []struct {
+		name   string
+		stderr string
+	}{
+		{"docker no such container", "Error response from daemon: No such container: aileron-sbx-x\n"},
+		{"is not running", "Error: container aileron-sbx-x is not running\n"},
+		{"already stopped", "Error: container already stopped\n"},
+		{"mixed case", "ERROR RESPONSE FROM DAEMON: NO SUCH CONTAINER\n"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var userStderr bytes.Buffer
+			runner := &stderrWritingRunner{stderrText: tc.stderr, errReturn: errors.New("exit status 1")}
+			if err := StopContainer(context.Background(), runner, "docker", "aileron-sbx-x", 10, io.Discard, &userStderr); err != nil {
+				t.Fatalf("StopContainer = %v, want nil (already-gone suppressed)", err)
+			}
+			// The runtime's stderr still reaches the caller's writer so
+			// the user sees the runtime output; only the returned error
+			// is suppressed.
+			if !strings.Contains(userStderr.String(), strings.TrimSpace(tc.stderr)[:5]) {
+				t.Fatalf("expected runtime stderr teed to caller; got %q", userStderr.String())
+			}
+		})
+	}
+}
+
+func TestStopContainerGenuineStderrErrorReturned(t *testing.T) {
+	wantErr := errors.New("exit status 1")
+	runner := &stderrWritingRunner{
+		stderrText: "Error response from daemon: permission denied while trying to connect to the Docker daemon socket\n",
+		errReturn:  wantErr,
+	}
+	err := StopContainer(context.Background(), runner, "docker", "aileron-sbx-x", 10, io.Discard, io.Discard)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("StopContainer error = %v, want %v (genuine error not suppressed)", err, wantErr)
 	}
 }
 

--- a/internal/sandbox/container/sysproc_other.go
+++ b/internal/sandbox/container/sysproc_other.go
@@ -1,0 +1,13 @@
+//go:build windows
+
+package container
+
+import "os/exec"
+
+// setRuntimeChildPgid is a no-op on Windows. Setpgid is a Unix-only
+// SysProcAttr field, and sandbox container launch is a Linux/macOS dev
+// path; Windows uses a different process-teardown model (job objects /
+// CTRL_BREAK), so the terminal-SIGINT-to-process-group race the Unix
+// helper guards against does not apply. The no-op keeps the package
+// building on Windows. See ADR-0025 and issue #999.
+func setRuntimeChildPgid(_ *exec.Cmd) {}

--- a/internal/sandbox/container/sysproc_unix.go
+++ b/internal/sandbox/container/sysproc_unix.go
@@ -1,0 +1,29 @@
+//go:build !windows
+
+package container
+
+import (
+	"os/exec"
+	"syscall"
+)
+
+// setRuntimeChildPgid places the container-runtime child (docker/podman)
+// in its own process group so a terminal Ctrl-C does not reach it
+// directly.
+//
+// A one-shot sandbox container runs in the foreground, so without this
+// the `docker run` child shares aileron's process group. A terminal
+// SIGINT is delivered to the whole foreground process group, which would
+// hit `docker` concurrently with aileron's own salvage handler and tear
+// the container down out from under the graceful `docker stop --time`.
+// Setpgid isolates the child so the terminal SIGINT reaches only
+// aileron, leaving aileron's handler solely responsible for an orderly
+// stop-then-Capture. See ADR-0025 and issue #999.
+//
+// Existing SysProcAttr fields are preserved; only Setpgid is forced on.
+func setRuntimeChildPgid(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+}

--- a/internal/sandbox/container/sysproc_unix_test.go
+++ b/internal/sandbox/container/sysproc_unix_test.go
@@ -1,0 +1,56 @@
+//go:build !windows
+
+package container
+
+import (
+	"context"
+	"os/exec"
+	"syscall"
+	"testing"
+)
+
+// TestSetRuntimeChildPgidSetsPgid asserts the Unix helper places the
+// runtime child in its own process group so a terminal SIGINT does not
+// reach docker/podman directly (issue #999, ADR-0025).
+func TestSetRuntimeChildPgidSetsPgid(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", ":")
+	setRuntimeChildPgid(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil; Setpgid was not configured")
+	}
+	if !cmd.SysProcAttr.Setpgid {
+		t.Fatal("SysProcAttr.Setpgid = false, want true")
+	}
+}
+
+// TestSetRuntimeChildPgidPreservesExistingFields verifies the helper
+// only forces Setpgid on and leaves any pre-set SysProcAttr fields
+// intact.
+func TestSetRuntimeChildPgidPreservesExistingFields(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", ":")
+	cmd.SysProcAttr = &syscall.SysProcAttr{Foreground: false, Pgid: 0}
+	existing := cmd.SysProcAttr
+	setRuntimeChildPgid(cmd)
+	if cmd.SysProcAttr != existing {
+		t.Fatal("helper replaced the existing SysProcAttr rather than mutating it")
+	}
+	if !cmd.SysProcAttr.Setpgid {
+		t.Fatal("SysProcAttr.Setpgid = false, want true")
+	}
+}
+
+// TestExecRunnerRunWithPgidPropagatesExit confirms that setting the
+// child process group does not break normal execution: a fast no-op
+// command still succeeds, and a failing command still propagates a
+// non-nil error. A real terminal-Ctrl-C-to-process-group assertion is
+// not feasible in a headless test runner (no controlling TTY), which is
+// why the isolation correctness is covered by the Setpgid unit checks
+// above plus the salvage tests in internal/launch.
+func TestExecRunnerRunWithPgidPropagatesExit(t *testing.T) {
+	if err := (execRunner{}).Run(context.Background(), "/bin/sh", []string{"-c", ":"}, nil, nil); err != nil {
+		t.Fatalf("no-op command returned %v, want nil", err)
+	}
+	if err := (execRunner{}).Run(context.Background(), "/bin/sh", []string{"-c", "exit 3"}, nil, nil); err == nil {
+		t.Fatal("expected non-nil error from a failing command")
+	}
+}


### PR DESCRIPTION
## Summary

Residual correctness hardening for the #980 SIGINT salvage (builds on #1002/#1005).

- **Process-group isolation (P1).** `execRunner.Run` now sets `SysProcAttr.Setpgid = true` through a build-tagged helper (`sysproc_unix.go` / no-op `sysproc_other.go` on Windows). A one-shot sandbox container runs in the foreground, so a terminal Ctrl-C delivered SIGINT to the whole foreground process group and hit `docker`/`podman` directly, racing aileron's own salvage handler. Isolating the child means the terminal SIGINT reaches only aileron, which then owns an orderly `docker stop --time 10` followed by Capture.
- **`StopContainer` already-gone suppression (P2).** Tees the runtime's stderr into a buffer and treats `No such container` / `is not running` / `already stopped` (case-insensitive) as success. On a clean Ctrl-C the `--rm` container is often auto-removed before the salvage stop runs, so warning unconditionally was noisy. Genuine errors (permission denied, daemon unreachable) still return verbatim.
- **Explicit signal-gated join + comment clarification.** `launchSandbox` now tracks `signalFired` so the bounded-drain intent is explicit: the clean path closes `sigCh`, the goroutine returns without salvage, and `<-salvageDone` completes at once; only a real signal blocks the drain (until stop+Capture finish). Comments at the salvage goroutine and at `launchDirect` make explicit that only `launchDirect`'s cleanup discipline transfers to salvage, not its signal-forwarding behavior.

## Test plan

- [x] `go build ./...` and `GOOS=windows go build ./sandbox/container/...` (build-tagged helper compiles on Windows).
- [x] `go test ./internal/sandbox/container/... ./internal/launch/... -race -cover` — container 91.6%, launch 87.3%.
- [x] `go test ./internal/launch/... -run 'Salvage|FlushesCapture|CleanExit' -race -count=5` (race shakeout).
- [x] `go vet` clean; CodeRabbit review: 0 findings.
- [x] New `TestStopContainerSuppressesAlreadyGone` / `...GenuineStderrErrorReturned` cover the suppression contract.
- [x] New `TestSetRuntimeChildPgid*` assert Setpgid is set and preserves existing fields; `TestExecRunnerRunWithPgidPropagatesExit` confirms normal execution still works.
- [x] New `TestLaunchSandboxSignalFlushesCaptureToVault` proves a synthetic mid-session SIGINT lands the rotated credential bytes in the fake vault exactly once, with reclaim-before-read preserved; `TestLaunchSandboxCleanExitFlushesCaptureOnce` proves the clean path flushes once via the caller's gate.

**Accepted gap:** the real terminal-Ctrl-C-to-process-group race cannot be reproduced in a headless CI runner (no controlling TTY). The Setpgid isolation is correct independent of that observability and is covered by the unit checks plus the deterministic salvage tests.

Closes #999

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signal handling to eliminate misleading logs on clean shutdown
  * Container operations now gracefully handle already-removed containers without reporting errors
  * Enhanced process group isolation to prevent terminal signals from reaching container runtime

* **Tests**
  * Added comprehensive tests for signal-handling credential flushing and shutdown scenarios

<!-- end of auto-generated comment: release notes by coderabbit.ai -->