### PR TITLE
test(launch): make docker call-count assertions platform-independent

### DIFF
--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -16,22 +16,30 @@ import (
 
 // dropAuxiliaryDockerCalls removes the launcher's out-of-band runtime calls
 // so the surrounding contract assertions count only the build/validate/run
-// sequence. Two kinds are dropped:
+// sequence. Three kinds are dropped:
 //
 //   - the baked-MCP image-label detection calls
 //     (`docker image inspect --format '{{ ... ai.aileron.mcp.version }}'`) the
 //     launcher issues to choose between the host-mount and baked paths (#957);
 //     validateSandbox and launchSandbox each issue one.
-//   - the Linux-only no-op-gitconfig chown helper call
-//     (`docker run --entrypoint chown ... -R <uid> /mnt`) that the
-//     always-mount gitconfig path delegates to a short-lived root container so
-//     the non-root agent can read the host-owned bind-mounted dir (#1204).
-//     It fires only on linux and only when the image resolves a non-root agent
-//     UID, so without dropping it call-count assertions are platform-dependent.
+//   - the Linux-only agent-UID resolution inspect
+//     (`docker image inspect --format '{{.Config.User}}'`) the no-op-gitconfig
+//     chown hook issues to decide whether the host-owned bind-mounted dir
+//     needs chowning to the image's non-root agent UID (#1204, agent_uid.go).
+//   - the Linux-only chown helper call itself
+//     (`docker run --entrypoint chown ... -R <uid> /mnt`), delegated to a
+//     short-lived root container when that UID is non-root.
+//
+// The latter two fire only on linux (the hook returns early on other GOOS),
+// so without dropping them call-count assertions are platform-dependent —
+// the cause of the #1204 CI-only regression in TestLaunch_SandboxScaffold*.
 func dropAuxiliaryDockerCalls(calls []string) []string {
 	out := make([]string, 0, len(calls))
 	for _, c := range calls {
 		if strings.Contains(c, sandboxcontainer.MCPVersionLabel) {
+			continue
+		}
+		if strings.Contains(c, "{{.Config.User}}") {
 			continue
 		}
 		if strings.Contains(c, "--entrypoint\nchown") {
@@ -50,12 +58,13 @@ func dropAuxiliaryDockerCalls(calls []string) []string {
 // linux that broke TestLaunch_SandboxScaffoldBuildsAndRuns' "exactly two
 // calls" assertion (the call is a no-op on darwin, so it only failed in CI).
 func TestDropAuxiliaryDockerCalls(t *testing.T) {
-	inspectCall := "image\ninspect\n--format\n{{ index .Config.Labels \"" + sandboxcontainer.MCPVersionLabel + "\" }}\nimg:test"
+	mcpInspect := "image\ninspect\n--format\n{{ index .Config.Labels \"" + sandboxcontainer.MCPVersionLabel + "\" }}\nimg:test"
+	uidInspect := "image\ninspect\n--format\n{{.Config.User}}\nimg:test"
 	chownCall := "run\n--rm\n--user\n0\n--entrypoint\nchown\n--volume\n/host/transient:/mnt\nimg:test\n-R\n1000\n/mnt"
 	validateCall := "run\n--rm\nimg:test\n/bin/sh\n-c\nprobe"
 	runCall := "run\n--rm\n-it\nimg:test"
 
-	got := dropAuxiliaryDockerCalls([]string{inspectCall, validateCall, chownCall, runCall})
+	got := dropAuxiliaryDockerCalls([]string{mcpInspect, validateCall, uidInspect, chownCall, runCall})
 	want := []string{validateCall, runCall}
 	if len(got) != len(want) {
 		t.Fatalf("dropAuxiliaryDockerCalls kept %d calls, want %d:\n%v", len(got), len(want), got)

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -14,20 +14,57 @@ import (
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 )
 
-// dropBakedInspectCalls removes the baked-MCP image-label detection calls
-// (`docker image inspect --format '{{ ... ai.aileron.mcp.version }}'`) the
-// launcher issues to choose between the host-mount and baked paths (#957).
-// validateSandbox and launchSandbox each issue one; the surrounding contract
-// assertions care only about the build/validate/run calls.
-func dropBakedInspectCalls(calls []string) []string {
+// dropAuxiliaryDockerCalls removes the launcher's out-of-band runtime calls
+// so the surrounding contract assertions count only the build/validate/run
+// sequence. Two kinds are dropped:
+//
+//   - the baked-MCP image-label detection calls
+//     (`docker image inspect --format '{{ ... ai.aileron.mcp.version }}'`) the
+//     launcher issues to choose between the host-mount and baked paths (#957);
+//     validateSandbox and launchSandbox each issue one.
+//   - the Linux-only no-op-gitconfig chown helper call
+//     (`docker run --entrypoint chown ... -R <uid> /mnt`) that the
+//     always-mount gitconfig path delegates to a short-lived root container so
+//     the non-root agent can read the host-owned bind-mounted dir (#1204).
+//     It fires only on linux and only when the image resolves a non-root agent
+//     UID, so without dropping it call-count assertions are platform-dependent.
+func dropAuxiliaryDockerCalls(calls []string) []string {
 	out := make([]string, 0, len(calls))
 	for _, c := range calls {
 		if strings.Contains(c, sandboxcontainer.MCPVersionLabel) {
 			continue
 		}
+		if strings.Contains(c, "--entrypoint\nchown") {
+			continue
+		}
 		out = append(out, c)
 	}
 	return out
+}
+
+// TestDropAuxiliaryDockerCalls pins the filter that makes call-count
+// assertions platform-independent: the launcher's out-of-band image-inspect
+// and (linux-only) no-op-gitconfig chown helper calls must be dropped while
+// the build/validate/run sequence is preserved. Regression for #1204: the
+// always-mount gitconfig path added a `docker run --entrypoint chown` call on
+// linux that broke TestLaunch_SandboxScaffoldBuildsAndRuns' "exactly two
+// calls" assertion (the call is a no-op on darwin, so it only failed in CI).
+func TestDropAuxiliaryDockerCalls(t *testing.T) {
+	inspectCall := "image\ninspect\n--format\n{{ index .Config.Labels \"" + sandboxcontainer.MCPVersionLabel + "\" }}\nimg:test"
+	chownCall := "run\n--rm\n--user\n0\n--entrypoint\nchown\n--volume\n/host/transient:/mnt\nimg:test\n-R\n1000\n/mnt"
+	validateCall := "run\n--rm\nimg:test\n/bin/sh\n-c\nprobe"
+	runCall := "run\n--rm\n-it\nimg:test"
+
+	got := dropAuxiliaryDockerCalls([]string{inspectCall, validateCall, chownCall, runCall})
+	want := []string{validateCall, runCall}
+	if len(got) != len(want) {
+		t.Fatalf("dropAuxiliaryDockerCalls kept %d calls, want %d:\n%v", len(got), len(want), got)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Fatalf("call %d = %q, want %q", i, got[i], want[i])
+		}
+	}
 }
 
 func TestResolveBinary_Found(t *testing.T) {
@@ -713,7 +750,7 @@ func TestLaunch_SandboxDiscoverySmokeMountsShimsForValidateAndRun(t *testing.T) 
 	if err != nil {
 		t.Fatalf("read docker args: %v", err)
 	}
-	calls := dropBakedInspectCalls(strings.Split(strings.TrimPrefix(string(data), "---\n"), "\n---\n"))
+	calls := dropAuxiliaryDockerCalls(strings.Split(strings.TrimPrefix(string(data), "---\n"), "\n---\n"))
 	if len(calls) != 2 {
 		t.Fatalf("docker calls = %d, want validate and run:\n%s", len(calls), data)
 	}
@@ -813,7 +850,7 @@ func TestLaunch_SandboxConnectorSpecPresentEmitsNoShim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read docker args: %v", err)
 	}
-	calls := dropBakedInspectCalls(strings.Split(strings.TrimPrefix(string(data), "---\n"), "\n---\n"))
+	calls := dropAuxiliaryDockerCalls(strings.Split(strings.TrimPrefix(string(data), "---\n"), "\n---\n"))
 	if len(calls) != 2 {
 		t.Fatalf("docker calls = %d, want validate and run:\n%s", len(calls), data)
 	}
@@ -902,7 +939,7 @@ func TestLaunch_SandboxScaffoldBuildsAndRuns(t *testing.T) {
 	if err != nil {
 		t.Fatalf("read docker args: %v", err)
 	}
-	calls := dropBakedInspectCalls(strings.Split(strings.TrimPrefix(string(data), "---\n"), "\n---\n"))
+	calls := dropAuxiliaryDockerCalls(strings.Split(strings.TrimPrefix(string(data), "---\n"), "\n---\n"))
 	if len(calls) != 2 {
 		t.Fatalf("docker calls = %d, want validate and run (build runs via @devcontainers/cli):\n%s", len(calls), data)
 	}


### PR DESCRIPTION
## Summary

Fixes the post-merge `main` CI failure introduced by PR #1234 (always-mount no-op gitconfig, #1204).

`TestLaunch_SandboxScaffoldBuildsAndRuns` failed on `Unit Tests (rest)` with `docker calls = 3, want validate and run`. Root cause:

- #1234 made the secret-free no-op gitconfig mount on **every** launch path, including the no-vault scaffold path.
- Its transient host dir is registered with the chown hook, which **on linux** delegates `chown -R <agent-uid> /mnt` to a short-lived root container (`docker run --entrypoint chown ...`) so the non-root agent can read the host-owned bind-mounted dir. This is the intended EPERM remedy #1204 shipped.
- That hook is a **no-op on darwin** (`agent_uid.go:82`), so the test passed locally but added a third docker call on linux CI.
- #1234 updated its skip-path *mount* tests but missed this scaffold *call-count* assertion.

The fix is test-only: generalize `dropBakedInspectCalls` → `dropAuxiliaryDockerCalls` so call-count assertions drop both the baked-MCP image-inspect calls and the linux-only chown helper call. Production behavior is correct and unchanged; the test encoded a stale 2-call expectation. Positive assertions on the chown call remain in `agent_uid_test.go`, untouched.

## Test plan

- `go test ./internal/launch/` passes (darwin).
- New `TestDropAuxiliaryDockerCalls` is a platform-independent regression test: it feeds a synthetic chown call (`--entrypoint chown`) plus inspect/validate/run calls and asserts only validate+run survive — so it fails if the filter regresses regardless of OS.
- `TestLaunch_SandboxScaffoldBuildsAndRuns`, `...DiscoverySmokeMountsShimsForValidateAndRun`, `...ConnectorSpecPresentEmitsNoShim` all pass.

Relates to #1204

🤖 Generated with [Claude Code](https://claude.com/claude-code)
