### PR TITLE
fix(test): assert partial order on approval/execution audit chain

### DIFF
--- a/internal/app/handlers_actions_test.go
+++ b/internal/app/handlers_actions_test.go
@@ -11,8 +11,8 @@ import (
 	"net/http/httptest"
 	"os"
 	"path/filepath"
-	"testing"
 	"strings"
+	"testing"
 	"time"
 
 	"github.com/ALRubinger/aileron/internal/action"
@@ -852,6 +852,185 @@ func eventTypesForSession(t *testing.T, store *audit.MemStore, sessionID string)
 	return out
 }
 
+// assertApprovedExecutionChain verifies the partial order that the system
+// actually guarantees for an approved action's audit chain.
+//
+// The chain is written by two goroutines with no happens-before on their
+// audit-store writes: ActionApprovalQueue.Decide emits approval.approved,
+// and a broadcast subscriber launches executeApprovedAction, which emits
+// execution.started then execution.succeeded. Approval causally gates
+// execution, but the two goroutines' audit-store writes have no ordering
+// guarantee relative to each other, so approval.approved may appear anywhere
+// after approval.requested, including after execution.succeeded. Asserting a
+// fixed [requested, approved, started, succeeded] sequence is therefore flaky.
+//
+// The contract this enforces:
+//   - the four event types present are exactly {approval.requested,
+//     approval.approved, execution.started, execution.succeeded};
+//   - approval.requested is first;
+//   - execution.started appears before execution.succeeded (by index);
+//   - approval.approved is present and appears after approval.requested.
+//
+// It deliberately makes no assertion about approval.approved's position
+// relative to the execution events. The optional label prefixes failure
+// messages (e.g. "approval \"id\" ") when several chains are checked in a loop.
+func assertApprovedExecutionChain(t *testing.T, label string, chain []model.EventType) {
+	t.Helper()
+
+	want := map[model.EventType]bool{
+		model.EventTypeApprovalRequested:  true,
+		model.EventTypeApprovalApproved:   true,
+		model.EventTypeExecutionStarted:   true,
+		model.EventTypeExecutionSucceeded: true,
+	}
+	if len(chain) != len(want) {
+		t.Fatalf("%schain = %v; want 4 events {approval.requested, approval.approved, execution.started, execution.succeeded}", label, chain)
+	}
+
+	idx := make(map[model.EventType]int, len(chain))
+	for i, ev := range chain {
+		if !want[ev] {
+			t.Errorf("%schain has unexpected event %s; chain = %v", label, ev, chain)
+		}
+		if _, dup := idx[ev]; dup {
+			t.Errorf("%schain has duplicate event %s; chain = %v", label, ev, chain)
+		}
+		idx[ev] = i
+	}
+	for ev := range want {
+		if _, ok := idx[ev]; !ok {
+			t.Errorf("%schain is missing event %s; chain = %v", label, ev, chain)
+		}
+	}
+	if t.Failed() {
+		return
+	}
+
+	if chain[0] != model.EventTypeApprovalRequested {
+		t.Errorf("%schain[0] = %s; want %s first", label, chain[0], model.EventTypeApprovalRequested)
+	}
+	if idx[model.EventTypeExecutionStarted] >= idx[model.EventTypeExecutionSucceeded] {
+		t.Errorf("%sexecution.started (idx %d) must precede execution.succeeded (idx %d); chain = %v",
+			label, idx[model.EventTypeExecutionStarted], idx[model.EventTypeExecutionSucceeded], chain)
+	}
+	if idx[model.EventTypeApprovalApproved] <= idx[model.EventTypeApprovalRequested] {
+		t.Errorf("%sapproval.approved (idx %d) must follow approval.requested (idx %d); chain = %v",
+			label, idx[model.EventTypeApprovalApproved], idx[model.EventTypeApprovalRequested], chain)
+	}
+}
+
+// TestAssertApprovedExecutionChain pins the contract of the partial-order
+// assertion shared by the approval round-trip tests. It is the regression
+// guard for feedback #1168: the helper must accept the observed flaky order
+// (approval.approved persisted after execution.succeeded) while still
+// rejecting chains that violate the order the system genuinely guarantees.
+func TestAssertApprovedExecutionChain(t *testing.T) {
+	cases := []struct {
+		name    string
+		chain   []model.EventType
+		wantErr bool
+	}{
+		{
+			name: "canonical order",
+			chain: []model.EventType{
+				model.EventTypeApprovalRequested,
+				model.EventTypeApprovalApproved,
+				model.EventTypeExecutionStarted,
+				model.EventTypeExecutionSucceeded,
+			},
+		},
+		{
+			// The exact interleaving observed flaking on the CI gate: the
+			// background executor's events land before the Decide path's
+			// approval.approved write. This MUST pass.
+			name: "approved persisted after succeeded",
+			chain: []model.EventType{
+				model.EventTypeApprovalRequested,
+				model.EventTypeExecutionStarted,
+				model.EventTypeExecutionSucceeded,
+				model.EventTypeApprovalApproved,
+			},
+		},
+		{
+			name: "approved persisted between execution events",
+			chain: []model.EventType{
+				model.EventTypeApprovalRequested,
+				model.EventTypeExecutionStarted,
+				model.EventTypeApprovalApproved,
+				model.EventTypeExecutionSucceeded,
+			},
+		},
+		{
+			name: "missing approval.approved",
+			chain: []model.EventType{
+				model.EventTypeApprovalRequested,
+				model.EventTypeExecutionStarted,
+				model.EventTypeExecutionSucceeded,
+			},
+			wantErr: true,
+		},
+		{
+			name: "missing execution.started",
+			chain: []model.EventType{
+				model.EventTypeApprovalRequested,
+				model.EventTypeApprovalApproved,
+				model.EventTypeExecutionSucceeded,
+			},
+			wantErr: true,
+		},
+		{
+			name: "succeeded before started",
+			chain: []model.EventType{
+				model.EventTypeApprovalRequested,
+				model.EventTypeApprovalApproved,
+				model.EventTypeExecutionSucceeded,
+				model.EventTypeExecutionStarted,
+			},
+			wantErr: true,
+		},
+		{
+			name: "approval.requested not first",
+			chain: []model.EventType{
+				model.EventTypeApprovalApproved,
+				model.EventTypeApprovalRequested,
+				model.EventTypeExecutionStarted,
+				model.EventTypeExecutionSucceeded,
+			},
+			wantErr: true,
+		},
+		{
+			name: "unexpected event present",
+			chain: []model.EventType{
+				model.EventTypeApprovalRequested,
+				model.EventTypeApprovalApproved,
+				model.EventTypeExecutionStarted,
+				model.EventTypeApprovalDenied,
+			},
+			wantErr: true,
+		},
+	}
+
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// Run the assertion against a throwaway *testing.T in its own
+			// goroutine: the helper's t.Fatalf path calls runtime.Goexit,
+			// which would otherwise abort this subtest before we can read
+			// the result. The closure returns only after Goexit (via the
+			// deferred close), so fake.Failed() is safe to read afterward.
+			fake := &testing.T{}
+			done := make(chan struct{})
+			go func() {
+				defer close(done)
+				assertApprovedExecutionChain(fake, "", tc.chain)
+			}()
+			<-done
+			if got := fake.Failed(); got != tc.wantErr {
+				t.Errorf("assertApprovedExecutionChain(%v) failed=%v; want failed=%v", tc.chain, got, tc.wantErr)
+			}
+		})
+	}
+}
+
 // TestRunAction_NoApproval_EmitsExecutionStartedAndSucceeded covers
 // R6 / R7 for the synchronous path: a non-approval action invoked via
 // /v1/actions/{name}/run lands an execution.started → execution.succeeded
