### PR TITLE
fix(launch): align Claude auth choose line with numbered options

### DIFF
--- a/cmd/aileron/claude_auth.go
+++ b/cmd/aileron/claude_auth.go
@@ -191,7 +191,7 @@ func promptClaudeAuthMode(stdin io.Reader, stdout io.Writer) (agents.ClaudeAuthM
 	fmt.Fprintln(stdout, "  [1] subscription  Claude Pro/Max via OAuth login (default)")
 	fmt.Fprintln(stdout, "  [2] api-key       Anthropic API key (ANTHROPIC_API_KEY)")
 	for {
-		fmt.Fprint(stdout, "Choose [subscription/api-key] (default subscription): ")
+		fmt.Fprint(stdout, "Choose [1/2] (default 1: subscription): ")
 		line, err := br.ReadString('\n')
 		choice := strings.TrimSpace(line)
 		if choice == "" {
@@ -212,7 +212,7 @@ func promptClaudeAuthMode(stdin io.Reader, stdout io.Writer) (agents.ClaudeAuthM
 		if mode, ok := parseClaudeAuthMode(choice); ok {
 			return mode, nil
 		}
-		fmt.Fprintf(stdout, "  unrecognized choice %q; please answer subscription or api-key\n", choice)
+		fmt.Fprintf(stdout, "  unrecognized choice %q; please answer 1 (subscription) or 2 (api-key)\n", choice)
 		if err != nil {
 			// Stream closed mid-prompt with no valid choice; fall back to the
 			// documented default rather than erroring the whole launch.

--- a/cmd/aileron/claude_auth_test.go
+++ b/cmd/aileron/claude_auth_test.go
@@ -505,3 +505,31 @@ func TestProbeClaudeVaultPresence_NoDaemon(t *testing.T) {
 		t.Errorf("probe with no daemon = %+v, want both absent", got)
 	}
 }
+
+// TestResolveClaudeAuthMode_ChooseLineMatchesNumberedOptions is the regression
+// test for #1380: the "Choose" line must speak in the same numeric terms as the
+// "[1]"/"[2]" options it lists, and the default hint must tie the number to the
+// mode name, so a reader can map the digit they type to the auth mode it picks.
+func TestResolveClaudeAuthMode_ChooseLineMatchesNumberedOptions(t *testing.T) {
+	// An empty vault forces the interactive prompt to run on the TTY path.
+	stubClaudeVaultPresence(t, claudeVaultPresence{})
+	var stdout bytes.Buffer
+	// Bare Enter takes the default after emitting the full prompt once.
+	if _, err := resolveClaudeAuthMode("", true, strings.NewReader("\n"), &stdout); err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	out := stdout.String()
+
+	// The choose line offers the same digits as the numbered options.
+	if !strings.Contains(out, "Choose [1/2]") {
+		t.Errorf("choose line does not offer numeric [1/2]: %q", out)
+	}
+	// The default hint ties the number to the mode name.
+	if !strings.Contains(out, "default 1: subscription") {
+		t.Errorf("default hint does not tie number to name: %q", out)
+	}
+	// The old name-only phrasing must be gone so the two referents line up.
+	if strings.Contains(out, "[subscription/api-key]") {
+		t.Errorf("choose line still uses name-only phrasing: %q", out)
+	}
+}


### PR DESCRIPTION
## Summary

The interactive first-run Claude auth prompt (`aileron launch claude`, no `--claude-auth`) lists its options as numbered entries `[1]`/`[2]`, but the choose line then read `Choose [subscription/api-key] (default subscription)`. The two ways of naming the options (numbers vs. names) did not line up, so it was not obvious that `subscription` is option 1 and `api-key` is option 2 (#1380).

This aligns the choose line and default hint with the numbered options:

- `Choose [1/2] (default 1: subscription): ` — same digits as the `[1]`/`[2]` list, with the default tied to its mode name.
- Re-ask line now reads `please answer 1 (subscription) or 2 (api-key)`.

Input parsing is unchanged: digits `1`/`2` and the names (and synonyms) were already accepted, so this is a pure prompt-text clarity change with no behavior change.

## Test plan

- New regression test `TestResolveClaudeAuthMode_ChooseLineMatchesNumberedOptions` asserts the choose line offers `[1/2]`, the default hint reads `default 1: subscription`, and the old name-only `[subscription/api-key]` phrasing is gone.
- Existing prompt tests (numeric `1`/`2`, names, bare-Enter default, re-ask path) still pass.
- `go build ./cmd/aileron/` and `go test ./cmd/aileron/ -run TestResolveClaudeAuthMode` green.

Closes #1380

🤖 Generated with [Claude Code](https://claude.com/claude-code)
