### PR TITLE
fix(server): bind docker bridge-gateway IP so sandbox can reach daemon on Linux

### DIFF
--- a/docs/src/content/docs/adr/0012-local-daemon-architecture.md
+++ b/docs/src/content/docs/adr/0012-local-daemon-architecture.md
@@ -57,6 +57,8 @@ http://127.0.0.1:54321
 
 Clients (CLI and launch) read `daemon.url` to find the daemon. `AILERON_API_URL` overrides remain available as a developer/test escape hatch but are not the primary mechanism.
 
+On **Linux with Docker**, the daemon additionally binds the Docker bridge-gateway IP (the host end of `docker0`, what `host-gateway` resolves to) on the *same* ephemeral port, serving the same token-protected handler. Without it a sandbox container cannot reach the daemon: the launcher rewrites the loopback URL to `host.docker.internal`, which `--add-host host.docker.internal:host-gateway` resolves to the bridge-gateway IP rather than loopback, so a loopback-only daemon refuses the container's connection. The advertised `daemon.url` stays the `127.0.0.1` URL (the launcher does the loopback→`host.docker.internal` rewrite per runtime); the bridge listener is gated by the same daemon token, never bound on macOS/Windows (Docker Desktop forwards `host.docker.internal` to loopback) or on non-Docker Linux, and a failed gateway derivation is a hard startup error rather than a silent wider bind.
+
 Why TCP and not a unix socket:
 
 - **The browser cannot speak unix sockets.** The webapp — including the vault unlock modal ratified in #429 — is HTTP. The daemon must expose HTTP on a port a browser can navigate to.

