### PR TITLE
fix(launch): disable redundant Codex OS sandbox in container

### DIFF
--- a/internal/launch/agents/codex.go
+++ b/internal/launch/agents/codex.go
@@ -148,10 +148,13 @@ func (c Codex) configureSandboxMCP(mcpBin string, mcpEnv map[string]string) ([]s
 	// Sandbox mode emits only our [mcp_servers.aileron] block — no
 	// merge with a host-side config. The empty-string baseline mirrors
 	// what mergeCodexMCPBlock produces when called with no prior file.
-	// Sandbox mode also emits `cli_auth_credentials_store = "file"`
-	// as a top-level key so the in-container Codex resolves auth
-	// from auth.json — the AuthSpec FileBinding writes auth.json
-	// into the same directory at launch (R22).
+	// Sandbox mode also emits two top-level keys:
+	// `sandbox_mode = "danger-full-access"` disables Codex's redundant
+	// in-container OS sandbox (the Alpine image ships no bubblewrap, so
+	// it would only warn and fall back), and
+	// `cli_auth_credentials_store = "file"` so the in-container Codex
+	// resolves auth from auth.json — the AuthSpec FileBinding writes
+	// auth.json into the same directory at launch (R22).
 	body := mergeCodexSandboxConfig(mcpBin, mcpEnv)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		return nil, nil, fmt.Errorf("writing codex sandbox config: %w", err)
@@ -165,16 +168,33 @@ func (c Codex) configureSandboxMCP(mcpBin string, mcpEnv map[string]string) ([]s
 }
 
 // mergeCodexSandboxConfig is the ModeSandbox variant of the merge.
-// In addition to the [mcp_servers.aileron] block, it prepends
-// `cli_auth_credentials_store = "file"` as a top-level key so the
-// in-container Codex CLI reads auth.json instead of trying to use
-// the macOS Keychain / Linux secret-tool keyring (which do not
-// exist inside the sandbox). The host config is never touched
-// under ModeSandbox.
+// In addition to the [mcp_servers.aileron] block, it prepends two
+// top-level keys:
+//
+//   - `sandbox_mode = "danger-full-access"` disables Codex's own
+//     OS sandbox (bubblewrap/Landlock on the Linux container) for
+//     local exec. The Alpine sandbox-base image ships no bwrap binary,
+//     so
+//     leaving Codex's sandbox enabled prints a "could not find
+//     bubblewrap on PATH" warning on every launch and falls back to a
+//     bundled copy. The outer Aileron Docker container is the real
+//     isolation boundary — Codex's sandbox/approval machinery governs
+//     only its local exec while Aileron mediates MCP/gateway actions —
+//     so the nested in-container sandbox is redundant. This key
+//     silences the warning at the source. It is sandbox-mode only;
+//     configureHostMCP is untouched, so host launches keep Codex's
+//     normal sandboxing.
+//   - `cli_auth_credentials_store = "file"` so the in-container Codex
+//     CLI reads auth.json instead of trying to use the macOS Keychain
+//     / Linux secret-tool keyring (which do not exist inside the
+//     sandbox).
+//
+// The host config is never touched under ModeSandbox.
 func mergeCodexSandboxConfig(mcpBin string, mcpEnv map[string]string) string {
-	// Start with the top-level key, then append the [mcp_servers.*]
+	// Start with the top-level keys, then append the [mcp_servers.*]
 	// block via the existing merge over an empty baseline.
-	return `cli_auth_credentials_store = "file"` + "\n" +
+	return `sandbox_mode = "danger-full-access"` + "\n" +
+		`cli_auth_credentials_store = "file"` + "\n" +
 		mergeCodexMCPBlock("", mcpBin, mcpEnv)
 }
 

--- a/internal/launch/agents/codex_auth_test.go
+++ b/internal/launch/agents/codex_auth_test.go
@@ -10,6 +10,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"os"
+	"path/filepath"
 	"strings"
 	"testing"
 	"time"
@@ -373,6 +374,60 @@ func TestCodex_SandboxConfig_EmitsCliAuthCredentialsStoreFile(t *testing.T) {
 	}
 	if !strings.Contains(string(body), "[mcp_servers.aileron]") {
 		t.Errorf("config.toml missing [mcp_servers.aileron] block:\n%s", body)
+	}
+}
+
+func TestCodex_SandboxConfig_EmitsSandboxModeDangerFullAccess(t *testing.T) {
+	// #1163: sandbox-mode config.toml must include
+	// `sandbox_mode = "danger-full-access"` as a top-level key so the
+	// in-container Codex disables its own OS sandbox (bubblewrap). The
+	// Alpine sandbox-base image ships no bwrap, so leaving Codex's
+	// sandbox on prints a "could not find bubblewrap on PATH" warning
+	// on every launch. The outer Aileron Docker container is the real
+	// isolation boundary, so the nested Codex sandbox is redundant.
+	_, mounts, err := agents.Codex{}.ConfigureMCP("/usr/local/bin/aileron-mcp",
+		map[string]string{"AILERON_URL": "http://x"}, "", launch.ModeSandbox)
+	if err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("mounts = %d, want 1", len(mounts))
+	}
+	body, err := readFile(mounts[0].Source)
+	if err != nil {
+		t.Fatalf("read mount: %v", err)
+	}
+	if !strings.Contains(string(body), `sandbox_mode = "danger-full-access"`) {
+		t.Errorf("config.toml missing sandbox_mode top-level key:\n%s", body)
+	}
+}
+
+func TestCodex_HostConfig_OmitsSandboxMode(t *testing.T) {
+	// #1163 guard: the sandbox-mode fix must NOT leak into host-mode
+	// config. Host launches keep Codex's normal OS sandbox, so
+	// configureHostMCP must never write `sandbox_mode` into the user's
+	// ~/.codex/config.toml. ModeHost merges into a home-directory file,
+	// so isolate HOME to a tempdir for the duration of the test.
+	tmpHome := t.TempDir()
+	t.Setenv("HOME", tmpHome)
+
+	args, mounts, err := agents.Codex{}.ConfigureMCP("/usr/local/bin/aileron-mcp",
+		map[string]string{"AILERON_URL": "http://x"}, "", launch.ModeHost)
+	if err != nil {
+		t.Fatalf("ConfigureMCP: %v", err)
+	}
+	if args != nil {
+		t.Errorf("ModeHost args = %v, want nil", args)
+	}
+	if mounts != nil {
+		t.Errorf("ModeHost mounts = %v, want nil", mounts)
+	}
+	body, err := readFile(filepath.Join(tmpHome, ".codex", "config.toml"))
+	if err != nil {
+		t.Fatalf("read host config.toml: %v", err)
+	}
+	if strings.Contains(string(body), "sandbox_mode") {
+		t.Errorf("host config.toml must not contain sandbox_mode:\n%s", body)
 	}
 }
 

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -612,7 +612,7 @@ func nestedMountTarget(mounts []sandboxcontainer.Volume) string {
 func TestCollapseNestedMCPMounts_CollapsesFileIntoParentDir(t *testing.T) {
 	dirSource := t.TempDir() // host-side source for /home/agent/.codex/
 	cfgSource := filepath.Join(t.TempDir(), "config.toml")
-	cfgBody := []byte("cli_auth_credentials_store = \"file\"\n\n[mcp_servers.aileron]\ncommand = \"/usr/local/bin/aileron-mcp\"\n")
+	cfgBody := []byte("sandbox_mode = \"danger-full-access\"\ncli_auth_credentials_store = \"file\"\n\n[mcp_servers.aileron]\ncommand = \"/usr/local/bin/aileron-mcp\"\n")
 	if err := os.WriteFile(cfgSource, cfgBody, 0o600); err != nil {
 		t.Fatalf("seed config.toml: %v", err)
 	}


### PR DESCRIPTION
## Summary

`aileron launch --sandbox=docker codex` printed a `Codex could not find bubblewrap on PATH` warning on every launch. Codex runs its own OS sandbox (bubblewrap/Landlock on Linux) for local exec, but the Alpine `sandbox-base` image (`images/sandbox-base/Containerfile`) ships no `bwrap` binary, so Codex warned and fell back to a bundled copy on each run.

The outer Aileron Docker container is the real isolation boundary, so the nested in-container Codex sandbox is redundant (matches the existing `codex.go` doc comment: Codex's sandbox/approval machinery governs only its local exec while Aileron mediates MCP/gateway actions). The fix adds a top-level `sandbox_mode = "danger-full-access"` key to the sandbox-mode `config.toml` emitted by `mergeCodexSandboxConfig` in `internal/launch/agents/codex.go`, which disables Codex's internal OS sandbox and silences the warning at the source.

This is sandbox-mode only. The host config path (`configureHostMCP`) is untouched, so host launches keep Codex's normal sandboxing.

### Why not install bubblewrap in the image
`bwrap` needs unprivileged user-namespace / setuid support that isn't reliably available inside the unprivileged Docker container, so it could still fail at runtime, and even when it worked it would leave a pointless nested sandbox-in-sandbox. Configuring Codex off the redundant layer is cleaner and matches the established pattern of steering in-container Codex behavior through the sandbox `config.toml`.

## Test plan

- `go test ./internal/launch/...` — all green.
- New regression test `TestCodex_SandboxConfig_EmitsSandboxModeDangerFullAccess` asserts the sandbox `config.toml` carries `sandbox_mode = "danger-full-access"`.
- New guard test `TestCodex_HostConfig_OmitsSandboxMode` asserts host-mode `config.toml` does NOT contain `sandbox_mode` (the fix must not leak into host launches).
- Updated the `TestCollapseNestedMCPMounts_CollapsesFileIntoParentDir` fixture in `launcher_internal_test.go` to include the new key in its hard-coded expected sandbox config body.

Closes #1163

🤖 Generated with [Claude Code](https://claude.com/claude-code)