### PR TITLE
feat(auth): add tool-agnostic container capture driver

### DIFF
--- a/internal/auth/capture/capture.go
+++ b/internal/auth/capture/capture.go
@@ -1,0 +1,228 @@
+// Package capture is a provider-independent substrate for acquiring a
+// credential by driving an interactive CLI login inside a container and
+// reading the produced token back out.
+//
+// It is the tool-agnostic core extracted from the bespoke
+// `aileron auth github` device-flow capture (#1286). All tool-specific
+// knowledge — the container image, the container name, the login arg
+// vector, the token-read arg vector, the config-dir env, the optional
+// BROWSER shim, the vault path, and the kind metadata stamp — is a
+// parameter on Driver. Nothing about any particular CLI (gh, github.com,
+// user/github, --web, …) is compiled into this package.
+//
+// The driver runs the SAME named container for both execs: an
+// interactive login writes the tool's credential into the container's
+// config home, and a second exec reads it back. An ephemeral second
+// container would not see what the login wrote, so the shared container
+// is load-bearing — the lifecycle (clear stale name, start, login, read,
+// teardown-on-every-exit) is the substrate this package owns.
+//
+// The vault PUT is NOT owned here. `internal` cannot import `cmd`, where
+// the daemon vault transport lives, so storage is expressed as an
+// injected StoreFunc seam. The driver stamps the captured bytes with the
+// configured kind and hands them to Store; the HTTP status → message
+// mapping stays caller-side (#1288). The driver surfaces the store
+// error verbatim.
+package capture
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+
+	"golang.org/x/term"
+)
+
+// ErrEmptyToken is returned by Acquire when the login exec completes but
+// the token read yields only whitespace. The token is never stored in
+// that case: an empty credential would fail closed at the binding
+// boundary, so the driver reports the incomplete login rather than
+// persisting a useless entry.
+var ErrEmptyToken = errors.New("capture: token read returned an empty value; login did not complete")
+
+// StoreFunc persists the captured credential. It is the seam that keeps
+// the driver transport-agnostic: production wiring supplies a closure
+// over the daemon vault PUT (#1288); tests supply a recording fake.
+//
+// storeAt is the vault path, kind is the metadata Type stamp, and value
+// is the trimmed credential bytes. The returned error is surfaced
+// verbatim by Acquire — the caller owns any status → message mapping.
+type StoreFunc func(ctx context.Context, storeAt, kind string, value []byte) error
+
+// stdinIsTerminal reports whether the operator's stdin is a real
+// terminal. It is a package var so tests can drive both branches.
+//
+// An interactive CLI login (e.g. a device-flow prompt) typically renders
+// through a prompt library that requires a pseudo-TTY, so the login exec
+// needs `-t`. We gate on a real stdin so a non-TTY / CI caller does not
+// hit the runtime's "cannot enable tty mode on non tty input" — they get
+// a plain `exec -i` instead (which will not complete an interactive
+// login, but fails cleanly rather than mis-allocating a PTY).
+var stdinIsTerminal = func() bool {
+	return term.IsTerminal(int(os.Stdin.Fd()))
+}
+
+// Driver captures a credential by driving an interactive CLI login
+// inside a container and reading the produced token back out. Every
+// tool-specific value is a field; the zero Driver is not usable — Runner,
+// RuntimeExe, Image, ContainerName, LoginArgs, TokenArgs, StoreAt, and
+// Store must be set.
+type Driver struct {
+	// Runner executes runtime commands. Defaults via New to
+	// sandboxcontainer.DefaultRunner(); tests inject a fake.
+	Runner sandboxcontainer.Runner
+	// RuntimeExe is the resolved runtime executable, e.g. "docker".
+	RuntimeExe string
+	// Image is the fully-resolved container image to run. Image / base-image
+	// resolution policy stays in the caller; the driver takes a ready string.
+	Image string
+	// ContainerName is the deterministic name for the long-lived container.
+	ContainerName string
+
+	// LoginArgs is the interactive login command run inside the container,
+	// minus the exec scaffolding — e.g. {"gh","auth","login","--web"}. The
+	// driver prepends exec/-i/-t/--env tokens and the container name.
+	LoginArgs []string
+	// TokenArgs is the token-read command run inside the same container,
+	// e.g. {"gh","auth","token"}. The driver prepends `exec <name>`.
+	TokenArgs []string
+
+	// ConfigDirEnv, when non-empty, is passed as a single `--env=K=V` token
+	// (e.g. "GH_CONFIG_DIR=/path") on BOTH the login and token execs so the
+	// token read sees the same config home the login wrote to. Empty omits it.
+	ConfigDirEnv string
+	// BrowserShim, when non-empty, is passed as `--env=BROWSER=<shim>` on the
+	// login exec only, to turn a missing-browser open into a clean no-op.
+	// Empty omits it. The non-interactive token read never carries it.
+	BrowserShim string
+
+	// StoreAt is the vault path the captured credential is stored at.
+	StoreAt string
+	// Kind is the metadata Type stamped on the stored credential.
+	Kind string
+	// Store persists the credential. Required.
+	Store StoreFunc
+}
+
+// New constructs a Driver with the runtime resolved and the Runner
+// defaulted to the production exec runner, mirroring the github flow's
+// constructor. Image/base-image resolution stays caller-side: pass a
+// fully-resolved image. The returned Driver still needs LoginArgs,
+// TokenArgs, ContainerName, StoreAt, Kind, and Store set by the caller.
+func New(runtime, image string) (*Driver, error) {
+	runtimeExe, err := sandboxcontainer.ResolveRuntime(runtime)
+	if err != nil {
+		return nil, err
+	}
+	return &Driver{
+		Runner:     sandboxcontainer.DefaultRunner(),
+		RuntimeExe: runtimeExe,
+		Image:      image,
+	}, nil
+}
+
+// Capture starts the container, runs the interactive login, reads the
+// token from that same container, then tears the container down. The
+// teardown is deferred so a mid-flow failure still removes the container.
+// The returned bytes are the token with trailing CR/LF trimmed.
+func (d *Driver) Capture(ctx context.Context) ([]byte, error) {
+	// Clear any container left behind by a prior run that died before its
+	// teardown (e.g. SIGKILL): the name is deterministic, so a stale
+	// container would make `run --name` fail with "name already in use".
+	// rm -f on a nonexistent name is a harmless no-op, so the error is
+	// ignored.
+	_ = d.Runner.Run(ctx, d.RuntimeExe,
+		[]string{"rm", "-f", d.ContainerName}, io.Discard, io.Discard)
+
+	// Start one long-lived container we exec into twice. --rm is not used
+	// because we explicitly `rm -f` in the deferred teardown; sleep keeps
+	// it alive between the login and token execs.
+	var startErr bytes.Buffer
+	runArgs := []string{
+		"run", "-d", "--name", d.ContainerName,
+		d.Image, "sleep", "3600",
+	}
+	if err := d.Runner.Run(ctx, d.RuntimeExe, runArgs, io.Discard, &startErr); err != nil {
+		return nil, fmt.Errorf("starting container: %w%s", err, stderrSuffix(&startErr))
+	}
+	// Tear the container down regardless of how Capture exits.
+	defer func() {
+		_ = d.Runner.Run(context.Background(), d.RuntimeExe,
+			[]string{"rm", "-f", d.ContainerName}, io.Discard, io.Discard)
+	}()
+
+	// Interactive login. The login's stdin/stdout are wired to the host
+	// terminal by the Runner so the operator can read any prompt.
+	//
+	// The login exec gets `-t` when stdin is a real terminal so a
+	// prompt-library login renders. `-i` and `-t` are passed as separate
+	// args so the Runner's interactiveTTYRun gate matches `-t` and hands
+	// the child the controlling terminal's foreground process group —
+	// required because the Runner isolates the runtime child into its own
+	// process group, where raw-mode tcsetattr would otherwise fail with
+	// SIGTTOU/EINTR.
+	loginArgs := []string{"exec", "-i"}
+	if stdinIsTerminal() {
+		loginArgs = append(loginArgs, "-t")
+	}
+	// The browser shim, when set, makes a missing-browser open a clean
+	// no-op. Passed as a single `--env=K=V` token so it stays a
+	// `-`-prefixed exec flag (the runtime's arg parsing skips those).
+	if d.BrowserShim != "" {
+		loginArgs = append(loginArgs, "--env=BROWSER="+d.BrowserShim)
+	}
+	// The config-dir env is on BOTH execs so the token read sees the same
+	// config home the login wrote to.
+	if d.ConfigDirEnv != "" {
+		loginArgs = append(loginArgs, "--env="+d.ConfigDirEnv)
+	}
+	loginArgs = append(loginArgs, d.ContainerName)
+	loginArgs = append(loginArgs, d.LoginArgs...)
+	if err := d.Runner.Run(ctx, d.RuntimeExe, loginArgs, os.Stdout, os.Stderr); err != nil {
+		return nil, fmt.Errorf("login: %w", err)
+	}
+
+	// Read the token the login wrote into the config home of THIS container.
+	var tokenOut, tokenErr bytes.Buffer
+	tokenArgs := []string{"exec"}
+	if d.ConfigDirEnv != "" {
+		tokenArgs = append(tokenArgs, "--env="+d.ConfigDirEnv)
+	}
+	tokenArgs = append(tokenArgs, d.ContainerName)
+	tokenArgs = append(tokenArgs, d.TokenArgs...)
+	if err := d.Runner.Run(ctx, d.RuntimeExe, tokenArgs, &tokenOut, &tokenErr); err != nil {
+		return nil, fmt.Errorf("reading token: %w%s", err, stderrSuffix(&tokenErr))
+	}
+	return bytes.TrimRight(tokenOut.Bytes(), "\r\n"), nil
+}
+
+// Acquire is the full driver entrypoint: it captures the token, guards
+// the empty-after-trim case (no store, ErrEmptyToken), then stamps the
+// configured kind and hands the bytes to Store. Store's error is
+// returned verbatim. Store is never called on a capture failure or an
+// empty token.
+func (d *Driver) Acquire(ctx context.Context) error {
+	token, err := d.Capture(ctx)
+	if err != nil {
+		return err
+	}
+	if len(bytes.TrimSpace(token)) == 0 {
+		return ErrEmptyToken
+	}
+	return d.Store(ctx, d.StoreAt, d.Kind, token)
+}
+
+// stderrSuffix renders captured stderr as a trailing context fragment
+// for an error message, or "" when there is none.
+func stderrSuffix(b *bytes.Buffer) string {
+	s := bytes.TrimSpace(b.Bytes())
+	if len(s) == 0 {
+		return ""
+	}
+	return ": " + string(s)
+}

