### PR TITLE
test(sandbox): prove aws CLI SigV4 sealing end-to-end and reconcile proxy matrix

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -372,6 +372,11 @@ tasks:
     cmds:
       - go test -tags=integration_sandbox -race -run TestSandboxMCP ./internal/app/...
 
+  test:integration:sandbox-proxy-clients:
+    desc: "Run the real-client sandbox-proxy subprocess integration tests: curl (credential injection + proxied audit) and aws (SigV4 re-sign end-to-end + seal). In-process daemon + intercepting CONNECT/TLS proxy + fake HTTPS upstream; the CLIs run as host subprocesses. Fail-fast — requires `curl` AND `aws` on PATH (no self-skip)."
+    cmds:
+      - go test -tags=integration_sandbox -race -run 'TestSandboxProxyCurlIntegration|TestSandboxProxyAWSSigV4Integration' ./internal/app/...
+
   test:integration:auth-github-route:
     desc: "Run the auth github route-drift guard (#1157): stands up the real daemon handler over a MemVault and asserts the CLI's hardcoded vault path still resolves to the spec-registered route. In-process, no external prereqs (no self-skip)."
     dir: cmd/aileron

--- a/docs/src/content/docs/development/sandbox-proxy-cli-matrix.md
+++ b/docs/src/content/docs/development/sandbox-proxy-cli-matrix.md
@@ -189,7 +189,7 @@ The `gh` sentinel-swap is asserted by the deterministic end-to-end test `TestSen
 
 ## aws (AWS CLI)
 
-`aws` does not read `HTTPS_PROXY` from the standard env by default — it reads `HTTPS_PROXY` only when configured to do so via `~/.aws/config`, or via the deprecated `--no-verify-ssl` workaround. The cleanest path is to set `HTTPS_PROXY` and `AWS_CA_BUNDLE` env vars and rely on `aws`'s standard env support.
+`aws`'s botocore HTTP layer reads `HTTPS_PROXY` from the environment, so the launcher-set proxy applies with no extra config. You only need to point `aws` at Aileron's session CA. Set `AWS_CA_BUNDLE` to the mounted CA so botocore trusts the proxy's intercepted TLS.
 
 ### Install
 
@@ -212,29 +212,33 @@ aws configure set aws_secret_access_key placeholder-aileron-injects-real
 aws configure set region us-east-1
 ```
 
+`aws` is `proxy-sealable` via `sigv4-resign`. The placeholder credentials above let botocore sign the request locally so it leaves the client. At the TLS proxy boundary the daemon strips that local signature and re-signs the request with the real secret access key resolved host-side, using the access key id, region, and service declared in the `sigv4-resign` host binding. The real secret access key never enters the container; it is HMAC key material the daemon holds in the vault. See [ADR-0019](/adr/0019-v4-https-data-plane/).
+
 ### Success case
 
-For an installed AWS connector spec with, say, `GET /` on `sts.us-east-1.amazonaws.com`:
+For a `sigv4-resign` host binding on `s3.amazonaws.com` whose `credential_ref` resolves the secret access key from your vault (`user/aws`):
 
 ```bash
-aws sts get-caller-identity
+aws s3api list-buckets
 ```
 
 Expected:
 
-- 200 with the calling identity.
-- `connector.proxy.proxied` audit, `aileron.proxy.upstream.host: "sts.us-east-1.amazonaws.com"`.
+- 200 with the upstream's response body.
+- A `sandbox.proxy.binding_injected` audit event with `aileron.proxy.binding.host: "s3.amazonaws.com"` and `aileron.proxy.binding.scheme: "sigv4-resign"`. The upstream received a well-formed `Authorization: AWS4-HMAC-SHA256 …` header whose `Credential=<access-key-id>/.../<region>/<service>/aws4_request` scope and signature validate against the daemon's secret. The placeholder secret you configured locally never reaches the upstream, and the audit payload holds no secret bytes.
+
+The verification point is that the secret access key is present in the daemon vault and nowhere in the container. The container's static credentials are placeholders. The signature the upstream accepts was computed host-side with the real secret.
 
 ### Unmatched case
 
 ```bash
-aws ec2 describe-instances  # unmatched if no ec2 operation is in the spec
+aws ec2 describe-instances --region us-east-1  # unmatched if no sigv4-resign binding covers ec2
 ```
 
 Expected:
 
-- `aws` reports the EC2 endpoint's actual response. Without an installed credential the request returns a SigV4 authentication error.
-- `sandbox.proxy.passthrough` audit, `aileron.proxy.upstream.host: "ec2.us-east-1.amazonaws.com"`. The proxy does not inject a credential and does not refuse the request.
+- `aws` reports the EC2 endpoint's actual response. With no `sigv4-resign` binding for that host the proxy injects nothing, so the placeholder credentials botocore signed with reach the upstream and AWS returns a SigV4 authentication error.
+- `sandbox.proxy.passthrough` audit, `aileron.proxy.upstream.host: "ec2.us-east-1.amazonaws.com"`. The proxy does not re-sign the request and does not refuse it. A matched host gets a real signature; an unmatched host passes through unchanged.
 
 ## What "no credential leak" means in practice
 
