### PR TITLE
feat(sandbox): author the gh devcontainer Feature carrying its customizations.aileron unit

### DIFF
--- a/.github/workflows/sandbox-features.yml
+++ b/.github/workflows/sandbox-features.yml
@@ -55,7 +55,7 @@ jobs:
       # PR runs validate the Features package without pushing; ci.yml's
       # integration-sandbox-features job is the build/compose acceptance gate, so
       # this keeps the PR path lightweight. `devcontainer features package` walks
-      # the directory, processes each sub-Feature (claude, codex), and fails on a
+      # the directory, processes each sub-Feature (claude, codex, gh), and fails on a
       # malformed manifest. It is the same directory-walk the publish step uses,
       # minus the push.
       - name: Validate Features package
@@ -76,7 +76,7 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       # `devcontainer features publish` walks images/sandbox-features and pushes
-      # each sub-Feature (claude, codex) to ghcr.io/<namespace>/<id>. A "0.0.1"
+      # each sub-Feature (claude, codex, gh) to ghcr.io/<namespace>/<id>. A "0.0.1"
       # manifest publishes the tag set 0.0.1, 0.0, 0, and latest, so the
       # scaffold's ":0" reference resolves.
       #

--- a/images/sandbox-features/gh/devcontainer-feature.json
+++ b/images/sandbox-features/gh/devcontainer-feature.json
@@ -1,0 +1,42 @@
+{
+  "id": "gh",
+  "version": "0.0.1",
+  "name": "GitHub CLI",
+  "description": "Installs the GitHub CLI (github-cli) onto the Aileron Alpine sandbox base so it is on PATH for the non-root agent user, and carries gh's full CLI-capability unit (acquisition + credential sealing) under customizations.aileron.cli.",
+  "documentationURL": "https://docs.withaileron.ai/development/sandbox-agent-images/",
+  "customizations": {
+    "aileron": {
+      "cli": {
+        "name": "gh",
+        "key": "user/github",
+        "presence": {
+          "builtin": "base"
+        },
+        "acquisition": {
+          "mode": "device-flow",
+          "container_name": "aileron-auth-github",
+          "login_cmd": ["gh", "auth", "login", "--hostname", "github.com", "--git-protocol", "https", "--web"],
+          "token_cmd": ["gh", "auth", "token", "--hostname", "github.com"],
+          "browser_shim": "echo"
+        },
+        "sealing": [
+          {
+            "host": "github.com",
+            "scheme": "basic",
+            "emit_mechanism": "inject",
+            "username": "x-access-token"
+          },
+          {
+            "host": "api.github.com",
+            "scheme": "bearer",
+            "emit_mechanism": "sentinel-swap",
+            "sentinel": {
+              "value": "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA",
+              "env": "GH_TOKEN"
+            }
+          }
+        ]
+      }
+    }
+  }
+}

--- a/images/sandbox-features/gh/install.sh
+++ b/images/sandbox-features/gh/install.sh
@@ -1,0 +1,23 @@
+#!/bin/sh
+# Aileron sandbox Feature: GitHub CLI (gh).
+#
+# Single source of truth for the gh install recipe when gh ships as a
+# composable Feature. This script runs as root during the image build on the
+# Aileron Alpine sandbox base; the resulting `gh` binary lands on PATH for the
+# non-root `agent` user.
+#
+# Unlike the agent Features (claude, codex), gh is an apk-only install with no
+# npm package: it is a CLI-capability Feature, not an npm agent recipe. Its
+# parity target is the base images/sandbox-base/Containerfile `github-cli`
+# line, not the npm-keyed recipe table in
+# internal/sandbox/composition/recipes.go.
+set -eu
+
+# github-cli ships only in Alpine's community repo, which alpine:3.24 does not
+# enable by default. Scope the community repo to this single apk invocation via
+# --repository (pinned to v3.24 to match the base FROM tag) so the install
+# reproduces the base Containerfile's community-repo scoping exactly. apk
+# --no-cache keeps the step idempotent and image-layer-clean.
+apk add --no-cache \
+    --repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community \
+    github-cli

