### PR TITLE
feat(auth): define gh acquisition as a capture descriptor + registry

### DIFF
--- a/internal/auth/capture/defaults/gh.yaml
+++ b/internal/auth/capture/defaults/gh.yaml
@@ -1,0 +1,45 @@
+# Built-in capture descriptor for GitHub's `gh` CLI.
+#
+# This is the "config, not code" form of the bespoke device-flow capture
+# in cmd/aileron/auth_github.go (containerDeviceFlow.Capture). It declares
+# the same acquisition knowledge as data so a tool's login flow ships as
+# YAML rather than Go: adding a second tool is a new file in this
+# defaults/ directory, never new capture code.
+#
+# This file lives in the embedded defaults/ layer, the trusted built-in
+# tier of the built-in -> user config convention. A user descriptor at
+# ~/.aileron/capture-descriptors.yaml can override this by name (built-in
+# < user precedence), so gh is a normal default layer, not privileged Go.
+#
+# PARITY (load-bearing): the fields below must drive capture.Driver to the
+# byte-identical container exec arg vectors the bespoke flow produces. Two
+# choices keep that parity and MUST NOT change without updating the bespoke
+# flow in lockstep:
+#
+#   - browser_shim: echo — the bespoke login passes --env=BROWSER=echo so a
+#     missing-browser open is a clean no-op (the operator reads the printed
+#     device URL on the host). It is on the login exec only.
+#   - config_dir is OMITTED. The bespoke flow sets NO config-dir env: gh
+#     writes its default ~/.config/gh/hosts.yml, and both the login and the
+#     token read run in the same long-lived container, so the token read
+#     sees what the login wrote. Setting config_dir here would add an
+#     `--env=` token to both execs that the bespoke flow does not emit,
+#     diverging the arg vectors and breaking parity. The config_dir ->
+#     ConfigDirEnv mapping exists in the schema for a future tool that needs
+#     it; gh does not.
+#
+# image is intentionally left empty: image / base-image resolution stays
+# caller-side, and the binder takes a resolved image string. store_at and
+# kind match the bespoke flow's vault path (user/github) and kind stamp
+# (user), so the daemon resolves the same credential the host-binding's
+# credential-ref (user/github) names.
+version: v1
+name: gh
+image: ""
+container_name: aileron-auth-github
+login_cmd: [gh, auth, login, --hostname, github.com, --git-protocol, https, --web]
+token_cmd: [gh, auth, token, --hostname, github.com]
+browser_shim: echo
+config_dir: ""
+store_at: user/github
+kind: user

