### PR TITLE
fix(launch): always mount no-op gitconfig regardless of vault state

### DIFF
--- a/internal/launch/github_inject.go
+++ b/internal/launch/github_inject.go
@@ -69,9 +69,12 @@ type githubInjectPrep struct {
 	// #1196). The sentinel is non-secret and safe to place in the env.
 	EnvAdditions map[string]string
 
-	// Mounts append to the sandbox volume list. Carries the individual
-	// secret-free gitconfig file mount when a usable user/github entry
-	// was found; empty otherwise. The mount holds no secret regardless.
+	// Mounts append to the sandbox volume list. Always carries the
+	// individual secret-free no-op gitconfig file mount, regardless of
+	// vault state (entry present, missing, locked, or empty token). The
+	// gitconfig content is invariant and holds no secret, so it is mounted
+	// on every launch so git-over-HTTPS emits a completable unauthenticated
+	// request instead of blocking on a prompt or shelling out to `gh`.
 	Mounts []sandboxcontainer.Volume
 
 	// Cleanup removes the transient host directory holding the rendered
@@ -80,74 +83,28 @@ type githubInjectPrep struct {
 	Cleanup func()
 }
 
-// emptyGitHubInjectPrep returns a clean, no-op prep: no env, no mount,
-// and a nil-safe Cleanup. Used on every skip path (no entry, locked
-// vault, empty token) so the caller can unconditionally defer Cleanup
-// and range over EnvAdditions/Mounts.
-func emptyGitHubInjectPrep() githubInjectPrep {
-	return githubInjectPrep{
-		EnvAdditions: map[string]string{},
-		Cleanup:      func() {},
-	}
-}
-
-// prepareGitHubInject probes the user-level GitHub entry in the vault
-// and, when a usable token is present, mounts a read-only, secret-free
-// no-op gitconfig at /home/agent/.gitconfig.
-//
-// Under the ADR-0019 sealing model (#1195) the token never enters the
-// container: no GH_TOKEN env is set and the gitconfig carries no secret
-// bytes. The mounted helper makes git emit a fully-formed but
-// unauthenticated HTTPS request that the daemon proxy seals at egress
-// via the user/github host bindings. The vault probe is retained only
-// to drive the locked-vault warning UX and to gate the (secret-free)
-// mount the same way the pre-sealing code did, keeping the prep shape
-// stable; the daemon binding independently handles the locked/empty
-// case fail-closed, so a missed mount never leaks or breaks auth.
-//
-// Skip-clean semantics: a missing entry (ErrUserCredentialsNotFound) or
-// a locked vault (vault.ErrCredentialUnavailable) returns an empty prep
-// with no error — the launch proceeds with GitHub operations simply
-// unauthenticated. A token that is empty after trimming is treated the
-// same way. Only an unexpected daemon error aborts.
+// renderNoopGitconfigMount creates the transient host directory, writes
+// the static secret-free no-op gitconfig, applies the chown hook, and
+// returns a prep carrying the read-only file mount and a real Cleanup.
+// EnvAdditions is initialized empty; the caller adds GH_TOKEN only on the
+// token-present path. This is invoked on EVERY launch path (entry
+// present, missing, locked, empty token) because the gitconfig content
+// is invariant and secret-free regardless of vault state (Key Decision 4,
+// #1195): always mounting it lets git-over-HTTPS emit a completable
+// unauthenticated request the daemon seals at egress, instead of blocking
+// on a prompt or shelling out to `gh`.
 //
 // chownHook, when non-nil, is applied to the transient directory before
-// the mount is added. On rootful Docker Linux the host operator owns
+// the mount is assembled. On rootful Docker Linux the host operator owns
 // the 0700 transient dir, which the in-container agent UID cannot
 // traverse; the hook chowns the tree to the agent UID so git-over-HTTPS
 // can read the helper line. A hook failure is non-fatal: the injector
 // warns and proceeds, since a same-UID environment needs no chown.
-func prepareGitHubInject(
-	ctx context.Context,
-	daemon userCredsDaemon,
+func renderNoopGitconfigMount(
 	sessionLog *slog.Logger,
 	stderr io.Writer,
 	chownHook func(dir string) error,
 ) (githubInjectPrep, error) {
-	secret, err := daemon.GetUserCredentials(ctx, githubUserService)
-	if err != nil {
-		switch {
-		case errors.Is(err, ErrUserCredentialsNotFound):
-			// No user/github entry — proceed unauthenticated.
-			return emptyGitHubInjectPrep(), nil
-		case errors.Is(err, vault.ErrCredentialUnavailable):
-			// Vault locked — no token available this launch. Warn so the
-			// user knows GitHub ops will be unauthenticated, but never
-			// abort the launch.
-			githubInjectWarn(sessionLog, stderr,
-				fmt.Errorf("vault locked; GitHub operations in the sandbox will be unauthenticated until you unlock the vault"))
-			return emptyGitHubInjectPrep(), nil
-		default:
-			return githubInjectPrep{}, fmt.Errorf("read user github credentials: %w", err)
-		}
-	}
-
-	token := strings.TrimSpace(string(secret.Value))
-	if token == "" {
-		// An entry with no usable token is equivalent to no entry.
-		return emptyGitHubInjectPrep(), nil
-	}
-
 	dir, err := os.MkdirTemp("", "aileron-github-inject-")
 	if err != nil {
 		return githubInjectPrep{}, fmt.Errorf("create github inject dir: %w", err)
@@ -179,23 +136,91 @@ func prepareGitHubInject(
 		}
 	}
 
-	prep := emptyGitHubInjectPrep()
+	return githubInjectPrep{
+		EnvAdditions: map[string]string{},
+		Mounts: []sandboxcontainer.Volume{{
+			Source:   hostPath,
+			Target:   githubConfigTarget,
+			ReadOnly: true,
+		}},
+		Cleanup: cleanup,
+	}, nil
+}
+
+// prepareGitHubInject probes the user-level GitHub entry in the vault and
+// always mounts a read-only, secret-free no-op gitconfig at
+// /home/agent/.gitconfig — on every path, whether the entry is present,
+// missing, the vault is locked, or the token is empty (Key Decision 4,
+// #1195). The gitconfig content is invariant and carries no secret bytes,
+// so mounting it unconditionally leaks nothing while ensuring
+// git-over-HTTPS always emits a completable unauthenticated request the
+// daemon proxy seals at egress via the user/github host bindings, instead
+// of blocking on a prompt or shelling out to `gh`.
+//
+// Under the ADR-0019 sealing model (#1195) the token never enters the
+// container: the gitconfig carries no secret bytes and GH_TOKEN, when
+// set, holds only the non-secret sentinel. The vault probe drives the
+// locked-vault warning UX and gates the GH_TOKEN sentinel (which requires
+// a real daemon-side credential to swap), but no longer gates the mount.
+//
+// Skip-clean semantics: a missing entry (ErrUserCredentialsNotFound) or
+// a locked vault (vault.ErrCredentialUnavailable) still mounts the no-op
+// gitconfig with no error and no GH_TOKEN — the launch proceeds with
+// GitHub operations simply unauthenticated. A token that is empty after
+// trimming is treated the same way. Only an unexpected daemon error
+// aborts. The locked-vault warning is still emitted.
+//
+// chownHook is threaded into renderNoopGitconfigMount; see its doc for
+// the rootful-Docker-Linux rationale and the non-fatal-on-failure
+// contract.
+func prepareGitHubInject(
+	ctx context.Context,
+	daemon userCredsDaemon,
+	sessionLog *slog.Logger,
+	stderr io.Writer,
+	chownHook func(dir string) error,
+) (githubInjectPrep, error) {
+	secret, err := daemon.GetUserCredentials(ctx, githubUserService)
+	if err != nil {
+		switch {
+		case errors.Is(err, ErrUserCredentialsNotFound):
+			// No user/github entry — proceed unauthenticated, but still
+			// mount the secret-free no-op gitconfig.
+			return renderNoopGitconfigMount(sessionLog, stderr, chownHook)
+		case errors.Is(err, vault.ErrCredentialUnavailable):
+			// Vault locked — no token available this launch. Warn so the
+			// user knows GitHub ops will be unauthenticated, but never
+			// abort the launch; still mount the secret-free no-op gitconfig.
+			githubInjectWarn(sessionLog, stderr,
+				fmt.Errorf("vault locked; GitHub operations in the sandbox will be unauthenticated until you unlock the vault"))
+			return renderNoopGitconfigMount(sessionLog, stderr, chownHook)
+		default:
+			return githubInjectPrep{}, fmt.Errorf("read user github credentials: %w", err)
+		}
+	}
+
+	token := strings.TrimSpace(string(secret.Value))
+	if token == "" {
+		// An entry with no usable token is equivalent to no entry: mount
+		// the no-op gitconfig, set no GH_TOKEN.
+		return renderNoopGitconfigMount(sessionLog, stderr, chownHook)
+	}
+
+	prep, err := renderNoopGitconfigMount(sessionLog, stderr, chownHook)
+	if err != nil {
+		return githubInjectPrep{}, err
+	}
 	// GH_TOKEN carries the non-secret sentinel, never the real token.
 	// `gh` short-circuits locally without a token, so we plant the
 	// sentinel to make it issue its request; the daemon recognizes the
 	// sentinel at the TLS boundary and swaps in the real user/github
 	// credential (emit-mechanism B, #1196). The real secret never enters
-	// the container in env, mount, or args. The mount below carries only
-	// the secret-free no-op git credential helper (emit-mechanism A for
+	// the container in env, mount, or args. The mount carries only the
+	// secret-free no-op git credential helper (emit-mechanism A for
 	// git-over-HTTPS, which the daemon seals from the unauthenticated
-	// request git emits).
+	// request git emits). The sentinel is gated to the token-present path
+	// because the sentinel-swap requires a real daemon-side credential.
 	prep.EnvAdditions["GH_TOKEN"] = sentinel.GitHubTokenSentinel
-	prep.Mounts = []sandboxcontainer.Volume{{
-		Source:   hostPath,
-		Target:   githubConfigTarget,
-		ReadOnly: true,
-	}}
-	prep.Cleanup = cleanup
 	return prep, nil
 }
 

--- a/internal/launch/github_inject_launcher_test.go
+++ b/internal/launch/github_inject_launcher_test.go
@@ -63,7 +63,11 @@ func TestLauncherMergesGitHubInject_TokenPresent(t *testing.T) {
 	}
 }
 
-func TestLauncherMergesGitHubInject_NoEntryIsCleanSkip(t *testing.T) {
+func TestLauncherMergesGitHubInject_NoEntryStillMountsNoopGitconfig(t *testing.T) {
+	// Key Decision 4 (#1195): even with no user/github entry the launcher
+	// appends the secret-free no-op gitconfig mount (so git-over-HTTPS
+	// does not block in the sandbox), but no GH_TOKEN is merged (the
+	// sentinel-swap needs a real daemon-side credential).
 	daemon := &fakeUserCredsDaemon{err: ErrUserCredentialsNotFound}
 
 	agentEnv := map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "agent-oauth"}
@@ -80,13 +84,22 @@ func TestLauncherMergesGitHubInject_NoEntryIsCleanSkip(t *testing.T) {
 	proxyMounts = append(proxyMounts, ghPrep.Mounts...)
 
 	if _, ok := agentEnv["GH_TOKEN"]; ok {
-		t.Errorf("GH_TOKEN injected on clean skip; want absent")
+		t.Errorf("GH_TOKEN injected on no-entry path; want absent")
 	}
-	if len(proxyMounts) != 0 {
-		t.Errorf("mounts appended on clean skip; want none, got %+v", proxyMounts)
+	var found bool
+	for _, m := range proxyMounts {
+		if m.Target == "/home/agent/.gitconfig" {
+			found = true
+			if !m.ReadOnly {
+				t.Errorf("no-op gitconfig mount ReadOnly = false, want true")
+			}
+		}
 	}
-	// The unrelated AuthSpec env survives the no-op merge.
+	if !found {
+		t.Errorf("no-op gitconfig mount missing on no-entry path; got %+v", proxyMounts)
+	}
+	// The unrelated AuthSpec env survives the merge.
 	if agentEnv["CLAUDE_CODE_OAUTH_TOKEN"] != "agent-oauth" {
-		t.Errorf("clean skip disturbed existing env: %q", agentEnv["CLAUDE_CODE_OAUTH_TOKEN"])
+		t.Errorf("no-entry path disturbed existing env: %q", agentEnv["CLAUDE_CODE_OAUTH_TOKEN"])
 	}
 }

--- a/internal/launch/github_inject_test.go
+++ b/internal/launch/github_inject_test.go
@@ -24,9 +24,14 @@ import (
 //     helper, and a no-op empty-credential helper scoped to
 //     https://github.com. The real token is sealed daemon-side at egress,
 //     never env-injected and never in the mount.
-//   - ErrUserCredentialsNotFound and a locked vault both yield an empty
-//     prep with no error and a nil-safe Cleanup (skip-clean).
-//   - An empty-after-trim token is treated as no token.
+//   - Key Decision 4 (#1195): the static secret-free no-op gitconfig is
+//     mounted on EVERY path — ErrUserCredentialsNotFound, a locked vault,
+//     and an empty-after-trim token all yield exactly one read-only mount
+//     at /home/agent/.gitconfig with no error and a real Cleanup that
+//     removes the transient dir. The GH_TOKEN sentinel is gated to the
+//     token-present path only (the sentinel-swap needs a real daemon-side
+//     credential), so it is absent on those skip paths.
+//   - An empty-after-trim token is treated as no token (mount, no token).
 //   - The chown hook is invoked exactly once with the transient root
 //     dir (P1 wiring), and the transient dir is 0700 (traverse bit),
 //     never 0600.
@@ -147,6 +152,10 @@ func TestPrepareGitHubInject_GitconfigIsSecretFreeRegardlessOfToken(t *testing.T
 }
 
 func TestPrepareGitHubInject_NotFoundIsCleanSkip(t *testing.T) {
+	// Key Decision 4 (#1195): a missing entry still mounts the static
+	// secret-free no-op gitconfig (so git-over-HTTPS does not block), but
+	// sets no GH_TOKEN (the sentinel-swap needs a real daemon-side
+	// credential).
 	daemon := &fakeUserCredsDaemon{err: ErrUserCredentialsNotFound}
 	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
 	if err != nil {
@@ -155,47 +164,77 @@ func TestPrepareGitHubInject_NotFoundIsCleanSkip(t *testing.T) {
 	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
 		t.Errorf("GH_TOKEN set on not-found, want absent")
 	}
-	if len(prep.Mounts) != 0 {
-		t.Errorf("Mounts = %d, want 0 on not-found", len(prep.Mounts))
+	if len(prep.Mounts) != 1 {
+		t.Fatalf("Mounts = %d, want 1 (no-op gitconfig) on not-found", len(prep.Mounts))
+	}
+	if prep.Mounts[0].Target != "/home/agent/.gitconfig" {
+		t.Errorf("mount Target = %q, want /home/agent/.gitconfig", prep.Mounts[0].Target)
+	}
+	if !prep.Mounts[0].ReadOnly {
+		t.Errorf("mount ReadOnly = false, want true")
 	}
 	if prep.Cleanup == nil {
 		t.Fatal("Cleanup nil on not-found; want nil-safe no-op")
 	}
+	src := prep.Mounts[0].Source
+	if _, statErr := os.Stat(src); statErr != nil {
+		t.Fatalf("mounted gitconfig %q not present before cleanup: %v", src, statErr)
+	}
 	prep.Cleanup() // must not panic
+	if _, statErr := os.Stat(src); !errors.Is(statErr, fs.ErrNotExist) {
+		t.Errorf("Cleanup did not remove transient dir: stat err = %v, want ErrNotExist", statErr)
+	}
 }
 
 func TestPrepareGitHubInject_LockedVaultIsCleanSkip(t *testing.T) {
+	// Key Decision 4 (#1195): a locked vault still mounts the static
+	// secret-free no-op gitconfig and still emits the locked-vault
+	// warning, but sets no GH_TOKEN.
 	var stderr bytes.Buffer
 	daemon := &fakeUserCredsDaemon{err: vault.ErrCredentialUnavailable}
 	prep, err := prepareGitHubInject(context.Background(), daemon, nil, &stderr, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v, want clean skip on locked vault", err)
 	}
+	defer prep.Cleanup()
 	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
 		t.Errorf("GH_TOKEN set on locked vault, want absent")
 	}
-	if len(prep.Mounts) != 0 {
-		t.Errorf("Mounts = %d, want 0 on locked vault", len(prep.Mounts))
+	if len(prep.Mounts) != 1 {
+		t.Fatalf("Mounts = %d, want 1 (no-op gitconfig) on locked vault", len(prep.Mounts))
+	}
+	if prep.Mounts[0].Target != "/home/agent/.gitconfig" {
+		t.Errorf("mount Target = %q, want /home/agent/.gitconfig", prep.Mounts[0].Target)
+	}
+	if !prep.Mounts[0].ReadOnly {
+		t.Errorf("mount ReadOnly = false, want true")
 	}
 	if stderr.Len() == 0 {
 		t.Errorf("expected a non-fatal locked-vault warning on stderr")
 	}
-	prep.Cleanup()
 }
 
 func TestPrepareGitHubInject_EmptyTokenIsCleanSkip(t *testing.T) {
+	// Key Decision 4 (#1195): an empty-after-trim token still mounts the
+	// static secret-free no-op gitconfig, but sets no GH_TOKEN.
 	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("   \n")}}
 	prep, err := prepareGitHubInject(context.Background(), daemon, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v", err)
 	}
+	defer prep.Cleanup()
 	if _, ok := prep.EnvAdditions["GH_TOKEN"]; ok {
 		t.Errorf("GH_TOKEN set on empty-after-trim token, want absent")
 	}
-	if len(prep.Mounts) != 0 {
-		t.Errorf("Mounts = %d, want 0 on empty token", len(prep.Mounts))
+	if len(prep.Mounts) != 1 {
+		t.Fatalf("Mounts = %d, want 1 (no-op gitconfig) on empty token", len(prep.Mounts))
 	}
-	prep.Cleanup()
+	if prep.Mounts[0].Target != "/home/agent/.gitconfig" {
+		t.Errorf("mount Target = %q, want /home/agent/.gitconfig", prep.Mounts[0].Target)
+	}
+	if !prep.Mounts[0].ReadOnly {
+		t.Errorf("mount ReadOnly = false, want true")
+	}
 }
 
 func TestPrepareGitHubInject_UnexpectedDaemonErrorAborts(t *testing.T) {


### PR DESCRIPTION
## Summary

Implements Key Decision 4 from review-residual #1204 (sub-issue #1195): the static credential-helper gitconfig mounted at `/home/agent/.gitconfig` is invariant and secret-free regardless of vault state, so it is now mounted on **every** launch path — not-found, locked vault, empty-after-trim token, and token-present alike.

Previously `prepareGitHubInject` gated the mount to the token-present path. On every skip path it returned no Mounts, which defeated the no-op helper's purpose: git-over-HTTPS would block on an interactive prompt or shell out to `gh` instead of emitting the completable unauthenticated request the daemon forward-proxy seals at egress.

### What changed
- Extracted `renderNoopGitconfigMount` (temp-dir creation + chmod 0700 + `WriteFile(gitCredentialHelperConfig)` + chown hook + read-only Mount + Cleanup assembly). It is invoked on all four return paths.
- `GH_TOKEN = sentinel.GitHubTokenSentinel` stays gated to the token-present path only — the sentinel-swap (emit-mechanism B, #1196) requires a real daemon-side credential to swap, so planting the sentinel without a backing credential would be wrong.
- The locked-vault stderr warning is preserved.
- Removed the now-unused `emptyGitHubInjectPrep` helper.
- The mounted gitconfig content (`gitCredentialHelperConfig`) is unchanged and carries no secret, so always-mounting leaks nothing.

The launcher caller already `defer ghPrep.Cleanup()`s and ranges over `EnvAdditions`/`Mounts` unconditionally, so always returning a real Cleanup + one Mount is safe.

## Test plan
- Rewrote `TestPrepareGitHubInject_{NotFound,LockedVault,EmptyToken}IsCleanSkip` to assert `len(Mounts)==1` targeting `/home/agent/.gitconfig` (read-only), `GH_TOKEN` absent, and (not-found case) that Cleanup removes the transient dir.
- Updated the launcher-wiring no-entry test (`TestLauncherMergesGitHubInject_NoEntryStillMountsNoopGitconfig`) to assert the no-op gitconfig mount is appended and GH_TOKEN is not merged.
- Token-present, secret-free-regardless-of-token, chown-hook, and unexpected-daemon-error tests unchanged and still pass.
- `go test ./internal/launch/` green; `go vet` clean; `gofmt` clean; `internal` module builds.

Closes #1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved GitHub authentication reliability in sandbox environments by ensuring consistent behavior when credentials are unavailable, locked, or empty, eliminating edge-case setup failures.

* **Refactor**
  * Reorganized GitHub credential injection mechanism to always mount required configuration files and defer token substitution to the daemon-side runtime boundary, enhancing security and consistency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->