--- a/internal/cli/gh_feature_unit_test.go
+++ b/internal/cli/gh_feature_unit_test.go
@@ -1,0 +1,225 @@
+package cli
+
+import (
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"reflect"
+	"testing"
+
+	"gopkg.in/yaml.v3"
+
+	"github.com/ALRubinger/aileron/internal/auth/capture"
+	"github.com/ALRubinger/aileron/internal/proxybinding"
+)
+
+// TestGHFeatureUnitParsesAndMatchesDefaults is the load-bearing acceptance test
+// for the gh devcontainer Feature authored under images/sandbox-features/gh/.
+// It proves two contracts:
+//
+//  1. The customizations.aileron.cli block in gh's manifest parses into this
+//     package's Unit type and validates, with the exact acquisition and sealing
+//     values the brief specifies.
+//  2. The Feature's unit is byte-for-byte in intent with the SHIPPED central
+//     defaults it is destined to replace: internal/auth/capture/defaults/gh.yaml
+//     (acquisition) and internal/proxybinding/defaults/github.yaml (sealing).
+//     This is the regression guard that catches any future edit to either
+//     source diverging from the Feature before the cutover sub-issue removes
+//     them.
+//
+// It is a plain `go test` with no build tag: cheap, always-run, no Docker.
+func TestGHFeatureUnitParsesAndMatchesDefaults(t *testing.T) {
+	unit := parseGHFeatureUnit(t)
+
+	// (1) Envelope identity and reserved-plane values.
+	if unit.Name != "gh" {
+		t.Fatalf("unit.Name = %q, want %q", unit.Name, "gh")
+	}
+	if unit.Key != "user/github" {
+		t.Fatalf("unit.Key = %q, want %q", unit.Key, "user/github")
+	}
+	if unit.Presence == nil || unit.Presence.Builtin != "base" {
+		t.Fatalf("unit.Presence = %+v, want builtin=base", unit.Presence)
+	}
+	if unit.Acquisition.Mode != AcquisitionModeDeviceFlow {
+		t.Fatalf("unit.Acquisition.Mode = %q, want %q", unit.Acquisition.Mode, AcquisitionModeDeviceFlow)
+	}
+
+	// The derived kind is the first path segment of the key. ToCaptureDescriptor
+	// is the canonical derivation; assert through it rather than re-deriving.
+	desc, err := unit.ToCaptureDescriptor()
+	if err != nil {
+		t.Fatalf("unit.ToCaptureDescriptor: %v", err)
+	}
+	if desc.Kind != "user" {
+		t.Fatalf("derived kind = %q, want %q", desc.Kind, "user")
+	}
+	if desc.StoreAt != "user/github" {
+		t.Fatalf("derived store_at = %q, want %q", desc.StoreAt, "user/github")
+	}
+
+	// (2a) Acquisition matches the shipped capture default field-for-field.
+	ghDefault := loadCaptureDefault(t)
+
+	if !reflect.DeepEqual(unit.Acquisition.LoginCmd, ghDefault.LoginCmd) {
+		t.Fatalf("login_cmd = %#v, want %#v (from gh.yaml)", unit.Acquisition.LoginCmd, ghDefault.LoginCmd)
+	}
+	if !reflect.DeepEqual(unit.Acquisition.TokenCmd, ghDefault.TokenCmd) {
+		t.Fatalf("token_cmd = %#v, want %#v (from gh.yaml)", unit.Acquisition.TokenCmd, ghDefault.TokenCmd)
+	}
+	if unit.Acquisition.BrowserShim != ghDefault.BrowserShim {
+		t.Fatalf("browser_shim = %q, want %q (from gh.yaml)", unit.Acquisition.BrowserShim, ghDefault.BrowserShim)
+	}
+	if unit.Acquisition.ContainerName != ghDefault.ContainerName {
+		t.Fatalf("container_name = %q, want %q (from gh.yaml)", unit.Acquisition.ContainerName, ghDefault.ContainerName)
+	}
+	if unit.Acquisition.ConfigDir != ghDefault.ConfigDir {
+		t.Fatalf("config_dir = %q, want %q (from gh.yaml; gh omits it)", unit.Acquisition.ConfigDir, ghDefault.ConfigDir)
+	}
+	// The converted descriptor must reproduce the shipped store_at and kind.
+	if desc.StoreAt != ghDefault.StoreAt {
+		t.Fatalf("derived store_at = %q, want %q (from gh.yaml)", desc.StoreAt, ghDefault.StoreAt)
+	}
+	if desc.Kind != ghDefault.Kind {
+		t.Fatalf("derived kind = %q, want %q (from gh.yaml)", desc.Kind, ghDefault.Kind)
+	}
+
+	// (2b) Sealing matches the shipped proxybinding default field-for-field.
+	githubDefault := loadProxyBindingDefault(t)
+	entries, err := unit.ToSealingEntries()
+	if err != nil {
+		t.Fatalf("unit.ToSealingEntries: %v", err)
+	}
+	if len(entries) != len(githubDefault.Bindings) {
+		t.Fatalf("sealing has %d bindings, want %d (from github.yaml)", len(entries), len(githubDefault.Bindings))
+	}
+	for i := range entries {
+		got := entries[i]
+		want := githubDefault.Bindings[i]
+		if !reflect.DeepEqual(got, want) {
+			t.Fatalf("sealing[%d] = %#v, want %#v (from github.yaml)", i, got, want)
+		}
+	}
+
+	// Spell out the load-bearing literals so a default edit that changes the
+	// intent (not just the byte layout) is unmistakable in the failure.
+	if entries[0].Host != "github.com" || entries[0].Scheme != "basic" ||
+		entries[0].EmitMechanism != "inject" || entries[0].Username != "x-access-token" {
+		t.Fatalf("github.com binding = %#v, want host=github.com scheme=basic emit=inject username=x-access-token", entries[0])
+	}
+	if entries[1].Host != "api.github.com" || entries[1].Scheme != "bearer" ||
+		entries[1].EmitMechanism != "sentinel-swap" || entries[1].Sentinel == nil ||
+		entries[1].Sentinel.Value != "ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA" ||
+		entries[1].Sentinel.Env != "GH_TOKEN" {
+		t.Fatalf("api.github.com binding = %#v, want host=api.github.com scheme=bearer emit=sentinel-swap sentinel{value=ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA env=GH_TOKEN}", entries[1])
+	}
+	// The derived credential_ref must equal the key on every binding.
+	for i := range entries {
+		if entries[i].CredentialRef != "user/github" {
+			t.Fatalf("sealing[%d].CredentialRef = %q, want %q (derived from key)", i, entries[i].CredentialRef, "user/github")
+		}
+	}
+}
+
+// parseGHFeatureUnit reads the gh Feature manifest, extracts the
+// customizations.aileron.cli block, re-encodes it as YAML, and feeds it through
+// the canonical Parse so the test exercises the same decode path a loader will.
+func parseGHFeatureUnit(t *testing.T) Unit {
+	t.Helper()
+	manifestPath := filepath.Join(sandboxFeaturesContext(t), "gh", "devcontainer-feature.json")
+	raw, err := os.ReadFile(manifestPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", manifestPath, err)
+	}
+
+	var manifest struct {
+		Customizations struct {
+			Aileron struct {
+				CLI json.RawMessage `json:"cli"`
+			} `json:"aileron"`
+		} `json:"customizations"`
+	}
+	if err := json.Unmarshal(raw, &manifest); err != nil {
+		t.Fatalf("%s is not valid JSON: %v", manifestPath, err)
+	}
+	if len(manifest.Customizations.Aileron.CLI) == 0 {
+		t.Fatalf("%s has no customizations.aileron.cli block", manifestPath)
+	}
+
+	// JSON is a subset of YAML, but routing through a generic map and re-marshal
+	// to YAML mirrors how a host loader will hand the block to Parse and avoids
+	// coupling the test to JSON-vs-YAML decode quirks.
+	var generic map[string]any
+	if err := json.Unmarshal(manifest.Customizations.Aileron.CLI, &generic); err != nil {
+		t.Fatalf("decode customizations.aileron.cli: %v", err)
+	}
+	yamlBytes, err := yaml.Marshal(generic)
+	if err != nil {
+		t.Fatalf("re-marshal cli block to yaml: %v", err)
+	}
+
+	unit, err := Parse(yamlBytes)
+	if err != nil {
+		t.Fatalf("Parse(gh customizations.aileron.cli): %v\nblock:\n%s", err, yamlBytes)
+	}
+	return unit
+}
+
+// loadCaptureDefault parses the shipped capture default for gh.
+func loadCaptureDefault(t *testing.T) capture.CaptureDescriptor {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "internal", "auth", "capture", "defaults", "gh.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	desc, err := capture.ParseCaptureDescriptor(raw)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return desc
+}
+
+// loadProxyBindingDefault parses the shipped proxybinding default for github.
+func loadProxyBindingDefault(t *testing.T) proxybinding.Descriptor {
+	t.Helper()
+	path := filepath.Join(repoRoot(t), "internal", "proxybinding", "defaults", "github.yaml")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	desc, err := proxybinding.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse %s: %v", path, err)
+	}
+	return desc
+}
+
+// sandboxFeaturesContext locates the repo-root images/sandbox-features
+// directory by walking up from the test working directory, mirroring
+// featuresContext in internal/sandbox/composition/features_test.go.
+func sandboxFeaturesContext(t *testing.T) string {
+	t.Helper()
+	return filepath.Join(repoRoot(t), "images", "sandbox-features")
+}
+
+// repoRoot walks up from the test working directory to the repo root, located
+// by the images/sandbox-features marker directory.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	start, err := os.Getwd()
+	if err != nil {
+		t.Fatalf("getwd: %v", err)
+	}
+	dir := start
+	for {
+		if info, err := os.Stat(filepath.Join(dir, "images", "sandbox-features")); err == nil && info.IsDir() {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("repo root (images/sandbox-features marker) not found from %s", start)
+		}
+		dir = parent
+	}
+}

