### PR TITLE
feat(release): publish Scoop manifest to dedicated bucket

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -69,6 +69,12 @@ jobs:
           # across repos. Configure as a repo secret before tagging
           # the first release.
           HOMEBREW_TAP_GITHUB_TOKEN: ${{ secrets.HOMEBREW_TAP_GITHUB_TOKEN }}
+          # PAT with contents:write on ALRubinger/scoop-aileron, used by
+          # goreleaser's scoops step to commit aileron.json. Same
+          # cross-repo constraint as the Homebrew tap: GITHUB_TOKEN
+          # scopes to this repo only and can't write across repos.
+          # Configure as a repo secret before tagging the first release.
+          SCOOP_BUCKET_GITHUB_TOKEN: ${{ secrets.SCOOP_BUCKET_GITHUB_TOKEN }}
 
       - name: Trigger docs site rebuild
         # The docs site's `$lib/data/release.ts` fetches the latest

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -121,6 +121,35 @@ homebrew_casks:
             system_command "/usr/bin/xattr", args: ["-dr", "com.apple.quarantine", staged_path]
           end
 
+scoops:
+  # Scoop manifest auto-published to the scoop-aileron bucket on each
+  # release, giving Windows users a one-line install. After release:
+  #   scoop bucket add aileron https://github.com/ALRubinger/scoop-aileron
+  #   scoop install aileron
+  #
+  # The bucket is a separate GitHub repo (scoop-aileron); goreleaser
+  # commits the manifest (aileron.json) there using
+  # SCOOP_BUCKET_GITHUB_TOKEN — a PAT with contents:write scope on the
+  # bucket repo, set as a secret in this repo. Default GITHUB_TOKEN
+  # can't write across repos.
+  #
+  # The manifest references the bundled "aileron" archive id (the
+  # windows zip), so all three binaries (aileron, aileron-server,
+  # aileron-mcp) land on PATH. amd64-only falls out of the build matrix:
+  # windows/arm64 is ignored, so the only windows archive is the amd64
+  # zip and the manifest's architecture map carries just the 64bit entry.
+  - name: aileron
+    ids:
+      - aileron # the bundled archive id above (all three binaries)
+    repository:
+      owner: ALRubinger
+      name: scoop-aileron
+      branch: main
+      token: "{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}"
+    homepage: https://withaileron.ai
+    description: Local LLM gateway for AI agents to take consequential action without holding credentials
+    license: Apache-2.0
+
 nfpms:
   # Linux distro packages: .deb (Debian/Ubuntu), .rpm (RHEL/Fedora),
   # .apk (Alpine). One bundled "aileron" package per format/arch


### PR DESCRIPTION
## Summary

Adds a `scoops:` block to `.goreleaser.yml` that publishes a Scoop manifest (`aileron.json`) to the dedicated `ALRubinger/scoop-aileron` bucket repo on each release, giving Windows users `scoop install aileron`. Mirrors the existing `homebrew_casks` precedent exactly:

- References the bundled `aileron` archive id, so all three binaries (`aileron`, `aileron-server`, `aileron-mcp`) land on PATH.
- Targets `ALRubinger/scoop-aileron` (`owner`/`name`/`branch: main`), authed via a new `SCOOP_BUCKET_GITHUB_TOKEN` PAT (`{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}`).
- Copies `homepage` / `description` / `license` verbatim from the cask block.
- Windows amd64 only — falls out of the existing build matrix (windows/arm64 stays ignored), so the manifest's `architecture` map carries just the `64bit` entry.

Wires the new PAT into the release workflow's "Run GoReleaser" step, alongside `HOMEBREW_TAP_GITHUB_TOKEN`.

No Go code, no ADR — a mechanical distribution-channel addition mirroring established precedent. Versions stay at 0.0.x. The `signs:`/cosign, `builds`, `archives`, `homebrew_casks`, `nfpms`, `checksum`, `changelog`, and `release` blocks are untouched.

## Operator prerequisite (before the next tagged release)

This PR is independently mergeable — snapshot mode does not push to the bucket. Before the next tagged release, the operator must:

1. Create the empty `ALRubinger/scoop-aileron` repo.
2. Set the `SCOOP_BUCKET_GITHUB_TOKEN` repo secret (a PAT with `contents:write` on `ALRubinger/scoop-aileron`). The default `GITHUB_TOKEN` cannot write across repos.

## Test plan

- [x] `goreleaser check` passes clean on the edited config (the `{{ .Env.SCOOP_BUCKET_GITHUB_TOKEN }}` template resolves only at release time, not at check time).
- [x] `goreleaser release --snapshot --clean --skip=sign` generates `dist/scoop/aileron.json` (used `--skip=sign` because cosign is unavailable off-CI; the `signs:` config is unchanged and release-time signing stays intact).
- [x] Generated `aileron.json` `bin` array lists all three binaries: `aileron.exe`, `aileron-server.exe`, `aileron-mcp.exe`.
- [x] `architecture.64bit.url` points at `aileron_{version}_windows_amd64.zip`; no 32bit/arm64 entry present.
- [x] `release.yml` passes `SCOOP_BUCKET_GITHUB_TOKEN` to the GoReleaser step; workflow remains valid YAML.

Closes #1095