### PR TITLE
feat(cli): add customizations.aileron.cli unit schema + internal/cli package

### DIFF
--- a/internal/cli/parse.go
+++ b/internal/cli/parse.go
@@ -1,0 +1,204 @@
+package cli
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ALRubinger/aileron/internal/auth/capture"
+	"github.com/ALRubinger/aileron/internal/proxybinding"
+)
+
+// Parse strictly decodes a single CLI-capability unit and validates it.
+// Decoding is strict: an unknown YAML key is an error rather than a silently
+// ignored field, mirroring both source packages so a typo in a unit fails fast
+// instead of shipping a capability that does nothing. Malformed YAML and any
+// field that fails [Unit.Validate] are errors.
+//
+// Parse never reads secret bytes. A unit carries only non-secret acquisition
+// knowledge and credential references.
+func Parse(data []byte) (Unit, error) {
+	dec := yaml.NewDecoder(bytes.NewReader(data))
+	dec.KnownFields(true)
+
+	var u Unit
+	if err := dec.Decode(&u); err != nil {
+		return Unit{}, fmt.Errorf("cli: parse unit: %w", err)
+	}
+
+	if err := u.Validate(); err != nil {
+		return Unit{}, fmt.Errorf("cli: unit %q: %w", u.Name, err)
+	}
+
+	return u, nil
+}
+
+// Validate checks a unit's envelope rules, then delegates acquisition and
+// sealing validation to the canonical capture and proxybinding validators. It
+// enforces the required name and well-formed key, rejects any re-declaration
+// of a key-derived field, rejects the reserved planes this umbrella does not
+// implement, and surfaces the delegated validators' errors verbatim under a
+// cli-scoped prefix.
+//
+// Validate never re-implements scheme, host, sentinel, or arg-vector
+// semantics. Those live in the source packages and are reached through the
+// conversion adapters.
+func (u *Unit) Validate() error {
+	if u.Name == "" {
+		return fmt.Errorf("missing required field: name")
+	}
+	if u.Key == "" {
+		return fmt.Errorf("missing required field: key")
+	}
+	kind, ok := deriveKind(u.Key)
+	if !ok {
+		return fmt.Errorf("key %q is malformed: want \"<kind>/<service>\" with a non-empty first segment", u.Key)
+	}
+
+	// The key is the single source of store_at, kind, and every sealing
+	// credential_ref. A unit that re-declares any derived field (even equal to
+	// the derived value) is an error so the key stays the one source of truth.
+	if u.StoreAt != "" {
+		return fmt.Errorf("store_at must not be declared: it is derived from key %q (got store_at %q)", u.Key, u.StoreAt)
+	}
+	if u.CredentialRef != "" {
+		return fmt.Errorf("credential_ref must not be declared: it is derived from key %q (got credential_ref %q)", u.Key, u.CredentialRef)
+	}
+	if u.Kind != "" {
+		return fmt.Errorf("kind must not be declared: it is derived from key %q (got kind %q)", u.Key, u.Kind)
+	}
+
+	// Reserved planes: forward-declared this umbrella, not implemented. Reject
+	// explicitly so a unit that names them fails loudly rather than silently
+	// doing nothing.
+	if u.Acquisition.Mode == AcquisitionModeDirectToken {
+		return fmt.Errorf("acquisition.mode %q is not yet implemented in this umbrella", AcquisitionModeDirectToken)
+	}
+	if len(u.State) > 0 {
+		return fmt.Errorf("state is reserved and not yet implemented in this umbrella")
+	}
+
+	// Delegate acquisition validation to capture's canonical validator.
+	desc, err := u.toCaptureDescriptor(kind)
+	if err != nil {
+		return err
+	}
+	if err := desc.Validate(); err != nil {
+		return fmt.Errorf("acquisition: %w", err)
+	}
+
+	// Delegate sealing validation to proxybinding's canonical validator, one
+	// entry at a time. A sealing entry that re-declares credential_ref is
+	// caught by the per-binding guard inside the conversion.
+	entries, err := u.toSealingEntries()
+	if err != nil {
+		return err
+	}
+	for i := range entries {
+		if err := entries[i].Validate(); err != nil {
+			return fmt.Errorf("sealing[%d] (%q): %w", i, entries[i].Host, err)
+		}
+	}
+
+	return nil
+}
+
+// deriveKind returns the kind stamp derived from a key, the first
+// slash-delimited segment (e.g. "user/github" -> "user"). It reports false
+// when the key has no non-empty first segment, so a malformed key is a
+// validation error rather than an empty kind.
+func deriveKind(key string) (string, bool) {
+	idx := strings.IndexByte(key, '/')
+	if idx <= 0 {
+		return "", false
+	}
+	return key[:idx], true
+}
+
+// ToCaptureDescriptor converts the unit's acquisition block into the canonical
+// capture.CaptureDescriptor, deriving store_at and kind from the unit's key.
+// It validates the envelope (a well-formed key) before converting so a caller
+// receives either a valid-shaped descriptor or an error, never a half-derived
+// one. The returned descriptor is the single source the capture driver
+// consumes; this package never re-implements its field semantics.
+func (u *Unit) ToCaptureDescriptor() (capture.CaptureDescriptor, error) {
+	if u.Key == "" {
+		return capture.CaptureDescriptor{}, fmt.Errorf("missing required field: key")
+	}
+	kind, ok := deriveKind(u.Key)
+	if !ok {
+		return capture.CaptureDescriptor{}, fmt.Errorf("key %q is malformed: want \"<kind>/<service>\" with a non-empty first segment", u.Key)
+	}
+	return u.toCaptureDescriptor(kind)
+}
+
+// toCaptureDescriptor builds the descriptor from a pre-derived kind. It is the
+// internal helper Validate and ToCaptureDescriptor share so the field mapping
+// lives in one place.
+func (u *Unit) toCaptureDescriptor(kind string) (capture.CaptureDescriptor, error) {
+	return capture.CaptureDescriptor{
+		Version:       capture.CaptureSchemaVersion,
+		Name:          u.Name,
+		Image:         u.Acquisition.Image,
+		ContainerName: u.Acquisition.ContainerName,
+		LoginCmd:      u.Acquisition.LoginCmd,
+		TokenCmd:      u.Acquisition.TokenCmd,
+		BrowserShim:   u.Acquisition.BrowserShim,
+		ConfigDir:     u.Acquisition.ConfigDir,
+		StoreAt:       u.Key,
+		Kind:          kind,
+	}, nil
+}
+
+// ToSealingEntries converts the unit's sealing block into canonical
+// proxybinding.Entry values, deriving each entry's credential_ref from the
+// unit's key. A sealing entry that re-declares credential_ref is rejected so
+// the key stays the single source. The returned entries are validated by the
+// caller (or by Validate) through proxybinding's canonical Entry.Validate;
+// this package never re-implements scheme, host, or sentinel semantics.
+func (u *Unit) ToSealingEntries() ([]proxybinding.Entry, error) {
+	if u.Key == "" {
+		return nil, fmt.Errorf("missing required field: key")
+	}
+	if _, ok := deriveKind(u.Key); !ok {
+		return nil, fmt.Errorf("key %q is malformed: want \"<kind>/<service>\" with a non-empty first segment", u.Key)
+	}
+	return u.toSealingEntries()
+}
+
+// toSealingEntries is the internal helper that maps each Binding onto a
+// proxybinding.Entry. It enforces the no-re-declaration rule on each entry's
+// credential_ref and copies the sentinel block when present.
+func (u *Unit) toSealingEntries() ([]proxybinding.Entry, error) {
+	if len(u.Sealing) == 0 {
+		return nil, nil
+	}
+	entries := make([]proxybinding.Entry, 0, len(u.Sealing))
+	for i := range u.Sealing {
+		b := &u.Sealing[i]
+		if b.CredentialRef != "" {
+			return nil, fmt.Errorf("sealing[%d] (%q): credential_ref must not be declared: it is derived from key %q (got credential_ref %q)", i, b.Host, u.Key, b.CredentialRef)
+		}
+		var sentinel *proxybinding.Sentinel
+		if b.Sentinel != nil {
+			sentinel = &proxybinding.Sentinel{
+				Value: b.Sentinel.Value,
+				Env:   b.Sentinel.Env,
+			}
+		}
+		entries = append(entries, proxybinding.Entry{
+			Host:          b.Host,
+			CredentialRef: u.Key,
+			Scheme:        b.Scheme,
+			EmitMechanism: b.EmitMechanism,
+			Sentinel:      sentinel,
+			Username:      b.Username,
+			Header:        b.Header,
+			Template:      b.Template,
+			QueryParam:    b.QueryParam,
+		})
+	}
+	return entries, nil
+}

