### PR TITLE
test(app): cover GET vault_get_failed 500 audit and leak branch

### DIFF
--- a/internal/app/handlers_local_vault_secrets_test.go
+++ b/internal/app/handlers_local_vault_secrets_test.go
@@ -971,6 +971,23 @@ func TestDeleteAgentCredentials_GetErrorEmitsFailureEvent(t *testing.T) {
 	assertNoCredentialLeak(t, events, logBuf)
 }
 
+// GET 500-branch auditing: a generic vault Get error on the read path emits
+// a vault_get_failed failure event and never leaks credential bytes to the
+// audit payload or the session log.
+
+func TestGetAgentCredentials_GetErrorEmitsFailureEvent(t *testing.T) {
+	s, store, logBuf := newAuditingAgentCredentialsServer(t, getErrVault{})
+	rec := httptest.NewRecorder()
+	req := httptest.NewRequest(http.MethodGet, "/v1/vault/agents/claude/credentials", nil)
+	s.GetAgentCredentials(rec, req, "claude")
+	assertStatus(t, rec, http.StatusInternalServerError)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultCredentialRead)
+	assertFailureClass(t, ev, "vault_get_failed")
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
 func TestDeleteAgentCredentials_DeleteErrorEmitsFailureEvent(t *testing.T) {
 	// deleteErrVault.Get returns a secret value before Delete fails, so
 	// this also reinforces the Unit 2 guard: the loaded secret must not


### PR DESCRIPTION
## Summary
- Adds `TestGetAgentCredentials_GetErrorEmitsFailureEvent` in `internal/app/handlers_local_vault_secrets_test.go`, mirroring the existing `TestDeleteAgentCredentials_GetErrorEmitsFailureEvent`.
- The GET handler's own `vault_get_failed` 500 emission + credential-leak-prevention branch was previously unexercised: no test drove `GetAgentCredentials` against `getErrVault`. The DELETE sibling only covers the DELETE handler's path.
- Resolves the sole remaining actionable finding from review-residual #1009 (sub-issue #985).

## Test plan
- [x] `go test ./app/ -run TestGetAgentCredentials_GetErrorEmitsFailureEvent` passes.
- [x] Full `go test ./app/` package passes.
- [x] `go build ./...` and `go vet ./app/` clean.

Closes #1009

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added test coverage for error handling in agent credential retrieval, ensuring the system properly responds to failures and emits appropriate audit events while maintaining credential security in logs.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->