### PR TITLE
fix(sandbox): remap agent uid without shadow's home-tree chown

### DIFF
--- a/images/sandbox-base/bin/aileron-remap-agent-uid
+++ b/images/sandbox-base/bin/aileron-remap-agent-uid
@@ -60,25 +60,60 @@ if [ -d "$workspace" ]; then
   # Never remap to root (uid 0): the agent must stay unprivileged. A
   # root-owned workspace already grants the agent no less access than before,
   # and remapping the agent to uid 0 would defeat the non-root sandbox model.
+  #
+  # We rewrite /etc/passwd and /etc/group directly rather than calling shadow's
+  # `usermod -u` / `groupmod -g`. shadow's `usermod -u` automatically rewrites
+  # ownership of the ENTIRE home tree (/home/agent) as part of the uid change,
+  # and that walk is NOT prune-aware: it descends into the operator's
+  # bind-mounted workspace at $workspace and prints
+  # "usermod: Failed to change ownership of the home directory" (issue #1467).
+  # Editing the account databases in place changes only the numeric ids; the
+  # deliberate, workspace-pruning re-chown below (the `find ... -prune` block)
+  # then owns the home-scaffolding re-chown without ever touching the workspace.
+  #
+  # remap_field rewrites COLUMN (1-based) of the line whose first colon-field is
+  # `agent` in FILE, replacing it with VALUE. The rewrite is atomic: a sibling
+  # temp file is written then `mv`'d over the target so a crash mid-write can
+  # never leave a truncated account database.
+  remap_field() {
+    file="$1"
+    column="$2"
+    value="$3"
+    tmp="$file.aileron-remap.$$"
+    awk -F: -v OFS=: -v col="$column" -v val="$value" '
+      $1 == "agent" { $col = val }
+      { print }
+    ' "$file" >"$tmp"
+    chmod --reference="$file" "$tmp"
+    mv "$tmp" "$file"
+  }
+
   remap_uid=""
   remap_gid=""
   if [ "$want_gid" != "0" ] && [ "$want_gid" != "$cur_gid" ]; then
-    groupmod -g "$want_gid" -o agent
+    # /etc/group: name:passwd:GID:members — rewrite the agent group's GID.
+    remap_field /etc/group 3 "$want_gid"
+    # /etc/passwd: name:passwd:UID:GID:... — keep the agent user's primary GID
+    # pointed at the agent group's new numeric GID.
+    remap_field /etc/passwd 4 "$want_gid"
     remap_gid="$want_gid"
   fi
   if [ "$want_uid" != "0" ] && [ "$want_uid" != "$cur_uid" ]; then
-    usermod -u "$want_uid" -o agent
+    # /etc/passwd: name:passwd:UID:GID:... — rewrite the agent user's UID.
+    remap_field /etc/passwd 3 "$want_uid"
     remap_uid="$want_uid"
   fi
 
   # Re-assert ownership of the agent's home scaffolding (dotfiles, proxy/CA and
   # manifest dirs) after the remap so the agent still owns them under its new
-  # uid/gid. usermod -u rewrites ownership only for files already owned by the
-  # OLD uid, so this also covers anything created since build time. CRITICAL:
-  # the workspace bind mount lives at $workspace under /home/agent and is the
-  # operator's real host CWD; it must NOT be recursively chowned (that would
-  # rewrite the host project's file ownership, and is unnecessary because the
-  # agent uid was just aligned to the workspace owner). Prune it from the walk.
+  # uid/gid. Because we changed the ids by editing /etc/passwd and /etc/group
+  # directly (not via usermod -u), nothing rewrote home ownership for us, so this
+  # walk is the SOLE re-chown and must cover the agent's home scaffolding.
+  # CRITICAL: the workspace bind mount lives at $workspace under /home/agent and
+  # is the operator's real host CWD; it must NOT be recursively chowned (that
+  # would rewrite the host project's file ownership, and is unnecessary because
+  # the agent uid was just aligned to the workspace owner). Prune it from the
+  # walk.
   if [ -n "$remap_uid" ] || [ -n "$remap_gid" ]; then
     new_uid="${remap_uid:-$cur_uid}"
     new_gid="${remap_gid:-$cur_gid}"

