### PR TITLE
feat(sandbox): persistent cache volumes for stateful sandbox CLIs

### DIFF
--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -18,7 +18,7 @@ import (
 
 func runSandbox(args []string, registry *launch.Registry, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check>")
+		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check|clear>")
 		return 1
 	}
 	switch args[0] {
@@ -30,9 +30,11 @@ func runSandbox(args []string, registry *launch.Registry, stdout, stderr io.Writ
 		return runSandboxBuild(args[1:], stdout, stderr)
 	case "check":
 		return runSandboxCheck(args[1:], stdout, stderr)
+	case "clear":
+		return runSandboxClear(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown sandbox command: %q\n", args[0])
-		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check>")
+		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check|clear>")
 		return 1
 	}
 }
@@ -108,6 +110,9 @@ func runSandboxPlan(args []string, stdout, stderr io.Writer) int {
 		} else {
 			fmt.Fprintf(stdout, "features: %s\n", strings.Join(refs, ", "))
 		}
+	}
+	for _, c := range plan.Aileron.Caches {
+		fmt.Fprintf(stdout, "cache: %s -> %s\n", c.Name, c.Path)
 	}
 	return 0
 }
@@ -252,6 +257,75 @@ func reportBakedMCPVersion(stdout, stderr io.Writer, baked, host string) {
 
 func sandboxCheckError(err error) string {
 	return strings.ReplaceAll(err.Error(), "--sandbox-build", "--build")
+}
+
+// runSandboxClear evicts the Aileron-managed persistent cache volumes declared
+// in customizations.aileron.caches. Eviction is manual (issue #1190): there is
+// no max-age or auto-eviction, so this command is the only way a stateful CLI's
+// cached store is discarded. The volumes are keyed by (agent, workspace
+// identity), matching launchSandbox's naming, so --agent must name the same
+// agent the cache was created under. A volume that does not exist is a no-op
+// (idempotent), so clearing a never-launched or already-cleared cache succeeds.
+func runSandboxClear(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("sandbox clear", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	runtimeName := flags.String("runtime", sandboxcontainer.DefaultRuntime, "Container runtime: auto or docker")
+	agent := flags.String("agent", "", "Agent the cache volumes are keyed under (required)")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: aileron sandbox clear --agent=<agent> [--runtime=auto|docker]")
+		return 1
+	}
+	if strings.TrimSpace(*agent) == "" {
+		fmt.Fprintln(stderr, "error: --agent is required (cache volumes are keyed by agent)")
+		fmt.Fprintln(stderr, "usage: aileron sandbox clear --agent=<agent> [--runtime=auto|docker]")
+		return 1
+	}
+	cwd, err := os.Getwd()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	plan, err := sandboxcomposition.Discover(cwd, version.Version, *agent)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	resolved, err := plan.ResolveCaches(*agent, cwd)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if len(resolved) == 0 {
+		fmt.Fprintln(stdout, "no caches declared in customizations.aileron.caches; nothing to clear")
+		return 0
+	}
+	failed := false
+	for _, rc := range resolved {
+		if err := sandboxRemoveVolumeFn(context.Background(), *runtimeName, rc.VolumeName, stdout, stderr); err != nil {
+			fmt.Fprintf(stderr, "error: remove cache %s (volume %s): %v\n", rc.Cache.Name, rc.VolumeName, err)
+			failed = true
+			continue
+		}
+		fmt.Fprintf(stdout, "cleared cache %s (volume %s)\n", rc.Cache.Name, rc.VolumeName)
+	}
+	if failed {
+		return 1
+	}
+	return 0
+}
+
+// sandboxRemoveVolumeFn resolves the runtime and removes one managed cache
+// volume. Swappable in tests so the clear command's argv/identity wiring is
+// exercised without a container runtime on PATH.
+var sandboxRemoveVolumeFn = func(ctx context.Context, runtimeName, name string, stdout, stderr io.Writer) error {
+	resolved, err := sandboxcontainer.ResolveRuntime(runtimeName)
+	if err != nil {
+		return err
+	}
+	return sandboxcontainer.RemoveVolume(ctx, sandboxcontainer.DefaultRunner(), resolved, name, stdout, stderr)
 }
 
 var sandboxBuildFn = func(ctx context.Context, runtimeName string, stdout, stderr io.Writer, opts sandboxcontainer.BuildOptions) (sandboxcontainer.BuildResult, error) {

--- a/cmd/aileron/sandbox_test.go
+++ b/cmd/aileron/sandbox_test.go
@@ -320,3 +320,138 @@ func TestSandboxCheckValidateOptionsWiring(t *testing.T) {
 		t.Fatal("ValidateOptions.RequireProxyTrust must round-trip")
 	}
 }
+
+func writeCacheDevcontainer(t *testing.T, dir string) {
+	t.Helper()
+	devDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	body := `{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "customizations": {"aileron": {"caches": [
+    {"name": "printingpress", "path": "/home/agent/.local/share/printingpress"},
+    {"name": "gh", "path": "/home/agent/.config/gh"}
+  ]}}
+}`
+	if err := os.WriteFile(filepath.Join(devDir, "devcontainer.json"), []byte(body), 0o644); err != nil {
+		t.Fatalf("write devcontainer.json: %v", err)
+	}
+}
+
+func TestRunSandboxPlanPrintsCaches(t *testing.T) {
+	dir := t.TempDir()
+	writeCacheDevcontainer(t, dir)
+	t.Chdir(dir)
+	var out, errb bytes.Buffer
+	if code := runSandboxPlan(nil, &out, &errb); code != 0 {
+		t.Fatalf("runSandboxPlan = %d, stderr: %s", code, errb.String())
+	}
+	got := out.String()
+	if !strings.Contains(got, "cache: printingpress -> /home/agent/.local/share/printingpress\n") {
+		t.Fatalf("plan output missing printingpress cache line:\n%s", got)
+	}
+	if !strings.Contains(got, "cache: gh -> /home/agent/.config/gh\n") {
+		t.Fatalf("plan output missing gh cache line:\n%s", got)
+	}
+}
+
+func stubSandboxRemoveVolume(t *testing.T) *[]string {
+	t.Helper()
+	orig := sandboxRemoveVolumeFn
+	t.Cleanup(func() { sandboxRemoveVolumeFn = orig })
+	var removed []string
+	sandboxRemoveVolumeFn = func(_ context.Context, _ string, name string, _, _ io.Writer) error {
+		removed = append(removed, name)
+		return nil
+	}
+	return &removed
+}
+
+func TestRunSandboxClearRemovesDeclaredCacheVolumes(t *testing.T) {
+	dir := t.TempDir()
+	writeCacheDevcontainer(t, dir)
+	t.Chdir(dir)
+	removed := stubSandboxRemoveVolume(t)
+	var out, errb bytes.Buffer
+	if code := runSandboxClear([]string{"--agent=claude", "--runtime=docker"}, &out, &errb); code != 0 {
+		t.Fatalf("runSandboxClear = %d, stderr: %s", code, errb.String())
+	}
+	// The volumes removed must match the (agent, workspace, name) keying the
+	// launcher mounts, so clear evicts exactly what launch created.
+	want := []string{
+		sandboxcomposition.CacheVolumeName("claude", dir, "printingpress"),
+		sandboxcomposition.CacheVolumeName("claude", dir, "gh"),
+	}
+	if len(*removed) != 2 || (*removed)[0] != want[0] || (*removed)[1] != want[1] {
+		t.Fatalf("removed = %v, want %v", *removed, want)
+	}
+	if !strings.Contains(out.String(), "cleared cache printingpress") {
+		t.Fatalf("stdout = %q, want cleared lines", out.String())
+	}
+}
+
+func TestRunSandboxClearRequiresAgent(t *testing.T) {
+	dir := t.TempDir()
+	writeCacheDevcontainer(t, dir)
+	t.Chdir(dir)
+	var out, errb bytes.Buffer
+	if code := runSandboxClear(nil, &out, &errb); code != 1 {
+		t.Fatalf("runSandboxClear = %d, want 1 (missing --agent)", code)
+	}
+	if !strings.Contains(errb.String(), "--agent is required") {
+		t.Fatalf("stderr = %q, want --agent required error", errb.String())
+	}
+}
+
+func TestRunSandboxClearNoCachesIsNoOp(t *testing.T) {
+	dir := t.TempDir()
+	// devcontainer with no caches declared.
+	devDir := filepath.Join(dir, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "devcontainer.json"), []byte(`{"image":"x"}`), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	t.Chdir(dir)
+	removed := stubSandboxRemoveVolume(t)
+	var out, errb bytes.Buffer
+	if code := runSandboxClear([]string{"--agent=claude"}, &out, &errb); code != 0 {
+		t.Fatalf("runSandboxClear = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if len(*removed) != 0 {
+		t.Fatalf("removed = %v, want none (no caches declared)", *removed)
+	}
+	if !strings.Contains(out.String(), "nothing to clear") {
+		t.Fatalf("stdout = %q, want nothing-to-clear message", out.String())
+	}
+}
+
+func TestRunSandboxClearReportsRemoveFailure(t *testing.T) {
+	dir := t.TempDir()
+	writeCacheDevcontainer(t, dir)
+	t.Chdir(dir)
+	orig := sandboxRemoveVolumeFn
+	t.Cleanup(func() { sandboxRemoveVolumeFn = orig })
+	sandboxRemoveVolumeFn = func(_ context.Context, _ string, _ string, _, _ io.Writer) error {
+		return context.DeadlineExceeded
+	}
+	var out, errb bytes.Buffer
+	if code := runSandboxClear([]string{"--agent=claude", "--runtime=docker"}, &out, &errb); code != 1 {
+		t.Fatalf("runSandboxClear = %d, want 1 on remove failure", code)
+	}
+	if !strings.Contains(errb.String(), "remove cache") {
+		t.Fatalf("stderr = %q, want remove-cache error", errb.String())
+	}
+}
+
+func TestRunSandboxUnknownSubcommand(t *testing.T) {
+	var out, errb bytes.Buffer
+	if code := runSandbox([]string{"bogus"}, nil, &out, &errb); code != 1 {
+		t.Fatalf("runSandbox bogus = %d, want 1", code)
+	}
+	if !strings.Contains(errb.String(), "clear") {
+		t.Fatalf("usage must mention clear subcommand; stderr=%q", errb.String())
+	}
+}

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -25,6 +25,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 | `aileron sandbox plan` | Inspect the normalized composition tier and image Aileron infers from the current project. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox build` | Build the Tier 0 sandbox-base image or Tier 1 devcontainer image with Docker. Tier 2 BYO images are reported without build or injection. | [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron sandbox check [--runtime=auto\|docker] [--build=auto\|always\|never] --agent=<command>` | Validate that the selected sandbox image can launch an agent command before starting a session. | [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron sandbox clear --agent=<command> [--runtime=auto\|docker]` | Remove the Aileron-managed persistent cache volumes (`customizations.aileron.caches`) for an agent in the current project. Eviction is manual; clearing an absent cache is a no-op. | [ADR-0017](/adr/0017-sandbox-composition) |
 
 Docker is the only supported sandbox runtime in v4. Podman is planned but not yet supported ([ADR-0014](/adr/0014-spawn-sandbox-technology/)); passing `--sandbox=podman` or `--runtime=podman` fails with `podman runtime is not supported yet (v4 is Docker-only); see ADR-0014`.
 

--- a/docs/src/content/docs/development/sandbox-composition.md
+++ b/docs/src/content/docs/development/sandbox-composition.md
@@ -121,6 +121,51 @@ aileron sandbox check --runtime=docker --build=never --agent=codex
 
 `sandbox check` uses the same composition plan, build policy, and minimal image validation as sandbox launch. It reports the selected tier, runtime, image, command, and `support: ok` when the command is available. Agent-specific image recipes and support status live in the [sandbox agent image matrix](/development/sandbox-agent-images/).
 
+## Persist a CLI's Local Store with Caches
+
+A stateful, DB-backed CLI run in the sandbox keeps a local store on disk: a SQLite/FTS5 index, an `gh` config tree, a search cache. The sandbox container is one-shot, so without a persistent mount that store is rebuilt from scratch on every cold start. Declare a cache under `customizations.aileron.caches` to give the store an Aileron-managed Docker volume that survives container teardown ([#1190](https://github.com/ALRubinger/aileron/issues/1190)):
+
+```jsonc
+{
+  "image": "ghcr.io/alrubinger/aileron-sandbox-base:<version>",
+  "customizations": {
+    "aileron": {
+      "caches": [
+        // name: a stable identifier for the cache.
+        // path: the absolute in-container directory the CLI keeps its store in.
+        { "name": "printingpress", "path": "/home/agent/.local/share/printingpress" },
+        { "name": "gh", "path": "/home/agent/.config/gh" }
+      ]
+    }
+  }
+}
+```
+
+Each declared cache mounts a named Docker volume at its `path`. The volume is keyed by `(agent, workspace identity, cache name)`, so the same agent in the same project reuses its store across launches, while a different workspace gets a fresh one. Docker auto-provisions the volume on the first launch that mounts it. `name` must contain only letters, digits, `-`, `_`, or `.`; `path` must be absolute; names and paths must be unique within the block.
+
+The cache holds whatever the CLI writes there, in plaintext on the host. This matches the v4 single-user posture where the operator is the user ([ADR-0011](/adr/0011-local-encrypted-vault/)); the cache is not the credential vault and must not be used for secrets.
+
+`sandbox plan` lists declared caches:
+
+```text
+tier: devcontainer
+image: ghcr.io/alrubinger/aileron-sandbox-base:edge
+devcontainer: .devcontainer/devcontainer.json
+cache: printingpress -> /home/agent/.local/share/printingpress
+cache: gh -> /home/agent/.config/gh
+```
+
+### Clear a Cache
+
+Eviction is manual: there is no max-age and nothing is auto-evicted. Use `sandbox clear` to discard the cache volumes for an agent in the current project (for example after re-authenticating a CLI to a different account):
+
+```bash
+aileron sandbox clear --agent=claude
+aileron sandbox clear --agent=codex --runtime=docker
+```
+
+`--agent` is required because the cache volume is keyed by agent. `clear` removes only the volumes that match the declared caches for that `(agent, workspace)`, so it never touches another agent's or another project's store. Clearing a cache that was never created, or clearing twice, is a no-op.
+
 ## Run During Launch
 
 Use `--sandbox` on `aileron launch` to have launch prepare the composition-selected image and start the agent inside it:

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -86,6 +86,12 @@ type SandboxLaunchPlan struct {
 	Image   string
 	Tier    sandboxcomposition.Tier
 	Built   bool
+	// Caches carries the persistent cache volumes declared in
+	// customizations.aileron.caches. launchSandbox resolves each to a named
+	// Docker volume keyed by (agent, workspace identity) and mounts it at the
+	// cache's container path so the CLI's local store survives container
+	// teardown (issue #1190). Nil when the plan declares no caches.
+	Caches []sandboxcomposition.Cache
 }
 
 // ResolveBinary searches PATH for the first matching binary name from
@@ -224,6 +230,7 @@ func prepareSandbox(ctx context.Context, workDir, agent, runtimeName, buildPolic
 			Runtime: runtime,
 			Image:   result.Image,
 			Tier:    result.Tier,
+			Caches:  plan.Aileron.Caches,
 		}, nil
 	}
 	if err != nil {
@@ -234,6 +241,7 @@ func prepareSandbox(ctx context.Context, workDir, agent, runtimeName, buildPolic
 		Image:   result.Image,
 		Tier:    result.Tier,
 		Built:   result.Built,
+		Caches:  plan.Aileron.Caches,
 	}, nil
 }
 
@@ -794,9 +802,18 @@ func collapseNestedMCPMounts(existing []sandboxcontainer.Volume, mcpMounts []MCP
 // inside any of them. A directory mount is identified by target shape: an
 // MCP single-file mount and a directory mount are distinguished only by
 // whether target is a strict path prefix of another mount's target.
+//
+// Named volumes (persistent caches, #1190) are never returned as the
+// enclosing mount: their Source is a Docker volume name, not a host path, so
+// collapseNestedMCPMounts cannot relocate a file into them. An MCP file
+// nested under a cache directory is left as its own bind mount instead of
+// being silently written into a host directory named after the volume.
 func enclosingDirMount(mounts []sandboxcontainer.Volume, target string) *sandboxcontainer.Volume {
 	clean := path.Clean(target)
 	for i := range mounts {
+		if mounts[i].Named {
+			continue
+		}
 		dir := path.Clean(mounts[i].Target)
 		if dir == clean {
 			continue
@@ -818,6 +835,17 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 		return LaunchResult{}, err
 	}
 	mounts = append(mounts, extraMounts...)
+
+	// Persistent cache volumes (issue #1190): resolve each declared cache to a
+	// named Docker volume keyed by (agent, workspace identity) and mount it at
+	// the cache's container path, so a stateful CLI's local store (e.g.
+	// PrintingPress' SQLite/FTS5 store) survives container teardown. Docker
+	// auto-provisions the named volume on first mount.
+	cacheMounts, err := sandboxCacheMounts(plan.Caches, config.Agent.Name(), config.Dir)
+	if err != nil {
+		return LaunchResult{}, err
+	}
+	mounts = append(mounts, cacheMounts...)
 
 	// Unbaked image: resolve aileron-mcp on the host and bind-mount it
 	// read-only at the container's well-known MCP binary path. Matches the
@@ -1063,6 +1091,33 @@ func sandboxRuntimeMounts() ([]sandboxcontainer.Volume, error) {
 			continue
 		}
 		mounts = append(mounts, candidate)
+	}
+	return mounts, nil
+}
+
+// sandboxCacheMounts resolves declared persistent caches to named-volume
+// mounts keyed by (agent, workspace identity). Each cache's container path
+// becomes the mount target and the derived volume name (see
+// CacheVolumeName) the source; Named=true tells runArgs to emit
+// `--volume <name>:<target>` so Docker auto-provisions and persists the volume
+// across container teardown (issue #1190). The caches are writable: the CLI
+// must update its store. Returns nil when no caches are declared.
+func sandboxCacheMounts(caches []sandboxcomposition.Cache, agent, workDir string) ([]sandboxcontainer.Volume, error) {
+	if len(caches) == 0 {
+		return nil, nil
+	}
+	plan := sandboxcomposition.Plan{Aileron: sandboxcomposition.AileronCustomization{Caches: caches}}
+	resolved, err := plan.ResolveCaches(agent, workDir)
+	if err != nil {
+		return nil, fmt.Errorf("resolve sandbox caches: %w", err)
+	}
+	mounts := make([]sandboxcontainer.Volume, 0, len(resolved))
+	for _, rc := range resolved {
+		mounts = append(mounts, sandboxcontainer.Volume{
+			Source: rc.VolumeName,
+			Target: rc.Cache.Path,
+			Named:  true,
+		})
 	}
 	return mounts, nil
 }

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -766,3 +766,68 @@ func TestEnclosingDirMount_IdentityTargetNotEnclosing(t *testing.T) {
 		t.Fatal("enclosingDirMount returned nil for nested target, want the dir mount")
 	}
 }
+
+func TestSandboxCacheMountsResolvesNamedVolumes(t *testing.T) {
+	caches := []sandboxcomposition.Cache{
+		{Name: "printingpress", Path: "/home/agent/.local/share/printingpress"},
+		{Name: "gh", Path: "/home/agent/.config/gh"},
+	}
+	mounts, err := sandboxCacheMounts(caches, "claude", "/home/u/proj")
+	if err != nil {
+		t.Fatalf("sandboxCacheMounts: %v", err)
+	}
+	if len(mounts) != 2 {
+		t.Fatalf("mounts = %+v, want 2", mounts)
+	}
+	for i, c := range caches {
+		if !mounts[i].Named {
+			t.Fatalf("mounts[%d].Named = false, want true (cache must be a named volume)", i)
+		}
+		if mounts[i].Target != c.Path {
+			t.Fatalf("mounts[%d].Target = %q, want %q", i, mounts[i].Target, c.Path)
+		}
+		want := sandboxcomposition.CacheVolumeName("claude", "/home/u/proj", c.Name)
+		if mounts[i].Source != want {
+			t.Fatalf("mounts[%d].Source = %q, want %q", i, mounts[i].Source, want)
+		}
+		// Cache mounts are writable: the CLI must update its store.
+		if mounts[i].ReadOnly {
+			t.Fatalf("mounts[%d].ReadOnly = true, want false (cache must be writable)", i)
+		}
+	}
+}
+
+func TestSandboxCacheMountsEmptyReturnsNil(t *testing.T) {
+	mounts, err := sandboxCacheMounts(nil, "claude", "/ws")
+	if err != nil {
+		t.Fatalf("sandboxCacheMounts: %v", err)
+	}
+	if mounts != nil {
+		t.Fatalf("mounts = %+v, want nil for no caches", mounts)
+	}
+}
+
+func TestSandboxCacheMountsRequiresAgent(t *testing.T) {
+	caches := []sandboxcomposition.Cache{{Name: "x", Path: "/a"}}
+	_, err := sandboxCacheMounts(caches, "", "/ws")
+	if err == nil {
+		t.Fatal("sandboxCacheMounts with empty agent: want error")
+	}
+}
+
+func TestEnclosingDirMountSkipsNamedVolumes(t *testing.T) {
+	// A named cache volume must never be treated as the enclosing directory
+	// for a nested MCP file: its Source is a Docker volume name, not a host
+	// path, so collapsing a file into it would write to a bogus host dir.
+	mounts := []sandboxcontainer.Volume{
+		{Source: "aileron-cache-claude-x-abc", Target: "/home/agent/.codex", Named: true},
+	}
+	if got := enclosingDirMount(mounts, "/home/agent/.codex/config.toml"); got != nil {
+		t.Fatalf("enclosingDirMount returned %+v for a named-volume parent, want nil", got)
+	}
+	// A non-named directory mount still matches.
+	mounts = append(mounts, sandboxcontainer.Volume{Source: "/host/dir", Target: "/home/agent/.config"})
+	if got := enclosingDirMount(mounts, "/home/agent/.config/app.toml"); got == nil {
+		t.Fatal("enclosingDirMount returned nil for a host-path dir parent, want the dir mount")
+	}
+}

--- a/internal/sandbox/composition/composition.go
+++ b/internal/sandbox/composition/composition.go
@@ -3,10 +3,13 @@ package composition
 
 import (
 	"bytes"
+	"crypto/sha256"
+	"encoding/hex"
 	"encoding/json"
 	"errors"
 	"fmt"
 	"os"
+	"path"
 	"path/filepath"
 	"strings"
 )
@@ -89,6 +92,25 @@ type AileronCustomization struct {
 	Image           string `json:"image,omitempty"`
 	Mediation       string `json:"mediation,omitempty"`
 	ApprovalSurface string `json:"approval_surface,omitempty"`
+	// Caches declares persistent, Aileron-managed cache volumes for
+	// stateful, DB-backed CLIs run in the sandbox. Each entry maps a
+	// container data path (e.g. a CLI's SQLite/FTS5 store) to a named
+	// Docker volume Aileron auto-provisions, so the store survives container
+	// teardown instead of being rebuilt on every cold start. The volume is
+	// keyed by (agent, workspace identity, cache name) at launch time, so
+	// re-auth to a different workspace gets a fresh store; eviction is
+	// manual via `aileron sandbox clear`. See issue #1190.
+	Caches []Cache `json:"caches,omitempty"`
+}
+
+// Cache is one declared persistent cache mount. Name is a stable,
+// human-meaningful identifier for the cache (e.g. "printingpress"); it is
+// combined with the agent and workspace identity to derive the managed Docker
+// volume name. Path is the absolute in-container directory where the CLI keeps
+// its local store; it becomes the volume's mount target.
+type Cache struct {
+	Name string `json:"name"`
+	Path string `json:"path"`
 }
 
 type devcontainerConfig struct {
@@ -216,7 +238,68 @@ func parseDevcontainer(b []byte) (devcontainerConfig, error) {
 			return cfg, fmt.Errorf("customizations.aileron.approval_surface must be webapp, tui, or both")
 		}
 	}
+	if err := validateCaches(cfg.Customizations.Aileron.Caches); err != nil {
+		return cfg, err
+	}
 	return cfg, nil
+}
+
+// validateCaches enforces the contract for customizations.aileron.caches: each
+// entry needs a non-empty name and an absolute container path, names must be
+// unique (the name keys the managed volume), and paths must be unique (two
+// caches cannot target the same directory). A malformed declaration is a hard
+// parse error so the operator sees it at `sandbox plan` rather than as a silent
+// mount surprise at launch.
+func validateCaches(caches []Cache) error {
+	seenNames := make(map[string]struct{}, len(caches))
+	seenPaths := make(map[string]struct{}, len(caches))
+	for i, c := range caches {
+		name := strings.TrimSpace(c.Name)
+		if name == "" {
+			return fmt.Errorf("customizations.aileron.caches[%d]: name is required", i)
+		}
+		if !isValidCacheName(name) {
+			return fmt.Errorf("customizations.aileron.caches[%d]: name %q must contain only letters, digits, '-', '_', or '.'", i, name)
+		}
+		// Cache paths are in-container paths, always Unix-style with a
+		// leading "/", regardless of the host OS. Use the path package
+		// (forward-slash semantics) rather than filepath, whose IsAbs/Clean
+		// would wrongly reject or mangle a "/..." container path on a Windows
+		// host.
+		cpath := strings.TrimSpace(c.Path)
+		if cpath == "" {
+			return fmt.Errorf("customizations.aileron.caches[%d] (%s): path is required", i, name)
+		}
+		if !path.IsAbs(cpath) {
+			return fmt.Errorf("customizations.aileron.caches[%d] (%s): path %q must be absolute", i, name, cpath)
+		}
+		if _, dup := seenNames[name]; dup {
+			return fmt.Errorf("customizations.aileron.caches: duplicate cache name %q", name)
+		}
+		seenNames[name] = struct{}{}
+		cleanPath := path.Clean(cpath)
+		if _, dup := seenPaths[cleanPath]; dup {
+			return fmt.Errorf("customizations.aileron.caches: duplicate cache path %q", cleanPath)
+		}
+		seenPaths[cleanPath] = struct{}{}
+	}
+	return nil
+}
+
+// isValidCacheName reports whether name is safe to embed in a Docker volume
+// name. Docker volume names must match [a-zA-Z0-9][a-zA-Z0-9_.-]*; restricting
+// the cache name to this alphabet keeps the derived volume name valid without
+// further escaping.
+func isValidCacheName(name string) bool {
+	for _, r := range name {
+		switch {
+		case r >= 'a' && r <= 'z', r >= 'A' && r <= 'Z', r >= '0' && r <= '9':
+		case r == '-' || r == '_' || r == '.':
+		default:
+			return false
+		}
+	}
+	return true
 }
 
 // BaseImage returns the Aileron-owned sandbox-base image for version.
@@ -265,6 +348,63 @@ func parseMount(raw json.RawMessage) (Mount, error) {
 		return Mount{}, fmt.Errorf("parse devcontainer mount: %w", err)
 	}
 	return Mount{Source: obj.Source, Target: obj.Target, ReadOnly: obj.ReadOnly}, nil
+}
+
+// CacheVolumeNamePrefix is the prefix every Aileron-managed cache volume name
+// carries. It namespaces these volumes apart from any other Docker volumes on
+// the host and lets `aileron sandbox clear` and operators recognize them.
+const CacheVolumeNamePrefix = "aileron-cache"
+
+// ResolvedCache pairs a declared cache with the managed Docker volume name it
+// resolves to for a given (agent, workspace identity). The launcher mounts
+// VolumeName at Cache.Path; `aileron sandbox clear` removes VolumeName.
+type ResolvedCache struct {
+	Cache      Cache
+	VolumeName string
+}
+
+// CacheVolumeName derives the managed Docker volume name for a cache, keyed by
+// (agent, workspace identity, cache name). The workspace path is hashed so
+// re-auth/use against a different workspace gets a fresh store (issue #1190),
+// while the agent and cache name stay human-readable in the volume name for
+// operator legibility. The result matches Docker's volume-name grammar
+// because agent and cacheName are constrained alphabets (agent ids and
+// isValidCacheName) and the workspace component is hex.
+func CacheVolumeName(agent, workspaceDir, cacheName string) string {
+	abs, err := filepath.Abs(workspaceDir)
+	if err != nil {
+		abs = workspaceDir
+	}
+	sum := sha256.Sum256([]byte(abs))
+	workspaceID := hex.EncodeToString(sum[:])[:12]
+	return strings.Join([]string{
+		CacheVolumeNamePrefix,
+		strings.TrimSpace(agent),
+		strings.TrimSpace(cacheName),
+		workspaceID,
+	}, "-")
+}
+
+// ResolveCaches resolves every declared cache in the plan to its managed
+// Docker volume name for the given agent and workspace directory. It returns
+// nil when the plan declares no caches, so launch paths with no caches add no
+// mounts. agent must be non-empty: the cache volume is keyed by agent, so an
+// empty agent would collide caches across agents sharing a workspace.
+func (p Plan) ResolveCaches(agent, workspaceDir string) ([]ResolvedCache, error) {
+	if len(p.Aileron.Caches) == 0 {
+		return nil, nil
+	}
+	if strings.TrimSpace(agent) == "" {
+		return nil, fmt.Errorf("resolve caches: agent is required to key the cache volume")
+	}
+	out := make([]ResolvedCache, 0, len(p.Aileron.Caches))
+	for _, c := range p.Aileron.Caches {
+		out = append(out, ResolvedCache{
+			Cache:      c,
+			VolumeName: CacheVolumeName(agent, workspaceDir, c.Name),
+		})
+	}
+	return out, nil
 }
 
 func stripJSONComments(in []byte) ([]byte, error) {

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -431,6 +431,154 @@ func TestDiscoverRejectsNonObjectFeatures(t *testing.T) {
 	}
 }
 
+func TestDiscoverParsesCachesIntoPlan(t *testing.T) {
+	dir := t.TempDir()
+	writeDevcontainer(t, dir, `{
+  "image": "mcr.microsoft.com/devcontainers/base:ubuntu",
+  "customizations": {
+    "aileron": {
+      "caches": [
+        {"name": "printingpress", "path": "/home/agent/.local/share/printingpress"},
+        {"name": "gh", "path": "/home/agent/.config/gh"}
+      ]
+    }
+  }
+}`)
+	plan, err := Discover(dir, "0.4.0", "")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if len(plan.Aileron.Caches) != 2 {
+		t.Fatalf("Caches = %+v, want 2", plan.Aileron.Caches)
+	}
+	if plan.Aileron.Caches[0].Name != "printingpress" || plan.Aileron.Caches[0].Path != "/home/agent/.local/share/printingpress" {
+		t.Fatalf("Caches[0] = %+v", plan.Aileron.Caches[0])
+	}
+	if plan.Aileron.Caches[1].Name != "gh" || plan.Aileron.Caches[1].Path != "/home/agent/.config/gh" {
+		t.Fatalf("Caches[1] = %+v", plan.Aileron.Caches[1])
+	}
+}
+
+func TestParseDevcontainerRejectsInvalidCaches(t *testing.T) {
+	cases := []struct {
+		name string
+		json string
+		want string
+	}{
+		{
+			name: "missing name",
+			json: `{"customizations":{"aileron":{"caches":[{"path":"/data"}]}}}`,
+			want: "name is required",
+		},
+		{
+			name: "missing path",
+			json: `{"customizations":{"aileron":{"caches":[{"name":"x"}]}}}`,
+			want: "path is required",
+		},
+		{
+			name: "relative path",
+			json: `{"customizations":{"aileron":{"caches":[{"name":"x","path":"data"}]}}}`,
+			want: "must be absolute",
+		},
+		{
+			name: "duplicate name",
+			json: `{"customizations":{"aileron":{"caches":[{"name":"x","path":"/a"},{"name":"x","path":"/b"}]}}}`,
+			want: "duplicate cache name",
+		},
+		{
+			name: "duplicate path",
+			json: `{"customizations":{"aileron":{"caches":[{"name":"x","path":"/a"},{"name":"y","path":"/a"}]}}}`,
+			want: "duplicate cache path",
+		},
+		{
+			name: "invalid name char",
+			json: `{"customizations":{"aileron":{"caches":[{"name":"bad/name","path":"/a"}]}}}`,
+			want: "must contain only",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := parseDevcontainer([]byte(tc.json))
+			if err == nil {
+				t.Fatalf("parseDevcontainer: expected error")
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Fatalf("error = %v, want substring %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateCachesAcceptsUnixContainerPath(t *testing.T) {
+	// Cache paths are in-container Unix paths. They must validate as absolute
+	// on every host OS, so validation uses the path package, not filepath
+	// (filepath.IsAbs("/x") is false on Windows). Regression for the
+	// cross-platform finding.
+	_, err := parseDevcontainer([]byte(`{"customizations":{"aileron":{"caches":[{"name":"pp","path":"/home/agent/.local/share/pp"}]}}}`))
+	if err != nil {
+		t.Fatalf("parseDevcontainer rejected a valid Unix container path: %v", err)
+	}
+}
+
+func TestCacheVolumeNameIsDeterministicAndWorkspaceKeyed(t *testing.T) {
+	a := CacheVolumeName("claude", "/home/u/projA", "printingpress")
+	again := CacheVolumeName("claude", "/home/u/projA", "printingpress")
+	if a != again {
+		t.Fatalf("CacheVolumeName not deterministic: %q vs %q", a, again)
+	}
+	if !strings.HasPrefix(a, CacheVolumeNamePrefix+"-claude-printingpress-") {
+		t.Fatalf("CacheVolumeName = %q, want prefix %s-claude-printingpress-", a, CacheVolumeNamePrefix)
+	}
+	// Different workspace -> different volume (re-auth to a different
+	// workspace gets a fresh store).
+	if b := CacheVolumeName("claude", "/home/u/projB", "printingpress"); a == b {
+		t.Fatalf("expected distinct volumes for distinct workspaces, both = %q", a)
+	}
+	// Different agent -> different volume.
+	if b := CacheVolumeName("codex", "/home/u/projA", "printingpress"); a == b {
+		t.Fatalf("expected distinct volumes for distinct agents, both = %q", a)
+	}
+	// Different cache name -> different volume.
+	if b := CacheVolumeName("claude", "/home/u/projA", "gh"); a == b {
+		t.Fatalf("expected distinct volumes for distinct cache names, both = %q", a)
+	}
+}
+
+func TestResolveCaches(t *testing.T) {
+	plan := Plan{Aileron: AileronCustomization{Caches: []Cache{
+		{Name: "printingpress", Path: "/data/pp"},
+		{Name: "gh", Path: "/data/gh"},
+	}}}
+	resolved, err := plan.ResolveCaches("claude", "/ws")
+	if err != nil {
+		t.Fatalf("ResolveCaches: %v", err)
+	}
+	if len(resolved) != 2 {
+		t.Fatalf("resolved = %+v, want 2", resolved)
+	}
+	if resolved[0].Cache.Path != "/data/pp" || resolved[0].VolumeName != CacheVolumeName("claude", "/ws", "printingpress") {
+		t.Fatalf("resolved[0] = %+v", resolved[0])
+	}
+}
+
+func TestResolveCachesEmptyReturnsNil(t *testing.T) {
+	resolved, err := Plan{}.ResolveCaches("claude", "/ws")
+	if err != nil {
+		t.Fatalf("ResolveCaches: %v", err)
+	}
+	if resolved != nil {
+		t.Fatalf("resolved = %+v, want nil", resolved)
+	}
+}
+
+func TestResolveCachesRequiresAgent(t *testing.T) {
+	plan := Plan{Aileron: AileronCustomization{Caches: []Cache{{Name: "x", Path: "/a"}}}}
+	_, err := plan.ResolveCaches("", "/ws")
+	if err == nil || !strings.Contains(err.Error(), "agent is required") {
+		t.Fatalf("err = %v, want agent-required error", err)
+	}
+}
+
 func writeDevcontainer(t *testing.T, dir, body string) {
 	t.Helper()
 	path := filepath.Join(dir, DefaultDevcontainerPath)

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -177,11 +177,20 @@ type RunOptions struct {
 	Name string
 }
 
-// Volume describes an additional host bind mount for a sandbox container.
+// Volume describes an additional mount for a sandbox container.
+//
+// By default Source is a host path: it is resolved with filepath.Abs and
+// emitted as a bind mount (`--volume <abs-host-path>:<target>`). When Named is
+// true, Source is instead a Docker named-volume identifier: it is NOT
+// path-resolved and is emitted as `--volume <name>:<target>`, so Docker
+// auto-provisions and persists the volume across container teardown. Named
+// volumes back the Aileron-managed persistent caches (issue #1190); the
+// existing credential and MCP bind-mounts keep Named=false.
 type Volume struct {
 	Source   string
 	Target   string
 	ReadOnly bool
+	Named    bool
 }
 
 // RunResult reports the selected runtime after a sandbox container exits.
@@ -530,6 +539,49 @@ func StopContainer(ctx context.Context, runner Runner, runtimeName, name string,
 	return err
 }
 
+// RemoveVolume issues `<runtimeName> volume rm <name>` through runner so
+// `aileron sandbox clear` can evict a managed persistent cache volume (issue
+// #1190). An empty name is a no-op. A volume that does not exist is treated as
+// success (returns nil): clearing a cache that was never created, or clearing
+// twice, is idempotent rather than an error. A nil runner falls back to the
+// real runtime so the CLI path works without wiring.
+func RemoveVolume(ctx context.Context, runner Runner, runtimeName, name string, stdout, stderr io.Writer) error {
+	if strings.TrimSpace(name) == "" {
+		return nil
+	}
+	if runner == nil {
+		runner = execRunner{}
+	}
+	if stdout == nil {
+		stdout = io.Discard
+	}
+	if stderr == nil {
+		stderr = io.Discard
+	}
+	var stderrBuf bytes.Buffer
+	teedStderr := io.MultiWriter(stderr, &stderrBuf)
+	err := runner.Run(ctx, runtimeName, []string{"volume", "rm", name}, stdout, teedStderr)
+	if err != nil && isVolumeAlreadyGone(stderrBuf.String()) {
+		return nil
+	}
+	return err
+}
+
+// isVolumeAlreadyGone reports whether a `volume rm` error's stderr indicates
+// the target volume did not exist, so clearing an absent cache is idempotent.
+func isVolumeAlreadyGone(stderr string) bool {
+	lowered := strings.ToLower(stderr)
+	for _, signature := range []string{
+		"no such volume",
+		"not found",
+	} {
+		if strings.Contains(lowered, signature) {
+			return true
+		}
+	}
+	return false
+}
+
 // isContainerAlreadyGone reports whether a container-runtime stop error's
 // stderr indicates the target container was already removed or stopped.
 // Matched case-insensitively against the signatures Docker
@@ -720,9 +772,16 @@ func runArgs(runtimeName string, opts RunOptions) ([]string, error) {
 		if strings.TrimSpace(volume.Source) == "" || strings.TrimSpace(volume.Target) == "" {
 			return nil, fmt.Errorf("sandbox volume source and target are required")
 		}
-		source, err := filepath.Abs(volume.Source)
-		if err != nil {
-			return nil, fmt.Errorf("resolve sandbox volume source: %w", err)
+		source := volume.Source
+		if !volume.Named {
+			// Host bind mount: resolve to an absolute host path. A named
+			// volume's Source is a Docker volume identifier, not a path, so
+			// it must NOT be path-resolved (issue #1190).
+			abs, err := filepath.Abs(volume.Source)
+			if err != nil {
+				return nil, fmt.Errorf("resolve sandbox volume source: %w", err)
+			}
+			source = abs
 		}
 		spec := source + ":" + volume.Target
 		if volume.ReadOnly {

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -1013,6 +1013,70 @@ func TestRunMountsAdditionalReadWriteVolumes(t *testing.T) {
 	}
 }
 
+func TestRunMountsNamedVolumeWithoutPathResolution(t *testing.T) {
+	pinHostOSDarwin(t)
+	dir := t.TempDir()
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:   "aileron-sandbox-base:test",
+		WorkDir: dir,
+		Volumes: []Volume{{
+			Source: "aileron-cache-claude-printingpress-abc123",
+			Target: "/home/agent/.local/share/printingpress",
+			Named:  true,
+		}},
+		Command: []string{"codex"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	// A named volume's source must be emitted verbatim (NOT filepath.Abs'd):
+	// a path-resolved volume name would become an absolute host path and
+	// turn the named volume into a bind mount.
+	want := "aileron-cache-claude-printingpress-abc123:/home/agent/.local/share/printingpress"
+	found := false
+	for i := 0; i < len(runner.args)-1; i++ {
+		if runner.args[i] == "--volume" && runner.args[i+1] == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("named volume spec %q missing from args: %#v", want, runner.args)
+	}
+}
+
+func TestRunMountsReadOnlyNamedVolume(t *testing.T) {
+	pinHostOSDarwin(t)
+	dir := t.TempDir()
+	runner := &recordingRunner{}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Run(context.Background(), RunOptions{
+		Image:   "aileron-sandbox-base:test",
+		WorkDir: dir,
+		Volumes: []Volume{{
+			Source:   "aileron-cache-x",
+			Target:   "/data",
+			Named:    true,
+			ReadOnly: true,
+		}},
+		Command: []string{"codex"},
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	want := "aileron-cache-x:/data:ro"
+	found := false
+	for i := 0; i < len(runner.args)-1; i++ {
+		if runner.args[i] == "--volume" && runner.args[i+1] == want {
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatalf("read-only named volume spec %q missing from args: %#v", want, runner.args)
+	}
+}
+
 func TestRunRejectsIncompleteAdditionalVolume(t *testing.T) {
 	_, err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Run(context.Background(), RunOptions{
 		Image:   "aileron-sandbox-base:test",
@@ -1389,6 +1453,53 @@ func TestStopContainerEmptyNameIsNoOp(t *testing.T) {
 	}
 	if len(runner.calls) != 0 {
 		t.Fatalf("expected no runner calls for empty name; got %v", runner.calls)
+	}
+}
+
+func TestRemoveVolumeIssuesVolumeRm(t *testing.T) {
+	runner := &recordingRunner{}
+	if err := RemoveVolume(context.Background(), runner, "docker", "aileron-cache-x", io.Discard, io.Discard); err != nil {
+		t.Fatalf("RemoveVolume: %v", err)
+	}
+	want := []string{"volume", "rm", "aileron-cache-x"}
+	if runner.name != "docker" || !reflect.DeepEqual(runner.args, want) {
+		t.Fatalf("runner = %s %#v, want docker %#v", runner.name, runner.args, want)
+	}
+}
+
+func TestRemoveVolumeEmptyNameIsNoOp(t *testing.T) {
+	runner := &callRecordingRunner{errs: []error{errors.New("must not run")}}
+	if err := RemoveVolume(context.Background(), runner, "docker", "", io.Discard, io.Discard); err != nil {
+		t.Fatalf("RemoveVolume empty name = %v, want nil", err)
+	}
+	if len(runner.calls) != 0 {
+		t.Fatalf("expected no runner calls for empty name; got %v", runner.calls)
+	}
+}
+
+func TestRemoveVolumeSuppressesAlreadyGone(t *testing.T) {
+	cases := []string{
+		"Error: No such volume: aileron-cache-x\n",
+		"Error response from daemon: get aileron-cache-x: not found\n",
+	}
+	for _, stderr := range cases {
+		var userStderr bytes.Buffer
+		runner := &stderrWritingRunner{stderrText: stderr, errReturn: errors.New("exit status 1")}
+		if err := RemoveVolume(context.Background(), runner, "docker", "aileron-cache-x", io.Discard, &userStderr); err != nil {
+			t.Fatalf("RemoveVolume = %v, want nil (already-gone suppressed) for %q", err, stderr)
+		}
+	}
+}
+
+func TestRemoveVolumeGenuineErrorReturned(t *testing.T) {
+	wantErr := errors.New("exit status 1")
+	runner := &stderrWritingRunner{
+		stderrText: "Error response from daemon: volume is in use\n",
+		errReturn:  wantErr,
+	}
+	err := RemoveVolume(context.Background(), runner, "docker", "aileron-cache-x", io.Discard, io.Discard)
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("RemoveVolume error = %v, want %v (genuine error not suppressed)", err, wantErr)
 	}
 }
 


### PR DESCRIPTION
## Summary

Stateful, DB-backed CLIs run in the one-shot Docker sandbox (PrintingPress' SQLite/FTS5 store, `gh` state, search caches) rebuilt their local store from scratch on every cold start, because the container is ephemeral and nothing survived teardown. This adds an Aileron-managed persistent cache volume so the store carries across launches.

Declare caches under `customizations.aileron.caches`:

```jsonc
"customizations": { "aileron": { "caches": [
  { "name": "printingpress", "path": "/home/agent/.local/share/printingpress" },
  { "name": "gh", "path": "/home/agent/.config/gh" }
]}}
```

Each cache mounts a named Docker volume at its `path`, keyed by `(agent, workspace identity, cache name)`. The same agent in the same project reuses its store; a different workspace gets a fresh one (so re-auth to a different account is clean). Docker auto-provisions the volume on first mount.

Design per the operator-settled triage of #1190:
- **Q1** Narrow, standalone Aileron-managed volume under `customizations.aileron`, decoupled from any binding descriptor. A new `Volume.Named` mount type carries it (host bind mounts unchanged).
- **Q2** Plaintext-on-host, acceptable for the v4 single-user/local posture (operator = user), consistent with ADR-0011. No sealed mount in this PR.
- **Q3** Keyed by (CLI, workspace identity, cache name). Eviction is manual via `aileron sandbox clear --agent=<agent>`; no max-age, no auto-evict. The optional postStart incremental sync is deferred (out of scope).

### Changes
- `composition`: parse + validate `customizations.aileron.caches` (absolute Unix container path, Docker-safe name, unique names/paths); `CacheVolumeName` derivation and `Plan.ResolveCaches`.
- `container`: `Volume.Named` so `runArgs` emits `--volume <name>:<target>` without `filepath.Abs`; `RemoveVolume` with idempotent already-gone suppression.
- `launch`: `launchSandbox` resolves declared caches to named-volume mounts; `enclosingDirMount` skips named volumes so an MCP file is never written into a Docker volume name mistaken for a host dir.
- `cmd`: `aileron sandbox clear --agent` for manual eviction; a `cache:` line in `sandbox plan`.
- Docs: sandbox-composition guide gets a "Persist a CLI's Local Store with Caches" + "Clear a Cache" section; CLI reference adds `sandbox clear`.

## Test plan
- `go test ./internal/sandbox/... ./internal/launch/... ./cmd/aileron/...` — all green; coverage stays above the repo bar (composition 93.8%, container 91.0%, cmd 85.4%, launch 87.4%).
- New table tests cover: caches parse + every validation error, deterministic/workspace-keyed/agent-keyed volume naming, `ResolveCaches`, named-volume argv construction (RW + RO, no path resolution), `RemoveVolume` (argv, empty-name no-op, already-gone suppression, genuine error), the `clear` command (removes the matching volumes, requires `--agent`, no-caches no-op, remove-failure exit code), `sandboxCacheMounts` wiring, and the `enclosingDirMount` named-volume skip.
- Cross-platform regression: cache-path validation uses the `path` package (not `filepath`), so a `/...` container path validates as absolute on a Windows host. Locked by `TestValidateCachesAcceptsUnixContainerPath` (from CodeRabbit review).

Closes #1190

🤖 Generated with [Claude Code](https://claude.com/claude-code)
