### PR TITLE
fix(sandbox): re-pull floating published tags under auto

### DIFF
--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -137,7 +137,7 @@ Launch uses `--sandbox-build=auto` by default. Build policy options are:
 
 | Policy | Behavior |
 |---|---|
-| `auto` | Use the selected image if it already exists locally; build Tier 0/Tier 1 images only when missing. |
+| `auto` | Use the selected image if it already exists locally; build Tier 0/Tier 1 images only when missing. A published image carrying a floating tag (`edge`/`latest`) is always re-pulled so it re-resolves to the current upstream digest each launch; version-pinned published tags are cached locally. |
 | `always` | Rebuild Tier 0/Tier 1 images before validation and launch. |
 | `never` | Do not build; fail with an actionable error if the selected image is missing locally. |
 

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -326,7 +326,13 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 			}
 			return result, nil
 		case BuildPolicyAuto:
-			if b.imageExists(ctx, runner, runtimeName, result.Image) {
+			// A floating tag (edge/latest) keeps its name while its upstream
+			// digest moves, so a stale local copy would permanently satisfy the
+			// existence check and `auto` would never re-pull. Only honor the
+			// existence short-circuit for version-pinned tags; floating tags fall
+			// through to the pull below so they re-resolve to the current digest
+			// each launch (issue #1174).
+			if !isFloatingTag(result.Image) && b.imageExists(ctx, runner, runtimeName, result.Image) {
 				return result, nil
 			}
 		}
@@ -372,6 +378,40 @@ func (b Builder) shouldBuild(ctx context.Context, runner Runner, runtimeName, im
 	default:
 		return false, fmt.Errorf("unsupported sandbox build policy %q (want auto, always, or never)", policy)
 	}
