### PR TITLE
fix(sandbox): tunnel WebSocket upgrades through the sandbox proxy

### DIFF
--- a/docs/src/content/docs/guides/observability.md
+++ b/docs/src/content/docs/guides/observability.md
@@ -42,7 +42,7 @@ Today, five families of events land in the log:
 - **Action execution:** Every invocation records which connector it called, which capability it exercised, and which binding identity satisfied it ([ADR-0003](/adr/0003-action-model), [ADR-0011](/adr/0011-local-credential-vault)). Credential bytes are never recorded.
 - **Failure:** Every failure surfaces with a stable `class`, `boundary`, retry, and `audit_id` ([ADR-0010](/adr/0010-failure-handling)). The same `audit_id` is stamped onto the agent-visible tool-result envelope, so the LLM's "what went wrong?" reaction can be traced back to a specific event.
 - **Approval lifecycle:** Three event types: `approval.requested`, `approval.approved`, `approval.denied`. Each carries the same `aileron.approval.id` so a request and its decision are trivially correlated.
-- **Sandbox HTTPS data plane:** Generated connector shims and transparent sandbox proxy requests emit proxy audit events. `connector.proxy.proxied` and `connector.proxy.rejected` identify the resolved connector operation, upstream scheme/host/path, decision, proxy source, and response status or rejection reason. `sandbox.proxy.passthrough` records cooperative HTTPS requests whose upstream did not uniquely match an installed connector spec; the proxy forwards them unmodified and audits the upstream host, path, method, and response status. `sandbox.proxy.rejected` records protocol-level failures in the transparent proxy path (non-CONNECT request, missing session CA, connector specs invalid or unavailable, upstream unreachable during passthrough). `sandbox.proxy.disabled` records launch sessions that start with the v4 HTTPS proxy not in force (operator opt-out, preflight failure, or unsupported sandbox mode). These events never record credential bytes, request bodies, raw headers, query strings, or full upstream URLs.
+- **Sandbox HTTPS data plane:** Generated connector shims and transparent sandbox proxy requests emit proxy audit events. `connector.proxy.proxied` and `connector.proxy.rejected` identify the resolved connector operation, upstream scheme/host/path, decision, proxy source, and response status or rejection reason. `sandbox.proxy.passthrough` records cooperative HTTPS requests whose upstream did not uniquely match an installed connector spec; the proxy forwards them unmodified and audits the upstream host, path, method, and response status. `sandbox.proxy.upgrade` records WebSocket (and other HTTP Upgrade) handshakes forwarded through the passthrough boundary; the proxy preserves the upgrade headers, relays the upstream `101 Switching Protocols`, and opens a bidirectional byte tunnel. `sandbox.proxy.rejected` records protocol-level failures in the transparent proxy path (non-CONNECT request, missing session CA, connector specs invalid or unavailable, upstream unreachable during passthrough). `sandbox.proxy.disabled` records launch sessions that start with the v4 HTTPS proxy not in force (operator opt-out, preflight failure, or unsupported sandbox mode). These events never record credential bytes, request bodies, raw headers, query strings, or full upstream URLs.
 
 The schema is durable. Every payload field uses the OpenTelemetry-namespaced key shape (`aileron.connector.fqn`, `aileron.binding.name`, `aileron.failure.class`, etc.). Consumers (log shippers, trace tools, custom queries) read the same vocabulary regardless of which surface they came in through.
 
@@ -159,17 +159,17 @@ Every span carries the OTel-namespaced shape locked in for the audit payload. Wh
 | `aileron.connector.op` | The connector operation name (e.g. `list_recent_emails`). |
 | `aileron.connector.hash` | The content-addressed hash of the connector binary. |
 
-**Sandbox HTTPS data plane** (`connector.proxy.proxied`, `connector.proxy.rejected`, `sandbox.proxy.passthrough`, `sandbox.proxy.rejected` audit events):
+**Sandbox HTTPS data plane** (`connector.proxy.proxied`, `connector.proxy.rejected`, `sandbox.proxy.passthrough`, `sandbox.proxy.upgrade`, `sandbox.proxy.rejected` audit events):
 
 | Attribute | Description |
 |---|---|
 | `aileron.proxy.source` | Where the proxy attempt entered Aileron: `generated_connector_shim`, `daemon_request_boundary`, `transparent_connect_tls`, or `launcher` (for `sandbox.proxy.disabled`). |
-| `aileron.proxy.decision` | `proxied`, `rejected`, `passthrough`, or `disabled`. |
+| `aileron.proxy.decision` | `proxied`, `rejected`, `passthrough`, `upgrade`, or `disabled`. |
 | `aileron.proxy.method` | HTTP method after daemon-side normalization. |
 | `aileron.proxy.upstream.scheme` | Upstream scheme. Currently `https` for mediated requests. |
 | `aileron.proxy.upstream.host` | Upstream host, including port when present. |
 | `aileron.proxy.upstream.path` | Upstream path only. Query strings are intentionally omitted. |
-| `aileron.proxy.upstream.status` | Upstream HTTP status for proxied and passthrough requests. |
+| `aileron.proxy.upstream.status` | Upstream HTTP status for proxied, passthrough, and upgrade requests (the WebSocket handshake status, e.g. `101`, for `sandbox.proxy.upgrade`). |
 | `aileron.proxy.reject_reason` | Rejection class for `sandbox.proxy.rejected`. Narrow protocol-level set: `non_connect_proxy_request_unsupported`, `session_ca_unavailable`, `connector_specs_invalid`, `connector_specs_unavailable`, `passthrough_target_not_allowed`, `passthrough_upstream_unreachable`, `passthrough_upstream_request_invalid`, `passthrough_upstream_read_failed`, `passthrough_upstream_response_too_large`. |
 | `aileron.connector.reject_reason` | Rejection class after a connector operation has been resolved. |
 | `aileron.connector.fqn` | Set on connector-resolved proxy events. |
@@ -178,7 +178,7 @@ Every span carries the OTel-namespaced shape locked in for the audit payload. Wh
 | `aileron.connector.credential` | Credential kind required by the spec, not the credential value. |
 | `aileron.session.id` | Launch session associated with the sandbox request when present. |
 
