### PR TITLE
feat(sandbox): author Claude and Codex install recipes as devcontainer Features

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -583,6 +583,44 @@ jobs:
         if: always()
         run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml down -v
 
+  integration-sandbox-features:
+    name: Integration Tests (Sandbox Features)
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: |
+            internal/go.mod
+            test/integration/go.mod
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      # The repo source never calls npm directly; installing the
+      # @devcontainers/cli here in the CI shell is the toolchain the
+      # fail-fast Feature build test (#1082) drives via exec. The test FAILS
+      # (no self-skip) if the CLI, Node, Docker, or the base image is absent.
+      - name: Install @devcontainers/cli
+        run: npm install -g @devcontainers/cli
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Builds the aileron/sandbox-base image from images/sandbox-base (the
+      # test's Builder uses the AILERON_SANDBOX_BASE_CONTEXT the task target
+      # sets), composes each agent Feature with @devcontainers/cli, and asserts
+      # `command -v claude` / `command -v codex` exit 0 in the built image. The
+      # ubuntu runner has Docker; this is the fail-fast acceptance environment.
+      - name: Build sandbox Features and verify CLIs on PATH (#1082)
+        run: task test:integration:sandbox-features
+
   integration-e2e:
     name: Integration Tests (E2E)
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -384,6 +384,17 @@ tasks:
       AILERON_SANDBOX_BASE_CONTEXT:
         sh: cd "{{.ROOT_DIR}}/images/sandbox-base" && pwd
 
+  test:integration:sandbox-features:
+    desc: "Build the per-agent sandbox Features (claude/codex) with @devcontainers/cli and assert each agent CLI is on PATH in the composed image (#1082); fail-fast — requires Docker + Node + @devcontainers/cli (no self-skip)"
+    dir: internal
+    cmds:
+      - go test -tags=integration_sandbox -run TestSandboxFeatures ./launch/...
+    env:
+      AILERON_SANDBOX_BASE_CONTEXT:
+        sh: cd "{{.ROOT_DIR}}/images/sandbox-base" && pwd
+      AILERON_SANDBOX_FEATURES_CONTEXT:
+        sh: cd "{{.ROOT_DIR}}/images/sandbox-features" && pwd
+
   test:e2e:integration:
     desc: Run Playwright E2E tests against running services
     dir: ui

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -34,7 +34,7 @@ The harness-free `aileron/sandbox-base` intentionally does not include agent CLI
 
 ## Claude Code Feature
 
-The Claude Code agent Feature installs the `claude` CLI onto `aileron/sandbox-base`. It is the single source of truth that Aileron CI bakes into the prebuilt Claude image and that you compose for Tier 1. The Feature authoring lands in [#1082](https://github.com/ALRubinger/aileron/issues/1082).
+The Claude Code agent Feature installs the `claude` CLI onto `aileron/sandbox-base`. It is the single source of truth that Aileron CI bakes into the prebuilt Claude image and that you compose for Tier 1. The Feature lives at `images/sandbox-features/claude/` (`devcontainer-feature.json` plus `install.sh`).
 
 For the Tier 0 zero-build path, launch the prebuilt image directly:
 
@@ -54,7 +54,7 @@ Claude Code still owns its own authentication flow. Do not bake Claude, Anthropi
 
 ## Codex Feature
 
-The Codex agent Feature installs the `codex` CLI onto `aileron/sandbox-base`. The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine base. Like the Claude Feature, it is baked into the prebuilt Codex image and composable for Tier 1, and its authoring lands in [#1082](https://github.com/ALRubinger/aileron/issues/1082).
+The Codex agent Feature installs the `codex` CLI onto `aileron/sandbox-base`. The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine base. Like the Claude Feature, it is baked into the prebuilt Codex image and composable for Tier 1. The Feature lives at `images/sandbox-features/codex/` (`devcontainer-feature.json` plus `install.sh`).
 
 For the Tier 0 zero-build path:
 

--- a/images/sandbox-features/claude/devcontainer-feature.json
+++ b/images/sandbox-features/claude/devcontainer-feature.json
@@ -1,0 +1,7 @@
+{
+  "id": "claude",
+  "version": "0.0.1",
+  "name": "Claude Code CLI",
+  "description": "Installs the Anthropic Claude Code CLI (@anthropic-ai/claude-code) onto the Aileron Alpine sandbox base so it is on PATH for the non-root agent user.",
+  "documentationURL": "https://docs.withaileron.ai/development/sandbox-agent-images/"
+}

--- a/images/sandbox-features/claude/install.sh
+++ b/images/sandbox-features/claude/install.sh
@@ -1,0 +1,19 @@
+#!/bin/sh
+# Aileron sandbox Feature: Claude Code CLI.
+#
+# Single source of truth for the Claude install recipe. This script runs as
+# root during the image build on the Aileron Alpine sandbox base; the
+# resulting `claude` binary lands on PATH for the non-root `agent` user.
+#
+# The npm package and apk prerequisites are mirrored by the in-repo recipe
+# table in internal/sandbox/composition/recipes.go; features_test.go asserts
+# the two agree, so any drift fails CI.
+set -eu
+
+# Prerequisites present in the Alpine base substrate. apk --no-cache keeps the
+# step idempotent and image-layer-clean.
+apk add --no-cache git nodejs npm ripgrep
+
+# The @anthropic-ai/claude-code npm package installs cleanly on musl/Alpine.
+# npm -g re-runs cleanly, so the install is idempotent.
+npm install -g @anthropic-ai/claude-code

--- a/images/sandbox-features/codex/devcontainer-feature.json
+++ b/images/sandbox-features/codex/devcontainer-feature.json
@@ -1,0 +1,7 @@
+{
+  "id": "codex",
+  "version": "0.0.1",
+  "name": "Codex CLI",
+  "description": "Installs the OpenAI Codex CLI (@openai/codex) onto the Aileron Alpine sandbox base so it is on PATH for the non-root agent user.",
+  "documentationURL": "https://docs.withaileron.ai/development/sandbox-agent-images/"
+}

--- a/images/sandbox-features/codex/install.sh
+++ b/images/sandbox-features/codex/install.sh
@@ -1,0 +1,20 @@
+#!/bin/sh
+# Aileron sandbox Feature: Codex CLI.
+#
+# Single source of truth for the Codex install recipe. This script runs as
+# root during the image build on the Aileron Alpine sandbox base; the
+# resulting `codex` binary lands on PATH for the non-root `agent` user.
+#
+# The npm package and apk prerequisites are mirrored by the in-repo recipe
+# table in internal/sandbox/composition/recipes.go; features_test.go asserts
+# the two agree, so any drift fails CI.
+set -eu
+
+# Prerequisites present in the Alpine base substrate. apk --no-cache keeps the
+# step idempotent and image-layer-clean.
+apk add --no-cache git nodejs npm ripgrep
+
+# The @openai/codex npm package ships prebuilt musl binaries, so it installs
+# cleanly on the Alpine base. npm -g re-runs cleanly, so the install is
+# idempotent.
+npm install -g @openai/codex

--- a/internal/launch/sandbox_features_integration_test.go
+++ b/internal/launch/sandbox_features_integration_test.go
@@ -144,8 +144,14 @@ func buildSandboxFeaturesBaseImage(ctx context.Context, t *testing.T, rt string)
 }
 
 // buildComposedImage writes a minimal devcontainer.json that FROMs the test
-// base image and references the local Feature directory by path, then runs
-// `devcontainer build` and returns the resulting image id.
+// base image and references the local Feature directory by a RELATIVE path,
+// then runs `devcontainer build` and returns the resulting image id.
+//
+// @devcontainers/cli rejects an absolute path as a feature id ("An Absolute
+// path to a local feature is not allowed"). Local Features must live beneath
+// the workspace's .devcontainer/ and be referenced relative to it (e.g.
+// "./claude"). The source Feature is copied into the transient workspace so
+// the test never mutates the repo tree.
 func buildComposedImage(ctx context.Context, t *testing.T, featureDir, agent string) string {
 	t.Helper()
 	workspace := t.TempDir()
@@ -154,13 +160,16 @@ func buildComposedImage(ctx context.Context, t *testing.T, featureDir, agent str
 		t.Fatalf("mkdir .devcontainer: %v", err)
 	}
 
-	// Reference the local Feature directory by absolute path. @devcontainers/cli
-	// accepts a filesystem path as a feature id, building it from source.
+	// Copy the Feature into .devcontainer/<agent>/ so it can be referenced by
+	// the only path form the CLI accepts: relative to .devcontainer.
+	localFeatureDir := filepath.Join(devDir, agent)
+	copyFeatureDir(t, featureDir, localFeatureDir)
+
 	dc := map[string]any{
 		"name":  "aileron-sandbox-feature-" + agent,
 		"image": sandboxFeaturesBaseImage,
 		"features": map[string]any{
-			featureDir: map[string]any{},
+			"./" + agent: map[string]any{},
 		},
 	}
 	raw, err := json.MarshalIndent(dc, "", "  ")
@@ -186,6 +195,43 @@ func buildComposedImage(ctx context.Context, t *testing.T, featureDir, agent str
 	}
 	t.Logf("devcontainer build %s ->\n%s", agent, stdout.String())
 	return image
+}
+
+// copyFeatureDir copies the Feature's files (devcontainer-feature.json,
+// install.sh) from src into dst, preserving file modes so install.sh keeps
+// its executable bit. The Feature directory is flat (no subdirectories), so a
+// shallow copy suffices.
+func copyFeatureDir(t *testing.T, src, dst string) {
+	t.Helper()
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		t.Fatalf("mkdir feature dst %s: %v", dst, err)
+	}
+	entries, err := os.ReadDir(src)
+	if err != nil {
+		t.Fatalf("read feature dir %s: %v", src, err)
+	}
+	for _, e := range entries {
+		if e.IsDir() {
+			continue
+		}
+		info, err := e.Info()
+		if err != nil {
+			t.Fatalf("stat %s: %v", e.Name(), err)
+		}
+		raw, err := os.ReadFile(filepath.Join(src, e.Name()))
+		if err != nil {
+			t.Fatalf("read %s: %v", e.Name(), err)
+		}
+		dstPath := filepath.Join(dst, e.Name())
+		if err := os.WriteFile(dstPath, raw, info.Mode().Perm()); err != nil {
+			t.Fatalf("write %s: %v", e.Name(), err)
+		}
+		// WriteFile's create mode is masked by umask, so re-apply the source
+		// mode explicitly to preserve install.sh's executable bit.
+		if err := os.Chmod(dstPath, info.Mode().Perm()); err != nil {
+			t.Fatalf("chmod %s: %v", e.Name(), err)
+		}
+	}
 }
 
 // assertCommandOnPath runs the built image and asserts `command -v <cmd>`

--- a/internal/launch/sandbox_features_integration_test.go
+++ b/internal/launch/sandbox_features_integration_test.go
@@ -1,0 +1,212 @@
+//go:build integration_sandbox
+
+// Sandbox Feature build e2e test (#1082).
+//
+// This test exercises the load-bearing contract of the per-agent
+// devcontainer Features under images/sandbox-features/<agent>/: composing the
+// Aileron sandbox base with a single agent Feature must produce an image where
+// that agent's CLI is on PATH for the running user.
+//
+// It drives @devcontainers/cli directly (NOT Aileron's own
+// composition.Discover build path — that wiring is #1083's scope):
+//
+//   - Build the aileron/sandbox-base image (Tier base) via the Builder.
+//   - Generate a minimal devcontainer.json that FROMs the freshly built base
+//     and references the local Feature directory by path.
+//   - `devcontainer build` the composed image.
+//   - `docker run` the built image and assert `command -v <cli>` exits 0.
+//
+// Per #1082 this test is FAIL-FAST: there is no t.Skip. If Go, Node,
+// @devcontainers/cli, Docker, or the base image is absent, the test FAILS.
+// CI provisions the toolchain (see the integration-sandbox-features job).
+//
+// Run with:
+//
+//	task test:integration:sandbox-features
+//
+// or directly:
+//
+//	go test -tags=integration_sandbox -run TestSandboxFeatures ./launch/...
+package launch
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+const sandboxFeaturesBaseImage = "aileron/sandbox-base:features-test"
+
+// sandboxFeatureCase is one agent's build-and-verify contract.
+type sandboxFeatureCase struct {
+	agent   string // Feature id / directory name under images/sandbox-features
+	command string // the CLI binary that must be on PATH after the build
+}
+
+func TestSandboxFeatures(t *testing.T) {
+	rt, err := sandboxcontainer.ResolveRuntime("docker")
+	if err != nil {
+		// Fail-fast per #1082: CI provisions Docker; absence is a job failure,
+		// not a skip.
+		t.Fatalf("no docker runtime on PATH (required, not skipped): %v", err)
+	}
+	requireDevcontainersCLI(t)
+
+	ctx, cancel := context.WithTimeout(context.Background(), 15*time.Minute)
+	defer cancel()
+
+	buildSandboxFeaturesBaseImage(ctx, t, rt)
+
+	featuresRoot := sandboxFeaturesContext(t)
+
+	cases := []sandboxFeatureCase{
+		{agent: "claude", command: "claude"},
+		{agent: "codex", command: "codex"},
+	}
+	for _, tc := range cases {
+		tc := tc
+		t.Run(tc.agent, func(t *testing.T) {
+			featureDir := filepath.Join(featuresRoot, tc.agent)
+			if _, err := os.Stat(filepath.Join(featureDir, "devcontainer-feature.json")); err != nil {
+				t.Fatalf("feature %q not found at %s: %v", tc.agent, featureDir, err)
+			}
+			image := buildComposedImage(ctx, t, featureDir, tc.agent)
+			assertCommandOnPath(ctx, t, rt, image, tc.command)
+		})
+	}
+}
+
+// requireDevcontainersCLI fails the test (does not skip) if the
+// @devcontainers/cli is not invokable.
+func requireDevcontainersCLI(t *testing.T) {
+	t.Helper()
+	cmd := exec.Command("devcontainer", "--version")
+	if err := cmd.Run(); err != nil {
+		t.Fatalf("@devcontainers/cli not on PATH (required, not skipped): %v; install with `npm install -g @devcontainers/cli`", err)
+	}
+}
+
+// sandboxFeaturesContext resolves the images/sandbox-features directory,
+// honoring AILERON_SANDBOX_FEATURES_CONTEXT, otherwise walking up from cwd.
+func sandboxFeaturesContext(t *testing.T) string {
+	t.Helper()
+	if env := strings.TrimSpace(os.Getenv("AILERON_SANDBOX_FEATURES_CONTEXT")); env != "" {
+		return env
+	}
+	start, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := start
+	for {
+		candidate := filepath.Join(dir, "images", "sandbox-features")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("images/sandbox-features context not found from %s; set AILERON_SANDBOX_FEATURES_CONTEXT", start)
+		}
+		dir = parent
+	}
+}
+
+// buildSandboxFeaturesBaseImage builds the sandbox-base image under a
+// dedicated test tag so the composed Features FROM a known-good substrate.
+func buildSandboxFeaturesBaseImage(ctx context.Context, t *testing.T, rt string) {
+	t.Helper()
+	builder := sandboxcontainer.Builder{
+		Runtime: rt,
+		Stdout:  testLogWriter{t},
+		Stderr:  testLogWriter{t},
+	}
+	plan := sandboxcomposition.Plan{
+		Tier:  sandboxcomposition.TierBase,
+		Image: sandboxFeaturesBaseImage,
+	}
+	if _, err := builder.Build(ctx, sandboxcontainer.BuildOptions{
+		Plan:   plan,
+		Tag:    sandboxFeaturesBaseImage,
+		Policy: sandboxcontainer.BuildPolicyAlways,
+	}); err != nil {
+		t.Fatalf("build sandbox-base test image: %v (set AILERON_SANDBOX_BASE_CONTEXT to images/sandbox-base if the context was not found)", err)
+	}
+}
+
+// buildComposedImage writes a minimal devcontainer.json that FROMs the test
+// base image and references the local Feature directory by path, then runs
+// `devcontainer build` and returns the resulting image id.
+func buildComposedImage(ctx context.Context, t *testing.T, featureDir, agent string) string {
+	t.Helper()
+	workspace := t.TempDir()
+	devDir := filepath.Join(workspace, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatalf("mkdir .devcontainer: %v", err)
+	}
+
+	// Reference the local Feature directory by absolute path. @devcontainers/cli
+	// accepts a filesystem path as a feature id, building it from source.
+	dc := map[string]any{
+		"name":  "aileron-sandbox-feature-" + agent,
+		"image": sandboxFeaturesBaseImage,
+		"features": map[string]any{
+			featureDir: map[string]any{},
+		},
+	}
+	raw, err := json.MarshalIndent(dc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal devcontainer.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "devcontainer.json"), raw, 0o644); err != nil {
+		t.Fatalf("write devcontainer.json: %v", err)
+	}
+
+	image := fmt.Sprintf("aileron/sandbox-feature-%s:test", agent)
+	args := []string{
+		"build",
+		"--workspace-folder", workspace,
+		"--image-name", image,
+	}
+	var stdout, stderr bytes.Buffer
+	c := exec.CommandContext(ctx, "devcontainer", args...)
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	if err := c.Run(); err != nil {
+		t.Fatalf("devcontainer build for %s failed: %v\nstdout:\n%s\nstderr:\n%s", agent, err, stdout.String(), stderr.String())
+	}
+	t.Logf("devcontainer build %s ->\n%s", agent, stdout.String())
+	return image
+}
+
+// assertCommandOnPath runs the built image and asserts `command -v <cmd>`
+// exits 0, proving the Feature put the agent CLI on PATH.
+func assertCommandOnPath(ctx context.Context, t *testing.T, rt, image, cmd string) {
+	t.Helper()
+	args := []string{
+		"run", "--rm",
+		image,
+		"/bin/sh", "-c", "command -v " + cmd,
+	}
+	var stdout, stderr bytes.Buffer
+	c := exec.CommandContext(ctx, rt, args...)
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	if err := c.Run(); err != nil {
+		t.Fatalf("`command -v %s` failed in image %s: %v\nstdout: %q\nstderr: %q\nThe Feature must put %q on PATH for the running user.", cmd, image, err, stdout.String(), stderr.String(), cmd)
+	}
+	if path := strings.TrimSpace(stdout.String()); path == "" {
+		t.Fatalf("`command -v %s` produced no PATH entry in image %s; the Feature did not install the CLI", cmd, image)
+	} else {
+		t.Logf("%s resolved to %s in image %s", cmd, path, image)
+	}
+}

