### PR TITLE
fix(sandbox): enrich validate failure with tier and published-image context

### DIFF
--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -222,6 +222,7 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 	// aileron-mcp mounted under sandbox check, so requiring it would fail.
 	bakedVersion := sandboxCheckBakedVersionFn(context.Background(), resolvedRuntime, result.Image)
 	if err := sandboxCheckValidateFn(context.Background(), resolvedRuntime, cwd, result.Image, command, bakedVersion != ""); err != nil {
+		err = sandboxcomposition.EnrichValidateError(err, result.Tier, command, version.Version, cwd)
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}

--- a/docs/src/content/docs/development/v4-acceptance.md
+++ b/docs/src/content/docs/development/v4-acceptance.md
@@ -60,6 +60,8 @@ aileron sandbox check --runtime=docker --agent="$AGENT"
 
 Expect `support: ok`, along with the selected tier, runtime, image, and command. A development build resolves the floating `edge` base image tag, and launch pulls it automatically. No separate image build is needed for the smoke.
 
+The working directory determines the resolved tier. A `.devcontainer/` in the directory you run from selects the devcontainer tier, which builds the project image from that authored config and can ignore `--agent`. If the project image was built without the requested agent's CLI, validate fails and now names the tier, the discovered `.devcontainer/devcontainer.json`, and the published per-agent image you could use instead. To pick the build-free published image, run from a directory without a `.devcontainer/`, or add the agent's Feature to the devcontainer.
+
 ## Step 4: Launch the agent inside the container
 
 ```bash

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -271,6 +271,7 @@ func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchC
 		})
 	}
 	if err := validateSandboxImageForLaunch(ctx, plan, config, agentEnv, mounts, commandName); err != nil {
+		err = sandboxcomposition.EnrichValidateError(err, plan.Tier, config.Agent.Name(), version.Version, config.Dir)
 		return fmt.Errorf("sandbox image %s is not launchable for %s: %w", plan.Image, config.Agent.Name(), err)
 	}
 	return nil

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -2,6 +2,7 @@ package launch
 
 import (
 	"context"
+	"errors"
 	"io"
 	"log/slog"
 	"os"
@@ -11,7 +12,9 @@ import (
 	"strings"
 	"testing"
 
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/version"
 )
 
 type emptyBinaryAgent struct{}
@@ -37,6 +40,21 @@ func (a namedBinaryAgent) ConfigureMCP(string, map[string]string, string, Mode) 
 	return nil, nil, nil
 }
 func (a namedBinaryAgent) AuthSpec() AuthSpec { return AuthSpec{} }
+
+// publishedNameAgent reports its name as a published agent id (e.g. "claude")
+// so Discover/EnrichValidateError treat it as having a published per-agent
+// image. namedBinaryAgent hardcodes Name() to "named", which is unpublished.
+type publishedNameAgent struct{ name string }
+
+func (a publishedNameAgent) Name() string           { return a.name }
+func (a publishedNameAgent) BinaryNames() []string  { return []string{a.name} }
+func (a publishedNameAgent) Args() []string         { return nil }
+func (a publishedNameAgent) Env() map[string]string { return nil }
+func (a publishedNameAgent) LLMEndpointEnv() string { return "" }
+func (a publishedNameAgent) ConfigureMCP(string, map[string]string, string, Mode) ([]string, []MCPMount, error) {
+	return nil, nil, nil
+}
+func (a publishedNameAgent) AuthSpec() AuthSpec { return AuthSpec{} }
 
 func TestFirstAgentBinaryHandlesEmptyAgent(t *testing.T) {
 	if got := firstAgentBinary(emptyBinaryAgent{}); got != "" {
@@ -162,6 +180,42 @@ func TestValidateSandboxPassesRuntimeMounts(t *testing.T) {
 	for _, absent := range []string{"/etc/aileron/tools.txt", "/usr/local/bin/google"} {
 		if hasMountTarget(got, absent) {
 			t.Fatalf("validateSandbox mounts = %#v, should not include retired shim surface %s", got, absent)
+		}
+	}
+}
+
+// TestValidateSandboxEnrichesDevcontainerMismatch covers the wiring of the
+// CWD-determined-tier enrichment into the launch validate path. When the
+// underlying validate reports the agent CLI is missing on a devcontainer-tier
+// plan for a published agent, validateSandbox must surface the enriched message
+// naming the tier, the discovered devcontainer path, and the published image.
+func TestValidateSandboxEnrichesDevcontainerMismatch(t *testing.T) {
+	orig := validateSandboxImageForLaunch
+	t.Cleanup(func() { validateSandboxImageForLaunch = orig })
+	validateSandboxImageForLaunch = func(_ context.Context, _ SandboxLaunchPlan, _ LaunchConfig, _ map[string]string, _ []sandboxcontainer.Volume, _ string) error {
+		return errors.New("validate sandbox image image:test: agent command not found in sandbox image: claude: exit status 127")
+	}
+
+	workDir := t.TempDir()
+	err := validateSandbox(context.Background(), SandboxLaunchPlan{
+		Runtime: "docker",
+		Image:   "image:test",
+		Tier:    sandboxcomposition.TierDevcontainer,
+	}, LaunchConfig{
+		Agent: publishedNameAgent{name: "claude"},
+		Dir:   workDir,
+	}, nil)
+	if err == nil {
+		t.Fatal("validateSandbox: want error, got nil")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		string(sandboxcomposition.TierDevcontainer),
+		filepath.Join(workDir, sandboxcomposition.DefaultDevcontainerPath),
+		sandboxcomposition.PublishedAgentImage("claude", version.Version),
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("validateSandbox error missing %q: %s", want, msg)
 		}
 	}
 }

--- a/internal/sandbox/composition/validatehint.go
+++ b/internal/sandbox/composition/validatehint.go
@@ -2,7 +2,7 @@ package composition
 
 import (
 	"fmt"
-	"path/filepath"
+	"path"
 	"strings"
 )
 
@@ -40,7 +40,12 @@ func EnrichValidateError(err error, tier Tier, agent, version, workDir string) e
 	if wd == "" {
 		wd = "."
 	}
-	devcontainerPath := filepath.Join(wd, DefaultDevcontainerPath)
+	// Use path.Join (forward-slash) rather than filepath.Join: this builds an
+	// informational path describing the launch CWD and the devcontainer file for
+	// an error message. DefaultDevcontainerPath is a forward-slash literal and
+	// the sandbox is a Linux container, so the displayed path must stay POSIX on
+	// every host OS rather than picking up Windows backslashes.
+	devcontainerPath := path.Join(wd, DefaultDevcontainerPath)
 	publishedImage := PublishedAgentImage(agent, version)
 	return fmt.Errorf("%w\n"+
 		"resolved tier=%s because %s exists in the working directory %s; "+

--- a/internal/sandbox/composition/validatehint.go
+++ b/internal/sandbox/composition/validatehint.go
@@ -1,0 +1,51 @@
+package composition
+
+import (
+	"fmt"
+	"path/filepath"
+	"strings"
+)
+
+// agentNotFoundMarker is the substring the in-container validation script emits
+// when the agent CLI is not on PATH (see internal/sandbox/container/runtime.go
+// validationScript). The launch and `sandbox check` call sites match on it to
+// detect the CWD-determined-tier mismatch and enrich the error.
+const agentNotFoundMarker = "agent command not found in sandbox image:"
+
+// EnrichValidateError augments a sandbox-image validate failure with tier, CWD,
+// and published-image context when the failure is the CWD-determined-tier
+// mismatch: a hand-authored .devcontainer/ in workDir selected the devcontainer
+// tier (whose project image was built without the requested agent's CLI), while
+// a published per-agent image for that agent exists as an alternative.
+//
+// Discover's tier precedence is unchanged. The authored devcontainer stays
+// authoritative; this only makes the failure honest about why the agent was
+// absent and what the operator can do. When the failure is not that case
+// (different tier, no published image, or a different validate error),
+// EnrichValidateError returns err unchanged.
+func EnrichValidateError(err error, tier Tier, agent, version, workDir string) error {
+	if err == nil {
+		return nil
+	}
+	if tier != TierDevcontainer {
+		return err
+	}
+	if !strings.Contains(err.Error(), agentNotFoundMarker) {
+		return err
+	}
+	if agent == "" || !PublishedAgentExists(agent) {
+		return err
+	}
+	wd := workDir
+	if wd == "" {
+		wd = "."
+	}
+	devcontainerPath := filepath.Join(wd, DefaultDevcontainerPath)
+	publishedImage := PublishedAgentImage(agent, version)
+	return fmt.Errorf("%w\n"+
+		"resolved tier=%s because %s exists in the working directory %s; "+
+		"that project image was built without the %q agent CLI on PATH. "+
+		"A published per-agent image %s exists as an alternative: "+
+		"launch from a directory without a .devcontainer/, or add the %q agent Feature to %s.",
+		err, TierDevcontainer, devcontainerPath, wd, agent, publishedImage, agent, devcontainerPath)
+}

--- a/internal/sandbox/composition/validatehint_test.go
+++ b/internal/sandbox/composition/validatehint_test.go
@@ -1,0 +1,98 @@
+package composition
+
+import (
+	"errors"
+	"strings"
+	"testing"
+)
+
+// agentNotFoundErr mimics the validate failure the in-container script produces
+// when the agent CLI is not on PATH (see runtime.go validationScript).
+func agentNotFoundErr(agent string) error {
+	return errors.New("validate sandbox image: agent command not found in sandbox image: " + agent)
+}
+
+// TestEnrichValidateErrorDevcontainerMismatch reproduces the CWD-determined-tier
+// failure: a .devcontainer/ in workDir selected the devcontainer tier, its
+// project image lacks the requested agent CLI, and a published per-agent image
+// exists. The enriched error must name the tier, the discovered devcontainer
+// path/CWD, and the published image. This fails before the fix (the raw error
+// names none of those) and passes after.
+func TestEnrichValidateErrorDevcontainerMismatch(t *testing.T) {
+	const (
+		agent   = "claude"
+		version = "1.2.3"
+		workDir = "/home/dev/project"
+	)
+	if !PublishedAgentExists(agent) {
+		t.Fatalf("precondition: %q must have a published image", agent)
+	}
+	base := agentNotFoundErr(agent)
+	got := EnrichValidateError(base, TierDevcontainer, agent, version, workDir)
+	msg := got.Error()
+
+	if !strings.Contains(msg, string(TierDevcontainer)) {
+		t.Errorf("enriched error does not name the tier %q: %s", TierDevcontainer, msg)
+	}
+	wantPath := workDir + "/" + DefaultDevcontainerPath
+	if !strings.Contains(msg, wantPath) {
+		t.Errorf("enriched error does not name the devcontainer path %q: %s", wantPath, msg)
+	}
+	if !strings.Contains(msg, workDir) {
+		t.Errorf("enriched error does not name the CWD %q: %s", workDir, msg)
+	}
+	wantImage := PublishedAgentImage(agent, version)
+	if !strings.Contains(msg, wantImage) {
+		t.Errorf("enriched error does not name the published image %q: %s", wantImage, msg)
+	}
+	// The original error must remain wrapped so callers' %w chains still match.
+	if !errors.Is(got, base) {
+		t.Errorf("enriched error does not wrap the original validate error")
+	}
+}
+
+func TestEnrichValidateErrorNonDevcontainerTierUnchanged(t *testing.T) {
+	base := agentNotFoundErr("claude")
+	for _, tier := range []Tier{TierBase, TierPublished, TierBYOImage} {
+		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project")
+		if got != base {
+			t.Errorf("tier %q: error was enriched, want unchanged: %s", tier, got.Error())
+		}
+	}
+}
+
+func TestEnrichValidateErrorUnpublishedAgentUnchanged(t *testing.T) {
+	const agent = "no-such-agent"
+	if PublishedAgentExists(agent) {
+		t.Fatalf("precondition: %q must not have a published image", agent)
+	}
+	base := agentNotFoundErr(agent)
+	got := EnrichValidateError(base, TierDevcontainer, agent, "1.2.3", "/home/dev/project")
+	if got != base {
+		t.Errorf("unpublished agent: error was enriched, want unchanged: %s", got.Error())
+	}
+}
+
+func TestEnrichValidateErrorUnrelatedFailureUnchanged(t *testing.T) {
+	base := errors.New("validate sandbox image: sandbox workspace is not writable at /workspace")
+	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "/home/dev/project")
+	if got != base {
+		t.Errorf("unrelated failure: error was enriched, want unchanged: %s", got.Error())
+	}
+}
+
+func TestEnrichValidateErrorNilUnchanged(t *testing.T) {
+	if got := EnrichValidateError(nil, TierDevcontainer, "claude", "1.2.3", "/home/dev/project"); got != nil {
+		t.Errorf("nil error: got %v, want nil", got)
+	}
+}
+
+func TestEnrichValidateErrorEmptyWorkDirDefaultsToCwd(t *testing.T) {
+	base := agentNotFoundErr("claude")
+	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "")
+	// filepath.Join(".", path) cleans to the bare relative path.
+	wantPath := DefaultDevcontainerPath
+	if !strings.Contains(got.Error(), wantPath) {
+		t.Errorf("empty workDir: enriched error does not name %q: %s", wantPath, got.Error())
+	}
+}


### PR DESCRIPTION
## Summary

When a hand-authored `.devcontainer/` sits in the working directory, `Discover` resolves the devcontainer tier and builds the project image from that authored config. If that image was built without the requested agent's CLI on PATH, the in-container validate step failed with a working-directory-blind message: `agent command not found in sandbox image: <agent>`. Operators hit this when they ran `aileron launch`/`aileron sandbox check --agent X` from a directory that has a `.devcontainer/` for a different agent, with no hint that the CWD chose the tier or that a published per-agent image exists.

Per the operator decision on #1206 (Option B): the authored devcontainer stays authoritative. We do NOT silently swap in the published per-agent image. Instead the validate failure is now honest about why the agent was absent and what the operator can do.

### What changed
- New `composition.EnrichValidateError(err, tier, agent, version, workDir)` detects the CWD-determined-tier mismatch (agent-not-found marker AND `TierDevcontainer` AND `PublishedAgentExists(agent)`). When matched it wraps the error naming: the resolved tier, the `.devcontainer/devcontainer.json` discovered relative to the working directory, that the project image was built without that agent's CLI, and the published per-agent image (`PublishedAgentImage`) as an alternative. Non-matching cases (other tiers, unpublished agents, unrelated validate failures, nil) pass through unchanged. `Discover`'s tier precedence is untouched, no image swap.
- Wired the helper into both validate call sites so launch and `sandbox check` stay at parity: `internal/launch/launcher.go` `validateSandbox` and `cmd/aileron/sandbox.go` sandbox-check validate.
- Runbook note in `docs/development/v4-acceptance.md` near the sandbox check step: the working directory determines the resolved tier, a `.devcontainer/` selects the devcontainer tier and can ignore `--agent`.

No OpenAPI change (this is sandbox tier/validate plumbing, not the HTTP API).

## Test plan
- `internal/sandbox/composition/validatehint_test.go`: regression test reproducing the CWD-dependent failure (devcontainer tier + published agent + agent-not-found) asserting the enriched message names the tier, the devcontainer path/CWD, and the published image. Fails before the fix (raw error names none of those), passes after. Plus pass-through cases for non-devcontainer tiers, unpublished agents, unrelated failures, nil, and empty workDir.
- `internal/launch/launcher_internal_test.go` `TestValidateSandboxEnrichesDevcontainerMismatch`: covers the launch-path wiring end-to-end through `validateSandbox`.
- `go test ./sandbox/... ./launch/...` (internal module) and `go test ./...` (cmd/aileron) green; `go vet` clean.
- CodeRabbit review clean against the changed files (the only findings were in pre-existing worktree artifacts I did not touch).

Closes #1206

🤖 Generated with [Claude Code](https://claude.com/claude-code)