### PR TITLE
fix(spawn): raise daemon spawn timeout for Windows cold start

### DIFF
--- a/cmd/aileron/daemon_cli.go
+++ b/cmd/aileron/daemon_cli.go
@@ -55,7 +55,7 @@ func runDaemonStart(_ []string, stdout, stderr io.Writer) int {
 		fmt.Fprintln(stderr, "Hint: run 'task build:server' to build it next to the aileron binary.")
 		return 1
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), spawn.ResolveContextBudget)
 	defer cancel()
 	url, err := spawnResolveFn(ctx, spawn.Options{
 		StateDir: stateDir,

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -616,7 +616,7 @@ func spawnResolveOnce() (string, error) {
 	if err != nil {
 		return "", fmt.Errorf("locate daemon binary: %w", err)
 	}
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+	ctx, cancel := context.WithTimeout(context.Background(), spawn.ResolveContextBudget)
 	defer cancel()
 	raw, err := spawnResolveFn(ctx, spawn.Options{
 		StateDir: stateDir,

--- a/internal/daemon/spawn/spawn.go
+++ b/internal/daemon/spawn/spawn.go
@@ -58,7 +58,16 @@ type Options struct {
 	BinaryArgs []string
 
 	// SpawnTimeout caps how long Resolve waits for daemon.json after
-	// triggering a spawn. Default 5s.
+	// triggering a spawn. Defaults to defaultSpawnTimeout.
+	//
+	// This is a poll deadline for a daemon that is on its way up, not a
+	// liveness budget: a genuinely dead daemon is detected immediately
+	// via the SpawnFn `exited` channel (see waitForDaemon), so a long
+	// SpawnTimeout never makes a real failure hang. It only buys a
+	// slow-but-healthy cold start the time it needs — notably on Windows,
+	// where process creation, exe load, and a first-run Defender scan of
+	// the freshly built daemon binary routinely push readiness past a few
+	// seconds.
 	SpawnTimeout time.Duration
 
 	// PollInterval is how often Resolve polls daemon.json after
@@ -78,6 +87,26 @@ type Options struct {
 // the helper has nothing to fork-exec.
 var ErrNoBinary = errors.New("daemon binary path is empty (set Options.Binary)")
 
+// defaultSpawnTimeout is the poll deadline applied when Options.SpawnTimeout
+// is unset. It is deliberately generous: every CLI caller already wraps
+// Resolve in an outer context (the launcher and `aileron daemon start`
+// both pass a context larger than this), and a genuinely dead daemon fails
+// fast via the SpawnFn `exited` channel regardless of this value. The
+// budget therefore only governs how long a slow-but-healthy cold start is
+// given to publish daemon.json. The previous 5s tripped on Windows cold
+// starts (slower process creation plus a first-run Defender scan of the
+// freshly built daemon binary), reporting a startup failure for a daemon
+// that was in fact coming up fine; 30s clears that window with margin.
+const defaultSpawnTimeout = 30 * time.Second
+
+// ResolveContextBudget is the outer-context timeout callers should apply
+// when wrapping Resolve. It sits above defaultSpawnTimeout so the inner
+// poll deadline expires first and Resolve returns its diagnostic timeout
+// error (with a daemon-log tail) rather than a bare context.DeadlineExceeded.
+// Callers that build their own context.WithTimeout around Resolve should
+// use this value so the two budgets stay in agreement.
+const ResolveContextBudget = defaultSpawnTimeout + 5*time.Second
+
 // Resolve returns the URL of the running Aileron daemon, spawning
 // one if none is reachable. The fast path is one daemon.json read
 // plus a sub-millisecond TCP probe; the spawn path acquires a
@@ -95,7 +124,7 @@ func Resolve(ctx context.Context, opts Options) (string, error) {
 	}
 
 	if opts.SpawnTimeout <= 0 {
-		opts.SpawnTimeout = 5 * time.Second
+		opts.SpawnTimeout = defaultSpawnTimeout
 	}
 	if opts.PollInterval <= 0 {
 		opts.PollInterval = 50 * time.Millisecond

--- a/internal/daemon/spawn/spawn_test.go
+++ b/internal/daemon/spawn/spawn_test.go
@@ -684,3 +684,82 @@ func TestResolve_TimeoutWithoutLogStillReturnsTimeoutError(t *testing.T) {
 		t.Errorf("error %q should mention timeout", err.Error())
 	}
 }
+
+// TestResolve_DefaultTimeout_ToleratesSlowColdStart is the regression
+// for #1404: a cold `aileron launch` on Windows reported "daemon did
+// not become ready within 5s" because the unset SpawnTimeout defaulted
+// to 5s, which is shorter than a Windows cold start (slower process
+// creation plus a first-run Defender scan of the freshly built daemon
+// binary). The daemon was coming up fine; the poll window was just too
+// short, so a retry — hitting the now-published daemon.json — succeeded.
+//
+// Contract: with SpawnTimeout left unset, Resolve must keep polling
+// past the old 5s window for a daemon that is still on its way up. The
+// daemon here publishes daemon.json after 5.5s; the pre-fix 5s default
+// would have timed out before that, the 30s default resolves cleanly.
+//
+// Tagged slow via a guard so `go test -short` skips the multi-second
+// wait; the full suite (and CI) still exercises it.
+func TestResolve_DefaultTimeout_ToleratesSlowColdStart(t *testing.T) {
+	if testing.Short() {
+		t.Skip("skips the multi-second cold-start wait in -short mode")
+	}
+	dir := t.TempDir()
+
+	got, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:     dir,
+		EnvLookup:    emptyEnv,
+		PollInterval: 25 * time.Millisecond,
+		// SpawnTimeout deliberately unset — exercises the default.
+		SpawnFn: func(_ context.Context, stateDir string) (<-chan error, error) {
+			// Publish daemon.json only after the old 5s default would
+			// have already fired, simulating a slow Windows cold start.
+			go func() {
+				time.Sleep(5500 * time.Millisecond)
+				_, _ = fakeDaemon(t, stateDir)
+			}()
+			return nil, nil
+		},
+	})
+	if err != nil {
+		t.Fatalf("Resolve with default timeout should tolerate a slow cold start, got: %v", err)
+	}
+	if got == "" {
+		t.Fatal("got empty URL")
+	}
+}
+
+// TestResolve_DefaultTimeout_StillFailsFastOnDeadDaemon guards the
+// other half of the #1404 fix: lengthening the default poll window must
+// not make a genuinely dead daemon hang. A daemon that exits before
+// publishing daemon.json is detected immediately via the SpawnFn
+// `exited` channel, so Resolve returns its early-exit error well before
+// the (now 30s) default SpawnTimeout — not after it.
+func TestResolve_DefaultTimeout_StillFailsFastOnDeadDaemon(t *testing.T) {
+	dir := t.TempDir()
+
+	exited := make(chan error, 1)
+	exited <- errors.New("exit status 1")
+
+	start := time.Now()
+	_, err := spawn.Resolve(context.Background(), spawn.Options{
+		StateDir:     dir,
+		EnvLookup:    emptyEnv,
+		PollInterval: 25 * time.Millisecond,
+		// SpawnTimeout unset — the long default must not govern this path.
+		SpawnFn: func(context.Context, string) (<-chan error, error) {
+			return exited, nil
+		},
+	})
+	elapsed := time.Since(start)
+
+	if err == nil {
+		t.Fatal("expected early-exit error, got nil")
+	}
+	if !strings.Contains(err.Error(), "exited before becoming ready") {
+		t.Errorf("error %q should mention early exit", err.Error())
+	}
+	if elapsed > 1*time.Second {
+		t.Errorf("Resolve took %s; a dead daemon must fail fast via the exited channel, not wait the default SpawnTimeout", elapsed)
+	}
+}

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -494,7 +494,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 		}
 		opts.Binary = binary
 	}
-	resolveCtx, cancelResolve := context.WithTimeout(ctx, 10*time.Second)
+	resolveCtx, cancelResolve := context.WithTimeout(ctx, spawn.ResolveContextBudget)
 	daemonURL, err := spawn.Resolve(resolveCtx, opts)
 	cancelResolve()
 	if err != nil {


### PR DESCRIPTION
## Summary

Fixes #1404. A cold `aileron launch <agent>` on Windows frequently reported `daemon did not become ready within 5s` (with an alarming daemon-log tail) even though the daemon was coming up fine — a Windows cold start (slower process creation plus a first-run Defender scan of the freshly built daemon binary) routinely exceeds 5s. Because the daemon is spawned detached, it kept starting after the failed `launch`, so a retry hit the now-published `daemon.json` and succeeded. The user learned to "just run it again" — a poor first-run experience.

### Root cause

`spawn.Resolve` left `Options.SpawnTimeout` unset, defaulting to **5s**, which capped the poll loop before the callers' **10s** outer context could ever help. The two budgets disagreed, so the extra 5s of context was dead.

### Fix

- Raise the default `SpawnTimeout` to **30s** (named constant `defaultSpawnTimeout`), generous enough to absorb a Windows cold start.
- Add an exported `spawn.ResolveContextBudget` (= `defaultSpawnTimeout + 5s`) and point all three callers' outer contexts at it (`internal/launch/launcher.go`, `cmd/aileron/main.go`, `cmd/aileron/daemon_cli.go`). The outer context now sits just above the inner poll deadline, so the diagnostic timeout error (with daemon-log tail) surfaces instead of a bare `context.DeadlineExceeded`. The two budgets stay in agreement.

A genuinely dead daemon still fails fast via the existing `SpawnFn` `exited` channel, so the longer window only benefits a slow-but-healthy cold start; it never makes a real failure hang.

## Test plan

- `TestResolve_DefaultTimeout_ToleratesSlowColdStart` — regression for #1404: with `SpawnTimeout` unset, a daemon that publishes `daemon.json` after 5.5s (past the old 5s cap) resolves cleanly. Verified it **fails** at the old 5s default and **passes** at 30s.
- `TestResolve_DefaultTimeout_StillFailsFastOnDeadDaemon` — guards the other half: a daemon that exits before publishing fails fast via the `exited` channel (<1s), not after the 30s default.
- Full suites green: `go test ./internal/daemon/spawn/ ./internal/launch/ ./cmd/aileron/`.
- `go vet` clean; spawn package coverage 85.5%.
- CodeRabbit review: 0 findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)



Closes #1404
