### PR TITLE
fix(launch): validate Claude credentials host-side before vault PUT

### DIFF
--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -191,6 +191,14 @@ func (c Claude) AuthSpec() launch.AuthSpec {
 			Render:   claudeRender,
 			Capture:  claudeCapture,
 			Fresher:  claudeFresher,
+			// CaptureValidate probes Claude's profile endpoint host-side
+			// with the captured access token before the vault PUT, so a
+			// bad/expired token an in-container login wrote (fallback,
+			// headless, or in-session rotation) is rejected rather than
+			// persisted for future launches. Runs on the host because the
+			// sandbox's deny-by-default egress (ADR-0005) blocks the probe
+			// in-container.
+			CaptureValidate: claudeCaptureValidate,
 			// HostAcquire runs a host-side OAuth flow (hosted-callback
 			// paste with PKCE, then a profile fetch that stamps the
 			// subscription tier) when the vault is empty and host-login is

--- a/internal/launch/agents/claude_apikey_auth_test.go
+++ b/internal/launch/agents/claude_apikey_auth_test.go
@@ -4,6 +4,8 @@ import (
 	"bytes"
 	"context"
 	"io"
+	"net/http"
+	"net/http/httptest"
 	"strings"
 	"testing"
 
@@ -11,6 +13,39 @@ import (
 	"github.com/ALRubinger/aileron/internal/launch/agents"
 	"github.com/ALRubinger/aileron/internal/vault"
 )
+
+// claudeModelsCapture records what the api-key validation probe sent so a
+// test can assert the acquirer's contract with the provider (the key
+// header and version header on the GET /v1/models request).
+type claudeModelsCapture struct {
+	apiKey  string
+	version string
+	path    string
+}
+
+// claudeModelsServer is an httptest server standing in for Claude's
+// /v1/models endpoint that the api-key validation probe hits. status is
+// the HTTP status it returns, letting a test drive the 2xx (valid key)
+// and 401 (invalid key) branches. The returned capture records the
+// x-api-key / anthropic-version headers and the request path.
+func claudeModelsServer(t *testing.T, status int) (*httptest.Server, *claudeModelsCapture) {
+	t.Helper()
+	cap := &claudeModelsCapture{}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.apiKey = r.Header.Get("x-api-key")
+		cap.version = r.Header.Get("anthropic-version")
+		cap.path = r.URL.Path
+		w.Header().Set("Content-Type", "application/json")
+		w.WriteHeader(status)
+		if status/100 == 2 {
+			_, _ = io.WriteString(w, `{"data":[{"id":"claude-3"}]}`)
+		} else {
+			_, _ = io.WriteString(w, `{"type":"error","error":{"type":"authentication_error","message":"invalid x-api-key"}}`)
+		}
+	}))
+	t.Cleanup(srv.Close)
+	return srv, cap
+}
 
 // Claude api-key auth contract (#1339):
 //
