### PR TITLE
fix(launch): accept launch flags after the agent name

### DIFF
--- a/cmd/aileron/auth.go
+++ b/cmd/aileron/auth.go
@@ -67,7 +67,7 @@ func runAuthImport(agentName string, registry *launch.Registry, stdout, stderr i
 	if err != nil {
 		if errors.Is(err, hostimport.ErrNotAuthenticated) {
 			fmt.Fprintf(stderr, "error: no host credentials found for %s\n", agentName)
-			fmt.Fprintf(stderr, "log in first, then re-run; or use interactive in-container login: aileron launch %s --sandbox=docker\n", agentName)
+			fmt.Fprintf(stderr, "log in first, then re-run; or use interactive in-container login: aileron launch --sandbox=docker %s\n", agentName)
 			return 1
 		}
 		// Any other extraction error (including the Linux-keyring

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -105,6 +105,18 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 			return 1
 		}
 
+		// aileron's own launch flags may also appear after the agent name;
+		// consume them wherever they land so `aileron launch claude
+		// --sandbox=docker` behaves identically to `aileron launch
+		// --sandbox=docker claude`. Everything else forwards to the agent.
+		// A standalone `--` stops consumption and forwards the rest
+		// verbatim, so an aileron-named flag can still be passed through.
+		agentArgs, err := applyTrailingLaunchFlags(launchFlags, launchArgs[1:])
+		if err != nil {
+			fmt.Fprintf(stderr, "error: %v\n", err)
+			return 1
+		}
+
 		// Capture cwd so the daemon's session record carries working_dir
 		// (rendered by `aileron sessions list`). os.Getwd basically never
 		// errors in practice; on the rare case it does, fall through with
@@ -113,7 +125,7 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 
 		result, err := launchFn(context.Background(), launch.LaunchConfig{
 			Agent:              agent,
-			Args:               launchArgs[1:],
+			Args:               agentArgs,
 			Dir:                cwd,
 			LogLevel:           launch.ParseLogLevel(*logLevel),
 			SandboxRuntime:     *sandboxRuntime,
@@ -438,6 +450,74 @@ var spawnResolveFn = spawn.Resolve
 // launchFn is a package-level seam so tests can assert on the
 // LaunchConfig the CLI builds without depending on a running daemon.
 var launchFn = launch.Launch
+
+// launchFlagTakesValue reports whether an aileron launch flag consumes a
+// following value token. All current launch flags are string-valued; a
+// bool launch flag would return false here and be matched only in its
+// `--flag` / `--flag=value` forms.
+func launchFlagTakesValue(name string) bool {
+	switch name {
+	case "log-level", "sandbox", "sandbox-build", "sandbox-proxy":
+		return true
+	default:
+		return false
+	}
+}
+
+// parseLaunchFlagToken extracts a flag name and optional inline value
+// from a single- or double-dash token. It returns name == "" for any
+// non-flag token, including a bare "-" or "--".
+func parseLaunchFlagToken(arg string) (name, value string, hasValue bool) {
+	if len(arg) < 2 || arg[0] != '-' {
+		return "", "", false
+	}
+	trimmed := arg[1:]
+	if trimmed[0] == '-' {
+		trimmed = trimmed[1:]
+	}
+	if trimmed == "" { // "-" or "--"
+		return "", "", false
+	}
+	if eq := strings.IndexByte(trimmed, '='); eq >= 0 {
+		return trimmed[:eq], trimmed[eq+1:], true
+	}
+	return trimmed, "", false
+}
+
+// applyTrailingLaunchFlags consumes aileron launch flags that appear
+// after the agent name, applying each to fs, and returns the remaining
+// arguments to forward to the agent. This makes launch-flag position
+// irrelevant: `aileron launch claude --sandbox=docker` resolves the same
+// as `aileron launch --sandbox=docker claude`. A standalone "--"
+// terminates consumption — it is dropped and every following token
+// forwards verbatim, so a flag that shares an aileron launch-flag name
+// can still be passed through to the agent.
+func applyTrailingLaunchFlags(fs *flag.FlagSet, tail []string) ([]string, error) {
+	var agentArgs []string
+	for i := 0; i < len(tail); i++ {
+		arg := tail[i]
+		if arg == "--" {
+			agentArgs = append(agentArgs, tail[i+1:]...)
+			break
+		}
+		name, value, hasValue := parseLaunchFlagToken(arg)
+		if name != "" && launchFlagTakesValue(name) {
+			if !hasValue {
+				if i+1 >= len(tail) {
+					return nil, fmt.Errorf("flag --%s after the agent name needs a value", name)
+				}
+				value = tail[i+1]
+				i++
+			}
+			if err := fs.Set(name, value); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		agentArgs = append(agentArgs, arg)
+	}
+	return agentArgs, nil
+}
 
 // ensureVaultUnlockedFn is the seam for the run() vault state-machine
 // hook. Tests for the dispatched commands swap this to a no-op so they

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -204,6 +204,57 @@ func TestRun_LaunchPropagatesSandboxProxyFlag(t *testing.T) {
 	}
 }
 
+// TestRun_LaunchFlagsAfterAgentName locks the contract that aileron's
+// own launch flags are position-independent: they resolve the same
+// whether they appear before or after the agent name, they are NOT
+// forwarded to the agent, genuinely-unknown args still forward, and a
+// standalone "--" forwards an aileron-named flag through to the agent.
+// Regression for the cryptic `unknown option '--sandbox=docker'` the
+// agent CLI emitted when the flag landed after the agent name.
+func TestRun_LaunchFlagsAfterAgentName(t *testing.T) {
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+
+	cases := []struct {
+		name        string
+		args        []string
+		wantRuntime string
+		wantBuild   string
+		wantArgs    string // agent passthrough args, space-joined
+	}{
+		{"eq form after agent", []string{"launch", "claude", "--sandbox=docker"}, "docker", "auto", ""},
+		{"space form after agent", []string{"launch", "claude", "--sandbox", "docker"}, "docker", "auto", ""},
+		{"before agent still works", []string{"launch", "--sandbox=docker", "claude"}, "docker", "auto", ""},
+		{"split before and after", []string{"launch", "--sandbox=docker", "claude", "--sandbox-build=never"}, "docker", "never", ""},
+		{"unknown agent args forward", []string{"launch", "claude", "--model", "opus", "--sandbox=docker"}, "docker", "auto", "--model opus"},
+		{"double dash forwards through", []string{"launch", "claude", "--", "--sandbox=docker"}, "off", "auto", "--sandbox=docker"},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured launch.LaunchConfig
+			launchFn = func(_ context.Context, cfg launch.LaunchConfig) (launch.LaunchResult, error) {
+				captured = cfg
+				return launch.LaunchResult{ExitCode: 0}, nil
+			}
+			var stdout, stderr bytes.Buffer
+			code := run(tc.args, newTestRegistry(), &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit = %d (stderr=%q)", code, stderr.String())
+			}
+			if captured.SandboxRuntime != tc.wantRuntime {
+				t.Errorf("SandboxRuntime = %q, want %q", captured.SandboxRuntime, tc.wantRuntime)
+			}
+			if captured.SandboxBuildPolicy != tc.wantBuild {
+				t.Errorf("SandboxBuildPolicy = %q, want %q", captured.SandboxBuildPolicy, tc.wantBuild)
+			}
+			if got := strings.Join(captured.Args, " "); got != tc.wantArgs {
+				t.Errorf("agent Args = %q, want %q", got, tc.wantArgs)
+			}
+		})
+	}
+}
+
 func TestRun_LaunchLogLevelNoAgent(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"launch", "--log-level=debug"}, newTestRegistry(), &stdout, &stderr)

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -228,6 +228,7 @@ func TestRun_LaunchFlagsAfterAgentName(t *testing.T) {
 		{"split before and after", []string{"launch", "--sandbox=docker", "claude", "--sandbox-build=never"}, "docker", "never", ""},
 		{"unknown agent args forward", []string{"launch", "claude", "--model", "opus", "--sandbox=docker"}, "docker", "auto", "--model opus"},
 		{"double dash forwards through", []string{"launch", "claude", "--", "--sandbox=docker"}, "off", "auto", "--sandbox=docker"},
+		{"bare dash forwards to agent", []string{"launch", "claude", "-"}, "off", "auto", "-"},
 	}
 
 	for _, tc := range cases {
@@ -252,6 +253,50 @@ func TestRun_LaunchFlagsAfterAgentName(t *testing.T) {
 				t.Errorf("agent Args = %q, want %q", got, tc.wantArgs)
 			}
 		})
