### PR TITLE
feat(sandbox): split edge (dev) and latest (release) sandbox image tags

### DIFF
--- a/.github/workflows/sandbox-agents.yml
+++ b/.github/workflows/sandbox-agents.yml
@@ -97,12 +97,12 @@ jobs:
       # On v* tags and workflow_dispatch (the paths that PUBLISH), FROM the
       # GHCR-published base. The base workflow (sandbox-base.yml) publishes the
       # exact release tag (`type=ref,event=tag`, e.g. v0.0.1) plus a floating
-      # `latest` on v* tag builds and on workflow_dispatch. A v* build FROMs the
-      # version-pinned tag so the per-agent image deterministically composes
-      # onto THIS release's base, not
-      # whatever `latest` happens to point at (the base and per-agent workflows
-      # run concurrently on the same tag push). workflow_dispatch FROMs `latest`,
-      # the one tag reliably present from the previous release. Gate on
+      # `latest` on v* tag builds, and a floating `edge` on workflow_dispatch. A
+      # v* build FROMs the version-pinned tag so the per-agent image
+      # deterministically composes onto THIS release's base, not whatever
+      # `latest` happens to point at (the base and per-agent workflows run
+      # concurrently on the same tag push). workflow_dispatch FROMs `edge`, the
+      # base tip just published off the same dev branch. Gate on
       # `docker manifest inspect` so a missing base surfaces a precise error
       # naming the absent tag instead of an opaque FROM failure deep in the build.
       #
@@ -119,14 +119,14 @@ jobs:
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             BASE_REF="${BASE_IMAGE_NAME}:${GITHUB_REF#refs/tags/}"
           elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
-            BASE_REF="${BASE_IMAGE_NAME}:latest"
+            BASE_REF="${BASE_IMAGE_NAME}:edge"
           else
             BASE_REF=""
           fi
           if [[ -n "${BASE_REF}" ]]; then
             echo "Verifying published base image ${BASE_REF} exists..."
             if ! docker manifest inspect "${BASE_REF}" >/dev/null 2>&1; then
-              echo "::error::Base image ${BASE_REF} not found in GHCR. The sandbox-base workflow (sandbox-base.yml) publishes the release tag and 'latest' on v* tag builds; ensure the base release published that tag before building per-agent images." >&2
+              echo "::error::Base image ${BASE_REF} not found in GHCR. The sandbox-base workflow (sandbox-base.yml) publishes the release tag and 'latest' on v* tag builds, and 'edge' on workflow_dispatch; run sandbox-base for this ref before building per-agent images." >&2
               exit 1
             fi
             echo "base_image=${BASE_REF}" >> "$GITHUB_OUTPUT"
@@ -203,7 +203,8 @@ jobs:
           tags: |
             type=raw,value=${{ steps.ver.outputs.version }}-${{ steps.cli.outputs.version }}
             type=sha,prefix=git-
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=edge,enable=${{ github.event_name == 'workflow_dispatch' }}
           labels: |
             org.opencontainers.image.title=Aileron sandbox ${{ matrix.agent }}
             org.opencontainers.image.description=Aileron sandbox base composed with the ${{ matrix.agent }} agent CLI Feature.

--- a/.github/workflows/sandbox-base.yml
+++ b/.github/workflows/sandbox-base.yml
@@ -62,7 +62,8 @@ jobs:
           tags: |
             type=ref,event=tag
             type=sha,prefix=git-
