### PR TITLE
ci(sandbox): repoint sandbox-base default to GHCR

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,7 +682,7 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
-      # Builds the aileron/sandbox-base image from images/sandbox-base (the
+      # Builds the aileron-sandbox-base image from images/sandbox-base (the
       # test's Builder uses the AILERON_SANDBOX_BASE_CONTEXT the task target
       # sets), then: (#1082) composes each agent Feature directly with
       # @devcontainers/cli and asserts `command -v claude` / `command -v codex`,

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -21,7 +21,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 
 | Command | Purpose | Ratified by |
 |---|---|---|
-| `aileron sandbox init [--force]` | Scaffold a Feature-composing `.devcontainer/devcontainer.json` for Tier 1 sandbox composition. It sets `aileron/sandbox-base:<version>` as the base image, lists the Claude agent Feature as the worked example, and shows a commented customer-tooling Feature slot. | [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron sandbox init [--force]` | Scaffold a Feature-composing `.devcontainer/devcontainer.json` for Tier 1 sandbox composition. It sets `ghcr.io/alrubinger/aileron-sandbox-base:<version>` as the base image, lists the Claude agent Feature as the worked example, and shows a commented customer-tooling Feature slot. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox plan` | Inspect the normalized composition tier and image Aileron infers from the current project. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox build` | Build the Tier 0 sandbox-base image or Tier 1 devcontainer image with Docker. Tier 2 BYO images are reported without build or injection. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox check [--runtime=auto\|docker] [--build=auto\|always\|never] --agent=<command>` | Validate that the selected sandbox image can launch an agent command before starting a session. | [ADR-0017](/adr/0017-sandbox-composition) |

--- a/docs/src/content/docs/development/index.md
+++ b/docs/src/content/docs/development/index.md
@@ -14,7 +14,7 @@ If you're looking for end-user docs, the [Getting Started](/getting-started/) gu
 - [Binary Architecture](/development/binary-architecture/) — the four binaries Aileron ships, who calls whom, and which process owns which trust boundary.
 - [Building from Source](/development/building-from-source/) — prerequisites, the Taskfile entry points, and how the embedded assets (webapp, forwarder WASM) get folded in.
 - [Running Tests](/development/running-tests/) — unit, integration, race, coverage. What CI runs, and how to reproduce a CI failure locally.
-- [Sandbox Composition](/development/sandbox-composition/) — how Aileron uses devcontainer.json, `aileron/sandbox-base`, and `aileron sandbox` to define the agent container image.
+- [Sandbox Composition](/development/sandbox-composition/) — how Aileron uses devcontainer.json, `ghcr.io/alrubinger/aileron-sandbox-base`, and `aileron sandbox` to define the agent container image.
 - [Sandbox Agent Images](/development/sandbox-agent-images/) — which agent commands are supported by the selected sandbox image and how to check them before launch.
 - [Sandbox Connector Specs](/development/sandbox-connector-specs/) — how installed connector specs drive data-plane operation validation in sandboxed launch sessions.
 - [Sandbox Proxy CLI Verification Matrix](/development/sandbox-proxy-cli-matrix/) — verify the v4 HTTPS proxy works with `curl`, `gh`, and `aws`; success and failure cases with expected audit events.

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -30,11 +30,11 @@ Under `--sandbox=docker` the launcher resolves the host-built `aileron-mcp` bina
 
 Docker is the only supported sandbox runtime in v4. Podman is planned but not yet supported; its `host.containers.internal` host alias is the deferred re-add path, and passing `--runtime=podman` fails with `podman runtime is not supported yet (v4 is Docker-only); see ADR-0014` (see [ADR-0014](/adr/0014-spawn-sandbox-technology/)).
 
-The harness-free `aileron/sandbox-base` intentionally does not include agent CLIs ([ADR-0017](/adr/0017-sandbox-composition/)). Each agent install is authored once as a devcontainer Feature, the single source of truth that Aileron CI bakes into prebuilt per-agent images and that customers compose for Tier 1. The prebuilt per-agent image is the zero-build Tier 0 default, owned by [#965](https://github.com/ALRubinger/aileron/issues/965). Use Tier 1 when you want Aileron's base runtime plus an agent plus your own tools, or Tier 2 when your team owns the full image.
+The harness-free `ghcr.io/alrubinger/aileron-sandbox-base` intentionally does not include agent CLIs ([ADR-0017](/adr/0017-sandbox-composition/)). Each agent install is authored once as a devcontainer Feature, the single source of truth that Aileron CI bakes into prebuilt per-agent images and that customers compose for Tier 1. The prebuilt per-agent image is the zero-build Tier 0 default, owned by [#965](https://github.com/ALRubinger/aileron/issues/965). Use Tier 1 when you want Aileron's base runtime plus an agent plus your own tools, or Tier 2 when your team owns the full image.
 
 ## Claude Code Feature
 
-The Claude Code agent Feature installs the `claude` CLI onto `aileron/sandbox-base`. It is the single source of truth that Aileron CI bakes into the prebuilt Claude image and that you compose for Tier 1. The Feature lives at `images/sandbox-features/claude/` (`devcontainer-feature.json` plus `install.sh`).
+The Claude Code agent Feature installs the `claude` CLI onto `ghcr.io/alrubinger/aileron-sandbox-base`. It is the single source of truth that Aileron CI bakes into the prebuilt Claude image and that you compose for Tier 1. The Feature lives at `images/sandbox-features/claude/` (`devcontainer-feature.json` plus `install.sh`).
 
 For the Tier 0 zero-build path, launch the prebuilt image directly:
 
@@ -54,7 +54,7 @@ Claude Code still owns its own authentication flow. Do not bake Claude, Anthropi
 
 ## Codex Feature
 
-The Codex agent Feature installs the `codex` CLI onto `aileron/sandbox-base`. The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine base. Like the Claude Feature, it is baked into the prebuilt Codex image and composable for Tier 1. The Feature lives at `images/sandbox-features/codex/` (`devcontainer-feature.json` plus `install.sh`).
+The Codex agent Feature installs the `codex` CLI onto `ghcr.io/alrubinger/aileron-sandbox-base`. The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine base. Like the Claude Feature, it is baked into the prebuilt Codex image and composable for Tier 1. The Feature lives at `images/sandbox-features/codex/` (`devcontainer-feature.json` plus `install.sh`).
 
 For the Tier 0 zero-build path:
 
@@ -99,7 +99,7 @@ A BYO image meets the proxy contract by providing two helpers on `PATH`:
 | `aileron-install-proxy-ca` | Installs the mounted CA into the in-container trust store. Must accept `--check` to dry-run the trust-store probe without writing anything, and must accept an optional positional CA file argument (default `${AILERON_SANDBOX_PROXY_CA_FILE:-/etc/aileron/proxy/ca.pem}`). Exits 0 on success, 2 when the CA file is missing or empty, 126 when invoked unprivileged for an install, 127 when the underlying trust-store tooling is missing. |
 | `aileron-run-with-proxy-ca` | Entrypoint wrapper that installs the CA as root, then drops privileges to the `agent` user and executes the requested agent command. The launcher always starts the container through this wrapper when the proxy is in force. |
 
-The canonical implementations ship with the `aileron/sandbox-base` image. BYO authors who derive from another base distro can write drop-in equivalents — the launcher only cares about the CLI shape, not the trust-store mechanism. Pick the mechanism that matches the base:
+The canonical implementations ship with the `ghcr.io/alrubinger/aileron-sandbox-base` image. BYO authors who derive from another base distro can write drop-in equivalents — the launcher only cares about the CLI shape, not the trust-store mechanism. Pick the mechanism that matches the base:
 
 | Base distro | Install file at | Apply with | Notes |
 |---|---|---|---|

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -29,7 +29,7 @@ The scaffold composes the base image with the Claude agent Feature as the worked
 ```jsonc
 {
   "name": "Aileron sandbox",
-  "image": "aileron/sandbox-base:<version>",
+  "image": "ghcr.io/alrubinger/aileron-sandbox-base:<version>",
   "features": {
     // The agent Feature installs the agent CLI onto the base image. Swap
     // "claude" for another published agent (e.g. "codex"), or list several.
@@ -60,14 +60,14 @@ With no `.devcontainer/devcontainer.json`, the output is Tier 0:
 
 ```text
 tier: base
-image: aileron/sandbox-base:latest
+image: ghcr.io/alrubinger/aileron-sandbox-base:latest
 ```
 
 With the starter scaffold, the output is Tier 1 and names the composed devcontainer:
 
 ```text
 tier: devcontainer
-image: aileron/sandbox-base:latest
+image: ghcr.io/alrubinger/aileron-sandbox-base:latest
 devcontainer: .devcontainer/devcontainer.json
 ```
 

--- a/docs/src/content/docs/development/sandbox-proxy-cli-matrix.md
+++ b/docs/src/content/docs/development/sandbox-proxy-cli-matrix.md
@@ -35,7 +35,7 @@ The proxy URL inside the container is `$HTTPS_PROXY`. The launcher sets it; you 
 
 ### Install
 
-`aileron/sandbox-base` ships with `curl`. For other base images:
+`ghcr.io/alrubinger/aileron-sandbox-base` ships with `curl`. For other base images:
 
 | Distro | Install |
 |---|---|

--- a/docs/src/content/docs/meet-aileron/v4.mdx
+++ b/docs/src/content/docs/meet-aileron/v4.mdx
@@ -139,7 +139,7 @@ In v4 these are colocated with the management plane in one daemon process. In v4
 The composed runtime environment. v4 is Docker-only; Podman is deferred behind a preserved runtime seam, not rejected ([#1050](https://github.com/ALRubinger/aileron/issues/1050)). Contents:
 
 - The agent (Claude Code or other), configured to use `HTTPS_PROXY` for credentialed outbound HTTPS, with its LLM endpoint pointed at the daemon.
-- `aileron-mcp`, registered with the agent as the Aileron tool surface. The published `aileron/sandbox-base` image bakes the binary in for sealed runtimes ([#957](https://github.com/ALRubinger/aileron/issues/957)); local Tier 0 and devcontainer images take it as a read-only host-mount for version-lockstep with the host CLI.
+- `aileron-mcp`, registered with the agent as the Aileron tool surface. The published `ghcr.io/alrubinger/aileron-sandbox-base` image bakes the binary in for sealed runtimes ([#957](https://github.com/ALRubinger/aileron/issues/957)); local Tier 0 and devcontainer images take it as a read-only host-mount for version-lockstep with the host CLI.
 - bash plus any user-installed tools. v4 does not intercept the shell. Container-only shell-layer mediation was prototyped under [#801](https://github.com/ALRubinger/aileron/issues/801) and withdrawn in [#952](https://github.com/ALRubinger/aileron/issues/952); container isolation, the credential boundary, and tool-level approval gating cover the named risks (see [ADR-0021](/adr/0021-v4-shell-layer-mediation), Withdrawn).
 - The `aileron` CLI for status queries, audit, approvals, and action browsing.
 - The proxy's CA certificate installed in the system trust store.
@@ -148,7 +148,7 @@ The composed runtime environment. v4 is Docker-only; Podman is deferred behind a
 
 ### Sandbox composition contract
 
-v4 uses `.devcontainer/devcontainer.json` as the project-local composition substrate ([ADR-0017](/adr/0017-sandbox-composition)). If the file is absent, Aileron uses `aileron/sandbox-base:<version>` directly. If present, Aileron reads standard devcontainer build/image settings and the Aileron-specific `customizations.aileron` block.
+v4 uses `.devcontainer/devcontainer.json` as the project-local composition substrate ([ADR-0017](/adr/0017-sandbox-composition)). If the file is absent, Aileron uses `ghcr.io/alrubinger/aileron-sandbox-base:<version>` directly. If present, Aileron reads standard devcontainer build/image settings and the Aileron-specific `customizations.aileron` block.
 
 ```json
 {
@@ -166,7 +166,7 @@ v4 uses `.devcontainer/devcontainer.json` as the project-local composition subst
 
 `customizations.aileron.image` selects the BYO-image tier, where Aileron uses the image as supplied and injects the runtime contract at launch: `aileron-mcp`, session env, manifest mounts, proxy bootstrap, and the session CA. Images that participate in the HTTPS proxy must include the `aileron-install-proxy-ca` and `aileron-run-with-proxy-ca` helpers; launch validation checks the contract before the agent starts.
 
-`aileron sandbox init` scaffolds the starter `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile`. The Dockerfile extends `aileron/sandbox-base:<version>`, pre-fills the install recipe for the agent named in `--agent` (defaults to `claude`), and ships additional tool snippets commented out for you to enable as needed. Tool installation remains standard container work; Aileron does not maintain an `aileron.yaml` tool resolver.
+`aileron sandbox init` scaffolds the starter `.devcontainer/devcontainer.json` and `.devcontainer/Dockerfile`. The Dockerfile extends `ghcr.io/alrubinger/aileron-sandbox-base:<version>`, pre-fills the install recipe for the agent named in `--agent` (defaults to `claude`), and ships additional tool snippets commented out for you to enable as needed. Tool installation remains standard container work; Aileron does not maintain an `aileron.yaml` tool resolver.
 
 ## Tool discoverability
 

--- a/internal/launch/authspec_bindmount_integration_test.go
+++ b/internal/launch/authspec_bindmount_integration_test.go
@@ -21,7 +21,7 @@
 //   - Skips unless GOOS == linux and a Docker runtime is on PATH
 //     (macOS/Windows Docker Desktop translates UIDs via its file-sharing
 //     shim, so the bug does not reproduce there).
-//   - Builds the aileron/sandbox-base image (Tier base).
+//   - Builds the aileron-sandbox-base image (Tier base).
 //   - Creates a transient dir exactly as prepareAuthSpec does and seeds
 //     a credential file.
 //   - Negative control: WITHOUT the chown fix, an in-container write as
@@ -51,7 +51,7 @@ import (
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 )
 
-const authSpecBindMountTestImage = "aileron/sandbox-base:authspec-bindmount-test"
+const authSpecBindMountTestImage = "aileron-sandbox-base:authspec-bindmount-test"
 
 func TestAuthSpecBindMountWritable(t *testing.T) {
 	if runtime.GOOS != "linux" {

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -979,15 +979,15 @@ func TestLaunch_SandboxBuildRunsPreparedImage(t *testing.T) {
 	}
 	args := string(data)
 	for _, want := range []string{
-		"build\n-t\naileron/sandbox-base:latest\n",
+		"build\n-t\nghcr.io/alrubinger/aileron-sandbox-base:latest\n",
 		"run\n--rm\n-i\n",
-		"--env\nAILERON_SANDBOX_IMAGE=aileron/sandbox-base:latest\n",
+		"--env\nAILERON_SANDBOX_IMAGE=ghcr.io/alrubinger/aileron-sandbox-base:latest\n",
 		"--env\nAILERON_SANDBOX_TIER=base\n",
 		"--env\nAILERON_SANDBOX_RUNTIME=docker\n",
 		// Default-on proxy bootstrap routes the agent through
 		// aileron-run-with-proxy-ca; the image name still precedes the
 		// agent argv but the bootstrap wrapper sits between them.
-		"aileron/sandbox-base:latest\naileron-run-with-proxy-ca\nclaude\n--dangerously-skip-permissions\n",
+		"ghcr.io/alrubinger/aileron-sandbox-base:latest\naileron-run-with-proxy-ca\nclaude\n--dangerously-skip-permissions\n",
 	} {
 		if !strings.Contains(args, want) {
 			t.Errorf("expected %q in docker args:\n%s", want, args)

--- a/internal/launch/run_with_proxy_ca_integration_test.go
+++ b/internal/launch/run_with_proxy_ca_integration_test.go
@@ -48,7 +48,7 @@ import (
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 )
 
-const runWithProxyCATestImage = "aileron/sandbox-base:run-with-proxy-ca-test"
+const runWithProxyCATestImage = "aileron-sandbox-base:run-with-proxy-ca-test"
 
 func TestRunWithProxyCAPassesFlaggedCommand(t *testing.T) {
 	rt, err := sandboxcontainer.ResolveRuntime("docker")

--- a/internal/launch/sandbox_features_integration_test.go
+++ b/internal/launch/sandbox_features_integration_test.go
@@ -10,7 +10,7 @@
 // It drives @devcontainers/cli directly (NOT Aileron's own
 // composition.Discover build path — that wiring is #1083's scope):
 //
-//   - Build the aileron/sandbox-base image (Tier base) via the Builder.
+//   - Build the aileron-sandbox-base image (Tier base) via the Builder.
 //   - Generate a minimal devcontainer.json that FROMs the freshly built base
 //     and references the local Feature directory by path.
 //   - `devcontainer build` the composed image.
@@ -45,7 +45,7 @@ import (
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 )
 
-const sandboxFeaturesBaseImage = "aileron/sandbox-base:features-test"
+const sandboxFeaturesBaseImage = "aileron-sandbox-base:features-test"
 
 // sandboxFeatureCase is one agent's build-and-verify contract.
 type sandboxFeatureCase struct {

--- a/internal/sandbox/composition/composition.go
+++ b/internal/sandbox/composition/composition.go
@@ -19,7 +19,9 @@ const (
 	// naming a dockerfile. `sandbox init` no longer scaffolds this file.
 	DefaultDockerfilePath = ".devcontainer/Dockerfile"
 	// DefaultBaseImageRepository is the image Aileron owns for Tier 0 and Tier 1.
-	DefaultBaseImageRepository = "aileron/sandbox-base"
+	// It is published to GHCR by the sandbox-base CI workflow and mirrors the
+	// DefaultFeatureRepository prefix style.
+	DefaultBaseImageRepository = "ghcr.io/alrubinger/aileron-sandbox-base"
 	// DefaultFeatureRepository is the registry path that hosts Aileron's
 	// per-agent devcontainer Features. The scaffold composes one of these
 	// Features (see FeatureReference) into the starter devcontainer.json, and

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -15,7 +15,7 @@ func TestDiscoverMissingDevcontainerUsesBaseImage(t *testing.T) {
 	if plan.Tier != TierBase {
 		t.Fatalf("Tier = %s, want %s", plan.Tier, TierBase)
 	}
-	if plan.Image != "aileron/sandbox-base:0.4.0" {
+	if plan.Image != "ghcr.io/alrubinger/aileron-sandbox-base:0.4.0" {
 		t.Fatalf("Image = %q", plan.Image)
 	}
 }
@@ -47,7 +47,7 @@ func TestDiscoverDevcontainerBuildPlan(t *testing.T) {
 	if plan.Tier != TierDevcontainer {
 		t.Fatalf("Tier = %s, want %s", plan.Tier, TierDevcontainer)
 	}
-	if plan.BaseImage != "aileron/sandbox-base:latest" {
+	if plan.BaseImage != "ghcr.io/alrubinger/aileron-sandbox-base:latest" {
 		t.Fatalf("BaseImage = %q", plan.BaseImage)
 	}
 	if plan.DockerfilePath != "Dockerfile" {
@@ -187,7 +187,7 @@ func TestInitWritesFeatureComposingDevcontainer(t *testing.T) {
 	if plan.Tier != TierDevcontainer {
 		t.Fatalf("Tier = %s, want %s", plan.Tier, TierDevcontainer)
 	}
-	if plan.Image != "aileron/sandbox-base:0.4.0" {
+	if plan.Image != "ghcr.io/alrubinger/aileron-sandbox-base:0.4.0" {
 		t.Fatalf("Image = %q, want the base image", plan.Image)
 	}
 	// Exactly one active Feature: the default agent Feature. The customer

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -546,12 +546,12 @@ fi
 if [ "${2:-0}" = "1" ]; then
   if ! command -v aileron-install-proxy-ca >/dev/null 2>&1; then
     echo "sandbox proxy bootstrap requires aileron-install-proxy-ca in the sandbox image" >&2
-    echo "extend the current aileron/sandbox-base image or disable AILERON_SANDBOX_PROXY_BOOTSTRAP" >&2
+    echo "extend the current ghcr.io/alrubinger/aileron-sandbox-base image or disable AILERON_SANDBOX_PROXY_BOOTSTRAP" >&2
     exit 127
   fi
   if ! command -v aileron-run-with-proxy-ca >/dev/null 2>&1; then
     echo "sandbox proxy bootstrap requires aileron-run-with-proxy-ca in the sandbox image" >&2
-    echo "extend the current aileron/sandbox-base image or disable AILERON_SANDBOX_PROXY_BOOTSTRAP" >&2
+    echo "extend the current ghcr.io/alrubinger/aileron-sandbox-base image or disable AILERON_SANDBOX_PROXY_BOOTSTRAP" >&2
     exit 127
   fi
   aileron-install-proxy-ca --check "${AILERON_SANDBOX_PROXY_CA_FILE:-/etc/aileron/proxy/ca.pem}"

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -82,16 +82,16 @@ func TestBuildBaseImageUsesLocalContainerfile(t *testing.T) {
 		WorkDir: dir,
 		Plan: composition.Plan{
 			Tier:  composition.TierBase,
-			Image: "aileron/sandbox-base:test",
+			Image: "aileron-sandbox-base:test",
 		},
 	})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if !result.Built || result.Image != "aileron/sandbox-base:test" {
+	if !result.Built || result.Image != "aileron-sandbox-base:test" {
 		t.Fatalf("result = %+v", result)
 	}
-	want := []string{"build", "-t", "aileron/sandbox-base:test", "-f", containerfile, filepath.Dir(containerfile)}
+	want := []string{"build", "-t", "aileron-sandbox-base:test", "-f", containerfile, filepath.Dir(containerfile)}
 	if runner.name != "docker" || !reflect.DeepEqual(runner.args, want) {
 		t.Fatalf("runner = %s %#v, want docker %#v", runner.name, runner.args, want)
 	}
@@ -310,7 +310,7 @@ func TestBuildBaseImageAutoSkipsExistingImage(t *testing.T) {
 		Policy:  BuildPolicyAuto,
 		Plan: composition.Plan{
 			Tier:  composition.TierBase,
-			Image: "aileron/sandbox-base:test",
+			Image: "aileron-sandbox-base:test",
 		},
 	})
 	if err != nil {
@@ -319,7 +319,7 @@ func TestBuildBaseImageAutoSkipsExistingImage(t *testing.T) {
 	if result.Built {
 		t.Fatalf("result.Built = true, want false")
 	}
-	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", "aileron/sandbox-base:test"}}}
+	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", "aileron-sandbox-base:test"}}}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
 	}
@@ -340,7 +340,7 @@ func TestBuildBaseImageAutoBuildsMissingImage(t *testing.T) {
 		Policy:  BuildPolicyAuto,
 		Plan: composition.Plan{
 			Tier:  composition.TierBase,
-			Image: "aileron/sandbox-base:test",
+			Image: "aileron-sandbox-base:test",
 		},
 	})
 	if err != nil {
@@ -350,8 +350,8 @@ func TestBuildBaseImageAutoBuildsMissingImage(t *testing.T) {
 		t.Fatalf("result.Built = false, want true")
 	}
 	want := []runnerCall{
-		{name: "docker", args: []string{"image", "inspect", "aileron/sandbox-base:test"}},
-		{name: "docker", args: []string{"build", "-t", "aileron/sandbox-base:test", "-f", containerfile, filepath.Dir(containerfile)}},
+		{name: "docker", args: []string{"image", "inspect", "aileron-sandbox-base:test"}},
+		{name: "docker", args: []string{"build", "-t", "aileron-sandbox-base:test", "-f", containerfile, filepath.Dir(containerfile)}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
@@ -365,7 +365,7 @@ func TestBuildBaseImageNeverRequiresExistingImage(t *testing.T) {
 		Policy:  BuildPolicyNever,
 		Plan: composition.Plan{
 			Tier:  composition.TierBase,
-			Image: "aileron/sandbox-base:test",
+			Image: "aileron-sandbox-base:test",
 		},
 	})
 	if err == nil {
@@ -383,7 +383,7 @@ func TestBuildBaseImageNeverSkipsExistingImage(t *testing.T) {
 		Policy:  BuildPolicyNever,
 		Plan: composition.Plan{
 			Tier:  composition.TierBase,
-			Image: "aileron/sandbox-base:test",
+			Image: "aileron-sandbox-base:test",
 		},
 	})
 	if err != nil {
@@ -392,7 +392,7 @@ func TestBuildBaseImageNeverSkipsExistingImage(t *testing.T) {
 	if result.Built {
 		t.Fatalf("result.Built = true, want false")
 	}
-	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", "aileron/sandbox-base:test"}}}
+	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", "aileron-sandbox-base:test"}}}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
 	}
@@ -404,7 +404,7 @@ func TestBuildRejectsUnsupportedPolicy(t *testing.T) {
 		Policy:  "sometimes",
 		Plan: composition.Plan{
 			Tier:  composition.TierBase,
-			Image: "aileron/sandbox-base:test",
+			Image: "aileron-sandbox-base:test",
 		},
 	})
 	if err == nil {
@@ -460,7 +460,7 @@ func TestBuildBaseImageRejectsUnsupportedRuntime(t *testing.T) {
 		WorkDir: t.TempDir(),
 		Plan: composition.Plan{
 			Tier:  composition.TierBase,
-			Image: "aileron/sandbox-base:test",
+			Image: "aileron-sandbox-base:test",
 		},
 	})
 	if err == nil {
@@ -591,7 +591,7 @@ func TestExecRunnerRun(t *testing.T) {
 }
 
 func TestBaseBuildArgsReportsMissingContext(t *testing.T) {
-	_, err := baseBuildArgs(t.TempDir(), "aileron/sandbox-base:test")
+	_, err := baseBuildArgs(t.TempDir(), "aileron-sandbox-base:test")
 	if err == nil {
 		t.Fatal("expected missing context error")
 	}
@@ -670,7 +670,7 @@ func TestBuilderStreamsRuntimeOutput(t *testing.T) {
 		WorkDir: dir,
 		Plan: composition.Plan{
 			Tier:  composition.TierBase,
-			Image: "aileron/sandbox-base:test",
+			Image: "aileron-sandbox-base:test",
 		},
 	})
 	if err != nil {
@@ -697,7 +697,7 @@ func TestRunMountsWorkspaceAndExecutesCommand(t *testing.T) {
 	dir := t.TempDir()
 	runner := &recordingRunner{}
 	result, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
-		Image:   "aileron/sandbox-base:test",
+		Image:   "aileron-sandbox-base:test",
 		WorkDir: dir,
 		Env: map[string]string{
 			"Z_VAR": "last",
@@ -717,7 +717,7 @@ func TestRunMountsWorkspaceAndExecutesCommand(t *testing.T) {
 		"--volume", dir + ":" + WorkspacePath,
 		"--env", "A_VAR=first",
 		"--env", "Z_VAR=last",
-		"aileron/sandbox-base:test",
+		"aileron-sandbox-base:test",
 		"codex", "--model", "gpt-5",
 	}
 	if runner.name != "docker" || !reflect.DeepEqual(runner.args, want) {
@@ -730,7 +730,7 @@ func TestRunCanOverrideContainerUser(t *testing.T) {
 	dir := t.TempDir()
 	runner := &recordingRunner{}
 	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
-		Image:   "aileron/sandbox-base:test",
+		Image:   "aileron-sandbox-base:test",
 		WorkDir: dir,
 		User:    "root",
 		Command: []string{"aileron-run-with-proxy-ca", "codex"},
@@ -743,7 +743,7 @@ func TestRunCanOverrideContainerUser(t *testing.T) {
 		"--user", "root",
 		"--workdir", WorkspacePath,
 		"--volume", dir + ":" + WorkspacePath,
-		"aileron/sandbox-base:test",
+		"aileron-sandbox-base:test",
 		"aileron-run-with-proxy-ca", "codex",
 	}
 	if !reflect.DeepEqual(runner.args, want) {
@@ -760,7 +760,7 @@ func TestRunMountsAdditionalReadOnlyVolumes(t *testing.T) {
 	}
 	runner := &recordingRunner{}
 	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
-		Image:   "aileron/sandbox-base:test",
+		Image:   "aileron-sandbox-base:test",
 		WorkDir: dir,
 		Volumes: []Volume{{
 			Source:   extra,
@@ -778,7 +778,7 @@ func TestRunMountsAdditionalReadOnlyVolumes(t *testing.T) {
 		"--workdir", WorkspacePath,
 		"--volume", dir + ":" + WorkspacePath,
 		"--volume", absExtra + ":/opt/aileron/manifests/actions:ro",
-		"aileron/sandbox-base:test",
+		"aileron-sandbox-base:test",
 		"codex",
 	}
 	if !reflect.DeepEqual(runner.args, want) {
@@ -794,7 +794,7 @@ func TestRunMountsAdditionalReadWriteVolumes(t *testing.T) {
 	}
 	runner := &recordingRunner{}
 	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
-		Image:   "aileron/sandbox-base:test",
+		Image:   "aileron-sandbox-base:test",
 		WorkDir: dir,
 		Volumes: []Volume{{
 			Source: extra,
@@ -821,7 +821,7 @@ func TestRunMountsAdditionalReadWriteVolumes(t *testing.T) {
 
 func TestRunRejectsIncompleteAdditionalVolume(t *testing.T) {
 	_, err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Run(context.Background(), RunOptions{
-		Image:   "aileron/sandbox-base:test",
+		Image:   "aileron-sandbox-base:test",
 		Volumes: []Volume{{Target: "/opt/aileron/manifests/actions"}},
 		Command: []string{"codex"},
 	})
@@ -833,7 +833,7 @@ func TestRunRejectsIncompleteAdditionalVolume(t *testing.T) {
 func TestRunAddsTTYWhenRequested(t *testing.T) {
 	runner := &recordingRunner{}
 	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
-		Image:   "aileron/sandbox-base:test",
+		Image:   "aileron-sandbox-base:test",
 		Command: []string{"claude"},
 		TTY:     true,
 	})
@@ -856,7 +856,7 @@ func TestRunRejectsMissingImage(t *testing.T) {
 
 func TestRunRejectsMissingCommand(t *testing.T) {
 	_, err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Run(context.Background(), RunOptions{
-		Image: "aileron/sandbox-base:test",
+		Image: "aileron-sandbox-base:test",
 	})
 	if err == nil {
 		t.Fatal("expected missing command error")


### PR DESCRIPTION
## Summary

The sandbox-base **publish** workflow was already migrated to GHCR before this PR: `.github/workflows/sandbox-base.yml` sets `IMAGE_NAME: ghcr.io/alrubinger/aileron-sandbox-base`, declares `permissions: packages: write`, logs into `ghcr.io`, and publishes on the same triggers (tag `v*`, `workflow_dispatch`). `images/sandbox-base/Containerfile.published`'s header already documents the GHCR target. This PR does **not** re-migrate the workflow.

This is the **consumer-side repoint**: the load-bearing default that a default Tier 0 `aileron launch --sandbox=docker` resolves now points at the GHCR base instead of the Docker Hub short-name `aileron/sandbox-base`.

- Flip `DefaultBaseImageRepository` in `internal/sandbox/composition/composition.go` to `ghcr.io/alrubinger/aileron-sandbox-base` (mirrors the existing `DefaultFeatureRepository` GHCR prefix style). This repoints `BaseImage(version)` → `Discover` → launch/runtime; tag-resolution semantics (`""`/`dev` → `latest`, else version) are unchanged.
- Scrub the Docker Hub short-name from the two proxy-bootstrap error strings in `internal/sandbox/container/runtime.go`.
- Repoint the base image string across current published docs (`development/*`, `cli/index.md`, `meet-aileron/v4.mdx`).
- Update composition + launcher tests to assert the GHCR default; rename arbitrary **local build-tag** constants in integration tests (`aileron/sandbox-base:<suffix>` → `aileron-sandbox-base:<suffix>`) for consistency — these are locally built, not registry pulls.

### Out of scope / flagged follow-up

- **ADRs are intentionally untouched** (`feedback_adr_immutable`, historical record). ADR-0017 still names `aileron/sandbox-base:<version>` as the composition base. If that should track the new canonical name, it is a one-line follow-up — call it out rather than silently editing the ADR.
- No dual-publish or back-compat shim (pre-release; clean cut-over).

## Test plan

- [x] `go build` across all workspace modules (`cmd/aileron`, `cmd/aileron-mcp`, `internal`, `sdk/go`) clean.
- [x] `go test ./internal/sandbox/composition/... ./internal/launch/... ./internal/sandbox/container/...` green.
- [x] `go vet -tags=integration_sandbox ./internal/launch/... ./internal/sandbox/container/...` compiles (Docker/Node-gated integration bodies build-verified only in this environment).
- [x] `grep "aileron/sandbox-base"` across `*.go` and non-ADR/non-plans docs returns nothing.

Closes #1085