### PR TITLE
fix(launch): don't surface benign freshness-gate skip as capture failure

### DIFF
--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -538,8 +538,17 @@ func prepareAuthSpec(
 								fmt.Errorf("freshness comparison failed: %w (skipping PUT so the prior vault entry is retained; inspect %s or re-login)", ferr, target.HostPath))
 							continue
 						case !fresher:
-							captureWarn(sessionLog, stderr, agentName, target.HostPath,
-								errors.New("captured credential is not newer than the vault entry; skipping write so a stale capture does not clobber a fresher rotation"))
+							// Not a failure: the freshness gate is doing its
+							// job. On a re-launch where the agent did not rotate
+							// its credential, the captured copy is not newer than
+							// the vault entry, so skipping the write is the
+							// correct steady-state outcome (and the common case
+							// on every clean exit after the first login). Record
+							// it in the session log for post-mortems, but do NOT
+							// print to stderr — the user should not see a
+							// "capture failed" line for normal operation.
+							sessionLog.Info("skipping credential capture: not newer than vault entry (freshness gate held)",
+								"agent", agentName, "host_path", target.HostPath)
 							continue
 						}
 					}

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -1088,7 +1088,8 @@ func TestPrepareAuthSpec_StaleCaptureNotFresherSkipsPut(t *testing.T) {
 	daemon.seed("claude", []byte("current")) // present at render and capture
 	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return false, nil })
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	var stderr bytes.Buffer
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), &stderr, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -1100,6 +1101,13 @@ func TestPrepareAuthSpec_StaleCaptureNotFresherSkipsPut(t *testing.T) {
 
 	if len(daemon.puts) != 0 {
 		t.Fatalf("a not-fresher capture must not clobber the vault; puts=%d", len(daemon.puts))
+	}
+	// The not-newer outcome is the freshness gate working as designed, not
+	// a failure. It must NOT surface a "capture failed" line on stderr —
+	// the common steady-state on every clean exit after the first login
+	// would otherwise alarm the user with a benign no-op.
+	if strings.Contains(stderr.String(), "failed") {
+		t.Errorf("not-newer capture must not print a failure to stderr; got %q", stderr.String())
 	}
 }
 


### PR DESCRIPTION
## Summary

On the second (and every later) clean exit of a sandbox Claude session, the launcher printed:

```
[launcher] capture for claude failed: captured credential is not newer than the vault entry; skipping write so a stale capture does not clobber a fresher rotation
```

Nothing actually failed. After the first `/login`, the OAuth creds are in the vault; on a re-launch where Claude didn't rotate the token, the capture-on-exit re-reads the same creds, the freshness gate sees they're **not newer**, and correctly skips the write. That's the gate *succeeding* — the normal steady-state — but `captureWarn` framed it as `capture for claude failed` on stderr, alarming the user with a benign no-op.

This logs the not-newer outcome at `Info` in the session log (kept for post-mortems) instead of emitting a stderr failure line. **Genuine** capture failures are untouched and still warn on stderr: malformed captured envelope, freshness-comparison error, PUT failure, and vault-read error.

## Test plan

- [x] `go test ./launch/...` green.
- [x] `TestPrepareAuthSpec_StaleCaptureNotFresherSkipsPut` extended to assert stderr contains no "failed" line for the not-newer case (still asserts no PUT).
- [x] The genuine-failure tests (schema drift, persist failure, etc.) still assert `capture for claude failed` on stderr — unchanged.
- [x] CodeRabbit: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)