### PR TITLE
feat(sandbox): user-level host->credential binding table at TLS boundary

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -437,6 +437,16 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	server.bindings = bindingStore
 	server.oauth2Sessions = newOAuth2Sessions()
 
+	// --- Host->credential binding table (#1193) ---
+	// The user-level host-binding table is consulted at the TLS
+	// forward-proxy boundary when no connector spec matches a decrypted
+	// request (ADR-0019 launch passthrough). v1 has no config wire
+	// format yet (the launch/policy schema and authoring CLI are a
+	// follow-on); the daemon leaves server.hostBindings at its nil
+	// zero value, which preserves today's passthrough behavior exactly.
+	// A nil/empty binding.HostBindings never matches, so the regression
+	// path is the default until a config source populates the table.
+
 	// --- Scope-drift detection (#726) ---
 	// Hook fires after every successful connector install. If the
 	// installed manifest demands an OAuth scope the binding's recorded

--- a/internal/app/handlers.go
+++ b/internal/app/handlers.go
@@ -92,6 +92,7 @@ type apiServer struct {
 	localDaemonToken     string                        // local-daemon bearer token; empty disables local bearer auth
 	actionApprovalTTL    time.Duration                 // how long RunAction holds the response open before timing out; default 5m, configurable for tests
 	bindings             binding.Store                 // capability bindings (ADR-0006); nil when no vault is wired
+	hostBindings         binding.HostBindings          // user-level host->credential bindings at the TLS forward-proxy boundary (#1193); nil/empty = today's passthrough
 	specLoader           connectorSpecLoader           // installed connector operation specs for generated sandbox shims; nil loads from cstore.DefaultRoot
 	oauth2Sessions       *oauth2Sessions               // ADR-0006 server-driven OAuth dance state; lazy-initialized on first use
 	oauth2HTTPClient     *http.Client                  // for OAuth token exchanges; nil → http.DefaultClient

--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -2,6 +2,7 @@ package app
 
 import (
 	"bytes"
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
@@ -13,10 +14,12 @@ import (
 
 	api "github.com/ALRubinger/aileron/internal/api/gen"
 	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/binding"
 	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
 	"github.com/ALRubinger/aileron/internal/credential"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/sandbox/discovery"
+	"github.com/ALRubinger/aileron/internal/vault"
 )
 
 const connectorOperationNotProxyableMessage = "connector operation is not proxyable through the daemon HTTPS data plane; the spec lacks a required field (method, hosts, path) or uses an unsupported HTTP method"
@@ -511,6 +514,109 @@ func (s *apiServer) injectSandboxProxyCredential(w http.ResponseWriter, r *http.
 		return false
 	}
 	return true
+}
+
+// Stable reject reasons emitted when a host-binding match resolves to a
+// credential the daemon cannot inject. Wire identifiers carried in the
+// rejection audit payload (aileron.proxy.reject_reason) — never the
+// credential bytes or the credential-ref.
+const (
+	hostBindingRejectLockedVault           = "binding_locked_vault"
+	hostBindingRejectCredentialUnavailable = "binding_credential_unavailable"
+	hostBindingRejectUnsupportedScheme     = "binding_unsupported_scheme"
+)
+
+// injectSandboxProxyHostBindingCredential resolves the credential a
+// matched host binding points at (daemon-side, through the vault) and
+// injects it onto the upstream request per the binding's scheme. It
+// returns ok=true when the request is ready to dial upstream, or
+// ok=false and a stable reject reason when resolution or injection
+// fails closed.
+//
+// Resolution goes through credential.VaultResolver against the daemon's
+// vault keyed by hb.CredentialRef, so a locked or absent vault yields a
+// resolver error and the request fails closed (the caller writes a 5xx
+// to the in-container client). No secret bytes are logged, echoed into
+// the response body, or written into the audit payload.
+//
+// The scheme switch is the seam #1194 slots into: this PR implements
+// the `bearer` path concretely (mirroring injectSandboxProxyCredential's
+// Authorization: Bearer behavior) and rejects any other scheme as
+// unsupported until #1194's scheme-keyed injector replaces the switch.
+func (s *apiServer) injectSandboxProxyHostBindingCredential(ctx context.Context, req *http.Request, hb binding.HostBinding) (bool, string) {
+	if s.vault == nil {
+		return false, hostBindingRejectCredentialUnavailable
+	}
+	// The credential-ref's first segment is its kind (<kind>/<service>/<identity>).
+	expectedKind, _, _ := strings.Cut(hb.CredentialRef, "/")
+	resolver := &credential.VaultResolver{
+		Vault:        s.vault,
+		VaultPath:    hb.CredentialRef,
+		ExpectedKind: expectedKind,
+	}
+	cred, err := resolver.Resolve(ctx)
+	if err != nil {
+		if errors.Is(err, vault.ErrCredentialUnavailable) {
+			return false, hostBindingRejectLockedVault
+		}
+		return false, hostBindingRejectCredentialUnavailable
+	}
+	return applyHostBindingScheme(req, hb.Scheme, cred)
+}
+
+// applyHostBindingScheme applies the named injection scheme to the
+// upstream request using the resolved credential. This is the narrow
+// seam #1194's scheme-keyed injector replaces: its signature is
+// (req, scheme, cred) so the binding-match wiring is untouched when the
+// closed scheme set lands. v1 implements `bearer`; every other scheme
+// in binding.HostBindingSchemes is accepted at config time but rejected
+// here until #1194 fills it in, which fails closed rather than silently
+// passing an un-injected request upstream.
+func applyHostBindingScheme(req *http.Request, scheme string, cred credential.Credential) (bool, string) {
+	switch scheme {
+	case binding.SchemeBearer:
+		req.Header.Set("Authorization", "Bearer "+string(cred.Value))
+		return true, ""
+	default:
+		return false, hostBindingRejectUnsupportedScheme
+	}
+}
+
+// recordSandboxProxyBindingInjected emits sandbox.proxy.binding_injected
+// for a request that matched a host binding and was re-issued upstream
+// with the bound credential injected. The payload carries the matched
+// host pattern, scheme, and upstream destination/status; it never
+// carries the credential bytes or the credential-ref. nil-recorder safe
+// like its siblings.
+func (s *apiServer) recordSandboxProxyBindingInjected(r *http.Request, source, hostPattern, scheme string, upstream *url.URL, upstreamStatus int) string {
+	if s.auditRecorder == nil {
+		if s.newID != nil {
+			return s.newID()
+		}
+		return audit.DefaultIDFn()
+	}
+	payload := map[string]any{
+		"aileron.proxy.boundary":        "https_proxy",
+		"aileron.proxy.mediation":       "https_proxy",
+		"aileron.proxy.source":          source,
+		"aileron.proxy.decision":        "binding_injected",
+		"aileron.proxy.method":          r.Method,
+		"aileron.proxy.binding.host":    hostPattern,
+		"aileron.proxy.binding.scheme":  scheme,
+		"aileron.proxy.upstream.scheme": upstream.Scheme,
+		"aileron.proxy.upstream.host":   upstream.Host,
+		"aileron.proxy.upstream.path":   sandboxProxyUpstreamPath(upstream),
+		"aileron.proxy.upstream.status": upstreamStatus,
+	}
+	if sessionID := strings.TrimSpace(r.Header.Get("X-Aileron-Session-Id")); sessionID != "" {
+		payload["aileron.session.id"] = sessionID
+	}
+	return s.auditRecorder.RecordSuccess(
+		r.Context(),
+		model.EventTypeSandboxProxyBindingInjected,
+		model.ActorRef{Type: model.ActorTypeAgent, ID: "sandbox-proxy"},
+		payload,
+	)
 }
 
 func ptrNonEmpty(value string) *string {

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -173,6 +173,13 @@ func (s *apiServer) handleSandboxForwardProxyDecrypted(conn net.Conn, decrypted 
 	match, ok, err := s.matchSandboxForwardProxyOperation(decrypted.Method, upstream)
 	if err != nil {
 		if errors.Is(err, errSandboxForwardProxyAmbiguousOperation) {
+			// Precedence: connector-spec -> host-binding -> passthrough.
+			// An ambiguous connector-spec match yields no unique spec, so
+			// the host-binding table is consulted before passthrough,
+			// exactly as on the no-match branch below.
+			if s.routeSandboxForwardProxyHostBinding(conn, decrypted, auth, targetHost, upstream) {
+				return
+			}
 			s.passthroughSandboxForwardProxy(conn, decrypted, auth, targetHost, upstream)
 			return
 		}
@@ -181,6 +188,12 @@ func (s *apiServer) handleSandboxForwardProxyDecrypted(conn net.Conn, decrypted 
 		return
 	}
 	if !ok {
+		// Precedence: a unique connector-spec match wins (handled below);
+		// otherwise the host-binding table is consulted before falling to
+		// passthrough.
+		if s.routeSandboxForwardProxyHostBinding(conn, decrypted, auth, targetHost, upstream) {
+			return
+		}
 		s.passthroughSandboxForwardProxy(conn, decrypted, auth, targetHost, upstream)
 		return
 	}
@@ -198,6 +211,100 @@ func (s *apiServer) handleSandboxForwardProxyDecrypted(conn net.Conn, decrypted 
 		return
 	}
 	writeSandboxForwardProxyResponse(conn, auth.SessionID, targetHost, result.UpstreamStatus, derefString(result.ContentType), result.BodyBase64)
+}
+
+// routeSandboxForwardProxyHostBinding consults the user-level
+// host->credential binding table (#1193) for the decrypted request's
+// target host. It is called only when no unique connector spec matched,
+// so the precedence is connector-spec -> host-binding -> passthrough.
+//
+// On a binding match it resolves the bound credential daemon-side
+// (through the vault), injects it onto a fresh upstream request per the
+// binding's scheme, re-issues the request, and streams the response
+// back to the in-container client. The credential bytes never reach the
+// container: only the upstream status, headers, and body are written
+// back. On a resolve/inject failure the request fails closed with an
+// error response carrying no secret bytes, and a rejection is recorded;
+// passthrough is NOT taken for a bound host whose credential is
+// unavailable. It returns handled=false (without writing anything) only
+// when no binding matched, so the caller falls through to passthrough.
+//
+// The private-IP-literal refusal that guards the passthrough path is
+// applied here too: a bound host that is a private IP literal is
+// refused before any upstream dial, closing the same SSRF vector.
+func (s *apiServer) routeSandboxForwardProxyHostBinding(conn net.Conn, decrypted *http.Request, auth sandboxProxyAuth, targetHost string, upstream *url.URL) bool {
+	hostForMatch := targetHost
+	if h, _, err := net.SplitHostPort(targetHost); err == nil {
+		hostForMatch = h
+	}
+	hb, ok := s.hostBindings.Match(hostForMatch)
+	if !ok {
+		return false
+	}
+
+	if sandboxForwardProxyTargetIsPrivateIPLiteral(targetHost) {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "passthrough_target_not_allowed")
+		writeSandboxForwardProxyError(conn, http.StatusForbidden, auth.SessionID, targetHost, "sandbox proxy passthrough refuses private, loopback, or link-local IP literals")
+		return true
+	}
+
+	body, contentType, err := readSandboxForwardProxyRequestBody(decrypted)
+	if err != nil {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, sandboxForwardProxyBodyRejectReason(err))
+		writeSandboxForwardProxyError(conn, http.StatusRequestEntityTooLarge, auth.SessionID, targetHost, err.Error())
+		return true
+	}
+
+	var reqBody io.Reader
+	if body != nil {
+		reqBody = bytes.NewReader(body)
+	}
+	upstreamReq, err := http.NewRequestWithContext(decrypted.Context(), decrypted.Method, upstream.String(), reqBody)
+	if err != nil {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "binding_upstream_request_invalid")
+		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy host-binding upstream request is invalid")
+		return true
+	}
+	upstreamReq.ContentLength = int64(len(body))
+	copyPassthroughRequestHeaders(upstreamReq.Header, decrypted.Header)
+	if contentType != "" {
+		upstreamReq.Header.Set("Content-Type", contentType)
+	}
+
+	if injected, reason := s.injectSandboxProxyHostBindingCredential(decrypted.Context(), upstreamReq, hb); !injected {
+		status := http.StatusInternalServerError
+		if reason == hostBindingRejectUnsupportedScheme {
+			status = http.StatusForbidden
+		}
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, reason)
+		writeSandboxForwardProxyError(conn, status, auth.SessionID, targetHost, "sandbox proxy host-binding credential is unavailable")
+		return true
+	}
+
+	client := sandboxProxyHTTPClient(s.sandboxProxyClient)
+	resp, err := client.Do(upstreamReq)
+	if err != nil {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "binding_upstream_unreachable")
+		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy host-binding upstream unreachable")
+		return true
+	}
+	defer resp.Body.Close()
+
+	respBody, err := io.ReadAll(io.LimitReader(resp.Body, sandboxProxyMaxResponseBytes+1))
+	if err != nil {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "binding_upstream_read_failed")
+		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy host-binding upstream response read failed")
+		return true
+	}
+	if len(respBody) > sandboxProxyMaxResponseBytes {
+		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "binding_upstream_response_too_large")
+		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy host-binding upstream response exceeded size limit")
+		return true
+	}
+
+	s.recordSandboxProxyBindingInjected(decrypted, sandboxProxySourceTransparentConnectTLS, hb.HostPattern, hb.Scheme, upstream, resp.StatusCode)
+	writeSandboxForwardProxyPassthroughResponse(conn, auth.SessionID, targetHost, resp, respBody)
+	return true
 }
 
 // passthroughSandboxForwardProxy forwards a decrypted CONNECT/TLS

