### PR TITLE
feat(launch): capture gh OAuth device-flow token into user/github

### DIFF
--- a/cmd/aileron/auth.go
+++ b/cmd/aileron/auth.go
@@ -14,9 +14,14 @@ import (
 
 const authUsage = `usage:
   aileron auth <agent> --import-from-host
+  aileron auth github [--runtime <auto|docker>] [--image <ref>]
 
 Seed the vault from an already-authenticated host install.
-<agent> must be claude or codex.`
+<agent> must be claude or codex.
+
+aileron auth github runs gh's OAuth device-authorization flow inside a
+container that ships gh, then stores the captured bearer token at the
+user/github vault path.`
 
 // runAuth dispatches `aileron auth <agent> ...`. The only verb in v1 is
 // `--import-from-host`, which reads an already-authenticated host
@@ -30,6 +35,14 @@ func runAuth(args []string, registry *launch.Registry, stdout, stderr io.Writer)
 	if len(args) == 0 {
 		fmt.Fprintln(stderr, authUsage)
 		return 1
+	}
+
+	// `github` is a standalone user-level acquisition verb, not an
+	// <agent>. Intercept it before the host-import path so it is not
+	// parsed as the <agent> positional. It drives gh's OAuth device flow
+	// inside a container and stores the result at user/github.
+	if args[0] == "github" {
+		return runAuthGitHub(args[1:], stdout, stderr)
 	}
 
 	// Require <agent> as the first positional so the flag parser does

--- a/cmd/aileron/auth_github.go
+++ b/cmd/aileron/auth_github.go
@@ -133,6 +133,14 @@ type containerDeviceFlow struct {
 // container, then tears the container down. The teardown is deferred so
 // a mid-flow failure still removes the container.
 func (c *containerDeviceFlow) Capture(ctx context.Context) ([]byte, error) {
+	// Clear any container left behind by a prior run that died before its
+	// teardown (e.g. SIGKILL): the name is deterministic, so a stale
+	// container would make `run --name` fail with "name already in use".
+	// rm -f on a nonexistent name is a harmless no-op, so the error is
+	// ignored.
+	_ = c.runner.Run(ctx, c.runtimeExe,
+		[]string{"rm", "-f", c.containerName}, io.Discard, io.Discard)
+
 	// Start one long-lived container we exec into twice. --rm is not used
 	// because we explicitly `rm -f` in the deferred teardown; sleep keeps
 	// it alive between the login and token execs.

--- a/cmd/aileron/auth_github.go
+++ b/cmd/aileron/auth_github.go
@@ -1,0 +1,189 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/version"
+)
+
+// deviceFlowRunner performs gh's OAuth device-authorization flow and
+// returns the captured user-to-server bearer token bytes. It is a seam
+// so tests can substitute a fake without driving a real container or
+// reaching GitHub. The production implementation is containerDeviceFlow.
+type deviceFlowRunner interface {
+	// Capture drives the device flow and returns the raw bearer token
+	// (trailing newline trimmed). It is interactive: the operator reads
+	// the user code + verification URL gh prints, authorizes in a
+	// browser, and gh completes the grant.
+	Capture(ctx context.Context) ([]byte, error)
+}
+
+// newDeviceFlowRunner builds the production runner. It is a package var
+// so runAuthGitHub's tests substitute a fake flow without a container.
+var newDeviceFlowRunner = func(runtime, image string) (deviceFlowRunner, error) {
+	runtimeExe, err := sandboxcontainer.ResolveRuntime(runtime)
+	if err != nil {
+		return nil, err
+	}
+	image = resolveDeviceFlowImage(image)
+	return &containerDeviceFlow{
+		runner:        sandboxcontainer.DefaultRunner(),
+		runtimeExe:    runtimeExe,
+		image:         image,
+		containerName: "aileron-auth-github",
+	}, nil
+}
+
+// resolveDeviceFlowImage returns the container image for the device
+// flow: the caller's --image override when set, otherwise the sandbox
+// base image. The base image ships gh (#1146) and is agent-independent,
+// which matches the user-level (not per-agent) nature of this
+// credential. edge for dev builds, latest for releases (#1141).
+func resolveDeviceFlowImage(override string) string {
+	if override != "" {
+		return override
+	}
+	return sandboxcomposition.BaseImage(version.Version)
+}
+
+// runAuthGitHub implements `aileron auth github`. It drives gh's OAuth
+// device flow inside a container that ships gh, captures the resulting
+// non-expiring bearer token, and PUTs it to the user/github vault path
+// through the daemon. OAuth is acquisition UX only: a single bearer
+// token is stored, no refresh machinery, HTTPS only.
+func runAuthGitHub(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("auth github", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	runtime := flags.String("runtime", sandboxcontainer.DefaultRuntime,
+		"Container runtime: auto or docker")
+	image := flags.String("image", "",
+		"Override the container image (defaults to the gh-bearing sandbox base image)")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: aileron auth github [--runtime <auto|docker>] [--image <ref>]")
+		return 1
+	}
+
+	runner, err := newDeviceFlowRunner(*runtime, *image)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	token, err := runner.Capture(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "error: GitHub device-flow login failed: %v\n", err)
+		return 1
+	}
+	if len(bytes.TrimSpace(token)) == 0 {
+		fmt.Fprintln(stderr, "error: gh returned an empty token; login did not complete")
+		return 1
+	}
+
+	// Marshaling a struct with a single []byte field cannot fail; the
+	// error is discarded here matching runAuthImport's precedent.
+	body, _ := json.Marshal(agentCredentialsBody{Value: token})
+	status, respBody, err := vaultDoRequest(http.MethodPut,
+		"/vault/user/github/credentials", body)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	switch status {
+	case http.StatusNoContent:
+		fmt.Fprintln(stdout, "Stored user/github")
+		return 0
+	case http.StatusLocked:
+		fmt.Fprintln(stderr, "error: vault is locked; unlock it first")
+		return 1
+	case http.StatusServiceUnavailable:
+		fmt.Fprintln(stderr, "error: daemon is not configured with a vault")
+		return 1
+	default:
+		fmt.Fprintf(stderr, "server returned %d: %s\n", status, string(respBody))
+		return 1
+	}
+}
+
+// containerDeviceFlow drives gh's device flow inside one persistent
+// container so the token gh auth login writes to ~/.config/gh/hosts.yml
+// survives to the gh auth token read. It runs the SAME named container
+// for both gh calls: an ephemeral second `docker run` would not see the
+// hosts.yml the login wrote, so the shared container is load-bearing.
+type containerDeviceFlow struct {
+	runner        sandboxcontainer.Runner
+	runtimeExe    string // the resolved runtime executable, e.g. "docker"
+	image         string
+	containerName string
+}
+
+// Capture starts the container, runs the interactive gh auth login
+// (device flow), reads the token with gh auth token from that same
+// container, then tears the container down. The teardown is deferred so
+// a mid-flow failure still removes the container.
+func (c *containerDeviceFlow) Capture(ctx context.Context) ([]byte, error) {
+	// Start one long-lived container we exec into twice. --rm is not used
+	// because we explicitly `rm -f` in the deferred teardown; sleep keeps
+	// it alive between the login and token execs.
+	var startErr bytes.Buffer
+	runArgs := []string{
+		"run", "-d", "--name", c.containerName,
+		c.image, "sleep", "3600",
+	}
+	if err := c.runner.Run(ctx, c.runtimeExe, runArgs, io.Discard, &startErr); err != nil {
+		return nil, fmt.Errorf("starting container: %w%s", err, stderrSuffix(&startErr))
+	}
+	// Tear the container down regardless of how Capture exits.
+	defer func() {
+		_ = c.runner.Run(context.Background(), c.runtimeExe,
+			[]string{"rm", "-f", c.containerName}, io.Discard, io.Discard)
+	}()
+
+	// Interactive device-flow login. gh prints the user code + the
+	// verification URL to the operator's terminal; its stdin/stdout are
+	// wired to the host terminal by the Runner so the operator can read
+	// the prompt. HTTPS only — never configure SSH (-p https). Output is
+	// surfaced so the operator sees gh's instructions.
+	loginArgs := []string{
+		"exec", "-i", c.containerName,
+		"gh", "auth", "login",
+		"--hostname", "github.com",
+		"--git-protocol", "https",
+		"--web",
+	}
+	if err := c.runner.Run(ctx, c.runtimeExe, loginArgs, os.Stdout, os.Stderr); err != nil {
+		return nil, fmt.Errorf("gh auth login: %w", err)
+	}
+
+	// Read the token gh auth login wrote to hosts.yml in THIS container.
+	var tokenOut, tokenErr bytes.Buffer
+	tokenArgs := []string{
+		"exec", c.containerName,
+		"gh", "auth", "token", "--hostname", "github.com",
+	}
+	if err := c.runner.Run(ctx, c.runtimeExe, tokenArgs, &tokenOut, &tokenErr); err != nil {
+		return nil, fmt.Errorf("gh auth token: %w%s", err, stderrSuffix(&tokenErr))
+	}
+	return bytes.TrimRight(tokenOut.Bytes(), "\r\n"), nil
+}
+
+// stderrSuffix renders captured stderr as a trailing context fragment
+// for an error message, or "" when there is none.
+func stderrSuffix(b *bytes.Buffer) string {
+	s := bytes.TrimSpace(b.Bytes())
+	if len(s) == 0 {
+		return ""
+	}
+	return ": " + string(s)
+}

--- a/cmd/aileron/auth_github_test.go
+++ b/cmd/aileron/auth_github_test.go
@@ -1,0 +1,459 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+)
+
+// These tests pin the contract of `aileron auth github`:
+//
+//   - The captured bearer token is PUT base64-encoded to
+//     /v1/vault/user/github/credentials (the #1147 user namespace).
+//   - A capture failure, an empty token, and a non-204 daemon status
+//     each surface a clean message with exit 1 and (for capture/empty)
+//     no PUT.
+//   - The production containerDeviceFlow runs ONE shared container for
+//     both gh calls (req 1): the token read sees the hosts.yml the login
+//     wrote because it is the same container, not a second docker run.
+
+// stubDeviceFlow is an injectable deviceFlowRunner for the store-path
+// tests. It never touches a container or GitHub.
+type stubDeviceFlow struct {
+	token []byte
+	err   error
+}
+
+func (s stubDeviceFlow) Capture(context.Context) ([]byte, error) {
+	return s.token, s.err
+}
+
+// withStubDeviceFlow swaps newDeviceFlowRunner for one that returns the
+// given stub, restoring the original on cleanup.
+func withStubDeviceFlow(t *testing.T, stub deviceFlowRunner, capErr error) {
+	t.Helper()
+	orig := newDeviceFlowRunner
+	newDeviceFlowRunner = func(runtime, image string) (deviceFlowRunner, error) {
+		return stub, capErr
+	}
+	t.Cleanup(func() { newDeviceFlowRunner = orig })
+}
+
+func TestRunAuthGitHub_HappyPathStoresTokenAtUserGitHub(t *testing.T) {
+	token := []byte("gho_exampletoken1234567890")
+	var gotMethod, gotPath string
+	var gotValue []byte
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		gotMethod = r.Method
+		gotPath = r.URL.Path
+		var body agentCredentialsBody
+		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
+			t.Fatalf("decode body: %v", err)
+		}
+		gotValue = body.Value
+		w.WriteHeader(http.StatusNoContent)
+	})
+	withStubDeviceFlow(t, stubDeviceFlow{token: token}, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuthGitHub(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if gotMethod != http.MethodPut || gotPath != "/vault/user/github/credentials" {
+		t.Errorf("request = %s %s, want PUT /vault/user/github/credentials", gotMethod, gotPath)
+	}
+	if !bytes.Equal(gotValue, token) {
+		t.Errorf("stored value = %q, want %q", gotValue, token)
+	}
+	if !strings.Contains(stdout.String(), "Stored user/github") {
+		t.Errorf("stdout = %q, want success message", stdout.String())
+	}
+}
+
+func TestRunAuthGitHub_CaptureFailureNoPUT(t *testing.T) {
+	called := false
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	withStubDeviceFlow(t, stubDeviceFlow{err: errors.New("device flow timed out")}, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuthGitHub(nil, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if called {
+		t.Error("daemon PUT was issued despite a capture failure")
+	}
+	if !strings.Contains(stderr.String(), "device-flow login failed") {
+		t.Errorf("stderr = %q, want capture failure message", stderr.String())
+	}
+}
+
+func TestRunAuthGitHub_EmptyTokenGuardNoPUT(t *testing.T) {
+	called := false
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		called = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	// Whitespace-only is treated as empty after trimming.
+	withStubDeviceFlow(t, stubDeviceFlow{token: []byte("  \n")}, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuthGitHub(nil, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if called {
+		t.Error("daemon PUT was issued despite an empty token")
+	}
+	if !strings.Contains(stderr.String(), "empty token") {
+		t.Errorf("stderr = %q, want empty-token message", stderr.String())
+	}
+}
+
+func TestRunAuthGitHub_StoreFailureSurfacesCleanly(t *testing.T) {
+	cases := []struct {
+		name   string
+		status int
+		want   string
+	}{
+		{"locked", http.StatusLocked, "vault is locked"},
+		{"noVault", http.StatusServiceUnavailable, "not configured with a vault"},
+		{"unexpected", http.StatusInternalServerError, "server returned 500"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+				w.WriteHeader(tc.status)
+			})
+			withStubDeviceFlow(t, stubDeviceFlow{token: []byte("gho_tok")}, nil)
+
+			var stdout, stderr bytes.Buffer
+			code := runAuthGitHub(nil, &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("exit = %d, want 1; stderr=%s", code, stderr.String())
+			}
+			if !strings.Contains(stderr.String(), tc.want) {
+				t.Errorf("stderr = %q, want substring %q", stderr.String(), tc.want)
+			}
+		})
+	}
+}
+
+func TestRunAuthGitHub_RunnerConstructionErrorSurfaces(t *testing.T) {
+	orig := newDeviceFlowRunner
+	newDeviceFlowRunner = func(runtime, image string) (deviceFlowRunner, error) {
+		return nil, errors.New("no container runtime found on PATH")
+	}
+	t.Cleanup(func() { newDeviceFlowRunner = orig })
+
+	var stdout, stderr bytes.Buffer
+	code := runAuthGitHub(nil, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "no container runtime") {
+		t.Errorf("stderr = %q, want runtime-resolution error", stderr.String())
+	}
+}
+
+func TestRunAuthGitHub_RejectsExtraPositionalArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runAuthGitHub([]string{"unexpected"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("stderr = %q, want usage", stderr.String())
+	}
+}
+
+func TestNewDeviceFlowRunner_RejectsUnsupportedRuntime(t *testing.T) {
+	// An unsupported runtime fails fast in ResolveRuntime before any
+	// container work, exercising the production constructor's error path.
+	if _, err := newDeviceFlowRunner("podman", ""); err == nil {
+		t.Fatal("expected an error for an unsupported runtime")
+	}
+}
+
+func TestResolveDeviceFlowImage(t *testing.T) {
+	const override = "ghcr.io/example/custom:tag"
+	if got := resolveDeviceFlowImage(override); got != override {
+		t.Errorf("override image = %q, want %q", got, override)
+	}
+	// With no override it falls back to the gh-bearing sandbox base image.
+	def := resolveDeviceFlowImage("")
+	if !strings.HasPrefix(def, "ghcr.io/alrubinger/aileron-sandbox-base:") {
+		t.Errorf("default image = %q, want sandbox-base reference", def)
+	}
+}
+
+// --- req 1: shared-container regression guard ---
+
+// recordingRunner is a fake sandboxcontainer.Runner that records every
+// invocation and models the load-bearing shared-container behavior:
+// `gh auth token` only yields a token when a prior `gh auth login` exec
+// ran against the SAME container name. An ephemeral-container
+// implementation (a second `docker run` before the token read) cannot
+// satisfy this — there would be no logged-in container to read from.
+type recordingRunner struct {
+	calls         [][]string
+	loggedInNames map[string]bool
+	runContainer  string // the container name created by `run -d`
+	token         string
+}
+
+func (r *recordingRunner) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
+	r.calls = append(r.calls, args)
+	if r.loggedInNames == nil {
+		r.loggedInNames = map[string]bool{}
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	switch args[0] {
+	case "run":
+		// docker run -d --name <name> <image> sleep <n>
+		r.runContainer = containerNameFromRunArgs(args)
+		return nil
+	case "exec":
+		cname, gh := parseExecArgs(args)
+		if !gh.isGH {
+			return nil
+		}
+		switch {
+		case gh.sub == "login":
+			if cname != r.runContainer {
+				return errors.New("login targeted a container that was never created")
+			}
+			r.loggedInNames[cname] = true
+			return nil
+		case gh.sub == "token":
+			// The token read must hit the SAME container the login ran in.
+			if !r.loggedInNames[cname] {
+				return errors.New("gh auth token: not logged in to this container")
+			}
+			_, _ = io.WriteString(stdout, r.token+"\n")
+			return nil
+		}
+	case "rm":
+		return nil
+	}
+	return nil
+}
+
+type ghCall struct {
+	isGH bool
+	sub  string
+}
+
+// parseExecArgs extracts the container name and the gh subcommand from a
+// `docker exec [-i] <name> gh <sub> ...` arg slice.
+func parseExecArgs(args []string) (container string, gh ghCall) {
+	i := 1 // skip "exec"
+	for i < len(args) && strings.HasPrefix(args[i], "-") {
+		i++ // skip exec flags like -i
+	}
+	if i >= len(args) {
+		return "", ghCall{}
+	}
+	container = args[i]
+	i++
+	// gh invocations are `gh auth <sub> ...`; the meaningful subcommand
+	// is the token after "auth".
+	if i < len(args) && args[i] == "gh" {
+		gh.isGH = true
+		if i+1 < len(args) && args[i+1] == "auth" && i+2 < len(args) {
+			gh.sub = args[i+2]
+		}
+	}
+	return container, gh
+}
+
+// containerNameFromRunArgs returns the value following --name in a run
+// arg slice.
+func containerNameFromRunArgs(args []string) string {
+	for i, a := range args {
+		if a == "--name" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+func TestContainerDeviceFlow_UsesOneSharedContainerForBothGHCalls(t *testing.T) {
+	rr := &recordingRunner{token: "gho_sharedcontainertoken"}
+	flow := &containerDeviceFlow{
+		runner:        rr,
+		runtimeExe:    "docker",
+		image:         "ghcr.io/alrubinger/aileron-sandbox-base:edge",
+		containerName: "aileron-auth-github",
+	}
+
+	token, err := flow.Capture(context.Background())
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if string(token) != "gho_sharedcontainertoken" {
+		t.Errorf("token = %q, want the captured value (trimmed)", token)
+	}
+
+	// Exactly one `docker run` — no ephemeral second run for the token read.
+	runs := 0
+	for _, c := range rr.calls {
+		if len(c) > 0 && c[0] == "run" {
+			runs++
+		}
+	}
+	if runs != 1 {
+		t.Fatalf("docker run count = %d, want exactly 1 (shared container)", runs)
+	}
+
+	// The login and token execs both target the one created container.
+	if rr.runContainer != "aileron-auth-github" {
+		t.Fatalf("created container = %q, want aileron-auth-github", rr.runContainer)
+	}
+	var loginContainer, tokenContainer string
+	for _, c := range rr.calls {
+		if len(c) == 0 || c[0] != "exec" {
+			continue
+		}
+		cname, gh := parseExecArgs(c)
+		switch gh.sub {
+		case "login":
+			loginContainer = cname
+		case "token":
+			tokenContainer = cname
+		}
+	}
+	if loginContainer != rr.runContainer {
+		t.Errorf("login container = %q, want %q", loginContainer, rr.runContainer)
+	}
+	if tokenContainer != rr.runContainer {
+		t.Errorf("token container = %q, want %q (same as login)", tokenContainer, rr.runContainer)
+	}
+
+	// The container is torn down.
+	teardown := false
+	for _, c := range rr.calls {
+		if len(c) >= 3 && c[0] == "rm" && c[1] == "-f" && c[2] == "aileron-auth-github" {
+			teardown = true
+		}
+	}
+	if !teardown {
+		t.Error("container was not torn down with rm -f")
+	}
+}
+
+func TestContainerDeviceFlow_TearsDownOnLoginFailure(t *testing.T) {
+	// A runner that fails the login exec but records all calls, so we can
+	// assert the deferred teardown still ran.
+	rr := &failingLoginRunner{}
+	flow := &containerDeviceFlow{
+		runner:        rr,
+		runtimeExe:    "docker",
+		image:         "img",
+		containerName: "aileron-auth-github",
+	}
+	_, err := flow.Capture(context.Background())
+	if err == nil {
+		t.Fatal("expected an error from the failing login")
+	}
+	if !rr.removed {
+		t.Error("container was not removed after a mid-flow failure")
+	}
+}
+
+type failingLoginRunner struct {
+	removed bool
+}
+
+func (r *failingLoginRunner) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		return nil
+	}
+	switch args[0] {
+	case "run":
+		return nil
+	case "exec":
+		_, gh := parseExecArgs(args)
+		if gh.sub == "login" {
+			return errors.New("login failed")
+		}
+		return nil
+	case "rm":
+		r.removed = true
+		return nil
+	}
+	return nil
+}
+
+// scriptedRunner fails a chosen step and writes a stderr fragment, so we
+// can assert Capture surfaces the runtime's stderr (via stderrSuffix).
+type scriptedRunner struct {
+	failStep  string // "run" or "token"
+	stderrMsg string
+	removed   bool
+}
+
+func (r *scriptedRunner) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
+	if len(args) == 0 {
+		return nil
+	}
+	switch args[0] {
+	case "run":
+		if r.failStep == "run" {
+			_, _ = io.WriteString(stderr, r.stderrMsg)
+			return errors.New("exit status 125")
+		}
+		return nil
+	case "exec":
+		_, gh := parseExecArgs(args)
+		if gh.sub == "token" && r.failStep == "token" {
+			_, _ = io.WriteString(stderr, r.stderrMsg)
+			return errors.New("exit status 1")
+		}
+		return nil
+	case "rm":
+		r.removed = true
+		return nil
+	}
+	return nil
+}
+
+func TestContainerDeviceFlow_StartFailureSurfacesStderr(t *testing.T) {
+	rr := &scriptedRunner{failStep: "run", stderrMsg: "image not found"}
+	flow := &containerDeviceFlow{runner: rr, runtimeExe: "docker", image: "img", containerName: "aileron-auth-github"}
+	_, err := flow.Capture(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when the container fails to start")
+	}
+	if !strings.Contains(err.Error(), "starting container") || !strings.Contains(err.Error(), "image not found") {
+		t.Errorf("err = %v, want start-failure context with runtime stderr", err)
+	}
+	// No container was created, so no teardown is expected; the defer
+	// still runs but the assertion here is only that we surfaced cleanly.
+}
+
+func TestContainerDeviceFlow_TokenReadFailureSurfacesStderrAndTearsDown(t *testing.T) {
+	rr := &scriptedRunner{failStep: "token", stderrMsg: "no oauth token"}
+	flow := &containerDeviceFlow{runner: rr, runtimeExe: "docker", image: "img", containerName: "aileron-auth-github"}
+	_, err := flow.Capture(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when gh auth token fails")
+	}
+	if !strings.Contains(err.Error(), "gh auth token") || !strings.Contains(err.Error(), "no oauth token") {
+		t.Errorf("err = %v, want token-failure context with runtime stderr", err)
+	}
+	if !rr.removed {
+		t.Error("container was not torn down after a token-read failure")
+	}
+}

--- a/cmd/aileron/auth_github_test.go
+++ b/cmd/aileron/auth_github_test.go
@@ -165,6 +165,33 @@ func TestRunAuthGitHub_RunnerConstructionErrorSurfaces(t *testing.T) {
 	}
 }
 
+func TestRunAuthGitHub_RejectsUnknownFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	code := runAuthGitHub([]string{"--nope"}, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1", code)
+	}
+}
+
+func TestRunAuthGitHub_TransportErrorSurfaces(t *testing.T) {
+	// Capture succeeds, but the daemon is unreachable: vaultDoRequest's
+	// transport error must surface cleanly with exit 1 and no panic.
+	withStubDeviceFlow(t, stubDeviceFlow{token: []byte("gho_tok")}, nil)
+	// Point at a closed port so the HTTP client errors at the transport
+	// layer rather than returning a status.
+	t.Setenv("AILERON_API_URL", "http://127.0.0.1:0/v1")
+	t.Setenv("AILERON_TOKEN", "test-token")
+
+	var stdout, stderr bytes.Buffer
+	code := runAuthGitHub(nil, &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "error:") {
+		t.Errorf("stderr = %q, want a transport error", stderr.String())
+	}
+}
+
 func TestRunAuthGitHub_RejectsExtraPositionalArgs(t *testing.T) {
 	var stdout, stderr bytes.Buffer
 	code := runAuthGitHub([]string{"unexpected"}, &stdout, &stderr)
@@ -181,6 +208,18 @@ func TestNewDeviceFlowRunner_RejectsUnsupportedRuntime(t *testing.T) {
 	// container work, exercising the production constructor's error path.
 	if _, err := newDeviceFlowRunner("podman", ""); err == nil {
 		t.Fatal("expected an error for an unsupported runtime")
+	}
+}
+
+func TestStderrSuffix(t *testing.T) {
+	if got := stderrSuffix(bytes.NewBufferString("")); got != "" {
+		t.Errorf("empty stderr suffix = %q, want empty", got)
+	}
+	if got := stderrSuffix(bytes.NewBufferString("   \n")); got != "" {
+		t.Errorf("whitespace stderr suffix = %q, want empty", got)
+	}
+	if got := stderrSuffix(bytes.NewBufferString("boom\n")); got != ": boom" {
+		t.Errorf("stderr suffix = %q, want %q", got, ": boom")
 	}
 }
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -110,6 +110,15 @@ Approval-gated actions return an approval-pending message instead of running imm
 
 The `put`, `delete`, and `list` verbs talk to the running daemon and operate only on the `agents/<name>/oauth` namespace. They never open the vault file directly and reject any other path. See [Sandbox Agent Auth](/development/sandbox-agent-auth/) for the seeding and recovery flows.
 
+## Auth
+
+| Command | Purpose | Ratified by |
+|---|---|---|
+| `aileron auth <agent> --import-from-host` | Seed the vault from an already-authenticated host install of claude or codex. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
+| `aileron auth github [--runtime <auto\|docker>] [--image <ref>]` | Run gh's OAuth device-authorization flow inside a gh-bearing container and store the captured bearer token at `user/github`. HTTPS only; no refresh machinery. | — |
+
+`aileron auth github` is a one-time acquisition flow: it drives `gh auth login` and `gh auth token` in the same container, then PUTs the token to the user-level `user/github` vault namespace through the daemon.
+
 ## Utility
 
 | Command | Purpose | Ratified by |


### PR DESCRIPTION
## Summary

Adds a one-time `aileron auth github` verb that runs gh's OAuth device-authorization flow inside a container that ships `gh` (#1146), captures the resulting non-expiring user-to-server bearer token, and PUTs it to the `user/github` vault namespace through the #1147 daemon endpoint.

- **Dispatch:** `github` is intercepted at the top of `runAuth` (before the `<agent> --import-from-host` path) so it is not parsed as the `<agent>` positional; routed to the new `runAuthGitHub`. The claude/codex host-import path is untouched.
- **Device-flow runner seam:** `deviceFlowRunner` is an injectable interface. The production `containerDeviceFlow` drives `sandboxcontainer.Runner` to run **one persistent container** for both gh calls: `run -d --name <name> <image> sleep …` → `exec … gh auth login` (device flow, prints the user code + verification URL to the operator) → `exec … gh auth token` (reads the token gh wrote to `~/.config/gh/hosts.yml` in that *same* container) → `rm -f` (deferred so a mid-flow failure still tears the container down).
- **Store path:** the captured token (trailing newline trimmed) is marshaled as `agentCredentialsBody{Value: token}` and PUT to `/v1/vault/user/github/credentials` via `vaultDoRequest`. Status codes map to clear CLI output (204 success, 423 locked, 503 no vault, default `server returned %d`).
- **Image:** defaults to the gh-bearing sandbox base image (`edge` for dev, `latest` for releases), overridable with `--image`; runtime selectable with `--runtime`.

OAuth is acquisition UX only: a single bearer token is stored, no refresh machinery, HTTPS only, no metadata stamping (the merged #1147 `agentCredentialsBody` is `Value`-only). gh owns the OAuth App registration and grant; this never reimplements the device grant or calls GitHub directly.

### Scope

Consumer-side only. No OpenAPI/`internal/api` change (endpoint delivered by #1147). No daemon-side handler work. No `--status`/`--logout`, no refresh/expiry, no host-import, no SSH.

## Test plan

`cmd/aileron/auth_github_test.go` (new), reusing `fakeVaultServer`:

- **Happy path:** stubbed runner returns a fixed token; `fakeVaultServer` asserts `PUT /vault/user/github/credentials` and that the decoded `value` equals the token bytes; exit 0 + "Stored user/github". Never hits real GitHub.
- **Capture failure:** stubbed runner errors → exit 1, clean message, no PUT.
- **Store failure:** 423 / 503 / 500 each surface cleanly with exit 1.
- **Empty-token guard:** whitespace-only token → exit 1, no PUT.
- **Runner-construction error** and **extra-positional-args** guards.
- **(req 1) Shared-container regression guard:** a fake `sandboxcontainer.Runner` records every invocation; asserts exactly one `docker run` (no ephemeral second run for the token read) and that both `gh auth login` and `gh auth token` target the same created container. The fake's `gh auth token` only returns a token when a prior `gh auth login` ran against that same container name, so an ephemeral-container implementation fails this test.
- **Teardown on mid-flow failure**, **start-failure stderr surfacing**, **token-read-failure stderr surfacing**, **image-default resolution**.

`go build ./cmd/aileron`, `task vet:go`, and `task test:go` all pass. New-code coverage: `Capture` 100%, `runAuthGitHub` 91%, `resolveDeviceFlowImage` 100%.

Closes #1148

🤖 Generated with [Claude Code](https://claude.com/claude-code)
