### PR TITLE
test(launch): guard authspec bind-mount negative control on root host

### DIFF
--- a/internal/launch/agent_uid_test.go
+++ b/internal/launch/agent_uid_test.go
@@ -312,6 +312,56 @@ func TestChownHooksDelegateToRuntimeOnLinux(t *testing.T) {
 	}
 }
 
+// TestAgentDirChownHookSurfacesResolverError covers the forward-hook
+// closure's resolver-error branch (agent_uid.go): when
+// resolveAgentUIDCached fails inside the closure (e.g. a transient
+// inspect / `id -u` failure on a live launch), the closure must
+// propagate that error — so prepareAuthSpec warns and continues — and
+// must NOT attempt a chown. Linux-only, where the hook is non-nil.
+func TestAgentDirChownHookSurfacesResolverError(t *testing.T) {
+	if goruntime.GOOS != "linux" {
+		t.Skipf("chown hooks are only non-nil on Linux; GOOS=%s", goruntime.GOOS)
+	}
+
+	// Unique image so the failure never lands in (or reads from) a cache
+	// entry shared with another test; the cleanup evicts it regardless.
+	img := "img:resolverr-" + t.Name()
+	t.Cleanup(func() {
+		agentUIDCacheMu.Lock()
+		delete(agentUIDCache, agentUIDCacheKey{runtime: "docker", image: img})
+		agentUIDCacheMu.Unlock()
+	})
+
+	// The first (inspect) call fails, so the resolver returns an error
+	// before any UID is known and the closure must bail out.
+	runner := &fakeUIDRunner{
+		outputs: []string{"no such image\n"},
+		errs:    []error{errors.New("exit status 1")},
+	}
+	hook := newAgentDirChownHook(context.Background(), runner, "docker", img)
+	if hook == nil {
+		t.Fatal("expected non-nil forward hook on Linux")
+	}
+
+	err := hook("/host/transient")
+	if err == nil {
+		t.Fatal("expected the closure to surface the resolver error")
+	}
+	if !strings.Contains(err.Error(), "inspect") {
+		t.Fatalf("error should name the failing resolver step (inspect), got %v", err)
+	}
+	// Only the inspect call may have run; a resolver failure must not be
+	// followed by a chown run.
+	if len(runner.calls) != 1 {
+		t.Fatalf("resolver failure must not trigger a chown; got %d calls: %v", len(runner.calls), runner.calls)
+	}
+	for _, call := range runner.calls {
+		if got := strings.Join(call, " "); strings.Contains(got, "--entrypoint chown") {
+			t.Fatalf("no chown run may be issued after a resolver failure; saw %q", got)
+		}
+	}
+}
+
 func TestChownTreeViaRuntimeRunsPrivilegedChown(t *testing.T) {
 	// The host launcher is unprivileged, so the chown is delegated to a
 	// root container that bind-mounts the tree. Assert the argv encodes

--- a/internal/launch/authspec_bindmount_integration_test.go
+++ b/internal/launch/authspec_bindmount_integration_test.go
@@ -76,6 +76,16 @@ func TestAuthSpecBindMountWritable(t *testing.T) {
 		t.Fatalf("sandbox-base image resolved agent UID 0 (root); the image's USER directive should select the non-root `agent` user — the bind-mount writability contract is meaningless as root")
 	}
 	hostUID := os.Getuid()
+	if hostUID == 0 {
+		// Negative control guard. The container still runs as the non-root
+		// image `agent` user (runAsAgent does not pass --user 0), so the
+		// EPERM the test reproduces fires even when the host runner is root;
+		// a root host does NOT bypass the in-container DAC check. We skip
+		// because a root host does not model the unprivileged operator the
+		// AuthSpec lifecycle targets — the negative control's value is
+		// reproducing the operator's reality, and a root runner is not it.
+		t.Skipf("host runner is root (UID 0); the negative control runs the container as the non-root image `agent` user so EPERM still fires regardless of host root, but a root host does not model the unprivileged operator the AuthSpec lifecycle targets, so the control is run only on a non-root host")
+	}
 	if hostUID == agentUID {
 		t.Skipf("host UID %d equals container agent UID %d; the EPERM mismatch this test guards cannot occur in this environment", hostUID, agentUID)
 	}


### PR DESCRIPTION
## Summary

Review-residual test-robustness follow-ups for #988 (bind-mount chown / reclaim). Scope is purely launch-side test robustness; no production-code, OpenAPI, or approval-gating changes.

- **Unit 1 — negative-control root-host guard.** `TestAuthSpecBindMountWritable` now skips when the host runner is root (UID 0). The skip message states the corrected rationale: `runAsAgent` does not pass `--user 0`, so the container still runs as the non-root image `agent` user and EPERM fires regardless of host root — the skip is because a root host does not model the unprivileged operator the AuthSpec lifecycle targets, NOT because root bypasses the container DAC check. Placed before the `hostUID == agentUID` guard (root is the more fundamental disqualifier).
- **Unit 2 — resolver-error closure-branch unit test.** `TestAgentDirChownHookSurfacesResolverError` (Linux-gated) covers the forward chown hook's previously-uncovered resolver-error branch: when `resolveAgentUIDCached` fails inside the closure (a transient inspect / `id -u` failure on a live launch), the closure propagates the error so the launcher warns and continues, and issues no chown run.

The other items raised by the #988 plan and #1008 findings were verified already satisfied on current `main` via #1005 (dedicated Taskfile target, `chownTreeViaRuntime` + hooks + reclaim, the chown/UID diagnostic, and the success-only cache doc) and are confirmed no-ops here.

## Test plan

- [x] `go test ./internal/launch/...` — all pass.
- [x] `go vet ./internal/launch/...` and `go vet -tags=integration_sandbox ./internal/launch/...` — clean.
- [x] `GOOS=linux go test -tags=integration_sandbox -c ./internal/launch/` — Linux integration package compiles.
- [x] Unit 2 skips on darwin (hook is Linux-only by design) and compiles for Linux; on a Linux host it executes.
- **Accepted environmental gap:** the development/CI host here is non-root macOS, so the Unit 1 root-host skip path and the Unit 2 Linux execution path are reasoned about and compile-verified but not exercised end-to-end here. On a non-root Linux Docker host the integration test runs unchanged; on a root Linux host it self-skips with the corrected message.

Closes #997

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for error handling in agent directory operations.
  * Improved test robustness by adding appropriate skip conditions for root user scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->