--- a/internal/server/bridge.go
+++ b/internal/server/bridge.go
@@ -1,0 +1,178 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"fmt"
+	"net"
+	"os/exec"
+	goruntime "runtime"
+	"strings"
+	"time"
+)
+
+// dockerBridgeProbeTimeout bounds the `docker network inspect` /
+// `ip route` subprocess calls used to derive the bridge-gateway IP. The
+// daemon must not hang at startup if the Docker daemon is unresponsive.
+const dockerBridgeProbeTimeout = 5 * time.Second
+
+// Indirections over package-level dependencies so unit tests can drive
+// the derivation logic without a real Docker daemon. Production wires
+// these to the real OS / Docker.
+var (
+	// hostGOOS is runtime.GOOS behind a seam so tests can simulate
+	// non-Linux hosts (where no bridge bind is needed).
+	hostGOOS = func() string { return goruntime.GOOS }
+	// dockerNetworkInspectBridge returns the raw stdout of
+	// `docker network inspect bridge`. Returns an error when Docker is
+	// absent or the command fails.
+	dockerNetworkInspectBridge = realDockerNetworkInspectBridge
+	// docker0RouteGateway returns the bridge-gateway IP derived from the
+	// host's route to the docker0 interface, used as a fallback when
+	// `docker network inspect` yields no usable gateway.
+	docker0RouteGateway = realDocker0RouteGateway
+	// dockerOnPath reports whether a `docker` binary is resolvable on
+	// PATH. Behind a seam so the bridge-bind regression test can force
+	// the Linux+Docker path without a real Docker install.
+	dockerOnPath = func() bool {
+		_, err := exec.LookPath("docker")
+		return err == nil
+	}
+)
+
+// bridgeBindNeeded reports whether this host needs a second listener on
+// the Docker bridge-gateway IP for in-container reachability.
+//
+// Only Linux+Docker needs it: there `host.docker.internal` resolves
+// (via `--add-host host.docker.internal:host-gateway`) to the bridge
+// gateway IP, NOT loopback, so a loopback-only daemon is unreachable
+// from the sandbox container. On macOS / Windows, Docker Desktop
+// forwards `host.docker.internal` to the host loopback, so the existing
+// 127.0.0.1 listener already covers the container path and no second
+// bind is needed. Non-Docker Linux likewise needs nothing.
+func bridgeBindNeeded() bool {
+	if hostGOOS() != "linux" {
+		return false
+	}
+	return dockerOnPath()
+}
+
+// deriveDockerBridgeGatewayIP returns the Docker default-bridge gateway
+// IP (the host end of docker0, what `host-gateway` resolves to on
+// Linux). It tries `docker network inspect bridge` first (authoritative:
+// the gateway Docker actually configured), falling back to the host's
+// route to the docker0 interface.
+//
+// A failed derivation is returned as an error: per the issue the daemon
+// must fail loud and actionable rather than silently binding wider
+// (e.g. 0.0.0.0). Callers gate this behind [bridgeBindNeeded] so it only
+// runs on Linux+Docker.
+func deriveDockerBridgeGatewayIP(ctx context.Context) (string, error) {
+	ip, primaryErr := bridgeGatewayFromNetworkInspect(ctx)
+	if primaryErr == nil {
+		return ip, nil
+	}
+
+	ip, fallbackErr := docker0RouteGateway(ctx)
+	if fallbackErr == nil {
+		return ip, nil
+	}
+
+	return "", fmt.Errorf("derive docker bridge-gateway IP: docker network inspect bridge failed (%v) and docker0 route fallback failed (%v); "+
+		"the daemon needs this IP to be reachable from the sandbox container on Linux — "+
+		"verify Docker is running and the default bridge network exists", primaryErr, fallbackErr)
+}
+
+// dockerNetwork mirrors the subset of `docker network inspect` JSON the
+// derivation needs: the IPAM gateway addresses configured on the bridge
+// network.
+type dockerNetwork struct {
+	IPAM struct {
+		Config []struct {
+			Gateway string `json:"Gateway"`
+		} `json:"Config"`
+	} `json:"IPAM"`
+}
+
+// bridgeGatewayFromNetworkInspect parses `docker network inspect bridge`
+// and returns the first IPv4 gateway in IPAM.Config. IPv6-only gateways
+// are skipped: the `--add-host host-gateway` path and docker0 default to
+// IPv4, so an IPv4 gateway is what the container reaches.
+func bridgeGatewayFromNetworkInspect(ctx context.Context) (string, error) {
+	out, err := dockerNetworkInspectBridge(ctx)
+	if err != nil {
+		return "", err
+	}
+	var nets []dockerNetwork
+	if err := json.Unmarshal(out, &nets); err != nil {
+		return "", fmt.Errorf("parse docker network inspect output: %w", err)
+	}
+	for _, n := range nets {
+		for _, c := range n.IPAM.Config {
+			gw := strings.TrimSpace(c.Gateway)
+			if gw == "" {
+				continue
+			}
+			ip := net.ParseIP(gw)
+			if ip == nil || ip.To4() == nil {
+				continue
+			}
+			return ip.String(), nil
+		}
+	}
+	return "", fmt.Errorf("no IPv4 gateway in docker bridge IPAM config")
+}
+
+// realDockerNetworkInspectBridge runs `docker network inspect bridge`
+// and returns its stdout. Bounded by [dockerBridgeProbeTimeout].
+func realDockerNetworkInspectBridge(ctx context.Context) ([]byte, error) {
+	cctx, cancel := context.WithTimeout(ctx, dockerBridgeProbeTimeout)
+	defer cancel()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(cctx, "docker", "network", "inspect", "bridge")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return nil, fmt.Errorf("docker network inspect bridge: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	return stdout.Bytes(), nil
+}
+
+// realDocker0RouteGateway derives the bridge-gateway IP from the host's
+// route to the docker0 interface via `ip -j route show dev docker0`. The
+// docker0 interface's own address is the gateway containers reach, so we
+// read the route's `prefsrc` (the source address the host uses on that
+// link), which equals the bridge-gateway IP.
+//
+// Used only as a fallback when `docker network inspect bridge` fails;
+// callers gate it behind Linux+Docker.
+func realDocker0RouteGateway(ctx context.Context) (string, error) {
+	cctx, cancel := context.WithTimeout(ctx, dockerBridgeProbeTimeout)
+	defer cancel()
+	var stdout, stderr bytes.Buffer
+	cmd := exec.CommandContext(cctx, "ip", "-j", "route", "show", "dev", "docker0")
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+	if err := cmd.Run(); err != nil {
+		return "", fmt.Errorf("ip route show dev docker0: %w: %s", err, strings.TrimSpace(stderr.String()))
+	}
+	var routes []struct {
+		PrefSrc string `json:"prefsrc"`
+	}
+	if err := json.Unmarshal(stdout.Bytes(), &routes); err != nil {
+		return "", fmt.Errorf("parse ip route output: %w", err)
+	}
+	for _, r := range routes {
+		src := strings.TrimSpace(r.PrefSrc)
+		if src == "" {
+			continue
+		}
+		ip := net.ParseIP(src)
+		if ip == nil || ip.To4() == nil {
+			continue
+		}
+		return ip.String(), nil
+	}
+	return "", fmt.Errorf("no IPv4 prefsrc on docker0 route")
+}

--- a/internal/server/bridge_test.go
+++ b/internal/server/bridge_test.go
@@ -1,0 +1,181 @@
+package main
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+)
+
+// withStubbedHostGOOS swaps hostGOOS for the duration of the test and
+// restores it on cleanup.
+func withStubbedHostGOOS(t *testing.T, goos string) {
+	t.Helper()
+	prev := hostGOOS
+	hostGOOS = func() string { return goos }
+	t.Cleanup(func() { hostGOOS = prev })
+}
+
+// withStubbedDerivation swaps the two Docker-probing seams so the
+// derivation logic can be exercised without a real Docker daemon.
+func withStubbedDerivation(t *testing.T, inspect func(context.Context) ([]byte, error), route func(context.Context) (string, error)) {
+	t.Helper()
+	prevInspect := dockerNetworkInspectBridge
+	prevRoute := docker0RouteGateway
+	dockerNetworkInspectBridge = inspect
+	docker0RouteGateway = route
+	t.Cleanup(func() {
+		dockerNetworkInspectBridge = prevInspect
+		docker0RouteGateway = prevRoute
+	})
+}
+
+// TestBridgeBindNeeded_NonLinux pins the contract that non-Linux hosts
+// never need a bridge listener: Docker Desktop forwards
+// host.docker.internal to the host loopback, so the existing 127.0.0.1
+// listener already covers the container path.
+func TestBridgeBindNeeded_NonLinux(t *testing.T) {
+	for _, goos := range []string{"darwin", "windows"} {
+		t.Run(goos, func(t *testing.T) {
+			withStubbedHostGOOS(t, goos)
+			if bridgeBindNeeded() {
+				t.Errorf("bridgeBindNeeded() = true on %s; want false (Docker Desktop forwards to loopback)", goos)
+			}
+		})
+	}
+}
+
+// TestBridgeBindNeeded_LinuxDocker covers the positive branch: Linux
+// with a docker binary on PATH needs the bridge listener.
+func TestBridgeBindNeeded_LinuxDocker(t *testing.T) {
+	withStubbedHostGOOS(t, "linux")
+	prev := dockerOnPath
+	dockerOnPath = func() bool { return true }
+	t.Cleanup(func() { dockerOnPath = prev })
+	if !bridgeBindNeeded() {
+		t.Error("bridgeBindNeeded() = false on Linux+Docker; want true")
+	}
+}
+
+// TestBridgeBindNeeded_LinuxNoDocker covers non-Docker Linux: no docker
+// binary means no bridge listener is needed.
+func TestBridgeBindNeeded_LinuxNoDocker(t *testing.T) {
+	withStubbedHostGOOS(t, "linux")
+	prev := dockerOnPath
+	dockerOnPath = func() bool { return false }
+	t.Cleanup(func() { dockerOnPath = prev })
+	if bridgeBindNeeded() {
+		t.Error("bridgeBindNeeded() = true on Linux without Docker; want false")
+	}
+}
+
+// TestDeriveDockerBridgeGatewayIP_PrimaryInspect covers the happy path:
+// `docker network inspect bridge` yields an IPv4 gateway and that IP is
+// returned without consulting the docker0-route fallback.
+func TestDeriveDockerBridgeGatewayIP_PrimaryInspect(t *testing.T) {
+	inspectJSON := `[{"IPAM":{"Config":[{"Subnet":"172.17.0.0/16","Gateway":"172.17.0.1"}]}}]`
+	withStubbedDerivation(t,
+		func(context.Context) ([]byte, error) { return []byte(inspectJSON), nil },
+		func(context.Context) (string, error) {
+			t.Error("docker0 route fallback should not run when inspect succeeds")
+			return "", nil
+		},
+	)
+	ip, err := deriveDockerBridgeGatewayIP(context.Background())
+	if err != nil {
+		t.Fatalf("deriveDockerBridgeGatewayIP: %v", err)
+	}
+	if ip != "172.17.0.1" {
+		t.Errorf("ip = %q, want 172.17.0.1", ip)
+	}
+}
+
+// TestDeriveDockerBridgeGatewayIP_SkipsIPv6Gateway verifies the
+// derivation skips IPv6-only IPAM entries and returns the first IPv4
+// gateway, matching the IPv4 `host-gateway`/docker0 reachability path.
+func TestDeriveDockerBridgeGatewayIP_SkipsIPv6Gateway(t *testing.T) {
+	inspectJSON := `[{"IPAM":{"Config":[{"Gateway":"fd00::1"},{"Gateway":"172.18.0.1"}]}}]`
+	withStubbedDerivation(t,
+		func(context.Context) ([]byte, error) { return []byte(inspectJSON), nil },
+		func(context.Context) (string, error) { return "", errors.New("unused") },
+	)
+	ip, err := deriveDockerBridgeGatewayIP(context.Background())
+	if err != nil {
+		t.Fatalf("deriveDockerBridgeGatewayIP: %v", err)
+	}
+	if ip != "172.18.0.1" {
+		t.Errorf("ip = %q, want 172.18.0.1 (IPv6 gateway should be skipped)", ip)
+	}
+}
+
+// TestDeriveDockerBridgeGatewayIP_FallsBackToRoute covers the fallback:
+// when `docker network inspect` fails (or yields no usable gateway), the
+// docker0-route derivation supplies the IP.
+func TestDeriveDockerBridgeGatewayIP_FallsBackToRoute(t *testing.T) {
+	withStubbedDerivation(t,
+		func(context.Context) ([]byte, error) { return nil, errors.New("docker daemon down") },
+		func(context.Context) (string, error) { return "172.17.0.1", nil },
+	)
+	ip, err := deriveDockerBridgeGatewayIP(context.Background())
+	if err != nil {
+		t.Fatalf("deriveDockerBridgeGatewayIP: %v", err)
+	}
+	if ip != "172.17.0.1" {
+		t.Errorf("ip = %q, want 172.17.0.1 from fallback", ip)
+	}
+}
+
+// TestDeriveDockerBridgeGatewayIP_NoIPv4InInspectFallsBack pins that an
+// inspect output with only IPv6 gateways (no IPv4) is treated as a
+// derivation miss and triggers the docker0-route fallback rather than
+// erroring outright.
+func TestDeriveDockerBridgeGatewayIP_NoIPv4InInspectFallsBack(t *testing.T) {
+	inspectJSON := `[{"IPAM":{"Config":[{"Gateway":"fd00::1"}]}}]`
+	withStubbedDerivation(t,
+		func(context.Context) ([]byte, error) { return []byte(inspectJSON), nil },
+		func(context.Context) (string, error) { return "172.19.0.1", nil },
+	)
+	ip, err := deriveDockerBridgeGatewayIP(context.Background())
+	if err != nil {
+		t.Fatalf("deriveDockerBridgeGatewayIP: %v", err)
+	}
+	if ip != "172.19.0.1" {
+		t.Errorf("ip = %q, want 172.19.0.1 from fallback", ip)
+	}
+}
+
+// TestDeriveDockerBridgeGatewayIP_HardErrorOnBothFail is the core
+// security property from issue #1471: when neither derivation source
+// yields a gateway, the daemon must fail loud and actionable rather than
+// silently binding a wider address (e.g. 0.0.0.0). The error must name
+// both failed sources.
+func TestDeriveDockerBridgeGatewayIP_HardErrorOnBothFail(t *testing.T) {
+	withStubbedDerivation(t,
+		func(context.Context) ([]byte, error) { return nil, errors.New("inspect boom") },
+		func(context.Context) (string, error) { return "", errors.New("route boom") },
+	)
+	_, err := deriveDockerBridgeGatewayIP(context.Background())
+	if err == nil {
+		t.Fatal("deriveDockerBridgeGatewayIP: expected hard error when both sources fail, got nil")
+	}
+	if !strings.Contains(err.Error(), "inspect boom") || !strings.Contains(err.Error(), "route boom") {
+		t.Errorf("error = %q; want both underlying failures named", err)
+	}
+}
+
+// TestDeriveDockerBridgeGatewayIP_MalformedInspectFallsBack ensures
+// unparseable inspect JSON is treated as a primary-source failure and
+// triggers the fallback rather than panicking or returning garbage.
+func TestDeriveDockerBridgeGatewayIP_MalformedInspectFallsBack(t *testing.T) {
+	withStubbedDerivation(t,
+		func(context.Context) ([]byte, error) { return []byte(`{not json`), nil },
+		func(context.Context) (string, error) { return "172.20.0.1", nil },
+	)
+	ip, err := deriveDockerBridgeGatewayIP(context.Background())
+	if err != nil {
+		t.Fatalf("deriveDockerBridgeGatewayIP: %v", err)
+	}
+	if ip != "172.20.0.1" {
+		t.Errorf("ip = %q, want 172.20.0.1", ip)
+	}
+}

