### PR TITLE
fix(launch): allocate a PTY for the gh device-flow login exec

### DIFF
--- a/cmd/aileron/auth_github.go
+++ b/cmd/aileron/auth_github.go
@@ -13,7 +13,22 @@ import (
 	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 	"github.com/ALRubinger/aileron/internal/version"
+
+	"golang.org/x/term"
 )
+
+// stdinIsTerminal reports whether the operator's stdin is a real
+// terminal. It is a package var so tests can drive both branches.
+// gh's interactive device-flow login renders a prompt through a
+// prompt library that requires a pseudo-TTY; the login exec therefore
+// needs `docker exec -t`. We gate on a real stdin so a non-TTY / CI
+// caller does not hit docker's "cannot enable tty mode on non tty
+// input" — they get a plain `exec -i` instead (which will not complete
+// an interactive login, but fails cleanly rather than mis-allocating a
+// PTY).
+var stdinIsTerminal = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
 
 // deviceFlowRunner performs gh's OAuth device-authorization flow and
 // returns the captured user-to-server bearer token bytes. It is a seam
@@ -163,13 +178,26 @@ func (c *containerDeviceFlow) Capture(ctx context.Context) ([]byte, error) {
 	// wired to the host terminal by the Runner so the operator can read
 	// the prompt. HTTPS only — never configure SSH (-p https). Output is
 	// surfaced so the operator sees gh's instructions.
-	loginArgs := []string{
-		"exec", "-i", c.containerName,
+	//
+	// gh's prompt needs a pseudo-TTY, so the exec gets `-t` when stdin
+	// is a real terminal. Without it `gh auth login --web` hangs with no
+	// visible prompt (the prompt library never renders). `-i` and `-t`
+	// are passed as separate args so the Runner's interactiveTTYRun gate
+	// matches `-t` and hands the child the controlling terminal's
+	// foreground process group — required because the Runner isolates
+	// the docker child into its own process group, where docker's
+	// raw-mode tcsetattr would otherwise fail with SIGTTOU/EINTR.
+	loginArgs := []string{"exec", "-i"}
+	if stdinIsTerminal() {
+		loginArgs = append(loginArgs, "-t")
+	}
+	loginArgs = append(loginArgs,
+		c.containerName,
 		"gh", "auth", "login",
 		"--hostname", "github.com",
 		"--git-protocol", "https",
 		"--web",
-	}
+	)
 	if err := c.runner.Run(ctx, c.runtimeExe, loginArgs, os.Stdout, os.Stderr); err != nil {
 		return nil, fmt.Errorf("gh auth login: %w", err)
 	}

--- a/cmd/aileron/auth_github_test.go
+++ b/cmd/aileron/auth_github_test.go
@@ -392,6 +392,82 @@ func TestContainerDeviceFlow_UsesOneSharedContainerForBothGHCalls(t *testing.T) 
 	}
 }
 
