### PR TITLE
fix(vault): make vault delete accept the name vault list prints

### DIFF
--- a/cmd/aileron/vault.go
+++ b/cmd/aileron/vault.go
@@ -61,8 +61,11 @@ const envVaultPassphrase = "AILERON_VAULT_PASSPHRASE"
 const vaultUsage = `usage:
   aileron vault init [--passphrase-file <path>]
   aileron vault put agents/<name>/oauth --from-file <path>
-  aileron vault delete agents/<name>/oauth [--yes]
-  aileron vault list [--scope agent|user|all] [--prefix agents/] [--json]`
+  aileron vault delete <name> [--yes]
+  aileron vault list [--scope agent|user|all] [--prefix agents/] [--json]
+
+The <name> delete accepts is exactly what vault list prints (e.g. claude);
+the full agents/<name>/oauth path form is also accepted.`
 
 // runVault dispatches `aileron vault <subcommand>`.
 //
@@ -91,26 +94,43 @@ func runVault(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	}
 }
 
-// agentOAuthPathName validates that arg matches the agents-only
-// namespace `agents/<name>/oauth` and returns <name>. The vault
-// put/delete verbs are namespace-locked: they refuse any other path
-// client-side before issuing an HTTP call, so the operator CLI can
-// never reach a non-agent vault key (ADR-0025).
+// agentOAuthPathName validates that arg names an agents-only credential
+// entry and returns the agent <name>. The vault put/delete verbs are
+// namespace-locked: they refuse anything outside the agents namespace
+// client-side before issuing an HTTP call, so the operator CLI can never
+// reach a non-agent vault key (ADR-0025).
+//
+// Two equivalent forms are accepted so the identifier round-trips with
+// `vault list`, which prints the bare agent name (#1302):
+//   - the bare agent name `list` emits, e.g. `claude`
+//   - the full path form, e.g. `agents/claude/oauth`
+//
+// Both resolve to the same <name>; whatever `list` shows can be pasted
+// straight into delete.
 func agentOAuthPathName(arg string) (string, error) {
 	const prefix = "agents/"
 	const suffix = "/oauth"
-	// Guard the length before slicing: "agents/oauth" passes both
-	// HasPrefix and HasSuffix (the prefix and suffix overlap) but would
-	// slice out of range.
-	if len(arg) < len(prefix)+len(suffix) ||
-		!strings.HasPrefix(arg, prefix) || !strings.HasSuffix(arg, suffix) {
-		return "", fmt.Errorf("path must be agents/<name>/oauth (got %q)", arg)
+	// Full path form: agents/<name>/oauth. Guard the length before
+	// slicing — "agents/oauth" passes both HasPrefix and HasSuffix (the
+	// prefix and suffix overlap) but would slice out of range.
+	if strings.HasPrefix(arg, prefix) || strings.HasSuffix(arg, suffix) {
+		if len(arg) < len(prefix)+len(suffix) ||
+			!strings.HasPrefix(arg, prefix) || !strings.HasSuffix(arg, suffix) {
+			return "", fmt.Errorf("name must be an agent name or agents/<name>/oauth (got %q)", arg)
+		}
+		name := arg[len(prefix) : len(arg)-len(suffix)]
+		if name == "" || strings.Contains(name, "/") {
+			return "", fmt.Errorf("name must be an agent name or agents/<name>/oauth (got %q)", arg)
+		}
+		return name, nil
 	}
-	name := arg[len(prefix) : len(arg)-len(suffix)]
-	if name == "" || strings.Contains(name, "/") {
-		return "", fmt.Errorf("path must be agents/<name>/oauth (got %q)", arg)
+	// Bare-name form: the identifier `vault list` prints. Reject any
+	// path-shaped or empty value so a stray prefix/suffix can't slip a
+	// non-agent key through.
+	if arg == "" || strings.Contains(arg, "/") {
+		return "", fmt.Errorf("name must be an agent name or agents/<name>/oauth (got %q)", arg)
 	}
-	return name, nil
+	return arg, nil
 }
 
 // agentCredentialsBody is the local minimal subset of the
@@ -218,7 +238,7 @@ func runVaultPut(args []string, stdout, stderr io.Writer) int {
 func runVaultDelete(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	pathArg, flagArgs, ok := splitPathArg(args)
 	if !ok {
-		fmt.Fprintln(stderr, "usage: aileron vault delete agents/<name>/oauth [--yes]")
+		fmt.Fprintln(stderr, "usage: aileron vault delete <name> [--yes] (name as shown by vault list, or agents/<name>/oauth)")
 		return 1
 	}
 	flags := flag.NewFlagSet("vault delete", flag.ContinueOnError)

--- a/cmd/aileron/vault_verbs_test.go
+++ b/cmd/aileron/vault_verbs_test.go
@@ -124,6 +124,79 @@ func TestRunVaultDelete_YesSkipsPromptAndDeletes(t *testing.T) {
 	}
 }
 
+// #1302: the identifier `vault list` prints (the bare agent name) must
+// be deletable as-is — copy a list line, paste it into delete, done. The
+// full agents/<name>/oauth path form keeps working too.
+func TestRunVaultDelete_AcceptsBareNameFromList(t *testing.T) {
+	const listed = "codex" // exactly what `vault list` prints for this entry
+	gotDelete := false
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.Method == http.MethodDelete && r.URL.Path == "/vault/agents/"+listed+"/credentials" {
+			gotDelete = true
+			w.WriteHeader(http.StatusNoContent)
+			return
+		}
+		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runVault([]string{"delete", listed, "--yes"},
+		strings.NewReader(""), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !gotDelete {
+		t.Errorf("DELETE not issued for bare name %q", listed)
+	}
+	if !strings.Contains(stdout.String(), "Deleted agents/"+listed+"/oauth") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+}
+
+// The list-output == delete-input contract (#1302): every name `vault
+// list` emits must resolve, via the delete validator, back to the same
+// agent the daemon keys the DELETE on. This pins the round-trip directly
+// against the identifier list prints, so the two verbs can't drift apart.
+func TestVaultListNamesRoundTripIntoDelete(t *testing.T) {
+	for _, listed := range []string{"claude", "codex", "my-agent"} {
+		name, err := agentOAuthPathName(listed)
+		if err != nil {
+			t.Errorf("agentOAuthPathName(%q) errored: %v; a name from `vault list` must be deletable", listed, err)
+			continue
+		}
+		if name != listed {
+			t.Errorf("agentOAuthPathName(%q) = %q, want %q (the listed name)", listed, name, listed)
+		}
+		// The full-path form list could equivalently emit must resolve identically.
+		full := "agents/" + listed + "/oauth"
+		if got, err := agentOAuthPathName(full); err != nil || got != listed {
+			t.Errorf("agentOAuthPathName(%q) = (%q, %v), want (%q, nil)", full, got, err, listed)
+		}
+	}
+}
+
+// Guard the namespace lock survives the bare-name acceptance: a bare
+// value that is path-shaped (contains a slash) must still be rejected so
+// no non-agent key can slip through the new form.
+func TestRunVaultDelete_RejectsBarePathShapedName(t *testing.T) {
+	for _, arg := range []string{"user/github", "internal/secret", "a/b/c"} {
+		called := false
+		fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+			called = true
+			w.WriteHeader(http.StatusNoContent)
+		})
+		var stdout, stderr bytes.Buffer
+		code := runVault([]string{"delete", arg, "--yes"},
+			strings.NewReader(""), &stdout, &stderr)
+		if code == 0 {
+			t.Errorf("arg %q: exit = 0, want non-zero", arg)
+		}
+		if called {
+			t.Errorf("arg %q: HTTP issued for rejected name", arg)
+		}
+	}
+}
+
 func TestRunVaultDelete_InteractiveCancelMakesNoCall(t *testing.T) {
 	for _, answer := range []string{"n\n", "\n"} {
 		called := false

--- a/cmd/aileron/vault_verbs_test.go
+++ b/cmd/aileron/vault_verbs_test.go
@@ -197,6 +197,19 @@ func TestRunVaultDelete_RejectsBarePathShapedName(t *testing.T) {
 	}
 }
 
+// Guard the namespace lock for the full-path form: a value that carries
+// the agents/ prefix and /oauth suffix but extracts to an empty or
+// slash-bearing <name> (e.g. `agents//oauth`, `agents/a/b/oauth`) must
+// still be rejected, so no nested or empty key can slip through the path
+// form (ADR-0025).
+func TestAgentOAuthPathName_RejectsMalformedFullPath(t *testing.T) {
+	for _, arg := range []string{"agents//oauth", "agents/a/b/oauth"} {
+		if name, err := agentOAuthPathName(arg); err == nil {
+			t.Errorf("agentOAuthPathName(%q) = (%q, nil), want error", arg, name)
+		}
+	}
+}
+
 func TestRunVaultDelete_InteractiveCancelMakesNoCall(t *testing.T) {
 	for _, answer := range []string{"n\n", "\n"} {
 		called := false

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -105,10 +105,10 @@ Approval-gated actions return an approval-pending message instead of running imm
 |---|---|---|
 | `aileron vault init [--passphrase-file <path>]` | Create the local file vault. Deliberate first-run flow; refuses to overwrite an existing vault. | [ADR-0011](/adr/0011-local-credential-vault) |
 | `aileron vault put agents/<name>/oauth --from-file <path>` | Write a per-agent credential envelope from a file, bytes verbatim. Daemon-backed; agents namespace only. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
-| `aileron vault delete agents/<name>/oauth [--yes]` | Delete a per-agent credential envelope. Confirms first unless `--yes`. Daemon-backed; agents namespace only. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
-| `aileron vault list [--json]` | List agents with a stored credential entry, metadata only. The credential value is never listed. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
+| `aileron vault delete <name> [--yes]` | Delete a per-agent credential envelope. `<name>` is the identifier `vault list` prints (e.g. `claude`); the `agents/<name>/oauth` path form is also accepted. Confirms first unless `--yes`. Daemon-backed; agents namespace only. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
+| `aileron vault list [--json]` | List agents with a stored credential entry, metadata only. The credential value is never listed. Each printed name is exactly what `vault delete` accepts. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
 
-The `put`, `delete`, and `list` verbs talk to the running daemon and operate only on the `agents/<name>/oauth` namespace. They never open the vault file directly and reject any other path. See [Sandbox Agent Auth](/development/sandbox-agent-auth/) for the seeding and recovery flows.
+The `put`, `delete`, and `list` verbs talk to the running daemon and operate only on the `agents/<name>/oauth` namespace. They never open the vault file directly and reject any other path. What `vault list` prints for an entry is exactly what `vault delete` takes to remove it, so a listed line can be pasted straight into `delete`. See [Sandbox Agent Auth](/development/sandbox-agent-auth/) for the seeding and recovery flows.
 
 ## Auth
 

--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -118,7 +118,7 @@ The other vault writes are:
 
 The bytes must match the envelope schema in the table above when set manually. Render validates on the way in; a malformed envelope fails the launch with a clear error before the container starts.
 
-`aileron vault list` shows which agents currently have an entry, metadata only. The credential value is never listed.
+`aileron vault list` shows which agents currently have an entry, metadata only. The credential value is never listed. Each name it prints is exactly what `aileron vault delete` accepts, so a listed line can be pasted straight into a delete.
 
 ```
 aileron vault list
@@ -147,10 +147,10 @@ When the host install is not authenticated (the file is absent or empty, or the 
 
 To re-login from scratch (vault entry stale, refresh token revoked, or just starting over), the recovery path is whichever of these you can execute:
 
-- Delete the agent's entry with `aileron vault delete agents/<agent>/oauth`. The next launch finds no entry, falls through to the in-container login bootstrap, and re-seeds a fresh credential on clean exit. This is a daemon-backed command, so the daemon must be running.
+- Delete the agent's entry with `aileron vault delete <agent>` (the name `aileron vault list` prints; the `agents/<agent>/oauth` path form also works). The next launch finds no entry, falls through to the in-container login bootstrap, and re-seeds a fresh credential on clean exit. This is a daemon-backed command, so the daemon must be running.
 
   ```
-  aileron vault delete agents/claude/oauth
+  aileron vault delete claude
   ```
 
   The command confirms before deleting. Pass `--yes` to skip the prompt in scripts.


### PR DESCRIPTION
## Summary

`aileron vault list` prints bare agent names (e.g. `claude`, `codex`), but `aileron vault delete` previously required the full `agents/<name>/oauth` path. What you read out of `list` was not what you could paste into `delete` — the two verbs spoke different dialects for the same entry (#1302).

This makes the list output round-trip into delete: `agentOAuthPathName` now accepts the bare agent name `list` prints in addition to the full `agents/<name>/oauth` path form. Both resolve to the same agent, so a listed line can be copied and pasted straight into `delete`.

The namespace lock (ADR-0025) is preserved. A path-shaped or empty value — anything containing `/`, or a partial `agents/`-only / `/oauth`-only form like `agents/oauth` — is still rejected client-side before any HTTP call, so the operator CLI can never reach a non-agent vault key.

Chosen approach: extend `delete` to accept the listed name rather than change `list` to emit full paths. Emitting paths would misrepresent `--scope user` entries (which have no delete verb at all) and disrupt the existing list / `--json` output, whereas accepting the bare name is fully backward compatible (the full path form still works) and satisfies the contract for the agent surface the operator actually hit.

Docs (CLI reference + Sandbox Agent Auth recovery flow) and usage strings updated to show the bare-name form and state the round-trip guarantee.

## Test plan

- `go test ./cmd/aileron/` — all pass, including new regression tests:
  - `TestRunVaultDelete_AcceptsBareNameFromList` — the bare name `list` prints deletes the entry and keys the DELETE on `/vault/agents/<name>/credentials`.
  - `TestVaultListNamesRoundTripIntoDelete` — every listed name resolves, via the delete validator, back to the same agent; the full-path form resolves identically.
  - `TestRunVaultDelete_RejectsBarePathShapedName` — a bare value containing `/` (`user/github`, `internal/secret`, `a/b/c`) is still rejected with no HTTP call, guarding the namespace lock.
- Existing `agents/oauth` overlap and non-agent-path rejection tests still pass.
- `go vet ./cmd/aileron/` and `gofmt` clean.

Closes #1302

🤖 Generated with [Claude Code](https://claude.com/claude-code)