--- a/internal/auth/capture/capture_test.go
+++ b/internal/auth/capture/capture_test.go
@@ -1,0 +1,571 @@
+package capture
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"io"
+	"strings"
+	"testing"
+)
+
+// These tests pin the contract of the provider-independent capture
+// driver:
+//
+//   - The shared container is load-bearing: exactly one `run`, and both
+//     the login and token execs target it, with teardown on every exit.
+//   - The TTY gate puts a standalone `-t` (plus `-i`) on the login exec
+//     only when stdin is a terminal; the token read never gets `-t`.
+//   - The BROWSER shim and config-dir env appear exactly where the
+//     contract says (browser: login only; config-dir: both execs).
+//   - Acquire stores the trimmed token via the injected StoreFunc on the
+//     happy path, and NEVER calls Store on a capture failure or an empty
+//     token. Store's error is surfaced verbatim.
+
+// --- fakes ---------------------------------------------------------------
+
+// recordingRunner records every invocation and models the load-bearing
+// shared-container behavior: the token read only yields a token when a
+// prior login exec ran against the SAME container name. An
+// ephemeral-container implementation cannot satisfy this.
+type recordingRunner struct {
+	calls         [][]string
+	loggedInNames map[string]bool
+	runContainer  string
+	token         string
+}
+
+func (r *recordingRunner) Run(_ context.Context, _ string, args []string, stdout, _ io.Writer) error {
+	r.calls = append(r.calls, args)
+	if r.loggedInNames == nil {
+		r.loggedInNames = map[string]bool{}
+	}
+	if len(args) == 0 {
+		return nil
+	}
+	switch args[0] {
+	case "run":
+		r.runContainer = containerNameFromRunArgs(args)
+		return nil
+	case "exec":
+		cname, sub := parseExecArgs(args)
+		switch sub {
+		case "login":
+			if cname != r.runContainer {
+				return errors.New("login targeted a container that was never created")
+			}
+			r.loggedInNames[cname] = true
+			return nil
+		case "token":
+			if !r.loggedInNames[cname] {
+				return errors.New("token read: not logged in to this container")
+			}
+			_, _ = io.WriteString(stdout, r.token+"\n")
+			return nil
+		}
+	case "rm":
+		return nil
+	}
+	return nil
+}
+
+// parseExecArgs extracts the container name and the tool subcommand from
+// an `exec [flags] <name> <tool> <verb> <sub> ...` arg slice. The login
+// vector here is {"<tool>","auth","login",...} and the token vector is
+// {"<tool>","auth","token"}, so the meaningful token is the one after
+// "auth".
+func parseExecArgs(args []string) (container, sub string) {
+	i := 1 // skip "exec"
+	for i < len(args) && strings.HasPrefix(args[i], "-") {
+		i++ // skip exec flags like -i, -t, --env=...
+	}
+	if i >= len(args) {
+		return "", ""
+	}
+	container = args[i]
+	i++
+	// Walk to "auth" and read the verb after it.
+	for j := i; j+1 < len(args); j++ {
+		if args[j] == "auth" {
+			return container, args[j+1]
+		}
+	}
+	return container, ""
+}
+
+func containerNameFromRunArgs(args []string) string {
+	for i, a := range args {
+		if a == "--name" && i+1 < len(args) {
+			return args[i+1]
+		}
+	}
+	return ""
+}
+
+// failingLoginRunner fails the login exec but records the teardown.
+type failingLoginRunner struct{ removed bool }
+
+func (r *failingLoginRunner) Run(_ context.Context, _ string, args []string, _, _ io.Writer) error {
+	if len(args) == 0 {
+		return nil
+	}
+	switch args[0] {
+	case "run":
+		return nil
+	case "exec":
+		if _, sub := parseExecArgs(args); sub == "login" {
+			return errors.New("login failed")
+		}
+		return nil
+	case "rm":
+		r.removed = true
+		return nil
+	}
+	return nil
+}
+
+// scriptedRunner fails a chosen step and writes a stderr fragment.
+type scriptedRunner struct {
+	failStep  string // "run" or "token"
+	stderrMsg string
+	removed   bool
+}
+
+func (r *scriptedRunner) Run(_ context.Context, _ string, args []string, _, stderr io.Writer) error {
+	if len(args) == 0 {
+		return nil
+	}
+	switch args[0] {
+	case "run":
+		if r.failStep == "run" {
+			_, _ = io.WriteString(stderr, r.stderrMsg)
+			return errors.New("exit status 125")
+		}
+		return nil
+	case "exec":
+		if _, sub := parseExecArgs(args); sub == "token" && r.failStep == "token" {
+			_, _ = io.WriteString(stderr, r.stderrMsg)
+			return errors.New("exit status 1")
+		}
+		return nil
+	case "rm":
+		r.removed = true
+		return nil
+	}
+	return nil
+}
+
+// recordingStore records the args of the last Store call and returns a
+// configurable error.
+type recordingStore struct {
+	called  int
+	storeAt string
+	kind    string
+	value   []byte
+	retErr  error
+}
+
+func (s *recordingStore) fn() StoreFunc {
+	return func(_ context.Context, storeAt, kind string, value []byte) error {
+		s.called++
+		s.storeAt = storeAt
+		s.kind = kind
+		s.value = append([]byte(nil), value...)
+		return s.retErr
+	}
+}
+
+// newTestDriver builds a Driver wired to the given runner and store with
+// a representative tool-specific config (modeled on the gh flow, but no
+// gh literals are load-bearing here).
+func newTestDriver(runner interface {
+	Run(context.Context, string, []string, io.Writer, io.Writer) error
+}, store StoreFunc) *Driver {
+	return &Driver{
+		Runner:        runnerFunc(runner.Run),
+		RuntimeExe:    "docker",
+		Image:         "img",
+		ContainerName: "aileron-auth-cli",
+		LoginArgs:     []string{"gh", "auth", "login", "--web"},
+		TokenArgs:     []string{"gh", "auth", "token"},
+		StoreAt:       "/vault/user/github/credentials",
+		Kind:          "user",
+		Store:         store,
+	}
+}
+
+// runnerFunc adapts a Run method value to the sandboxcontainer.Runner
+// interface without importing the package's concrete fakes.
+type runnerFunc func(context.Context, string, []string, io.Writer, io.Writer) error
+
+func (f runnerFunc) Run(ctx context.Context, name string, args []string, stdout, stderr io.Writer) error {
+	return f(ctx, name, args, stdout, stderr)
+}
+
+func execArgsBySub(calls [][]string) (login, token []string) {
+	for _, c := range calls {
+		if len(c) == 0 || c[0] != "exec" {
+			continue
+		}
+		switch _, sub := parseExecArgs(c); sub {
+		case "login":
+			login = c
+		case "token":
+			token = c
+		}
+	}
+	return login, token
+}
+
+func hasArg(args []string, want string) bool {
+	for _, a := range args {
+		if a == want {
+			return true
+		}
+	}
+	return false
+}
+
+// --- Capture: shared-container + lifecycle -------------------------------
+
+func TestCapture_UsesOneSharedContainerForBothCalls(t *testing.T) {
+	rr := &recordingRunner{token: "tok_shared"}
+	d := newTestDriver(rr, (&recordingStore{}).fn())
+
+	token, err := d.Capture(context.Background())
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if string(token) != "tok_shared" {
+		t.Errorf("token = %q, want the captured value (trimmed)", token)
+	}
+
+	runs := 0
+	for _, c := range rr.calls {
+		if len(c) > 0 && c[0] == "run" {
+			runs++
+		}
+	}
+	if runs != 1 {
+		t.Fatalf("run count = %d, want exactly 1 (shared container)", runs)
+	}
+	if rr.runContainer != "aileron-auth-cli" {
+		t.Fatalf("created container = %q, want aileron-auth-cli", rr.runContainer)
+	}
+
+	login, token2 := execArgsBySub(rr.calls)
+	lc, _ := parseExecArgs(login)
+	tc, _ := parseExecArgs(token2)
+	if lc != rr.runContainer {
+		t.Errorf("login container = %q, want %q", lc, rr.runContainer)
+	}
+	if tc != rr.runContainer {
+		t.Errorf("token container = %q, want %q (same as login)", tc, rr.runContainer)
+	}
+
+	teardown := false
+	for _, c := range rr.calls {
+		if len(c) >= 3 && c[0] == "rm" && c[1] == "-f" && c[2] == "aileron-auth-cli" {
+			teardown = true
+		}
+	}
+	if !teardown {
+		t.Error("container was not torn down with rm -f")
+	}
+}
+
+func TestCapture_TTYGate(t *testing.T) {
+	driveTTY := func(t *testing.T, isTTY bool) (login, token []string) {
+		t.Helper()
+		orig := stdinIsTerminal
+		stdinIsTerminal = func() bool { return isTTY }
+		t.Cleanup(func() { stdinIsTerminal = orig })
+
+		rr := &recordingRunner{token: "tok"}
+		d := newTestDriver(rr, (&recordingStore{}).fn())
+		if _, err := d.Capture(context.Background()); err != nil {
+			t.Fatalf("Capture: %v", err)
+		}
+		return execArgsBySub(rr.calls)
+	}
+
+	t.Run("terminal stdin allocates a PTY for login only", func(t *testing.T) {
+		login, token := driveTTY(t, true)
+		if !hasArg(login, "-t") {
+			t.Errorf("login = %v; want standalone -t when stdin is a terminal", login)
+		}
+		if !hasArg(login, "-i") {
+			t.Errorf("login = %v; want -i", login)
+		}
+		if hasArg(login, "-it") {
+			t.Errorf("login = %v; -i and -t must be separate args", login)
+		}
+		if hasArg(token, "-t") {
+			t.Errorf("token = %v; the non-interactive read must not allocate a PTY", token)
+		}
+	})
+
+	t.Run("non-terminal stdin omits the PTY flag", func(t *testing.T) {
+		login, _ := driveTTY(t, false)
+		if hasArg(login, "-t") {
+			t.Errorf("login = %v; want NO -t when stdin is not a terminal", login)
+		}
+		if !hasArg(login, "-i") {
+			t.Errorf("login = %v; want -i even without a terminal", login)
+		}
+	})
+}
+
+func TestCapture_BrowserShimOnLoginOnly(t *testing.T) {
+	rr := &recordingRunner{token: "tok"}
+	d := newTestDriver(rr, (&recordingStore{}).fn())
+	d.BrowserShim = "echo"
+	if _, err := d.Capture(context.Background()); err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	login, token := execArgsBySub(rr.calls)
+	if !hasArg(login, "--env=BROWSER=echo") {
+		t.Errorf("login = %v; want --env=BROWSER=echo", login)
+	}
+	if hasArg(token, "--env=BROWSER=echo") {
+		t.Errorf("token = %v; the token read must not set BROWSER", token)
+	}
+}
+
+func TestCapture_BrowserShimAbsentWhenUnset(t *testing.T) {
+	rr := &recordingRunner{token: "tok"}
+	d := newTestDriver(rr, (&recordingStore{}).fn())
+	// BrowserShim left empty.
+	if _, err := d.Capture(context.Background()); err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	login, _ := execArgsBySub(rr.calls)
+	for _, a := range login {
+		if strings.HasPrefix(a, "--env=BROWSER=") {
+			t.Errorf("login = %v; want no BROWSER env when BrowserShim is unset", login)
+		}
+	}
+}
+
+func TestCapture_ConfigDirEnvOnBothExecs(t *testing.T) {
+	rr := &recordingRunner{token: "tok"}
+	d := newTestDriver(rr, (&recordingStore{}).fn())
+	d.ConfigDirEnv = "GH_CONFIG_DIR=/cfg"
+	if _, err := d.Capture(context.Background()); err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	login, token := execArgsBySub(rr.calls)
+	if !hasArg(login, "--env=GH_CONFIG_DIR=/cfg") {
+		t.Errorf("login = %v; want config-dir env on the login exec", login)
+	}
+	if !hasArg(token, "--env=GH_CONFIG_DIR=/cfg") {
+		t.Errorf("token = %v; want config-dir env on the token exec too", token)
+	}
+}
+
+func TestCapture_ConfigDirEnvAbsentWhenUnset(t *testing.T) {
+	rr := &recordingRunner{token: "tok"}
+	d := newTestDriver(rr, (&recordingStore{}).fn())
+	if _, err := d.Capture(context.Background()); err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	login, token := execArgsBySub(rr.calls)
+	for _, c := range [][]string{login, token} {
+		for _, a := range c {
+			if strings.HasPrefix(a, "--env=GH_CONFIG_DIR") {
+				t.Errorf("exec = %v; want no config-dir env when ConfigDirEnv is unset", c)
+			}
+		}
+	}
+}
+
+func TestCapture_TearsDownOnLoginFailure(t *testing.T) {
+	rr := &failingLoginRunner{}
+	d := newTestDriver(rr, (&recordingStore{}).fn())
+	if _, err := d.Capture(context.Background()); err == nil {
+		t.Fatal("expected an error from the failing login")
+	}
+	if !rr.removed {
+		t.Error("container was not removed after a mid-flow failure")
+	}
+}
+
+func TestCapture_StartFailureSurfacesStderr(t *testing.T) {
+	rr := &scriptedRunner{failStep: "run", stderrMsg: "image not found"}
+	d := newTestDriver(rr, (&recordingStore{}).fn())
+	_, err := d.Capture(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when the container fails to start")
+	}
+	if !strings.Contains(err.Error(), "starting container") || !strings.Contains(err.Error(), "image not found") {
+		t.Errorf("err = %v, want start-failure context with runtime stderr", err)
+	}
+}
+
+func TestCapture_TokenReadFailureSurfacesStderrAndTearsDown(t *testing.T) {
+	rr := &scriptedRunner{failStep: "token", stderrMsg: "no token"}
+	d := newTestDriver(rr, (&recordingStore{}).fn())
+	_, err := d.Capture(context.Background())
+	if err == nil {
+		t.Fatal("expected an error when the token read fails")
+	}
+	if !strings.Contains(err.Error(), "reading token") || !strings.Contains(err.Error(), "no token") {
+		t.Errorf("err = %v, want token-failure context with runtime stderr", err)
+	}
+	if !rr.removed {
+		t.Error("container was not torn down after a token-read failure")
+	}
+}
+
+func TestCapture_TrimsTrailingCRLF(t *testing.T) {
+	// The recordingRunner appends "\n"; assert the trailing newline is gone.
+	rr := &recordingRunner{token: "tok_trim"}
+	d := newTestDriver(rr, (&recordingStore{}).fn())
+	token, err := d.Capture(context.Background())
+	if err != nil {
+		t.Fatalf("Capture: %v", err)
+	}
+	if string(token) != "tok_trim" {
+		t.Errorf("token = %q, want trailing newline trimmed", token)
+	}
+}
+
+// --- Acquire: store-and-stamp + the five named scenarios -----------------
+
+func TestAcquire_HappyPathStoresTrimmedToken(t *testing.T) {
+	rr := &recordingRunner{token: "tok_happy"}
+	store := &recordingStore{}
+	d := newTestDriver(rr, store.fn())
+
+	if err := d.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	if store.called != 1 {
+		t.Fatalf("Store called %d times, want exactly 1", store.called)
+	}
+	if store.storeAt != "/vault/user/github/credentials" {
+		t.Errorf("storeAt = %q, want the configured path", store.storeAt)
+	}
+	if store.kind != "user" {
+		t.Errorf("kind = %q, want the configured stamp", store.kind)
+	}
+	if string(store.value) != "tok_happy" {
+		t.Errorf("stored value = %q, want the trimmed token", store.value)
+	}
+}
+
+func TestAcquire_EmptyTokenDoesNotStore(t *testing.T) {
+	rr := &recordingRunner{token: "   "} // whitespace-only → empty after trim
+	store := &recordingStore{}
+	d := newTestDriver(rr, store.fn())
+
+	err := d.Acquire(context.Background())
+	if !errors.Is(err, ErrEmptyToken) {
+		t.Fatalf("err = %v, want ErrEmptyToken", err)
+	}
+	if store.called != 0 {
+		t.Error("Store was called despite an empty token")
+	}
+}
+
+func TestAcquire_VaultLockedErrorPropagates(t *testing.T) {
+	rr := &recordingRunner{token: "tok"}
+	locked := errors.New("vault is locked")
+	store := &recordingStore{retErr: locked}
+	d := newTestDriver(rr, store.fn())
+
+	if err := d.Acquire(context.Background()); !errors.Is(err, locked) {
+		t.Fatalf("err = %v, want the locked error surfaced verbatim", err)
+	}
+	if store.called != 1 {
+		t.Error("Store should have been attempted before the locked error")
+	}
+}
+
+func TestAcquire_NoVaultErrorPropagates(t *testing.T) {
+	rr := &recordingRunner{token: "tok"}
+	noVault := errors.New("daemon is not configured with a vault")
+	store := &recordingStore{retErr: noVault}
+	d := newTestDriver(rr, store.fn())
+
+	if err := d.Acquire(context.Background()); !errors.Is(err, noVault) {
+		t.Fatalf("err = %v, want the no-vault error surfaced verbatim", err)
+	}
+}
+
+func TestAcquire_NonTTYStillCompletesStore(t *testing.T) {
+	orig := stdinIsTerminal
+	stdinIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsTerminal = orig })
+
+	rr := &recordingRunner{token: "tok_nontty"}
+	store := &recordingStore{}
+	d := newTestDriver(rr, store.fn())
+
+	if err := d.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	// The gate omits -t but must not break the happy path store.
+	login, _ := execArgsBySub(rr.calls)
+	if hasArg(login, "-t") {
+		t.Errorf("login = %v; want no -t in non-TTY mode", login)
+	}
+	if store.called != 1 || string(store.value) != "tok_nontty" {
+		t.Errorf("store called=%d value=%q, want one call with the token", store.called, store.value)
+	}
+}
+
+func TestAcquire_CaptureFailureDoesNotStore(t *testing.T) {
+	rr := &scriptedRunner{failStep: "run", stderrMsg: "boom"}
+	store := &recordingStore{}
+	d := newTestDriver(rr, store.fn())
+
+	if err := d.Acquire(context.Background()); err == nil {
+		t.Fatal("expected the capture error to propagate")
+	}
+	if store.called != 0 {
+		t.Error("Store was called despite a capture failure")
+	}
+}
+
+// --- constructor ---------------------------------------------------------
+
+func TestNew_DefaultsRunnerAndResolvesRuntime(t *testing.T) {
+	// "auto" resolves to the host's available runtime (docker). The
+	// constructor must default the Runner and carry the image through.
+	d, err := New("auto", "ghcr.io/example/img:tag")
+	if err != nil {
+		t.Skipf("no container runtime resolvable in this environment: %v", err)
+	}
+	if d.Runner == nil {
+		t.Error("Runner was not defaulted")
+	}
+	if d.RuntimeExe == "" {
+		t.Error("RuntimeExe was not resolved")
+	}
+	if d.Image != "ghcr.io/example/img:tag" {
+		t.Errorf("Image = %q, want the passed image", d.Image)
+	}
+}
+
+func TestNew_RejectsUnsupportedRuntime(t *testing.T) {
+	// An unsupported runtime fails fast in ResolveRuntime before any
+	// container work, exercising the constructor's error path.
+	if _, err := New("podman", ""); err == nil {
+		t.Fatal("expected an error for an unsupported runtime")
+	}
+}
+
+// --- helpers -------------------------------------------------------------
+
+func TestStderrSuffix(t *testing.T) {
+	if got := stderrSuffix(bytes.NewBufferString("")); got != "" {
+		t.Errorf("empty suffix = %q, want empty", got)
+	}
+	if got := stderrSuffix(bytes.NewBufferString("   \n")); got != "" {
+		t.Errorf("whitespace suffix = %q, want empty", got)
+	}
+	if got := stderrSuffix(bytes.NewBufferString("boom\n")); got != ": boom" {
+		t.Errorf("suffix = %q, want %q", got, ": boom")
+	}
+}


