### PR TITLE
feat(launch): Claude host-side credential seeding via paste-code OAuth

### DIFF
--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -75,6 +75,18 @@ When the container exits cleanly, Capture reads the file the agent wrote and PUT
 
 Goose's EnvBinding has no Capture (there is no credential file to snapshot), so first-launch seeding for Goose is by manual `aileron vault put agents/goose/oauth` rather than by an in-container login that Capture stores.
 
+## Host-side seeding (Claude)
+
+When the vault is empty, the binding is not `Required`, and host-login is enabled, a binding may declare a host-side acquirer (`FileBinding.HostAcquire`, [ADR-0025](/adr/0025-vault-backed-agent-auth)). The launcher runs the acquirer on the **host** before the container starts, PUTs the returned credential to the vault, and renders it into the bind-mount, so the very first launch is silent instead of dropping into the in-container login. A cancelled or failed acquire is non-fatal: the launcher falls back to the in-container login path described above.
+
+Claude Code declares such an acquirer. It tries two mechanisms in order:
+
+1. **`claude setup-token` shortcut.** When the `claude` CLI is on the host `PATH`, the launcher runs `claude setup-token`, which prints a single long-lived bare token. The launcher wraps it into a `claudeAiOauth` envelope with `accessToken` set and `refreshToken`/`expiresAt`/`scopes` left empty (the setup-token path has no refresh token or expiry). If the CLI is absent or the command fails, it falls through to the paste flow.
+
+2. **Hosted-callback paste flow (PKCE).** The launcher opens Claude's consent URL in the host browser and prompts on the **host terminal** (not the container TTY) for the `<code>#<state>` string the consent page renders. It exchanges the code for tokens against Claude's token endpoint using PKCE (no client secret) and stores an envelope whose `expiresAt` is in milliseconds. The paste happening on the host terminal is what makes this flow work on Windows, where reading from the container TTY was the blocker.
+
+The OAuth client is Claude Code's public client, registered only for the hosted callback `https://platform.claude.com/oauth/code/callback`; loopback (`127.0.0.1`) redirect URIs are rejected by the token endpoint, which is why this flow uses the paste mechanism rather than a loopback listener or device-auth.
+
 ## Manual seeding
 
 `aileron vault put` writes a per-agent credential envelope directly. It is a daemon-backed command, so the daemon must be running and the vault unlocked.

