### PR TITLE
docs(launch): correct vault-path purpose after gate relaxed

### DIFF
--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -28,9 +28,9 @@ Two binding shapes appear in the table. A **FileBinding** backs a rotatable on-d
 
 Goose authenticates with a provider API key (resolved from `<PROVIDER>_API_KEY` or its keyring), so its binding is an EnvBinding rendering the stored key into `ANTHROPIC_API_KEY` (Goose's default provider under launch; seed the matching key for a different provider). OpenCode and Pi each persist provider credentials in a standalone `auth.json` (OpenCode under `~/.local/share/opencode/`, Pi under `~/.pi/agent/`), so both use a byte-identity FileBinding. Pi's `auth.json` is the dedicated credential file, distinct from `settings.json`, so the binding never snapshots non-credential session state.
 
-The vault path's third segment is the literal `oauth` for every agent even when the stored secret is an API key, not an OAuth bundle. The daemon's per-agent endpoint and `vaultPathConforms` (in `internal/launch/authspec.go`) require exactly `agents/<name>/oauth`; any other shape fails launch validation.
+The vault path's third segment names a known credential purpose: `oauth` for an OAuth bundle or `apikey` for a provider API key. `vaultPathConforms` (in `internal/launch/authspec.go`) accepts that closed set via `isKnownAgentCredentialPurpose`; an unrecognized purpose fails launch validation.
 
-The daemon's HTTP surface scopes the path at the routing layer. `GET/PUT /v1/vault/agents/{name}/credentials` translates `{name}` internally to `agents/<name>/oauth`. Other vault paths are unreachable through this endpoint.
+The daemon's HTTP surface scopes the path at the routing layer. `GET/PUT /v1/vault/agents/{name}/credentials` routes the third segment via the `purpose` query parameter, which defaults to `oauth` (so `agents/<name>/oauth`) and selects `agents/<name>/<purpose>` for any other known purpose. Other vault paths are unreachable through this endpoint.
 
 ## How a launch resolves credentials
 


### PR DESCRIPTION
## Summary

PR #1354 relaxed `vaultPathConforms` (`internal/launch/authspec.go`) to accept any known credential purpose via `isKnownAgentCredentialPurpose` (`oauth` or `apikey`, `internal/launch/daemon_client.go`), and routed the per-agent daemon endpoint through a `purpose` query parameter that defaults to `oauth`. The `sandbox-agent-auth.md` doc was not updated and became false:

- Line 31 asserted the third vault-path segment is "the literal `oauth` for every agent" and that validation requires "exactly `agents/<name>/oauth`".
- Line 33 said the daemon endpoint "translates `{name}` internally to `agents/<name>/oauth`".

This corrects both paragraphs to describe the closed purpose set (`oauth`/`apikey`) accepted by `isKnownAgentCredentialPurpose`, that an unrecognized purpose fails launch validation, and that the daemon endpoint routes the third segment via the `purpose` query parameter (defaulting to `oauth`).

Doc-only change; no code or generated files touched.

## Test plan

- Verified against `origin/main` that `vaultPathConforms` gates on `isKnownAgentCredentialPurpose` (oauth/apikey) and that `agentCredentialsEndpoint` appends `?purpose=<value>` for non-default purposes, defaulting to `oauth`.
- Grep confirmed no remaining stale "literal `oauth`" / "exactly `agents/<name>/oauth`" assertions in the file.

Closes #1353

🤖 Generated with [Claude Code](https://claude.com/claude-code)