### PR TITLE
fix(mcp): make action-discovery failures distinguishable and agent-visible

### DIFF
--- a/cmd/aileron-mcp/main.go
+++ b/cmd/aileron-mcp/main.go
@@ -15,6 +15,14 @@
 // a per-session unix socket; ADR-0012 step 9B-2 moved comms ownership
 // to the daemon and switched the wire to HTTP long-poll.
 //
+// When AILERON_URL is set the server also exposes an always-present
+// `aileron_diagnostics` tool. Action discovery is best-effort: if it
+// fails (daemon unreachable, 401 unauthorized, daemon error) or returns
+// zero actions, the server keeps serving the built-in tools and records
+// the classified reason. `aileron_diagnostics` reports that reason and
+// the remediation so an agent can answer "why are connector actions
+// missing?" without an operator reading the stderr warning.
+//
 // The binary communicates over stdio using JSON-RPC 2.0, per the MCP
 // specification.
 //
@@ -44,6 +52,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"fmt"
 	"io"
 	"log/slog"
@@ -232,6 +241,113 @@ type actionApprovalResult struct {
 	Failure json.RawMessage `json:"failure,omitempty"`
 }
 
+// discoveryReason classifies the outcome of a /v1/actions discovery
+// attempt so the generic "discovery failed" warning can be replaced
+// with one that names the actual failure mode, and so the synthetic
+// aileron_diagnostics tool can explain it to the agent.
+type discoveryReason int
+
+const (
+	// reasonOK means discovery succeeded and returned at least one action.
+	reasonOK discoveryReason = iota
+	// reasonUnreachable means the HTTP request never completed — the
+	// daemon is not listening (connection refused, DNS, timeout).
+	reasonUnreachable
+	// reasonUnauthorized means the daemon returned 401 — a stale or
+	// missing AILERON_TOKEN / session.
+	reasonUnauthorized
+	// reasonHTTPError means the daemon returned a non-200 status other
+	// than 401 (e.g. 5xx), or the response body failed to decode.
+	reasonHTTPError
+	// reasonEmpty means discovery succeeded over the wire but the daemon
+	// reported zero installed actions.
+	reasonEmpty
+)
+
+// discoveryDiagnostic captures the outcome of the most recent discovery
+// attempt: its classified reason, the action count on success, and (for
+// failures) the underlying error for the stderr log. It is the single
+// source the reason-tagged warning and the aileron_diagnostics tool both
+// read from.
+type discoveryDiagnostic struct {
+	reason discoveryReason
+	// count is the number of enabled actions discovered (only meaningful
+	// when reason is reasonOK).
+	count int
+	// err is the transport/decode/status error, if any. Nil for reasonOK
+	// and reasonEmpty.
+	err error
+}
+
+// ok reports whether discovery succeeded with at least one action.
+func (d discoveryDiagnostic) ok() bool { return d.reason == reasonOK }
+
+// summary returns a short, reason-tagged phrase naming the failure mode,
+// with the daemon URL interpolated where it aids diagnosis. Used as the
+// human-facing line in both the stderr warning and the synthetic tool's
+// output.
+func (d discoveryDiagnostic) summary(url string) string {
+	switch d.reason {
+	case reasonOK:
+		return fmt.Sprintf("discovered %d action(s) from %s", d.count, url)
+	case reasonUnreachable:
+		return fmt.Sprintf("daemon unreachable at %s", url)
+	case reasonUnauthorized:
+		return "unauthorized (stale or missing AILERON_TOKEN / session)"
+	case reasonHTTPError:
+		if d.err != nil {
+			return "daemon error: " + d.err.Error()
+		}
+		return "daemon returned an unexpected response"
+	case reasonEmpty:
+		return fmt.Sprintf("daemon at %s returned 0 actions", url)
+	default:
+		return "unknown discovery state"
+	}
+}
+
+// remediation returns the suggested operator fix for a failed discovery,
+// or the empty string when discovery succeeded. Surfaced to the agent via
+// aileron_diagnostics so "why do I only see the built-in tools?" is
+// answerable without reading stderr.
+func (d discoveryDiagnostic) remediation() string {
+	switch d.reason {
+	case reasonUnreachable:
+		return "Start the daemon (e.g. run `aileron launch`) and confirm AILERON_URL points at it."
+	case reasonUnauthorized:
+		return "Re-authenticate: the AILERON_TOKEN or session is stale. Re-run `aileron launch` to mint a fresh token."
+	case reasonHTTPError:
+		return "Check the daemon logs; it returned an unexpected response to /v1/actions."
+	case reasonEmpty:
+		return "Install actions with `aileron action add <name>`, then they will appear without restarting."
+	default:
+		return ""
+	}
+}
+
+// discoveryError wraps a discovery failure with its classified reason so
+// callers (startup, refresh) can build a reason-tagged warning and record
+// the diagnostic. Unwraps to the underlying error for callers that only
+// care that discovery failed.
+type discoveryError struct {
+	reason discoveryReason
+	err    error
+}
+
+func (e *discoveryError) Error() string { return e.err.Error() }
+func (e *discoveryError) Unwrap() error { return e.err }
+
+// aileronDiagnosticsTool is an always-present (when AILERON_URL is set)
+// synthetic tool the agent can call to learn why connector actions are
+// missing. Mirrors the always-on check_action_status precedent. Its
+// description and call result report the classified discovery state and
+// the remediation so the degraded surface is answerable from the agent.
+var aileronDiagnosticsTool = toolDef{
+	Name:        "aileron_diagnostics",
+	Description: "Report Aileron's action-discovery health. Call this to learn why connector action tools may be missing — it distinguishes a daemon that is unreachable, an unauthorized (stale token/session) response, a daemon error, and a daemon that returned zero installed actions, and reports how many actions are currently exposed plus the remediation. Useful when the agent sees only the built-in tools and expects connector actions.",
+	InputSchema: schema{Type: "object"},
+}
+
 // --- Server ---
 
 type server struct {
@@ -246,9 +362,9 @@ type server struct {
 	// path use a tighter timeout without affecting comms.
 	commsHTTPClient *http.Client
 
-	// actionsMu guards actionTools and actionNameMap. The request loop
-	// reads them (tools/list, tools/call) while the refresh poller
-	// (refreshLoop) swaps them on change, so every access is locked.
+	// actionsMu guards actionTools, actionNameMap, and discovery. The
+	// request loop reads them (tools/list, tools/call) while the refresh
+	// poller (refreshLoop) swaps them on change, so every access is locked.
 	actionsMu sync.RWMutex
 	// Discovered actions, populated at startup when AILERON_URL is set and
 	// refreshed in place by the poller. Keys of actionNameMap are
@@ -256,6 +372,12 @@ type server struct {
 	// (kebab-case) used in /v1/actions/{name}/run.
 	actionTools   []toolDef
 	actionNameMap map[string]string
+	// discovery records the outcome of the most recent /v1/actions
+	// discovery attempt (startup or a refresh tick). The aileron_diagnostics
+	// synthetic tool reports it so the degraded state is answerable from
+	// the agent, not just from stderr. Zero value (reasonOK, no count)
+	// before the first attempt.
+	discovery discoveryDiagnostic
 
 	// out is where JSON-RPC responses and notifications are written
 	// (os.Stdout in production). writeMu serializes writes so the
@@ -402,11 +524,21 @@ func main() {
 	// if discovery fails (daemon not running yet, vault locked, etc.)
 	// we proceed without action tools. Comms tools remain available.
 	if s.aileronURL != "" {
-		if tools, nameMap, err := s.discoverActions(context.Background()); err != nil {
+		tools, nameMap, err := s.discoverActions(context.Background())
+		diag := classifyDiscovery(tools, err)
+		s.setDiscovery(diag)
+		if err != nil {
 			slog.Warn("action discovery failed; continuing without action tools",
-				"url", s.aileronURL, "error", err)
+				"url", s.aileronURL, "reason", diag.summary(s.aileronURL), "error", err)
 		} else {
 			s.setActions(tools, nameMap)
+			if !diag.ok() {
+				// Wire succeeded but the daemon exposes no actions —
+				// distinct from a transport/auth failure, and worth a
+				// reason-tagged line so the operator isn't left guessing.
+				slog.Warn("action discovery returned no actions",
+					"url", s.aileronURL, "reason", diag.summary(s.aileronURL))
+			}
 		}
 	}
 
@@ -467,6 +599,43 @@ func (s *server) setActions(tools []toolDef, nameMap map[string]string) {
 	defer s.actionsMu.Unlock()
 	s.actionTools = tools
 	s.actionNameMap = nameMap
+}
+
+// classifyDiscovery turns a discoverActions result into a
+// discoveryDiagnostic. A discoveryError carries its own classified
+// reason; a success with zero tools is reasonEmpty (the daemon answered
+// but exposes no actions); a success with tools is reasonOK. Any error
+// that is not a *discoveryError is treated as an HTTP-class failure so
+// the diagnostic is never silently dropped.
+func classifyDiscovery(tools []toolDef, err error) discoveryDiagnostic {
+	if err != nil {
+		var de *discoveryError
+		if errors.As(err, &de) {
+			return discoveryDiagnostic{reason: de.reason, err: err}
+		}
+		return discoveryDiagnostic{reason: reasonHTTPError, err: err}
+	}
+	if len(tools) == 0 {
+		return discoveryDiagnostic{reason: reasonEmpty}
+	}
+	return discoveryDiagnostic{reason: reasonOK, count: len(tools)}
+}
+
+// setDiscovery records the latest discovery diagnostic under the same
+// lock that guards the action cache, so the aileron_diagnostics tool and
+// the refresh poller never read a torn state.
+func (s *server) setDiscovery(d discoveryDiagnostic) {
+	s.actionsMu.Lock()
+	defer s.actionsMu.Unlock()
+	s.discovery = d
+}
+
+// discoveryState returns a copy of the latest discovery diagnostic under
+// the read lock.
+func (s *server) discoveryState() discoveryDiagnostic {
+	s.actionsMu.RLock()
+	defer s.actionsMu.RUnlock()
+	return s.discovery
 }
 
 // refreshInterval parses the AILERON_MCP_REFRESH_INTERVAL env value
@@ -547,11 +716,15 @@ func (s *server) refreshLoop(ctx context.Context, interval time.Duration) {
 // a notification was emitted.
 func (s *server) refreshOnce(ctx context.Context) bool {
 	tools, nameMap, err := s.discoverActions(ctx)
+	diag := classifyDiscovery(tools, err)
+	s.setDiscovery(diag)
 	if err != nil {
 		// Leave the working surface intact; surface the failure on
-		// stderr so it's visible without poisoning the tool list.
+		// stderr so it's visible without poisoning the tool list. The
+		// reason tag distinguishes unreachable / unauthorized / daemon
+		// error so the operator can tell the modes apart.
 		slog.Warn("action refresh failed; keeping existing tool surface",
-			"url", s.aileronURL, "error", err)
+			"url", s.aileronURL, "reason", diag.summary(s.aileronURL), "error", err)
 		return false
 	}
 
@@ -677,6 +850,14 @@ func (s *server) availableTools() []toolDef {
 	// are discovered (a fresh daemon), the agent might be working
 	// against an approval id minted by an earlier session.
 	tools = append(tools, checkActionStatusTool)
+	// aileron_diagnostics is always available whenever there is a daemon
+	// to discover against (AILERON_URL set). It answers "why do I only
+	// see the built-in tools?" from the agent — reporting whether
+	// discovery is degraded and how to fix it — mirroring the always-on
+	// check_action_status precedent.
+	if s.aileronURL != "" {
+		tools = append(tools, aileronDiagnosticsTool)
+	}
 	return tools
 }
 
@@ -701,6 +882,8 @@ func (s *server) dispatchTool(ctx context.Context, name string, args map[string]
 		return s.httpRequest(args)
 	case "check_action_status":
 		return s.checkActionStatus(ctx, args)
+	case "aileron_diagnostics":
+		return s.diagnostics()
 	default:
 		return errorResult("unknown tool: " + name)
 	}
@@ -956,15 +1139,19 @@ func (s *server) discoverActions(ctx context.Context) ([]toolDef, map[string]str
 	s.setActionAuthHeaders(req)
 	resp, err := s.httpClient.Do(req)
 	if err != nil {
-		return nil, nil, err
+		return nil, nil, &discoveryError{reason: reasonUnreachable, err: err}
 	}
 	defer resp.Body.Close()
 	if resp.StatusCode != http.StatusOK {
-		return nil, nil, fmt.Errorf("/v1/actions: %s", resp.Status)
+		reason := reasonHTTPError
+		if resp.StatusCode == http.StatusUnauthorized {
+			reason = reasonUnauthorized
+		}
+		return nil, nil, &discoveryError{reason: reason, err: fmt.Errorf("/v1/actions: %s", resp.Status)}
 	}
 	var alr actionListResponse
 	if err := json.NewDecoder(resp.Body).Decode(&alr); err != nil {
-		return nil, nil, fmt.Errorf("decoding /v1/actions: %w", err)
+		return nil, nil, &discoveryError{reason: reasonHTTPError, err: fmt.Errorf("decoding /v1/actions: %w", err)}
 	}
 	tools := make([]toolDef, 0, len(alr.Items))
 	nameMap := make(map[string]string, len(alr.Items))
@@ -1128,6 +1315,36 @@ func (s *server) checkActionStatus(ctx context.Context, args map[string]any) too
 	return toolResult{
 		Content: []toolContent{{Type: "text", Text: formatActionApprovalResult(result)}},
 	}
+}
+
+// diagnostics implements the aileron_diagnostics MCP tool. It reports
+// the classified outcome of the most recent /v1/actions discovery so the
+// agent can answer "why are connector actions missing?" without the
+// operator reading stderr. Not an error result even when discovery is
+// degraded — the tool call itself succeeded; the degraded state rides in
+// the text.
+func (s *server) diagnostics() toolResult {
+	if s.aileronURL == "" {
+		return toolResult{Content: []toolContent{{Type: "text",
+			Text: "Aileron daemon not configured (AILERON_URL not set); no connector actions are expected. Only built-in tools are available."}}}
+	}
+	d := s.discoveryState()
+	var b strings.Builder
+	if d.ok() {
+		fmt.Fprintf(&b, "Action discovery healthy: %s.", d.summary(s.aileronURL))
+		return toolResult{Content: []toolContent{{Type: "text", Text: b.String()}}}
+	}
+	fmt.Fprintf(&b, "Action discovery degraded: %s.", d.summary(s.aileronURL))
+	if d.reason == reasonEmpty {
+		b.WriteString(" The daemon is reachable and authorized, but no actions are installed, so only the built-in tools are exposed.")
+	} else {
+		b.WriteString(" Only the built-in tools are exposed; connector actions could not be discovered.")
+	}
+	if rem := d.remediation(); rem != "" {
+		b.WriteString("\nRemediation: ")
+		b.WriteString(rem)
+	}
+	return toolResult{Content: []toolContent{{Type: "text", Text: b.String()}}}
 }
 
 // formatActionApprovalResult turns the API response into an LLM-

--- a/cmd/aileron-mcp/main_test.go
+++ b/cmd/aileron-mcp/main_test.go
@@ -5,6 +5,7 @@ import (
 	"bytes"
 	"context"
 	"encoding/json"
+	"errors"
 	"io"
 	"net/http"
 	"net/http/httptest"
@@ -1699,4 +1700,249 @@ func TestMaybeStartRefreshPoller_StartsAndStopsOnCancel(t *testing.T) {
 		}
 	}
 	cancel()
+}
+
+// --- Discovery failure classification + aileron_diagnostics tool ---
+
+// TestDiscoverActions_UnreachableClassified asserts a transport failure
+// (daemon not listening) classifies as reasonUnreachable so the warning
+// and diagnostics tool can say "daemon unreachable", not a generic error.
+func TestDiscoverActions_UnreachableClassified(t *testing.T) {
+	// Point at a closed port so the request fails at the transport layer.
+	s := &server{aileronURL: "http://127.0.0.1:1", httpClient: &http.Client{Timeout: time.Second}}
+	_, _, err := s.discoverActions(context.Background())
+	if err == nil {
+		t.Fatal("expected transport error for unreachable daemon")
+	}
+	diag := classifyDiscovery(nil, err)
+	if diag.reason != reasonUnreachable {
+		t.Fatalf("reason = %v, want reasonUnreachable", diag.reason)
+	}
+	if !strings.Contains(diag.summary(s.aileronURL), "unreachable") {
+		t.Errorf("summary = %q, want it to mention 'unreachable'", diag.summary(s.aileronURL))
+	}
+}
+
+// TestDiscoverActions_UnauthorizedClassified asserts a 401 classifies as
+// reasonUnauthorized — distinct from a generic HTTP error — so the
+// operator learns the token/session is stale.
+func TestDiscoverActions_UnauthorizedClassified(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client()}
+	_, _, err := s.discoverActions(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 401")
+	}
+	diag := classifyDiscovery(nil, err)
+	if diag.reason != reasonUnauthorized {
+		t.Fatalf("reason = %v, want reasonUnauthorized", diag.reason)
+	}
+	if !strings.Contains(diag.summary(srv.URL), "unauthorized") {
+		t.Errorf("summary = %q, want 'unauthorized'", diag.summary(srv.URL))
+	}
+	if !strings.Contains(diag.remediation(), "Re-authenticate") {
+		t.Errorf("remediation = %q, want re-auth guidance", diag.remediation())
+	}
+}
+
+// TestDiscoverActions_HTTPErrorClassified asserts a non-401 non-200 (500)
+// classifies as reasonHTTPError, keeping it distinct from unreachable /
+// unauthorized.
+func TestDiscoverActions_HTTPErrorClassified(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client()}
+	_, _, err := s.discoverActions(context.Background())
+	if err == nil {
+		t.Fatal("expected error for 500")
+	}
+	diag := classifyDiscovery(nil, err)
+	if diag.reason != reasonHTTPError {
+		t.Fatalf("reason = %v, want reasonHTTPError", diag.reason)
+	}
+}
+
+// TestClassifyDiscovery_EmptyIsReasonEmpty asserts a successful response
+// carrying zero actions classifies as reasonEmpty — the wire succeeded
+// but the daemon exposes nothing, distinct from a discovery failure.
+func TestClassifyDiscovery_EmptyIsReasonEmpty(t *testing.T) {
+	diag := classifyDiscovery([]toolDef{}, nil)
+	if diag.reason != reasonEmpty {
+		t.Fatalf("reason = %v, want reasonEmpty", diag.reason)
+	}
+	if diag.ok() {
+		t.Error("ok() = true for empty result")
+	}
+	if !strings.Contains(diag.summary("http://x"), "0 actions") {
+		t.Errorf("summary = %q, want '0 actions'", diag.summary("http://x"))
+	}
+}
+
+// TestClassifyDiscovery_SuccessIsReasonOK asserts a non-empty result
+// classifies as reasonOK with the action count.
+func TestClassifyDiscovery_SuccessIsReasonOK(t *testing.T) {
+	diag := classifyDiscovery([]toolDef{{Name: "a"}, {Name: "b"}}, nil)
+	if !diag.ok() {
+		t.Fatalf("ok() = false, reason = %v", diag.reason)
+	}
+	if diag.count != 2 {
+		t.Errorf("count = %d, want 2", diag.count)
+	}
+}
+
+// TestAvailableTools_IncludesDiagnosticsWhenURLSet asserts the synthetic
+// aileron_diagnostics tool is present whenever AILERON_URL is set, so the
+// agent can always ask why connector actions are missing.
+func TestAvailableTools_IncludesDiagnosticsWhenURLSet(t *testing.T) {
+	s := &server{aileronURL: "http://127.0.0.1:1", httpClient: &http.Client{}}
+	names := map[string]bool{}
+	for _, td := range s.availableTools() {
+		names[td.Name] = true
+	}
+	if !names["aileron_diagnostics"] {
+		t.Errorf("aileron_diagnostics missing; tools = %v", names)
+	}
+}
+
+// TestAvailableTools_OmitsDiagnosticsWhenNoURL asserts the diagnostics
+// tool is absent when there is no daemon to discover against — it would
+// have nothing to report and would inflate the host-launch tool surface.
+func TestAvailableTools_OmitsDiagnosticsWhenNoURL(t *testing.T) {
+	s := &server{commsURL: "http://x", sessionID: "sess-x", httpClient: &http.Client{}}
+	for _, td := range s.availableTools() {
+		if td.Name == "aileron_diagnostics" {
+			t.Fatal("aileron_diagnostics present without AILERON_URL")
+		}
+	}
+}
+
+// TestDiagnostics_ReportsUnreachable asserts the synthetic tool's result
+// names the unreachable daemon and the remediation when discovery failed
+// at the transport layer — the operator's core complaint, answerable
+// from the agent.
+func TestDiagnostics_ReportsUnreachable(t *testing.T) {
+	s := &server{aileronURL: "http://127.0.0.1:1", httpClient: &http.Client{}}
+	s.setDiscovery(discoveryDiagnostic{reason: reasonUnreachable, err: context.DeadlineExceeded})
+	res := s.diagnostics()
+	if res.IsError {
+		t.Fatal("diagnostics should not be an error result")
+	}
+	text := res.Content[0].Text
+	if !strings.Contains(text, "degraded") || !strings.Contains(text, "unreachable") {
+		t.Errorf("text = %q, want degraded + unreachable", text)
+	}
+	if !strings.Contains(text, "aileron launch") {
+		t.Errorf("text = %q, want remediation mentioning aileron launch", text)
+	}
+}
+
+// TestDiagnostics_ReportsUnauthorized asserts a 401 surfaces as a
+// re-auth prompt the agent can relay.
+func TestDiagnostics_ReportsUnauthorized(t *testing.T) {
+	s := &server{aileronURL: "http://daemon", httpClient: &http.Client{}}
+	s.setDiscovery(discoveryDiagnostic{reason: reasonUnauthorized})
+	text := s.diagnostics().Content[0].Text
+	if !strings.Contains(text, "unauthorized") {
+		t.Errorf("text = %q, want 'unauthorized'", text)
+	}
+	if !strings.Contains(text, "Re-authenticate") {
+		t.Errorf("text = %q, want re-auth remediation", text)
+	}
+}
+
+// TestDiagnostics_ReportsEmpty asserts a reachable-but-empty daemon is
+// reported as such, distinct from a transport/auth failure.
+func TestDiagnostics_ReportsEmpty(t *testing.T) {
+	s := &server{aileronURL: "http://daemon", httpClient: &http.Client{}}
+	s.setDiscovery(discoveryDiagnostic{reason: reasonEmpty})
+	text := s.diagnostics().Content[0].Text
+	if !strings.Contains(text, "0 actions") {
+		t.Errorf("text = %q, want '0 actions'", text)
+	}
+	if !strings.Contains(text, "reachable and authorized") {
+		t.Errorf("text = %q, want note that daemon is reachable", text)
+	}
+}
+
+// TestDiagnostics_ReportsHealthy asserts a successful discovery reports a
+// healthy state with the action count.
+func TestDiagnostics_ReportsHealthy(t *testing.T) {
+	s := &server{aileronURL: "http://daemon", httpClient: &http.Client{}}
+	s.setDiscovery(discoveryDiagnostic{reason: reasonOK, count: 21})
+	text := s.diagnostics().Content[0].Text
+	if !strings.Contains(text, "healthy") || !strings.Contains(text, "21") {
+		t.Errorf("text = %q, want healthy + count", text)
+	}
+}
+
+// TestDiagnostics_NoURL asserts that without AILERON_URL the tool still
+// answers (it is only registered when URL is set, but the dispatch path
+// is defensive) and explains that no connector actions are expected.
+func TestDiagnostics_NoURL(t *testing.T) {
+	s := &server{httpClient: &http.Client{}}
+	text := s.diagnostics().Content[0].Text
+	if !strings.Contains(text, "AILERON_URL not set") {
+		t.Errorf("text = %q, want AILERON_URL note", text)
+	}
+}
+
+// TestRefreshOnce_RecordsDiagnosticOnFailure asserts a refresh failure
+// updates the cached diagnostic so a later aileron_diagnostics call
+// reflects the current (degraded) state, while leaving the tool surface
+// intact.
+func TestRefreshOnce_RecordsDiagnosticOnFailure(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, _ *http.Request) {
+		w.WriteHeader(http.StatusUnauthorized)
+	}))
+	defer srv.Close()
+
+	s := &server{aileronURL: srv.URL, httpClient: srv.Client()}
+	// Seed a healthy prior surface so we can confirm it survives.
+	s.setActions([]toolDef{{Name: "ship_update"}}, map[string]string{"ship_update": "ship-update"})
+	if s.refreshOnce(context.Background()) {
+		t.Error("refreshOnce reported a change on a failed discovery")
+	}
+	if d := s.discoveryState(); d.reason != reasonUnauthorized {
+		t.Fatalf("recorded reason = %v, want reasonUnauthorized", d.reason)
+	}
+	// Tool surface must be untouched.
+	s.actionsMu.RLock()
+	got := len(s.actionTools)
+	s.actionsMu.RUnlock()
+	if got != 1 {
+		t.Errorf("action surface mutated on failure: len = %d, want 1", got)
+	}
+}
+
+// TestDispatchTool_RoutesDiagnostics asserts the dispatcher routes the
+// synthetic tool name to the diagnostics handler.
+func TestDispatchTool_RoutesDiagnostics(t *testing.T) {
+	s := &server{aileronURL: "http://daemon", httpClient: &http.Client{}}
+	s.setDiscovery(discoveryDiagnostic{reason: reasonOK, count: 3})
+	res := s.dispatchTool(context.Background(), "aileron_diagnostics", nil)
+	if res.IsError {
+		t.Fatalf("unexpected error result: %+v", res)
+	}
+	if !strings.Contains(res.Content[0].Text, "healthy") {
+		t.Errorf("text = %q, want healthy report", res.Content[0].Text)
+	}
+}
+
+// TestDiagnostics_ReportsHTTPError asserts a non-401 daemon error surfaces
+// the daemon-error summary (including the status) so the operator can tell
+// it apart from unreachable / unauthorized.
+func TestDiagnostics_ReportsHTTPError(t *testing.T) {
+	s := &server{aileronURL: "http://daemon", httpClient: &http.Client{}}
+	s.setDiscovery(discoveryDiagnostic{reason: reasonHTTPError, err: errors.New("/v1/actions: 500 Internal Server Error")})
+	text := s.diagnostics().Content[0].Text
+	if !strings.Contains(text, "daemon error") || !strings.Contains(text, "500") {
+		t.Errorf("text = %q, want daemon error with status", text)
+	}
 }


