### PR TITLE
fix(launch): unwrap Scoop shim to real aileron-mcp path in agent MCP config

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -189,10 +189,79 @@ func resolveSibling(selfPath, name string) (string, error) {
 	for _, c := range siblingCandidates(name, exeSuffix()) {
 		candidate := filepath.Join(dir, c)
 		if _, err := os.Stat(candidate); err == nil {
-			return filepath.Abs(candidate)
+			abs, err := filepath.Abs(candidate)
+			if err != nil {
+				return "", err
+			}
+			return resolveShimTarget(abs), nil
 		}
 	}
-	return exec.LookPath(name)
+	found, err := exec.LookPath(name)
+	if err != nil {
+		return "", err
+	}
+	return resolveShimTarget(found), nil
+}
+
+// resolveShimTarget unwraps a Scoop shim to the real binary it launches.
+//
+// On a Scoop install (Windows), `aileron-mcp.exe` on PATH / next to
+// `aileron.exe` is not the real binary but a ~133 KB kiennq launcher
+// stub. Scoop records the real target in a co-located `<name>.shim`
+// sidecar as `path = "...\apps\aileron\current\aileron-mcp.exe"`. The
+// stub re-execs that target and works fine standalone, but an agent that
+// spawns the command under a Windows sandbox (e.g. Codex with
+// `[windows] sandbox = "elevated"`) fails to launch the stub with
+// `OS error 2` (issue #1405). Writing the real target into the agent's
+// MCP config instead of the shim path avoids the indirection so the MCP
+// server starts on first launch.
+//
+// When no sidecar is present, or it cannot be read/parsed, or the target
+// it names does not exist on disk, the original path is returned
+// unchanged — this is a best-effort unwrap that never makes a working
+// path worse. The lookup is keyed off the sidecar (not GOOS) so a shim
+// layout planted in a test resolves on any host.
+func resolveShimTarget(binPath string) string {
+	shimPath := strings.TrimSuffix(binPath, filepath.Ext(binPath)) + ".shim"
+	data, err := os.ReadFile(shimPath)
+	if err != nil {
+		return binPath
+	}
+	target := parseShimPath(string(data))
+	if target == "" {
+		return binPath
+	}
+	if !filepath.IsAbs(target) {
+		target = filepath.Join(filepath.Dir(binPath), target)
+	}
+	if _, err := os.Stat(target); err != nil {
+		return binPath
+	}
+	abs, err := filepath.Abs(target)
+	if err != nil {
+		return binPath
+	}
+	return abs
+}
+
+// parseShimPath extracts the real binary path from the contents of a
+// Scoop `.shim` sidecar, whose body is an INI-like list of `key = value`
+// lines. It returns the value of the first `path` key (surrounding
+// double quotes stripped), or "" when no `path` key is present.
+func parseShimPath(contents string) string {
+	for _, line := range strings.Split(contents, "\n") {
+		key, value, ok := strings.Cut(line, "=")
+		if !ok {
+			continue
+		}
+		if strings.TrimSpace(key) != "path" {
+			continue
+		}
+		value = strings.TrimSpace(value)
+		value = strings.Trim(value, `"`)
+		return value
+	}
+	return ""
 }
 
 // resolveMCPBinary locates aileron-mcp. The MCP server is a required

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -185,15 +185,18 @@ func siblingCandidates(name, suffix string) []string {
 // fallback and already applies %PATHEXT% on Windows, so it needs no
 // extra handling.
 func resolveSibling(selfPath, name string) (string, error) {
+	// Absolutize once so the sibling candidate (and any shim target
+	// resolved relative to it) is absolute without a per-candidate
+	// filepath.Abs guard. A relative selfPath (e.g. os.Args[0]) is
+	// resolved against the cwd here.
+	if abs, err := filepath.Abs(selfPath); err == nil {
+		selfPath = abs
+	}
 	dir := filepath.Dir(selfPath)
 	for _, c := range siblingCandidates(name, exeSuffix()) {
 		candidate := filepath.Join(dir, c)
 		if _, err := os.Stat(candidate); err == nil {
-			abs, err := filepath.Abs(candidate)
-			if err != nil {
-				return "", err
-			}
-			return resolveShimTarget(abs), nil
+			return resolveShimTarget(candidate), nil
 		}
 	}
 	found, err := exec.LookPath(name)
@@ -221,6 +224,10 @@ func resolveSibling(selfPath, name string) (string, error) {
 // unchanged — this is a best-effort unwrap that never makes a working
 // path worse. The lookup is keyed off the sidecar (not GOOS) so a shim
 // layout planted in a test resolves on any host.
+//
+// binPath is expected to be absolute (resolveSibling absolutizes before
+// calling). A relative `path` value in the sidecar is resolved against
+// binPath's directory, so the returned target is absolute too.
 func resolveShimTarget(binPath string) string {
 	shimPath := strings.TrimSuffix(binPath, filepath.Ext(binPath)) + ".shim"
 	data, err := os.ReadFile(shimPath)
@@ -237,11 +244,7 @@ func resolveShimTarget(binPath string) string {
 	if _, err := os.Stat(target); err != nil {
 		return binPath
 	}
-	abs, err := filepath.Abs(target)
-	if err != nil {
-		return binPath
-	}
-	return abs
+	return target
 }
 
 // parseShimPath extracts the real binary path from the contents of a

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -657,6 +657,120 @@ func TestResolveSibling_FindsHostSibling(t *testing.T) {
 	}
 }
 
+// TestResolveSibling_UnwrapsScoopShim is the regression test for #1405:
+// on a Scoop install the sibling next to `aileron` is the ~133 KB Scoop
+// launcher stub, not the real binary, and an agent that spawns it under a
+// Windows sandbox (Codex) fails with OS error 2. resolveSibling must read
+// the co-located `<name>.shim` sidecar and write the real target into the
+// agent's MCP config instead of the stub path. The lookup is keyed off the
+// sidecar (not GOOS) so it is verifiable from any host.
+func TestResolveSibling_UnwrapsScoopShim(t *testing.T) {
+	dir := t.TempDir()
+	selfPath := filepath.Join(dir, "aileron"+exeSuffix())
+	if err := os.WriteFile(selfPath, []byte("self"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// The Scoop shim stub sits next to aileron; the real binary lives under
+	// apps/.../current. parseShimPath unwraps the stub to the real target.
+	stub := filepath.Join(dir, "aileron-mcp"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("scoop shim stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realDir := filepath.Join(dir, "apps", "aileron", "current")
+	if err := os.MkdirAll(realDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBin := filepath.Join(realDir, "aileron-mcp"+exeSuffix())
+	if err := os.WriteFile(realBin, []byte("the real 14 MB binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sidecar := filepath.Join(dir, "aileron-mcp.shim")
+	if err := os.WriteFile(sidecar, []byte("path = \""+realBin+"\"\nargs = \n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveSibling(selfPath, "aileron-mcp")
+	if err != nil {
+		t.Fatalf("resolveSibling: %v", err)
+	}
+	want, _ := filepath.Abs(realBin)
+	if got != want {
+		t.Fatalf("resolveSibling = %q, want the real target %q (not the Scoop shim stub)", got, want)
+	}
+}
+
+// TestResolveSibling_NoShimSidecarReturnsSiblingUnchanged confirms the
+// common (non-Scoop) layout is untouched: with no `<name>.shim` sidecar,
+// resolveSibling returns the sibling itself, not an empty or altered path.
+func TestResolveSibling_NoShimSidecarReturnsSiblingUnchanged(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("bare-named sibling is not the Windows on-disk shape; covered by siblingCandidates tests")
+	}
+	dir := t.TempDir()
+	selfPath := filepath.Join(dir, "aileron")
+	if err := os.WriteFile(selfPath, []byte("self"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	mcp := filepath.Join(dir, "aileron-mcp")
+	if err := os.WriteFile(mcp, []byte("real binary, no shim"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	got, err := resolveSibling(selfPath, "aileron-mcp")
+	if err != nil {
+		t.Fatalf("resolveSibling: %v", err)
+	}
+	want, _ := filepath.Abs(mcp)
+	if got != want {
+		t.Fatalf("resolveSibling = %q, want %q (sibling unchanged when no shim sidecar)", got, want)
+	}
+}
+
+// TestResolveShimTarget_MissingTargetFallsBackToShim guards the
+// best-effort contract: a `.shim` sidecar that names a target which does
+// not exist on disk (stale/broken shim) must leave the original path
+// unchanged rather than returning a dangling path the agent cannot spawn.
+func TestResolveShimTarget_MissingTargetFallsBackToShim(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "aileron-mcp"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sidecar := filepath.Join(dir, "aileron-mcp.shim")
+	missing := filepath.Join(dir, "does-not-exist", "aileron-mcp"+exeSuffix())
+	if err := os.WriteFile(sidecar, []byte("path = \""+missing+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveShimTarget(stub); got != stub {
+		t.Fatalf("resolveShimTarget = %q, want original stub %q when target is missing", got, stub)
+	}
+}
+
+// TestParseShimPath covers the sidecar parser's contract directly: it
+// returns the first `path` value with surrounding quotes stripped, and ""
+// when no `path` key is present.
+func TestParseShimPath(t *testing.T) {
+	for _, c := range []struct {
+		name string
+		in   string
+		want string
+	}{
+		// A real Scoop .shim records the path verbatim with single
+		// backslashes (it is not TOML, so there is no escaping to undo);
+		// parseShimPath only strips the surrounding quotes.
+		{"quoted windows path", `path = "C:\Users\alr\scoop\apps\aileron\current\aileron-mcp.exe"` + "\nargs = \n", `C:\Users\alr\scoop\apps\aileron\current\aileron-mcp.exe`},
+		{"unquoted", "path = /usr/local/bin/real\n", "/usr/local/bin/real"},
+		{"no path key", "args = --foo\nother = bar\n", ""},
+		{"empty", "", ""},
+		{"path among other keys", "args = x\npath = /real\n", "/real"},
+	} {
+		t.Run(c.name, func(t *testing.T) {
+			if got := parseShimPath(c.in); got != c.want {
+				t.Fatalf("parseShimPath(%q) = %q, want %q", c.in, got, c.want)
+			}
+		})
+	}
+}
+
 // TestValidateSandboxRuntimeRejectsPodman is the launch-path regression
 // test for #1051: --sandbox=podman must fail validation with the
 // Docker-only message. The runtime seam (the runtimeName parameter)

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -745,6 +745,49 @@ func TestResolveShimTarget_MissingTargetFallsBackToShim(t *testing.T) {
 	}
 }
 
+// TestResolveShimTarget_NoPathKeyReturnsBinUnchanged covers a sidecar
+// that exists but declares no `path` key: parseShimPath yields "" and the
+// original binary path must be returned, never an empty string.
+func TestResolveShimTarget_NoPathKeyReturnsBinUnchanged(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "aileron-mcp"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sidecar := filepath.Join(dir, "aileron-mcp.shim")
+	if err := os.WriteFile(sidecar, []byte("args = --foo\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if got := resolveShimTarget(stub); got != stub {
+		t.Fatalf("resolveShimTarget = %q, want original stub %q when sidecar has no path key", got, stub)
+	}
+}
+
+// TestResolveShimTarget_RelativeTargetResolvesAgainstBinDir covers the
+// defensive normalization for a sidecar whose `path` is relative: it is
+// resolved against the stub's directory before the existence check, and
+// the absolute real target is returned.
+func TestResolveShimTarget_RelativeTargetResolvesAgainstBinDir(t *testing.T) {
+	dir := t.TempDir()
+	stub := filepath.Join(dir, "aileron-mcp"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realName := "real-aileron-mcp" + exeSuffix()
+	if err := os.WriteFile(filepath.Join(dir, realName), []byte("real binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	sidecar := filepath.Join(dir, "aileron-mcp.shim")
+	if err := os.WriteFile(sidecar, []byte("path = "+realName+"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	got := resolveShimTarget(stub)
+	want, _ := filepath.Abs(filepath.Join(dir, realName))
+	if got != want {
+		t.Fatalf("resolveShimTarget = %q, want %q (relative target resolved against bin dir)", got, want)
+	}
+}
+
 // TestParseShimPath covers the sidecar parser's contract directly: it
 // returns the first `path` value with surrounding quotes stripped, and ""
 // when no `path` key is present.


### PR DESCRIPTION
## Summary

Fixes #1405. On a Scoop install (Windows), the `aileron-mcp.exe` next to `aileron.exe` (and on PATH) is the ~133 KB Scoop launcher **stub**, not the real binary. `resolveSibling` found that stub and wrote its path into the agent's MCP config (e.g. Codex's `config.toml`). The stub re-execs the real binary and works standalone, but Codex spawns it under a Windows sandbox and the indirection fails to launch with `OS error 2` — so `aileron` appeared in `/mcp` with **no tools**.

`resolveSibling` now reads the co-located `<name>.shim` sidecar Scoop writes:

```
path = "C:\Users\alr\scoop\apps\aileron\current\aileron-mcp.exe"
```

and resolves to that real target before it is written into any agent MCP config, so the MCP server starts on first launch. The unwrap is **best-effort** and keyed off the sidecar (not GOOS): with no sidecar, an unreadable sidecar, or a target that no longer exists on disk, the original path is returned unchanged, so the common non-Scoop layout is untouched. The same indirection would hit any agent that spawns the MCP command, so the fix lives in the shared resolver rather than the Codex path.

### Relationship to prior issues
- #1390 fixed a **different** failure mode (side-by-side layout, missing `.exe` suffix). This is the unaddressed root cause behind the persistent #1387 symptom, not a regression of #1390.

## Test plan

New tests in `internal/launch/launcher_internal_test.go` (portable — keyed off the sidecar, run on Linux CI):

- `TestResolveSibling_UnwrapsScoopShim` — plants a stub + `<name>.shim` sidecar + real target; asserts `resolveSibling` returns the **real** target, not the stub. Regression for #1405.
- `TestResolveSibling_NoShimSidecarReturnsSiblingUnchanged` — no sidecar -> sibling unchanged (common layout untouched).
- `TestResolveShimTarget_MissingTargetFallsBackToShim` — sidecar names a missing target -> original path returned (best-effort contract).
- `TestParseShimPath` — table test for the sidecar parser (quoted Windows path, unquoted, no `path` key, empty, path among other keys).

`go test ./internal/launch/...` green; `go vet` clean. `parseShimPath` 100% covered; `resolveShimTarget` 80% (remaining branches are defensive fallbacks).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
