### PR TITLE
fix(proxybinding): reject emit_mechanism B at load time until #1196

### DIFF
--- a/docs/src/content/docs/guides/binding-descriptors.md
+++ b/docs/src/content/docs/guides/binding-descriptors.md
@@ -27,7 +27,7 @@ Each binding is a quad plus scheme-specific fields.
 - `host` is the upstream host matched at the proxy boundary. It is an exact host (`api.linear.app`) or a single leading-wildcard form (`*.example.com`). Ports are not part of the pattern.
 - `credential_ref` is a vault credential reference the daemon resolves at injection time. It is a connector-style binding name (`<kind>/<service>/<identity>`) or a user-level reference (`user/<service>`), the namespace `aileron auth <service>` writes. It is never the credential bytes. The descriptor names where the credential lives, never its value.
 - `scheme` is one of the closed injection-scheme set: `bearer`, `basic`, `header-template`, `query-param`, `sigv4-resign`. An unknown scheme is a load-time error. `sigv4-resign` is enumerated but not yet implemented.
-- `emit_mechanism` declares how the credential reaches egress. `A` injects the credential unconditionally at the proxy. `B` is sentinel-swap, where the launcher plants a non-secret sentinel the proxy swaps for the real credential. The field is optional and defaults to `A`. An unknown value is a load-time error.
+- `emit_mechanism` declares how the credential reaches egress. `A` injects the credential unconditionally at the proxy. `B` is sentinel-swap, where the launcher plants a non-secret sentinel the proxy swaps for the real credential. The field is optional and defaults to `A`. Mechanism `B` is rejected at load time until the sentinel-swap egress path ([#1196](https://github.com/ALRubinger/aileron/issues/1196)) is wired, because a descriptor must never validate against a mechanism no proxy code can honor. Today only `A` is accepted; an unknown value is also a load-time error.
 
 Scheme-specific fields:
 
@@ -42,7 +42,7 @@ Decoding is strict. An unknown YAML key is an error, not a silently ignored fiel
 Descriptors load from three layers, in increasing precedence.
 
 1. **Built-in defaults.** Community profiles Aileron ships, embedded at build time. The Linear descriptor above is one.
-2. **Project layer.** `.aileron/binding-descriptors.yaml` relative to your working project.
+2. **Project layer.** `.aileron/binding-descriptors.yaml` relative to the working directory. For the running daemon this resolves against the daemon's working directory, not the directory a `launch` invocation was issued from: the binding table is loaded once at daemon construction and is daemon-global. Per-launch resolution against the launch repo root is deliberately deferred future work.
 3. **User layer.** `~/.aileron/binding-descriptors.yaml`.
 
 A later layer overrides an earlier one per `host` key. A user descriptor can replace a shipped community profile for the same host without editing the shipped file. A new host in any layer is added on top of the others rather than replacing them. An absent project or user file is not an error. It simply contributes nothing.

--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -27,7 +27,10 @@
 // This package defines the descriptor format and the three-layer loader.
 // It does not implement the binding-table consult (#1193), the injectors
 // (#1194), or the sentinel-swap mechanism (#1196, mechanism B); it only
-// validates the emit_mechanism field against the known set. Persisting a
+// validates the emit_mechanism field against the implemented set. Because
+// the sentinel-swap egress path is not yet wired (#1196), this loader
+// accepts only mechanism "A" and rejects emit_mechanism "B" at load time;
+// "B" becomes a valid descriptor value once #1196 lands. Persisting a
 // stateful CLI's local cache across ephemeral sandboxes is out of scope
 // and tracked separately (#1190).
 //
@@ -52,15 +55,19 @@ import (
 const SchemaVersion = "v1"
 
 // EmitMechanisms is the closed set of emit-mechanism values a descriptor
-// may declare. It mirrors internal/binding.EmitMechanism: mechanism "A"
-// injects unconditionally at the proxy (the client emits a no-credential
-// request), and mechanism "B" is sentinel-swap (the launcher plants a
-// non-secret sentinel the proxy swaps for the real credential at egress,
-// defined by #1196). This package validates the field against this set
-// and rejects unknown values; it does not implement either mechanism.
+// may declare at load time. Mechanism "A" injects unconditionally at the
+// proxy (the client emits a no-credential request). Mechanism "B" is
+// sentinel-swap (the launcher plants a non-secret sentinel the proxy swaps
+// for the real credential at egress), and is intentionally absent from
+// this set: until the sentinel-swap egress path is wired (#1196), a
+// descriptor that declares emit_mechanism "B" is rejected at load time
+// rather than accepted into a table no code can honor. This keeps the
+// fail-closed posture: a descriptor never validates against a mechanism
+// the proxy cannot enforce. The canonical internal/binding.EmitMechanismB
+// constant is kept for the future #1196 code; this loader simply does not
+// accept it yet.
 var EmitMechanisms = map[string]struct{}{
 	string(binding.EmitMechanismA): {},
-	string(binding.EmitMechanismB): {},
 }
 
 // Descriptor is a parsed, versioned binding-descriptor document. One
@@ -107,7 +114,10 @@ type Entry struct {
 
 	// EmitMechanism declares how the credential reaches egress: "A"
 	// (inject at the proxy) or "B" (sentinel-swap, #1196). Optional;
-	// empty defaults to "A". An unknown value is a load-time error.
+	// empty defaults to "A". Until the sentinel-swap egress path is wired
+	// (#1196), only "A" is accepted: "B" is rejected at load time rather
+	// than admitted into a table no code can honor. Any other value is
+	// also a load-time error.
 	EmitMechanism string `yaml:"emit_mechanism"`
 
 	// Username is the non-secret HTTP basic-auth username, required only
@@ -200,7 +210,9 @@ func (e *Entry) Validate() error {
 		mech = string(binding.EmitMechanismA)
 	}
 	if _, ok := EmitMechanisms[mech]; !ok {
-		return fmt.Errorf("unknown emit_mechanism %q (want A or B)", e.EmitMechanism)
+		// "B" (sentinel-swap) is rejected at load time until #1196 wires
+		// the egress path; only "A" is accepted today.
+		return fmt.Errorf("unsupported emit_mechanism %q (only %q is accepted until sentinel-swap (#1196) lands)", e.EmitMechanism, string(binding.EmitMechanismA))
 	}
 
 	switch e.Scheme {

--- a/internal/proxybinding/descriptor_test.go
+++ b/internal/proxybinding/descriptor_test.go
@@ -120,6 +120,13 @@ func TestParse_Errors(t *testing.T) {
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: C\n",
 		},
 		{
+			// Mechanism B (sentinel-swap) is rejected at load time until
+			// #1196 wires the egress path: a descriptor must not validate
+			// against a mechanism no proxy code can honor (fail-closed).
+			name: "unsupported emit_mechanism B (sentinel-swap, #1196 not yet wired)",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: B\n",
+		},
+		{
 			name: "header-template missing header",
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: header-template\n    template: \"{token}\"\n",
 		},
@@ -170,6 +177,38 @@ func TestParse_Errors(t *testing.T) {
 				t.Fatalf("Parse(%s) = nil error, want error", tc.name)
 			}
 		})
+	}
+}
+
+// TestParse_EmitMechanismBRejectedUntil1196 pins the operator decision that
+// emit_mechanism "B" (sentinel-swap) is rejected at load time until the
+// sentinel-swap egress path (#1196) is wired: a descriptor must never
+// validate against a mechanism no proxy code can honor. Mechanism "A" (the
+// implemented path) and the empty default (which means "A") must still
+// parse. This is the fail-closed contract; it is intentionally decoupled
+// from the table above so the policy is explicit and survives refactors.
+func TestParse_EmitMechanismBRejectedUntil1196(t *testing.T) {
+	const base = "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n"
+
+	// "A" and the empty default are accepted.
+	if _, err := Parse([]byte(base + "    emit_mechanism: A\n")); err != nil {
+		t.Errorf("emit_mechanism A: Parse = %v, want nil", err)
+	}
+	if _, err := Parse([]byte(base)); err != nil {
+		t.Errorf("emit_mechanism omitted (defaults to A): Parse = %v, want nil", err)
+	}
+
+	// "B" is rejected at load time, and the canonical constant for it is
+	// the value the rejected descriptor declares.
+	bYAML := base + "    emit_mechanism: " + string(binding.EmitMechanismB) + "\n"
+	if _, err := Parse([]byte(bYAML)); err == nil {
+		t.Fatalf("emit_mechanism B: Parse = nil error, want load-time rejection")
+	}
+
+	// The canonical constant is unchanged for future #1196 code even
+	// though the loader does not accept it yet.
+	if string(binding.EmitMechanismB) != "B" {
+		t.Errorf("binding.EmitMechanismB = %q, want %q", string(binding.EmitMechanismB), "B")
 	}
 }
 

--- a/internal/proxybinding/paths.go
+++ b/internal/proxybinding/paths.go
@@ -23,6 +23,12 @@ func DefaultUserPath() string {
 // `.aileron/binding-descriptors.yaml` relative to the given working
 // directory (the middle layer). An empty workdir roots it at the current
 // directory. The file need not exist.
+//
+// For the running daemon this resolves against the daemon's working
+// directory, not the directory a `launch` invocation was issued from: the
+// binding table is loaded once at daemon construction and is daemon-global.
+// Per-launch resolution against the launch repo root is deferred future
+// work.
 func DefaultProjectPath(workdir string) string {
 	return filepath.Join(workdir, ".aileron", "binding-descriptors.yaml")
 }


### PR DESCRIPTION
## Summary

Resolves the remaining actionable findings from review-residual #1202 (sub-issue #1197), per the operator's two decisions:

1. **Reject `emit_mechanism: B` at load time until #1196.** The shipped loader included `binding.EmitMechanismB` in `proxybinding.EmitMechanisms`, so `Entry.Validate` treated `emit_mechanism: B` as well-formed even though no proxy code can honor sentinel-swap until #1196 lands. That is a fail-open. This removes `EmitMechanismB` from the accepted set (keeping only `EmitMechanismA`) so a descriptor declaring `B` is rejected at load time. The canonical `internal/binding.EmitMechanismB` constant is left unchanged for future #1196 code. Doc comments and the validate error message are updated to state the rejection; `binding-descriptors.md` reflects it too.

2. **Document daemon-CWD-relative project-layer resolution.** No code change: the project layer already resolves against the daemon's working directory (`internal/app/app.go` passes an empty workdir to `DefaultLoadOptions`). `binding-descriptors.md` and `DefaultProjectPath`'s doc comment now state this and note that per-launch resolution against the launch repo root is deferred future work, because the binding table is loaded once at daemon construction and is daemon-global.

## Test plan

- Added `TestParse_EmitMechanismBRejectedUntil1196`: asserts `A` and the empty default parse, `B` is rejected at load time, and `binding.EmitMechanismB` still equals `"B"`.
- Added an `emit_mechanism: B` case to the `TestParse_Errors` table.
- `go build ./...` clean in the `internal` module.
- `go test ./proxybinding/... ./binding/... ./app/...` all pass; `proxybinding` coverage 94.5%.

Closes #1202

🤖 Generated with [Claude Code](https://claude.com/claude-code)
