### PR TITLE
fix(cli): aileron stop cleans up daemon.json itself on Windows

### DIFF
--- a/cmd/aileron/daemon_cli.go
+++ b/cmd/aileron/daemon_cli.go
@@ -55,7 +55,7 @@ func runDaemonStart(_ []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "Hint: run 'task build:server' to build it next to the aileron binary.")
 		return 1
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), spawn.ResolveContextBudget)
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
 	defer cancel()
 	url, err := spawnResolveFn(ctx, spawn.Options{
 		StateDir: stateDir,
@@ -69,10 +69,25 @@ func runDaemonStart(_ []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
-// runDaemonStop sends SIGTERM to the daemon (PID from daemon.json)
-// and waits for daemon.json to be removed, signalling clean shutdown.
-// Idempotent — if the daemon isn't running, exits 0 with a short
-// note rather than failing.
+// signalDaemonStopFn is the seam runDaemonStop calls to terminate the
+// daemon process. It defaults to the platform implementation
+// (signalDaemonStop) and is overridable in tests so the Windows stop
+// path (kill succeeds, daemon does not self-clean) can be exercised on
+// any host.
+var signalDaemonStopFn = signalDaemonStop
+
+// runDaemonStop terminates the daemon (PID from daemon.json) and ensures
+// its discovery files are gone before reporting success. Idempotent — if
+// the daemon isn't running, exits 0 with a short note rather than failing.
+//
+// Cleanup of daemon.json/daemon.pid depends on the platform stop
+// mechanism, reported by signalDaemonStop via selfCleans:
+//   - selfCleans=true (Unix SIGTERM): the daemon removes the files in its
+//     own shutdown defer; the CLI waits for them to disappear.
+//   - selfCleans=false (Windows TerminateProcess): the kill is abrupt and
+//     uncatchable, so the daemon never runs its defer. The CLI removes the
+//     files itself and reports success immediately — without this, the
+//     wait loop would spin the full timeout and fail on every first stop.
 func runDaemonStop(_ []string, stdout, stderr io.Writer) int {
 	stateDir, err := defaultStateDir()
 	if err != nil {
@@ -89,7 +104,7 @@ func runDaemonStop(_ []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	notRunning, err := signalDaemonStop(info.PID)
+	notRunning, selfCleans, err := signalDaemonStopFn(info.PID)
 	if notRunning {
 		// PID is not alive: stale daemon.json from a prior crash.
 		// Clean it up for the operator and exit 0; the daemon is
@@ -101,6 +116,18 @@ func runDaemonStop(_ []string, stdout, stderr io.Writer) int {
 	if err != nil {
 		fmt.Fprintf(stderr, "aileron: signal daemon (pid %d): %v\n", info.PID, err)
 		return 1
+	}
+
+	if !selfCleans {
+		// The platform kill does not trigger the daemon's shutdown defer
+		// (Windows TerminateProcess), so the daemon will never remove its
+		// own discovery files. Remove them ourselves and report success.
+		if err := discovery.Remove(stateDir); err != nil {
+			fmt.Fprintf(stderr, "aileron: remove daemon.json: %v\n", err)
+			return 1
+		}
+		fmt.Fprintf(stdout, "Aileron daemon stopped (pid %d).\n", info.PID)
+		return 0
 	}
 
 	// Wait for the daemon to clean up its discovery files. The daemon

--- a/cmd/aileron/daemon_cli_test.go
+++ b/cmd/aileron/daemon_cli_test.go
@@ -438,12 +438,108 @@ func TestSpawnResolveOnce_PropagatesSpawnError(t *testing.T) {
 // default kernel.pid_max (4194304) being reused, and unlikely to be a
 // live process on a Windows runner.
 func TestSignalDaemonStop_NotRunningPID(t *testing.T) {
-	notRunning, err := signalDaemonStop(9999999)
+	notRunning, _, err := signalDaemonStop(9999999)
 	if err != nil {
 		t.Fatalf("signalDaemonStop(9999999): unexpected err: %v", err)
 	}
 	if !notRunning {
 		t.Fatal("signalDaemonStop(9999999): notRunning = false, want true (PID should not exist)")
+	}
+}
+
+// withSignalDaemonStop substitutes the signalDaemonStopFn seam for the
+// duration of a test, restoring it on cleanup. Lets us drive the stop
+// command down either platform's path (selfCleans true/false) without
+// terminating a real process.
+func withSignalDaemonStop(t *testing.T, fn func(int) (notRunning, selfCleans bool, err error)) {
+	t.Helper()
+	orig := signalDaemonStopFn
+	signalDaemonStopFn = fn
+	t.Cleanup(func() { signalDaemonStopFn = orig })
+}
+
+// TestRunDaemonStop_WindowsKill_CLICleansUp is the regression test for
+// issue #1403: on Windows the kill succeeds but is uncatchable, so the
+// daemon never removes its own daemon.json/daemon.pid (selfCleans=false).
+// The CLI must remove the discovery files itself and report success on
+// the FIRST invocation — not spin the wait loop and exit 1.
+func TestRunDaemonStop_WindowsKill_CLICleansUp(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+
+	if err := discovery.Write(stateDir, discovery.Info{
+		URL:       "http://127.0.0.1:1",
+		PID:       4242,
+		Version:   "win",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate the Windows kill: process terminated (notRunning=false),
+	// but the daemon will NOT self-clean (selfCleans=false). Crucially the
+	// fake does NOT remove daemon.json, mirroring the uncatchable kill.
+	var gotPID int
+	withSignalDaemonStop(t, func(pid int) (bool, bool, error) {
+		gotPID = pid
+		return false, false, nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStop(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0 on first stop; stderr=%s", code, stderr.String())
+	}
+	if gotPID != 4242 {
+		t.Errorf("signalDaemonStop called with pid %d, want 4242", gotPID)
+	}
+	if !strings.Contains(stdout.String(), "stopped (pid 4242)") {
+		t.Errorf("stdout should report success; got %q", stdout.String())
+	}
+	if strings.Contains(stderr.String(), "did not exit") {
+		t.Errorf("stderr must not report a timeout failure; got %q", stderr.String())
+	}
+	// The CLI must have removed the discovery files itself, since the
+	// daemon could not.
+	if _, err := discovery.Read(stateDir); !errors.Is(err, discovery.ErrNotRunning) {
+		t.Errorf("daemon.json should be removed by the CLI; Read err = %v", err)
+	}
+}
+
+// TestRunDaemonStop_UnixSIGTERM_WaitsForSelfClean covers the graceful
+// path: the daemon self-cleans (selfCleans=true), so the CLI waits for
+// daemon.json to disappear before reporting success.
+func TestRunDaemonStop_UnixSIGTERM_WaitsForSelfClean(t *testing.T) {
+	t.Setenv("HOME", t.TempDir())
+	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+
+	if err := discovery.Write(stateDir, discovery.Info{
+		URL:       "http://127.0.0.1:1",
+		PID:       4243,
+		Version:   "unix",
+		StartedAt: time.Now().UTC(),
+	}); err != nil {
+		t.Fatal(err)
+	}
+
+	// Simulate SIGTERM to a real daemon: the signal succeeds and the
+	// daemon will self-clean. Mimic the shutdown defer by removing the
+	// discovery files asynchronously so the CLI's wait loop observes it.
+	withSignalDaemonStop(t, func(int) (bool, bool, error) {
+		go func() {
+			time.Sleep(20 * time.Millisecond)
+			_ = discovery.Remove(stateDir)
+		}()
+		return false, true, nil
+	})
+
+	var stdout, stderr bytes.Buffer
+	code := runDaemonStop(nil, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "stopped (pid 4243)") {
+		t.Errorf("stdout should report success; got %q", stdout.String())
 	}
 }
 

--- a/cmd/aileron/daemon_cli_unix.go
+++ b/cmd/aileron/daemon_cli_unix.go
@@ -9,16 +9,19 @@ import (
 
 // signalDaemonStop sends SIGTERM to pid for graceful shutdown. The
 // daemon's own signal handler tears down the listener and removes
-// daemon.json/daemon.pid via its shutdown defer (see internal/server).
+// daemon.json/daemon.pid via its shutdown defer (see internal/server),
+// so selfCleans is true: the caller waits for the daemon to remove its
+// own discovery files rather than removing them itself.
 //
-// Returns (true, nil) when the PID is not alive (ESRCH) — the caller
-// treats this as a stale daemon.json from a prior crash and cleans up.
-func signalDaemonStop(pid int) (notRunning bool, err error) {
+// Returns (notRunning=true, selfCleans=false, nil) when the PID is not
+// alive (ESRCH) — the caller treats this as a stale daemon.json from a
+// prior crash and cleans up.
+func signalDaemonStop(pid int) (notRunning, selfCleans bool, err error) {
 	if err := syscall.Kill(pid, syscall.SIGTERM); err != nil {
 		if errors.Is(err, syscall.ESRCH) {
-			return true, nil
+			return true, false, nil
 		}
-		return false, err
+		return false, false, err
 	}
-	return false, nil
+	return false, true, nil
 }

--- a/cmd/aileron/daemon_cli_windows.go
+++ b/cmd/aileron/daemon_cli_windows.go
@@ -10,28 +10,31 @@ import (
 // signalDaemonStop terminates the daemon process. Windows has no SIGTERM
 // equivalent that flows to a non-console child in another session, so
 // this calls TerminateProcess (via os.Process.Kill). The daemon's
-// shutdown defer does NOT run, so daemon.json and daemon.pid may be
-// left behind — the next aileron command will detect the stale entry
-// (via this same function returning notRunning=true) and clean up.
+// shutdown defer does NOT run, so daemon.json and daemon.pid are left
+// behind. selfCleans is therefore false on a successful kill: the caller
+// must remove the discovery files itself instead of waiting for the
+// daemon to perform cleanup it can never run.
 //
-// Returns (true, nil) when the PID is not alive — either FindProcess
-// failed to open the process (e.g. PID does not exist), or Kill
-// reported the process was already done.
-func signalDaemonStop(pid int) (notRunning bool, err error) {
+// Returns (notRunning=true, selfCleans=false, nil) when the PID is not
+// alive — either FindProcess failed to open the process (e.g. PID does
+// not exist), or Kill reported the process was already done.
+func signalDaemonStop(pid int) (notRunning, selfCleans bool, err error) {
 	proc, err := os.FindProcess(pid)
 	if err != nil {
 		// On Windows os.FindProcess returns an error when OpenProcess
 		// fails — typically because the PID doesn't exist or the caller
 		// lacks permission. Treat both as "not running" for daemon stop:
 		// either the daemon is gone, or we can't terminate it anyway.
-		return true, nil
+		return true, false, nil
 	}
 	defer func() { _ = proc.Release() }()
 	if err := proc.Kill(); err != nil {
 		if errors.Is(err, os.ErrProcessDone) {
-			return true, nil
+			return true, false, nil
 		}
-		return false, err
+		return false, false, err
 	}
-	return false, nil
+	// Kill via TerminateProcess is abrupt and uncatchable, so the daemon
+	// never runs its shutdown defer. The caller cleans up discovery files.
+	return false, false, nil
 }


### PR DESCRIPTION
## Summary

Fixes #1403: on Windows, `aileron stop` errored on every first invocation with `daemon did not exit within 5s; daemon.json still present` (exit 1); a second run then reported the daemon wasn't running and removed the stale file.

Root cause: the Windows kill uses `TerminateProcess` (via `os.Process.Kill`), which is abrupt and uncatchable, so the daemon never runs its shutdown defer and never removes its own `daemon.json`/`daemon.pid`. But `runDaemonStop` entered the same wait-for-the-daemon-to-self-clean loop the Unix SIGTERM path uses. On Windows that file never disappears, so the loop spun the full 5s and exited 1.

The fix surfaces the platform difference explicitly. `signalDaemonStop` now returns a `selfCleans` bool:

- **Unix (SIGTERM)** → `selfCleans=true`: the daemon removes its files in its shutdown defer; the CLI keeps waiting for them to disappear (unchanged behavior).
- **Windows (TerminateProcess)** → `selfCleans=false`: the CLI removes the discovery files itself via `discovery.Remove` and reports success immediately on the first call.

## Changes

- `cmd/aileron/daemon_cli_unix.go` / `daemon_cli_windows.go` — `signalDaemonStop` returns `(notRunning, selfCleans, err)`.
- `cmd/aileron/daemon_cli.go` — `runDaemonStop` branches on `selfCleans`; on `false` it removes the discovery files and exits 0. Adds a `signalDaemonStopFn` seam so the platform-specific stop path is testable on any host.

## Test plan

- New `TestRunDaemonStop_WindowsKill_CLICleansUp` regression test: simulates the Windows kill (succeeds, daemon does NOT self-clean) and asserts the CLI removes `daemon.json` and reports success with exit 0 on the **first** call — fails before the fix (would spin the loop and exit 1), passes after.
- New `TestRunDaemonStop_UnixSIGTERM_WaitsForSelfClean` covers the graceful path (daemon self-cleans, CLI waits).
- Existing stop/stale/dispatch tests updated for the new signature; all green.
- `GOOS=windows go build` and `GOOS=windows go vet` of `./cmd/aileron/` pass (build-tagged Windows file compiles).
- `go test ./cmd/aileron/` green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `aileron vault delete` now accepts agent names directly (as shown by `vault list`) instead of requiring full paths.

* **Bug Fixes**
  * Improved daemon stop behavior to handle platforms where the daemon cannot self-clean; CLI now removes discovery files as needed for graceful shutdown.

* **Documentation**
  * Updated vault command documentation and examples to reflect simplified delete syntax using agent names.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->