### PR TITLE
fix(launch): chown codex auth tree after placing MCP config

### DIFF
--- a/internal/launch/authspec_container_read_integration_test.go
+++ b/internal/launch/authspec_container_read_integration_test.go
@@ -126,6 +126,14 @@ func TestAuthSpecInContainerCredentialReadCapture(t *testing.T) {
 		}
 		defer prep.Cleanup()
 
+		// The chown is deferred (issue #1488): in production launchSandbox
+		// invokes prep.ChownFn AFTER placing the MCP config, just before
+		// running the container. Mirror that ordering here so the rendered
+		// credential is owned by the agent UID before the in-container read.
+		if err := prep.ChownFn(); err != nil {
+			t.Fatalf("prep.ChownFn: %v", err)
+		}
+
 		// The container asserts the read matches the seeded credential
 		// (proving the rendered file is readable at ContainerPath inside the
 		// sandbox), then rotates it via tmpfile + rename so capture has a
@@ -168,6 +176,12 @@ func TestAuthSpecInContainerCredentialReadCapture(t *testing.T) {
 			t.Fatalf("prepareAuthSpec: %v", err)
 		}
 		defer prep.Cleanup()
+
+		// Deferred chown (issue #1488): mirror launchSandbox's post-placement
+		// invocation so the agent can read the rendered credential.
+		if err := prep.ChownFn(); err != nil {
+			t.Fatalf("prep.ChownFn: %v", err)
+		}
 
 		script := containerReadAssertOnly(claudeCredsContainerPath)
 		env := map[string]string{"EXPECTED": string(seeded)}