-The proxy mediates credential injection at the TLS boundary. It is not an egress allowlist. Cooperative HTTPS requests whose decrypted target does not uniquely match an installed connector spec are forwarded to the upstream unmodified and recorded as `sandbox.proxy.passthrough`. `sandbox.proxy.rejected` is reserved for protocol-level failures. See [ADR-0019](/adr/0019-v4-https-data-plane/) for the full credential-injection-only model and the threat-model scope.
+The proxy mediates credential injection at the TLS boundary. It is not an egress allowlist. Cooperative HTTPS requests whose decrypted target does not uniquely match an installed connector spec are forwarded to the upstream unmodified and recorded as `sandbox.proxy.passthrough`. WebSocket (and other HTTP Upgrade) handshakes are forwarded through the same passthrough boundary with their `Upgrade`/`Connection`/`Sec-WebSocket-*` headers preserved; the proxy relays the upstream's `101 Switching Protocols` response and opens a bidirectional byte tunnel, recorded as `sandbox.proxy.upgrade`. No credential is injected on either path. `sandbox.proxy.rejected` is reserved for protocol-level failures. See [ADR-0019](/adr/0019-v4-https-data-plane/) for the full credential-injection-only model and the threat-model scope.
 
 Migration note: operators who previously queried `sandbox.proxy.rejected` with reason `operation_not_matched` or `ambiguous_operation_match` to surface "agent attempted unknown upstream" should switch to querying `sandbox.proxy.passthrough`. Those two reject reasons are no longer emitted in production. The cooperative-passthrough behavior records the same operational signal as a new event family.
 

--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -664,6 +664,39 @@ func (s *apiServer) recordSandboxProxyPassthrough(r *http.Request, source, metho
 	)
 }
 
