### PR TITLE
fix(sandbox): hand interactive run -t the foreground process group

### DIFF
--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -17,6 +17,8 @@ import (
 	"strconv"
 	"strings"
 
+	"golang.org/x/term"
+
 	"github.com/ALRubinger/aileron/internal/sandbox/composition"
 )
 
@@ -63,8 +65,50 @@ func (execRunner) Run(ctx context.Context, name string, args []string, stdout, s
 	// `docker stop --time` followed by Capture — instead of racing a
 	// concurrent runtime-initiated kill. No-op on Windows. See ADR-0025
 	// and issue #999.
-	setRuntimeChildPgid(cmd)
+	configureRuntimeChild(cmd, args, stdinIsTerminal())
 	return cmd.Run()
+}
+
+// configureRuntimeChild sets the process-group attributes for a runtime
+// child. It always isolates the child into its own process group so a
+// terminal Ctrl-C reaches aileron rather than docker/podman directly
+// (ADR-0025, issue #999). For an interactive container `run -t` on a
+// real terminal it additionally hands the child the controlling
+// terminal's foreground process group — without that the runtime's
+// raw-mode tcsetattr runs from a background group and fails with
+// SIGTTOU/EINTR ("unable to set IO streams as raw terminal: interrupted
+// system call"). The stdinTTY gate keeps non-interactive / CI
+// invocations on the background-isolation path, where promoting a child
+// to foreground without a controlling terminal would fail the exec.
+func configureRuntimeChild(cmd *exec.Cmd, args []string, stdinTTY bool) {
+	setRuntimeChildPgid(cmd)
+	if stdinTTY && interactiveTTYRun(args) {
+		setRuntimeChildForeground(cmd)
+	}
+}
+
+// stdinIsTerminal reports whether the process's stdin is a real
+// terminal. Package-level so tests can drive the foreground branch in
+// execRunner.Run without a controlling TTY.
+var stdinIsTerminal = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// interactiveTTYRun reports whether args describe an interactive
+// container `run` that allocates a pseudo-TTY (`-t`). Only such a run
+// needs the runtime child to own the terminal's foreground process
+// group. Image builds (`build -t <tag>`) and non-TTY runs do not — the
+// `run` verb gate keeps the `-t` build-tag flag from matching.
+func interactiveTTYRun(args []string) bool {
+	if len(args) == 0 || args[0] != "run" {
+		return false
+	}
+	for _, a := range args {
+		if a == "-t" {
+			return true
+		}
+	}
+	return false
 }
 
 // Builder builds the image required by a sandbox composition plan.

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -46,6 +46,27 @@ func (r *callRecordingRunner) Run(_ context.Context, name string, args []string,
 	return err
 }
 
+func TestInteractiveTTYRun(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want bool
+	}{
+		{"run with tty", []string{"run", "--rm", "-i", "-t", "img", "claude"}, true},
+		{"run without tty", []string{"run", "--rm", "-i", "img", "claude"}, false},
+		{"build with tag flag is not a tty run", []string{"build", "-t", "img", "-f", "Dockerfile", "."}, false},
+		{"image inspect", []string{"image", "inspect", "img"}, false},
+		{"empty args", nil, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := interactiveTTYRun(tc.args); got != tc.want {
+				t.Fatalf("interactiveTTYRun(%v) = %v, want %v", tc.args, got, tc.want)
+			}
+		})
+	}
+}
+
 func TestBuildBaseImageUsesLocalContainerfile(t *testing.T) {
 	dir := t.TempDir()
 	containerfile := filepath.Join(dir, "images", "sandbox-base", "Containerfile")

--- a/internal/sandbox/container/sysproc_other.go
+++ b/internal/sandbox/container/sysproc_other.go
@@ -11,3 +11,10 @@ import "os/exec"
 // helper guards against does not apply. The no-op keeps the package
 // building on Windows. See ADR-0025 and issue #999.
 func setRuntimeChildPgid(_ *exec.Cmd) {}
+
+// setRuntimeChildForeground is a no-op on Windows. Foreground/Ctty are
+// Unix-only SysProcAttr fields for terminal job control; Windows uses a
+// different console model, so the interactive-raw-terminal handoff the
+// Unix helper performs does not apply. The no-op keeps the package
+// building on Windows. See ADR-0025 and issue #1014.
+func setRuntimeChildForeground(_ *exec.Cmd) {}

--- a/internal/sandbox/container/sysproc_unix.go
+++ b/internal/sandbox/container/sysproc_unix.go
@@ -27,3 +27,24 @@ func setRuntimeChildPgid(cmd *exec.Cmd) {
 	}
 	cmd.SysProcAttr.Setpgid = true
 }
