### PR TITLE
feat(sandbox): reposition init to Feature-composing scaffold, drop --agent

### DIFF
--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -330,8 +330,10 @@ func TestRunSandboxInitCreatesDevcontainerScaffold(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(dir, ".devcontainer", "devcontainer.json")); err != nil {
 		t.Fatalf("devcontainer.json not created: %v", err)
 	}
-	if _, err := os.Stat(filepath.Join(dir, ".devcontainer", "Dockerfile")); err != nil {
-		t.Fatalf("Dockerfile not created: %v", err)
+	// init scaffolds a Feature-composing devcontainer.json only; it no longer
+	// writes a per-agent Dockerfile.
+	if _, err := os.Stat(filepath.Join(dir, ".devcontainer", "Dockerfile")); !os.IsNotExist(err) {
+		t.Fatalf("Dockerfile should not be created: stat err = %v", err)
 	}
 }
 
@@ -375,55 +377,29 @@ func TestRunSandboxRequiresSubcommand(t *testing.T) {
 	}
 }
 
-func TestRunSandboxInitAgentFlagSelectsRecipe(t *testing.T) {
-	dir := t.TempDir()
-	oldWd, _ := os.Getwd()
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldWd) })
+func TestRunSandboxInitRejectsAgentFlag(t *testing.T) {
+	// The --agent flag was removed (no deprecation). The standard flag parser
+	// rejects the unknown flag and surfaces the new usage text without writing
+	// any scaffold.
+	for _, arg := range []string{"--agent=claude", "--agent=anything"} {
+		dir := t.TempDir()
+		oldWd, _ := os.Getwd()
+		if err := os.Chdir(dir); err != nil {
+			t.Fatalf("chdir: %v", err)
+		}
+		t.Cleanup(func() { _ = os.Chdir(oldWd) })
 
-	reg := newTestRegistry()
-	reg.Register(agents.Codex{})
-
-	var stdout, stderr bytes.Buffer
-	code := run([]string{"sandbox", "init", "--agent=codex"}, reg, &stdout, &stderr)
-	if code != 0 {
-		t.Fatalf("expected exit code 0, got %d; stderr=%q", code, stderr.String())
-	}
-	if !strings.Contains(stdout.String(), "agent: codex") {
-		t.Fatalf("stdout missing agent line: %q", stdout.String())
-	}
-	body, err := os.ReadFile(filepath.Join(dir, ".devcontainer", "Dockerfile"))
-	if err != nil {
-		t.Fatalf("read Dockerfile: %v", err)
-	}
-	if !strings.Contains(string(body), "npm install -g @openai/codex") {
-		t.Fatalf("Dockerfile missing codex recipe:\n%s", string(body))
-	}
-}
-
-func TestRunSandboxInitAgentFlagRejectsUnknownAgent(t *testing.T) {
-	dir := t.TempDir()
-	oldWd, _ := os.Getwd()
-	if err := os.Chdir(dir); err != nil {
-		t.Fatalf("chdir: %v", err)
-	}
-	t.Cleanup(func() { _ = os.Chdir(oldWd) })
-
-	var stdout, stderr bytes.Buffer
-	code := run([]string{"sandbox", "init", "--agent=bogus"}, newTestRegistry(), &stdout, &stderr)
-	if code != 1 {
-		t.Fatalf("expected exit code 1, got %d", code)
-	}
-	if !strings.Contains(stderr.String(), `unknown agent: "bogus"`) {
-		t.Fatalf("stderr = %q", stderr.String())
-	}
-	if !strings.Contains(stderr.String(), "available agents:") {
-		t.Fatalf("stderr missing agent list: %q", stderr.String())
-	}
-	if _, err := os.Stat(filepath.Join(dir, ".devcontainer")); !os.IsNotExist(err) {
-		t.Fatalf("scaffold should not be written for unknown agent: stat err = %v", err)
+		var stdout, stderr bytes.Buffer
+		code := run([]string{"sandbox", "init", arg}, newTestRegistry(), &stdout, &stderr)
+		if code != 1 {
+			t.Fatalf("%s: expected exit code 1, got %d; stderr=%q", arg, code, stderr.String())
+		}
+		if !strings.Contains(stderr.String(), "flag provided but not defined: -agent") {
+			t.Fatalf("%s: stderr missing flag error: %q", arg, stderr.String())
+		}
+		if _, err := os.Stat(filepath.Join(dir, ".devcontainer", "devcontainer.json")); !os.IsNotExist(err) {
+			t.Fatalf("%s: scaffold should not be written when the flag is rejected: stat err = %v", arg, err)
+		}
 	}
 }
 
@@ -7218,7 +7194,6 @@ func TestPreviewSuiteRefs_NonOKSurfacesDaemonError(t *testing.T) {
 		}
 	}
 }