--- a/internal/launch/workspace_uid_remap_integration_test.go
+++ b/internal/launch/workspace_uid_remap_integration_test.go
@@ -38,8 +38,10 @@ import (
 	"context"
 	"os"
 	"os/exec"
+	"path/filepath"
 	"runtime"
 	"strings"
+	"syscall"
 	"testing"
 	"time"
 
@@ -106,6 +108,64 @@ func TestWorkspaceUIDRemap(t *testing.T) {
 		}
 		if got := strings.TrimSpace(stdout); got != "writable" {
 			t.Fatalf("in-container probe output = %q, want %q", got, "writable")
+		}
+	})
+
+	// Regression for #1467: the remap must NOT trigger shadow's non-prune-aware
+	// home-tree chown. Before the fix, the helper called `usermod -u`, whose
+	// built-in ownership walk descended into the bind-mounted workspace and
+	// printed "usermod: Failed to change ownership of the home directory". The
+	// fix rewrites /etc/passwd and /etc/group directly, so no such walk runs.
+	// The remap stderr must be free of any usermod chown-failure noise while the
+	// workspace stays writable.
+	t.Run("remap_emits_no_home_chown_failure", func(t *testing.T) {
+		hostWorkspace := newWorkspaceDir(t, hostUID)
+		stdout, stderr, runErr := runWorkspaceProbe(ctx, rt, hostWorkspace, true, probeCmd)
+		if runErr != nil {
+			t.Fatalf("remap probe failed (host UID %d, agent UID %d): %v\nstderr: %s", hostUID, agentUID, runErr, strings.TrimSpace(stderr))
+		}
+		if got := strings.TrimSpace(stdout); got != "writable" {
+			t.Fatalf("remap probe output = %q, want %q (workspace must stay writable)", got, "writable")
+		}
+		for _, marker := range []string{"usermod", "Failed to change ownership"} {
+			if strings.Contains(stderr, marker) {
+				t.Fatalf("remap stderr contained %q, indicating shadow's non-prune-aware home-tree chown ran (regression #1467):\n%s", marker, strings.TrimSpace(stderr))
+			}
+		}
+	})
+
+	// Regression for #1467: the remap must leave the operator's host files inside
+	// the bind-mounted workspace untouched. A pre-existing file the operator
+	// created in the workspace must retain its host ownership after the remap —
+	// proving the prune-aware re-chown excluded the workspace and that shadow's
+	// recursive home chown (which would rewrite the host project's ownership) did
+	// not run.
+	t.Run("remap_leaves_host_workspace_files_untouched", func(t *testing.T) {
+		hostWorkspace := newWorkspaceDir(t, hostUID)
+		hostFile := filepath.Join(hostWorkspace, "operator-file.txt")
+		if err := os.WriteFile(hostFile, []byte("host content\n"), 0o644); err != nil {
+			t.Fatalf("seed host workspace file: %v", err)
+		}
+		before, err := os.Stat(hostFile)
+		if err != nil {
+			t.Fatalf("stat seeded host file: %v", err)
+		}
+		beforeUID := before.Sys().(*syscall.Stat_t).Uid
+
+		// Run the remap; the command is incidental, the side effect on host
+		// ownership is what we assert.
+		_, stderr, runErr := runWorkspaceProbe(ctx, rt, hostWorkspace, true, "echo done")
+		if runErr != nil {
+			t.Fatalf("remap probe failed: %v\nstderr: %s", runErr, strings.TrimSpace(stderr))
+		}
+
+		after, err := os.Stat(hostFile)
+		if err != nil {
+			t.Fatalf("stat host file after remap: %v", err)
+		}
+		afterUID := after.Sys().(*syscall.Stat_t).Uid
+		if afterUID != beforeUID {
+			t.Fatalf("host workspace file ownership changed by the remap: uid %d -> %d (regression #1467: the workspace bind mount must be pruned from the re-chown and shadow's recursive home chown must not run)", beforeUID, afterUID)
 		}
 	})
 }


### PR DESCRIPTION
## Summary

`aileron-remap-agent-uid` aligns the in-container `agent` uid/gid to the bind-mounted workspace owner so the agent can write the operator's CWD. It did this with shadow's `groupmod -g` / `usermod -u`.

`usermod -u` automatically rewrites ownership of the entire home tree (`/home/agent`) as part of the uid change, and that walk is **not** prune-aware. It descends into the operator's bind-mounted workspace at `/home/agent/workspace` and prints:

```
usermod: Failed to change ownership of the home directory
```

The helper already has a deliberate, prune-aware re-chown (`find /home/agent -path "$workspace" -prune -o -exec chown ...`) that correctly excludes the workspace, but it ran *after* usermod's built-in non-prune-aware chown.

### Fix

Change the agent uid/gid by editing `/etc/passwd` and `/etc/group` directly (atomic temp-file + `mv`), which changes only the numeric ids and never walks the home tree. The existing prune-aware `find` block becomes the sole re-chown of the agent's home scaffolding, excluding the workspace bind mount as intended.

- The rewrite is atomic: awk writes a sibling temp file, `chmod --reference` preserves the original mode, then `mv` swaps it in. A crash mid-write can never truncate an account database. `set -e` aborts before `mv` if awk fails.
- Only the `agent` line is touched (`$1 == "agent"`); all other accounts are printed verbatim.
- The previous `-o` (non-unique id) semantics are preserved naturally — direct edits carry no uniqueness constraint.

Single shell file changed plus the regression test. No OpenAPI/codegen impact.

## Test plan

- Extended the build-tagged integration test `internal/launch/workspace_uid_remap_integration_test.go` (`integration_sandbox`, Linux + Docker only):
  - `remap_emits_no_home_chown_failure` — asserts the remap stderr contains no `usermod` / `Failed to change ownership` string and the workspace stays writable.
  - `remap_leaves_host_workspace_files_untouched` — seeds a host file inside the workspace, runs the remap, and asserts the host file's ownership is unchanged (the prune held and shadow's recursive chown did not run).
- `shellcheck -s sh images/sandbox-base/bin/aileron-remap-agent-uid` — clean.
- Verified the field rewrites locally against synthetic `/etc/passwd` and `/etc/group`: only the agent line changes, UID/GID land in the right columns, other accounts untouched.
- `go vet -tags=integration_sandbox ./internal/launch/...` (darwin + `GOOS=linux`), `go build ./internal/...` and `cmd/aileron` build clean; `go test ./internal/launch/...` green.

The integration path is Linux + Docker only (macOS Docker Desktop translates uids via its file-sharing shim, so the DAC mismatch does not reproduce), so the new assertions execute in CI's sandbox integration job and skip on this dev host. The change keeps the test under the `integration_sandbox` build tag accordingly.

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved UID/GID remapping for sandboxed environments to prevent unintended ownership changes to mounted workspaces.

* **Tests**
  * Added integration test coverage for workspace UID remapping, verifying workspace remains writable and file ownership is properly preserved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->