@@ -1042,21 +1221,13 @@ func TestRunAction_Approval_FullChainEmitsApprovalAndExecutionEvents(t *testing.
 		time.Sleep(10 * time.Millisecond)
 	}
 
+	// approval.approved (Decide path) and the execution events (background
+	// executor goroutine) are written to the audit store by two goroutines
+	// with no ordering guarantee, so approval.approved can land anywhere after
+	// approval.requested — including after execution.succeeded. Assert the
+	// partial order the system guarantees rather than a fixed sequence.
 	chain := eventTypesForSession(t, store, "sess-u8-approval")
-	want := []model.EventType{
-		model.EventTypeApprovalRequested,
-		model.EventTypeApprovalApproved,
-		model.EventTypeExecutionStarted,
-		model.EventTypeExecutionSucceeded,
-	}
-	if len(chain) != len(want) {
-		t.Fatalf("event chain for session = %v; want %v", chain, want)
-	}
-	for i, w := range want {
-		if chain[i] != w {
-			t.Errorf("chain[%d] = %s; want %s", i, chain[i], w)
-		}
-	}
+	assertApprovedExecutionChain(t, "", chain)
 }
 
 // TestRunAction_Approval_Denied_OmitsExecutionEvents pins R6a's deny

--- a/internal/app/sandbox_mcp_test.go
+++ b/internal/app/sandbox_mcp_test.go
@@ -717,26 +717,12 @@ func TestSandboxMCP_Approval_RoundTripsWithApprovedDecide(t *testing.T) {
 
 	waitForChain(t, h.auditStore, sessionID, model.EventTypeExecutionSucceeded, 5*time.Second)
 
+	// Approval causally gates execution, but approval.approved (Decide path)
+	// and the execution events (background executor goroutine) are written to
+	// the audit store by two goroutines with no ordering guarantee, so assert
+	// only the partial order the system actually provides.
 	chain := eventChainForSession(t, h.auditStore, sessionID)
-	if len(chain) != 4 {
-		t.Fatalf("event chain = %v; want 4 events (approval.requested, approval.approved, execution.started, execution.succeeded)", chain)
-	}
-	// approval.requested is always first and execution.succeeded always last.
-	// The middle pair (approval.approved from the Decide path, execution.started
-	// from the background executor goroutine) is emitted from two goroutines with
-	// no guaranteed audit-write ordering, so assert it as an unordered set rather
-	// than a fixed sequence. Approval still causally precedes execution; only the
-	// two log writes may interleave.
-	if chain[0] != model.EventTypeApprovalRequested {
-		t.Errorf("chain[0] = %s; want %s", chain[0], model.EventTypeApprovalRequested)
-	}
-	if chain[3] != model.EventTypeExecutionSucceeded {
-		t.Errorf("chain[3] = %s; want %s", chain[3], model.EventTypeExecutionSucceeded)
-	}
-	middle := map[model.EventType]bool{chain[1]: true, chain[2]: true}
-	if !middle[model.EventTypeApprovalApproved] || !middle[model.EventTypeExecutionStarted] {
-		t.Errorf("chain middle = [%s %s]; want {approval.approved, execution.started} in either order", chain[1], chain[2])
-	}
+	assertApprovedExecutionChain(t, "", chain)
 }
 
 // TestSandboxMCP_Denied exercises R6a: when the user denies the
