### PR TITLE
fix(launch): collapse scoop `current` junction so Codex's Windows sandbox can spawn aileron-mcp

### DIFF
--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -196,14 +196,40 @@ func resolveSibling(selfPath, name string) (string, error) {
 	for _, c := range siblingCandidates(name, exeSuffix()) {
 		candidate := filepath.Join(dir, c)
 		if _, err := os.Stat(candidate); err == nil {
-			return resolveShimTarget(candidate), nil
+			return resolveReparsePoints(resolveShimTarget(candidate)), nil
 		}
 	}
 	found, err := exec.LookPath(name)
 	if err != nil {
 		return "", err
 	}
-	return resolveShimTarget(found), nil
+	return resolveReparsePoints(resolveShimTarget(found)), nil
+}
+
+// resolveReparsePoints collapses symlinks and Windows directory junctions
+// in path to a concrete on-disk path, best-effort.
+//
+// Scoop exposes an installed binary through an
+// `...\apps\<app>\current\...` directory junction (a reparse point) that
+// points at the versioned install dir. resolveShimTarget unwraps the
+// Scoop stub to that junction path; a normal shell launch traverses it
+// fine, but Codex's elevated Windows sandbox cannot spawn a command whose
+// path crosses the junction and still fails with `OS error 2` even after
+// the stub is unwrapped — the successor symptom to #1405, where writing
+// the real (but junction-rooted) target was necessary yet not sufficient.
+// The command written into the agent's MCP config must therefore be the
+// resolved versioned path (`...\apps\<app>\0.0.9\...`). EvalSymlinks
+// resolves junctions as well as symlinks on Windows.
+//
+// On failure (the path does not exist, or the platform cannot evaluate
+// it) the input is returned unchanged so a working path is never made
+// worse. The behavior is keyed off on-disk reparse data, not GOOS, so a
+// symlink planted in a test exercises it on any host.
+func resolveReparsePoints(path string) string {
+	if resolved, err := filepath.EvalSymlinks(path); err == nil {
+		return resolved
+	}
+	return path
 }
 
 // resolveShimTarget unwraps a Scoop shim to the real binary it launches.

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -581,7 +581,7 @@ func TestResolveSandboxMCPBinary_PrefersLinuxSibling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveSandboxMCPBinary: %v", err)
 	}
-	want, _ := filepath.Abs(linuxBin)
+	want := wantResolvedPath(t, linuxBin)
 	if got != want {
 		t.Fatalf("got %q, want %q (the Linux-suffixed sibling)", got, want)
 	}
@@ -605,7 +605,7 @@ func TestResolveSandboxMCPBinary_FallsBackToHostBinary(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveSandboxMCPBinary: %v", err)
 	}
-	want, _ := filepath.Abs(hostBin)
+	want := wantResolvedPath(t, hostBin)
 	if got != want {
 		t.Fatalf("got %q, want %q (fallback to plain aileron-mcp)", got, want)
 	}
@@ -691,7 +691,7 @@ func TestResolveSibling_FindsHostSibling(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveSibling: %v", err)
 	}
-	want, _ := filepath.Abs(mcp)
+	want := wantResolvedPath(t, mcp)
 	if got != want {
 		t.Fatalf("resolveSibling = %q, want %q", got, want)
 	}
@@ -733,9 +733,80 @@ func TestResolveSibling_UnwrapsScoopShim(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveSibling: %v", err)
 	}