-
 
 // TestRunSandboxBuildRejectsPodman is the CLI-surface regression test for
 // #1051: passing --runtime=podman to `sandbox build` must surface the

--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -23,7 +23,7 @@ func runSandbox(args []string, registry *launch.Registry, stdout, stderr io.Writ
 	}
 	switch args[0] {
 	case "init":
-		return runSandboxInit(args[1:], registry, stdout, stderr)
+		return runSandboxInit(args[1:], stdout, stderr)
 	case "plan":
 		return runSandboxPlan(args[1:], stdout, stderr)
 	case "build":
@@ -37,21 +37,15 @@ func runSandbox(args []string, registry *launch.Registry, stdout, stderr io.Writ
 	}
 }
 
-func runSandboxInit(args []string, registry *launch.Registry, stdout, stderr io.Writer) int {
+func runSandboxInit(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("sandbox init", flag.ContinueOnError)
 	flags.SetOutput(stderr)
-	force := flags.Bool("force", false, "Overwrite existing .devcontainer files")
-	agent := flags.String("agent", sandboxcomposition.DefaultAgent, "Agent CLI to scaffold the install recipe for")
+	force := flags.Bool("force", false, "Overwrite an existing .devcontainer/devcontainer.json")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
 	if flags.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: aileron sandbox init [--force] [--agent=<name>]")
-		return 1
-	}
-	if _, ok := registry.Get(*agent); !ok {
-		fmt.Fprintf(stderr, "unknown agent: %q\n", *agent)
-		fmt.Fprintf(stderr, "available agents: %s\n", strings.Join(registry.Names(), ", "))
+		fmt.Fprintln(stderr, "usage: aileron sandbox init [--force]")
 		return 1
 	}
 	cwd, err := os.Getwd()
@@ -63,15 +57,12 @@ func runSandboxInit(args []string, registry *launch.Registry, stdout, stderr io.
 		WorkDir: cwd,
 		Version: version.Version,
 		Force:   *force,
-		Agent:   *agent,
 	})
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
 	fmt.Fprintf(stdout, "created %s\n", result.DevcontainerPath)
-	fmt.Fprintf(stdout, "created %s\n", result.DockerfilePath)
-	fmt.Fprintf(stdout, "agent: %s\n", *agent)
 	return 0
 }
 

--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -91,7 +91,7 @@ This ADR follows the updated sandbox runtime direction:
 
 ## CLI surface
 