--- a/internal/cli/parse_test.go
+++ b/internal/cli/parse_test.go
@@ -1,0 +1,451 @@
+package cli_test
+
+import (
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/auth/capture"
+	"github.com/ALRubinger/aileron/internal/cli"
+)
+
+// ghUnitYAML is the umbrella's gh unit expressed in the customizations.aileron
+// .cli wire shape. Its acquisition block mirrors
+// internal/auth/capture/defaults/gh.yaml and its sealing block mirrors
+// internal/proxybinding/defaults/github.yaml, so a successful parse proves the
+// unit type can express both end-to-end targets.
+const ghUnitYAML = `
+name: gh
+key: user/github
+presence:
+  builtin: base
+acquisition:
+  mode: device-flow
+  container_name: aileron-auth-github
+  login_cmd: [gh, auth, login, --hostname, github.com, --git-protocol, https, --web]
+  token_cmd: [gh, auth, token, --hostname, github.com]
+  browser_shim: echo
+sealing:
+  - host: github.com
+    scheme: basic
+    emit_mechanism: inject
+    username: x-access-token
+  - host: api.github.com
+    scheme: bearer
+    emit_mechanism: sentinel-swap
+    sentinel:
+      value: ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA
+      env: GH_TOKEN
+state: {}
+`
+
+func TestParseGhHappyPath(t *testing.T) {
+	u, err := cli.Parse([]byte(ghUnitYAML))
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+	if u.Name != "gh" {
+		t.Errorf("Name = %q, want %q", u.Name, "gh")
+	}
+	if u.Key != "user/github" {
+		t.Errorf("Key = %q, want %q", u.Key, "user/github")
+	}
+}
+
+func TestGhAcquisitionExpressibility(t *testing.T) {
+	u, err := cli.Parse([]byte(ghUnitYAML))
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	desc, err := u.ToCaptureDescriptor()
+	if err != nil {
+		t.Fatalf("ToCaptureDescriptor() returned error: %v", err)
+	}
+
+	// The descriptor must equal the values in the gh capture default,
+	// including the key-derived store_at and kind.
+	if desc.Version != capture.CaptureSchemaVersion {
+		t.Errorf("Version = %q, want %q", desc.Version, capture.CaptureSchemaVersion)
+	}
+	if desc.Name != "gh" {
+		t.Errorf("Name = %q, want %q", desc.Name, "gh")
+	}
+	if desc.ContainerName != "aileron-auth-github" {
+		t.Errorf("ContainerName = %q, want %q", desc.ContainerName, "aileron-auth-github")
+	}
+	wantLogin := []string{"gh", "auth", "login", "--hostname", "github.com", "--git-protocol", "https", "--web"}
+	if !equalStrings(desc.LoginCmd, wantLogin) {
+		t.Errorf("LoginCmd = %v, want %v", desc.LoginCmd, wantLogin)
+	}
+	wantToken := []string{"gh", "auth", "token", "--hostname", "github.com"}
+	if !equalStrings(desc.TokenCmd, wantToken) {
+		t.Errorf("TokenCmd = %v, want %v", desc.TokenCmd, wantToken)
+	}
+	if desc.BrowserShim != "echo" {
+		t.Errorf("BrowserShim = %q, want %q", desc.BrowserShim, "echo")
+	}
+	if desc.ConfigDir != "" {
+		t.Errorf("ConfigDir = %q, want empty (gh omits it)", desc.ConfigDir)
+	}
+	if desc.StoreAt != "user/github" {
+		t.Errorf("StoreAt = %q, want %q", desc.StoreAt, "user/github")
+	}
+	if desc.Kind != "user" {
+		t.Errorf("Kind = %q, want %q", desc.Kind, "user")
+	}
+
+	// The converted descriptor passes capture's canonical validator.
+	if err := desc.Validate(); err != nil {
+		t.Errorf("capture Validate() returned error: %v", err)
+	}
+}
+
+func TestGhSealingExpressibility(t *testing.T) {
+	u, err := cli.Parse([]byte(ghUnitYAML))
+	if err != nil {
+		t.Fatalf("Parse() returned error: %v", err)
+	}
+
+	entries, err := u.ToSealingEntries()
+	if err != nil {
+		t.Fatalf("ToSealingEntries() returned error: %v", err)
+	}
+	if len(entries) != 2 {
+		t.Fatalf("len(entries) = %d, want 2", len(entries))
+	}
+
+	// github.com -> basic, inject, username x-access-token.
+	e0 := entries[0]
+	if e0.Host != "github.com" || e0.Scheme != "basic" || e0.EmitMechanism != "inject" || e0.Username != "x-access-token" {
+		t.Errorf("entry[0] = %+v, want github.com basic/inject/x-access-token", e0)
+	}
+	if e0.CredentialRef != "user/github" {
+		t.Errorf("entry[0].CredentialRef = %q, want %q", e0.CredentialRef, "user/github")
+	}
+
+	// api.github.com -> bearer, sentinel-swap, sentinel value+env.
+	e1 := entries[1]
+	if e1.Host != "api.github.com" || e1.Scheme != "bearer" || e1.EmitMechanism != "sentinel-swap" {
+		t.Errorf("entry[1] = %+v, want api.github.com bearer/sentinel-swap", e1)
+	}
+	if e1.Sentinel == nil || e1.Sentinel.Value != "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA" || e1.Sentinel.Env != "GH_TOKEN" {
+		t.Errorf("entry[1].Sentinel = %+v, want value+GH_TOKEN", e1.Sentinel)
+	}
+	if e1.CredentialRef != "user/github" {
+		t.Errorf("entry[1].CredentialRef = %q, want %q", e1.CredentialRef, "user/github")
+	}
+
+	// Both entries pass proxybinding's canonical validator and adapt to a
+	// HostBinding.
+	for i := range entries {
+		if err := entries[i].Validate(); err != nil {
+			t.Errorf("entry[%d] Validate() returned error: %v", i, err)
+		}
+		if _, err := entries[i].ToHostBinding(); err != nil {
+			t.Errorf("entry[%d] ToHostBinding() returned error: %v", i, err)
+		}
+	}
+}
+
+func TestKeyDerivationConflictRejected(t *testing.T) {
+	// Each derived field, when re-declared, fails with an error naming the
+	// field. This is the brief's named regression test for single-source key
+	// derivation.
+	cases := map[string]string{
+		"store_at": `
+name: gh
+key: user/github
+store_at: user/github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`,
+		"credential_ref": `
+name: gh
+key: user/github
+credential_ref: user/github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`,
+		"kind": `
+name: gh
+key: user/github
+kind: user
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`,
+	}
+	for field, doc := range cases {
+		t.Run(field, func(t *testing.T) {
+			_, err := cli.Parse([]byte(doc))
+			if err == nil {
+				t.Fatalf("Parse() succeeded, want error naming %q", field)
+			}
+			if !strings.Contains(err.Error(), field) {
+				t.Errorf("error %q does not name field %q", err.Error(), field)
+			}
+		})
+	}
+}
+
+func TestSealingCredentialRefRedeclarationRejected(t *testing.T) {
+	doc := `
+name: gh
+key: user/github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+sealing:
+  - host: github.com
+    scheme: basic
+    username: x-access-token
+    credential_ref: user/github
+`
+	_, err := cli.Parse([]byte(doc))
+	if err == nil {
+		t.Fatal("Parse() succeeded, want error rejecting a sealing credential_ref re-declaration")
+	}
+	if !strings.Contains(err.Error(), "credential_ref") {
+		t.Errorf("error %q does not name credential_ref", err.Error())
+	}
+}
+
+func TestMalformedKeyRejected(t *testing.T) {
+	cases := map[string]string{
+		"empty key": `
+name: gh
+key: ""
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`,
+		"no slash": `
+name: gh
+key: github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`,
+		"empty first segment": `
+name: gh
+key: /github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`,
+	}
+	for name, doc := range cases {
+		t.Run(name, func(t *testing.T) {
+			if _, err := cli.Parse([]byte(doc)); err == nil {
+				t.Fatalf("Parse() succeeded, want error for %s", name)
+			}
+		})
+	}
+}
+
+func TestMissingNameRejected(t *testing.T) {
+	doc := `
+key: user/github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`
+	_, err := cli.Parse([]byte(doc))
+	if err == nil {
+		t.Fatal("Parse() succeeded, want error for missing name")
+	}
+	if !strings.Contains(err.Error(), "name") {
+		t.Errorf("error %q does not name the missing field", err.Error())
+	}
+}
+
+func TestReservedDirectTokenRejected(t *testing.T) {
+	doc := `
+name: gh
+key: user/github
+acquisition:
+  mode: direct-token
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`
+	_, err := cli.Parse([]byte(doc))
+	if err == nil {
+		t.Fatal("Parse() succeeded, want not-yet-implemented error for direct-token")
+	}
+	if !strings.Contains(err.Error(), "direct-token") || !strings.Contains(err.Error(), "not yet implemented") {
+		t.Errorf("error %q does not explain direct-token is not yet implemented", err.Error())
+	}
+}
+
+func TestReservedNonEmptyStateRejected(t *testing.T) {
+	doc := `
+name: gh
+key: user/github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+state:
+  cache: /some/path
+`
+	_, err := cli.Parse([]byte(doc))
+	if err == nil {
+		t.Fatal("Parse() succeeded, want not-yet-implemented error for non-empty state")
+	}
+	if !strings.Contains(err.Error(), "state") || !strings.Contains(err.Error(), "reserved") {
+		t.Errorf("error %q does not explain state is reserved", err.Error())
+	}
+}
+
+func TestStateAbsentAndEmptyAreValid(t *testing.T) {
+	absent := `
+name: gh
+key: user/github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`
+	empty := absent + "state: {}\n"
+	for name, doc := range map[string]string{"absent": absent, "empty": empty} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := cli.Parse([]byte(doc)); err != nil {
+				t.Errorf("Parse() returned error for %s state: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestDelegatedSealingValidationSurfaces(t *testing.T) {
+	bogusScheme := `
+name: gh
+key: user/github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+sealing:
+  - host: github.com
+    scheme: bogus
+`
+	sentinelSwapNoSentinel := `
+name: gh
+key: user/github
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+sealing:
+  - host: api.github.com
+    scheme: bearer
+    emit_mechanism: sentinel-swap
+`
+	for name, doc := range map[string]string{
+		"bogus scheme":            bogusScheme,
+		"sentinel-swap, no block": sentinelSwapNoSentinel,
+	} {
+		t.Run(name, func(t *testing.T) {
+			if _, err := cli.Parse([]byte(doc)); err == nil {
+				t.Fatalf("Parse() succeeded, want delegated proxybinding error for %s", name)
+			}
+		})
+	}
+}
+
+func TestDelegatedAcquisitionValidationSurfaces(t *testing.T) {
+	// A missing login_cmd proves delegation to capture's validator: this
+	// package never re-implements the required-login_cmd rule.
+	doc := `
+name: gh
+key: user/github
+acquisition:
+  mode: device-flow
+  container_name: c
+  token_cmd: [gh]
+`
+	_, err := cli.Parse([]byte(doc))
+	if err == nil {
+		t.Fatal("Parse() succeeded, want delegated capture error for missing login_cmd")
+	}
+	if !strings.Contains(err.Error(), "login_cmd") {
+		t.Errorf("error %q does not name login_cmd", err.Error())
+	}
+}
+
+func TestStrictDecodeRejectsUnknownKey(t *testing.T) {
+	doc := `
+name: gh
+key: user/github
+bogus_field: oops
+acquisition:
+  mode: device-flow
+  container_name: c
+  login_cmd: [gh]
+  token_cmd: [gh]
+`
+	if _, err := cli.Parse([]byte(doc)); err == nil {
+		t.Fatal("Parse() succeeded, want strict-decode error for unknown key")
+	}
+}
+
+func TestParseMalformedYAML(t *testing.T) {
+	if _, err := cli.Parse([]byte("name: [unterminated")); err == nil {
+		t.Fatal("Parse() succeeded, want error for malformed YAML")
+	}
+}
+
+// TestAdaptersGuardMalformedKey proves the public adapters refuse a malformed
+// key independently of Validate, so a caller cannot derive a half-formed
+// descriptor or entry.
+func TestAdaptersGuardMalformedKey(t *testing.T) {
+	u := cli.Unit{Name: "gh", Key: "github"}
+	if _, err := u.ToCaptureDescriptor(); err == nil {
+		t.Error("ToCaptureDescriptor() succeeded on malformed key, want error")
+	}
+	if _, err := u.ToSealingEntries(); err == nil {
+		t.Error("ToSealingEntries() succeeded on malformed key, want error")
+	}
+
+	empty := cli.Unit{Name: "gh"}
+	if _, err := empty.ToCaptureDescriptor(); err == nil {
+		t.Error("ToCaptureDescriptor() succeeded on empty key, want error")
+	}
+	if _, err := empty.ToSealingEntries(); err == nil {
+		t.Error("ToSealingEntries() succeeded on empty key, want error")
+	}
+}
+
+func equalStrings(a, b []string) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if a[i] != b[i] {
+			return false
+		}
+	}
+	return true
+}

