### PR TITLE
fix(launch): pre-accept Claude bypass-permissions disclaimer in sandbox

### DIFF
--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -277,7 +277,7 @@ var errClaudeEnvelopeMalformed = errors.New("claude: credentials envelope is mal
 const claudeWorkspacePath = "/home/agent/workspace"
 
 // claudeOnboardingStub is the payload written to /home/agent/.claude.json
-// on every launch. It short-circuits three first-run interruptions so a
+// on every launch. It short-circuits the first-run interruptions so a
 // vault-rendered sandbox launch is silent end-to-end:
 //
 //   - hasCompletedOnboarding skips the theme picker / first-run wizard.
@@ -293,6 +293,17 @@ const claudeWorkspacePath = "/home/agent/workspace"
 //     workspace, so the agent does not block on it on every launch. The
 //     sandbox container is the trust boundary, so pre-accepting inside
 //     it is safe.
+//   - bypassPermissionsModeAccepted pre-accepts the
+//     "Bypassing Permissions" disclaimer that Claude Code shows the
+//     first time it runs under --dangerously-skip-permissions. The
+//     sandbox launch always passes that flag (Args(ModeSandbox)), so
+//     without this the first launch blocks on an interactive
+//     "do you want to dangerously skip permissions?" confirmation —
+//     defeating the hands-off Cloud startup the flag exists to provide.
+//     The opt-in is already expressed by Aileron passing the flag; the
+//     container is the trust boundary (ADR-0015), so pre-accepting the
+//     disclaimer inside it is consistent with the pre-accepted trust
+//     dialog above. (#1379)
 //
 // Built from a typed value rather than a string literal so the nested
 // shape stays valid as Anthropic adds onboarding fields.
@@ -303,12 +314,14 @@ func mustMarshalOnboardingStub() []byte {
 		HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
 	}
 	stub := struct {
-		HasCompletedOnboarding bool                    `json:"hasCompletedOnboarding"`
-		InstallMethod          string                  `json:"installMethod"`
-		Projects               map[string]projectTrust `json:"projects"`
+		HasCompletedOnboarding        bool                    `json:"hasCompletedOnboarding"`
+		BypassPermissionsModeAccepted bool                    `json:"bypassPermissionsModeAccepted"`
+		InstallMethod                 string                  `json:"installMethod"`
+		Projects                      map[string]projectTrust `json:"projects"`
 	}{
-		HasCompletedOnboarding: true,
-		InstallMethod:          "global",
+		HasCompletedOnboarding:        true,
+		BypassPermissionsModeAccepted: true,
+		InstallMethod:                 "global",
 		Projects: map[string]projectTrust{
 			claudeWorkspacePath: {HasTrustDialogAccepted: true},
 		},

--- a/internal/launch/agents/claude_auth_test.go
+++ b/internal/launch/agents/claude_auth_test.go
@@ -67,18 +67,22 @@ func TestClaude_AuthSpec_Shape(t *testing.T) {
 	assertOnboardingStub(t, sf.Content)
 }
 
-// assertOnboardingStub verifies the three contractual flags the stub
-// must carry to make a sandbox launch silent: onboarding completed,
-// installMethod matching the devcontainer's npm-global install (so
-// `/doctor` is clean), and the workspace pre-trusted (so the folder
-// trust dialog does not fire). Parsed semantically rather than matched
-// as a string so field ordering or additive fields do not break it.
+// assertOnboardingStub verifies the contractual flags the stub must
+// carry to make a sandbox launch silent: onboarding completed, the
+// bypass-permissions disclaimer pre-accepted (so the first
+// --dangerously-skip-permissions launch does not block on the
+// confirmation prompt, #1379), installMethod matching the devcontainer's
+// npm-global install (so `/doctor` is clean), and the workspace
+// pre-trusted (so the folder trust dialog does not fire). Parsed
+// semantically rather than matched as a string so field ordering or
+// additive fields do not break it.
 func assertOnboardingStub(t *testing.T, content []byte) {
 	t.Helper()
 	var stub struct {
-		HasCompletedOnboarding bool   `json:"hasCompletedOnboarding"`
-		InstallMethod          string `json:"installMethod"`
-		Projects               map[string]struct {
+		HasCompletedOnboarding        bool   `json:"hasCompletedOnboarding"`
+		BypassPermissionsModeAccepted bool   `json:"bypassPermissionsModeAccepted"`
+		InstallMethod                 string `json:"installMethod"`
+		Projects                      map[string]struct {
 			HasTrustDialogAccepted bool `json:"hasTrustDialogAccepted"`
 		} `json:"projects"`
 	}
@@ -87,6 +91,9 @@ func assertOnboardingStub(t *testing.T, content []byte) {
 	}
 	if !stub.HasCompletedOnboarding {
 		t.Errorf("hasCompletedOnboarding = false; the theme picker will paint on every launch")
+	}
+	if !stub.BypassPermissionsModeAccepted {
+		t.Errorf("bypassPermissionsModeAccepted = false; the first --dangerously-skip-permissions launch will block on the \"do you want to dangerously skip permissions?\" confirmation")
 	}
 	if stub.InstallMethod != "global" {
 		t.Errorf("installMethod = %q, want \"global\" to match the devcontainer's `npm install -g`; a mismatch makes /doctor report the CLI missing", stub.InstallMethod)


### PR DESCRIPTION
## Summary

On the first launch of Aileron Launch Cloud inside the container, Claude Code stopped to ask the operator to confirm "do you want to dangerously skip permissions?" before Cloud finished starting up — even though the sandbox always launches Claude with `--dangerously-skip-permissions`. This defeated the hands-off Cloud startup the flag exists to provide (#1379).

### Root cause

Claude Code shows a one-time "Bypassing Permissions" disclaimer the first time it runs under `--dangerously-skip-permissions`. The CLI gates this on the top-level `bypassPermissionsModeAccepted` flag in `~/.claude.json` (the disclaimer fires when `!E_().bypassPermissionsModeAccepted`). Aileron's onboarding stub at `/home/agent/.claude.json` already pre-accepts the folder trust dialog and completes onboarding, but did not set this flag, so the disclaimer blocked every fresh container.

### Fix

Add `bypassPermissionsModeAccepted: true` to `claudeOnboardingStub`. The opt-in is already expressed by Aileron passing `--dangerously-skip-permissions` under `Args(ModeSandbox)`; the container is the trust boundary (ADR-0015), so pre-accepting the disclaimer inside it is consistent with the trust dialog already pre-accepted there. The stub is materialized only on sandbox launch (`if sandboxEnabled` in the launcher), so the host's `~/.claude.json` is never modified — host launch uses the narrower `--allowedTools` posture and never shows the disclaimer.

## Test plan

- Extended the `assertOnboardingStub` contract helper (covers both `TestClaude_AuthSpec_SubscriptionMode` and `TestClaude_OnboardingStub_Constant`) to assert `bypassPermissionsModeAccepted` is true, with a failure message that names the exact prompt that returns if it regresses. This fails before the change and passes after.
- `go test ./internal/launch/...` green (agents, launch, hostimport).
- `go build ./internal/...` and `go vet ./internal/launch/agents/...` clean.

Closes #1379

🤖 Generated with [Claude Code](https://claude.com/claude-code)

