### PR TITLE
ci(sandbox): build and publish multi-arch per-agent sandbox images

### DIFF
--- a/.github/workflows/sandbox-agents.yml
+++ b/.github/workflows/sandbox-agents.yml
@@ -68,6 +68,18 @@ jobs:
           version: 3.x
           repo-token: ${{ secrets.GITHUB_TOKEN }}
 
+      # Log in to GHCR before any registry access on the publishing paths so the
+      # base-tag `docker manifest inspect`, the GHCR-base pull during the smoke
+      # build, and the multi-arch push are all authenticated. PRs never touch
+      # GHCR (they build the base locally), so login is skipped there.
+      - name: Log in to GitHub Container Registry
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
       # Aileron version stamped into the image tag. Tag builds carry the release
       # version (v-prefix stripped to match version.Version); PR and dispatch
       # builds use "dev", consistent with sandbox-base.yml and the host CLI.
@@ -127,31 +139,39 @@ jobs:
       # On PR, build the in-repo base (single-arch, loaded) so the per-agent bake
       # below can FROM it. The published recipe compiles aileron-mcp from source,
       # so the repo-root context is required (it matches sandbox-base.yml).
+      #
+      # Built with plain `docker build` (the default docker driver), NOT the
+      # buildx docker-container driver from setup-buildx-action. The container
+      # driver keeps its own isolated image store, so an image it `--load`s into
+      # the daemon is invisible to a SUBSEQUENT container-driver build resolving
+      # `FROM aileron-sandbox-base:pr-local` (it would fall through to Docker Hub
+      # and fail). The default driver shares the daemon store, so the per-agent
+      # smoke build below sees this base. The multi-arch push step still uses
+      # buildx; it only runs on v*/dispatch where it FROMs the GHCR base.
       - name: Build base image locally (PR)
         if: ${{ steps.base.outputs.build_local == 'true' }}
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: images/sandbox-base/Containerfile.published
-          load: true
-          tags: aileron-sandbox-base:pr-local
-          build-args: |
-            AILERON_VERSION=${{ steps.ver.outputs.version }}
-            AILERON_COMMIT=${{ github.sha }}
+        run: |
+          docker build \
+            --file images/sandbox-base/Containerfile.published \
+            --tag aileron-sandbox-base:pr-local \
+            --build-arg AILERON_VERSION=${{ steps.ver.outputs.version }} \
+            --build-arg AILERON_COMMIT=${{ github.sha }} \
+            .
 
-      # Single-arch local load so the next steps can `docker run` the image to
-      # resolve the agent CLI version and to run the launchability smoke. The
-      # multi-arch build below cannot use `load: true`.
+      # Single-arch build into the daemon image store so the next steps can
+      # `docker run` the image to resolve the agent CLI version and run the
+      # launchability smoke. Uses plain `docker build` (default docker driver)
+      # so it both shares the daemon store with the PR base build above and
+      # leaves the resulting :smoke image visible to `docker run`. The multi-arch
+      # push build below cannot `--load` and runs only on v*/dispatch.
       - name: Build image for smoke test
-        uses: docker/build-push-action@v7
-        with:
-          context: .
-          file: images/sandbox-agents/Containerfile.published
-          load: true
-          tags: aileron-sandbox-${{ matrix.agent }}:smoke
-          build-args: |
-            BASE_IMAGE=${{ steps.base.outputs.base_image }}
-            AGENT=${{ matrix.agent }}
+        run: |
+          docker build \
+            --file images/sandbox-agents/Containerfile.published \
+            --tag aileron-sandbox-${{ matrix.agent }}:smoke \
+            --build-arg BASE_IMAGE=${{ steps.base.outputs.base_image }} \
+            --build-arg AGENT=${{ matrix.agent }} \
+            .
 
       # Resolve the installed agent CLI version from the loaded image. `<agent>
       # --version` prints a line containing a semver; extract the first semver so
@@ -186,14 +206,6 @@ jobs:
           labels: |
             org.opencontainers.image.title=Aileron sandbox ${{ matrix.agent }}
             org.opencontainers.image.description=Aileron sandbox base composed with the ${{ matrix.agent }} agent CLI Feature.
-
-      - name: Log in to GitHub Container Registry
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
-        uses: docker/login-action@v4
-        with:
-          registry: ghcr.io
-          username: ${{ github.actor }}
-          password: ${{ secrets.GITHUB_TOKEN }}
 
       # Multi-arch build + push. Runs only on the publishing paths (v* tags and
       # manual dispatch), where the base is the multi-arch GHCR image. It is