+}
+
+// isFloatingTag reports whether an image reference carries a floating tag
+// (`edge` or `latest`) whose upstream digest can move while the tag name stays
+// fixed. The composition layer assigns these tags (composition.imageTag), so a
+// local copy of a floating tag can go stale silently. Version-pinned tags (and
+// digest references) are stable, so callers may safely cache them; floating tags
+// must re-pull under `auto` to track the current digest (issue #1174).
+//
+// The tag is the segment after the last `:` that follows the final `/` (so a
+// registry host:port prefix like `ghcr.io:443/x` is not mistaken for a tag).
+// A reference with no tag segment defaults to `latest`, matching Docker's own
+// implicit-tag behavior, and is therefore treated as floating.
+func isFloatingTag(image string) bool {
+	switch parseImageTag(image) {
+	case "edge", "latest":
+		return true
+	default:
+		return false
+	}
+}
+
+// parseImageTag extracts the tag segment from an image reference. It returns the
+// substring after the last `:` that appears after the final `/`, or `latest`
+// when the reference carries no tag (Docker's implicit default).
+func parseImageTag(image string) string {
+	ref := image
+	if slash := strings.LastIndex(ref, "/"); slash != -1 {
+		ref = ref[slash+1:]
+	}
+	if colon := strings.LastIndex(ref, ":"); colon != -1 {
+		return ref[colon+1:]
+	}
+	return "latest"
 }
 
 func (b Builder) imageExists(ctx context.Context, runner Runner, runtimeName, image string) bool {

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -441,15 +441,49 @@ func TestBuildBYOImageDoesNotBuild(t *testing.T) {
 
 const publishedImage = "ghcr.io/alrubinger/aileron-sandbox-claude:latest"
 
+// publishedPinnedImage is a version-pinned published-image reference. Its tag is
+// stable (the upstream digest never moves under a pinned tag), so a local copy
+// may be cached under `auto` (issue #1174).
+const publishedPinnedImage = "ghcr.io/alrubinger/aileron-sandbox-claude:v0.0.42"
+
+// publishedEdgeImage carries the floating `edge` tag, whose upstream digest
+// moves while the tag name stays fixed (issue #1174).
+const publishedEdgeImage = "ghcr.io/alrubinger/aileron-sandbox-claude:edge"
+
+func TestIsFloatingTag(t *testing.T) {
+	cases := []struct {
+		image string
+		want  bool
+	}{
+		{"ghcr.io/alrubinger/aileron-sandbox-claude:latest", true},
+		{"ghcr.io/alrubinger/aileron-sandbox-claude:edge", true},
+		{"ghcr.io/alrubinger/aileron-sandbox-claude:v0.0.42", false},
+		{"ghcr.io/alrubinger/aileron-sandbox-claude:0.0.42", false},
+		// No tag segment defaults to latest → floating.
+		{"ghcr.io/alrubinger/aileron-sandbox-claude", true},
+		// A registry host:port prefix with no tag is not mistaken for a tag.
+		{"localhost:5000/aileron-sandbox-claude", true},
+		// A registry host:port prefix plus a pinned tag.
+		{"localhost:5000/aileron-sandbox-claude:v1.2.3", false},
+		// A registry host:port prefix plus a floating tag.
+		{"localhost:5000/aileron-sandbox-claude:edge", true},
+	}
+	for _, c := range cases {
+		if got := isFloatingTag(c.image); got != c.want {
+			t.Errorf("isFloatingTag(%q) = %v, want %v", c.image, got, c.want)
+		}
+	}
+}
+
 func TestBuildPublishedAutoPullsMissingImage(t *testing.T) {
-	// image inspect fails (absent) → pull.
+	// A pinned image absent locally → inspect (fails) → pull.
 	runner := &callRecordingRunner{errs: []error{errors.New("missing"), nil}}
 	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
 		WorkDir: t.TempDir(),
 		Policy:  BuildPolicyAuto,
 		Plan: composition.Plan{
 			Tier:  composition.TierPublished,
-			Image: publishedImage,
+			Image: publishedPinnedImage,
 		},
 	})
 	if err != nil {
@@ -458,41 +492,76 @@ func TestBuildPublishedAutoPullsMissingImage(t *testing.T) {
 	if result.Built {
 		t.Fatalf("result.Built = true, want false (a pull is not a local build)")
 	}
-	if result.Image != publishedImage {
-		t.Fatalf("result.Image = %q, want %q", result.Image, publishedImage)
+	if result.Image != publishedPinnedImage {
+		t.Fatalf("result.Image = %q, want %q", result.Image, publishedPinnedImage)
 	}
 	if result.Tier != composition.TierPublished {
 		t.Fatalf("result.Tier = %q, want %q", result.Tier, composition.TierPublished)
 	}
 	want := []runnerCall{
-		{name: "docker", args: []string{"image", "inspect", publishedImage}},
-		{name: "docker", args: []string{"pull", publishedImage}},
+		{name: "docker", args: []string{"image", "inspect", publishedPinnedImage}},
+		{name: "docker", args: []string{"pull", publishedPinnedImage}},
 	}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
 	}
 }
 
-func TestBuildPublishedAutoSkipsExistingImage(t *testing.T) {
-	// image inspect succeeds (present) → no pull.
+func TestBuildPublishedAutoSkipsExistingPinnedImage(t *testing.T) {
+	// A version-pinned tag is present locally → no pull (its digest never moves).
 	runner := &callRecordingRunner{}
 	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
 		WorkDir: t.TempDir(),
 		Policy:  BuildPolicyAuto,
 		Plan: composition.Plan{
 			Tier:  composition.TierPublished,
-			Image: publishedImage,
+			Image: publishedPinnedImage,
 		},
 	})
 	if err != nil {
 		t.Fatalf("Build: %v", err)
 	}
-	if result.Image != publishedImage {
-		t.Fatalf("result.Image = %q, want %q", result.Image, publishedImage)
+	if result.Image != publishedPinnedImage {
+		t.Fatalf("result.Image = %q, want %q", result.Image, publishedPinnedImage)
 	}
-	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", publishedImage}}}
+	want := []runnerCall{{name: "docker", args: []string{"image", "inspect", publishedPinnedImage}}}
 	if !reflect.DeepEqual(runner.calls, want) {
 		t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+	}
+}
+
+// TestBuildPublishedAutoRepullsExistingFloatingImage is the issue #1174
+// regression: a floating tag (edge/latest) that is already present locally must
+// still pull under `auto`, because its upstream digest can have moved. The fix
+// skips the existence short-circuit for floating tags, so no `image inspect`
+// probe happens and the build goes straight to `pull`.
+func TestBuildPublishedAutoRepullsExistingFloatingImage(t *testing.T) {
+	for _, image := range []string{publishedImage, publishedEdgeImage} {
+		t.Run(image, func(t *testing.T) {
+			runner := &callRecordingRunner{}
+			result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+				WorkDir: t.TempDir(),
+				Policy:  BuildPolicyAuto,
+				Plan: composition.Plan{
+					Tier:  composition.TierPublished,
+					Image: image,
+				},
+			})
+			if err != nil {
+				t.Fatalf("Build: %v", err)
+			}
+			if result.Built {
+				t.Fatalf("result.Built = true, want false (a pull is not a local build)")
+			}
+			if result.Image != image {
+				t.Fatalf("result.Image = %q, want %q", result.Image, image)
+			}
+			// Floating tags skip the inspect probe and pull unconditionally.
+			want := []runnerCall{{name: "docker", args: []string{"pull", image}}}
+			if !reflect.DeepEqual(runner.calls, want) {
+				t.Fatalf("calls = %#v, want %#v", runner.calls, want)
+			}
+		})
 	}
 }
 


