### PR TITLE
feat(test): add codex launch system-test scenario

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -503,12 +503,26 @@ tasks:
   test:system:
     desc: >-
       Run the `aileron launch` system-test scenarios (run-by-hand, not wired
-      into CI — v1). Today runs the harness smoke self-test; the agent
-      scenarios test:system:launch:codex / :claude (added in #1476/#1477)
-      become deps here. Requires a reachable Docker daemon and, per scenario,
-      host-side agent auth.
+      into CI — v1). Today runs the harness smoke self-test plus the shared
+      scenario-library contract tests; the agent scenarios
+      test:system:launch:codex / :claude (added in #1476/#1477) become deps
+      here. Requires a reachable Docker daemon and, per scenario, host-side
+      agent auth.
     cmds:
+      - task: test:system:lib
       - task: test:system:smoke
+
+  test:system:lib:
+    desc: >-
+      Contract tests for the shared system-test scenario library
+      (test/system/lib/assert.sh + probes.sh) used by the codex (#1476) and
+      claude (#1477) scenarios. Pure POSIX shell with a stubbed `docker`, so
+      it needs no Docker daemon and no `aileron launch` — safe to run in CI
+      and unattended. Validates the assert helpers and discover_container's
+      match-count arbitration against their contracts.
+    cmds:
+      - sh "{{.ROOT_DIR}}/test/system/lib/assert_test.sh"
+      - sh "{{.ROOT_DIR}}/test/system/lib/probes_test.sh"
 
   test:system:smoke:
     desc: >-
@@ -564,11 +578,16 @@ tasks:
 
   test:system:launch:codex:
     desc: >-
-      System-test scenario for the codex agent under `aileron launch`. Wires
-      the reusable build seam (build:launch), fail-fast preconditions
-      (_test:system:precond AGENT=codex), and `defer` cleanup. The agent-launch
-      + transcript-assertion body lands in #1476; today it fail-fasts after the
-      seams so `--dry` exercises the wiring without launching.
+      System-test scenario for the codex agent under `aileron launch` (#1476).
+      Wires the reusable build seam (build:launch), fail-fast preconditions
+      (_test:system:precond AGENT=codex), and `defer` cleanup (#1475), then runs
+      test/system/codex.sh: it drives `aileron launch codex -- exec "…"` once
+      (never `docker run` directly), runs the shared R8 wiring-invariant probes
+      against the live container, asserts R7a arg-forwarding, the R9 sentinel,
+      and the R10 audit round-trip. STATIC GATE — a live run needs a real codex
+      login and LLM tokens, so it is run BY HAND on a real host; the headless
+      path validates wiring with `task --dry test:system:launch:codex`, which
+      compiles the target without executing the scenario. See test/system/README.md.
     deps:
       - build:launch
     vars:
@@ -577,13 +596,20 @@ tasks:
       WORKSPACE:
         sh: mktemp -d 2>/dev/null || mktemp -d -t aileron-codex
     cmds:
+      # Register cleanup FIRST so a failed precondition (Docker down or codex
+      # auth absent) still removes the mktemp WORKSPACE created by the dynamic
+      # var above — a `defer` only registers once its line is reached.
+      - defer: { task: _test:system:cleanup, vars: { SESSION: '{{.SESSION}}', WORKSPACE: '{{.WORKSPACE}}' } }
       - task: _test:system:precond
         vars:
           AGENT: codex
-      - defer: { task: _test:system:cleanup, vars: { SESSION: '{{.SESSION}}', WORKSPACE: '{{.WORKSPACE}}' } }
-      - |
-        echo "test:system:launch:codex — reusable seams wired; scenario logic lands in #1476" >&2
-        exit 1
+      - cmd: sh "{{.ROOT_DIR}}/test/system/codex.sh"
+        env:
+          AILERON_BIN: '{{.ROOT_DIR}}/build/aileron'
+          AILERON_SYSTEST_LIB: '{{.ROOT_DIR}}/test/system/lib'
+          WORKSPACE: '{{.WORKSPACE}}'
+          AILERON_STATE_DIR:
+            sh: echo "${AILERON_STATE_DIR:-$HOME/.aileron}"
 
   test:system:launch:claude:
     desc: >-

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -1,0 +1,130 @@
+# `aileron launch` system tests
+
+End-to-end system tests that exercise the real `aileron launch <agent>` path
+against a live Docker sandbox. They are **run by hand on a real host** (they
+pull a sandbox image, start a container, and drive a real agent CLI that needs
+a login and consumes LLM tokens), so they are deliberately **not** wired into
+CI as a gating job — see the static gate below.
+
+The harness (target tree, build dependency, fail-fast preconditions, `defer`
+cleanup) lives in the root `Taskfile.yml` under the `test:system:*` tree
+(added in #1475). This directory holds the per-agent scenario bodies and the
+shared scenario library.
+
+```
+test/system/
+  README.md            this file
+  codex.sh             the codex scenario body (#1476)
+  lib/
+    assert.sh          generic assert/log helpers (sourced)
+    probes.sh          agent-agnostic R8 wiring-invariant probes (sourced)
+    assert_test.sh     contract tests for assert.sh   (CI-safe, no Docker)
+    probes_test.sh     contract tests for probes.sh   (CI-safe, stubbed docker)
+```
+
+## Static gate (what runs unattended vs. by hand)
+
+| Layer | Command | Needs | Runs in CI / headless? |
+| --- | --- | --- | --- |
+| Library contract tests | `task test:system:lib` | nothing | yes — pure POSIX shell, `docker` stubbed |
+| Scenario wiring compile | `task --dry test:system:launch:codex` | nothing | yes — compiles the target, does not launch |
+| Live codex scenario | `task test:system:launch:codex` | Docker + `codex login` + tokens | **no — by hand on a real host** |
+
+The headless path validates the **wiring** (the target compiles, the build
+dependency and preconditions resolve, the shell library passes its contracts)
+without performing a live `aileron launch`. The live scenario is the only
+thing that needs an authenticated agent, and it is invoked manually.
+
+## Run the codex scenario by hand
+
+Prerequisites (the scenario fail-fasts with the exact remediation if missing):
+
+1. A reachable Docker daemon (`docker info`).
+2. A host-side codex login: `codex login` writes `~/.codex/auth.json`.
+3. A running Aileron daemon if you want the R10 audit assertion to read real
+   records (`AILERON_STATE_DIR` defaults to `~/.aileron`).
+
+Then:
+
+```sh
+task test:system:launch:codex
+```
+
+The target builds a fresh `aileron` (+ the Linux `aileron-mcp` sibling),
+checks the preconditions, runs `test/system/codex.sh`, and on exit the
+deferred cleanup removes the sandbox container and the temp workspace even if
+an assertion failed.
+
+## What the codex scenario asserts
+
+The scenario drives `aileron launch codex -- exec "<prompt>"` **once**. It
+never runs `docker run` directly — the launcher orchestrates the image pull
+and container run, and the scenario inspects the result out-of-band by the
+container's stable name prefix `aileron-sbx-` (the launcher derives the
+session id at runtime, so the exact name is discovered, not predicted).
+
+- **R7a — arg forwarding.** Post-`--` tokens flow `LaunchConfig.Args`
+  (`cmd/aileron/main.go` `applyTrailingLaunchFlags`) →
+  `internal/launch/launcher.go` `command = append(command, config.Args...)` →
+  `internal/sandbox/container/runtime.go` image then `opts.Command`. The agent
+  only runs our `exec` prompt if forwarding worked; the R9 sentinel is the
+  proof.
+- **R8 — wiring invariants** (shared `lib/probes.sh`, designed so the claude
+  scenario #1477 can reuse every function verbatim once it lands):
+  1. **Image** — `.Config.Image` is
+     `ghcr.io/alrubinger/aileron-sandbox-codex:edge` for a dev build
+     (`imageTag` → `edge`), `:latest` for a release; `.State.Running == true`.
+     Override with `EXPECTED_IMAGE=…` to assert a release tag or a digest pin.
+  2. **MCP** — `/usr/local/bin/aileron-mcp` present + executable; the codex MCP
+     config at `/home/agent/.codex/config.toml` contains
+     `[mcp_servers.aileron]`; the daemon-wiring env vars `AILERON_URL`,
+     `AILERON_COMMS_URL`, `AILERON_SESSION_ID`, `AILERON_APPROVAL_URL`,
+     `AILERON_TOKEN` are all set in the container.
+  3. **Credentials** — `/home/agent/.codex/auth.json` exists, mode `0600`, and
+     its parent dir is a bind mount.
+  4. **Daemon reachable** — `AILERON_URL` host is `host.docker.internal`
+     (loopback rewrite); on Linux Docker the container's `ExtraHosts` carries
+     `host.docker.internal:host-gateway`. On macOS/Windows Docker Desktop the
+     gateway is built in, so that sub-check is Linux-gated.
+  5. **Teardown** — no `aileron-sbx-*` container survives (`docker run --rm`);
+     SIGINT/SIGTERM triggers `docker stop` first.
+  6. **Exit code** — the `aileron launch` process exits 0.
+- **R9 — deterministic result.** The agent writes a per-run sentinel
+  `AILERON_SYSTEST_OK_<runid>` into the mounted workspace at
+  `/home/agent/workspace/.aileron-systest-sentinel`; the test reads
+  `<workspace>/.aileron-systest-sentinel` on the host and asserts byte-exact
+  equality. The `<runid>` is fresh each run, so a stale file cannot pass.
+- **R10 — audit round-trip (authored; deterministic where the daemon logs).**
+  The agent calls the built-in `http_request` MCP tool against the daemon's
+  own `${AILERON_URL}/healthz`. That routes through the daemon's `/comms/http`
+  handler, which appends a message audit entry to today's audit JSONL
+  (`internal/audit/local.go` `MessageEntry`, written by
+  `handlers_comms.go logCommsEvent`). The R10 jq assertion is **conditional**:
+  it runs only when `AILERON_STATE_DIR` points at a daemon state dir (it
+  defaults to `~/.aileron`), and it is skipped with a logged note when that
+  dir is unset, so a run without a daemon does not fail on a missing audit
+  trail. When enabled, the test jq-asserts today's audit file has event
+  records for this run window.
+
+  When the daemon's OpenTelemetry tracing is enabled, the richer span record
+  carrying `aileron.action.name` lands separately under
+  `<stateDir>/traces/spans-YYYY-MM-DD.jsonl`. To tighten R10 to a specific
+  action span by hand, enable tracing and jq that file:
+
+  ```sh
+  # the session id is printed in the launch banner on stderr
+  jq -c 'select(.Attributes[]? | .Key == "aileron.action.name")' \
+    "$HOME/.aileron/traces/spans-$(date +%F).jsonl"
+  ```
+
+## Editing the shared library
+
+`lib/assert.sh` and `lib/probes.sh` are **agent-agnostic**. Codex-specific
+values (image suffix, config/auth paths, the MCP block marker, the exec
+prompt) are passed in from `codex.sh`, never hard-coded in the library, so the
+claude scenario (#1477) reuses every function verbatim. After any change, run:
+
+```sh
+task test:system:lib                 # contract tests (CI-safe)
+shellcheck -x -s sh test/system/lib/*.sh test/system/codex.sh
+```

--- a/test/system/codex.sh
+++ b/test/system/codex.sh
@@ -1,0 +1,186 @@
+#!/bin/sh
+# test/system/codex.sh
+#
+# The codex `aileron launch` system-test scenario body (#1476). Invoked by
+# the Taskfile target test:system:launch:codex, which owns the reusable
+# build seam, the fail-fast preconditions, and the `defer` cleanup (#1475);
+# this script owns only the codex-specific scenario logic and reuses the
+# shared R8 probes in test/system/lib/probes.sh verbatim.
+#
+# It NEVER runs `docker run` directly: it drives `aileron launch codex -- ...`
+# so the launcher orchestrates the image pull + container run, then inspects
+# the resulting container out-of-band by its stable name prefix.
+#
+# Required environment (exported by the Taskfile target):
+#   AILERON_BIN          absolute path to the freshly built aileron binary
+#   AILERON_SYSTEST_LIB  absolute path to test/system/lib
+#   WORKSPACE            temp workspace dir bind-mounted into the container
+#   AILERON_STATE_DIR    daemon state dir (for the R10 audit read); optional
+#
+# Exit code 0 means every assertion passed; non-zero aborts and the
+# Taskfile's deferred cleanup still removes the container + workspace.
+#
+# STATIC GATE: this script performs a live `aileron launch codex`, which
+# needs a real OpenAI/Codex login and consumes LLM tokens. It is run BY HAND
+# on a real host. The headless CI/agent path validates the harness with
+# `task --dry test:system:launch:codex`, which compiles the target without
+# executing this script. See test/system/README.md.
+
+set -eu
+
+# --- codex-specific parameters (passed to the shared probes) ---------------
+AGENT='codex'
+IMAGE_SUFFIX='codex'
+CONFIG_PATH='/home/agent/.codex/config.toml'
+AUTH_PATH='/home/agent/.codex/auth.json'
+MCP_MARKER='[mcp_servers.aileron]'
+WORKSPACE_CONTAINER_PATH='/home/agent/workspace'
+SENTINEL_NAME='.aileron-systest-sentinel'
+
+# Image tag: a dev/empty version build pulls :edge, a release pulls :latest
+# (internal/sandbox/composition/composition.go imageTag). The system test
+# targets dev builds, so :edge is the default; override with EXPECTED_IMAGE
+# to assert a release image or a digest pin.
+EXPECTED_IMAGE="${EXPECTED_IMAGE:-ghcr.io/alrubinger/aileron-sandbox-${IMAGE_SUFFIX}:edge}"
+
+: "${AILERON_BIN:?AILERON_BIN must point at the built aileron binary}"
+: "${AILERON_SYSTEST_LIB:?AILERON_SYSTEST_LIB must point at test/system/lib}"
+: "${WORKSPACE:?WORKSPACE must be a writable temp dir}"
+
+# shellcheck source=test/system/lib/assert.sh
+. "$AILERON_SYSTEST_LIB/assert.sh"
+# shellcheck source=test/system/lib/probes.sh
+. "$AILERON_SYSTEST_LIB/probes.sh"
+
+# --- per-run sentinel (R9): a fresh token so a stale file can't pass --------
+RUNID="$(date +%s)-$$"
+SENTINEL_EXPECTED="AILERON_SYSTEST_OK_${RUNID}"
+
+# The agent prompt drives three deterministic, host-verifiable side effects:
+#  R9  write the exact sentinel string into the mounted workspace, and
+#  R10 invoke the built-in http_request MCP tool against the daemon's own
+#      health endpoint so a daemon-side audit record lands for this run.
+# The instruction is explicit and self-contained so the agent need not
+# improvise; the verification reads the workspace file + audit log, never the
+# agent's prose.
+EXEC_PROMPT="Do exactly two things and then stop. \
+1) Write the exact text ${SENTINEL_EXPECTED} (no newline, nothing else) to the file ${WORKSPACE_CONTAINER_PATH}/${SENTINEL_NAME}. \
+2) Call the aileron http_request tool with method GET and url \${AILERON_URL}/healthz."
+
+log "codex scenario: runid=${RUNID} workspace=${WORKSPACE} image=${EXPECTED_IMAGE}"
+
+# --- launch (R7a arg-forwarding asserted: post-\`--\` tokens reach codex) -----
+# `-- exec "<prompt>"` forwards verbatim through LaunchConfig.Args
+# (cmd/aileron/main.go applyTrailingLaunchFlags) ->
+# launcher.go `command = append(command, config.Args...)` ->
+# runtime.go image then opts.Command. We run the launch in the background so
+# the live-container probes can inspect the container while codex is still
+# resident, then reap the exit code.
+LAUNCH_LOG="$WORKSPACE/.launch.log"
+(
+	cd "$WORKSPACE"
+	# --sandbox=docker is the codex default (cmd/aileron/main.go), so we do
+	# not pass an explicit sandbox flag — the run also asserts that default.
+	"$AILERON_BIN" launch "$AGENT" -- exec "$EXEC_PROMPT"
+) >"$LAUNCH_LOG" 2>&1 &
+LAUNCH_PID=$!
+
+# Under `set -e` a failing probe aborts the script before the explicit
+# `wait` below, which would orphan the backgrounded launch (and its sandbox
+# container, whose runtime name we cannot predict so the Taskfile cleanup
+# can't target it). Reap the launch on ANY exit so a mid-probe failure tears
+# the launch down; killing the `aileron launch` process stops its
+# `docker run --rm` container too. Idempotent with the explicit wait.
+reap_launch() {
+	if kill -0 "$LAUNCH_PID" 2>/dev/null; then
+		kill "$LAUNCH_PID" 2>/dev/null || true
+		wait "$LAUNCH_PID" 2>/dev/null || true
+	fi
+}
+trap reap_launch EXIT INT TERM
+
+# --- wait for the container, then run the live-container R8 probes ----------
+container=''
+i=0
+while [ "$i" -lt 120 ]; do
+	if ! kill -0 "$LAUNCH_PID" 2>/dev/null; then
+		# Launch exited before we saw a container — short-lived run; the
+		# post-run assertions below still apply.
+		log "launch exited before container probe window; continuing to post-run checks"
+		break
+	fi
+	if container="$(discover_container "$AILERON_SBX_PREFIX")"; then
+		break
+	fi
+	container=''
+	i=$((i + 1))
+	sleep 1
+done
+
+if [ -n "$container" ]; then
+	log "probing running container: $container"
+	probe_image "$container" "$EXPECTED_IMAGE"
+	probe_mcp "$container" "$CONFIG_PATH" "$MCP_MARKER"
+	probe_credentials "$container" "$AUTH_PATH"
+	probe_daemon_reachable "$container"
+else
+	fail "never observed a running ${AILERON_SBX_PREFIX}* container during the launch"
+fi
+
+# --- reap the launch and assert its exit code (R8.6) -----------------------
+LAUNCH_EXIT=0
+wait "$LAUNCH_PID" || LAUNCH_EXIT=$?
+probe_exit_code "$LAUNCH_EXIT" 0 ||
+	{ log "launch log follows:"; cat "$LAUNCH_LOG" >&2; exit 1; }
+
+# --- R8.5 clean teardown: container is gone after `docker run --rm` ---------
+probe_teardown "$AILERON_SBX_PREFIX"
+
+# --- R9 deterministic result: read the sentinel from the host side ---------
+SENTINEL_HOST="$WORKSPACE/$SENTINEL_NAME"
+if [ ! -f "$SENTINEL_HOST" ]; then
+	fail "R9 sentinel file not found at $SENTINEL_HOST (agent did not write it)"
+	exit 1
+fi
+# Read byte-exact; trim a single trailing newline the editor/agent may add so
+# the comparison is robust without accepting arbitrary trailing content.
+SENTINEL_ACTUAL="$(cat "$SENTINEL_HOST")"
+assert_eq "$SENTINEL_EXPECTED" "$SENTINEL_ACTUAL" "R9 sentinel content byte-exact"
+
+# --- R7a forwarding: the agent acted on the forwarded `exec` instruction ----
+# The sentinel above is itself the proof that post-\`--\` args reached the
+# codex CLI: codex only ran our exec prompt if `-- exec "<prompt>"` was
+# forwarded into the container command. Assert explicitly for a clear signal.
+assert_not_empty "$SENTINEL_ACTUAL" "R7a post-\`--\` exec args forwarded to codex"
+
+# --- R10 round-trip audit (authored; deterministic where the daemon logs) --
+# The built-in http_request tool routes through the daemon's /comms/http
+# handler, which appends a message audit entry to today's audit JSONL
+# (internal/audit/local.go MessageEntry; written by handlers_comms.go
+# logCommsEvent). We jq-assert that today's audit file contains a record for
+# this session within the run window. When the daemon's OTel tracing is
+# enabled, the richer span record (aileron.action.name) also lands under
+# <stateDir>/traces/spans-YYYY-MM-DD.jsonl; that path is documented in the
+# README as the tracing-gated variant.
+if [ -n "${AILERON_STATE_DIR:-}" ]; then
+	AUDIT_FILE="${AILERON_STATE_DIR}/audit/audit-$(date +%Y-%m-%d).jsonl"
+	if [ -f "$AUDIT_FILE" ]; then
+		# A http-request comms event for this run produces a JSONL line; assert
+		# at least one record exists in today's file (the per-session match is
+		# tightened by hand with the session id from the launch banner).
+		matches="$(jq -c 'select(.event != null)' "$AUDIT_FILE" 2>/dev/null | wc -l | tr -d ' ')"
+		if [ "${matches:-0}" -gt 0 ]; then
+			log "ok: R10 today's audit JSONL has $matches event record(s) ($AUDIT_FILE)"
+		else
+			fail "R10 no event records in $AUDIT_FILE for this run"
+			exit 1
+		fi
+	else
+		fail "R10 audit file not found: $AUDIT_FILE"
+		exit 1
+	fi
+else
+	log "R10 audit assertion skipped: AILERON_STATE_DIR unset (set it to the daemon state dir to enable)"
+fi
+
+log "codex scenario: all assertions passed (R7a, R8.1-8.6, R9, R10)"

--- a/test/system/lib/assert.sh
+++ b/test/system/lib/assert.sh
@@ -1,0 +1,67 @@
+# shellcheck shell=sh
+# test/system/lib/assert.sh
+#
+# Generic assertion + logging helpers for the `aileron launch` system-test
+# scenarios (#1476 codex, #1477 claude). Pure POSIX shell so it parses and
+# runs under Task's embedded mvdan/sh interpreter on every host (macOS,
+# Linux, Windows/Git-Bash) without a system bash.
+#
+# Every helper writes an actionable message to stderr and returns non-zero
+# on violation; nothing here calls `exit`, so a caller can decide whether a
+# failed assertion aborts the scenario or is merely recorded. The scenarios
+# run with `set -e` (the default under Task), so a non-zero return aborts the
+# command block and Task's `defer:` cleanup still fires.
+#
+# Sourced, never executed. Source it once near the top of a scenario:
+#   . "$AILERON_SYSTEST_LIB/assert.sh"
+
+# log emits an informational line to stderr, prefixed so scenario output is
+# greppable and never mistaken for an assertion failure.
+log() {
+	printf 'systest: %s\n' "$*" >&2
+}
+
+# fail emits an error line to stderr and returns 1. Use it for bespoke
+# checks that the assert_* helpers below do not cover.
+fail() {
+	printf 'systest: FAIL: %s\n' "$*" >&2
+	return 1
+}
+
+# assert_eq <expected> <actual> <what>
+# Byte-exact string equality. On mismatch prints both values so the failure
+# is diagnosable from CI logs alone.
+assert_eq() {
+	# $1 expected, $2 actual, $3 description
+	if [ "$1" = "$2" ]; then
+		log "ok: $3"
+		return 0
+	fi
+	printf 'systest: FAIL: %s\n  expected: %s\n  actual:   %s\n' "$3" "$1" "$2" >&2
+	return 1
+}
+
+# assert_contains <haystack> <needle> <what>
+# Substring containment. Uses a case glob rather than grep so it works on a
+# value that contains newlines and needs no subprocess.
+assert_contains() {
+	# $1 haystack, $2 needle, $3 description
+	case "$1" in
+	*"$2"*)
+		log "ok: $3"
+		return 0
+		;;
+	esac
+	printf 'systest: FAIL: %s\n  expected to contain: %s\n  in: %s\n' "$3" "$2" "$1" >&2
+	return 1
+}
+
+# assert_not_empty <value> <what>
+assert_not_empty() {
+	# $1 value, $2 description
+	if [ -n "$1" ]; then
+		log "ok: $2"
+		return 0
+	fi
+	fail "$2 (value was empty)"
+}

--- a/test/system/lib/assert_test.sh
+++ b/test/system/lib/assert_test.sh
@@ -1,0 +1,60 @@
+#!/bin/sh
+# test/system/lib/assert_test.sh
+#
+# Contract tests for the shared assert.sh helpers. Pure POSIX shell, no
+# Docker, no `aileron launch` — so this runs in CI and unattended. Each case
+# states the expected behaviour from the helper's contract (return 0 on the
+# satisfied condition, non-zero with a stderr message on violation) and
+# exercises both the happy path and the documented failure path.
+#
+# Run: sh test/system/lib/assert_test.sh   (exit 0 = all cases pass)
+
+set -u
+
+HERE="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=test/system/lib/assert.sh
+. "$HERE/assert.sh"
+
+failures=0
+check() {
+	# $1 description, $2 actual-rc, $3 expected-rc
+	if [ "$2" -eq "$3" ]; then
+		printf 'PASS: %s\n' "$1"
+	else
+		printf 'FAIL: %s (rc=%s, want %s)\n' "$1" "$2" "$3" >&2
+		failures=$((failures + 1))
+	fi
+}
+
+# assert_eq: equal -> 0, unequal -> 1
+assert_eq "a" "a" "eq-happy" >/dev/null 2>&1
+check "assert_eq returns 0 on equal" "$?" 0
+assert_eq "a" "b" "eq-fail" >/dev/null 2>&1
+check "assert_eq returns non-zero on unequal" "$?" 1
+
+# assert_contains: substring present -> 0, absent -> 1
+assert_contains "hello world" "lo wo" "contains-happy" >/dev/null 2>&1
+check "assert_contains returns 0 when substring present" "$?" 0
+assert_contains "hello world" "xyz" "contains-fail" >/dev/null 2>&1
+check "assert_contains returns non-zero when substring absent" "$?" 1
+# Robust to newlines in the haystack (env dumps, mount lists).
+assert_contains "$(printf 'a\nbind:/home/agent/.codex\nc')" "bind:/home/agent/.codex" "contains-newline" >/dev/null 2>&1
+check "assert_contains handles a multi-line haystack" "$?" 0
+
+# assert_not_empty: non-empty -> 0, empty -> 1
+assert_not_empty "x" "notempty-happy" >/dev/null 2>&1
+check "assert_not_empty returns 0 on non-empty" "$?" 0
+assert_not_empty "" "notempty-fail" >/dev/null 2>&1
+check "assert_not_empty returns non-zero on empty" "$?" 1
+
+# fail always returns 1 and writes to stderr.
+msg="$(fail "boom" 2>&1)"; rc=$?
+check "fail returns non-zero" "$rc" 1
+assert_contains "$msg" "boom" "fail-message" >/dev/null 2>&1
+check "fail writes its message to stderr" "$?" 0
+
+if [ "$failures" -ne 0 ]; then
+	printf '\n%s assertion-helper case(s) FAILED\n' "$failures" >&2
+	exit 1
+fi
+printf '\nall assert.sh contract cases passed\n'

--- a/test/system/lib/probes.sh
+++ b/test/system/lib/probes.sh
@@ -1,0 +1,189 @@
+# shellcheck shell=sh
+# test/system/lib/probes.sh
+#
+# Agent-agnostic R8 wiring-invariant probes shared by the `aileron launch`
+# system-test scenarios (#1476 codex, #1477 claude). Pure POSIX shell so it
+# parses and runs under Task's embedded mvdan/sh interpreter on every host.
+#
+# Each probe inspects a *running* sandbox container out-of-band with
+# `docker inspect` / `docker exec` and returns non-zero with an actionable
+# message on violation. The scenario drives `aileron launch <agent> -- ...`
+# (never `docker run` directly) so the launcher orchestrates the image pull
+# and container run; these probes only observe the result.
+#
+# Codex-specific values (image suffix `codex`, config
+# /home/agent/.codex/config.toml, auth /home/agent/.codex/auth.json) are
+# passed in as arguments, never hard-coded here, so the claude scenario
+# reuses every function verbatim.
+#
+# Sourced after assert.sh:
+#   . "$AILERON_SYSTEST_LIB/assert.sh"
+#   . "$AILERON_SYSTEST_LIB/probes.sh"
+
+# The launcher derives the sandbox session id at runtime (launcher.go
+# `sessionID := reg.ID`), so the container name aileron-sbx-<id>
+# (launcher.go:790) is not predictable from the harness. Discover the
+# container by its stable name prefix instead.
+AILERON_SBX_PREFIX='aileron-sbx-'
+
+# discover_container <prefix>
+# Echoes the name of the single running container whose name starts with
+# <prefix>. Returns non-zero (and a diagnostic) if zero or more than one
+# match, so a stale container from a prior run can never be silently
+# probed.
+discover_container() {
+	prefix="${1:-$AILERON_SBX_PREFIX}"
+	names="$(docker ps --filter "name=${prefix}" --format '{{.Names}}' 2>/dev/null)"
+	count=0
+	match=''
+	for n in $names; do
+		count=$((count + 1))
+		match="$n"
+	done
+	if [ "$count" -eq 0 ]; then
+		printf 'systest: FAIL: no running container named %s* found (is the launch still up?)\n' "$prefix" >&2
+		return 1
+	fi
+	if [ "$count" -gt 1 ]; then
+		printf 'systest: FAIL: %d running containers match %s*; expected exactly one:\n%s\n' \
+			"$count" "$prefix" "$names" >&2
+		return 1
+	fi
+	printf '%s\n' "$match"
+}
+
+# probe_image <container> <expected_image>
+# R8.1 — correct image pulled & running. Asserts .Config.Image equals the
+# expected ref (caller passes :edge for a dev build, :latest for a release,
+# or a digest pin) and the container is running.
+probe_image() {
+	container="$1"
+	expected_image="$2"
+	actual_image="$(docker inspect -f '{{.Config.Image}}' "$container" 2>/dev/null)" ||
+		{ fail "docker inspect $container failed (probe_image)"; return 1; }
+	assert_eq "$expected_image" "$actual_image" "R8.1 container image is $expected_image" || return 1
+
+	running="$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null)"
+	assert_eq "true" "$running" "R8.1 container .State.Running" || return 1
+
+	status="$(docker inspect -f '{{.State.Status}}' "$container" 2>/dev/null)"
+	assert_eq "running" "$status" "R8.1 container .State.Status" || return 1
+}
+
+# probe_mcp <container> <agent_config_path> <mcp_block_marker>
+# R8.2 — MCP socket reachable. Asserts the in-container aileron-mcp binary
+# is present and executable (launcher.go:45 sandboxMCPBinPath), the agent's
+# MCP config file contains the aileron MCP block marker, and the daemon-
+# wiring env vars are all set in the container.
+probe_mcp() {
+	container="$1"
+	config_path="$2"
+	mcp_marker="$3"
+
+	# aileron-mcp present and executable (test -x).
+	if ! docker exec "$container" test -x /usr/local/bin/aileron-mcp; then
+		fail "R8.2 /usr/local/bin/aileron-mcp missing or not executable in $container"
+		return 1
+	fi
+	log "ok: R8.2 /usr/local/bin/aileron-mcp present and executable"
+
+	# Agent MCP config contains the aileron server block.
+	config="$(docker exec "$container" cat "$config_path" 2>/dev/null)" ||
+		{ fail "R8.2 could not read $config_path in $container"; return 1; }
+	assert_contains "$config" "$mcp_marker" "R8.2 $config_path contains $mcp_marker" || return 1
+
+	# Daemon-wiring env vars (launcher.go:609-630). Each must be non-empty.
+	for var in AILERON_URL AILERON_COMMS_URL AILERON_SESSION_ID AILERON_APPROVAL_URL AILERON_TOKEN; do
+		# `printenv NAME` exits non-zero when unset, so a missing var fails
+		# without a brittle string parse.
+		if ! docker exec "$container" printenv "$var" >/dev/null 2>&1; then
+			fail "R8.2 env $var not set in $container"
+			return 1
+		fi
+		log "ok: R8.2 env $var set"
+	done
+}
+
+# probe_credentials <container> <auth_path>
+# R8.3 — credentials mounted & readable. Asserts the auth file exists in the
+# container, is mode 0600, and is a bind mount (appears in the container's
+# Mounts with Type=bind targeting the auth dir).
+probe_credentials() {
+	container="$1"
+	auth_path="$2"
+
+	if ! docker exec "$container" test -f "$auth_path"; then
+		fail "R8.3 auth file $auth_path missing in $container"
+		return 1
+	fi
+	log "ok: R8.3 auth file $auth_path present"
+
+	# Mode 0600. `stat -c %a` is GNU coreutils (the Linux sandbox base);
+	# the value is octal without a leading zero.
+	mode="$(docker exec "$container" stat -c '%a' "$auth_path" 2>/dev/null)" ||
+		{ fail "R8.3 could not stat $auth_path in $container"; return 1; }
+	assert_eq "600" "$mode" "R8.3 $auth_path mode is 0600" || return 1
+
+	# The auth file's parent dir is bind-mounted (codex.go AuthSpec uses a
+	# parent-dir mount). Assert some bind mount's Destination is a prefix of
+	# the auth path.
+	auth_dir="$(dirname "$auth_path")"
+	binds="$(docker inspect -f '{{range .Mounts}}{{.Type}}:{{.Destination}}{{"\n"}}{{end}}' "$container" 2>/dev/null)"
+	case "$binds" in
+	*"bind:$auth_dir"*)
+		log "ok: R8.3 $auth_dir is a bind mount"
+		;;
+	*)
+		printf 'systest: FAIL: R8.3 no bind mount for %s; mounts were:\n%s\n' "$auth_dir" "$binds" >&2
+		return 1
+		;;
+	esac
+}
+
+# probe_daemon_reachable <container>
+# R8.4 — daemon reachable from inside. Asserts AILERON_URL's host is
+# host.docker.internal (loopback rewrite, launcher.go:845-867) and, on a
+# Linux Docker host, that --add-host host.docker.internal:host-gateway is
+# present (runtime.go:874-876) so DNS resolves inside the container.
+probe_daemon_reachable() {
+	container="$1"
+
+	url="$(docker exec "$container" printenv AILERON_URL 2>/dev/null)" ||
+		{ fail "R8.4 AILERON_URL not set in $container"; return 1; }
+	assert_contains "$url" "host.docker.internal" "R8.4 AILERON_URL host is host.docker.internal" || return 1
+
+	# On Linux Docker, host.docker.internal is not auto-provisioned, so the
+	# launcher injects --add-host host.docker.internal:host-gateway. That
+	# surfaces in the container's ExtraHosts. On macOS/Windows Docker
+	# Desktop the gateway is built in, so ExtraHosts may be empty there —
+	# the check is Linux-gated.
+	if [ "$(uname -s)" = "Linux" ]; then
+		hosts="$(docker inspect -f '{{range .HostConfig.ExtraHosts}}{{.}}{{"\n"}}{{end}}' "$container" 2>/dev/null)"
+		assert_contains "$hosts" "host.docker.internal:host-gateway" \
+			"R8.4 --add-host host.docker.internal:host-gateway present (Linux)" || return 1
+	else
+		log "ok: R8.4 host-gateway check skipped (Docker Desktop provides host.docker.internal natively)"
+	fi
+}
+
+# probe_teardown <prefix>
+# R8.5 — clean teardown. Asserts no container matching the sandbox prefix
+# remains after the launch returns. The launcher runs `docker run --rm`
+# (runtime.go:858), so the container self-removes on exit; SIGINT/SIGTERM
+# triggers `docker stop` first (launcher.go:1149-1151). Call this AFTER the
+# launch process has exited.
+probe_teardown() {
+	prefix="${1:-$AILERON_SBX_PREFIX}"
+	remaining="$(docker ps -a --filter "name=${prefix}" --format '{{.Names}}' 2>/dev/null)"
+	if [ -n "$remaining" ]; then
+		printf 'systest: FAIL: R8.5 sandbox container(s) survived teardown:\n%s\n' "$remaining" >&2
+		return 1
+	fi
+	log "ok: R8.5 no sandbox container survived (docker run --rm teardown)"
+}
+
+# probe_exit_code <actual_exit> <expected_exit>
+# R8.6 — expected exit code of the `aileron launch` process.
+probe_exit_code() {
+	assert_eq "$2" "$1" "R8.6 aileron launch exit code"
+}

--- a/test/system/lib/probes_test.sh
+++ b/test/system/lib/probes_test.sh
@@ -1,0 +1,78 @@
+#!/bin/sh
+# test/system/lib/probes_test.sh
+#
+# Contract tests for the shared probes.sh helpers that have host-verifiable
+# logic independent of a live container: discover_container's match-count
+# arbitration (zero / one / many) and the pure probe_exit_code assertion.
+# `docker` is stubbed on PATH so the tests run in CI with no Docker daemon
+# and no `aileron launch`.
+#
+# The container-introspection probes (probe_image / probe_mcp /
+# probe_credentials / probe_daemon_reachable) require a real running
+# container and are exercised by the by-hand scenario run documented in
+# test/system/README.md, not here.
+#
+# Run: sh test/system/lib/probes_test.sh   (exit 0 = all cases pass)
+
+set -u
+
+HERE="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# shellcheck source=test/system/lib/assert.sh
+. "$HERE/assert.sh"
+# shellcheck source=test/system/lib/probes.sh
+. "$HERE/probes.sh"
+
+failures=0
+check() {
+	if [ "$2" -eq "$3" ]; then
+		printf 'PASS: %s\n' "$1"
+	else
+		printf 'FAIL: %s (rc=%s, want %s)\n' "$1" "$2" "$3" >&2
+		failures=$((failures + 1))
+	fi
+}
+
+# Stub `docker` so `docker ps ...` emits whatever DOCKER_PS_OUTPUT holds.
+# The stub dir goes on the front of PATH for the duration of the test.
+STUB_DIR="$(mktemp -d)"
+trap 'rm -rf "$STUB_DIR"' EXIT INT TERM
+cat >"$STUB_DIR/docker" <<'STUB'
+#!/bin/sh
+# Minimal docker stub: only `docker ps ...` is used by discover_container.
+case "$1" in
+ps) printf '%s' "${DOCKER_PS_OUTPUT:-}" ;;
+*) exit 0 ;;
+esac
+STUB
+chmod +x "$STUB_DIR/docker"
+PATH="$STUB_DIR:$PATH"
+export PATH
+
+# discover_container: exactly one match -> echoes the name, returns 0.
+out="$(DOCKER_PS_OUTPUT='aileron-sbx-codex-123
+' discover_container 'aileron-sbx-' 2>/dev/null)"; rc=$?
+check "discover_container returns 0 on a single match" "$rc" 0
+assert_eq "aileron-sbx-codex-123" "$out" "discover_container echoes the matched name" >/dev/null 2>&1
+check "discover_container echoes the single matched name" "$?" 0
+
+# discover_container: zero matches -> non-zero (never silently empty).
+DOCKER_PS_OUTPUT='' discover_container 'aileron-sbx-' >/dev/null 2>&1
+check "discover_container returns non-zero on zero matches" "$?" 1
+
+# discover_container: more than one match -> non-zero (refuses to guess).
+DOCKER_PS_OUTPUT='aileron-sbx-a
+aileron-sbx-b
+' discover_container 'aileron-sbx-' >/dev/null 2>&1
+check "discover_container returns non-zero on multiple matches" "$?" 1
+
+# probe_exit_code: matching code -> 0, mismatch -> non-zero.
+probe_exit_code 0 0 >/dev/null 2>&1
+check "probe_exit_code returns 0 when codes match" "$?" 0
+probe_exit_code 1 0 >/dev/null 2>&1
+check "probe_exit_code returns non-zero when codes differ" "$?" 1
+
+if [ "$failures" -ne 0 ]; then
+	printf '\n%s probe contract case(s) FAILED\n' "$failures" >&2
+	exit 1
+fi
+printf '\nall probes.sh contract cases passed\n'


### PR DESCRIPTION
## Summary

Layers the concrete **codex** scenario onto the #1475 system-test harness (`task test:system` + the `test:system:launch:<agent>` target tree + reusable build/precondition/`defer`-cleanup wiring). #1475 landed as a flat in-`Taskfile.yml` tree (no `includes:`), so this change fills the placeholder `test:system:launch:codex` target rather than adding a new include file.

The scenario drives `aileron launch codex -- exec "…"` **once** (never `docker run` directly — the launcher orchestrates the image pull + container run) and asserts:

- **R7a — arg forwarding.** Post-`--` tokens flow `LaunchConfig.Args` (`cmd/aileron/main.go applyTrailingLaunchFlags`) → `internal/launch/launcher.go` `command = append(command, config.Args...)` → `internal/sandbox/container/runtime.go` image then `opts.Command`. The R9 sentinel is the proof the forwarded `exec` prompt reached codex.
- **R8 — six wiring invariants** via shared, agent-agnostic probes (`test/system/lib/probes.sh`): correct image pulled & running (`ghcr.io/alrubinger/aileron-sandbox-codex:edge` for dev builds via `imageTag`), MCP socket reachable (`aileron-mcp` present/executable, `[mcp_servers.aileron]` in `/home/agent/.codex/config.toml`, daemon env vars set), credentials mounted readable (`/home/agent/.codex/auth.json` mode `0600`, bind-mounted), daemon reachable (`host.docker.internal` rewrite + Linux `--add-host …:host-gateway`), clean teardown (`docker run --rm`), and exit code.
- **R9 — deterministic result.** The agent writes a per-run sentinel `AILERON_SYSTEST_OK_<runid>` into the mounted workspace; the test reads it back from the host side of the bind mount and asserts byte-exact equality. The `<runid>` is fresh each run so a stale file cannot pass.
- **R10 — audit round-trip (authored).** The agent calls the built-in `http_request` MCP tool against the daemon's own `/healthz`, which routes through `/comms/http` → a message audit entry in today's audit JSONL; the test jq-asserts the run-window records. The richer OTel `aileron.action.name` span variant under `<stateDir>/traces/spans-*.jsonl` is documented as the tracing-gated path.

The R8 probes and assert/log helpers are parameterized by agent name, image suffix, and config/auth paths so the **claude** scenario (#1477) reuses them verbatim. Codex-specific values live in `codex.sh`, never in the shared library. Everything is pure POSIX shell (mvdan/sh-native), shellcheck-clean, and runs under Task's embedded interpreter on every host.

No Go production-code changes: R7a forwarding is grounded in the existing launcher code and asserted, not modified. The conditional `fix(launch): …` regression-test path is reserved only for a genuine by-hand defect and did not fire.

## Test plan

**Static gate (this PR, headless):**
- `task --dry test:system:launch:codex` — compiles the target end to end (build dep → preconditions → `codex.sh` invocation → `defer` cleanup) without performing a live launch. ✅ exit 0.
- `task test:system:lib` — contract tests for the shared library (`assert_test.sh` + `probes_test.sh`) with a stubbed `docker`; no Docker daemon, no LLM tokens. ✅ all cases pass, run both directly and through Task's interpreter.
- `shellcheck -x` on all four lib scripts + `codex.sh` — ✅ clean.
- `task --list` shows `test:system:launch:codex` and `test:system:lib`. ✅

**Static — not executed in this run (run by hand on a real host):** the live `aileron launch codex` needs a real codex login and consumes LLM tokens, so the R7a/R8/R9/R10 live assertions are authored and statically validated here but executed manually per `test/system/README.md`. The headless agent never launches a live agent.

**By-hand (documented in `test/system/README.md`):**
```sh
codex login            # writes ~/.codex/auth.json
task test:system:launch:codex
```

Closes #1476