--- a/internal/app/sandbox_forward_proxy_host_binding_test.go
+++ b/internal/app/sandbox_forward_proxy_host_binding_test.go
@@ -1,0 +1,641 @@
+package app
+
+import (
+	"context"
+	"crypto/x509"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/binding"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+	"github.com/ALRubinger/aileron/internal/credential"
+	"github.com/ALRubinger/aileron/internal/model"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// hostBindingProxySetup wires an apiServer fronted by a CONNECT/TLS
+// intercepting proxy, with a configurable host-binding table, vault,
+// connector specs, and a stub upstream transport. Each scenario sets
+// only what it needs.
+type hostBindingProxySetup struct {
+	srv    *apiServer
+	client *http.Client
+}
+
+func newHostBindingProxySetup(t *testing.T, srv *apiServer) *hostBindingProxySetup {
+	t.Helper()
+	stateDir := t.TempDir()
+	caPEM := writeSandboxProxyTestCA(t, stateDir, "session-123")
+	srv.localDaemonToken = "daemon-token"
+	srv.sandboxProxyStateDir = stateDir
+
+	proxy := httptest.NewServer(srv.sandboxForwardProxyMiddleware(http.NotFoundHandler()))
+	t.Cleanup(proxy.Close)
+
+	roots := x509.NewCertPool()
+	if !roots.AppendCertsFromPEM(caPEM) {
+		t.Fatal("failed to append CA cert")
+	}
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	return &hostBindingProxySetup{
+		srv:    srv,
+		client: newSandboxForwardProxyClient(t, proxyURL, roots),
+	}
+}
+
+func mustVaultWith(t *testing.T, name, kind string, value []byte) vault.Vault {
+	t.Helper()
+	v := vault.NewMemVault()
+	if err := v.Put(context.Background(), name, value, vault.Metadata{Type: kind}); err != nil {
+		t.Fatalf("vault put: %v", err)
+	}
+	return v
+}
+
+func mustHostBindingTable(t *testing.T, host, ref, scheme string) binding.HostBindings {
+	t.Helper()
+	hb, err := binding.NewHostBinding(host, ref, scheme)
+	if err != nil {
+		t.Fatalf("NewHostBinding: %v", err)
+	}
+	return binding.HostBindings{hb}
+}
+
+// TestSandboxForwardProxy_HostBindingInjectsAndSealsCredential is the
+// happy path: a request whose host matches a binding gets the bound
+// credential injected daemon-side; the upstream sees the bearer token
+// but the in-container client never does, and a binding_injected audit
+// event is emitted with no secret bytes.
+func TestSandboxForwardProxy_HostBindingInjectsAndSealsCredential(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	var upstreamAuth, upstreamURL string
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-host-binding" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_secret")),
+		hostBindings:  mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "bearer"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			upstreamURL = req.URL.String()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.example.test/v1/resource?q=1")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, string(body))
+	}
+	if string(body) != `{"ok":true}` {
+		t.Errorf("body = %q, want upstream body verbatim", string(body))
+	}
+	if upstreamAuth != "Bearer hb_secret" {
+		t.Fatalf("upstream Authorization = %q, want Bearer hb_secret", upstreamAuth)
+	}
+	if upstreamURL != "https://api.example.test/v1/resource?q=1" {
+		t.Errorf("upstream URL = %q", upstreamURL)
+	}
+	// The in-container client must never see the raw token in any
+	// response header or body.
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			if strings.Contains(v, "hb_secret") {
+				t.Errorf("response header %s leaked credential: %q", k, v)
+			}
+		}
+	}
+	if strings.Contains(string(body), "hb_secret") {
+		t.Error("response body leaked credential")
+	}
+
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	evt := events[0]
+	if evt.EventType != model.EventTypeSandboxProxyBindingInjected {
+		t.Fatalf("event type = %q, want %q", evt.EventType, model.EventTypeSandboxProxyBindingInjected)
+	}
+	if got := evt.Payload["aileron.proxy.binding.host"]; got != "api.example.test" {
+		t.Errorf("binding.host = %v, want api.example.test", got)
+	}
+	if got := evt.Payload["aileron.proxy.binding.scheme"]; got != "bearer" {
+		t.Errorf("binding.scheme = %v, want bearer", got)
+	}
+	if got := evt.Payload["aileron.proxy.upstream.status"]; got != http.StatusOK {
+		t.Errorf("upstream.status = %v, want 200", got)
+	}
+	sandboxProxyBindingInjectedShape.validate(t, evt.Payload)
+	payloadJSON, _ := json.Marshal(evt.Payload)
+	for _, forbidden := range []string{"hb_secret", "api_key/github/octocat", "q=1"} {
+		if strings.Contains(string(payloadJSON), forbidden) {
+			t.Errorf("audit payload leaked %q: %s", forbidden, payloadJSON)
+		}
+	}
+}
+
+// TestSandboxForwardProxy_HostBindingNonMatchPassesThrough is the
+// regression guard: a host that matches no binding passes through
+// unchanged, injects nothing, and emits sandbox.proxy.passthrough.
+func TestSandboxForwardProxy_HostBindingNonMatchPassesThrough(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	var upstreamAuth string
+	var upstreamBody []byte
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-passthrough" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_secret")),
+		hostBindings:  mustHostBindingTable(t, "bound.example.test", "api_key/github/octocat", "bearer"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			upstreamBody, _ = io.ReadAll(req.Body)
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"text/plain"}},
+				Body:       io.NopCloser(strings.NewReader("verbatim")),
+			}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Post("https://other.example.test/echo", "application/json", strings.NewReader(`{"k":"v"}`))
+	if err != nil {
+		t.Fatalf("POST through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if string(body) != "verbatim" {
+		t.Errorf("body = %q, want verbatim", string(body))
+	}
+	if upstreamAuth != "" {
+		t.Errorf("upstream Authorization = %q, want empty (no binding match)", upstreamAuth)
+	}
+	if string(upstreamBody) != `{"k":"v"}` {
+		t.Errorf("upstream body = %q, want byte-for-byte", string(upstreamBody))
+	}
+
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyPassthrough {
+		t.Fatalf("event type = %q, want passthrough", events[0].EventType)
+	}
+}
+
+// TestSandboxForwardProxy_HostBindingLockedVaultFailsClosed asserts a
+// bound host whose vault is locked fails closed: no upstream dial, no
+// secret bytes anywhere, a binding_locked_vault rejection, and NOT a
+// passthrough.
+func TestSandboxForwardProxy_HostBindingLockedVaultFailsClosed(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	dialed := false
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-locked" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		// LockableVault constructed empty is locked: Get returns
+		// vault.ErrCredentialUnavailable.
+		vault:        vault.NewLockableVault(),
+		hostBindings: mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "bearer"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			dialed = true
+			t.Errorf("upstream must not be dialed when vault is locked; got %s", req.URL)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.example.test/v1/resource")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode < 500 {
+		t.Fatalf("status = %d, want fail-closed 5xx", resp.StatusCode)
+	}
+	if dialed {
+		t.Error("upstream was dialed despite locked vault")
+	}
+	if strings.Contains(string(body), "hb_secret") {
+		t.Error("response body leaked credential")
+	}
+
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	evt := events[0]
+	if evt.EventType != model.EventTypeSandboxProxyRejected {
+		t.Fatalf("event type = %q, want rejected", evt.EventType)
+	}
+	if got := evt.Payload["aileron.proxy.reject_reason"]; got != hostBindingRejectLockedVault {
+		t.Errorf("reject_reason = %v, want %q", got, hostBindingRejectLockedVault)
+	}
+	payloadJSON, _ := json.Marshal(evt.Payload)
+	if strings.Contains(string(payloadJSON), "hb_secret") {
+		t.Errorf("audit payload leaked credential: %s", payloadJSON)
+	}
+}
+
+// TestSandboxForwardProxy_HostBindingMissingCredentialFailsClosed
+// asserts a bound host whose credential is absent from the vault fails
+// closed without passthrough.
+func TestSandboxForwardProxy_HostBindingMissingCredentialFailsClosed(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-missing" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         vault.NewMemVault(), // empty: no entry at the ref path
+		hostBindings:  mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "bearer"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Errorf("upstream must not be dialed when credential is missing; got %s", req.URL)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.example.test/v1/resource")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode < 500 {
+		t.Fatalf("status = %d, want fail-closed 5xx", resp.StatusCode)
+	}
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != hostBindingRejectCredentialUnavailable {
+		t.Errorf("reject_reason = %v, want %q", got, hostBindingRejectCredentialUnavailable)
+	}
+}
+
+// TestSandboxForwardProxy_HostBindingUnsupportedSchemeFailsClosed
+// asserts a binding declaring a scheme in the closed set but not yet
+// implemented (the #1194 seam: e.g. `basic`) fails closed rather than
+// dialing upstream with an un-injected request.
+func TestSandboxForwardProxy_HostBindingUnsupportedSchemeFailsClosed(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-scheme" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_secret")),
+		hostBindings:  mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "basic"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Errorf("upstream must not be dialed for an unsupported scheme; got %s", req.URL)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.example.test/v1/resource")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != hostBindingRejectUnsupportedScheme {
+		t.Errorf("reject_reason = %v, want %q", got, hostBindingRejectUnsupportedScheme)
+	}
+}
+
+// TestSandboxForwardProxy_HostBindingUpstreamUnreachableFailsClosed
+// asserts a transport error after successful injection fails closed
+// with a 502 and a binding_upstream_unreachable rejection.
+func TestSandboxForwardProxy_HostBindingUpstreamUnreachableFailsClosed(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-unreachable" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_secret")),
+		hostBindings:  mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "bearer"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return nil, io.ErrUnexpectedEOF
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.example.test/v1/resource")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != "binding_upstream_unreachable" {
+		t.Errorf("reject_reason = %v, want binding_upstream_unreachable", got)
+	}
+}
+
+// TestSandboxForwardProxy_HostBindingResponseTooLargeFailsClosed
+// asserts the binding path caps the upstream response at the same 4 MiB
+// limit as the matched/credentialed connector path and the passthrough
+// path, failing closed with a 502.
+func TestSandboxForwardProxy_HostBindingResponseTooLargeFailsClosed(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	big := strings.Repeat("a", (4<<20)+1024)
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-too-large" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_secret")),
+		hostBindings:  mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "bearer"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/octet-stream"}},
+				Body:       io.NopCloser(strings.NewReader(big)),
+			}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.example.test/large")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusBadGateway {
+		t.Fatalf("status = %d, want 502", resp.StatusCode)
+	}
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != "binding_upstream_response_too_large" {
+		t.Errorf("reject_reason = %v, want binding_upstream_response_too_large", got)
+	}
+}
+
+// TestSandboxForwardProxy_HostBindingRefusesPrivateIPLiteral asserts a
+// bound host that is a private IP literal is refused before any dial,
+// closing the SSRF vector on the binding path exactly as on passthrough.
+func TestSandboxForwardProxy_HostBindingRefusesPrivateIPLiteral(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-ssrf" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_secret")),
+		hostBindings:  mustHostBindingTable(t, "169.254.169.254", "api_key/github/octocat", "bearer"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			t.Errorf("must not dial private IP literal; got %s", req.URL)
+			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://169.254.169.254/latest/meta-data/")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+
+	if resp.StatusCode != http.StatusForbidden {
+		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	}
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != "passthrough_target_not_allowed" {
+		t.Errorf("reject_reason = %v, want passthrough_target_not_allowed", got)
+	}
+}
+
+// TestSandboxForwardProxy_ConnectorSpecWinsOverHostBinding asserts
+// precedence: a request matching BOTH a connector-spec operation and a
+// host binding resolves via the connector spec (connector.proxy.proxied,
+// not sandbox.proxy.binding_injected).
+func TestSandboxForwardProxy_ConnectorSpecWinsOverHostBinding(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	var upstreamAuth string
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-precedence" }),
+		specLoader: func() ([]connectorspec.Spec, error) {
+			return []connectorspec.Spec{{
+				SchemaVersion: connectorspec.SchemaVersion,
+				Connector:     connectorspec.Connector{FQN: "github://acme/aileron-connector-linear", Version: "1.0.0"},
+				Tools: []connectorspec.Tool{{
+					Name: "linear",
+					Operations: []connectorspec.Operation{{
+						Name:       "issues.list",
+						Method:     http.MethodGet,
+						Path:       "/graphql",
+						Hosts:      []string{"api.example.test"},
+						Credential: "api_key",
+					}},
+				}},
+			}}, nil
+		},
+		// Connector-spec credential path uses the bindings store; the
+		// host-binding table also matches the same host. Spec must win.
+		bindings:     sandboxProxyTestBindingStore{resolver: sandboxProxyTestResolver{cred: credential.Credential{Kind: "api_key", Value: []byte("spec_token")}}},
+		vault:        mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_token")),
+		hostBindings: mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "bearer"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusAccepted,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.example.test/graphql?query=viewer")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusAccepted {
+		t.Fatalf("status = %d, want 202", resp.StatusCode)
+	}
+	if upstreamAuth != "Bearer spec_token" {
+		t.Fatalf("upstream Authorization = %q, want Bearer spec_token (connector spec wins)", upstreamAuth)
+	}
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeConnectorProxyProxied {
+		t.Fatalf("event type = %q, want connector.proxy.proxied (spec wins)", events[0].EventType)
+	}
+}
+
+// TestSandboxForwardProxy_AmbiguousSpecFallsToHostBinding asserts that
+// an ambiguous connector-spec match (no unique spec) falls to the
+// host-binding table before passthrough.
+func TestSandboxForwardProxy_AmbiguousSpecFallsToHostBinding(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	var upstreamAuth string
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-ambiguous" }),
+		specLoader: func() ([]connectorspec.Spec, error) {
+			// Two connectors declare the same (method, host, path), so the
+			// match is ambiguous and yields no unique spec.
+			op := connectorspec.Operation{
+				Name:   "issues.list",
+				Method: http.MethodGet,
+				Path:   "/graphql",
+				Hosts:  []string{"api.example.test"},
+			}
+			return []connectorspec.Spec{
+				{
+					SchemaVersion: connectorspec.SchemaVersion,
+					Connector:     connectorspec.Connector{FQN: "github://acme/connector-a", Version: "1.0.0"},
+					Tools:         []connectorspec.Tool{{Name: "a", Operations: []connectorspec.Operation{op}}},
+				},
+				{
+					SchemaVersion: connectorspec.SchemaVersion,
+					Connector:     connectorspec.Connector{FQN: "github://acme/connector-b", Version: "1.0.0"},
+					Tools:         []connectorspec.Tool{{Name: "b", Operations: []connectorspec.Operation{op}}},
+				},
+			}, nil
+		},
+		vault:        mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_token")),
+		hostBindings: mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "bearer"),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.example.test/graphql")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200", resp.StatusCode)
+	}
+	if upstreamAuth != "Bearer hb_token" {
+		t.Fatalf("upstream Authorization = %q, want Bearer hb_token (ambiguous spec falls to host binding)", upstreamAuth)
+	}
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyBindingInjected {
+		t.Fatalf("event type = %q, want binding_injected", events[0].EventType)
+	}
+}
+
+// TestSandboxForwardProxy_AmbiguousSpecNoBindingPassesThrough asserts
+// that with an ambiguous spec and no host binding for the target, the
+// request still falls through to passthrough (preserving prior
+// behavior).
+func TestSandboxForwardProxy_AmbiguousSpecNoBindingPassesThrough(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-ambiguous-passthrough" }),
+		specLoader: func() ([]connectorspec.Spec, error) {
+			op := connectorspec.Operation{
+				Name:   "issues.list",
+				Method: http.MethodGet,
+				Path:   "/graphql",
+				Hosts:  []string{"api.example.test"},
+			}
+			return []connectorspec.Spec{
+				{
+					SchemaVersion: connectorspec.SchemaVersion,
+					Connector:     connectorspec.Connector{FQN: "github://acme/connector-a", Version: "1.0.0"},
+					Tools:         []connectorspec.Tool{{Name: "a", Operations: []connectorspec.Operation{op}}},
+				},
+				{
+					SchemaVersion: connectorspec.SchemaVersion,
+					Connector:     connectorspec.Connector{FQN: "github://acme/connector-b", Version: "1.0.0"},
+					Tools:         []connectorspec.Tool{{Name: "b", Operations: []connectorspec.Operation{op}}},
+				},
+			}, nil
+		},
+		// Host binding table is empty for this host.
+		hostBindings: nil,
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.example.test/graphql")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	io.Copy(io.Discard, resp.Body)
+
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyPassthrough {
+		t.Fatalf("event type = %q, want passthrough", events[0].EventType)
+	}
+}