+// recordSandboxProxyUpgrade emits sandbox.proxy.upgrade for a WebSocket
+// (or other HTTP Upgrade) handshake forwarded through the passthrough
+// boundary. The upstream's handshake status is recorded; no credential
+// is injected and the tunnel bytes never appear in the payload.
+func (s *apiServer) recordSandboxProxyUpgrade(r *http.Request, source, method string, upstream *url.URL, upstreamStatus int) string {
+	if s.auditRecorder == nil {
+		if s.newID != nil {
+			return s.newID()
+		}
+		return audit.DefaultIDFn()
+	}
+	payload := map[string]any{
+		"aileron.proxy.boundary":        "https_proxy",
+		"aileron.proxy.mediation":       "https_proxy",
+		"aileron.proxy.source":          source,
+		"aileron.proxy.decision":        "upgrade",
+		"aileron.proxy.method":          method,
+		"aileron.proxy.upstream.scheme": upstream.Scheme,
+		"aileron.proxy.upstream.host":   upstream.Host,
+		"aileron.proxy.upstream.path":   sandboxProxyUpstreamPath(upstream),
+		"aileron.proxy.upstream.status": upstreamStatus,
+	}
+	if sessionID := strings.TrimSpace(r.Header.Get("X-Aileron-Session-Id")); sessionID != "" {
+		payload["aileron.session.id"] = sessionID
+	}
+	return s.auditRecorder.RecordSuccess(
+		r.Context(),
+		model.EventTypeSandboxProxyUpgrade,
+		model.ActorRef{Type: model.ActorTypeAgent, ID: "sandbox-proxy"},
+		payload,
+	)
+}
+
 // recordSandboxProxyProtocolRejected emits sandbox.proxy.rejected for
 // protocol-level failures only: non-CONNECT proxy requests, session CA
 // unavailable, connector specs invalid/unavailable, and passthrough

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -3,6 +3,7 @@ package app
 import (
 	"bufio"
 	"bytes"
+	"context"
 	"crypto/rand"
 	"crypto/rsa"
 	"crypto/tls"
@@ -152,10 +153,21 @@ func (s *apiServer) handleSandboxForwardProxyConnect(w http.ResponseWriter, r *h
 	s.handleSandboxForwardProxyDecrypted(tlsConn, decrypted, auth, targetHost)
 }
 
-func (s *apiServer) handleSandboxForwardProxyDecrypted(conn io.Writer, decrypted *http.Request, auth sandboxProxyAuth, targetHost string) {
+func (s *apiServer) handleSandboxForwardProxyDecrypted(conn net.Conn, decrypted *http.Request, auth sandboxProxyAuth, targetHost string) {
 	upstream, err := sandboxForwardProxyUpstreamURL(targetHost, decrypted)
 	if err != nil {
 		writeSandboxForwardProxyError(conn, http.StatusBadRequest, auth.SessionID, targetHost, "sandbox proxy decrypted request target is invalid")
+		return
+	}
+	// A WebSocket (or other HTTP Upgrade) handshake cannot be served by
+	// the buffered client.Do path: the upstream answers 101 and opens a
+	// bidirectional byte tunnel, not a single buffered response. These
+	// requests are forwarded through the passthrough boundary with the
+	// Upgrade/Connection/Sec-WebSocket-* headers preserved. No connector
+	// spec match is attempted because credential injection is not
+	// meaningful for a raw byte tunnel (ADR-0019 passthrough posture).
+	if sandboxForwardProxyIsWebSocketUpgrade(decrypted) {
+		s.upgradeSandboxForwardProxy(conn, decrypted, auth, targetHost, upstream)
 		return
 	}
 	match, ok, err := s.matchSandboxForwardProxyOperation(decrypted.Method, upstream)
@@ -211,7 +223,7 @@ func (s *apiServer) handleSandboxForwardProxyDecrypted(conn io.Writer, decrypted
 // agent should never see. Hostnames that resolve to private IPs are
 // not blocked at this layer (DNS-rebinding is out of scope for this
 // control; container-level network hardening is the deeper defense).
-func (s *apiServer) passthroughSandboxForwardProxy(conn io.Writer, decrypted *http.Request, auth sandboxProxyAuth, targetHost string, upstream *url.URL) {
+func (s *apiServer) passthroughSandboxForwardProxy(conn net.Conn, decrypted *http.Request, auth sandboxProxyAuth, targetHost string, upstream *url.URL) {
 	if sandboxForwardProxyTargetIsPrivateIPLiteral(targetHost) {
 		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "passthrough_target_not_allowed")
 		writeSandboxForwardProxyError(conn, http.StatusForbidden, auth.SessionID, targetHost, "sandbox proxy passthrough refuses private, loopback, or link-local IP literals")
@@ -253,6 +265,236 @@ func (s *apiServer) passthroughSandboxForwardProxy(conn io.Writer, decrypted *ht
 
 	s.recordSandboxProxyPassthrough(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, resp.StatusCode)
 	writeSandboxForwardProxyPassthroughResponse(conn, auth.SessionID, targetHost, resp, body)
+}
+
+// sandboxForwardProxyIsWebSocketUpgrade reports whether the decrypted
+// request is a WebSocket handshake: method GET, a Connection header
+// whose token list contains "upgrade", and an Upgrade header naming
+// "websocket". The token checks are case-insensitive per RFC 6455 and
+// RFC 7230 (Connection is a comma-separated token list).
+func sandboxForwardProxyIsWebSocketUpgrade(r *http.Request) bool {
+	if r.Method != http.MethodGet {
+		return false
+	}
+	if !strings.EqualFold(strings.TrimSpace(r.Header.Get("Upgrade")), "websocket") {
+		return false
+	}
+	return headerListContainsToken(r.Header.Values("Connection"), "upgrade")
+}
+
+// headerListContainsToken reports whether any of the comma-separated
+// header values contains the given token (case-insensitive).
+func headerListContainsToken(values []string, token string) bool {
+	for _, v := range values {
+		for _, field := range strings.Split(v, ",") {
+			if strings.EqualFold(strings.TrimSpace(field), token) {
+				return true
+			}
+		}
+	}
+	return false
+}
+
+// upgradeSandboxForwardProxy relays a WebSocket (or other HTTP Upgrade)
+// handshake through the passthrough boundary and, on a successful 101,
+// opens a bidirectional byte tunnel between the in-container client and
+// the upstream. The Upgrade/Connection/Sec-WebSocket-* headers are
+// preserved verbatim (unlike the buffered passthrough path, which
+// strips hop-by-hop headers). The upstream is dialed over TLS using the
+// configured sandbox proxy transport's dialer and TLS config. No
+// credential is injected (ADR-0019 passthrough posture).
+//
+// The tunnel is byte-for-byte with no response-size cap, consistent
+// with the passthrough model's no-cap rationale: resource budgets are
+// operator-managed at the container runtime layer, not the proxy. The
+// private-IP-literal refusal guard applies here exactly as it does on
+// the buffered passthrough path.
+func (s *apiServer) upgradeSandboxForwardProxy(conn net.Conn, decrypted *http.Request, auth sandboxProxyAuth, targetHost string, upstream *url.URL) {
+	if sandboxForwardProxyTargetIsPrivateIPLiteral(targetHost) {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "passthrough_target_not_allowed")
+		writeSandboxForwardProxyError(conn, http.StatusForbidden, auth.SessionID, targetHost, "sandbox proxy passthrough refuses private, loopback, or link-local IP literals")
+		return
+	}
+
+	upstreamConn, err := s.dialSandboxForwardProxyUpstreamTLS(decrypted.Context(), targetHost)
+	if err != nil {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "passthrough_upstream_unreachable")
+		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy upgrade upstream unreachable")
+		return
+	}
+	defer upstreamConn.Close()
+
+	upstreamReq := sandboxForwardProxyUpgradeRequest(decrypted, targetHost, upstream)
+	if err := upstreamReq.Write(upstreamConn); err != nil {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "passthrough_upstream_unreachable")
+		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy upgrade upstream write failed")
+		return
+	}
+
+	upstreamReader := bufio.NewReader(upstreamConn)
+	resp, err := http.ReadResponse(upstreamReader, upstreamReq)
+	if err != nil {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "passthrough_upstream_read_failed")
+		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy upgrade upstream response read failed")
+		return
+	}
+
+	// Relay the upstream's handshake response (status line + headers)
+	// verbatim back to the in-container client. The X-Aileron headers are
+	// injected so the client can correlate the tunnel with its session.
+	if err := writeSandboxForwardProxyUpgradeResponse(conn, auth.SessionID, targetHost, resp); err != nil {
+		resp.Body.Close()
+		return
+	}
+
+	s.recordSandboxProxyUpgrade(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, resp.StatusCode)
+
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		// Upstream declined the upgrade. The status and headers have been
+		// relayed; drain and close without opening a tunnel.
+		resp.Body.Close()
+		return
+	}
+	resp.Body.Close()
+
+	sandboxForwardProxyTunnel(conn, upstreamConn, upstreamReader)
+}
+
+// dialSandboxForwardProxyUpstreamTLS dials the upstream over TLS,
+// reusing the configured sandbox proxy transport's DialContext and TLS
+// config when present so tests (and any custom transport wiring) take
+// effect for the upgrade path exactly as they do for buffered
+// passthrough.
+func (s *apiServer) dialSandboxForwardProxyUpstreamTLS(ctx context.Context, targetHost string) (net.Conn, error) {
+	addr := targetHost
+	if _, _, err := net.SplitHostPort(addr); err != nil {
+		addr = net.JoinHostPort(targetHost, "443")
+	}
+	serverName := targetHost
+	if h, _, err := net.SplitHostPort(targetHost); err == nil {
+		serverName = h
+	}
+
+	dialContext := (&net.Dialer{Timeout: 30 * time.Second}).DialContext
+	var tlsConfig *tls.Config
+	if s.sandboxProxyClient != nil {
+		if tr, ok := s.sandboxProxyClient.Transport.(*http.Transport); ok && tr != nil {
+			if tr.DialContext != nil {
+				dialContext = tr.DialContext
+			}
+			if tr.TLSClientConfig != nil {
+				tlsConfig = tr.TLSClientConfig.Clone()
+			}
+		}
+	}
+	if tlsConfig == nil {
+		tlsConfig = &tls.Config{MinVersion: tls.VersionTLS12}
+	}
+	if tlsConfig.ServerName == "" {
+		tlsConfig.ServerName = serverName
+	}
+
+	rawConn, err := dialContext(ctx, "tcp", addr)
+	if err != nil {
+		return nil, err
+	}
+	tlsConn := tls.Client(rawConn, tlsConfig)
+	if err := tlsConn.HandshakeContext(ctx); err != nil {
+		rawConn.Close()
+		return nil, err
+	}
+	return tlsConn, nil
+}
+
+// sandboxForwardProxyUpgradeRequest builds the upstream-facing upgrade
+// request, copying every client header verbatim (including the
+// Upgrade, Connection, and Sec-WebSocket-* headers that the buffered
+// passthrough path strips as hop-by-hop). The proxy-specific session
+// header is removed so it never leaks to the upstream.
+func sandboxForwardProxyUpgradeRequest(decrypted *http.Request, targetHost string, upstream *url.URL) *http.Request {
+	req := &http.Request{
+		Method:     http.MethodGet,
+		URL:        &url.URL{Path: upstream.Path, RawQuery: upstream.RawQuery},
+		Host:       targetHost,
+		Proto:      "HTTP/1.1",
+		ProtoMajor: 1,
+		ProtoMinor: 1,
+		Header:     make(http.Header, len(decrypted.Header)),
+	}
+	for k, vs := range decrypted.Header {
+		if http.CanonicalHeaderKey(k) == "X-Aileron-Session-Id" {
+			continue
+		}
+		for _, v := range vs {
+			req.Header.Add(k, v)
+		}
+	}
+	return req
+}
+
+// writeSandboxForwardProxyUpgradeResponse relays the upstream handshake
+// response (status line and headers) verbatim to the in-container
+// client, appending the X-Aileron correlation headers.
+func writeSandboxForwardProxyUpgradeResponse(conn net.Conn, sessionID, targetHost string, resp *http.Response) error {
+	sessionID = sandboxForwardProxyHeaderValue(sessionID)
+	targetHost = sandboxForwardProxyHeaderValue(targetHost)
+
+	var sb strings.Builder
+	statusText := resp.Status
+	if i := strings.IndexByte(statusText, ' '); i >= 0 {
+		statusText = strings.TrimSpace(statusText[i+1:])
+	}
+	if statusText == "" {
+		statusText = http.StatusText(resp.StatusCode)
+	}
+	fmt.Fprintf(&sb, "HTTP/1.1 %d %s\r\n", resp.StatusCode, statusText)
+	for _, k := range sortedHeaderKeys(resp.Header) {
+		for _, v := range resp.Header.Values(k) {
+			fmt.Fprintf(&sb, "%s: %s\r\n", k, sandboxForwardProxyHeaderValue(v))
+		}
+	}
+	fmt.Fprintf(&sb, "X-Aileron-Session-Id: %s\r\nX-Aileron-Proxy-Upstream-Host: %s\r\n\r\n", sessionID, targetHost)
+
+	_, err := io.WriteString(conn, sb.String())
+	return err
+}
+
+// sandboxForwardProxyTunnel copies bytes bidirectionally between the
+// in-container client connection and the upstream connection until
+// either side closes. Any bytes already buffered in upstreamReader
+// (read past the handshake response) are flushed to the client first.
+func sandboxForwardProxyTunnel(clientConn, upstreamConn net.Conn, upstreamReader *bufio.Reader) {
+	done := make(chan struct{}, 2)
+	go func() {
+		if n := upstreamReader.Buffered(); n > 0 {
+			if buffered, err := upstreamReader.Peek(n); err == nil {
+				_, _ = clientConn.Write(buffered)
+				_, _ = upstreamReader.Discard(n)
+			}
+		}
+		_, _ = io.Copy(clientConn, upstreamReader)
+		closeWriteOrConn(clientConn)
+		done <- struct{}{}
+	}()
+	go func() {
+		_, _ = io.Copy(upstreamConn, clientConn)
+		closeWriteOrConn(upstreamConn)
+		done <- struct{}{}
+	}()
+	<-done
+	<-done
+}
+
+// closeWriteOrConn half-closes the write side of conn when supported
+// (TLS and TCP conns expose CloseWrite), signaling EOF to the peer
+// without tearing down the read direction. Falls back to a full close.
+func closeWriteOrConn(conn net.Conn) {
+	type closeWriter interface{ CloseWrite() error }
+	if cw, ok := conn.(closeWriter); ok {
+		_ = cw.CloseWrite()
+		return
+	}
+	_ = conn.Close()
 }
 
 // sandboxForwardProxyTargetIsPrivateIPLiteral reports whether the

--- a/internal/app/sandbox_forward_proxy_passthrough_test.go
+++ b/internal/app/sandbox_forward_proxy_passthrough_test.go
@@ -33,6 +33,7 @@ type passthroughIntegrationSetup struct {
 	client      *http.Client
 	auditStore  *audit.MemStore
 	logicalHost string
+	roots       *x509.CertPool
 }
 
 func newPassthroughIntegrationSetup(t *testing.T, upstreamHandler http.Handler) *passthroughIntegrationSetup {
@@ -97,6 +98,7 @@ func newPassthroughIntegrationSetup(t *testing.T, upstreamHandler http.Handler) 
 		client:      newSandboxForwardProxyClient(t, proxyURL, roots),
 		auditStore:  auditStore,
 		logicalHost: logicalHost,
+		roots:       roots,
 	}
 }
 

