### PR TITLE
docs(cli): reconcile CLI reference with real surface, drop ADR column

### DIFF
--- a/docs/src/content/docs/cli/index.md
+++ b/docs/src/content/docs/cli/index.md
@@ -8,23 +8,30 @@ The `aileron` CLI is a thin HTTP client over the Aileron server's API. The same 
 
 The server's API is defined in [`internal/api/openapi.yaml`](https://github.com/ALRubinger/aileron/blob/main/internal/api/openapi.yaml) and is the **authoritative source** for every endpoint. CLI commands are routed to specific HTTP operations there. New CLI surface lands by extending the OpenAPI spec, regenerating the server stubs (`task generate:api`), implementing the handler, and wiring the CLI command to call it.
 
-This page is the human-readable index of CLI commands grouped by concern. Each command lists its purpose, its options, and the ADR(s) that ratify its behavior.
+This page is the human-readable index of CLI commands grouped by concern. Each command lists its purpose, its subcommands, and its syntax. Run `aileron help` or `aileron <command>` with no subcommand to see the same syntax from the binary itself.
 
 ## Runtime lifecycle
 
-| Command | Purpose | Ratified by |
-|---|---|---|
-| `aileron launch [--local] [--sandbox=auto\|docker] [--sandbox-build=auto\|always\|never]` | Launch an AI coding agent connected to the Aileron daemon. The Docker sandbox is the default; the agent command runs inside the prepared project sandbox image. `--local` runs the agent directly on the host instead, and conflicts with an explicit `--sandbox`. | [ADR-0011](/adr/0011-local-credential-vault), [ADR-0017](/adr/0017-sandbox-composition) |
-| `aileron status` | Report the running runtime: version, listen address, action count, connector count, binding count, vault state. Read-only; safe to run frequently. | — |
+| Command | Purpose |
+|---|---|
+| `aileron launch [--log-level=<level>] [--local] [--sandbox=auto\|docker] [--sandbox-build=auto\|always\|never] [--sandbox-proxy=auto\|on\|off] [--host-login=auto\|on\|off] [--claude-auth=subscription\|api-key] <agent> [args...]` | Launch an AI coding agent connected to the Aileron daemon. The Docker sandbox is the default; the agent command runs inside the prepared project sandbox image. `--local` runs the agent directly on the host instead, and conflicts with an explicit `--sandbox`. |
+| `aileron status [runtime\|notifications\|vault]` | Report the running runtime: version, listen address, action count, connector count, binding count, vault state. The optional section argument narrows output to one of `runtime`, `notifications`, or `vault`. Read-only; safe to run frequently. |
+| `aileron daemon start\|stop\|status` | Manage the local Aileron daemon. `start` is idempotent and prints the URL if one is already running. `stop` sends SIGTERM. `status` reports whether the daemon is running and its vault state. The daemon also auto-spawns on demand for any command that needs it. |
+| `aileron stop` | Alias for `aileron daemon stop`. |
+
+The `--claude-auth` flag only affects the `claude` agent; every other agent ignores it. An empty value (the default) prompts on a TTY and resolves to `subscription` off a TTY.
 
 ## Sandbox composition
 
-| Command | Purpose | Ratified by |
-|---|---|---|
-| `aileron sandbox init [--force]` | Scaffold a Feature-composing `.devcontainer/devcontainer.json` for Tier 1 sandbox composition. It sets `ghcr.io/alrubinger/aileron-sandbox-base:<version>` as the base image, lists the Claude agent Feature as the worked example, and shows a commented customer-tooling Feature slot. | [ADR-0017](/adr/0017-sandbox-composition) |
-| `aileron sandbox plan` | Inspect the normalized composition tier and image Aileron infers from the current project. | [ADR-0017](/adr/0017-sandbox-composition) |
-| `aileron sandbox build` | Build the Tier 0 sandbox-base image or Tier 1 devcontainer image with Docker. Tier 2 BYO images are reported without build or injection. | [ADR-0017](/adr/0017-sandbox-composition) |
-| `aileron sandbox check [--runtime=auto\|docker] [--build=auto\|always\|never] --agent=<command>` | Validate that the selected sandbox image can launch an agent command before starting a session. | [ADR-0017](/adr/0017-sandbox-composition) |
+The sandbox group is `aileron sandbox [init|plan|build|check|cache]`.
+
+| Command | Purpose |
+|---|---|
+| `aileron sandbox init [--force]` | Scaffold a Feature-composing `.devcontainer/devcontainer.json` for Tier 1 sandbox composition. It sets `ghcr.io/alrubinger/aileron-sandbox-base:<version>` as the base image, lists the Claude agent Feature as the worked example, and shows a commented customer-tooling Feature slot. |
+| `aileron sandbox plan` | Inspect the normalized composition tier and image Aileron infers from the current project. |
+| `aileron sandbox build [--runtime=auto\|docker] [--tag=<image>]` | Build the Tier 0 sandbox-base image or Tier 1 devcontainer image with Docker. Tier 2 BYO images are reported without build or injection. |
+| `aileron sandbox check [--runtime=auto\|docker] [--build=auto\|always\|never] [--agent=<command>] [command]` | Validate that the selected sandbox image can launch an agent command before starting a session. |
+| `aileron sandbox cache clear [--runtime=auto\|docker]` | Remove cached sandbox build artifacts so the next build starts clean. |
 
 Docker is the only supported sandbox runtime in v4. Podman is planned but not yet supported ([ADR-0014](/adr/0014-spawn-sandbox-technology/)); passing `--sandbox=podman` or `--runtime=podman` fails with `podman runtime is not supported yet (v4 is Docker-only); see ADR-0014`.
 