+
+// setRuntimeChildForeground promotes the runtime child's new process
+// group to the foreground of the controlling terminal so an interactive
+// `docker run -t` can put the terminal into raw mode. Without it the
+// child sits in the background group set by setRuntimeChildPgid and the
+// raw-mode tcsetattr fails with SIGTTOU/EINTR.
+//
+// The Go runtime performs the tcsetpgrp(Ctty) handoff in the child with
+// SIGTTOU masked. Ctty is the child's stdin (fd 0), which execRunner
+// wires to the host terminal. Callers gate this on a real stdin
+// terminal; setting Foreground without a controlling terminal would make
+// the exec fail. Setpgid is required for Foreground, so it is forced on
+// here too. See ADR-0025 and issue #1014.
+func setRuntimeChildForeground(cmd *exec.Cmd) {
+	if cmd.SysProcAttr == nil {
+		cmd.SysProcAttr = &syscall.SysProcAttr{}
+	}
+	cmd.SysProcAttr.Setpgid = true
+	cmd.SysProcAttr.Foreground = true
+	cmd.SysProcAttr.Ctty = 0
+}

--- a/internal/sandbox/container/sysproc_unix_test.go
+++ b/internal/sandbox/container/sysproc_unix_test.go
@@ -54,3 +54,73 @@ func TestExecRunnerRunWithPgidPropagatesExit(t *testing.T) {
 		t.Fatal("expected non-nil error from a failing command")
 	}
 }
