### PR TITLE
fix(sandbox): drop privileges with su-exec so flagged agent commands run

### DIFF
--- a/images/sandbox-base/Containerfile
+++ b/images/sandbox-base/Containerfile
@@ -13,6 +13,7 @@ RUN apk add --no-cache \
     grep \
     procps \
     sed \
+    su-exec \
     tini \
     wget
 

--- a/images/sandbox-base/bin/aileron-run-with-proxy-ca
+++ b/images/sandbox-base/bin/aileron-run-with-proxy-ca
@@ -12,4 +12,12 @@ if [ "$(id -u)" != "0" ]; then
 fi
 
 aileron-install-proxy-ca "${AILERON_SANDBOX_PROXY_CA_FILE:-/etc/aileron/proxy/ca.pem}"
-exec su -p -s /bin/sh agent -c 'exec "$@"' aileron-agent "$@"
+
+# Drop to the unprivileged agent user and exec the command directly.
+# su-exec execs argv without a shell and without option parsing, so a
+# command carrying `--`-prefixed flags (e.g. `claude --allowedTools ...`)
+# reaches the agent intact. BusyBox `su -c` is unusable here: its getopt
+# scans the whole argv and rejects the inner command's long flags
+# ("su: unrecognized option: allowedTools"). Direct exec also keeps the
+# agent as tini's child for clean signal forwarding.
+exec su-exec agent "$@"

