### PR TITLE
feat(launch): inject GH_TOKEN per launch + wire git credential helper

### DIFF
--- a/internal/launch/daemon_client.go
+++ b/internal/launch/daemon_client.go
@@ -213,6 +213,75 @@ func (c *daemonClient) GetAgentCredentials(ctx context.Context, name string) (va
 	}
 }
 
+// ErrUserCredentialsNotFound is the typed Go error the daemon client
+// surfaces when a GET against the user-level credential endpoint
+// returns `{error: {code: "vault_not_found"}}`. The GitHub injector
+// discriminates this from a locked vault so a genuinely empty
+// `user/<service>` entry yields a clean, unauthenticated launch
+// rather than aborting. Mirrors [ErrAgentCredentialsNotFound] for the
+// agent-independent user namespace (#1149).
+var ErrUserCredentialsNotFound = errors.New("daemon: user credentials not found")
+
+// GetUserCredentials fetches the user-level credential envelope at
+// `user/<service>` through the daemon's HTTP surface. This namespace
+// is agent-independent: the credential belongs to the user, not a
+// single agent (e.g. `user/github`). The daemon's `vault_not_found`
+// error code surfaces as [ErrUserCredentialsNotFound]; a locked vault
+// surfaces as [vault.ErrCredentialUnavailable]. Callers wrap typed
+// checks with `errors.Is`.
+//
+// Structurally identical to [GetAgentCredentials] — same envelope
+// decode, same body-code discrimination — but targets the
+// `/v1/vault/user/{service}/credentials` route owned by the merged
+// OpenAPI spec.
+func (c *daemonClient) GetUserCredentials(ctx context.Context, service string) (vault.Secret, error) {
+	endpoint := c.baseURL + "/v1/vault/user/" + url.PathEscape(service) + "/credentials"
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return vault.Secret{}, err
+	}
+	c.authorize(req)
+	resp, err := c.client.Do(req)
+	if err != nil {
+		return vault.Secret{}, fmt.Errorf("get user credentials: %w", err)
+	}
+	defer resp.Body.Close()
+
+	switch resp.StatusCode {
+	case http.StatusOK:
+		var body agentCredentialsBody
+		if err := json.NewDecoder(resp.Body).Decode(&body); err != nil {
+			return vault.Secret{}, fmt.Errorf("decode user credentials: %w", err)
+		}
+		secret := vault.Secret{Value: body.Value}
+		if body.Metadata != nil {
+			secret.Metadata = vault.Metadata{
+				Type:        body.Metadata.Type,
+				Environment: body.Metadata.Environment,
+				Labels:      body.Metadata.Labels,
+			}
+		}
+		return secret, nil
+	case http.StatusNotFound:
+		// Any 404 maps to ErrUserCredentialsNotFound, regardless of body
+		// code. Unlike the per-agent path — where a bare 404 could mask a
+		// daemon routing bug worth surfacing — user-level GitHub injection
+		// is purely additive and optional: a missing route (older daemon),
+		// an empty entry (`vault_not_found`), or any generic 404 all mean
+		// "no usable token this launch," which the injector turns into a
+		// clean, unauthenticated launch rather than an abort. Mapping every
+		// 404 here keeps the optional feature from ever breaking a launch.
+		return vault.Secret{}, ErrUserCredentialsNotFound
+	case http.StatusLocked:
+		if classifyVaultError(resp) == "vault_locked" {
+			return vault.Secret{}, vault.ErrCredentialUnavailable
+		}
+		return vault.Secret{}, httpStatusError(resp, "GET user credentials")
+	default:
+		return vault.Secret{}, httpStatusError(resp, "GET user credentials")
+	}
+}
+
 // PutAgentCredentials writes the per-agent credential envelope back
 // to the daemon's vault. Used by the launcher's Capture pass on
 // clean container exit and by Codex's pre-launch refresh hook (the

