### PR TITLE
feat(cli): owner-granularity keyring trust/list/revoke + install prompts

### DIFF
--- a/cmd/aileron/keyring.go
+++ b/cmd/aileron/keyring.go
@@ -519,7 +519,10 @@ func runKeyringList(args []string, stdout, stderr io.Writer) int {
 
 	fmt.Fprintf(stdout, "Trusted publishers (%d):\n", len(ownerList))
 	for _, owner := range ownerList {
-		ownerKeys := keyring.Keys(owner)
+		// OwnerKeys is the documented owner-read accessor; owner-level and
+		// per-repo grants share one flat key map, so this returns exactly
+		// the owner-level fingerprints for the header.
+		ownerKeys := keyring.OwnerKeys(owner)
 		fmt.Fprintf(stdout, "  %s  (%d owner %s)\n", owner, len(ownerKeys), pluralKeys(len(ownerKeys)))
 		for _, key := range ownerKeys {
 			fmt.Fprintf(stdout, "    %s\n", fingerprint(key))

--- a/cmd/aileron/keyring.go
+++ b/cmd/aileron/keyring.go
@@ -4,10 +4,12 @@ import (
 	"crypto/ed25519"
 	"crypto/sha256"
 	"encoding/base64"
+	"flag"
 	"fmt"
 	"io"
 	"net/http"
 	"net/url"
+	"sort"
 	"strings"
 	"time"
 
@@ -56,15 +58,27 @@ func runKeyring(args []string, stdout, stderr io.Writer) int {
 	}
 }
 
-// runKeyringTrust fetches a publisher's ed25519 public key from the
-// conventional `keys/publisher.pub` path on the source repo's default
-// branch (per ADR-0002) and adds it to the local keyring. Adding a
-// key the keyring already trusts for the same authority is a no-op,
-// so re-running is safe.
+// runKeyringTrust grants owner-level trust for a connector publisher
+// (ADR-0013 per-publisher trust). Two input forms are accepted:
+//
+//   - A full per-repo FQN (`github://owner/repo`) fetches that repo's
+//     own `keys/publisher.pub` on its default branch (per ADR-0002) and
+//     writes an owner-level grant for `github://owner`, so the single
+//     grant covers every connector that publisher ships.
+//   - A bare owner (`github://owner`) resolves the publisher's key from
+//     the Hub catalog entry's `key_url` for that owner. When no Hub
+//     entry carries a resolvable `key_url`, the command errors with
+//     guidance to trust via a specific connector instead of guessing a
+//     profile-repo path.
+//
+// Writing an owner-level key the keyring already trusts is a no-op, so
+// re-running is safe.
 func runKeyringTrust(args []string, stdout, stderr io.Writer) int {
 	if len(args) != 1 {
 		fmt.Fprintln(stderr, "usage: aileron keyring trust <authority>")
-		fmt.Fprintln(stderr, "  authority: e.g. github://ALRubinger/aileron-connector-google")
+		fmt.Fprintln(stderr, "  authority: github://owner            (trust the whole publisher, key resolved via the Hub)")
+		fmt.Fprintln(stderr, "             github://owner/connector  (trust the whole publisher, key from the connector repo)")
+		fmt.Fprintln(stderr, "  Trusting an owner covers every connector that publisher ships.")
 		return 1
 	}
 	authority := args[0]
@@ -73,9 +87,9 @@ func runKeyringTrust(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	pub, err := fetchPublisherKey(authority)
+	ownerAuthority, pub, err := resolveTrustKey(authority, stderr)
 	if err != nil {
-		fmt.Fprintf(stderr, "error: fetch publisher key for %s: %v\n", authority, err)
+		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
 
@@ -90,23 +104,127 @@ func runKeyringTrust(args []string, stdout, stderr io.Writer) int {
 		return 1
 	}
 
-	if keyring.HasKey(authority, pub) {
-		fmt.Fprintf(stdout, "Known publisher already trusted: %s\n", authority)
+	if keyring.HasOwnerKey(ownerAuthority, pub) {
+		fmt.Fprintf(stdout, "Publisher already trusted: %s\n", ownerAuthority)
 		fmt.Fprintf(stdout, "  Fingerprint: %s\n", fingerprint(pub))
 		fmt.Fprintf(stdout, "  Keyring: %s\n", path)
 		return 0
 	}
 
-	keyring.Add(authority, pub)
+	keyring.AddOwner(ownerAuthority, pub)
 	if err := keyring.SaveKeyring(path); err != nil {
 		fmt.Fprintf(stderr, "error: save keyring: %v\n", err)
 		return 1
 	}
 
-	fmt.Fprintf(stdout, "✓ Trusted publisher %s\n", authority)
+	fmt.Fprintf(stdout, "✓ Trusted publisher %s\n", ownerAuthority)
+	fmt.Fprintln(stdout, "  This covers every connector this publisher ships.")
 	fmt.Fprintf(stdout, "  Fingerprint: %s\n", fingerprint(pub))
 	fmt.Fprintf(stdout, "  Keyring: %s\n", path)
 	return 0
+}
+
+// resolveTrustKey maps a `keyring trust` argument to the owner-level
+// authority to grant and the publisher key to grant it. A full per-repo
+// FQN resolves the key from that connector's own `keys/publisher.pub`;
+// a bare owner resolves it from the Hub entry's `key_url`. Either way
+// the returned authority is owner-level (`<scheme>://<owner>`) so the
+// grant lands in the owners map per ADR-0013.
+func resolveTrustKey(authority string, stderr io.Writer) (string, ed25519.PublicKey, error) {
+	if isBareOwnerAuthority(authority) {
+		// Normalize a trailing slash so the grant key is canonical
+		// (`github://acme`, not `github://acme/`).
+		ownerAuthority := strings.TrimRight(authority, "/")
+		pub, err := resolveOwnerKeyFromHub(ownerAuthority, stderr)
+		if err != nil {
+			return "", nil, err
+		}
+		return ownerAuthority, pub, nil
+	}
+	fqn, err := cstore.ParseFQN(authority)
+	if err != nil {
+		return "", nil, fmt.Errorf("parse authority %s: %w", authority, err)
+	}
+	pub, err := fetchPublisherKey(fqn.Authority())
+	if err != nil {
+		return "", nil, fmt.Errorf("fetch publisher key for %s: %w", fqn.Authority(), err)
+	}
+	return fqn.OwnerAuthority(), pub, nil
+}
+
+// isBareOwnerAuthority reports whether s is a `<scheme>://<owner>` with
+// no repo segment after the host. ParseFQN rejects this shape ("missing
+// repo segment"), so the bare-owner branch is detected here before
+// parsing. A trailing slash (`github://owner/`) is treated as bare so
+// it routes to Hub resolution rather than a per-repo fetch with an
+// empty repo.
+func isBareOwnerAuthority(s string) bool {
+	const sep = "://"
+	idx := strings.Index(s, sep)
+	if idx < 0 {
+		return false
+	}
+	rest := s[idx+len(sep):]
+	slash := strings.Index(rest, "/")
+	if slash < 0 {
+		return rest != ""
+	}
+	// `github://owner/` (trailing slash, nothing after) is still bare.
+	return strings.TrimRight(rest[slash+1:], "/") == ""
+}
+
+// resolveOwnerKeyFromHub resolves a publisher's signing key from the Hub
+// catalog for a bare owner authority (`github://owner`). It queries the
+// connectors catalog and uses the first entry whose publisher matches
+// the owner and whose `key_url` is non-empty, fetching and decoding that
+// key. The key always comes from a connector's own per-repo
+// `keys/publisher.pub` (the `key_url` the Hub records); this never
+// guesses a `<owner>/<owner>` profile-repo path. When no entry yields a
+// usable `key_url`, it returns an error pointing the user at the
+// specific-connector form.
+func resolveOwnerKeyFromHub(ownerAuthority string, stderr io.Writer) (ed25519.PublicKey, error) {
+	// Append a placeholder repo so ParseFQN (which requires a repo
+	// segment) yields the owner; trim any trailing slash on the input
+	// first so `github://owner/` does not produce a double slash.
+	fqn, err := cstore.ParseFQN(strings.TrimRight(ownerAuthority, "/") + "/_")
+	if err != nil {
+		return nil, fmt.Errorf("parse owner authority %s: %w", ownerAuthority, err)
+	}
+	owner := fqn.Owner
+	ownerAuthority = fqn.OwnerAuthority()
+
+	entries, code := fetchHubConnectors("", stderr)
+	if code != 0 {
+		return nil, fmt.Errorf("query Hub for publisher %s; trust via a specific connector, e.g. keyring trust %s/<repo>", ownerAuthority, ownerAuthority)
+	}
+	for _, e := range entries {
+		if e.KeyURL == "" {
+			continue
+		}
+		if !ownerMatchesEntry(owner, e) {
+			continue
+		}
+		pub, err := fetchKeyFromURL(e.KeyURL)
+		if err != nil {
+			return nil, fmt.Errorf("fetch publisher key from %s (Hub key_url for %s): %w", e.KeyURL, ownerAuthority, err)
+		}
+		return pub, nil
+	}
+	return nil, fmt.Errorf("no Hub entry with a publisher key for %s; trust via a specific connector, e.g. keyring trust %s/<repo>", ownerAuthority, ownerAuthority)
+}
+
+// ownerMatchesEntry reports whether a Hub connector entry belongs to the
+// named owner. The owner is matched against the entry's FQN owner
+// segment (authoritative) and, as a fallback, the publisher_github
+// field, so the resolution does not depend on a single field's
+// population.
+func ownerMatchesEntry(owner string, e hubConnectorEntry) bool {
+	if e.FQN != "" {
+		if fqn, err := cstore.ParseFQN(e.FQN); err == nil && fqn.Owner == owner {
+			return true
+		}
+	}
+	return e.PublisherGithub == owner
 }
 
 // fetchPublisherKey downloads the ed25519 public key a connector
@@ -132,7 +250,17 @@ func fetchPublisherKey(authority string) (ed25519.PublicKey, error) {
 		url.PathEscape(fqn.Repo),
 		publisherKeyPath,
 	)
+	return fetchKeyFromURL(keyURL)
+}
 
+// fetchKeyFromURL GETs an ed25519 public key from an absolute URL and
+// decodes it (PEM or base64). Shared by fetchPublisherKey (the
+// convention-path fetch) and the Hub `key_url` resolution
+// (resolveOwnerKeyFromHub), so both honor the same timeout, size cap,
+// and decode rules. The 404 message names the convention path because
+// that is the most common cause for the per-repo fetch; the Hub path
+// fetches a fully-qualified `key_url` and surfaces the same status.
+func fetchKeyFromURL(keyURL string) (ed25519.PublicKey, error) {
 	client := &http.Client{Timeout: publisherKeyFetchTimeout}
 	resp, err := client.Get(keyURL)
 	if err != nil {
@@ -187,18 +315,58 @@ func newTrustState() *trustState {
 // so subsequent same-authority actions in the suite skip without
 // re-prompting.
 func (s *trustState) ensure(authority string, autoYes bool, stdin io.Reader, stdout, stderr io.Writer) error {
-	if s.declined[authority] {
-		return fmt.Errorf("publisher %s trust previously declined this run; skipping", authority)
-	}
-	if s.trusted[authority] {
+	// Key the in-run memo on the owner authority so the first connector
+	// of a publisher resolves trust for every sibling connector in the
+	// same run: a second `<owner>/<other-repo>` maps to the same owner
+	// key and short-circuits without re-prompting (suite single-prompt-
+	// per-owner). A malformed authority degrades to keying on the raw
+	// string, which is still safe (it just loses cross-repo sharing).
+	owner := ownerAuthorityOf(authority)
+	// A previously-resolved owner suppresses this run's re-prompt for any
+	// sibling connector; a previously-resolved exact per-repo authority
+	// suppresses only itself. Check both scopes so an owner grant earned
+	// for one connector covers the next under the same publisher, while a
+	// per-repo-only resolution does not.
+	if (owner != "" && (s.declined[owner] || s.trusted[owner])) || s.declined[authority] || s.trusted[authority] {
+		if s.declined[owner] || s.declined[authority] {
+			return fmt.Errorf("publisher %s trust previously declined this run; skipping", authority)
+		}
 		return nil
 	}
-	if err := ensureAuthorityTrusted(authority, autoYes, stdin, stdout, stderr); err != nil {
-		s.declined[authority] = true
+	ownerCovered, err := ensureAuthorityTrusted(authority, autoYes, stdin, stdout, stderr)
+	if err != nil {
+		// Decline at the granularity that was attempted: the owner when an
+		// owner grant was the path, else the exact authority. Declining at
+		// owner granularity matches the suite single-prompt-per-owner rule.
+		if owner != "" {
+			s.declined[owner] = true
+		} else {
+			s.declined[authority] = true
+		}
 		return err
 	}
-	s.trusted[authority] = true
+	// Record trust at owner granularity only when the resolution actually
+	// covered the owner (owner grant present or written). A per-repo-pin
+	// no-op records only the exact authority, so a sibling still prompts.
+	if ownerCovered && owner != "" {
+		s.trusted[owner] = true
+	} else {
+		s.trusted[authority] = true
+	}
 	return nil
+}
+
+// ownerAuthorityOf derives the owner-level authority
+// (`<scheme>://<owner>`) from a per-repo authority by reusing fqn.go
+// parsing. Returns "" when the authority does not parse, so callers can
+// fall back to the raw string rather than widening trust on a malformed
+// input (matching verify.go's degrade-to-per-repo behavior).
+func ownerAuthorityOf(authority string) string {
+	fqn, err := cstore.ParseFQN(authority)
+	if err != nil {
+		return ""
+	}
+	return fqn.OwnerAuthority()
 }
 
 // ensureAuthorityTrusted is the install-time bridge to the keyring:
@@ -217,44 +385,82 @@ func (s *trustState) ensure(authority string, autoYes bool, stdin io.Reader, std
 // Single-action callers can use this directly. Suite callers should
 // thread a *trustState through trustState.ensure so the same
 // authority isn't prompted twice across the suite.
-func ensureAuthorityTrusted(authority string, autoYes bool, stdin io.Reader, stdout, stderr io.Writer) error {
+// The boolean return reports whether trust now resolves at owner
+// granularity (an owner-level grant is present or was just written), as
+// opposed to a per-repo-only pin. trustState.ensure uses it to decide
+// whether to suppress re-prompts for sibling connectors under the same
+// owner this run.
+func ensureAuthorityTrusted(authority string, autoYes bool, stdin io.Reader, stdout, stderr io.Writer) (bool, error) {
 	path := cstore.DefaultKeyringPath()
 	if path == "" {
-		return fmt.Errorf("cannot determine home directory; set $HOME or run `aileron keyring trust %s` manually", authority)
+		return false, fmt.Errorf("cannot determine home directory; set $HOME or run `aileron keyring trust %s` manually", authority)
 	}
 	keyring, err := cstore.LoadKeyring(path)
 	if err != nil {
-		return fmt.Errorf("load keyring %q: %w", path, err)
+		return false, fmt.Errorf("load keyring %q: %w", path, err)
+	}
+
+	// Trusted predicate == verify.go's union resolution: an install
+	// verifies when the owner-level grant OR the per-repo grant has a
+	// key. Short-circuit on either so we never re-prompt for an
+	// authority that already verifies. The owner-level scope is what an
+	// accepted prompt writes; the per-repo scope honors a standalone pin
+	// a user may have placed by hand.
+	ownerAuthority := ownerAuthorityOf(authority)
+	ownerHasKey := ownerAuthority != "" && len(keyring.OwnerKeys(ownerAuthority)) > 0
+	if ownerHasKey {
+		return true, nil
 	}
 	if len(keyring.Keys(authority)) > 0 {
-		return nil
+		// Satisfied by a per-repo pin only: not owner-covered.
+		return false, nil
 	}
 
 	fmt.Fprintln(stdout)
 	fmt.Fprintf(stdout, "Publisher %s is not yet trusted.\n", authority)
 	fmt.Fprintf(stdout, "  Aileron will fetch %s on the publisher's default branch\n", publisherKeyPath)
-	fmt.Fprintln(stdout, "  and use that key to verify signed installs from this publisher.")
+	if ownerAuthority != "" {
+		fmt.Fprintf(stdout, "  and trust %s to verify signed installs from every connector\n", ownerAuthority)
+		fmt.Fprintln(stdout, "  this publisher ships.")
+	} else {
+		fmt.Fprintln(stdout, "  and use that key to verify signed installs from this publisher.")
+	}
 
 	if !autoYes {
 		ans := strings.ToLower(strings.TrimSpace(promptLine(stdin, stdout,
 			fmt.Sprintf("Trust publisher %s? [y/N]: ", authority))))
 		if ans != "y" && ans != "yes" {
-			return fmt.Errorf("publisher %s not trusted; aborting", authority)
+			return false, fmt.Errorf("publisher %s not trusted; aborting", authority)
 		}
 	}
 
+	// Exactly one fetch: the per-repo connector key already on the
+	// convention path. The grant is written owner-level so it covers
+	// every connector the publisher ships (ADR-0013) — no second fetch,
+	// avoiding the #563 single-install regression.
 	pub, err := fetchPublisherKey(authority)
 	if err != nil {
-		return fmt.Errorf("fetch publisher key for %s: %w", authority, err)
+		return false, fmt.Errorf("fetch publisher key for %s: %w", authority, err)
 	}
-	keyring.Add(authority, pub)
+	ownerCovered := ownerAuthority != ""
+	grantAuthority := ownerAuthority
+	if grantAuthority == "" {
+		// Malformed authority: fall back to a per-repo grant so the
+		// install can still proceed, mirroring verify.go's degrade path.
+		grantAuthority = authority
+		if !keyring.HasKey(grantAuthority, pub) {
+			keyring.Add(grantAuthority, pub)
+		}
+	} else if !keyring.HasOwnerKey(grantAuthority, pub) {
+		keyring.AddOwner(grantAuthority, pub)
+	}
 	if err := keyring.SaveKeyring(path); err != nil {
-		return fmt.Errorf("save keyring: %w", err)
+		return false, fmt.Errorf("save keyring: %w", err)
 	}
-	fmt.Fprintf(stdout, "✓ Trusted publisher %s\n", authority)
+	fmt.Fprintf(stdout, "✓ Trusted publisher %s\n", grantAuthority)
 	fmt.Fprintf(stdout, "  Fingerprint: %s\n", fingerprint(pub))
 	fmt.Fprintf(stdout, "  Keyring: %s\n", path)
-	return nil
+	return ownerCovered, nil
 }
 
 // runKeyringList prints the trusted publishers and a fingerprint per
@@ -286,29 +492,85 @@ func runKeyringList(args []string, stdout, stderr io.Writer) int {
 		return 0
 	}
 
-	fmt.Fprintf(stdout, "Trusted publishers (%d):\n", len(authorities))
+	// Group every authority under its owner. Owner-level grants surface
+	// as the owner's own fingerprints; per-repo grants nest under the
+	// same owner. An owner with only per-repo grants still gets a header
+	// (no owner-level line). Owners are printed sorted; per-repo
+	// authorities under each owner are printed sorted.
+	owners := map[string]bool{}
+	perRepoByOwner := map[string][]string{}
 	for _, authority := range authorities {
-		keys := keyring.Keys(authority)
-		fmt.Fprintf(stdout, "  %s  (%d %s)\n", authority, len(keys), pluralKeys(len(keys)))
-		for _, key := range keys {
+		owner := ownerAuthorityOf(authority)
+		if owner == "" {
+			// Authority that does not parse: treat it as its own owner
+			// bucket so it is never silently dropped from the listing.
+			owner = authority
+		}
+		owners[owner] = true
+		if authority != owner {
+			perRepoByOwner[owner] = append(perRepoByOwner[owner], authority)
+		}
+	}
+	ownerList := make([]string, 0, len(owners))
+	for owner := range owners {
+		ownerList = append(ownerList, owner)
+	}
+	sort.Strings(ownerList)
+
+	fmt.Fprintf(stdout, "Trusted publishers (%d):\n", len(ownerList))
+	for _, owner := range ownerList {
+		ownerKeys := keyring.Keys(owner)
+		fmt.Fprintf(stdout, "  %s  (%d owner %s)\n", owner, len(ownerKeys), pluralKeys(len(ownerKeys)))
+		for _, key := range ownerKeys {
 			fmt.Fprintf(stdout, "    %s\n", fingerprint(key))
+		}
+		repos := perRepoByOwner[owner]
+		sort.Strings(repos)
+		for _, repo := range repos {
+			keys := keyring.Keys(repo)
+			fmt.Fprintf(stdout, "    %s  (%d %s)\n", repo, len(keys), pluralKeys(len(keys)))
+			for _, key := range keys {
+				fmt.Fprintf(stdout, "      %s\n", fingerprint(key))
+			}
 		}
 	}
 	fmt.Fprintf(stdout, "\nKeyring: %s\n", path)
 	return 0
 }
 
-// runKeyringRevoke removes every key registered for a publisher.
-// Subsequent install attempts for that authority fail closed until
-// the publisher is re-trusted. There is no per-key revocation in v1 —
-// rotation under one authority is rare enough that the additional
-// flag space is not worth carrying.
+// runKeyringRevoke retracts trust. Two mutually-exclusive forms:
+//
+//   - `revoke <authority>` removes a whole grant. An owner authority
+//     (`github://owner`) drops the owner-level grant via RemoveOwner; an
+//     exact per-repo authority (`github://owner/repo`) drops that
+//     per-repo grant via Remove. Either way, installs that depended on
+//     the removed grant fail closed until re-trusted.
+//   - `revoke --key <fingerprint>` removes one key wherever it appears —
+//     across every owner and per-repo authority that registered it,
+//     leaving each authority's other keys intact. This is the path for
+//     retiring a single rotated or compromised key. `--key=<fp>` and
+//     `--key <fp>` are both accepted.
+//
+// Supplying both forms, or neither, is a usage error.
 func runKeyringRevoke(args []string, stdout, stderr io.Writer) int {
-	if len(args) != 1 {
-		fmt.Fprintln(stderr, "usage: aileron keyring revoke <authority>")
+	flags := flag.NewFlagSet("keyring revoke", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	keyFP := flags.String("key", "", "Revoke a single key everywhere by its fingerprint (sha256:...)")
+	if err := flags.Parse(args); err != nil {
 		return 1
 	}
-	authority := args[0]
+	rest := flags.Args()
+
+	switch {
+	case *keyFP != "" && len(rest) > 0:
+		fmt.Fprintln(stderr, "usage: aileron keyring revoke <authority>  OR  aileron keyring revoke --key <fingerprint>")
+		fmt.Fprintln(stderr, "  (supply exactly one of an authority or --key, not both)")
+		return 1
+	case *keyFP == "" && len(rest) != 1:
+		fmt.Fprintln(stderr, "usage: aileron keyring revoke <authority>  OR  aileron keyring revoke --key <fingerprint>")
+		return 1
+	}
+
 	path := cstore.DefaultKeyringPath()
 	if path == "" {
 		fmt.Fprintln(stderr, "error: cannot determine home directory")
@@ -319,7 +581,23 @@ func runKeyringRevoke(args []string, stdout, stderr io.Writer) int {
 		fmt.Fprintf(stderr, "error: load keyring %q: %v\n", path, err)
 		return 1
 	}
-	if !keyring.Remove(authority) {
+
+	if *keyFP != "" {
+		return revokeByFingerprint(keyring, path, *keyFP, stdout, stderr)
+	}
+	return revokeAuthority(keyring, path, rest[0], stdout, stderr)
+}
+
+// revokeAuthority removes a whole grant: the owner-level grant when the
+// argument is a bare owner, else the exact per-repo grant.
+func revokeAuthority(keyring *cstore.Ed25519Keyring, path, authority string, stdout, stderr io.Writer) int {
+	removed := false
+	if owner := ownerAuthorityOf(authority); owner == authority {
+		removed = keyring.RemoveOwner(authority)
+	} else {
+		removed = keyring.Remove(authority)
+	}
+	if !removed {
 		fmt.Fprintf(stdout, "Not trusted: %s (no change)\n", authority)
 		return 0
 	}
@@ -330,6 +608,42 @@ func runKeyringRevoke(args []string, stdout, stderr io.Writer) int {
 	fmt.Fprintf(stdout, "✓ Revoked publisher %s\n", authority)
 	fmt.Fprintf(stdout, "  Keyring: %s\n", path)
 	return 0
+}
+
+// revokeByFingerprint removes the key whose fingerprint matches fp from
+// every authority (owner-level and per-repo) that registered it. An
+// authority emptied by the removal is dropped entirely (RemoveKey).
+func revokeByFingerprint(keyring *cstore.Ed25519Keyring, path, fp string, stdout, stderr io.Writer) int {
+	removedFrom := 0
+	// Snapshot authorities first: RemoveKey can delete an authority,
+	// which would otherwise mutate the set mid-iteration.
+	for _, authority := range keyring.Authorities() {
+		for _, key := range keyring.Keys(authority) {
+			if fingerprint(key) == fp {
+				if keyring.RemoveKey(authority, key) {
+					removedFrom++
+				}
+			}
+		}
+	}
+	if removedFrom == 0 {
+		fmt.Fprintf(stdout, "No key with fingerprint %s (no change)\n", fp)
+		return 0
+	}
+	if err := keyring.SaveKeyring(path); err != nil {
+		fmt.Fprintf(stderr, "error: save keyring: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "✓ Revoked key %s from %d %s\n", fp, removedFrom, pluralAuthorities(removedFrom))
+	fmt.Fprintf(stdout, "  Keyring: %s\n", path)
+	return 0
+}
+
+func pluralAuthorities(n int) string {
+	if n == 1 {
+		return "authority"
+	}
+	return "authorities"
 }
 
 // decodePublicKey decodes an ed25519 public key from raw bytes. Tries

--- a/cmd/aileron/keyring_test.go
+++ b/cmd/aileron/keyring_test.go
@@ -6,6 +6,7 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/base64"
+	"encoding/json"
 	"encoding/pem"
 	"net/http"
 	"net/http/httptest"
@@ -15,6 +16,41 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/cstore"
 )
+
+// seedOwnerGrant writes an owner-level grant directly to the test
+// keyring and returns the public key. Used by list/revoke tests that
+// need a known owner grant without going through the network path.
+func seedOwnerGrant(t *testing.T, ownerAuthority string) ed25519.PublicKey {
+	t.Helper()
+	pub, _ := genTestKey(t)
+	path := cstore.DefaultKeyringPath()
+	kr, err := cstore.LoadKeyring(path)
+	if err != nil {
+		t.Fatalf("seedOwnerGrant load: %v", err)
+	}
+	kr.AddOwner(ownerAuthority, pub)
+	if err := kr.SaveKeyring(path); err != nil {
+		t.Fatalf("seedOwnerGrant save: %v", err)
+	}
+	return pub
+}
+
+// seedPerRepoGrant writes a per-repo grant directly to the test keyring
+// and returns the public key.
+func seedPerRepoGrant(t *testing.T, authority string) ed25519.PublicKey {
+	t.Helper()
+	pub, _ := genTestKey(t)
+	path := cstore.DefaultKeyringPath()
+	kr, err := cstore.LoadKeyring(path)
+	if err != nil {
+		t.Fatalf("seedPerRepoGrant load: %v", err)
+	}
+	kr.Add(authority, pub)
+	if err := kr.SaveKeyring(path); err != nil {
+		t.Fatalf("seedPerRepoGrant save: %v", err)
+	}
+	return pub
+}
 
 // genTestKey returns a fresh ed25519 keypair plus its PEM-encoded
 // public key (the form `openssl pkey -pubout` produces).
@@ -122,8 +158,10 @@ func TestKeyringTrust_AddsKeyAndPersists(t *testing.T) {
 	if rc != 0 {
 		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Trusted publisher github://example/repo") {
-		t.Errorf("expected success message; got: %s", stdout.String())
+	// A full-FQN trust resolves the repo's own key but grants it
+	// owner-level, so the success message names the owner authority.
+	if !strings.Contains(stdout.String(), "Trusted publisher github://example\n") {
+		t.Errorf("expected owner-level success message; got: %s", stdout.String())
 	}
 
 	keyringPath := filepath.Join(home, ".aileron", "keyring.json")
@@ -131,8 +169,11 @@ func TestKeyringTrust_AddsKeyAndPersists(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadKeyring: %v", err)
 	}
-	if !kr.HasKey("github://example/repo", pub) {
-		t.Errorf("keyring at %s does not contain the trusted key", keyringPath)
+	if !kr.HasOwnerKey("github://example", pub) {
+		t.Errorf("keyring at %s does not contain the owner-level trusted key", keyringPath)
+	}
+	if len(kr.Keys("github://example/repo")) != 0 {
+		t.Errorf("trust should not write a per-repo grant; got %d", len(kr.Keys("github://example/repo")))
 	}
 }
 
@@ -154,8 +195,8 @@ func TestKeyringTrust_DuplicateAddIsNoOp(t *testing.T) {
 	if rc != 0 {
 		t.Fatalf("re-trust rc = %d; stderr = %s", rc, stderr.String())
 	}
-	if !strings.Contains(stdout.String(), "Known publisher already trusted") {
-		t.Errorf("expected duplicate-add to print 'Known publisher already trusted'; got: %s", stdout.String())
+	if !strings.Contains(stdout.String(), "Publisher already trusted") {
+		t.Errorf("expected duplicate-add to print 'Publisher already trusted'; got: %s", stdout.String())
 	}
 	if strings.Contains(stdout.String(), "✓ Trusted publisher") {
 		t.Errorf("re-trust should not print success message; got: %s", stdout.String())
@@ -187,14 +228,15 @@ func TestKeyringTrust_RotationAddsAlongsideExisting(t *testing.T) {
 	if err != nil {
 		t.Fatalf("LoadKeyring: %v", err)
 	}
-	if !kr.HasKey("github://example/repo", pub1) {
+	// Rotation accumulates both keys under the owner-level grant.
+	if !kr.HasOwnerKey("github://example", pub1) {
 		t.Error("first key not preserved after rotation")
 	}
-	if !kr.HasKey("github://example/repo", pub2) {
+	if !kr.HasOwnerKey("github://example", pub2) {
 		t.Error("rotated key not added")
 	}
-	if got := len(kr.Keys("github://example/repo")); got != 2 {
-		t.Errorf("len(keys) = %d, want 2", got)
+	if got := len(kr.OwnerKeys("github://example")); got != 2 {
+		t.Errorf("len(owner keys) = %d, want 2", got)
 	}
 }
 
@@ -240,8 +282,8 @@ func TestKeyringTrust_InvalidAuthority(t *testing.T) {
 	if rc := runKeyring([]string{"trust", "not-a-uri"}, stdout, stderr); rc == 0 {
 		t.Fatal("expected non-zero exit for malformed authority")
 	}
-	if !strings.Contains(stderr.String(), "fetch publisher key") {
-		t.Errorf("expected fetch error context; got: %s", stderr.String())
+	if !strings.Contains(stderr.String(), "parse authority") {
+		t.Errorf("expected parse error context; got: %s", stderr.String())
 	}
 }
 
@@ -308,10 +350,12 @@ func TestKeyringList_PrintsTrustedAuthoritiesSorted(t *testing.T) {
 		t.Fatalf("list rc = %d; stderr = %s", rc, stderr.String())
 	}
 	out := stdout.String()
-	idxA := strings.Index(out, "github://a/first")
-	idxB := strings.Index(out, "github://b/second")
+	// Trust writes owner-level grants, so list groups under the owner
+	// authorities `github://a` and `github://b`, sorted.
+	idxA := strings.Index(out, "github://a ")
+	idxB := strings.Index(out, "github://b ")
 	if idxA < 0 || idxB < 0 {
-		t.Fatalf("expected both authorities in output; got: %s", out)
+		t.Fatalf("expected both owner authorities in output; got: %s", out)
 	}
 	if idxA > idxB {
 		t.Errorf("expected sorted order (a before b); got: %s", out)
@@ -334,7 +378,9 @@ func TestKeyringRevoke_RemovesAuthority(t *testing.T) {
 
 	stdout.Reset()
 	stderr.Reset()
-	if rc := runKeyring([]string{"revoke", "github://example/repo"}, stdout, stderr); rc != 0 {
+	// trust github://example/repo grants owner-level trust for
+	// github://example, so revocation targets the owner authority.
+	if rc := runKeyring([]string{"revoke", "github://example"}, stdout, stderr); rc != 0 {
 		t.Fatalf("revoke rc = %d; stderr = %s", rc, stderr.String())
 	}
 	if !strings.Contains(stdout.String(), "Revoked publisher") {
@@ -380,6 +426,169 @@ func TestRunKeyring_UnknownSubcommand(t *testing.T) {
 	}
 }
 
+// --- keyring trust: owner-level grant from a full FQN ---
+
+// TestKeyringTrust_FullFQNWritesOwnerGrantNotPerRepo asserts the
+// headline #1418 behavior: trusting a full per-repo FQN fetches that
+// repo's own key but records an owner-level grant (under "owners"), with
+// no per-repo entry, so the grant covers every connector the publisher
+// ships.
+func TestKeyringTrust_FullFQNWritesOwnerGrantNotPerRepo(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/connector/HEAD/keys/publisher.pub": pemBytes,
+	})
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "github://acme/connector"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+
+	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("expected owner-level grant under github://acme")
+	}
+	if len(kr.Keys("github://acme/connector")) != 0 {
+		t.Error("expected NO per-repo grant under github://acme/connector")
+	}
+
+	// Re-running is a no-op (no duplicate owner key).
+	stdout.Reset()
+	stderr.Reset()
+	if rc := runKeyring([]string{"trust", "github://acme/connector"}, stdout, stderr); rc != 0 {
+		t.Fatalf("re-trust rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Publisher already trusted") {
+		t.Errorf("expected no-op message; got: %s", stdout.String())
+	}
+	kr2, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if got := len(kr2.OwnerKeys("github://acme")); got != 1 {
+		t.Errorf("owner keys = %d after re-trust, want 1 (no duplicate)", got)
+	}
+}
+
+// --- keyring trust: bare owner resolved via the Hub ---
+
+// withMockHub points fetchHubConnectors' transport (bindingAPIBaseURL,
+// via AILERON_API_URL) at an in-process server serving /v1/hub/connectors
+// with the supplied entries.
+func withMockHub(t *testing.T, entries []hubConnectorEntry) {
+	t.Helper()
+	body, err := json.Marshal(hubConnectorList{Connectors: entries})
+	if err != nil {
+		t.Fatalf("marshal hub list: %v", err)
+	}
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/hub/connectors" {
+			http.NotFound(w, r)
+			return
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write(body)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+}
+
+func TestKeyringTrust_BareOwnerResolvesViaHubKeyURL(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	// The raw server serves the connector's own publisher.pub; the Hub
+	// entry's key_url points at it.
+	setBody := withMockGitHubRaw(t, map[string][]byte{
+		"/acme/connector/HEAD/keys/publisher.pub": pemBytes,
+	})
+	_ = setBody
+	keyURL := rawGitHubBase + "/acme/connector/HEAD/keys/publisher.pub"
+	withMockHub(t, []hubConnectorEntry{
+		{FQN: "github://acme/connector", PublisherGithub: "acme", KeyURL: keyURL},
+	})
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "github://acme"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("expected owner-level grant for github://acme from Hub key_url")
+	}
+}
+
+// TestKeyringTrust_BareOwnerTrailingSlashResolvesAsOwner asserts
+// `github://acme/` is treated as the acme owner (routed to Hub
+// resolution), not a per-repo authority with an empty repo.
+func TestKeyringTrust_BareOwnerTrailingSlashResolvesAsOwner(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	withMockGitHubRaw(t, map[string][]byte{
+		"/acme/connector/HEAD/keys/publisher.pub": pemBytes,
+	})
+	keyURL := rawGitHubBase + "/acme/connector/HEAD/keys/publisher.pub"
+	withMockHub(t, []hubConnectorEntry{
+		{FQN: "github://acme/connector", PublisherGithub: "acme", KeyURL: keyURL},
+	})
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"trust", "github://acme/"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("trailing-slash owner should write a canonical github://acme grant")
+	}
+	if len(kr.OwnerKeys("github://acme/")) != 0 {
+		t.Error("grant key must be canonical (no trailing slash)")
+	}
+}
+
+// TestKeyringTrust_BareOwnerNoHubEntryErrorsWithGuidance asserts that a
+// bare owner with no resolvable Hub key_url fails with guidance and never
+// guesses a profile-repo raw path.
+func TestKeyringTrust_BareOwnerNoHubEntryErrorsWithGuidance(t *testing.T) {
+	home := withTempHome(t)
+	// Raw server records every request so we can assert no <owner>/<owner>
+	// profile-repo path is ever fetched.
+	var rawPaths []string
+	rawSrv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		rawPaths = append(rawPaths, r.URL.Path)
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(rawSrv.Close)
+	prev := rawGitHubBase
+	rawGitHubBase = rawSrv.URL
+	t.Cleanup(func() { rawGitHubBase = prev })
+
+	// Hub returns an entry for a different owner / one with no key_url.
+	withMockHub(t, []hubConnectorEntry{
+		{FQN: "github://other/connector", PublisherGithub: "other", KeyURL: rawSrv.URL + "/other/connector/HEAD/keys/publisher.pub"},
+		{FQN: "github://acme/connector", PublisherGithub: "acme", KeyURL: ""},
+	})
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "github://acme"}, stdout, stderr)
+	if rc == 0 {
+		t.Fatal("expected non-zero exit when no Hub key_url resolves for the owner")
+	}
+	if !strings.Contains(stderr.String(), "keyring trust github://acme/<repo>") {
+		t.Errorf("expected guidance to trust via a specific connector; got: %s", stderr.String())
+	}
+	// Never fetched a guessed <owner>/<owner> profile path.
+	for _, p := range rawPaths {
+		if strings.Contains(p, "/acme/acme/") {
+			t.Errorf("must not fetch a guessed profile-repo path; got request to %q", p)
+		}
+	}
+	// Keyring unchanged.
+	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if len(kr.Authorities()) != 0 {
+		t.Errorf("keyring should be unchanged; got %v", kr.Authorities())
+	}
+}
+
 // --- fingerprint helper ---
 
 func TestFingerprint_StableAndShort(t *testing.T) {
@@ -394,5 +603,382 @@ func TestFingerprint_StableAndShort(t *testing.T) {
 	}
 	if got := len(a); got > 32 {
 		t.Errorf("fingerprint too long for terminal display: %d chars (%q)", got, a)
+	}
+}
+
+// --- keyring list grouped by owner ---
+
+func TestKeyringList_GroupsByOwner(t *testing.T) {
+	withTempHome(t)
+	ownerPub := seedOwnerGrant(t, "github://acme")
+	repo1Pub := seedPerRepoGrant(t, "github://acme/conn1")
+	repo2Pub := seedPerRepoGrant(t, "github://acme/conn2")
+	otherPub := seedPerRepoGrant(t, "github://other/conn")
+	_ = ownerPub
+	_ = repo1Pub
+	_ = repo2Pub
+	_ = otherPub
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"list"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	out := stdout.String()
+
+	// Owners sorted: github://acme header before github://other header.
+	idxAcme := strings.Index(out, "github://acme ")
+	idxOther := strings.Index(out, "github://other ")
+	if idxAcme < 0 || idxOther < 0 {
+		t.Fatalf("expected both owner headers; got: %s", out)
+	}
+	if idxAcme > idxOther {
+		t.Errorf("expected acme before other; got: %s", out)
+	}
+	// Owner-level fingerprint shown under the acme header.
+	if !strings.Contains(out, "(1 owner key)") {
+		t.Errorf("expected owner-key count line; got: %s", out)
+	}
+	// Per-repo grants nested under acme, sorted.
+	idxConn1 := strings.Index(out, "github://acme/conn1")
+	idxConn2 := strings.Index(out, "github://acme/conn2")
+	if idxConn1 < 0 || idxConn2 < 0 {
+		t.Fatalf("expected both per-repo entries under acme; got: %s", out)
+	}
+	if !(idxAcme < idxConn1 && idxConn1 < idxConn2 && idxConn2 < idxOther) {
+		t.Errorf("expected acme header < conn1 < conn2 < other header; got: %s", out)
+	}
+}
+
+// TestKeyringList_OwnerWithOnlyPerRepoGrantsRendersHeader asserts an
+// owner that has only per-repo grants (no owner-level key) still gets a
+// group header, with no owner-level fingerprint line.
+func TestKeyringList_OwnerWithOnlyPerRepoGrantsRendersHeader(t *testing.T) {
+	withTempHome(t)
+	seedPerRepoGrant(t, "github://acme/conn1")
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"list"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "github://acme  (0 owner keys)") {
+		t.Errorf("expected owner header with zero owner keys; got: %s", out)
+	}
+	if !strings.Contains(out, "github://acme/conn1") {
+		t.Errorf("expected per-repo entry under the owner; got: %s", out)
+	}
+}
+
+func TestKeyringList_WrongArgCount(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"list", "extra"}, stdout, stderr); rc == 0 {
+		t.Fatal("expected non-zero exit for extra arg")
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("expected usage hint; got: %s", stderr.String())
+	}
+}
+
+// --- keyring revoke: owner and --key forms ---
+
+func TestKeyringRevoke_OwnerRemovesOwnerGrantLeavesPerRepo(t *testing.T) {
+	home := withTempHome(t)
+	seedOwnerGrant(t, "github://acme")
+	repoPub := seedPerRepoGrant(t, "github://acme/conn")
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"revoke", "github://acme"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Revoked publisher github://acme") {
+		t.Errorf("expected revoke message; got: %s", stdout.String())
+	}
+	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if len(kr.OwnerKeys("github://acme")) != 0 {
+		t.Error("owner grant should be gone")
+	}
+	if !kr.HasKey("github://acme/conn", repoPub) {
+		t.Error("per-repo grant under acme should be untouched")
+	}
+}
+
+func TestKeyringRevoke_OwnerNoGrantIsNoChange(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"revoke", "github://acme"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no change") {
+		t.Errorf("expected no-change message; got: %s", stdout.String())
+	}
+}
+
+func TestKeyringRevoke_KeyFlagRemovesAcrossOwnerAndPerRepo(t *testing.T) {
+	home := withTempHome(t)
+	// Same key registered under an owner AND a per-repo authority, plus
+	// an unrelated key that must survive.
+	shared, _ := genTestKey(t)
+	other, _ := genTestKey(t)
+	path := cstore.DefaultKeyringPath()
+	kr, _ := cstore.LoadKeyring(path)
+	kr.AddOwner("github://acme", shared)
+	kr.Add("github://acme/conn", shared)
+	kr.Add("github://acme/conn", other)
+	if err := kr.SaveKeyring(path); err != nil {
+		t.Fatalf("seed save: %v", err)
+	}
+	fp := fingerprint(shared)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"revoke", "--key", fp}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Revoked key") {
+		t.Errorf("expected key-revoke message; got: %s", stdout.String())
+	}
+	kr2, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if kr2.HasOwnerKey("github://acme", shared) {
+		t.Error("shared key should be removed from owner authority")
+	}
+	if kr2.HasKey("github://acme/conn", shared) {
+		t.Error("shared key should be removed from per-repo authority")
+	}
+	if !kr2.HasKey("github://acme/conn", other) {
+		t.Error("unrelated key under the per-repo authority must survive")
+	}
+}
+
+func TestKeyringRevoke_KeyEqualsFormParsesIdentically(t *testing.T) {
+	withTempHome(t)
+	pub := seedOwnerGrant(t, "github://acme")
+	fp := fingerprint(pub)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"revoke", "--key=" + fp}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Revoked key") {
+		t.Errorf("expected key-revoke message; got: %s", stdout.String())
+	}
+}
+
+func TestKeyringRevoke_UnknownKeyIsNoChange(t *testing.T) {
+	withTempHome(t)
+	seedOwnerGrant(t, "github://acme")
+	unknown, _ := genTestKey(t)
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"revoke", "--key", fingerprint(unknown)}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "no change") {
+		t.Errorf("expected no-change message; got: %s", stdout.String())
+	}
+}
+
+func TestKeyringRevoke_BothFormsIsUsageError(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"revoke", "github://acme", "--key", "sha256:abc"}, stdout, stderr)
+	if rc == 0 {
+		t.Fatal("expected usage error when both authority and --key are given")
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("expected usage hint; got: %s", stderr.String())
+	}
+}
+
+func TestKeyringRevoke_NeitherFormIsUsageError(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"revoke"}, stdout, stderr); rc == 0 {
+		t.Fatal("expected usage error when neither authority nor --key is given")
+	}
+	if !strings.Contains(stderr.String(), "usage:") {
+		t.Errorf("expected usage hint; got: %s", stderr.String())
+	}
+}
+
+// --- install bridge: ensureAuthorityTrusted writes owner grants ---
+
+// TestEnsureAuthorityTrusted_AutoYesWritesOwnerGrantSingleFetch asserts
+// the #563 single-install flow now writes an owner-level grant from one
+// fetch of the per-repo connector key.
+func TestEnsureAuthorityTrusted_AutoYesWritesOwnerGrantSingleFetch(t *testing.T) {
+	home := withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	fetches := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/acme/conn/HEAD/keys/publisher.pub" {
+			fetches++
+			w.Write(pemBytes)
+			return
+		}
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	prev := rawGitHubBase
+	rawGitHubBase = srv.URL
+	t.Cleanup(func() { rawGitHubBase = prev })
+
+	var stdout, stderr bytes.Buffer
+	if err := ensureAuthorityTrustedErr(t, "github://acme/conn", true, &stdout, &stderr); err != nil {
+		t.Fatalf("ensureAuthorityTrusted: %v; stderr=%s", err, stderr.String())
+	}
+	if fetches != 1 {
+		t.Errorf("expected exactly one key fetch, got %d", fetches)
+	}
+	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("expected owner-level grant after auto-yes accept")
+	}
+}
+
+// TestEnsureAuthorityTrusted_OwnerGrantCoversSiblingNoFetch asserts that
+// once an owner grant exists, a different repo under the same owner is a
+// no-op with no prompt and no fetch.
+func TestEnsureAuthorityTrusted_OwnerGrantCoversSiblingNoFetch(t *testing.T) {
+	withTempHome(t)
+	seedOwnerGrant(t, "github://acme")
+	hits := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		hits++
+		http.NotFound(w, r)
+	}))
+	t.Cleanup(srv.Close)
+	prev := rawGitHubBase
+	rawGitHubBase = srv.URL
+	t.Cleanup(func() { rawGitHubBase = prev })
+
+	var stdout, stderr bytes.Buffer
+	if err := ensureAuthorityTrustedErr(t, "github://acme/other-conn", false, &stdout, &stderr); err != nil {
+		t.Fatalf("expected nil (already owner-trusted), got %v", err)
+	}
+	if hits != 0 {
+		t.Errorf("expected zero fetches when owner grant covers the repo, got %d", hits)
+	}
+	if strings.Contains(stdout.String(), "is not yet trusted") {
+		t.Errorf("should not prompt when owner grant exists; got: %s", stdout.String())
+	}
+}
+
+// TestEnsureAuthorityTrusted_PerRepoPinDoesNotCoverSibling asserts a
+// standalone per-repo pin satisfies that exact repo but NOT a sibling
+// under the same owner (per-repo pin does not read as owner-trust).
+func TestEnsureAuthorityTrusted_PerRepoPinDoesNotCoverSibling(t *testing.T) {
+	withTempHome(t)
+	seedPerRepoGrant(t, "github://acme/conn")
+
+	// Exact repo: no-op, no prompt.
+	var stdout, stderr bytes.Buffer
+	if err := ensureAuthorityTrustedErr(t, "github://acme/conn", false, &stdout, &stderr); err != nil {
+		t.Fatalf("pinned repo should be a no-op, got %v", err)
+	}
+	if strings.Contains(stdout.String(), "is not yet trusted") {
+		t.Errorf("pinned repo should not prompt; got: %s", stdout.String())
+	}
+
+	// Sibling repo: prompts (decline aborts). Empty stdin => declines.
+	stdout.Reset()
+	stderr.Reset()
+	err := ensureAuthorityTrustedErr(t, "github://acme/sibling", false, &stdout, &stderr)
+	if err == nil {
+		t.Fatal("sibling should prompt and abort on empty stdin")
+	}
+	if !strings.Contains(stdout.String(), "is not yet trusted") {
+		t.Errorf("expected sibling prompt; got: %s", stdout.String())
+	}
+}
+
+// TestTrustStateEnsure_SuiteSinglePromptPerOwner asserts that within one
+// run, ensure() for two connectors of the same owner fetches/writes once
+// and the second short-circuits.
+func TestTrustStateEnsure_SuiteSinglePromptPerOwner(t *testing.T) {
+	withTempHome(t)
+	pub, pemBytes := genTestKey(t)
+	fetches := 0
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		fetches++
+		w.Write(pemBytes)
+	}))
+	t.Cleanup(srv.Close)
+	prev := rawGitHubBase
+	rawGitHubBase = srv.URL
+	t.Cleanup(func() { rawGitHubBase = prev })
+
+	st := newTrustState()
+	var stdout, stderr bytes.Buffer
+	if err := st.ensure("github://acme/conn1", true, strings.NewReader(""), &stdout, &stderr); err != nil {
+		t.Fatalf("first ensure: %v", err)
+	}
+	if err := st.ensure("github://acme/conn2", true, strings.NewReader(""), &stdout, &stderr); err != nil {
+		t.Fatalf("second ensure: %v", err)
+	}
+	if fetches != 1 {
+		t.Errorf("expected one fetch across two sibling connectors, got %d", fetches)
+	}
+	_ = pub
+}
+
+// ensureAuthorityTrustedErr is a thin test adapter that drives the
+// install bridge with an empty stdin (so an un-accepted prompt declines)
+// and discards the owner-covered bool, returning only the error.
+func ensureAuthorityTrustedErr(t *testing.T, authority string, autoYes bool, stdout, stderr *bytes.Buffer) error {
+	t.Helper()
+	_, err := ensureAuthorityTrusted(authority, autoYes, strings.NewReader(""), stdout, stderr)
+	return err
+}
+
+// TestKeyringRevoke_ExactPerRepoAuthority asserts revoking an exact
+// per-repo authority (not a bare owner) removes just that per-repo grant
+// via the Remove path.
+func TestKeyringRevoke_ExactPerRepoAuthority(t *testing.T) {
+	home := withTempHome(t)
+	ownerPub := seedOwnerGrant(t, "github://acme")
+	seedPerRepoGrant(t, "github://acme/conn")
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"revoke", "github://acme/conn"}, stdout, stderr); rc != 0 {
+		t.Fatalf("rc = %d; stderr = %s", rc, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Revoked publisher github://acme/conn") {
+		t.Errorf("expected per-repo revoke message; got: %s", stdout.String())
+	}
+	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
+	if len(kr.Keys("github://acme/conn")) != 0 {
+		t.Error("per-repo grant should be removed")
+	}
+	if !kr.HasOwnerKey("github://acme", ownerPub) {
+		t.Error("owner grant must survive a per-repo revoke")
+	}
+}
+
+// TestKeyringTrust_BareOwnerHubFetchFailsGuidance asserts that when the
+// Hub query itself fails (daemon unreachable / non-200), trust errors
+// with the same trust-via-connector guidance.
+func TestKeyringTrust_BareOwnerHubFetchFailsGuidance(t *testing.T) {
+	withTempHome(t)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	t.Cleanup(srv.Close)
+	t.Setenv("AILERON_API_URL", srv.URL+"/v1")
+
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	rc := runKeyring([]string{"trust", "github://acme"}, stdout, stderr)
+	if rc == 0 {
+		t.Fatal("expected non-zero exit when the Hub query fails")
+	}
+	if !strings.Contains(stderr.String(), "keyring trust github://acme/<repo>") {
+		t.Errorf("expected trust-via-connector guidance; got: %s", stderr.String())
+	}
+}
+
+func TestKeyringRevoke_UnknownFlagIsUsageError(t *testing.T) {
+	withTempHome(t)
+	stdout, stderr := &bytes.Buffer{}, &bytes.Buffer{}
+	if rc := runKeyring([]string{"revoke", "--bogus"}, stdout, stderr); rc == 0 {
+		t.Fatal("expected non-zero exit for unknown flag")
 	}
 }

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -5241,10 +5241,12 @@ func TestRunActionAdd_CrossAuthorityDepPromptsTrust(t *testing.T) {
 	home := withTempHome(t)
 	depPub, depPem := genTestKey(t)
 	withMockGitHubRaw(t, map[string][]byte{
-		"/acme/conn-dep/HEAD/keys/publisher.pub": depPem,
+		"/other/conn-dep/HEAD/keys/publisher.pub": depPem,
 	})
-	// Trust the action's authority but NOT the dep's authority.
-	trustTestAuthority(t, "github://acme/conn")
+	// Trust the action's publisher (owner github://acme) but NOT the
+	// dep's publisher (owner github://other), so the dep's owner-level
+	// trust is genuinely absent and the prompt must fire.
+	trustTestAuthority(t, "github://acme")
 
 	installCalled := false
 	fakeBindingServer(t, func(w http.ResponseWriter, r *http.Request) {
@@ -5256,7 +5258,7 @@ func TestRunActionAdd_CrossAuthorityDepPromptsTrust(t *testing.T) {
 				"hash":"sha256:abc","name":"my-action",
 				"signature_status":"verified",
 				"connector_deps":[
-					{"fqn":"github://acme/conn-dep","version":"1.0.0","hash":"sha256:dep","already_installed":false}
+					{"fqn":"github://other/conn-dep","version":"1.0.0","hash":"sha256:dep","already_installed":false}
 				]
 			}`)
 		case "/actions/install":
@@ -5278,12 +5280,12 @@ func TestRunActionAdd_CrossAuthorityDepPromptsTrust(t *testing.T) {
 	if !installCalled {
 		t.Error("install should fire after trust + consent")
 	}
-	if !strings.Contains(stdout.String(), "Trust publisher github://acme/conn-dep?") {
-		t.Errorf("expected trust prompt for cross-authority dep; got: %s", stdout.String())
+	if !strings.Contains(stdout.String(), "Trust publisher github://other/conn-dep?") {
+		t.Errorf("expected trust prompt for cross-publisher dep; got: %s", stdout.String())
 	}
 	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
-	if !kr.HasOwnerKey("github://acme", depPub) {
-		t.Error("dep authority should be trusted (owner-level) after auto-trust")
+	if !kr.HasOwnerKey("github://other", depPub) {
+		t.Error("dep publisher should be trusted (owner-level) after auto-trust")
 	}
 }
 

--- a/cmd/aileron/main_test.go
+++ b/cmd/aileron/main_test.go
@@ -4483,7 +4483,7 @@ func TestRunActionAdd_AutoTrustPromptsAndInstalls(t *testing.T) {
 	for _, want := range []string{
 		"Publisher github://acme/conn is not yet trusted",
 		"Trust publisher github://acme/conn?",
-		"✓ Trusted publisher github://acme/conn",
+		"✓ Trusted publisher github://acme\n",
 		"Action install preview",
 		"Install? [y/n]:",
 		"Added: my-action",
@@ -4492,13 +4492,14 @@ func TestRunActionAdd_AutoTrustPromptsAndInstalls(t *testing.T) {
 			t.Errorf("output missing %q:\n%s", want, out)
 		}
 	}
-	// Trust must persist across runs.
+	// Trust must persist across runs; the grant is owner-level so it
+	// covers every connector this publisher ships (ADR-0013).
 	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
 	if err != nil {
 		t.Fatalf("LoadKeyring: %v", err)
 	}
-	if !kr.HasKey("github://acme/conn", pub) {
-		t.Error("keyring should contain trusted key after auto-trust")
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("keyring should contain owner-level trusted key after auto-trust")
 	}
 }
 
@@ -4595,8 +4596,8 @@ func TestRunActionAdd_HubCompositeAcceptTrustsAuthoritiesAndInstalls(t *testing.
 	if err != nil {
 		t.Fatalf("LoadKeyring: %v", err)
 	}
-	if !kr.HasKey("github://acme/conn", pub) {
-		t.Error("keyring should contain trusted key after composite accept")
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("keyring should contain owner-level trusted key after composite accept")
 	}
 }
 
@@ -5186,15 +5187,15 @@ func TestRunActionAdd_YesFlagAutoTrusts(t *testing.T) {
 	if strings.Contains(stdout.String(), "Trust publisher github://acme/conn?") {
 		t.Errorf("--yes should suppress the trust prompt; got: %s", stdout.String())
 	}
-	if !strings.Contains(stdout.String(), "✓ Trusted publisher github://acme/conn") {
-		t.Errorf("expected key-added confirmation line; got: %s", stdout.String())
+	if !strings.Contains(stdout.String(), "✓ Trusted publisher github://acme\n") {
+		t.Errorf("expected owner-level key-added confirmation line; got: %s", stdout.String())
 	}
 	kr, err := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
 	if err != nil {
 		t.Fatalf("LoadKeyring: %v", err)
 	}
-	if !kr.HasKey("github://acme/conn", pub) {
-		t.Error("keyring should contain trusted key after --yes auto-trust")
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("keyring should contain owner-level trusted key after --yes auto-trust")
 	}
 }
 
@@ -5281,8 +5282,8 @@ func TestRunActionAdd_CrossAuthorityDepPromptsTrust(t *testing.T) {
 		t.Errorf("expected trust prompt for cross-authority dep; got: %s", stdout.String())
 	}
 	kr, _ := cstore.LoadKeyring(filepath.Join(home, ".aileron", "keyring.json"))
-	if !kr.HasKey("github://acme/conn-dep", depPub) {
-		t.Error("dep authority should be trusted after auto-trust")
+	if !kr.HasOwnerKey("github://acme", depPub) {
+		t.Error("dep authority should be trusted (owner-level) after auto-trust")
 	}
 }
 
@@ -6561,8 +6562,8 @@ actions = [
 	if err != nil {
 		t.Fatalf("LoadKeyring: %v", err)
 	}
-	if !kr.HasKey("github://acme/conn", pub) {
-		t.Error("keyring should contain trusted key after composite accept")
+	if !kr.HasOwnerKey("github://acme", pub) {
+		t.Error("keyring should contain owner-level trusted key after composite accept")
 	}
 }
 

--- a/internal/cstore/fqn_test.go
+++ b/internal/cstore/fqn_test.go
@@ -119,6 +119,22 @@ func TestFQN_OwnerAuthority_ReturnsSchemeOwner(t *testing.T) {
 	}
 }
 
+func TestFQN_SubpathBearing_AuthorityDropsSubpathOwnerDropsRepo(t *testing.T) {
+	// A subpath-bearing FQN must reduce to the repo authority and the
+	// owner authority cleanly — owner-level trust derivation keys on
+	// OwnerAuthority(), never the subpath-bearing string.
+	f, err := ParseFQN("github://acme/foo/actions/x")
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if got, want := f.Authority(), "github://acme/foo"; got != want {
+		t.Errorf("Authority() = %q, want %q (subpath dropped)", got, want)
+	}
+	if got, want := f.OwnerAuthority(), "github://acme"; got != want {
+		t.Errorf("OwnerAuthority() = %q, want %q (repo + subpath dropped)", got, want)
+	}
+}
+
 func TestParseRef_AcceptsCanonicalCompactForm(t *testing.T) {
 	r, err := ParseRef("github://aileron/slack@1.2.0")
 	if err != nil {

--- a/internal/cstore/keyring_config.go
+++ b/internal/cstore/keyring_config.go
@@ -280,6 +280,42 @@ func (k *Ed25519Keyring) Remove(authority string) bool {
 	return true
 }
 
+// RemoveKey drops a single public key from an authority. Returns true
+// when the key was present (and removed), false when the authority or
+// the key was not registered. When the removal empties the authority,
+// the authority is dropped entirely so a subsequent Authorities() /
+// list does not surface an empty entry. This is the per-key counterpart
+// to Remove (whole-authority): `aileron keyring revoke --key <fp>` uses
+// it to retract one rotated/compromised key across every authority
+// (owners and publishers) that registered it, without disturbing the
+// authority's other keys.
+func (k *Ed25519Keyring) RemoveKey(authority string, pub ed25519.PublicKey) bool {
+	k.mu.Lock()
+	defer k.mu.Unlock()
+	existing, ok := k.keys[authority]
+	if !ok {
+		return false
+	}
+	kept := make([]ed25519.PublicKey, 0, len(existing))
+	removed := false
+	for _, e := range existing {
+		if ed25519.PublicKey(e).Equal(pub) {
+			removed = true
+			continue
+		}
+		kept = append(kept, e)
+	}
+	if !removed {
+		return false
+	}
+	if len(kept) == 0 {
+		delete(k.keys, authority)
+	} else {
+		k.keys[authority] = kept
+	}
+	return true
+}
+
 // HasKey reports whether the keyring already trusts the given public
 // key for the authority. Used by callers (e.g. `aileron keyring trust`)
 // to detect duplicate adds and avoid bloating the file with copies of

--- a/internal/cstore/keyring_config_test.go
+++ b/internal/cstore/keyring_config_test.go
@@ -699,6 +699,51 @@ func TestKeyringRemoveOwner_TrueHitFalseMiss(t *testing.T) {
 	}
 }
 
+func TestKeyringRemoveKey_RemovesOneLeavesSiblingsDropsEmptied(t *testing.T) {
+	pub1, _, _ := ed25519.GenerateKey(rand.Reader)
+	pub2, _, _ := ed25519.GenerateKey(rand.Reader)
+	absent, _, _ := ed25519.GenerateKey(rand.Reader)
+	kr := cstore.NewEd25519Keyring()
+	kr.Add("github://acme/connector", pub1)
+	kr.Add("github://acme/connector", pub2)
+	kr.AddOwner("github://acme", pub1)
+
+	// Remove one key from a multi-key authority: the sibling survives,
+	// the authority stays present.
+	if !kr.RemoveKey("github://acme/connector", pub1) {
+		t.Fatal("RemoveKey(present) = false; want true")
+	}
+	if kr.HasKey("github://acme/connector", pub1) {
+		t.Error("removed key still present")
+	}
+	if !kr.HasKey("github://acme/connector", pub2) {
+		t.Error("sibling key was dropped; want preserved")
+	}
+
+	// Removing the last key from an authority drops the authority so a
+	// subsequent Authorities()/list does not surface an empty entry.
+	if !kr.RemoveKey("github://acme/connector", pub2) {
+		t.Fatal("RemoveKey(last key) = false; want true")
+	}
+	for _, a := range kr.Authorities() {
+		if a == "github://acme/connector" {
+			t.Error("emptied authority not dropped from Authorities()")
+		}
+	}
+	// The owner-level grant is independent and untouched.
+	if !kr.HasOwnerKey("github://acme", pub1) {
+		t.Error("owner-level grant removed by per-repo RemoveKey")
+	}
+
+	// Absent key / absent authority both return false.
+	if kr.RemoveKey("github://acme", absent) {
+		t.Error("RemoveKey(absent key) = true; want false")
+	}
+	if kr.RemoveKey("github://nope/none", pub1) {
+		t.Error("RemoveKey(absent authority) = true; want false")
+	}
+}
+
 func TestKeyringOwnerAuthorities_SortedOwnerOnlySplitFromAuthorities(t *testing.T) {
 	// A keyring with one owner-level entry and one per-repo entry returns
 	// just the owner authority from OwnerAuthorities() and just the repo


### PR DESCRIPTION
## Summary

Moves the keyring CLI and install-time trust prompts to **owner granularity** (ADR-0013 per-publisher trust). A single grant for `github://owner` now covers every connector that publisher ships, matching the owner∪per-repo union that `cstore.Verify` already resolves.

- **`keyring trust github://owner/repo`** fetches that connector's own `keys/publisher.pub` (unchanged ADR-0002 convention path) and writes an **owner-level** grant for `github://owner`. No per-repo entry is written; the success message names the owner.
- **`keyring trust github://owner`** (bare owner) resolves the publisher key from the **Hub entry's `key_url`** for that owner. When no entry carries a resolvable `key_url`, it errors with guidance (`keyring trust github://owner/<repo>`) and never guesses a `<owner>/<owner>` profile-repo path. A trailing slash (`github://owner/`) is treated as the bare owner.
- **Install/suite prompts** write the owner grant from the **already-fetched** per-repo key — exactly one fetch, preserving the #563 single-install flow. The trusted predicate is the owner∪per-repo union; a standalone per-repo pin satisfies its exact repo but does **not** read as owner-trust (a sibling still prompts). Within one run, accepting trust for one connector suppresses the prompt for siblings under the same owner.
- **`keyring list`** groups by owner: owner-level fingerprints first, then per-repo grants nested under each owner header. An owner with only per-repo grants still gets a header.
- **`keyring revoke github://owner`** drops the owner grant; an exact per-repo authority drops that grant; **`keyring revoke --key <fp>`** removes one key across every authority (owners + publishers), both `--key <fp>` and `--key=<fp>` forms. Mutual exclusion enforced.
- Adds `cstore.Ed25519Keyring.RemoveKey` (independently tested) backing the `--key` revoke; it drops an authority emptied by the removal.

No OpenAPI/generated-server or daemon changes — CLI plus one cstore accessor.

## Test plan

- `task test:go` green (all modules).
- New `internal/cstore` tests: `RemoveKey` (removes one, keeps siblings, drops emptied authority, false for absent); subpath-bearing FQN owner derivation.
- New `cmd/aileron` tests cover each contract scenario: full-FQN owner grant (no per-repo, idempotent re-run); bare-owner Hub resolution (success, trailing slash, no-entry guidance with assertion that no `/owner/owner/` raw path is fetched, Hub-query failure); list grouping by owner (sorted, nested, owner-with-only-per-repo header, wrong-arg); revoke owner/exact-per-repo/`--key`/`--key=`/unknown-fp/both/neither/unknown-flag; install bridge writes owner grant in a single fetch, owner grant covers siblings with zero fetch, per-repo pin does not cover sibling, suite single-prompt-per-owner.
- Existing install-flow assertions in `main_test.go` updated to expect the owner-level grant + message.
- New keyring code covered >80% (`task test:go:cover`); remaining gaps are defensive home-dir / save-error branches consistent with the rest of the file.

Closes #1418

🤖 Generated with [Claude Code](https://claude.com/claude-code)
