### PR TITLE
chore(proxybinding): rename emit mechanisms to inject/sentinel-swap

### DIFF
--- a/docs/src/content/docs/adr/0019-v4-https-data-plane.md
+++ b/docs/src/content/docs/adr/0019-v4-https-data-plane.md
@@ -91,17 +91,17 @@ The initial implementation lands four schemes fully (`bearer`, `basic`, `header-
 
 #### Emit mechanisms
 
-The substrate emits the injected credential to the upstream by one of two mechanisms.
+The substrate emits the injected credential to the upstream by one of two mechanisms. A binding descriptor names the mechanism in its `emit_mechanism` field, with the value `inject` or `sentinel-swap`.
 
-The first is empty or no-op credential config. The agent holds no credential material and the request carries no placeholder; the proxy adds the credential at the TLS boundary on a request that arrived without one.
+The first is `inject`. The agent holds no credential material and the request carries no placeholder. The proxy adds the credential at the TLS boundary on a request that arrived without one. This is the default for a binding that declares no `emit_mechanism`.
 
-The second is sentinel-swap. The agent holds a non-secret, format-mimicking placeholder that looks like a credential of the right shape but carries no secret value. The agent puts the sentinel where the credential would go, and the proxy swaps the sentinel for the real secret at egress. This covers clients that refuse to issue a request unless a syntactically valid credential is present.
+The second is `sentinel-swap`. The agent holds a non-secret, format-mimicking placeholder that looks like a credential of the right shape but carries no secret value. The agent puts the sentinel where the credential would go, and the proxy swaps the sentinel for the real secret at egress. This covers clients that refuse to issue a request unless a syntactically valid credential is present.
 
 Both mechanisms preserve the sealing claim. The agent only ever holds the sentinel, which is useless on its own, so the "agent never sees raw secret bytes" decision above still holds. Raw credential bytes are still never written to container env, image layers, mounted project files, or command-line args; the swap happens at the proxy, not in the container.
 
 #### Sealability rule and residual exception
 
-A credential is proxy-sealable if and only if some scheme plus emit-mechanism combination completes its request at the proxy boundary. Most credentials are sealable: pick the scheme the service expects, pick empty config or sentinel-swap depending on whether the client tolerates a missing credential, and the proxy finishes the request without the agent ever holding the secret.
+A credential is proxy-sealable if and only if some scheme plus emit-mechanism combination completes its request at the proxy boundary. Most credentials are sealable: pick the scheme the service expects, pick `inject` or `sentinel-swap` depending on whether the client tolerates a missing credential, and the proxy finishes the request without the agent ever holding the secret.
 
 The residual exception is narrow. It is the conjunction of two conditions: a CLI that short-circuits the proxy (it does not honor `HTTPS_PROXY` or otherwise bypasses the TLS boundary) and that also rejects a syntactically valid sentinel (so sentinel-swap cannot satisfy it). A CLI that does only one of these is still sealable. Only the conjunction forces env injection, which is unsealed. This sits inside the existing threat-model scope: the cooperative-client assumption already governs whether the proxy sees the request, and a short-circuiting client is the same class of non-cooperative behavior described in [the threat model scope](#threat-model-scope) below.
 

--- a/docs/src/content/docs/development/sandbox-proxy-cli-matrix.md
+++ b/docs/src/content/docs/development/sandbox-proxy-cli-matrix.md
@@ -14,16 +14,16 @@ Each CLI has two properties that govern how Aileron seals its traffic. These are
 
 | CLI | proxy-sealable | emit-mechanism |
 |---|---|---|
-| curl | yes | A |
-| gh | yes | B |
-| aws | yes | A |
+| curl | yes | inject |
+| gh | yes | sentinel-swap |
+| aws | yes | inject |
 
 `proxy-sealable` means the daemon can inject the real credential at the TLS forward-proxy boundary so the container never holds it.
 
 `emit-mechanism` is how the in-container client is made to emit a request the proxy can seal. It is independent of the injection scheme (bearer, basic, and so on), which is how the proxy writes the credential once the request arrives.
 
-- Mechanism A: the launcher plants no token. The client emits an unauthenticated request, and the proxy injects the bound credential unconditionally at egress. `curl` issues the request with no token. `git`-over-HTTPS issues an unauthenticated request because the launcher mounts a no-op credential helper.
-- Mechanism B: the launcher plants a non-secret, format-mimicking sentinel token. Some clients short-circuit locally when they hold no token, so they never issue the request and there is nothing for the proxy to seal. The sentinel makes the client treat itself as authenticated and issue the request. The proxy then swaps the sentinel for the real credential at egress. The proxy swaps only the sentinel it itself planted. A foreign token on a mechanism-B host is forwarded unchanged. See [ADR-0019](/adr/0019-v4-https-data-plane/).
+- The `inject` mechanism: the launcher plants no token. The client emits an unauthenticated request, and the proxy injects the bound credential unconditionally at egress. `curl` issues the request with no token. `git`-over-HTTPS issues an unauthenticated request because the launcher mounts a no-op credential helper.
+- The `sentinel-swap` mechanism: the launcher plants a non-secret, format-mimicking sentinel token. Some clients short-circuit locally when they hold no token, so they never issue the request and there is nothing for the proxy to seal. The sentinel makes the client treat itself as authenticated and issue the request. The proxy then swaps the sentinel for the real credential at egress. The proxy swaps only the sentinel it itself planted. A foreign token on a `sentinel-swap` host is forwarded unchanged. See [ADR-0019](/adr/0019-v4-https-data-plane/).
 
 ## What the proxy guarantees
 
@@ -129,9 +129,9 @@ Expected:
 
 ## gh (GitHub CLI)
 
-`gh` is `proxy-sealable` via `emit-mechanism` B. It honors `HTTPS_PROXY` once you set it, and it picks up the system CA store, so it works through the Aileron proxy with no extra config. Aileron seals it against the built-in `api.github.com` host binding, so you do not need an installed GitHub connector spec for `gh api` to work.
+`gh` is `proxy-sealable` via `sentinel-swap`. It honors `HTTPS_PROXY` once you set it, and it picks up the system CA store, so it works through the Aileron proxy with no extra config. Aileron seals it against the built-in `api.github.com` host binding, so you do not need an installed GitHub connector spec for `gh api` to work.
 
-`gh` is the reason mechanism B exists. `gh` validates its auth state locally before making a request. With no token it short-circuits and never issues the request, so mechanism A (plant nothing, seal the emitted request) has nothing to seal. The launcher closes this gap by planting a non-secret, format-mimicking sentinel as `GH_TOKEN` when a `user/github` entry exists in your vault. The sentinel passes `gh`'s own local validation, so `gh` issues its request. The daemon recognizes the sentinel at the TLS boundary and swaps in your real GitHub token before the request leaves the host. The real token never enters the container. The sentinel is non-secret and safe to see in `echo $GH_TOKEN` output; presenting it to GitHub authenticates nothing.
+`gh` is the reason the `sentinel-swap` mechanism exists. `gh` validates its auth state locally before making a request. With no token it short-circuits and never issues the request, so the `inject` mechanism (plant nothing, seal the emitted request) has nothing to seal. The launcher closes this gap by planting a non-secret, format-mimicking sentinel as `GH_TOKEN` when a `user/github` entry exists in your vault. The sentinel passes `gh`'s own local validation, so `gh` issues its request. The daemon recognizes the sentinel at the TLS boundary and swaps in your real GitHub token before the request leaves the host. The real token never enters the container. The sentinel is non-secret and safe to see in `echo $GH_TOKEN` output; presenting it to GitHub authenticates nothing.
 
 Store your token once with `aileron auth github`. The launcher does the rest on every sandbox launch.
 

--- a/docs/src/content/docs/guides/binding-descriptors.md
+++ b/docs/src/content/docs/guides/binding-descriptors.md
@@ -17,7 +17,7 @@ bindings:
   - host: api.linear.app
     credential_ref: user/linear
     scheme: header-template
-    emit_mechanism: A
+    emit_mechanism: inject
     header: Authorization
     template: "{token}"
 ```
@@ -27,7 +27,7 @@ Each binding is a quad plus scheme-specific fields.
 - `host` is the upstream host matched at the proxy boundary. It is an exact host (`api.linear.app`) or a single leading-wildcard form (`*.example.com`). Ports are not part of the pattern.
 - `credential_ref` is a vault credential reference the daemon resolves at injection time. It is a connector-style binding name (`<kind>/<service>/<identity>`) or a user-level reference (`user/<service>`), the namespace `aileron auth <service>` writes. It is never the credential bytes. The descriptor names where the credential lives, never its value.
 - `scheme` is one of the closed injection-scheme set: `bearer`, `basic`, `header-template`, `query-param`, `sigv4-resign`. An unknown scheme is a load-time error. `sigv4-resign` is enumerated but not yet implemented.
-- `emit_mechanism` declares how the credential reaches egress. `A` injects the credential unconditionally at the proxy. `B` is sentinel-swap, where the launcher plants a non-secret sentinel the proxy swaps for the real credential. The field is optional and defaults to `A`. A value outside the closed set (`A`, `B`) is a load-time error. A mechanism-`B` binding must declare a `sentinel` block. A mechanism-`A` binding must declare none.
+- `emit_mechanism` declares how the credential reaches egress. `inject` injects the credential unconditionally at the proxy. `sentinel-swap` plants a non-secret sentinel the proxy swaps for the real credential. The field is optional and defaults to `inject`. A value outside the closed set (`inject`, `sentinel-swap`) is a load-time error. A `sentinel-swap` binding must declare a `sentinel` block. An `inject` binding must declare none.
 
 Scheme-specific fields:
 
@@ -35,9 +35,9 @@ Scheme-specific fields:
 - `header` and `template` are required for the `header-template` scheme. `header` is the header name to set. `template` is the verbatim header value with a `{token}` placeholder the daemon substitutes with the credential at injection time.
 - `query_param` is required for the `query-param` scheme. It is the query-parameter name the credential is set on.
 
-Mechanism-`B` fields:
+`sentinel-swap` fields:
 
-- `sentinel` is a nested block required for the `B` emit mechanism and forbidden for `A`. It has two fields, both non-secret.
+- `sentinel` is a nested block required for the `sentinel-swap` emit mechanism and forbidden for `inject`. It has two fields, both non-secret.
 - `sentinel.value` is the format-mimicking placeholder the launcher plants inside the container and the proxy recognizes at egress. The value is non-secret and safe to commit. Presenting it upstream authenticates nothing. The proxy swaps it for the real credential before the request leaves the boundary.
 - `sentinel.env` is the environment-variable name the launcher sets to `sentinel.value` inside the container. This is what generalizes the plant target, so the launcher is not hardcoded to one CLI's variable.
 
@@ -70,9 +70,11 @@ The built-in Linear descriptor (shown at the top of this page) then seals every 
 
 This is the whole generalization proof. Linear is a tool nobody special-cased in the proxy. It is sealed entirely by a descriptor. Adding another vendor is a new descriptor, never new proxy code.
 
-## Worked example: a mechanism-B sentinel
+## Worked example: a sentinel-swap binding
 
-Some CLIs refuse to issue a request when they hold no token. They validate locally and short-circuit, so the proxy never sees an outbound request to seal. `gh` is the canonical case. Mechanism `B` closes this gap. The launcher plants a non-secret placeholder under an environment variable the CLI reads, the CLI's local check passes, and the CLI issues the request. The proxy recognizes the placeholder at egress and swaps in the real credential.
+Some CLIs refuse to issue a request when they hold no token. They validate locally and short-circuit, so the proxy never sees an outbound request to seal. `gh` is the canonical case. The `sentinel-swap` mechanism closes this gap. The launcher plants a non-secret placeholder under an environment variable the CLI reads, the CLI's local check passes, and the CLI issues the request. The proxy recognizes the placeholder at egress and swaps in the real credential.
+
+`sentinel-swap` works for any host that declares a `sentinel` block, not just GitHub. The recognizer is generic: a request is swapped only when its carrier matches that binding's own `sentinel.value`, so a foreign token on a `sentinel-swap` host is left untouched. GitHub is one instance of the pattern.
 
 ```yaml
 version: v1
@@ -80,7 +82,7 @@ bindings:
   - host: api.github.com
     credential_ref: user/github
     scheme: bearer
-    emit_mechanism: B
+    emit_mechanism: sentinel-swap
     sentinel:
       value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA
       env: GH_TOKEN
@@ -100,20 +102,20 @@ bindings:
   - host: github.com
     credential_ref: user/github
     scheme: basic
-    emit_mechanism: A
+    emit_mechanism: inject
     username: x-access-token
   - host: api.github.com
     credential_ref: user/github
     scheme: bearer
-    emit_mechanism: B
+    emit_mechanism: sentinel-swap
     sentinel:
       value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA
       env: GH_TOKEN
 ```
 
-`github.com` is `basic`, mechanism `A`. git-over-HTTPS sends `Authorization: Basic base64(x-access-token:<token>)`, the documented convention for authenticating git with a GitHub token. git issues an unauthenticated request, so the proxy injects the credential unconditionally with no sentinel needed.
+`github.com` is `basic`, `inject`. git-over-HTTPS sends `Authorization: Basic base64(x-access-token:<token>)`, the documented convention for authenticating git with a GitHub token. git issues an unauthenticated request, so the proxy injects the credential unconditionally with no sentinel needed.
 
-`api.github.com` is `bearer`, mechanism `B`. `gh` short-circuits locally without a token, so the launcher plants the sentinel as `GH_TOKEN`, `gh` issues the request, and the proxy swaps the sentinel for the real credential at egress. A foreign token the agent supplies itself is left untouched.
+`api.github.com` is `bearer`, `sentinel-swap`. `gh` short-circuits locally without a token, so the launcher plants the sentinel as `GH_TOKEN`, `gh` issues the request, and the proxy swaps the sentinel for the real credential at egress. A foreign token the agent supplies itself is left untouched.
 
 Both bindings resolve the same `user/github` reference. Store your token once:
 

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -449,8 +449,8 @@ func NewHandlerWithConfig(log *slog.Logger, cfg Config) (http.Handler, error) {
 	// per-CLI proxy code.
 	//
 	// GitHub is no longer special-cased in Go (#1248). Its two bindings
-	// (github.com -> basic, mechanism A; api.github.com -> bearer,
-	// mechanism B with a sentinel-swap) now ship as a trusted built-in
+	// (github.com -> basic, inject; api.github.com -> bearer,
+	// sentinel-swap) now ship as a trusted built-in
 	// descriptor (internal/proxybinding/defaults/github.yaml) alongside
 	// Linear, picked up by the same embedded defaults glob. A user
 	// descriptor can override either host, so GitHub is a normal default

--- a/internal/app/github_bindings_testsupport_test.go
+++ b/internal/app/github_bindings_testsupport_test.go
@@ -15,8 +15,8 @@ import (
 //
 // The proxy/sentinel-swap tests use this to source the GitHub bindings
 // from the same place production reads them, replacing the deleted bespoke
-// Go constructor. Their behavioral assertions (mechanism A basic-auth
-// sealing, mechanism B sentinel-swap, foreign-token passthrough) are
+// Go constructor. Their behavioral assertions (inject basic-auth
+// sealing, sentinel-swap, foreign-token passthrough) are
 // unchanged; only the binding source moved from bespoke Go to the
 // descriptor path.
 func githubDefaultBindings(t *testing.T) binding.HostBindings {

--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -652,8 +652,8 @@ func (s *apiServer) recordSandboxProxyBindingInjected(r *http.Request, source, h
 }
 
 // recordSandboxProxyForeignTokenNotSwapped emits
-// sandbox.proxy.foreign_token_not_swapped for a request on an
-// emit-mechanism B host binding (#1196) that carried a foreign
+// sandbox.proxy.foreign_token_not_swapped for a request on a
+// sentinel-swap host binding that carried a foreign
 // (non-sentinel) token. The proxy did not swap it: it forwarded the
 // request unchanged with no real credential injected. The payload
 // carries the matched host pattern, scheme, and upstream

--- a/internal/app/handlers_sandbox_forward_proxy.go
+++ b/internal/app/handlers_sandbox_forward_proxy.go
@@ -271,14 +271,14 @@ func (s *apiServer) routeSandboxForwardProxyHostBinding(conn net.Conn, decrypted
 		upstreamReq.Header.Set("Content-Type", contentType)
 	}
 
-	// Emit-mechanism B sentinel-swap gate (#1196). For a mechanism-B
-	// binding the proxy seals only tokens it itself planted: the
-	// recognized sentinel is stripped here and replaced by the real
-	// credential below, while a foreign token is forwarded unchanged with
-	// no real secret injected. A mechanism-A binding always injects.
+	// Sentinel-swap gate. For a sentinel-swap binding the proxy seals only
+	// tokens it itself planted: the recognized sentinel is stripped here and
+	// replaced by the real credential below, while a foreign token is
+	// forwarded unchanged with no real secret injected. An inject binding
+	// always injects.
 	switch decideSentinelSwap(upstreamReq, hb) {
 	case sentinelSwapPassthroughForeign:
-		// The agent supplied its own token on a mechanism-B host. Do not
+		// The agent supplied its own token on a sentinel-swap host. Do not
 		// swap: dial upstream with the foreign carrier intact and no real
 		// credential injected. The sentinel/secret never enter this path.
 		resp, err := s.dialSandboxForwardProxyHostBinding(conn, decrypted, auth, targetHost, upstream, upstreamReq)

--- a/internal/app/sandbox_forward_proxy_sentinel.go
+++ b/internal/app/sandbox_forward_proxy_sentinel.go
@@ -9,19 +9,18 @@ import (
 
 // sentinelSwapDecision is the result of inspecting the inbound credential
 // carrier on a matched host binding to decide whether the egress seam
-// should inject the bound credential (emit-mechanism B sentinel-swap,
-// ADR-0019, #1196).
+// should inject the bound credential (sentinel-swap, ADR-0019).
 type sentinelSwapDecision int
 
 const (
 	// sentinelSwapInject means proceed with the binding's injection
-	// scheme: either the binding is emit-mechanism A (the default, always
-	// inject), or it is mechanism B and the inbound carrier is the
+	// scheme: either the binding is emit-mechanism inject (the default,
+	// always inject), or it is sentinel-swap and the inbound carrier is the
 	// recognized sentinel (which is stripped before injection so it never
-	// reaches upstream), or it is mechanism B with no carrier at all.
+	// reaches upstream), or it is sentinel-swap with no carrier at all.
 	sentinelSwapInject sentinelSwapDecision = iota
 
-	// sentinelSwapPassthroughForeign means the binding is mechanism B and
+	// sentinelSwapPassthroughForeign means the binding is sentinel-swap and
 	// the inbound carrier is a foreign (non-sentinel) token. The proxy
 	// must NOT swap it: it seals only tokens it planted. The request is
 	// forwarded unchanged with the foreign carrier intact and no real
@@ -38,24 +37,24 @@ const carrierHeader = "Authorization"
 // matched host binding and returns whether the egress seam should inject
 // the bound credential or forward a foreign token unchanged.
 //
-// For an emit-mechanism A binding it always returns sentinelSwapInject:
-// mechanism A plants nothing and injects unconditionally, the pre-#1196
-// behavior, so the carrier (if any) is overwritten by the scheme.
+// For an inject binding it always returns sentinelSwapInject: the inject
+// mechanism plants nothing and injects unconditionally, so the carrier
+// (if any) is overwritten by the scheme.
 //
-// For an emit-mechanism B binding it gates on the carrier:
+// For a sentinel-swap binding it gates on the carrier:
 //   - the recognized sentinel  -> strip the carrier and inject (the
 //     sentinel value is never forwarded upstream);
 //   - a foreign, non-empty token -> do not inject; forward unchanged;
 //   - no carrier / empty carrier -> inject per the binding's scheme.
 //
-// Recognition is binding-driven (#1247): the matched binding carries the
-// sentinel value the launcher planted (HostBinding.SentinelValue), so the
+// Recognition is binding-driven: the matched binding carries the sentinel
+// value the launcher planted (HostBinding.SentinelValue), so the
 // launch-side plant and the proxy-side recognizer read one source of
 // truth and cannot drift. There is no GitHub special-casing here. Any
-// mechanism-B host is recognized by its own binding's sentinel value with
-// no change to this decision path.
+// sentinel-swap host is recognized by its own binding's sentinel value
+// with no change to this decision path.
 func decideSentinelSwap(req *http.Request, hb binding.HostBinding) sentinelSwapDecision {
-	if hb.EmitMechanism != binding.EmitMechanismB {
+	if hb.EmitMechanism != binding.EmitMechanismSentinelSwap {
 		return sentinelSwapInject
 	}
 
@@ -78,17 +77,17 @@ func decideSentinelSwap(req *http.Request, hb binding.HostBinding) sentinelSwapD
 }
 
 // bindingSentinelMatches reports whether carrier bears the sentinel the
-// launcher plants for this mechanism-B binding. The carrier may be the
+// launcher plants for this sentinel-swap binding. The carrier may be the
 // bare sentinel (gh sets GH_TOKEN verbatim and some clients send the
 // token alone) or a "Bearer <sentinel>" / "token <sentinel>" form, so
 // the scheme prefix is tolerated before the exact sentinel match.
 //
-// The match reads the binding's own SentinelValue (#1247): there is no
-// GitHub special-casing. The comparison is exact, case-sensitive, and
-// does no trimming beyond the auth-scheme prefix, preserving the
-// foreign-token-safe property (only our own plant is swapped). A
-// SentinelValue of "" never matches, so an A-or-misconstructed binding
-// can never match an empty or any carrier.
+// The match reads the binding's own SentinelValue: there is no GitHub
+// special-casing. The comparison is exact, case-sensitive, and does no
+// trimming beyond the auth-scheme prefix, preserving the foreign-token-safe
+// property (only our own plant is swapped). A SentinelValue of "" never
+// matches, so an inject-or-misconstructed binding can never match an empty
+// or any carrier.
 func bindingSentinelMatches(hb binding.HostBinding, carrier string) bool {
 	return hb.SentinelValue != "" && stripAuthScheme(carrier) == hb.SentinelValue
 }

--- a/internal/app/sandbox_forward_proxy_sentinel_swap_test.go
+++ b/internal/app/sandbox_forward_proxy_sentinel_swap_test.go
@@ -15,9 +15,9 @@ import (
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
-// Emit-mechanism B sentinel-swap contract at the egress boundary (#1196),
+// Sentinel-swap contract at the egress boundary,
 // driven through the real forward-proxy CONNECT/TLS path against the
-// built-in api.github.com binding (bearer, mechanism B):
+// built-in api.github.com binding (bearer, sentinel-swap):
 //
 //	(a) a request bearing the reserved sentinel is swapped: the upstream
 //	    sees the real credential via the bearer scheme, never the sentinel.
@@ -28,15 +28,15 @@ import (
 //	    sentinel, or foreign-token bytes.
 
 func TestSentinelSwap_SecondDistinctBindingSwapsIndependently(t *testing.T) {
-	// A second, distinct mechanism-B binding swaps its own sentinel for its
-	// own credential through the real proxy path, independently of GitHub
-	// (#1247). The GitHub sentinel on this host is foreign and must not be
+	// A second, distinct sentinel-swap binding swaps its own sentinel for its
+	// own credential through the real proxy path, independently of GitHub.
+	// The GitHub sentinel on this host is foreign and must not be
 	// swapped, proving recognition is per-binding, not GitHub-special.
 	const otherSentinelVal = "sk_AILERONSENTINELSECONDBINDINGXXXXXXXX"
 	const realOther = "sk_realsecondbinding_secret"
 
 	other, err := binding.NewHostBinding("api.second.test", "user/second", binding.SchemeBearer,
-		binding.WithEmitMechanismB(), binding.WithSentinel(otherSentinelVal, "SECOND_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel(otherSentinelVal, "SECOND_TOKEN"))
 	if err != nil {
 		t.Fatalf("NewHostBinding(second): %v", err)
 	}
@@ -222,7 +222,7 @@ func TestSentinelSwap_BareSentinelWithoutSchemePrefixIsSwapped(t *testing.T) {
 }
 
 func TestSentinelSwap_NoCarrierStillInjects(t *testing.T) {
-	// A mechanism-B host with no inbound carrier injects per the binding's
+	// A sentinel-swap host with no inbound carrier injects per the binding's
 	// scheme (the sentinel-swap gate governs only the carrier-present case).
 	const realToken = "ghp_nocarrier_secret"
 	v := mustVaultWith(t, "user/github", "user", []byte(realToken))
@@ -238,7 +238,7 @@ func TestSentinelSwap_NoCarrierStillInjects(t *testing.T) {
 	_, _ = io.Copy(io.Discard, resp.Body)
 
 	if upstreamAuth != "Bearer "+realToken {
-		t.Errorf("upstream Authorization = %q, want Bearer %s on a no-carrier mechanism-B request", upstreamAuth, realToken)
+		t.Errorf("upstream Authorization = %q, want Bearer %s on a no-carrier sentinel-swap request", upstreamAuth, realToken)
 	}
 }
 

--- a/internal/app/sandbox_forward_proxy_sentinel_test.go
+++ b/internal/app/sandbox_forward_proxy_sentinel_test.go
@@ -9,14 +9,14 @@ import (
 )
 
 // Unit-level coverage of the sentinel-swap decision helper, independent
-// of the proxy plumbing (#1196). The end-to-end behavior is covered in
+// of the proxy plumbing. The end-to-end behavior is covered in
 // sandbox_forward_proxy_sentinel_swap_test.go; these assert the decision
 // branches and that the sentinel is stripped from the carrier on a swap.
 
-func mustHostBindingB(t *testing.T) binding.HostBinding {
+func mustHostBindingSentinelSwap(t *testing.T) binding.HostBinding {
 	t.Helper()
 	hb, err := binding.NewHostBinding("api.github.com", "user/github", binding.SchemeBearer,
-		binding.WithEmitMechanismB(), binding.WithSentinel(sentinel.GitHubTokenSentinel, "GH_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel(sentinel.GitHubTokenSentinel, "GH_TOKEN"))
 	if err != nil {
 		t.Fatalf("NewHostBinding: %v", err)
 	}
@@ -31,20 +31,21 @@ func reqWithAuth(value string) *http.Request {
 	return r
 }
 
-func TestDecideSentinelSwap_MechanismAAlwaysInjects(t *testing.T) {
+func TestDecideSentinelSwap_InjectAlwaysInjects(t *testing.T) {
 	hb, err := binding.NewHostBinding("github.com", "user/github", binding.SchemeBasic, binding.WithBasicUsername("x-access-token"))
 	if err != nil {
 		t.Fatalf("NewHostBinding: %v", err)
 	}
-	// Even with a foreign carrier present, mechanism A injects (overwrites).
+	// Even with a foreign carrier present, the inject mechanism injects
+	// (overwrites).
 	r := reqWithAuth("Bearer ghp_someforeigntoken")
 	if got := decideSentinelSwap(r, hb); got != sentinelSwapInject {
-		t.Errorf("mechanism A decision = %v, want inject", got)
+		t.Errorf("inject decision = %v, want inject", got)
 	}
 }
 
 func TestDecideSentinelSwap_SentinelIsStrippedAndInjected(t *testing.T) {
-	hb := mustHostBindingB(t)
+	hb := mustHostBindingSentinelSwap(t)
 	r := reqWithAuth("Bearer " + sentinel.GitHubTokenSentinel)
 	if got := decideSentinelSwap(r, hb); got != sentinelSwapInject {
 		t.Errorf("sentinel decision = %v, want inject", got)
@@ -57,7 +58,7 @@ func TestDecideSentinelSwap_SentinelIsStrippedAndInjected(t *testing.T) {
 }
 
 func TestDecideSentinelSwap_ForeignTokenIsNotSwapped(t *testing.T) {
-	hb := mustHostBindingB(t)
+	hb := mustHostBindingSentinelSwap(t)
 	const foreign = "Bearer ghp_theusersowntoken1234567890abcd"
 	r := reqWithAuth(foreign)
 	if got := decideSentinelSwap(r, hb); got != sentinelSwapPassthroughForeign {
@@ -70,7 +71,7 @@ func TestDecideSentinelSwap_ForeignTokenIsNotSwapped(t *testing.T) {
 }
 
 func TestDecideSentinelSwap_NoCarrierInjects(t *testing.T) {
-	hb := mustHostBindingB(t)
+	hb := mustHostBindingSentinelSwap(t)
 	r := reqWithAuth("")
 	if got := decideSentinelSwap(r, hb); got != sentinelSwapInject {
 		t.Errorf("no-carrier decision = %v, want inject", got)
@@ -95,7 +96,7 @@ func TestStripAuthScheme(t *testing.T) {
 }
 
 func TestBindingSentinelMatches_ReadsBindingSentinelValue(t *testing.T) {
-	gh := mustHostBindingB(t)
+	gh := mustHostBindingSentinelSwap(t)
 	if !bindingSentinelMatches(gh, "Bearer "+sentinel.GitHubTokenSentinel) {
 		t.Error("github binding did not recognize its own sentinel")
 	}
@@ -108,10 +109,10 @@ func TestBindingSentinelMatches_ReadsBindingSentinelValue(t *testing.T) {
 }
 
 func TestBindingSentinelMatches_DistinctSentinelsAreIndependent(t *testing.T) {
-	gh := mustHostBindingB(t)
+	gh := mustHostBindingSentinelSwap(t)
 	const otherSentinel = "sk_AILERONSENTINELOTHER"
 	other, err := binding.NewHostBinding("api.other.test", "user/other", binding.SchemeBearer,
-		binding.WithEmitMechanismB(), binding.WithSentinel(otherSentinel, "OTHER_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel(otherSentinel, "OTHER_TOKEN"))
 	if err != nil {
 		t.Fatalf("NewHostBinding: %v", err)
 	}
@@ -127,7 +128,7 @@ func TestBindingSentinelMatches_DistinctSentinelsAreIndependent(t *testing.T) {
 }
 
 func TestBindingSentinelMatches_EmptySentinelNeverMatches(t *testing.T) {
-	hb := binding.HostBinding{EmitMechanism: binding.EmitMechanismB}
+	hb := binding.HostBinding{EmitMechanism: binding.EmitMechanismSentinelSwap}
 	if bindingSentinelMatches(hb, "") {
 		t.Error("empty-sentinel binding matched an empty carrier")
 	}
@@ -139,7 +140,7 @@ func TestBindingSentinelMatches_EmptySentinelNeverMatches(t *testing.T) {
 func TestDecideSentinelSwap_SecondBindingSwapsIndependently(t *testing.T) {
 	const otherSentinel = "sk_AILERONSENTINELOTHER"
 	other, err := binding.NewHostBinding("api.other.test", "user/other", binding.SchemeBearer,
-		binding.WithEmitMechanismB(), binding.WithSentinel(otherSentinel, "OTHER_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel(otherSentinel, "OTHER_TOKEN"))
 	if err != nil {
 		t.Fatalf("NewHostBinding: %v", err)
 	}

--- a/internal/binding/host_binding.go
+++ b/internal/binding/host_binding.go
@@ -47,27 +47,28 @@ const SchemeHeaderTemplate = "header-template"
 const SchemeQueryParam = "query-param"
 
 // EmitMechanism names how the in-container client is made to emit a
-// request the proxy can seal at egress (ADR-0019, #1196). It is
-// orthogonal to [HostBinding.Scheme], which is how the proxy injects the
-// credential once the request arrives.
+// request the proxy can seal at egress (ADR-0019). It is orthogonal to
+// [HostBinding.Scheme], which is how the proxy injects the credential
+// once the request arrives.
 type EmitMechanism string
 
 const (
-	// EmitMechanismA is the default: the launcher plants no token. The
+	// EmitMechanismInject is the default: the launcher plants no token. The
 	// client emits an unauthenticated (or no-credential) request, and the
 	// proxy unconditionally injects the bound credential at egress. Used
 	// for clients that issue the request without holding a token (curl,
 	// git-over-HTTPS with a no-op credential helper).
-	EmitMechanismA EmitMechanism = "A"
+	EmitMechanismInject EmitMechanism = "inject"
 
-	// EmitMechanismB is sentinel-swap: the launcher plants a non-secret,
-	// format-mimicking sentinel token so a client that short-circuits
-	// locally without a token (e.g. `gh`) issues its request. The proxy
-	// swaps the sentinel for the real credential at egress, and ONLY
-	// swaps when it recognizes its own planted sentinel. A foreign token
-	// on a mechanism-B host is left untouched (no steal-swap, no real
-	// secret injected). See the swap recognizer at the egress seam.
-	EmitMechanismB EmitMechanism = "B"
+	// EmitMechanismSentinelSwap is sentinel-swap: the launcher plants a
+	// non-secret, format-mimicking sentinel token so a client that
+	// short-circuits locally without a token (e.g. `gh`) issues its
+	// request. The proxy swaps the sentinel for the real credential at
+	// egress, and ONLY swaps when it recognizes its own planted sentinel. A
+	// foreign token on a sentinel-swap host is left untouched (no
+	// steal-swap, no real secret injected). See the swap recognizer at the
+	// egress seam.
+	EmitMechanismSentinelSwap EmitMechanism = "sentinel-swap"
 )
 
 // HostBinding is the declarative triple that maps an upstream host
@@ -128,11 +129,11 @@ type HostBinding struct {
 
 	// EmitMechanism declares how the in-container client is made to emit
 	// a sealable request (see [EmitMechanism]). The zero value is
-	// [EmitMechanismA] (plant nothing, inject unconditionally), which
-	// preserves the pre-#1196 behavior. [EmitMechanismB] enables the
-	// sentinel-swap gate at egress for hosts whose client short-circuits
-	// without a planted token. Set via [WithEmitMechanismB], which also
-	// requires the sentinel shape below.
+	// [EmitMechanismInject] (plant nothing, inject unconditionally).
+	// [EmitMechanismSentinelSwap] enables the sentinel-swap gate at egress
+	// for hosts whose client short-circuits without a planted token. Set
+	// via [WithEmitMechanismSentinelSwap], which also requires the sentinel
+	// shape below.
 	EmitMechanism EmitMechanism
 
 	// SentinelValue is the non-secret, format-mimicking placeholder the
@@ -141,15 +142,17 @@ type HostBinding struct {
 	// egress recognizer compares the inbound carrier against this exact
 	// value to decide whether to swap in the real credential. It carries
 	// no authority and is safe to embed, log, and read in-sandbox (see the
-	// internal/sentinel package doc). Required for [EmitMechanismB],
-	// forbidden for [EmitMechanismA]. Set via [WithSentinel].
+	// internal/sentinel package doc). Required for
+	// [EmitMechanismSentinelSwap], forbidden for [EmitMechanismInject]. Set
+	// via [WithSentinel].
 	SentinelValue string
 
 	// SentinelEnv is the environment-variable name the launcher sets to
 	// [HostBinding.SentinelValue] in the sandbox so the client treats
 	// itself as authenticated (e.g. `GH_TOKEN`). It is a non-secret env
-	// name, never the credential bytes. Required for [EmitMechanismB],
-	// forbidden for [EmitMechanismA]. Set via [WithSentinel].
+	// name, never the credential bytes. Required for
+	// [EmitMechanismSentinelSwap], forbidden for [EmitMechanismInject]. Set
+	// via [WithSentinel].
 	SentinelEnv string
 }
 
@@ -189,30 +192,31 @@ func WithQueryParam(name string) HostBindingOption {
 	return func(hb *HostBinding) { hb.QueryParamName = name }
 }
 
-// WithEmitMechanismB marks the binding as [EmitMechanismB] (sentinel-
-// swap). Use it for a host whose in-container client short-circuits
-// locally without a planted token (e.g. `gh`): the launcher plants a
-// non-secret sentinel and the egress seam swaps it for the real
-// credential only when it recognizes its own plant. Without this option
-// a binding defaults to [EmitMechanismA] (plant nothing, inject
-// unconditionally).
+// WithEmitMechanismSentinelSwap marks the binding as
+// [EmitMechanismSentinelSwap]. Use it for a host whose in-container
+// client short-circuits locally without a planted token (e.g. `gh`): the
+// launcher plants a non-secret sentinel and the egress seam swaps it for
+// the real credential only when it recognizes its own plant. Without this
+// option a binding defaults to [EmitMechanismInject] (plant nothing,
+// inject unconditionally).
 //
-// A mechanism-B binding also requires the sentinel shape: pair this
+// A sentinel-swap binding also requires the sentinel shape: pair this
 // option with [WithSentinel] so the binding carries the value to plant
 // and the env var to plant it into. The constructor rejects a
-// mechanism-B binding with no sentinel, since it could never be planted
+// sentinel-swap binding with no sentinel, since it could never be planted
 // or recognized.
-func WithEmitMechanismB() HostBindingOption {
-	return func(hb *HostBinding) { hb.EmitMechanism = EmitMechanismB }
+func WithEmitMechanismSentinelSwap() HostBindingOption {
+	return func(hb *HostBinding) { hb.EmitMechanism = EmitMechanismSentinelSwap }
 }
 
 // WithSentinel sets the non-secret [HostBinding.SentinelValue] and
-// [HostBinding.SentinelEnv] the launcher plants for a mechanism-B
-// binding. Both are required for [EmitMechanismB] and must not be set on
-// an [EmitMechanismA] binding (an A binding plants nothing, so a stray
-// sentinel is a configuration error caught at construction). The value
-// is the single source of truth shared by the launch-side planter and
-// the proxy-side recognizer, so the two cannot drift.
+// [HostBinding.SentinelEnv] the launcher plants for a sentinel-swap
+// binding. Both are required for [EmitMechanismSentinelSwap] and must not
+// be set on an [EmitMechanismInject] binding (an inject binding plants
+// nothing, so a stray sentinel is a configuration error caught at
+// construction). The value is the single source of truth shared by the
+// launch-side planter and the proxy-side recognizer, so the two cannot
+// drift.
 func WithSentinel(value, env string) HostBindingOption {
 	return func(hb *HostBinding) {
 		hb.SentinelValue = value
@@ -245,7 +249,7 @@ func NewHostBinding(hostPattern, credentialRef, scheme string, opts ...HostBindi
 	if _, ok := HostBindingSchemes[scheme]; !ok {
 		return HostBinding{}, fmt.Errorf("host binding: unknown injection scheme %q", scheme)
 	}
-	hb := HostBinding{HostPattern: hp, CredentialRef: credentialRef, Scheme: scheme, EmitMechanism: EmitMechanismA}
+	hb := HostBinding{HostPattern: hp, CredentialRef: credentialRef, Scheme: scheme, EmitMechanism: EmitMechanismInject}
 	for _, opt := range opts {
 		opt(&hb)
 	}
@@ -258,11 +262,11 @@ func NewHostBinding(hostPattern, credentialRef, scheme string, opts ...HostBindi
 	if scheme == SchemeQueryParam && hb.QueryParamName == "" {
 		return HostBinding{}, fmt.Errorf("host binding: query-param scheme requires a param name (WithQueryParam)")
 	}
-	if hb.EmitMechanism == EmitMechanismB && (hb.SentinelValue == "" || hb.SentinelEnv == "") {
-		return HostBinding{}, fmt.Errorf("host binding: emit-mechanism B requires a sentinel value and env (WithSentinel)")
+	if hb.EmitMechanism == EmitMechanismSentinelSwap && (hb.SentinelValue == "" || hb.SentinelEnv == "") {
+		return HostBinding{}, fmt.Errorf("host binding: emit-mechanism sentinel-swap requires a sentinel value and env (WithSentinel)")
 	}
-	if hb.EmitMechanism == EmitMechanismA && (hb.SentinelValue != "" || hb.SentinelEnv != "") {
-		return HostBinding{}, fmt.Errorf("host binding: emit-mechanism A must not carry a sentinel (WithSentinel)")
+	if hb.EmitMechanism == EmitMechanismInject && (hb.SentinelValue != "" || hb.SentinelEnv != "") {
+		return HostBinding{}, fmt.Errorf("host binding: emit-mechanism inject must not carry a sentinel (WithSentinel)")
 	}
 	return hb, nil
 }

--- a/internal/binding/host_binding_test.go
+++ b/internal/binding/host_binding_test.go
@@ -33,27 +33,26 @@ func TestNewHostBinding_AcceptsValidInput(t *testing.T) {
 	}
 }
 
-func TestNewHostBinding_DefaultsToEmitMechanismA(t *testing.T) {
+func TestNewHostBinding_DefaultsToEmitMechanismInject(t *testing.T) {
 	// A binding constructed without an emit-mechanism option defaults to
-	// mechanism A (plant nothing, inject unconditionally), preserving the
-	// pre-#1196 behavior.
+	// the inject mechanism (plant nothing, inject unconditionally).
 	hb, err := binding.NewHostBinding("api.example.com", "user/example", "bearer")
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if hb.EmitMechanism != binding.EmitMechanismA {
-		t.Errorf("EmitMechanism = %q, want A by default", hb.EmitMechanism)
+	if hb.EmitMechanism != binding.EmitMechanismInject {
+		t.Errorf("EmitMechanism = %q, want inject by default", hb.EmitMechanism)
 	}
 }
 
-func TestNewHostBinding_WithEmitMechanismB(t *testing.T) {
+func TestNewHostBinding_WithEmitMechanismSentinelSwap(t *testing.T) {
 	hb, err := binding.NewHostBinding("api.github.com", "user/github", "bearer",
-		binding.WithEmitMechanismB(), binding.WithSentinel("ghp_sentinel", "GH_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel("ghp_sentinel", "GH_TOKEN"))
 	if err != nil {
 		t.Fatalf("unexpected error: %v", err)
 	}
-	if hb.EmitMechanism != binding.EmitMechanismB {
-		t.Errorf("EmitMechanism = %q, want B after WithEmitMechanismB", hb.EmitMechanism)
+	if hb.EmitMechanism != binding.EmitMechanismSentinelSwap {
+		t.Errorf("EmitMechanism = %q, want sentinel-swap after WithEmitMechanismSentinelSwap", hb.EmitMechanism)
 	}
 	if hb.SentinelValue != "ghp_sentinel" {
 		t.Errorf("SentinelValue = %q, want ghp_sentinel", hb.SentinelValue)
@@ -63,45 +62,45 @@ func TestNewHostBinding_WithEmitMechanismB(t *testing.T) {
 	}
 }
 
-func TestNewHostBinding_MechanismBRequiresSentinel(t *testing.T) {
+func TestNewHostBinding_SentinelSwapRequiresSentinel(t *testing.T) {
 	if _, err := binding.NewHostBinding("api.github.com", "user/github", "bearer",
-		binding.WithEmitMechanismB()); err == nil {
-		t.Fatal("expected error for mechanism-B binding with no sentinel, got nil")
+		binding.WithEmitMechanismSentinelSwap()); err == nil {
+		t.Fatal("expected error for sentinel-swap binding with no sentinel, got nil")
 	}
 	if _, err := binding.NewHostBinding("api.github.com", "user/github", "bearer",
-		binding.WithEmitMechanismB(), binding.WithSentinel("ghp_sentinel", "")); err == nil {
-		t.Fatal("expected error for mechanism-B binding with empty sentinel env, got nil")
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel("ghp_sentinel", "")); err == nil {
+		t.Fatal("expected error for sentinel-swap binding with empty sentinel env, got nil")
 	}
 	if _, err := binding.NewHostBinding("api.github.com", "user/github", "bearer",
-		binding.WithEmitMechanismB(), binding.WithSentinel("", "GH_TOKEN")); err == nil {
-		t.Fatal("expected error for mechanism-B binding with empty sentinel value, got nil")
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel("", "GH_TOKEN")); err == nil {
+		t.Fatal("expected error for sentinel-swap binding with empty sentinel value, got nil")
 	}
 }
 
-func TestNewHostBinding_MechanismARejectsSentinel(t *testing.T) {
+func TestNewHostBinding_InjectRejectsSentinel(t *testing.T) {
 	if _, err := binding.NewHostBinding("api.example.com", "user/example", "bearer",
 		binding.WithSentinel("ghp_sentinel", "GH_TOKEN")); err == nil {
-		t.Fatal("expected error for mechanism-A binding carrying a sentinel, got nil")
+		t.Fatal("expected error for inject binding carrying a sentinel, got nil")
 	}
 }
 
 func TestNewHostBinding_SentinelIndependentOfScheme(t *testing.T) {
 	bearer, err := binding.NewHostBinding("api.bearer.test", "user/bearer", binding.SchemeBearer,
-		binding.WithEmitMechanismB(), binding.WithSentinel("sent_bearer", "BEARER_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel("sent_bearer", "BEARER_TOKEN"))
 	if err != nil {
-		t.Fatalf("bearer-B with sentinel: %v", err)
+		t.Fatalf("bearer sentinel-swap with sentinel: %v", err)
 	}
 	if bearer.SentinelValue != "sent_bearer" || bearer.SentinelEnv != "BEARER_TOKEN" {
-		t.Errorf("bearer-B sentinel = (%q,%q)", bearer.SentinelValue, bearer.SentinelEnv)
+		t.Errorf("bearer sentinel-swap sentinel = (%q,%q)", bearer.SentinelValue, bearer.SentinelEnv)
 	}
 	header, err := binding.NewHostBinding("api.header.test", "user/header", binding.SchemeHeaderTemplate,
 		binding.WithHeaderTemplate("Authorization", "<token>"),
-		binding.WithEmitMechanismB(), binding.WithSentinel("sent_header", "HEADER_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel("sent_header", "HEADER_TOKEN"))
 	if err != nil {
-		t.Fatalf("header-template-B with sentinel: %v", err)
+		t.Fatalf("header-template sentinel-swap with sentinel: %v", err)
 	}
 	if header.SentinelValue != "sent_header" || header.SentinelEnv != "HEADER_TOKEN" {
-		t.Errorf("header-template-B sentinel = (%q,%q)", header.SentinelValue, header.SentinelEnv)
+		t.Errorf("header-template sentinel-swap sentinel = (%q,%q)", header.SentinelValue, header.SentinelEnv)
 	}
 }
 

--- a/internal/launch/github_inject.go
+++ b/internal/launch/github_inject.go
@@ -24,12 +24,12 @@ const githubUserService = "github"
 // githubCredentialRef is the vault path the user-level GitHub token lives
 // at (`user/github`). The launcher resolves it to gate the no-op
 // gitconfig warnings and to reuse the resolved token when planting the
-// GitHub mechanism-B binding's sentinel, avoiding a second daemon call.
+// GitHub sentinel-swap binding's sentinel, avoiding a second daemon call.
 const githubCredentialRef = "user/github"
 
 // userRefPrefix is the namespace prefix of a user-level credential ref
 // (`user/<service>`). The launcher derives the service slug a
-// mechanism-B binding's sentinel is gated on by trimming this prefix.
+// sentinel-swap binding's sentinel is gated on by trimming this prefix.
 const userRefPrefix = "user/"
 
 // githubConfigTarget is where the credential-helper gitconfig is mounted
@@ -71,15 +71,15 @@ type userCredsDaemon interface {
 type githubInjectPrep struct {
 	// EnvAdditions merge into the agent's env. Under the ADR-0019
 	// sealing model this never carries a secret. It does carry the
-	// non-secret sentinel of each mechanism-B binding whose credential
+	// non-secret sentinel of each sentinel-swap binding whose credential
 	// resolves to a usable vault entry: a client that short-circuits
 	// locally without a token (e.g. `gh`) issues its request only when a
 	// format-mimicking placeholder passes its local validation. Each
 	// planted pair is the binding's own SentinelEnv set to its
-	// SentinelValue (#1247), so the GitHub binding still plants GH_TOKEN
+	// SentinelValue, so the GitHub binding still plants GH_TOKEN
 	// with sentinel.GitHubTokenSentinel byte-for-byte. The daemon
 	// recognizes the sentinel at the TLS boundary and swaps in the real
-	// credential (emit-mechanism B, #1196). The sentinel is non-secret and
+	// credential (sentinel-swap). The sentinel is non-secret and
 	// safe to place in the env.
 	EnvAdditions map[string]string
 
@@ -170,19 +170,19 @@ func renderNoopGitconfigMount(
 // request the daemon proxy seals at egress via the user/github host
 // bindings, instead of blocking on a prompt or shelling out to `gh`.
 //
-// It then plants the sentinel of each mechanism-B binding in mechBBindings
-// whose credential resolves to a usable vault entry (#1247): the binding's
-// non-secret SentinelValue is set into its SentinelEnv. The GitHub binding
-// still plants GH_TOKEN with sentinel.GitHubTokenSentinel byte-for-byte;
-// any additional B binding plants its own pair independently. The real
-// credential never enters the container: it is resolved daemon-side and
-// injected at the TLS boundary.
+// It then plants the sentinel of each sentinel-swap binding in
+// sentinelSwapBindings whose credential resolves to a usable vault entry:
+// the binding's non-secret SentinelValue is set into its SentinelEnv. The
+// GitHub binding still plants GH_TOKEN with sentinel.GitHubTokenSentinel
+// byte-for-byte; any additional sentinel-swap binding plants its own pair
+// independently. The real credential never enters the container: it is
+// resolved daemon-side and injected at the TLS boundary.
 //
 // Under the ADR-0019 sealing model (#1195) the token never enters the
 // container in env, mount, or args. The GitHub vault probe drives the
 // locked-vault warning UX and supplies the reused GitHub token; it no
-// longer gates the mount, and each B binding's sentinel is gated on that
-// binding's own credential resolving.
+// longer gates the mount, and each sentinel-swap binding's sentinel is
+// gated on that binding's own credential resolving.
 //
 // Skip-clean semantics: a missing entry (ErrUserCredentialsNotFound) or a
 // locked vault (vault.ErrCredentialUnavailable) still mounts the no-op
@@ -198,15 +198,15 @@ func renderNoopGitconfigMount(
 func prepareGitHubInject(
 	ctx context.Context,
 	daemon userCredsDaemon,
-	mechBBindings []binding.HostBinding,
+	sentinelSwapBindings []binding.HostBinding,
 	sessionLog *slog.Logger,
 	stderr io.Writer,
 	chownHook func(dir string) error,
 ) (githubInjectPrep, error) {
 	// Resolve the GitHub user credential first: it drives the locked-vault
 	// warning UX and is reused (without a second daemon call) when planting
-	// the GitHub mechanism-B binding's sentinel below. A missing entry or a
-	// locked vault is a clean skip for GitHub (githubToken stays empty, so
+	// the GitHub sentinel-swap binding's sentinel below. A missing entry or
+	// a locked vault is a clean skip for GitHub (githubToken stays empty, so
 	// the GitHub sentinel is gated out), never a launch abort; only an
 	// unexpected daemon error aborts.
 	var githubToken string
@@ -225,22 +225,23 @@ func prepareGitHubInject(
 		return githubInjectPrep{}, fmt.Errorf("read user github credentials: %w", err)
 	}
 
-	// Always mount the secret-free no-op gitconfig (mechanism A for
+	// Always mount the secret-free no-op gitconfig (inject mechanism for
 	// git-over-HTTPS) on every path, regardless of vault state.
 	prep, err := renderNoopGitconfigMount(sessionLog, stderr, chownHook)
 	if err != nil {
 		return githubInjectPrep{}, err
 	}
 
-	// Plant each mechanism-B binding's sentinel into its env, gated on the
+	// Plant each sentinel-swap binding's sentinel into its env, gated on the
 	// binding's credential resolving to a usable token. The GitHub token
 	// resolved above is reused so the GitHub binding is not probed twice;
-	// any other B binding's credential is resolved fresh and independently.
-	plantSentinels(ctx, daemon, &prep, mechBBindings, githubToken)
+	// any other sentinel-swap binding's credential is resolved fresh and
+	// independently.
+	plantSentinels(ctx, daemon, &prep, sentinelSwapBindings, githubToken)
 	return prep, nil
 }
 
-// plantSentinels plants each mechanism-B binding's non-secret sentinel
+// plantSentinels plants each sentinel-swap binding's non-secret sentinel
 // value into its env var, but only when the binding's credential
 // resolves to a usable token (the swap has nothing to swap to otherwise).
 // A binding's sentinel is non-secret, so the planted env never carries a
@@ -256,15 +257,15 @@ func plantSentinels(
 	ctx context.Context,
 	daemon userCredsDaemon,
 	prep *githubInjectPrep,
-	mechBBindings []binding.HostBinding,
+	sentinelSwapBindings []binding.HostBinding,
 	githubToken string,
 ) {
-	for _, hb := range mechBBindings {
-		if hb.EmitMechanism != binding.EmitMechanismB {
+	for _, hb := range sentinelSwapBindings {
+		if hb.EmitMechanism != binding.EmitMechanismSentinelSwap {
 			continue
 		}
-		// A B binding with no sentinel shape cannot be planted. The
-		// constructor rejects this, so it is a defensive skip.
+		// A sentinel-swap binding with no sentinel shape cannot be planted.
+		// The constructor rejects this, so it is a defensive skip.
 		if hb.SentinelValue == "" || hb.SentinelEnv == "" {
 			continue
 		}
@@ -297,23 +298,22 @@ func hasUsableCredential(ctx context.Context, daemon userCredsDaemon, credential
 	return strings.TrimSpace(string(secret.Value)) != ""
 }
 
-// mechanismBHostBindings assembles the canonical host-binding table the
+// sentinelSwapHostBindings assembles the canonical host-binding table the
 // daemon recognizer reads (proxybinding.LoadHostBindings: every binding
 // flows from the descriptor layers, including the trusted GitHub built-in
 // shipped as defaults/github.yaml since #1248) and returns only the
-// mechanism-B subset the planter plants sentinels for. Sharing the
+// sentinel-swap subset the planter plants sentinels for. Sharing the
 // assembly keeps the launch-side plant and the proxy-side match reading
-// one source of truth across the process boundary (#1247). A malformed
-// descriptor surfaces an error rather than degrading to an empty plant
-// set.
-func mechanismBHostBindings() ([]binding.HostBinding, error) {
+// one source of truth across the process boundary. A malformed descriptor
+// surfaces an error rather than degrading to an empty plant set.
+func sentinelSwapHostBindings() ([]binding.HostBinding, error) {
 	all, err := proxybinding.LoadHostBindings(proxybinding.DefaultLoadOptions())
 	if err != nil {
 		return nil, err
 	}
 	var out []binding.HostBinding
 	for _, hb := range all {
-		if hb.EmitMechanism == binding.EmitMechanismB {
+		if hb.EmitMechanism == binding.EmitMechanismSentinelSwap {
 			out = append(out, hb)
 		}
 	}

--- a/internal/launch/github_inject_launcher_test.go
+++ b/internal/launch/github_inject_launcher_test.go
@@ -28,7 +28,7 @@ func TestLauncherMergesGitHubInject_TokenPresent(t *testing.T) {
 	agentEnv := map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "agent-oauth"}
 	var proxyMounts []sandboxcontainer.Volume
 
-	ghPrep, err := prepareGitHubInject(context.Background(), daemon, githubMechBBindings(t), nil, nil, nil)
+	ghPrep, err := prepareGitHubInject(context.Background(), daemon, githubSentinelSwapBindings(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v", err)
 	}
@@ -38,7 +38,7 @@ func TestLauncherMergesGitHubInject_TokenPresent(t *testing.T) {
 	}
 	proxyMounts = append(proxyMounts, ghPrep.Mounts...)
 
-	// Sealed model (#1195/#1196): the merge appends the secret-free
+	// Sealed model (#1195): the merge appends the secret-free
 	// gitconfig mount and sets GH_TOKEN to the NON-SECRET sentinel. The
 	// real token never reaches agentEnv.
 	if agentEnv["GH_TOKEN"] != sentinel.GitHubTokenSentinel {
@@ -73,7 +73,7 @@ func TestLauncherMergesGitHubInject_NoEntryStillMountsNoopGitconfig(t *testing.T
 	agentEnv := map[string]string{"CLAUDE_CODE_OAUTH_TOKEN": "agent-oauth"}
 	var proxyMounts []sandboxcontainer.Volume
 
-	ghPrep, err := prepareGitHubInject(context.Background(), daemon, githubMechBBindings(t), nil, nil, nil)
+	ghPrep, err := prepareGitHubInject(context.Background(), daemon, githubSentinelSwapBindings(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v", err)
 	}

--- a/internal/launch/github_inject_test.go
+++ b/internal/launch/github_inject_test.go
@@ -13,8 +13,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
-// prepareGitHubInject contract (#1149, sealed by #1195, sentinel-swap
-// added by #1196):
+// prepareGitHubInject contract (#1149, sealed by #1195, sentinel-swap):
 //
 //   - The agent never holds the GitHub secret. A usable user/github
 //     entry yields a GH_TOKEN env set to the non-secret
@@ -38,14 +37,14 @@ import (
 //     never 0600.
 //   - An unexpected daemon error aborts (it is not silently swallowed).
 
-// githubMechBBindings returns the GitHub mechanism-B binding set the
-// launcher passes to the planter. It is the canonical GitHub binding
+// githubSentinelSwapBindings returns the GitHub sentinel-swap binding set
+// the launcher passes to the planter. It is the canonical GitHub binding
 // carrying the GH_TOKEN sentinel, so a planter test exercises the
-// byte-for-byte GitHub plant path (#1247).
-func githubMechBBindings(t *testing.T) []binding.HostBinding {
+// byte-for-byte GitHub plant path.
+func githubSentinelSwapBindings(t *testing.T) []binding.HostBinding {
 	t.Helper()
 	hb, err := binding.NewHostBinding("api.github.com", "user/github", binding.SchemeBearer,
-		binding.WithEmitMechanismB(), binding.WithSentinel(sentinel.GitHubTokenSentinel, "GH_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel(sentinel.GitHubTokenSentinel, "GH_TOKEN"))
 	if err != nil {
 		t.Fatalf("NewHostBinding: %v", err)
 	}
@@ -53,7 +52,7 @@ func githubMechBBindings(t *testing.T) []binding.HostBinding {
 }
 
 // fakeMultiServiceDaemon serves per-service secrets so a planter test can
-// exercise a second, distinct mechanism-B binding alongside GitHub. A
+// exercise a second, distinct sentinel-swap binding alongside GitHub. A
 // service with no entry returns ErrUserCredentialsNotFound.
 type fakeMultiServiceDaemon struct {
 	secrets map[string]vault.Secret
@@ -82,17 +81,17 @@ func (f *fakeUserCredsDaemon) GetUserCredentials(_ context.Context, service stri
 	return f.secret, f.err
 }
 
-func TestPrepareGitHubInject_SecondMechanismBBindingPlantedIndependently(t *testing.T) {
-	// A second, distinct mechanism-B binding with its own value+env is
-	// planted into its own env var, independently of GitHub (#1247), when
+func TestPrepareGitHubInject_SecondSentinelSwapBindingPlantedIndependently(t *testing.T) {
+	// A second, distinct sentinel-swap binding with its own value+env is
+	// planted into its own env var, independently of GitHub, when
 	// its credential resolves to a usable token.
 	const otherSentinel = "sk_AILERONSENTINELOTHER"
 	other, err := binding.NewHostBinding("api.other.test", "user/other", binding.SchemeBearer,
-		binding.WithEmitMechanismB(), binding.WithSentinel(otherSentinel, "OTHER_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel(otherSentinel, "OTHER_TOKEN"))
 	if err != nil {
 		t.Fatalf("NewHostBinding(other): %v", err)
 	}
-	gh := githubMechBBindings(t)[0]
+	gh := githubSentinelSwapBindings(t)[0]
 
 	daemon := &fakeMultiServiceDaemon{secrets: map[string]vault.Secret{
 		"github": {Value: []byte("ghp_real")},
@@ -119,15 +118,15 @@ func TestPrepareGitHubInject_SecondMechanismBBindingPlantedIndependently(t *test
 }
 
 func TestPrepareGitHubInject_SecondBindingWithoutCredentialPlantsNothing(t *testing.T) {
-	// A mechanism-B binding whose credential ref has no usable vault entry
+	// A sentinel-swap binding whose credential ref has no usable vault entry
 	// plants nothing (the swap would have nothing to swap to), while the
 	// GitHub binding with a usable token still plants its sentinel.
 	other, err := binding.NewHostBinding("api.other.test", "user/other", binding.SchemeBearer,
-		binding.WithEmitMechanismB(), binding.WithSentinel("sk_AILERONSENTINELOTHER", "OTHER_TOKEN"))
+		binding.WithEmitMechanismSentinelSwap(), binding.WithSentinel("sk_AILERONSENTINELOTHER", "OTHER_TOKEN"))
 	if err != nil {
 		t.Fatalf("NewHostBinding(other): %v", err)
 	}
-	gh := githubMechBBindings(t)[0]
+	gh := githubSentinelSwapBindings(t)[0]
 
 	// Only github resolves; "other" has no entry.
 	daemon := &fakeMultiServiceDaemon{secrets: map[string]vault.Secret{
@@ -147,19 +146,20 @@ func TestPrepareGitHubInject_SecondBindingWithoutCredentialPlantsNothing(t *test
 	}
 }
 
-func TestPrepareGitHubInject_SkipsNonBAndSentinellessBindings(t *testing.T) {
-	// plantSentinels defensively skips a non-mechanism-B binding and a B
-	// binding with no sentinel shape (the constructor normally rejects the
-	// latter, so this is the fail-safe path). Neither plants any env.
-	mechA, err := binding.NewHostBinding("api.a.test", "user/a", binding.SchemeBearer)
+func TestPrepareGitHubInject_SkipsNonSentinelSwapAndSentinellessBindings(t *testing.T) {
+	// plantSentinels defensively skips a non-sentinel-swap binding and a
+	// sentinel-swap binding with no sentinel shape (the constructor normally
+	// rejects the latter, so this is the fail-safe path). Neither plants any
+	// env.
+	injectBinding, err := binding.NewHostBinding("api.a.test", "user/a", binding.SchemeBearer)
 	if err != nil {
-		t.Fatalf("NewHostBinding(mechA): %v", err)
+		t.Fatalf("NewHostBinding(injectBinding): %v", err)
 	}
 	sentinelless := binding.HostBinding{
 		HostPattern:   "api.b.test",
 		CredentialRef: "user/b",
 		Scheme:        binding.SchemeBearer,
-		EmitMechanism: binding.EmitMechanismB,
+		EmitMechanism: binding.EmitMechanismSentinelSwap,
 		// No SentinelValue/SentinelEnv: the defensive skip path.
 	}
 
@@ -169,40 +169,40 @@ func TestPrepareGitHubInject_SkipsNonBAndSentinellessBindings(t *testing.T) {
 		"b":      {Value: []byte("b_real")},
 	}}
 	prep, err := prepareGitHubInject(context.Background(), daemon,
-		[]binding.HostBinding{githubMechBBindings(t)[0], mechA, sentinelless}, nil, nil, nil)
+		[]binding.HostBinding{githubSentinelSwapBindings(t)[0], injectBinding, sentinelless}, nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v", err)
 	}
 	defer prep.Cleanup()
 
-	// Only the GitHub B binding with a sentinel plants anything.
+	// Only the GitHub sentinel-swap binding with a sentinel plants anything.
 	if got := prep.EnvAdditions["GH_TOKEN"]; got != sentinel.GitHubTokenSentinel {
 		t.Errorf("GH_TOKEN = %q, want the GitHub sentinel", got)
 	}
 	if len(prep.EnvAdditions) != 1 {
-		t.Errorf("EnvAdditions = %v, want only GH_TOKEN (non-B and sentinelless bindings plant nothing)", prep.EnvAdditions)
+		t.Errorf("EnvAdditions = %v, want only GH_TOKEN (non-sentinel-swap and sentinelless bindings plant nothing)", prep.EnvAdditions)
 	}
 }
 
 func TestPrepareGitHubInject_TokenPresent(t *testing.T) {
-	// Sealed model (#1195/#1196): a usable token mounts a secret-free
+	// Sealed model (#1195): a usable token mounts a secret-free
 	// gitconfig and sets GH_TOKEN to the NON-SECRET sentinel (so `gh`
 	// does not short-circuit). The real token bytes must never appear in
 	// the env or the mounted file; the daemon swaps the sentinel for the
 	// real credential at egress.
 	const tokenValue = "ghp_realtoken"
 	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte(tokenValue)}}
-	prep, err := prepareGitHubInject(context.Background(), daemon, githubMechBBindings(t), nil, nil, nil)
+	prep, err := prepareGitHubInject(context.Background(), daemon, githubSentinelSwapBindings(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v", err)
 	}
 	defer prep.Cleanup()
 
 	// GH_TOKEN must be present and equal to the sentinel, and recognized
-	// by the proxy-side recognizer. This is the emit-mechanism B plant.
+	// by the proxy-side recognizer. This is the sentinel-swap plant.
 	ghToken, ok := prep.EnvAdditions["GH_TOKEN"]
 	if !ok {
-		t.Fatalf("GH_TOKEN absent from EnvAdditions; emit-mechanism B must plant the sentinel so gh does not short-circuit")
+		t.Fatalf("GH_TOKEN absent from EnvAdditions; sentinel-swap must plant the sentinel so gh does not short-circuit")
 	}
 	if ghToken != sentinel.GitHubTokenSentinel {
 		t.Errorf("GH_TOKEN = %q, want the GitHub sentinel %q; the binding's SentinelValue is the single source of truth the proxy recognizer also reads", ghToken, sentinel.GitHubTokenSentinel)
@@ -233,7 +233,7 @@ func TestPrepareGitHubInject_TokenPresent(t *testing.T) {
 	if bytes.Contains(content, []byte(tokenValue)) {
 		t.Errorf("gitconfig source leaked the token; got:\n%s", content)
 	}
-	// No `gh` credential helper: emit-mechanism A is git-only, sealed at
+	// No `gh` credential helper: the inject mechanism is git-only, sealed at
 	// egress; the agent must not shell out to gh for credentials.
 	if bytes.Contains(content, []byte("!gh auth git-credential")) {
 		t.Errorf("gitconfig source still references gh credential helper; got:\n%s", content)
@@ -257,12 +257,12 @@ func TestPrepareGitHubInject_GitconfigIsSecretFreeRegardlessOfToken(t *testing.T
 	a := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_alpha")}}
 	b := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_bravo\n")}}
 
-	prepA, err := prepareGitHubInject(context.Background(), a, githubMechBBindings(t), nil, nil, nil)
+	prepA, err := prepareGitHubInject(context.Background(), a, githubSentinelSwapBindings(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject(a): %v", err)
 	}
 	defer prepA.Cleanup()
-	prepB, err := prepareGitHubInject(context.Background(), b, githubMechBBindings(t), nil, nil, nil)
+	prepB, err := prepareGitHubInject(context.Background(), b, githubSentinelSwapBindings(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject(b): %v", err)
 	}
@@ -286,7 +286,7 @@ func TestPrepareGitHubInject_NotFoundIsCleanSkip(t *testing.T) {
 	// sets no GH_TOKEN (the sentinel-swap needs a real daemon-side
 	// credential).
 	daemon := &fakeUserCredsDaemon{err: ErrUserCredentialsNotFound}
-	prep, err := prepareGitHubInject(context.Background(), daemon, githubMechBBindings(t), nil, nil, nil)
+	prep, err := prepareGitHubInject(context.Background(), daemon, githubSentinelSwapBindings(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v", err)
 	}
@@ -321,7 +321,7 @@ func TestPrepareGitHubInject_LockedVaultIsCleanSkip(t *testing.T) {
 	// warning, but sets no GH_TOKEN.
 	var stderr bytes.Buffer
 	daemon := &fakeUserCredsDaemon{err: vault.ErrCredentialUnavailable}
-	prep, err := prepareGitHubInject(context.Background(), daemon, githubMechBBindings(t), nil, &stderr, nil)
+	prep, err := prepareGitHubInject(context.Background(), daemon, githubSentinelSwapBindings(t), nil, &stderr, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v, want clean skip on locked vault", err)
 	}
@@ -347,7 +347,7 @@ func TestPrepareGitHubInject_EmptyTokenIsCleanSkip(t *testing.T) {
 	// Key Decision 4 (#1195): an empty-after-trim token still mounts the
 	// static secret-free no-op gitconfig, but sets no GH_TOKEN.
 	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("   \n")}}
-	prep, err := prepareGitHubInject(context.Background(), daemon, githubMechBBindings(t), nil, nil, nil)
+	prep, err := prepareGitHubInject(context.Background(), daemon, githubSentinelSwapBindings(t), nil, nil, nil)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v", err)
 	}
@@ -368,7 +368,7 @@ func TestPrepareGitHubInject_EmptyTokenIsCleanSkip(t *testing.T) {
 
 func TestPrepareGitHubInject_UnexpectedDaemonErrorAborts(t *testing.T) {
 	daemon := &fakeUserCredsDaemon{err: errors.New("daemon down")}
-	_, err := prepareGitHubInject(context.Background(), daemon, githubMechBBindings(t), nil, nil, nil)
+	_, err := prepareGitHubInject(context.Background(), daemon, githubSentinelSwapBindings(t), nil, nil, nil)
 	if err == nil {
 		t.Fatal("expected error on unexpected daemon failure")
 	}
@@ -388,7 +388,7 @@ func TestPrepareGitHubInject_ChownHookInvokedOnceWithTransientDir(t *testing.T) 
 		return nil
 	}
 
-	prep, err := prepareGitHubInject(context.Background(), daemon, githubMechBBindings(t), nil, nil, hook)
+	prep, err := prepareGitHubInject(context.Background(), daemon, githubSentinelSwapBindings(t), nil, nil, hook)
 	if err != nil {
 		t.Fatalf("prepareGitHubInject: %v", err)
 	}
@@ -421,7 +421,7 @@ func TestPrepareGitHubInject_ChownHookFailureIsNonFatal(t *testing.T) {
 	daemon := &fakeUserCredsDaemon{secret: vault.Secret{Value: []byte("ghp_x")}}
 	hook := func(string) error { return errors.New("chown boom") }
 
-	prep, err := prepareGitHubInject(context.Background(), daemon, githubMechBBindings(t), nil, &stderr, hook)
+	prep, err := prepareGitHubInject(context.Background(), daemon, githubSentinelSwapBindings(t), nil, &stderr, hook)
 	if err != nil {
 		t.Fatalf("chown failure must be non-fatal, got: %v", err)
 	}

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -543,9 +543,9 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		// /home/agent/.gitconfig. The real token never enters the
 		// container: `gh` issues its request because the sentinel passes
 		// its local validation, and the daemon swaps the sentinel for the
-		// real credential at the TLS boundary (emit-mechanism B, #1196);
+		// real credential at the TLS boundary (sentinel-swap);
 		// git-over-HTTPS emits an unauthenticated request the daemon seals
-		// the same way (emit-mechanism A). A missing entry or locked vault
+		// the same way (inject). A missing entry or locked vault
 		// is a clean, non-fatal skip — the launch proceeds with GitHub
 		// operations unauthenticated. The chown hook mirrors the AuthSpec
 		// one: on rootful Docker Linux the host operator owns the
@@ -554,16 +554,16 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		ghChownHook := newAgentDirChownHook(ctx, sandboxcontainer.DefaultRunner(),
 			sandboxPlan.Runtime, sandboxPlan.Image)
 		// Assemble the same host-binding table the daemon recognizer reads
-		// (GitHub Go bindings + descriptor bindings) and pass the
-		// mechanism-B subset to the planter, so the launch-side plant and
-		// the proxy-side swap share one source of truth (#1247). A
-		// malformed descriptor fails the launch loudly rather than silently
-		// shipping no sentinel.
-		mechBBindings, err := mechanismBHostBindings()
+		// (every binding flows from the descriptor layers) and pass the
+		// sentinel-swap subset to the planter, so the launch-side plant and
+		// the proxy-side swap share one source of truth. A malformed
+		// descriptor fails the launch loudly rather than silently shipping
+		// no sentinel.
+		sentinelSwapBindings, err := sentinelSwapHostBindings()
 		if err != nil {
-			return LaunchResult{}, fmt.Errorf("assemble mechanism-B host bindings: %w", err)
+			return LaunchResult{}, fmt.Errorf("assemble sentinel-swap host bindings: %w", err)
 		}
-		ghPrep, err := prepareGitHubInject(ctx, client, mechBBindings, sessionLog, os.Stderr, ghChownHook)
+		ghPrep, err := prepareGitHubInject(ctx, client, sentinelSwapBindings, sessionLog, os.Stderr, ghChownHook)
 		if err != nil {
 			return LaunchResult{}, fmt.Errorf("prepare github inject: %w", err)
 		}

--- a/internal/model/model.go
+++ b/internal/model/model.go
@@ -337,8 +337,8 @@ const (
 	// ADR-0019.
 	EventTypeSandboxProxyBindingInjected EventType = "sandbox.proxy.binding_injected"
 
-	// Sandbox proxy event for a request on an emit-mechanism B host
-	// binding (sentinel-swap, #1196) whose inbound credential carrier
+	// Sandbox proxy event for a request on a sentinel-swap host
+	// binding whose inbound credential carrier
 	// bore a FOREIGN (non-sentinel) token. The proxy seals only tokens it
 	// itself planted, so it did NOT swap: it forwarded the request
 	// upstream with the agent-supplied token intact and injected no real

--- a/internal/proxybinding/binding.go
+++ b/internal/proxybinding/binding.go
@@ -29,15 +29,15 @@ func (e *Entry) ToHostBinding() (binding.HostBinding, error) {
 		opts = append(opts, binding.WithQueryParam(e.QueryParam))
 	}
 
-	if e.EmitMechanism == string(binding.EmitMechanismB) {
-		opts = append(opts, binding.WithEmitMechanismB())
-		// A mechanism-B entry carries the sentinel shape (value + env) it
-		// validated at parse time (#1246). Carry it onto the binding so the
-		// launcher plants the value into the env and the proxy recognizes it
-		// at egress, both reading one source of truth (#1247). The
-		// constructor enforces the B-requires-sentinel rule, so a malformed
-		// entry that reached here with no sentinel fails construction below
-		// rather than silently shipping an unplantable binding.
+	if e.EmitMechanism == string(binding.EmitMechanismSentinelSwap) {
+		opts = append(opts, binding.WithEmitMechanismSentinelSwap())
+		// A sentinel-swap entry carries the sentinel shape (value + env) it
+		// validated at parse time. Carry it onto the binding so the launcher
+		// plants the value into the env and the proxy recognizes it at
+		// egress, both reading one source of truth. The constructor enforces
+		// the sentinel-swap-requires-sentinel rule, so a malformed entry that
+		// reached here with no sentinel fails construction below rather than
+		// silently shipping an unplantable binding.
 		if e.Sentinel != nil {
 			opts = append(opts, binding.WithSentinel(e.Sentinel.Value, e.Sentinel.Env))
 		}

--- a/internal/proxybinding/binding_test.go
+++ b/internal/proxybinding/binding_test.go
@@ -13,7 +13,7 @@ func TestToHostBinding_LinearMapsParams(t *testing.T) {
 		Host:          "api.linear.app",
 		CredentialRef: "user/linear",
 		Scheme:        binding.SchemeHeaderTemplate,
-		EmitMechanism: "A",
+		EmitMechanism: "inject",
 		Header:        "Authorization",
 		Template:      "{token}",
 	}
@@ -33,8 +33,8 @@ func TestToHostBinding_LinearMapsParams(t *testing.T) {
 	if hb.HeaderName != "Authorization" || hb.HeaderTemplate != "{token}" {
 		t.Errorf("header params = (%q,%q), want (Authorization,{token})", hb.HeaderName, hb.HeaderTemplate)
 	}
-	if hb.EmitMechanism != binding.EmitMechanismA {
-		t.Errorf("emit mechanism = %q, want A", hb.EmitMechanism)
+	if hb.EmitMechanism != binding.EmitMechanismInject {
+		t.Errorf("emit mechanism = %q, want inject", hb.EmitMechanism)
 	}
 }
 
@@ -70,22 +70,22 @@ func TestToHostBinding_QueryParamCarriesName(t *testing.T) {
 	}
 }
 
-func TestToHostBinding_EmitMechanismBCarriesSentinel(t *testing.T) {
-	// A mechanism-B entry's sentinel value and env adapt onto the binding
-	// (#1247) so the launcher and the proxy read one source of truth.
+func TestToHostBinding_SentinelSwapCarriesSentinel(t *testing.T) {
+	// A sentinel-swap entry's sentinel value and env adapt onto the binding
+	// so the launcher and the proxy read one source of truth.
 	e := Entry{
 		Host:          "api.example.com",
 		CredentialRef: "user/example",
 		Scheme:        binding.SchemeBearer,
-		EmitMechanism: "B",
+		EmitMechanism: "sentinel-swap",
 		Sentinel:      &Sentinel{Value: "sent_example", Env: "EXAMPLE_TOKEN"},
 	}
 	hb, err := e.ToHostBinding()
 	if err != nil {
 		t.Fatalf("ToHostBinding: %v", err)
 	}
-	if hb.EmitMechanism != binding.EmitMechanismB {
-		t.Errorf("emit mechanism = %q, want B", hb.EmitMechanism)
+	if hb.EmitMechanism != binding.EmitMechanismSentinelSwap {
+		t.Errorf("emit mechanism = %q, want sentinel-swap", hb.EmitMechanism)
 	}
 	if hb.SentinelValue != "sent_example" {
 		t.Errorf("SentinelValue = %q, want sent_example", hb.SentinelValue)
@@ -95,35 +95,35 @@ func TestToHostBinding_EmitMechanismBCarriesSentinel(t *testing.T) {
 	}
 }
 
-func TestToHostBinding_EmitMechanismBWithoutSentinelErrors(t *testing.T) {
-	// A mechanism-B entry that reached adaptation with no sentinel block is
-	// rejected by the constructor — a B binding that could never be planted
-	// or recognized must fail loudly rather than ship.
+func TestToHostBinding_SentinelSwapWithoutSentinelErrors(t *testing.T) {
+	// A sentinel-swap entry that reached adaptation with no sentinel block is
+	// rejected by the constructor — a sentinel-swap binding that could never
+	// be planted or recognized must fail loudly rather than ship.
 	e := Entry{
 		Host:          "api.example.com",
 		CredentialRef: "user/example",
 		Scheme:        binding.SchemeBearer,
-		EmitMechanism: "B",
+		EmitMechanism: "sentinel-swap",
 	}
 	if _, err := e.ToHostBinding(); err == nil {
-		t.Fatal("ToHostBinding for mechanism-B entry with no sentinel = nil error, want error")
+		t.Fatal("ToHostBinding for sentinel-swap entry with no sentinel = nil error, want error")
 	}
 }
 
-func TestToHostBinding_MechanismACarriesNoSentinel(t *testing.T) {
-	// A mechanism-A entry adapts with empty sentinel fields.
+func TestToHostBinding_InjectCarriesNoSentinel(t *testing.T) {
+	// An inject entry adapts with empty sentinel fields.
 	e := Entry{
 		Host:          "api.example.com",
 		CredentialRef: "user/example",
 		Scheme:        binding.SchemeBearer,
-		EmitMechanism: "A",
+		EmitMechanism: "inject",
 	}
 	hb, err := e.ToHostBinding()
 	if err != nil {
 		t.Fatalf("ToHostBinding: %v", err)
 	}
 	if hb.SentinelValue != "" || hb.SentinelEnv != "" {
-		t.Errorf("mechanism-A binding carries a sentinel (%q,%q), want none", hb.SentinelValue, hb.SentinelEnv)
+		t.Errorf("inject binding carries a sentinel (%q,%q), want none", hb.SentinelValue, hb.SentinelEnv)
 	}
 }
 

--- a/internal/proxybinding/defaults/github.yaml
+++ b/internal/proxybinding/defaults/github.yaml
@@ -20,13 +20,13 @@
 #
 # Two hosts, two schemes, two emit mechanisms:
 #
-#   - github.com -> basic, mechanism A. git-over-HTTPS sends
+#   - github.com -> basic, inject. git-over-HTTPS sends
 #     "Authorization: Basic base64(x-access-token:<token>)", the
 #     documented convention for authenticating git with a GitHub token.
 #     git issues an unauthenticated request (its no-op credential helper
 #     supplies empty credentials), so the proxy injects unconditionally
 #     with no sentinel needed.
-#   - api.github.com -> bearer, mechanism B. `gh`/REST sends
+#   - api.github.com -> bearer, sentinel-swap. `gh`/REST sends
 #     "Authorization: Bearer <token>". `gh` short-circuits locally
 #     without a token, so the launcher plants a non-secret sentinel as
 #     GH_TOKEN; the proxy swaps the sentinel for the real credential at
@@ -43,12 +43,12 @@ bindings:
   - host: github.com
     credential_ref: user/github
     scheme: basic
-    emit_mechanism: A
+    emit_mechanism: inject
     username: x-access-token
   - host: api.github.com
     credential_ref: user/github
     scheme: bearer
-    emit_mechanism: B
+    emit_mechanism: sentinel-swap
     sentinel:
       value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA
       env: GH_TOKEN

--- a/internal/proxybinding/defaults/linear.yaml
+++ b/internal/proxybinding/defaults/linear.yaml
@@ -17,6 +17,6 @@ bindings:
   - host: api.linear.app
     credential_ref: user/linear
     scheme: header-template
-    emit_mechanism: A
+    emit_mechanism: inject
     header: Authorization
     template: "{token}"

--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -26,13 +26,12 @@
 //
 // This package defines the descriptor format and the two-layer loader.
 // It does not implement the binding-table consult (#1193) or the injectors
-// (#1194). It accepts both emit mechanisms: mechanism "A" (inject at the
-// proxy) and mechanism "B" (sentinel-swap). A mechanism-B binding declares
-// a non-secret `sentinel` block (a placeholder value plus the env-var name
-// the launcher plants it under); this loader validates that schema while
-// the egress code that consumes those fields lands separately (#1247).
-// Persisting a stateful CLI's local cache across ephemeral sandboxes is out
-// of scope and tracked separately (#1190).
+// (#1194). It accepts both emit mechanisms: "inject" (inject at the proxy)
+// and "sentinel-swap". A sentinel-swap binding declares a non-secret
+// `sentinel` block (a placeholder value plus the env-var name the launcher
+// plants it under); this loader validates that schema and the egress code
+// consumes those fields. Persisting a stateful CLI's local cache across
+// ephemeral sandboxes is out of scope and tracked separately (#1190).
 //
 // [ADR-0019]: https://docs.withaileron.ai/adr/0019-v4-https-data-plane
 package proxybinding
@@ -55,17 +54,16 @@ import (
 const SchemaVersion = "v1"
 
 // EmitMechanisms is the closed set of emit-mechanism values a descriptor
-// may declare at load time. Mechanism "A" injects unconditionally at the
-// proxy (the client emits a no-credential request). Mechanism "B" is
-// sentinel-swap (the launcher plants a non-secret sentinel the proxy swaps
-// for the real credential at egress); a mechanism-B binding must declare a
-// `sentinel` block naming the placeholder value and the env-var name the
-// launcher plants it under. A value outside this set (e.g. "C") is a
-// load-time error, so a descriptor never validates against a mechanism the
-// proxy cannot enforce.
+// may declare at load time. "inject" injects unconditionally at the proxy
+// (the client emits a no-credential request). "sentinel-swap" plants a
+// non-secret sentinel the proxy swaps for the real credential at egress;
+// a sentinel-swap binding must declare a `sentinel` block naming the
+// placeholder value and the env-var name the launcher plants it under. A
+// value outside this set (e.g. "C") is a load-time error, so a descriptor
+// never validates against a mechanism the proxy cannot enforce.
 var EmitMechanisms = map[string]struct{}{
-	string(binding.EmitMechanismA): {},
-	string(binding.EmitMechanismB): {},
+	string(binding.EmitMechanismInject):       {},
+	string(binding.EmitMechanismSentinelSwap): {},
 }
 
 // Descriptor is a parsed, versioned binding-descriptor document. One
@@ -110,21 +108,21 @@ type Entry struct {
 	// unknown scheme is a load-time error (fail closed, no silent skip).
 	Scheme string `yaml:"scheme"`
 
-	// EmitMechanism declares how the credential reaches egress: "A"
-	// (inject at the proxy) or "B" (sentinel-swap). Optional; empty
-	// defaults to "A". A mechanism-B binding must declare a non-empty
-	// [Entry.Sentinel] block; a mechanism-A binding (explicit or defaulted)
+	// EmitMechanism declares how the credential reaches egress: "inject"
+	// (inject at the proxy) or "sentinel-swap". Optional; empty defaults to
+	// "inject". A sentinel-swap binding must declare a non-empty
+	// [Entry.Sentinel] block; an inject binding (explicit or defaulted)
 	// must declare none. Any value outside the closed set is a load-time
 	// error.
 	EmitMechanism string `yaml:"emit_mechanism"`
 
-	// Sentinel is the mechanism-B placeholder declaration: the non-secret
+	// Sentinel is the sentinel-swap placeholder declaration: the non-secret
 	// value the launcher plants inside the container and the env-var name it
-	// plants under. It is required and non-empty for mechanism "B" and
-	// forbidden for mechanism "A" (a stray sentinel on a mechanism-A binding
-	// is a load-time error, since the field is meaningless without B). It is
-	// a pointer so an absent block is distinguishable from a present block
-	// with empty fields. See [Sentinel].
+	// plants under. It is required and non-empty for "sentinel-swap" and
+	// forbidden for "inject" (a stray sentinel on an inject binding is a
+	// load-time error, since the field is meaningless without sentinel-swap).
+	// It is a pointer so an absent block is distinguishable from a present
+	// block with empty fields. See [Sentinel].
 	Sentinel *Sentinel `yaml:"sentinel"`
 
 	// Username is the non-secret HTTP basic-auth username, required only
@@ -147,7 +145,7 @@ type Entry struct {
 	QueryParam string `yaml:"query_param"`
 }
 
-// Sentinel is the per-binding mechanism-B placeholder declaration. It makes
+// Sentinel is the per-binding sentinel-swap placeholder declaration. It makes
 // both the placeholder value and its plant location data rather than Go
 // constants, so a token-in-env CLI is expressible purely by a descriptor.
 //
@@ -161,12 +159,12 @@ type Sentinel struct {
 	// Value is the non-secret, format-mimicking placeholder the launcher
 	// plants and the proxy recognizes (e.g.
 	// "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"). It is required and
-	// non-empty for mechanism "B". It is non-secret and safe to commit.
+	// non-empty for "sentinel-swap". It is non-secret and safe to commit.
 	Value string `yaml:"value"`
 
 	// Env is the environment-variable name the launcher sets to [Sentinel.Value]
 	// inside the container (e.g. "GH_TOKEN"). It is required and non-empty for
-	// mechanism "B". It generalizes the plant target so the launcher is not
+	// "sentinel-swap". It generalizes the plant target so the launcher is not
 	// hardcoded to a single CLI's env var.
 	Env string `yaml:"env"`
 }
@@ -238,30 +236,30 @@ func (e *Entry) Validate() error {
 
 	mech := e.EmitMechanism
 	if mech == "" {
-		mech = string(binding.EmitMechanismA)
+		mech = string(binding.EmitMechanismInject)
 	}
 	if _, ok := EmitMechanisms[mech]; !ok {
-		return fmt.Errorf("unknown emit_mechanism %q (want one of %q or %q)", e.EmitMechanism, string(binding.EmitMechanismA), string(binding.EmitMechanismB))
+		return fmt.Errorf("unknown emit_mechanism %q (want one of %q or %q)", e.EmitMechanism, string(binding.EmitMechanismInject), string(binding.EmitMechanismSentinelSwap))
 	}
 
-	// Mechanism B requires a non-empty sentinel block (value + env);
-	// mechanism A (explicit or defaulted) forbids one. The sentinel names
-	// the placeholder the launcher plants and the env var it plants it
-	// under, so the field is meaningless without B (fail closed).
+	// Sentinel-swap requires a non-empty sentinel block (value + env);
+	// inject (explicit or defaulted) forbids one. The sentinel names the
+	// placeholder the launcher plants and the env var it plants it under,
+	// so the field is meaningless without sentinel-swap (fail closed).
 	switch mech {
-	case string(binding.EmitMechanismB):
+	case string(binding.EmitMechanismSentinelSwap):
 		if e.Sentinel == nil {
-			return fmt.Errorf("emit_mechanism %q requires a sentinel block", string(binding.EmitMechanismB))
+			return fmt.Errorf("emit_mechanism %q requires a sentinel block", string(binding.EmitMechanismSentinelSwap))
 		}
 		if e.Sentinel.Value == "" {
-			return fmt.Errorf("emit_mechanism %q requires a non-empty sentinel.value", string(binding.EmitMechanismB))
+			return fmt.Errorf("emit_mechanism %q requires a non-empty sentinel.value", string(binding.EmitMechanismSentinelSwap))
 		}
 		if e.Sentinel.Env == "" {
-			return fmt.Errorf("emit_mechanism %q requires a non-empty sentinel.env", string(binding.EmitMechanismB))
+			return fmt.Errorf("emit_mechanism %q requires a non-empty sentinel.env", string(binding.EmitMechanismSentinelSwap))
 		}
 	default:
 		if e.Sentinel != nil {
-			return fmt.Errorf("emit_mechanism %q must not declare a sentinel block (sentinel applies only to mechanism %q)", string(binding.EmitMechanismA), string(binding.EmitMechanismB))
+			return fmt.Errorf("emit_mechanism %q must not declare a sentinel block (sentinel applies only to %q)", string(binding.EmitMechanismInject), string(binding.EmitMechanismSentinelSwap))
 		}
 	}
 

--- a/internal/proxybinding/descriptor_test.go
+++ b/internal/proxybinding/descriptor_test.go
@@ -16,7 +16,7 @@ bindings:
   - host: api.linear.app
     credential_ref: user/linear
     scheme: header-template
-    emit_mechanism: A
+    emit_mechanism: inject
     header: Authorization
     template: "{token}"
 `
@@ -120,37 +120,48 @@ func TestParse_Errors(t *testing.T) {
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: C\n",
 		},
 		{
-			// Mechanism B requires a sentinel block; a bare "B" with no
-			// sentinel is a load-time error (fail-closed).
-			name: "emit_mechanism B without sentinel block",
+			// The closed set accepts only "inject"/"sentinel-swap"; the bare
+			// legacy value "A" is no longer a valid mechanism.
+			name: "legacy emit_mechanism A rejected",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: A\n",
+		},
+		{
+			// The bare legacy value "B" is no longer a valid mechanism.
+			name: "legacy emit_mechanism B rejected",
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: B\n",
 		},
 		{
-			// Mechanism B with a sentinel block missing its value.
-			name: "emit_mechanism B with empty sentinel.value",
-			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: B\n    sentinel:\n      env: GH_TOKEN\n",
+			// Sentinel-swap requires a sentinel block; a bare "sentinel-swap"
+			// with no sentinel is a load-time error (fail-closed).
+			name: "emit_mechanism sentinel-swap without sentinel block",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: sentinel-swap\n",
 		},
 		{
-			// Mechanism B with a sentinel block missing its env.
-			name: "emit_mechanism B with empty sentinel.env",
-			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: B\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n",
+			// Sentinel-swap with a sentinel block missing its value.
+			name: "emit_mechanism sentinel-swap with empty sentinel.value",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: sentinel-swap\n    sentinel:\n      env: GH_TOKEN\n",
 		},
 		{
-			// A stray sentinel on an explicit mechanism-A binding is an error.
-			name: "emit_mechanism A with a stray sentinel block",
-			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: A\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n",
+			// Sentinel-swap with a sentinel block missing its env.
+			name: "emit_mechanism sentinel-swap with empty sentinel.env",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: sentinel-swap\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n",
 		},
 		{
-			// A stray sentinel on a defaulted (omitted) mechanism-A binding
-			// is an error.
-			name: "defaulted mechanism A with a stray sentinel block",
+			// A stray sentinel on an explicit inject binding is an error.
+			name: "emit_mechanism inject with a stray sentinel block",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: inject\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n",
+		},
+		{
+			// A stray sentinel on a defaulted (omitted) inject binding is an
+			// error.
+			name: "defaulted inject with a stray sentinel block",
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n",
 		},
 		{
 			// Strict decode recurses into the nested sentinel mapping: an
 			// unknown key inside the block is a load-time error.
 			name: "unknown key nested under sentinel",
-			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: B\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n      bogus: nope\n",
+			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n    emit_mechanism: sentinel-swap\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n      bogus: nope\n",
 		},
 		{
 			name: "header-template missing header",
@@ -206,38 +217,38 @@ func TestParse_Errors(t *testing.T) {
 	}
 }
 
-// TestParse_EmitMechanismBSentinelSchema pins the mechanism-B schema this
-// issue freezes (#1246). A well-formed mechanism-B descriptor declares a
-// sentinel block with both value and env, and those fields round-trip onto
-// the parsed Entry. A mechanism-B descriptor missing the block or either
-// field is rejected, and a mechanism-A descriptor that carries a stray
-// sentinel is rejected. Mechanism "A" and the empty default still parse.
-// This is the fail-closed contract; it is intentionally decoupled from the
-// table-driven cases so the policy is explicit and survives refactors.
-func TestParse_EmitMechanismBSentinelSchema(t *testing.T) {
+// TestParse_SentinelSwapSchema pins the sentinel-swap schema. A well-formed
+// sentinel-swap descriptor declares a sentinel block with both value and
+// env, and those fields round-trip onto the parsed Entry. A sentinel-swap
+// descriptor missing the block or either field is rejected, and an inject
+// descriptor that carries a stray sentinel is rejected. "inject" and the
+// empty default still parse. This is the fail-closed contract; it is
+// intentionally decoupled from the table-driven cases so the policy is
+// explicit and survives refactors.
+func TestParse_SentinelSwapSchema(t *testing.T) {
 	const base = "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: bearer\n"
 
-	// "A" and the empty default are accepted with no sentinel.
-	if _, err := Parse([]byte(base + "    emit_mechanism: A\n")); err != nil {
-		t.Errorf("emit_mechanism A: Parse = %v, want nil", err)
+	// "inject" and the empty default are accepted with no sentinel.
+	if _, err := Parse([]byte(base + "    emit_mechanism: inject\n")); err != nil {
+		t.Errorf("emit_mechanism inject: Parse = %v, want nil", err)
 	}
 	if _, err := Parse([]byte(base)); err != nil {
-		t.Errorf("emit_mechanism omitted (defaults to A): Parse = %v, want nil", err)
+		t.Errorf("emit_mechanism omitted (defaults to inject): Parse = %v, want nil", err)
 	}
 
-	// A well-formed mechanism-B descriptor parses and the sentinel fields
+	// A well-formed sentinel-swap descriptor parses and the sentinel fields
 	// round-trip onto the Entry.
 	const wantValue = "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA"
 	const wantEnv = "GH_TOKEN"
-	bYAML := base + "    emit_mechanism: " + string(binding.EmitMechanismB) + "\n" +
+	swapYAML := base + "    emit_mechanism: " + string(binding.EmitMechanismSentinelSwap) + "\n" +
 		"    sentinel:\n      value: " + wantValue + "\n      env: " + wantEnv + "\n"
-	d, err := Parse([]byte(bYAML))
+	d, err := Parse([]byte(swapYAML))
 	if err != nil {
-		t.Fatalf("well-formed mechanism B: Parse = %v, want nil", err)
+		t.Fatalf("well-formed sentinel-swap: Parse = %v, want nil", err)
 	}
 	e := d.Bindings[0]
-	if e.EmitMechanism != string(binding.EmitMechanismB) {
-		t.Errorf("emit_mechanism = %q, want %q", e.EmitMechanism, string(binding.EmitMechanismB))
+	if e.EmitMechanism != string(binding.EmitMechanismSentinelSwap) {
+		t.Errorf("emit_mechanism = %q, want %q", e.EmitMechanism, string(binding.EmitMechanismSentinelSwap))
 	}
 	if e.Sentinel == nil {
 		t.Fatalf("sentinel block = nil, want populated")
@@ -249,9 +260,9 @@ func TestParse_EmitMechanismBSentinelSchema(t *testing.T) {
 		t.Errorf("sentinel.env = %q, want %q", e.Sentinel.Env, wantEnv)
 	}
 
-	// The canonical constant is the value mechanism-B descriptors declare.
-	if string(binding.EmitMechanismB) != "B" {
-		t.Errorf("binding.EmitMechanismB = %q, want %q", string(binding.EmitMechanismB), "B")
+	// The canonical constant is the value sentinel-swap descriptors declare.
+	if string(binding.EmitMechanismSentinelSwap) != "sentinel-swap" {
+		t.Errorf("binding.EmitMechanismSentinelSwap = %q, want %q", string(binding.EmitMechanismSentinelSwap), "sentinel-swap")
 	}
 }
 
@@ -269,13 +280,13 @@ func TestParse_NoSecretBytesInDescriptor(t *testing.T) {
 		t.Errorf("credential_ref = %q, expected a vault reference, not a secret", e.CredentialRef)
 	}
 
-	// A mechanism-B sentinel value is a recognizable placeholder, not a
+	// A sentinel-swap sentinel value is a recognizable placeholder, not a
 	// secret: it embeds the reserved "AILERONSENTINEL" marker so a reader
 	// (or a log) can tell at a glance it carries no authority.
-	const bYAML = "version: v1\nbindings:\n  - host: api.github.com\n    credential_ref: user/github\n    scheme: bearer\n    emit_mechanism: B\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n"
-	db, err := Parse([]byte(bYAML))
+	const swapYAML = "version: v1\nbindings:\n  - host: api.github.com\n    credential_ref: user/github\n    scheme: bearer\n    emit_mechanism: sentinel-swap\n    sentinel:\n      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA\n      env: GH_TOKEN\n"
+	db, err := Parse([]byte(swapYAML))
 	if err != nil {
-		t.Fatalf("Parse mechanism B: %v", err)
+		t.Fatalf("Parse sentinel-swap: %v", err)
 	}
 	sentinel := db.Bindings[0].Sentinel
 	if sentinel == nil {

--- a/internal/proxybinding/github_defaults_test.go
+++ b/internal/proxybinding/github_defaults_test.go
@@ -12,8 +12,9 @@ import (
 // #1248), replacing the bespoke Go bindings. These tests assert the
 // descriptor contract through the public Load/LoadHostBindings output: the
 // two GitHub bindings appear in the built-in layer with no user descriptor
-// configured, github.com is basic/A with no sentinel, and api.github.com
-// is bearer/B carrying the GitHub sentinel value and GH_TOKEN env. They
+// configured, github.com is basic/inject with no sentinel, and
+// api.github.com is bearer/sentinel-swap carrying the GitHub sentinel value
+// and GH_TOKEN env. They
 // assert against the loaded table, never the file internals, so they
 // survive a descriptor reformat that preserves the contract.
 
@@ -29,8 +30,8 @@ func TestLoad_BuiltinIncludesGitHub(t *testing.T) {
 	if apex.Scheme != binding.SchemeBasic {
 		t.Errorf("github.com scheme = %q, want basic", apex.Scheme)
 	}
-	if apex.EmitMechanism != string(binding.EmitMechanismA) {
-		t.Errorf("github.com emit_mechanism = %q, want A", apex.EmitMechanism)
+	if apex.EmitMechanism != string(binding.EmitMechanismInject) {
+		t.Errorf("github.com emit_mechanism = %q, want inject", apex.EmitMechanism)
 	}
 	if apex.CredentialRef != "user/github" {
 		t.Errorf("github.com credential_ref = %q, want user/github", apex.CredentialRef)
@@ -38,9 +39,9 @@ func TestLoad_BuiltinIncludesGitHub(t *testing.T) {
 	if apex.Username != "x-access-token" {
 		t.Errorf("github.com username = %q, want x-access-token", apex.Username)
 	}
-	// Mechanism A carries no sentinel block.
+	// The inject mechanism carries no sentinel block.
 	if apex.Sentinel != nil {
-		t.Errorf("github.com carries a sentinel block %+v, want none for mechanism A", apex.Sentinel)
+		t.Errorf("github.com carries a sentinel block %+v, want none for inject", apex.Sentinel)
 	}
 
 	api, ok := findEntry(entries, "api.github.com")
@@ -50,14 +51,14 @@ func TestLoad_BuiltinIncludesGitHub(t *testing.T) {
 	if api.Scheme != binding.SchemeBearer {
 		t.Errorf("api.github.com scheme = %q, want bearer", api.Scheme)
 	}
-	if api.EmitMechanism != string(binding.EmitMechanismB) {
-		t.Errorf("api.github.com emit_mechanism = %q, want B", api.EmitMechanism)
+	if api.EmitMechanism != string(binding.EmitMechanismSentinelSwap) {
+		t.Errorf("api.github.com emit_mechanism = %q, want sentinel-swap", api.EmitMechanism)
 	}
 	if api.CredentialRef != "user/github" {
 		t.Errorf("api.github.com credential_ref = %q, want user/github", api.CredentialRef)
 	}
 	if api.Sentinel == nil {
-		t.Fatal("api.github.com missing sentinel block, want one for mechanism B")
+		t.Fatal("api.github.com missing sentinel block, want one for sentinel-swap")
 	}
 	if api.Sentinel.Value != sentinel.GitHubTokenSentinel {
 		t.Errorf("api.github.com sentinel.value = %q, want %q", api.Sentinel.Value, sentinel.GitHubTokenSentinel)
@@ -87,11 +88,11 @@ func TestLoadHostBindings_MatchesGitHub(t *testing.T) {
 	if apex.BasicUsername != "x-access-token" {
 		t.Errorf("github.com BasicUsername = %q, want x-access-token", apex.BasicUsername)
 	}
-	if apex.EmitMechanism != binding.EmitMechanismA {
-		t.Errorf("github.com EmitMechanism = %q, want A", apex.EmitMechanism)
+	if apex.EmitMechanism != binding.EmitMechanismInject {
+		t.Errorf("github.com EmitMechanism = %q, want inject", apex.EmitMechanism)
 	}
 	if apex.SentinelValue != "" || apex.SentinelEnv != "" {
-		t.Errorf("github.com carries a sentinel (%q,%q), want none for mechanism A", apex.SentinelValue, apex.SentinelEnv)
+		t.Errorf("github.com carries a sentinel (%q,%q), want none for inject", apex.SentinelValue, apex.SentinelEnv)
 	}
 
 	api, ok := table.Match("api.github.com")
@@ -101,8 +102,8 @@ func TestLoadHostBindings_MatchesGitHub(t *testing.T) {
 	if api.Scheme != binding.SchemeBearer {
 		t.Errorf("api.github.com scheme = %q, want bearer", api.Scheme)
 	}
-	if api.EmitMechanism != binding.EmitMechanismB {
-		t.Errorf("api.github.com EmitMechanism = %q, want B", api.EmitMechanism)
+	if api.EmitMechanism != binding.EmitMechanismSentinelSwap {
+		t.Errorf("api.github.com EmitMechanism = %q, want sentinel-swap", api.EmitMechanism)
 	}
 	if api.SentinelValue != sentinel.GitHubTokenSentinel {
 		t.Errorf("api.github.com SentinelValue = %q, want %q", api.SentinelValue, sentinel.GitHubTokenSentinel)
@@ -188,13 +189,13 @@ func TestLoad_UserOverridesGitHub(t *testing.T) {
 	}
 
 	// api.github.com is untouched by the override and stays the shipped
-	// default (bearer, mechanism B, GitHub sentinel).
+	// default (bearer, sentinel-swap, GitHub sentinel).
 	api, ok := findEntry(entries, "api.github.com")
 	if !ok {
 		t.Fatal("user override of github.com dropped the shipped api.github.com default")
 	}
-	if api.Scheme != binding.SchemeBearer || api.EmitMechanism != string(binding.EmitMechanismB) {
-		t.Errorf("api.github.com = %q/%q, want bearer/B (default preserved)", api.Scheme, api.EmitMechanism)
+	if api.Scheme != binding.SchemeBearer || api.EmitMechanism != string(binding.EmitMechanismSentinelSwap) {
+		t.Errorf("api.github.com = %q/%q, want bearer/sentinel-swap (default preserved)", api.Scheme, api.EmitMechanism)
 	}
 	if api.Sentinel == nil || api.Sentinel.Value != sentinel.GitHubTokenSentinel {
 		t.Errorf("api.github.com sentinel changed under a github.com-only override: %+v", api.Sentinel)

--- a/internal/sentinel/sentinel.go
+++ b/internal/sentinel/sentinel.go
@@ -4,18 +4,19 @@
 // recognizes and swaps for the real credential at egress (ADR-0019,
 // umbrella #1191).
 //
-// # Why a sentinel exists (emit-mechanism B)
+// # Why a sentinel exists (sentinel-swap)
 //
 // Some CLIs short-circuit locally when they hold no auth token: they
 // never issue the network request, so the proxy has nothing to seal.
 // `gh` is the canonical example. `gh api user` with no configured token
 // fails locally and emits no request to api.github.com.
 //
-// Emit-mechanism A (the launcher plants nothing; the CLI emits an
+// The inject mechanism (the launcher plants nothing; the CLI emits an
 // unauthenticated request the proxy seals at egress) therefore does not
-// work for such CLIs. Emit-mechanism B closes the gap: the launcher
-// plants a reserved, non-secret placeholder that passes the CLI's local
-// format check, so the CLI does issue the request. The proxy then
+// work for such CLIs. The sentinel-swap mechanism closes the gap: the
+// launcher plants a reserved, non-secret placeholder that passes the
+// CLI's local format check, so the CLI does issue the request. The proxy
+// then
 // recognizes the placeholder at egress and swaps in the real credential
 // it resolves daemon-side. The placeholder bytes never reach upstream.
 //
@@ -31,8 +32,8 @@
 // # Single source of truth
 //
 // This package supplies the canonical sentinel *value*, but the
-// recognizer no longer lives here (#1247). Recognition is binding-driven
-// at the proxy seam: a mechanism-B host binding carries the value it was
+// recognizer no longer lives here. Recognition is binding-driven
+// at the proxy seam: a sentinel-swap host binding carries the value it was
 // planted with, and the egress recognizer compares the inbound carrier
 // against that binding's value. The launch-side planter reads the same
 // value from the same binding, so the plant and the match cannot drift.
@@ -47,10 +48,10 @@ package sentinel
 // launcher plants as GH_TOKEN so `gh` treats itself as authenticated and
 // issues its request instead of short-circuiting. It is the canonical
 // GitHub sentinel value the GitHub host binding declares via WithSentinel
-// (and later github.yaml, #1248). The daemon proxy recognizes it at
-// egress by comparing the inbound carrier against the matched binding's
-// SentinelValue and swaps in the real user/github credential before the
-// request leaves the host (#1247).
+// in github.yaml. The daemon proxy recognizes it at egress by comparing
+// the inbound carrier against the matched binding's SentinelValue and
+// swaps in the real user/github credential before the request leaves the
+// host.
 //
 // Shape: it mimics `gh`'s classic personal-access-token format so `gh`'s
 // own local validation accepts it: the `ghp_` prefix followed by a


### PR DESCRIPTION
## Summary

Cross-cutting clarity pass for umbrella #1245: renames the A/B emit-mechanism identifiers and wire values to behavior names. The field name `emit_mechanism` and the `EmitMechanism` type name are unchanged; only the accepted values and the Go constants change.

- `A` -> `inject`, `B` -> `sentinel-swap` everywhere (descriptor wire values, Go constants, the `WithEmitMechanismSentinelSwap()` option, swap/planter decision keys).
- The descriptor parser now accepts ONLY `inject`/`sentinel-swap`. The bare legacy `A`/`B` are load-time errors, consistent with the closed-set fail-closed contract.
- Shipped defaults `github.yaml` and `linear.yaml` flip to the new values.
- ADR-0019's `#### Emit mechanisms` subsection names the two mechanisms by their behavior so the ADR connects to the descriptor wire values. The separate, unrelated **Model A / Model B** match-source axis is left byte-for-byte unchanged (verified: the `Model [AB]` line count is identical before and after).
- The binding-descriptors guide folds in the generalized framing: `sentinel-swap` works for any host that declares a `sentinel` block, with GitHub as one instance, no GitHub-only or "inert until a later issue" caveat.
- The CLI matrix table and prose rename `A`/`B` to `inject`/`sentinel-swap`.

No behavior change: the inject path, the sentinel-swap path, foreign-token passthrough, and the audit event shape are all preserved. Tests are renamed but keep their behavioral assertions. No `EmitMechanism` type rename, no `emit_mechanism` tag change, no sentinel-byte change, no OpenAPI/cmd/webapp changes.

## Test plan

- `task test:go` — full Go suite green (binding, proxybinding, app, launch, sentinel, model included).
- `go vet` on the touched packages — clean.
- `task lint:docs`, `task build:docs`, `task test:docs` — all green (Astro check 0 errors, 127 pages built, doc unit tests pass).
- Acceptance greps:
  - `\b(EmitMechanism[AB]|WithEmitMechanismB)\b` over `internal/*.go` — empty.
  - `\bmechanism [AB]\b|\bmechanism-[AB]\b|\bemit-mechanism [AB]\b` over `internal/` + the three doc files — empty.
  - `emit_mechanism:\s*[AB]\b` over `internal/`/`docs/` — only the two intentional rejection-test fixtures in `descriptor_test.go` that assert the legacy values are now refused.
  - `Model [AB]` line count in ADR-0019 unchanged (7 before, 7 after).
- CodeRabbit review against `main` — 0 findings.

Closes #1249

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated binding descriptor documentation with explicit emit mechanism naming (`inject` and `sentinel-swap`) replacing previous abstract labels.
  * Clarified credential handling behavior and sentinel-based authentication flows in guides and architecture documentation.

* **Improvements**
  * Strengthened validation of credential binding configurations with clearer error messages for mechanism constraints and sentinel requirements.
  * Updated default credential bindings to use explicit mechanism identifiers for improved transparency.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->