@@ -248,19 +252,28 @@ This should return nothing. The audit subsystem sanitizes payloads before they t
 
 ## Automated coverage
 
-A `curl`-driven Go integration test lives at `internal/app/sandbox_proxy_curl_integration_test.go` and runs under the `integration_sandbox` build tag:
+Two real-client subprocess integration tests live under the `integration_sandbox` build tag and run together with one command:
 
 ```bash
-task test:integration:sandbox
+task test:integration:sandbox-proxy-clients
 ```
 
-The test stands up a fake HTTPS upstream, runs `curl` as a host subprocess pointed at the in-process proxy with a generated session CA, and asserts:
+The target is fail-fast and requires both `curl` and `aws` on PATH. It does not self-skip.
+
+A `curl`-driven Go integration test lives at `internal/app/sandbox_proxy_curl_integration_test.go`. The test stands up a fake HTTPS upstream, runs `curl` as a host subprocess pointed at the in-process proxy with a generated session CA, and asserts:
 
 1. `curl` honors the `HTTPS_PROXY` env var (proves env-driven configuration works for the canonical case).
 2. The proxy injects the credential at the boundary (the fake upstream sees `Authorization: Bearer <secret>`, never the `curl` invocation).
 3. The container's `curl` invocation does not carry the credential (proves credential isolation).
 4. A `connector.proxy.proxied` audit event is emitted with the matched connector FQN, tool, operation, upstream host (not URL), and `aileron.connector.boundary: https_proxy`.
 
-The `gh` sentinel-swap is covered deterministically by `internal/app/sandbox_forward_proxy_sentinel_swap_test.go`, which drives sentinel-bearing and foreign-token requests through the in-process proxy against a fake `api.github.com` upstream and asserts the swap, the no-swap, the sentinel-never-reaches-upstream isolation, and the no-secret audit shape. It does not require real `gh`, a real token, or real network.
+An `aws`-driven SigV4 integration test lives at `internal/app/sandbox_proxy_aws_sigv4_integration_test.go`. The test stands up a SigV4-validating fake HTTPS upstream, runs `aws s3api list-buckets` as a host subprocess against a `sigv4-resign` host binding with the secret access key in the daemon vault and placeholder static credentials in the subprocess environment, and asserts:
 
-The `aws` recipe above is manual-only for now. The same harness can be extended to cover it when there is a published Aileron connector spec for the upstream.
+1. `aws` honors `HTTPS_PROXY` and `AWS_CA_BUNDLE` (proves env-driven configuration works for the AWS CLI).
+2. The upstream receives a syntactically and cryptographically valid `AWS4-HMAC-SHA256` Authorization header whose signature the upstream recomputes with the same secret the daemon holds and confirms matches (proves a genuine valid SigV4 reached upstream, not merely a 200).
+3. The real secret access key appears in none of the `aws` subprocess environment, the `aws` argv, or any upstream request header, query, or body (proves credential isolation).
+4. A `sandbox.proxy.binding_injected` audit event is emitted with `aileron.proxy.binding.scheme: "sigv4-resign"` and the upstream host, and no secret bytes in the payload.
+
+The upstream is a local SigV4-validating stub, not live AWS. The stub recomputes the canonical request and signature from what it received using the secret the daemon vault holds, which proves the proxy emitted a valid signature without requiring network egress to AWS or a real account.
+
+The `gh` sentinel-swap is covered deterministically by `internal/app/sandbox_forward_proxy_sentinel_swap_test.go`, which drives sentinel-bearing and foreign-token requests through the in-process proxy against a fake `api.github.com` upstream and asserts the swap, the no-swap, the sentinel-never-reaches-upstream isolation, and the no-secret audit shape. It does not require real `gh`, a real token, or real network.