@@ -32,13 +39,16 @@ See [Sandbox Composition](/development/sandbox-composition/) for the full workfl
 
 ## Actions
 
-| Command | Purpose | Ratified by |
-|---|---|---|
-| `aileron action add <FQN>@<version>` | Fetch an action template from the named source and copy it into `~/.aileron/actions/`. Walks declared connector dependencies and prompts for each. | [ADR-0003](/adr/0003-action-model), [ADR-0007](/adr/0007-install-consent) |
-| `aileron action update <name>` | Fetch the latest version of an installed action's template; show a diff against the local file; apply on confirmation. | [ADR-0003](/adr/0003-action-model) |
-| `aileron action list` | List every action in `~/.aileron/actions/` with its source FQN, version, and connector dependencies. | [ADR-0003](/adr/0003-action-model) |
-| `aileron action run <name>` | Invoke an installed action directly from the terminal through the same daemon endpoint used by the agent-facing MCP server. Useful for smoke tests, connector diagnostics, and scripts. | [ADR-0003](/adr/0003-action-model), [ADR-0008](/adr/0008-intent-matching), [ADR-0009](/adr/0009-user-channel) |
-| `aileron action remove <name>` | Delete an installed action file. Connectors no longer referenced are *not* automatically removed; use `aileron connector gc`. | [ADR-0003](/adr/0003-action-model) |
+| Command | Purpose |
+|---|---|
+| `aileron action add <FQN> [--version=<v>] [--force] [--yes] [--no-bind]` | Fetch an action template from the named source and copy it into `~/.aileron/actions/`. Walks declared connector dependencies and prompts for each. On a fresh machine it also prompts to trust the publisher's signing key and to consent to each connector install. |
+| `aileron action add-suite <SOURCE> [--force] [--yes] [--no-bind]` | Install a suite of actions in declaration order, sharing trust and connector state across the set so a publisher's prompt fires at most once. `<SOURCE>` is a remote `<scheme>://<owner>/<repo>/<file-path>@<ref>` or a local filesystem path. |
+| `aileron action list [--json]` | List every action in `~/.aileron/actions/` with its source FQN, version, and connector dependencies. |
+| `aileron action run <NAME> [--arg k=v ...] [--args <json>] [--json] [--audit-id-out <path>]` | Invoke an installed action directly from the terminal through the same daemon endpoint used by the agent-facing MCP server. Useful for smoke tests, connector diagnostics, and scripts. |
+| `aileron action enable <NAME>` | Re-surface a disabled action to the LLM. The change is recorded in `~/.aileron/action-state.json`. |
+| `aileron action disable <NAME>` | Hide an installed action from the LLM without uninstalling it. The manifest file is left in place; the change is recorded in `~/.aileron/action-state.json`. |
+
+MCP servers that cached the tool list at boot need to be restarted before an enable or disable toggle takes effect with the LLM.
 
 ### `aileron action run`
 
@@ -74,66 +84,119 @@ Approval-gated actions return an approval-pending message instead of running imm
 
 ## Connectors
 
