### PR TITLE
docs: document the system-test suite (run, prereqs, cross-OS)

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,7 @@ Everything lives at **[docs.withaileron.ai](https://docs.withaileron.ai)**:
 - [API Reference](https://docs.withaileron.ai/api) — full OpenAPI specification
 - [Repository Layout](https://docs.withaileron.ai/development/repo-layout/) — how the source tree is organized
 - [Building from Source](https://docs.withaileron.ai/development/building-from-source/) — prerequisites and Taskfile entry points for contributors
+- [Running Tests](https://docs.withaileron.ai/development/running-tests/) — the test layers and how to run the by-hand black-box system-test suite
 
 ## License
 

--- a/docs/src/content/docs/development/index.md
+++ b/docs/src/content/docs/development/index.md
@@ -13,7 +13,7 @@ If you're looking for end-user docs, the [Getting Started](/getting-started/) gu
 - [Repo Layout](/development/repo-layout/) — the directory tree, where each concern lives, and how the workspace is wired.
 - [Binary Architecture](/development/binary-architecture/) — the four binaries Aileron ships, who calls whom, and which process owns which trust boundary.
 - [Building from Source](/development/building-from-source/) — prerequisites, the Taskfile entry points, and how the embedded assets (webapp, forwarder WASM) get folded in.
-- [Running Tests](/development/running-tests/) — unit, integration, race, coverage. What CI runs, and how to reproduce a CI failure locally.
+- [Running Tests](/development/running-tests/) — unit, integration, race, coverage, and the by-hand black-box system suite. What CI runs, how to reproduce a CI failure locally, and how to run the manual system suite.
 - [Sandbox Composition](/development/sandbox-composition/) — how Aileron uses devcontainer.json, `ghcr.io/alrubinger/aileron-sandbox-base`, and `aileron sandbox` to define the agent container image.
 - [Sandbox Agent Images](/development/sandbox-agent-images/) — which agent commands are supported by the selected sandbox image and how to check them before launch.
 - [Sandbox Connector Specs](/development/sandbox-connector-specs/) — how installed connector specs drive data-plane operation validation in sandboxed launch sessions.

--- a/docs/src/content/docs/development/running-tests.md
+++ b/docs/src/content/docs/development/running-tests.md
@@ -1,6 +1,6 @@
 ---
 title: "Running Tests"
-description: "Unit, integration, race, coverage. What CI runs, and how to reproduce a CI failure locally."
+description: "Unit, integration, race, coverage: what CI runs and how to reproduce a CI failure locally, plus the by-hand black-box system suite."
 order: 4
 ---
 
@@ -94,6 +94,48 @@ If a test passes locally but fails in CI, the usual suspects are:
 - **Goroutine leaks or races** — surface under `-race`; the inline `task test:go` skips it.
 - **TempDir vs HOME** — tests that touch `~/.aileron/` need `t.Setenv("HOME", t.TempDir())`. The CI runners have no fallback path.
 - **Time-of-day or timezone** — tests that compare against `time.Now()` without an injected clock will be flaky on slow CI runners.
+
+## System tests (black-box CLI)
+
+The system-test suite sits above the unit, integration, and sandbox-integration layers. It builds the shipped `aileron` binary and drives the real `aileron launch <agent> -- <agent-flag> "..."` path against a live Docker sandbox, for example `aileron launch codex -- exec "..."` or `aileron launch claude -- -p "..."`, then asserts on the result with shell and `jq`. The lower layers prove that Docker works on the host. The `test:go` unit layer exercises Go functions in isolation. The `task test:integration` layer runs Playwright against running services. The `integration_sandbox` Go tests call `docker run` and the sandbox Go functions directly. The system suite proves that `aileron launch` itself correctly drives Docker on the host. It does not replace any of those layers, and it sits above them.
+
+### Run it
+
+```sh
+task test:system               # lib contract tests + harness smoke + the codex and claude scenarios
+task test:system:lib           # POSIX-shell contract tests for the shared scenario library (no Docker, CI-safe)
+task test:system:smoke         # harness self-test: build fires, Docker precondition gates, defer cleanup runs
+task test:system:launch:codex  # the codex scenario in isolation: aileron launch codex -- exec "..."
+task test:system:launch:claude # the claude scenario in isolation: aileron launch claude -- -p "..."
+```
+
+Each agent scenario builds a fresh `aileron` (plus the Linux `aileron-mcp` sibling), runs the launch once, and on exit a deferred cleanup removes the sandbox container and the temporary workspace even when an assertion failed.
+
+### Host prerequisites
+
+- **A reachable Docker daemon.** On macOS and Windows this means Docker Desktop running; on Linux it means `dockerd`. The suite checks `docker info` before any launch.
+- **The target agent's auth already present.** The codex scenario expects `~/.codex/auth.json` (created by `codex login`). The claude scenario expects `~/.claude/.credentials.json` (created by `claude /login`). v1 does not inject any LLM secret; you authenticate once with your own `aileron launch <agent>` login and the suite reuses that file.
+- **Optional: a running Aileron daemon** if you want the audit round-trip assertion to read real records (`AILERON_STATE_DIR` defaults to `~/.aileron`).
+
+A missing prerequisite stops the run immediately and prints the exact remediation command, for example `Authenticate first with: claude /login`. The suite never silently skips a scenario when a prerequisite is absent.
+
+A live agent scenario needs a real login and consumes LLM tokens, so it is run by hand. The headless path validates the wiring without launching:
+
+```sh
+task --dry test:system:launch:codex   # compiles the target, resolves deps and preconditions, does not launch
+```
+
+### Cross-OS
+
+The same suite runs unmodified on Ubuntu, Fedora, macOS, and Windows, with the container path included on all four. Task runs each target's command steps through its embedded `mvdan/sh` interpreter, so the Taskfile-level shell logic is portable without a host Bash. Windows uses the stdio exec path and does not use a Unix PTY. OS and distribution versions are unpinned in v1.
+
+The launch container path is not gated by the spawn-primitive availability probes (`internal/sandbox/sandbox_available_*.go`, [ADR-0014](/adr/0014-spawn-sandbox-technology/)). Those probes guard the separate spawn-primitive OS confinement subsystem. The `aileron launch` container path works on all four OS families regardless of that gate, so the system suite runs everywhere Docker runs.
+
+### Scope boundary
+
+v1 is portable and run by hand. `task test:system` is not wired into CI. The maintainer runs it on real hosts across the four OS families. CI-matrix automation, including self-hosted runners, cloud VMs, and secret injection, is deferred to a later initiative.
+
+For the human-driven manual runbook this suite complements, see the [v4 Manual Acceptance Runbook](/development/v4-acceptance/). The scenario bodies and the shared probe library are documented in `test/system/README.md` in the repository.
 
 ## Testing philosophy
 

--- a/docs/src/content/docs/development/v4-acceptance.md
+++ b/docs/src/content/docs/development/v4-acceptance.md
@@ -137,3 +137,4 @@ If the draft appears in Gmail and the audit log shows the approval and execution
 - [Sandbox MCP — Manual Verification Walkthrough](/development/sandbox-mcp-walkthrough/) — the detailed round-trip, per-agent registration detail, and troubleshooting.
 - [Sandbox Agent Auth](/development/sandbox-agent-auth/) — signing an agent in ahead of time.
 - [Sandbox Composition](/development/sandbox-composition/) — how `aileron sandbox` builds and checks the image.
+- [Running Tests: System tests](/development/running-tests/#system-tests-black-box-cli) — the automated by-hand equivalent of this runbook, driven through `task test:system`.


### PR DESCRIPTION
## Summary

Documents the black-box CLI system-test suite that landed via #1475-#1477 (umbrella #1474). This is the docs sub-issue (item 4).

- Adds a **System tests (black-box CLI)** section to the contributor `Running Tests` page (`docs/src/content/docs/development/running-tests.md`):
  - **What it is / how it differs** from the unit (`task test:go`), `integration` (Playwright), and `integration_sandbox` (Go `docker run`) layers. The lower layers prove Docker works on the host; the system suite proves `aileron launch` correctly drives Docker. It sits above them and does not replace them.
  - **Run it** — the real merged targets: `task test:system`, `task test:system:lib`, `task test:system:smoke`, `task test:system:launch:codex` (`aileron launch codex -- exec "..."`), `task test:system:launch:claude` (`aileron launch claude -- -p "..."`), plus the `task --dry` wiring check.
  - **Host prerequisites** — Docker daemon (Docker Desktop on macOS/Windows); the target agent's auth already present (`~/.codex/auth.json` via `codex login`, `~/.claude/.credentials.json` via `claude /login`); no LLM-secret injection in v1; fail-fast precondition behavior with the exact remediation, never a silent skip.
  - **Cross-OS** — the same suite runs unmodified on Ubuntu, Fedora, macOS, Windows, container path on all four; Windows uses the stdio exec path, no Unix PTY; versions unpinned in v1. States plainly the launch container path is **not** gated by the spawn-primitive availability probes (ADR-0014), so it works on all four OS families.
  - **Scope boundary** — v1 is portable and run by hand; `task test:system` is not in CI; CI-matrix automation (self-hosted runners, cloud VMs, secret injection) is deferred.
- Cross-links the section to and from the **v4 Manual Acceptance Runbook**.
- Refreshes the development index `Running Tests` blurb.
- Adds a `Running Tests` bullet to the README Documentation list per the repo's "README is the GitHub-landing overview" convention.

All target names, batch flags, auth-file paths, and image refs were reconciled against the actually-merged `test:system*` targets in `Taskfile.yml` (the brief required documenting what shipped, not the planned names).

Voice rules honored in the new docs prose: no em-dashes, no "not just X, Y", one thought per sentence.

## Test plan

- `task test:docs` — green (13/13 rehype/build unit tests pass).
- `task build:docs` — green; the new section renders, the `system-tests-black-box-cli` anchor that v4-acceptance links to is generated, ADR-0014 and v4-acceptance links resolve, no broken-link warnings.
- Self-review via CodeRabbit (`coderabbit review --agent -t committed --base origin/main`): 0 findings after fixing two (a frontmatter "What CI runs" accuracy nit and a vague command placeholder).
- Out of scope (owned by #1475-#1477 / deferred): any `Taskfile.yml` or test-code change, CI wiring for `test:system`, new Go tests.

Closes #1478
