### PR TITLE
refactor(sandbox-base): compose gh as a Feature carrying its CLI-unit label

### DIFF
--- a/.github/workflows/sandbox-base.yml
+++ b/.github/workflows/sandbox-base.yml
@@ -34,12 +34,29 @@ jobs:
   build:
     name: Build sandbox-base
     runs-on: ubuntu-latest
+    # A throwaway local registry the PR compose path pushes the substrate to and
+    # FROMs. The stage-2 `devcontainer build` runs under the buildx
+    # docker-container driver (an isolated BuildKit container), which cannot see
+    # images in the local docker store. On publish the substrate lives in GHCR so
+    # the driver can pull it; the PR path now mirrors that through localhost:5000
+    # instead of a `load`ed image the driver can't reach (the #1342 regression
+    # reverted in #1348). The service is idle on tag/dispatch publish builds.
+    services:
+      registry:
+        image: registry:2
+        ports:
+          - 5000:5000
     steps:
       - uses: actions/checkout@v6
 
       - uses: docker/setup-qemu-action@v4
 
+      # network=host lets the docker-container builder reach the localhost:5000
+      # registry service (BuildKit treats localhost registries as insecure/http
+      # automatically), so it can both push and FROM the PR substrate.
       - uses: docker/setup-buildx-action@v4
+        with:
+          driver-opts: network=host
 
       # Version stamped into the baked aileron-mcp and the
       # ai.aileron.mcp.version image label. Tag builds carry the release
@@ -76,41 +93,107 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      # context is the repo root so the builder stage can compile aileron-mcp
-      # from go.work + source; the baked recipe lives in Containerfile.published.
-      - name: Build image
+      - name: Resolve publish flag
+        id: publish
+        run: echo "publish=${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}" >> "$GITHUB_OUTPUT"
+
+      # Node + @devcontainers/cli, pinned to match ci.yml and
+      # sandbox-features.yml so the three workflows stay aligned (umbrella #1319).
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+      - name: Install @devcontainers/cli
+        run: npm install -g @devcontainers/cli@0.87.0
+
+      # Stage 1 (substrate): build the repo-root, multi-arch, mcp-baked substrate
+      # exactly as before, minus github-cli (gh now ships as a Feature, composed
+      # in stage 2). context is the repo root so the mcp-builder stage can compile
+      # aileron-mcp from go.work + source. On publish the multi-arch substrate is
+      # pushed to a short-lived per-sha GHCR ref that the compose stage FROMs; on
+      # PR it is pushed single-arch to the localhost:5000 registry service the
+      # compose stage FROMs (the docker-container driver can pull a registry but
+      # not a `load`ed local image).
+      - name: Build substrate (publish, multi-arch)
+        if: ${{ steps.publish.outputs.publish == 'true' }}
         uses: docker/build-push-action@v7
         with:
           context: .
           file: images/sandbox-base/Containerfile.published
           platforms: linux/amd64,linux/arm64
-          push: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
-          tags: ${{ steps.meta.outputs.tags }}
-          labels: ${{ steps.meta.outputs.labels }}
+          push: true
+          tags: ${{ env.IMAGE_NAME }}:substrate-${{ github.sha }}
           build-args: |
             AILERON_VERSION=${{ steps.ver.outputs.version }}
             AILERON_COMMIT=${{ github.sha }}
 
-      # Single-arch local load so the next step can `docker run` the image.
-      # The multi-arch build above cannot use `load: true`.
-      - name: Build image for smoke test
+      - name: Build substrate (PR, single-arch push to local registry)
+        if: ${{ steps.publish.outputs.publish != 'true' }}
         uses: docker/build-push-action@v7
         with:
           context: .
           file: images/sandbox-base/Containerfile.published
-          load: true
-          tags: aileron-sandbox-base:smoke
+          push: true
+          tags: localhost:5000/aileron-sandbox-base-substrate:pr
           build-args: |
             AILERON_VERSION=${{ steps.ver.outputs.version }}
             AILERON_COMMIT=${{ github.sha }}
 
