### PR TITLE
docs(proxybinding): correct LoadHostBindings to two-layer loader

### DIFF
--- a/internal/proxybinding/binding.go
+++ b/internal/proxybinding/binding.go
@@ -51,7 +51,7 @@ func (e *Entry) ToHostBinding() (binding.HostBinding, error) {
 }
 
 // LoadHostBindings is the convenience the apiServer wiring calls: it loads
-// the three merged descriptor layers and adapts them to the canonical
+// the two merged descriptor layers (built-in -> user) and adapts them to the canonical
 // binding table in one step. A load or adaptation error is surfaced rather
 // than swallowed so a malformed descriptor fails construction loudly
 // instead of silently shipping an empty (passthrough) table.


### PR DESCRIPTION
## Summary

The `LoadHostBindings` doc comment in `internal/proxybinding/binding.go` said it "loads the three merged descriptor layers", but `loader.go` `Load()` applies exactly two layers: built-in defaults (`parseBuiltinDefaults`) then an optional user file. There is no project layer. The guide and `internal/app/app.go` comments were already corrected to two-layer; this fixes the remaining drift assigned to Unit 6, which #1263 did not address.

Pure doc-comment correction, no behavior change.

## Test plan

- `go build ./internal/proxybinding/...` — passes
- `go test ./internal/proxybinding/...` — passes

No regression test applies; this is a comment-only change with no observable behavior.

Closes #1257