### PR TITLE
fix(sandbox): relabel workspace bind mount for SELinux enforcing hosts

### DIFF
--- a/internal/sandbox/composition/validatehint.go
+++ b/internal/sandbox/composition/validatehint.go
@@ -12,6 +12,14 @@ import (
 // detect the CWD-determined-tier mismatch and enrich the error.
 const agentNotFoundMarker = "agent command not found in sandbox image:"
 
+// workspaceNotWritableMarker is the substring the in-container validation script
+// emits when the writability probe fails (see runtime.go validationScript, the
+// exit-3 branch). The bare runtime failure surfaces as an opaque "exit status
+// 3"; EnrichValidateError matches this marker to explain the most common cause
+// (SELinux denying the confined container process access to the host-labeled
+// workspace bind mount) and the remedy.
+const workspaceNotWritableMarker = "sandbox workspace is not writable at"
+
 // EnrichValidateError augments a sandbox-image validate failure with tier, CWD,
 // and published-image context when the failure is the CWD-determined-tier
 // mismatch: a hand-authored .devcontainer/ in workDir selected the devcontainer
@@ -26,6 +34,13 @@ const agentNotFoundMarker = "agent command not found in sandbox image:"
 func EnrichValidateError(err error, tier Tier, agent, version, workDir string) error {
 	if err == nil {
 		return nil
+	}
+	// The writability failure is tier-independent: any sandbox tier bind-mounts
+	// the operator's workspace, and SELinux on the host denies the confined
+	// container process access to it regardless of which image was selected.
+	// Match and enrich before the devcontainer-specific branch below.
+	if strings.Contains(err.Error(), workspaceNotWritableMarker) {
+		return enrichWorkspaceNotWritable(err, workDir)
 	}
 	if tier != TierDevcontainer {
 		return err
@@ -53,4 +68,29 @@ func EnrichValidateError(err error, tier Tier, agent, version, workDir string) e
 		"A published per-agent image %s exists as an alternative: "+
 		"launch from a directory without a .devcontainer/, or add the %q agent Feature to %s.",
 		err, TierDevcontainer, devcontainerPath, wd, agent, publishedImage, agent, devcontainerPath)
+}
+
+// enrichWorkspaceNotWritable augments the opaque workspace-writability failure
+// with the SELinux root cause and remediation. The bare runtime surface is an
+// uninformative "exit status 3"; on a Linux host with SELinux enforcing, the
+// confined container process (the image's non-root agent user) is denied access
+// to the host-labeled workspace bind mount. Aileron now applies a `:z` relabel
+// to the mount automatically, so this message also points operators at the
+// manual fallback for hosts where the automatic relabel cannot take effect.
+func enrichWorkspaceNotWritable(err error, workDir string) error {
+	wd := workDir
+	if wd == "" {
+		wd = "."
+	}
+	return fmt.Errorf("%w\n"+
+		"the sandbox container could not write to the mounted workspace %s. "+
+		"On a Linux host with SELinux in enforcing mode, the host directory's "+
+		"SELinux label denies the container's non-root agent user access to the "+
+		"bind mount. Aileron applies a shared SELinux relabel (the `:z` mount "+
+		"option) automatically when it detects SELinux enforcing; if the failure "+
+		"persists, relabel the directory manually with "+
+		"`chcon -Rt svirt_sandbox_file_t %s` (or run the host with SELinux "+
+		"permissive). On non-SELinux hosts, check that the workspace directory is "+
+		"writable by the container's agent user.",
+		err, wd, wd)
 }

--- a/internal/sandbox/composition/validatehint_test.go
+++ b/internal/sandbox/composition/validatehint_test.go
@@ -74,10 +74,52 @@ func TestEnrichValidateErrorUnpublishedAgentUnchanged(t *testing.T) {
 }
 
 func TestEnrichValidateErrorUnrelatedFailureUnchanged(t *testing.T) {
-	base := errors.New("validate sandbox image: sandbox workspace is not writable at /workspace")
+	base := errors.New("validate sandbox image: image must support /bin/sh command execution")
 	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "/home/dev/project")
 	if got != base {
 		t.Errorf("unrelated failure: error was enriched, want unchanged: %s", got.Error())
+	}
+}
+
+// TestEnrichValidateErrorWorkspaceNotWritable verifies the opaque writability
+// failure (which surfaces to the operator as a bare "exit status 3") is enriched
+// with the SELinux root cause, the automatic-relabel note, and the manual
+// fallback. This fails before the fix (the raw error explains none of those) and
+// passes after.
+func TestEnrichValidateErrorWorkspaceNotWritable(t *testing.T) {
+	const workDir = "/home/dev/project"
+	base := errors.New("validate sandbox image img: sandbox workspace is not writable at /home/agent/workspace: exit status 3")
+	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir)
+	msg := got.Error()
+
+	for _, want := range []string{
+		"SELinux",       // names the root cause
+		"enforcing",     // names the enforcing-mode condition
+		"automatically", // states Aileron applies the relabel itself
+		"`:z`",          // names the relabel mount option
+		"chcon",         // gives the manual fallback command
+		workDir,         // names the operator's workspace
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("enriched writability error missing %q: %s", want, msg)
+		}
+	}
+	// The original error must remain wrapped so callers' %w chains still match.
+	if !errors.Is(got, base) {
+		t.Errorf("enriched error does not wrap the original validate error")
+	}
+}
+
+// TestEnrichValidateErrorWorkspaceNotWritableAllTiers verifies the writability
+// enrichment is tier-independent: every sandbox tier bind-mounts the workspace,
+// so the SELinux denial can occur regardless of which image was selected.
+func TestEnrichValidateErrorWorkspaceNotWritableAllTiers(t *testing.T) {
+	base := errors.New("validate sandbox image img: sandbox workspace is not writable at /home/agent/workspace: exit status 3")
+	for _, tier := range []Tier{TierBase, TierPublished, TierBYOImage, TierDevcontainer} {
+		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project")
+		if !strings.Contains(got.Error(), "SELinux") {
+			t.Errorf("tier %q: writability error was not enriched: %s", tier, got.Error())
+		}
 	}
 }
 

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -27,6 +27,22 @@ import (
 // test runner's OS.
 var hostOS = func() string { return goruntime.GOOS }
 
+// selinuxEnforcing reports whether the host is running SELinux in
+// enforcing mode. It is a package-level indirection (mirroring the hostOS
+// seam) so the SELinux-relabel argv branch stays unit-testable without
+// depending on the test runner's host. The kernel exposes the current
+// mode at /sys/fs/selinux/enforce: the file holds "1" when enforcing and
+// "0" when permissive, and is absent when SELinux is disabled or the host
+// is not Linux. Any read error (absent file, non-Linux host) means "not
+// enforcing", so the relabel suffix is only ever added where it is needed.
+var selinuxEnforcing = func() bool {
+	data, err := os.ReadFile("/sys/fs/selinux/enforce")
+	if err != nil {
+		return false
+	}
+	return strings.TrimSpace(string(data)) == "1"
+}
+
 const DefaultRuntime = "auto"
 const WorkspacePath = "/home/agent/workspace"
 const AgentImagesDocsURL = "https://docs.withaileron.ai/development/sandbox-agent-images/"
@@ -773,9 +789,25 @@ func runArgs(runtimeName string, opts RunOptions) ([]string, error) {
 	if runtimeName == "docker" && hostOS() == "linux" {
 		args = append(args, "--add-host", "host.docker.internal:host-gateway")
 	}
+	// On a Linux host running SELinux in enforcing mode, a host bind mount keeps
+	// the host's SELinux label, so the container's confined process (the image's
+	// non-root agent user) is denied access to it. Docker's `:z` mount option
+	// asks the runtime to relabel the mount with a shared (svirt_sandbox_file_t)
+	// label so the container can read and write it. We use `:z` rather than `:Z`
+	// (private) because the workspace mount is the operator's real project CWD
+	// that the host must keep accessing; a private relabel would lock the host
+	// out. The suffix is only emitted on Linux Docker under SELinux enforcing,
+	// where it is required; elsewhere it is omitted (it would be rejected or be a
+	// no-op). Named volumes are managed by the runtime and already carry a
+	// container-accessible label, so they are not relabeled.
+	relabel := runtimeName == "docker" && hostOS() == "linux" && selinuxEnforcing()
+	workspaceSpec := absWorkDir + ":" + WorkspacePath
+	if relabel {
+		workspaceSpec += ":z"
+	}
 	args = append(args,
 		"--workdir", WorkspacePath,
-		"--volume", absWorkDir+":"+WorkspacePath,
+		"--volume", workspaceSpec,
 	)
 	for _, volume := range opts.Volumes {
 		if strings.TrimSpace(volume.Source) == "" || strings.TrimSpace(volume.Target) == "" {
@@ -792,9 +824,22 @@ func runArgs(runtimeName string, opts RunOptions) ([]string, error) {
 			}
 			source = abs
 		}
-		spec := source + ":" + volume.Target
+		// Mount options go in the third `:`-delimited field as a comma-separated
+		// list (e.g. `ro,z`). Emitting them as separate `:`-delimited fields
+		// (`ro:z`) would make Docker read a fourth field and reject the spec, so
+		// ro and the SELinux relabel must be joined here. Host bind mounts need
+		// the same relabel as the workspace mount; named volumes are
+		// runtime-managed and already container-accessible.
+		var mountOpts []string
 		if volume.ReadOnly {
-			spec += ":ro"
+			mountOpts = append(mountOpts, "ro")
+		}
+		if relabel && !volume.Named {
+			mountOpts = append(mountOpts, "z")
+		}
+		spec := source + ":" + volume.Target
+		if len(mountOpts) > 0 {
+			spec += ":" + strings.Join(mountOpts, ",")
 		}
 		args = append(args, "--volume", spec)
 	}

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -1507,6 +1507,123 @@ func TestRunArgs_LinuxNonDockerOmitsHostGateway(t *testing.T) {
 	}
 }
 
+// --- runArgs SELinux :z workspace relabel (#1458) ---
+
+// pinSELinux overrides the package-level hostOS and selinuxEnforcing seams so
+// the relabel argv branch can be exercised on any test runner.
+func pinSELinux(t *testing.T, os string, enforcing bool) {
+	t.Helper()
+	origOS := hostOS
+	origSE := selinuxEnforcing
+	hostOS = func() string { return os }
+	selinuxEnforcing = func() bool { return enforcing }
+	t.Cleanup(func() {
+		hostOS = origOS
+		selinuxEnforcing = origSE
+	})
+}
+
+// workspaceMountSpec returns the value following the first "--volume" flag,
+// which runArgs always emits as the workspace bind mount.
+func workspaceMountSpec(t *testing.T, args []string) string {
+	t.Helper()
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--volume" {
+			return args[i+1]
+		}
+	}
+	t.Fatalf("no --volume found in args: %v", args)
+	return ""
+}
+
+func TestRunArgs_LinuxSELinuxEnforcingRelabelsWorkspace(t *testing.T) {
+	pinSELinux(t, "linux", true)
+	opts := runOptsForGateway(t)
+	args, err := runArgs("docker", opts)
+	if err != nil {
+		t.Fatalf("runArgs: %v", err)
+	}
+	spec := workspaceMountSpec(t, args)
+	if !strings.HasSuffix(spec, ":"+WorkspacePath+":z") {
+		t.Errorf("workspace mount %q missing :z relabel suffix under SELinux enforcing", spec)
+	}
+}
+
+func TestRunArgs_LinuxSELinuxEnforcingRelabelsHostVolumes(t *testing.T) {
+	pinSELinux(t, "linux", true)
+	dir := t.TempDir()
+	extra := filepath.Join(dir, "actions")
+	if err := os.MkdirAll(extra, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	args, err := runArgs("docker", RunOptions{
+		Image:   "img",
+		WorkDir: dir,
+		Command: []string{"sh"},
+		Volumes: []Volume{
+			{Source: extra, Target: "/opt/aileron/manifests/actions", ReadOnly: true},
+			{Source: "aileron-cache-npm", Target: "/home/agent/.npm", Named: true},
+		},
+	})
+	if err != nil {
+		t.Fatalf("runArgs: %v", err)
+	}
+	absExtra, _ := filepath.Abs(extra)
+	joined := strings.Join(args, " ")
+	// A read-only host bind mount keeps ro and gains z, joined as a single
+	// comma-separated options field (Docker rejects ro:z as a fourth field).
+	if !strings.Contains(joined, "--volume "+absExtra+":/opt/aileron/manifests/actions:ro,z") {
+		t.Errorf("host bind mount missing ro,z options under SELinux enforcing; got %v", args)
+	}
+	// A named volume is runtime-managed and must NOT be relabeled.
+	for i := 0; i < len(args)-1; i++ {
+		if args[i] == "--volume" && strings.HasPrefix(args[i+1], "aileron-cache-npm:") {
+			if strings.HasSuffix(args[i+1], ":z") {
+				t.Errorf("named volume must not be relabeled; got %q", args[i+1])
+			}
+		}
+	}
+}
+
+func TestRunArgs_DarwinOmitsRelabel(t *testing.T) {
+	pinSELinux(t, "darwin", true) // enforcing forced true, but non-Linux must skip
+	opts := runOptsForGateway(t)
+	args, err := runArgs("docker", opts)
+	if err != nil {
+		t.Fatalf("runArgs: %v", err)
+	}
+	spec := workspaceMountSpec(t, args)
+	if strings.HasSuffix(spec, ":z") {
+		t.Errorf("workspace mount %q must not be relabeled on darwin", spec)
+	}
+}
+
+func TestRunArgs_LinuxNonEnforcingOmitsRelabel(t *testing.T) {
+	pinSELinux(t, "linux", false)
+	opts := runOptsForGateway(t)
+	args, err := runArgs("docker", opts)
+	if err != nil {
+		t.Fatalf("runArgs: %v", err)
+	}
+	spec := workspaceMountSpec(t, args)
+	if strings.HasSuffix(spec, ":z") {
+		t.Errorf("workspace mount %q must not be relabeled when SELinux is not enforcing", spec)
+	}
+}
+
+func TestRunArgs_LinuxNonDockerOmitsRelabel(t *testing.T) {
+	pinSELinux(t, "linux", true)
+	opts := runOptsForGateway(t)
+	args, err := runArgs("nondocker", opts)
+	if err != nil {
+		t.Fatalf("runArgs: %v", err)
+	}
+	spec := workspaceMountSpec(t, args)
+	if strings.HasSuffix(spec, ":z") {
+		t.Errorf("workspace mount %q must not be relabeled on a non-docker runtime", spec)
+	}
+}
+
 // --- BakedMCPVersion image-label detection (U3 / #957) ---
 
 func TestBakedMCPVersion(t *testing.T) {


### PR DESCRIPTION
## Summary

On a Linux host running SELinux in enforcing mode (e.g. Fedora 44), `aileron launch` fails with an opaque `exit status 3`. The launch-time validation container runs as the image's non-root `agent` user, and SELinux denies that confined process write access to the host-labeled workspace bind mount, so the in-container writability probe (`validationScript`, exit 3) fails. Nothing in the surfaced error explained the cause.

This PR makes the workspace writable on SELinux hosts and replaces the opaque failure with remediation guidance.

- **`internal/sandbox/container/runtime.go`**
  - New `selinuxEnforcing` package var (mirrors the existing `hostOS` seam) that reads `/sys/fs/selinux/enforce`; any read error (absent file, non-Linux host) means "not enforcing", so the relabel is only ever applied where needed.
  - `runArgs` adds Docker's `:z` (shared) relabel option to the workspace bind mount and to additional host bind mounts when running Docker on Linux with SELinux enforcing. `:z` is chosen over `:Z` (private) because the mount is the operator's real project CWD that the host must keep accessing. Named volumes are runtime-managed and are not relabeled.
  - Read-only host mounts now join `ro` and `z` into a single comma-separated options field (`ro,z`); emitting them as separate `:`-delimited fields would make Docker read a fourth field and reject the spec.
- **`internal/sandbox/composition/validatehint.go`**
  - `EnrichValidateError` now matches the writability marker (tier-independent, since every tier bind-mounts the workspace) and enriches the error with the SELinux root cause, the note that Aileron applies the relabel automatically, and a manual `chcon -Rt svirt_sandbox_file_t` fallback for hosts where the automatic relabel cannot take effect.

The relabel (not `chown`) is the correct remedy here because the workspace is the operator's own directory; the existing `chown` hooks (`agent_uid.go`) apply to Aileron-injected dirs the operator does not own.

No OpenAPI/spec or generated-code impact. No backwards-compat shims.

## Test plan

- `go build ./...` (internal + cmd/aileron modules): green.
- `go test ./...` (internal module) and `go test ./...` (cmd/aileron): green.
- `go vet ./sandbox/...`: clean. `gofmt -l`: clean.
- New `runArgs` regression tests: `:z` present on the workspace mount under mocked Linux + enforcing; absent on darwin (even with enforcing forced true), on non-enforcing Linux, and on a non-docker runtime; host bind mounts gain `ro,z`; named volumes are not relabeled.
- New `EnrichValidateError` test asserting the enriched writability text names the SELinux cause, the automatic relabel, the `:z` option, the `chcon` fallback, and the workspace path; plus an all-tiers test.
- Verified the runArgs regression test fails before the fix (relabel forced off → `missing :z relabel suffix`) and passes after.
- CodeRabbit review of the diff: 0 findings.

Closes #1458

🤖 Generated with [Claude Code](https://claude.com/claude-code)
