### PR TITLE
fix(vault): make fully-qualified agents/<name>/oauth the canonical form

### DIFF
--- a/cmd/aileron/vault.go
+++ b/cmd/aileron/vault.go
@@ -61,11 +61,11 @@ const envVaultPassphrase = "AILERON_VAULT_PASSPHRASE"
 const vaultUsage = `usage:
   aileron vault init [--passphrase-file <path>]
   aileron vault put agents/<name>/oauth --from-file <path>
-  aileron vault delete <name> [--yes]
+  aileron vault delete agents/<name>/oauth [--yes]
   aileron vault list [--scope agent|user|all] [--prefix agents/] [--json]
 
-The <name> delete accepts is exactly what vault list prints (e.g. claude);
-the full agents/<name>/oauth path form is also accepted.`
+vault delete takes the fully-qualified agents/<name>/oauth path, exactly
+what vault list prints for an agent entry.`
 
 // runVault dispatches `aileron vault <subcommand>`.
 //
@@ -100,37 +100,26 @@ func runVault(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 // client-side before issuing an HTTP call, so the operator CLI can never
 // reach a non-agent vault key (ADR-0025).
 //
-// Two equivalent forms are accepted so the identifier round-trips with
-// `vault list`, which prints the bare agent name (#1302):
-//   - the bare agent name `list` emits, e.g. `claude`
-//   - the full path form, e.g. `agents/claude/oauth`
+// Only the fully-qualified path form is accepted, exactly what `vault
+// list` prints for an agent entry (#1317):
+//   - agents/<name>/oauth, e.g. `agents/claude/oauth`
 //
-// Both resolve to the same <name>; whatever `list` shows can be pasted
-// straight into delete.
+// Whatever `list` shows for an agent can be pasted straight into delete.
 func agentOAuthPathName(arg string) (string, error) {
 	const prefix = "agents/"
 	const suffix = "/oauth"
-	// Full path form: agents/<name>/oauth. Guard the length before
-	// slicing — "agents/oauth" passes both HasPrefix and HasSuffix (the
-	// prefix and suffix overlap) but would slice out of range.
-	if strings.HasPrefix(arg, prefix) || strings.HasSuffix(arg, suffix) {
-		if len(arg) < len(prefix)+len(suffix) ||
-			!strings.HasPrefix(arg, prefix) || !strings.HasSuffix(arg, suffix) {
-			return "", fmt.Errorf("name must be an agent name or agents/<name>/oauth (got %q)", arg)
-		}
-		name := arg[len(prefix) : len(arg)-len(suffix)]
-		if name == "" || strings.Contains(name, "/") {
-			return "", fmt.Errorf("name must be an agent name or agents/<name>/oauth (got %q)", arg)
-		}
-		return name, nil
+	// Fully-qualified form only: agents/<name>/oauth. Guard the length
+	// before slicing — "agents/oauth" passes both HasPrefix and HasSuffix
+	// (the prefix and suffix overlap) but would slice out of range.
+	if len(arg) < len(prefix)+len(suffix) ||
+		!strings.HasPrefix(arg, prefix) || !strings.HasSuffix(arg, suffix) {
+		return "", fmt.Errorf("name must be agents/<name>/oauth (got %q)", arg)
 	}
-	// Bare-name form: the identifier `vault list` prints. Reject any
-	// path-shaped or empty value so a stray prefix/suffix can't slip a
-	// non-agent key through.
-	if arg == "" || strings.Contains(arg, "/") {
-		return "", fmt.Errorf("name must be an agent name or agents/<name>/oauth (got %q)", arg)
+	name := arg[len(prefix) : len(arg)-len(suffix)]
+	if name == "" || strings.Contains(name, "/") {
+		return "", fmt.Errorf("name must be agents/<name>/oauth (got %q)", arg)
 	}
-	return arg, nil
+	return name, nil
 }
 
 // agentCredentialsBody is the local minimal subset of the
@@ -238,7 +227,7 @@ func runVaultPut(args []string, stdout, stderr io.Writer) int {
 func runVaultDelete(args []string, stdin io.Reader, stdout, stderr io.Writer) int {
 	pathArg, flagArgs, ok := splitPathArg(args)
 	if !ok {
-		fmt.Fprintln(stderr, "usage: aileron vault delete <name> [--yes] (name as shown by vault list, or agents/<name>/oauth)")
+		fmt.Fprintln(stderr, "usage: aileron vault delete agents/<name>/oauth [--yes] (exactly what vault list prints)")
 		return 1
 	}
 	flags := flag.NewFlagSet("vault delete", flag.ContinueOnError)
@@ -364,7 +353,7 @@ func runVaultList(args []string, stdout, stderr io.Writer) int {
 				}
 				emitted++
 			} else {
-				lines = append(lines, a.Name)
+				lines = append(lines, "agents/"+a.Name+"/oauth")
 			}
 		}
 	}
@@ -389,7 +378,7 @@ func runVaultList(args []string, stdout, stderr io.Writer) int {
 				}
 				emitted++
 			} else {
-				lines = append(lines, u.Service)
+				lines = append(lines, "user/"+u.Service)
 			}
 		}
 	}