--- a/internal/launch/daemon_client_user_credentials_test.go
+++ b/internal/launch/daemon_client_user_credentials_test.go
@@ -1,0 +1,170 @@
+package launch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// daemon_client.go user-credentials contract (#1149):
+//
+//   - GetUserCredentials targets /v1/vault/user/{service}/credentials
+//     (agent-independent namespace) and decodes a 200 envelope into
+//     vault.Secret, including metadata round-trip.
+//   - GET 404 with body code `vault_not_found` surfaces as
+//     ErrUserCredentialsNotFound (distinct from a generic 404), so the
+//     GitHub injector cleanly skips on an empty vault entry.
+//   - GET 423 with body code `vault_locked` surfaces as
+//     vault.ErrCredentialUnavailable (distinct from a 5xx).
+//   - An unexpected 5xx must NOT collapse to ErrUserCredentialsNotFound.
+//   - The bearer token is sent when configured.
+
+func TestDaemonClient_GetUserCredentials_Success(t *testing.T) {
+	want := vault.Secret{
+		Value: []byte("ghp_exampletoken"),
+		Metadata: vault.Metadata{
+			Type:        "oauth_refresh_token",
+			Environment: "personal",
+			Labels:      map[string]string{"k": "v"},
+		},
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.Method != http.MethodGet || r.URL.Path != "/v1/vault/user/github/credentials" {
+			t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+		}
+		body := agentCredentialsBody{
+			Value: want.Value,
+			Metadata: &agentCredentialsMetadataDTO{
+				Type:        want.Metadata.Type,
+				Environment: want.Metadata.Environment,
+				Labels:      want.Metadata.Labels,
+			},
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(body)
+	}))
+	defer srv.Close()
+
+	c := newDaemonClient(srv.URL)
+	got, err := c.GetUserCredentials(context.Background(), "github")
+	if err != nil {
+		t.Fatalf("GetUserCredentials: %v", err)
+	}
+	if string(got.Value) != string(want.Value) {
+		t.Errorf("Value = %q, want %q", got.Value, want.Value)
+	}
+	if got.Metadata.Type != "oauth_refresh_token" {
+		t.Errorf("Metadata.Type = %q, want oauth_refresh_token", got.Metadata.Type)
+	}
+	if got.Metadata.Environment != "personal" {
+		t.Errorf("Metadata.Environment = %q, want personal", got.Metadata.Environment)
+	}
+	if got.Metadata.Labels["k"] != "v" {
+		t.Errorf("Metadata.Labels[k] = %q, want v", got.Metadata.Labels["k"])
+	}
+}
+
+func TestDaemonClient_GetUserCredentials_VaultNotFoundCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    "vault_not_found",
+				"message": "no credential entry for user/github",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := newDaemonClient(srv.URL)
+	_, err := c.GetUserCredentials(context.Background(), "github")
+	if !errors.Is(err, ErrUserCredentialsNotFound) {
+		t.Fatalf("err = %v, want ErrUserCredentialsNotFound", err)
+	}
+}
+
+func TestDaemonClient_GetUserCredentials_Bare404MapsToNotFound(t *testing.T) {
+	// A bare 404 with no body code (an older daemon lacking the route,
+	// or a generic not-found) must also map to ErrUserCredentialsNotFound
+	// so the optional GitHub injection degrades to a clean,
+	// unauthenticated launch instead of aborting.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.NotFound(w, r)
+	}))
+	defer srv.Close()
+
+	c := newDaemonClient(srv.URL)
+	_, err := c.GetUserCredentials(context.Background(), "github")
+	if !errors.Is(err, ErrUserCredentialsNotFound) {
+		t.Fatalf("err = %v, want ErrUserCredentialsNotFound for a bare 404", err)
+	}
+}
+
+func TestDaemonClient_GetUserCredentials_VaultLockedCode(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(http.StatusLocked)
+		_ = json.NewEncoder(w).Encode(map[string]any{
+			"error": map[string]any{
+				"code":    "vault_locked",
+				"message": "unlock the vault first",
+			},
+		})
+	}))
+	defer srv.Close()
+
+	c := newDaemonClient(srv.URL)
+	_, err := c.GetUserCredentials(context.Background(), "github")
+	if !errors.Is(err, vault.ErrCredentialUnavailable) {
+		t.Fatalf("err = %v, want vault.ErrCredentialUnavailable", err)
+	}
+}
+
+func TestDaemonClient_GetUserCredentials_GenericNonOKReturnsStatusError(t *testing.T) {
+	// An unexpected 5xx must NOT collapse to ErrUserCredentialsNotFound;
+	// that would mistakenly treat a daemon outage as "no github token"
+	// and silently skip injection. Status errors propagate as the
+	// generic httpStatusError shape.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = io.WriteString(w, "boom")
+	}))
+	defer srv.Close()
+
+	c := newDaemonClient(srv.URL)
+	_, err := c.GetUserCredentials(context.Background(), "github")
+	if err == nil {
+		t.Fatal("expected error on 500")
+	}
+	if errors.Is(err, ErrUserCredentialsNotFound) {
+		t.Errorf("err matched ErrUserCredentialsNotFound on 500; got %v", err)
+	}
+	if errors.Is(err, vault.ErrCredentialUnavailable) {
+		t.Errorf("err matched vault.ErrCredentialUnavailable on 500; got %v", err)
+	}
+}
+
+func TestDaemonClient_GetUserCredentials_BearerTokenSent(t *testing.T) {
+	seen := make(chan string, 1)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		seen <- r.Header.Get("Authorization")
+		_ = json.NewEncoder(w).Encode(agentCredentialsBody{Value: []byte("x")})
+	}))
+	defer srv.Close()
+
+	c := newDaemonClient(srv.URL, "tok_launch")
+	if _, err := c.GetUserCredentials(context.Background(), "github"); err != nil {
+		t.Fatalf("GetUserCredentials: %v", err)
+	}
+	if got := <-seen; !strings.HasPrefix(got, "Bearer ") {
+		t.Errorf("Authorization = %q, want bearer", got)
+	}
+}

