### PR TITLE
ci(sandbox): publish :latest on workflow_dispatch for sandbox images

### DIFF
--- a/.github/workflows/sandbox-agents.yml
+++ b/.github/workflows/sandbox-agents.yml
@@ -97,8 +97,9 @@ jobs:
       # On v* tags and workflow_dispatch (the paths that PUBLISH), FROM the
       # GHCR-published base. The base workflow (sandbox-base.yml) publishes the
       # exact release tag (`type=ref,event=tag`, e.g. v0.0.1) plus a floating
-      # `latest` on v* tag builds. A v* build FROMs the version-pinned tag so the
-      # per-agent image deterministically composes onto THIS release's base, not
+      # `latest` on v* tag builds and on workflow_dispatch. A v* build FROMs the
+      # version-pinned tag so the per-agent image deterministically composes
+      # onto THIS release's base, not
       # whatever `latest` happens to point at (the base and per-agent workflows
       # run concurrently on the same tag push). workflow_dispatch FROMs `latest`,
       # the one tag reliably present from the previous release. Gate on
@@ -202,7 +203,7 @@ jobs:
           tags: |
             type=raw,value=${{ steps.ver.outputs.version }}-${{ steps.cli.outputs.version }}
             type=sha,prefix=git-
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
           labels: |
             org.opencontainers.image.title=Aileron sandbox ${{ matrix.agent }}
             org.opencontainers.image.description=Aileron sandbox base composed with the ${{ matrix.agent }} agent CLI Feature.

--- a/.github/workflows/sandbox-base.yml
+++ b/.github/workflows/sandbox-base.yml
@@ -62,7 +62,7 @@ jobs:
           tags: |
             type=ref,event=tag
             type=sha,prefix=git-
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
           labels: |
             org.opencontainers.image.title=Aileron sandbox base
             org.opencontainers.image.description=Minimal sandbox substrate for Aileron-managed agent containers.

--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -92,6 +92,10 @@ homebrew_casks:
   # with contents:write scope on the tap repo, set as a secret in this
   # repo. Default GITHUB_TOKEN can't write across repos.
   - name: aileron
+    # Prerelease tags (a hyphen in the version, e.g. v0.0.5-cr-1) exist to
+    # smoke-test the publish pipeline; they must not move the stable tap. `auto`
+    # skips the tap commit whenever release.prerelease resolves true.
+    skip_upload: "auto"
     ids:
       - aileron # the bundled archive id above (all four binaries)
     repository:
@@ -139,6 +143,10 @@ scoops:
   # windows/arm64 is ignored, so the only windows archive is the amd64
   # zip and the manifest's architecture map carries just the 64bit entry.
   - name: aileron
+    # Prerelease tags (a hyphen in the version, e.g. v0.0.5-cr-1) exist to
+    # smoke-test the publish pipeline; they must not move the stable bucket.
+    # `auto` skips the manifest commit whenever release.prerelease resolves true.
+    skip_upload: "auto"
     ids:
       - aileron # the bundled archive id above (all three binaries)
     repository:


### PR DESCRIPTION
## Summary

`aileron sandbox build` / `launch --sandbox=docker` resolve `ghcr.io/alrubinger/aileron-sandbox-base:latest` (and per-agent `aileron-sandbox-<agent>:latest`), but those images have never been published: the publish step only fires on a `v*` tag push or `workflow_dispatch`, and **`latest` was gated to v* tags only**. So a `workflow_dispatch` published `git-<sha>` without the `:latest` tag the default consumers want — leaving no way to seed a usable image short of cutting a release tag. (`sandbox-agents` already FROMs `base:latest` on dispatch, a chicken-and-egg the base never resolved.)

Changes:
- **`sandbox-base.yml` / `sandbox-agents.yml`** — add `|| github.event_name == 'workflow_dispatch'` to the `type=raw,value=latest` enable condition, so a manual run publishes `:latest`. This gives a tag-free way to test the publish pipeline and to seed the default-consumed image.
- **`.goreleaser.yml`** — set `skip_upload: "auto"` on `homebrew_casks` and `scoops`. A `v*` tag also fires `release.yml` (goreleaser); without this, a prerelease tag like `v0.0.5-cr-1` would commit a prerelease formula/manifest to the stable `homebrew-aileron` / `scoop-aileron` taps. `release.prerelease` is already `auto`; this makes the taps respect it.

After merge, base + per-agent `:latest` can be published with no release tag:
```
gh workflow run sandbox-base.yml    # publishes aileron-sandbox-base:latest
gh workflow run sandbox-agents.yml  # FROMs base:latest, publishes per-agent :latest
```
(or via the **Run workflow** button on each workflow's Actions page). Note: newly-created GHCR packages default to **private** — `docker login ghcr.io` as the owner, or flip the packages to public, before an anonymous `docker pull`.

## Test plan

- [ ] PR-triggered `sandbox-base` and `sandbox-agents` runs go green (their paths filters include their own workflow files), confirming the edited YAML still parses and the bake/smoke path is intact. These PR runs do **not** push (push gated on tag/dispatch), so they validate without publishing.
- [ ] `goreleaser check` passes locally (verified).
- [ ] After merge: `gh workflow run sandbox-base.yml` publishes `ghcr.io/alrubinger/aileron-sandbox-base:latest`; then `gh workflow run sandbox-agents.yml` publishes `ghcr.io/alrubinger/aileron-sandbox-<agent>:latest`. Confirm `docker manifest inspect` resolves each after making the packages pullable.
- [ ] `aileron sandbox build` then completes the pull instead of `denied` (unblocks the #962 manual E2E).

Refs: #962 (manual E2E blocked by the missing image), #1138 / #1139 (the GHCR repoint that introduced the gap).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated Docker image tagging strategy to apply `latest` tags consistently across automated and manual build triggers.
  * Enhanced release publishing configuration to properly handle prerelease versions and prevent unintended updates to stable package repositories.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->