### PR TITLE
fix(sandbox): tolerate read-only launcher mounts in agent-uid remap

### DIFF
--- a/images/sandbox-base/bin/aileron-remap-agent-uid
+++ b/images/sandbox-base/bin/aileron-remap-agent-uid
@@ -105,20 +105,33 @@ if [ -d "$workspace" ]; then
   fi
 
   # Re-assert ownership of the agent's home scaffolding (dotfiles, proxy/CA and
-  # manifest dirs) after the remap so the agent still owns them under its new
-  # uid/gid. Because we changed the ids by editing /etc/passwd and /etc/group
-  # directly (not via usermod -u), nothing rewrote home ownership for us, so this
-  # walk is the SOLE re-chown and must cover the agent's home scaffolding.
-  # CRITICAL: the workspace bind mount lives at $workspace under /home/agent and
-  # is the operator's real host CWD; it must NOT be recursively chowned (that
-  # would rewrite the host project's file ownership, and is unnecessary because
-  # the agent uid was just aligned to the workspace owner). Prune it from the
-  # walk.
+  # manifest dirs) plus the launcher-managed WRITABLE mounts the agent must own
+  # under its new id — the host-chowned auth trees and fresh, root-owned Docker
+  # named cache volumes. Because we changed the ids by editing /etc/passwd and
+  # /etc/group directly (not via usermod -u), nothing rewrote home ownership for
+  # us, so this walk is the SOLE re-chown.
+  #
+  # It chowns EVERYTHING under /home/agent except the workspace, and tolerates
+  # per-entry chown failures:
+  #   - Prune $workspace: it is the operator's real host CWD; recursively
+  #     chowning it would rewrite the host project's ownership (and is
+  #     unnecessary — the agent id was just aligned to the workspace owner).
+  #   - Do NOT scope the walk by current ownership. The launcher mounts fresh
+  #     Docker named cache volumes under /home/agent that come up root-owned, and
+  #     the now-non-root agent must own them to use its cache. An owner-scoped
+  #     walk (e.g. only entries already owned by the old agent id) would skip
+  #     those root-owned mounts and silently break the cache.
+  #   - Tolerate failures (`2>/dev/null || true`): the launcher also bind-mounts
+  #     read-only files under /home/agent (.claude.json, .gitconfig today; codex's
+  #     config tomorrow — issue #1467). chowning a read-only mount fails EROFS,
+  #     which under `set -e` would otherwise abort the entrypoint before the agent
+  #     starts. Those mounts are host-managed and need no in-container re-chown,
+  #     so a failed chown must not fail the launch.
   if [ -n "$remap_uid" ] || [ -n "$remap_gid" ]; then
     new_uid="${remap_uid:-$cur_uid}"
     new_gid="${remap_gid:-$cur_gid}"
     find /home/agent -path "$workspace" -prune -o \
-      -exec chown -h "$new_uid:$new_gid" {} +
+      -exec chown -h "$new_uid:$new_gid" {} + 2>/dev/null || true
   fi
 fi
 

--- a/internal/launch/workspace_uid_remap_integration_test.go
+++ b/internal/launch/workspace_uid_remap_integration_test.go
@@ -36,6 +36,7 @@ package launch
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"os"
 	"os/exec"
 	"path/filepath"
@@ -168,6 +169,58 @@ func TestWorkspaceUIDRemap(t *testing.T) {
 			t.Fatalf("host workspace file ownership changed by the remap: uid %d -> %d (regression #1467: the workspace bind mount must be pruned from the re-chown and shadow's recursive home chown must not run)", beforeUID, afterUID)
 		}
 	})
