### PR TITLE
fix(ci): wait for concurrently-built base tag in sandbox-agents

### DIFF
--- a/.github/workflows/sandbox-agents.yml
+++ b/.github/workflows/sandbox-agents.yml
@@ -100,11 +100,21 @@ jobs:
       # `latest` on v* tag builds, and a floating `edge` on workflow_dispatch. A
       # v* build FROMs the version-pinned tag so the per-agent image
       # deterministically composes onto THIS release's base, not whatever
-      # `latest` happens to point at (the base and per-agent workflows run
-      # concurrently on the same tag push). workflow_dispatch FROMs `edge`, the
-      # base tip just published off the same dev branch. Gate on
-      # `docker manifest inspect` so a missing base surfaces a precise error
-      # naming the absent tag instead of an opaque FROM failure deep in the build.
+      # `latest` happens to point at.
+      #
+      # sandbox-base.yml and this workflow are two SEPARATE workflows, both
+      # triggered directly by `push: tags: v*`, so on a tag push they start
+      # CONCURRENTLY. This step therefore cannot assume the base tag is already
+      # published: when the agent build reaches it before sandbox-base.yml has
+      # finished its multi-arch push, the base tag is briefly absent. So poll
+      # `docker manifest inspect` on a bounded retry loop, WAITING for the base
+      # tag to appear before FROM-ing it (issue #1256). A base that genuinely
+      # never publishes still surfaces the precise error naming the absent tag
+      # after the timeout, instead of an opaque FROM failure deep in the build.
+      # workflow_dispatch FROMs `edge`, the base tip just published off the same
+      # dev branch (the watcher in sandbox-agents-watch.yml dispatches this
+      # workflow directly, and an `edge` published by an earlier base run is
+      # already present, so the poll returns immediately).
       #
       # On pull_request nothing is published and the GHCR base may not exist yet
       # (no v* release has run sandbox-base.yml). Build the base locally from the
@@ -114,6 +124,13 @@ jobs:
       # + smoke path self-contained.
       - name: Resolve and verify base image
         id: base
+        env:
+          # Bounded wait for the concurrently-building base tag to publish.
+          # ~10 min at 15s intervals (40 attempts) comfortably covers a
+          # multi-arch base build + push while still failing fast enough on a
+          # base that never publishes.
+          BASE_WAIT_ATTEMPTS: "40"
+          BASE_WAIT_INTERVAL_SECONDS: "15"
         run: |
           set -euo pipefail
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
@@ -124,11 +141,17 @@ jobs:
             BASE_REF=""
           fi
           if [[ -n "${BASE_REF}" ]]; then
-            echo "Verifying published base image ${BASE_REF} exists..."
-            if ! docker manifest inspect "${BASE_REF}" >/dev/null 2>&1; then
-              echo "::error::Base image ${BASE_REF} not found in GHCR. The sandbox-base workflow (sandbox-base.yml) publishes the release tag and 'latest' on v* tag builds, and 'edge' on workflow_dispatch; run sandbox-base for this ref before building per-agent images." >&2
-              exit 1
-            fi
+            echo "Waiting for published base image ${BASE_REF} (up to ${BASE_WAIT_ATTEMPTS} attempts, ${BASE_WAIT_INTERVAL_SECONDS}s apart)..."
+            attempt=1
+            while ! docker manifest inspect "${BASE_REF}" >/dev/null 2>&1; do
+              if [[ "${attempt}" -ge "${BASE_WAIT_ATTEMPTS}" ]]; then
+                echo "::error::Base image ${BASE_REF} not found in GHCR after ${BASE_WAIT_ATTEMPTS} attempts over $((BASE_WAIT_ATTEMPTS * BASE_WAIT_INTERVAL_SECONDS))s. The sandbox-base workflow (sandbox-base.yml) publishes the release tag and 'latest' on v* tag builds, and 'edge' on workflow_dispatch; it runs concurrently with this workflow on the same tag push, so this step waits for it. If it never appears, confirm sandbox-base ran for this ref." >&2
+                exit 1
+              fi
+              echo "Base image ${BASE_REF} not present yet (attempt ${attempt}/${BASE_WAIT_ATTEMPTS}); retrying in ${BASE_WAIT_INTERVAL_SECONDS}s..."
+              sleep "${BASE_WAIT_INTERVAL_SECONDS}"
+              attempt=$((attempt + 1))
+            done
             echo "base_image=${BASE_REF}" >> "$GITHUB_OUTPUT"
             echo "Using published base image ${BASE_REF}."
           else

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -53,6 +53,8 @@ Aileron CI publishes one multi-arch image per agent to GHCR. Each image is baked
 
 Each image is built for `linux/amd64` and `linux/arm64`, so a `docker pull` resolves the manifest for your platform automatically.
 