@@ -91,9 +126,11 @@ func TestClaudeAPIKey_Render_RejectsEmpty(t *testing.T) {
 
 func TestClaudeAPIKey_HostAcquire_ReturnsApiKeySecret(t *testing.T) {
 	eb := claudeAPIKeyBinding(t)
+	srv, capture := claudeModelsServer(t, http.StatusOK)
 	var out bytes.Buffer
 	secret, err := eb.HostAcquire(context.Background(), launch.HostAcquireDeps{
 		Ctx:          context.Background(),
+		HTTPClient:   testHTTPClient(srv.URL),
 		Out:          &out,
 		CodePrompter: scriptedPrompter("  sk-ant-xyz  ", nil),
 	})
@@ -102,6 +139,18 @@ func TestClaudeAPIKey_HostAcquire_ReturnsApiKeySecret(t *testing.T) {
 	}
 	if string(secret.Value) != "sk-ant-xyz" {
 		t.Errorf("Secret.Value = %q, want trimmed sk-ant-xyz", secret.Value)
+	}
+	// The validation probe must present the trimmed key via x-api-key
+	// (NOT a Bearer token) and the pinned anthropic-version, against the
+	// models endpoint.
+	if capture.apiKey != "sk-ant-xyz" {
+		t.Errorf("probe x-api-key = %q, want trimmed sk-ant-xyz", capture.apiKey)
+	}
+	if capture.version == "" {
+		t.Errorf("probe anthropic-version header is empty; want it set")
+	}
+	if capture.path != "/v1/models" {
+		t.Errorf("probe path = %q, want /v1/models", capture.path)
 	}
 	if secret.Metadata.Type != "api_key" {
 		t.Errorf("Metadata.Type = %q, want api_key", secret.Metadata.Type)
@@ -127,6 +176,7 @@ func TestClaudeAPIKey_HostAcquire_ReturnsApiKeySecret(t *testing.T) {
 // a writer to print its own.
 func TestClaudeAPIKey_HostAcquire_PrompterReceivesNilWriter(t *testing.T) {
 	eb := claudeAPIKeyBinding(t)
+	srv, _ := claudeModelsServer(t, http.StatusOK)
 	var out bytes.Buffer
 	gotWriter := io.Writer(&out) // sentinel: must be overwritten to nil
 	called := false
@@ -137,6 +187,7 @@ func TestClaudeAPIKey_HostAcquire_PrompterReceivesNilWriter(t *testing.T) {
 	}
 	if _, err := eb.HostAcquire(context.Background(), launch.HostAcquireDeps{
 		Ctx:          context.Background(),
+		HTTPClient:   testHTTPClient(srv.URL),
 		Out:          &out,
 		CodePrompter: prompter,
 	}); err != nil {
@@ -192,4 +243,67 @@ func TestClaudeAPIKey_HostAcquire_NilPrompterIsNonFatal(t *testing.T) {
 		t.Errorf("nil prompter must yield empty Secret, got %q", secret.Value)
 	}
 	_ = err
+}
+
+// Regression (#1384, sub-req B): a pasted key that authenticates (2xx
+// from the models probe) is seeded; a key the provider rejects (401) is
+// NOT seeded — the acquirer returns an empty Secret so the launcher logs
+// and falls back to the in-container login rather than persisting a dead
+// key into the vault.
+func TestClaudeAPIKey_HostAcquire_ValidKeyIsSeeded(t *testing.T) {
+	eb := claudeAPIKeyBinding(t)
+	srv, _ := claudeModelsServer(t, http.StatusOK)
+	secret, err := eb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:          context.Background(),
+		HTTPClient:   testHTTPClient(srv.URL),
+		CodePrompter: scriptedPrompter("sk-ant-valid", nil),
+	})
+	if err != nil {
+		t.Fatalf("HostAcquire: %v", err)
+	}
+	if string(secret.Value) != "sk-ant-valid" {
+		t.Errorf("Secret.Value = %q, want sk-ant-valid", secret.Value)
+	}
+}
+
+func TestClaudeAPIKey_HostAcquire_InvalidKeyIsNotSeeded(t *testing.T) {
+	eb := claudeAPIKeyBinding(t)
+	srv, _ := claudeModelsServer(t, http.StatusUnauthorized)
+	var out bytes.Buffer
+	secret, err := eb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:          context.Background(),
+		HTTPClient:   testHTTPClient(srv.URL),
+		Out:          &out,
+		CodePrompter: scriptedPrompter("sk-ant-revoked", nil),
+	})
+	// A rejected key is non-fatal: empty Secret (no seed) so the launcher
+	// falls back. An accompanying error is permitted as a fallback signal.
+	if len(secret.Value) != 0 {
+		t.Errorf("invalid key must yield empty Secret (no seed), got %q", secret.Value)
+	}
+	if err == nil {
+		t.Error("invalid key should surface a (non-fatal) error so the launcher logs the fallback")
+	}
+	// The user sees a message explaining the key did not validate.
+	if !strings.Contains(out.String(), "did not validate") {
+		t.Errorf("Out = %q, want a message that the key did not validate", out.String())
+	}
+}
+
+// A 403 (e.g. key valid but lacking model access) is treated the same as
+// a 401: not seeded, launcher falls back.
+func TestClaudeAPIKey_HostAcquire_ForbiddenKeyIsNotSeeded(t *testing.T) {
+	eb := claudeAPIKeyBinding(t)
+	srv, _ := claudeModelsServer(t, http.StatusForbidden)
+	secret, err := eb.HostAcquire(context.Background(), launch.HostAcquireDeps{
+		Ctx:          context.Background(),
+		HTTPClient:   testHTTPClient(srv.URL),
+		CodePrompter: scriptedPrompter("sk-ant-forbidden", nil),
+	})
+	if len(secret.Value) != 0 {
+		t.Errorf("forbidden key must yield empty Secret (no seed), got %q", secret.Value)
+	}
+	if err == nil {
+		t.Error("forbidden key should surface a (non-fatal) error so the launcher logs the fallback")
+	}
 }

--- a/internal/launch/agents/claude_auth.go
+++ b/internal/launch/agents/claude_auth.go
@@ -47,6 +47,16 @@ const (
 	// `user:profile` scope, requested in claudeOAuthScopes, authorizes
 	// it) so the seeded envelope can carry a subscriptionType.
 	claudeProfileURL = "https://api.anthropic.com/api/oauth/profile"
+	// claudeModelsURL is a cheap authenticated endpoint used to validate
+	// a raw ANTHROPIC_API_KEY host-side before it is seeded into the
+	// vault. Unlike the OAuth profile endpoint (Bearer token), API keys
+	// authenticate with the `x-api-key` header, so this probe cannot
+	// reuse claudeFetchProfile.
+	claudeModelsURL = "https://api.anthropic.com/v1/models"
+	// claudeAnthropicVersion is the stable Anthropic API version header
+	// the api-key validation probe sends. It matches the version pinned
+	// elsewhere in the codebase (internal/app handlers).
+	claudeAnthropicVersion = "2023-06-01"
 )
 
 // claudeOAuthScopes are the scopes Claude Code requests for a
@@ -219,10 +229,60 @@ func claudeAPIKeyHostAcquire(ctx context.Context, deps launch.HostAcquireDeps) (
 		// empty Secret, no seed, no error.
 		return vault.Secret{}, nil
 	}
+	// Validate the pasted key host-side before seeding the vault. A
+	// mistyped or revoked key would otherwise be persisted and the
+	// container would launch with a dead key. On failure return an empty
+	// Secret (the existing non-fatal contract) so the launcher logs and
+	// falls back to the in-container login rather than seeding a dead key.
+	if err := claudeValidateAPIKey(ctx, deps.HTTPClient, key); err != nil {
+		if deps.Out != nil {
+			fmt.Fprintf(deps.Out,
+				"The pasted Anthropic API key did not validate (%v); not seeding it. Falling back to the in-container login.\n", err)
+		}
+		return vault.Secret{}, fmt.Errorf("claude: pasted api key failed validation: %w", err)
+	}
 	return vault.Secret{
 		Value:    []byte(key),
 		Metadata: vault.Metadata{Type: "api_key"},
 	}, nil
+}
+
+// claudeValidateAPIKey confirms a raw ANTHROPIC_API_KEY authenticates by
+// issuing a cheap GET against Claude's models endpoint with the
+// `x-api-key` header. A 2xx confirms the key; a 401/403 (or any other
+// non-2xx) means the key is mistyped or revoked. Network errors are also
+// surfaced as failures so the launcher falls back rather than seeding an
+// unvalidated key.
+//
+// API keys use `x-api-key`, NOT a Bearer token, so this deliberately does
+// NOT reuse claudeFetchProfile. The HTTP client is taken from the caller
+// (HostAcquireDeps.HTTPClient) so an httptest server can stand in.
+// Mirroring claudeFetchProfile's posture, a non-2xx surfaces only the
+// HTTP status; the raw body is redacted so a verbose or hostile provider
+// response cannot leak into the user-facing launch error.
+func claudeValidateAPIKey(ctx context.Context, client *http.Client, key string) error {
+	if client == nil {
+		client = http.DefaultClient
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, claudeModelsURL, nil)
+	if err != nil {
+		return fmt.Errorf("claude: build api-key validation request: %w", err)
+	}
+	req.Header.Set("x-api-key", key)
+	req.Header.Set("anthropic-version", claudeAnthropicVersion)
+	req.Header.Set("Accept", "application/json")
+
+	resp, err := client.Do(req)
+	if err != nil {
+		return fmt.Errorf("claude: api-key validation request: %w", err)
+	}
+	defer resp.Body.Close()
+	_, _ = io.Copy(io.Discard, resp.Body)
+	if resp.StatusCode/100 != 2 {
+		// Redact the raw body; surface only the status.
+		return fmt.Errorf("claude: api-key validation failed: provider returned %d", resp.StatusCode)
+	}
+	return nil
 }
 
 // claudeCredentialEnvelope mirrors the on-disk shape of Claude's
