### PR TITLE
fix(sandbox): remap agent uid to workspace owner so Linux+Docker launches are writable

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -682,6 +682,20 @@ jobs:
         env:
           AILERON_SANDBOX_BASE_CONTEXT: ${{ github.workspace }}/images/sandbox-base
 
+      - name: Run workspace uid-remap integration test (#1461)
+        # The ubuntu runner has rootful Docker, where the host operator's UID
+        # owns the workspace bind mount but the container runs as the image's
+        # non-root agent user — the exact DAC mismatch that blocks the
+        # writability probe (exit 3) and that the aileron-remap-agent-uid
+        # entrypoint fixes by remapping the agent uid to the workspace owner.
+        # The test self-skips on non-Linux / no-Docker hosts, so this is the
+        # acceptance environment. Additive step so a failure is attributable to
+        # this specific contract.
+        run: go test -tags=integration_sandbox -run TestWorkspaceUIDRemap ./launch/...
+        working-directory: internal
+        env:
+          AILERON_SANDBOX_BASE_CONTEXT: ${{ github.workspace }}/images/sandbox-base
+
       - name: Run in-container credential read + capture round-trip test (#1025)
         # Closes the ADR-0025 verification gap that was previously covered only
         # by a manual smoke-check: renders a Claude-shaped AuthSpec, launches a

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -691,7 +691,7 @@ jobs:
         # The test self-skips on non-Linux / no-Docker hosts, so this is the
         # acceptance environment. Additive step so a failure is attributable to
         # this specific contract.
-        run: go test -tags=integration_sandbox -run TestWorkspaceUIDRemap ./launch/...
+        run: go test -v -tags=integration_sandbox -run TestWorkspaceUIDRemap ./launch/...
         working-directory: internal
         env:
           AILERON_SANDBOX_BASE_CONTEXT: ${{ github.workspace }}/images/sandbox-base

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -391,7 +391,7 @@ tasks:
     desc: "Run the workspace uid-remap integration test on a Linux Docker host (#1461): proves the agent uid mismatch blocks the writability probe and that the aileron-remap-agent-uid entrypoint fixes it; self-skips on non-Linux or when no Docker runtime is on PATH"
     dir: internal
     cmds:
-      - go test -tags=integration_sandbox -run TestWorkspaceUIDRemap ./launch/...
+      - go test -v -tags=integration_sandbox -run TestWorkspaceUIDRemap ./launch/...
     env:
       AILERON_SANDBOX_BASE_CONTEXT:
         sh: cd "{{.ROOT_DIR}}/images/sandbox-base" && pwd

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -387,6 +387,15 @@ tasks:
       AILERON_SANDBOX_BASE_CONTEXT:
         sh: cd "{{.ROOT_DIR}}/images/sandbox-base" && pwd
 
+  test:integration:workspace-uid-remap:
+    desc: "Run the workspace uid-remap integration test on a Linux Docker host (#1461): proves the agent uid mismatch blocks the writability probe and that the aileron-remap-agent-uid entrypoint fixes it; self-skips on non-Linux or when no Docker runtime is on PATH"
+    dir: internal
+    cmds:
+      - go test -tags=integration_sandbox -run TestWorkspaceUIDRemap ./launch/...
+    env:
+      AILERON_SANDBOX_BASE_CONTEXT:
+        sh: cd "{{.ROOT_DIR}}/images/sandbox-base" && pwd
+
   test:integration:authspec-container-read:
     desc: "Run the in-container credential read + capture round-trip integration test (#1025): renders a Claude-shaped AuthSpec, launches a real container, asserts the agent reads the credential at ContainerPath and that an in-container rotation round-trips to the vault on clean exit. Fail-fast — requires Docker (no self-skip)."
     dir: internal

--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -317,7 +317,7 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 	// aileron-mcp mounted under sandbox check, so requiring it would fail.
 	bakedVersion := sandboxCheckBakedVersionFn(context.Background(), resolvedRuntime, result.Image)
 	if err := sandboxCheckValidateFn(context.Background(), resolvedRuntime, cwd, result.Image, command, bakedVersion != ""); err != nil {
-		err = sandboxcomposition.EnrichValidateError(err, result.Tier, command, version.Version, cwd)
+		err = sandboxcomposition.EnrichValidateError(err, result.Tier, command, version.Version, cwd, sandboxcontainer.WorkspaceRelabelActive(resolvedRuntime))
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}
@@ -370,6 +370,7 @@ var sandboxCheckValidateFn = func(ctx context.Context, runtimeName, workDir, ima
 		Command:           []string{command},
 		RequireProxyTrust: sandboxCheckRequiresProxyTrust(runtimeName),
 		RequireMCPBinary:  requireMCPBinary,
+		RemapWorkspaceUID: sandboxcontainer.WorkspaceUIDRemapActive(runtimeName),
 	})
 }
 

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -197,7 +197,7 @@ A third operational requirement therefore applies to BYO images that run as a no
 
 3. The `aileron-remap-agent-uid` helper must be on `PATH` and the image must let it run as root at startup before dropping to the agent user. The helper needs `usermod`/`groupmod` (the `shadow` package on Alpine, `passwd`/`shadow-utils` on Debian/RHEL) and a `stat` that supports `-c` (GNU coreutils). The canonical implementation ships with the sandbox-base image.
 
