### PR TITLE
feat(launch): default to Docker sandbox, add --local for host launch

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -84,9 +84,10 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		launchFlags := flag.NewFlagSet("launch", flag.ContinueOnError)
 		launchFlags.SetOutput(stderr)
 		logLevel := launchFlags.String("log-level", "info", "Log level: trace, debug, info, warn, error")
-		sandboxRuntime := launchFlags.String("sandbox", "off", "Prepare sandbox image with runtime: off, auto, or docker")
+		sandboxRuntime := launchFlags.String("sandbox", "docker", "Prepare sandbox image with runtime: auto or docker (default; use --local for host launch)")
+		local := launchFlags.Bool("local", false, "Launch the agent directly on the host instead of in the Docker sandbox")
 		sandboxBuild := launchFlags.String("sandbox-build", "auto", "Sandbox build policy during launch: auto, always, or never")
-		sandboxProxy := launchFlags.String("sandbox-proxy", "auto", "Sandbox HTTPS proxy bootstrap: auto, on, or off (auto = on for --sandbox=docker)")
+		sandboxProxy := launchFlags.String("sandbox-proxy", "auto", "Sandbox HTTPS proxy bootstrap: auto, on, or off (auto = on for the Docker sandbox)")
 		hostLogin := launchFlags.String("host-login", "auto", "Host-side credential acquisition on vault miss: auto, on, or off (off forces in-container login)")
 		if err := launchFlags.Parse(args[1:]); err != nil {
 			return 1
@@ -94,7 +95,7 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		launchArgs := launchFlags.Args()
 
 		if len(launchArgs) < 1 {
-			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] [--sandbox=off|auto|docker] [--sandbox-build=auto|always|never] [--sandbox-proxy=auto|on|off] [--host-login=auto|on|off] <agent> [args...]")
+			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] [--local] [--sandbox=auto|docker] [--sandbox-build=auto|always|never] [--sandbox-proxy=auto|on|off] [--host-login=auto|on|off] <agent> [args...]")
 			fmt.Fprintf(stderr, "agents: %s\n", strings.Join(registry.Names(), ", "))
 			return 1
 		}
@@ -116,6 +117,24 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		if err != nil {
 			fmt.Fprintf(stderr, "error: %v\n", err)
 			return 1
+		}
+
+		// `aileron launch` defaults to the Docker sandbox; --local forces a
+		// host launch. Combining --local with an explicit --sandbox is a
+		// fail-fast contradiction. --sandbox stays reserved for selecting a
+		// future container runtime, so it never means "host".
+		sandboxExplicit := false
+		launchFlags.Visit(func(f *flag.Flag) {
+			if f.Name == "sandbox" {
+				sandboxExplicit = true
+			}
+		})
+		if *local {
+			if sandboxExplicit {
+				fmt.Fprintln(stderr, "error: --local conflicts with --sandbox; --local launches on the host, --sandbox selects a container runtime")
+				return 1
+			}
+			*sandboxRuntime = "off"
 		}
 
 		// Capture cwd so the daemon's session record carries working_dir
@@ -188,8 +207,8 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "aileron — the execution layer for AI coding agents")
 	fmt.Fprintln(w)
 	fmt.Fprintln(w, "usage:")
-	fmt.Fprintln(w, "  aileron launch [--sandbox=<runtime>] [--sandbox-build=<policy>] <agent> [args...]")
-	fmt.Fprintln(w, "                                      Launch an AI coding agent connected to the Aileron daemon")
+	fmt.Fprintln(w, "  aileron launch [--local] [--sandbox=<runtime>] [--sandbox-build=<policy>] <agent> [args...]")
+	fmt.Fprintln(w, "                                      Launch an AI coding agent in the Docker sandbox (default) or on the host with --local")
 	fmt.Fprintln(w, "  aileron vault init                 Create the local encrypted vault with a passphrase")
 	fmt.Fprintln(w, "  aileron auth <agent> --import-from-host  Seed the vault from an authenticated host install (claude|codex)")
 	fmt.Fprintln(w, "  aileron secret set <name>          Store a secret in the encrypted vault")
@@ -466,6 +485,20 @@ func launchFlagTakesValue(name string) bool {
 	}
 }
 
