### PR TITLE
feat(launch): freshness-gated AuthSpec capture with first-login-safe PUT

### DIFF
--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -93,6 +93,7 @@ func (c Claude) AuthSpec() launch.AuthSpec {
 			Required: false,
 			Render:   claudeRender,
 			Capture:  claudeCapture,
+			Fresher:  claudeFresher,
 		}},
 		StaticFiles: []launch.StaticFile{{
 			ContainerPath: claudeOnboardingContainerPath,

--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -97,6 +97,47 @@ func claudeCapture(b []byte) (vault.Secret, error) {
 	}, nil
 }
 
+// claudeFresher reports whether the captured Claude credential
+// envelope is strictly newer than the one currently in the vault,
+// comparing `claudeAiOauth.expiresAt`. The launcher's CaptureFn
+// calls this in the present@render/present@capture branch so a
+// stale capture (e.g. a second concurrent launch that did not
+// rotate) cannot clobber a fresher rotation.
+//
+// Tie-break hardening for the `expiresAt,omitempty` risk: Anthropic
+// leaves expiresAt absent (0) on some envelopes. Equal timestamps —
+// including both-zero — are NOT strictly newer, so we return false.
+// The one carve-out: if the captured envelope's expiresAt is 0 while
+// the access tokens differ, a real rotation happened that simply did
+// not populate expiresAt. Dropping that write would lose the
+// rotation, so we treat it as fresher. A parse failure on either side
+// returns an error; the launcher then retains the prior entry rather
+// than risk clobbering it with an envelope it cannot reason about.
+func claudeFresher(captured, current vault.Secret) (bool, error) {
+	var capEnv, curEnv claudeCredentialEnvelope
+	if err := json.Unmarshal(captured.Value, &capEnv); err != nil {
+		return false, fmt.Errorf("%w: parse captured: %v", errClaudeEnvelopeMalformed, err)
+	}
+	if err := json.Unmarshal(current.Value, &curEnv); err != nil {
+		return false, fmt.Errorf("%w: parse current: %v", errClaudeEnvelopeMalformed, err)
+	}
+	capExp := capEnv.ClaudeAiOauth.ExpiresAt
+	curExp := curEnv.ClaudeAiOauth.ExpiresAt
+	if capExp > curExp {
+		return true, nil
+	}
+	if capExp == curExp {
+		// Both-zero (or genuinely equal) timestamps are not strictly
+		// newer — except a real rotation that left expiresAt unset.
+		if capExp == 0 &&
+			capEnv.ClaudeAiOauth.AccessToken != curEnv.ClaudeAiOauth.AccessToken {
+			return true, nil
+		}
+		return false, nil
+	}
+	return false, nil
+}
+
 // validateClaudeEnvelope checks the JSON parses and carries a
 // non-empty `claudeAiOauth.accessToken`. We intentionally tolerate
 // extra fields and absent optional fields (Anthropic may add new

--- a/internal/launch/agents/claude_auth_test.go
+++ b/internal/launch/agents/claude_auth_test.go
@@ -3,6 +3,7 @@ package agents_test
 import (
 	"bytes"
 	"errors"
+	"strconv"
 	"strings"
 	"testing"
 
@@ -189,4 +190,52 @@ func TestClaude_Capture_ErrorWrapsSentinel(t *testing.T) {
 	if errors.Is(err, nil) {
 		t.Fatal("Capture error must be non-nil for malformed envelope")
 	}
+}
+
+func TestClaude_Fresher(t *testing.T) {
+	fresher := agents.Claude{}.AuthSpec().FileBindings[0].Fresher
+	if fresher == nil {
+		t.Fatal("Claude binding must supply a Fresher so a stale concurrent capture cannot clobber a fresher rotation")
+	}
+	env := func(token string, expiresAt int64) vault.Secret {
+		if expiresAt == 0 {
+			return vault.Secret{Value: []byte(`{"claudeAiOauth":{"accessToken":"` + token + `"}}`)}
+		}
+		return vault.Secret{Value: []byte(`{"claudeAiOauth":{"accessToken":"` + token + `","expiresAt":` + itoa(expiresAt) + `}}`)}
+	}
+	tests := []struct {
+		name              string
+		captured, current vault.Secret
+		want              bool
+	}{
+		{"newer expiresAt is fresher", env("a", 200), env("a", 100), true},
+		{"older expiresAt is not fresher", env("a", 100), env("a", 200), false},
+		{"equal non-zero expiresAt is not fresher", env("a", 100), env("a", 100), false},
+		{"both-zero same token is not fresher", env("a", 0), env("a", 0), false},
+		{"both-zero different token is a rotation without expiry, treat as fresher", env("new", 0), env("old", 0), true},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fresher(tt.captured, tt.current)
+			if err != nil {
+				t.Fatalf("fresher: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("fresher = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	// A malformed envelope on either side must error so the launcher
+	// retains the prior entry rather than clobbering it.
+	if _, err := fresher(vault.Secret{Value: []byte("not json")}, env("a", 100)); err == nil {
+		t.Error("expected error for malformed captured envelope")
+	}
+	if _, err := fresher(env("a", 100), vault.Secret{Value: []byte("not json")}); err == nil {
+		t.Error("expected error for malformed current envelope")
+	}
+}
+
+func itoa(n int64) string {
+	return strconv.FormatInt(n, 10)
 }

--- a/internal/launch/agents/codex.go
+++ b/internal/launch/agents/codex.go
@@ -105,6 +105,7 @@ func (c Codex) AuthSpec() launch.AuthSpec {
 			Required:         false,
 			Render:           codexRender,
 			Capture:          codexCapture,
+			Fresher:          codexFresher,
 			PreLaunchRefresh: codexPreLaunchRefresh,
 		}},
 	}

--- a/internal/launch/agents/codex_auth.go
+++ b/internal/launch/agents/codex_auth.go
@@ -130,6 +130,62 @@ func parseCodexEnvelope(b []byte) (codexAuthEnvelope, error) {
 	return env, nil
 }
 
+// codexFresher reports whether the captured Codex auth envelope is
+// strictly newer than the one currently in the vault. The freshness
+// timestamp is `tokens.expires_at` (RFC3339) when present, falling
+// back to the top-level `last_refresh` when expires_at is empty —
+// upstream Codex does not always populate expires_at, but it does
+// stamp last_refresh after a rotation. Each side independently uses
+// its own best-available timestamp; comparing a captured expires_at
+// against a current last_refresh (or vice versa) is acceptable
+// because both are monotonic proxies for "when this bundle was
+// minted."
+//
+// captured strictly after current → fresher (true). Equal → false.
+// If neither side yields a parseable timestamp but the access tokens
+// differ, a real rotation happened without a usable freshness signal;
+// we treat it as fresher rather than drop the write. A parse failure
+// of either envelope returns an error so the launcher retains the
+// prior entry.
+func codexFresher(captured, current vault.Secret) (bool, error) {
+	capEnv, err := parseCodexEnvelope(captured.Value)
+	if err != nil {
+		return false, fmt.Errorf("freshness parse captured: %w", err)
+	}
+	curEnv, err := parseCodexEnvelope(current.Value)
+	if err != nil {
+		return false, fmt.Errorf("freshness parse current: %w", err)
+	}
+	capTime, capOK := codexFreshnessTime(capEnv)
+	curTime, curOK := codexFreshnessTime(curEnv)
+	if capOK && curOK {
+		return capTime.After(curTime), nil
+	}
+	// One or both sides lack a parseable timestamp. Don't drop a real
+	// rotation: if the access tokens differ, treat captured as fresher.
+	if capEnv.Tokens.AccessToken != curEnv.Tokens.AccessToken {
+		return true, nil
+	}
+	return false, nil
+}
+
+// codexFreshnessTime returns the envelope's best-available freshness
+// timestamp: tokens.expires_at when parseable, else last_refresh. The
+// bool reports whether any timestamp parsed.
+func codexFreshnessTime(env codexAuthEnvelope) (time.Time, bool) {
+	if env.Tokens.ExpiresAt != "" {
+		if t, err := time.Parse(time.RFC3339, env.Tokens.ExpiresAt); err == nil {
+			return t, true
+		}
+	}
+	if env.LastRefresh != "" {
+		if t, err := time.Parse(time.RFC3339, env.LastRefresh); err == nil {
+			return t, true
+		}
+	}
+	return time.Time{}, false
+}
+
 // codexPreLaunchRefresh checks whether the stored access token is
 // within codexRefreshLeeway of expiry. If so, it exchanges the
 // refresh token for a new bundle via [credential.DoRefresh],

--- a/internal/launch/agents/codex_auth_test.go
+++ b/internal/launch/agents/codex_auth_test.go
@@ -453,3 +453,58 @@ type urlParts struct {
 // readFile reads a host path; tiny indirection kept for clarity at
 // the call site.
 func readFile(path string) ([]byte, error) { return os.ReadFile(path) }
+
+func TestCodex_Fresher(t *testing.T) {
+	fresher := agents.Codex{}.AuthSpec().FileBindings[0].Fresher
+	if fresher == nil {
+		t.Fatal("Codex binding must supply a Fresher so a stale concurrent capture cannot clobber a fresher rotation")
+	}
+	// A valid chatgpt-mode envelope; expiresAt / lastRefresh optional.
+	env := func(token, expiresAt, lastRefresh string) vault.Secret {
+		tokens := `"access_token":"` + token + `","refresh_token":"r"`
+		if expiresAt != "" {
+			tokens += `,"expires_at":"` + expiresAt + `"`
+		}
+		body := `{"auth_mode":"chatgpt","tokens":{` + tokens + `}`
+		if lastRefresh != "" {
+			body += `,"last_refresh":"` + lastRefresh + `"`
+		}
+		body += `}`
+		return vault.Secret{Value: []byte(body)}
+	}
+	t0 := "2026-06-01T00:00:00Z"
+	t1 := "2026-06-02T00:00:00Z"
+	tests := []struct {
+		name              string
+		captured, current vault.Secret
+		want              bool
+	}{
+		{"newer expires_at is fresher", env("a", t1, ""), env("a", t0, ""), true},
+		{"older expires_at is not fresher", env("a", t0, ""), env("a", t1, ""), false},
+		{"equal expires_at is not fresher", env("a", t0, ""), env("a", t0, ""), false},
+		{"last_refresh fallback when no expires_at", env("a", "", t1), env("a", "", t0), true},
+		{"no timestamps, different token is a rotation, treat as fresher", env("new", "", ""), env("old", "", ""), true},
+		{"no timestamps, same token is not fresher", env("a", "", ""), env("a", "", ""), false},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			got, err := fresher(tt.captured, tt.current)
+			if err != nil {
+				t.Fatalf("fresher: %v", err)
+			}
+			if got != tt.want {
+				t.Errorf("fresher = %v, want %v", got, tt.want)
+			}
+		})
+	}
+
+	// A malformed (non-chatgpt) envelope must error so the launcher
+	// retains the prior entry.
+	bad := vault.Secret{Value: []byte(`{"auth_mode":"api_key","tokens":{"access_token":"a"}}`)}
+	if _, err := fresher(bad, env("a", t0, "")); err == nil {
+		t.Error("expected error for malformed captured envelope")
+	}
+	if _, err := fresher(env("a", t0, ""), bad); err == nil {
+		t.Error("expected error for malformed current envelope")
+	}
+}

--- a/internal/launch/authspec.go
+++ b/internal/launch/authspec.go
@@ -104,6 +104,23 @@ type FileBinding struct {
 	// failure mode and recovery path.
 	Capture func([]byte) (vault.Secret, error)
 
+	// Fresher, when non-nil, gates the capture-time vault write on a
+	// freshness comparison. CaptureFn calls it with the secret the
+	// agent just rotated (captured) and the entry currently in the
+	// vault (current); it must return true iff captured is strictly
+	// newer than current. Only a true result triggers the PUT.
+	//
+	// A nil Fresher preserves last-writer-wins: every clean capture
+	// PUTs unconditionally. This is the behavior all agents had before
+	// the hook existed, so leaving Fresher nil is the safe default for
+	// agents that never rotate their credential in-container.
+	//
+	// Returning a non-nil error skips the PUT and retains the prior
+	// vault entry — a comparison the launcher cannot make safely must
+	// never clobber the stored credential. See ADR-0025's
+	// freshness-comparison section.
+	Fresher func(captured, current vault.Secret) (bool, error)
+
 	// PreLaunchRefresh, when non-nil, runs before Render. It
 	// receives the resolved vault secret plus the daemon-backed
 	// dependencies needed to refresh and persist a rotated token,

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -100,13 +100,24 @@ type authSpecPrep struct {
 // rule is "Builder.Run returned nil OR graceful shutdown stopped
 // the container cleanly").
 //
-// The plan calls for a freshness comparison (only PUT when the
-// captured envelope is newer than the current vault entry). v1
-// ships last-writer-wins per the Risks section — concurrent launch
-// races against the same agent are not in the v1 ICP, and the
-// refresh token survives the race because both writers exchanged
-// the same upstream token. A Fresher hook on FileBinding is a
-// clean follow-up if real users surface the concern.
+// Capture decides whether to PUT using a presence-aware, three-way
+// branch keyed on whether the vault entry was present at render time
+// versus at capture time (see ADR-0025's freshness-comparison
+// section):
+//
+//   - absent@render, absent@capture → first-login seed → PUT.
+//   - present@render, absent@capture → the operator ran
+//     `aileron vault delete` mid-session → honor the delete, skip PUT.
+//   - present@render, present@capture → run the binding's Fresher
+//     hook; PUT only when the captured envelope is strictly newer.
+//
+// A FileBinding with a nil Fresher preserves last-writer-wins: the
+// present/present branch PUTs unconditionally. This was the behavior
+// before the hook existed (concurrent launch races against the same
+// agent are not in the v1 ICP, and the refresh token survives the
+// race because both writers exchanged the same upstream token).
+// Agents that rotate their credential in-container (Claude, Codex)
+// supply a Fresher so a stale capture cannot clobber a newer entry.
 // chownTransientDir, when non-nil, is invoked once after every
 // FileBinding and StaticFile has been written to the transient host
 // directory and before the mount list is returned. It receives
@@ -233,6 +244,15 @@ func prepareAuthSpec(
 		HostPath  string
 		VaultName string // last segment of VaultPath
 		Capture   func([]byte) (vault.Secret, error)
+		// PresentAtRender records whether the vault entry existed when
+		// the launcher rendered this binding. It is the only correct
+		// disambiguator between a first-login seed (absent@render) and
+		// a deliberate mid-session delete (present@render) when the
+		// capture-time GET returns not-found.
+		PresentAtRender bool
+		// Fresher is the binding's optional freshness hook; nil
+		// preserves last-writer-wins. See FileBinding.Fresher.
+		Fresher func(captured, current vault.Secret) (bool, error)
 	}
 	var captureTargets []fileCapture
 
@@ -269,9 +289,11 @@ func prepareAuthSpec(
 			// but the group dir still exists for StaticFiles or
 			// other file bindings under the same parent.
 			captureTargets = append(captureTargets, fileCapture{
-				HostPath:  filepath.Join(hostDir, path.Base(fb.ContainerPath)),
-				VaultName: vaultBindingTail(fb.VaultPath),
-				Capture:   fb.Capture,
+				HostPath:        filepath.Join(hostDir, path.Base(fb.ContainerPath)),
+				VaultName:       vaultBindingTail(fb.VaultPath),
+				Capture:         fb.Capture,
+				PresentAtRender: false,
+				Fresher:         fb.Fresher,
 			})
 			continue
 		case getErr != nil:
@@ -313,9 +335,11 @@ func prepareAuthSpec(
 		}
 		prep.RenderedAnyCredential = true
 		captureTargets = append(captureTargets, fileCapture{
-			HostPath:  hostPath,
-			VaultName: vaultBindingTail(fb.VaultPath),
-			Capture:   fb.Capture,
+			HostPath:        hostPath,
+			VaultName:       vaultBindingTail(fb.VaultPath),
+			Capture:         fb.Capture,
+			PresentAtRender: true,
+			Fresher:         fb.Fresher,
 		})
 		// MountAsFile bindings get an individual file mount at
 		// ContainerPath. The mount is writable so Capture can read
@@ -462,6 +486,55 @@ func prepareAuthSpec(
 						fmt.Errorf("schema-validate captured bytes: %w (skipping vault write so a partial-write or schema-drift session does not clobber the prior entry; inspect %s or re-login)",
 							err, target.HostPath))
 					continue
+				}
+				// Decide whether to PUT via the presence-aware,
+				// three-way branch (ADR-0025). Read the current vault
+				// entry: absent-now plus present-at-render means the
+				// operator deleted the entry mid-session and we must
+				// honor the delete; absent-now plus absent-at-render is
+				// a first-login seed and must PUT.
+				current, getErr := daemon.GetAgentCredentials(captureCtx, target.VaultName)
+				absentNow := errors.Is(getErr, ErrAgentCredentialsNotFound)
+				switch {
+				case getErr != nil && !absentNow:
+					// A genuine GET failure (or a cancelled context on
+					// shutdown). Either way we cannot make the freshness
+					// decision safely, so retain the prior entry rather
+					// than blind-PUT and risk clobbering a newer one.
+					if errors.Is(getErr, context.Canceled) || errors.Is(getErr, context.DeadlineExceeded) {
+						captureWarn(sessionLog, stderr, agentName, target.HostPath,
+							fmt.Errorf("capture GET cancelled: %w; skipping freshness-gated PUT to avoid clobbering the vault entry on shutdown", getErr))
+						continue
+					}
+					captureWarn(sessionLog, stderr, agentName, target.HostPath,
+						fmt.Errorf("read current vault entry for freshness check: %w (skipping PUT so the prior entry is retained; rerun the launch to retry)", getErr))
+					continue
+				case absentNow && target.PresentAtRender:
+					// present@render, absent@capture: the operator ran
+					// `aileron vault delete` mid-session. Honor it.
+					captureWarn(sessionLog, stderr, agentName, target.HostPath,
+						errors.New("vault entry deleted mid-session; honoring the delete and skipping capture so the credential is not silently resurrected"))
+					continue
+				case absentNow && !target.PresentAtRender:
+					// absent@render, absent@capture: first-login seed.
+					// PUT unconditionally even when Fresher is non-nil —
+					// there is no prior entry to compare against.
+				default:
+					// present@render, present@capture: gate on Fresher.
+					// nil Fresher preserves last-writer-wins.
+					if target.Fresher != nil {
+						fresher, ferr := target.Fresher(captured, current)
+						if ferr != nil {
+							captureWarn(sessionLog, stderr, agentName, target.HostPath,
+								fmt.Errorf("freshness comparison failed: %w (skipping PUT so the prior vault entry is retained; inspect %s or re-login)", ferr, target.HostPath))
+							continue
+						}
+						if !fresher {
+							captureWarn(sessionLog, stderr, agentName, target.HostPath,
+								errors.New("captured credential is not newer than the vault entry; skipping write so a stale capture does not clobber a fresher rotation"))
+							continue
+						}
+					}
 				}
 				if err := daemon.PutAgentCredentials(captureCtx, target.VaultName, captured); err != nil {
 					captureWarn(sessionLog, stderr, agentName, target.HostPath,

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -46,8 +46,14 @@ type fakeDaemon struct {
 	store     map[string]vault.Secret
 	getErrors map[string]error
 	putErrors map[string]error
-	puts      []putRecord
-	gets      []string
+	// getSeq, when populated for a name, supplies a per-call error
+	// sequence consumed in order. A nil entry means "no error, use the
+	// store" for that call. This lets a scenario make the render GET
+	// succeed and the capture GET cancel/fail without affecting the
+	// other. getSeq takes precedence over getErrors for that name.
+	getSeq map[string][]error
+	puts   []putRecord
+	gets   []string
 }
 
 type putRecord struct {
@@ -60,6 +66,7 @@ func newFakeDaemon() *fakeDaemon {
 		store:     map[string]vault.Secret{},
 		getErrors: map[string]error{},
 		putErrors: map[string]error{},
+		getSeq:    map[string][]error{},
 	}
 }
 
@@ -69,10 +76,31 @@ func (f *fakeDaemon) seed(name string, value []byte) {
 	f.store[name] = vault.Secret{Value: value, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}
 }
 
+// deleteEntry simulates an operator running `aileron vault delete`
+// mid-session: the entry vanishes from the store so a subsequent GET
+// returns ErrAgentCredentialsNotFound.
+func (f *fakeDaemon) deleteEntry(name string) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	delete(f.store, name)
+}
+
 func (f *fakeDaemon) GetAgentCredentials(_ context.Context, name string) (vault.Secret, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 	f.gets = append(f.gets, name)
+	if seq, ok := f.getSeq[name]; ok && len(seq) > 0 {
+		err := seq[0]
+		f.getSeq[name] = seq[1:]
+		if err != nil {
+			return vault.Secret{}, err
+		}
+		s, ok := f.store[name]
+		if !ok {
+			return vault.Secret{}, ErrAgentCredentialsNotFound
+		}
+		return s, nil
+	}
 	if err, ok := f.getErrors[name]; ok {
 		return vault.Secret{}, err
 	}
@@ -293,7 +321,9 @@ func TestPrepareAuthSpec_CaptureOnCleanExitPersistsRotatedFile(t *testing.T) {
 			ContainerPath: "/home/agent/.claude/.credentials.json",
 			Mode:          0o600,
 			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
-			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}, nil },
+			Capture: func(b []byte) (vault.Secret, error) {
+				return vault.Secret{Value: b, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}, nil
+			},
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
@@ -975,6 +1005,165 @@ func TestPrepareAuthSpec_ReclaimHookErrorIsNonFatal(t *testing.T) {
 	}
 	if len(daemon.puts) != 1 {
 		t.Fatalf("capture must still attempt the PUT after a non-fatal reclaim error; puts=%d", len(daemon.puts))
+	}
+}
+
+// freshnessSpec builds a single-FileBinding AuthSpec with byte-identity
+// Render/Capture and the supplied Fresher, for exercising CaptureFn's
+// presence-aware PUT decision.
+func freshnessSpec(fresher func(captured, current vault.Secret) (bool, error)) AuthSpec {
+	return AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Mode:          0o600,
+			Required:      false,
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+			Fresher:       fresher,
+		}},
+	}
+}
+
+func captureHostPath(prep authSpecPrep) string {
+	return filepath.Join(prep.Mounts[0].Source, ".credentials.json")
+}
+
+// P0 regression (see #1010): a first login seeds an empty vault, so the
+// capture-time GET returns NotFound just like a deliberate delete. The
+// entry was ABSENT at render, so this must PUT (seed) — even with a
+// non-nil Fresher that would otherwise gate the write. Skipping it would
+// silently lose every first-login credential.
+func TestPrepareAuthSpec_FirstLoginSeedWithFresherStillPuts(t *testing.T) {
+	daemon := newFakeDaemon() // empty vault → absent at render
+	// A Fresher that always reports "not fresher" — proves the first-login
+	// branch never consults it (there is no prior entry to compare).
+	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return false, nil })
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if err := os.WriteFile(captureHostPath(prep), []byte("seeded-on-first-login"), 0o600); err != nil {
+		t.Fatalf("simulate first-login write: %v", err)
+	}
+	prep.CaptureFn(context.Background())
+
+	if len(daemon.puts) != 1 {
+		t.Fatalf("first-login seed must PUT even with a non-nil Fresher; puts=%d", len(daemon.puts))
+	}
+	if got := string(daemon.puts[0].Secret.Value); got != "seeded-on-first-login" {
+		t.Errorf("seeded value = %q, want seeded-on-first-login", got)
+	}
+}
+
+func TestPrepareAuthSpec_DeliberateDeleteMidSessionSkipsPut(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.seed("claude", []byte("old")) // present at render
+	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return true, nil })
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if err := os.WriteFile(captureHostPath(prep), []byte("rotated"), 0o600); err != nil {
+		t.Fatalf("simulate rotation: %v", err)
+	}
+	daemon.deleteEntry("claude") // operator deletes mid-session
+
+	prep.CaptureFn(context.Background())
+
+	if len(daemon.puts) != 0 {
+		t.Fatalf("a mid-session delete (present@render, absent@capture) must be honored; puts=%d", len(daemon.puts))
+	}
+}
+
+func TestPrepareAuthSpec_StaleCaptureNotFresherSkipsPut(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.seed("claude", []byte("current")) // present at render and capture
+	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return false, nil })
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+	if err := os.WriteFile(captureHostPath(prep), []byte("stale-rotation"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	prep.CaptureFn(context.Background())
+
+	if len(daemon.puts) != 0 {
+		t.Fatalf("a not-fresher capture must not clobber the vault; puts=%d", len(daemon.puts))
+	}
+}
+
+func TestPrepareAuthSpec_FresherTruePuts(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.seed("claude", []byte("current"))
+	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return true, nil })
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+	if err := os.WriteFile(captureHostPath(prep), []byte("fresh-rotation"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	prep.CaptureFn(context.Background())
+
+	if len(daemon.puts) != 1 || string(daemon.puts[0].Secret.Value) != "fresh-rotation" {
+		t.Fatalf("a strictly-fresher capture must PUT; puts=%d", len(daemon.puts))
+	}
+}
+
+func TestPrepareAuthSpec_FresherErrorSkipsPut(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.seed("claude", []byte("current"))
+	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return false, errors.New("malformed envelope") })
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+	if err := os.WriteFile(captureHostPath(prep), []byte("rotation"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	prep.CaptureFn(context.Background())
+
+	if len(daemon.puts) != 0 {
+		t.Fatalf("a Fresher error must retain the prior entry (skip PUT); puts=%d", len(daemon.puts))
+	}
+}
+
+// On a SIGINT/SIGTERM salvage the captureCtx may already be cancelled.
+// A cancelled freshness GET must skip the PUT with a distinct
+// cancellation path rather than clobber or blind-PUT.
+func TestPrepareAuthSpec_CaptureGetCancelledSkipsPut(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.seed("claude", []byte("current"))
+	// Render GET succeeds (store hit); capture GET returns context.Canceled.
+	daemon.getSeq["claude"] = []error{nil, context.Canceled}
+	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return true, nil })
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+	if err := os.WriteFile(captureHostPath(prep), []byte("rotation"), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	prep.CaptureFn(context.Background())
+
+	if len(daemon.puts) != 0 {
+		t.Fatalf("a cancelled capture GET must skip the freshness-gated PUT; puts=%d", len(daemon.puts))
 	}
 }
 


