### PR TITLE
fix(vault): open controlling terminal cross-platform for passphrase prompt

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -1181,7 +1181,7 @@ func defaultPromptPassphrase(prompt string, w io.Writer) (string, error) {
 	if w != nil && prompt != "" {
 		fmt.Fprint(w, prompt)
 	}
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	tty, err := openControllingTerminal()
 	if err != nil {
 		return "", fmt.Errorf("cannot open terminal: %w", err)
 	}

--- a/cmd/aileron/tty_test.go
+++ b/cmd/aileron/tty_test.go
@@ -1,0 +1,39 @@
+package main
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+)
+
+// TestOpenControllingTerminal asserts that the controlling-terminal opener
+// resolves the correct platform device. The regression this guards is
+// feedback #1250: on Windows the passphrase prompt hardcoded the POSIX
+// device /dev/tty, which does not exist, so first-run (runVaultInit ->
+// defaultPromptPassphrase) crashed with
+// "open /dev/tty: The system cannot find the path specified" — a
+// path-not-found (fs.ErrNotExist) error.
+//
+// On a host with a controlling terminal the opener succeeds and returns a
+// handle whose Fd() is usable by golang.org/x/term. In CI / non-interactive
+// contexts there may be no terminal, so the open can fail — but it must fail
+// because the device is unavailable, never because the path does not exist.
+// A fs.ErrNotExist here means we asked the OS for the wrong device name,
+// which is exactly the bug being fixed.
+func TestOpenControllingTerminal(t *testing.T) {
+	f, err := openControllingTerminal()
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("openControllingTerminal returned path-not-found %v; the platform terminal device name is wrong", err)
+		}
+		// No controlling terminal in this environment (e.g. CI). The
+		// device name was resolved correctly; the open just failed
+		// because no terminal is attached. That is acceptable.
+		t.Skipf("no controlling terminal available in this environment: %v", err)
+	}
+	defer f.Close()
+
+	if f.Fd() == 0 && f.Name() == "" {
+		t.Fatalf("openControllingTerminal returned an unusable handle")
+	}
+}

--- a/cmd/aileron/tty_test.go
+++ b/cmd/aileron/tty_test.go
@@ -1,8 +1,10 @@
 package main
 
 import (
+	"bytes"
 	"errors"
 	"io/fs"
+	"strings"
 	"testing"
 )
 
@@ -35,5 +37,25 @@ func TestOpenControllingTerminal(t *testing.T) {
 
 	if f.Fd() == 0 && f.Name() == "" {
 		t.Fatalf("openControllingTerminal returned an unusable handle")
+	}
+}
+
+// TestDefaultPromptPassphrase_NoTerminalFailsGracefully exercises the real
+// default prompt (not the injectable `promptPassphrase` seam) when no
+// controlling terminal is available. The contract is that it surfaces a
+// clear "cannot open terminal" error rather than hanging or panicking — the
+// same fallback a user hits running non-interactively. We guard against a
+// hang by only running when the terminal is genuinely absent; if a tty is
+// attached, term.ReadPassword would block, so we skip.
+func TestDefaultPromptPassphrase_NoTerminalFailsGracefully(t *testing.T) {
+	if f, err := openControllingTerminal(); err == nil {
+		f.Close()
+		t.Skip("controlling terminal present; skipping to avoid blocking on read")
+	}
+	var buf bytes.Buffer
+	if _, err := defaultPromptPassphrase("passphrase: ", &buf); err == nil {
+		t.Fatal("expected error when no controlling terminal is available")
+	} else if !strings.Contains(err.Error(), "cannot open terminal") {
+		t.Fatalf("err = %v, want 'cannot open terminal'", err)
 	}
 }

--- a/cmd/aileron/tty_unix.go
+++ b/cmd/aileron/tty_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package main
+
+import "os"
+
+// openControllingTerminal opens the controlling terminal for interactive
+// passphrase prompts. On POSIX systems this is /dev/tty, which refers to
+// the process's controlling terminal regardless of stdin/stdout redirection.
+//
+// The returned *os.File's Fd() is a valid terminal file descriptor for
+// golang.org/x/term.ReadPassword. The caller owns the file and must Close it.
+func openControllingTerminal() (*os.File, error) {
+	return os.OpenFile("/dev/tty", os.O_RDWR, 0)
+}

