### PR TITLE
fix(launch): run sandbox Codex non-interactively

### DIFF
--- a/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
+++ b/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
@@ -152,6 +152,16 @@ The most common cause is a cross-arch host: an `arm64` host bind-mounting into a
 
 Claude Code's `mcp__<server>__<tool>` convention disambiguates by server. A user's `draft_email` from `userthing` appears as `mcp__userthing__draft_email` alongside `mcp__aileron__draft_email`. Both work independently; the agent picks based on intent. There is no conflict.
 
+### Codex: sandbox runs non-interactively (approval + folder trust)
+
+Under `aileron launch --sandbox`, the generated `/home/agent/.codex/config.toml` pre-sets Codex's non-interactive keys so an ephemeral container runs end-to-end without operator prompts:
+
+- `approval_policy = "never"` suppresses Codex's per-tool approval prompts (the ones you would otherwise hit on each MCP tool call, e.g. `list_recent_emails` / `get_email`).
+- `sandbox_mode = "danger-full-access"` defers OS isolation to the outer Aileron container.
+- a `[projects."/home/agent/workspace"]` block with `trust_level = "trusted"` pre-accepts Codex's "trust the current folder?" prompt for the bind-mounted workspace.
+
+This is **sandbox-mode only**. The outer container is the trust boundary ([ADR-0015](/adr/0015-launch-audit-scope/)) and Aileron still mediates every action the agent calls through `aileron-mcp` + the gateway (the HITL approval chain in this walkthrough is unaffected — it runs in the daemon, not in Codex). A host-mode launch never touches `~/.codex/config.toml`'s approval, sandbox, or folder-trust settings; you own those.
+
 ### Codex: user devcontainer MCP entries masked
 
 The Codex sandbox path bind-mounts a generated `config.toml` into the container at `/home/agent/.codex/config.toml`. Any user-shipped `[mcp_servers.foo]` entry in a devcontainer-baked config is silently masked by the launcher-provided file. Aileron does NOT promise a Codex multi-config-file workaround today — whether Codex reads additional `~/.codex/*.toml` files is unverified. If you want Codex + sandbox with extra MCP servers, pre-merge your entries into a wrapper script that writes a combined config before `aileron launch` invokes Codex.

--- a/internal/launch/agents/codex.go
+++ b/internal/launch/agents/codex.go
@@ -29,12 +29,20 @@ type Codex struct{}
 func (c Codex) Name() string          { return "codex" }
 func (c Codex) BinaryNames() []string { return []string{"codex"} }
 
-// Args returns no extra arguments. Approval policy + sandbox mode for
-// Codex live in `~/.codex/config.toml` (e.g. `approval_policy = "never"`
-// for fully autonomous runs); we do not override them at launch time.
-// Users who want Codex's own approval prompt suppressed can set that in
-// their config or pass `--dangerously-bypass-approvals-and-sandbox`
-// themselves.
+// Args returns no extra arguments. Approval policy, sandbox mode, and
+// folder trust for Codex live in `~/.codex/config.toml`, not on the CLI.
+//
+// In ModeHost we do NOT override them: a host launch runs against the
+// user's real machine, so Codex's own approval prompt and folder-trust
+// dialog stay in force and the user owns those settings.
+//
+// In ModeSandbox the generated config.toml (mergeCodexSandboxConfig)
+// pre-sets them for an ephemeral, non-interactive run: `approval_policy
+// = "never"` suppresses per-tool approval prompts, `sandbox_mode =
+// "danger-full-access"` defers isolation to the outer container, and a
+// `[projects."/home/agent/workspace"]` block pre-accepts the
+// folder-trust prompt. The sandbox container is the trust boundary
+// (ADR-0015), so auto-approving inside it is safe.
 func (c Codex) Args() []string { return nil }
 
 func (c Codex) Env() map[string]string { return nil }
@@ -59,12 +67,17 @@ func (c Codex) LLMEndpointEnv() string { return "OPENAI_BASE_URL" }
 //     The host `~/.codex/config.toml` is never touched. The in-
 //     container Codex reads this file at startup. See ADR-0024.
 //
