### PR TITLE
docs: lead the Windows install tab with Scoop, keep the zip fallback

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -72,9 +72,22 @@ We're about to take your first flight with Aileron. In under 5 minutes, you'll b
   {
     value: "windows",
     label: "Windows",
-    lang: "powershell",
-    note: "Extract the zip and add the directory to PATH. Note that Windows support is not yet confirmed; file an issue if not working correctly.",
-    code: `Invoke-WebRequest -Uri https://github.com/ALRubinger/aileron/releases/latest/download/aileron_${latestRelease.version}_windows_amd64.zip -OutFile aileron.zip\nExpand-Archive aileron.zip -DestinationPath $env:USERPROFILE\\aileron`,
+    note: "Windows support is still being verified on real hardware. Please file an issue if anything does not work.",
+    variants: [
+      {
+        value: "scoop",
+        label: "Scoop",
+        lang: "powershell",
+        code: `scoop bucket add aileron https://github.com/ALRubinger/scoop-aileron\nscoop install aileron`,
+      },
+      {
+        value: "zip",
+        label: "Manual (.zip)",
+        lang: "powershell",
+        note: "Extract the zip and add the directory to PATH.",
+        code: `Invoke-WebRequest -Uri https://github.com/ALRubinger/aileron/releases/latest/download/aileron_${latestRelease.version}_windows_amd64.zip -OutFile aileron.zip\nExpand-Archive aileron.zip -DestinationPath $env:USERPROFILE\\aileron`,
+      },
+    ],
   },
 ]} />
 


### PR DESCRIPTION
## Summary

Sub-issue #1097 of umbrella #1094. Updates the Getting Started Windows install tab so `scoop install aileron` is the primary path.

- Windows tab now uses the `variants` mechanism (same as the Linux deb/rpm/apk tab).
- **Scoop** is the first, default-selected variant, showing the two-liner:
  `scoop bucket add aileron https://github.com/ALRubinger/scoop-aileron` then `scoop install aileron`.
- The manual **.zip** download is retained as a secondary variant, keeping its extract-and-add-to-PATH note.
- The support caveat moves to the platform level (applies to both paths) and is softened: "Windows support is still being verified on real hardware. Please file an issue if anything does not work."

Incorporates the deferred plan-review findings in #1100 (platform-level caveat placement; non-redundant note wording; `lang`/`html` confirmed cosmetic on this page).

## Test plan

- [x] `task build:docs` succeeds (123 pages built).
- [x] Docs writing voice: no em-dash, one thought per sentence.
- [ ] Visual check of the rendered tab (Scoop default-selected, zip secondary) — best confirmed on the deployed docs preview.

🤖 Generated with [Claude Code](https://claude.com/claude-code)