--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -94,6 +94,14 @@ func (c Claude) AuthSpec() launch.AuthSpec {
 			Render:   claudeRender,
 			Capture:  claudeCapture,
 			Fresher:  claudeFresher,
+			// HostAcquire runs a host-side OAuth flow (setup-token
+			// shortcut, else hosted-callback paste with PKCE) when the
+			// vault is empty and host-login is enabled, so the user
+			// authenticates in their own browser/terminal rather than
+			// inside the container TTY. The launcher owns the vault PUT
+			// and the validating Render; a cancel/failure is non-fatal
+			// and falls back to the in-container login.
+			HostAcquire: claudeHostAcquire,
 		}},
 		StaticFiles: []launch.StaticFile{{
 			ContainerPath: claudeOnboardingContainerPath,

--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -1,13 +1,132 @@
 package agents
 
 import (
+	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"os/exec"
+	"strings"
+	"time"
 
 	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/oauth"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
+
+// Claude Code subscription-OAuth client + endpoints.
+//
+// These values are Anthropic's public Claude Code client; they were
+// verified against the live `claude` install / public documentation
+// before this code was written (see the PR body for #1270 for the
+// citations). The client is a PUBLIC OAuth client — no client_secret —
+// and is registered ONLY for the hosted callback below.
+//
+//   - claudeOAuthClientID is Claude Code's public client id.
+//   - claudeAuthorizeURL is the consent page the host browser opens.
+//   - claudeTokenURL is the token-exchange endpoint (PKCE, no secret).
+//   - claudeHostedCallbackURL is the ONLY redirect_uri the token
+//     endpoint accepts for this client. Loopback (127.0.0.1) redirect
+//     URIs return `400 invalid_grant`, which is why the host flow uses
+//     the hosted-callback "paste the code" mechanism rather than a
+//     loopback listener or device-auth (see #1275 P0).
+//
+// The authorize page renders the authorization response as a
+// `<code>#<state>` string for the user to copy; the acquirer splits on
+// `#` before the token exchange.
+const (
+	claudeOAuthClientID     = "9d1c250a-e61b-44d9-88ed-5944d1962f5e"
+	claudeAuthorizeURL      = "https://claude.ai/oauth/authorize"
+	claudeTokenURL          = "https://platform.claude.com/v1/oauth/token"
+	claudeHostedCallbackURL = "https://platform.claude.com/oauth/code/callback"
+)
+
+// claudeOAuthScopes are the scopes Claude Code requests for a
+// subscription (Pro/Max) login. `user:inference` is what lets the
+// seeded token drive model calls; the others mirror the upstream CLI's
+// requested set so the consent screen matches what a native `claude`
+// login shows.
+var claudeOAuthScopes = []string{
+	"user:inference",
+	"user:profile",
+	"user:sessions:claude_code",
+	"user:mcp_servers",
+}
+
+// buildClaudeAuthorizeURL composes Claude's consent URL with PKCE +
+// state. The `code=true` query param tells the authorize page to render
+// the authorization response as a copyable `<code>#<state>` string
+// (the hosted-callback paste mechanism) rather than auto-redirecting.
+func buildClaudeAuthorizeURL(pkce oauth.PKCEPair, state string) string {
+	q := url.Values{
+		"code":                  {"true"},
+		"client_id":             {claudeOAuthClientID},
+		"response_type":         {"code"},
+		"redirect_uri":          {claudeHostedCallbackURL},
+		"scope":                 {strings.Join(claudeOAuthScopes, " ")},
+		"state":                 {state},
+		"code_challenge":        {pkce.Challenge},
+		"code_challenge_method": {pkce.Method},
+	}
+	sep := "?"
+	if strings.Contains(claudeAuthorizeURL, "?") {
+		sep = "&"
+	}
+	return claudeAuthorizeURL + sep + q.Encode()
+}
+
+// claudeEnvelopeFromTokenResponse converts a successful token-exchange
+// response into the on-disk `claudeAiOauth` envelope.
+//
+// expiresInSec is the provider's `expires_in` (SECONDS). Claude's
+// `.credentials.json` stores `claudeAiOauth.expiresAt` in MILLISECONDS
+// (the real file carries values like 1775212290694), so we convert to
+// an absolute ms timestamp. A non-positive expiresInSec leaves
+// expiresAt at 0 (omitted), matching envelopes that ship without an
+// expiry.
+func claudeEnvelopeFromTokenResponse(access, refresh string, expiresInSec int, scopes []string) ([]byte, error) {
+	env := claudeCredentialEnvelope{
+		ClaudeAiOauth: claudeAiOauth{
+			AccessToken:  access,
+			RefreshToken: refresh,
+			Scopes:       scopes,
+		},
+	}
+	if expiresInSec > 0 {
+		env.ClaudeAiOauth.ExpiresAt = time.Now().
+			Add(time.Duration(expiresInSec) * time.Second).UnixMilli()
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		// The shape is fixed; marshaling only fails on a programming
+		// error. Wrap rather than panic so a caller in the acquire path
+		// degrades to the in-container fallback instead of crashing.
+		return nil, fmt.Errorf("claude: marshal acquired envelope: %w", err)
+	}
+	return b, nil
+}
+
+// claudeEnvelopeFromBareToken builds an envelope from the single bare
+// token `claude setup-token` prints on stdout. Unlike the
+// hosted-callback exchange, setup-token yields no refresh token, no
+// expiry, and no scope list — it is a long-lived token. We populate
+// `accessToken` only and leave `refreshToken`/`expiresAt`/`scopes`
+// empty (omitted). This is a deliberate divergence from the
+// hosted-callback envelope, documented so a reader does not mistake the
+// missing fields for a bug.
+func claudeEnvelopeFromBareToken(token string) ([]byte, error) {
+	env := claudeCredentialEnvelope{
+		ClaudeAiOauth: claudeAiOauth{AccessToken: token},
+	}
+	b, err := json.Marshal(env)
+	if err != nil {
+		return nil, fmt.Errorf("claude: marshal setup-token envelope: %w", err)
+	}
+	return b, nil
+}
 
 // claudeCredentialsContainerPath is where Claude Code reads its
 // subscription-OAuth credentials inside the sandbox container. The
@@ -207,4 +326,223 @@ func validateClaudeEnvelope(b []byte) error {
 			errClaudeEnvelopeMalformed)
 	}
 	return nil
+}
+
+// claudeHostAcquire is Claude's host-side credential acquirer, wired to
+// the FileBinding's HostAcquire hook (see AuthSpec in claude.go). The
+// launcher invokes it only when the vault GET misses, the binding is not
+// Required, and host-login is enabled; it returns a vault.Secret that
+// the launcher PUTs to agents/claude/oauth and renders before the
+// container starts.
+//
+// Contract (per #1268, enforced by the launcher):
+//   - A returned Secret with a non-empty Value seeds the vault.
+//   - An empty Secret (with a nil error) or a non-nil error is
+//     NON-FATAL: the launcher logs and falls back to the legacy
+//     in-container login. So a cancel / unavailable-CLI / failed
+//     exchange must surface as one of those, never as a partial seed.
+//
+// Two acquisition mechanisms, tried in order:
+//
+//  1. `claude setup-token` SHORTCUT (opportunistic). When the `claude`
+//     CLI is on PATH we run it first; it prints a single long-lived
+//     bare token on stdout (NOT a full claudeAiOauth JSON envelope). We
+//     wrap that bare token into an envelope with accessToken only
+//     (refreshToken/expiresAt/scopes empty — see
+//     claudeEnvelopeFromBareToken). The CLI may be absent; that is
+//     expected, not an error.
+//
+//  2. Hosted-callback PASTE flow (the real OAuth, with PKCE). Open the
+//     consent URL in the host browser, have the user paste the
+//     `<code>#<state>` string from the hosted callback page on the HOST
+//     terminal, verify state, exchange the code for tokens (PKCE, no
+//     client_secret), and build a ms-expiry envelope.
+func claudeHostAcquire(ctx context.Context, deps launch.HostAcquireDeps) (vault.Secret, error) {
+	// 1. setup-token shortcut.
+	if secret, ok := claudeSetupTokenShortcut(ctx); ok {
+		return secret, nil
+	}
+	// 2. Hosted-callback paste flow.
+	return claudeHostedCallbackAcquire(ctx, deps)
+}
+
+// claudeSetupTokenShortcut tries `claude setup-token`. It returns
+// (secret, true) only on a clean run that yields a usable bare token;
+// any failure (CLI absent, non-zero exit, empty/garbled output,
+// envelope build error) returns (_, false) so the caller falls through
+// to the hosted-callback flow. It never returns an error: a failed
+// shortcut is not itself a fatal acquire failure.
+func claudeSetupTokenShortcut(ctx context.Context) (vault.Secret, bool) {
+	if _, err := exec.LookPath("claude"); err != nil {
+		return vault.Secret{}, false
+	}
+	out, err := exec.CommandContext(ctx, "claude", "setup-token").Output()
+	if err != nil {
+		return vault.Secret{}, false
+	}
+	token := strings.TrimSpace(string(out))
+	if token == "" {
+		return vault.Secret{}, false
+	}
+	envelope, err := claudeEnvelopeFromBareToken(token)
+	if err != nil {
+		return vault.Secret{}, false
+	}
+	return vault.Secret{
+		Value:    envelope,
+		Metadata: vault.Metadata{Type: "oauth_refresh_token"},
+	}, true
+}
+
+// claudeHostedCallbackAcquire runs the PKCE authorization-code flow
+// against Claude's hosted callback, reading the pasted code from the
+// host terminal via deps.CodePrompter.
+func claudeHostedCallbackAcquire(ctx context.Context, deps launch.HostAcquireDeps) (vault.Secret, error) {
+	if deps.CodePrompter == nil {
+		// No way to read the pasted code. Non-fatal: let the launcher
+		// fall back to the in-container login.
+		return vault.Secret{}, errors.New("claude: no code prompter available for host paste flow")
+	}
+
+	pkce, err := oauth.NewPKCE()
+	if err != nil {
+		return vault.Secret{}, fmt.Errorf("claude: %w", err)
+	}
+	state, err := oauth.NewState()
+	if err != nil {
+		return vault.Secret{}, fmt.Errorf("claude: %w", err)
+	}
+
+	authURL := buildClaudeAuthorizeURL(pkce, state)
+	if deps.Browser != nil {
+		if err := deps.Browser.Open(authURL); err != nil {
+			// Opening the browser failed (headless host, no opener).
+			// Non-fatal: fall back to in-container login.
+			return vault.Secret{}, fmt.Errorf("claude: open consent URL: %w", err)
+		}
+	}
+
+	pasted, err := deps.CodePrompter(ctx, nil)
+	if err != nil {
+		return vault.Secret{}, fmt.Errorf("claude: read pasted code: %w", err)
+	}
+	code, gotState := splitClaudeCodeState(pasted)
+	if code == "" {
+		return vault.Secret{}, errors.New("claude: pasted code was empty")
+	}
+	// The hosted-callback page renders `<code>#<state>`. When the user
+	// pasted the state too, verify it matches to bind the code to this
+	// session. A paste of the bare code (no `#state`) is tolerated —
+	// some users copy only the code — because PKCE already binds the
+	// exchange to this client's verifier.
+	if gotState != "" && gotState != state {
+		return vault.Secret{}, errors.New("claude: pasted state does not match; aborting to avoid a cross-session code")
+	}
+
+	access, refresh, expiresIn, scopes, err := claudeExchangeCode(ctx, deps.HTTPClient, code, pkce.Verifier, state)
+	if err != nil {
+		return vault.Secret{}, err
+	}
+	envelope, err := claudeEnvelopeFromTokenResponse(access, refresh, expiresIn, scopes)
+	if err != nil {
+		return vault.Secret{}, err
+	}
+	return vault.Secret{
+		Value:    envelope,
+		Metadata: vault.Metadata{Type: "oauth_refresh_token"},
+	}, nil
+}
+
+// splitClaudeCodeState splits a pasted `<code>#<state>` string on the
+// first `#`. A paste with no `#` yields (code, "").
+func splitClaudeCodeState(pasted string) (code, state string) {
+	pasted = strings.TrimSpace(pasted)
+	if i := strings.Index(pasted, "#"); i >= 0 {
+		return strings.TrimSpace(pasted[:i]), strings.TrimSpace(pasted[i+1:])
+	}
+	return pasted, ""
+}
+
+// claudeExchangeCode POSTs the authorization code to Claude's token
+// endpoint with PKCE (no client_secret — public client) and returns the
+// access token, refresh token, expires_in (seconds), and granted
+// scopes.
+//
+// Per RFC 6749 §5.2 a token-error body may carry token hints; mirroring
+// credential.DoRefresh's posture, a non-2xx response surfaces only the
+// HTTP status (and the standard `error` code when present), never the
+// raw body, so a hostile or verbose provider response cannot leak into
+// the user-facing launch error.
+func claudeExchangeCode(ctx context.Context, client *http.Client, code, verifier, state string) (access, refresh string, expiresIn int, scopes []string, err error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	body := url.Values{
+		"grant_type":    {"authorization_code"},
+		"code":          {code},
+		"redirect_uri":  {claudeHostedCallbackURL},
+		"client_id":     {claudeOAuthClientID},
+		"code_verifier": {verifier},
+		"state":         {state},
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, claudeTokenURL,
+		strings.NewReader(body.Encode()))
+	if err != nil {
+		return "", "", 0, nil, fmt.Errorf("claude: build token request: %w", err)
+	}
+	req.Header.Set("Content-Type", "application/x-www-form-urlencoded")
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", 0, nil, fmt.Errorf("claude: token exchange: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		// Redact the raw body; surface only status + standard error code.
+		if errCode := parseClaudeTokenErrorCode(respBody); errCode != "" {
+			return "", "", 0, nil, fmt.Errorf("claude: token exchange failed: provider returned %d (%s)",
+				resp.StatusCode, errCode)
+		}
+		return "", "", 0, nil, fmt.Errorf("claude: token exchange failed: provider returned %d", resp.StatusCode)
+	}
+
+	var parsed struct {
+		AccessToken  string `json:"access_token"`
+		RefreshToken string `json:"refresh_token"`
+		ExpiresIn    int    `json:"expires_in"`
+		TokenType    string `json:"token_type"`
+		Scope        string `json:"scope"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", "", 0, nil, fmt.Errorf("claude: parse token response: %w", err)
+	}
+	if parsed.AccessToken == "" {
+		return "", "", 0, nil, errors.New("claude: token response missing access_token")
+	}
+	granted := strings.Fields(parsed.Scope)
+	if len(granted) == 0 {
+		// Provider omitted `scope` (RFC 6749 §5.1 permits this when the
+		// granted set matches the requested set); record what we asked
+		// for.
+		granted = append([]string(nil), claudeOAuthScopes...)
+	}
+	return parsed.AccessToken, parsed.RefreshToken, parsed.ExpiresIn, granted, nil
+}
+
+// parseClaudeTokenErrorCode extracts the RFC 6749 §5.2 `error` field
+// from a token-error body, if present. Returns "" when the body does
+// not parse or carries no `error` — the caller then surfaces the bare
+// HTTP status. Only the short standardized code is surfaced; the
+// free-text `error_description` is intentionally not, since it may echo
+// request material.
+func parseClaudeTokenErrorCode(body []byte) string {
+	var e struct {
+		Error string `json:"error"`
+	}
+	if err := json.Unmarshal(body, &e); err != nil {
+		return ""
+	}
+	return e.Error
 }

--- a/internal/launch/agents/claude_host_acquire_test.go
+++ b/internal/launch/agents/claude_host_acquire_test.go
@@ -1,0 +1,364 @@
+package agents_test
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+)
+
+// Claude host-acquire contract (#1270):
+//
+//   - Hosted-callback happy path: browser opened with the consent URL,
+//     code pasted on the host, code exchanged → Secret round-trips the
+//     binding's own Render; expiresAt is in milliseconds.
+//   - setup-token shortcut: when `claude` is on PATH and prints a bare
+//     token, the shortcut path seeds an accessToken-only envelope
+//     (no refresh/expiry).
+//   - CLI absent: hosted-callback path taken (browser + prompter
+//     consulted).
+//   - Acquire failure (token 400 / prompter error / state mismatch):
+//     returns an error so the launcher falls back to in-container login.
+//   - Provider error body is not leaked into the returned error.
+
+// redirectTransport rewrites every outbound request to the test
+// server, so the acquirer's hardcoded claudeTokenURL const reaches the
+// httptest endpoint without exposing a URL seam in production code.
+type redirectTransport struct{ base *url.URL }
+
+func (rt redirectTransport) RoundTrip(req *http.Request) (*http.Response, error) {
+	req.URL.Scheme = rt.base.Scheme
+	req.URL.Host = rt.base.Host
+	return http.DefaultTransport.RoundTrip(req)
+}
+
+func testHTTPClient(serverURL string) *http.Client {
+	u, _ := url.Parse(serverURL)
+	return &http.Client{Transport: redirectTransport{base: u}}
+}
+
+// recordingOpener records the URL it was asked to open and reports a
+// configurable error.
+type recordingOpener struct {
+	opened string
+	err    error
+}
+
+func (o *recordingOpener) Open(rawURL string) error {
+	o.opened = rawURL
+	return o.err
+}
+
+// emptyPATH points PATH at a directory with no `claude` binary so the
+// setup-token shortcut's LookPath misses and the hosted-callback path
+// is taken.
+func emptyPATH(t *testing.T) {
+	t.Helper()
+	t.Setenv("PATH", t.TempDir())
+}
+
+// stubClaudeOnPATH writes a fake `claude` executable that, for
+// `setup-token`, prints stdoutLine and exits 0. Skips on Windows where
+// the shell-script stub is not executable.
+func stubClaudeOnPATH(t *testing.T, stdoutLine string) {
+	t.Helper()
+	if runtime.GOOS == "windows" {
+		t.Skip("shell-script stub is not executable on windows")
+	}
+	dir := t.TempDir()
+	// Escape single quotes (' -> '\'') so an stdoutLine carrying one
+	// cannot break the single-quoted shell literal.
+	escaped := strings.ReplaceAll(stdoutLine, "'", `'\''`)
+	script := "#!/bin/sh\nif [ \"$1\" = \"setup-token\" ]; then printf '%s\\n' '" + escaped + "'; exit 0; fi\nexit 1\n"
+	bin := filepath.Join(dir, "claude")
+	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	t.Setenv("PATH", dir)
+}
+
+func scriptedPrompter(value string, err error) func(context.Context, io.Writer) (string, error) {
+	return func(_ context.Context, _ io.Writer) (string, error) {
+		return value, err
+	}
+}
+
+func claudeHostAcquireBinding(t *testing.T) launch.FileBinding {
+	t.Helper()
+	fb := agents.Claude{}.AuthSpec().FileBindings[0]
+	if fb.HostAcquire == nil {
+		t.Fatal("Claude binding must declare HostAcquire for host-side seeding")
+	}
+	return fb
+}
+
+func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
+	emptyPATH(t)
+
+	var gotForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		_ = r.ParseForm()
+		gotForm = r.PostForm
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = io.WriteString(w, `{"access_token":"acc-tok","refresh_token":"ref-tok","expires_in":28800,"token_type":"Bearer","scope":"user:inference"}`)
+	}))
+	defer srv.Close()
+
+	opener := &recordingOpener{}
+	fb := claudeHostAcquireBinding(t)
+	secret, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:          context.Background(),
+		HTTPClient:   testHTTPClient(srv.URL),
+		Browser: opener,
+		// Paste a bare code (no #state). The acquirer generates the
+		// state internally and tolerates a bare-code paste since PKCE
+		// already binds the exchange; a state-carrying paste is covered
+		// by TestClaudeHostAcquire_StateMismatchReturnsError.
+		CodePrompter: scriptedPrompter("the-code", nil),
+	})
+	if err != nil {
+		t.Fatalf("HostAcquire: %v", err)
+	}
+	if len(secret.Value) == 0 {
+		t.Fatal("HostAcquire returned empty Secret on the happy path")
+	}
+	// The acquired Secret must round-trip the binding's own Render,
+	// proving the launcher will accept it.
+	if _, err := fb.Render(secret); err != nil {
+		t.Fatalf("acquired Secret rejected by Render: %v", err)
+	}
+	// Browser was opened with the consent URL carrying the client id.
+	if !strings.Contains(opener.opened, "client_id=9d1c250a") {
+		t.Errorf("browser opened %q, want consent URL with client_id", opener.opened)
+	}
+	// Token exchange used authorization_code + PKCE verifier, no secret.
+	if gotForm.Get("grant_type") != "authorization_code" {
+		t.Errorf("grant_type = %q, want authorization_code", gotForm.Get("grant_type"))
+	}
+	if gotForm.Get("code") != "the-code" {
+		t.Errorf("code = %q, want the-code (fragment split on #)", gotForm.Get("code"))
+	}
+	if gotForm.Get("code_verifier") == "" {
+		t.Error("code_verifier missing from token exchange (PKCE required)")
+	}
+	if gotForm.Get("client_secret") != "" {
+		t.Error("client_secret sent; Claude Code is a public client (PKCE only)")
+	}
+	// expiresAt in the seeded envelope must be milliseconds.
+	var env struct {
+		ClaudeAiOauth struct {
+			AccessToken string `json:"accessToken"`
+			ExpiresAt   int64  `json:"expiresAt"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(secret.Value, &env); err != nil {
+		t.Fatalf("unmarshal seeded envelope: %v", err)
+	}
+	if env.ClaudeAiOauth.AccessToken != "acc-tok" {
+		t.Errorf("seeded accessToken = %q, want acc-tok", env.ClaudeAiOauth.AccessToken)
+	}
+	if env.ClaudeAiOauth.ExpiresAt <= 1_000_000_000_000 {
+		t.Errorf("seeded expiresAt = %d, want milliseconds magnitude", env.ClaudeAiOauth.ExpiresAt)
+	}
+}
+
+func TestClaudeHostAcquire_SetupTokenShortcut(t *testing.T) {
+	stubClaudeOnPATH(t, "sk-ant-bare-token")
+
+	opener := &recordingOpener{}
+	fb := claudeHostAcquireBinding(t)
+	// HTTPClient/CodePrompter must NOT be consulted on the shortcut
+	// path; pass a prompter that fails the test if called.
+	secret, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:     context.Background(),
+		Browser: opener,
+		CodePrompter: func(context.Context, io.Writer) (string, error) {
+			t.Fatal("CodePrompter consulted on the setup-token shortcut path")
+			return "", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("HostAcquire (shortcut): %v", err)
+	}
+	if opener.opened != "" {
+		t.Errorf("browser opened on shortcut path: %q", opener.opened)
+	}
+	var env struct {
+		ClaudeAiOauth struct {
+			AccessToken  string `json:"accessToken"`
+			RefreshToken string `json:"refreshToken"`
+			ExpiresAt    int64  `json:"expiresAt"`
+		} `json:"claudeAiOauth"`
+	}
+	if err := json.Unmarshal(secret.Value, &env); err != nil {
+		t.Fatalf("unmarshal shortcut envelope: %v", err)
+	}
+	if env.ClaudeAiOauth.AccessToken != "sk-ant-bare-token" {
+		t.Errorf("accessToken = %q, want sk-ant-bare-token", env.ClaudeAiOauth.AccessToken)
+	}
+	if env.ClaudeAiOauth.RefreshToken != "" {
+		t.Errorf("refreshToken = %q, want empty on setup-token path", env.ClaudeAiOauth.RefreshToken)
+	}
+	if env.ClaudeAiOauth.ExpiresAt != 0 {
+		t.Errorf("expiresAt = %d, want 0 on setup-token path", env.ClaudeAiOauth.ExpiresAt)
+	}
+}
+
+func TestClaudeHostAcquire_CLIAbsentTakesHostedCallback(t *testing.T) {
+	emptyPATH(t)
+
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		_, _ = io.WriteString(w, `{"access_token":"acc","expires_in":100}`)
+	}))
+	defer srv.Close()
+
+	opener := &recordingOpener{}
+	prompterCalled := false
+	fb := claudeHostAcquireBinding(t)
+	_, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:        context.Background(),
+		HTTPClient: testHTTPClient(srv.URL),
+		Browser:    opener,
+		CodePrompter: func(context.Context, io.Writer) (string, error) {
+			prompterCalled = true
+			return "bare-code-no-state", nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("HostAcquire: %v", err)
+	}
+	if opener.opened == "" {
+		t.Error("browser not opened on the hosted-callback path")
+	}
+	if !prompterCalled {
+		t.Error("code prompter not consulted on the hosted-callback path")
+	}
+}
+
+func TestClaudeHostAcquire_TokenEndpoint400ReturnsError(t *testing.T) {
+	emptyPATH(t)
+
+	const secretLeak = "super-secret-token-hint-DO-NOT-LEAK"
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+		_, _ = io.WriteString(w, `{"error":"invalid_grant","error_description":"`+secretLeak+`"}`)
+	}))
+	defer srv.Close()
+
+	fb := claudeHostAcquireBinding(t)
+	secret, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:          context.Background(),
+		HTTPClient:   testHTTPClient(srv.URL),
+		Browser:      &recordingOpener{},
+		CodePrompter: scriptedPrompter("bare-code", nil),
+	})
+	if err == nil {
+		t.Fatal("expected error on token endpoint 400 so the launcher falls back")
+	}
+	if len(secret.Value) != 0 {
+		t.Error("Secret must be empty on a failed exchange")
+	}
+	// The standard error code is allowed; the free-text description (and
+	// any token hint it carries) must NOT leak into the user-facing
+	// error string.
+	if strings.Contains(err.Error(), secretLeak) {
+		t.Errorf("provider error_description leaked into error: %v", err)
+	}
+	if !strings.Contains(err.Error(), "invalid_grant") {
+		t.Errorf("err = %v, want the standard error code invalid_grant surfaced", err)
+	}
+}
+
+func TestClaudeHostAcquire_PrompterErrorReturnsError(t *testing.T) {
+	emptyPATH(t)
+
+	fb := claudeHostAcquireBinding(t)
+	_, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:          context.Background(),
+		Browser:      &recordingOpener{},
+		CodePrompter: scriptedPrompter("", io.ErrUnexpectedEOF),
+	})
+	if err == nil {
+		t.Fatal("expected error when the code prompter fails")
+	}
+}
+
+func TestClaudeHostAcquire_StateMismatchReturnsError(t *testing.T) {
+	emptyPATH(t)
+
+	// A token server that would succeed, to prove the abort happens
+	// BEFORE the exchange when the pasted state does not match.
+	exchangeHit := false
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		exchangeHit = true
+		_, _ = io.WriteString(w, `{"access_token":"acc","expires_in":100}`)
+	}))
+	defer srv.Close()
+
+	fb := claudeHostAcquireBinding(t)
+	_, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:          context.Background(),
+		HTTPClient:   testHTTPClient(srv.URL),
+		Browser:      &recordingOpener{},
+		CodePrompter: scriptedPrompter("code#deadbeef-not-the-real-state", nil),
+	})
+	if err == nil {
+		t.Fatal("expected error on state mismatch")
+	}
+	if exchangeHit {
+		t.Error("token exchange ran despite state mismatch; the code may be cross-session")
+	}
+}
+
+func TestClaudeHostAcquire_BrowserOpenFailureIsNonFatal(t *testing.T) {
+	emptyPATH(t)
+
+	fb := claudeHostAcquireBinding(t)
+	prompterCalled := false
+	secret, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:     context.Background(),
+		Browser: &recordingOpener{err: io.ErrClosedPipe},
+		CodePrompter: func(context.Context, io.Writer) (string, error) {
+			prompterCalled = true
+			return "code", nil
+		},
+	})
+	if err == nil {
+		t.Fatal("expected error when the browser cannot be opened")
+	}
+	if len(secret.Value) != 0 {
+		t.Error("Secret must be empty when the consent URL cannot be opened")
+	}
+	// The flow aborts at the browser-open step; the prompter is never
+	// reached because there is no consent page for the user to act on.
+	if prompterCalled {
+		t.Error("code prompter consulted after the browser failed to open")
+	}
+}
+
+func TestClaudeHostAcquire_NilPrompterIsNonFatal(t *testing.T) {
+	emptyPATH(t)
+
+	fb := claudeHostAcquireBinding(t)
+	secret, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:     context.Background(),
+		Browser: &recordingOpener{},
+		// CodePrompter nil: the acquirer has no way to read the code.
+	})
+	if err == nil {
+		t.Fatal("expected error when no CodePrompter is provided")
+	}
+	if len(secret.Value) != 0 {
+		t.Error("Secret must be empty when the paste flow cannot run")
+	}
+}

