### PR TITLE
docs(v4): rewrite acceptance runbook as a human checklist, fix stale CLI

### DIFF
--- a/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
+++ b/docs/src/content/docs/development/sandbox-mcp-walkthrough.md
@@ -13,9 +13,7 @@ The integration test at `internal/app/sandbox_mcp_test.go` (build tag `integrati
 - Docker installed and running.
 - A development build of the Aileron CLI and `aileron-mcp` siblings, both on `PATH`. `task build:cli && task build:mcp` produces them under `./build/`.
 - `jq` available on `PATH` (used by the audit-verification command below).
-- A Google OAuth client configured via `aileron binding setup gmail` (or any installed action you want to test).
-- The `aileron-connector-google` connector installed (`aileron connector install github://ALRubinger/aileron-connector-google`).
-- The `draft-email` action installed (`aileron action install github://ALRubinger/aileron-connector-google/actions/draft-email`).
+- The Google connector and its `draft-email` action installed, with a Google credential bound. The simplest path is the suite installer, which fetches the connector, installs its actions, and walks Google sign-in in one command: `aileron action add-suite github://ALRubinger/aileron-connector-google/suite.toml@latest`. (To install them individually instead: `aileron connector install github://ALRubinger/aileron-connector-google` then `aileron action add github://ALRubinger/aileron-connector-google/actions/draft-email`.)
 
 ## What to validate (agents and runtimes)
 
@@ -48,10 +46,10 @@ Pick the agent to validate. Every other step is identical.
 
 ```bash
 AGENT=claude   # one of: claude | pi | goose | opencode | codex
-aileron launch --sandbox=docker "$AGENT"
+aileron launch "$AGENT"
 ```
 
-The launcher will:
+`aileron launch` runs the agent in a Docker sandbox by default; no `--sandbox` flag is needed. The launcher will:
 
 1. Resolve the host-built `aileron-mcp` binary and bind-mount it read-only into the container at `/usr/local/bin/aileron-mcp`. The launcher skips this step when the resolved image already bakes `aileron-mcp` in. It detects a baked image by reading the `ai.aileron.mcp.version` label ([issue #957](https://github.com/ALRubinger/aileron/issues/957)). The published `ghcr.io/alrubinger/aileron-sandbox-base` image bakes the binary so sealed customer-operated runtimes launch without a host `aileron-mcp`. The local Tier 0 base build stays unbaked and keeps using this host-mount.
 2. Build the MCP environment (`AILERON_URL` rewritten to `host.docker.internal:<port>`, `AILERON_SESSION_ID`, `AILERON_TOKEN`).
@@ -83,22 +81,21 @@ The agent calls `mcp__aileron__draft_email`. The flow:
 6. `aileron-mcp`'s `check_action_status` polling surfaces the result back to the agent.
 7. The audit log records the chain `approval.requested → approval.approved → execution.started → execution.succeeded`, all stamped with the launch session id.
 
-Verify the audit chain:
+Verify the audit chain. List the recent entries (there is no session filter; audit is keyed by `audit_id`, so look at the recent window right after the run):
 
 ```bash
-aileron audit list --session "$(aileron sessions list --json | jq -r '.[0].id')"
+aileron audit list --limit 20
 ```
 
-Assert the four contractual events are present for the session in one shot:
+Assert the four contractual events are present in one shot. `audit list --json` returns `{"events":[...]}`, and each event carries an `event_type`:
 
 ```bash
-SESSION=$(aileron sessions list --json | jq -r '.[0].id')
-aileron audit list --session "$SESSION" --json \
-  | jq -r '[.[].type] | sort | unique' \
+aileron audit list --limit 20 --json \
+  | jq -r '[.events[].event_type] | sort | unique' \
   | jq -e 'index("approval.requested") and index("approval.approved")
            and index("execution.started") and index("execution.succeeded")' \
-  && echo "PASS: audit chain complete for $SESSION" \
-  || echo "FAIL: audit chain incomplete for $SESSION"
+  && echo "PASS: audit chain complete" \
+  || echo "FAIL: audit chain incomplete"
 ```
 
 Verify the draft landed in Gmail's draft folder. That is the upstream contract under test.
@@ -107,7 +104,7 @@ Verify the draft landed in Gmail's draft folder. That is the upstream contract u
 
 `aileron-mcp` discovers actions from the daemon's `/v1/actions` at startup, then keeps the agent's tool list current while the session runs. It advertises the MCP `tools.listChanged` capability during `initialize` and re-discovers actions on a background poll. When the action set changes, it swaps its cache and emits a `notifications/tools/list_changed` to the host, which re-pulls `tools/list`.
 
-This means an `aileron action install`, `aileron action enable`, `aileron action disable`, or `aileron action remove` in another terminal reaches the running agent within a poll cycle. Installing or enabling an action surfaces it; disabling or removing one drops it. No agent restart.
+This means an `aileron action add`, `aileron action enable`, or `aileron action disable` in another terminal reaches the running agent within a poll cycle. Adding or enabling an action surfaces it; disabling one drops it. No agent restart.
 
 The poll interval is `AILERON_MCP_REFRESH_INTERVAL` (a Go duration such as `5s`, or a bare integer interpreted as seconds). It defaults to `5s`. Set it to `0` to disable the poller and freeze the tool surface at the boot snapshot. The knob is only consulted when `AILERON_URL` is set.
 
@@ -157,7 +154,7 @@ To verify, add a user MCP server to your global Claude Code config (`~/.config/c
 Re-launch under sandbox:
 
 ```bash
-aileron launch --sandbox=docker claude
+aileron launch claude
 ```
 
 In Claude, `/mcp` should show BOTH `aileron` and `userthing`. Both work independently. The Aileron daemon never sees the `userthing` traffic.

--- a/docs/src/content/docs/development/v4-acceptance.md
+++ b/docs/src/content/docs/development/v4-acceptance.md
@@ -1,29 +1,33 @@
 ---
 title: "v4 Manual Acceptance Runbook"
-description: "The hands-on steps an operator runs to perform the manual half of v4 acceptance: build Aileron, launch an agent in a Docker sandbox, and verify the agent sees the aileron tool surface."
+description: "The hands-on steps a person runs to confirm Aileron's containerized runtime works end to end on macOS and Windows: launch an agent in the sandbox and watch it use a real Aileron tool."
 order: 11
 ---
 
-This page is the operator runbook for the manual half of v4 acceptance. It is the concrete, copy-pasteable sequence you run by hand to fill the macOS and Windows cells of the v4 matrix in [issue #747](https://github.com/ALRubinger/aileron/issues/747). The Linux column is automated in CI, so you never hand-run it (it is green when CI is green).
+This is the checklist a person runs by hand to confirm v4 works end to end. v4 ships Aileron as a containerized runtime: the AI agent runs inside a Docker sandbox, and Aileron mediates every real-world action it takes (approvals, credentials, audit) at the edge of that container.
 
-For the at-a-glance "is v4 done?" verdict and how each item maps to the #747 bar, jump to [Current status](#current-status) at the bottom. The rest of this page is the procedure.
+We prove this automatically on Linux in CI, so you never run the Linux column by hand. GitHub's macOS and Windows runners can't run Linux Docker containers, so a person has to confirm those two by hand. That's what this page is for.
 
-## The acceptance bar, in one sentence
+The full "is v4 done?" picture lives in [issue #747](https://github.com/ALRubinger/aileron/issues/747); you record the results of this runbook in [issue #962](https://github.com/ALRubinger/aileron/issues/962).
 
-For each agent on each operating system, the bar is: **the agent launches inside a Docker container and lists `aileron` with its `draft_email` tool**. That is the whole bar for a macOS or Windows cell. Every step below exists to get you to that check.
+## What you're checking, in one sentence
 
-A full action round-trip (through to a real Gmail draft, with the HITL approval and audit chain) is the optional gold-standard check on at least one agent per OS. It is covered in [Step 6](#step-6-optional-full-action-round-trip).
+For each agent on macOS and on Windows: **the agent launches inside the Docker sandbox and can see the `aileron` tool, including `draft_email`.**
+
+If it sees the tool, the whole runtime is wired: the container started, Aileron is reachable from inside it, and the agent's tool catalog is coming from Aileron. That single check is the bar for a cell.
+
+Once per operating system, on at least one agent, also run the optional full round-trip ([Step 6](#step-6-optional-prove-a-real-action-end-to-end)): ask the agent to draft an email, approve it, and confirm a real Gmail draft appears. That proves the action actually executes through to the real world, with a human approval in the middle.
 
 ## Before you start
 
 You need:
 
-- **Docker** installed and running. Docker Desktop on macOS and Windows both run the same Linux `sandbox-base` image (Windows via the WSL2 backend).
-- The **Go toolchain** and **[Task](https://taskfile.dev)** to build from source.
-- A clone of this repo, and `jq` on `PATH` (used by the optional audit check in Step 6).
-- For the optional full round-trip only: a Google OAuth client configured via `aileron binding setup gmail`. The light smoke does not need it.
+- **Docker** installed and running. Docker Desktop on both macOS and Windows runs the same Linux sandbox image (Windows uses its WSL2 backend), so the steps are identical on both.
+- A build of the `aileron` CLI on your `PATH` (see [Step 1](#step-1-build-and-install-aileron)).
+- A Google account, for the action the smoke uses.
+- `jq` on your `PATH`, only if you run the optional round-trip in Step 6.
 
-## Step 1: Build the binaries
+## Step 1: Build and install Aileron
 
 The sandbox launch needs two host binaries on `PATH`: the `aileron` CLI and its `aileron-mcp` sibling.
 
@@ -32,109 +36,104 @@ task build:cli && task build:mcp
 export PATH="$PWD/build:$PATH"
 ```
 
-`build:cli` produces `build/aileron`. `build:mcp` produces `build/aileron-mcp`, and on a macOS or Windows host it also cross-builds a `build/aileron-mcp-linux-<arch>` sibling, because the launcher bind-mounts a Linux `aileron-mcp` into the Linux container. Confirm both resolve:
+Confirm both resolve:
 
 ```bash
-aileron --version && aileron-mcp --version
+aileron version && aileron-mcp --version
 ```
 
-## Step 2: Install the action the smoke looks for
+## Step 2: Install the Gmail actions
 
-The smoke checks that the agent sees `draft_email`. That tool comes from the Google connector's draft-email action, so install both to put it in the catalog:
+The smoke looks for the `draft_email` tool. It comes from the Google connector's action suite, so install the suite. This one command fetches the connector, installs its actions, and walks you through Google sign-in:
 
 ```bash
-aileron connector install github://ALRubinger/aileron-connector-google
-aileron action install github://ALRubinger/aileron-connector-google/actions/draft-email
+aileron action add-suite github://ALRubinger/aileron-connector-google/suite.toml@latest
 ```
 
-Without an installed action, the `aileron` MCP server registers but exposes no tools, and the smoke has nothing to look for.
+On a fresh machine this prompts you to create a vault passphrase, trust the publisher, and sign in to Google once. The connector ships its own Google OAuth client, so there's no Google Cloud Console setup on your end. After it finishes, `aileron action list` shows `draft-email` among the installed actions.
 
-## Step 3: Check the container image before launching
+## Step 3: Launch an agent in the sandbox
 
-Validate that the sandbox image can run your chosen agent. This catches an image or arch problem before a daemon-backed launch starts:
+`aileron launch` runs the agent inside a Docker sandbox by default. Pick the agent you're checking and launch it:
 
 ```bash
 AGENT=claude   # one of: claude | pi | goose | opencode | codex
-aileron sandbox check --runtime=docker --agent="$AGENT"
+aileron launch "$AGENT"
 ```
 
-Expect `support: ok`, along with the selected tier, runtime, image, and command. A development build resolves the floating `edge` base image tag, and launch pulls it automatically. No separate image build is needed for the smoke.
+Aileron prepares and starts the container, wires the agent up to Aileron, and starts the agent. The first launch may prompt you to sign in to the agent (for example, Claude's Pro/Max login). That sign-in happens on your host terminal and browser, never inside the container, and it's reused on later launches.
 
-The working directory determines the resolved tier. A `.devcontainer/` in the directory you run from selects the devcontainer tier, which builds the project image from that authored config and can ignore `--agent`. If the project image was built without the requested agent's CLI, validate fails and now names the tier, the discovered `.devcontainer/devcontainer.json`, and the published per-agent image you could use instead. To pick the build-free published image, run from a directory without a `.devcontainer/`, or add the agent's Feature to the devcontainer.
+If a launch fails before the agent starts, run `aileron sandbox check --agent="$AGENT"` first; it validates the image can run the agent and explains what's wrong.
 
-## Step 4: Launch the agent inside the container
+## Step 4: Confirm the agent sees the `aileron` tool
 
-```bash
-aileron launch --sandbox=docker "$AGENT"
-```
+This is the check. How you list tools depends on the agent:
 
-The launcher resolves and pulls the base image, bind-mounts `aileron-mcp` into the container, rewrites `AILERON_URL` to `host.docker.internal:<port>`, registers `aileron-mcp` with the agent (the mechanism differs per agent, see the table in [Step 5](#step-5-verify-the-agent-sees-aileron--draft_email)), validates the container can run `aileron-mcp`, and starts the agent. If the agent has no vaulted credential, it runs its normal in-container login on first launch; see [Sandbox Agent Auth](/development/sandbox-agent-auth/) for seeding credentials ahead of time.
-
-### Cold first-launch acceptance (host-side acquirer)
-
-Run this variant on each OS with a host-login-capable agent (Claude or Codex) and an **empty vault** for that agent. Delete any existing entry first with `aileron vault delete agents/$AGENT/oauth`. Launch as above. The launcher detects the vault miss and runs the host-side acquirer before the container starts.
-
-- Claude opens its consent page in the host browser and prompts on the host terminal for the code the page renders. Paste the code at the host prompt.
-- Codex prints a verification URL and a one-time user code on the host terminal, opens the verification page in the host browser, and polls. Enter the code in the browser.
-
-The acceptance pass: the prompt and the browser open on the **host**, never inside the container TTY, and once the host login completes the container starts silent with no in-container login wizard. A subsequent launch also starts silent, proving the acquired credential was seeded to the vault.
-
-This is the manual Windows acceptance step for the no-container-TTY guarantee. The `cmd /c start "" <url>` browser invocation is unit-tested for argv shape on every platform, but a real Windows run is the only way to confirm the browser actually opens on the host and the paste lands on the host terminal rather than the container TTY. Record a pass or fail for this cell per OS. The Linux runner additionally exercises the silent-render launcher path in automated tests.
-
-## Step 5: Verify the agent sees `aileron` + `draft_email`
-
-This is the acceptance check. How you list tools depends on the agent:
-
-| Agent | How to verify |
+| Agent | How to check |
 |---|---|
 | Claude | Type `/mcp`. Expect one server named `aileron`. Look for `draft_email`. |
-| Codex | Type `/mcp`. Same expectation as Claude. |
-| Pi | Ask the agent to list its available tools, or make a draft request and confirm it invokes the Aileron tool. |
+| Codex | Type `/mcp`. Same as Claude. |
+| Pi | Ask the agent to list its available tools, or just make a draft request (Step 6) and confirm it uses the Aileron tool. |
 | Goose | Same as Pi. |
 | OpenCode | Same as Pi. |
 
-The runtime-agnostic proof, valid for every agent, is in the session log: `.aileron/session.log` under the launch directory records `aileron-mcp`'s discovery call against the daemon. If the agent lists `aileron` with `draft_email` (or the session log shows the successful discovery call), **that cell passes**. Exit the agent.
+If the agent lists `aileron` with `draft_email`, **this cell passes.** Exit the agent.
 
-Codex is the highest-risk cell on any OS, because it is the only agent whose MCP registration is a bind-mounted `config.toml` rather than a CLI flag or workspace file. Validate it deliberately.
+Pay special attention to **Codex**: it's the one agent wired up differently from the others, so it's the most likely to surprise you. Check it deliberately on each operating system.
 
-## Step 6 (optional): full action round-trip
+## Step 5: Record the result
 
-For the gold-standard check on at least one agent per OS, run an action end to end: ask the agent to draft an email, approve the HITL request, and confirm the `approval.requested → approval.approved → execution.started → execution.succeeded` audit chain plus the real Gmail draft. The full sequence, the exact prompt, and the `jq` audit assertion are in the [Sandbox MCP Manual Verification Walkthrough](/development/sandbox-mcp-walkthrough/#run). That page also has the [troubleshooting](/development/sandbox-mcp-walkthrough/#troubleshooting) for the common failures (tools missing from a cross-arch host, `host.docker.internal` not resolving on Linux, baked-image version skew).
+Record each agent you checked, per operating system, in [issue #962](https://github.com/ALRubinger/aileron/issues/962) (edit the issue body, don't add a comment). Note your OS, architecture, Docker version, the `aileron version` output, and the agent's version. If anything didn't match these steps, write down what happened.
 
-## Step 7: Record the result
+The matrix you're filling:
 
-Record each agent × OS cell you ran in [issue #962](https://github.com/ALRubinger/aileron/issues/962), in the issue body rather than a comment, so the matrix always reflects current state. Note the environment for each cell: OS, arch, Docker version, Aileron CLI commit, agent version, and any deviation. If you also ran the optional round-trip, note that the audit assertion printed `PASS` and the draft landed in Gmail.
-
-### The matrix you are filling
-
-The v4 bar requires every supported agent on Docker across all three operating systems. You hand-run only the macOS and Windows columns:
-
-| Agent ↓ / Runtime → | macOS Docker (manual smoke) | Linux Docker (CI) | Windows Docker (manual smoke) |
+| Agent ↓ / OS → | macOS (by hand) | Linux (automatic, CI) | Windows (by hand) |
 |---|---|---|---|
-| Claude | ☐ | automated | ☐ |
-| Pi | ☐ | automated | ☐ |
-| Goose | ☐ | automated | ☐ |
-| OpenCode | ☐ | automated | ☐ |
-| Codex | ☐ | automated | ☐ |
+| Claude | ☐ | ✅ CI | ☐ |
+| Pi | ☐ | ✅ CI | ☐ |
+| Goose | ☐ | ✅ CI | ☐ |
+| OpenCode | ☐ | ✅ CI | ☐ |
+| Codex | ☐ | ✅ CI | ☐ |
 
-The Linux cells are covered by `TestSandboxMCPRegistration_Matrix` (unit suite) and `TestSandboxMCP` (integration job, build tag `integration_sandbox`), merged in PR [#1064](https://github.com/ALRubinger/aileron/pull/1064). They are green when CI is green.
+The Linux column is green whenever CI is green; you never fill it by hand.
+
+## Step 6 (optional): prove a real action end to end
+
+Do this once per operating system, on at least one agent. It proves an action runs all the way through to the real world with a human approval in the middle.
+
+1. With the agent running, ask it to draft an email:
+
+   > Draft an email to alice@example.com saying I'm running late
+
+2. The agent calls `draft_email`. Because drafting is a real-world write, Aileron pauses and surfaces an approval. Approve it, either in the webapp link the agent shows you, or in another terminal:
+
+   ```bash
+   aileron approval approve <id>
+   ```
+
+3. Confirm a draft actually landed in your Gmail Drafts folder.
+
+4. (Optional) Confirm Aileron recorded the trail. List the recent audit entries and check you see the approval and the execution for the draft:
+
+   ```bash
+   aileron audit list --limit 10
+   ```
+
+   You should see the request being approved and then the action executing successfully.
+
+If the draft appears in Gmail and the audit log shows the approval and execution, the round-trip passes for that operating system.
 
 ## Current status
 
-**v4 is NOT yet delivered.** Everything in the v4 bar is shipped except two gating items in the "Verify and prove" section of [#747](https://github.com/ALRubinger/aileron/issues/747):
+**v4 is not yet fully delivered.** Everything in the v4 bar is built and the Linux column is automated and green. What remains is the hands-on confirmation on macOS and Windows (this runbook) plus the demo recording, both tracked under [#747](https://github.com/ALRubinger/aileron/issues/747):
 
-| Gating item | Status | Notes |
-|---|---|---|
-| Integration test variants — in-container, never-approved, concurrency ([#960](https://github.com/ALRubinger/aileron/issues/960)) | ✅ | Merged via PR [#1037](https://github.com/ALRubinger/aileron/pull/1037). |
-| Manual E2E ([#962](https://github.com/ALRubinger/aileron/issues/962)) | ☐ | Linux automated and green for all five agents. macOS and Windows light per-agent smoke pending (this runbook). Claude × macOS full round-trip done 2026-06-15. |
-| Demo script + recorded walkthrough ([#852](https://github.com/ALRubinger/aileron/issues/852)) | ☐ | Pending. |
+| Remaining item | Status |
+|---|---|
+| macOS + Windows manual smoke, per agent ([#962](https://github.com/ALRubinger/aileron/issues/962)) | In progress. Claude on macOS has a full round-trip done; the rest are pending. |
+| Demo script + recorded walkthrough ([#852](https://github.com/ALRubinger/aileron/issues/852)) | Pending. |
 
-Not gating v4 closure: the agent-auth v4.x deferral ([#1027](https://github.com/ALRubinger/aileron/issues/1027), closed; its container integration test [#1025](https://github.com/ALRubinger/aileron/issues/1025) landed, and [#987](https://github.com/ALRubinger/aileron/issues/987) moved to v5 [#1065](https://github.com/ALRubinger/aileron/issues/1065)) and platform packaging ([#1094](https://github.com/ALRubinger/aileron/issues/1094)).
+## Related pages
 
-## Sources
-
-- [Issue #747](https://github.com/ALRubinger/aileron/issues/747) — the v4 milestone, its "Verify and prove" bar, and the 2026-06-15 scope note.
-- [Issue #962](https://github.com/ALRubinger/aileron/issues/962) — where you record the macOS and Windows manual-smoke results.
-- [Sandbox MCP Manual Verification Walkthrough](/development/sandbox-mcp-walkthrough/) — the optional full round-trip steps, the per-agent registration detail, and troubleshooting.
-- [Sandbox Agent Auth](/development/sandbox-agent-auth/) — seeding vault-backed agent credentials before launch.
-- [Sandbox Composition](/development/sandbox-composition/) — `aileron sandbox` plan, build, and check; how the base image tag resolves.
+- [Sandbox MCP — Manual Verification Walkthrough](/development/sandbox-mcp-walkthrough/) — the detailed round-trip, per-agent registration detail, and troubleshooting.
+- [Sandbox Agent Auth](/development/sandbox-agent-auth/) — signing an agent in ahead of time.
+- [Sandbox Composition](/development/sandbox-composition/) — how `aileron sandbox` builds and checks the image.


### PR DESCRIPTION
## Summary

Realigns the v4 manual-acceptance docs with the **current** `aileron` CLI surface and reshapes the runbook into a simple list a person follows by hand. Companion to the rewrite of [issue #962](https://github.com/ALRubinger/aileron/issues/962), which is now the human checklist for confirming v4 is shipped end to end.

The CLI moved on since these docs were written, so several commands were stale:

- `aileron launch <agent>` now runs the Docker sandbox **by default** — the old `aileron launch --sandbox=docker <agent>` flag is no longer needed.
- Setup is `aileron action add-suite github://ALRubinger/aileron-connector-google/suite.toml@latest` (installs the connector, its actions, and walks Google sign-in in one command). There is no `aileron binding setup gmail`.
- `aileron audit list` has **no `--session` flag**; its JSON shape is `{"events":[{"event_type":...}]}`. The old assertion filtered on a non-existent flag and the wrong field path.
- `aileron action install` / `aileron action remove` are not real verbs; the surface is `add` / `add-suite` / `disable`.
- `aileron version` (not `aileron --version`).

### `docs/.../development/v4-acceptance.md` (the runbook)
Rewritten to lead with *what we're doing and why* in plain terms, with simplified human instructions and no ADR/PR/impl detail. The optional round-trip's jq audit assertion is replaced with a plain `aileron audit list --limit 10` eyeball check.

### `docs/.../development/sandbox-mcp-walkthrough.md` (the detailed companion)
Targeted fixes for the same stale commands. The detailed audit assertion is kept but corrected to assert over a recent `--limit` window against the real `events[].event_type` shape.

## Test plan

- [x] Every command in both docs verified against the reconciled CLI reference and the cobra command definitions in `cmd/aileron/` (launch defaults, action verbs, audit flags + JSON shape in `cmd/aileron/main.go`).
- [x] Grep sweep confirms no `--sandbox=docker`, `audit list --session`, `action install/remove`, `binding setup gmail`, or `aileron --version` remain in either doc.
- Docs-only change; no code paths touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
