### PR TITLE
docs(adr): amend ADR-0025 to record generalized acquisition

### DIFF
--- a/docs/src/content/docs/adr/0025-vault-backed-agent-auth.md
+++ b/docs/src/content/docs/adr/0025-vault-backed-agent-auth.md
@@ -56,6 +56,16 @@ The daemon's new endpoints are namespace-scoped at the routing layer: `{name}` t
 
 **Two distinct host-seed paths for two distinct populations.** The daemon-driven cold-launch acquirer described here handles the never-logged-in or not-installed user, acquiring a fresh credential on the host at first launch. It is a different mechanism from `aileron auth <agent> --import-from-host` (described under Alternatives Considered below), which reads an already-authenticated host CLI install into the vault. Import-from-host serves the user who already logged the host CLI in. The cold-launch acquirer serves the user who never has. They are complementary and neither supersedes the other.
 
+**Descriptor-driven acquisition (amendment, umbrella [#1290](https://github.com/ALRubinger/aileron/issues/1290)).** This amendment generalizes the standalone user-level acquisition path, `aileron auth github`, so a tool's login flow ships as data rather than as compiled-in Go. The unit of that data is a **capture descriptor**, which is distinct from the AuthSpec FileBinding "descriptor" used elsewhere in this ADR. The AuthSpec FileBinding descriptor governs the **binding** side: rendering a stored vault credential into the running sandbox and capturing in-container rotations back. A capture descriptor governs the **acquisition** side: how a one-time login is run in a container to mint a credential the vault did not yet hold. The two senses are kept separate throughout this file.
+
+`aileron auth github` resolves the `gh` capture descriptor **by name** through a registry, then drives the generic `capture.Driver` from the descriptor's fields. The descriptor supplies the login flow, the container image, the vault path, and the credential kind. No provider knowledge is compiled into core. Adding a second tool is a new shipped YAML descriptor under the capture defaults, never new Go.
+
+The `gh` descriptor ships as a **trusted YAML default loaded by the auth domain's own embed and loader in `internal/auth/capture`** (`embed.go`, `loader.go`, and the by-name `Registry` in `registry.go`). It follows the same two-layer built-in-then-user convention as the proxybinding `github.yaml` trusted default, and it is **not** loaded by proxybinding. The auth domain owns its acquisition descriptors and proxybinding owns its binding descriptors; the two loaders are independent.
+
+The GitHub one-command UX is unchanged. `aileron auth github` still runs `gh auth login` and `gh auth token` in one container, prints the device URL, stores the token at `user/github`, and returns the same exit codes. The in-container interactive login remains the documented acquisition path the descriptor drives; the descriptor expresses that flow as data rather than replacing it.
+
+This acquisition-side generalization mirrors the binding and egress-side generalization that routed GitHub through the uniform proxybinding descriptor path (issues [#1244](https://github.com/ALRubinger/aileron/issues/1244) and [#1245](https://github.com/ALRubinger/aileron/issues/1245)).
+
 **Sandbox-only in v1.** Host launch (`aileron launch <agent>` with no sandbox flag) is deliberately not vault-backed. Host launch already resolves a working install's credentials from the host user's own `~/.claude/` and `~/.codex/`. `prepareAuthSpec` runs only on the sandbox path and is intentionally not wired into host launch. Intervening on the host path risks breaking a working install, so the host path stays untouched in v1. Vault-backed host auth would render vault entries into host paths and capture rotations back to the vault. That work warrants a separate PR with explicit user testing, and is deferred. The host-parity question was evaluated under issue [#983](https://github.com/ALRubinger/aileron/issues/983): three options were weighed, extending `AuthSpec` to host launch, a hybrid, and documenting the sandbox-only stance. Documenting the sandbox-only stance was chosen for v1. Host-launch parity for `AuthSpec` stays architecturally clean to extend later, and is not part of this decision.
 
 ## Consequences
@@ -123,6 +133,9 @@ The current decision stores refresh tokens in the vault and hands them to the ag
 
 - [Issue #969](https://github.com/ALRubinger/aileron/issues/969). Vault-backed agent auth injection (this ADR's tracking issue)
 - [Issue #1267](https://github.com/ALRubinger/aileron/issues/1267). Host-side cold-launch credential acquirer umbrella (the host-acquirer-phase amendment)
+- [Issue #1290](https://github.com/ALRubinger/aileron/issues/1290). Descriptor-driven acquisition umbrella (the capture-descriptor amendment)
+- [Issue #1244](https://github.com/ALRubinger/aileron/issues/1244). Generalize the emit mechanism so GitHub is just another binding descriptor (the binding-side sibling)
+- [Issue #1245](https://github.com/ALRubinger/aileron/issues/1245). Route GitHub through the uniform binding descriptor path (the binding-side sibling)
 - [Issue #747](https://github.com/ALRubinger/aileron/issues/747). Milestone v4 umbrella
 - [ADR-0011](/adr/0011-local-credential-vault). Vault is the daemon's trust boundary
 - [ADR-0012](/adr/0012-local-daemon-architecture). Daemon owns the unlocked vault

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -115,9 +115,9 @@ The `put`, `delete`, and `list` verbs talk to the running daemon and operate onl
 | Command | Purpose | Ratified by |
 |---|---|---|
 | `aileron auth <agent> --import-from-host` | Seed the vault from an already-authenticated host install of claude or codex. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
-| `aileron auth github [--runtime <auto\|docker>] [--image <ref>]` | Run gh's OAuth device-authorization flow inside a gh-bearing container and store the captured bearer token at `user/github`. HTTPS only; no refresh machinery. | — |
+| `aileron auth github [--runtime <auto\|docker>] [--image <ref>]` | Run gh's OAuth device-authorization flow inside a gh-bearing container and store the captured bearer token at `user/github`. HTTPS only; no refresh machinery. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
 
-`aileron auth github` is a one-time acquisition flow: it drives `gh auth login` and `gh auth token` in the same container, then PUTs the token to the user-level `user/github` vault namespace through the daemon.
+`aileron auth github` is a one-time acquisition flow. The `github` verb resolves the shipped `gh` capture descriptor by name and drives the generic capture flow. That flow runs `gh auth login` and `gh auth token` in the same container, then PUTs the token to the user-level `user/github` vault namespace through the daemon. The provider knowledge ships as a trusted YAML descriptor in the auth domain, so adding another tool is a new descriptor rather than new code.
 
 ## Utility
 


### PR DESCRIPTION
## Summary

Docs-only change recording the generalized, capture-descriptor-driven user-level acquisition mechanism (umbrella #1290), which shipped via #1306 (capture descriptor + registry) and #1312 (route `auth github` through the registry).

- **`docs/src/content/docs/adr/0025-vault-backed-agent-auth.md`** — adds a "Descriptor-driven acquisition (amendment, umbrella #1290)" subsection under Decision that:
  - introduces the term **capture descriptor** and disambiguates it from the existing AuthSpec FileBinding "descriptor" (acquisition side vs binding side);
  - records that `aileron auth github` resolves the `gh` capture descriptor **by name** through a registry and drives the generic `capture.Driver`, with provider knowledge shipped as YAML data, not compiled Go;
  - states the descriptor ships as a trusted YAML default loaded by the auth domain's own embed/loader in `internal/auth/capture` (`embed.go`, `loader.go`, `registry.go`), following the same two-layer convention as proxybinding's `github.yaml` but **not** loaded by proxybinding;
  - notes the GitHub one-command UX (`user/github`, exit codes) is unchanged and retains the in-container interactive login as the documented path;
  - cross-links #1244/#1245 as the binding/egress-side sibling and adds References entries.
- **`docs/src/content/docs/cli/index.md`** — the `aileron auth github` row now cites `[ADR-0025]` (matching the adjacent `--import-from-host` row), and the mechanism prose describes the descriptor-driven flow.

Scope boundaries respected: no edits to `cmd/aileron/auth.go`, `internal/auth/capture/*`, the launcher cold-launch (`HostAcquire`) paragraphs, or README. `sandbox-agent-auth.md` left unchanged (it documents the agent-vault path, a different namespace, and is still accurate). No overclaimed supersession; the in-container fallback and `--import-from-host` deferral framing stay intact.

## Test plan

- `task build:docs` — Astro Starlight site builds green, 127 pages, both edited pages render (no broken `/adr/...` links).
- `git grep '—' docs/src/content/docs/adr/0025-vault-backed-agent-auth.md` returns nothing (0 em-dashes preserved); no em-dashes in any added line.
- Every `ADR-NNNN` cross-reference in the file is a Markdown link; new issue cross-refs (#1290/#1244/#1245) are links.
- "capture descriptor" appears and is disambiguated; the proxybinding-loads-them claim is absent; in-container fallback paragraph still present.
- `git status` confirms only the two intended files changed; `docs/dist` not staged.

Closes #1289
