### PR TITLE
feat(sandbox): wire WASM connector path to SigV4 via aws_sigv4 kind

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -139,6 +139,7 @@ github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mailgun/raymond/v2 v2.0.48 h1:5dmlB680ZkFG2RN/0lvTAghrSxIESeu9/2aeDqACtjw=
 github.com/mailgun/raymond/v2 v2.0.48/go.mod h1:lsgvL50kgt1ylcFJYZiULi5fjPBkkhNfj4KA0W54Z18=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=

--- a/internal/cstore/manifest.go
+++ b/internal/cstore/manifest.go
@@ -124,12 +124,24 @@ type ManifestNetwork struct {
 // placeholder is substituted with the bound credential's value. Only
 // consulted when `Kind == "api_key"` (OAuth2 access tokens have an RFC-
 // fixed `Bearer` wire format and ignore these fields).
+//
+// `Region`, `Service`, and `AccessKeyID` are optional, aws_sigv4-specific
+// knobs that supply the non-secret inputs to AWS Signature Version 4
+// request signing (`internal/credential/inject`). They are required when
+// `Kind == "aws_sigv4"` and rejected on every other kind. None of the
+// three is secret: AccessKeyID appears verbatim in the `Credential=`
+// field of the signed `Authorization` header, and Region/Service form the
+// public credential scope. The bound vault credential's value is the AWS
+// secret access key and is never named in the manifest.
 type ManifestCredential struct {
-	Kind   string          `toml:"kind"`
-	Scope  string          `toml:"scope"`
-	Header string          `toml:"header,omitempty"`
-	Format string          `toml:"format,omitempty"`
-	OAuth2 *ManifestOAuth2 `toml:"oauth2,omitempty"`
+	Kind        string          `toml:"kind"`
+	Scope       string          `toml:"scope"`
+	Header      string          `toml:"header,omitempty"`
+	Format      string          `toml:"format,omitempty"`
+	Region      string          `toml:"region,omitempty"`
+	Service     string          `toml:"service,omitempty"`
+	AccessKeyID string          `toml:"access_key_id,omitempty"`
+	OAuth2      *ManifestOAuth2 `toml:"oauth2,omitempty"`
 }
 
 // ManifestOAuth2 is `[capabilities.credential.oauth2]` — the OAuth
@@ -448,6 +460,11 @@ const CredentialKindOAuth2 = "oauth2"
 // CredentialKindAPIKey names the API-key credential kind.
 const CredentialKindAPIKey = "api_key"
 
+// CredentialKindAWSSigV4 names the AWS Signature Version 4 credential
+// kind. The bound vault value is the secret access key; the non-secret
+// inputs (region, service, access key id) come from the manifest.
+const CredentialKindAWSSigV4 = "aws_sigv4"
+
 // validateCredential enforces the v1 closed set of credential kinds
 // and the kind-specific manifest requirements documented in ADR-0002.
 //
@@ -457,8 +474,12 @@ const CredentialKindAPIKey = "api_key"
 //     required and must declare authorize_url, token_url, client_id,
 //     and at least one scope. URL fields must be valid `https://`
 //     URLs.
+//   - kind = "aws_sigv4": `region`, `service`, and `access_key_id` are
+//     all required (they are the non-secret SigV4 signing inputs); the
+//     api_key-only `header`/`format` knobs and the
+//     `[capabilities.credential.oauth2]` table must be absent.
 //
-// Other kinds are rejected at install time. Kinds outside the v1 set
+// Other kinds are rejected at install time. Kinds outside the closed set
 // (basic, x509, etc.) are post-MVP and require an ADR amendment.
 func validateCredential(c *ManifestCredential, file string) error {
 	switch c.Kind {
@@ -518,10 +539,62 @@ func validateCredential(c *ManifestCredential, file string) error {
 				"[capabilities.credential].format is only valid when kind = %q", CredentialKindAPIKey)
 		}
 		return validateOAuth2(c.OAuth2, file)
+	case CredentialKindAWSSigV4:
+		// `region`, `service`, and `access_key_id` are the non-secret
+		// inputs to SigV4 signing. All three are required: signing fails
+		// without any of them, so reject at install rather than at the
+		// first signed request. The secret access key is bound from the
+		// vault, never declared here.
+		if strings.TrimSpace(c.Region) == "" {
+			return newValidationErr(file,
+				"[capabilities.credential].region is required when kind = %q", c.Kind)
+		}
+		if strings.TrimSpace(c.Service) == "" {
+			return newValidationErr(file,
+				"[capabilities.credential].service is required when kind = %q", c.Kind)
+		}
+		if strings.TrimSpace(c.AccessKeyID) == "" {
+			return newValidationErr(file,
+				"[capabilities.credential].access_key_id is required when kind = %q", c.Kind)
+		}
+		// region, service, and access_key_id are emitted verbatim into the
+		// SigV4 `Authorization` header (the credential scope and
+		// `Credential=` field). A CR/LF in any of them would corrupt HTTP
+		// framing or smuggle a header once injected — net/http's
+		// Header.Set does not sanitize the value. Fail closed at install,
+		// mirroring the api_key `format` newline check.
+		for _, f := range []struct {
+			name, value string
+		}{
+			{"region", c.Region},
+			{"service", c.Service},
+			{"access_key_id", c.AccessKeyID},
+		} {
+			if strings.ContainsAny(f.value, "\r\n") {
+				return newValidationErr(file,
+					"[capabilities.credential].%s must not contain newline characters", f.name)
+			}
+		}
+		// `header`/`format` are api_key-specific and the oauth2 table is
+		// oauth2-specific; none shapes the SigV4 wire format. Reject them
+		// so a manifest can't imply a knob that the SigV4 path ignores.
+		if c.Header != "" {
+			return newValidationErr(file,
+				"[capabilities.credential].header is only valid when kind = %q", CredentialKindAPIKey)
+		}
+		if c.Format != "" {
+			return newValidationErr(file,
+				"[capabilities.credential].format is only valid when kind = %q", CredentialKindAPIKey)
+		}
+		if c.OAuth2 != nil {
+			return newValidationErr(file,
+				"[capabilities.credential.oauth2] must be absent when kind = %q", c.Kind)
+		}
+		return nil
 	default:
 		return newValidationErr(file,
-			"[capabilities.credential].kind %q is not in the v1 closed set (%q, %q)",
-			c.Kind, CredentialKindAPIKey, CredentialKindOAuth2)
+			"[capabilities.credential].kind %q is not in the closed set (%q, %q, %q)",
+			c.Kind, CredentialKindAPIKey, CredentialKindOAuth2, CredentialKindAWSSigV4)
 	}
 }
 