--- a/internal/cli/unit.go
+++ b/internal/cli/unit.go
@@ -1,0 +1,194 @@
+// Package cli defines the declarative CLI-capability unit that lives under a
+// devcontainer Feature's customizations.aileron.cli block (umbrella #1319).
+// A unit declares one CLI tool's complete credential story as data: how the
+// credential is acquired and where each outbound host's credential is sealed
+// at the proxy boundary.
+//
+// A unit is an envelope, not a new credential format. The acquisition block
+// is the wire shape of internal/auth/capture's CaptureDescriptor, and each
+// sealing entry is the wire shape of internal/proxybinding's Entry. This
+// package owns only the envelope concerns the unit adds on top of those two
+// formats. It owns the unit shape, the single-source derivation of vault keys
+// from one key field, and the rejection of the reserved planes this umbrella
+// forward-declares but does not yet implement.
+//
+// Field semantics are not duplicated here. The meaning of a login arg vector,
+// a sealing scheme, a sentinel block, or a host pattern lives in the source
+// packages. This package converts a unit into a capture.CaptureDescriptor and
+// a slice of proxybinding.Entry, then delegates validation to the canonical
+// capture.(*CaptureDescriptor).Validate and proxybinding.(*Entry).Validate.
+// There is one matcher, one name contract, and one scheme set, and they live
+// where they always have.
+//
+// # Scope
+//
+// This package ships the type, the parser, the validator, and the two
+// conversion adapters. It does not load, merge, or embed any defaults, and it
+// adds no daemon command. Loader wiring is tracked separately (#1322).
+package cli
+
+// AcquisitionModeDeviceFlow is the only acquisition mode this umbrella
+// implements. A device-flow unit drives an interactive container login and
+// reads the token back out, mapping field-for-field onto capture's driver.
+const AcquisitionModeDeviceFlow = "device-flow"
+
+// AcquisitionModeDirectToken is the forward-declared mode for units that
+// supply a token directly rather than acquiring one through an interactive
+// login. It is reserved for this umbrella. A unit naming it fails validation with
+// an explicit not-yet-implemented error rather than a silent best-effort
+// decode.
+const AcquisitionModeDirectToken = "direct-token"
+
+// Unit is the YAML-facing CLI-capability unit parsed from a Feature's
+// customizations.aileron.cli block. One unit declares a single CLI tool's
+// name, its one vault key, how the credential is acquired, and how each
+// outbound host seals it. The unit derives every per-store vault key from the
+// single Key field so a tool's credential identity is declared once.
+type Unit struct {
+	// Name is the tool identifier (e.g. "gh"). Required and non-empty. It is
+	// the registry key the acquisition descriptor is keyed by.
+	Name string `yaml:"name"`
+
+	// Key is the single vault key the unit's credential lives at, in
+	// "<kind>/<service>" form (e.g. "user/github"). Required. It is the single
+	// source for the acquisition store_at, the acquisition kind (the first
+	// path segment), and every sealing entry's credential_ref. The unit must
+	// not re-declare any of those derived fields; doing so is a load error.
+	Key string `yaml:"key"`
+
+	// Presence is the reserved built-in-presence declaration (e.g.
+	// {builtin: base}). It is accepted and validated for well-formedness but
+	// no behavior branches on it this umbrella. It is a pointer so an absent
+	// block is distinguishable from a present one.
+	Presence *Presence `yaml:"presence"`
+
+	// Acquisition is the credential-acquisition block. Its fields mirror
+	// capture.CaptureDescriptor one-to-one so conversion is a field copy.
+	// Required.
+	Acquisition Acquisition `yaml:"acquisition"`
+
+	// Sealing is the ordered list of per-host credential-sealing bindings.
+	// Each entry mirrors proxybinding.Entry's wire shape, minus the
+	// credential_ref the unit derives from Key. Optional; an empty list is a
+	// valid unit that acquires a credential but seals no host.
+	Sealing []Binding `yaml:"sealing"`
+
+	// State is the reserved cross-sandbox state block. It is typed as a map so
+	// an absent or empty block is distinguishable from a non-empty one. An
+	// absent or empty State is valid; a non-empty State fails validation with
+	// an explicit not-yet-implemented error this umbrella.
+	State map[string]any `yaml:"state"`
+
+	// StoreAt, CredentialRef, and Kind are the derived fields. The unit must
+	// not declare them: they are the single-source derivation from Key, and an
+	// explicit re-declaration (even one equal to the derived value) is a load
+	// error so Key stays the one source of truth. They carry the unit's YAML
+	// tags so a re-declaration is captured by the strict decoder rather than
+	// rejected as an unknown field.
+	StoreAt       string `yaml:"store_at"`
+	CredentialRef string `yaml:"credential_ref"`
+	Kind          string `yaml:"kind"`
+}
+
+// Presence is the reserved built-in-presence declaration. It names whether a
+// tool is present in a built-in image tier. It is accepted as data this
+// umbrella with no behavior branching on it.
+type Presence struct {
+	// Builtin names the built-in image tier the tool is present in (e.g.
+	// "base"). Reserved; no behavior branches on it this umbrella.
+	Builtin string `yaml:"builtin"`
+}
+
+// Acquisition is the credential-acquisition block of a unit. Its fields mirror
+// internal/auth/capture's CaptureDescriptor one-to-one (minus the version,
+// store_at, and kind the envelope supplies) so the unit converts to a
+// CaptureDescriptor by field copy and delegates validation to capture.
+type Acquisition struct {
+	// Mode is the acquisition mode, one of the AcquisitionMode constants.
+	// Required. Only device-flow is implemented this umbrella; direct-token is
+	// forward-declared and rejected.
+	Mode string `yaml:"mode"`
+
+	// LoginCmd is the interactive login command run inside the container,
+	// minus the exec scaffolding. Maps to CaptureDescriptor.LoginCmd.
+	LoginCmd []string `yaml:"login_cmd"`
+
+	// TokenCmd is the token-read command run inside the same container. Maps
+	// to CaptureDescriptor.TokenCmd.
+	TokenCmd []string `yaml:"token_cmd"`
+
+	// BrowserShim, when non-empty, is the BROWSER shim planted on the login
+	// exec (e.g. "echo"). Optional. Maps to CaptureDescriptor.BrowserShim.
+	BrowserShim string `yaml:"browser_shim"`
+
+	// ConfigDir, when non-empty, is the single K=V config-dir env token
+	// planted on both execs. Optional; gh omits it. Maps to
+	// CaptureDescriptor.ConfigDir.
+	ConfigDir string `yaml:"config_dir"`
+
+	// Image is an optional pre-resolved container image. Normally empty. Maps
+	// to CaptureDescriptor.Image.
+	Image string `yaml:"image"`
+
+	// ContainerName is the deterministic name for the long-lived capture
+	// container (e.g. "aileron-auth-github"). Required for device-flow. Maps
+	// to CaptureDescriptor.ContainerName.
+	ContainerName string `yaml:"container_name"`
+}
+
+// Binding is one per-host sealing entry of a unit. Its fields mirror
+// internal/proxybinding's Entry wire shape, minus the credential_ref the unit
+// derives from Key. A unit converts each Binding into a proxybinding.Entry and
+// delegates validation to proxybinding so the scheme set, sentinel rules, and
+// host-pattern legality live in one place.
+type Binding struct {
+	// Host is the upstream host pattern matched at the proxy boundary. Maps to
+	// proxybinding.Entry.Host.
+	Host string `yaml:"host"`
+
+	// Scheme is the injection scheme. Maps to proxybinding.Entry.Scheme.
+	Scheme string `yaml:"scheme"`
+
+	// EmitMechanism declares how the credential reaches egress. Optional;
+	// empty defaults to inject. Maps to proxybinding.Entry.EmitMechanism.
+	EmitMechanism string `yaml:"emit_mechanism"`
+
+	// Sentinel is the sentinel-swap placeholder declaration. Maps to
+	// proxybinding.Entry.Sentinel.
+	Sentinel *SentinelSpec `yaml:"sentinel"`
+
+	// Username is the basic-auth username. Maps to proxybinding.Entry.Username.
+	Username string `yaml:"username"`
+
+	// Header is the header name for the header-template scheme. Maps to
+	// proxybinding.Entry.Header.
+	Header string `yaml:"header"`
+
+	// Template is the verbatim header value for the header-template scheme.
+	// Maps to proxybinding.Entry.Template.
+	Template string `yaml:"template"`
+
+	// QueryParam is the query-parameter name for the query-param scheme. Maps
+	// to proxybinding.Entry.QueryParam.
+	QueryParam string `yaml:"query_param"`
+
+	// CredentialRef is the derived field. The unit must not declare it: it is
+	// derived from Key, and an explicit re-declaration is a load error so Key
+	// stays the single source. It carries the proxybinding YAML tag so a
+	// re-declaration is captured by the strict decoder rather than rejected as
+	// an unknown field.
+	CredentialRef string `yaml:"credential_ref"`
+}
+
+// SentinelSpec is a unit's sentinel-swap placeholder declaration. It mirrors
+// internal/proxybinding's Sentinel: a non-secret placeholder value plus the
+// env-var name the launcher plants it under. Every field is non-secret.
+type SentinelSpec struct {
+	// Value is the non-secret, format-mimicking placeholder. Maps to
+	// proxybinding.Sentinel.Value.
+	Value string `yaml:"value"`
+
+	// Env is the env-var name the launcher plants the value under. Maps to
+	// proxybinding.Sentinel.Env.
+	Env string `yaml:"env"`
+}


