### PR TITLE
feat(sandbox): add Aileron-managed cache volumes keyed by (CLI, identity)

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -210,7 +210,7 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron sync [--bind-all] [--yes]  Reconcile installed actions: install missing connectors; report unbound capabilities")
 	fmt.Fprintln(w, "  aileron audit [list|show]          View the action-execution audit log (ADR-0010)")
 	fmt.Fprintln(w, "  aileron sessions [list|get]        View `aileron launch` session records (ADR-0012)")
-	fmt.Fprintln(w, "  aileron sandbox [init|plan|build|check]  Scaffold, inspect, build, or validate sandbox images")
+	fmt.Fprintln(w, "  aileron sandbox [init|plan|build|check|cache]  Scaffold, inspect, build, validate, or GC sandbox images")
 	fmt.Fprintln(w, "  aileron daemon start|stop|status   Manage the local Aileron daemon (auto-spawned on demand)")
 	fmt.Fprintln(w, "  aileron stop                       Alias for 'aileron daemon stop'")
 	fmt.Fprintln(w, "  aileron open [approvals|approval <id>]  Open the Aileron webapp (default: root) in your browser")

--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"context"
 	"errors"
 	"flag"
@@ -18,7 +19,7 @@ import (
 
 func runSandbox(args []string, registry *launch.Registry, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check>")
+		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check|cache>")
 		return 1
 	}
 	switch args[0] {
@@ -30,11 +31,105 @@ func runSandbox(args []string, registry *launch.Registry, stdout, stderr io.Writ
 		return runSandboxBuild(args[1:], stdout, stderr)
 	case "check":
 		return runSandboxCheck(args[1:], stdout, stderr)
+	case "cache":
+		return runSandboxCache(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown sandbox command: %q\n", args[0])
-		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check>")
+		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check|cache>")
 		return 1
 	}
+}
+
+// runSandboxCache dispatches the manual cache-volume management subcommands.
+// Operators evict Aileron-managed sandbox caches by hand (no max-age policy),
+// so the only verb today is `clear`.
+func runSandboxCache(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, "usage: aileron sandbox cache <clear>")
+		return 1
+	}
+	switch args[0] {
+	case "clear":
+		return runSandboxCacheClear(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown sandbox cache command: %q\n", args[0])
+		fmt.Fprintln(stderr, "usage: aileron sandbox cache <clear>")
+		return 1
+	}
+}
+
+// runSandboxCacheClear removes every Aileron-managed sandbox cache volume
+// (those whose name carries the CacheVolumePrefix). This is the manual
+// garbage-collection path the operator chose over an automatic max-age policy.
+// It is safe to run between launches; Docker recreates a volume on the next
+// mount that needs it.
+func runSandboxCacheClear(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("sandbox cache clear", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	runtimeName := flags.String("runtime", sandboxcontainer.DefaultRuntime, "Container runtime: auto or docker")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: aileron sandbox cache clear [--runtime=auto|docker]")
+		return 1
+	}
+	runtime, err := sandboxcontainer.ResolveRuntime(*runtimeName)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	names, err := sandboxCacheListFn(context.Background(), runtime)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if len(names) == 0 {
+		fmt.Fprintln(stdout, "no Aileron-managed sandbox cache volumes to remove")
+		return 0
+	}
+	if err := sandboxCacheRemoveFn(context.Background(), runtime, names); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	for _, name := range names {
+		fmt.Fprintf(stdout, "removed %s\n", name)
+	}
+	fmt.Fprintf(stdout, "removed %d cache volume(s)\n", len(names))
+	return 0
+}
+
+// sandboxCacheListFn lists the Aileron-managed sandbox cache volumes for the
+// given runtime, filtered by CacheVolumePrefix. Swappable in tests.
+var sandboxCacheListFn = func(ctx context.Context, runtime string) ([]string, error) {
+	var out bytes.Buffer
+	err := sandboxcontainer.DefaultRunner().Run(ctx, runtime,
+		[]string{"volume", "ls", "--quiet", "--filter", "name=" + sandboxcomposition.CacheVolumePrefix},
+		&out, io.Discard)
+	if err != nil {
+		return nil, fmt.Errorf("list sandbox cache volumes: %w", err)
+	}
+	var names []string
+	for _, line := range strings.Split(out.String(), "\n") {
+		name := strings.TrimSpace(line)
+		// Docker's name filter is a substring match; require the prefix so an
+		// unrelated volume that merely contains the prefix mid-name is not
+		// swept. Aileron names always start with the prefix.
+		if strings.HasPrefix(name, sandboxcomposition.CacheVolumePrefix) {
+			names = append(names, name)
+		}
+	}
+	return names, nil
+}
+
+// sandboxCacheRemoveFn removes the named sandbox cache volumes. Swappable in
+// tests.
+var sandboxCacheRemoveFn = func(ctx context.Context, runtime string, names []string) error {
+	args := append([]string{"volume", "rm"}, names...)
+	if err := sandboxcontainer.DefaultRunner().Run(ctx, runtime, args, io.Discard, io.Discard); err != nil {
+		return fmt.Errorf("remove sandbox cache volumes: %w", err)
+	}
+	return nil
 }
 
 func runSandboxInit(args []string, stdout, stderr io.Writer) int {

--- a/cmd/aileron/sandbox_cache_test.go
+++ b/cmd/aileron/sandbox_cache_test.go
@@ -1,0 +1,120 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+func swapCacheFns(t *testing.T, list func(context.Context, string) ([]string, error), remove func(context.Context, string, []string) error) {
+	t.Helper()
+	origList, origRemove := sandboxCacheListFn, sandboxCacheRemoveFn
+	t.Cleanup(func() {
+		sandboxCacheListFn = origList
+		sandboxCacheRemoveFn = origRemove
+	})
+	sandboxCacheListFn = list
+	sandboxCacheRemoveFn = remove
+}
+
+func TestRunSandboxCacheClearRemovesVolumes(t *testing.T) {
+	var removed []string
+	swapCacheFns(t,
+		func(context.Context, string) ([]string, error) {
+			return []string{"aileron-cache-npm-abc", "aileron-cache-pip-def"}, nil
+		},
+		func(_ context.Context, _ string, names []string) error {
+			removed = names
+			return nil
+		},
+	)
+	var out, errb bytes.Buffer
+	if code := runSandboxCacheClear([]string{"--runtime=docker"}, &out, &errb); code != 0 {
+		t.Fatalf("runSandboxCacheClear = %d, stderr: %s", code, errb.String())
+	}
+	if len(removed) != 2 {
+		t.Fatalf("removed = %v, want 2", removed)
+	}
+	got := out.String()
+	if !strings.Contains(got, "removed aileron-cache-npm-abc") || !strings.Contains(got, "removed 2 cache volume(s)") {
+		t.Fatalf("unexpected stdout: %q", got)
+	}
+}
+
+func TestRunSandboxCacheClearNoVolumes(t *testing.T) {
+	removeCalled := false
+	swapCacheFns(t,
+		func(context.Context, string) ([]string, error) { return nil, nil },
+		func(context.Context, string, []string) error { removeCalled = true; return nil },
+	)
+	var out, errb bytes.Buffer
+	if code := runSandboxCacheClear([]string{"--runtime=docker"}, &out, &errb); code != 0 {
+		t.Fatalf("runSandboxCacheClear = %d, stderr: %s", code, errb.String())
+	}
+	if removeCalled {
+		t.Fatal("remove must not run when there are no volumes")
+	}
+	if !strings.Contains(out.String(), "no Aileron-managed sandbox cache volumes") {
+		t.Fatalf("unexpected stdout: %q", out.String())
+	}
+}
+
+func TestRunSandboxCacheClearListError(t *testing.T) {
+	swapCacheFns(t,
+		func(context.Context, string) ([]string, error) { return nil, errors.New("boom") },
+		func(context.Context, string, []string) error { return nil },
+	)
+	var out, errb bytes.Buffer
+	if code := runSandboxCacheClear([]string{"--runtime=docker"}, &out, &errb); code != 1 {
+		t.Fatalf("runSandboxCacheClear = %d, want 1", code)
+	}
+	if !strings.Contains(errb.String(), "boom") {
+		t.Fatalf("stderr = %q", errb.String())
+	}
+}
+
+func TestRunSandboxCacheClearRemoveError(t *testing.T) {
+	swapCacheFns(t,
+		func(context.Context, string) ([]string, error) { return []string{"aileron-cache-npm-abc"}, nil },
+		func(context.Context, string, []string) error { return errors.New("rm failed") },
+	)
+	var out, errb bytes.Buffer
+	if code := runSandboxCacheClear([]string{"--runtime=docker"}, &out, &errb); code != 1 {
+		t.Fatalf("runSandboxCacheClear = %d, want 1", code)
+	}
+	if !strings.Contains(errb.String(), "rm failed") {
+		t.Fatalf("stderr = %q", errb.String())
+	}
+}
+
+func TestRunSandboxCacheRejectsExtraArgs(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runSandboxCacheClear([]string{"extra"}, &out, &errb); code != 1 {
+		t.Fatalf("runSandboxCacheClear = %d, want 1", code)
+	}
+	if !strings.Contains(errb.String(), "usage:") {
+		t.Fatalf("stderr = %q", errb.String())
+	}
+}
+
+func TestRunSandboxCacheUnknownSubcommand(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runSandboxCache([]string{"bogus"}, &out, &errb); code != 1 {
+		t.Fatalf("runSandboxCache = %d, want 1", code)
+	}
+	if !strings.Contains(errb.String(), "unknown sandbox cache command") {
+		t.Fatalf("stderr = %q", errb.String())
+	}
+}
+
+func TestRunSandboxCacheNoSubcommand(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runSandboxCache(nil, &out, &errb); code != 1 {
+		t.Fatalf("runSandboxCache = %d, want 1", code)
+	}
+	if !strings.Contains(errb.String(), "usage: aileron sandbox cache") {
+		t.Fatalf("stderr = %q", errb.String())
+	}
+}

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -191,6 +191,44 @@ Set `customizations.aileron.image` when your team owns the complete image:
 
 In BYO-image mode, launch uses the image as supplied and layers on Aileron's session env, manifest mounts, and the `aileron-mcp` tool surface. Images that participate in the v4 HTTPS proxy must include `aileron-install-proxy-ca` and `aileron-run-with-proxy-ca` helpers that meet the [BYO Image Proxy Contract](/development/sandbox-agent-images/#byo-image-proxy-contract). `aileron sandbox check --agent=...` validates both contracts for every Docker run.
 
+## Cache Volumes
+
+Tools the agent runs inside the sandbox (package managers, language toolchains) build up caches that are expensive to rebuild on every launch. Declare an Aileron-managed cache under `customizations.aileron.cache_paths` to persist one across launches in a named Docker volume:
+
+```jsonc
+{
+  "customizations": {
+    "aileron": {
+      "cache_paths": [
+        // Each entry is keyed by (cli, identity). The same key reuses the same
+        // volume across launches; a different identity keys a fresh store.
+        { "cli": "npm", "identity": "acme-workspace", "container_path": "/home/agent/.npm" },
+        { "cli": "pip", "identity": "acme-workspace", "container_path": "/home/agent/.cache/pip" }
+      ]
+    }
+  }
+}
+```
+
+Each entry has three fields:
+
+| Field | Meaning |
+|---|---|
+| `cli` | The tool the cache belongs to. Required. It is part of the volume key and is sanitized into the volume name for legibility. |
+| `identity` | The credential or workspace identity the cache is scoped to. Re-authenticating to a different identity keys a different volume, so caches never leak across identities. It is hashed into the volume name and never written to the host in plaintext. |
+| `container_path` | The absolute in-container mount point for the cache. Required. |
+
+On launch, Aileron mounts each declared cache as a read-write Docker named volume named `aileron-cache-<cli>-<hash-of-identity>`. Docker creates the volume on first mount and reuses it on every launch with the same key. The volume holds plaintext on the host, which is acceptable for v4 single-user/local mode; it is not an encrypted or sealed mount.
+
+Eviction is manual. There is no max-age or auto-expiry policy. Remove every Aileron-managed cache volume with:
+
+```bash
+aileron sandbox cache clear
+aileron sandbox cache clear --runtime=docker
+```
+
+`cache clear` removes only volumes carrying the `aileron-cache-` prefix and is safe to run between launches; Docker recreates a volume on the next launch that mounts it.
+
 ## What Belongs in the Image
 
 Put ordinary project tooling in the devcontainer: language runtimes, CLIs, package managers, private CA bundles, and internal helper tools.

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -86,6 +86,10 @@ type SandboxLaunchPlan struct {
 	Image   string
 	Tier    sandboxcomposition.Tier
 	Built   bool
+	// CachePaths carries the Aileron-managed cache-volume declarations from the
+	// project's customizations.aileron block. launchSandbox turns each entry
+	// into a deterministically named Docker volume mounted at ContainerPath.
+	CachePaths []sandboxcomposition.CachePath
 }
 
 // ResolveBinary searches PATH for the first matching binary name from
@@ -221,19 +225,21 @@ func prepareSandbox(ctx context.Context, workDir, agent, runtimeName, buildPolic
 			return SandboxLaunchPlan{}, runtimeErr
 		}
 		return SandboxLaunchPlan{
-			Runtime: runtime,
-			Image:   result.Image,
-			Tier:    result.Tier,
+			Runtime:    runtime,
+			Image:      result.Image,
+			Tier:       result.Tier,
+			CachePaths: plan.Aileron.CachePaths,
 		}, nil
 	}
 	if err != nil {
 		return SandboxLaunchPlan{}, err
 	}
 	return SandboxLaunchPlan{
-		Runtime: result.Runtime,
-		Image:   result.Image,
-		Tier:    result.Tier,
-		Built:   result.Built,
+		Runtime:    result.Runtime,
+		Image:      result.Image,
+		Tier:       result.Tier,
+		Built:      result.Built,
+		CachePaths: plan.Aileron.CachePaths,
 	}, nil
 }
 