--- a/internal/app/sandbox_proxy_aws_sigv4_integration_test.go
+++ b/internal/app/sandbox_proxy_aws_sigv4_integration_test.go
@@ -1,0 +1,517 @@
+//go:build integration_sandbox
+
+// AWS-CLI SigV4 end-to-end coverage for the v4 sandbox HTTPS proxy.
+//
+// This test runs a real `aws` host subprocess against an in-process
+// proxy + a SigV4-validating fake upstream registered behind a
+// `sigv4-resign` host binding. It proves the load-bearing end-to-end
+// contract for issue #1505: a genuine `aws` CLI invocation through the
+// sealed proxy produces a valid AWS Signature Version 4 that the upstream
+// cryptographically accepts, while the secret access key never enters the
+// CLI's environment, argv, or any observable upstream surface.
+//
+// Unlike the in-process binding-layer proof
+// (TestSandboxForwardProxy_HostBindingSigV4ResignInjectsSignature, which
+// drives a mock transport), this test drives the real `aws` client as a
+// host subprocess so the env-driven configuration path (HTTPS_PROXY +
+// AWS_CA_BUNDLE) is exercised exactly as it is inside the sandbox
+// container. It mirrors the curl integration test's scaffold (state dir +
+// generated session CA + logical-host DialContext redirect + fake HTTPS
+// upstream) and adds a SigV4-validating upstream: the upstream recomputes
+// the canonical request and signature from what it received, using the
+// same secret access key the daemon vault holds, and asserts the recomputed
+// signature matches the one the proxy emitted. A matching signature proves
+// a genuine valid SigV4 reached upstream, not merely a 200.
+//
+// The test is gated behind the `integration_sandbox` build tag so it does
+// not run during the normal `task test:go` suite. Run with:
+//
+//	task test:integration:sandbox-proxy-clients
+//
+// `aws` availability: per repo policy (no skip-when-unsupported), the test
+// FAILS (t.Fatalf) if `aws` is not on PATH rather than skipping. The
+// dedicated task target documents the prerequisite.
+package app
+
+import (
+	"context"
+	"crypto/hmac"
+	"crypto/sha256"
+	"crypto/x509"
+	"encoding/hex"
+	"encoding/json"
+	"io"
+	"net"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"sort"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/audit"
+	"github.com/ALRubinger/aileron/internal/binding"
+	connectorspec "github.com/ALRubinger/aileron/internal/connector/spec"
+	"github.com/ALRubinger/aileron/internal/model"
+)
+
+func TestSandboxProxyAWSSigV4Integration_RealClientProducesValidSignatureAndSeals(t *testing.T) {
+	awsPath, err := exec.LookPath("aws")
+	if err != nil {
+		// Fail-fast, not skip: repo policy forbids skip-when-unsupported.
+		// The task target test:integration:sandbox-proxy-clients documents
+		// `aws` as a prerequisite.
+		t.Fatalf("aws not on PATH; install the AWS CLI to run this integration test: %v", err)
+	}
+
+	// The secret access key the daemon vault holds. The `aws` subprocess
+	// is configured with a DIFFERENT placeholder secret; the test asserts
+	// this real secret never appears in the subprocess env or argv, and
+	// that the upstream nonetheless validates a signature computed with it.
+	const secretAccessKey = "wJalrXUtnFEMIK7MDENGbPxRfiCYEXAMPLEKEY"
+	const accessKeyID = "AKIDEXAMPLE"
+	const region = "us-east-1"
+	const service = "s3"
+
+	// Placeholder static credentials handed to the `aws` subprocess. These
+	// are NOT the real secret; the daemon re-signs at egress with the vault
+	// secret above. The placeholder must be a syntactically plausible value
+	// so botocore signs the request locally before it reaches the proxy.
+	const placeholderAccessKeyID = "AKIAIOSFODNN7PLACEHLDR"
+	const placeholderSecretKey = "placeholderAileronInjectsRealSecretXXXXXX"
+
+	// SigV4-validating upstream. It recomputes the canonical request and
+	// signature from what it received using the real secret access key and
+	// asserts a match. It also records every request surface so the test
+	// can assert the secret never appears anywhere.
+	type upstreamCapture struct {
+		auth        string
+		amzDate     string
+		contentHash string
+		sigValid    bool
+		credScope   string
+		surfaces    []string // headers, query, body — every byte the upstream saw
+	}
+	var cap upstreamCapture
+	upstream := httptest.NewTLSServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		cap.auth = r.Header.Get("Authorization")
+		cap.amzDate = r.Header.Get(headerAmzDate)
+		cap.contentHash = r.Header.Get(headerAmzContentSha256)
+
+		// Record every observable surface for the no-leak assertion.
+		for k, vs := range r.Header {
+			for _, v := range vs {
+				cap.surfaces = append(cap.surfaces, k+": "+v)
+			}
+		}
+		cap.surfaces = append(cap.surfaces, "query: "+r.URL.RawQuery)
+		body, _ := io.ReadAll(r.Body)
+		cap.surfaces = append(cap.surfaces, "body: "+string(body))
+
+		// Validate the SigV4 signature: recompute from the received request
+		// using the real secret and compare to the emitted Signature=.
+		valid, scope := validateSigV4(r, body, []byte(secretAccessKey), accessKeyID, region, service)
+		cap.sigValid = valid
+		cap.credScope = scope
+
+		// Return a minimal, valid s3api list-buckets XML body so the aws
+		// client treats the call as a success.
+		w.Header().Set("Content-Type", "application/xml")
+		_, _ = w.Write([]byte(`<?xml version="1.0" encoding="UTF-8"?>` +
+			`<ListAllMyBucketsResult><Buckets></Buckets>` +
+			`<Owner><ID>aileron-test-owner</ID></Owner></ListAllMyBucketsResult>`))
+	}))
+	defer upstream.Close()
+
+	upstreamURL, err := url.Parse(upstream.URL)
+	if err != nil {
+		t.Fatalf("parse upstream URL: %v", err)
+	}
+	upstreamLoopbackAddr := upstreamURL.Host
+
+	// The logical host the aws client targets. The proxy intercepts the
+	// CONNECT to logicalHost:443 and dials the loopback upstream via the
+	// outbound transport's DialContext redirect.
+	const logicalHost = "s3.amazonaws.test"
+	const logicalHostPort = logicalHost + ":443"
+
+	stateDir := t.TempDir()
+	caPEM := writeSandboxProxyTestCA(t, stateDir, "session-123")
+
+	outboundRoots := x509.NewCertPool()
+	outboundRoots.AddCert(upstream.Certificate())
+	outboundTransport := &http.Transport{
+		TLSClientConfig: upstream.Client().Transport.(*http.Transport).TLSClientConfig.Clone(),
+		DialContext: func(ctx context.Context, network, addr string) (net.Conn, error) {
+			if addr == logicalHostPort {
+				addr = upstreamLoopbackAddr
+			}
+			d := net.Dialer{}
+			return d.DialContext(ctx, network, addr)
+		},
+	}
+	outboundTransport.TLSClientConfig.RootCAs = outboundRoots
+	outboundTransport.TLSClientConfig.InsecureSkipVerify = true // upstream cert is for 127.0.0.1; reached under the logical hostname.
+
+	// Build the apiServer with the secret in the vault under user/aws and a
+	// sigv4-resign host binding carrying only the non-secret access-key-id,
+	// region, and service. This mirrors the in-process happy-path test's
+	// wiring exactly.
+	auditStore := audit.NewMemStore()
+	srv := &apiServer{
+		localDaemonToken:     "daemon-token",
+		sandboxProxyStateDir: stateDir,
+		auditStore:           auditStore,
+		auditRecorder:        audit.NewRecorder(auditStore, nil, func() string { return "audit-aws-sigv4-integration" }),
+		specLoader:           func() ([]connectorspec.Spec, error) { return nil, nil },
+		vault:                mustVaultWith(t, "user/aws", "user", []byte(secretAccessKey)),
+		hostBindings: mustHostBindingTableOpts(t, logicalHost, "user/aws", "sigv4-resign",
+			binding.WithSigV4Resign(accessKeyID, region, service)),
+		sandboxProxyClient: &http.Client{Transport: outboundTransport},
+	}
+
+	proxy := httptest.NewServer(srv.sandboxForwardProxyMiddleware(http.NotFoundHandler()))
+	defer proxy.Close()
+
+	// Write the session CA to a tempfile for AWS_CA_BUNDLE.
+	caBundleDir := t.TempDir()
+	caBundle := filepath.Join(caBundleDir, "aileron-session-ca.pem")
+	if err := os.WriteFile(caBundle, caPEM, 0o600); err != nil {
+		t.Fatalf("write aws ca bundle: %v", err)
+	}
+
+	proxyURL, err := url.Parse(proxy.URL)
+	if err != nil {
+		t.Fatalf("parse proxy URL: %v", err)
+	}
+	// The proxy URL must carry the session/daemon-token basic auth the
+	// CONNECT handshake requires. botocore reads HTTPS_PROXY including
+	// userinfo and sends it as Proxy-Authorization.
+	proxyWithAuth := *proxyURL
+	proxyWithAuth.User = url.UserPassword("session-123", "daemon-token")
+
+	// Resolve the logical host to the proxy's loopback address via a hosts
+	// override so botocore's CONNECT target reaches the in-process proxy
+	// without a real DNS entry. botocore honors HTTPS_PROXY for the CONNECT
+	// regardless, but the endpoint URL host must resolve for the client to
+	// proceed; we point it at the proxy host's loopback IP.
+	endpoint := "https://" + logicalHostPort
+
+	// Build aws argv. s3api list-buckets is a deterministic GET with no
+	// body. --endpoint-url targets the logical host; --region pins the
+	// signing region. No real secret on argv.
+	args := []string{
+		"s3api", "list-buckets",
+		"--endpoint-url", endpoint,
+		"--region", region,
+		"--output", "json",
+	}
+	for _, arg := range args {
+		if strings.Contains(arg, secretAccessKey) {
+			t.Fatalf("aws argv leaked the real secret access key: %v", args)
+		}
+	}
+
+	// Build the subprocess env: ONLY HTTPS_PROXY, AWS_CA_BUNDLE, region,
+	// and the placeholder static creds. Never the real secret. A throwaway
+	// HOME/config dir keeps the run hermetic (no ambient ~/.aws profile).
+	awsHome := t.TempDir()
+	env := []string{
+		"HTTPS_PROXY=" + proxyWithAuth.String(),
+		"https_proxy=" + proxyWithAuth.String(),
+		"AWS_CA_BUNDLE=" + caBundle,
+		"AWS_ACCESS_KEY_ID=" + placeholderAccessKeyID,
+		"AWS_SECRET_ACCESS_KEY=" + placeholderSecretKey,
+		"AWS_DEFAULT_REGION=" + region,
+		"AWS_REGION=" + region,
+		"HOME=" + awsHome,
+		"AWS_CONFIG_FILE=" + filepath.Join(awsHome, "config"),
+		"AWS_SHARED_CREDENTIALS_FILE=" + filepath.Join(awsHome, "credentials"),
+		"AWS_EC2_METADATA_DISABLED=true",
+		"AWS_PAGER=",
+		// PATH so aws can find its bundled python interpreter where needed.
+		"PATH=" + os.Getenv("PATH"),
+	}
+	for _, e := range env {
+		if strings.Contains(e, secretAccessKey) {
+			t.Fatalf("aws env leaked the real secret access key: %v", e)
+		}
+	}
+
+	ctx, cancel := context.WithCancel(context.Background())
+	defer cancel()
+	cmd := exec.CommandContext(ctx, awsPath, args...)
+	cmd.Env = env
+	out, err := cmd.CombinedOutput()
+	if err != nil {
+		t.Fatalf("aws s3api list-buckets: %v\noutput:\n%s", err, string(out))
+	}
+
+	// The aws client received and parsed the upstream's XML body into JSON.
+	if !strings.Contains(string(out), "aileron-test-owner") {
+		t.Fatalf("aws output did not contain expected upstream owner id; output:\n%s", string(out))
+	}
+
+	// Signature assertion (the seal): the upstream received a syntactically
+	// AND cryptographically valid AWS4-HMAC-SHA256 signature, recomputed
+	// with the same secret the daemon holds. This proves a genuine valid
+	// SigV4 reached upstream, not merely a 200.
+	if !strings.HasPrefix(cap.auth, "AWS4-HMAC-SHA256 ") {
+		t.Fatalf("upstream Authorization = %q, want AWS4-HMAC-SHA256 prefix", cap.auth)
+	}
+	if !cap.sigValid {
+		t.Fatalf("upstream SigV4 signature did not validate against the daemon's secret; Authorization=%q", cap.auth)
+	}
+	wantScope := region + "/" + service + "/aws4_request"
+	if !strings.HasSuffix(cap.credScope, wantScope) {
+		t.Errorf("credential scope = %q, want suffix %q", cap.credScope, wantScope)
+	}
+	if !strings.Contains(cap.auth, "Credential="+accessKeyID+"/") {
+		t.Errorf("Authorization missing Credential=%s/...: %q", accessKeyID, cap.auth)
+	}
+	if cap.amzDate == "" {
+		t.Error("upstream X-Amz-Date is empty")
+	}
+	if cap.contentHash == "" {
+		t.Error("upstream X-Amz-Content-Sha256 is empty")
+	}
+
+	// No-leak assertion: the real secret access key appears in NONE of the
+	// aws subprocess env, the aws argv, or any upstream request surface
+	// (header, query, body). The argv/env were checked above before launch;
+	// re-assert the upstream surfaces here.
+	for _, s := range cap.surfaces {
+		if strings.Contains(s, secretAccessKey) {
+			t.Fatalf("upstream request surface leaked the real secret access key: %q", s)
+		}
+	}
+	// The placeholder secret must also never reach the upstream: the proxy
+	// strips the client's signature and re-signs, so no placeholder-derived
+	// signature survives. (The placeholder is only the secret material for
+	// the client-side signature the proxy discards.)
+	if strings.Contains(cap.auth, placeholderAccessKeyID) {
+		t.Errorf("upstream Authorization carried the placeholder access key id (proxy did not re-sign): %q", cap.auth)
+	}
+
+	// Audit assertion: a single sandbox.proxy.binding_injected event with
+	// scheme sigv4-resign and the logical host, and no secret bytes in the
+	// payload JSON.
+	events, err := auditStore.ListEvents(context.Background(), audit.EventFilter{})
+	if err != nil {
+		t.Fatalf("ListEvents: %v", err)
+	}
+	if len(events) != 1 {
+		t.Fatalf("events = %d, want 1; events=%+v", len(events), events)
+	}
+	evt := events[0]
+	if evt.EventType != model.EventTypeSandboxProxyBindingInjected {
+		t.Fatalf("event type = %q, want %q", evt.EventType, model.EventTypeSandboxProxyBindingInjected)
+	}
+	if got := evt.Payload["aileron.proxy.binding.scheme"]; got != "sigv4-resign" {
+		t.Errorf("binding.scheme = %v, want sigv4-resign", got)
+	}
+	if got := evt.Payload["aileron.proxy.binding.host"]; got != logicalHost {
+		t.Errorf("binding.host = %v, want %s", got, logicalHost)
+	}
+	sandboxProxyBindingInjectedShape.validate(t, evt.Payload)
+	payloadJSON, _ := json.Marshal(evt.Payload)
+	for _, forbidden := range []string{secretAccessKey, placeholderSecretKey, "user/aws"} {
+		if strings.Contains(string(payloadJSON), forbidden) {
+			t.Errorf("audit payload leaked %q: %s", forbidden, payloadJSON)
+		}
+	}
+}
+
+// SigV4 header names, duplicated here so the test is independent of the
+// (unexported) signer's constants. The upstream validator below is a
+// from-scratch reimplementation of the SigV4 verification path; it shares
+// no code with internal/credential/inject so a bug in the signer cannot
+// mask itself in the validator.
+const (
+	headerAmzDate          = "X-Amz-Date"
+	headerAmzContentSha256 = "X-Amz-Content-Sha256"
+)
+
+// validateSigV4 recomputes the AWS4-HMAC-SHA256 signature from the request
+// the upstream received and compares it to the Signature= field of the
+// Authorization header. It returns whether the recomputed signature matches
+// and the credential scope string parsed from the header. The recomputation
+// uses only the headers listed in SignedHeaders, the request method, the
+// canonical URI/query, and the X-Amz-Content-Sha256 payload hash, per the
+// SigV4 spec. A match proves the proxy emitted a genuine valid signature
+// over exactly what reached the upstream.
+func validateSigV4(r *http.Request, body []byte, secretAccessKey []byte, wantAccessKeyID, region, service string) (bool, string) {
+	auth := r.Header.Get("Authorization")
+	if !strings.HasPrefix(auth, "AWS4-HMAC-SHA256 ") {
+		return false, ""
+	}
+	rest := strings.TrimPrefix(auth, "AWS4-HMAC-SHA256 ")
+
+	var credential, signedHeaders, signature string
+	for _, part := range strings.Split(rest, ",") {
+		part = strings.TrimSpace(part)
+		switch {
+		case strings.HasPrefix(part, "Credential="):
+			credential = strings.TrimPrefix(part, "Credential=")
+		case strings.HasPrefix(part, "SignedHeaders="):
+			signedHeaders = strings.TrimPrefix(part, "SignedHeaders=")
+		case strings.HasPrefix(part, "Signature="):
+			signature = strings.TrimPrefix(part, "Signature=")
+		}
+	}
+	if credential == "" || signedHeaders == "" || signature == "" {
+		return false, ""
+	}
+
+	// Credential = <accessKeyID>/<date>/<region>/<service>/aws4_request
+	credParts := strings.SplitN(credential, "/", 2)
+	if len(credParts) != 2 || credParts[0] != wantAccessKeyID {
+		return false, credential
+	}
+	scope := credParts[1] // <date>/<region>/<service>/aws4_request
+	scopeParts := strings.Split(scope, "/")
+	if len(scopeParts) != 4 {
+		return false, scope
+	}
+	scopeDate := scopeParts[0]
+	if scopeParts[1] != region || scopeParts[2] != service || scopeParts[3] != "aws4_request" {
+		return false, scope
+	}
+
+	xAmzDate := r.Header.Get(headerAmzDate)
+	if xAmzDate == "" {
+		return false, scope
+	}
+
+	// Payload hash: prefer the X-Amz-Content-Sha256 header (what the signer
+	// used), falling back to a recompute over the received body.
+	payloadHash := r.Header.Get(headerAmzContentSha256)
+	if payloadHash == "" {
+		sum := sha256.Sum256(body)
+		payloadHash = hex.EncodeToString(sum[:])
+	}
+
+	// Canonical headers from the SignedHeaders list, reading the request's
+	// actual header values. host is sourced from r.Host.
+	signedNames := strings.Split(signedHeaders, ";")
+	sort.Strings(signedNames)
+	var cb strings.Builder
+	for _, name := range signedNames {
+		cb.WriteString(name)
+		cb.WriteByte(':')
+		if name == "host" {
+			host := r.Host
+			if host == "" {
+				host = r.URL.Host
+			}
+			cb.WriteString(strings.TrimSpace(host))
+		} else {
+			cb.WriteString(strings.TrimSpace(r.Header.Get(name)))
+		}
+		cb.WriteByte('\n')
+	}
+
+	canonicalURI := r.URL.EscapedPath()
+	if canonicalURI == "" {
+		canonicalURI = "/"
+	}
+	canonicalQuery := canonicalizeQuery(r.URL.RawQuery)
+
+	canonicalRequest := strings.Join([]string{
+		r.Method,
+		canonicalURI,
+		canonicalQuery,
+		cb.String(),
+		signedHeaders,
+		payloadHash,
+	}, "\n")
+
+	stringToSign := strings.Join([]string{
+		"AWS4-HMAC-SHA256",
+		xAmzDate,
+		scope,
+		hexSHA256Test([]byte(canonicalRequest)),
+	}, "\n")
+
+	signingKey := deriveSigningKeyTest(secretAccessKey, scopeDate, region, service)
+	want := hex.EncodeToString(hmacSHA256Test(signingKey, []byte(stringToSign)))
+	return hmac.Equal([]byte(want), []byte(signature)), scope
+}
+
+// canonicalizeQuery returns the SigV4 canonical query string: parameters
+// sorted by name then value, each name/value RFC 3986 percent-encoded.
+func canonicalizeQuery(raw string) string {
+	if raw == "" {
+		return ""
+	}
+	type kv struct{ k, v string }
+	var pairs []kv
+	for _, part := range strings.Split(raw, "&") {
+		if part == "" {
+			continue
+		}
+		name, value, _ := strings.Cut(part, "=")
+		pairs = append(pairs, kv{k: uriEncodeTest(name), v: uriEncodeTest(value)})
+	}
+	sort.Slice(pairs, func(i, j int) bool {
+		if pairs[i].k != pairs[j].k {
+			return pairs[i].k < pairs[j].k
+		}
+		return pairs[i].v < pairs[j].v
+	})
+	var b strings.Builder
+	for i, p := range pairs {
+		if i > 0 {
+			b.WriteByte('&')
+		}
+		b.WriteString(p.k)
+		b.WriteByte('=')
+		b.WriteString(p.v)
+	}
+	return b.String()
+}
+
+func uriEncodeTest(s string) string {
+	// The query values arrive already percent-encoded from the URL; decode
+	// then re-encode for a stable canonical form.
+	dec := s
+	if u, err := url.QueryUnescape(s); err == nil {
+		dec = u
+	}
+	var b strings.Builder
+	for i := 0; i < len(dec); i++ {
+		c := dec[i]
+		switch {
+		case c >= 'A' && c <= 'Z', c >= 'a' && c <= 'z', c >= '0' && c <= '9',
+			c == '-', c == '_', c == '.', c == '~':
+			b.WriteByte(c)
+		default:
+			const hexDigits = "0123456789ABCDEF"
+			b.WriteByte('%')
+			b.WriteByte(hexDigits[c>>4])
+			b.WriteByte(hexDigits[c&0x0f])
+		}
+	}
+	return b.String()
+}
+
+func deriveSigningKeyTest(secret []byte, date, region, service string) []byte {
+	kDate := hmacSHA256Test(append([]byte("AWS4"), secret...), []byte(date))
+	kRegion := hmacSHA256Test(kDate, []byte(region))
+	kService := hmacSHA256Test(kRegion, []byte(service))
+	return hmacSHA256Test(kService, []byte("aws4_request"))
+}
+
+func hmacSHA256Test(key, data []byte) []byte {
+	h := hmac.New(sha256.New, key)
+	h.Write(data)
+	return h.Sum(nil)
+}
+
+func hexSHA256Test(data []byte) string {
+	sum := sha256.Sum256(data)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/credential/inject/inject_test.go
+++ b/internal/credential/inject/inject_test.go
@@ -312,6 +312,51 @@ func TestInjectSigV4ResignVectors(t *testing.T) {
 	}
 }
 
