### PR TITLE
fix(docs): render sidebar nav without waiting for hydration

### DIFF
--- a/docs/src/components/Sidebar.svelte
+++ b/docs/src/components/Sidebar.svelte
@@ -113,7 +113,7 @@
   style="background-image: var(--pattern-sidebar); background-repeat: repeat;"
 >
   <div class="p-4 flex flex-col h-full">
-    <nav class="flex-1 min-h-0 overflow-y-auto pr-4 -mr-4 flex flex-col gap-4 {mounted ? 'visible' : 'invisible'}" aria-label="Documentation">
+    <nav class="flex-1 min-h-0 overflow-y-auto pr-4 -mr-4 flex flex-col gap-4" aria-label="Documentation">
       {#each navigation as item}
         {#if isSection(item)}
           {@render section(item, 0)}
@@ -136,7 +136,7 @@
     </nav>
 
     <!-- External links pinned to the bottom of the sidebar. -->
-    <nav class="mt-6 shrink-0 bg-neutral-600 rounded-lg p-2 shadow-low {mounted ? 'visible' : 'invisible'}" aria-label="References">
+    <nav class="mt-6 shrink-0 bg-neutral-600 rounded-lg p-2 shadow-low" aria-label="References">
       {#each externalLinks as link}
         {@const active = currentPath === link.href || currentPath === link.href + '/'}
         {@const Icon = iconMap[link.label]}


### PR DESCRIPTION
## Summary

The docs sidebar appeared empty when viewed locally or on Railway branch deploys (production was unaffected). The nav tree is fully server-rendered into the static HTML, but `Sidebar.svelte` gated both nav blocks with `{mounted ? 'visible' : 'invisible'}`, hiding the content until the Svelte island hydrated in the browser. Wherever hydration was delayed or blocked, the sidebar stayed empty even though every link was already in the DOM.

This drops the visibility gate so the nav renders straight from the static HTML (progressive enhancement). `mounted` is kept for the expand/collapse `transition:slide` duration guard, which still suppresses the animation flash on first paint, so there is no dead code and no regression there.

## Test plan

- [x] `pnpm run build` — static HTML `<nav>` no longer carries `invisible` (only the intentional `lg:invisible` mobile-toggle button remains)
- [x] Headless Chrome against the built site: sidebar renders with all sections and hydration/interactivity still work
- [x] `pnpm run test` — 8/8 pass
- [x] `coderabbit review` — 0 findings

🤖 Generated with [Claude Code](https://claude.com/claude-code)