### PR DESCRIPTION
## Summary

Completes #984: adds an optional `FileBinding.Fresher` hook so an in-container credential rotation is PUT back to the vault only when strictly newer than the stored entry, and honors a deliberate mid-session `aileron vault delete` instead of resurrecting the entry on capture.

The capture-time PUT decision is **presence-aware** to avoid the data-loss trap (the P0 a prior plan review caught, #1010): a first login seeds an empty vault, so the capture GET returns `NotFound` exactly like a deliberate delete. Capture branches on whether the entry existed **at render time**:

- absent@render, absent@capture → **first-login seed → PUT** (even with a non-nil `Fresher`)
- present@render, absent@capture → operator deleted mid-session → **skip PUT**
- present@render, present@capture → gate on `Fresher`; nil preserves last-writer-wins

A cancelled capture GET (SIGINT/SIGTERM salvage) skips the PUT distinctly from a genuine failure so graceful shutdown never clobbers the entry. Claude compares `claudeAiOauth.expiresAt`; Codex compares `tokens.expires_at` with a `last_refresh` fallback; both treat token-changed-without-timestamp as a rotation.

This work was produced by an orchestrate-umbrella run whose work agent completed the implementation but crashed before committing; the implementation was verified and the missing tests written during shepherding.

## Test plan

- [x] `go test ./internal/launch/...` — green
- [x] New CaptureFn contract tests: first-login-seed-with-Fresher **PUTs** (P0 regression guard), deliberate-delete skips, stale/not-fresher skips, fresher-true PUTs, Fresher-error skips, cancelled-GET skips
- [x] `TestClaude_Fresher` / `TestCodex_Fresher` cover newer/older/equal/both-zero-rotation/malformed
- [x] Existing `TestPrepareAuthSpec_EmptyVaultFirstLaunchProducesWritableParentMount` still passes (first-login still seeds)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced credential management with intelligent freshness comparison to prevent stale credentials from overwriting newer ones in storage.

* **Tests**
  * Added comprehensive test coverage for credential freshness validation logic and edge cases including rotation scenarios and mid-session deletions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->