### PR TITLE
fix(oauth): escape cmd.exe metacharacters in Windows browser-open URLs

### DIFF
--- a/cmd/aileron/open.go
+++ b/cmd/aileron/open.go
@@ -124,9 +124,11 @@ func buildOpenURL(base string, target openTarget, approvalID string) string {
 	}
 }
 
-// openInBrowser shells out to the platform's URL-opener. The argv
-// shape is single-string-URL on every supported platform; we never
-// invoke a shell, so a URL containing meta characters can't inject.
+// openInBrowser shells out to the platform's URL-opener. macOS and
+// Linux pass the URL as a single argv element with no shell. Windows
+// goes through `cmd /c start`, whose command-line parser treats `&` and
+// other metacharacters specially, so the URL is caret-escaped first
+// (see escapeURLForWindowsCmd) to keep every query parameter intact.
 //
 // Platforms not in the switch (e.g. freebsd) return an error rather
 // than silently no-oping — the operator at least learns why the
@@ -142,7 +144,14 @@ func openInBrowser(ctx context.Context, target string) error {
 	case "windows":
 		// `start` is a cmd builtin, not a binary. Empty string is the
 		// window title (a quirk of `start`'s argument grammar).
-		name, args = "cmd", []string{"/c", "start", "", target}
+		//
+		// cmd.exe parses the command line itself and treats `&` as a
+		// command separator, so a URL with multiple query parameters
+		// would be truncated at the first `&`. Caret-escape the cmd
+		// metacharacters so the full URL reaches `start`. Today these
+		// URLs carry at most one query parameter, but the defect is the
+		// same one fixed in internal/oauth's browser opener.
+		name, args = "cmd", []string{"/c", "start", "", escapeURLForWindowsCmd(target)}
 	default:
 		return fmt.Errorf("no browser opener registered for %s", runtime.GOOS)
 	}
@@ -150,6 +159,31 @@ func openInBrowser(ctx context.Context, target string) error {
 		return fmt.Errorf("%s: %w", name, err)
 	}
 	return nil
+}
+
+// escapeURLForWindowsCmd caret-escapes the cmd.exe metacharacters in s
+// so a URL handed to `cmd /c start "" <url>` reaches the browser intact
+// rather than being truncated or mangled by cmd's command-line parser.
+//
+// The load-bearing case is `&` (cmd's command separator): without
+// escaping it, every query parameter after the first is dropped. The
+// full set of cmd metacharacters is escaped for safety — `^` itself
+// (escaped first so the carets we add aren't re-escaped), `&`, `|`,
+// `<`, `>`, `(`, `)`, and `%` (which `start` would otherwise treat as
+// the start of a `%VAR%` expansion). Only Windows routes through cmd;
+// the macOS/Linux openers pass the URL as a single argv element.
+func escapeURLForWindowsCmd(s string) string {
+	replacer := strings.NewReplacer(
+		"^", "^^",
+		"&", "^&",
+		"|", "^|",
+		"<", "^<",
+		">", "^>",
+		"(", "^(",
+		")", "^)",
+		"%", "^%",
+	)
+	return replacer.Replace(s)
 }
 
 // Test seams. Tests replace these with fakes to avoid touching

--- a/cmd/aileron/open_test.go
+++ b/cmd/aileron/open_test.go
@@ -84,6 +84,48 @@ func TestBuildOpenURL(t *testing.T) {
 	}
 }
 
+// --- escapeURLForWindowsCmd contract ---
+
+// TestEscapeURLForWindowsCmd is the regression test for the `aileron
+// open` opener carrying the same cmd.exe-truncation defect as the OAuth
+// browser opener: a multi-parameter URL handed to `cmd /c start ""
+// <url>` is cut off at the first `&` because cmd treats it as a command
+// separator. The metacharacters must be caret-escaped so the whole URL
+// survives. Today `aileron open`'s URLs carry at most one query param so
+// the bug is latent, but the escaping must still hold every parameter.
+func TestEscapeURLForWindowsCmd(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain URL unchanged", "http://127.0.0.1:50419/approvals", "http://127.0.0.1:50419/approvals"},
+		{"single query param unchanged", "http://127.0.0.1:50419/approvals?focus=act-42", "http://127.0.0.1:50419/approvals?focus=act-42"},
+		{"multi param ampersands escaped", "http://h/approvals?focus=a&tab=b&sort=c", "http://h/approvals?focus=a^&tab=b^&sort=c"},
+		{"all metacharacters", `&|<>()%`, `^&^|^<^>^(^)^%`},
+		{"caret escaped first", "a^&b", "a^^^&b"},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			got := escapeURLForWindowsCmd(c.in)
+			if got != c.want {
+				t.Errorf("escapeURLForWindowsCmd(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
+	}
+
+	// Spot-check the load-bearing property: every parameter of a
+	// multi-param URL survives the escape (the bug dropped all but the
+	// first).
+	const multi = "http://h/approvals?focus=act-42&tab=open&sort=newest"
+	escaped := escapeURLForWindowsCmd(multi)
+	for _, frag := range []string{"focus=act-42", "tab=open", "sort=newest"} {
+		if !strings.Contains(escaped, frag) {
+			t.Errorf("escaped %q missing %q", escaped, frag)
+		}
+	}
+}
+
 // --- runOpen ---
 
 // stubOpener captures the URL passed to the browser opener and

--- a/internal/oauth/browser.go
+++ b/internal/oauth/browser.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"os/exec"
 	"runtime"
+	"strings"
 )
 
 // Opener opens a URL in the user's default browser. The default