--- a/internal/launch/github_inject.go
+++ b/internal/launch/github_inject.go
@@ -1,0 +1,175 @@
+package launch
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+	"strings"
+
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// githubUserService is the single hardcoded user-level service name the
+// injector reads from the vault (`user/github`). The route shape lives
+// in the daemon client; this constant names only the service slug.
+const githubUserService = "github"
+
+// githubConfigTarget is where the credential-helper gitconfig is mounted
+// inside the container. It sits directly under /home/agent — the same
+// parent as the workspace mount in v4 — so it must be delivered as an
+// individual file mount, not a directory mount, mirroring Claude's
+// .claude.json carve-out so the workspace mount is not masked.
+const githubConfigTarget = "/home/agent/.gitconfig"
+
+// gitCredentialHelperConfig is the static, token-independent gitconfig
+// that wires git's HTTPS credential helper to `gh`. The token never
+// appears in this file; it flows only via the GH_TOKEN env var, which
+// `gh auth git-credential` reads at request time. Because the content
+// never changes, the mount is read-only.
+const gitCredentialHelperConfig = "[credential \"https://github.com\"]\n\thelper = !gh auth git-credential\n"
+
+// userCredsDaemon is the one-method subset of *daemonClient the GitHub
+// injector depends on. Defined as an interface so tests substitute a
+// fake without spinning up an httptest server.
+type userCredsDaemon interface {
+	GetUserCredentials(ctx context.Context, service string) (vault.Secret, error)
+}
+
+// githubInjectPrep is the output of prepareGitHubInject — the env and
+// mount additions the launcher merges into the sandbox launch, plus a
+// cleanup for the transient host directory. Its shape mirrors
+// authSpecPrep but is deliberately separate: this injector is
+// user-level and runs on every sandbox launch independent of the
+// per-agent AuthSpec.
+type githubInjectPrep struct {
+	// EnvAdditions merge into the agent's env. Carries GH_TOKEN when a
+	// usable token was found; empty otherwise.
+	EnvAdditions map[string]string
+
+	// Mounts append to the sandbox volume list. Carries the individual
+	// gitconfig file mount when a token was found; empty otherwise.
+	Mounts []sandboxcontainer.Volume
+
+	// Cleanup removes the transient host directory holding the rendered
+	// gitconfig. Always non-nil and safe to call (a no-op when no
+	// directory was created).
+	Cleanup func()
+}
+
+// emptyGitHubInjectPrep returns a clean, no-op prep: no env, no mount,
+// and a nil-safe Cleanup. Used on every skip path (no entry, locked
+// vault, empty token) so the caller can unconditionally defer Cleanup
+// and range over EnvAdditions/Mounts.
+func emptyGitHubInjectPrep() githubInjectPrep {
+	return githubInjectPrep{
+		EnvAdditions: map[string]string{},
+		Cleanup:      func() {},
+	}
+}
+
+// prepareGitHubInject reads the user-level GitHub token from the vault
+// and, when present, produces a GH_TOKEN env addition plus a read-only
+// bind mount of a static git credential-helper gitconfig at
+// /home/agent/.gitconfig.
+//
+// Skip-clean semantics: a missing entry (ErrUserCredentialsNotFound) or
+// a locked vault (vault.ErrCredentialUnavailable) returns an empty prep
+// with no error — the launch proceeds with GitHub operations simply
+// unauthenticated. A token that is empty after trimming is treated the
+// same way. Only an unexpected daemon error aborts.
+//
+// chownHook, when non-nil, is applied to the transient directory before
+// the mount is added. On rootful Docker Linux the host operator owns
+// the 0700 transient dir, which the in-container agent UID cannot
+// traverse; the hook chowns the tree to the agent UID so git-over-HTTPS
+// can read the helper line. A hook failure is non-fatal: the injector
+// warns and proceeds, since a same-UID environment needs no chown.
+func prepareGitHubInject(
+	ctx context.Context,
+	daemon userCredsDaemon,
+	sessionLog *slog.Logger,
+	stderr io.Writer,
+	chownHook func(dir string) error,
+) (githubInjectPrep, error) {
+	secret, err := daemon.GetUserCredentials(ctx, githubUserService)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrUserCredentialsNotFound):
+			// No user/github entry — proceed unauthenticated.
+			return emptyGitHubInjectPrep(), nil
+		case errors.Is(err, vault.ErrCredentialUnavailable):
+			// Vault locked — no token available this launch. Warn so the
+			// user knows GitHub ops will be unauthenticated, but never
+			// abort the launch.
+			githubInjectWarn(sessionLog, stderr,
+				fmt.Errorf("vault locked; GitHub operations in the sandbox will be unauthenticated until you unlock the vault"))
+			return emptyGitHubInjectPrep(), nil
+		default:
+			return githubInjectPrep{}, fmt.Errorf("read user github credentials: %w", err)
+		}
+	}
+
+	token := strings.TrimSpace(string(secret.Value))
+	if token == "" {
+		// An entry with no usable token is equivalent to no entry.
+		return emptyGitHubInjectPrep(), nil
+	}
+
+	dir, err := os.MkdirTemp("", "aileron-github-inject-")
+	if err != nil {
+		return githubInjectPrep{}, fmt.Errorf("create github inject dir: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(dir) }
+
+	// 0700 (not 0600): the dir needs its traverse bit so the mounted
+	// file beneath it is reachable. The in-container agent reaches the
+	// file via the chown hook below on rootful Docker Linux.
+	if err := os.Chmod(dir, 0o700); err != nil {
+		cleanup()
+		return githubInjectPrep{}, fmt.Errorf("chmod github inject dir: %w", err)
+	}
+
+	hostPath := filepath.Join(dir, ".gitconfig")
+	if err := os.WriteFile(hostPath, []byte(gitCredentialHelperConfig), 0o644); err != nil {
+		cleanup()
+		return githubInjectPrep{}, fmt.Errorf("write github inject gitconfig: %w", err)
+	}
+
+	// Chown the transient tree to the in-container agent UID before the
+	// mount is added. Non-fatal on failure: warn and proceed, since a
+	// same-UID environment (macOS/Windows shim, or a root-owned image)
+	// needs no chown and the hook is nil there anyway.
+	if chownHook != nil {
+		if err := chownHook(dir); err != nil {
+			githubInjectWarn(sessionLog, stderr,
+				fmt.Errorf("chown github inject dir to image agent UID: %w; the agent runs as a non-root system user while the host operator owns this bind-mounted dir, so git-over-HTTPS may be unable to read the credential helper line (EPERM) — the remedy is the chown-to-agent-UID fix on the gitconfig bind mount", err))
+		}
+	}
+
+	prep := emptyGitHubInjectPrep()
+	prep.EnvAdditions["GH_TOKEN"] = token
+	prep.Mounts = []sandboxcontainer.Volume{{
+		Source:   hostPath,
+		Target:   githubConfigTarget,
+		ReadOnly: true,
+	}}
+	prep.Cleanup = cleanup
+	return prep, nil
+}
+
+// githubInjectWarn emits a non-fatal diagnostic to the session log and
+// the user's stderr, matching the captureWarn one-liner shape used by
+// the auth-spec runtime.
+func githubInjectWarn(log *slog.Logger, stderr io.Writer, err error) {
+	if log != nil {
+		log.Warn("github inject", "error", err)
+	}
+	if stderr != nil {
+		fmt.Fprintf(stderr, "[launcher] github inject: %v\n", err)
+	}
+}

--- a/internal/launch/github_inject_launcher_test.go
+++ b/internal/launch/github_inject_launcher_test.go
@@ -1,0 +1,84 @@
+package launch
+
+import (
+	"context"
+	"testing"
+
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// Launcher wiring contract (#1149): the launcher merges the GitHub
+// injector's EnvAdditions into the composed agentEnv and appends its
+// mounts onto the sandbox volume list. These tests exercise that exact
+// merge — env merge plus mount append — against a fake daemon, so the
+// wiring is verified without standing up the full container launch.
+//
+// The merge mirrors launcher.go's sandbox-only block:
+//
+//	for k, v := range ghPrep.EnvAdditions { agentEnv[k] = v }
+//	proxyMounts = append(proxyMounts, ghPrep.Mounts...)
+
+func TestLauncherMergesGitHubInject_TokenPresent(t *testing.T) {
+	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_launch")}}
+
+	// Pre-existing agent env (e.g. AuthSpec EnvBindings) with a distinct
+	// key set — GH_TOKEN must not clobber it and vice-versa.
+	agentEnv := map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "agent-oauth"}
+	var proxyMounts []sandboxcontainer.Volume
+
+	ghPrep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareGitHubInject: %v", err)
+	}
+	defer ghPrep.Cleanup()
+	for k, v := range ghPrep.EnvAdditions {
+		agentEnv[k] = v
+	}
+	proxyMounts = append(proxyMounts, ghPrep.Mounts...)
+
+	if agentEnv["GH_TOKEN"] != "ghp_launch" {
+		t.Errorf("agentEnv[GH_TOKEN] = %q, want ghp_launch", agentEnv["GH_TOKEN"])
+	}
+	if agentEnv["CLAUDE_CODE_OAUTH_TOKEN"] != "agent-oauth" {
+		t.Errorf("GitHub inject clobbered the AuthSpec env binding: %q", agentEnv["CLAUDE_CODE_OAUTH_TOKEN"])
+	}
+
+	var found bool
+	for _, m := range proxyMounts {
+		if m.Target == "/home/agent/.gitconfig" {
+			found = true
+		}
+	}
+	if !found {
+		t.Errorf("mount list missing /home/agent/.gitconfig; got %+v", proxyMounts)
+	}
+}
+
+func TestLauncherMergesGitHubInject_NoEntryIsCleanSkip(t *testing.T) {
+	daemon := &fakeUserCredsDaemon{err: ErrUserCredentialsNotFound}
+
+	agentEnv := map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "agent-oauth"}
+	var proxyMounts []sandboxcontainer.Volume
+
+	ghPrep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareGitHubInject: %v", err)
+	}
+	defer ghPrep.Cleanup()
+	for k, v := range ghPrep.EnvAdditions {
+		agentEnv[k] = v
+	}
+	proxyMounts = append(proxyMounts, ghPrep.Mounts...)
+
+	if _, ok := agentEnv["GH_TOKEN"]; ok {
+		t.Errorf("GH_TOKEN injected on clean skip; want absent")
+	}
+	if len(proxyMounts) != 0 {
+		t.Errorf("mounts appended on clean skip; want none, got %+v", proxyMounts)
+	}
+	// The unrelated AuthSpec env survives the no-op merge.
+	if agentEnv["CLAUDE_CODE_OAUTH_TOKEN"] != "agent-oauth" {
+		t.Errorf("clean skip disturbed existing env: %q", agentEnv["CLAUDE_CODE_OAUTH_TOKEN"])
+	}
+}

