### PR TITLE
ci(sandbox): add daily watcher to republish stale agent edge images

### DIFF
--- a/.github/workflows/sandbox-agents-watch.yml
+++ b/.github/workflows/sandbox-agents-watch.yml
@@ -1,0 +1,224 @@
+name: Sandbox Agent Image Freshness
+
+# Keeps the published per-agent sandbox images
+# (ghcr.io/alrubinger/aileron-sandbox-{claude,codex}) fresh against upstream
+# agent-CLI npm releases by detecting drift and re-triggering sandbox-agents.yml.
+#
+# Corrected mechanism (verified against shipped reality):
+#   - The agent Feature install scripts run `npm install -g <pkg>` with NO
+#     version pin (images/sandbox-features/<agent>/install.sh), so a fresh
+#     sandbox-agents.yml run already bakes the *latest* CLI at build time and
+#     stamps the resolved version into the tag. Freshness therefore needs NO
+#     source edit, only a re-trigger of the existing workflow.
+#   - The baked CLI version is recoverable from GHCR: sandbox-agents.yml pushes
+#     `edge` and `dev-<cli-version>` to the SAME digest in one workflow_dispatch
+#     build. This watcher resolves the `edge` manifest digest, finds the
+#     sibling `dev-<semver>` tag on that same digest, and parses the semver as
+#     the baked version. No OCI-label probing or image pull is required.
+#
+# Freshness target = `edge` only (and its `dev-<cli>` sibling). The watcher
+# dispatches sandbox-agents.yml on workflow_dispatch, which republishes `edge`
+# (aileron version resolves to "dev"); `latest` and the release-pinned
+# `<aileron-version>-<agent-cli-version>` tags move ONLY on `v*` tag pushes.
+# Dev/main consumers pull `edge` (per imageTag resolution in
+# internal/sandbox/composition/composition.go) and get freshness automatically.
+# `latest` freshness between releases is an ACCEPTED, INTENTIONAL gap: a release
+# is an immutable point and `latest` names the most-recent release, so a
+# background job must never clobber it. This is documented in
+# docs/src/content/docs/development/sandbox-agent-images.md.
+#
+# sandbox-agents.yml has a hardcoded [claude, codex] matrix and a bare
+# workflow_dispatch (no inputs). A single `gh workflow run sandbox-agents.yml`
+# rebuilds BOTH agents. This watcher dispatches the whole workflow when *either*
+# agent is stale; rebuilding the non-stale agent is a harmless no-op `edge`
+# republish (same digest, same version). We deliberately do NOT add a
+# workflow_dispatch input to scope dispatch per-agent (keeps sandbox-agents.yml
+# untouched, per the #1088 plan).
+#
+# Re-pushing `edge`/`dev-<cli>` to the existing aileron-sandbox-<agent> package
+# preserves its current visibility (visibility is per-package, not per-tag; the
+# packages already exist from #1086/#1138), so no visibility automation is
+# needed.
+#
+# Digest pinning of the resolved image is OUT of scope here (owned by #1233).
+#
+# Uses only GITHUB_TOKEN. No secrets, no baked credentials.
+
+on:
+  schedule:
+    # Daily at 07:00 UTC, an off-peak hour for both US and EU working days,
+    # so a drift-triggered rebuild lands before the workday rather than during
+    # peak Actions contention.
+    - cron: "0 7 * * *"
+  workflow_dispatch:
+    inputs:
+      dry_run:
+        description: "Detect drift and report without dispatching the rebuild"
+        type: boolean
+        default: true
+
+permissions:
+  # packages: read enumerates GHCR tags / resolves manifest digests.
+  # actions: write dispatches sandbox-agents.yml via `gh workflow run`.
+  # No contents: write, no packages: write — the watcher never edits the repo
+  # nor pushes images itself.
+  packages: read
+  actions: write
+
+concurrency:
+  group: sandbox-agents-watch-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  watch:
+    name: Detect agent CLI drift
+    runs-on: ubuntu-latest
+    steps:
+      - name: Detect drift and conditionally dispatch rebuild
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          # github.event.inputs.dry_run is empty on schedule; treat empty as
+          # false so scheduled runs dispatch on drift.
+          DRY_RUN: ${{ github.event.inputs.dry_run }}
+        run: |
+          set -euo pipefail
+
+          OWNER="alrubinger"
+
+          # Agent -> npm package. Mirrors the [claude, codex] matrix in
+          # sandbox-agents.yml and NPMPackage in
+          # internal/sandbox/composition/recipes.go (the source of truth for the
+          # package names; kept inline here to avoid a repo checkout). A case
+          # lookup (not an associative array) keeps this portable across bash
+          # versions under `set -u`.
+          npm_pkg_for() {
+            case "$1" in
+              claude) echo "@anthropic-ai/claude-code" ;;
+              codex) echo "@openai/codex" ;;
+              *) return 1 ;;
+            esac
+          }
+
+          any_stale=false
+
+          {
+            echo "## Sandbox agent image freshness"
+            echo
+            echo "Mode: ${DRY_RUN:-false (scheduled)}"
+            echo
+          } >> "$GITHUB_STEP_SUMMARY"
+
+          # Mint a GHCR registry pull token from GITHUB_TOKEN for a repository,
+          # then echo the bearer token.
+          ghcr_token() {
+            local repo="$1"
+            curl -fsSL \
+              -H "Authorization: Bearer ${GH_TOKEN}" \
+              "https://ghcr.io/token?scope=repository:${repo}:pull&service=ghcr.io" \
+              | jq -r '.token'
+          }
+
+          # Resolve the manifest digest for a tag (works for multi-arch image
+          # indexes; we only need the digest identity, not its contents).
+          manifest_digest() {
+            local token="$1" repo="$2" ref="$3"
+            curl -fsSL -o /dev/null -D - \
+              -H "Authorization: Bearer ${token}" \
+              -H "Accept: application/vnd.oci.image.index.v1+json" \
+              -H "Accept: application/vnd.docker.distribution.manifest.list.v2+json" \
+              -H "Accept: application/vnd.oci.image.manifest.v1+json" \
+              -H "Accept: application/vnd.docker.distribution.manifest.v2+json" \
+              "https://ghcr.io/v2/${repo}/manifests/${ref}" \
+              | tr -d '\r' \
+              | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}'
+          }
+
+          for agent in claude codex; do
+            pkg="$(npm_pkg_for "${agent}")"
+            repo="${OWNER}/aileron-sandbox-${agent}"
+
+            # npm-latest. Fail the step if it cannot be resolved: a watcher that
+            # silently can't see upstream must not pass green.
+            npm_latest="$(npm view "${pkg}" version 2>/dev/null || true)"
+            if [ -z "${npm_latest}" ]; then
+              echo "::error::Could not resolve npm-latest version for ${pkg} (agent ${agent})." >&2
+              exit 1
+            fi
+
+            token="$(ghcr_token "${repo}" || true)"
+            if [ -z "${token}" ] || [ "${token}" = "null" ]; then
+              echo "::error::Could not mint a GHCR pull token for ${repo} (agent ${agent})." >&2
+              exit 1
+            fi
+
+            edge_digest="$(manifest_digest "${token}" "${repo}" "edge" || true)"
+            if [ -z "${edge_digest}" ]; then
+              echo "::error::Could not resolve the 'edge' manifest digest for ${repo} (agent ${agent}). Has sandbox-agents.yml ever published 'edge'?" >&2
+              exit 1
+            fi
+
+            # Enumerate tags; find the dev-<semver> tag co-located on the edge
+            # digest. That semver is the baked CLI version.
+            tags="$(curl -fsSL \
+              -H "Authorization: Bearer ${token}" \
+              "https://ghcr.io/v2/${repo}/tags/list" \
+              | jq -r '.tags[]' || true)"
+            if [ -z "${tags}" ]; then
+              echo "::error::Could not enumerate tags for ${repo} (agent ${agent})." >&2
+              exit 1
+            fi
+
+            baked=""
+            while IFS= read -r tag; do
+              case "${tag}" in
+                dev-*) ;;
+                *) continue ;;
+              esac
+              d="$(manifest_digest "${token}" "${repo}" "${tag}" || true)"
+              if [ "${d}" = "${edge_digest}" ]; then
+                candidate="${tag#dev-}"
+                # Accept only a clean semver as the baked version.
+                if printf '%s' "${candidate}" | grep -qE '^[0-9]+\.[0-9]+\.[0-9]+$'; then
+                  baked="${candidate}"
+                  break
+                fi
+              fi
+            done <<< "${tags}"
+
+            if [ -z "${baked}" ]; then
+              echo "::error::Could not parse the baked CLI version for ${repo} (agent ${agent}): no dev-<semver> tag found on the edge digest ${edge_digest}." >&2
+              exit 1
+            fi
+
+            if [ "${npm_latest}" != "${baked}" ]; then
+              any_stale=true
+              if [ "${DRY_RUN}" = "true" ]; then
+                echo "- \`${agent}\`: npm \`${npm_latest}\` vs baked \`${baked}\` → would dispatch (dry-run)" >> "$GITHUB_STEP_SUMMARY"
+              else
+                echo "- \`${agent}\`: npm \`${npm_latest}\` vs baked \`${baked}\` → stale, will dispatch rebuild" >> "$GITHUB_STEP_SUMMARY"
+              fi
+            else
+              echo "- \`${agent}\`: npm \`${npm_latest}\` vs baked \`${baked}\` → in sync, skipped" >> "$GITHUB_STEP_SUMMARY"
+            fi
+          done
+
+          echo >> "$GITHUB_STEP_SUMMARY"
+
+          # Conditional dispatch: any agent stale AND not a dry run.
+          if [ "${any_stale}" != "true" ]; then
+            echo "All agents in sync; no rebuild dispatched." >> "$GITHUB_STEP_SUMMARY"
+            echo "All agents in sync; no rebuild dispatched."
+            exit 0
+          fi
+
+          if [ "${DRY_RUN}" = "true" ]; then
+            echo "Drift detected, but dry-run requested: rebuild NOT dispatched." >> "$GITHUB_STEP_SUMMARY"
+            echo "Drift detected, but dry-run requested: rebuild NOT dispatched."
+            exit 0
+          fi
+
+          # Dispatch the whole sandbox-agents.yml (no inputs). Rebuilding the
+          # non-stale agent is a harmless no-op edge republish.
+          gh workflow run sandbox-agents.yml --ref "${GITHUB_REF_NAME}"
+          echo "Drift detected: dispatched sandbox-agents.yml to refresh edge images." >> "$GITHUB_STEP_SUMMARY"
+          echo "Drift detected: dispatched sandbox-agents.yml to refresh edge images."

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -38,7 +38,7 @@ With no `.devcontainer` in the project, `aileron launch --sandbox=docker <agent>
 
 `sandbox check --agent=<agent>` resolves the same image, so a passing check matches what launch will run.
 
-The launcher resolves a floating tag for this build-free default: a release build pulls `latest` (which the image workflows move only on a `v*` tag), and a dev build off `main` pulls `edge` (published on `workflow_dispatch`). So `latest` always names the most recent release and a dev run never clobbers it. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so the floating tag is the correct in-process pin. Digest pinning and the freshness policy that consumes it are owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088); the resolver is the seam where that pinned reference plugs in.
+The launcher resolves a floating tag for this build-free default: a release build pulls `latest` (which the image workflows move only on a `v*` tag), and a dev build off `main` pulls `edge` (published on `workflow_dispatch`). So `latest` always names the most recent release and a dev run never clobbers it. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so the floating tag is the correct in-process pin. The freshness policy that keeps `edge` current is owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088). Digest pinning is owned by [#1233](https://github.com/ALRubinger/aileron/issues/1233); the resolver is the seam where that pinned reference plugs in.
 
 When the requested agent has no published image, launch falls back to the customization tier. The image validation then emits the actionable message to install the agent CLI in the sandbox image or launch with `--sandbox=off`.
 
@@ -70,7 +70,13 @@ Pull a pinned version, for example Aileron `0.0.1` with the Claude CLI at `2.1.1
 docker pull ghcr.io/alrubinger/aileron-sandbox-claude:0.0.1-2.1.179
 ```
 
-CI smoke-tests every published image for launchability before it ships. The smoke asserts the agent CLI resolves on `PATH` and that the launcher's image validation succeeds. Republishing an image when a new agent CLI version releases is tracked by [#1088](https://github.com/ALRubinger/aileron/issues/1088).
+CI smoke-tests every published image for launchability before it ships. The smoke asserts the agent CLI resolves on `PATH` and that the launcher's image validation succeeds.
+
+A daily watcher workflow (`sandbox-agents-watch.yml`) keeps the `edge` images fresh against upstream agent-CLI releases. It polls npm for the latest `@anthropic-ai/claude-code` and `@openai/codex` versions. It compares each against the CLI version baked into the `edge` image, recovered from the `dev-<cli-version>` tag co-located on the `edge` manifest digest. On drift it re-triggers `sandbox-agents.yml`, which rebuilds from the unpinned Feature install scripts and so bakes the latest CLI. The refreshed build publishes `edge` and `dev-<cli-version>`. Dev and main consumers pull `edge`, so they pick up new agent CLIs automatically without a release.
+
+`latest` and the release-pinned `<aileron-version>-<agent-cli-version>` tags move on `v*` releases only, by design. A released user on `latest` stays pinned to that release's CLI version until the next release. This is intentional. A release is an immutable point and `latest` names the most-recent release, so a background job must never clobber it. Keeping `latest` fresh between releases is an accepted gap, not a bug.
+
+The watcher supports a `dry_run` `workflow_dispatch` input for demonstration, which detects and reports drift without dispatching a rebuild. It uses only `GITHUB_TOKEN` and bakes no credentials anywhere. Digest pinning of the resolved image is tracked separately by [#1233](https://github.com/ALRubinger/aileron/issues/1233).
 
 ## Claude Code Feature
 


### PR DESCRIPTION
## Summary

Adds `.github/workflows/sandbox-agents-watch.yml`, a daily scheduled watcher that keeps the published per-agent sandbox `edge` images fresh against upstream agent-CLI npm releases.

For each agent (`claude`, `codex`) it:
- resolves npm-latest via `npm view <pkg> version`,
- recovers the CLI version baked into the `edge` image by resolving the `edge` manifest digest on GHCR and finding the `dev-<semver>` sibling tag co-located on that same digest,
- compares the two and, if **any** agent drifts, dispatches the existing `sandbox-agents.yml` (no inputs) to rebuild. The unpinned Feature install scripts (`npm install -g <pkg>` with no version) mean the rebuild bakes the latest CLI with no source edit.

Design decisions (per the #1088 plan):
- **`sandbox-agents.yml` is untouched.** A single `gh workflow run` rebuilds both agents; rebuilding the non-stale agent is a harmless no-op `edge` republish.
- **Freshness target is `edge` only.** `latest` and the release-pinned `<aileron-version>-<agent-cli-version>` tags move on `v*` releases by design; the watcher never clobbers them. This accepted gap is documented as intentional.
- **Minimal permissions:** `packages: read` + `actions: write`. No `contents: write`, no `packages: write`. Uses only `GITHUB_TOKEN`, bakes no credentials.
- **Cadence:** daily `cron: "0 7 * * *"` (off-peak UTC) plus a `dry_run` `workflow_dispatch` input (default `true`) for demonstration.
- **Digest pinning stays out of scope** (owned by #1233); no Go/launcher/composition changes.

Also updates `docs/src/content/docs/development/sandbox-agent-images.md` to document the cadence, the mechanism, and the intentional `latest` tag policy, and re-points the digest-pinning reference to #1233.

## Test plan

- `actionlint .github/workflows/sandbox-agents-watch.yml` — clean.
- Ran the watcher's drift-detection logic locally against live GHCR + npm (bash, the runner's interpreter). It correctly resolved npm-latest and the baked `edge` version for both agents and reported `claude` in sync, `codex` stale (`npm 0.141.0 vs baked 0.140.0`) — matching real registry state. This validates the digest-correlation and semver-parsing paths end to end, not just YAML validity.
- `task lint:docs` (astro check) — 0 errors, 0 warnings.
- Confirmed no em-dashes introduced in the docs additions.
- Reviewed with CodeRabbit; the one minor finding (missing `|| true` on the token call so the helpful validation error can print under `set -e`) was applied.

No new automated CI gate is added (per plan): local `actionlint` + the local drift-logic dry-run is the merge bar. After merge, a `workflow_dispatch` `dry_run=true` run can confirm the live summary surface.

Closes #1088
