### PR TITLE
feat(launch): --claude-auth flag + first-run prompt + active-mode banner

### DIFF
--- a/cmd/aileron/claude_auth.go
+++ b/cmd/aileron/claude_auth.go
@@ -1,0 +1,100 @@
+package main
+
+import (
+	"bufio"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+	"golang.org/x/term"
+)
+
+// isTTYFn reports whether the CLI is attached to an interactive terminal on
+// stdin. It is a package-level seam so tests can force the prompt path
+// (true) or the non-interactive default path (false) without a real TTY.
+var isTTYFn = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
+
+// resolveClaudeAuthMode selects the Claude auth mode to thread onto the
+// launched Claude agent (#1340). It only performs mode *selection*; the
+// AuthSpec branching for the selected mode lives in agents.Claude.AuthSpec.
+//
+// Resolution rules:
+//   - flagVal == "api-key"      -> ClaudeAuthModeAPIKey
+//   - flagVal == "subscription" -> ClaudeAuthModeSubscription
+//   - flagVal is any other non-empty value -> usage error (fail fast)
+//   - flagVal == "" && isTTY    -> interactive first-run prompt (reads one
+//     line from stdin, re-asking on unrecognized input)
+//   - flagVal == "" && !isTTY   -> ClaudeAuthModeSubscription WITHOUT reading
+//     stdin (the non-interactive default; stdin is left untouched so a piped
+//     stdin destined for the agent is never consumed).
+func resolveClaudeAuthMode(flagVal string, isTTY bool, stdin io.Reader, stdout io.Writer) (agents.ClaudeAuthMode, error) {
+	if flagVal != "" {
+		mode, ok := parseClaudeAuthMode(flagVal)
+		if !ok {
+			return 0, fmt.Errorf("invalid --claude-auth value %q: want %q or %q", flagVal, "subscription", "api-key")
+		}
+		return mode, nil
+	}
+	if !isTTY {
+		// Non-interactive: default to subscription and DO NOT read stdin.
+		return agents.ClaudeAuthModeSubscription, nil
+	}
+	return promptClaudeAuthMode(stdin, stdout)
+}
+
+// parseClaudeAuthMode maps an explicit flag value to a mode. It accepts the
+// two canonical spellings plus a small set of obvious synonyms so a hurried
+// invocation is not rejected. The canonical, documented values are
+// "subscription" and "api-key".
+func parseClaudeAuthMode(v string) (agents.ClaudeAuthMode, bool) {
+	switch strings.ToLower(strings.TrimSpace(v)) {
+	case "subscription", "sub", "s":
+		return agents.ClaudeAuthModeSubscription, true
+	case "api-key", "apikey", "api_key", "key", "k":
+		return agents.ClaudeAuthModeAPIKey, true
+	default:
+		return 0, false
+	}
+}
+
+// promptClaudeAuthMode runs the interactive first-run selection, writing the
+// choices to stdout and reading one line from stdin per attempt. It re-asks
+// on unrecognized input and returns an error only if stdin yields EOF before
+// a valid choice (e.g. the input stream closes).
+func promptClaudeAuthMode(stdin io.Reader, stdout io.Writer) (agents.ClaudeAuthMode, error) {
+	br := bufio.NewReader(stdin)
+	fmt.Fprintln(stdout, "How should Claude authenticate?")
+	fmt.Fprintln(stdout, "  [1] subscription  Claude Pro/Max via OAuth login (default)")
+	fmt.Fprintln(stdout, "  [2] api-key       Anthropic API key (ANTHROPIC_API_KEY)")
+	for {
+		fmt.Fprint(stdout, "Choose [subscription/api-key] (default subscription): ")
+		line, err := br.ReadString('\n')
+		choice := strings.TrimSpace(line)
+		if choice == "" {
+			if err != nil {
+				// EOF with no input on this attempt: take the default rather
+				// than spinning forever on a closed stream.
+				return agents.ClaudeAuthModeSubscription, nil
+			}
+			// Bare Enter selects the default.
+			return agents.ClaudeAuthModeSubscription, nil
+		}
+		switch strings.ToLower(choice) {
+		case "1":
+			return agents.ClaudeAuthModeSubscription, nil
+		case "2":
+			return agents.ClaudeAuthModeAPIKey, nil
+		}
+		if mode, ok := parseClaudeAuthMode(choice); ok {
+			return mode, nil
+		}
+		fmt.Fprintf(stdout, "  unrecognized choice %q; please answer subscription or api-key\n", choice)
+		if err != nil {
+			// Stream closed mid-prompt with no valid choice; fall back to the
+			// documented default rather than erroring the whole launch.
+			return agents.ClaudeAuthModeSubscription, nil
+		}
+	}
+}