--- a/cmd/aileron/tty_windows.go
+++ b/cmd/aileron/tty_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package main
+
+import "os"
+
+// openControllingTerminal opens the controlling terminal for interactive
+// passphrase prompts. Windows has no /dev/tty; the documented equivalent is
+// the console device pair CONIN$ (input) and CONOUT$ (output), which refer
+// to the process's attached console regardless of stdin/stdout redirection.
+//
+// We open CONIN$ read/write so the returned handle can both read keystrokes
+// and have echo toggled. The returned *os.File's Fd() is a valid console
+// handle for golang.org/x/term.ReadPassword, which uses the Windows console
+// mode APIs (GetConsoleMode/SetConsoleMode) under the hood. The caller owns
+// the file and must Close it.
+func openControllingTerminal() (*os.File, error) {
+	return os.OpenFile("CONIN$", os.O_RDWR, 0)
+}

--- a/cmd/aileron/vault.go
+++ b/cmd/aileron/vault.go
@@ -553,7 +553,7 @@ const (
 // readVaultPassphrase resolves a passphrase from (in order):
 //  1. The supplied file path, if non-empty.
 //  2. The AILERON_VAULT_PASSPHRASE env var.
-//  3. An interactive prompt on /dev/tty.
+//  3. An interactive prompt on the controlling terminal.
 //
 // Returns the passphrase and the source it came from. Trailing CR/LF is
 // stripped from file/env values so common shell idioms (heredocs,
@@ -577,7 +577,7 @@ func readVaultPassphrase(passphraseFile, prompt string, w io.Writer) (string, pa
 }
 
 // willPromptInteractively reports whether the next readVaultPassphrase
-// call would fall through to /dev/tty. Mirrors readVaultPassphrase's
+// call would fall through to the controlling terminal. Mirrors readVaultPassphrase's
 // dispatch order — file > env > interactive — so callers can decide
 // whether to print user-facing context (e.g. the new-vault banner)
 // BEFORE the prompt fires, instead of inferring interactivity from

--- a/internal/launch/secrets.go
+++ b/internal/launch/secrets.go
@@ -79,13 +79,13 @@ func ValidateTokenRef(field, value string) error {
 
 // OpenVaultFunc is the function used to open the vault when vault
 // references are found in token fields. Defaults to prompting for a
-// passphrase on /dev/tty. Replaceable in tests.
+// passphrase on the controlling terminal. Replaceable in tests.
 var OpenVaultFunc = promptAndOpenVault
 
 func promptAndOpenVault(w io.Writer) (vault.Vault, error) {
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	tty, err := openControllingTerminal()
 	if err != nil {
-		return nil, fmt.Errorf("cannot open /dev/tty for passphrase prompt: %w", err)
+		return nil, fmt.Errorf("cannot open terminal for passphrase prompt: %w", err)
 	}
 	defer tty.Close()
 

--- a/internal/launch/tty_test.go
+++ b/internal/launch/tty_test.go
@@ -1,0 +1,38 @@
+package launch
+
+import (
+	"errors"
+	"io/fs"
+	"testing"
+)
+
+// TestOpenControllingTerminal asserts that the controlling-terminal opener
+// resolves the correct platform device. The regression this guards is
+// feedback #1250: on Windows the prompt path hardcoded the POSIX device
+// /dev/tty, which does not exist, so first-run crashed with
+// "open /dev/tty: The system cannot find the path specified" — a
+// path-not-found (fs.ErrNotExist) error.
+//
+// On a host with a controlling terminal the opener succeeds and returns a
+// handle whose Fd() is usable by golang.org/x/term. In CI / non-interactive
+// contexts there may be no terminal, so the open can fail — but it must fail
+// because the device is unavailable, never because the path does not exist.
+// A fs.ErrNotExist here means we asked the OS for the wrong device name,
+// which is exactly the bug being fixed.
+func TestOpenControllingTerminal(t *testing.T) {
+	f, err := openControllingTerminal()
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			t.Fatalf("openControllingTerminal returned path-not-found %v; the platform terminal device name is wrong", err)
+		}
+		// No controlling terminal in this environment (e.g. CI). The
+		// device name was resolved correctly; the open just failed
+		// because no terminal is attached. That is acceptable.
+		t.Skipf("no controlling terminal available in this environment: %v", err)
+	}
+	defer f.Close()
+
+	if f.Fd() == 0 && f.Name() == "" {
+		t.Fatalf("openControllingTerminal returned an unusable handle")
+	}
+}

--- a/internal/launch/tty_test.go
+++ b/internal/launch/tty_test.go
@@ -1,8 +1,10 @@
 package launch
 
 import (
+	"bytes"
 	"errors"
 	"io/fs"
+	"strings"
 	"testing"
 )
 
@@ -34,5 +36,24 @@ func TestOpenControllingTerminal(t *testing.T) {
 
 	if f.Fd() == 0 && f.Name() == "" {
 		t.Fatalf("openControllingTerminal returned an unusable handle")
+	}
+}
+
+// TestPromptAndOpenVault_NoTerminalFailsGracefully exercises the real
+// default vault prompter (not the injectable `OpenVaultFunc` seam) when no
+// controlling terminal is available. The contract is that it surfaces a
+// clear "cannot open terminal" error rather than hanging or panicking. We
+// guard against a hang by only running when the terminal is genuinely
+// absent; if a tty is attached, term.ReadPassword would block, so we skip.
+func TestPromptAndOpenVault_NoTerminalFailsGracefully(t *testing.T) {
+	if f, err := openControllingTerminal(); err == nil {
+		f.Close()
+		t.Skip("controlling terminal present; skipping to avoid blocking on read")
+	}
+	var buf bytes.Buffer
+	if _, err := promptAndOpenVault(&buf); err == nil {
+		t.Fatal("expected error when no controlling terminal is available")
+	} else if !strings.Contains(err.Error(), "cannot open terminal") {
+		t.Fatalf("err = %v, want 'cannot open terminal'", err)
 	}
 }

--- a/internal/launch/tty_unix.go
+++ b/internal/launch/tty_unix.go
@@ -1,0 +1,15 @@
+//go:build unix
+
+package launch
+
+import "os"
+
+// openControllingTerminal opens the controlling terminal for interactive
+// passphrase prompts. On POSIX systems this is /dev/tty, which refers to
+// the process's controlling terminal regardless of stdin/stdout redirection.
+//
+// The returned *os.File's Fd() is a valid terminal file descriptor for
+// golang.org/x/term.ReadPassword. The caller owns the file and must Close it.
+func openControllingTerminal() (*os.File, error) {
+	return os.OpenFile("/dev/tty", os.O_RDWR, 0)
+}

--- a/internal/launch/tty_windows.go
+++ b/internal/launch/tty_windows.go
@@ -1,0 +1,19 @@
+//go:build windows
+
+package launch
+
+import "os"
+
+// openControllingTerminal opens the controlling terminal for interactive
+// passphrase prompts. Windows has no /dev/tty; the documented equivalent is
+// the console device pair CONIN$ (input) and CONOUT$ (output), which refer
+// to the process's attached console regardless of stdin/stdout redirection.
+//
+// We open CONIN$ read/write so the returned handle can both read keystrokes
+// and have echo toggled. The returned *os.File's Fd() is a valid console
+// handle for golang.org/x/term.ReadPassword, which uses the Windows console
+// mode APIs (GetConsoleMode/SetConsoleMode) under the hood. The caller owns
+// the file and must Close it.
+func openControllingTerminal() (*os.File, error) {
+	return os.OpenFile("CONIN$", os.O_RDWR, 0)
+}

--- a/internal/launch/vault.go
+++ b/internal/launch/vault.go
@@ -4,7 +4,6 @@ import (
 	"errors"
 	"fmt"
 	"io"
-	"os"
 	"strings"
 
 	"github.com/ALRubinger/aileron/internal/vault"
@@ -115,12 +114,12 @@ func unlockExistingVault(path string, prompter PassphrasePrompter, w io.Writer, 
 	return nil, fmt.Errorf("vault unlock loop exited without resolution")
 }
 
-// defaultPassphrasePrompter reads from /dev/tty without echoing.
-// Used as the fallback when the caller doesn't inject a prompter.
+// defaultPassphrasePrompter reads from the controlling terminal without
+// echoing. Used as the fallback when the caller doesn't inject a prompter.
 func defaultPassphrasePrompter(prompt string, w io.Writer) (string, error) {
-	tty, err := os.OpenFile("/dev/tty", os.O_RDWR, 0)
+	tty, err := openControllingTerminal()
 	if err != nil {
-		return "", fmt.Errorf("cannot open /dev/tty: %w", err)
+		return "", fmt.Errorf("cannot open terminal: %w", err)
 	}
 	defer tty.Close()
 	fmt.Fprint(w, "aileron: ", prompt)

--- a/internal/launch/vault_test.go
+++ b/internal/launch/vault_test.go
@@ -178,11 +178,11 @@ func tamperVault(t *testing.T, path, passphrase string) {
 }
 
 func TestEnsureVault_DefaultPrompterFailsGracefullyOffTTY(t *testing.T) {
-	// In test contexts there's no /dev/tty open, so calling the
-	// default prompter should fail with a clear error rather than
-	// hanging or panicking. We exercise this by calling EnsureVault
-	// with prompter=nil and checking that we get the expected
-	// "cannot open /dev/tty" error.
+	// In test contexts there's no controlling terminal open, so
+	// calling the default prompter should fail with a clear error
+	// rather than hanging or panicking. We exercise this by calling
+	// EnsureVault with prompter=nil and checking that we get the
+	// expected "cannot open terminal" error.
 	if _, err := EnsureVault(filepath.Join(t.TempDir(), "secrets.json"), nil, &bytes.Buffer{}, 1); err == nil {
 		t.Error("expected error from default prompter without a tty")
 	}

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -532,7 +532,8 @@ func isLoopbackBind(bindAddr string) bool {
 // is local-daemon-only, so a missing file there is benign.
 //
 // `prompter` is forwarded to [launch.EnsureVault] for the interactive
-// path; nil means use the package default which reads from `/dev/tty`.
+// path; nil means use the package default which reads from the
+// controlling terminal (/dev/tty on POSIX, CONIN$ on Windows).
 func selectVault(log *slog.Logger, vaultPath string, isTTY bool, prompter launch.PassphrasePrompter, w io.Writer) (app.Config, error) {
 	if os.Getenv("AILERON_DATABASE_URL") != "" {
 		log.Info("cloud-shaped daemon: skipping local vault (postgres-backed)")


### PR DESCRIPTION
## Summary

Windows first-run crashed because the interactive passphrase prompt hardcoded the POSIX device `/dev/tty`, which does not exist on Windows:

```
cannot open terminal: open /dev/tty: The system cannot find the path specified.
```

The repro path is `runVaultInit -> readVaultPassphrase -> promptPassphrase -> defaultPromptPassphrase`. The same `os.OpenFile("/dev/tty", ...)` + `term.ReadPassword(fd)` pattern was duplicated at four sites across two modules.

This PR introduces an `openControllingTerminal` helper using the repo's existing build-tag split convention (`tty_unix.go` / `tty_windows.go`):

- **Unix** opens `/dev/tty` exactly as before.
- **Windows** opens the console device `CONIN$` (the documented Windows equivalent of the controlling terminal), returning a handle whose `Fd()` works with `golang.org/x/term`'s console-mode APIs.

All four prompt sites now route through the helper:
- `cmd/aileron` `defaultPromptPassphrase`
- `internal/launch` `defaultPassphrasePrompter`
- `internal/launch` `promptAndOpenVault`

Because `cmd/aileron` and `internal` are separate Go modules, the helper pair is added to each. Stale `/dev/tty` comments are updated in `cmd/aileron/vault.go`, `internal/launch/{vault,secrets}.go`, and `internal/server/main.go`.

No OpenAPI/spec change (CLI-only, no API surface). No backwards-compat shim.

## Test plan

- New regression test `TestOpenControllingTerminal` in both modules asserts the opener resolves the correct platform device: it must never fail with `fs.ErrNotExist` (path-not-found, the exact Windows bug). When a controlling terminal is attached the handle is usable; in non-interactive CI it skips because the device exists but no terminal is attached.
- Existing injectable-seam prompter tests (`TestEnsureVault_*`, `TestReadVaultPassphrase_*`, `TestRunVaultInit_*`, `TestPromptAndUnlock*`) stay green.
- `go build ./...` and `GOOS=windows GOARCH=amd64 go build ./...` pass for both `internal` and `cmd/aileron` modules.
- `go vet` + full package test suites green for `internal/launch`, `internal/server`, and `cmd/aileron`.

Closes #1250

🤖 Generated with [Claude Code](https://claude.com/claude-code)
