### PR TITLE
docs(sandbox): remove em-dashes from vault-path table

### DIFF
--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -21,8 +21,8 @@ Per-agent credentials live under the namespace `agents/<name>/<purpose>`:
 | `agents/claude/oauth`   | Claude Code  | FileBinding | `{"claudeAiOauth":{"accessToken":...,"refreshToken":...,"expiresAt":...,"scopes":[...]}}` |
 | `agents/codex/oauth`    | OpenAI Codex | FileBinding | `{"auth_mode":"chatgpt","tokens":{"access_token":...,"refresh_token":...,"id_token":...,"account_id":...},"last_refresh":"..."}` |
 | `agents/goose/oauth`    | Goose        | EnvBinding  | Raw provider API key (opaque bytes), rendered into `ANTHROPIC_API_KEY` |
-| `agents/opencode/oauth` | OpenCode     | FileBinding | `{"<provider>":{...credential...},...}` — `auth.json` keyed by provider name |
-| `agents/pi/oauth`       | Pi           | FileBinding | `{"<provider>":{"type":"api_key","key":...},...}` — `auth.json` keyed by provider name |
+| `agents/opencode/oauth` | OpenCode     | FileBinding | `{"<provider>":{...credential...},...}` (`auth.json` keyed by provider name) |
+| `agents/pi/oauth`       | Pi           | FileBinding | `{"<provider>":{"type":"api_key","key":...},...}` (`auth.json` keyed by provider name) |
 
 Two binding shapes appear in the table. A **FileBinding** backs a rotatable on-disk credential file: the launcher renders the vault bytes into the file before launch and snapshots the (possibly rotated) file back via Capture on clean exit. An **EnvBinding** backs a static credential read from the environment: the launcher renders the stored secret into one or more env vars at launch and has nothing to capture, because an env-key agent does not rewrite a credential file in-container.
 


### PR DESCRIPTION
## Summary

Docs-only cleanup carried over from #983's residual. The vault path scheme table in `docs/src/content/docs/development/sandbox-agent-auth.md` contained the only two remaining em-dashes (`—`) in the file, both in the final `Envelope / secret shape` column where a `—` separated a JSON code span from a trailing prose gloss.

Replaced each `—` with a parenthetical, e.g. `` `<json>` (`auth.json` keyed by provider name) ``. This removes the em-dash, keeps one thought per cell, and preserves the table's 5-column structure (pipe count unchanged).

Two residual items from #996 were deliberately skipped as moot/cosmetic: correcting the now-deleted brief pointer and retitling the closed #983. Noting them here so #996 closes as addressed.

## Test plan

No code test applies to this docs-only prose edit. Verification is by:

- [x] **Grep proof:** `grep -c "—" docs/src/content/docs/development/sandbox-agent-auth.md` returns `0`.
- [x] **Table-render check:** both edited rows keep 5 columns / matching pipe count with the header (line 19); final cell reads naturally as a parenthetical gloss.
- [x] `task lint:docs` (`astro check`) passes with 0 errors / 0 warnings — run as a sanity check only; it does not validate table-cell prose, so it is not cited as proof of the prose edit's correctness.

Closes #996

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified formatting in agent authentication documentation for vault path specifications and secret envelope configurations, improving readability of setup guidelines.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->