### PR TITLE
feat(proxybinding): accept emit_mechanism B with a per-binding sentinel

### DIFF
--- a/docs/src/content/docs/guides/binding-descriptors.md
+++ b/docs/src/content/docs/guides/binding-descriptors.md
@@ -27,13 +27,21 @@ Each binding is a quad plus scheme-specific fields.
 - `host` is the upstream host matched at the proxy boundary. It is an exact host (`api.linear.app`) or a single leading-wildcard form (`*.example.com`). Ports are not part of the pattern.
 - `credential_ref` is a vault credential reference the daemon resolves at injection time. It is a connector-style binding name (`<kind>/<service>/<identity>`) or a user-level reference (`user/<service>`), the namespace `aileron auth <service>` writes. It is never the credential bytes. The descriptor names where the credential lives, never its value.
 - `scheme` is one of the closed injection-scheme set: `bearer`, `basic`, `header-template`, `query-param`, `sigv4-resign`. An unknown scheme is a load-time error. `sigv4-resign` is enumerated but not yet implemented.
-- `emit_mechanism` declares how the credential reaches egress. `A` injects the credential unconditionally at the proxy. `B` is sentinel-swap, where the launcher plants a non-secret sentinel the proxy swaps for the real credential. The field is optional and defaults to `A`. Mechanism `B` is rejected at load time until the sentinel-swap egress path ([#1196](https://github.com/ALRubinger/aileron/issues/1196)) is wired, because a descriptor must never validate against a mechanism no proxy code can honor. Today only `A` is accepted; an unknown value is also a load-time error.
+- `emit_mechanism` declares how the credential reaches egress. `A` injects the credential unconditionally at the proxy. `B` is sentinel-swap, where the launcher plants a non-secret sentinel the proxy swaps for the real credential. The field is optional and defaults to `A`. A value outside the closed set (`A`, `B`) is a load-time error. A mechanism-`B` binding must declare a `sentinel` block. A mechanism-`A` binding must declare none.
 
 Scheme-specific fields:
 
 - `username` is required for the `basic` scheme. It is the non-secret HTTP basic-auth username (e.g. `x-access-token` for git-over-HTTPS). The token always rides in the password field.
 - `header` and `template` are required for the `header-template` scheme. `header` is the header name to set. `template` is the verbatim header value with a `{token}` placeholder the daemon substitutes with the credential at injection time.
 - `query_param` is required for the `query-param` scheme. It is the query-parameter name the credential is set on.
+
+Mechanism-`B` fields:
+
+- `sentinel` is a nested block required for the `B` emit mechanism and forbidden for `A`. It has two fields, both non-secret.
+- `sentinel.value` is the format-mimicking placeholder the launcher plants inside the container and the proxy recognizes at egress. The value is non-secret and safe to commit. Presenting it upstream authenticates nothing. The proxy swaps it for the real credential before the request leaves the boundary.
+- `sentinel.env` is the environment-variable name the launcher sets to `sentinel.value` inside the container. This is what generalizes the plant target, so the launcher is not hardcoded to one CLI's variable.
+
+The plant target is an environment-variable name only. A CLI that reads its token from a config file rather than an environment variable is not yet expressible. `sentinel.env` covers `gh` and the common token-in-environment case.
 
 Decoding is strict. An unknown YAML key is an error, not a silently ignored field, so a typo fails fast instead of shipping a binding that does nothing. A wrong or missing `version` is an error so the format can evolve without a silent misparse.
 
@@ -61,6 +69,24 @@ aileron auth linear
 The built-in Linear descriptor (shown at the top of this page) then seals every request to `api.linear.app`. The Linear CLI inside the sandbox holds no key. The daemon resolves `user/linear` and injects it at egress. If the vault has no `user/linear` entry, the binding still matches but resolution fails closed: no header is added and no secret leaks. An unauthenticated request behaves exactly as it would with no binding configured.
 
 This is the whole generalization proof. Linear is a tool nobody special-cased in the proxy. It is sealed entirely by a descriptor. Adding another vendor is a new descriptor, never new proxy code.
+
+## Worked example: a mechanism-B sentinel
+
+Some CLIs refuse to issue a request when they hold no token. They validate locally and short-circuit, so the proxy never sees an outbound request to seal. `gh` is the canonical case. Mechanism `B` closes this gap. The launcher plants a non-secret placeholder under an environment variable the CLI reads, the CLI's local check passes, and the CLI issues the request. The proxy recognizes the placeholder at egress and swaps in the real credential.
+
+```yaml
+version: v1
+bindings:
+  - host: api.github.com
+    credential_ref: user/github
+    scheme: bearer
+    emit_mechanism: B
+    sentinel:
+      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA
+      env: GH_TOKEN
+```
+
+This example is the schema only. The descriptor loader validates the `sentinel` block here. The egress code that plants the value and swaps it at the proxy boundary is tracked separately in [issue #1247](https://github.com/ALRubinger/aileron/issues/1247). The `value` is a placeholder with no authority, so it is safe to commit in a shipped descriptor.
 
 ## Out of scope: stateful CLI caches
 

--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -25,14 +25,14 @@
 // # Scope
 //
 // This package defines the descriptor format and the two-layer loader.
-// It does not implement the binding-table consult (#1193), the injectors
-// (#1194), or the sentinel-swap mechanism (#1196, mechanism B); it only
-// validates the emit_mechanism field against the implemented set. Because
-// the sentinel-swap egress path is not yet wired (#1196), this loader
-// accepts only mechanism "A" and rejects emit_mechanism "B" at load time;
-// "B" becomes a valid descriptor value once #1196 lands. Persisting a
-// stateful CLI's local cache across ephemeral sandboxes is out of scope
-// and tracked separately (#1190).
+// It does not implement the binding-table consult (#1193) or the injectors
+// (#1194). It accepts both emit mechanisms: mechanism "A" (inject at the
+// proxy) and mechanism "B" (sentinel-swap). A mechanism-B binding declares
+// a non-secret `sentinel` block (a placeholder value plus the env-var name
+// the launcher plants it under); this loader validates that schema while
+// the egress code that consumes those fields lands separately (#1247).
+// Persisting a stateful CLI's local cache across ephemeral sandboxes is out
+// of scope and tracked separately (#1190).
 //
 // [ADR-0019]: https://docs.withaileron.ai/adr/0019-v4-https-data-plane
 package proxybinding
@@ -58,16 +58,14 @@ const SchemaVersion = "v1"
 // may declare at load time. Mechanism "A" injects unconditionally at the
 // proxy (the client emits a no-credential request). Mechanism "B" is
 // sentinel-swap (the launcher plants a non-secret sentinel the proxy swaps
-// for the real credential at egress), and is intentionally absent from
-// this set: until the sentinel-swap egress path is wired (#1196), a
-// descriptor that declares emit_mechanism "B" is rejected at load time
-// rather than accepted into a table no code can honor. This keeps the
-// fail-closed posture: a descriptor never validates against a mechanism
-// the proxy cannot enforce. The canonical internal/binding.EmitMechanismB
-// constant is kept for the future #1196 code; this loader simply does not
-// accept it yet.
+// for the real credential at egress); a mechanism-B binding must declare a
+// `sentinel` block naming the placeholder value and the env-var name the
+// launcher plants it under. A value outside this set (e.g. "C") is a
+// load-time error, so a descriptor never validates against a mechanism the
+// proxy cannot enforce.
 var EmitMechanisms = map[string]struct{}{
 	string(binding.EmitMechanismA): {},
+	string(binding.EmitMechanismB): {},
 }
 
 // Descriptor is a parsed, versioned binding-descriptor document. One
@@ -113,12 +111,21 @@ type Entry struct {
 	Scheme string `yaml:"scheme"`
 
 	// EmitMechanism declares how the credential reaches egress: "A"
-	// (inject at the proxy) or "B" (sentinel-swap, #1196). Optional;
-	// empty defaults to "A". Until the sentinel-swap egress path is wired
-	// (#1196), only "A" is accepted: "B" is rejected at load time rather
-	// than admitted into a table no code can honor. Any other value is
-	// also a load-time error.
+	// (inject at the proxy) or "B" (sentinel-swap). Optional; empty
+	// defaults to "A". A mechanism-B binding must declare a non-empty
+	// [Entry.Sentinel] block; a mechanism-A binding (explicit or defaulted)
+	// must declare none. Any value outside the closed set is a load-time
+	// error.
 	EmitMechanism string `yaml:"emit_mechanism"`
+
+	// Sentinel is the mechanism-B placeholder declaration: the non-secret
+	// value the launcher plants inside the container and the env-var name it
+	// plants under. It is required and non-empty for mechanism "B" and
+	// forbidden for mechanism "A" (a stray sentinel on a mechanism-A binding
+	// is a load-time error, since the field is meaningless without B). It is
+	// a pointer so an absent block is distinguishable from a present block
+	// with empty fields. See [Sentinel].
+	Sentinel *Sentinel `yaml:"sentinel"`
 
 	// Username is the non-secret HTTP basic-auth username, required only
 	// for the basic scheme (e.g. "x-access-token" for git-over-HTTPS).
@@ -138,6 +145,30 @@ type Entry struct {
 	// QueryParam is the query-parameter name to set, required only for the
 	// query-param scheme.
 	QueryParam string `yaml:"query_param"`
+}
+
+// Sentinel is the per-binding mechanism-B placeholder declaration. It makes
+// both the placeholder value and its plant location data rather than Go
+// constants, so a token-in-env CLI is expressible purely by a descriptor.
+//
+// Every field is non-secret. The Value carries no authority: presenting it
+// upstream authenticates nothing, so it is safe to embed in source, commit,
+// and print in logs. The launcher plants Value under the Env env-var name
+// inside the container so the CLI's local validation passes and it issues
+// the request; the proxy then recognizes Value at egress and swaps in the
+// real credential. The placeholder bytes never reach upstream.
+type Sentinel struct {
+	// Value is the non-secret, format-mimicking placeholder the launcher
+	// plants and the proxy recognizes (e.g.
+	// "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"). It is required and
+	// non-empty for mechanism "B". It is non-secret and safe to commit.
+	Value string `yaml:"value"`
+
+	// Env is the environment-variable name the launcher sets to [Sentinel.Value]
+	// inside the container (e.g. "GH_TOKEN"). It is required and non-empty for
+	// mechanism "B". It generalizes the plant target so the launcher is not
+	// hardcoded to a single CLI's env var.
+	Env string `yaml:"env"`
 }
 
 // TokenPlaceholder is the substring a header-template's Template
@@ -210,9 +241,28 @@ func (e *Entry) Validate() error {
 		mech = string(binding.EmitMechanismA)
 	}
 	if _, ok := EmitMechanisms[mech]; !ok {
-		// "B" (sentinel-swap) is rejected at load time until #1196 wires
-		// the egress path; only "A" is accepted today.
-		return fmt.Errorf("unsupported emit_mechanism %q (only %q is accepted until sentinel-swap (#1196) lands)", e.EmitMechanism, string(binding.EmitMechanismA))
+		return fmt.Errorf("unknown emit_mechanism %q (want one of %q or %q)", e.EmitMechanism, string(binding.EmitMechanismA), string(binding.EmitMechanismB))
+	}
+
+	// Mechanism B requires a non-empty sentinel block (value + env);
+	// mechanism A (explicit or defaulted) forbids one. The sentinel names
+	// the placeholder the launcher plants and the env var it plants it
+	// under, so the field is meaningless without B (fail closed).
+	switch mech {
+	case string(binding.EmitMechanismB):
+		if e.Sentinel == nil {
+			return fmt.Errorf("emit_mechanism %q requires a sentinel block", string(binding.EmitMechanismB))
+		}
+		if e.Sentinel.Value == "" {
+			return fmt.Errorf("emit_mechanism %q requires a non-empty sentinel.value", string(binding.EmitMechanismB))
+		}
+		if e.Sentinel.Env == "" {
+			return fmt.Errorf("emit_mechanism %q requires a non-empty sentinel.env", string(binding.EmitMechanismB))
+		}
+	default:
+		if e.Sentinel != nil {
+			return fmt.Errorf("emit_mechanism %q must not declare a sentinel block (sentinel applies only to mechanism %q)", string(binding.EmitMechanismA), string(binding.EmitMechanismB))
+		}
 	}
 
 	switch e.Scheme {

--- a/internal/proxybinding/descriptor_test.go
+++ b/internal/proxybinding/descriptor_test.go
@@ -120,11 +120,37 @@ func TestParse_Errors(t *testing.T) {
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: C\n",
 		},
 		{
-			// Mechanism B (sentinel-swap) is rejected at load time until
-			// #1196 wires the egress path: a descriptor must not validate
-			// against a mechanism no proxy code can honor (fail-closed).
-			name: "unsupported emit_mechanism B (sentinel-swap, #1196 not yet wired)",
+			// Mechanism B requires a sentinel block; a bare "B" with no
+			// sentinel is a load-time error (fail-closed).
+			name: "emit_mechanism B without sentinel block",
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: B\n",
+		},
+		{
+			// Mechanism B with a sentinel block missing its value.
+			name: "emit_mechanism B with empty sentinel.value",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: B\n    sentinel:\n      env: GH_TOKEN\n",
+		},
+		{
+			// Mechanism B with a sentinel block missing its env.
+			name: "emit_mechanism B with empty sentinel.env",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: B\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n",
+		},
+		{
+			// A stray sentinel on an explicit mechanism-A binding is an error.
+			name: "emit_mechanism A with a stray sentinel block",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: A\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n",
+		},
+		{
+			// A stray sentinel on a defaulted (omitted) mechanism-A binding
+			// is an error.
+			name: "defaulted mechanism A with a stray sentinel block",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n",
+		},
+		{
+			// Strict decode recurses into the nested sentinel mapping: an
+			// unknown key inside the block is a load-time error.
+			name: "unknown key nested under sentinel",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: B\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n      bogus: nope\n",
 		},
 		{
 			name: "header-template missing header",
@@ -180,17 +206,18 @@ func TestParse_Errors(t *testing.T) {
 	}
 }
 
-// TestParse_EmitMechanismBRejectedUntil1196 pins the operator decision that
-// emit_mechanism "B" (sentinel-swap) is rejected at load time until the
-// sentinel-swap egress path (#1196) is wired: a descriptor must never
-// validate against a mechanism no proxy code can honor. Mechanism "A" (the
-// implemented path) and the empty default (which means "A") must still
-// parse. This is the fail-closed contract; it is intentionally decoupled
-// from the table above so the policy is explicit and survives refactors.
-func TestParse_EmitMechanismBRejectedUntil1196(t *testing.T) {
+// TestParse_EmitMechanismBSentinelSchema pins the mechanism-B schema this
+// issue freezes (#1246). A well-formed mechanism-B descriptor declares a
+// sentinel block with both value and env, and those fields round-trip onto
+// the parsed Entry. A mechanism-B descriptor missing the block or either
+// field is rejected, and a mechanism-A descriptor that carries a stray
+// sentinel is rejected. Mechanism "A" and the empty default still parse.
+// This is the fail-closed contract; it is intentionally decoupled from the
+// table-driven cases so the policy is explicit and survives refactors.
+func TestParse_EmitMechanismBSentinelSchema(t *testing.T) {
 	const base = "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n"
 
-	// "A" and the empty default are accepted.
+	// "A" and the empty default are accepted with no sentinel.
 	if _, err := Parse([]byte(base + "    emit_mechanism: A\n")); err != nil {
 		t.Errorf("emit_mechanism A: Parse = %v, want nil", err)
 	}
@@ -198,15 +225,31 @@ func TestParse_EmitMechanismBRejectedUntil1196(t *testing.T) {
 		t.Errorf("emit_mechanism omitted (defaults to A): Parse = %v, want nil", err)
 	}
 
-	// "B" is rejected at load time, and the canonical constant for it is
-	// the value the rejected descriptor declares.
-	bYAML := base + "    emit_mechanism: " + string(binding.EmitMechanismB) + "\n"
-	if _, err := Parse([]byte(bYAML)); err == nil {
-		t.Fatalf("emit_mechanism B: Parse = nil error, want load-time rejection")
+	// A well-formed mechanism-B descriptor parses and the sentinel fields
+	// round-trip onto the Entry.
+	const wantValue = "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"
+	const wantEnv = "GH_TOKEN"
+	bYAML := base + "    emit_mechanism: " + string(binding.EmitMechanismB) + "\n" +
+		"    sentinel:\n      value: " + wantValue + "\n      env: " + wantEnv + "\n"
+	d, err := Parse([]byte(bYAML))
+	if err != nil {
+		t.Fatalf("well-formed mechanism B: Parse = %v, want nil", err)
+	}
+	e := d.Bindings[0]
+	if e.EmitMechanism != string(binding.EmitMechanismB) {
+		t.Errorf("emit_mechanism = %q, want %q", e.EmitMechanism, string(binding.EmitMechanismB))
+	}
+	if e.Sentinel == nil {
+		t.Fatalf("sentinel block = nil, want populated")
+	}
+	if e.Sentinel.Value != wantValue {
+		t.Errorf("sentinel.value = %q, want %q", e.Sentinel.Value, wantValue)
+	}
+	if e.Sentinel.Env != wantEnv {
+		t.Errorf("sentinel.env = %q, want %q", e.Sentinel.Env, wantEnv)
 	}
 
-	// The canonical constant is unchanged for future #1196 code even
-	// though the loader does not accept it yet.
+	// The canonical constant is the value mechanism-B descriptors declare.
 	if string(binding.EmitMechanismB) != "B" {
 		t.Errorf("binding.EmitMechanismB = %q, want %q", string(binding.EmitMechanismB), "B")
 	}
@@ -224,5 +267,21 @@ func TestParse_NoSecretBytesInDescriptor(t *testing.T) {
 	// The credential-ref is a vault path, never a token.
 	if !strings.HasPrefix(e.CredentialRef, "user/") {
 		t.Errorf("credential_ref = %q, expected a vault reference, not a secret", e.CredentialRef)
+	}
+
+	// A mechanism-B sentinel value is a recognizable placeholder, not a
+	// secret: it embeds the reserved "AILERONSENTINEL" marker so a reader
+	// (or a log) can tell at a glance it carries no authority.
+	const bYAML = "version: v1\nbindings:\n  - host: api.github.com\n    credential_ref: user/github\n    scheme: bearer\n    emit_mechanism: B\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n"
+	db, err := Parse([]byte(bYAML))
+	if err != nil {
+		t.Fatalf("Parse mechanism B: %v", err)
+	}
+	sentinel := db.Bindings[0].Sentinel
+	if sentinel == nil {
+		t.Fatalf("sentinel = nil, want populated")
+	}
+	if !strings.Contains(sentinel.Value, "AILERONSENTINEL") {
+		t.Errorf("sentinel.value = %q, expected a recognizable placeholder, not a secret", sentinel.Value)
 	}
 }


### PR DESCRIPTION
## Summary

Un-gates emit-mechanism B (sentinel-swap) in the `internal/proxybinding` descriptor loader now that the egress-path issue is no longer blocking, and makes the sentinel a per-binding **descriptor field** so both the placeholder value and its plant location are data, not Go constants.

A mechanism-B binding now declares a nested `sentinel:` block with exactly two non-secret fields:
- `value` — the format-mimicking placeholder the launcher plants and the proxy recognizes (e.g. `ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA`).
- `env` — the env-var name the launcher sets to `value` inside the container (e.g. `GH_TOKEN`).

The `sentinel.env` field generalizes the plant target so a non-GitHub token-in-env CLI is expressible purely by data.

This issue is **schema + validation + load-time acceptance + guide only**. It does not wire any egress or planter behavior. The egress code that consumes `sentinel.value`/`sentinel.env` lands in #1247. `ToHostBinding`'s existing `WithEmitMechanismB()` path is unchanged.

### Changes
- `EmitMechanisms` map gains `binding.EmitMechanismB`; the stale "rejected until #1196" branch and doc prose are removed.
- New `Sentinel` struct (`value`/`env`) and pointer `Entry.Sentinel` field (pointer so block-absent is distinguishable from block-present-with-empty-fields).
- Load-time rules: mechanism B requires a non-empty `sentinel.value` AND `sentinel.env` (distinct errors for missing block, empty value, empty env); mechanism A (explicit or defaulted) forbids any sentinel block; unknown mechanisms (e.g. `C`) still error.
- Strict YAML decode recurses into the nested block, so an unknown key under `sentinel` is a load-time error (contract-pinned by a test).
- Guide updated: drops the #1196-rejection prose, documents the `sentinel` block, notes the accepted gap that the plant target is an env-var name only, and adds a worked mechanism-B `gh` example framed as schema-only.

### Accepted gap
Plant target is an env-var name only. File-based / config-file sentinel planting is explicitly out of scope; `sentinel.env` covers `gh` and the common token-in-env CLI case. This is documented in the guide.

## Test plan
- `go test ./internal/proxybinding/...` green; package coverage 94.6%, `Entry.Validate` at 100% (all new B branches: missing block, empty value, empty env, stray-on-A; plus nested-unknown-key strict-decode).
- `go test ./internal/binding/...` green (no source change there; sanity check `ToHostBinding` did not regress).
- `go vet ./internal/proxybinding/...` clean; `internal` module builds.
- CodeRabbit review: 0 findings.
- Verified no lingering "rejected until #1196" / "only mechanism A" wording in touched files; no em-dashes in the guide.

Closes #1246
