### PR TITLE
test(launch): cover the Out=stderr default wiring in prepareAuthSpec

### DIFF
--- a/internal/launch/authspec_host_acquire_test.go
+++ b/internal/launch/authspec_host_acquire_test.go
@@ -1,6 +1,7 @@
 package launch
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"errors"
@@ -84,7 +85,12 @@ func TestPrepareAuthSpec_HostAcquireSeedsVaultAndRenders(t *testing.T) {
 		}},
 	}
 
-	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	// Pass a real stderr writer so the launcher's default wiring of the
+	// acquirer's Out (Out: stderr in prepareAuthSpec) is exercised, not
+	// just defaulted to nil. A write-only host flow (Codex device-auth)
+	// surfaces its user_code via this writer.
+	stderr := &bytes.Buffer{}
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil, true)
 	if err != nil {
 		t.Fatalf("prepareAuthSpec: %v", err)
 	}
@@ -101,6 +107,9 @@ func TestPrepareAuthSpec_HostAcquireSeedsVaultAndRenders(t *testing.T) {
 	}
 	if spy.gotDeps.HTTPClient == nil {
 		t.Errorf("acquirer deps HTTPClient is nil; launcher should supply a timed client")
+	}
+	if spy.gotDeps.Out != stderr {
+		t.Errorf("acquirer deps Out = %v, want the launcher's stderr writer (Out: stderr default wiring)", spy.gotDeps.Out)
 	}
 
 	if len(daemon.puts) != 1 {


### PR DESCRIPTION
## Summary

Closes the last open finding from review-residual #1282 (umbrella #1267).

The launcher defaults the host acquirer's `Out` writer to its stderr (`Out: stderr` in `prepareAuthSpec`, `authspec_runtime.go`). That writer is the only surface a write-only host flow (Codex device-authorization `user_code`) has on a headless host where the browser cannot open. The existing `prepareAuthSpec` spy test passed `nil` for the `stderr` parameter, so the `Out: stderr` wiring line had no direct coverage — nulling it would not be caught.

This passes a real `*bytes.Buffer` as `stderr` and asserts the acquirer received it via `deps.Out`, covering the default-wiring line. Test-only; no behavior change.

## Test plan

- `go test ./internal/launch/ -run TestPrepareAuthSpec_HostAcquire` passes.
- The new assertion fails if the `Out: stderr` wiring is removed.

Closes #1282

🤖 Generated with [Claude Code](https://claude.com/claude-code)