+
+	// Regression for #1467 (facet 2): the launcher bind-mounts read-only config
+	// files directly under /home/agent (.claude.json, .gitconfig today; codex's
+	// config tomorrow), owned by the image agent uid. The remap's re-chown of the
+	// home scaffolding must tolerate them: chowning a read-only mount fails EROFS,
+	// which under the helper's `set -e` aborted the entrypoint before the agent
+	// started (exit 1, "chown: ... Read-only file system"). The fix tolerates the
+	// failed chown (the re-chown suppresses per-entry errors). With such a mount
+	// present the probe must still succeed and the remap stderr must carry no
+	// chown error.
+	t.Run("remap_tolerates_readonly_home_mounts", func(t *testing.T) {
+		hostWorkspace := newWorkspaceDir(t, hostUID)
+		// A read-only file at its real launcher target under /home/agent. The
+		// re-chown walks all of /home/agent (except the pruned workspace), so it
+		// attempts to chown this mount; pre-fix that EROFS aborted the launch.
+		roFile := seedAgentOwnedFile(ctx, t, rt, ".claude.json")
+		mount := roFile + ":/home/agent/.claude.json:ro"
+		stdout, stderr, runErr := runWorkspaceProbe(ctx, rt, hostWorkspace, true, probeCmd, mount)
+		if runErr != nil {
+			t.Fatalf("remap probe failed with a read-only home mount present (host UID %d, agent UID %d): %v\nstderr: %s\nRegression #1467 facet 2: the re-chown must tolerate read-only launcher bind mounts under /home/agent rather than abort the entrypoint.", hostUID, agentUID, runErr, strings.TrimSpace(stderr))
+		}
+		if got := strings.TrimSpace(stdout); got != "writable" {
+			t.Fatalf("remap probe output = %q, want %q (workspace must stay writable with a read-only home mount present)", got, "writable")
+		}
+		for _, marker := range []string{"chown:", "Read-only file system"} {
+			if strings.Contains(stderr, marker) {
+				t.Fatalf("remap stderr contained %q, indicating the re-chown choked on the read-only home mount (regression #1467 facet 2):\n%s", marker, strings.TrimSpace(stderr))
+			}
+		}
+	})
+
+	// Regression for #1467 (cache-volume facet caught in review): the launcher
+	// mounts fresh Docker named cache volumes under /home/agent that come up
+	// ROOT-owned; the remap must re-chown them to the new agent id so the
+	// non-root agent can use its cache. An owner-scoped re-chown would skip a
+	// root-owned mount and silently break the cache, so the re-chown must NOT be
+	// owner-scoped. Assert the remapped agent can WRITE a root-owned writable
+	// mount under /home/agent.
+	t.Run("remap_rechowns_root_owned_writable_mount", func(t *testing.T) {
+		hostWorkspace := newWorkspaceDir(t, hostUID)
+		cacheDir := seedRootOwnedDir(ctx, t, rt)
+		// Writable (no :ro), at a cache-like path under /home/agent.
+		mount := cacheDir + ":/home/agent/.cache/aileron-remap-test"
+		cmd := "probe=/home/agent/.cache/aileron-remap-test/.w-$$; : > \"$probe\" && rm -f \"$probe\" && echo writable"
+		stdout, stderr, runErr := runWorkspaceProbe(ctx, rt, hostWorkspace, true, cmd, mount)
+		if runErr != nil {
+			t.Fatalf("remap probe could not write a root-owned mount under /home/agent (host UID %d, agent UID %d): %v\nstderr: %s\nRegression #1467: the remap must re-chown root-owned writable mounts (fresh named cache volumes) to the agent; an owner-scoped re-chown would skip them.", hostUID, agentUID, runErr, strings.TrimSpace(stderr))
+		}
+		if got := strings.TrimSpace(stdout); got != "writable" {
+			t.Fatalf("remap probe output = %q, want %q (agent must be able to write a remapped root-owned mount)", got, "writable")
+		}
+	})
 }
 
 // buildWorkspaceRemapBaseImage builds the sandbox-base image under a dedicated
@@ -209,16 +262,74 @@ func newWorkspaceDir(t *testing.T, ownerUID int) string {
 	return dir
 }
 
+// runRootInSeedDir runs `script` as root in a throwaway container with dir
+// bind-mounted at /seed. It exists because the unprivileged test runner cannot
+// set up fixture ownership itself (chown to a foreign uid/gid).
+func runRootInSeedDir(ctx context.Context, t *testing.T, rt, dir, script string) {
+	t.Helper()
+	var out bytes.Buffer
+	c := exec.CommandContext(ctx, rt,
+		"run", "--rm", "--user", "0",
+		"--volume", dir+":/seed",
+		workspaceRemapTestImage,
+		"/bin/sh", "-c", script,
+	)
+	c.Stdout = &out
+	c.Stderr = &out
+	if err := c.Run(); err != nil {
+		t.Fatalf("root seed container failed (%s): %v\n%s", script, err, strings.TrimSpace(out.String()))
+	}
+}
+
+// seedAgentOwnedFile creates a 0644 file named `name`, owned by the image agent
+// user, inside a fresh 0755 temp dir, and returns its host path. `chown
+// agent:agent` resolves the agent user's numeric uid:gid from the image's own
+// passwd/group. This models the launcher's read-only config mounts
+// (.claude.json/.gitconfig), which it owns to the image agent user.
+func seedAgentOwnedFile(ctx context.Context, t *testing.T, rt, name string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod seed dir 0755: %v", err)
+	}
+	runRootInSeedDir(ctx, t, rt, dir, fmt.Sprintf(
+		"printf '{}\\n' > /seed/%[1]s && chown agent:agent /seed/%[1]s && chmod 0644 /seed/%[1]s", name))
+	return filepath.Join(dir, name)
+}
+
+// seedRootOwnedDir returns a fresh 0755 temp dir chowned to root:root via a root
+// container, modelling a fresh Docker named cache volume (which comes up
+// root-owned when its path is not pre-created in the image). It registers a
+// cleanup that restores test-runner ownership so the temp-dir RemoveAll — run by
+// the unprivileged runner — can delete the tree even if the remap (or a failing
+// assertion) left it root-owned.
+func seedRootOwnedDir(ctx context.Context, t *testing.T, rt string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.Chmod(dir, 0o755); err != nil {
+		t.Fatalf("chmod seed dir 0755: %v", err)
+	}
+	runRootInSeedDir(ctx, t, rt, dir, "chown 0:0 /seed")
+	t.Cleanup(func() {
+		runRootInSeedDir(context.WithoutCancel(ctx), t, rt, dir,
+			fmt.Sprintf("chown -R %d:%d /seed", os.Getuid(), os.Getgid()))
+	})
+	return dir
+}
+
 // runWorkspaceProbe runs a one-shot container with hostWorkspace bind-mounted
 // WRITABLE at the sandbox WorkspacePath and runs cmd. When remap is true it
 // routes through `aileron-remap-agent-uid su-exec agent /bin/sh -c cmd` as root
 // (the production launch chain for the non-proxy path); otherwise it runs as the
 // image default agent user. Returns stdout, stderr, and the run error.
