### PR TITLE
fix(sandbox): republish edge images on merge to main and detect stale base

### DIFF
--- a/.github/workflows/sandbox-agents.yml
+++ b/.github/workflows/sandbox-agents.yml
@@ -11,6 +11,15 @@ name: Sandbox Agent Images
 # and Builder.Validate succeeds (RequireProxyTrust=false, RequireMCPBinary=false,
 # mirroring the #1121/#1083 path). Republish-on-agent-release automation is owned
 # by #1088 and out of scope here.
+#
+# Triggers that PUBLISH:
+#   - push: tags v*       -> latest + release-pinned tags (a release)
+#   - workflow_dispatch   -> edge (the sandbox-agents-watch.yml CLI-drift refresh)
+#   - workflow_run        -> edge, cascaded AFTER the base republishes edge on a
+#                            merge to main, so agents compose onto the fresh base
+#                            and never a stale one (issue #1466). The job-level
+#                            guard restricts this to successful main-branch base
+#                            runs.
 
 on:
   pull_request:
@@ -23,6 +32,15 @@ on:
   push:
     tags:
       - "v*"
+  # Cascade after the base republishes `edge` on a merge to main (issue #1466).
+  # Agents FROM the base, so they must rebuild AFTER the base finishes, never
+  # concurrently: a workflow_run trigger keyed on sandbox-base's completion
+  # guarantees the freshly-republished base:edge is already in GHCR before the
+  # per-agent compose runs, so agents never compose onto a stale base. The
+  # job-level guard below restricts this to successful main-branch base runs.
+  workflow_run:
+    workflows: ["Sandbox Base Image"]
+    types: [completed]
   workflow_dispatch:
 
 permissions:
@@ -36,6 +54,14 @@ jobs:
   build:
     name: Build sandbox-${{ matrix.agent }}
     runs-on: ubuntu-latest
+    # Skip the cascade leg unless the triggering base run SUCCEEDED on main: a
+    # failed or non-main base run must not republish agent edge onto a base that
+    # never shipped. All other triggers (pull_request, v* tag, workflow_dispatch)
+    # run unconditionally. Issue #1466.
+    if: >-
+      github.event_name != 'workflow_run' ||
+      (github.event.workflow_run.conclusion == 'success' &&
+       github.event.workflow_run.head_branch == 'main')
     # Per-agent + per-ref concurrency so the two matrix legs do NOT cancel each
     # other (a workflow-level group keyed only by ref/workflow would, since
     # matrix.agent is out of scope there) and a new push to the same ref + agent
@@ -73,7 +99,7 @@ jobs:
       # build, and the multi-arch push are all authenticated. PRs never touch
       # GHCR (they build the base locally), so login is skipped there.
       - name: Log in to GitHub Container Registry
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
@@ -135,7 +161,12 @@ jobs:
           set -euo pipefail
           if [[ "${GITHUB_REF}" == refs/tags/v* ]]; then
             BASE_REF="${BASE_IMAGE_NAME}:${GITHUB_REF#refs/tags/}"
-          elif [[ "${{ github.event_name }}" == "workflow_dispatch" ]]; then
+          elif [[ "${{ github.event_name }}" == "workflow_dispatch" || "${{ github.event_name }}" == "workflow_run" ]]; then
+            # workflow_dispatch (watcher refresh) and workflow_run (the merge-to-
+            # main cascade, issue #1466) both FROM the base `edge` tag the base
+            # workflow just republished. On the cascade the base run that
+            # triggered us has already completed its multi-arch push, so `edge`
+            # is present and the poll below returns immediately.
             BASE_REF="${BASE_IMAGE_NAME}:edge"
           else
             BASE_REF=""
