### PR TITLE
refactor(proxybinding): drop project-layer binding descriptor

### DIFF
--- a/docs/src/content/docs/guides/binding-descriptors.md
+++ b/docs/src/content/docs/guides/binding-descriptors.md
@@ -1,6 +1,6 @@
 ---
 title: "Binding Descriptors"
-description: "A binding descriptor is a small YAML file that seals an arbitrary CLI's credential at the network boundary without writing any per-CLI code. This page covers the descriptor schema, the three-layer loading order, and a worked Linear example."
+description: "A binding descriptor is a small YAML file that seals an arbitrary CLI's credential at the network boundary without writing any per-CLI code. This page covers the descriptor schema, the two-layer loading order, and a worked Linear example."
 ---
 
 A command-line tool that talks to a third-party API needs a credential. The usual answer is to hand that credential to the tool, which means the credential lives wherever the tool runs. Aileron's credential-sealing substrate takes a different path. The credential stays in your vault, the agent in the sandbox never holds it, and the daemon injects it at the TLS forward-proxy boundary on the way out. See [ADR-0019](/adr/0019-v4-https-data-plane/) for the data-plane design this builds on.
@@ -37,15 +37,14 @@ Scheme-specific fields:
 
 Decoding is strict. An unknown YAML key is an error, not a silently ignored field, so a typo fails fast instead of shipping a binding that does nothing. A wrong or missing `version` is an error so the format can evolve without a silent misparse.
 
-## Three-layer loading
+## Two-layer loading
 
-Descriptors load from three layers, in increasing precedence.
+Descriptors load from two layers, in increasing precedence.
 
 1. **Built-in defaults.** Community profiles Aileron ships, embedded at build time. The Linear descriptor above is one.
-2. **Project layer.** `.aileron/binding-descriptors.yaml` relative to the working directory. For the running daemon this resolves against the daemon's working directory, not the directory a `launch` invocation was issued from: the binding table is loaded once at daemon construction and is daemon-global. Per-launch resolution against the launch repo root is deliberately deferred future work.
-3. **User layer.** `~/.aileron/binding-descriptors.yaml`.
+2. **User layer.** `~/.aileron/binding-descriptors.yaml`.
 
-A later layer overrides an earlier one per `host` key. A user descriptor can replace a shipped community profile for the same host without editing the shipped file. A new host in any layer is added on top of the others rather than replacing them. An absent project or user file is not an error. It simply contributes nothing.
+A later layer overrides an earlier one per `host` key. A user descriptor can replace a shipped community profile for the same host without editing the shipped file. A new host in any layer is added on top of the others rather than replacing them. An absent user file is not an error. It simply contributes nothing.
 
 One invalid layer fails the whole load with a clear error. A malformed descriptor never degrades to a partial or empty binding table, because a typo that silently disables sealing would be a fail-open we reject.
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -449,8 +449,8 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	//      daemon-side, kept as Go code because their schemes differ per
 	//      host and one needs sentinel-swap (#1196).
 	//   2. The declarative binding descriptors (#1197), loaded through the
-	//      generic three-layer loader (built-in profiles -> project ->
-	//      user). This is the "config, not code" path: a third-party CLI
+	//      generic two-layer loader (built-in profiles -> user). This is
+	//      the "config, not code" path: a third-party CLI
 	//      (e.g. Linear, api.linear.app via header-template) is sealed by
 	//      shipping a descriptor, with zero per-CLI proxy code.
 	//
@@ -465,7 +465,7 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 		// surface it rather than silently dropping the seal.
 		return nil, fmt.Errorf("seed github host bindings: %w", err)
 	}
