### PR TITLE
ci: remove un-timed-out apt path from host-service Playwright jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -476,7 +476,42 @@ jobs:
 
       - name: Install Playwright browsers
         working-directory: webapp
-        run: pnpm exec playwright install --with-deps chromium
+        # #1218: bound the apt acquire path so a stalled or unreachable apt
+        # mirror fails fast instead of hanging unbounded. The apt config is the
+        # real fail-fast lever: `Acquire::http::Timeout` aborts any single
+        # connection that stalls for 30s, and `Acquire::Retries` retries it a
+        # few times before giving up. A stalled/unreachable mirror can no
+        # longer hang the install indefinitely; apt itself bounds every
+        # acquire. The retry loop wraps the whole install (apt-get internal to
+        # `--with-deps` *and* the browser download) for transient failures;
+        # before each retry it heals any half-applied dpkg state with
+        # `dpkg --configure -a` + `apt-get -f install` so a retry can succeed
+        # rather than dying on a stale dpkg lock. `timeout --kill-after` is a
+        # belt-and-suspenders ceiling that escalates SIGTERM->SIGKILL.
+        run: |
+          sudo tee /etc/apt/apt.conf.d/99aileron-ci-timeouts >/dev/null <<'EOF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          EOF
+          for attempt in 1 2 3; do
+            if timeout --kill-after=30 900 pnpm exec playwright install --with-deps chromium; then
+              exit 0
+            fi
+            echo "Playwright install attempt ${attempt} failed; healing dpkg state and retrying" >&2
+            # `timeout` only signals the direct child; an apt-get spawned by
+            # `--with-deps` can be orphaned and keep holding the dpkg lock.
+            # Reap any lingering apt/dpkg, then repair half-applied state so
+            # the next attempt does not die on a stale lock.
+            sudo pkill -9 -x apt-get || true
+            sudo pkill -9 -x dpkg || true
+            sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock || true
+            sudo dpkg --configure -a || true
+            sudo apt-get -f install -y || true
+            sleep $((attempt * 15))
+          done
+          echo "Playwright install failed after 3 attempts" >&2
+          exit 1
 
       - name: Run integration E2E (real daemon + seed fixture)
         run: webapp/scripts/run-integration-e2e.sh
@@ -790,9 +825,43 @@ jobs:
 
       - name: Install Playwright dependencies
         working-directory: ui
+        # #1218: bound the apt acquire path so a stalled or unreachable apt
+        # mirror fails fast instead of hanging unbounded. The apt config is the
+        # real fail-fast lever: `Acquire::http::Timeout` aborts any single
+        # connection that stalls for 30s, and `Acquire::Retries` retries it a
+        # few times before giving up. A stalled/unreachable mirror can no
+        # longer hang the install indefinitely; apt itself bounds every
+        # acquire. The retry loop wraps the whole install (apt-get internal to
+        # `--with-deps` *and* the browser download) for transient failures;
+        # before each retry it heals any half-applied dpkg state with
+        # `dpkg --configure -a` + `apt-get -f install` so a retry can succeed
+        # rather than dying on a stale dpkg lock. `timeout --kill-after` is a
+        # belt-and-suspenders ceiling that escalates SIGTERM->SIGKILL.
         run: |
           pnpm install --frozen-lockfile
-          pnpm exec playwright install --with-deps chromium
+          sudo tee /etc/apt/apt.conf.d/99aileron-ci-timeouts >/dev/null <<'EOF'
+          Acquire::Retries "3";
+          Acquire::http::Timeout "30";
+          Acquire::https::Timeout "30";
+          EOF
+          for attempt in 1 2 3; do
+            if timeout --kill-after=30 900 pnpm exec playwright install --with-deps chromium; then
+              exit 0
+            fi
+            echo "Playwright install attempt ${attempt} failed; healing dpkg state and retrying" >&2
+            # `timeout` only signals the direct child; an apt-get spawned by
+            # `--with-deps` can be orphaned and keep holding the dpkg lock.
+            # Reap any lingering apt/dpkg, then repair half-applied state so
+            # the next attempt does not die on a stale lock.
+            sudo pkill -9 -x apt-get || true
+            sudo pkill -9 -x dpkg || true
+            sudo rm -f /var/lib/dpkg/lock-frontend /var/lib/dpkg/lock /var/cache/apt/archives/lock || true
+            sudo dpkg --configure -a || true
+            sudo apt-get -f install -y || true
+            sleep $((attempt * 15))
+          done
+          echo "Playwright install failed after 3 attempts" >&2
+          exit 1
 
       - name: Run Playwright integration E2E tests
         working-directory: ui