--- a/internal/launch/github_inject_test.go
+++ b/internal/launch/github_inject_test.go
@@ -1,0 +1,211 @@
+package launch
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io/fs"
+	"os"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// prepareGitHubInject contract (#1149):
+//
+//   - A usable token yields GH_TOKEN (trimmed) plus a read-only file
+//     mount at /home/agent/.gitconfig whose host source contains the
+//     exact `!gh auth git-credential` helper line.
+//   - A trailing newline in the stored secret is trimmed from GH_TOKEN.
+//   - ErrUserCredentialsNotFound and a locked vault both yield an empty
+//     prep with no error and a nil-safe Cleanup (skip-clean).
+//   - An empty-after-trim token is treated as no token.
+//   - The chown hook is invoked exactly once with the transient root
+//     dir (P1 wiring), and the transient dir is 0700 (traverse bit),
+//     never 0600.
+//   - An unexpected daemon error aborts (it is not silently swallowed).
+
+// fakeUserCredsDaemon is a one-method fake implementing userCredsDaemon.
+type fakeUserCredsDaemon struct {
+	secret vault.Secret
+	err    error
+	calls  int
+}
+
+func (f *fakeUserCredsDaemon) GetUserCredentials(_ context.Context, service string) (vault.Secret, error) {
+	f.calls++
+	if service != githubUserService {
+		return vault.Secret{}, errors.New("unexpected service: " + service)
+	}
+	return f.secret, f.err
+}
+
+func TestPrepareGitHubInject_TokenPresent(t *testing.T) {
+	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_realtoken")}}
+	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareGitHubInject: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if got := prep.EnvAdditions["GH_TOKEN"]; got != "ghp_realtoken" {
+		t.Errorf("GH_TOKEN = %q, want ghp_realtoken", got)
+	}
+	if len(prep.Mounts) != 1 {
+		t.Fatalf("Mounts = %d, want 1", len(prep.Mounts))
+	}
+	m := prep.Mounts[0]
+	if m.Target != "/home/agent/.gitconfig" {
+		t.Errorf("mount Target = %q, want /home/agent/.gitconfig", m.Target)
+	}
+	if !m.ReadOnly {
+		t.Errorf("mount ReadOnly = false, want true")
+	}
+	content, readErr := os.ReadFile(m.Source)
+	if readErr != nil {
+		t.Fatalf("read mount source %q: %v", m.Source, readErr)
+	}
+	if !bytes.Contains(content, []byte("!gh auth git-credential")) {
+		t.Errorf("gitconfig source missing helper line; got:\n%s", content)
+	}
+	if !bytes.Contains(content, []byte("[credential \"https://github.com\"]")) {
+		t.Errorf("gitconfig source missing credential section; got:\n%s", content)
+	}
+}
+
+func TestPrepareGitHubInject_TrimsTrailingNewline(t *testing.T) {
+	// Regression: a secret stored with a trailing newline must not leak
+	// the newline into GH_TOKEN (it would break gh's token parsing).
+	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_x\n")}}
+	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareGitHubInject: %v", err)
+	}
+	defer prep.Cleanup()
+	if got := prep.EnvAdditions["GH_TOKEN"]; got != "ghp_x" {
+		t.Errorf("GH_TOKEN = %q, want ghp_x (trimmed)", got)
+	}
+}
+
+func TestPrepareGitHubInject_NotFoundIsCleanSkip(t *testing.T) {
+	daemon := &fakeUserCredsDaemon{err: ErrUserCredentialsNotFound}
+	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareGitHubInject: %v", err)
+	}
+	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
+		t.Errorf("GH_TOKEN set on not-found, want absent")
+	}
+	if len(prep.Mounts) != 0 {
+		t.Errorf("Mounts = %d, want 0 on not-found", len(prep.Mounts))
+	}
+	if prep.Cleanup == nil {
+		t.Fatal("Cleanup nil on not-found; want nil-safe no-op")
+	}
+	prep.Cleanup() // must not panic
+}
+
+func TestPrepareGitHubInject_LockedVaultIsCleanSkip(t *testing.T) {
+	var stderr bytes.Buffer
+	daemon := &fakeUserCredsDaemon{err: vault.ErrCredentialUnavailable}
+	prep, err := prepareGitHubInject(context.Background(), daemon, nil, &stderr, nil)
+	if err != nil {
+		t.Fatalf("prepareGitHubInject: %v, want clean skip on locked vault", err)
+	}
+	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
+		t.Errorf("GH_TOKEN set on locked vault, want absent")
+	}
+	if len(prep.Mounts) != 0 {
+		t.Errorf("Mounts = %d, want 0 on locked vault", len(prep.Mounts))
+	}
+	if stderr.Len() == 0 {
+		t.Errorf("expected a non-fatal locked-vault warning on stderr")
+	}
+	prep.Cleanup()
+}
+
+func TestPrepareGitHubInject_EmptyTokenIsCleanSkip(t *testing.T) {
+	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("   \n")}}
+	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareGitHubInject: %v", err)
+	}
+	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
+		t.Errorf("GH_TOKEN set on empty-after-trim token, want absent")
+	}
+	if len(prep.Mounts) != 0 {
+		t.Errorf("Mounts = %d, want 0 on empty token", len(prep.Mounts))
+	}
+	prep.Cleanup()
+}
+
+func TestPrepareGitHubInject_UnexpectedDaemonErrorAborts(t *testing.T) {
+	daemon := &fakeUserCredsDaemon{err: errors.New("daemon down")}
+	_, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
+	if err == nil {
+		t.Fatal("expected error on unexpected daemon failure")
+	}
+	if errors.Is(err, ErrUserCredentialsNotFound) {
+		t.Errorf("unexpected error collapsed to not-found: %v", err)
+	}
+}
+
+func TestPrepareGitHubInject_ChownHookInvokedOnceWithTransientDir(t *testing.T) {
+	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_x")}}
+
+	var seenDir string
+	calls := 0
+	hook := func(dir string) error {
+		calls++
+		seenDir = dir
+		return nil
+	}
+
+	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, hook)
+	if err != nil {
+		t.Fatalf("prepareGitHubInject: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if calls != 1 {
+		t.Errorf("chown hook called %d times, want exactly 1", calls)
+	}
+	// The hook must receive the transient ROOT dir (parent of the
+	// rendered file), so the recursive chown covers both dir and file.
+	if seenDir == "" {
+		t.Fatal("chown hook received empty dir")
+	}
+	wantParent := seenDir + string(os.PathSeparator) + ".gitconfig"
+	if prep.Mounts[0].Source != wantParent {
+		t.Errorf("mount source %q is not under chowned dir %q", prep.Mounts[0].Source, seenDir)
+	}
+
+	info, statErr := os.Stat(seenDir)
+	if statErr != nil {
+		t.Fatalf("stat transient dir: %v", statErr)
+	}
+	if perm := info.Mode().Perm(); perm != fs.FileMode(0o700) {
+		t.Errorf("transient dir perm = %o, want 0700 (needs traverse bit, not 0600)", perm)
+	}
+}
+
+func TestPrepareGitHubInject_ChownHookFailureIsNonFatal(t *testing.T) {
+	var stderr bytes.Buffer
+	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_x")}}
+	hook := func(string) error { return errors.New("chown boom") }
+
+	prep, err := prepareGitHubInject(context.Background(), daemon, nil, &stderr, hook)
+	if err != nil {
+		t.Fatalf("chown failure must be non-fatal, got: %v", err)
+	}
+	defer prep.Cleanup()
+	if prep.EnvAdditions["GH_TOKEN"] != "ghp_x" {
+		t.Errorf("GH_TOKEN not set after non-fatal chown failure")
+	}
+	if len(prep.Mounts) != 1 {
+		t.Errorf("Mounts = %d, want 1 after non-fatal chown failure", len(prep.Mounts))
+	}
+	if stderr.Len() == 0 {
+		t.Errorf("expected a non-fatal chown warning on stderr")
+	}
+}

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -527,6 +527,29 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 			fmt.Fprintf(os.Stderr, "[launcher] no credentials in vault for %s; agent will prompt for login\n",
 				config.Agent.Name())
 		}
