### PR TITLE
feat(cstore): owner-level resolution in signature verify

### DIFF
--- a/internal/cstore/keyring_config_test.go
+++ b/internal/cstore/keyring_config_test.go
@@ -461,9 +461,19 @@ func TestLoadKeyring_V2FileWithBothMapsLoadsIndependently(t *testing.T) {
 	if err := kr.Verify("github://acme/connector", []byte("r"), []byte("m"), repoSig); err != nil {
 		t.Errorf("repo key did not verify under repo authority: %v", err)
 	}
-	// The owner key must NOT verify under the repo authority (independence).
-	if err := kr.Verify("github://acme/connector", []byte("o"), []byte("m"), ownerSig); err == nil {
-		t.Error("owner key should not verify under a per-repo authority")
+	// The two maps load into independent storage entries: OwnerKeys and
+	// Keys each return only their own scope's key, with no cross-bleed.
+	if got := kr.OwnerKeys("github://acme"); len(got) != 1 || !got[0].Equal(ownerPub) {
+		t.Errorf("OwnerKeys(github://acme) = %v, want only the owner key", got)
+	}
+	if got := kr.Keys("github://acme/connector"); len(got) != 1 || !got[0].Equal(repoPub) {
+		t.Errorf("Keys(github://acme/connector) = %v, want only the repo key", got)
+	}
+	// Under ADR-0013 (#1417) Verify resolves against the union of the
+	// owner-level and per-repo grants, so the owner key DOES verify under
+	// the per-repo authority — an owner grant authorizes every repo.
+	if err := kr.Verify("github://acme/connector", []byte("o"), []byte("m"), ownerSig); err != nil {
+		t.Errorf("owner key should verify under a per-repo authority via the union: %v", err)
 	}
 }
 

--- a/internal/cstore/verify.go
+++ b/internal/cstore/verify.go
@@ -18,6 +18,14 @@ import (
 // same canonical-hash input from ADR-0004) and the detached signature.
 // `authority` is the FQN's `<scheme>://<owner>/<repo>` triple — Verifier
 // implementations look up authorized keys keyed by this string.
+//
+// Resolution is the union of the owner-level grant
+// (`<scheme>://<owner>`, ADR-0013 per-publisher trust) and the per-repo
+// grant for `authority`: a signature that verifies against any key in
+// either scope is accepted. The union is positive-only — there is no
+// per-repo deny override of an owner-level grant. Fail-closed is
+// preserved: when the union is empty (neither scope trusts a key),
+// Verify fails with ClassSignatureFailure.
 type Verifier interface {
 	Verify(authority string, binary, manifest, signature []byte) error
 }
@@ -30,12 +38,20 @@ type Verifier interface {
 //
 //   - The signed payload is `binary || manifest` (the canonical-hash input
 //     from ADR-0004).
-//   - At least one registered key for the authority must verify the
-//     signature for the call to succeed.
-//   - When the authority has zero registered keys, Verify fails with
+//   - Resolution is the union of the owner-level grant
+//     (`<scheme>://<owner>`, ADR-0013 per-publisher trust) and the
+//     per-repo grant (`<scheme>://<owner>/<repo>`) for the authority. At
+//     least one key in that union must verify the signature for the call
+//     to succeed. The union is positive-only: there is no per-repo deny
+//     override of an owner-level grant, so an owner-level grant authorizes
+//     every repo under that owner.
+//   - When the union is empty (neither the owner-level nor the per-repo
+//     scope has a registered key), Verify fails with
 //     ClassSignatureFailure ("no signing key registered"). This is the
 //     "fail closed" behavior demanded by ADR-0004's failure-modes table —
-//     unsigned binaries are not accepted.
+//     unsigned binaries are not accepted. A malformed authority does not
+//     widen trust: owner derivation is skipped and resolution degrades to
+//     per-repo-only, still fail-closed.
 //
 // Key distribution and rotation are out of scope per ADR-0002 ("signing-
 // keys-and-rotation will be its own implementation note rather than a
@@ -74,10 +90,36 @@ func (k *Ed25519Keyring) AddOwner(ownerAuthority string, pub ed25519.PublicKey) 
 	k.Add(ownerAuthority, pub)
 }
 
-// Verify implements Verifier.
+// Verify implements Verifier. It resolves against the union of the
+// owner-level grant (`<scheme>://<owner>`) and the per-repo grant
+// (`authority`) per ADR-0013; see the Ed25519Keyring "Verification
+// semantics" doc block. A signature matching any key in either scope
+// succeeds; an empty union fails closed with ClassSignatureFailure.
 func (k *Ed25519Keyring) Verify(authority string, binary, manifest, signature []byte) error {
+	// Derive the owner-level authority from the per-repo authority by
+	// reusing fqn.go parsing (not a raw substring split). A malformed
+	// authority must not widen trust: on parse error we leave
+	// ownerAuthority empty so only the per-repo scope contributes,
+	// keeping the fail-closed behavior identical to the v1 path.
+	var ownerAuthority string
+	if parsed, err := ParseFQN(authority); err == nil {
+		ownerAuthority = parsed.OwnerAuthority()
+	}
+
+	// Snapshot both scopes under a single RLock so the union is an
+	// atomic read of the keyring — an owner grant added between the two
+	// lookups cannot produce a torn view. Copy into a local slice and
+	// release the lock before the (CPU-bound) ed25519 verification.
 	k.mu.RLock()
-	keys := append([]ed25519.PublicKey(nil), k.keys[authority]...)
+	perRepo := k.keys[authority]
+	keys := make([]ed25519.PublicKey, 0, len(perRepo)+len(k.keys[ownerAuthority]))
+	keys = append(keys, perRepo...)
+	// ownerAuthority == authority cannot happen for a well-formed FQN
+	// (the owner key has no repo segment), and ownerAuthority == "" maps
+	// to no entry, so this never double-counts the per-repo keys.
+	if ownerAuthority != "" {
+		keys = append(keys, k.keys[ownerAuthority]...)
+	}
 	k.mu.RUnlock()
 
 	if len(keys) == 0 {

--- a/internal/cstore/verify_test.go
+++ b/internal/cstore/verify_test.go
@@ -105,6 +105,154 @@ func TestEd25519Keyring_DifferentAuthorityIsDifferentTrustDomain(t *testing.T) {
 	}
 }
 
+// TestEd25519Keyring_OwnerLevelGrantAuthorizesEveryRepo pins the core
+// ADR-0013 feature: an owner-level grant (`<scheme>://<owner>`, no repo
+// segment) authorizes a signature for *every* repo under that owner with
+// no per-repo entry. Trust once by identity; all repos are covered.
+func TestEd25519Keyring_OwnerLevelGrantAuthorizesEveryRepo(t *testing.T) {
+	binary := []byte("BIN")
+	manifest := []byte("MAN")
+	sig, pub := signedManifest(t, binary, manifest)
+
+	ring := NewEd25519Keyring()
+	ring.AddOwner("github://aileron", pub) // owner-level only, no per-repo
+
+	for _, authority := range []string{"github://aileron/repoA", "github://aileron/repoB"} {
+		if err := ring.Verify(authority, binary, manifest, sig); err != nil {
+			t.Errorf("Verify(%q) under owner-level grant err = %v", authority, err)
+		}
+	}
+}
+
+// TestEd25519Keyring_UntrustedOwnerFailsClosed pins fail-closed for the
+// owner dimension: with neither an owner-level grant nor a per-repo
+// grant, Verify must reject with ClassSignatureFailure and the
+// "no signing key" diagnosis.
+func TestEd25519Keyring_UntrustedOwnerFailsClosed(t *testing.T) {
+	binary := []byte("BIN")
+	manifest := []byte("MAN")
+	sig, _ := signedManifest(t, binary, manifest)
+
+	ring := NewEd25519Keyring() // empty: no owner-level, no per-repo
+	err := ring.Verify("github://aileron/slack", binary, manifest, sig)
+	if err == nil {
+		t.Fatal("Verify with no grant of any scope succeeded; want failure")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) || aerr.Class != ClassSignatureFailure {
+		t.Fatalf("err class = %v, want ClassSignatureFailure", aerr)
+	}
+	if !strings.Contains(err.Error(), "no signing key") {
+		t.Errorf("err = %q; want it to mention missing key", err.Error())
+	}
+}
+
+// TestEd25519Keyring_PerRepoGrantStillAuthorizes guards the v1 path:
+// a per-repo grant with no owner-level grant present still authorizes
+// exactly its FQN. The owner-level union must not regress per-repo-only
+// behavior.
+func TestEd25519Keyring_PerRepoGrantStillAuthorizes(t *testing.T) {
+	binary := []byte("BIN")
+	manifest := []byte("MAN")
+	sig, pub := signedManifest(t, binary, manifest)
+
+	ring := NewEd25519Keyring()
+	ring.Add("github://aileron/slack", pub) // per-repo only, no owner-level
+
+	if err := ring.Verify("github://aileron/slack", binary, manifest, sig); err != nil {
+		t.Errorf("Verify under per-repo-only grant err = %v", err)
+	}
+}
+
+// TestEd25519Keyring_UnionAcceptsEitherScope pins the no-deny-list union
+// semantics: when an owner-level grant (key A) and a per-repo grant
+// (key B) both exist for the same authority, a signature under A AND a
+// signature under B each verify. Neither scope shadows the other.
+func TestEd25519Keyring_UnionAcceptsEitherScope(t *testing.T) {
+	binary := []byte("BIN")
+	manifest := []byte("MAN")
+	sigA, pubA := signedManifest(t, binary, manifest) // owner-level key
+	sigB, pubB := signedManifest(t, binary, manifest) // per-repo key
+
+	ring := NewEd25519Keyring()
+	ring.AddOwner("github://aileron", pubA)
+	ring.Add("github://aileron/slack", pubB)
+
+	if err := ring.Verify("github://aileron/slack", binary, manifest, sigA); err != nil {
+		t.Errorf("Verify under owner-level key (A) err = %v", err)
+	}
+	if err := ring.Verify("github://aileron/slack", binary, manifest, sigB); err != nil {
+		t.Errorf("Verify under per-repo key (B) err = %v", err)
+	}
+}
+
+// TestEd25519Keyring_OwnerDerivationIsSchemeAgnostic confirms owner
+// derivation uses ParseFQN (not a hardcoded `github`): an owner-level
+// grant under gitlab:// authorizes a gitlab:// repo.
+func TestEd25519Keyring_OwnerDerivationIsSchemeAgnostic(t *testing.T) {
+	binary := []byte("BIN")
+	manifest := []byte("MAN")
+	sig, pub := signedManifest(t, binary, manifest)
+
+	ring := NewEd25519Keyring()
+	ring.AddOwner("gitlab://acme", pub)
+
+	if err := ring.Verify("gitlab://acme/widgets", binary, manifest, sig); err != nil {
+		t.Errorf("Verify(gitlab://acme/widgets) under gitlab owner grant err = %v", err)
+	}
+}
+
+// TestEd25519Keyring_OwnerGrantDoesNotLeakAcrossOwners pins that the
+// derived owner-level key is owner-scoped: an owner-level grant for
+// github://aileron must NOT authorize github://acme/slack (different
+// owner). The "different authority is a different trust domain"
+// invariant holds for the owner dimension too.
+func TestEd25519Keyring_OwnerGrantDoesNotLeakAcrossOwners(t *testing.T) {
+	binary := []byte("BIN")
+	manifest := []byte("MAN")
+	sig, pub := signedManifest(t, binary, manifest)
+
+	ring := NewEd25519Keyring()
+	ring.AddOwner("github://aileron", pub)
+
+	err := ring.Verify("github://acme/slack", binary, manifest, sig)
+	if err == nil {
+		t.Fatal("Verify across owners under owner-level grant succeeded; want failure")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) || aerr.Class != ClassSignatureFailure {
+		t.Fatalf("err class = %v, want ClassSignatureFailure", aerr)
+	}
+}
+
+// TestEd25519Keyring_MalformedAuthorityStaysFailClosed pins the single
+// behavioral risk: a malformed authority must not widen trust. The
+// ParseFQN error path degrades to per-repo-only resolution; with no
+// matching per-repo entry it fails closed (and never panics), even when
+// the keyring is non-empty.
+func TestEd25519Keyring_MalformedAuthorityStaysFailClosed(t *testing.T) {
+	binary := []byte("BIN")
+	manifest := []byte("MAN")
+	sig, pub := signedManifest(t, binary, manifest)
+
+	// Non-empty keyring: an owner-level grant and a per-repo grant under
+	// a well-formed owner exist, but the queried authority is malformed.
+	ring := NewEd25519Keyring()
+	ring.AddOwner("github://aileron", pub)
+	ring.Add("github://aileron/slack", pub)
+
+	for _, bad := range []string{"not-a-valid-fqn", "ftp://aileron/slack", "github://other-owner"} {
+		err := ring.Verify(bad, binary, manifest, sig)
+		if err == nil {
+			t.Fatalf("Verify(%q) on malformed/owner-only authority succeeded; want failure", bad)
+		}
+		var aerr *Error
+		if !errors.As(err, &aerr) || aerr.Class != ClassSignatureFailure {
+			t.Fatalf("Verify(%q) err class = %v, want ClassSignatureFailure", bad, aerr)
+		}
+	}
+}
+
 // TestReloadingKeyring_PicksUpFileChangesWithoutDaemonRestart pins the
 // fix for finding #4 of #532: when the user runs `aileron keyring trust
 // <authority> <pubkey>`, the CLI writes to ~/.aileron/keyring.json


### PR DESCRIPTION
## Summary

Makes an owner-level grant (`<scheme>://<owner>`) authorize a connector at signature-verify time, per ADR-0013 per-publisher trust.

Previously `Ed25519Keyring.Verify(authority, ...)` resolved keys only against the exact per-repo authority (`<scheme>://<owner>/<repo>`). It now resolves against the **union** of (owner-level grant keys ∪ per-repo grant keys) and verifies if the signature matches **any** key in that union. Trust an owner once by identity and every repo under that owner is covered, with no per-repo deny override (positive grants only — no precedence conflict).

Key properties:
- **Fail-closed preserved.** An empty union (neither scope has a registered key) ⇒ `ClassSignatureFailure` with the existing "no signing key registered for authority %q" message, keyed on the per-repo authority the caller asked for.
- **Owner derivation reuses `fqn.go`.** The owner-level authority is derived via `ParseFQN(authority)` + `FQN.OwnerAuthority()`, not a raw substring split.
- **Malformed authority does not widen trust.** On `ParseFQN` error, owner derivation is skipped and resolution degrades to per-repo-only — still fail-closed, never panics.
- **Atomic read.** Both scopes are snapshotted under a single `RLock` before the CPU-bound ed25519 verification, so an owner grant added between the two lookups cannot produce a torn view.

Consumes the owner-keyed storage from #1416 (landed as #1430). `ReloadingKeyring.Verify` inherits the new resolution for free via delegation. No CLI, schema/loader, trust-state, ADR, or OpenAPI changes (those are #1418/#1419/#1420) — this is a pure internal `cstore` change.

One stale assertion from #1416 was updated: `TestLoadKeyring_V2FileWithBothMapsLoadsIndependently` previously asserted at the `Verify` level that an owner key does NOT verify under a per-repo authority. That is exactly the behavior this issue changes. Storage independence is now asserted through the `OwnerKeys`/`Keys` accessors, and the union behavior is asserted at `Verify`.

## Test plan

- `go test -run 'Ed25519Keyring|ReloadingKeyring' -count=1 ./internal/cstore/...` — green.
- `go test -cover ./internal/cstore/...` — 88.1%; `Verify` at 100% function coverage (owner-key fetch, parse-error fallback, union iteration all exercised).
- `go build ./internal/... ./cmd/aileron/...` and `go vet ./internal/cstore/...` — clean.
- **Regression discipline (stash-the-fix):** scenarios 1 (owner grant authorizes multiple repos), 4 (union accepts either scope), and 5 (scheme-agnostic owner derivation) each fail with `verify.go` reverted and pass with the fix.

New tests in `verify_test.go` cover: owner grant authorizes multiple repos with no per-repo entry; untrusted owner fails closed; per-repo grant still authorizes its FQN; union accepts either scope (no deny-list); scheme-agnostic owner derivation (`gitlab://`); owner grant does not leak across owners; malformed authority stays fail-closed.

Closes #1417
