### PR TITLE
chore(git): enforce worktree-only commits via committed pre-commit hook

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,36 @@
+#!/bin/sh
+# Refuse commits in the PRIMARY working tree — all work must happen in a git
+# worktree, so the primary checkout's default branch only ever fast-forwards from
+# origin (never gets a local-only commit that diverges on the next pull).
+#
+# Activate after clone with:  task setup     (sets core.hooksPath=.githooks)
+#
+# Linked worktrees have a git-dir under .../worktrees/<name>; the primary does not.
+# This hook is shared across every worktree of the repo; we allow the linked ones
+# and block only the primary checkout.
+#
+# Deliberate one-off (rare, e.g. a README edit on the default branch):
+#   ALLOW_PRIMARY_COMMIT=1 git commit ...
+
+case "$(git rev-parse --absolute-git-dir)" in
+  */worktrees/*) exit 0 ;;   # linked worktree → allowed
+esac
+
+[ -n "$ALLOW_PRIMARY_COMMIT" ] && exit 0
+
+branch="$(git symbolic-ref --quiet --short HEAD 2>/dev/null || echo DETACHED)"
+cat >&2 <<EOF
+✗ Refusing to commit in the primary checkout (branch: $branch).
+
+  All work must happen in a git worktree so the default branch only
+  fast-forwards from origin. A direct commit here is what makes 'git pull'
+  report divergent branches.
+
+  Do this instead:
+    git worktree add ../<name> -b <branch>     # or use EnterWorktree
+    cd ../<name> && <make changes> && git commit ...
+
+  Deliberate one-off (rare, e.g. a README edit):
+    ALLOW_PRIMARY_COMMIT=1 git commit ...
+EOF
+exit 1

--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -12,9 +12,13 @@
 # Deliberate one-off (rare, e.g. a README edit on the default branch):
 #   ALLOW_PRIMARY_COMMIT=1 git commit ...
 
-case "$(git rev-parse --absolute-git-dir)" in
-  */worktrees/*) exit 0 ;;   # linked worktree → allowed
-esac
+# A linked worktree's git-dir differs from the common git-dir; the primary
+# checkout's two are identical. Comparing them is path-name agnostic — a repo
+# that happens to live under a directory named "worktrees" won't fool it.
+gitdir="$(git rev-parse --absolute-git-dir)"
+commondir="$(git rev-parse --git-common-dir)"
+case "$commondir" in /*) ;; *) commondir="$(CDPATH= cd -- "$commondir" && pwd)" ;; esac
+[ "$gitdir" != "$commondir" ] && exit 0   # linked worktree → allowed
 
 [ -n "$ALLOW_PRIMARY_COMMIT" ] && exit 0
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,3 +1,23 @@
+# Worktree Discipline (enforced)
+
+All work happens in a **git worktree**, never in the primary checkout. Branch in a
+worktree → PR → squash-merge; the primary checkout only ever `git fetch` /
+`git pull --ff-only`. A direct commit on the primary checkout's default branch is
+what makes a later `git pull` report divergent branches, so it is **blocked**.
+
+Enforcement is a committed `pre-commit` hook (`.githooks/pre-commit`) that refuses
+commits made in the primary checkout (commits in linked worktrees are allowed).
+Activate it once per clone:
+
+```sh
+task setup    # sets core.hooksPath=.githooks
+```
+
+This is not advisory — it is the mechanism that keeps the default branch a clean
+fast-forward mirror of origin. Start work with `git worktree add` (or the
+`EnterWorktree` tool). A rare, deliberate primary-checkout commit can bypass with
+`ALLOW_PRIMARY_COMMIT=1 git commit ...`.
+
 # OpenAPI Spec is the Source of Truth
 
 The OpenAPI specification at `internal/api/openapi.yaml` is the authoritative definition of the Aileron API. All API changes — new endpoints, schema modifications, parameter changes — **must** be made in the spec first. The Go server interface and types are generated from it:

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -12,6 +12,15 @@ tasks:
     cmds:
       - task --list
 
+  setup:
+    desc: One-time local setup after clone (activates committed git hooks)
+    cmds:
+      # Point git at the committed hooks so they survive re-clone and are shared
+      # across all worktrees. The pre-commit hook refuses commits in the primary
+      # checkout, keeping the default branch a pure fast-forward mirror of origin.
+      - git config core.hooksPath .githooks
+      - 'echo "git hooks activated (core.hooksPath=.githooks)"'
+
   generate:
     desc: Run all code generators
     cmds:


### PR DESCRIPTION
## Problem

The primary checkout's `main` keeps diverging from `origin/main` (recurring "divergent branches" on `git pull`). Root cause, from `git reflog main`: agents running `git commit` **directly on the primary checkout's `main`** instead of in a worktree. That local-only commit diverges once the same work squash-merges as a PR (the "un-squashed twin"). The worktree-isolated agent flows aren't the offenders — interactive sessions / flows that skip a worktree are.

## Fix — make it structurally impossible, durably

A committed `pre-commit` hook that **refuses commits in the primary checkout**, allowing them only in linked worktrees. `main` can then only ever fast-forward from origin.

- **`.githooks/pre-commit`** — blocks a commit when the git-dir is *not* under `.../worktrees/` (the primary checkout); linked worktrees pass, so every worktree-isolated flow is unaffected. Escape hatch: `ALLOW_PRIMARY_COMMIT=1 git commit ...`.
- **`task setup`** — activates it via `git config core.hooksPath .githooks` (committed hooks survive re-clone and are shared across all worktrees; git can't auto-enable hooks, so this one-time activation is the standard pattern).
- **CLAUDE.md → "Worktree Discipline (enforced)"** — documents the rule and `task setup` for both agents and humans.

Committed (not just a local `.git/hooks/` file) precisely so it's **portable** — it travels with the repo instead of living in one machine's config.

## Test plan

- `sh -n .githooks/pre-commit` — syntax clean.
- Verified behavior on the equivalent local hook: commit on primary `main` → refused (nothing lands); commit in a linked worktree (`.git/worktrees/*`) → allowed; `ALLOW_PRIMARY_COMMIT=1` → bypass works. This very PR was committed from a worktree.
- Tooling/docs only — no Go/source change.

Note: `task setup` must be run once per existing clone to activate (new contributors too). Does not retroactively change history.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Added comprehensive development workflow guidelines specifying git worktree usage for feature development and branch commits.

* **Chores**
  * Implemented enforcement blocking direct commits on the primary checkout; worktrees and fast-forward merges are now required.
  * Added one-time setup task to activate the enforcement mechanism locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->