### PR TITLE
docs(adr): record agent-as-Feature sandbox model in ADR-0017

### DIFF
--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -14,6 +14,8 @@ order: 17
 
 > **Revision note, 2026-06-15:** This ADR originally described a launch-scoped static `tools.txt` manifest and `/usr/local/bin` connector shims as the in-container tool surface. [#959](https://github.com/ALRubinger/aileron/issues/959) retired that surface; `aileron-mcp` ([ADR-0024](/adr/0024-sandbox-mcp-parity)) is now the sole in-container tool surface. The composition tiers and the read-only manifest mounts are unchanged. The base image keeps `wget` for general tooling, but it is no longer a launch-validated shim requirement. Passages below have been updated to reflect the retired surface.
 
+> **Revision note, 2026-06-16:** Umbrella [#1080](https://github.com/ALRubinger/aileron/issues/1080) moves each agent install from a per-agent baked Dockerfile layer to a devcontainer Feature. The base image stays harness-free and gains no agent CLIs. Aileron CI bakes prebuilt per-agent images from the same Feature, and those images become the Tier 0 default (their publishing and launch-time auto-resolution are owned by [#965](https://github.com/ALRubinger/aileron/issues/965), forward-referenced here). Customers compose the same agent Feature alongside their own tooling Feature for the customization tier. The build engine, the diamond-inheritance resolution, and the CLI surface prose below are updated to reflect the Feature model. The CLI changes that this model implies land in sibling issues ([#1082](https://github.com/ALRubinger/aileron/issues/1082), [#1083](https://github.com/ALRubinger/aileron/issues/1083), [#1084](https://github.com/ALRubinger/aileron/issues/1084)); this ADR records the model and the build-engine decision.
+
 ## Context
 
 Aileron is moving from a host-launched MCP-first runtime toward the Aileron Way: the agent runs inside a container Aileron defines, with credentialed HTTPS traffic flowing through the Aileron data plane and shell/runtime boundaries mediated inside the container.
@@ -30,8 +32,8 @@ Aileron supports three tiers:
 
 | Tier | Contract |
 |---|---|
-| Tier 0: base image | No `.devcontainer/devcontainer.json`; Aileron uses `aileron/sandbox-base:<version>` directly. |
-| Tier 1: devcontainer | `.devcontainer/devcontainer.json` exists; Aileron composes the sandbox using its build/image settings. The starter path is `.devcontainer/Dockerfile` extending `aileron/sandbox-base:<version>`. |
+| Tier 0: prebuilt per-agent image | No `.devcontainer/devcontainer.json`; launch auto-resolves the prebuilt per-agent image `ghcr.io/alrubinger/aileron-sandbox-<agent>` baked from the agent Feature. Publishing and launch-time auto-resolution are owned by [#965](https://github.com/ALRubinger/aileron/issues/965). The bare `aileron/sandbox-base:<version>` stays the harness-free root that each agent Feature layers onto. |
+| Tier 1: devcontainer | `.devcontainer/devcontainer.json` exists; Aileron composes the sandbox from the Features it lists. The starter path lists `aileron/sandbox-base:<version>` as the base plus an agent Feature plus an optional customer-tooling Feature under `features`. |
 | Tier 2: BYO image | `customizations.aileron.image` names a fully custom image. Aileron uses it as supplied and injects the runtime contract at launch. |
 
 The Aileron extension block starts narrow:
@@ -50,7 +52,31 @@ The Aileron extension block starts narrow:
 
 `image` selects the BYO-image tier. `mediation` and `approval_surface` are declared here so the config surface exists before the approval UI adds the runtime behavior. (The `mediation` slot was originally also intended to anchor container-only shell mediation; that surface was prototyped under [#801](https://github.com/ALRubinger/aileron/issues/801) and withdrawn in [#952](https://github.com/ALRubinger/aileron/issues/952). See [ADR-0021](/adr/0021-v4-shell-layer-mediation) (Withdrawn).)
 
-The Aileron-owned base image contains only the runtime substrate: shell utilities and the proxy/session bootstrap helpers. CA installation hooks layer onto this base as those features land. The base image does not carry language runtimes or third-party development tools.
+The Aileron-owned base image contains only the runtime substrate: shell utilities and the proxy/session bootstrap helpers. CA installation hooks layer onto this base as those features land. The base image stays harness-free and does not carry language runtimes, third-party development tools, or agent CLIs.
+
+## Composition model: Features
+
+Each agent install is authored once as a devcontainer Feature. A Feature is a self-contained install unit that runs on top of any base, so the agent CLI is no longer a baked layer inside a per-agent image. A customer's own tooling is its own Feature and stays agent-agnostic. A Tier 1 sandbox is composed by listing the base image and these Features in `devcontainer.json`:
+
+```jsonc
+{
+  "image": "aileron/sandbox-base:<version>",
+  "features": {
+    "ghcr.io/alrubinger/aileron-features/<agent>:1": {},
+    "ghcr.io/acme/internal-tools:1": {}
+  }
+}
+```
+
+The agent Feature is the single source of truth. Aileron CI bakes the prebuilt per-agent images ([#965](https://github.com/ALRubinger/aileron/issues/965)) from the same Feature that customers compose directly. There is one install recipe per agent, consumed two ways.
+
+### Diamond-inheritance resolution
+
+Docker `FROM` is single-parent. A per-agent baked layer cannot also carry arbitrary customer tooling unless the customer rebuilds the whole agent layer on their own base, because "base + customer tools" and "base + agent" are two lineages that never merge into "base + customer tools + agent". Features compose independently onto one base, so "base + customer tools + agent" is expressible without merging two image lineages. This is the diamond-inheritance resolution that authoring the agent as a Feature provides. The spawn-sandbox technology decision in [ADR-0014](/adr/0014-spawn-sandbox-technology) and the harness-free base in [ADR-0024](/adr/0024-sandbox-mcp-parity) are the substrate the Feature model builds on.
+
+### Build engine
+
+Composing standard `features` requires either the official `@devcontainers/cli` or a reimplementation of Feature resolution and ordering. `composition.Discover` currently parses `image`, `build`, `mounts`, and `customizations.aileron`, but not `features`. The final call is to drive sandbox builds through `@devcontainers/cli` so standard `features` compose without Aileron reimplementing the resolver. The alternative considered is a raw `docker build` that runs each Feature's install script in order; it is recorded as the fallback if the CLI dependency proves unworkable. The resolver wiring lands in [#1083](https://github.com/ALRubinger/aileron/issues/1083).
 
 ## Single-binary alignment
 
@@ -63,16 +89,11 @@ This ADR follows the updated sandbox runtime direction:
 
 ## CLI surface
 
-`aileron sandbox init` scaffolds:
-
-- `.devcontainer/devcontainer.json`
-- `.devcontainer/Dockerfile`
-
-The Dockerfile extends `aileron/sandbox-base:<version>`, pre-fills the install recipe for the agent named in `--agent` (default `claude`), and ships additional tool snippets (GitHub CLI, Node.js, Python, kubectl, Terraform) commented out for users to enable as needed. The snippets are guidance, not a runtime resolver. Users own their container contents using normal Docker/devcontainer workflows.
+`aileron sandbox init` scaffolds a Feature-composing `.devcontainer/devcontainer.json` for the customization tier. The scaffold lists `aileron/sandbox-base:<version>` as the base image and an agent Feature plus an optional customer-tooling Feature under `features`, so users compose their own tooling alongside the agent through standard devcontainer workflows. Under the Feature model `init` no longer scaffolds a per-agent `.devcontainer/Dockerfile`, and the `--agent` flag is removed because the agent is selected by the listed Feature rather than a baked recipe. The `init` reposition and the `--agent` removal land in [#1084](https://github.com/ALRubinger/aileron/issues/1084).
 
 `aileron sandbox plan` is an inspection helper that reports the normalized tier/image/dockerfile plan.
 
-`aileron sandbox build` is the first user-facing build consumer of that plan. It builds Tier 0 from Aileron's local sandbox-base image definition and Tier 1 from the devcontainer Dockerfile through Docker. Tier 2 BYO images are selected as-is; launch validates the minimal runtime contract before running the agent.
+`aileron sandbox build` is the first user-facing build consumer of that plan. It resolves the Tier 0 prebuilt per-agent image and composes the Tier 1 devcontainer Features through the build engine recorded above. Tier 2 BYO images are selected as-is; launch validates the minimal runtime contract before running the agent. The `features`-composing build path lands in [#1083](https://github.com/ALRubinger/aileron/issues/1083).
 
 `aileron sandbox check --agent=<command>` prepares the selected image with the same build policy as launch and validates that the image can run the requested agent command before starting a daemon-backed session. This is the user-facing preflight for the sandbox agent image support matrix tracked in [#894](https://github.com/ALRubinger/aileron/issues/894).
 
@@ -110,6 +131,10 @@ The first implementations establish the contract, image-build substrate, contain
 - [Issue #895](https://github.com/ALRubinger/aileron/issues/895) — connector specs and generated HTTPS shims
 - [Issue #896](https://github.com/ALRubinger/aileron/issues/896) — HTTPS proxy/data-plane mediation
 - [Issue #897](https://github.com/ALRubinger/aileron/issues/897) — dynamic discovery refresh
+- [Issue #1080](https://github.com/ALRubinger/aileron/issues/1080) — agent-as-Feature sandbox model umbrella
+- [Issue #965](https://github.com/ALRubinger/aileron/issues/965) — prebuilt per-agent image publishing and auto-resolution
+- [ADR-0014](/adr/0014-spawn-sandbox-technology) — spawn sandbox technology
+- [ADR-0024](/adr/0024-sandbox-mcp-parity) — harness-free base and in-container MCP parity
 - [ADR-0015](/adr/0015-launch-audit-scope) — old host launch audit boundary
 - [ADR-0018](/adr/0018-v4-single-binary-runtime) — single-binary runtime model
 - [ADR-0019](/adr/0019-v4-https-data-plane) — HTTPS data-plane mediation

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -19,9 +19,9 @@ The check uses the same composition plan and minimal launch validation as `ailer
 
 | Agent | Command | Sandbox image support | MCP under `--sandbox=docker` | Notes |
 |---|---|---|---|---|
-| Claude Code | `claude` | Documented recipe | ✓ via `--mcp-config` | First-class recipe below. Use `sandbox check --agent=claude` before launch. |
-| Codex | `codex` | Documented recipe | ✓ via bind-mounted `config.toml` | Recipe below; scaffold with `sandbox init --agent=codex`. Sandbox launch writes a generated `config.toml` to a host tempdir and bind-mounts it into `/home/agent/.codex/config.toml` (ADR-0024). Host `~/.codex/config.toml` is never touched. |
-| Goose | `goose` | Command contract only | ✓ via `--with-extension` | Install the CLI in Tier 1 or BYO images; no maintained recipe yet. |
+| Claude Code | `claude` | Agent Feature | ✓ via `--mcp-config` | First-class Feature below. Use `sandbox check --agent=claude` before launch. |
+| Codex | `codex` | Agent Feature | ✓ via bind-mounted `config.toml` | Feature below. Sandbox launch writes a generated `config.toml` to a host tempdir and bind-mounts it into `/home/agent/.codex/config.toml` ([ADR-0024](/adr/0024-sandbox-mcp-parity/)). Host `~/.codex/config.toml` is never touched. |
+| Goose | `goose` | Command contract only | ✓ via `--with-extension` | List the agent Feature in Tier 1, or install the CLI in a BYO image; no maintained Feature yet. |
 | OpenCode | `opencode` | Command contract only | ✓ via workspace `opencode.json` | Launcher writes `opencode.json` into the launch directory; the workspace bind-mount makes it readable in-container. |
 | Pi | `pi` | Command contract only | ✓ via `--mcp-config` | Shares Claude's MCP wiring. |
 | Other agents | varies | Unsupported | n/a | Add an Aileron launch agent and an image recipe before relying on sandbox launch. |
@@ -30,49 +30,43 @@ Under `--sandbox=docker` the launcher resolves the host-built `aileron-mcp` bina
 
 Docker is the only supported sandbox runtime in v4. Podman is planned but not yet supported; its `host.containers.internal` host alias is the deferred re-add path, and passing `--runtime=podman` fails with `podman runtime is not supported yet (v4 is Docker-only); see ADR-0014` (see [ADR-0014](/adr/0014-spawn-sandbox-technology/)).
 
-Tier 0 `aileron/sandbox-base` intentionally does not include agent CLIs. Use Tier 1 when you want Aileron's base runtime plus an installed agent, or Tier 2 when your team owns the full image.
+The harness-free `aileron/sandbox-base` intentionally does not include agent CLIs ([ADR-0017](/adr/0017-sandbox-composition/)). Each agent install is authored once as a devcontainer Feature, the single source of truth that Aileron CI bakes into prebuilt per-agent images and that customers compose for Tier 1. The prebuilt per-agent image is the zero-build Tier 0 default, owned by [#965](https://github.com/ALRubinger/aileron/issues/965). Use Tier 1 when you want Aileron's base runtime plus an agent plus your own tools, or Tier 2 when your team owns the full image.
 
-## Claude Code Recipe
+## Claude Code Feature
 
-`aileron sandbox init` scaffolds for Claude Code by default — the generated `.devcontainer/Dockerfile` already extends `aileron/sandbox-base`, switches to `USER root`, runs the Claude install, and switches back to `USER agent`. No edits required:
+The Claude Code agent Feature installs the `claude` CLI onto `aileron/sandbox-base`. It is the single source of truth that Aileron CI bakes into the prebuilt Claude image and that you compose for Tier 1. The Feature authoring lands in [#1082](https://github.com/ALRubinger/aileron/issues/1082).
 
-```bash
-aileron sandbox init
-```
-
-Build and validate:
-
-```bash
-aileron sandbox build --runtime=docker
-aileron sandbox check --runtime=docker --agent=claude
-```
-
-Then launch:
+For the Tier 0 zero-build path, launch the prebuilt image directly:
 
 ```bash
 aileron launch --sandbox=docker claude
 ```
 
-Claude Code still owns its own authentication flow. Do not bake Claude, Anthropic, cloud, or Aileron credentials into the image.
-
-## Codex Recipe
-
-`aileron sandbox init --agent=codex` scaffolds a ready-to-build `.devcontainer/Dockerfile` for Codex. The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine base:
+For the Tier 1 customization path, list the Claude Feature in your `devcontainer.json` (see [Scaffold a Starter Devcontainer](/development/sandbox-composition/#scaffold-a-starter-devcontainer)), then validate and launch:
 
 ```bash
-aileron sandbox init --agent=codex
+aileron sandbox build --runtime=docker
+aileron sandbox check --runtime=docker --agent=claude
+aileron launch --sandbox=docker claude
 ```
 
-Build and validate:
+Claude Code still owns its own authentication flow. Do not bake Claude, Anthropic, cloud, or Aileron credentials into the image.
+
+## Codex Feature
+
+The Codex agent Feature installs the `codex` CLI onto `aileron/sandbox-base`. The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine base. Like the Claude Feature, it is baked into the prebuilt Codex image and composable for Tier 1, and its authoring lands in [#1082](https://github.com/ALRubinger/aileron/issues/1082).
+
+For the Tier 0 zero-build path:
+
+```bash
+aileron launch --sandbox=docker codex
+```
+
+For the Tier 1 customization path, list the Codex Feature in your `devcontainer.json`, then validate and launch:
 
 ```bash
 aileron sandbox build --runtime=docker
 aileron sandbox check --runtime=docker --agent=codex
-```
-
-Then launch:
-
-```bash
 aileron launch --sandbox=docker codex
 ```
 

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -12,33 +12,21 @@ This page covers the user-facing workflow. Runtime launch support can scaffold, 
 
 | Tier | Use when | How to configure |
 |---|---|---|
-| Tier 0: base image | You want the minimal Aileron runtime substrate with no extra project tools. | Do not create `.devcontainer/devcontainer.json`. |
-| Tier 1: devcontainer | You want to extend Aileron's base image with project tools. | Create `.devcontainer/devcontainer.json` and a Dockerfile. |
+| Tier 0: prebuilt per-agent image | You want a working agent sandbox with no init and no local build. | Do not create `.devcontainer/devcontainer.json`; launch auto-resolves the prebuilt per-agent image baked from the agent Feature. Publishing and auto-resolution are owned by [#965](https://github.com/ALRubinger/aileron/issues/965). |
+| Tier 1: devcontainer | You want Aileron's base image plus an agent plus your own project tools. | Create `.devcontainer/devcontainer.json` listing the base image, an agent Feature, and an optional customer-tooling Feature under `features`. |
 | Tier 2: BYO image | Your team already owns a compliant image. | Set `customizations.aileron.image` in `.devcontainer/devcontainer.json`. |
 
 ## Scaffold a Starter Devcontainer
 
-From a project root:
+Tier 1 is the customization tier. You reach for it when you want Aileron's base image plus an agent plus your own project tools in one sandbox. The recorded model ([ADR-0017](/adr/0017-sandbox-composition/)) is that `aileron sandbox init` scaffolds a Feature-composing `.devcontainer/devcontainer.json` rather than a per-agent Dockerfile:
 
-```bash
-aileron sandbox init
-```
-
-This creates:
-
-```text
-.devcontainer/
-  devcontainer.json
-  Dockerfile
-```
-
-The generated `devcontainer.json` is deliberately small:
-
-```json
+```jsonc
 {
   "name": "Aileron sandbox",
-  "build": {
-    "dockerfile": "Dockerfile"
+  "image": "aileron/sandbox-base:<version>",
+  "features": {
+    "ghcr.io/alrubinger/aileron-features/<agent>:1": {},
+    "ghcr.io/acme/internal-tools:1": {}
   },
   "customizations": {
     "aileron": {
@@ -49,19 +37,9 @@ The generated `devcontainer.json` is deliberately small:
 }
 ```
 
-The generated Dockerfile starts from `aileron/sandbox-base:<version>`, switches to `USER root` for installs, and switches back to `USER agent` before launch. The chosen agent's install recipe is pre-filled and ready to build; additional tool snippets (GitHub CLI, Node.js, Python, kubectl, Terraform) ship commented out for you to enable as needed.
+The agent is selected by the agent Feature you list, and your own tooling is its own Feature alongside it. The same agent Feature is the single source of truth that Aileron CI bakes into the prebuilt per-agent images ([#965](https://github.com/ALRubinger/aileron/issues/965)), so the customization tier and the zero-build default share one install recipe per agent.
 
-By default `aileron sandbox init` scaffolds for Claude Code. Pass `--agent=<name>` to scaffold for a different agent — Aileron writes a ready-to-build recipe when one is documented, or a `TODO` install stub otherwise:
-
-```bash
-aileron sandbox init --agent=codex
-```
-
-Use `--force` only when you intentionally want to replace the existing scaffold:
-
-```bash
-aileron sandbox init --force
-```
+The `sandbox init` reposition to scaffold this Feature-composing devcontainer, and the removal of the per-agent Dockerfile and the `--agent` flag, are implemented in [#1084](https://github.com/ALRubinger/aileron/issues/1084). The `features`-composing build path is implemented in [#1083](https://github.com/ALRubinger/aileron/issues/1083).
 
 ## Inspect the Plan
 
@@ -78,13 +56,12 @@ tier: base
 image: aileron/sandbox-base:latest
 ```
 
-With the starter scaffold, the output is Tier 1 and includes the Dockerfile:
+With the starter scaffold, the output is Tier 1 and names the composed devcontainer:
 
 ```text
 tier: devcontainer
 image: aileron/sandbox-base:latest
 devcontainer: .devcontainer/devcontainer.json
-dockerfile: Dockerfile
 ```
 
 ## Build the Image
@@ -108,8 +85,8 @@ Build behavior by tier:
 
 | Tier | Build behavior |
 |---|---|
-| Tier 0 | Builds the local `images/sandbox-base/Containerfile` as `aileron/sandbox-base:<version>`. |
-| Tier 1 | Builds the devcontainer Dockerfile and tags it as a deterministic local `aileron/sandbox-project:<hash>` image unless `--tag` is supplied. |
+| Tier 0 | Resolves the prebuilt per-agent image baked from the agent Feature. Publishing and auto-resolution are owned by [#965](https://github.com/ALRubinger/aileron/issues/965). |
+| Tier 1 | Composes the devcontainer Features onto the base image and tags the result as a deterministic local `aileron/sandbox-project:<hash>` image unless `--tag` is supplied. The recorded build engine is `@devcontainers/cli` so standard `features` compose ([ADR-0017](/adr/0017-sandbox-composition/)); the `features`-composing build path lands in [#1083](https://github.com/ALRubinger/aileron/issues/1083). |
 | Tier 2 | Does not build. The BYO image is reported as-is; launch validates it before agent startup. |
 
 When building the base image outside the source tree, set `AILERON_SANDBOX_BASE_CONTEXT` to the directory containing the sandbox-base `Containerfile`.
@@ -177,7 +154,7 @@ Before running the agent, launch validates the selected image with the same env,
 - allow a temporary file to be written in the mounted workspace
 - resolve the agent command on `PATH`
 
-The agent command must already exist in the selected image. For Tier 1, install the agent CLI in your devcontainer Dockerfile. Tier 2 uses the BYO image as supplied while Aileron's runtime injection remains limited to session env, manifest mounts, and the `aileron-mcp` tool surface. See the [sandbox agent image matrix](/development/sandbox-agent-images/) for the current support contract and recipes.
+The agent command must already exist in the selected image. For Tier 1, list the agent Feature in your `devcontainer.json` so the agent CLI installs onto the base. Tier 2 uses the BYO image as supplied while Aileron's runtime injection remains limited to session env, manifest mounts, and the `aileron-mcp` tool surface. See the [sandbox agent image matrix](/development/sandbox-agent-images/) for the current support contract and recipes.
 
 ## Use a BYO Image
 


### PR DESCRIPTION
## Summary

Amends `ADR-0017: Sandbox Composition` in place (pre-MVP convention, no supersede) to record the agent-as-Feature sandbox model decided in umbrella #1080, and reconciles the two companion dev docs with it.

- **Agent install = devcontainer Feature.** Each agent install is authored once as a devcontainer Feature; the base stays harness-free and gains no agent CLIs. The same Feature is CI-baked into prebuilt per-agent images and composed directly by customers (single source of truth).
- **Three tiers restated in Feature terms.** Tier 0 becomes the prebuilt per-agent image (`ghcr.io/alrubinger/aileron-sandbox-<agent>`) auto-resolved with no `.devcontainer`, with publishing/auto-resolution forward-referenced to #965 (not claimed as shipped). Tier 1 composes the base image plus an agent Feature plus an optional customer-tooling Feature under `features`. Tier 2 unchanged.
- **Build engine decision recorded.** Final call is `@devcontainers/cli` so standard `features` compose; the raw-`docker build` + per-Feature install-script fallback is recorded as the alternative considered. Notes that `composition.Discover` does not yet parse `features`.
- **Diamond/single-parent resolution recorded.** Docker `FROM` is single-parent, so a per-agent baked layer cannot also carry arbitrary customer tooling; Features compose independently onto one base, making "base + customer tools + agent" expressible.
- **Cross-references.** ADR-0014 and ADR-0024 linked in prose and References; umbrella #1080 and image-publishing #965 added to References. CLI-behavior prose that lands in siblings (#1082/#1083/#1084) is framed as the recorded model and linked rather than claimed as live.
- **Companion docs.** `development/sandbox-composition.md` and `development/sandbox-agent-images.md` updated so their tier tables and recipes match the Feature model and drop the per-agent-Dockerfile / `init --agent` default framing.

No CLI/code changes, no image publishing, no new ADR. Those are owned by #1082/#1083/#1084/#965.

## Test plan

- [x] `task build:docs` succeeds (123 pages built, no broken internal links)
- [x] `task lint:docs` (astro check): 0 errors, 0 warnings, 0 hints
- [x] `task test:docs`: all docs unit tests pass
- [x] No em-dashes in added prose; References-list bullets follow the existing house `— description` style
- [x] No "not just X, Y" construction; one thought per sentence
- [x] Every `ADR-NNNN` cross-reference is a Markdown hyperlink to `/adr/...`
- [x] Tier tables across the ADR and both dev docs are mutually consistent (three tiers, same Tier 0 default)
- [x] Forward references to #965 framed as owned-by-#965, not shipped

Closes #1081