--- a/internal/app/sandbox_forward_proxy_upgrade_test.go
+++ b/internal/app/sandbox_forward_proxy_upgrade_test.go
@@ -1,0 +1,480 @@
+package app
+
+import (
+	"bufio"
+	"context"
+	"crypto/sha1"
+	"crypto/tls"
+	"crypto/x509"
+	"encoding/base64"
+	"encoding/binary"
+	"fmt"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+	"github.com/ALRubinger/aileron/internal/model"
+)
+
+const websocketGUID = "258EAFA5-E914-47DA-95CA-C5AB0DC85B11"
+
+// websocketEchoUpstreamHandler is a minimal RFC 6455 server: it
+// completes the opening handshake (validating the Connection/Upgrade
+// headers survived the proxy) and echoes a single text frame back. A
+// request that is NOT a websocket upgrade (e.g. headers stripped to a
+// plain GET) is answered 405 Method Not Allowed — this is exactly the
+// symptom the pre-fix proxy produced, so the regression test can assert
+// on it.
+func websocketEchoUpstreamHandler(observedUpgrade *string) http.HandlerFunc {
+	return func(w http.ResponseWriter, r *http.Request) {
+		if observedUpgrade != nil {
+			*observedUpgrade = r.Header.Get("Upgrade")
+		}
+		if !strings.EqualFold(r.Header.Get("Upgrade"), "websocket") ||
+			!strings.Contains(strings.ToLower(r.Header.Get("Connection")), "upgrade") {
+			http.Error(w, "expected websocket upgrade", http.StatusMethodNotAllowed)
+			return
+		}
+		key := r.Header.Get("Sec-WebSocket-Key")
+		accept := websocketAcceptKey(key)
+
+		hj, ok := w.(http.Hijacker)
+		if !ok {
+			http.Error(w, "no hijack", http.StatusInternalServerError)
+			return
+		}
+		conn, _, err := hj.Hijack()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+
+		_, _ = io.WriteString(conn, "HTTP/1.1 101 Switching Protocols\r\n"+
+			"Upgrade: websocket\r\n"+
+			"Connection: Upgrade\r\n"+
+			"Sec-WebSocket-Accept: "+accept+"\r\n\r\n")
+
+		// Echo loop: read one client frame, write it back as a server
+		// frame (unmasked).
+		reader := bufio.NewReader(conn)
+		payload, err := readWebSocketTextFrame(reader)
+		if err != nil {
+			return
+		}
+		_, _ = conn.Write(encodeWebSocketTextFrame(payload, false))
+	}
+}
+
+func websocketAcceptKey(key string) string {
+	h := sha1.New()
+	_, _ = io.WriteString(h, key+websocketGUID)
+	return base64.StdEncoding.EncodeToString(h.Sum(nil))
+}
+
+// encodeWebSocketTextFrame encodes a single, final text frame. When
+// masked is true the payload is masked per RFC 6455 (client-to-server
+// frames must be masked).
+func encodeWebSocketTextFrame(payload []byte, masked bool) []byte {
+	var frame []byte
+	frame = append(frame, 0x81) // FIN + text opcode
+	length := len(payload)
+	maskBit := byte(0)
+	if masked {
+		maskBit = 0x80
+	}
+	switch {
+	case length < 126:
+		frame = append(frame, maskBit|byte(length))
+	case length < 1<<16:
+		frame = append(frame, maskBit|126)
+		var ext [2]byte
+		binary.BigEndian.PutUint16(ext[:], uint16(length))
+		frame = append(frame, ext[:]...)
+	default:
+		frame = append(frame, maskBit|127)
+		var ext [8]byte
+		binary.BigEndian.PutUint64(ext[:], uint64(length))
+		frame = append(frame, ext[:]...)
+	}
+	if masked {
+		mask := []byte{0xAA, 0xBB, 0xCC, 0xDD}
+		frame = append(frame, mask...)
+		for i, b := range payload {
+			frame = append(frame, b^mask[i%4])
+		}
+		return frame
+	}
+	return append(frame, payload...)
+}
+
+// readWebSocketTextFrame reads a single text frame, unmasking the
+// payload when the mask bit is set.
+func readWebSocketTextFrame(r *bufio.Reader) ([]byte, error) {
+	header := make([]byte, 2)
+	if _, err := io.ReadFull(r, header); err != nil {
+		return nil, err
+	}
+	masked := header[1]&0x80 != 0
+	length := int(header[1] & 0x7F)
+	switch length {
+	case 126:
+		ext := make([]byte, 2)
+		if _, err := io.ReadFull(r, ext); err != nil {
+			return nil, err
+		}
+		length = int(binary.BigEndian.Uint16(ext))
+	case 127:
+		ext := make([]byte, 8)
+		if _, err := io.ReadFull(r, ext); err != nil {
+			return nil, err
+		}
+		length = int(binary.BigEndian.Uint64(ext))
+	}
+	var mask []byte
+	if masked {
+		mask = make([]byte, 4)
+		if _, err := io.ReadFull(r, mask); err != nil {
+			return nil, err
+		}
+	}
+	payload := make([]byte, length)
+	if _, err := io.ReadFull(r, payload); err != nil {
+		return nil, err
+	}
+	if masked {
+		for i := range payload {
+			payload[i] ^= mask[i%4]
+		}
+	}
+	return payload, nil
+}
+
+// dialThroughSandboxProxyTLS performs CONNECT host:443 through the
+// proxy with Basic proxy auth, then completes the inner TLS handshake
+// against the proxy's MITM leaf certificate. The returned conn is the
+// in-container TLS connection: writing an HTTP request to it drives the
+// decrypted-request handling path, exactly as the real in-container
+// client does.
+func dialThroughSandboxProxyTLS(t *testing.T, proxyURL *url.URL, roots *x509.CertPool, logicalHost string) net.Conn {
+	t.Helper()
+	raw, err := net.Dial("tcp", proxyURL.Host)
+	if err != nil {
+		t.Fatalf("dial proxy: %v", err)
+	}
+	connectReq := "CONNECT " + logicalHost + ":443 HTTP/1.1\r\n" +
+		"Host: " + logicalHost + ":443\r\n" +
+		"Proxy-Authorization: " + basicProxyAuth("session-123", "daemon-token") + "\r\n\r\n"
+	if _, err := io.WriteString(raw, connectReq); err != nil {
+		raw.Close()
+		t.Fatalf("write CONNECT: %v", err)
+	}
+	br := bufio.NewReader(raw)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodConnect})
+	if err != nil {
+		raw.Close()
+		t.Fatalf("read CONNECT response: %v", err)
+	}
+	if resp.StatusCode != http.StatusOK {
+		raw.Close()
+		t.Fatalf("CONNECT status = %d, want 200", resp.StatusCode)
+	}
+	if br.Buffered() > 0 {
+		t.Fatalf("unexpected buffered bytes after CONNECT response")
+	}
+	tlsConn := tls.Client(raw, &tls.Config{
+		RootCAs:    roots,
+		ServerName: logicalHost,
+		MinVersion: tls.VersionTLS12,
+	})
+	if err := tlsConn.Handshake(); err != nil {
+		raw.Close()
+		t.Fatalf("inner TLS handshake: %v", err)
+	}
+	t.Cleanup(func() { tlsConn.Close() })
+	return tlsConn
+}
+
+// writeWebSocketUpgradeRequest writes a real RFC 6455 opening handshake
+// request to conn for the given path.
+func writeWebSocketUpgradeRequest(t *testing.T, conn net.Conn, logicalHost, path, key string) {
+	t.Helper()
+	req := fmt.Sprintf("GET %s HTTP/1.1\r\n"+
+		"Host: %s\r\n"+
+		"Upgrade: websocket\r\n"+
+		"Connection: Upgrade\r\n"+
+		"Sec-WebSocket-Key: %s\r\n"+
+		"Sec-WebSocket-Version: 13\r\n\r\n", path, logicalHost, key)
+	if _, err := io.WriteString(conn, req); err != nil {
+		t.Fatalf("write upgrade request: %v", err)
+	}
+}
+
+func TestSandboxForwardProxy_WebSocketUpgradeTunnelsEchoRoundTrip(t *testing.T) {
+	var observedUpgrade string
+	setup := newPassthroughIntegrationSetup(t, websocketEchoUpstreamHandler(&observedUpgrade))
+
+	conn := dialThroughSandboxProxyTLS(t, setup.proxyURL, setup.roots, setup.logicalHost)
+
+	const key = "dGhlIHNhbXBsZSBub25jZQ=="
+	writeWebSocketUpgradeRequest(t, conn, setup.logicalHost, "/backend-api/codex/responses", key)
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatalf("read handshake response: %v", err)
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("handshake status = %d, want 101", resp.StatusCode)
+	}
+	if got := resp.Header.Get("Upgrade"); !strings.EqualFold(got, "websocket") {
+		t.Errorf("relayed Upgrade header = %q, want websocket", got)
+	}
+	if got := resp.Header.Get("Sec-WebSocket-Accept"); got != websocketAcceptKey(key) {
+		t.Errorf("Sec-WebSocket-Accept = %q, want %q", got, websocketAcceptKey(key))
+	}
+
+	// The upstream must have seen the Upgrade header preserved through the
+	// proxy — the pre-fix bug stripped it.
+	if !strings.EqualFold(observedUpgrade, "websocket") {
+		t.Errorf("upstream observed Upgrade = %q, want websocket (header must survive the proxy)", observedUpgrade)
+	}
+
+	// Bidirectional tunnel: send a masked client frame, expect the echoed
+	// payload back.
+	const message = "hello over the tunnel"
+	if _, err := conn.Write(encodeWebSocketTextFrame([]byte(message), true)); err != nil {
+		t.Fatalf("write client frame: %v", err)
+	}
+	echoed, err := readWebSocketTextFrame(br)
+	if err != nil {
+		t.Fatalf("read echoed frame: %v", err)
+	}
+	if string(echoed) != message {
+		t.Errorf("echoed payload = %q, want %q", string(echoed), message)
+	}
+
+	events, err := setup.auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1; events=%+v", len(events), events)
+	}
+	evt := events[0]
+	if evt.EventType != model.EventTypeSandboxProxyUpgrade {
+		t.Fatalf("event type = %q, want %q", evt.EventType, model.EventTypeSandboxProxyUpgrade)
+	}
+	if got := evt.Payload["aileron.proxy.upstream.host"]; got != setup.logicalHost {
+		t.Errorf("upstream host = %v, want %s", got, setup.logicalHost)
+	}
+	if got := evt.Payload["aileron.proxy.upstream.path"]; got != "/backend-api/codex/responses" {
+		t.Errorf("upstream path = %v, want /backend-api/codex/responses", got)
+	}
+	if got := evt.Payload["aileron.proxy.upstream.status"]; got != http.StatusSwitchingProtocols {
+		t.Errorf("upstream status = %v, want 101", got)
+	}
+	if got := evt.Payload["aileron.session.id"]; got != "session-123" {
+		t.Errorf("session id = %v, want session-123", got)
+	}
+	sandboxProxyUpgradeShape.validate(t, evt.Payload)
+}
+
+// TestSandboxForwardProxy_WebSocketUpgradeRegression is the regression
+// guard for issue #1164: before the fix, the proxy stripped the
+// Upgrade/Connection headers and forwarded a plain GET, so a WebSocket
+// handshake arrived at the upstream as a non-upgrade request and was
+// answered 405 Method Not Allowed (never a 101). This test asserts the
+// pre-fix behavior is gone: the handshake yields 101, not a 4xx/5xx,
+// and the Upgrade header reaches the upstream intact.
+func TestSandboxForwardProxy_WebSocketUpgradeRegression(t *testing.T) {
+	var observedUpgrade string
+	setup := newPassthroughIntegrationSetup(t, websocketEchoUpstreamHandler(&observedUpgrade))
+
+	conn := dialThroughSandboxProxyTLS(t, setup.proxyURL, setup.roots, setup.logicalHost)
+	writeWebSocketUpgradeRequest(t, conn, setup.logicalHost, "/backend-api/codex/responses", "dGhlIHNhbXBsZSBub25jZQ==")
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatalf("read handshake response: %v", err)
+	}
+	if resp.StatusCode == http.StatusMethodNotAllowed {
+		t.Fatalf("handshake returned 405 — pre-fix behavior (Upgrade header stripped, forwarded as plain GET)")
+	}
+	if resp.StatusCode != http.StatusSwitchingProtocols {
+		t.Fatalf("handshake status = %d, want 101 (upgrade must complete)", resp.StatusCode)
+	}
+	if observedUpgrade == "" {
+		t.Errorf("upstream observed no Upgrade header — the proxy stripped it (the #1164 bug)")
+	}
+}
+
+// TestSandboxForwardProxy_WebSocketUpgradeRelaysNon101Verbatim covers
+// the branch where the upstream declines the upgrade: the proxy relays
+// the upstream's non-101 status and headers verbatim and records the
+// upgrade audit event with that status, without opening a tunnel.
+func TestSandboxForwardProxy_WebSocketUpgradeRelaysNon101Verbatim(t *testing.T) {
+	setup := newPassthroughIntegrationSetup(t, http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		// Upstream rejects the handshake with 403 rather than 101.
+		w.Header().Set("X-Upstream-Decline", "true")
+		w.WriteHeader(http.StatusForbidden)
+		_, _ = w.Write([]byte("upgrade declined"))
+	}))
+
+	conn := dialThroughSandboxProxyTLS(t, setup.proxyURL, setup.roots, setup.logicalHost)
+	writeWebSocketUpgradeRequest(t, conn, setup.logicalHost, "/ws", "dGhlIHNhbXBsZSBub25jZQ==")
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatalf("read handshake response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (non-101 relayed verbatim)", resp.StatusCode)
+	}
+	if got := resp.Header.Get("X-Upstream-Decline"); got != "true" {
+		t.Errorf("X-Upstream-Decline = %q, want true (upstream header relayed)", got)
+	}
+
+	events, err := setup.auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyUpgrade {
+		t.Fatalf("event type = %q, want %q", events[0].EventType, model.EventTypeSandboxProxyUpgrade)
+	}
+	if got := events[0].Payload["aileron.proxy.upstream.status"]; got != http.StatusForbidden {
+		t.Errorf("upstream status = %v, want 403", got)
+	}
+}
+
+// TestSandboxForwardProxy_WebSocketUpgradeUpstreamUnreachable covers the
+// dial-failure branch: when the upstream cannot be reached the proxy
+// returns 502 and records sandbox.proxy.rejected.
+func TestSandboxForwardProxy_WebSocketUpgradeUpstreamUnreachable(t *testing.T) {
+	stateDir := t.TempDir()
+	caPEM := writeSandboxProxyTestCA(t, stateDir, "session-123")
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		localDaemonToken:     "daemon-token",
+		sandboxProxyStateDir: stateDir,
+		auditRecorder:        audit.NewRecorder(auditStore, nil, func() string { return "audit-ws-unreachable" }),
+		specLoader: func() ([]connectorspec.Spec, error) {
+			return nil, nil
+		},
+		sandboxProxyClient: &http.Client{Transport: &http.Transport{
+			DialContext: func(context.Context, string, string) (net.Conn, error) {
+				return nil, fmt.Errorf("dial refused")
+			},
+		}},
+	}
+	proxy := httptest.NewServer(srv.sandboxForwardProxyMiddleware(http.NotFoundHandler()))
+	t.Cleanup(proxy.Close)
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		t.Fatal("failed to append CA cert")
+	}
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+
+	conn := dialThroughSandboxProxyTLS(t, proxyURL, roots, setupLogicalHostUnreachable)
+	writeWebSocketUpgradeRequest(t, conn, setupLogicalHostUnreachable, "/ws", "dGhlIHNhbXBsZSBub25jZQ==")
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatalf("read handshake response: %v", err)
+	}
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502 (upstream unreachable)", resp.StatusCode)
+	}
+
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyRejected {
+		t.Fatalf("event type = %q, want %q", events[0].EventType, model.EventTypeSandboxProxyRejected)
+	}
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != "passthrough_upstream_unreachable" {
+		t.Errorf("reject_reason = %v, want passthrough_upstream_unreachable", got)
+	}
+}
+
+const setupLogicalHostUnreachable = "api.unreachable.test"
+
+// TestSandboxForwardProxy_WebSocketUpgradeRefusesPrivateIPLiteral keeps
+// the SSRF guard green on the upgrade path: a WebSocket handshake to a
+// private/metadata IP literal must be refused at the passthrough
+// boundary, never tunneled.
+func TestSandboxForwardProxy_WebSocketUpgradeRefusesPrivateIPLiteral(t *testing.T) {
+	stateDir := t.TempDir()
+	caPEM := writeSandboxProxyTestCA(t, stateDir, "session-123")
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		localDaemonToken:     "daemon-token",
+		sandboxProxyStateDir: stateDir,
+		auditRecorder:        audit.NewRecorder(auditStore, nil, func() string { return "audit-ws-ssrf" }),
+		specLoader: func() ([]connectorspec.Spec, error) {
+			return nil, nil
+		},
+		sandboxProxyClient: &http.Client{Transport: &http.Transport{
+			DialContext: func(context.Context, string, string) (net.Conn, error) {
+				t.Fatalf("upgrade must not dial upstream for private IP literal target")
+				return nil, nil
+			},
+		}},
+	}
+	proxy := httptest.NewServer(srv.sandboxForwardProxyMiddleware(http.NotFoundHandler()))
+	t.Cleanup(proxy.Close)
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		t.Fatal("failed to append CA cert")
+	}
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+
+	conn := dialThroughSandboxProxyTLS(t, proxyURL, roots, "169.254.169.254")
+	writeWebSocketUpgradeRequest(t, conn, "169.254.169.254", "/ws", "dGhlIHNhbXBsZSBub25jZQ==")
+
+	br := bufio.NewReader(conn)
+	resp, err := http.ReadResponse(br, &http.Request{Method: http.MethodGet})
+	if err != nil {
+		t.Fatalf("read handshake response: %v", err)
+	}
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403 (private IP literal refused)", resp.StatusCode)
+	}
+
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyRejected {
+		t.Fatalf("event type = %q, want %q", events[0].EventType, model.EventTypeSandboxProxyRejected)
+	}
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != "passthrough_target_not_allowed" {
+		t.Errorf("reject_reason = %v, want passthrough_target_not_allowed", got)
+	}
+}