--- a/internal/launch/sandbox_features_composition_integration_test.go
+++ b/internal/launch/sandbox_features_composition_integration_test.go
@@ -159,6 +159,102 @@ func TestSandboxFeaturesComposeViaAileron(t *testing.T) {
 	}
 }
 
+// TestGHFeatureComposesViaAileron composes the gh CLI-capability Feature plus a
+// trivial probe Feature through Aileron's Discover -> Build path and asserts
+// `gh` resolves on PATH in the built image. It is a sibling of
+// TestSandboxFeaturesComposeViaAileron rather than a third Feature inside it so
+// gh's apk-only install path stays independent of the codex npm path and the
+// two tests do not share a Feature-count assertion.
+//
+// The Feature's customizations.aileron.cli block is inert to @devcontainers/cli
+// (it ignores unknown customization namespaces), so this test proves install
+// correctness only; the unit-parse correctness of that block is covered by the
+// always-run TestGHFeatureUnitParsesAndMatchesDefaults in internal/cli.
+func TestGHFeatureComposesViaAileron(t *testing.T) {
+	rt, err := sandboxcontainer.ResolveRuntime("docker")
+	if err != nil {
+		// Fail-fast: CI provisions Docker; absence is a job failure, not a skip.
+		t.Fatalf("no docker runtime on PATH (required, not skipped): %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 20*time.Minute)
+	defer cancel()
+
+	buildSandboxFeaturesBaseImage(ctx, t, rt)
+
+	featuresRoot := sandboxFeaturesContext(t)
+	ghFeatureDir := filepath.Join(featuresRoot, "gh")
+	if _, err := os.Stat(filepath.Join(ghFeatureDir, "devcontainer-feature.json")); err != nil {
+		t.Fatalf("gh feature not found at %s: %v", ghFeatureDir, err)
+	}
+
+	workspace := t.TempDir()
+	devDir := filepath.Join(workspace, ".devcontainer")
+	if err := os.MkdirAll(devDir, 0o755); err != nil {
+		t.Fatalf("mkdir .devcontainer: %v", err)
+	}
+
+	// Copy the gh Feature into .devcontainer/gh: the only path form
+	// @devcontainers/cli accepts for a local Feature is relative to .devcontainer.
+	copyFeatureDir(t, ghFeatureDir, filepath.Join(devDir, "gh"))
+
+	// A trivial second Feature so the plan composes more than one Feature,
+	// matching the codex composition test's shape.
+	const probeTool = "aileron-gh-feature-probe"
+	writeProbeFeature(t, filepath.Join(devDir, "probe"), probeTool)
+
+	dc := map[string]any{
+		"name":  "aileron-gh-feature-composition",
+		"image": sandboxFeaturesBaseImage,
+		"features": map[string]any{
+			"./gh":    map[string]any{},
+			"./probe": map[string]any{},
+		},
+	}
+	raw, err := json.MarshalIndent(dc, "", "  ")
+	if err != nil {
+		t.Fatalf("marshal devcontainer.json: %v", err)
+	}
+	if err := os.WriteFile(filepath.Join(devDir, "devcontainer.json"), raw, 0o644); err != nil {
+		t.Fatalf("write devcontainer.json: %v", err)
+	}
+
+	plan, err := sandboxcomposition.Discover(workspace, "test", "")
+	if err != nil {
+		t.Fatalf("composition.Discover: %v", err)
+	}
+	if plan.Tier != sandboxcomposition.TierDevcontainer {
+		t.Fatalf("plan.Tier = %s, want %s", plan.Tier, sandboxcomposition.TierDevcontainer)
+	}
+	if len(plan.Features) != 2 {
+		t.Fatalf("plan.Features = %#v, want 2 (gh + probe)", plan.Features)
+	}
+
+	builder := sandboxcontainer.Builder{
+		Runtime: rt,
+		Stdout:  testLogWriter{t},
+		Stderr:  testLogWriter{t},
+	}
+	result, err := builder.Build(ctx, sandboxcontainer.BuildOptions{
+		WorkDir: workspace,
+		Plan:    plan,
+		Policy:  sandboxcontainer.BuildPolicyAlways,
+	})
+	if err != nil {
+		t.Fatalf("Builder.Build via @devcontainers/cli: %v", err)
+	}
+	if !result.Built {
+		t.Fatalf("result.Built = false, want true (features require a build)")
+	}
+	if result.Image == "" {
+		t.Fatalf("result.Image is empty")
+	}
+
+	// Both the gh CLI and the probe tool must resolve on PATH.
+	assertCommandOnPath(ctx, t, rt, result.Image, "gh")
+	assertCommandOnPath(ctx, t, rt, result.Image, probeTool)
+}
+
 // writeProbeFeature authors a minimal local devcontainer Feature whose
 // install.sh drops an executable `tool` onto PATH. It exists to prove
 // multi-Feature composition without depending on a published Feature ref.

--- a/internal/sandbox/composition/features_test.go
+++ b/internal/sandbox/composition/features_test.go
@@ -46,9 +46,18 @@ type featureManifest struct {
 	Description string `json:"description"`
 }
 
+// featureIDs is every Feature published from images/sandbox-features: the npm
+// agent Features (claude, codex) plus the apk-only CLI-capability Feature (gh).
+// The shared manifest-validity and install-presence contracts apply to all of
+// them; the npm-recipe parity and scaffold-reference contracts apply only to
+// the agent Features (see TestFeatureInstallScriptsMatchCanonicalRecipe and
+// TestScaffoldFeatureReferenceMatchesManifestVersion, which keep their own
+// agent-only lists).
+var featureIDs = []string{"claude", "codex", "gh"}
+
 func TestFeatureManifestsAreValid(t *testing.T) {
 	root := featuresContext(t)
-	for _, agent := range []string{"claude", "codex"} {
+	for _, agent := range featureIDs {
 		agent := agent
 		t.Run(agent, func(t *testing.T) {
 			path := filepath.Join(root, agent, "devcontainer-feature.json")
@@ -159,7 +168,7 @@ func sortedKeys(m map[string]bool) []string {
 
 func TestFeatureInstallScriptsArePresentAndExecutable(t *testing.T) {
 	root := featuresContext(t)
-	for _, agent := range []string{"claude", "codex"} {
+	for _, agent := range featureIDs {
 		agent := agent
 		t.Run(agent, func(t *testing.T) {
 			path := filepath.Join(root, agent, "install.sh")
@@ -245,5 +254,50 @@ func TestFeatureInstallScriptsMatchCanonicalRecipe(t *testing.T) {
 				}
 			}
 		})
+	}
+}
+
+// TestGHFeatureInstallScriptMatchesBaseContainerfile is the gh-specific install
+// parity check. gh is not an npm agent recipe (no @vendor/pkg, not in
+// agentRecipes), so it is deliberately excluded from
+// TestFeatureInstallScriptsMatchCanonicalRecipe. Its parity target is instead
+// the base images/sandbox-base/Containerfile `github-cli` line: same package,
+// same v3.24 community-repo scoping, apk-only, and no baked credential.
+func TestGHFeatureInstallScriptMatchesBaseContainerfile(t *testing.T) {
+	root := featuresContext(t)
+	path := filepath.Join(root, "gh", "install.sh")
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read %s: %v", path, err)
+	}
+	body := string(raw)
+
+	// apk-only: the Alpine base has no apt-get, and gh has no npm package.
+	if !strings.Contains(body, "apk add") {
+		t.Fatalf("%s must install via apk (the Alpine base has no apt-get):\n%s", path, body)
+	}
+	if strings.Contains(body, "apt-get") {
+		t.Fatalf("%s uses apt-get; the Alpine base requires apk:\n%s", path, body)
+	}
+	if strings.Contains(body, "npm install") {
+		t.Fatalf("%s installs via npm; gh is an apk-only CLI Feature, not an npm agent recipe:\n%s", path, body)
+	}
+
+	// Installs the github-cli apk package, scoped to the v3.24 community repo,
+	// reproducing the base Containerfile's community-repo line.
+	if !strings.Contains(body, "github-cli") {
+		t.Fatalf("%s must install the github-cli apk package:\n%s", path, body)
+	}
+	const communityRepo = "--repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community"
+	if !strings.Contains(body, communityRepo) {
+		t.Fatalf("%s must scope the v3.24 community repo with %q (parity with images/sandbox-base/Containerfile):\n%s", path, communityRepo, body)
+	}
+
+	// No credential reads baked into the Feature: the sealing data lives in the
+	// manifest's customizations.aileron.cli block, never in the install script.
+	for _, secret := range []string{"GH_TOKEN", "GITHUB_TOKEN"} {
+		if strings.Contains(body, secret) {
+			t.Fatalf("%s references credential env var %q; the gh Feature must not read or bake credentials:\n%s", path, secret, body)
+		}
 	}
 }


### PR DESCRIPTION
## Summary

Authors `images/sandbox-features/gh/` as a single self-contained devcontainer Feature that (a) installs `github-cli` onto the Aileron Alpine sandbox base via `apk` and (b) carries gh's full CLI-capability unit under `customizations.aileron.cli`, conforming to the `internal/cli` schema landed in #1332.

- **`install.sh`** (mode 100755): apk-only install scoped to the v3.24 community repo, reproducing the base `images/sandbox-base/Containerfile` `github-cli` line. No npm (gh is a CLI-capability Feature, not an npm agent recipe), no baked credential.
- **`devcontainer-feature.json`**: `id: gh`, `version: 0.0.1`, mirroring the claude/codex manifest shape, plus a `customizations.aileron.cli` block whose acquisition + sealing values mirror the shipped central defaults byte-for-byte in intent.
- The unit derives `store_at`/`credential_ref`/`kind` from the single `key: user/github` per #1332's single-source rule; none are re-declared.

### Scope (explicit)

This issue produces the artifact and proves it composes. It does **not** delete `internal/auth/capture/defaults/gh.yaml` or `internal/proxybinding/defaults/github.yaml`, does **not** wire any host-side loader, and does **not** touch `scaffold.go`/`FeatureReference`/`recipes.go`/the base Containerfile. Those are the later cutover sub-issue. gh is **not** added to `agentRecipes`, the npm-recipe parity loop, or the scaffold-reference loop (it is apk-only with no scaffold reference).

## Test plan

- **`internal/cli/gh_feature_unit_test.go`** (new, always-run, no build tag): parses the manifest's `customizations.aileron.cli` block into the `cli.Unit` type and asserts field-for-field equality with **both** central defaults (`gh.yaml` acquisition + `github.yaml` sealing), including the exact sentinel value `ghp_AILERONSENTINELAAAAAAAAAAAAAAAAAAAAA` and `GH_TOKEN`. This is the load-bearing drift guard. `go test ./internal/cli/...` green, 98.5% coverage.
- **`internal/sandbox/composition/features_test.go`**: gh added to the shared manifest-validity and install-exec-bit loops via a new `featureIDs` slice; the npm-recipe and scaffold-reference loops keep their agent-only `{claude, codex}` lists unchanged. New `TestGHFeatureInstallScriptMatchesBaseContainerfile` asserts apk-only, `github-cli`, v3.24 community-repo scoping, no `apt-get`/`npm`, and no baked `GH_TOKEN`/`GITHUB_TOKEN`. `go test ./internal/sandbox/composition/...` green.
- **`internal/launch/sandbox_features_composition_integration_test.go`** (`integration_sandbox` tag, fail-fast): new sibling `TestGHFeatureComposesViaAileron` composes the gh Feature + a probe Feature through Aileron's `Discover -> Build` path and asserts `gh` resolves on PATH. Requires Docker; CI's `integration-sandbox-features` job is the gate. Compiles clean under the build tag locally (`go vet -tags=integration_sandbox`).
- `devcontainer features package ./images/sandbox-features` accepts the gh Feature locally (the PR gate): "Packaged 3 features!".
- `task build` green.

### Notes

- CodeRabbit CLI review was rate-limited (free-tier, ~13 min cooldown) at PR-open time; the repo's CodeRabbit PR bot will review on this PR. I self-reviewed the diff for scope and correctness. No P0 findings.

Closes #1320