--- a/internal/server/main.go
+++ b/internal/server/main.go
@@ -335,12 +335,69 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 		return fmt.Errorf("listen %s: %w", bindAddr, err)
 	}
 
-	url := "http://" + listener.Addr().String()
-	var daemonToken string
-	if shouldProtectLocalDaemon(listener.Addr()) {
-		daemonToken, err = generateDaemonToken()
+	// On Linux+Docker the daemon ALWAYS additionally binds the Docker
+	// bridge-gateway IP at startup (issue #1471, Q2 Option A). Without it
+	// a sandbox container cannot reach the daemon: the launcher rewrites
+	// the loopback daemon URL to host.docker.internal, which
+	// `--add-host host.docker.internal:host-gateway` resolves to the
+	// bridge-gateway IP (~172.17.0.1), NOT loopback — so a loopback-only
+	// daemon gets a kernel RST (ConnectionRefused) on every API call.
+	// This single bind covers BOTH routed paths the issue names: the
+	// ANTHROPIC_BASE_URL gateway and the HTTPS_PROXY sandbox egress proxy,
+	// because both target the same daemon via host.docker.internal.
+	//
+	// macOS / Windows Docker Desktop forward host.docker.internal to the
+	// host loopback, so no second listener is needed there; bridgeBindNeeded
+	// gates this to Linux+Docker only. A failed gateway derivation is a
+	// hard, actionable error rather than a silent wider bind.
+	var bridgeListener net.Listener
+	if bridgeBindNeeded() {
+		bridgeIP, derr := deriveDockerBridgeGatewayIP(ctx)
+		if derr != nil {
+			_ = listener.Close()
+			return fmt.Errorf("bind docker bridge-gateway listener: %w", derr)
+		}
+		// Bind the bridge IP on the SAME port the OS assigned the primary
+		// loopback listener, so the host.docker.internal:<port> the
+		// launcher advertises lands on this listener.
+		_, primaryPort, err := net.SplitHostPort(listener.Addr().String())
 		if err != nil {
 			_ = listener.Close()
+			return fmt.Errorf("read primary listener port: %w", err)
+		}
+		bridgeAddr := net.JoinHostPort(bridgeIP, primaryPort)
+		bridgeListener, err = net.Listen("tcp", bridgeAddr)
+		if err != nil {
+			_ = listener.Close()
+			return fmt.Errorf("listen %s (docker bridge-gateway): %w", bridgeAddr, err)
+		}
+	}
+
+	// closeListeners closes both the primary and (if bound) bridge
+	// listeners. Used on every early-return error path between here and
+	// the point where srv.Serve takes ownership, so a startup failure
+	// never leaks a bound socket.
+	closeListeners := func() {
+		_ = listener.Close()
+		if bridgeListener != nil {
+			_ = bridgeListener.Close()
+		}
+	}
+
+	url := "http://" + listener.Addr().String()
+	var daemonToken string
+	// The daemon is protected when the primary listener is loopback OR
+	// when a bridge listener is bound: the daemon token is daemon-wide
+	// (cfg.LocalDaemonToken) and both listeners share one handler, so the
+	// wider bridge listener must never ship UNAUTHENTICATED. Without the
+	// bridgeListener clause a loopback primary + bridge pair would still
+	// mint a token (loopback is protected), but making the dependency
+	// explicit keeps the bridge listener token-gated even if the primary
+	// bind classification ever changes.
+	if shouldProtectLocalDaemon(listener.Addr()) || bridgeListener != nil {
+		daemonToken, err = generateDaemonToken()
+		if err != nil {
+			closeListeners()
 			return fmt.Errorf("generate daemon token: %w", err)
 		}
 		cfg.LocalDaemonToken = daemonToken
@@ -351,7 +408,7 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 		// lifetime, so a fresh key on each restart is acceptable.
 		caveatKey, err := auth.GenerateCaveatSigningKey()
 		if err != nil {
-			_ = listener.Close()
+			closeListeners()
 			return fmt.Errorf("generate caveat signing key: %w", err)
 		}
 		cfg.CaveatSigningKey = caveatKey
@@ -376,7 +433,7 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 		Token:     daemonToken,
 	}
 	if err := discovery.Write(opts.StateDir, info); err != nil {
-		_ = listener.Close()
+		closeListeners()
 		return fmt.Errorf("publish discovery: %w", err)
 	}
 	// skipDiscoveryRemove gates the deferred discovery.Remove. The
@@ -397,7 +454,7 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 
 	handler, err := app.NewHandlerWithConfig(log, cfg)
 	if err != nil {
-		_ = listener.Close()
+		closeListeners()
 		return err
 	}
 
@@ -416,7 +473,9 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 		IdleTimeout:       120 * time.Second,
 	}
 