-| Command | Purpose | Ratified by |
-|---|---|---|
-| `aileron connector install <FQN>@<version>` | Install a connector by FQN: fetch, verify signature, verify hash, store in the content-addressed store at `~/.aileron/store/`. | [ADR-0002](/adr/0002-connector-model), [ADR-0004](/adr/0004-dependency-resolution), [ADR-0007](/adr/0007-install-consent) |
-| `aileron connector check` | Walk every connector referenced by installed actions; query upstream sources for newer versions; print a per-connector update report. Network-dependent. Pre-release versions excluded by default. | [ADR-0004](/adr/0004-dependency-resolution) |
-| `aileron connector update <FQN>` | Bump the version reference for a connector across all action files that use it, after explicit confirmation. | [ADR-0003](/adr/0003-action-model), [ADR-0004](/adr/0004-dependency-resolution) |
-| `aileron connector list` | List every connector in the local store with its FQN, version, hash, and which installed actions reference it. | [ADR-0004](/adr/0004-dependency-resolution) |
+| Command | Purpose |
+|---|---|
+| `aileron connector install <FQN> [--version=<v>] [--hash=<sha256:...>] [--yes]` | Install a connector by FQN: fetch, verify signature, verify hash, store in the content-addressed store at `~/.aileron/store/`. Pass `--yes` to auto-accept install consent in non-interactive use. |
+| `aileron connector check [--include-prerelease] [--json]` | Walk every connector referenced by installed actions; query upstream sources for newer versions; print a per-connector update report. Network-dependent. Pre-release versions are excluded unless `--include-prerelease` is passed. |
+
+## Keyring
+
+The keyring is the v1 source of trust for connector signature verification. Every `aileron connector install` checks the binary's signature against keys registered for the FQN's authority; without an entry, install fails closed. The keyring file lives at `~/.aileron/keyring.json`.
+
+| Command | Purpose |
+|---|---|
+| `aileron keyring trust <authority>` | Authorize a publisher's signing key at owner granularity, so the single grant covers every connector that publisher ships. The key is resolved automatically: `github://owner/connector` reads that repo's `keys/publisher.pub` on its default branch, and a bare `github://owner` resolves the key from the Hub catalog entry's `key_url`. Re-running is a safe no-op. |
+| `aileron keyring list` | List trusted publishers and their key fingerprints. |
+| `aileron keyring revoke <authority>` | Remove a publisher's keys from the trust list. Pass `--key <fingerprint>` instead of an authority to revoke a single key by fingerprint. |
+
+## Hub
+
+| Command | Purpose |
+|---|---|
+| `aileron hub list [connectors\|actions\|suites] [--json]` | List entries published to the Hub. The optional positional argument narrows to one catalog type; with none, all types are listed. |
+| `aileron hub search <query> [--type connectors\|actions\|suites] [--json]` | Search Hub entries by keyword, optionally filtered to one catalog type. |
+| `aileron hub show <FQN> [--type connectors\|actions\|suites] [--json]` | Show a single Hub entry by FQN. |
+
+## Secrets
+
+| Command | Purpose |
+|---|---|
+| `aileron secret set [--passphrase-file <path>] <name>` | Store a secret in the encrypted vault. The first secret on a new vault prompts to create and confirm the vault passphrase. Reference the stored value as `vault:<name>` in `aileron.yaml`. |
+| `aileron secret list [--json]` | List stored secret names. The secret value is never printed. |
 
 ## Bindings
 
-| Command | Purpose | Ratified by |
-|---|---|---|
-| `aileron binding setup [<connector-FQN>]` | Pre-bind every capability the connector declares (or every capability across all installed connectors when run without an argument). Used for headless setup and proactive setup. | [ADR-0006](/adr/0006-capability-binding-ux) |
-| `aileron binding list` | List every binding on this machine: kind, scope, identity, last-used timestamp, refresh status. | [ADR-0006](/adr/0006-capability-binding-ux) |
-| `aileron binding inspect <name>` | Show one binding's metadata: capability type, scope, account, created/last-used/last-refresh timestamps, connectors that use it. | [ADR-0006](/adr/0006-capability-binding-ux) |
-| `aileron binding rebind <name>` | Replace an existing binding with a fresh credential (after rotation, after revocation). Same flow as first-use binding. | [ADR-0006](/adr/0006-capability-binding-ux) |
-| `aileron binding revoke <name>` | Remove a binding entirely. Subsequent invocations of any connector that would have used it trigger first-use binding. | [ADR-0006](/adr/0006-capability-binding-ux) |
+| Command | Purpose |
+|---|---|
+| `aileron binding setup <connector-FQN>` | Pre-bind every capability the named connector declares. Used for headless setup and proactive setup. |
+| `aileron binding list [--connector FQN] [--kind KIND] [--json]` | List every binding on this machine: kind, scope, identity, last-used timestamp, refresh status. |
+| `aileron binding inspect <name>` | Show one binding's metadata: capability type, scope, account, created/last-used/last-refresh timestamps, connectors that use it. |
+| `aileron binding rebind <name>` | Replace an existing binding with a fresh credential (after rotation, after revocation). Same flow as first-use binding. |
+| `aileron binding reauthorize <name>` | Re-run the authorization flow for an existing binding, for example to widen scope or recover from an upstream revocation, keeping the binding's name. |
+| `aileron binding revoke <name>` | Remove a binding entirely. Subsequent invocations of any connector that would have used it trigger first-use binding. |
 
 ## Sync and verify
 
