### PR TITLE
feat(launch): relax authspec gate to known purposes + EnvBinding host-acquire

### DIFF
--- a/internal/launch/authspec.go
+++ b/internal/launch/authspec.go
@@ -67,6 +67,41 @@ type EnvBinding struct {
 	// Render maps a resolved vault secret to one or more env vars.
 	// Returning an error aborts the launch.
 	Render func(vault.Secret) (map[string]string, error)
+
+	// HostAcquire, when non-nil, is a host-side credential acquirer the
+	// launcher invokes when the vault GET for this binding misses and
+	// the binding is not Required. It mirrors FileBinding.HostAcquire
+	// exactly, save that an EnvBinding has no bind-mounted file: on
+	// success the launcher PUTs the acquired Secret through the daemon
+	// (vault before render) and then runs Render into the agent's env
+	// additions rather than writing a file.
+	//
+	// Contract:
+	//
+	//   - The returned Secret must satisfy this same binding's Render.
+	//     The launcher renders the acquired Secret immediately, so a
+	//     malformed envelope surfaces as a launch-aborting Render error
+	//     rather than seeding garbage into the vault.
+	//
+	//   - The acquirer must NOT require the agent CLI to be installed on
+	//     the host. The baseline path is pure Go (HTTP + browser open).
+	//     An acquirer may opportunistically shell out to the agent
+	//     binary as a shortcut, but it must fall back to the pure-Go flow
+	//     when the binary is absent or the shortcut fails.
+	//
+	//   - A returned Secret with an empty Value, or a cancelled/failed
+	//     acquire (non-nil error), is non-fatal: the launcher logs a
+	//     warning and falls back to the legacy in-container login path
+	//     (no env addition; the agent logs in inside the container and
+	//     capture-on-exit seeds the vault). Only a daemon PUT failure or
+	//     a Render failure of a successfully acquired Secret aborts the
+	//     launch.
+	//
+	// A nil HostAcquire preserves the legacy in-container path. The
+	// per-launch `--host-login` flag (and AILERON_LAUNCH_HOST_LOGIN env)
+	// can force the legacy path even for a binding that declares an
+	// acquirer.
+	HostAcquire func(context.Context, HostAcquireDeps) (vault.Secret, error)
 }
 
 // FileBinding declares one file-shaped binding: a host-side file
@@ -327,18 +362,22 @@ var ErrAuthSpecEmptyPath = errors.New("authspec: binding has empty path")
 
 // ErrAuthSpecBadVaultPath is returned when a binding's VaultPath
 // does not follow the documented `agents/<name>/<purpose>` scheme.
-// The daemon endpoint scopes by name and stores at the canonical
-// `agents/<name>/oauth` path; bindings that use a different shape
-// would silently misroute today, so validation rejects them up
-// front.
+// The daemon endpoint scopes by name and routes the third segment
+// via the `purpose` query parameter, but only for a known purpose
+// (`oauth` or `apikey`). A binding whose third segment is an
+// unrecognized purpose would silently route to an unintended vault
+// slot (a typo like `oath` would open a brand-new destination), so
+// validation rejects it up front.
 var ErrAuthSpecBadVaultPath = errors.New("authspec: vault path does not match agents/<name>/<purpose>")
 
 // vaultPathConforms reports whether a binding's VaultPath follows