@@ -227,7 +258,7 @@ jobs:
             type=raw,value=${{ steps.ver.outputs.version }}-${{ steps.cli.outputs.version }}
             type=sha,prefix=git-
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=edge,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=edge,enable=${{ github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' }}
           labels: |
             org.opencontainers.image.title=Aileron sandbox ${{ matrix.agent }}
             org.opencontainers.image.description=Aileron sandbox base composed with the ${{ matrix.agent }} agent CLI Feature.
@@ -240,7 +271,7 @@ jobs:
       # the repo root so the Containerfile's COPY of images/sandbox-features
       # resolves.
       - name: Build and push image
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' }}
         uses: docker/build-push-action@v7
         with:
           context: .
@@ -259,7 +290,7 @@ jobs:
       # RequireMCPBinary=false), exactly as the launcher validates it
       # (#1121/#1083 path).
       - name: Smoke test loaded image
-        if: ${{ !(startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch') }}
+        if: ${{ !(startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run') }}
         run: task test:integration:sandbox-agent-image
         env:
           AILERON_SANDBOX_AGENT_IMAGE: aileron-sandbox-${{ matrix.agent }}:smoke
@@ -272,7 +303,7 @@ jobs:
       # multi-arch manifest selection — not just the locally-loaded :smoke
       # image, so a real v* release validates the exact artifact consumers pull.
       - name: Smoke test published image
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || github.event_name == 'workflow_run' }}
         run: |
           set -euo pipefail
           PUSHED_REF="ghcr.io/alrubinger/aileron-sandbox-${{ matrix.agent }}:${{ steps.ver.outputs.version }}-${{ steps.cli.outputs.version }}"

--- a/.github/workflows/sandbox-base.yml
+++ b/.github/workflows/sandbox-base.yml
@@ -17,6 +17,20 @@ on:
   push:
     tags:
       - "v*"
+    # Merge to main republishes `edge` so dev/main consumers (which pull `edge`
+    # per imageTag resolution in internal/sandbox/composition/composition.go)
+    # never run against a base image older than the in-repo image source. Reuse
+    # the PR `paths` filter so only image-affecting merges trigger a republish.
+    # Issue #1466.
+    branches: [main]
+    paths:
+      - ".github/workflows/sandbox-base.yml"
+      - "images/sandbox-base/**"
+      - "cmd/aileron-mcp/**"
+      - "internal/**"
+      - "sdk/go/**"
+      - "go.work"
+      - "go.work.sum"
   workflow_dispatch:
 
 permissions:
@@ -80,22 +94,24 @@ jobs:
             type=ref,event=tag
             type=sha,prefix=git-
             type=raw,value=latest,enable=${{ startsWith(github.ref, 'refs/tags/v') }}
-            type=raw,value=edge,enable=${{ github.event_name == 'workflow_dispatch' }}
+            type=raw,value=edge,enable=${{ github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
           labels: |
             org.opencontainers.image.title=Aileron sandbox base
             org.opencontainers.image.description=Minimal sandbox substrate for Aileron-managed agent containers.
 
       - name: Log in to GitHub Container Registry
-        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}
+        if: ${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}
         uses: docker/login-action@v4
         with:
           registry: ghcr.io
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
+      # Publish on v* tags (latest + release), manual dispatch (edge), and merge
+      # to main (edge republish, issue #1466).
       - name: Resolve publish flag
         id: publish
-        run: echo "publish=${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' }}" >> "$GITHUB_OUTPUT"
+        run: echo "publish=${{ startsWith(github.ref, 'refs/tags/v') || github.event_name == 'workflow_dispatch' || (github.event_name == 'push' && github.ref == 'refs/heads/main') }}" >> "$GITHUB_OUTPUT"
 
       # Node + @devcontainers/cli, pinned to match ci.yml and
       # sandbox-features.yml so the three workflows stay aligned (umbrella #1319).

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -38,7 +38,7 @@ With no `.devcontainer` in the project, `aileron launch --sandbox=docker <agent>
 
 `sandbox check --agent=<agent>` resolves the same image, so a passing check matches what launch will run.
 
-The launcher resolves the image for this build-free default in two ways. A release build with a recorded digest pin pulls a fixed image by `@sha256` (see [Reproducible releases](#reproducible-releases-digest-pinning) below). Otherwise it resolves a floating tag: a release build with no recorded pin pulls `latest` (which the image workflows move only on a `v*` tag), and a dev build off `main` pulls `edge` (published on `workflow_dispatch`). So `latest` always names the most recent release and a dev run never clobbers it. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so the floating tag is the fallback when no digest is pinned. The freshness policy that keeps `edge` current is owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088).
+The launcher resolves the image for this build-free default in two ways. A release build with a recorded digest pin pulls a fixed image by `@sha256` (see [Reproducible releases](#reproducible-releases-digest-pinning) below). Otherwise it resolves a floating tag: a release build with no recorded pin pulls `latest` (which the image workflows move only on a `v*` tag), and a dev build off `main` pulls `edge` (republished on every merge to `main` that touches the image source, and on `workflow_dispatch`). So `latest` always names the most recent release and a dev run never clobbers it. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so the floating tag is the fallback when no digest is pinned. The freshness policy that keeps `edge` current is owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088).
 
 When the requested agent has no published image, launch falls back to the customization tier. The image validation then emits the actionable message to install the agent CLI in the sandbox image or launch with `--local`.
 
@@ -55,14 +55,16 @@ Each image is built for `linux/amd64` and `linux/arm64`, so a `docker pull` reso
 
 The base image (`sandbox-base.yml`) and the per-agent images (`sandbox-agents.yml`) are two separate workflows, both triggered directly by a `v*` tag push, so they run concurrently on the same tag. A per-agent build `FROM`s the version-pinned base tag, so before that `FROM` it waits for the base tag to publish: it polls the registry on a bounded retry loop until the concurrently-building base tag appears. A base that never publishes surfaces a precise timeout error naming the absent tag rather than failing mid-build.
 
-The tag scheme is `<aileron-version>-<agent-cli-version>` plus two floating tags: `latest`, moved only by a `v*` tag release, and `edge`, moved by a `workflow_dispatch` publish off `main`. The `<aileron-version>` is the Aileron release the image was built from. The `<agent-cli-version>` is the agent CLI version baked into the image, resolved at build time from the installed package. A git-traceability tag `git-<sha>` is also published.
+On a merge to `main` the two workflows run in sequence rather than concurrently. The base workflow runs on the `main` push (filtered to image-affecting paths) and republishes `base:edge`. The per-agent workflow then runs as a `workflow_run` cascade keyed on the base workflow's completion, so it starts only after the base finishes its multi-arch push and composes the agents onto the freshly republished `base:edge`, never a stale one. The cascade leg runs only when the triggering base run succeeded on `main`. This keeps the image source and the `edge` tags in lockstep, so an in-repo change to the image (for example a new in-image entrypoint helper) cannot leave dev/main consumers pulling a base that predates it.
+
+The tag scheme is `<aileron-version>-<agent-cli-version>` plus two floating tags: `latest`, moved only by a `v*` tag release, and `edge`, republished on every merge to `main` that touches the image source and on a `workflow_dispatch`. The `<aileron-version>` is the Aileron release the image was built from. The `<agent-cli-version>` is the agent CLI version baked into the image, resolved at build time from the installed package. A git-traceability tag `git-<sha>` is also published.
 
 Pull the most recent release (`latest`), or the latest dev publish off `main` (`edge`):
 
 ```bash
 docker pull ghcr.io/alrubinger/aileron-sandbox-claude:latest
 docker pull ghcr.io/alrubinger/aileron-sandbox-codex:latest
-# tip of main, published on workflow_dispatch:
+# tip of main, republished on every image-affecting merge to main:
 docker pull ghcr.io/alrubinger/aileron-sandbox-claude:edge
 ```
 

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -47,6 +47,13 @@ const DefaultRuntime = "auto"
 const WorkspacePath = "/home/agent/workspace"
 const AgentImagesDocsURL = "https://docs.withaileron.ai/development/sandbox-agent-images/"
 
+// remapAgentUIDHelper is the in-image entrypoint helper (shipped by
+// images/sandbox-base) the remap-enabled launch/validate path prepends as the
+// container command so the agent uid is remapped to the workspace owner before
+// the agent starts (issue #1461). Centralized here so the validate prepend and
+// the stale-image diagnostic in Validate name the exact same binary.
+const remapAgentUIDHelper = "aileron-remap-agent-uid"
+
 // WorkspaceUIDRemapActive reports whether a launch/validate against runtimeName
 // should route the container through the aileron-remap-agent-uid entrypoint to
 // align the in-container agent uid/gid with the workspace owner. The DAC uid
@@ -693,7 +700,7 @@ func (b Builder) Validate(ctx context.Context, opts ValidateOptions) error {
 	user := ""
 	if opts.RemapWorkspaceUID {
 		user = "root"
-		command = append([]string{"aileron-remap-agent-uid", "su-exec", "agent"}, command...)
+		command = append([]string{remapAgentUIDHelper, "su-exec", "agent"}, command...)
 	}
 	_, err := builder.Run(ctx, RunOptions{
 		Runtime: opts.Runtime,
@@ -708,11 +715,43 @@ func (b Builder) Validate(ctx context.Context, opts ValidateOptions) error {
 		return nil
 	}
 	detail := strings.TrimSpace(stderr.String())
+	// A remap-enabled validate prepends aileron-remap-agent-uid as the literal
+	// container command (see above). When the image predates the entrypoint
+	// contract and lacks that helper, the image's tini entrypoint fails to exec
+	// it (exit 127) BEFORE the validation script ever runs, so none of the
+	// script's friendly diagnostics are produced. Detect that tini exec-failure
+	// signature and translate it into an actionable message naming the stale
+	// image, instead of letting the opaque tini error reach the launcher. See
+	// issue #1466.
+	if opts.RemapWorkspaceUID && missingEntrypointHelperSignature(detail) {
+		return fmt.Errorf("validate sandbox image %s: %s: %w", opts.Image, staleEntrypointContractMessage, err)
+	}
 	if detail != "" {
 		detail = sandboxValidationDetail(detail)
 		return fmt.Errorf("validate sandbox image %s: %s: %w", opts.Image, detail, err)
 	}
 	return fmt.Errorf("validate sandbox image %s: image must support /bin/sh command execution, a writable %s workspace mount, and agent command %q on PATH; see %s: %w", opts.Image, WorkspacePath, opts.Command[0], AgentImagesDocsURL, err)
+}
+
+// staleEntrypointContractMessage is surfaced when a remap-enabled launch hits a
+// sandbox image whose tini entrypoint cannot exec the aileron-remap-agent-uid
+// helper because the image predates the launcher's in-image entrypoint
+// contract. It tells the operator the concrete remedy: rebuild the edge images.
+const staleEntrypointContractMessage = "sandbox image predates this launcher's entrypoint contract: the in-image " +
+	remapAgentUIDHelper + " helper is missing, so the container entrypoint fails before launch. " +
+	"Rebuild the base+agent edge images (or pull a newer edge tag); see " + AgentImagesDocsURL
+
+// missingEntrypointHelperSignature reports whether the container runtime's
+// stderr carries the tini exec-failure signature emitted when PID 1 cannot
+// exec the aileron-remap-agent-uid helper (the helper is absent from a stale
+// image). tini prints `exec <prog> failed: No such file or directory` and
+// exits 127; matching the helper name plus the "exec ... failed" framing keeps
+// this from firing on unrelated stderr that merely mentions the helper.
+func missingEntrypointHelperSignature(stderr string) bool {
+	lowered := strings.ToLower(stderr)
+	return strings.Contains(lowered, "exec "+remapAgentUIDHelper+" failed") ||
+		(strings.Contains(lowered, remapAgentUIDHelper) &&
+			strings.Contains(lowered, "no such file or directory"))
 }
 
 func sandboxValidationDetail(detail string) string {

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -1233,6 +1233,70 @@ func TestValidateReportsActionableRuntimeFailure(t *testing.T) {
 	}
 }
 
+// TestValidateReportsStaleEntrypointContract reproduces the issue #1466 failure
+// class: a remap-enabled validate prepends aileron-remap-agent-uid as the
+// container command, but the image predates the entrypoint contract and lacks
+// that helper, so the image's tini entrypoint fails to exec it (exit 127) with
+// the tini "exec <prog> failed: No such file or directory" signature before the
+// validation script runs. Validate must translate that into an actionable
+// rebuild-edge message instead of surfacing the opaque tini error.
+func TestValidateReportsStaleEntrypointContract(t *testing.T) {
+	runner := runnerFunc(func(_ context.Context, _ string, _ []string, _, stderr io.Writer) error {
+		// Verbatim tini diagnostic when PID 1 cannot exec its child.
+		_, _ = stderr.Write([]byte("[FATAL tini (8)] exec aileron-remap-agent-uid failed: No such file or directory\n"))
+		return errors.New("exit status 127")
+	})
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Image:             "ghcr.io/alrubinger/aileron-sandbox-claude:edge",
+		WorkDir:           t.TempDir(),
+		Command:           []string{"claude"},
+		RemapWorkspaceUID: true,
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	msg := err.Error()
+	for _, want := range []string{
+		"validate sandbox image ghcr.io/alrubinger/aileron-sandbox-claude:edge",
+		"predates this launcher's entrypoint contract",
+		"aileron-remap-agent-uid",
+		"Rebuild the base+agent edge images",
+		AgentImagesDocsURL,
+	} {
+		if !strings.Contains(msg, want) {
+			t.Fatalf("error %q does not contain %q", msg, want)
+		}
+	}
+	// The opaque tini line must not be the headline diagnostic; the actionable
+	// remedy replaces it.
+	if strings.Contains(msg, "[FATAL tini") {
+		t.Fatalf("error should not surface the raw tini diagnostic, got %q", msg)
+	}
+}
+
+// TestValidateStaleEntrypointSignatureRequiresRemap guards the gate: the
+// stale-entrypoint translation only fires on the remap path. A non-remap
+// validate that happens to see the helper name in stderr must fall through to
+// the verbatim-detail path, not the rebuild-edge message.
+func TestValidateStaleEntrypointSignatureRequiresRemap(t *testing.T) {
+	runner := runnerFunc(func(_ context.Context, _ string, _ []string, _, stderr io.Writer) error {
+		_, _ = stderr.Write([]byte("exec aileron-remap-agent-uid failed: No such file or directory\n"))
+		return errors.New("exit status 127")
+	})
+	err := Builder{Runtime: "docker", Runner: runner}.Validate(context.Background(), ValidateOptions{
+		Image:   "ghcr.io/acme/agent:latest",
+		WorkDir: t.TempDir(),
+		Command: []string{"codex"},
+		// RemapWorkspaceUID intentionally false.
+	})
+	if err == nil {
+		t.Fatal("expected validation error")
+	}
+	if strings.Contains(err.Error(), "predates this launcher's entrypoint contract") {
+		t.Fatalf("non-remap validate must not emit the stale-entrypoint message, got %q", err.Error())
+	}
+}
+
 func TestValidateRejectsMissingImage(t *testing.T) {
 	err := Builder{Runtime: "docker", Runner: &recordingRunner{}}.Validate(context.Background(), ValidateOptions{
 		Command: []string{"codex"},


### PR DESCRIPTION
## Summary

Closes the failure class in #1466: dev/main consumers pulling a base sandbox image whose source has advanced past the published `edge` tag, surfacing as an opaque tini exit-127 when the in-image `aileron-remap-agent-uid` entrypoint helper is absent.

Root cause: both sandbox image workflows only published `edge` on `workflow_dispatch`, and the only automated edge refresh (`sandbox-agents-watch.yml`) fires solely on upstream npm CLI drift. An in-repo image-source change (e.g. #1464 adding the `aileron-remap-agent-uid` helper) never moved `edge`, so source↔edge skew shipped the launcher a base image missing the entrypoint helper it now requires. The remap-enabled validate path prepends that helper as the literal container command; when it is missing, the image's tini entrypoint fails to exec it (exit 127) before the validation script runs, so no friendly diagnostic is produced.

### Part A (CI)
- `sandbox-base.yml`: added a `push: branches:[main]` trigger reusing the PR `paths` filter; broadened the `edge` enable + login + publish gating to recognize the main-push path. (Per GitHub docs, `paths` filters are not evaluated for tag pushes, so the existing `v*` release publish is unaffected.)
- `sandbox-agents.yml`: cascades AFTER base via a `workflow_run` trigger keyed on the "Sandbox Base Image" workflow's completion, gated at the job level to `conclusion == success && head_branch == main`, so the base→agents FROM ordering is honored and agents compose onto the freshly-republished `base:edge`. Broadened the login/publish gating, the `edge` enable, the smoke-test gating, and the base-resolution `edge` branch to recognize the cascade.

### Part B (Go)
- `Builder.Validate` detects the tini exec-failure signature for the missing `aileron-remap-agent-uid` helper (gated to the remap path) and emits an actionable message ("sandbox image predates this launcher's entrypoint contract ... Rebuild the base+agent edge images") instead of the opaque tini error.
- Centralized the `aileron-remap-agent-uid` literal into a package constant so the validate prepend and the diagnostic name the same binary.

Docs: updated `sandbox-agent-images.md` to describe the merge-to-main edge republish and the base→agents cascade.

## Test plan
- `go build ./...` — green.
- `go test ./...` (internal module) — green.
- New regression tests in `internal/sandbox/container/runtime_test.go`:
  - `TestValidateReportsStaleEntrypointContract` reproduces the exit-127 tini path (`[FATAL tini ...] exec aileron-remap-agent-uid failed: No such file or directory`) and asserts the new actionable message; verified failing before the fix and passing after.
  - `TestValidateStaleEntrypointSignatureRequiresRemap` guards that the translation only fires on the remap path.
- `Validate` branch and `missingEntrypointHelperSignature` at 100% line coverage; container package total 91.9%.
- `actionlint` clean on both changed workflows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