--- a/internal/sandbox/composition/features_test.go
+++ b/internal/sandbox/composition/features_test.go
@@ -1,0 +1,141 @@
+package composition
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// featuresContext locates the repo-root images/sandbox-features directory by
+// walking up from the test working directory for the marker, honoring an
+// optional AILERON_SANDBOX_FEATURES_CONTEXT override for parity with the
+// AILERON_SANDBOX_BASE_CONTEXT override used by the container runtime.
+func featuresContext(t *testing.T) string {
+	t.Helper()
+	if env := strings.TrimSpace(os.Getenv("AILERON_SANDBOX_FEATURES_CONTEXT")); env != "" {
+		return env
+	}
+	start, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := start
+	for {
+		candidate := filepath.Join(dir, "images", "sandbox-features")
+		if info, err := os.Stat(candidate); err == nil && info.IsDir() {
+			return candidate
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("images/sandbox-features context not found from %s; set AILERON_SANDBOX_FEATURES_CONTEXT", start)
+		}
+		dir = parent
+	}
+}
+
+// featureManifest is the minimal subset of devcontainer-feature.json the
+// contract asserts on.
+type featureManifest struct {
+	ID          string `json:"id"`
+	Version     string `json:"version"`
+	Name        string `json:"name"`
+	Description string `json:"description"`
+}
+
+func TestFeatureManifestsAreValid(t *testing.T) {
+	root := featuresContext(t)
+	for _, agent := range []string{"claude", "codex"} {
+		agent := agent
+		t.Run(agent, func(t *testing.T) {
+			path := filepath.Join(root, agent, "devcontainer-feature.json")
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			var m featureManifest
+			if err := json.Unmarshal(raw, &m); err != nil {
+				t.Fatalf("%s is not valid JSON: %v", path, err)
+			}
+			if m.ID != agent {
+				t.Fatalf("%s id = %q, want %q", path, m.ID, agent)
+			}
+			if strings.TrimSpace(m.Version) == "" {
+				t.Fatalf("%s missing version", path)
+			}
+			if strings.TrimSpace(m.Name) == "" {
+				t.Fatalf("%s missing name", path)
+			}
+			if strings.TrimSpace(m.Description) == "" {
+				t.Fatalf("%s missing description", path)
+			}
+		})
+	}
+}
+
+func TestFeatureInstallScriptsArePresentAndExecutable(t *testing.T) {
+	root := featuresContext(t)
+	for _, agent := range []string{"claude", "codex"} {
+		agent := agent
+		t.Run(agent, func(t *testing.T) {
+			path := filepath.Join(root, agent, "install.sh")
+			info, err := os.Stat(path)
+			if err != nil {
+				t.Fatalf("stat %s: %v", path, err)
+			}
+			if info.Mode()&0o111 == 0 {
+				t.Fatalf("%s is not executable (mode %v); install.sh must have the executable bit set", path, info.Mode())
+			}
+		})
+	}
+}
+
+func TestFeatureInstallScriptsMatchCanonicalRecipe(t *testing.T) {
+	root := featuresContext(t)
+	for _, agent := range []string{"claude", "codex"} {
+		agent := agent
+		t.Run(agent, func(t *testing.T) {
+			recipe, ok := recipeForAgent(agent)
+			if !ok {
+				t.Fatalf("no canonical recipe for agent %q", agent)
+			}
+			path := filepath.Join(root, agent, "install.sh")
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			body := string(raw)
+
+			// The Feature must install via the canonical npm package, and the
+			// install line must put that agent's CLI on PATH.
+			wantNPM := "npm install -g " + recipe.NPMPackage
+			if !strings.Contains(body, wantNPM) {
+				t.Fatalf("%s missing canonical npm install %q:\n%s", path, wantNPM, body)
+			}
+
+			// Drift guard: the apk prerequisites named in the canonical table
+			// must all be installed by the Feature.
+			if !strings.Contains(body, "apk add") {
+				t.Fatalf("%s must install prerequisites with apk (the Alpine base has no apt-get):\n%s", path, body)
+			}
+			for _, pkg := range recipe.Prereqs {
+				if !strings.Contains(body, pkg) {
+					t.Fatalf("%s missing canonical apk prerequisite %q:\n%s", path, pkg, body)
+				}
+			}
+
+			// The Alpine base uses apk; apt-get must never appear.
+			if strings.Contains(body, "apt-get") {
+				t.Fatalf("%s uses apt-get; the Alpine base requires apk:\n%s", path, body)
+			}
+
+			// No credential reads baked into the Feature.
+			for _, secret := range []string{"ANTHROPIC_API_KEY", "OPENAI_API_KEY"} {
+				if strings.Contains(body, secret) {
+					t.Fatalf("%s references credential env var %q; Features must not read or bake credentials:\n%s", path, secret, body)
+				}
+			}
+		})
+	}
+}

