### PR TITLE
test(cmd): fix Windows daemon-stop tests reading wrong state dir

### DIFF
--- a/cmd/aileron/daemon_cli_test.go
+++ b/cmd/aileron/daemon_cli_test.go
@@ -439,8 +439,11 @@ func withSignalDaemonStop(t *testing.T, fn func(int) (notRunning, selfCleans boo
 // The CLI must remove the discovery files itself and report success on
 // the FIRST invocation — not spin the wait loop and exit 1.
 func TestRunDaemonStop_WindowsKill_CLICleansUp(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+	// setTestHome (not a raw HOME setenv) so the state dir resolves to the
+	// same place on Windows, where runDaemonStop's os.UserHomeDir() reads
+	// USERPROFILE rather than HOME. A bare HOME setenv left the CLI reading a
+	// different dir and reporting "not running". See issue #577.
+	stateDir := filepath.Join(setTestHome(t), ".aileron")
 
 	if err := discovery.Write(stateDir, discovery.Info{
 		URL:       "http://127.0.0.1:1",
@@ -485,8 +488,11 @@ func TestRunDaemonStop_WindowsKill_CLICleansUp(t *testing.T) {
 // path: the daemon self-cleans (selfCleans=true), so the CLI waits for
 // daemon.json to disappear before reporting success.
 func TestRunDaemonStop_UnixSIGTERM_WaitsForSelfClean(t *testing.T) {
-	t.Setenv("HOME", t.TempDir())
-	stateDir := filepath.Join(os.Getenv("HOME"), ".aileron")
+	// setTestHome (not a raw HOME setenv) so the state dir resolves to the
+	// same place on Windows, where runDaemonStop's os.UserHomeDir() reads
+	// USERPROFILE rather than HOME. A bare HOME setenv left the CLI reading a
+	// different dir and reporting "not running". See issue #577.
+	stateDir := filepath.Join(setTestHome(t), ".aileron")
 
 	if err := discovery.Write(stateDir, discovery.Info{
 		URL:       "http://127.0.0.1:1",


### PR DESCRIPTION
## Summary

`main` is currently red on **Unit Tests (Windows)**: `TestRunDaemonStop_WindowsKill_CLICleansUp` and `TestRunDaemonStop_UnixSIGTERM_WaitsForSelfClean` fail with `signalDaemonStop called with pid 0, want 4242` and `stdout ... got "Aileron daemon is not running."`.

Root cause is a test-only portability bug. Both tests set only `HOME` and compute the state dir from `os.Getenv("HOME")`, but `runDaemonStop` resolves the state dir via `os.UserHomeDir()`, which on **Windows reads `USERPROFILE`**, not `HOME`. The CLI looked in a different directory than the test wrote `discovery.json` to, saw "not running", and skipped the stop path entirely (pid 0, no cleanup).

The repo already has a `setTestHome` helper that sets `HOME`, `USERPROFILE`, and `HOMEDRIVE`/`HOMEPATH` per platform. Both tests now route through it. Production code is unchanged.

This breakage was exposed (not introduced) when #1414 turned on the full `cmd/aileron` suite on the Windows runner; the failure was invisible to the local (macOS) merge gate because `HOME` works there.

## Test plan

- [x] `go vet ./cmd/aileron/` clean
- [x] `go test -race -run TestRunDaemonStop ./cmd/aileron/` passes on macOS (unchanged)
- [ ] **Unit Tests (Windows)** green in CI — the only platform that exercises the fixed path (cannot be verified locally on macOS)

Relates to #577, #1414

🤖 Generated with [Claude Code](https://claude.com/claude-code)
