### PR TITLE
ci: run pure-Playwright jobs in the official Playwright container

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -294,6 +294,14 @@ jobs:
     name: UI Tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    container:
+      # Pinned to match the Playwright version resolved in ui/pnpm-lock.yaml
+      # (currently 1.60.0). The image bakes Chromium + its system deps, so no
+      # `playwright install --with-deps` / apt-get is needed. JOINT BUMP: when
+      # ui/pnpm-lock.yaml's Playwright pin changes, bump this tag in lockstep
+      # (and the matching tag in the test-webapp job) so the baked browser
+      # stays compatible with the installed @playwright/test.
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
     steps:
       - uses: actions/checkout@v6
 
@@ -318,16 +326,6 @@ jobs:
       - name: Build for E2E (with coverage instrumentation)
         working-directory: ui
         run: E2E_COVERAGE=1 pnpm build
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-ui-${{ hashFiles('ui/pnpm-lock.yaml') }}
-
-      - name: Install Playwright browsers
-        working-directory: ui
-        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E tests
         working-directory: ui
@@ -376,6 +374,14 @@ jobs:
     name: Webapp Tests
     runs-on: ubuntu-latest
     timeout-minutes: 25
+    container:
+      # Pinned to match the Playwright version resolved in webapp/pnpm-lock.yaml
+      # (currently 1.60.0). The image bakes Chromium + its system deps, so no
+      # `playwright install --with-deps` / apt-get is needed. JOINT BUMP: when
+      # webapp/pnpm-lock.yaml's Playwright pin changes, bump this tag in lockstep
+      # (and the matching tag in the test-ui job) so the baked browser
+      # stays compatible with the installed @playwright/test.
+      image: mcr.microsoft.com/playwright:v1.60.0-noble
     steps:
       - uses: actions/checkout@v6
 
@@ -403,16 +409,6 @@ jobs:
       - name: Build for E2E
         working-directory: webapp
         run: pnpm build
-
-      - name: Cache Playwright browsers
-        uses: actions/cache@v5
-        with:
-          path: ~/.cache/ms-playwright
-          key: ${{ runner.os }}-playwright-webapp-${{ hashFiles('webapp/pnpm-lock.yaml') }}
-
-      - name: Install Playwright browsers
-        working-directory: webapp
-        run: pnpm exec playwright install --with-deps chromium
 
       - name: Run E2E tests (mocked)
         working-directory: webapp


### PR DESCRIPTION
## Summary

Migrates the two self-contained Playwright CI jobs — `test-ui` and `test-webapp` in `.github/workflows/ci.yml` — to run inside `mcr.microsoft.com/playwright:v1.60.0-noble` via the job-level `container:` key.

The official image bakes Chromium and its system dependencies at `/ms-playwright` (with `PLAYWRIGHT_BROWSERS_PATH` pointed there), so the only `apt-get`-invoking path in these jobs — `pnpm exec playwright install --with-deps chromium` — is removed entirely. The image tag `v1.60.0-noble` matches the Playwright version pinned in both `ui/pnpm-lock.yaml` and `webapp/pnpm-lock.yaml` (1.60.0), so the baked browser is exactly what `playwright test` expects and browser tests run unchanged.

The now-pointless "Cache Playwright browsers" steps (`actions/cache` on `~/.cache/ms-playwright`) are also removed: inside the container the browsers live at the baked `/ms-playwright` path, not `~/.cache/ms-playwright`, so that cache stored nothing. A pin comment on each `container:` block documents the joint-bump contract between the image tag and the lockfile Playwright pin.

### What stays the same
- `runs-on: ubuntu-latest` and `timeout-minutes: 25` are preserved on both jobs (the latter added by #1222 / the #1216 contract). `container:` sits alongside them.
- The pnpm store cache (`actions/setup-node` with `cache: pnpm`) is retained. `setup-node` resolves the store via `pnpm store path` relative to the in-container `$HOME`, so it adapts automatically and the lockfile-hash cache key stays valid.
- Every other step (pnpm install, unit tests, build, E2E, nyc coverage, design-token generation, Codecov uploads, failure-artifact upload) is untouched.

### Scope boundary
Only the two pure-Playwright jobs are migrated. `test-webapp-integration` and `integration-e2e` need Go / Task / docker-compose and a real daemon, so they are not pure-Playwright and are explicitly out of scope (tracked under separate umbrella sub-issues).

## Test plan
- `internal/ci/ci_workflow_test.go` (#1216 regression guard, parses `ci.yml` and asserts every job declares `timeout-minutes`) passes locally — confirms valid YAML and that adding `container:` did not displace `timeout-minutes` on either job.
- The meaningful CI signal is the migrated jobs themselves: `test-ui` and `test-webapp` must go green with browser tests **actually executing** in-container.
  - No `apt-get` output anywhere in the job logs.
  - "Run E2E tests" / "Run E2E tests (mocked)" report executed, passing browser cases (`ui/test-results/junit-playwright.xml` and `webapp/test-results/junit-playwright.xml` show real cases, not zero/skipped).
  - pnpm install is fast with a store-cache hit (no dependency re-download).

Closes #1217

🤖 Generated with [Claude Code](https://claude.com/claude-code)
