### PR TITLE
test(system): make R8 image probe tolerate digest-pinned refs

### DIFF
--- a/test/system/README.md
+++ b/test/system/README.md
@@ -73,10 +73,12 @@ session id at runtime, so the exact name is discovered, not predicted).
   proof.
 - **R8 — wiring invariants** (shared `lib/probes.sh`, designed so the claude
   scenario #1477 can reuse every function verbatim once it lands):
-  1. **Image** — `.Config.Image` is
-     `ghcr.io/alrubinger/aileron-sandbox-codex:edge` for a dev build
-     (`imageTag` → `edge`), `:latest` for a release; `.State.Running == true`.
-     Override with `EXPECTED_IMAGE=…` to assert a release tag or a digest pin.
+  1. **Image** — `.Config.Image` references the
+     `ghcr.io/alrubinger/aileron-sandbox-codex` repo with either a floating tag
+     (`:edge` for a dev build, `:latest` for a release) or an `@sha256:` digest
+     pin (the reproducible-release path resolves the floating ref to a digest),
+     and `.State.Running == true`. Override with `EXPECTED_IMAGE=…` to assert a
+     specific ref exactly.
   2. **MCP** — `/usr/local/bin/aileron-mcp` present + executable; the codex MCP
      config at `/home/agent/.codex/config.toml` contains
      `[mcp_servers.aileron]`; the daemon-wiring env vars `AILERON_URL`,
@@ -125,8 +127,10 @@ The claude scenario (`test/system/claude.sh`) is the sibling of the codex one
 and reuses the same shared R8 probes. It differs only in the claude-specific
 bindings (issue #1477):
 
-- **Image** — `.Config.Image` is `ghcr.io/alrubinger/aileron-sandbox-claude:edge`
-  for a dev build, `:latest` for a release (`EXPECTED_IMAGE=…` to override).
+- **Image** — `.Config.Image` references the
+  `ghcr.io/alrubinger/aileron-sandbox-claude` repo with a floating tag
+  (`:edge` dev, `:latest` release) or an `@sha256:` digest pin
+  (`EXPECTED_IMAGE=…` to assert a specific ref exactly).
 - **MCP** — claude is wired via the `--mcp-config <json>` CLI flag
   (`internal/launch/agents/claude.go` `ConfigureMCP`), **not** a `config.toml`.
   The probe asserts the `--mcp-config` flag and the `"aileron"` server marker on

--- a/test/system/lib/probes.sh
+++ b/test/system/lib/probes.sh
@@ -52,16 +52,71 @@ discover_container() {
 	printf '%s\n' "$match"
 }
 
+# image_repo <image_ref>
+# Echoes the repository portion of an image ref — everything before the `:tag`
+# or `@sha256:` digest suffix. `:edge`, `:latest`, and `@sha256:abc…` all strip
+# to the same repo. A bare repo (no tag, no digest) echoes unchanged.
+# Pure string logic (no docker), so it is host-verifiable in the contract test.
+image_repo() {
+	ref="$1"
+	# Strip an `@…` digest suffix first (a digest ref never also carries `:tag`
+	# after the `@`, and the repo's registry `host:port` colon precedes the `@`).
+	case "$ref" in
+	*@*) ref="${ref%@*}" ;;
+	esac
+	# Strip a trailing `:tag`. Guard against a registry `host:port` with no tag
+	# (e.g. `localhost:5000/x`) by only stripping when the final path segment
+	# (after the last `/`) contains the colon.
+	last="${ref##*/}"
+	case "$last" in
+	*:*) ref="${ref%:*}" ;;
+	esac
+	printf '%s' "$ref"
+}
+
+# image_ref_matches <expected_ref> <actual_ref>
+# R8.1 image-equality with digest tolerance. The launcher resolves the
+# expected floating ref (e.g. ghcr.io/alrubinger/aileron-sandbox-codex:edge)
+# to whatever it pulled: the same floating tag on a dev build, or a
+# `…-codex@sha256:…` digest pin on a reproducible release (scaffold.go
+# PublishedAgentImage, #1233). A match requires the SAME repository plus
+# either a floating tag (`:edge`/`:latest`) or an `@sha256:` digest — so a
+# pinned release no longer fails this probe, while a wrong repo/agent (e.g.
+# the claude image) still does. Pure string logic; host-verifiable.
+image_ref_matches() {
+	expected="$1"
+	actual="$2"
+	exp_repo="$(image_repo "$expected")"
+	act_repo="$(image_repo "$actual")"
+	[ "$exp_repo" = "$act_repo" ] || return 1
+	# Accept a floating tag or an @sha256: digest on the matched repo.
+	case "$actual" in
+	"${act_repo}:edge" | "${act_repo}:latest") return 0 ;;
+	"${act_repo}@sha256:"*) return 0 ;;
+	esac
+	# Exact match against the expected ref (covers a caller-supplied digest or
+	# any other explicit EXPECTED_IMAGE override).
+	[ "$expected" = "$actual" ]
+}
+
 # probe_image <container> <expected_image>