+// TestContainerDeviceFlow_LoginExecAllocatesTTYWithStdin is the
+// regression guard for #1165: `gh auth login --web` renders an
+// interactive prompt that needs a pseudo-TTY, so the login exec must
+// carry `-t` when the operator's stdin is a real terminal (without it
+// the command hangs with no visible prompt). A non-terminal / CI stdin
+// must NOT get `-t` (docker rejects a PTY on non-tty input), and the
+// non-interactive token read must never allocate a PTY. `-i` and `-t`
+// must be separate args so the Runner's interactiveTTYRun gate matches.
+func TestContainerDeviceFlow_LoginExecAllocatesTTYWithStdin(t *testing.T) {
+	loginAndTokenArgs := func(t *testing.T, isTTY bool) (login, token []string) {
+		t.Helper()
+		orig := stdinIsTerminal
+		stdinIsTerminal = func() bool { return isTTY }
+		t.Cleanup(func() { stdinIsTerminal = orig })
+
+		rr := &recordingRunner{token: "gho_tok"}
+		flow := &containerDeviceFlow{
+			runner:        rr,
+			runtimeExe:    "docker",
+			image:         "img",
+			containerName: "aileron-auth-github",
+		}
+		if _, err := flow.Capture(context.Background()); err != nil {
+			t.Fatalf("Capture: %v", err)
+		}
+		for _, c := range rr.calls {
+			if len(c) == 0 || c[0] != "exec" {
+				continue
+			}
+			_, gh := parseExecArgs(c)
+			switch gh.sub {
+			case "login":
+				login = c
+			case "token":
+				token = c
+			}
+		}
+		return login, token
+	}
+
+	hasFlag := func(args []string, f string) bool {
+		for _, a := range args {
+			if a == f {
+				return true
+			}
+		}
+		return false
+	}
+
+	t.Run("terminal stdin allocates a PTY for the login exec", func(t *testing.T) {
+		login, token := loginAndTokenArgs(t, true)
+		if !hasFlag(login, "-t") {
+			t.Errorf("login exec = %v; want a standalone -t (PTY) flag when stdin is a terminal", login)
+		}
+		if !hasFlag(login, "-i") {
+			t.Errorf("login exec = %v; want -i", login)
+		}
+		if hasFlag(login, "-it") {
+			t.Errorf("login exec = %v; -i and -t must be separate args (not -it) so interactiveTTYRun matches -t", login)
+		}
+		if hasFlag(token, "-t") {
+			t.Errorf("token exec = %v; the non-interactive token read must not allocate a PTY", token)
+		}
+	})
+
+	t.Run("non-terminal stdin omits the PTY flag", func(t *testing.T) {
+		login, _ := loginAndTokenArgs(t, false)
+		if hasFlag(login, "-t") {
+			t.Errorf("login exec = %v; want NO -t when stdin is not a terminal (docker rejects a PTY on non-tty input)", login)
+		}
+		if !hasFlag(login, "-i") {
+			t.Errorf("login exec = %v; want -i even without a terminal", login)
+		}
+	})
+}
+
 func TestContainerDeviceFlow_TearsDownOnLoginFailure(t *testing.T) {
 	// A runner that fails the login exec but records all calls, so we can
 	// assert the deferred teardown still ran.

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -115,12 +115,16 @@ var stdinIsTerminal = func() bool {
 }
 
 // interactiveTTYRun reports whether args describe an interactive
-// container `run` that allocates a pseudo-TTY (`-t`). Only such a run
-// needs the runtime child to own the terminal's foreground process
-// group. Image builds (`build -t <tag>`) and non-TTY runs do not — the
-// `run` verb gate keeps the `-t` build-tag flag from matching.
+// container `run` or `exec` that allocates a pseudo-TTY (`-t`). Only
+// such a command needs the runtime child to own the terminal's
+// foreground process group — without it docker's raw-mode tcsetattr
+// runs from a background group and fails with SIGTTOU/EINTR. Both the
+// interactive `run -t` (an agent shell) and `exec -t` (the gh
+// device-flow login in `aileron auth github`) need this. Image builds
+// (`build -t <tag>`) do not — the verb gate keeps the `-t` build-tag
+// flag from matching.
 func interactiveTTYRun(args []string) bool {
-	if len(args) == 0 || args[0] != "run" {
+	if len(args) == 0 || (args[0] != "run" && args[0] != "exec") {
 		return false
 	}
 	for _, a := range args {

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -55,6 +55,8 @@ func TestInteractiveTTYRun(t *testing.T) {
 	}{
 		{"run with tty", []string{"run", "--rm", "-i", "-t", "img", "claude"}, true},
 		{"run without tty", []string{"run", "--rm", "-i", "img", "claude"}, false},
+		{"exec with tty", []string{"exec", "-i", "-t", "c", "gh", "auth", "login"}, true},
+		{"exec without tty", []string{"exec", "-i", "c", "gh", "auth", "token"}, false},
 		{"build with tag flag is not a tty run", []string{"build", "-t", "img", "-f", "Dockerfile", "."}, false},
 		{"image inspect", []string{"image", "inspect", "img"}, false},
 		{"empty args", nil, false},

--- a/internal/sandbox/container/sysproc_unix_test.go
+++ b/internal/sandbox/container/sysproc_unix_test.go
@@ -106,6 +106,9 @@ func TestConfigureRuntimeChildGating(t *testing.T) {
 		{"interactive run on terminal", []string{"run", "--rm", "-i", "-t", "img", "claude"}, true, true},
 		{"interactive run without terminal", []string{"run", "--rm", "-i", "-t", "img", "claude"}, false, false},
 		{"non-tty run on terminal", []string{"run", "--rm", "-i", "img", "claude"}, true, false},
+		{"interactive exec on terminal", []string{"exec", "-i", "-t", "c", "gh", "auth", "login"}, true, true},
+		{"interactive exec without terminal", []string{"exec", "-i", "-t", "c", "gh", "auth", "login"}, false, false},
+		{"non-tty exec on terminal", []string{"exec", "-i", "c", "gh", "auth", "token"}, true, false},
 		{"build on terminal", []string{"build", "-t", "img", "."}, true, false},
 	}
 	for _, tc := range cases {


### PR DESCRIPTION
## Summary

`aileron auth github` (the gh OAuth device-flow capture shipped in #1148) **hung with no visible prompt**. Root cause: `gh auth login --web` renders an interactive prompt through a library that requires a pseudo-TTY, but the login ran as `docker exec -i` (stdin wired, **no `-t`**), so the prompt never rendered and the command blocked forever. Confirmed live: a manual `docker exec -it … gh auth login --web` renders the prompt (`? Authenticate Git with your GitHub credentials?`); the same exec without `-t` hangs.

This is the confirmed fix for the held P1 finding in residual #1165 (umbrella #1145).

### The two-part fix
1. **`cmd/aileron/auth_github.go`** — add `-t` to the login exec, but **only when the operator's stdin is a real terminal** (`stdinIsTerminal`). CI / non-TTY callers keep a plain `-i`, because docker rejects a PTY on non-tty input. `-i` and `-t` are passed as **separate args** (not `-it`) so the Runner's gate can match `-t`.
2. **`internal/sandbox/container/runtime.go`** — broaden `interactiveTTYRun` to recognize an interactive `exec -t`, not just `run -t`. Without this the docker child (which the Runner deliberately isolates into its own process group for Ctrl-C handling) never receives the controlling terminal's foreground process group, and docker's raw-mode `tcsetattr` fails from a background group with `SIGTTOU`/`EINTR`. This is precisely why a manual `docker exec -it` worked (the shell foregrounds it) but aileron's child did not.

The non-interactive `gh auth token` read is untouched (it captures stdout and must not allocate a PTY).

## Test plan
- **New regression test** `TestContainerDeviceFlow_LoginExecAllocatesTTYWithStdin` (`cmd/aileron`): asserts the login exec carries a standalone `-t` when stdin is a terminal, omits it when not, keeps `-i` in both cases, never folds into `-it`, and never adds `-t` to the token read. Fails before this change (login exec never had `-t`), passes after.
- **`TestInteractiveTTYRun`** (`internal/sandbox/container`): added `exec -t` → true and `exec` (no `-t`) → false cases.
- **`TestConfigureRuntimeChildGating`** (`internal/sandbox/container`): added interactive `exec -t` on/off-terminal and non-tty `exec` cases, asserting the foreground handoff fires only for `exec -t` on a real terminal.
- `go build`, `go vet`, `gofmt -l`, and full `go test ./cmd/aileron/ ./internal/sandbox/container/` all clean. No go.mod changes (`golang.org/x/term` already a direct dep). No generated code touched.
- **Manual:** verified the `-it` exec renders gh's prompt in the live container; the end-to-end `aileron auth github` re-run (with this fix) is the final confirmation, which the operator will run.

Closes #1165

🤖 Generated with [Claude Code](https://claude.com/claude-code)