-| Command | Purpose | Ratified by |
-|---|---|---|
-| `aileron sync` | Walk `~/.aileron/actions/`; install any missing connectors into the local store; surface unbound capability requirements. Idempotent. | [ADR-0004](/adr/0004-dependency-resolution) |
-| `aileron sync --bind-all` | Like `sync`, but additionally pre-binds every required capability before exiting. Useful for fresh-machine setup. | [ADR-0006](/adr/0006-capability-binding-ux) |
-| `aileron sync --yes` | Headless mode. Auto-approves install consent for every new connector encountered. Per-command flag; no global config. | [ADR-0007](/adr/0007-install-consent) |
+| Command | Purpose |
+|---|---|
+| `aileron sync` | Walk `~/.aileron/actions/`; install any missing connectors into the local store; surface unbound capability requirements. Idempotent. |
+| `aileron sync --bind-all` | Like `sync`, but additionally pre-binds every required capability before exiting. Useful for fresh-machine setup. |
+| `aileron sync --yes` | Headless mode. Auto-approves install consent for every new connector encountered. Per-command flag; no global config. |
 
 ## Vault
 
-| Command | Purpose | Ratified by |
-|---|---|---|
-| `aileron vault init [--passphrase-file <path>]` | Create the local file vault. Deliberate first-run flow; refuses to overwrite an existing vault. | [ADR-0011](/adr/0011-local-credential-vault) |
-| `aileron vault put agents/<name>/<purpose> --from-file <path>` | Write a per-agent credential envelope from a file, bytes verbatim. The `<purpose>` segment (e.g. `oauth`, `apikey`) selects which credential to write. Daemon-backed; agents namespace only. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
-| `aileron vault delete agents/<name>/<purpose> [--yes]` | Delete a per-agent credential envelope. The argument is the fully-qualified path `vault list` prints (e.g. `agents/claude/oauth`, `agents/claude/apikey`). Confirms first unless `--yes`. Daemon-backed; agents namespace only. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
-| `aileron vault list [--scope agent\|user\|all] [--prefix agents/] [--include-control-plane] [--json]` | List vault entries, metadata only. The credential value is never listed. With no `--scope` it prints the union of every locally-owned namespace (agent, user, and capability-binding credentials, which include connector entries like `connectors/<provider>/default` and `oauth2/<provider>/...`), each line prefixed with its scope. `--scope` narrows to a single typed namespace; `--include-control-plane` adds the `connected-accounts/` and `llm-config/` namespaces to the union. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
+| Command | Purpose |
+|---|---|
+| `aileron vault init [--passphrase-file <path>]` | Create the local file vault. Deliberate first-run flow; refuses to overwrite an existing vault. |
+| `aileron vault put agents/<name>/<purpose> --from-file <path>` | Write a per-agent credential envelope from a file, bytes verbatim. The `<purpose>` segment (e.g. `oauth`, `apikey`) selects which credential to write. Daemon-backed; agents namespace only. |
+| `aileron vault delete agents/<name>/<purpose> [--yes]` | Delete a per-agent credential envelope. The argument is the fully-qualified path `vault list` prints (e.g. `agents/claude/oauth`, `agents/claude/apikey`). Confirms first unless `--yes`. Daemon-backed; agents namespace only. |
+| `aileron vault list [--scope agent\|user\|all] [--prefix agents/] [--include-control-plane] [--json]` | List vault entries, metadata only. The credential value is never listed. With no `--scope` it prints the union of every locally-owned namespace (agent, user, and capability-binding credentials, which include connector entries like `connectors/<provider>/default` and `oauth2/<provider>/...`), each line prefixed with its scope. `--scope` narrows to a single typed namespace; `--include-control-plane` adds the `connected-accounts/` and `llm-config/` namespaces to the union. |
 
 The `put` and `delete` verbs talk to the running daemon and operate only on the `agents/<name>/<purpose>` namespace. They never open the vault file directly and reject any other path. The `<purpose>` segment must match `^[a-z0-9][a-z0-9_-]*$` and defaults to `oauth` for entries an older daemon returns without one. What `vault list --scope agent` prints for an agent entry is the fully-qualified `agents/<name>/<purpose>` path, exactly what `vault delete` takes to remove it, so a listed line can be pasted straight into `delete`. An agent holding both an OAuth envelope and an API key surfaces as two distinct lines (`agents/<name>/oauth` and `agents/<name>/apikey`).
 