-> This addresses [SELinux relabeling](#byo-image-proxy-contract) for a different failure: the `:z` relabel handles SELinux MAC denials on enforcing hosts, while the uid remap handles the DAC permission mismatch that occurs on every Linux + Docker host regardless of SELinux. Both can apply on the same host.
+> This addresses a different failure than SELinux relabeling: the `:z` relabel handles SELinux MAC denials on enforcing hosts, while the uid remap handles the DAC permission mismatch that occurs on every Linux + Docker host regardless of SELinux. Both can apply on the same host.
 
 ## Current Limits
 

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -142,6 +142,8 @@ A BYO image must provide:
 - a writable `/home/agent/workspace` bind mount when launched by Docker
 - the requested agent command on `PATH`
 
+On Linux + Docker the launcher additionally routes the container through the `aileron-remap-agent-uid` entrypoint (see the proxy contract below). A BYO image that runs as a non-root user must ship that helper so the workspace bind mount is writable by the agent. See [Workspace ownership on Linux](#workspace-ownership-on-linux).
+
 Validate a BYO image by setting `customizations.aileron.image` in `.devcontainer/devcontainer.json` and running:
 
 ```bash
@@ -160,6 +162,7 @@ A BYO image meets the proxy contract by providing two helpers on `PATH`:
 |---|---|
 | `aileron-install-proxy-ca` | Installs the mounted CA into the in-container trust store. Must accept `--check` to dry-run the trust-store probe without writing anything, and must accept an optional positional CA file argument (default `${AILERON_SANDBOX_PROXY_CA_FILE:-/etc/aileron/proxy/ca.pem}`). Exits 0 on success, 2 when the CA file is missing or empty, 126 when invoked unprivileged for an install, 127 when the underlying trust-store tooling is missing. |
 | `aileron-run-with-proxy-ca` | Entrypoint wrapper that installs the CA as root, then drops privileges to the `agent` user and executes the requested agent command. The launcher always starts the container through this wrapper when the proxy is in force. |
+| `aileron-remap-agent-uid` | Entrypoint wrapper that, started as root, remaps the in-container `agent` user/group to the numeric uid/gid owning the mounted workspace, then execs the rest of its argv still as root. The launcher prepends it on Linux + Docker so the workspace bind mount is writable by the agent. See [Workspace ownership on Linux](#workspace-ownership-on-linux). |
 
 The canonical implementations ship with the `ghcr.io/alrubinger/aileron-sandbox-base` image. BYO authors who derive from another base distro can write drop-in equivalents — the launcher only cares about the CLI shape, not the trust-store mechanism. Pick the mechanism that matches the base:
 
@@ -181,6 +184,20 @@ aileron sandbox check --runtime=docker --build=never --agent=claude
 ```
 
 The check reports `support: ok` only when the agent command and both proxy helpers are present and the `--check` probe succeeds. To launch without the proxy — useful for images that cannot meet the contract during initial bring-up — pass `--sandbox-proxy=off` on `aileron launch`. `sandbox check` does not honor that opt-out; it always exercises the full contract so BYO authors see the same failures the launcher would see.
+
+## Workspace ownership on Linux
+
+`aileron launch --sandbox=docker` bind-mounts your current working directory into the container at `/home/agent/workspace`. The container runs as the image's non-root `agent` user. On Linux + Docker the workspace bind mount keeps the host directory's owner uid (your operator uid, e.g. `1000`), while the `agent` user has its own uid baked into the image. When those differ, the directory's `0755` permissions deny the agent write access, so the agent cannot create files in your workspace.
+
+To fix this, the launcher routes the container through the `aileron-remap-agent-uid` entrypoint on Linux + Docker. Started as root, it reads the workspace owner's uid/gid, remaps the in-container `agent` user/group to match, then drops to the agent user before the agent runs. The remap composes with the proxy contract: the launcher chains `aileron-remap-agent-uid` ahead of `aileron-run-with-proxy-ca` so the order is remap uid, then install the CA, then drop to the agent user.
+
+This is scoped to Linux + Docker. On macOS and Windows, Docker Desktop's file-sharing layer translates uids at the boundary, so the mismatch never surfaces and the remap is skipped.
+
+A third operational requirement therefore applies to BYO images that run as a non-root user on Linux:
+
+3. The `aileron-remap-agent-uid` helper must be on `PATH` and the image must let it run as root at startup before dropping to the agent user. The helper needs `usermod`/`groupmod` (the `shadow` package on Alpine, `passwd`/`shadow-utils` on Debian/RHEL) and a `stat` that supports `-c` (GNU coreutils). The canonical implementation ships with the sandbox-base image.
+
+> This addresses [SELinux relabeling](#byo-image-proxy-contract) for a different failure: the `:z` relabel handles SELinux MAC denials on enforcing hosts, while the uid remap handles the DAC permission mismatch that occurs on every Linux + Docker host regardless of SELinux. Both can apply on the same host.
 
 ## Current Limits
 

--- a/images/sandbox-base/Containerfile
+++ b/images/sandbox-base/Containerfile
@@ -36,6 +36,7 @@ RUN apk add --no-cache \
     grep \
     procps \
     sed \
+    shadow \
     su-exec \
     tini \
     wget
@@ -46,7 +47,11 @@ RUN addgroup -S agent && adduser -S -G agent -h /home/agent agent \
 
 COPY bin/aileron-install-proxy-ca /usr/local/bin/aileron-install-proxy-ca
 COPY bin/aileron-run-with-proxy-ca /usr/local/bin/aileron-run-with-proxy-ca
-RUN chmod 0755 /usr/local/bin/aileron-install-proxy-ca /usr/local/bin/aileron-run-with-proxy-ca
+COPY bin/aileron-remap-agent-uid /usr/local/bin/aileron-remap-agent-uid
+RUN chmod 0755 \
+    /usr/local/bin/aileron-install-proxy-ca \
+    /usr/local/bin/aileron-run-with-proxy-ca \
+    /usr/local/bin/aileron-remap-agent-uid
 
 WORKDIR /home/agent/workspace
 USER agent

--- a/images/sandbox-base/Containerfile.published
+++ b/images/sandbox-base/Containerfile.published
@@ -86,6 +86,7 @@ RUN apk add --no-cache \
     grep \
     procps \
     sed \
+    shadow \
     su-exec \
     tini \
     wget
@@ -96,7 +97,11 @@ RUN addgroup -S agent && adduser -S -G agent -h /home/agent agent \
 
 COPY images/sandbox-base/bin/aileron-install-proxy-ca /usr/local/bin/aileron-install-proxy-ca
 COPY images/sandbox-base/bin/aileron-run-with-proxy-ca /usr/local/bin/aileron-run-with-proxy-ca
-RUN chmod 0755 /usr/local/bin/aileron-install-proxy-ca /usr/local/bin/aileron-run-with-proxy-ca
+COPY images/sandbox-base/bin/aileron-remap-agent-uid /usr/local/bin/aileron-remap-agent-uid
+RUN chmod 0755 \
+    /usr/local/bin/aileron-install-proxy-ca \
+    /usr/local/bin/aileron-run-with-proxy-ca \
+    /usr/local/bin/aileron-remap-agent-uid
 
 # Baked aileron-mcp from the builder stage. Root-owned, world-executable
 # (matches the proxy-CA helpers). The launcher's sandboxMCPBinPath const and

--- a/images/sandbox-base/bin/aileron-remap-agent-uid
+++ b/images/sandbox-base/bin/aileron-remap-agent-uid
@@ -60,20 +60,30 @@ if [ -d "$workspace" ]; then
   # Never remap to root (uid 0): the agent must stay unprivileged. A
   # root-owned workspace already grants the agent no less access than before,
   # and remapping the agent to uid 0 would defeat the non-root sandbox model.
+  remap_uid=""
+  remap_gid=""
   if [ "$want_gid" != "0" ] && [ "$want_gid" != "$cur_gid" ]; then
     groupmod -g "$want_gid" -o agent
+    remap_gid="$want_gid"
   fi
   if [ "$want_uid" != "0" ] && [ "$want_uid" != "$cur_uid" ]; then
     usermod -u "$want_uid" -o agent
-    # usermod -u rewrites ownership of files inside the home directory tree
-    # automatically, but only for files already owned by the OLD uid. The home
-    # directory and proxy/manifest scaffolding were chowned to the agent at
-    # build time, so they follow. Re-assert ownership of the home tree so the
-    # agent still owns its dotfiles after the remap.
-    chown -R "$want_uid:$want_gid" /home/agent
-  elif [ "$want_gid" != "0" ] && [ "$want_gid" != "$cur_gid" ]; then
-    # gid changed but uid did not: realign group ownership of the home tree.
-    chown -R "$want_uid:$want_gid" /home/agent
+    remap_uid="$want_uid"
+  fi
+
+  # Re-assert ownership of the agent's home scaffolding (dotfiles, proxy/CA and
+  # manifest dirs) after the remap so the agent still owns them under its new
+  # uid/gid. usermod -u rewrites ownership only for files already owned by the
+  # OLD uid, so this also covers anything created since build time. CRITICAL:
+  # the workspace bind mount lives at $workspace under /home/agent and is the
+  # operator's real host CWD; it must NOT be recursively chowned (that would
+  # rewrite the host project's file ownership, and is unnecessary because the
+  # agent uid was just aligned to the workspace owner). Prune it from the walk.
+  if [ -n "$remap_uid" ] || [ -n "$remap_gid" ]; then
+    new_uid="${remap_uid:-$cur_uid}"
+    new_gid="${remap_gid:-$cur_gid}"
+    find /home/agent -path "$workspace" -prune -o \
+      -exec chown -h "$new_uid:$new_gid" {} +
   fi
 fi
 

--- a/images/sandbox-base/bin/aileron-remap-agent-uid
+++ b/images/sandbox-base/bin/aileron-remap-agent-uid
@@ -1,0 +1,80 @@
+#!/bin/sh
+#
+# aileron-remap-agent-uid — remap the in-container `agent` user/group so its
+# numeric uid/gid matches the owner of the mounted workspace, then exec the
+# rest of the argv (still as root). This is the canonical implementation for
+# aileron/sandbox-base.
+#
+# Why: `aileron launch --sandbox=docker` runs the container as the image's
+# non-root `agent` user, while the workspace bind mount is the operator's host
+# CWD owned by the host uid (e.g. 1000). When those uids differ, DAC denies the
+# agent user write access to the 0755 workspace directory ("other" carries no
+# write bit) and the agent cannot create files. PR #1460's `:z` SELinux relabel
+# only addresses MAC denials on SELinux-enforcing hosts; it is a no-op against a
+# DAC uid mismatch and on daemons without SELinux support. This helper fixes the
+# DAC mismatch directly by aligning the agent uid/gid to the workspace owner.
+#
+# Strategy B (issue #1461): keep the "container runs as agent + the host chowns
+# transient auth trees to the agent uid" invariant intact. Rather than inverting
+# that ownership model, the entrypoint remaps the agent identity itself at
+# startup so the existing invariant lands on the right numeric uid.
+#
+# CLI contract:
+#   aileron-remap-agent-uid COMMAND [ARG...]
+#       Must run as root. Remap agent uid/gid to the workspace owner, then
+#       `exec COMMAND [ARG...]` still as root. The caller composes the
+#       privilege drop (e.g. `aileron-run-with-proxy-ca` installs the CA then
+#       `su-exec agent`, or a bare `su-exec agent COMMAND`).
+#
+# Exit codes:
+#   0    success (execs COMMAND, inheriting its exit code)
+#   64   no command supplied
+#   126  invoked without root
+#
+# See https://docs.withaileron.ai/development/sandbox-agent-images/#byo-image-proxy-contract
+# for the full BYO entrypoint contract.
+set -eu
+
+if [ "$#" -eq 0 ]; then
+  echo "usage: aileron-remap-agent-uid COMMAND [ARG...]" >&2
+  exit 64
+fi
+
+if [ "$(id -u)" != "0" ]; then
+  echo "aileron-remap-agent-uid must run as root" >&2
+  exit 126
+fi
+
+workspace="${AILERON_SANDBOX_WORKSPACE:-/home/agent/workspace}"
+
+# Read the workspace owner's numeric uid/gid. If the workspace is absent (an
+# image started without the bind mount) the remap is skipped and the argv is
+# exec'd unchanged — the no-op keeps non-launch invocations working.
+if [ -d "$workspace" ]; then
+  want_uid="$(stat -c '%u' "$workspace")"
+  want_gid="$(stat -c '%g' "$workspace")"
+
+  cur_uid="$(id -u agent)"
+  cur_gid="$(id -g agent)"
+
+  # Never remap to root (uid 0): the agent must stay unprivileged. A
+  # root-owned workspace already grants the agent no less access than before,
+  # and remapping the agent to uid 0 would defeat the non-root sandbox model.
+  if [ "$want_gid" != "0" ] && [ "$want_gid" != "$cur_gid" ]; then
+    groupmod -g "$want_gid" -o agent
+  fi
+  if [ "$want_uid" != "0" ] && [ "$want_uid" != "$cur_uid" ]; then
+    usermod -u "$want_uid" -o agent
+    # usermod -u rewrites ownership of files inside the home directory tree
+    # automatically, but only for files already owned by the OLD uid. The home
+    # directory and proxy/manifest scaffolding were chowned to the agent at
+    # build time, so they follow. Re-assert ownership of the home tree so the
+    # agent still owns its dotfiles after the remap.
+    chown -R "$want_uid:$want_gid" /home/agent
+  elif [ "$want_gid" != "0" ] && [ "$want_gid" != "$cur_gid" ]; then
+    # gid changed but uid did not: realign group ownership of the home tree.
+    chown -R "$want_uid:$want_gid" /home/agent
+  fi
+fi
+
+exec "$@"

--- a/internal/launch/agent_uid.go
+++ b/internal/launch/agent_uid.go
@@ -28,7 +28,12 @@ const remapAgentUIDHelper = "aileron-remap-agent-uid"
 // container package's decision so the launch path, the validate probe, and the
 // SELinux-relabel argv all share one source of truth for the Linux+Docker gate
 // (mirroring newAgentDirChownHook's GOOS guard; issue #1461).
-func workspaceUIDRemapActive(runtime string) bool {
+//
+// It is a package-level seam (var, not func) so tests can pin the gate
+// independent of the test runner's OS: the real value is GOOS-dependent, so
+// argv-asserting launcher tests would otherwise pass on macOS and fail on Linux
+// (and vice versa).
+var workspaceUIDRemapActive = func(runtime string) bool {
 	return sandboxcontainer.WorkspaceUIDRemapActive(strings.TrimSpace(runtime))
 }
 

--- a/internal/launch/agent_uid.go
+++ b/internal/launch/agent_uid.go
@@ -13,6 +13,64 @@ import (
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 )
 
+// remapAgentUIDHelper is the in-image entrypoint helper (shipped by
+// images/sandbox-base) that, started as root, remaps the container's `agent`
+// user/group to the numeric uid/gid owning the mounted workspace, then execs
+// the rest of its argv still as root. The launcher prepends it so the
+// privilege drop the next link performs (aileron-run-with-proxy-ca's su-exec,
+// or a bare su-exec) lands on the workspace-owner uid, fixing the DAC mismatch
+// that otherwise denies the agent write access to the operator's bind-mounted
+// CWD. See issue #1461 and the BYO entrypoint contract.
+const remapAgentUIDHelper = "aileron-remap-agent-uid"
+
+// workspaceUIDRemapActive reports whether `aileron launch` should route the
+// sandbox container through the remap-agent-uid entrypoint. It delegates to the
+// container package's decision so the launch path, the validate probe, and the
+// SELinux-relabel argv all share one source of truth for the Linux+Docker gate
+// (mirroring newAgentDirChownHook's GOOS guard; issue #1461).
+func workspaceUIDRemapActive(runtime string) bool {
+	return sandboxcontainer.WorkspaceUIDRemapActive(strings.TrimSpace(runtime))
+}
+
+// sandboxEntrypointCommand composes the in-container entrypoint chain for a
+// sandbox launch and returns the final command argv and the runtime --user.
+//
+// Both the proxy-CA bootstrap and the workspace uid remap must run as root
+// before the agent starts, then drop to the unprivileged agent user. They
+// compose as a chain of root wrappers in this order: become root -> remap the
+// agent uid to the workspace owner -> install the proxy CA -> su-exec agent.
+// Each wrapper execs the next; the final privilege drop happens exactly once.
+//
+//	proxy on,  remap on:  [remap, run-with-proxy-ca, CMD...]   user=root
+//	proxy on,  remap off: [run-with-proxy-ca, CMD...]          user=root
+//	proxy off, remap on:  [remap, su-exec, agent, CMD...]      user=root
+//	proxy off, remap off: [CMD...]                             user=""   (image default agent user)
+//
+// The remap is gated to Linux+Docker by the caller (workspaceUIDRemapActive),
+// mirroring newAgentDirChownHook's GOOS guard, so macOS/Windows Docker Desktop
+// is untouched. The returned slice is a fresh allocation; the input command is
+// not mutated.
+func sandboxEntrypointCommand(command []string, proxyActive, remapActive bool) (cmd []string, user string) {
+	cmd = append([]string(nil), command...)
+	if proxyActive {
+		user = "root"
+		cmd = append([]string{"aileron-run-with-proxy-ca"}, cmd...)
+	}
+	if remapActive {
+		user = "root"
+		if proxyActive {
+			// aileron-run-with-proxy-ca performs the privilege drop; the
+			// remap helper only needs to remap then exec it (still root).
+			cmd = append([]string{remapAgentUIDHelper}, cmd...)
+		} else {
+			// No proxy wrapper to drop privileges, so the remap helper hands
+			// off to su-exec itself.
+			cmd = append([]string{remapAgentUIDHelper, "su-exec", "agent"}, cmd...)
+		}
+	}
+	return cmd, user
+}
+
 // agentUIDCacheKey identifies a resolved UID lookup by runtime+image so
 // repeated launches against the same image pay the inspect/run cost at
 // most once per process.

--- a/internal/launch/agent_uid_test.go
+++ b/internal/launch/agent_uid_test.go
@@ -426,3 +426,68 @@ func TestResolveAgentUIDValidatesInputs(t *testing.T) {
 		t.Fatal("expected error for empty image")
 	}
 }
+
+// TestSandboxEntrypointCommand covers the four entrypoint-composition cases
+// (#1461): the remap and proxy-CA wrappers each force --user root and the chain
+// drops to the agent user exactly once, in the order remap -> proxy-CA ->
+// su-exec agent.
+func TestSandboxEntrypointCommand(t *testing.T) {
+	base := []string{"claude", "--flag", "value"}
+	cases := []struct {
+		name     string
+		proxy    bool
+		remap    bool
+		wantCmd  []string
+		wantUser string
+	}{
+		{
+			name:     "neither: image default agent user",
+			proxy:    false,
+			remap:    false,
+			wantCmd:  []string{"claude", "--flag", "value"},
+			wantUser: "",
+		},
+		{
+			name:     "proxy only",
+			proxy:    true,
+			remap:    false,
+			wantCmd:  []string{"aileron-run-with-proxy-ca", "claude", "--flag", "value"},
+			wantUser: "root",
+		},
+		{
+			name:     "remap only drops via su-exec",
+			proxy:    false,
+			remap:    true,
+			wantCmd:  []string{"aileron-remap-agent-uid", "su-exec", "agent", "claude", "--flag", "value"},
+			wantUser: "root",
+		},
+		{
+			name:     "proxy and remap compose: remap then proxy-ca",
+			proxy:    true,
+			remap:    true,
+			wantCmd:  []string{"aileron-remap-agent-uid", "aileron-run-with-proxy-ca", "claude", "--flag", "value"},
+			wantUser: "root",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			gotCmd, gotUser := sandboxEntrypointCommand(base, tc.proxy, tc.remap)
+			if gotUser != tc.wantUser {
+				t.Errorf("user = %q, want %q", gotUser, tc.wantUser)
+			}
+			if strings.Join(gotCmd, " ") != strings.Join(tc.wantCmd, " ") {
+				t.Errorf("command = %v, want %v", gotCmd, tc.wantCmd)
+			}
+		})
+	}
+}
+
+// TestSandboxEntrypointCommandDoesNotMutateInput guards against the prepend
+// aliasing the caller's slice.
+func TestSandboxEntrypointCommandDoesNotMutateInput(t *testing.T) {
+	base := []string{"claude"}
+	_, _ = sandboxEntrypointCommand(base, true, true)
+	if len(base) != 1 || base[0] != "claude" {
+		t.Errorf("input command was mutated: %v", base)
+	}
+}

--- a/internal/launch/export_test.go
+++ b/internal/launch/export_test.go
@@ -1,0 +1,15 @@
+package launch
+
+import "testing"
+
+// PinWorkspaceUIDRemapForTest overrides the workspaceUIDRemapActive gate for
+// the duration of the test and restores it on cleanup. The real gate is
+// GOOS-dependent (Linux+Docker only), so argv-asserting launcher tests must pin
+// it to a known value to stay deterministic across the test runner's OS
+// (issue #1461). Exposed to the external launch_test package.
+func PinWorkspaceUIDRemapForTest(t *testing.T, active bool) {
+	t.Helper()
+	orig := workspaceUIDRemapActive
+	workspaceUIDRemapActive = func(string) bool { return active }
+	t.Cleanup(func() { workspaceUIDRemapActive = orig })
+}

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -455,7 +455,7 @@ func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchC
 		})
 	}
 	if err := validateSandboxImageForLaunch(ctx, plan, config, agentEnv, mounts, commandName); err != nil {
-		err = sandboxcomposition.EnrichValidateError(err, plan.Tier, config.Agent.Name(), version.Version, config.Dir)
+		err = sandboxcomposition.EnrichValidateError(err, plan.Tier, config.Agent.Name(), version.Version, config.Dir, sandboxcontainer.WorkspaceRelabelActive(plan.Runtime))
 		return fmt.Errorf("sandbox image %s is not launchable for %s: %w", plan.Image, config.Agent.Name(), err)
 	}
 	return nil