@@ -417,6 +477,46 @@ func claudeFresher(captured, current vault.Secret) (bool, error) {
 	// Equal timestamps (including both-zero with identical tokens) are
 	// not strictly newer.
 	return false, nil
+}
+
+// claudeCaptureValidate is the FileBinding.CaptureValidate hook for the
+// subscription (OAuth) binding. The launcher calls it on the host after
+// the in-container capture path has read a rotated/first-login
+// .credentials.json and validateClaudeEnvelope confirmed its structure,
+// but before the vault PUT. It parses the captured envelope and probes
+// Claude's profile endpoint with the access token; a non-2xx response or
+// a token whose organization carries no recognizable subscription tier
+// means the credential cannot authenticate, so it returns an error and
+// the launcher skips the PUT (retaining any prior entry).
+//
+// Honest scope: this cannot pre-validate the *running* session — in the
+// default in-container flow the credential does not exist until Claude
+// Code logs in mid-session. The durable harm it prevents is a bad or
+// expired token captured from a fallback/headless login (or an
+// in-session rotation) poisoning the vault for future launches.
+//
+// The probe runs host-side because the sandbox's deny-by-default network
+// policy (ADR-0005) blocks api.anthropic.com from inside the container;
+// we deliberately do NOT widen [capabilities.network] to probe in-
+// container.
+func claudeCaptureValidate(ctx context.Context, client *http.Client, captured vault.Secret) error {
+	var env claudeCredentialEnvelope
+	if err := json.Unmarshal(captured.Value, &env); err != nil {
+		return fmt.Errorf("%w: parse for validation: %v", errClaudeEnvelopeMalformed, err)
+	}
+	if env.ClaudeAiOauth.AccessToken == "" {
+		return fmt.Errorf("%w: claudeAiOauth.accessToken is empty", errClaudeEnvelopeMalformed)
+	}
+	subscriptionType, _, err := claudeFetchProfile(ctx, client, env.ClaudeAiOauth.AccessToken)
+	if err != nil {
+		return fmt.Errorf("claude: captured token failed live validation: %w", err)
+	}
+	if subscriptionType == "" {
+		// A 2xx with no recognizable organization_type: the token
+		// authenticated but does not back a usable subscription session.
+		return errors.New("claude: captured token authenticated but reports no subscription tier (unusable session)")
+	}
+	return nil
 }
 
 // validateClaudeEnvelope checks the JSON parses and carries a