### PR DESCRIPTION
## Summary

`aileron-mcp` silently degraded to the built-in tools whenever `/v1/actions` discovery failed, emitting a single generic `slog.Warn("action discovery failed; continuing without action tools")`. That warning could not distinguish the three failure modes (daemon unreachable, `401` stale token/session, daemon returned 0 actions), and from the agent's side you just saw "only the built-in tools" with no way to ask why. This fog made #1406 and the #1447 Windows/Codex debug harder than they should have been.

This change makes the failure both **distinguishable** and **answerable from the agent**:

- **Classified discovery outcomes.** `discoverActions` now wraps failures in a `*discoveryError` carrying a typed reason: `reasonUnreachable` (transport), `reasonUnauthorized` (401), `reasonHTTPError` (other non-200 / decode), with `reasonEmpty` (wire-OK but zero actions) and `reasonOK` derived at the caller.
- **Cached diagnostic.** The latest outcome is recorded on the server struct under `actionsMu` at both startup and every refresh tick, so the current degraded state is always readable.
- **Reason-tagged stderr.** The startup and refresh warnings now interpolate a reason summary ("daemon unreachable at `<url>`", "unauthorized (stale or missing AILERON_TOKEN / session)", "daemon error: …", "daemon at `<url>` returned 0 actions") instead of one generic line.
- **`aileron_diagnostics` synthetic tool.** Always present whenever `AILERON_URL` is set (mirroring the always-on `check_action_status` precedent). Its result reports whether discovery is healthy or degraded, the classified reason, and the remediation (run `aileron launch`, re-auth, install actions), so an agent can answer "why do I only see the built-in tools?" without an operator reading stderr.

The working tool surface is never overwritten on a failed refresh — the existing "must not corrupt the surface" contract is preserved; only the diagnostic is updated.

Scope is limited to `cmd/aileron-mcp`. No OpenAPI spec change (no daemon API surface touched).

## Test plan

- `go test ./...` in `cmd/aileron-mcp` — all green; package coverage 81.3%.
- New regression tests in `main_test.go`:
  - Each classified reason: unreachable (closed port), unauthorized (401), HTTP error (500), empty (zero actions → `reasonEmpty`), success (`reasonOK` + count).
  - Synthetic tool presence gated on `AILERON_URL` (present when set, absent otherwise) and dispatch routing.
  - `aileron_diagnostics` result text for each state (unreachable/unauthorized/empty/healthy/http-error/no-URL).
  - `refreshOnce` records the diagnostic on failure while leaving the tool surface intact.
- `go vet` clean; `gofmt` clean.
- CodeRabbit review (`coderabbit review --base main`): 0 findings.

Closes #1448

🤖 Generated with [Claude Code](https://claude.com/claude-code)
