### PR TITLE
fix(launch): parse codex usercode interval from string-encoded number

### DIFF
--- a/internal/launch/agents/codex_auth.go
+++ b/internal/launch/agents/codex_auth.go
@@ -9,6 +9,7 @@ import (
 	"io"
 	"net/http"
 	"net/url"
+	"strconv"
 	"strings"
 	"time"
 
@@ -384,16 +385,53 @@ var codexDeviceSleep = func(ctx context.Context, d time.Duration) error {
 	}
 }
 
+// codexInterval is the poll interval (in seconds) advertised by the
+// usercode endpoint. Codex's upstream UserCodeResp deserializes interval
+// with a custom deserializer that accepts BOTH a JSON number and a
+// string-encoded number, and the live endpoint sends the string form
+// (e.g. "interval":"5"). Modeling the field as a plain Go int therefore
+// fails the device-code parse on the real wire format, killing host
+// credential capture. codexInterval tolerates a JSON number, a
+// string-encoded number, and absence/null (which yields 0, so the
+// launcher falls back to codexDeviceDefaultInterval).
+type codexInterval int
+
+// UnmarshalJSON accepts the interval as either a JSON number or a
+// string-encoded number, mirroring Codex's upstream custom deserializer.
+// A JSON null is treated as absence (0). A non-numeric string is a hard
+// parse error so a genuinely malformed response is still surfaced.
+func (ci *codexInterval) UnmarshalJSON(data []byte) error {
+	trimmed := strings.TrimSpace(string(data))
+	if trimmed == "null" {
+		*ci = 0
+		return nil
+	}
+	// Strip surrounding quotes for the string-encoded form. strconv.Atoi
+	// then validates the numeric content of both the bare-number and the
+	// string-encoded number identically.
+	unquoted := strings.Trim(trimmed, `"`)
+	if unquoted == "" {
+		*ci = 0
+		return nil
+	}
+	n, err := strconv.Atoi(unquoted)
+	if err != nil {
+		return fmt.Errorf("interval: not a number: %q", unquoted)
+	}
+	*ci = codexInterval(n)
+	return nil
+}
+
 // codexDeviceUserCodeResponse is the JSON the usercode endpoint returns.
 // Field names mirror Codex's UserCodeResp (device_auth_id, user_code,
-// interval) in codex-rs/login/src/device_code_auth.rs. The upstream
-// struct accepts a string-encoded interval via a custom deserializer; we
-// model interval as a number here and tolerate its absence (the launcher
-// falls back to codexDeviceDefaultInterval).
+// interval) in codex-rs/login/src/device_code_auth.rs. interval is typed
+// as codexInterval to accept the string-encoded value the live endpoint
+// sends (see codexInterval); the launcher tolerates its absence by
+// falling back to codexDeviceDefaultInterval.
 type codexDeviceUserCodeResponse struct {
-	DeviceAuthID string `json:"device_auth_id"`
-	UserCode     string `json:"user_code"`
-	Interval     int    `json:"interval"`
+	DeviceAuthID string        `json:"device_auth_id"`
+	UserCode     string        `json:"user_code"`
+	Interval     codexInterval `json:"interval"`
 }
 
 // codexDevicePollResponse is the success body the deviceauth/token

--- a/internal/launch/agents/codex_host_acquire_test.go
+++ b/internal/launch/agents/codex_host_acquire_test.go
@@ -9,6 +9,7 @@ import (
 	"net/http"
 	"net/http/httptest"
 	"net/url"
+	"strconv"
 	"strings"
 	"sync"
 	"testing"
@@ -142,10 +143,16 @@ func fakeDeviceAuthServer(t *testing.T, st *codexDeviceServerState) *httptest.Se
 				_, _ = io.WriteString(w, st.usercodeRawBody)
 				return
 			}
+			// The live usercode endpoint sends interval as a
+			// STRING-encoded number (Codex's upstream UserCodeResp uses a
+			// custom deserializer). Emit the string form so the harness
+			// exercises the real wire shape; the launcher's codexInterval
+			// type must tolerate it. Regression for the device-code parse
+			// failure that killed host credential capture (#1489).
 			_ = json.NewEncoder(w).Encode(map[string]any{
 				"device_auth_id": "dev-1",
 				"user_code":      "WXYZ-1234",
-				"interval":       st.userCodeInterval,
+				"interval":       strconv.Itoa(st.userCodeInterval),
 			})
 
 		case strings.HasSuffix(r.URL.Path, "/deviceauth/token"):