--- a/internal/launch/agents/claude_host_acquire_test.go
+++ b/internal/launch/agents/claude_host_acquire_test.go
@@ -13,6 +13,7 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/launch"
 	"github.com/ALRubinger/aileron/internal/launch/agents"
+	"github.com/ALRubinger/aileron/internal/vault"
 )
 
 // Claude host-acquire contract (#1270, #1304):
@@ -351,5 +352,78 @@ func TestClaudeHostAcquire_NilPrompterIsNonFatal(t *testing.T) {
 	}
 	if len(secret.Value) != 0 {
 		t.Error("Secret must be empty when the paste flow cannot run")
+	}
+}
+
+// Claude CaptureValidate contract (#1384, sub-req A): the subscription
+// binding's CaptureValidate hook probes the profile endpoint host-side
+// with the captured access token. A token whose profile fetch returns a
+// recognizable tier passes (nil error → launcher proceeds to PUT); a
+// non-2xx profile fetch, a 2xx with no tier, or a structurally-broken
+// envelope fails (non-nil error → launcher skips the PUT).
+//
+// Exercised through the PUBLIC CaptureValidate field on the binding so the
+// test pins the wired-up behavior, not the unexported helper.
+
+func claudeCaptureValidateHook(t *testing.T) func(context.Context, *http.Client, vault.Secret) error {
+	t.Helper()
+	fb := claudeHostAcquireBinding(t)
+	if fb.CaptureValidate == nil {
+		t.Fatal("Claude binding must declare CaptureValidate for capture-time validation")
+	}
+	return fb.CaptureValidate
+}
+
+func TestClaudeCaptureValidate_ValidTokenPasses(t *testing.T) {
+	srv, capture := claudeOAuthServer(t, "claude_max")
+	validate := claudeCaptureValidateHook(t)
+	envelope := vault.Secret{Value: []byte(`{"claudeAiOauth":{"accessToken":"acc-tok"}}`)}
+	if err := validate(context.Background(), testHTTPClient(srv.URL), envelope); err != nil {
+		t.Fatalf("CaptureValidate rejected a live token: %v", err)
+	}
+	// The probe must present the captured access token as a Bearer (OAuth,
+	// NOT x-api-key).
+	if capture.profileAuth != "Bearer acc-tok" {
+		t.Errorf("profile Authorization = %q, want Bearer acc-tok", capture.profileAuth)
+	}
+}
+
+func TestClaudeCaptureValidate_ProfileNon2xxFails(t *testing.T) {
+	// A profile endpoint that 401s simulates a bad/expired captured token.
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	t.Cleanup(srv.Close)
+	validate := claudeCaptureValidateHook(t)
+	envelope := vault.Secret{Value: []byte(`{"claudeAiOauth":{"accessToken":"bad-tok"}}`)}
+	if err := validate(context.Background(), testHTTPClient(srv.URL), envelope); err == nil {
+		t.Fatal("CaptureValidate must reject a token whose profile fetch is non-2xx")
+	}
+}
+
+func TestClaudeCaptureValidate_NoTierFails(t *testing.T) {
+	// A 2xx profile with an unrecognized organization_type yields an empty
+	// tier; the token authenticated but does not back a usable session.
+	srv, _ := claudeOAuthServer(t, "")
+	validate := claudeCaptureValidateHook(t)
+	envelope := vault.Secret{Value: []byte(`{"claudeAiOauth":{"accessToken":"acc-tok"}}`)}
+	if err := validate(context.Background(), testHTTPClient(srv.URL), envelope); err == nil {
+		t.Fatal("CaptureValidate must reject a token whose profile reports no tier")
+	}
+}
+
+func TestClaudeCaptureValidate_MalformedEnvelopeFails(t *testing.T) {
+	// A captured payload that does not parse / carries no access token is
+	// rejected before any network call.
+	validate := claudeCaptureValidateHook(t)
+	for name, val := range map[string][]byte{
+		"not json":          []byte("garbage"),
+		"empty accessToken": []byte(`{"claudeAiOauth":{"accessToken":""}}`),
+	} {
+		t.Run(name, func(t *testing.T) {
+			if err := validate(context.Background(), http.DefaultClient, vault.Secret{Value: val}); err == nil {
+				t.Fatal("CaptureValidate must reject a malformed/tokenless envelope")
+			}
+		})
 	}
 }