--- a/internal/launch/agents/claude_oauth_internal_test.go
+++ b/internal/launch/agents/claude_oauth_internal_test.go
@@ -1,0 +1,143 @@
+package agents
+
+import (
+	"encoding/json"
+	"net/url"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/oauth"
+)
+
+// Unit 1 contract: the pure OAuth builders.
+//
+//   - buildClaudeAuthorizeURL embeds the public client id, the S256
+//     challenge + method, the hosted-callback redirect, the state, and
+//     the requested scopes.
+//   - claudeEnvelopeFromTokenResponse emits an envelope that passes
+//     validateClaudeEnvelope and whose expiresAt is in MILLISECONDS.
+//   - claudeEnvelopeFromBareToken populates accessToken only; refresh,
+//     expiry, and scopes are absent.
+
+func TestBuildClaudeAuthorizeURL_CarriesPKCEStateScopesAndCallback(t *testing.T) {
+	pkce := oauth.PKCEPair{Verifier: "ver", Challenge: "chal-xyz", Method: "S256"}
+	raw := buildClaudeAuthorizeURL(pkce, "state-abc")
+
+	if !strings.HasPrefix(raw, claudeAuthorizeURL+"?") {
+		t.Fatalf("authorize URL = %q, want prefix %q?", raw, claudeAuthorizeURL)
+	}
+	u, err := url.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse authorize URL: %v", err)
+	}
+	q := u.Query()
+	checks := map[string]string{
+		"client_id":             claudeOAuthClientID,
+		"response_type":         "code",
+		"redirect_uri":          claudeHostedCallbackURL,
+		"state":                 "state-abc",
+		"code_challenge":        "chal-xyz",
+		"code_challenge_method": "S256",
+	}
+	for k, want := range checks {
+		if got := q.Get(k); got != want {
+			t.Errorf("authorize URL %s = %q, want %q", k, got, want)
+		}
+	}
+	if got := q.Get("scope"); got != strings.Join(claudeOAuthScopes, " ") {
+		t.Errorf("authorize URL scope = %q, want %q", got, strings.Join(claudeOAuthScopes, " "))
+	}
+	// The hosted-callback paste mechanism is selected by code=true.
+	if got := q.Get("code"); got != "true" {
+		t.Errorf("authorize URL code = %q, want \"true\"", got)
+	}
+}
+
+func TestClaudeEnvelopeFromTokenResponse_ExpiresAtIsMilliseconds(t *testing.T) {
+	scopes := []string{"user:inference"}
+	b, err := claudeEnvelopeFromTokenResponse("access-tok", "refresh-tok", 28800, scopes)
+	if err != nil {
+		t.Fatalf("claudeEnvelopeFromTokenResponse: %v", err)
+	}
+	if err := validateClaudeEnvelope(b); err != nil {
+		t.Fatalf("built envelope failed validation: %v", err)
+	}
+	var env claudeCredentialEnvelope
+	if err := json.Unmarshal(b, &env); err != nil {
+		t.Fatalf("unmarshal envelope: %v", err)
+	}
+	if env.ClaudeAiOauth.AccessToken != "access-tok" {
+		t.Errorf("accessToken = %q, want access-tok", env.ClaudeAiOauth.AccessToken)
+	}
+	if env.ClaudeAiOauth.RefreshToken != "refresh-tok" {
+		t.Errorf("refreshToken = %q, want refresh-tok", env.ClaudeAiOauth.RefreshToken)
+	}
+	// expiresAt must be an absolute ms timestamp, not seconds and not a
+	// relative duration. The real claude file carries ~1.7e12; anything
+	// > 1e12 is unambiguously milliseconds-since-epoch (seconds-since-
+	// epoch is ~1.7e9, three orders of magnitude smaller).
+	if env.ClaudeAiOauth.ExpiresAt <= 1_000_000_000_000 {
+		t.Errorf("expiresAt = %d, want milliseconds magnitude (> 1e12)", env.ClaudeAiOauth.ExpiresAt)
+	}
+	if len(env.ClaudeAiOauth.Scopes) != 1 || env.ClaudeAiOauth.Scopes[0] != "user:inference" {
+		t.Errorf("scopes = %v, want [user:inference]", env.ClaudeAiOauth.Scopes)
+	}
+}
+
+func TestClaudeEnvelopeFromTokenResponse_NoExpiryWhenZero(t *testing.T) {
+	b, err := claudeEnvelopeFromTokenResponse("a", "r", 0, nil)
+	if err != nil {
+		t.Fatalf("claudeEnvelopeFromTokenResponse: %v", err)
+	}
+	var env claudeCredentialEnvelope
+	if err := json.Unmarshal(b, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.ClaudeAiOauth.ExpiresAt != 0 {
+		t.Errorf("expiresAt = %d, want 0 when expires_in is non-positive", env.ClaudeAiOauth.ExpiresAt)
+	}
+}
+
+func TestClaudeEnvelopeFromBareToken_AccessTokenOnly(t *testing.T) {
+	b, err := claudeEnvelopeFromBareToken("bare-long-lived-token")
+	if err != nil {
+		t.Fatalf("claudeEnvelopeFromBareToken: %v", err)
+	}
+	if err := validateClaudeEnvelope(b); err != nil {
+		t.Fatalf("bare-token envelope failed validation: %v", err)
+	}
+	var env claudeCredentialEnvelope
+	if err := json.Unmarshal(b, &env); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if env.ClaudeAiOauth.AccessToken != "bare-long-lived-token" {
+		t.Errorf("accessToken = %q, want bare-long-lived-token", env.ClaudeAiOauth.AccessToken)
+	}
+	if env.ClaudeAiOauth.RefreshToken != "" {
+		t.Errorf("refreshToken = %q, want empty (setup-token has no refresh)", env.ClaudeAiOauth.RefreshToken)
+	}
+	if env.ClaudeAiOauth.ExpiresAt != 0 {
+		t.Errorf("expiresAt = %d, want 0 (setup-token has no expiry)", env.ClaudeAiOauth.ExpiresAt)
+	}
+	if len(env.ClaudeAiOauth.Scopes) != 0 {
+		t.Errorf("scopes = %v, want empty (setup-token has no scope list)", env.ClaudeAiOauth.Scopes)
+	}
+}
+
+func TestSplitClaudeCodeState(t *testing.T) {
+	tests := []struct {
+		in, wantCode, wantState string
+	}{
+		{"abc#xyz", "abc", "xyz"},
+		{"  abc#xyz  ", "abc", "xyz"},
+		{"justcode", "justcode", ""},
+		{"abc#xyz#extra", "abc", "xyz#extra"},
+	}
+	for _, tt := range tests {
+		code, state := splitClaudeCodeState(tt.in)
+		if code != tt.wantCode || state != tt.wantState {
+			t.Errorf("splitClaudeCodeState(%q) = (%q,%q), want (%q,%q)",
+				tt.in, code, state, tt.wantCode, tt.wantState)
+		}
+	}
+}

--- a/internal/launch/agents/claude_oauth_internal_test.go
+++ b/internal/launch/agents/claude_oauth_internal_test.go
@@ -1,7 +1,10 @@
 package agents
 
 import (
+	"context"
 	"encoding/json"
+	"io"
+	"net/http"
 	"net/url"
 	"strings"
 	"testing"
@@ -138,6 +141,127 @@ func TestSplitClaudeCodeState(t *testing.T) {
 		if code != tt.wantCode || state != tt.wantState {
 			t.Errorf("splitClaudeCodeState(%q) = (%q,%q), want (%q,%q)",
 				tt.in, code, state, tt.wantCode, tt.wantState)
+		}
+	}
+}
+
+// cannedTokenClient returns an *http.Client whose transport answers every
+// request with the given status and body, with no network. It lets the
+// claudeExchangeCode error branches be exercised against the hardcoded
+// claudeTokenURL const without a real server.
+type cannedRoundTripper struct {
+	status int
+	body   string
+}
+
+func (rt cannedRoundTripper) RoundTrip(*http.Request) (*http.Response, error) {
+	return &http.Response{
+		StatusCode: rt.status,
+		Body:       io.NopCloser(strings.NewReader(rt.body)),
+		Header:     make(http.Header),
+	}, nil
+}
+
+func cannedTokenClient(status int, body string) *http.Client {
+	return &http.Client{Transport: cannedRoundTripper{status: status, body: body}}
+}
+
+// TestClaudeExchangeCode_NonOKWithErrorCodeRedactsDescription asserts a
+// token-error body surfaces only the HTTP status and the RFC 6749 `error`
+// code; the free-text error_description (which may echo request material)
+// must never reach the user-facing error.
+func TestClaudeExchangeCode_NonOKWithErrorCodeRedactsDescription(t *testing.T) {
+	const secret = "leaked-request-material-do-not-surface"
+	client := cannedTokenClient(http.StatusBadRequest,
+		`{"error":"invalid_grant","error_description":"`+secret+`"}`)
+
+	_, _, _, _, err := claudeExchangeCode(context.Background(), client, "code", "ver", "state")
+	if err == nil {
+		t.Fatal("expected error on 400 token response, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "400") || !strings.Contains(msg, "invalid_grant") {
+		t.Errorf("error %q should carry status 400 and the error code invalid_grant", msg)
+	}
+	if strings.Contains(msg, secret) {
+		t.Errorf("error %q leaked the error_description; it must be redacted", msg)
+	}
+}
+
+// TestClaudeExchangeCode_NonOKWithoutErrorCodeSurfacesBareStatus covers the
+// branch where the error body does not parse as an RFC 6749 error object:
+// only the bare HTTP status is surfaced.
+func TestClaudeExchangeCode_NonOKWithoutErrorCodeSurfacesBareStatus(t *testing.T) {
+	client := cannedTokenClient(http.StatusInternalServerError, "upstream proxy error, not json")
+
+	_, _, _, _, err := claudeExchangeCode(context.Background(), client, "code", "ver", "state")
+	if err == nil {
+		t.Fatal("expected error on 500 token response, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "500") {
+		t.Errorf("error %q should carry the bare status 500", msg)
+	}
+	if strings.Contains(msg, "not json") {
+		t.Errorf("error %q leaked the raw body; it must be redacted", msg)
+	}
+}
+
+// TestClaudeExchangeCode_MissingAccessToken covers a 2xx response whose
+// JSON omits access_token: the exchange must fail rather than seed an
+// unusable envelope.
+func TestClaudeExchangeCode_MissingAccessToken(t *testing.T) {
+	client := cannedTokenClient(http.StatusOK, `{"refresh_token":"r","expires_in":28800}`)
+
+	_, _, _, _, err := claudeExchangeCode(context.Background(), client, "code", "ver", "state")
+	if err == nil || !strings.Contains(err.Error(), "access_token") {
+		t.Fatalf("expected missing-access_token error, got %v", err)
+	}
+}
+
+// TestClaudeExchangeCode_MalformedJSON covers a 2xx response whose body is
+// not valid JSON.
+func TestClaudeExchangeCode_MalformedJSON(t *testing.T) {
+	client := cannedTokenClient(http.StatusOK, `{not valid json`)
+
+	_, _, _, _, err := claudeExchangeCode(context.Background(), client, "code", "ver", "state")
+	if err == nil || !strings.Contains(err.Error(), "parse token response") {
+		t.Fatalf("expected parse error, got %v", err)
+	}
+}
+
+// TestClaudeExchangeCode_OmittedScopeDefaultsToRequested covers the branch
+// where the provider omits `scope` (RFC 6749 §5.1): the granted set
+// defaults to the requested scopes, and expires_in is returned as seconds.
+func TestClaudeExchangeCode_OmittedScopeDefaultsToRequested(t *testing.T) {
+	client := cannedTokenClient(http.StatusOK,
+		`{"access_token":"at","refresh_token":"rt","expires_in":28800,"token_type":"Bearer"}`)
+
+	access, refresh, expiresIn, scopes, err := claudeExchangeCode(
+		context.Background(), client, "code", "ver", "state")
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if access != "at" || refresh != "rt" || expiresIn != 28800 {
+		t.Errorf("got access=%q refresh=%q expiresIn=%d, want at/rt/28800", access, refresh, expiresIn)
+	}
+	if strings.Join(scopes, " ") != strings.Join(claudeOAuthScopes, " ") {
+		t.Errorf("omitted scope should default to requested %v, got %v", claudeOAuthScopes, scopes)
+	}
+}
+
+func TestParseClaudeTokenErrorCode(t *testing.T) {
+	tests := []struct {
+		name, body, want string
+	}{
+		{"standard error", `{"error":"invalid_grant","error_description":"x"}`, "invalid_grant"},
+		{"no error field", `{"foo":"bar"}`, ""},
+		{"malformed body", `not json at all`, ""},
+		{"empty body", ``, ""},
+	}
+	for _, tt := range tests {
+		if got := parseClaudeTokenErrorCode([]byte(tt.body)); got != tt.want {
+			t.Errorf("%s: parseClaudeTokenErrorCode(%q) = %q, want %q", tt.name, tt.body, got, tt.want)
 		}
 	}
 }

--- a/internal/launch/authspec.go
+++ b/internal/launch/authspec.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"io"
 	"io/fs"
 	"net/http"
 	"strings"
@@ -265,6 +266,24 @@ type HostAcquireDeps struct {
 	// is oauth.SystemBrowser{}; tests inject a fake Opener so the flow
 	// runs headless.
 	Browser oauth.Opener
+
+	// CodePrompter reads the authorization code the user copies out of
+	// the provider's hosted-callback page and pastes back. It is the
+	// seam that keeps the paste on the HOST terminal rather than the
+	// container TTY (the original Windows blocker the host flow fixes).
+	//
+	// promptW is where the acquirer writes the human-facing prompt
+	// ("paste the code from your browser:"); the returned string is the
+	// trimmed line the user typed. The launcher defaults this to a
+	// controlling-terminal line reader (defaultHostCodePrompter); tests
+	// inject a scripted prompter so the acquirer stays pure-Go and
+	// headless-testable.
+	//
+	// A nil CodePrompter means the acquirer has no way to read the
+	// pasted code: the hosted-callback path must treat that as a
+	// non-fatal acquire failure and let the launcher fall back to the
+	// in-container login.
+	CodePrompter func(ctx context.Context, promptW io.Writer) (string, error)
 }
 
 // ErrAuthSpecRenderNil is returned by validateAuthSpec when a

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -341,6 +341,16 @@ func prepareAuthSpec(
 					Ctx:        ctx,
 					HTTPClient: preLaunchRefreshHTTPClient(),
 					Browser:    oauth.SystemBrowser{},
+					// Default the paste prompt to a controlling-terminal
+					// line reader writing to the launcher's stderr, so the
+					// code is pasted on the HOST terminal (not the
+					// container TTY). Tests inject a scripted prompter.
+					CodePrompter: func(ctx context.Context, promptW io.Writer) (string, error) {
+						if promptW == nil {
+							promptW = stderr
+						}
+						return defaultHostCodePrompter(ctx, promptW)
+					},
 				})
 				switch {
 				case acqErr != nil:

--- a/internal/launch/host_code_prompt.go
+++ b/internal/launch/host_code_prompt.go
@@ -1,0 +1,59 @@
+package launch
+
+import (
+	"bufio"
+	"context"
+	"fmt"
+	"io"
+	"strings"
+)
+
+// defaultHostCodePrompter is the launcher's production CodePrompter for
+// the host-side hosted-callback ("paste the code") flow. It writes the
+// human-facing prompt to promptW (the launcher's stderr) and reads one
+// line from the process's CONTROLLING TERMINAL — not stdin.
+//
+// Reading from the controlling terminal (rather than stdin) is what
+// keeps the paste on the HOST, even when the launcher's stdin is wired
+// to the container's PTY. This is the original Windows-blocker fix: the
+// user pastes the code into their own terminal, never into the
+// container TTY.
+//
+// The pasted authorization code is NOT a secret in the password sense
+// (it is single-use and short-lived) and can be long, so we read a
+// plain line with bufio.Reader.ReadString('\n') rather than
+// term.ReadPassword (which suppresses echo and caps line length on some
+// platforms). The returned value is whitespace-trimmed.
+//
+// ctx cancellation is honored on a best-effort basis: a blocked
+// terminal read cannot itself be interrupted, but if the context is
+// already done when the prompter is entered we return immediately
+// without prompting so a cancelled launch does not paint a stray
+// prompt.
+func defaultHostCodePrompter(ctx context.Context, promptW io.Writer) (string, error) {
+	if err := ctx.Err(); err != nil {
+		return "", err
+	}
+	tty, err := openControllingTerminal()
+	if err != nil {
+		return "", fmt.Errorf("open controlling terminal for code paste: %w", err)
+	}
+	defer tty.Close()
+
+	if promptW != nil {
+		fmt.Fprint(promptW, "Paste the code from your browser and press Enter: ")
+	}
+
+	line, err := bufio.NewReader(tty).ReadString('\n')
+	// ReadString returns the data read so far together with io.EOF when
+	// the terminal is closed before a newline; a pasted-then-EOF code is
+	// still usable, so only treat a non-EOF error as fatal.
+	if err != nil && err != io.EOF {
+		return "", fmt.Errorf("read pasted code from terminal: %w", err)
+	}
+	code := strings.TrimSpace(line)
+	if code == "" {
+		return "", fmt.Errorf("no code entered")
+	}
+	return code, nil
+}

--- a/internal/launch/host_code_prompt_test.go
+++ b/internal/launch/host_code_prompt_test.go
@@ -1,0 +1,44 @@
+package launch
+
+import (
+	"bytes"
+	"context"
+	"testing"
+)
+
+// defaultHostCodePrompter contract:
+//
+//   - An already-cancelled context returns the context error immediately
+//     and never opens the terminal or paints a prompt (a cancelled
+//     launch must not leave a stray prompt on the user's screen).
+//   - With a live context but no controlling terminal (CI), it surfaces
+//     a clear open error rather than hanging — mirroring the vault
+//     prompter's no-terminal contract.
+
+func TestDefaultHostCodePrompter_CancelledContextReturnsEarly(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel()
+
+	var buf bytes.Buffer
+	got, err := defaultHostCodePrompter(ctx, &buf)
+	if err == nil {
+		t.Fatal("expected the cancelled-context error")
+	}
+	if got != "" {
+		t.Errorf("got %q, want empty string on cancellation", got)
+	}
+	if buf.Len() != 0 {
+		t.Errorf("prompt painted %q despite a cancelled context", buf.String())
+	}
+}
+
+func TestDefaultHostCodePrompter_NoTerminalFailsGracefully(t *testing.T) {
+	if f, err := openControllingTerminal(); err == nil {
+		f.Close()
+		t.Skip("controlling terminal present; skipping to avoid blocking on read")
+	}
+	var buf bytes.Buffer
+	if _, err := defaultHostCodePrompter(context.Background(), &buf); err == nil {
+		t.Fatal("expected an error when no controlling terminal is available")
+	}
+}


### PR DESCRIPTION
## Summary

Implements Claude's host-side credential acquirer and attaches it to the Claude `FileBinding`'s `HostAcquire` hook (the SPI merged in #1276 / #1268). Part of umbrella #1267.

When the vault is empty for `agents/claude/oauth`, the binding is not `Required`, and host-login is enabled, the launcher now seeds the vault on the **host** before the container starts — so the first launch is silent rather than dropping into the in-container login. A cancelled or failed acquire is non-fatal and falls back to the in-container login (contract owned by #1268's `prepareAuthSpec`, untouched here).

Two acquisition mechanisms, tried in order:

1. **`claude setup-token` shortcut (opportunistic).** When `claude` is on `PATH`, run `setup-token`; it prints a single long-lived bare token. We wrap it into a `claudeAiOauth` envelope with `accessToken` only — `refreshToken`/`expiresAt`/`scopes` are intentionally left empty (the setup-token path has no refresh token or expiry). CLI absence is expected, not an error.
2. **Hosted-callback paste flow (PKCE).** Open the consent URL in the host browser, read the pasted `<code>#<state>` from the **host terminal** (never the container TTY — the original Windows blocker), verify state, exchange the code (public client, PKCE, no client secret), and store an envelope whose `expiresAt` is in **milliseconds**.

`HostAcquireDeps` gains an injectable `CodePrompter` seam so the acquirer stays pure-Go and headless-testable; the launcher defaults it to a controlling-terminal line reader (reusing `openControllingTerminal` + `bufio`, a plain line read, not `term.ReadPassword`). This is a non-breaking struct addition; the merged spy test still compiles and passes.

### Verified OAuth values (acceptance requirement)

Verified against the live `claude` install behavior and public documentation before implementing:

| Field | Value |
| --- | --- |
| Client ID | `9d1c250a-e61b-44d9-88ed-5944d1962f5e` (public client, no secret) |
| Authorize URL | `https://claude.ai/oauth/authorize` (with `code=true` to render the copyable `<code>#<state>`) |
| Token URL | `https://platform.claude.com/v1/oauth/token` |
| Hosted callback (only accepted `redirect_uri`) | `https://platform.claude.com/oauth/code/callback` |
| Scopes | `user:inference user:profile user:sessions:claude_code user:mcp_servers` |
| Token exchange | `grant_type=authorization_code`, `code`, `redirect_uri=<hosted callback>`, `client_id`, `code_verifier`, `state` (PKCE-only) |
| `expires_in` | seconds (e.g. 28800); converted to absolute ms for `claudeAiOauth.expiresAt` |

Loopback (`127.0.0.1`) and device-auth are rejected per #1275 P0: the public client is registered only for the hosted callback, and the token endpoint returns `400 invalid_grant` for any loopback redirect — hence the paste-code mechanism.

### Two parse contracts

- **Hosted-callback exchange** → full envelope: `accessToken`, `refreshToken`, `expiresAt` (ms), `scopes`.
- **Bare setup-token** → `accessToken` only; the other fields are deliberately empty. Documented in code so the divergence is not mistaken for a bug.

### Security posture

- Token-error bodies are redacted: only the HTTP status and the RFC 6749 `error` code are surfaced; the free-text `error_description` (which may echo request material) is never put in the user-facing error. Mirrors `credential.DoRefresh`.
- State is verified when the user pastes `<code>#<state>`; a mismatch aborts before the exchange so a cross-session code is never redeemed. A bare-code paste is tolerated because PKCE already binds the exchange.

## Scope

- No changes to `prepareAuthSpec`'s acquire/PUT/render/fallback logic (merged + tested under #1268) beyond adding the `CodePrompter` field and its launcher default.
- No other agents touched. No loopback/device-auth. No OpenAPI changes. Versions stay 0.0.x.

## Test plan

- `go -C internal test ./launch/... ./oauth/...` — pass.
- `go -C internal vet ./...` and `go -C internal vet -tags integration_sandbox ./launch/...` — clean (both build tags compile).
- `go -C internal build ./...`, `go -C cmd/aileron build ./...`, `go -C cmd/aileron-mcp build ./...` — pass.
- New tests cover every contract branch from the brief: hosted-callback happy path (httptest token endpoint via injected RoundTripper, fake `Opener`, scripted prompter; envelope round-trips `Render`, `expiresAt` asserted ms-magnitude), setup-token shortcut (stubbed `claude` binary on a temp PATH; `refreshToken`/`expiresAt` empty), CLI-absent → hosted-callback path, token 400 / prompter error / state mismatch / nil-prompter / browser-open failure → non-fatal error with empty Secret, and a redaction assertion that the provider `error_description` does not leak. Coverage on the new acquirer functions is 75–100% (uncovered lines are defensive marshal/rand error paths).
- CodeRabbit review run pre-PR: one minor test-helper finding (single-quote escaping in the shell stub), fixed.

Closes #1270

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enabled silent first-launch credential seeding for Claude with host-side authentication
  * Added quick token setup shortcut option for faster credential configuration
  * Implemented OAuth authentication with browser-based consent and code-pasting fallback

* **Documentation**
  * Added configuration guide for host-side Claude authentication

* **Tests**
  * Added comprehensive test coverage for new authentication workflows

<!-- end of auto-generated comment: release notes by coderabbit.ai -->