--- a/internal/launch/authspec_runtime.go
+++ b/internal/launch/authspec_runtime.go
@@ -69,6 +69,20 @@ type authSpecPrep struct {
 	// into launchSandbox's existing defer because the order matters.
 	Cleanup func()
 
+	// ChownFn, when non-nil, recursively chowns the transient auth tree
+	// to the resolved in-container agent UID. It is invoked by the
+	// launcher AFTER the agent's MCP config has been placed into the
+	// tree (collapseNestedMCPMounts) so the single delegated chown
+	// re-owns config.toml alongside auth.json. Running the chown earlier
+	// (e.g. at the tail of prepareAuthSpec) re-owned the tree to the
+	// foreign agent UID with mode 0700 before the unprivileged host
+	// launcher placed the nested MCP config, so the MkdirAll/WriteFile
+	// in collapseNestedMCPMounts failed with EPERM on rootful Docker
+	// Linux (issue #1488). A nil ChownFn (no chown hook supplied, or a
+	// non-Linux host) is a safe no-op. The launcher must invoke it
+	// exactly once before the container starts.
+	ChownFn func() error
+
 	// HasBindings reports whether the prep produced any auth-spec
 	// state. False means the agent shipped an empty AuthSpec{} and
 	// the launcher should treat the prep as a no-op (Goose, Pi,
@@ -119,23 +133,29 @@ type authSpecPrep struct {
 // race because both writers exchanged the same upstream token).
 // Agents that rotate their credential in-container (Claude, Codex)
 // supply a Fresher so a stale capture cannot clobber a newer entry.
-// chownTransientDir, when non-nil, is invoked once after every
-// FileBinding and StaticFile has been written to the transient host
-// directory and before the mount list is returned. It receives
-// hostRoot and is expected to recursively change ownership of the tree
-// to the resolved in-container agent UID. On rootful-Docker Linux the
-// host operator's UID owns the transient dir, but the container runs as
-// the image's `agent` system user; a writable bind mount preserves host
-// ownership, so the agent's mid-session credential rewrite (Claude's
-// tmpfile+rename of .credentials.json) fails with EPERM without this
-// chown. The launcher supplies a Linux-only closure; on macOS/Windows
-// (where the Docker Desktop file-sharing shim translates UIDs) it is
-// nil and the chown is skipped. A nil hook is a no-op.
+// chownTransientDir, when non-nil, recursively changes ownership of the
+// transient tree (hostRoot) to the resolved in-container agent UID. On
+// rootful-Docker Linux the host operator's UID owns the transient dir,
+// but the container runs as the image's `agent` system user; a writable
+// bind mount preserves host ownership, so the agent's mid-session
+// credential rewrite (Claude's tmpfile+rename of .credentials.json)
+// fails with EPERM without this chown. The launcher supplies a
+// Linux-only closure; on macOS/Windows (where the Docker Desktop
+// file-sharing shim translates UIDs) it is nil and the chown is skipped.
+//
+// prepareAuthSpec does NOT invoke chownTransientDir directly. It wraps it
+// in prep.ChownFn (a no-op when the hook is nil) and the launcher invokes
+// that closure AFTER it has placed the agent's MCP config into the tree
+// (collapseNestedMCPMounts), so the single delegated chown re-owns
+// config.toml alongside auth.json. Invoking it here at prep time would
+// re-own the tree to the foreign agent UID with mode 0700 before the
+// unprivileged host launcher placed the nested MCP config, and that
+// host-side write would then fail with EPERM (issue #1488).
 //
 // Resolver failures are surfaced as a non-fatal warning and launch
 // proceeds (the prior behavior); the hook returns an error only so the
-// launcher can decide warn-vs-abort. prepareAuthSpec treats a hook
-// error as non-fatal.
+// closure can decide warn-vs-abort. prep.ChownFn treats a hook error as
+// non-fatal and never propagates it.
 func prepareAuthSpec(
 	ctx context.Context,
 	agentName string,
@@ -151,6 +171,7 @@ func prepareAuthSpec(
 		EnvAdditions: map[string]string{},
 		Cleanup:      func() {},
 		CaptureFn:    func(context.Context) {},
+		ChownFn:      func() error { return nil },
 	}
 
 	if len(spec.EnvBindings) == 0 && len(spec.FileBindings) == 0 && len(spec.StaticFiles) == 0 {
@@ -532,17 +553,34 @@ func prepareAuthSpec(
 		}
 	}
 
-	// Chown the transient tree to the in-container agent UID now that
-	// every file is written and before the dir is mounted. On Linux
-	// rootful Docker this is the fix that lets the agent rewrite its
-	// credentials through the writable bind mount; on other platforms
-	// the hook is nil. A resolver/chown failure is non-fatal: warn with
-	// a permanent diagnostic naming the UID mismatch and the chown fix,
-	// then proceed so a transient lookup hiccup never aborts a launch.
+	// Defer the chown of the transient tree to the in-container agent
+	// UID into a closure the launcher invokes AFTER it has placed the
+	// agent's MCP config into the tree (collapseNestedMCPMounts). On
+	// Linux rootful Docker this is the fix that lets the agent rewrite
+	// its credentials through the writable bind mount; on other
+	// platforms the hook is nil and the closure is a no-op.
+	//
+	// Ordering matters (issue #1488): Codex's MCP config.toml nests
+	// under the AuthSpec's /home/agent/.codex/ directory mount, so the
+	// launcher's collapse step does an unprivileged host-side
+	// MkdirAll+WriteFile into this tree. If the chown ran here (at prep
+	// time) it would re-own the whole tree to the foreign agent UID with
+	// mode 0700 first, and that later host-side write would fail with
+	// EPERM. Running the chown after the placement lets the single
+	// delegated chown re-own config.toml alongside auth.json. A
+	// resolver/chown failure is non-fatal: warn with a permanent
+	// diagnostic naming the UID mismatch and the chown fix, then proceed
+	// so a transient lookup hiccup never aborts a launch.
 	if chownTransientDir != nil {
-		if err := chownTransientDir(hostRoot); err != nil {
-			captureWarn(sessionLog, stderr, agentName, hostRoot,
-				fmt.Errorf("chown transient auth dir to image agent UID: %w; the agent runs as a non-root system user while the host operator owns this bind-mounted dir (host UID vs resolved agent UID mismatch), so in-container credential rotation may fail with EPERM — the remedy is the chown-to-agent-UID fix on the AuthSpec bind mount", err))
+		prep.ChownFn = func() error {
+			if err := chownTransientDir(hostRoot); err != nil {
+				captureWarn(sessionLog, stderr, agentName, hostRoot,
+					fmt.Errorf("chown transient auth dir to image agent UID: %w; the agent runs as a non-root system user while the host operator owns this bind-mounted dir (host UID vs resolved agent UID mismatch), so in-container credential rotation may fail with EPERM — the remedy is the chown-to-agent-UID fix on the AuthSpec bind mount", err))
+			}
+			// The warning above is the user-facing surface; a chown hiccup
+			// is non-fatal, so the launcher treats this as best-effort and
+			// the closure never returns an error.
+			return nil
 		}
 	}
 

--- a/internal/launch/authspec_runtime_test.go
+++ b/internal/launch/authspec_runtime_test.go
@@ -1152,6 +1152,19 @@ func TestPrepareAuthSpec_ChownHookInvokedWithHostRootAfterFilesExist(t *testing.
 	}
 	defer prep.Cleanup()
 
+	// The chown is deferred (issue #1488): prep wraps the hook in
+	// prep.ChownFn and the launcher invokes it AFTER placing the MCP
+	// config, not at prep time. So the hook must not have run yet.
+	if gotDir != "" {
+		t.Fatal("chown hook ran during prepareAuthSpec; it must be deferred to prep.ChownFn so the launcher can place the MCP config first")
+	}
+	if prep.ChownFn == nil {
+		t.Fatal("prep.ChownFn must be non-nil when a chown hook is supplied")
+	}
+	if err := prep.ChownFn(); err != nil {
+		t.Fatalf("prep.ChownFn: %v", err)
+	}
+
 	if gotDir == "" {
 		t.Fatal("chown hook was never invoked")
 	}
@@ -1213,6 +1226,12 @@ func TestPrepareAuthSpec_ChownHookErrorIsNonFatal(t *testing.T) {
 
 	if len(prep.Mounts) != 1 {
 		t.Fatalf("Mounts = %d, want 1 (prep proceeds despite hook error)", len(prep.Mounts))
+	}
+	// The chown is deferred into prep.ChownFn; invoking it surfaces the
+	// non-fatal warning. A hook error must not propagate out of ChownFn
+	// (the launcher proceeds with the launch).
+	if err := prep.ChownFn(); err != nil {
+		t.Fatalf("ChownFn must not propagate a hook error, got %v", err)
 	}
 	// The permanent diagnostic must name the UID mismatch and the
 	// chown-to-agent-UID remedy so a regression is attributable.

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -792,7 +792,7 @@ func Launch(ctx context.Context, config LaunchConfig) (LaunchResult, error) {
 	var result LaunchResult
 	var runErr error
 	if sandboxEnabled {
-		result, runErr = launchSandbox(ctx, sandboxPlan, config, agentEnv, containerName, captureOnce, sessionLog, proxyBootstrap.Mounts...)
+		result, runErr = launchSandbox(ctx, sandboxPlan, config, agentEnv, containerName, captureOnce, authPrep.ChownFn, sessionLog, proxyBootstrap.Mounts...)
 	} else {
 		result, runErr = launchHost(ctx, config, daemonURL, sessionID, daemonToken, agentEnv)
 	}
@@ -1020,7 +1020,16 @@ func enclosingDirMount(mounts []sandboxcontainer.Volume, target string) *sandbox
 	return nil
 }
 
-func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, agentEnv map[string]string, containerName string, captureOnce func(), sessionLog *slog.Logger, extraMounts ...sandboxcontainer.Volume) (LaunchResult, error) {
+// chownAuthTree, when non-nil, recursively chowns the AuthSpec transient
+// tree to the resolved in-container agent UID. The launcher invokes it
+// AFTER collapseNestedMCPMounts has placed the agent's MCP config into
+// that tree, so the single delegated chown re-owns config.toml alongside
+// auth.json. Running the chown before the placement re-owned the tree to
+// the foreign agent UID with mode 0700 first, which made the unprivileged
+// host-side MkdirAll/WriteFile in the collapse fail with EPERM on rootful
+// Docker Linux (issue #1488). A nil chownAuthTree is a safe no-op (host
+// launch, non-Linux host, or an agent with no AuthSpec).
+func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchConfig, agentEnv map[string]string, containerName string, captureOnce func(), chownAuthTree func() error, sessionLog *slog.Logger, extraMounts ...sandboxcontainer.Volume) (LaunchResult, error) {
 	commandName := firstAgentBinary(config.Agent)
 	if commandName == "" {
 		return LaunchResult{}, fmt.Errorf("agent %q has no container command", config.Agent.Name())
@@ -1077,6 +1086,20 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 		return LaunchResult{}, fmt.Errorf("placing MCP config for %s: %w", config.Agent.Name(), err)
 	}
 	mounts = collapsed
+
+	// Chown the AuthSpec transient tree to the in-container agent UID now
+	// that the MCP config has been placed into it (issue #1488). The chown
+	// MUST follow the collapse above: the collapse does an unprivileged
+	// host-side MkdirAll+WriteFile of Codex's config.toml into the AuthSpec
+	// dir mount's host source, and chowning the tree to the foreign agent
+	// UID with mode 0700 first would make that write fail with EPERM on
+	// rootful Docker Linux. The single delegated chown here re-owns
+	// config.toml alongside auth.json. A nil hook is a safe no-op.
+	if chownAuthTree != nil {
+		if err := chownAuthTree(); err != nil {
+			return LaunchResult{}, fmt.Errorf("chowning auth tree for %s: %w", config.Agent.Name(), err)
+		}
+	}
 
 	command := append([]string{commandName}, config.Agent.Args(ModeSandbox)...)
 	command = append(command, extraArgs...)

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -14,6 +14,7 @@ import (
 
 	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/vault"
 	"github.com/ALRubinger/aileron/internal/version"
 )
 
@@ -170,7 +171,7 @@ func TestHostMCPEnvOmitsEmptyToken(t *testing.T) {
 func TestLaunchSandboxRejectsAgentWithoutBinary(t *testing.T) {
 	_, err := launchSandbox(nil, SandboxLaunchPlan{Runtime: "docker", Image: "image:test"}, LaunchConfig{
 		Agent: emptyBinaryAgent{},
-	}, nil, "aileron-sbx-test", func() {}, nil)
+	}, nil, "aileron-sbx-test", func() {}, nil, nil)
 	if err == nil {
 		t.Fatal("expected missing container command error")
 	}
@@ -375,7 +376,7 @@ func launchSandboxCapturedVolumes(t *testing.T) []sandboxcontainer.Volume {
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
 	_, err := launchSandbox(context.Background(), SandboxLaunchPlan{Runtime: "docker", Image: "image:test"}, LaunchConfig{
 		Agent: namedBinaryAgent{name: "claude"},
-	}, map[string]string{}, "aileron-sbx-test", func() {}, logger)
+	}, map[string]string{}, "aileron-sbx-test", func() {}, nil, logger)
 	if err != nil {
 		t.Fatalf("launchSandbox: %v", err)
 	}
@@ -1097,5 +1098,120 @@ func TestEnclosingDirMount_IdentityTargetNotEnclosing(t *testing.T) {
 	}
 	if got := enclosingDirMount(mounts, "/home/agent/.codex/config.toml"); got == nil {
 		t.Fatal("enclosingDirMount returned nil for nested target, want the dir mount")
+	}
+}
+
+// codexNestedMCPMount returns a Codex-shaped AuthSpec whose single
+// FileBinding produces a directory mount at /home/agent/.codex/
+// (MountAsFile=false), mirroring the real Codex AuthSpec the launcher
+// materializes. With an empty vault the no-creds path runs ensureGroup
+// and keeps the .codex dir mounted because MountAsFile is false, exactly
+// the shape that triggered issue #1488.
+func codexNestedMCPSpec() AuthSpec {
+	return AuthSpec{
+		FileBindings: []FileBinding{{
+			VaultPath:     "agents/codex/oauth",
+			ContainerPath: "/home/agent/.codex/auth.json",
+			Mode:          0o600,
+			Required:      false,
+			Render:        func(s vault.Secret) ([]byte, error) { return s.Value, nil },
+			Capture:       func(b []byte) (vault.Secret, error) { return vault.Secret{Value: b}, nil },
+		}},
+	}
+}
+
+// TestChownAfterMCPPlacement_CodexOrdering is the #1488 regression. The
+// chown that re-owns the AuthSpec transient tree to the foreign agent UID
+// (mode 0700) must run AFTER the launcher places Codex's config.toml into
+// the .codex directory mount, otherwise the unprivileged host-side write
+// in collapseNestedMCPMounts fails with EPERM ("permission denied").
+//
+// The test drives the production ordering: prepareAuthSpec renders the
+// AuthSpec (deferring the chown into prep.ChownFn), collapseNestedMCPMounts
+// places config.toml into the .codex dir mount source, THEN prep.ChownFn
+// runs. The chown hook emulates the foreign-UID 0700 state by stripping
+// write permission from the group dir; because the placement already ran,
+// it succeeds. A control assertion shows the inverse ordering (chown then
+// place) fails — proving the test would catch a regression that re-ordered
+// the chown back before the placement.
+func TestChownAfterMCPPlacement_CodexOrdering(t *testing.T) {
+	daemon := newFakeDaemon() // empty vault: no-creds path, .codex still mounted
+
+	// The chown hook emulates the EPERM the real chown-to-foreign-UID-0700
+	// causes for an unprivileged host process: it removes write permission
+	// from the .codex group dir so any later host-side write fails.
+	var chowned bool
+	hook := func(dir string) error {
+		chowned = true
+		codexDir := filepath.Join(dir, "home", "agent", ".codex")
+		if err := os.Chmod(codexDir, 0o500); err != nil {
+			return err
+		}
+		// Restore at cleanup so prep.Cleanup's RemoveAll can recurse.
+		t.Cleanup(func() { _ = os.Chmod(codexDir, 0o700) })
+		return nil
+	}
+
+	prep, err := prepareAuthSpec(context.Background(), "codex", codexNestedMCPSpec(),
+		daemon, newTestLogger(), nil, hook, nil, true)
+	if err != nil {
+		t.Fatalf("prepareAuthSpec: %v", err)
+	}
+	defer prep.Cleanup()
+
+	// The chown must be deferred, not run at prep time.
+	if chowned {
+		t.Fatal("chown ran during prepareAuthSpec; #1488 requires it to be deferred so the MCP config is placed first")
+	}
+	if len(prep.Mounts) != 1 || prep.Mounts[0].Target != "/home/agent/.codex" {
+		t.Fatalf("expected one /home/agent/.codex dir mount, got %+v", prep.Mounts)
+	}
+
+	// Build the sandbox mount list as launchSandbox does and run the
+	// nested-collapse placement BEFORE the chown.
+	cfgSource := filepath.Join(t.TempDir(), "config.toml")
+	cfgBody := []byte("[mcp_servers.aileron]\ncommand = \"/usr/local/bin/aileron-mcp\"\n")
+	if err := os.WriteFile(cfgSource, cfgBody, 0o600); err != nil {
+		t.Fatalf("seed config.toml: %v", err)
+	}
+	mcp := []MCPMount{{Source: cfgSource, Target: "/home/agent/.codex/config.toml", ReadOnly: true}}
+
+	collapsed, err := collapseNestedMCPMounts(prep.Mounts, mcp)
+	if err != nil {
+		t.Fatalf("collapseNestedMCPMounts (placement must succeed before chown): %v", err)
+	}
+	// config.toml must now live inside the .codex dir mount source.
+	placed := filepath.Join(prep.Mounts[0].Source, "config.toml")
+	if data, err := os.ReadFile(placed); err != nil {
+		t.Fatalf("config.toml not placed into .codex dir mount: %v", err)
+	} else if string(data) != string(cfgBody) {
+		t.Errorf("placed config.toml = %q, want %q", data, cfgBody)
+	}
+	if n := nestedMountTarget(collapsed); n != "" {
+		t.Fatalf("nested bind mount survived collapse: %q", n)
+	}
+
+	// Now the chown runs (deferred). It must not error out of ChownFn.
+	if err := prep.ChownFn(); err != nil {
+		t.Fatalf("prep.ChownFn: %v", err)
+	}
+	if !chowned {
+		t.Fatal("prep.ChownFn did not invoke the chown hook")
+	}
+
+	// Control: prove the bug the ordering prevents. Once the dir is
+	// chowned (0500 here), a fresh placement into it fails with EPERM —
+	// which is exactly what the old "chown during prep" ordering caused.
+	cfg2 := filepath.Join(t.TempDir(), "config.toml")
+	if err := os.WriteFile(cfg2, cfgBody, 0o600); err != nil {
+		t.Fatalf("seed second config.toml: %v", err)
+	}
+	if os.Geteuid() != 0 { // root bypasses DAC, so the control only holds unprivileged
+		if _, err := collapseNestedMCPMounts(
+			[]sandboxcontainer.Volume{{Source: prep.Mounts[0].Source, Target: "/home/agent/.codex"}},
+			[]MCPMount{{Source: cfg2, Target: "/home/agent/.codex/sub/config.toml"}},
+		); err == nil {
+			t.Fatal("placement into a chowned (write-denied) dir unexpectedly succeeded; the control proves the ordering matters")
+		}
 	}
 }

--- a/internal/launch/launcher_signal_test.go
+++ b/internal/launch/launcher_signal_test.go
@@ -115,7 +115,7 @@ func runSalvageLaunchSandbox(t *testing.T, captureOnce func()) (LaunchResult, er
 	// A real (discarding) logger exercises the sessionLog != nil
 	// branches the production launcher always takes.
 	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
-	return launchSandbox(context.Background(), plan, cfg, map[string]string{}, "aileron-sbx-test", captureOnce, logger)
+	return launchSandbox(context.Background(), plan, cfg, map[string]string{}, "aileron-sbx-test", captureOnce, nil, logger)
 }
 
 // TestLaunchSandboxSignalSalvagesCapture is the core regression: a


### PR DESCRIPTION
## Summary

`aileron launch codex` (Linux, rootful Docker) died at startup with:

```
placing MCP config for codex: ... mkdir /tmp/aileron-agent-auth-codex-*/home: permission denied
```

Root cause is an ordering bug between the agent-UID chown hook and MCP-config placement:

- `prepareAuthSpec` materializes the transient auth tree and, at its tail, invoked `chownTransientDir`, which recursively chowns the **entire** `hostRoot` tree to the foreign in-container agent UID (e.g. 1000) at mode `0700` via a delegated root container (the host launcher is unprivileged).
- Later, `launchSandbox` calls `collapseNestedMCPMounts`, which detects Codex's `config.toml` (target `/home/agent/.codex/config.toml`) as nested under the AuthSpec's `/home/agent/.codex/` directory mount and relocates it with an unprivileged host-side `os.MkdirAll`/`os.WriteFile` into the group dir.
- Because the tree was already chowned to the foreign UID with mode `0700`, the unprivileged launcher can no longer write into it, so the placement fails with EPERM.

This is independent of whether credentials exist: the no-creds path still runs `ensureGroup` and keeps the `.codex` dir mounted (`MountAsFile=false`), so a fresh `launch codex` against an empty vault dies here too.

### Fix

Defer the chown so it runs **after** the MCP config has been placed into the tree:

- `prepareAuthSpec` no longer invokes `chownTransientDir` inline. It wraps it in `prep.ChownFn` (a no-op when the hook is nil).
- The launcher threads `authPrep.ChownFn` into `launchSandbox` and invokes it right after `collapseNestedMCPMounts`. The single delegated chown re-owns `config.toml` alongside `auth.json` while the host operator still owns the tree during placement.

Non-nested agents (everyone but Codex today) are unaffected: their MCP mount is appended unchanged with no ordering dependency. The reclaim hook and capture-on-exit are unchanged. No API/spec change — internal launcher plumbing only.

The sibling Codex device-code interval-parse defect (#1489) is out of scope here and landed separately as #1490.

## Test plan

- `TestChownAfterMCPPlacement_CodexOrdering` (new): drives the Codex-shaped nested MCP mount through the deferred-chown ordering. It asserts the chown is deferred (not run at prep time), that `collapseNestedMCPMounts` places `config.toml` into the `.codex` dir mount source successfully, and that `prep.ChownFn` then runs. A control assertion shows that placement into an already-chowned (write-denied) dir fails — proving the test catches a regression that re-orders the chown back before placement. Verified this test (and the updated `TestPrepareAuthSpec_ChownHookInvokedWithHostRootAfterFilesExist`) **fail** under the old inline-chown ordering and pass after the fix.
- Updated `TestPrepareAuthSpec_ChownHookInvokedWithHostRootAfterFilesExist` and `TestPrepareAuthSpec_ChownHookErrorIsNonFatal` to invoke `prep.ChownFn` at the new call point; they still assert the hook receives `hostRoot`, that rendered files exist when it runs, and that a hook error is non-fatal.
- `go test ./internal/launch/...` — all pass.
- Full Go suite (`./internal/...`, `cmd/aileron`, `cmd/aileron-mcp`, `sdk/go`) — all pass. `go vet` and `gofmt` clean.

On non-Linux hosts the chown hook is nil, so the unit-level reorder check still applies (the closure is a no-op).

Closes #1488

🤖 Generated with [Claude Code](https://claude.com/claude-code)