--- a/.github/workflows/sandbox-agents.yml
+++ b/.github/workflows/sandbox-agents.yml
@@ -1,0 +1,213 @@
+name: Sandbox Agent Images
+
+# Builds and publishes the multi-arch per-agent sandbox images
+# (ghcr.io/alrubinger/aileron-sandbox-claude and -codex), each baked from the
+# GHCR-published sandbox base (#1085) plus the agent's devcontainer Feature
+# install script (#1082). One workflow, one matrix leg per agent, so claude and
+# codex stay in lockstep with no file duplication (#1086).
+#
+# Each published image is smoke-tested by the launchability validation in
+# internal/launch/sandbox_agent_image_smoke_test.go: the agent CLI is on PATH
+# and Builder.Validate succeeds (RequireProxyTrust=false, RequireMCPBinary=false,
+# mirroring the #1121/#1083 path). Republish-on-agent-release automation is owned
+# by #1088 and out of scope here.
+
+on:
+  pull_request:
+    branches: [main]
+    paths:
+      - ".github/workflows/sandbox-agents.yml"
+      - "images/sandbox-agents/**"
+      - "images/sandbox-features/**"
+      - "internal/launch/sandbox_agent_image_smoke_test.go"
+  push:
+    tags:
+      - "v*"
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  packages: write
+
+env:
+  BASE_IMAGE_NAME: ghcr.io/alrubinger/aileron-sandbox-base
+
+jobs:
+  build:
+    name: Build sandbox-${{ matrix.agent }}
+    runs-on: ubuntu-latest
+    # Per-agent + per-ref concurrency so the two matrix legs do NOT cancel each
+    # other (a workflow-level group keyed only by ref/workflow would, since
+    # matrix.agent is out of scope there) and a new push to the same ref + agent
+    # supersedes an in-flight run.
+    concurrency:
+      group: sandbox-agents-${{ github.ref }}-${{ matrix.agent }}
+      cancel-in-progress: true
+    strategy:
+      fail-fast: false
+      matrix:
+        # The agent name doubles as the Feature subdirectory under
+        # images/sandbox-features/<agent>, the AGENT build-arg, and the agent CLI
+        # command asserted on PATH.
+        agent: [claude, codex]
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: docker/setup-qemu-action@v4
+
+      - uses: docker/setup-buildx-action@v4
+
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: internal/go.mod
+
+      - name: Install Task
+        uses: arduino/setup-task@v2
+        with:
+          version: 3.x
+          repo-token: ${{ secrets.GITHUB_TOKEN }}
+
+      # Aileron version stamped into the image tag. Tag builds carry the release
+      # version (v-prefix stripped to match version.Version); PR and dispatch
+      # builds use "dev", consistent with sandbox-base.yml and the host CLI.
+      - name: Resolve aileron version
+        id: ver
+        run: |
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            echo "version=${GITHUB_REF#refs/tags/v}" >> "$GITHUB_OUTPUT"
+          else
+            echo "version=dev" >> "$GITHUB_OUTPUT"
+          fi
+
+      # Resolve the GHCR base tag this build will FROM, and fail fast if it does
+      # not exist. The base workflow (sandbox-base.yml) publishes the exact
+      # release tag (`type=ref,event=tag`, e.g. v0.0.1) plus a floating `latest`
+      # on v* tag builds. On a v* trigger this workflow FROMs the version-pinned
+      # base tag so the per-agent image deterministically composes onto THIS
+      # release's base, not whatever `latest` happens to point at (the base and
+      # per-agent workflows run concurrently on the same tag push, so `latest`
+      # may still point at the prior release when this step runs). For PR and
+      # workflow_dispatch the version-pinned tag does not exist, so fall back to
+      # `latest`, the one tag reliably present from the previous release. Gate on
+      # `docker manifest inspect` so a missing base surfaces a precise error
+      # naming the absent tag instead of an opaque FROM failure deep in the build.
+      - name: Resolve and verify base image tag
+        id: base
+        run: |
+          set -euo pipefail
+          if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
+            BASE_TAG="${GITHUB_REF#refs/tags/}"
+          else
+            BASE_TAG="latest"
+          fi
+          BASE_REF="${BASE_IMAGE_NAME}:${BASE_TAG}"
+          echo "Verifying base image ${BASE_REF} exists..."
+          if ! docker manifest inspect "${BASE_REF}" >/dev/null 2>&1; then
+            echo "::error::Base image ${BASE_REF} not found in GHCR. The sandbox-base workflow (sandbox-base.yml) publishes the release tag and 'latest' on v* tag builds; ensure the base release published the '${BASE_TAG}' tag before building per-agent images." >&2
+            exit 1
+          fi
+          echo "base_image=${BASE_REF}" >> "$GITHUB_OUTPUT"
+          echo "Base image ${BASE_REF} present."
+
+      # Single-arch local load so the next steps can `docker run` the image to
+      # resolve the agent CLI version and to run the launchability smoke. The
+      # multi-arch build below cannot use `load: true`.
+      - name: Build image for smoke test
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: images/sandbox-agents/Containerfile.published
+          load: true
+          tags: aileron-sandbox-${{ matrix.agent }}:smoke
+          build-args: |
+            BASE_IMAGE=${{ steps.base.outputs.base_image }}
+            AGENT=${{ matrix.agent }}
+
+      # Resolve the installed agent CLI version from the loaded image. `<agent>
+      # --version` prints a line containing a semver; extract the first semver so
+      # the tag is clean regardless of surrounding prose. The agent CLI never
+      # holds credentials, so probing --version bakes nothing sensitive.
+      - name: Resolve agent CLI version
+        id: cli
+        run: |
+          set -euo pipefail
+          IMG=aileron-sandbox-${{ matrix.agent }}:smoke
+          raw=$(docker run --rm "$IMG" ${{ matrix.agent }} --version 2>&1 || true)
+          echo "raw ${{ matrix.agent }} --version: $raw"
+          cli_version=$(printf '%s' "$raw" | grep -oE '[0-9]+\.[0-9]+\.[0-9]+' | head -n1 || true)
+          if [ -z "$cli_version" ]; then
+            echo "::error::Could not resolve ${{ matrix.agent }} CLI version from \`${{ matrix.agent }} --version\` output: $raw" >&2
+            exit 1
+          fi
+          echo "version=${cli_version}" >> "$GITHUB_OUTPUT"
+          echo "resolved ${{ matrix.agent }} CLI version: ${cli_version}"
+
+      # Image tags: <aileron-version>-<agent-cli-version>, a git-<sha> for
+      # traceability, and floating latest on v* tag builds only.
+      - name: Generate image metadata
+        id: meta
+        uses: docker/metadata-action@v6
+        with:
+          images: ghcr.io/alrubinger/aileron-sandbox-${{ matrix.agent }}
+          tags: |
+            type=raw,value=${{ steps.ver.outputs.version }}-${{ steps.cli.outputs.version }}
+            type=sha,prefix=git-
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+          labels: |
+            org.opencontainers.image.title=Aileron sandbox ${{ matrix.agent }}
+            org.opencontainers.image.description=Aileron sandbox base composed with the ${{ matrix.agent }} agent CLI Feature.
+
+      - name: Log in to GitHub Container Registry
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      # Multi-arch build + push. Push only on v* tags and manual dispatch; PRs
+      # build (above, for the smoke) but never publish. Context is the repo root
+      # so the Containerfile's COPY of images/sandbox-features resolves.
+      - name: Build and push image
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: images/sandbox-agents/Containerfile.published
+          platforms: linux/amd64,linux/arm64
+          push: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          build-args: |
+            BASE_IMAGE=${{ steps.base.outputs.base_image }}
+            AGENT=${{ matrix.agent }}
+
+      # Launchability smoke against the LOADED :smoke image on PR, where nothing
+      # is pushed so there is no published manifest to pull. Asserts the agent
+      # CLI is on PATH and Builder.Validate succeeds (RequireProxyTrust=false,
+      # RequireMCPBinary=false), exactly as the launcher validates it
+      # (#1121/#1083 path).
+      - name: Smoke test loaded image
+        if: ${{ !(startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') }}
+        run: task test:integration:sandbox-agent-image
+        env:
+          AILERON_SANDBOX_AGENT_IMAGE: aileron-sandbox-${{ matrix.agent }}:smoke
+          AILERON_SANDBOX_AGENT_COMMAND: ${{ matrix.agent }}
+
+      # Published-manifest smoke (P2): whenever a push happened (v* tag release
+      # AND workflow_dispatch dry-run), pull the freshly published manifest back
+      # and run the same launchability validation against the PULLED ref. This
+      # exercises the published-manifest path — registry round-trip and
+      # multi-arch manifest selection — not just the locally-loaded :smoke
+      # image, so a real v* release validates the exact artifact consumers pull.
+      - name: Smoke test published image
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        run: |
+          set -euo pipefail
+          PUSHED_REF="ghcr.io/alrubinger/aileron-sandbox-${{ matrix.agent }}:${{ steps.ver.outputs.version }}-${{ steps.cli.outputs.version }}"
+          echo "Pulling published manifest ${PUSHED_REF}..."
+          docker pull "${PUSHED_REF}"
+          task test:integration:sandbox-agent-image
+        env:
+          AILERON_SANDBOX_AGENT_IMAGE: ghcr.io/alrubinger/aileron-sandbox-${{ matrix.agent }}:${{ steps.ver.outputs.version }}-${{ steps.cli.outputs.version }}
+          AILERON_SANDBOX_AGENT_COMMAND: ${{ matrix.agent }}

--- a/.github/workflows/sandbox-agents.yml
+++ b/.github/workflows/sandbox-agents.yml
@@ -80,35 +80,64 @@ jobs:
             echo "version=dev" >> "$GITHUB_OUTPUT"
           fi
 
-      # Resolve the GHCR base tag this build will FROM, and fail fast if it does
-      # not exist. The base workflow (sandbox-base.yml) publishes the exact
-      # release tag (`type=ref,event=tag`, e.g. v0.0.1) plus a floating `latest`
-      # on v* tag builds. On a v* trigger this workflow FROMs the version-pinned
-      # base tag so the per-agent image deterministically composes onto THIS
-      # release's base, not whatever `latest` happens to point at (the base and
-      # per-agent workflows run concurrently on the same tag push, so `latest`
-      # may still point at the prior release when this step runs). For PR and
-      # workflow_dispatch the version-pinned tag does not exist, so fall back to
-      # `latest`, the one tag reliably present from the previous release. Gate on
+      # Resolve the base image this build will FROM.
+      #
+      # On v* tags and workflow_dispatch (the paths that PUBLISH), FROM the
+      # GHCR-published base. The base workflow (sandbox-base.yml) publishes the
+      # exact release tag (`type=ref,event=tag`, e.g. v0.0.1) plus a floating
+      # `latest` on v* tag builds. A v* build FROMs the version-pinned tag so the
+      # per-agent image deterministically composes onto THIS release's base, not
+      # whatever `latest` happens to point at (the base and per-agent workflows
+      # run concurrently on the same tag push). workflow_dispatch FROMs `latest`,
+      # the one tag reliably present from the previous release. Gate on
       # `docker manifest inspect` so a missing base surfaces a precise error
       # naming the absent tag instead of an opaque FROM failure deep in the build.
-      - name: Resolve and verify base image tag
+      #
+      # On pull_request nothing is published and the GHCR base may not exist yet
+      # (no v* release has run sandbox-base.yml). Build the base locally from the
+      # in-repo recipe and FROM that, mirroring how the composition integration
+      # test (sandbox_features_composition_integration_test.go) builds the base
+      # rather than depending on a registry-published one. This keeps the PR bake
+      # + smoke path self-contained.
+      - name: Resolve and verify base image
         id: base
         run: |
           set -euo pipefail
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
-            BASE_TAG="${GITHUB_REF#refs/tags/}"
+            BASE_REF="${BASE_IMAGE_NAME}:${GITHUB_REF#refs/tags/}"
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+            BASE_REF="${BASE_IMAGE_NAME}:latest"
           else
-            BASE_TAG="latest"
+            BASE_REF=""
           fi
-          BASE_REF="${BASE_IMAGE_NAME}:${BASE_TAG}"
-          echo "Verifying base image ${BASE_REF} exists..."
-          if ! docker manifest inspect "${BASE_REF}" >/dev/null 2>&1; then
-            echo "::error::Base image ${BASE_REF} not found in GHCR. The sandbox-base workflow (sandbox-base.yml) publishes the release tag and 'latest' on v* tag builds; ensure the base release published the '${BASE_TAG}' tag before building per-agent images." >&2
-            exit 1
+          if [[ -n "${BASE_REF}" ]]; then
+            echo "Verifying published base image ${BASE_REF} exists..."
+            if ! docker manifest inspect "${BASE_REF}" >/dev/null 2>&1; then
+              echo "::error::Base image ${BASE_REF} not found in GHCR. The sandbox-base workflow (sandbox-base.yml) publishes the release tag and 'latest' on v* tag builds; ensure the base release published that tag before building per-agent images." >&2
+              exit 1
+            fi
+            echo "base_image=${BASE_REF}" >> "$GITHUB_OUTPUT"
+            echo "Using published base image ${BASE_REF}."
+          else
+            echo "build_local=true" >> "$GITHUB_OUTPUT"
+            echo "base_image=aileron-sandbox-base:pr-local" >> "$GITHUB_OUTPUT"
+            echo "PR build: will build the base locally from images/sandbox-base/Containerfile.published."
           fi
-          echo "base_image=${BASE_REF}" >> "$GITHUB_OUTPUT"
-          echo "Base image ${BASE_REF} present."
+
+      # On PR, build the in-repo base (single-arch, loaded) so the per-agent bake
+      # below can FROM it. The published recipe compiles aileron-mcp from source,
+      # so the repo-root context is required (it matches sandbox-base.yml).
+      - name: Build base image locally (PR)
+        if: ${{ steps.base.outputs.build_local == 'true' }}
+        uses: docker/build-push-action@v7
+        with:
+          context: .
+          file: images/sandbox-base/Containerfile.published
+          load: true
+          tags: aileron-sandbox-base:pr-local
+          build-args: |
+            AILERON_VERSION=${{ steps.ver.outputs.version }}
+            AILERON_COMMIT=${{ github.sha }}
 
       # Single-arch local load so the next steps can `docker run` the image to
       # resolve the agent CLI version and to run the launchability smoke. The
@@ -166,16 +195,21 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # Multi-arch build + push. Push only on v* tags and manual dispatch; PRs
-      # build (above, for the smoke) but never publish. Context is the repo root
-      # so the Containerfile's COPY of images/sandbox-features resolves.
+      # Multi-arch build + push. Runs only on the publishing paths (v* tags and
+      # manual dispatch), where the base is the multi-arch GHCR image. It is
+      # skipped on PR: a PR FROMs the locally-built single-arch base, which
+      # cannot satisfy a linux/amd64,linux/arm64 build, and the single-arch
+      # smoke build above already validates the per-agent bake on PR. Context is
+      # the repo root so the Containerfile's COPY of images/sandbox-features
+      # resolves.
       - name: Build and push image
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
         uses: docker/build-push-action@v7
         with:
           context: .
           file: images/sandbox-agents/Containerfile.published
           platforms: linux/amd64,linux/arm64
-          push: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+          push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
           build-args: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -367,6 +367,12 @@ tasks:
       AILERON_SANDBOX_FEATURES_CONTEXT:
         sh: cd "{{.ROOT_DIR}}/images/sandbox-features" && pwd
 
+  test:integration:sandbox-agent-image:
+    desc: "Smoke-test a published per-agent sandbox image (claude/codex): assert the agent CLI is on PATH and Builder.Validate succeeds (launchability), against the image ref in AILERON_SANDBOX_AGENT_IMAGE (#1086); fail-fast — requires Docker and the env set (no self-skip)"
+    dir: internal
+    cmds:
+      - go test -tags=integration_sandbox -run TestSandboxAgentImageSmoke ./launch/...
+
   test:e2e:integration:
     desc: Run Playwright E2E tests against running services
     dir: ui

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -32,6 +32,34 @@ Docker is the only supported sandbox runtime in v4. Podman is planned but not ye
 
 The harness-free `ghcr.io/alrubinger/aileron-sandbox-base` intentionally does not include agent CLIs ([ADR-0017](/adr/0017-sandbox-composition/)). Each agent install is authored once as a devcontainer Feature, the single source of truth that Aileron CI bakes into prebuilt per-agent images and that customers compose for Tier 1. The prebuilt per-agent image is the zero-build Tier 0 default, owned by [#965](https://github.com/ALRubinger/aileron/issues/965). Use Tier 1 when you want Aileron's base runtime plus an agent plus your own tools, or Tier 2 when your team owns the full image.
 
+## Prebuilt Per-Agent Images
+
+Aileron CI publishes one multi-arch image per agent to GHCR. Each image is baked from the GHCR sandbox base plus that agent's devcontainer Feature install script, so the Feature stays the single source of truth.
+
+| Agent | Image |
+|---|---|
+| Claude Code | `ghcr.io/alrubinger/aileron-sandbox-claude` |
+| Codex | `ghcr.io/alrubinger/aileron-sandbox-codex` |
+
+Each image is built for `linux/amd64` and `linux/arm64`, so a `docker pull` resolves the manifest for your platform automatically.
+
+The tag scheme is `<aileron-version>-<agent-cli-version>` plus a floating `latest`. The `<aileron-version>` is the Aileron release the image was built from. The `<agent-cli-version>` is the agent CLI version baked into the image, resolved at build time from the installed package. A git-traceability tag `git-<sha>` is also published.
+
+Pull the latest image:
+
+```bash
+docker pull ghcr.io/alrubinger/aileron-sandbox-claude:latest
+docker pull ghcr.io/alrubinger/aileron-sandbox-codex:latest
+```
+
+Pull a pinned version, for example Aileron `0.0.1` with the Claude CLI at `2.1.179`:
+
+```bash
+docker pull ghcr.io/alrubinger/aileron-sandbox-claude:0.0.1-2.1.179
+```
+
+CI smoke-tests every published image for launchability before it ships. The smoke asserts the agent CLI resolves on `PATH` and that the launcher's image validation succeeds. Republishing an image when a new agent CLI version releases is tracked by [#1088](https://github.com/ALRubinger/aileron/issues/1088).
+
 ## Claude Code Feature
 
 The Claude Code agent Feature installs the `claude` CLI onto `ghcr.io/alrubinger/aileron-sandbox-base`. It is the single source of truth that Aileron CI bakes into the prebuilt Claude image and that you compose for Tier 1. The Feature lives at `images/sandbox-features/claude/` (`devcontainer-feature.json` plus `install.sh`).

--- a/images/sandbox-agents/Containerfile.published
+++ b/images/sandbox-agents/Containerfile.published
@@ -1,0 +1,53 @@
+# Published per-agent sandbox image
+# (ghcr.io/alrubinger/aileron-sandbox-<agent>).
+#
+# This recipe BAKES one agent CLI onto the GHCR-published sandbox base. It is a
+# single parameterized recipe shared by every agent: the AGENT build-arg selects
+# which devcontainer Feature install script runs, so claude and codex stay in
+# lockstep with no per-agent Dockerfile duplication (issue #1086). The agent
+# Feature scripts under images/sandbox-features/<agent>/install.sh are the single
+# source of truth for the install recipe (issues #1082/#1083); CI bakes them
+# here.
+#
+# Build context is the REPO ROOT (the workflow passes `context: .`) because the
+# COPY below pulls in the images/sandbox-features tree. A repo-root .dockerignore
+# keeps the context lean; it must not exclude images/sandbox-features.
+#
+# The base already bakes aileron-mcp and stamps the ai.aileron.mcp.version label
+# (issue #957), so this recipe inherits both — it only layers the agent CLI on
+# top and never reintroduces the host-mount fallback.
+
+# BASE_IMAGE is the fully-qualified GHCR base reference resolved by the workflow
+# (e.g. ghcr.io/alrubinger/aileron-sandbox-base:latest). The workflow asserts the
+# tag exists via `docker manifest inspect` before building so a missing base
+# fails fast with a precise message instead of an opaque FROM error.
+ARG BASE_IMAGE=ghcr.io/alrubinger/aileron-sandbox-base:latest
+FROM ${BASE_IMAGE}
+
+# AGENT selects the Feature install script. It is interpolated ONLY in the RUN
+# body below, never in a COPY source path: a build-arg in a COPY source is
+# ambiguous and brittle, so the COPY pulls the whole lean features tree with a
+# literal source and the RUN picks the agent subdirectory.
+ARG AGENT
+
+LABEL org.opencontainers.image.title="Aileron sandbox ${AGENT}"
+LABEL org.opencontainers.image.description="Aileron sandbox base composed with the ${AGENT} agent CLI Feature."
+LABEL org.opencontainers.image.source="https://github.com/ALRubinger/aileron"
+
+# The Feature install scripts run as root on the Alpine base (apk add, npm -g).
+# The base's final stage drops to USER agent, so switch back to root for the
+# install, then restore the base's runtime invariants afterward.
+USER root
+
+# Literal source path (no ${AGENT} interpolation). The RUN body, where ${AGENT}
+# is unambiguous, selects the agent subdirectory and runs its install.sh. The
+# tree is removed in the same layer so the Feature sources do not bloat the
+# published image.
+COPY images/sandbox-features /tmp/aileron-features
+RUN sh "/tmp/aileron-features/${AGENT}/install.sh" \
+    && rm -rf /tmp/aileron-features
+
+# Restore the base's final-stage invariants so the composed image launches
+# exactly as the base does: non-root agent user, workspace CWD.
+WORKDIR /home/agent/workspace
+USER agent

--- a/internal/launch/sandbox_agent_image_smoke_test.go
+++ b/internal/launch/sandbox_agent_image_smoke_test.go
@@ -1,0 +1,113 @@
+//go:build integration_sandbox
+
+// Per-agent published image launchability smoke (#1086).
+//
+// Where sandbox_features_composition_integration_test.go (#1083) builds a
+// features-composed image inside the test and validates it, this test takes an
+// ALREADY-BUILT per-agent image — the `:smoke` single-arch load produced by the
+// sandbox-agents.yml workflow on PR, or the freshly PUBLISHED manifest pulled
+// back on workflow_dispatch — and asserts it is launchable exactly as the
+// launcher validates it.
+//
+// The image ref and the agent command are passed via env so one test body
+// serves both matrix legs (claude, codex) and both CI paths (loaded `:smoke`
+// vs. pulled published manifest):
+//
+//	AILERON_SANDBOX_AGENT_IMAGE    fully-qualified image ref to validate
+//	AILERON_SANDBOX_AGENT_COMMAND  agent CLI that must resolve on PATH (claude/codex)
+//
+// The smoke mirrors the #1121/#1083 launchability path: assert the agent CLI is
+// on PATH, then run Builder.Validate with RequireProxyTrust=false and
+// RequireMCPBinary=false. Both gates are unset because this composed image
+// derives from the base WITHOUT a launch-time ca.pem mounted and the host-mount
+// is not in play for the smoke; the launchability contract under test is a
+// writable /home/agent/workspace, the correct CWD, and the agent on PATH.
+//
+// Per the umbrella's two-layer test posture this test is FAIL-FAST: there is no
+// t.Skip. If Docker, the env, or the image is absent, the test FAILS. CI
+// provisions the toolchain and sets the env per matrix agent.
+//
+// Run with:
+//
+//	task test:integration:sandbox-agent-image
+//
+// or directly:
+//
+//	AILERON_SANDBOX_AGENT_IMAGE=... AILERON_SANDBOX_AGENT_COMMAND=claude \
+//	  go test -tags=integration_sandbox -run TestSandboxAgentImageSmoke ./launch/...
+package launch
+
+import (
+	"context"
+	"os"
+	"testing"
+	"time"
+
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// TestSandboxAgentImageSmoke validates that the per-agent image named by
+// AILERON_SANDBOX_AGENT_IMAGE is launchable: the agent CLI named by
+// AILERON_SANDBOX_AGENT_COMMAND is on PATH, and Builder.Validate succeeds with
+// both the proxy-trust and MCP-binary gates unset.
+func TestSandboxAgentImageSmoke(t *testing.T) {
+	image := os.Getenv("AILERON_SANDBOX_AGENT_IMAGE")
+	if image == "" {
+		// Fail-fast: CI sets the image ref per matrix agent; absence is a job
+		// configuration failure, not a skip.
+		t.Fatalf("AILERON_SANDBOX_AGENT_IMAGE must be set to the per-agent image ref under test (required, not skipped)")
+	}
+	command := os.Getenv("AILERON_SANDBOX_AGENT_COMMAND")
+	if command == "" {
+		t.Fatalf("AILERON_SANDBOX_AGENT_COMMAND must be set to the agent CLI (claude/codex) expected on PATH (required, not skipped)")
+	}
+
+	rt, err := sandboxcontainer.ResolveRuntime("docker")
+	if err != nil {
+		// Fail-fast: CI provisions Docker; absence is a job failure, not a skip.
+		t.Fatalf("no docker runtime on PATH (required, not skipped): %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+
+	// (a) The agent Feature put the CLI on PATH for the running user.
+	assertCommandOnPath(ctx, t, rt, image, command)
+
+	// (b) Launchability: the image satisfies the launch-time runtime contract,
+	// not merely carrying the agent CLI on PATH. Builder.Validate runs the same
+	// probe the launcher uses — a writable /home/agent/workspace mount, CWD
+	// there, and the agent command resolvable.
+	builder := sandboxcontainer.Builder{
+		Stdout: testLogWriter{t},
+		Stderr: testLogWriter{t},
+	}
+
+	// The workspace is bind-mounted at /home/agent/workspace and the container
+	// runs as the non-root `agent` user, whose uid does not match the host uid
+	// that owns t.TempDir() (0700). On a Linux Docker host that makes the mount
+	// unwritable to `agent`, so Validate's writable-workspace probe fails; make
+	// it world-writable so the launchability check exercises the IMAGE contract,
+	// not host/container uid mapping. (Docker Desktop masks this with permissive
+	// file sharing, which is why it only surfaces on Linux CI.)
+	workspace := t.TempDir()
+	if err := os.Chmod(workspace, 0o777); err != nil {
+		t.Fatalf("chmod validate workspace: %v", err)
+	}
+
+	// RequireProxyTrust and RequireMCPBinary are both false: the composed image
+	// derives from the base WITHOUT a launch-time ca.pem mounted, so the proxy
+	// gate would fail deterministically, and the MCP host-mount is not exercised
+	// by this image-only smoke (#957/ADR-0024). The launchability contract under
+	// test is the writable workspace, CWD, and agent-on-PATH only.
+	if err := builder.Validate(ctx, sandboxcontainer.ValidateOptions{
+		Runtime:           rt,
+		Image:             image,
+		WorkDir:           workspace,
+		Command:           []string{command},
+		RequireProxyTrust: false,
+		RequireMCPBinary:  false,
+	}); err != nil {
+		t.Fatalf("Builder.Validate (launchability of published per-agent image %s): %v", image, err)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a CI pipeline that bakes and publishes multi-arch (`linux/amd64`+`linux/arm64`) per-agent sandbox images — `ghcr.io/alrubinger/aileron-sandbox-claude` and `-codex` — each composed from the GHCR-published `aileron-sandbox-base` plus the agent's devcontainer Feature install script. The Feature scripts under `images/sandbox-features/<agent>/install.sh` stay the single source of truth; one parameterized `Containerfile.published` bakes any agent via `BASE_IMAGE`/`AGENT` build-args.

- **`images/sandbox-agents/Containerfile.published`** — `FROM ${BASE_IMAGE}`, `COPY images/sandbox-features` (literal source, no `${AGENT}` interpolation in the COPY path), `RUN sh /tmp/aileron-features/${AGENT}/install.sh`, then restores the base's `USER agent` / `WORKDIR /home/agent/workspace` invariants.
- **`.github/workflows/sandbox-agents.yml`** — one workflow, `strategy.matrix.agent: [claude, codex]`, per-agent job-level concurrency. Resolves the aileron version and agent-CLI version (probed from the loaded image), fails fast on a missing base tag via `docker manifest inspect`, multi-arch build+push on `v*`/dispatch, single-arch `:smoke` load for the launchability smoke. Tags: `<aileron-version>-<agent-cli-version>`, `git-<sha>`, and floating `latest` on `v*`.
- **`internal/launch/sandbox_agent_image_smoke_test.go`** (build tag `integration_sandbox`) — parameterized via `AILERON_SANDBOX_AGENT_IMAGE`/`AILERON_SANDBOX_AGENT_COMMAND`; asserts `command -v <agent>` resolves and `Builder.Validate` succeeds with `RequireProxyTrust=false`, `RequireMCPBinary=false`, reusing the #1121/#1083 path. Fail-fast (no `t.Skip`).
- **`Taskfile.yml`** — `test:integration:sandbox-agent-image` target.
- **Docs** — "Prebuilt Per-Agent Images" subsection listing both images, the tag scheme, and `docker pull` examples.

No credentials are baked: the only secret usages are GHCR login and the setup-task repo-token; none flow into `build-args`. No OpenAPI/`server.gen.go` change (CI + image plumbing only). Republish-on-agent-release automation is out of scope (#1088).

## Test plan

- [x] Built both per-agent images locally from the in-repo base (`docker build --build-arg BASE_IMAGE=... --build-arg AGENT=claude`/`=codex`); confirmed `command -v claude` → `/usr/local/bin/claude`, `command -v codex` → `/usr/local/bin/codex`, both run as `agent` in `/home/agent/workspace`.
- [x] `<agent> --version` probe extracts a clean semver (claude `2.1.179`, codex `0.140.0`).
- [x] Go launchability smoke passes against both loaded images via `task test:integration:sandbox-agent-image`.
- [x] Fail-fast verified: missing `AILERON_SANDBOX_AGENT_IMAGE` fails the test rather than skipping.
- [x] `actionlint` clean; `go build`/`go vet` clean on the `internal` module; `composition` unit tests pass (no recipe drift).
- [x] CodeRabbit review pass: fixed the per-agent concurrency group (was matrix-blind) and extended the published-manifest smoke to `v*` releases.
- [ ] CI green on this PR (multi-arch build runs without push on PR; smoke runs against the loaded `:smoke` image per matrix agent).

Closes #1086

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Prebuilt multi-architecture per-agent sandbox container images now available on GHCR for Claude and Codex agents with deterministic version-based tagging.

* **Documentation**
  * Added guide documenting prebuilt per-agent sandbox images, including naming scheme, supported platforms, and usage examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->