-            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+            type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
+            type=raw,value=edge,enable=${{ github.event_name == 'workflow_dispatch' }}
           labels: |
             org.opencontainers.image.title=Aileron sandbox base
             org.opencontainers.image.description=Minimal sandbox substrate for Aileron-managed agent containers.

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -38,7 +38,7 @@ With no `.devcontainer` in the project, `aileron launch --sandbox=docker <agent>
 
 `sandbox check --agent=<agent>` resolves the same image, so a passing check matches what launch will run.
 
-The launcher resolves the floating `latest` tag for this build-free default. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so `latest` is the correct in-process pin. Digest pinning and the freshness policy that consumes it are owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088); the resolver is the seam where that pinned reference plugs in.
+The launcher resolves a floating tag for this build-free default: a release build pulls `latest` (which the image workflows move only on a `v*` tag), and a dev build off `main` pulls `edge` (published on `workflow_dispatch`). So `latest` always names the most recent release and a dev run never clobbers it. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so the floating tag is the correct in-process pin. Digest pinning and the freshness policy that consumes it are owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088); the resolver is the seam where that pinned reference plugs in.
 
 When the requested agent has no published image, launch falls back to the customization tier. The image validation then emits the actionable message to install the agent CLI in the sandbox image or launch with `--sandbox=off`.
 
@@ -53,13 +53,15 @@ Aileron CI publishes one multi-arch image per agent to GHCR. Each image is baked
 
 Each image is built for `linux/amd64` and `linux/arm64`, so a `docker pull` resolves the manifest for your platform automatically.
 
-The tag scheme is `<aileron-version>-<agent-cli-version>` plus a floating `latest`. The `<aileron-version>` is the Aileron release the image was built from. The `<agent-cli-version>` is the agent CLI version baked into the image, resolved at build time from the installed package. A git-traceability tag `git-<sha>` is also published.
+The tag scheme is `<aileron-version>-<agent-cli-version>` plus two floating tags: `latest`, moved only by a `v*` tag release, and `edge`, moved by a `workflow_dispatch` publish off `main`. The `<aileron-version>` is the Aileron release the image was built from. The `<agent-cli-version>` is the agent CLI version baked into the image, resolved at build time from the installed package. A git-traceability tag `git-<sha>` is also published.
 
-Pull the latest image:
+Pull the most recent release (`latest`), or the latest dev publish off `main` (`edge`):
 
 ```bash
 docker pull ghcr.io/alrubinger/aileron-sandbox-claude:latest
 docker pull ghcr.io/alrubinger/aileron-sandbox-codex:latest
+# tip of main, published on workflow_dispatch:
+docker pull ghcr.io/alrubinger/aileron-sandbox-claude:edge
 ```
 
 Pull a pinned version, for example Aileron `0.0.1` with the Claude CLI at `2.1.179`:

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -68,14 +68,16 @@ With no `.devcontainer/devcontainer.json`, the output is Tier 0:
 
 ```text
 tier: base
-image: ghcr.io/alrubinger/aileron-sandbox-base:latest
+image: ghcr.io/alrubinger/aileron-sandbox-base:edge
 ```
+
+The base image tag tracks the CLI: a dev build off `main` resolves the floating `edge` tag, and a released CLI resolves `latest` (the most recent release).
 
 With the starter scaffold, the output is Tier 1 and names the composed devcontainer:
 
 ```text
 tier: devcontainer
