### PR TITLE
test(auth): guard cli-vs-daemon vault path drift for auth github

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -612,6 +612,21 @@ jobs:
         run: go test -tags=integration_sandbox -race -run TestSandboxMCP ./app/...
         working-directory: internal
 
+      - name: Run auth github route-drift guard (#1157)
+        # Guards against silent drift between the CLI's HARDCODED vault path
+        # in cmd/aileron/auth_github.go ("/vault/user/github/credentials") and
+        # the daemon's spec-registered route ("/v1/vault/user/{service}/
+        # credentials"). The build-tagged test stands up the real daemon
+        # handler over a MemVault, points runAuthGitHub at it with a stubbed
+        # device flow, and asserts the PUT resolves to the real handler (exit
+        # 0 / "Stored user/github") rather than 404/405. It is in-process with
+        # no external prereqs, so it never self-skips. Build-tagged
+        # (`integration`) so it stays out of the default unit suite; this
+        # dedicated step is the only place it runs. Additive step so a failure
+        # is attributable to this specific contract.
+        run: go test -tags=integration -race -run TestRunAuthGitHub_PUTReachesRealDaemonRoute .
+        working-directory: cmd/aileron
+
       - name: Stop server to flush coverage data
         if: ${{ !cancelled() }}
         run: docker compose -f deploy/docker-compose.yml -f deploy/docker-compose.coverage.yml stop server

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -347,6 +347,12 @@ tasks:
     cmds:
       - go test -tags=integration_sandbox -race -run TestSandboxMCP ./internal/app/...
 
+  test:integration:auth-github-route:
+    desc: "Run the auth github route-drift guard (#1157): stands up the real daemon handler over a MemVault and asserts the CLI's hardcoded vault path still resolves to the spec-registered route. In-process, no external prereqs (no self-skip)."
+    dir: cmd/aileron
+    cmds:
+      - go test -tags=integration -race -run TestRunAuthGitHub_PUTReachesRealDaemonRoute .
+
   test:integration:authspec-bindmount:
     desc: "Run the AuthSpec bind-mount writability integration test on a Linux Docker host (#988); self-skips on non-Linux or when no Docker runtime is on PATH"
     dir: internal

--- a/cmd/aileron/auth_github_route_integration_test.go
+++ b/cmd/aileron/auth_github_route_integration_test.go
@@ -1,0 +1,94 @@
+//go:build integration
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/app"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// TestRunAuthGitHub_PUTReachesRealDaemonRoute is the path-drift guard the
+// /cw-sweep decision (2026-06-18, issue #1157) called for. The CLI PUTs the
+// captured GitHub token to a HARDCODED string in auth_github.go
+// ("/vault/user/github/credentials", base URL supplies the "/v1" prefix),
+// while the daemon registers the route INDEPENDENTLY from the OpenAPI spec
+// via api.HandlerFromMux ("/v1/vault/user/{service}/credentials", backed by
+// userCredentialVaultPath in internal/app). The existing unit tests
+// (auth_github_test.go) re-encode the same hardcoded path into their fake
+// server, so they cannot catch the two drifting out of lockstep.
+//
+// This test closes that blind spot: it stands up the REAL daemon handler
+// (app.NewHandlerWithConfig, which registers the user-credentials route
+// through the generated mux derived from the spec) over a MemVault, points
+// the CLI at it, stubs the device flow so no container/GitHub is touched,
+// and asserts runAuthGitHub returns exit 0 with the success message — i.e.
+// the PUT resolved to the real PutUserCredentials handler and stored the
+// credential, NOT a 404 from a route mismatch.
+//
+// Because the request reaches the handler through the spec-derived mux,
+// changing userCredentialVaultPath or the spec's route template without
+// updating the CLI's hardcoded path reddens this test. It is build-tagged
+// (`integration`) so it stays out of the normal unit suite and runs in the
+// dedicated integration step instead; it has no external prerequisites
+// (pure in-process httptest), so it never self-skips.
+func TestRunAuthGitHub_PUTReachesRealDaemonRoute(t *testing.T) {
+	// The real daemon handler, with the user-credentials route registered
+	// from the OpenAPI spec and an unlocked in-memory vault behind it.
+	handler, err := app.NewHandlerWithConfig(
+		slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		app.Config{Vault: vault.NewMemVault()},
+	)
+	if err != nil {
+		t.Fatalf("NewHandlerWithConfig: %v", err)
+	}
+	srv := httptest.NewServer(handler)
+	t.Cleanup(srv.Close)
+
+	// Point the CLI's daemon client at the real handler. The "/v1" prefix
+	// lives in the base URL, matching production (bindingAPIBaseURL).
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+	t.Setenv("AILERON_TOKEN", "test-token")
+
+	// Stub the device flow so the test drives only the store path: no
+	// container, no GitHub. A real (non-empty) token so the empty-token
+	// guard does not short-circuit before the PUT.
+	withStubDeviceFlow(t, stubDeviceFlow{token: []byte("gho_routedrifttoken1234567890")}, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runAuthGitHub(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 (the PUT must resolve to the real daemon route, not 404); stderr=%s",
+			code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Stored user/github") {
+		t.Errorf("stdout = %q, want the success message confirming the credential was stored", stdout.String())
+	}
+
+	// Independently confirm the daemon actually holds the credential at the
+	// user/github route the CLI targeted: a GET against the same spec route
+	// must now return 200, proving the PUT landed (not silently 404'd).
+	req, err := http.NewRequestWithContext(context.Background(),
+		http.MethodGet, srv.URL+"/v1/vault/user/github/credentials", nil)
+	if err != nil {
+		t.Fatalf("build GET request: %v", err)
+	}
+	req.Header.Set("Authorization", "Bearer test-token")
+	resp, err := http.DefaultClient.Do(req)
+	if err != nil {
+		t.Fatalf("GET stored credential: %v", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		t.Errorf("GET user/github after store = %d, want 200 (the PUT did not land at the daemon route)",
+			resp.StatusCode)
+	}
+}


### PR DESCRIPTION
## Summary

Adds a build-tagged integration test that guards against silent drift between the CLI's hardcoded vault path and the daemon's spec-registered route — the only live item left on feedback #1157 (the operator's recorded /cw-sweep decision, 2026-06-18). All four original P1/P2 plan findings and the three predecessor issues (#1146, #1147, #1148) already shipped; the path-drift guard was the sole remainder, and the approach was pre-decided: a build-tagged integration test, not a shared constant, no production change.

The coupling this closes: `cmd/aileron/auth_github.go` PUTs the captured GitHub token to a hardcoded string `"/vault/user/github/credentials"` (the `/v1` prefix comes from the base URL), while the daemon registers the route independently from the OpenAPI spec via `api.HandlerFromMux` as `"/v1/vault/user/{service}/credentials"`, backed by `userCredentialVaultPath` in `internal/app`. The existing unit tests (`auth_github_test.go`) re-encode that same hardcoded path into their fake server, so they cannot catch the two drifting out of lockstep — exactly the blind spot the operator flagged.

## What the test does

`TestRunAuthGitHub_PUTReachesRealDaemonRoute` (build tag `integration`, package `main` under `cmd/aileron/`):

- Stands up the **real** daemon handler via `app.NewHandlerWithConfig` over a `vault.NewMemVault()` — this registers the user-credentials route through the generated mux derived from the spec.
- Serves it with `httptest.NewServer`, sets `AILERON_API_URL` to `srv.URL + "/v1"`.
- Stubs the device flow via the existing `withStubDeviceFlow` seam (fake token; no container, no GitHub).
- Calls `runAuthGitHub` and asserts exit 0 / `"Stored user/github"`, then GETs the same spec route and asserts 200 — proving the PUT resolved to the real handler, not a 404/405.

Because the request reaches the handler through the spec-derived mux (independent of the CLI's hardcoded string), changing `userCredentialVaultPath` or the spec route template without updating the CLI reddens the test.

It is build-tagged so it stays out of the default unit suite; a dedicated CI step (in the existing integration job) and a `test:integration:auth-github-route` Taskfile target run it. The test is fully in-process with no external prerequisites, so it never self-skips.

No production code changed. No shared-constant refactor.

## Test plan

- `go test -tags=integration -run TestRunAuthGitHub_PUTReachesRealDaemonRoute ./cmd/aileron/` — passes.
- Drift spot-check: temporarily mutated the generated PUT route template (`/v1/vault/user/{service}/credentials` -> `/v1/vault/user-moved/{service}/credentials`) and confirmed the test goes RED (`server returned 405: method not allowed`); reverted the generated file (no diff).
- `go test -race ./cmd/aileron/` (default suite, no tag) — green; the new test is correctly excluded.
- `go test -tags=integration -race ./cmd/aileron/` — green.
- `go vet -tags=integration ./cmd/aileron/` — clean.
- `coderabbit review --agent` — zero findings in the changed files.

Closes #1157

🤖 Generated with [Claude Code](https://claude.com/claude-code)
