### PR TITLE
ci: guard Playwright E2E against silent skips and tag/lockfile drift

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -296,7 +296,7 @@ jobs:
     timeout-minutes: 25
     container:
       # Pinned to match the Playwright version resolved in ui/pnpm-lock.yaml
-      # (currently 1.60.0). The image bakes Chromium + its system deps, so no
+      # (currently 1.61.0). The image bakes Chromium + its system deps, so no
       # `playwright install --with-deps` / apt-get is needed. JOINT BUMP: when
       # ui/pnpm-lock.yaml's Playwright pin changes, bump this tag in lockstep
       # (and the matching tag in the test-webapp job) so the baked browser
@@ -330,6 +330,29 @@ jobs:
       - name: Run E2E tests
         working-directory: ui
         run: pnpm test:e2e
+
+      # Anti-silent-skip guard: a Playwright run that executes zero tests
+      # (config drift, glob mismatch, an offline browser image that makes
+      # every spec self-skip) still exits 0. Fail the job unless the JUnit
+      # report records at least one executed testcase, so "green" always
+      # means "tests actually ran".
+      - name: Assert E2E tests executed (anti-silent-skip)
+        working-directory: ui
+        run: |
+          report="test-results/junit-playwright.xml"
+          if [ ! -f "$report" ]; then
+            echo "::error::Playwright JUnit report $report not found; E2E tests did not produce results" >&2
+            exit 1
+          fi
+          # Count <testcase> elements: each one is an executed test. grep -o
+          # counts occurrences (not lines), so multiple testcases on one line
+          # are each counted.
+          cases="$(grep -o '<testcase' "$report" | wc -l | tr -d ' ')"
+          echo "Playwright executed $cases test(s)"
+          if [ "$cases" -eq 0 ]; then
+            echo "::error::Playwright executed 0 tests; refusing to pass on a silent skip" >&2
+            exit 1
+          fi
 
       - name: Generate E2E coverage report
         if: ${{ !cancelled() }}
@@ -376,7 +399,7 @@ jobs:
     timeout-minutes: 25
     container:
       # Pinned to match the Playwright version resolved in webapp/pnpm-lock.yaml
-      # (currently 1.60.0). The image bakes Chromium + its system deps, so no
+      # (currently 1.61.0). The image bakes Chromium + its system deps, so no
       # `playwright install --with-deps` / apt-get is needed. JOINT BUMP: when
       # webapp/pnpm-lock.yaml's Playwright pin changes, bump this tag in lockstep
       # (and the matching tag in the test-ui job) so the baked browser
@@ -413,6 +436,29 @@ jobs:
       - name: Run E2E tests (mocked)
         working-directory: webapp
         run: pnpm test:e2e
+
+      # Anti-silent-skip guard: a Playwright run that executes zero tests
+      # (config drift, glob mismatch, an offline browser image that makes
+      # every spec self-skip) still exits 0. Fail the job unless the JUnit
+      # report records at least one executed testcase, so "green" always
+      # means "tests actually ran".
+      - name: Assert E2E tests executed (anti-silent-skip)
+        working-directory: webapp
+        run: |
+          report="test-results/junit-playwright.xml"
+          if [ ! -f "$report" ]; then
+            echo "::error::Playwright JUnit report $report not found; E2E tests did not produce results" >&2
+            exit 1
+          fi
+          # Count <testcase> elements: each one is an executed test. grep -o
+          # counts occurrences (not lines), so multiple testcases on one line
+          # are each counted.
+          cases="$(grep -o '<testcase' "$report" | wc -l | tr -d ' ')"
+          echo "Playwright executed $cases test(s)"
+          if [ "$cases" -eq 0 ]; then
+            echo "::error::Playwright executed 0 tests; refusing to pass on a silent skip" >&2
+            exit 1
+          fi
 
       - name: Upload Playwright report on failure
         if: failure()

