### PR TITLE
feat(sandbox): flag inert BYO features in plan; assert launchability in features e2e

### DIFF
--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -100,7 +100,14 @@ func runSandboxPlan(args []string, stdout, stderr io.Writer) int {
 			refs = append(refs, ref)
 		}
 		sort.Strings(refs)
-		fmt.Fprintf(stdout, "features: %s\n", strings.Join(refs, ", "))
+		// On a Tier 2 BYO image the features are parsed for inspection but never
+		// applied (the image is used as-is), so flag them as inert rather than
+		// implying they compose into the sandbox.
+		if plan.Tier == sandboxcomposition.TierBYOImage {
+			fmt.Fprintf(stdout, "features (ignored — BYO image): %s\n", strings.Join(refs, ", "))
+		} else {
+			fmt.Fprintf(stdout, "features: %s\n", strings.Join(refs, ", "))
+		}
 	}
 	return 0
 }

--- a/cmd/aileron/sandbox_test.go
+++ b/cmd/aileron/sandbox_test.go
@@ -47,6 +47,38 @@ func TestRunSandboxPlanPrintsFeatures(t *testing.T) {
 	}
 }
 
+func TestRunSandboxPlanFlagsFeaturesInertOnBYOImage(t *testing.T) {
+	dir := t.TempDir()
+	devDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	// A BYO image (customizations.aileron.image) with features: the image is
+	// used as-is, so the features are inert and must be flagged as such.
+	body := `{"customizations":{"aileron":{"image":"ghcr.io/acme/own:1"}},"features":{"ghcr.io/aileron/codex:1":{}}}`
+	if err := os.WriteFile(filepath.Join(devDir, "devcontainer.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write devcontainer.json: %v", err)
+	}
+	t.Chdir(dir)
+
+	var out, errb bytes.Buffer
+	if code := runSandboxPlan(nil, &out, &errb); code != 0 {
+		t.Fatalf("runSandboxPlan = %d, stderr: %s", code, errb.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "tier: byo_image") {
+		t.Fatalf("plan output missing BYO tier line:\n%s", got)
+	}
+	wantLine := "features (ignored — BYO image): ghcr.io/aileron/codex:1\n"
+	if !strings.Contains(got, wantLine) {
+		t.Fatalf("plan output missing %q:\n%s", wantLine, got)
+	}
+	// It must NOT print the unqualified "features:" line that implies they apply.
+	if strings.Contains(got, "features: ghcr.io/aileron/codex:1") {
+		t.Fatalf("BYO plan must not present features as applied:\n%s", got)
+	}
+}
+
 func TestSandboxCheckRequiresProxyTrust(t *testing.T) {
 	cases := []struct {
 		name      string

--- a/internal/app/sandbox_mcp_test.go
+++ b/internal/app/sandbox_mcp_test.go
@@ -1012,22 +1012,27 @@ func TestSandboxMCP_Concurrency_DistinctApprovalsAttributedCorrectly(t *testing.
 		t.Fatalf("Decide pending[0]: %v", err)
 	}
 
-	wantChain := []model.EventType{
-		model.EventTypeApprovalRequested,
-		model.EventTypeApprovalApproved,
-		model.EventTypeExecutionStarted,
-		model.EventTypeExecutionSucceeded,
-	}
 	for _, entry := range pending {
 		waitForApprovalChain(t, h.auditStore, entry.ID, model.EventTypeExecutionSucceeded, 5*time.Second)
 		chain := eventChainForApproval(t, h.auditStore, entry.ID)
-		if len(chain) != len(wantChain) {
-			t.Fatalf("approval %q chain = %v; want %v", entry.ID, chain, wantChain)
+		if len(chain) != 4 {
+			t.Fatalf("approval %q chain = %v; want 4 events (approval.requested, approval.approved, execution.started, execution.succeeded)", entry.ID, chain)
 		}
-		for i, w := range wantChain {
-			if chain[i] != w {
-				t.Errorf("approval %q chain[%d] = %s; want %s", entry.ID, i, chain[i], w)
-			}
+		// approval.requested is always first and execution.succeeded always last.
+		// The middle pair (approval.approved from the Decide path, execution.started
+		// from the background executor goroutine) is emitted from two goroutines
+		// with no guaranteed audit-write ordering, so assert it as an unordered set
+		// rather than a fixed sequence. Approval still causally precedes execution;
+		// only the two log writes may interleave.
+		if chain[0] != model.EventTypeApprovalRequested {
+			t.Errorf("approval %q chain[0] = %s; want %s", entry.ID, chain[0], model.EventTypeApprovalRequested)
+		}
+		if chain[3] != model.EventTypeExecutionSucceeded {
+			t.Errorf("approval %q chain[3] = %s; want %s", entry.ID, chain[3], model.EventTypeExecutionSucceeded)
+		}
+		middle := map[model.EventType]bool{chain[1]: true, chain[2]: true}
+		if !middle[model.EventTypeApprovalApproved] || !middle[model.EventTypeExecutionStarted] {
+			t.Errorf("approval %q chain middle = [%s %s]; want {approval.approved, execution.started} in either order", entry.ID, chain[1], chain[2])
 		}
 	}
 

--- a/internal/launch/sandbox_features_composition_integration_test.go
+++ b/internal/launch/sandbox_features_composition_integration_test.go
@@ -139,6 +139,16 @@ func TestSandboxFeaturesComposeViaAileron(t *testing.T) {
 	// RequireMCPBinary is false here because aileron-mcp is bind-mounted at
 	// launch (ADR-0024), not baked into the base image under test.
 	validateWorkspace := t.TempDir()
+	// The workspace is bind-mounted at /home/agent/workspace and the container
+	// runs as the non-root `agent` user, whose uid does not match the host uid
+	// that owns t.TempDir() (0700). On a Linux Docker host that makes the mount
+	// unwritable to `agent`, so Validate's writable-workspace probe fails; make
+	// it world-writable so the launchability check exercises the IMAGE contract,
+	// not host/container uid mapping. (Docker Desktop masks this with permissive
+	// file sharing, which is why it only surfaces on Linux CI.)
+	if err := os.Chmod(validateWorkspace, 0o777); err != nil {
+		t.Fatalf("chmod validate workspace: %v", err)
+	}
 	if err := builder.Validate(ctx, sandboxcontainer.ValidateOptions{
 		Runtime: rt,
 		Image:   result.Image,

--- a/internal/launch/sandbox_features_composition_integration_test.go
+++ b/internal/launch/sandbox_features_composition_integration_test.go
@@ -128,9 +128,25 @@ func TestSandboxFeaturesComposeViaAileron(t *testing.T) {
 		t.Fatalf("result.Image is empty")
 	}
 
-	// Both declared tools must resolve on PATH in the composed image.
-	assertCommandOnPath(ctx, t, rt, result.Image, "codex")
+	// The customer-tooling Feature's probe tool must resolve on PATH.
 	assertCommandOnPath(ctx, t, rt, result.Image, probeTool)
+
+	// Launchability: the composed image must satisfy the launch-time runtime
+	// contract, not merely carry the agent CLI on PATH. Builder.Validate runs
+	// the same probe the launcher uses — a writable /home/agent/workspace mount,
+	// CWD there, and the agent command resolvable — so the test reflects that a
+	// features-composed image is actually launchable, not just tool-on-PATH.
+	// RequireMCPBinary is false here because aileron-mcp is bind-mounted at
+	// launch (ADR-0024), not baked into the base image under test.
+	validateWorkspace := t.TempDir()
+	if err := builder.Validate(ctx, sandboxcontainer.ValidateOptions{
+		Runtime: rt,
+		Image:   result.Image,
+		WorkDir: validateWorkspace,
+		Command: []string{"codex"},
+	}); err != nil {
+		t.Fatalf("Builder.Validate (launchability of composed image): %v", err)
+	}
 }
 
 // writeProbeFeature authors a minimal local devcontainer Feature whose


### PR DESCRIPTION
## Summary
Resolves the #1083 plan-review residual (#1106). Both findings were non-P0.

- **`sandbox plan` BYO features display (P2).** On a Tier 2 BYO image, `features` are parsed for inspection but never applied. The plan now prints `features (ignored — BYO image): …` instead of an unqualified `features: …`. Unit-tested.
- **Feature-composition e2e launchability (P1).** `TestSandboxFeaturesComposeViaAileron` now drives `Builder.Validate` against the composed image (writable `/home/agent/workspace` mount, CWD there, agent on PATH), proving launchability rather than just `command -v`. `RequireMCPBinary` left false because `aileron-mcp` is bind-mounted at launch (ADR-0024).

### Incidental CI repair (to land this PR green)
- The e2e's `Validate` workspace is `chmod 0777`'d: on Linux CI the bind-mounted `t.TempDir()` (0700, runner uid) is unwritable to the in-container `agent` user; Docker Desktop masked it locally.
- `TestSandboxMCP_Concurrency_DistinctApprovalsAttributedCorrectly` had the same over-strict async event-ordering assertion fixed for the single-approval case in #1118; the middle `approval.approved`/`execution.started` pair is now asserted as an unordered set. (Pre-existing flake, unrelated to #1106, blocking this PR's `Integration Tests (Go)`.)

## Test plan
- [x] `go test ./cmd/aileron/...` green
- [x] `go test -tags=integration_sandbox -run TestSandboxFeaturesComposeViaAileron ./internal/launch/` green locally
- [x] `go test -tags=integration_sandbox -count=2 -run TestSandboxMCP_Concurrency... ./internal/app/` green
- [ ] CI green

Closes #1106. Relates to umbrella #1080.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * `sandbox plan` command now clearly distinguishes Bring Your Own Image cases in the output, marking features as "ignored — BYO image" rather than displaying them as active features.

* **Tests**
  * Added test coverage for BYO image feature handling.
  * Improved concurrent operation test assertions.
  * Enhanced feature composition integration test validation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->