### PR TITLE
feat(cstore): keyring v2 schema + loader with owner-level entries

### DIFF
--- a/internal/cstore/fqn.go
+++ b/internal/cstore/fqn.go
@@ -60,6 +60,17 @@ func (f FQN) Authority() string {
 	return f.Scheme + "://" + f.Owner + "/" + f.Repo
 }
 
+// OwnerAuthority returns the owner-level authority portion of the FQN —
+// the `<scheme>://<owner>` pair, dropping the repo segment that
+// Authority() includes. ADR-0013 owner-level (per-publisher) trust uses
+// this string as the keyring lookup key so a single grant covers every
+// repo a publisher owns. Callers and the keyring's owner/per-repo
+// partitioning derive the owner authority from here rather than
+// string-splitting Authority().
+func (f FQN) OwnerAuthority() string {
+	return f.Scheme + "://" + f.Owner
+}
+
 // fqnSchemes is the closed v1 set per ADR-0004. Adding a remote
 // resolver scheme requires implementing the resolver's four
 // operations (resolve URL, fetch, verify signature, list

--- a/internal/cstore/fqn_test.go
+++ b/internal/cstore/fqn_test.go
@@ -58,9 +58,9 @@ func TestParseFQN_RejectsUnknownScheme(t *testing.T) {
 
 func TestParseFQN_RejectsMissingRepoOrOwner(t *testing.T) {
 	for _, in := range []string{
-		"github://owner",      // missing repo
-		"github://",           // missing both
-		"",                    // empty
+		"github://owner",       // missing repo
+		"github://",            // missing both
+		"",                     // empty
 		"github://owner@1.0.0", // version suffix forbidden
 	} {
 		t.Run(in, func(t *testing.T) {
@@ -82,6 +82,40 @@ func TestFQN_Authority_ReturnsSchemeOwnerRepo(t *testing.T) {
 	}
 	if got, want := f.Authority(), "github://aileron/integrations"; got != want {
 		t.Errorf("Authority() = %q, want %q", got, want)
+	}
+}
+
+func TestFQN_OwnerAuthority_ReturnsSchemeOwner(t *testing.T) {
+	// ADR-0013: owner-level (per-publisher) trust keys on
+	// `<scheme>://<owner>`, dropping the repo segment Authority()
+	// includes. The two accessors differ exactly by the repo segment.
+	cases := []struct {
+		fqn           string
+		wantOwner     string
+		wantAuthority string
+	}{
+		{"github://acme/connector/sub", "github://acme", "github://acme/connector"},
+		{"gitlab://acme/connector", "gitlab://acme", "gitlab://acme/connector"},
+		{"hub://acme/namespace/nested", "hub://acme", "hub://acme/namespace"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.fqn, func(t *testing.T) {
+			f, err := ParseFQN(tc.fqn)
+			if err != nil {
+				t.Fatalf("parse: %v", err)
+			}
+			if got := f.OwnerAuthority(); got != tc.wantOwner {
+				t.Errorf("OwnerAuthority() = %q, want %q", got, tc.wantOwner)
+			}
+			if got := f.Authority(); got != tc.wantAuthority {
+				t.Errorf("Authority() = %q, want %q", got, tc.wantAuthority)
+			}
+			// The owner authority is the per-repo authority minus the
+			// `/<repo>` segment.
+			if want := f.OwnerAuthority() + "/" + f.Repo; want != f.Authority() {
+				t.Errorf("OwnerAuthority()+/+Repo = %q, want Authority() = %q", want, f.Authority())
+			}
+		})
 	}
 }
 

--- a/internal/cstore/keyring_config.go
+++ b/internal/cstore/keyring_config.go
@@ -12,24 +12,74 @@ import (
 	"os"
 	"path/filepath"
 	"sort"
+	"strings"
 )
 
 // keyringFile is the JSON shape persisted at ~/.aileron/keyring.json
 // (and overridden via the path passed to LoadKeyring). It maps FQN
 // authority strings to one or more base64-encoded ed25519 public keys.
 //
+// The v2 shape is hybrid: two sibling maps segregate the two grant kinds
+// ADR-0013 introduces.
+//
+//		{
+//		  "version": 2,
+//		  "owners":     { "github://acme":           ["<b64>", ...] },
+//		  "publishers": { "github://acme/connector":  ["<b64>", ...] }
+//		}
+//
+//	  - Publishers is the unchanged v1 field; its keys are per-repo
+//	    authorities (`<scheme>://<owner>/<repo>`).
+//	  - Owners is new in v2; its keys are owner-level authorities
+//	    (`<scheme>://<owner>`, no repo segment) granting trust across every
+//	    repo a publisher owns.
+//
+// Both maps fold into the same flat in-memory key map, so Verify is
+// unchanged and an owner-level grant coexists with a per-repo grant for
+// the same publisher as two independent entries. A v1 file (only
+// Publishers, "version": 1) loads losslessly under the v2 loader: its
+// per-repo entries land untouched and Owners is simply empty.
+//
 // Multiple keys per authority support publisher key rotation: callers
 // install a new key alongside the old one, switch signing to the new
 // key, then drop the old. The verifier accepts any registered key.
 type keyringFile struct {
 	Version    int                 `json:"version"`
+	Owners     map[string][]string `json:"owners,omitempty"`
 	Publishers map[string][]string `json:"publishers"`
+}
+
+// isOwnerAuthority reports whether s is an owner-level authority
+// (`<scheme>://<owner>`, no repo segment) rather than a per-repo
+// authority (`<scheme>://<owner>/<repo>`). The single classifier drives
+// both the load-time "v1 must not carry owners" guard and the save-time
+// owners/publishers partition, so the rule lives in exactly one place.
+//
+// Classification is by path segments after the `://` separator: zero
+// slashes after the host means owner-level; one or more means per-repo.
+// Strings without `://` (which never occur for valid authorities) are
+// treated as owner-level so they are not silently dropped from a save.
+func isOwnerAuthority(s string) bool {
+	const sep = "://"
+	idx := strings.Index(s, sep)
+	if idx < 0 {
+		return true
+	}
+	return !strings.Contains(s[idx+len(sep):], "/")
 }
 
 // LoadKeyring loads an Ed25519Keyring from a JSON file at the given
 // path. Per ADR-0002's "signing keys and rotation" deferral, the file
-// is the v1 source of trust — users edit it (or a future
+// is the source of trust — users edit it (or a future
 // `aileron keyring add` command does) to authorize a publisher.
+//
+// Versions 1 and 2 are accepted. A v1 file carries only per-repo grants
+// in "publishers"; the v2 loader reads it losslessly (its per-repo
+// entries land untouched and the owner-level set is empty). A v2 file
+// additionally carries owner-level grants in "owners". Both maps fold
+// into the same flat in-memory key map. This is a hybrid forward-read,
+// not a deprecation shim: v1 files are not rewritten until the next
+// SaveKeyring, which emits v2.
 //
 // Behavior:
 //
@@ -38,13 +88,19 @@ type keyringFile struct {
 //     install with ClassSignatureFailure. Aileron defaults to no
 //     trusted publishers; users opt in.
 //   - Malformed JSON → ClassValidationError.
-//   - Unsupported version → ClassValidationError.
-//   - Bad base64 or invalid key length → ClassValidationError.
+//   - Unsupported version (anything other than 1 or 2) →
+//     ClassValidationError.
+//   - A "version": 1 document carrying an "owners" map →
+//     ClassValidationError. Owner-level grants are a v2-only feature;
+//     honoring them under v1 would let a downgrade hide trust.
+//   - Empty authority key in either map → ClassValidationError.
+//   - Bad base64 or invalid key length in either map →
+//     ClassValidationError.
 //
-// The single "Publishers" key per authority accepts a list of base64
-// public keys (raw ed25519, 32 bytes after decode). Both base64
-// standard encoding (with padding) and URL encoding (with or without
-// padding) are accepted; standard is canonical.
+// Each authority maps to a list of base64 public keys (raw ed25519, 32
+// bytes after decode). Both base64 standard encoding (with padding) and
+// URL encoding (with or without padding) are accepted; standard is
+// canonical.
 func LoadKeyring(path string) (*Ed25519Keyring, error) {
 	bytes, err := os.ReadFile(path)
 	if err != nil {
@@ -58,26 +114,45 @@ func LoadKeyring(path string) (*Ed25519Keyring, error) {
 		return nil, newError(ClassValidationError, BoundaryRuntime, false,
 			"keyring %q: invalid JSON: %s", path, err.Error())
 	}
-	if doc.Version != 1 {
+	if doc.Version != 1 && doc.Version != 2 {
 		return nil, newError(ClassValidationError, BoundaryRuntime, false,
-			"keyring %q: unsupported version %d (expected 1)", path, doc.Version)
+			"keyring %q: unsupported version %d (expected 1 or 2)", path, doc.Version)
+	}
+	if doc.Version == 1 && len(doc.Owners) > 0 {
+		return nil, newError(ClassValidationError, BoundaryRuntime, false,
+			"keyring %q: owner-level grants require version 2 (found %d owners under version 1)",
+			path, len(doc.Owners))
 	}
 	kr := NewEd25519Keyring()
-	for authority, pubs := range doc.Publishers {
+	if err := loadAuthorities(path, doc.Publishers, kr); err != nil {
+		return nil, err
+	}
+	if err := loadAuthorities(path, doc.Owners, kr); err != nil {
+		return nil, err
+	}
+	return kr, nil
+}
+
+// loadAuthorities decodes a map of authority → base64 keys into kr,
+// applying the empty-authority and key-decode validation shared by the
+// owners and publishers maps. Both grant kinds fold into the same flat
+// key map.
+func loadAuthorities(path string, authorities map[string][]string, kr *Ed25519Keyring) error {
+	for authority, pubs := range authorities {
 		if authority == "" {
-			return nil, newError(ClassValidationError, BoundaryRuntime, false,
+			return newError(ClassValidationError, BoundaryRuntime, false,
 				"keyring %q: empty authority key", path)
 		}
 		for i, pubB64 := range pubs {
 			pub, err := decodeEd25519Pub(pubB64)
 			if err != nil {
-				return nil, newError(ClassValidationError, BoundaryRuntime, false,
+				return newError(ClassValidationError, BoundaryRuntime, false,
 					"keyring %q: authority %q key[%d]: %s", path, authority, i, err.Error())
 			}
 			kr.Add(authority, pub)
 		}
 	}
-	return kr, nil
+	return nil
 }
 
 // decodeEd25519Pub decodes a base64-encoded ed25519 public key,
@@ -103,11 +178,20 @@ func decodeEd25519Pub(s string) (ed25519.PublicKey, error) {
 	return nil, fmt.Errorf("not valid base64")
 }
 
-// SaveKeyring writes the keyring's current state to disk as the v1
-// JSON shape. Authorities are emitted in sorted order so successive
-// saves produce stable diffs. The file is written with mode 0600 to
-// match the surrounding ~/.aileron/ files (vault, secrets); parent
-// directories are created with 0700 if missing.
+// SaveKeyring writes the keyring's current state to disk as the v2
+// JSON shape. The flat in-memory key map is partitioned back into the
+// "owners" and "publishers" maps by authority shape: owner-level
+// authorities (`<scheme>://<owner>`) go to "owners"; per-repo
+// authorities (`<scheme>://<owner>/<repo>`) go to "publishers". Both
+// maps emit authorities in sorted order so successive saves produce
+// stable diffs.
+//
+// "version" is always 2. When the keyring has no owner-level entries the
+// "owners" map is empty and omitted from the JSON (omitempty), so a file
+// whose content is v1-shaped stays clean while still declaring version
+// 2. The file is written with mode 0600 to match the surrounding
+// ~/.aileron/ files (vault, secrets); parent directories are created
+// with 0700 if missing.
 //
 // Save is the inverse of LoadKeyring: a subsequent Load reads back an
 // equivalent keyring (modulo key ordering within each authority,
@@ -115,17 +199,29 @@ func decodeEd25519Pub(s string) (ed25519.PublicKey, error) {
 func (k *Ed25519Keyring) SaveKeyring(path string) error {
 	k.mu.RLock()
 	doc := keyringFile{
-		Version:    1,
-		Publishers: make(map[string][]string, len(k.keys)),
+		Version:    2,
+		Owners:     map[string][]string{},
+		Publishers: map[string][]string{},
 	}
 	for authority, pubs := range k.keys {
 		encoded := make([]string, 0, len(pubs))
 		for _, pub := range pubs {
 			encoded = append(encoded, base64.StdEncoding.EncodeToString(pub))
 		}
-		doc.Publishers[authority] = encoded
+		if isOwnerAuthority(authority) {
+			doc.Owners[authority] = encoded
+		} else {
+			doc.Publishers[authority] = encoded
+		}
 	}
 	k.mu.RUnlock()
+
+	// omitempty fires on a nil map, not an empty non-nil one; drop the
+	// owners map explicitly when there are no owner-level grants so the
+	// common v1-shaped file omits the key entirely.
+	if len(doc.Owners) == 0 {
+		doc.Owners = nil
+	}
 
 	body, err := json.MarshalIndent(doc, "", "  ")
 	if err != nil {
@@ -197,6 +293,48 @@ func (k *Ed25519Keyring) HasKey(authority string, pub ed25519.PublicKey) bool {
 		}
 	}
 	return false
+}
+
+// OwnerAuthorities returns the owner-level authorities
+// (`<scheme>://<owner>`, no repo segment) the keyring has at least one
+// key registered for, in sorted order. It filters the flat key map to
+// owner-level entries, so it is the owner-grant counterpart to
+// Authorities(), which returns the per-repo set. ADR-0013 install-time
+// UX enumerates owner grants via this accessor without seeing per-repo
+// noise.
+func (k *Ed25519Keyring) OwnerAuthorities() []string {
+	k.mu.RLock()
+	defer k.mu.RUnlock()
+	out := make([]string, 0, len(k.keys))
+	for authority := range k.keys {
+		if isOwnerAuthority(authority) {
+			out = append(out, authority)
+		}
+	}
+	sort.Strings(out)
+	return out
+}
+
+// OwnerKeys returns a copy of the keys registered for an owner-level
+// authority. Returns nil if the authority is not present. Mirrors
+// Keys() for the owner-keyed call sites; derive the owner authority via
+// FQN.OwnerAuthority().
+func (k *Ed25519Keyring) OwnerKeys(ownerAuthority string) []ed25519.PublicKey {
+	return k.Keys(ownerAuthority)
+}
+
+// RemoveOwner drops every key registered for an owner-level authority.
+// Returns true when the authority was present (and its keys were
+// removed), false when it was not registered. Mirrors Remove().
+func (k *Ed25519Keyring) RemoveOwner(ownerAuthority string) bool {
+	return k.Remove(ownerAuthority)
+}
+
+// HasOwnerKey reports whether the keyring already trusts the given
+// public key for an owner-level authority. Mirrors HasKey() for the
+// owner-keyed call sites; matches on exact key and exact authority.
+func (k *Ed25519Keyring) HasOwnerKey(ownerAuthority string, pub ed25519.PublicKey) bool {
+	return k.HasKey(ownerAuthority, pub)
 }
 
 // ParsePEMPublicKey decodes a PEM-encoded ed25519 public key

--- a/internal/cstore/keyring_config_test.go
+++ b/internal/cstore/keyring_config_test.go
@@ -5,6 +5,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"errors"
 	"os"
@@ -402,6 +403,375 @@ func TestLoadKeyring_RetainsErrFromIO(t *testing.T) {
 	// errors.Is(fs.ErrNotExist) must be false for this case.
 	if _, err := cstore.LoadKeyring(dir); errors.Is(err, os.ErrNotExist) {
 		t.Error("EISDIR was misinterpreted as missing file")
+	}
+}
+
+// --- v2 schema: owners + publishers ---
+
+func TestLoadKeyring_V1FileLoadsUnderV2LoaderNoDataLoss(t *testing.T) {
+	// A version:1 file with only per-repo grants loads losslessly under
+	// the v2 loader: the per-repo key verifies and OwnerAuthorities() is
+	// empty.
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	body := `{"version":1,"publishers":{"github://acme/connector":["` +
+		base64.StdEncoding.EncodeToString(pub) + `"]}}`
+	p := filepath.Join(t.TempDir(), "k.json")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	kr, err := cstore.LoadKeyring(p)
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	sig := ed25519.Sign(priv, append([]byte("x"), []byte("y")...))
+	if err := kr.Verify("github://acme/connector", []byte("x"), []byte("y"), sig); err != nil {
+		t.Errorf("per-repo key did not verify: %v", err)
+	}
+	if got := kr.OwnerAuthorities(); len(got) != 0 {
+		t.Errorf("OwnerAuthorities() = %v, want empty for a v1 file", got)
+	}
+	if got := kr.Authorities(); len(got) != 1 || got[0] != "github://acme/connector" {
+		t.Errorf("Authorities() = %v, want [github://acme/connector]", got)
+	}
+}
+
+func TestLoadKeyring_V2FileWithBothMapsLoadsIndependently(t *testing.T) {
+	// An owner key verifies via the owner authority, a repo key via the
+	// repo authority, independently of each other.
+	ownerPub, ownerPriv, _ := ed25519.GenerateKey(rand.Reader)
+	repoPub, repoPriv, _ := ed25519.GenerateKey(rand.Reader)
+	body := `{
+		"version": 2,
+		"owners": {"github://acme": ["` + base64.StdEncoding.EncodeToString(ownerPub) + `"]},
+		"publishers": {"github://acme/connector": ["` + base64.StdEncoding.EncodeToString(repoPub) + `"]}
+	}`
+	p := filepath.Join(t.TempDir(), "k.json")
+	if err := os.WriteFile(p, []byte(body), 0o600); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	kr, err := cstore.LoadKeyring(p)
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	ownerSig := ed25519.Sign(ownerPriv, append([]byte("o"), []byte("m")...))
+	if err := kr.Verify("github://acme", []byte("o"), []byte("m"), ownerSig); err != nil {
+		t.Errorf("owner key did not verify under owner authority: %v", err)
+	}
+	repoSig := ed25519.Sign(repoPriv, append([]byte("r"), []byte("m")...))
+	if err := kr.Verify("github://acme/connector", []byte("r"), []byte("m"), repoSig); err != nil {
+		t.Errorf("repo key did not verify under repo authority: %v", err)
+	}
+	// The owner key must NOT verify under the repo authority (independence).
+	if err := kr.Verify("github://acme/connector", []byte("o"), []byte("m"), ownerSig); err == nil {
+		t.Error("owner key should not verify under a per-repo authority")
+	}
+}
+
+func TestSaveKeyring_V2RoundTripBothMaps(t *testing.T) {
+	ownerPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	repoPub, _, _ := ed25519.GenerateKey(rand.Reader)
+
+	kr := cstore.NewEd25519Keyring()
+	kr.Add("github://acme/connector", repoPub)
+	kr.AddOwner("github://acme", ownerPub)
+
+	p := filepath.Join(t.TempDir(), "keyring.json")
+	if err := kr.SaveKeyring(p); err != nil {
+		t.Fatalf("SaveKeyring: %v", err)
+	}
+
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read back: %v", err)
+	}
+	var doc struct {
+		Version    int                 `json:"version"`
+		Owners     map[string][]string `json:"owners"`
+		Publishers map[string][]string `json:"publishers"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("unmarshal saved file: %v", err)
+	}
+	if doc.Version != 2 {
+		t.Errorf("saved version = %d, want 2", doc.Version)
+	}
+	if _, ok := doc.Owners["github://acme"]; !ok {
+		t.Errorf("owners map missing github://acme: %v", doc.Owners)
+	}
+	if _, ok := doc.Publishers["github://acme/connector"]; !ok {
+		t.Errorf("publishers map missing github://acme/connector: %v", doc.Publishers)
+	}
+
+	loaded, err := cstore.LoadKeyring(p)
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !loaded.HasOwnerKey("github://acme", ownerPub) {
+		t.Error("owner key not preserved across round-trip")
+	}
+	if !loaded.HasKey("github://acme/connector", repoPub) {
+		t.Error("repo key not preserved across round-trip")
+	}
+}
+
+func TestSaveKeyring_OmitsOwnersWhenNoneButStillV2(t *testing.T) {
+	// A keyring with only per-repo entries saves version:2 with no
+	// "owners" key (omitempty) yet still reloads.
+	repoPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	kr := cstore.NewEd25519Keyring()
+	kr.Add("github://acme/connector", repoPub)
+
+	p := filepath.Join(t.TempDir(), "keyring.json")
+	if err := kr.SaveKeyring(p); err != nil {
+		t.Fatalf("SaveKeyring: %v", err)
+	}
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read: %v", err)
+	}
+	var probe map[string]json.RawMessage
+	if err := json.Unmarshal(raw, &probe); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if string(probe["version"]) != "2" {
+		t.Errorf("version = %s, want 2", probe["version"])
+	}
+	if _, present := probe["owners"]; present {
+		t.Errorf("owners key should be omitted when there are no owner grants; file: %s", raw)
+	}
+	loaded, err := cstore.LoadKeyring(p)
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !loaded.HasKey("github://acme/connector", repoPub) {
+		t.Error("repo key not preserved")
+	}
+}
+
+func TestLoadKeyring_RejectsVersionsOtherThan1And2(t *testing.T) {
+	for _, ver := range []string{"3", "0"} {
+		t.Run("version_"+ver, func(t *testing.T) {
+			p := filepath.Join(t.TempDir(), "k.json")
+			_ = os.WriteFile(p, []byte(`{"version":`+ver+`}`), 0o600)
+			_, err := cstore.LoadKeyring(p)
+			if err == nil {
+				t.Fatalf("expected error on version %s", ver)
+			}
+			var cerr *cstore.Error
+			if !errors.As(err, &cerr) || cerr.Class != cstore.ClassValidationError {
+				t.Errorf("err class = %v, want ClassValidationError", err)
+			}
+		})
+	}
+}
+
+func TestLoadKeyring_RejectsOwnersUnderVersion1(t *testing.T) {
+	// Owner-level grants are v2-only; a downgrade to version:1 that still
+	// lists owners must be rejected, not silently honored.
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	body := `{"version":1,"owners":{"github://acme":["` +
+		base64.StdEncoding.EncodeToString(pub) + `"]}}`
+	p := filepath.Join(t.TempDir(), "k.json")
+	_ = os.WriteFile(p, []byte(body), 0o600)
+	_, err := cstore.LoadKeyring(p)
+	if err == nil {
+		t.Fatal("expected error: owners under version 1")
+	}
+	var cerr *cstore.Error
+	if !errors.As(err, &cerr) || cerr.Class != cstore.ClassValidationError {
+		t.Errorf("err class = %v, want ClassValidationError", err)
+	}
+}
+
+func TestLoadKeyring_RejectsBadKeyInOwners(t *testing.T) {
+	p := filepath.Join(t.TempDir(), "k.json")
+	_ = os.WriteFile(p, []byte(`{"version":2,"owners":{"github://acme":["not-base64!!!"]}}`), 0o600)
+	_, err := cstore.LoadKeyring(p)
+	if err == nil {
+		t.Fatal("expected error on invalid base64 in owners")
+	}
+	var cerr *cstore.Error
+	if !errors.As(err, &cerr) || cerr.Class != cstore.ClassValidationError {
+		t.Errorf("err class = %v, want ClassValidationError", err)
+	}
+}
+
+func TestLoadKeyring_RejectsWrongLengthKeyInOwners(t *testing.T) {
+	tooShort := base64.StdEncoding.EncodeToString([]byte("only-a-few-bytes"))
+	p := filepath.Join(t.TempDir(), "k.json")
+	_ = os.WriteFile(p, []byte(`{"version":2,"owners":{"github://acme":["`+tooShort+`"]}}`), 0o600)
+	_, err := cstore.LoadKeyring(p)
+	if err == nil {
+		t.Fatal("expected error on wrong key length in owners")
+	}
+	var cerr *cstore.Error
+	if !errors.As(err, &cerr) || cerr.Class != cstore.ClassValidationError {
+		t.Errorf("err class = %v, want ClassValidationError", err)
+	}
+}
+
+func TestLoadKeyring_RejectsEmptyAuthorityInOwners(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	body := `{"version":2,"owners":{"":["` + base64.StdEncoding.EncodeToString(pub) + `"]}}`
+	p := filepath.Join(t.TempDir(), "k.json")
+	_ = os.WriteFile(p, []byte(body), 0o600)
+	_, err := cstore.LoadKeyring(p)
+	if err == nil {
+		t.Fatal("expected error on empty authority in owners")
+	}
+	var cerr *cstore.Error
+	if !errors.As(err, &cerr) || cerr.Class != cstore.ClassValidationError {
+		t.Errorf("err class = %v, want ClassValidationError", err)
+	}
+}
+
+// --- owner-keyed helper contracts ---
+
+func TestKeyringAddOwner_RegistersUnderOwnerAuthority(t *testing.T) {
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	kr := cstore.NewEd25519Keyring()
+	kr.AddOwner("github://acme", pub)
+	sig := ed25519.Sign(priv, append([]byte("a"), []byte("b")...))
+	if err := kr.Verify("github://acme", []byte("a"), []byte("b"), sig); err != nil {
+		t.Errorf("AddOwner key did not verify: %v", err)
+	}
+}
+
+func TestKeyringOwnerKeys_CopyAndNilForAbsent(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	kr := cstore.NewEd25519Keyring()
+	kr.AddOwner("github://acme", pub)
+
+	keys := kr.OwnerKeys("github://acme")
+	if len(keys) != 1 {
+		t.Fatalf("len(OwnerKeys) = %d, want 1", len(keys))
+	}
+	keys[0] = ed25519.PublicKey(make([]byte, 32)) // mutate the copy
+	again := kr.OwnerKeys("github://acme")
+	if !ed25519.PublicKey(again[0]).Equal(pub) {
+		t.Error("OwnerKeys() returned a slice aliased to internal storage")
+	}
+	if got := kr.OwnerKeys("github://absent"); got != nil {
+		t.Errorf("OwnerKeys(absent) = %v, want nil", got)
+	}
+}
+
+func TestKeyringHasOwnerKey_ExactKeyAndAuthorityOnly(t *testing.T) {
+	pub1, _, _ := ed25519.GenerateKey(rand.Reader)
+	pub2, _, _ := ed25519.GenerateKey(rand.Reader)
+	kr := cstore.NewEd25519Keyring()
+	kr.AddOwner("github://acme", pub1)
+
+	if !kr.HasOwnerKey("github://acme", pub1) {
+		t.Error("HasOwnerKey should be true for the added key")
+	}
+	if kr.HasOwnerKey("github://acme", pub2) {
+		t.Error("HasOwnerKey should be false for a different key")
+	}
+	if kr.HasOwnerKey("github://other", pub1) {
+		t.Error("HasOwnerKey should be false for a different authority")
+	}
+}
+
+func TestKeyringRemoveOwner_TrueHitFalseMiss(t *testing.T) {
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	kr := cstore.NewEd25519Keyring()
+	kr.AddOwner("github://acme", pub)
+
+	if !kr.RemoveOwner("github://acme") {
+		t.Error("RemoveOwner(present) = false; want true")
+	}
+	if kr.RemoveOwner("github://acme") {
+		t.Error("RemoveOwner(absent) = true; want false")
+	}
+	if got := kr.OwnerAuthorities(); len(got) != 0 {
+		t.Errorf("OwnerAuthorities after remove = %v, want empty", got)
+	}
+}
+
+func TestKeyringOwnerAuthorities_SortedOwnerOnlySplitFromAuthorities(t *testing.T) {
+	// A keyring with one owner-level entry and one per-repo entry returns
+	// just the owner authority from OwnerAuthorities() and just the repo
+	// authority from Authorities().
+	ownerPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	repoPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	owner2Pub, _, _ := ed25519.GenerateKey(rand.Reader)
+
+	kr := cstore.NewEd25519Keyring()
+	kr.Add("github://acme/connector", repoPub)
+	kr.AddOwner("github://zzz", owner2Pub)
+	kr.AddOwner("github://acme", ownerPub)
+
+	gotOwners := kr.OwnerAuthorities()
+	wantOwners := []string{"github://acme", "github://zzz"}
+	if len(gotOwners) != len(wantOwners) {
+		t.Fatalf("OwnerAuthorities() = %v, want %v", gotOwners, wantOwners)
+	}
+	for i, w := range wantOwners {
+		if gotOwners[i] != w {
+			t.Errorf("OwnerAuthorities()[%d] = %q, want %q (sorted, owner-only)", i, gotOwners[i], w)
+		}
+	}
+	// Authorities() returns the full flat set (owner + per-repo), but the
+	// per-repo authority must be present and the owner-level split must
+	// not leak into OwnerAuthorities's exclusion of the repo entry.
+	gotAuth := kr.Authorities()
+	foundRepo := false
+	for _, a := range gotAuth {
+		if a == "github://acme/connector" {
+			foundRepo = true
+		}
+	}
+	if !foundRepo {
+		t.Errorf("Authorities() = %v, want it to include github://acme/connector", gotAuth)
+	}
+	// The per-repo authority is NOT an owner authority.
+	for _, a := range gotOwners {
+		if a == "github://acme/connector" {
+			t.Error("OwnerAuthorities() leaked a per-repo authority")
+		}
+	}
+}
+
+// --- parsing-unchanged regression (brief: decode + PEM stay byte-for-byte) ---
+
+func TestLoadKeyring_DecodeUnchangedAcrossBase64Variants(t *testing.T) {
+	// Guards the brief's "decodeEd25519Pub stays unchanged" requirement:
+	// std/raw-std/url/raw-url base64 all decode and verify, in both the
+	// owners and publishers maps.
+	pub, priv, _ := ed25519.GenerateKey(rand.Reader)
+	encs := map[string]string{
+		"std":     base64.StdEncoding.EncodeToString(pub),
+		"raw_std": base64.RawStdEncoding.EncodeToString(pub),
+		"url":     base64.URLEncoding.EncodeToString(pub),
+		"raw_url": base64.RawURLEncoding.EncodeToString(pub),
+	}
+	for name, encoded := range encs {
+		t.Run(name, func(t *testing.T) {
+			body := `{"version":2,"owners":{"github://acme":["` + encoded + `"]}}`
+			p := filepath.Join(t.TempDir(), "k.json")
+			_ = os.WriteFile(p, []byte(body), 0o600)
+			kr, err := cstore.LoadKeyring(p)
+			if err != nil {
+				t.Fatalf("LoadKeyring(%s): %v", name, err)
+			}
+			sig := ed25519.Sign(priv, append([]byte("x"), []byte("y")...))
+			if err := kr.Verify("github://acme", []byte("x"), []byte("y"), sig); err != nil {
+				t.Errorf("%s: owner verify: %v", name, err)
+			}
+		})
+	}
+}
+
+func TestParsePEMPublicKey_UnchangedRoundTrip(t *testing.T) {
+	// Guards the brief's "ParsePEMPublicKey stays unchanged" requirement.
+	pub, _, _ := ed25519.GenerateKey(rand.Reader)
+	got, err := cstore.ParsePEMPublicKey(makeTestPEM(t, pub))
+	if err != nil {
+		t.Fatalf("ParsePEMPublicKey: %v", err)
+	}
+	if !ed25519.PublicKey(got).Equal(pub) {
+		t.Error("PKIX PEM round-trip changed the key")
 	}
 }
 

--- a/internal/cstore/verify.go
+++ b/internal/cstore/verify.go
@@ -62,6 +62,18 @@ func (k *Ed25519Keyring) Add(authority string, pub ed25519.PublicKey) {
 	k.keys[authority] = append(k.keys[authority], pub)
 }
 
+// AddOwner registers a public key as authorized for an owner-level
+// authority (`<scheme>://<owner>`, no repo segment) per ADR-0013
+// per-publisher trust. An owner-level grant and a per-repo grant for the
+// same publisher coexist as independent entries in the same flat key
+// map; this is a thin, discoverability wrapper over Add that documents
+// the owner-level contract for the owner-keyed call sites. Derive the
+// owner authority via FQN.OwnerAuthority(). Multiple keys may be
+// registered for the same owner to support key rotation.
+func (k *Ed25519Keyring) AddOwner(ownerAuthority string, pub ed25519.PublicKey) {
+	k.Add(ownerAuthority, pub)
+}
+
 // Verify implements Verifier.
 func (k *Ed25519Keyring) Verify(authority string, binary, manifest, signature []byte) error {
 	k.mu.RLock()


### PR DESCRIPTION
## Summary

Implements the ADR-0013 v2 keyring schema that carries owner-level (per-publisher) trust alongside the existing per-repo entries. This is the storage + loader + helpers foundation that the install-time UX sub-issues (#1417–#1420) build on.

- **Hybrid v2 on-disk shape.** `keyringFile` gains an `owners` map (`<scheme>://<owner>` authorities) as a sibling to the unchanged `publishers` map (`<scheme>://<owner>/<repo>`). Both fold into the same flat in-memory key map, so `Verify` is unchanged and an owner-level grant coexists with a per-repo grant for the same publisher as two independent entries.
- **`LoadKeyring` accepts version 1 and 2.** A v1 file loads losslessly under the v2 loader (per-repo entries land untouched, owner set empty). A `version: 1` document that nonetheless carries an `owners` map is rejected as a `ClassValidationError` so a downgrade cannot silently hide trust. Empty-authority and bad-key (base64/length) validation applies to both maps.
- **`SaveKeyring` always emits version 2**, partitioning the flat map back into `owners`/`publishers` by authority shape via a single `isOwnerAuthority` classifier (zero `/` after `<scheme>://` ⇒ owner-level). Both maps sorted for stable diffs; the `owners` map is omitted (`omitempty`) when there are no owner grants, so a v1-shaped file stays clean while still declaring version 2.
- **`FQN.OwnerAuthority()`** returns `<scheme>://<owner>` so callers and the partition never hand-split `Authority()`.
- **Owner-keyed helpers** `AddOwner` / `OwnerKeys` / `HasOwnerKey` / `RemoveOwner` / `OwnerAuthorities` mirror the per-repo helper contracts over the same storage. `OwnerAuthorities()` filters to owner-level entries (counterpart to `Authorities()`).

Out of scope (deferred to #1417–#1420): any `aileron keyring` CLI surface for owner trust, HTTP/install-decision handler changes, and `Verify`-time owner fallback. `Verify` logic is untouched.

ADR-0013 explicitly anticipates this: it reserves the `version` field for "a future v2 schema that supports per-publisher entries alongside or instead of per-repo entries" and names "hybrid coexistence with v1 per-repo entries" as a candidate shape — which is what this implements.

## Test plan

- `go test ./internal/cstore/` — all pass. New-code coverage: `OwnerAuthority` 100%, `LoadKeyring` 100%, `loadAuthorities` 100%, `OwnerAuthorities`/`OwnerKeys`/`RemoveOwner`/`HasOwnerKey`/`AddOwner` 100%. The residual uncovered lines are pre-existing defensive branches (`isOwnerAuthority` no-`://` guard, `SaveKeyring` marshal-error path) that cannot be exercised without contorting inputs.
- New tests cover: v1-loads-under-v2 (no data loss), v2 both-maps independent verify, v2 round-trip (both maps, version 2 emitted), owners-omitted-when-none, version 0/3 reject, v1+owners reject, bad/short/empty key in `owners`, all five owner-keyed helper contracts, and a parsing-unchanged regression (`decodeEd25519Pub` across std/raw-std/url/raw-url base64 + `ParsePEMPublicKey` PKIX round-trip).
- Regression-checked dependent suites that save/reload keyrings: `internal/app` (`-run 'Keyring|Trust|Install|Hub'`) and `cmd/aileron` (`-run 'Keyring|Trust|Install'`) both green — backward compatible because the v2 loader reads what the v2 saver writes.
- `gofmt` clean on all touched files; `coderabbit review` reports 0 findings.

Closes #1416

🤖 Generated with [Claude Code](https://claude.com/claude-code)
