### PR TITLE
docs: reframe preflight prereq as agent credential, not host install

### DIFF
--- a/docs/src/lib/components/ui/liftoff-preflight.svelte
+++ b/docs/src/lib/components/ui/liftoff-preflight.svelte
@@ -28,23 +28,33 @@
 -->
 <AccordionPrimitive.Root type="multiple" class="cn-preflight my-6 w-full">
 
-	<AccordionPrimitive.Item value="claude-code" class={itemClass}>
+	<AccordionPrimitive.Item value="agent-credential" class={itemClass}>
 		<AccordionPrimitive.Header>
 			<AccordionPrimitive.Trigger class={triggerClass}>
-				<span>Claude Code</span>
+				<span>An agent credential</span>
 				<ChevronDown size={16} class="shrink-0 transition-transform" />
 			</AccordionPrimitive.Trigger>
 		</AccordionPrimitive.Header>
 		<AccordionPrimitive.Content forceMount class={contentClass}>
 			<p>
-				Install and configure
-				<a href="https://docs.claude.com/en/docs/claude-code/setup">Claude Code</a>. Claude Code can
-				authenticate two ways. Subscription mode signs in with a Claude Pro/Max account via OAuth
-				login and needs no API key. API-key mode reads an Anthropic API key from
-				<code>ANTHROPIC_API_KEY</code>. You pick the mode at launch with
-				<code>--claude-auth=subscription|api-key</code>, or by answering the first-run prompt where
-				Enter selects subscription. Aileron's launcher routes Claude Code's LLM calls through Aileron
-				locally. It does not supply or replace your credentials.
+				<code>aileron launch</code> runs the agent inside the container, so you do not install the
+				agent CLI on your host. You only need a credential the launcher can seed into the sandbox.
+				Two agents are supported.
+			</p>
+			<p>
+				Claude needs either a Claude Pro/Max subscription or an Anthropic API key. Subscription mode
+				signs in with a Claude account via OAuth login and is the default. API-key mode reads an
+				Anthropic API key from <code>ANTHROPIC_API_KEY</code>. Pick the mode at launch with
+				<code>--claude-auth=subscription|api-key</code>, or answer the first-run prompt where Enter
+				selects subscription.
+			</p>
+			<p>
+				Codex needs either a Codex/OpenAI subscription or an OpenAI API key. Both agents seed the
+				credential the same way. First launch runs an in-container login, or a host-side acquirer
+				stores the credential in the vault before the container starts. The vault then renders it
+				into every later launch silently. See
+				<a href="/development/sandbox-agent-auth/">Sandbox Agent Auth</a> for the full
+				mode-selection and seeding detail.
 			</p>
 		</AccordionPrimitive.Content>
 	</AccordionPrimitive.Item>


### PR DESCRIPTION
## Summary

The "Liftoff in 5 Minutes" preflight checklist on the Getting Started page opened with a prerequisite that told users to install and configure Claude Code on the host with an Anthropic API key in `ANTHROPIC_API_KEY`. That over-states host setup. Under the now-default container launch (`aileron launch claude` runs the agent in the Docker sandbox per [ADR-0025](https://withaileron.ai/adr/0025-vault-backed-agent-auth/)), the user does not install the agent CLI on the host. They only need a credential the launcher seeds into the sandbox, via an in-container login on first launch or a host-side acquirer that stores it in the vault.

This rewrites the preflight item in `liftoff-preflight.svelte`:

- Retitles the accordion item from "Claude Code" to "An agent credential".
- Frames the requirement as a credential/account, not a host install.
- Presents the two supported agent paths the issue prescribes and ADR-0025 confirms: Claude (Claude Pro/Max subscription OR Anthropic API key) and Codex (Codex/OpenAI subscription OR OpenAI API key).
- Keeps the "Docker" and "A Google account" items unchanged.

Scope is the prerequisites/Preflight section only. The sections 3-6 walkthrough deliberately uses Claude as the worked example and stays as-is, as does the page title/description.

Honors the docs writing voice (no em-dashes, no "not just X, Y", one thought per sentence).

## Test plan

- `task lint:docs` (astro check): 0 errors, 0 warnings, 0 hints.
- `task test:docs`: 8/8 pass.
- `pnpm build` (static site): 129 pages built, complete. No tests assert on the preflight component text (verified by grep), so no test changes are needed; this is a docs-prose-only change.

Closes #1388

🤖 Generated with [Claude Code](https://claude.com/claude-code)
