### PR TITLE
fix(launch): silence gh's failed browser-open in the device-flow login

### DIFF
--- a/cmd/aileron/auth_github.go
+++ b/cmd/aileron/auth_github.go
@@ -191,6 +191,15 @@ func (c *containerDeviceFlow) Capture(ctx context.Context) ([]byte, error) {
 	if stdinIsTerminal() {
 		loginArgs = append(loginArgs, "-t")
 	}
+	// Point gh's browser-open at a no-op. The container ships no browser,
+	// so gh's default open (xdg-open / x-www-browser / wslview) fails with
+	// a noisy "executable file not found in $PATH" that reads like an
+	// error even though the device flow is fine — the operator just opens
+	// the printed URL on the host. BROWSER=echo turns the open step into a
+	// clean success that reprints the verification URL at the exact moment
+	// the operator needs it. Passed as a single `--env=K=V` token so it
+	// stays a `-`-prefixed exec flag (the arg parsing skips those).
+	loginArgs = append(loginArgs, "--env=BROWSER=echo")
 	loginArgs = append(loginArgs,
 		c.containerName,
 		"gh", "auth", "login",

--- a/cmd/aileron/auth_github_test.go
+++ b/cmd/aileron/auth_github_test.go
@@ -468,6 +468,53 @@ func TestContainerDeviceFlow_LoginExecAllocatesTTYWithStdin(t *testing.T) {
 	})
 }
 
+// TestContainerDeviceFlow_LoginSilencesBrowserOpen guards the browser
+// no-op: the capture container ships no browser, so gh's default
+// open-in-browser step fails with a noisy "executable file not found"
+// that reads like an error. The login exec sets BROWSER=echo (as a
+// single `--env=K=V` token so it stays a `-`-prefixed flag) to make the
+// open a clean no-op. The non-interactive token read must not carry it.
+func TestContainerDeviceFlow_LoginSilencesBrowserOpen(t *testing.T) {
+	rr := &recordingRunner{token: "gho_tok"}
+	flow := &containerDeviceFlow{
+		runner:        rr,
+		runtimeExe:    "docker",
+		image:         "img",
+		containerName: "aileron-auth-github",
+	}
+	if _, err := flow.Capture(context.Background()); err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+
+	has := func(args []string, want string) bool {
+		for _, a := range args {
+			if a == want {
+				return true
+			}
+		}
+		return false
+	}
+	var login, token []string
+	for _, c := range rr.calls {
+		if len(c) == 0 || c[0] != "exec" {
+			continue
+		}
+		_, gh := parseExecArgs(c)
+		switch gh.sub {
+		case "login":
+			login = c
+		case "token":
+			token = c
+		}
+	}
+	if !has(login, "--env=BROWSER=echo") {
+		t.Errorf("login exec = %v; want --env=BROWSER=echo to silence gh's failed browser-open", login)
+	}
+	if has(token, "--env=BROWSER=echo") {
+		t.Errorf("token exec = %v; the non-interactive token read must not set BROWSER", token)
+	}
+}
+
 func TestContainerDeviceFlow_TearsDownOnLoginFailure(t *testing.T) {
 	// A runner that fails the login exec but records all calls, so we can
 	// assert the deferred teardown still ran.


### PR DESCRIPTION
## Summary

Live-testing `aileron auth github` (now that #1177 fixed the TTY hang) surfaced a cosmetic-but-confusing wart: gh's device flow prints

```
! Failed opening a web browser at https://github.com/login/device
  exec: "xdg-open,x-www-browser,www-browser,wslview": executable file not found in $PATH
  Please try entering the URL in your browser manually
```

because the capture container ships no browser. The flow is fine — the operator opens the printed URL on the host — but the red error reads like a failure.

This sets `BROWSER=echo` on the login exec so gh's open step is a clean no-op that reprints the verification URL exactly when the operator needs to act, instead of erroring. The non-interactive `gh auth token` read is untouched.

Implementation note: passed as a single `--env=BROWSER=echo` token (not `--env BROWSER=echo`) so it stays a `-`-prefixed exec flag — the device-flow arg parsing and the Runner's `interactiveTTYRun` gate both skip/ignore `-`-prefixed flags, so the container-name parsing and the `-t` PTY gate are unaffected.

Follow-up to #1177 / residual context in #1165 (umbrella #1145). No issue closed; this is a polish discovered during the live verification of that fix.

## Test plan
- **New regression test** `TestContainerDeviceFlow_LoginSilencesBrowserOpen` (`cmd/aileron`): asserts the login exec carries `--env=BROWSER=echo` and the token read does not. Fails before this change, passes after.
- Existing `TestContainerDeviceFlow_*` (shared-container, TTY, teardown) still pass — `--env=BROWSER=echo` is correctly skipped by `parseExecArgs` as a leading flag, so container-name parsing is unchanged.
- `go build`, `go vet`, `gofmt -l`, `go test ./cmd/aileron/` all clean. No go.mod or generated-code changes.
- **Manual:** the prior run reached the device-flow prompt and produced a one-time code (TTY fix confirmed working); this change removes the spurious browser error from that same flow.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
