### PR TITLE
fix(launch): lead workspace-not-writable error with actionable fix

### DIFF
--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -8,6 +8,7 @@ import (
 	"fmt"
 	"io"
 	"os"
+	"runtime"
 	"sort"
 	"strings"
 
@@ -317,7 +318,7 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 	// aileron-mcp mounted under sandbox check, so requiring it would fail.
 	bakedVersion := sandboxCheckBakedVersionFn(context.Background(), resolvedRuntime, result.Image)
 	if err := sandboxCheckValidateFn(context.Background(), resolvedRuntime, cwd, result.Image, command, bakedVersion != ""); err != nil {
-		err = sandboxcomposition.EnrichValidateError(err, result.Tier, command, version.Version, cwd, sandboxcontainer.WorkspaceRelabelActive(resolvedRuntime))
+		err = sandboxcomposition.EnrichValidateError(err, result.Tier, command, version.Version, cwd, runtime.GOOS, sandboxcontainer.WorkspaceRelabelActive(resolvedRuntime))
 		fmt.Fprintf(stderr, "error: %v\n", err)
 		return 1
 	}

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -455,7 +455,7 @@ func validateSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchC
 		})
 	}
 	if err := validateSandboxImageForLaunch(ctx, plan, config, agentEnv, mounts, commandName); err != nil {
-		err = sandboxcomposition.EnrichValidateError(err, plan.Tier, config.Agent.Name(), version.Version, config.Dir, sandboxcontainer.WorkspaceRelabelActive(plan.Runtime))
+		err = sandboxcomposition.EnrichValidateError(err, plan.Tier, config.Agent.Name(), version.Version, config.Dir, runtime.GOOS, sandboxcontainer.WorkspaceRelabelActive(plan.Runtime))
 		return fmt.Errorf("sandbox image %s is not launchable for %s: %w", plan.Image, config.Agent.Name(), err)
 	}
 	return nil

--- a/internal/sandbox/composition/validatehint.go
+++ b/internal/sandbox/composition/validatehint.go
@@ -15,12 +15,16 @@ const agentNotFoundMarker = "agent command not found in sandbox image:"
 // workspaceNotWritableMarker is the substring the in-container validation script
 // emits when the writability probe fails (see runtime.go validationScript, the
 // exit-3 branch). The bare runtime failure surfaces as an opaque "exit status
-// 3"; EnrichValidateError matches this marker to explain the real cause and the
-// remedy. There are two distinct causes: a DAC uid mismatch (the non-root agent
-// user's uid differs from the host workspace owner, so "other" carries no write
-// bit on the 0755 directory) and, on SELinux-enforcing hosts, a MAC denial. The
-// enrichment picks the right diagnosis from whether the `:z` SELinux relabel was
-// actually applied (issue #1461).
+// 3"; EnrichValidateError matches this marker to lead with the one actionable
+// remedy (the launch working directory is not writable; run from a directory you
+// own) and then append a platform-appropriate deeper diagnostic. The diagnostic
+// has distinct causes by platform: a DAC uid mismatch on Linux + Docker (the
+// non-root agent user's uid differs from the host workspace owner, so "other"
+// carries no write bit on the 0755 directory), a MAC denial on SELinux-enforcing
+// hosts, and the C:\WINDOWS\system32 default-CWD trap on Windows (where Docker
+// Desktop translates uids and the uid-remap machinery does not apply). The
+// enrichment picks the diagnosis from hostOS and whether the `:z` SELinux
+// relabel was actually applied (issues #1461 and #1495).
 const workspaceNotWritableMarker = "sandbox workspace is not writable at"
 
 // EnrichValidateError augments a sandbox-image validate failure with tier, CWD,
@@ -34,7 +38,7 @@ const workspaceNotWritableMarker = "sandbox workspace is not writable at"
 // absent and what the operator can do. When the failure is not that case
 // (different tier, no published image, or a different validate error),
 // EnrichValidateError returns err unchanged.