### PR DESCRIPTION
## Summary

Part of umbrella #1319. Defines the CLI-capability unit *type, parser, validator, and conversion adapters only*. No loader wiring (that is #1322), no embed, no behavior change.

New package `internal/cli` (import path `github.com/ALRubinger/aileron/internal/cli`):

- `Unit` (plus `Acquisition`, `Binding`, `Presence`, `SentinelSpec`) — the YAML-facing shape of the `customizations.aileron.cli` block.
- `Parse([]byte) (Unit, error)` — strict decode (`KnownFields(true)`), mirroring both source packages so a typo fails fast.
- `(*Unit).Validate()` — envelope rules, then **delegated** acquisition/sealing validation.
- `(*Unit).ToCaptureDescriptor()` and `(*Unit).ToSealingEntries()` — conversion adapters into the canonical `capture.CaptureDescriptor` and `[]proxybinding.Entry`.

### Convert, do not duplicate

`internal/cli` owns only the *envelope* concerns: the unit shape, single-source `key` derivation, and reserved-plane rejection. It converts into `capture.CaptureDescriptor` and `proxybinding.Entry`, then **delegates** all field-semantic validation to the canonical `capture.(*CaptureDescriptor).Validate()` and `proxybinding.(*Entry).Validate()`. Scheme, host-pattern, sentinel, and arg-vector semantics are never re-implemented here. No changes to `internal/auth/capture` or `internal/proxybinding` — they are referenced and reused.