@@ -819,6 +825,16 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 	}
 	mounts = append(mounts, extraMounts...)
 
+	// Aileron-managed cache volumes: each declared (CLI, identity) cache becomes
+	// a deterministically named Docker volume mounted read-write at its
+	// container path. Docker auto-creates the volume on first mount and persists
+	// it across launches; re-auth to a different identity keys a fresh volume.
+	cacheMounts, err := sandboxCacheVolumes(plan.CachePaths)
+	if err != nil {
+		return LaunchResult{}, err
+	}
+	mounts = append(mounts, cacheMounts...)
+
 	// Unbaked image: resolve aileron-mcp on the host and bind-mount it
 	// read-only at the container's well-known MCP binary path. Matches the
 	// resolution shape host launch uses (ADR-0024). Sandbox-flavored lookup
@@ -1063,6 +1079,38 @@ func sandboxRuntimeMounts() ([]sandboxcontainer.Volume, error) {
 			continue
 		}
 		mounts = append(mounts, candidate)
+	}
+	return mounts, nil
+}
+
+// sandboxCacheVolumes maps each declared cache path to a Docker named-volume
+// mount. The volume name is derived deterministically from (CLI, identity) so a
+// tool's cache survives across launches while a different identity keys a fresh
+// store. ContainerPath must be an absolute in-container path; a CLI is required
+// because it is part of the volume key. The volumes are mounted read-write
+// (caches are writable by definition).
+func sandboxCacheVolumes(paths []sandboxcomposition.CachePath) ([]sandboxcontainer.Volume, error) {
+	if len(paths) == 0 {
+		return nil, nil
+	}
+	mounts := make([]sandboxcontainer.Volume, 0, len(paths))
+	for _, p := range paths {
+		cli := strings.TrimSpace(p.CLI)
+		if cli == "" {
+			return nil, fmt.Errorf("sandbox cache path requires a cli")
+		}
+		containerPath := strings.TrimSpace(p.ContainerPath)
+		if containerPath == "" {
+			return nil, fmt.Errorf("sandbox cache path for cli %q requires a container_path", cli)
+		}
+		if !path.IsAbs(containerPath) {
+			return nil, fmt.Errorf("sandbox cache container_path %q for cli %q must be absolute", containerPath, cli)
+		}
+		mounts = append(mounts, sandboxcontainer.Volume{
+			Source: sandboxcomposition.CacheVolumeName(cli, p.Identity),
+			Target: containerPath,
+			Named:  true,
+		})
 	}
 	return mounts, nil
 }

