### PR TITLE
ci: add windows-latest release smoke job for the Scoop path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -220,6 +220,73 @@ jobs:
           # *_windows.go files that Linux runs cannot measure.
           flags: unit
 
+  release-smoke-windows:
+    # Windows release smoke for the Scoop distribution path (#1094). We
+    # cannot exercise real Windows from the dev environment, so this job
+    # is the safety net: it validates the GoReleaser config (including the
+    # scoops block), builds the Windows artifacts, and confirms the binary
+    # runs natively.
+    #
+    # The Scoop manifest (aileron.json) is written only by GoReleaser's
+    # publish pipe, which --snapshot disables, so a snapshot never emits
+    # dist/scoop/aileron.json. `goreleaser check` is therefore what
+    # validates the scoops block on a PR; the snapshot build then proves
+    # the windows/amd64 zip is produced and the binary executes.
+    name: Windows Release Smoke
+    runs-on: windows-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          # Matches the three binaries GoReleaser builds (./internal/server,
+          # ./cmd/aileron, ./cmd/aileron-mcp).
+          cache-dependency-path: |
+            internal/go.mod
+            cmd/aileron/go.mod
+            cmd/aileron-mcp/go.mod
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Install GoReleaser
+        # `task release:*` invokes a bare `goreleaser` binary; nothing else
+        # in this job provisions it, so install it explicitly here (the same
+        # action release.yml uses, in install-only mode).
+        uses: goreleaser/goreleaser-action@v7
+        with:
+          distribution: goreleaser
+          version: "~> v2"
+          install-only: true
+
+      - name: Validate GoReleaser config
+        run: task release:check
+
+      - name: Build snapshot artifacts
+        # --skip=sign: cosign keyless signing needs OIDC this PR job does not
+        # provision. Signing is exercised by the real release workflow, not
+        # this smoke. aileron-server embeds internal/app/webapp_dist/, which
+        # ships a .gitkeep stub, so the snapshot compiles without a webapp
+        # build step.
+        run: task release:snapshot -- --skip=sign
+
+      - name: Verify the Windows binary runs natively
+        shell: bash
+        run: |
+          set -e
+          exe=$(find dist -name 'aileron.exe' -path '*windows_amd64*' | head -n1)
+          if [ -z "$exe" ]; then
+            echo "aileron.exe not found in dist:"
+            ls -R dist
+            exit 1
+          fi
+          echo "Running: $exe version"
+          "$exe" version
+
   test-ui:
     name: UI Tests
     runs-on: ubuntu-latest

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -419,10 +419,15 @@ tasks:
       - task: test:integration
       - task: down
 
-  release:snapshot:
-    desc: Test GoReleaser locally (snapshot, no publish)
+  release:check:
+    desc: Validate the GoReleaser config (includes the scoops and homebrew_casks blocks)
     cmds:
-      - goreleaser release --snapshot --clean
+      - goreleaser check
+
+  release:snapshot:
+    desc: Test GoReleaser locally (snapshot, no publish). Pass extra flags after --, e.g. `task release:snapshot -- --skip=sign`.
+    cmds:
+      - goreleaser release --snapshot --clean {{.CLI_ARGS}}
 
   health:
     desc: Check the server health endpoint


### PR DESCRIPTION
## Summary

Adds a `release-smoke-windows` CI job (sub-issue #1096 of umbrella #1094) that catches Scoop and Windows breakage automatically on every PR, since real Windows cannot be exercised from the dev environment.

The job, on `windows-latest`:
- `goreleaser check` — validates the whole `.goreleaser.yml`, **including the `scoops:` block** landed in #1095.
- `task release:snapshot -- --skip=sign` — builds the snapshot artifacts (produces the `windows_amd64` zip).
- runs the built `aileron.exe version` to confirm the binary executes natively on Windows.

Supporting Taskfile changes: a new `release:check` target, and `release:snapshot` now forwards `{{.CLI_ARGS}}` so callers can pass `--skip=sign`.

## Correction to the umbrella's stated acceptance

The umbrella (#1094) and this sub-issue's brief assert that `task release:snapshot` *generates the Scoop manifest* (`dist/scoop/aileron.json`) and that CI should assert on it. **That is not achievable**: empirically (GoReleaser v2.16.0) the `scoops` pipe runs only in the **publish** phase, which `--snapshot` disables — a snapshot writes the Homebrew cask (its pipe has a default-phase writer) but never the Scoop manifest, with or without the bucket token. So the manifest-existence assertion is replaced with `goreleaser check`, which is the correct PR-time validator of the `scoops:` config. This is documented in the job's comment and in residual triage for #1105/#1101.

## Test plan

- [x] `task release:check` passes locally (validates config incl. scoops).
- [x] `task release:snapshot -- --skip=sign` resolves to `goreleaser release --snapshot --clean --skip=sign` (CLI_ARGS forwarding verified via `task --dry`).
- [x] Snapshot build produces `dist/aileron_windows_amd64_v1/aileron.exe` (verified on macOS host); the job's `find` locates it.
- [ ] The `release-smoke-windows` job is green on this PR (the real Windows validation — only observable in CI).

🤖 Generated with [Claude Code](https://claude.com/claude-code)