### PR TITLE
fix(launch): resolve Claude auth mode from the vault before prompting

### DIFF
--- a/cmd/aileron/claude_auth.go
+++ b/cmd/aileron/claude_auth.go
@@ -2,10 +2,13 @@ package main
 
 import (
 	"bufio"
+	"context"
 	"fmt"
 	"io"
+	"net/http"
 	"os"
 	"strings"
+	"time"
 
 	"github.com/ALRubinger/aileron/internal/launch/agents"
 	"golang.org/x/term"
@@ -16,19 +19,121 @@ import (
 // (true) or the non-interactive default path (false) without a real TTY.
 var isTTYFn = func() bool { return term.IsTerminal(int(os.Stdin.Fd())) }
 
-// resolveClaudeAuthMode selects the Claude auth mode to thread onto the
-// launched Claude agent (#1340). It only performs mode *selection*; the
-// AuthSpec branching for the selected mode lives in agents.Claude.AuthSpec.
+// claudeVaultPresence reports which of Claude's two credential slots are
+// already populated in the daemon's vault: the subscription OAuth envelope
+// (agents/claude/oauth) and/or the raw API key (agents/claude/apikey).
+// resolveClaudeAuthMode consults it so a launch with a credential already
+// stored does not re-ask a question the CLI can answer itself (#1381).
+type claudeVaultPresence struct {
+	subscription bool // agents/claude/oauth populated
+	apiKey       bool // agents/claude/apikey populated
+}
+
+// claude credential purposes on the daemon's vault wire surface. These are
+// the third path segment of agents.claudeVaultPath ("agents/claude/oauth")
+// and agents.claudeAPIKeyVaultPath ("agents/claude/apikey"); the daemon's
+// GET /v1/vault/agents/claude/credentials route selects between them via the
+// `purpose` query parameter.
+const (
+	claudePurposeSubscription = "oauth"
+	claudePurposeAPIKey       = "apikey"
+)
+
+// claudeVaultProbeTimeout caps the loopback round-trips the presence probe
+// makes to the daemon. ensureVaultUnlockedFn has already guaranteed the
+// daemon is up with the vault unlocked, so these are small, fast GETs; a
+// generous bound keeps a wedged daemon from stalling the launch.
+const claudeVaultProbeTimeout = 5 * time.Second
+
+// claudeVaultPresenceFn is the package-level seam for the vault-presence
+// probe so tests can drive resolveClaudeAuthMode across all four slot
+// states without a running daemon. Production wiring talks to the daemon
+// via the same discovery.Read(stateDir) -> URL/token pattern open.go uses.
+var claudeVaultPresenceFn = probeClaudeVaultPresence
+
+// probeClaudeVaultPresence asks the running daemon which Claude credential
+// slots are populated. It mirrors the daemon-access pattern in open.go:
+// resolve the state dir, read daemon.json for the URL + token, then GET the
+// per-agent credential endpoint once per purpose.
 //
-// Resolution rules:
-//   - flagVal == "api-key"      -> ClaudeAuthModeAPIKey
-//   - flagVal == "subscription" -> ClaudeAuthModeSubscription
-//   - flagVal is any other non-empty value -> usage error (fail fast)
-//   - flagVal == "" && isTTY    -> interactive first-run prompt (reads one
-//     line from stdin, re-asking on unrecognized input)
-//   - flagVal == "" && !isTTY   -> ClaudeAuthModeSubscription WITHOUT reading
-//     stdin (the non-interactive default; stdin is left untouched so a piped
-//     stdin destined for the agent is never consumed).
+// A populated slot returns 200; an empty slot returns 404 with
+// {error:{code:"vault_not_found"}}. The probe is best-effort: any failure
+// to resolve or reach the daemon (or any non-200/404 status) is reported as
+// "slot absent" for that purpose so resolution falls back to its prior
+// behavior (prompt on a TTY, subscription default otherwise) rather than
+// erroring the launch. ensureVaultUnlockedFn runs before dispatch, so in the
+// normal case the daemon is up and the vault is unlocked.
+func probeClaudeVaultPresence(ctx context.Context) claudeVaultPresence {
+	stateDir, err := defaultStateDirFn()
+	if err != nil {
+		return claudeVaultPresence{}
+	}
+	info, err := discoveryReadFn(stateDir)
+	if err != nil {
+		return claudeVaultPresence{}
+	}
+	base := strings.TrimRight(info.URL, "/")
+	client := &http.Client{Timeout: claudeVaultProbeTimeout}
+	probe := func(purpose string) bool {
+		return claudeCredentialPresent(ctx, client, base, info.Token, purpose)
+	}
+	return claudeVaultPresence{
+		subscription: probe(claudePurposeSubscription),
+		apiKey:       probe(claudePurposeAPIKey),
+	}
+}
+
+// claudeCredentialPresent issues a single GET against the daemon's per-agent
+// credential endpoint for the given purpose and reports whether the slot is
+// populated. Only a 200 counts as present; a 404 (empty slot) and any other
+// outcome (locked vault, transport error, unexpected status) count as absent
+// so a probe failure never escalates into a launch failure.
+func claudeCredentialPresent(ctx context.Context, client *http.Client, base, token, purpose string) bool {
+	endpoint := base + "/v1/vault/agents/claude/credentials"
+	if purpose != "" && purpose != claudePurposeSubscription {
+		// The default purpose (oauth) is omitted from the query string so the
+		// request matches the daemon's pre-purpose wire shape; a non-default
+		// purpose is appended explicitly.
+		endpoint += "?purpose=" + purpose
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, endpoint, nil)
+	if err != nil {
+		return false
+	}
+	if token != "" {
+		req.Header.Set("Authorization", "Bearer "+token)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return false
+	}
+	defer resp.Body.Close()
+	return resp.StatusCode == http.StatusOK
+}
+
+// resolveClaudeAuthMode selects the Claude auth mode to thread onto the
+// launched Claude agent (#1340, #1381). It only performs mode *selection*;
+// the AuthSpec branching for the selected mode lives in
+// agents.Claude.AuthSpec.
+//
+// Resolution rules, in order:
+//
+//   - An explicit flag always wins and short-circuits before any vault
+//     probe: flagVal == "api-key" -> ClaudeAuthModeAPIKey, "subscription" ->
+//     ClaudeAuthModeSubscription, any other non-empty value -> usage error
+//     (fail fast).
+//   - On an empty flag the resolver consults the vault (#1381) so it does
+//     not re-ask a question a stored credential already answers:
+//   - only the subscription slot populated -> ClaudeAuthModeSubscription
+//   - only the api-key slot populated       -> ClaudeAuthModeAPIKey
+//   - both slots populated                  -> ClaudeAuthModeSubscription
+//     (subscription is the documented default tie-break)
+//     This holds on BOTH the TTY and non-TTY paths: a lone stored credential
+//     resolves without prompting and WITHOUT reading stdin.
+//   - Empty flag with NEITHER slot populated falls back to the prior
+//     behavior: a TTY runs the interactive first-run prompt; a non-TTY
+//     defaults to subscription WITHOUT reading stdin (the piped stdin
+//     destined for the agent is never consumed).
 func resolveClaudeAuthMode(flagVal string, isTTY bool, stdin io.Reader, stdout io.Writer) (agents.ClaudeAuthMode, error) {
 	if flagVal != "" {
 		mode, ok := parseClaudeAuthMode(flagVal)
@@ -37,8 +142,25 @@ func resolveClaudeAuthMode(flagVal string, isTTY bool, stdin io.Reader, stdout i
 		}
 		return mode, nil
 	}
+
+	// Empty flag: consult the vault before prompting or defaulting. The probe
+	// is best-effort; a daemon/transport failure reports both slots absent,
+	// which falls through to the prior prompt/default behavior below.
+	ctx, cancel := context.WithTimeout(context.Background(), claudeVaultProbeTimeout)
+	defer cancel()
+	presence := claudeVaultPresenceFn(ctx)
+	switch {
+	case presence.subscription:
+		// Both-populated and subscription-only both resolve to subscription;
+		// subscription is the documented default tie-break.
+		return agents.ClaudeAuthModeSubscription, nil
+	case presence.apiKey:
+		return agents.ClaudeAuthModeAPIKey, nil
+	}
+
 	if !isTTY {
-		// Non-interactive: default to subscription and DO NOT read stdin.
+		// Non-interactive, no stored credential: default to subscription and
+		// DO NOT read stdin.
 		return agents.ClaudeAuthModeSubscription, nil
 	}
 	return promptClaudeAuthMode(stdin, stdout)

--- a/cmd/aileron/claude_auth_test.go
+++ b/cmd/aileron/claude_auth_test.go
@@ -4,12 +4,40 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
+	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/launch/agents"
 )
+
+// stubClaudeVaultPresence installs a fixed vault-presence probe result for
+// the duration of a test and restores the original on cleanup. It lets the
+// resolveClaudeAuthMode tests exercise every slot state without a running
+// daemon.
+func stubClaudeVaultPresence(t *testing.T, p claudeVaultPresence) {
+	t.Helper()
+	orig := claudeVaultPresenceFn
+	t.Cleanup(func() { claudeVaultPresenceFn = orig })
+	claudeVaultPresenceFn = func(context.Context) claudeVaultPresence { return p }
+}
+
+// failClaudeVaultPresence installs a probe that fails the test if it is ever
+// invoked. It guards the explicit-flag short-circuit: an explicit
+// --claude-auth value must resolve before any vault probe runs.
+func failClaudeVaultPresence(t *testing.T) {
+	t.Helper()
+	orig := claudeVaultPresenceFn
+	t.Cleanup(func() { claudeVaultPresenceFn = orig })
+	claudeVaultPresenceFn = func(context.Context) claudeVaultPresence {
+		t.Helper()
+		t.Fatal("vault presence probe ran despite an explicit --claude-auth value")
+		return claudeVaultPresence{}
+	}
+}
 
 // failingReader fails the test if Read is ever called. It guards the P2
 // stdin contract: the non-interactive resolution path must never touch
@@ -168,7 +196,9 @@ func TestResolveClaudeAuthMode_ExplicitValues(t *testing.T) {
 	for _, tc := range cases {
 		t.Run(tc.in, func(t *testing.T) {
 			// isTTY true + a failing reader proves an explicit value bypasses
-			// the prompt entirely (no stdin read even on a TTY).
+			// the prompt entirely (no stdin read even on a TTY); a failing
+			// probe proves it also bypasses the vault entirely.
+			failClaudeVaultPresence(t)
 			got, err := resolveClaudeAuthMode(tc.in, true, failingReader{t}, io.Discard)
 			if err != nil {
 				t.Fatalf("unexpected error: %v", err)
@@ -181,6 +211,7 @@ func TestResolveClaudeAuthMode_ExplicitValues(t *testing.T) {
 }
 
 func TestResolveClaudeAuthMode_InvalidExplicit(t *testing.T) {
+	failClaudeVaultPresence(t)
 	_, err := resolveClaudeAuthMode("nonsense", false, failingReader{t}, io.Discard)
 	if err == nil {
 		t.Fatal("expected an error for an invalid explicit value")
@@ -191,8 +222,10 @@ func TestResolveClaudeAuthMode_InvalidExplicit(t *testing.T) {
 }
 
 // TestResolveClaudeAuthMode_NonInteractiveDefault is the P2 stdin contract:
-// empty flag + no TTY must return subscription WITHOUT reading stdin.
+// empty flag + no TTY + empty vault must return subscription WITHOUT reading
+// stdin.
 func TestResolveClaudeAuthMode_NonInteractiveDefault(t *testing.T) {
+	stubClaudeVaultPresence(t, claudeVaultPresence{})
 	var stdout bytes.Buffer
 	got, err := resolveClaudeAuthMode("", false, failingReader{t}, &stdout)
 	if err != nil {
@@ -223,6 +256,7 @@ func TestResolveClaudeAuthMode_InteractivePrompt(t *testing.T) {
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
+			stubClaudeVaultPresence(t, claudeVaultPresence{})
 			var stdout bytes.Buffer
 			got, err := resolveClaudeAuthMode("", true, strings.NewReader(tc.stdin), &stdout)
 			if err != nil {
@@ -241,6 +275,7 @@ func TestResolveClaudeAuthMode_InteractivePrompt(t *testing.T) {
 // TestResolveClaudeAuthMode_PromptReasksOnInvalid asserts the re-ask line is
 // printed when the first answer is unrecognized.
 func TestResolveClaudeAuthMode_PromptReasksOnInvalid(t *testing.T) {
+	stubClaudeVaultPresence(t, claudeVaultPresence{})
 	var stdout bytes.Buffer
 	got, err := resolveClaudeAuthMode("", true, strings.NewReader("xyz\nsubscription\n"), &stdout)
 	if err != nil {
@@ -251,5 +286,222 @@ func TestResolveClaudeAuthMode_PromptReasksOnInvalid(t *testing.T) {
 	}
 	if !strings.Contains(stdout.String(), "unrecognized choice") {
 		t.Errorf("expected re-ask message, got %q", stdout.String())
+	}
+}
+
+// --- vault-aware resolution (#1381) ---
+
+// TestResolveClaudeAuthMode_VaultPresence is the #1381 matrix: with an empty
+// --claude-auth flag, the four vault slot states resolve deterministically on
+// BOTH the TTY and non-TTY paths. A populated slot must resolve without
+// prompting and without reading stdin (failingReader guards the latter); only
+// the neither-populated state falls back to prompt (TTY) or subscription
+// default (non-TTY).
+func TestResolveClaudeAuthMode_VaultPresence(t *testing.T) {
+	cases := []struct {
+		name     string
+		presence claudeVaultPresence
+		want     agents.ClaudeAuthMode
+	}{
+		{"subscription only", claudeVaultPresence{subscription: true}, agents.ClaudeAuthModeSubscription},
+		{"api-key only", claudeVaultPresence{apiKey: true}, agents.ClaudeAuthModeAPIKey},
+		{"both -> subscription tie-break", claudeVaultPresence{subscription: true, apiKey: true}, agents.ClaudeAuthModeSubscription},
+	}
+	for _, tc := range cases {
+		for _, tty := range []bool{true, false} {
+			name := tc.name
+			if tty {
+				name += " (tty)"
+			} else {
+				name += " (non-tty)"
+			}
+			t.Run(name, func(t *testing.T) {
+				stubClaudeVaultPresence(t, tc.presence)
+				var stdout bytes.Buffer
+				// failingReader proves the populated-slot path never reads
+				// stdin, even on a TTY where a prompt would otherwise read it.
+				got, err := resolveClaudeAuthMode("", tty, failingReader{t}, &stdout)
+				if err != nil {
+					t.Fatalf("unexpected error: %v", err)
+				}
+				if got != tc.want {
+					t.Errorf("mode = %v, want %v", got, tc.want)
+				}
+				if stdout.Len() != 0 {
+					t.Errorf("populated-slot path wrote output (should not prompt): %q", stdout.String())
+				}
+			})
+		}
+	}
+}
+
+// TestResolveClaudeAuthMode_PopulatedSlotDoesNotPrompt is the #1381
+// regression: an empty flag on a TTY with a populated slot must NOT enter
+// the interactive prompt. Before the fix the resolver always prompted on a
+// TTY regardless of stored credentials. We force a TTY and supply scripted
+// stdin that, if the prompt ran, would select the WRONG mode — proving the
+// vault answer (not the stdin) drives the result.
+func TestResolveClaudeAuthMode_PopulatedSlotDoesNotPrompt(t *testing.T) {
+	t.Run("subscription slot, stdin would pick api-key", func(t *testing.T) {
+		stubClaudeVaultPresence(t, claudeVaultPresence{subscription: true})
+		var stdout bytes.Buffer
+		// "2" / "api-key" is what the prompt would consume; if the prompt
+		// ran, the result would be api-key. We assert subscription.
+		got, err := resolveClaudeAuthMode("", true, strings.NewReader("api-key\n"), &stdout)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != agents.ClaudeAuthModeSubscription {
+			t.Errorf("mode = %v, want subscription (vault should win, prompt must not run)", got)
+		}
+		if strings.Contains(stdout.String(), "How should Claude authenticate?") {
+			t.Errorf("prompt ran despite a populated subscription slot: %q", stdout.String())
+		}
+	})
+	t.Run("api-key slot, stdin would pick subscription", func(t *testing.T) {
+		stubClaudeVaultPresence(t, claudeVaultPresence{apiKey: true})
+		var stdout bytes.Buffer
+		got, err := resolveClaudeAuthMode("", true, strings.NewReader("subscription\n"), &stdout)
+		if err != nil {
+			t.Fatalf("unexpected error: %v", err)
+		}
+		if got != agents.ClaudeAuthModeAPIKey {
+			t.Errorf("mode = %v, want api-key (vault should win, prompt must not run)", got)
+		}
+		if strings.Contains(stdout.String(), "How should Claude authenticate?") {
+			t.Errorf("prompt ran despite a populated api-key slot: %q", stdout.String())
+		}
+	})
+}
+
+// TestResolveClaudeAuthMode_ExplicitWinsOverVault locks flag precedence: an
+// explicit flag short-circuits before the vault probe, so a stored
+// subscription credential does not override an explicit --claude-auth=api-key
+// (and vice versa). The probe is stubbed to the OPPOSITE slot to prove the
+// flag, not the vault, decides.
+func TestResolveClaudeAuthMode_ExplicitWinsOverVault(t *testing.T) {
+	cases := []struct {
+		name     string
+		flag     string
+		presence claudeVaultPresence
+		want     agents.ClaudeAuthMode
+	}{
+		{"flag api-key beats stored subscription", "api-key", claudeVaultPresence{subscription: true}, agents.ClaudeAuthModeAPIKey},
+		{"flag subscription beats stored api-key", "subscription", claudeVaultPresence{apiKey: true}, agents.ClaudeAuthModeSubscription},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// An explicit value must resolve before the probe, so installing a
+			// failing probe (not tc.presence) proves the short-circuit.
+			failClaudeVaultPresence(t)
+			got, err := resolveClaudeAuthMode(tc.flag, true, failingReader{t}, io.Discard)
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("mode = %v, want %v", got, tc.want)
+			}
+		})
+	}
+}
+
+// --- probeClaudeVaultPresence (daemon-access path) ---
+
+// TestProbeClaudeVaultPresence_Wiring exercises the real probe against a
+// fake daemon: it must GET the per-agent credential endpoint once per
+// purpose, send the bearer token, omit the query for the default (oauth)
+// purpose and append `?purpose=apikey` for the api-key slot, and map 200 ->
+// present / 404 -> absent. The seams over defaultStateDirFn and
+// discoveryReadFn let it run without a real ~/.aileron or daemon.json.
+func TestProbeClaudeVaultPresence_Wiring(t *testing.T) {
+	cases := []struct {
+		name         string
+		oauthStatus  int
+		apikeyStatus int
+		wantSub      bool
+		wantAPIKey   bool
+	}{
+		{"both present", http.StatusOK, http.StatusOK, true, true},
+		{"subscription only", http.StatusOK, http.StatusNotFound, true, false},
+		{"api-key only", http.StatusNotFound, http.StatusOK, false, true},
+		{"neither", http.StatusNotFound, http.StatusNotFound, false, false},
+		{"locked vault counts as absent", http.StatusLocked, http.StatusLocked, false, false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var gotOAuthReq, gotAPIKeyReq, gotToken bool
+			srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+				if r.URL.Path != "/v1/vault/agents/claude/credentials" {
+					t.Errorf("unexpected path %q", r.URL.Path)
+					w.WriteHeader(http.StatusInternalServerError)
+					return
+				}
+				if r.Header.Get("Authorization") == "Bearer tok-123" {
+					gotToken = true
+				}
+				switch r.URL.Query().Get("purpose") {
+				case "":
+					// Default (oauth) purpose omits the query parameter.
+					gotOAuthReq = true
+					w.WriteHeader(tc.oauthStatus)
+				case "apikey":
+					gotAPIKeyReq = true
+					w.WriteHeader(tc.apikeyStatus)
+				default:
+					t.Errorf("unexpected purpose %q", r.URL.Query().Get("purpose"))
+					w.WriteHeader(http.StatusInternalServerError)
+				}
+			}))
+			t.Cleanup(srv.Close)
+
+			origState := defaultStateDirFn
+			origDisc := discoveryReadFn
+			t.Cleanup(func() {
+				defaultStateDirFn = origState
+				discoveryReadFn = origDisc
+			})
+			defaultStateDirFn = func() (string, error) { return t.TempDir(), nil }
+			discoveryReadFn = func(string) (discovery.Info, error) {
+				return discovery.Info{URL: srv.URL, Token: "tok-123"}, nil
+			}
+
+			got := probeClaudeVaultPresence(context.Background())
+			if got.subscription != tc.wantSub {
+				t.Errorf("subscription = %v, want %v", got.subscription, tc.wantSub)
+			}
+			if got.apiKey != tc.wantAPIKey {
+				t.Errorf("apiKey = %v, want %v", got.apiKey, tc.wantAPIKey)
+			}
+			if !gotOAuthReq {
+				t.Error("probe did not request the oauth slot")
+			}
+			if !gotAPIKeyReq {
+				t.Error("probe did not request the apikey slot")
+			}
+			if !gotToken {
+				t.Error("probe did not send the daemon bearer token")
+			}
+		})
+	}
+}
+
+// TestProbeClaudeVaultPresence_NoDaemon proves the probe degrades to
+// "both slots absent" when the daemon is unreachable (discovery miss), so a
+// probe failure never escalates into a launch failure — resolution falls
+// back to its prior prompt/default behavior.
+func TestProbeClaudeVaultPresence_NoDaemon(t *testing.T) {
+	origState := defaultStateDirFn
+	origDisc := discoveryReadFn
+	t.Cleanup(func() {
+		defaultStateDirFn = origState
+		discoveryReadFn = origDisc
+	})
+	defaultStateDirFn = func() (string, error) { return t.TempDir(), nil }
+	discoveryReadFn = func(string) (discovery.Info, error) {
+		return discovery.Info{}, discovery.ErrNotRunning
+	}
+	got := probeClaudeVaultPresence(context.Background())
+	if got.subscription || got.apiKey {
+		t.Errorf("probe with no daemon = %+v, want both absent", got)
 	}
 }

--- a/docs/src/content/docs/development/sandbox-agent-auth.md
+++ b/docs/src/content/docs/development/sandbox-agent-auth.md
@@ -67,10 +67,19 @@ aileron launch --claude-auth=api-key claude         # ANTHROPIC_API_KEY
 
 The flag is position-independent like the other `aileron launch` flags (`aileron launch claude --claude-auth=api-key` is equivalent). Only `subscription` and `api-key` are valid; any other non-empty value fails the launch with a usage error.
 
-Unlike the tri-state launch flags, `--claude-auth` defaults to the empty string, which means **unresolved**:
+Unlike the tri-state launch flags, `--claude-auth` defaults to the empty string, which means **unresolved**. An explicit flag always wins and is resolved before anything else. On an empty flag the launcher first consults the vault so it does not re-ask a question a stored credential already answers:
+
+- If only the subscription slot (`agents/claude/oauth`) is populated, the launch resolves to subscription.
+- If only the api-key slot (`agents/claude/apikey`) is populated, the launch resolves to api-key. This holds with no TTY too, so a stored key on a CI box launches in api-key mode without re-asking.
+- If both slots are populated, the launch resolves to subscription (the documented default tie-break).
+- A populated slot never prompts and never reads stdin, even on an interactive terminal.
+
+Only when **neither** slot is populated does the launcher fall back to the prior first-run behavior:
 
 - On an interactive terminal, an empty flag triggers a one-line first-run prompt asking which mode to use (Enter selects subscription).
 - With no TTY (a pipe or CI), an empty flag defaults to subscription **without reading stdin**, so a piped stdin destined for the agent is never consumed.
+
+The vault probe runs against the already-unlocked daemon and is best-effort. If the daemon is unreachable the launch falls back to the prompt-or-default behavior above rather than failing.
 
 On a sandbox launch the launcher prints exactly one active-mode banner line to stderr so the selected mode is visible at a glance:
 


### PR DESCRIPTION
## Summary

An empty `--claude-auth` on an interactive terminal always ran the first-run "How should Claude authenticate?" prompt, even when a Claude credential was already stored in the vault. A launch re-asked a question the CLI could answer itself (#1381).

`resolveClaudeAuthMode` now consults the vault on an empty flag before prompting or defaulting:

- **only subscription slot** (`agents/claude/oauth`) populated -> subscription
- **only api-key slot** (`agents/claude/apikey`) populated -> api-key (including on a non-TTY CI box, so a stored key launches without re-asking)
- **both** populated -> subscription (the documented default tie-break)
- a populated slot never prompts and never reads stdin
- **neither** populated -> prior behavior (prompt on a TTY, subscription default off a TTY, stdin untouched)

Flag precedence is unchanged: an explicit `--claude-auth=subscription|api-key` wins and short-circuits **before** any vault probe.

The probe is a package-level seam (`claudeVaultPresenceFn`) that GETs the daemon's per-agent credential endpoint once per purpose, using the same `discovery.Read(stateDir)` -> daemon URL/token pattern `open.go` already uses. `ensureVaultUnlockedFn` runs before dispatch, so the daemon is up with the vault unlocked. The probe is best-effort: any discovery/transport failure (or a locked-vault / non-200 status) reports the slot absent, so a probe failure degrades to the prompt-or-default fallback rather than failing the launch.

Docs: `docs/.../development/sandbox-agent-auth.md` "Claude auth mode selection" updated to describe the vault-aware gating.

## Test plan

- `go test ./cmd/aileron/ ./internal/launch/...` green; `cmd/aileron` coverage 85.6%.
- New table tests cover all four vault states x flag set/empty x TTY/non-TTY.
- Regression test (`TestResolveClaudeAuthMode_PopulatedSlotDoesNotPrompt`): an empty flag on a TTY with a populated slot must NOT prompt; verified it **fails** against the pre-fix resolver and **passes** with the fix. The scripted stdin would select the wrong mode if the prompt ran, proving the vault answer drives the result.
- `TestResolveClaudeAuthMode_ExplicitWinsOverVault`: explicit flag short-circuits before the probe (a failing probe stub proves no probe runs).
- `TestProbeClaudeVaultPresence_Wiring` (httptest fake daemon): asserts one GET per purpose, bearer token sent, default purpose omits the query string, `?purpose=apikey` appended, 200->present / 404|locked->absent.
- `TestProbeClaudeVaultPresence_NoDaemon`: discovery miss degrades to both-absent.

Closes #1381

🤖 Generated with [Claude Code](https://claude.com/claude-code)