--- a/internal/app/sandbox_proxy_audit_shape_test.go
+++ b/internal/app/sandbox_proxy_audit_shape_test.go
@@ -192,6 +192,29 @@ var (
 		},
 	}
 
+	sandboxProxyBindingInjectedShape = sandboxProxyEventShape{
+		eventType: "sandbox.proxy.binding_injected",
+		requiredFields: []string{
+			"aileron.proxy.boundary",
+			"aileron.proxy.mediation",
+			"aileron.proxy.source",
+			"aileron.proxy.decision",
+			"aileron.proxy.method",
+			"aileron.proxy.binding.host",
+			"aileron.proxy.binding.scheme",
+			"aileron.proxy.upstream.scheme",
+			"aileron.proxy.upstream.host",
+			"aileron.proxy.upstream.path",
+			"aileron.proxy.upstream.status",
+		},
+		allowedFields: []string{
+			"aileron.session.id",
+		},
+		forbiddenSubstrs: []string{
+			"lin_secret", "Bearer ", "Authorization",
+		},
+	}
+
 	sandboxProxyDisabledShape = sandboxProxyEventShape{
 		eventType: "sandbox.proxy.disabled",
 		requiredFields: []string{
@@ -291,6 +314,43 @@ func TestSandboxProxyAuditShape_SandboxProxyPassthroughConforms(t *testing.T) {
 		t.Fatalf("event type = %q", events[0].EventType)
 	}
 	sandboxProxyPassthroughShape.validate(t, events[0].Payload)
+}
+
+func TestSandboxProxyAuditShape_SandboxProxyBindingInjectedConforms(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-shape-binding" }),
+	}
+	req := httptest.NewRequest(http.MethodConnect, "/", nil)
+	req.Header.Set("X-Aileron-Session-Id", "session-shape-test")
+	req.Method = http.MethodGet
+	upstream, _ := url.Parse("https://api.example.test/v1/resource")
+	srv.recordSandboxProxyBindingInjected(req, sandboxProxySourceTransparentConnectTLS, "*.example.test", "bearer", upstream, 200)
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyBindingInjected {
+		t.Fatalf("event type = %q", events[0].EventType)
+	}
+	sandboxProxyBindingInjectedShape.validate(t, events[0].Payload)
+}
+
+func TestSandboxProxyAuditShape_BindingInjectedNilRecorderIsIDSafe(t *testing.T) {
+	upstream, _ := url.Parse("https://api.example.test/v1/resource")
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	// With newID wired, the recorder mints from it.
+	srv := &apiServer{newID: func() string { return "minted-id" }}
+	if got := srv.recordSandboxProxyBindingInjected(req, sandboxProxySourceTransparentConnectTLS, "*.example.test", "bearer", upstream, 200); got != "minted-id" {
+		t.Errorf("audit id = %q, want minted-id", got)
+	}
+
+	// With no newID and no recorder, it falls back to the default ID fn.
+	srvNoID := &apiServer{}
+	if got := srvNoID.recordSandboxProxyBindingInjected(req, sandboxProxySourceTransparentConnectTLS, "*.example.test", "bearer", upstream, 200); strings.TrimSpace(got) == "" {
+		t.Error("audit id must be non-empty even with no recorder and no newID")
+	}
 }
 
 func TestSandboxProxyAuditShape_SandboxProxyUpgradeConforms(t *testing.T) {

--- a/internal/binding/host_binding.go
+++ b/internal/binding/host_binding.go
@@ -1,0 +1,158 @@
+package binding
+
+import (
+	"fmt"
+	"strings"
+)
+
+// HostBindingSchemes is the closed set of injection schemes a host
+// binding may declare. The egress-side injector that consumes a matched
+// binding (#1194) is keyed on these exact strings. v1 implements
+// `bearer` concretely; the remaining schemes are reserved for the
+// scheme-keyed injector that lands alongside this table.
+//
+// The set is closed deliberately: a host binding that names a scheme
+// outside this set is a configuration error caught at construction
+// rather than a silent passthrough at the egress boundary.
+var HostBindingSchemes = map[string]struct{}{
+	"bearer":          {},
+	"basic":           {},
+	"header-template": {},
+	"query-param":     {},
+	"sigv4-resign":    {},
+}
+
+// SchemeBearer is the only scheme this PR injects concretely. It
+// mirrors the connector-spec path's `Authorization: Bearer <token>`
+// behavior. The remaining schemes in [HostBindingSchemes] are accepted
+// at construction but slot into the #1194 injector at egress time.
+const SchemeBearer = "bearer"
+
+// HostBinding is the declarative triple that maps an upstream host
+// pattern to a vault credential and the scheme used to inject it. It is
+// a distinct concept from [Binding]: a [Binding] is keyed on
+// (connector FQN, kind) and resolves a connector-spec credential
+// reference, whereas a HostBinding is keyed on a host pattern and is
+// consulted at the TLS forward-proxy boundary when no connector spec
+// matched (ADR-0019 launch passthrough).
+//
+// The zero value is invalid; construct via [NewHostBinding].
+type HostBinding struct {
+	// HostPattern is an exact host (`api.example.com`) or a single
+	// leading-wildcard form (`*.example.com`). The wildcard matches
+	// exactly one or more leading labels' worth of suffix (see
+	// [HostBindings.Match] for the matching rule). Ports are not part
+	// of the pattern; callers strip the port before matching.
+	HostPattern string
+
+	// CredentialRef is a vault binding name (`<kind>/<service>/<identity>`)
+	// the daemon resolves through the credential layer at egress time.
+	// It is never the credential bytes; it points at where the bytes
+	// live in the user's vault.
+	CredentialRef string
+
+	// Scheme is the injection scheme, one of [HostBindingSchemes].
+	Scheme string
+}
+
+// NewHostBinding validates and constructs a HostBinding. It rejects an
+// empty or malformed host pattern, a credential-ref that does not parse
+// as a binding name, and a scheme outside [HostBindingSchemes]. The
+// validation is the construction-time guard the issue's acceptance
+// criterion requires: no invalid binding ever reaches the matcher.
+func NewHostBinding(hostPattern, credentialRef, scheme string) (HostBinding, error) {
+	hp := strings.TrimSpace(strings.ToLower(hostPattern))
+	if hp == "" {
+		return HostBinding{}, fmt.Errorf("host binding: empty host pattern")
+	}
+	if err := validateHostPattern(hp); err != nil {
+		return HostBinding{}, err
+	}
+	if !nameRe.MatchString(credentialRef) {
+		return HostBinding{}, fmt.Errorf("host binding: invalid credential ref %q: must match <kind>/<service>/<identity>", credentialRef)
+	}
+	if _, ok := HostBindingSchemes[scheme]; !ok {
+		return HostBinding{}, fmt.Errorf("host binding: unknown injection scheme %q", scheme)
+	}
+	return HostBinding{HostPattern: hp, CredentialRef: credentialRef, Scheme: scheme}, nil
+}
+
+// validateHostPattern enforces the exact-host or single leading-wildcard
+// form. A wildcard pattern is `*.<suffix>` where <suffix> is a
+// non-empty dotted host with at least one dot (so `*.com` matching a
+// bare TLD is rejected as too broad). Exact patterns must be a
+// non-empty dotted or single-label host with no wildcard.
+func validateHostPattern(hp string) error {
+	if strings.HasPrefix(hp, "*.") {
+		suffix := strings.TrimPrefix(hp, "*.")
+		if suffix == "" || strings.Contains(suffix, "*") || !strings.Contains(suffix, ".") {
+			return fmt.Errorf("host binding: invalid wildcard host pattern %q: want *.<domain.tld>", hp)
+		}
+		return nil
+	}
+	if strings.Contains(hp, "*") {
+		return fmt.Errorf("host binding: wildcard only allowed as a single leading label (%q)", hp)
+	}
+	return nil
+}
+
+// HostBindings is an ordered lookup over host bindings. Match resolves
+// the most specific binding for a host: an exact-host binding always
+// beats a wildcard, and among wildcards the longest matching suffix
+// wins. The zero value (nil) is a valid empty table whose Match always
+// returns false, which is what preserves today's passthrough behavior
+// when no bindings are configured.
+type HostBindings []HostBinding
+
+// Match returns the most specific HostBinding whose pattern matches the
+// given host, and true, or the zero binding and false when none match.
+//
+// Matching rule:
+//   - The host is lowercased and any port is the caller's
+//     responsibility to strip before calling.
+//   - An exact-host pattern matches only that host.
+//   - A wildcard pattern `*.example.com` matches any host that is a
+//     proper subdomain (`a.example.com`, `a.b.example.com`) but NOT the
+//     apex (`example.com`).
+//   - Resolution is deterministic: exact beats wildcard; among matching
+//     wildcards the longest suffix wins. There is no silent multi-match.
+func (h HostBindings) Match(host string) (HostBinding, bool) {
+	host = strings.TrimSpace(strings.ToLower(host))
+	if host == "" {
+		return HostBinding{}, false
+	}
+
+	var exact *HostBinding
+	var bestWildcard *HostBinding
+	bestWildcardLen := -1
+
+	for i := range h {
+		hb := h[i]
+		if strings.HasPrefix(hb.HostPattern, "*.") {
+			suffix := strings.TrimPrefix(hb.HostPattern, "*.")
+			// Proper-subdomain match: host ends with ".<suffix>" and has
+			// at least one label before the suffix. The apex host
+			// (equal to suffix) does not match a wildcard.
+			if strings.HasSuffix(host, "."+suffix) && len(host) > len(suffix)+1 {
+				if len(suffix) > bestWildcardLen {
+					bestWildcardLen = len(suffix)
+					hbCopy := hb
+					bestWildcard = &hbCopy
+				}
+			}
+			continue
+		}
+		if hb.HostPattern == host {
+			hbCopy := hb
+			exact = &hbCopy
+		}
+	}
+
+	if exact != nil {
+		return *exact, true
+	}
+	if bestWildcard != nil {
+		return *bestWildcard, true
+	}
+	return HostBinding{}, false
+}

--- a/internal/binding/host_binding_test.go
+++ b/internal/binding/host_binding_test.go
@@ -1,0 +1,156 @@
+package binding_test
+
+import (
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+// mustHostBinding constructs a HostBinding or fails the test. Used to
+// build the lookup tables under test.
+func mustHostBinding(t *testing.T, host, ref, scheme string) binding.HostBinding {
+	t.Helper()
+	hb, err := binding.NewHostBinding(host, ref, scheme)
+	if err != nil {
+		t.Fatalf("NewHostBinding(%q,%q,%q): %v", host, ref, scheme, err)
+	}
+	return hb
+}
+
+func TestNewHostBinding_AcceptsValidInput(t *testing.T) {
+	hb, err := binding.NewHostBinding("API.Example.com", "oauth2/github/octocat", "bearer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hb.HostPattern != "api.example.com" {
+		t.Errorf("HostPattern = %q, want lowercased api.example.com", hb.HostPattern)
+	}
+	if hb.CredentialRef != "oauth2/github/octocat" {
+		t.Errorf("CredentialRef = %q", hb.CredentialRef)
+	}
+	if hb.Scheme != "bearer" {
+		t.Errorf("Scheme = %q", hb.Scheme)
+	}
+}
+
+func TestNewHostBinding_RejectsInvalidScheme(t *testing.T) {
+	if _, err := binding.NewHostBinding("api.example.com", "oauth2/github/octocat", "magic"); err == nil {
+		t.Fatal("expected error for unknown scheme, got nil")
+	}
+}
+
+func TestNewHostBinding_RejectsInvalidCredentialRef(t *testing.T) {
+	for _, ref := range []string{"", "not-a-binding-name", "oauth2/github", "../escape/x"} {
+		if _, err := binding.NewHostBinding("api.example.com", ref, "bearer"); err == nil {
+			t.Errorf("expected error for credential ref %q, got nil", ref)
+		}
+	}
+}
+
+func TestNewHostBinding_RejectsInvalidHostPattern(t *testing.T) {
+	for _, host := range []string{"", "  ", "*.com", "*", "a.*.com", "foo*.com", "*."} {
+		if _, err := binding.NewHostBinding(host, "oauth2/github/octocat", "bearer"); err == nil {
+			t.Errorf("expected error for host pattern %q, got nil", host)
+		}
+	}
+}
+
+func TestHostBindings_Match_Exact(t *testing.T) {
+	tbl := binding.HostBindings{
+		mustHostBinding(t, "api.example.com", "oauth2/github/octocat", "bearer"),
+	}
+	hb, ok := tbl.Match("api.example.com")
+	if !ok {
+		t.Fatal("expected exact match")
+	}
+	if hb.CredentialRef != "oauth2/github/octocat" {
+		t.Errorf("CredentialRef = %q", hb.CredentialRef)
+	}
+	// Port-stripping is the caller's job; the matcher sees the bare host.
+	if _, ok := tbl.Match("other.example.com"); ok {
+		t.Error("expected no match for unrelated host")
+	}
+}
+
+func TestHostBindings_Match_Wildcard(t *testing.T) {
+	tbl := binding.HostBindings{
+		mustHostBinding(t, "*.example.com", "oauth2/github/octocat", "bearer"),
+	}
+	for _, host := range []string{"a.example.com", "a.b.example.com", "deep.nested.example.com"} {
+		if _, ok := tbl.Match(host); !ok {
+			t.Errorf("expected wildcard match for %q", host)
+		}
+	}
+	// Apex does not match a wildcard.
+	if _, ok := tbl.Match("example.com"); ok {
+		t.Error("wildcard must not match the apex host")
+	}
+	// A different domain does not match.
+	if _, ok := tbl.Match("a.other.com"); ok {
+		t.Error("wildcard must not match a different domain")
+	}
+}
+
+func TestHostBindings_Match_ExactBeatsWildcard(t *testing.T) {
+	tbl := binding.HostBindings{
+		mustHostBinding(t, "*.example.com", "oauth2/wild/card", "bearer"),
+		mustHostBinding(t, "api.example.com", "oauth2/exact/match", "bearer"),
+	}
+	hb, ok := tbl.Match("api.example.com")
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if hb.CredentialRef != "oauth2/exact/match" {
+		t.Errorf("CredentialRef = %q, want exact to win over wildcard", hb.CredentialRef)
+	}
+}
+
+func TestHostBindings_Match_LongestSuffixWins(t *testing.T) {
+	tbl := binding.HostBindings{
+		mustHostBinding(t, "*.example.com", "oauth2/short/suffix", "bearer"),
+		mustHostBinding(t, "*.svc.example.com", "oauth2/long/suffix", "bearer"),
+	}
+	hb, ok := tbl.Match("a.svc.example.com")
+	if !ok {
+		t.Fatal("expected a match")
+	}
+	if hb.CredentialRef != "oauth2/long/suffix" {
+		t.Errorf("CredentialRef = %q, want longest matching suffix to win", hb.CredentialRef)
+	}
+	// A host only the short wildcard covers still resolves to the short one.
+	hb2, ok := tbl.Match("a.example.com")
+	if !ok {
+		t.Fatal("expected a match for short-only host")
+	}
+	if hb2.CredentialRef != "oauth2/short/suffix" {
+		t.Errorf("CredentialRef = %q, want short suffix", hb2.CredentialRef)
+	}
+}
+
+func TestHostBindings_Match_NoMatchReturnsFalse(t *testing.T) {
+	tbl := binding.HostBindings{
+		mustHostBinding(t, "api.example.com", "oauth2/github/octocat", "bearer"),
+	}
+	if _, ok := tbl.Match("nope.test"); ok {
+		t.Error("expected no match")
+	}
+	if _, ok := tbl.Match(""); ok {
+		t.Error("empty host must not match")
+	}
+}
+
+func TestHostBindings_Match_NilTableIsEmpty(t *testing.T) {
+	var tbl binding.HostBindings
+	if _, ok := tbl.Match("api.example.com"); ok {
+		t.Error("nil table must never match (preserves passthrough default)")
+	}
+}
+
+func TestHostBindings_Match_CaseInsensitiveHost(t *testing.T) {
+	tbl := binding.HostBindings{
+		mustHostBinding(t, "api.example.com", "oauth2/github/octocat", "bearer"),
+	}
+	if _, ok := tbl.Match("API.Example.COM"); !ok {
+		t.Error("host match must be case-insensitive")
+	}
+}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -326,6 +326,17 @@ const (
 	// credential is injected. See ADR-0019.
 	EventTypeSandboxProxyUpgrade EventType = "sandbox.proxy.upgrade"
 
+	// Sandbox proxy event for a cooperative HTTPS request that matched
+	// a user-level host->credential binding (the host-binding table at
+	// the TLS boundary, #1193) when no connector spec matched. The
+	// daemon resolved the bound credential from the vault, injected it
+	// per the binding's scheme, re-issued the request upstream, and
+	// streamed the response back. The credential bytes and the
+	// credential-ref are never present in the payload; only the matched
+	// host pattern, scheme, and upstream destination/status. See
+	// ADR-0019.
+	EventTypeSandboxProxyBindingInjected EventType = "sandbox.proxy.binding_injected"
+
 	// Sandbox proxy event for launches that proceed (or refuse to
 	// proceed) without the HTTPS data-plane bootstrap. Emitted by the
 	// launcher when proxy bootstrap is opted out, preflight fails, or


### PR DESCRIPTION
## Summary

Inserts a user-level host→credential binding lookup at the TLS forward-proxy boundary (the ADR-0019 launch passthrough subsystem in `handlers_sandbox_forward_proxy.go`, not the deny-by-default `internal/sandbox/network.go` HostPolicy). When a decrypted CONNECT/TLS request matches no unique connector spec, the daemon now consults a new host-pattern-keyed binding table before falling to passthrough.

On a binding match the daemon resolves the bound credential daemon-side through the vault, injects it per the binding's scheme onto a re-issued upstream request, and seals the secret: only the upstream status, headers, and body return to the in-container client. The credential bytes never cross into the container and never appear in any audit payload.

### Key behavior
- **Precedence: connector-spec → host-binding → passthrough.** The host-binding lookup runs only on the no-unique-spec branches (`!ok` and the ambiguous-spec branch), so a request matching both a connector spec and a host binding resolves via the connector spec.
- **New typed lookup keyed on host** (`internal/binding/host_binding.go`): `HostBinding{HostPattern, CredentialRef, Scheme}` + `HostBindings.Match`. Matching is exact-host plus single leading-wildcard (`*.example.com`); exact beats wildcard and longest matching suffix wins. No silent multi-match. Construction validates the scheme against the closed set and the credential-ref against the binding-name regex.
- **Fails closed.** A locked vault (`binding_locked_vault`) or absent credential (`binding_credential_unavailable`) yields a 5xx with no secret bytes in the response or audit, and passthrough is NOT taken for a bound host with a broken vault. The private-IP-literal SSRF guard applies on the binding path too.
- **`bearer` scheme implemented concretely** (mirrors the connector path's `Authorization: Bearer`). The remaining closed-set schemes (`basic`/`header-template`/`query-param`/`sigv4-resign`) slot into #1194's scheme-keyed injector behind a narrow `applyHostBindingScheme(req, scheme, cred)` seam; until then they fail closed with `binding_unsupported_scheme`.
- **New audit event** `sandbox.proxy.binding_injected` carrying the matched host pattern, scheme, and upstream destination/status — never the credential-ref or token bytes.
- **Config source is a follow-on.** v1 leaves `apiServer.hostBindings` at its nil zero value (empty table never matches), so today's passthrough behavior is preserved exactly as the default. No OpenAPI change — this is an internal TLS-boundary code path.

## Test plan
- `internal/binding/host_binding_test.go` — exact/wildcard match, exact-beats-wildcard, longest-suffix-wins, no-match, nil-table, case-insensitivity, and construction-time rejection of invalid scheme/ref/host. 100% coverage of the new binding code.
- `internal/app/sandbox_forward_proxy_host_binding_test.go` — end-to-end through a CONNECT/TLS intercepting proxy:
  - binding match injects + seals the credential (upstream sees `Bearer`, container never does, `binding_injected` audit emitted with no secret bytes)
  - non-matching host passes through unchanged (regression: no Authorization, byte-for-byte body, `sandbox.proxy.passthrough`)
  - locked vault and missing credential fail closed (no dial, no secret leak, correct reject reason)
  - precedence: connector-spec wins over host binding; ambiguous spec falls to host binding then passthrough
  - unsupported scheme, upstream-unreachable, response-too-large, and private-IP-literal all fail closed
- `internal/app/sandbox_proxy_audit_shape_test.go` — shape conformance + nil-recorder ID safety for the new event.
- Full `go test github.com/ALRubinger/aileron/internal/...` green.

CodeRabbit reported one finding (an unresolved `nameRe` reference) which is a false positive: `nameRe` is defined at package scope in `internal/binding/binding.go` and is accessible from the same package; the suite compiles and passes.

Closes #1193

🤖 Generated with [Claude Code](https://claude.com/claude-code)
