### PR TITLE
fix(launch): collapse nested Codex config.toml mount into .codex dir

### DIFF
--- a/internal/launch/agents/codex.go
+++ b/internal/launch/agents/codex.go
@@ -85,11 +85,16 @@ func (c Codex) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string, m
 // host-side inode to bind, so the login would write into the
 // container overlay FS and Capture would see nothing.
 //
-// ConfigureMCP under ModeSandbox still installs a read-only file
-// mount at /home/agent/.codex/config.toml. Container runtimes apply
-// mounts in declaration order; the file mount lands after the
-// auth-spec dir mount and overlays config.toml at its specific path
-// without masking auth.json.
+// ConfigureMCP under ModeSandbox renders config.toml to a temp file
+// and returns it as an MCPMount targeting
+// /home/agent/.codex/config.toml. The launcher detects that this
+// target is nested inside the AuthSpec's /home/agent/.codex/ directory
+// mount and relocates the file into that mount's host-side source dir
+// (collapseNestedMCPMounts in launcher.go), so a single directory mount
+// carries both auth.json and config.toml. Emitting config.toml as a
+// separate nested file-inside-dir bind mount is what broke under macOS
+// Docker Desktop's virtiofs (runc: "mountpoint outside of rootfs",
+// issue #1143).
 //
 // The PreLaunchRefresh hook exchanges the refresh token for a new
 // access token against auth.openai.com before the container starts,

--- a/internal/launch/agents/codex_test.go
+++ b/internal/launch/agents/codex_test.go
@@ -135,6 +135,13 @@ command = "/usr/local/bin/other-mcp"
 // the contract: under ModeSandbox the host ~/.codex/config.toml is
 // never created; instead a temp config.toml is written and a Volume
 // mount is returned targeting /home/agent/.codex/config.toml.
