### PR TITLE
fix(launch): disable claude auto-updater in the sandbox container

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -403,6 +403,16 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		agentEnv["AILERON_APPROVAL_URL"] = agentEndpointURL + "/approvals"
 		agentEnv["AILERON_TOOLS_FILE"] = sandboxToolsFilePath
 		agentEnv["AILERON_SHIMS_DIR"] = sandboxShimsDirPath
+		// Disable Claude Code's in-container auto-updater. The sandbox
+		// image installs the agent into a root-owned global prefix
+		// (`npm install -g`), so the non-root agent user's update write
+		// fails with "no write permission to npm prefix". Self-updating
+		// inside an ephemeral container is also pointless — the image is
+		// the unit of versioning, so a successful update would be lost on
+		// the next launch anyway. The var is Claude-specific; other
+		// agents ignore it. Host launch is unaffected (this block is
+		// sandbox-only), so a user's own writable install still updates.
+		agentEnv["DISABLE_AUTOUPDATER"] = "1"
 		if daemonToken != "" {
 			agentEnv["AILERON_TOKEN"] = daemonToken
 		}

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -250,6 +250,10 @@ func TestLaunch_SandboxBYOImageRunsContainer(t *testing.T) {
 		"--env\nAILERON_TOOLS_FILE=/etc/aileron/tools.txt\n",
 		"--env\nAILERON_SHIMS_DIR=/usr/local/bin\n",
 		"--env\nAILERON_URL=http://host.docker.internal:",
+		// Sandbox launch disables the in-container auto-updater: the
+		// image's npm-global prefix is root-owned and the image is the
+		// versioning unit, so a self-update would fail and be pointless.
+		"--env\nDISABLE_AUTOUPDATER=1\n",
 		"ghcr.io/acme/agent:latest\ncodex\n--ask-for-approval\nnever\n",
 	} {
 		if !strings.Contains(args, want) {


### PR DESCRIPTION
## Summary

Removes the `Auto-update failed: no write permission to npm prefix` error that fired on every Claude sandbox launch (v4 manual E2E #962).

The sandbox image installs Claude via `npm install -g` into a **root-owned** global prefix, but the agent runs as the non-root `agent` user — so the auto-updater's write is denied. Self-updating inside an ephemeral container is pointless anyway: the image is the unit of versioning, so any successful update is discarded on the next launch.

Set `DISABLE_AUTOUPDATER=1` in the launcher's **sandbox-only** env block. The variable is Claude-specific (other agents ignore it), and host launch is untouched, so a user's own writable install keeps auto-updating.

### Not in this PR: the "API Usage Billing / not logged in" observation
Investigated and it is **expected first-run behavior, not a bug**:
- The launcher injects only `ANTHROPIC_BASE_URL` (no API key/token). Aileron's gateway is a **transparent pass-through** (`handlers_gateway.go`): it forwards Claude's own `Authorization` bearer to the upstream, which defaults to `https://api.anthropic.com` (`config/gateway.go`).
- The vault is empty, so Claude has no credentials and (with a custom base URL set) does not auto-prompt the subscription wizard. Running **`/login`** inside the container authenticates the Pro/Max subscription; the bearer is forwarded through the gateway to Anthropic, and the AuthSpec Capture persists the OAuth envelope to the vault so subsequent launches are silent.
- So Pro/Max works once logged in — no code change required. (A possible future nicety: make the launcher's "agent will prompt for login" message accurate, since Claude doesn't auto-prompt when `ANTHROPIC_BASE_URL` is set.)

## Test plan

- [x] `go test ./launch/...` green; sandbox-launch test now asserts `--env DISABLE_AUTOUPDATER=1` in the docker args.
- [x] Mode-gating: the var is set inside the `if sandboxEnabled` block, so host launch is unaffected.
- [x] CodeRabbit: 0 findings.
- [x] Auto-updater disable mechanism confirmed against official Claude Code docs (`DISABLE_AUTOUPDATER=1`).
- [ ] Reporter to confirm: no auto-update error on next sandbox launch; `/login` authenticates Pro/Max.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed auto-updater behavior in sandboxed environments to prevent file system access conflicts in containerized setups.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->