-`vault list` itself is read-only and broader: the default (no `--scope`) walks the vault once and surfaces every locally-owned namespace, so connector and capability-binding credentials appear alongside the agent and user entries instead of being silently hidden. Listing works on a locked vault because it never decrypts a stored value (metadata is plaintext per [ADR-0011](/adr/0011-local-credential-vault)). The two tenant-keyed control-plane namespaces (`connected-accounts/`, `llm-config/`) are excluded unless `--include-control-plane` is passed. See [Sandbox Agent Auth](/development/sandbox-agent-auth/) for the seeding and recovery flows.
+`vault list` itself is read-only and broader: the default (no `--scope`) walks the vault once and surfaces every locally-owned namespace, so connector and capability-binding credentials appear alongside the agent and user entries instead of being silently hidden. Listing works on a locked vault because it never decrypts a stored value (metadata is plaintext). The two tenant-keyed control-plane namespaces (`connected-accounts/`, `llm-config/`) are excluded unless `--include-control-plane` is passed. See [Sandbox Agent Auth](/development/sandbox-agent-auth/) for the seeding and recovery flows.
 
 ## Auth
 
-| Command | Purpose | Ratified by |
-|---|---|---|
-| `aileron auth <agent> --import-from-host` | Seed the vault from an already-authenticated host install of claude or codex. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
-| `aileron auth github [--runtime <auto\|docker>] [--image <ref>]` | Run gh's OAuth device-authorization flow inside a gh-bearing container and store the captured bearer token at `user/github`. HTTPS only; no refresh machinery. | [ADR-0025](/adr/0025-vault-backed-agent-auth) |
+| Command | Purpose |
+|---|---|
+| `aileron auth <agent> --import-from-host` | Seed the vault from an already-authenticated host install of claude or codex. |
+| `aileron auth github [--runtime <auto\|docker>] [--image <ref>]` | Run gh's OAuth device-authorization flow inside a gh-bearing container and store the captured bearer token at `user/github`. HTTPS only; no refresh machinery. |
 
 `aileron auth github` is a one-time acquisition flow. The `github` verb resolves the shipped `gh` capture descriptor by name and drives the generic capture flow. That flow runs `gh auth login` and `gh auth token` in the same container, then PUTs the token to the user-level `user/github` vault namespace through the daemon. The provider knowledge ships as a trusted YAML descriptor in the auth domain, so adding another tool is a new descriptor rather than new code.
 
+## Approvals
+
+| Command | Purpose |
+|---|---|
+| `aileron approval list` | List pending action-approval requests. |
+| `aileron approval approve <id> [--reason "..."]` | Approve a pending action so the agent's blocked tool call unblocks. The optional `--reason` is recorded with the decision. |
+| `aileron approval deny <id> [--reason "..."]` | Deny a pending action so the agent receives `approval_denied`. The optional `--reason` is recorded with the decision. |
+
+## Audit
+
+| Command | Purpose |
+|---|---|
+| `aileron audit list [--since RFC3339] [--audit-id ID] [--connector FQN] [--class CLASS] [--limit N] [--json]` | List action-execution audit-log entries, optionally filtered by time, audit id, connector, or class. |
+| `aileron audit show <audit-id>` | Show the full record for one audit-log entry. |
+
+## Sessions
+
+| Command | Purpose |
+|---|---|
+| `aileron sessions list [--active] [--agent NAME] [--since RFC3339] [--limit N] [--json]` | List `aileron launch` session records. A bare `aileron sessions` lists too, answering "what did I run today?" without ceremony. |
+| `aileron sessions get <session-id> [--json]` | Show one session record by id. |
+| `aileron sessions watch <session-id> [--no-follow]` | Stream a session's events as they arrive. Pass `--no-follow` to print the current snapshot and exit. |
+
+## Browser
+
+| Command | Purpose |
+|---|---|
+| `aileron open [approvals \| approval <id>]` | Open the Aileron webapp in your browser. With no argument it opens the root; `approvals` opens the approvals view; `approval <id>` focuses one approval, mirroring the URL the terminal notifier prints. |
+
 ## Utility
 