+      # Stage 2 (compose): render a scratch devcontainer workspace that FROMs the
+      # substrate and composes the gh Feature on top, then build it with
+      # @devcontainers/cli. The compose installs gh and emits the
+      # devcontainer.metadata label carrying gh's customizations.aileron.cli unit
+      # (the unit loader, #1322, reads it). renderWorkspace mirrors the umbrella's
+      # verified probe: a .devcontainer/devcontainer.json from the committed
+      # template plus a copy of images/sandbox-features/gh.
+      - name: Compose gh + publish multi-arch manifest
+        run: |
+          set -euo pipefail
+
+          renderWorkspace() {
+            local ws="$1" substrate="$2"
+            rm -rf "$ws" && mkdir -p "$ws/.devcontainer"
+            cp -r images/sandbox-features/gh "$ws/.devcontainer/gh"
+            SUBSTRATE_IMAGE="$substrate" envsubst < images/sandbox-base/compose/devcontainer.json.tmpl \
+              > "$ws/.devcontainer/devcontainer.json"
+          }
+
+          if [ "${{ steps.publish.outputs.publish }}" = "true" ]; then
+            SUBSTRATE="${IMAGE_NAME}:substrate-${{ github.sha }}"
+            DIGESTS=()
+            for arch in amd64 arm64; do
+              renderWorkspace "compose-$arch" "$SUBSTRATE"
+              FINAL="${IMAGE_NAME}:compose-${{ github.sha }}-$arch"
+              devcontainer build \
+                --workspace-folder "compose-$arch" \
+                --platform "linux/$arch" \
+                --image-name "$FINAL"
+              docker push "$FINAL"
+              DIGESTS+=("${IMAGE_NAME}@$(docker buildx imagetools inspect "$FINAL" --format '{{.Manifest.Digest}}')")
+            done
+            # Assemble the published multi-arch manifest under every meta tag.
+            while IFS= read -r tag; do
+              [ -n "$tag" ] || continue
+              docker buildx imagetools create --tag "$tag" "${DIGESTS[@]}"
+            done <<< "${{ steps.meta.outputs.tags }}"
+          else
+            # PR: compose single-arch onto the substrate pulled from the local
+            # registry (same docker-container driver as publish) for smoke only.
+            # devcontainer build loads the result into the docker store so the
+            # smoke step can `docker run` it.
+            renderWorkspace compose-pr localhost:5000/aileron-sandbox-base-substrate:pr
+            devcontainer build \
+              --workspace-folder compose-pr \
+              --image-name aileron-sandbox-base:smoke
+          fi
+
       # Single-arch local load of the Tier 0 Containerfile so the smoke step can
       # `docker run` it. This recipe takes the images/sandbox-base context (no
       # repo-root, no AILERON_VERSION/COMMIT build-args) and is UNBAKED (no
-      # aileron-mcp). Building it here is the only CI gate on the local recipe;
-      # without it, dropping github-cli from Containerfile would stay green
-      # (issue #1151 P1).
+      # aileron-mcp). It still installs gh via apk (the local Tier 0
+      # Feature-compose move is #1321b), so it remains the #1151 P1 gate on the
+      # local recipe.
       - name: Build local Tier 0 image for smoke test
+        if: ${{ steps.publish.outputs.publish != 'true' }}
         uses: docker/build-push-action@v7
         with:
           context: images/sandbox-base
@@ -118,22 +201,18 @@ jobs:
           load: true
           tags: aileron-sandbox-base-local:smoke
 
-      # Image-fidelity smoke against the published (baked) image: the bash
-      # substrate, the baked-MCP invariants (#957, the binary runs and the
-      # version label is present), and the #959 invariants (no tools.txt or
-      # tools profile banner survives, the proxy CA path is intact for
-      # bootstrap). Earlier matrices exercised the #801 shell-mediation
-      # surface that #952 fully removed.
+      # Image-fidelity smoke against the composed published image (PR only, where
+      # the composed image is loaded as :smoke): gh is present via the Feature AND
+      # the devcontainer.metadata label carries gh's CLI unit, plus the bash
+      # substrate, the baked-MCP invariants (#957), and the #959 invariants.
       - name: Smoke test image
+        if: ${{ steps.publish.outputs.publish != 'true' }}
         run: |
           set -euo pipefail
 
-          # github-cli is part of the base substrate (issue #1146): both recipes
-          # install it from Alpine's community repo. assertGhVersion runs
-          # `gh --version` and relies on set -e to fail the job on a non-zero
-          # exit, exercising the "gh exists and exits 0" acceptance. Invoked
-          # against BOTH the local Tier 0 image (the #1151 P1 gate on the local
-          # recipe) and the published image (proving the recipes stay in sync).
+          # gh present on both the composed published image (via the Feature) and
+          # the local Tier 0 image (still apk, until #1321b). set -e fails the job
+          # on a non-zero `gh --version`.
           assertGhVersion() {
             local img="$1"
             echo "asserting gh --version on $img"
@@ -141,6 +220,16 @@ jobs:
           }
           assertGhVersion aileron-sandbox-base-local:smoke
           assertGhVersion aileron-sandbox-base:smoke