--- a/internal/app/sandbox_proxy_audit_shape_test.go
+++ b/internal/app/sandbox_proxy_audit_shape_test.go
@@ -171,6 +171,27 @@ var (
 		},
 	}
 
+	sandboxProxyUpgradeShape = sandboxProxyEventShape{
+		eventType: "sandbox.proxy.upgrade",
+		requiredFields: []string{
+			"aileron.proxy.boundary",
+			"aileron.proxy.mediation",
+			"aileron.proxy.source",
+			"aileron.proxy.decision",
+			"aileron.proxy.method",
+			"aileron.proxy.upstream.scheme",
+			"aileron.proxy.upstream.host",
+			"aileron.proxy.upstream.path",
+			"aileron.proxy.upstream.status",
+		},
+		allowedFields: []string{
+			"aileron.session.id",
+		},
+		forbiddenSubstrs: []string{
+			"lin_secret", "Bearer ", "Authorization",
+		},
+	}
+
 	sandboxProxyDisabledShape = sandboxProxyEventShape{
 		eventType: "sandbox.proxy.disabled",
 		requiredFields: []string{
@@ -272,6 +293,28 @@ func TestSandboxProxyAuditShape_SandboxProxyPassthroughConforms(t *testing.T) {
 	sandboxProxyPassthroughShape.validate(t, events[0].Payload)
 }
 
+func TestSandboxProxyAuditShape_SandboxProxyUpgradeConforms(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-shape-upgrade" }),
+	}
+	req := httptest.NewRequest(http.MethodConnect, "/", nil)
+	req.Header.Set("X-Aileron-Session-Id", "session-shape-test")
+	upstream, _ := url.Parse("https://api.unknown.test/backend-api/codex/responses")
+	srv.recordSandboxProxyUpgrade(req, sandboxProxySourceTransparentConnectTLS, "GET", upstream, http.StatusSwitchingProtocols)
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyUpgrade {
+		t.Fatalf("event type = %q", events[0].EventType)
+	}
+	sandboxProxyUpgradeShape.validate(t, events[0].Payload)
+	if got := events[0].Payload["aileron.proxy.upstream.status"]; got != http.StatusSwitchingProtocols {
+		t.Errorf("upstream status = %v, want 101", got)
+	}
+}
+
 // TestSandboxProxyAuditShape_SandboxProxyDisabledConforms pins the
 // sandbox.proxy.disabled family (gate A). RecordSandboxProxyDisabled is
 // the daemon endpoint the launcher posts to once per launch session
@@ -368,6 +411,7 @@ func TestSandboxProxyAuditShape_NoCredentialLeakAcrossFamilies(t *testing.T) {
 	srv.recordSandboxProxyRejected(proxyReq, sandboxProxySourceTransparentConnectTLS, fqn, "linear", "GET", upstream, op, "upstream_transport_failed")
 	srv.recordSandboxProxyProtocolRejected(proxyReq, sandboxProxySourceTransparentConnectTLS, "GET", upstream, "session_ca_unavailable")
 	srv.recordSandboxProxyPassthrough(proxyReq, sandboxProxySourceTransparentConnectTLS, "GET", upstream, 200)
+	srv.recordSandboxProxyUpgrade(proxyReq, sandboxProxySourceTransparentConnectTLS, "GET", upstream, http.StatusSwitchingProtocols)
 	srv.recordConnectorOperationRejected(proxyReq, fqn, "linear", op)
 
 	mode := "docker"
@@ -383,8 +427,8 @@ func TestSandboxProxyAuditShape_NoCredentialLeakAcrossFamilies(t *testing.T) {
 	srv.RecordSandboxProxyDisabled(httptest.NewRecorder(), disabledReq)
 
 	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
-	if len(events) != 6 {
-		t.Fatalf("events = %d, want 6 (one per emitter)", len(events))
+	if len(events) != 7 {
+		t.Fatalf("events = %d, want 7 (one per emitter)", len(events))
 	}
 	for _, ev := range events {
 		payloadJSON, _ := json.Marshal(ev.Payload)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -317,6 +317,15 @@ const (
 	// credential is injected. See ADR-0019.
 	EventTypeSandboxProxyPassthrough EventType = "sandbox.proxy.passthrough"
 
+	// Sandbox proxy event for cooperative HTTPS requests that are a
+	// WebSocket (or other HTTP Upgrade) handshake whose upstream no
+	// installed connector spec matched. The proxy preserves the
+	// Upgrade/Connection/Sec-WebSocket-* headers, relays the upstream's
+	// 101 (or non-101) response verbatim, and opens a bidirectional byte
+	// tunnel between the in-container client and the upstream. No
+	// credential is injected. See ADR-0019.
+	EventTypeSandboxProxyUpgrade EventType = "sandbox.proxy.upgrade"
+
 	// Sandbox proxy event for launches that proceed (or refuse to
 	// proceed) without the HTTPS data-plane bootstrap. Emitted by the
 	// launcher when proxy bootstrap is opted out, preflight fails, or


### PR DESCRIPTION
## Summary

The sandbox egress forward proxy (`internal/app/handlers_sandbox_forward_proxy.go`) is a TLS-MITM CONNECT proxy. After the inner TLS handshake it read exactly one decrypted HTTP request and served it via a buffered `client.Do`. It had **zero support for HTTP Upgrade / WebSocket**:

- The passthrough path stripped the `Upgrade` and `Connection` headers as hop-by-hop (`isSandboxForwardProxyHopByHopRequestHeader`).
- So a `GET wss://chatgpt.com/backend-api/codex/responses` upgrade was forwarded as a plain `GET`, and the upstream answered **405 Method Not Allowed** — exactly the symptom Codex reported in #1164.
- Even had the headers survived, the proxy never relayed a `101 Switching Protocols` nor opened a bidirectional byte tunnel.

This change detects a WebSocket upgrade in the decrypted-request path (method `GET`, `Connection` token list contains `upgrade`, `Upgrade: websocket`) and routes it to a new upgrade tunnel instead of the buffered path:

1. Keeps the existing private-IP-literal SSRF refusal guard.
2. Dials the upstream over TLS, reusing the sandbox proxy transport's `DialContext` and `TLSClientConfig`.
3. Writes the upgrade request with `Upgrade`/`Connection`/`Sec-WebSocket-*` headers **preserved** (the proxy-only `X-Aileron-Session-Id` is stripped so it never leaks upstream).
4. Reads the upstream's `101` (or non-101) response and relays the status line + headers verbatim back over the in-container TLS conn.
5. `io.Copy` bidirectionally between the client TLS conn and the upstream conn until either side closes (`CloseWrite` half-close on each direction).

The tunnel is byte-for-byte with no response-size cap (consistent with the passthrough model's no-cap rationale, ADR-0019) and injects no credential. A new `sandbox.proxy.upgrade` audit event records the handshake (host, path, method, upstream status). Observability docs updated.

This is the launch-container passthrough proxy, not the deny-by-default connector/spawn `HostPolicy` in `network.go`.

## Test plan

- `internal/app/sandbox_forward_proxy_upgrade_test.go` (new):
  - **Integration**: stands up an RFC 6455 WebSocket-echo upstream behind the CONNECT/TLS intercepting proxy, drives a real handshake through the proxy to the logical host, and asserts a `101`, the relayed `Sec-WebSocket-Accept`, a full echoed frame round-trip (masked client frame in, unmasked echo out), and the `sandbox.proxy.upgrade` audit event.
  - **Regression (#1164)**: asserts the pre-fix behavior is gone — the upgrade no longer returns 405 with stripped `Upgrade` headers; the upstream observes the `Upgrade` header intact and answers `101`. Verified failing before the fix (405) and passing after.
  - **SSRF guard**: a WebSocket upgrade to `169.254.169.254` is refused at the passthrough boundary (`403`, `passthrough_target_not_allowed`), never dialed.
  - **Error paths**: non-101 upstream response relayed verbatim with audit; upstream-unreachable yields `502` + `passthrough_upstream_unreachable`.
- `internal/app/sandbox_proxy_audit_shape_test.go`: new `sandbox.proxy.upgrade` shape conformance test + the emitter added to the cross-family no-credential-leak sweep.
- `go test ./...` green across the `internal` module; `go vet` and `gofmt` clean.
- CodeRabbit review: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
