### PR TITLE
feat(launch): add host-side credential acquisition SPI + seeding plumbing

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -87,13 +87,14 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		sandboxRuntime := launchFlags.String("sandbox", "off", "Prepare sandbox image with runtime: off, auto, or docker")
 		sandboxBuild := launchFlags.String("sandbox-build", "auto", "Sandbox build policy during launch: auto, always, or never")
 		sandboxProxy := launchFlags.String("sandbox-proxy", "auto", "Sandbox HTTPS proxy bootstrap: auto, on, or off (auto = on for --sandbox=docker)")
+		hostLogin := launchFlags.String("host-login", "auto", "Host-side credential acquisition on vault miss: auto, on, or off (off forces in-container login)")
 		if err := launchFlags.Parse(args[1:]); err != nil {
 			return 1
 		}
 		launchArgs := launchFlags.Args()
 
 		if len(launchArgs) < 1 {
-			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] [--sandbox=off|auto|docker] [--sandbox-build=auto|always|never] [--sandbox-proxy=auto|on|off] <agent> [args...]")
+			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] [--sandbox=off|auto|docker] [--sandbox-build=auto|always|never] [--sandbox-proxy=auto|on|off] [--host-login=auto|on|off] <agent> [args...]")
 			fmt.Fprintf(stderr, "agents: %s\n", strings.Join(registry.Names(), ", "))
 			return 1
 		}
@@ -131,6 +132,7 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 			SandboxRuntime:     *sandboxRuntime,
 			SandboxBuildPolicy: *sandboxBuild,
 			SandboxProxy:       *sandboxProxy,