@@ -66,8 +67,43 @@ func browserArgv(goos, url string) ([]string, error) {
 	case "windows":
 		// `cmd /c start "" <url>` — the empty title argument prevents
 		// `start` from interpreting a quoted URL as a window title.
-		return []string{"cmd", "/c", "start", "", url}, nil
+		//
+		// cmd.exe parses the command line itself and treats unescaped
+		// metacharacters (notably `&`, which separates commands) as
+		// shell syntax, so an OAuth authorize URL like
+		// `…?code=true&client_id=…&state=…` would be truncated at the
+		// first `&` and the browser would receive only the leading
+		// parameter. Escape the metacharacters with a caret so the full
+		// URL — every query parameter — survives to `start`.
+		return []string{"cmd", "/c", "start", "", escapeURLForWindowsCmd(url)}, nil
 	default:
 		return nil, fmt.Errorf("oauth: no browser-open command for GOOS=%q", goos)
 	}
+}
+
+// escapeURLForWindowsCmd caret-escapes the cmd.exe metacharacters in s
+// so a URL handed to `cmd /c start "" <url>` reaches the browser intact
+// rather than being truncated or mangled by cmd's command-line parser.
+//
+// The load-bearing case is `&` (cmd's command separator): without
+// escaping it, every query parameter after the first is dropped. For
+// safety the full set of cmd metacharacters is escaped — `^` itself
+// (escaped first so the carets we add aren't re-escaped), `&`, `|`,
+// `<`, `>`, `(`, `)`, and `%` (which `start` would otherwise treat as
+// the start of a `%VAR%` expansion). macOS/Linux openers pass the URL
+// as a single argv element with no shell, so this is Windows-only.
+func escapeURLForWindowsCmd(s string) string {
+	// `^` must be replaced first; otherwise the carets introduced for
+	// the other metacharacters would themselves be doubled.
+	replacer := strings.NewReplacer(
+		"^", "^^",
+		"&", "^&",
+		"|", "^|",
+		"<", "^<",
+		">", "^>",
+		"(", "^(",
+		")", "^)",
+		"%", "^%",
+	)
+	return replacer.Replace(s)
 }

--- a/internal/oauth/browser_internal_test.go
+++ b/internal/oauth/browser_internal_test.go
@@ -112,6 +112,84 @@ func TestBrowserArgv_PerPlatformContract(t *testing.T) {
 	}
 }
 