### PR DESCRIPTION
## Summary

The two host-service Playwright jobs — `test-webapp-integration` (Webapp Integration E2E) and `integration-e2e` (Integration Tests E2E) — ran `pnpm exec playwright install --with-deps chromium` on the bare `ubuntu-latest` runner with no bound on the apt acquire path. `--with-deps` invokes `apt-get` internally, and a stalled or unreachable apt mirror could hang the install unbounded, relying solely on the job-level `timeout-minutes` to eventually kill the whole run.

This PR takes **Route 2** from the umbrella — harden the apt path on the bare runner — chosen over Route 1 (containerize) for least risk to host-service wiring:

- `test-webapp-integration` does not use docker-compose. `run-integration-e2e.sh` spawns a host-process daemon on an ephemeral loopback port and runs Playwright in the same script against that URL. Containerizing Playwright would force an in-container browser to reach a host-process daemon on a random loopback port — no fixed published port to map. High variance for a hands-off run.
- `integration-e2e` binds services on the runner's `localhost:8080`/`localhost:3000` via docker compose; host Playwright reaches them directly. Containerizing would need host networking plus `localhost` → `host.docker.internal` URL rewrites.

Route 2 touches none of that wiring. Both jobs stay on `ubuntu-latest`; every service-start step, env var, `localhost` reference, and the ephemeral-loopback daemon in `run-integration-e2e.sh` are untouched. The browser still installs to `~/.cache/ms-playwright` (cache steps unchanged) and tests still execute on the host runner exactly as today. No third-party retry action is added; hardening is inline.

### How a stalled/unreachable-mirror scenario now fails fast

Each install step now, before installing, writes apt acquire config to `/etc/apt/apt.conf.d/99aileron-ci-timeouts`:
- `Acquire::http::Timeout "30"` / `Acquire::https::Timeout "30"` — abort any single connection that stalls (no bytes) for 30s.
- `Acquire::Retries "3"` — retry an aborted acquire a few times before apt gives up.

This is the real fail-fast lever: a stalled/unreachable mirror can no longer hang the install indefinitely; apt itself bounds every acquire. The install is then wrapped in a per-attempt `timeout --kill-after=30 900` ceiling plus a 3-attempt retry loop. Because `timeout` only signals the direct child and an `apt-get` spawned by `--with-deps` can be orphaned holding the dpkg lock, the loop reaps lingering apt/dpkg and heals any half-applied state (`dpkg --configure -a` + `apt-get -f install`) before each retry, so a retry can actually succeed rather than dying on a stale dpkg lock.

The first iteration of this PR used a bare `timeout 600` with no dpkg recovery. On the `integration-e2e` run that killed a legitimately slow-but-progressing font download mid-flight; the orphaned `apt-get` kept the dpkg lock and the next two attempts failed instantly with `Could not get lock /var/lib/dpkg/lock-frontend`. The current version raises the ceiling and, critically, reaps the orphan + heals dpkg state between attempts so retries recover. Fail-fast behavior is documented here and in the self-documenting comment above each step rather than asserted in a test (CI-only change; adding a test that asserts on a failure path is out of scope).

## Test plan

- `actionlint .github/workflows/ci.yml` passes (exit 0; includes shellcheck over the `run:` blocks).
- Both rendered `run:` blocks extracted and verified with `bash -n` (syntax OK); heredoc body and `EOF` render at shell column 0. The kill+orphan-lock+heal recovery sequence was simulated locally: attempt 1 killed leaving an orphaned lock, heal clears it, attempt 2 succeeds.
- Diff is scoped to the two install steps only: no changes to any `timeout-minutes` (job-level from #1222 and the two `timeout-minutes: 5` docker-compose step guards are byte-for-byte unchanged), `runs-on`, `container`, env var, or `run-integration-e2e.sh`.
- Acceptance: both `Webapp Integration E2E` and `Integration Tests (E2E)` green on this PR with the Playwright suites actually executing (assertions running against the real daemon / docker-compose services, junit uploaded to Codecov), not merely passing install.

Closes #1218

🤖 Generated with [Claude Code](https://claude.com/claude-code)