+The base image (`sandbox-base.yml`) and the per-agent images (`sandbox-agents.yml`) are two separate workflows, both triggered directly by a `v*` tag push, so they run concurrently on the same tag. A per-agent build `FROM`s the version-pinned base tag, so before that `FROM` it waits for the base tag to publish: it polls the registry on a bounded retry loop until the concurrently-building base tag appears. A base that never publishes surfaces a precise timeout error naming the absent tag rather than failing mid-build.
+
 The tag scheme is `<aileron-version>-<agent-cli-version>` plus two floating tags: `latest`, moved only by a `v*` tag release, and `edge`, moved by a `workflow_dispatch` publish off `main`. The `<aileron-version>` is the Aileron release the image was built from. The `<agent-cli-version>` is the agent CLI version baked into the image, resolved at build time from the installed package. A git-traceability tag `git-<sha>` is also published.
 
 Pull the most recent release (`latest`), or the latest dev publish off `main` (`edge`):


### PR DESCRIPTION
## Summary

`sandbox-base.yml` and `sandbox-agents.yml` are two **separate** workflows, both triggered directly by `push: tags: v*`, so they start **concurrently** on a tag push. The "Resolve and verify base image" step in `sandbox-agents.yml` did a single `docker manifest inspect "${BASE_REF}"` and exited `1` immediately if the base tag was not present yet. When the agent build reached that step before `sandbox-base.yml` finished its multi-arch base push, the inspect failed and the whole `agent-images` job failed. That is the release-CI flakiness reported in #1256.

This replaces the one-shot gate with a **bounded poll/retry loop** on the publishing paths (`v*` tags and `workflow_dispatch`):

- Polls `docker manifest inspect` every 15s, up to 40 attempts (~10 min), waiting for the concurrently-building base tag to appear before `FROM`-ing it.
- Preserves the existing precise error message as the **timeout** failure, so a base that genuinely never publishes still surfaces it (now naming the elapsed wait).
- Leaves the **PR path** (local base build) completely untouched — it never polls.
- Updates the now-inaccurate inline comment and the `sandbox-agent-images.md` doc note to describe the wait.

Deliberately not restructured into a cross-workflow `needs:`/`workflow_run` dependency: that would collapse two separately-triggered workflows or re-root the agent trigger on `workflow_run` (losing the tag ref and complicating the PR/dispatch matrix paths), and would break the `sandbox-agents-watch.yml` freshness path that dispatches `sandbox-agents.yml` directly. The wait-for-tag poll is the minimal deterministic fix and keeps both workflows independently dispatchable.

## Test plan

This is a CI-workflow-only change (no Go/spec code), so the behavioral gate is the embedded shell logic. Verified the extracted `Resolve and verify base image` script against a mocked `docker manifest inspect` across all branches:

- **tag, base present immediately** → resolves `base_image=...:v0.0.1`, no wait.
- **tag, base appears at attempt 5** (the race this fixes) → waits, then resolves.
- **tag, base never appears** → fails with the precise timeout error after the bounded attempts.
- **workflow_dispatch** → resolves `...:edge`.
- **pull_request** → builds local base, never polls (untouched path).

`actionlint` passes on the modified workflow; YAML parses cleanly.

Closes #1256
