### PR TITLE
feat(credential): seal git/GitHub via emit-mechanism A host bindings

### DIFF
--- a/cmd/aileron/auth_github.go
+++ b/cmd/aileron/auth_github.go
@@ -17,6 +17,29 @@ import (
 	"golang.org/x/term"
 )
 
+// userGitHubCredentialKind is the metadata Type stamped on the
+// user/github vault entry. It must equal the first segment of the
+// host-binding credential-ref (`user/github`) so the daemon's
+// VaultResolver kind check passes when a github.com / api.github.com
+// request is sealed at the TLS boundary (ADR-0019, #1195).
+const userGitHubCredentialKind = "user"
+
+// userCredentialsBody is the wire shape the user-credential PUT
+// marshals: the secret bytes plus optional non-secret metadata. It is a
+// local subset of api.AgentCredentials (cmd/aileron does not depend on
+// internal/api/gen, matching the agentCredentialsBody precedent).
+type userCredentialsBody struct {
+	Value    []byte                   `json:"value"`
+	Metadata *userCredentialsMetadata `json:"metadata,omitempty"`
+}
+
+// userCredentialsMetadata is the local subset of
+// api.AgentCredentialsMetadata the user-credential PUT sets. Only Type
+// is carried today; the daemon binding resolver keys on it.
+type userCredentialsMetadata struct {
+	Type string `json:"type,omitempty"`
+}
+
 // stdinIsTerminal reports whether the operator's stdin is a real
 // terminal. It is a package var so tests can drive both branches.
 // gh's interactive device-flow login renders a prompt through a
