### PR TITLE
feat(launch): auto-resolve published per-agent image when no devcontainer

### DIFF
--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -81,7 +81,7 @@ func runSandboxPlan(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
-	plan, err := sandboxcomposition.Discover(cwd, version.Version)
+	plan, err := sandboxcomposition.Discover(cwd, version.Version, "")
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
@@ -129,7 +129,7 @@ func runSandboxBuild(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
-	plan, err := sandboxcomposition.Discover(cwd, version.Version)
+	plan, err := sandboxcomposition.Discover(cwd, version.Version, "")
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
@@ -182,7 +182,11 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
-	plan, err := sandboxcomposition.Discover(cwd, version.Version)
+	// Pass the resolved agent command so `sandbox check` resolves the same
+	// published per-agent image the launcher would (launch/check parity). With
+	// no .devcontainer and a published agent, this plans TierPublished and the
+	// build step pulls (or inspects) the per-agent image.
+	plan, err := sandboxcomposition.Discover(cwd, version.Version, command)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1

--- a/cmd/aileron/sandbox_test.go
+++ b/cmd/aileron/sandbox_test.go
@@ -9,6 +9,7 @@ import (
 	"strings"
 	"testing"
 
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 	"github.com/ALRubinger/aileron/internal/version"
 )
@@ -44,6 +45,22 @@ func TestRunSandboxPlanPrintsFeatures(t *testing.T) {
 	}
 	if !strings.Contains(got, "tier: devcontainer") {
 		t.Fatalf("plan output missing tier line:\n%s", got)
+	}
+}
+
+func TestRunSandboxPlanNoDevcontainerStaysOnBaseTier(t *testing.T) {
+	// `sandbox plan` passes no agent, so a project without a .devcontainer must
+	// keep the base tier rather than resolving a published per-agent image.
+	t.Chdir(t.TempDir())
+	var out, errb bytes.Buffer
+	if code := runSandboxPlan(nil, &out, &errb); code != 0 {
+		t.Fatalf("runSandboxPlan = %d, stderr: %s", code, errb.String())
+	}
+	if !strings.Contains(out.String(), "tier: base") {
+		t.Fatalf("plan output = %q, want base tier", out.String())
+	}
+	if !strings.Contains(out.String(), sandboxcomposition.BaseImage(version.Version)) {
+		t.Fatalf("plan output = %q, want base image", out.String())
 	}
 }
 
@@ -235,6 +252,60 @@ func TestRunSandboxCheckUnbakedNoSkewNoRequireMCP(t *testing.T) {
 	}
 	if strings.Contains(out.String(), "baked aileron-mcp") || strings.Contains(errb.String(), "warning:") {
 		t.Fatalf("unbaked check must not mention baked mcp; stdout=%q stderr=%q", out.String(), errb.String())
+	}
+}
+
+// captureSandboxCheckPlan swaps the build/baked/validate seams and returns a
+// pointer to the composition plan runSandboxCheck resolves and hands to the
+// builder. It lets the test assert the resolved image without a real runtime.
+func captureSandboxCheckPlan(t *testing.T) *sandboxcomposition.Plan {
+	t.Helper()
+	origBuild := sandboxCheckBuildFn
+	origBaked := sandboxCheckBakedVersionFn
+	origValidate := sandboxCheckValidateFn
+	t.Cleanup(func() {
+		sandboxCheckBuildFn = origBuild
+		sandboxCheckBakedVersionFn = origBaked
+		sandboxCheckValidateFn = origValidate
+	})
+	var gotPlan sandboxcomposition.Plan
+	sandboxCheckBuildFn = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.BuildOptions) (sandboxcontainer.BuildResult, error) {
+		gotPlan = opts.Plan
+		return sandboxcontainer.BuildResult{Runtime: "docker", Image: opts.Plan.Image, Tier: opts.Plan.Tier}, nil
+	}
+	sandboxCheckBakedVersionFn = func(context.Context, string, string) string { return "" }
+	sandboxCheckValidateFn = func(context.Context, string, string, string, string, bool) error { return nil }
+	return &gotPlan
+}
+
+func TestRunSandboxCheckPublishedAgentResolvesPerAgentImage(t *testing.T) {
+	t.Chdir(t.TempDir())
+	plan := captureSandboxCheckPlan(t)
+	var out, errb bytes.Buffer
+	if code := runSandboxCheck([]string{"--agent=claude"}, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if plan.Tier != sandboxcomposition.TierPublished {
+		t.Fatalf("plan.Tier = %s, want %s", plan.Tier, sandboxcomposition.TierPublished)
+	}
+	want := sandboxcomposition.PublishedAgentImage("claude", version.Version)
+	if plan.Image != want {
+		t.Fatalf("plan.Image = %q, want %q (parity with launch)", plan.Image, want)
+	}
+}
+
+func TestRunSandboxCheckUnpublishedAgentUsesBaseImage(t *testing.T) {
+	t.Chdir(t.TempDir())
+	plan := captureSandboxCheckPlan(t)
+	var out, errb bytes.Buffer
+	if code := runSandboxCheck([]string{"--agent=goose"}, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if plan.Tier != sandboxcomposition.TierBase {
+		t.Fatalf("plan.Tier = %s, want %s", plan.Tier, sandboxcomposition.TierBase)
+	}
+	if plan.Image != sandboxcomposition.BaseImage(version.Version) {
+		t.Fatalf("plan.Image = %q, want base image", plan.Image)
 	}
 }
 

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -32,6 +32,16 @@ Docker is the only supported sandbox runtime in v4. Podman is planned but not ye
 
 The harness-free `ghcr.io/alrubinger/aileron-sandbox-base` intentionally does not include agent CLIs ([ADR-0017](/adr/0017-sandbox-composition/)). Each agent install is authored once as a devcontainer Feature, the single source of truth that Aileron CI bakes into prebuilt per-agent images and that customers compose for Tier 1. The prebuilt per-agent image is the zero-build Tier 0 default, owned by [#965](https://github.com/ALRubinger/aileron/issues/965). Use Tier 1 when you want Aileron's base runtime plus an agent plus your own tools, or Tier 2 when your team owns the full image.
 
+## Build-Free Default
+
+With no `.devcontainer` in the project, `aileron launch --sandbox=docker <agent>` is build-free for a published agent. The launcher resolves the prebuilt per-agent image `ghcr.io/alrubinger/aileron-sandbox-<agent>` and pulls it. There is no `sandbox init`, no Dockerfile, and no local image build. The published agents today are `claude` and `codex`.
+
+`sandbox check --agent=<agent>` resolves the same image, so a passing check matches what launch will run.
+
+The launcher resolves the floating `latest` tag for this build-free default. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so `latest` is the correct in-process pin. Digest pinning and the freshness policy that consumes it are owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088); the resolver is the seam where that pinned reference plugs in.
+
+When the requested agent has no published image, launch falls back to the customization tier. The image validation then emits the actionable message to install the agent CLI in the sandbox image or launch with `--sandbox=off`.
+
 ## Prebuilt Per-Agent Images
 
 Aileron CI publishes one multi-arch image per agent to GHCR. Each image is baked from the GHCR sandbox base plus that agent's devcontainer Feature install script, so the Feature stays the single source of truth.

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -193,7 +193,7 @@ func normalizeLaunchBuildPolicy(policy string) (string, error) {
 	}
 }
 
-func prepareSandbox(ctx context.Context, workDir, runtimeName, buildPolicy string, stdout, stderr io.Writer) (SandboxLaunchPlan, error) {
+func prepareSandbox(ctx context.Context, workDir, agent, runtimeName, buildPolicy string, stdout, stderr io.Writer) (SandboxLaunchPlan, error) {
 	if err := validateSandboxRuntime(runtimeName); err != nil {
 		return SandboxLaunchPlan{}, err
 	}
@@ -201,7 +201,7 @@ func prepareSandbox(ctx context.Context, workDir, runtimeName, buildPolicy strin
 	if err != nil {
 		return SandboxLaunchPlan{}, err
 	}
-	plan, err := sandboxcomposition.Discover(workDir, version.Version)
+	plan, err := sandboxcomposition.Discover(workDir, version.Version, agent)
 	if err != nil {
 		return SandboxLaunchPlan{}, err
 	}
@@ -362,7 +362,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	}
 	var sandboxPlan SandboxLaunchPlan
 	if sandboxEnabled {
-		plan, err := prepareSandboxForLaunch(ctx, config.Dir, config.SandboxRuntime, config.SandboxBuildPolicy, os.Stdout, os.Stderr)
+		plan, err := prepareSandboxForLaunch(ctx, config.Dir, config.Agent.Name(), config.SandboxRuntime, config.SandboxBuildPolicy, os.Stdout, os.Stderr)
 		if err != nil {
 			return LaunchResult{}, fmt.Errorf("prepare sandbox: %w", err)
 		}

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -995,6 +995,63 @@ func TestLaunch_SandboxBuildRunsPreparedImage(t *testing.T) {
 	}
 }
 
+// publishedAgent reports a Name() that has a published per-agent sandbox image
+// (claude/codex), so the no-.devcontainer launch path resolves the build-free
+// TierPublished default and pulls the per-agent image instead of building the
+// local base.
+type publishedAgent struct {
+	scriptAgent
+	name string
+}
+
+func (a publishedAgent) Name() string { return a.name }
+
+func TestLaunch_SandboxNoDevcontainerPublishedAgentPullsPerAgentImage(t *testing.T) {
+	dir := t.TempDir()
+	// No images/sandbox-base context and no .devcontainer: the only build-free
+	// route is the published per-agent image. If the launcher fell back to the
+	// base build it would fail to find the Containerfile context.
+	binDir := t.TempDir()
+	argsFile := filepath.Join(dir, "docker-args.txt")
+	docker := filepath.Join(binDir, "docker")
+	if err := os.WriteFile(docker, []byte("#!/bin/sh\nprintf '%s\\n' \"$@\" >> "+argsFile+"\nprintf '%s\\n' --- >> "+argsFile+"\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:              publishedAgent{scriptAgent: scriptAgent{script: "claude"}, name: "claude"},
+		Dir:                dir,
+		Args:               []string{"--dangerously-skip-permissions"},
+		SandboxRuntime:     "docker",
+		SandboxBuildPolicy: "always",
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read docker args: %v", err)
+	}
+	args := string(data)
+	const image = "ghcr.io/alrubinger/aileron-sandbox-claude:latest"
+	for _, want := range []string{
+		"pull\n" + image + "\n",
+		"run\n--rm\n-i\n",
+		"--env\nAILERON_SANDBOX_IMAGE=" + image + "\n",
+		"--env\nAILERON_SANDBOX_TIER=published\n",
+		image + "\naileron-run-with-proxy-ca\nclaude\n--dangerously-skip-permissions\n",
+	} {
+		if !strings.Contains(args, want) {
+			t.Errorf("expected %q in docker args:\n%s", want, args)
+		}
+	}
+	// The published path must not build the local base image.
+	if strings.Contains(args, "build\n-t\nghcr.io/alrubinger/aileron-sandbox-base") {
+		t.Errorf("published launch unexpectedly built the local base image:\n%s", args)
+	}
+}
+
 func TestLaunch_SandboxBuildFailureFailsBeforeAgentStart(t *testing.T) {
 	dir := t.TempDir()
 	baseDir := filepath.Join(dir, "images", "sandbox-base")

--- a/internal/launch/sandbox_features_composition_integration_test.go
+++ b/internal/launch/sandbox_features_composition_integration_test.go
@@ -97,7 +97,7 @@ func TestSandboxFeaturesComposeViaAileron(t *testing.T) {
 	}
 
 	// Drive Aileron's own composition + build plumbing.
-	plan, err := sandboxcomposition.Discover(workspace, "test")
+	plan, err := sandboxcomposition.Discover(workspace, "test", "")
 	if err != nil {
 		t.Fatalf("composition.Discover: %v", err)
 	}

--- a/internal/sandbox/composition/composition.go
+++ b/internal/sandbox/composition/composition.go
@@ -22,6 +22,13 @@ const (
 	// It is published to GHCR by the sandbox-base CI workflow and mirrors the
 	// DefaultFeatureRepository prefix style.
 	DefaultBaseImageRepository = "ghcr.io/alrubinger/aileron-sandbox-base"
+	// DefaultPublishedImageRepository is the registry prefix that hosts Aileron's
+	// prebuilt per-agent sandbox images. The per-agent image name is this prefix
+	// plus "-<agent>" (see PublishedAgentImage), e.g.
+	// ghcr.io/alrubinger/aileron-sandbox-claude. These images bake the agent CLI
+	// and aileron-mcp onto the base, so the default build-free launch path pulls
+	// one of them instead of building the agent-less base locally (#1086, #1087).
+	DefaultPublishedImageRepository = "ghcr.io/alrubinger/aileron-sandbox"
 	// DefaultFeatureRepository is the registry path that hosts Aileron's
 	// per-agent devcontainer Features. The scaffold composes one of these
 	// Features (see FeatureReference) into the starter devcontainer.json, and
@@ -36,6 +43,13 @@ const (
 	TierBase         Tier = "base"
 	TierDevcontainer Tier = "devcontainer"
 	TierBYOImage     Tier = "byo_image"
+	// TierPublished is the build-free Tier 0 default for an agent with a
+	// prebuilt per-agent image. With no .devcontainer present and a published
+	// agent requested, Discover resolves this tier with Image set to the
+	// per-agent image (see PublishedAgentImage). The container builder pulls the
+	// image instead of building the local base, because the base carries no
+	// agent CLI (#1086, #1087).
+	TierPublished Tier = "published"
 )
 
 // Plan is the normalized sandbox-composition plan consumed by launch/runtime
@@ -96,7 +110,16 @@ type devcontainerCustomizations struct {
 }
 
 // Discover returns the sandbox image-composition plan for workDir.
-func Discover(workDir, version string) (Plan, error) {
+//
+// agent is the launch agent's name (e.g. "claude", "codex"). It only affects
+// the no-.devcontainer branch: when a project authors no .devcontainer and the
+// agent has a published per-agent image (PublishedAgentExists), Discover
+// resolves the build-free Tier 0 default (TierPublished) whose Image is that
+// per-agent image. An empty agent or an agent with no published image keeps the
+// existing local-base behavior (TierBase), so `sandbox plan`/`build` (which pass
+// no agent) and unsupported agents are unchanged. The agent never perturbs Tier
+// 1/Tier 2 resolution when a .devcontainer is present.
+func Discover(workDir, version, agent string) (Plan, error) {
 	if workDir == "" {
 		workDir = "."
 	}
@@ -105,6 +128,13 @@ func Discover(workDir, version string) (Plan, error) {
 	b, err := os.ReadFile(devcontainerPath)
 	if err != nil {
 		if errors.Is(err, os.ErrNotExist) {
+			if agent != "" && PublishedAgentExists(agent) {
+				return Plan{
+					Tier:      TierPublished,
+					BaseImage: baseImage,
+					Image:     PublishedAgentImage(agent, version),
+				}, nil
+			}
 			return Plan{Tier: TierBase, BaseImage: baseImage, Image: baseImage}, nil
 		}
 		return Plan{}, fmt.Errorf("read %s: %w", devcontainerPath, err)

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -8,7 +8,7 @@ import (
 )
 
 func TestDiscoverMissingDevcontainerUsesBaseImage(t *testing.T) {
-	plan, err := Discover(t.TempDir(), "0.4.0")
+	plan, err := Discover(t.TempDir(), "0.4.0", "")
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -17,6 +17,107 @@ func TestDiscoverMissingDevcontainerUsesBaseImage(t *testing.T) {
 	}
 	if plan.Image != "ghcr.io/alrubinger/aileron-sandbox-base:0.4.0" {
 		t.Fatalf("Image = %q", plan.Image)
+	}
+}
+
+func TestDiscoverMissingDevcontainerPublishedAgentResolvesPerAgentImage(t *testing.T) {
+	for _, tc := range []struct {
+		agent     string
+		wantImage string
+	}{
+		{"claude", "ghcr.io/alrubinger/aileron-sandbox-claude:0.4.0"},
+		{"codex", "ghcr.io/alrubinger/aileron-sandbox-codex:0.4.0"},
+	} {
+		t.Run(tc.agent, func(t *testing.T) {
+			plan, err := Discover(t.TempDir(), "0.4.0", tc.agent)
+			if err != nil {
+				t.Fatalf("Discover: %v", err)
+			}
+			if plan.Tier != TierPublished {
+				t.Fatalf("Tier = %s, want %s", plan.Tier, TierPublished)
+			}
+			if plan.Image != tc.wantImage {
+				t.Fatalf("Image = %q, want %q", plan.Image, tc.wantImage)
+			}
+			if plan.BaseImage != BaseImage("0.4.0") {
+				t.Fatalf("BaseImage = %q, want %q", plan.BaseImage, BaseImage("0.4.0"))
+			}
+		})
+	}
+}
+
+func TestDiscoverMissingDevcontainerUnpublishedAgentFallsBackToBase(t *testing.T) {
+	// goose has no recipe/published image, so it must keep the base behavior so
+	// the downstream actionable "install the agent CLI or --sandbox=off" path
+	// stays intact.
+	plan, err := Discover(t.TempDir(), "0.4.0", "goose")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if plan.Tier != TierBase {
+		t.Fatalf("Tier = %s, want %s", plan.Tier, TierBase)
+	}
+	if plan.Image != BaseImage("0.4.0") {
+		t.Fatalf("Image = %q, want %q", plan.Image, BaseImage("0.4.0"))
+	}
+}
+
+func TestDiscoverMissingDevcontainerEmptyAgentStaysOnBase(t *testing.T) {
+	// `sandbox plan`/`build` pass no agent; that path must keep the base tier.
+	plan, err := Discover(t.TempDir(), "0.4.0", "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if plan.Tier != TierBase {
+		t.Fatalf("Tier = %s, want %s", plan.Tier, TierBase)
+	}
+}
+
+func TestDiscoverDevcontainerIgnoresAgentForTierResolution(t *testing.T) {
+	// A present .devcontainer resolves Tier 1/Tier 2 regardless of the agent;
+	// the agent param only affects the no-.devcontainer branch.
+	dir := t.TempDir()
+	writeDevcontainer(t, dir, `{
+  "image": "ghcr.io/acme/custom:1",
+  "customizations": {"aileron": {"image": "ghcr.io/acme/byo:1"}}
+}`)
+	plan, err := Discover(dir, "0.4.0", "claude")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if plan.Tier != TierBYOImage {
+		t.Fatalf("Tier = %s, want %s", plan.Tier, TierBYOImage)
+	}
+	if plan.Image != "ghcr.io/acme/byo:1" {
+		t.Fatalf("Image = %q", plan.Image)
+	}
+}
+
+func TestPublishedAgentImage(t *testing.T) {
+	for _, tc := range []struct {
+		version string
+		want    string
+	}{
+		{"", "ghcr.io/alrubinger/aileron-sandbox-claude:latest"},
+		{"dev", "ghcr.io/alrubinger/aileron-sandbox-claude:latest"},
+		{"0.4.0", "ghcr.io/alrubinger/aileron-sandbox-claude:0.4.0"},
+	} {
+		if got := PublishedAgentImage("claude", tc.version); got != tc.want {
+			t.Fatalf("PublishedAgentImage(claude, %q) = %q, want %q", tc.version, got, tc.want)
+		}
+	}
+}
+
+func TestPublishedAgentExists(t *testing.T) {
+	for agent, want := range map[string]bool{
+		"claude": true,
+		"codex":  true,
+		"goose":  false,
+		"":       false,
+	} {
+		if got := PublishedAgentExists(agent); got != want {
+			t.Fatalf("PublishedAgentExists(%q) = %v, want %v", agent, got, want)
+		}
 	}
 }
 
@@ -40,7 +141,7 @@ func TestDiscoverDevcontainerBuildPlan(t *testing.T) {
   }
 }`)
 
-	plan, err := Discover(dir, "dev")
+	plan, err := Discover(dir, "dev", "")
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -71,7 +172,7 @@ func TestDiscoverDevcontainerRootDockerfileAndImage(t *testing.T) {
   "dockerFile": "Dockerfile.custom"
 }`)
 
-	plan, err := Discover(dir, "0.4.0")
+	plan, err := Discover(dir, "0.4.0", "")
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -98,7 +199,7 @@ func TestDiscoverAileronImageIsBYOImage(t *testing.T) {
   }
 }`)
 
-	plan, err := Discover(dir, "0.4.0")
+	plan, err := Discover(dir, "0.4.0", "")
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -117,7 +218,7 @@ func TestDiscoverInvalidMountReturnsError(t *testing.T) {
 	dir := t.TempDir()
 	writeDevcontainer(t, dir, `{"mounts":[42]}`)
 
-	_, err := Discover(dir, "0.4.0")
+	_, err := Discover(dir, "0.4.0", "")
 	if err == nil {
 		t.Fatal("expected mount parse error")
 	}
@@ -180,7 +281,7 @@ func TestInitWritesFeatureComposingDevcontainer(t *testing.T) {
 
 	// Assert on the produced config shape via Discover (the contract), not on
 	// the raw scaffold text.
-	plan, err := Discover(dir, "0.4.0")
+	plan, err := Discover(dir, "0.4.0", "")
 	if err != nil {
 		t.Fatalf("Discover scaffolded devcontainer: %v", err)
 	}
@@ -258,7 +359,7 @@ func TestDiscoverParsesFeaturesIntoPlan(t *testing.T) {
   "customizations": {"aileron": {"approval_surface": "both"}}
 }`)
 
-	plan, err := Discover(dir, "0.4.0")
+	plan, err := Discover(dir, "0.4.0", "")
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -287,7 +388,7 @@ func TestDiscoverWithoutFeaturesLeavesNilMap(t *testing.T) {
 	dir := t.TempDir()
 	writeDevcontainer(t, dir, `{"build": {"dockerfile": "Dockerfile"}}`)
 
-	plan, err := Discover(dir, "0.4.0")
+	plan, err := Discover(dir, "0.4.0", "")
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -303,7 +404,7 @@ func TestDiscoverCarriesFeaturesOnBYOImagePlan(t *testing.T) {
   "customizations": {"aileron": {"image": "ghcr.io/acme/agent:2026"}}
 }`)
 
-	plan, err := Discover(dir, "0.4.0")
+	plan, err := Discover(dir, "0.4.0", "")
 	if err != nil {
 		t.Fatalf("Discover: %v", err)
 	}
@@ -321,7 +422,7 @@ func TestDiscoverRejectsNonObjectFeatures(t *testing.T) {
 	dir := t.TempDir()
 	writeDevcontainer(t, dir, `{"features": ["ghcr.io/acme/tool:1"]}`)
 
-	_, err := Discover(dir, "0.4.0")
+	_, err := Discover(dir, "0.4.0", "")
 	if err == nil {
 		t.Fatal("expected parse error for non-object features")
 	}

--- a/internal/sandbox/composition/scaffold.go
+++ b/internal/sandbox/composition/scaffold.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // DefaultAgent is the agent whose Feature the scaffold demonstrates. It is no
@@ -66,6 +67,38 @@ func Init(opts InitOptions) (InitResult, error) {
 // hard-coding a premature 1.0.0.
 func FeatureReference(agent string) string {
 	return DefaultFeatureRepository + "/" + agent + ":0"
+}
+
+// PublishedAgentImage returns the prebuilt per-agent sandbox image reference for
+// an agent (e.g. "ghcr.io/alrubinger/aileron-sandbox-claude:latest"). It is the
+// one place in Go that names the per-agent image registry path and tag,
+// mirroring BaseImage for the base image. These images bake the agent CLI and
+// aileron-mcp onto the base, so the build-free Tier 0 default pulls one instead
+// of building the agent-less base (#1086, #1087).
+//
+// The tag follows the same normalization as BaseImage: an empty or "dev"
+// version maps to "latest". The launcher resolves this floating "latest" pin at
+// launch time because a version-pinned tag (<aileron-version>-<agent-cli-version>)
+// requires the agent CLI version, which is not known here. Digest pinning and
+// the freshness policy that consumes it are owned by #1088; this helper is the
+// seam where that pinned reference plugs in.
+func PublishedAgentImage(agent, version string) string {
+	tag := strings.TrimSpace(version)
+	if tag == "" || tag == "dev" {
+		tag = "latest"
+	}
+	return DefaultPublishedImageRepository + "-" + agent + ":" + tag
+}
+
+// PublishedAgentExists reports whether agent has a prebuilt per-agent image to
+// pull for the build-free default. It reuses the agentRecipes set, which is the
+// single source of truth for "this agent has a verified recipe and ships a
+// published Feature/image" (see recipes.go). Discover and `sandbox check` share
+// this predicate so both resolve the same image (the launch/check parity
+// requirement). New agents that gain a recipe automatically gain auto-resolve.
+func PublishedAgentExists(agent string) bool {
+	_, ok := recipeForAgent(agent)
+	return ok
 }
 
 // starterDevcontainer emits the Feature-composing devcontainer.json recorded in

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -307,6 +307,35 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 		}
 		result.Built = true
 		return result, nil
+	case composition.TierPublished:
+		// A published per-agent image is pulled, never built locally — that is
+		// the whole point of the build-free default. The Runner/runtimeName seam
+		// (ADR-0014) is preserved: the pull threads runtimeName exactly like the
+		// build path. A pull is not a local build, so Built stays false; the
+		// launcher keys image env wiring off Image, not Built.
+		runtimeName, err := resolveRuntime(b.Runtime, b.Runner == nil)
+		if err != nil {
+			return BuildResult{}, err
+		}
+		result.Runtime = runtimeName
+		result.Image = opts.Plan.Image
+		switch policy {
+		case BuildPolicyNever:
+			if !b.imageExists(ctx, runner, runtimeName, result.Image) {
+				return BuildResult{}, fmt.Errorf("sandbox image %s not found locally and sandbox build policy is never; run `%s pull %s` or use --sandbox-build=auto|always", result.Image, runtimeName, result.Image)
+			}
+			return result, nil
+		case BuildPolicyAuto:
+			if b.imageExists(ctx, runner, runtimeName, result.Image) {
+				return result, nil
+			}
+		}
+		// BuildPolicyAuto with the image absent, or BuildPolicyAlways: pull it.
+		pullArgs := []string{"pull", result.Image}
+		if err := runner.Run(ctx, runtimeName, pullArgs, stdout, stderr); err != nil {
+			return BuildResult{}, fmt.Errorf("%s %s: %w", runtimeName, strings.Join(pullArgs, " "), err)
+		}
+		return result, nil
 	case composition.TierBYOImage:
 		result.Image = opts.Plan.Image
 		return result, ErrNoBuildRequired

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -439,6 +439,129 @@ func TestBuildBYOImageDoesNotBuild(t *testing.T) {
 	}
 }
 
+const publishedImage = "ghcr.io/alrubinger/aileron-sandbox-claude:latest"
+
+func TestBuildPublishedAutoPullsMissingImage(t *testing.T) {
+	// image inspect fails (absent) → pull.
+	runner := &callRecordingRunner{errs: []error{errors.New("missing"), nil}}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: t.TempDir(),
+		Policy:  BuildPolicyAuto,
+		Plan: composition.Plan{
+			Tier:  composition.TierPublished,
+			Image: publishedImage,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if result.Built {
+		t.Fatalf("result.Built = true, want false (a pull is not a local build)")
+	}
+	if result.Image != publishedImage {
+		t.Fatalf("result.Image = %q, want %q", result.Image, publishedImage)
+	}
+	if result.Tier != composition.TierPublished {
+		t.Fatalf("result.Tier = %q, want %q", result.Tier, composition.TierPublished)
+	}
+	want := []runnerCall{
+		{name: "docker", args: []string{"image", "inspect", publishedImage}},
+		{name: "docker", args: []string{"pull", publishedImage}},
+	}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestBuildPublishedAutoSkipsExistingImage(t *testing.T) {
+	// image inspect succeeds (present) → no pull.
+	runner := &callRecordingRunner{}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: t.TempDir(),
+		Policy:  BuildPolicyAuto,
+		Plan: composition.Plan{
+			Tier:  composition.TierPublished,
+			Image: publishedImage,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if result.Image != publishedImage {
+		t.Fatalf("result.Image = %q, want %q", result.Image, publishedImage)
+	}
+	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", publishedImage}}}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestBuildPublishedNeverSkipsExistingImage(t *testing.T) {
+	runner := &callRecordingRunner{}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: t.TempDir(),
+		Policy:  BuildPolicyNever,
+		Plan: composition.Plan{
+			Tier:  composition.TierPublished,
+			Image: publishedImage,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if result.Image != publishedImage {
+		t.Fatalf("result.Image = %q, want %q", result.Image, publishedImage)
+	}
+	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", publishedImage}}}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+func TestBuildPublishedNeverErrorsOnMissingImage(t *testing.T) {
+	runner := &callRecordingRunner{errs: []error{errors.New("missing")}}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: t.TempDir(),
+		Policy:  BuildPolicyNever,
+		Plan: composition.Plan{
+			Tier:  composition.TierPublished,
+			Image: publishedImage,
+		},
+	})
+	if err == nil {
+		t.Fatal("expected missing image error")
+	}
+	if !strings.Contains(err.Error(), "sandbox build policy is never") {
+		t.Fatalf("error = %v", err)
+	}
+	if !strings.Contains(err.Error(), publishedImage) {
+		t.Fatalf("error %v does not mention the image %q", err, publishedImage)
+	}
+}
+
+func TestBuildPublishedAlwaysPullsRegardlessOfPresence(t *testing.T) {
+	runner := &callRecordingRunner{}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: t.TempDir(),
+		Policy:  BuildPolicyAlways,
+		Plan: composition.Plan{
+			Tier:  composition.TierPublished,
+			Image: publishedImage,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	if result.Image != publishedImage {
+		t.Fatalf("result.Image = %q, want %q", result.Image, publishedImage)
+	}
+	// always pulls without an inspect probe.
+	want := []runnerCall{{name: "docker", args: []string{"pull", publishedImage}}}
+	if !reflect.DeepEqual(runner.calls, want) {
+		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
 func TestBuildDevcontainerImageDoesNotRequireRuntime(t *testing.T) {
 	result, err := Builder{Runtime: "definitely-not-a-runtime"}.Build(context.Background(), BuildOptions{
 		WorkDir: t.TempDir(),


### PR DESCRIPTION
## Summary

With no `.devcontainer` present, `aileron launch --sandbox=docker <agent>` is now build-free for a published agent (`claude`, `codex`). Discovery resolves the prebuilt per-agent image `ghcr.io/alrubinger/aileron-sandbox-<agent>` as the Tier 0 default and the container builder **pulls** it instead of building the agent-less local base. `sandbox check --agent=<agent>` resolves the **same** image so a passing check matches what launch runs.

- `composition.Discover` gains an `agent` parameter; the no-`.devcontainer` branch returns `TierPublished` with `Image = PublishedAgentImage(agent, version)` when the agent has a published image. The published-image set reuses the existing `agentRecipes` map (`PublishedAgentExists`) so it cannot drift from the Features/images.
- New `composition.TierPublished` + `PublishedAgentImage`/`PublishedAgentExists` helpers, mirroring `BaseImage`/`FeatureReference`. `DefaultPublishedImageRepository` is the single Go place naming the per-agent image repo.
- `container.Builder.Build` learns a `TierPublished` case: pull-on-miss under `auto`, always-pull under `always`, `image inspect` + actionable error under `never`. A pull is not a local build, so `Built` stays `false`; the launcher keys env wiring off `Image`/`Tier`.
- The launcher threads `config.Agent.Name()` into discovery; `AILERON_SANDBOX_IMAGE` and `AILERON_SANDBOX_TIER=published` flow to the container env automatically.
- Unpublished agents and any project with a `.devcontainer` keep the existing Tier 0/1/2 behavior unchanged, including the actionable "install the agent CLI or `--sandbox=off`" validation message.

The launcher resolves the floating `latest` tag (a version-pinned tag needs the agent CLI version, unknown at resolve time). Digest pinning / freshness automation is owned by #1088; this resolver is the documented seam where it plugs in. No new runtime (Docker-only, ADR-0014); no OpenAPI/approval surface touched; no backwards-compat shim.

## Test plan

- [x] `composition`: Discover resolves `TierPublished` + per-agent image for claude/codex; falls back to `TierBase` for unpublished (goose) and empty agent; `.devcontainer` present ignores agent for tier resolution; `PublishedAgentImage` tag normalization (`""`/`dev`/`0.4.0`); `PublishedAgentExists` predicate.
- [x] `container`: `TierPublished` pulls on auto+absent, skips on auto+present, no-pull on never+present, actionable error on never+absent, always-pulls regardless of presence (argv asserted via fake Runner).
- [x] `launch`: no-`.devcontainer` + published agent → docker argv contains `pull ... aileron-sandbox-claude:latest` and `run ... aileron-sandbox-claude:latest`, `AILERON_SANDBOX_TIER=published`, and NO local base build. Existing non-published-agent base-build test retained.
- [x] `sandbox check`: `--agent=claude` resolves the published image (parity), `--agent=goose` uses base; `sandbox plan` with no agent stays on base tier.
- [x] `go test` green across `internal/...` and `cmd/aileron/...`; CodeRabbit review clean (0 findings).
- [x] Docs updated (`sandbox-agent-images.md`): build-free default, `latest` resolution, #1088 digest seam, unpublished fallback.

Closes #1087