-# R8.1 — correct image pulled & running. Asserts .Config.Image equals the
-# expected ref (caller passes :edge for a dev build, :latest for a release,
-# or a digest pin) and the container is running.
+# R8.1 — correct image pulled & running. Asserts .Config.Image references the
+# same repository as the expected ref and carries either a floating tag
+# (`:edge`/`:latest`) or an `@sha256:` digest pin (release reproducibility),
+# and that the container is running. An explicit EXPECTED_IMAGE that names a
+# digest or other ref still matches exactly.
 probe_image() {
 	container="$1"
 	expected_image="$2"
 	actual_image="$(docker inspect -f '{{.Config.Image}}' "$container" 2>/dev/null)" ||
 		{ fail "docker inspect $container failed (probe_image)"; return 1; }
-	assert_eq "$expected_image" "$actual_image" "R8.1 container image is $expected_image" || return 1
+	if image_ref_matches "$expected_image" "$actual_image"; then
+		log "ok: R8.1 container image matches $expected_image (actual: $actual_image)"
+	else
+		printf 'systest: FAIL: R8.1 container image\n  expected: %s (or its @sha256 digest on the same repo)\n  actual:   %s\n' \
+			"$expected_image" "$actual_image" >&2
+		return 1
+	fi
 
 	running="$(docker inspect -f '{{.State.Running}}' "$container" 2>/dev/null)"
 	assert_eq "true" "$running" "R8.1 container .State.Running" || return 1

--- a/test/system/lib/probes_test.sh
+++ b/test/system/lib/probes_test.sh
@@ -87,6 +87,52 @@ check "probe_exit_code returns 0 when codes match" "$?" 0
 probe_exit_code 1 0 >/dev/null 2>&1
 check "probe_exit_code returns non-zero when codes differ" "$?" 1
 
+# --- image_repo / image_ref_matches: R8.1 digest-tolerant image equality -----
+# These are pure string helpers (no docker), so they are host-verifiable here.
+
+# image_repo strips a floating tag, a digest, or a bare ref to the same repo.
+out="$(image_repo 'ghcr.io/alrubinger/aileron-sandbox-codex:edge')"
+assert_eq "ghcr.io/alrubinger/aileron-sandbox-codex" "$out" "image_repo strips :edge" >/dev/null 2>&1
+check "image_repo strips a floating tag" "$?" 0
+out="$(image_repo 'ghcr.io/alrubinger/aileron-sandbox-codex@sha256:abc123')"
+assert_eq "ghcr.io/alrubinger/aileron-sandbox-codex" "$out" "image_repo strips @sha256 digest" >/dev/null 2>&1
+check "image_repo strips an @sha256 digest" "$?" 0
+out="$(image_repo 'localhost:5000/aileron-sandbox-codex')"
+assert_eq "localhost:5000/aileron-sandbox-codex" "$out" "image_repo keeps a registry host:port with no tag" >/dev/null 2>&1
+check "image_repo keeps a registry host:port when there is no tag" "$?" 0
+
+# A floating-tag expected ref matches the same floating tag.
+image_ref_matches 'ghcr.io/alrubinger/aileron-sandbox-codex:edge' \
+	'ghcr.io/alrubinger/aileron-sandbox-codex:edge' >/dev/null 2>&1
+check "image_ref_matches accepts the same floating tag" "$?" 0
+
+# THE REGRESSION: a floating expected ref matches the digest the launcher
+# actually pulled on a reproducible release (#1233). Strict assert_eq failed
+# here; image_ref_matches must accept it.
+image_ref_matches 'ghcr.io/alrubinger/aileron-sandbox-codex:edge' \
+	'ghcr.io/alrubinger/aileron-sandbox-codex@sha256:deadbeef' >/dev/null 2>&1
+check "image_ref_matches accepts a digest pin on the same repo (release path)" "$?" 0
+
+# A :latest expected ref also matches a digest on the same repo.
+image_ref_matches 'ghcr.io/alrubinger/aileron-sandbox-codex:latest' \
+	'ghcr.io/alrubinger/aileron-sandbox-codex@sha256:deadbeef' >/dev/null 2>&1
+check "image_ref_matches accepts a digest pin against a :latest expectation" "$?" 0
+
+# A DIFFERENT repo/agent (claude image) must still fail even via a digest.
+image_ref_matches 'ghcr.io/alrubinger/aileron-sandbox-codex:edge' \
+	'ghcr.io/alrubinger/aileron-sandbox-claude@sha256:deadbeef' >/dev/null 2>&1
+check "image_ref_matches rejects a digest pin on a different agent repo" "$?" 1
+
+# A wrong (non-floating, non-digest) tag on the right repo must still fail.
+image_ref_matches 'ghcr.io/alrubinger/aileron-sandbox-codex:edge' \
+	'ghcr.io/alrubinger/aileron-sandbox-codex:v0.0.1' >/dev/null 2>&1
+check "image_ref_matches rejects an unexpected tag on the right repo" "$?" 1
+
+# An explicit EXPECTED_IMAGE digest override matches exactly.
+image_ref_matches 'ghcr.io/alrubinger/aileron-sandbox-codex@sha256:abc' \
+	'ghcr.io/alrubinger/aileron-sandbox-codex@sha256:abc' >/dev/null 2>&1
+check "image_ref_matches accepts an exact digest override" "$?" 0
+
 # --- probe_mcp_runtime: the agent-agnostic R8.2 core (binary + env) ----------
 # All sub-checks green: aileron-mcp present (test -x rc 0) and every daemon env
 # var set (printenv rc 0) -> returns 0.


### PR DESCRIPTION
## Summary

Operator-authorized fix for the parked finding in #1482 (feature #1476). The shared R8 image probe (`test/system/lib/probes.sh` `probe_image`) used a strict `assert_eq` against the floating expected ref. On the reproducible-release path the launcher resolves the floating ref to a `…@sha256:` digest pin (`scaffold.go` `PublishedAgentImage`, #1233), so a pinned release run failed R8.1 with a false negative.

This makes the probe digest-tolerant exactly as the operator specified in #1482: assert the `ghcr.io/alrubinger/aileron-sandbox-<agent>` repo prefix AND accept either a floating tag (`:edge`/`:latest`) OR an `@sha256:` digest, instead of the strict exact match. An explicit `EXPECTED_IMAGE` override still matches exactly. The claude scenario reuses this probe, so the fix covers both #1476 and #1477.

Implemented as two pure, host-verifiable helpers:
- `image_repo` — strips a tag or `@sha256:` digest to the repository (registry `host:port` with no tag preserved).
- `image_ref_matches` — same repo AND (floating tag OR `@sha256:` digest), with an exact-match fallback for an explicit `EXPECTED_IMAGE`.

A wrong repo/agent (e.g. the claude image via a digest) or an unexpected tag still fails.

The other two findings in #1482 were resolved/moot at ship (R10 no longer asserts the never-produced `aileron.action.name`; the `test/system/` harness landed via #1475/#1484) — no code change for those.

## Test plan

- `sh test/system/lib/probes_test.sh` — all contract cases pass, including new regression cases: digest pin accepted on the same repo (the case that failed under strict `assert_eq`), `:latest`-vs-digest accepted, different-agent digest rejected, unexpected tag rejected, exact digest override accepted.
- `shellcheck -s sh` clean (only the pre-existing SC1091 source-following info).
- README updated to describe the digest-tolerant default for both scenarios.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated sandbox image assertion documentation to clarify support for both floating tags and digest-pinned references.

* **Tests**
  * Added test coverage for Docker image reference matching logic, validating correct handling of floating tags and digest pins.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->