@@ -106,9 +129,21 @@ func runAuthGitHub(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	// Marshaling a struct with a single []byte field cannot fail; the
-	// error is discarded here matching runAuthImport's precedent.
-	body, _ := json.Marshal(agentCredentialsBody{Value: token})
+	// Stamp the credential's metadata Type as "user" so the daemon's
+	// host->credential binding resolver (ADR-0019) can validate the kind
+	// it resolves for user/github. The binding's credential-ref is
+	// `user/github`, whose first segment ("user") is the expected kind;
+	// VaultResolver fails closed if the stored Type does not match. Older
+	// entries written before this stamp carry an empty Type and will not
+	// resolve through a binding until re-run, which is the intended
+	// fail-closed posture rather than a silent unauthenticated request.
+	//
+	// Marshaling cannot fail for these field types; the error is
+	// discarded matching runAuthImport's precedent.
+	body, _ := json.Marshal(userCredentialsBody{
+		Value:    token,
+		Metadata: &userCredentialsMetadata{Type: userGitHubCredentialKind},
+	})
 	status, respBody, err := vaultDoRequest(http.MethodPut,
 		"/vault/user/github/credentials", body)
 	if err != nil {

--- a/cmd/aileron/auth_github_test.go
+++ b/cmd/aileron/auth_github_test.go
@@ -46,16 +46,19 @@ func withStubDeviceFlow(t *testing.T, stub deviceFlowRunner, capErr error) {
 
 func TestRunAuthGitHub_HappyPathStoresTokenAtUserGitHub(t *testing.T) {
 	token := []byte("gho_exampletoken1234567890")
-	var gotMethod, gotPath string
+	var gotMethod, gotPath, gotType string
 	var gotValue []byte
 	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
 		gotMethod = r.Method
 		gotPath = r.URL.Path
-		var body agentCredentialsBody
+		var body userCredentialsBody
 		if err := json.NewDecoder(r.Body).Decode(&body); err != nil {
 			t.Fatalf("decode body: %v", err)
 		}
 		gotValue = body.Value
+		if body.Metadata != nil {
+			gotType = body.Metadata.Type
+		}
 		w.WriteHeader(http.StatusNoContent)
 	})
 	withStubDeviceFlow(t, stubDeviceFlow{token: token}, nil)
@@ -70,6 +73,12 @@ func TestRunAuthGitHub_HappyPathStoresTokenAtUserGitHub(t *testing.T) {
 	}
 	if !bytes.Equal(gotValue, token) {
 		t.Errorf("stored value = %q, want %q", gotValue, token)
+	}
+	// The metadata Type must be "user" so the daemon's host-binding
+	// resolver (ADR-0019, #1195) can validate the kind it resolves for
+	// user/github at the TLS boundary.
+	if gotType != "user" {
+		t.Errorf("stored metadata.type = %q, want user", gotType)
 	}
 	if !strings.Contains(stdout.String(), "Stored user/github") {
 		t.Errorf("stdout = %q, want success message", stdout.String())

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -442,10 +442,21 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	// forward-proxy boundary when no connector spec matches a decrypted
 	// request (ADR-0019 launch passthrough). v1 has no config wire
 	// format yet (the launch/policy schema and authoring CLI are a
-	// follow-on); the daemon leaves server.hostBindings at its nil
-	// zero value, which preserves today's passthrough behavior exactly.
-	// A nil/empty binding.HostBindings never matches, so the regression
-	// path is the default until a config source populates the table.
+	// follow-on), so the only bindings seeded here are the built-in
+	// GitHub pair (#1195): github.com -> basic and api.github.com ->
+	// bearer, both resolving user/github daemon-side. The agent never
+	// holds the GitHub secret; the daemon injects it at egress. With no
+	// user/github entry the bindings still match but resolution fails
+	// closed (no secret, no Authorization header), so an unauthenticated
+	// GitHub request behaves exactly as before today's passthrough.
+	if ghBindings, err := gitHubHostBindings(); err != nil {
+		// A construction error here is a programming bug (the host
+		// patterns and schemes are constants), not operator input;
+		// surface it rather than silently dropping the seal.
+		return nil, fmt.Errorf("seed github host bindings: %w", err)
+	} else {
+		server.hostBindings = ghBindings
+	}
 
 	// --- Scope-drift detection (#726) ---
 	// Hook fires after every successful connector install. If the

--- a/internal/app/github_bindings.go
+++ b/internal/app/github_bindings.go
@@ -1,0 +1,61 @@
+package app
+
+import (
+	"fmt"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+// githubCredentialRef is the vault path the user-level GitHub token
+// lives at (`user/github`), written by `aileron auth github`. Both
+// GitHub host bindings resolve this same entry daemon-side; only the
+// injection scheme differs per host. It is a credential *reference*,
+// never the credential bytes.
+const githubCredentialRef = "user/github"
+
+// githubBasicUsername is the HTTP basic-auth username git-over-HTTPS
+// uses against github.com: the token rides in the password field while
+// the username is a fixed, non-secret sentinel. This is the documented
+// convention for authenticating git with a GitHub token.
+const githubBasicUsername = "x-access-token"
+
+// gitHubHostBindings returns the two user-level host->credential
+// bindings that seal GitHub traffic at the TLS forward-proxy boundary
+// (ADR-0019, umbrella #1191). The agent inside the sandbox holds no
+// GitHub secret; the daemon resolves user/github from the vault and
+// injects the credential per the matched binding's scheme:
+//
+//   - github.com -> basic, emitting
+//     "Authorization: Basic base64(x-access-token:<token>)", the
+//     git-over-HTTPS convention used by `git clone`/`git push`.
+//   - api.github.com -> bearer, emitting
+//     "Authorization: Bearer <token>", the `gh`/REST convention.
+//
+// Both name the same credential-ref (user/github); the scheme is what
+// differs. No secret bytes appear in the returned descriptors: a
+// binding names where the credential lives, never its value. Resolution
+// fails closed daemon-side when the vault is locked or the entry is
+// absent (the binding-injection path writes no Authorization header and
+// no secret in that case; see injectSandboxProxyHostBindingCredential).
+//
+// The two host patterns are exact (no wildcard): only github.com and
+// api.github.com are sealed, so a request to any other *.github.com
+// host (raw.githubusercontent.com is a different apex entirely) falls
+// through to passthrough rather than being injected with a credential
+// it was not scoped for.
+func gitHubHostBindings() (binding.HostBindings, error) {
+	apex, err := binding.NewHostBinding(
+		"github.com", githubCredentialRef, binding.SchemeBasic,
+		binding.WithBasicUsername(githubBasicUsername),
+	)
+	if err != nil {
+		return nil, fmt.Errorf("github host binding (github.com): %w", err)
+	}
+	api, err := binding.NewHostBinding(
+		"api.github.com", githubCredentialRef, binding.SchemeBearer,
+	)
+	if err != nil {
+		return nil, fmt.Errorf("github host binding (api.github.com): %w", err)
+	}
+	return binding.HostBindings{apex, api}, nil
+}

--- a/internal/app/github_bindings_test.go
+++ b/internal/app/github_bindings_test.go
@@ -1,0 +1,114 @@
+package app
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+// gitHubHostBindings contract (#1195): the constructor returns exactly
+// the two user-level GitHub bindings, both naming the user/github
+// credential-ref, with github.com -> basic (username x-access-token) and
+// api.github.com -> bearer. No descriptor inlines a secret: a binding
+// names where the credential lives, never its value.
+
+func TestGitHubHostBindings_ReturnsExactlyTwoBindings(t *testing.T) {
+	bindings, err := gitHubHostBindings()
+	if err != nil {
+		t.Fatalf("gitHubHostBindings: %v", err)
+	}
+	if len(bindings) != 2 {
+		t.Fatalf("len(bindings) = %d, want 2", len(bindings))
+	}
+}
+
+func TestGitHubHostBindings_ApexIsBasicWithAccessTokenUser(t *testing.T) {
+	bindings, err := gitHubHostBindings()
+	if err != nil {
+		t.Fatalf("gitHubHostBindings: %v", err)
+	}
+	hb, ok := bindings.Match("github.com")
+	if !ok {
+		t.Fatal("no binding matched github.com")
+	}
+	if hb.Scheme != binding.SchemeBasic {
+		t.Errorf("github.com scheme = %q, want %q", hb.Scheme, binding.SchemeBasic)
+	}
+	if hb.BasicUsername != "x-access-token" {
+		t.Errorf("github.com BasicUsername = %q, want x-access-token", hb.BasicUsername)
+	}
+	if hb.CredentialRef != "user/github" {
+		t.Errorf("github.com CredentialRef = %q, want user/github", hb.CredentialRef)
+	}
+}
+
+func TestGitHubHostBindings_APIIsBearer(t *testing.T) {
+	bindings, err := gitHubHostBindings()
+	if err != nil {
+		t.Fatalf("gitHubHostBindings: %v", err)
+	}
+	hb, ok := bindings.Match("api.github.com")
+	if !ok {
+		t.Fatal("no binding matched api.github.com")
+	}
+	if hb.Scheme != binding.SchemeBearer {
+		t.Errorf("api.github.com scheme = %q, want %q", hb.Scheme, binding.SchemeBearer)
+	}
+	if hb.CredentialRef != "user/github" {
+		t.Errorf("api.github.com CredentialRef = %q, want user/github", hb.CredentialRef)
+	}
+	// The bearer binding carries no basic username (it is irrelevant to
+	// the scheme); a stray username here would be a copy-paste bug.
+	if hb.BasicUsername != "" {
+		t.Errorf("api.github.com BasicUsername = %q, want empty for bearer", hb.BasicUsername)
+	}
+}
+
+func TestGitHubHostBindings_ExactHostsOnly(t *testing.T) {
+	// Only the two exact apexes are sealed. A different github.com
+	// subdomain (e.g. raw content host) must not match either binding,
+	// so it falls through to passthrough rather than receiving a
+	// credential it was never scoped for.
+	bindings, err := gitHubHostBindings()
+	if err != nil {
+		t.Fatalf("gitHubHostBindings: %v", err)
+	}
+	for _, host := range []string{
+		"raw.githubusercontent.com",
+		"codeload.github.com",
+		"gist.github.com",
+		"evilgithub.com",
+		"github.com.attacker.test",
+	} {
+		if _, ok := bindings.Match(host); ok {
+			t.Errorf("host %q unexpectedly matched a GitHub binding; want passthrough", host)
+		}
+	}
+}
+
+func TestGitHubHostBindings_NoSecretBytesInDescriptors(t *testing.T) {
+	// A binding descriptor names a credential-ref, never the credential
+	// value. Assert no field looks like an inlined token.
+	bindings, err := gitHubHostBindings()
+	if err != nil {
+		t.Fatalf("gitHubHostBindings: %v", err)
+	}
+	for _, hb := range bindings {
+		for _, field := range []string{hb.HostPattern, hb.CredentialRef, hb.Scheme, hb.BasicUsername} {
+			lower := strings.ToLower(field)
+			// GitHub token prefixes (ghp_, gho_, github_pat_) would be the
+			// shape of an inlined secret. The basic username is a fixed,
+			// non-secret sentinel and is allowed even though it ends in
+			// "token".
+			if lower == "x-access-token" {
+				continue
+			}
+			for _, marker := range []string{"ghp_", "gho_", "github_pat_", "token"} {
+				if strings.Contains(lower, marker) {
+					t.Errorf("binding field %q looks like an inlined secret (matched %q)", field, marker)
+				}
+			}
+		}
+	}
+}

--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -17,6 +17,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/binding"
 	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
 	"github.com/ALRubinger/aileron/internal/credential"
+	"github.com/ALRubinger/aileron/internal/credential/inject"
 	"github.com/ALRubinger/aileron/internal/model"
 	"github.com/ALRubinger/aileron/internal/sandbox/discovery"
 	"github.com/ALRubinger/aileron/internal/vault"
@@ -561,24 +562,50 @@ func (s *apiServer) injectSandboxProxyHostBindingCredential(ctx context.Context,
 		}
 		return false, hostBindingRejectCredentialUnavailable
 	}
-	return applyHostBindingScheme(req, hb.Scheme, cred)
+	return applyHostBindingScheme(req, hb, cred)
 }
 
 // applyHostBindingScheme applies the named injection scheme to the
-// upstream request using the resolved credential. This is the narrow
-// seam #1194's scheme-keyed injector replaces: its signature is
-// (req, scheme, cred) so the binding-match wiring is untouched when the
-// closed scheme set lands. v1 implements `bearer`; every other scheme
-// in binding.HostBindingSchemes is accepted at config time but rejected
-// here until #1194 fills it in, which fails closed rather than silently
-// passing an un-injected request upstream.
-func applyHostBindingScheme(req *http.Request, scheme string, cred credential.Credential) (bool, string) {
-	switch scheme {
-	case binding.SchemeBearer:
-		req.Header.Set("Authorization", "Bearer "+string(cred.Value))
-		return true, ""
-	default:
+// upstream request using the resolved credential. It is the narrow seam
+// over the #1194 scheme-keyed injector (internal/credential/inject):
+// the binding-match wiring is untouched and the injector owns the wire
+// shape of every scheme, so a header convention lives in exactly one
+// place. `bearer` and `basic` are implemented (basic carries the
+// non-secret username from the binding); the remaining members of
+// binding.HostBindingSchemes are accepted at config time but rejected
+// here, which fails closed rather than silently passing an un-injected
+// request upstream.
+//
+// The resolved credential bytes flow only into [inject.Inject], which
+// writes them solely onto the request's Authorization header. They are
+// never copied into the returned reject reason or any audit payload.
+func applyHostBindingScheme(req *http.Request, hb binding.HostBinding, cred credential.Credential) (bool, string) {
+	scheme, params, ok := hostBindingInjectScheme(hb)
+	if !ok {
 		return false, hostBindingRejectUnsupportedScheme
+	}
+	if err := inject.Inject(req, scheme, cred.Value, params); err != nil {
+		// A missing param or an unimplemented scheme fails closed; the
+		// error never carries the secret (inject keeps it off every
+		// observable surface) so it is safe to map to a stable reason.
+		return false, hostBindingRejectUnsupportedScheme
+	}
+	return true, ""
+}
+
+// hostBindingInjectScheme maps a binding's scheme string and its
+// non-secret params onto the closed [inject.Scheme] set. It returns
+// ok=false for any scheme this proxy does not yet inject (a member of
+// binding.HostBindingSchemes whose wire shape is deferred), so the
+// caller fails closed instead of dialing upstream un-injected.
+func hostBindingInjectScheme(hb binding.HostBinding) (inject.Scheme, inject.Params, bool) {
+	switch hb.Scheme {
+	case binding.SchemeBearer:
+		return inject.SchemeBearer, inject.Params{}, true
+	case binding.SchemeBasic:
+		return inject.SchemeBasic, inject.Params{Username: hb.BasicUsername}, true
+	default:
+		return "", inject.Params{}, false
 	}
 }
 

--- a/internal/app/sandbox_forward_proxy_github_binding_test.go
+++ b/internal/app/sandbox_forward_proxy_github_binding_test.go
@@ -1,0 +1,153 @@
+package app
+
+import (
+	"encoding/base64"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// End-to-end contract for the two built-in GitHub host bindings (#1195),
+// driving a decrypted request through the real forward-proxy boundary:
+//
+//   - github.com gets Authorization: Basic base64(x-access-token:<token>)
+//     injected (the git-over-HTTPS convention).
+//   - api.github.com gets Authorization: Bearer <token> (the gh/REST
+//     convention).
+//   - a locked/absent vault fails closed: no Authorization header reaches
+//     the upstream, and no secret leaks into the response.
+//
+// The credential at user/github is stored with metadata Type "user" so
+// the daemon's VaultResolver kind check (keyed on the credential-ref's
+// first segment) passes, matching what `aileron auth github` writes.
+
+func newGitHubBindingServer(t *testing.T, v vault.Vault, captureAuth *string) *apiServer {
+	t.Helper()
+	ghBindings, err := gitHubHostBindings()
+	if err != nil {
+		t.Fatalf("gitHubHostBindings: %v", err)
+	}
+	auditStore := audit.NewMemStore()
+	return &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-github-binding" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         v,
+		hostBindings:  ghBindings,
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if captureAuth != nil {
+				*captureAuth = req.Header.Get("Authorization")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+}
+
+func TestGitHubBinding_DotComGetsBasicAuth(t *testing.T) {
+	const token = "ghp_clone_secret"
+	v := mustVaultWith(t, "user/github", "user", []byte(token))
+	var upstreamAuth string
+	srv := newGitHubBindingServer(t, v, &upstreamAuth)
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://github.com/octocat/repo.git/info/refs?service=git-upload-pack")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	wantAuth := "Basic " + base64.StdEncoding.EncodeToString([]byte("x-access-token:"+token))
+	if upstreamAuth != wantAuth {
+		t.Fatalf("upstream Authorization = %q, want %q", upstreamAuth, wantAuth)
+	}
+	// The in-container client never sees the raw token.
+	if strings.Contains(string(body), token) {
+		t.Error("response body leaked the token")
+	}
+	for k, vs := range resp.Header {
+		for _, val := range vs {
+			if strings.Contains(val, token) {
+				t.Errorf("response header %s leaked the token: %q", k, val)
+			}
+		}
+	}
+}
+
+func TestGitHubBinding_APIGetsBearerAuth(t *testing.T) {
+	const token = "ghp_rest_secret"
+	v := mustVaultWith(t, "user/github", "user", []byte(token))
+	var upstreamAuth string
+	srv := newGitHubBindingServer(t, v, &upstreamAuth)
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.github.com/user")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	if upstreamAuth != "Bearer "+token {
+		t.Fatalf("upstream Authorization = %q, want Bearer %s", upstreamAuth, token)
+	}
+	if strings.Contains(string(body), token) {
+		t.Error("response body leaked the token")
+	}
+}
+
+func TestGitHubBinding_LockedVaultFailsClosedNoSecret(t *testing.T) {
+	// An empty LockableVault is locked: Get returns
+	// vault.ErrCredentialUnavailable, so the binding resolves to nothing.
+	const token = "ghp_locked_secret"
+	v := vault.NewLockableVault()
+
+	var upstreamAuth string
+	upstreamCalled := false
+	srv := newGitHubBindingServer(t, v, &upstreamAuth)
+	// Replace the transport to record whether the upstream was dialed.
+	srv.sandboxProxyClient = &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+		upstreamCalled = true
+		upstreamAuth = req.Header.Get("Authorization")
+		return &http.Response{
+			StatusCode: http.StatusOK,
+			Header:     http.Header{},
+			Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+		}, nil
+	})}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.github.com/user")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	// Fail-closed: a bound host whose credential is unavailable is NOT
+	// passed through; it gets an error status with no secret.
+	if resp.StatusCode == http.StatusOK {
+		t.Errorf("status = 200 on locked vault; want fail-closed error")
+	}
+	if upstreamCalled {
+		t.Errorf("upstream was dialed on locked vault; want fail-closed before dial")
+	}
+	if strings.Contains(string(body), token) || strings.Contains(upstreamAuth, token) {
+		t.Error("token leaked on locked-vault path")
+	}
+}

--- a/internal/app/sandbox_forward_proxy_host_binding_test.go
+++ b/internal/app/sandbox_forward_proxy_host_binding_test.go
@@ -306,8 +306,9 @@ func TestSandboxForwardProxy_HostBindingMissingCredentialFailsClosed(t *testing.
 
 // TestSandboxForwardProxy_HostBindingUnsupportedSchemeFailsClosed
 // asserts a binding declaring a scheme in the closed set but not yet
-// implemented (the #1194 seam: e.g. `basic`) fails closed rather than
-// dialing upstream with an un-injected request.
+// injected by the proxy (e.g. `sigv4-resign`, which the #1194 injector
+// enumerates but defers) fails closed rather than dialing upstream with
+// an un-injected request.
 func TestSandboxForwardProxy_HostBindingUnsupportedSchemeFailsClosed(t *testing.T) {
 	auditStore := audit.NewMemStore()
 	srv := &apiServer{
@@ -315,7 +316,7 @@ func TestSandboxForwardProxy_HostBindingUnsupportedSchemeFailsClosed(t *testing.
 		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-scheme" }),
 		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
 		vault:         mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_secret")),
-		hostBindings:  mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "basic"),
+		hostBindings:  mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "sigv4-resign"),
 		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
 			t.Errorf("upstream must not be dialed for an unsupported scheme; got %s", req.URL)
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil

--- a/internal/binding/host_binding.go
+++ b/internal/binding/host_binding.go
@@ -2,6 +2,7 @@ package binding
 
 import (
 	"fmt"
+	"regexp"
 	"strings"
 )
 
@@ -22,11 +23,16 @@ var HostBindingSchemes = map[string]struct{}{
 	"sigv4-resign":    {},
 }
 
-// SchemeBearer is the only scheme this PR injects concretely. It
-// mirrors the connector-spec path's `Authorization: Bearer <token>`
-// behavior. The remaining schemes in [HostBindingSchemes] are accepted
-// at construction but slot into the #1194 injector at egress time.
+// SchemeBearer mirrors the connector-spec path's
+// `Authorization: Bearer <token>` behavior.
 const SchemeBearer = "bearer"
+
+// SchemeBasic emits `Authorization: Basic base64(<username>:<token>)`,
+// the HTTP basic-auth convention git-over-HTTPS uses (username
+// `x-access-token`, token in the password field). The username travels
+// in [HostBinding.BasicUsername]; it is a non-secret param, never the
+// credential bytes.
+const SchemeBasic = "basic"
 
 // HostBinding is the declarative triple that maps an upstream host
 // pattern to a vault credential and the scheme used to inject it. It is
@@ -45,22 +51,55 @@ type HostBinding struct {
 	// of the pattern; callers strip the port before matching.
 	HostPattern string
 
-	// CredentialRef is a vault binding name (`<kind>/<service>/<identity>`)
-	// the daemon resolves through the credential layer at egress time.
-	// It is never the credential bytes; it points at where the bytes
-	// live in the user's vault.
+	// CredentialRef is a vault path the daemon resolves through the
+	// credential layer at egress time. Two shapes are valid: a
+	// connector-style binding name (`<kind>/<service>/<identity>`) or a
+	// user-level credential ref (`user/<service>`), the namespace that
+	// `aileron auth <service>` writes. It is never the credential bytes;
+	// it points at where the bytes live in the user's vault.
 	CredentialRef string
 
 	// Scheme is the injection scheme, one of [HostBindingSchemes].
 	Scheme string
+
+	// BasicUsername is the username portion of HTTP basic auth, used
+	// only when Scheme is [SchemeBasic] (e.g. `x-access-token` for
+	// git-over-HTTPS). It is a non-secret param: the token always goes
+	// in the password field, never here. Required for the basic scheme,
+	// ignored for every other scheme.
+	BasicUsername string
+}
+
+// userRefRe matches the user-level credential namespace `user/<service>`
+// that `aileron auth <service>` writes (see userCredentialVaultPath). It
+// is the only valid two-segment credential ref: connector-style refs
+// must still carry the full `<kind>/<service>/<identity>` triple.
+var userRefRe = regexp.MustCompile(`^user/([a-z0-9][a-z0-9_-]*)$`)
+
+// HostBindingOption configures optional, scheme-specific fields on a
+// [HostBinding] at construction. Options keep the positional signature
+// of [NewHostBinding] stable while letting schemes that need extra
+// non-secret params (e.g. basic auth's username) declare them.
+type HostBindingOption func(*HostBinding)
+
+// WithBasicUsername sets [HostBinding.BasicUsername], the non-secret
+// username used by [SchemeBasic]. It is required for that scheme.
+func WithBasicUsername(username string) HostBindingOption {
+	return func(hb *HostBinding) { hb.BasicUsername = username }
 }
 
 // NewHostBinding validates and constructs a HostBinding. It rejects an
-// empty or malformed host pattern, a credential-ref that does not parse
-// as a binding name, and a scheme outside [HostBindingSchemes]. The
-// validation is the construction-time guard the issue's acceptance
-// criterion requires: no invalid binding ever reaches the matcher.
-func NewHostBinding(hostPattern, credentialRef, scheme string) (HostBinding, error) {
+// empty or malformed host pattern, a credential-ref that is neither a
+// connector binding name (`<kind>/<service>/<identity>`) nor a
+// user-level ref (`user/<service>`), and a scheme outside
+// [HostBindingSchemes]. When the scheme is [SchemeBasic] a non-empty
+// [WithBasicUsername] is required: a basic binding with no username
+// could never produce a well-formed Authorization header, so it is a
+// configuration error caught here rather than a fail-closed reject at
+// egress. The validation is the construction-time guard the issue's
+// acceptance criterion requires: no invalid binding ever reaches the
+// matcher.
+func NewHostBinding(hostPattern, credentialRef, scheme string, opts ...HostBindingOption) (HostBinding, error) {
 	hp := strings.TrimSpace(strings.ToLower(hostPattern))
 	if hp == "" {
 		return HostBinding{}, fmt.Errorf("host binding: empty host pattern")
@@ -68,13 +107,20 @@ func NewHostBinding(hostPattern, credentialRef, scheme string) (HostBinding, err
 	if err := validateHostPattern(hp); err != nil {
 		return HostBinding{}, err
 	}
-	if !nameRe.MatchString(credentialRef) {
-		return HostBinding{}, fmt.Errorf("host binding: invalid credential ref %q: must match <kind>/<service>/<identity>", credentialRef)
+	if !nameRe.MatchString(credentialRef) && !userRefRe.MatchString(credentialRef) {
+		return HostBinding{}, fmt.Errorf("host binding: invalid credential ref %q: must match <kind>/<service>/<identity> or user/<service>", credentialRef)
 	}
 	if _, ok := HostBindingSchemes[scheme]; !ok {
 		return HostBinding{}, fmt.Errorf("host binding: unknown injection scheme %q", scheme)
 	}
-	return HostBinding{HostPattern: hp, CredentialRef: credentialRef, Scheme: scheme}, nil
+	hb := HostBinding{HostPattern: hp, CredentialRef: credentialRef, Scheme: scheme}
+	for _, opt := range opts {
+		opt(&hb)
+	}
+	if scheme == SchemeBasic && hb.BasicUsername == "" {
+		return HostBinding{}, fmt.Errorf("host binding: basic scheme requires a username (WithBasicUsername)")
+	}
+	return hb, nil
 }
 
 // validateHostPattern enforces the exact-host or single leading-wildcard

--- a/internal/binding/host_binding_test.go
+++ b/internal/binding/host_binding_test.go
@@ -39,6 +39,50 @@ func TestNewHostBinding_RejectsInvalidScheme(t *testing.T) {
 	}
 }
 
+func TestNewHostBinding_AcceptsUserCredentialRef(t *testing.T) {
+	// The user-level namespace (`user/<service>`) is the second valid
+	// credential-ref shape: it is what `aileron auth <service>` writes
+	// and what the GitHub bindings (#1195) name.
+	hb, err := binding.NewHostBinding("api.github.com", "user/github", "bearer")
+	if err != nil {
+		t.Fatalf("unexpected error for user/github ref: %v", err)
+	}
+	if hb.CredentialRef != "user/github" {
+		t.Errorf("CredentialRef = %q, want user/github", hb.CredentialRef)
+	}
+}
+
+func TestNewHostBinding_RejectsOtherTwoSegmentRefs(t *testing.T) {
+	// Only `user/<service>` is a valid two-segment ref; a connector-style
+	// ref must still carry the full triple. A two-segment connector ref
+	// remains a configuration error.
+	for _, ref := range []string{"oauth2/github", "api_key/stripe", "user/", "user/Bad-CASE"} {
+		if _, err := binding.NewHostBinding("api.example.com", ref, "bearer"); err == nil {
+			t.Errorf("expected error for credential ref %q, got nil", ref)
+		}
+	}
+}
+
+func TestNewHostBinding_BasicSchemeRequiresUsername(t *testing.T) {
+	// A basic binding with no username can never produce a well-formed
+	// Authorization header, so it is rejected at construction rather than
+	// failing closed at egress.
+	if _, err := binding.NewHostBinding("github.com", "user/github", "basic"); err == nil {
+		t.Fatal("expected error for basic scheme without username, got nil")
+	}
+	hb, err := binding.NewHostBinding("github.com", "user/github", "basic",
+		binding.WithBasicUsername("x-access-token"))
+	if err != nil {
+		t.Fatalf("unexpected error for basic scheme with username: %v", err)
+	}
+	if hb.BasicUsername != "x-access-token" {
+		t.Errorf("BasicUsername = %q, want x-access-token", hb.BasicUsername)
+	}
+	if hb.Scheme != binding.SchemeBasic {
+		t.Errorf("Scheme = %q, want %q", hb.Scheme, binding.SchemeBasic)
+	}
+}
+
 func TestNewHostBinding_RejectsInvalidCredentialRef(t *testing.T) {
 	for _, ref := range []string{"", "not-a-binding-name", "oauth2/github", "../escape/x"} {
 		if _, err := binding.NewHostBinding("api.example.com", ref, "bearer"); err == nil {

--- a/internal/launch/github_inject.go
+++ b/internal/launch/github_inject.go
@@ -26,12 +26,21 @@ const githubUserService = "github"
 // .claude.json carve-out so the workspace mount is not masked.
 const githubConfigTarget = "/home/agent/.gitconfig"
 
-// gitCredentialHelperConfig is the static, token-independent gitconfig
-// that wires git's HTTPS credential helper to `gh`. The token never
-// appears in this file; it flows only via the GH_TOKEN env var, which
-// `gh auth git-credential` reads at request time. Because the content
-// never changes, the mount is read-only.
-const gitCredentialHelperConfig = "[credential \"https://github.com\"]\n\thelper = !gh auth git-credential\n"
+// gitCredentialHelperConfig is the static, token-independent, and
+// secret-free gitconfig mounted at /home/agent/.gitconfig. Under the
+// ADR-0019 sealing model (#1195) the GitHub token never enters the
+// container: it is resolved daemon-side and injected at the TLS
+// forward-proxy boundary by the user/github host bindings. This file
+// therefore carries no secret and no reference to `gh`.
+//
+// The helper is a no-op that returns empty credentials. Resetting the
+// helper list (the bare `helper =`) clears any inherited helper, and
+// the empty-credential shell helper makes git emit a fully-formed but
+// *unauthenticated* HTTPS request instead of blocking on an interactive
+// prompt or shelling out to `gh`. The daemon proxy then seals that
+// request at egress. Because the content never changes and holds no
+// secret, the mount is read-only and identical on every launch.
+const gitCredentialHelperConfig = "[credential \"https://github.com\"]\n\thelper =\n\thelper = \"!f() { test \\\"$1\\\" = get && exit 0; }; f\"\n"
 
 // userCredsDaemon is the one-method subset of *daemonClient the GitHub
 // injector depends on. Defined as an interface so tests substitute a
@@ -47,12 +56,16 @@ type userCredsDaemon interface {
 // user-level and runs on every sandbox launch independent of the
 // per-agent AuthSpec.
 type githubInjectPrep struct {
-	// EnvAdditions merge into the agent's env. Carries GH_TOKEN when a
-	// usable token was found; empty otherwise.
+	// EnvAdditions merge into the agent's env. Under the ADR-0019
+	// sealing model (#1195) this never carries a GitHub secret: the
+	// token is resolved daemon-side and injected at the TLS boundary, so
+	// no GH_TOKEN is set. The field is retained for shape parity with
+	// authSpecPrep and for any future non-secret GitHub env.
 	EnvAdditions map[string]string
 
 	// Mounts append to the sandbox volume list. Carries the individual
-	// gitconfig file mount when a token was found; empty otherwise.
+	// secret-free gitconfig file mount when a usable user/github entry
+	// was found; empty otherwise. The mount holds no secret regardless.
 	Mounts []sandboxcontainer.Volume
 
 	// Cleanup removes the transient host directory holding the rendered
@@ -72,10 +85,19 @@ func emptyGitHubInjectPrep() githubInjectPrep {
 	}
 }
 
-// prepareGitHubInject reads the user-level GitHub token from the vault
-// and, when present, produces a GH_TOKEN env addition plus a read-only
-// bind mount of a static git credential-helper gitconfig at
-// /home/agent/.gitconfig.
+// prepareGitHubInject probes the user-level GitHub entry in the vault
+// and, when a usable token is present, mounts a read-only, secret-free
+// no-op gitconfig at /home/agent/.gitconfig.
+//
+// Under the ADR-0019 sealing model (#1195) the token never enters the
+// container: no GH_TOKEN env is set and the gitconfig carries no secret
+// bytes. The mounted helper makes git emit a fully-formed but
+// unauthenticated HTTPS request that the daemon proxy seals at egress
+// via the user/github host bindings. The vault probe is retained only
+// to drive the locked-vault warning UX and to gate the (secret-free)
+// mount the same way the pre-sealing code did, keeping the prep shape
+// stable; the daemon binding independently handles the locked/empty
+// case fail-closed, so a missed mount never leaks or breaks auth.
 //
 // Skip-clean semantics: a missing entry (ErrUserCredentialsNotFound) or
 // a locked vault (vault.ErrCredentialUnavailable) returns an empty prep
@@ -152,7 +174,10 @@ func prepareGitHubInject(
 	}
 
 	prep := emptyGitHubInjectPrep()
-	prep.EnvAdditions["GH_TOKEN"] = token
+	// No GH_TOKEN: the secret never enters the container under the
+	// ADR-0019 sealing model (#1195). The daemon resolves user/github
+	// and injects it at the TLS boundary via the host bindings. The
+	// mount below carries only the secret-free no-op gitconfig.
 	prep.Mounts = []sandboxcontainer.Volume{{
 		Source:   hostPath,
 		Target:   githubConfigTarget,

--- a/internal/launch/github_inject_launcher_test.go
+++ b/internal/launch/github_inject_launcher_test.go
@@ -23,7 +23,7 @@ func TestLauncherMergesGitHubInject_TokenPresent(t *testing.T) {
 	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_launch")}}
 
 	// Pre-existing agent env (e.g. AuthSpec EnvBindings) with a distinct
-	// key set — GH_TOKEN must not clobber it and vice-versa.
+	// key set — the GitHub merge must not clobber it.
 	agentEnv := map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "agent-oauth"}
 	var proxyMounts []sandboxcontainer.Volume
 
@@ -37,13 +37,16 @@ func TestLauncherMergesGitHubInject_TokenPresent(t *testing.T) {
 	}
 	proxyMounts = append(proxyMounts, ghPrep.Mounts...)
 
-	if agentEnv["GH_TOKEN"] != "ghp_launch" {
-		t.Errorf("agentEnv[GH_TOKEN] = %q, want ghp_launch", agentEnv["GH_TOKEN"])
+	// Sealed model (#1195): the merge appends the secret-free gitconfig
+	// mount but adds NO GH_TOKEN. The token never reaches agentEnv.
+	if _, ok := agentEnv["GH_TOKEN"]; ok {
+		t.Errorf("GH_TOKEN merged into agentEnv; sealed model must not env-inject the secret")
 	}
 	if agentEnv["CLAUDE_CODE_OAUTH_TOKEN"] != "agent-oauth" {
 		t.Errorf("GitHub inject clobbered the AuthSpec env binding: %q", agentEnv["CLAUDE_CODE_OAUTH_TOKEN"])
 	}
 
+	// The mount shape is preserved: the static gitconfig is still mounted.
 	var found bool
 	for _, m := range proxyMounts {
 		if m.Target == "/home/agent/.gitconfig" {

--- a/internal/launch/github_inject_test.go
+++ b/internal/launch/github_inject_test.go
@@ -11,12 +11,14 @@ import (
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
-// prepareGitHubInject contract (#1149):
+// prepareGitHubInject contract (#1149, sealed by #1195):
 //
-//   - A usable token yields GH_TOKEN (trimmed) plus a read-only file
-//     mount at /home/agent/.gitconfig whose host source contains the
-//     exact `!gh auth git-credential` helper line.
-//   - A trailing newline in the stored secret is trimmed from GH_TOKEN.
+//   - The agent never holds the GitHub secret. A usable user/github
+//     entry yields NO GH_TOKEN env and a read-only file mount at
+//     /home/agent/.gitconfig whose host source contains NO secret
+//     bytes, NO `!gh auth git-credential` helper, and a no-op
+//     empty-credential helper scoped to https://github.com. The token
+//     is sealed daemon-side at the TLS boundary, not env-injected.
 //   - ErrUserCredentialsNotFound and a locked vault both yield an empty
 //     prep with no error and a nil-safe Cleanup (skip-clean).
 //   - An empty-after-trim token is treated as no token.
@@ -41,15 +43,19 @@ func (f *fakeUserCredsDaemon) GetUserCredentials(_ context.Context, service stri
 }
 
 func TestPrepareGitHubInject_TokenPresent(t *testing.T) {
-	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_realtoken")}}
+	// Sealed model (#1195): a usable token mounts a secret-free gitconfig
+	// and sets NO GH_TOKEN. The token bytes must never appear in the env
+	// or the mounted file; the daemon seals the request at egress.
+	const tokenValue = "ghp_realtoken"
+	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte(tokenValue)}}
 	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v", err)
 	}
 	defer prep.Cleanup()
 
-	if got := prep.EnvAdditions["GH_TOKEN"]; got != "ghp_realtoken" {
-		t.Errorf("GH_TOKEN = %q, want ghp_realtoken", got)
+	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
+		t.Errorf("GH_TOKEN present in EnvAdditions; sealed model must not env-inject the secret")
 	}
 	if len(prep.Mounts) != 1 {
 		t.Fatalf("Mounts = %d, want 1", len(prep.Mounts))
@@ -65,25 +71,54 @@ func TestPrepareGitHubInject_TokenPresent(t *testing.T) {
 	if readErr != nil {
 		t.Fatalf("read mount source %q: %v", m.Source, readErr)
 	}
-	if !bytes.Contains(content, []byte("!gh auth git-credential")) {
-		t.Errorf("gitconfig source missing helper line; got:\n%s", content)
+	// No secret bytes in the mounted gitconfig.
+	if bytes.Contains(content, []byte(tokenValue)) {
+		t.Errorf("gitconfig source leaked the token; got:\n%s", content)
 	}
+	// No `gh` credential helper: emit-mechanism A is git-only, sealed at
+	// egress; the agent must not shell out to gh for credentials.
+	if bytes.Contains(content, []byte("!gh auth git-credential")) {
+		t.Errorf("gitconfig source still references gh credential helper; got:\n%s", content)
+	}
+	// The no-op helper is scoped to the GitHub HTTPS credential section
+	// so git emits a completable unauthenticated request instead of
+	// blocking on a prompt.
 	if !bytes.Contains(content, []byte("[credential \"https://github.com\"]")) {
 		t.Errorf("gitconfig source missing credential section; got:\n%s", content)
 	}
+	if !bytes.Contains(content, []byte("helper =")) {
+		t.Errorf("gitconfig source missing no-op (empty) helper; got:\n%s", content)
+	}
 }
 
-func TestPrepareGitHubInject_TrimsTrailingNewline(t *testing.T) {
-	// Regression: a secret stored with a trailing newline must not leak
-	// the newline into GH_TOKEN (it would break gh's token parsing).
-	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_x\n")}}
-	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
+func TestPrepareGitHubInject_GitconfigIsSecretFreeRegardlessOfToken(t *testing.T) {
+	// Regression: whatever the stored token value, the mounted gitconfig
+	// is byte-for-byte identical and contains no secret. This locks the
+	// sealed state so a future change cannot reintroduce a token-bearing
+	// gitconfig without breaking a test.
+	a := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_alpha")}}
+	b := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_bravo\n")}}
+
+	prepA, err := prepareGitHubInject(context.Background(), a, nil, nil, nil)
 	if err != nil {
-		t.Fatalf("prepareGitHubInject: %v", err)
+		t.Fatalf("prepareGitHubInject(a): %v", err)
 	}
-	defer prep.Cleanup()
-	if got := prep.EnvAdditions["GH_TOKEN"]; got != "ghp_x" {
-		t.Errorf("GH_TOKEN = %q, want ghp_x (trimmed)", got)
+	defer prepA.Cleanup()
+	prepB, err := prepareGitHubInject(context.Background(), b, nil, nil, nil)
+	if err != nil {
+		t.Fatalf("prepareGitHubInject(b): %v", err)
+	}
+	defer prepB.Cleanup()
+
+	contentA, _ := os.ReadFile(prepA.Mounts[0].Source)
+	contentB, _ := os.ReadFile(prepB.Mounts[0].Source)
+	if !bytes.Equal(contentA, contentB) {
+		t.Errorf("gitconfig differs by token value; must be token-independent:\nA=%s\nB=%s", contentA, contentB)
+	}
+	for _, leak := range []string{"ghp_alpha", "ghp_bravo"} {
+		if bytes.Contains(contentA, []byte(leak)) || bytes.Contains(contentB, []byte(leak)) {
+			t.Errorf("gitconfig leaked token %q", leak)
+		}
 	}
 }
 
@@ -199,8 +234,8 @@ func TestPrepareGitHubInject_ChownHookFailureIsNonFatal(t *testing.T) {
 		t.Fatalf("chown failure must be non-fatal, got: %v", err)
 	}
 	defer prep.Cleanup()
-	if prep.EnvAdditions["GH_TOKEN"] != "ghp_x" {
-		t.Errorf("GH_TOKEN not set after non-fatal chown failure")
+	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
+		t.Errorf("GH_TOKEN present after chown failure; sealed model must not env-inject the secret")
 	}
 	if len(prep.Mounts) != 1 {
 		t.Errorf("Mounts = %d, want 1 after non-fatal chown failure", len(prep.Mounts))


### PR DESCRIPTION
## Summary

Seals GitHub traffic under the ADR-0019 host→credential substrate (umbrella #1191, Wave 3), consuming the binding table (#1193 / merged #1209) and the scheme-keyed injector (#1194 / merged #1211). The agent inside the sandbox no longer holds the GitHub secret; the daemon proxy injects it at the TLS egress boundary.

**Daemon side (`internal/app`)**
- Seeds two user-level host bindings at `apiServer` construction, both resolving the same `user/github` vault entry daemon-side:
  - `github.com` → `basic`, emitting `Authorization: Basic base64("x-access-token:" + <token>)` (the git-over-HTTPS convention).
  - `api.github.com` → `bearer`, emitting `Authorization: Bearer <token>` (the `gh`/REST convention).
- Wires the `internal/credential/inject` injector into the host-binding egress seam for `bearer` and `basic`, so each scheme's wire shape lives in exactly one place. Schemes the proxy does not yet inject (`header-template`, `query-param`, `sigv4-resign`) still fail closed.
- Resolution fails closed on a locked/absent vault: no `Authorization` header, no secret bytes in the response or audit.

**Binding model (`internal/binding`)**
- `HostBinding` now accepts the `user/<service>` credential-ref shape (what `aileron auth <service>` writes) in addition to the connector `<kind>/<service>/<identity>` triple, and carries a non-secret `BasicUsername` (required for `basic`, via `WithBasicUsername`). The existing 3-arg `NewHostBinding` callers are unchanged (variadic option).

**Credential metadata (`cmd/aileron`)**
- `aileron auth github` now stamps metadata `Type: "user"` on the `user/github` entry so the daemon's `VaultResolver` kind check (keyed on the ref's first segment) passes at egress. Older entries carry an empty Type and won't resolve through the binding until re-run — the intended fail-closed posture, never a silent leak.

**Launcher side (secret-free) (`internal/launch`)**
- Removes the `GH_TOKEN` env injection entirely; the token never enters the container.
- Replaces the `gh auth git-credential` helper with a static, secret-free no-op empty-credential helper scoped to `https://github.com`, so git emits a completable *unauthenticated* HTTPS request the proxy seals at egress (no prompt, no `gh` shell-out). The mount shape, 0700 transient dir, and `chownHook` are unchanged.

### Scope
Consumes #1193/#1194 (does not rebuild them). Does not amend ADR-0019 (#1192), does not touch `gh`'s sentinel-swap path (emit-mechanism B, #1196), and adds no GitHub connector spec. No OpenAPI change (binding table is internal daemon state). Versioning stays 0.0.x; passthrough subsystem only, `HostPolicy` untouched.

## Test plan

- `go test ./...` green in both `internal` and `cmd/aileron` modules.
- Inverted launcher regression tests fail on the pre-sealing code (they demanded the `GH_TOKEN` leak + `gh` helper) and pass after:
  - `TestPrepareGitHubInject_TokenPresent` now asserts **no** `GH_TOKEN`, **no** token bytes in the gitconfig, **no** `!gh auth git-credential`, and the no-op helper scoped to `https://github.com`.
  - `TestPrepareGitHubInject_GitconfigIsSecretFreeRegardlessOfToken` locks the gitconfig as byte-identical and secret-free across token values.
  - `TestLauncherMergesGitHubInject_TokenPresent` asserts the mount is still appended while `GH_TOKEN` is absent and the AuthSpec env is not clobbered.
- New daemon tests:
  - `internal/app/github_bindings_test.go` — the constructor returns exactly the two bindings with the right hosts/schemes/ref/username and no inlined secret.
  - `internal/app/sandbox_forward_proxy_github_binding_test.go` — end-to-end through the real CONNECT/TLS proxy: `github.com` gets `Basic base64(x-access-token:<token>)`, `api.github.com` gets `Bearer <token>`, and a locked vault fails closed (no upstream dial, no Authorization, no leak).
  - `internal/binding/host_binding_test.go` — `user/<service>` ref accepted, other 2-segment refs still rejected, `basic` requires a username.
- `aileron auth github` happy-path test now asserts metadata `Type: "user"` is stamped.
- `go vet` clean; CodeRabbit review clean (one minor test-only case-sensitivity nit fixed).

Closes #1195

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in GitHub host bindings that automatically inject credentials at the daemon boundary.
  * GitHub credentials are no longer stored in container environment variables; they are now sealed and injected at the TLS proxy layer for enhanced security.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->