### PR TITLE
test(sandbox): automate per-agent MCP validation matrix + CI + docs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -532,6 +532,21 @@ jobs:
         env:
           AILERON_SANDBOX_BASE_CONTEXT: ${{ github.workspace }}/images/sandbox-base
 
+      - name: Run sandbox MCP integration tests (#962 — Linux automated column)
+        # Exercises the aileron-mcp <-> daemon round-trip behind the sandbox
+        # MCP parity work (#953, ADR-0024) over BOTH transports: the host
+        # subprocess (Docker-free) and a real container (docker run against
+        # debian:bookworm-slim with the cross-built linux aileron-mcp bind-
+        # mounted read-only, reaching the in-process daemon via
+        # host.docker.internal). Asserts tools/list exposes draft_email and
+        # the contractual audit-event chain. The ubuntu runner has Docker, so
+        # the container variants run here; they self-skip only if Docker or
+        # the linux cross-build is unavailable. Per-agent MCP registration is
+        # covered separately by TestSandboxMCPRegistration_Matrix in the unit
+        # suite. Additive step so a failure is attributable to this contract.
+        run: go test -tags=integration_sandbox -race -run TestSandboxMCP ./app/...
+        working-directory: internal
+
       - name: Stop server to flush coverage data
         if: ${{ !cancelled() }}
         run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml stop server

--- a/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
+++ b/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
@@ -6,7 +6,7 @@ order: 9
 
 This walkthrough exercises the v4 sandbox MCP wiring (ADR-0024) with a real agent and a real action. Use it to confirm a development build of Aileron is wired correctly, or to repro a sandbox-MCP issue with a known-good harness.
 
-The integration test at `test/integration/sandbox_mcp_test.go` (build tag `integration_sandbox`) covers the same flow under automation. This walkthrough is the human-facing companion when you want to watch each step.
+The integration test at `internal/app/sandbox_mcp_test.go` (build tag `integration_sandbox`) covers the same flow under automation with a stub upstream. This walkthrough is the human-facing companion when you want to watch each step against a real connector.
 
 ## What you need
 
@@ -17,10 +17,29 @@ The integration test at `test/integration/sandbox_mcp_test.go` (build tag `integ
 - The `aileron-connector-google` connector installed (`aileron connector install github://ALRubinger/aileron-connector-google`).
 - The `draft-email` action installed (`aileron action install github://ALRubinger/aileron-connector-google/actions/draft-email`).
 
+## What to validate (agents and runtimes)
+
+v4 closes when the full round-trip is verified for every supported agent on every supported Docker runtime. The only thing that varies per agent is how `aileron-mcp` is registered (see ADR-0024). Everything after registration is identical across agents.
+
+| Agent | Identifier | MCP registration mechanism |
+|---|---|---|
+| Claude | `claude` | `--mcp-config` JSON |
+| Pi | `pi` | `--mcp-config` JSON |
+| Goose | `goose` | `--with-extension` |
+| OpenCode | `opencode` | `opencode.json` in the workspace |
+| Codex | `codex` | bind-mounted `config.toml` |
+
+Supported runtimes are Docker on macOS, Linux, and Windows. Docker Desktop on Windows runs Linux containers through the WSL2 backend, which is the same `sandbox-base` image used on macOS and Linux. The launcher adds `--add-host=host.docker.internal:host-gateway` on Linux only. macOS and Windows Docker Desktop resolve `host.docker.internal` automatically.
+
+Run the validation script below once per cell of the agent-by-runtime matrix. Record each result in issue [#962](https://github.com/ALRubinger/aileron/issues/962).
+
 ## Run
 
+Pick the agent to validate. Every other step is identical.
+
 ```bash
-aileron launch --sandbox=docker claude
+AGENT=claude   # one of: claude | pi | goose | opencode | codex
+aileron launch --sandbox=docker "$AGENT"
 ```
 
 The launcher will:
@@ -31,13 +50,13 @@ The launcher will:
 4. Validate the container can `command -v aileron-mcp` AND `aileron-mcp --version` exits 0 (catches arch mismatch).
 5. Start the container with `--add-host=host.docker.internal:host-gateway` on Linux Docker.
 
-Once Claude is running:
+Once the agent is running, confirm the `aileron` MCP server registered. Claude and Codex list servers with `/mcp`:
 
 ```text
 > /mcp
 ```
 
-You should see one MCP server named `aileron` with the Aileron action catalog. Look for `draft_email`.
+You should see one MCP server named `aileron` with the Aileron action catalog. Look for `draft_email`. Goose, OpenCode, and Pi surface their tool list differently. For those, ask the agent to list its available tools, or skip straight to the draft request below and confirm it invokes the Aileron tool. The session log (`.aileron/session.log` under the launch directory) records `aileron-mcp`'s discovery call against the daemon, which is the runtime-agnostic proof that registration succeeded.
 
 Then ask:
 
@@ -45,23 +64,49 @@ Then ask:
 > Draft an email to alice@example.com saying I'm running late
 ```
 
-Claude calls `mcp__aileron__draft_email`. The flow:
+The agent calls `mcp__aileron__draft_email`. The flow:
 
 1. `aileron-mcp` (inside the container) POSTs `/v1/actions/draft-email/run` to the daemon (on the host, via `host.docker.internal`) with `X-Aileron-Session-Id` set to the launch session.
 2. The daemon sees the action manifest declares `[approval]` and returns `202 Accepted` with a `review_url`.
-3. `aileron-mcp` surfaces the review URL back to Claude, which surfaces it to you.
+3. `aileron-mcp` surfaces the review URL back to the agent, which surfaces it to you.
 4. Open the review URL in your browser, or run `aileron approval approve <id>` in another terminal.
 5. The daemon executes the action: fetches the OAuth credential from the vault, calls Gmail's draft endpoint, returns the draft id.
-6. `aileron-mcp`'s `check_action_status` polling surfaces the result back to Claude.
+6. `aileron-mcp`'s `check_action_status` polling surfaces the result back to the agent.
 7. The audit log records the chain `approval.requested → approval.approved → execution.started → execution.succeeded`, all stamped with the launch session id.
 
 Verify the audit chain:
 
 ```bash
-aileron audit list --session $(aileron sessions list --json | jq -r '.[0].id')
+aileron audit list --session "$(aileron sessions list --json | jq -r '.[0].id')"
 ```
 
-Verify the draft landed in Gmail's draft folder — that's the upstream contract under test.
+Assert the four contractual events are present for the session in one shot:
+
+```bash
+SESSION=$(aileron sessions list --json | jq -r '.[0].id')
+aileron audit list --session "$SESSION" --json \
+  | jq -r '[.[].type] | sort | unique' \
+  | jq -e 'index("approval.requested") and index("approval.approved")
+           and index("execution.started") and index("execution.succeeded")' \
+  && echo "PASS: audit chain complete for $SESSION" \
+  || echo "FAIL: audit chain incomplete for $SESSION"
+```
+
+Verify the draft landed in Gmail's draft folder. That is the upstream contract under test.
+
+## Record the result
+
+A cell of the matrix passes when, for that agent on that runtime: the agent invoked `mcp__aileron__draft_email`, the approval surfaced and you approved it, the draft appeared in Gmail, and the audit assertion above printed `PASS`. Record each cell in issue [#962](https://github.com/ALRubinger/aileron/issues/962) (its body, not a comment) with the environment (OS, arch, Docker version, Aileron CLI commit, agent version), the outcome, any deviations, and rough time spent.
+
+| Agent ↓ / Runtime → | macOS Docker | Linux Docker | Windows Docker |
+|---|---|---|---|
+| Claude | ☐ | ☐ | ☐ |
+| Pi | ☐ | ☐ | ☐ |
+| Goose | ☐ | ☐ | ☐ |
+| OpenCode | ☐ | ☐ | ☐ |
+| Codex | ☐ | ☐ | ☐ |
+
+Codex is the highest-risk cell on any runtime because it is the only agent whose MCP registration uses a bind-mounted `config.toml` rather than a CLI flag or workspace file. Validate it deliberately and read the Codex troubleshooting note below.
 
 ## Verify coexistence with a user MCP server (R3)
 

--- a/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
+++ b/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
@@ -19,7 +19,7 @@ The integration test at `internal/app/sandbox_mcp_test.go` (build tag `integrati
 
 ## What to validate (agents and runtimes)
 
-v4 closes when the full round-trip is verified for every supported agent on every supported Docker runtime. The only thing that varies per agent is how `aileron-mcp` is registered (see ADR-0024). Everything after registration is identical across agents.
+The per-agent bar is **"the agent sees `aileron` and its `draft_email` tool"**. The only thing that varies per agent is how `aileron-mcp` is registered (see ADR-0024). Everything after registration is identical across agents.
 
 | Agent | Identifier | MCP registration mechanism |
 |---|---|---|
@@ -31,7 +31,16 @@ v4 closes when the full round-trip is verified for every supported agent on ever
 
 Supported runtimes are Docker on macOS, Linux, and Windows. Docker Desktop on Windows runs Linux containers through the WSL2 backend, which is the same `sandbox-base` image used on macOS and Linux. The launcher adds `--add-host=host.docker.internal:host-gateway` on Linux only. macOS and Windows Docker Desktop resolve `host.docker.internal` automatically.
 
-Run the validation script below once per cell of the agent-by-runtime matrix. Record each result in issue [#962](https://github.com/ALRubinger/aileron/issues/962).
+### Linux is automated
+
+The Linux column is covered in CI, so you do not run it by hand:
+
+- `TestSandboxMCPRegistration_Matrix` (`internal/launch/agents`) asserts, per agent, that the `ModeSandbox` registration references the `aileron-mcp` binary and carries every daemon env var. It runs in the standard unit suite.
+- `TestSandboxMCP` (`internal/app`, build tag `integration_sandbox`) runs the `aileron-mcp` to daemon round-trip over both a host subprocess and a real Docker container, asserts `tools/list` exposes `draft_email`, and checks the `approval.requested → approval.approved → execution.started → execution.succeeded` audit chain. It runs in the CI integration job on Linux.
+
+### macOS and Windows are a light manual smoke
+
+GitHub-hosted macOS and Windows runners cannot run Linux Docker containers, so those two columns are not automatable in CI. The container itself is the same Linux image on all three operating systems, and the host-side launcher code is unit-tested on macOS and Windows already, so the residual risk is only host Docker networking (`host.docker.internal` resolution). Cover it with a **light manual smoke** per agent rather than a full Gmail round-trip: launch the agent, confirm it lists `aileron` with `draft_email`, then exit. Record each in issue [#962](https://github.com/ALRubinger/aileron/issues/962). A full round-trip (through to a real Gmail draft and approval) on at least one agent per OS is the optional gold-standard check; the steps below walk through it.
 
 ## Run
 
@@ -96,15 +105,15 @@ Verify the draft landed in Gmail's draft folder. That is the upstream contract u
 
 ## Record the result
 
-A cell of the matrix passes when, for that agent on that runtime: the agent invoked `mcp__aileron__draft_email`, the approval surfaced and you approved it, the draft appeared in Gmail, and the audit assertion above printed `PASS`. Record each cell in issue [#962](https://github.com/ALRubinger/aileron/issues/962) (its body, not a comment) with the environment (OS, arch, Docker version, Aileron CLI commit, agent version), the outcome, any deviations, and rough time spent.
+The **Linux column is automated** (the tests above), so those cells are green when CI is green; you do not hand-run them. For **macOS and Windows**, the per-agent bar is the light smoke: the agent listed `aileron` with `draft_email`. Record those cells in issue [#962](https://github.com/ALRubinger/aileron/issues/962) (its body, not a comment) with the environment (OS, arch, Docker version, Aileron CLI commit, agent version) and any deviations. If you also run the optional full round-trip, note that the audit assertion above printed `PASS` and the draft landed in Gmail.
 
-| Agent ↓ / Runtime → | macOS Docker | Linux Docker | Windows Docker |
+| Agent ↓ / Runtime → | macOS Docker (manual smoke) | Linux Docker (CI) | Windows Docker (manual smoke) |
 |---|---|---|---|
-| Claude | ☐ | ☐ | ☐ |
-| Pi | ☐ | ☐ | ☐ |
-| Goose | ☐ | ☐ | ☐ |
-| OpenCode | ☐ | ☐ | ☐ |
-| Codex | ☐ | ☐ | ☐ |
+| Claude | ☐ | automated | ☐ |
+| Pi | ☐ | automated | ☐ |
+| Goose | ☐ | automated | ☐ |
+| OpenCode | ☐ | automated | ☐ |
+| Codex | ☐ | automated | ☐ |
 
 Codex is the highest-risk cell on any runtime because it is the only agent whose MCP registration uses a bind-mounted `config.toml` rather than a CLI flag or workspace file. Validate it deliberately and read the Codex troubleshooting note below.
 

--- a/internal/launch/agents/sandbox_mcp_matrix_test.go
+++ b/internal/launch/agents/sandbox_mcp_matrix_test.go
@@ -1,0 +1,113 @@
+package agents_test
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+)
+
+// TestSandboxMCPRegistration_Matrix is the automated companion to the
+// manual sandbox E2E (#962). For every supported agent it asserts the v4
+// sandbox-launch MCP registration contract (ADR-0024): under ModeSandbox,
+// ConfigureMCP must register the aileron-mcp binary and carry every
+// daemon-env var the MCP server needs, no matter which mechanism the agent
+// uses (--mcp-config JSON for Claude/Pi, --with-extension for Goose, an
+// opencode.json workspace file for OpenCode, or a bind-mounted config.toml
+// for Codex).
+//
+// Combined with the integration round-trip in
+// internal/app/sandbox_mcp_test.go (which proves aileron-mcp exposes
+// draft_email over tools/list and calls it end-to-end through a real
+// container), this is the per-agent "agent sees aileron + draft_email"
+// coverage for the Linux column of the #962 matrix.
+//
+// Pure Go: no Docker, no agent binaries. The registration logic is
+// host-OS-independent, so one CI run covers it; macOS and Windows
+// container launch are confirmed by a light manual smoke (see the
+// sandbox MCP walkthrough).
+func TestSandboxMCPRegistration_Matrix(t *testing.T) {
+	const mcpBin = "/usr/local/bin/aileron-mcp"
+	mcpEnv := map[string]string{
+		"AILERON_URL":          "http://host.docker.internal:7777",
+		"AILERON_COMMS_URL":    "http://host.docker.internal:7777",
+		"AILERON_SESSION_ID":   "sess-matrix-001",
+		"AILERON_APPROVAL_URL": "http://host.docker.internal:7777/approvals",
+	}
+
+	cases := []struct {
+		name  string
+		agent launch.Agent
+	}{
+		{"claude", agents.Claude{}},
+		{"pi", agents.Pi{}},
+		{"goose", agents.Goose{}},
+		{"opencode", agents.OpenCode{}},
+		{"codex", agents.Codex{}},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Isolate any home / XDG / workspace writes to temp dirs so the
+			// test never touches the developer's real agent config.
+			t.Setenv("HOME", t.TempDir())
+			t.Setenv("XDG_CONFIG_HOME", t.TempDir())
+			dir := t.TempDir()
+
+			args, mounts, err := tc.agent.ConfigureMCP(mcpBin, mcpEnv, dir, launch.ModeSandbox)
+			if err != nil {
+				t.Fatalf("ConfigureMCP(ModeSandbox): %v", err)
+			}
+
+			blob := registrationSurface(t, args, mounts, dir)
+
+			if !strings.Contains(blob, mcpBin) {
+				t.Errorf("%s sandbox registration does not reference the aileron-mcp binary %q\n--- registration surface ---\n%s", tc.name, mcpBin, blob)
+			}
+			for k, v := range mcpEnv {
+				if !strings.Contains(blob, v) {
+					t.Errorf("%s sandbox registration is missing daemon env %s (value %q)\n--- registration surface ---\n%s", tc.name, k, v, blob)
+				}
+			}
+		})
+	}
+}
+
+// registrationSurface flattens everything an agent's ConfigureMCP produces
+// into one string for contract assertions: the CLI args it returns, the
+// contents of any bind-mount source file (Codex), and any file it writes
+// into the workspace dir (OpenCode). The assertion is mechanism-agnostic
+// on purpose — the contract is "aileron-mcp is registered with the daemon
+// env", not "registered via this specific syntax".
+func registrationSurface(t *testing.T, args []string, mounts []launch.MCPMount, dir string) string {
+	t.Helper()
+	var b strings.Builder
+	b.WriteString(strings.Join(args, "\n"))
+	for _, m := range mounts {
+		data, err := os.ReadFile(m.Source)
+		if err != nil {
+			t.Fatalf("reading MCP mount source %s: %v", m.Source, err)
+		}
+		b.WriteByte('\n')
+		b.Write(data)
+	}
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		t.Fatalf("reading workspace dir %s: %v", dir, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		data, err := os.ReadFile(filepath.Join(dir, e.Name()))
+		if err != nil {
+			t.Fatalf("reading workspace file %s: %v", e.Name(), err)
+		}
+		b.WriteByte('\n')
+		b.Write(data)
+	}
+	return b.String()
+}


### PR DESCRIPTION
## Summary

Implements the v4 sandbox MCP validation as **automated CI on Linux + a light manual smoke on macOS/Windows**, replacing the originally-proposed 15 manual round-trips. Decision context: the per-agent difference is purely the MCP *registration* mechanism (ADR-0024); everything downstream is agent-agnostic and already covered by the integration round-trip.

- **New `TestSandboxMCPRegistration_Matrix`** (`internal/launch/agents`): table-driven over all five agents (claude/pi/goose/opencode/codex). Asserts each agent's `ModeSandbox` `ConfigureMCP` registers the `aileron-mcp` binary and carries every daemon env var, across every mechanism (`--mcp-config`, `--with-extension`, `opencode.json`, bind-mounted `config.toml`). Pure Go, no Docker, runs in the unit suite.
- **Wire `TestSandboxMCP` into CI** (`integration_sandbox`): the existing host+container round-trip (asserts `tools/list` exposes `draft_email` and the full audit chain) now runs in the Linux integration job. It was previously unwired (the file noted CI wiring as a follow-up).
- **Docs**: the walkthrough now states Linux is automated (names both tests), and macOS/Windows are a light per-agent "sees aileron + draft_email" smoke, since GitHub-hosted mac/Win runners can't run Linux Docker. Keeps the full round-trip as the optional gold-standard. Also adds the agent-parameterized run + `jq` audit assertion, and fixes a stale integration-test path.

## Why not 15 manual round-trips

GitHub-hosted macOS/Windows runners cannot run Linux Docker containers, and driving five real agent CLIs in CI (auth, headless tool enumeration) is brittle. The registration contract is the real per-agent risk; the round-trip is agent-independent. So Linux is fully automated and mac/Win get a quick host-networking smoke. See #962 for the updated matrix.

## Test plan

- [x] `go test ./internal/launch/agents/` — `TestSandboxMCPRegistration_Matrix` passes for all 5 agents.
- [x] `go test -tags=integration_sandbox -run TestSandboxMCP ./internal/app/...` — host + container transports pass locally (Docker up).
- [x] `task build:docs` — Astro build passes (123 pages).
- [x] `ci.yml` valid YAML; new step mirrors the existing `TestAuthSpecBindMountWritable` step.

🤖 Generated with [Claude Code](https://claude.com/claude-code)