### PR TITLE
fix(test): accept vault-backed claude credential in system-test precond

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -450,10 +450,12 @@ tasks:
     internal: true
     desc: >-
       Fail-fast preconditions for an agent system-test scenario: Docker must be
-      reachable AND the agent's host-side auth file (the launcher's AuthSpec
-      mounts these) must exist. Pass AGENT=codex|claude. On a missing auth
-      file, exits non-zero naming the file and the command to create it — never
-      a silent skip.
+      reachable AND the agent's credential must be resolvable. Pass
+      AGENT=codex|claude. For codex the host-side auth file the launcher's
+      AuthSpec mounts must exist. For claude the credential is vault-backed
+      (agents/claude/oauth), so the gate passes when EITHER the host file
+      exists OR the vault/daemon holds the entry. On a missing credential,
+      exits non-zero naming the remediation — never a silent skip.
     vars:
       AGENT: '{{.AGENT}}'
     cmds:
@@ -465,20 +467,32 @@ tasks:
           codex)
             authfile="$HOME/.codex/auth.json"
             logincmd="codex login"
+            if [ ! -f "$authfile" ]; then
+              echo "Missing codex auth file: $authfile. Authenticate first with: $logincmd" >&2
+              exit 1
+            fi
             ;;
           claude)
+            # Claude's credential is vault-backed (agents/claude/oauth): the
+            # launcher's AuthSpec renders it into the sandbox at run time, so
+            # the host file may be absent on a machine where the credential
+            # lives only in the vault. Accept EITHER source.
             authfile="$HOME/.claude/.credentials.json"
             logincmd="claude /login"
+            if [ -f "$authfile" ]; then
+              :
+            elif aileron vault list --scope agent 2>/dev/null | grep -qx "agents/claude/oauth"; then
+              :
+            else
+              echo "Missing claude credential: neither host file $authfile nor a vault entry (agents/claude/oauth) is present. Authenticate first with: $logincmd" >&2
+              exit 1
+            fi
             ;;
           *)
             echo "Unknown AGENT '{{.AGENT}}' (expected codex or claude)" >&2
             exit 1
             ;;
         esac
-        if [ ! -f "$authfile" ]; then
-          echo "Missing {{.AGENT}} auth file: $authfile. Authenticate first with: $logincmd" >&2
-          exit 1
-        fi
 
   _test:system:cleanup:
     internal: true

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -148,10 +148,12 @@ audit round-trip are identical to codex and reuse the shared probes unchanged.
 Prerequisites (the scenario fail-fasts with the exact remediation if missing):
 
 1. A reachable Docker daemon (`docker info`).
-2. A host-side Claude login. Claude's credentials are vault-captured on first
-   launch (ADR-0025), not a plain creds file you write directly: run
-   `aileron launch claude` once and complete the in-flow login (or
-   `claude /login`) so `~/.claude/.credentials.json` is populated.
+2. A Claude login resolvable by the launcher's AuthSpec. Claude's credentials
+   are vault-backed (`agents/claude/oauth`, ADR-0025), so the precondition
+   passes when EITHER the host file `~/.claude/.credentials.json` exists OR the
+   vault holds the entry (`aileron vault list --scope agent` prints
+   `agents/claude/oauth`). Run `aileron launch claude` once and complete the
+   in-flow login (or `claude /login`) to populate it.
 3. A running Aileron daemon if you want the R10 audit assertion to read real
    records (`AILERON_STATE_DIR` defaults to `~/.aileron`).
 


### PR DESCRIPTION
## Summary

The `_test:system:precond` helper in `Taskfile.yml` hard-gated the **claude**
scenario on the host file `$HOME/.claude/.credentials.json` (`Taskfile.yml`,
old lines 470/478-481) with no vault fallback. But Claude's agent credential is
vault-backed (`agents/claude/oauth`, ADR-0025): the launcher's AuthSpec renders
it into the sandbox at run time, so on a host where the credential lives only in
the vault the host file is absent and the precond false-negatived, blocking the
system-test scenario even though the credential is fully resolvable.

This reconciles the claude precond to the vault model:

- The gate passes when **EITHER** the host file `$HOME/.claude/.credentials.json`
  exists **OR** `aileron vault list --scope agent` reports the
  `agents/claude/oauth` entry.
- It still fails fast with the actionable remediation message only when
  **neither** source is present.
- The **codex** branch is unchanged — it remains a host-file check on
  `$HOME/.codex/auth.json`.

`test/system/README.md` prerequisite #2 is updated to describe the
EITHER/OR resolution.

This is the operator-authorized exact change for cw-review-residual #1483
(sub-issue #1475); no other behavior changes.

## Test plan

- `task --dry test:system:launch:claude` and `task --dry test:system:launch:codex`
  both compile the target cleanly (the repo's static gate for the by-hand
  system-test scenarios).
- `shellcheck -s sh` clean on the rewritten precond shell.
- `task test:system:smoke` (real build + Docker precondition + defer cleanup)
  passes: "harness OK".
- Functional verification of the claude branch (temp HOME + stubbed `aileron`):
  - host file present → exit 0
  - host file absent, vault lists `agents/claude/oauth` → exit 0
  - host file absent, vault lists other entries only → exit 1 + remediation
  - host file absent, `aileron`/daemon unavailable → exit 1 + remediation

Closes #1483
