### PR TITLE
fix(launch): stamp Claude subscription tier so Max/Pro is recognized

### DIFF
--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -94,13 +94,14 @@ func (c Claude) AuthSpec() launch.AuthSpec {
 			Render:   claudeRender,
 			Capture:  claudeCapture,
 			Fresher:  claudeFresher,
-			// HostAcquire runs a host-side OAuth flow (setup-token
-			// shortcut, else hosted-callback paste with PKCE) when the
-			// vault is empty and host-login is enabled, so the user
-			// authenticates in their own browser/terminal rather than
-			// inside the container TTY. The launcher owns the vault PUT
-			// and the validating Render; a cancel/failure is non-fatal
-			// and falls back to the in-container login.
+			// HostAcquire runs a host-side OAuth flow (hosted-callback
+			// paste with PKCE, then a profile fetch that stamps the
+			// subscription tier) when the vault is empty and host-login is
+			// enabled, so the user authenticates in their own
+			// browser/terminal rather than inside the container TTY. The
+			// launcher owns the vault PUT and the validating Render; a
+			// cancel/failure is non-fatal and falls back to the
+			// in-container login.
 			HostAcquire: claudeHostAcquire,
 		}},
 		StaticFiles: []launch.StaticFile{{

--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -8,7 +8,6 @@ import (
 	"io"
 	"net/http"
 	"net/url"
-	"os/exec"
 	"strings"
 	"time"
 
@@ -42,6 +41,12 @@ const (
 	claudeAuthorizeURL      = "https://claude.ai/oauth/authorize"
 	claudeTokenURL          = "https://platform.claude.com/v1/oauth/token"
 	claudeHostedCallbackURL = "https://platform.claude.com/oauth/code/callback"
+	// claudeProfileURL is the OAuth profile endpoint Claude Code reads to
+	// learn the signed-in organization's subscription tier. It is fetched
+	// host-side with the freshly-exchanged access token (the
+	// `user:profile` scope, requested in claudeOAuthScopes, authorizes
+	// it) so the seeded envelope can carry a subscriptionType.
+	claudeProfileURL = "https://api.anthropic.com/api/oauth/profile"
 )
 
 // claudeOAuthScopes are the scopes Claude Code requests for a
@@ -87,12 +92,14 @@ func buildClaudeAuthorizeURL(pkce oauth.PKCEPair, state string) string {
 // an absolute ms timestamp. A non-positive expiresInSec leaves
 // expiresAt at 0 (omitted), matching envelopes that ship without an
 // expiry.
-func claudeEnvelopeFromTokenResponse(access, refresh string, expiresInSec int, scopes []string) ([]byte, error) {
+func claudeEnvelopeFromTokenResponse(access, refresh string, expiresInSec int, scopes []string, subscriptionType, rateLimitTier string) ([]byte, error) {
 	env := claudeCredentialEnvelope{
 		ClaudeAiOauth: claudeAiOauth{
-			AccessToken:  access,
-			RefreshToken: refresh,
-			Scopes:       scopes,
+			AccessToken:      access,
+			RefreshToken:     refresh,
+			Scopes:           scopes,
+			SubscriptionType: subscriptionType,
+			RateLimitTier:    rateLimitTier,
 		},
 	}
 	if expiresInSec > 0 {
@@ -105,25 +112,6 @@ func claudeEnvelopeFromTokenResponse(access, refresh string, expiresInSec int, s
 		// error. Wrap rather than panic so a caller in the acquire path
 		// degrades to the in-container fallback instead of crashing.
 		return nil, fmt.Errorf("claude: marshal acquired envelope: %w", err)
-	}
-	return b, nil
-}
-
-// claudeEnvelopeFromBareToken builds an envelope from the single bare
-// token `claude setup-token` prints on stdout. Unlike the
-// hosted-callback exchange, setup-token yields no refresh token, no
-// expiry, and no scope list — it is a long-lived token. We populate
-// `accessToken` only and leave `refreshToken`/`expiresAt`/`scopes`
-// empty (omitted). This is a deliberate divergence from the
-// hosted-callback envelope, documented so a reader does not mistake the
-// missing fields for a bug.
-func claudeEnvelopeFromBareToken(token string) ([]byte, error) {
-	env := claudeCredentialEnvelope{
-		ClaudeAiOauth: claudeAiOauth{AccessToken: token},
-	}
-	b, err := json.Marshal(env)
-	if err != nil {
-		return nil, fmt.Errorf("claude: marshal setup-token envelope: %w", err)
 	}
 	return b, nil
 }
@@ -165,6 +153,20 @@ type claudeAiOauth struct {
 	RefreshToken string   `json:"refreshToken,omitempty"`
 	ExpiresAt    int64    `json:"expiresAt,omitempty"`
 	Scopes       []string `json:"scopes,omitempty"`
+	// SubscriptionType is the Max/Pro tier Claude Code uses to decide
+	// whether a seeded credential is a subscription session (Max/Pro/
+	// Enterprise/Team) rather than a raw "Claude API" key. Without it the
+	// CLI reports not-logged-in even with a valid access token
+	// (anthropics/claude-code#34262). The host acquirer fetches the tier
+	// from the profile endpoint after the token exchange and stamps it
+	// here; "omitempty" keeps it absent on envelopes that never carried
+	// a tier (e.g. those rendered verbatim from a vault entry).
+	SubscriptionType string `json:"subscriptionType,omitempty"`
+	// RateLimitTier mirrors the organization's rate-limit tier from the
+	// profile endpoint. Claude Code surfaces it alongside the
+	// subscription type; it is informational and absent when the profile
+	// did not report one.
+	RateLimitTier string `json:"rateLimitTier,omitempty"`
 }
 
 // errClaudeEnvelopeMalformed is returned by claudeCapture when the
@@ -342,56 +344,23 @@ func validateClaudeEnvelope(b []byte) error {
 //     in-container login. So a cancel / unavailable-CLI / failed
 //     exchange must surface as one of those, never as a partial seed.
 //
-// Two acquisition mechanisms, tried in order:
+// Acquisition mechanism: the hosted-callback PASTE flow (the real
+// OAuth, with PKCE). Open the consent URL in the host browser, have the
+// user paste the `<code>#<state>` string from the hosted callback page
+// on the HOST terminal, verify state, exchange the code for tokens
+// (PKCE, no client_secret), fetch the subscription tier from the
+// profile endpoint, and build a ms-expiry envelope stamped with that
+// tier.
 //
-//  1. `claude setup-token` SHORTCUT (opportunistic). When the `claude`
-//     CLI is on PATH we run it first; it prints a single long-lived
-//     bare token on stdout (NOT a full claudeAiOauth JSON envelope). We
-//     wrap that bare token into an envelope with accessToken only
-//     (refreshToken/expiresAt/scopes empty — see
-//     claudeEnvelopeFromBareToken). The CLI may be absent; that is
-//     expected, not an error.
-//
-//  2. Hosted-callback PASTE flow (the real OAuth, with PKCE). Open the
-//     consent URL in the host browser, have the user paste the
-//     `<code>#<state>` string from the hosted callback page on the HOST
-//     terminal, verify state, exchange the code for tokens (PKCE, no
-//     client_secret), and build a ms-expiry envelope.
+// The `claude setup-token` shortcut was deliberately removed (#1304):
+// setup-token returns a long-lived API-key-style token with no
+// subscription metadata, so Claude Code treated the seeded credential
+// as a raw "Claude API" key and reported not-logged-in for Max/Pro
+// users (anthropics/claude-code#34262). Subscription launches must
+// always run the PKCE flow so the envelope carries a subscriptionType;
+// this also drops the implicit dependency on a host `claude` binary.
 func claudeHostAcquire(ctx context.Context, deps launch.HostAcquireDeps) (vault.Secret, error) {
-	// 1. setup-token shortcut.
-	if secret, ok := claudeSetupTokenShortcut(ctx); ok {
-		return secret, nil
-	}
-	// 2. Hosted-callback paste flow.
 	return claudeHostedCallbackAcquire(ctx, deps)
-}
-
-// claudeSetupTokenShortcut tries `claude setup-token`. It returns
-// (secret, true) only on a clean run that yields a usable bare token;
-// any failure (CLI absent, non-zero exit, empty/garbled output,
-// envelope build error) returns (_, false) so the caller falls through
-// to the hosted-callback flow. It never returns an error: a failed
-// shortcut is not itself a fatal acquire failure.
-func claudeSetupTokenShortcut(ctx context.Context) (vault.Secret, bool) {
-	if _, err := exec.LookPath("claude"); err != nil {
-		return vault.Secret{}, false
-	}
-	out, err := exec.CommandContext(ctx, "claude", "setup-token").Output()
-	if err != nil {
-		return vault.Secret{}, false
-	}
-	token := strings.TrimSpace(string(out))
-	if token == "" {
-		return vault.Secret{}, false
-	}
-	envelope, err := claudeEnvelopeFromBareToken(token)
-	if err != nil {
-		return vault.Secret{}, false
-	}
-	return vault.Secret{
-		Value:    envelope,
-		Metadata: vault.Metadata{Type: "oauth_refresh_token"},
-	}, true
 }
 
 // claudeHostedCallbackAcquire runs the PKCE authorization-code flow
@@ -451,7 +420,20 @@ func claudeHostedCallbackAcquire(ctx context.Context, deps launch.HostAcquireDep
 	if err != nil {
 		return vault.Secret{}, err
 	}
-	envelope, err := claudeEnvelopeFromTokenResponse(access, refresh, expiresIn, scopes)
+	// Fetch the subscription tier host-side. A token exchange that
+	// succeeds but yields no subscriptionType reproduces #1304: the
+	// rendered envelope would look like a raw Claude API key and Claude
+	// Code reports not-logged-in. Treat a missing tier as a non-fatal
+	// acquire failure (empty Secret / error) per the HostAcquire
+	// contract — never seed a tier-less envelope silently.
+	subscriptionType, rateLimitTier, err := claudeFetchProfile(ctx, deps.HTTPClient, access)
+	if err != nil {
+		return vault.Secret{}, err
+	}
+	if subscriptionType == "" {
+		return vault.Secret{}, errors.New("claude: profile fetch returned no subscription tier; cannot seed a recognizable Max/Pro session (re-login)")
+	}
+	envelope, err := claudeEnvelopeFromTokenResponse(access, refresh, expiresIn, scopes, subscriptionType, rateLimitTier)
 	if err != nil {
 		return vault.Secret{}, err
 	}
@@ -537,6 +519,78 @@ func claudeExchangeCode(ctx context.Context, client *http.Client, code, verifier
 		granted = append([]string(nil), claudeOAuthScopes...)
 	}
 	return parsed.AccessToken, parsed.RefreshToken, parsed.ExpiresIn, granted, nil
+}
+
+// claudeFetchProfile GETs Claude's OAuth profile endpoint with the
+// freshly-exchanged access token and maps the organization's
+// `organization_type` to the subscriptionType Claude Code recognizes
+// (claude_max -> max, claude_pro -> pro, claude_enterprise ->
+// enterprise, claude_team -> team) and surfaces the organization's
+// `rate_limit_tier` verbatim as rateLimitTier.
+//
+// Claude Code derives the tier from this profile endpoint, not from a
+// token claim, so this host-side fetch is what lets the seeded envelope
+// carry a non-null subscriptionType (#1304). An empty subscriptionType
+// return (unknown/absent organization_type) is a non-fatal signal the
+// caller turns into an acquire failure rather than seeding a tier-less
+// envelope.
+//
+// Mirroring claudeExchangeCode's posture, a non-2xx response surfaces
+// only the HTTP status; the raw body is redacted so a verbose or
+// hostile provider response cannot leak into the user-facing launch
+// error.
+func claudeFetchProfile(ctx context.Context, client *http.Client, accessToken string) (subscriptionType, rateLimitTier string, err error) {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, claudeProfileURL, nil)
+	if err != nil {
+		return "", "", fmt.Errorf("claude: build profile request: %w", err)
+	}
+	req.Header.Set("Authorization", "Bearer "+accessToken)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return "", "", fmt.Errorf("claude: profile fetch: %w", err)
+	}
+	defer resp.Body.Close()
+	respBody, _ := io.ReadAll(resp.Body)
+	if resp.StatusCode/100 != 2 {
+		// Redact the raw body; surface only the status.
+		return "", "", fmt.Errorf("claude: profile fetch failed: provider returned %d", resp.StatusCode)
+	}
+
+	var parsed struct {
+		Organization struct {
+			OrganizationType string `json:"organization_type"`
+			RateLimitTier    string `json:"rate_limit_tier"`
+		} `json:"organization"`
+	}
+	if err := json.Unmarshal(respBody, &parsed); err != nil {
+		return "", "", fmt.Errorf("claude: parse profile response: %w", err)
+	}
+	return mapClaudeOrganizationType(parsed.Organization.OrganizationType), parsed.Organization.RateLimitTier, nil
+}
+
+// mapClaudeOrganizationType maps the profile endpoint's
+// `organization.organization_type` to the subscriptionType string
+// Claude Code recognizes. An unknown or absent type maps to "" so the
+// caller treats it as a missing tier (non-fatal acquire failure) rather
+// than stamping an unrecognized value into the envelope.
+func mapClaudeOrganizationType(orgType string) string {
+	switch orgType {
+	case "claude_max":
+		return "max"
+	case "claude_pro":
+		return "pro"
+	case "claude_enterprise":
+		return "enterprise"
+	case "claude_team":
+		return "team"
+	default:
+		return ""
+	}
 }
 
 // parseClaudeTokenErrorCode extracts the RFC 6749 §5.2 `error` field

--- a/internal/launch/agents/claude_host_acquire_test.go
+++ b/internal/launch/agents/claude_host_acquire_test.go
@@ -55,28 +55,40 @@ func (o *recordingOpener) Open(rawURL string) error {
 	return o.err
 }
 
+// claudeOAuthCapture records what the two legs of the host flow saw, so
+// tests can assert the acquirer's contract with the provider: the token
+// exchange's POST form and the Authorization header the profile fetch
+// presented.
+type claudeOAuthCapture struct {
+	tokenForm   url.Values
+	profileAuth string
+}
+
 // claudeOAuthServer is an httptest server that answers both legs of the
 // host flow the redirectTransport rewrites onto it: the token exchange
 // (path /v1/oauth/token) and the profile fetch (path
 // /api/oauth/profile). orgType is echoed back as the profile's
 // organization_type so a test can drive the tier-mapping. A blank
-// orgType yields a profile with no recognizable tier.
-func claudeOAuthServer(t *testing.T, orgType string) (*httptest.Server, *url.Values) {
+// orgType yields a profile with no recognizable tier. The returned
+// capture records the token-exchange form and the profile request's
+// Authorization header.
+func claudeOAuthServer(t *testing.T, orgType string) (*httptest.Server, *claudeOAuthCapture) {
 	t.Helper()
-	var gotForm url.Values
+	cap := &claudeOAuthCapture{}
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		w.Header().Set("Content-Type", "application/json")
 		switch r.URL.Path {
 		case "/api/oauth/profile":
+			cap.profileAuth = r.Header.Get("Authorization")
 			_, _ = io.WriteString(w, `{"organization":{"organization_type":"`+orgType+`","rate_limit_tier":"default_claude_max_20x"}}`)
 		default: // token exchange
 			_ = r.ParseForm()
-			gotForm = r.PostForm
+			cap.tokenForm = r.PostForm
 			_, _ = io.WriteString(w, `{"access_token":"acc-tok","refresh_token":"ref-tok","expires_in":28800,"token_type":"Bearer","scope":"user:inference"}`)
 		}
 	}))
 	t.Cleanup(srv.Close)
-	return srv, &gotForm
+	return srv, cap
 }
 
 func scriptedPrompter(value string, err error) func(context.Context, io.Writer) (string, error) {
@@ -95,7 +107,7 @@ func claudeHostAcquireBinding(t *testing.T) launch.FileBinding {
 }
 
 func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
-	srv, gotFormP := claudeOAuthServer(t, "claude_max")
+	srv, capture := claudeOAuthServer(t, "claude_max")
 
 	opener := &recordingOpener{}
 	var out bytes.Buffer
@@ -131,8 +143,14 @@ func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
 	if !strings.Contains(out.String(), "client_id=9d1c250a") {
 		t.Errorf("Out missing the authorize URL; got %q", out.String())
 	}
+	// The profile fetch must present the freshly-exchanged access token
+	// as a Bearer credential; that is what authorizes reading the
+	// subscription tier (#1304).
+	if capture.profileAuth != "Bearer acc-tok" {
+		t.Errorf("profile Authorization = %q, want %q", capture.profileAuth, "Bearer acc-tok")
+	}
 	// Token exchange used authorization_code + PKCE verifier, no secret.
-	gotForm := *gotFormP
+	gotForm := capture.tokenForm
 	if gotForm.Get("grant_type") != "authorization_code" {
 		t.Errorf("grant_type = %q, want authorization_code", gotForm.Get("grant_type"))
 	}

--- a/internal/launch/agents/claude_host_acquire_test.go
+++ b/internal/launch/agents/claude_host_acquire_test.go
@@ -8,9 +8,6 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
-	"os"
-	"path/filepath"
-	"runtime"
 	"strings"
 	"testing"
 
@@ -18,18 +15,16 @@ import (
 	"github.com/ALRubinger/aileron/internal/launch/agents"
 )
 
-// Claude host-acquire contract (#1270):
+// Claude host-acquire contract (#1270, #1304):
 //
 //   - Hosted-callback happy path: browser opened with the consent URL,
-//     code pasted on the host, code exchanged → Secret round-trips the
-//     binding's own Render; expiresAt is in milliseconds.
-//   - setup-token shortcut: when `claude` is on PATH and prints a bare
-//     token, the shortcut path seeds an accessToken-only envelope
-//     (no refresh/expiry).
-//   - CLI absent: hosted-callback path taken (browser + prompter
-//     consulted).
-//   - Acquire failure (token 400 / prompter error / state mismatch):
-//     returns an error so the launcher falls back to in-container login.
+//     code pasted on the host, code exchanged, profile fetched → Secret
+//     round-trips the binding's own Render; expiresAt is in
+//     milliseconds; subscriptionType is stamped from the profile so
+//     Claude Code recognizes a Max/Pro session (#1304).
+//   - Acquire failure (token 400 / prompter error / state mismatch /
+//     profile fetch yields no tier): returns an error so the launcher
+//     falls back to in-container login.
 //   - Provider error body is not leaked into the returned error.
 
 // redirectTransport rewrites every outbound request to the test
@@ -60,32 +55,28 @@ func (o *recordingOpener) Open(rawURL string) error {
 	return o.err
 }
 
-// emptyPATH points PATH at a directory with no `claude` binary so the
-// setup-token shortcut's LookPath misses and the hosted-callback path
-// is taken.
-func emptyPATH(t *testing.T) {
+// claudeOAuthServer is an httptest server that answers both legs of the
+// host flow the redirectTransport rewrites onto it: the token exchange
+// (path /v1/oauth/token) and the profile fetch (path
+// /api/oauth/profile). orgType is echoed back as the profile's
+// organization_type so a test can drive the tier-mapping. A blank
+// orgType yields a profile with no recognizable tier.
+func claudeOAuthServer(t *testing.T, orgType string) (*httptest.Server, *url.Values) {
 	t.Helper()
-	t.Setenv("PATH", t.TempDir())
-}
-
-// stubClaudeOnPATH writes a fake `claude` executable that, for
-// `setup-token`, prints stdoutLine and exits 0. Skips on Windows where
-// the shell-script stub is not executable.
-func stubClaudeOnPATH(t *testing.T, stdoutLine string) {
-	t.Helper()
-	if runtime.GOOS == "windows" {
-		t.Skip("shell-script stub is not executable on windows")
-	}
-	dir := t.TempDir()
-	// Escape single quotes (' -> '\'') so an stdoutLine carrying one
-	// cannot break the single-quoted shell literal.
-	escaped := strings.ReplaceAll(stdoutLine, "'", `'\''`)
-	script := "#!/bin/sh\nif [ \"$1\" = \"setup-token\" ]; then printf '%s\\n' '" + escaped + "'; exit 0; fi\nexit 1\n"
-	bin := filepath.Join(dir, "claude")
-	if err := os.WriteFile(bin, []byte(script), 0o755); err != nil {
-		t.Fatalf("write stub: %v", err)
-	}
-	t.Setenv("PATH", dir)
+	var gotForm url.Values
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		switch r.URL.Path {
+		case "/api/oauth/profile":
+			_, _ = io.WriteString(w, `{"organization":{"organization_type":"`+orgType+`","rate_limit_tier":"default_claude_max_20x"}}`)
+		default: // token exchange
+			_ = r.ParseForm()
+			gotForm = r.PostForm
+			_, _ = io.WriteString(w, `{"access_token":"acc-tok","refresh_token":"ref-tok","expires_in":28800,"token_type":"Bearer","scope":"user:inference"}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, &gotForm
 }
 
 func scriptedPrompter(value string, err error) func(context.Context, io.Writer) (string, error) {
@@ -104,16 +95,7 @@ func claudeHostAcquireBinding(t *testing.T) launch.FileBinding {
 }
 
 func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
-	emptyPATH(t)
-
-	var gotForm url.Values
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
-		_ = r.ParseForm()
-		gotForm = r.PostForm
-		w.Header().Set("Content-Type", "application/json")
-		_, _ = io.WriteString(w, `{"access_token":"acc-tok","refresh_token":"ref-tok","expires_in":28800,"token_type":"Bearer","scope":"user:inference"}`)
-	}))
-	defer srv.Close()
+	srv, gotFormP := claudeOAuthServer(t, "claude_max")
 
 	opener := &recordingOpener{}
 	var out bytes.Buffer
@@ -150,6 +132,7 @@ func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
 		t.Errorf("Out missing the authorize URL; got %q", out.String())
 	}
 	// Token exchange used authorization_code + PKCE verifier, no secret.
+	gotForm := *gotFormP
 	if gotForm.Get("grant_type") != "authorization_code" {
 		t.Errorf("grant_type = %q, want authorization_code", gotForm.Get("grant_type"))
 	}
@@ -162,11 +145,17 @@ func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
 	if gotForm.Get("client_secret") != "" {
 		t.Error("client_secret sent; Claude Code is a public client (PKCE only)")
 	}
-	// expiresAt in the seeded envelope must be milliseconds.
+	// expiresAt in the seeded envelope must be milliseconds, and the
+	// subscription tier must be stamped from the profile so Claude Code
+	// recognizes a Max/Pro session (#1304). Assert presence + shape
+	// rather than a hardcoded guess: subscriptionType is non-empty and
+	// equals the mapped value for the profile's organization_type.
 	var env struct {
 		ClaudeAiOauth struct {
-			AccessToken string `json:"accessToken"`
-			ExpiresAt   int64  `json:"expiresAt"`
+			AccessToken      string `json:"accessToken"`
+			ExpiresAt        int64  `json:"expiresAt"`
+			SubscriptionType string `json:"subscriptionType"`
+			RateLimitTier    string `json:"rateLimitTier"`
 		} `json:"claudeAiOauth"`
 	}
 	if err := json.Unmarshal(secret.Value, &env); err != nil {
@@ -178,84 +167,42 @@ func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
 	if env.ClaudeAiOauth.ExpiresAt <= 1_000_000_000_000 {
 		t.Errorf("seeded expiresAt = %d, want milliseconds magnitude", env.ClaudeAiOauth.ExpiresAt)
 	}
+	if env.ClaudeAiOauth.SubscriptionType == "" {
+		t.Error("seeded subscriptionType is empty; Claude Code will treat this as a raw API key (#1304)")
+	}
+	if env.ClaudeAiOauth.SubscriptionType != "max" {
+		t.Errorf("seeded subscriptionType = %q, want max (mapped from organization_type=claude_max)",
+			env.ClaudeAiOauth.SubscriptionType)
+	}
+	if env.ClaudeAiOauth.RateLimitTier == "" {
+		t.Error("seeded rateLimitTier is empty; want the profile's rate_limit_tier carried through")
+	}
 }
 
-func TestClaudeHostAcquire_SetupTokenShortcut(t *testing.T) {
-	stubClaudeOnPATH(t, "sk-ant-bare-token")
+// TestClaudeHostAcquire_ProfileTierMissingReturnsError covers a clean
+// token exchange whose profile fetch yields no recognizable
+// subscription tier (#1304): the acquirer must NOT seed a tier-less
+// envelope; it returns an empty Secret + error so the launcher falls
+// back to the in-container login.
+func TestClaudeHostAcquire_ProfileTierMissingReturnsError(t *testing.T) {
+	srv, _ := claudeOAuthServer(t, "claude_unknown")
 
-	opener := &recordingOpener{}
 	fb := claudeHostAcquireBinding(t)
-	// HTTPClient/CodePrompter must NOT be consulted on the shortcut
-	// path; pass a prompter that fails the test if called.
 	secret, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
-		Ctx:     context.Background(),
-		Browser: opener,
-		CodePrompter: func(context.Context, io.Writer) (string, error) {
-			t.Fatal("CodePrompter consulted on the setup-token shortcut path")
-			return "", nil
-		},
+		Ctx:          context.Background(),
+		HTTPClient:   testHTTPClient(srv.URL),
+		Browser:      &recordingOpener{},
+		CodePrompter: scriptedPrompter("the-code", nil),
 	})
-	if err != nil {
-		t.Fatalf("HostAcquire (shortcut): %v", err)
+	if err == nil {
+		t.Fatal("expected error when the profile fetch yields no subscription tier")
 	}
-	if opener.opened != "" {
-		t.Errorf("browser opened on shortcut path: %q", opener.opened)
-	}
-	var env struct {
-		ClaudeAiOauth struct {
-			AccessToken  string `json:"accessToken"`
-			RefreshToken string `json:"refreshToken"`
-			ExpiresAt    int64  `json:"expiresAt"`
-		} `json:"claudeAiOauth"`
-	}
-	if err := json.Unmarshal(secret.Value, &env); err != nil {
-		t.Fatalf("unmarshal shortcut envelope: %v", err)
-	}
-	if env.ClaudeAiOauth.AccessToken != "sk-ant-bare-token" {
-		t.Errorf("accessToken = %q, want sk-ant-bare-token", env.ClaudeAiOauth.AccessToken)
-	}
-	if env.ClaudeAiOauth.RefreshToken != "" {
-		t.Errorf("refreshToken = %q, want empty on setup-token path", env.ClaudeAiOauth.RefreshToken)
-	}
-	if env.ClaudeAiOauth.ExpiresAt != 0 {
-		t.Errorf("expiresAt = %d, want 0 on setup-token path", env.ClaudeAiOauth.ExpiresAt)
-	}
-}
-
-func TestClaudeHostAcquire_CLIAbsentTakesHostedCallback(t *testing.T) {
-	emptyPATH(t)
-
-	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
-		_, _ = io.WriteString(w, `{"access_token":"acc","expires_in":100}`)
-	}))
-	defer srv.Close()
-
-	opener := &recordingOpener{}
-	prompterCalled := false
-	fb := claudeHostAcquireBinding(t)
-	_, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
-		Ctx:        context.Background(),
-		HTTPClient: testHTTPClient(srv.URL),
-		Browser:    opener,
-		CodePrompter: func(context.Context, io.Writer) (string, error) {
-			prompterCalled = true
-			return "bare-code-no-state", nil
-		},
-	})
-	if err != nil {
-		t.Fatalf("HostAcquire: %v", err)
-	}
-	if opener.opened == "" {
-		t.Error("browser not opened on the hosted-callback path")
-	}
-	if !prompterCalled {
-		t.Error("code prompter not consulted on the hosted-callback path")
+	if len(secret.Value) != 0 {
+		t.Error("Secret must be empty when no subscription tier could be obtained")
 	}
 }
 
 func TestClaudeHostAcquire_TokenEndpoint400ReturnsError(t *testing.T) {
-	emptyPATH(t)
-
 	const secretLeak = "super-secret-token-hint-DO-NOT-LEAK"
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
 		w.WriteHeader(http.StatusBadRequest)
@@ -288,8 +235,6 @@ func TestClaudeHostAcquire_TokenEndpoint400ReturnsError(t *testing.T) {
 }
 
 func TestClaudeHostAcquire_PrompterErrorReturnsError(t *testing.T) {
-	emptyPATH(t)
-
 	fb := claudeHostAcquireBinding(t)
 	_, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
 		Ctx:          context.Background(),
@@ -302,8 +247,6 @@ func TestClaudeHostAcquire_PrompterErrorReturnsError(t *testing.T) {
 }
 
 func TestClaudeHostAcquire_StateMismatchReturnsError(t *testing.T) {
-	emptyPATH(t)
-
 	// A token server that would succeed, to prove the abort happens
 	// BEFORE the exchange when the pasted state does not match.
 	exchangeHit := false
@@ -329,8 +272,6 @@ func TestClaudeHostAcquire_StateMismatchReturnsError(t *testing.T) {
 }
 
 func TestClaudeHostAcquire_BrowserOpenFailureIsNonFatal(t *testing.T) {
-	emptyPATH(t)
-
 	fb := claudeHostAcquireBinding(t)
 	prompterCalled := false
 	secret, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
@@ -355,8 +296,6 @@ func TestClaudeHostAcquire_BrowserOpenFailureIsNonFatal(t *testing.T) {
 }
 
 func TestClaudeHostAcquire_NilPrompterIsNonFatal(t *testing.T) {
-	emptyPATH(t)
-
 	fb := claudeHostAcquireBinding(t)
 	secret, err := fb.HostAcquire(context.Background(), launch.HostAcquireDeps{
 		Ctx:     context.Background(),

--- a/internal/launch/agents/claude_oauth_internal_test.go
+++ b/internal/launch/agents/claude_oauth_internal_test.go
@@ -18,9 +18,8 @@ import (
 //     challenge + method, the hosted-callback redirect, the state, and
 //     the requested scopes.
 //   - claudeEnvelopeFromTokenResponse emits an envelope that passes
-//     validateClaudeEnvelope and whose expiresAt is in MILLISECONDS.
-//   - claudeEnvelopeFromBareToken populates accessToken only; refresh,
-//     expiry, and scopes are absent.
+//     validateClaudeEnvelope and whose expiresAt is in MILLISECONDS,
+//     stamping the subscriptionType / rateLimitTier it is given.
 
 func TestBuildClaudeAuthorizeURL_CarriesPKCEStateScopesAndCallback(t *testing.T) {
 	pkce := oauth.PKCEPair{Verifier: "ver", Challenge: "chal-xyz", Method: "S256"}
@@ -58,7 +57,7 @@ func TestBuildClaudeAuthorizeURL_CarriesPKCEStateScopesAndCallback(t *testing.T)
 
 func TestClaudeEnvelopeFromTokenResponse_ExpiresAtIsMilliseconds(t *testing.T) {
 	scopes := []string{"user:inference"}
-	b, err := claudeEnvelopeFromTokenResponse("access-tok", "refresh-tok", 28800, scopes)
+	b, err := claudeEnvelopeFromTokenResponse("access-tok", "refresh-tok", 28800, scopes, "max", "default_claude_max_20x")
 	if err != nil {
 		t.Fatalf("claudeEnvelopeFromTokenResponse: %v", err)
 	}
@@ -85,10 +84,18 @@ func TestClaudeEnvelopeFromTokenResponse_ExpiresAtIsMilliseconds(t *testing.T) {
 	if len(env.ClaudeAiOauth.Scopes) != 1 || env.ClaudeAiOauth.Scopes[0] != "user:inference" {
 		t.Errorf("scopes = %v, want [user:inference]", env.ClaudeAiOauth.Scopes)
 	}
+	// The subscription tier / rate-limit tier must be stamped so Claude
+	// Code recognizes the credential as a Max/Pro session (#1304).
+	if env.ClaudeAiOauth.SubscriptionType != "max" {
+		t.Errorf("subscriptionType = %q, want max", env.ClaudeAiOauth.SubscriptionType)
+	}
+	if env.ClaudeAiOauth.RateLimitTier != "default_claude_max_20x" {
+		t.Errorf("rateLimitTier = %q, want default_claude_max_20x", env.ClaudeAiOauth.RateLimitTier)
+	}
 }
 
 func TestClaudeEnvelopeFromTokenResponse_NoExpiryWhenZero(t *testing.T) {
-	b, err := claudeEnvelopeFromTokenResponse("a", "r", 0, nil)
+	b, err := claudeEnvelopeFromTokenResponse("a", "r", 0, nil, "pro", "")
 	if err != nil {
 		t.Fatalf("claudeEnvelopeFromTokenResponse: %v", err)
 	}
@@ -101,29 +108,106 @@ func TestClaudeEnvelopeFromTokenResponse_NoExpiryWhenZero(t *testing.T) {
 	}
 }
 
-func TestClaudeEnvelopeFromBareToken_AccessTokenOnly(t *testing.T) {
-	b, err := claudeEnvelopeFromBareToken("bare-long-lived-token")
+// TestClaudeEnvelopeFromTokenResponse_OmitsEmptyTierFields proves the
+// tier fields are absent (not present-but-empty) when no tier is
+// supplied, so an envelope rendered from a vault entry that never
+// carried a tier round-trips unchanged.
+func TestClaudeEnvelopeFromTokenResponse_OmitsEmptyTierFields(t *testing.T) {
+	b, err := claudeEnvelopeFromTokenResponse("a", "r", 0, nil, "", "")
 	if err != nil {
-		t.Fatalf("claudeEnvelopeFromBareToken: %v", err)
+		t.Fatalf("claudeEnvelopeFromTokenResponse: %v", err)
 	}
-	if err := validateClaudeEnvelope(b); err != nil {
-		t.Fatalf("bare-token envelope failed validation: %v", err)
+	if strings.Contains(string(b), "subscriptionType") {
+		t.Errorf("envelope %q should omit subscriptionType when empty", b)
 	}
-	var env claudeCredentialEnvelope
-	if err := json.Unmarshal(b, &env); err != nil {
-		t.Fatalf("unmarshal: %v", err)
+	if strings.Contains(string(b), "rateLimitTier") {
+		t.Errorf("envelope %q should omit rateLimitTier when empty", b)
 	}
-	if env.ClaudeAiOauth.AccessToken != "bare-long-lived-token" {
-		t.Errorf("accessToken = %q, want bare-long-lived-token", env.ClaudeAiOauth.AccessToken)
+}
+
+// TestMapClaudeOrganizationType maps the profile endpoint's
+// organization_type to the subscriptionType Claude Code recognizes;
+// an unknown type maps to "" so the acquirer treats it as a missing
+// tier rather than stamping an unrecognized value.
+func TestMapClaudeOrganizationType(t *testing.T) {
+	tests := map[string]string{
+		"claude_max":        "max",
+		"claude_pro":        "pro",
+		"claude_enterprise": "enterprise",
+		"claude_team":       "team",
+		"":                  "",
+		"something_else":    "",
 	}
-	if env.ClaudeAiOauth.RefreshToken != "" {
-		t.Errorf("refreshToken = %q, want empty (setup-token has no refresh)", env.ClaudeAiOauth.RefreshToken)
+	for in, want := range tests {
+		if got := mapClaudeOrganizationType(in); got != want {
+			t.Errorf("mapClaudeOrganizationType(%q) = %q, want %q", in, got, want)
+		}
 	}
-	if env.ClaudeAiOauth.ExpiresAt != 0 {
-		t.Errorf("expiresAt = %d, want 0 (setup-token has no expiry)", env.ClaudeAiOauth.ExpiresAt)
+}
+
+// TestClaudeFetchProfile_MapsOrganizationType drives the profile fetch
+// against a canned 200 body and asserts the mapped tier + rate-limit
+// tier, and that the access token is sent as a Bearer credential.
+func TestClaudeFetchProfile_MapsOrganizationType(t *testing.T) {
+	client := cannedTokenClient(http.StatusOK,
+		`{"organization":{"organization_type":"claude_max","rate_limit_tier":"default_claude_max_20x"}}`)
+
+	sub, rate, err := claudeFetchProfile(context.Background(), client, "acc-tok")
+	if err != nil {
+		t.Fatalf("claudeFetchProfile: %v", err)
 	}
-	if len(env.ClaudeAiOauth.Scopes) != 0 {
-		t.Errorf("scopes = %v, want empty (setup-token has no scope list)", env.ClaudeAiOauth.Scopes)
+	if sub != "max" {
+		t.Errorf("subscriptionType = %q, want max", sub)
+	}
+	if rate != "default_claude_max_20x" {
+		t.Errorf("rateLimitTier = %q, want default_claude_max_20x", rate)
+	}
+}
+
+// TestClaudeFetchProfile_NonOKRedactsBody asserts a non-2xx profile
+// response surfaces only the status, never the raw body (mirroring the
+// token-exchange posture).
+func TestClaudeFetchProfile_NonOKRedactsBody(t *testing.T) {
+	const leak = "profile-body-DO-NOT-LEAK"
+	client := cannedTokenClient(http.StatusUnauthorized, leak)
+
+	_, _, err := claudeFetchProfile(context.Background(), client, "acc-tok")
+	if err == nil {
+		t.Fatal("expected error on non-2xx profile response")
+	}
+	if !strings.Contains(err.Error(), "401") {
+		t.Errorf("err = %v, want the bare status 401 surfaced", err)
+	}
+	if strings.Contains(err.Error(), leak) {
+		t.Errorf("profile body leaked into error: %v", err)
+	}
+}
+
+// TestClaudeFetchProfile_UnknownTypeYieldsEmpty covers a clean 200 whose
+// organization_type is unrecognized: subscriptionType is "" so the
+// acquirer turns it into a non-fatal acquire failure rather than seeding
+// a tier-less envelope.
+func TestClaudeFetchProfile_UnknownTypeYieldsEmpty(t *testing.T) {
+	client := cannedTokenClient(http.StatusOK,
+		`{"organization":{"organization_type":"claude_unknown"}}`)
+
+	sub, _, err := claudeFetchProfile(context.Background(), client, "acc-tok")
+	if err != nil {
+		t.Fatalf("claudeFetchProfile: %v", err)
+	}
+	if sub != "" {
+		t.Errorf("subscriptionType = %q, want empty for an unknown organization_type", sub)
+	}
+}
+
+// TestClaudeFetchProfile_MalformedJSON covers a 2xx body that is not
+// valid JSON.
+func TestClaudeFetchProfile_MalformedJSON(t *testing.T) {
+	client := cannedTokenClient(http.StatusOK, `{not valid json`)
+
+	_, _, err := claudeFetchProfile(context.Background(), client, "acc-tok")
+	if err == nil || !strings.Contains(err.Error(), "parse profile response") {
+		t.Fatalf("expected parse error, got %v", err)
 	}
 }
 

--- a/internal/launch/agents/codex_auth.go
+++ b/internal/launch/agents/codex_auth.go
@@ -433,10 +433,10 @@ type codexDeviceTokenResponse struct {
 // and host-login is enabled; it returns a vault.Secret the launcher PUTs
 // to agents/codex/oauth and renders before the container starts.
 //
-// Unlike Claude (which has a setup-token CLI shortcut and a paste-back
-// hosted-callback fallback), Codex has a single mechanism: the
-// OpenAI device-authorization flow. It needs no localhost callback and
-// no host CLI, so it is pure Go end-to-end:
+// Unlike Claude (which uses a paste-back hosted-callback PKCE flow),
+// Codex has a single mechanism: the OpenAI device-authorization flow.
+// It needs no localhost callback and no host CLI, so it is pure Go
+// end-to-end:
 //
 //  1. Request a device code (codexRequestDeviceCode).
 //  2. Surface the verification URL + user_code on deps.Out and open the

--- a/internal/launch/authspec.go
+++ b/internal/launch/authspec.go
@@ -157,10 +157,11 @@ type FileBinding struct {
 	// then a token exchange) and returns the vault.Secret the launcher
 	// then PUTs through the daemon and renders to the bind-mounted
 	// file — exactly as a vault-resident credential would be. The flow
-	// is pure Go HTTP plus an optional opportunistic CLI shortcut (for
-	// example Claude's `claude setup-token`). No token is ever placed
-	// in the agent's environment; the acquired Secret follows the same
-	// vault-seeded path as every other credential (ADR-0025).
+	// is pure Go HTTP; an acquirer may layer on an optional opportunistic
+	// CLI shortcut, but the baseline must not require the agent binary on
+	// the host. No token is ever placed in the agent's environment; the
+	// acquired Secret follows the same vault-seeded path as every other
+	// credential (ADR-0025).
 	//
 	// Contract:
 	//
@@ -172,9 +173,8 @@ type FileBinding struct {
 	//   - The acquirer must NOT require the agent CLI to be installed on
 	//     the host. The baseline path is pure Go (HTTP + browser open).
 	//     An acquirer may opportunistically shell out to the agent
-	//     binary as a shortcut (Claude tries `claude setup-token` when
-	//     it is on PATH), but it must fall back to the pure-Go flow when
-	//     the binary is absent or the shortcut fails.
+	//     binary as a shortcut, but it must fall back to the pure-Go flow
+	//     when the binary is absent or the shortcut fails.
 	//
 	//   - A returned Secret with an empty Value, or a cancelled/failed
 	//     acquire (non-nil error), is non-fatal: the launcher logs a


### PR DESCRIPTION
## Summary

A host-acquired Claude subscription envelope was written without `subscriptionType`, so Claude Code in the sandbox treated the seeded credential as a raw "Claude API" key rather than a Max/Pro session and reported not-logged-in (matches anthropics/claude-code#34262).

This implements Option (A) from the triage of #1304: keep the host browser + host-terminal paste PKCE flow, drop the setup-token shortcut, and after the token exchange fetch the tier host-side and stamp `subscriptionType` (+ `rateLimitTier`) into the envelope.

### Changes (`internal/launch/agents/claude_auth.go`)

- Added `SubscriptionType` / `RateLimitTier` (`json:",omitempty"`) to the `claudeAiOauth` struct.
- Added `claudeFetchProfile` that `GET`s `https://api.anthropic.com/api/oauth/profile` with `Authorization: Bearer <accessToken>`, mapping `organization.organization_type` (`claude_max`->`max`, `claude_pro`->`pro`, `claude_enterprise`->`enterprise`, `claude_team`->`team`) and `organization.rate_limit_tier`. Non-2xx redacts the body and surfaces only the status, mirroring `claudeExchangeCode`. The `user:profile` scope was already requested.
- `claudeHostedCallbackAcquire` now fetches the profile after the token exchange and passes the tier into `claudeEnvelopeFromTokenResponse`, so the rendered `.credentials.json` carries a non-null `subscriptionType`.
- Removed the `claude setup-token` shortcut from `claudeHostAcquire` (and the now-dead `claudeSetupTokenShortcut` / `claudeEnvelopeFromBareToken` and their tests). Subscription launches always use PKCE; this also drops the implicit host `claude`-on-PATH dependency.
- A clean exchange whose profile fetch yields no recognizable tier is treated as a non-fatal acquire failure (empty Secret + error) per the documented `HostAcquire` fallback contract, never seeding a tier-less envelope silently.

Stale doc comments referencing the removed setup-token shortcut were updated in `authspec.go`, `claude.go`, and `codex_auth.go`.

## Test plan

- `TestClaudeHostAcquire_HostedCallbackHappyPath` now drives both the token exchange and the `/api/oauth/profile` call against one httptest server (via the existing `redirectTransport`) returning `organization_type=claude_max`, and asserts the rendered envelope round-trips `Render` and carries a non-null `subscriptionType` (`=max`) and `rateLimitTier` — presence/shape, not a hardcoded guess.
- `TestClaudeHostAcquire_ProfileTierMissingReturnsError` covers the non-fatal-failure path when the profile yields no recognizable tier.
- New internal tests: `claudeFetchProfile` happy path, non-2xx body redaction, unknown-type -> empty, malformed JSON; `mapClaudeOrganizationType` table; tier-field omitempty.
- Updated `claudeEnvelopeFromTokenResponse` tests for the new signature; removed the setup-token tests.
- `go build ./internal/...`, `go vet ./internal/launch/...`, and `go test ./internal/launch/...` all pass (agents coverage 90.0%).

Closes #1304

🤖 Generated with [Claude Code](https://claude.com/claude-code)