+// launchFlagIsBool reports whether name is an aileron launch flag that
+// takes no value (a boolean toggle). Trailing bool flags must be
+// consumed too, so `aileron launch claude --local` behaves identically
+// to `aileron launch --local claude`; otherwise the token would fall
+// through to agentArgs and leak to the agent.
+func launchFlagIsBool(name string) bool {
+	switch name {
+	case "local":
+		return true
+	default:
+		return false
+	}
+}
+
 // parseLaunchFlagToken extracts a flag name and optional inline value
 // from a single- or double-dash token. It returns name == "" for any
 // non-flag token, including a bare "-" or "--".
@@ -510,6 +543,17 @@ func applyTrailingLaunchFlags(fs *flag.FlagSet, tail []string) ([]string, error)
 				}
 				value = tail[i+1]
 				i++
+			}
+			if err := fs.Set(name, value); err != nil {
+				return nil, err
+			}
+			continue
+		}
+		if name != "" && launchFlagIsBool(name) {
+			// A bool flag may still carry an inline value (--local=true).
+			// Default to "true" for the bare form.
+			if !hasValue {
+				value = "true"
 			}
 			if err := fs.Set(name, value); err != nil {
 				return nil, err

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -270,8 +270,10 @@ func TestRun_LaunchFlagsAfterAgentName(t *testing.T) {
 		{"before agent still works", []string{"launch", "--sandbox=docker", "claude"}, "docker", "auto", ""},
 		{"split before and after", []string{"launch", "--sandbox=docker", "claude", "--sandbox-build=never"}, "docker", "never", ""},
 		{"unknown agent args forward", []string{"launch", "claude", "--model", "opus", "--sandbox=docker"}, "docker", "auto", "--model opus"},
-		{"double dash forwards through", []string{"launch", "claude", "--", "--sandbox=docker"}, "off", "auto", "--sandbox=docker"},
-		{"bare dash forwards to agent", []string{"launch", "claude", "-"}, "off", "auto", "-"},
+		// After "--" the --sandbox=docker forwards to the agent, so aileron
+		// never sees it; the default Docker sandbox runtime still applies.
+		{"double dash forwards through", []string{"launch", "claude", "--", "--sandbox=docker"}, "docker", "auto", "--sandbox=docker"},
+		{"bare dash forwards to agent", []string{"launch", "claude", "-"}, "docker", "auto", "-"},
 	}
 
 	for _, tc := range cases {
@@ -316,6 +318,95 @@ func TestRun_LaunchTrailingFlagMissingValue(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "needs a value") {
 		t.Errorf("stderr = %q, want it to mention the missing value", stderr.String())
+	}
+}
+
+// TestRun_LaunchDefaultsToDockerSandbox locks the contract that omitting
+// every sandbox flag selects the Docker sandbox runtime. This is the flip
+// from the old host-by-default behavior.
+func TestRun_LaunchDefaultsToDockerSandbox(t *testing.T) {
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+
+	var captured launch.LaunchConfig
+	launchFn = func(_ context.Context, cfg launch.LaunchConfig) (launch.LaunchResult, error) {
+		captured = cfg
+		return launch.LaunchResult{ExitCode: 0}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"launch", "claude"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d (stderr=%q)", code, stderr.String())
+	}
+	if captured.SandboxRuntime != "docker" {
+		t.Errorf("SandboxRuntime = %q, want docker (default)", captured.SandboxRuntime)
+	}
+}
+
+// TestRun_LaunchLocalForcesHostLaunch verifies --local maps to the "off"
+// runtime (host launch) in both the before-agent and trailing forms, and
+// that the bool flag is never leaked to the agent.
+func TestRun_LaunchLocalForcesHostLaunch(t *testing.T) {
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"before agent", []string{"launch", "--local", "claude"}},
+		{"trailing bare form", []string{"launch", "claude", "--local"}},
+		{"trailing inline form", []string{"launch", "claude", "--local=true"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var captured launch.LaunchConfig
+			launchFn = func(_ context.Context, cfg launch.LaunchConfig) (launch.LaunchResult, error) {
+				captured = cfg
+				return launch.LaunchResult{ExitCode: 0}, nil
+			}
+			var stdout, stderr bytes.Buffer
+			code := run(tc.args, newTestRegistry(), &stdout, &stderr)
+			if code != 0 {
+				t.Fatalf("exit = %d (stderr=%q)", code, stderr.String())
+			}
+			if captured.SandboxRuntime != "off" {
+				t.Errorf("SandboxRuntime = %q, want off (host launch)", captured.SandboxRuntime)
+			}
+			if len(captured.Args) != 0 {
+				t.Errorf("--local leaked to agent args: %v", captured.Args)
+			}
+		})
+	}
+}
+
+// TestRun_LaunchLocalSandboxConflict verifies that combining --local with
+// an explicit --sandbox fails fast rather than silently picking one. The
+// conflict holds whether the flags appear before or after the agent name.
+func TestRun_LaunchLocalSandboxConflict(t *testing.T) {
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+	launchFn = func(_ context.Context, _ launch.LaunchConfig) (launch.LaunchResult, error) {
+		t.Fatal("launch should not run when --local conflicts with --sandbox")
+		return launch.LaunchResult{}, nil
+	}
+
+	cases := [][]string{
+		{"launch", "--local", "--sandbox=docker", "claude"},
+		{"launch", "--sandbox=auto", "--local", "claude"},
+		{"launch", "claude", "--local", "--sandbox=docker"},
+	}
+	for _, args := range cases {
+		t.Run(strings.Join(args, " "), func(t *testing.T) {
+			var stdout, stderr bytes.Buffer
+			code := run(args, newTestRegistry(), &stdout, &stderr)
+			if code != 1 {
+				t.Fatalf("exit = %d, want 1", code)
+			}
+			if !strings.Contains(stderr.String(), "--local conflicts with --sandbox") {
+				t.Errorf("stderr = %q, want it to mention the --local/--sandbox conflict", stderr.String())
+			}
+		})
 	}
 }
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -14,7 +14,7 @@ This page is the human-readable index of CLI commands grouped by concern. Each c
 
 | Command | Purpose | Ratified by |
 |---|---|---|