+
+		// User-level GitHub injection runs on every sandbox launch,
+		// independent of the per-agent AuthSpec: it reads the
+		// agent-independent `user/github` token from the vault and, when
+		// present, exports GH_TOKEN and mounts a static git
+		// credential-helper gitconfig at /home/agent/.gitconfig so both
+		// `gh` and git-over-HTTPS authenticate inside the sandbox. A
+		// missing entry or locked vault is a clean, non-fatal skip — the
+		// launch proceeds with GitHub operations unauthenticated. The
+		// chown hook mirrors the AuthSpec one: on rootful Docker Linux
+		// the host operator owns the transient dir, so the tree is
+		// chowned to the image's agent UID before mounting. See #1149.
+		ghChownHook := newAgentDirChownHook(ctx, sandboxcontainer.DefaultRunner(),
+			sandboxPlan.Runtime, sandboxPlan.Image)
+		ghPrep, err := prepareGitHubInject(ctx, client, sessionLog, os.Stderr, ghChownHook)
+		if err != nil {
+			return LaunchResult{}, fmt.Errorf("prepare github inject: %w", err)
+		}
+		defer ghPrep.Cleanup()
+		for k, v := range ghPrep.EnvAdditions {
+			agentEnv[k] = v
+		}
+		proxyBootstrap.Mounts = append(proxyBootstrap.Mounts, ghPrep.Mounts...)
 	}
 
 	// captureOnce wraps the AuthSpec Capture so the clean-exit gate


