### PR TITLE
fix(docs): hydrate the OS install tabs so platform switching works

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -89,7 +89,7 @@ We're about to take your first flight with Aileron. In under 5 minutes, you'll b
       },
     ],
   },
-]} />
+]} client:load />
 
 Prefer to compile it yourself? See [Building from Source](/development/building-from-source/).
 


### PR DESCRIPTION
## Summary

The "Install Aileron" OS switcher on https://docs.withaileron.ai/getting-started/ shows nothing when you click **Windows** (or **Linux**). Root cause: the `OsInstallTabs` island is rendered **without a client directive**, so it ships as static SSR HTML with no hydration. The default macOS panel paints, but there is no client-side JS to switch panels, so every other tab is unreachable.

This is pre-existing (not introduced by the Scoop docs change #1097); #1097's content is in the DOM but you cannot navigate to it.

Fix: add `client:load` to the usage, exactly like the sibling `LiftoffPreflight` island on the same page (line 36). The component's `.astro` wrapper already renders the island with `client:load`; this page imports the `.svelte` directly and so had no directive.

## Verification

Built the docs (`task build:docs`, 123 pages) and inspected `dist/getting-started/index.html`:

- **Before:** the page had exactly one `client:load` island (LiftoffPreflight); `OsInstallTabs` emitted static markup, no `<astro-island>`.
- **After:** `OsInstallTabs` emits `<astro-island ... component-url=".../os-install-tabs.*.js" ... ssr client="load">` with the full platforms array (macOS, Linux deb/rpm/apk, Windows scoop+zip) in its props — i.e. it hydrates and tab switching works.

No lightweight unit test exists for Astro hydration directives, so this is verified by build-output inspection rather than an automated assertion. The interactive behavior is best confirmed on the Railway PR preview.

## Test plan

- [x] `task build:docs` succeeds.
- [x] Built HTML shows the `OsInstallTabs` island hydrated with `client:load`.
- [ ] On the PR preview, clicking **Windows** shows the Scoop tab (default) + Manual (.zip) tab; **Linux** shows deb/rpm/apk.

🤖 Generated with [Claude Code](https://claude.com/claude-code)