### PR TITLE
feat(mcp): refresh sandbox tool surface mid-session without restart

### DIFF
--- a/cmd/aileron-mcp/main.go
+++ b/cmd/aileron-mcp/main.go
@@ -29,6 +29,14 @@
 //	                       AILERON_SESSION_ID to enable comms tools.
 //	AILERON_SESSION_ID   - The launch session id the daemon stamps on
 //	                       comms approval entries.
+//	AILERON_MCP_REFRESH_INTERVAL
+//	                     - How often (Go duration, e.g. "5s") the server
+//	                       re-discovers actions from the daemon so an
+//	                       install/enable/disable/remove mid-session
+//	                       refreshes the agent's tool surface without a
+//	                       restart. Defaults to 5s. Set to "0" to disable
+//	                       the poller and freeze the tool surface at boot.
+//	                       Only consulted when AILERON_URL is set.
 package main
 
 import (
@@ -43,7 +51,10 @@ import (
 	"net/url"
 	"os"
 	"os/signal"
+	"reflect"
+	"strconv"
 	"strings"
+	"sync"
 	"syscall"
 	"time"
 
@@ -61,6 +72,13 @@ import (
 // spans this binary emits. Mirrors the convention in
 // internal/action and internal/observability.
 const tracerName = "github.com/ALRubinger/aileron/cmd/aileron-mcp"
+
+// defaultRefreshInterval is how often the action-refresh poller
+// re-discovers actions from the daemon when AILERON_MCP_REFRESH_INTERVAL
+// is unset. Short enough that an install/enable/disable surfaces to the
+// agent within a couple of poll cycles, long enough that the steady-state
+// GET /v1/actions load is negligible.
+const defaultRefreshInterval = 5 * time.Second
 
 // --- JSON-RPC types ---
 
@@ -228,11 +246,25 @@ type server struct {
 	// path use a tighter timeout without affecting comms.
 	commsHTTPClient *http.Client
 
-	// Discovered actions, populated at startup when AILERON_URL is set.
-	// Keys of actionNameMap are snake_case (LLM-facing) tool names;
-	// values are manifest names (kebab-case) used in /v1/actions/{name}/run.
+	// actionsMu guards actionTools and actionNameMap. The request loop
+	// reads them (tools/list, tools/call) while the refresh poller
+	// (refreshLoop) swaps them on change, so every access is locked.
+	actionsMu sync.RWMutex
+	// Discovered actions, populated at startup when AILERON_URL is set and
+	// refreshed in place by the poller. Keys of actionNameMap are
+	// snake_case (LLM-facing) tool names; values are manifest names
+	// (kebab-case) used in /v1/actions/{name}/run.
 	actionTools   []toolDef
 	actionNameMap map[string]string
+
+	// out is where JSON-RPC responses and notifications are written
+	// (os.Stdout in production). writeMu serializes writes so the
+	// request loop's responses and the poller's tools/list_changed
+	// notification never interleave on the wire. nil out disables
+	// notification emission (the unit tests that don't exercise the
+	// wire leave it nil).
+	out     io.Writer
+	writeMu sync.Mutex
 }
 
 // commsAvailable reports whether the env carries enough context to
@@ -283,7 +315,7 @@ var draftReplyTool = toolDef{
 }
 
 var checkActionStatusTool = toolDef{
-	Name: "check_action_status",
+	Name:        "check_action_status",
 	Description: "Check the status of an approval-gated action call. Call this when an earlier tool returned a `pending_approval` response carrying an approval_id, and you want to know whether the user has approved, denied, or whether the action has finished running. The response carries one of: pending_approval, running, completed (with the result), denied (with the user's reason), failed (with the failure details). Polling is optional — the user knows the next move once they see the approval prompt; this tool exists for agents that want to close the loop on an action they initiated.",
 	InputSchema: schema{
 		Type: "object",
@@ -363,6 +395,7 @@ func main() {
 		// + a small buffer so the daemon's bounded response always
 		// wins over a transport timeout.
 		commsHTTPClient: &http.Client{Timeout: 6 * time.Minute},
+		out:             os.Stdout,
 	}
 
 	// Discover installed actions from the Aileron daemon. Best-effort:
@@ -373,10 +406,14 @@ func main() {
 			slog.Warn("action discovery failed; continuing without action tools",
 				"url", s.aileronURL, "error", err)
 		} else {
-			s.actionTools = tools
-			s.actionNameMap = nameMap
+			s.setActions(tools, nameMap)
 		}
 	}
+
+	// Refresh the action surface in the background so an
+	// install/enable/disable/remove mid-session reaches the agent
+	// without a restart.
+	s.maybeStartRefreshPoller(context.Background(), os.Getenv("AILERON_MCP_REFRESH_INTERVAL"))
 
 	// Handle SIGTERM and SIGINT for graceful shutdown.
 	sigCh := make(chan os.Signal, 1)
@@ -403,9 +440,162 @@ func main() {
 		resp := s.handle(req)
 		if resp != nil {
 			data, _ := json.Marshal(resp)
-			fmt.Fprintf(os.Stdout, "%s\n", data)
+			s.writeLine(data)
 		}
 	}
+}
+
+// writeLine writes one newline-terminated JSON-RPC frame to s.out
+// under writeMu so the request loop's responses and the refresh
+// poller's tools/list_changed notification never interleave on the
+// shared stdout stream. A nil out makes this a no-op (tests that
+// don't exercise the wire).
+func (s *server) writeLine(data []byte) {
+	if s.out == nil {
+		return
+	}
+	s.writeMu.Lock()
+	defer s.writeMu.Unlock()
+	fmt.Fprintf(s.out, "%s\n", data)
+}
+
+// setActions atomically replaces the cached action tool surface. Used
+// by both the startup discovery and the refresh poller; centralizes
+// the lock so callers can't forget it.
+func (s *server) setActions(tools []toolDef, nameMap map[string]string) {
+	s.actionsMu.Lock()
+	defer s.actionsMu.Unlock()
+	s.actionTools = tools
+	s.actionNameMap = nameMap
+}
+
+// refreshInterval parses the AILERON_MCP_REFRESH_INTERVAL env value
+// into a poll interval. Empty falls back to the default; "0" (or any
+// non-positive duration) disables the poller — ok=false. An
+// unparseable value logs a warning and falls back to the default so a
+// typo never silently freezes the tool surface.
+func refreshInterval(raw string) (time.Duration, bool) {
+	raw = strings.TrimSpace(raw)
+	if raw == "" {
+		return defaultRefreshInterval, true
+	}
+	// Accept a bare "0" as the explicit disable switch even though
+	// time.ParseDuration would also accept "0s".
+	if d, err := time.ParseDuration(raw); err == nil {
+		if d <= 0 {
+			return 0, false
+		}
+		return d, true
+	}
+	// A bare integer ("0") isn't a valid Go duration; treat 0 as
+	// disable and any other bare integer as seconds for ergonomics.
+	if n, err := strconv.Atoi(raw); err == nil {
+		if n <= 0 {
+			return 0, false
+		}
+		return time.Duration(n) * time.Second, true
+	}
+	slog.Warn("AILERON_MCP_REFRESH_INTERVAL is not a valid duration; using default",
+		"value", raw, "default", defaultRefreshInterval)
+	return defaultRefreshInterval, true
+}
+
+// maybeStartRefreshPoller starts the background action-refresh poller
+// when both conditions hold: AILERON_URL is set (there is a daemon to
+// poll) and the interval knob does not disable it. rawInterval is the
+// AILERON_MCP_REFRESH_INTERVAL value. Returns true when a poller was
+// started. Split from main so the start decision is unit-testable.
+func (s *server) maybeStartRefreshPoller(ctx context.Context, rawInterval string) bool {
+	if s.aileronURL == "" {
+		return false
+	}
+	interval, ok := refreshInterval(rawInterval)
+	if !ok {
+		return false
+	}
+	go s.refreshLoop(ctx, interval)
+	return true
+}
+
+// refreshLoop periodically re-discovers actions from the daemon and,
+// when the resulting tool surface differs from the cached one,
+// atomically swaps the cache and emits notifications/tools/list_changed
+// so the host re-pulls tools/list. Hosts only re-list after this
+// signal, so the proactive poll-and-notify is the mechanism — a
+// refresh on tools/list alone would never fire.
+//
+// Failure handling honors the "must not corrupt the working tool
+// surface" contract: a discovery error logs to stderr and leaves the
+// existing cache untouched; the good surface is never overwritten with
+// an error state.
+func (s *server) refreshLoop(ctx context.Context, interval time.Duration) {
+	ticker := time.NewTicker(interval)
+	defer ticker.Stop()
+	for {
+		select {
+		case <-ctx.Done():
+			return
+		case <-ticker.C:
+			s.refreshOnce(ctx)
+		}
+	}
+}
+
+// refreshOnce performs a single discovery + diff + conditional swap.
+// Split from refreshLoop so the per-tick behavior is unit-testable
+// without driving a ticker. Returns true when the surface changed and
+// a notification was emitted.
+func (s *server) refreshOnce(ctx context.Context) bool {
+	tools, nameMap, err := s.discoverActions(ctx)
+	if err != nil {
+		// Leave the working surface intact; surface the failure on
+		// stderr so it's visible without poisoning the tool list.
+		slog.Warn("action refresh failed; keeping existing tool surface",
+			"url", s.aileronURL, "error", err)
+		return false
+	}
+
+	// Diff on the tool defs alone: actionNameMap is a pure function of
+	// the discovered tools (snake_case name → manifest name), so equal
+	// tool surfaces imply an equal name map. No need to diff both.
+	s.actionsMu.RLock()
+	unchanged := toolDefsEqual(s.actionTools, tools)
+	s.actionsMu.RUnlock()
+	if unchanged {
+		return false
+	}
+
+	s.setActions(tools, nameMap)
+	s.emitToolsListChanged()
+	return true
+}
+
+// emitToolsListChanged writes a JSON-RPC notification telling the host
+// the tool list changed. Notifications carry no id and expect no
+// response, per JSON-RPC 2.0 / the MCP spec.
+func (s *server) emitToolsListChanged() {
+	data, _ := json.Marshal(map[string]any{
+		"jsonrpc": "2.0",
+		"method":  "notifications/tools/list_changed",
+	})
+	s.writeLine(data)
+}
+
+// toolDefsEqual reports whether two discovered tool surfaces are
+// identical (same tools, same order, same schemas). discoverActions
+// preserves the daemon's response order, so order-sensitive equality
+// is correct: a reordering from the daemon is a real change the host
+// should see. Compared by value via the JSON shapes the structs carry.
+func toolDefsEqual(a, b []toolDef) bool {
+	if len(a) != len(b) {
+		return false
+	}
+	for i := range a {
+		if !reflect.DeepEqual(a[i], b[i]) {
+			return false
+		}
+	}
+	return true
 }
 
 func (s *server) handle(req jsonrpcRequest) *jsonrpcResponse {
@@ -417,7 +607,13 @@ func (s *server) handle(req jsonrpcRequest) *jsonrpcResponse {
 			Result: map[string]any{
 				"protocolVersion": "2024-11-05",
 				"capabilities": map[string]any{
-					"tools": map[string]any{},
+					// listChanged: true tells the host we proactively emit
+					// notifications/tools/list_changed when the action set
+					// changes mid-session, so it should re-pull tools/list
+					// on that signal rather than caching the boot snapshot.
+					"tools": map[string]any{
+						"listChanged": true,
+					},
 				},
 				"serverInfo": map[string]any{
 					"name":    "aileron",
@@ -472,8 +668,11 @@ func (s *server) availableTools() []toolDef {
 	// Dynamically discovered Aileron actions from the daemon's
 	// /v1/actions endpoint (per ADR-0008 — kept in MCP shape rather
 	// than the OpenAI/Anthropic shape because the agent host's MCP
-	// integration is the consumer here).
+	// integration is the consumer here). Read under the lock the
+	// refresh poller swaps the slice under.
+	s.actionsMu.RLock()
 	tools = append(tools, s.actionTools...)
+	s.actionsMu.RUnlock()
 	// check_action_status is always available — even when no actions
 	// are discovered (a fresh daemon), the agent might be working
 	// against an approval id minted by an earlier session.
@@ -483,7 +682,11 @@ func (s *server) availableTools() []toolDef {
 
 func (s *server) dispatchTool(ctx context.Context, name string, args map[string]any) toolResult {
 	// Discovered actions: route to /v1/actions/{name}/run on the daemon.
-	if manifestName, ok := s.actionNameMap[name]; ok {
+	// Read the map under the lock the refresh poller swaps it under.
+	s.actionsMu.RLock()
+	manifestName, ok := s.actionNameMap[name]
+	s.actionsMu.RUnlock()
+	if ok {
 		return s.runAction(ctx, manifestName, args)
 	}
 	// Comms tools: handled in-process via the launch product's Unix socket.
@@ -767,9 +970,12 @@ func (s *server) discoverActions(ctx context.Context) ([]toolDef, map[string]str
 	nameMap := make(map[string]string, len(alr.Items))
 	for _, a := range alr.Items {
 		// Disabled actions are hidden from tools/list so the LLM never
-		// learns they exist this session. The MCP server caches at boot,
-		// so a re-enable requires a restart to surface the action again
-		// — documented behavior, deliberate trade-off vs. polling.
+		// learns they exist this session. The refresh poller
+		// (refreshLoop) re-runs this discovery on AILERON_MCP_REFRESH_INTERVAL
+		// and emits notifications/tools/list_changed on a diff, so a
+		// re-enable resurfaces the action without a restart. A restart
+		// is only needed for static config the poller does not re-read
+		// (AILERON_URL, comms env), per the sandbox MCP walkthrough.
 		if !a.isEnabled() {
 			continue
 		}

--- a/cmd/aileron-mcp/main_test.go
+++ b/cmd/aileron-mcp/main_test.go
@@ -1,6 +1,8 @@
 package main
 
 import (
+	"bufio"
+	"bytes"
 	"context"
 	"encoding/json"
 	"io"
@@ -8,7 +10,9 @@ import (
 	"net/http/httptest"
 	"reflect"
 	"strings"
+	"sync"
 	"testing"
+	"time"
 )
 
 // --- JSON-RPC handling ---
@@ -88,7 +92,7 @@ func TestDispatchTool_UnknownTool(t *testing.T) {
 // which the MCP server registers unconditionally so the agent can
 // poll outcomes from any session.
 func TestAvailableTools_CommsOnly(t *testing.T) {
-	s := &server{commsURL:    "http://x", sessionID: "sess-x", httpClient: &http.Client{}}
+	s := &server{commsURL: "http://x", sessionID: "sess-x", httpClient: &http.Client{}}
 	tools := s.availableTools()
 	if len(tools) != 5 {
 		t.Fatalf("expected 4 comms tools + check_action_status, got %d", len(tools))
@@ -126,8 +130,8 @@ func TestAvailableTools_ActionsOnly(t *testing.T) {
 
 func TestAvailableTools_CommsAndActions(t *testing.T) {
 	s := &server{
-		commsURL:    "http://x", sessionID: "sess-x",
-		httpClient:  &http.Client{},
+		commsURL: "http://x", sessionID: "sess-x",
+		httpClient: &http.Client{},
 		actionTools: []toolDef{
 			{Name: "ship_update", Description: "x", InputSchema: schema{Type: "object"}},
 			{Name: "list_emails", Description: "y", InputSchema: schema{Type: "object"}},
@@ -1295,4 +1299,404 @@ func commsServerWithFakeDaemon(t *testing.T, handler http.Handler) *server {
 		httpClient:      &http.Client{},
 		commsHTTPClient: &http.Client{},
 	}
+}
+
+// --- Mid-session action refresh (issue #897) ---
+
+// syncBuffer is a goroutine-safe bytes.Buffer so a test can read the
+// poller's emitted notifications while the refresh goroutine (or a
+// direct refreshOnce call) writes to s.out under writeMu.
+type syncBuffer struct {
+	mu  sync.Mutex
+	buf bytes.Buffer
+}
+
+func (b *syncBuffer) Write(p []byte) (int, error) {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.Write(p)
+}
+
+func (b *syncBuffer) String() string {
+	b.mu.Lock()
+	defer b.mu.Unlock()
+	return b.buf.String()
+}
+
+// emittedMethods parses every newline-delimited JSON-RPC frame written
+// to the buffer and returns the "method" field of each. Non-JSON or
+// frames without a method are skipped.
+func emittedMethods(t *testing.T, s string) []string {
+	t.Helper()
+	var methods []string
+	sc := bufio.NewScanner(strings.NewReader(s))
+	for sc.Scan() {
+		line := strings.TrimSpace(sc.Text())
+		if line == "" {
+			continue
+		}
+		var frame struct {
+			Method string `json:"method"`
+		}
+		if err := json.Unmarshal([]byte(line), &frame); err != nil {
+			continue
+		}
+		if frame.Method != "" {
+			methods = append(methods, frame.Method)
+		}
+	}
+	return methods
+}
+
+func countListChanged(t *testing.T, s string) int {
+	t.Helper()
+	n := 0
+	for _, m := range emittedMethods(t, s) {
+		if m == "notifications/tools/list_changed" {
+			n++
+		}
+	}
+	return n
+}
+
+func TestHandle_Initialize_AdvertisesListChanged(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	resp := s.handle(jsonrpcRequest{
+		JSONRPC: "2.0",
+		ID:      json.RawMessage(`1`),
+		Method:  "initialize",
+	})
+	if resp == nil || resp.Error != nil {
+		t.Fatalf("unexpected error: %+v", resp)
+	}
+	result, ok := resp.Result.(map[string]any)
+	if !ok {
+		t.Fatal("expected map result")
+	}
+	caps, ok := result["capabilities"].(map[string]any)
+	if !ok {
+		t.Fatalf("capabilities missing or wrong type: %#v", result["capabilities"])
+	}
+	tools, ok := caps["tools"].(map[string]any)
+	if !ok {
+		t.Fatalf("capabilities.tools missing or wrong type: %#v", caps["tools"])
+	}
+	if tools["listChanged"] != true {
+		t.Errorf("capabilities.tools.listChanged = %v, want true", tools["listChanged"])
+	}
+}
+
+// mutableActions is a goroutine-safe holder for the action set an
+// httptest daemon serves, so a test can swap what GET /v1/actions
+// returns between poll cycles while the poller goroutine reads it
+// concurrently (no data race on the slice).
+type mutableActions struct {
+	mu    sync.Mutex
+	items []actionMeta
+}
+
+func newMutableActions(items ...actionMeta) *mutableActions {
+	return &mutableActions{items: items}
+}
+
+func (m *mutableActions) set(items ...actionMeta) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	m.items = items
+}
+
+func (m *mutableActions) get() []actionMeta {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	return append([]actionMeta(nil), m.items...)
+}
+
+func (m *mutableActions) handler() http.Handler {
+	return http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.Header().Set("Content-Type", "application/json")
+		_ = json.NewEncoder(w).Encode(actionListResponse{Items: m.get()})
+	})
+}
+
+func enabledPtr() *bool  { b := true; return &b }
+func disabledPtr() *bool { b := false; return &b }
+
+func TestRefreshOnce_EmitsOnActionAdded(t *testing.T) {
+	actions := newMutableActions(actionMeta{Name: "ship-update", Body: "# Ship", Enabled: enabledPtr()})
+	srv := httptest.NewServer(actions.handler())
+	defer srv.Close()
+
+	out := &syncBuffer{}
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client(), out: out}
+	// Seed the cache with the startup surface.
+	tools, nameMap, err := s.discoverActions(context.Background())
+	if err != nil {
+		t.Fatalf("discoverActions: %v", err)
+	}
+	s.setActions(tools, nameMap)
+
+	// Add a second action and poll.
+	actions.set(
+		actionMeta{Name: "ship-update", Body: "# Ship", Enabled: enabledPtr()},
+		actionMeta{Name: "list-emails", Body: "# List", Enabled: enabledPtr()},
+	)
+	if !s.refreshOnce(context.Background()) {
+		t.Fatal("refreshOnce returned false; expected a change (action added)")
+	}
+	if got := countListChanged(t, out.String()); got != 1 {
+		t.Fatalf("list_changed emissions = %d, want 1", got)
+	}
+	// The new action is now routable.
+	s.actionsMu.RLock()
+	_, ok := s.actionNameMap["list_emails"]
+	s.actionsMu.RUnlock()
+	if !ok {
+		t.Error("added action 'list-emails' not present in nameMap after refresh")
+	}
+}
+
+func TestRefreshOnce_EmitsOnActionEnabled(t *testing.T) {
+	actions := newMutableActions(actionMeta{Name: "list-emails", Body: "# List", Enabled: disabledPtr()})
+	srv := httptest.NewServer(actions.handler())
+	defer srv.Close()
+
+	out := &syncBuffer{}
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client(), out: out}
+	tools, nameMap, _ := s.discoverActions(context.Background())
+	s.setActions(tools, nameMap)
+	// Disabled action is hidden at boot.
+	s.actionsMu.RLock()
+	hidden := len(s.actionTools)
+	s.actionsMu.RUnlock()
+	if hidden != 0 {
+		t.Fatalf("disabled action surfaced at boot: %d tools", hidden)
+	}
+
+	actions.set(actionMeta{Name: "list-emails", Body: "# List", Enabled: enabledPtr()})
+	if !s.refreshOnce(context.Background()) {
+		t.Fatal("refreshOnce returned false; expected a change (action enabled)")
+	}
+	if got := countListChanged(t, out.String()); got != 1 {
+		t.Fatalf("list_changed emissions = %d, want 1", got)
+	}
+}
+
+func TestRefreshOnce_EmitsOnActionDisabled(t *testing.T) {
+	actions := newMutableActions(actionMeta{Name: "list-emails", Body: "# List", Enabled: enabledPtr()})
+	srv := httptest.NewServer(actions.handler())
+	defer srv.Close()
+
+	out := &syncBuffer{}
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client(), out: out}
+	tools, nameMap, _ := s.discoverActions(context.Background())
+	s.setActions(tools, nameMap)
+
+	actions.set(actionMeta{Name: "list-emails", Body: "# List", Enabled: disabledPtr()})
+	if !s.refreshOnce(context.Background()) {
+		t.Fatal("refreshOnce returned false; expected a change (action disabled)")
+	}
+	if got := countListChanged(t, out.String()); got != 1 {
+		t.Fatalf("list_changed emissions = %d, want 1", got)
+	}
+	s.actionsMu.RLock()
+	remaining := len(s.actionTools)
+	s.actionsMu.RUnlock()
+	if remaining != 0 {
+		t.Errorf("disabled action still surfaced after refresh: %d tools", remaining)
+	}
+}
+
+func TestRefreshOnce_EmitsOnActionRemoved(t *testing.T) {
+	actions := newMutableActions(
+		actionMeta{Name: "ship-update", Body: "# Ship", Enabled: enabledPtr()},
+		actionMeta{Name: "list-emails", Body: "# List", Enabled: enabledPtr()},
+	)
+	srv := httptest.NewServer(actions.handler())
+	defer srv.Close()
+
+	out := &syncBuffer{}
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client(), out: out}
+	tools, nameMap, _ := s.discoverActions(context.Background())
+	s.setActions(tools, nameMap)
+
+	actions.set(actionMeta{Name: "ship-update", Body: "# Ship", Enabled: enabledPtr()}) // remove list-emails
+	if !s.refreshOnce(context.Background()) {
+		t.Fatal("refreshOnce returned false; expected a change (action removed)")
+	}
+	if got := countListChanged(t, out.String()); got != 1 {
+		t.Fatalf("list_changed emissions = %d, want 1", got)
+	}
+	s.actionsMu.RLock()
+	_, ok := s.actionNameMap["list_emails"]
+	s.actionsMu.RUnlock()
+	if ok {
+		t.Error("removed action 'list-emails' still routable after refresh")
+	}
+}
+
+func TestRefreshOnce_NoEmitWhenUnchanged(t *testing.T) {
+	actions := newMutableActions(actionMeta{Name: "ship-update", Body: "# Ship", Enabled: enabledPtr()})
+	srv := httptest.NewServer(actions.handler())
+	defer srv.Close()
+
+	out := &syncBuffer{}
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client(), out: out}
+	tools, nameMap, _ := s.discoverActions(context.Background())
+	s.setActions(tools, nameMap)
+
+	if s.refreshOnce(context.Background()) {
+		t.Fatal("refreshOnce returned true; expected no change")
+	}
+	if got := countListChanged(t, out.String()); got != 0 {
+		t.Fatalf("list_changed emissions = %d, want 0 (no change)", got)
+	}
+}
+
+func TestRefreshOnce_FailureLeavesSurfaceIntact(t *testing.T) {
+	// First call succeeds, subsequent calls 500 — proves a refresh
+	// failure does not overwrite a good cache (the #897 contract:
+	// failures must not corrupt the working tool surface).
+	var calls int
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		calls++
+		if calls == 1 {
+			w.Header().Set("Content-Type", "application/json")
+			_ = json.NewEncoder(w).Encode(actionListResponse{
+				Items: []actionMeta{{Name: "ship-update", Body: "# Ship", Enabled: enabledPtr()}},
+			})
+			return
+		}
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	out := &syncBuffer{}
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client(), out: out}
+	tools, nameMap, err := s.discoverActions(context.Background())
+	if err != nil {
+		t.Fatalf("seed discovery: %v", err)
+	}
+	s.setActions(tools, nameMap)
+
+	if s.refreshOnce(context.Background()) {
+		t.Fatal("refreshOnce returned true on a failed discovery")
+	}
+	if got := countListChanged(t, out.String()); got != 0 {
+		t.Fatalf("list_changed emitted on failure: %d", got)
+	}
+	// The good surface survives.
+	s.actionsMu.RLock()
+	_, ok := s.actionNameMap["ship_update"]
+	n := len(s.actionTools)
+	s.actionsMu.RUnlock()
+	if !ok || n != 1 {
+		t.Errorf("failure corrupted surface: tools=%d, ship_update present=%v", n, ok)
+	}
+}
+
+func TestRefreshInterval(t *testing.T) {
+	cases := []struct {
+		raw     string
+		wantDur time.Duration
+		wantOn  bool
+	}{
+		{"", defaultRefreshInterval, true},
+		{"10s", 10 * time.Second, true},
+		{"2m", 2 * time.Minute, true},
+		{"3", 3 * time.Second, true}, // bare integer → seconds
+		{"0", 0, false},              // explicit disable
+		{"0s", 0, false},             // zero duration → disable
+		{"  ", defaultRefreshInterval, true},
+		{"-5s", 0, false},                         // non-positive → disable
+		{"garbage", defaultRefreshInterval, true}, // typo falls back to default
+	}
+	for _, tc := range cases {
+		gotDur, gotOn := refreshInterval(tc.raw)
+		if gotOn != tc.wantOn {
+			t.Errorf("refreshInterval(%q) enabled = %v, want %v", tc.raw, gotOn, tc.wantOn)
+			continue
+		}
+		if gotOn && gotDur != tc.wantDur {
+			t.Errorf("refreshInterval(%q) = %v, want %v", tc.raw, gotDur, tc.wantDur)
+		}
+	}
+}
+
+func TestWriteLine_NilOutIsNoop(t *testing.T) {
+	s := &server{} // out is nil
+	// Must not panic.
+	s.writeLine([]byte(`{"jsonrpc":"2.0"}`))
+}
+
+func TestRefreshLoop_StopsOnContextCancel(t *testing.T) {
+	actions := newMutableActions(actionMeta{Name: "ship-update", Body: "# Ship", Enabled: enabledPtr()})
+	srv := httptest.NewServer(actions.handler())
+	defer srv.Close()
+
+	out := &syncBuffer{}
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client(), out: out}
+	tools, nameMap, _ := s.discoverActions(context.Background())
+	s.setActions(tools, nameMap)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	done := make(chan struct{})
+	go func() {
+		s.refreshLoop(ctx, 10*time.Millisecond)
+		close(done)
+	}()
+	cancel()
+	select {
+	case <-done:
+	case <-time.After(2 * time.Second):
+		t.Fatal("refreshLoop did not return after context cancel")
+	}
+}
+
+func TestMaybeStartRefreshPoller_NoURLDoesNotStart(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	if s.maybeStartRefreshPoller(context.Background(), "5s") {
+		t.Error("poller started without AILERON_URL")
+	}
+}
+
+func TestMaybeStartRefreshPoller_DisabledIntervalDoesNotStart(t *testing.T) {
+	s := &server{aileronURL: "http://127.0.0.1:1", httpClient: &http.Client{}}
+	if s.maybeStartRefreshPoller(context.Background(), "0") {
+		t.Error("poller started with interval=0 (disabled)")
+	}
+}
+
+func TestMaybeStartRefreshPoller_StartsAndStopsOnCancel(t *testing.T) {
+	actions := newMutableActions(actionMeta{Name: "ship-update", Body: "# Ship", Enabled: enabledPtr()})
+	srv := httptest.NewServer(actions.handler())
+	defer srv.Close()
+
+	out := &syncBuffer{}
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client(), out: out}
+	tools, nameMap, _ := s.discoverActions(context.Background())
+	s.setActions(tools, nameMap)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	if !s.maybeStartRefreshPoller(ctx, "10ms") {
+		t.Fatal("poller did not start with valid URL + interval")
+	}
+
+	// Flip the served set; the running poller should emit list_changed.
+	actions.set(
+		actionMeta{Name: "ship-update", Body: "# Ship", Enabled: enabledPtr()},
+		actionMeta{Name: "list-emails", Body: "# List", Enabled: enabledPtr()},
+	)
+	deadline := time.After(2 * time.Second)
+	for {
+		if countListChanged(t, out.String()) >= 1 {
+			break
+		}
+		select {
+		case <-deadline:
+			t.Fatal("poller never emitted list_changed after action added")
+		case <-time.After(5 * time.Millisecond):
+		}
+	}
+	cancel()
 }

--- a/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
+++ b/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
@@ -103,6 +103,26 @@ aileron audit list --session "$SESSION" --json \
 
 Verify the draft landed in Gmail's draft folder. That is the upstream contract under test.
 
+## Refresh the tool surface without a restart
+
+`aileron-mcp` discovers actions from the daemon's `/v1/actions` at startup, then keeps the agent's tool list current while the session runs. It advertises the MCP `tools.listChanged` capability during `initialize` and re-discovers actions on a background poll. When the action set changes, it swaps its cache and emits a `notifications/tools/list_changed` to the host, which re-pulls `tools/list`.
+
+This means an `aileron action install`, `aileron action enable`, `aileron action disable`, or `aileron action remove` in another terminal reaches the running agent within a poll cycle. Installing or enabling an action surfaces it; disabling or removing one drops it. No agent restart.
+
+The poll interval is `AILERON_MCP_REFRESH_INTERVAL` (a Go duration such as `5s`, or a bare integer interpreted as seconds). It defaults to `5s`. Set it to `0` to disable the poller and freeze the tool surface at the boot snapshot. The knob is only consulted when `AILERON_URL` is set.
+
+A discovery failure during a refresh (daemon momentarily unreachable, vault locked) logs to stderr and leaves the existing tool surface intact. The working tool list is never overwritten with an error state, so a transient failure can never strand the agent without its tools.
+
+### When a restart is still required
+
+The poller re-reads the action catalog, nothing else. A restart is genuinely required to pick up changes to the static configuration `aileron-mcp` reads once at boot:
+
+- `AILERON_URL` (which daemon to talk to)
+- `AILERON_TOKEN` (the bearer token)
+- `AILERON_COMMS_URL` and `AILERON_SESSION_ID` (the comms tool surface: `read_messages`, `send_message`, `draft_reply`, `http_request`)
+
+These are launch-time wiring, not catalog state, so they fall outside the refresh path by design.
+
 ## Record the result
 
 The **Linux column is automated** (the tests above), so those cells are green when CI is green; you do not hand-run them. For **macOS and Windows**, the per-agent bar is the light smoke: the agent listed `aileron` with `draft_email`. Record those cells in issue [#962](https://github.com/ALRubinger/aileron/issues/962) (its body, not a comment) with the environment (OS, arch, Docker version, Aileron CLI commit, agent version) and any deviations. If you also run the optional full round-trip, note that the audit assertion above printed `PASS` and the draft landed in Gmail.


### PR DESCRIPTION
## Summary

Installing, enabling, disabling, or removing an action in a running v4 sandbox session was invisible to the agent until restart: `aileron-mcp` discovered actions from the daemon's `/v1/actions` only at startup and never emitted `tools/list_changed`. This makes the refresh an MCP-side, self-contained concern (the shim/`tools.txt` watcher design from #959 is retired).

What changed (all in `cmd/aileron-mcp`):

- `initialize` advertises `capabilities.tools.listChanged=true` so hosts know to re-pull `tools/list` on the signal.
- A background poller (started when `AILERON_URL` is set) re-runs `discoverActions` on an interval, diffs the tool surface against the cache, and on change atomically swaps the cache and writes `notifications/tools/list_changed` through a writer mutex shared with the response path. Hosts only re-list after that signal, so a proactive trigger is required; refreshing on `tools/list` alone would never fire.
- `actionTools`/`actionNameMap` are now `RWMutex`-guarded so the request loop and the poller share them safely.
- Refresh failures log to stderr and **leave the working tool surface intact** (never overwrite a good cache with an error), per the "must not corrupt the working tool surface" requirement.
- `AILERON_MCP_REFRESH_INTERVAL` knob (default `5s`; `0` disables the poller).
- The deliberate "requires a restart" comment in `discoverActions` is updated, and the sandbox MCP walkthrough documents when a restart is still genuinely required (static config: `AILERON_URL`, `AILERON_TOKEN`, comms env, which the poller does not re-read).

## Test plan

- `go test -race -cover ./cmd/aileron-mcp/...` passes; coverage 81.0%.
- New unit tests (httptest pattern): poller emits `list_changed` on action add / enable / disable / remove; no emission when unchanged; a refresh failure leaves the cache intact (no emit, good surface survives); `initialize` advertises `listChanged`; interval parsing (default, duration, bare-int seconds, `0`/`0s`/negative disable, garbage falls back); poller start gating (no URL, disabled interval, starts + stops on context cancel).
- `task build:mcp` builds the host + Linux `wasip1`-adjacent targets clean.
- The existing `integration_sandbox` round-trip (`internal/app`) is unaffected (no behavior change on the request path).

Closes #897

🤖 Generated with [Claude Code](https://claude.com/claude-code)