-| `aileron launch [--sandbox=off\|auto\|docker] [--sandbox-build=auto\|always\|never]` | Launch an AI coding agent connected to the Aileron daemon. `--sandbox` prepares the project sandbox image and runs the agent command inside it; `off` preserves direct host launch. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
+| `aileron launch [--local] [--sandbox=auto\|docker] [--sandbox-build=auto\|always\|never]` | Launch an AI coding agent connected to the Aileron daemon. The Docker sandbox is the default; the agent command runs inside the prepared project sandbox image. `--local` runs the agent directly on the host instead, and conflicts with an explicit `--sandbox`. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
 | `aileron status` | Report the running runtime: version, listen address, action count, connector count, binding count, vault state. Read-only; safe to run frequently. | — |
 
 ## Sandbox composition

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -40,7 +40,7 @@ With no `.devcontainer` in the project, `aileron launch --sandbox=docker <agent>
 
 The launcher resolves the image for this build-free default in two ways. A release build with a recorded digest pin pulls a fixed image by `@sha256` (see [Reproducible releases](#reproducible-releases-digest-pinning) below). Otherwise it resolves a floating tag: a release build with no recorded pin pulls `latest` (which the image workflows move only on a `v*` tag), and a dev build off `main` pulls `edge` (published on `workflow_dispatch`). So `latest` always names the most recent release and a dev run never clobbers it. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so the floating tag is the fallback when no digest is pinned. The freshness policy that keeps `edge` current is owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088).
 
-When the requested agent has no published image, launch falls back to the customization tier. The image validation then emits the actionable message to install the agent CLI in the sandbox image or launch with `--sandbox=off`.
+When the requested agent has no published image, launch falls back to the customization tier. The image validation then emits the actionable message to install the agent CLI in the sandbox image or launch with `--local`.
 
 ## Prebuilt Per-Agent Images
 

--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -157,6 +157,12 @@ If you'd rather drive each step yourself, the single-action form `aileron action
 aileron launch claude
 ```
 
+`aileron launch` runs the agent in the Docker sandbox by default. To launch the agent directly on the host instead, add `--local`:
+
+```sh
+aileron launch --local claude
+```
+
 You'll see a banner like:
 
 ```

