### PR TITLE
feat(sandbox): add first-class Codex install recipe to scaffold

### DIFF
--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -302,8 +302,8 @@ func TestRunSandboxInitAgentFlagSelectsRecipe(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read Dockerfile: %v", err)
 	}
-	if !strings.Contains(string(body), "TODO: install the codex CLI") {
-		t.Fatalf("Dockerfile missing codex TODO stub:\n%s", string(body))
+	if !strings.Contains(string(body), "npm install -g @openai/codex") {
+		t.Fatalf("Dockerfile missing codex recipe:\n%s", string(body))
 	}
 }
 

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -20,7 +20,7 @@ The check uses the same composition plan and minimal launch validation as `ailer
 | Agent | Command | Sandbox image support | MCP under `--sandbox=docker` | Notes |
 |---|---|---|---|---|
 | Claude Code | `claude` | Documented recipe | ✓ via `--mcp-config` | First-class recipe below. Use `sandbox check --agent=claude` before launch. |
-| Codex | `codex` | Command contract only | ✓ via bind-mounted `config.toml` | Sandbox launch writes a generated `config.toml` to a host tempdir and bind-mounts it into `/home/agent/.codex/config.toml` (ADR-0024). Host `~/.codex/config.toml` is never touched. |
+| Codex | `codex` | Documented recipe | ✓ via bind-mounted `config.toml` | Recipe below; scaffold with `sandbox init --agent=codex`. Sandbox launch writes a generated `config.toml` to a host tempdir and bind-mounts it into `/home/agent/.codex/config.toml` (ADR-0024). Host `~/.codex/config.toml` is never touched. |
 | Goose | `goose` | Command contract only | ✓ via `--with-extension` | Install the CLI in Tier 1 or BYO images; no maintained recipe yet. |
 | OpenCode | `opencode` | Command contract only | ✓ via workspace `opencode.json` | Launcher writes `opencode.json` into the launch directory; the workspace bind-mount makes it readable in-container. |
 | Pi | `pi` | Command contract only | ✓ via `--mcp-config` | Shares Claude's MCP wiring. |
@@ -54,6 +54,29 @@ aileron launch --sandbox=docker claude
 ```
 
 Claude Code still owns its own authentication flow. Do not bake Claude, Anthropic, cloud, or Aileron credentials into the image.
+
+## Codex Recipe
+
+`aileron sandbox init --agent=codex` scaffolds a ready-to-build `.devcontainer/Dockerfile` for Codex. The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine base:
+
+```bash
+aileron sandbox init --agent=codex
+```
+
+Build and validate:
+
+```bash
+aileron sandbox build --runtime=docker
+aileron sandbox check --runtime=docker --agent=codex
+```
+
+Then launch:
+
+```bash
+aileron launch --sandbox=docker codex
+```
+
+Codex owns its own authentication flow. Do not bake OpenAI, cloud, or Aileron credentials into the image.
 
 ## BYO Image Contract
 

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -229,7 +229,7 @@ func TestInitDefaultsToClaudeRecipeReadyToBuild(t *testing.T) {
 	}
 }
 
