### PR TITLE
fix(launch): resolve aileron-mcp sibling with .exe on Windows

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -146,13 +146,51 @@ func ResolveBinary(names []string) (string, error) {
 	return "", fmt.Errorf("could not find any of %v on PATH", names)
 }
 
+// exeSuffix is the platform's executable file extension. On Windows the
+// aileron and aileron-mcp binaries are written as `aileron.exe` /
+// `aileron-mcp.exe`, so a bare sibling name like "aileron-mcp" never
+// resolves on disk; everywhere else it is empty.
+func exeSuffix() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}
+
+// siblingCandidates returns the on-disk filenames to probe for a sibling
+// binary, in priority order. With a non-empty platform suffix (".exe" on
+// Windows) the suffixed filename is tried first because that is the real
+// name the Windows build produces; the bare name is still probed so a
+// manually placed extension-less binary resolves too. Off Windows the
+// suffix is empty and the single bare name is returned. The suffix is
+// passed in (rather than read from runtime.GOOS) so the Windows ordering
+// is unit-testable from any host.
+func siblingCandidates(name, suffix string) []string {
+	if suffix != "" && !strings.HasSuffix(name, suffix) {
+		return []string{name + suffix, name}
+	}
+	return []string{name}
+}
+
 // resolveSibling looks for a binary next to the given executable path,
 // then falls back to searching PATH.
+//
+// On Windows the on-disk sibling carries an `.exe` extension while the
+// caller passes the bare name (e.g. "aileron-mcp"), so the sibling
+// candidate is probed both with and without the platform exeSuffix; a
+// bare-name os.Stat would otherwise miss `aileron-mcp.exe`, fall
+// through, and let the launcher write an unresolvable
+// `command = "aileron-mcp"` into Codex's config.toml — which fails at
+// MCP startup with OS error 2 (issue #1387). exec.LookPath is the final
+// fallback and already applies %PATHEXT% on Windows, so it needs no
+// extra handling.
 func resolveSibling(selfPath, name string) (string, error) {
 	dir := filepath.Dir(selfPath)
-	candidate := filepath.Join(dir, name)
-	if _, err := os.Stat(candidate); err == nil {
-		return filepath.Abs(candidate)
+	for _, c := range siblingCandidates(name, exeSuffix()) {
+		candidate := filepath.Join(dir, c)
+		if _, err := os.Stat(candidate); err == nil {
+			return filepath.Abs(candidate)
+		}
 	}
 	return exec.LookPath(name)
 }

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -592,6 +592,71 @@ func TestResolveSandboxMCPBinary_PropagatesMissingError(t *testing.T) {
 	}
 }
 