--- a/docs/src/content/docs/meet-aileron/v4.mdx
+++ b/docs/src/content/docs/meet-aileron/v4.mdx
@@ -103,7 +103,7 @@ The v4 binary set is two cooperating binaries. `aileron` is the product boundary
 
 One binary, multiple modes:
 
-- `aileron launch <agent>`: starts a session. Prepares the sandbox, registers the session, wires `aileron-mcp` into the agent, and runs the agent in the container. Holds the master key briefly during launch, then the daemon owns the session.
+- `aileron launch <agent>`: starts a session. Prepares the sandbox, registers the session, wires `aileron-mcp` into the agent, and runs the agent in the container. The Docker sandbox is the default; `--local` launches the agent directly on the host instead. Holds the master key briefly during launch, then the daemon owns the session.
 - The local daemon (auto-spawned, long-lived): hosts the management plane (sessions, audit, policy, approvals, the connector and action stores) and the data plane (HTTPS proxy plus credential mediation) as logical components. Single-user v4 colocates them all in one process; v4.x and v5 split them.
 - `aileron status`, `aileron approval`, `aileron audit`, `aileron actions`, `aileron vault`, `aileron sessions`: user-facing CLI subcommands. Talk to the daemon over HTTPS with the session token.
 

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -620,7 +620,7 @@ fi
 rm -f "$probe"
 if ! command -v "$1" >/dev/null 2>&1; then
   echo "agent command not found in sandbox image: $1" >&2
-  echo "install the agent CLI in the sandbox image or launch with --sandbox=off" >&2
+  echo "install the agent CLI in the sandbox image or launch with --local" >&2
   echo "agent image recipes: ` + AgentImagesDocsURL + `" >&2
   exit 127
 fi


### PR DESCRIPTION
## Summary

Flips `aileron launch` to run the agent in the Docker sandbox by default and adds a `--local` flag for host launch. This makes the container the default deployment, matching the v4 "Aileron Way" model where the agent runs inside an environment Aileron defines.

- `cmd/aileron/main.go`: `--sandbox` default changes `off` -> `docker`. Omitting every sandbox flag now selects the `docker` runtime. New `--local` boolean flag forces a host launch by mapping to the `off` runtime. Usage strings (launch line + top-level `usage()`) updated.
- **Interaction (the item #1305 flagged for triage):** `--local` combined with an explicit `--sandbox=docker`/`auto` is a fail-fast conflict error; `--local` alone => host; neither => docker default. `--sandbox` stays reserved for selecting a future container runtime (e.g. podman) per the v4 Runner/runtimeName seam.
- `applyTrailingLaunchFlags` now consumes boolean launch flags, so `aileron launch claude --local` behaves identically to `aileron launch --local claude`. Previously a trailing bool flag fell through to `agentArgs` and leaked to the agent (regression-tested).
- The launcher's in-sandbox "agent command not found" hint and the docs now point at `--local` instead of the now-undocumented `--sandbox=off`.
- Docs updated: `cli/index.md`, `development/sandbox-agent-images.md`, `getting-started.mdx`, `meet-aileron/v4.mdx`.

The launcher resolver logic needed no change: `sandboxLaunchEnabled`, `resolveSandboxProxyState`, `resolveHostLogin`, and `sandboxProxyModeSupportsBootstrap` already key off the mode string, so the `auto` proxy/host-login paths light up automatically under the new default.

## Test plan

- `go test ./cmd/aileron/... ./internal/launch/... ./internal/sandbox/...` — green.
- New tests in `cmd/aileron/main_test.go`:
  - `TestRun_LaunchDefaultsToDockerSandbox` — no flag => `docker`.
  - `TestRun_LaunchLocalForcesHostLaunch` — `--local` => `off` (host), before-agent / trailing-bare / trailing-inline forms, asserts no leak to agent args.
  - `TestRun_LaunchLocalSandboxConflict` — `--local` + explicit `--sandbox` fails fast with exit 1, before and after the agent name.
- Updated two existing `TestRun_LaunchFlagsAfterAgentName` cases whose expected runtime flipped from `off` to `docker` under the new default (the `--`-forwarded and bare-`-` cases never set `--sandbox`, so the default now applies).

Closes #1305

🤖 Generated with [Claude Code](https://claude.com/claude-code)
