### PR TITLE
docs(auth): document store_at as a logical vault key; normalize fixtures

### DIFF
--- a/internal/auth/capture/capture.go
+++ b/internal/auth/capture/capture.go
@@ -101,7 +101,11 @@ type Driver struct {
 	// Empty omits it. The non-interactive token read never carries it.
 	BrowserShim string
 
-	// StoreAt is the vault path the captured credential is stored at.
+	// StoreAt is the logical vault key the captured credential is stored
+	// at (e.g. "user/github"), passed verbatim to Store. The Driver does
+	// not interpret it: the configured StoreFunc owns the convention. The
+	// production StoreFunc expands it to the daemon path
+	// /vault/<StoreAt>/credentials; a test StoreFunc may record it as-is.
 	StoreAt string
 	// Kind is the metadata Type stamped on the stored credential.
 	Kind string

--- a/internal/auth/capture/capture_test.go
+++ b/internal/auth/capture/capture_test.go
@@ -188,7 +188,7 @@ func newTestDriver(runner interface {
 		ContainerName: "aileron-auth-cli",
 		LoginArgs:     []string{"gh", "auth", "login", "--web"},
 		TokenArgs:     []string{"gh", "auth", "token"},
-		StoreAt:       "/vault/user/github/credentials",
+		StoreAt:       "user/github",
 		Kind:          "user",
 		Store:         store,
 	}
@@ -443,8 +443,8 @@ func TestAcquire_HappyPathStoresTrimmedToken(t *testing.T) {
 	if store.called != 1 {
 		t.Fatalf("Store called %d times, want exactly 1", store.called)
 	}
-	if store.storeAt != "/vault/user/github/credentials" {
-		t.Errorf("storeAt = %q, want the configured path", store.storeAt)
+	if store.storeAt != "user/github" {
+		t.Errorf("storeAt = %q, want the configured logical key", store.storeAt)
 	}
 	if store.kind != "user" {
 		t.Errorf("kind = %q, want the configured stamp", store.kind)

--- a/internal/auth/capture/defaults/gh.yaml
+++ b/internal/auth/capture/defaults/gh.yaml
@@ -29,10 +29,12 @@
 #     it; gh does not.
 #
 # image is intentionally left empty: image / base-image resolution stays
-# caller-side, and the binder takes a resolved image string. store_at and
-# kind match the bespoke flow's vault path (user/github) and kind stamp
-# (user), so the daemon resolves the same credential the host-binding's
-# credential-ref (user/github) names.
+# caller-side, and the binder takes a resolved image string. store_at is a
+# logical vault key, not a full daemon path: the production StoreFunc
+# expands it to /vault/<store_at>/credentials. store_at and kind match the
+# bespoke flow's logical key (user/github) and kind stamp (user), so the
+# daemon resolves the same credential the host-binding's credential-ref
+# (user/github) names.
 version: v1
 name: gh
 image: ""

--- a/internal/auth/capture/descriptor.go
+++ b/internal/auth/capture/descriptor.go
@@ -88,8 +88,10 @@ type CaptureDescriptor struct {
 	// exec arg vectors from the bespoke flow.
 	ConfigDir string `yaml:"config_dir"`
 
-	// StoreAt is the vault path the captured credential is stored at (e.g.
-	// "user/github"). Required; maps to Driver.StoreAt.
+	// StoreAt is the logical vault key the captured credential is stored
+	// at (e.g. "user/github"), not a full daemon path. Required; maps to
+	// Driver.StoreAt. The production StoreFunc expands it to
+	// /vault/<store_at>/credentials.
 	StoreAt string `yaml:"store_at"`
 
 	// Kind is the metadata Type stamped on the stored credential (e.g.


### PR DESCRIPTION
## Summary

Resolves the #1300 escalation from umbrella #1290. The capture descriptor's `store_at` is a **logical** vault key (`user/github`) that the production `StoreFunc` (`cmd/aileron/auth_github.go:userCredentialStore`) expands to `/vault/<store_at>/credentials`. The `Driver.StoreAt` / `descriptor.go` doc comments called it "the vault path," and the `capture_test.go` fixtures used the full daemon path, while the shipped `gh.yaml` + parity test use the logical key. That inconsistency is a convention/doc seam, not a bug.

This documents the convention and normalizes the test fixtures. **No behavior change** — the Driver forwards `StoreAt` verbatim to the configured `StoreFunc`; `aileron auth github` already stores to `/vault/user/github/credentials` correctly.

- `capture.go`, `descriptor.go`, `gh.yaml`: document `store_at` as a logical key the StoreFunc expands, not a full path.
- `capture_test.go`: normalize the fixture + assertion from `/vault/user/github/credentials` to the logical key `user/github`.

## Test plan

- `go test ./internal/auth/capture/...` — green.
- `go vet` + `go build ./internal/auth/... ./cmd/aileron/...` — clean.
- No production code path changed; the parity test (`gh_parity_test.go`) and CLI behavior (`Stored user/github`) are unaffected.

Closes #1300

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Enhanced documentation to clarify how vault keys are interpreted and expanded during credential storage operations in the authentication capture system.

* **Chores**
  * Updated internal test configuration and default values to align with improved documentation standards.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->