### PR TITLE
feat(proxy): binding-descriptor format + Linear generalization proof

### DIFF
--- a/docs/src/content/docs/guides/binding-descriptors.md
+++ b/docs/src/content/docs/guides/binding-descriptors.md
@@ -1,0 +1,68 @@
+---
+title: "Binding Descriptors"
+description: "A binding descriptor is a small YAML file that seals an arbitrary CLI's credential at the network boundary without writing any per-CLI code. This page covers the descriptor schema, the three-layer loading order, and a worked Linear example."
+---
+
+A command-line tool that talks to a third-party API needs a credential. The usual answer is to hand that credential to the tool, which means the credential lives wherever the tool runs. Aileron's credential-sealing substrate takes a different path. The credential stays in your vault, the agent in the sandbox never holds it, and the daemon injects it at the TLS forward-proxy boundary on the way out. See [ADR-0019](/adr/0019-v4-https-data-plane/) for the data-plane design this builds on.
+
+A **binding descriptor** is how you tell that substrate which host gets which credential, and how to inject it. It is config, not code. A CLI vendor or a community profile ships a descriptor, the descriptor flows through a generic loader into the binding table, and the tool is sealed. No branch anywhere in the proxy keys on the tool's name. Re-representing a CLI as an MCP tool is the wrong move here and is explicitly rejected by [ADR-0024](/adr/0024-sandbox-mcp-parity/). The CLI stays a binary. Only its credential is injected.
+
+## The descriptor format
+
+A descriptor is a versioned YAML document with a list of per-host bindings.
+
+```yaml
+version: v1
+bindings:
+  - host: api.linear.app
+    credential_ref: user/linear
+    scheme: header-template
+    emit_mechanism: A
+    header: Authorization
+    template: "{token}"
+```
+
+Each binding is a quad plus scheme-specific fields.
+
+- `host` is the upstream host matched at the proxy boundary. It is an exact host (`api.linear.app`) or a single leading-wildcard form (`*.example.com`). Ports are not part of the pattern.
+- `credential_ref` is a vault credential reference the daemon resolves at injection time. It is a connector-style binding name (`<kind>/<service>/<identity>`) or a user-level reference (`user/<service>`), the namespace `aileron auth <service>` writes. It is never the credential bytes. The descriptor names where the credential lives, never its value.
+- `scheme` is one of the closed injection-scheme set: `bearer`, `basic`, `header-template`, `query-param`, `sigv4-resign`. An unknown scheme is a load-time error. `sigv4-resign` is enumerated but not yet implemented.
+- `emit_mechanism` declares how the credential reaches egress. `A` injects the credential unconditionally at the proxy. `B` is sentinel-swap, where the launcher plants a non-secret sentinel the proxy swaps for the real credential. The field is optional and defaults to `A`. An unknown value is a load-time error.
+
+Scheme-specific fields:
+
+- `username` is required for the `basic` scheme. It is the non-secret HTTP basic-auth username (e.g. `x-access-token` for git-over-HTTPS). The token always rides in the password field.
+- `header` and `template` are required for the `header-template` scheme. `header` is the header name to set. `template` is the verbatim header value with a `{token}` placeholder the daemon substitutes with the credential at injection time.
+- `query_param` is required for the `query-param` scheme. It is the query-parameter name the credential is set on.
+
+Decoding is strict. An unknown YAML key is an error, not a silently ignored field, so a typo fails fast instead of shipping a binding that does nothing. A wrong or missing `version` is an error so the format can evolve without a silent misparse.
+
+## Three-layer loading
+
+Descriptors load from three layers, in increasing precedence.
+
+1. **Built-in defaults.** Community profiles Aileron ships, embedded at build time. The Linear descriptor above is one.
+2. **Project layer.** `.aileron/binding-descriptors.yaml` relative to your working project.
+3. **User layer.** `~/.aileron/binding-descriptors.yaml`.
+
+A later layer overrides an earlier one per `host` key. A user descriptor can replace a shipped community profile for the same host without editing the shipped file. A new host in any layer is added on top of the others rather than replacing them. An absent project or user file is not an error. It simply contributes nothing.
+
+One invalid layer fails the whole load with a clear error. A malformed descriptor never degrades to a partial or empty binding table, because a typo that silently disables sealing would be a fail-open we reject.
+
+## Worked example: Linear
+
+[Linear](https://linear.app/)'s API authenticates with a personal API key sent verbatim in the `Authorization` header with no `Bearer` prefix. The `header-template` scheme expresses exactly that. The `template` is the bare `{token}`, so the daemon emits `Authorization: <key>` with nothing prepended.
+
+Store your key in the vault under the reference the descriptor names:
+
+```sh
+aileron auth linear
+```
+
+The built-in Linear descriptor (shown at the top of this page) then seals every request to `api.linear.app`. The Linear CLI inside the sandbox holds no key. The daemon resolves `user/linear` and injects it at egress. If the vault has no `user/linear` entry, the binding still matches but resolution fails closed: no header is added and no secret leaks. An unauthenticated request behaves exactly as it would with no binding configured.
+
+This is the whole generalization proof. Linear is a tool nobody special-cased in the proxy. It is sealed entirely by a descriptor. Adding another vendor is a new descriptor, never new proxy code.
+
+## Out of scope: stateful CLI caches
+
+Some CLIs keep a local cache or index between runs (for example a SQLite or full-text-search store). Persisting that local state across ephemeral sandboxes is **not** handled by binding descriptors and is **not** implemented here. A descriptor seals a credential at the network boundary. It does nothing about on-disk state inside the sandbox. Cache persistence is tracked separately in [issue #1190](https://github.com/ALRubinger/aileron/issues/1190). Choosing a stateless-credential tool like Linear as the proving example keeps this guide cleanly within the credential-injection boundary.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -76,7 +76,8 @@ export const navigation: NavItem[] = [
       { label: 'Authoring an Action Suite', href: '/guides/authoring-an-action-suite/' },
       { label: 'Publishing a Connector', href: '/guides/publishing-a-connector/' },
       { label: 'Publishing to the Hub', href: '/guides/publishing-to-the-hub/' },
-      { label: 'Observability', href: '/guides/observability/' }
+      { label: 'Observability', href: '/guides/observability/' },
+      { label: 'Binding Descriptors', href: '/guides/binding-descriptors/' }
     ]
   },
   {

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -30,6 +30,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/notify"
 	"github.com/ALRubinger/aileron/internal/observability"
 	"github.com/ALRubinger/aileron/internal/policy"
+	"github.com/ALRubinger/aileron/internal/proxybinding"
 	"github.com/ALRubinger/aileron/internal/sandbox"
 	"github.com/ALRubinger/aileron/internal/sessions"
 	"github.com/ALRubinger/aileron/internal/source"
@@ -371,41 +372,41 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	sourceReg := source.NewRegistry()
 
 	server := &apiServer{
-		log:                     log,
-		registry:                registry,
-		policyEngine:            policyEngine,
-		orchestrator:            orchestrator,
-		vault:                   v,
-		lockableVault:           lockableVault,
-		localVaultPath:          cfg.LocalVaultPath,
-		vaultLocked:             startVaultLocked,
-		vaultUnlockedCh:         newVaultUnlockedCh(startVaultLocked),
-		notifier:                notifier,
-		intents:                 intentStore,
-		approvals:               approvalStore,
-		policies:                policyStore,
-		grants:                  grantStore,
-		executions:              executionStore,
-		connectors:              connectorStore,
-		connectedAccounts:       connectedAccountStore,
-		drafts:                  draftStore,
-		instructions:            instructionStore,
-		feedback:                feedbackStore,
-		credentials:             credentialStore,
-		fundingSources:          fundingSourceStore,
-		llmConfigs:              llmConfigStore,
-		traces:                  traceStore,
-		sourceRegistry:          sourceReg,
-		openAIProxy:             openAIProxy,
-		anthropicProxy:          anthropicProxy,
-		localDaemonToken:        cfg.LocalDaemonToken,
-		sandboxProxyStateDir:    cfg.SandboxProxyStateDir,
-		newID:                   idGen,
-		actions:                 action.NewStore(action.DefaultDir()),
-		actionState:             newActionStateStore(log),
-		installer:               newConnectorInstaller(log),
-		versionLister:           cstore.DefaultVersionLister(),
-		hub:                     newHubClient(),
+		log:                  log,
+		registry:             registry,
+		policyEngine:         policyEngine,
+		orchestrator:         orchestrator,
+		vault:                v,
+		lockableVault:        lockableVault,
+		localVaultPath:       cfg.LocalVaultPath,
+		vaultLocked:          startVaultLocked,
+		vaultUnlockedCh:      newVaultUnlockedCh(startVaultLocked),
+		notifier:             notifier,
+		intents:              intentStore,
+		approvals:            approvalStore,
+		policies:             policyStore,
+		grants:               grantStore,
+		executions:           executionStore,
+		connectors:           connectorStore,
+		connectedAccounts:    connectedAccountStore,
+		drafts:               draftStore,
+		instructions:         instructionStore,
+		feedback:             feedbackStore,
+		credentials:          credentialStore,
+		fundingSources:       fundingSourceStore,
+		llmConfigs:           llmConfigStore,
+		traces:               traceStore,
+		sourceRegistry:       sourceReg,
+		openAIProxy:          openAIProxy,
+		anthropicProxy:       anthropicProxy,
+		localDaemonToken:     cfg.LocalDaemonToken,
+		sandboxProxyStateDir: cfg.SandboxProxyStateDir,
+		newID:                idGen,
+		actions:              action.NewStore(action.DefaultDir()),
+		actionState:          newActionStateStore(log),
+		installer:            newConnectorInstaller(log),
+		versionLister:        cstore.DefaultVersionLister(),
+		hub:                  newHubClient(),
 	}
 	if res, err := server.actions.Load(); err != nil {
 		log.Warn("failed to load actions directory", "dir", server.actions.Dir(), "error", err)
@@ -440,23 +441,38 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	// --- Host->credential binding table (#1193) ---
 	// The user-level host-binding table is consulted at the TLS
 	// forward-proxy boundary when no connector spec matches a decrypted
-	// request (ADR-0019 launch passthrough). v1 has no config wire
-	// format yet (the launch/policy schema and authoring CLI are a
-	// follow-on), so the only bindings seeded here are the built-in
-	// GitHub pair (#1195): github.com -> basic and api.github.com ->
-	// bearer, both resolving user/github daemon-side. The agent never
-	// holds the GitHub secret; the daemon injects it at egress. With no
-	// user/github entry the bindings still match but resolution fails
-	// closed (no secret, no Authorization header), so an unauthenticated
-	// GitHub request behaves exactly as before today's passthrough.
-	if ghBindings, err := gitHubHostBindings(); err != nil {
+	// request (ADR-0019 launch passthrough). It is seeded from two
+	// sources, in order:
+	//
+	//   1. The built-in GitHub pair (#1195): github.com -> basic and
+	//      api.github.com -> bearer, both resolving user/github
+	//      daemon-side, kept as Go code because their schemes differ per
+	//      host and one needs sentinel-swap (#1196).
+	//   2. The declarative binding descriptors (#1197), loaded through the
+	//      generic three-layer loader (built-in profiles -> project ->
+	//      user). This is the "config, not code" path: a third-party CLI
+	//      (e.g. Linear, api.linear.app via header-template) is sealed by
+	//      shipping a descriptor, with zero per-CLI proxy code.
+	//
+	// The agent never holds these secrets; the daemon injects them at
+	// egress. With no matching vault entry a binding still matches but
+	// resolution fails closed (no secret, no header), so an
+	// unauthenticated request behaves exactly as today's passthrough.
+	ghBindings, err := gitHubHostBindings()
+	if err != nil {
 		// A construction error here is a programming bug (the host
 		// patterns and schemes are constants), not operator input;
 		// surface it rather than silently dropping the seal.
 		return nil, fmt.Errorf("seed github host bindings: %w", err)
-	} else {
-		server.hostBindings = ghBindings
 	}
+	descriptorBindings, err := proxybinding.LoadHostBindings(proxybinding.DefaultLoadOptions(""))
+	if err != nil {
+		// A malformed descriptor must fail loudly, not degrade to an empty
+		// (passthrough) table: a typo that silently disables sealing is a
+		// fail-open we explicitly reject.
+		return nil, fmt.Errorf("load binding descriptors: %w", err)
+	}
+	server.hostBindings = append(ghBindings, descriptorBindings...)
 
 	// --- Scope-drift detection (#726) ---
 	// Hook fires after every successful connector install. If the

--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -570,15 +570,16 @@ func (s *apiServer) injectSandboxProxyHostBindingCredential(ctx context.Context,
 // over the #1194 scheme-keyed injector (internal/credential/inject):
 // the binding-match wiring is untouched and the injector owns the wire
 // shape of every scheme, so a header convention lives in exactly one
-// place. `bearer` and `basic` are implemented (basic carries the
-// non-secret username from the binding); the remaining members of
-// binding.HostBindingSchemes are accepted at config time but rejected
-// here, which fails closed rather than silently passing an un-injected
-// request upstream.
+// place. `bearer`, `basic`, `header-template`, and `query-param` are
+// implemented (each carries its non-secret params from the binding); the
+// remaining member of binding.HostBindingSchemes (sigv4-resign) is
+// accepted at config time but rejected here, which fails closed rather
+// than silently passing an un-injected request upstream.
 //
 // The resolved credential bytes flow only into [inject.Inject], which
-// writes them solely onto the request's Authorization header. They are
-// never copied into the returned reject reason or any audit payload.
+// writes them solely onto the request header or query parameter the
+// scheme defines. They are never copied into the returned reject reason
+// or any audit payload.
 func applyHostBindingScheme(req *http.Request, hb binding.HostBinding, cred credential.Credential) (bool, string) {
 	scheme, params, ok := hostBindingInjectScheme(hb)
 	if !ok {
@@ -604,6 +605,10 @@ func hostBindingInjectScheme(hb binding.HostBinding) (inject.Scheme, inject.Para
 		return inject.SchemeBearer, inject.Params{}, true
 	case binding.SchemeBasic:
 		return inject.SchemeBasic, inject.Params{Username: hb.BasicUsername}, true
+	case binding.SchemeHeaderTemplate:
+		return inject.SchemeHeaderTemplate, inject.Params{HeaderName: hb.HeaderName, Template: hb.HeaderTemplate}, true
+	case binding.SchemeQueryParam:
+		return inject.SchemeQueryParam, inject.Params{ParamName: hb.QueryParamName}, true
 	default:
 		return "", inject.Params{}, false
 	}

--- a/internal/app/sandbox_forward_proxy_binding_descriptor_test.go
+++ b/internal/app/sandbox_forward_proxy_binding_descriptor_test.go
@@ -1,0 +1,244 @@
+package app
+
+import (
+	"encoding/json"
+	"io"
+	"net/http"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+	"github.com/ALRubinger/aileron/internal/proxybinding"
+)
+
+// The generalization proof (#1197): a third-party CLI nobody special-cased
+// in the proxy (Linear, api.linear.app) is sealed purely by a descriptor
+// that flows through the real loader into the binding table, with zero
+// per-CLI proxy code. Linear authenticates with its API key sent verbatim
+// in the Authorization header with NO Bearer prefix; the header-template
+// scheme expresses that. The agent in the sandbox never holds the key; the
+// daemon resolves user/linear and injects it at the TLS forward-proxy
+// boundary.
+func TestBindingDescriptor_LinearSealedViaDescriptorOnly(t *testing.T) {
+	const token = "lin_api_secret_key"
+	v := mustVaultWith(t, "user/linear", "user", []byte(token))
+
+	// Load the Linear binding through the REAL loader (built-in defaults
+	// layer, no overrides). No hand-built binding, no per-CLI code.
+	table, err := proxybinding.LoadHostBindings(proxybinding.LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadHostBindings: %v", err)
+	}
+
+	auditStore := audit.NewMemStore()
+	var upstreamAuth string
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-linear-descriptor" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         v,
+		hostBindings:  table,
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"data":{"viewer":{"id":"me"}}}`)),
+			}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.linear.app/graphql")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+
+	// Verbatim Authorization: the key with NO "Bearer " prefix.
+	if upstreamAuth != token {
+		t.Fatalf("upstream Authorization = %q, want verbatim %q (no Bearer)", upstreamAuth, token)
+	}
+	if strings.HasPrefix(upstreamAuth, "Bearer ") {
+		t.Errorf("upstream Authorization = %q carries a Bearer prefix; Linear wants the bare key", upstreamAuth)
+	}
+
+	// Sealing: the in-container client never sees the raw token, in the
+	// body or any response header.
+	if strings.Contains(string(body), token) {
+		t.Error("response body leaked the token")
+	}
+	for k, vals := range resp.Header {
+		for _, val := range vals {
+			if strings.Contains(val, token) {
+				t.Errorf("response header %s leaked the token: %q", k, val)
+			}
+		}
+	}
+
+	// Sealing in the audit trail: no audit event carries the secret.
+	events, err := auditStore.ListEvents(t.Context(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("audit list events: %v", err)
+	}
+	for _, ev := range events {
+		raw, _ := json.Marshal(ev.Payload)
+		if strings.Contains(string(raw), token) {
+			t.Errorf("audit event %s leaked the token", ev.EventType)
+		}
+	}
+}
+
+// A query-param descriptor (a different scheme) injects the credential as
+// a URL query parameter and seals it. This exercises the query-param arm
+// of the generic injection-scheme mapping through the real proxy boundary,
+// proving the descriptor path is not Linear/header-template specific.
+func TestBindingDescriptor_QueryParamSchemeInjectsAndSeals(t *testing.T) {
+	const token = "qp_api_secret"
+	dir := t.TempDir()
+	userPath := filepath.Join(dir, "user.yaml")
+	if err := os.WriteFile(userPath, []byte(
+		"version: v1\nbindings:\n  - host: api.qpexample.test\n    credential_ref: user/qpexample\n    scheme: query-param\n    query_param: api_key\n"), 0o600); err != nil {
+		t.Fatalf("write user descriptor: %v", err)
+	}
+
+	table, err := proxybinding.LoadHostBindings(proxybinding.LoadOptions{UserPath: userPath})
+	if err != nil {
+		t.Fatalf("LoadHostBindings: %v", err)
+	}
+
+	v := mustVaultWith(t, "user/qpexample", "user", []byte(token))
+	var upstreamQuery string
+	srv := &apiServer{
+		auditStore:    audit.NewMemStore(),
+		auditRecorder: audit.NewRecorder(audit.NewMemStore(), nil, func() string { return "audit-qp" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         v,
+		hostBindings:  table,
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamQuery = req.URL.Query().Get("api_key")
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{"ok":true}`))}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.qpexample.test/v1/resource")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, body)
+	}
+	if upstreamQuery != token {
+		t.Errorf("upstream api_key query = %q, want %q", upstreamQuery, token)
+	}
+	// Sealing: the in-container client never sees the raw token, in the
+	// body or any response header.
+	if strings.Contains(string(body), token) {
+		t.Error("response body leaked the token")
+	}
+	for k, vals := range resp.Header {
+		for _, val := range vals {
+			if strings.Contains(val, token) {
+				t.Errorf("response header %s leaked the token: %q", k, val)
+			}
+		}
+	}
+}
+
+// Fail-closed: a locked/absent vault yields no Authorization header and no
+// secret, and the upstream is not dialed. The descriptor only names where
+// the credential lives; resolution happens daemon-side and fails closed.
+func TestBindingDescriptor_LinearLockedVaultFailsClosed(t *testing.T) {
+	// token is a defensive placeholder: it is deliberately NOT stored in
+	// the vault. The point of this test is that no credential resolves, so
+	// the leak assertions below confirm the fail-closed path never invents
+	// or echoes a secret. Any string would do; a token-shaped one makes the
+	// assertion's intent legible.
+	const token = "lin_locked_secret"
+	// No user/linear entry: the binding matches but resolution misses.
+	v := mustVaultWith(t, "user/other", "user", []byte("unrelated"))
+
+	table, err := proxybinding.LoadHostBindings(proxybinding.LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadHostBindings: %v", err)
+	}
+
+	var upstreamAuth string
+	upstreamCalled := false
+	srv := &apiServer{
+		auditStore:    audit.NewMemStore(),
+		auditRecorder: audit.NewRecorder(audit.NewMemStore(), nil, func() string { return "audit-linear-locked" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         v,
+		hostBindings:  table,
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamCalled = true
+			upstreamAuth = req.Header.Get("Authorization")
+			return &http.Response{StatusCode: http.StatusOK, Header: http.Header{}, Body: io.NopCloser(strings.NewReader(`{}`))}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://api.linear.app/graphql")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode == http.StatusOK {
+		t.Errorf("status = 200 with missing credential; want fail-closed error")
+	}
+	if upstreamCalled {
+		t.Error("upstream dialed despite missing credential; want fail-closed before dial")
+	}
+	if strings.Contains(string(body), token) || strings.Contains(upstreamAuth, token) {
+		t.Error("token leaked on fail-closed path")
+	}
+}
+
+// "Config, not code": no source file on the proxy path branches on a
+// CLI/service name. Sealing Linear must be a descriptor change, never a
+// code change. This greppable invariant fails if anyone reintroduces a
+// per-CLI branch in proxy code (the BYOCLI mistake, #959 / ADR-0024).
+func TestBindingDescriptor_NoPerCLIBranchInProxyCode(t *testing.T) {
+	// Files implementing the forward-proxy boundary and the host-binding
+	// injection path. A literal CLI/service name here would mean the
+	// substrate special-cased a vendor instead of staying generic.
+	proxyPathFiles := []string{
+		"handlers_sandbox_forward_proxy.go",
+		"handlers_connector_operations.go",
+		"sandbox_forward_proxy_sentinel.go",
+	}
+	// Lowercased needles for CLI/service names that must never appear as a
+	// branch in proxy code. GitHub is intentionally excluded: its bindings
+	// are a deliberate built-in Go pair (github_bindings.go), which is a
+	// separate seeding file, not the generic proxy path under test here.
+	forbidden := []string{"linear", "printingpress", "printing_press"}
+
+	for _, name := range proxyPathFiles {
+		path := filepath.Join(".", name)
+		data, err := os.ReadFile(path)
+		if err != nil {
+			t.Fatalf("read %s: %v", name, err)
+		}
+		lower := strings.ToLower(string(data))
+		for _, needle := range forbidden {
+			if strings.Contains(lower, needle) {
+				t.Errorf("%s references %q: proxy code must stay generic, seal CLIs via descriptor (config, not code)", name, needle)
+			}
+		}
+	}
+}

--- a/internal/binding/host_binding.go
+++ b/internal/binding/host_binding.go
@@ -34,6 +34,18 @@ const SchemeBearer = "bearer"
 // credential bytes.
 const SchemeBasic = "basic"
 
+// SchemeHeaderTemplate emits an arbitrary header set to a verbatim
+// template value, with a token placeholder the egress injector (#1194)
+// substitutes with the credential bytes. It expresses a vendor header
+// that carries the token with no fixed prefix, e.g. Linear's verbatim
+// `Authorization: <key>` (no `Bearer`). Carries [HostBinding.HeaderName]
+// and [HostBinding.HeaderTemplate], both non-secret.
+const SchemeHeaderTemplate = "header-template"
+
+// SchemeQueryParam emits the credential as a URL query parameter named by
+// [HostBinding.QueryParamName].
+const SchemeQueryParam = "query-param"
+
 // EmitMechanism names how the in-container client is made to emit a
 // request the proxy can seal at egress (ADR-0019, #1196). It is
 // orthogonal to [HostBinding.Scheme], which is how the proxy injects the
@@ -93,6 +105,27 @@ type HostBinding struct {
 	// ignored for every other scheme.
 	BasicUsername string
 
+	// HeaderName is the header to set, used only when Scheme is
+	// [SchemeHeaderTemplate] (e.g. `Authorization` or a vendor header).
+	// It is a non-secret param. Required for the header-template scheme,
+	// ignored otherwise.
+	HeaderName string
+
+	// HeaderTemplate is the verbatim header value for
+	// [SchemeHeaderTemplate], with a token placeholder substituted with
+	// the credential bytes at egress (the injector owns the placeholder
+	// convention). It lets a vendor express a header that carries the
+	// token without a fixed prefix (e.g. Linear's verbatim
+	// `Authorization: <key>` with no `Bearer`). Non-secret: it is a
+	// template, never the credential bytes. Required for the
+	// header-template scheme, ignored otherwise.
+	HeaderTemplate string
+
+	// QueryParamName is the query-parameter name to set, used only when
+	// Scheme is [SchemeQueryParam]. Non-secret. Required for the
+	// query-param scheme, ignored otherwise.
+	QueryParamName string
+
 	// EmitMechanism declares how the in-container client is made to emit
 	// a sealable request (see [EmitMechanism]). The zero value is
 	// [EmitMechanismA] (plant nothing, inject unconditionally), which
@@ -118,6 +151,24 @@ type HostBindingOption func(*HostBinding)
 // username used by [SchemeBasic]. It is required for that scheme.
 func WithBasicUsername(username string) HostBindingOption {
 	return func(hb *HostBinding) { hb.BasicUsername = username }
+}
+
+// WithHeaderTemplate sets the non-secret [HostBinding.HeaderName] and
+// [HostBinding.HeaderTemplate] used by [SchemeHeaderTemplate]. Both are
+// required for that scheme: a header-template binding with no header name
+// or no template could never produce a well-formed header, so an empty
+// value is a construction error.
+func WithHeaderTemplate(header, template string) HostBindingOption {
+	return func(hb *HostBinding) {
+		hb.HeaderName = header
+		hb.HeaderTemplate = template
+	}
+}
+
+// WithQueryParam sets the non-secret [HostBinding.QueryParamName] used by
+// [SchemeQueryParam]. It is required for that scheme.
+func WithQueryParam(name string) HostBindingOption {
+	return func(hb *HostBinding) { hb.QueryParamName = name }
 }
 
 // WithEmitMechanismB marks the binding as [EmitMechanismB] (sentinel-
@@ -162,6 +213,12 @@ func NewHostBinding(hostPattern, credentialRef, scheme string, opts ...HostBindi
 	}
 	if scheme == SchemeBasic && hb.BasicUsername == "" {
 		return HostBinding{}, fmt.Errorf("host binding: basic scheme requires a username (WithBasicUsername)")
+	}
+	if scheme == SchemeHeaderTemplate && (hb.HeaderName == "" || hb.HeaderTemplate == "") {
+		return HostBinding{}, fmt.Errorf("host binding: header-template scheme requires a header name and template (WithHeaderTemplate)")
+	}
+	if scheme == SchemeQueryParam && hb.QueryParamName == "" {
+		return HostBinding{}, fmt.Errorf("host binding: query-param scheme requires a param name (WithQueryParam)")
 	}
 	return hb, nil
 }

--- a/internal/binding/host_binding_test.go
+++ b/internal/binding/host_binding_test.go
@@ -107,6 +107,40 @@ func TestNewHostBinding_BasicSchemeRequiresUsername(t *testing.T) {
 	}
 }
 
+func TestNewHostBinding_HeaderTemplateRequiresHeaderAndTemplate(t *testing.T) {
+	// A header-template binding with no header or no template can never
+	// produce a well-formed header, so it is rejected at construction.
+	if _, err := binding.NewHostBinding("api.linear.app", "user/linear", "header-template"); err == nil {
+		t.Fatal("expected error for header-template without header/template, got nil")
+	}
+	if _, err := binding.NewHostBinding("api.linear.app", "user/linear", "header-template",
+		binding.WithHeaderTemplate("Authorization", "")); err == nil {
+		t.Fatal("expected error for header-template with empty template, got nil")
+	}
+	hb, err := binding.NewHostBinding("api.linear.app", "user/linear", "header-template",
+		binding.WithHeaderTemplate("Authorization", "{token}"))
+	if err != nil {
+		t.Fatalf("unexpected error for valid header-template: %v", err)
+	}
+	if hb.HeaderName != "Authorization" || hb.HeaderTemplate != "{token}" {
+		t.Errorf("header params = (%q,%q), want (Authorization,{token})", hb.HeaderName, hb.HeaderTemplate)
+	}
+}
+
+func TestNewHostBinding_QueryParamRequiresName(t *testing.T) {
+	if _, err := binding.NewHostBinding("api.example.com", "user/example", "query-param"); err == nil {
+		t.Fatal("expected error for query-param without a param name, got nil")
+	}
+	hb, err := binding.NewHostBinding("api.example.com", "user/example", "query-param",
+		binding.WithQueryParam("api_key"))
+	if err != nil {
+		t.Fatalf("unexpected error for valid query-param: %v", err)
+	}
+	if hb.QueryParamName != "api_key" {
+		t.Errorf("QueryParamName = %q, want api_key", hb.QueryParamName)
+	}
+}
+
 func TestNewHostBinding_RejectsInvalidCredentialRef(t *testing.T) {
 	for _, ref := range []string{"", "not-a-binding-name", "oauth2/github", "../escape/x"} {
 		if _, err := binding.NewHostBinding("api.example.com", ref, "bearer"); err == nil {

--- a/internal/proxybinding/binding.go
+++ b/internal/proxybinding/binding.go
@@ -1,0 +1,74 @@
+package proxybinding
+
+import (
+	"fmt"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+// ToHostBinding adapts a descriptor Entry into the canonical
+// internal/binding.HostBinding the proxy table (#1193) consumes. It maps
+// the declared scheme and emit-mechanism plus the scheme-specific
+// non-secret params onto the constructor's options.
+//
+// The constructor is the single source of truth for binding legality:
+// host-pattern form and credential-ref name contract are validated there,
+// so the descriptor format and the binding table can never disagree about
+// what a well-formed binding is. ToHostBinding carries no secret bytes; a
+// HostBinding, like an Entry, names where the credential lives, never its
+// value.
+func (e *Entry) ToHostBinding() (binding.HostBinding, error) {
+	var opts []binding.HostBindingOption
+
+	switch e.Scheme {
+	case binding.SchemeBasic:
+		opts = append(opts, binding.WithBasicUsername(e.Username))
+	case binding.SchemeHeaderTemplate:
+		opts = append(opts, binding.WithHeaderTemplate(e.Header, e.Template))
+	case binding.SchemeQueryParam:
+		opts = append(opts, binding.WithQueryParam(e.QueryParam))
+	}
+
+	if e.EmitMechanism == string(binding.EmitMechanismB) {
+		opts = append(opts, binding.WithEmitMechanismB())
+	}
+
+	hb, err := binding.NewHostBinding(e.Host, e.CredentialRef, e.Scheme, opts...)
+	if err != nil {
+		return binding.HostBinding{}, fmt.Errorf("adapt descriptor entry: %w", err)
+	}
+	return hb, nil
+}
+
+// LoadHostBindings is the convenience the apiServer wiring calls: it loads
+// the three merged descriptor layers and adapts them to the canonical
+// binding table in one step. A load or adaptation error is surfaced rather
+// than swallowed so a malformed descriptor fails construction loudly
+// instead of silently shipping an empty (passthrough) table.
+func LoadHostBindings(opts LoadOptions) (binding.HostBindings, error) {
+	entries, err := Load(opts)
+	if err != nil {
+		return nil, err
+	}
+	return ToHostBindings(entries)
+}
+
+// ToHostBindings adapts a slice of validated entries into a
+// binding.HostBindings table, preserving order. A nil or empty slice
+// yields a nil table, which internal/binding treats as a valid empty
+// table whose Match always misses, preserving today's passthrough
+// behavior when no descriptors are configured.
+func ToHostBindings(entries []Entry) (binding.HostBindings, error) {
+	if len(entries) == 0 {
+		return nil, nil
+	}
+	out := make(binding.HostBindings, 0, len(entries))
+	for i := range entries {
+		hb, err := entries[i].ToHostBinding()
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, hb)
+	}
+	return out, nil
+}

--- a/internal/proxybinding/binding_test.go
+++ b/internal/proxybinding/binding_test.go
@@ -1,0 +1,115 @@
+package proxybinding
+
+import (
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+// A non-GitHub host entry (Linear) adapts to a host binding whose host,
+// scheme, credential-ref, and header-template params match the descriptor.
+func TestToHostBinding_LinearMapsParams(t *testing.T) {
+	e := Entry{
+		Host:          "api.linear.app",
+		CredentialRef: "user/linear",
+		Scheme:        binding.SchemeHeaderTemplate,
+		EmitMechanism: "A",
+		Header:        "Authorization",
+		Template:      "{token}",
+	}
+	hb, err := e.ToHostBinding()
+	if err != nil {
+		t.Fatalf("ToHostBinding: %v", err)
+	}
+	if hb.HostPattern != "api.linear.app" {
+		t.Errorf("host = %q, want api.linear.app", hb.HostPattern)
+	}
+	if hb.Scheme != binding.SchemeHeaderTemplate {
+		t.Errorf("scheme = %q, want header-template", hb.Scheme)
+	}
+	if hb.CredentialRef != "user/linear" {
+		t.Errorf("credential_ref = %q, want user/linear", hb.CredentialRef)
+	}
+	if hb.HeaderName != "Authorization" || hb.HeaderTemplate != "{token}" {
+		t.Errorf("header params = (%q,%q), want (Authorization,{token})", hb.HeaderName, hb.HeaderTemplate)
+	}
+	if hb.EmitMechanism != binding.EmitMechanismA {
+		t.Errorf("emit mechanism = %q, want A", hb.EmitMechanism)
+	}
+}
+
+func TestToHostBinding_BasicCarriesUsername(t *testing.T) {
+	e := Entry{
+		Host:          "git.example.com",
+		CredentialRef: "user/example",
+		Scheme:        binding.SchemeBasic,
+		Username:      "x-access-token",
+	}
+	hb, err := e.ToHostBinding()
+	if err != nil {
+		t.Fatalf("ToHostBinding: %v", err)
+	}
+	if hb.BasicUsername != "x-access-token" {
+		t.Errorf("basic username = %q, want x-access-token", hb.BasicUsername)
+	}
+}
+
+func TestToHostBinding_QueryParamCarriesName(t *testing.T) {
+	e := Entry{
+		Host:          "api.example.com",
+		CredentialRef: "user/example",
+		Scheme:        binding.SchemeQueryParam,
+		QueryParam:    "api_key",
+	}
+	hb, err := e.ToHostBinding()
+	if err != nil {
+		t.Fatalf("ToHostBinding: %v", err)
+	}
+	if hb.QueryParamName != "api_key" {
+		t.Errorf("query param name = %q, want api_key", hb.QueryParamName)
+	}
+}
+
+func TestToHostBinding_EmitMechanismB(t *testing.T) {
+	e := Entry{
+		Host:          "api.example.com",
+		CredentialRef: "user/example",
+		Scheme:        binding.SchemeBearer,
+		EmitMechanism: "B",
+	}
+	hb, err := e.ToHostBinding()
+	if err != nil {
+		t.Fatalf("ToHostBinding: %v", err)
+	}
+	if hb.EmitMechanism != binding.EmitMechanismB {
+		t.Errorf("emit mechanism = %q, want B", hb.EmitMechanism)
+	}
+}
+
+// An empty entry slice produces a nil table, which internal/binding treats
+// as a valid empty table whose Match always misses (passthrough preserved).
+func TestToHostBindings_EmptyIsNilPassthrough(t *testing.T) {
+	table, err := ToHostBindings(nil)
+	if err != nil {
+		t.Fatalf("ToHostBindings(nil): %v", err)
+	}
+	if table != nil {
+		t.Errorf("ToHostBindings(nil) = %v, want nil table", table)
+	}
+	if _, ok := table.Match("api.linear.app"); ok {
+		t.Error("nil table matched a host; want passthrough miss")
+	}
+}
+
+// An invalid entry surfaces an error from the adapter rather than producing
+// a malformed binding.
+func TestToHostBindings_InvalidEntryErrors(t *testing.T) {
+	_, err := ToHostBindings([]Entry{{
+		Host:          "api.example.com",
+		CredentialRef: "user/example",
+		Scheme:        binding.SchemeBasic, // basic with no username is invalid
+	}})
+	if err == nil {
+		t.Fatal("ToHostBindings with invalid entry = nil error, want error")
+	}
+}

--- a/internal/proxybinding/defaults/linear.yaml
+++ b/internal/proxybinding/defaults/linear.yaml
@@ -1,0 +1,22 @@
+# Built-in binding descriptor for the Linear CLI (api.linear.app).
+#
+# This is the proving community profile for the credential-sealing
+# substrate: Linear is a third-party CLI nobody special-cased in the
+# proxy. It is sealed purely by this descriptor flowing through the
+# generic loader into the binding table, with zero per-CLI proxy code.
+#
+# Linear's API authenticates with a personal API key sent verbatim in the
+# Authorization header with NO "Bearer" prefix. The header-template scheme
+# expresses that: the template is "{token}", so the egress injector sets
+# "Authorization: <key>" exactly. The agent in the sandbox never holds the
+# key; the daemon resolves user/linear from the vault and injects it at the
+# TLS forward-proxy boundary. With no user/linear entry the binding still
+# matches but resolution fails closed (no header, no secret).
+version: v1
+bindings:
+  - host: api.linear.app
+    credential_ref: user/linear
+    scheme: header-template
+    emit_mechanism: A
+    header: Authorization
+    template: "{token}"

--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -1,0 +1,245 @@
+// Package proxybinding parses and loads declarative host->credential
+// binding descriptors and converts them into the binding-table entries
+// the TLS forward-proxy boundary consults (ADR-0019, umbrella #1191).
+//
+// A descriptor is the "config, not code" half of the credential-sealing
+// substrate. The binding table (#1193, internal/binding.HostBindings) and
+// the scheme-keyed injector (#1194, internal/credential/inject) are the
+// "code" half: they consult a host->credential mapping at egress and bind
+// the resolved secret onto the outbound request. This package supplies
+// the missing declarative format so a CLI vendor or community profile can
+// ship a descriptor that flows generically through the loader into the
+// table, with zero per-CLI proxy code. The proving example is Linear
+// (api.linear.app, header-template emitting a verbatim
+// "Authorization: <token>" with no Bearer prefix); nothing in the proxy
+// path branches on "linear" or any CLI name.
+//
+// # Secret handling
+//
+// A descriptor carries only a credential *reference* (a vault path), never
+// the credential bytes. This package never reads, resolves, or logs secret
+// material: resolution happens daemon-side at injection time (#1193's
+// responsibility). The descriptor format is therefore safe to embed,
+// commit, and ship.
+//
+// # Scope
+//
+// This package defines the descriptor format and the three-layer loader.
+// It does not implement the binding-table consult (#1193), the injectors
+// (#1194), or the sentinel-swap mechanism (#1196, mechanism B); it only
+// validates the emit_mechanism field against the known set. Persisting a
+// stateful CLI's local cache across ephemeral sandboxes is out of scope
+// and tracked separately (#1190).
+//
+// [ADR-0019]: https://docs.withaileron.ai/adr/0019-v4-https-data-plane
+package proxybinding
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+	"github.com/ALRubinger/aileron/internal/credential/inject"
+)
+
+// SchemaVersion is the only descriptor schema version this loader
+// understands. The format is versioned so it can evolve under 0.0.x
+// without a silent misparse: a descriptor that names any other version is
+// a load-time error rather than a best-effort decode against the wrong
+// field set.
+const SchemaVersion = "v1"
+
+// EmitMechanisms is the closed set of emit-mechanism values a descriptor
+// may declare. It mirrors internal/binding.EmitMechanism: mechanism "A"
+// injects unconditionally at the proxy (the client emits a no-credential
+// request), and mechanism "B" is sentinel-swap (the launcher plants a
+// non-secret sentinel the proxy swaps for the real credential at egress,
+// defined by #1196). This package validates the field against this set
+// and rejects unknown values; it does not implement either mechanism.
+var EmitMechanisms = map[string]struct{}{
+	string(binding.EmitMechanismA): {},
+	string(binding.EmitMechanismB): {},
+}
+
+// Descriptor is a parsed, versioned binding-descriptor document. One
+// document carries a version and an ordered list of per-host entries.
+// A CLI vendor or community profile ships a Descriptor; the loader merges
+// the built-in, project, and user layers into a single validated set.
+type Descriptor struct {
+	// Version is the schema version. It must equal [SchemaVersion]; any
+	// other value is rejected at parse time so the format can evolve under
+	// 0.0.x without a silent misparse.
+	Version string `yaml:"version"`
+
+	// Bindings is the ordered list of per-host binding entries in this
+	// document. Within a single document, host keys must be unique; across
+	// layers, a later layer's entry for a host overrides an earlier one
+	// (see [Load]).
+	Bindings []Entry `yaml:"bindings"`
+}
+
+// Entry is a single declarative host->credential binding: the {host,
+// credential-ref, scheme, emit-mechanism} quad plus the scheme-specific
+// non-secret params. It is a self-contained value type so this package is
+// independently testable; [Entry.ToHostBinding] adapts it to the canonical
+// internal/binding.HostBinding the proxy table consumes.
+type Entry struct {
+	// Host is the upstream host pattern matched at the proxy boundary. It
+	// is an exact host ("api.linear.app") or a single leading-wildcard
+	// form ("*.example.com"), mirroring internal/binding.HostBinding's
+	// match semantics rather than inventing a second matcher. Ports are
+	// not part of the pattern.
+	Host string `yaml:"host"`
+
+	// CredentialRef is a vault credential reference resolved daemon-side
+	// at injection time, never to the container. It is a connector-style
+	// binding name ("<kind>/<service>/<identity>") or a user-level ref
+	// ("user/<service>"), the same name contract internal/binding
+	// enforces. It is never the credential bytes.
+	CredentialRef string `yaml:"credential_ref"`
+
+	// Scheme is one of the closed injection-scheme set (#1194):
+	// bearer | basic | header-template | query-param | sigv4-resign. An
+	// unknown scheme is a load-time error (fail closed, no silent skip).
+	Scheme string `yaml:"scheme"`
+
+	// EmitMechanism declares how the credential reaches egress: "A"
+	// (inject at the proxy) or "B" (sentinel-swap, #1196). Optional;
+	// empty defaults to "A". An unknown value is a load-time error.
+	EmitMechanism string `yaml:"emit_mechanism"`
+
+	// Username is the non-secret HTTP basic-auth username, required only
+	// for the basic scheme (e.g. "x-access-token" for git-over-HTTPS).
+	Username string `yaml:"username"`
+
+	// Header is the header name to set, required only for the
+	// header-template scheme (e.g. "Authorization" or a vendor header).
+	Header string `yaml:"header"`
+
+	// Template is the verbatim header value for the header-template
+	// scheme, with the "{token}" placeholder substituted with the secret
+	// at inject time. Required for header-template. To emit Linear's
+	// verbatim "Authorization: <key>" with no Bearer prefix, set
+	// Template to "{token}".
+	Template string `yaml:"template"`
+
+	// QueryParam is the query-parameter name to set, required only for the
+	// query-param scheme.
+	QueryParam string `yaml:"query_param"`
+}
+
+// TokenPlaceholder is the substring a header-template's Template
+// substitutes with the resolved secret at inject time. It mirrors the
+// placeholder the injector (#1194) uses, so a descriptor author and the
+// egress injector agree on the token slot.
+const TokenPlaceholder = "{token}"
+
+// Parse strictly decodes a single descriptor document and validates it.
+// Decoding is strict: an unknown YAML key is an error rather than a
+// silently ignored field, so a typo in a descriptor fails fast instead of
+// shipping a binding that does nothing. Malformed YAML, a wrong or missing
+// version, and any entry that fails [Entry.Validate] are all errors.
+//
+// Parse never reads secret bytes; a descriptor carries only a credential
+// reference.
+func Parse(data []byte) (Descriptor, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var d Descriptor
+	if err := dec.Decode(&d); err != nil {
+		return Descriptor{}, fmt.Errorf("proxybinding: parse descriptor: %w", err)
+	}
+
+	if d.Version != SchemaVersion {
+		return Descriptor{}, fmt.Errorf("proxybinding: unsupported descriptor version %q (want %q)", d.Version, SchemaVersion)
+	}
+
+	seen := make(map[string]struct{}, len(d.Bindings))
+	for i := range d.Bindings {
+		e := &d.Bindings[i]
+		if err := e.Validate(); err != nil {
+			return Descriptor{}, fmt.Errorf("proxybinding: binding %d (%q): %w", i, e.Host, err)
+		}
+		if _, dup := seen[e.Host]; dup {
+			return Descriptor{}, fmt.Errorf("proxybinding: duplicate host %q within a single descriptor", e.Host)
+		}
+		seen[e.Host] = struct{}{}
+	}
+
+	return d, nil
+}
+
+// Validate checks that an Entry's required fields are present and
+// internally consistent. It enforces the closed scheme set, the closed
+// emit-mechanism set, and the scheme-specific param requirements. It does
+// not resolve the credential or touch any secret.
+//
+// Validation reuses the canonical internal/binding constructor so the
+// descriptor format and the binding table agree on host-pattern and
+// credential-ref legality: there is exactly one matcher and one name
+// contract, not two.
+func (e *Entry) Validate() error {
+	if e.Host == "" {
+		return fmt.Errorf("missing required field: host")
+	}
+	if e.CredentialRef == "" {
+		return fmt.Errorf("missing required field: credential_ref")
+	}
+	if e.Scheme == "" {
+		return fmt.Errorf("missing required field: scheme")
+	}
+	if _, err := inject.ParseScheme(e.Scheme); err != nil {
+		return fmt.Errorf("unknown scheme %q (want one of %v)", e.Scheme, schemeNames())
+	}
+
+	mech := e.EmitMechanism
+	if mech == "" {
+		mech = string(binding.EmitMechanismA)
+	}
+	if _, ok := EmitMechanisms[mech]; !ok {
+		return fmt.Errorf("unknown emit_mechanism %q (want A or B)", e.EmitMechanism)
+	}
+
+	switch e.Scheme {
+	case string(inject.SchemeBasic):
+		if e.Username == "" {
+			return fmt.Errorf("basic scheme requires a username")
+		}
+	case string(inject.SchemeHeaderTemplate):
+		if e.Header == "" {
+			return fmt.Errorf("header-template scheme requires a header name")
+		}
+		if e.Template == "" {
+			return fmt.Errorf("header-template scheme requires a template")
+		}
+	case string(inject.SchemeQueryParam):
+		if e.QueryParam == "" {
+			return fmt.Errorf("query-param scheme requires a query_param name")
+		}
+	}
+
+	// Reuse the canonical constructor's host-pattern and credential-ref
+	// validation. ToHostBinding is the single source of truth for what a
+	// well-formed binding looks like; calling it here surfaces a malformed
+	// host or credential-ref as a parse error rather than a wiring-time
+	// surprise.
+	if _, err := e.ToHostBinding(); err != nil {
+		return err
+	}
+	return nil
+}
+
+// schemeNames returns the closed scheme set as plain strings, for error
+// messages. It tracks inject.AllSchemes so a new scheme appears in the
+// message without a second hand-maintained list.
+func schemeNames() []string {
+	all := inject.AllSchemes()
+	out := make([]string, len(all))
+	for i, s := range all {
+		out[i] = string(s)
+	}
+	return out
+}

--- a/internal/proxybinding/descriptor_test.go
+++ b/internal/proxybinding/descriptor_test.go
@@ -1,0 +1,189 @@
+package proxybinding
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+// linearDescriptorYAML is the verbatim-Authorization Linear case: a
+// header-template scheme whose template is the bare "{token}", producing
+// "Authorization: <key>" with no Bearer prefix.
+const linearDescriptorYAML = `
+version: v1
+bindings:
+  - host: api.linear.app
+    credential_ref: user/linear
+    scheme: header-template
+    emit_mechanism: A
+    header: Authorization
+    template: "{token}"
+`
+
+func TestParse_LinearHeaderTemplateRoundTrips(t *testing.T) {
+	d, err := Parse([]byte(linearDescriptorYAML))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	if d.Version != SchemaVersion {
+		t.Errorf("version = %q, want %q", d.Version, SchemaVersion)
+	}
+	if len(d.Bindings) != 1 {
+		t.Fatalf("bindings = %d, want 1", len(d.Bindings))
+	}
+	e := d.Bindings[0]
+	if e.Host != "api.linear.app" {
+		t.Errorf("host = %q, want api.linear.app", e.Host)
+	}
+	if e.Scheme != binding.SchemeHeaderTemplate {
+		t.Errorf("scheme = %q, want header-template", e.Scheme)
+	}
+	if e.Header != "Authorization" {
+		t.Errorf("header = %q, want Authorization", e.Header)
+	}
+	// The verbatim shape: template is the bare token slot, no "Bearer ".
+	if e.Template != "{token}" {
+		t.Errorf("template = %q, want %q (no Bearer prefix)", e.Template, "{token}")
+	}
+	if strings.Contains(strings.ToLower(e.Template), "bearer") {
+		t.Errorf("template = %q must not carry a Bearer prefix", e.Template)
+	}
+}
+
+func TestParse_EachSchemeValidates(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+		want string
+	}{
+		{
+			name: "bearer",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n",
+			want: binding.SchemeBearer,
+		},
+		{
+			name: "basic",
+			yaml: "version: v1\nbindings:\n  - host: git.example.com\n    credential_ref: user/example\n    scheme: basic\n    username: x-access-token\n",
+			want: binding.SchemeBasic,
+		},
+		{
+			name: "header-template",
+			yaml: "version: v1\nbindings:\n  - host: api.linear.app\n    credential_ref: user/linear\n    scheme: header-template\n    header: Authorization\n    template: \"{token}\"\n",
+			want: binding.SchemeHeaderTemplate,
+		},
+		{
+			name: "query-param",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: query-param\n    query_param: api_key\n",
+			want: binding.SchemeQueryParam,
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			d, err := Parse([]byte(tc.yaml))
+			if err != nil {
+				t.Fatalf("Parse: %v", err)
+			}
+			if got := d.Bindings[0].Scheme; got != tc.want {
+				t.Errorf("scheme = %q, want %q", got, tc.want)
+			}
+			if _, err := d.Bindings[0].ToHostBinding(); err != nil {
+				t.Errorf("ToHostBinding: %v", err)
+			}
+		})
+	}
+}
+
+func TestParse_Errors(t *testing.T) {
+	cases := []struct {
+		name string
+		yaml string
+	}{
+		{
+			name: "missing host",
+			yaml: "version: v1\nbindings:\n  - credential_ref: user/example\n    scheme: bearer\n",
+		},
+		{
+			name: "missing credential_ref",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    scheme: bearer\n",
+		},
+		{
+			name: "missing scheme",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n",
+		},
+		{
+			name: "unknown scheme",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: oauth-magic\n",
+		},
+		{
+			name: "unknown emit_mechanism",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: C\n",
+		},
+		{
+			name: "header-template missing header",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: header-template\n    template: \"{token}\"\n",
+		},
+		{
+			name: "header-template missing template",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: header-template\n    header: Authorization\n",
+		},
+		{
+			name: "basic missing username",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: basic\n",
+		},
+		{
+			name: "query-param missing param",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: query-param\n",
+		},
+		{
+			name: "invalid credential_ref",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: not a ref\n    scheme: bearer\n",
+		},
+		{
+			name: "invalid host pattern",
+			yaml: "version: v1\nbindings:\n  - host: \"*.com\"\n    credential_ref: user/example\n    scheme: bearer\n",
+		},
+		{
+			name: "unknown yaml key",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    bogus_field: nope\n",
+		},
+		{
+			name: "wrong version",
+			yaml: "version: v2\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n",
+		},
+		{
+			name: "missing version",
+			yaml: "bindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n",
+		},
+		{
+			name: "malformed yaml",
+			yaml: "version: v1\nbindings: [this is: not valid",
+		},
+		{
+			name: "duplicate host in one descriptor",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n  - host: api.example.com\n    credential_ref: user/other\n    scheme: bearer\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := Parse([]byte(tc.yaml)); err == nil {
+				t.Fatalf("Parse(%s) = nil error, want error", tc.name)
+			}
+		})
+	}
+}
+
+// A descriptor carries only a credential reference; no descriptor field
+// resembles a secret. This guards the fail-closed property that the loader
+// never reads secret bytes.
+func TestParse_NoSecretBytesInDescriptor(t *testing.T) {
+	d, err := Parse([]byte(linearDescriptorYAML))
+	if err != nil {
+		t.Fatalf("Parse: %v", err)
+	}
+	e := d.Bindings[0]
+	// The credential-ref is a vault path, never a token.
+	if !strings.HasPrefix(e.CredentialRef, "user/") {
+		t.Errorf("credential_ref = %q, expected a vault reference, not a secret", e.CredentialRef)
+	}
+}

--- a/internal/proxybinding/embed.go
+++ b/internal/proxybinding/embed.go
@@ -1,0 +1,15 @@
+package proxybinding
+
+import "embed"
+
+// builtinDefaults holds the descriptors Aileron ships as the built-in
+// layer of the three-layer config convention (built-in -> project ->
+// user). Each file under defaults/ is a community profile that seals a
+// third-party CLI by descriptor alone. linear.yaml is the proving
+// example; adding another vendor is a new file here, never new proxy code.
+//
+//go:embed defaults/*.yaml
+var builtinDefaults embed.FS
+
+// builtinDefaultsDir is the directory the embed glob roots at.
+const builtinDefaultsDir = "defaults"

--- a/internal/proxybinding/loader.go
+++ b/internal/proxybinding/loader.go
@@ -1,0 +1,138 @@
+package proxybinding
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+)
+
+// LoadOptions selects the project and user descriptor layers that override
+// the built-in defaults. Both paths are optional: an empty path or an
+// absent file contributes no entries, so an operator who ships nothing
+// gets exactly the built-in profiles.
+type LoadOptions struct {
+	// ProjectPath is a descriptor file relative to (or rooted at) the
+	// working project, the middle layer. It overrides built-in entries for
+	// the same host and is itself overridden by the user layer. Empty or
+	// absent contributes nothing.
+	ProjectPath string
+
+	// UserPath is the per-user descriptor file (e.g. under ~/.aileron),
+	// the highest-precedence layer. It overrides both built-in and project
+	// entries for the same host. Empty or absent contributes nothing.
+	UserPath string
+}
+
+// Load merges the three configuration layers (built-in defaults, then
+// project, then user) into a single validated, ordered set of entries
+// keyed on host. This mirrors the three-layer policy/config convention
+// used elsewhere in the codebase: later layers override earlier ones per
+// host key, so a user descriptor can replace a shipped community profile
+// for the same host without editing it.
+//
+// Precedence is strictly built-in < project < user. Within the merged
+// result, entries are ordered deterministically by host so the binding
+// table is reproducible across loads.
+//
+// Every layer is parsed strictly (unknown keys, wrong version, malformed
+// YAML, and invalid entries are errors). An invalid layer fails the whole
+// load with a clear error and never silently drops entries: a typo in a
+// descriptor must not degrade to a partial, surprising binding set. A
+// missing project or user file is not an error (an absent layer is an
+// empty layer); only a present-but-unreadable or present-but-invalid file
+// fails.
+func Load(opts LoadOptions) ([]Entry, error) {
+	merged := make(map[string]Entry)
+
+	builtin, err := parseBuiltinDefaults()
+	if err != nil {
+		return nil, fmt.Errorf("proxybinding: load built-in defaults: %w", err)
+	}
+	applyLayer(merged, builtin)
+
+	if opts.ProjectPath != "" {
+		project, err := parseLayerFile(opts.ProjectPath)
+		if err != nil {
+			return nil, fmt.Errorf("proxybinding: load project layer %q: %w", opts.ProjectPath, err)
+		}
+		applyLayer(merged, project)
+	}
+
+	if opts.UserPath != "" {
+		user, err := parseLayerFile(opts.UserPath)
+		if err != nil {
+			return nil, fmt.Errorf("proxybinding: load user layer %q: %w", opts.UserPath, err)
+		}
+		applyLayer(merged, user)
+	}
+
+	out := make([]Entry, 0, len(merged))
+	for _, e := range merged {
+		out = append(out, e)
+	}
+	sort.Slice(out, func(i, j int) bool { return out[i].Host < out[j].Host })
+	return out, nil
+}
+
+// applyLayer overlays a layer's entries onto the merged map, last-write-
+// wins per host. The map carries the override semantics; ordering is
+// re-derived deterministically by Load.
+func applyLayer(merged map[string]Entry, layer []Entry) {
+	for _, e := range layer {
+		merged[e.Host] = e
+	}
+}
+
+// parseBuiltinDefaults parses every embedded descriptor under defaults/.
+// A malformed shipped descriptor is a programming error (it is embedded at
+// build time), so it fails the load rather than being skipped.
+func parseBuiltinDefaults() ([]Entry, error) {
+	dirEntries, err := fs.ReadDir(builtinDefaults, builtinDefaultsDir)
+	if err != nil {
+		return nil, err
+	}
+	var out []Entry
+	// Sort filenames for a deterministic built-in order before later
+	// layers override per host.
+	names := make([]string, 0, len(dirEntries))
+	for _, de := range dirEntries {
+		if de.IsDir() {
+			continue
+		}
+		names = append(names, de.Name())
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		data, err := fs.ReadFile(builtinDefaults, builtinDefaultsDir+"/"+name)
+		if err != nil {
+			return nil, fmt.Errorf("read embedded %s: %w", name, err)
+		}
+		d, err := Parse(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse embedded %s: %w", name, err)
+		}
+		out = append(out, d.Bindings...)
+	}
+	return out, nil
+}
+
+// parseLayerFile reads and parses one on-disk descriptor layer. A missing
+// file is not an error: it returns nil entries so an absent layer
+// contributes nothing. A present-but-unreadable or present-but-invalid
+// file is an error.
+func parseLayerFile(path string) ([]Entry, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	d, err := Parse(data)
+	if err != nil {
+		return nil, err
+	}
+	return d.Bindings, nil
+}

--- a/internal/proxybinding/loader_test.go
+++ b/internal/proxybinding/loader_test.go
@@ -1,0 +1,196 @@
+package proxybinding
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/binding"
+)
+
+func writeDescriptor(t *testing.T, dir, name, body string) string {
+	t.Helper()
+	path := filepath.Join(dir, name)
+	if err := os.WriteFile(path, []byte(body), 0o600); err != nil {
+		t.Fatalf("write %s: %v", name, err)
+	}
+	return path
+}
+
+func findEntry(entries []Entry, host string) (Entry, bool) {
+	for _, e := range entries {
+		if e.Host == host {
+			return e, true
+		}
+	}
+	return Entry{}, false
+}
+
+// Built-in-only load yields the shipped Linear entry: the embedded
+// community profile is the floor with no override layers configured.
+func TestLoad_BuiltinOnlyYieldsLinear(t *testing.T) {
+	entries, err := Load(LoadOptions{})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	e, ok := findEntry(entries, "api.linear.app")
+	if !ok {
+		t.Fatalf("built-in load missing api.linear.app; got %v", entries)
+	}
+	if e.Scheme != binding.SchemeHeaderTemplate {
+		t.Errorf("linear scheme = %q, want header-template", e.Scheme)
+	}
+	if e.CredentialRef != "user/linear" {
+		t.Errorf("linear credential_ref = %q, want user/linear", e.CredentialRef)
+	}
+}
+
+// The user layer overrides a built-in host: redefining api.linear.app in
+// the user descriptor wins.
+func TestLoad_UserOverridesBuiltin(t *testing.T) {
+	dir := t.TempDir()
+	userPath := writeDescriptor(t, dir, "user.yaml",
+		"version: v1\nbindings:\n  - host: api.linear.app\n    credential_ref: user/linear-override\n    scheme: bearer\n")
+
+	entries, err := Load(LoadOptions{UserPath: userPath})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	e, ok := findEntry(entries, "api.linear.app")
+	if !ok {
+		t.Fatal("missing api.linear.app after user override")
+	}
+	if e.Scheme != binding.SchemeBearer {
+		t.Errorf("after user override scheme = %q, want bearer", e.Scheme)
+	}
+	if e.CredentialRef != "user/linear-override" {
+		t.Errorf("credential_ref = %q, want user/linear-override", e.CredentialRef)
+	}
+}
+
+// Precedence is built-in < project < user. The project layer overrides the
+// built-in for a host, and the user layer overrides the project.
+func TestLoad_PrecedenceOrder(t *testing.T) {
+	dir := t.TempDir()
+	projectPath := writeDescriptor(t, dir, "project.yaml",
+		"version: v1\nbindings:\n  - host: api.linear.app\n    credential_ref: user/from-project\n    scheme: bearer\n")
+	userPath := writeDescriptor(t, dir, "user.yaml",
+		"version: v1\nbindings:\n  - host: api.linear.app\n    credential_ref: user/from-user\n    scheme: bearer\n")
+
+	// Project overrides built-in (no user layer).
+	entries, err := Load(LoadOptions{ProjectPath: projectPath})
+	if err != nil {
+		t.Fatalf("Load (project only): %v", err)
+	}
+	e, _ := findEntry(entries, "api.linear.app")
+	if e.CredentialRef != "user/from-project" {
+		t.Errorf("project-only credential_ref = %q, want user/from-project", e.CredentialRef)
+	}
+
+	// User overrides project.
+	entries, err = Load(LoadOptions{ProjectPath: projectPath, UserPath: userPath})
+	if err != nil {
+		t.Fatalf("Load (project+user): %v", err)
+	}
+	e, _ = findEntry(entries, "api.linear.app")
+	if e.CredentialRef != "user/from-user" {
+		t.Errorf("project+user credential_ref = %q, want user/from-user (user wins)", e.CredentialRef)
+	}
+}
+
+// Absent project/user files are not errors: an absent layer is an empty
+// layer, leaving the built-in floor intact.
+func TestLoad_AbsentLayersNoError(t *testing.T) {
+	dir := t.TempDir()
+	entries, err := Load(LoadOptions{
+		ProjectPath: filepath.Join(dir, "does-not-exist-project.yaml"),
+		UserPath:    filepath.Join(dir, "does-not-exist-user.yaml"),
+	})
+	if err != nil {
+		t.Fatalf("Load with absent layers: %v", err)
+	}
+	if _, ok := findEntry(entries, "api.linear.app"); !ok {
+		t.Error("absent override layers should leave built-in Linear entry")
+	}
+}
+
+// An invalid layer fails the whole load with a clear error and does not
+// silently drop entries.
+func TestLoad_InvalidLayerFails(t *testing.T) {
+	dir := t.TempDir()
+	bad := writeDescriptor(t, dir, "bad.yaml",
+		"version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: not-a-scheme\n")
+
+	_, err := Load(LoadOptions{UserPath: bad})
+	if err == nil {
+		t.Fatal("Load with invalid layer = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "user layer") {
+		t.Errorf("error %q should name the offending layer", err.Error())
+	}
+}
+
+// An invalid project layer fails the load and names the project layer.
+func TestLoad_InvalidProjectLayerFails(t *testing.T) {
+	dir := t.TempDir()
+	bad := writeDescriptor(t, dir, "bad-project.yaml",
+		"version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: not-a-scheme\n")
+
+	_, err := Load(LoadOptions{ProjectPath: bad})
+	if err == nil {
+		t.Fatal("Load with invalid project layer = nil error, want error")
+	}
+	if !strings.Contains(err.Error(), "project layer") {
+		t.Errorf("error %q should name the project layer", err.Error())
+	}
+}
+
+// LoadHostBindings surfaces a load error rather than returning an empty
+// (passthrough) table.
+func TestLoadHostBindings_InvalidLayerErrors(t *testing.T) {
+	dir := t.TempDir()
+	bad := writeDescriptor(t, dir, "bad.yaml",
+		"version: v2\nbindings: []\n")
+	if _, err := LoadHostBindings(LoadOptions{UserPath: bad}); err == nil {
+		t.Fatal("LoadHostBindings with invalid layer = nil error, want error")
+	}
+}
+
+// A new host in an override layer is added on top of the built-in floor,
+// not replacing it (override is per host key).
+func TestLoad_NewHostAddedAcrossLayers(t *testing.T) {
+	dir := t.TempDir()
+	userPath := writeDescriptor(t, dir, "user.yaml",
+		"version: v1\nbindings:\n  - host: api.other.com\n    credential_ref: user/other\n    scheme: bearer\n")
+
+	entries, err := Load(LoadOptions{UserPath: userPath})
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if _, ok := findEntry(entries, "api.linear.app"); !ok {
+		t.Error("built-in Linear entry dropped when user added a new host")
+	}
+	if _, ok := findEntry(entries, "api.other.com"); !ok {
+		t.Error("user-added host missing")
+	}
+}
+
+// LoadHostBindings adapts the merged set to a binding table whose Match
+// resolves the loaded host.
+func TestLoadHostBindings_MatchesLinear(t *testing.T) {
+	table, err := LoadHostBindings(LoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadHostBindings: %v", err)
+	}
+	hb, ok := table.Match("api.linear.app")
+	if !ok {
+		t.Fatal("table.Match(api.linear.app) = false, want true")
+	}
+	if hb.Scheme != binding.SchemeHeaderTemplate {
+		t.Errorf("matched scheme = %q, want header-template", hb.Scheme)
+	}
+	if hb.CredentialRef != "user/linear" {
+		t.Errorf("matched credential_ref = %q, want user/linear", hb.CredentialRef)
+	}
+}

--- a/internal/proxybinding/paths.go
+++ b/internal/proxybinding/paths.go
@@ -1,0 +1,38 @@
+package proxybinding
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DefaultUserPath returns the per-user descriptor file path,
+// `~/.aileron/binding-descriptors.yaml`, the highest-precedence layer of
+// the three-layer config convention. When the home directory cannot be
+// resolved it falls back to a relative path under `.aileron`, matching the
+// rest of the config package's home-dir handling. The file need not exist;
+// an absent user layer contributes no entries.
+func DefaultUserPath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".aileron", "binding-descriptors.yaml")
+	}
+	return filepath.Join(home, ".aileron", "binding-descriptors.yaml")
+}
+
+// DefaultProjectPath returns the project-layer descriptor file path,
+// `.aileron/binding-descriptors.yaml` relative to the given working
+// directory (the middle layer). An empty workdir roots it at the current
+// directory. The file need not exist.
+func DefaultProjectPath(workdir string) string {
+	return filepath.Join(workdir, ".aileron", "binding-descriptors.yaml")
+}
+
+// DefaultLoadOptions returns the standard project and user descriptor
+// layer paths for daemon construction. The built-in defaults layer is
+// always embedded; these two paths select the optional override layers.
+func DefaultLoadOptions(workdir string) LoadOptions {
+	return LoadOptions{
+		ProjectPath: DefaultProjectPath(workdir),
+		UserPath:    DefaultUserPath(),
+	}
+}

