### PR TITLE
fix(launch): isolate Claude auth URL on its own line

### DIFF
--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -481,7 +481,7 @@ func claudeHostedCallbackAcquire(ctx context.Context, deps launch.HostAcquireDep
 	// record of what was launched. Mirrors the Codex device flow.
 	if deps.Out != nil {
 		fmt.Fprintf(deps.Out,
-			"To authorize Claude, open %s in your browser and paste back the code shown.\n",
+			"To authorize Claude, open this link\n\n%s\n\nin your browser and paste back the code shown.\n",
 			authURL)
 	}
 	if deps.Browser != nil {

--- a/internal/launch/agents/claude_host_acquire_test.go
+++ b/internal/launch/agents/claude_host_acquire_test.go
@@ -143,6 +143,32 @@ func TestClaudeHostAcquire_HostedCallbackHappyPath(t *testing.T) {
 	if !strings.Contains(out.String(), "client_id=9d1c250a") {
 		t.Errorf("Out missing the authorize URL; got %q", out.String())
 	}
+	// The URL must sit alone on its own line, fenced by blank lines above
+	// and below, so a user can select/copy it without dragging surrounding
+	// prose (#1385). Find the line carrying the URL and assert it is exactly
+	// the URL, with a blank line immediately before and after.
+	{
+		lines := strings.Split(out.String(), "\n")
+		urlLine := -1
+		for i, ln := range lines {
+			if strings.Contains(ln, "client_id=9d1c250a") {
+				urlLine = i
+				break
+			}
+		}
+		if urlLine < 0 {
+			t.Fatalf("Out missing the authorize URL line; got %q", out.String())
+		}
+		if strings.TrimSpace(lines[urlLine]) != lines[urlLine] || strings.Contains(lines[urlLine], " ") {
+			t.Errorf("URL line carries prose; want bare URL, got %q", lines[urlLine])
+		}
+		if urlLine == 0 || strings.TrimSpace(lines[urlLine-1]) != "" {
+			t.Errorf("URL line not fenced by a blank line above; got %q", out.String())
+		}
+		if urlLine+1 >= len(lines) || strings.TrimSpace(lines[urlLine+1]) != "" {
+			t.Errorf("URL line not fenced by a blank line below; got %q", out.String())
+		}
+	}
 	// The profile fetch must present the freshly-exchanged access token
 	// as a Bearer credential; that is what authorizes reading the
 	// subscription tier (#1304).


### PR DESCRIPTION
## Summary

The first-launch Claude subscription auth prompt embedded the authorize URL mid-sentence:

```
To authorize Claude, open https://claude.ai/oauth/authorize?... in your browser and paste back the code shown.
```

The URL could not be selected or copied without dragging the surrounding prose. This reflows the prompt in `internal/launch/agents/claude_auth.go` so the URL sits alone on its own line, fenced by blank lines:

```
To authorize Claude, open this link

https://claude.ai/oauth/authorize?...

in your browser and paste back the code shown.
```

Terminal prose only; no spec/codegen/README/ADR impact.

## Test plan

- Extended `TestClaudeHostAcquire_HostedCallbackHappyPath` (which already captures `deps.Out`) to locate the line carrying the authorize URL and assert it is exactly the URL (no prose, no spaces) and is fenced by a blank line above and below.
- Verified the new assertion fails against the old inline string and passes after the reflow.
- `go build ./internal/...` clean.
- `go test ./internal/launch/...` green (launch, agents, hostimport).

Closes #1385