+	}
+}
+
+// TestRun_LaunchTrailingFlagMissingValue verifies that an aileron launch
+// flag placed after the agent name with no value fails fast with a clear
+// message instead of launching with a bogus value.
+func TestRun_LaunchTrailingFlagMissingValue(t *testing.T) {
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+	launchFn = func(_ context.Context, _ launch.LaunchConfig) (launch.LaunchResult, error) {
+		t.Fatal("launch should not run when a trailing flag is missing its value")
+		return launch.LaunchResult{}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"launch", "claude", "--sandbox"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "needs a value") {
+		t.Errorf("stderr = %q, want it to mention the missing value", stderr.String())
+	}
+}
+
+// TestParseLaunchFlagToken covers the dash/flag token classifier across
+// non-flags, bare dashes, and both inline-value and value-less flag forms.
+func TestParseLaunchFlagToken(t *testing.T) {
+	cases := []struct {
+		arg, name, value string
+		hasValue         bool
+	}{
+		{"claude", "", "", false},
+		{"-", "", "", false},
+		{"--", "", "", false},
+		{"--sandbox", "sandbox", "", false},
+		{"--sandbox=docker", "sandbox", "docker", true},
+		{"-sandbox=docker", "sandbox", "docker", true},
+		{"--log-level=debug", "log-level", "debug", true},
+	}
+	for _, tc := range cases {
+		name, value, hasValue := parseLaunchFlagToken(tc.arg)
+		if name != tc.name || value != tc.value || hasValue != tc.hasValue {
+			t.Errorf("parseLaunchFlagToken(%q) = (%q, %q, %v), want (%q, %q, %v)",
+				tc.arg, name, value, hasValue, tc.name, tc.value, tc.hasValue)
+		}
 	}
 }
 


