### PR TITLE
test(cstore): assert v2 keyring serializes grants into correct buckets

### DIFF
--- a/internal/cstore/keyring_config_test.go
+++ b/internal/cstore/keyring_config_test.go
@@ -251,6 +251,69 @@ func TestSaveKeyring_FileMode0600(t *testing.T) {
 	}
 }
 
+func TestSaveKeyring_PartitionsOwnerAndRepoGrantsIntoCorrectBuckets(t *testing.T) {
+	// The v2 file format (ADR-0013) is a contract: owner-level grants
+	// (<scheme>://<owner>) serialize under "owners", per-repo grants
+	// (<scheme>://<owner>/<repo>) under "publishers". HasKey/HasOwnerKey
+	// read the same flattened map and so cannot distinguish the buckets;
+	// this test re-parses the raw saved JSON to guard the partition
+	// directly, which is the only assertion that catches a Save-time
+	// misclassification of an owner authority as a per-repo one.
+	ownerPub, _, _ := ed25519.GenerateKey(rand.Reader)
+	repoPub, _, _ := ed25519.GenerateKey(rand.Reader)
+
+	kr := cstore.NewEd25519Keyring()
+	kr.AddOwner("github://acme", ownerPub)
+	kr.Add("github://acme/connector", repoPub)
+
+	path := filepath.Join(t.TempDir(), "keyring.json")
+	if err := kr.SaveKeyring(path); err != nil {
+		t.Fatalf("SaveKeyring: %v", err)
+	}
+
+	raw, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatalf("read saved keyring: %v", err)
+	}
+	var doc struct {
+		Version    int                 `json:"version"`
+		Owners     map[string][]string `json:"owners"`
+		Publishers map[string][]string `json:"publishers"`
+	}
+	if err := json.Unmarshal(raw, &doc); err != nil {
+		t.Fatalf("parse saved keyring: %v", err)
+	}
+
+	if doc.Version != 2 {
+		t.Errorf("saved version = %d, want 2", doc.Version)
+	}
+	if _, ok := doc.Owners["github://acme"]; !ok {
+		t.Errorf("owner grant github://acme not under \"owners\"; owners=%v", doc.Owners)
+	}
+	if _, ok := doc.Publishers["github://acme/connector"]; !ok {
+		t.Errorf("per-repo grant github://acme/connector not under \"publishers\"; publishers=%v", doc.Publishers)
+	}
+	// Cross-check: neither grant leaked into the other bucket.
+	if _, ok := doc.Publishers["github://acme"]; ok {
+		t.Error("owner grant leaked into \"publishers\"")
+	}
+	if _, ok := doc.Owners["github://acme/connector"]; ok {
+		t.Error("per-repo grant leaked into \"owners\"")
+	}
+
+	// And the partition survives a reload at the resolution layer.
+	loaded, err := cstore.LoadKeyring(path)
+	if err != nil {
+		t.Fatalf("LoadKeyring: %v", err)
+	}
+	if !loaded.HasOwnerKey("github://acme", ownerPub) {
+		t.Error("owner-level grant not resolvable after round-trip")
+	}
+	if !loaded.HasKey("github://acme/connector", repoPub) {
+		t.Error("per-repo grant not resolvable after round-trip")
+	}
+}
+
 // --- Authorities / Keys / Remove / HasKey ---
 
 func TestKeyringAuthorities_SortedAndDeduplicated(t *testing.T) {


### PR DESCRIPTION
## Summary

Closes the one open review-residual (#1424) from umbrella #1415's first run. The P1 finding noted that the v2 keyring's Save round-trip tests assert reconstruction via `HasKey`/`HasOwnerKey`, both of which read the flattened in-memory map and therefore pass regardless of which JSON bucket (`owners` vs `publishers`) a grant serialized into.

This adds `TestSaveKeyring_PartitionsOwnerAndRepoGrantsIntoCorrectBuckets`, which re-parses the raw saved keyring JSON and asserts:

- an owner-level grant (`github://acme`) lands under `owners`,
- a per-repo grant (`github://acme/connector`) lands under `publishers`,
- neither leaks into the other bucket,
- and the partition still resolves after reload.

The `owners`/`publishers` partition is the v2 file-format contract ratified in [ADR-0013](https://github.com/ALRubinger/aileron/blob/main/docs/src/content/docs/adr/0013-connector-hub-and-trust-distribution.md) (#1439) and is relied on by the load-time "v1 document carrying an `owners` map is rejected" guard, so it is a behavioral contract worth pinning rather than an implementation accident. Test-only; no production code changed.

## Test plan

- [x] `go test ./internal/cstore/` passes (new test + all existing cstore tests green).
- [x] New test exercises the format contract through the public API (`AddOwner`, `Add`, `SaveKeyring`, `LoadKeyring`) plus a raw-JSON parse, not internals.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