### PR DESCRIPTION
## Summary

Extracts the provider-independent substrate from the bespoke `aileron auth github` device-flow capture (`cmd/aileron/auth_github.go`) into a standalone, tool-agnostic driver at `internal/auth/capture`.

The `Driver`:
- optionally clears a stale named container, starts a long-lived container,
- runs a TTY-gated interactive login (with optional `BROWSER` shim and optional config-dir `--env`),
- reads the produced token from the **same** container (the shared container is load-bearing),
- guards the empty-after-trim case,
- stamps a `Kind` and stores the bytes via an injected `StoreFunc` seam,
- and tears the container down on every exit path.

All tool-specific knowledge (`gh` literals, `github.com`, `user/github`, `--web`, etc.) is a parameter. Nothing GitHub-specific is compiled in.

### Why a `StoreFunc` seam instead of owning the vault PUT
This is a multi-module workspace and `internal` cannot import `cmd`, where `vaultDoRequest` and the credential body types live. Storing is therefore expressed as a caller-supplied `StoreFunc func(ctx, storeAt, kind string, value []byte) error`. The driver surfaces the store error verbatim; the HTTP status -> message mapping (204 -> ok, 423 -> locked, 503 -> no-vault) stays caller-side. The production wiring supplies a closure over `vaultDoRequest` in #1288.

