### PR TITLE
ci: add job-level timeout-minutes to every CI job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,7 @@ jobs:
   lint:
     name: Lint & Verify
     runs-on: ubuntu-latest
+    timeout-minutes: 15
     steps:
       - uses: actions/checkout@v6
 
@@ -69,6 +70,7 @@ jobs:
     # merges by file.
     name: Unit Tests (${{ matrix.shard }})
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     strategy:
       fail-fast: false
       matrix:
@@ -126,6 +128,7 @@ jobs:
     # ubuntu job doesn't already see.
     name: Unit Tests (macOS)
     runs-on: macos-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
 
@@ -174,6 +177,7 @@ jobs:
     # them here would mask the real signal from the new code paths.
     name: Unit Tests (Windows)
     runs-on: windows-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
 
@@ -232,6 +236,7 @@ jobs:
     # the windows/amd64 zip is produced and the binary executes.
     name: Windows Release Smoke
     runs-on: windows-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
@@ -288,6 +293,7 @@ jobs:
   test-ui:
     name: UI Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
 
@@ -369,6 +375,7 @@ jobs:
   test-webapp:
     name: Webapp Tests
     runs-on: ubuntu-latest
+    timeout-minutes: 25
     steps:
       - uses: actions/checkout@v6
 
@@ -429,6 +436,7 @@ jobs:
   test-webapp-integration:
     name: Webapp Integration E2E
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
@@ -495,6 +503,7 @@ jobs:
   docs:
     name: Docs
     runs-on: ubuntu-latest
+    timeout-minutes: 20
     steps:
       - uses: actions/checkout@v6
 
@@ -538,6 +547,7 @@ jobs:
   integration-go:
     name: Integration Tests (Go)
     runs-on: ubuntu-latest
+    timeout-minutes: 35
     steps:
       - uses: actions/checkout@v6
 
@@ -681,6 +691,7 @@ jobs:
   integration-sandbox-features:
     name: Integration Tests (Sandbox Features)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 
@@ -726,6 +737,7 @@ jobs:
   integration-e2e:
     name: Integration Tests (E2E)
     runs-on: ubuntu-latest
+    timeout-minutes: 30
     steps:
       - uses: actions/checkout@v6
 

--- a/internal/ci/ci_workflow_test.go
+++ b/internal/ci/ci_workflow_test.go
@@ -1,0 +1,88 @@
+package ci
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// githubActionsDefaultTimeoutMinutes is the implicit per-job ceiling GitHub
+// Actions applies when a job declares no timeout-minutes. The whole point of
+// this guard is to ensure no job inherits it, so any declared value must be
+// strictly below it.
+const githubActionsDefaultTimeoutMinutes = 360
+
+// ciWorkflow models just enough of .github/workflows/ci.yml to inspect each
+// job's timeout-minutes. yaml.Node is used for the value so a missing key is
+// distinguishable from a present-but-zero one, and so we can report the
+// offending job by name.
+type ciWorkflow struct {
+	Jobs map[string]struct {
+		TimeoutMinutes *int `yaml:"timeout-minutes"`
+	} `yaml:"jobs"`
+}
+
+// findRepoRoot walks up from the test's working directory until it finds a
+// directory containing .github/workflows/ci.yml. This makes the test robust to
+// being invoked from the internal module root (cwd = internal, as the CI `rest`
+// shard does) or from the repo root (go test ./internal/ci/...).
+func findRepoRoot(t *testing.T) string {
+	t.Helper()
+
+	dir, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+
+	for {
+		candidate := filepath.Join(dir, ".github", "workflows", "ci.yml")
+		if _, statErr := os.Stat(candidate); statErr == nil {
+			return dir
+		}
+
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not locate .github/workflows/ci.yml walking up from working directory")
+		}
+		dir = parent
+	}
+}
+
+// TestEveryCIJobHasTimeoutMinutes asserts the contract for #1216: every job in
+// .github/workflows/ci.yml declares a job-level timeout-minutes so a stalled
+// step fails fast instead of inheriting the 360-minute GitHub Actions default.
+//
+// The job set is derived from the file at test time — it is not hard-coded — so
+// jobs added later are automatically held to the same contract. Deleting any
+// job's timeout-minutes makes this test fail and names the offending job.
+func TestEveryCIJobHasTimeoutMinutes(t *testing.T) {
+	root := findRepoRoot(t)
+	path := filepath.Join(root, ".github", "workflows", "ci.yml")
+
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+
+	var wf ciWorkflow
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("unmarshal %s: %v", path, err)
+	}
+
+	if len(wf.Jobs) == 0 {
+		t.Fatalf("no jobs found in %s; expected ci.yml to define at least one job", path)
+	}
+
+	for name, job := range wf.Jobs {
+		switch {
+		case job.TimeoutMinutes == nil:
+			t.Errorf("job %q is missing job-level timeout-minutes; a stalled step would inherit the %d-minute GitHub Actions default", name, githubActionsDefaultTimeoutMinutes)
+		case *job.TimeoutMinutes <= 0:
+			t.Errorf("job %q has non-positive timeout-minutes %d; expected a positive integer", name, *job.TimeoutMinutes)
+		case *job.TimeoutMinutes >= githubActionsDefaultTimeoutMinutes:
+			t.Errorf("job %q has timeout-minutes %d which meets or exceeds the %d-minute GitHub Actions default; set a tighter bound so the job fails fast", name, *job.TimeoutMinutes, githubActionsDefaultTimeoutMinutes)
+		}
+	}
+}

