### PR TITLE
fix(launch): pre-trust workspace and match installMethod in claude stub

### DIFF
--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -54,13 +54,60 @@ type claudeAiOauth struct {
 // and the user's recovery options (inspect, re-login, etc.) per R13.
 var errClaudeEnvelopeMalformed = errors.New("claude: credentials envelope is malformed")
 
-// claudeOnboardingStub is the constant payload written to
-// /home/agent/.claude.json on every launch. {"hasCompletedOnboarding":
-// true, "installMethod": "native"} short-circuits Claude's first-run
-// wizard so the user does not pay the theme-picker tax on every
-// sandbox launch. Kept as a package-level constant so the schema is
-// visible in one place when Anthropic adds new onboarding fields.
-var claudeOnboardingStub = []byte(`{"hasCompletedOnboarding":true,"installMethod":"native"}`)
+// claudeWorkspacePath is the container directory the launcher runs
+// Claude in (the bind-mounted project workspace). It must match
+// container.WorkspacePath and the runtime `--workdir`; it is hardcoded
+// here to keep the agents package free of an import on the container
+// package, mirroring how the credential/onboarding paths above are
+// spelled out literally.
+const claudeWorkspacePath = "/home/agent/workspace"
+
+// claudeOnboardingStub is the payload written to /home/agent/.claude.json
+// on every launch. It short-circuits three first-run interruptions so a
+// vault-rendered sandbox launch is silent end-to-end:
+//
+//   - hasCompletedOnboarding skips the theme picker / first-run wizard.
+//   - installMethod "global" matches the devcontainer's
+//     `npm install -g @anthropic-ai/claude-code`. Claude's `/doctor`
+//     uses installMethod to decide where to verify the binary; "native"
+//     made it look for ~/.local/bin/claude (the native-installer path,
+//     which the npm install never creates) and report the CLI as
+//     "missing or broken". "global" verifies the PATH-resolved global
+//     binary the devcontainer actually installs.
+//   - projects[workspace].hasTrustDialogAccepted pre-accepts the folder
+//     trust dialog ("Is this a project you trust?") for the bind-mounted
+//     workspace, so the agent does not block on it on every launch. The
+//     sandbox container is the trust boundary, so pre-accepting inside
+//     it is safe.
+//
+// Built from a typed value rather than a string literal so the nested
+// shape stays valid as Anthropic adds onboarding fields.
+var claudeOnboardingStub = mustMarshalOnboardingStub()
+
+func mustMarshalOnboardingStub() []byte {
+	type projectTrust struct {
+		HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
+	}
+	stub := struct {
+		HasCompletedOnboarding bool                    `json:"hasCompletedOnboarding"`
+		InstallMethod          string                  `json:"installMethod"`
+		Projects               map[string]projectTrust `json:"projects"`
+	}{
+		HasCompletedOnboarding: true,
+		InstallMethod:          "global",
+		Projects: map[string]projectTrust{
+			claudeWorkspacePath: {HasTrustDialogAccepted: true},
+		},
+	}
+	b, err := json.Marshal(stub)
+	if err != nil {
+		// The shape is a fixed literal; marshaling it cannot fail at
+		// runtime. Panic so a refactor that breaks it surfaces in tests
+		// rather than silently shipping an empty onboarding file.
+		panic("claude: marshaling onboarding stub: " + err.Error())
+	}
+	return b
+}
 
 // claudeRender writes the vault's stored bytes into the in-container
 // credentials file verbatim. We validate the envelope on the way

--- a/internal/launch/agents/claude_auth_test.go
+++ b/internal/launch/agents/claude_auth_test.go
@@ -2,6 +2,7 @@ package agents_test
 
 import (
 	"bytes"
+	"encoding/json"
 	"errors"
 	"strconv"
 	"strings"
@@ -63,8 +64,36 @@ func TestClaude_AuthSpec_Shape(t *testing.T) {
 	if sf.Mode != 0o644 {
 		t.Errorf("StaticFile mode = %v, want 0644", sf.Mode)
 	}
-	if string(sf.Content) != `{"hasCompletedOnboarding":true,"installMethod":"native"}` {
-		t.Errorf("StaticFile content drift: %q", sf.Content)
+	assertOnboardingStub(t, sf.Content)
+}
+
+// assertOnboardingStub verifies the three contractual flags the stub
+// must carry to make a sandbox launch silent: onboarding completed,
+// installMethod matching the devcontainer's npm-global install (so
+// `/doctor` is clean), and the workspace pre-trusted (so the folder
+// trust dialog does not fire). Parsed semantically rather than matched
+// as a string so field ordering or additive fields do not break it.
+func assertOnboardingStub(t *testing.T, content []byte) {
+	t.Helper()
+	var stub struct {
+		HasCompletedOnboarding bool   `json:"hasCompletedOnboarding"`
+		InstallMethod          string `json:"installMethod"`
+		Projects               map[string]struct {
+			HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
+		} `json:"projects"`
+	}
+	if err := json.Unmarshal(content, &stub); err != nil {
+		t.Fatalf("onboarding stub is not valid JSON: %v (content=%q)", err, content)
+	}
+	if !stub.HasCompletedOnboarding {
+		t.Errorf("hasCompletedOnboarding = false; the theme picker will paint on every launch")
+	}
+	if stub.InstallMethod != "global" {
+		t.Errorf("installMethod = %q, want \"global\" to match the devcontainer's `npm install -g`; a mismatch makes /doctor report the CLI missing", stub.InstallMethod)
+	}
+	const workspace = "/home/agent/workspace"
+	if !stub.Projects[workspace].HasTrustDialogAccepted {
+		t.Errorf("projects[%q].hasTrustDialogAccepted = false; the folder trust dialog will block every launch", workspace)
 	}
 }
 
@@ -164,15 +193,13 @@ func TestClaude_AuthSpec_RoundTrip(t *testing.T) {
 }
 
 func TestClaude_OnboardingStub_Constant(t *testing.T) {
-	// The onboarding stub must be the documented content per R18 /
-	// AE4. A drift here means Claude paints the theme picker on
-	// every launch and the user notices.
+	// The onboarding stub must carry the flags that make a launch silent
+	// per R18 / AE4: drift here means Claude paints the theme picker,
+	// reports itself broken via /doctor, or blocks on the folder trust
+	// dialog on every launch.
 	spec := agents.Claude{}.AuthSpec()
 	sf := spec.StaticFiles[0]
-	const want = `{"hasCompletedOnboarding":true,"installMethod":"native"}`
-	if string(sf.Content) != want {
-		t.Errorf("onboarding stub drift: got %q, want %q", sf.Content, want)
-	}
+	assertOnboardingStub(t, sf.Content)
 }
 
 // errIsMalformed pins the error sentinel pattern in Claude's


### PR DESCRIPTION
## Summary

Removes two first-run interruptions that fired on **every** Claude sandbox launch (found during v4 manual E2E #962, after the launch chain finally reached Claude via #1028 + #1030):

1. **Folder-trust dialog** — Claude blocked on "Is this a project you trust?" for `/home/agent/workspace` on each launch.
2. **`/doctor` setup issue** — `claude command at /home/agent/.local/bin/claude missing or broken` (`~/.local/bin` doesn't exist).

Both trace to `/home/agent/.claude.json`, the onboarding stub the launcher writes fresh each launch:

- The stub set `installMethod: "native"`, so Claude's `/doctor` verified the **native-installer** path `~/.local/bin/claude` — which the devcontainer's `npm install -g @anthropic-ai/claude-code` never creates. Changed to `"global"` to match the npm-global install (verified against an authoritative `~/.claude.json`: an npm-global Claude reports `installMethod: "global"`).
- The stub never recorded workspace trust. Added `projects["/home/agent/workspace"].hasTrustDialogAccepted = true` (the field Claude uses to suppress the dialog). The sandbox container is the trust boundary, so pre-accepting inside it is safe and consistent with the existing approach of pre-completing onboarding.

The stub is now built from a typed value (nested shape stays valid as fields are added) and the tests assert the three contractual flags semantically rather than matching a brittle JSON string.

Because the stub is bind-mounted from the Go constant at launch, **no image rebuild** is needed — only the CLI binary.

## Test plan

- [x] `go test ./launch/...` green; stub tests rewritten to parse-and-assert `hasCompletedOnboarding`, `installMethod == "global"`, and workspace `hasTrustDialogAccepted`.
- [x] Rendered stub verified: `{"hasCompletedOnboarding":true,"installMethod":"global","projects":{"/home/agent/workspace":{"hasTrustDialogAccepted":true}}}`.
- [x] CodeRabbit: 0 findings.
- [x] Schema cross-checked against a real `~/.claude.json` (trust field + installMethod values).
- [ ] Reporter to confirm: `aileron launch --sandbox=docker claude` no longer shows the trust dialog or the /doctor warning.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
- Updated Claude onboarding to use global installation method, pre-accept workspace trust dialog, and complete onboarding by default.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->