### Scope
**Substrate only.** This PR does NOT rewire `aileron auth github`. `cmd/aileron/auth_github.go` and `auth_github_test.go` are byte-for-byte unchanged; the dispatch swap to the new driver is #1288. No `internal/proxybinding`, OpenAPI, or `go.mod`/`go.work` changes.

## Test plan

New package `internal/auth/capture` ships contract tests with fake `Runner` and recording `StoreFunc` (no real containers, no HTTP):

- shared-container regression: exactly one `run`; login + token execs target the created container; teardown runs.
- TTY gate: terminal stdin -> login gets standalone `-t` + `-i` (not `-it`); token never gets `-t`; non-terminal -> no `-t`, still `-i`.
- `BROWSER` shim on login only; config-dir env on both execs; both absent when unset.
- teardown on login failure; start-failure surfaces runtime stderr; token-read failure surfaces stderr AND tears down; trailing CR/LF trimmed.
- `Acquire` five named scenarios: happy-path stores trimmed token with configured `StoreAt`/`Kind`; empty-token -> no store + `ErrEmptyToken`; vault-locked and no-vault errors propagate verbatim; non-TTY still completes the store; plus capture-failure -> no store.
- constructor `New`: defaults the runner + resolves runtime; rejects unsupported runtime.

Verification:
- `go build ./...` (internal module) — green
- `go vet ./auth/capture/...` — clean
- `go test ./auth/capture/... -count=1 -cover` — **100.0% of statements**
- `task build` — green
- `coderabbit review --base main` — 0 findings

Closes #1286

🤖 Generated with [Claude Code](https://claude.com/claude-code)