+
+          # The composed image carries gh's CLI-capability unit in the
+          # devcontainer.metadata label (the #1322 loader's source of truth).
+          meta=$(docker inspect --format '{{ index .Config.Labels "devcontainer.metadata" }}' aileron-sandbox-base:smoke)
+          if ! printf '%s' "$meta" | grep -q '"key":"user/github"'; then
+            echo "devcontainer.metadata label missing gh's customizations.aileron.cli unit"
+            echo "$meta"
+            exit 1
+          fi
+          echo "devcontainer.metadata carries gh unit"
 
           IMG=aileron-sandbox-base:smoke
           docker run --rm "$IMG" bash -c 'echo hi' | grep -q '^hi$'

--- a/images/sandbox-base/Containerfile
+++ b/images/sandbox-base/Containerfile
@@ -20,6 +20,11 @@ LABEL org.opencontainers.image.source="https://github.com/ALRubinger/aileron"
 # --repository (pinned to v3.24 to match the FROM tag) so the rest of the
 # package set stays main-only. Keep this list in sync with
 # Containerfile.published's final stage (issue #957).
+#
+# Transitional (umbrella #1319): the PUBLISHED recipe drops github-cli and
+# composes the gh Feature on top instead. This LOCAL recipe keeps the apk line
+# until #1321b moves the local Tier 0 build to the same Feature-compose path; so
+# the two package lists are intentionally out of sync only on github-cli for now.
 RUN apk add --no-cache \
     --repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community \
     bash \

--- a/images/sandbox-base/Containerfile.published
+++ b/images/sandbox-base/Containerfile.published
@@ -66,19 +66,23 @@ LABEL org.opencontainers.image.source="https://github.com/ALRubinger/aileron"
 ARG AILERON_VERSION=dev
 LABEL ai.aileron.mcp.version="${AILERON_VERSION}"
 
-# github-cli ships only in Alpine's community repo, which alpine:3.24 does not
-# enable by default. Scope the community repo to this single apk invocation via
-# --repository (pinned to v3.24 to match the FROM tag) so the rest of the
-# package set stays main-only. Keep this list in sync with Containerfile (the
-# local Tier 0 recipe; issue #957).
+# Base substrate packages. github-cli is NOT installed here: gh ships as a
+# composable devcontainer Feature (images/sandbox-features/gh) layered onto this
+# published substrate by the thin compose step in sandbox-base.yml, carrying
+# gh's CLI-capability unit in the devcontainer.metadata label (umbrella #1319).
+# Every package below lives in Alpine's main repo, so no --repository=community
+# flag is needed.
+#
+# Transitional (umbrella #1319): this PUBLISHED recipe drops github-cli; the
+# LOCAL Tier 0 Containerfile still installs it via apk until #1321b moves the
+# local build to the same Feature-compose path. The two lists are intentionally
+# out of sync only on github-cli for now (was: kept in sync per issue #957).
 RUN apk add --no-cache \
-    --repository=https://dl-cdn.alpinelinux.org/alpine/v3.24/community \
     bash \
     ca-certificates \
     coreutils \
     findutils \
     gawk \
-    github-cli \
     grep \
     procps \
     sed \