--- a/internal/launch/agents/claude_test.go
+++ b/internal/launch/agents/claude_test.go
@@ -96,6 +96,12 @@ func TestClaude_AuthSpec_SubscriptionMode(t *testing.T) {
 					t.Errorf("subscription FileBinding references the apikey slot %q", fb.VaultPath)
 				}
 			}
+			// The oauth binding declares a CaptureValidate hook so a
+			// captured in-container token is liveness-probed host-side
+			// before the vault PUT (#1384).
+			if spec.FileBindings[0].CaptureValidate == nil {
+				t.Errorf("subscription FileBinding must declare CaptureValidate for capture-time liveness validation")
+			}
 		})
 	}
 }

--- a/internal/launch/authspec.go
+++ b/internal/launch/authspec.go
@@ -174,6 +174,32 @@ type FileBinding struct {
 	// returns a plain error so garbage is never written.
 	Fresher func(captured, current vault.Secret) (bool, error)
 
+	// CaptureValidate, when non-nil, runs after the binding's Capture
+	// succeeds and BEFORE the presence/Fresher branch decides whether
+	// to PUT. It is a host-side liveness probe: the launcher hands it
+	// an *http.Client (the same timed pre-launch client RefreshDeps
+	// uses) plus the just-captured Secret, and the hook confirms the
+	// credential actually authenticates against the vendor.
+	//
+	// A nil error means the credential is live and the PUT proceeds (the
+	// usual presence/Fresher gating still applies). A non-nil error
+	// means the credential did not authenticate (a bad, expired, or
+	// garbage token an in-container login wrote): CaptureFn logs a
+	// stderr warning and SKIPS the PUT, so the prior vault entry — if
+	// any — is retained rather than overwritten with a credential that
+	// cannot work. A token that poisons the vault for future launches is
+	// the durable harm this guards against; it cannot pre-validate the
+	// running session, whose credential does not exist until the agent
+	// logs in mid-session.
+	//
+	// The probe MUST run host-side. The container's deny-by-default
+	// network policy (ADR-0005) blocks outbound calls to the vendor, so
+	// the validation lives here in the launcher (which runs on the host),
+	// not inside the sandbox. The hook is invoked on every clean capture,
+	// before the freshness gate, so an invalid token is rejected on
+	// re-launch as well as on first seed.
+	CaptureValidate func(ctx context.Context, client *http.Client, captured vault.Secret) error
+
 	// PreLaunchRefresh, when non-nil, runs before Render. It
 	// receives the resolved vault secret plus the daemon-backed
 	// dependencies needed to refresh and persist a rotated token,

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -334,6 +334,9 @@ func prepareAuthSpec(
 		// Fresher is the binding's optional freshness hook; nil
 		// preserves last-writer-wins. See FileBinding.Fresher.
 		Fresher func(captured, current vault.Secret) (bool, error)
+		// CaptureValidate is the binding's optional host-side liveness
+		// probe; nil skips validation. See FileBinding.CaptureValidate.
+		CaptureValidate func(ctx context.Context, client *http.Client, captured vault.Secret) error
 	}
 	var captureTargets []fileCapture
 
@@ -371,6 +374,7 @@ func prepareAuthSpec(
 			Capture:         fb.Capture,
 			PresentAtRender: true,
 			Fresher:         fb.Fresher,
+			CaptureValidate: fb.CaptureValidate,
 		})
 		// MountAsFile bindings get an individual file mount at
 		// ContainerPath. The mount is writable so Capture can read
