### PR TITLE
docs: document container-default launch and inline cloud auth flow

### DIFF
--- a/docs/src/content/docs/getting-started.mdx
+++ b/docs/src/content/docs/getting-started.mdx
@@ -157,13 +157,31 @@ If you'd rather drive each step yourself, the single-action form `aileron action
 aileron launch claude
 ```
 
-`aileron launch` runs the agent in the Docker sandbox by default. To launch the agent directly on the host instead, add `--local`:
+`aileron launch` runs the agent inside a Docker container by default. The container is the sandbox: Claude Code runs in an isolated environment, never on your host. Because that isolation is the trust boundary, the sandboxed launch starts Claude Code with `--dangerously-skip-permissions`, so the agent works without stopping for per-command confirmation. The sandbox is what makes that safe. The agent can move fast inside a box it cannot escape.
+
+To launch the agent directly on the host instead, add `--local`:
 
 ```sh
 aileron launch --local claude
 ```
 
+The host launch keeps a narrower posture. It pre-approves only the agent's shell commands and Aileron's own tools, not blanket skip-permissions.
+
 The first launch resolves how Claude authenticates. Subscription mode signs in with a Claude Pro/Max account via OAuth login and is the default. API-key mode uses an Anthropic API key from `ANTHROPIC_API_KEY`. Pass `--claude-auth=subscription` or `--claude-auth=api-key` to pre-select the mode, or answer the first-run prompt where Enter selects subscription. The launcher prints the active mode as `Claude auth mode: subscription (Pro/Max)` or `Claude auth mode: API key`. See [Sandbox Agent Auth](/development/sandbox-agent-auth/) for the full mode-selection and seeding detail.
+
+In subscription mode, the first launch walks you through the cloud login right here. Aileron prints the authorize URL and opens it in your browser:
+
+```
+To authorize Claude, open https://claude.ai/oauth/authorize?... in your browser and paste back the code shown.
+```
+
+Sign in with your Claude Pro/Max account in the browser, copy the code the page shows, and paste it back at the prompt:
+
+```
+Paste the code from your browser and press Enter:
+```
+
+The paste stays on your host terminal, never inside the container. Aileron exchanges the code, seeds the credential into your vault, and the credential is reused on later launches. This first-run flow happens once.
 
 You'll see a banner like:
 

--- a/docs/src/lib/components/ui/liftoff-preflight.svelte
+++ b/docs/src/lib/components/ui/liftoff-preflight.svelte
@@ -49,6 +49,23 @@
 		</AccordionPrimitive.Content>
 	</AccordionPrimitive.Item>
 
+	<AccordionPrimitive.Item value="docker" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>Docker</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content forceMount class={contentClass}>
+			<p>
+				Docker installed and the daemon running.
+				<a href="https://www.docker.com/products/docker-desktop/">Docker Desktop</a> is the easy
+				path on macOS and Windows. <code>aileron launch</code> runs the agent inside a container by
+				default, so the daemon must be reachable before you launch.
+			</p>
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+
 	<AccordionPrimitive.Item value="google" class={itemClass}>
 		<AccordionPrimitive.Header>
 			<AccordionPrimitive.Trigger class={triggerClass}>


### PR DESCRIPTION
## Summary

Updates the Getting Started guide for the container-by-default launch behavior (#1305) and the working cloud auth flow (#1303, #1304), closing #1307.

- **Step 3 narrative**: `aileron launch claude` now runs Claude Code inside a Docker container by default. The guide explains the sandbox is the trust boundary, that the sandboxed launch starts Claude Code with `--dangerously-skip-permissions` (per #1330) so the agent works without per-command confirmation, and the *why*: the isolation is what makes that safe. The narrower `--allowedTools` posture for `--local` host launches is noted.
- **Inline cloud auth flow**: the subscription first-run login is documented inline in step 3 (no separate section), quoting the **real** terminal output verbatim from the launcher: the authorize-URL line (`internal/launch/agents/claude_auth.go:484`) and the paste-the-code prompt (`internal/launch/host_code_prompt.go:44`).
- **Docker prerequisite**: new accordion item in the Preflight Checklist island (`liftoff-preflight.svelte`): "Docker installed and the daemon running," with Docker Desktop as the easy path on macOS/Windows.

The auth-mode preflight wording was already handled by #1341 and is not duplicated here. Additions follow the docs writing voice (no em-dashes, one thought per sentence).

## Test plan

- `task lint:docs` (astro check): 0 errors, 0 warnings, 0 hints
- `task test:docs`: 8/8 pass
- `task build:docs`: 127 pages built; verified the rendered `getting-started/index.html` contains the new auth-flow lines, Docker prereq, and skip-permissions copy
- Verified the quoted terminal strings match the shipped launcher source exactly

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Expanded getting-started guide to clarify Docker container isolation for Claude Code execution and authentication flow
  * Added Docker requirement check to preflight checklist with daemon dependency information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->