### PR TITLE
ci(sandbox): publish agent devcontainer Features to GHCR

### DIFF
--- a/.github/workflows/sandbox-features.yml
+++ b/.github/workflows/sandbox-features.yml
@@ -1,0 +1,93 @@
+name: Sandbox Agent Features
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/sandbox-features.yml"
+      - "images/sandbox-features/**"
+  push:
+    branches: [main]
+    # The paths filter gates branch pushes so a main push only publishes when
+    # the Features change. It also applies to tag pushes, so a release tag that
+    # needs to republish the Features must touch images/sandbox-features/** or
+    # be driven through workflow_dispatch.
+    paths:
+      - "images/sandbox-features/**"
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+concurrency:
+  group: sandbox-features-${{ github.ref }}
+  cancel-in-progress: true
+
+env:
+  # GHCR namespace that hosts the agent Features. Matches
+  # composition.DefaultFeatureRepository (ghcr.io/alrubinger/aileron-features)
+  # and the base image owner used by sandbox-base.yml.
+  FEATURES_NAMESPACE: alrubinger/aileron-features
+
+jobs:
+  publish:
+    name: Publish agent Features
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      # Node 22 matches the integration-sandbox-features job in ci.yml so both
+      # paths exercise the Features with one Node major.
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "22"
+
+      # The repo source never calls npm directly; installing @devcontainers/cli
+      # in this CI shell is the publish toolchain. Pin to the same version the
+      # Go source pins (container.DevcontainerCLIVersion) so the compose path in
+      # ci.yml and this publish path use one reproducible CLI.
+      - name: Install @devcontainers/cli
+        run: npm install -g @devcontainers/cli@0.87.0
+
+      # PR runs validate the Features package without pushing; ci.yml's
+      # integration-sandbox-features job is the build/compose acceptance gate, so
+      # this keeps the PR path lightweight. `devcontainer features package` walks
+      # the directory, processes each sub-Feature (claude, codex), and fails on a
+      # malformed manifest. It is the same directory-walk the publish step uses,
+      # minus the push.
+      - name: Validate Features package
+        run: |
+          set -euo pipefail
+          devcontainer features package ./images/sandbox-features \
+            --output-folder "${RUNNER_TEMP}/sandbox-features-package"
+
+      # GHCR login and publish only on push to main, release tags, and manual
+      # dispatch. Pull requests stop after manifest validation. This mirrors the
+      # push gating in sandbox-base.yml.
+      - name: Log in to GitHub Container Registry
+        if: ${{ github.event_name != 'pull_request' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # `devcontainer features publish` walks images/sandbox-features and pushes
+      # each sub-Feature (claude, codex) to ghcr.io/<namespace>/<id>. A "0.0.1"
+      # manifest publishes the tag set 0.0.1, 0.0, 0, and latest, so the
+      # scaffold's ":0" reference resolves.
+      #
+      # First publish requires a one-time manual flip of each GHCR package to
+      # public visibility so `aileron sandbox build` (which does no docker login)
+      # can pull anonymously. See docs/development/sandbox-composition.md.
+      - name: Publish agent Features to GHCR
+        if: ${{ github.event_name != 'pull_request' }}
+        run: |
+          set -euo pipefail
+          devcontainer features publish \
+            ./images/sandbox-features \
+            --namespace "${FEATURES_NAMESPACE}" \
+            --registry ghcr.io

--- a/docs/src/content/docs/adr/0017-sandbox-composition.md
+++ b/docs/src/content/docs/adr/0017-sandbox-composition.md
@@ -62,7 +62,7 @@ Each agent install is authored once as a devcontainer Feature. A Feature is a se
 {
   "image": "aileron/sandbox-base:<version>",
   "features": {
-    "ghcr.io/alrubinger/aileron-features/<agent>:1": {},
+    "ghcr.io/alrubinger/aileron-features/<agent>:0": {},
     "ghcr.io/acme/internal-tools:1": {}
   }
 }

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -33,7 +33,7 @@ The scaffold composes the base image with the Claude agent Feature as the worked
   "features": {
     // The agent Feature installs the agent CLI onto the base image. Swap
     // "claude" for another published agent (e.g. "codex"), or list several.
-    "ghcr.io/alrubinger/aileron-features/claude:1": {}
+    "ghcr.io/alrubinger/aileron-features/claude:0": {}
     // Add your own tooling as its own Feature alongside the agent Feature:
     // "ghcr.io/acme/internal-tools:1": {}
   },
@@ -47,6 +47,14 @@ The scaffold composes the base image with the Claude agent Feature as the worked
 ```
 
 The agent is selected by the agent Feature you list, and your own tooling is its own Feature alongside it. Swap the agent reference or uncomment the tooling slot to suit your project. The same agent Feature is the single source of truth that Aileron CI bakes into the prebuilt per-agent images ([#965](https://github.com/ALRubinger/aileron/issues/965)), so the customization tier and the zero-build default share one install recipe per agent. The `features`-composing build path is implemented in [#1083](https://github.com/ALRubinger/aileron/issues/1083).
+
+### How the agent Features are published
+
+The agent Features under `images/sandbox-features/<agent>/` are published to GitHub Container Registry by the `.github/workflows/sandbox-features.yml` workflow. The workflow runs `devcontainer features publish` on push to `main` when `images/sandbox-features/**` changes, and on release tags. Pull-request runs validate the Feature manifests without publishing.
+
+Each Feature manifest stays on the `0.0.1` house version. `devcontainer features publish` emits the tag set `0.0.1`, `0.0`, `0`, and `latest` from that manifest. The scaffold pins the broadest in-house major tag, `:0`, so a 0.0.x patch bump republishes the `0` tag and the scaffold keeps resolving without re-scaffolding.
+
+The first publish requires a one-time manual step. CI cannot set the visibility of a GHCR package on its first push, so each new package starts private. `aileron sandbox build` pulls Features anonymously and performs no `docker login`, so each package must be flipped to public in its GHCR package settings after the first publish. This is a one-time operator step per package, not a recurring CI action.
 
 ## Inspect the Plan
 

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -207,7 +207,7 @@ func TestInitWritesFeatureComposingDevcontainer(t *testing.T) {
 }
 
 func TestFeatureReferenceNamesPublishedFeature(t *testing.T) {
-	if got, want := FeatureReference("claude"), DefaultFeatureRepository+"/claude:1"; got != want {
+	if got, want := FeatureReference("claude"), DefaultFeatureRepository+"/claude:0"; got != want {
 		t.Fatalf("FeatureReference = %q, want %q", got, want)
 	}
 }

--- a/internal/sandbox/composition/features_test.go
+++ b/internal/sandbox/composition/features_test.go
@@ -5,6 +5,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"sort"
 	"strings"
 	"testing"
 )
@@ -73,6 +74,87 @@ func TestFeatureManifestsAreValid(t *testing.T) {
 			}
 		})
 	}
+}
+
+// TestScaffoldFeatureReferenceMatchesManifestVersion guards the drift class that
+// motivated #1123: the scaffold once pinned ":1" while the Features published a
+// "0.0.1" manifest, so a fresh `sandbox init` + `sandbox build` could not
+// resolve the Feature. `devcontainer features publish` emits the tag set
+// {major.minor.patch, major.minor, major, latest} from a semver manifest, so the
+// scaffold's reference tag is only valid when it is a member of that set. This
+// test encodes the Option-B invariant (scaffold pins the major tag, manifest
+// stays on the 0.0.x house version) as a contract rather than a literal: a
+// future manifest bump to e.g. "0.1.0" still passes because "0" stays in the
+// published set, while a scaffold drift to ":1" against a "0.x" manifest or a
+// manifest bump that drops the "0" major fails loudly here.
+func TestScaffoldFeatureReferenceMatchesManifestVersion(t *testing.T) {
+	root := featuresContext(t)
+	for _, agent := range []string{"claude", "codex"} {
+		agent := agent
+		t.Run(agent, func(t *testing.T) {
+			path := filepath.Join(root, agent, "devcontainer-feature.json")
+			raw, err := os.ReadFile(path)
+			if err != nil {
+				t.Fatalf("read %s: %v", path, err)
+			}
+			var m featureManifest
+			if err := json.Unmarshal(raw, &m); err != nil {
+				t.Fatalf("%s is not valid JSON: %v", path, err)
+			}
+
+			tags := publishedTagSet(t, m.Version)
+			ref := FeatureReference(agent)
+			refTag := referenceTag(t, ref)
+			if !tags[refTag] {
+				t.Fatalf("scaffold reference %q pins tag %q, which is not in the tag set %v published by `devcontainer features publish` for manifest version %q; reconcile internal/sandbox/composition/scaffold.go with %s",
+					ref, refTag, sortedKeys(tags), m.Version, path)
+			}
+		})
+	}
+}
+
+// publishedTagSet returns the tags `devcontainer features publish` emits for a
+// semver manifest version: the full "major.minor.patch", the "major.minor"
+// prefix, the "major" prefix, and "latest".
+func publishedTagSet(t *testing.T, version string) map[string]bool {
+	t.Helper()
+	v := strings.TrimSpace(version)
+	parts := strings.Split(v, ".")
+	if len(parts) != 3 {
+		t.Fatalf("manifest version %q is not major.minor.patch semver", version)
+	}
+	for _, p := range parts {
+		if p == "" {
+			t.Fatalf("manifest version %q has an empty component", version)
+		}
+	}
+	return map[string]bool{
+		parts[0]:                  true, // major
+		parts[0] + "." + parts[1]: true, // major.minor
+		parts[0] + "." + parts[1] + "." + parts[2]: true, // major.minor.patch
+		"latest": true,
+	}
+}
+
+// referenceTag extracts the tag from a Feature reference of the form
+// "<registry>/<path>:<tag>". The registry host carries no port in any Aileron
+// reference, so the final ":" segment is the tag.
+func referenceTag(t *testing.T, ref string) string {
+	t.Helper()
+	idx := strings.LastIndex(ref, ":")
+	if idx < 0 || idx == len(ref)-1 {
+		t.Fatalf("Feature reference %q has no tag", ref)
+	}
+	return ref[idx+1:]
+}
+
+func sortedKeys(m map[string]bool) []string {
+	keys := make([]string, 0, len(m))
+	for k := range m {
+		keys = append(keys, k)
+	}
+	sort.Strings(keys)
+	return keys
 }
 
 func TestFeatureInstallScriptsArePresentAndExecutable(t *testing.T) {

--- a/internal/sandbox/composition/scaffold.go
+++ b/internal/sandbox/composition/scaffold.go
@@ -52,13 +52,20 @@ func Init(opts InitOptions) (InitResult, error) {
 }
 
 // FeatureReference returns the canonical devcontainer Feature reference for an
-// agent (e.g. "ghcr.io/alrubinger/aileron-features/claude:1"). It is the one
+// agent (e.g. "ghcr.io/alrubinger/aileron-features/claude:0"). It is the one
 // place in Go that names the Feature registry path and tag, mirroring the
 // BaseImage helper for the base image. The same reference identifies the
 // Features authored under images/sandbox-features/<agent>/ and composed by the
 // Tier 1 build path (#1083).
+//
+// The tag is ":0", the broadest in-house major tag. A "0.0.1" Feature manifest
+// publishes the tag set "0.0.1", "0.0", "0", and "latest" through
+// `devcontainer features publish`, so pinning ":0" lets 0.0.x patch bumps
+// resolve without re-scaffolding. The scaffold stays on the major tag while the
+// manifest holds the 0.0.x house version, keeping the two consistent without
+// hard-coding a premature 1.0.0.
 func FeatureReference(agent string) string {
-	return DefaultFeatureRepository + "/" + agent + ":1"
+	return DefaultFeatureRepository + "/" + agent + ":0"
 }
 
 // starterDevcontainer emits the Feature-composing devcontainer.json recorded in


### PR DESCRIPTION
## Summary

- Add `.github/workflows/sandbox-features.yml` that runs `devcontainer features publish` to push the `claude` and `codex` agent Features under `images/sandbox-features/` to `ghcr.io/alrubinger/aileron-features/<agent>` on push to `main` (when the Features change) and on `v*` release tags. Pull requests validate via `devcontainer features package` (directory-walk, no push). The CLI is pinned to `0.87.0`, matching `container.DevcontainerCLIVersion`.
- Reconcile the scaffold tag with the `0.0.1` Feature manifest (Option B): `FeatureReference` now emits `:0` instead of `:1`. A `0.0.1` manifest publishes the tag set `0.0.1`, `0.0`, `0`, `latest`, so the broadest in-house major tag `:0` resolves and 0.0.x patch bumps need no re-scaffold. This fixes the GHCR `403` / `Could not resolve Feature manifest` a fresh `sandbox init` + `sandbox build` previously hit.
- Add `TestScaffoldFeatureReferenceMatchesManifestVersion`: a regression test that fails if the scaffold's reference tag and the published manifest version ever drift apart again. The invariant is encoded as a contract (the reference tag must be a member of the published tag set), not a literal, so a future manifest bump to e.g. `0.1.0` still passes while a scaffold drift to `:1` fails loudly.
- Update `docs/development/sandbox-composition.md` and ADR-0017 to reference `:0` and document the publish workflow plus the one-time manual GHCR public-visibility flip.

## Follow-up (manual, one-time)

CI cannot set the visibility of a GHCR package on its first push, so each new package starts private. `aileron sandbox build` pulls anonymously with no `docker login`, so after the first publish each package (`claude`, `codex`) must be flipped to **public** in its GHCR package settings. Documented in `sandbox-composition.md`.

## Test plan

- [x] `cd internal && go test ./sandbox/composition/...` green.
- [x] Negative check: flipping `FeatureReference` back to `:1` locally makes `TestScaffoldFeatureReferenceMatchesManifestVersion` fail for both agents; restored to `:0`.
- [x] `actionlint .github/workflows/sandbox-features.yml` clean.
- [x] `devcontainer features package ./images/sandbox-features` (CLI `0.87.0`) processes both Features and exits 0 — the PR validation step.
- [ ] CI-level: on merge to `main`, confirm the workflow pushes `ghcr.io/alrubinger/aileron-features/{claude,codex}` with tags `0.0.1`, `0.0`, `0`, `latest`, then perform the one-time public-visibility flip and confirm an anonymous `devcontainer features info manifest ghcr.io/alrubinger/aileron-features/claude:0` resolves.

Closes #1123