-	want, _ := filepath.Abs(realBin)
+	want := wantResolvedPath(t, realBin)
 	if got != want {
 		t.Fatalf("resolveSibling = %q, want the real target %q (not the Scoop shim stub)", got, want)
+	}
+}
+
+// wantResolvedPath returns the absolute, reparse-point-resolved form of p,
+// matching what resolveSibling now emits. It is needed because resolveSibling
+// collapses symlinks/junctions (resolveReparsePoints) and t.TempDir() is
+// itself a symlink on macOS (/var -> /private/var); a bare filepath.Abs
+// would otherwise mismatch the resolved result on that host.
+func wantResolvedPath(t *testing.T, p string) string {
+	t.Helper()
+	abs, err := filepath.Abs(p)
+	if err != nil {
+		t.Fatalf("filepath.Abs(%q): %v", p, err)
+	}
+	resolved, err := filepath.EvalSymlinks(abs)
+	if err != nil {
+		t.Fatalf("filepath.EvalSymlinks(%q): %v", abs, err)
+	}
+	return resolved
+}
+
+// TestResolveSibling_ResolvesScoopCurrentJunction is the regression test for
+// the successor to #1405: unwrapping the Scoop stub to the real target was
+// necessary but not sufficient, because that target rides the
+// `...\apps\<app>\current\...` directory junction. A normal shell launch
+// traverses the junction, but Codex's elevated Windows sandbox cannot spawn a
+// command whose path crosses it and still fails with OS error 2.
+// resolveSibling must collapse the junction to the versioned install dir
+// (`...\apps\<app>\0.0.9\...`) before the command is written into config.toml.
+// A POSIX symlink stands in for the Windows junction so this is verifiable on
+// any host.
+func TestResolveSibling_ResolvesScoopCurrentJunction(t *testing.T) {
+	// Canonicalize the base so the only reparse point under test is the
+	// `current` link, not t.TempDir()'s own /var -> /private/var on macOS.
+	dir := wantResolvedPath(t, t.TempDir())
+	selfPath := filepath.Join(dir, "aileron"+exeSuffix())
+	if err := os.WriteFile(selfPath, []byte("self"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	stub := filepath.Join(dir, "aileron-mcp"+exeSuffix())
+	if err := os.WriteFile(stub, []byte("scoop shim stub"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	versionedDir := filepath.Join(dir, "apps", "aileron", "0.0.9")
+	if err := os.MkdirAll(versionedDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	realBin := filepath.Join(versionedDir, "aileron-mcp"+exeSuffix())
+	if err := os.WriteFile(realBin, []byte("the real 14 MB binary"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// `current` is a junction to the versioned dir on a real Scoop install;
+	// a directory symlink is the cross-platform stand-in.
+	currentLink := filepath.Join(dir, "apps", "aileron", "current")
+	if err := os.Symlink(versionedDir, currentLink); err != nil {
+		t.Skipf("cannot create symlink on this host (unprivileged Windows?): %v", err)
+	}
+	// The Scoop sidecar points at the binary *through* the current junction,
+	// exactly as resolveShimTarget would hand it back.
+	shimTarget := filepath.Join(currentLink, "aileron-mcp"+exeSuffix())
+	sidecar := filepath.Join(dir, "aileron-mcp.shim")
+	if err := os.WriteFile(sidecar, []byte("path = \""+shimTarget+"\"\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	got, err := resolveSibling(selfPath, "aileron-mcp")
+	if err != nil {
+		t.Fatalf("resolveSibling: %v", err)
+	}
+	if got != realBin {
+		t.Fatalf("resolveSibling = %q, want junction-free %q (sandbox spawns the versioned path, not the `current` junction)", got, realBin)
 	}
 }
 
@@ -759,7 +830,7 @@ func TestResolveSibling_NoShimSidecarReturnsSiblingUnchanged(t *testing.T) {
 	if err != nil {
 		t.Fatalf("resolveSibling: %v", err)
 	}
-	want, _ := filepath.Abs(mcp)
+	want := wantResolvedPath(t, mcp)
 	if got != want {
 		t.Fatalf("resolveSibling = %q, want %q (sibling unchanged when no shim sidecar)", got, want)
 	}


### PR DESCRIPTION
## Summary

On Windows + Scoop, `aileron launch codex` still failed with **`MCP startup failed: ... no such file or directory (os error 2)`** and Aileron showed up in Codex with **zero tools**, even after #1405 (write the real shim target, not the Scoop stub) and #1406 (include `AILERON_TOKEN`).

Root cause, confirmed by live diagnosis on a Windows host: the real target Scoop records and that #1405 now writes is `C:\Users\<u>\scoop\apps\aileron\current\aileron-mcp.exe`. `current` is a Scoop **directory junction** (a reparse point) pointing at the versioned install dir. A normal PowerShell launch traverses the junction fine — but Codex's elevated Windows sandbox (`[windows] sandbox = "elevated"`) cannot spawn a command whose path crosses the junction, so `CreateProcess` returns `OS error 2`. The MCP server never starts, so no `tools/list` succeeds.

Editing `config.toml` by hand to point at the junction-free versioned path (`...\apps\aileron\0.0.9\aileron-mcp.exe`) made the MCP server start under the same `elevated` sandbox — proving the junction is the gate.

## Fix

`resolveSibling` now runs the resolved command path through `filepath.EvalSymlinks` (new `resolveReparsePoints` helper) after unwrapping the Scoop shim. `EvalSymlinks` collapses Windows junctions as well as symlinks, so the command written into Codex's `config.toml` is the versioned install path the sandbox can launch. It is best-effort: a path that cannot be evaluated is returned unchanged, so a working path is never made worse, and non-Windows installs are unaffected (a no-op when there are no reparse points).

This is the successor to #1405 — that fix was necessary (stop writing the stub) but not sufficient (the real target still rode the junction).

## Test plan

- New regression test `TestResolveSibling_ResolvesScoopCurrentJunction`: plants a Scoop-shaped layout where the shim sidecar points at the binary *through* a `current` symlink (the cross-platform stand-in for the Windows junction) and asserts `resolveSibling` returns the junction-free versioned path. **Verified it fails before the fix** (returns the `current` path) **and passes after**.
- Existing resolver tests updated to expect the canonical (reparse-resolved) path, since `t.TempDir()` is itself a symlink on macOS; added `wantResolvedPath` helper.
- `go test ./internal/launch/` green; `go vet` clean; `cmd/aileron` builds.

### Remaining end-to-end verification (needs a Windows build)
The code-level fix and regression are verified, but the full "26 tools in Codex" confirmation requires installing a build carrying this change on the Windows host and running `aileron launch codex` against a live daemon. The standalone-`codex` run during diagnosis showed only the ~5 built-in tools because it used a stale `config.toml` env pointing at a daemon that was no longer running (expected per #1406), not a connector-discovery regression.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved binary path resolution to properly collapse Windows symlinks and directory junctions.
  * Enhanced compatibility with Scoop package manager installations by better unwrapping shim sidecars.
  * Increased robustness of path resolution across platforms.

* **Tests**
  * Added regression test for junction collapsing in package manager installations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->