-`aileron sandbox init` scaffolds a Feature-composing `.devcontainer/devcontainer.json` for the customization tier. The scaffold lists `aileron/sandbox-base:<version>` as the base image and an agent Feature plus an optional customer-tooling Feature under `features`, so users compose their own tooling alongside the agent through standard devcontainer workflows. Under the Feature model `init` no longer scaffolds a per-agent `.devcontainer/Dockerfile`, and the `--agent` flag is removed because the agent is selected by the listed Feature rather than a baked recipe. The `init` reposition and the `--agent` removal land in [#1084](https://github.com/ALRubinger/aileron/issues/1084).
+`aileron sandbox init` scaffolds a Feature-composing `.devcontainer/devcontainer.json` for the customization tier. The scaffold lists `aileron/sandbox-base:<version>` as the base image and an agent Feature plus an optional customer-tooling Feature under `features`, so users compose their own tooling alongside the agent through standard devcontainer workflows. Under the Feature model `init` no longer scaffolds a per-agent `.devcontainer/Dockerfile`, and the `--agent` flag is removed because the agent is selected by the listed Feature rather than a baked recipe.
 
 `aileron sandbox plan` is an inspection helper that reports the normalized tier/image/dockerfile plan, including a `features:` summary line listing the parsed Feature references when the devcontainer declares any.
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -21,7 +21,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 
 | Command | Purpose | Ratified by |
 |---|---|---|
-| `aileron sandbox init [--agent=<name>] [--force]` | Scaffold `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile` for sandbox composition. The Dockerfile extends `aileron/sandbox-base:<version>`, pre-fills the install recipe for `--agent` (defaults to `claude`), and ships additional tool snippets commented out. | [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron sandbox init [--force]` | Scaffold a Feature-composing `.devcontainer/devcontainer.json` for Tier 1 sandbox composition. It sets `aileron/sandbox-base:<version>` as the base image, lists the Claude agent Feature as the worked example, and shows a commented customer-tooling Feature slot. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox plan` | Inspect the normalized composition tier and image Aileron infers from the current project. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox build` | Build the Tier 0 sandbox-base image or Tier 1 devcontainer image with Docker. Tier 2 BYO images are reported without build or injection. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox check [--runtime=auto\|docker] [--build=auto\|always\|never] --agent=<command>` | Validate that the selected sandbox image can launch an agent command before starting a session. | [ADR-0017](/adr/0017-sandbox-composition) |

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -18,15 +18,24 @@ This page covers the user-facing workflow. Runtime launch support can scaffold, 
 
 ## Scaffold a Starter Devcontainer
 
-Tier 1 is the customization tier. You reach for it when you want Aileron's base image plus an agent plus your own project tools in one sandbox. The recorded model ([ADR-0017](/adr/0017-sandbox-composition/)) is that `aileron sandbox init` scaffolds a Feature-composing `.devcontainer/devcontainer.json` rather than a per-agent Dockerfile:
+Tier 1 is the customization tier. You reach for it when you want Aileron's base image plus an agent plus your own project tools in one sandbox. `aileron sandbox init` scaffolds a Feature-composing `.devcontainer/devcontainer.json` ([ADR-0017](/adr/0017-sandbox-composition/)). It writes only that file. It does not write a per-agent Dockerfile, and it takes no agent flag:
+
+```bash
+aileron sandbox init
+```
+
+The scaffold composes the base image with the Claude agent Feature as the worked example, and demonstrates a commented customer-tooling Feature slot:
 
 ```jsonc
 {
   "name": "Aileron sandbox",
   "image": "aileron/sandbox-base:<version>",
   "features": {
-    "ghcr.io/alrubinger/aileron-features/<agent>:1": {},
-    "ghcr.io/acme/internal-tools:1": {}
+    // The agent Feature installs the agent CLI onto the base image. Swap
+    // "claude" for another published agent (e.g. "codex"), or list several.
+    "ghcr.io/alrubinger/aileron-features/claude:1": {}
+    // Add your own tooling as its own Feature alongside the agent Feature:
+    // "ghcr.io/acme/internal-tools:1": {}
   },
   "customizations": {
     "aileron": {
@@ -37,9 +46,7 @@ Tier 1 is the customization tier. You reach for it when you want Aileron's base 
 }
 ```
 
-The agent is selected by the agent Feature you list, and your own tooling is its own Feature alongside it. The same agent Feature is the single source of truth that Aileron CI bakes into the prebuilt per-agent images ([#965](https://github.com/ALRubinger/aileron/issues/965)), so the customization tier and the zero-build default share one install recipe per agent.
-
-The `sandbox init` reposition to scaffold this Feature-composing devcontainer, and the removal of the per-agent Dockerfile and the `--agent` flag, are implemented in [#1084](https://github.com/ALRubinger/aileron/issues/1084). The `features`-composing build path is implemented in [#1083](https://github.com/ALRubinger/aileron/issues/1083).
+The agent is selected by the agent Feature you list, and your own tooling is its own Feature alongside it. Swap the agent reference or uncomment the tooling slot to suit your project. The same agent Feature is the single source of truth that Aileron CI bakes into the prebuilt per-agent images ([#965](https://github.com/ALRubinger/aileron/issues/965)), so the customization tier and the zero-build default share one install recipe per agent. The `features`-composing build path is implemented in [#1083](https://github.com/ALRubinger/aileron/issues/1083).
 
 ## Inspect the Plan
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -224,6 +224,7 @@ golang.org/x/mod v0.17.0/go.mod h1:hTbmBsO62+eylJbnUtE2MGJUyE7QWk4xUqPFrRgJ+7c=
 golang.org/x/mod v0.21.0/go.mod h1:6SkKJ3Xj0I0BrPOZoBy3bdMptDDU9oJrpohJ3eWZ1fY=
 golang.org/x/mod v0.34.0/go.mod h1:ykgH52iCZe79kzLLMhyCUzhMci+nQj+0XkbXpNYtVjY=
 golang.org/x/mod v0.35.0/go.mod h1:+GwiRhIInF8wPm+4AoT6L0FA1QWAad3OMdTRx4tFYlU=
+golang.org/x/mod v0.36.0/go.mod h1:moc6ELqsWcOw5Ef3xVprK5ul/MvtVvkIXLziUOICjUQ=
 golang.org/x/net v0.0.0-20190327091125-710a502c58a2/go.mod h1:t9HGtf8HONx5eT2rtn7q6eTqICYqUVnKs3thJo3Qplg=
 golang.org/x/net v0.0.0-20211015210444-4f30a5c0130f/go.mod h1:9nx3DQGgdP8bBQD5qxJ1jj9UTztislL4KSBs9R2vV5Y=
 golang.org/x/net v0.37.0/go.mod h1:ivrbrMbzFq5J41QOQh0siUuly180yBYtLp+CKbEaFx8=

--- a/internal/sandbox/composition/composition.go
+++ b/internal/sandbox/composition/composition.go
@@ -14,10 +14,17 @@ import (
 const (
 	// DefaultDevcontainerPath is the canonical project-local devcontainer file.
 	DefaultDevcontainerPath = ".devcontainer/devcontainer.json"
-	// DefaultDockerfilePath is the starter Dockerfile path scaffolded by Aileron.
+	// DefaultDockerfilePath is the conventional Dockerfile path Discover assumes
+	// for a hand-authored Tier 1 devcontainer that declares a build without
+	// naming a dockerfile. `sandbox init` no longer scaffolds this file.
 	DefaultDockerfilePath = ".devcontainer/Dockerfile"
 	// DefaultBaseImageRepository is the image Aileron owns for Tier 0 and Tier 1.
 	DefaultBaseImageRepository = "aileron/sandbox-base"
+	// DefaultFeatureRepository is the registry path that hosts Aileron's
+	// per-agent devcontainer Features. The scaffold composes one of these
+	// Features (see FeatureReference) into the starter devcontainer.json, and
+	// the same Features are baked into the prebuilt per-agent images (#965).
+	DefaultFeatureRepository = "ghcr.io/alrubinger/aileron-features"
 )
 
 // Tier describes how a sandbox image should be composed.

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -164,124 +164,51 @@ func TestParseDevcontainerRejectsUnterminatedBlockComment(t *testing.T) {
 	}
 }
 
-func TestInitWritesStarterDevcontainerAndDockerfile(t *testing.T) {
+func TestInitWritesFeatureComposingDevcontainer(t *testing.T) {
 	dir := t.TempDir()
 	result, err := Init(InitOptions{WorkDir: dir, Version: "0.4.0"})
 	if err != nil {
 		t.Fatalf("Init: %v", err)
 	}
-	if result.DevcontainerPath != DefaultDevcontainerPath || result.DockerfilePath != DefaultDockerfilePath {
-		t.Fatalf("result = %+v", result)
+	if result.DevcontainerPath != DefaultDevcontainerPath {
+		t.Fatalf("DevcontainerPath = %q, want %q", result.DevcontainerPath, DefaultDevcontainerPath)
 	}
-	dev, err := os.ReadFile(filepath.Join(dir, DefaultDevcontainerPath))
+	// init no longer writes a per-agent Dockerfile.
+	if _, err := os.Stat(filepath.Join(dir, DefaultDockerfilePath)); !os.IsNotExist(err) {
+		t.Fatalf("init should not write a Dockerfile: stat err = %v", err)
+	}
+
+	// Assert on the produced config shape via Discover (the contract), not on
+	// the raw scaffold text.
+	plan, err := Discover(dir, "0.4.0")
 	if err != nil {
-		t.Fatalf("read devcontainer: %v", err)
+		t.Fatalf("Discover scaffolded devcontainer: %v", err)
 	}
-	if !strings.Contains(string(dev), `"customizations"`) || !strings.Contains(string(dev), `"aileron"`) {
-		t.Fatalf("devcontainer missing Aileron customization:\n%s", string(dev))
+	if plan.Tier != TierDevcontainer {
+		t.Fatalf("Tier = %s, want %s", plan.Tier, TierDevcontainer)
 	}
-	dockerfile, err := os.ReadFile(filepath.Join(dir, DefaultDockerfilePath))
-	if err != nil {
-		t.Fatalf("read Dockerfile: %v", err)
+	if plan.Image != "aileron/sandbox-base:0.4.0" {
+		t.Fatalf("Image = %q, want the base image", plan.Image)
 	}
-	if !strings.Contains(string(dockerfile), "FROM aileron/sandbox-base:0.4.0") {
-		t.Fatalf("Dockerfile =\n%s", string(dockerfile))
+	// Exactly one active Feature: the default agent Feature. The customer
+	// tooling slot is commented out, so Discover must not see it.
+	if len(plan.Features) != 1 {
+		t.Fatalf("Features = %#v, want exactly one active feature", plan.Features)
 	}
-	for _, line := range strings.Split(string(dockerfile), "\n") {
-		trimmed := strings.TrimLeft(line, "# ")
-		if strings.HasPrefix(trimmed, "RUN ") && strings.Contains(trimmed, "apt-get") {
-			t.Fatalf("Dockerfile snippets must use apk against the Alpine base, not apt-get:\n%s", string(dockerfile))
-		}
+	if _, ok := plan.Features[FeatureReference("claude")]; !ok {
+		t.Fatalf("Features missing %q: %#v", FeatureReference("claude"), plan.Features)
 	}
-	for _, snippet := range []string{"--- GitHub CLI ---", "--- Node.js ---", "--- Python ---", "--- kubectl ---", "--- Terraform ---"} {
-		if !strings.Contains(string(dockerfile), snippet) {
-			t.Fatalf("Dockerfile missing menu snippet %q:\n%s", snippet, string(dockerfile))
-		}
+	if plan.Aileron.Mediation != "default" {
+		t.Fatalf("Aileron.Mediation = %q, want default", plan.Aileron.Mediation)
+	}
+	if plan.Aileron.ApprovalSurface != "both" {
+		t.Fatalf("Aileron.ApprovalSurface = %q, want both", plan.Aileron.ApprovalSurface)
 	}
 }
 
-func TestInitDefaultsToClaudeRecipeReadyToBuild(t *testing.T) {
-	dir := t.TempDir()
-	if _, err := Init(InitOptions{WorkDir: dir, Version: "0.4.0"}); err != nil {
-		t.Fatalf("Init: %v", err)
-	}
-	dockerfile, err := os.ReadFile(filepath.Join(dir, DefaultDockerfilePath))
-	if err != nil {
-		t.Fatalf("read Dockerfile: %v", err)
-	}
-	body := string(dockerfile)
-	for _, want := range []string{
-		"\nUSER root\n",
-		"\nUSER agent\n",
-		"--- Claude Code ---",
-		"npm install -g @anthropic-ai/claude-code",
-	} {
-		if !strings.Contains(body, want) {
-			t.Fatalf("default Dockerfile missing %q:\n%s", want, body)
-		}
-	}
-	// The Claude install RUN must NOT be commented out — that was the
-	// pre-#963 footgun.
-	for _, line := range strings.Split(body, "\n") {
-		if strings.Contains(line, "@anthropic-ai/claude-code") && strings.HasPrefix(strings.TrimSpace(line), "#") {
-			t.Fatalf("Claude install RUN should be uncommented:\n%s", body)
-		}
-	}
-}
-
-func TestInitWithCodexRecipeReadyToBuild(t *testing.T) {
-	dir := t.TempDir()
-	if _, err := Init(InitOptions{WorkDir: dir, Version: "0.4.0", Agent: "codex"}); err != nil {
-		t.Fatalf("Init: %v", err)
-	}
-	dockerfile, err := os.ReadFile(filepath.Join(dir, DefaultDockerfilePath))
-	if err != nil {
-		t.Fatalf("read Dockerfile: %v", err)
-	}
-	body := string(dockerfile)
-	for _, want := range []string{
-		"\nUSER root\n",
-		"\nUSER agent\n",
-		"--- Codex ---",
-		"npm install -g @openai/codex",
-	} {
-		if !strings.Contains(body, want) {
-			t.Fatalf("codex Dockerfile missing %q:\n%s", want, body)
-		}
-	}
-	if strings.Contains(body, "@anthropic-ai/claude-code") {
-		t.Fatalf("codex Dockerfile should not include the Claude recipe:\n%s", body)
-	}
-	// The Codex install RUN must NOT be commented out.
-	for _, line := range strings.Split(body, "\n") {
-		if strings.Contains(line, "@openai/codex") && strings.HasPrefix(strings.TrimSpace(line), "#") {
-			t.Fatalf("Codex install RUN should be uncommented:\n%s", body)
-		}
-	}
-}
-
-func TestInitWithUnknownAgentEmitsTODOStub(t *testing.T) {
-	dir := t.TempDir()
-	if _, err := Init(InitOptions{WorkDir: dir, Version: "0.4.0", Agent: "frobnicate"}); err != nil {
-		t.Fatalf("Init: %v", err)
-	}
-	dockerfile, err := os.ReadFile(filepath.Join(dir, DefaultDockerfilePath))
-	if err != nil {
-		t.Fatalf("read Dockerfile: %v", err)
-	}
-	body := string(dockerfile)
-	for _, want := range []string{
-		"\nUSER root\n",
-		"\nUSER agent\n",
-		"TODO: install the frobnicate CLI",
-		"sandbox-agent-images",
-	} {
-		if !strings.Contains(body, want) {
-			t.Fatalf("frobnicate Dockerfile missing %q:\n%s", want, body)
-		}
-	}
-	if strings.Contains(body, "@anthropic-ai/claude-code") {
-		t.Fatalf("frobnicate Dockerfile should not include the Claude recipe:\n%s", body)
+func TestFeatureReferenceNamesPublishedFeature(t *testing.T) {
+	if got, want := FeatureReference("claude"), DefaultFeatureRepository+"/claude:1"; got != want {
+		t.Fatalf("FeatureReference = %q, want %q", got, want)
 	}
 }
 
@@ -299,24 +226,24 @@ func TestInitDoesNotOverwriteWithoutForce(t *testing.T) {
 	}
 }
 
-func TestInitForceOverwritesExistingFiles(t *testing.T) {
+func TestInitForceOverwritesExistingDevcontainer(t *testing.T) {
 	dir := t.TempDir()
 	if _, err := Init(InitOptions{WorkDir: dir}); err != nil {
 		t.Fatalf("first Init: %v", err)
 	}
-	path := filepath.Join(dir, DefaultDockerfilePath)
+	path := filepath.Join(dir, DefaultDevcontainerPath)
 	if err := os.WriteFile(path, []byte("custom"), 0o644); err != nil {
-		t.Fatalf("write custom Dockerfile: %v", err)
+		t.Fatalf("write custom devcontainer: %v", err)
 	}
 	if _, err := Init(InitOptions{WorkDir: dir, Force: true, Version: "0.4.0"}); err != nil {
 		t.Fatalf("force Init: %v", err)
 	}
 	got, err := os.ReadFile(path)
 	if err != nil {
-		t.Fatalf("read Dockerfile: %v", err)
+		t.Fatalf("read devcontainer: %v", err)
 	}
 	if string(got) == "custom" {
-		t.Fatal("Dockerfile was not overwritten")
+		t.Fatal("devcontainer was not overwritten")
 	}
 }
 

--- a/internal/sandbox/composition/recipes.go
+++ b/internal/sandbox/composition/recipes.go
@@ -4,14 +4,12 @@ package composition
 // the Aileron Alpine sandbox base. It names the apk prerequisites and the
 // global npm package that puts the agent's CLI on PATH.
 //
-// This table is the single source of truth for the recipe *content* shared by
-// two consumers:
-//
-//   - agentInstallSnippet (scaffold.go), which still emits an inline Dockerfile
-//     snippet for `aileron sandbox init` until #1084 swaps the scaffold to
-//     reference the published Feature.
-//   - the devcontainer Features under images/sandbox-features/<agent>/, whose
-//     install.sh scripts express the same recipe.
+// This table is the single source of truth for the recipe *content* consumed
+// by the devcontainer Features under images/sandbox-features/<agent>/, whose
+// install.sh scripts express the same recipe. The `aileron sandbox init`
+// scaffold no longer emits an inline Dockerfile snippet; it references the
+// published Feature directly (see FeatureReference in scaffold.go), so the
+// recipe table now feeds only the Features.
 //
 // features_test.go asserts the Feature install.sh scripts agree with this
 // table, so any drift between the two fails CI.
@@ -26,8 +24,7 @@ type agentRecipe struct {
 }
 
 // agentRecipes maps an agent id to its canonical install recipe. Agents absent
-// from this map have no verified Tier 1 recipe and fall back to the TODO stub
-// in agentInstallSnippet.
+// from this map have no verified Tier 1 recipe and ship no published Feature.
 var agentRecipes = map[string]agentRecipe{
 	"claude": {
 		Prereqs:    []string{"git", "nodejs", "npm", "ripgrep"},

--- a/internal/sandbox/composition/scaffold.go
+++ b/internal/sandbox/composition/scaffold.go
@@ -5,13 +5,13 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
-// DefaultAgent is the agent the scaffold targets when --agent is omitted.
-// Claude Code and Codex have documented Tier 1 install recipes today (see
-// docs/development/sandbox-agent-images.md); other agents emit a
-// structurally correct Dockerfile with a TODO install stub.
+// DefaultAgent is the agent whose Feature the scaffold demonstrates. It is no
+// longer selectable from the CLI; `aileron sandbox init` always emits the
+// Claude Feature as the worked example of the compose model, and customers
+// swap or add Feature references by hand. Claude Code and Codex have published
+// agent Features today (see docs/development/sandbox-agent-images.md).
 const DefaultAgent = "claude"
 
 // InitOptions configures the sandbox scaffold operation.
@@ -19,16 +19,17 @@ type InitOptions struct {
 	WorkDir string
 	Version string
 	Force   bool
-	Agent   string
 }
 
 // InitResult reports which files were written.
 type InitResult struct {
 	DevcontainerPath string
-	DockerfilePath   string
 }
 
-// Init writes the starter devcontainer scaffold for sandbox composition.
+// Init writes the starter devcontainer scaffold for sandbox composition. The
+// scaffold composes the Aileron base image with a per-agent Feature, which is
+// the Tier 1 customization model recorded in ADR-0017. It no longer writes a
+// per-agent Dockerfile; the zero-build per-agent-image flow is owned by #965.
 func Init(opts InitOptions) (InitResult, error) {
 	workDir := opts.WorkDir
 	if workDir == "" {
@@ -36,38 +37,45 @@ func Init(opts InitOptions) (InitResult, error) {
 	}
 	dir := filepath.Join(workDir, ".devcontainer")
 	devcontainerPath := filepath.Join(workDir, DefaultDevcontainerPath)
-	dockerfilePath := filepath.Join(workDir, DefaultDockerfilePath)
 	if err := os.MkdirAll(dir, 0o755); err != nil {
 		return InitResult{}, fmt.Errorf("create %s: %w", dir, err)
 	}
-	for _, path := range []string{devcontainerPath, dockerfilePath} {
-		if _, err := os.Stat(path); err == nil && !opts.Force {
-			return InitResult{}, fmt.Errorf("%s already exists (use --force to overwrite)", path)
-		} else if err != nil && !errors.Is(err, os.ErrNotExist) {
-			return InitResult{}, fmt.Errorf("stat %s: %w", path, err)
-		}
+	if _, err := os.Stat(devcontainerPath); err == nil && !opts.Force {
+		return InitResult{}, fmt.Errorf("%s already exists (use --force to overwrite)", devcontainerPath)
+	} else if err != nil && !errors.Is(err, os.ErrNotExist) {
+		return InitResult{}, fmt.Errorf("stat %s: %w", devcontainerPath, err)
 	}
-	if err := os.WriteFile(devcontainerPath, []byte(starterDevcontainer()), 0o644); err != nil {
+	if err := os.WriteFile(devcontainerPath, []byte(starterDevcontainer(opts.Version)), 0o644); err != nil {
 		return InitResult{}, fmt.Errorf("write %s: %w", devcontainerPath, err)
 	}
-	agent := opts.Agent
-	if agent == "" {
-		agent = DefaultAgent
-	}
-	if err := os.WriteFile(dockerfilePath, []byte(starterDockerfile(opts.Version, agent)), 0o644); err != nil {
-		return InitResult{}, fmt.Errorf("write %s: %w", dockerfilePath, err)
-	}
-	return InitResult{
-		DevcontainerPath: DefaultDevcontainerPath,
-		DockerfilePath:   DefaultDockerfilePath,
-	}, nil
+	return InitResult{DevcontainerPath: DefaultDevcontainerPath}, nil
 }
 
-func starterDevcontainer() string {
-	return `{
+// FeatureReference returns the canonical devcontainer Feature reference for an
+// agent (e.g. "ghcr.io/alrubinger/aileron-features/claude:1"). It is the one
+// place in Go that names the Feature registry path and tag, mirroring the
+// BaseImage helper for the base image. The same reference identifies the
+// Features authored under images/sandbox-features/<agent>/ and composed by the
+// Tier 1 build path (#1083).
+func FeatureReference(agent string) string {
+	return DefaultFeatureRepository + "/" + agent + ":1"
+}
+
+// starterDevcontainer emits the Feature-composing devcontainer.json recorded in
+// docs/development/sandbox-composition.md. It composes the Aileron base image
+// with the default agent Feature and demonstrates the customer-tooling slot as
+// a commented Feature so `Discover` parses exactly one active Feature. JSONC
+// comments are valid here because Discover strips them before parsing.
+func starterDevcontainer(version string) string {
+	return fmt.Sprintf(`{
   "name": "Aileron sandbox",
-  "build": {
-    "dockerfile": "Dockerfile"
+  "image": %q,
+  "features": {
+    // The agent Feature installs the agent CLI onto the base image. Swap
+    // "claude" for another published agent (e.g. "codex"), or list several.
+    %q: {}
+    // Add your own tooling as its own Feature alongside the agent Feature:
+    // "ghcr.io/acme/internal-tools:1": {}
   },
   "customizations": {
     "aileron": {
@@ -76,77 +84,5 @@ func starterDevcontainer() string {
     }
   }
 }
-`
-}
-
-func starterDockerfile(version, agent string) string {
-	return fmt.Sprintf(`FROM %s
-
-# Aileron's base image is Alpine-based and runs as the non-root "agent"
-# user. Switch to root to install tools, then switch back to agent before
-# launch. All install snippets use apk; do not use apt-get here.
-
-USER root
-
-%s
-
-# Uncomment additional tool snippets below as needed. Keep rarely
-# changing snippets earlier for better layer caching.
-#
-# # --- GitHub CLI ---
-# RUN apk add --no-cache github-cli
-#
-# # --- Node.js ---
-# RUN apk add --no-cache nodejs npm
-#
-# # --- Python ---
-# RUN apk add --no-cache python3 py3-pip
-#
-# # --- kubectl ---
-# RUN apk add --no-cache kubectl
-#
-# # --- Terraform ---
-# RUN apk add --no-cache terraform
-
-USER agent
-`, BaseImage(version), agentInstallSnippet(agent))
-}
-
-// agentInstallSnippet returns the install recipe for agent. Agents with
-// a documented Tier 1 recipe are pre-filled and uncommented; agents
-// without one get a TODO stub that still produces a buildable Dockerfile
-// once the user fills it in.
-//
-// The Claude/Codex snippets are derived from the canonical agentRecipes
-// table (recipes.go), which is also the source of truth for the devcontainer
-// Features under images/sandbox-features/<agent>/. There is exactly one place
-// that names the apk prerequisites and the npm package per agent.
-func agentInstallSnippet(agent string) string {
-	if recipe, ok := recipeForAgent(agent); ok {
-		return fmt.Sprintf(`# --- %s ---
-RUN apk add --no-cache %s && \
-    npm install -g %s`,
-			agentSnippetLabel(agent),
-			strings.Join(recipe.Prereqs, " "),
-			recipe.NPMPackage)
-	}
-	return fmt.Sprintf(`# --- TODO: install the %s CLI ---
-# Aileron does not yet ship a verified install recipe for %s.
-# Replace this stub with an install that puts %q on PATH and uses apk
-# against the Alpine base. See:
-#   https://docs.withaileron.ai/development/sandbox-agent-images/
-# RUN apk add --no-cache ...`, agent, agent, agent)
-}
-
-// agentSnippetLabel returns the human-facing heading for an agent's Dockerfile
-// install snippet (e.g. "Claude Code"). Falls back to the agent id.
-func agentSnippetLabel(agent string) string {
-	switch agent {
-	case "claude":
-		return "Claude Code"
-	case "codex":
-		return "Codex"
-	default:
-		return agent
-	}
+`, BaseImage(version), FeatureReference(DefaultAgent))
 }


### PR DESCRIPTION
## Summary

- Reposition `aileron sandbox init` from scaffolding a per-agent `.devcontainer/Dockerfile` to scaffolding a Feature-composing `.devcontainer/devcontainer.json` for the Tier 1 customization tier (ADR-0017). The scaffold sets `aileron/sandbox-base:<version>` as the base image, lists the Claude agent Feature as the worked example, and shows a commented customer-tooling Feature slot.
- Remove the `--agent` flag with no deprecation. An unknown flag now fails `flag.Parse`, surfacing the new `usage: aileron sandbox init [--force]`. `InitOptions.Agent`, `InitResult.DockerfilePath`, and the `starterDockerfile`/`agentInstallSnippet`/`agentSnippetLabel` helpers are deleted.
- Name the Feature reference once: add `FeatureReference(agent)` and `DefaultFeatureRepository` to the composition package, mirroring the existing `BaseImage(version)` pattern (`ghcr.io/alrubinger/aileron-features/<agent>:1`).
- `recipes.go` and its `agentRecipes` table stay (still consumed by the Feature install.sh drift guard in `features_test.go`); only the doc comments are updated.
- The Tier 1 build path (`runtime.go` Dockerfile resolution for hand-authored devcontainers) is unchanged. This slice only changes what `init` writes.
- Docs aligned: `sandbox-composition.md`, `cli/index.md`, and ADR-0017 present-tense the shipped scaffold and the `--agent` removal. The zero-build per-agent-image flow remains forward-referenced to #965.

## Test plan

- [x] `go test ./sandbox/composition/...` (internal module) — new `TestInitWritesFeatureComposingDevcontainer` round-trips the scaffold through `Discover`, asserting Tier 1, the base image, exactly one active Feature (`FeatureReference("claude")`), and the `customizations.aileron` block. `TestFeatureReferenceNamesPublishedFeature` pins the reference. Force-overwrite and already-exists paths covered.
- [x] `go test ./...` (cmd/aileron module) — `TestRunSandboxInitCreatesDevcontainerScaffold` asserts the Dockerfile is NOT written; new `TestRunSandboxInitRejectsAgentFlag` asserts `--agent=...` exits 1 with the flag error and writes no scaffold.
- [x] `gofmt -l` clean, `go vet` clean on both modules.
- [x] Composition package coverage 91.3%; the only uncovered `Init` lines are the `MkdirAll`/non-`NotExist` stat error wraps (environment-failure defensive paths, uncovered before this change too).

Closes #1084

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified `sandbox init` command: removed `--agent` flag parameter; now scaffolds `.devcontainer/devcontainer.json` with Feature-based agent composition (defaults to Claude).

* **Documentation**
  * Updated CLI and development guides to reflect the streamlined sandbox initialization workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->