+// TestInjectSigV4ResignDropsClientAuthorization is the regression guard
+// for the AWS-CLI end-to-end path (#1505): a SigV4-aware client (botocore)
+// pre-signs the request and carries its own AWS4-HMAC-SHA256 Authorization
+// header. If the signer folded that stale header into the canonical request
+// and the SignedHeaders list, it would then overwrite it with the new
+// Authorization, producing a signature over a header value the upstream
+// never receives. AWS rejects that with SignatureDoesNotMatch.
+//
+// The contract: the signer must drop the inbound Authorization before
+// deriving the signed-header set, so the emitted signature is identical to
+// the one produced for the same request with no inbound Authorization. We
+// assert byte-for-byte equality against the get-vanilla published vector,
+// which proves `authorization` is absent from SignedHeaders and the
+// canonical request.
+func TestInjectSigV4ResignDropsClientAuthorization(t *testing.T) {
+	pinClock(t)
+	req, err := http.NewRequest(http.MethodGet, "https://example.amazonaws.com/", nil)
+	if err != nil {
+		t.Fatalf("http.NewRequest: %v", err)
+	}
+	// A SigV4-aware client's stale, self-computed Authorization header.
+	req.Header.Set("Authorization",
+		"AWS4-HMAC-SHA256 Credential=CLIENTKEY/20150830/us-east-1/service/aws4_request, "+
+			"SignedHeaders=host;x-amz-date, Signature=deadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeefdeadbeef")
+
+	if err := Inject(req, SchemeSigV4Resign, []byte(vectorSecretKey), Params{
+		AccessKeyID: vectorAccessKeyID,
+		Region:      vectorRegion,
+		Service:     vectorService,
+	}); err != nil {
+		t.Fatalf("Inject sigv4: %v", err)
+	}
+
+	// Identical to the get-vanilla vector: the stale Authorization did not
+	// enter the canonical request or the SignedHeaders list.
+	wantAuth := authHeader("host;x-amz-content-sha256;x-amz-date",
+		"726c5c4879a6b4ccbbd3b24edbd6b8826d34f87450fbbf4e85546fc7ba9c1642")
+	if got := req.Header.Get("Authorization"); got != wantAuth {
+		t.Errorf("Authorization mismatch (stale client header was not dropped)\n got = %q\nwant = %q", got, wantAuth)
+	}
+	if strings.Contains(req.Header.Get("Authorization"), "CLIENTKEY") {
+		t.Error("emitted Authorization still references the client's stale credential")
+	}
+}
+
 func TestInjectSigV4MissingAccessKeyID(t *testing.T) {
 	req := newReq(t, "https://example.amazonaws.com/")
 	err := Inject(req, SchemeSigV4Resign, []byte(vectorSecretKey), Params{

--- a/internal/credential/inject/sigv4.go
+++ b/internal/credential/inject/sigv4.go
@@ -60,6 +60,19 @@ func signSigV4(req *http.Request, secretAccessKey []byte, accessKeyID, region, s
 		return fmt.Errorf("inject: sigv4-resign read request body: %w", err)
 	}
 
+	// Drop any inbound Authorization header before deriving the signed-header
+	// set. A SigV4-aware client (e.g. the AWS CLI / botocore) pre-signs the
+	// request and carries its own AWS4-HMAC-SHA256 Authorization. If that
+	// stale header were left in place it would be folded into the canonical
+	// request and the SignedHeaders list, then overwritten by the new
+	// Authorization we set below. The result would be a signature computed
+	// over a header value the upstream never receives, which AWS rejects with
+	// SignatureDoesNotMatch. Removing it keeps the signature consistent with
+	// exactly what the upstream sees. (X-Amz-Date and X-Amz-Content-Sha256
+	// are overwritten by the Set calls below, so their signed value already
+	// matches the final value.)
+	req.Header.Del(hdrAuthorization)
+
 	// Stage the headers that participate in the signature. We set them on
 	// the request first so the canonical/signed header derivation reads
 	// the real header set (which keeps a future X-Amz-Security-Token


### PR DESCRIPTION
## Summary

Proves `aws` CLI SigV4 sealing end-to-end through the v4 sandbox forward proxy and reconciles the CLI verification matrix doc to the real `sigv4-resign` path. Branches off and targets `integration/sigv4-sealing`.

This issue adds the **real-`aws`-CLI subprocess** proof that the in-process binding-layer tests (`TestSandboxForwardProxy_HostBindingSigV4Resign*`) could not give: a genuine `aws` invocation, configured only with `HTTPS_PROXY` + `AWS_CA_BUNDLE` + placeholder static creds, produces a request the daemon re-signs with the vault-held secret access key, and the upstream cryptographically accepts that signature.

### Scope note — one product fix (not originally planned)

The plan scoped this as test + docs only. Driving a real `aws` client through the path surfaced a genuine correctness bug in `internal/credential/inject/sigv4.go`:

- A SigV4-aware client (the AWS CLI / botocore) pre-signs its request and carries its own `Authorization: AWS4-HMAC-SHA256 …` header.
- The signer folded that stale header into the canonical request **and** the `SignedHeaders` list, then overwrote it with the new `Authorization`.
- The emitted signature therefore covered a header value the upstream never receives. Real AWS rejects this with `SignatureDoesNotMatch`.

Without the fix the entire deliverable is impossible: no valid signature can reach upstream whenever the client pre-signs (which the AWS CLI always does). Fix is one line — `req.Header.Del(hdrAuthorization)` before deriving the signed-header set — plus a signer-level regression test that fails before and passes after. `X-Amz-Date` / `X-Amz-Content-Sha256` are already `Set`-overwritten, so they self-correct; only `Authorization` needed dropping. Existing published-vector tests and the in-process binding tests still pass unchanged.

### Changes

- `internal/app/sandbox_proxy_aws_sigv4_integration_test.go` (new, `//go:build integration_sandbox`): real `aws s3api list-buckets` subprocess against an in-process proxy + SigV4-validating fake upstream. The upstream recomputes the canonical request and signature from what it received using the daemon's secret and asserts a match (the seal is the validated signature, not a bare 200). Fail-fast `t.Fatalf` if `aws` is absent (no skip). Independent from-scratch validator so a signer bug cannot mask itself.
- `internal/credential/inject/sigv4.go`: drop inbound `Authorization` before signing (the fix above).
- `internal/credential/inject/inject_test.go`: `TestInjectSigV4ResignDropsClientAuthorization` regression test — a request with a stale client `Authorization` now yields the identical signature as the `get-vanilla` published vector.
- `Taskfile.yml`: new fail-fast `test:integration:sandbox-proxy-clients` target that actually runs the curl + aws subprocess tests (the prior `test:integration:sandbox` ran only `TestSandboxMCP`, so neither subprocess test ran under any target).
- `docs/src/content/docs/development/sandbox-proxy-cli-matrix.md`: rewrote the `## aws` recipe to the real `sigv4-resign` sealing flow (success = `binding_injected` audit with a validated signature; unmatched = passthrough), corrected the inaccurate "aws does not read HTTPS_PROXY" claim, and updated `## Automated coverage` to document the aws/SigV4 automated test and the new run command, removing the "manual-only" sentence.

## Test plan

- `task test:integration:sandbox-proxy-clients` — runs both curl and aws subprocess tests green (verified locally with AWS CLI 2.35.11 installed).
- `go test -tags=integration_sandbox -race -run TestSandboxProxyAWSSigV4Integration ./internal/app/...` — green.
- `go test ./internal/credential/inject/...` — green, 94% coverage; regression test confirmed failing before the product fix and passing after.
- `go test -run 'TestSandboxForwardProxy_HostBindingSigV4' ./internal/app/...` — in-process binding tests still green (fix is signature-only, no contract change).
- `go test ./internal/...`, `cmd/aileron`, `cmd/aileron-mcp` — green.
- `go vet -tags=integration_sandbox ./internal/app/...` — clean.

CodeRabbit CLI was rate-limited at PR-open time (31 min cooldown); it will run on the PR. Manual self-review found no correctness/security/scope issues beyond the documented product fix.

Closes #1505

🤖 Generated with [Claude Code](https://claude.com/claude-code)