+// TestSiblingCandidates_WindowsTriesExeFirst is the regression test for
+// #1387: on Windows the launcher must probe `aileron-mcp.exe` (the real
+// filename the Windows build produces) before the bare `aileron-mcp`,
+// otherwise resolveSibling's os.Stat misses the binary, falls through,
+// and the launcher writes an unresolvable `command = "aileron-mcp"` into
+// Codex's config.toml — which fails at MCP startup with OS error 2.
+//
+// The suffix is a parameter so this Windows-specific ordering is
+// verifiable from any host (CI runs these on Linux).
+func TestSiblingCandidates_WindowsTriesExeFirst(t *testing.T) {
+	got := siblingCandidates("aileron-mcp", ".exe")
+	want := []string{"aileron-mcp.exe", "aileron-mcp"}
+	if len(got) != len(want) || got[0] != want[0] || got[1] != want[1] {
+		t.Fatalf("siblingCandidates(\"aileron-mcp\", \".exe\") = %v, want %v", got, want)
+	}
+}
+
+// TestSiblingCandidates_NonWindowsBareNameOnly confirms that off Windows
+// (empty suffix) the lookup is unchanged: a single bare candidate, no
+// spurious `.exe` probe.
+func TestSiblingCandidates_NonWindowsBareNameOnly(t *testing.T) {
+	got := siblingCandidates("aileron-mcp", "")
+	if len(got) != 1 || got[0] != "aileron-mcp" {
+		t.Fatalf("siblingCandidates(\"aileron-mcp\", \"\") = %v, want [aileron-mcp]", got)
+	}
+}
+
+// TestSiblingCandidates_AlreadySuffixed guards against a double suffix
+// when a caller passes a name that already ends in the platform suffix:
+// the bare name is returned as-is rather than producing `foo.exe.exe`.
+func TestSiblingCandidates_AlreadySuffixed(t *testing.T) {
+	got := siblingCandidates("aileron-mcp.exe", ".exe")
+	if len(got) != 1 || got[0] != "aileron-mcp.exe" {
+		t.Fatalf("siblingCandidates(\"aileron-mcp.exe\", \".exe\") = %v, want [aileron-mcp.exe]", got)
+	}
+}
+
+// TestResolveSibling_FindsHostSibling exercises resolveSibling end-to-end
+// on the current host: a bare-named sibling placed next to the running
+// binary resolves to its absolute path. This locks the non-Windows
+// happy path so the #1387 candidate-ordering change does not regress the
+// common Linux/macOS install layout.
+func TestResolveSibling_FindsHostSibling(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bare-named sibling is not the Windows on-disk shape; covered by siblingCandidates tests")
+	}
+	dir := t.TempDir()
+	selfPath := filepath.Join(dir, "aileron")
+	if err := os.WriteFile(selfPath, []byte("self"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(dir, "aileron-mcp")
+	if err := os.WriteFile(mcp, []byte("mcp"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveSibling(selfPath, "aileron-mcp")
+	if err != nil {
+		t.Fatalf("resolveSibling: %v", err)
+	}
+	want, _ := filepath.Abs(mcp)
+	if got != want {
+		t.Fatalf("resolveSibling = %q, want %q", got, want)
+	}
+}
+
 // TestValidateSandboxRuntimeRejectsPodman is the launch-path regression
 // test for #1051: --sandbox=podman must fail validation with the
 // Docker-only message. The runtime seam (the runtimeName parameter)


### PR DESCRIPTION
## Summary

On Windows, launching Codex through Aileron failed to start the Aileron MCP server: Codex reported `MCP startup failed: no such file or directory, OS error 2`, and `/mcp` listed `aileron` with `tools: none`, so the whole Aileron integration was non-functional (issue #1387).

Root cause is in `resolveSibling` (`internal/launch/launcher.go`). It probed only the bare filename `aileron-mcp` next to the running binary. The Windows build produces `aileron-mcp.exe`, so `os.Stat("…/aileron-mcp")` missed it and fell through to `exec.LookPath`. In the common install layout where the MCP binary sits beside `aileron` but is not on `PATH`, that also missed, and the launcher wrote an unresolvable `command = "aileron-mcp"` into Codex's `config.toml`. Codex (which spawns the command verbatim) then failed with OS error 2.

The fix probes the platform executable extension (`.exe` on Windows) first, keeps the bare name as a fallback (so a manually placed extension-less binary still resolves), and leaves `exec.LookPath` — which already applies `%PATHEXT%` — as the final fallback. The candidate-ordering logic is extracted into a pure, suffix-parameterized helper (`siblingCandidates`) so the Windows-specific behavior is unit-testable from any host. Non-Windows behavior is unchanged (empty suffix yields the single bare candidate).

## Test plan

- `TestSiblingCandidates_WindowsTriesExeFirst` — regression test for #1387: `siblingCandidates("aileron-mcp", ".exe")` must yield `["aileron-mcp.exe", "aileron-mcp"]` (suffixed first). This is the behavior that was missing before the fix.
- `TestSiblingCandidates_NonWindowsBareNameOnly` — empty suffix yields the single bare name, locking the unchanged Linux/macOS path.
- `TestSiblingCandidates_AlreadySuffixed` — no double `.exe` when the name already carries the suffix.
- `TestResolveSibling_FindsHostSibling` — end-to-end on the host: a bare-named sibling resolves to its absolute path (the common Linux/macOS install layout).
- `go test ./internal/launch/...` green; `go vet ./internal/launch/` clean; `GOOS=windows GOARCH=amd64 go build ./internal/launch/` succeeds.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