-	serveErr := make(chan error, 1)
+	// serveErr is buffered for both listeners so neither serve goroutine
+	// blocks on send when run() has already returned via another branch.
+	serveErr := make(chan error, 2)
 	go func() {
 		log.Info("daemon listening", "url", url, "pid", info.PID, "version", info.Version)
 		if err := srv.Serve(listener); err != nil && !errors.Is(err, http.ErrServerClosed) {
@@ -425,6 +484,23 @@ func run(ctx context.Context, log *slog.Logger, opts options) error {
 		}
 		serveErr <- nil
 	}()
+
+	// Second listener on the Docker bridge-gateway IP, serving the SAME
+	// handler so in-container clients (reaching the daemon via
+	// host.docker.internal) hit the identical app — auth, vault, actions,
+	// and proxy endpoints all included. srv.Shutdown closes every
+	// listener srv.Serve has registered, so the deferred shutdown below
+	// tears this down too; no separate close is needed on the happy path.
+	if bridgeListener != nil {
+		go func() {
+			log.Info("daemon listening on docker bridge-gateway", "addr", bridgeListener.Addr().String(), "pid", info.PID)
+			if err := srv.Serve(bridgeListener); err != nil && !errors.Is(err, http.ErrServerClosed) {
+				serveErr <- err
+				return
+			}
+			serveErr <- nil
+		}()
+	}
 
 	// Lock-inode watcher. Closes inodeMismatch when the daemon.lock
 	// path's inode changes from originalLockInode (or the file is

--- a/internal/server/main_test.go
+++ b/internal/server/main_test.go
@@ -1076,6 +1076,172 @@ func TestRun_SeedApprovals_PropagatesLoadErrors(t *testing.T) {
 	}
 }
 
