### PR TITLE
test(cmd): run full cmd/aileron suite on windows CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -207,9 +207,7 @@ jobs:
           # file-mode test runs here so %USERPROFILE% path resolution is
           # verified on a real Windows runner.
           (cd internal && go test -v -race -coverprofile=coverage-windows-internal.txt ./daemon/discovery/... ./daemon/spawn/... ./sandbox/... ./launch/hostimport/...)
-          # cmd/aileron's full suite is gated behind #577 on Windows.
-          # Run only the helpers with a Windows-specific implementation.
-          (cd cmd/aileron && go test -race -coverprofile=coverage-windows-aileron.txt -run 'TestSignalDaemonStop' .)
+          (cd cmd/aileron && go test -race -coverprofile=coverage-windows-aileron.txt .)
 
       - name: Upload coverage reports to Codecov
         uses: codecov/codecov-action@v7

--- a/cmd/aileron/daemon_cli_test.go
+++ b/cmd/aileron/daemon_cli_test.go
@@ -49,7 +49,7 @@ func TestRunDaemon_UnknownSubcommand(t *testing.T) {
 // --- daemon stop ---
 
 func TestRunDaemonStop_NoDaemon_IsIdempotent(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	var stdout, stderr bytes.Buffer
 	code := runDaemonStop(nil, &stdout, &stderr)
 	if code != 0 {
@@ -61,8 +61,8 @@ func TestRunDaemonStop_NoDaemon_IsIdempotent(t *testing.T) {
 }
 
 func TestRunDaemonStop_StaleDaemonJSON_CleansUp(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+	home := setTestHome(t)
+	stateDir := filepath.Join(home, ".aileron")
 
 	// Write daemon.json with a PID that's almost certainly not alive.
 	// PID 1 (init) exists on Unix, so use a fabricated high one.
@@ -91,7 +91,7 @@ func TestRunDaemonStop_StaleDaemonJSON_CleansUp(t *testing.T) {
 // --- daemon status ---
 
 func TestRunDaemonStatus_NoDaemon(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	var stdout, stderr bytes.Buffer
 	code := runDaemonStatus(nil, &stdout, &stderr)
 	if code != 0 {
@@ -103,8 +103,8 @@ func TestRunDaemonStatus_NoDaemon(t *testing.T) {
 }
 
 func TestRunDaemonStatus_RunningDaemon_RendersInfo(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+	home := setTestHome(t)
+	stateDir := filepath.Join(home, ".aileron")
 
 	// Bind a real loopback port so daemon.json carries a reachable URL.
 	ln, err := net.Listen("tcp", "127.0.0.1:0")
@@ -193,8 +193,8 @@ func TestProbeLocalVaultLocked_Non200(t *testing.T) {
 }
 
 func TestRunDaemonStatus_WithVaultProbe(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+	home := setTestHome(t)
+	stateDir := filepath.Join(home, ".aileron")
 
 	// Real httptest server that serves the local vault status endpoint.
 	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
@@ -241,7 +241,7 @@ func TestBindingAPIBaseURL_RespectsAILERON_API_URL(t *testing.T) {
 // --- runDaemon dispatch ---
 
 func TestRunDaemon_DispatchToStop(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	var stdout, stderr bytes.Buffer
 	code := runDaemon([]string{"stop"}, &stdout, &stderr)
 	if code != 0 {
@@ -265,7 +265,7 @@ func withSpawnResolve(t *testing.T, fn func(context.Context, spawn.Options) (str
 }
 
 func TestRunDaemonStart_HappyPath_PrintsURL(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 
 	withSpawnResolve(t, func(_ context.Context, opts spawn.Options) (string, error) {
 		// Sanity: opts.StateDir resolves to ~/.aileron under the test HOME.
@@ -278,12 +278,7 @@ func TestRunDaemonStart_HappyPath_PrintsURL(t *testing.T) {
 	// daemonBinaryPath looks for a sibling 'aileron-server' binary;
 	// when not found it falls back to PATH lookup, which will fail in
 	// test. Place a no-op binary on PATH so the resolution succeeds.
-	binDir := t.TempDir()
-	server := filepath.Join(binDir, "aileron-server")
-	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	stageServerOnPath(t)
 
 	var stdout, stderr bytes.Buffer
 	code := runDaemonStart(nil, &stdout, &stderr)
@@ -296,14 +291,9 @@ func TestRunDaemonStart_HappyPath_PrintsURL(t *testing.T) {
 }
 
 func TestRunDaemonStart_SpawnError_NonZeroExit(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 
-	binDir := t.TempDir()
-	server := filepath.Join(binDir, "aileron-server")
-	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	stageServerOnPath(t)
 
 	withSpawnResolve(t, func(context.Context, spawn.Options) (string, error) {
 		return "", errors.New("spawn-failed-on-purpose")
@@ -320,7 +310,7 @@ func TestRunDaemonStart_SpawnError_NonZeroExit(t *testing.T) {
 }
 
 func TestRunDaemonStart_BinaryNotFound_NonZeroExit(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	// Empty PATH and no sibling 'aileron-server' next to the test
 	// binary → daemonBinaryPath fails before spawn is even called.
 	t.Setenv("PATH", "")
@@ -341,13 +331,8 @@ func TestRunDaemonStart_BinaryNotFound_NonZeroExit(t *testing.T) {
 // --- spawnResolveOnce (the body that spawnResolveCached wraps) ---
 
 func TestSpawnResolveOnce_HappyPath(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	binDir := t.TempDir()
-	server := filepath.Join(binDir, "aileron-server")
-	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	setTestHome(t)
+	stageServerOnPath(t)
 
 	withSpawnResolve(t, func(_ context.Context, opts spawn.Options) (string, error) {
 		return "http://127.0.0.1:54321", nil
@@ -364,13 +349,8 @@ func TestSpawnResolveOnce_HappyPath(t *testing.T) {
 }
 
 func TestSpawnResolveOnce_TrimsTrailingSlash(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	binDir := t.TempDir()
-	server := filepath.Join(binDir, "aileron-server")
-	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	setTestHome(t)
+	stageServerOnPath(t)
 
 	withSpawnResolve(t, func(context.Context, spawn.Options) (string, error) {
 		return "http://127.0.0.1:54321/", nil
@@ -386,7 +366,7 @@ func TestSpawnResolveOnce_TrimsTrailingSlash(t *testing.T) {
 }
 
 func TestSpawnResolveOnce_BinaryMissing_Errors(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	t.Setenv("PATH", "")
 
 	_, err := spawnResolveOnce()
@@ -399,13 +379,8 @@ func TestSpawnResolveOnce_BinaryMissing_Errors(t *testing.T) {
 }
 
 func TestSpawnResolveOnce_PropagatesSpawnError(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	binDir := t.TempDir()
-	server := filepath.Join(binDir, "aileron-server")
-	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
-		t.Fatal(err)
-	}
-	t.Setenv("PATH", binDir+":"+os.Getenv("PATH"))
+	setTestHome(t)
+	stageServerOnPath(t)
 
 	wantErr := errors.New("kaboom")
 	withSpawnResolve(t, func(context.Context, spawn.Options) (string, error) {
@@ -450,12 +425,12 @@ func TestSignalDaemonStop_NotRunningPID(t *testing.T) {
 // --- defaultStateDir / daemonBinaryPath ---
 
 func TestDefaultStateDir_UnderHome(t *testing.T) {
-	t.Setenv("HOME", "/test/home")
+	home := setTestHome(t)
 	got, err := defaultStateDir()
 	if err != nil {
 		t.Fatalf("defaultStateDir: %v", err)
 	}
-	want := "/test/home/.aileron"
+	want := filepath.Join(home, ".aileron")
 	if got != want {
 		t.Errorf("got %q, want %q", got, want)
 	}
@@ -501,9 +476,10 @@ func TestDaemonBinaryPath_FindsSibling(t *testing.T) {
 func TestDaemonBinaryPath_FallsBackToPATH(t *testing.T) {
 	// No sibling 'aileron-server' near the test binary (we don't write
 	// one), so resolution should fall back to PATH lookup. Place one
-	// on PATH — mirrors the Homebrew install layout.
+	// on PATH — mirrors the Homebrew install layout. The exeSuffix keeps
+	// exec.LookPath able to find it on Windows.
 	binDir := t.TempDir()
-	server := filepath.Join(binDir, "aileron-server")
+	server := filepath.Join(binDir, "aileron-server"+exeSuffix)
 	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
 		t.Fatal(err)
 	}
@@ -536,7 +512,7 @@ func TestDaemonBinaryPath_NotFound(t *testing.T) {
 }
 
 func TestRunDaemon_DispatchToStatus(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	var stdout, stderr bytes.Buffer
 	code := runDaemon([]string{"status"}, &stdout, &stderr)
 	if code != 0 {

--- a/cmd/aileron/keyring_test.go
+++ b/cmd/aileron/keyring_test.go
@@ -32,14 +32,12 @@ func genTestKey(t *testing.T) (ed25519.PublicKey, []byte) {
 	return pub, pemBytes
 }
 
-// withTempHome points $HOME at a fresh temp dir for the test, so the
-// CLI's DefaultKeyringPath() lands inside the test's filesystem and
-// the test does not pollute the user's real ~/.aileron.
+// withTempHome points the home directory at a fresh temp dir for the
+// test, so the CLI's DefaultKeyringPath() lands inside the test's
+// filesystem and the test does not pollute the user's real ~/.aileron.
 func withTempHome(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
-	return dir
+	return setTestHome(t)
 }
 
 // withMockGitHubRaw stands up an httptest server that mimics

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -892,8 +892,7 @@ func TestRunSandboxPlanSurfacesParseError(t *testing.T) {
 }
 
 func TestRunStatus_All(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := setTestHome(t)
 	oldWd, _ := os.Getwd()
 	os.Chdir(dir)
 	defer os.Chdir(oldWd)
@@ -916,8 +915,7 @@ func TestRunStatus_All(t *testing.T) {
 }
 
 func TestRunStatus_Notifications(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := setTestHome(t)
 	configDir := filepath.Join(dir, ".aileron")
 	os.MkdirAll(configDir, 0o755)
 	os.WriteFile(filepath.Join(configDir, "config.yaml"), []byte(`
@@ -947,8 +945,7 @@ notifications:
 }
 
 func TestRunStatus_Vault(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t)
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"status", "vault"}, newTestRegistry(), &stdout, &stderr)
@@ -962,8 +959,7 @@ func TestRunStatus_Vault(t *testing.T) {
 }
 
 func TestRunStatus_VaultWithSecrets(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := setTestHome(t)
 
 	vaultPath := filepath.Join(dir, ".aileron", "secrets.json")
 	os.MkdirAll(filepath.Dir(vaultPath), 0o700)
@@ -1085,8 +1081,7 @@ func TestRunStatus_RuntimeReachable(t *testing.T) {
 // existing sections. Operators reach for `aileron status` first; the
 // daemon snapshot must be there without an extra subcommand.
 func TestRunStatus_RuntimeIncludedInDefault(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := setTestHome(t)
 	oldWd, _ := os.Getwd()
 	os.Chdir(dir)
 	defer os.Chdir(oldWd)
@@ -1145,8 +1140,7 @@ func TestRunSecret_SetNoName(t *testing.T) {
 }
 
 func TestRunSecret_ListEmpty(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t)
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"secret", "list"}, newTestRegistry(), &stdout, &stderr)
@@ -1162,8 +1156,7 @@ func TestRunSecret_ListEmpty(t *testing.T) {
 }
 
 func TestRunSecret_ListWithSecrets(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := setTestHome(t)
 
 	// Pre-populate the vault file directly (skip encryption for test).
 	vaultPath := filepath.Join(dir, ".aileron", "secrets.json")
@@ -1188,8 +1181,7 @@ func TestRunSecret_ListWithSecrets(t *testing.T) {
 // not the human-targeted prose. Lets scripts detect "nothing here yet"
 // without grepping for "No secrets stored".
 func TestRunSecret_ListJSON_Empty(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	setTestHome(t)
 
 	var stdout, stderr bytes.Buffer
 	code := run([]string{"secret", "list", "--json"}, newTestRegistry(), &stdout, &stderr)
@@ -1204,8 +1196,7 @@ func TestRunSecret_ListJSON_Empty(t *testing.T) {
 // TestRunSecret_ListJSON_NDJSON: --json with secrets emits one
 // JSON-encoded name per line.
 func TestRunSecret_ListJSON_NDJSON(t *testing.T) {
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := setTestHome(t)
 
 	vaultPath := filepath.Join(dir, ".aileron", "secrets.json")
 	if err := os.MkdirAll(filepath.Dir(vaultPath), 0o700); err != nil {
@@ -1728,7 +1719,7 @@ func TestBindingAPIBaseURL_OverrideTrimsTrailingSlash(t *testing.T) {
 }
 
 func TestDaemonAuthTokenPrefersEnvironment(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	t.Setenv("AILERON_TOKEN", "tok_env")
 	if got := daemonAuthToken(); got != "tok_env" {
 		t.Fatalf("daemonAuthToken = %q, want tok_env", got)
@@ -1736,8 +1727,8 @@ func TestDaemonAuthTokenPrefersEnvironment(t *testing.T) {
 }
 
 func TestDaemonAuthTokenReadsDiscovery(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+	home := setTestHome(t)
+	stateDir := filepath.Join(home, ".aileron")
 	if err := discovery.Write(stateDir, discovery.Info{
 		URL:   "http://127.0.0.1:8721",
 		Token: "tok_file",
@@ -1750,7 +1741,7 @@ func TestDaemonAuthTokenReadsDiscovery(t *testing.T) {
 }
 
 func TestSetDaemonAuthorization(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
+	setTestHome(t)
 	t.Setenv("AILERON_TOKEN", "tok_req")
 	req := httptest.NewRequest(http.MethodGet, "http://daemon.test/v1/status", nil)
 

--- a/cmd/aileron/testhelpers_test.go
+++ b/cmd/aileron/testhelpers_test.go
@@ -1,0 +1,57 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// exeSuffix is the executable extension exec.LookPath requires when
+// finding a binary on PATH: ".exe" on Windows, empty elsewhere. PATH
+// lookup ignores extensionless files on Windows, so staged fake
+// binaries must carry this suffix to be discoverable.
+var exeSuffix = func() string {
+	if runtime.GOOS == "windows" {
+		return ".exe"
+	}
+	return ""
+}()
+
+// setTestHome redirects the process home directory to a fresh temp dir
+// for the duration of the test and returns that dir.
+//
+// os.UserHomeDir() reads $HOME on Unix but %USERPROFILE% on Windows
+// (with %HOMEDRIVE%+%HOMEPATH% as a fallback). Setting HOME alone
+// leaves the Windows runner's real home in play, so this helper sets
+// all of them at once. Tests that need the directory should use the
+// returned value rather than re-reading os.Getenv("HOME"), which is
+// not the source of truth on Windows.
+func setTestHome(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	t.Setenv("HOME", dir)
+	t.Setenv("USERPROFILE", dir)
+	if runtime.GOOS == "windows" {
+		vol := filepath.VolumeName(dir)
+		t.Setenv("HOMEDRIVE", vol)
+		t.Setenv("HOMEPATH", dir[len(vol):])
+	}
+	return dir
+}
+
+// stageServerOnPath writes a no-op "aileron-server" binary into a fresh
+// temp dir, prepends that dir to PATH, and returns the dir. The binary
+// is named with exeSuffix so exec.LookPath finds it on every platform.
+// Daemon-start tests mock the spawn seam, so the binary is never
+// executed; only exec.LookPath must locate it.
+func stageServerOnPath(t *testing.T) string {
+	t.Helper()
+	binDir := t.TempDir()
+	server := filepath.Join(binDir, "aileron-server"+exeSuffix)
+	if err := os.WriteFile(server, []byte("#!/bin/sh\nexit 0\n"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+	return binDir
+}

--- a/cmd/aileron/vault_state_test.go
+++ b/cmd/aileron/vault_state_test.go
@@ -70,8 +70,7 @@ func withVaultStateSeams(t *testing.T, fakes vaultStateFakes) {
 // in. Returns the temp HOME dir.
 func scopeHomeAndAPIURL(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := setTestHome(t)
 	t.Setenv("AILERON_API_URL", "")
 	t.Setenv(envVaultPassphrase, "")
 	return dir

--- a/cmd/aileron/vault_test.go
+++ b/cmd/aileron/vault_test.go
@@ -47,8 +47,7 @@ func scriptPrompt(answers ...string) func() {
 
 func vaultInitTempHome(t *testing.T) string {
 	t.Helper()
-	dir := t.TempDir()
-	t.Setenv("HOME", dir)
+	dir := setTestHome(t)
 	t.Setenv(envVaultPassphrase, "")
 	return filepath.Join(dir, ".aileron", "secrets.json")
 }


### PR DESCRIPTION
## Summary

The `test-windows` job pinned `cmd/aileron` to a single test (`TestSignalDaemonStop`) because the rest of the suite carried Windows-hostile test scaffolding. Production code already ships on Windows (#1390/#1394/#1396); only the tests needed hardening. This PR makes the whole `cmd/aileron` package run green on `windows-latest` and drops the pin.

What changed:

- **New `cmd/aileron/testhelpers_test.go`:**
  - `setTestHome(t)` sets `HOME` + `USERPROFILE` (plus `HOMEDRIVE`/`HOMEPATH` on Windows) to one temp dir and **returns it**, so `os.UserHomeDir()` resolves into the test filesystem on every platform. `os.UserHomeDir()` reads `%USERPROFILE%` on Windows, so a bare `t.Setenv("HOME", ...)` leaked the runner's real home. Tests use the return value instead of re-reading `os.Getenv("HOME")`, which is not the source of truth on Windows.
  - `stageServerOnPath(t)` stages a fake `aileron-server` carrying the platform exe suffix and joins `PATH` with `os.PathListSeparator` (`;` on Windows).
  - `exeSuffix` exposes `.exe` on Windows, empty elsewhere.
- Routed the `withTempHome`, `scopeHomeAndAPIURL`, `vaultInitTempHome` helpers and every inline `t.Setenv("HOME", ...)` site in `daemon_cli`, `keyring`, `main`, `vault`, and `vault_state` tests through `setTestHome`.
- `TestDefaultStateDir_UnderHome` now computes its `want` via `filepath.Join(home, ".aileron")` instead of asserting the hardcoded POSIX path `/test/home/.aileron`.
- PATH-staged fake binaries carry `exeSuffix` so `exec.LookPath` finds them on Windows. The **sibling-stat** branch (`TestDaemonBinaryPath_FindsSibling`) keeps the extensionless name because production `daemonBinaryPath` stats the sibling as bare `aileron-server` even on Windows; only the PATH fallback uses `exec.LookPath`.
- `.github/workflows/ci.yml`: dropped `-run 'TestSignalDaemonStop'` and the `#577` gating comment so `windows-latest` runs the full package. Kept the `coverage-windows-aileron.txt` profile + Codecov upload (`flags: unit`).

Out of scope (operator-deferred fast-follow): `internal/launch`'s bare-HOME instances; those launch packages aren't in the Windows matrix yet.

## Test plan

- `go test -race ./cmd/aileron` passes on darwin.
- `GOOS=windows go vet ./cmd/aileron` passes.
- `GOOS=windows go test -c -o /tmp/aileron_win_test.exe ./cmd/aileron` builds clean (compiles the Windows test binary to catch build-time breakage before CI).
- `gofmt`/`go vet` clean on all changed files.
- The real proof is CI: the `Platform Tests (windows-latest)` job now runs the whole `cmd/aileron` package instead of one test.

Closes #577

🤖 Generated with [Claude Code](https://claude.com/claude-code)
