### PR TITLE
docs(adr): scope ADR-0026 deferred auth-convergence bullet to non-base CLIs

### DIFF
--- a/docs/src/content/docs/adr/0026-cli-capability-units.md
+++ b/docs/src/content/docs/adr/0026-cli-capability-units.md
@@ -100,7 +100,7 @@ Both central files were removed under [#1323](https://github.com/ALRubinger/aile
 
 The following are explicitly forward-declared and not done in this umbrella.
 
-- `aileron auth <cli>` capture-image convergence, so the standalone user-level acquisition command resolves a CLI's acquisition from the same unit the launcher reads.
+- `aileron auth <cli>` capture-image convergence for a Feature-installed non-base CLI. The standalone `aileron auth github` command already resolves gh's acquisition from the same image unit layer the launcher reads, because gh installs in the base image that `aileron auth` inspects. A CLI installed by a non-base Feature is not yet reachable by `aileron auth`, so its acquisition cannot converge on its unit this way.
 - The acquisition `direct-token` mode, for tools that supply a token directly rather than acquiring one through an interactive login (the `linear-pp-cli` case).
 - The `state` and cross-sandbox cache plane, absorbing the cache-persistence ask tracked in [#1190](https://github.com/ALRubinger/aileron/issues/1190).
 - Third-party untrusted units and the trust tiers that gate them, so a unit from an untrusted Feature is held to a different bar than a trusted in-house one.


### PR DESCRIPTION
## Summary

Follow-up to #1376 (the CLI-capability-unit ADR + guide for #1324). The shipped ADR-0026 "Deferred follow-on" list claimed `aileron auth <cli>` capture-image convergence is **not done**, but that contradicts the code on `main`.

`cmd/aileron/auth_github.go` already routes the standalone `aileron auth github` command through the image gh-Feature unit layer (`captureRegistry` → `imageCaptureRegistry` → `imageCaptureLayers` → `unitloader.LayersFromImage`), the same unit source the launcher reads. Its own comment: *"As of #1323 gh no longer ships as a central embedded default; its capture descriptor comes from the sandbox base image's gh CLI Feature unit."* So gh's acquisition has already converged on the unit.

What actually remains deferred is convergence for a **Feature-installed non-base CLI**: `aileron auth` inspects the base image only, so a CLI installed by a non-base Feature is not yet reachable. This PR re-scopes the bullet to say that, so the ADR no longer asserts a code state that does not exist.

Surfaced as the low-confidence P1 escalation in review-residual #1375 during the cw-orchestrate run for #1324; verified high-confidence against the shipped code.

## Test plan

- Docs-only change, one bullet in `docs/src/content/docs/adr/0026-cli-capability-units.md`.
- Verified the claim against `origin/main:cmd/aileron/auth_github.go` (lines ~123-138, 160-188) and `internal/app/app.go` (host uses the same `unitloader.LayersFromImage`).
- Docs-voice preserved: no em-dashes, one thought per sentence.

Relates to #1324. Part of #1319. Resolves the P1 in #1375.

🤖 Generated with [Claude Code](https://claude.com/claude-code)