--- a/internal/launch/sandbox_cache_test.go
+++ b/internal/launch/sandbox_cache_test.go
@@ -1,0 +1,86 @@
+package launch
+
+import (
+	"testing"
+
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
+)
+
+func TestSandboxCacheVolumesEmpty(t *testing.T) {
+	mounts, err := sandboxCacheVolumes(nil)
+	if err != nil {
+		t.Fatalf("sandboxCacheVolumes(nil): %v", err)
+	}
+	if len(mounts) != 0 {
+		t.Fatalf("mounts = %+v, want none", mounts)
+	}
+}
+
+func TestSandboxCacheVolumesMapsDeclarations(t *testing.T) {
+	paths := []sandboxcomposition.CachePath{
+		{CLI: "npm", Identity: "ws-A", ContainerPath: "/home/agent/.npm"},
+		{CLI: "pip", Identity: "ws-A", ContainerPath: "/home/agent/.cache/pip"},
+	}
+	mounts, err := sandboxCacheVolumes(paths)
+	if err != nil {
+		t.Fatalf("sandboxCacheVolumes: %v", err)
+	}
+	if len(mounts) != 2 {
+		t.Fatalf("mounts = %+v, want 2", mounts)
+	}
+	for i, m := range mounts {
+		if !m.Named {
+			t.Fatalf("mount %d is not Named: %+v", i, m)
+		}
+		if m.ReadOnly {
+			t.Fatalf("cache mount %d must be read-write: %+v", i, m)
+		}
+	}
+	wantFirst := sandboxcomposition.CacheVolumeName("npm", "ws-A")
+	if mounts[0].Source != wantFirst {
+		t.Fatalf("mounts[0].Source = %q, want %q", mounts[0].Source, wantFirst)
+	}
+	if mounts[0].Target != "/home/agent/.npm" {
+		t.Fatalf("mounts[0].Target = %q", mounts[0].Target)
+	}
+}
+
+func TestSandboxCacheVolumesRequiresCLI(t *testing.T) {
+	_, err := sandboxCacheVolumes([]sandboxcomposition.CachePath{
+		{Identity: "ws", ContainerPath: "/cache"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing cli")
+	}
+}
+
+func TestSandboxCacheVolumesRequiresContainerPath(t *testing.T) {
+	_, err := sandboxCacheVolumes([]sandboxcomposition.CachePath{
+		{CLI: "npm", Identity: "ws"},
+	})
+	if err == nil {
+		t.Fatal("expected error for missing container_path")
+	}
+}
+
+func TestSandboxCacheVolumesRejectsRelativeContainerPath(t *testing.T) {
+	_, err := sandboxCacheVolumes([]sandboxcomposition.CachePath{
+		{CLI: "npm", Identity: "ws", ContainerPath: "relative/cache"},
+	})
+	if err == nil {
+		t.Fatal("expected error for relative container_path")
+	}
+}
+
+func TestSandboxCacheVolumesEmptyIdentityAllowed(t *testing.T) {
+	// Identity is optional; an empty identity is a valid (deterministic) key.
+	mounts, err := sandboxCacheVolumes([]sandboxcomposition.CachePath{
+		{CLI: "npm", ContainerPath: "/cache"},
+	})
+	if err != nil {
+		t.Fatalf("sandboxCacheVolumes: %v", err)
+	}
+	if len(mounts) != 1 || mounts[0].Source != sandboxcomposition.CacheVolumeName("npm", "") {
+		t.Fatalf("mounts = %+v", mounts)
+	}
+}

--- a/internal/sandbox/composition/cache.go
+++ b/internal/sandbox/composition/cache.go
@@ -1,0 +1,52 @@
+package composition
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strings"
+)
+
+// CacheVolumePrefix is the common name prefix for every Aileron-managed sandbox
+// cache volume. The manual GC command (`aileron sandbox cache clear`) keys off
+// this prefix to find the volumes it may remove, so no Aileron-owned cache
+// volume may exist without it.
+const CacheVolumePrefix = "aileron-cache"
+
+// CacheVolumeName derives the deterministic Docker named-volume name for a cache
+// keyed by (cli, identity). The CLI is sanitized into the name for human
+// legibility; the identity is hashed (never carried verbatim) so re-auth to a
+// different workspace/identity yields a distinct volume and caches never leak
+// across identities.
+//
+// Shape: aileron-cache-<sanitized-cli>-<sha12(identity)>. The same (cli,
+// identity) pair always maps to the same name, which is what lets a tool's cache
+// survive across launches; a different identity maps to a different name, which
+// is what scopes the cache to that identity.
+func CacheVolumeName(cli, identity string) string {
+	sum := sha256.Sum256([]byte(identity))
+	digest := hex.EncodeToString(sum[:])[:12]
+	return CacheVolumePrefix + "-" + sanitizeVolumeSegment(cli) + "-" + digest
+}
+
+// sanitizeVolumeSegment reduces an arbitrary CLI label to the character set
+// Docker accepts in a volume name ([a-zA-Z0-9][a-zA-Z0-9_.-]*). Any other rune
+// becomes '-'; an empty result collapses to "cli" so the assembled name is
+// always a valid, non-empty volume name. The identity is not run through this
+// helper because it is hashed, not embedded.
+func sanitizeVolumeSegment(s string) string {
+	s = strings.ToLower(strings.TrimSpace(s))
+	var b strings.Builder
+	for _, r := range s {
+		switch {
+		case r >= 'a' && r <= 'z', r >= '0' && r <= '9', r == '_', r == '.', r == '-':
+			b.WriteRune(r)
+		default:
+			b.WriteRune('-')
+		}
+	}
+	out := strings.Trim(b.String(), "-")
+	if out == "" {
+		return "cli"
+	}
+	return out
+}

--- a/internal/sandbox/composition/cache_test.go
+++ b/internal/sandbox/composition/cache_test.go
@@ -1,0 +1,75 @@
+package composition
+
+import (
+	"strings"
+	"testing"
+)
+
+func TestCacheVolumeNameDeterministic(t *testing.T) {
+	a := CacheVolumeName("npm", "workspace-A")
+	b := CacheVolumeName("npm", "workspace-A")
+	if a != b {
+		t.Fatalf("same (cli, identity) yielded different names: %q vs %q", a, b)
+	}
+}
+
+func TestCacheVolumeNameDiffersByIdentity(t *testing.T) {
+	a := CacheVolumeName("npm", "workspace-A")
+	b := CacheVolumeName("npm", "workspace-B")
+	if a == b {
+		t.Fatalf("different identities collided to %q", a)
+	}
+}
+
+func TestCacheVolumeNameDiffersByCLI(t *testing.T) {
+	a := CacheVolumeName("npm", "id")
+	b := CacheVolumeName("pip", "id")
+	if a == b {
+		t.Fatalf("different CLIs collided to %q", a)
+	}
+}
+
+func TestCacheVolumeNameCarriesPrefixAndCLI(t *testing.T) {
+	name := CacheVolumeName("npm", "id")
+	if !strings.HasPrefix(name, CacheVolumePrefix+"-") {
+		t.Fatalf("name %q missing prefix %q", name, CacheVolumePrefix)
+	}
+	if !strings.Contains(name, "-npm-") {
+		t.Fatalf("name %q does not embed sanitized cli", name)
+	}
+}
+
+func TestCacheVolumeNameDoesNotLeakIdentity(t *testing.T) {
+	identity := "alice@example.com/secret-workspace"
+	name := CacheVolumeName("npm", identity)
+	if strings.Contains(name, "alice") || strings.Contains(name, "secret") || strings.Contains(name, "@") {
+		t.Fatalf("identity leaked into volume name %q", name)
+	}
+}
+
+func TestCacheVolumeNameSanitizesCLI(t *testing.T) {
+	// An arbitrary CLI label must reduce to Docker's accepted character set.
+	name := CacheVolumeName("My Weird/CLI!", "id")
+	// Everything after the prefix and before the 12-hex digest must be a valid
+	// volume-name segment: [a-z0-9_.-].
+	if strings.ContainsAny(name, " /!@") {
+		t.Fatalf("name %q contains characters Docker rejects in a volume name", name)
+	}
+}
+
+func TestCacheVolumeNameEmptyCLICollapses(t *testing.T) {
+	name := CacheVolumeName("   ", "id")
+	// An empty/whitespace CLI must still produce a valid, non-empty name.
+	if !strings.HasPrefix(name, CacheVolumePrefix+"-cli-") {
+		t.Fatalf("empty cli did not collapse to a valid name: %q", name)
+	}
+}
+
+func TestCacheVolumeNameDigestLength(t *testing.T) {
+	name := CacheVolumeName("npm", "id")
+	parts := strings.Split(name, "-")
+	digest := parts[len(parts)-1]
+	if len(digest) != 12 {
+		t.Fatalf("digest %q is %d chars, want 12", digest, len(digest))
+	}
+}

--- a/internal/sandbox/composition/composition.go
+++ b/internal/sandbox/composition/composition.go
@@ -89,6 +89,28 @@ type AileronCustomization struct {
 	Image           string `json:"image,omitempty"`
 	Mediation       string `json:"mediation,omitempty"`
 	ApprovalSurface string `json:"approval_surface,omitempty"`
+	// CachePaths declares Aileron-managed named-volume caches mounted into the
+	// sandbox. Each entry is keyed by (CLI, identity) so a tool's cache survives
+	// across launches but re-auth to a different workspace/identity yields a
+	// fresh store. The volume holds plaintext on the host (acceptable for v4
+	// single-user/local mode) and is created on first mount; manual eviction is
+	// via `aileron sandbox cache clear`. See docs/development/sandbox-composition.md.
+	CachePaths []CachePath `json:"cache_paths,omitempty"`
+}
+
+// CachePath declares one Aileron-managed cache volume mounted into the sandbox.
+type CachePath struct {
+	// CLI names the tool the cache belongs to (e.g. "npm", "pip"). It is part
+	// of the volume key and is sanitized into the deterministic volume name.
+	CLI string `json:"cli,omitempty"`
+	// Identity scopes the cache to a credential/workspace identity. Re-auth to a
+	// different identity yields a different volume, so caches never leak across
+	// identities. It is hashed into the volume name and never appears in plaintext
+	// on the host.
+	Identity string `json:"identity,omitempty"`
+	// ContainerPath is the absolute in-container mount point for the cache (e.g.
+	// "/home/agent/.npm").
+	ContainerPath string `json:"container_path,omitempty"`
 }
 
 type devcontainerConfig struct {

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -165,6 +165,50 @@ func TestDiscoverDevcontainerBuildPlan(t *testing.T) {
 	}
 }
 
+func TestDiscoverParsesCachePaths(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainer(t, dir, `{
+  "customizations": {
+    "aileron": {
+      "cache_paths": [
+        {"cli": "npm", "identity": "workspace-A", "container_path": "/home/agent/.npm"},
+        {"cli": "pip", "identity": "workspace-A", "container_path": "/home/agent/.cache/pip"}
+      ]
+    }
+  }
+}`)
+
+	plan, err := Discover(dir, "dev", "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(plan.Aileron.CachePaths) != 2 {
+		t.Fatalf("CachePaths = %+v, want 2 entries", plan.Aileron.CachePaths)
+	}
+	first := plan.Aileron.CachePaths[0]
+	if first.CLI != "npm" || first.Identity != "workspace-A" || first.ContainerPath != "/home/agent/.npm" {
+		t.Fatalf("first CachePath = %+v", first)
+	}
+	second := plan.Aileron.CachePaths[1]
+	if second.CLI != "pip" || second.ContainerPath != "/home/agent/.cache/pip" {
+		t.Fatalf("second CachePath = %+v", second)
+	}
+}
+
+func TestDiscoverNoCachePathsWhenAbsent(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainer(t, dir, `{
+  "customizations": {"aileron": {"approval_surface": "tui"}}
+}`)
+	plan, err := Discover(dir, "dev", "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(plan.Aileron.CachePaths) != 0 {
+		t.Fatalf("CachePaths = %+v, want none", plan.Aileron.CachePaths)
+	}
+}
+
 func TestDiscoverDevcontainerRootDockerfileAndImage(t *testing.T) {
 	dir := t.TempDir()
 	writeDevcontainer(t, dir, `{

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -177,11 +177,19 @@ type RunOptions struct {
 	Name string
 }
 
-// Volume describes an additional host bind mount for a sandbox container.
+// Volume describes an additional mount for a sandbox container. By default
+// Source is a host path bind-mounted at Target. When Named is set, Source is a
+// Docker named volume instead: it is emitted verbatim as <name>:<target>
+// (no host-path resolution), and Docker auto-creates the volume on first mount.
 type Volume struct {
 	Source   string
 	Target   string
 	ReadOnly bool
+	// Named marks Source as a Docker named volume rather than a host path. The
+	// runtime emits the mount without resolving Source to an absolute path
+	// (filepath.Abs would mangle a volume name), letting Docker create and reuse
+	// a persistent managed volume. Used for Aileron-managed sandbox caches.
+	Named bool
 }
 
 // RunResult reports the selected runtime after a sandbox container exits.
@@ -720,9 +728,16 @@ func runArgs(runtimeName string, opts RunOptions) ([]string, error) {
 		if strings.TrimSpace(volume.Source) == "" || strings.TrimSpace(volume.Target) == "" {
 			return nil, fmt.Errorf("sandbox volume source and target are required")
 		}
-		source, err := filepath.Abs(volume.Source)
-		if err != nil {
-			return nil, fmt.Errorf("resolve sandbox volume source: %w", err)
+		source := volume.Source
+		if !volume.Named {
+			// Host bind mount: resolve to an absolute path. A named volume must
+			// be emitted verbatim — filepath.Abs would mangle the volume name
+			// into a host path under the working directory.
+			abs, err := filepath.Abs(volume.Source)
+			if err != nil {
+				return nil, fmt.Errorf("resolve sandbox volume source: %w", err)
+			}
+			source = abs
 		}
 		spec := source + ":" + volume.Target
 		if volume.ReadOnly {

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -1013,6 +1013,69 @@ func TestRunMountsAdditionalReadWriteVolumes(t *testing.T) {
 	}
 }
 
+func TestRunMountsNamedVolumeVerbatim(t *testing.T) {
+	dir := t.TempDir()
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:   "aileron-sandbox-base:test",
+		WorkDir: dir,
+		Volumes: []Volume{{
+			Source: "aileron-cache-npm-deadbeef0123",
+			Target: "/home/agent/.npm",
+			Named:  true,
+		}},
+		Command: []string{"codex"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// A named volume must be emitted verbatim as <name>:<target>; filepath.Abs
+	// must NOT run on it (that would mangle the volume name into a host path).
+	wantSpec := "aileron-cache-npm-deadbeef0123:/home/agent/.npm"
+	found := false
+	for i := 0; i < len(runner.args)-1; i++ {
+		if runner.args[i] == "--volume" && runner.args[i+1] == wantSpec {
+			found = true
+		}
+		// Guard against the named volume being absolutized: no arg may contain
+		// the workdir-joined form of the volume name.
+		if strings.Contains(runner.args[i+1], filepath.Join(dir, "aileron-cache-npm-deadbeef0123")) {
+			t.Fatalf("named volume was absolutized: %q", runner.args[i+1])
+		}
+	}
+	if !found {
+		t.Fatalf("named volume spec %q missing from args: %#v", wantSpec, runner.args)
+	}
+}
+
+func TestRunMountsNamedVolumeReadOnly(t *testing.T) {
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image: "aileron-sandbox-base:test",
+		Volumes: []Volume{{
+			Source:   "aileron-cache-pip-abc123",
+			Target:   "/cache",
+			Named:    true,
+			ReadOnly: true,
+		}},
+		Command: []string{"codex"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	wantSpec := "aileron-cache-pip-abc123:/cache:ro"
+	found := false
+	for i := 0; i < len(runner.args)-1; i++ {
+		if runner.args[i] == "--volume" && runner.args[i+1] == wantSpec {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("read-only named volume spec %q missing from args: %#v", wantSpec, runner.args)
+	}
+}
+
 func TestRunRejectsIncompleteAdditionalVolume(t *testing.T) {
 	_, err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Run(context.Background(), RunOptions{
 		Image:   "aileron-sandbox-base:test",


### PR DESCRIPTION
## Summary

Adds a narrow, standalone Aileron-managed cache-volume mechanism for `aileron launch --sandbox`, resolving feedback #1190. A project declares per-`(CLI, identity)` caches under `customizations.aileron.cache_paths`; each becomes a deterministically named Docker named volume mounted into the sandbox so tool caches (package managers, language toolchains) survive across launches. Re-authenticating to a different workspace/identity keys a fresh volume, so caches never leak across identities.

Per the operator's cleared design answers on #1190:
- (a) standalone named volume, decoupled from any binding descriptor (the #1181 host→credential binding descriptor was dropped on `main` in f5280c9, so this routes cleanly to a standalone cache).
- (b) plaintext-on-host, acceptable for v4 single-user/local mode — no encrypted/sealed mount.
- (c) keyed by `(CLI, credential/workspace identity)`, manual GC only, `postStart` incremental sync deferred.

### What changed
- **composition**: parse `cache_paths` (`{cli, identity, container_path}`) into `AileronCustomization`. `CacheVolumeName(cli, identity)` derives `aileron-cache-<sanitized-cli>-<sha12(identity)>` — the identity is hashed (never written to the host in plaintext) and the CLI is sanitized into a valid Docker volume-name segment.
- **container**: add `Volume.Named`. When set, `runArgs` emits `<name>:<target>` verbatim and skips `filepath.Abs` (which would mangle a volume name into a host path). Docker auto-creates the named volume on first mount, so no explicit `docker volume create`.
- **launch**: map each declared cache path to a read-write named `Volume` appended to the sandbox mount set; thread `CachePaths` through `SandboxLaunchPlan`.
- **cmd**: `aileron sandbox cache clear [--runtime]` removes only `aileron-cache-*` volumes (manual eviction; no auto max-age policy).
- **docs**: new "Cache Volumes" section in the sandbox-composition guide.

### Out of scope (per operator)
`postStart` incremental sync; encrypted/sealed mount; any host→credential binding descriptor.

## Test plan
- `go test ./internal/sandbox/... ./internal/launch/ ./cmd/aileron/...` — all green.
- New unit tests:
  - `runArgs` named-volume emission (verbatim `<name>:<target>`, no `Abs`; read-only variant) and a guard that the name is never absolutized.
  - composition parse of `cache_paths`; absence yields no entries.
  - deterministic naming: same `(cli, identity)` ⇒ same name; different identity/CLI ⇒ different name; identity never leaks into the name; CLI sanitization; empty-CLI collapse; 12-char digest.
  - launcher mapping: required `cli`/`container_path`, rejected relative path, empty-identity allowed, read-write + Named.
  - `sandbox cache clear`: removes matched volumes, no-op when none, list/remove error paths, arg/subcommand validation.
- Coverage on changed packages: composition 93.4%, container 91.4%, cmd/aileron 85.2%; new functions at/near 100%.
- CodeRabbit review: 0 findings.

Closes #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `aileron sandbox cache clear` command to manually remove Aileron-managed cache volumes
  * Added support for persistent build caches through `customizations.aileron.cache_paths` configuration
  * Cache volumes are automatically created and reused as Docker named volumes across launches

* **Documentation**
  * Added Cache Volumes section explaining cache configuration and manual eviction

<!-- end of auto-generated comment: release notes by coderabbit.ai -->