@@ -459,6 +463,7 @@ func prepareAuthSpec(
 				Capture:         fb.Capture,
 				PresentAtRender: false,
 				Fresher:         fb.Fresher,
+				CaptureValidate: fb.CaptureValidate,
 			})
 			continue
 		case getErr != nil:
@@ -620,6 +625,23 @@ func prepareAuthSpec(
 						fmt.Errorf("schema-validate captured bytes: %w (skipping vault write so a partial-write or schema-drift session does not clobber the prior entry; inspect %s or re-login)",
 							err, target.HostPath))
 					continue
+				}
+				// Host-side liveness probe. The Capture above only checks
+				// envelope structure; CaptureValidate confirms the captured
+				// credential actually authenticates against the vendor. Run
+				// it before the presence/Fresher branch so a bad, expired, or
+				// garbage token an in-container login wrote is rejected on
+				// every clean capture (first seed and re-launch alike) rather
+				// than poisoning the vault for future launches. The probe is
+				// host-side because the container's deny-by-default network
+				// policy (ADR-0005) blocks the vendor call from inside the
+				// sandbox.
+				if target.CaptureValidate != nil {
+					if err := target.CaptureValidate(captureCtx, preLaunchRefreshHTTPClient(), captured); err != nil {
+						captureWarn(sessionLog, stderr, agentName, target.HostPath,
+							fmt.Errorf("validate captured credential: %w (skipping vault write so an unusable token does not overwrite the prior entry; re-login to seed a working credential)", err))
+						continue
+					}
 				}
 				// Decide whether to PUT via the presence-aware,
 				// three-way branch (ADR-0025). Read the current vault

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io/fs"
 	"log/slog"