--- a/internal/ci/playwright_pin_test.go
+++ b/internal/ci/playwright_pin_test.go
@@ -1,0 +1,154 @@
+package ci
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"regexp"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+)
+
+// playwrightPinChecks pairs a CI job whose container bakes a Playwright browser
+// image with the pnpm lockfile whose resolved @playwright/test version must
+// stay in lockstep with that image tag. When Renovate bumps one without the
+// other, the baked browser and the installed @playwright/test drift apart,
+// which surfaces as an opaque offline/launch failure in E2E rather than a clear
+// "versions don't match" error. This guard turns that silent class of breakage
+// into a failing unit test at the source of truth.
+var playwrightPinChecks = []struct {
+	job      string // job key in .github/workflows/ci.yml
+	lockfile string // pnpm lockfile path relative to repo root
+}{
+	{job: "test-ui", lockfile: filepath.Join("ui", "pnpm-lock.yaml")},
+	{job: "test-webapp", lockfile: filepath.Join("webapp", "pnpm-lock.yaml")},
+}
+
+// ciWorkflowImages models just enough of ci.yml to read each job's container
+// image. Kept separate from ciWorkflow (timeout test) so each guard owns its
+// own minimal projection of the file.
+type ciWorkflowImages struct {
+	Jobs map[string]struct {
+		Container struct {
+			Image string `yaml:"image"`
+		} `yaml:"container"`
+	} `yaml:"jobs"`
+}
+
+// playwrightImageVersion extracts the semantic version from a Microsoft
+// Playwright container image reference such as
+// "mcr.microsoft.com/playwright:v1.61.0-noble" -> "1.61.0".
+var playwrightImageVersion = regexp.MustCompile(`playwright:v(\d+\.\d+\.\d+)`)
+
+// parsePlaywrightImageTag returns the X.Y.Z version baked into a Playwright
+// container image reference.
+func parsePlaywrightImageTag(image string) (string, error) {
+	m := playwrightImageVersion.FindStringSubmatch(image)
+	if m == nil {
+		return "", fmt.Errorf("image %q does not look like an mcr.microsoft.com/playwright:vX.Y.Z-* reference", image)
+	}
+	return m[1], nil
+}
+
+// pnpmLockfile models the part of a pnpm-lock.yaml needed to read the resolved
+// version of a top-level dependency. The lockfile's `importers` section maps
+// each workspace package (the repo root is ".") to its dependencies, and each
+// dependency records both the declared `specifier` and the concretely
+// `version` pnpm resolved it to. We assert against the resolved version because
+// that is the @playwright/test the job actually installs.
+type pnpmLockfile struct {
+	Importers map[string]struct {
+		Dependencies    map[string]pnpmDep `yaml:"dependencies"`
+		DevDependencies map[string]pnpmDep `yaml:"devDependencies"`
+	} `yaml:"importers"`
+}
+
+type pnpmDep struct {
+	Specifier string `yaml:"specifier"`
+	Version   string `yaml:"version"`
+}
+
+// resolvedPlaywrightTestVersion returns the X.Y.Z version pnpm resolved for
+// @playwright/test in the root importer of the given lockfile. A pnpm version
+// string may carry a peer-dependency suffix (e.g. "1.61.0(foo@2)"); only the
+// leading semver is returned.
+var leadingSemver = regexp.MustCompile(`^(\d+\.\d+\.\d+)`)
+
+func resolvedPlaywrightTestVersion(lock pnpmLockfile) (string, error) {
+	root, ok := lock.Importers["."]
+	if !ok {
+		return "", fmt.Errorf("lockfile has no root (\".\") importer")
+	}
+	dep, ok := root.Dependencies["@playwright/test"]
+	if !ok {
+		dep, ok = root.DevDependencies["@playwright/test"]
+	}
+	if !ok {
+		return "", fmt.Errorf("@playwright/test not found in root importer dependencies or devDependencies")
+	}
+	m := leadingSemver.FindStringSubmatch(dep.Version)
+	if m == nil {
+		return "", fmt.Errorf("@playwright/test resolved version %q does not start with an X.Y.Z semver", dep.Version)
+	}
+	return m[1], nil
+}
+
+// TestPlaywrightImageTagMatchesLockfile asserts the contract for #1221: the
+// Playwright container image tag pinned in each E2E job must match the
+// @playwright/test version resolved in that job's pnpm lockfile. Bumping one
+// without the other (the typical Renovate failure mode) makes this test fail
+// and names both the job and the divergent versions, instead of letting the
+// mismatch surface as an opaque browser-launch error inside E2E.
+func TestPlaywrightImageTagMatchesLockfile(t *testing.T) {
+	root := findRepoRoot(t)
+
+	workflowPath := filepath.Join(root, ".github", "workflows", "ci.yml")
+	data, err := os.ReadFile(workflowPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", workflowPath, err)
+	}
+
+	var wf ciWorkflowImages
+	if err := yaml.Unmarshal(data, &wf); err != nil {
+		t.Fatalf("unmarshal %s: %v", workflowPath, err)
+	}
+
+	for _, check := range playwrightPinChecks {
+		check := check
+		t.Run(check.job, func(t *testing.T) {
+			job, ok := wf.Jobs[check.job]
+			if !ok {
+				t.Fatalf("job %q not found in %s", check.job, workflowPath)
+			}
+			if job.Container.Image == "" {
+				t.Fatalf("job %q has no container.image; expected an mcr.microsoft.com/playwright image", check.job)
+			}
+
+			imageVersion, err := parsePlaywrightImageTag(job.Container.Image)
+			if err != nil {
+				t.Fatalf("job %q: %v", check.job, err)
+			}
+
+			lockPath := filepath.Join(root, check.lockfile)
+			lockData, err := os.ReadFile(lockPath)
+			if err != nil {
+				t.Fatalf("read %s: %v", lockPath, err)
+			}
+
+			var lock pnpmLockfile
+			if err := yaml.Unmarshal(lockData, &lock); err != nil {
+				t.Fatalf("unmarshal %s: %v", lockPath, err)
+			}
+
+			lockVersion, err := resolvedPlaywrightTestVersion(lock)
+			if err != nil {
+				t.Fatalf("%s: %v", check.lockfile, err)
+			}
+
+			if imageVersion != lockVersion {
+				t.Errorf("Playwright version drift in job %q: container image pins v%s but %s resolves @playwright/test %s. Bump the ci.yml image tag and the lockfile in lockstep (JOINT BUMP).", check.job, imageVersion, check.lockfile, lockVersion)
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Two CI reliability guards for the `test-ui` and `test-webapp` jobs, both answered GO during triage of review-residual #1221 (sub-issue #1217):

1. **Anti-silent-skip guard.** After each `Run E2E tests` step, a new `Assert E2E tests executed` step parses `test-results/junit-playwright.xml` and fails the job unless at least one `<testcase>` was executed. A Playwright run that executes zero tests (config drift, glob mismatch, an offline browser image that makes every spec self-skip) still exits `0` today; this enforces the standing "tests fail fast, no silent skips" principle so a green job always means tests actually ran.

2. **Playwright tag ↔ lockfile pin lint.** New `internal/ci/playwright_pin_test.go` asserts the `container.image` Playwright tag in each E2E job (`v1.61.0-noble`) matches the `@playwright/test` version resolved in that job's `pnpm-lock.yaml` (`1.61.0`). When Renovate bumps one without the other, the baked browser and installed `@playwright/test` drift apart and surface as an opaque browser-launch failure inside E2E; this turns that into a clear, named unit-test failure at the source of truth. The job/lockfile set is data-driven, and the resolved version is read from the lockfile's root importer (handles `dependencies` or `devDependencies`).

Also corrected the stale `(currently 1.60.0)` JOINT BUMP comments to `1.61.0` to match the actual image pin.

## Test plan

- `go test ./ci/...` from `internal/` — passes (`TestPlaywrightImageTagMatchesLockfile/test-ui`, `/test-webapp`, plus the existing timeout guard).
- Negative check: temporarily editing the `test-ui` image tag to `v1.60.0` makes `TestPlaywrightImageTagMatchesLockfile` fail and names the job + divergent versions, proving the guard is real (not a mirror). Reverted.
- Anti-silent-skip shell logic validated against sample JUnit XML: 3 `<testcase>` elements → counts 3 (passes); empty `<testsuites tests="0">` → counts 0 (fails as intended). `grep -o '<testcase' | wc -l` counts occurrences, so multiple testcases on one line are each counted.
- `gofmt -l`, `go vet ./ci/...` clean; `ci.yml` validates as YAML via `gopkg.in/yaml.v3`.

Closes #1221

🤖 Generated with [Claude Code](https://claude.com/claude-code)