-func TestInitWithUnknownAgentEmitsTODOStub(t *testing.T) {
+func TestInitWithCodexRecipeReadyToBuild(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := Init(InitOptions{WorkDir: dir, Version: "0.4.0", Agent: "codex"}); err != nil {
 		t.Fatalf("Init: %v", err)
@@ -242,8 +242,8 @@ func TestInitWithUnknownAgentEmitsTODOStub(t *testing.T) {
 	for _, want := range []string{
 		"\nUSER root\n",
 		"\nUSER agent\n",
-		"TODO: install the codex CLI",
-		"sandbox-agent-images",
+		"--- Codex ---",
+		"npm install -g @openai/codex",
 	} {
 		if !strings.Contains(body, want) {
 			t.Fatalf("codex Dockerfile missing %q:\n%s", want, body)
@@ -251,6 +251,37 @@ func TestInitWithUnknownAgentEmitsTODOStub(t *testing.T) {
 	}
 	if strings.Contains(body, "@anthropic-ai/claude-code") {
 		t.Fatalf("codex Dockerfile should not include the Claude recipe:\n%s", body)
+	}
+	// The Codex install RUN must NOT be commented out.
+	for _, line := range strings.Split(body, "\n") {
+		if strings.Contains(line, "@openai/codex") && strings.HasPrefix(strings.TrimSpace(line), "#") {
+			t.Fatalf("Codex install RUN should be uncommented:\n%s", body)
+		}
+	}
+}
+
+func TestInitWithUnknownAgentEmitsTODOStub(t *testing.T) {
+	dir := t.TempDir()
+	if _, err := Init(InitOptions{WorkDir: dir, Version: "0.4.0", Agent: "frobnicate"}); err != nil {
+		t.Fatalf("Init: %v", err)
+	}
+	dockerfile, err := os.ReadFile(filepath.Join(dir, DefaultDockerfilePath))
+	if err != nil {
+		t.Fatalf("read Dockerfile: %v", err)
+	}
+	body := string(dockerfile)
+	for _, want := range []string{
+		"\nUSER root\n",
+		"\nUSER agent\n",
+		"TODO: install the frobnicate CLI",
+		"sandbox-agent-images",
+	} {
+		if !strings.Contains(body, want) {
+			t.Fatalf("frobnicate Dockerfile missing %q:\n%s", want, body)
+		}
+	}
+	if strings.Contains(body, "@anthropic-ai/claude-code") {
+		t.Fatalf("frobnicate Dockerfile should not include the Claude recipe:\n%s", body)
 	}
 }
 

--- a/internal/sandbox/composition/scaffold.go
+++ b/internal/sandbox/composition/scaffold.go
@@ -8,9 +8,9 @@ import (
 )
 
 // DefaultAgent is the agent the scaffold targets when --agent is omitted.
-// Claude Code is the only agent with a documented Tier 1 install recipe
-// today (see docs/development/sandbox-agent-images.md); other agents emit
-// a structurally correct Dockerfile with a TODO install stub.
+// Claude Code and Codex have documented Tier 1 install recipes today (see
+// docs/development/sandbox-agent-images.md); other agents emit a
+// structurally correct Dockerfile with a TODO install stub.
 const DefaultAgent = "claude"
 
 // InitOptions configures the sandbox scaffold operation.
@@ -121,6 +121,12 @@ func agentInstallSnippet(agent string) string {
 		return `# --- Claude Code ---
 RUN apk add --no-cache git nodejs npm ripgrep && \
     npm install -g @anthropic-ai/claude-code`
+	case "codex":
+		// The @openai/codex npm package ships prebuilt musl binaries, so it
+		// installs cleanly on the Alpine base.
+		return `# --- Codex ---
+RUN apk add --no-cache git nodejs npm ripgrep && \
+    npm install -g @openai/codex`
 	default:
 		return fmt.Sprintf(`# --- TODO: install the %s CLI ---
 # Aileron does not yet ship a verified install recipe for %s.


### PR DESCRIPTION
## Summary
- `aileron sandbox init --agent=codex` now scaffolds a ready-to-build `.devcontainer/Dockerfile` that installs `@openai/codex`, instead of emitting a TODO stub. Previously `aileron launch --sandbox=docker codex` failed image validation with `agent command not found in sandbox image: codex`.
- The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine `sandbox-base` and reuses the `nodejs`/`npm` already pulled in by the install line.
- Docs: Codex moves from "Command contract only" to "Documented recipe" in the support matrix, with a new Codex Recipe section mirroring the Claude one.

## Test plan
- [x] `go test ./internal/sandbox/...` — all green
- [x] `go vet ./internal/sandbox/... ./internal/launch/...`
- [x] New `TestInitWithCodexRecipeReadyToBuild` asserts the uncommented `npm install -g @openai/codex` recipe; existing TODO-stub test repointed to an unknown agent
- [x] Verified end-to-end on Docker: scaffolded the codex devcontainer, `sandbox build --runtime=docker`, then `sandbox check --runtime=docker --agent=codex` → `support: ok`

🤖 Generated with [Claude Code](https://claude.com/claude-code)