### PR TITLE
docs(development): add v4 acceptance scorecard runbook

### DIFF
--- a/docs/src/content/docs/development/index.md
+++ b/docs/src/content/docs/development/index.md
@@ -18,6 +18,7 @@ If you're looking for end-user docs, the [Getting Started](/getting-started/) gu
 - [Sandbox Agent Images](/development/sandbox-agent-images/) — which agent commands are supported by the selected sandbox image and how to check them before launch.
 - [Sandbox Connector Specs](/development/sandbox-connector-specs/) — how installed connector specs drive data-plane operation validation in sandboxed launch sessions.
 - [Sandbox Proxy CLI Verification Matrix](/development/sandbox-proxy-cli-matrix/) — verify the v4 HTTPS proxy works with `curl`, `gh`, and `aws`; success and failure cases with expected audit events.
+- [v4 Acceptance Scorecard](/development/v4-acceptance/) — the living "is v4 done?" runbook and pass/fail scorecard mapped 1:1 to the v4 bar in issue #747, with the current verdict and what gates closure.
 - [Submitting Changes](/development/submitting-changes/) — branch and PR conventions, commit message format, ADR amendments, what gets reviewed.
 - [Adding an Agent](/development/adding-an-agent/) — how to wire a new AI coding agent into `aileron launch` via the `Agent` SPI.
 - [Sandbox Agent Auth](/development/sandbox-agent-auth/) — vault-backed credential injection for `aileron launch <agent> --sandbox=docker`: vault path scheme, per-agent envelope schemas, the in-container-login-then-snapshot flow, manual seeding via `aileron vault put`, and the recovery path.