--- a/images/sandbox-base/compose/README.md
+++ b/images/sandbox-base/compose/README.md
@@ -1,0 +1,27 @@
+# Published sandbox-base compose layer (umbrella #1319)
+
+The published `aileron-sandbox-base` image is built in two stages:
+
+1. **Substrate** — `images/sandbox-base/Containerfile.published` builds the
+   repo-root, multi-arch, mcp-baked substrate exactly as before, minus
+   `github-cli` (gh now ships as a Feature, not an apk line).
+2. **Compose** — a thin `@devcontainers/cli build` step does `FROM <substrate>`
+   and composes the `images/sandbox-features/gh` Feature on top. That step
+   installs `gh` and emits the `devcontainer.metadata` image label carrying gh's
+   CLI-capability unit (`customizations.aileron.cli`), which the unit loader
+   (#1322) reads at launch/auth time.
+
+`sandbox-base.yml` renders `devcontainer.json` from `devcontainer.json.tmpl`
+(substituting the per-arch substrate ref) into a scratch workspace alongside a
+copy of the gh Feature, then runs `devcontainer build --platform linux/<arch>`
+per architecture and assembles the published multi-arch manifest with
+`docker buildx imagetools create`.
+
+The empirical basis (probed before implementing, umbrella #1319):
+- `@devcontainers/cli@0.87.0` carries the arbitrary `customizations.aileron`
+  namespace into the `devcontainer.metadata` label in full fidelity.
+- Composing the real gh Feature onto an Alpine substrate that ends in
+  `USER agent` + a custom entrypoint installs `gh` and preserves the user,
+  entrypoint, and cmd.
+- `devcontainer build --platform linux/arm64` produces an arm64 image with the
+  label intact.

--- a/images/sandbox-base/compose/devcontainer.json.tmpl
+++ b/images/sandbox-base/compose/devcontainer.json.tmpl
@@ -1,0 +1,7 @@
+{
+  "name": "aileron-sandbox-base",
+  "image": "${SUBSTRATE_IMAGE}",
+  "features": {
+    "./gh": {}
+  }
+}


### PR DESCRIPTION
## Summary

Part of umbrella #1319 (atomic CLI capability units). **Redo of #1342**, which was merged over a red `Build sandbox-base` check and reverted in #1348.

Makes the published `aileron-sandbox-base` image carry gh's CLI-capability unit in its `devcontainer.metadata` label, so the unit loader (#1322) can read gh's acquisition + sealing config from the image instead of central `gh.yaml`/`github.yaml`. The substrate build is unchanged except that `github-cli` moves out of the apk line; gh now composes on top as the `images/sandbox-features/gh` devcontainer Feature.

## What broke #1342, and the fix

The stage-2 `devcontainer build` compose runs under the buildx **docker-container driver** (the isolated BuildKit container created by `setup-buildx-action`), which **cannot see images in the local docker store**. #1342's PR path built the substrate with `load: true` and then `FROM`ed it — so the driver tried to *pull* `aileron-sandbox-base-substrate:pr` from Docker Hub and failed (`repository does not exist`). The local spikes passed only because the local default builder is the `docker` driver, which *can* see local images. The publish path was never broken because its substrate lives in GHCR.

The fix aligns the PR path with the publish path: a throwaway `registry:2` **service** on `localhost:5000`, the buildx builder on `network=host`, and the PR substrate **pushed to** the local registry instead of `load`ed. Both PR and publish now compose `FROM` a registry under the same docker-container driver — so the PR smoke genuinely exercises the same mechanism the release uses, closing the PR-green/publish-red divergence that caused the revert.

## Verified locally (faithful repro, not the docker-driver spike)

Reproduced CI's exact configuration — docker-container driver + `network=host` + a localhost registry (not the `docker` driver the original spikes used):

| Check | Result |
|---|---|
| `devcontainer build` pulls substrate `FROM localhost:<reg>` under the docker-container driver | ✅ (the exact step that failed in #1342) |
| Composed image loads into the docker store for `docker run` smoke | ✅ (`#15 importing to docker`) |
| `gh` present via the Feature | ✅ |
| `devcontainer.metadata` carries gh's unit (`"key":"user/github"`) | ✅ full unit |
| Base `ai.aileron.mcp.version` label preserved through compose | ✅ |
| `USER agent` preserved | ✅ |

## Test plan

- **CI validates the PR path end-to-end** on a real ubuntu runner: substrate build → push to the localhost:5000 service → single-arch compose → smoke (gh present + `"key":"user/github"` in the `devcontainer.metadata` label + the existing mcp/bash/#959 invariants).
- The **multi-arch publish path** (per-arch compose + `imagetools` manifest) only runs on a tag/dispatch build; it reuses the same registry-FROM mechanism the PR path now exercises, but is validated for real on the first release build. Flagging this as the one path PR CI does not fully cover.
- **Merge gated on the `Build sandbox-base` check being verified green** — the lesson from #1342/#1348.

## Deferred (named in #1319, not here)

Local Tier-0 launcher compose (#1321b — the local `Containerfile` keeps `apk github-cli` for now), the unit loader (#1322), the cutover deleting central defaults (#1323), and the ADR/guide (#1324).

Part of #1319. Closes #1321.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
