### PR TITLE
test(vault): pin list-on-locked-vault returns 200 empty (#981)

### DIFF
--- a/internal/app/handlers_local_vault_secrets_test.go
+++ b/internal/app/handlers_local_vault_secrets_test.go
@@ -381,6 +381,30 @@ func TestListAgentCredentials_EmptyVaultReturnsEmptyArray(t *testing.T) {
 	}
 }
 
+func TestListAgentCredentials_LockedVaultReturnsEmptyOK(t *testing.T) {
+	// A locked LockableVault (no inner) returns an empty slice from List
+	// rather than ErrCredentialUnavailable, because listing never
+	// decrypts a stored value (see vault.LockableVault.List). Unlike
+	// Get/Put/Delete, List does NOT yield 423 on a locked vault — it
+	// returns 200 with an empty agents array. Pin that contract so a
+	// future change cannot quietly add a 423 path to list.
+	lv := vault.NewLockableVault()
+	s := newAgentCredentialsServer(t, lv)
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/agents", nil)
+	s.ListAgentCredentials(rec, req)
+	assertStatus(t, rec, http.StatusOK)
+
+	var got api.AgentCredentialsList
+	mustDecode(t, rec.Body, &got)
+	if got.Agents == nil {
+		t.Fatal("agents must be a non-nil (empty) array")
+	}
+	if len(got.Agents) != 0 {
+		t.Errorf("agents = %v, want empty on locked vault", got.Agents)
+	}
+}
+
 func TestListAgentCredentials_FiltersNonAgentPaths(t *testing.T) {
 	v := vault.NewMemVault()
 	s := newAgentCredentialsServer(t, v)


### PR DESCRIPTION
## Summary

- Adds `TestListAgentCredentials_LockedVaultReturnsEmptyOK` to pin that the daemon list-credentials handler returns 200 with an empty agents array on a locked vault (unlike Get/Put/Delete, which return 423).
- Resolves the only remaining actionable finding from the deferred plan-review residual #992 for feature #981.

The locked Get/Put/Delete cases were already enumerated in the test matrix; List was not, leaving room for a future regression that adds a 423 path to listing. `vault.LockableVault.List` returns empty when locked because listing never decrypts a stored value.

## Test plan

- [x] `go test ./internal/app/ -run TestListAgentCredentials -count=1` passes

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage to verify that listing agent credentials returns an empty list with a successful response when the vault is locked.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->