+
+// TestSetRuntimeChildForegroundSetsForeground asserts the helper hands
+// the child the controlling terminal's foreground process group so an
+// interactive `docker run -t` can enter raw mode. Regression for the
+// "unable to set IO streams as raw terminal: interrupted system call"
+// failure introduced when #1014 isolated the runtime child into a
+// background process group.
+func TestSetRuntimeChildForegroundSetsForeground(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", ":")
+	setRuntimeChildForeground(cmd)
+	if cmd.SysProcAttr == nil {
+		t.Fatal("SysProcAttr is nil; foreground was not configured")
+	}
+	if !cmd.SysProcAttr.Setpgid {
+		t.Fatal("SysProcAttr.Setpgid = false, want true (Foreground requires Setpgid)")
+	}
+	if !cmd.SysProcAttr.Foreground {
+		t.Fatal("SysProcAttr.Foreground = false, want true")
+	}
+	if cmd.SysProcAttr.Ctty != 0 {
+		t.Fatalf("SysProcAttr.Ctty = %d, want 0 (child stdin)", cmd.SysProcAttr.Ctty)
+	}
+}
+
+// TestSetRuntimeChildForegroundPreservesExistingFields verifies the
+// helper mutates rather than replaces a pre-set SysProcAttr.
+func TestSetRuntimeChildForegroundPreservesExistingFields(t *testing.T) {
+	cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", ":")
+	cmd.SysProcAttr = &syscall.SysProcAttr{}
+	existing := cmd.SysProcAttr
+	setRuntimeChildForeground(cmd)
+	if cmd.SysProcAttr != existing {
+		t.Fatal("helper replaced the existing SysProcAttr rather than mutating it")
+	}
+}
+
+// TestConfigureRuntimeChildGating pins the foreground gate: an
+// interactive `run -t` on a real terminal gets the foreground handoff,
+// while a non-terminal stdin or a non-`run`/non-TTY argv stays on the
+// background-isolation path. The background path is what #1014 wants for
+// CI and for graceful-stop salvage; the foreground path is what an
+// interactive raw-mode container needs.
+func TestConfigureRuntimeChildGating(t *testing.T) {
+	cases := []struct {
+		name           string
+		args           []string
+		stdinTTY       bool
+		wantForeground bool
+	}{
+		{"interactive run on terminal", []string{"run", "--rm", "-i", "-t", "img", "claude"}, true, true},
+		{"interactive run without terminal", []string{"run", "--rm", "-i", "-t", "img", "claude"}, false, false},
+		{"non-tty run on terminal", []string{"run", "--rm", "-i", "img", "claude"}, true, false},
+		{"build on terminal", []string{"build", "-t", "img", "."}, true, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			cmd := exec.CommandContext(context.Background(), "/bin/sh", "-c", ":")
+			configureRuntimeChild(cmd, tc.args, tc.stdinTTY)
+			if cmd.SysProcAttr == nil {
+				t.Fatal("SysProcAttr is nil; Setpgid isolation was not configured")
+			}
+			if !cmd.SysProcAttr.Setpgid {
+				t.Fatal("SysProcAttr.Setpgid = false; isolation must always apply")
+			}
+			if cmd.SysProcAttr.Foreground != tc.wantForeground {
+				t.Fatalf("SysProcAttr.Foreground = %v, want %v", cmd.SysProcAttr.Foreground, tc.wantForeground)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the interactive sandbox launch failure surfaced during v4 manual E2E (#962):

```
error: prepare agent ... unable to set IO streams as raw terminal: interrupted system call
```

PR #1014 isolated the container runtime child into its own process group (`Setpgid=true`) so a terminal Ctrl-C reaches **aileron** — for the ADR-0025 graceful-stop + AuthSpec salvage path — instead of `docker`/`podman`. But that left an interactive `docker run -t` in a **background** process group, where the runtime's raw-mode `tcsetattr` triggers SIGTTOU and the ioctl returns EINTR (`interrupted system call`). Interactive launches were broken as a result.

This restores interactive launch by promoting the runtime child to the controlling terminal's **foreground** process group (`Foreground` + `Ctty`) — but only for an interactive `run -t` on a real stdin terminal:

- Ctrl-C now reaches the in-container agent (e.g. interrupt Claude), which is the correct interactive UX; AuthSpec Capture runs via the clean-exit gate on container exit.
- Non-`run`, non-TTY, and non-terminal (CI / daemon-spawned builds) invocations keep the background-isolation behavior from #1014 — the `run` verb gate keeps the `build -t <tag>` flag from matching, and the stdin-terminal gate prevents a foreground handoff (which would fail the exec) when there is no controlling terminal.

Follow-up (agreed separately): a PTY-wrapper where aileron allocates its own PTY and stays foreground on the real terminal, preserving *both* aileron-owned Ctrl-C salvage and a working raw TTY — aligns with the documented "aileron owns the PTY" direction and the future approval TUI. Tracked in a separate issue.

### Note on the other error in the same session
The earlier `decode agent credentials: invalid character '<'` was a **stale daemon** (running since 2026-06-09, predating the `/v1/vault/agents/{name}/credentials` endpoint): the unknown `/v1` route fell through to the SPA catch-all and returned `200` + HTML, which the daemon client tried to JSON-decode. Restarting to spawn the fresh daemon resolved it. Not addressed in this PR; a separate hardening (JSON 404 for unmatched `/v1/*` instead of SPA fallthrough) is worth considering.

## Test plan

- [x] `go test ./sandbox/... ./launch/...` — all green
- [x] `interactiveTTYRun` table test: `run -t` → true; `build -t` → false; `run` (no `-t`) → false; `image inspect` → false; empty → false
- [x] `configureRuntimeChild` gating: foreground only for interactive `run -t` on a terminal; background isolation otherwise
- [x] `setRuntimeChildForeground` sets `Setpgid`+`Foreground`+`Ctty=0`, mutates existing `SysProcAttr` in place
- [x] CodeRabbit review — 0 findings
- [ ] Manual: `aileron launch --sandbox=docker claude` enters the container with a working interactive TTY (reporter verifying)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced interactive container support with improved terminal handling. Interactive container runs now properly manage terminal foreground process groups for optimal terminal I/O behavior across Unix and Windows platforms.

* **Tests**
  * Added comprehensive tests for terminal and process group handling to ensure reliable behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->