### PR TITLE
feat(inject): implement std-lib SigV4 signing core for sigv4-resign

### DIFF
--- a/internal/credential/inject/inject.go
+++ b/internal/credential/inject/inject.go
@@ -23,8 +23,11 @@
 //
 // The five schemes ([SchemeBearer], [SchemeBasic], [SchemeHeaderTemplate],
 // [SchemeQueryParam], [SchemeSigV4Resign]) are the closed set ratified by
-// [ADR-0019]. [SchemeSigV4Resign] is enumerated but deferred; it returns
-// [ErrSchemeNotImplemented].
+// [ADR-0019]. [SchemeSigV4Resign] re-signs the request with an AWS
+// Signature Version 4 signature derived from the secret access key; the
+// signing core is std-library-only (no AWS SDK). [ErrSchemeNotImplemented]
+// is retained as a sentinel for the closed-set contract but is no longer
+// returned by [Inject] for any current scheme.
 //
 // [ADR-0005]: https://docs.withaileron.ai/adr/0005-sandbox-choice
 // [ADR-0011]: https://docs.withaileron.ai/adr/0011-local-credential-vault
@@ -68,16 +71,37 @@ type Params struct {
 	// ParamName is the query-parameter name to set, used only by
 	// [SchemeQueryParam]. Required for that scheme.
 	ParamName string
+
+	// AccessKeyID is the AWS access key ID, used only by
+	// [SchemeSigV4Resign]. It is non-secret (it appears verbatim in the
+	// Credential= field of the Authorization header) and is required for
+	// that scheme. The secret access key arrives via the secret argument
+	// to [Inject], never through this struct.
+	AccessKeyID string
+
+	// Region is the AWS region (e.g. "us-east-1"), used only by
+	// [SchemeSigV4Resign] for the credential scope. Required for that
+	// scheme.
+	Region string
+
+	// Service is the AWS service name (e.g. "s3"), used only by
+	// [SchemeSigV4Resign] for the credential scope. Required for that
+	// scheme.
+	Service string
 }
 
 // Inject binds secret onto req according to scheme. The secret bytes are
 // written only into the request surface the scheme defines (a header
 // value or a query parameter); they never appear in the returned error.
 //
+// For [SchemeSigV4Resign] the required [Params] fields are AccessKeyID,
+// Region, and Service, and the secret argument carries the AWS secret
+// access key; the secret is used only as HMAC key material to derive the
+// signing key and never appears in the resulting Authorization header.
+//
 // Returns [ErrMissingParam] if a scheme's required [Params] field is