@@ -474,6 +474,7 @@ func validateSandboxImage(ctx context.Context, plan SandboxLaunchPlan, config La
 		Command:           []string{commandName},
 		RequireProxyTrust: agentEnv["AILERON_SANDBOX_PROXY_MODE"] != "",
 		RequireMCPBinary:  true,
+		RemapWorkspaceUID: workspaceUIDRemapActive(plan.Runtime),
 	}); err != nil {
 		return err
 	}
@@ -1080,11 +1081,11 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 	command := append([]string{commandName}, config.Agent.Args(ModeSandbox)...)
 	command = append(command, extraArgs...)
 	command = append(command, config.Args...)
-	user := ""
-	if sandboxProxyBootstrapActive(agentEnv) {
-		user = "root"
-		command = append([]string{"aileron-run-with-proxy-ca"}, command...)
-	}
+	command, user := sandboxEntrypointCommand(
+		command,
+		sandboxProxyBootstrapActive(agentEnv),
+		workspaceUIDRemapActive(plan.Runtime),
+	)
 
 	runOpts := sandboxcontainer.RunOptions{
 		Runtime: plan.Runtime,

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -277,6 +277,10 @@ func TestLaunch_AgentMCPArgs_Appended(t *testing.T) {
 }
 
 func TestLaunch_SandboxBYOImageRunsContainer(t *testing.T) {
+	// Pin the workspace uid-remap gate off so this test asserts the
+	// OS-independent container shape; the Linux+Docker remap chain is covered
+	// by TestLaunch_SandboxWorkspaceUIDRemap* (#1461).
+	launch.PinWorkspaceUIDRemapForTest(t, false)
 	// Proxy bootstrap is default-on for --sandbox=docker per the
 	// U3 plan. This test exercises the opt-out path via
 	// --sandbox-proxy=off so it can assert the rest of the container
@@ -557,6 +561,12 @@ func TestLaunch_SandboxProxyLegacyEnvVarIgnored(t *testing.T) {
 // AILERON_SANDBOX_PROXY_MODE env, no --user root, no
 // aileron-run-with-proxy-ca prefix.
 func TestLaunch_SandboxProxyOffViaFlag(t *testing.T) {
+	// Pin the workspace uid-remap gate off: this test asserts that
+	// --sandbox-proxy=off does not force --user root, which only holds when the
+	// remap is also inactive (the remap independently forces root on
+	// Linux+Docker). The remap-on behavior is covered by
+	// TestLaunch_SandboxWorkspaceUIDRemap* (#1461).
+	launch.PinWorkspaceUIDRemapForTest(t, false)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	t.Setenv("AILERON_SANDBOX_PROXY", "")
@@ -818,6 +828,10 @@ func TestLaunch_SandboxMountsAileronManifestStores(t *testing.T) {
 }
 
 func TestLaunch_SandboxDiscoverySmokeMountsShimsForValidateAndRun(t *testing.T) {
+	// Pin the workspace uid-remap gate off so the run-command assertion checks
+	// the proxy-ca wrapper shape directly; the remap chain is covered by
+	// TestLaunch_SandboxWorkspaceUIDRemap* (#1461).
+	launch.PinWorkspaceUIDRemapForTest(t, false)
 	home := t.TempDir()
 	t.Setenv("HOME", home)
 	actionsDir := filepath.Join(home, ".aileron", "actions")
@@ -1092,6 +1106,10 @@ func TestLaunch_SandboxScaffoldBuildsAndRuns(t *testing.T) {
 }
 
 func TestLaunch_SandboxBuildRunsPreparedImage(t *testing.T) {
+	// Pin the workspace uid-remap gate off so the run command asserts the
+	// proxy-ca wrapper shape; the remap chain is covered by
+	// TestLaunch_SandboxWorkspaceUIDRemap* (#1461).
+	launch.PinWorkspaceUIDRemapForTest(t, false)
 	dir := t.TempDir()
 	baseDir := filepath.Join(dir, "images", "sandbox-base")
 	if err := os.MkdirAll(baseDir, 0o755); err != nil {
@@ -1152,6 +1170,10 @@ type publishedAgent struct {
 func (a publishedAgent) Name() string { return a.name }
 
 func TestLaunch_SandboxNoDevcontainerPublishedAgentPullsPerAgentImage(t *testing.T) {
+	// Pin the workspace uid-remap gate off so the run command asserts the
+	// proxy-ca wrapper shape; the remap chain is covered by
+	// TestLaunch_SandboxWorkspaceUIDRemap* (#1461).
+	launch.PinWorkspaceUIDRemapForTest(t, false)
 	dir := t.TempDir()
 	// No images/sandbox-base context and no .devcontainer: the only build-free
 	// route is the published per-agent image. If the launcher fell back to the
@@ -1406,6 +1428,38 @@ func setupSandboxDockerCaptureLaunch(t *testing.T, dir string, agent launch.Agen
 		t.Fatalf("read docker args: %v", err)
 	}
 	return string(data)
+}
+
+// TestLaunch_SandboxWorkspaceUIDRemapChainsAheadOfProxyCA verifies the
+// Linux+Docker workspace uid-remap (#1461): when the gate is active the launcher
+// runs the container as root and prepends aileron-remap-agent-uid ahead of the
+// proxy-CA wrapper, so the order is remap -> install CA -> su-exec agent.
+func TestLaunch_SandboxWorkspaceUIDRemapChainsAheadOfProxyCA(t *testing.T) {
+	launch.PinWorkspaceUIDRemapForTest(t, true)
+	dir := t.TempDir()
+	args := setupSandboxDockerCaptureLaunch(t, dir, claudeTestAgent{})
+
+	if !strings.Contains(args, "--user\nroot\n") {
+		t.Errorf("expected --user root under active workspace uid-remap; got:\n%s", args)
+	}
+	// The remap helper must immediately precede the proxy-CA wrapper, which in
+	// turn precedes the agent image command.
+	if !regexp.MustCompile(`ghcr.io/acme/agent:latest\naileron-remap-agent-uid\naileron-run-with-proxy-ca\n`).MatchString(args) {
+		t.Errorf("expected remap helper chained ahead of the proxy-ca wrapper; got:\n%s", args)
+	}
+}
+
+// TestLaunch_SandboxWorkspaceUIDRemapInactiveOmitsHelper is the negative: with
+// the gate inactive (non-Linux / non-Docker) the remap helper and forced root
+// must not appear; the proxy-ca wrapper stands alone.
+func TestLaunch_SandboxWorkspaceUIDRemapInactiveOmitsHelper(t *testing.T) {
+	launch.PinWorkspaceUIDRemapForTest(t, false)
+	dir := t.TempDir()
+	args := setupSandboxDockerCaptureLaunch(t, dir, claudeTestAgent{})
+
+	if strings.Contains(args, "aileron-remap-agent-uid") {
+		t.Errorf("remap helper must not appear when the gate is inactive; got:\n%s", args)
+	}
 }
 
 // TestLaunch_Sandbox_MountsAileronMCPBinary verifies the host-built

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -1450,8 +1450,11 @@ func TestLaunch_SandboxWorkspaceUIDRemapChainsAheadOfProxyCA(t *testing.T) {
 }
 
 // TestLaunch_SandboxWorkspaceUIDRemapInactiveOmitsHelper is the negative: with
-// the gate inactive (non-Linux / non-Docker) the remap helper and forced root
-// must not appear; the proxy-ca wrapper stands alone.
+// the gate inactive (non-Linux / non-Docker) the remap helper must not appear,
+// and the proxy-ca wrapper stands alone in front of the agent image command.
+// Note: --user root is still expected here because the proxy bootstrap is
+// default-on for --sandbox=docker and runs its own root wrapper; the remap is
+// not what forces root in this case.
 func TestLaunch_SandboxWorkspaceUIDRemapInactiveOmitsHelper(t *testing.T) {
 	launch.PinWorkspaceUIDRemapForTest(t, false)
 	dir := t.TempDir()
@@ -1459,6 +1462,10 @@ func TestLaunch_SandboxWorkspaceUIDRemapInactiveOmitsHelper(t *testing.T) {
 
 	if strings.Contains(args, "aileron-remap-agent-uid") {
 		t.Errorf("remap helper must not appear when the gate is inactive; got:\n%s", args)
+	}
+	// The proxy-ca wrapper stands alone, immediately following the image.
+	if !regexp.MustCompile(`ghcr.io/acme/agent:latest\naileron-run-with-proxy-ca\n`).MatchString(args) {
+		t.Errorf("expected the proxy-ca wrapper directly after the image with no remap helper; got:\n%s", args)
 	}
 }
 

--- a/internal/launch/workspace_uid_remap_integration_test.go
+++ b/internal/launch/workspace_uid_remap_integration_test.go
@@ -1,0 +1,175 @@
+//go:build integration_sandbox
+
+// Workspace uid-remap integration test (#1461).
+//
+// This test exercises the DAC uid-mismatch contract on the platform where it
+// actually breaks: rootful Docker on Linux. `aileron launch --sandbox=docker`
+// runs the container as the image's non-root `agent` user, while the workspace
+// bind mount is the operator's host CWD owned by the host uid (e.g. 1000). When
+// those uids differ, DAC denies the agent write access to the 0755 workspace
+// directory ("other" carries no write bit), so the in-container writability
+// probe (runtime.go validationScript, the `: > "$probe"` branch) exits 3 and the
+// launch is blocked. PR #1460's `:z` SELinux relabel does not address this: it
+// is a MAC remedy and a no-op against a DAC mismatch / on daemons without
+// SELinux support.
+//
+// The fix (strategy B): the aileron-remap-agent-uid entrypoint, started as
+// root, remaps the in-container `agent` uid/gid to the workspace owner, then
+// drops to the agent user via su-exec. This test proves:
+//
+//   - Negative control: running as the image's default agent user against a
+//     workspace owned by a different uid FAILS the writability probe (exit 3).
+//   - Positive case: running through aileron-remap-agent-uid + su-exec agent
+//     against the same workspace SUCCEEDS — the remap aligned the agent uid to
+//     the workspace owner so the agent can write.
+//
+// The test skips unless GOOS == linux and a Docker runtime is on PATH
+// (macOS/Windows Docker Desktop translates uids via its file-sharing shim, so
+// the mismatch does not reproduce there), mirroring the AuthSpec bind-mount test.
+//
+// Run with:
+//
+//	task test:integration:workspace-uid-remap
+//	go test -tags=integration_sandbox -run TestWorkspaceUIDRemap ./internal/launch/...
+package launch
+
+import (
+	"bytes"
+	"context"
+	"os"
+	"os/exec"
+	"runtime"
+	"strings"
+	"testing"
+	"time"
+
+	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+const workspaceRemapTestImage = "aileron-sandbox-base:workspace-uid-remap-test"
+
+func TestWorkspaceUIDRemap(t *testing.T) {
+	if runtime.GOOS != "linux" {
+		t.Skipf("workspace DAC uid mismatch only reproduces on Linux; GOOS=%s translates uids via the Docker Desktop shim", runtime.GOOS)
+	}
+	rt, err := sandboxcontainer.ResolveRuntime("docker")
+	if err != nil {
+		t.Skipf("no docker runtime on PATH: %v", err)
+	}
+
+	ctx, cancel := context.WithTimeout(context.Background(), 5*time.Minute)
+	defer cancel()
+
+	buildWorkspaceRemapBaseImage(ctx, t, rt)
+
+	runner := sandboxcontainer.DefaultRunner()
+	agentUID, err := resolveAgentUID(ctx, runner, rt, workspaceRemapTestImage)
+	if err != nil {
+		t.Fatalf("resolve agent UID for %s: %v", workspaceRemapTestImage, err)
+	}
+	if agentUID == 0 {
+		t.Fatalf("sandbox-base image resolved agent UID 0 (root); the image's USER directive should select the non-root `agent` user — the workspace DAC contract is meaningless as root")
+	}
+	hostUID := os.Getuid()
+	if hostUID == 0 {
+		t.Skipf("host runner is root (UID 0); the negative control needs an unprivileged workspace owner whose uid differs from the container agent uid, which a root runner cannot model")
+	}
+	if hostUID == agentUID {
+		t.Skipf("host UID %d equals container agent UID %d; the DAC mismatch this test guards cannot occur in this environment", hostUID, agentUID)
+	}
+
+	// The workspace is the operator's CWD: a 0755 directory owned by the host
+	// uid, bind-mounted at WorkspacePath. The probe mirrors the in-container
+	// validation script's writability test exactly.
+	const probeCmd = "probe=.aileron-remap-probe-$$; : > \"$probe\" && rm -f \"$probe\" && echo writable"
+
+	// Negative control: as the image default agent user, the agent uid differs
+	// from the workspace owner, so DAC denies the write and the probe fails.
+	t.Run("negative_control_without_remap_fails", func(t *testing.T) {
+		hostWorkspace := newWorkspaceDir(t, hostUID)
+		stdout, stderr, runErr := runWorkspaceProbe(ctx, rt, hostWorkspace, false, probeCmd)
+		if runErr == nil {
+			t.Fatalf("expected the in-container write to FAIL without the remap (host UID %d owns the workspace, container runs as agent UID %d), but it succeeded; stdout=%q", hostUID, agentUID, stdout)
+		}
+		t.Logf("negative control reproduced the DAC denial the remap guards: host UID %d owns the workspace bind mount but the container runs as agent UID %d; the remedy is the aileron-remap-agent-uid entrypoint. runtime stderr: %s", hostUID, agentUID, strings.TrimSpace(stderr))
+	})
+
+	// Positive case: routing through aileron-remap-agent-uid (as root) remaps
+	// the agent uid to the workspace owner before dropping to the agent user,
+	// so the write succeeds.
+	t.Run("with_remap_write_succeeds", func(t *testing.T) {
+		hostWorkspace := newWorkspaceDir(t, hostUID)
+		stdout, stderr, runErr := runWorkspaceProbe(ctx, rt, hostWorkspace, true, probeCmd)
+		if runErr != nil {
+			t.Fatalf("in-container write FAILED even WITH the remap (host UID %d, agent UID %d): %v\nstderr: %s\nThis is the regression #1461 guards: the entrypoint must remap the agent uid to the workspace owner so the agent can write the operator's CWD.", hostUID, agentUID, runErr, strings.TrimSpace(stderr))
+		}
+		if got := strings.TrimSpace(stdout); got != "writable" {
+			t.Fatalf("in-container probe output = %q, want %q", got, "writable")
+		}
+	})
+}
+
+// buildWorkspaceRemapBaseImage builds the sandbox-base image under a dedicated
+// test tag. The build must include the new aileron-remap-agent-uid helper and
+// the shadow package (usermod/groupmod), so a green build is itself part of the
+// contract.
+func buildWorkspaceRemapBaseImage(ctx context.Context, t *testing.T, rt string) {
+	t.Helper()
+	builder := sandboxcontainer.Builder{
+		Runtime: rt,
+		Stdout:  testLogWriter{t},
+		Stderr:  testLogWriter{t},
+	}
+	plan := sandboxcomposition.Plan{
+		Tier:  sandboxcomposition.TierBase,
+		Image: workspaceRemapTestImage,
+	}
+	if _, err := builder.Build(ctx, sandboxcontainer.BuildOptions{
+		Plan:   plan,
+		Tag:    workspaceRemapTestImage,
+		Policy: sandboxcontainer.BuildPolicyAlways,
+	}); err != nil {
+		t.Fatalf("build sandbox-base test image: %v (set AILERON_SANDBOX_BASE_CONTEXT to images/sandbox-base if the context was not found)", err)
+	}
+}
+
+// newWorkspaceDir creates a 0755 directory owned by the test-runner uid,
+// modelling the operator's CWD that the launcher bind-mounts as the workspace.
+func newWorkspaceDir(t *testing.T, ownerUID int) string {
+	t.Helper()
+	dir := t.TempDir()
+	// t.TempDir already creates the dir owned by the test-runner uid with mode
+	// 0700; widen to 0755 so the bug is "other has no write bit" rather than
+	// "other has no access at all", matching a normal project CWD.
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod workspace 0755: %v", err)
+	}
+	_ = ownerUID // ownership is already the test-runner uid; documented for clarity.
+	return dir
+}
+
+// runWorkspaceProbe runs a one-shot container with hostWorkspace bind-mounted
+// WRITABLE at the sandbox WorkspacePath and runs cmd. When remap is true it
+// routes through `aileron-remap-agent-uid su-exec agent /bin/sh -c cmd` as root
+// (the production launch chain for the non-proxy path); otherwise it runs as the
+// image default agent user. Returns stdout, stderr, and the run error.
+func runWorkspaceProbe(ctx context.Context, rt, hostWorkspace string, remap bool, cmd string) (string, string, error) {
+	args := []string{
+		"run", "--rm",
+		"--workdir", sandboxcontainer.WorkspacePath,
+		"--volume", hostWorkspace + ":" + sandboxcontainer.WorkspacePath,
+	}
+	if remap {
+		args = append(args, "--user", "0", workspaceRemapTestImage,
+			"aileron-remap-agent-uid", "su-exec", "agent", "/bin/sh", "-c", cmd)
+	} else {
+		args = append(args, workspaceRemapTestImage, "/bin/sh", "-c", cmd)
+	}
+	var stdout, stderr bytes.Buffer
+	c := exec.CommandContext(ctx, rt, args...)
+	c.Stdout = &stdout
+	c.Stderr = &stderr
+	err := c.Run()
+	return stdout.String(), stderr.String(), err
+}

--- a/internal/sandbox/composition/validatehint.go
+++ b/internal/sandbox/composition/validatehint.go
@@ -15,9 +15,12 @@ const agentNotFoundMarker = "agent command not found in sandbox image:"
 // workspaceNotWritableMarker is the substring the in-container validation script
 // emits when the writability probe fails (see runtime.go validationScript, the
 // exit-3 branch). The bare runtime failure surfaces as an opaque "exit status
-// 3"; EnrichValidateError matches this marker to explain the most common cause
-// (SELinux denying the confined container process access to the host-labeled
-// workspace bind mount) and the remedy.
+// 3"; EnrichValidateError matches this marker to explain the real cause and the
+// remedy. There are two distinct causes: a DAC uid mismatch (the non-root agent
+// user's uid differs from the host workspace owner, so "other" carries no write
+// bit on the 0755 directory) and, on SELinux-enforcing hosts, a MAC denial. The
+// enrichment picks the right diagnosis from whether the `:z` SELinux relabel was
+// actually applied (issue #1461).
 const workspaceNotWritableMarker = "sandbox workspace is not writable at"
 
 // EnrichValidateError augments a sandbox-image validate failure with tier, CWD,
@@ -31,16 +34,16 @@ const workspaceNotWritableMarker = "sandbox workspace is not writable at"
 // absent and what the operator can do. When the failure is not that case
 // (different tier, no published image, or a different validate error),
 // EnrichValidateError returns err unchanged.
-func EnrichValidateError(err error, tier Tier, agent, version, workDir string) error {
+func EnrichValidateError(err error, tier Tier, agent, version, workDir string, selinuxRelabelActive bool) error {
 	if err == nil {
 		return nil
 	}
 	// The writability failure is tier-independent: any sandbox tier bind-mounts
-	// the operator's workspace, and SELinux on the host denies the confined
-	// container process access to it regardless of which image was selected.
-	// Match and enrich before the devcontainer-specific branch below.
+	// the operator's workspace, and the container's non-root agent user can be
+	// denied access regardless of which image was selected. Match and enrich
+	// before the devcontainer-specific branch below.
 	if strings.Contains(err.Error(), workspaceNotWritableMarker) {
-		return enrichWorkspaceNotWritable(err, workDir)
+		return enrichWorkspaceNotWritable(err, workDir, selinuxRelabelActive)
 	}
 	if tier != TierDevcontainer {
 		return err
@@ -71,26 +74,50 @@ func EnrichValidateError(err error, tier Tier, agent, version, workDir string) e
 }
 
 // enrichWorkspaceNotWritable augments the opaque workspace-writability failure
-// with the SELinux root cause and remediation. The bare runtime surface is an
-// uninformative "exit status 3"; on a Linux host with SELinux enforcing, the
-// confined container process (the image's non-root agent user) is denied access
-// to the host-labeled workspace bind mount. Aileron now applies a `:z` relabel
-// to the mount automatically, so this message also points operators at the
-// manual fallback for hosts where the automatic relabel cannot take effect.
-func enrichWorkspaceNotWritable(err error, workDir string) error {
+// ("exit status 3") with its real root cause and remediation. There are two
+// distinct causes, and the selinuxRelabelActive flag (from
+// container.WorkspaceRelabelActive: Linux + Docker + SELinux enforcing)
+// disambiguates them:
+//
+//   - selinuxRelabelActive: Aileron applied the `:z` SELinux relabel to the
+//     mount, so a SELinux MAC denial is the plausible remaining cause. Keep the
+//     SELinux guidance and the manual `chcon` fallback.
+//   - !selinuxRelabelActive: the daemon has no SELinux support, or SELinux is
+//     not enforcing, so the `:z` relabel was never emitted. The cause is a DAC
+//     uid mismatch — the container's non-root agent user has a different numeric
+//     uid than the host owner of the workspace, so "other" carries no write bit
+//     on the 0755 directory. Report that mismatch and the remap remediation, and
+//     do NOT claim Aileron applied any relabel (it did not).
+//
+// Aileron's startup remap (aileron-remap-agent-uid) aligns the agent uid to the
+// workspace owner on Linux+Docker, so a persistent DAC failure points at an
+// image whose entrypoint does not run the remap (e.g. a BYO image missing the
+// helper) or a workspace the host operator cannot themselves write.
+func enrichWorkspaceNotWritable(err error, workDir string, selinuxRelabelActive bool) error {
 	wd := workDir
 	if wd == "" {
 		wd = "."
 	}
+	if selinuxRelabelActive {
+		return fmt.Errorf("%w\n"+
+			"the sandbox container could not write to the mounted workspace %s. "+
+			"This host runs SELinux in enforcing mode, so the host directory's "+
+			"SELinux label can deny the container's non-root agent user access to "+
+			"the bind mount. Aileron applied a shared SELinux relabel (the `:z` "+
+			"mount option) automatically; if the failure persists, relabel the "+
+			"directory manually with `chcon -Rt svirt_sandbox_file_t %s` (or run "+
+			"the host with SELinux permissive).",
+			err, wd, wd)
+	}
 	return fmt.Errorf("%w\n"+
 		"the sandbox container could not write to the mounted workspace %s. "+
-		"On a Linux host with SELinux in enforcing mode, the host directory's "+
-		"SELinux label denies the container's non-root agent user access to the "+
-		"bind mount. Aileron applies a shared SELinux relabel (the `:z` mount "+
-		"option) automatically when it detects SELinux enforcing; if the failure "+
-		"persists, relabel the directory manually with "+
-		"`chcon -Rt svirt_sandbox_file_t %s` (or run the host with SELinux "+
-		"permissive). On non-SELinux hosts, check that the workspace directory is "+
-		"writable by the container's agent user.",
+		"The container's non-root agent user does not own the workspace bind "+
+		"mount: its in-container uid differs from the host user that owns %s, so "+
+		"the directory's permissions deny the agent write access. Aileron remaps "+
+		"the agent uid to the workspace owner at container start "+
+		"(aileron-remap-agent-uid) on Linux+Docker; if the failure persists, the "+
+		"image's entrypoint may not run that remap (BYO images must ship the "+
+		"helper on PATH and chain it as root before dropping to the agent user). "+
+		"Confirm the host directory is writable by you, the launching user.",
 		err, wd, wd)
 }

--- a/internal/sandbox/composition/validatehint_test.go
+++ b/internal/sandbox/composition/validatehint_test.go
@@ -28,7 +28,7 @@ func TestEnrichValidateErrorDevcontainerMismatch(t *testing.T) {
 		t.Fatalf("precondition: %q must have a published image", agent)
 	}
 	base := agentNotFoundErr(agent)
-	got := EnrichValidateError(base, TierDevcontainer, agent, version, workDir)
+	got := EnrichValidateError(base, TierDevcontainer, agent, version, workDir, false)
 	msg := got.Error()
 
 	if !strings.Contains(msg, string(TierDevcontainer)) {
@@ -54,7 +54,7 @@ func TestEnrichValidateErrorDevcontainerMismatch(t *testing.T) {
 func TestEnrichValidateErrorNonDevcontainerTierUnchanged(t *testing.T) {
 	base := agentNotFoundErr("claude")
 	for _, tier := range []Tier{TierBase, TierPublished, TierBYOImage} {
-		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project")
+		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project", false)
 		if got != base {
 			t.Errorf("tier %q: error was enriched, want unchanged: %s", tier, got.Error())
 		}
@@ -67,7 +67,7 @@ func TestEnrichValidateErrorUnpublishedAgentUnchanged(t *testing.T) {
 		t.Fatalf("precondition: %q must not have a published image", agent)
 	}
 	base := agentNotFoundErr(agent)
-	got := EnrichValidateError(base, TierDevcontainer, agent, "1.2.3", "/home/dev/project")
+	got := EnrichValidateError(base, TierDevcontainer, agent, "1.2.3", "/home/dev/project", false)
 	if got != base {
 		t.Errorf("unpublished agent: error was enriched, want unchanged: %s", got.Error())
 	}
@@ -75,21 +75,23 @@ func TestEnrichValidateErrorUnpublishedAgentUnchanged(t *testing.T) {
 
 func TestEnrichValidateErrorUnrelatedFailureUnchanged(t *testing.T) {
 	base := errors.New("validate sandbox image: image must support /bin/sh command execution")
-	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "/home/dev/project")
+	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "/home/dev/project", false)
 	if got != base {
 		t.Errorf("unrelated failure: error was enriched, want unchanged: %s", got.Error())
 	}
 }
 
-// TestEnrichValidateErrorWorkspaceNotWritable verifies the opaque writability
-// failure (which surfaces to the operator as a bare "exit status 3") is enriched
-// with the SELinux root cause, the automatic-relabel note, and the manual
-// fallback. This fails before the fix (the raw error explains none of those) and
-// passes after.
-func TestEnrichValidateErrorWorkspaceNotWritable(t *testing.T) {
+const workspaceNotWritableErr = "validate sandbox image img: sandbox workspace is not writable at /home/agent/workspace: exit status 3"
+
+// TestEnrichValidateErrorWorkspaceNotWritableSELinux verifies that when the
+// `:z` SELinux relabel was actually applied (selinuxRelabelActive=true), the
+// opaque "exit status 3" is enriched with the SELinux root cause, the
+// automatic-relabel note, and the manual `chcon` fallback. This is the
+// SELinux-enforcing-host branch.
+func TestEnrichValidateErrorWorkspaceNotWritableSELinux(t *testing.T) {
 	const workDir = "/home/dev/project"
-	base := errors.New("validate sandbox image img: sandbox workspace is not writable at /home/agent/workspace: exit status 3")
-	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir)
+	base := errors.New(workspaceNotWritableErr)
+	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir, true)
 	msg := got.Error()
 
 	for _, want := range []string{
@@ -110,28 +112,80 @@ func TestEnrichValidateErrorWorkspaceNotWritable(t *testing.T) {
 	}
 }
 
+// TestEnrichValidateErrorWorkspaceNotWritableUIDMismatch is the regression test
+// for issue #1461: when the `:z` relabel was NOT applied (the daemon lacks
+// SELinux support, or SELinux is not enforcing — selinuxRelabelActive=false),
+// the real cause is a DAC uid mismatch, not SELinux. The enriched message must
+// name the uid mismatch and the remap remediation, and must NOT claim Aileron
+// applied a relabel or point at SELinux/chcon. Before the fix this branch
+// emitted the SELinux wording unconditionally; this fails before and passes
+// after.
+func TestEnrichValidateErrorWorkspaceNotWritableUIDMismatch(t *testing.T) {
+	const workDir = "/home/dev/project"
+	base := errors.New(workspaceNotWritableErr)
+	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir, false)
+	msg := got.Error()
+
+	for _, want := range []string{
+		"uid",                     // names the DAC uid mismatch
+		"aileron-remap-agent-uid", // names the remap remediation
+		workDir,                   // names the operator's workspace
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("DAC-mismatch error missing %q: %s", want, msg)
+		}
+	}
+	// The misleading SELinux wording must be gone in this branch.
+	for _, absent := range []string{
+		"SELinux",
+		"chcon",
+		"`:z`",
+		"automatically", // must not claim Aileron applied a relabel it didn't
+	} {
+		if strings.Contains(msg, absent) {
+			t.Errorf("DAC-mismatch error must not mention %q (no relabel was applied): %s", absent, msg)
+		}
+	}
+	if !errors.Is(got, base) {
+		t.Errorf("enriched error does not wrap the original validate error")
+	}
+}
+
 // TestEnrichValidateErrorWorkspaceNotWritableAllTiers verifies the writability
 // enrichment is tier-independent: every sandbox tier bind-mounts the workspace,
-// so the SELinux denial can occur regardless of which image was selected.
+// so the denial can occur regardless of which image was selected. Exercised on
+// the DAC-mismatch branch (the common non-SELinux case).
 func TestEnrichValidateErrorWorkspaceNotWritableAllTiers(t *testing.T) {
-	base := errors.New("validate sandbox image img: sandbox workspace is not writable at /home/agent/workspace: exit status 3")
+	base := errors.New(workspaceNotWritableErr)
 	for _, tier := range []Tier{TierBase, TierPublished, TierBYOImage, TierDevcontainer} {
-		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project")
-		if !strings.Contains(got.Error(), "SELinux") {
+		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project", false)
+		if !strings.Contains(got.Error(), "uid") {
 			t.Errorf("tier %q: writability error was not enriched: %s", tier, got.Error())
 		}
 	}
 }
 
+// TestEnrichWorkspaceNotWritableEmptyWorkDirDefaultsToCwd covers the empty
+// workDir default ("." substitution) on both writability branches.
+func TestEnrichWorkspaceNotWritableEmptyWorkDirDefaultsToCwd(t *testing.T) {
+	base := errors.New(workspaceNotWritableErr)
+	for _, selinux := range []bool{true, false} {
+		got := EnrichValidateError(base, TierBase, "claude", "1.2.3", "", selinux)
+		if !strings.Contains(got.Error(), "workspace .") {
+			t.Errorf("selinux=%v: empty workDir not defaulted to '.': %s", selinux, got.Error())
+		}
+	}
+}
+
 func TestEnrichValidateErrorNilUnchanged(t *testing.T) {
-	if got := EnrichValidateError(nil, TierDevcontainer, "claude", "1.2.3", "/home/dev/project"); got != nil {
+	if got := EnrichValidateError(nil, TierDevcontainer, "claude", "1.2.3", "/home/dev/project", false); got != nil {
 		t.Errorf("nil error: got %v, want nil", got)
 	}
 }
 
 func TestEnrichValidateErrorEmptyWorkDirDefaultsToCwd(t *testing.T) {
 	base := agentNotFoundErr("claude")
-	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "")
+	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "", false)
 	// filepath.Join(".", path) cleans to the bare relative path.
 	wantPath := DefaultDevcontainerPath
 	if !strings.Contains(got.Error(), wantPath) {

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -47,6 +47,29 @@ const DefaultRuntime = "auto"
 const WorkspacePath = "/home/agent/workspace"
 const AgentImagesDocsURL = "https://docs.withaileron.ai/development/sandbox-agent-images/"
 
+// WorkspaceUIDRemapActive reports whether a launch/validate against runtimeName
+// should route the container through the aileron-remap-agent-uid entrypoint to
+// align the in-container agent uid/gid with the workspace owner. The DAC uid
+// mismatch only reproduces on rootful Docker on Linux: a host bind mount keeps
+// the host uid, and the non-root agent user is denied write access to the 0755
+// workspace. macOS/Windows Docker Desktop translate uids at the file-sharing
+// boundary, so the remap is scoped to Linux+Docker, mirroring the launcher's
+// AuthSpec chown guard (issue #1461). It shares the hostOS() seam with the
+// SELinux-relabel decision so both stay unit-testable together.
+func WorkspaceUIDRemapActive(runtimeName string) bool {
+	return runtimeName == "docker" && hostOS() == "linux"
+}
+
+// WorkspaceRelabelActive reports whether runArgs adds the `:z` SELinux relabel
+// suffix to host bind mounts for runtimeName: only on rootful Docker on Linux
+// with SELinux in enforcing mode (PR #1460). Exported so the validate-error
+// enrichment can decide whether the SELinux relabel was actually applied (and
+// thus whether SELinux guidance is relevant) versus the daemon lacking SELinux
+// support, where a DAC uid mismatch is the real cause (issue #1461).
+func WorkspaceRelabelActive(runtimeName string) bool {
+	return runtimeName == "docker" && hostOS() == "linux" && selinuxEnforcing()
+}
+
 // DevcontainerCLIVersion pins the @devcontainers/cli version Aileron uses to
 // build a Tier 1 devcontainer that declares `features`. Raw `docker build`
 // cannot apply Features, so the Features build path routes through
@@ -244,6 +267,15 @@ type ValidateOptions struct {
 	// cross-arch ENOEXEC case where `command -v` succeeds but the
 	// binary fails to exec inside the container. See ADR-0024.
 	RequireMCPBinary bool
+	// RemapWorkspaceUID routes the validation run through the
+	// aileron-remap-agent-uid entrypoint exactly as the real launch does:
+	// the container starts as root, the helper remaps the agent uid/gid to
+	// the workspace owner, then drops to the agent user before the
+	// writability probe runs. Without this the probe runs as the image's
+	// default agent uid and would still report exit 3 on a DAC mismatch even
+	// after the launch path is fixed, so validation must mirror the run. Set
+	// by the launcher / `sandbox check` on Linux+Docker (issue #1461).
+	RemapWorkspaceUID bool
 }
 
 // Build builds the image for plan. Tier 0 builds Aileron's local sandbox-base
@@ -642,21 +674,35 @@ func (b Builder) Validate(ctx context.Context, opts ValidateOptions) error {
 	if builder.Stderr == nil {
 		builder.Stderr = &stderr
 	}
+	// The validation script runs as the image's default agent user. When the
+	// real launch remaps the agent uid to the workspace owner (Linux+Docker,
+	// issue #1461), the probe must run through the same remap or it would
+	// report exit 3 on a DAC mismatch the launch path no longer hits. Prepend
+	// the remap entrypoint and start as root; the helper drops to the agent
+	// user via su-exec before exec'ing /bin/sh, so the probe sees the remapped
+	// identity exactly as the agent will at runtime.
+	command := []string{
+		"/bin/sh",
+		"-c",
+		validationScript,
+		"aileron-validate",
+		opts.Command[0],
+		boolArg(opts.RequireProxyTrust),
+		boolArg(opts.RequireMCPBinary),
+	}
+	user := ""
+	if opts.RemapWorkspaceUID {
+		user = "root"
+		command = append([]string{"aileron-remap-agent-uid", "su-exec", "agent"}, command...)
+	}
 	_, err := builder.Run(ctx, RunOptions{
 		Runtime: opts.Runtime,
 		Image:   opts.Image,
 		WorkDir: opts.WorkDir,
 		Env:     opts.Env,
 		Volumes: opts.Volumes,
-		Command: []string{
-			"/bin/sh",
-			"-c",
-			validationScript,
-			"aileron-validate",
-			opts.Command[0],
-			boolArg(opts.RequireProxyTrust),
-			boolArg(opts.RequireMCPBinary),
-		},
+		User:    user,
+		Command: command,
 	})
 	if err == nil {
 		return nil
@@ -800,7 +846,7 @@ func runArgs(runtimeName string, opts RunOptions) ([]string, error) {
 	// where it is required; elsewhere it is omitted (it would be rejected or be a
 	// no-op). Named volumes are managed by the runtime and already carry a
 	// container-accessible label, so they are not relabeled.
-	relabel := runtimeName == "docker" && hostOS() == "linux" && selinuxEnforcing()
+	relabel := WorkspaceRelabelActive(runtimeName)
 	workspaceSpec := absWorkDir + ":" + WorkspacePath
 	if relabel {
 		workspaceSpec += ":z"

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -1624,6 +1624,101 @@ func TestRunArgs_LinuxNonDockerOmitsRelabel(t *testing.T) {
 	}
 }
 
+// --- Workspace uid-remap gate + Validate routing (#1461) ---
+
+func TestWorkspaceUIDRemapActive(t *testing.T) {
+	cases := []struct {
+		name    string
+		os      string
+		runtime string
+		want    bool
+	}{
+		{"linux docker remaps", "linux", "docker", true},
+		{"darwin docker skips", "darwin", "docker", false},
+		{"windows docker skips", "windows", "docker", false},
+		{"linux non-docker skips", "linux", "podman", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			// enforcing is irrelevant to the remap gate; pin it false.
+			pinSELinux(t, tc.os, false)
+			if got := WorkspaceUIDRemapActive(tc.runtime); got != tc.want {
+				t.Errorf("WorkspaceUIDRemapActive(%q) on %s = %v, want %v", tc.runtime, tc.os, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestWorkspaceRelabelActive(t *testing.T) {
+	cases := []struct {
+		name      string
+		os        string
+		enforcing bool
+		runtime   string
+		want      bool
+	}{
+		{"linux docker enforcing relabels", "linux", true, "docker", true},
+		{"linux docker non-enforcing skips", "linux", false, "docker", false},
+		{"darwin docker enforcing skips", "darwin", true, "docker", false},
+		{"linux non-docker enforcing skips", "linux", true, "podman", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			pinSELinux(t, tc.os, tc.enforcing)
+			if got := WorkspaceRelabelActive(tc.runtime); got != tc.want {
+				t.Errorf("WorkspaceRelabelActive(%q) os=%s enforcing=%v = %v, want %v", tc.runtime, tc.os, tc.enforcing, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestValidateRoutesThroughRemapWhenRequested asserts that with
+// RemapWorkspaceUID set, Validate runs the container as root and prepends the
+// aileron-remap-agent-uid + su-exec chain so the writability probe sees the
+// remapped agent identity (issue #1461). Without it, the probe runs as the
+// image default user with no wrapper.
+func TestValidateRoutesThroughRemapWhenRequested(t *testing.T) {
+	runner := &recordingRunner{}
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Runtime:           "docker",
+		Image:             "img",
+		Command:           []string{"claude"},
+		RemapWorkspaceUID: true,
+	})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	joined := strings.Join(runner.args, " ")
+	if !strings.Contains(joined, "--user root") {
+		t.Errorf("remap Validate must run as root; args: %v", runner.args)
+	}
+	// The remap helper, su-exec, agent, then the validation shell must appear
+	// in order before the image, with the remap chain immediately preceding
+	// /bin/sh.
+	if !strings.Contains(joined, "aileron-remap-agent-uid su-exec agent /bin/sh -c") {
+		t.Errorf("remap Validate must chain remap->su-exec->agent->/bin/sh; args: %v", runner.args)
+	}
+}
+
+func TestValidateNoRemapByDefault(t *testing.T) {
+	runner := &recordingRunner{}
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Runtime: "docker",
+		Image:   "img",
+		Command: []string{"claude"},
+	})
+	if err != nil {
+		t.Fatalf("Validate: %v", err)
+	}
+	joined := strings.Join(runner.args, " ")
+	if strings.Contains(joined, "--user root") {
+		t.Errorf("default Validate must not force root; args: %v", runner.args)
+	}
+	if strings.Contains(joined, "aileron-remap-agent-uid") {
+		t.Errorf("default Validate must not prepend the remap helper; args: %v", runner.args)
+	}
+}
+
 // --- BakedMCPVersion image-label detection (U3 / #957) ---
 
 func TestBakedMCPVersion(t *testing.T) {


### PR DESCRIPTION
## Summary

`aileron launch --sandbox=docker` runs the container as the image's non-root `agent` user, while the workspace bind mount is the operator's host CWD owned by the host uid (e.g. 1000). On Linux + Docker those uids differ, so DAC denies the agent write access to the 0755 workspace directory ("other" has no write bit), and the in-container writability probe (`runtime.go` `validationScript`, the `: > "$probe"` branch) exits 3, blocking launch. PR #1460's `:z` SELinux relabel is a MAC remedy and a no-op against this DAC mismatch and on daemons without SELinux support, so it does not fix the reported failure.

This implements strategy B from the issue (operator-selected): a root entrypoint remaps the in-container `agent` uid/gid to the workspace owner at startup, then drops privileges, keeping the "container runs as agent + AuthSpec chowns to agent" invariant intact (no inversion of `agent_uid.go`).

### What changed

- **New entrypoint helper** `images/sandbox-base/bin/aileron-remap-agent-uid` (wired into both `Containerfile` and `Containerfile.published`, kept in sync per #957; adds the `shadow` package for `usermod`/`groupmod`). Started as root, it remaps the `agent` user/group to the workspace owner, then execs the rest of its argv still as root. It composes with `aileron-run-with-proxy-ca` so the order is: become root -> remap uid -> install CA -> su-exec agent.
- **Launcher** (`internal/launch`): on the non-proxy path it now sets `User=root` and prepends the remap helper (+ `su-exec agent` to perform the drop); on the proxy path it chains the remap ahead of `aileron-run-with-proxy-ca`. Gated to Linux + Docker via `WorkspaceUIDRemapActive`, mirroring `newAgentDirChownHook`'s `GOOS==linux` guard. The composition is extracted into a pure, unit-tested `sandboxEntrypointCommand`.
- **Validate** (`internal/sandbox/container`): `Builder.Validate` runs the writability probe through the same remap (`RemapWorkspaceUID`) so validation reflects the real run; otherwise launch would stay blocked at exit 3 even after the run path is fixed.
- **Diagnosis fix** (`internal/sandbox/composition/validatehint.go`): `enrichWorkspaceNotWritable` now reports the DAC uid mismatch as the cause when the `:z` relabel was not applied (daemon lacks SELinux support / not enforcing), and stops claiming Aileron "already applied the relabel automatically". SELinux guidance is kept only for SELinux-capable daemons. The relabel/remap gates share one source of truth (`WorkspaceRelabelActive` / `WorkspaceUIDRemapActive`).
- **Docs**: new "Workspace ownership on Linux" section + the remap helper added to the BYO entrypoint contract.

## Test plan

- `go test ./internal/sandbox/... ./internal/launch/... ./cmd/aileron/...` — green. New unit tests:
  - `sandboxEntrypointCommand` (all four proxy x remap cases + no-mutation guard).
  - `WorkspaceUIDRemapActive` / `WorkspaceRelabelActive` gate matrices.
  - `Validate` remap routing (root + `aileron-remap-agent-uid su-exec agent /bin/sh` chain) and the no-remap default.
  - Both diagnosis branches: SELinux-active keeps the SELinux/`chcon` wording; the DAC-mismatch branch (regression for #1461) asserts the uid-mismatch + remap remediation and that the misleading SELinux/`automatically` wording is gone.
- Per-function coverage of all new code is 100% (changed packages: composition 93.1%, container 91.4%, launch 88.2%).
- Build-tagged Linux+Docker integration regression `TestWorkspaceUIDRemap` (`task test:integration:workspace-uid-remap`, added to CI): negative control (agent user, mismatched workspace owner) fails the writability probe; positive case (via `aileron-remap-agent-uid`) succeeds. Self-skips on non-Linux / no-Docker.
- Local macOS verification (the Go seams + a local `sandbox-base` build): the image builds with the new helper + `shadow`; a traced container run confirms `stat -c` / `usermod` / `groupmod` are present and the helper remaps then drops to `agent` cleanly.

### Caveat

Full end-to-end proof of the DAC reproduction needs a Linux + Docker host (the operator's Fedora box and CI's Linux Docker integration jobs); on macOS Docker Desktop the gRPC-FUSE shim translates mount ownership so the mismatch does not reproduce locally (which is exactly why the integration test is Linux-gated). The local macOS run covers the Go seams and the local `sandbox-base` build only.

Closes #1461

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added workspace UID remapping support for Linux with Docker environments to resolve bind-mount ownership mismatches between host and container.

* **Documentation**
  * Updated sandbox agent image documentation with workspace ownership guidance, remapping requirements, and helper contract specifications.

* **Tests**
  * Added integration tests for workspace UID remapping validation on Linux.
  * Added unit tests for remapping logic and command composition.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->