--- a/cmd/aileron/vault_verbs_test.go
+++ b/cmd/aileron/vault_verbs_test.go
@@ -124,21 +124,40 @@ func TestRunVaultDelete_YesSkipsPromptAndDeletes(t *testing.T) {
 	}
 }
 
-// #1302: the identifier `vault list` prints (the bare agent name) must
-// be deletable as-is — copy a list line, paste it into delete, done. The
-// full agents/<name>/oauth path form keeps working too.
-func TestRunVaultDelete_AcceptsBareNameFromList(t *testing.T) {
-	const listed = "codex" // exactly what `vault list` prints for this entry
+// #1317 flips the canonical form: `vault list` now prints the
+// fully-qualified agents/<name>/oauth, and delete accepts ONLY that form.
+// Regression for the flip — the bare agent name (what #1302/#1310
+// accepted) is now rejected before any HTTP, while the fully-qualified
+// line `list` emits round-trips straight into delete.
+func TestRunVaultDelete_AcceptsFullyQualifiedFromList(t *testing.T) {
+	const bare = "codex"                       // the pre-#1317 form, now rejected
+	const listed = "agents/" + bare + "/oauth" // exactly what `vault list` prints
+
+	// The bare name is rejected client-side, no DELETE issued.
+	bareCalled := false
+	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
+		bareCalled = true
+		w.WriteHeader(http.StatusNoContent)
+	})
+	var bstdout, bstderr bytes.Buffer
+	if code := runVault([]string{"delete", bare, "--yes"},
+		strings.NewReader(""), &bstdout, &bstderr); code == 0 {
+		t.Errorf("bare name %q: exit = 0, want non-zero (bare form no longer accepted)", bare)
+	}
+	if bareCalled {
+		t.Errorf("bare name %q: HTTP issued for rejected form", bare)
+	}
+
+	// The fully-qualified line from `list` round-trips into delete.
 	gotDelete := false
 	fakeVaultServer(t, func(w http.ResponseWriter, r *http.Request) {
-		if r.Method == http.MethodDelete && r.URL.Path == "/vault/agents/"+listed+"/credentials" {
+		if r.Method == http.MethodDelete && r.URL.Path == "/vault/agents/"+bare+"/credentials" {
 			gotDelete = true
 			w.WriteHeader(http.StatusNoContent)
 			return
 		}
 		t.Errorf("unexpected request: %s %s", r.Method, r.URL.Path)
 	})
-
 	var stdout, stderr bytes.Buffer
 	code := runVault([]string{"delete", listed, "--yes"},
 		strings.NewReader(""), &stdout, &stderr)
@@ -146,31 +165,33 @@ func TestRunVaultDelete_AcceptsBareNameFromList(t *testing.T) {
 		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 	}
 	if !gotDelete {
-		t.Errorf("DELETE not issued for bare name %q", listed)
+		t.Errorf("DELETE not issued for fully-qualified %q", listed)
 	}
-	if !strings.Contains(stdout.String(), "Deleted agents/"+listed+"/oauth") {
+	if !strings.Contains(stdout.String(), "Deleted agents/"+bare+"/oauth") {
 		t.Errorf("stdout = %q", stdout.String())
 	}
 }
 
-// The list-output == delete-input contract (#1302): every name `vault
-// list` emits must resolve, via the delete validator, back to the same
-// agent the daemon keys the DELETE on. This pins the round-trip directly
-// against the identifier list prints, so the two verbs can't drift apart.
+// The list-output == delete-input contract (#1317): every line `vault
+// list` emits for an agent must resolve, via the delete validator, back
+// to the same agent the daemon keys the DELETE on. list now prints the
+// fully-qualified agents/<name>/oauth, so feed exactly that. The bare
+// name (the pre-#1317 form) must no longer validate.
 func TestVaultListNamesRoundTripIntoDelete(t *testing.T) {
-	for _, listed := range []string{"claude", "codex", "my-agent"} {
+	for _, agent := range []string{"claude", "codex", "my-agent"} {
+		// The fully-qualified line list prints is the sole accepted form.
+		listed := "agents/" + agent + "/oauth"
 		name, err := agentOAuthPathName(listed)
 		if err != nil {
-			t.Errorf("agentOAuthPathName(%q) errored: %v; a name from `vault list` must be deletable", listed, err)
+			t.Errorf("agentOAuthPathName(%q) errored: %v; a line from `vault list` must be deletable", listed, err)
 			continue
 		}
-		if name != listed {
-			t.Errorf("agentOAuthPathName(%q) = %q, want %q (the listed name)", listed, name, listed)
+		if name != agent {
+			t.Errorf("agentOAuthPathName(%q) = %q, want %q", listed, name, agent)
 		}
-		// The full-path form list could equivalently emit must resolve identically.
-		full := "agents/" + listed + "/oauth"
-		if got, err := agentOAuthPathName(full); err != nil || got != listed {
-			t.Errorf("agentOAuthPathName(%q) = (%q, %v), want (%q, nil)", full, got, err, listed)
+		// The bare name is no longer a valid delete input.
+		if got, err := agentOAuthPathName(agent); err == nil {
+			t.Errorf("agentOAuthPathName(%q) = (%q, nil), want error (bare form no longer accepted)", agent, got)
 		}
 	}
 }
@@ -282,8 +303,8 @@ func TestRunVaultList_DefaultAndJSON(t *testing.T) {
 		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 	}
 	lines := strings.Fields(stdout.String())
-	if len(lines) != 2 || lines[0] != "claude" || lines[1] != "codex" {
-		t.Errorf("default output = %q, want claude/codex one per line", stdout.String())
+	if len(lines) != 2 || lines[0] != "agents/claude/oauth" || lines[1] != "agents/codex/oauth" {
+		t.Errorf("default output = %q, want fully-qualified agents/<name>/oauth one per line", stdout.String())
 	}
 
 	var jout, jerr bytes.Buffer
@@ -528,8 +549,8 @@ func TestRunVaultList_ScopeUser(t *testing.T) {
 	if code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 	}
-	if strings.TrimSpace(stdout.String()) != "github" {
-		t.Errorf("stdout = %q, want github", stdout.String())
+	if strings.TrimSpace(stdout.String()) != "user/github" {
+		t.Errorf("stdout = %q, want user/github", stdout.String())
 	}
 	if strings.Contains(stdout.String(), secret) || strings.Contains(stdout.String(), "value") {
 		t.Errorf("stdout leaked credential material: %q", stdout.String())
@@ -594,8 +615,8 @@ func TestRunVaultList_ScopeAll(t *testing.T) {
 		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
 	}
 	lines := strings.Fields(stdout.String())
-	if len(lines) != 2 || lines[0] != "claude" || lines[1] != "github" {
-		t.Errorf("output = %q, want claude then github", stdout.String())
+	if len(lines) != 2 || lines[0] != "agents/claude/oauth" || lines[1] != "user/github" {
+		t.Errorf("output = %q, want agents/claude/oauth then user/github", stdout.String())
 	}
 }
 

--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -105,10 +105,10 @@ Approval-gated actions return an approval-pending message instead of running imm
 |---|---|---|
 | `aileron vault init [--passphrase-file <path>]` | Create the local file vault. Deliberate first-run flow; refuses to overwrite an existing vault. | [ADR-0011](/adr/0011-local-credential-vault) |
 | `aileron vault put agents/<name>/oauth --from-file <path>` | Write a per-agent credential envelope from a file, bytes verbatim. Daemon-backed; agents namespace only. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
-| `aileron vault delete <name> [--yes]` | Delete a per-agent credential envelope. `<name>` is the identifier `vault list` prints (e.g. `claude`); the `agents/<name>/oauth` path form is also accepted. Confirms first unless `--yes`. Daemon-backed; agents namespace only. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
-| `aileron vault list [--json]` | List agents with a stored credential entry, metadata only. The credential value is never listed. Each printed name is exactly what `vault delete` accepts. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
+| `aileron vault delete agents/<name>/oauth [--yes]` | Delete a per-agent credential envelope. The argument is the fully-qualified path `vault list` prints (e.g. `agents/claude/oauth`). Confirms first unless `--yes`. Daemon-backed; agents namespace only. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
+| `aileron vault list [--json]` | List agents with a stored credential entry, metadata only. The credential value is never listed. Each printed line is the fully-qualified path (`agents/<name>/oauth`), exactly what `vault delete` accepts. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
 
-The `put`, `delete`, and `list` verbs talk to the running daemon and operate only on the `agents/<name>/oauth` namespace. They never open the vault file directly and reject any other path. What `vault list` prints for an entry is exactly what `vault delete` takes to remove it, so a listed line can be pasted straight into `delete`. See [Sandbox Agent Auth](/development/sandbox-agent-auth/) for the seeding and recovery flows.
+The `put`, `delete`, and `list` verbs talk to the running daemon and operate only on the `agents/<name>/oauth` namespace. They never open the vault file directly and reject any other path. What `vault list` prints for an agent entry is the fully-qualified `agents/<name>/oauth` path, exactly what `vault delete` takes to remove it, so a listed line can be pasted straight into `delete`. See [Sandbox Agent Auth](/development/sandbox-agent-auth/) for the seeding and recovery flows.
 
 ## Auth
 

--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -118,7 +118,7 @@ The other vault writes are:
 
 The bytes must match the envelope schema in the table above when set manually. Render validates on the way in; a malformed envelope fails the launch with a clear error before the container starts.
 
-`aileron vault list` shows which agents currently have an entry, metadata only. The credential value is never listed. Each name it prints is exactly what `aileron vault delete` accepts, so a listed line can be pasted straight into a delete.
+`aileron vault list` shows which agents currently have an entry, metadata only. The credential value is never listed. Each line it prints is the fully-qualified path (`agents/<name>/oauth`), exactly what `aileron vault delete` accepts, so a listed line can be pasted straight into a delete.
 
 ```
 aileron vault list
@@ -147,10 +147,10 @@ When the host install is not authenticated (the file is absent or empty, or the 
 
 To re-login from scratch (vault entry stale, refresh token revoked, or just starting over), the recovery path is whichever of these you can execute:
 
-- Delete the agent's entry with `aileron vault delete <agent>` (the name `aileron vault list` prints; the `agents/<agent>/oauth` path form also works). The next launch finds no entry, falls through to the in-container login bootstrap, and re-seeds a fresh credential on clean exit. This is a daemon-backed command, so the daemon must be running.
+- Delete the agent's entry with `aileron vault delete agents/<agent>/oauth` (the fully-qualified path `aileron vault list` prints). The next launch finds no entry, falls through to the in-container login bootstrap, and re-seeds a fresh credential on clean exit. This is a daemon-backed command, so the daemon must be running.
 
   ```
-  aileron vault delete claude
+  aileron vault delete agents/claude/oauth
   ```
 
   The command confirms before deleting. Pass `--yes` to skip the prompt in scripts.


### PR DESCRIPTION
## Summary

Flips the canonical vault credential identifier to the fully-qualified path, per the operator's stated preference for one clear form (#1317). PR #1310 had widened `vault delete` to also accept the bare name (`claude`) that `vault list` printed; this reverses that direction.

- **`vault list` output**: text/human-readable lines now print the fully-qualified form — `agents/<name>/oauth` for agent scope and `user/<service>` for user scope. The `--json` NDJSON path is unchanged: it keeps emitting the raw summary objects (`name`/`service`), since that is a structured contract rather than a copy-paste line.
- **`vault delete` validation**: `agentOAuthPathName` now accepts ONLY the fully-qualified `agents/<name>/oauth` path. The bare-name branch is dropped. Overlap/malformed guards (`agents/oauth`, `agents//oauth`, `agents/a/b/oauth`) still reject.
- **Usage strings + doc comments**: `vaultUsage`, the delete usage line, and the `agentOAuthPathName` doc comment now describe the single fully-qualified form.
- **Docs**: `cli/index.md` and `development/sandbox-agent-auth.md` examples show `aileron vault delete agents/claude/oauth`, dropping bare-name examples.

Scope note: user entries are listable but the CLI has no `vault delete` for the user namespace today (no user DELETE endpoint, validator is agents-locked — predates #1302/#1310). Printing `user/<service>` is a display-symmetry improvement; adding user-scope delete is intentionally out of scope. No OpenAPI change (pure CLI display + client-side validation).

## Test plan

- `TestRunVaultList_DefaultAndJSON` now expects `agents/claude/oauth` / `agents/codex/oauth` text lines; NDJSON assertions unchanged.
- `TestRunVaultList_ScopeUser` / `ScopeAll` expect `user/github`.
- `TestRunVaultDelete_AcceptsFullyQualifiedFromList` (renamed from `_AcceptsBareNameFromList`) is the before/after regression: the bare name `codex` is now REJECTED with no HTTP, and the fully-qualified line `list` prints round-trips into delete.
- `TestVaultListNamesRoundTripIntoDelete` feeds the fully-qualified strings `list` emits and asserts the bare name no longer validates.
- Full `go test ./cmd/aileron/` and `./internal/launch/...` green. `agentOAuthPathName` at 100% coverage.

Closes #1317

🤖 Generated with [Claude Code](https://claude.com/claude-code)