### PR TITLE
feat(credential): seal gh via emit-mechanism B sentinel-swap

### DIFF
--- a/docs/src/content/docs/development/sandbox-proxy-cli-matrix.md
+++ b/docs/src/content/docs/development/sandbox-proxy-cli-matrix.md
@@ -8,6 +8,23 @@ This page is how you confirm the v4 sandbox HTTPS proxy is mediating credentials
 
 The matrix complements the [Sandbox MCP walkthrough](/development/sandbox-mcp-walkthrough/) (which exercises the same data plane from the agent's MCP transport) and the [BYO Image Proxy Contract](/development/sandbox-agent-images/#byo-image-proxy-contract) (which is what these CLIs depend on inside the container).
 
+## Per-CLI sealing properties
+
+Each CLI has two properties that govern how Aileron seals its traffic. These are documentation properties, not config fields.
+
+| CLI | proxy-sealable | emit-mechanism |
+|---|---|---|
+| curl | yes | A |
+| gh | yes | B |
+| aws | yes | A |
+
+`proxy-sealable` means the daemon can inject the real credential at the TLS forward-proxy boundary so the container never holds it.
+
+`emit-mechanism` is how the in-container client is made to emit a request the proxy can seal. It is independent of the injection scheme (bearer, basic, and so on), which is how the proxy writes the credential once the request arrives.
+
+- Mechanism A: the launcher plants no token. The client emits an unauthenticated request, and the proxy injects the bound credential unconditionally at egress. `curl` issues the request with no token. `git`-over-HTTPS issues an unauthenticated request because the launcher mounts a no-op credential helper.
+- Mechanism B: the launcher plants a non-secret, format-mimicking sentinel token. Some clients short-circuit locally when they hold no token, so they never issue the request and there is nothing for the proxy to seal. The sentinel makes the client treat itself as authenticated and issue the request. The proxy then swaps the sentinel for the real credential at egress. The proxy swaps only the sentinel it itself planted. A foreign token on a mechanism-B host is forwarded unchanged. See [ADR-0019](/adr/0019-v4-https-data-plane/).
+
 ## What the proxy guarantees
 
 When you call an installed connector operation through the proxy:
@@ -112,7 +129,11 @@ Expected:
 
 ## gh (GitHub CLI)
 
-`gh` honors `HTTPS_PROXY` once you set it, and it picks up the system CA store, so it works through the Aileron proxy with no extra config — as long as you have an installed GitHub connector spec whose host is `api.github.com` (or `github.com` for `git`-shaped operations).
+`gh` is `proxy-sealable` via `emit-mechanism` B. It honors `HTTPS_PROXY` once you set it, and it picks up the system CA store, so it works through the Aileron proxy with no extra config. Aileron seals it against the built-in `api.github.com` host binding, so you do not need an installed GitHub connector spec for `gh api` to work.
+
+`gh` is the reason mechanism B exists. `gh` validates its auth state locally before making a request. With no token it short-circuits and never issues the request, so mechanism A (plant nothing, seal the emitted request) has nothing to seal. The launcher closes this gap by planting a non-secret, format-mimicking sentinel as `GH_TOKEN` when a `user/github` entry exists in your vault. The sentinel passes `gh`'s own local validation, so `gh` issues its request. The daemon recognizes the sentinel at the TLS boundary and swaps in your real GitHub token before the request leaves the host. The real token never enters the container. The sentinel is non-secret and safe to see in `echo $GH_TOKEN` output; presenting it to GitHub authenticates nothing.
+
+Store your token once with `aileron auth github`. The launcher does the rest on every sandbox launch.
 
 ### Install
 
@@ -124,16 +145,18 @@ Expected:
 
 ### Configure
 
+There is nothing to configure inside the container. The launcher already set `HTTPS_PROXY` and planted the sentinel `GH_TOKEN`. You can confirm both:
+
 ```bash
-# Confirm HTTPS_PROXY is set by the launcher
+# Set by the launcher
 echo $HTTPS_PROXY
 
-# gh requires you to "log in" to a host once per profile.
-# Through the Aileron proxy, the credential is injected by the daemon,
-# so use the "token" flow with a placeholder — gh's own auth state
-# only needs to think it's authenticated.
-echo "placeholder-token-aileron-injects-real" | gh auth login --with-token
+# The non-secret sentinel the launcher planted. This is NOT your real
+# token; the daemon swaps it for the real one at egress.
+echo $GH_TOKEN
 ```
+
+Do not run `gh auth login` with a hand-typed placeholder. The launcher's sentinel is the only token `gh` needs, and the daemon owns the swap.
 
 ### Success case
 
@@ -144,18 +167,25 @@ gh api user
 Expected:
 
 - 200 with the authenticated user's JSON.
-- `connector.proxy.proxied` audit, `aileron.proxy.upstream.host: "api.github.com"`.
+- A `sandbox.proxy.binding_injected` audit event with `aileron.proxy.binding.host: "api.github.com"` and `aileron.proxy.binding.scheme: "bearer"`. The daemon swapped the sentinel for the real token; the upstream saw `Authorization: Bearer <real-token>` and the audit payload holds no token or sentinel bytes.
 
-### Unmatched case
+### Foreign-token case
+
+If you supply your own token instead of the sentinel (for example you ran `gh auth login --with-token` with a real token), the proxy does not swap it. It seals only the sentinel it planted.
 
 ```bash
-gh repo list --json id  # unmatched if no `repos` operation is in the spec
+echo "ghp_your_own_real_token" | gh auth login --with-token
+gh api user
 ```
 
 Expected:
 
-- `gh` reports the upstream's actual response. Without an installed credential the GitHub API returns 401; `gh` surfaces that to the user.
-- `sandbox.proxy.passthrough` audit, `aileron.proxy.upstream.host: "api.github.com"`. The proxy does not inject a credential and does not refuse the request.
+- The upstream sees your own token unchanged. The daemon injects nothing.
+- A `sandbox.proxy.foreign_token_not_swapped` audit event with `aileron.proxy.binding.host: "api.github.com"`. The payload holds no token bytes.
+
+### Verification status
+
+The `gh` sentinel-swap is asserted by the deterministic end-to-end test `TestSentinelSwap_*` in `internal/app/sandbox_forward_proxy_sentinel_swap_test.go`, which drives a sentinel-bearing and a foreign-token request through the real CONNECT/TLS proxy boundary against a fake `api.github.com` upstream and asserts the swap, the no-swap, the isolation, and the audit shape. A real `gh` against live `api.github.com` over the network is not exercised in CI (it requires a real GitHub token and network egress from the test runner), so this row is asserted by the deterministic test rather than by an empirical live-network run.
 
 ## aws (AWS CLI)
 
@@ -231,4 +261,6 @@ The test stands up a fake HTTPS upstream, runs `curl` as a host subprocess point
 3. The container's `curl` invocation does not carry the credential (proves credential isolation).
 4. A `connector.proxy.proxied` audit event is emitted with the matched connector FQN, tool, operation, upstream host (not URL), and `aileron.connector.boundary: https_proxy`.
 
-The `gh` and `aws` recipes above are manual-only for now; the same harness can be extended to cover them when there's a published Aileron connector spec for each upstream.
+The `gh` sentinel-swap is covered deterministically by `internal/app/sandbox_forward_proxy_sentinel_swap_test.go`, which drives sentinel-bearing and foreign-token requests through the in-process proxy against a fake `api.github.com` upstream and asserts the swap, the no-swap, the sentinel-never-reaches-upstream isolation, and the no-secret audit shape. It does not require real `gh`, a real token, or real network.
+
+The `aws` recipe above is manual-only for now. The same harness can be extended to cover it when there is a published Aileron connector spec for the upstream.

--- a/internal/app/github_bindings.go
+++ b/internal/app/github_bindings.go
@@ -25,18 +25,26 @@ const githubBasicUsername = "x-access-token"
 // GitHub secret; the daemon resolves user/github from the vault and
 // injects the credential per the matched binding's scheme:
 //
-//   - github.com -> basic, emitting
+//   - github.com -> basic, emit-mechanism A, emitting
 //     "Authorization: Basic base64(x-access-token:<token>)", the
 //     git-over-HTTPS convention used by `git clone`/`git push`.
-//   - api.github.com -> bearer, emitting
-//     "Authorization: Bearer <token>", the `gh`/REST convention.
+//     git-over-HTTPS issues an unauthenticated request (its no-op
+//     credential helper supplies empty credentials), so the proxy
+//     injects unconditionally with no sentinel needed.
+//   - api.github.com -> bearer, emit-mechanism B, emitting
+//     "Authorization: Bearer <token>", the `gh`/REST convention. `gh`
+//     short-circuits locally without a token, so the launcher plants a
+//     non-secret sentinel as GH_TOKEN; the proxy swaps the sentinel for
+//     the real credential at egress and leaves a foreign token untouched
+//     (#1196).
 //
-// Both name the same credential-ref (user/github); the scheme is what
-// differs. No secret bytes appear in the returned descriptors: a
-// binding names where the credential lives, never its value. Resolution
-// fails closed daemon-side when the vault is locked or the entry is
-// absent (the binding-injection path writes no Authorization header and
-// no secret in that case; see injectSandboxProxyHostBindingCredential).
+// Both name the same credential-ref (user/github); the scheme and emit
+// mechanism are what differ. No secret bytes appear in the returned
+// descriptors: a binding names where the credential lives, never its
+// value. Resolution fails closed daemon-side when the vault is locked or
+// the entry is absent (the binding-injection path writes no Authorization
+// header and no secret in that case; see
+// injectSandboxProxyHostBindingCredential).
 //
 // The two host patterns are exact (no wildcard): only github.com and
 // api.github.com are sealed, so a request to any other *.github.com
@@ -53,6 +61,7 @@ func gitHubHostBindings() (binding.HostBindings, error) {
 	}
 	api, err := binding.NewHostBinding(
 		"api.github.com", githubCredentialRef, binding.SchemeBearer,
+		binding.WithEmitMechanismB(),
 	)
 	if err != nil {
 		return nil, fmt.Errorf("github host binding (api.github.com): %w", err)

--- a/internal/app/github_bindings_test.go
+++ b/internal/app/github_bindings_test.go
@@ -65,6 +65,31 @@ func TestGitHubHostBindings_APIIsBearer(t *testing.T) {
 	}
 }
 
+func TestGitHubHostBindings_EmitMechanisms(t *testing.T) {
+	// The emit mechanism differs per host (#1196): git-over-HTTPS on
+	// github.com issues an unauthenticated request the proxy seals
+	// (mechanism A), while `gh` short-circuits without a token so
+	// api.github.com uses the sentinel-swap gate (mechanism B).
+	bindings, err := gitHubHostBindings()
+	if err != nil {
+		t.Fatalf("gitHubHostBindings: %v", err)
+	}
+	apex, ok := bindings.Match("github.com")
+	if !ok {
+		t.Fatal("no binding matched github.com")
+	}
+	if apex.EmitMechanism != binding.EmitMechanismA {
+		t.Errorf("github.com EmitMechanism = %q, want A (git emits an unauthenticated request)", apex.EmitMechanism)
+	}
+	api, ok := bindings.Match("api.github.com")
+	if !ok {
+		t.Fatal("no binding matched api.github.com")
+	}
+	if api.EmitMechanism != binding.EmitMechanismB {
+		t.Errorf("api.github.com EmitMechanism = %q, want B (gh short-circuits without a token)", api.EmitMechanism)
+	}
+}
+
 func TestGitHubHostBindings_ExactHostsOnly(t *testing.T) {
 	// Only the two exact apexes are sealed. A different github.com
 	// subdomain (e.g. raw content host) must not match either binding,

--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -646,6 +646,46 @@ func (s *apiServer) recordSandboxProxyBindingInjected(r *http.Request, source, h
 	)
 }
 
+// recordSandboxProxyForeignTokenNotSwapped emits
+// sandbox.proxy.foreign_token_not_swapped for a request on an
+// emit-mechanism B host binding (#1196) that carried a foreign
+// (non-sentinel) token. The proxy did not swap it: it forwarded the
+// request unchanged with no real credential injected. The payload
+// carries the matched host pattern, scheme, and upstream
+// destination/status; it never carries the foreign token, the sentinel,
+// the real credential, or the credential-ref. nil-recorder safe like its
+// siblings.
+func (s *apiServer) recordSandboxProxyForeignTokenNotSwapped(r *http.Request, source, hostPattern, scheme string, upstream *url.URL, upstreamStatus int) string {
+	if s.auditRecorder == nil {
+		if s.newID != nil {
+			return s.newID()
+		}
+		return audit.DefaultIDFn()
+	}
+	payload := map[string]any{
+		"aileron.proxy.boundary":        "https_proxy",
+		"aileron.proxy.mediation":       "https_proxy",
+		"aileron.proxy.source":          source,
+		"aileron.proxy.decision":        "foreign_token_not_swapped",
+		"aileron.proxy.method":          r.Method,
+		"aileron.proxy.binding.host":    hostPattern,
+		"aileron.proxy.binding.scheme":  scheme,
+		"aileron.proxy.upstream.scheme": upstream.Scheme,
+		"aileron.proxy.upstream.host":   upstream.Host,
+		"aileron.proxy.upstream.path":   sandboxProxyUpstreamPath(upstream),
+		"aileron.proxy.upstream.status": upstreamStatus,
+	}
+	if sessionID := strings.TrimSpace(r.Header.Get("X-Aileron-Session-Id")); sessionID != "" {
+		payload["aileron.session.id"] = sessionID
+	}
+	return s.auditRecorder.RecordSuccess(
+		r.Context(),
+		model.EventTypeSandboxProxyForeignTokenNotSwapped,
+		model.ActorRef{Type: model.ActorTypeAgent, ID: "sandbox-proxy"},
+		payload,
+	)
+}
+
 func ptrNonEmpty(value string) *string {
 	if strings.TrimSpace(value) == "" {
 		return nil

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -271,6 +271,28 @@ func (s *apiServer) routeSandboxForwardProxyHostBinding(conn net.Conn, decrypted
 		upstreamReq.Header.Set("Content-Type", contentType)
 	}
 
+	// Emit-mechanism B sentinel-swap gate (#1196). For a mechanism-B
+	// binding the proxy seals only tokens it itself planted: the
+	// recognized sentinel is stripped here and replaced by the real
+	// credential below, while a foreign token is forwarded unchanged with
+	// no real secret injected. A mechanism-A binding always injects.
+	switch decideSentinelSwap(upstreamReq, hb) {
+	case sentinelSwapPassthroughForeign:
+		// The agent supplied its own token on a mechanism-B host. Do not
+		// swap: dial upstream with the foreign carrier intact and no real
+		// credential injected. The sentinel/secret never enter this path.
+		resp, err := s.dialSandboxForwardProxyHostBinding(conn, decrypted, auth, targetHost, upstream, upstreamReq)
+		if err != nil {
+			return true
+		}
+		defer resp.body.Close()
+		s.recordSandboxProxyForeignTokenNotSwapped(decrypted, sandboxProxySourceTransparentConnectTLS, hb.HostPattern, hb.Scheme, upstream, resp.statusCode)
+		writeSandboxForwardProxyPassthroughResponse(conn, auth.SessionID, targetHost, resp.resp, resp.bodyBytes)
+		return true
+	case sentinelSwapInject:
+		// fall through to credential injection below.
+	}
+
 	if injected, reason := s.injectSandboxProxyHostBindingCredential(decrypted.Context(), upstreamReq, hb); !injected {
 		status := http.StatusInternalServerError
 		if reason == hostBindingRejectUnsupportedScheme {
@@ -281,30 +303,65 @@ func (s *apiServer) routeSandboxForwardProxyHostBinding(conn net.Conn, decrypted
 		return true
 	}
 
+	dialed, err := s.dialSandboxForwardProxyHostBinding(conn, decrypted, auth, targetHost, upstream, upstreamReq)
+	if err != nil {
+		return true
+	}
+	defer dialed.body.Close()
+
+	s.recordSandboxProxyBindingInjected(decrypted, sandboxProxySourceTransparentConnectTLS, hb.HostPattern, hb.Scheme, upstream, dialed.statusCode)
+	writeSandboxForwardProxyPassthroughResponse(conn, auth.SessionID, targetHost, dialed.resp, dialed.bodyBytes)
+	return true
+}
+
+// sandboxForwardProxyHostBindingResponse carries an upstream response
+// dialed on the host-binding path back to the caller so the caller can
+// record its own audit decision (binding_injected vs.
+// foreign_token_not_swapped) before writing the response. body is the
+// response body the caller must Close; bodyBytes is the size-capped,
+// already-read body to write back.
+type sandboxForwardProxyHostBindingResponse struct {
+	resp       *http.Response
+	body       io.Closer
+	bodyBytes  []byte
+	statusCode int
+}
+
+// dialSandboxForwardProxyHostBinding dials the prepared upstream request
+// on the host-binding path, reading and size-capping the response. On any
+// failure it records the matching protocol-rejection audit event, writes
+// the error envelope to conn, and returns a non-nil error so the caller
+// returns handled. On success the caller owns recording the audit
+// decision and closing the returned body.
+func (s *apiServer) dialSandboxForwardProxyHostBinding(conn net.Conn, decrypted *http.Request, auth sandboxProxyAuth, targetHost string, upstream *url.URL, upstreamReq *http.Request) (sandboxForwardProxyHostBindingResponse, error) {
 	client := sandboxProxyHTTPClient(s.sandboxProxyClient)
 	resp, err := client.Do(upstreamReq)
 	if err != nil {
 		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "binding_upstream_unreachable")
 		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy host-binding upstream unreachable")
-		return true
+		return sandboxForwardProxyHostBindingResponse{}, err
 	}
-	defer resp.Body.Close()
 
 	respBody, err := io.ReadAll(io.LimitReader(resp.Body, sandboxProxyMaxResponseBytes+1))
 	if err != nil {
+		resp.Body.Close()
 		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "binding_upstream_read_failed")
 		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy host-binding upstream response read failed")
-		return true
+		return sandboxForwardProxyHostBindingResponse{}, err
 	}
 	if len(respBody) > sandboxProxyMaxResponseBytes {
+		resp.Body.Close()
 		s.recordSandboxProxyProtocolRejected(decrypted, sandboxProxySourceTransparentConnectTLS, decrypted.Method, upstream, "binding_upstream_response_too_large")
 		writeSandboxForwardProxyError(conn, http.StatusBadGateway, auth.SessionID, targetHost, "sandbox proxy host-binding upstream response exceeded size limit")
-		return true
+		return sandboxForwardProxyHostBindingResponse{}, fmt.Errorf("sandbox proxy host-binding upstream response exceeded size limit")
 	}
 
-	s.recordSandboxProxyBindingInjected(decrypted, sandboxProxySourceTransparentConnectTLS, hb.HostPattern, hb.Scheme, upstream, resp.StatusCode)
-	writeSandboxForwardProxyPassthroughResponse(conn, auth.SessionID, targetHost, resp, respBody)
-	return true
+	return sandboxForwardProxyHostBindingResponse{
+		resp:       resp,
+		body:       resp.Body,
+		bodyBytes:  respBody,
+		statusCode: resp.StatusCode,
+	}, nil
 }
 
 // passthroughSandboxForwardProxy forwards a decrypted CONNECT/TLS

--- a/internal/app/sandbox_forward_proxy_sentinel.go
+++ b/internal/app/sandbox_forward_proxy_sentinel.go
@@ -1,0 +1,108 @@
+package app
+
+import (
+	"net/http"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+	"github.com/ALRubinger/aileron/internal/sentinel"
+)
+
+// sentinelSwapDecision is the result of inspecting the inbound credential
+// carrier on a matched host binding to decide whether the egress seam
+// should inject the bound credential (emit-mechanism B sentinel-swap,
+// ADR-0019, #1196).
+type sentinelSwapDecision int
+
+const (
+	// sentinelSwapInject means proceed with the binding's injection
+	// scheme: either the binding is emit-mechanism A (the default, always
+	// inject), or it is mechanism B and the inbound carrier is the
+	// recognized sentinel (which is stripped before injection so it never
+	// reaches upstream), or it is mechanism B with no carrier at all.
+	sentinelSwapInject sentinelSwapDecision = iota
+
+	// sentinelSwapPassthroughForeign means the binding is mechanism B and
+	// the inbound carrier is a foreign (non-sentinel) token. The proxy
+	// must NOT swap it: it seals only tokens it planted. The request is
+	// forwarded unchanged with the foreign carrier intact and no real
+	// credential injected. This is the load-bearing safety property.
+	sentinelSwapPassthroughForeign
+)
+
+// carrierHeader is the request header the GitHub bearer/basic schemes
+// carry the credential in. The sentinel rides here when `gh` issues its
+// request, so it is the header the swap gate inspects and strips.
+const carrierHeader = "Authorization"
+
+// decideSentinelSwap inspects the inbound credential carrier on req for a
+// matched host binding and returns whether the egress seam should inject
+// the bound credential or forward a foreign token unchanged.
+//
+// For an emit-mechanism A binding it always returns sentinelSwapInject:
+// mechanism A plants nothing and injects unconditionally, the pre-#1196
+// behavior, so the carrier (if any) is overwritten by the scheme.
+//
+// For an emit-mechanism B binding it gates on the carrier:
+//   - the recognized sentinel  -> strip the carrier and inject (the
+//     sentinel value is never forwarded upstream);
+//   - a foreign, non-empty token -> do not inject; forward unchanged;
+//   - no carrier / empty carrier -> inject per the binding's scheme.
+//
+// Recognition is delegated to the sentinel package (the single source of
+// truth shared with the launcher) so the launch-side plant and the
+// proxy-side recognizer cannot drift. Only the GitHub sentinel exists
+// today; a future mechanism-B host adds its own recognizer here without
+// touching the binding-match wiring.
+func decideSentinelSwap(req *http.Request, hb binding.HostBinding) sentinelSwapDecision {
+	if hb.EmitMechanism != binding.EmitMechanismB {
+		return sentinelSwapInject
+	}
+
+	carrier := strings.TrimSpace(req.Header.Get(carrierHeader))
+	if carrier == "" {
+		// No carrier: nothing to swap, inject per the binding's scheme.
+		return sentinelSwapInject
+	}
+
+	if bindingSentinelMatches(hb, carrier) {
+		// Our own plant: strip it so it never reaches upstream, then let
+		// the scheme inject the real credential in its place.
+		req.Header.Del(carrierHeader)
+		return sentinelSwapInject
+	}
+
+	// A foreign token the agent supplied itself. We neither steal-swap it
+	// nor leak our secret: forward it unchanged.
+	return sentinelSwapPassthroughForeign
+}
+
+// bindingSentinelMatches reports whether carrier bears the sentinel the
+// launcher plants for this mechanism-B binding. The carrier may be the
+// bare sentinel (gh sets GH_TOKEN verbatim and some clients send the
+// token alone) or a "Bearer <sentinel>" / "token <sentinel>" form, so
+// the scheme prefix is tolerated before the exact sentinel match.
+//
+// Only the GitHub sentinel is wired today; the credential-ref's GitHub
+// shape selects it. A future mechanism-B host pattern adds its own arm.
+func bindingSentinelMatches(hb binding.HostBinding, carrier string) bool {
+	value := stripAuthScheme(carrier)
+	if hb.CredentialRef == githubCredentialRef {
+		return sentinel.IsGitHubTokenSentinel(value)
+	}
+	return false
+}
+
+// stripAuthScheme removes a leading "Bearer " or "token " auth-scheme
+// prefix (case-insensitive) so the remaining value can be matched
+// against the bare sentinel. A carrier with no recognized prefix is
+// returned trimmed and unchanged.
+func stripAuthScheme(carrier string) string {
+	carrier = strings.TrimSpace(carrier)
+	for _, prefix := range []string{"Bearer ", "token "} {
+		if len(carrier) >= len(prefix) && strings.EqualFold(carrier[:len(prefix)], prefix) {
+			return strings.TrimSpace(carrier[len(prefix):])
+		}
+	}
+	return carrier
+}

--- a/internal/app/sandbox_forward_proxy_sentinel_swap_test.go
+++ b/internal/app/sandbox_forward_proxy_sentinel_swap_test.go
@@ -1,0 +1,212 @@
+package app
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+	"github.com/ALRubinger/aileron/internal/sentinel"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// Emit-mechanism B sentinel-swap contract at the egress boundary (#1196),
+// driven through the real forward-proxy CONNECT/TLS path against the
+// built-in api.github.com binding (bearer, mechanism B):
+//
+//	(a) a request bearing the reserved sentinel is swapped: the upstream
+//	    sees the real credential via the bearer scheme, never the sentinel.
+//	(b) a request bearing a foreign (non-sentinel) token is NOT swapped:
+//	    the upstream sees the foreign token unchanged and no real secret.
+//	(c) the sentinel string never reaches the upstream in any case.
+//	(d) neither the swap nor the no-swap audit event carries any secret,
+//	    sentinel, or foreign-token bytes.
+
+func newGitHubSentinelServer(t *testing.T, v vault.Vault, capture *string) (*apiServer, *audit.MemStore) {
+	t.Helper()
+	ghBindings, err := gitHubHostBindings()
+	if err != nil {
+		t.Fatalf("gitHubHostBindings: %v", err)
+	}
+	store := audit.NewMemStore()
+	srv := &apiServer{
+		auditStore:    store,
+		auditRecorder: audit.NewRecorder(store, nil, func() string { return "audit-sentinel-swap" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         v,
+		hostBindings:  ghBindings,
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			if capture != nil {
+				*capture = req.Header.Get("Authorization")
+			}
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	return srv, store
+}
+
+func TestSentinelSwap_SentinelIsSwappedForRealCredential(t *testing.T) {
+	const realToken = "ghp_realrealreal_secret"
+	v := mustVaultWith(t, "user/github", "user", []byte(realToken))
+	var upstreamAuth string
+	srv, store := newGitHubSentinelServer(t, v, &upstreamAuth)
+	setup := newHostBindingProxySetup(t, srv)
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// gh sends the planted sentinel as a bearer token.
+	req.Header.Set("Authorization", "Bearer "+sentinel.GitHubTokenSentinel)
+	resp, err := setup.client.Do(req)
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	// (a) the upstream sees the real credential via bearer.
+	if upstreamAuth != "Bearer "+realToken {
+		t.Errorf("upstream Authorization = %q, want Bearer %s", upstreamAuth, realToken)
+	}
+	// (c) the sentinel never reaches the upstream.
+	if strings.Contains(upstreamAuth, sentinel.GitHubTokenSentinel) {
+		t.Errorf("upstream Authorization leaked the sentinel: %q", upstreamAuth)
+	}
+	// The in-container client never sees the real token.
+	if strings.Contains(string(body), realToken) {
+		t.Error("response body leaked the real token")
+	}
+	// (d) audit carries no secret/sentinel bytes; a binding_injected event
+	// is recorded for the swap.
+	assertNoSecretInAudit(t, store, realToken, sentinel.GitHubTokenSentinel)
+	assertAuditDecision(t, store, "binding_injected")
+}
+
+func TestSentinelSwap_ForeignTokenIsNotSwapped(t *testing.T) {
+	const realToken = "ghp_realrealreal_secret"
+	const foreignToken = "ghp_userssowntokenABCDEF1234567890wxyz"
+	v := mustVaultWith(t, "user/github", "user", []byte(realToken))
+	var upstreamAuth string
+	srv, store := newGitHubSentinelServer(t, v, &upstreamAuth)
+	setup := newHostBindingProxySetup(t, srv)
+
+	req, err := http.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
+	if err != nil {
+		t.Fatalf("new request: %v", err)
+	}
+	// The agent supplied its own token, not the sentinel.
+	req.Header.Set("Authorization", "Bearer "+foreignToken)
+	resp, err := setup.client.Do(req)
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	// (b) the foreign token is forwarded unchanged; no real secret.
+	if upstreamAuth != "Bearer "+foreignToken {
+		t.Errorf("upstream Authorization = %q, want the foreign token unchanged (Bearer %s)", upstreamAuth, foreignToken)
+	}
+	if strings.Contains(upstreamAuth, realToken) {
+		t.Errorf("upstream Authorization leaked the real token on a foreign-token request: %q", upstreamAuth)
+	}
+	// (c) the sentinel never appears either.
+	if strings.Contains(upstreamAuth, sentinel.GitHubTokenSentinel) {
+		t.Errorf("upstream Authorization leaked the sentinel: %q", upstreamAuth)
+	}
+	if strings.Contains(string(body), realToken) {
+		t.Error("response body leaked the real token")
+	}
+	// (d) audit records the no-swap decision and carries no real secret.
+	assertNoSecretInAudit(t, store, realToken, sentinel.GitHubTokenSentinel)
+	assertAuditDecision(t, store, "foreign_token_not_swapped")
+}
+
+func TestSentinelSwap_BareSentinelWithoutSchemePrefixIsSwapped(t *testing.T) {
+	// Some clients send the token value alone (no "Bearer " prefix). The
+	// gate tolerates that and still recognizes our plant.
+	const realToken = "ghp_bareseal_secret"
+	v := mustVaultWith(t, "user/github", "user", []byte(realToken))
+	var upstreamAuth string
+	srv, _ := newGitHubSentinelServer(t, v, &upstreamAuth)
+	setup := newHostBindingProxySetup(t, srv)
+
+	req, _ := http.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
+	req.Header.Set("Authorization", sentinel.GitHubTokenSentinel)
+	resp, err := setup.client.Do(req)
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if upstreamAuth != "Bearer "+realToken {
+		t.Errorf("upstream Authorization = %q, want Bearer %s (bare sentinel must still swap)", upstreamAuth, realToken)
+	}
+}
+
+func TestSentinelSwap_NoCarrierStillInjects(t *testing.T) {
+	// A mechanism-B host with no inbound carrier injects per the binding's
+	// scheme (the sentinel-swap gate governs only the carrier-present case).
+	const realToken = "ghp_nocarrier_secret"
+	v := mustVaultWith(t, "user/github", "user", []byte(realToken))
+	var upstreamAuth string
+	srv, _ := newGitHubSentinelServer(t, v, &upstreamAuth)
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.github.com/user")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+
+	if upstreamAuth != "Bearer "+realToken {
+		t.Errorf("upstream Authorization = %q, want Bearer %s on a no-carrier mechanism-B request", upstreamAuth, realToken)
+	}
+}
+
+// assertNoSecretInAudit scans every recorded audit event's payload for
+// any of the forbidden values (the real secret and the sentinel) and
+// fails if any appears. It mirrors sandbox_proxy_audit_shape_test.go's
+// grep-style isolation assertion.
+func assertNoSecretInAudit(t *testing.T, store *audit.MemStore, forbidden ...string) {
+	t.Helper()
+	events, _ := store.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) == 0 {
+		t.Fatal("no audit events recorded; expected at least one proxy event")
+	}
+	for _, ev := range events {
+		raw, err := json.Marshal(ev.Payload)
+		if err != nil {
+			t.Fatalf("marshal audit payload: %v", err)
+		}
+		for _, secret := range forbidden {
+			if secret != "" && strings.Contains(string(raw), secret) {
+				t.Errorf("audit payload leaked forbidden value %q: %s", secret, raw)
+			}
+		}
+	}
+}
+
+// assertAuditDecision asserts at least one recorded event carries the
+// given aileron.proxy.decision value.
+func assertAuditDecision(t *testing.T, store *audit.MemStore, decision string) {
+	t.Helper()
+	events, _ := store.ListEvents(context.Background(), audit.EventFilter{})
+	for _, ev := range events {
+		if d, ok := ev.Payload["aileron.proxy.decision"].(string); ok && d == decision {
+			return
+		}
+	}
+	t.Errorf("no audit event with decision %q; events=%d", decision, len(events))
+}

--- a/internal/app/sandbox_forward_proxy_sentinel_test.go
+++ b/internal/app/sandbox_forward_proxy_sentinel_test.go
@@ -1,0 +1,110 @@
+package app
+
+import (
+	"net/http"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+	"github.com/ALRubinger/aileron/internal/sentinel"
+)
+
+// Unit-level coverage of the sentinel-swap decision helper, independent
+// of the proxy plumbing (#1196). The end-to-end behavior is covered in
+// sandbox_forward_proxy_sentinel_swap_test.go; these assert the decision
+// branches and that the sentinel is stripped from the carrier on a swap.
+
+func mustHostBindingB(t *testing.T) binding.HostBinding {
+	t.Helper()
+	hb, err := binding.NewHostBinding("api.github.com", githubCredentialRef, binding.SchemeBearer, binding.WithEmitMechanismB())
+	if err != nil {
+		t.Fatalf("NewHostBinding: %v", err)
+	}
+	return hb
+}
+
+func reqWithAuth(value string) *http.Request {
+	r, _ := http.NewRequest(http.MethodGet, "https://api.github.com/user", nil)
+	if value != "" {
+		r.Header.Set(carrierHeader, value)
+	}
+	return r
+}
+
+func TestDecideSentinelSwap_MechanismAAlwaysInjects(t *testing.T) {
+	hb, err := binding.NewHostBinding("github.com", githubCredentialRef, binding.SchemeBasic, binding.WithBasicUsername("x-access-token"))
+	if err != nil {
+		t.Fatalf("NewHostBinding: %v", err)
+	}
+	// Even with a foreign carrier present, mechanism A injects (overwrites).
+	r := reqWithAuth("Bearer ghp_someforeigntoken")
+	if got := decideSentinelSwap(r, hb); got != sentinelSwapInject {
+		t.Errorf("mechanism A decision = %v, want inject", got)
+	}
+}
+
+func TestDecideSentinelSwap_SentinelIsStrippedAndInjected(t *testing.T) {
+	hb := mustHostBindingB(t)
+	r := reqWithAuth("Bearer " + sentinel.GitHubTokenSentinel)
+	if got := decideSentinelSwap(r, hb); got != sentinelSwapInject {
+		t.Errorf("sentinel decision = %v, want inject", got)
+	}
+	// The sentinel carrier must be stripped so the scheme can set the real
+	// credential and the sentinel never rides upstream.
+	if v := r.Header.Get(carrierHeader); v != "" {
+		t.Errorf("carrier after swap = %q, want stripped (empty)", v)
+	}
+}
+
+func TestDecideSentinelSwap_ForeignTokenIsNotSwapped(t *testing.T) {
+	hb := mustHostBindingB(t)
+	const foreign = "Bearer ghp_theusersowntoken1234567890abcd"
+	r := reqWithAuth(foreign)
+	if got := decideSentinelSwap(r, hb); got != sentinelSwapPassthroughForeign {
+		t.Errorf("foreign-token decision = %v, want passthrough-foreign", got)
+	}
+	// The foreign carrier must be left intact for the unchanged forward.
+	if v := r.Header.Get(carrierHeader); v != foreign {
+		t.Errorf("foreign carrier mutated = %q, want unchanged %q", v, foreign)
+	}
+}
+
+func TestDecideSentinelSwap_NoCarrierInjects(t *testing.T) {
+	hb := mustHostBindingB(t)
+	r := reqWithAuth("")
+	if got := decideSentinelSwap(r, hb); got != sentinelSwapInject {
+		t.Errorf("no-carrier decision = %v, want inject", got)
+	}
+}
+
+func TestStripAuthScheme(t *testing.T) {
+	cases := map[string]string{
+		"Bearer abc":     "abc",
+		"bearer abc":     "abc",
+		"token abc":      "abc",
+		"TOKEN abc":      "abc",
+		"abc":            "abc",
+		"  Bearer  abc ": "abc",
+		"Basic xyz":      "Basic xyz", // unrecognized scheme left intact
+	}
+	for in, want := range cases {
+		if got := stripAuthScheme(in); got != want {
+			t.Errorf("stripAuthScheme(%q) = %q, want %q", in, got, want)
+		}
+	}
+}
+
+func TestBindingSentinelMatches_OnlyGitHubRefRecognized(t *testing.T) {
+	gh := mustHostBindingB(t)
+	if !bindingSentinelMatches(gh, "Bearer "+sentinel.GitHubTokenSentinel) {
+		t.Error("github binding did not recognize its own sentinel")
+	}
+	// A mechanism-B binding for a different credential-ref has no wired
+	// recognizer yet, so it never matches (fails safe: no swap).
+	other, err := binding.NewHostBinding("api.other.test", "user/other", binding.SchemeBearer, binding.WithEmitMechanismB())
+	if err != nil {
+		t.Fatalf("NewHostBinding: %v", err)
+	}
+	if bindingSentinelMatches(other, "Bearer "+sentinel.GitHubTokenSentinel) {
+		t.Error("non-github binding matched the github sentinel; recognizers must be per-binding")
+	}
+}

--- a/internal/app/sandbox_proxy_audit_shape_test.go
+++ b/internal/app/sandbox_proxy_audit_shape_test.go
@@ -215,6 +215,29 @@ var (
 		},
 	}
 
+	sandboxProxyForeignTokenNotSwappedShape = sandboxProxyEventShape{
+		eventType: "sandbox.proxy.foreign_token_not_swapped",
+		requiredFields: []string{
+			"aileron.proxy.boundary",
+			"aileron.proxy.mediation",
+			"aileron.proxy.source",
+			"aileron.proxy.decision",
+			"aileron.proxy.method",
+			"aileron.proxy.binding.host",
+			"aileron.proxy.binding.scheme",
+			"aileron.proxy.upstream.scheme",
+			"aileron.proxy.upstream.host",
+			"aileron.proxy.upstream.path",
+			"aileron.proxy.upstream.status",
+		},
+		allowedFields: []string{
+			"aileron.session.id",
+		},
+		forbiddenSubstrs: []string{
+			"lin_secret", "Bearer ", "Authorization",
+		},
+	}
+
 	sandboxProxyDisabledShape = sandboxProxyEventShape{
 		eventType: "sandbox.proxy.disabled",
 		requiredFields: []string{
@@ -334,6 +357,41 @@ func TestSandboxProxyAuditShape_SandboxProxyBindingInjectedConforms(t *testing.T
 		t.Fatalf("event type = %q", events[0].EventType)
 	}
 	sandboxProxyBindingInjectedShape.validate(t, events[0].Payload)
+}
+
+func TestSandboxProxyAuditShape_ForeignTokenNotSwappedConforms(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-shape-foreign" }),
+	}
+	req := httptest.NewRequest(http.MethodConnect, "/", nil)
+	req.Header.Set("X-Aileron-Session-Id", "session-shape-test")
+	req.Method = http.MethodGet
+	upstream, _ := url.Parse("https://api.github.com/user")
+	srv.recordSandboxProxyForeignTokenNotSwapped(req, sandboxProxySourceTransparentConnectTLS, "api.github.com", "bearer", upstream, 200)
+	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	if events[0].EventType != model.EventTypeSandboxProxyForeignTokenNotSwapped {
+		t.Fatalf("event type = %q", events[0].EventType)
+	}
+	sandboxProxyForeignTokenNotSwappedShape.validate(t, events[0].Payload)
+}
+
+func TestSandboxProxyAuditShape_ForeignTokenNotSwappedNilRecorderIsIDSafe(t *testing.T) {
+	upstream, _ := url.Parse("https://api.github.com/user")
+	req := httptest.NewRequest(http.MethodGet, "/", nil)
+
+	srv := &apiServer{newID: func() string { return "minted-id" }}
+	if got := srv.recordSandboxProxyForeignTokenNotSwapped(req, sandboxProxySourceTransparentConnectTLS, "api.github.com", "bearer", upstream, 200); got != "minted-id" {
+		t.Errorf("audit id = %q, want minted-id", got)
+	}
+
+	srvNoID := &apiServer{}
+	if got := srvNoID.recordSandboxProxyForeignTokenNotSwapped(req, sandboxProxySourceTransparentConnectTLS, "api.github.com", "bearer", upstream, 200); strings.TrimSpace(got) == "" {
+		t.Error("audit id must be non-empty even with no recorder and no newID")
+	}
 }
 
 func TestSandboxProxyAuditShape_BindingInjectedNilRecorderIsIDSafe(t *testing.T) {

--- a/internal/binding/host_binding.go
+++ b/internal/binding/host_binding.go
@@ -34,6 +34,30 @@ const SchemeBearer = "bearer"
 // credential bytes.
 const SchemeBasic = "basic"
 
+// EmitMechanism names how the in-container client is made to emit a
+// request the proxy can seal at egress (ADR-0019, #1196). It is
+// orthogonal to [HostBinding.Scheme], which is how the proxy injects the
+// credential once the request arrives.
+type EmitMechanism string
+
+const (
+	// EmitMechanismA is the default: the launcher plants no token. The
+	// client emits an unauthenticated (or no-credential) request, and the
+	// proxy unconditionally injects the bound credential at egress. Used
+	// for clients that issue the request without holding a token (curl,
+	// git-over-HTTPS with a no-op credential helper).
+	EmitMechanismA EmitMechanism = "A"
+
+	// EmitMechanismB is sentinel-swap: the launcher plants a non-secret,
+	// format-mimicking sentinel token so a client that short-circuits
+	// locally without a token (e.g. `gh`) issues its request. The proxy
+	// swaps the sentinel for the real credential at egress, and ONLY
+	// swaps when it recognizes its own planted sentinel. A foreign token
+	// on a mechanism-B host is left untouched (no steal-swap, no real
+	// secret injected). See the swap recognizer at the egress seam.
+	EmitMechanismB EmitMechanism = "B"
+)
+
 // HostBinding is the declarative triple that maps an upstream host
 // pattern to a vault credential and the scheme used to inject it. It is
 // a distinct concept from [Binding]: a [Binding] is keyed on
@@ -68,6 +92,14 @@ type HostBinding struct {
 	// in the password field, never here. Required for the basic scheme,
 	// ignored for every other scheme.
 	BasicUsername string
+
+	// EmitMechanism declares how the in-container client is made to emit
+	// a sealable request (see [EmitMechanism]). The zero value is
+	// [EmitMechanismA] (plant nothing, inject unconditionally), which
+	// preserves the pre-#1196 behavior. [EmitMechanismB] enables the
+	// sentinel-swap gate at egress for hosts whose client short-circuits
+	// without a planted token. Set via [WithEmitMechanismB].
+	EmitMechanism EmitMechanism
 }
 
 // userRefRe matches the user-level credential namespace `user/<service>`
@@ -86,6 +118,17 @@ type HostBindingOption func(*HostBinding)
 // username used by [SchemeBasic]. It is required for that scheme.
 func WithBasicUsername(username string) HostBindingOption {
 	return func(hb *HostBinding) { hb.BasicUsername = username }
+}
+
+// WithEmitMechanismB marks the binding as [EmitMechanismB] (sentinel-
+// swap). Use it for a host whose in-container client short-circuits
+// locally without a planted token (e.g. `gh`): the launcher plants a
+// non-secret sentinel and the egress seam swaps it for the real
+// credential only when it recognizes its own plant. Without this option
+// a binding defaults to [EmitMechanismA] (plant nothing, inject
+// unconditionally).
+func WithEmitMechanismB() HostBindingOption {
+	return func(hb *HostBinding) { hb.EmitMechanism = EmitMechanismB }
 }
 
 // NewHostBinding validates and constructs a HostBinding. It rejects an
@@ -113,7 +156,7 @@ func NewHostBinding(hostPattern, credentialRef, scheme string, opts ...HostBindi
 	if _, ok := HostBindingSchemes[scheme]; !ok {
 		return HostBinding{}, fmt.Errorf("host binding: unknown injection scheme %q", scheme)
 	}
-	hb := HostBinding{HostPattern: hp, CredentialRef: credentialRef, Scheme: scheme}
+	hb := HostBinding{HostPattern: hp, CredentialRef: credentialRef, Scheme: scheme, EmitMechanism: EmitMechanismA}
 	for _, opt := range opts {
 		opt(&hb)
 	}

--- a/internal/binding/host_binding_test.go
+++ b/internal/binding/host_binding_test.go
@@ -33,6 +33,30 @@ func TestNewHostBinding_AcceptsValidInput(t *testing.T) {
 	}
 }
 
+func TestNewHostBinding_DefaultsToEmitMechanismA(t *testing.T) {
+	// A binding constructed without an emit-mechanism option defaults to
+	// mechanism A (plant nothing, inject unconditionally), preserving the
+	// pre-#1196 behavior.
+	hb, err := binding.NewHostBinding("api.example.com", "user/example", "bearer")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hb.EmitMechanism != binding.EmitMechanismA {
+		t.Errorf("EmitMechanism = %q, want A by default", hb.EmitMechanism)
+	}
+}
+
+func TestNewHostBinding_WithEmitMechanismB(t *testing.T) {
+	hb, err := binding.NewHostBinding("api.github.com", "user/github", "bearer",
+		binding.WithEmitMechanismB())
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hb.EmitMechanism != binding.EmitMechanismB {
+		t.Errorf("EmitMechanism = %q, want B after WithEmitMechanismB", hb.EmitMechanism)
+	}
+}
+
 func TestNewHostBinding_RejectsInvalidScheme(t *testing.T) {
 	if _, err := binding.NewHostBinding("api.example.com", "oauth2/github/octocat", "magic"); err == nil {
 		t.Fatal("expected error for unknown scheme, got nil")

--- a/internal/launch/github_inject.go
+++ b/internal/launch/github_inject.go
@@ -11,6 +11,7 @@ import (
 	"strings"
 
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/sentinel"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
@@ -57,10 +58,15 @@ type userCredsDaemon interface {
 // per-agent AuthSpec.
 type githubInjectPrep struct {
 	// EnvAdditions merge into the agent's env. Under the ADR-0019
-	// sealing model (#1195) this never carries a GitHub secret: the
-	// token is resolved daemon-side and injected at the TLS boundary, so
-	// no GH_TOKEN is set. The field is retained for shape parity with
-	// authSpecPrep and for any future non-secret GitHub env.
+	// sealing model this never carries a GitHub secret. It does carry a
+	// non-secret GH_TOKEN set to sentinel.GitHubTokenSentinel when a
+	// usable user/github entry exists: `gh` short-circuits locally
+	// without a token in its env, so emit-mechanism A (plant nothing,
+	// seal the emitted request) cannot work for `gh`. The sentinel is a
+	// format-mimicking placeholder that passes `gh`'s local validation so
+	// `gh` issues its request; the daemon recognizes the sentinel at the
+	// TLS boundary and swaps in the real credential (emit-mechanism B,
+	// #1196). The sentinel is non-secret and safe to place in the env.
 	EnvAdditions map[string]string
 
 	// Mounts append to the sandbox volume list. Carries the individual
@@ -174,10 +180,16 @@ func prepareGitHubInject(
 	}
 
 	prep := emptyGitHubInjectPrep()
-	// No GH_TOKEN: the secret never enters the container under the
-	// ADR-0019 sealing model (#1195). The daemon resolves user/github
-	// and injects it at the TLS boundary via the host bindings. The
-	// mount below carries only the secret-free no-op gitconfig.
+	// GH_TOKEN carries the non-secret sentinel, never the real token.
+	// `gh` short-circuits locally without a token, so we plant the
+	// sentinel to make it issue its request; the daemon recognizes the
+	// sentinel at the TLS boundary and swaps in the real user/github
+	// credential (emit-mechanism B, #1196). The real secret never enters
+	// the container in env, mount, or args. The mount below carries only
+	// the secret-free no-op git credential helper (emit-mechanism A for
+	// git-over-HTTPS, which the daemon seals from the unauthenticated
+	// request git emits).
+	prep.EnvAdditions["GH_TOKEN"] = sentinel.GitHubTokenSentinel
 	prep.Mounts = []sandboxcontainer.Volume{{
 		Source:   hostPath,
 		Target:   githubConfigTarget,

--- a/internal/launch/github_inject_launcher_test.go
+++ b/internal/launch/github_inject_launcher_test.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/sentinel"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
@@ -37,10 +38,14 @@ func TestLauncherMergesGitHubInject_TokenPresent(t *testing.T) {
 	}
 	proxyMounts = append(proxyMounts, ghPrep.Mounts...)
 
-	// Sealed model (#1195): the merge appends the secret-free gitconfig
-	// mount but adds NO GH_TOKEN. The token never reaches agentEnv.
-	if _, ok := agentEnv["GH_TOKEN"]; ok {
-		t.Errorf("GH_TOKEN merged into agentEnv; sealed model must not env-inject the secret")
+	// Sealed model (#1195/#1196): the merge appends the secret-free
+	// gitconfig mount and sets GH_TOKEN to the NON-SECRET sentinel. The
+	// real token never reaches agentEnv.
+	if agentEnv["GH_TOKEN"] != sentinel.GitHubTokenSentinel {
+		t.Errorf("GH_TOKEN merged into agentEnv = %q, want the sentinel %q", agentEnv["GH_TOKEN"], sentinel.GitHubTokenSentinel)
+	}
+	if agentEnv["GH_TOKEN"] == "ghp_launch" {
+		t.Errorf("GH_TOKEN merged into agentEnv holds the real token; sealed model must not env-inject the secret")
 	}
 	if agentEnv["CLAUDE_CODE_OAUTH_TOKEN"] != "agent-oauth" {
 		t.Errorf("GitHub inject clobbered the AuthSpec env binding: %q", agentEnv["CLAUDE_CODE_OAUTH_TOKEN"])

--- a/internal/launch/github_inject_test.go
+++ b/internal/launch/github_inject_test.go
@@ -8,17 +8,22 @@ import (
 	"os"
 	"testing"
 
+	"github.com/ALRubinger/aileron/internal/sentinel"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
-// prepareGitHubInject contract (#1149, sealed by #1195):
+// prepareGitHubInject contract (#1149, sealed by #1195, sentinel-swap
+// added by #1196):
 //
 //   - The agent never holds the GitHub secret. A usable user/github
-//     entry yields NO GH_TOKEN env and a read-only file mount at
-//     /home/agent/.gitconfig whose host source contains NO secret
-//     bytes, NO `!gh auth git-credential` helper, and a no-op
-//     empty-credential helper scoped to https://github.com. The token
-//     is sealed daemon-side at the TLS boundary, not env-injected.
+//     entry yields a GH_TOKEN env set to the non-secret
+//     sentinel.GitHubTokenSentinel (so `gh` does not short-circuit and
+//     issues its request, which the daemon seals at the TLS boundary)
+//     and a read-only file mount at /home/agent/.gitconfig whose host
+//     source contains NO secret bytes, NO `!gh auth git-credential`
+//     helper, and a no-op empty-credential helper scoped to
+//     https://github.com. The real token is sealed daemon-side at egress,
+//     never env-injected and never in the mount.
 //   - ErrUserCredentialsNotFound and a locked vault both yield an empty
 //     prep with no error and a nil-safe Cleanup (skip-clean).
 //   - An empty-after-trim token is treated as no token.
@@ -43,9 +48,11 @@ func (f *fakeUserCredsDaemon) GetUserCredentials(_ context.Context, service stri
 }
 
 func TestPrepareGitHubInject_TokenPresent(t *testing.T) {
-	// Sealed model (#1195): a usable token mounts a secret-free gitconfig
-	// and sets NO GH_TOKEN. The token bytes must never appear in the env
-	// or the mounted file; the daemon seals the request at egress.
+	// Sealed model (#1195/#1196): a usable token mounts a secret-free
+	// gitconfig and sets GH_TOKEN to the NON-SECRET sentinel (so `gh`
+	// does not short-circuit). The real token bytes must never appear in
+	// the env or the mounted file; the daemon swaps the sentinel for the
+	// real credential at egress.
 	const tokenValue = "ghp_realtoken"
 	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte(tokenValue)}}
 	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
@@ -54,8 +61,25 @@ func TestPrepareGitHubInject_TokenPresent(t *testing.T) {
 	}
 	defer prep.Cleanup()
 
-	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
-		t.Errorf("GH_TOKEN present in EnvAdditions; sealed model must not env-inject the secret")
+	// GH_TOKEN must be present and equal to the sentinel, and recognized
+	// by the proxy-side recognizer. This is the emit-mechanism B plant.
+	ghToken, ok := prep.EnvAdditions["GH_TOKEN"]
+	if !ok {
+		t.Fatalf("GH_TOKEN absent from EnvAdditions; emit-mechanism B must plant the sentinel so gh does not short-circuit")
+	}
+	if ghToken != sentinel.GitHubTokenSentinel {
+		t.Errorf("GH_TOKEN = %q, want the sentinel %q", ghToken, sentinel.GitHubTokenSentinel)
+	}
+	if !sentinel.IsGitHubTokenSentinel(ghToken) {
+		t.Errorf("GH_TOKEN %q is not recognized by IsGitHubTokenSentinel; launch and proxy would drift", ghToken)
+	}
+	// The real token bytes must never appear anywhere in the env. This is
+	// the ADR-0019 regression guard: before this fix the real token was
+	// injected here verbatim.
+	for k, v := range prep.EnvAdditions {
+		if v == tokenValue {
+			t.Errorf("EnvAdditions[%q] holds the real token; the agent must never see the secret", k)
+		}
 	}
 	if len(prep.Mounts) != 1 {
 		t.Fatalf("Mounts = %d, want 1", len(prep.Mounts))
@@ -234,8 +258,14 @@ func TestPrepareGitHubInject_ChownHookFailureIsNonFatal(t *testing.T) {
 		t.Fatalf("chown failure must be non-fatal, got: %v", err)
 	}
 	defer prep.Cleanup()
-	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
-		t.Errorf("GH_TOKEN present after chown failure; sealed model must not env-inject the secret")
+	// A non-fatal chown failure still produces the full prep: the
+	// non-secret sentinel GH_TOKEN and the secret-free mount. The real
+	// token never appears regardless.
+	if prep.EnvAdditions["GH_TOKEN"] != sentinel.GitHubTokenSentinel {
+		t.Errorf("GH_TOKEN after chown failure = %q, want the sentinel", prep.EnvAdditions["GH_TOKEN"])
+	}
+	if prep.EnvAdditions["GH_TOKEN"] == "ghp_x" {
+		t.Errorf("GH_TOKEN holds the real token after chown failure; the agent must never see the secret")
 	}
 	if len(prep.Mounts) != 1 {
 		t.Errorf("Mounts = %d, want 1 after non-fatal chown failure", len(prep.Mounts))

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -530,16 +530,21 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		}
 
 		// User-level GitHub injection runs on every sandbox launch,
-		// independent of the per-agent AuthSpec: it reads the
-		// agent-independent `user/github` token from the vault and, when
-		// present, exports GH_TOKEN and mounts a static git
-		// credential-helper gitconfig at /home/agent/.gitconfig so both
-		// `gh` and git-over-HTTPS authenticate inside the sandbox. A
-		// missing entry or locked vault is a clean, non-fatal skip — the
-		// launch proceeds with GitHub operations unauthenticated. The
-		// chown hook mirrors the AuthSpec one: on rootful Docker Linux
-		// the host operator owns the transient dir, so the tree is
-		// chowned to the image's agent UID before mounting. See #1149.
+		// independent of the per-agent AuthSpec: it probes the
+		// agent-independent `user/github` token in the vault and, when
+		// present, exports a NON-SECRET sentinel GH_TOKEN and mounts a
+		// secret-free git credential-helper gitconfig at
+		// /home/agent/.gitconfig. The real token never enters the
+		// container: `gh` issues its request because the sentinel passes
+		// its local validation, and the daemon swaps the sentinel for the
+		// real credential at the TLS boundary (emit-mechanism B, #1196);
+		// git-over-HTTPS emits an unauthenticated request the daemon seals
+		// the same way (emit-mechanism A). A missing entry or locked vault
+		// is a clean, non-fatal skip — the launch proceeds with GitHub
+		// operations unauthenticated. The chown hook mirrors the AuthSpec
+		// one: on rootful Docker Linux the host operator owns the
+		// transient dir, so the tree is chowned to the image's agent UID
+		// before mounting. See #1149.
 		ghChownHook := newAgentDirChownHook(ctx, sandboxcontainer.DefaultRunner(),
 			sandboxPlan.Runtime, sandboxPlan.Image)
 		ghPrep, err := prepareGitHubInject(ctx, client, sessionLog, os.Stderr, ghChownHook)

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -337,6 +337,17 @@ const (
 	// ADR-0019.
 	EventTypeSandboxProxyBindingInjected EventType = "sandbox.proxy.binding_injected"
 
+	// Sandbox proxy event for a request on an emit-mechanism B host
+	// binding (sentinel-swap, #1196) whose inbound credential carrier
+	// bore a FOREIGN (non-sentinel) token. The proxy seals only tokens it
+	// itself planted, so it did NOT swap: it forwarded the request
+	// upstream with the agent-supplied token intact and injected no real
+	// credential. The payload carries the matched host pattern, scheme,
+	// and upstream destination/status; it never carries the foreign token,
+	// the sentinel, the real credential, or the credential-ref. See
+	// ADR-0019.
+	EventTypeSandboxProxyForeignTokenNotSwapped EventType = "sandbox.proxy.foreign_token_not_swapped"
+
 	// Sandbox proxy event for launches that proceed (or refuse to
 	// proceed) without the HTTPS data-plane bootstrap. Emitted by the
 	// launcher when proxy bootstrap is opted out, preflight fails, or

--- a/internal/sentinel/sentinel.go
+++ b/internal/sentinel/sentinel.go
@@ -1,0 +1,73 @@
+// Package sentinel holds the reserved, non-secret, format-mimicking
+// placeholder tokens that the launcher plants in a sandbox so a CLI's
+// own local validation passes, and that the daemon's forward proxy
+// recognizes and swaps for the real credential at egress (ADR-0019,
+// umbrella #1191).
+//
+// # Why a sentinel exists (emit-mechanism B)
+//
+// Some CLIs short-circuit locally when they hold no auth token: they
+// never issue the network request, so the proxy has nothing to seal.
+// `gh` is the canonical example. `gh api user` with no configured token
+// fails locally and emits no request to api.github.com.
+//
+// Emit-mechanism A (the launcher plants nothing; the CLI emits an
+// unauthenticated request the proxy seals at egress) therefore does not
+// work for such CLIs. Emit-mechanism B closes the gap: the launcher
+// plants a reserved, non-secret placeholder that passes the CLI's local
+// format check, so the CLI does issue the request. The proxy then
+// recognizes the placeholder at egress and swaps in the real credential
+// it resolves daemon-side. The placeholder bytes never reach upstream.
+//
+// # The sentinel is non-secret and safe to embed
+//
+// Every value in this package is a compile-time constant with no
+// entropy and no secret. It is safe to embed in source, print in logs,
+// and read inside the sandbox. It carries no authority: presenting the
+// sentinel to GitHub authenticates nothing. Its only job is to be a
+// well-formed-looking placeholder the proxy can recognize as its own
+// plant and swap.
+//
+// # Single source of truth
+//
+// The launch-side injector and the proxy-side recognizer both import
+// this package, so the value they agree on cannot drift. Recognition is
+// an exact match against the reserved value; because the value is
+// non-secret, a plain comparison is sufficient (there is no secret to
+// protect against a timing side-channel).
+//
+// [ADR-0019]: https://docs.withaileron.ai/adr/0019-v4-https-data-plane
+package sentinel
+
+// GitHubTokenSentinel is the reserved, non-secret placeholder the
+// launcher plants as GH_TOKEN so `gh` treats itself as authenticated and
+// issues its request instead of short-circuiting. The daemon proxy
+// recognizes it at egress (see [IsGitHubTokenSentinel]) and swaps in the
+// real user/github credential before the request leaves the host.
+//
+// Shape: it mimics `gh`'s classic personal-access-token format so `gh`'s
+// own local validation accepts it: the `ghp_` prefix followed by a
+// 36-character alphanumeric body, 40 characters total. The body is an
+// all-`A` filler with an embedded, human-readable "AILERONSENTINEL"
+// marker so anyone who sees it in a log or a process listing recognizes
+// it as the deliberate Aileron placeholder and not a real leaked token.
+// The marker uses only A-Z, staying within `gh`'s accepted charset.
+//
+// It is NOT a secret. Presenting it to GitHub authenticates nothing.
+const GitHubTokenSentinel = "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"
+
+// IsGitHubTokenSentinel reports whether token is exactly the reserved
+// GitHub sentinel. It is the proxy-side recognizer: only a token the
+// launcher itself planted (an exact match) is swapped for the real
+// credential at egress. Any other value (a real-looking `ghp_…` token a
+// user supplied themselves, an empty string, or a whitespace-padded
+// variant) returns false and is left untouched, which is the load-
+// bearing safety property: the proxy seals only tokens it planted and
+// never steal-swaps a foreign token.
+//
+// The comparison is exact and case-sensitive with no trimming: the
+// launcher plants the value verbatim, so a padded or altered variant is
+// by definition not the plant and must not be treated as one.
+func IsGitHubTokenSentinel(token string) bool {
+	return token == GitHubTokenSentinel
+}

--- a/internal/sentinel/sentinel_test.go
+++ b/internal/sentinel/sentinel_test.go
@@ -1,0 +1,78 @@
+package sentinel_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/sentinel"
+)
+
+// The sentinel contract (#1196):
+//
+//   - The GitHub sentinel mimics gh's classic PAT shape so gh's own
+//     local validation accepts it and does not short-circuit: the
+//     `ghp_` prefix, a 40-char total length, and an alphanumeric body.
+//   - It is non-secret and self-identifying: it carries a human-readable
+//     marker so it is recognizable as the deliberate Aileron placeholder.
+//   - IsGitHubTokenSentinel matches only the exact reserved value and
+//     rejects every foreign token (real-looking ghp_…, empty, padded).
+
+func TestGitHubTokenSentinel_FormatMimicsGitHubPAT(t *testing.T) {
+	s := sentinel.GitHubTokenSentinel
+
+	if !strings.HasPrefix(s, "ghp_") {
+		t.Errorf("sentinel %q lacks the ghp_ prefix gh validates against", s)
+	}
+	// gh's classic PAT is 40 chars (ghp_ + 36-char body). The sentinel
+	// must hit that exact length so gh's local format check accepts it.
+	if len(s) != 40 {
+		t.Errorf("sentinel length = %d, want 40 (ghp_ + 36-char body)", len(s))
+	}
+	body := strings.TrimPrefix(s, "ghp_")
+	if len(body) != 36 {
+		t.Errorf("sentinel body length = %d, want 36", len(body))
+	}
+	for i, r := range body {
+		isAllowed := (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || (r >= '0' && r <= '9')
+		if !isAllowed {
+			t.Errorf("sentinel body has non-alphanumeric rune %q at %d; gh accepts only [A-Za-z0-9]", r, i)
+		}
+	}
+}
+
+func TestGitHubTokenSentinel_IsSelfIdentifyingAndNonSecret(t *testing.T) {
+	// The sentinel must announce itself so anyone who sees it in a log or
+	// a process listing knows it is the Aileron placeholder, not a leaked
+	// secret. The marker is the non-secret signal.
+	if !strings.Contains(sentinel.GitHubTokenSentinel, "AILERONSENTINEL") {
+		t.Errorf("sentinel %q lacks the self-identifying AILERONSENTINEL marker", sentinel.GitHubTokenSentinel)
+	}
+}
+
+func TestIsGitHubTokenSentinel_MatchesExactReservedValue(t *testing.T) {
+	if !sentinel.IsGitHubTokenSentinel(sentinel.GitHubTokenSentinel) {
+		t.Error("IsGitHubTokenSentinel returned false for the exact reserved value")
+	}
+}
+
+func TestIsGitHubTokenSentinel_RejectsForeignTokens(t *testing.T) {
+	foreign := []struct {
+		name  string
+		token string
+	}{
+		{"real-looking ghp_ token", "ghp_1234567890abcdefghijklmnopqrstuvwx"},
+		{"empty", ""},
+		{"whitespace only", "   "},
+		{"leading whitespace padding", " " + sentinel.GitHubTokenSentinel},
+		{"trailing whitespace padding", sentinel.GitHubTokenSentinel + " "},
+		{"newline padding", sentinel.GitHubTokenSentinel + "\n"},
+		{"truncated sentinel", strings.TrimSuffix(sentinel.GitHubTokenSentinel, "A")},
+		{"different prefix", strings.Replace(sentinel.GitHubTokenSentinel, "ghp_", "ghs_", 1)},
+		{"lowercased", strings.ToLower(sentinel.GitHubTokenSentinel)},
+	}
+	for _, tc := range foreign {
+		if sentinel.IsGitHubTokenSentinel(tc.token) {
+			t.Errorf("%s: IsGitHubTokenSentinel(%q) = true, want false (foreign tokens must not be recognized)", tc.name, tc.token)
+		}
+	}
+}


### PR DESCRIPTION
## Summary

Wave 3 of umbrella #1191. `gh` validates its auth state locally and short-circuits when it holds no token, so it never issues its request and emit-mechanism A (the launcher plants nothing; the proxy seals the emitted request, shipped in #1212) has nothing to seal. This adds emit-mechanism B (sentinel-swap) and wires `gh`/`api.github.com` onto it.

- **`internal/sentinel`** — a new package that is the single source of truth for the reserved, non-secret, format-mimicking GitHub token sentinel (`ghp_`-shaped, 40 chars, self-identifying `AILERONSENTINEL` marker) and its `IsGitHubTokenSentinel` recognizer. The launch-side plant and the proxy-side swap both import it so they cannot drift.
- **Launcher** (`internal/launch/github_inject.go`) — plants `GH_TOKEN=sentinel` (not the real token) when a usable `user/github` entry exists. The sentinel passes `gh`'s local validation so `gh` issues its request. The real token never enters env, mount, or args; the git credential-helper mount stays secret-free (mechanism A for git-over-HTTPS).
- **Egress sentinel-swap gate** (`internal/app/sandbox_forward_proxy_sentinel.go`, wired into `handlers_sandbox_forward_proxy.go`) — on a mechanism-B binding the proxy swaps **only the sentinel it itself planted**: it strips the sentinel and lets the bearer scheme inject the real credential; a **foreign token is forwarded unchanged** (the load-bearing no-steal-swap safety property); the sentinel never reaches upstream.
- **Binding** (`internal/binding/host_binding.go`) — adds an `EmitMechanism` field (default A) plus `WithEmitMechanismB()`. `api.github.com → bearer` is tagged B; `github.com → basic` stays A.
- **Audit** — new `sandbox.proxy.foreign_token_not_swapped` event records the no-swap decision; payload carries no token/sentinel/secret bytes.
- **Docs** — the CLI matrix gains a `proxy-sealable` + `emit-mechanism` table per CLI (curl A, gh B, aws A) and the `gh` recipe is rewritten to the sentinel-swap flow, replacing the old manual `placeholder-token` prose.

ADR-0019 hold: the agent only ever holds the non-secret sentinel; the real token is resolved daemon-side at egress.

## Test plan

- `internal/sentinel` — format/recognizer unit tests (100% coverage): prefix/length/charset, self-identifying marker, exact match, foreign-token rejection (real-looking `ghp_…`, empty, padded, truncated, lowercased).
- `internal/launch` — `prepareGitHubInject` now asserts `GH_TOKEN == sentinel` and the real token bytes are absent from env and mount (the ADR-0019 regression guard); skip-clean paths still plant nothing.
- `internal/app` — end-to-end through the real CONNECT/TLS proxy boundary against a fake `api.github.com` upstream: (a) sentinel-bearing request → upstream sees the real bearer credential, never the sentinel; (b) foreign token → forwarded unchanged, no real secret; (c) sentinel never reaches upstream; (d) audit shape carries no secret/sentinel/foreign-token bytes. Plus unit coverage of the decision helper and the new audit event (shape + nil-recorder).
- `internal/binding` — `EmitMechanism` default-A and `WithEmitMechanismB` tests.

`go vet` and `go test` green across `internal/{sentinel,binding,model,app,launch}`. `coderabbit review --base main` reports 0 findings.

**Empirical gap (intentional):** the `gh`→live-`api.github.com` over-the-network path is not exercised in CI (it needs a real token and egress from the runner). The matrix doc records the `gh` row as asserted by the deterministic in-process test rather than claiming a live-network verification.

Closes #1196

🤖 Generated with [Claude Code](https://claude.com/claude-code)