+// TestBrowserArgv_WindowsEscapesCmdMetacharacters is the regression
+// test for the host-acquire OAuth bug: the Claude authorize URL is
+// `base?code=true&client_id=…&code_challenge=…&state=…`, and on Windows
+// `cmd /c start "" <url>` truncates it at the first `&` because cmd
+// treats `&` as a command separator. The Windows argv must caret-escape
+// the metacharacters so every parameter survives; the macOS/Linux argv
+// must pass the URL byte-for-byte unchanged (no shell, so no escaping).
+func TestBrowserArgv_WindowsEscapesCmdMetacharacters(t *testing.T) {
+	const url = "https://claude.ai/oauth/authorize?code=true&client_id=abc123&code_challenge=xYz_chal&state=st-987&scope=read%20write"
+
+	// Windows: the final argv element is the escaped URL, and it must
+	// preserve every parameter (the bug dropped everything after the
+	// first `&`).
+	t.Run("windows", func(t *testing.T) {
+		argv, err := browserArgv("windows", url)
+		if err != nil {
+			t.Fatalf("browserArgv(windows): %v", err)
+		}
+		want := []string{"cmd", "/c", "start", "",
+			"https://claude.ai/oauth/authorize?code=true^&client_id=abc123^&code_challenge=xYz_chal^&state=st-987^&scope=read^%20write"}
+		if !equalArgv(argv, want) {
+			t.Fatalf("browserArgv(windows) = %v;\nwant %v", argv, want)
+		}
+		escaped := argv[len(argv)-1]
+		// Every parameter must survive (the bug truncated at the first &).
+		for _, frag := range []string{"client_id=abc123", "code_challenge=xYz_chal", "state=st-987"} {
+			if !strings.Contains(escaped, frag) {
+				t.Errorf("escaped URL %q missing %q", escaped, frag)
+			}
+		}
+		// The `&` separators must be caret-escaped, not raw.
+		if strings.Contains(escaped, "true&client_id") {
+			t.Errorf("escaped URL %q still has an unescaped & before client_id", escaped)
+		}
+		if strings.Count(escaped, "^&") != 4 {
+			t.Errorf("escaped URL %q: want 4 caret-escaped ampersands, got %d", escaped, strings.Count(escaped, "^&"))
+		}
+	})
+
+	// macOS/Linux: single argv element, URL byte-identical to input.
+	for _, goos := range []string{"darwin", "linux"} {
+		t.Run(goos, func(t *testing.T) {
+			argv, err := browserArgv(goos, url)
+			if err != nil {
+				t.Fatalf("browserArgv(%s): %v", goos, err)
+			}
+			if argv[len(argv)-1] != url {
+				t.Errorf("browserArgv(%s) URL = %q; want byte-identical %q", goos, argv[len(argv)-1], url)
+			}
+		})
+	}
+}
+
+// TestEscapeURLForWindowsCmd pins the per-character escaping contract,
+// including the `^`-first ordering (so an existing caret doesn't get the
+// carets we add re-escaped) and the no-op case for URLs with no
+// metacharacters.
+func TestEscapeURLForWindowsCmd(t *testing.T) {
+	cases := []struct {
+		name string
+		in   string
+		want string
+	}{
+		{"plain URL unchanged", "https://example.test/path", "https://example.test/path"},
+		{"ampersand", "a&b", "a^&b"},
+		{"all metacharacters", `&|<>()%`, `^&^|^<^>^(^)^%`},
+		{"caret escaped first", "a^&b", "a^^^&b"},
+		{"empty", "", ""},
+	}
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			if got := escapeURLForWindowsCmd(c.in); got != c.want {
+				t.Errorf("escapeURLForWindowsCmd(%q) = %q; want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 func equalArgv(got, want []string) bool {
 	if len(got) != len(want) {
 		return false


### PR DESCRIPTION
## Summary

On Windows the host-side browser opener runs `cmd /c start "" <url>`. cmd.exe parses the command line itself and treats `&` as a command separator, so the Claude OAuth authorize URL built by `buildClaudeAuthorizeURL` — `base?code=true&client_id=…&code_challenge=…&state=…` — was truncated at the first `&`. The browser received only `code=true` plus `client_id`; `code_challenge`, `state`, `scope`, and `redirect_uri` were dropped, breaking the Claude subscription host-acquire consent flow (issue #1386).

The fix caret-escapes the cmd metacharacters in the URL before handing it to `start`, so every query parameter survives:

- `internal/oauth/browser.go` — new pure helper `escapeURLForWindowsCmd` applied in `browserArgv` for the `windows` case. The load-bearing escape is `&` → `^&`; for safety the full cmd set is escaped (`^ & | < > ( ) %`), with `^` escaped first.
- `cmd/aileron/open.go` — the `aileron open` opener uses the identical `cmd /c start "" <target>` pattern and carries the same defect (latent today, since those URLs have at most one query param). Fixed for the same root cause.

macOS (`open`) and Linux (`xdg-open`) pass the URL as a single argv element with no shell, so they are unaffected and left byte-for-byte unchanged.

No OpenAPI/codegen touched (host-side CLI code only).

## Test plan

- `internal/oauth/browser_internal_test.go`: added `TestBrowserArgv_WindowsEscapesCmdMetacharacters` (regression) using a realistic multi-param OAuth URL containing `&` — asserts the Windows argv's final element preserves `client_id`, `code_challenge`, and `state` with caret-escaped `&`, and that the darwin/linux rows are byte-identical to the input URL. Added `TestEscapeURLForWindowsCmd` pinning the per-character escape contract (including `^`-first ordering).
- `cmd/aileron/open_test.go`: added `TestEscapeURLForWindowsCmd` with the analogous multi-param assertion.
- Fail-before confirmed: with the production helpers reverted, both test binaries fail to compile (`undefined: escapeURLForWindowsCmd`) and the Windows argv assertion would fail; pass-after with the fix in place.
- `go test` green for `internal/oauth` (changed funcs `browserArgv` and `escapeURLForWindowsCmd` at 100% line coverage) and `cmd/aileron`.
- `go vet` clean; CodeRabbit review on the diff returned 0 findings.

True end-to-end Windows verification (a real browser window opening with the full URL) is the manual v4-acceptance step and is not automatable in CI.

Closes #1386

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed URL truncation issue on Windows when opening links in a browser. URLs containing query parameters and special characters (such as `&`, `|`, `<`, `>`, parentheses, and percent signs) will now open correctly and completely. This applies to authentication flows and general link opening.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->