### PR TITLE
test(sandbox): in-container, never-approved, and concurrency MCP variants (#960)

### DIFF
--- a/docs/plans/2026-06-13-001-test-sandbox-mcp-variants-plan.md
+++ b/docs/plans/2026-06-13-001-test-sandbox-mcp-variants-plan.md
@@ -1,0 +1,235 @@
+---
+title: "test: sandbox MCP integration variants (in-container, never-approved, concurrency)"
+type: test
+status: active
+date: 2026-06-13
+issue: 960
+origin: GitHub issue #960
+---
+
+# test: sandbox MCP integration variants (in-container, never-approved, concurrency)
+
+## Summary
+
+Extend the existing `integration_sandbox` test (`internal/app/sandbox_mcp_test.go`) with the three variants deferred from #953: a real **in-container** `aileron-mcp` run, a **never-approved** edge case (R6b), and a **concurrency** edge case (R6c). The existing host-subprocess round-trip is **kept** as the always-on path; the in-container variant runs only when Docker is on `PATH`. R6b and R6c run on the host-subprocess transport (no Docker needed), since their contract — pending-stays-pending and per-`approval_id` event attribution — is transport-independent.
+
+This is a test-only change. No production code is modified.
+
+---
+
+## Problem Frame
+
+`internal/app/sandbox_mcp_test.go` today proves the load-bearing R6/R7 contract (MCP `tools/call` → in-process daemon round-trip → session-id-stamped audit chain) with `aileron-mcp` running as a **host subprocess** pointing at the daemon's loopback address. Three variants were deliberately deferred (see the file's `TODO(#953)` block):
+
+1. **Runtime realism** — the real deployment runs `aileron-mcp` *inside* a container reaching the daemon via `host.docker.internal`, with the binary bind-mounted read-only and `--add-host` on Linux. The host-subprocess shape never exercises container networking or the bind-mount.
+2. **R6b never-approved** — an approval-required action whose approval is never decided must stay pending, emit no `execution.*` events, and not mutate daemon state.
+3. **R6c concurrency** — two parallel `draft_email` calls must produce two distinct `approval_id`s, and approving them in reverse order must emit correctly attributed per-call event chains, with the upstream stub seeing exactly two requests.
+
+The goal is coverage, not a contract change: R6/R7 already hold; these variants add container-runtime realism plus two contractual edge cases the host shape can also exercise but that were never written.
+
+---
+
+## Requirements
+
+Traced to #960's scope checklist:
+
+- **R1** — In-container round-trip: launch `aileron-mcp` via `docker run -i --rm`, binary bind-mounted at `/usr/local/bin/aileron-mcp:ro`, daemon reachable at `host.docker.internal:<port>`, `--add-host=host.docker.internal:host-gateway` on Linux. Assert the same R6/R7 chain the host transport asserts.
+- **R2** — Docker skip guard: if `docker` is not on `PATH`, skip only the in-container variant (the host, R6b, and R6c variants still run).
+- **R3** — Base-image pre-pull in `TestMain` (a known-good glibc image with `/bin/sh`, e.g. `debian:bookworm-slim`) to mitigate registry rate-limiting on CI runners.
+- **R4** — Daemon bound to a Docker-reachable, non-loopback address (`0.0.0.0:0`) so the container can reach it; host transport keeps using a loopback-equivalent URL.
+- **R5 (R6b)** — Never-approved variant: after `tools/call`, two `check_action_status` polls 100ms apart return pending; no `execution.*` events emit; the approval entry is unchanged; entry deleted as cleanup.
+- **R6 (R6c)** — Concurrency variant: two parallel `tools/call draft_email` yield two distinct `approval_id`s; approving in reverse order emits the right per-`approval_id` event chain; the upstream stub records exactly two requests with the correct per-call args.
+- **R7** — Update the file's `TODO`/doc comment to record what is now covered and what (if anything) remains deferred.
+
+---
+
+## High-Level Technical Design
+
+The in-container variant only changes *where* `aileron-mcp` runs and *how it reaches the daemon*; the JSON-RPC-over-stdio protocol and the audit assertions are unchanged.
+
+```mermaid
+sequenceDiagram
+    participant T as test (host process)
+    participant D as in-process daemon<br/>(httptest on 0.0.0.0:PORT)
+    participant C as docker run -i<br/>aileron-mcp (container)
+    participant U as upstream stub<br/>(httptest)
+    T->>C: spawn; write JSON-RPC on stdin
+    C->>D: HTTP via host.docker.internal:PORT<br/>(--add-host on Linux)
+    D->>U: connector call (draft_email)
+    U-->>D: 200
+    D-->>C: tools/call result
+    C-->>T: JSON-RPC on stdout
+    T->>D: read audit MemStore → assert R6/R7 chain
+```
+
+The host transport is identical except the middle two participants collapse: `aileron-mcp` runs as a host subprocess and reaches the daemon at `127.0.0.1:PORT`.
+
+---
+
+## Key Technical Decisions
+
+- **KTD1 — Transport seam, keep both.** Introduce a transport notion (`host` | `container`) that `spawnMCP` switches on. The host path is the existing `exec.CommandContext(mcpBinaryPath)`; the container path is `docker run -i --rm ... <image> /usr/local/bin/aileron-mcp`. Both return the same `*mcpProcess` wrapping stdin/stdout pipes, so every downstream helper (`initializeMCP`, `callTool`, `request`) is transport-agnostic. Rationale: preserves the fast, Docker-free round-trip coverage while adding runtime realism; the alternative (replace host with container) would make the whole suite Docker-only and lose dev-machine/CI-without-Docker coverage. (User-confirmed: keep both.)
+- **KTD2 — Bind the daemon to `0.0.0.0:0` for reachability.** `httptest.NewServer` binds `127.0.0.1`, which a container cannot reach. Use `httptest.NewUnstartedServer` + a custom `net.Listen("tcp", "0.0.0.0:0")` listener, then `Start()`. Derive two URLs from the chosen port: `127.0.0.1:PORT` for the host transport, `host.docker.internal:PORT` for the container transport. Rationale: one daemon serves both transports; the bind address is the only networking change.
+- **KTD3 — R6b/R6c run on the host transport.** Their contract (pending-stays-pending; per-`approval_id` attribution) is independent of where `aileron-mcp` runs, and the host transport is Docker-free and faster/less flaky. Only the round-trip variant (R1) needs the container to prove networking + bind-mount. Rationale: maximizes coverage per CI minute and keeps the Docker-gated surface minimal.
+- **KTD4 — Per-`approval_id` event correlation via a new helper.** Events already carry `approval_id` in `Payload` (see `internal/approval/action_queue.go:611`). Add `eventChainForApproval(store, approvalID)` mirroring the existing `eventChainForSession` but keying on `Payload["approval_id"]`. Rationale: R6c needs per-call attribution within one session; session-keyed filtering can't distinguish the two concurrent calls.
+- **KTD5 — Docker gating via `exec.LookPath("docker")`.** Skip the in-container variant (not the whole test) when Docker is absent. Rationale: simplest guard, no new import; matches #960's "skip the in-container variant" wording. (`internal/sandbox/container.ResolveRuntime` is the launch-side equivalent but pulls a heavier dependency into `package app`'s test; `LookPath` is sufficient here.)
+
+---
+
+## Implementation Units
+
+### U1. Transport seam, 0.0.0.0 daemon bind, Docker skip guard, base-image pre-pull
+
+**Goal:** Establish the harness changes every variant builds on: a `host|container` transport seam in `spawnMCP`, a Docker-reachable daemon bind, a skip guard, and a `TestMain` image pre-pull.
+
+**Requirements:** R2, R3, R4 (enables R1).
+
+**Dependencies:** none.
+
+**Files:**
+- `internal/app/sandbox_mcp_test.go` (modify: `TestMain`, `newDaemonHarness`, `spawnMCP`)
+
+**Approach:**
+- Add a `dockerAvailable()` helper (`exec.LookPath("docker")`) and a `skipWithoutDocker(t)` guard.
+- In `TestMain`, when Docker is available, `docker pull debian:bookworm-slim` (a glibc image with `/bin/sh`) once, before `m.Run()`; log-and-continue on failure so a pull failure surfaces as a clear skip rather than a per-test hang.
+- Change `newDaemonHarness` to start the daemon on a `0.0.0.0:0` listener via `httptest.NewUnstartedServer` + custom `net.Listener`, then expose both a `loopbackURL` (`127.0.0.1:PORT`) and a `containerURL` (`host.docker.internal:PORT`). Existing tests use `loopbackURL`.
+- Refactor `spawnMCP(t, sessionID, token)` to `spawnMCP(t, transport, sessionID, token)` (or a small options struct). `transport=host` keeps today's behavior; `transport=container` runs `docker run -i --rm --add-host=host.docker.internal:host-gateway` (Linux only for `--add-host`; gate via `runtime.GOOS`) `-v <mcpBinaryPath>:/usr/local/bin/aileron-mcp:ro -e AILERON_URL=<containerURL> -e AILERON_SESSION_ID=... -e AILERON_TOKEN=... <image> /usr/local/bin/aileron-mcp`, wiring the container's stdin/stdout into the same `*mcpProcess`.
+
+**Patterns to follow:**
+- `internal/launch/run_with_proxy_ca_integration_test.go` and `internal/launch/authspec_bindmount_integration_test.go` — Docker skip-guard, `docker run` argv assembly, and container-stdio handling under the same `integration_sandbox` tag.
+- The existing `spawnMCP` / `mcpProcess` (lines ~189-338) for the stdio wrapper that must stay transport-agnostic.
+
+**Test scenarios:**
+- Existing host-transport tests continue to pass unchanged through the refactored `spawnMCP(host, ...)` and `loopbackURL` (regression guard).
+- `dockerAvailable()` returns false → in-container call sites skip cleanly (verified indirectly via U2).
+- Test expectation: no new standalone assertions in U1 beyond preserving the existing suite; U1 is harness scaffolding consumed by U2-U4.
+
+**Verification:** `task test:integration:sandbox` still green with the refactored harness; the three existing tests run via `transport=host`.
+
+---
+
+### U2. In-container round-trip variant (R1)
+
+**Goal:** Prove the R6/R7 round-trip with `aileron-mcp` running inside a real container.
+
+**Requirements:** R1 (advances #960 in-container checkbox).
+
+**Dependencies:** U1.
+
+**Files:**
+- `internal/app/sandbox_mcp_test.go` (add: `TestSandboxMCP_InContainer_NoApproval_RoundTripsAndEmitsAuditChain` or a transport-parameterized run of the existing no-approval round-trip)
+
+**Approach:** Reuse the existing no-approval round-trip assertions, driven through `spawnMCP(container, ...)`. Guard with `skipWithoutDocker(t)`. The daemon uses `containerURL`. Assert the same chain the host variant asserts; the only new surface is networking + bind-mount, so the assertion set is intentionally identical.
+
+**Patterns to follow:** `TestSandboxMCP_NoApproval_RoundTripsAndEmitsAuditChain` (line ~440) for the assertion shape; mirror its `waitForChain` / `eventChainForSession` usage.
+
+**Test scenarios:**
+- Covers F (sandbox MCP parity) / R6. Docker present: `tools/call draft_email` in-container returns non-error; audit chain for the session equals the host variant's chain (`execution.started → execution.succeeded`, no approval events for the no-approval manifest), stamped with the launch session id.
+- Docker absent: the test skips with a clear reason (no failure).
+- Container cannot reach daemon (negative realism): if `--add-host` / bind is wrong the round-trip times out — the existing `waitForChain` timeout surfaces it; ensure the failure message names the container transport.
+
+**Verification:** With Docker present, the in-container round-trip passes on macOS (Docker Desktop) and Linux (`--add-host`); without Docker it skips.
+
+---
+
+### U3. Never-approved variant (R6b)
+
+**Goal:** Prove an approval-required action left undecided stays pending with no execution side effects.
+
+**Requirements:** R5.
+
+**Dependencies:** U1.
+
+**Files:**
+- `internal/app/sandbox_mcp_test.go` (add: `TestSandboxMCP_NeverApproved_StaysPendingNoExecution`)
+
+**Approach:** Use the approval-required manifest (`draftEmailManifestApproval`), host transport. `tools/call draft_email` → capture `approval_id`. Poll `check_action_status` twice, 100ms apart; assert each returns the pending status word and never a terminal payload. Never call `Decide`. Assert the session's audit chain contains `approval.requested` but no `execution.*` event, and the approval entry is still pending in the store. Delete the entry as cleanup.
+
+**Patterns to follow:** `TestSandboxMCP_Approval_RoundTripsWithApprovedDecide` (line ~484) for obtaining the entry/`approval_id` and the approval store handle (`h.srv.actionApprovals`); `check_action_status` tool behavior in `cmd/aileron-mcp/main.go:887` (returns a status-word text block; `pending` for undecided).
+
+**Test scenarios:**
+- Covers R6b. After `tools/call`: `check_action_status` poll #1 → "pending"; 100ms later poll #2 → still "pending".
+- `eventChainForSession` contains `approval.requested` and contains **no** `execution.started` / `execution.succeeded` / `execution.failed`.
+- The approval entry remains in pending state in `actionApprovals` (no spurious decide/state change).
+- Cleanup: deleting the pending entry succeeds and leaves no lingering state.
+
+**Verification:** Test passes without Docker; asserts pending + absence of execution events deterministically (no reliance on timing beyond the two bounded polls).
+
+---
+
+### U4. Concurrency variant (R6c)
+
+**Goal:** Prove two concurrent approval-required calls get distinct `approval_id`s and correctly attributed per-call event chains.
+
+**Requirements:** R6.
+
+**Dependencies:** U1; adds the `eventChainForApproval` helper (KTD4).
+
+**Files:**
+- `internal/app/sandbox_mcp_test.go` (add: `TestSandboxMCP_Concurrency_DistinctApprovalsAttributedCorrectly`; add helper `eventChainForApproval`)
+
+**Approach:** Issue two `tools/call draft_email` requests concurrently (host transport), with distinct per-call args (e.g. different recipients) so the upstream stub can distinguish them. Collect the two `approval_id`s; assert they differ. Approve in **reverse** order via `h.srv.actionApprovals.Decide`. Assert each `approval_id`'s event chain (via `eventChainForApproval`) is the correct `approval.requested → approval.approved → execution.started → execution.succeeded`. Assert the upstream stub recorded exactly two requests with the correct per-call args.
+
+**Approach note (deferred to implementation):** Achieving genuine concurrency over JSON-RPC stdio requires either id-multiplexing over one `mcpProcess` connection or two connections/processes. The contract under test (two distinct `approval_id`s + per-`approval_id` attribution) is independent of the multiplexing mechanism — pick the mechanism during implementation; if one connection's synchronous `request` cannot overlap calls, use two `spawnMCP(host, ...)` connections in the same session. Record the choice in a code comment.
+
+**Patterns to follow:** `eventChainForSession` (line ~402) as the template for `eventChainForApproval` (swap `Payload["aileron.session.id"]` for `Payload["approval_id"]`); the upstream stub's request recording in `newDaemonHarness` for the "exactly two requests" assertion.
+
+**Test scenarios:**
+- Covers R6c. Two concurrent `tools/call` → two non-empty, **distinct** `approval_id`s.
+- Approve B then A (reverse order): `eventChainForApproval(A)` and `eventChainForApproval(B)` each equal `[approval.requested, approval.approved, execution.started, execution.succeeded]`; no cross-attribution (A's chain contains no B events).
+- Upstream stub recorded exactly two requests; each carries the recipient passed to its originating call (per-call arg fidelity).
+- Edge: if both calls collapsed to one `approval_id`, the distinct-id assertion fails loudly (guards against accidental dedup).
+
+**Verification:** Test passes without Docker; per-`approval_id` chains are attributed correctly regardless of approval order.
+
+---
+
+### U5. Update TODO and doc comment
+
+**Goal:** Make the file's header reflect reality — what is now covered, what remains deferred.
+
+**Requirements:** R7.
+
+**Dependencies:** U2, U3, U4.
+
+**Files:**
+- `internal/app/sandbox_mcp_test.go` (modify: the package doc comment + `TODO(#953)` block)
+
+**Approach:** Replace the `TODO(#953)` block with a short statement that the in-container, R6b, and R6c variants now exist; carry forward only genuinely deferred items (e.g. per-agent E2E beyond `aileron-mcp`, CI-pipeline integration) with their tracking refs. Note the host transport remains the always-on path and the container variant is Docker-gated.
+
+**Test scenarios:** Test expectation: none — documentation-only change.
+
+**Verification:** The header accurately describes the variants and gating; no stale "deferred" claims for work now done.
+
+---
+
+## Risks & Dependencies
+
+- **Registry rate-limiting on CI (R-risk5, from #960).** Mitigated by pulling the base image once in `TestMain` and skipping (not failing) when Docker/the pull is unavailable. Use a small known-good glibc image (`debian:bookworm-slim`); distroless static images lack `/bin/sh` the MCP process path may need.
+- **Container → daemon reachability differs by OS.** macOS/Windows Docker Desktop provide `host.docker.internal` natively; Linux needs `--add-host=host.docker.internal:host-gateway`. Gate the `--add-host` flag on `runtime.GOOS == "linux"`. Binding the daemon to `0.0.0.0:0` is required for any container reachability.
+- **Concurrency over stdio (U4).** A single synchronous JSON-RPC connection may not overlap calls; the mechanism (id-multiplexing vs. two connections) is deferred to implementation. The asserted contract is mechanism-independent.
+- **0.0.0.0 bind exposure.** The test daemon listens on all interfaces on an ephemeral port for the test's lifetime only. Acceptable for a build-tag-gated integration test; do not carry this binding into non-test code.
+- **Flakiness.** Container startup adds latency; reuse the existing `waitForChain` timeout (bump only if needed) and ensure skip/cleanup paths don't leak containers (`--rm` + context cancellation on the `docker run`).
+
+---
+
+## Scope Boundaries
+
+**In scope:** the three variants above, the harness changes that enable them, and the doc/TODO update — all within `internal/app/sandbox_mcp_test.go` (plus the one new helper in that file).
+
+**Out of scope (from #960):**
+- Per-agent E2E variants beyond `aileron-mcp` (Codex / Goose / OpenCode / Pi as MCP client) — unit coverage + the manual recipe (#962) cover those.
+- CI-pipeline integration of the `integration_sandbox` tag — filed separately once the variants land locally.
+
+### Deferred to Follow-Up Work
+- Wiring `task test:integration:sandbox` (with the new Docker-gated variant) into a CI job — separate issue, after these land and prove stable locally.
+
+---
+
+## Sources & Research
+
+- #960 (issue body) — the variant checklist and explicit out-of-scope.
+- `internal/app/sandbox_mcp_test.go` — existing harness: `TestMain` (builds `aileron-mcp`), `newDaemonHarness` (loopback `httptest` daemon + audit `MemStore` + upstream stub), `spawnMCP`/`mcpProcess` (JSON-RPC over stdio), `eventChainForSession`/`waitForChain`, and the three existing R6/R7 tests.
+- `cmd/aileron-mcp/main.go:285,477,887` — `check_action_status` tool (always available; requires `approval_id`; returns a status-word text block) confirming R6b is expressible.
+- `internal/approval/action_queue.go:611` — approval events carry `approval_id` in `Payload`, confirming R6c per-call correlation is expressible via a sibling of `eventChainForSession`.
+- `internal/launch/run_with_proxy_ca_integration_test.go`, `internal/launch/authspec_bindmount_integration_test.go` — established `integration_sandbox` Docker-gated patterns (skip guard, `docker run` argv, base-image build/pull, container stdio) to mirror.

--- a/internal/app/sandbox_mcp_test.go
+++ b/internal/app/sandbox_mcp_test.go
@@ -593,6 +593,55 @@ func TestSandboxMCP_NoApproval_RoundTripsAndEmitsAuditChain(t *testing.T) {
 	}
 }
 
+// TestSandboxMCP_InContainer_NoApproval_RoundTripsAndEmitsAuditChain is
+// the in-container counterpart of the no-approval round-trip (R1): it
+// runs aileron-mcp inside a real sandbox container reaching the daemon
+// via host.docker.internal, and asserts the identical R6/R7 audit chain.
+// The R6/R7 contract is transport-independent, so the assertion set
+// matches the host variant exactly — the only added surface under test
+// is container networking and the read-only binary bind-mount. Skips
+// when Docker is unavailable.
+func TestSandboxMCP_InContainer_NoApproval_RoundTripsAndEmitsAuditChain(t *testing.T) {
+	skipWithoutDocker(t)
+	h := newDaemonHarness(t, draftEmailManifestNoApproval)
+
+	const sessionID = "sess-in-container"
+	p := h.spawnMCP(t, transportContainer, sessionID, "")
+
+	initializeMCP(t, p)
+	tools := listTools(t, p)
+	if !containsTool(tools, "draft_email") {
+		t.Fatalf("tools/list missing draft_email; got %v", toolNames(tools))
+	}
+
+	result := callTool(t, p, "draft_email", map[string]any{
+		"to":      "alice@example.com",
+		"subject": "hello from container",
+		"body":    "test body",
+	})
+	if isErr, _ := result["isError"].(bool); isErr {
+		t.Fatalf("in-container tools/call draft_email returned isError=true: %v", result)
+	}
+
+	want := []model.EventType{
+		model.EventTypeExecutionStarted,
+		model.EventTypeExecutionSucceeded,
+	}
+	// Container start + networking add latency over the host subprocess;
+	// give the round-trip a wider window than the host variant's 5s.
+	waitForChain(t, h.auditStore, sessionID, model.EventTypeExecutionSucceeded, 30*time.Second)
+
+	chain := eventChainForSession(t, h.auditStore, sessionID)
+	if len(chain) != len(want) {
+		t.Fatalf("in-container event chain = %v; want %v", chain, want)
+	}
+	for i, w := range want {
+		if chain[i] != w {
+			t.Errorf("chain[%d] = %s; want %s", i, chain[i], w)
+		}
+	}
+}
+
 // TestSandboxMCP_Approval_RoundTripsWithApprovedDecide covers R6's
 // load-bearing approval claim: an MCP tools/call against an
 // [approval]-gated action returns the 202 pending response, registers

--- a/internal/app/sandbox_mcp_test.go
+++ b/internal/app/sandbox_mcp_test.go
@@ -39,12 +39,14 @@ import (
 	"encoding/json"
 	"fmt"
 	"io"
+	"net"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"os/exec"
 	"path/filepath"
 	"runtime"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -117,13 +119,50 @@ Drafts and sends an email; user must approve before delivery.
 `
 
 // mcpBinaryPath is resolved once by TestMain so each test reuses the
-// same compiled binary.
+// same compiled binary. It targets the host platform and is used by the
+// host-subprocess transport.
 var mcpBinaryPath string
+
+// mcpBinaryPathLinux is a linux/<host-arch> cross-build of aileron-mcp,
+// resolved by TestMain only when Docker is available. The in-container
+// transport bind-mounts this binary — a host-platform build (e.g. a
+// darwin binary on macOS) cannot execute inside the linux sandbox image.
+var mcpBinaryPathLinux string
+
+// sandboxBaseImage is the container image the in-container transport
+// runs aileron-mcp inside. A small glibc image with /bin/sh; distroless
+// static images omit the shell aileron-mcp's process path may rely on.
+const sandboxBaseImage = "debian:bookworm-slim"
+
+// dockerAvailable reports whether a `docker` CLI is on PATH. The
+// in-container variant is skipped (not failed) when it is absent.
+func dockerAvailable() bool {
+	_, err := exec.LookPath("docker")
+	return err == nil
+}
+
+// skipWithoutDocker skips the calling test when Docker is unavailable,
+// so the host-transport, never-approved, and concurrency variants still
+// run on machines and CI lanes without Docker.
+func skipWithoutDocker(t *testing.T) {
+	t.Helper()
+	if !dockerAvailable() {
+		t.Skip("docker not on PATH; skipping in-container variant")
+	}
+}
 
 // TestMain builds the aileron-mcp binary from source so the
 // integration test exercises the real production binary, not a mock.
 // Skips the whole package if `go build` fails (no Go toolchain in
 // the test environment is the only realistic failure mode).
+//
+// When Docker is available it also (a) cross-builds a linux binary for
+// the in-container transport and (b) pre-pulls the sandbox base image,
+// so the per-test container run does not pay a first-touch pull (which
+// is also where registry rate-limiting bites on shared CI runners).
+// Both are best-effort: a failure logs and leaves mcpBinaryPathLinux
+// unset, and the in-container variant skips with a clear reason rather
+// than hanging mid-test.
 func TestMain(m *testing.M) {
 	dir, err := os.MkdirTemp("", "aileron-mcp-integration-*")
 	if err != nil {
@@ -145,6 +184,25 @@ func TestMain(m *testing.M) {
 	}
 	mcpBinaryPath = bin
 
+	if dockerAvailable() {
+		linuxBin := filepath.Join(dir, "aileron-mcp-linux")
+		build := exec.Command("go", "build", "-o", linuxBin, "github.com/ALRubinger/aileron/cmd/aileron-mcp")
+		// Match the container's default platform: Docker Desktop runs the
+		// host architecture, so a linux/<host-arch> build executes natively.
+		build.Env = append(os.Environ(), "GOOS=linux", "GOARCH="+runtime.GOARCH, "CGO_ENABLED=0")
+		build.Stderr = os.Stderr
+		if err := build.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "TestMain: cross-build linux aileron-mcp (in-container variant will skip): %v\n", err)
+		} else {
+			mcpBinaryPathLinux = linuxBin
+		}
+		pull := exec.Command("docker", "pull", sandboxBaseImage)
+		pull.Stderr = os.Stderr
+		if err := pull.Run(); err != nil {
+			fmt.Fprintf(os.Stderr, "TestMain: pre-pull %s (in-container variant may pull on demand or skip): %v\n", sandboxBaseImage, err)
+		}
+	}
+
 	os.Exit(m.Run())
 }
 
@@ -158,6 +216,12 @@ type daemonHarness struct {
 	auditStore *audit.MemStore
 	httpServer *httptest.Server
 	mcpProcess *mcpProcess
+	// loopbackURL is the daemon URL the host transport uses
+	// (127.0.0.1:<port>). containerURL is the same daemon reached from
+	// inside a container via host.docker.internal:<port>. Both resolve
+	// to the one listener bound on 0.0.0.0 below.
+	loopbackURL  string
+	containerURL string
 }
 
 func newDaemonHarness(t *testing.T, manifest string) *daemonHarness {
@@ -173,32 +237,86 @@ func newDaemonHarness(t *testing.T, manifest string) *daemonHarness {
 
 	mux := http.NewServeMux()
 	api.HandlerFromMux(srv, mux)
-	httpSrv := httptest.NewServer(mux)
+
+	// Bind on 0.0.0.0 (not the httptest default of 127.0.0.1) so a
+	// sandbox container can reach the daemon via host.docker.internal.
+	// The host transport still connects over loopback to the same port.
+	ln, err := net.Listen("tcp", "0.0.0.0:0")
+	if err != nil {
+		t.Fatalf("listen 0.0.0.0: %v", err)
+	}
+	httpSrv := httptest.NewUnstartedServer(mux)
+	httpSrv.Listener.Close()
+	httpSrv.Listener = ln
+	httpSrv.Start()
 	t.Cleanup(httpSrv.Close)
 
+	port := strconv.Itoa(ln.Addr().(*net.TCPAddr).Port)
 	return &daemonHarness{
-		srv:        srv,
-		auditStore: store,
-		httpServer: httpSrv,
+		srv:          srv,
+		auditStore:   store,
+		httpServer:   httpSrv,
+		loopbackURL:  "http://127.0.0.1:" + port,
+		containerURL: "http://host.docker.internal:" + port,
 	}
 }
 
-// spawnMCP starts an aileron-mcp host subprocess pointed at this
-// harness's daemon URL. Returns a handle the test uses to send/receive
-// JSON-RPC messages.
-func (h *daemonHarness) spawnMCP(t *testing.T, sessionID, token string) *mcpProcess {
+// mcpTransport selects where aileron-mcp runs for a given spawn.
+type mcpTransport int
+
+const (
+	// transportHost runs aileron-mcp as a host subprocess reaching the
+	// daemon over loopback — the fast, Docker-free path.
+	transportHost mcpTransport = iota
+	// transportContainer runs aileron-mcp inside a sandbox container via
+	// `docker run -i`, reaching the daemon through host.docker.internal.
+	transportContainer
+)
+
+// spawnMCP starts an aileron-mcp process pointed at this harness's
+// daemon and returns a handle for JSON-RPC over its stdio. The transport
+// selects host-subprocess vs in-container execution; both yield an
+// identical *mcpProcess so every downstream helper is transport-agnostic.
+func (h *daemonHarness) spawnMCP(t *testing.T, transport mcpTransport, sessionID, token string) *mcpProcess {
 	t.Helper()
-	if mcpBinaryPath == "" {
-		t.Fatal("mcpBinaryPath unset; TestMain did not run")
-	}
 	ctx, cancel := context.WithCancel(context.Background())
-	cmd := exec.CommandContext(ctx, mcpBinaryPath)
-	cmd.Env = append(os.Environ(),
-		"AILERON_URL="+h.httpServer.URL,
-		"AILERON_TOKEN="+token,
-		"AILERON_SESSION_ID="+sessionID,
-		"AILERON_OTEL_ENABLED=false",
-	)
+
+	var cmd *exec.Cmd
+	switch transport {
+	case transportContainer:
+		if mcpBinaryPathLinux == "" {
+			cancel()
+			t.Skip("linux aileron-mcp cross-build unavailable; skipping in-container variant")
+		}
+		args := []string{"run", "-i", "--rm"}
+		// macOS/Windows Docker Desktop provide host.docker.internal
+		// natively; rootful Linux Docker needs this explicit mapping.
+		if runtime.GOOS == "linux" {
+			args = append(args, "--add-host=host.docker.internal:host-gateway")
+		}
+		args = append(args,
+			"-v", mcpBinaryPathLinux+":/usr/local/bin/aileron-mcp:ro",
+			"-e", "AILERON_URL="+h.containerURL,
+			"-e", "AILERON_TOKEN="+token,
+			"-e", "AILERON_SESSION_ID="+sessionID,
+			"-e", "AILERON_OTEL_ENABLED=false",
+			sandboxBaseImage,
+			"/usr/local/bin/aileron-mcp",
+		)
+		cmd = exec.CommandContext(ctx, "docker", args...)
+	default:
+		if mcpBinaryPath == "" {
+			cancel()
+			t.Fatal("mcpBinaryPath unset; TestMain did not run")
+		}
+		cmd = exec.CommandContext(ctx, mcpBinaryPath)
+		cmd.Env = append(os.Environ(),
+			"AILERON_URL="+h.loopbackURL,
+			"AILERON_TOKEN="+token,
+			"AILERON_SESSION_ID="+sessionID,
+			"AILERON_OTEL_ENABLED=false",
+		)
+	}
 
 	stdin, err := cmd.StdinPipe()
 	if err != nil {
@@ -441,7 +559,7 @@ func TestSandboxMCP_NoApproval_RoundTripsAndEmitsAuditChain(t *testing.T) {
 	h := newDaemonHarness(t, draftEmailManifestNoApproval)
 
 	const sessionID = "sess-no-approval"
-	p := h.spawnMCP(t, sessionID, "")
+	p := h.spawnMCP(t, transportHost, sessionID, "")
 
 	initializeMCP(t, p)
 	tools := listTools(t, p)
@@ -485,7 +603,7 @@ func TestSandboxMCP_Approval_RoundTripsWithApprovedDecide(t *testing.T) {
 	h := newDaemonHarness(t, draftEmailManifestApproval)
 
 	const sessionID = "sess-approval-approved"
-	p := h.spawnMCP(t, sessionID, "")
+	p := h.spawnMCP(t, transportHost, sessionID, "")
 
 	initializeMCP(t, p)
 	tools := listTools(t, p)
@@ -554,7 +672,7 @@ func TestSandboxMCP_Denied(t *testing.T) {
 	h := newDaemonHarness(t, draftEmailManifestApproval)
 
 	const sessionID = "sess-approval-denied"
-	p := h.spawnMCP(t, sessionID, "")
+	p := h.spawnMCP(t, transportHost, sessionID, "")
 
 	initializeMCP(t, p)
 	_ = listTools(t, p)

--- a/internal/app/sandbox_mcp_test.go
+++ b/internal/app/sandbox_mcp_test.go
@@ -52,6 +52,7 @@ import (
 	"testing"
 	"time"
 
+	"github.com/ALRubinger/aileron/internal/action"
 	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/approval"
 	"github.com/ALRubinger/aileron/internal/audit"
@@ -392,11 +393,27 @@ type jsonrpcResponse struct {
 	} `json:"error,omitempty"`
 }
 
-// request sends a JSON-RPC request, then reads JSON-RPC frames from
-// stdout until it finds one whose id matches. Notifications (id=0) and
-// unrelated responses are skipped.
+// request sends a JSON-RPC request and fails the test on any transport
+// error. It wraps requestErr for the common case where an error is
+// fatal to the test.
 func (p *mcpProcess) request(method string, params any) jsonrpcResponse {
 	p.t.Helper()
+	resp, err := p.requestErr(method, params)
+	if err != nil {
+		p.t.Fatalf("%v", err)
+	}
+	return resp
+}
+
+// requestErr sends a JSON-RPC request, then reads JSON-RPC frames from
+// stdout until it finds one whose id matches. Notifications (id=0) and
+// unrelated responses are skipped. It returns an error instead of
+// failing the test so callers running in a separate goroutine (the
+// concurrency variant) do not call t.Fatalf off the test goroutine.
+// Each mcpProcess has its own reader, so distinct processes may run
+// requestErr concurrently; a single process must not (the reader is not
+// demultiplexed).
+func (p *mcpProcess) requestErr(method string, params any) (jsonrpcResponse, error) {
 	p.mu.Lock()
 	p.nextID++
 	id := p.nextID
@@ -405,17 +422,17 @@ func (p *mcpProcess) request(method string, params any) jsonrpcResponse {
 	req := jsonrpcRequest{JSONRPC: "2.0", ID: id, Method: method, Params: params}
 	data, err := json.Marshal(req)
 	if err != nil {
-		p.t.Fatalf("marshal request: %v", err)
+		return jsonrpcResponse{}, fmt.Errorf("marshal request: %w", err)
 	}
 	if _, err := p.stdin.Write(append(data, '\n')); err != nil {
-		p.t.Fatalf("write request %s: %v", method, err)
+		return jsonrpcResponse{}, fmt.Errorf("write request %s: %w", method, err)
 	}
 
 	deadline := time.Now().Add(15 * time.Second)
 	for time.Now().Before(deadline) {
 		line, err := p.reader.ReadString('\n')
 		if err != nil {
-			p.t.Fatalf("read response (method=%s): %v", method, err)
+			return jsonrpcResponse{}, fmt.Errorf("read response (method=%s): %w", method, err)
 		}
 		line = strings.TrimSpace(line)
 		if line == "" {
@@ -427,11 +444,10 @@ func (p *mcpProcess) request(method string, params any) jsonrpcResponse {
 			continue
 		}
 		if resp.ID == id {
-			return resp
+			return resp, nil
 		}
 	}
-	p.t.Fatalf("timed out waiting for response to %s", method)
-	return jsonrpcResponse{}
+	return jsonrpcResponse{}, fmt.Errorf("timed out waiting for response to %s", method)
 }
 
 // notify sends a JSON-RPC notification (no id, no response expected).
@@ -843,6 +859,180 @@ func TestSandboxMCP_NeverApproved_StaysPendingNoExecution(t *testing.T) {
 	stillPending := h.srv.actionApprovals.List()
 	if len(stillPending) != 1 || stillPending[0].ID != entry.ID {
 		t.Fatalf("approval entry should remain pending and unchanged; got %d entries", len(stillPending))
+	}
+}
+
+// recordingExecutor is an action.Executor double that records every
+// Execute call's name and args under a mutex, so the concurrency variant
+// can assert exactly-two executions with the right per-call inputs. It
+// always succeeds, mirroring StubExecutor's no-error contract.
+type recordingExecutor struct {
+	mu    sync.Mutex
+	calls []recordedCall
+}
+
+type recordedCall struct {
+	name string
+	args map[string]any
+}
+
+func (e *recordingExecutor) Execute(_ context.Context, name string, args map[string]any) (action.Result, error) {
+	e.mu.Lock()
+	e.calls = append(e.calls, recordedCall{name: name, args: args})
+	e.mu.Unlock()
+	return action.Result{Content: `{"recorded":true}`}, nil
+}
+
+func (e *recordingExecutor) recordedRecipients() []string {
+	e.mu.Lock()
+	defer e.mu.Unlock()
+	out := make([]string, 0, len(e.calls))
+	for _, c := range e.calls {
+		if to, _ := c.args["to"].(string); to != "" {
+			out = append(out, to)
+		}
+	}
+	return out
+}
+
+// eventChainForApproval returns the chronological event types correlated
+// to a single approval id. Both approval.* and execution.* events stamp
+// the same aileron.approval.id payload key (see action_queue.go
+// recordRequested/recordDecided and handlers.go actionExecutionPayload),
+// so this isolates one call's chain even when several share a session.
+func eventChainForApproval(t *testing.T, store *audit.MemStore, approvalID string) []model.EventType {
+	t.Helper()
+	all, err := store.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	out := make([]model.EventType, 0, len(all))
+	for i := len(all) - 1; i >= 0; i-- {
+		if got, _ := all[i].Payload["aileron.approval.id"].(string); got == approvalID {
+			out = append(out, all[i].EventType)
+		}
+	}
+	return out
+}
+
+// waitForApprovalChain polls until the given approval's chain contains
+// the terminal event, or the deadline expires.
+func waitForApprovalChain(t *testing.T, store *audit.MemStore, approvalID string, terminal model.EventType, timeout time.Duration) {
+	t.Helper()
+	deadline := time.Now().Add(timeout)
+	for time.Now().Before(deadline) {
+		for _, e := range eventChainForApproval(t, store, approvalID) {
+			if e == terminal {
+				return
+			}
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("timed out waiting for %s on approval %q; chain so far: %v",
+		terminal, approvalID, eventChainForApproval(t, store, approvalID))
+}
+
+// TestSandboxMCP_Concurrency_DistinctApprovalsAttributedCorrectly covers
+// R6c: two concurrent draft_email calls produce two distinct approval
+// ids; approving them in reverse order emits the correct, isolated
+// per-approval event chain for each; and the executor runs exactly twice
+// with the two distinct recipients. Host transport, Docker-free. Genuine
+// concurrency uses two separate aileron-mcp processes (one per call)
+// since a single process's stdio reader is not demultiplexed.
+func TestSandboxMCP_Concurrency_DistinctApprovalsAttributedCorrectly(t *testing.T) {
+	h := newDaemonHarness(t, draftEmailManifestApproval)
+	rec := &recordingExecutor{}
+	h.srv.executor = rec
+
+	const sessionID = "sess-concurrency"
+	p1 := h.spawnMCP(t, transportHost, sessionID, "")
+	p2 := h.spawnMCP(t, transportHost, sessionID, "")
+	initializeMCP(t, p1)
+	initializeMCP(t, p2)
+
+	// Fire both tools/call requests concurrently. requestErr returns an
+	// error rather than calling t.Fatalf so neither goroutine touches the
+	// test goroutine's failure path.
+	type callOutcome struct {
+		resp jsonrpcResponse
+		err  error
+	}
+	results := make([]callOutcome, 2)
+	recipients := []string{"erin@example.com", "frank@example.com"}
+	var wg sync.WaitGroup
+	for i, p := range []*mcpProcess{p1, p2} {
+		wg.Add(1)
+		go func(i int, p *mcpProcess) {
+			defer wg.Done()
+			resp, err := p.requestErr("tools/call", map[string]any{
+				"name": "draft_email",
+				"arguments": map[string]any{
+					"to":      recipients[i],
+					"subject": "concurrent",
+					"body":    "body",
+				},
+			})
+			results[i] = callOutcome{resp: resp, err: err}
+		}(i, p)
+	}
+	wg.Wait()
+	for i, r := range results {
+		if r.err != nil {
+			t.Fatalf("concurrent tools/call %d: %v", i, r.err)
+		}
+		if r.resp.Error != nil {
+			t.Fatalf("concurrent tools/call %d: %d %s", i, r.resp.Error.Code, r.resp.Error.Message)
+		}
+	}
+
+	// Both calls registered a pending approval; ids must be distinct.
+	pending := h.srv.actionApprovals.List()
+	if len(pending) != 2 {
+		t.Fatalf("pending approvals = %d; want 2", len(pending))
+	}
+	if pending[0].ID == pending[1].ID {
+		t.Fatalf("concurrent calls collapsed to one approval id %q; want two distinct ids", pending[0].ID)
+	}
+
+	// Approve in reverse registration order. Each approval's chain must
+	// be its own complete, isolated sequence regardless of order.
+	if err := h.srv.actionApprovals.Decide(pending[1].ID, true, "", nil); err != nil {
+		t.Fatalf("Decide pending[1]: %v", err)
+	}
+	if err := h.srv.actionApprovals.Decide(pending[0].ID, true, "", nil); err != nil {
+		t.Fatalf("Decide pending[0]: %v", err)
+	}
+
+	wantChain := []model.EventType{
+		model.EventTypeApprovalRequested,
+		model.EventTypeApprovalApproved,
+		model.EventTypeExecutionStarted,
+		model.EventTypeExecutionSucceeded,
+	}
+	for _, entry := range pending {
+		waitForApprovalChain(t, h.auditStore, entry.ID, model.EventTypeExecutionSucceeded, 5*time.Second)
+		chain := eventChainForApproval(t, h.auditStore, entry.ID)
+		if len(chain) != len(wantChain) {
+			t.Fatalf("approval %q chain = %v; want %v", entry.ID, chain, wantChain)
+		}
+		for i, w := range wantChain {
+			if chain[i] != w {
+				t.Errorf("approval %q chain[%d] = %s; want %s", entry.ID, i, chain[i], w)
+			}
+		}
+	}
+
+	// The executor ran exactly twice, once per call, with the two
+	// distinct recipients — proving per-call args were not crossed.
+	got := rec.recordedRecipients()
+	if len(got) != 2 {
+		t.Fatalf("executor recorded %d calls; want 2 (%v)", len(got), got)
+	}
+	gotSet := map[string]bool{got[0]: true, got[1]: true}
+	for _, want := range recipients {
+		if !gotSet[want] {
+			t.Errorf("executor did not receive a call for %q; recorded %v", want, got)
+		}
 	}
 }
 

--- a/internal/app/sandbox_mcp_test.go
+++ b/internal/app/sandbox_mcp_test.go
@@ -773,6 +773,79 @@ func TestSandboxMCP_Denied(t *testing.T) {
 	}
 }
 
+// TestSandboxMCP_NeverApproved_StaysPendingNoExecution covers R6b: an
+// [approval]-gated action whose approval is never decided must stay
+// pending across polls, emit no execution.* events, and leave the
+// approval queue unchanged. The contract is transport-independent, so
+// this runs on the host transport (Docker-free).
+func TestSandboxMCP_NeverApproved_StaysPendingNoExecution(t *testing.T) {
+	h := newDaemonHarness(t, draftEmailManifestApproval)
+
+	const sessionID = "sess-never-approved"
+	p := h.spawnMCP(t, transportHost, sessionID, "")
+
+	initializeMCP(t, p)
+	_ = listTools(t, p)
+
+	result := callTool(t, p, "draft_email", map[string]any{
+		"to":      "dave@example.com",
+		"subject": "never decided",
+		"body":    "pending forever",
+	})
+	if isErr, _ := result["isError"].(bool); isErr {
+		t.Fatalf("tools/call returned isError=true: %v", result)
+	}
+
+	pending := h.srv.actionApprovals.List()
+	if len(pending) != 1 {
+		t.Fatalf("pending approvals = %d; want 1", len(pending))
+	}
+	entry := pending[0]
+
+	// Poll check_action_status twice, 100ms apart. Decide is never
+	// called: each poll must report a non-terminal (pending) status.
+	for i := 0; i < 2; i++ {
+		statusResult := callTool(t, p, "check_action_status", map[string]any{"approval_id": entry.ID})
+		text := strings.ToLower(firstTextContent(statusResult))
+		if !strings.Contains(text, "pending") {
+			t.Fatalf("poll %d: check_action_status = %q; want a pending status", i, text)
+		}
+		for _, terminal := range []string{"completed", "denied", "failed"} {
+			if strings.Contains(text, terminal) {
+				t.Fatalf("poll %d: undecided approval reported terminal status %q in %q", i, terminal, text)
+			}
+		}
+		if i == 0 {
+			time.Sleep(100 * time.Millisecond)
+		}
+	}
+
+	// The audit chain must be exactly approval.requested — no execution.*
+	// events fire for an action that was never approved.
+	chain := eventChainForSession(t, h.auditStore, sessionID)
+	for _, evt := range chain {
+		if strings.HasPrefix(string(evt), "execution.") {
+			t.Errorf("never-approved path emitted %s; expected no execution.* events", evt)
+		}
+	}
+	want := []model.EventType{model.EventTypeApprovalRequested}
+	if len(chain) != len(want) {
+		t.Fatalf("event chain = %v; want %v", chain, want)
+	}
+	if chain[0] != want[0] {
+		t.Errorf("chain[0] = %s; want %s", chain[0], want[0])
+	}
+
+	// The entry must still be pending and unchanged — polling must not
+	// mutate queue state. No explicit delete is needed: newDaemonHarness
+	// gives each test a fresh in-memory queue, so the undecided entry
+	// cannot leak into another test.
+	stillPending := h.srv.actionApprovals.List()
+	if len(stillPending) != 1 || stillPending[0].ID != entry.ID {
+		t.Fatalf("approval entry should remain pending and unchanged; got %d entries", len(stillPending))
+	}
+}
+
 // firstTextContent extracts the first text-typed content entry from an
 // MCP tool result payload. Returns the empty string when no text
 // content is present.

--- a/internal/app/sandbox_mcp_test.go
+++ b/internal/app/sandbox_mcp_test.go
@@ -12,25 +12,29 @@
 //
 //	task test:integration:sandbox
 //
-// Docker availability: the plan's preferred execution mode is to run
-// `aileron-mcp` inside a sandbox container reaching the daemon via
-// `host.docker.internal`. This implementation uses the plan's
-// explicitly-approved fallback: `aileron-mcp` runs as a HOST subprocess
-// of the test, pointing AILERON_URL at the in-process daemon's
-// loopback address. The load-bearing R6/R7 assertions (round-trip
-// + exclusive audit-event chain stamped with the launch session id)
-// are identical regardless of whether the binary runs on the host or
-// in a container; the container variant is deferred as a follow-up.
+// Transports (#960): the round-trip runs over two transports selected by
+// spawnMCP. The HOST transport runs `aileron-mcp` as a subprocess of the
+// test reaching the daemon over loopback — the always-on, Docker-free
+// path. The CONTAINER transport runs it inside a sandbox container via
+// `docker run -i` (binary bind-mounted read-only, daemon reached through
+// `host.docker.internal`, `--add-host` on Linux); it is Docker-gated and
+// skips when Docker or the linux cross-build is unavailable. The
+// load-bearing R6/R7 assertions (round-trip + exclusive audit-event
+// chain stamped with the launch session id) are identical across
+// transports, so the in-container variant asserts the same chain.
 //
-// TODO(#953):
-//   - Promote to the in-container variant (bind-mount aileron-mcp at
-//     /usr/local/bin/aileron-mcp:ro, run via docker run -i with
-//     --add-host=host.docker.internal:host-gateway on Linux, daemon
-//     bound to 0.0.0.0:0).
-//   - Add R6b (never-approved) and R6c (concurrency) variants. R6b
-//     needs a poll-on-demand assertion via the check_action_status
-//     tool; R6c needs two parallel tools/call requests with distinct
-//     approval_ids.
+// Variants covered here:
+//   - R6/R7 no-approval and approval round-trips (host + in-container).
+//   - R6a denied path (no execution.* after denial).
+//   - R6b never-approved: check_action_status stays pending, no
+//     execution.* events, queue entry unchanged.
+//   - R6c concurrency: two parallel calls yield distinct approval ids
+//     with correctly attributed, isolated per-approval event chains.
+//
+// Still deferred (tracked separately, not by this file):
+//   - Per-agent E2E beyond aileron-mcp (Codex/Goose/OpenCode/Pi as MCP
+//     client) — unit coverage + the manual recipe (#962) cover those.
+//   - Wiring this tag into a CI job — separate follow-up once stable.
 package app
 
 import (


### PR DESCRIPTION
## Summary

Closes the three sandbox-MCP integration variants deferred from #953, all in `internal/app/sandbox_mcp_test.go` (build tag `integration_sandbox`). Test-only change — no production code modified.

- **Transport seam (U1):** `spawnMCP` now takes a `host | container` transport. The daemon binds on `0.0.0.0:0` (loopback URL for host, `host.docker.internal` URL for the container). `TestMain` cross-builds a linux `aileron-mcp` and pre-pulls `debian:bookworm-slim` when Docker is present (a macOS-built binary can't run in a linux container; the pre-pull mitigates CI registry rate-limiting). A `docker`-on-PATH guard skips only the in-container variant.
- **In-container round-trip (U2, R1):** runs `aileron-mcp` inside a real container via `docker run -i` (`--add-host` on Linux, binary bind-mounted `:ro`) and asserts the same R6/R7 audit chain as the host transport. Docker-gated.
- **Never-approved (U3, R6b):** two `check_action_status` polls 100ms apart stay pending; chain is exactly `approval.requested` with no `execution.*`; queue entry unchanged. Host transport.
- **Concurrency (U4, R6c):** two concurrent `draft_email` calls (one `aileron-mcp` process each) get distinct approval ids; approving in reverse order yields correct, isolated per-approval chains (correlated via the shared `aileron.approval.id` payload key); a recording executor double asserts exactly two executions with the two distinct recipients. Host transport.
- **Docs (U5):** the file's `TODO(#953)` block now reflects what's covered and what's genuinely deferred.

**Kept both transports** (per design decision): the host subprocess stays the always-on, Docker-free path; the container variant adds runtime realism only where it matters (the round-trip). R6b/R6c are transport-independent, so they run host-only.

Two small implementation notes vs. the issue text, both verified against the code:
- The issue's "upstream stub records two requests" maps to a recording `action.Executor` double — this harness executes via `action.StubExecutor`, not an HTTP upstream.
- Per-call correlation keys on `aileron.approval.id` (the payload key both approval and execution events actually stamp), not `approval_id`.

Plan: `docs/plans/2026-06-13-001-test-sandbox-mcp-variants-plan.md`.

## Test plan

- [x] `go test -tags=integration_sandbox -run TestSandboxMCP ./internal/app/...` — all 6 variants green together (incl. in-container against real Docker on macOS/arm64).
- [x] Existing host-transport tests unchanged in behavior through the refactored harness.
- [x] In-container variant skips cleanly when Docker / the linux cross-build is absent.
- [x] CodeRabbit: 0 findings.
- [ ] Out of scope (filed separately): per-agent E2E beyond aileron-mcp; wiring the `integration_sandbox` tag into a CI job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Expanded sandbox MCP test coverage to include in-container execution paths and approval edge cases.
  * Added tests validating pending-state behavior, concurrent approval handling, and isolated event chain attribution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->