-// Sandbox mode emits ONLY the [mcp_servers.aileron] block — no merge
-// against a host-side config — so any other [mcp_servers.foo] entries
-// the user has on the host don't leak into the container. Users
+// For MCP, sandbox mode emits ONLY the [mcp_servers.aileron] block — no
+// merge against a host-side config — so any other [mcp_servers.foo]
+// entries the user has on the host don't leak into the container. Users
 // wanting extra MCP servers under Codex+sandbox configure them via
 // their devcontainer or via a wrapper merge; the manual recipe at
 // docs/development/sandbox-mcp-walkthrough.md documents the limitation.
+//
+// Sandbox mode additionally pre-sets Codex's non-interactive keys
+// (approval_policy, sandbox_mode, folder trust_level) so the ephemeral
+// container runs end-to-end without operator prompts; see
+// mergeCodexSandboxConfig. Host mode leaves all of those to the user.
 func (c Codex) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string, mode launch.Mode) ([]string, []launch.MCPMount, error) {
 	if mode == launch.ModeSandbox {
 		return c.configureSandboxMCP(mcpBin, mcpEnv)
@@ -139,6 +152,15 @@ func (c Codex) configureHostMCP(mcpBin string, mcpEnv map[string]string) ([]stri
 // inside the sandbox container.
 const codexSandboxConfigContainerPath = "/home/agent/.codex/config.toml"
 
+// codexSandboxWorkspacePath is the in-container directory the launcher
+// runs Codex in (the bind-mounted project workspace). It must match
+// container.WorkspacePath and the runtime `--workdir`; it is spelled
+// out literally here, mirroring claudeWorkspacePath, to keep the agents
+// package free of an import on the container package. The generated
+// sandbox config.toml pre-trusts this folder so Codex does not block on
+// its folder-trust prompt on every launch.
+const codexSandboxWorkspacePath = "/home/agent/workspace"
+
 func (c Codex) configureSandboxMCP(mcpBin string, mcpEnv map[string]string) ([]string, []launch.MCPMount, error) {
 	dir, err := os.MkdirTemp("", "aileron-codex-sandbox-*")
 	if err != nil {
@@ -148,13 +170,17 @@ func (c Codex) configureSandboxMCP(mcpBin string, mcpEnv map[string]string) ([]s
 	// Sandbox mode emits only our [mcp_servers.aileron] block — no
 	// merge with a host-side config. The empty-string baseline mirrors
 	// what mergeCodexMCPBlock produces when called with no prior file.
-	// Sandbox mode also emits two top-level keys:
+	// Sandbox mode also emits the non-interactive keys that let an
+	// ephemeral container run end-to-end without operator prompts:
+	// `approval_policy = "never"` suppresses per-tool approval prompts,
 	// `sandbox_mode = "danger-full-access"` disables Codex's redundant
 	// in-container OS sandbox (the Alpine image ships no bubblewrap, so
-	// it would only warn and fall back), and
-	// `cli_auth_credentials_store = "file"` so the in-container Codex
-	// resolves auth from auth.json — the AuthSpec FileBinding writes
-	// auth.json into the same directory at launch (R22).
+	// it would only warn and fall back), `cli_auth_credentials_store =
+	// "file"` so the in-container Codex resolves auth from auth.json —
+	// the AuthSpec FileBinding writes auth.json into the same directory
+	// at launch (R22) — and a [projects."/home/agent/workspace"] block
+	// with `trust_level = "trusted"` to pre-accept the folder-trust
+	// prompt for the bind-mounted workspace.
 	body := mergeCodexSandboxConfig(mcpBin, mcpEnv)
 	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
 		return nil, nil, fmt.Errorf("writing codex sandbox config: %w", err)
@@ -168,9 +194,16 @@ func (c Codex) configureSandboxMCP(mcpBin string, mcpEnv map[string]string) ([]s
 }
 
 // mergeCodexSandboxConfig is the ModeSandbox variant of the merge.
-// In addition to the [mcp_servers.aileron] block, it prepends two
-// top-level keys:
+// In addition to the [mcp_servers.aileron] block, it prepends the
+// non-interactive top-level keys and a folder-trust block that let an
+// ephemeral container run end-to-end without operator prompts:
 //
+//   - `approval_policy = "never"` suppresses Codex's per-tool approval
+//     prompts (the operator hit these on list_recent_emails / get_email).
+//     The sandbox container is the trust boundary (ADR-0015) and Aileron
+//     still mediates every action the agent calls through aileron-mcp +
+//     the gateway, so auto-approving Codex's local exec inside the
+//     ephemeral container is safe.
 //   - `sandbox_mode = "danger-full-access"` disables Codex's own
 //     OS sandbox (bubblewrap/Landlock on the Linux container) for
 //     local exec. The Alpine sandbox-base image ships no bwrap binary,
@@ -188,13 +221,23 @@ func (c Codex) configureSandboxMCP(mcpBin string, mcpEnv map[string]string) ([]s
 //     CLI reads auth.json instead of trying to use the macOS Keychain
 //     / Linux secret-tool keyring (which do not exist inside the
 //     sandbox).
+//   - a [projects."/home/agent/workspace"] block with `trust_level =
+//     "trusted"` pre-accepts Codex's "trust the current folder?" prompt
+//     for the bind-mounted workspace, mirroring how Claude pre-sets
+//     hasTrustDialogAccepted for the same path (claude_auth.go).
 //
-// The host config is never touched under ModeSandbox.
+// All of these are sandbox-mode only. The host config is never touched
+// under ModeSandbox, and host launches keep Codex's normal approval
+// policy, sandboxing, and folder-trust behavior.
 func mergeCodexSandboxConfig(mcpBin string, mcpEnv map[string]string) string {
-	// Start with the top-level keys, then append the [mcp_servers.*]
-	// block via the existing merge over an empty baseline.
-	return `sandbox_mode = "danger-full-access"` + "\n" +
-		`cli_auth_credentials_store = "file"` + "\n" +
+	// Start with the top-level keys, append the workspace folder-trust
+	// block, then the [mcp_servers.*] block via the existing merge over
+	// an empty baseline.
+	return `approval_policy = "never"` + "\n" +
+		`sandbox_mode = "danger-full-access"` + "\n" +
+		`cli_auth_credentials_store = "file"` + "\n\n" +
+		`[projects."` + codexSandboxWorkspacePath + `"]` + "\n" +
+		`trust_level = "trusted"` + "\n\n" +
 		mergeCodexMCPBlock("", mcpBin, mcpEnv)
 }
 

--- a/internal/launch/agents/codex_auth_test.go
+++ b/internal/launch/agents/codex_auth_test.go
@@ -426,8 +426,20 @@ func TestCodex_HostConfig_OmitsSandboxMode(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read host config.toml: %v", err)
 	}
-	if strings.Contains(string(body), "sandbox_mode") {
-		t.Errorf("host config.toml must not contain sandbox_mode:\n%s", body)
+	// #1162 guard: the sandbox-only non-interactive keys (approval
+	// policy override + workspace folder-trust block) must likewise never
+	// leak into the host config. configureHostMCP only writes the
+	// [mcp_servers.aileron] block; host launches keep the user's own
+	// approval policy and folder-trust behavior.
+	for _, forbidden := range []string{
+		"sandbox_mode",
+		`approval_policy = "never"`,
+		"trust_level",
+		"[projects.",
+	} {
+		if strings.Contains(string(body), forbidden) {
+			t.Errorf("host config.toml must not contain %q:\n%s", forbidden, body)
+		}
 	}
 }
 

--- a/internal/launch/agents/codex_test.go
+++ b/internal/launch/agents/codex_test.go
@@ -186,6 +186,45 @@ func TestCodex_ConfigureMCP_SandboxMode_WritesTempAndReturnsMount(t *testing.T) 
 	}
 }
 
+// TestCodex_ConfigureMCP_SandboxMode_NonInteractiveKeys pins the
+// non-interactive contract for an ephemeral sandbox run (feedback #1162):
+// the generated config.toml must suppress Codex's per-tool approval
+// prompts, defer isolation to the outer container, and pre-accept the
+// folder-trust prompt for the bind-mounted workspace. Without these the
+// operator hits an approval prompt on each MCP tool call
+// (list_recent_emails / get_email) and a "trust the current folder?"
+// dialog at launch. The sandbox container is the trust boundary
+// (ADR-0015), so auto-approving inside it is safe.
+func TestCodex_ConfigureMCP_SandboxMode_NonInteractiveKeys(t *testing.T) {
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+
+	_, mounts, err := agents.Codex{}.ConfigureMCP("/usr/local/bin/aileron-mcp", map[string]string{
+		"AILERON_URL": "http://host.docker.internal:7000",
+	}, "", launch.ModeSandbox)
+	if err != nil {
+		t.Fatalf("ConfigureMCP sandbox: %v", err)
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("Mounts = %d, want 1", len(mounts))
+	}
+	body, err := os.ReadFile(mounts[0].Source)
+	if err != nil {
+		t.Fatalf("read temp config.toml: %v", err)
+	}
+	content := string(body)
+	for _, want := range []string{
+		`approval_policy = "never"`,
+		`sandbox_mode = "danger-full-access"`,
+		`[projects."/home/agent/workspace"]`,
+		`trust_level = "trusted"`,
+	} {
+		if !strings.Contains(content, want) {
+			t.Errorf("sandbox config.toml missing non-interactive key %q:\n%s", want, content)
+		}
+	}
+}
+
 // TestCodex_ConfigureMCP_SandboxMode_DoesNotTouchHostConfig is the
 // load-bearing safety guarantee: a sandbox launch must not mutate the
 // host ~/.codex/config.toml. A user running both host-mode and


### PR DESCRIPTION
## Summary

In `--sandbox` mode the generated Codex `config.toml` (built by `mergeCodexSandboxConfig`) previously only set `sandbox_mode = "danger-full-access"` and `cli_auth_credentials_store = "file"`. Codex's `Args()` and `Env()` both return `nil`, so nothing suppressed:

- the launch-time **"trust the current folder?"** prompt, or
- the **per-MCP-tool approval prompts** the operator hit on `list_recent_emails` / `get_email`.

This change extends `mergeCodexSandboxConfig` (ModeSandbox **only**) to also emit Codex's non-interactive keys:

- `approval_policy = "never"` — suppresses per-tool approval prompts.
- a `[projects."/home/agent/workspace"]` block with `trust_level = "trusted"` — pre-accepts the folder-trust prompt for the bind-mounted workspace, mirroring how Claude pre-sets `hasTrustDialogAccepted` for the same path (`claude_auth.go`).

The sandbox container is the trust boundary ([ADR-0015](https://github.com/ALRubinger/aileron/blob/main/docs/src/content/docs/adr/0015-launch-audit-scope.md)), and Aileron still mediates every action the agent calls through `aileron-mcp` + the gateway (the HITL approval chain is unaffected — it runs in the daemon, not in Codex). **Host mode is unchanged**: `configureHostMCP` keeps the user's own approval policy, sandbox, and folder-trust settings.

### Files changed
- `internal/launch/agents/codex.go` — emit the two new keys in `mergeCodexSandboxConfig`; new `codexSandboxWorkspacePath` const; updated doc comments (the old `Args()` comment claimed Aileron does not override approval policy).
- `internal/launch/agents/codex_test.go` — new `TestCodex_ConfigureMCP_SandboxMode_NonInteractiveKeys` regression test asserting all three keys.
- `internal/launch/agents/codex_auth_test.go` — extended `TestCodex_HostConfig_OmitsSandboxMode` to assert the new keys never leak into the host config.
- `docs/src/content/docs/development/sandbox-mcp-walkthrough.md` — new "Codex: sandbox runs non-interactively" note.

## Test plan

- `go test ./internal/launch/...` — all green (agents, launch, hostimport).
- New regression test fails before the change (the three keys are absent) and passes after.
- Host-untouched invariant (`TestCodex_ConfigureMCP_SandboxMode_DoesNotTouchHostConfig`) and no-user-MCP-leak invariant (`TestCodex_ConfigureMCP_SandboxMode_FreshFileNoUserEntries`) still pass.
- Verified the generated `config.toml` parses as valid TOML (`[projects."/home/agent/workspace"]` closes cleanly before `[mcp_servers.aileron]`).

Closes #1162

🤖 Generated with [Claude Code](https://claude.com/claude-code)
