### PR TITLE
test(cstore): pin cross-scheme owner isolation fails closed

### DIFF
--- a/internal/cstore/verify_test.go
+++ b/internal/cstore/verify_test.go
@@ -225,6 +225,30 @@ func TestEd25519Keyring_OwnerGrantDoesNotLeakAcrossOwners(t *testing.T) {
 	}
 }
 
+// TestEd25519Keyring_OwnerGrantDoesNotLeakAcrossSchemes pins that the
+// derived owner-level key is scheme-scoped: an owner-level grant for
+// github://aileron must NOT authorize gitlab://aileron/widgets (same
+// owner segment, different scheme). Keys are keyed by the full
+// scheme://owner string, so the two are distinct trust domains and the
+// cross-scheme case fails closed.
+func TestEd25519Keyring_OwnerGrantDoesNotLeakAcrossSchemes(t *testing.T) {
+	binary := []byte("BIN")
+	manifest := []byte("MAN")
+	sig, pub := signedManifest(t, binary, manifest)
+
+	ring := NewEd25519Keyring()
+	ring.AddOwner("github://aileron", pub)
+
+	err := ring.Verify("gitlab://aileron/widgets", binary, manifest, sig)
+	if err == nil {
+		t.Fatal("Verify across schemes under owner-level grant succeeded; want failure")
+	}
+	var aerr *Error
+	if !errors.As(err, &aerr) || aerr.Class != ClassSignatureFailure {
+		t.Fatalf("err class = %v, want ClassSignatureFailure", aerr)
+	}
+}
+
 // TestEd25519Keyring_MalformedAuthorityStaysFailClosed pins the single
 // behavioral risk: a malformed authority must not widen trust. The
 // ParseFQN error path degrades to per-repo-only resolution; with no


### PR DESCRIPTION
## Summary

Adds `TestEd25519Keyring_OwnerGrantDoesNotLeakAcrossSchemes` to `internal/cstore/verify_test.go`, closing the one remaining actionable finding from the #1417 plan review (residual #1425).

The shipped keyring suite already pins scheme-agnostic owner derivation (`OwnerDerivationIsSchemeAgnostic`) and cross-OWNER non-leak (`OwnerGrantDoesNotLeakAcrossOwners`), but nothing asserted the specific cross-SCHEME case the acceptance item demands: an owner grant for `github://aileron` must fail closed for `gitlab://aileron/<repo>` (same owner segment, different scheme). Because keys are keyed by the full `scheme://owner` string the code is already structurally safe; this test pins that invariant against regression.

The new test asserts `Verify("gitlab://aileron/widgets", ...)` under a `github://aileron` owner grant returns an `*Error` with `Class == ClassSignatureFailure`, mirroring `TestEd25519Keyring_OwnerGrantDoesNotLeakAcrossOwners`.

## Test plan

- `go test ./internal/cstore/` — green (new test passes; full package passes)
- `go vet ./internal/cstore/` — clean

Closes #1425