--- a/internal/cstore/manifest_test.go
+++ b/internal/cstore/manifest_test.go
@@ -475,8 +475,170 @@ func TestValidateManifest_RejectsUnknownKind(t *testing.T) {
 	if err == nil {
 		t.Fatal("expected error for unknown kind")
 	}
-	if !strings.Contains(err.Error(), "v1 closed set") {
+	if !strings.Contains(err.Error(), "closed set") {
 		t.Errorf("err = %v", err)
+	}
+	// The rejection message must enumerate every valid kind so operators
+	// can see what they may use, including the aws_sigv4 kind.
+	for _, want := range []string{CredentialKindAPIKey, CredentialKindOAuth2, CredentialKindAWSSigV4} {
+		if !strings.Contains(err.Error(), want) {
+			t.Errorf("err = %v, want it to name valid kind %q", err, want)
+		}
+	}
+}
+
+// --- aws_sigv4 credential validation tests (#1504) ---
+
+func TestValidateManifest_AcceptsAWSSigV4Kind(t *testing.T) {
+	m := canonicalManifestForTest()
+	m.Capabilities.Credential = &ManifestCredential{
+		Kind:        CredentialKindAWSSigV4,
+		Scope:       "Read your S3 buckets",
+		Region:      "us-east-1",
+		Service:     "s3",
+		AccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+	}
+	if err := ValidateManifest(m, "ok.toml"); err != nil {
+		t.Errorf("Validate() = %v", err)
+	}
+}
+
+func TestValidateManifest_RejectsAWSSigV4MissingFields(t *testing.T) {
+	// Each of region/service/access_key_id is required for signing. A
+	// manifest missing any one must fail closed at install with a
+	// field-named message, not at the first signed request.
+	cases := []struct {
+		name string
+		cred *ManifestCredential
+		want string
+	}{
+		{
+			name: "missing region",
+			cred: &ManifestCredential{Kind: CredentialKindAWSSigV4, Service: "s3", AccessKeyID: "AKIA"},
+			want: "region",
+		},
+		{
+			name: "missing service",
+			cred: &ManifestCredential{Kind: CredentialKindAWSSigV4, Region: "us-east-1", AccessKeyID: "AKIA"},
+			want: "service",
+		},
+		{
+			name: "missing access_key_id",
+			cred: &ManifestCredential{Kind: CredentialKindAWSSigV4, Region: "us-east-1", Service: "s3"},
+			want: "access_key_id",
+		},
+		{
+			name: "blank region",
+			cred: &ManifestCredential{Kind: CredentialKindAWSSigV4, Region: "   ", Service: "s3", AccessKeyID: "AKIA"},
+			want: "region",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := canonicalManifestForTest()
+			m.Capabilities.Credential = tc.cred
+			err := ValidateManifest(m, "ok.toml")
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) {
+				t.Errorf("err = %v, want mention of %q", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateManifest_RejectsAWSSigV4WithHeaderOrFormat(t *testing.T) {
+	// header/format are api_key-specific; they do not shape the SigV4
+	// wire format. Reject so a manifest can't imply an ignored knob.
+	cases := []struct {
+		name string
+		cred *ManifestCredential
+	}{
+		{
+			name: "header",
+			cred: &ManifestCredential{Kind: CredentialKindAWSSigV4, Region: "us-east-1", Service: "s3", AccessKeyID: "AKIA", Header: "X-API-Key"},
+		},
+		{
+			name: "format",
+			cred: &ManifestCredential{Kind: CredentialKindAWSSigV4, Region: "us-east-1", Service: "s3", AccessKeyID: "AKIA", Format: "{key}"},
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := canonicalManifestForTest()
+			m.Capabilities.Credential = tc.cred
+			err := ValidateManifest(m, "ok.toml")
+			if err == nil {
+				t.Fatalf("expected error for %s on aws_sigv4", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.name) {
+				t.Errorf("err = %v, want mention of %q", err, tc.name)
+			}
+		})
+	}
+}
+
+func TestValidateManifest_RejectsAWSSigV4FieldsWithNewline(t *testing.T) {
+	// region/service/access_key_id are interpolated verbatim into the
+	// SigV4 Authorization header. A CR/LF would corrupt HTTP framing or
+	// smuggle a header; reject at install.
+	base := func() *ManifestCredential {
+		return &ManifestCredential{
+			Kind:        CredentialKindAWSSigV4,
+			Region:      "us-east-1",
+			Service:     "s3",
+			AccessKeyID: "AKIA",
+		}
+	}
+	cases := []struct {
+		name  string
+		mutfn func(*ManifestCredential)
+		want  string
+	}{
+		{"region CRLF", func(c *ManifestCredential) { c.Region = "us-east-1\r\nX: y" }, "region"},
+		{"service LF", func(c *ManifestCredential) { c.Service = "s3\ninjected" }, "service"},
+		{"access_key_id CR", func(c *ManifestCredential) { c.AccessKeyID = "AKIA\rX" }, "access_key_id"},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			m := canonicalManifestForTest()
+			cred := base()
+			tc.mutfn(cred)
+			m.Capabilities.Credential = cred
+			err := ValidateManifest(m, "ok.toml")
+			if err == nil {
+				t.Fatalf("expected error for %s", tc.name)
+			}
+			if !strings.Contains(err.Error(), tc.want) || !strings.Contains(err.Error(), "newline") {
+				t.Errorf("err = %v, want mention of %q and newline", err, tc.want)
+			}
+		})
+	}
+}
+
+func TestValidateManifest_RejectsAWSSigV4WithOAuth2Table(t *testing.T) {
+	// The oauth2 table is oauth2-specific; rejecting it keeps the closed
+	// set's kind/table pairing one-to-one.
+	m := canonicalManifestForTest()
+	m.Capabilities.Credential = &ManifestCredential{
+		Kind:        CredentialKindAWSSigV4,
+		Region:      "us-east-1",
+		Service:     "s3",
+		AccessKeyID: "AKIA",
+		OAuth2: &ManifestOAuth2{
+			AuthorizeURL: "https://example.com/authorize",
+			TokenURL:     "https://example.com/token",
+			ClientID:     "abc",
+			Scopes:       []string{"x"},
+		},
+	}
+	err := ValidateManifest(m, "ok.toml")
+	if err == nil {
+		t.Fatal("expected error for oauth2 table on aws_sigv4")
+	}
+	if !strings.Contains(err.Error(), "oauth2") {
+		t.Errorf("err = %v, want mention of oauth2", err)
 	}
 }
 

--- a/internal/sandbox/host.go
+++ b/internal/sandbox/host.go
@@ -16,6 +16,8 @@ import (
 	"github.com/tetratelabs/wazero/api"
 
 	"github.com/ALRubinger/aileron/internal/credential"
+	"github.com/ALRubinger/aileron/internal/credential/inject"
+	"github.com/ALRubinger/aileron/internal/cstore"
 )
 
 // HTTPDoer is the narrow HTTP-client surface the sandbox needs. It
@@ -70,6 +72,16 @@ type hostState struct {
 	// wire format.
 	credentialHeader string
 	credentialFormat string
+
+	// credentialRegion, credentialService, and credentialAccessKeyID are
+	// the manifest's `[capabilities.credential].region` / `.service` /
+	// `.access_key_id` fields, only consulted for aws_sigv4 credentials.
+	// They are the non-secret SigV4 signing inputs; the secret access key
+	// arrives separately from the credential resolver. Empty for every
+	// other kind.
+	credentialRegion      string
+	credentialService     string
+	credentialAccessKeyID string
 
 	// credentialResolver is the per-Invoke handle the host uses to
 	// fetch a bound credential when the connector's http_request
@@ -463,6 +475,35 @@ func injectCredential(ctx context.Context, s *hostState, req *http.Request, requ
 	case "api_key":
 		header, format := apiKeyInjection(s.credentialHeader, s.credentialFormat)
 		req.Header.Set(header, strings.ReplaceAll(format, "{key}", string(cred.Value)))
+	case cstore.CredentialKindAWSSigV4:
+		// Re-sign the request with AWS Signature Version 4 via the shared
+		// signer. The signer buffers and restores req.Body for the payload
+		// hash, so the body survives to the outbound dial; the host must
+		// not consume it beforehand (the request was built with a
+		// re-readable bytes.Reader over the envelope body). The secret
+		// access key (cred.Value) is used only as HMAC key material and
+		// never appears in the resulting header — nor in any error below.
+		params := inject.Params{
+			AccessKeyID: s.credentialAccessKeyID,
+			Region:      s.credentialRegion,
+			Service:     s.credentialService,
+		}
+		if injErr := inject.Inject(req, inject.SchemeSigV4Resign, cred.Value, params); injErr != nil {
+			// Fail closed. A missing required param is a manifest/runtime
+			// configuration defect (capability_denied); anything else is a
+			// signing-time runtime failure. Neither path echoes cred.Value.
+			if errors.Is(injErr, inject.ErrMissingParam) {
+				return newCapabilityDenied(
+					"http_request: aws_sigv4 signing inputs incomplete (region, service, and access_key_id are required)",
+					map[string]any{
+						"connector":       s.connectorFQN,
+						"capability_kind": cred.Kind,
+						"boundary_detail": "connector_manifest",
+					})
+			}
+			return newConnectorRuntimeError(fmt.Sprintf(
+				"http_request: aws_sigv4 sign: %s", injErr.Error()))
+		}
 	default:
 		return newCapabilityDenied(
 			"http_request: unsupported credential kind for v1 injection",

--- a/internal/sandbox/host_credential_test.go
+++ b/internal/sandbox/host_credential_test.go
@@ -1,8 +1,12 @@
 package sandbox
 
 import (
+	"bytes"
 	"context"
+	"crypto/sha256"
 	"errors"
+	"fmt"
+	"io"
 	"net/http"
 	"net/http/httptest"
 	"strings"
@@ -289,21 +293,135 @@ func TestInjectCredential_OAuth2IgnoresFormatOverride(t *testing.T) {
 }
 
 func TestInjectCredential_UnsupportedKindIsDenied(t *testing.T) {
-	// A vault entry whose kind passed validation but isn't in the v1
-	// closed set ("oauth2"/"api_key") cannot be wired into a request —
-	// return capability_denied rather than silently dropping or
-	// guessing the header. SigV4 etc. land in a follow-up issue.
+	// A vault entry whose kind isn't in the host-injection closed set
+	// ("oauth2"/"api_key"/"aws_sigv4") cannot be wired into a request —
+	// return capability_denied rather than silently dropping or guessing
+	// the header. "basic" is a recognized post-MVP kind that the host
+	// injection path does not yet implement, so it exercises the
+	// default-arm denial without colliding with a supported kind.
 	st := &hostState{
 		connectorFQN:           "github://x/y",
-		expectedCredentialKind: "sigv4",
+		expectedCredentialKind: "basic",
 		credentialResolver: &stubResolver{
-			cred: credential.Credential{Kind: "sigv4", Value: []byte("AKIA...")},
+			cred: credential.Credential{Kind: "basic", Value: []byte("user:pass")},
 		},
 	}
 	req, _ := http.NewRequest("GET", "https://example.com", nil)
-	err := injectCredential(context.Background(), st, req, "sigv4")
+	err := injectCredential(context.Background(), st, req, "basic")
 	if err == nil {
 		t.Fatal("expected denial for unsupported kind")
+	}
+	if err.Class != ClassCapabilityDenied {
+		t.Errorf("class = %s, want capability_denied", err.Class)
+	}
+}
+
+func TestInjectCredential_AWSSigV4SignsRequest(t *testing.T) {
+	// aws_sigv4 with valid params and a bound secret access key produces
+	// a structurally valid SigV4 Authorization header plus the canonical
+	// X-Amz-Date / X-Amz-Content-Sha256 headers. Exact-vector signing is
+	// covered by the inject package's own tests; here we assert the host
+	// dispatch routes through the shared signer.
+	st := &hostState{
+		connectorFQN:           "github://acme/s3",
+		expectedCredentialKind: cstore.CredentialKindAWSSigV4,
+		credentialRegion:       "us-east-1",
+		credentialService:      "s3",
+		credentialAccessKeyID:  "AKIAIOSFODNN7EXAMPLE",
+		credentialResolver: &stubResolver{
+			cred: credential.Credential{
+				Kind:  cstore.CredentialKindAWSSigV4,
+				Value: []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+			},
+		},
+	}
+	req, _ := http.NewRequest("GET", "https://s3.amazonaws.com/bucket/key", nil)
+	if err := injectCredential(context.Background(), st, req, cstore.CredentialKindAWSSigV4); err != nil {
+		t.Fatalf("expected success; got %v", err)
+	}
+	auth := req.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256") {
+		t.Errorf("Authorization = %q, want AWS4-HMAC-SHA256 prefix", auth)
+	}
+	if !strings.Contains(auth, "Credential=AKIAIOSFODNN7EXAMPLE/") {
+		t.Errorf("Authorization = %q, want it to carry the access key id in Credential=", auth)
+	}
+	if req.Header.Get("X-Amz-Date") == "" {
+		t.Error("X-Amz-Date header not set")
+	}
+	if req.Header.Get("X-Amz-Content-Sha256") == "" {
+		t.Error("X-Amz-Content-Sha256 header not set")
+	}
+}
+
+func TestInjectCredential_AWSSigV4DeniedOnMissingParams(t *testing.T) {
+	// When a required signing input is empty at injection time the host
+	// fails closed with capability_denied, and the secret access key must
+	// never appear in the error message or details.
+	const secret = "wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"
+	cases := []struct {
+		name        string
+		region      string
+		service     string
+		accessKeyID string
+	}{
+		{"missing region", "", "s3", "AKIA"},
+		{"missing service", "us-east-1", "", "AKIA"},
+		{"missing access key id", "us-east-1", "s3", ""},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			st := &hostState{
+				connectorFQN:           "github://acme/s3",
+				expectedCredentialKind: cstore.CredentialKindAWSSigV4,
+				credentialRegion:       tc.region,
+				credentialService:      tc.service,
+				credentialAccessKeyID:  tc.accessKeyID,
+				credentialResolver: &stubResolver{
+					cred: credential.Credential{
+						Kind:  cstore.CredentialKindAWSSigV4,
+						Value: []byte(secret),
+					},
+				},
+			}
+			req, _ := http.NewRequest("GET", "https://s3.amazonaws.com/bucket/key", nil)
+			err := injectCredential(context.Background(), st, req, cstore.CredentialKindAWSSigV4)
+			if err == nil {
+				t.Fatalf("expected denial for %s", tc.name)
+			}
+			if err.Class != ClassCapabilityDenied {
+				t.Errorf("class = %s, want capability_denied", err.Class)
+			}
+			if strings.Contains(err.Message, secret) {
+				t.Errorf("error message leaked the secret access key: %q", err.Message)
+			}
+			for k, v := range err.Details {
+				if s, ok := v.(string); ok && strings.Contains(s, secret) {
+					t.Errorf("error detail %q leaked the secret access key: %q", k, s)
+				}
+			}
+			// The request must be left unsigned on failure.
+			if req.Header.Get("Authorization") != "" {
+				t.Errorf("Authorization set on failed signing: %q", req.Header.Get("Authorization"))
+			}
+		})
+	}
+}
+
+func TestInjectCredential_AWSSigV4KindMismatchDenied(t *testing.T) {
+	// The manifest declares aws_sigv4 but the envelope asks for a
+	// different kind — the pre-switch guard denies before any signing.
+	st := &hostState{
+		connectorFQN:           "github://acme/s3",
+		expectedCredentialKind: cstore.CredentialKindAWSSigV4,
+		credentialRegion:       "us-east-1",
+		credentialService:      "s3",
+		credentialAccessKeyID:  "AKIA",
+	}
+	req, _ := http.NewRequest("GET", "https://s3.amazonaws.com", nil)
+	err := injectCredential(context.Background(), st, req, "oauth2")
+	if err == nil {
+		t.Fatal("expected denial on kind mismatch")
 	}
 	if err.Class != ClassCapabilityDenied {
 		t.Errorf("class = %s, want capability_denied", err.Class)
@@ -350,13 +468,94 @@ func TestHostHTTPRequest_CredentialInjectionEndToEnd(t *testing.T) {
 	}
 }
 
+// TestHostHTTPRequest_AWSSigV4BodySurvivesRewind is the rewind
+// regression for the WASM connector SigV4 path. The shared signer reads
+// req.Body fully to compute the payload hash, then restores it; this test
+// proves (a) the upstream still receives the complete body after signing
+// and (b) the X-Amz-Content-Sha256 the signer set equals SHA-256 of the
+// body the upstream actually read — i.e. rewind happened and the payload
+// hash is over the real bytes. Mirrors how hostHTTPRequest builds the
+// request: a POST with a non-empty body via a re-readable bytes.Reader.
+func TestHostHTTPRequest_AWSSigV4BodySurvivesRewind(t *testing.T) {
+	const body = `{"Bucket":"my-bucket","Key":"objects/report.json"}`
+
+	var (
+		gotBody       []byte
+		gotContentSha string
+		gotAuth       string
+	)
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		gotBody, _ = io.ReadAll(r.Body)
+		gotContentSha = r.Header.Get("X-Amz-Content-Sha256")
+		gotAuth = r.Header.Get("Authorization")
+		w.WriteHeader(http.StatusOK)
+	}))
+	t.Cleanup(srv.Close)
+
+	host := httpHostFromURL(srv.URL)
+	manifest := &cstore.Manifest{
+		Connector: cstore.ManifestConnector{Name: "github://acme/s3", Version: "1.0.0"},
+		Capabilities: cstore.ManifestCapabilities{
+			Network: &cstore.ManifestNetwork{Hosts: []string{host}},
+			Credential: &cstore.ManifestCredential{
+				Kind:        cstore.CredentialKindAWSSigV4,
+				Region:      "us-east-1",
+				Service:     "s3",
+				AccessKeyID: "AKIAIOSFODNN7EXAMPLE",
+			},
+		},
+	}
+	st := &hostState{
+		policy:                 NewHostPolicy(manifest),
+		doer:                   srv.Client(),
+		connectorFQN:           manifest.Connector.Name,
+		expectedCredentialKind: cstore.CredentialKindAWSSigV4,
+		credentialRegion:       "us-east-1",
+		credentialService:      "s3",
+		credentialAccessKeyID:  "AKIAIOSFODNN7EXAMPLE",
+		credentialResolver: &stubResolver{
+			cred: credential.Credential{
+				Kind:  cstore.CredentialKindAWSSigV4,
+				Value: []byte("wJalrXUtnFEMI/K7MDENG/bPxRfiCYEXAMPLEKEY"),
+			},
+		},
+	}
+
+	if err := callHTTPRequestBodyForTest(st, http.MethodPost, srv.URL+"/bucket", body, cstore.CredentialKindAWSSigV4); err != nil {
+		t.Fatalf("http_request: %v", err)
+	}
+
+	if string(gotBody) != body {
+		t.Errorf("upstream body = %q, want %q (body did not survive signing rewind)", string(gotBody), body)
+	}
+	wantSha := fmt.Sprintf("%x", sha256.Sum256(gotBody))
+	if gotContentSha != wantSha {
+		t.Errorf("X-Amz-Content-Sha256 = %q, want sha256(body) = %q", gotContentSha, wantSha)
+	}
+	if !strings.HasPrefix(gotAuth, "AWS4-HMAC-SHA256") {
+		t.Errorf("upstream Authorization = %q, want AWS4-HMAC-SHA256 prefix", gotAuth)
+	}
+}
+
 // callHTTPRequestForTest mimics what hostHTTPRequest does after
 // envelope decoding, so the test can drive the credential-injection
 // branch without the WASM round-trip. Centralising the dialing path
 // here keeps the assertion focused on whether the header reaches the
 // upstream.
 func callHTTPRequestForTest(s *hostState, url, credentialKind string) *Error {
-	req, err := http.NewRequest(http.MethodGet, url, nil)
+	return callHTTPRequestBodyForTest(s, http.MethodGet, url, "", credentialKind)
+}
+
+// callHTTPRequestBodyForTest is callHTTPRequestForTest with an explicit
+// method and request body, built the same way hostHTTPRequest builds it
+// (a re-readable bytes.Reader over the body) so the credential-injection
+// branch sees a body it can buffer and restore.
+func callHTTPRequestBodyForTest(s *hostState, method, url, body, credentialKind string) *Error {
+	var reqBody io.Reader
+	if body != "" {
+		reqBody = bytes.NewReader([]byte(body))
+	}
+	req, err := http.NewRequest(method, url, reqBody)
 	if err != nil {
 		return newConnectorRuntimeError(err.Error())
 	}

--- a/internal/sandbox/wazero.go
+++ b/internal/sandbox/wazero.go
@@ -202,6 +202,9 @@ func (c *wazeroConnector) Invoke(ctx context.Context, call Call) (Result, error)
 		expectedCredentialKind: manifestCredentialKind(c.manifest),
 		credentialHeader:       manifestCredentialHeader(c.manifest),
 		credentialFormat:       manifestCredentialFormat(c.manifest),
+		credentialRegion:       manifestCredentialRegion(c.manifest),
+		credentialService:      manifestCredentialService(c.manifest),
+		credentialAccessKeyID:  manifestCredentialAccessKeyID(c.manifest),
 		credentialResolver:     call.CredentialResolver,
 		spawnPolicy:            c.spawnPolicy,
 		spawnExecutor:          c.runtime.spawnExecutor,
@@ -359,6 +362,37 @@ func manifestCredentialFormat(m *cstore.Manifest) string {
 		return ""
 	}
 	return m.Capabilities.Credential.Format
+}
+
+// manifestCredentialRegion safely returns the connector manifest's
+// optional `[capabilities.credential].region`. Empty string when the
+// connector did not declare a credential capability or is not aws_sigv4.
+func manifestCredentialRegion(m *cstore.Manifest) string {
+	if m == nil || m.Capabilities.Credential == nil {
+		return ""
+	}
+	return m.Capabilities.Credential.Region
+}
+
+// manifestCredentialService safely returns the connector manifest's
+// optional `[capabilities.credential].service`. Empty string when the
+// connector did not declare a credential capability or is not aws_sigv4.
+func manifestCredentialService(m *cstore.Manifest) string {
+	if m == nil || m.Capabilities.Credential == nil {
+		return ""
+	}
+	return m.Capabilities.Credential.Service
+}
+
+// manifestCredentialAccessKeyID safely returns the connector manifest's
+// optional `[capabilities.credential].access_key_id`. Empty string when
+// the connector did not declare a credential capability or is not
+// aws_sigv4.
+func manifestCredentialAccessKeyID(m *cstore.Manifest) string {
+	if m == nil || m.Capabilities.Credential == nil {
+		return ""
+	}
+	return m.Capabilities.Credential.AccessKeyID
 }
 
 // toSet converts a slice of capability strings to a lookup set used by


### PR DESCRIPTION
## Summary

Wires the WASM connector egress path to AWS Signature Version 4 via a new `aws_sigv4` credential kind, routing through the shared `inject.SchemeSigV4Resign` signer (#1502/#1518) rather than re-implementing signing at the host.

- **Manifest** (`internal/cstore/manifest.go`): new `CredentialKindAWSSigV4 = "aws_sigv4"` const and three optional, non-secret `ManifestCredential` TOML fields — `region`, `service`, `access_key_id`. New `validateCredential` arm requires all three (fail closed on missing), rejects the api_key-only `header`/`format` knobs and the `oauth2` table, and rejects CR/LF in the three fields (they are emitted verbatim into the `Authorization` header). The closed-set rejection message now enumerates all three kinds.
- **Host dispatch** (`internal/sandbox/host.go`): new `case cstore.CredentialKindAWSSigV4` in `injectCredential` builds `inject.Params{AccessKeyID, Region, Service}` and calls `inject.Inject(req, inject.SchemeSigV4Resign, cred.Value, params)`. Errors map fail-closed: `inject.ErrMissingParam` → `capability_denied`, anything else → `connector_runtime_error`. The secret access key never appears in any error.
- **Plumbing** (`internal/sandbox/host.go`, `wazero.go`): three `hostState` fields (`credentialRegion/Service/AccessKeyID`), three nil-safe `manifestCredential*` accessors, wired into the per-invoke `hostState` literal.

The shared signer buffers and restores `req.Body` for the payload hash, so the host does not double-buffer; the request is already built with a re-readable `bytes.Reader`.

Out of scope (unchanged): the shared signer itself, the proxy egress SigV4 path, `X-Amz-Security-Token`/STS session credentials, any OpenAPI surface.

## Test plan

- `internal/cstore`: accepts a valid `aws_sigv4` manifest; rejects each missing/blank required field with a field-named message; rejects CR/LF in region/service/access_key_id; rejects `header`/`format`/`oauth2` table on the kind; the closed-set message names all three kinds. `go test ./internal/cstore/...` green, coverage 88.5%.
- `internal/sandbox`: `aws_sigv4` signs a request (Authorization `AWS4-HMAC-SHA256` prefix + `Credential=<akid>/`, `X-Amz-Date` and `X-Amz-Content-Sha256` set); missing region/service/access_key_id at injection → `capability_denied` with no secret leak in message/details and request left unsigned; kind-mismatch denied by the pre-switch guard; **end-to-end rewind regression** — a POST with a non-empty body through `injectCredential`→`doer.Do` against an `httptest` upstream asserts the upstream received the full body and `sha256(body)` equals the `X-Amz-Content-Sha256` the signer set. Repurposed the stale `TestInjectCredential_UnsupportedKindIsDenied` stub off the now-supported `sigv4` string onto `basic` to keep default-arm coverage. `go test ./internal/sandbox/...` green, coverage 86.0%.
- `go build ./...` and `go vet` clean across all workspace modules; `coderabbit review` returns 0 findings (one major CR/LF-injection finding raised and fixed).

Closes #1504