-// the ADR-0025 namespace scheme. The daemon's per-agent endpoint
-// translates `{name}` to `agents/<name>/oauth`; until v1 ships a
-// way for the launcher to read arbitrary purposes from the daemon,
-// every binding must use that exact suffix or the round-trip
-// through the daemon would silently misroute.
+// the ADR-0025 namespace scheme. A conforming path is exactly
+// `agents/<name>/<purpose>` where <name> is non-empty and <purpose>
+// is a known credential purpose (see isKnownAgentCredentialPurpose:
+// `oauth` or `apikey`). The daemon routes the purpose via the
+// `purpose` query parameter, so any known purpose round-trips
+// correctly; the gate stays a closed set so a typo cannot silently
+// route to a brand-new vault slot.
 func vaultPathConforms(p string) bool {
 	p = strings.TrimLeft(p, "/")
 	parts := strings.Split(p, "/")
@@ -348,7 +387,7 @@ func vaultPathConforms(p string) bool {
 	if parts[0] != "agents" {
 		return false
 	}
-	if parts[1] == "" || parts[2] != "oauth" {
+	if parts[1] == "" || !isKnownAgentCredentialPurpose(parts[2]) {
 		return false
 	}
 	return true

--- a/internal/launch/authspec_host_acquire_test.go
+++ b/internal/launch/authspec_host_acquire_test.go
@@ -247,7 +247,7 @@ func TestPrepareAuthSpec_HostLoginDisabledSkipsAcquirer(t *testing.T) {
 
 func TestPrepareAuthSpec_HostAcquirePutFailureAbortsLaunch(t *testing.T) {
 	daemon := newFakeDaemon()
-	daemon.putErrors["claude"] = errors.New("vault locked")
+	daemon.setPutErrorOAuth("claude", errors.New("vault locked"))
 	spy := &spyAcquirer{secret: vault.Secret{Value: acquireClaudeEnvelope("tok", futureExpiresAtMS)}}
 
 	spec := AuthSpec{
@@ -451,6 +451,262 @@ func TestHostAcquireSilentRender_StatusLineGate(t *testing.T) {
 			t.Errorf("status line = %q, want %q", line, want)
 		}
 	})
+}
+
+// apiKeyEnvRender mirrors an api-key EnvBinding's Render contract: it
+// requires a non-empty Value and surfaces it as a single env var. The
+// var reads the acquired bytes so a render-without-PUT (or a misrouted
+// PUT) would be observable in the resulting EnvAdditions.
+func apiKeyEnvRender(s vault.Secret) (map[string]string, error) {
+	if len(s.Value) == 0 {
+		return nil, errors.New("api-key envelope is empty")
+	}
+	return map[string]string{"AGENT_API_KEY": string(s.Value)}, nil
+}
+
+// TestPrepareAuthSpec_EnvBindingHostAcquireSeedsVaultAndRenders is the
+// EnvBinding mirror of the FileBinding host-acquire happy path: an empty
+// vault plus a declared acquirer plus host-login enabled acquires on the
+// host, PUTs the Secret at the binding's (name, purpose), and renders
+// the var into EnvAdditions with RenderedAnyCredential set. It also
+// pins the deps wiring (Browser, HTTPClient, Out) the launcher supplies.
+func TestPrepareAuthSpec_EnvBindingHostAcquireSeedsVaultAndRenders(t *testing.T) {
+	daemon := newFakeDaemon() // empty vault
+	spy := &spyAcquirer{secret: vault.Secret{Value: []byte("sk-acquired")}}
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath:   "agents/claude/apikey",
+			Required:    false,
+			Render:      apiKeyEnvRender,
+			HostAcquire: spy.acquire,
+		}},
+	}
+
+	stderr := &bytes.Buffer{}
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if spy.calls != 1 {
+		t.Fatalf("acquirer calls = %d, want 1", spy.calls)
+	}
+	if _, ok := spy.gotBrows.(oauth.SystemBrowser); !ok {
+		t.Errorf("acquirer deps Browser = %T, want oauth.SystemBrowser", spy.gotBrows)
+	}
+	if spy.gotDeps.HTTPClient == nil {
+		t.Errorf("acquirer deps HTTPClient is nil; launcher should supply a timed client")
+	}
+	if spy.gotDeps.Out != stderr {
+		t.Errorf("acquirer deps Out = %v, want the launcher's stderr writer", spy.gotDeps.Out)
+	}
+
+	// Exactly one PUT, at the binding's (name, purpose) destination.
+	if len(daemon.puts) != 1 {
+		t.Fatalf("PUTs = %d, want 1", len(daemon.puts))
+	}
+	if daemon.puts[0].Name != "claude" || daemon.puts[0].Purpose != "apikey" {
+		t.Errorf("PUT destination = (%q,%q), want (claude,apikey)", daemon.puts[0].Name, daemon.puts[0].Purpose)
+	}
+	if string(daemon.puts[0].Secret.Value) != "sk-acquired" {
+		t.Errorf("PUT value = %q, want sk-acquired", daemon.puts[0].Secret.Value)
+	}
+
+	// PUT-before-render ordering: the value rendered into the env is the
+	// acquired value, and it landed in the daemon's recorded PUTs. A
+	// render-without-PUT would leave daemon.puts empty.
+	if got := prep.EnvAdditions["AGENT_API_KEY"]; got != "sk-acquired" {
+		t.Errorf("EnvAdditions[AGENT_API_KEY] = %q, want sk-acquired", got)
+	}
+	if !prep.RenderedAnyCredential {
+		t.Errorf("RenderedAnyCredential = false; a successful env host-acquire must set it")
+	}
+}
+
+// TestPrepareAuthSpec_EnvBindingHostAcquireErrorFallsBack pins the
+// non-fatal acquire-error path: no PUT, no env addition, no error, and
+// RenderedAnyCredential stays false.
+func TestPrepareAuthSpec_EnvBindingHostAcquireErrorFallsBack(t *testing.T) {
+	daemon := newFakeDaemon()
+	spy := &spyAcquirer{err: errors.New("user cancelled consent")}
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath:   "agents/claude/apikey",
+			Render:      apiKeyEnvRender,
+			HostAcquire: spy.acquire,
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v (env acquire failure must be non-fatal)", err)
+	}
+	defer prep.Cleanup()
+
+	if spy.calls != 1 {
+		t.Fatalf("acquirer calls = %d, want 1", spy.calls)
+	}
+	if len(daemon.puts) != 0 {
+		t.Errorf("PUTs = %d, want 0", len(daemon.puts))
+	}
+	if _, ok := prep.EnvAdditions["AGENT_API_KEY"]; ok {
+		t.Errorf("EnvAdditions seeded on acquire failure: %v", prep.EnvAdditions)
+	}
+	if prep.RenderedAnyCredential {
+		t.Errorf("RenderedAnyCredential = true; an acquire failure must leave it false")
+	}
+}
+
+// TestPrepareAuthSpec_EnvBindingHostAcquireEmptySecretFallsBack pins the
+// empty-Secret non-fatal path.
+func TestPrepareAuthSpec_EnvBindingHostAcquireEmptySecretFallsBack(t *testing.T) {
+	daemon := newFakeDaemon()
+	spy := &spyAcquirer{secret: vault.Secret{}} // empty Value
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath:   "agents/claude/apikey",
+			Render:      apiKeyEnvRender,
+			HostAcquire: spy.acquire,
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if spy.calls != 1 {
+		t.Fatalf("acquirer calls = %d, want 1", spy.calls)
+	}
+	if len(daemon.puts) != 0 {
+		t.Errorf("PUTs = %d, want 0 (empty Secret → fallback)", len(daemon.puts))
+	}
+	if prep.RenderedAnyCredential {
+		t.Errorf("RenderedAnyCredential = true; an empty acquired Secret must fall back")
+	}
+}
+
+// TestPrepareAuthSpec_EnvBindingHostLoginDisabledSkipsAcquirer pins that
+// a disabled host-login never consults the env acquirer even when
+// declared.
+func TestPrepareAuthSpec_EnvBindingHostLoginDisabledSkipsAcquirer(t *testing.T) {
+	daemon := newFakeDaemon()
+	spy := &spyAcquirer{secret: vault.Secret{Value: []byte("sk-x")}}
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath:   "agents/claude/apikey",
+			Render:      apiKeyEnvRender,
+			HostAcquire: spy.acquire,
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, false)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	if spy.calls != 0 {
+		t.Errorf("acquirer calls = %d, want 0 (host-login disabled)", spy.calls)
+	}
+	if len(daemon.puts) != 0 {
+		t.Errorf("PUTs = %d, want 0", len(daemon.puts))
+	}
+	if prep.RenderedAnyCredential {
+		t.Errorf("RenderedAnyCredential = true; disabled host-login must take the in-container path")
+	}
+}
+
+// TestPrepareAuthSpec_EnvBindingHostAcquirePutFailureAborts pins the
+// PUT-failure-aborts-launch contract. The env loop precedes
+// os.MkdirTemp, so there is no transient dir to leak on abort.
+func TestPrepareAuthSpec_EnvBindingHostAcquirePutFailureAborts(t *testing.T) {
+	daemon := newFakeDaemon()
+	daemon.setPutError("claude", "apikey", errors.New("vault locked"))
+	spy := &spyAcquirer{secret: vault.Secret{Value: []byte("sk-x")}}
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath:   "agents/claude/apikey",
+			Render:      apiKeyEnvRender,
+			HostAcquire: spy.acquire,
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err == nil {
+		t.Fatal("expected error when daemon PUT of the host-acquired env secret fails")
+	}
+	if spy.calls != 1 {
+		t.Errorf("acquirer calls = %d, want 1", spy.calls)
+	}
+	// No transient dir was created (env loop precedes MkdirTemp): Cleanup
+	// is the no-op default and Mounts is empty.
+	prep.Cleanup()
+	if len(prep.Mounts) != 0 {
+		t.Errorf("Mounts = %d on aborted launch, want 0", len(prep.Mounts))
+	}
+}
+
+// TestPrepareAuthSpec_EnvBindingRequiredIgnoresAcquirer pins the
+// required-but-empty fast-fail: the required check precedes any acquire,
+// so the acquirer is never consulted.
+func TestPrepareAuthSpec_EnvBindingRequiredIgnoresAcquirer(t *testing.T) {
+	daemon := newFakeDaemon() // empty vault
+	spy := &spyAcquirer{secret: vault.Secret{Value: []byte("sk-x")}}
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath:   "agents/claude/apikey",
+			Required:    true,
+			Render:      apiKeyEnvRender,
+			HostAcquire: spy.acquire,
+		}},
+	}
+
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err == nil {
+		t.Fatal("expected required-but-empty error")
+	}
+	if spy.calls != 0 {
+		t.Errorf("acquirer calls = %d, want 0 (required check precedes acquire)", spy.calls)
+	}
+}
+
+// TestPrepareAuthSpec_EnvBindingHostAcquireMalformedSecretAborts pins
+// that a malformed acquired Secret surfaces the Render error (launch
+// aborts) rather than silently seeding garbage into the env. The PUT
+// happens first (vault before render), so the abort is the Render call.
+func TestPrepareAuthSpec_EnvBindingHostAcquireMalformedSecretAborts(t *testing.T) {
+	daemon := newFakeDaemon()
+	// apiKeyEnvRender rejects an empty Value; an acquirer that returns a
+	// non-empty but render-incompatible Secret would also abort. Use a
+	// render that rejects this specific value to model garbage.
+	spy := &spyAcquirer{secret: vault.Secret{Value: []byte("garbage")}}
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath: "agents/claude/apikey",
+			Render: func(s vault.Secret) (map[string]string, error) {
+				if string(s.Value) == "garbage" {
+					return nil, errors.New("malformed api-key envelope")
+				}
+				return map[string]string{"AGENT_API_KEY": string(s.Value)}, nil
+			},
+			HostAcquire: spy.acquire,
+		}},
+	}
+
+	_, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err == nil {
+		t.Fatal("expected Render error for a malformed acquired env secret")
+	}
+	if spy.calls != 1 {
+		t.Errorf("acquirer calls = %d, want 1", spy.calls)
+	}
+	// The PUT happened before the failing Render (vault before render).
+	if len(daemon.puts) != 1 {
+		t.Errorf("PUTs = %d, want 1 (vault-before-render: the PUT precedes the failing Render)", len(daemon.puts))
+	}
 }
 
 // claudeShapedRender mirrors the Claude credential envelope's Render

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -161,17 +161,94 @@ func prepareAuthSpec(
 	}
 	prep.HasBindings = true
 