--- a/internal/launch/run_with_proxy_ca_integration_test.go
+++ b/internal/launch/run_with_proxy_ca_integration_test.go
@@ -1,0 +1,156 @@
+//go:build integration_sandbox
+
+// Proxy-CA wrapper argument-passthrough integration test.
+//
+// When sandbox proxy bootstrap is active the launcher prefixes the
+// in-container command with `aileron-run-with-proxy-ca` and runs the
+// container as root; the wrapper installs the session CA and then drops
+// to the unprivileged `agent` user to exec the real agent command. That
+// command routinely carries `--`-prefixed flags (Claude:
+// `--allowedTools ...`, `--dangerously-skip-permissions`).
+//
+// The wrapper must pass those flags through to the agent untouched. An
+// earlier implementation dropped privileges with BusyBox `su -c`, whose
+// getopt scans the whole argv and rejected the inner command's long
+// flags ("su: unrecognized option: allowedTools"), aborting the launch
+// before the agent ever started. This test reproduces that failure mode
+// on the real Alpine base image: it builds sandbox-base, runs the
+// wrapper with a flagged command, and asserts the flags reach the inner
+// command while it runs as the unprivileged agent user.
+//
+// Unlike the AuthSpec bind-mount test this is not Linux-only — the bug
+// lives in the container's BusyBox userland, which is identical across
+// hosts — so it runs anywhere a Docker runtime is available.
+//
+// Run with:
+//
+//	go test -tags=integration_sandbox -run TestRunWithProxyCAPassesFlaggedCommand ./internal/launch/...
+package launch
+
+import (
+	"bytes"
+	"context"
+	"crypto/ecdsa"
+	"crypto/elliptic"
+	"crypto/rand"
+	"crypto/x509"
+	"crypto/x509/pkix"
+	"encoding/pem"
+	"math/big"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+const runWithProxyCATestImage = "aileron/sandbox-base:run-with-proxy-ca-test"
+
+func TestRunWithProxyCAPassesFlaggedCommand(t *testing.T) {
+	rt, err := sandboxcontainer.ResolveRuntime("docker")
+	if err != nil {
+		t.Skipf("no docker runtime on PATH: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	buildRunWithProxyCABaseImage(ctx, t, rt)
+
+	// The wrapper aborts unless the CA install succeeds, so feed it a real
+	// single-certificate PEM bind-mounted into the container.
+	caDir := t.TempDir()
+	caPath := filepath.Join(caDir, "ca.pem")
+	writeSelfSignedCAPEM(t, caPath)
+	const containerCAPath = "/tmp/aileron-test-ca.pem"
+
+	// Echo the dropped-to user and the positional args the inner shell
+	// received. `$*` joins $1.. — i.e. everything after the `_` argv0 —
+	// which is exactly the flag list the wrapper must forward verbatim.
+	const innerScript = `printf 'user=%s\nargs=%s\n' "$(id -un)" "$*"`
+
+	args := []string{
+		"run", "--rm",
+		"--user", "root",
+		"--volume", caPath + ":" + containerCAPath + ":ro",
+		"--env", "AILERON_SANDBOX_PROXY_CA_FILE=" + containerCAPath,
+		"--entrypoint", "/usr/local/bin/aileron-run-with-proxy-ca",
+		runWithProxyCATestImage,
+		"/bin/sh", "-c", innerScript, "_",
+		"--allowedTools", "Bash(*) mcp__aileron",
+		"--dangerously-skip-permissions",
+	}
+	var stdout, stderr bytes.Buffer
+	c := exec.CommandContext(ctx, rt, args...)
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	if err := c.Run(); err != nil {
+		t.Fatalf("aileron-run-with-proxy-ca failed to launch a flagged command: %v\nstdout=%q\nstderr=%q\n\nThis is the regression: the wrapper must drop privileges with a tool that execs the command directly (su-exec). BusyBox `su -c` parses the inner command's `--`-flags as its own options and aborts the launch.", err, stdout.String(), stderr.String())
+	}
+
+	out := stdout.String()
+	if !strings.Contains(out, "user=agent") {
+		t.Fatalf("command did not run as the unprivileged `agent` user\nstdout=%q\nstderr=%q", out, stderr.String())
+	}
+	// Load-bearing assertion: every `--`-prefixed flag reached the inner
+	// command rather than being swallowed by the privilege-drop tool.
+	for _, want := range []string{"--allowedTools", "Bash(*) mcp__aileron", "--dangerously-skip-permissions"} {
+		if !strings.Contains(out, want) {
+			t.Fatalf("flag %q did not reach the inner command — the privilege-drop tool consumed it\nstdout=%q\nstderr=%q", want, out, stderr.String())
+		}
+	}
+}
+
+// buildRunWithProxyCABaseImage builds the sandbox-base image under a
+// dedicated test tag. AILERON_SANDBOX_BASE_CONTEXT may point at the
+// images/sandbox-base context; otherwise the Builder walks up from cwd.
+func buildRunWithProxyCABaseImage(ctx context.Context, t *testing.T, rt string) {
+	t.Helper()
+	builder := sandboxcontainer.Builder{
+		Runtime: rt,
+		Stdout:  testLogWriter{t},
+		Stderr:  testLogWriter{t},
+	}
+	plan := sandboxcomposition.Plan{
+		Tier:  sandboxcomposition.TierBase,
+		Image: runWithProxyCATestImage,
+	}
+	if _, err := builder.Build(ctx, sandboxcontainer.BuildOptions{
+		Plan:   plan,
+		Tag:    runWithProxyCATestImage,
+		Policy: sandboxcontainer.BuildPolicyAlways,
+	}); err != nil {
+		t.Fatalf("build sandbox-base test image: %v (set AILERON_SANDBOX_BASE_CONTEXT to images/sandbox-base if the context was not found)", err)
+	}
+}
+
+// writeSelfSignedCAPEM writes a single self-signed CA certificate to
+// path so aileron-install-proxy-ca has a valid, non-empty PEM to install.
+func writeSelfSignedCAPEM(t *testing.T, path string) {
+	t.Helper()
+	key, err := ecdsa.GenerateKey(elliptic.P256(), rand.Reader)
+	if err != nil {
+		t.Fatalf("generate CA key: %v", err)
+	}
+	tmpl := &x509.Certificate{
+		SerialNumber:          big.NewInt(1),
+		Subject:               pkix.Name{CommonName: "aileron-test-proxy-ca"},
+		NotBefore:             time.Now().Add(-time.Hour),
+		NotAfter:              time.Now().Add(24 * time.Hour),
+		IsCA:                  true,
+		BasicConstraintsValid: true,
+		KeyUsage:              x509.KeyUsageCertSign | x509.KeyUsageCRLSign,
+	}
+	der, err := x509.CreateCertificate(rand.Reader, tmpl, tmpl, &key.PublicKey, key)
+	if err != nil {
+		t.Fatalf("create self-signed CA: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "CERTIFICATE", Bytes: der})
+	if err := os.WriteFile(path, pemBytes, 0o644); err != nil {
+		t.Fatalf("write CA pem: %v", err)
+	}
+}


### PR DESCRIPTION
## Summary

Fixes the next interactive sandbox-launch failure found during v4 manual E2E (#962), after the raw-terminal fix (#1028):

```
su: unrecognized option: allowedTools
BusyBox v1.37.0 ... Usage: su [-lmp] [-s SH] [-] [USER [FILE ARGS | -c 'CMD' [ARG0 ARGS]]]
```

When sandbox proxy bootstrap is active, the launcher runs the container as root and prefixes the command with `aileron-run-with-proxy-ca`. That wrapper installs the session CA, then drops to the unprivileged `agent` user to exec the agent. The privilege drop used BusyBox `su -c`:

```sh
exec su -p -s /bin/sh agent -c 'exec "$@"' aileron-agent "$@"
```

BusyBox `su`'s getopt scans the **entire** argv — including the inner command's args — and rejects `--allowedTools` (a Claude CLI flag) as an unknown `su` option, aborting the launch before the agent ever starts. GNU `su` permutes differently, so this only bites on the Alpine base.

**Fix:** drop privileges with `su-exec` (Alpine's standard tool for this), which execs the command directly — no shell, no option parsing — so `--`-prefixed flags reach the agent intact:

```sh
exec su-exec agent "$@"
```

Direct exec also keeps the agent as tini's PID-tree child for clean signal forwarding (relevant now that Ctrl-C reaches the container after #1028).

## Test plan

- [x] New `integration_sandbox` regression test (`TestRunWithProxyCAPassesFlaggedCommand`): builds `sandbox-base`, runs the wrapper with a flagged command, asserts the flags reach the **agent** user.
- [x] Verified **fails before** the fix — reproduces the exact `su: unrecognized option: allowedTools` BusyBox error — and **passes after**.
- [x] Manual: rebuilt `aileron/sandbox-base:latest`; `aileron-run-with-proxy-ca /bin/sh -c '...' _ --allowedTools '...' --dangerously-skip-permissions` → `user=agent`, flags intact.
- [x] CodeRabbit: 1 finding ("su-exec not in Alpine 3.23") — **verified false positive**: `apk add su-exec` on `alpine:3.23` installs `su-exec-0.3-r0` at `/sbin/su-exec`.
- [ ] Reporter to retest `aileron launch --sandbox=docker claude --sandbox-build=always`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced privilege-dropping mechanism in the sandbox to reliably preserve command-line flags and arguments during execution.

* **Tests**
  * Added integration test to verify flag passthrough when running unprivileged processes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->