-	descriptorBindings, err := proxybinding.LoadHostBindings(proxybinding.DefaultLoadOptions(""))
+	descriptorBindings, err := proxybinding.LoadHostBindings(proxybinding.DefaultLoadOptions())
 	if err != nil {
 		// A malformed descriptor must fail loudly, not degrade to an empty
 		// (passthrough) table: a typo that silently disables sealing is a

--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -73,7 +73,7 @@ var EmitMechanisms = map[string]struct{}{
 // Descriptor is a parsed, versioned binding-descriptor document. One
 // document carries a version and an ordered list of per-host entries.
 // A CLI vendor or community profile ships a Descriptor; the loader merges
-// the built-in, project, and user layers into a single validated set.
+// the built-in and user layers into a single validated set.
 type Descriptor struct {
 	// Version is the schema version. It must equal [SchemaVersion]; any
 	// other value is rejected at parse time so the format can evolve under

--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -24,7 +24,7 @@
 //
 // # Scope
 //
-// This package defines the descriptor format and the three-layer loader.
+// This package defines the descriptor format and the two-layer loader.
 // It does not implement the binding-table consult (#1193), the injectors
 // (#1194), or the sentinel-swap mechanism (#1196, mechanism B); it only
 // validates the emit_mechanism field against the implemented set. Because

--- a/internal/proxybinding/embed.go
+++ b/internal/proxybinding/embed.go
@@ -3,8 +3,8 @@ package proxybinding
 import "embed"
 
 // builtinDefaults holds the descriptors Aileron ships as the built-in
-// layer of the three-layer config convention (built-in -> project ->
-// user). Each file under defaults/ is a community profile that seals a
+// layer of the two-layer config convention (built-in -> user). Each file
+// under defaults/ is a community profile that seals a
 // third-party CLI by descriptor alone. linear.yaml is the proving
 // example; adding another vendor is a new file here, never new proxy code.
 //

--- a/internal/proxybinding/loader.go
+++ b/internal/proxybinding/loader.go
@@ -8,41 +8,34 @@ import (
 	"sort"
 )
 
-// LoadOptions selects the project and user descriptor layers that override
-// the built-in defaults. Both paths are optional: an empty path or an
-// absent file contributes no entries, so an operator who ships nothing
-// gets exactly the built-in profiles.
+// LoadOptions selects the user descriptor layer that overrides the
+// built-in defaults. UserPath is optional: an empty path or an absent file
+// contributes no entries, so an operator who ships nothing gets exactly the
+// built-in profiles.
 type LoadOptions struct {
-	// ProjectPath is a descriptor file relative to (or rooted at) the
-	// working project, the middle layer. It overrides built-in entries for
-	// the same host and is itself overridden by the user layer. Empty or
-	// absent contributes nothing.
-	ProjectPath string
-
 	// UserPath is the per-user descriptor file (e.g. under ~/.aileron),
-	// the highest-precedence layer. It overrides both built-in and project
-	// entries for the same host. Empty or absent contributes nothing.
+	// the highest-precedence layer. It overrides built-in entries for the
+	// same host. Empty or absent contributes nothing.
 	UserPath string
 }
 
-// Load merges the three configuration layers (built-in defaults, then
-// project, then user) into a single validated, ordered set of entries
-// keyed on host. This mirrors the three-layer policy/config convention
-// used elsewhere in the codebase: later layers override earlier ones per
-// host key, so a user descriptor can replace a shipped community profile
-// for the same host without editing it.
+// Load merges the two configuration layers (built-in defaults, then user)
+// into a single validated, ordered set of entries keyed on host. This
+// mirrors the layered policy/config convention used elsewhere in the
+// codebase: the later layer overrides the earlier one per host key, so a
+// user descriptor can replace a shipped community profile for the same host
+// without editing it.
 //
-// Precedence is strictly built-in < project < user. Within the merged
-// result, entries are ordered deterministically by host so the binding
-// table is reproducible across loads.
+// Precedence is strictly built-in < user. Within the merged result, entries
+// are ordered deterministically by host so the binding table is
+// reproducible across loads.
 //
 // Every layer is parsed strictly (unknown keys, wrong version, malformed
 // YAML, and invalid entries are errors). An invalid layer fails the whole
 // load with a clear error and never silently drops entries: a typo in a
 // descriptor must not degrade to a partial, surprising binding set. A
-// missing project or user file is not an error (an absent layer is an
-// empty layer); only a present-but-unreadable or present-but-invalid file
-// fails.
+// missing user file is not an error (an absent layer is an empty layer);
+// only a present-but-unreadable or present-but-invalid file fails.
 func Load(opts LoadOptions) ([]Entry, error) {
 	merged := make(map[string]Entry)
 
@@ -51,14 +44,6 @@ func Load(opts LoadOptions) ([]Entry, error) {
 		return nil, fmt.Errorf("proxybinding: load built-in defaults: %w", err)
 	}
 	applyLayer(merged, builtin)
-
-	if opts.ProjectPath != "" {
-		project, err := parseLayerFile(opts.ProjectPath)
-		if err != nil {
-			return nil, fmt.Errorf("proxybinding: load project layer %q: %w", opts.ProjectPath, err)
-		}
-		applyLayer(merged, project)
-	}
 
 	if opts.UserPath != "" {
 		user, err := parseLayerFile(opts.UserPath)

--- a/internal/proxybinding/loader_test.go
+++ b/internal/proxybinding/loader_test.go
@@ -69,49 +69,35 @@ func TestLoad_UserOverridesBuiltin(t *testing.T) {
 	}
 }
 
-// Precedence is built-in < project < user. The project layer overrides the
-// built-in for a host, and the user layer overrides the project.
+// Precedence is built-in < user. The user layer overrides the built-in for
+// a host.
 func TestLoad_PrecedenceOrder(t *testing.T) {
 	dir := t.TempDir()
-	projectPath := writeDescriptor(t, dir, "project.yaml",
-		"version: v1\nbindings:\n  - host: api.linear.app\n    credential_ref: user/from-project\n    scheme: bearer\n")
 	userPath := writeDescriptor(t, dir, "user.yaml",
 		"version: v1\nbindings:\n  - host: api.linear.app\n    credential_ref: user/from-user\n    scheme: bearer\n")
 
-	// Project overrides built-in (no user layer).
-	entries, err := Load(LoadOptions{ProjectPath: projectPath})
+	entries, err := Load(LoadOptions{UserPath: userPath})
 	if err != nil {
-		t.Fatalf("Load (project only): %v", err)
+		t.Fatalf("Load (user): %v", err)
 	}
 	e, _ := findEntry(entries, "api.linear.app")
-	if e.CredentialRef != "user/from-project" {
-		t.Errorf("project-only credential_ref = %q, want user/from-project", e.CredentialRef)
-	}
-
-	// User overrides project.
-	entries, err = Load(LoadOptions{ProjectPath: projectPath, UserPath: userPath})
-	if err != nil {
-		t.Fatalf("Load (project+user): %v", err)
-	}
-	e, _ = findEntry(entries, "api.linear.app")
 	if e.CredentialRef != "user/from-user" {
-		t.Errorf("project+user credential_ref = %q, want user/from-user (user wins)", e.CredentialRef)
+		t.Errorf("user credential_ref = %q, want user/from-user (user wins)", e.CredentialRef)
 	}
 }
 
-// Absent project/user files are not errors: an absent layer is an empty
-// layer, leaving the built-in floor intact.
+// An absent user file is not an error: an absent layer is an empty layer,
+// leaving the built-in floor intact.
 func TestLoad_AbsentLayersNoError(t *testing.T) {
 	dir := t.TempDir()
 	entries, err := Load(LoadOptions{
-		ProjectPath: filepath.Join(dir, "does-not-exist-project.yaml"),
-		UserPath:    filepath.Join(dir, "does-not-exist-user.yaml"),
+		UserPath: filepath.Join(dir, "does-not-exist-user.yaml"),
 	})
 	if err != nil {
-		t.Fatalf("Load with absent layers: %v", err)
+		t.Fatalf("Load with absent layer: %v", err)
 	}
 	if _, ok := findEntry(entries, "api.linear.app"); !ok {
-		t.Error("absent override layers should leave built-in Linear entry")
+		t.Error("absent override layer should leave built-in Linear entry")
 	}
 }
 
@@ -128,21 +114,6 @@ func TestLoad_InvalidLayerFails(t *testing.T) {
 	}
 	if !strings.Contains(err.Error(), "user layer") {
 		t.Errorf("error %q should name the offending layer", err.Error())
-	}
-}
-
-// An invalid project layer fails the load and names the project layer.
-func TestLoad_InvalidProjectLayerFails(t *testing.T) {
-	dir := t.TempDir()
-	bad := writeDescriptor(t, dir, "bad-project.yaml",
-		"version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: not-a-scheme\n")
-
-	_, err := Load(LoadOptions{ProjectPath: bad})
-	if err == nil {
-		t.Fatal("Load with invalid project layer = nil error, want error")
-	}
-	if !strings.Contains(err.Error(), "project layer") {
-		t.Errorf("error %q should name the project layer", err.Error())
 	}
 }
 

--- a/internal/proxybinding/paths.go
+++ b/internal/proxybinding/paths.go
@@ -7,7 +7,7 @@ import (
 
 // DefaultUserPath returns the per-user descriptor file path,
 // `~/.aileron/binding-descriptors.yaml`, the highest-precedence layer of
-// the three-layer config convention. When the home directory cannot be
+// the two-layer config convention. When the home directory cannot be
 // resolved it falls back to a relative path under `.aileron`, matching the
 // rest of the config package's home-dir handling. The file need not exist;
 // an absent user layer contributes no entries.
@@ -19,26 +19,11 @@ func DefaultUserPath() string {
 	return filepath.Join(home, ".aileron", "binding-descriptors.yaml")
 }
 
-// DefaultProjectPath returns the project-layer descriptor file path,
-// `.aileron/binding-descriptors.yaml` relative to the given working
-// directory (the middle layer). An empty workdir roots it at the current
-// directory. The file need not exist.
-//
-// For the running daemon this resolves against the daemon's working
-// directory, not the directory a `launch` invocation was issued from: the
-// binding table is loaded once at daemon construction and is daemon-global.
-// Per-launch resolution against the launch repo root is deferred future
-// work.
-func DefaultProjectPath(workdir string) string {
-	return filepath.Join(workdir, ".aileron", "binding-descriptors.yaml")
-}
-
-// DefaultLoadOptions returns the standard project and user descriptor
-// layer paths for daemon construction. The built-in defaults layer is
-// always embedded; these two paths select the optional override layers.
-func DefaultLoadOptions(workdir string) LoadOptions {
+// DefaultLoadOptions returns the standard user descriptor layer path for
+// daemon construction. The built-in defaults layer is always embedded; the
+// user path selects the optional override layer.
+func DefaultLoadOptions() LoadOptions {
 	return LoadOptions{
-		ProjectPath: DefaultProjectPath(workdir),
-		UserPath:    DefaultUserPath(),
+		UserPath: DefaultUserPath(),
 	}
 }

--- a/internal/proxybinding/paths_test.go
+++ b/internal/proxybinding/paths_test.go
@@ -12,24 +12,16 @@ func TestDefaultPaths(t *testing.T) {
 		t.Errorf("DefaultUserPath = %q, want .../.aileron/binding-descriptors.yaml", user)
 	}
 
-	project := DefaultProjectPath("/work/proj")
-	if project != filepath.Join("/work/proj", ".aileron", "binding-descriptors.yaml") {
-		t.Errorf("DefaultProjectPath = %q", project)
-	}
-
-	opts := DefaultLoadOptions("/work/proj")
-	if opts.ProjectPath != project {
-		t.Errorf("DefaultLoadOptions.ProjectPath = %q, want %q", opts.ProjectPath, project)
-	}
-	if opts.UserPath == "" {
-		t.Error("DefaultLoadOptions.UserPath is empty")
+	opts := DefaultLoadOptions()
+	if opts.UserPath != user {
+		t.Errorf("DefaultLoadOptions.UserPath = %q, want %q", opts.UserPath, user)
 	}
 }
 
-// DefaultLoadOptions paths must load cleanly against the embedded defaults
-// even when the override files do not exist (the common daemon case).
+// DefaultLoadOptions must load cleanly against the embedded defaults even
+// when the user override file does not exist (the common daemon case).
 func TestDefaultLoadOptions_LoadsBuiltinWhenLayersAbsent(t *testing.T) {
-	opts := DefaultLoadOptions(t.TempDir())
+	opts := DefaultLoadOptions()
 	entries, err := Load(opts)
 	if err != nil {
 		t.Fatalf("Load(DefaultLoadOptions): %v", err)


### PR DESCRIPTION
## Summary

Collapses the binding-descriptor loader from three layers to two: built-in defaults `<` user. The project layer is removed.

The project layer resolved `.aileron/binding-descriptors.yaml` against the running daemon's working directory, not the launch repo root, so it never delivered the per-project behavior its name implied (the binding table is daemon-global, loaded once at construction). Its only counter-case, a private internal host mapped to an org/community built-in with no named user, is served by the built-in defaults layer. The triage in #1242 resolved that case and noted there is no migration concern because this is a pre-release internal API with no public guarantee.

### Changes
- `internal/proxybinding/paths.go`: remove `DefaultProjectPath`; `DefaultLoadOptions` now takes no `workdir` arg and sets only `UserPath`.
- `internal/proxybinding/loader.go`: remove `LoadOptions.ProjectPath` and its load/`applyLayer` block; rewrite the `Load`/`LoadOptions` doc comments to describe two layers.
- `internal/app/app.go`: update the sole non-test call site to no-arg `DefaultLoadOptions()`; update the adjacent explanatory comment.
- `internal/proxybinding/descriptor.go`, `embed.go`: update "three-layer" comments to "two-layer".
- `docs/src/content/docs/guides/binding-descriptors.md`: rewrite the loading section and the page description to two-layer, dropping the project-layer bullet and the daemon-CWD caveat.
- Tests: `paths_test.go` and `loader_test.go` updated; project-layer cases converted to user-layer override coverage. The two-layer precedence and absent-layer regression cases are retained.

#1202 (which extended the project layer) is superseded by this removal; no separate action is needed there.

## Test plan
- `go build ./...` (internal + cmd/aileron): clean.
- `go vet ./proxybinding/... ./app/...`: clean.
- `go test ./proxybinding/... ./app/...`: pass.
- `go test ./proxybinding/... -cover`: 94.2% of statements.

Closes #1242

🤖 Generated with [Claude Code](https://claude.com/claude-code)