+//
+// The returned mount target is intentionally nested under the AuthSpec's
+// /home/agent/.codex/ directory mount: the launcher
+// (collapseNestedMCPMounts) relocates the file into that directory's
+// host-side source instead of emitting a separate nested bind mount, so
+// no file-inside-dir bind reaches runc. See issue #1143 and the launcher
+// regression test TestCollapseNestedMCPMounts_CollapsesFileIntoParentDir.
 func TestCodex_ConfigureMCP_SandboxMode_WritesTempAndReturnsMount(t *testing.T) {
 	home := t.TempDir()
 	t.Setenv("HOME", home)

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -11,6 +11,7 @@ import (
 	"os"
 	"os/exec"
 	"os/signal"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -709,6 +710,75 @@ func launchHost(ctx context.Context, config LaunchConfig, daemonURL, sessionID s
 	return launchDirect(cmd, config)
 }
 
+// collapseNestedMCPMounts merges an agent's ConfigureMCP mounts into the
+// existing volume list, relocating any MCP *file* mount whose target sits
+// strictly inside an already-mounted directory rather than adding it as a
+// separate nested bind mount.
+//
+// Nested file-inside-directory bind mounts are the failure mode behind
+// issue #1143: Codex's AuthSpec emits a writable directory mount at
+// /home/agent/.codex/ (so the in-container login can write auth.json),
+// while ConfigureMCP emits a separate single-file mount of config.toml at
+// /home/agent/.codex/config.toml. On macOS Docker Desktop (virtiofs), runc
+// rejects creating the inner mountpoint with "mountpoint ... is outside of
+// rootfs" and container init dies. Collapsing the file into the parent
+// directory's host-side source means a single directory mount carries both
+// files and no nested bind exists.
+//
+// When an MCP mount's target is not nested under any existing directory
+// mount, it is appended unchanged — preserving the prior behavior for every
+// agent that does not collide with an AuthSpec directory mount.
+func collapseNestedMCPMounts(existing []sandboxcontainer.Volume, mcpMounts []MCPMount) ([]sandboxcontainer.Volume, error) {
+	out := existing
+	for _, m := range mcpMounts {
+		parent := enclosingDirMount(out, m.Target)
+		if parent == nil {
+			out = append(out, sandboxcontainer.Volume{
+				Source:   m.Source,
+				Target:   m.Target,
+				ReadOnly: m.ReadOnly,
+			})
+			continue
+		}
+		// Relocate the file into the parent directory mount's host-side
+		// source so the single directory mount exposes it at m.Target.
+		// path.Base mirrors the in-container layout the agent reads.
+		rel := strings.TrimPrefix(m.Target, parent.Target)
+		rel = strings.TrimPrefix(rel, "/")
+		dst := filepath.Join(parent.Source, rel)
+		if err := os.MkdirAll(filepath.Dir(dst), 0o700); err != nil {
+			return nil, fmt.Errorf("create parent dir for %s: %w", dst, err)
+		}
+		data, err := os.ReadFile(m.Source)
+		if err != nil {
+			return nil, fmt.Errorf("read MCP config %s: %w", m.Source, err)
+		}
+		if err := os.WriteFile(dst, data, 0o600); err != nil {
+			return nil, fmt.Errorf("write MCP config into %s: %w", dst, err)
+		}
+	}
+	return out, nil
+}
+
+// enclosingDirMount returns the volume in mounts whose target is a
+// directory strictly containing target, or nil when target is not nested
+// inside any of them. A directory mount is identified by target shape: an
+// MCP single-file mount and a directory mount are distinguished only by
+// whether target is a strict path prefix of another mount's target.
+func enclosingDirMount(mounts []sandboxcontainer.Volume, target string) *sandboxcontainer.Volume {
+	clean := path.Clean(target)
+	for i := range mounts {
+		dir := path.Clean(mounts[i].Target)
+		if dir == clean {
+			continue
+		}
+		if strings.HasPrefix(clean, dir+"/") {
+			return &mounts[i]
+		}
+	}
+	return nil
+}
+
 func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, agentEnv map[string]string, containerName string, captureOnce func(), sessionLog *slog.Logger, extraMounts ...sandboxcontainer.Volume) (LaunchResult, error) {
 	commandName := firstAgentBinary(config.Agent)
 	if commandName == "" {
@@ -751,13 +821,11 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 	if mcpErr != nil {
 		return LaunchResult{}, fmt.Errorf("configuring MCP for %s: %w", config.Agent.Name(), mcpErr)
 	}
-	for _, m := range mcpMounts {
-		mounts = append(mounts, sandboxcontainer.Volume{
-			Source:   m.Source,
-			Target:   m.Target,
-			ReadOnly: m.ReadOnly,
-		})
+	collapsed, err := collapseNestedMCPMounts(mounts, mcpMounts)
+	if err != nil {
+		return LaunchResult{}, fmt.Errorf("placing MCP config for %s: %w", config.Agent.Name(), err)
 	}
+	mounts = collapsed
 
 	command := append([]string{commandName}, config.Agent.Args()...)
 	command = append(command, extraArgs...)

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -5,6 +5,7 @@ import (
 	"io"
 	"log/slog"
 	"os"
+	"path"
 	"path/filepath"
 	"runtime"
 	"strings"
@@ -578,5 +579,104 @@ func TestSandboxProxyModeSupportsBootstrapDockerOnly(t *testing.T) {
 		if got := sandboxProxyModeSupportsBootstrap(c.mode); got != c.want {
 			t.Fatalf("sandboxProxyModeSupportsBootstrap(%q) = %v, want %v", c.mode, got, c.want)
 		}
+	}
+}
+
+// nestedMountTarget reports the first volume target that sits strictly
+// inside another volume's directory target — the failure mode behind
+// issue #1143. It returns "" when no mount is nested. A file-inside-dir
+// bind mount is what runc rejects under macOS Docker Desktop virtiofs.
+func nestedMountTarget(mounts []sandboxcontainer.Volume) string {
+	for i := range mounts {
+		inner := path.Clean(mounts[i].Target)
+		for j := range mounts {
+			if i == j {
+				continue
+			}
+			outer := path.Clean(mounts[j].Target)
+			if strings.HasPrefix(inner, outer+"/") {
+				return mounts[i].Target
+			}
+		}
+	}
+	return ""
+}
+
+// TestCollapseNestedMCPMounts_CollapsesFileIntoParentDir is the #1143
+// regression: an MCP config file mount whose target is nested inside an
+// existing writable directory mount (Codex's /home/agent/.codex/ +
+// config.toml) must NOT survive as a separate nested bind mount. Instead
+// the file is relocated into the directory mount's host-side source so a
+// single directory mount carries both files. No bind mount may have a
+// target strictly inside another mount's target.
+func TestCollapseNestedMCPMounts_CollapsesFileIntoParentDir(t *testing.T) {
+	dirSource := t.TempDir() // host-side source for /home/agent/.codex/
+	cfgSource := filepath.Join(t.TempDir(), "config.toml")
+	cfgBody := []byte("cli_auth_credentials_store = \"file\"\n\n[mcp_servers.aileron]\ncommand = \"/usr/local/bin/aileron-mcp\"\n")
+	if err := os.WriteFile(cfgSource, cfgBody, 0o600); err != nil {
+		t.Fatalf("seed config.toml: %v", err)
+	}
+
+	existing := []sandboxcontainer.Volume{
+		{Source: dirSource, Target: "/home/agent/.codex", ReadOnly: false},
+	}
+	mcp := []MCPMount{
+		{Source: cfgSource, Target: "/home/agent/.codex/config.toml", ReadOnly: true},
+	}
+
+	got, err := collapseNestedMCPMounts(existing, mcp)
+	if err != nil {
+		t.Fatalf("collapseNestedMCPMounts: %v", err)
+	}
+
+	if n := nestedMountTarget(got); n != "" {
+		t.Fatalf("nested bind mount survived collapse: %q in %+v", n, got)
+	}
+	if len(got) != 1 {
+		t.Fatalf("expected 1 collapsed mount, got %d: %+v", len(got), got)
+	}
+	if got[0].Target != "/home/agent/.codex" {
+		t.Errorf("surviving mount target = %q, want /home/agent/.codex", got[0].Target)
+	}
+
+	// config.toml must now live inside the directory mount's source so the
+	// single directory mount exposes it at /home/agent/.codex/config.toml.
+	placed := filepath.Join(dirSource, "config.toml")
+	data, err := os.ReadFile(placed)
+	if err != nil {
+		t.Fatalf("config.toml not relocated into dir mount source: %v", err)
+	}
+	if string(data) != string(cfgBody) {
+		t.Errorf("relocated config.toml body mismatch:\nwant %q\ngot  %q", cfgBody, data)
+	}
+}
+
+// TestCollapseNestedMCPMounts_PreservesNonNestedMount confirms an MCP
+// mount that does not collide with any directory mount is appended
+// unchanged — the behavior every non-Codex agent relies on.
+func TestCollapseNestedMCPMounts_PreservesNonNestedMount(t *testing.T) {
+	cfgSource := filepath.Join(t.TempDir(), "opencode.json")
+	if err := os.WriteFile(cfgSource, []byte("{}"), 0o600); err != nil {
+		t.Fatalf("seed: %v", err)
+	}
+	existing := []sandboxcontainer.Volume{
+		{Source: t.TempDir(), Target: "/home/agent/.claude", ReadOnly: false},
+	}
+	mcp := []MCPMount{
+		{Source: cfgSource, Target: "/home/agent/.config/opencode/opencode.json", ReadOnly: true},
+	}
+
+	got, err := collapseNestedMCPMounts(existing, mcp)
+	if err != nil {
+		t.Fatalf("collapseNestedMCPMounts: %v", err)
+	}
+	if len(got) != 2 {
+		t.Fatalf("expected 2 mounts (non-nested preserved), got %d: %+v", len(got), got)
+	}
+	if got[1].Target != "/home/agent/.config/opencode/opencode.json" {
+		t.Errorf("non-nested mount target = %q, want preserved", got[1].Target)
+	}
+	if !got[1].ReadOnly {
+		t.Errorf("non-nested mount ReadOnly = false, want preserved true")
 	}
 }

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -680,3 +680,35 @@ func TestCollapseNestedMCPMounts_PreservesNonNestedMount(t *testing.T) {
 		t.Errorf("non-nested mount ReadOnly = false, want preserved true")
 	}
 }
+
+// TestCollapseNestedMCPMounts_MissingSourceErrors confirms a relocation
+// surfaces an error when the rendered MCP config file is missing rather
+// than silently dropping it — a launch must fail loudly if the agent's
+// ConfigureMCP promised a file that is not on disk.
+func TestCollapseNestedMCPMounts_MissingSourceErrors(t *testing.T) {
+	existing := []sandboxcontainer.Volume{
+		{Source: t.TempDir(), Target: "/home/agent/.codex", ReadOnly: false},
+	}
+	mcp := []MCPMount{
+		{Source: filepath.Join(t.TempDir(), "does-not-exist.toml"), Target: "/home/agent/.codex/config.toml", ReadOnly: true},
+	}
+	if _, err := collapseNestedMCPMounts(existing, mcp); err == nil {
+		t.Fatal("expected error for missing MCP config source, got nil")
+	}
+}
+
+// TestEnclosingDirMount_IdentityTargetNotEnclosing confirms a mount whose
+// target exactly equals another mount's target is not treated as nested
+// (only a strict parent encloses), so an identical-target MCP mount is
+// appended rather than relocated.
+func TestEnclosingDirMount_IdentityTargetNotEnclosing(t *testing.T) {
+	mounts := []sandboxcontainer.Volume{
+		{Source: "/h/a", Target: "/home/agent/.codex"},
+	}
+	if got := enclosingDirMount(mounts, "/home/agent/.codex"); got != nil {
+		t.Fatalf("enclosingDirMount returned %+v for identical target, want nil", got)
+	}
+	if got := enclosingDirMount(mounts, "/home/agent/.codex/config.toml"); got == nil {
+		t.Fatal("enclosingDirMount returned nil for nested target, want the dir mount")
+	}
+}


### PR DESCRIPTION
## Summary

`aileron launch --sandbox=docker codex` produced two bind mounts that collided at `/home/agent/.codex/`:

- Codex's AuthSpec emits a writable **directory** mount at `/home/agent/.codex/` so the in-container login can write `auth.json` (and Capture reads it back).
- Codex's `ConfigureMCP` (ModeSandbox) emits a separate single-**file** mount of `config.toml` at `/home/agent/.codex/config.toml`.

The launcher appended the file mount as a nested bind-mount *inside* the already-mounted directory. On macOS Docker Desktop (virtiofs), runc rejects creating that inner mountpoint with `mountpoint ... is outside of rootfs`, killing container init.

The fix collapses the two mounts into one. The launcher now detects any MCP config file whose target sits strictly inside an existing directory mount and relocates the file into that directory's host-side source dir (`collapseNestedMCPMounts`), so a single directory mount carries both `auth.json` and `config.toml` and no file-inside-dir bind reaches runc.

Contracts preserved:
- Host `~/.codex/config.toml` is never touched (`codex_test.go`).
- `auth.json` stays writable for capture; the dir mount is still writable.
- `config.toml` is read-only to the agent's purpose (the agent never rewrites it).
- MCP-server isolation (only `[mcp_servers.aileron]`) is unchanged.
- Non-nested MCP mounts are appended unchanged, so Claude (no MCP mount) and OpenCode (workspace-local config) are unaffected.

## Test plan

- [x] `go build ./...` (internal module) is green.
- [x] `go test ./launch/... ./sandbox/...` is green.
- [x] New regression test `TestCollapseNestedMCPMounts_CollapsesFileIntoParentDir` asserts no surviving bind mount has a target nested strictly inside another mount's target, and that `config.toml` is relocated into the dir-mount source.
- [x] New test `TestCollapseNestedMCPMounts_PreservesNonNestedMount` confirms non-colliding MCP mounts pass through unchanged.
- [x] Verified the pre-fix append-only path produces a nested mount (the bug) and the new path removes it, via a throwaway test against the same detector.
- [x] Verified Claude and OpenCode do not hit this path (neither returns a nesting MCP mount).

Closes #1143