### PR DESCRIPTION
## Summary

Injects the user-level GitHub credential into every sandbox launch so both `gh` and `git`-over-HTTPS authenticate inside the container, without ever writing the token to disk.

On each sandbox launch (independent of the per-agent AuthSpec), the launcher:

1. Reads the agent-independent `user/github` token from the local vault via a new daemon-client method `GetUserCredentials(ctx, "github")`, hitting the merged `GET /v1/vault/user/{service}/credentials` route.
2. When a usable token is present, exports `GH_TOKEN` (trimmed) and bind-mounts a **static, token-independent** gitconfig at `/home/agent/.gitconfig` containing only `helper = !gh auth git-credential`. The token never appears in any file; it flows solely via `GH_TOKEN`, which `gh auth git-credential` reads at request time.
3. Chowns the transient gitconfig dir to the image's `agent` UID (reusing the existing AuthSpec `newAgentDirChownHook`) so the in-container agent can traverse the `0700` dir and read the helper line on rootful Docker Linux.

Skip-clean semantics: a missing entry, a bare 404 from an older daemon, an empty-after-trim token, or a locked vault is a non-fatal skip — the launch proceeds with GitHub operations unauthenticated. Only an unexpected daemon error aborts.

The injector lives in its own file (`internal/launch/github_inject.go`) with its own one-method daemon interface so it is independently testable.

