### PR TITLE
fix(vault): omit raw rejected service from user-credential audit records

### DIFF
--- a/internal/app/handlers_local_vault_user.go
+++ b/internal/app/handlers_local_vault_user.go
@@ -53,9 +53,20 @@ func userCredentialVaultPath(service string) string {
 func (s *apiServer) emitVaultUserCredentialEvent(ctx context.Context, eventType model.EventType, service string, actor model.ActorRef, sessionID, errClass string) {
 	logArgs := []any{
 		"event", string(eventType),
-		"service", service,
-		"actor", actor.ID,
 	}
+	// service is the attacker-controlled `{service}` path parameter. The
+	// validation-failure handlers pass "" so the raw, unvalidated value is
+	// never stamped into the slog line or the audit payload: a rejected
+	// `{service}` may carry CR/LF or other control bytes that forge extra
+	// log fields, or be unbounded enough to bloat the audit record. On every
+	// other path service has already passed validateUserService (an anchored
+	// `^[a-z0-9][a-z0-9_-]*$` allow-list), so it is safe to record. Only the
+	// `failure.class` is kept for a rejected request, mirroring how the
+	// untrusted session header is dropped when it sanitizes to empty.
+	if service != "" {
+		logArgs = append(logArgs, "service", service)
+	}
+	logArgs = append(logArgs, "actor", actor.ID)
 	if sessionID != "" {
 		logArgs = append(logArgs, "session", sessionID)
 	}
@@ -73,8 +84,9 @@ func (s *apiServer) emitVaultUserCredentialEvent(ctx context.Context, eventType 
 	if s.auditRecorder == nil {
 		return
 	}
-	payload := map[string]any{
-		"aileron.vault.user.service": service,
+	payload := map[string]any{}
+	if service != "" {
+		payload["aileron.vault.user.service"] = service
 	}
 	if sessionID != "" {
 		payload["aileron.session.id"] = sessionID
@@ -99,7 +111,7 @@ func (s *apiServer) GetUserCredentials(w http.ResponseWriter, r *http.Request, s
 	if !validateUserService(service) {
 		writeError(w, http.StatusBadRequest, "invalid_request",
 			"service must match ^[a-z0-9][a-z0-9_-]*$")
-		s.emitVaultUserCredentialEvent(ctx, model.EventTypeVaultUserCredentialRead, service, actor, sessionID, "invalid_request")
+		s.emitVaultUserCredentialEvent(ctx, model.EventTypeVaultUserCredentialRead, "", actor, sessionID, "invalid_request")
 		return
 	}
 	if s.vault == nil {
@@ -142,7 +154,7 @@ func (s *apiServer) PutUserCredentials(w http.ResponseWriter, r *http.Request, s
 	if !validateUserService(service) {
 		writeError(w, http.StatusBadRequest, "invalid_request",
 			"service must match ^[a-z0-9][a-z0-9_-]*$")
-		s.emitVaultUserCredentialEvent(ctx, model.EventTypeVaultUserCredentialWrite, service, actor, sessionID, "invalid_request")
+		s.emitVaultUserCredentialEvent(ctx, model.EventTypeVaultUserCredentialWrite, "", actor, sessionID, "invalid_request")
 		return
 	}
 	if s.vault == nil {
@@ -198,7 +210,7 @@ func (s *apiServer) DeleteUserCredentials(w http.ResponseWriter, r *http.Request
 	if !validateUserService(service) {
 		writeError(w, http.StatusBadRequest, "invalid_request",
 			"service must match ^[a-z0-9][a-z0-9_-]*$")
-		s.emitVaultUserCredentialEvent(ctx, model.EventTypeVaultUserCredentialDelete, service, actor, sessionID, "invalid_request")
+		s.emitVaultUserCredentialEvent(ctx, model.EventTypeVaultUserCredentialDelete, "", actor, sessionID, "invalid_request")
 		return
 	}
 	if s.vault == nil {

--- a/internal/app/handlers_local_vault_user_test.go
+++ b/internal/app/handlers_local_vault_user_test.go
@@ -527,6 +527,41 @@ func TestUserCredentials_InvalidServiceOmitsRawServiceFromAudit(t *testing.T) {
 	}
 }
 
+// TestUserCredentials_SessionHeaderAttributesActor proves the optional
+// X-Aileron-Session-Id header attributes a user-credential operation to that
+// session: the actor ID and the `aileron.session.id` payload key both carry the
+// sanitized value, and the slog line records `session`. Mirrors the per-agent
+// session-attribution contract for the user namespace.
+func TestUserCredentials_SessionHeaderAttributesActor(t *testing.T) {
+	s, store, logBuf := newAuditingUserCredentialsServer(t, vault.NewMemVault())
+
+	body := api.AgentCredentials{Value: []byte(vaultCredentialSecret)}
+	raw, err := json.Marshal(body)
+	if err != nil {
+		t.Fatal(err)
+	}
+	req := httptest.NewRequest(http.MethodPut, "/v1/vault/user/github/credentials",
+		bytes.NewReader(raw))
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("X-Aileron-Session-Id", "sess-123")
+	rec := httptest.NewRecorder()
+	s.PutUserCredentials(rec, req, "github")
+	assertStatus(t, rec, http.StatusNoContent)
+
+	events := listVaultCredentialEvents(t, store)
+	ev := requireSingleEvent(t, events, model.EventTypeVaultUserCredentialWrite)
+	if ev.Actor.Type != model.ActorTypeService || ev.Actor.ID != "sess-123" {
+		t.Errorf("actor = %+v, want service/sess-123", ev.Actor)
+	}
+	if ev.Payload["aileron.session.id"] != "sess-123" {
+		t.Errorf("session id = %v, want sess-123", ev.Payload["aileron.session.id"])
+	}
+	if !strings.Contains(logBuf.String(), "session=sess-123") {
+		t.Errorf("slog line missing session attribution: %q", logBuf.String())
+	}
+	assertNoCredentialLeak(t, events, logBuf)
+}
+
 // --- 500 branches ---
 
 func TestGetUserCredentials_GetErrorReturns500(t *testing.T) {

--- a/internal/app/handlers_local_vault_user_test.go
+++ b/internal/app/handlers_local_vault_user_test.go
@@ -7,6 +7,7 @@ import (
 	"log/slog"
 	"net/http"
 	"net/http/httptest"
+	"strings"
 	"testing"
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
@@ -31,6 +32,9 @@ import (
 //   - Success Get/Put/Delete emit EventTypeVaultUserCredential* carrying
 //     `aileron.vault.user.service` and never `aileron.vault.agent` nor the
 //     credential bytes.
+//   - An invalid `{service}` failure event records only `failure.class` and
+//     omits the raw, attacker-controlled value from both
+//     `aileron.vault.user.service` and the slog line (#1156).
 
 func newUserCredentialsServer(t *testing.T, v vault.Vault) *apiServer {
 	t.Helper()
@@ -224,13 +228,13 @@ func TestValidateUserService(t *testing.T) {
 		{"github2", true},
 		{"2github", true},
 		{"", false},
-		{"GitHub", false},        // uppercase
-		{"-github", false},       // leading dash
-		{"_github", false},       // leading underscore
-		{"git hub", false},       // space
-		{"git/hub", false},       // slash
-		{"..", false},            // dot-dot
-		{"../agents", false},     // traversal
+		{"GitHub", false},    // uppercase
+		{"-github", false},   // leading dash
+		{"_github", false},   // leading underscore
+		{"git hub", false},   // space
+		{"git/hub", false},   // slash
+		{"..", false},        // dot-dot
+		{"../agents", false}, // traversal
 		{"agents/claude/oauth", false},
 		{"git.hub", false}, // dot not allowed
 	}
@@ -465,6 +469,62 @@ func TestUserCredentials_InvalidServiceEmitsFailureEvent(t *testing.T) {
 	ev := requireSingleEvent(t, events, model.EventTypeVaultUserCredentialRead)
 	assertFailureClass(t, ev, "invalid_request")
 	assertNoCredentialLeak(t, events, logBuf)
+}
+
+// TestUserCredentials_InvalidServiceOmitsRawServiceFromAudit is the #1156
+// regression: the rejected `{service}` is fully attacker-controlled, so its
+// validation-failure event must record only `failure.class` and never stamp
+// the raw value into `aileron.vault.user.service` or the slog line. The probe
+// carries CR/LF, a NUL, a forged-field marker, and an over-long tail — bytes
+// that, if recorded, would inject extra log fields or bloat the audit record.
+// Before the fix every verb stamped the raw value; this fails then, passes now.
+func TestUserCredentials_InvalidServiceOmitsRawServiceFromAudit(t *testing.T) {
+	const marker = "forged.field=evil"
+	malicious := "BAD\r\n" + marker + "\x00" + strings.Repeat("z", 4096)
+
+	putBody, err := json.Marshal(api.AgentCredentials{Value: []byte("x")})
+	if err != nil {
+		t.Fatalf("marshal put body: %v", err)
+	}
+
+	cases := []struct {
+		name string
+		ev   model.EventType
+		do   func(s *apiServer)
+	}{
+		{"GET", model.EventTypeVaultUserCredentialRead, func(s *apiServer) {
+			req := httptest.NewRequest(http.MethodGet, "/v1/vault/user/x/credentials", nil)
+			s.GetUserCredentials(httptest.NewRecorder(), req, malicious)
+		}},
+		{"PUT", model.EventTypeVaultUserCredentialWrite, func(s *apiServer) {
+			req := httptest.NewRequest(http.MethodPut, "/v1/vault/user/x/credentials",
+				bytes.NewReader(putBody))
+			req.Header.Set("Content-Type", "application/json")
+			s.PutUserCredentials(httptest.NewRecorder(), req, malicious)
+		}},
+		{"DELETE", model.EventTypeVaultUserCredentialDelete, func(s *apiServer) {
+			req := httptest.NewRequest(http.MethodDelete, "/v1/vault/user/x/credentials", nil)
+			s.DeleteUserCredentials(httptest.NewRecorder(), req, malicious)
+		}},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			s, store, logBuf := newAuditingUserCredentialsServer(t, vault.NewMemVault())
+			c.do(s)
+
+			events := listVaultCredentialEvents(t, store)
+			ev := requireSingleEvent(t, events, c.ev)
+			assertFailureClass(t, ev, "invalid_request")
+
+			if got, ok := ev.Payload["aileron.vault.user.service"]; ok {
+				t.Errorf("rejected service stamped into audit payload: %v", got)
+			}
+			if strings.Contains(logBuf.String(), marker) {
+				t.Errorf("raw rejected service leaked into slog line: %q", logBuf.String())
+			}
+		})
+	}
 }
 
 // --- 500 branches ---


### PR DESCRIPTION
## Summary

Fixes an audit-hygiene gap in the user-level vault credential endpoint (`/v1/vault/user/{service}/credentials`, shipped in #1147 / PR #1161), surfaced as the audit-hygiene finding in review-residual **#1156**.

On a `{service}` validation failure, all three verbs (GET/PUT/DELETE) passed the **raw, unvalidated, attacker-controlled** `{service}` to `emitVaultUserCredentialEvent`, which stamped it verbatim into:
- the audit payload key `aileron.vault.user.service`, and
- the `slog` line (`service=...`).

A `{service}` carrying CR/LF or other control bytes could forge extra log fields / audit-record lines; an unbounded value could bloat the record. The codebase already established this hygiene boundary for the untrusted `X-Aileron-Session-Id` header (`sanitizeSessionID`) but hadn't applied equivalent handling to the rejected `{service}`.

### Fix
- The three validation-failure branches now pass `""` instead of the raw `service`, so only `failure.class=invalid_request` is recorded for a rejection.
- `emitVaultUserCredentialEvent` omits the service field from both the log args and the payload when it's empty (mirroring the existing `sessionID != ""` omit).
- **Post-validation paths are unchanged**: by the time any other event fires, `service` has already passed the anchored `^[a-z0-9][a-z0-9_-]*$` allow-list, so it's safe to record (success events still carry `aileron.vault.user.service`).

This is scoped to the audit DECISION finding. The residual's second open finding (a one-line OpenAPI prose note that the empty-value PUT 400 carries `invalid_request`) is cosmetic and left for the autofix-on sweep — hence this PR `Resolves` the security finding but does not close #1156.

## Test plan

- **New regression test** `TestUserCredentials_InvalidServiceOmitsRawServiceFromAudit` drives an injection probe (`"BAD\r\n" + "forged.field=evil" + "\x00" + 4096×"z"`) through GET/PUT/DELETE and asserts the failure event omits `aileron.vault.user.service` and the marker never reaches the slog buffer.
  - **Verified fail-before / pass-after**: reverted the handler change → all three sub-tests fail (raw value in payload + log); re-applied → green.
- `go test ./internal/app/` — pass (16.8s). `go vet` clean. `gofmt` clean.
- Coverage: changed handler verbs 100%, `emitVaultUserCredentialEvent` 90.9% (remaining gap is the pre-existing nil-recorder branch); package total 82.3%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
