### PR TITLE
fix(launch): inject AILERON_TOKEN into host MCP env

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -751,7 +751,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	if sandboxEnabled {
 		result, runErr = launchSandbox(ctx, sandboxPlan, config, agentEnv, containerName, captureOnce, sessionLog, proxyBootstrap.Mounts...)
 	} else {
-		result, runErr = launchHost(ctx, config, daemonURL, sessionID, agentEnv)
+		result, runErr = launchHost(ctx, config, daemonURL, sessionID, daemonToken, agentEnv)
 	}
 
 	// Capture fires on clean container exit (R15) and on the
@@ -872,7 +872,7 @@ func printStartupBanner(w io.Writer, daemonURL, sessionID, logPath string, vault
 	}
 }
 
-func launchHost(ctx context.Context, config LaunchConfig, daemonURL, sessionID string, agentEnv map[string]string) (LaunchResult, error) {
+func launchHost(ctx context.Context, config LaunchConfig, daemonURL, sessionID, daemonToken string, agentEnv map[string]string) (LaunchResult, error) {
 	agentPath, err := ResolveBinary(config.Agent.BinaryNames())
 	if err != nil {
 		return LaunchResult{}, fmt.Errorf("agent %q: %w", config.Agent.Name(), err)
@@ -887,12 +887,7 @@ func launchHost(ctx context.Context, config LaunchConfig, daemonURL, sessionID s
 	}
 
 	allArgs := append(config.Agent.Args(ModeHost), config.Args...)
-	mcpEnv := map[string]string{
-		"AILERON_URL":          daemonURL,
-		"AILERON_COMMS_URL":    daemonURL,
-		"AILERON_SESSION_ID":   sessionID,
-		"AILERON_APPROVAL_URL": daemonURL + "/approvals",
-	}
+	mcpEnv := hostMCPEnv(daemonURL, sessionID, daemonToken)
 	extraArgs, mcpMounts, mcpErr := config.Agent.ConfigureMCP(mcpBin, mcpEnv, config.Dir, ModeHost)
 	if mcpErr != nil {
 		return LaunchResult{}, fmt.Errorf("configuring MCP for %s: %w", config.Agent.Name(), mcpErr)
@@ -1202,6 +1197,36 @@ var sandboxSignalNotify = func(ch chan<- os.Signal, sigs ...os.Signal) {
 
 var sandboxSignalStop = func(ch chan<- os.Signal) {
 	signal.Stop(ch)
+}
+
+// hostMCPEnv builds the env block aileron-mcp reads when it runs as a
+// stdio subprocess of the agent under host launch (ModeHost). It mirrors
+// sandboxMCPEnv: the four daemon-coordinate vars are always present, and
+// AILERON_TOKEN is included only when the daemon advertises one.
+//
+// The token is load-bearing for the /v1/actions discovery call, which the
+// daemon gates behind Authorization: Bearer (only /v1/health,
+// /v1/auth/handshake, and the gateway paths skip auth). Codex spawns its
+// MCP server with only the declared config.toml env block, so without an
+// explicit AILERON_TOKEN here it 401s and silently falls back to the
+// built-in tools (issue #1406). Claude works regardless because Claude
+// Code's MCP child inherits the parent process env, but relying on that is
+// the bug.
+//
+// An empty token is omitted entirely rather than injected as an empty
+// value: an empty Bearer deterministically 401s, so writing the key would
+// only mask the "no token advertised" case as a malformed-token failure.
+func hostMCPEnv(daemonURL, sessionID, daemonToken string) map[string]string {
+	mcpEnv := map[string]string{
+		"AILERON_URL":          daemonURL,
+		"AILERON_COMMS_URL":    daemonURL,
+		"AILERON_SESSION_ID":   sessionID,
+		"AILERON_APPROVAL_URL": daemonURL + "/approvals",
+	}
+	if daemonToken != "" {
+		mcpEnv["AILERON_TOKEN"] = daemonToken
+	}
+	return mcpEnv
 }
 
 // sandboxMCPEnv builds the env block aileron-mcp reads when it runs as

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -127,6 +127,46 @@ func TestDaemonAPIBaseURLAppendsV1(t *testing.T) {
 	}
 }
 
+// TestHostMCPEnvIncludesTokenWhenAdvertised is the regression test for
+// issue #1406: host-launch aileron-mcp must receive AILERON_TOKEN so its
+// /v1/actions discovery call carries Authorization: Bearer. Without it
+// Codex's MCP server (which only sees the declared config env) 401s and
+// falls back to the built-in tools.
+func TestHostMCPEnvIncludesTokenWhenAdvertised(t *testing.T) {
+	const (
+		daemonURL = "http://127.0.0.1:48123"
+		sessionID = "sess-1406"
+		token     = "tok-abc123"
+	)
+	env := hostMCPEnv(daemonURL, sessionID, token)
+
+	if got := env["AILERON_TOKEN"]; got != token {
+		t.Fatalf("hostMCPEnv AILERON_TOKEN = %q, want %q", got, token)
+	}
+	wantBase := map[string]string{
+		"AILERON_URL":          daemonURL,
+		"AILERON_COMMS_URL":    daemonURL,
+		"AILERON_SESSION_ID":   sessionID,
+		"AILERON_APPROVAL_URL": daemonURL + "/approvals",
+	}
+	for k, want := range wantBase {
+		if got := env[k]; got != want {
+			t.Fatalf("hostMCPEnv[%q] = %q, want %q", k, got, want)
+		}
+	}
+}
+
+// TestHostMCPEnvOmitsEmptyToken asserts that an unadvertised (empty) token
+// is omitted entirely rather than written as AILERON_TOKEN="". An empty
+// Bearer deterministically 401s, so the key must be absent so aileron-mcp
+// treats it as "no token" rather than "malformed token".
+func TestHostMCPEnvOmitsEmptyToken(t *testing.T) {
+	env := hostMCPEnv("http://127.0.0.1:48123", "sess-1406", "")
+	if _, present := env["AILERON_TOKEN"]; present {
+		t.Fatalf("hostMCPEnv set AILERON_TOKEN with an empty token; want key absent")
+	}
+}
+
 func TestLaunchSandboxRejectsAgentWithoutBinary(t *testing.T) {
 	_, err := launchSandbox(nil, SandboxLaunchPlan{Runtime: "docker", Image: "image:test"}, LaunchConfig{
 		Agent: emptyBinaryAgent{},


### PR DESCRIPTION
## Summary

In host launch, `launchHost` (internal/launch/launcher.go) built the `aileron-mcp` env block with the daemon coordinates (`AILERON_URL`/`COMMS_URL`/`SESSION_ID`/`APPROVAL_URL`) but **no `AILERON_TOKEN`**. `aileron-mcp` sends `Authorization: Bearer <token>` on its `/v1/actions` discovery call, which the daemon gates behind auth (the middleware skip-list is only `/v1/health`, `/v1/auth/handshake`, and the gateway paths). With no token the call 401s and the agent silently falls back to the five built-in tools.

Claude masked the bug because Claude Code's MCP child inherits the parent process env (`buildEnv` merges `os.Environ()`). Codex spawns its MCP server with only the declared `config.toml` env block, so the omission bit only Codex.

### Change
- New testable helper `hostMCPEnv(daemonURL, sessionID, daemonToken)` mirroring `sandboxMCPEnv`: the four daemon coordinates are always present, and `AILERON_TOKEN` is included only when the daemon advertises one.
- An empty token is **omitted** entirely rather than injected as `AILERON_TOKEN=""`, since an empty Bearer deterministically 401s — writing the key would mask "no token advertised" as a malformed-token failure.
- Thread the already-in-scope `daemonToken` into `launchHost`.

No daemon/auth changes: the daemon correctly requires the token; only the client-side env wiring was wrong. Separate from #1405 (Scoop shim MCP startup); independently mergeable.

## Test plan
- `go test ./internal/launch/` — green.
- New regression tests in `launcher_internal_test.go`:
  - `TestHostMCPEnvIncludesTokenWhenAdvertised` — asserts the host MCP env contains `AILERON_TOKEN=<token>` plus the four daemon coordinates when a token is advertised.
  - `TestHostMCPEnvOmitsEmptyToken` — asserts the key is absent (not empty-valued) when no token is advertised.
- `hostMCPEnv` helper at 100% statement coverage.
- `go vet ./internal/launch/` and `gofmt -l` clean.

Closes #1406

🤖 Generated with [Claude Code](https://claude.com/claude-code)