+	"net/http"
 	"os"
 	"path/filepath"
 	"strings"
@@ -474,6 +475,110 @@ func TestPrepareAuthSpec_CaptureSchemaFailureSkipsPut(t *testing.T) {
 	}
 	if !strings.Contains(stderr.String(), "capture for claude failed") {
 		t.Errorf("expected stderr warning; got %q", stderr.String())
+	}
+}
+
+// Regression (#1384, sub-req A): a CaptureValidate hook that fails (the
+// captured credential did not authenticate against the vendor) must cause
+// the launcher to SKIP the PUT, retaining the prior vault entry rather
+// than overwriting it with an unusable token. The hook runs after Capture
+// and before the Fresher/presence branch.
+func TestPrepareAuthSpec_CaptureValidateFailureSkipsPut(t *testing.T) {
+	prior := []byte(`{"claudeAiOauth":{"accessToken":"prior"}}`)
+	captured := []byte(`{"claudeAiOauth":{"accessToken":"bad-new"}}`)
+
+	daemon := newFakeDaemon()
+	daemon.seed("claude", prior)
+
+	stderr := &bytes.Buffer{}
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture: func(b []byte) (vault.Secret, error) {
+				return vault.Secret{Value: b, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}, nil
+			},
+			CaptureValidate: func(_ context.Context, _ *http.Client, _ vault.Secret) error {
+				return errors.New("token failed live validation")
+			},
+		}},
+	}
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), stderr, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	hostPath := filepath.Join(prep.Mounts[0].Source, ".credentials.json")
+	if err := os.WriteFile(hostPath, captured, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	beforePuts := len(daemon.puts)
+	prep.CaptureFn(context.Background())
+
+	if len(daemon.puts) != beforePuts {
+		t.Errorf("CaptureValidate failure should skip PUT; got %d new puts", len(daemon.puts)-beforePuts)
+	}
+	// Prior vault entry must be retained unchanged.
+	got, getErr := daemon.GetAgentCredentials(context.Background(), "claude", "oauth")
+	if getErr != nil {
+		t.Fatalf("GetAgentCredentials after skipped PUT: %v", getErr)
+	}
+	if !bytes.Equal(got.Value, prior) {
+		t.Errorf("prior entry = %q, want it retained as %q", got.Value, prior)
+	}
+	if !strings.Contains(stderr.String(), "capture for claude failed") {
+		t.Errorf("expected stderr warning; got %q", stderr.String())
+	}
+}
+
+// Regression (#1384, sub-req A): a CaptureValidate hook that PASSES must
+// let the PUT proceed — a valid captured token is persisted as today.
+func TestPrepareAuthSpec_CaptureValidateSuccessPersists(t *testing.T) {
+	prior := []byte(`{"claudeAiOauth":{"accessToken":"prior","expiresAt":1}}`)
+	captured := []byte(`{"claudeAiOauth":{"accessToken":"fresh","expiresAt":2}}`)
+
+	daemon := newFakeDaemon()
+	daemon.seed("claude", prior)
+
+	validated := false
+	spec := AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/claude/oauth",
+			ContainerPath: "/home/agent/.claude/.credentials.json",
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture: func(b []byte) (vault.Secret, error) {
+				return vault.Secret{Value: b, Metadata: vault.Metadata{Type: "oauth_refresh_token"}}, nil
+			},
+			CaptureValidate: func(_ context.Context, _ *http.Client, _ vault.Secret) error {
+				validated = true
+				return nil
+			},
+		}},
+	}
+	prep, err := prepareAuthSpec(context.Background(), "claude", spec, daemon, newTestLogger(), nil, nil, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	hostPath := filepath.Join(prep.Mounts[0].Source, ".credentials.json")
+	if err := os.WriteFile(hostPath, captured, 0o600); err != nil {
+		t.Fatal(err)
+	}
+
+	prep.CaptureFn(context.Background())
+
+	if !validated {
+		t.Error("CaptureValidate hook was never invoked")
+	}
+	if len(daemon.puts) != 1 {
+		t.Fatalf("daemon.puts = %d, want 1 (valid token persists)", len(daemon.puts))
+	}
+	if !bytes.Equal(daemon.puts[0].Secret.Value, captured) {
+		t.Errorf("PUT value = %q, want %q", daemon.puts[0].Secret.Value, captured)
 	}
 }
 