--- a/internal/launch/agents/codex_interval_internal_test.go
+++ b/internal/launch/agents/codex_interval_internal_test.go
@@ -1,0 +1,65 @@
+package agents
+
+import (
+	"encoding/json"
+	"testing"
+)
+
+// codexInterval contract: the usercode endpoint's interval field must
+// parse from the string-encoded number the live Codex endpoint actually
+// sends, while still accepting a bare JSON number, null, and absence.
+// This is the regression for #1489, where modeling interval as a plain
+// int failed the device-code parse on the real wire format and silently
+// killed host credential capture.
+func TestCodexInterval_UnmarshalJSON(t *testing.T) {
+	cases := []struct {
+		name    string
+		json    string
+		want    codexInterval
+		wantErr bool
+	}{
+		{"string-encoded number (live wire format)", `"5"`, 5, false},
+		{"bare JSON number", `7`, 7, false},
+		{"string zero", `"0"`, 0, false},
+		{"null is treated as absence", `null`, 0, false},
+		{"empty string is treated as absence", `""`, 0, false},
+		{"non-numeric string is a parse error", `"abc"`, 0, true},
+		{"non-numeric bare token is a parse error", `true`, 0, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			var ci codexInterval
+			err := json.Unmarshal([]byte(tc.json), &ci)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("expected error for %q, got nil (value %d)", tc.json, ci)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error for %q: %v", tc.json, err)
+			}
+			if ci != tc.want {
+				t.Errorf("interval = %d, want %d", ci, tc.want)
+			}
+		})
+	}
+}
+
+// The full usercode response must decode when interval arrives as the
+// string-encoded form, populating the device_auth_id/user_code fields the
+// poll loop depends on (the exact failure path reported in #1489).
+func TestCodexDeviceUserCodeResponse_StringInterval(t *testing.T) {
+	const body = `{"device_auth_id":"dev-1","user_code":"WXYZ-1234","interval":"5"}`
+	var dc codexDeviceUserCodeResponse
+	if err := json.Unmarshal([]byte(body), &dc); err != nil {
+		t.Fatalf("parse device-code response with string interval: %v", err)
+	}
+	if dc.DeviceAuthID != "dev-1" || dc.UserCode != "WXYZ-1234" {
+		t.Errorf("got device_auth_id=%q user_code=%q, want dev-1 / WXYZ-1234",
+			dc.DeviceAuthID, dc.UserCode)
+	}
+	if dc.Interval != 5 {
+		t.Errorf("interval = %d, want 5", dc.Interval)
+	}
+}


### PR DESCRIPTION
## Summary

The codex usercode endpoint returns `interval` as a **string-encoded number** (Codex upstream uses a custom deserializer that accepts both a JSON number and a string-encoded one; the live endpoint sends the string form, e.g. `"interval":"5"`). `codexDeviceUserCodeResponse.Interval` was typed as a plain `int`, so the device-code parse failed on the real wire format with:

```
codex: parse device-code response: json: cannot unmarshal string into Go struct field codexDeviceUserCodeResponse.interval of type int
```

`codexHostAcquire` treats that error as non-fatal, so host credential capture **silently fell back to in-container login**.

### Fix

- Introduce a `codexInterval int` named type with an `UnmarshalJSON` that tolerates a JSON number, a string-encoded number, and null/empty/absence (yielding `0`, so the launcher keeps falling back to `codexDeviceDefaultInterval`). Non-numeric content stays a hard parse error so genuinely malformed responses still surface.
- Change `codexDeviceUserCodeResponse.Interval` to `codexInterval`. `time.Duration(dc.Interval)` at the poll site keeps working via the named-int conversion.

### Out of scope

The issue's sibling defect (mkdir permission denied placing the codex MCP config) is filed separately and not touched here.

## Test plan

- New in-package regression test `codex_interval_internal_test.go` covers the parse variants (string / number / null / empty / invalid) plus a full-response decode with a string interval.
- The device-auth harness (`codex_host_acquire_test.go`) now emits `interval` in the live **string-encoded** form.
- Verified the regression: with the old `int` field, the harness tests fail with the exact error from the issue; with the fix, `go build`, `go vet`, and `go test ./internal/launch/agents/` are all green.

Closes #1489


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved an issue with device authentication to properly handle variable response formats from the authentication service, ensuring more reliable authentication flows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->