+	// hostAcquireDeps builds the dependency bag handed to a binding's
+	// HostAcquire hook. Both the EnvBinding loop below and the
+	// FileBinding loop further down build identical deps, so the wiring
+	// lives in one place: HTTPClient is the timed pre-launch client,
+	// Browser defaults to the system browser, the paste prompt reads
+	// from the HOST terminal (not the container TTY), and Out surfaces a
+	// write-only flow's instructions on stderr.
+	hostAcquireDeps := func() HostAcquireDeps {
+		return HostAcquireDeps{
+			Ctx:        ctx,
+			HTTPClient: preLaunchRefreshHTTPClient(),
+			Browser:    oauth.SystemBrowser{},
+			CodePrompter: func(ctx context.Context, promptW io.Writer) (string, error) {
+				if promptW == nil {
+					promptW = stderr
+				}
+				return defaultHostCodePrompter(ctx, promptW)
+			},
+			Out: stderr,
+		}
+	}
+
 	// Render env bindings first. They don't touch the host FS and
 	// don't need the transient dir, so a Required-but-missing env
 	// binding fails fast before any mount setup.
+	//
+	// P2 no-cleanup invariant: this loop runs BEFORE the os.MkdirTemp
+	// that creates the transient host directory below, so an abort/return
+	// from inside this loop (a PUT or Render failure on the host-acquire
+	// branch) has no host-side transient state to clean up. This depends
+	// on the env loop staying ahead of the MkdirTemp call.
 	for i, eb := range spec.EnvBindings {
 		ebName, ebPurpose := vaultBindingNameAndPurpose(eb.VaultPath)
 		secret, err := daemon.GetAgentCredentials(ctx, ebName, ebPurpose)
 		switch {
 		case errors.Is(err, ErrAgentCredentialsNotFound):
+			// Required-but-empty fails fast. The required check runs
+			// before any host-acquire attempt, so a required binding
+			// never consults the acquirer.
 			if eb.Required {
 				return prep, fmt.Errorf("auth spec: env binding %d at %q is required but the vault is empty — seed with `aileron vault put %s`",
 					i, eb.VaultPath, eb.VaultPath)
+			}
+			// Required=false on empty vault. If the binding declares a
+			// host acquirer and host-login is enabled, run the host-side
+			// OAuth flow, PUT the acquired Secret through the daemon
+			// (vault before render), then Render into the env additions
+			// so the credential is treated exactly as a vault-resident
+			// one. Mirrors the FileBinding host-acquire branch; the only
+			// difference is there is no file to write/mount.
+			if eb.HostAcquire != nil && hostLoginEnabled {
+				acquired, acqErr := eb.HostAcquire(ctx, hostAcquireDeps())
+				switch {
+				case acqErr != nil:
+					// Acquire failed or was cancelled. Non-fatal: warn and
+					// fall back to the legacy in-container path (no env
+					// addition).
+					captureWarn(sessionLog, stderr, agentName, eb.VaultPath,
+						fmt.Errorf("host credential acquisition failed: %w; falling back to in-container login", acqErr))
+					continue
+				case len(acquired.Value) == 0:
+					// Acquirer returned an empty Secret (e.g. user declined
+					// consent). Treat as fallback, no PUT, no env addition.
+					sessionLog.Info("host credential acquisition returned empty secret; falling back to in-container login",
+						"agent", agentName, "vault_path", eb.VaultPath)
+					continue
+				default:
+					// Vault-before-render ordering: persist the acquired
+					// Secret before rendering it into the env. A PUT failure
+					// aborts the launch rather than silently dropping a
+					// just-acquired credential. The env loop precedes
+					// os.MkdirTemp, so there is no transient dir to clean up.
+					if err := daemon.PutAgentCredentials(ctx, ebName, ebPurpose, acquired); err != nil {
+						return prep, fmt.Errorf("auth spec: persist host-acquired credential %q: %w", eb.VaultPath, err)
+					}
+					rendered, err := eb.Render(acquired)
+					if err != nil {
+						// A malformed acquired Secret surfaces as a launch-
+						// aborting Render error rather than seeding garbage
+						// into the env. No transient dir exists yet.
+						return prep, fmt.Errorf("auth spec: render host-acquired env binding %d %q: %w", i, eb.VaultPath, err)
+					}
+					for k, v := range rendered {
+						prep.EnvAdditions[k] = v
+					}
+					prep.RenderedAnyCredential = true
+					continue
+				}
 			}
 			continue
 		case err != nil:
@@ -342,26 +419,7 @@ func prepareAuthSpec(
 			// launcher.go is suppressed automatically because the tail
 			// sets RenderedAnyCredential = true.
 			if fb.HostAcquire != nil && hostLoginEnabled {
-				acquired, acqErr := fb.HostAcquire(ctx, HostAcquireDeps{
-					Ctx:        ctx,
-					HTTPClient: preLaunchRefreshHTTPClient(),
-					Browser:    oauth.SystemBrowser{},
-					// Default the paste prompt to a controlling-terminal
-					// line reader writing to the launcher's stderr, so the
-					// code is pasted on the HOST terminal (not the
-					// container TTY). Tests inject a scripted prompter.
-					CodePrompter: func(ctx context.Context, promptW io.Writer) (string, error) {
-						if promptW == nil {
-							promptW = stderr
-						}
-						return defaultHostCodePrompter(ctx, promptW)
-					},
-					// Out is the launcher's stderr so a write-only host
-					// flow (Codex device-authorization) can surface the
-					// verification URL + user_code on the HOST terminal,
-					// even on a headless host where the browser cannot open.
-					Out: stderr,
-				})
+				acquired, acqErr := fb.HostAcquire(ctx, hostAcquireDeps())
 				switch {
 				case acqErr != nil:
 					// Acquire failed or was cancelled. Non-fatal: warn

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -42,19 +42,38 @@ import (
 // fake records calls so assertions can pin "did we PUT?" / "did we
 // GET the right name?" — the real daemon HTTP server is exercised
 // in daemon_client_agent_credentials_test.go.
+//
+// The store and per-name error/sequence maps are keyed by the FULL
+// destination (name, purpose), not by name alone. Keying by name only
+// would let a purpose misroute go GREEN: two bindings on the same agent
+// (oauth + apikey) would collapse onto one store key, so a PUT that
+// targeted the wrong purpose would still appear to land. With the
+// composite key a misroute reads/writes a different slot and the
+// assertion fails, which is the whole point of the distinct-destination
+// test. The seed/deleteEntry/getErrors/putErrors helpers default the
+// purpose to oauth so existing single-purpose tests keep compiling.
 type fakeDaemon struct {
 	mu        sync.Mutex
-	store     map[string]vault.Secret
-	getErrors map[string]error
-	putErrors map[string]error
-	// getSeq, when populated for a name, supplies a per-call error
-	// sequence consumed in order. A nil entry means "no error, use the
-	// store" for that call. This lets a scenario make the render GET
+	store     map[daemonKey]vault.Secret
+	getErrors map[daemonKey]error
+	putErrors map[daemonKey]error
+	// getSeq, when populated for a destination, supplies a per-call
+	// error sequence consumed in order. A nil entry means "no error, use
+	// the store" for that call. This lets a scenario make the render GET
 	// succeed and the capture GET cancel/fail without affecting the
-	// other. getSeq takes precedence over getErrors for that name.
-	getSeq map[string][]error
+	// other. getSeq takes precedence over getErrors for that
+	// destination.
+	getSeq map[daemonKey][]error
 	puts   []putRecord
 	gets   []getRecord
+}
+
+// daemonKey is the composite (name, purpose) destination key the fake
+// daemon routes by, mirroring the daemon's real per-(name, purpose)
+// vault slots.
+type daemonKey struct {
+	Name    string
+	Purpose string
 }
 
 type putRecord struct {
@@ -70,48 +89,96 @@ type getRecord struct {
 
 func newFakeDaemon() *fakeDaemon {
 	return &fakeDaemon{
-		store:     map[string]vault.Secret{},
-		getErrors: map[string]error{},
-		putErrors: map[string]error{},
-		getSeq:    map[string][]error{},
+		store:     map[daemonKey]vault.Secret{},
+		getErrors: map[daemonKey]error{},
+		putErrors: map[daemonKey]error{},
+		getSeq:    map[daemonKey][]error{},
 	}
 }
 
-func (f *fakeDaemon) seed(name string, value []byte) {
+// seedPurpose seeds the vault slot at the full (name, purpose)
+// destination. Use this when a test exercises a non-oauth purpose.
+func (f *fakeDaemon) seedPurpose(name, purpose string, value []byte) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	f.store[name] = vault.Secret{Value: value, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}
+	f.store[daemonKey{Name: name, Purpose: purpose}] = vault.Secret{Value: value, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}
 }
 
-// deleteEntry simulates an operator running `aileron vault delete`
-// mid-session: the entry vanishes from the store so a subsequent GET
-// returns ErrAgentCredentialsNotFound.
-func (f *fakeDaemon) deleteEntry(name string) {
+// seed is the thin oauth-defaulting shim over seedPurpose so the
+// existing single-purpose tests keep compiling unchanged.
+func (f *fakeDaemon) seed(name string, value []byte) {
+	f.seedPurpose(name, defaultAgentCredentialPurpose, value)
+}
+
+// deleteEntryPurpose simulates an operator running `aileron vault
+// delete` mid-session against a specific (name, purpose) destination.
+func (f *fakeDaemon) deleteEntryPurpose(name, purpose string) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	delete(f.store, name)
+	delete(f.store, daemonKey{Name: name, Purpose: purpose})
+}
+
+// deleteEntry is the oauth-defaulting shim over deleteEntryPurpose: the
+// entry vanishes from the store so a subsequent GET returns
+// ErrAgentCredentialsNotFound.
+func (f *fakeDaemon) deleteEntry(name string) {
+	f.deleteEntryPurpose(name, defaultAgentCredentialPurpose)
+}
+
+// setGetError installs a GET error for the (name, purpose) destination.
+func (f *fakeDaemon) setGetError(name, purpose string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getErrors[daemonKey{Name: name, Purpose: purpose}] = err
+}
+
+// setGetErrorOAuth installs a GET error for the oauth slot — the
+// oauth-defaulting shim existing single-purpose tests use.
+func (f *fakeDaemon) setGetErrorOAuth(name string, err error) {
+	f.setGetError(name, defaultAgentCredentialPurpose, err)
+}
+
+// setPutError installs a PUT error for the (name, purpose) destination.
+func (f *fakeDaemon) setPutError(name, purpose string, err error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.putErrors[daemonKey{Name: name, Purpose: purpose}] = err
+}
+
+// setPutErrorOAuth installs a PUT error for the oauth slot.
+func (f *fakeDaemon) setPutErrorOAuth(name string, err error) {
+	f.setPutError(name, defaultAgentCredentialPurpose, err)
+}
+
+// setGetSeqOAuth installs a per-call GET error sequence for the oauth
+// slot, consumed in order.
+func (f *fakeDaemon) setGetSeqOAuth(name string, seq []error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.getSeq[daemonKey{Name: name, Purpose: defaultAgentCredentialPurpose}] = seq
 }
 
 func (f *fakeDaemon) GetAgentCredentials(_ context.Context, name, purpose string) (vault.Secret, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	key := daemonKey{Name: name, Purpose: purpose}
 	f.gets = append(f.gets, getRecord{Name: name, Purpose: purpose})
-	if seq, ok := f.getSeq[name]; ok && len(seq) > 0 {
+	if seq, ok := f.getSeq[key]; ok && len(seq) > 0 {
 		err := seq[0]
-		f.getSeq[name] = seq[1:]
+		f.getSeq[key] = seq[1:]
 		if err != nil {
 			return vault.Secret{}, err
 		}
-		s, ok := f.store[name]
+		s, ok := f.store[key]
 		if !ok {
 			return vault.Secret{}, ErrAgentCredentialsNotFound
 		}
 		return s, nil
 	}
-	if err, ok := f.getErrors[name]; ok {
+	if err, ok := f.getErrors[key]; ok {
 		return vault.Secret{}, err
 	}
-	s, ok := f.store[name]
+	s, ok := f.store[key]
 	if !ok {
 		return vault.Secret{}, ErrAgentCredentialsNotFound
 	}
@@ -121,11 +188,12 @@ func (f *fakeDaemon) GetAgentCredentials(_ context.Context, name, purpose string
 func (f *fakeDaemon) PutAgentCredentials(_ context.Context, name, purpose string, secret vault.Secret) error {
 	f.mu.Lock()
 	defer f.mu.Unlock()
-	if err, ok := f.putErrors[name]; ok {
+	key := daemonKey{Name: name, Purpose: purpose}
+	if err, ok := f.putErrors[key]; ok {
 		return err
 	}
 	f.puts = append(f.puts, putRecord{Name: name, Purpose: purpose, Secret: secret})
-	f.store[name] = secret
+	f.store[key] = secret
 	return nil
 }
 
@@ -530,7 +598,7 @@ func TestPrepareAuthSpec_EnvBindingMerges(t *testing.T) {
 func TestPrepareAuthSpec_CapturePutFailureSurfacesWarning(t *testing.T) {
 	daemon := newFakeDaemon()
 	daemon.seed("claude", []byte(`{"x":1}`))
-	daemon.putErrors["claude"] = errors.New("daemon offline")
+	daemon.setPutErrorOAuth("claude", errors.New("daemon offline"))
 
 	stderr := &bytes.Buffer{}
 	spec := AuthSpec{
@@ -606,7 +674,7 @@ func TestPrepareAuthSpec_EnvBindingOptionalMissingContinues(t *testing.T) {
 
 func TestPrepareAuthSpec_EnvBindingGetErrorPropagates(t *testing.T) {
 	daemon := newFakeDaemon()
-	daemon.getErrors["example"] = errors.New("network down")
+	daemon.setGetErrorOAuth("example", errors.New("network down"))
 	spec := AuthSpec{
 		EnvBindings: []EnvBinding{{
 			VaultPath: "agents/example/oauth",
@@ -658,7 +726,7 @@ func TestPrepareAuthSpec_FileBindingRenderErrorPropagates(t *testing.T) {
 
 func TestPrepareAuthSpec_FileBindingGetErrorPropagates(t *testing.T) {
 	daemon := newFakeDaemon()
-	daemon.getErrors["claude"] = errors.New("daemon offline")
+	daemon.setGetErrorOAuth("claude", errors.New("daemon offline"))
 	spec := AuthSpec{
 		FileBindings: []FileBinding{{
 			VaultPath:     "agents/claude/oauth",
@@ -763,6 +831,96 @@ func TestPrepareAuthSpec_RejectsNonConformingVaultPath(t *testing.T) {
 		newTestLogger(), nil, nil, nil, true)
 	if !errors.Is(err, ErrAuthSpecBadVaultPath) {
 		t.Fatalf("err = %v, want ErrAuthSpecBadVaultPath", err)
+	}
+}
+
+// TestPrepareAuthSpec_TwoBindingsDistinctPurposesRouteSeparately is the
+// residual #1344 regression: two bindings on the SAME agent name but
+// distinct purposes (apikey + oauth) must route to distinct vault
+// destinations. The EnvBinding at agents/foo/apikey is host-acquire
+// seeded; the FileBinding at agents/foo/oauth is vault-resident. The
+// apikey PUT must land at (foo, apikey) and the oauth read at
+// (foo, oauth) — a routing bug that collapses both onto name `foo`
+// would overwrite the oauth slot with the apikey value (or vice-versa)
+// and fail these assertions. The re-keyed fakeDaemon is what makes the
+// misroute observable rather than silently green.
+func TestPrepareAuthSpec_TwoBindingsDistinctPurposesRouteSeparately(t *testing.T) {
+	daemon := newFakeDaemon()
+	// Seed only the oauth slot (vault-resident FileBinding). The apikey
+	// slot is empty so the EnvBinding takes the host-acquire path.
+	oauthEnvelope := []byte(`{"claudeAiOauth":{"accessToken":"oauth-tok"}}`)
+	daemon.seedPurpose("foo", "oauth", oauthEnvelope)
+
+	spy := &spyAcquirer{secret: vault.Secret{Value: []byte("sk-apikey")}}
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath: "agents/foo/apikey",
+			Render: func(s vault.Secret) (map[string]string, error) {
+				return map[string]string{"FOO_KEY": string(s.Value)}, nil
+			},
+			HostAcquire: spy.acquire,
+		}},
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/foo/oauth",
+			ContainerPath: "/home/agent/.foo/.credentials.json",
+			Mode:          0o600,
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+		}},
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "foo", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	// The apikey EnvBinding host-acquired and PUT exactly one entry, at
+	// (foo, apikey) — NOT (foo, oauth).
+	if len(daemon.puts) != 1 {
+		t.Fatalf("PUTs = %d, want 1 (the apikey host-acquire seed)", len(daemon.puts))
+	}
+	if daemon.puts[0].Name != "foo" || daemon.puts[0].Purpose != "apikey" {
+		t.Errorf("PUT destination = (%q,%q), want (foo,apikey)", daemon.puts[0].Name, daemon.puts[0].Purpose)
+	}
+
+	// The oauth read landed at (foo, oauth): assert a GET recorded that
+	// destination.
+	var sawOAuthGet bool
+	for _, g := range daemon.gets {
+		if g.Name == "foo" && g.Purpose == "oauth" {
+			sawOAuthGet = true
+		}
+	}
+	if !sawOAuthGet {
+		t.Errorf("no GET at (foo,oauth) recorded; gets=%v", daemon.gets)
+	}
+
+	// The apikey seed did NOT overwrite the oauth slot: the oauth slot
+	// still holds the original envelope, and the apikey slot holds the
+	// acquired key.
+	gotOAuth, err := daemon.GetAgentCredentials(context.Background(), "foo", "oauth")
+	if err != nil {
+		t.Fatalf("GET (foo,oauth): %v", err)
+	}
+	if string(gotOAuth.Value) != string(oauthEnvelope) {
+		t.Errorf("oauth slot = %q, want the original envelope %q (apikey PUT must not clobber it)", gotOAuth.Value, oauthEnvelope)
+	}
+	gotApikey, err := daemon.GetAgentCredentials(context.Background(), "foo", "apikey")
+	if err != nil {
+		t.Fatalf("GET (foo,apikey): %v", err)
+	}
+	if string(gotApikey.Value) != "sk-apikey" {
+		t.Errorf("apikey slot = %q, want sk-apikey", gotApikey.Value)
+	}
+
+	// The rendered env var carries the apikey, and the oauth credential
+	// rendered into a mounted file.
+	if got := prep.EnvAdditions["FOO_KEY"]; got != "sk-apikey" {
+		t.Errorf("EnvAdditions[FOO_KEY] = %q, want sk-apikey", got)
+	}
+	if !prep.RenderedAnyCredential {
+		t.Errorf("RenderedAnyCredential = false; both bindings rendered")
 	}
 }
 
@@ -1206,7 +1364,7 @@ func TestPrepareAuthSpec_CaptureGetCancelledSkipsPut(t *testing.T) {
 	daemon := newFakeDaemon()
 	daemon.seed("claude", []byte("current"))
 	// Render GET succeeds (store hit); capture GET returns context.Canceled.
-	daemon.getSeq["claude"] = []error{nil, context.Canceled}
+	daemon.setGetSeqOAuth("claude", []error{nil, context.Canceled})
 	spec := freshnessSpec(func(_, _ vault.Secret) (bool, error) { return true, nil })
 
 	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)

--- a/internal/launch/authspec_test.go
+++ b/internal/launch/authspec_test.go
@@ -213,6 +213,78 @@ func TestValidateAuthSpec_AcceptsCompleteSpec(t *testing.T) {
 	}
 }
 
+// TestVaultPathConforms_KnownPurposeSet pins the relaxed gate: the
+// third path segment must be a known credential purpose (oauth or
+// apikey), not "any non-empty string". A typo'd purpose (oath,
+// api-key) routes to a brand-new vault slot, so the gate keeps the
+// vocabulary closed. The apikey case is the SUB2 regression: it was
+// rejected before the relaxation and must validate now.
+func TestVaultPathConforms_KnownPurposeSet(t *testing.T) {
+	tests := []struct {
+		name string
+		path string
+		want bool
+	}{
+		{"oauth purpose validates", "agents/claude/oauth", true},
+		{"apikey purpose validates (SUB2 regression)", "agents/claude/apikey", true},
+		{"leading slash tolerated", "/agents/claude/apikey", true},
+		{"unknown purpose api-key rejected", "agents/x/api-key", false},
+		{"typo purpose oath rejected", "agents/x/oath", false},
+		{"empty name rejected", "agents//oauth", false},
+		{"wrong root rejected", "secrets/x/oauth", false},
+		{"too few segments rejected", "agents/claude", false},
+		{"too many segments rejected", "agents/claude/oauth/extra", false},
+		{"empty purpose rejected", "agents/claude/", false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := vaultPathConforms(tc.path); got != tc.want {
+				t.Fatalf("vaultPathConforms(%q) = %v, want %v", tc.path, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateAuthSpec_ApikeyPurposeAccepted is the end-to-end
+// validation regression: an EnvBinding and a FileBinding at
+// `agents/<name>/apikey` pass validateAuthSpec after the SUB2
+// relaxation (both were rejected by the oauth-only gate before).
+func TestValidateAuthSpec_ApikeyPurposeAccepted(t *testing.T) {
+	spec := AuthSpec{
+		EnvBindings: []EnvBinding{{
+			VaultPath: "agents/claude/apikey",
+			Render:    func(vault.Secret) (map[string]string, error) { return nil, nil },
+		}},
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/apikey",
+			ContainerPath: "/home/agent/.cfg",
+			Render:        func(vault.Secret) ([]byte, error) { return nil, nil },
+			Capture:       func([]byte) (vault.Secret, error) { return vault.Secret{}, nil },
+		}},
+	}
+	if err := validateAuthSpec(spec); err != nil {
+		t.Fatalf("validateAuthSpec rejected apikey purpose: %v", err)
+	}
+}
+
+// TestValidateAuthSpec_UnknownPurposeRejected pins the closed-set
+// guarantee at the spec level: a binding whose third segment is an
+// unknown purpose still returns ErrAuthSpecBadVaultPath so a typo
+// cannot silently route to a new vault slot.
+func TestValidateAuthSpec_UnknownPurposeRejected(t *testing.T) {
+	for _, vp := range []string{"agents/x/oath", "agents/x/api-key", "agents/x/token"} {
+		spec := AuthSpec{
+			EnvBindings: []EnvBinding{{
+				VaultPath: vp,
+				Render:    func(vault.Secret) (map[string]string, error) { return nil, nil },
+			}},
+		}
+		if err := validateAuthSpec(spec); !errors.Is(err, ErrAuthSpecBadVaultPath) {
+			t.Errorf("validateAuthSpec(%q) = %v, want ErrAuthSpecBadVaultPath", vp, err)
+		}
+	}
+}
+
 // TestAuthSpec_AgentConformance asserts that the launch package's
 // internal Agent fixtures return a non-panicking AuthSpec value,
 // even when the spec is empty. Agents may ship empty specs (Goose,

--- a/internal/launch/daemon_client.go
+++ b/internal/launch/daemon_client.go
@@ -26,6 +26,24 @@ const daemonHTTPTimeout = 5 * time.Second
 // pre-purpose wire shape.
 const defaultAgentCredentialPurpose = "oauth"
 
+// apikeyAgentCredentialPurpose is the second known credential purpose:
+// a long-lived API key bound at `agents/<name>/apikey`, distinct from the
+// rotating OAuth bundle at `agents/<name>/oauth`. The daemon routes it via
+// the `purpose` query parameter (see agentCredentialsEndpoint); the launcher
+// keeps the vocabulary closed so a typo (`oath`, `api-key`) cannot silently
+// open a brand-new vault slot.
+const apikeyAgentCredentialPurpose = "apikey"
+
+// isKnownAgentCredentialPurpose reports whether p is a purpose the launcher
+// knows how to route. The set is intentionally closed: validateAuthSpec uses
+// it as the third-segment gate for `agents/<name>/<purpose>` vault paths so an
+// unrecognized purpose is rejected up front rather than routed to an unintended
+// destination. Extend this set (and the daemon's accepted purposes) together
+// when a new purpose is introduced.
+func isKnownAgentCredentialPurpose(p string) bool {
+	return p == defaultAgentCredentialPurpose || p == apikeyAgentCredentialPurpose
+}
+
 // daemonClient is a thin HTTP client over the daemon's /v1 surface,
 // used by Launch to register and end the agent's session and to peek
 // at the vault state for the startup banner. Production code creates


### PR DESCRIPTION
## Summary

SUB2 of umbrella #1336. Builds on SUB1 (#1349, merged) which already threaded the `purpose` path segment through every daemon GET/PUT. This change is launch-layer only (no daemon/API/OpenAPI surface touched).

- **Relax the validation gate to a closed known-purpose set.** `vaultPathConforms` previously required the third segment to be exactly `oauth`. It now accepts any *known* purpose via `isKnownAgentCredentialPurpose` (`oauth` or `apikey`), keeping the vocabulary closed so a typo like `agents/x/oath` still routes nowhere new and is rejected up front. New `apikeyAgentCredentialPurpose` constant and helper live in `daemon_client.go` beside `defaultAgentCredentialPurpose`.
- **Add `HostAcquire` to `EnvBinding`, mirroring `FileBinding.HostAcquire`.** On a not-`Required` vault miss with `--host-login` enabled, the launcher acquires the credential on the host, PUTs it through the daemon at the binding's `(name, purpose)` (vault before render), then runs `Render` into the agent's env additions and sets `RenderedAnyCredential`. Acquire error / empty Secret are non-fatal fallbacks to the in-container path; a daemon PUT failure or a Render failure of the acquired Secret aborts the launch. The env loop runs before `os.MkdirTemp`, so there is no transient host state to clean up on abort.
- **Dedup the host-acquire deps wiring.** Both the Env and File loops now build `HostAcquireDeps` through one shared closure so the two cannot diverge.
- **Re-key the test `fakeDaemon` by `(name, purpose)`.** Keying by name alone let a purpose misroute pass silently when two bindings share an agent name. With the composite key, the new distinct-destination test fails on a routing collapse. Existing single-purpose tests keep compiling via oauth-defaulting shims (`seed`, `deleteEntry`, `setGetErrorOAuth`, etc.).

No agent wiring changes: the only EnvBinding in the tree (Goose) leaves `HostAcquire` nil and keeps its legacy path. The Claude api-key EnvBinding that *uses* this capability is a later sub-issue, out of scope here.

## Test plan

- `go test ./internal/launch/... -cover` — green, package coverage 87.5% (>80% bar).
- New regression tests fail on origin/main behavior and pass after:
  - `agents/claude/apikey` now validates; unknown purposes (`oath`, `api-key`) still return `ErrAuthSpecBadVaultPath` (`TestVaultPathConforms_KnownPurposeSet`, `TestValidateAuthSpec_ApikeyPurposeAccepted`, `TestValidateAuthSpec_UnknownPurposeRejected`).
  - EnvBinding host-acquire: happy path (PUT at `(name,apikey)` before render, env var seeded, `RenderedAnyCredential` set), acquire-error / empty-Secret non-fatal, host-login-disabled skips acquirer, PUT-failure aborts, Required-but-empty ignores acquirer, malformed-Secret aborts on Render (PUT already recorded).
  - `TestPrepareAuthSpec_TwoBindingsDistinctPurposesRouteSeparately` proves apikey + oauth on one agent route to distinct slots without clobbering each other.
- `go vet ./internal/launch/...`, `gofmt` on changed files, and `go build ./internal/...` clean.

Closes #1338

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added host-side credential acquisition with automatic fallback to in-container authentication when acquisition is unavailable or disabled
  * Expanded credential type support beyond OAuth to include API key credentials
  * Added option to force legacy authentication path via flag or environment variable

<!-- end of auto-generated comment: release notes by coderabbit.ai -->