### PR DESCRIPTION
## Summary

Validate Claude credentials host-side before they are written to the vault, for both the OAuth/subscription envelope and the raw API key. Previously a bad, expired, or mistyped credential could be persisted and the container would launch into a guaranteed failure, leaving the user to manually delete the bad vault entry.

### Sub-requirement A — OAuth/subscription capture-time validation
- New optional `FileBinding.CaptureValidate` hook of shape `func(ctx, *http.Client, vault.Secret) error`. The launcher's `CaptureFn` invokes it after `Capture` succeeds and **before** the presence/`Fresher` branch, passing the timed pre-launch HTTP client.
- Claude's `claudeCaptureValidate` parses the captured envelope and calls the existing `claudeFetchProfile` host-side. A non-2xx fetch or a token with no subscription tier returns an error, so `CaptureFn` warns and **skips the PUT** (prior entry retained). A valid token persists as today.
- Runs on the host: the container's deny-by-default egress (ADR-0005) blocks `api.anthropic.com` from inside the sandbox. `[capabilities.network]` is unchanged.
- **Honest scope:** this cannot pre-validate the *running* session (the in-container credential does not exist until Claude logs in mid-session). It prevents a bad/expired token from poisoning the vault for future launches and on in-session rotation.

### Sub-requirement B — API-key host-acquire validation
- `claudeAPIKeyHostAcquire` now probes `GET https://api.anthropic.com/v1/models` with `x-api-key: <key>` and `anthropic-version: 2023-06-01` (via a new `claudeValidateAPIKey` helper) before returning the Secret.
- A 2xx seeds the key; a 401/403/other non-2xx returns an empty Secret (non-fatal) so the launcher falls back to the in-container login rather than seeding a dead key.
- API keys use `x-api-key` (not Bearer), so this deliberately does NOT reuse `claudeFetchProfile`. The HTTP client is taken from `deps.HTTPClient` for the httptest seam.

## Test plan
- `internal/launch/agents`:
  - `TestClaudeCaptureValidate_*` — valid token passes (Bearer presented), profile non-2xx fails, no-tier fails, malformed envelope fails (no network call).
  - `TestClaudeAPIKey_HostAcquire_ValidKeyIsSeeded` / `_InvalidKeyIsNotSeeded` / `_ForbiddenKeyIsNotSeeded` — 2xx seeds, 401/403 yields empty Secret with a user-facing message; probe presents `x-api-key` + `anthropic-version` against `/v1/models`.
  - Updated the existing api-key happy-path tests to supply an httptest models server.
  - `TestClaude_AuthSpec_SubscriptionMode` now asserts the oauth binding declares `CaptureValidate`.
- `internal/launch`:
  - `TestPrepareAuthSpec_CaptureValidateFailureSkipsPut` — failing hook skips the PUT, prior entry retained, stderr warning emitted.
  - `TestPrepareAuthSpec_CaptureValidateSuccessPersists` — passing hook lets the PUT proceed.
- Full `internal/...` suite passes; `go vet` clean. New helpers: `claudeCaptureValidate` 100%, `claudeAPIKeyHostAcquire` 100%, `claudeValidateAPIKey` 81% (remaining lines are the nil-client/build-request defensive paths). CodeRabbit review: 0 findings.

Closes #1384

🤖 Generated with [Claude Code](https://claude.com/claude-code)