-image: ghcr.io/alrubinger/aileron-sandbox-base:latest
+image: ghcr.io/alrubinger/aileron-sandbox-base:edge
 devcontainer: .devcontainer/devcontainer.json
 ```
 
@@ -106,7 +108,7 @@ Build behavior by tier:
 
 When building the base image outside the source tree, set `AILERON_SANDBOX_BASE_CONTEXT` to the directory containing the sandbox-base `Containerfile`.
 
-Release tags also build the sandbox-base image for `linux/amd64` and `linux/arm64` and publish it to GitHub Container Registry as `ghcr.io/alrubinger/aileron-sandbox-base:<version>`. Pull-request runs build both platforms without publishing, so image regressions are caught before release.
+Release tags also build the sandbox-base image for `linux/amd64` and `linux/arm64` and publish it to GitHub Container Registry as `ghcr.io/alrubinger/aileron-sandbox-base:<version>` and the floating `latest`. A `workflow_dispatch` run publishes the same multi-arch image under the floating `edge` tag, the tip-of-`main` build that dev CLIs resolve. Pull-request runs build both platforms without publishing, so image regressions are caught before release.
 
 ## Check Agent Support
 

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -979,15 +979,15 @@ func TestLaunch_SandboxBuildRunsPreparedImage(t *testing.T) {
 	}
 	args := string(data)
 	for _, want := range []string{
-		"build\n-t\nghcr.io/alrubinger/aileron-sandbox-base:latest\n",
+		"build\n-t\nghcr.io/alrubinger/aileron-sandbox-base:edge\n",
 		"run\n--rm\n-i\n",
-		"--env\nAILERON_SANDBOX_IMAGE=ghcr.io/alrubinger/aileron-sandbox-base:latest\n",
+		"--env\nAILERON_SANDBOX_IMAGE=ghcr.io/alrubinger/aileron-sandbox-base:edge\n",
 		"--env\nAILERON_SANDBOX_TIER=base\n",
 		"--env\nAILERON_SANDBOX_RUNTIME=docker\n",
 		// Default-on proxy bootstrap routes the agent through
 		// aileron-run-with-proxy-ca; the image name still precedes the
 		// agent argv but the bootstrap wrapper sits between them.
-		"ghcr.io/alrubinger/aileron-sandbox-base:latest\naileron-run-with-proxy-ca\nclaude\n--dangerously-skip-permissions\n",
+		"ghcr.io/alrubinger/aileron-sandbox-base:edge\naileron-run-with-proxy-ca\nclaude\n--dangerously-skip-permissions\n",
 	} {
 		if !strings.Contains(args, want) {
 			t.Errorf("expected %q in docker args:\n%s", want, args)
@@ -1034,7 +1034,7 @@ func TestLaunch_SandboxNoDevcontainerPublishedAgentPullsPerAgentImage(t *testing
 		t.Fatalf("read docker args: %v", err)
 	}
 	args := string(data)
-	const image = "ghcr.io/alrubinger/aileron-sandbox-claude:latest"
+	const image = "ghcr.io/alrubinger/aileron-sandbox-claude:edge"
 	for _, want := range []string{
 		"pull\n" + image + "\n",
 		"run\n--rm\n-i\n",

--- a/internal/sandbox/composition/composition.go
+++ b/internal/sandbox/composition/composition.go
@@ -221,11 +221,22 @@ func parseDevcontainer(b []byte) (devcontainerConfig, error) {
 
 // BaseImage returns the Aileron-owned sandbox-base image for version.
 func BaseImage(version string) string {
-	tag := strings.TrimSpace(version)
-	if tag == "" || tag == "dev" {
-		tag = "latest"
+	return DefaultBaseImageRepository + ":" + imageTag(version)
+}
+
+// imageTag maps an Aileron CLI version to the floating sandbox-image tag it
+// consumes. A dev or empty version (a build off main, not a release) pulls
+// `edge`, the tip published by the sandbox image workflows on workflow_dispatch.
+// A real release version pulls `latest`, which those workflows move only on a
+// v* tag build. So `latest` always names the most recent release and a dev run
+// can never clobber it. Reproducible per-release digest pinning (so a given
+// release pulls a fixed image rather than floating `latest`) is owned by #1088.
+func imageTag(version string) string {
+	v := strings.TrimSpace(version)
+	if v == "" || v == "dev" {
+		return "edge"
 	}
-	return DefaultBaseImageRepository + ":" + tag
+	return "latest"
 }
 
 func resolveDockerfilePath(cfg devcontainerConfig) string {

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -15,7 +15,7 @@ func TestDiscoverMissingDevcontainerUsesBaseImage(t *testing.T) {
 	if plan.Tier != TierBase {
 		t.Fatalf("Tier = %s, want %s", plan.Tier, TierBase)
 	}
-	if plan.Image != "ghcr.io/alrubinger/aileron-sandbox-base:0.4.0" {
+	if plan.Image != "ghcr.io/alrubinger/aileron-sandbox-base:latest" {
 		t.Fatalf("Image = %q", plan.Image)
 	}
 }
@@ -25,8 +25,8 @@ func TestDiscoverMissingDevcontainerPublishedAgentResolvesPerAgentImage(t *testi
 		agent     string
 		wantImage string
 	}{
-		{"claude", "ghcr.io/alrubinger/aileron-sandbox-claude:0.4.0"},
-		{"codex", "ghcr.io/alrubinger/aileron-sandbox-codex:0.4.0"},
+		{"claude", "ghcr.io/alrubinger/aileron-sandbox-claude:latest"},
+		{"codex", "ghcr.io/alrubinger/aileron-sandbox-codex:latest"},
 	} {
 		t.Run(tc.agent, func(t *testing.T) {
 			plan, err := Discover(t.TempDir(), "0.4.0", tc.agent)
@@ -98,9 +98,9 @@ func TestPublishedAgentImage(t *testing.T) {
 		version string
 		want    string
 	}{
-		{"", "ghcr.io/alrubinger/aileron-sandbox-claude:latest"},
-		{"dev", "ghcr.io/alrubinger/aileron-sandbox-claude:latest"},
-		{"0.4.0", "ghcr.io/alrubinger/aileron-sandbox-claude:0.4.0"},
+		{"", "ghcr.io/alrubinger/aileron-sandbox-claude:edge"},
+		{"dev", "ghcr.io/alrubinger/aileron-sandbox-claude:edge"},
+		{"0.4.0", "ghcr.io/alrubinger/aileron-sandbox-claude:latest"},
 	} {
 		if got := PublishedAgentImage("claude", tc.version); got != tc.want {
 			t.Fatalf("PublishedAgentImage(claude, %q) = %q, want %q", tc.version, got, tc.want)
@@ -148,7 +148,7 @@ func TestDiscoverDevcontainerBuildPlan(t *testing.T) {
 	if plan.Tier != TierDevcontainer {
 		t.Fatalf("Tier = %s, want %s", plan.Tier, TierDevcontainer)
 	}
-	if plan.BaseImage != "ghcr.io/alrubinger/aileron-sandbox-base:latest" {
+	if plan.BaseImage != "ghcr.io/alrubinger/aileron-sandbox-base:edge" {
 		t.Fatalf("BaseImage = %q", plan.BaseImage)
 	}
 	if plan.DockerfilePath != "Dockerfile" {
@@ -288,7 +288,7 @@ func TestInitWritesFeatureComposingDevcontainer(t *testing.T) {
 	if plan.Tier != TierDevcontainer {
 		t.Fatalf("Tier = %s, want %s", plan.Tier, TierDevcontainer)
 	}
-	if plan.Image != "ghcr.io/alrubinger/aileron-sandbox-base:0.4.0" {
+	if plan.Image != "ghcr.io/alrubinger/aileron-sandbox-base:latest" {
 		t.Fatalf("Image = %q, want the base image", plan.Image)
 	}
 	// Exactly one active Feature: the default agent Feature. The customer

--- a/internal/sandbox/composition/scaffold.go
+++ b/internal/sandbox/composition/scaffold.go
@@ -5,7 +5,6 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
-	"strings"
 )
 
 // DefaultAgent is the agent whose Feature the scaffold demonstrates. It is no
@@ -76,18 +75,16 @@ func FeatureReference(agent string) string {
 // aileron-mcp onto the base, so the build-free Tier 0 default pulls one instead
 // of building the agent-less base (#1086, #1087).
 //
-// The tag follows the same normalization as BaseImage: an empty or "dev"
-// version maps to "latest". The launcher resolves this floating "latest" pin at
-// launch time because a version-pinned tag (<aileron-version>-<agent-cli-version>)
-// requires the agent CLI version, which is not known here. Digest pinning and
-// the freshness policy that consumes it are owned by #1088; this helper is the
-// seam where that pinned reference plugs in.
+// The tag follows the same normalization as BaseImage (see imageTag): a dev or
+// empty version pulls the floating `edge` tag published off main on
+// workflow_dispatch, and a release version pulls `latest`, which moves only on a
+// v* tag build. The launcher resolves the floating pin at launch time because a
+// version-pinned tag (<aileron-version>-<agent-cli-version>) requires the agent
+// CLI version, which is not known here. Digest pinning and the freshness policy
+// that consumes it are owned by #1088; this helper is the seam where that pinned
+// reference plugs in.
 func PublishedAgentImage(agent, version string) string {
-	tag := strings.TrimSpace(version)
-	if tag == "" || tag == "dev" {
-		tag = "latest"
-	}
-	return DefaultPublishedImageRepository + "-" + agent + ":" + tag
+	return DefaultPublishedImageRepository + "-" + agent + ":" + imageTag(version)
 }
 
 // PublishedAgentExists reports whether agent has a prebuilt per-agent image to


### PR DESCRIPTION
## Summary

Follow-up to #1140. That PR let `workflow_dispatch` publish `:latest` so a usable sandbox image could be seeded without cutting a release tag. The problem: `:latest` is the **customer-facing** floating tag the launcher resolves for the build-free per-agent default (`PublishedAgentImage`, see `docs/development/sandbox-agent-images.md`). So a dev dispatch off `main` would overwrite the most-recent-release image, and customers would pull a dev build until the next release re-published `:latest`.

This gives dev builds their own floating tag, so the two never collide:

- **`:latest`** = most recent release. Moved only by a `v*` tag build.
- **`:edge`** = tip of `main`. Moved by `workflow_dispatch`.

### Changes

- **`sandbox-base.yml` / `sandbox-agents.yml`**: on `workflow_dispatch`, publish `type=raw,value=edge` instead of `latest`; `latest` returns to v* tags only. `sandbox-agents` FROMs `base:edge` on dispatch to match (it already FROMs the version-pinned base on tags).
- **Go** (`imageTag`, shared by `BaseImage` and `PublishedAgentImage`): a dev or empty version resolves `edge`; a release version resolves `latest`.
- **Docs**: `sandbox-agent-images.md` and `sandbox-composition.md` describe the edge/latest split.

### Behavior note (please confirm)

Released consumption now floats on `:latest` rather than the previous version-pinned tag (`:0.4.0` base / `:0.4.0` per-agent). Those version-pinned tags weren't reliably published anyway — the base workflow publishes `:v0.4.0` (with the `v`) and the per-agent workflow publishes `:0.4.0-<cli-version>`, neither of which the old helpers' `:0.4.0` matched. Reproducible per-release pinning (digest-based) remains owned by #1088. If you'd rather preserve a version-pinned released consumer instead of floating `:latest`, say so and I'll adjust.

## Test plan

- [x] `go test ./internal/sandbox/... ./internal/launch/... ./cmd/aileron/...` green locally (composition, launch, runtime, cmd).
- [x] Unit tests updated: dev/empty → `:edge`, release version → `:latest` (`composition_test.go`, `launcher_test.go`).
- [ ] PR-triggered `sandbox-base` / `sandbox-agents` runs go green (validate the edited workflow YAML + bake/smoke; these PR runs don't publish).
- [ ] After merge: `gh workflow run "Sandbox Base Image"` publishes `aileron-sandbox-base:edge`; then `gh workflow run "Sandbox Agent Images"` FROMs `base:edge` and publishes `aileron-sandbox-<agent>:edge`. A dev `./build/aileron sandbox build` then resolves `:edge`.

Refs: #1140 (the dispatch-publish path this refines), #1088 (digest pinning), #962 (manual E2E this unblocks).