+// canBindLoopbackAlias reports whether the host can bind a secondary
+// loopback address (127.0.0.2). Linux treats the whole 127.0.0.0/8 as
+// loopback; macOS only configures 127.0.0.1 by default. The bridge-bind
+// regression test needs a second bindable IP to stand in for the Docker
+// bridge-gateway IP, so it skips where one isn't available.
+func canBindLoopbackAlias(t *testing.T, addr string) bool {
+	t.Helper()
+	l, err := net.Listen("tcp", addr+":0")
+	if err != nil {
+		return false
+	}
+	_ = l.Close()
+	return true
+}
+
+// TestRun_BridgeListener_ReachableAndTokenProtected is the regression
+// test for issue #1471: on Linux+Docker the daemon must additionally
+// bind the Docker bridge-gateway IP at the SAME ephemeral port as the
+// loopback listener, serving the same token-protected handler, so a
+// sandbox container reaching the daemon via host.docker.internal can
+// actually connect.
+//
+// It stubs the OS + Docker seams so no real Docker daemon is needed and
+// pins the bridge IP to a secondary loopback alias (127.0.0.2). It then
+// asserts BOTH halves of the operator's answer:
+//   - reachability: an authenticated request on the bridge IP:port
+//     succeeds (the SYN no longer gets a kernel RST), and
+//   - auth: an unauthenticated request on that same wider listener is
+//     rejected (the bridge listener is NOT shipped UNAUTHENTICATED).
+func TestRun_BridgeListener_ReachableAndTokenProtected(t *testing.T) {
+	const bridgeIP = "127.0.0.2"
+	if !canBindLoopbackAlias(t, bridgeIP) {
+		t.Skipf("cannot bind %s on this host (no loopback alias); bridge bind is exercised on Linux/CI", bridgeIP)
+	}
+
+	// Force the Linux+Docker code path and pin the derived bridge IP to
+	// a bindable loopback alias, independent of any real Docker network.
+	withStubbedHostGOOS(t, "linux")
+	prevDockerOnPath := dockerOnPath
+	dockerOnPath = func() bool { return true }
+	t.Cleanup(func() { dockerOnPath = prevDockerOnPath })
+	withStubbedDerivation(t,
+		func(context.Context) ([]byte, error) {
+			return []byte(`[{"IPAM":{"Config":[{"Gateway":"` + bridgeIP + `"}]}}]`), nil
+		},
+		func(context.Context) (string, error) { return bridgeIP, nil },
+	)
+
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+	seedVault(t, vaultPath)
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	opts := options{
+		BindAddr:  "127.0.0.1:0",
+		StateDir:  stateDir,
+		VaultPath: vaultPath,
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	}
+
+	runErr := make(chan error, 1)
+	go func() { runErr <- run(ctx, log, opts) }()
+	info := waitForDaemon(t, stateDir, 3*time.Second)
+
+	// A token must have been minted: the wider bridge listener must be
+	// authenticated, so the discovery token is non-empty.
+	if info.Token == "" {
+		t.Fatal("daemon token is empty; the bridge listener would ship UNAUTHENTICATED")
+	}
+
+	// The advertised URL stays the loopback URL: the launcher rewrites
+	// loopback→host.docker.internal at containerURLForRuntime, so
+	// advertisement is unchanged by the bridge bind.
+	if !strings.HasPrefix(info.URL, "http://127.0.0.1:") {
+		t.Errorf("advertised URL = %q, want loopback (bridge bind must not change advertisement)", info.URL)
+	}
+
+	// Derive the bridge endpoint at the SAME port the loopback listener
+	// advertised — that is the port host.docker.internal:<port> resolves
+	// to inside the container.
+	_, port, err := net.SplitHostPort(strings.TrimPrefix(info.URL, "http://"))
+	if err != nil {
+		t.Fatalf("parse advertised URL %q: %v", info.URL, err)
+	}
+	bridgeURL := "http://" + net.JoinHostPort(bridgeIP, port)
+
+	// Reachability: an authenticated request on the bridge IP succeeds.
+	authed := doDaemonRequest(t, http.MethodGet, bridgeURL+"/v1/vault/status", info.Token, "")
+	defer authed.Body.Close()
+	if authed.StatusCode == http.StatusUnauthorized {
+		t.Fatalf("authed request on bridge listener got 401; the daemon token should be accepted there")
+	}
+	if authed.StatusCode >= 500 {
+		t.Fatalf("authed request on bridge listener got %d; expected a served response", authed.StatusCode)
+	}
+
+	// Auth: an unauthenticated request on the SAME wider listener is
+	// rejected — the bridge listener is token-protected.
+	unauth := doDaemonRequest(t, http.MethodGet, bridgeURL+"/v1/vault/status", "", "")
+	defer unauth.Body.Close()
+	if unauth.StatusCode != http.StatusUnauthorized {
+		t.Errorf("unauth request on bridge listener = %d, want 401; the wider listener must stay token-protected", unauth.StatusCode)
+	}
+
+	cancel()
+	<-runErr
+}
+
+// TestRun_BridgeDerivationFailureIsHardError pins issue #1471's
+// fail-loud contract: when the bridge-gateway IP cannot be derived on a
+// Linux+Docker host, run() returns an error and binds nothing wider,
+// rather than silently falling back to 0.0.0.0 or loopback-only. No
+// discovery files are left behind.
+func TestRun_BridgeDerivationFailureIsHardError(t *testing.T) {
+	withStubbedHostGOOS(t, "linux")
+	prevDockerOnPath := dockerOnPath
+	dockerOnPath = func() bool { return true }
+	t.Cleanup(func() { dockerOnPath = prevDockerOnPath })
+	withStubbedDerivation(t,
+		func(context.Context) ([]byte, error) { return nil, errors.New("docker down") },
+		func(context.Context) (string, error) { return "", errors.New("no docker0") },
+	)
+
+	stateDir := t.TempDir()
+	vaultPath := filepath.Join(t.TempDir(), "secrets.json")
+	seedVault(t, vaultPath)
+
+	log := slog.New(slog.NewTextHandler(io.Discard, nil))
+	err := run(context.Background(), log, options{
+		BindAddr:  "127.0.0.1:0",
+		StateDir:  stateDir,
+		VaultPath: vaultPath,
+		IsTTY:     false,
+		Stderr:    io.Discard,
+	})
+	if err == nil {
+		t.Fatal("run should hard-error when the bridge-gateway IP cannot be derived")
+	}
+	if !strings.Contains(err.Error(), "bridge-gateway") {
+		t.Errorf("err = %v; want a bridge-gateway derivation error", err)
+	}
+	for _, name := range []string{discovery.InfoFile, discovery.PIDFile} {
+		if _, statErr := os.Stat(filepath.Join(stateDir, name)); !errors.Is(statErr, os.ErrNotExist) {
+			t.Errorf("%s exists after derivation failure; nothing should have been published", name)
+		}
+	}
+}
+
+// TestShouldProtectLocalDaemon_BridgePairMintsToken pins that when a
+// bridge listener is bound alongside the loopback primary, the daemon
+// still mints and requires a token. Exercised via run() in
+// TestRun_BridgeListener_ReachableAndTokenProtected; this case documents
+// the unit-level contract that loopback primaries are always protected,
+// which the bridge pair relies on.
+func TestShouldProtectLocalDaemon_BridgePairMintsToken(t *testing.T) {
+	// The loopback primary is always protected; the bridge listener
+	// shares that protection because both serve one token-gated handler.
+	if !shouldProtectLocalDaemon(&net.TCPAddr{IP: net.IPv4(127, 0, 0, 1), Port: 0}) {
+		t.Fatal("loopback primary must be protected; the bridge pair depends on it")
+	}
+}
+
 // tamper corrupts the vault file at `path` by overwriting its first
 // byte. Any subsequent vault.Unlock call returns vault.ErrVaultTampered.
 func tamper(t *testing.T, path string) {


### PR DESCRIPTION
## Summary

On Linux + Docker, `aileron launch claude` started the agent but every API call failed with `Unable to connect to API (ConnectionRefused)`. The daemon bound `127.0.0.1` only, which a sandbox container cannot reach: the launcher rewrites the loopback daemon URL to `host.docker.internal`, and `--add-host host.docker.internal:host-gateway` (`internal/sandbox/container/runtime.go`) resolves that to the Docker bridge-gateway IP (~`172.17.0.1`), not loopback. The container's SYN got a kernel RST. This broke **both** routed paths the issue names — the `ANTHROPIC_BASE_URL` gateway and the `HTTPS_PROXY` sandbox egress proxy — because both target the same daemon via `host.docker.internal`.

This implements the operator-settled design (issue #1471, Q1 + Q2 Option A):

- On **Linux + Docker only**, the daemon now ALWAYS additionally binds the derived bridge-gateway IP at the **same ephemeral port** as the loopback listener, serving the **same** `app.NewHandlerWithConfig` handler via a second `srv.Serve` goroutine. One bind covers both routed paths.
- New bridge-derivation helper (`internal/server/bridge.go`): primary `docker network inspect bridge` (IPAM gateway), fallback to the host's `docker0` route. A failed derivation is a **hard, actionable startup error**, never a silent wider bind, and never `0.0.0.0`.
- macOS / Windows (Docker Desktop forwards `host.docker.internal` to loopback) and non-Docker Linux bind nothing extra.
- The daemon-token protection decision now also fires when the bridge listener is bound, so the wider listener is **never shipped unauthenticated** (the daemon token is daemon-wide and both listeners share one handler).
- `isLoopbackBind` / `--dev-seed-approvals` / the `AILERON_WEBAPP_URL` default stay keyed off the loopback URL. The advertised discovery URL stays the `127.0.0.1` URL; the launcher does the loopback→`host.docker.internal` rewrite per runtime, so advertisement is unchanged.

Scope: `internal/server/main.go` + the new `internal/server/bridge.go`; no launcher/runtime changes (they already resolve `host.docker.internal` to the bridge IP). ADR-0012's transport section is amended to record the Linux+Docker second bind.

## Test plan

- `internal/server/bridge_test.go` — unit tests for the derivation helper: primary inspect, IPv6-skip, docker0 fallback, malformed-inspect fallback, no-IPv4-falls-back, and the hard-error-when-both-fail security property; plus `bridgeBindNeeded` gating across darwin/windows/linux+docker/linux-no-docker.
- `TestRun_BridgeListener_ReachableAndTokenProtected` (regression) — drives `run()` with the OS+Docker seams stubbed and the bridge IP pinned to `127.0.0.2`; asserts an **authenticated** request on the bridge IP:port succeeds (reachability) and an **unauthenticated** one is rejected (the wider listener stays token-protected), and that the advertised URL stays loopback. Verified it **fails with ConnectionRefused before the fix** and passes after (run on Linux via `golang:1.26rc1` container; skips on macOS where `127.0.0.2` is not a bindable loopback alias).
- `TestRun_BridgeDerivationFailureIsHardError` — `run()` returns an error and publishes no discovery files when derivation fails.
- Full `internal/server` + `internal/launch/...` suites pass; `go vet` clean; CodeRabbit review clean (0 findings).

Closes #1471

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * On Linux with Docker: the daemon now binds an additional listener on the Docker bridge gateway, allowing container access via `host.docker.internal` on the same port while maintaining token-based authentication requirements.

* **Documentation**
  * Updated architecture documentation detailing daemon transport behavior, listener configuration, and initialization logic for Docker environments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->