### PR TITLE
test: unbreak main after #1084 — scaffold launch test + flaky MCP approval-chain

### DIFF
--- a/internal/app/sandbox_mcp_test.go
+++ b/internal/app/sandbox_mcp_test.go
@@ -718,19 +718,24 @@ func TestSandboxMCP_Approval_RoundTripsWithApprovedDecide(t *testing.T) {
 	waitForChain(t, h.auditStore, sessionID, model.EventTypeExecutionSucceeded, 5*time.Second)
 
 	chain := eventChainForSession(t, h.auditStore, sessionID)
-	want := []model.EventType{
-		model.EventTypeApprovalRequested,
-		model.EventTypeApprovalApproved,
-		model.EventTypeExecutionStarted,
-		model.EventTypeExecutionSucceeded,
+	if len(chain) != 4 {
+		t.Fatalf("event chain = %v; want 4 events (approval.requested, approval.approved, execution.started, execution.succeeded)", chain)
 	}
-	if len(chain) != len(want) {
-		t.Fatalf("event chain = %v; want %v", chain, want)
+	// approval.requested is always first and execution.succeeded always last.
+	// The middle pair (approval.approved from the Decide path, execution.started
+	// from the background executor goroutine) is emitted from two goroutines with
+	// no guaranteed audit-write ordering, so assert it as an unordered set rather
+	// than a fixed sequence. Approval still causally precedes execution; only the
+	// two log writes may interleave.
+	if chain[0] != model.EventTypeApprovalRequested {
+		t.Errorf("chain[0] = %s; want %s", chain[0], model.EventTypeApprovalRequested)
 	}
-	for i, w := range want {
-		if chain[i] != w {
-			t.Errorf("chain[%d] = %s; want %s", i, chain[i], w)
-		}
+	if chain[3] != model.EventTypeExecutionSucceeded {
+		t.Errorf("chain[3] = %s; want %s", chain[3], model.EventTypeExecutionSucceeded)
+	}
+	middle := map[model.EventType]bool{chain[1]: true, chain[2]: true}
+	if !middle[model.EventTypeApprovalApproved] || !middle[model.EventTypeExecutionStarted] {
+		t.Errorf("chain middle = [%s %s]; want {approval.approved, execution.started} in either order", chain[1], chain[2])
 	}
 }
 

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -856,11 +856,20 @@ func TestLaunch_SandboxScaffoldBuildsAndRuns(t *testing.T) {
 
 	binDir := t.TempDir()
 	argsFile := filepath.Join(dir, "docker-args.txt")
-	docker := filepath.Join(binDir, "docker")
-	script := "#!/bin/sh\nprintf '%s\\n' '---' >> " + argsFile + "\nprintf '%s\\n' \"$@\" >> " + argsFile + "\n"
-	if err := os.WriteFile(docker, []byte(script), 0o755); err != nil {
-		t.Fatal(err)
+	npxArgsFile := filepath.Join(dir, "npx-args.txt")
+	// The Feature-composing scaffold (no Dockerfile) builds through
+	// @devcontainers/cli, which the build path execs as `npx`. Validation and
+	// run still go through `docker`. Stub both so the launch wiring is asserted
+	// hermetically; a real Feature build is proven in the dedicated
+	// integration-sandbox-features job.
+	writeStub := func(name, dest string) {
+		script := "#!/bin/sh\nprintf '%s\\n' '---' >> " + dest + "\nprintf '%s\\n' \"$@\" >> " + dest + "\n"
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
 	}
+	writeStub("docker", argsFile)
+	writeStub("npx", npxArgsFile)
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
@@ -873,26 +882,31 @@ func TestLaunch_SandboxScaffoldBuildsAndRuns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("launch: %v", err)
 	}
+	image := sandboxcontainer.ProjectImageTag(dir)
+	// The Feature scaffold builds via @devcontainers/cli (npx), not docker build.
+	npxData, err := os.ReadFile(npxArgsFile)
+	if err != nil {
+		t.Fatalf("read npx args: %v", err)
+	}
+	for _, want := range []string{
+		"@devcontainers/cli@",
+		"build\n",
+		"--workspace-folder\n" + dir + "\n",
+		"--image-name\n" + image + "\n",
+	} {
+		if !strings.Contains(string(npxData), want) {
+			t.Fatalf("devcontainers/cli build call missing %q:\n%s", want, npxData)
+		}
+	}
 	data, err := os.ReadFile(argsFile)
 	if err != nil {
 		t.Fatalf("read docker args: %v", err)
 	}
 	calls := dropBakedInspectCalls(strings.Split(strings.TrimPrefix(string(data), "---\n"), "\n---\n"))
-	if len(calls) != 3 {
-		t.Fatalf("docker calls = %d, want build, validate, and run:\n%s", len(calls), data)
+	if len(calls) != 2 {
+		t.Fatalf("docker calls = %d, want validate and run (build runs via @devcontainers/cli):\n%s", len(calls), data)
 	}
-	buildCall, validateCall, runCall := calls[0], calls[1], calls[2]
-	image := sandboxcontainer.ProjectImageTag(dir)
-	dockerfile := filepath.Join(dir, ".devcontainer", "Dockerfile")
-	for _, want := range []string{
-		"build\n-t\n" + image + "\n",
-		"-f\n" + dockerfile + "\n",
-		"\n" + dir,
-	} {
-		if !strings.Contains(buildCall, want) {
-			t.Fatalf("build call missing %q:\n%s", want, buildCall)
-		}
-	}
+	validateCall, runCall := calls[0], calls[1]
 	for _, call := range []struct {
 		name string
 		args string


### PR DESCRIPTION
## Summary
Unbreaks `main` (commit `abef622`, the #1084 merge), which is red on two CI checks. Two test-only fixes.

### 1. `Unit Tests (rest)` regression — `internal/launch` (in-scope, from #1084)
`TestLaunch_SandboxScaffoldBuildsAndRuns` was not updated when #1084 repointed `sandbox init` to a Feature-composing `devcontainer.json`. With no Dockerfile, the Tier 1 build now routes through `@devcontainers/cli` (#1083) rather than `docker build`, but the test stubbed only `docker` and asserted the old Dockerfile build — so the **real** `npx @devcontainers/cli build` executed on the Go-only unit shard and failed (`No manifest found for aileron/sandbox-base:test`).

Fix: stub `npx` alongside `docker`; assert the build invokes the devcontainers/cli path (`build --workspace-folder --image-name`) while validate/run still go through `docker`. Stays hermetic and in the unit shard; the real Feature build is proven by the dedicated `integration-sandbox-features` job.

### 2. `Integration Tests (Go)` flake — `internal/app` (pre-existing, unrelated)
`TestSandboxMCP_Approval_RoundTripsWithApprovedDecide` asserted a fixed 4-event audit chain, but `approval.approved` (Decide path) and `execution.started` (background executor goroutine) are emitted from two goroutines with no guaranteed audit-write order. They intermittently swap, failing the test with no real defect (approval still causally precedes execution; only the log writes interleave).

Fix: pin `approval.requested` first and `execution.succeeded` last; assert the middle pair as an unordered set.

The product behavior (#1084 / #1083) is correct; only stale/over-strict tests needed updating.

## Test plan
- [x] `go test -race ./internal/launch/...` green
- [x] `go test -tags=integration_sandbox -race -count=3 -run TestSandboxMCP_Approval_RoundTripsWithApprovedDecide ./internal/app/...` green
- [ ] CI `Unit Tests (rest)` and `Integration Tests (Go)` green on this PR

Relates to umbrella #1080; follow-up to #1084 (#1117).