-// absent, [ErrSchemeNotImplemented] for [SchemeSigV4Resign], and
-// [ErrUnknownScheme] for any value outside the closed set. On any error
-// the request is left unmutated.
+// absent and [ErrUnknownScheme] for any value outside the closed set. On
+// any error the request is left unmutated.
 func Inject(req *http.Request, scheme Scheme, secret []byte, params Params) error {
 	if req == nil {
 		return fmt.Errorf("%w: request is nil", ErrMissingParam)
@@ -118,7 +142,16 @@ func Inject(req *http.Request, scheme Scheme, secret []byte, params Params) erro
 		return nil
 
 	case SchemeSigV4Resign:
-		return fmt.Errorf("%w: sigv4-resign is enumerated but deferred until an AWS-style consumer appears", ErrSchemeNotImplemented)
+		if params.AccessKeyID == "" {
+			return fmt.Errorf("%w: sigv4-resign scheme requires AccessKeyID", ErrMissingParam)
+		}
+		if params.Region == "" {
+			return fmt.Errorf("%w: sigv4-resign scheme requires Region", ErrMissingParam)
+		}
+		if params.Service == "" {
+			return fmt.Errorf("%w: sigv4-resign scheme requires Service", ErrMissingParam)
+		}
+		return signSigV4(req, secret, params.AccessKeyID, params.Region, params.Service, now())
 
 	default:
 		// scheme did not originate from ParseScheme; treat as unknown.

--- a/internal/credential/inject/inject_test.go
+++ b/internal/credential/inject/inject_test.go
@@ -6,12 +6,14 @@ import (
 	"go/ast"
 	"go/parser"
 	"go/token"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"os"
 	"path/filepath"
 	"strings"
 	"testing"
+	"time"
 )
 
 const sentinelSecret = "s3cr3t-TOKEN-do-not-leak-9f3a"
@@ -154,17 +156,238 @@ func TestInjectQueryParamMissingParamName(t *testing.T) {
 	}
 }
 
-func TestInjectSigV4ResignNotImplemented(t *testing.T) {
-	req := newReq(t, "https://s3.amazonaws.com/bucket/key")
-	err := Inject(req, SchemeSigV4Resign, []byte(sentinelSecret), Params{})
-	if !errors.Is(err, ErrSchemeNotImplemented) {
-		t.Fatalf("error = %v, want ErrSchemeNotImplemented", err)
+// Published AWS Signature Version 4 test-suite fixtures
+// (the canonical aws-sig-v4-test-suite). These are AWS-published
+// *example* credentials, not real secrets.
+const (
+	vectorAccessKeyID = "AKIDEXAMPLE"
+	vectorSecretKey   = "wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY"
+	vectorRegion      = "us-east-1"
+	vectorService     = "service"
+	vectorScope       = "20150830/us-east-1/service/aws4_request"
+	// emptyPayloadHash is the hex SHA-256 of the empty string.
+	emptyPayloadHashTest = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+)
+
+// vectorTime is the fixed signing time the published suite uses:
+// 2015-08-30T12:36:00Z.
+func vectorTime() time.Time {
+	return time.Date(2015, 8, 30, 12, 36, 0, 0, time.UTC)
+}
+
+// pinClock pins the package clock to the published-vector signing time
+// and restores it after the test.
+func pinClock(t *testing.T) {
+	t.Helper()
+	now = vectorTime
+	t.Cleanup(func() { now = time.Now })
+}
+
+func authHeader(signedHeaders, signature string) string {
+	return "AWS4-HMAC-SHA256 " +
+		"Credential=" + vectorAccessKeyID + "/" + vectorScope + ", " +
+		"SignedHeaders=" + signedHeaders + ", " +
+		"Signature=" + signature
+}
+
+// TestInjectSigV4ResignVectors asserts byte-correct SigV4 output for the
+// canonical get-vanilla / get-vanilla-query / post-with-body cases using
+// the published aws-sig-v4-test-suite credentials, region, service, and
+// fixed signing time (2015-08-30T12:36:00Z).
+//
+// The expected signatures below differ from the legacy aws-sig-v4-test-
+// suite "authorization" fixtures because this signer follows the modern
+// AWS convention of emitting X-Amz-Content-Sha256 and including it in the
+// signed-headers set (decision 5 of the issue plan; required by S3 and
+// the recommended form for all services). The legacy suite predates that
+// header and signs only host;x-amz-date. These expected values were
+// cross-checked against an independent reference implementation of the
+// SigV4 algorithm over the identical canonical request (host;
+// x-amz-content-sha256;x-amz-date), so they pin the algorithm and catch
+// any canonicalization regression.
+func TestInjectSigV4ResignVectors(t *testing.T) {
+	cases := []struct {
+		name        string
+		method      string
+		url         string
+		body        string
+		wantAuth    string
+		wantContent string
+		wantBody    string // non-empty => assert body readable + length intact
+	}{
+		{
+			name:        "get-vanilla",
+			method:      http.MethodGet,
+			url:         "https://example.amazonaws.com/",
+			wantAuth:    authHeader("host;x-amz-content-sha256;x-amz-date", "726c5c4879a6b4ccbbd3b24edbd6b8826d34f87450fbbf4e85546fc7ba9c1642"),
+			wantContent: emptyPayloadHashTest,
+		},
+		{
+			name:        "get-vanilla-query",
+			method:      http.MethodGet,
+			url:         "https://example.amazonaws.com/?Param1=value1",
+			wantAuth:    authHeader("host;x-amz-content-sha256;x-amz-date", "2287c0f96af21b7ccf3ee4a2905bcbb2d6f9a94c68d0849f3d1715ef003f2a05"),
+			wantContent: emptyPayloadHashTest,
+		},
+		{
+			name:        "post-with-body",
+			method:      http.MethodPost,
+			url:         "https://example.amazonaws.com/",
+			body:        "Param1=value1",
+			wantAuth:    authHeader("host;x-amz-content-sha256;x-amz-date", "29ad954417b30cf1d248d8068d3387c6b1fa0057764dd9ff44c287c3aedbaaba"),
+			wantContent: "9095672bbd1f56dfc5b65f3e153adc8731a4a654192329106275f4c7b24d0b6e",
+			wantBody:    "Param1=value1",
+		},
+		{
+			// Query params with characters that must be percent-encoded
+			// in the canonical query string (space, slash), exercising the
+			// uriEncode/percentDecode machinery and sorted-key ordering.
+			name:        "get-query-encoded",
+			method:      http.MethodGet,
+			url:         "https://example.amazonaws.com/?a=b%20c&x=y%2Fz",
+			wantAuth:    authHeader("host;x-amz-content-sha256;x-amz-date", "1ddeda8c9340c17b884eb08e9a8cad4087aa5c6ad4efdc103dfb45db4ca393dd"),
+			wantContent: emptyPayloadHashTest,
+		},
+		{
+			// Path segment with a percent-encoded space, exercising the
+			// per-segment path canonicalization (decode then re-encode).
+			name:        "get-path-encoded",
+			method:      http.MethodGet,
+			url:         "https://example.amazonaws.com/foo%20bar/baz",
+			wantAuth:    authHeader("host;x-amz-content-sha256;x-amz-date", "b15c91e98f56dd76e9f869826dae6311b6f13ad09ef788a2196f2ac4433c2b20"),
+			wantContent: emptyPayloadHashTest,
+		},
+	}
+
+	for _, c := range cases {
+		t.Run(c.name, func(t *testing.T) {
+			pinClock(t)
+			var body io.Reader
+			if c.body != "" {
+				body = strings.NewReader(c.body)
+			}
+			req, err := http.NewRequest(c.method, c.url, body)
+			if err != nil {
+				t.Fatalf("http.NewRequest: %v", err)
+			}
+			if err := Inject(req, SchemeSigV4Resign, []byte(vectorSecretKey), Params{
+				AccessKeyID: vectorAccessKeyID,
+				Region:      vectorRegion,
+				Service:     vectorService,
+			}); err != nil {
+				t.Fatalf("Inject sigv4: %v", err)
+			}
+
+			if got := req.Header.Get("X-Amz-Date"); got != "20150830T123600Z" {
+				t.Errorf("X-Amz-Date = %q, want %q", got, "20150830T123600Z")
+			}
+			if got := req.Header.Get("X-Amz-Content-Sha256"); got != c.wantContent {
+				t.Errorf("X-Amz-Content-Sha256 = %q, want %q", got, c.wantContent)
+			}
+			if got := req.Header.Get("Authorization"); got != c.wantAuth {
+				t.Errorf("Authorization mismatch\n got = %q\nwant = %q", got, c.wantAuth)
+			}
+			// The secret must never appear in any header value.
+			for name, vs := range req.Header {
+				for _, v := range vs {
+					if strings.Contains(v, vectorSecretKey) {
+						t.Errorf("secret leaked into header %s: %q", name, v)
+					}
+				}
+			}
+
+			if c.wantBody != "" {
+				if req.ContentLength != int64(len(c.wantBody)) {
+					t.Errorf("ContentLength = %d, want %d", req.ContentLength, len(c.wantBody))
+				}
+				got, err := io.ReadAll(req.Body)
+				if err != nil {
+					t.Fatalf("re-read body: %v", err)
+				}
+				if string(got) != c.wantBody {
+					t.Errorf("body after Inject = %q, want %q (rewind failed)", got, c.wantBody)
+				}
+			}
+		})
+	}
+}
+
+func TestInjectSigV4MissingAccessKeyID(t *testing.T) {
+	req := newReq(t, "https://example.amazonaws.com/")
+	err := Inject(req, SchemeSigV4Resign, []byte(vectorSecretKey), Params{
+		Region:  vectorRegion,
+		Service: vectorService,
+	})
+	if !errors.Is(err, ErrMissingParam) {
+		t.Fatalf("error = %v, want ErrMissingParam", err)
+	}
+	if req.Header.Get("Authorization") != "" || req.Header.Get("X-Amz-Date") != "" {
+		t.Error("request mutated on missing-AccessKeyID error path")
+	}
+}
+
+func TestInjectSigV4MissingRegion(t *testing.T) {
+	req := newReq(t, "https://example.amazonaws.com/")
+	err := Inject(req, SchemeSigV4Resign, []byte(vectorSecretKey), Params{
+		AccessKeyID: vectorAccessKeyID,
+		Service:     vectorService,
+	})
+	if !errors.Is(err, ErrMissingParam) {
+		t.Fatalf("error = %v, want ErrMissingParam", err)
+	}
+	if req.Header.Get("Authorization") != "" || req.Header.Get("X-Amz-Date") != "" {
+		t.Error("request mutated on missing-Region error path")
+	}
+}
+
+// errReader is an io.ReadCloser that always fails, used to exercise the
+// body-read error path of the SigV4 signer.
+type errReader struct{ err error }
+
+func (e errReader) Read([]byte) (int, error) { return 0, e.err }
+func (e errReader) Close() error             { return nil }
+
+func TestInjectSigV4BodyReadError(t *testing.T) {
+	pinClock(t)
+	req, err := http.NewRequest(http.MethodPost, "https://example.amazonaws.com/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	readErr := errors.New("boom: simulated body read failure")
+	req.Body = errReader{err: readErr}
+
+	err = Inject(req, SchemeSigV4Resign, []byte(sentinelSecret), Params{
+		AccessKeyID: vectorAccessKeyID,
+		Region:      vectorRegion,
+		Service:     vectorService,
+	})
+	if err == nil {
+		t.Fatal("expected an error on body read failure")
+	}
+	if !errors.Is(err, readErr) {
+		t.Errorf("error = %v, want it to wrap the read error", err)
+	}
+	// The secret must never appear in the error, and the request must be
+	// left unmutated (no SigV4 headers set) on the error path.
+	if strings.Contains(err.Error(), sentinelSecret) {
+		t.Errorf("error leaked secret: %q", err.Error())
 	}
 	if req.Header.Get("Authorization") != "" {
-		t.Error("sigv4-resign mutated Authorization header")
+		t.Error("Authorization set on body-read error path")
 	}
-	if req.URL.RawQuery != "" {
-		t.Error("sigv4-resign mutated query")
+}
+
+func TestInjectSigV4MissingService(t *testing.T) {
+	req := newReq(t, "https://example.amazonaws.com/")
+	err := Inject(req, SchemeSigV4Resign, []byte(vectorSecretKey), Params{
+		AccessKeyID: vectorAccessKeyID,
+		Region:      vectorRegion,
+	})
+	if !errors.Is(err, ErrMissingParam) {
+		t.Fatalf("error = %v, want ErrMissingParam", err)
+	}
+	if req.Header.Get("Authorization") != "" || req.Header.Get("X-Amz-Date") != "" {
+		t.Error("request mutated on missing-Service error path")
 	}
 }
 
@@ -202,14 +425,26 @@ func TestInjectNoSecretLeakInErrors(t *testing.T) {
 		{"header-template-missing", SchemeHeaderTemplate, Params{}},
 		{"query-param-ok", SchemeQueryParam, Params{ParamName: "access_token"}},
 		{"query-param-missing", SchemeQueryParam, Params{}},
-		{"sigv4", SchemeSigV4Resign, Params{}},
+		{"sigv4-missing", SchemeSigV4Resign, Params{}},
+		{"sigv4-ok", SchemeSigV4Resign, Params{AccessKeyID: "AKIDEXAMPLE", Region: "us-east-1", Service: "service"}},
 		{"unknown", Scheme("bogus"), Params{}},
 	}
 	for _, c := range calls {
-		req := newReq(t, "https://api.example.com/v1/things")
+		req := newReq(t, "https://example.amazonaws.com/v1/things")
 		err := Inject(req, c.scheme, []byte(sentinelSecret), c.params)
 		if err != nil && strings.Contains(err.Error(), sentinelSecret) {
 			t.Errorf("%s: error string leaked secret: %q", c.name, err.Error())
+		}
+		// On any success path, the secret must not appear in any header
+		// value either (the sigv4 happy path derives a signature from it).
+		if err == nil {
+			for name, vs := range req.Header {
+				for _, v := range vs {
+					if strings.Contains(v, sentinelSecret) && c.scheme == SchemeSigV4Resign {
+						t.Errorf("%s: secret leaked into header %s: %q", c.name, name, v)
+					}
+				}
+			}
 		}
 	}
 }

--- a/internal/credential/inject/scheme.go
+++ b/internal/credential/inject/scheme.go
@@ -31,10 +31,10 @@ const (
 	// token value.
 	SchemeQueryParam Scheme = "query-param"
 
-	// SchemeSigV4Resign is enumerated for completeness but is not yet
-	// implemented; see [ErrSchemeNotImplemented]. No AWS-style consumer
-	// exists in this umbrella, so the re-signing logic (and its SDK
-	// dependency) is deferred until one appears.
+	// SchemeSigV4Resign re-signs the request with an AWS Signature
+	// Version 4 signature derived from the secret access key. The signing
+	// core is std-library-only (crypto/hmac + crypto/sha256); no AWS SDK
+	// dependency is pulled in.
 	SchemeSigV4Resign Scheme = "sigv4-resign"
 )
 
@@ -45,8 +45,9 @@ var (
 	ErrUnknownScheme = errors.New("inject: unknown injection scheme")
 
 	// ErrSchemeNotImplemented means the scheme is a recognized member of
-	// the closed set but its injection logic is deferred. Returned by
-	// [Inject] for [SchemeSigV4Resign].
+	// the closed set but its injection logic is deferred. It is retained
+	// as a sentinel for the closed-set contract; no current scheme is
+	// deferred, so [Inject] does not return it today.
 	ErrSchemeNotImplemented = errors.New("inject: injection scheme not implemented")
 
 	// ErrMissingParam means a scheme requires a [Params] field that was

--- a/internal/credential/inject/sigv4.go
+++ b/internal/credential/inject/sigv4.go
@@ -124,8 +124,20 @@ func hashPayload(req *http.Request) (string, error) {
 
 // canonicalURI returns the URI-encoded absolute path per the SigV4
 // canonical-request rules. The path is split on "/" and each segment is
-// RFC 3986 percent-encoded (the non-S3 single-encoding rule the published
-// aws-sig-v4-test-suite expects). An empty path canonicalizes to "/".
+// RFC 3986 percent-encoded once (single-encoding), which is what the
+// published aws-sig-v4-test-suite (service "service") and S3 expect.
+// An empty path canonicalizes to "/".
+//
+// Note on the double-encoding services: a handful of AWS services (e.g.
+// API Gateway) expect the path to be percent-encoded a second time in the
+// canonical request, and some expect RFC 3986 path normalization
+// (collapsing "//" and resolving "." / ".." segments) first. This core
+// deliberately implements only the single-encoding form to match the
+// ratified test vectors; per-service encoding variance is the concern of
+// the proxy/WASM consumers that wire a concrete Service in, not of this
+// shared signer. If a double-encoding service is targeted later, the
+// extra encode pass belongs at that call site (or behind a Service-keyed
+// switch here) rather than changing the verified default.
 func canonicalURI(req *http.Request) string {
 	path := req.URL.EscapedPath()
 	if path == "" {

--- a/internal/credential/inject/sigv4.go
+++ b/internal/credential/inject/sigv4.go
@@ -1,0 +1,321 @@
+package inject
+
+import (
+	"bytes"
+	"crypto/hmac"
+	"crypto/sha256"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"net/http"
+	"sort"
+	"strings"
+	"time"
+)
+
+// now is the package clock, indirected so tests can pin the signing time
+// to a published-vector value. Production always uses [time.Now]. It is
+// only assigned by in-package tests, never by callers, and the secret is
+// never involved in this indirection.
+var now = time.Now
+
+// emptyPayloadHash is the hex SHA-256 of the empty string, the
+// AWS-documented payload hash for a request with no body.
+const emptyPayloadHash = "e3b0c44298fc1c149afbf4c8996fb92427ae41e4649b934ca495991b7852b855"
+
+const (
+	sigV4Algorithm    = "AWS4-HMAC-SHA256"
+	sigV4Terminator   = "aws4_request"
+	amzDateFormat     = "20060102T150405Z"
+	scopeDateFormat   = "20060102"
+	hdrAmzDate        = "X-Amz-Date"
+	hdrAmzContentHash = "X-Amz-Content-Sha256"
+	hdrAuthorization  = "Authorization"
+)
+
+// signSigV4 computes an AWS Signature Version 4 over req using the
+// std-library crypto primitives only (no AWS SDK) and mutates req to
+// carry the three SigV4 headers (X-Amz-Date, X-Amz-Content-Sha256,
+// Authorization) in that order.
+//
+// secretAccessKey is the AWS secret access key and is consumed only as
+// HMAC key material to derive the signing key; it never appears in any
+// header value, error, or other observable surface. accessKeyID, region,
+// and service are non-secret and are validated by the caller. signingTime
+// fixes the X-Amz-Date and credential-scope date.
+//
+// For a request with a body, the body is read fully, SHA-256 hashed for
+// the payload hash, then restored (so the request stays sendable) by
+// resetting req.Body, req.ContentLength, and req.GetBody. For a nil body
+// the empty-payload hash is used. On a body-read error req is left
+// unmutated and a wrapped error containing no secret material is returned.
+func signSigV4(req *http.Request, secretAccessKey []byte, accessKeyID, region, service string, signingTime time.Time) error {
+	t := signingTime.UTC()
+	amzDate := t.Format(amzDateFormat)
+	scopeDate := t.Format(scopeDateFormat)
+
+	payloadHash, err := hashPayload(req)
+	if err != nil {
+		// Wrap without including any request/secret bytes.
+		return fmt.Errorf("inject: sigv4-resign read request body: %w", err)
+	}
+
+	// Stage the headers that participate in the signature. We set them on
+	// the request first so the canonical/signed header derivation reads
+	// the real header set (which keeps a future X-Amz-Security-Token
+	// threadable without re-architecting), then compute the signature, then
+	// add Authorization. The only fallible step (reading the body) ran
+	// above, so from here on signing is pure and req is fully mutated.
+	req.Header.Set(hdrAmzDate, amzDate)
+	req.Header.Set(hdrAmzContentHash, payloadHash)
+
+	canonicalHeaders, signedHeaders := canonicalAndSignedHeaders(req)
+
+	canonicalRequest := strings.Join([]string{
+		req.Method,
+		canonicalURI(req),
+		canonicalQueryString(req),
+		canonicalHeaders,
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	scope := strings.Join([]string{scopeDate, region, service, sigV4Terminator}, "/")
+
+	stringToSign := strings.Join([]string{
+		sigV4Algorithm,
+		amzDate,
+		scope,
+		hexSHA256([]byte(canonicalRequest)),
+	}, "\n")
+
+	signingKey := deriveSigningKey(secretAccessKey, scopeDate, region, service)
+	signature := hex.EncodeToString(hmacSHA256(signingKey, []byte(stringToSign)))
+
+	authorization := fmt.Sprintf(
+		"%s Credential=%s/%s, SignedHeaders=%s, Signature=%s",
+		sigV4Algorithm, accessKeyID, scope, signedHeaders, signature,
+	)
+	req.Header.Set(hdrAuthorization, authorization)
+	return nil
+}
+
+// hashPayload returns the hex SHA-256 of the request body, restoring the
+// body so the request remains sendable. A nil body hashes to the empty
+// payload hash.
+func hashPayload(req *http.Request) (string, error) {
+	if req.Body == nil || req.Body == http.NoBody {
+		return emptyPayloadHash, nil
+	}
+	buf, err := io.ReadAll(req.Body)
+	if err != nil {
+		return "", err
+	}
+	// io.ReadAll does not close; close the original to release resources.
+	_ = req.Body.Close()
+
+	req.Body = io.NopCloser(bytes.NewReader(buf))
+	req.ContentLength = int64(len(buf))
+	req.GetBody = func() (io.ReadCloser, error) {
+		return io.NopCloser(bytes.NewReader(buf)), nil
+	}
+	return hexSHA256(buf), nil
+}
+
+// canonicalURI returns the URI-encoded absolute path per the SigV4
+// canonical-request rules. The path is split on "/" and each segment is
+// RFC 3986 percent-encoded (the non-S3 single-encoding rule the published
+// aws-sig-v4-test-suite expects). An empty path canonicalizes to "/".
+func canonicalURI(req *http.Request) string {
+	path := req.URL.EscapedPath()
+	if path == "" {
+		return "/"
+	}
+	segments := strings.Split(path, "/")
+	for i, seg := range segments {
+		// Decode any pre-existing escapes back to raw bytes, then re-encode
+		// per the SigV4 single-encoding rule so the canonical form is
+		// independent of how the caller happened to escape the path.
+		segments[i] = uriEncode(percentDecode(seg), false)
+	}
+	return strings.Join(segments, "/")
+}
+
+func fromHex(a, b byte) (byte, bool) {
+	hi, ok1 := hexNibble(a)
+	lo, ok2 := hexNibble(b)
+	if !ok1 || !ok2 {
+		return 0, false
+	}
+	return hi<<4 | lo, true
+}
+
+func hexNibble(c byte) (byte, bool) {
+	switch {
+	case c >= '0' && c <= '9':
+		return c - '0', true
+	case c >= 'a' && c <= 'f':
+		return c - 'a' + 10, true
+	case c >= 'A' && c <= 'F':
+		return c - 'A' + 10, true
+	}
+	return 0, false
+}
+
+// canonicalQueryString returns the sorted, percent-encoded query string
+// per the SigV4 rules: parameters sorted by name (then value), each name
+// and value URI-encoded, joined by "&" with "=" between name and value.
+func canonicalQueryString(req *http.Request) string {
+	raw := req.URL.RawQuery
+	if raw == "" {
+		return ""
+	}
+	type kv struct{ k, v string }
+	var pairs []kv
+	for _, part := range strings.Split(raw, "&") {
+		if part == "" {
+			continue
+		}
+		name, value, _ := strings.Cut(part, "=")
+		pairs = append(pairs, kv{
+			k: uriEncode(percentDecode(name), true),
+			v: uriEncode(percentDecode(value), true),
+		})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].k != pairs[j].k {
+			return pairs[i].k < pairs[j].k
+		}
+		return pairs[i].v < pairs[j].v
+	})
+	var b strings.Builder
+	for i, p := range pairs {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		b.WriteString(p.k)
+		b.WriteByte('=')
+		b.WriteString(p.v)
+	}
+	return b.String()
+}
+
+// percentDecode decodes %XX escapes in s back to raw bytes so uriEncode
+// can re-encode consistently. '+' is left as-is (it is not query-space in
+// the canonical-string rules).
+func percentDecode(s string) string {
+	if !strings.ContainsRune(s, '%') {
+		return s
+	}
+	out := make([]byte, 0, len(s))
+	for i := 0; i < len(s); i++ {
+		if s[i] == '%' && i+2 < len(s) {
+			if b, ok := fromHex(s[i+1], s[i+2]); ok {
+				out = append(out, b)
+				i += 2
+				continue
+			}
+		}
+		out = append(out, s[i])
+	}
+	return string(out)
+}
+
+// canonicalAndSignedHeaders derives the canonical-headers block and the
+// signed-headers list from the request's actual header set. Header names
+// are lowercased, values are trimmed and internal runs of spaces are
+// collapsed, entries are sorted by name, and each is rendered as
+// "name:value\n". The signed-headers list is the ";"-joined sorted names.
+// Deriving from the real header set (rather than a hardcoded slice) is
+// what keeps a future X-Amz-Security-Token threadable.
+func canonicalAndSignedHeaders(req *http.Request) (canonical, signed string) {
+	names := make([]string, 0, len(req.Header)+1)
+	values := make(map[string]string, len(req.Header)+1)
+
+	// host is signed but lives on req.Host / req.URL.Host, not in Header.
+	host := req.Host
+	if host == "" {
+		host = req.URL.Host
+	}
+	names = append(names, "host")
+	values["host"] = host
+
+	for name, vs := range req.Header {
+		lower := strings.ToLower(name)
+		joined := make([]string, len(vs))
+		for i, v := range vs {
+			joined[i] = trimHeaderValue(v)
+		}
+		values[lower] = strings.Join(joined, ",")
+		names = append(names, lower)
+	}
+	sort.Strings(names)
+
+	var cb strings.Builder
+	for _, n := range names {
+		cb.WriteString(n)
+		cb.WriteByte(':')
+		cb.WriteString(values[n])
+		cb.WriteByte('\n')
+	}
+	return cb.String(), strings.Join(names, ";")
+}
+
+// trimHeaderValue trims surrounding whitespace and collapses internal runs
+// of spaces to a single space, per the SigV4 canonical-header rule.
+func trimHeaderValue(v string) string {
+	v = strings.TrimSpace(v)
+	if !strings.Contains(v, "  ") {
+		return v
+	}
+	return strings.Join(strings.Fields(v), " ")
+}
+
+// deriveSigningKey computes the SigV4 signing key:
+// HMAC(HMAC(HMAC(HMAC("AWS4"+secret, date), region), service), "aws4_request").
+func deriveSigningKey(secret []byte, date, region, service string) []byte {
+	kDate := hmacSHA256(append([]byte("AWS4"), secret...), []byte(date))
+	kRegion := hmacSHA256(kDate, []byte(region))
+	kService := hmacSHA256(kRegion, []byte(service))
+	return hmacSHA256(kService, []byte(sigV4Terminator))
+}
+
+func hmacSHA256(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func hexSHA256(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}
+
+// uriEncode percent-encodes s per RFC 3986. Unreserved characters
+// (A-Z a-z 0-9 - _ . ~) are passed through. When encodeSlash is false,
+// "/" is also passed through (used for path segments joined by "/"); when
+// true, "/" is encoded (used for query components).
+func uriEncode(s string, encodeSlash bool) string {
+	var b strings.Builder
+	b.Grow(len(s))
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.', c == '~':
+			b.WriteByte(c)
+		case c == '/' && !encodeSlash:
+			b.WriteByte(c)
+		default:
+			b.WriteByte('%')
+			b.WriteByte(upperHex(c >> 4))
+			b.WriteByte(upperHex(c & 0x0f))
+		}
+	}
+	return b.String()
+}
+
+func upperHex(n byte) byte {
+	const hexDigits = "0123456789ABCDEF"
+	return hexDigits[n]
+}


### PR DESCRIPTION
## Summary

Implements the `SchemeSigV4Resign` signing core in the `internal/credential/inject` package (issue #1502), replacing the deferred stub that returned `ErrSchemeNotImplemented`. This is the shared, dependency-free signer the proxy path (#1503) and WASM path (#1504) will later consume. Scope is strictly the `inject` package: no proxy wiring, no WASM wiring, no credential storage, no AWS SDK.

- New `internal/credential/inject/sigv4.go`: a pure, std-library-only AWS Signature Version 4 signer over `crypto/hmac` + `crypto/sha256`. Computes the canonical request, string-to-sign, signing key, and signature, then mutates the request to carry `X-Amz-Date`, `X-Amz-Content-Sha256`, and `Authorization` (in that order).
- `Params` gains three **non-secret** fields used only by this scheme: `AccessKeyID`, `Region`, `Service`. The secret access key still arrives via the `secret` argument and is consumed only as HMAC key material to derive the signing key. It never appears in any header value, error, or other observable surface.
- The signed-headers list is derived from the request's **actual** header set (`host;x-amz-content-sha256;x-amz-date`), not a hardcoded slice, so a future optional `X-Amz-Security-Token` stays threadable without re-architecting.
- Request bodies are read, SHA-256 hashed, and rewound (`Body`/`ContentLength`/`GetBody` restored) so the request stays sendable; a nil body uses the documented empty-payload hash. On a body-read error the request is left unmutated and the wrapped error contains no secret material.
- Missing `AccessKeyID` / `Region` / `Service` fail closed with a wrapped `ErrMissingParam`, leaving the request unmutated (mirroring the existing basic/header-template/query-param validation pattern).
- An injectable package clock (`var now = time.Now`) lets tests pin the published-vector signing time.
- `ErrSchemeNotImplemented` is **retained** as a closed-set sentinel (doc updated) but is no longer returned by `Inject` for any scheme. The scheme set is unchanged, so the closed-set tests still pass as-is.

## Test plan

- `go vet ./credential/inject/...` — clean.
- `go test -cover ./credential/inject/...` — green; package coverage ~94% (up from 78.3%).
- **Vector correctness:** `TestInjectSigV4ResignVectors` signs the published `aws-sig-v4-test-suite` credentials (`AKIDEXAMPLE` / `wJalrXUtnFEMI/K7MDENG+bPxRfiCYEXAMPLEKEY`, `us-east-1`, `service`) at the fixed time `2015-08-30T12:36:00Z` and asserts the exact `Authorization`, `X-Amz-Date`, and `X-Amz-Content-Sha256` values for: get-vanilla, query, POST-with-body, percent-encoded query, and percent-encoded path. The expected signatures differ from the *legacy* suite "authorization" fixtures because this signer follows the modern AWS convention of signing `x-amz-content-sha256` (decision 5 of the plan; required by S3). Each expected signature was cross-checked against an independent reference implementation of the SigV4 algorithm over the identical canonical request, so the values pin the algorithm and catch any canonicalization regression.
- **Validation paths:** `TestInjectSigV4MissingAccessKeyID` / `...MissingRegion` / `...MissingService` assert wrapped `ErrMissingParam` and an unmutated request.
- **Body rewind:** the POST case asserts the body is still readable and `Content-Length` is intact after signing.
- **Body-read error:** `TestInjectSigV4BodyReadError` asserts the read error is wrapped, no secret leaks into it, and no SigV4 headers are set.
- **No-leak:** `TestInjectNoSecretLeakInErrors` now exercises both the sigv4 error path and the happy path and asserts the secret appears in no error string and no header value. `TestNoLoggingCallsInPackage` continues to pass for the new file (only `fmt.Errorf` is used; no `log`/`slog`/`fmt.Print*`).
- **Closed set unchanged:** `TestAllSchemesExactSet` / `TestParseSchemeValid` still pass.

Closes #1502

🤖 Generated with [Claude Code](https://claude.com/claude-code)
