### PR TITLE
docs: update sandbox docs to Docker-only runtime

### DIFF
--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -14,7 +14,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 
 | Command | Purpose | Ratified by |
 |---|---|---|
-| `aileron launch [--sandbox=off\|auto\|docker\|podman] [--sandbox-build=auto\|always\|never]` | Launch an AI coding agent connected to the Aileron daemon. `--sandbox` prepares the project sandbox image and runs the agent command inside it; `off` preserves direct host launch. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron launch [--sandbox=off\|auto\|docker] [--sandbox-build=auto\|always\|never]` | Launch an AI coding agent connected to the Aileron daemon. `--sandbox` prepares the project sandbox image and runs the agent command inside it; `off` preserves direct host launch. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron status` | Report the running runtime: version, listen address, action count, connector count, binding count, vault state. Read-only; safe to run frequently. | — |
 
 ## Sandbox composition
@@ -23,8 +23,10 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 |---|---|---|
 | `aileron sandbox init [--agent=<name>] [--force]` | Scaffold `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile` for sandbox composition. The Dockerfile extends `aileron/sandbox-base:<version>`, pre-fills the install recipe for `--agent` (defaults to `claude`), and ships additional tool snippets commented out. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox plan` | Inspect the normalized composition tier and image Aileron infers from the current project. | [ADR-0017](/adr/0017-sandbox-composition) |
-| `aileron sandbox build` | Build the Tier 0 sandbox-base image or Tier 1 devcontainer image with Docker or Podman. Tier 2 BYO images are reported without build or injection. | [ADR-0017](/adr/0017-sandbox-composition) |
-| `aileron sandbox check [--runtime=auto\|docker\|podman] [--build=auto\|always\|never] --agent=<command>` | Validate that the selected sandbox image can launch an agent command before starting a session. | [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron sandbox build` | Build the Tier 0 sandbox-base image or Tier 1 devcontainer image with Docker. Tier 2 BYO images are reported without build or injection. | [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron sandbox check [--runtime=auto\|docker] [--build=auto\|always\|never] --agent=<command>` | Validate that the selected sandbox image can launch an agent command before starting a session. | [ADR-0017](/adr/0017-sandbox-composition) |
+
+Docker is the only supported sandbox runtime in v4. Podman is planned but not yet supported ([ADR-0014](/adr/0014-spawn-sandbox-technology/)); passing `--sandbox=podman` or `--runtime=podman` fails with `podman runtime is not supported yet (v4 is Docker-only); see ADR-0014`.
 
 See [Sandbox Composition](/development/sandbox-composition/) for the full workflow and [Sandbox Agent Images](/development/sandbox-agent-images/) for the support matrix and recipes.
 

--- a/docs/src/content/docs/development/adding-an-agent.md
+++ b/docs/src/content/docs/development/adding-an-agent.md
@@ -4,7 +4,7 @@ description: "How to wire a new AI coding agent into `aileron launch`."
 order: 6
 ---
 
-`aileron launch <agent>` runs a supported AI coding agent under the Aileron daemon. With `--sandbox=off`, host launch wires the agent to the daemon and current MCP/gateway path. With `--sandbox=auto|docker|podman`, sandbox launch prepares a container image, validates that the agent command exists inside it, and runs the agent in the container with Aileron's session env and generated discovery/action shims. Adding a new agent means writing one Go file under `internal/launch/agents/`, registering it in `cmd/aileron/main.go`, documenting whether its command is available in sandbox images, and shipping tests.
+`aileron launch <agent>` runs a supported AI coding agent under the Aileron daemon. With `--sandbox=off`, host launch wires the agent to the daemon and current MCP/gateway path. With `--sandbox=auto|docker`, sandbox launch prepares a container image, validates that the agent command exists inside it, and runs the agent in the container with Aileron's session env and generated discovery/action shims. Adding a new agent means writing one Go file under `internal/launch/agents/`, registering it in `cmd/aileron/main.go`, documenting whether its command is available in sandbox images, and shipping tests.
 
 ## When `aileron launch` is the right answer
 

--- a/docs/src/content/docs/development/binary-architecture.md
+++ b/docs/src/content/docs/development/binary-architecture.md
@@ -56,7 +56,7 @@ Per [ADR-0015](/adr/0015-launch-audit-scope), Aileron's host-launch audit bounda
 ## What runs where
 
 - **`aileron launch <agent>`** with `--sandbox=off` starts the agent host as a subprocess and wires `aileron-mcp` into its MCP transport (per [ADR-0012](/adr/0012-local-daemon-architecture)). The daemon auto-spawns on first call and stays running as long as a session is active.
-- **`aileron launch --sandbox=auto|docker|podman <agent>`** prepares the selected sandbox image, validates it, and runs the agent command in a container. It bind-mounts the host-built `aileron-mcp` at `/usr/local/bin/aileron-mcp:ro` and registers it with the in-container agent (ADR-0024), and injects `AILERON_API_URL`, session metadata, `tools.txt`, and generated connector shims as a complementary non-MCP-native CLI surface.
+- **`aileron launch --sandbox=auto|docker <agent>`** prepares the selected sandbox image, validates it, and runs the agent command in a container. It bind-mounts the host-built `aileron-mcp` at `/usr/local/bin/aileron-mcp:ro` and registers it with the in-container agent (ADR-0024), and injects `AILERON_API_URL`, session metadata, `tools.txt`, and generated connector shims as a complementary non-MCP-native CLI surface.
 - **`aileron daemon start|stop|status`** controls the daemon directly. Useful for diagnostics, rare in normal use.
 - **`aileron-mcp`** can be installed standalone with `task mcp:setup` when an agent host needs the MCP server outside an `aileron launch` session.
 - **`aileron-enclave`** is post-MVP for the default install. The credential vault works without it via the local-mode path in [ADR-0011](/adr/0011-local-credential-vault). When the TEE-backed escrow lands, this binary is what runs inside Confidential Space.

--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -10,7 +10,7 @@ This page is for operators and contributors. It documents the per-agent envelope
 
 ## Host launch is not vault-backed in v1
 
-Vault-backed credential injection applies only to `aileron launch <agent> --sandbox=docker` (and `--sandbox=podman`). A plain `aileron launch <agent>` host launch is not vault-backed in v1. Host launch lets the agent find its own credentials in the host user's home directory (`~/.claude/`, `~/.codex/`). `prepareAuthSpec` does not run on the host path, so the `AuthSpec` lifecycle is sandbox-only. Host-side vault-backed auth is a deliberately deferred follow-up that needs its own PR and explicit user testing. See [ADR-0025](/adr/0025-vault-backed-agent-auth) for the decision record.
+Vault-backed credential injection applies only to `aileron launch <agent> --sandbox=docker`. A plain `aileron launch <agent>` host launch is not vault-backed in v1. Host launch lets the agent find its own credentials in the host user's home directory (`~/.claude/`, `~/.codex/`). `prepareAuthSpec` does not run on the host path, so the `AuthSpec` lifecycle is sandbox-only. Host-side vault-backed auth is a deliberately deferred follow-up that needs its own PR and explicit user testing. See [ADR-0025](/adr/0025-vault-backed-agent-auth) for the decision record.
 
 ## Vault path scheme
 

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -10,7 +10,7 @@ Use `sandbox check` to validate an image before starting a daemon-backed session
 
 ```bash
 aileron sandbox check --runtime=docker --agent=claude
-aileron sandbox check --runtime=podman --build=never --agent=codex
+aileron sandbox check --runtime=docker --build=never --agent=codex
 ```
 
 The check uses the same composition plan and minimal launch validation as `aileron launch --sandbox=...`: `/bin/sh`, the `/home/agent/workspace` mount, workspace write access, and the requested agent command on `PATH`.
@@ -26,7 +26,9 @@ The check uses the same composition plan and minimal launch validation as `ailer
 | Pi | `pi` | Command contract only | ✓ via `--mcp-config` | Shares Claude's MCP wiring. |
 | Other agents | varies | Unsupported | n/a | Add an Aileron launch agent and an image recipe before relying on sandbox launch. |
 
-Under `--sandbox=docker` the launcher resolves the host-built `aileron-mcp` binary, bind-mounts it read-only at `/usr/local/bin/aileron-mcp`, builds an `mcpEnv` rewritten for the runtime (`host.docker.internal` on Docker, `host.containers.internal` on Podman), and calls each agent's `ConfigureMCP` hook. Four of the five agents (Claude, Pi, Goose, OpenCode) work without any agent-side code change because their config is either inline-with-exec (`--mcp-config`, `--with-extension`) or workspace-local (`opencode.json` in the bind-mounted workspace). Codex is the one exception — its host `~/.codex/config.toml` is irrelevant inside the container, so the launcher writes a generated `config.toml` to a host tempdir and bind-mounts it. See [ADR-0024](/adr/0024-sandbox-mcp-parity/) and the [manual walkthrough](/development/sandbox-mcp-walkthrough/) for the load-bearing flow.
+Under `--sandbox=docker` the launcher resolves the host-built `aileron-mcp` binary, bind-mounts it read-only at `/usr/local/bin/aileron-mcp`, builds an `mcpEnv` rewritten for the runtime (`host.docker.internal` on Docker), and calls each agent's `ConfigureMCP` hook. Four of the five agents (Claude, Pi, Goose, OpenCode) work without any agent-side code change because their config is either inline-with-exec (`--mcp-config`, `--with-extension`) or workspace-local (`opencode.json` in the bind-mounted workspace). Codex is the one exception — its host `~/.codex/config.toml` is irrelevant inside the container, so the launcher writes a generated `config.toml` to a host tempdir and bind-mounts it. See [ADR-0024](/adr/0024-sandbox-mcp-parity/) and the [manual walkthrough](/development/sandbox-mcp-walkthrough/) for the load-bearing flow.
+
+Docker is the only supported sandbox runtime in v4. Podman is planned but not yet supported; its `host.containers.internal` host alias is the deferred re-add path, and passing `--runtime=podman` fails with `podman runtime is not supported yet (v4 is Docker-only); see ADR-0014` (see [ADR-0014](/adr/0014-spawn-sandbox-technology/)).
 
 Tier 0 `aileron/sandbox-base` intentionally does not include agent CLIs. Use Tier 1 when you want Aileron's base runtime plus an installed agent, or Tier 2 when your team owns the full image.
 
@@ -58,7 +60,7 @@ Claude Code still owns its own authentication flow. Do not bake Claude, Anthropi
 A BYO image must provide:
 
 - `/bin/sh`
-- a writable `/home/agent/workspace` bind mount when launched by Docker or Podman
+- a writable `/home/agent/workspace` bind mount when launched by Docker
 - the requested agent command on `PATH`
 - `wget` when Aileron mounts generated connector shims
 
@@ -72,7 +74,7 @@ aileron sandbox check --runtime=docker --build=never --agent=claude
 
 `aileron launch --sandbox=docker` runs the HTTPS proxy by default ([ADR-0019](/adr/0019-v4-https-data-plane/)). The launcher mounts a session-scoped CA at `/etc/aileron/proxy/ca.pem`, sets standard proxy env (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`), and runs the agent through the `aileron-run-with-proxy-ca` wrapper. For the proxy to terminate TLS without breaking the agent's HTTPS clients, the in-container trust store must include that CA before the agent starts.
 
-`aileron sandbox check --agent=<command>` validates the proxy contract for every `--runtime=docker` and `--runtime=podman` invocation. The check exits non-zero with an actionable message when the image is missing any of the required pieces below. The launch-time validation runs the same script.
+`aileron sandbox check --agent=<command>` validates the proxy contract for every `--runtime=docker` invocation. The check exits non-zero with an actionable message when the image is missing any of the required pieces below. The launch-time validation runs the same script.
 
 A BYO image meets the proxy contract by providing two helpers on `PATH`:
 

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -95,12 +95,14 @@ Use `sandbox build` to build the image selected by the plan:
 aileron sandbox build
 ```
 
-Aileron detects Docker or Podman from `PATH`. You can choose explicitly:
+Aileron detects Docker from `PATH`. You can choose it explicitly:
 
 ```bash
-aileron sandbox build --runtime=podman
+aileron sandbox build --runtime=docker
 aileron sandbox build --runtime=docker --tag=ghcr.io/acme/agent-dev:local
 ```
+
+Docker is the only supported sandbox runtime in v4. Podman is planned but not yet supported ([ADR-0014](/adr/0014-spawn-sandbox-technology/)); passing `--runtime=podman` fails with `podman runtime is not supported yet (v4 is Docker-only); see ADR-0014`.
 
 Build behavior by tier:
 
@@ -120,7 +122,7 @@ Use `sandbox check` to validate that the selected image can run an agent command
 
 ```bash
 aileron sandbox check --runtime=docker --agent=claude
-aileron sandbox check --runtime=podman --build=never --agent=codex
+aileron sandbox check --runtime=docker --build=never --agent=codex
 ```
 
 `sandbox check` uses the same composition plan, build policy, and minimal image validation as sandbox launch. It reports the selected tier, runtime, image, command, and `support: ok` when the command is available. Agent-specific image recipes and support status live in the [sandbox agent image matrix](/development/sandbox-agent-images/).
@@ -132,10 +134,10 @@ Use `--sandbox` on `aileron launch` to have launch prepare the composition-selec
 ```bash
 aileron launch --sandbox=auto claude
 aileron launch --sandbox=docker codex
-aileron launch --sandbox=podman goose
+aileron launch --sandbox=docker goose
 ```
 
-`auto` detects Docker or Podman from `PATH`. `docker` and `podman` select a runtime explicitly. The default is `--sandbox=off`, which preserves the current direct host launch path.
+`auto` detects Docker from `PATH`. `docker` selects the runtime explicitly. The default is `--sandbox=off`, which preserves the current direct host launch path. Podman is planned but not yet supported ([ADR-0014](/adr/0014-spawn-sandbox-technology/)); passing `--sandbox=podman` fails with `podman runtime is not supported yet (v4 is Docker-only); see ADR-0014`.
 
 Launch uses `--sandbox-build=auto` by default. Build policy options are:
 
@@ -149,16 +151,16 @@ Examples:
 
 ```bash
 aileron launch --sandbox=docker --sandbox-build=always claude
-aileron launch --sandbox=podman --sandbox-build=never codex
+aileron launch --sandbox=docker --sandbox-build=never codex
 ```
 
 `aileron sandbox build` remains the explicit manual build command and always invokes the selected runtime build for Tier 0/Tier 1.
 
-The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_API_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, discovery hints (`AILERON_TOOLS_FILE`, `AILERON_SHIMS_DIR`), and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). `AILERON_API_URL` points at the daemon's `/v1` API and is the stable endpoint for sandbox-side execution shims. For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker and `host.containers.internal` for Podman.
+The project directory is mounted at `/home/agent/workspace`, and the agent starts there. Launch passes session-scoped Aileron daemon env into the container, including `AILERON_URL`, `AILERON_API_URL`, `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`, discovery hints (`AILERON_TOOLS_FILE`, `AILERON_SHIMS_DIR`), and the sandbox image metadata (`AILERON_SANDBOX_IMAGE`, `AILERON_SANDBOX_TIER`, `AILERON_SANDBOX_RUNTIME`). `AILERON_API_URL` points at the daemon's `/v1` API and is the stable endpoint for sandbox-side execution shims. For local daemon URLs, launch rewrites the container-facing host to `host.docker.internal` for Docker. Podman's `host.containers.internal` alias is the deferred re-add path, not yet supported.
 
-The HTTPS proxy bootstrap is default-on for `--sandbox=docker` and `--sandbox=podman`. Sandbox launch generates a session-local CA, mounts the public CA at `/etc/aileron/proxy/ca.pem`, and sets standard proxy env (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`) plus Aileron metadata (`AILERON_SANDBOX_PROXY_MODE`, `AILERON_SANDBOX_PROXY_URL`, `AILERON_SANDBOX_PROXY_CA_FILE`). The proxy URL uses standard proxy userinfo so clients can send `Proxy-Authorization`; it carries the launch session id and, when present, the local daemon token. Images used with this mode must provide `aileron-install-proxy-ca` and `aileron-run-with-proxy-ca` (see the [BYO image proxy contract](/development/sandbox-agent-images/#byo-image-proxy-contract)); the current sandbox-base image includes both and launch validation checks both before the agent starts. The container starts through `aileron-run-with-proxy-ca`, installs the mounted CA as root, then drops back to the `agent` user before executing the requested agent command.
+The HTTPS proxy bootstrap is default-on for `--sandbox=docker`. Sandbox launch generates a session-local CA, mounts the public CA at `/etc/aileron/proxy/ca.pem`, and sets standard proxy env (`HTTPS_PROXY`, `HTTP_PROXY`, `NO_PROXY`) plus Aileron metadata (`AILERON_SANDBOX_PROXY_MODE`, `AILERON_SANDBOX_PROXY_URL`, `AILERON_SANDBOX_PROXY_CA_FILE`). The proxy URL uses standard proxy userinfo so clients can send `Proxy-Authorization`; it carries the launch session id and, when present, the local daemon token. Images used with this mode must provide `aileron-install-proxy-ca` and `aileron-run-with-proxy-ca` (see the [BYO image proxy contract](/development/sandbox-agent-images/#byo-image-proxy-contract)); the current sandbox-base image includes both and launch validation checks both before the agent starts. The container starts through `aileron-run-with-proxy-ca`, installs the mounted CA as root, then drops back to the `agent` user before executing the requested agent command.
 
-Use `--sandbox-proxy=auto|on|off` (default `auto`) or `AILERON_SANDBOX_PROXY=auto|on|off` to control bootstrap. The flag wins over the env var; the env var wins over the default. `auto` resolves to `on` for `docker`/`podman` and to `off` for every other `--sandbox` mode. `on` forces bootstrap; if the selected sandbox mode cannot support bootstrap (e.g. `--sandbox=off`), launch refuses with an actionable error before the container starts. `off` skips bootstrap for the session, and the daemon records a `sandbox.proxy.disabled` audit event with reason `user_opt_out`.
+Use `--sandbox-proxy=auto|on|off` (default `auto`) or `AILERON_SANDBOX_PROXY=auto|on|off` to control bootstrap. The flag wins over the env var; the env var wins over the default. `auto` resolves to `on` for `docker` and to `off` for every other `--sandbox` mode. `on` forces bootstrap; if the selected sandbox mode cannot support bootstrap (e.g. `--sandbox=off`), launch refuses with an actionable error before the container starts. `off` skips bootstrap for the session, and the daemon records a `sandbox.proxy.disabled` audit event with reason `user_opt_out`.
 
 When bootstrap is requested but the selected image lacks the BYO contract helpers, launch fails preflight before the container starts, prints an actionable error citing the contract docs and the `--sandbox-proxy=off` opt-out, and records a `sandbox.proxy.disabled` audit event with reason `preflight_failed`. Non-container sandbox modes record reason `unsupported_sandbox_mode`. Tip: pre-existing pipelines that set `AILERON_SANDBOX_PROXY_BOOTSTRAP` should switch to `AILERON_SANDBOX_PROXY`; the former is no longer honored.
 
@@ -197,7 +199,7 @@ Set `customizations.aileron.image` when your team owns the complete image:
 }
 ```
 
-In BYO-image mode, launch uses the image as supplied and layers on Aileron's session env, manifest mounts, generated discovery files, and connector shims. Images that participate in the v4 HTTPS proxy must include `aileron-install-proxy-ca` and `aileron-run-with-proxy-ca` helpers that meet the [BYO Image Proxy Contract](/development/sandbox-agent-images/#byo-image-proxy-contract). `aileron sandbox check --agent=...` validates both contracts for every Docker or Podman run.
+In BYO-image mode, launch uses the image as supplied and layers on Aileron's session env, manifest mounts, generated discovery files, and connector shims. Images that participate in the v4 HTTPS proxy must include `aileron-install-proxy-ca` and `aileron-run-with-proxy-ca` helpers that meet the [BYO Image Proxy Contract](/development/sandbox-agent-images/#byo-image-proxy-contract). `aileron sandbox check --agent=...` validates both contracts for every Docker run.
 
 ## What Belongs in the Image
 

--- a/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
+++ b/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
@@ -10,7 +10,7 @@ The integration test at `test/integration/sandbox_mcp_test.go` (build tag `integ
 
 ## What you need
 
-- Docker or Podman installed and running.
+- Docker installed and running.
 - A development build of the Aileron CLI and `aileron-mcp` siblings, both on `PATH`. `task build:cli && task build:mcp` produces them under `./build/`.
 - `jq` available on `PATH` (used by the audit-verification command below).
 - A Google OAuth client configured via `aileron binding setup gmail` (or any installed action you want to test).
@@ -114,7 +114,7 @@ Linux Docker does not configure `host.docker.internal` automatically. The launch
 docker run --rm --add-host=host.docker.internal:host-gateway alpine getent hosts host.docker.internal
 ```
 
-macOS and Windows Docker Desktop handle this automatically. Podman uses `host.containers.internal` natively (no flag needed).
+macOS and Windows Docker Desktop handle this automatically. Podman's native `host.containers.internal` alias is the deferred re-add path; Podman is planned but not yet supported in v4 ([ADR-0014](/adr/0014-spawn-sandbox-technology/)).
 
 ## Sources
 

--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -189,8 +189,8 @@ Migration note: operators who previously queried `sandbox.proxy.rejected` with r
 | `aileron.proxy.source` | Always `launcher`. The launcher is the only emitter for this event family. |
 | `aileron.proxy.boundary` | Always `https_proxy`. |
 | `aileron.proxy.decision` | Always `disabled`. |
-| `aileron.proxy.disabled_reason` | Why the proxy is not in force for this session: `user_opt_out` (operator passed `--sandbox-proxy=off` or `AILERON_SANDBOX_PROXY=off`), `preflight_failed` (image lacks `aileron-install-proxy-ca` / `aileron-run-with-proxy-ca`; launch was refused), or `unsupported_sandbox_mode` (sandbox runtime is `off` or not `docker`/`podman`). |
-| `aileron.sandbox.mode` | The value of `--sandbox` for the session (`docker`, `podman`, `off`, etc.). |
+| `aileron.proxy.disabled_reason` | Why the proxy is not in force for this session: `user_opt_out` (operator passed `--sandbox-proxy=off` or `AILERON_SANDBOX_PROXY=off`), `preflight_failed` (image lacks `aileron-install-proxy-ca` / `aileron-run-with-proxy-ca`; launch was refused), or `unsupported_sandbox_mode` (the resolved sandbox mode does not support proxy bootstrap, e.g. `off`). |
+| `aileron.sandbox.mode` | The value of `--sandbox` for the session (`docker`, `off`, etc.). |
 | `aileron.sandbox.image` | Resolved sandbox image reference when known (omitted when the proxy was disabled before image resolution). |
 | `aileron.session.id` | Launch session id. |
 


### PR DESCRIPTION
## Summary

Reconciles the eight sandbox-related docs pages with the shipped Docker-only container runtime (#1058 on `main`). Documents shipped behavior only; no code or CLI-behavior changes.

- Removes `podman` from `--sandbox`/`--runtime` supported-value enumerations and example invocations across the CLI reference, agent-images matrix, composition, mcp-walkthrough, adding-an-agent, binary-architecture, and sandbox-agent-auth pages.
- Switches host-alias and auto-detection prose to Docker-only (`host.docker.internal`; `auto` probes only Docker, matching `resolveRuntime` in `internal/sandbox/container/runtime.go`).
- Corrects `observability.md` so the `unsupported_sandbox_mode` disabled_reason and the `sandbox.mode` value list no longer imply podman is a live mode. Reworded to match `internal/launch/proxy_bootstrap.go` semantics (only `docker`/DefaultRuntime support bootstrap; podman fails fast in runtime resolution before any proxy audit).
- Preserves the podman re-add path as legible "planned, not yet supported" notes linked to [ADR-0014](/adr/0014-spawn-sandbox-technology/), including a committed footnote on the CLI page.
- Documents the single shipped not-supported message verbatim for both `--runtime=podman` and `--sandbox=podman`: `podman runtime is not supported yet (v4 is Docker-only); see ADR-0014`.

ADR pages (`docs/src/content/docs/adr/`) are intentionally out of scope; they are the authoritative re-add record amended via their own process.

## Test plan

- [x] `task lint:docs` — 0 errors, 0 warnings, 0 hints.
- [x] `task build:docs` — 123 pages built clean.
- [x] `rg -i podman docs/src/content/docs/ --glob '!adr/**'` returns only intentional "planned / not yet supported" deferred notes.
- [x] `rg -i 'host\.containers\.internal' docs/src/content/docs/ --glob '!adr/**'` returns only deferred-note framing.
- [x] Not-supported message string verified verbatim against `internal/sandbox/container/runtime.go:559`.
- [x] observability reword cross-checked against `internal/launch/proxy_bootstrap.go` reason resolution.

Closes #1053

🤖 Generated with [Claude Code](https://claude.com/claude-code)