### Scope (non-goals)
- No OpenAPI / `server.gen.go` change — pure consumer of the existing read endpoint (`task generate:api` is a no-op).
- No `internal/sandbox/network.go` / proxy / allowlist change — `github.com` is already allow-by-default (asserted at `sandbox_forward_proxy_passthrough_test.go:370`).
- HTTPS-only: no SSH keys, no `~/.ssh`. Sandbox-only (matches AuthSpec's v1 scope). The capture side (`user/github` writes, #1148) is a sibling issue; this only reads.

## Test plan
- `go test ./internal/launch/... ./internal/app/... -cover` — green (launch 87.4%).
- New unit tests:
  - daemon client: 200 round-trip, `vault_not_found` 404, **bare 404 maps to not-found**, `vault_locked` 423, 5xx does not collapse to not-found, bearer sent.
  - injector: token present (env + mount + exact helper line), **trailing-newline trim regression** (`ghp_x\n` -> `ghp_x`), not-found/locked/empty-token clean skips, unexpected error aborts, **chown hook invoked exactly once with the transient root dir + dir is `0700` not `0600`**, chown failure non-fatal.
  - launcher merge: `GH_TOKEN` lands in `agentEnv` and the `/home/agent/.gitconfig` mount lands in the volume list without clobbering AuthSpec env; clean skip leaves both untouched. Full existing launcher integration suite passes (a bare-404 daemon no longer aborts launch).
- `task generate:api` produces no diff.
- CodeRabbit review: 0 findings.

Closes #1149

🤖 Generated with [Claude Code](https://claude.com/claude-code)