+			HostLogin:          *hostLogin,
 		})
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %v\n", err)
@@ -457,7 +459,7 @@ var launchFn = launch.Launch
 // `--flag` / `--flag=value` forms.
 func launchFlagTakesValue(name string) bool {
 	switch name {
-	case "log-level", "sandbox", "sandbox-build", "sandbox-proxy":
+	case "log-level", "sandbox", "sandbox-build", "sandbox-proxy", "host-login":
 		return true
 	default:
 		return false

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -174,6 +174,49 @@ func TestRun_LaunchPassesSandboxOptions(t *testing.T) {
 	if captured.SandboxProxy != "auto" {
 		t.Errorf("LaunchConfig.SandboxProxy = %q, want auto (default)", captured.SandboxProxy)
 	}
+	// --host-login defaults to "auto" so the launcher's resolver enables
+	// host-side acquisition when a binding declares one.
+	if captured.HostLogin != "auto" {
+		t.Errorf("LaunchConfig.HostLogin = %q, want auto (default)", captured.HostLogin)
+	}
+}
+
+// TestRun_LaunchPropagatesHostLoginFlag verifies the CLI threads the
+// --host-login flag through to LaunchConfig.HostLogin in both the
+// before-agent and trailing forms.
+func TestRun_LaunchPropagatesHostLoginFlag(t *testing.T) {
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+
+	cases := []struct {
+		name string
+		args []string
+		want string
+	}{
+		{"before agent", []string{"launch", "--host-login=off", "claude"}, "off"},
+		{"trailing eq form", []string{"launch", "claude", "--host-login=off"}, "off"},
+		{"trailing space form", []string{"launch", "claude", "--host-login", "on"}, "on"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured launch.LaunchConfig
+			launchFn = func(_ context.Context, cfg launch.LaunchConfig) (launch.LaunchResult, error) {
+				captured = cfg
+				return launch.LaunchResult{ExitCode: 0}, nil
+			}
+			var stdout, stderr bytes.Buffer
+			code := run(tc.args, newTestRegistry(), &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit = %d (stderr=%q)", code, stderr.String())
+			}
+			if captured.HostLogin != tc.want {
+				t.Errorf("LaunchConfig.HostLogin = %q, want %q", captured.HostLogin, tc.want)
+			}
+			if len(captured.Args) != 0 {
+				t.Errorf("host-login flag leaked to agent args: %v", captured.Args)
+			}
+		})
+	}
 }
 
 // TestRun_LaunchPropagatesSandboxProxyFlag verifies the CLI threads

--- a/internal/launch/authspec.go
+++ b/internal/launch/authspec.go
@@ -8,6 +8,7 @@ import (
 	"net/http"
 	"strings"
 
+	"github.com/ALRubinger/aileron/internal/oauth"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
 
@@ -148,6 +149,40 @@ type FileBinding struct {
 	// failed persist aborts the launch.
 	PreLaunchRefresh func(vault.Secret, RefreshDeps) (vault.Secret, error)
 
+	// HostAcquire, when non-nil, is a host-side credential acquirer the
+	// launcher invokes when the vault GET for this binding misses and
+	// the binding is not Required. It runs on the host (browser +
+	// loopback callback + token exchange, all pure Go) and returns the
+	// vault.Secret the launcher then PUTs through the daemon and renders
+	// to the bind-mounted file — exactly as a vault-resident credential
+	// would be. No token is ever placed in the agent's environment; the
+	// acquired Secret follows the same vault-seeded path as every other
+	// credential (ADR-0025).
+	//
+	// Contract:
+	//
+	//   - The returned Secret must satisfy this same binding's Render.
+	//     The launcher renders the acquired Secret immediately, so a
+	//     malformed envelope surfaces as a launch-aborting Render error
+	//     rather than seeding garbage into the vault.
+	//
+	//   - The acquirer must NOT assume the agent CLI is installed on the
+	//     host. Acquisition is pure Go (HTTP + browser open); the
+	//     launcher never shells out to the agent binary.
+	//
+	//   - A returned Secret with an empty Value, or a cancelled/failed
+	//     acquire (non-nil error), is non-fatal: the launcher logs a
+	//     warning and falls back to the legacy in-container login path
+	//     (no file written; capture-on-exit seeds the vault). Only a
+	//     daemon PUT failure or a Render failure of a successfully
+	//     acquired Secret aborts the launch.
+	//
+	// A nil HostAcquire preserves the legacy in-container path. The
+	// per-launch `--host-login` flag (and AILERON_LAUNCH_HOST_LOGIN env)
+	// can force the legacy path even for a binding that declares an
+	// acquirer.
+	HostAcquire func(context.Context, HostAcquireDeps) (vault.Secret, error)
+
 	// MountAsFile selects file-mount vs parent-dir mount strategy.
 	//
 	// When false (default), the launcher bind-mounts the binding's
@@ -201,6 +236,35 @@ type RefreshDeps struct {
 	// daemon client so the hook never opens the vault file itself —
 	// the daemon is the single trust boundary per ADR-0011.
 	PutAgentCredentials func(secret vault.Secret) error
+}
+
+// HostAcquireDeps is the bag of helpers a FileBinding's HostAcquire
+// hook needs to run a host-side OAuth flow: an HTTP client for the
+// token exchange and a browser opener for the consent URL. The
+// launcher fills it in before invoking the hook.
+//
+// Note the absence of a PutAgentCredentials helper: unlike
+// RefreshDeps, the acquirer does not persist the credential itself.
+// The launcher owns the PUT (and the immediate Render that validates
+// the acquired Secret), so the acquirer cannot skip seeding or seed an
+// envelope its own binding's Render would reject. This mirrors how
+// prepareAuthSpec owns the Render write for a vault-resident
+// credential.
+type HostAcquireDeps struct {
+	// Ctx is the launch context, propagated so the host OAuth flow
+	// (browser open, loopback callback wait, token POST) honors
+	// cancellation when the user kills the launch.
+	Ctx context.Context
+
+	// HTTPClient drives the token-exchange POST against the vendor's
+	// token URL. Tests inject httptest-backed clients; production uses
+	// a shared client with a sane timeout.
+	HTTPClient *http.Client
+
+	// Browser opens the provider's consent URL on the host. The default
+	// is oauth.SystemBrowser{}; tests inject a fake Opener so the flow
+	// runs headless.
+	Browser oauth.Opener
 }
 
 // ErrAuthSpecRenderNil is returned by validateAuthSpec when a

--- a/internal/launch/authspec_container_read_integration_test.go
+++ b/internal/launch/authspec_container_read_integration_test.go
@@ -120,7 +120,7 @@ func TestAuthSpecInContainerCredentialReadCapture(t *testing.T) {
 		daemon := newFakeDaemon()
 		daemon.seed(claudeVaultName, seeded)
 
-		prep, err := prepareAuthSpec(ctx, claudeVaultName, claudeFixtureAuthSpec(), daemon, newTestLogger(), io.Discard, chownFn, reclaimFn)
+		prep, err := prepareAuthSpec(ctx, claudeVaultName, claudeFixtureAuthSpec(), daemon, newTestLogger(), io.Discard, chownFn, reclaimFn, true)
 		if err != nil {
 			t.Fatalf("prepareAuthSpec: %v", err)
 		}
@@ -163,7 +163,7 @@ func TestAuthSpecInContainerCredentialReadCapture(t *testing.T) {
 		daemon := newFakeDaemon()
 		daemon.seed(claudeVaultName, seeded)
 
-		prep, err := prepareAuthSpec(ctx, claudeVaultName, claudeFixtureAuthSpec(), daemon, newTestLogger(), io.Discard, chownFn, reclaimFn)
+		prep, err := prepareAuthSpec(ctx, claudeVaultName, claudeFixtureAuthSpec(), daemon, newTestLogger(), io.Discard, chownFn, reclaimFn, true)
 		if err != nil {
 			t.Fatalf("prepareAuthSpec: %v", err)
 		}

--- a/internal/launch/authspec_host_acquire_test.go
+++ b/internal/launch/authspec_host_acquire_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"encoding/json"
 	"errors"
+	"fmt"
 	"os"
 	"path/filepath"
 	"testing"
@@ -53,8 +54,19 @@ func (s *spyAcquirer) acquire(_ context.Context, deps HostAcquireDeps) (vault.Se
 // claude .credentials.json claudeAiOauth.expiresAt format (ms, not seconds).
 const futureExpiresAtMS int64 = 1893456000000 // 2030-01-01Z
 
+// acquireClaudeEnvelope builds a self-contained claude oauth envelope for the
+// host-acquire tests. These tests are hermetic unit tests (no build tag), so
+// they cannot reuse the integration_sandbox-tagged claudeEnvelope helper in
+// authspec_container_read_integration_test.go; a uniquely-named local builder
+// keeps both the tagged and untagged builds compiling.
+func acquireClaudeEnvelope(access string, expiresAtMS int64) []byte {
+	return []byte(fmt.Sprintf(
+		`{"claudeAiOauth":{"accessToken":%q,"refreshToken":"rt","expiresAt":%d}}`,
+		access, expiresAtMS))
+}
+
 func TestPrepareAuthSpec_HostAcquireSeedsVaultAndRenders(t *testing.T) {
-	envelope := claudeEnvelope("acquired-tok", futureExpiresAtMS)
+	envelope := acquireClaudeEnvelope("acquired-tok", futureExpiresAtMS)
 	daemon := newFakeDaemon() // empty vault
 
 	spy := &spyAcquirer{secret: vault.Secret{Value: envelope, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}}
@@ -194,7 +206,7 @@ func TestPrepareAuthSpec_HostAcquireEmptySecretFallsBack(t *testing.T) {
 
 func TestPrepareAuthSpec_HostLoginDisabledSkipsAcquirer(t *testing.T) {
 	daemon := newFakeDaemon()
-	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok", futureExpiresAtMS)}}
+	spy := &spyAcquirer{secret: vault.Secret{Value: acquireClaudeEnvelope("tok", futureExpiresAtMS)}}
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{
 			VaultPath:     "agents/claude/oauth",
@@ -227,7 +239,7 @@ func TestPrepareAuthSpec_HostLoginDisabledSkipsAcquirer(t *testing.T) {
 func TestPrepareAuthSpec_HostAcquirePutFailureAbortsLaunch(t *testing.T) {
 	daemon := newFakeDaemon()
 	daemon.putErrors["claude"] = errors.New("vault locked")
-	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok", futureExpiresAtMS)}}
+	spy := &spyAcquirer{secret: vault.Secret{Value: acquireClaudeEnvelope("tok", futureExpiresAtMS)}}
 
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{
@@ -258,7 +270,7 @@ func TestPrepareAuthSpec_HostAcquirePutFailureAbortsLaunch(t *testing.T) {
 
 func TestPrepareAuthSpec_RequiredBindingIgnoresAcquirer(t *testing.T) {
 	daemon := newFakeDaemon() // empty vault
-	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok", futureExpiresAtMS)}}
+	spy := &spyAcquirer{secret: vault.Secret{Value: acquireClaudeEnvelope("tok", futureExpiresAtMS)}}
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{
 			VaultPath:     "agents/claude/oauth",
@@ -285,7 +297,7 @@ func TestPrepareAuthSpec_RequiredBindingIgnoresAcquirer(t *testing.T) {
 // daemon PUT match the file written into the mount.
 func TestPrepareAuthSpec_HostAcquireRoundTripsClaudeEnvelope(t *testing.T) {
 	daemon := newFakeDaemon()
-	envelope := claudeEnvelope("round-trip-tok", futureExpiresAtMS)
+	envelope := acquireClaudeEnvelope("round-trip-tok", futureExpiresAtMS)
 	spy := &spyAcquirer{secret: vault.Secret{Value: envelope}}
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{

--- a/internal/launch/authspec_host_acquire_test.go
+++ b/internal/launch/authspec_host_acquire_test.go
@@ -49,12 +49,12 @@ func (s *spyAcquirer) acquire(_ context.Context, deps HostAcquireDeps) (vault.Se
 	return s.secret, s.err
 }
 
-func claudeEnvelope(access string) []byte {
-	return []byte(`{"claudeAiOauth":{"accessToken":"` + access + `","refreshToken":"rt"}}`)
-}
+// futureExpiresAtMS is a far-future expiry in MILLISECONDS, matching the real
+// claude .credentials.json claudeAiOauth.expiresAt format (ms, not seconds).
+const futureExpiresAtMS int64 = 1893456000000 // 2030-01-01Z
 
 func TestPrepareAuthSpec_HostAcquireSeedsVaultAndRenders(t *testing.T) {
-	envelope := claudeEnvelope("acquired-tok")
+	envelope := claudeEnvelope("acquired-tok", futureExpiresAtMS)
 	daemon := newFakeDaemon() // empty vault
 
 	spy := &spyAcquirer{secret: vault.Secret{Value: envelope, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}}
@@ -194,7 +194,7 @@ func TestPrepareAuthSpec_HostAcquireEmptySecretFallsBack(t *testing.T) {
 
 func TestPrepareAuthSpec_HostLoginDisabledSkipsAcquirer(t *testing.T) {
 	daemon := newFakeDaemon()
-	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok")}}
+	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok", futureExpiresAtMS)}}
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{
 			VaultPath:     "agents/claude/oauth",
@@ -227,7 +227,7 @@ func TestPrepareAuthSpec_HostLoginDisabledSkipsAcquirer(t *testing.T) {
 func TestPrepareAuthSpec_HostAcquirePutFailureAbortsLaunch(t *testing.T) {
 	daemon := newFakeDaemon()
 	daemon.putErrors["claude"] = errors.New("vault locked")
-	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok")}}
+	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok", futureExpiresAtMS)}}
 
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{
@@ -258,7 +258,7 @@ func TestPrepareAuthSpec_HostAcquirePutFailureAbortsLaunch(t *testing.T) {
 
 func TestPrepareAuthSpec_RequiredBindingIgnoresAcquirer(t *testing.T) {
 	daemon := newFakeDaemon() // empty vault
-	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok")}}
+	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok", futureExpiresAtMS)}}
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{
 			VaultPath:     "agents/claude/oauth",
@@ -285,7 +285,7 @@ func TestPrepareAuthSpec_RequiredBindingIgnoresAcquirer(t *testing.T) {
 // daemon PUT match the file written into the mount.
 func TestPrepareAuthSpec_HostAcquireRoundTripsClaudeEnvelope(t *testing.T) {
 	daemon := newFakeDaemon()
-	envelope := claudeEnvelope("round-trip-tok")
+	envelope := claudeEnvelope("round-trip-tok", futureExpiresAtMS)
 	spy := &spyAcquirer{secret: vault.Secret{Value: envelope}}
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{

--- a/internal/launch/authspec_host_acquire_test.go
+++ b/internal/launch/authspec_host_acquire_test.go
@@ -1,0 +1,373 @@
+package launch
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/oauth"
+	"github.com/ALRubinger/aileron/internal/vault"
+)
+
+// authspec host-acquire contract (#1268):
+//
+//   - Empty vault + declared HostAcquire + host-login enabled →
+//     acquire on host, PUT the returned Secret through the daemon, and
+//     render+mount the credential exactly as a vault-resident one
+//     (RenderedAnyCredential == true so the in-container status line is
+//     suppressed).
+//   - Acquire error → non-fatal fallback: no PUT, legacy in-container
+//     capture target (PresentAtRender == false).
+//   - Acquire returns an empty Secret → fallback, no PUT.
+//   - host-login disabled → acquirer never invoked even when declared.
+//   - daemon PUT failure after a successful acquire → launch aborts and
+//     cleanup runs.
+//   - Required binding → required-but-empty error path is unchanged;
+//     the acquirer is never consulted (the required check runs first).
+//   - The acquired Secret round-trips the binding's own Render (a
+//     Claude-shaped envelope), and a malformed acquired Secret surfaces
+//     the Render error rather than silently seeding garbage.
+
+// spyAcquirer is a HostAcquire hook that records its invocation count
+// and returns a configurable Secret/error. It also captures the deps it
+// was handed so tests can assert the launcher wired a Browser through.
+type spyAcquirer struct {
+	calls    int
+	secret   vault.Secret
+	err      error
+	gotDeps  HostAcquireDeps
+	gotBrows oauth.Opener
+}
+
+func (s *spyAcquirer) acquire(_ context.Context, deps HostAcquireDeps) (vault.Secret, error) {
+	s.calls++
+	s.gotDeps = deps
+	s.gotBrows = deps.Browser
+	return s.secret, s.err
+}
+
+func claudeEnvelope(access string) []byte {
+	return []byte(`{"claudeAiOauth":{"accessToken":"` + access + `","refreshToken":"rt"}}`)
+}
+
+func TestPrepareAuthSpec_HostAcquireSeedsVaultAndRenders(t *testing.T) {
+	envelope := claudeEnvelope("acquired-tok")
+	daemon := newFakeDaemon() // empty vault
+
+	spy := &spyAcquirer{secret: vault.Secret{Value: envelope, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}}
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Mode:          0o600,
+			Required:      false,
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture: func(b []byte) (vault.Secret, error) {
+				return vault.Secret{Value: b, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}, nil
+			},
+			HostAcquire: spy.acquire,
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if spy.calls != 1 {
+		t.Fatalf("acquirer calls = %d, want 1", spy.calls)
+	}
+	if spy.gotBrows == nil {
+		t.Errorf("acquirer deps Browser is nil; launcher should default to oauth.SystemBrowser{}")
+	}
+	if _, ok := spy.gotBrows.(oauth.SystemBrowser); !ok {
+		t.Errorf("acquirer deps Browser = %T, want oauth.SystemBrowser", spy.gotBrows)
+	}
+	if spy.gotDeps.HTTPClient == nil {
+		t.Errorf("acquirer deps HTTPClient is nil; launcher should supply a timed client")
+	}
+
+	if len(daemon.puts) != 1 {
+		t.Fatalf("PUTs = %d, want exactly 1 (the host-acquired seed)", len(daemon.puts))
+	}
+	if daemon.puts[0].Name != "claude" {
+		t.Errorf("PUT name = %q, want claude", daemon.puts[0].Name)
+	}
+	if string(daemon.puts[0].Secret.Value) != string(envelope) {
+		t.Errorf("PUT value = %q, want %q", daemon.puts[0].Secret.Value, envelope)
+	}
+
+	if !prep.RenderedAnyCredential {
+		t.Errorf("RenderedAnyCredential = false; a successful host-acquire must suppress the in-container status line")
+	}
+
+	if len(prep.Mounts) != 1 {
+		t.Fatalf("Mounts = %d, want 1", len(prep.Mounts))
+	}
+	rendered := filepath.Join(prep.Mounts[0].Source, ".credentials.json")
+	got, err := os.ReadFile(rendered)
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+	if string(got) != string(envelope) {
+		t.Errorf("rendered bytes = %q, want %q", got, envelope)
+	}
+}
+
+func TestPrepareAuthSpec_HostAcquireErrorFallsBackToInContainer(t *testing.T) {
+	daemon := newFakeDaemon() // empty vault
+	spy := &spyAcquirer{err: errors.New("user cancelled consent")}
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Required:      false,
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+			HostAcquire:   spy.acquire,
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v (acquire failure must be non-fatal)", err)
+	}
+	defer prep.Cleanup()
+
+	if spy.calls != 1 {
+		t.Fatalf("acquirer calls = %d, want 1", spy.calls)
+	}
+	if len(daemon.puts) != 0 {
+		t.Errorf("PUTs = %d, want 0 (acquire failed → no seed)", len(daemon.puts))
+	}
+	if prep.RenderedAnyCredential {
+		t.Errorf("RenderedAnyCredential = true; an acquire failure must leave it false so the status line prints")
+	}
+	// Legacy capture target must exist (PresentAtRender == false) and no
+	// file should be written for the binding.
+	if len(prep.Mounts) != 1 {
+		t.Fatalf("Mounts = %d, want 1 (empty group dir for the capture target)", len(prep.Mounts))
+	}
+	entries, err := os.ReadDir(prep.Mounts[0].Source)
+	if err != nil {
+		t.Fatalf("read dir: %v", err)
+	}
+	if len(entries) != 0 {
+		t.Errorf("transient dir not empty after fallback: %v", entries)
+	}
+}
+
+func TestPrepareAuthSpec_HostAcquireEmptySecretFallsBack(t *testing.T) {
+	daemon := newFakeDaemon()
+	spy := &spyAcquirer{secret: vault.Secret{}} // empty Value
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Required:      false,
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+			HostAcquire:   spy.acquire,
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if spy.calls != 1 {
+		t.Fatalf("acquirer calls = %d, want 1", spy.calls)
+	}
+	if len(daemon.puts) != 0 {
+		t.Errorf("PUTs = %d, want 0 (empty Secret → fallback, no seed)", len(daemon.puts))
+	}
+	if prep.RenderedAnyCredential {
+		t.Errorf("RenderedAnyCredential = true; an empty acquired Secret must fall back")
+	}
+}
+
+func TestPrepareAuthSpec_HostLoginDisabledSkipsAcquirer(t *testing.T) {
+	daemon := newFakeDaemon()
+	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok")}}
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Required:      false,
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+			HostAcquire:   spy.acquire,
+		}},
+	}
+
+	// hostLoginEnabled == false: the acquirer must never be invoked.
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, false)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if spy.calls != 0 {
+		t.Errorf("acquirer calls = %d, want 0 (host-login disabled)", spy.calls)
+	}
+	if len(daemon.puts) != 0 {
+		t.Errorf("PUTs = %d, want 0", len(daemon.puts))
+	}
+	if prep.RenderedAnyCredential {
+		t.Errorf("RenderedAnyCredential = true; disabled host-login must take the in-container path")
+	}
+}
+
+func TestPrepareAuthSpec_HostAcquirePutFailureAbortsLaunch(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.putErrors["claude"] = errors.New("vault locked")
+	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok")}}
+
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Required:      false,
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+			HostAcquire:   spy.acquire,
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err == nil {
+		t.Fatal("expected error when daemon PUT of the host-acquired secret fails")
+	}
+	if spy.calls != 1 {
+		t.Errorf("acquirer calls = %d, want 1", spy.calls)
+	}
+	// The abort must have run cleanup (transient dir removed) and left no
+	// usable mount list. Cleanup is idempotent, so calling it again is
+	// safe regardless.
+	prep.Cleanup()
+	if len(prep.Mounts) != 0 {
+		t.Errorf("Mounts = %d on aborted launch, want 0", len(prep.Mounts))
+	}
+}
+
+func TestPrepareAuthSpec_RequiredBindingIgnoresAcquirer(t *testing.T) {
+	daemon := newFakeDaemon() // empty vault
+	spy := &spyAcquirer{secret: vault.Secret{Value: claudeEnvelope("tok")}}
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Required:      true, // required-but-empty must error before acquire
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+			HostAcquire:   spy.acquire,
+		}},
+	}
+
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err == nil {
+		t.Fatal("expected required-but-empty error")
+	}
+	if spy.calls != 0 {
+		t.Errorf("acquirer calls = %d, want 0 (required check precedes acquire)", spy.calls)
+	}
+}
+
+// TestPrepareAuthSpec_HostAcquireRoundTripsClaudeEnvelope proves the
+// acquired Secret is validated by a real render-shaped function: the
+// binding's own Render parses the Claude envelope, and the bytes the
+// daemon PUT match the file written into the mount.
+func TestPrepareAuthSpec_HostAcquireRoundTripsClaudeEnvelope(t *testing.T) {
+	daemon := newFakeDaemon()
+	envelope := claudeEnvelope("round-trip-tok")
+	spy := &spyAcquirer{secret: vault.Secret{Value: envelope}}
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Mode:          0o600,
+			Required:      false,
+			Render:        claudeShapedRender,
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+			HostAcquire:   spy.acquire,
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if len(daemon.puts) != 1 {
+		t.Fatalf("PUTs = %d, want 1", len(daemon.puts))
+	}
+	// The PUT'd bytes must themselves pass the binding's Render.
+	if _, err := claudeShapedRender(daemon.puts[0].Secret); err != nil {
+		t.Errorf("PUT'd secret does not round-trip Render: %v", err)
+	}
+	// The file on disk must equal the rendered bytes.
+	rendered := filepath.Join(prep.Mounts[0].Source, ".credentials.json")
+	got, err := os.ReadFile(rendered)
+	if err != nil {
+		t.Fatalf("read rendered file: %v", err)
+	}
+	want, _ := claudeShapedRender(spy.secret)
+	if string(got) != string(want) {
+		t.Errorf("file bytes = %q, want rendered %q", got, want)
+	}
+}
+
+// TestPrepareAuthSpec_HostAcquireMalformedSecretAborts proves a
+// malformed acquired Secret surfaces the Render error (launch aborts)
+// rather than silently seeding garbage. The daemon PUT happens first
+// (AE6), so the abort path is the Render call.
+func TestPrepareAuthSpec_HostAcquireMalformedSecretAborts(t *testing.T) {
+	daemon := newFakeDaemon()
+	spy := &spyAcquirer{secret: vault.Secret{Value: []byte("not json")}}
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Required:      false,
+			Render:        claudeShapedRender,
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+			HostAcquire:   spy.acquire,
+		}},
+	}
+
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err == nil {
+		t.Fatal("expected Render error for a malformed acquired secret")
+	}
+	if spy.calls != 1 {
+		t.Errorf("acquirer calls = %d, want 1", spy.calls)
+	}
+}
+
+// claudeShapedRender mirrors the Claude credential envelope's Render
+// contract: it requires a non-empty accessToken under claudeAiOauth and
+// returns the canonical bytes. It lives in the test because the launch
+// package cannot import the agents package (agents imports launch).
+func claudeShapedRender(s vault.Secret) ([]byte, error) {
+	type claudeOauth struct {
+		ClaudeAiOauth struct {
+			AccessToken  string `json:"accessToken"`
+			RefreshToken string `json:"refreshToken"`
+		} `json:"claudeAiOauth"`
+	}
+	var env claudeOauth
+	if err := json.Unmarshal(s.Value, &env); err != nil {
+		return nil, err
+	}
+	if env.ClaudeAiOauth.AccessToken == "" {
+		return nil, errors.New("claude envelope missing accessToken")
+	}
+	return s.Value, nil
+}

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -14,6 +14,7 @@ import (
 	"strings"
 	"time"
 
+	"github.com/ALRubinger/aileron/internal/oauth"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
@@ -144,6 +145,7 @@ func prepareAuthSpec(
 	stderr io.Writer,
 	chownTransientDir func(dir string) error,
 	reclaimTransientDir func(dir string) error,
+	hostLoginEnabled bool,
 ) (authSpecPrep, error) {
 	prep := authSpecPrep{
 		EnvAdditions: map[string]string{},
@@ -260,6 +262,50 @@ func prepareAuthSpec(
 	// refresh, Render bytes, write to the host-side subdir under the
 	// group dir for the binding's container parent. Track for capture.
 	fileMounts := []sandboxcontainer.Volume{}
+
+	// renderAndMount is the shared "render + write + mount +
+	// captureTarget" tail for a binding whose Secret is present at
+	// render time. It is reached both from the present-vault path and
+	// from the host-acquire success path so the two cannot diverge. On
+	// any error it runs cleanup and returns a launch-aborting error.
+	renderAndMount := func(fb FileBinding, hostDir string, secret vault.Secret) error {
+		rendered, renderErr := fb.Render(secret)
+		if renderErr != nil {
+			cleanup()
+			return fmt.Errorf("auth spec: render file binding %q: %w", fb.VaultPath, renderErr)
+		}
+		hostPath := filepath.Join(hostDir, path.Base(fb.ContainerPath))
+		mode := fb.Mode
+		if mode == 0 {
+			mode = 0o600
+		}
+		if err := os.WriteFile(hostPath, rendered, mode); err != nil {
+			cleanup()
+			return fmt.Errorf("auth spec: write %s: %w", hostPath, err)
+		}
+		prep.RenderedAnyCredential = true
+		captureTargets = append(captureTargets, fileCapture{
+			HostPath:        hostPath,
+			VaultName:       vaultBindingTail(fb.VaultPath),
+			Capture:         fb.Capture,
+			PresentAtRender: true,
+			Fresher:         fb.Fresher,
+		})
+		// MountAsFile bindings get an individual file mount at
+		// ContainerPath. The mount is writable so Capture can read
+		// back any in-container update the agent makes; for v1, no
+		// agent that uses MountAsFile actually rotates in-container,
+		// but writable keeps the API future-proof.
+		if fb.MountAsFile {
+			fileMounts = append(fileMounts, sandboxcontainer.Volume{
+				Source:   hostPath,
+				Target:   fb.ContainerPath,
+				ReadOnly: false,
+			})
+		}
+		return nil
+	}
+
 	for i, fb := range spec.FileBindings {
 		containerParent := path.Dir(fb.ContainerPath)
 		hostDir, err := ensureGroup(containerParent)
@@ -282,12 +328,52 @@ func prepareAuthSpec(
 				return prep, fmt.Errorf("auth spec: file binding %d at %q is required but the vault is empty — seed with `aileron vault put %s`",
 					i, fb.VaultPath, fb.VaultPath)
 			}
-			// Required=false on empty vault: the in-container agent
-			// performs its own login (paste-the-code OAuth fallback
-			// for Claude, device-auth for Codex). Capture on clean
-			// exit seeds the vault. No file written for this binding,
-			// but the group dir still exists for StaticFiles or
-			// other file bindings under the same parent.
+			// Required=false on empty vault. If the binding declares a
+			// host acquirer and host-login is enabled, run the host-side
+			// OAuth flow, PUT the acquired Secret through the daemon
+			// (AE6: vault before render/start), then fall through to the
+			// shared render-and-mount tail so the credential is treated
+			// exactly as a vault-resident one. The status line in
+			// launcher.go is suppressed automatically because the tail
+			// sets RenderedAnyCredential = true.
+			if fb.HostAcquire != nil && hostLoginEnabled {
+				acquired, acqErr := fb.HostAcquire(ctx, HostAcquireDeps{
+					Ctx:        ctx,
+					HTTPClient: preLaunchRefreshHTTPClient(),
+					Browser:    oauth.SystemBrowser{},
+				})
+				switch {
+				case acqErr != nil:
+					// Acquire failed or was cancelled. Non-fatal: warn
+					// and fall back to the legacy in-container path.
+					captureWarn(sessionLog, stderr, agentName, fb.VaultPath,
+						fmt.Errorf("host credential acquisition failed: %w; falling back to in-container login", acqErr))
+				case len(acquired.Value) == 0:
+					// Acquirer returned an empty Secret (e.g. user
+					// declined consent). Treat as fallback, no PUT.
+					sessionLog.Info("host credential acquisition returned empty secret; falling back to in-container login",
+						"agent", agentName, "vault_path", fb.VaultPath)
+				default:
+					// AE6 ordering: persist to the vault before the
+					// container starts. A PUT failure aborts the launch
+					// rather than silently dropping a just-acquired
+					// credential.
+					if err := daemon.PutAgentCredentials(ctx, vaultBindingTail(fb.VaultPath), acquired); err != nil {
+						cleanup()
+						return prep, fmt.Errorf("auth spec: persist host-acquired credential %q: %w", fb.VaultPath, err)
+					}
+					if err := renderAndMount(fb, hostDir, acquired); err != nil {
+						return prep, err
+					}
+					continue
+				}
+			}
+			// Legacy in-container path: the agent performs its own login
+			// (paste-the-code OAuth fallback for Claude, device-auth for
+			// Codex). Capture on clean exit seeds the vault. No file
+			// written for this binding, but the group dir still exists
+			// for StaticFiles or other file bindings under the same
+			// parent.
 			captureTargets = append(captureTargets, fileCapture{
 				HostPath:        filepath.Join(hostDir, path.Base(fb.ContainerPath)),
 				VaultName:       vaultBindingTail(fb.VaultPath),
@@ -319,39 +405,8 @@ func prepareAuthSpec(
 			secret = refreshed
 		}
 
-		rendered, renderErr := fb.Render(secret)
-		if renderErr != nil {
-			cleanup()
-			return prep, fmt.Errorf("auth spec: render file binding %d %q: %w", i, fb.VaultPath, renderErr)
-		}
-		hostPath := filepath.Join(hostDir, path.Base(fb.ContainerPath))
-		mode := fb.Mode
-		if mode == 0 {
-			mode = 0o600
-		}
-		if err := os.WriteFile(hostPath, rendered, mode); err != nil {
-			cleanup()
-			return prep, fmt.Errorf("auth spec: write %s: %w", hostPath, err)
-		}
-		prep.RenderedAnyCredential = true
-		captureTargets = append(captureTargets, fileCapture{
-			HostPath:        hostPath,
-			VaultName:       vaultBindingTail(fb.VaultPath),
-			Capture:         fb.Capture,
-			PresentAtRender: true,
-			Fresher:         fb.Fresher,
-		})
-		// MountAsFile bindings get an individual file mount at
-		// ContainerPath. The mount is writable so Capture can read
-		// back any in-container update the agent makes; for v1, no
-		// agent that uses MountAsFile actually rotates in-container,
-		// but writable keeps the API future-proof.
-		if fb.MountAsFile {
-			fileMounts = append(fileMounts, sandboxcontainer.Volume{
-				Source:   hostPath,
-				Target:   fb.ContainerPath,
-				ReadOnly: false,
-			})
+		if err := renderAndMount(fb, hostDir, secret); err != nil {
+			return prep, err
 		}
 	}
 

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -129,7 +129,7 @@ func newTestLogger() *slog.Logger {
 
 func TestPrepareAuthSpec_EmptySpecIsNoOp(t *testing.T) {
 	prep, err := prepareAuthSpec(context.Background(), "claude", AuthSpec{},
-		newFakeDaemon(), newTestLogger(), nil, nil, nil)
+		newFakeDaemon(), newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -165,7 +165,7 @@ func TestPrepareAuthSpec_FileBindingRendersFromVault(t *testing.T) {
 		}},
 	}
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -228,7 +228,7 @@ func TestPrepareAuthSpec_StaticFileLandsRegardlessOfVault(t *testing.T) {
 		}},
 	}
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -266,7 +266,7 @@ func TestPrepareAuthSpec_RequiredVaultMissingFailsLaunch(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil, nil)
+		newTestLogger(), nil, nil, nil, true)
 	if err == nil {
 		t.Fatal("expected error for required+empty vault")
 	}
@@ -290,7 +290,7 @@ func TestPrepareAuthSpec_EmptyVaultOptionalBindingDoesNotRender(t *testing.T) {
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil, nil)
+		newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -327,7 +327,7 @@ func TestPrepareAuthSpec_CaptureOnCleanExitPersistsRotatedFile(t *testing.T) {
 			},
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -369,7 +369,7 @@ func TestPrepareAuthSpec_CaptureSchemaFailureSkipsPut(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{}, errors.New("schema drift") },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -421,7 +421,7 @@ func TestPrepareAuthSpec_PreLaunchRefreshPersistsBeforeRender(t *testing.T) {
 			},
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -455,7 +455,7 @@ func TestPrepareAuthSpec_PreLaunchRefreshErrorAbortsLaunch(t *testing.T) {
 			},
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err == nil {
 		t.Fatal("expected error when PreLaunchRefresh fails")
 	}
@@ -472,7 +472,7 @@ func TestPrepareAuthSpec_CleanupRemovesTransientDir(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -500,7 +500,7 @@ func TestPrepareAuthSpec_EnvBindingMerges(t *testing.T) {
 			},
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -524,7 +524,7 @@ func TestPrepareAuthSpec_CapturePutFailureSurfacesWarning(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -557,7 +557,7 @@ func TestPrepareAuthSpec_EnvBindingRequiredMissingErrors(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "example", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil, nil)
+		newTestLogger(), nil, nil, nil, true)
 	if err == nil {
 		t.Fatal("expected error on required env binding with empty vault")
 	}
@@ -577,7 +577,7 @@ func TestPrepareAuthSpec_EnvBindingOptionalMissingContinues(t *testing.T) {
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "example", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil, nil)
+		newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -597,7 +597,7 @@ func TestPrepareAuthSpec_EnvBindingGetErrorPropagates(t *testing.T) {
 			Render:    func(s vault.Secret) (map[string]string, error) { return nil, nil },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err == nil {
 		t.Fatal("expected error when GET fails with non-NotFound")
 	}
@@ -616,7 +616,7 @@ func TestPrepareAuthSpec_EnvBindingRenderErrorPropagates(t *testing.T) {
 			Render:    func(s vault.Secret) (map[string]string, error) { return nil, errors.New("bad shape") },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "example", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err == nil {
 		t.Fatal("expected error when Render fails")
 	}
@@ -633,7 +633,7 @@ func TestPrepareAuthSpec_FileBindingRenderErrorPropagates(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err == nil {
 		t.Fatal("expected error when Render fails")
 	}
@@ -650,7 +650,7 @@ func TestPrepareAuthSpec_FileBindingGetErrorPropagates(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err == nil {
 		t.Fatal("expected error when GET fails with non-NotFound")
 	}
@@ -669,7 +669,7 @@ func TestPrepareAuthSpec_ValidationErrorReturnsBeforeFS(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil, nil)
+		newTestLogger(), nil, nil, nil, true)
 	if err == nil {
 		t.Fatal("expected validation error for nil Render")
 	}
@@ -697,7 +697,7 @@ func TestPrepareAuthSpec_EmptyVaultFirstLaunchProducesWritableParentMount(t *tes
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -743,7 +743,7 @@ func TestPrepareAuthSpec_RejectsNonConformingVaultPath(t *testing.T) {
 		}},
 	}
 	_, err := prepareAuthSpec(context.Background(), "example", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil, nil)
+		newTestLogger(), nil, nil, nil, true)
 	if !errors.Is(err, ErrAuthSpecBadVaultPath) {
 		t.Fatalf("err = %v, want ErrAuthSpecBadVaultPath", err)
 	}
@@ -767,7 +767,7 @@ func TestPrepareAuthSpec_R30BootstrapLineFiresOnEmptyVault(t *testing.T) {
 		}},
 	}
 	prep, err := prepareAuthSpec(context.Background(), "claude", spec, newFakeDaemon(),
-		newTestLogger(), nil, nil, nil)
+		newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -791,7 +791,7 @@ func TestPrepareAuthSpec_RenderedAnyCredentialIsTrueOnHit(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -819,7 +819,7 @@ func TestPrepareAuthSpec_MountAsFileSkipsParentDirMount(t *testing.T) {
 			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
 		}},
 	}
-	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "codex", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -866,7 +866,7 @@ func TestPrepareAuthSpec_ChownHookInvokedWithHostRootAfterFilesExist(t *testing.
 	}
 
 	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
-		daemon, newTestLogger(), nil, hook, nil)
+		daemon, newTestLogger(), nil, hook, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -899,7 +899,7 @@ func TestPrepareAuthSpec_NilChownHookLeavesFilesIntact(t *testing.T) {
 	// A nil hook is the non-Linux path: prep must still succeed and the
 	// rendered file must be present and unchanged.
 	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
-		daemon, newTestLogger(), nil, nil, nil)
+		daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -925,7 +925,7 @@ func TestPrepareAuthSpec_ChownHookErrorIsNonFatal(t *testing.T) {
 	hook := func(string) error { return errors.New("resolve agent uid: boom") }
 
 	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
-		daemon, newTestLogger(), stderr, hook, nil)
+		daemon, newTestLogger(), stderr, hook, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec must not fail on chown hook error, got %v", err)
 	}
@@ -952,7 +952,7 @@ func TestPrepareAuthSpec_ReclaimHookRunsBeforeCaptureRead(t *testing.T) {
 	reclaim := func(dir string) error { reclaimedDir = dir; return nil }
 
 	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
-		daemon, newTestLogger(), nil, nil, reclaim)
+		daemon, newTestLogger(), nil, nil, reclaim, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -989,7 +989,7 @@ func TestPrepareAuthSpec_ReclaimHookErrorIsNonFatal(t *testing.T) {
 	reclaim := func(string) error { return errors.New("chown via runtime: boom") }
 
 	prep, err := prepareAuthSpec(context.Background(), "claude", claudeFileBindingSpec(),
-		daemon, newTestLogger(), stderr, nil, reclaim)
+		daemon, newTestLogger(), stderr, nil, reclaim, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -1041,7 +1041,7 @@ func TestPrepareAuthSpec_FirstLoginSeedWithFresherStillPuts(t *testing.T) {
 	// branch never consults it (there is no prior entry to compare).
 	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return false, nil })
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -1065,7 +1065,7 @@ func TestPrepareAuthSpec_DeliberateDeleteMidSessionSkipsPut(t *testing.T) {
 	daemon.seed("claude", []byte("old")) // present at render
 	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return true, nil })
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -1089,7 +1089,7 @@ func TestPrepareAuthSpec_StaleCaptureNotFresherSkipsPut(t *testing.T) {
 	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return false, nil })
 
 	var stderr bytes.Buffer
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), &stderr, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), &stderr, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -1116,7 +1116,7 @@ func TestPrepareAuthSpec_FresherTruePuts(t *testing.T) {
 	daemon.seed("claude", []byte("current"))
 	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return true, nil })
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -1136,7 +1136,7 @@ func TestPrepareAuthSpec_FresherErrorSkipsPut(t *testing.T) {
 	daemon.seed("claude", []byte("current"))
 	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return false, errors.New("malformed envelope") })
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -1164,7 +1164,7 @@ func TestPrepareAuthSpec_CurrentMalformedOverwritesWithCapture(t *testing.T) {
 		return false, fmt.Errorf("%w: parse current: bad", ErrCurrentEnvelopeMalformed)
 	})
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -1192,7 +1192,7 @@ func TestPrepareAuthSpec_CaptureGetCancelledSkipsPut(t *testing.T) {
 	daemon.getSeq["claude"] = []error{nil, context.Canceled}
 	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return true, nil })
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil)
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}

--- a/internal/launch/host_login_test.go
+++ b/internal/launch/host_login_test.go
@@ -1,0 +1,36 @@
+package launch
+
+import "testing"
+
+// resolveHostLogin contract (#1268): flag > env > default(on). Only an
+// explicit "off" (on the flag, or via env when the flag is auto/empty)
+// disables host-side credential acquisition. "auto"/"on"/empty/unknown
+// all resolve to enabled.
+func TestResolveHostLogin(t *testing.T) {
+	cases := []struct {
+		name string
+		flag string
+		env  string
+		want bool
+	}{
+		{"default empty enables", "", "", true},
+		{"auto enables", "auto", "", true},
+		{"on enables", "on", "", true},
+		{"off disables", "off", "", false},
+		{"flag off beats env on", "off", "on", false},
+		{"flag on beats env off", "on", "off", true},
+		{"env off applies when flag auto", "auto", "off", false},
+		{"env on applies when flag empty", "", "on", true},
+		{"unknown flag falls through to env off", "bogus", "off", false},
+		{"unknown flag and unknown env default enabled", "bogus", "nonsense", true},
+		{"true alias enables", "true", "", true},
+		{"false alias disables", "false", "", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := resolveHostLogin(tc.flag, tc.env); got != tc.want {
+				t.Errorf("resolveHostLogin(%q, %q) = %v, want %v", tc.flag, tc.env, got, tc.want)
+			}
+		})
+	}
+}

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -71,6 +71,37 @@ type LaunchConfig struct {
 	// "off" disables it, and "auto" (or empty) defers to the default
 	// for the resolved sandbox runtime (on for docker).
 	SandboxProxy string
+	// HostLogin controls whether the launcher runs a binding's host-side
+	// credential acquirer (FileBinding.HostAcquire) on a vault miss.
+	// Tri-state: "on" or "auto" (or empty) enable host acquisition when
+	// a binding declares one; "off" forces the legacy in-container login
+	// path even for bindings that declare an acquirer. Overridable via
+	// the AILERON_LAUNCH_HOST_LOGIN env var.
+	HostLogin string
+}
+
+// hostLoginEnv is the environment variable that overrides the
+// --host-login flag's default. Values follow the same on|off|auto
+// tri-state as the flag.
+const hostLoginEnv = "AILERON_LAUNCH_HOST_LOGIN"
+
+// resolveHostLogin computes whether host-side credential acquisition is
+// enabled for a launch, given the user's flag and env-var inputs. The
+// precedence is flag > env > default, with "auto" (or empty, or an
+// unrecognized value) deferring to the next source. The default is
+// enabled: host acquisition only activates when a binding actually
+// declares a HostAcquire hook, so the safe default is to honor it.
+// Only an explicit "off" (on the flag, or via the env when the flag is
+// auto) forces the legacy in-container path.
+func resolveHostLogin(flagValue, envValue string) bool {
+	mode := normalizeSandboxProxyTriState(flagValue)
+	if mode == "" || mode == "auto" {
+		envMode := normalizeSandboxProxyTriState(envValue)
+		if envMode != "" {
+			mode = envMode
+		}
+	}
+	return mode != "off"
 }
 
 // LaunchResult holds the outcome of a launched agent process.
@@ -513,8 +544,9 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		// rotations are silently dropped on rootful Docker Linux.
 		reclaimHook := newTransientReclaimHook(ctx, sandboxcontainer.DefaultRunner(),
 			sandboxPlan.Runtime, sandboxPlan.Image)
+		hostLoginEnabled := resolveHostLogin(config.HostLogin, os.Getenv(hostLoginEnv))
 		prep, err := prepareAuthSpec(ctx, config.Agent.Name(), config.Agent.AuthSpec(),
-			client, sessionLog, os.Stderr, chownHook, reclaimHook)
+			client, sessionLog, os.Stderr, chownHook, reclaimHook, hostLoginEnabled)
 		if err != nil {
 			return LaunchResult{}, fmt.Errorf("prepare agent auth spec: %w", err)
 		}


### PR DESCRIPTION
## Summary

Part of umbrella #1267. This lands the host-side credential acquisition SPI and the launcher plumbing that drives daemon-backed seeding. No provider acquisition logic ships here (Claude is #1269, Codex is #1270).

- **New SPI:** `FileBinding.HostAcquire func(context.Context, HostAcquireDeps) (vault.Secret, error)` plus a `HostAcquireDeps` bag carrying `Ctx`, an `*http.Client`, and an `oauth.Opener` (default `oauth.SystemBrowser{}`). The contract: runs on the host, returns a Secret the same binding's `Render` accepts, must not assume the agent CLI is installed. Unlike `RefreshDeps`, the deps bag has no PUT helper — the launcher owns the PUT so the acquirer cannot skip seeding or seed an envelope its own Render would reject.
- **Empty-vault branch rewrite in `prepareAuthSpec`:** on a vault miss for a non-required binding that declares `HostAcquire` (and host-login is enabled), the launcher acquires on the host, PUTs the returned Secret through `daemon.PutAgentCredentials` (AE6: vault before render/start), then renders and mounts it via a shared render+write+mount+capture tail so the credential is treated exactly as a vault-resident one. A successful acquire sets `RenderedAnyCredential = true`, which automatically suppresses the in-container login status line.
- **Fallback safety:** a nil acquirer, an acquire error/cancel, or an empty returned Secret falls back to the legacy in-container path (no PUT, `PresentAtRender:false` capture target, capture-on-exit seeds the vault). Only a daemon PUT failure or a Render failure of a successfully acquired Secret aborts the launch.
- **Opt-out:** new tri-state `--host-login` flag (`auto`/`on`/`off`, default `auto`) plus `AILERON_LAUNCH_HOST_LOGIN` env override, mirroring `--sandbox-proxy`. `off` forces the legacy in-container path even when a binding declares an acquirer. Threaded through `LaunchConfig.HostLogin` → `resolveHostLogin` → `prepareAuthSpec`.

ADR-0025 compliance: the acquired credential seeds the vault and is rendered to a bind-mounted file. No token ever rides `composeAgentEnv`/`RunOptions.Env`. No OpenAPI/generated-code changes — the `PUT /v1/vault/agents/{name}/credentials` endpoint already exists.

## Test plan

- `internal/launch/authspec_host_acquire_test.go` (new): happy path (one PUT with the acquired Secret, file written, `RenderedAnyCredential==true`, deps carry a `SystemBrowser` + timed client); acquire-error fallback; empty-Secret fallback; host-login-disabled skips the acquirer; daemon PUT failure aborts and cleanup runs; required-binding error path never consults the acquirer; Claude-envelope round-trip through a real render-shaped function; malformed acquired Secret surfaces the Render error.
- `internal/launch/host_login_test.go` (new): `resolveHostLogin` tri-state precedence table.
- `cmd/aileron/main_test.go`: `--host-login` default is `auto`; flag propagates in before-agent and trailing forms and does not leak to agent args.
- Existing `prepareAuthSpec` callers updated for the new `hostLoginEnabled` param (defaulting to `true` preserves prior behavior).
- `go test ./internal/launch/...` and `./cmd/aileron/...` green; launch package coverage 87.9% (`resolveHostLogin` 100%). `go vet` clean, `gofmt` clean, CodeRabbit review returned 0 findings.

Closes #1268

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `--host-login` flag to `aileron launch` command supporting `auto`, `on`, and `off` values.
  * Added `AILERON_LAUNCH_HOST_LOGIN` environment variable for configuring host login behavior.
  * Implemented host-side OAuth credential acquisition with automatic fallback to in-container login flow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->