--- a/internal/auth/capture/descriptor.go
+++ b/internal/auth/capture/descriptor.go
@@ -1,0 +1,181 @@
+// This file defines the declarative capture-descriptor format: the
+// "config, not code" half of credential acquisition. The capture.Driver
+// (capture.go) is the tool-agnostic "code" half — it drives an
+// interactive CLI login inside a container and reads the token back out,
+// with every tool-specific value a field. This file supplies the missing
+// declarative format so a CLI's acquisition knowledge (the login arg
+// vector, the token-read arg vector, the optional config-dir env and
+// BROWSER shim, the vault path, and the kind stamp) ships as YAML data
+// rather than bespoke Go. `gh` is the one built-in descriptor; adding a
+// second tool is a new YAML under defaults/, never new Go.
+//
+// The format is the capture-scoped sibling of internal/proxybinding's
+// host->credential binding descriptor. It deliberately uses distinct
+// identifiers (CaptureDescriptor, ParseCaptureDescriptor,
+// CaptureSchemaVersion) so the two formats never blur together, even
+// though they live in different packages. This package neither imports
+// nor depends on proxybinding.
+package capture
+
+import (
+	"bytes"
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// CaptureSchemaVersion is the only capture-descriptor schema version this
+// loader understands. The format is versioned so it can evolve under
+// 0.0.x without a silent misparse: a descriptor that names any other
+// version is a load-time error rather than a best-effort decode against
+// the wrong field set.
+const CaptureSchemaVersion = "v1"
+
+// CaptureDescriptor is a parsed, versioned capture-descriptor document.
+// One document declares a single tool's credential-acquisition knowledge,
+// keyed by Name. A CLI vendor or community profile ships a
+// CaptureDescriptor; the loader merges the built-in and user layers into a
+// single validated set keyed on Name.
+//
+// Every field is non-secret data. The descriptor carries no credential
+// bytes: it names where the captured token is stored (StoreAt) and the
+// kind stamp, but the actual capture, the resolved image, and the vault
+// transport are supplied by the caller via [CaptureDescriptor.Apply].
+type CaptureDescriptor struct {
+	// Version is the schema version. It must equal [CaptureSchemaVersion];
+	// any other value is rejected at parse time so the format can evolve
+	// under 0.0.x without a silent misparse.
+	Version string `yaml:"version"`
+
+	// Name is the registry key, unique within a single layer. The registry
+	// resolves a descriptor by this name (e.g. "gh"); across layers a later
+	// layer's descriptor with the same Name overrides an earlier one.
+	Name string `yaml:"name"`
+
+	// Image is an optional pre-resolved container image. It is normally
+	// empty: image / base-image resolution policy stays caller-side, and
+	// [CaptureDescriptor.Apply] takes a resolved image string from the
+	// caller. A non-empty value here is a descriptor-supplied default the
+	// caller may override.
+	Image string `yaml:"image"`
+
+	// ContainerName is the deterministic name for the long-lived capture
+	// container (e.g. "aileron-auth-github"). Required.
+	ContainerName string `yaml:"container_name"`
+
+	// LoginCmd is the interactive login command run inside the container,
+	// minus the exec scaffolding — e.g.
+	// {"gh","auth","login","--web"}. The driver prepends the exec/-i/-t/
+	// --env tokens and the container name. Required and non-empty; maps to
+	// Driver.LoginArgs.
+	LoginCmd []string `yaml:"login_cmd"`
+
+	// TokenCmd is the token-read command run inside the same container,
+	// e.g. {"gh","auth","token"}. Required and non-empty; maps to
+	// Driver.TokenArgs.
+	TokenCmd []string `yaml:"token_cmd"`
+
+	// BrowserShim, when non-empty, is passed as `--env=BROWSER=<shim>` on
+	// the login exec only (e.g. "echo"), to turn a missing-browser open
+	// into a clean no-op. Optional; maps to Driver.BrowserShim.
+	BrowserShim string `yaml:"browser_shim"`
+
+	// ConfigDir, when non-empty, is a single `K=V` env token (e.g.
+	// "GH_CONFIG_DIR=/path") passed on BOTH execs so the token read sees
+	// the same config home the login wrote to. Optional; omitted/empty when
+	// unset; maps to Driver.ConfigDirEnv. `gh` leaves this empty (it writes
+	// the default ~/.config/gh/hosts.yml), so setting it would diverge the
+	// exec arg vectors from the bespoke flow.
+	ConfigDir string `yaml:"config_dir"`
+
+	// StoreAt is the vault path the captured credential is stored at (e.g.
+	// "user/github"). Required; maps to Driver.StoreAt.
+	StoreAt string `yaml:"store_at"`
+
+	// Kind is the metadata Type stamped on the stored credential (e.g.
+	// "user"). Required; maps to Driver.Kind.
+	Kind string `yaml:"kind"`
+}
+
+// ParseCaptureDescriptor strictly decodes a single capture-descriptor
+// document and validates it. Decoding is strict: an unknown YAML key is an
+// error rather than a silently ignored field, so a typo in a descriptor
+// fails fast instead of shipping an acquisition flow that does nothing.
+// Malformed YAML, a wrong or missing version, and any field that fails
+// [CaptureDescriptor.Validate] are all errors.
+//
+// ParseCaptureDescriptor never reads secret bytes; a descriptor carries
+// only non-secret acquisition knowledge.
+func ParseCaptureDescriptor(data []byte) (CaptureDescriptor, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var d CaptureDescriptor
+	if err := dec.Decode(&d); err != nil {
+		return CaptureDescriptor{}, fmt.Errorf("capture: parse descriptor: %w", err)
+	}
+
+	if d.Version != CaptureSchemaVersion {
+		return CaptureDescriptor{}, fmt.Errorf("capture: unsupported descriptor version %q (want %q)", d.Version, CaptureSchemaVersion)
+	}
+
+	if err := d.Validate(); err != nil {
+		return CaptureDescriptor{}, fmt.Errorf("capture: descriptor %q: %w", d.Name, err)
+	}
+
+	return d, nil
+}
+
+// Validate checks that a CaptureDescriptor's required fields are present.
+// It enforces the non-empty name/container_name/store_at/kind and the
+// non-empty login_cmd/token_cmd lists. It does not resolve the image or
+// touch any secret.
+func (d *CaptureDescriptor) Validate() error {
+	if d.Name == "" {
+		return fmt.Errorf("missing required field: name")
+	}
+	if d.ContainerName == "" {
+		return fmt.Errorf("missing required field: container_name")
+	}
+	if len(d.LoginCmd) == 0 {
+		return fmt.Errorf("missing required field: login_cmd (non-empty list)")
+	}
+	if len(d.TokenCmd) == 0 {
+		return fmt.Errorf("missing required field: token_cmd (non-empty list)")
+	}
+	if d.StoreAt == "" {
+		return fmt.Errorf("missing required field: store_at")
+	}
+	if d.Kind == "" {
+		return fmt.Errorf("missing required field: kind")
+	}
+	return nil
+}
+
+// Apply maps the descriptor's fields onto a *Driver, binding the
+// caller-resolved image and the StoreFunc the descriptor never owns. It is
+// the adapter from declarative data to the executable driver: every
+// tool-specific field (LoginArgs/TokenArgs/ConfigDirEnv/BrowserShim/
+// StoreAt/Kind/ContainerName/Image) comes from the descriptor, while the
+// transport (Store) and the resolved image come from the caller.
+//
+// image is the caller-resolved container image. When image is empty the
+// descriptor's own Image is used (normally empty for gh). store is the
+// vault PUT seam; it is required. Apply leaves the Driver's Runner and
+// RuntimeExe untouched so a caller may build the Driver via New (which
+// defaults them) and then Apply the descriptor on top.
+func (d *CaptureDescriptor) Apply(drv *Driver, image string, store StoreFunc) {
+	if image != "" {
+		drv.Image = image
+	} else if d.Image != "" {
+		drv.Image = d.Image
+	}
+	drv.ContainerName = d.ContainerName
+	drv.LoginArgs = append([]string(nil), d.LoginCmd...)
+	drv.TokenArgs = append([]string(nil), d.TokenCmd...)
+	drv.ConfigDirEnv = d.ConfigDir
+	drv.BrowserShim = d.BrowserShim
+	drv.StoreAt = d.StoreAt
+	drv.Kind = d.Kind
+	drv.Store = store
+}

--- a/internal/auth/capture/descriptor.go
+++ b/internal/auth/capture/descriptor.go
@@ -140,8 +140,18 @@ func (d *CaptureDescriptor) Validate() error {
 	if len(d.LoginCmd) == 0 {
 		return fmt.Errorf("missing required field: login_cmd (non-empty list)")
 	}
+	for i, arg := range d.LoginCmd {
+		if arg == "" {
+			return fmt.Errorf("login_cmd[%d] is an empty string", i)
+		}
+	}
 	if len(d.TokenCmd) == 0 {
 		return fmt.Errorf("missing required field: token_cmd (non-empty list)")
+	}
+	for i, arg := range d.TokenCmd {
+		if arg == "" {
+			return fmt.Errorf("token_cmd[%d] is an empty string", i)
+		}
 	}
 	if d.StoreAt == "" {
 		return fmt.Errorf("missing required field: store_at")
@@ -165,6 +175,9 @@ func (d *CaptureDescriptor) Validate() error {
 // RuntimeExe untouched so a caller may build the Driver via New (which
 // defaults them) and then Apply the descriptor on top.
 func (d *CaptureDescriptor) Apply(drv *Driver, image string, store StoreFunc) {
+	if store == nil {
+		panic("capture: Apply: store is required")
+	}
 	if image != "" {
 		drv.Image = image
 	} else if d.Image != "" {

--- a/internal/auth/capture/descriptor_test.go
+++ b/internal/auth/capture/descriptor_test.go
@@ -1,0 +1,201 @@
+package capture
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+)
+
+// validDescriptorYAML is a minimal well-formed capture descriptor used as
+// the base for the negative tests below (each mutates one field).
+const validDescriptorYAML = `version: v1
+name: gh
+image: ""
+container_name: aileron-auth-github
+login_cmd: [gh, auth, login, --web]
+token_cmd: [gh, auth, token]
+browser_shim: echo
+config_dir: ""
+store_at: user/github
+kind: user
+`
+
+func TestParseCaptureDescriptor_ValidRoundTrip(t *testing.T) {
+	d, err := ParseCaptureDescriptor([]byte(validDescriptorYAML))
+	if err != nil {
+		t.Fatalf("ParseCaptureDescriptor: %v", err)
+	}
+	if d.Version != CaptureSchemaVersion {
+		t.Errorf("Version = %q, want %q", d.Version, CaptureSchemaVersion)
+	}
+	if d.Name != "gh" {
+		t.Errorf("Name = %q, want gh", d.Name)
+	}
+	if d.ContainerName != "aileron-auth-github" {
+		t.Errorf("ContainerName = %q", d.ContainerName)
+	}
+	if want := []string{"gh", "auth", "login", "--web"}; !reflect.DeepEqual(d.LoginCmd, want) {
+		t.Errorf("LoginCmd = %v, want %v", d.LoginCmd, want)
+	}
+	if want := []string{"gh", "auth", "token"}; !reflect.DeepEqual(d.TokenCmd, want) {
+		t.Errorf("TokenCmd = %v, want %v", d.TokenCmd, want)
+	}
+	if d.BrowserShim != "echo" {
+		t.Errorf("BrowserShim = %q, want echo", d.BrowserShim)
+	}
+	if d.ConfigDir != "" {
+		t.Errorf("ConfigDir = %q, want empty", d.ConfigDir)
+	}
+	if d.StoreAt != "user/github" {
+		t.Errorf("StoreAt = %q", d.StoreAt)
+	}
+	if d.Kind != "user" {
+		t.Errorf("Kind = %q", d.Kind)
+	}
+}
+
+func TestParseCaptureDescriptor_UnknownKeyRejected(t *testing.T) {
+	y := validDescriptorYAML + "bogus_field: nope\n"
+	if _, err := ParseCaptureDescriptor([]byte(y)); err == nil {
+		t.Fatal("expected an error for an unknown YAML key (strict decode)")
+	}
+}
+
+func TestParseCaptureDescriptor_WrongVersionRejected(t *testing.T) {
+	y := strings.Replace(validDescriptorYAML, "version: v1", "version: v2", 1)
+	_, err := ParseCaptureDescriptor([]byte(y))
+	if err == nil {
+		t.Fatal("expected an error for an unsupported version")
+	}
+	if !strings.Contains(err.Error(), "unsupported descriptor version") {
+		t.Errorf("err = %v, want unsupported-version context", err)
+	}
+}
+
+func TestParseCaptureDescriptor_MalformedYAMLRejected(t *testing.T) {
+	if _, err := ParseCaptureDescriptor([]byte("this: : not: yaml")); err == nil {
+		t.Fatal("expected an error for malformed YAML")
+	}
+}
+
+func TestParseCaptureDescriptor_MissingRequiredFields(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(string) string
+		wantSub string
+	}{
+		{"empty name", func(s string) string { return strings.Replace(s, "name: gh", "name: \"\"", 1) }, "name"},
+		{"empty container_name", func(s string) string {
+			return strings.Replace(s, "container_name: aileron-auth-github", "container_name: \"\"", 1)
+		}, "container_name"},
+		{"empty login_cmd", func(s string) string {
+			return strings.Replace(s, "login_cmd: [gh, auth, login, --web]", "login_cmd: []", 1)
+		}, "login_cmd"},
+		{"empty token_cmd", func(s string) string {
+			return strings.Replace(s, "token_cmd: [gh, auth, token]", "token_cmd: []", 1)
+		}, "token_cmd"},
+		{"empty store_at", func(s string) string {
+			return strings.Replace(s, "store_at: user/github", "store_at: \"\"", 1)
+		}, "store_at"},
+		{"empty kind", func(s string) string { return strings.Replace(s, "kind: user", "kind: \"\"", 1) }, "kind"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			y := tc.mutate(validDescriptorYAML)
+			_, err := ParseCaptureDescriptor([]byte(y))
+			if err == nil {
+				t.Fatalf("expected an error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("err = %v, want mention of %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+// TestApply_MapsEveryFieldOntoDriver proves the descriptor->driver adapter
+// binds each field onto a real *Driver and that an omitted config_dir maps
+// to an empty ConfigDirEnv.
+func TestApply_MapsEveryFieldOntoDriver(t *testing.T) {
+	d, err := ParseCaptureDescriptor([]byte(validDescriptorYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	drv := &Driver{}
+	store := (&recordingStore{}).fn()
+	d.Apply(drv, "ghcr.io/example/img:tag", store)
+
+	if drv.Image != "ghcr.io/example/img:tag" {
+		t.Errorf("Image = %q, want the caller-resolved image", drv.Image)
+	}
+	if drv.ContainerName != "aileron-auth-github" {
+		t.Errorf("ContainerName = %q", drv.ContainerName)
+	}
+	if want := []string{"gh", "auth", "login", "--web"}; !reflect.DeepEqual(drv.LoginArgs, want) {
+		t.Errorf("LoginArgs = %v, want %v", drv.LoginArgs, want)
+	}
+	if want := []string{"gh", "auth", "token"}; !reflect.DeepEqual(drv.TokenArgs, want) {
+		t.Errorf("TokenArgs = %v, want %v", drv.TokenArgs, want)
+	}
+	if drv.BrowserShim != "echo" {
+		t.Errorf("BrowserShim = %q, want echo", drv.BrowserShim)
+	}
+	if drv.ConfigDirEnv != "" {
+		t.Errorf("ConfigDirEnv = %q, want empty when config_dir omitted", drv.ConfigDirEnv)
+	}
+	if drv.StoreAt != "user/github" {
+		t.Errorf("StoreAt = %q", drv.StoreAt)
+	}
+	if drv.Kind != "user" {
+		t.Errorf("Kind = %q", drv.Kind)
+	}
+	if drv.Store == nil {
+		t.Error("Store was not bound")
+	}
+}
+
+// TestApply_ConfigDirMapsThrough confirms the schema's general config_dir
+// -> ConfigDirEnv mapping works for a tool that does set it (gh does not).
+func TestApply_ConfigDirMapsThrough(t *testing.T) {
+	y := strings.Replace(validDescriptorYAML, `config_dir: ""`, `config_dir: GH_CONFIG_DIR=/cfg`, 1)
+	d, err := ParseCaptureDescriptor([]byte(y))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	drv := &Driver{}
+	d.Apply(drv, "img", (&recordingStore{}).fn())
+	if drv.ConfigDirEnv != "GH_CONFIG_DIR=/cfg" {
+		t.Errorf("ConfigDirEnv = %q, want the config_dir token", drv.ConfigDirEnv)
+	}
+}
+
+// TestApply_DescriptorImageUsedWhenCallerImageEmpty confirms the
+// descriptor's own Image is the fallback when the caller passes no image.
+func TestApply_DescriptorImageUsedWhenCallerImageEmpty(t *testing.T) {
+	y := strings.Replace(validDescriptorYAML, `image: ""`, `image: ghcr.io/desc/default:tag`, 1)
+	d, err := ParseCaptureDescriptor([]byte(y))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	drv := &Driver{}
+	d.Apply(drv, "", (&recordingStore{}).fn())
+	if drv.Image != "ghcr.io/desc/default:tag" {
+		t.Errorf("Image = %q, want the descriptor default when caller image empty", drv.Image)
+	}
+}
+
+// TestApply_CopiesCmdSlices ensures Apply does not alias the descriptor's
+// backing arrays, so mutating the Driver's args never corrupts a cached
+// descriptor.
+func TestApply_CopiesCmdSlices(t *testing.T) {
+	d, err := ParseCaptureDescriptor([]byte(validDescriptorYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	drv := &Driver{}
+	d.Apply(drv, "img", (&recordingStore{}).fn())
+	drv.LoginArgs[0] = "MUTATED"
+	if d.LoginCmd[0] != "gh" {
+		t.Errorf("descriptor LoginCmd was aliased and mutated: %v", d.LoginCmd)
+	}
+}

--- a/internal/auth/capture/descriptor_test.go
+++ b/internal/auth/capture/descriptor_test.go
@@ -46,6 +46,9 @@ func TestParseCaptureDescriptor_ValidRoundTrip(t *testing.T) {
 	if d.ConfigDir != "" {
 		t.Errorf("ConfigDir = %q, want empty", d.ConfigDir)
 	}
+	if d.Image != "" {
+		t.Errorf("Image = %q, want empty", d.Image)
+	}
 	if d.StoreAt != "user/github" {
 		t.Errorf("StoreAt = %q", d.StoreAt)
 	}

--- a/internal/auth/capture/descriptor_test.go
+++ b/internal/auth/capture/descriptor_test.go
@@ -113,6 +113,46 @@ func TestParseCaptureDescriptor_MissingRequiredFields(t *testing.T) {
 	}
 }
 
+func TestParseCaptureDescriptor_EmptyCmdElementRejected(t *testing.T) {
+	cases := []struct {
+		name    string
+		mutate  func(string) string
+		wantSub string
+	}{
+		{"empty login_cmd element", func(s string) string {
+			return strings.Replace(s, "login_cmd: [gh, auth, login, --web]", `login_cmd: [gh, "", login]`, 1)
+		}, "login_cmd"},
+		{"empty token_cmd element", func(s string) string {
+			return strings.Replace(s, "token_cmd: [gh, auth, token]", `token_cmd: [gh, ""]`, 1)
+		}, "token_cmd"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			y := tc.mutate(validDescriptorYAML)
+			_, err := ParseCaptureDescriptor([]byte(y))
+			if err == nil {
+				t.Fatalf("expected an error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.wantSub) {
+				t.Errorf("err = %v, want mention of %q", err, tc.wantSub)
+			}
+		})
+	}
+}
+
+func TestApply_NilStorePanics(t *testing.T) {
+	d, err := ParseCaptureDescriptor([]byte(validDescriptorYAML))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	defer func() {
+		if recover() == nil {
+			t.Error("Apply with a nil store should panic; the store is documented as required")
+		}
+	}()
+	d.Apply(&Driver{}, "img", nil)
+}
+
 // TestApply_MapsEveryFieldOntoDriver proves the descriptor->driver adapter
 // binds each field onto a real *Driver and that an omitted config_dir maps
 // to an empty ConfigDirEnv.

--- a/internal/auth/capture/embed.go
+++ b/internal/auth/capture/embed.go
@@ -1,0 +1,15 @@
+package capture
+
+import "embed"
+
+// builtinCaptureDefaults holds the capture descriptors Aileron ships as
+// the built-in (trusted) layer of the two-layer config convention
+// (built-in -> user). Each file under defaults/ declares one tool's
+// credential-acquisition knowledge as data. gh.yaml is the one shipped
+// example; adding another tool is a new file here, never new Go.
+//
+//go:embed defaults/*.yaml
+var builtinCaptureDefaults embed.FS
+
+// builtinCaptureDefaultsDir is the directory the embed glob roots at.
+const builtinCaptureDefaultsDir = "defaults"

--- a/internal/auth/capture/gh_parity_test.go
+++ b/internal/auth/capture/gh_parity_test.go
@@ -1,0 +1,146 @@
+package capture
+
+import (
+	"context"
+	"reflect"
+	"testing"
+)
+
+// This test is the acceptance gate for #1287: it proves the
+// descriptor-driven `gh` acquisition produces the byte-identical container
+// exec arg vectors and the same store call (user/github, kind user) as the
+// bespoke containerDeviceFlow in cmd/aileron/auth_github.go. It binds the
+// shipped gh.yaml onto the REAL capture.Driver via the registry and runs
+// the real Driver.Acquire path through the existing recordingRunner seam —
+// no stub driver, no invented interface.
+//
+// The bespoke flow (auth_github.go) emits exactly:
+//
+//	login: exec -i [-t] --env=BROWSER=echo aileron-auth-github \
+//	         gh auth login --hostname github.com --git-protocol https --web
+//	token: exec aileron-auth-github gh auth token --hostname github.com
+//
+// with NO config-dir --env token on either exec. Parity hinges on gh.yaml
+// omitting config_dir; if it were set, both vectors would gain an --env=
+// token the bespoke flow never emits.
+
+// bindGhFromRegistry resolves gh from the built-in registry, builds a bare
+// Driver (no runtime resolution needed — the recordingRunner is injected),
+// applies the descriptor, and wires the recording runner + store. It
+// exercises Apply against the real Driver type end-to-end.
+func bindGhFromRegistry(t *testing.T, rr *recordingRunner, store StoreFunc) *Driver {
+	t.Helper()
+	r, err := NewRegistry(CaptureLoadOptions{})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	d, ok := r.Resolve("gh")
+	if !ok {
+		t.Fatal("registry has no gh descriptor")
+	}
+	drv := &Driver{
+		Runner:     runnerFunc(rr.Run),
+		RuntimeExe: "docker",
+	}
+	// Caller resolves the image; gh.yaml leaves image empty.
+	d.Apply(drv, "ghcr.io/example/gh:latest", store)
+	return drv
+}
+
+func TestGhParity_ExecArgVectorsAndStore_NonTTY(t *testing.T) {
+	orig := stdinIsTerminal
+	stdinIsTerminal = func() bool { return false }
+	t.Cleanup(func() { stdinIsTerminal = orig })
+
+	rr := &recordingRunner{token: "gho_paritytoken"}
+	store := &recordingStore{}
+	drv := bindGhFromRegistry(t, rr, store.fn())
+
+	if err := drv.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	login, token := execArgsBySub(rr.calls)
+
+	wantLogin := []string{
+		"exec", "-i", "--env=BROWSER=echo", "aileron-auth-github",
+		"gh", "auth", "login",
+		"--hostname", "github.com",
+		"--git-protocol", "https",
+		"--web",
+	}
+	if !reflect.DeepEqual(login, wantLogin) {
+		t.Errorf("login exec vector mismatch\n got: %v\nwant: %v", login, wantLogin)
+	}
+
+	wantToken := []string{
+		"exec", "aileron-auth-github",
+		"gh", "auth", "token", "--hostname", "github.com",
+	}
+	if !reflect.DeepEqual(token, wantToken) {
+		t.Errorf("token exec vector mismatch\n got: %v\nwant: %v", token, wantToken)
+	}
+
+	if store.called != 1 {
+		t.Fatalf("Store called %d times, want exactly 1", store.called)
+	}
+	if store.storeAt != "user/github" {
+		t.Errorf("storeAt = %q, want user/github", store.storeAt)
+	}
+	if store.kind != "user" {
+		t.Errorf("kind = %q, want user", store.kind)
+	}
+	if string(store.value) != "gho_paritytoken" {
+		t.Errorf("stored token = %q, want the trimmed captured value", store.value)
+	}
+}
+
+func TestGhParity_LoginGetsPTYWhenTTY(t *testing.T) {
+	orig := stdinIsTerminal
+	stdinIsTerminal = func() bool { return true }
+	t.Cleanup(func() { stdinIsTerminal = orig })
+
+	rr := &recordingRunner{token: "gho_tok"}
+	drv := bindGhFromRegistry(t, rr, (&recordingStore{}).fn())
+	if err := drv.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+
+	login, token := execArgsBySub(rr.calls)
+	wantLogin := []string{
+		"exec", "-i", "-t", "--env=BROWSER=echo", "aileron-auth-github",
+		"gh", "auth", "login",
+		"--hostname", "github.com",
+		"--git-protocol", "https",
+		"--web",
+	}
+	if !reflect.DeepEqual(login, wantLogin) {
+		t.Errorf("login exec vector mismatch (TTY)\n got: %v\nwant: %v", login, wantLogin)
+	}
+	// The token read never gets -t and never carries the BROWSER shim.
+	for _, a := range token {
+		if a == "-t" || a == "--env=BROWSER=echo" {
+			t.Errorf("token exec must not carry %q: %v", a, token)
+		}
+	}
+}
+
+// TestGhParity_NoConfigDirEnvOnEitherExec is the explicit guard for the
+// parity-critical omission: gh.yaml must not set config_dir, so neither
+// exec carries an --env=*CONFIG_DIR token. This is the assertion that
+// catches a future edit that mistakenly adds config_dir.
+func TestGhParity_NoConfigDirEnvOnEitherExec(t *testing.T) {
+	rr := &recordingRunner{token: "gho_tok"}
+	drv := bindGhFromRegistry(t, rr, (&recordingStore{}).fn())
+	if err := drv.Acquire(context.Background()); err != nil {
+		t.Fatalf("Acquire: %v", err)
+	}
+	login, token := execArgsBySub(rr.calls)
+	for _, vec := range [][]string{login, token} {
+		for _, a := range vec {
+			if len(a) >= 6 && a[:6] == "--env=" && a != "--env=BROWSER=echo" {
+				t.Errorf("unexpected env token %q in exec vector %v (gh must omit config_dir)", a, vec)
+			}
+		}
+	}
+}

--- a/internal/auth/capture/loader.go
+++ b/internal/auth/capture/loader.go
@@ -1,0 +1,132 @@
+package capture
+
+import (
+	"errors"
+	"fmt"
+	"io/fs"
+	"os"
+	"sort"
+)
+
+// CaptureLoadOptions selects the user descriptor layer that overrides the
+// built-in defaults. UserPath is optional: an empty path or an absent file
+// contributes no descriptors, so an operator who ships nothing gets
+// exactly the built-in tools.
+type CaptureLoadOptions struct {
+	// UserPath is the per-user descriptor file (e.g. under ~/.aileron),
+	// the highest-precedence layer. It overrides built-in descriptors with
+	// the same name. Empty or absent contributes nothing.
+	UserPath string
+}
+
+// LoadCaptureDescriptors merges the two configuration layers (built-in
+// defaults, then user) into a single validated set of descriptors keyed on
+// name. This mirrors the layered config convention used elsewhere: the
+// later layer overrides the earlier one per name, so a user descriptor can
+// replace a shipped tool descriptor for the same name without editing it.
+//
+// Precedence is strictly built-in < user. The returned map is keyed on
+// descriptor name. The returned slice is the same set ordered
+// deterministically by name so callers that need a stable order (help
+// output, tests) get a reproducible result.
+//
+// Every layer is parsed strictly (unknown keys, wrong version, malformed
+// YAML, and invalid descriptors are errors). An invalid layer fails the
+// whole load with a clear error and never silently drops descriptors: a
+// typo must not degrade to a partial, surprising set. A missing user file
+// is not an error (an absent layer is an empty layer); only a
+// present-but-unreadable or present-but-invalid file fails. A malformed
+// shipped default fails the load: it is embedded at build time, so a bad
+// default is a programming error, not a runtime condition.
+func LoadCaptureDescriptors(opts CaptureLoadOptions) (map[string]CaptureDescriptor, []CaptureDescriptor, error) {
+	merged := make(map[string]CaptureDescriptor)
+
+	builtin, err := parseBuiltinCaptureDefaults()
+	if err != nil {
+		return nil, nil, fmt.Errorf("capture: load built-in defaults: %w", err)
+	}
+	applyCaptureLayer(merged, builtin)
+
+	if opts.UserPath != "" {
+		user, err := parseCaptureLayerFile(opts.UserPath)
+		if err != nil {
+			return nil, nil, fmt.Errorf("capture: load user layer %q: %w", opts.UserPath, err)
+		}
+		applyCaptureLayer(merged, user)
+	}
+
+	ordered := make([]CaptureDescriptor, 0, len(merged))
+	for _, d := range merged {
+		ordered = append(ordered, d)
+	}
+	sort.Slice(ordered, func(i, j int) bool { return ordered[i].Name < ordered[j].Name })
+	return merged, ordered, nil
+}
+
+// applyCaptureLayer overlays a layer's descriptors onto the merged map,
+// last-write-wins per name.
+func applyCaptureLayer(merged map[string]CaptureDescriptor, layer []CaptureDescriptor) {
+	for _, d := range layer {
+		merged[d.Name] = d
+	}
+}
+
+// parseBuiltinCaptureDefaults parses every embedded descriptor under
+// defaults/. A malformed shipped descriptor fails the load rather than
+// being skipped. A duplicate name across two shipped files is also an
+// error: each built-in tool must have a unique name within the trusted
+// layer.
+func parseBuiltinCaptureDefaults() ([]CaptureDescriptor, error) {
+	dirEntries, err := fs.ReadDir(builtinCaptureDefaults, builtinCaptureDefaultsDir)
+	if err != nil {
+		return nil, err
+	}
+	// Sort filenames for a deterministic built-in order before later
+	// layers override per name.
+	names := make([]string, 0, len(dirEntries))
+	for _, de := range dirEntries {
+		if de.IsDir() {
+			continue
+		}
+		names = append(names, de.Name())
+	}
+	sort.Strings(names)
+
+	var out []CaptureDescriptor
+	seen := make(map[string]struct{}, len(names))
+	for _, name := range names {
+		data, err := fs.ReadFile(builtinCaptureDefaults, builtinCaptureDefaultsDir+"/"+name)
+		if err != nil {
+			return nil, fmt.Errorf("read embedded %s: %w", name, err)
+		}
+		d, err := ParseCaptureDescriptor(data)
+		if err != nil {
+			return nil, fmt.Errorf("parse embedded %s: %w", name, err)
+		}
+		if _, dup := seen[d.Name]; dup {
+			return nil, fmt.Errorf("duplicate descriptor name %q across embedded defaults", d.Name)
+		}
+		seen[d.Name] = struct{}{}
+		out = append(out, d)
+	}
+	return out, nil
+}
+
+// parseCaptureLayerFile reads and parses one on-disk descriptor layer. A
+// missing file is not an error: it returns nil so an absent layer
+// contributes nothing. A present-but-unreadable or present-but-invalid
+// file is an error.
+func parseCaptureLayerFile(path string) ([]CaptureDescriptor, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, fs.ErrNotExist) {
+			return nil, nil
+		}
+		return nil, err
+	}
+	d, err := ParseCaptureDescriptor(data)
+	if err != nil {
+		return nil, err
+	}
+	return []CaptureDescriptor{d}, nil
+}

--- a/internal/auth/capture/loader_test.go
+++ b/internal/auth/capture/loader_test.go
@@ -1,0 +1,113 @@
+package capture
+
+import (
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestLoadCaptureDescriptors_BuiltinOnlyYieldsGh(t *testing.T) {
+	byName, ordered, err := LoadCaptureDescriptors(CaptureLoadOptions{})
+	if err != nil {
+		t.Fatalf("LoadCaptureDescriptors: %v", err)
+	}
+	gh, ok := byName["gh"]
+	if !ok {
+		t.Fatalf("built-in load missing gh; have %v", names(ordered))
+	}
+	if gh.ContainerName != "aileron-auth-github" {
+		t.Errorf("gh ContainerName = %q", gh.ContainerName)
+	}
+	if gh.StoreAt != "user/github" || gh.Kind != "user" {
+		t.Errorf("gh store_at/kind = %q/%q, want user/github + user", gh.StoreAt, gh.Kind)
+	}
+	if gh.BrowserShim != "echo" {
+		t.Errorf("gh BrowserShim = %q, want echo", gh.BrowserShim)
+	}
+	if gh.ConfigDir != "" {
+		t.Errorf("gh ConfigDir = %q, want empty (parity with bespoke flow)", gh.ConfigDir)
+	}
+}
+
+func TestLoadCaptureDescriptors_UserLayerOverridesByName(t *testing.T) {
+	dir := t.TempDir()
+	userPath := filepath.Join(dir, "capture-descriptors.yaml")
+	override := `version: v1
+name: gh
+container_name: my-override-container
+login_cmd: [gh, auth, login]
+token_cmd: [gh, auth, token]
+store_at: user/github
+kind: user
+`
+	if err := os.WriteFile(userPath, []byte(override), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	byName, _, err := LoadCaptureDescriptors(CaptureLoadOptions{UserPath: userPath})
+	if err != nil {
+		t.Fatalf("LoadCaptureDescriptors: %v", err)
+	}
+	gh := byName["gh"]
+	if gh.ContainerName != "my-override-container" {
+		t.Errorf("ContainerName = %q, want the user override", gh.ContainerName)
+	}
+}
+
+func TestLoadCaptureDescriptors_MissingUserFileContributesNothing(t *testing.T) {
+	byName, _, err := LoadCaptureDescriptors(CaptureLoadOptions{
+		UserPath: filepath.Join(t.TempDir(), "does-not-exist.yaml"),
+	})
+	if err != nil {
+		t.Fatalf("missing user file should not error: %v", err)
+	}
+	if _, ok := byName["gh"]; !ok {
+		t.Error("built-in gh should still load when the user file is absent")
+	}
+	if len(byName) != 1 {
+		t.Errorf("descriptor count = %d, want 1 (built-in only)", len(byName))
+	}
+}
+
+func TestLoadCaptureDescriptors_PresentButInvalidUserFileErrors(t *testing.T) {
+	dir := t.TempDir()
+	userPath := filepath.Join(dir, "capture-descriptors.yaml")
+	// Invalid: missing required store_at.
+	bad := `version: v1
+name: gh
+container_name: c
+login_cmd: [gh, auth, login]
+token_cmd: [gh, auth, token]
+kind: user
+`
+	if err := os.WriteFile(userPath, []byte(bad), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	_, _, err := LoadCaptureDescriptors(CaptureLoadOptions{UserPath: userPath})
+	if err == nil {
+		t.Fatal("expected an error for a present-but-invalid user file")
+	}
+	if !strings.Contains(err.Error(), "store_at") {
+		t.Errorf("err = %v, want store_at validation context", err)
+	}
+}
+
+func TestLoadCaptureDescriptors_OrderedDeterministically(t *testing.T) {
+	_, ordered, err := LoadCaptureDescriptors(CaptureLoadOptions{})
+	if err != nil {
+		t.Fatalf("load: %v", err)
+	}
+	for i := 1; i < len(ordered); i++ {
+		if ordered[i-1].Name > ordered[i].Name {
+			t.Errorf("ordered slice not sorted by name: %v", names(ordered))
+		}
+	}
+}
+
+func names(ds []CaptureDescriptor) []string {
+	out := make([]string, len(ds))
+	for i, d := range ds {
+		out[i] = d.Name
+	}
+	return out
+}

--- a/internal/auth/capture/paths.go
+++ b/internal/auth/capture/paths.go
@@ -1,0 +1,29 @@
+package capture
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// DefaultUserCapturePath returns the per-user capture-descriptor file
+// path, `~/.aileron/capture-descriptors.yaml`, the highest-precedence
+// layer of the two-layer config convention. When the home directory
+// cannot be resolved it falls back to a relative path under `.aileron`,
+// matching the rest of the config handling. The file need not exist; an
+// absent user layer contributes no descriptors.
+func DefaultUserCapturePath() string {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return filepath.Join(".aileron", "capture-descriptors.yaml")
+	}
+	return filepath.Join(home, ".aileron", "capture-descriptors.yaml")
+}
+
+// DefaultCaptureLoadOptions returns the standard user descriptor layer
+// path. The built-in defaults layer is always embedded; the user path
+// selects the optional override layer.
+func DefaultCaptureLoadOptions() CaptureLoadOptions {
+	return CaptureLoadOptions{
+		UserPath: DefaultUserCapturePath(),
+	}
+}

--- a/internal/auth/capture/paths_test.go
+++ b/internal/auth/capture/paths_test.go
@@ -1,0 +1,37 @@
+package capture
+
+import (
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+func TestDefaultUserCapturePath_HonorsHome(t *testing.T) {
+	t.Setenv("HOME", "/home/tester")
+	got := DefaultUserCapturePath()
+	want := filepath.Join("/home/tester", ".aileron", "capture-descriptors.yaml")
+	if got != want {
+		t.Errorf("DefaultUserCapturePath = %q, want %q", got, want)
+	}
+}
+
+func TestDefaultUserCapturePath_FallsBackRelative(t *testing.T) {
+	// An empty HOME makes os.UserHomeDir fail on unix, exercising the
+	// relative fallback branch.
+	t.Setenv("HOME", "")
+	got := DefaultUserCapturePath()
+	if !strings.HasSuffix(got, filepath.Join(".aileron", "capture-descriptors.yaml")) {
+		t.Errorf("DefaultUserCapturePath = %q, want a .aileron-relative fallback", got)
+	}
+	if filepath.IsAbs(got) {
+		t.Errorf("DefaultUserCapturePath = %q, want a relative fallback when HOME is unset", got)
+	}
+}
+
+func TestDefaultCaptureLoadOptions_UsesDefaultUserPath(t *testing.T) {
+	t.Setenv("HOME", "/home/tester")
+	opts := DefaultCaptureLoadOptions()
+	if opts.UserPath != DefaultUserCapturePath() {
+		t.Errorf("UserPath = %q, want DefaultUserCapturePath", opts.UserPath)
+	}
+}

--- a/internal/auth/capture/registry.go
+++ b/internal/auth/capture/registry.go
@@ -1,0 +1,70 @@
+package capture
+
+import (
+	"fmt"
+	"sort"
+)
+
+// Registry resolves a capture descriptor by name. It is a thin,
+// name-keyed wrapper over the loaded, layer-merged descriptor set. The
+// registry settles acquisition by tool name (e.g. "gh"); there is no
+// per-tool flag — the name is the only selector.
+type Registry struct {
+	byName map[string]CaptureDescriptor
+}
+
+// NewRegistry builds a Registry from the merged built-in + user descriptor
+// layers selected by opts. A load error (malformed shipped default,
+// present-but-invalid user file) is surfaced rather than degrading to a
+// partial registry.
+func NewRegistry(opts CaptureLoadOptions) (*Registry, error) {
+	byName, _, err := LoadCaptureDescriptors(opts)
+	if err != nil {
+		return nil, err
+	}
+	return &Registry{byName: byName}, nil
+}
+
+// DefaultRegistry builds a Registry from the embedded built-in defaults
+// plus the standard user descriptor layer path
+// ([DefaultUserCapturePath]). It is the production constructor.
+func DefaultRegistry() (*Registry, error) {
+	return NewRegistry(DefaultCaptureLoadOptions())
+}
+
+// Resolve returns the descriptor registered under name. ok is false for an
+// unknown name; the caller surfaces a clear "no such tool" error rather
+// than this package guessing.
+func (r *Registry) Resolve(name string) (CaptureDescriptor, bool) {
+	d, ok := r.byName[name]
+	return d, ok
+}
+
+// Names returns the registered descriptor names in sorted order, for help
+// or usage output.
+func (r *Registry) Names() []string {
+	names := make([]string, 0, len(r.byName))
+	for n := range r.byName {
+		names = append(names, n)
+	}
+	sort.Strings(names)
+	return names
+}
+
+// Bind resolves name, builds a Driver via New (resolving the runtime and
+// defaulting the Runner), applies the descriptor onto it with the
+// caller-resolved image and store seam, and returns the ready Driver. It
+// is the convenience path from a tool name to an executable Driver. An
+// unknown name is an error naming the registered tools.
+func (r *Registry) Bind(name, runtime, image string, store StoreFunc) (*Driver, error) {
+	d, ok := r.Resolve(name)
+	if !ok {
+		return nil, fmt.Errorf("capture: no descriptor registered for %q (have %v)", name, r.Names())
+	}
+	drv, err := New(runtime, image)
+	if err != nil {
+		return nil, err
+	}
+	d.Apply(drv, image, store)
+	return drv, nil
+}

--- a/internal/auth/capture/registry_test.go
+++ b/internal/auth/capture/registry_test.go
@@ -1,0 +1,98 @@
+package capture
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRegistry_ResolveGh(t *testing.T) {
+	r, err := NewRegistry(CaptureLoadOptions{})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	d, ok := r.Resolve("gh")
+	if !ok {
+		t.Fatal("Resolve(gh) not ok; want the built-in gh descriptor")
+	}
+	if d.Name != "gh" {
+		t.Errorf("Name = %q, want gh", d.Name)
+	}
+	if d.ContainerName != "aileron-auth-github" {
+		t.Errorf("ContainerName = %q", d.ContainerName)
+	}
+	if d.StoreAt != "user/github" || d.Kind != "user" {
+		t.Errorf("store_at/kind = %q/%q", d.StoreAt, d.Kind)
+	}
+}
+
+func TestRegistry_ResolveUnknown(t *testing.T) {
+	r, err := NewRegistry(CaptureLoadOptions{})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if _, ok := r.Resolve("nope"); ok {
+		t.Error("Resolve(nope) ok; want not-found for an unknown name")
+	}
+}
+
+func TestRegistry_Names(t *testing.T) {
+	r, err := NewRegistry(CaptureLoadOptions{})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	got := r.Names()
+	if len(got) != 1 || got[0] != "gh" {
+		t.Errorf("Names = %v, want [gh]", got)
+	}
+}
+
+func TestRegistry_UserOverrideResolves(t *testing.T) {
+	dir := t.TempDir()
+	userPath := filepath.Join(dir, "capture-descriptors.yaml")
+	override := `version: v1
+name: gh
+container_name: overridden
+login_cmd: [gh, auth, login]
+token_cmd: [gh, auth, token]
+store_at: user/github
+kind: user
+`
+	if err := os.WriteFile(userPath, []byte(override), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	r, err := NewRegistry(CaptureLoadOptions{UserPath: userPath})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	d, ok := r.Resolve("gh")
+	if !ok {
+		t.Fatal("Resolve(gh) not ok after override")
+	}
+	if d.ContainerName != "overridden" {
+		t.Errorf("ContainerName = %q, want the user override", d.ContainerName)
+	}
+}
+
+func TestRegistry_BindUnknownNameErrors(t *testing.T) {
+	r, err := NewRegistry(CaptureLoadOptions{})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	if _, err := r.Bind("nope", "auto", "img", (&recordingStore{}).fn()); err == nil {
+		t.Fatal("expected an error binding an unknown tool name")
+	}
+}
+
+func TestDefaultRegistry_LoadsGh(t *testing.T) {
+	// DefaultRegistry reads ~/.aileron/capture-descriptors.yaml (absent in
+	// the test env), so it must still load the built-in gh.
+	t.Setenv("HOME", t.TempDir())
+	r, err := DefaultRegistry()
+	if err != nil {
+		t.Fatalf("DefaultRegistry: %v", err)
+	}
+	if _, ok := r.Resolve("gh"); !ok {
+		t.Error("DefaultRegistry missing gh")
+	}
+}

--- a/internal/auth/capture/registry_test.go
+++ b/internal/auth/capture/registry_test.go
@@ -84,6 +84,38 @@ func TestRegistry_BindUnknownNameErrors(t *testing.T) {
 	}
 }
 
+func TestRegistry_BindGhProducesConfiguredDriver(t *testing.T) {
+	r, err := NewRegistry(CaptureLoadOptions{})
+	if err != nil {
+		t.Fatalf("NewRegistry: %v", err)
+	}
+	store := (&recordingStore{}).fn()
+	drv, err := r.Bind("gh", "auto", "ghcr.io/example/gh:latest", store)
+	if err != nil {
+		// New resolves a real runtime; skip where none is available rather
+		// than asserting on the environment.
+		t.Skipf("no container runtime resolvable in this environment: %v", err)
+	}
+	if drv.Runner == nil {
+		t.Error("Bind left Runner unset; New should have defaulted it")
+	}
+	if drv.RuntimeExe == "" {
+		t.Error("Bind left RuntimeExe unresolved")
+	}
+	if drv.Image != "ghcr.io/example/gh:latest" {
+		t.Errorf("Image = %q, want the caller-resolved image", drv.Image)
+	}
+	if drv.ContainerName != "aileron-auth-github" {
+		t.Errorf("ContainerName = %q", drv.ContainerName)
+	}
+	if drv.StoreAt != "user/github" || drv.Kind != "user" {
+		t.Errorf("store_at/kind = %q/%q", drv.StoreAt, drv.Kind)
+	}
+	if drv.Store == nil {
+		t.Error("Bind left Store unset")
+	}
+}
+
 func TestDefaultRegistry_LoadsGh(t *testing.T) {
 	// DefaultRegistry reads ~/.aileron/capture-descriptors.yaml (absent in
 	// the test env), so it must still load the built-in gh.


### PR DESCRIPTION
## Summary

Makes provider knowledge for credential acquisition **shipped data, not Go**. Introduces a versioned `CaptureDescriptor` YAML schema, a capture-scoped two-layer loader (embedded built-in defaults < optional user file), and a name-keyed `Registry`, all co-located with the already-merged `capture.Driver` (#1295) in `internal/auth/capture`. Ships `gh` as the one built-in descriptor.

The descriptor's fields drive the real `capture.Driver` end-to-end via `Apply`: `login_cmd → LoginArgs`, `token_cmd → TokenArgs`, `config_dir → ConfigDirEnv`, `browser_shim → BrowserShim`, `store_at → StoreAt`, `kind → Kind`, `container_name → ContainerName`. The caller supplies the resolved image and the vault `StoreFunc`, so the descriptor never owns transport.

`gh.yaml` is parity-identical to the bespoke `cmd/aileron/auth_github.go` device flow: `browser_shim: echo` and `config_dir` **omitted** (the bespoke flow sets no config-dir env). Setting it would add an `--env=` token to both exec vectors and diverge from the bespoke flow — called out in the file's header comment.

Mirrors the `internal/proxybinding` pattern with **distinct identifiers** (`CaptureDescriptor` / `ParseCaptureDescriptor` / `CaptureSchemaVersion`) for grep-ability; `proxybinding` is neither imported nor modified.

### Scope

This issue defines the descriptor + registry + shipped `gh` data and proves parity. It does **not** wire the registry into `cmd/aileron/auth_github.go` or remove the bespoke flow — that CLI cutover is a separate umbrella sub-issue. The parity test is the bridge that de-risks it.

### Files

- `internal/auth/capture/descriptor.go` — `CaptureDescriptor` schema, strict `ParseCaptureDescriptor`, `Validate`, `Apply` adapter onto `*Driver`
- `internal/auth/capture/embed.go`, `loader.go`, `paths.go` — `//go:embed defaults/*.yaml`, two-layer name-keyed `LoadCaptureDescriptors`, `DefaultUserCapturePath`
- `internal/auth/capture/registry.go` — `Registry.Resolve` / `Names` / `Bind`, `NewRegistry`, `DefaultRegistry`
- `internal/auth/capture/defaults/gh.yaml` — the one built-in descriptor

## Test plan

- `go test -cover ./auth/capture/...` (internal module) — **green, 93.8%**. Uncovered lines are fail-closed error returns over always-valid embedded data (would require fault injection to hit honestly).
- **Parity test** (`gh_parity_test.go`, the acceptance gate): resolves `gh` from the registry, `Apply`s onto a real `capture.Driver`, runs the real `Acquire` through the existing `recordingRunner` seam, and asserts:
  - login exec vector `[exec -i (-t) --env=BROWSER=echo aileron-auth-github gh auth login --hostname github.com --git-protocol https --web]` — byte-identical to the bespoke flow, no config-dir env token
  - token exec vector `[exec aileron-auth-github gh auth token --hostname github.com]`
  - `StoreFunc` called once with `storeAt=user/github`, `kind=user`, trimmed token
- Negative tests: unknown YAML key, wrong version, malformed YAML, each missing required field, empty `login_cmd`/`token_cmd` element; user-layer override-by-name, missing user file (no-op), present-but-invalid user file (error).
- `go build ./...` green in both the `internal` and `cmd/aileron` modules.
- `coderabbit` review clean (applied: nil-store guard in `Apply`, empty-cmd-element validation, round-trip `Image` assertion).

Closes #1287

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added built-in GitHub CLI authentication support with configurable descriptors.
  * Users can customize authentication methods via `~/.aileron/capture-descriptors.yaml`.
  * Implemented a registry system to manage and resolve authentication tools with flexible runtime configuration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->