### PR TITLE
feat(launch): print Claude auth URL to terminal before opening browser

### DIFF
--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -414,6 +414,14 @@ func claudeHostedCallbackAcquire(ctx context.Context, deps launch.HostAcquireDep
 	}
 
 	authURL := buildClaudeAuthorizeURL(pkce, state)
+	// Surface the authorize URL BEFORE opening the browser, so a headless
+	// host (or a failed browser open) still gives the user a copyable
+	// record of what was launched. Mirrors the Codex device flow.
+	if deps.Out != nil {
+		fmt.Fprintf(deps.Out,
+			"To authorize Claude, open %s in your browser and paste back the code shown.\n",
+			authURL)
+	}
 	if deps.Browser != nil {
 		if err := deps.Browser.Open(authURL); err != nil {
 			// Opening the browser failed (headless host, no opener).

--- a/internal/launch/agents/claude_host_acquire_test.go
+++ b/internal/launch/agents/claude_host_acquire_test.go
@@ -1,6 +1,7 @@
 package agents_test
 
 import (
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -115,11 +116,13 @@ func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
 	defer srv.Close()
 
 	opener := &recordingOpener{}
+	var out bytes.Buffer
 	fb := claudeHostAcquireBinding(t)
 	secret, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
-		Ctx:          context.Background(),
-		HTTPClient:   testHTTPClient(srv.URL),
-		Browser: opener,
+		Ctx:        context.Background(),
+		HTTPClient: testHTTPClient(srv.URL),
+		Browser:    opener,
+		Out:        &out,
 		// Paste a bare code (no #state). The acquirer generates the
 		// state internally and tolerates a bare-code paste since PKCE
 		// already binds the exchange; a state-carrying paste is covered
@@ -140,6 +143,11 @@ func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
 	// Browser was opened with the consent URL carrying the client id.
 	if !strings.Contains(opener.opened, "client_id=9d1c250a") {
 		t.Errorf("browser opened %q, want consent URL with client_id", opener.opened)
+	}
+	// The authorize URL is surfaced on deps.Out so the user has a
+	// copyable record of what was launched, mirroring the Codex flow.
+	if !strings.Contains(out.String(), "client_id=9d1c250a") {
+		t.Errorf("Out missing the authorize URL; got %q", out.String())
 	}
 	// Token exchange used authorization_code + PKCE verifier, no secret.
 	if gotForm.Get("grant_type") != "authorization_code" {


### PR DESCRIPTION
## Summary

The Claude host-side OAuth flow (`claudeHostedCallbackAcquire` in `internal/launch/agents/claude_auth.go`) computed `authURL := buildClaudeAuthorizeURL(...)` and called `deps.Browser.Open(authURL)`, but never printed the URL to the terminal. The user had no copyable record of what was launched.

The Codex device flow (`internal/launch/agents/codex_auth.go`) already prints its verification URL to `deps.Out` before opening the browser. This change mirrors that within-repo pattern for the Claude paste-back flow.

Before the `Browser.Open` call, a nil-guarded `fmt.Fprintf(deps.Out, ...)` now surfaces the full authorize URL every time (not only on the headless/open-failed fallback), instructing the user to open the URL and paste back the code shown. `deps.Out` was already plumbed into `HostAcquireDeps` (defaulted to the launcher's stderr on the live path); it just was not used by the Claude acquirer.

No API/spec change (purely internal launch wiring). No backwards-compat concern.

## Test plan

- Extended `TestClaudeHostAcquire_HostedCallbackHappyPath` in `internal/launch/agents/claude_host_acquire_test.go` to inject `Out: &bytes.Buffer{}` and assert it contains the authorize URL (`client_id=9d1c250a` substring), the same shape as the Codex `Out` assertion.
- Regression verified: the new assertion fails before the fix (`Out missing the authorize URL; got ""`) and passes after.
- `go build ./...` green.
- `go test ./internal/launch/...` green (launch, agents, hostimport).

Closes #1303