### PR DESCRIPTION
## Summary

The published-image pull path's `auto` build policy short-circuited on a local `docker image inspect` for any tag (`internal/sandbox/container/runtime.go`). Floating tags `edge`/`latest` (assigned by `composition.imageTag`) keep their names while their upstream digest moves, so a stale local copy permanently satisfied the existence check and `auto` never re-pulled.

This change classifies the tag carried in `result.Image` as floating (`edge`/`latest`) vs version-pinned, and in the `auto` published branch only honors the `imageExists` short-circuit for pinned tags. Floating tags fall through to the existing `docker pull` so they re-resolve to the current digest each launch.

- New testable helper `isFloatingTag` (+ `parseImageTag`): tag is the segment after the last `:` following the final `/`, defaulting to `latest` when absent (Docker's implicit default), which is treated as floating.
- Pinned-tag caching and `never`/`always` behavior are unchanged.
- Intent tradeoff honored: an offline launch of a floating tag now errors instead of using the stale copy.

## Test plan

- `TestIsFloatingTag` covers floating/pinned/no-tag/`host:port` registry-prefix cases.
- `TestBuildPublishedAutoRepullsExistingFloatingImage` (regression for #1174): a floating tag present locally still pulls under `auto`, skipping the inspect probe. Verified it FAILS before the fix and PASSES after.
- `TestBuildPublishedAutoSkipsExistingPinnedImage`: a pinned tag present locally is cached (no pull) — retargeted from the old `:latest` no-pull assertion.
- `TestBuildPublishedAutoPullsMissingImage`: retargeted to a pinned tag (missing → inspect → pull).
- Docs: updated the `auto` policy row in `docs/.../development/sandbox-composition.md`.
- `go test ./internal/sandbox/container/ -count=1` green; `go vet` clean.

Closes #1174

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Documentation**
  * Updated sandbox-build policy documentation to clarify how images are refreshed based on tag type.

* **Improvements**
  * Floating image tags (such as `edge` and `latest`) are now re-pulled on each launch to ensure the latest upstream changes are captured. Version-pinned image tags remain cached locally and reused across launches for efficiency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->