### PR TITLE
feat(proxy): wire sigv4-resign injection onto the HTTPS data-plane path

### DIFF
--- a/docs/src/content/docs/adr/0019-v4-https-data-plane.md
+++ b/docs/src/content/docs/adr/0019-v4-https-data-plane.md
@@ -87,7 +87,7 @@ The injection scheme set is closed. The five schemes are `bearer`, `basic`, `hea
 
 The concrete header shape is per service, not per scheme alone. The GitHub API takes `bearer`. Git over HTTPS takes `basic`. Linear takes `header-template` with its header written verbatim. The scheme names the mechanism; the service determines the exact wire form.
 
-The initial implementation lands four schemes fully (`bearer`, `basic`, `header-template`, `query-param`) plus `sigv4-resign` as a documented stub pending an AWS-style consumer. This is implementation staging, not a design gap. The design names all five and the stub is filled in when the first SigV4 consumer arrives.
+All five schemes are implemented. The SigV4 signing core is std-library-only, built on `crypto/hmac` and `crypto/sha256`, and pulls in no AWS SDK. A `sigv4-resign` binding carries three non-secret params: the access key id, the region, and the service. These are explicit binding fields and are never inferred from the request host. The bound credential value carries the AWS secret access key, which the signer consumes only as HMAC key material and never writes onto any header, error, or audit surface. Static keys are supported today. Session-token handling via `X-Amz-Security-Token` is a declared follow-up.
 
 #### Emit mechanisms
 

--- a/go.work.sum
+++ b/go.work.sum
@@ -139,6 +139,7 @@ github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mailgun/raymond/v2 v2.0.48 h1:5dmlB680ZkFG2RN/0lvTAghrSxIESeu9/2aeDqACtjw=
 github.com/mailgun/raymond/v2 v2.0.48/go.mod h1:lsgvL50kgt1ylcFJYZiULi5fjPBkkhNfj4KA0W54Z18=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=

--- a/internal/app/handlers_connector_operations.go
+++ b/internal/app/handlers_connector_operations.go
@@ -570,11 +570,11 @@ func (s *apiServer) injectSandboxProxyHostBindingCredential(ctx context.Context,
 // over the #1194 scheme-keyed injector (internal/credential/inject):
 // the binding-match wiring is untouched and the injector owns the wire
 // shape of every scheme, so a header convention lives in exactly one
-// place. `bearer`, `basic`, `header-template`, and `query-param` are
-// implemented (each carries its non-secret params from the binding); the
-// remaining member of binding.HostBindingSchemes (sigv4-resign) is
-// accepted at config time but rejected here, which fails closed rather
-// than silently passing an un-injected request upstream.
+// place. All five members of binding.HostBindingSchemes (`bearer`,
+// `basic`, `header-template`, `query-param`, and `sigv4-resign`) are
+// injected, each carrying its non-secret params from the binding. A scheme
+// the dispatch does not recognize still fails closed (no upstream dial
+// with an un-injected request) rather than silently passing through.
 //
 // The resolved credential bytes flow only into [inject.Inject], which
 // writes them solely onto the request header or query parameter the
@@ -595,10 +595,10 @@ func applyHostBindingScheme(req *http.Request, hb binding.HostBinding, cred cred
 }
 
 // hostBindingInjectScheme maps a binding's scheme string and its
-// non-secret params onto the closed [inject.Scheme] set. It returns
-// ok=false for any scheme this proxy does not yet inject (a member of
-// binding.HostBindingSchemes whose wire shape is deferred), so the
-// caller fails closed instead of dialing upstream un-injected.
+// non-secret params onto the closed [inject.Scheme] set. Every member of
+// binding.HostBindingSchemes maps to a concrete injector. It returns
+// ok=false for any scheme outside that set, so the caller fails closed
+// instead of dialing upstream un-injected.
 func hostBindingInjectScheme(hb binding.HostBinding) (inject.Scheme, inject.Params, bool) {
 	switch hb.Scheme {
 	case binding.SchemeBearer:
@@ -609,6 +609,8 @@ func hostBindingInjectScheme(hb binding.HostBinding) (inject.Scheme, inject.Para
 		return inject.SchemeHeaderTemplate, inject.Params{HeaderName: hb.HeaderName, Template: hb.HeaderTemplate}, true
 	case binding.SchemeQueryParam:
 		return inject.SchemeQueryParam, inject.Params{ParamName: hb.QueryParamName}, true
+	case binding.SchemeSigV4Resign:
+		return inject.SchemeSigV4Resign, inject.Params{AccessKeyID: hb.AccessKeyID, Region: hb.Region, Service: hb.Service}, true
 	default:
 		return "", inject.Params{}, false
 	}

--- a/internal/app/sandbox_forward_proxy_host_binding_test.go
+++ b/internal/app/sandbox_forward_proxy_host_binding_test.go
@@ -63,7 +63,15 @@ func mustVaultWith(t *testing.T, name, kind string, value []byte) vault.Vault {
 
 func mustHostBindingTable(t *testing.T, host, ref, scheme string) binding.HostBindings {
 	t.Helper()
-	hb, err := binding.NewHostBinding(host, ref, scheme)
+	return mustHostBindingTableOpts(t, host, ref, scheme)
+}
+
+// mustHostBindingTableOpts builds a single-entry binding table, threading
+// scheme-specific construction options (e.g. binding.WithSigV4Resign) so a
+// scheme that carries non-secret params can be exercised end to end.
+func mustHostBindingTableOpts(t *testing.T, host, ref, scheme string, opts ...binding.HostBindingOption) binding.HostBindings {
+	t.Helper()
+	hb, err := binding.NewHostBinding(host, ref, scheme, opts...)
 	if err != nil {
 		t.Fatalf("NewHostBinding: %v", err)
 	}
@@ -304,41 +312,149 @@ func TestSandboxForwardProxy_HostBindingMissingCredentialFailsClosed(t *testing.
 	}
 }
 
-// TestSandboxForwardProxy_HostBindingUnsupportedSchemeFailsClosed
-// asserts a binding declaring a scheme in the closed set but not yet
-// injected by the proxy (e.g. `sigv4-resign`, which the #1194 injector
-// enumerates but defers) fails closed rather than dialing upstream with
-// an un-injected request.
-func TestSandboxForwardProxy_HostBindingUnsupportedSchemeFailsClosed(t *testing.T) {
+// TestSandboxForwardProxy_HostBindingSigV4ResignInjectsSignature is the
+// sigv4-resign happy path: a request whose host matches a sigv4-resign
+// binding is re-signed daemon-side with the resolved secret access key.
+// The upstream sees a well-formed AWS4-HMAC-SHA256 Authorization header
+// plus X-Amz-Date and X-Amz-Content-Sha256; the Credential= field carries
+// the non-secret access-key-id and credential scope, but the secret access
+// key never appears on any header, body, or audit surface, and a
+// binding_injected audit event is emitted with scheme sigv4-resign.
+func TestSandboxForwardProxy_HostBindingSigV4ResignInjectsSignature(t *testing.T) {
+	auditStore := audit.NewMemStore()
+	const secretAccessKey = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY"
+	const accessKeyID = "AKIDEXAMPLE"
+	var upstreamAuth, upstreamDate, upstreamContentHash, upstreamURL string
+	srv := &apiServer{
+		auditStore:    auditStore,
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-sigv4" }),
+		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:         mustVaultWith(t, "user/aws", "user", []byte(secretAccessKey)),
+		hostBindings: mustHostBindingTableOpts(t, "s3.amazonaws.test", "user/aws", "sigv4-resign",
+			binding.WithSigV4Resign(accessKeyID, "us-east-1", "s3")),
+		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
+			upstreamAuth = req.Header.Get("Authorization")
+			upstreamDate = req.Header.Get("X-Amz-Date")
+			upstreamContentHash = req.Header.Get("X-Amz-Content-Sha256")
+			upstreamURL = req.URL.String()
+			return &http.Response{
+				StatusCode: http.StatusOK,
+				Header:     http.Header{"Content-Type": []string{"application/json"}},
+				Body:       io.NopCloser(strings.NewReader(`{"ok":true}`)),
+			}, nil
+		})},
+	}
+	setup := newHostBindingProxySetup(t, srv)
+
+	resp, err := setup.client.Get("https://s3.amazonaws.test/bucket/key?q=1")
+	if err != nil {
+		t.Fatalf("GET through proxy: %v", err)
+	}
+	defer resp.Body.Close()
+	body, _ := io.ReadAll(resp.Body)
+
+	if resp.StatusCode != http.StatusOK {
+		t.Fatalf("status = %d, want 200; body=%s", resp.StatusCode, string(body))
+	}
+	if !strings.HasPrefix(upstreamAuth, "AWS4-HMAC-SHA256 ") {
+		t.Fatalf("upstream Authorization = %q, want AWS4-HMAC-SHA256 prefix", upstreamAuth)
+	}
+	if !strings.Contains(upstreamAuth, "Credential="+accessKeyID+"/") {
+		t.Errorf("Authorization missing Credential=%s/...: %q", accessKeyID, upstreamAuth)
+	}
+	if !strings.Contains(upstreamAuth, "/us-east-1/s3/aws4_request") {
+		t.Errorf("Authorization missing credential scope: %q", upstreamAuth)
+	}
+	if !strings.Contains(upstreamAuth, "SignedHeaders=") || !strings.Contains(upstreamAuth, "Signature=") {
+		t.Errorf("Authorization missing SignedHeaders/Signature: %q", upstreamAuth)
+	}
+	if upstreamDate == "" {
+		t.Error("upstream X-Amz-Date is empty")
+	}
+	if upstreamContentHash == "" {
+		t.Error("upstream X-Amz-Content-Sha256 is empty")
+	}
+	if upstreamURL != "https://s3.amazonaws.test/bucket/key?q=1" {
+		t.Errorf("upstream URL = %q", upstreamURL)
+	}
+
+	// The secret access key must never appear on any observable surface:
+	// not in the signed Authorization header (it is only HMAC key material),
+	// nor in any response header or body.
+	if strings.Contains(upstreamAuth, secretAccessKey) {
+		t.Error("Authorization header leaked the secret access key")
+	}
+	for k, vs := range resp.Header {
+		for _, v := range vs {
+			if strings.Contains(v, secretAccessKey) {
+				t.Errorf("response header %s leaked credential: %q", k, v)
+			}
+		}
+	}
+	if strings.Contains(string(body), secretAccessKey) {
+		t.Error("response body leaked credential")
+	}
+
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1", len(events))
+	}
+	evt := events[0]
+	if evt.EventType != model.EventTypeSandboxProxyBindingInjected {
+		t.Fatalf("event type = %q, want %q", evt.EventType, model.EventTypeSandboxProxyBindingInjected)
+	}
+	if got := evt.Payload["aileron.proxy.binding.scheme"]; got != "sigv4-resign" {
+		t.Errorf("binding.scheme = %v, want sigv4-resign", got)
+	}
+	if got := evt.Payload["aileron.proxy.binding.host"]; got != "s3.amazonaws.test" {
+		t.Errorf("binding.host = %v, want s3.amazonaws.test", got)
+	}
+	sandboxProxyBindingInjectedShape.validate(t, evt.Payload)
+	payloadJSON, _ := json.Marshal(evt.Payload)
+	if strings.Contains(string(payloadJSON), secretAccessKey) {
+		t.Errorf("audit payload leaked the secret access key: %s", payloadJSON)
+	}
+}
+
+// TestSandboxForwardProxy_HostBindingSigV4MissingSecretFailsClosed asserts
+// a sigv4-resign binding whose vault secret is absent fails closed: no
+// upstream dial, a binding_credential_unavailable rejection, and not a
+// passthrough. The missing-required-param fail-closed mode is covered at
+// construction (NewHostBinding rejects it before the table is built).
+func TestSandboxForwardProxy_HostBindingSigV4MissingSecretFailsClosed(t *testing.T) {
 	auditStore := audit.NewMemStore()
 	srv := &apiServer{
 		auditStore:    auditStore,
-		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-scheme" }),
+		auditRecorder: audit.NewRecorder(auditStore, nil, func() string { return "audit-sigv4-missing" }),
 		specLoader:    func() ([]connectorspec.Spec, error) { return nil, nil },
-		vault:         mustVaultWith(t, "api_key/github/octocat", "api_key", []byte("hb_secret")),
-		hostBindings:  mustHostBindingTable(t, "api.example.test", "api_key/github/octocat", "sigv4-resign"),
+		vault:         vault.NewMemVault(), // empty: no entry at the ref path
+		hostBindings: mustHostBindingTableOpts(t, "s3.amazonaws.test", "user/aws", "sigv4-resign",
+			binding.WithSigV4Resign("AKIDEXAMPLE", "us-east-1", "s3")),
 		sandboxProxyClient: &http.Client{Transport: sandboxProxyRoundTripFunc(func(req *http.Request) (*http.Response, error) {
-			t.Errorf("upstream must not be dialed for an unsupported scheme; got %s", req.URL)
+			t.Errorf("upstream must not be dialed when the secret is missing; got %s", req.URL)
 			return &http.Response{StatusCode: http.StatusOK, Body: io.NopCloser(strings.NewReader(""))}, nil
 		})},
 	}
 	setup := newHostBindingProxySetup(t, srv)
 
-	resp, err := setup.client.Get("https://api.example.test/v1/resource")
+	resp, err := setup.client.Get("https://s3.amazonaws.test/bucket/key")
 	if err != nil {
 		t.Fatalf("GET through proxy: %v", err)
 	}
 	defer resp.Body.Close()
 
-	if resp.StatusCode != http.StatusForbidden {
-		t.Fatalf("status = %d, want 403", resp.StatusCode)
+	if resp.StatusCode < 500 {
+		t.Fatalf("status = %d, want fail-closed 5xx", resp.StatusCode)
 	}
 	events, _ := auditStore.ListEvents(context.Background(), audit.EventFilter{})
 	if len(events) != 1 {
 		t.Fatalf("events = %d, want 1", len(events))
 	}
-	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != hostBindingRejectUnsupportedScheme {
-		t.Errorf("reject_reason = %v, want %q", got, hostBindingRejectUnsupportedScheme)
+	if got := events[0].Payload["aileron.proxy.reject_reason"]; got != hostBindingRejectCredentialUnavailable {
+		t.Errorf("reject_reason = %v, want %q", got, hostBindingRejectCredentialUnavailable)
 	}
 }
 

--- a/internal/binding/host_binding.go
+++ b/internal/binding/host_binding.go
@@ -46,6 +46,15 @@ const SchemeHeaderTemplate = "header-template"
 // [HostBinding.QueryParamName].
 const SchemeQueryParam = "query-param"
 
+// SchemeSigV4Resign re-signs the request with an AWS Signature Version 4
+// signature. It carries the non-secret [HostBinding.AccessKeyID],
+// [HostBinding.Region], and [HostBinding.Service], all required for this
+// scheme. The secret access key travels in the resolved credential value
+// (never in the binding), and the egress injector consumes it only as HMAC
+// key material to derive the signing key. Static keys only: session tokens
+// (X-Amz-Security-Token) are a declared follow-up, not supported here.
+const SchemeSigV4Resign = "sigv4-resign"
+
 // EmitMechanism names how the in-container client is made to emit a
 // request the proxy can seal at egress (ADR-0019). It is orthogonal to
 // [HostBinding.Scheme], which is how the proxy injects the credential
@@ -127,6 +136,25 @@ type HostBinding struct {
 	// query-param scheme, ignored otherwise.
 	QueryParamName string
 
+	// AccessKeyID is the AWS access key ID, used only when Scheme is
+	// [SchemeSigV4Resign]. It is a non-secret param: it appears verbatim in
+	// the Credential= field of the signed Authorization header. The secret
+	// access key travels in the resolved credential value, never here.
+	// Required for the sigv4-resign scheme, ignored otherwise.
+	AccessKeyID string
+
+	// Region is the AWS region (e.g. "us-east-1") used for the SigV4
+	// credential scope, used only when Scheme is [SchemeSigV4Resign]. It is
+	// a non-secret param and is never inferred from the request host.
+	// Required for the sigv4-resign scheme, ignored otherwise.
+	Region string
+
+	// Service is the AWS service name (e.g. "s3") used for the SigV4
+	// credential scope, used only when Scheme is [SchemeSigV4Resign]. It is
+	// a non-secret param and is never inferred from the request host.
+	// Required for the sigv4-resign scheme, ignored otherwise.
+	Service string
+
 	// EmitMechanism declares how the in-container client is made to emit
 	// a sealable request (see [EmitMechanism]). The zero value is
 	// [EmitMechanismInject] (plant nothing, inject unconditionally).
@@ -190,6 +218,21 @@ func WithHeaderTemplate(header, template string) HostBindingOption {
 // [SchemeQueryParam]. It is required for that scheme.
 func WithQueryParam(name string) HostBindingOption {
 	return func(hb *HostBinding) { hb.QueryParamName = name }
+}
+
+// WithSigV4Resign sets the non-secret [HostBinding.AccessKeyID],
+// [HostBinding.Region], and [HostBinding.Service] used by
+// [SchemeSigV4Resign]. All three are required for that scheme: a
+// sigv4-resign binding with no access key id, region, or service could
+// never produce a well-formed signature, so an empty value is a
+// construction error. The secret access key is never set here; it travels
+// in the resolved credential value.
+func WithSigV4Resign(accessKeyID, region, service string) HostBindingOption {
+	return func(hb *HostBinding) {
+		hb.AccessKeyID = accessKeyID
+		hb.Region = region
+		hb.Service = service
+	}
 }
 
 // WithEmitMechanismSentinelSwap marks the binding as
@@ -261,6 +304,9 @@ func NewHostBinding(hostPattern, credentialRef, scheme string, opts ...HostBindi
 	}
 	if scheme == SchemeQueryParam && hb.QueryParamName == "" {
 		return HostBinding{}, fmt.Errorf("host binding: query-param scheme requires a param name (WithQueryParam)")
+	}
+	if scheme == SchemeSigV4Resign && (hb.AccessKeyID == "" || hb.Region == "" || hb.Service == "") {
+		return HostBinding{}, fmt.Errorf("host binding: sigv4-resign scheme requires access key id, region, and service (WithSigV4Resign)")
 	}
 	if hb.EmitMechanism == EmitMechanismSentinelSwap && (hb.SentinelValue == "" || hb.SentinelEnv == "") {
 		return HostBinding{}, fmt.Errorf("host binding: emit-mechanism sentinel-swap requires a sentinel value and env (WithSentinel)")

--- a/internal/binding/host_binding_test.go
+++ b/internal/binding/host_binding_test.go
@@ -188,6 +188,60 @@ func TestNewHostBinding_QueryParamRequiresName(t *testing.T) {
 	}
 }
 
+func TestNewHostBinding_SigV4ResignRequiresAllParams(t *testing.T) {
+	// A sigv4-resign binding needs an access key id, region, and service to
+	// produce a well-formed signature, so each missing individually is a
+	// construction error (the acceptance criterion: no invalid binding
+	// reaches the matcher). The secret access key is never a binding param;
+	// it travels in the resolved credential value.
+	missingCases := []struct {
+		name                         string
+		accessKeyID, region, service string
+	}{
+		{"missing access key id", "", "us-east-1", "s3"},
+		{"missing region", "AKIDEXAMPLE", "", "s3"},
+		{"missing service", "AKIDEXAMPLE", "us-east-1", ""},
+	}
+	for _, tc := range missingCases {
+		t.Run(tc.name, func(t *testing.T) {
+			if _, err := binding.NewHostBinding("s3.amazonaws.com", "user/aws", "sigv4-resign",
+				binding.WithSigV4Resign(tc.accessKeyID, tc.region, tc.service)); err == nil {
+				t.Fatalf("expected error for %s, got nil", tc.name)
+			}
+		})
+	}
+	// Bare sigv4-resign with no options is also rejected.
+	if _, err := binding.NewHostBinding("s3.amazonaws.com", "user/aws", "sigv4-resign"); err == nil {
+		t.Fatal("expected error for sigv4-resign without params, got nil")
+	}
+
+	hb, err := binding.NewHostBinding("s3.amazonaws.com", "user/aws", "sigv4-resign",
+		binding.WithSigV4Resign("AKIDEXAMPLE", "us-east-1", "s3"))
+	if err != nil {
+		t.Fatalf("unexpected error for valid sigv4-resign: %v", err)
+	}
+	if hb.Scheme != binding.SchemeSigV4Resign {
+		t.Errorf("Scheme = %q, want %q", hb.Scheme, binding.SchemeSigV4Resign)
+	}
+	if hb.AccessKeyID != "AKIDEXAMPLE" || hb.Region != "us-east-1" || hb.Service != "s3" {
+		t.Errorf("sigv4 params = (%q,%q,%q), want (AKIDEXAMPLE,us-east-1,s3)",
+			hb.AccessKeyID, hb.Region, hb.Service)
+	}
+}
+
+func TestWithSigV4Resign_IgnoredByNonSigV4Scheme(t *testing.T) {
+	// The sigv4 params are scheme-specific: a bearer binding that happens to
+	// carry them constructs fine and simply ignores them at egress.
+	hb, err := binding.NewHostBinding("api.example.com", "user/example", "bearer",
+		binding.WithSigV4Resign("AKIDEXAMPLE", "us-east-1", "s3"))
+	if err != nil {
+		t.Fatalf("unexpected error: %v", err)
+	}
+	if hb.Scheme != binding.SchemeBearer {
+		t.Errorf("Scheme = %q, want bearer", hb.Scheme)
+	}
+}
+
 func TestNewHostBinding_RejectsInvalidCredentialRef(t *testing.T) {
 	for _, ref := range []string{"", "not-a-binding-name", "oauth2/github", "../escape/x"} {
 		if _, err := binding.NewHostBinding("api.example.com", ref, "bearer"); err == nil {

--- a/internal/proxybinding/binding.go
+++ b/internal/proxybinding/binding.go
@@ -27,6 +27,8 @@ func (e *Entry) ToHostBinding() (binding.HostBinding, error) {
 		opts = append(opts, binding.WithHeaderTemplate(e.Header, e.Template))
 	case binding.SchemeQueryParam:
 		opts = append(opts, binding.WithQueryParam(e.QueryParam))
+	case binding.SchemeSigV4Resign:
+		opts = append(opts, binding.WithSigV4Resign(e.AccessKeyID, e.Region, e.Service))
 	}
 
 	if e.EmitMechanism == string(binding.EmitMechanismSentinelSwap) {

--- a/internal/proxybinding/binding_test.go
+++ b/internal/proxybinding/binding_test.go
@@ -70,6 +70,46 @@ func TestToHostBinding_QueryParamCarriesName(t *testing.T) {
 	}
 }
 
+func TestToHostBinding_SigV4ResignCarriesParams(t *testing.T) {
+	// A sigv4-resign entry's access key id, region, and service adapt onto
+	// the binding. The secret access key is never a descriptor field; it
+	// resolves daemon-side from the credential ref.
+	e := Entry{
+		Host:          "s3.amazonaws.com",
+		CredentialRef: "user/aws",
+		Scheme:        binding.SchemeSigV4Resign,
+		AccessKeyID:   "AKIDEXAMPLE",
+		Region:        "us-east-1",
+		Service:       "s3",
+	}
+	hb, err := e.ToHostBinding()
+	if err != nil {
+		t.Fatalf("ToHostBinding: %v", err)
+	}
+	if hb.Scheme != binding.SchemeSigV4Resign {
+		t.Errorf("scheme = %q, want sigv4-resign", hb.Scheme)
+	}
+	if hb.AccessKeyID != "AKIDEXAMPLE" || hb.Region != "us-east-1" || hb.Service != "s3" {
+		t.Errorf("sigv4 params = (%q,%q,%q), want (AKIDEXAMPLE,us-east-1,s3)",
+			hb.AccessKeyID, hb.Region, hb.Service)
+	}
+}
+
+func TestToHostBinding_SigV4ResignMissingParamErrors(t *testing.T) {
+	// A sigv4-resign entry missing any of the three params is rejected by the
+	// constructor (fail closed, no malformed binding ships).
+	e := Entry{
+		Host:          "s3.amazonaws.com",
+		CredentialRef: "user/aws",
+		Scheme:        binding.SchemeSigV4Resign,
+		AccessKeyID:   "AKIDEXAMPLE",
+		// Region and Service omitted.
+	}
+	if _, err := e.ToHostBinding(); err == nil {
+		t.Fatal("ToHostBinding for sigv4-resign with missing params = nil error, want error")
+	}
+}
+
 func TestToHostBinding_SentinelSwapCarriesSentinel(t *testing.T) {
 	// A sentinel-swap entry's sentinel value and env adapt onto the binding
 	// so the launcher and the proxy read one source of truth.

--- a/internal/proxybinding/descriptor.go
+++ b/internal/proxybinding/descriptor.go
@@ -143,6 +143,22 @@ type Entry struct {
 	// QueryParam is the query-parameter name to set, required only for the
 	// query-param scheme.
 	QueryParam string `yaml:"query_param"`
+
+	// AccessKeyID is the non-secret AWS access key ID, required only for the
+	// sigv4-resign scheme. It appears verbatim in the signed request's
+	// Credential= field; the secret access key travels in the resolved
+	// credential value, never here.
+	AccessKeyID string `yaml:"access_key_id"`
+
+	// Region is the non-secret AWS region (e.g. "us-east-1") used for the
+	// SigV4 credential scope, required only for the sigv4-resign scheme. It
+	// is never inferred from the host.
+	Region string `yaml:"region"`
+
+	// Service is the non-secret AWS service name (e.g. "s3") used for the
+	// SigV4 credential scope, required only for the sigv4-resign scheme. It
+	// is never inferred from the host.
+	Service string `yaml:"service"`
 }
 
 // Sentinel is the per-binding sentinel-swap placeholder declaration. It makes
@@ -278,6 +294,16 @@ func (e *Entry) Validate() error {
 	case string(inject.SchemeQueryParam):
 		if e.QueryParam == "" {
 			return fmt.Errorf("query-param scheme requires a query_param name")
+		}
+	case string(inject.SchemeSigV4Resign):
+		if e.AccessKeyID == "" {
+			return fmt.Errorf("sigv4-resign scheme requires an access_key_id")
+		}
+		if e.Region == "" {
+			return fmt.Errorf("sigv4-resign scheme requires a region")
+		}
+		if e.Service == "" {
+			return fmt.Errorf("sigv4-resign scheme requires a service")
 		}
 	}
 

--- a/internal/proxybinding/descriptor_test.go
+++ b/internal/proxybinding/descriptor_test.go
@@ -77,6 +77,11 @@ func TestParse_EachSchemeValidates(t *testing.T) {
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: query-param\n    query_param: api_key\n",
 			want: binding.SchemeQueryParam,
 		},
+		{
+			name: "sigv4-resign",
+			yaml: "version: v1\nbindings:\n  - host: s3.amazonaws.com\n    credential_ref: user/aws\n    scheme: sigv4-resign\n    access_key_id: AKIDEXAMPLE\n    region: us-east-1\n    service: s3\n",
+			want: binding.SchemeSigV4Resign,
+		},
 	}
 	for _, tc := range cases {
 		t.Run(tc.name, func(t *testing.T) {
@@ -178,6 +183,18 @@ func TestParse_Errors(t *testing.T) {
 		{
 			name: "query-param missing param",
 			yaml: "version: v1\nbindings:\n  - host: api.example.com\n    credential_ref: user/example\n    scheme: query-param\n",
+		},
+		{
+			name: "sigv4-resign missing access_key_id",
+			yaml: "version: v1\nbindings:\n  - host: s3.amazonaws.com\n    credential_ref: user/aws\n    scheme: sigv4-resign\n    region: us-east-1\n    service: s3\n",
+		},
+		{
+			name: "sigv4-resign missing region",
+			yaml: "version: v1\nbindings:\n  - host: s3.amazonaws.com\n    credential_ref: user/aws\n    scheme: sigv4-resign\n    access_key_id: AKIDEXAMPLE\n    service: s3\n",
+		},
+		{
+			name: "sigv4-resign missing service",
+			yaml: "version: v1\nbindings:\n  - host: s3.amazonaws.com\n    credential_ref: user/aws\n    scheme: sigv4-resign\n    access_key_id: AKIDEXAMPLE\n    region: us-east-1\n",
 		},
 		{
 			name: "invalid credential_ref",


### PR DESCRIPTION
## Summary

Wires the already-merged AWS SigV4 signing core (#1518) onto the host-binding and HTTPS forward-proxy mediation path so a `sigv4-resign` binding re-signs the upstream request with static AWS credentials. Before this change `sigv4-resign` was accepted at config time but rejected at the egress seam (fail closed); it now injects a real signature.

- `binding.HostBinding` gains the non-secret `AccessKeyID`/`Region`/`Service` fields, the `SchemeSigV4Resign` const, a `WithSigV4Resign(...)` option, and `NewHostBinding` validation that rejects the scheme unless all three params are present.
- The proxy's `hostBindingInjectScheme` maps `sigv4-resign` onto `inject.SchemeSigV4Resign` carrying its non-secret params; the `default` branch stays fail-closed.
- `proxybinding` descriptors thread `access_key_id`/`region`/`service` through `Entry`, `Entry.Validate`, and `ToHostBinding`.
- ADR-0019 prose updated: all five schemes are implemented, the signer is std-library-only (no AWS SDK), static keys are supported, session-token (`X-Amz-Security-Token`) handling is a declared follow-up.

### Security invariants preserved
- The secret access key travels only in the resolved credential value and is consumed solely as HMAC key material. It never reaches a header, error, log, or audit surface (asserted in tests).
- `Region`/`Service`/`AccessKeyID` are explicit binding params, never inferred from the request host.
- Static keys only; no session-token handling (out of scope, declared follow-up).
- Missing required param fails at construction; unresolvable secret fails closed at egress with `binding_credential_unavailable` and no upstream dial.

## Test plan

- `internal/binding`: valid sigv4-resign round-trips all three fields; each missing individually rejects at construction; a non-sigv4 scheme ignores the params.
- `internal/proxybinding`: descriptor with `scheme: sigv4-resign` + all three params parses, validates, and `ToHostBinding` round-trips; missing any field fails `Validate`; strict decode still rejects unknown keys.
- `internal/app`: repurposed the old "unsupported scheme fails closed" test into `TestSandboxForwardProxy_HostBindingSigV4ResignInjectsSignature` (asserts a well-formed `Authorization: AWS4-HMAC-SHA256 ...` with `Credential=<akid>/<scope>`, `X-Amz-Date`, `X-Amz-Content-Sha256`, secret absent from every surface, `binding_injected` audit event with scheme `sigv4-resign`), plus `TestSandboxForwardProxy_HostBindingSigV4MissingSecretFailsClosed`.
- `go test` green on `internal/{app,binding,proxybinding,credential,...}`; coverage: app 82.6%, binding 93.4%, proxybinding 95.0%.
- `coderabbit review --agent`: 0 findings.

No OpenAPI/endpoint changes (internal proxy mediation); `server.gen.go` untouched.

Closes #1503

🤖 Generated with [Claude Code](https://claude.com/claude-code)
