### PR TITLE
docs(sandbox): document binary==agent-id conflation in sandbox check

### DIFF
--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -186,6 +186,15 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 	// published per-agent image the launcher would (launch/check parity). With
 	// no .devcontainer and a published agent, this plans TierPublished and the
 	// build step pulls (or inspects) the per-agent image.
+	//
+	// NOTE: `command` does double duty here. It is both the PATH binary validated
+	// in-image AND the agent-id key Discover passes to PublishedAgentExists ->
+	// recipeForAgent (agentRecipes is keyed by agent id: "claude", "codex"). That
+	// only works because binary == id for every agent today. A future agent whose
+	// PATH binary differs from its recipe id would not match agentRecipes, so
+	// Discover would silently fall back to TierBase and lose launch/check
+	// parity. If such an agent is added, thread the binary and the agent id
+	// separately into Discover instead of relying on this conflation.
 	plan, err := sandboxcomposition.Discover(cwd, version.Version, command)
 	if err != nil {
 		fmt.Fprintf(stderr, "error: %v\n", err)


### PR DESCRIPTION
## Summary

`runSandboxCheck` (cmd/aileron/sandbox.go) passes the free-form `command` (a PATH binary) as the agent-id key into `Discover -> PublishedAgentExists -> recipeForAgent`, which is keyed by agent id (`agentRecipes` claude/codex in recipes.go). This works only because `binary == id` for every agent today. The existing comment explained the launch/check parity intent but did not document the conflation.

This PR extends the comment at the `Discover` call site to make the dual role of `command` explicit and to flag the silent `TierBase` fallback a future agent whose binary differs from its recipe id would hit. Comment-only addition, no behavior change.

Resolves the sole remaining actionable finding from review-residual #1127 (sub-issue #1087).

## Test plan

- `go build ./cmd/aileron/` — passes
- `go test ./cmd/aileron/ ./internal/sandbox/composition/` — passes
- No behavior change, so no new tests; the change is documentation at a call site.

Closes #1127

🤖 Generated with [Claude Code](https://claude.com/claude-code)