--- a/cmd/aileron/claude_auth_test.go
+++ b/cmd/aileron/claude_auth_test.go
@@ -1,0 +1,255 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+)
+
+// failingReader fails the test if Read is ever called. It guards the P2
+// stdin contract: the non-interactive resolution path must never touch
+// stdin (so a piped stdin destined for the agent is preserved).
+type failingReader struct{ t *testing.T }
+
+func (r failingReader) Read([]byte) (int, error) {
+	r.t.Helper()
+	r.t.Fatal("stdin was read on the non-interactive path; the supplied reader must be left untouched")
+	return 0, io.EOF
+}
+
+// capturedAuthMode runs `run` with the launchFn seam installed and returns
+// the auth mode threaded onto the launched claude agent. It asserts the
+// launch succeeded and that config.Agent is an agents.Claude value (the swap
+// stores a value, not a pointer).
+func capturedAuthMode(t *testing.T, args []string) agents.ClaudeAuthMode {
+	t.Helper()
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+
+	var captured launch.LaunchConfig
+	launchFn = func(_ context.Context, cfg launch.LaunchConfig) (launch.LaunchResult, error) {
+		captured = cfg
+		return launch.LaunchResult{ExitCode: 0}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := run(args, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("run(%v) exit = %d (stderr=%q)", args, code, stderr.String())
+	}
+	cl, ok := captured.Agent.(agents.Claude)
+	if !ok {
+		t.Fatalf("LaunchConfig.Agent = %T, want agents.Claude", captured.Agent)
+	}
+	return cl.AuthMode()
+}
+
+// TestRun_LaunchThreadsClaudeAuthModeExplicit covers Unit 2: an explicit
+// --claude-auth value reaches the swapped agents.Claude in LaunchConfig.Agent
+// (in both before-agent and trailing positions, per Unit 1's position
+// independence).
+func TestRun_LaunchThreadsClaudeAuthModeExplicit(t *testing.T) {
+	cases := []struct {
+		name string
+		args []string
+		want agents.ClaudeAuthMode
+	}{
+		{"api-key before agent", []string{"launch", "--claude-auth=api-key", "claude"}, agents.ClaudeAuthModeAPIKey},
+		{"subscription before agent", []string{"launch", "--claude-auth=subscription", "claude"}, agents.ClaudeAuthModeSubscription},
+		{"api-key trailing eq", []string{"launch", "claude", "--claude-auth=api-key"}, agents.ClaudeAuthModeAPIKey},
+		{"api-key trailing space", []string{"launch", "claude", "--claude-auth", "api-key"}, agents.ClaudeAuthModeAPIKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := capturedAuthMode(t, tc.args); got != tc.want {
+				t.Errorf("threaded auth mode = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// TestRun_LaunchClaudeAuthFlagNotForwarded locks that --claude-auth is
+// consumed by aileron and never leaks into the agent's args.
+func TestRun_LaunchClaudeAuthFlagNotForwarded(t *testing.T) {
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+	var captured launch.LaunchConfig
+	launchFn = func(_ context.Context, cfg launch.LaunchConfig) (launch.LaunchResult, error) {
+		captured = cfg
+		return launch.LaunchResult{ExitCode: 0}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"launch", "claude", "--claude-auth=api-key", "--", "--foo"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d (stderr=%q)", code, stderr.String())
+	}
+	for _, a := range captured.Args {
+		if strings.Contains(a, "claude-auth") {
+			t.Errorf("--claude-auth leaked to agent args: %v", captured.Args)
+		}
+	}
+	if len(captured.Args) != 1 || captured.Args[0] != "--foo" {
+		t.Errorf("agent args = %v, want [--foo]", captured.Args)
+	}
+}
+
+// TestRun_LaunchClaudeAuthInvalidFailsFast covers Unit 1's fail-fast: a
+// non-empty value that is not a recognized mode exits 1 with a clear error.
+func TestRun_LaunchClaudeAuthInvalidFailsFast(t *testing.T) {
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+	called := false
+	launchFn = func(_ context.Context, _ launch.LaunchConfig) (launch.LaunchResult, error) {
+		called = true
+		return launch.LaunchResult{ExitCode: 0}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	code := run([]string{"launch", "--claude-auth=bogus", "claude"}, newTestRegistry(), &stdout, &stderr)
+	if code != 1 {
+		t.Fatalf("exit = %d, want 1 (stderr=%q)", code, stderr.String())
+	}
+	if called {
+		t.Error("launchFn was called despite invalid --claude-auth")
+	}
+	if !strings.Contains(stderr.String(), "claude-auth") {
+		t.Errorf("error did not mention claude-auth: %q", stderr.String())
+	}
+}
+
+// TestRun_LaunchNonClaudeAgentNeverResolvesMode covers decision #3: a
+// non-claude agent passes through unchanged, never prompts, and never reads
+// stdin. We force a TTY and pass a failingReader as os.Stdin would be — but
+// since run() reads os.Stdin directly, we assert via the captured agent
+// identity that no swap happened, and that the prompt path was not entered
+// (isTTYFn true but no claude => resolver never called, no panic on stdin).
+func TestRun_LaunchNonClaudeAgentNeverResolvesMode(t *testing.T) {
+	origTTY := isTTYFn
+	t.Cleanup(func() { isTTYFn = origTTY })
+	isTTYFn = func() bool { return true } // would trigger a prompt for claude
+
+	origLaunch := launchFn
+	t.Cleanup(func() { launchFn = origLaunch })
+	var captured launch.LaunchConfig
+	launchFn = func(_ context.Context, cfg launch.LaunchConfig) (launch.LaunchResult, error) {
+		captured = cfg
+		return launch.LaunchResult{ExitCode: 0}, nil
+	}
+	var stdout, stderr bytes.Buffer
+	// pi is a non-claude agent; with a TTY forced, a claude launch would
+	// block reading os.Stdin. pi must not, proving the resolver is skipped.
+	code := run([]string{"launch", "--local", "pi"}, newTestRegistry(), &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d (stderr=%q)", code, stderr.String())
+	}
+	if _, ok := captured.Agent.(agents.Pi); !ok {
+		t.Fatalf("LaunchConfig.Agent = %T, want agents.Pi (unchanged)", captured.Agent)
+	}
+}
+
+// --- resolveClaudeAuthMode unit tests (Unit 3) ---
+
+func TestResolveClaudeAuthMode_ExplicitValues(t *testing.T) {
+	cases := []struct {
+		in   string
+		want agents.ClaudeAuthMode
+	}{
+		{"subscription", agents.ClaudeAuthModeSubscription},
+		{"sub", agents.ClaudeAuthModeSubscription},
+		{"s", agents.ClaudeAuthModeSubscription},
+		{"api-key", agents.ClaudeAuthModeAPIKey},
+		{"apikey", agents.ClaudeAuthModeAPIKey},
+		{"key", agents.ClaudeAuthModeAPIKey},
+		{"API-KEY", agents.ClaudeAuthModeAPIKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.in, func(t *testing.T) {
+			// isTTY true + a failing reader proves an explicit value bypasses
+			// the prompt entirely (no stdin read even on a TTY).
+			got, err := resolveClaudeAuthMode(tc.in, true, failingReader{t}, io.Discard)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("mode = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestResolveClaudeAuthMode_InvalidExplicit(t *testing.T) {
+	_, err := resolveClaudeAuthMode("nonsense", false, failingReader{t}, io.Discard)
+	if err == nil {
+		t.Fatal("expected an error for an invalid explicit value")
+	}
+	if !strings.Contains(err.Error(), "claude-auth") {
+		t.Errorf("error %q should mention the flag", err.Error())
+	}
+}
+
+// TestResolveClaudeAuthMode_NonInteractiveDefault is the P2 stdin contract:
+// empty flag + no TTY must return subscription WITHOUT reading stdin.
+func TestResolveClaudeAuthMode_NonInteractiveDefault(t *testing.T) {
+	var stdout bytes.Buffer
+	got, err := resolveClaudeAuthMode("", false, failingReader{t}, &stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != agents.ClaudeAuthModeSubscription {
+		t.Errorf("mode = %v, want subscription", got)
+	}
+	if stdout.Len() != 0 {
+		t.Errorf("non-interactive path wrote prompt text: %q", stdout.String())
+	}
+}
+
+// TestResolveClaudeAuthMode_InteractivePrompt covers the TTY first-run prompt:
+// scripted stdin yields the chosen mode and prompt text is emitted.
+func TestResolveClaudeAuthMode_InteractivePrompt(t *testing.T) {
+	cases := []struct {
+		name  string
+		stdin string
+		want  agents.ClaudeAuthMode
+	}{
+		{"api-key word", "api-key\n", agents.ClaudeAuthModeAPIKey},
+		{"subscription word", "subscription\n", agents.ClaudeAuthModeSubscription},
+		{"numeric 2", "2\n", agents.ClaudeAuthModeAPIKey},
+		{"numeric 1", "1\n", agents.ClaudeAuthModeSubscription},
+		{"bare enter defaults", "\n", agents.ClaudeAuthModeSubscription},
+		{"reask then valid", "huh?\napi-key\n", agents.ClaudeAuthModeAPIKey},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var stdout bytes.Buffer
+			got, err := resolveClaudeAuthMode("", true, strings.NewReader(tc.stdin), &stdout)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("mode = %v, want %v", got, tc.want)
+			}
+			if !strings.Contains(stdout.String(), "How should Claude authenticate?") {
+				t.Errorf("prompt text not emitted: %q", stdout.String())
+			}
+		})
+	}
+}
+
+// TestResolveClaudeAuthMode_PromptReasksOnInvalid asserts the re-ask line is
+// printed when the first answer is unrecognized.
+func TestResolveClaudeAuthMode_PromptReasksOnInvalid(t *testing.T) {
+	var stdout bytes.Buffer
+	got, err := resolveClaudeAuthMode("", true, strings.NewReader("xyz\nsubscription\n"), &stdout)
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if got != agents.ClaudeAuthModeSubscription {
+		t.Errorf("mode = %v, want subscription", got)
+	}
+	if !strings.Contains(stdout.String(), "unrecognized choice") {
+		t.Errorf("expected re-ask message, got %q", stdout.String())
+	}
+}

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -89,13 +89,21 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		sandboxBuild := launchFlags.String("sandbox-build", "auto", "Sandbox build policy during launch: auto, always, or never")
 		sandboxProxy := launchFlags.String("sandbox-proxy", "auto", "Sandbox HTTPS proxy bootstrap: auto, on, or off (auto = on for the Docker sandbox)")
 		hostLogin := launchFlags.String("host-login", "auto", "Host-side credential acquisition on vault miss: auto, on, or off (off forces in-container login)")
+		// --claude-auth selects Claude's auth mode (subscription|api-key).
+		// DIVERGENCE FROM SIBLING LAUNCH FLAGS (do not "fix" to a non-empty
+		// default): this defaults to "" (empty), not a tri-state like "auto".
+		// Empty means "unresolved": on a TTY it triggers the first-run
+		// selection prompt, off a TTY it defaults to subscription. A non-empty
+		// default would destroy empty-means-prompt. Only "subscription" and
+		// "api-key" are valid; any other non-empty value fails fast.
+		claudeAuth := launchFlags.String("claude-auth", "", "Claude auth mode: subscription or api-key (empty = prompt on a TTY, else subscription)")
 		if err := launchFlags.Parse(args[1:]); err != nil {
 			return 1
 		}
 		launchArgs := launchFlags.Args()
 
 		if len(launchArgs) < 1 {
-			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] [--local] [--sandbox=auto|docker] [--sandbox-build=auto|always|never] [--sandbox-proxy=auto|on|off] [--host-login=auto|on|off] <agent> [args...]")
+			fmt.Fprintln(stderr, "usage: aileron launch [--log-level=<level>] [--local] [--sandbox=auto|docker] [--sandbox-build=auto|always|never] [--sandbox-proxy=auto|on|off] [--host-login=auto|on|off] [--claude-auth=subscription|api-key] <agent> [args...]")
 			fmt.Fprintf(stderr, "agents: %s\n", strings.Join(registry.Names(), ", "))
 			return 1
 		}
@@ -135,6 +143,20 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 				return 1
 			}
 			*sandboxRuntime = "off"
+		}
+
+		// Claude auth-mode selection (#1340). Only the claude agent has an
+		// auth mode; every other agent passes through unchanged and never
+		// prompts. Resolve after trailing-flag application so a
+		// post-agent-name --claude-auth is honored, then swap the registered
+		// (zero-value subscription) Claude for one carrying the selected mode.
+		if agent.Name() == "claude" {
+			mode, err := resolveClaudeAuthMode(*claudeAuth, isTTYFn(), os.Stdin, stdout)
+			if err != nil {
+				fmt.Fprintf(stderr, "error: %v\n", err)
+				return 1
+			}
+			agent = agents.NewClaude(mode)
 		}
 
 		// Capture cwd so the daemon's session record carries working_dir
@@ -478,7 +500,7 @@ var launchFn = launch.Launch
 // `--flag` / `--flag=value` forms.
 func launchFlagTakesValue(name string) bool {
 	switch name {
-	case "log-level", "sandbox", "sandbox-build", "sandbox-proxy", "host-login":
+	case "log-level", "sandbox", "sandbox-build", "sandbox-proxy", "host-login", "claude-auth":
 		return true
 	default:
 		return false

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -34,11 +34,16 @@ import (
 // override doesn't suppress them.
 func init() {
 	ensureVaultUnlockedFn = func(string, io.Writer) error { return nil }
+	// Force the non-interactive path by default so launch tests that don't
+	// pass --claude-auth never block on the first-run prompt. Tests that
+	// exercise the prompt override isTTYFn locally.
+	isTTYFn = func() bool { return false }
 }
 
 func newTestRegistry() *launch.Registry {
 	r := launch.NewRegistry()
 	r.Register(agents.Claude{})
+	r.Register(agents.Pi{})
 	return r
 }
 

--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -56,6 +56,31 @@ For a quick manual check after changing a binding's container path, mount strate
 3. Confirm the agent starts **without** prompting for login. A login prompt means the in-container read failed (wrong path, mount mode, or envelope).
 4. Trigger or wait for an in-container credential rotation, exit the container cleanly, and re-run the launch. The second launch should also start silently, proving Capture round-tripped the rotation back to the vault.
 
+## Claude auth mode selection
+
+Claude Code supports two credential shapes: a Pro/Max OAuth subscription (`agents/claude/oauth`, a FileBinding) and a raw Anthropic API key (`agents/claude/apikey`, an EnvBinding rendering `ANTHROPIC_API_KEY`). The `--claude-auth` launch flag selects which one a Claude launch uses:
+
+```
+aileron launch --claude-auth=subscription claude   # Pro/Max OAuth
+aileron launch --claude-auth=api-key claude         # ANTHROPIC_API_KEY
+```
+
+The flag is position-independent like the other `aileron launch` flags (`aileron launch claude --claude-auth=api-key` is equivalent). Only `subscription` and `api-key` are valid; any other non-empty value fails the launch with a usage error.
+
+Unlike the tri-state launch flags, `--claude-auth` defaults to the empty string, which means **unresolved**:
+
+- On an interactive terminal, an empty flag triggers a one-line first-run prompt asking which mode to use (Enter selects subscription).
+- With no TTY (a pipe or CI), an empty flag defaults to subscription **without reading stdin**, so a piped stdin destined for the agent is never consumed.
+
+On a sandbox launch the launcher prints exactly one active-mode banner line to stderr so the selected mode is visible at a glance:
+
+```
+Claude auth mode: subscription (Pro/Max)
+Claude auth mode: API key
+```
+
+The banner is suppressed on host launch (`--local`), where the AuthSpec is not materialized and the mode is inert. The flag only affects the `claude` agent; every other agent ignores it and never prompts.
+
 ## First launch: in-container login seeds the vault
 
 When the vault has no entry for an agent, the launcher prints

--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -39,6 +39,27 @@ func NewClaude(mode ClaudeAuthMode) Claude { return Claude{authMode: mode} }
 func (c Claude) Name() string          { return "claude" }
 func (c Claude) BinaryNames() []string { return []string{"claude"} }
 
+// AuthMode returns the configured Claude auth mode. This is a display-only
+// read-back of the value passed to NewClaude (the zero value is
+// ClaudeAuthModeSubscription). It exists so the CLI can confirm which mode
+// it threaded onto the launched Claude and so the launcher can surface a
+// per-mode banner; it does NOT participate in AuthSpec selection (that
+// branching lives in AuthSpec on the unexported authMode field).
+func (c Claude) AuthMode() ClaudeAuthMode { return c.authMode }
+
+// AuthModeDisplay maps Claude's auth mode onto the launch package's
+// agent-agnostic display enum. The launch package cannot import this
+// package (agents already imports launch), so the launcher reads the mode
+// back through a launch-local interface that returns launch.AuthModeDisplay
+// rather than the agents-defined ClaudeAuthMode. This is display-only and
+// never feeds AuthSpec selection.
+func (c Claude) AuthModeDisplay() launch.AuthModeDisplay {
+	if c.authMode == ClaudeAuthModeAPIKey {
+		return launch.AuthModeDisplayAPIKey
+	}
+	return launch.AuthModeDisplaySubscription
+}
+
 // Args tells Claude Code how aggressively to auto-approve, branching on
 // the launch trust boundary.
 //

--- a/internal/launch/agents/claude_authmode_test.go
+++ b/internal/launch/agents/claude_authmode_test.go
@@ -1,0 +1,37 @@
+package agents_test
+
+import (
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch"
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+)
+
+// TestClaude_AuthMode_ReadsBack pins the display-only read-back contract
+// (#1340): NewClaude(mode).AuthMode() returns the mode it was built with,
+// and a bare Claude{} reports the zero-value subscription mode.
+func TestClaude_AuthMode_ReadsBack(t *testing.T) {
+	if got := agents.NewClaude(agents.ClaudeAuthModeAPIKey).AuthMode(); got != agents.ClaudeAuthModeAPIKey {
+		t.Errorf("NewClaude(APIKey).AuthMode() = %v, want APIKey", got)
+	}
+	if got := agents.NewClaude(agents.ClaudeAuthModeSubscription).AuthMode(); got != agents.ClaudeAuthModeSubscription {
+		t.Errorf("NewClaude(Subscription).AuthMode() = %v, want Subscription", got)
+	}
+	if got := (agents.Claude{}).AuthMode(); got != agents.ClaudeAuthModeSubscription {
+		t.Errorf("Claude{}.AuthMode() = %v, want zero-value Subscription", got)
+	}
+}
+
+// TestClaude_AuthModeDisplay maps the agent mode onto the launch package's
+// display enum the launcher reads for the active-mode banner.
+func TestClaude_AuthModeDisplay(t *testing.T) {
+	if got := agents.NewClaude(agents.ClaudeAuthModeAPIKey).AuthModeDisplay(); got != launch.AuthModeDisplayAPIKey {
+		t.Errorf("APIKey display = %v, want AuthModeDisplayAPIKey", got)
+	}
+	if got := agents.NewClaude(agents.ClaudeAuthModeSubscription).AuthModeDisplay(); got != launch.AuthModeDisplaySubscription {
+		t.Errorf("Subscription display = %v, want AuthModeDisplaySubscription", got)
+	}
+	if got := (agents.Claude{}).AuthModeDisplay(); got != launch.AuthModeDisplaySubscription {
+		t.Errorf("zero-value display = %v, want AuthModeDisplaySubscription", got)
+	}
+}

--- a/internal/launch/claude_auth_banner.go
+++ b/internal/launch/claude_auth_banner.go
@@ -1,0 +1,57 @@
+package launch
+
+import (
+	"fmt"
+	"io"
+)
+
+// AuthModeDisplay is an agent-agnostic, display-only enumeration of the
+// Claude auth mode used to render the active-mode startup banner. It lives
+// in the launch package (rather than reusing agents.ClaudeAuthMode) because
+// agents imports launch, so the launcher cannot import agents to name that
+// type. An agent exposes its mode to the launcher by implementing
+// claudeAuthModeReader (an AuthModeDisplay-returning method); this is purely
+// for signalling and never feeds AuthSpec selection.
+type AuthModeDisplay int
+
+const (
+	// AuthModeDisplaySubscription is the Pro/Max OAuth subscription flow.
+	// It is the zero value so a bare implementer defaults to subscription.
+	AuthModeDisplaySubscription AuthModeDisplay = iota
+	// AuthModeDisplayAPIKey is the raw ANTHROPIC_API_KEY flow.
+	AuthModeDisplayAPIKey
+)
+
+// claudeAuthModeReader is the narrow interface the launcher type-asserts
+// config.Agent against to read back its display auth mode. agents.Claude
+// satisfies it via AuthModeDisplay(). Keeping the method on a launch-defined
+// return type avoids the agents->launch import cycle.
+type claudeAuthModeReader interface {
+	AuthModeDisplay() AuthModeDisplay
+}
+
+// claudeAuthBannerLine renders the active-mode banner line for the given
+// display mode. The copy is byte-exact per feedback #1331 Q4.
+func claudeAuthBannerLine(mode AuthModeDisplay) string {
+	if mode == AuthModeDisplayAPIKey {
+		return "Claude auth mode: API key"
+	}
+	return "Claude auth mode: subscription (Pro/Max)"
+}
+
+// printClaudeAuthBanner emits exactly one active-mode banner line to w when
+// the launch is a sandbox launch (sandboxEnabled) of the claude agent and
+// the agent exposes its mode via claudeAuthModeReader. On host launch the
+// auth mode is inert (the launcher never materializes AuthSpec there), so no
+// banner is printed to avoid a false signal (P0). Non-claude agents and
+// agents that do not expose a mode are silently skipped.
+func printClaudeAuthBanner(w io.Writer, agent Agent, sandboxEnabled bool) {
+	if !sandboxEnabled || agent == nil || agent.Name() != "claude" {
+		return
+	}
+	reader, ok := agent.(claudeAuthModeReader)
+	if !ok {
+		return
+	}
+	fmt.Fprintln(w, claudeAuthBannerLine(reader.AuthModeDisplay()))
+}

--- a/internal/launch/claude_auth_banner_test.go
+++ b/internal/launch/claude_auth_banner_test.go
@@ -1,0 +1,94 @@
+package launch
+
+import (
+	"bytes"
+	"strings"
+	"testing"
+)
+
+// claudeModeAgent is a test agent that reports a name and a display auth
+// mode, satisfying both Agent and claudeAuthModeReader.
+type claudeModeAgent struct {
+	name string
+	mode AuthModeDisplay
+}
+
+func (a claudeModeAgent) Name() string           { return a.name }
+func (a claudeModeAgent) BinaryNames() []string  { return []string{a.name} }
+func (a claudeModeAgent) Args(_ Mode) []string   { return nil }
+func (a claudeModeAgent) Env() map[string]string { return nil }
+func (a claudeModeAgent) LLMEndpointEnv() string { return "" }
+func (a claudeModeAgent) ConfigureMCP(string, map[string]string, string, Mode) ([]string, []MCPMount, error) {
+	return nil, nil, nil
+}
+func (a claudeModeAgent) AuthSpec() AuthSpec               { return AuthSpec{} }
+func (a claudeModeAgent) AuthModeDisplay() AuthModeDisplay { return a.mode }
+
+func TestPrintClaudeAuthBanner_SandboxClaude(t *testing.T) {
+	cases := []struct {
+		name string
+		mode AuthModeDisplay
+		want string
+	}{
+		{"subscription", AuthModeDisplaySubscription, "Claude auth mode: subscription (Pro/Max)"},
+		{"api-key", AuthModeDisplayAPIKey, "Claude auth mode: API key"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var buf bytes.Buffer
+			printClaudeAuthBanner(&buf, claudeModeAgent{name: "claude", mode: tc.mode}, true)
+			got := strings.TrimRight(buf.String(), "\n")
+			if got != tc.want {
+				t.Errorf("banner = %q, want %q", got, tc.want)
+			}
+			// Exactly one line.
+			if n := strings.Count(buf.String(), "\n"); n != 1 {
+				t.Errorf("banner emitted %d newlines, want exactly 1: %q", n, buf.String())
+			}
+		})
+	}
+}
+
+// TestPrintClaudeAuthBanner_HostSuppressed is the P0 false-signal guard: on
+// host launch (sandboxEnabled=false) the mode is inert, so no banner.
+func TestPrintClaudeAuthBanner_HostSuppressed(t *testing.T) {
+	var buf bytes.Buffer
+	printClaudeAuthBanner(&buf, claudeModeAgent{name: "claude", mode: AuthModeDisplayAPIKey}, false)
+	if buf.Len() != 0 {
+		t.Errorf("host launch emitted a banner: %q", buf.String())
+	}
+}
+
+// TestPrintClaudeAuthBanner_NonClaudeSkipped covers decision #5's guard: a
+// non-claude agent never gets the banner even on the sandbox path.
+func TestPrintClaudeAuthBanner_NonClaudeSkipped(t *testing.T) {
+	var buf bytes.Buffer
+	printClaudeAuthBanner(&buf, claudeModeAgent{name: "codex", mode: AuthModeDisplayAPIKey}, true)
+	if buf.Len() != 0 {
+		t.Errorf("non-claude agent emitted a banner: %q", buf.String())
+	}
+}
+
+// TestPrintClaudeAuthBanner_ClaudeWithoutReaderSkipped covers the case where
+// the claude-named agent does not expose AuthModeDisplay: the type assertion
+// fails and the banner is silently skipped rather than panicking.
+func TestPrintClaudeAuthBanner_ClaudeWithoutReaderSkipped(t *testing.T) {
+	var buf bytes.Buffer
+	printClaudeAuthBanner(&buf, emptyClaudeAgent{}, true)
+	if buf.Len() != 0 {
+		t.Errorf("claude agent without AuthModeDisplay emitted a banner: %q", buf.String())
+	}
+}
+
+// emptyClaudeAgent is named "claude" but does not implement claudeAuthModeReader.
+type emptyClaudeAgent struct{}
+
+func (emptyClaudeAgent) Name() string           { return "claude" }
+func (emptyClaudeAgent) BinaryNames() []string  { return []string{"claude"} }
+func (emptyClaudeAgent) Args(_ Mode) []string   { return nil }
+func (emptyClaudeAgent) Env() map[string]string { return nil }
+func (emptyClaudeAgent) LLMEndpointEnv() string { return "" }
+func (emptyClaudeAgent) ConfigureMCP(string, map[string]string, string, Mode) ([]string, []MCPMount, error) {
+	return nil, nil, nil
+}
+func (emptyClaudeAgent) AuthSpec() AuthSpec { return AuthSpec{} }

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -577,6 +577,12 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 			fmt.Fprintf(os.Stderr, NoVaultCredentialMsgFormat, config.Agent.Name())
 		}
 
+		// Claude active-mode banner (#1340). Gated on the sandbox path
+		// because the auth mode is inert on host launch (AuthSpec is only
+		// materialized under sandbox), so emitting it there would be a false
+		// signal (P0). Non-claude agents are a no-op.
+		printClaudeAuthBanner(os.Stderr, config.Agent, sandboxEnabled)
+
 		// User-level GitHub injection runs on every sandbox launch,
 		// independent of the per-agent AuthSpec: it probes the
 		// agent-independent `user/github` token in the vault and, when


### PR DESCRIPTION
## Summary

User-facing selection and signalling for Claude's auth mode, built on the #1339 seam (`agents.NewClaude(mode)` + mode-aware `AuthSpec`). All four planned units land in one PR (P1: no decoupled merge).

- **`--claude-auth=subscription|api-key`** launch flag. Position-independent like the sibling launch flags and consumed wherever it lands (before or after the agent name). Invalid non-empty values fail fast with a usage error. It deliberately **defaults to `""` (unresolved)**, not a tri-state like `auto` — a doc comment on the flag spells this out so it is not "fixed" to a non-empty default (which would destroy empty-means-prompt).
- **`resolveClaudeAuthMode`** (pure helper, CLI layer): explicit value wins; empty + TTY runs a first-run prompt (re-asks on bad input); empty + no TTY returns subscription **without reading stdin**, so a piped stdin destined for the agent is never consumed.
- **Claude-scoped instance swap**: a `claude` launch replaces the registered zero-value `Claude` with `agents.NewClaude(selectedMode)`; every other agent passes through unchanged and never prompts.
- **Active-mode banner**: exactly one line on the sandbox path only — `Claude auth mode: subscription (Pro/Max)` or `Claude auth mode: API key` (copy byte-exact per feedback #1331 Q4). Suppressed on host launch (`--local`), where the mode is inert, to avoid a false signal (P0). The banner helper and its display enum live in the `launch` package to avoid the `agents -> launch` import cycle; `agents.Claude` exposes the mode via `AuthMode()` (agents-layer readback) and `AuthModeDisplay()` (launch-defined enum the launcher reads through a narrow interface).
- Only display + selection logic here; AuthSpec binding selection stays #1339-owned.

Docs: added a "Claude auth mode selection" section to `sandbox-agent-auth.md`.

## Test plan

- `internal/launch/agents`: `AuthMode()` / `AuthModeDisplay()` read-back incl. zero-value subscription.
- `internal/launch` (`printClaudeAuthBanner`): exact banner strings per mode on sandbox; **no banner** on host launch (P0 false-signal guard); non-claude skipped; claude-without-reader skipped (no panic).
- `cmd/aileron`: explicit `--claude-auth` threads the mode onto the swapped `agents.Claude` (before/after agent name); flag not forwarded to the agent; `bogus` value exits 1 without calling launch; non-claude agent unaffected; resolver unit tests cover explicit values, invalid, the **non-interactive no-stdin-read contract** (a `failingReader` that fails the test if `Read` is called), the interactive prompt (scripted stdin, numeric + word choices, bare-Enter default, re-ask), and explicit-value-bypasses-prompt-on-TTY.
- `task test:go` green. `gofmt`/`go vet` clean. CodeRabbit review: 0 findings. New helpers covered 90–100%.

Closes #1340

🤖 Generated with [Claude Code](https://claude.com/claude-code)
