### PR TITLE
fix(launch): make Claude launch flags mode-conditional for sandbox parity

### DIFF
--- a/cmd/aileron/auth_test.go
+++ b/cmd/aileron/auth_test.go
@@ -292,9 +292,9 @@ type fakeAuthAgent struct {
 	spec launch.AuthSpec
 }
 
-func (f fakeAuthAgent) Name() string          { return f.name }
-func (f fakeAuthAgent) BinaryNames() []string { return []string{f.name} }
-func (f fakeAuthAgent) Args() []string        { return nil }
+func (f fakeAuthAgent) Name() string                { return f.name }
+func (f fakeAuthAgent) BinaryNames() []string       { return []string{f.name} }
+func (f fakeAuthAgent) Args(_ launch.Mode) []string { return nil }
 func (f fakeAuthAgent) Env() map[string]string {
 	return nil
 }

--- a/internal/launch/agent.go
+++ b/internal/launch/agent.go
@@ -56,7 +56,13 @@ type Agent interface {
 	BinaryNames() []string
 	// Args returns CLI arguments the agent requires. These are prepended
 	// before any user-supplied arguments.
-	Args() []string
+	//
+	// mode is host vs sandbox. Agents whose approval posture differs by
+	// trust boundary branch on it: under ModeSandbox the container is the
+	// trust boundary (ADR-0015), so an agent may pass a broader
+	// auto-approve flag than under ModeHost. Agents whose flags are the
+	// same in both modes ignore the parameter.
+	Args(mode Mode) []string
 	// Env returns additional environment variables to set for the agent
 	// process. Returns nil if no extra env is needed.
 	Env() map[string]string

--- a/internal/launch/agent_test.go
+++ b/internal/launch/agent_test.go
@@ -53,11 +53,11 @@ type testAgent struct {
 	name string
 }
 
-func (a testAgent) Name() string           { return a.name }
-func (a testAgent) BinaryNames() []string  { return []string{a.name} }
-func (a testAgent) Args() []string         { return nil }
-func (a testAgent) Env() map[string]string { return nil }
-func (a testAgent) LLMEndpointEnv() string { return "" }
+func (a testAgent) Name() string                { return a.name }
+func (a testAgent) BinaryNames() []string       { return []string{a.name} }
+func (a testAgent) Args(_ launch.Mode) []string { return nil }
+func (a testAgent) Env() map[string]string      { return nil }
+func (a testAgent) LLMEndpointEnv() string      { return "" }
 func (a testAgent) ConfigureMCP(string, map[string]string, string, launch.Mode) ([]string, []launch.MCPMount, error) {
 	return nil, nil, nil
 }

--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -13,7 +13,20 @@ type Claude struct{}
 func (c Claude) Name() string          { return "claude" }
 func (c Claude) BinaryNames() []string { return []string{"claude"} }
 
-// Args tells Claude Code to auto-approve:
+// Args tells Claude Code how aggressively to auto-approve, branching on
+// the launch trust boundary.
+//
+// Under ModeSandbox the container is the trust boundary (ADR-0015): the
+// agent runs inside Aileron's sandbox, so we pass
+// --dangerously-skip-permissions alone to give Claude full YOLO
+// autonomy. This mirrors Codex's container posture
+// (approval_policy="never" + sandbox_mode="danger-full-access" in
+// mergeCodexSandboxConfig). The flag is passed alone, not alongside
+// --allowedTools, because --dangerously-skip-permissions subsumes all
+// per-tool gating; combining them would be redundant.
+//
+// Under ModeHost the agent runs directly on the host, so we keep the
+// narrower --allowedTools posture that auto-approves only:
 //   - Bash, so Claude Code's per-command prompt is suppressed. Per
 //     ADR-0015, Aileron is no longer the trust surface for the agent's
 //     local shell commands; Claude Code's own approval suppression
@@ -26,7 +39,10 @@ func (c Claude) BinaryNames() []string { return []string{"claude"} }
 // `--allowedTools` accepts a single value with space-separated
 // patterns; the bare `mcp__<server>` form whitelists every tool from
 // that server (including ones registered later in the session).
-func (c Claude) Args() []string {
+func (c Claude) Args(mode launch.Mode) []string {
+	if mode == launch.ModeSandbox {
+		return []string{"--dangerously-skip-permissions"}
+	}
 	return []string{"--allowedTools", "Bash(*) mcp__" + launch.MCPServerName}
 }
 

--- a/internal/launch/agents/claude_test.go
+++ b/internal/launch/agents/claude_test.go
@@ -25,19 +25,41 @@ func TestClaude_Identity(t *testing.T) {
 	}
 }
 
-func TestClaude_Args_AllowsBashAndAileronMCP(t *testing.T) {
-	args := agents.Claude{}.Args()
+// TestClaude_Args_HostAllowsBashAndAileronMCP pins the host-launch
+// posture: a host launch runs against the user's real machine, so
+// Claude keeps the narrower --allowedTools whitelist rather than full
+// permission skipping.
+func TestClaude_Args_HostAllowsBashAndAileronMCP(t *testing.T) {
+	args := agents.Claude{}.Args(launch.ModeHost)
 	if len(args) != 2 {
-		t.Fatalf("Args() = %v, want 2 entries", args)
+		t.Fatalf("Args(ModeHost) = %v, want 2 entries", args)
 	}
 	if args[0] != "--allowedTools" {
-		t.Errorf("Args()[0] = %q, want --allowedTools", args[0])
+		t.Errorf("Args(ModeHost)[0] = %q, want --allowedTools", args[0])
 	}
 	if !strings.Contains(args[1], "Bash(*)") {
-		t.Errorf("Args()[1] = %q, should allow Bash(*)", args[1])
+		t.Errorf("Args(ModeHost)[1] = %q, should allow Bash(*)", args[1])
 	}
 	if !strings.Contains(args[1], "mcp__"+launch.MCPServerName) {
-		t.Errorf("Args()[1] = %q, should allow mcp__%s", args[1], launch.MCPServerName)
+		t.Errorf("Args(ModeHost)[1] = %q, should allow mcp__%s", args[1], launch.MCPServerName)
+	}
+}
+
+// TestClaude_Args_SandboxSkipsPermissions is the regression test for
+// the container/sandbox parity fix: under ModeSandbox the container is
+// the trust boundary (ADR-0015), so Claude must pass
+// --dangerously-skip-permissions alone, mirroring Codex's container
+// YOLO posture. The narrower --allowedTools flag must NOT appear: the
+// skip flag subsumes it, and combining them would be redundant.
+func TestClaude_Args_SandboxSkipsPermissions(t *testing.T) {
+	args := agents.Claude{}.Args(launch.ModeSandbox)
+	if len(args) != 1 || args[0] != "--dangerously-skip-permissions" {
+		t.Fatalf("Args(ModeSandbox) = %v, want [--dangerously-skip-permissions]", args)
+	}
+	for _, a := range args {
+		if a == "--allowedTools" {
+			t.Errorf("Args(ModeSandbox) = %v, must not include --allowedTools alongside the skip flag", args)
+		}
 	}
 }
 

--- a/internal/launch/agents/codex.go
+++ b/internal/launch/agents/codex.go
@@ -43,7 +43,7 @@ func (c Codex) BinaryNames() []string { return []string{"codex"} }
 // `[projects."/home/agent/workspace"]` block pre-accepts the
 // folder-trust prompt. The sandbox container is the trust boundary
 // (ADR-0015), so auto-approving inside it is safe.
-func (c Codex) Args() []string { return nil }
+func (c Codex) Args(_ launch.Mode) []string { return nil }
 
 func (c Codex) Env() map[string]string { return nil }
 

--- a/internal/launch/agents/codex_test.go
+++ b/internal/launch/agents/codex_test.go
@@ -21,8 +21,11 @@ func TestCodex_Identity(t *testing.T) {
 	if c.LLMEndpointEnv() != "OPENAI_BASE_URL" {
 		t.Errorf("LLMEndpointEnv() = %q, want OPENAI_BASE_URL", c.LLMEndpointEnv())
 	}
-	if c.Args() != nil {
-		t.Errorf("Args() = %v, want nil", c.Args())
+	if c.Args(launch.ModeHost) != nil {
+		t.Errorf("Args(ModeHost) = %v, want nil", c.Args(launch.ModeHost))
+	}
+	if c.Args(launch.ModeSandbox) != nil {
+		t.Errorf("Args(ModeSandbox) = %v, want nil", c.Args(launch.ModeSandbox))
 	}
 	if c.Env() != nil {
 		t.Errorf("Env() = %v, want nil", c.Env())

--- a/internal/launch/agents/goose.go
+++ b/internal/launch/agents/goose.go
@@ -36,7 +36,7 @@ func (g Goose) BinaryNames() []string { return []string{"goose"} }
 // --with-extension …`. `--with-extension` is a session-subcommand
 // flag in Goose's clap config; without an explicit subcommand the
 // flag isn't recognized.
-func (g Goose) Args() []string { return []string{"session"} }
+func (g Goose) Args(_ launch.Mode) []string { return []string{"session"} }
 
 // Env sets GOOSE_MODE=auto so Goose runs without per-tool approval
 // prompts. Users who want Goose's own approval prompts can override

--- a/internal/launch/agents/goose_test.go
+++ b/internal/launch/agents/goose_test.go
@@ -39,7 +39,7 @@ func TestGoose_Env_ForcesAutonomousMode(t *testing.T) {
 // Goose's clap config; without an explicit subcommand the flag
 // isn't recognized and our extension wiring silently disappears.
 func TestGoose_Args_StartsSessionSubcommand(t *testing.T) {
-	args := agents.Goose{}.Args()
+	args := agents.Goose{}.Args(launch.ModeHost)
 	if len(args) != 1 || args[0] != "session" {
 		t.Errorf("Args() = %v, want [\"session\"]", args)
 	}

--- a/internal/launch/agents/opencode.go
+++ b/internal/launch/agents/opencode.go
@@ -24,8 +24,8 @@ type OpenCode struct{}
 func (o OpenCode) Name() string          { return "opencode" }
 func (o OpenCode) BinaryNames() []string { return []string{"opencode"} }
 
-func (o OpenCode) Args() []string         { return nil }
-func (o OpenCode) Env() map[string]string { return nil }
+func (o OpenCode) Args(_ launch.Mode) []string { return nil }
+func (o OpenCode) Env() map[string]string      { return nil }
 
 // LLMEndpointEnv returns "" — OpenCode configures the LLM provider
 // base URL per provider in `opencode.json`, not via a single env var.

--- a/internal/launch/agents/opencode_test.go
+++ b/internal/launch/agents/opencode_test.go
@@ -21,8 +21,8 @@ func TestOpenCode_Identity(t *testing.T) {
 	if o.LLMEndpointEnv() != "" {
 		t.Errorf("LLMEndpointEnv() = %q, want empty (provider URL per-provider)", o.LLMEndpointEnv())
 	}
-	if o.Args() != nil {
-		t.Errorf("Args() = %v, want nil", o.Args())
+	if o.Args(launch.ModeHost) != nil {
+		t.Errorf("Args(ModeHost) = %v, want nil", o.Args(launch.ModeHost))
 	}
 	if o.Env() != nil {
 		t.Errorf("Env() = %v, want nil", o.Env())

--- a/internal/launch/agents/pi.go
+++ b/internal/launch/agents/pi.go
@@ -17,7 +17,7 @@ func (p Pi) BinaryNames() []string { return []string{"pi"} }
 // tools. Per ADR-0015, Aileron is not the trust surface for the agent's
 // local shell commands; --tools just suppresses Pi's per-tool prompt
 // surface so the user is not double-prompted.
-func (p Pi) Args() []string {
+func (p Pi) Args(_ launch.Mode) []string {
 	return []string{"--tools", "bash,read,edit,write,grep,find,ls"}
 }
 

--- a/internal/launch/agents/pi_test.go
+++ b/internal/launch/agents/pi_test.go
@@ -26,7 +26,7 @@ func TestPi_Identity(t *testing.T) {
 }
 
 func TestPi_Args_AutoApproveTools(t *testing.T) {
-	args := agents.Pi{}.Args()
+	args := agents.Pi{}.Args(launch.ModeHost)
 	if len(args) != 2 || args[0] != "--tools" {
 		t.Fatalf("Args() = %v, want [--tools <list>]", args)
 	}

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -770,7 +770,7 @@ func launchHost(ctx context.Context, config LaunchConfig, daemonURL, sessionID s
 		return LaunchResult{}, err
 	}
 
-	allArgs := append(config.Agent.Args(), config.Args...)
+	allArgs := append(config.Agent.Args(ModeHost), config.Args...)
 	mcpEnv := map[string]string{
 		"AILERON_URL":          daemonURL,
 		"AILERON_COMMS_URL":    daemonURL,
@@ -924,7 +924,7 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 	}
 	mounts = collapsed
 
-	command := append([]string{commandName}, config.Agent.Args()...)
+	command := append([]string{commandName}, config.Agent.Args(ModeSandbox)...)
 	command = append(command, extraArgs...)
 	command = append(command, config.Args...)
 	user := ""

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -21,7 +21,7 @@ type emptyBinaryAgent struct{}
 
 func (emptyBinaryAgent) Name() string           { return "empty" }
 func (emptyBinaryAgent) BinaryNames() []string  { return nil }
-func (emptyBinaryAgent) Args() []string         { return nil }
+func (emptyBinaryAgent) Args(_ Mode) []string   { return nil }
 func (emptyBinaryAgent) Env() map[string]string { return nil }
 func (emptyBinaryAgent) LLMEndpointEnv() string { return "" }
 func (emptyBinaryAgent) ConfigureMCP(string, map[string]string, string, Mode) ([]string, []MCPMount, error) {
@@ -33,7 +33,7 @@ type namedBinaryAgent struct{ name string }
 
 func (a namedBinaryAgent) Name() string           { return "named" }
 func (a namedBinaryAgent) BinaryNames() []string  { return []string{a.name} }
-func (a namedBinaryAgent) Args() []string         { return nil }
+func (a namedBinaryAgent) Args(_ Mode) []string   { return nil }
 func (a namedBinaryAgent) Env() map[string]string { return nil }
 func (a namedBinaryAgent) LLMEndpointEnv() string { return "" }
 func (a namedBinaryAgent) ConfigureMCP(string, map[string]string, string, Mode) ([]string, []MCPMount, error) {
@@ -48,7 +48,7 @@ type publishedNameAgent struct{ name string }
 
 func (a publishedNameAgent) Name() string           { return a.name }
 func (a publishedNameAgent) BinaryNames() []string  { return []string{a.name} }
-func (a publishedNameAgent) Args() []string         { return nil }
+func (a publishedNameAgent) Args(_ Mode) []string   { return nil }
 func (a publishedNameAgent) Env() map[string]string { return nil }
 func (a publishedNameAgent) LLMEndpointEnv() string { return "" }
 func (a publishedNameAgent) ConfigureMCP(string, map[string]string, string, Mode) ([]string, []MCPMount, error) {

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -112,11 +112,11 @@ type scriptAgent struct {
 	mcpArgs  []string
 }
 
-func (a scriptAgent) Name() string           { return "test-script" }
-func (a scriptAgent) BinaryNames() []string  { return []string{a.script} }
-func (a scriptAgent) Args() []string         { return nil }
-func (a scriptAgent) Env() map[string]string { return a.extraEnv }
-func (a scriptAgent) LLMEndpointEnv() string { return "" }
+func (a scriptAgent) Name() string                { return "test-script" }
+func (a scriptAgent) BinaryNames() []string       { return []string{a.script} }
+func (a scriptAgent) Args(_ launch.Mode) []string { return nil }
+func (a scriptAgent) Env() map[string]string      { return a.extraEnv }
+func (a scriptAgent) LLMEndpointEnv() string      { return "" }
 func (a scriptAgent) ConfigureMCP(string, map[string]string, string, launch.Mode) ([]string, []launch.MCPMount, error) {
 	return a.mcpArgs, nil, nil
 }
@@ -1448,11 +1448,11 @@ func TestLaunch_Sandbox_AileronMCPMissing_FailsLoud(t *testing.T) {
 
 type claudeTestAgent struct{}
 
-func (claudeTestAgent) Name() string           { return "claude" }
-func (claudeTestAgent) BinaryNames() []string  { return []string{"claude"} }
-func (claudeTestAgent) Args() []string         { return nil }
-func (claudeTestAgent) Env() map[string]string { return nil }
-func (claudeTestAgent) LLMEndpointEnv() string { return "" }
+func (claudeTestAgent) Name() string                { return "claude" }
+func (claudeTestAgent) BinaryNames() []string       { return []string{"claude"} }
+func (claudeTestAgent) Args(_ launch.Mode) []string { return nil }
+func (claudeTestAgent) Env() map[string]string      { return nil }
+func (claudeTestAgent) LLMEndpointEnv() string      { return "" }
 func (claudeTestAgent) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string, _ launch.Mode) ([]string, []launch.MCPMount, error) {
 	envJSON := encodeJSON(t1, mcpEnv)
 	return []string{"--mcp-config", `{"mcpServers":{"aileron":{"command":"` + mcpBin + `","env":` + envJSON + `}}}`}, nil, nil
@@ -1461,11 +1461,11 @@ func (claudeTestAgent) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
 
 type piTestAgent struct{}
 
-func (piTestAgent) Name() string           { return "pi" }
-func (piTestAgent) BinaryNames() []string  { return []string{"pi"} }
-func (piTestAgent) Args() []string         { return nil }
-func (piTestAgent) Env() map[string]string { return nil }
-func (piTestAgent) LLMEndpointEnv() string { return "" }
+func (piTestAgent) Name() string                { return "pi" }
+func (piTestAgent) BinaryNames() []string       { return []string{"pi"} }
+func (piTestAgent) Args(_ launch.Mode) []string { return nil }
+func (piTestAgent) Env() map[string]string      { return nil }
+func (piTestAgent) LLMEndpointEnv() string      { return "" }
 func (piTestAgent) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string, _ launch.Mode) ([]string, []launch.MCPMount, error) {
 	envJSON := encodeJSON(t1, mcpEnv)
 	return []string{"--mcp-config", `{"mcpServers":{"aileron":{"command":"` + mcpBin + `","env":` + envJSON + `}}}`}, nil, nil
@@ -1474,11 +1474,11 @@ func (piTestAgent) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
 
 type gooseTestAgent struct{}
 
-func (gooseTestAgent) Name() string           { return "goose" }
-func (gooseTestAgent) BinaryNames() []string  { return []string{"goose"} }
-func (gooseTestAgent) Args() []string         { return []string{"session"} }
-func (gooseTestAgent) Env() map[string]string { return nil }
-func (gooseTestAgent) LLMEndpointEnv() string { return "" }
+func (gooseTestAgent) Name() string                { return "goose" }
+func (gooseTestAgent) BinaryNames() []string       { return []string{"goose"} }
+func (gooseTestAgent) Args(_ launch.Mode) []string { return []string{"session"} }
+func (gooseTestAgent) Env() map[string]string      { return nil }
+func (gooseTestAgent) LLMEndpointEnv() string      { return "" }
 func (gooseTestAgent) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string, _ launch.Mode) ([]string, []launch.MCPMount, error) {
 	// Mirror agents/goose.go's "ENV=val ENV=val cmd" shape, deterministic order.
 	keys := []string{}
@@ -1497,11 +1497,11 @@ func (gooseTestAgent) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
 
 type openCodeTestAgent struct{}
 
-func (openCodeTestAgent) Name() string           { return "opencode" }
-func (openCodeTestAgent) BinaryNames() []string  { return []string{"opencode"} }
-func (openCodeTestAgent) Args() []string         { return nil }
-func (openCodeTestAgent) Env() map[string]string { return nil }
-func (openCodeTestAgent) LLMEndpointEnv() string { return "" }
+func (openCodeTestAgent) Name() string                { return "opencode" }
+func (openCodeTestAgent) BinaryNames() []string       { return []string{"opencode"} }
+func (openCodeTestAgent) Args(_ launch.Mode) []string { return nil }
+func (openCodeTestAgent) Env() map[string]string      { return nil }
+func (openCodeTestAgent) LLMEndpointEnv() string      { return "" }
 func (openCodeTestAgent) ConfigureMCP(mcpBin string, mcpEnv map[string]string, dir string, _ launch.Mode) ([]string, []launch.MCPMount, error) {
 	if dir == "" {
 		cwd, _ := os.Getwd()


### PR DESCRIPTION
## Summary

Claude's launch flags are now mode-conditional, giving container/sandbox launches full autonomy while host/`--local` launches keep the narrower per-tool whitelist.

`Claude.Args()` previously returned `--allowedTools "Bash(*) mcp__aileron"` unconditionally, and the `Agent.Args()` interface method took no `Mode`, so it could not branch. Both launch paths (`launchHost`, `launchSandbox`) called it, so sandbox launches got the same narrow whitelist as host launches. Codex already implements the container-YOLO/host-normal split, but does it entirely via its injected `config.toml` (`Codex.Args()` returns nil); Claude has no config file, so the flag must come from argv and `Args()` must become mode-aware.

The sandbox container is the trust boundary (ADR-0015), so under `ModeSandbox` Claude now passes `--dangerously-skip-permissions` alone. This mirrors Codex's container posture (`approval_policy = "never"` + `sandbox_mode = "danger-full-access"` in `mergeCodexSandboxConfig`). The flag is passed alone, not alongside `--allowedTools`, because it subsumes all per-tool gating; combining them would be redundant.

### Changes
- `Agent.Args()` -> `Args(mode launch.Mode)` in `internal/launch/agent.go`, mirroring the existing `ConfigureMCP(..., mode Mode)` pattern.
- Both callers in `launcher.go` pass `ModeHost` / `ModeSandbox`.
- `Claude.Args(mode)`: `--dangerously-skip-permissions` under `ModeSandbox`; `--allowedTools "Bash(*) mcp__aileron"` under `ModeHost`.
- The other five agents (Codex, OpenCode, Goose, Pi) accept and ignore the mode. Behavior unchanged; they already auto-approve via their own mechanisms (Goose `GOOSE_MODE=auto`, Pi `--tools`, Codex/OpenCode config files). Out of scope per the issue, which frames this as a Claude-to-Codex parity fix.

## Test plan
- `TestClaude_Args_SandboxSkipsPermissions` (regression): `ModeSandbox` yields `--dangerously-skip-permissions` alone, and asserts `--allowedTools` is NOT present. Fails before the fix (old single-return impl always returned `--allowedTools`), passes after.
- `TestClaude_Args_HostAllowsBashAndAileronMCP`: `ModeHost` yields the `--allowedTools` pair (unchanged host posture).
- All mock/fake agents and the other agents' tests updated to pass a `Mode`.
- `go build` across all workspace modules; `go test ./launch/...` and `cmd/aileron` suites green; `gofmt` clean on touched files.

Closes #1330
