### PR TITLE
docs(test): clarify sandbox matrix test is a contract test, not a live-agent launch

### DIFF
--- a/internal/launch/agents/sandbox_mcp_matrix_test.go
+++ b/internal/launch/agents/sandbox_mcp_matrix_test.go
@@ -19,11 +19,15 @@ import (
 // opencode.json workspace file for OpenCode, or a bind-mounted config.toml
 // for Codex).
 //
-// Combined with the integration round-trip in
-// internal/app/sandbox_mcp_test.go (which proves aileron-mcp exposes
-// draft_email over tools/list and calls it end-to-end through a real
-// container), this is the per-agent "agent sees aileron + draft_email"
-// coverage for the Linux column of the #962 matrix.
+// This is a launcher-side contract test, NOT a live-agent launch. It does
+// not run claude/codex/goose/pi/opencode; it checks the registration
+// artifact Aileron generates for each. The integration round-trip in
+// internal/app/sandbox_mcp_test.go separately proves aileron-mcp itself
+// exposes draft_email over tools/list and round-trips through a real
+// container (with the test acting as the MCP client, not a real agent).
+// Whether each real agent actually honors the registration we generate
+// (e.g. Codex reads the bind-mounted config.toml, Goose parses
+// --with-extension) is covered by the manual smoke in #962.
 //
 // Pure Go: no Docker, no agent binaries. The registration logic is
 // host-OS-independent, so one CI run covers it; macOS and Windows


### PR DESCRIPTION
## Summary

Comment-only clarification on `TestSandboxMCPRegistration_Matrix`. The previous doc comment described it as the per-agent "agent sees aileron + draft_email" coverage, which reads as if the real agent CLIs (claude/codex/goose/pi/opencode) are launched. They are not.

Reworded to state plainly:
- This is a **launcher-side contract test**, not a live-agent launch — it inspects the registration artifact Aileron generates per agent.
- The integration round-trip (`internal/app/sandbox_mcp_test.go`) drives `aileron-mcp` with the **test acting as the MCP client**, not a real agent.
- Whether each real agent **honors** the registration (e.g. Codex reading the bind-mounted `config.toml`) is covered by the manual smoke in #962.

No logic change. #962 wording updated to match.

## Test plan

- [x] `gofmt` clean; `TestSandboxMCPRegistration_Matrix` still passes (comment-only).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Clarified test documentation for internal contract testing processes.

**Note:** This update contains no user-facing changes. It addresses internal testing documentation only.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->