@@ -1014,26 +1000,11 @@ func TestSandboxMCP_Concurrency_DistinctApprovalsAttributedCorrectly(t *testing.
 
 	for _, entry := range pending {
 		waitForApprovalChain(t, h.auditStore, entry.ID, model.EventTypeExecutionSucceeded, 5*time.Second)
+		// Each approval's chain must be its own complete sequence. As above,
+		// approval.approved and the execution events come from two goroutines
+		// with no audit-write ordering guarantee, so assert the partial order.
 		chain := eventChainForApproval(t, h.auditStore, entry.ID)
-		if len(chain) != 4 {
-			t.Fatalf("approval %q chain = %v; want 4 events (approval.requested, approval.approved, execution.started, execution.succeeded)", entry.ID, chain)
-		}
-		// approval.requested is always first and execution.succeeded always last.
-		// The middle pair (approval.approved from the Decide path, execution.started
-		// from the background executor goroutine) is emitted from two goroutines
-		// with no guaranteed audit-write ordering, so assert it as an unordered set
-		// rather than a fixed sequence. Approval still causally precedes execution;
-		// only the two log writes may interleave.
-		if chain[0] != model.EventTypeApprovalRequested {
-			t.Errorf("approval %q chain[0] = %s; want %s", entry.ID, chain[0], model.EventTypeApprovalRequested)
-		}
-		if chain[3] != model.EventTypeExecutionSucceeded {
-			t.Errorf("approval %q chain[3] = %s; want %s", entry.ID, chain[3], model.EventTypeExecutionSucceeded)
-		}
-		middle := map[model.EventType]bool{chain[1]: true, chain[2]: true}
-		if !middle[model.EventTypeApprovalApproved] || !middle[model.EventTypeExecutionStarted] {
-			t.Errorf("approval %q chain middle = [%s %s]; want {approval.approved, execution.started} in either order", entry.ID, chain[1], chain[2])
-		}
+		assertApprovedExecutionChain(t, fmt.Sprintf("approval %q ", entry.ID), chain)
 	}
 
 	// The executor ran exactly twice, once per call, with the two


### PR DESCRIPTION
## Summary

`TestSandboxMCP_Approval_RoundTripsWithApprovedDecide` intermittently failed on the blocking **Integration Tests (Go)** gate (seen on PR #1161, a re-run went green). It is a test-assertion bug, not a product bug.

The approved-action audit chain is written by two goroutines with no happens-before on their audit-store writes:

- `ActionApprovalQueue.Decide` (`internal/approval/action_queue.go`) emits `approval.approved`.
- A broadcast subscriber launches `go executeApprovedAction` (`internal/app/app.go`), which emits `execution.started` then `execution.succeeded`.

Approval causally gates execution and all four events are always emitted, but the audit-write interleaving is nondeterministic, so `approval.approved` can be persisted after `execution.succeeded`. Three tests over-specified this by pinning array positions.

This is the decided Option A from #1168: relax the assertions to the partial order the system actually guarantees. Option B (production-side causal ordering) is explicitly out of scope.

## Changes

- New shared test helper `assertApprovedExecutionChain(t, label, chain)` asserts: set equality over `{approval.requested, approval.approved, execution.started, execution.succeeded}`; `approval.requested` first; `execution.started` before `execution.succeeded` by index; `approval.approved` present and after `approval.requested`. It makes no assertion about `approval.approved`'s position relative to the execution events.
- Replaced the three over-strict assertions with the helper:
  - `internal/app/sandbox_mcp_test.go` — `TestSandboxMCP_Approval_RoundTripsWithApprovedDecide` (the one that flaked) and the multi-approval isolation test.
  - `internal/app/handlers_actions_test.go` — `TestRunAction_Approval_FullChainEmitsApprovalAndExecutionEvents` (was the strictest, exact-sequence loop).
- Updated the misleading in-code comments to state the true contract.
- Other `for i, w := range want` chain checks were audited and left as-is: they are pure-execution chains (single goroutine, deterministic) or deny paths (no execution events).

No production code changed.

## Test plan

- `go test ./internal/app/` — full package green.
- `go vet ./internal/app/` and `go vet -tags integration_sandbox ./internal/app/` — both clean; tagged tests compile.
- New `TestAssertApprovedExecutionChain` is the regression guard: the observed flaky order `[requested, started, succeeded, approved]` passes, while chains missing any of the four events, with `succeeded` before `started`, with `requested` not first, or with an unexpected event still fail.

Closes #1168

🤖 Generated with [Claude Code](https://claude.com/claude-code)
