### PR TITLE
docs: make Getting Started Claude preflight mode-aware

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -163,6 +163,8 @@ aileron launch claude
 aileron launch --local claude
 ```
 
+The first launch resolves how Claude authenticates. Subscription mode signs in with a Claude Pro/Max account via OAuth login and is the default. API-key mode uses an Anthropic API key from `ANTHROPIC_API_KEY`. Pass `--claude-auth=subscription` or `--claude-auth=api-key` to pre-select the mode, or answer the first-run prompt where Enter selects subscription. The launcher prints the active mode as `Claude auth mode: subscription (Pro/Max)` or `Claude auth mode: API key`. See [Sandbox Agent Auth](/development/sandbox-agent-auth/) for the full mode-selection and seeding detail.
+
 You'll see a banner like:
 
 ```

--- a/docs/src/lib/components/ui/liftoff-preflight.svelte
+++ b/docs/src/lib/components/ui/liftoff-preflight.svelte
@@ -38,9 +38,13 @@
 		<AccordionPrimitive.Content forceMount class={contentClass}>
 			<p>
 				Install and configure
-				<a href="https://docs.claude.com/en/docs/claude-code/setup">Claude Code</a> with an
-				Anthropic API key in <code>ANTHROPIC_API_KEY</code>. Aileron's launcher routes Claude
-				Code's LLM calls through Aileron locally. It does not supply or replace your API key.
+				<a href="https://docs.claude.com/en/docs/claude-code/setup">Claude Code</a>. Claude Code can
+				authenticate two ways. Subscription mode signs in with a Claude Pro/Max account via OAuth
+				login and needs no API key. API-key mode reads an Anthropic API key from
+				<code>ANTHROPIC_API_KEY</code>. You pick the mode at launch with
+				<code>--claude-auth=subscription|api-key</code>, or by answering the first-run prompt where
+				Enter selects subscription. Aileron's launcher routes Claude Code's LLM calls through Aileron
+				locally. It does not supply or replace your credentials.
 			</p>
 		</AccordionPrimitive.Content>
 	</AccordionPrimitive.Item>


### PR DESCRIPTION
## Summary

SUB5 of umbrella #1336. Makes the Getting Started "Preflight Checklist" and step-3 launch narrative mode-aware for Claude Code's two auth modes shipped in #1340, so an Anthropic API key is no longer presented as mandatory.

- **Preflight island** (`liftoff-preflight.svelte`): the Claude Code accordion item now states the two auth modes — subscription (Claude Pro/Max via OAuth login, no API key) and api-key (`ANTHROPIC_API_KEY`) — and how to pick one (`--claude-auth=subscription|api-key`, or the first-run prompt where Enter selects subscription). Keeps the true statement that the launcher routes Claude Code's LLM calls through Aileron locally and does not supply or replace your credentials. Keeps the existing setup link. The `google` accordion item and all accordion/styling structure are untouched.
- **Getting Started step 3** (`getting-started.mdx`): a short, voice-compliant note next to the `aileron launch claude` block describes mode resolution on first launch, one sentence per mode, the `--claude-auth` pre-select, and links to the existing [Sandbox Agent Auth](/development/sandbox-agent-auth/) dev doc for the full detail rather than duplicating it.

Quoted strings are byte-exact against the shipped code on `main`: `--claude-auth=subscription|api-key`, `Claude auth mode: subscription (Pro/Max)`, `Claude auth mode: API key`, `ANTHROPIC_API_KEY`.

This is a **docs-only** change.

## Design rationales (acceptance criteria)

- **README is scoped OUT.** `README.md` is a deliberate pointer-to-docs file with no launch/Claude/auth prose; it delegates all behavior docs to the site by design. The repo "update README" convention is satisfied by the site docs, which are the canonical behavior docs. No auth-mode prose was injected into the README.
- **The "preflight check code is updated" bullet is a verified no-op.** There is no `aileron launch claude` preflight that enforces a hard `ANTHROPIC_API_KEY` requirement. Every `ANTHROPIC_API_KEY` occurrence on the launch path (`internal/launch/agents/claude.go`, `internal/launch/agents/claude_auth.go`) renders the env binding in api-key mode; it is not a gating prereq check. The `internal/config/auth.go` usage is the cloud control-plane draft, unrelated to launch. No Go code change is made. Per the repo Testing Philosophy, a pure-prose docs change with no enforcing code adds no test.

## Test plan

- `task build:docs` succeeds; the build emits `/getting-started/` and the preflight island page with no errors.
- `pnpm run check` (astro check): 0 errors, 0 warnings, 0 hints across 26 Astro files.
- Verified the rendered "Claude Code" preflight item shows both modes and no longer presents `ANTHROPIC_API_KEY` as mandatory; the step-3 link `/development/sandbox-agent-auth/` resolves to a built page.

Closes #1341
