### PR TITLE
fix(launch): pass nil promptW to CodePrompter in api-key acquire

### DIFF
--- a/internal/launch/agents/claude_apikey_auth_test.go
+++ b/internal/launch/agents/claude_apikey_auth_test.go
@@ -118,6 +118,38 @@ func TestClaudeAPIKey_HostAcquire_ReturnsApiKeySecret(t *testing.T) {
 	}
 }
 
+// Regression (#1356): the api-key flow prints its own Anthropic-specific
+// paste banner to deps.Out, so it must invoke the CodePrompter with a nil
+// promptW. Passing deps.Out would make the production
+// defaultHostCodePrompter print a SECOND, wrong-domain banner ("Paste the
+// code from your browser..."), double-printing a confusing prompt. The
+// contract: the flow that owns the banner must not also hand the prompter
+// a writer to print its own.
+func TestClaudeAPIKey_HostAcquire_PrompterReceivesNilWriter(t *testing.T) {
+	eb := claudeAPIKeyBinding(t)
+	var out bytes.Buffer
+	gotWriter := io.Writer(&out) // sentinel: must be overwritten to nil
+	called := false
+	prompter := func(_ context.Context, promptW io.Writer) (string, error) {
+		called = true
+		gotWriter = promptW
+		return "sk-ant-xyz", nil
+	}
+	if _, err := eb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:          context.Background(),
+		Out:          &out,
+		CodePrompter: prompter,
+	}); err != nil {
+		t.Fatalf("HostAcquire: %v", err)
+	}
+	if !called {
+		t.Fatal("CodePrompter was never invoked")
+	}
+	if gotWriter != nil {
+		t.Errorf("CodePrompter promptW = %v, want nil (flow owns its own banner; non-nil double-prints)", gotWriter)
+	}
+}
+
 func TestClaudeAPIKey_HostAcquire_EmptyPasteIsNonFatal(t *testing.T) {
 	eb := claudeAPIKeyBinding(t)
 	for _, paste := range []string{"", "   \n\t"} {

--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -203,7 +203,11 @@ func claudeAPIKeyHostAcquire(ctx context.Context, deps launch.HostAcquireDeps) (
 		fmt.Fprintln(deps.Out,
 			"Paste your Anthropic API key to seed Claude's api-key auth, then press Enter.")
 	}
-	pasted, err := deps.CodePrompter(ctx, deps.Out)
+	// This flow prints its own (api-key-specific) paste banner above, so
+	// the prompter is invoked with a nil promptW to suppress the
+	// prompter's generic "Paste the code from your browser..." banner and
+	// avoid a second, wrong-domain prompt. Mirrors claudeHostedCallbackAcquire.
+	pasted, err := deps.CodePrompter(ctx, nil)
 	if err != nil {
 		// Read failed or was cancelled. Non-fatal: empty Secret so the
 		// launcher falls back to the in-container login.


### PR DESCRIPTION
## Summary

`claudeAPIKeyHostAcquire` (internal/launch/agents/claude_auth.go) prints its own Anthropic-specific paste banner to `deps.Out`, then invoked `deps.CodePrompter(ctx, deps.Out)`. With the production `defaultHostCodePrompter`, a non-nil `promptW` prints a SECOND, wrong-domain banner (`"Paste the code from your browser and press Enter: "`), double-printing a confusing prompt during the api-key seed flow.

The fix passes `nil` to the prompter instead, mirroring the established pattern in `claudeHostedCallbackAcquire` (same file), so the prompter suppresses its generic banner and the user sees only the api-key banner.

## Test plan

- Added `TestClaudeAPIKey_HostAcquire_PrompterReceivesNilWriter`, a regression test that injects a prompter capturing the `io.Writer` it receives and asserts it is `nil`. Verified it FAILS before the fix (receives the api-key banner writer) and PASSES after.
- `go test ./internal/launch/...` green; `internal/launch/agents` coverage 90.4%.
- `go build` + `go vet` clean.

Relates to #1356


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed Claude API key authentication flow to eliminate duplicate prompt banners and incorrect messages, ensuring users receive only the relevant API key paste instruction.

* **Tests**
  * Added regression test to verify correct prompt behavior during API key authentication workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->