### PR TITLE
fix(daemon): suppress lingering Windows console window on daemon spawn

### DIFF
--- a/internal/daemon/spawn/spawn.go
+++ b/internal/daemon/spawn/spawn.go
@@ -314,8 +314,9 @@ func urlToHostPort(u string) (string, error) {
 // The daemon is detached from the parent via [detachProcAttrs] so its
 // lifetime is independent of the parent: on POSIX, Setsid puts the
 // daemon in its own session so SIGHUP from the parent's terminal does
-// not propagate; on Windows, DETACHED_PROCESS|CREATE_NEW_PROCESS_GROUP
-// disconnects from the parent's console and signal group. The returned
+// not propagate; on Windows, CREATE_NO_WINDOW|CREATE_NEW_PROCESS_GROUP
+// runs the daemon with no console window and disconnects it from the
+// parent's signal group. The returned
 // channel is sent on (with the wait error or nil) when the child
 // exits, and waitForDaemon uses that signal to fail fast when the
 // daemon dies before publishing daemon.json.

--- a/internal/daemon/spawn/spawn_windows.go
+++ b/internal/daemon/spawn/spawn_windows.go
@@ -9,12 +9,20 @@ import (
 )
 
 // detachProcAttrs returns the SysProcAttr that detaches the daemon
-// from the parent's console and signal group. DETACHED_PROCESS gives
-// the daemon no console; CREATE_NEW_PROCESS_GROUP isolates it from
-// Ctrl-C / Ctrl-Break sent to the parent's group, so the daemon
-// survives the parent's exit.
+// from the parent's console and signal group. CREATE_NO_WINDOW is the
+// Microsoft-documented flag for running a console application with no
+// console window: unlike DETACHED_PROCESS, it does not let Windows
+// allocate a fresh console window for the console-subsystem
+// aileron-server binary when it is launched from an interactive shell.
+// CREATE_NEW_PROCESS_GROUP isolates the daemon from Ctrl-C /
+// Ctrl-Break sent to the parent's group, so the daemon survives the
+// parent's exit. The daemon's stdio is already redirected to
+// <stateDir>/daemon.log, so it needs no console.
+//
+// CREATE_NO_WINDOW is mutually exclusive with DETACHED_PROCESS and
+// CREATE_NEW_CONSOLE but composes with CREATE_NEW_PROCESS_GROUP.
 func detachProcAttrs() *syscall.SysProcAttr {
 	return &syscall.SysProcAttr{
-		CreationFlags: windows.DETACHED_PROCESS | windows.CREATE_NEW_PROCESS_GROUP,
+		CreationFlags: windows.CREATE_NO_WINDOW | windows.CREATE_NEW_PROCESS_GROUP,
 	}
 }

--- a/internal/daemon/spawn/spawn_windows_test.go
+++ b/internal/daemon/spawn/spawn_windows_test.go
@@ -1,0 +1,30 @@
+//go:build windows
+
+package spawn
+
+import (
+	"testing"
+
+	"golang.org/x/sys/windows"
+)
+
+// TestDetachProcAttrs_NoConsoleWindow is a regression test for #1383:
+// the daemon was fork-exec'd with DETACHED_PROCESS, which let Windows
+// allocate a lingering console window for the console-subsystem
+// aileron-server binary. The fix uses CREATE_NO_WINDOW instead, which
+// is documented to run a console application with no console window,
+// while still composing with CREATE_NEW_PROCESS_GROUP for signal-group
+// isolation.
+func TestDetachProcAttrs_NoConsoleWindow(t *testing.T) {
+	flags := detachProcAttrs().CreationFlags
+
+	if flags&windows.CREATE_NO_WINDOW == 0 {
+		t.Errorf("CreationFlags missing CREATE_NO_WINDOW: got %#x", flags)
+	}
+	if flags&windows.CREATE_NEW_PROCESS_GROUP == 0 {
+		t.Errorf("CreationFlags missing CREATE_NEW_PROCESS_GROUP: got %#x", flags)
+	}
+	if flags&windows.DETACHED_PROCESS != 0 {
+		t.Errorf("CreationFlags still sets DETACHED_PROCESS (#1383 regression): got %#x", flags)
+	}
+}


### PR DESCRIPTION
## Summary

On Windows, the daemon was fork-exec'd with `CreationFlags = DETACHED_PROCESS | CREATE_NEW_PROCESS_GROUP` (`internal/daemon/spawn/spawn_windows.go`). `aileron-server` is a console-subsystem Go binary, and `DETACHED_PROCESS` detaches it from the parent's console but does not reliably suppress a console window for a console app launched from an interactive PowerShell session. Windows therefore allocated a fresh console window (titled with the launching path, e.g. the Scoop shim) that lingered for the daemon's lifetime.

This `forkExec` path backs both direct daemon-start and `aileron launch` (`internal/launch/launcher.go` -> `spawn.Resolve` -> default `SpawnFn` -> `forkExec` -> `detachProcAttrs`), so the one fix covers both surfaces.

The fix switches the flag to `CREATE_NO_WINDOW | CREATE_NEW_PROCESS_GROUP`. `CREATE_NO_WINDOW` is the Microsoft-documented flag for running a console application with no console window; it is mutually exclusive with `DETACHED_PROCESS`/`CREATE_NEW_CONSOLE` but composes with `CREATE_NEW_PROCESS_GROUP`, so the daemon still gets its own signal/process group (Ctrl-C/Ctrl-Break isolation) and stays detached from the parent, while no window appears. The daemon's stdio is already redirected to `<stateDir>/daemon.log`, so losing the console costs nothing. The unix path (`Setsid`) is unaffected.

Also updates the detach-flag wording in the `forkExec` doc comment in `spawn.go` and the comment block in `spawn_windows.go`.

## Test plan

- Added `//go:build windows` internal regression test (`spawn_windows_test.go`, package `spawn`) asserting `detachProcAttrs().CreationFlags` has `CREATE_NO_WINDOW` and `CREATE_NEW_PROCESS_GROUP` set and `DETACHED_PROCESS` clear. Fails against the old flags, passes against the new ones.
- `GOOS=windows GOARCH=amd64 go build ./internal/daemon/spawn/` compiles.
- `GOOS=windows GOARCH=amd64 go vet ./internal/daemon/spawn/` passes (compiles the windows-tagged test).
- `GOOS=windows GOARCH=amd64 go build ./internal/launch/... ./internal/daemon/...` compiles.
- `go test ./internal/daemon/spawn/` passes on the host (unix path unchanged).

No spec/OpenAPI change.

Closes #1383