### PR DESCRIPTION
## Summary
- `aileron launch` parsed flags with Go's `flag` package, which stops at the first positional arg (the agent name). Flags placed **after** the agent — e.g. `aileron launch claude --sandbox=docker` — were forwarded to the agent CLI, which rejected them with a cryptic `unknown option '--sandbox=docker'`. The auth hint in `cmd/aileron/auth.go` instructed exactly this broken order.
- Launch flags (`--sandbox`, `--sandbox-build`, `--sandbox-proxy`, `--log-level`) are now **position-independent**: consumed wherever they appear, in both `--flag=value` and `--flag value` forms, with everything else forwarded to the agent. A standalone `--` forwards an aileron-named flag through to the agent verbatim.
- Canonicalized the auth hint to flags-first.

## Test plan
- [x] `TestRun_LaunchFlagsAfterAgentName` (new): flag-after-agent resolves to the same `LaunchConfig` as flag-first; the agent does **not** receive the consumed flag; unknown args still forward; `--` forwards an aileron-named flag through.
- [x] Existing launch-flag tests still pass (`--sandbox`/`--sandbox-build`/`--sandbox-proxy` before the agent).
- [x] `go vet` + full `go test ./cmd/aileron/` green; `task build:cli` succeeds.
- Result: `aileron launch claude --sandbox=docker` and `aileron launch --sandbox=docker claude` now behave identically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `aileron launch` now accepts launch flags after the agent name, enabling more flexible command-line argument ordering.

* **Bug Fixes**
  * Improved error message guidance for host authentication failures with clearer interactive login instructions.

* **Tests**
  * Added regression tests for launch flag positioning to ensure proper handling and argument forwarding.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->