--- a/internal/sandbox/composition/features_test.go
+++ b/internal/sandbox/composition/features_test.go
@@ -3,6 +3,7 @@ package composition
 import (
 	"encoding/json"
 	"os"
+	"os/exec"
 	"path/filepath"
 	"strings"
 	"testing"
@@ -80,14 +81,39 @@ func TestFeatureInstallScriptsArePresentAndExecutable(t *testing.T) {
 		agent := agent
 		t.Run(agent, func(t *testing.T) {
 			path := filepath.Join(root, agent, "install.sh")
-			info, err := os.Stat(path)
-			if err != nil {
+			if _, err := os.Stat(path); err != nil {
 				t.Fatalf("stat %s: %v", path, err)
 			}
-			if info.Mode()&0o111 == 0 {
-				t.Fatalf("%s is not executable (mode %v); install.sh must have the executable bit set", path, info.Mode())
-			}
+			// The executable bit is the load-bearing contract: the devcontainer
+			// build runs install.sh, and #965's publish workflow ships exactly
+			// what git tracks. Assert git's recorded mode (100755) rather than
+			// the filesystem mode, which is platform-dependent — Windows
+			// checkouts drop the Unix exec bit, but the committed mode is the
+			// real source of truth on every platform.
+			assertGitExecutable(t, root, path)
 		})
+	}
+}
+
+// assertGitExecutable fails unless git tracks path with the executable mode
+// (100755). root is used as the git working directory so the lookup works
+// regardless of the test's cwd.
+func assertGitExecutable(t *testing.T, root, path string) {
+	t.Helper()
+	cmd := exec.Command("git", "ls-files", "--stage", "--", path)
+	cmd.Dir = root
+	out, err := cmd.Output()
+	if err != nil {
+		t.Fatalf("git ls-files --stage %s (cwd %s): %v", path, root, err)
+	}
+	line := strings.TrimSpace(string(out))
+	if line == "" {
+		t.Fatalf("%s is not tracked by git; install.sh must be committed with the executable bit", path)
+	}
+	// Format: "<mode> <object> <stage>\t<file>"; mode is the first field.
+	mode := strings.Fields(line)[0]
+	if mode != "100755" {
+		t.Fatalf("%s has git mode %s, want 100755 (executable); run `git update-index --chmod=+x` or `chmod +x` before committing", path, mode)
 	}
 }
 

--- a/internal/sandbox/composition/recipes.go
+++ b/internal/sandbox/composition/recipes.go
@@ -1,0 +1,46 @@
+package composition
+
+// agentRecipe is the canonical, in-repo install recipe for an agent CLI on
+// the Aileron Alpine sandbox base. It names the apk prerequisites and the
+// global npm package that puts the agent's CLI on PATH.
+//
+// This table is the single source of truth for the recipe *content* shared by
+// two consumers:
+//
+//   - agentInstallSnippet (scaffold.go), which still emits an inline Dockerfile
+//     snippet for `aileron sandbox init` until #1084 swaps the scaffold to
+//     reference the published Feature.
+//   - the devcontainer Features under images/sandbox-features/<agent>/, whose
+//     install.sh scripts express the same recipe.
+//
+// features_test.go asserts the Feature install.sh scripts agree with this
+// table, so any drift between the two fails CI.
+type agentRecipe struct {
+	// AptPrereqs are the apk packages installed (via `apk add --no-cache`)
+	// before the npm install. Named "prereqs" rather than "apt" deliberately:
+	// the Alpine base uses apk, never apt-get.
+	Prereqs []string
+	// NPMPackage is the global npm package (`npm install -g <pkg>`) that
+	// installs the agent's CLI binary onto PATH.
+	NPMPackage string
+}
+
+// agentRecipes maps an agent id to its canonical install recipe. Agents absent
+// from this map have no verified Tier 1 recipe and fall back to the TODO stub
+// in agentInstallSnippet.
+var agentRecipes = map[string]agentRecipe{
+	"claude": {
+		Prereqs:    []string{"git", "nodejs", "npm", "ripgrep"},
+		NPMPackage: "@anthropic-ai/claude-code",
+	},
+	"codex": {
+		Prereqs:    []string{"git", "nodejs", "npm", "ripgrep"},
+		NPMPackage: "@openai/codex",
+	},
+}
+
+// recipeForAgent returns the canonical recipe for agent and whether one exists.
+func recipeForAgent(agent string) (agentRecipe, bool) {
+	r, ok := agentRecipes[agent]
+	return r, ok
+}

--- a/internal/sandbox/composition/scaffold.go
+++ b/internal/sandbox/composition/scaffold.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // DefaultAgent is the agent the scaffold targets when --agent is omitted.
@@ -115,24 +116,37 @@ USER agent
 // a documented Tier 1 recipe are pre-filled and uncommented; agents
 // without one get a TODO stub that still produces a buildable Dockerfile
 // once the user fills it in.
+//
+// The Claude/Codex snippets are derived from the canonical agentRecipes
+// table (recipes.go), which is also the source of truth for the devcontainer
+// Features under images/sandbox-features/<agent>/. There is exactly one place
+// that names the apk prerequisites and the npm package per agent.
 func agentInstallSnippet(agent string) string {
-	switch agent {
-	case "claude":
-		return `# --- Claude Code ---
-RUN apk add --no-cache git nodejs npm ripgrep && \
-    npm install -g @anthropic-ai/claude-code`
-	case "codex":
-		// The @openai/codex npm package ships prebuilt musl binaries, so it
-		// installs cleanly on the Alpine base.
-		return `# --- Codex ---
-RUN apk add --no-cache git nodejs npm ripgrep && \
-    npm install -g @openai/codex`
-	default:
-		return fmt.Sprintf(`# --- TODO: install the %s CLI ---
+	if recipe, ok := recipeForAgent(agent); ok {
+		return fmt.Sprintf(`# --- %s ---
+RUN apk add --no-cache %s && \
+    npm install -g %s`,
+			agentSnippetLabel(agent),
+			strings.Join(recipe.Prereqs, " "),
+			recipe.NPMPackage)
+	}
+	return fmt.Sprintf(`# --- TODO: install the %s CLI ---
 # Aileron does not yet ship a verified install recipe for %s.
 # Replace this stub with an install that puts %q on PATH and uses apk
 # against the Alpine base. See:
 #   https://docs.withaileron.ai/development/sandbox-agent-images/
 # RUN apk add --no-cache ...`, agent, agent, agent)
+}
+
+// agentSnippetLabel returns the human-facing heading for an agent's Dockerfile
+// install snippet (e.g. "Claude Code"). Falls back to the agent id.
+func agentSnippetLabel(agent string) string {
+	switch agent {
+	case "claude":
+		return "Claude Code"
+	case "codex":
+		return "Codex"
+	default:
+		return agent
 	}
 }


### PR DESCRIPTION
## Summary

- Move the Claude Code and Codex CLI install recipes out of the hardcoded `agentInstallSnippet` Go snippet into real, composable devcontainer Features under `images/sandbox-features/<agent>/`, one per agent, each a `{ devcontainer-feature.json, install.sh }` pair. This makes each agent's install live in one authoritative place that Aileron CI (#965), the e2e build wiring (#1083), and the scaffold (#1084) all consume.
- Centralize the per-agent npm package + apk prerequisites into a canonical `agentRecipes` table (`internal/sandbox/composition/recipes.go`). The scaffold snippet now derives its Claude/Codex output from this table instead of hardcoding the npm line twice; the duplicated recipe content is removed per the no-backwards-compat rule. The emitted Dockerfile snippet is byte-for-byte identical to before.
- Add always-on contract unit tests (`features_test.go`, no build tag, in the `sandbox` Codecov shard) that validate each Feature manifest, assert `install.sh` is executable, uses `apk` not `apt-get`, bakes no credentials, and **drift-guards** the Feature recipe against the canonical table.
- Add a build-tagged, fail-fast e2e test (`//go:build integration_sandbox`) that drives `@devcontainers/cli` directly to build base + Feature and assert `command -v claude` / `command -v codex` exits 0 in the composed image. No `t.Skip`: missing Docker/Node/CLI/base is a failure, not a skip.
- Wire the e2e test through a new `task test:integration:sandbox-features` target (no raw `docker`/`npm` in repo source) and a dedicated `Integration Tests (Sandbox Features)` CI job.
- Update `docs/.../sandbox-agent-images.md` to point at the now-landed Feature source location.

### Scope boundaries
- In scope: Claude + Codex Features, recipe centralization/de-dup, contract unit tests, build-tagged e2e test, task target, CI job.
- Out of scope (deferred): Goose/Pi/OpenCode Features; wiring the Feature through `composition.Discover` (#1083); rewriting the scaffold to reference the published Feature + the GHCR publish workflow (#1084 / #965). No MCP registration changes — the per-agent MCP matrix (#1064) is untouched.

## Test plan

- [x] `go test ./internal/sandbox/composition/...` green; coverage 88.8%.
- [x] `go test ./internal/sandbox/...` (full sandbox shard) green.
- [x] `go test ./internal/launch/...` (untagged) green — no regression.
- [x] Existing scaffold contract tests (`TestInitDefaultsToClaudeRecipeReadyToBuild`, `TestInitWithCodexRecipeReadyToBuild`, `TestInitWithUnknownAgentEmitsTODOStub`, `TestInitWritesStarterDevcontainerAndDockerfile`) still pass; emitted snippet unchanged.
- [x] `go vet -tags=integration_sandbox ./internal/launch/...` clean; `gofmt` clean.
- [x] Feature JSON manifests parse; `install.sh` files tracked with mode `100755`.
- [ ] New `integration-sandbox-features` CI job runs the fail-fast e2e build (requires Docker + Node + `@devcontainers/cli`; provisioned by the job). Not runnable locally here without that toolchain.

Closes #1082

🤖 Generated with [Claude Code](https://claude.com/claude-code)