-| Command | Purpose | Ratified by |
-|---|---|---|
-| `aileron version` | Print the runtime version. | — |
-| `aileron help [<command>]` | Show CLI help. | — |
+| Command | Purpose |
+|---|---|
+| `aileron version` | Print the runtime version. |
+| `aileron help [<command>]` | Show CLI help. |
 
 ## Architecture: CLI is an HTTP client
 
 Every command above resolves to one or more HTTP operations against the Aileron server. The server may be:
 
-- **Local** — a process the user started with `aileron launch`, listening on `localhost:8721/v1` (the v1 default).
-- **Hosted** — a future Aileron Cloud deployment reachable over HTTPS (post-MVP, paired with the hosted backend introduced in [ADR-0009](/adr/0009-user-channel) Phase 2).
+- **Local** — a process the user started with `aileron launch`, listening on a daemon-advertised address (the v1 default).
+- **Hosted** — a future Aileron Cloud deployment reachable over HTTPS (post-MVP).
 
 The CLI doesn't care which. It reads its target endpoint from configuration, opens HTTP, and invokes the spec'd operations. This separation means:
 


### PR DESCRIPTION
## Summary

Rewrites `docs/src/content/docs/cli/index.md` so the CLI reference matches the command surface the stdlib `flag`-based dispatcher in `cmd/aileron/main.go` actually exposes, and drops the provenance framing the issue flagged.

- **Drops the ADR column.** Every command table loses its `Ratified by` column (now `Command | Purpose`) and the L11 "the ADR(s) that ratify its behavior" framing is removed. The functional cross-links to `/development/` guides stay.
- **Removes nonexistent commands.** `aileron connector update <FQN>` and `aileron connector list` do not exist; `runConnector` only dispatches `install` and `check`.
- **Fixes wrong syntax.** `binding setup <connector-FQN>` is a required arg (not optional "all connectors"); `keyring trust <authority>` takes one arg with the key auto-resolved (was documented as two args); `status [runtime|notifications|vault]` takes an optional section arg.
- **Adds the undocumented groups.** `secret set|list`, `keyring trust|list|revoke` (`revoke --key`), `hub list|search|show`, `approval list|approve|deny` (`--reason`), `audit list|show`, `sessions list|get|watch` (`--no-follow`), `daemon start|stop|status` + `aileron stop` alias, and `open [approvals|approval <id>]`.
- **Adds missing subcommands.** `action enable|disable`, `binding reauthorize`, `sandbox cache clear`; the sandbox group line now reads `[init|plan|build|check|cache]`.
- **Corrects launch flags** to the real usage: adds `--log-level`, `--sandbox-proxy`, `--host-login`, `--claude-auth`.
- **Trims inline ADR-0011 provenance** from the vault prose where it read as provenance, keeping the functional `/development/sandbox-agent-auth/` link.

Docs-only change. No OpenAPI spec touched, so no regeneration needed.

## Test plan

- `task build:docs` — site builds, all 129 pages render (the GitHub 403 line is an unrelated release-version rate-limit fallback).
- `task lint:docs` (`astro check`) — 0 errors, 0 warnings, 0 hints.
- Manually cross-checked every documented command, subcommand, and flag against the dispatch switches and usage constants in `cmd/aileron/main.go`, `keyring.go`, `hub.go`, `approval.go`, `audit`, `sessions.go`, `sandbox.go`, `daemon_cli.go`, `open.go`, and `vault.go`.

Closes #1442

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Comprehensively updated CLI command reference and documentation to reflect current command surface
  * Expanded coverage of commands including `launch`, `actions`, `connector`, `vault`, `auth`, `approval`, `audit`, `sessions`, and more
  * Reorganized documentation with new sections for keyring, hub, secret, binding, and sync/verify operations
  * Updated architecture documentation describing server configuration and endpoint handling

<!-- end of auto-generated comment: release notes by coderabbit.ai -->