-func EnrichValidateError(err error, tier Tier, agent, version, workDir string, selinuxRelabelActive bool) error {
+func EnrichValidateError(err error, tier Tier, agent, version, workDir, hostOS string, selinuxRelabelActive bool) error {
 	if err == nil {
 		return nil
 	}
@@ -43,7 +47,7 @@ func EnrichValidateError(err error, tier Tier, agent, version, workDir string, s
 	// denied access regardless of which image was selected. Match and enrich
 	// before the devcontainer-specific branch below.
 	if strings.Contains(err.Error(), workspaceNotWritableMarker) {
-		return enrichWorkspaceNotWritable(err, workDir, selinuxRelabelActive)
+		return enrichWorkspaceNotWritable(err, workDir, hostOS, selinuxRelabelActive)
 	}
 	if tier != TierDevcontainer {
 		return err
@@ -74,50 +78,78 @@ func EnrichValidateError(err error, tier Tier, agent, version, workDir string, s
 }
 
 // enrichWorkspaceNotWritable augments the opaque workspace-writability failure
-// ("exit status 3") with its real root cause and remediation. There are two
-// distinct causes, and the selinuxRelabelActive flag (from
-// container.WorkspaceRelabelActive: Linux + Docker + SELinux enforcing)
-// disambiguates them:
+// ("exit status 3") with its real root cause and remediation. Every variant
+// LEADS with the one actionable sentence that matters to the user — the launch
+// working directory is not writable, so run from a directory you own (e.g.
+// somewhere under your home) — and only then appends a platform-appropriate
+// deeper diagnostic. The headline is the same on every OS; the diagnostic is
+// chosen from hostOS and the selinuxRelabelActive flag (from
+// container.WorkspaceRelabelActive: Linux + Docker + SELinux enforcing):
 //
-//   - selinuxRelabelActive: Aileron applied the `:z` SELinux relabel to the
-//     mount, so a SELinux MAC denial is the plausible remaining cause. Keep the
-//     SELinux guidance and the manual `chcon` fallback.
-//   - !selinuxRelabelActive: the daemon has no SELinux support, or SELinux is
-//     not enforcing, so the `:z` relabel was never emitted. The cause is a DAC
-//     uid mismatch — the container's non-root agent user has a different numeric
-//     uid than the host owner of the workspace, so "other" carries no write bit
-//     on the 0755 directory. Report that mismatch and the remap remediation, and
-//     do NOT claim Aileron applied any relabel (it did not).
+//   - selinuxRelabelActive (Linux + Docker + SELinux enforcing): Aileron applied
+//     the `:z` SELinux relabel to the mount, so a SELinux MAC denial is the
+//     plausible remaining cause. Append the SELinux note and the manual `chcon`
+//     fallback.
+//   - hostOS == "linux" (Docker, no SELinux relabel): the cause is a DAC uid
+//     mismatch — the container's non-root agent user has a different numeric uid
+//     than the host owner of the workspace, so "other" carries no write bit on
+//     the 0755 directory. Append the uid-remap diagnostic, but do NOT claim
+//     Aileron applied any relabel (it did not).
+//   - Windows: Docker Desktop translates uids at the file-sharing boundary, so
+//     the Linux uid-remap machinery does not apply. The common cause is the
+//     PowerShell default CWD of C:\WINDOWS\system32, which a normal user cannot
+//     write. Append the system32 trap and the `cd` to home remedy.
+//   - any other host (macOS, etc.): the file-sharing boundary likewise hides the
+//     uid mismatch, so the actionable headline stands alone with no Linux-only
+//     uid-remap internals.
 //
-// Aileron's startup remap (aileron-remap-agent-uid) aligns the agent uid to the
-// workspace owner on Linux+Docker, so a persistent DAC failure points at an
-// image whose entrypoint does not run the remap (e.g. a BYO image missing the
-// helper) or a workspace the host operator cannot themselves write.
-func enrichWorkspaceNotWritable(err error, workDir string, selinuxRelabelActive bool) error {
+// The Linux uid-remap detail (aileron-remap-agent-uid aligns the agent uid to
+// the workspace owner on Linux + Docker) stays available as the deeper Linux
+// diagnostic — a persistent DAC failure points at an image whose entrypoint does
+// not run the remap (e.g. a BYO image missing the helper) or a workspace the
+// host operator cannot themselves write — but it is no longer the headline, and
+// it is never shown on platforms where it does not apply.
+func enrichWorkspaceNotWritable(err error, workDir, hostOS string, selinuxRelabelActive bool) error {
 	wd := workDir
 	if wd == "" {
 		wd = "."
 	}
-	if selinuxRelabelActive {
-		return fmt.Errorf("%w\n"+
-			"the sandbox container could not write to the mounted workspace %s. "+
-			"This host runs SELinux in enforcing mode, so the host directory's "+
-			"SELinux label can deny the container's non-root agent user access to "+
-			"the bind mount. Aileron applied a shared SELinux relabel (the `:z` "+
-			"mount option) automatically; if the failure persists, relabel the "+
-			"directory manually with `chcon -Rt svirt_sandbox_file_t %s` (or run "+
-			"the host with SELinux permissive).",
-			err, wd, wd)
+	// Headline: the same actionable problem + simplest fix on every platform.
+	headline := fmt.Sprintf("the launch working directory %s is not writable by "+
+		"you, so the sandbox container cannot write to the mounted workspace. Run "+
+		"aileron from a directory you own (for example a project directory under "+
+		"your home directory) and try again.", wd)
+	switch {
+	case selinuxRelabelActive:
+		return fmt.Errorf("%w\n%s\n"+
+			"Deeper diagnostic: this host runs SELinux in enforcing mode, so the "+
+			"host directory's SELinux label can deny the container's non-root agent "+
+			"user access to the bind mount. Aileron applied a shared SELinux relabel "+
+			"(the `:z` mount option) automatically; if the failure persists on a "+
+			"directory you do own, relabel it manually with "+
+			"`chcon -Rt svirt_sandbox_file_t %s` (or run the host with SELinux "+
+			"permissive).",
+			err, headline, wd)
+	case hostOS == "linux":
+		return fmt.Errorf("%w\n%s\n"+
+			"Deeper diagnostic (Linux + Docker): the container's non-root agent user "+
+			"does not own the workspace bind mount. Its in-container uid differs "+
+			"from the host user that owns %s, so the directory's permissions deny "+
+			"the agent write access. Aileron remaps the agent uid to the workspace "+
+			"owner at container start (aileron-remap-agent-uid); if the failure "+
+			"persists on a directory you do own, the image's entrypoint may not run "+
+			"that remap (BYO images must ship the helper on PATH and chain it as "+
+			"root before dropping to the agent user).",
+			err, headline, wd)
+	case hostOS == "windows":
+		return fmt.Errorf("%w\n%s\n"+
+			"On Windows, PowerShell opens by default in C:\\WINDOWS\\system32, which "+
+			"a normal user cannot write. If that is your current directory, `cd` to "+
+			"your user home (for example `cd $HOME`) or a project directory under it "+
+			"and re-run. (Docker Desktop translates uids at the file-sharing "+
+			"boundary, so the Linux uid-remap machinery does not apply here.)",
+			err, headline)
+	default:
+		return fmt.Errorf("%w\n%s", err, headline)
 	}
-	return fmt.Errorf("%w\n"+
-		"the sandbox container could not write to the mounted workspace %s. "+
-		"The container's non-root agent user does not own the workspace bind "+
-		"mount: its in-container uid differs from the host user that owns %s, so "+
-		"the directory's permissions deny the agent write access. Aileron remaps "+
-		"the agent uid to the workspace owner at container start "+
-		"(aileron-remap-agent-uid) on Linux+Docker; if the failure persists, the "+
-		"image's entrypoint may not run that remap (BYO images must ship the "+
-		"helper on PATH and chain it as root before dropping to the agent user). "+
-		"Confirm the host directory is writable by you, the launching user.",
-		err, wd, wd)
 }

--- a/internal/sandbox/composition/validatehint_test.go
+++ b/internal/sandbox/composition/validatehint_test.go
@@ -28,7 +28,7 @@ func TestEnrichValidateErrorDevcontainerMismatch(t *testing.T) {
 		t.Fatalf("precondition: %q must have a published image", agent)
 	}
 	base := agentNotFoundErr(agent)
-	got := EnrichValidateError(base, TierDevcontainer, agent, version, workDir, false)
+	got := EnrichValidateError(base, TierDevcontainer, agent, version, workDir, "linux", false)
 	msg := got.Error()
 
 	if !strings.Contains(msg, string(TierDevcontainer)) {
@@ -54,7 +54,7 @@ func TestEnrichValidateErrorDevcontainerMismatch(t *testing.T) {
 func TestEnrichValidateErrorNonDevcontainerTierUnchanged(t *testing.T) {
 	base := agentNotFoundErr("claude")
 	for _, tier := range []Tier{TierBase, TierPublished, TierBYOImage} {
-		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project", false)
+		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project", "linux", false)
 		if got != base {
 			t.Errorf("tier %q: error was enriched, want unchanged: %s", tier, got.Error())
 		}
@@ -67,7 +67,7 @@ func TestEnrichValidateErrorUnpublishedAgentUnchanged(t *testing.T) {
 		t.Fatalf("precondition: %q must not have a published image", agent)
 	}
 	base := agentNotFoundErr(agent)
-	got := EnrichValidateError(base, TierDevcontainer, agent, "1.2.3", "/home/dev/project", false)
+	got := EnrichValidateError(base, TierDevcontainer, agent, "1.2.3", "/home/dev/project", "linux", false)
 	if got != base {
 		t.Errorf("unpublished agent: error was enriched, want unchanged: %s", got.Error())
 	}
@@ -75,7 +75,7 @@ func TestEnrichValidateErrorUnpublishedAgentUnchanged(t *testing.T) {
 
 func TestEnrichValidateErrorUnrelatedFailureUnchanged(t *testing.T) {
 	base := errors.New("validate sandbox image: image must support /bin/sh command execution")
-	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "/home/dev/project", false)
+	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "/home/dev/project", "linux", false)
 	if got != base {
 		t.Errorf("unrelated failure: error was enriched, want unchanged: %s", got.Error())
 	}
@@ -85,26 +85,32 @@ const workspaceNotWritableErr = "validate sandbox image img: sandbox workspace i
 
 // TestEnrichValidateErrorWorkspaceNotWritableSELinux verifies that when the
 // `:z` SELinux relabel was actually applied (selinuxRelabelActive=true), the
-// opaque "exit status 3" is enriched with the SELinux root cause, the
-// automatic-relabel note, and the manual `chcon` fallback. This is the
-// SELinux-enforcing-host branch.
+// opaque "exit status 3" leads with the actionable not-writable headline and
+// then appends the SELinux deeper diagnostic: the automatic-relabel note and the
+// manual `chcon` fallback. This is the SELinux-enforcing-host branch.
 func TestEnrichValidateErrorWorkspaceNotWritableSELinux(t *testing.T) {
 	const workDir = "/home/dev/project"
 	base := errors.New(workspaceNotWritableErr)
-	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir, true)
+	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir, "linux", true)
 	msg := got.Error()
 
 	for _, want := range []string{
-		"SELinux",       // names the root cause
-		"enforcing",     // names the enforcing-mode condition
-		"automatically", // states Aileron applies the relabel itself
-		"`:z`",          // names the relabel mount option
-		"chcon",         // gives the manual fallback command
-		workDir,         // names the operator's workspace
+		"not writable",      // leads with the actionable problem
+		"directory you own", // states the simplest fix
+		"SELinux",           // names the root cause
+		"enforcing",         // names the enforcing-mode condition
+		"automatically",     // states Aileron applies the relabel itself
+		"`:z`",              // names the relabel mount option
+		"chcon",             // gives the manual fallback command
+		workDir,             // names the operator's workspace
 	} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("enriched writability error missing %q: %s", want, msg)
 		}
+	}
+	// The actionable headline must come before the SELinux deeper diagnostic.
+	if strings.Index(msg, "not writable") > strings.Index(msg, "SELinux") {
+		t.Errorf("actionable headline must precede the SELinux diagnostic: %s", msg)
 	}
 	// The original error must remain wrapped so callers' %w chains still match.
 	if !errors.Is(got, base) {
@@ -113,20 +119,22 @@ func TestEnrichValidateErrorWorkspaceNotWritableSELinux(t *testing.T) {
 }
 
 // TestEnrichValidateErrorWorkspaceNotWritableUIDMismatch is the regression test
-// for issue #1461: when the `:z` relabel was NOT applied (the daemon lacks
-// SELinux support, or SELinux is not enforcing — selinuxRelabelActive=false),
-// the real cause is a DAC uid mismatch, not SELinux. The enriched message must
-// name the uid mismatch and the remap remediation, and must NOT claim Aileron
-// applied a relabel or point at SELinux/chcon. Before the fix this branch
-// emitted the SELinux wording unconditionally; this fails before and passes
-// after.
+// for issue #1461 (kept current for #1495): on Linux + Docker when the `:z`
+// relabel was NOT applied (the daemon lacks SELinux support, or SELinux is not
+// enforcing — selinuxRelabelActive=false), the real cause is a DAC uid mismatch,
+// not SELinux. The enriched message must lead with the actionable not-writable
+// headline and then append the uid-mismatch + remap remediation as the deeper
+// diagnostic, and must NOT claim Aileron applied a relabel or point at
+// SELinux/chcon.
 func TestEnrichValidateErrorWorkspaceNotWritableUIDMismatch(t *testing.T) {
 	const workDir = "/home/dev/project"
 	base := errors.New(workspaceNotWritableErr)
-	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir, false)
+	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir, "linux", false)
 	msg := got.Error()
 
 	for _, want := range []string{
+		"not writable",            // leads with the actionable problem
+		"directory you own",       // states the simplest fix
 		"uid",                     // names the DAC uid mismatch
 		"aileron-remap-agent-uid", // names the remap remediation
 		workDir,                   // names the operator's workspace
@@ -134,6 +142,11 @@ func TestEnrichValidateErrorWorkspaceNotWritableUIDMismatch(t *testing.T) {
 		if !strings.Contains(msg, want) {
 			t.Errorf("DAC-mismatch error missing %q: %s", want, msg)
 		}
+	}
+	// The actionable headline must precede the uid-remap deeper diagnostic — the
+	// internals are no longer the lead (issue #1495).
+	if strings.Index(msg, "not writable") > strings.Index(msg, "aileron-remap-agent-uid") {
+		t.Errorf("actionable headline must precede the uid-remap diagnostic: %s", msg)
 	}
 	// The misleading SELinux wording must be gone in this branch.
 	for _, absent := range []string{
@@ -151,41 +164,127 @@ func TestEnrichValidateErrorWorkspaceNotWritableUIDMismatch(t *testing.T) {
 	}
 }
 
+// TestEnrichValidateErrorWorkspaceNotWritableWindows is the regression test for
+// issue #1495: on Windows the Linux uid-remap machinery does not apply (Docker
+// Desktop translates uids at the file-sharing boundary), so the enriched message
+// must NOT lead with — or even mention — the uid-remap internals. It must lead
+// with the actionable not-writable headline and call out the
+// C:\WINDOWS\system32 PowerShell default-CWD trap with the `cd`-to-home remedy.
+func TestEnrichValidateErrorWorkspaceNotWritableWindows(t *testing.T) {
+	const workDir = `C:\WINDOWS\system32`
+	base := errors.New(workspaceNotWritableErr)
+	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir, "windows", false)
+	msg := got.Error()
+
+	for _, want := range []string{
+		"not writable",        // leads with the actionable problem
+		"directory you own",   // states the simplest fix
+		`C:\WINDOWS\system32`, // names the PowerShell default-CWD trap
+		"cd",                  // gives the one-step remedy
+		"home",                // points at the user home
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("Windows writability error missing %q: %s", want, msg)
+		}
+	}
+	// The Linux-only uid-remap internals must NOT appear on Windows: the helper
+	// does not run there, so naming it would point the user at a mechanism that
+	// does not apply (the core complaint of #1495). SELinux must be absent too.
+	for _, absent := range []string{
+		"aileron-remap-agent-uid",
+		"in-container uid",
+		"SELinux",
+		"chcon",
+	} {
+		if strings.Contains(msg, absent) {
+			t.Errorf("Windows writability error must not mention Linux-only %q: %s", absent, msg)
+		}
+	}
+	if !errors.Is(got, base) {
+		t.Errorf("enriched error does not wrap the original validate error")
+	}
+}
+
+// TestEnrichValidateErrorWorkspaceNotWritableMacOS verifies the macOS (and other
+// non-Linux, non-Windows) branch: Docker Desktop hides the uid mismatch at the
+// file-sharing boundary, so the actionable headline stands alone with no
+// Linux-only uid-remap internals and no SELinux/Windows specifics.
+func TestEnrichValidateErrorWorkspaceNotWritableMacOS(t *testing.T) {
+	const workDir = "/Users/dev/project"
+	base := errors.New(workspaceNotWritableErr)
+	got := EnrichValidateError(base, TierBase, "claude", "1.2.3", workDir, "darwin", false)
+	msg := got.Error()
+
+	for _, want := range []string{
+		"not writable",      // leads with the actionable problem
+		"directory you own", // states the simplest fix
+		workDir,             // names the operator's workspace
+	} {
+		if !strings.Contains(msg, want) {
+			t.Errorf("macOS writability error missing %q: %s", want, msg)
+		}
+	}
+	for _, absent := range []string{
+		"aileron-remap-agent-uid",
+		"in-container uid",
+		"SELinux",
+		"chcon",
+		`C:\WINDOWS\system32`,
+	} {
+		if strings.Contains(msg, absent) {
+			t.Errorf("macOS writability error must not mention %q: %s", absent, msg)
+		}
+	}
+	if !errors.Is(got, base) {
+		t.Errorf("enriched error does not wrap the original validate error")
+	}
+}
+
 // TestEnrichValidateErrorWorkspaceNotWritableAllTiers verifies the writability
 // enrichment is tier-independent: every sandbox tier bind-mounts the workspace,
-// so the denial can occur regardless of which image was selected. Exercised on
-// the DAC-mismatch branch (the common non-SELinux case).
+// so the denial can occur regardless of which image was selected. The actionable
+// headline must appear on every tier; exercised on the Linux DAC-mismatch branch
+// (the common non-SELinux case).
 func TestEnrichValidateErrorWorkspaceNotWritableAllTiers(t *testing.T) {
 	base := errors.New(workspaceNotWritableErr)
 	for _, tier := range []Tier{TierBase, TierPublished, TierBYOImage, TierDevcontainer} {
-		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project", false)
-		if !strings.Contains(got.Error(), "uid") {
+		got := EnrichValidateError(base, tier, "claude", "1.2.3", "/home/dev/project", "linux", false)
+		if !strings.Contains(got.Error(), "not writable") {
 			t.Errorf("tier %q: writability error was not enriched: %s", tier, got.Error())
 		}
 	}
 }
 
 // TestEnrichWorkspaceNotWritableEmptyWorkDirDefaultsToCwd covers the empty
-// workDir default ("." substitution) on both writability branches.
+// workDir default ("." substitution) on every writability branch.
 func TestEnrichWorkspaceNotWritableEmptyWorkDirDefaultsToCwd(t *testing.T) {
 	base := errors.New(workspaceNotWritableErr)
-	for _, selinux := range []bool{true, false} {
-		got := EnrichValidateError(base, TierBase, "claude", "1.2.3", "", selinux)
-		if !strings.Contains(got.Error(), "workspace .") {
-			t.Errorf("selinux=%v: empty workDir not defaulted to '.': %s", selinux, got.Error())
+	cases := []struct {
+		hostOS  string
+		selinux bool
+	}{
+		{"linux", true},    // SELinux branch
+		{"linux", false},   // Linux DAC-mismatch branch
+		{"windows", false}, // Windows branch
+		{"darwin", false},  // macOS / default branch
+	}
+	for _, tc := range cases {
+		got := EnrichValidateError(base, TierBase, "claude", "1.2.3", "", tc.hostOS, tc.selinux)
+		if !strings.Contains(got.Error(), "working directory . is not writable") {
+			t.Errorf("hostOS=%s selinux=%v: empty workDir not defaulted to '.': %s", tc.hostOS, tc.selinux, got.Error())
 		}
 	}
 }
 
 func TestEnrichValidateErrorNilUnchanged(t *testing.T) {
-	if got := EnrichValidateError(nil, TierDevcontainer, "claude", "1.2.3", "/home/dev/project", false); got != nil {
+	if got := EnrichValidateError(nil, TierDevcontainer, "claude", "1.2.3", "/home/dev/project", "linux", false); got != nil {
 		t.Errorf("nil error: got %v, want nil", got)
 	}
 }
 
 func TestEnrichValidateErrorEmptyWorkDirDefaultsToCwd(t *testing.T) {
 	base := agentNotFoundErr("claude")
-	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "", false)
+	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "", "linux", false)
 	// filepath.Join(".", path) cleans to the bare relative path.
 	wantPath := DefaultDevcontainerPath
 	if !strings.Contains(got.Error(), wantPath) {


### PR DESCRIPTION
## Summary

`aileron launch <agent>` (and `aileron sandbox check`) failed with a Linux-centric wall of text when the launch working directory was not writable. The headline described in-container uids and the `aileron-remap-agent-uid` helper — Linux+Docker internals that do not apply on Windows or macOS, where Docker Desktop translates uids at the file-sharing boundary. The one sentence that mattered ("run from a directory you own") was buried at the very end.

On Windows this was especially bad: PowerShell opens by default in `C:\WINDOWS\system32`, which a normal user cannot write, so the very first thing a Windows user does (open PowerShell, run `aileron launch claude`) produced a baffling failure that pointed at a mechanism that does not even apply to their platform. (Closes #1495.)

### Change

`EnrichValidateError` now leads every workspace-not-writable variant with the same short, actionable headline — the launch working directory is not writable; run aileron from a directory you own (e.g. a project under your home) — and only then appends a platform-appropriate **deeper diagnostic** chosen from the host OS:

- **SELinux-enforcing host:** the `chcon` / `:z` relabel note (unchanged content, now demoted below the headline).
- **Linux + Docker (no SELinux):** the uid-mismatch + `aileron-remap-agent-uid` detail (unchanged content, demoted below the headline).
- **Windows:** the `C:\WINDOWS\system32` PowerShell default-CWD trap plus the `cd $HOME` remedy. The Linux uid-remap internals are no longer shown.
- **macOS / other:** the actionable headline alone, with no Linux-only internals.

`runtime.GOOS` is plumbed into `EnrichValidateError` at both call sites (`internal/launch/launcher.go`, `cmd/aileron/sandbox.go`). The `composition` package stays free of `runtime.GOOS` so the enrichment remains unit-testable across every OS (mirroring the existing `selinuxRelabelActive` plumbing). User-facing strings carry no em-dashes per the docs-voice convention.

## Test plan

- `go test ./internal/sandbox/composition/...` — green, 93.7% statement coverage. New regression tests: `TestEnrichValidateErrorWorkspaceNotWritableWindows` (asserts the system32/`cd`/home guidance is present and the Linux uid-remap/SELinux internals are absent) and `...MacOS` (headline alone, no internals). The SELinux and Linux-DAC tests now assert the actionable headline precedes the deeper diagnostic.
- `go test ./internal/launch/... ./cmd/aileron/...` — green (the two call sites compile and run with the new `hostOS` argument).
- `go vet` clean on all three packages.
- CodeRabbit review: no findings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