-func runWorkspaceProbe(ctx context.Context, rt, hostWorkspace string, remap bool, cmd string) (string, string, error) {
+func runWorkspaceProbe(ctx context.Context, rt, hostWorkspace string, remap bool, cmd string, extraMounts ...string) (string, string, error) {
 	args := []string{
 		"run", "--rm",
 		"--workdir", sandboxcontainer.WorkspacePath,
 		"--volume", hostWorkspace + ":" + sandboxcontainer.WorkspacePath,
+	}
+	for _, m := range extraMounts {
+		args = append(args, "--volume", m)
 	}
 	if remap {
 		args = append(args, "--user", "0", workspaceRemapTestImage,


### PR DESCRIPTION
## Summary

Fixes the second (and final) facet of #1467: `aileron launch claude` on Linux+Docker died with `chown: changing ownership of '/home/agent/.claude.json': Read-only file system` (exit 1) — the entrypoint aborted before `exec`, so the agent never started.

## Root cause

`aileron-remap-agent-uid` re-owns the agent's home scaffolding after aligning the agent uid/gid to the workspace owner. That re-chown walked **all** of `/home/agent` (pruning only the workspace) and ran under `set -e`, so the first `chown` on a launcher-mounted **read-only** file under `/home/agent` (`.claude.json`, `.gitconfig`, both `ReadOnly: true`) failed EROFS and aborted the entrypoint before `exec "$@"`.

(Facet 1 — shadow `usermod -u`'s non-prune-aware home-tree chown — was already fixed on `main` by switching to direct `/etc/passwd`/`/etc/group` edits.)

## Fix

Tolerate per-entry chown failures so a read-only launcher mount can no longer fail the launch:

```diff
     find /home/agent -path "$workspace" -prune -o \
-      -exec chown -h "$new_uid:$new_gid" {} +
+      -exec chown -h "$new_uid:$new_gid" {} + 2>/dev/null || true
```

The walk deliberately stays **un-scoped** (it still chowns everything under `/home/agent` except the workspace): the agent must own not just its build-time scaffolding but also launcher-managed **writable** mounts — the host-chowned auth trees and fresh, **root-owned** Docker named cache volumes (`sandboxCacheVolumes`). An owner-scoped walk would skip those root-owned mounts and silently break the cache.

> Note: an earlier revision of this PR scoped the walk to old-agent-owned entries; the pre-PR review caught that this regresses root-owned named cache volumes vs. `main`, so the scoping was dropped in favor of failure tolerance alone.

## Tests

Two integration regressions added to `TestWorkspaceUIDRemap` (6 subtests total, green on Fedora rootful Docker, host uid 1000 / agent uid 100):
- `remap_tolerates_readonly_home_mounts` — read-only agent-owned file under `/home/agent`; remap must still succeed (fails before the fix: exit 1 EROFS).
- `remap_rechowns_root_owned_writable_mount` — root-owned writable dir under `/home/agent`; the remapped agent must be able to write it (guards against re-introducing owner-scoping).

## Validation

- Integration suite green (all 6 subtests).
- End-to-end: `aileron launch claude` against an `:edge` image overlaid with the fix brings up Claude Code with no chown error.
- Pre-PR review: CodeRabbit + local multi-agent code review; all actionable findings (incl. the cache-volume regression above) resolved.

Closes #1467

🤖 Generated with [Claude Code](https://claude.com/claude-code)