### `key` single-source derivation

`store_at = key`, `credential_ref = key`, `kind = first-segment(key)` (e.g. `user/github` → `user`). `key` must be non-empty with a non-empty first segment. Any explicit re-declaration of a derived field (`store_at`, `credential_ref`, `kind`, or a sealing entry's `credential_ref`) is a load error — even one equal to the derived value — so `key` stays the single source of truth.

### Reserved-plane rejection (forward-declared, not implemented)

- `acquisition.mode: direct-token` → explicit not-yet-implemented error.
- A non-empty `state` block → explicit reserved error; absent or `state: {}` is valid (typed `map[string]any`, length-checked so absent/`{}` vs non-empty is distinguishable).
- `presence` accepted as data; no behavior branches on it.

### Implementation notes (decisions flagged per the plan)

- **No separate version field.** The umbrella example shows none; the unit lives under a Feature, so a version field is implicit. Omitted, mirroring the issue example.
- **Adapter names** finalized as `ToCaptureDescriptor` / `ToSealingEntries`.
- **Redundant-but-equal re-declaration is rejected**, not tolerated — chosen to keep `key` the one source per the brief's "do not re-declare".

## Test plan

`internal/cli` has contract tests (98.5% statement coverage) covering every stated rule plus the two end-to-end expressibility targets:

- gh happy path; derived `store_at`/`credential_ref`/`kind` correct.
- **gh acquisition expressibility** — converts to a `CaptureDescriptor` whose fields equal `internal/auth/capture/defaults/gh.yaml` and passes `capture` `Validate`.
- **gh sealing expressibility** — converts to two `proxybinding.Entry` values matching `internal/proxybinding/defaults/github.yaml` (github.com basic/inject/x-access-token; api.github.com bearer/sentinel-swap/sentinel value+env), each passing `proxybinding` `Validate` and `ToHostBinding`.
- **key-derivation regression** — re-declared `store_at`/`credential_ref`/`kind` each fail with an error naming the field; sealing-entry `credential_ref` re-declaration rejected.
- malformed key (empty, no slash, empty first segment), missing name.
- reserved `direct-token` and non-empty `state` rejected; absent and `{}` state valid.
- **delegation proof** — bogus sealing scheme, sentinel-swap missing its sentinel block, and missing `login_cmd` each surface the canonical validators' errors (not a re-implementation).
- strict decode rejects an unknown key; malformed YAML rejected; adapters guard a malformed/empty key independently of `Validate`.

Verification run: `cd internal && go build ./... && go vet ./cli/... && go test ./... ` (full suite green) and `task build` (green). CodeRabbit review run pre-PR: one minor doc-grammar nit in this diff (fixed); the only other finding was in an untouched pre-existing file.

Closes #1325


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced strict YAML validation for CLI configuration units, including credential acquisition and sealing bindings.
  * Added support for device-flow credential acquisition mode with comprehensive validation of configuration schemas.

* **Tests**
  * Added extensive test coverage for CLI configuration parsing, validation, and conversion logic, including error scenarios and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->