### PR TITLE
fix(sandbox): surface friendly headline when docker daemon unreachable

### DIFF
--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -333,8 +333,8 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 		if err != nil {
 			return BuildResult{}, err
 		}
-		if err := runner.Run(ctx, runtimeName, args, stdout, stderr); err != nil {
-			return BuildResult{}, fmt.Errorf("%s %s: %w", runtimeName, strings.Join(args, " "), err)
+		if err := runBuildStep(ctx, runner, runtimeName, args, stdout, stderr); err != nil {
+			return BuildResult{}, err
 		}
 		result.Built = true
 		return result, nil
@@ -374,8 +374,8 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 			if err != nil {
 				return BuildResult{}, err
 			}
-			if err := runner.Run(ctx, name, args, stdout, stderr); err != nil {
-				return BuildResult{}, fmt.Errorf("%s %s: %w", name, strings.Join(args, " "), err)
+			if err := runBuildStep(ctx, runner, name, args, stdout, stderr); err != nil {
+				return BuildResult{}, err
 			}
 			result.Built = true
 			return result, nil
@@ -384,8 +384,8 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 		if err != nil {
 			return BuildResult{}, err
 		}
-		if err := runner.Run(ctx, runtimeName, args, stdout, stderr); err != nil {
-			return BuildResult{}, fmt.Errorf("%s %s: %w", runtimeName, strings.Join(args, " "), err)
+		if err := runBuildStep(ctx, runner, runtimeName, args, stdout, stderr); err != nil {
+			return BuildResult{}, err
 		}
 		result.Built = true
 		return result, nil
@@ -420,8 +420,8 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 		}
 		// BuildPolicyAuto with the image absent, or BuildPolicyAlways: pull it.
 		pullArgs := []string{"pull", result.Image}
-		if err := runner.Run(ctx, runtimeName, pullArgs, stdout, stderr); err != nil {
-			return BuildResult{}, fmt.Errorf("%s %s: %w", runtimeName, strings.Join(pullArgs, " "), err)
+		if err := runBuildStep(ctx, runner, runtimeName, pullArgs, stdout, stderr); err != nil {
+			return BuildResult{}, err
 		}
 		return result, nil
 	case composition.TierBYOImage:
@@ -430,6 +430,56 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 	default:
 		return BuildResult{}, fmt.Errorf("unsupported sandbox composition tier %q", opts.Plan.Tier)
 	}
+}
+
+// daemonUnreachableMessage is the friendly headline surfaced when a sandbox
+// build/pull fails because the container daemon could not be reached (Docker
+// Desktop not running, the npipe/socket absent). The underlying technical
+// error is still chained via %w so the raw transport diagnostic remains
+// available for deeper troubleshooting; it is just no longer the headline.
+const daemonUnreachableMessage = "Docker isn't reachable; make sure Docker Desktop is running and available, then try again"
+
+// runBuildStep runs a single container build/pull command and translates a
+// daemon-unreachable failure into a friendly headline. It mirrors the
+// tee-and-translate convention StopContainer and Validate already use: the
+// runtime's stderr is teed into a buffer so the failure cause can be inspected
+// without swallowing the live output the user sees. On a daemon-unreachable
+// signature the returned error leads with daemonUnreachableMessage while still
+// chaining the original `<runtime> <args>: <exit>` error via %w, so
+// errors.Is/Unwrap continue to expose the underlying diagnostic. All other
+// failures keep the established `%s %s: %w` framing verbatim.
+func runBuildStep(ctx context.Context, runner Runner, runtimeName string, args []string, stdout, stderr io.Writer) error {
+	var stderrBuf bytes.Buffer
+	teedStderr := io.MultiWriter(stderr, &stderrBuf)
+	err := runner.Run(ctx, runtimeName, args, stdout, teedStderr)
+	if err == nil {
+		return nil
+	}
+	wrapped := fmt.Errorf("%s %s: %w", runtimeName, strings.Join(args, " "), err)
+	if detectDaemonUnreachable(stderrBuf.String()) {
+		return fmt.Errorf("%s: %w", daemonUnreachableMessage, wrapped)
+	}
+	return wrapped
+}
+
+// detectDaemonUnreachable reports whether a container build/pull error's stderr
+// indicates the container daemon could not be reached. Matched
+// case-insensitively against the signatures the Docker CLI emits on each
+// platform: Windows npipe (`failed to connect to the docker API`, `the system
+// cannot find the file specified`) and macOS/Linux (`cannot connect to the
+// docker daemon`). See runBuildStep and issue #1496.
+func detectDaemonUnreachable(stderr string) bool {
+	lowered := strings.ToLower(stderr)
+	for _, signature := range []string{
+		"cannot connect to the docker daemon",
+		"failed to connect to the docker api",
+		"the system cannot find the file specified",
+	} {
+		if strings.Contains(lowered, signature) {
+			return true
+		}
+	}
+	return false
 }
 
 func normalizeBuildPolicy(policy string) (string, error) {

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -633,6 +633,108 @@ func TestBuildPublishedAlwaysPullsRegardlessOfPresence(t *testing.T) {
 	}
 }
 
+func TestDetectDaemonUnreachable(t *testing.T) {
+	cases := []struct {
+		name   string
+		stderr string
+		want   bool
+	}{
+		{"empty", "", false},
+		{"macos linux daemon", "Cannot connect to the Docker daemon at unix:///var/run/docker.sock.", true},
+		{"lowercase daemon", "cannot connect to the docker daemon", true},
+		{"windows npipe api", "failed to connect to the docker API at npipe:////./pipe/docker_engine", true},
+		{"windows file not found", "open //./pipe/docker_engine: The system cannot find the file specified.", true},
+		{"manifest unknown is not unreachable", "Error response from daemon: manifest unknown", false},
+		{"permission denied is not unreachable", "Got permission denied while trying to connect to the Docker daemon socket", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := detectDaemonUnreachable(tc.stderr); got != tc.want {
+				t.Fatalf("detectDaemonUnreachable(%q) = %v, want %v", tc.stderr, got, tc.want)
+			}
+		})
+	}
+}
+
+// TestBuildPullDaemonUnreachableFriendlyHeadline asserts that when a pull
+// fails because the container daemon is unreachable, Build leads with the
+// friendly "Docker isn't reachable" headline rather than the raw `exit status
+// 1` transport error, while still chaining the underlying error so
+// errors.Is/Unwrap exposes it for deeper diagnosis. Regression for #1496.
+func TestBuildPullDaemonUnreachableFriendlyHeadline(t *testing.T) {
+	cases := []struct {
+		name   string
+		stderr string
+	}{
+		{
+			name:   "windows npipe",
+			stderr: "error during connect: Get \"http://%2F%2F.%2Fpipe%2Fdocker_engine/v1.45/...\": open //./pipe/docker_engine: The system cannot find the file specified.\nfailed to connect to the docker API at npipe:////./pipe/docker_engine\n",
+		},
+		{
+			name:   "macos linux daemon",
+			stderr: "Cannot connect to the Docker daemon at unix:///var/run/docker.sock. Is the docker daemon running?\n",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			underlying := errors.New("exit status 1")
+			runner := &stderrWritingRunner{stderrText: tc.stderr, errReturn: underlying}
+			_, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+				WorkDir: t.TempDir(),
+				Policy:  BuildPolicyAlways,
+				Plan: composition.Plan{
+					Tier:  composition.TierPublished,
+					Image: publishedImage,
+				},
+			})
+			if err == nil {
+				t.Fatal("Build returned nil error, want daemon-unreachable failure")
+			}
+			if !strings.HasPrefix(err.Error(), daemonUnreachableMessage) {
+				t.Fatalf("error headline = %q, want it to lead with %q", err.Error(), daemonUnreachableMessage)
+			}
+			if strings.HasPrefix(err.Error(), "exit status 1") {
+				t.Fatalf("error leads with raw transport error: %q", err.Error())
+			}
+			// The technical error stays chained as a deeper diagnostic.
+			if !errors.Is(err, underlying) {
+				t.Fatalf("errors.Is(err, underlying) = false; underlying error not chained: %q", err.Error())
+			}
+			if !strings.Contains(err.Error(), "docker pull "+publishedImage) {
+				t.Fatalf("error %q dropped the underlying `docker pull` framing", err.Error())
+			}
+		})
+	}
+}
+
+// TestBuildPullErrorNotDaemonUnreachableKeepsVerbatimWrap asserts that a pull
+// failure whose stderr does NOT match a daemon-unreachable signature keeps the
+// established `<runtime> <args>: <err>` framing without the friendly headline.
+func TestBuildPullErrorNotDaemonUnreachableKeepsVerbatimWrap(t *testing.T) {
+	underlying := errors.New("exit status 1")
+	runner := &stderrWritingRunner{
+		stderrText: "Error response from daemon: manifest unknown\n",
+		errReturn:  underlying,
+	}
+	_, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir: t.TempDir(),
+		Policy:  BuildPolicyAlways,
+		Plan: composition.Plan{
+			Tier:  composition.TierPublished,
+			Image: publishedImage,
+		},
+	})
+	if err == nil {
+		t.Fatal("Build returned nil error, want pull failure")
+	}
+	if strings.Contains(err.Error(), daemonUnreachableMessage) {
+		t.Fatalf("non-daemon error gained the friendly headline: %q", err.Error())
+	}
+	if !errors.Is(err, underlying) {
+		t.Fatalf("underlying error not chained: %q", err.Error())
+	}
+}
+
 func TestBuildDevcontainerImageDoesNotRequireRuntime(t *testing.T) {
 	result, err := Builder{Runtime: "definitely-not-a-runtime"}.Build(context.Background(), BuildOptions{
 		WorkDir: t.TempDir(),


### PR DESCRIPTION
## Summary

When Docker is unreachable, `aileron launch <agent>` surfaced docker's raw transport error (`failed to connect to the docker API at npipe://...`) plus our wrapper `docker pull ...: exit status 1`, with no friendly "start Docker Desktop" headline. The Go error carried only `exit status 1`, so the daemon-unreachable cause was never recognized or reframed.

This mirrors the established tee-and-translate convention already used by `StopContainer` (`isContainerAlreadyGone`) and `Validate`. The four `Builder.Build` run-sites (base build, devcontainer CLI features, devcontainer build, published pull) now route through a shared `runBuildStep` that:

- tees the runtime's stderr into a `bytes.Buffer` during the run,
- on failure, detects a daemon-unreachable signature via `detectDaemonUnreachable`,
- wraps with a friendly headline (`Docker isn't reachable; make sure Docker Desktop is running and available, then try again`) that **still chains the original technical error via `%w`** so `errors.Is`/`Unwrap` continue to expose the underlying `docker pull ...: exit status 1` diagnostic.

Signatures are matched case-insensitively to cover Windows npipe (`failed to connect to the docker API`, `the system cannot find the file specified`) and macOS/Linux (`cannot connect to the docker daemon`). Non-daemon failures keep the established `%s %s: %w` framing verbatim. The launcher's `prepare sandbox:` wrap at `launcher.go:554` is unchanged; the headline now leads right after that prefix instead of the opaque exit code.

## Test plan

- `TestDetectDaemonUnreachable` — table covering macOS/Linux, Windows npipe (both signatures), and negative cases (manifest unknown, permission denied, empty).
- `TestBuildPullDaemonUnreachableFriendlyHeadline` — table (Windows npipe text + macOS/Linux `Cannot connect to the Docker daemon` text) asserts the returned error leads with the friendly headline (not raw `exit status 1`) while `errors.Is`/`Unwrap` still exposes the underlying error and the `docker pull <image>` framing.
- `TestBuildPullErrorNotDaemonUnreachableKeepsVerbatimWrap` — a non-daemon pull failure keeps the verbatim wrap and does not gain the headline.
- `go test ./internal/sandbox/container/ -cover` → `92.3%`, full `./internal/sandbox/... ./internal/launch/...` green, `go vet` clean.

Closes #1496

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced error handling for sandbox image build and pull operations. When Docker daemon is unreachable, users now see clearer, user-friendly error headlines instead of raw exit codes, while underlying technical details remain available for troubleshooting.

* **Tests**
  * Added comprehensive unit tests verifying daemon unreachability detection and proper error message formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->