### PR TITLE
test(vault): cover GET vault_get_failed 500 audit + leak branch

### DIFF
--- a/internal/app/handlers_local_vault_secrets_test.go
+++ b/internal/app/handlers_local_vault_secrets_test.go
@@ -971,6 +971,19 @@ func TestDeleteAgentCredentials_GetErrorEmitsFailureEvent(t *testing.T) {
 	assertNoCredentialLeak(t, events, logBuf)
 }
 
+func TestGetAgentCredentials_GetErrorEmitsFailureEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, getErrVault{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/agents/claude/credentials", nil)
+	s.GetAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusInternalServerError)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialRead)
+	assertFailureClass(t, ev, "vault_get_failed")
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
 func TestDeleteAgentCredentials_DeleteErrorEmitsFailureEvent(t *testing.T) {
 	// deleteErrVault.Get returns a secret value before Delete fails, so
 	// this also reinforces the Unit 2 guard: the loaded secret must not


### PR DESCRIPTION
## Summary

- Adds `TestGetAgentCredentials_GetErrorEmitsFailureEvent`, exercising the GET handler's `vault_get_failed` 500 branch (`handlers_local_vault_secrets.go:200-203`) for both failure-event emission with the correct class and no credential leak.
- Closes the GET coverage gap raised in residual #1009: previously only the DELETE-side 500 branches had auditing+leak tests, leaving GET's identical emitter path unexercised.

This satisfies the residual's item-1 requirement ("every verb, success + failure" leak/emission guarantee) for GET, mirroring `TestDeleteAgentCredentials_GetErrorEmitsFailureEvent`.

Residual: #1009. Feature: #985.

## Test plan

- [x] `go test ./internal/app/... -run TestGetAgentCredentials_GetErrorEmitsFailureEvent` passes
- [x] Full vault credential suite (Get/Put/Delete/List/Sanitize/VaultCredentials) passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error handling in credential retrieval operations, including audit event validation and credential leak prevention.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->