--- a/internal/ci/doc.go
+++ b/internal/ci/doc.go
@@ -1,0 +1,5 @@
+// Package ci holds CI-configuration regression guards. It ships no
+// production code; it exists so the workflow contract (every CI job
+// declares a job-level timeout-minutes) is asserted as a normal Go
+// unit test that auto-flows into the existing test shards.
+package ci


### PR DESCRIPTION
## Summary

Adds an explicit job-level `timeout-minutes` to **every** job in `.github/workflows/ci.yml` so a stalled step fails fast instead of inheriting the 360-minute GitHub Actions per-job default. The acute motivation is a hung `apt-get` inside `playwright install --with-deps`, which today could burn six hours before the runner reaps the job.

This is SUB1 of umbrella #1215 and lands first. It is CI-config-only plus a self-contained Go regression guard; no application source, OpenAPI spec, generated code, or Taskfile change.

### Per-job values (typical wall-time + headroom, none at 360)

| Job | timeout-minutes |
|---|---|
| `lint` | 15 |
| `test` (matrix) | 20 |
| `test-macos` | 25 |
| `test-windows` | 25 |
| `release-smoke-windows` | 30 |
| `test-ui` | 25 |
| `test-webapp` | 25 |
| `test-webapp-integration` | 30 |
| `docs` | 20 |
| `integration-go` | 35 |
| `integration-sandbox-features` | 30 |
| `integration-e2e` | 30 |

### Regression guard

`internal/ci/ci_workflow_test.go` (plus a one-line `internal/ci/doc.go` package decl) reads `.github/workflows/ci.yml`, derives the job set **from the file at test time** (no hard-coded list or count), and asserts every job declares a positive `timeout-minutes` strictly below 360. It reports the offending job by name on failure.

It auto-flows into the existing `Unit Tests (rest)` shard: `Taskfile.yml`'s `GO_TEST_PACKAGES` already globs `./internal/...` and the `rest` shard computes its package list at runtime, so the new package is picked up with zero workflow/Taskfile wiring. No new dependency — `gopkg.in/yaml.v3` is already a direct dep of `internal/go.mod` (`go.sum` unchanged).

### Preserved

The two existing **step-level** `timeout-minutes: 5` docker-compose guards (in `integration-go` and `integration-e2e`) are left exactly as-is; job-level timeouts are additive.

### Out of scope (deferred to umbrella #1215)

These five sibling workflows are intentionally **left untouched** to keep this PR minimal, highest-value, lowest-risk, and independently mergeable:

- `release.yml`
- `claude.yml`
- `sandbox-base.yml`
- `sandbox-features.yml`
- `sandbox-agents.yml`

The regression guard therefore scopes to `ci.yml` only.

## Test plan

- `cd internal && go test ./ci/...` — green (all 12 jobs timed).
- `go test ./internal/ci/...` from repo root — green (repo-root discovery walks up from cwd; verified working when invoked from both the `internal` module root and the repo root).
- `go vet ./ci/...` — clean.
- **Fails-before / passes-after proof:** temporarily deleting `lint`'s `timeout-minutes` makes the test fail with `job "lint" is missing job-level timeout-minutes...`; restoring it passes. Confirmed manually.
- `grep -cE '^    timeout-minutes' .github/workflows/ci.yml` = 12 job-level entries; the 2 step-level `timeout-minutes: 5` guards remain.
- No `go.mod`/`go.sum` diff.

Closes #1216
