### PR TITLE
feat(sandbox): add gh CLI to the sandbox base image

### DIFF
--- a/.github/workflows/sandbox-base.yml
+++ b/.github/workflows/sandbox-base.yml
@@ -104,6 +104,20 @@ jobs:
             AILERON_VERSION=${{ steps.ver.outputs.version }}
             AILERON_COMMIT=${{ github.sha }}
 
+      # Single-arch local load of the Tier 0 Containerfile so the smoke step can
+      # `docker run` it. This recipe takes the images/sandbox-base context (no
+      # repo-root, no AILERON_VERSION/COMMIT build-args) and is UNBAKED (no
+      # aileron-mcp). Building it here is the only CI gate on the local recipe;
+      # without it, dropping github-cli from Containerfile would stay green
+      # (issue #1151 P1).
+      - name: Build local Tier 0 image for smoke test
+        uses: docker/build-push-action@v7
+        with:
+          context: images/sandbox-base
+          file: images/sandbox-base/Containerfile
+          load: true
+          tags: aileron-sandbox-base-local:smoke
+
       # Image-fidelity smoke against the published (baked) image: the bash
       # substrate, the baked-MCP invariants (#957, the binary runs and the
       # version label is present), and the #959 invariants (no tools.txt or
@@ -113,6 +127,21 @@ jobs:
       - name: Smoke test image
         run: |
           set -euo pipefail
+
+          # github-cli is part of the base substrate (issue #1146): both recipes
+          # install it from Alpine's community repo. assertGhVersion runs
+          # `gh --version` and relies on set -e to fail the job on a non-zero
+          # exit, exercising the "gh exists and exits 0" acceptance. Invoked
+          # against BOTH the local Tier 0 image (the #1151 P1 gate on the local
+          # recipe) and the published image (proving the recipes stay in sync).
+          assertGhVersion() {
+            local img="$1"
+            echo "asserting gh --version on $img"
+            docker run --rm "$img" gh --version
+          }
+          assertGhVersion aileron-sandbox-base-local:smoke
+          assertGhVersion aileron-sandbox-base:smoke
+
           IMG=aileron-sandbox-base:smoke
           docker run --rm "$IMG" bash -c 'echo hi' | grep -q '^hi$'
           bash_path=$(docker run --rm "$IMG" which bash)

--- a/images/sandbox-base/Containerfile
+++ b/images/sandbox-base/Containerfile
@@ -15,12 +15,19 @@ LABEL org.opencontainers.image.title="Aileron sandbox base"
 LABEL org.opencontainers.image.description="Minimal sandbox substrate for Aileron-managed agent containers."
 LABEL org.opencontainers.image.source="https://github.com/ALRubinger/aileron"
 
+# github-cli ships only in Alpine's community repo, which alpine:3.24 does not
+# enable by default. Scope the community repo to this single apk invocation via
+# --repository (pinned to v3.24 to match the FROM tag) so the rest of the
+# package set stays main-only. Keep this list in sync with
+# Containerfile.published's final stage (issue #957).
 RUN apk add --no-cache \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community \
     bash \
     ca-certificates \
     coreutils \
     findutils \
     gawk \
+    github-cli \
     grep \
     procps \
     sed \

--- a/images/sandbox-base/Containerfile.published
+++ b/images/sandbox-base/Containerfile.published
@@ -66,12 +66,19 @@ LABEL org.opencontainers.image.source="https://github.com/ALRubinger/aileron"
 ARG AILERON_VERSION=dev
 LABEL ai.aileron.mcp.version="${AILERON_VERSION}"
 
+# github-cli ships only in Alpine's community repo, which alpine:3.24 does not
+# enable by default. Scope the community repo to this single apk invocation via
+# --repository (pinned to v3.24 to match the FROM tag) so the rest of the
+# package set stays main-only. Keep this list in sync with Containerfile (the
+# local Tier 0 recipe; issue #957).
 RUN apk add --no-cache \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community \
     bash \
     ca-certificates \
     coreutils \
     findutils \
     gawk \
+    github-cli \
     grep \
     procps \
     sed \


### PR DESCRIPTION
## Summary

Installs the GitHub CLI (`gh`) into the sandbox base substrate so every `aileron launch` sandbox ships with it.

- Uses the Alpine `github-cli` package (musl-native, never a glibc binary). It lives in Alpine's `community` repo, which `alpine:3.24` does not enable by default.
- Enables `community` narrowly via `--repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community` on the single existing `apk add` line (pinned to v3.24 to match the `FROM alpine:3.24` tag), so the rest of the package set stays main-only.
- Adds `github-cli` to BOTH base recipes — the local Tier 0 `Containerfile` and `Containerfile.published`'s final stage — keeping the package lists byte-identical per the #957 substrate-sync contract.
- No Go production changes; `gh` is base substrate, not a devcontainer Feature.

### CI gate (closes the #1151 P1 gap)

The smoke job previously built only `Containerfile.published`. Dropping `github-cli` from the local recipe would have stayed green. This PR:

- Adds a net-new build step that loads the local Tier 0 `Containerfile` single-arch (`aileron-sandbox-base-local:smoke`).
- Adds a single committed `assertGhVersion` helper that runs `gh --version` (asserting exit 0 via `set -euo pipefail`) against BOTH the local and published smoke images.

## Test plan

- [x] `docker build -f images/sandbox-base/Containerfile -t local:gh images/sandbox-base` succeeds; `docker run --rm local:gh gh --version` exits 0 (`gh version 2.93.0`).
- [x] `docker build -f images/sandbox-base/Containerfile.published -t pub:gh .` (repo-root context) succeeds; `docker run --rm pub:gh gh --version` exits 0.
- [x] The two recipes' `apk add` blocks are byte-identical (verified via `diff`).
- [x] Workflow YAML parses.
- [x] CodeRabbit review: 0 findings.
- The existing baked-MCP (#957) and #959 invariants in the smoke step are preserved unchanged.

Closes #1146