--- a/docs/src/content/docs/development/v4-acceptance.md
+++ b/docs/src/content/docs/development/v4-acceptance.md
@@ -1,0 +1,65 @@
+---
+title: "v4 Acceptance Scorecard"
+description: "The living 'is v4 done?' runbook and pass/fail scorecard, mapped 1:1 to the v4 acceptance bar in issue #747."
+order: 11
+---
+
+This page is the living checkpoint for v4 delivery. It answers one question: is the containerized AI-native runtime done?
+
+The v4 bar comes from [issue #747](https://github.com/ALRubinger/aileron/issues/747): an agent launches in the sandbox, authenticates, exercises actions and connectors through the Aileron HTTPS data plane, and every flow is audited, verified across macOS, Linux, and Windows (Docker), for every supported agent, with a recorded walkthrough. Per the 2026-06-15 scope note, Docker is the only runtime on all three operating systems (Podman stays descoped), and verification is automated on Linux with a light per-agent manual smoke on macOS and Windows.
+
+This page orients and links. It does not duplicate the proof-out steps; those live in the walkthrough and auth pages below. Update the scorecard here as gating items move.
+
+## Current verdict
+
+**v4 is NOT yet delivered.** Two gating items are outstanding: the macOS and Windows manual smoke for the Manual E2E item ([#962](https://github.com/ALRubinger/aileron/issues/962)), and the demo script plus recorded walkthrough ([#852](https://github.com/ALRubinger/aileron/issues/852)). Everything else in the v4 bar is shipped.
+
+## How to prove v4 end-to-end
+
+The full launch, authenticate, exercise-actions-and-connectors-through-the-HTTPS-data-plane, and confirm-audit sequence is already written. Compose these pages rather than re-running ad hoc steps:
+
+1. **Launch and exercise the data plane.** The [Sandbox MCP Manual Verification Walkthrough](/development/sandbox-mcp-walkthrough/) walks an action end-to-end inside a v4 sandbox container through the agent's MCP transport, with a real connector and a HITL approval, and verifies the `approval.requested → approval.approved → execution.started → execution.succeeded` audit chain.
+2. **Authenticate the agent.** The [Sandbox Agent Auth](/development/sandbox-agent-auth/) page covers vault-backed credential injection for `aileron launch <agent> --sandbox=docker`: the vault path scheme, the per-agent envelope schemas, the in-container login-then-snapshot flow, and the recovery path.
+3. **Verify CLI traffic through the proxy.** The [Sandbox Proxy CLI Verification Matrix](/development/sandbox-proxy-cli-matrix/) verifies the v4 HTTPS proxy with `curl`, `gh`, and `aws`, with the expected audit events for each.
+
+### The supported matrix
+
+The v4 bar requires every supported agent on Docker across all three operating systems:
+
+| Agent | macOS Docker | Linux Docker | Windows Docker |
+|---|---|---|---|
+| Claude | manual smoke | automated (CI) | manual smoke |
+| Pi | manual smoke | automated (CI) | manual smoke |
+| Goose | manual smoke | automated (CI) | manual smoke |
+| OpenCode | manual smoke | automated (CI) | manual smoke |
+| Codex | manual smoke | automated (CI) | manual smoke |
+
+The Linux column is automated in CI (the per-agent MCP-registration matrix plus the `aileron-mcp`↔daemon round-trip, merged in PR [#1064](https://github.com/ALRubinger/aileron/pull/1064)), so those cells are green when CI is green and you do not hand-run them. The macOS and Windows columns are a light per-agent manual smoke (the agent lists `aileron` with `draft_email`), recorded in [#962](https://github.com/ALRubinger/aileron/issues/962), because GitHub-hosted mac and Windows runners cannot run Linux Docker containers. The walkthrough documents this split and the per-agent×runtime table in full, including the per-agent MCP registration mechanism and the Codex troubleshooting notes.
+
+## Acceptance scorecard
+
+This maps 1:1 to the "Verify and prove" bar in [#747](https://github.com/ALRubinger/aileron/issues/747). Status legend: ✅ done, ☐ pending.
+
+### Gating items (these gate v4 closure)
+
+| Item | Status | Notes |
+|---|---|---|
+| Integration test variants — in-container, never-approved, concurrency ([#960](https://github.com/ALRubinger/aileron/issues/960)) | ✅ | Merged via PR [#1037](https://github.com/ALRubinger/aileron/pull/1037) on 2026-06-13. |
+| Manual E2E ([#962](https://github.com/ALRubinger/aileron/issues/962)) | ☐ | Linux automated and green via PR [#1064](https://github.com/ALRubinger/aileron/pull/1064) for all five agents. macOS and Windows light per-agent smoke pending. Claude × macOS full round-trip done 2026-06-15. |
+| Demo script + recorded walkthrough ([#852](https://github.com/ALRubinger/aileron/issues/852)) | ☐ | Pending. |
+
+Two gating items remain open, so the verdict above is NOT yet delivered.
+
+### Non-gating items (visibly distinguished; these do NOT gate v4 closure)
+
+| Item | Status | Why it does not gate v4 |
+|---|---|---|
+| Agent auth v4.x deferral ([#1027](https://github.com/ALRubinger/aileron/issues/1027)) | ☐ | Now just [#1025](https://github.com/ALRubinger/aileron/issues/1025) (container integration test), explicitly v4.x. [#987](https://github.com/ALRubinger/aileron/issues/987) (read-only-FS EnvBinding) was re-parented to v5 [#1065](https://github.com/ALRubinger/aileron/issues/1065) on 2026-06-17. |
+| Platform packaging — Scoop, Homebrew ([#1094](https://github.com/ALRubinger/aileron/issues/1094)) | ✅ | Windows install via Scoop supports the v4 Windows requirement but does not gate closure. Closure gates on the runtime smoke ([#962](https://github.com/ALRubinger/aileron/issues/962)), not packaging. |
+
+## Sources
+
+- [Issue #747](https://github.com/ALRubinger/aileron/issues/747) — the v4 milestone, its "Verify and prove" bar, and the 2026-06-15 scope note this scorecard tracks.
+- [Sandbox MCP Manual Verification Walkthrough](/development/sandbox-mcp-walkthrough/) — the per-agent×runtime proof-out steps and the automated-Linux / manual-mac-Windows split.
+- [Sandbox Agent Auth](/development/sandbox-agent-auth/) — the authenticate step of the v4 bar.
+- [Sandbox Proxy CLI Verification Matrix](/development/sandbox-proxy-cli-matrix/) — the data-plane proxy verification with `curl`, `gh`, and `aws`.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -91,6 +91,7 @@ export const navigation: NavItem[] = [
       { label: 'Sandbox Composition', href: '/development/sandbox-composition/' },
       { label: 'Sandbox Agent Images', href: '/development/sandbox-agent-images/' },
       { label: 'Sandbox Connector Specs', href: '/development/sandbox-connector-specs/' },
+      { label: 'v4 Acceptance Scorecard', href: '/development/v4-acceptance/' },
       { label: 'Submitting Changes', href: '/development/submitting-changes/' }
     ]
   },


### PR DESCRIPTION
## Summary

Adds a single docs-only page under `docs/development/` that serves as the living "is v4 done?" runbook and pass/fail acceptance scorecard, derived from issue #747's "Verify and prove" bar and the 2026-06-15 scope note.

The page composes rather than duplicates:

- It orients and links to the existing `sandbox-mcp-walkthrough.md` (launch + exercise the data plane + audit chain), `sandbox-agent-auth.md` (authenticate), and `sandbox-proxy-cli-matrix.md` (proxy CLI verification), which already hold the full E2E steps.
- It lays out the supported agent×runtime matrix (Claude, Pi, Goose, OpenCode, Codex on Docker across macOS/Linux/Windows), honoring the automated-on-Linux (PR #1064) plus light-manual-smoke-on-macOS/Windows (#962) split documented in the walkthrough.
- It carries a pass/fail acceptance scorecard mapped 1:1 to the v4 bar, with gating items (#962 Manual E2E, #852 demo + recorded walkthrough) visibly separated from non-gating items (#1027 v4.x deferral, #1094 platform packaging).
- The current live verdict is recorded: v4 NOT yet delivered (two gating items outstanding).

The page is wired into the Development sidebar group in `navigation.ts` and the section index `development/index.md`.

This is docs-only: no spec changes, no code, no generated files, no coverage gate. The section index's "update both README and this section" note does not apply, since this is a new contributor-facing runbook, not a build-flag or binary change.

## Test plan

- `astro check` (`npm run check` in `docs/`): 0 errors, 0 warnings, 0 hints.
- `astro build` (`npm run build`): full site builds; `/development/v4-acceptance/index.html` emitted and all internal links resolve.
- `npm test` (docs unit tests): 8/8 pass.
- Writing voice: prose avoids em-dashes; the only remaining em-dashes are verbatim issue-title labels and the established `[Link] — description` Sources/index list convention used across the existing dev docs.

Closes #1187

🤖 Generated with [Claude Code](https://claude.com/claude-code)