--- a/internal/proxybinding/paths_test.go
+++ b/internal/proxybinding/paths_test.go
@@ -1,0 +1,40 @@
+package proxybinding
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultPaths(t *testing.T) {
+	user := DefaultUserPath()
+	if !strings.HasSuffix(user, filepath.Join(".aileron", "binding-descriptors.yaml")) {
+		t.Errorf("DefaultUserPath = %q, want .../.aileron/binding-descriptors.yaml", user)
+	}
+
+	project := DefaultProjectPath("/work/proj")
+	if project != filepath.Join("/work/proj", ".aileron", "binding-descriptors.yaml") {
+		t.Errorf("DefaultProjectPath = %q", project)
+	}
+
+	opts := DefaultLoadOptions("/work/proj")
+	if opts.ProjectPath != project {
+		t.Errorf("DefaultLoadOptions.ProjectPath = %q, want %q", opts.ProjectPath, project)
+	}
+	if opts.UserPath == "" {
+		t.Error("DefaultLoadOptions.UserPath is empty")
+	}
+}
+
+// DefaultLoadOptions paths must load cleanly against the embedded defaults
+// even when the override files do not exist (the common daemon case).
+func TestDefaultLoadOptions_LoadsBuiltinWhenLayersAbsent(t *testing.T) {
+	opts := DefaultLoadOptions(t.TempDir())
+	entries, err := Load(opts)
+	if err != nil {
+		t.Fatalf("Load(DefaultLoadOptions): %v", err)
+	}
+	if _, ok := findEntry(entries, "api.linear.app"); !ok {
+		t.Error("default load missing built-in Linear entry")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the missing declarative piece of the credential-sealing substrate (umbrella #1191, wave 3): a **binding-descriptor format** and a **three-layer loader** that populates the host→credential binding table consulted at the TLS forward-proxy boundary (#1209/#1211/#1212 supplied the table, injector, and GitHub bindings; this PR supplies the format between them).

A descriptor is `{host, credential-ref, scheme, emit-mechanism}` plus scheme-specific params, shipped as versioned YAML by a CLI vendor or community profile. It flows through a generic loader into the binding table with **zero per-CLI proxy code**. The proving example is **Linear** (`api.linear.app`), a third-party CLI nobody special-cased: it is sealed purely by a shipped descriptor. Linear's verbatim `Authorization: <key>` (no `Bearer`) is expressed via the `header-template` scheme with a `{token}` template.

### What's here
- **`internal/proxybinding`** — `Descriptor`/`Entry` value types, a strict YAML parser (unknown keys, wrong version, unknown scheme/emit-mechanism, malformed YAML all error), a three-layer loader (built-in defaults → project → user, later overrides earlier per host), an embedded Linear default (`defaults/linear.yaml`), and a `ToHostBinding` adapter onto the canonical `internal/binding.HostBinding`.
- **`internal/binding`** — extends `HostBinding` to carry `header-template` (`HeaderName`/`HeaderTemplate`) and `query-param` (`QueryParamName`) params with validating constructor options. These are the canonical types the table/injector own; this fills in the two schemes the GitHub pair didn't exercise.
- **`internal/app`** — wires `header-template` and `query-param` through the injection-scheme mapping so they inject end-to-end, and loads descriptors at apiServer construction (appending to the built-in GitHub bindings). A malformed descriptor fails construction loudly rather than degrading to passthrough.
- **Docs** — `docs/guides/binding-descriptors.md` (schema, three-layer loading, Linear worked example, ADR-0019/ADR-0024 links, out-of-scope #1190 note).

### Security / sealing
The descriptor carries only a credential *reference*; secret bytes resolve daemon-side at injection time and never appear in any descriptor field, log, or audit payload. A locked/absent vault fails closed (no header, no secret, no upstream dial). Tests assert no leak through body, headers, or audit events.

### Scope (per plan)
Does not implement the table consult, the injectors, or sentinel-swap (mechanism B); only defines the format + loader and validates the `emit_mechanism` field. Does not re-represent any CLI as MCP. Does not persist stateful-CLI caches (#1190, documented as out of scope).

## Test plan
- `go test ./internal/proxybinding/... -cover` → 94.5% (uncovered lines are defensive-only: embedded-read failure, `UserHomeDir` failure).
- `go test ./internal/binding/... -cover` → 93%.
- `go test ./internal/app/...` → full suite green, including:
  - `TestBindingDescriptor_LinearSealedViaDescriptorOnly` — Linear sealed via the real loader through the real proxy boundary; verbatim `Authorization: <key>`, no leak in body/headers/audit.
  - `TestBindingDescriptor_QueryParamSchemeInjectsAndSeals` — a second scheme proves the path isn't Linear-specific.
  - `TestBindingDescriptor_LinearLockedVaultFailsClosed` — fail-closed, no dial, no secret.
  - `TestBindingDescriptor_NoPerCLIBranchInProxyCode` — greppable invariant: no `linear`/`printingpress` branch in proxy-path source (BYOCLI / ADR-0024).
- `task build:docs` → 127 pages built, new guide renders.
- `go vet` clean; `gofmt` clean.
- Pre-PR `coderabbit review` run: one false-positive "critical" (it read the plan's "layers" as Go packages; everything is one package, tests compile and pass), two minor findings addressed (clarified the fail-closed placeholder token, extended query-param sealing assertions to headers).

Closes #1197

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added Binding Descriptors—a declarative configuration system for attaching vault-stored credentials to upstream hosts
  * Support for multiple credential injection schemes (header-template, query-param, and existing basic/bearer)
  * Multi-layer configuration loading with built-in defaults, project-level, and user-level descriptor support

* **Documentation**
  * Added Binding Descriptors guide with schema reference and configuration examples
  * Added Observability guide

* **Tests**
  * Comprehensive test coverage for binding descriptors and credential injection schemes

<!-- end of auto-generated comment: release notes by coderabbit.ai -->