### PR TITLE
feat(sandbox): verified Node distribution fetcher reusing the cstore pipeline

### DIFF
--- a/go.work.sum
+++ b/go.work.sum
@@ -139,6 +139,7 @@ github.com/leodido/go-urn v1.4.0 h1:WT9HwE9SGECu3lg4d/dIA+jxlljEa1/ffXKmRjqdmIQ=
 github.com/leodido/go-urn v1.4.0/go.mod h1:bvxc+MVxLKB4z00jd1z+Dvzr47oO32F/QSNjSBOlFxI=
 github.com/mailgun/raymond/v2 v2.0.48 h1:5dmlB680ZkFG2RN/0lvTAghrSxIESeu9/2aeDqACtjw=
 github.com/mailgun/raymond/v2 v2.0.48/go.mod h1:lsgvL50kgt1ylcFJYZiULi5fjPBkkhNfj4KA0W54Z18=
+github.com/mailru/easyjson v0.7.7/go.mod h1:xzfreul335JAWq5oZzymOObrkdz5UnU4kGfJJLY9Nlc=
 github.com/mattn/go-colorable v0.1.13 h1:fFA4WZxdEF4tXPZVKMLwD8oUnCTTo08duU7wxecdEvA=
 github.com/mattn/go-colorable v0.1.13/go.mod h1:7S9/ev0klgBDR4GtXTXX8a3vIGJpMovkB8vQcUbaXHg=
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=

--- a/internal/cstore/dirstore_test.go
+++ b/internal/cstore/dirstore_test.go
@@ -1,0 +1,206 @@
+package cstore_test
+
+import (
+	"os"
+	"path/filepath"
+	"sync"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+)
+
+const (
+	testHashA = "aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa"
+	testHashB = "bbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbbb"
+)
+
+func TestCommitDir_HappyPathWritesTree(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "node")
+
+	entryDir, already, err := cstore.CommitDir(root, testHashA, func(dir string) error {
+		if err := os.MkdirAll(filepath.Join(dir, "bin"), 0o755); err != nil {
+			return err
+		}
+		return os.WriteFile(filepath.Join(dir, "bin", "node"), []byte("#!node"), 0o755)
+	})
+	if err != nil {
+		t.Fatalf("CommitDir: %v", err)
+	}
+	if already {
+		t.Fatalf("first commit reported alreadyPresent=true")
+	}
+
+	want := filepath.Join(root, "sha256", testHashA)
+	if entryDir != want {
+		t.Fatalf("entryDir = %q, want %q", entryDir, want)
+	}
+	got, err := os.ReadFile(filepath.Join(entryDir, "bin", "node"))
+	if err != nil {
+		t.Fatalf("read committed file: %v", err)
+	}
+	if string(got) != "#!node" {
+		t.Fatalf("committed content = %q, want %q", got, "#!node")
+	}
+}
+
+func TestCommitDir_DuplicateIsBenignNoOp(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "node")
+
+	if _, _, err := cstore.CommitDir(root, testHashA, func(dir string) error {
+		return os.WriteFile(filepath.Join(dir, "marker"), []byte("first"), 0o644)
+	}); err != nil {
+		t.Fatalf("first CommitDir: %v", err)
+	}
+
+	// Second commit of the same hash: the write callback's output must be
+	// discarded and the original entry left untouched.
+	entryDir, already, err := cstore.CommitDir(root, testHashA, func(dir string) error {
+		return os.WriteFile(filepath.Join(dir, "marker"), []byte("second"), 0o644)
+	})
+	if err != nil {
+		t.Fatalf("second CommitDir: %v", err)
+	}
+	if !already {
+		t.Fatalf("duplicate commit reported alreadyPresent=false")
+	}
+	got, err := os.ReadFile(filepath.Join(entryDir, "marker"))
+	if err != nil {
+		t.Fatalf("read entry: %v", err)
+	}
+	if string(got) != "first" {
+		t.Fatalf("entry content = %q, want the original %q", got, "first")
+	}
+}
+
+func TestCommitDir_ConcurrentSameHashConverges(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "node")
+
+	const n = 8
+	var wg sync.WaitGroup
+	results := make([]bool, n)
+	errs := make([]error, n)
+	wg.Add(n)
+	for i := 0; i < n; i++ {
+		go func(i int) {
+			defer wg.Done()
+			_, already, err := cstore.CommitDir(root, testHashA, func(dir string) error {
+				return os.WriteFile(filepath.Join(dir, "data"), []byte("same"), 0o644)
+			})
+			results[i] = already
+			errs[i] = err
+		}(i)
+	}
+	wg.Wait()
+
+	createdCount := 0
+	for i := 0; i < n; i++ {
+		if errs[i] != nil {
+			t.Fatalf("goroutine %d: %v", i, errs[i])
+		}
+		if !results[i] {
+			createdCount++
+		}
+	}
+	// Exactly one committer created the entry; the rest saw it already
+	// present. Crucially none errored.
+	if createdCount != 1 {
+		t.Fatalf("createdCount = %d, want exactly 1 (CAS race did not converge)", createdCount)
+	}
+}
+
+func TestCommitDir_DistinctHashesAreSeparateEntries(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "node")
+
+	for _, h := range []string{testHashA, testHashB} {
+		if _, _, err := cstore.CommitDir(root, h, func(dir string) error {
+			return os.WriteFile(filepath.Join(dir, "id"), []byte(h), 0o644)
+		}); err != nil {
+			t.Fatalf("CommitDir(%s): %v", h, err)
+		}
+	}
+	for _, h := range []string{testHashA, testHashB} {
+		got, err := os.ReadFile(filepath.Join(root, "sha256", h, "id"))
+		if err != nil {
+			t.Fatalf("read entry %s: %v", h, err)
+		}
+		if string(got) != h {
+			t.Fatalf("entry %s content = %q", h, got)
+		}
+	}
+}
+
+func TestCommitDir_RejectsInvalidHash(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "node")
+	for _, bad := range []string{"", "../escape", "ABCDEF", "abc/def", "sha256:abc"} {
+		called := false
+		_, _, err := cstore.CommitDir(root, bad, func(dir string) error {
+			called = true
+			return nil
+		})
+		if err == nil {
+			t.Fatalf("CommitDir(%q) = nil error, want rejection", bad)
+		}
+		if called {
+			t.Fatalf("CommitDir(%q) invoked the write callback before validating the hash", bad)
+		}
+	}
+}
+
+func TestCommitDir_CallbackErrorCommitsNothing(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "node")
+	wantErr := os.ErrPermission
+	_, _, err := cstore.CommitDir(root, testHashA, func(dir string) error {
+		return wantErr
+	})
+	if err == nil {
+		t.Fatalf("CommitDir with failing callback returned nil error")
+	}
+	present, hErr := cstore.HasDirHash(root, testHashA)
+	if hErr != nil {
+		t.Fatalf("HasDirHash: %v", hErr)
+	}
+	if present {
+		t.Fatalf("entry was committed despite callback failure")
+	}
+}
+
+func TestHasDirHash(t *testing.T) {
+	root := filepath.Join(t.TempDir(), "node")
+
+	present, err := cstore.HasDirHash(root, testHashA)
+	if err != nil {
+		t.Fatalf("HasDirHash before commit: %v", err)
+	}
+	if present {
+		t.Fatalf("HasDirHash = true before any commit")
+	}
+
+	if _, _, err := cstore.CommitDir(root, testHashA, func(dir string) error {
+		return os.WriteFile(filepath.Join(dir, "x"), []byte("y"), 0o644)
+	}); err != nil {
+		t.Fatalf("CommitDir: %v", err)
+	}
+
+	present, err = cstore.HasDirHash(root, testHashA)
+	if err != nil {
+		t.Fatalf("HasDirHash after commit: %v", err)
+	}
+	if !present {
+		t.Fatalf("HasDirHash = false after commit")
+	}
+}
+
+func TestDirEntryDir(t *testing.T) {
+	root := "/tmp/store/node"
+	got, err := cstore.DirEntryDir(root, testHashA)
+	if err != nil {
+		t.Fatalf("DirEntryDir: %v", err)
+	}
+	want := filepath.Join(root, "sha256", testHashA)
+	if got != want {
+		t.Fatalf("DirEntryDir = %q, want %q", got, want)
+	}
+	if _, err := cstore.DirEntryDir(root, "../bad"); err == nil {
+		t.Fatalf("DirEntryDir accepted an invalid hash")
+	}
+}

--- a/internal/cstore/dirstore_test.go
+++ b/internal/cstore/dirstore_test.go
@@ -1,6 +1,7 @@
 package cstore_test
 
 import (
+	"errors"
 	"os"
 	"path/filepath"
 	"sync"
@@ -154,6 +155,11 @@ func TestCommitDir_CallbackErrorCommitsNothing(t *testing.T) {
 	})
 	if err == nil {
 		t.Fatalf("CommitDir with failing callback returned nil error")
+	}
+	// The callback's error is surfaced verbatim so the caller can classify
+	// it in its own vocabulary.
+	if !errors.Is(err, wantErr) {
+		t.Fatalf("CommitDir did not return the callback error verbatim: %v", err)
 	}
 	present, hErr := cstore.HasDirHash(root, testHashA)
 	if hErr != nil {

--- a/internal/cstore/store.go
+++ b/internal/cstore/store.go
@@ -298,49 +298,158 @@ func (s *Store) persistIndex() error {
 // commit writes a freshly-extracted tarball into the store at sha256/<hex>/
 // using atomic-rename semantics:
 //
-//   1. Make a unique temp directory under tmp/.
-//   2. Write the three files into it.
-//   3. Rename the temp directory to sha256/<hex>/.
+//  1. Make a unique temp directory under tmp/.
+//  2. Write the three files into it.
+//  3. Rename the temp directory to sha256/<hex>/.
 //
 // Concurrent installs of the same hash converge naturally: rename of a
 // directory onto a non-empty existing directory fails on every Unix, so
 // the loser observes the entry in place and proceeds. The temp directory
 // is cleaned up afterward whether or not the rename succeeded.
 func (s *Store) commit(t *Tarball, ref Ref, hashHex string) error {
-	if err := os.MkdirAll(s.tmpRoot(), 0o755); err != nil {
-		return wrapStoreErr(err)
+	_, _, err := CommitDir(s.connectorsRoot(), hashHex, func(dir string) error {
+		return t.writeTo(dir)
+	})
+	if err != nil {
+		return err
 	}
-	if err := os.MkdirAll(s.sha256Root(), 0o755); err != nil {
-		return wrapStoreErr(err)
+	return s.recordIndex(ref, "sha256:"+hashHex)
+}
+
+// CommitDir atomically publishes a content-addressed directory tree under
+// root at `sha256/<hashHex>/`, reusing the same temp-dir → write →
+// atomic-rename → race-reconcile discipline as the connector store's
+// commit. It is content-agnostic: the caller's write callback populates a
+// fresh temp directory with whatever tree it wants (a connector triple, an
+// unpacked Node distribution, etc.), and CommitDir renames that directory
+// into place.
+//
+// Layout produced under root:
+//
+//	<root>/
+//	  sha256/
+//	    <hashHex>/        (the committed tree)
+//	  tmp/
+//	    <random>/         (transient; renamed atomically into sha256/<hashHex>/)
+//
+// The caller chooses root so independent caches never collide — the
+// connector store passes `<store>/connectors` and the Node distribution
+// cache passes `<store>/node`, so their sha256/ trees stay disjoint.
+//
+// hashHex is the hex SHA-256 of the content being addressed (no `sha256:`
+// prefix). It MUST be a non-empty lowercase hex string with no path
+// separators; CommitDir rejects anything else so a caller can never write
+// outside `<root>/sha256/`.
+//
+// Returns:
+//
+//   - entryDir: the absolute path `<root>/sha256/<hashHex>/`, valid whether
+//     this call created it or found it already present.
+//   - alreadyPresent: true when an entry for hashHex already existed and the
+//     write callback's output was discarded (benign duplicate/concurrent
+//     commit). The store converges because two commits of the same hash
+//     produce identical content by definition.
+//   - err: a structured store-unwritable error on any filesystem failure,
+//     or the callback's own error wrapped the same way.
+//
+// Concurrent commits of the same hash converge naturally: rename of a
+// directory onto an existing non-empty directory fails on every Unix, so
+// the loser observes the entry in place and reports alreadyPresent=true.
+// The temp directory is cleaned up afterward whether or not the rename
+// succeeded.
+func CommitDir(root, hashHex string, write func(dir string) error) (entryDir string, alreadyPresent bool, err error) {
+	if err := validateHashHex(hashHex); err != nil {
+		return "", false, err
+	}
+	sha256Root := filepath.Join(root, "sha256")
+	tmpRoot := filepath.Join(root, "tmp")
+	dst := filepath.Join(sha256Root, hashHex)
+
+	// Fast path: entry already present, skip the write entirely.
+	if _, statErr := os.Stat(dst); statErr == nil {
+		return dst, true, nil
 	}
 
-	tmp, err := uniqueTempDir(s.tmpRoot())
+	if err := os.MkdirAll(tmpRoot, 0o755); err != nil {
+		return "", false, wrapStoreErr(err)
+	}
+	if err := os.MkdirAll(sha256Root, 0o755); err != nil {
+		return "", false, wrapStoreErr(err)
+	}
+
+	tmp, err := uniqueTempDir(tmpRoot)
 	if err != nil {
-		return wrapStoreErr(err)
+		return "", false, wrapStoreErr(err)
 	}
 	defer os.RemoveAll(tmp)
 
-	if err := t.writeTo(tmp); err != nil {
-		return wrapStoreErr(err)
+	if err := write(tmp); err != nil {
+		// Preserve a structured error from the callback; wrap a plain one.
+		var sErr *Error
+		if errors.As(err, &sErr) {
+			return "", false, err
+		}
+		return "", false, wrapStoreErr(err)
 	}
 
-	dst := filepath.Join(s.sha256Root(), hashHex)
-	// If a parallel installer already won the race, dst exists. That's
-	// fine — both produced identical bytes (same hash). We can drop our
-	// temp directory and update the index.
+	// If a parallel committer already won the race, dst exists. Both
+	// produced identical bytes (same hash), so we drop our temp directory.
 	if _, err := os.Stat(dst); err == nil {
-		return s.recordIndex(ref, "sha256:"+hashHex)
+		return dst, true, nil
 	}
 	if err := os.Rename(tmp, dst); err != nil {
-		// Concurrent install may have raced and won between the Stat and
+		// Concurrent commit may have raced and won between the Stat and
 		// the Rename. Re-stat: if dst now exists, treat that as a benign
 		// race; otherwise surface the rename error.
 		if _, sErr := os.Stat(dst); sErr == nil {
-			return s.recordIndex(ref, "sha256:"+hashHex)
+			return dst, true, nil
 		}
-		return wrapStoreErr(err)
+		return "", false, wrapStoreErr(err)
 	}
-	return s.recordIndex(ref, "sha256:"+hashHex)
+	return dst, false, nil
+}
+
+// HasDirHash reports whether a content-addressed directory entry for
+// hashHex already exists under root (the companion lookup to CommitDir).
+// hashHex is the hex SHA-256 with no `sha256:` prefix.
+func HasDirHash(root, hashHex string) (bool, error) {
+	if err := validateHashHex(hashHex); err != nil {
+		return false, err
+	}
+	_, err := os.Stat(filepath.Join(root, "sha256", hashHex))
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, fs.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+// DirEntryDir returns the path `<root>/sha256/<hashHex>/` where a
+// content-addressed directory entry lives, without checking existence.
+func DirEntryDir(root, hashHex string) (string, error) {
+	if err := validateHashHex(hashHex); err != nil {
+		return "", err
+	}
+	return filepath.Join(root, "sha256", hashHex), nil
+}
+
+// validateHashHex rejects any hashHex that is empty, non-hex, or contains
+// path separators so a content-addressed commit can never escape its
+// sha256/ subtree.
+func validateHashHex(hashHex string) error {
+	if hashHex == "" {
+		return wrapStoreErr(fmt.Errorf("empty content hash"))
+	}
+	for i := 0; i < len(hashHex); i++ {
+		c := hashHex[i]
+		isHex := (c >= '0' && c <= '9') || (c >= 'a' && c <= 'f')
+		if !isHex {
+			return wrapStoreErr(fmt.Errorf("invalid content hash %q: expected lowercase hex", hashHex))
+		}
+	}
+	return nil
 }
 
 // uniqueTempDir creates and returns a fresh subdirectory of parent.

--- a/internal/cstore/store.go
+++ b/internal/cstore/store.go
@@ -308,7 +308,10 @@ func (s *Store) persistIndex() error {
 // is cleaned up afterward whether or not the rename succeeded.
 func (s *Store) commit(t *Tarball, ref Ref, hashHex string) error {
 	_, _, err := CommitDir(s.connectorsRoot(), hashHex, func(dir string) error {
-		return t.writeTo(dir)
+		// Wrap the tarball write's plain IO errors as store-unwritable to
+		// preserve commit's pre-refactor failure classification (CommitDir
+		// returns callback errors verbatim).
+		return wrapStoreErr(t.writeTo(dir))
 	})
 	if err != nil {
 		return err
@@ -384,12 +387,11 @@ func CommitDir(root, hashHex string, write func(dir string) error) (entryDir str
 	defer os.RemoveAll(tmp)
 
 	if err := write(tmp); err != nil {
-		// Preserve a structured error from the callback; wrap a plain one.
-		var sErr *Error
-		if errors.As(err, &sErr) {
-			return "", false, err
-		}
-		return "", false, wrapStoreErr(err)
+		// The callback owns its error semantics (it may classify unpack,
+		// validation, etc. failures in its own vocabulary). Return it
+		// verbatim so the caller can inspect it; CommitDir only wraps its
+		// own filesystem failures as store-unwritable.
+		return "", false, err
 	}
 
 	// If a parallel committer already won the race, dst exists. Both

--- a/internal/sandbox/nodedist/archivebuild_test.go
+++ b/internal/sandbox/nodedist/archivebuild_test.go
@@ -1,0 +1,57 @@
+package nodedist_test
+
+import (
+	"archive/tar"
+	"bytes"
+	"compress/gzip"
+	"testing"
+)
+
+// archiveEntry describes one file to place in a synthetic Node archive.
+type archiveEntry struct {
+	name string // archive path, including the top-level distro prefix
+	body []byte
+	mode int64 // unix mode bits; exec bit is asserted in tests
+}
+
+// buildTarGz builds a gzipped tar containing entries, including a top-level
+// directory entry for distroPrefix so the unpack prefix-strip is exercised.
+func buildTarGz(t *testing.T, distroPrefix string, entries []archiveEntry) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+
+	// Top-level directory entry.
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     distroPrefix + "/",
+		Typeflag: tar.TypeDir,
+		Mode:     0o755,
+	}); err != nil {
+		t.Fatalf("write dir header: %v", err)
+	}
+	for _, e := range entries {
+		mode := e.mode
+		if mode == 0 {
+			mode = 0o644
+		}
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     e.name,
+			Typeflag: tar.TypeReg,
+			Mode:     mode,
+			Size:     int64(len(e.body)),
+		}); err != nil {
+			t.Fatalf("write header %s: %v", e.name, err)
+		}
+		if _, err := tw.Write(e.body); err != nil {
+			t.Fatalf("write body %s: %v", e.name, err)
+		}
+	}
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return buf.Bytes()
+}

--- a/internal/sandbox/nodedist/errors.go
+++ b/internal/sandbox/nodedist/errors.go
@@ -1,0 +1,71 @@
+package nodedist
+
+import "fmt"
+
+// ErrorKind is the closed-set classification of nodedist failures. It
+// borrows cstore's failure vocabulary in spirit (fetch / checksum / signature
+// / store) while staying local to this package, since the Node flow does not
+// share cstore's connector-specific classes.
+type ErrorKind string
+
+const (
+	// ErrUnsupportedTarget is returned for a GOOS/GOARCH pair this package
+	// has no Node distribution mapping for.
+	ErrUnsupportedTarget ErrorKind = "unsupported_target"
+
+	// ErrInvalidVersion is an empty or malformed Node version string.
+	ErrInvalidVersion ErrorKind = "invalid_version"
+
+	// ErrFetchFailed is a download failure for one of the three URLs.
+	ErrFetchFailed ErrorKind = "fetch_failed"
+
+	// ErrBadSignature is a SHASUMS256.txt.asc that does not verify against
+	// the trusted keyring. No checksum from the file is trusted in this
+	// case.
+	ErrBadSignature ErrorKind = "bad_signature"
+
+	// ErrChecksumParse is a SHASUMS256.txt body that could not be parsed, or
+	// that does not contain an entry for the requested archive.
+	ErrChecksumParse ErrorKind = "checksum_parse"
+
+	// ErrChecksumMismatch is a downloaded archive whose SHA-256 does not
+	// match the signed entry in SHASUMS256.txt. Nothing is committed to the
+	// store on this failure.
+	ErrChecksumMismatch ErrorKind = "checksum_mismatch"
+
+	// ErrUnpack is an archive extraction failure (corrupt archive, zip-slip
+	// path traversal, unexpected layout).
+	ErrUnpack ErrorKind = "unpack_failed"
+
+	// ErrStore is a failure committing the unpacked tree to the
+	// content-addressed cache.
+	ErrStore ErrorKind = "store_failed"
+
+	// ErrConfig is a misconfigured Fetcher (nil HTTP, nil keyring, empty
+	// root).
+	ErrConfig ErrorKind = "config_error"
+)
+
+// Error is a structured nodedist failure carrying a classification, a
+// human-readable message, and an optional wrapped cause.
+type Error struct {
+	Kind    ErrorKind
+	Message string
+	Cause   error
+}
+
+// Error implements the error interface.
+func (e *Error) Error() string {
+	if e.Cause != nil {
+		return fmt.Sprintf("%s: %s: %v", e.Kind, e.Message, e.Cause)
+	}
+	return fmt.Sprintf("%s: %s", e.Kind, e.Message)
+}
+
+// Unwrap exposes the wrapped cause for errors.Is/As.
+func (e *Error) Unwrap() error { return e.Cause }
+
+// wrapErr builds a structured *Error of the given kind.
+func wrapErr(kind ErrorKind, cause error, format string, args ...any) *Error {
+	return &Error{Kind: kind, Message: fmt.Sprintf(format, args...), Cause: cause}
+}

--- a/internal/sandbox/nodedist/errors_test.go
+++ b/internal/sandbox/nodedist/errors_test.go
@@ -1,0 +1,25 @@
+package nodedist
+
+import (
+	"errors"
+	"testing"
+)
+
+func TestError_MessageAndUnwrap(t *testing.T) {
+	cause := errors.New("root cause")
+	e := &Error{Kind: ErrFetchFailed, Message: "fetch boom", Cause: cause}
+	if got := e.Error(); got != "fetch_failed: fetch boom: root cause" {
+		t.Fatalf("Error() = %q", got)
+	}
+	if !errors.Is(e, cause) {
+		t.Fatalf("Unwrap did not expose the cause")
+	}
+
+	noCause := &Error{Kind: ErrConfig, Message: "bad config"}
+	if got := noCause.Error(); got != "config_error: bad config" {
+		t.Fatalf("Error() without cause = %q", got)
+	}
+	if noCause.Unwrap() != nil {
+		t.Fatalf("Unwrap of a causeless error was non-nil")
+	}
+}

--- a/internal/sandbox/nodedist/fetch.go
+++ b/internal/sandbox/nodedist/fetch.go
@@ -1,0 +1,222 @@
+package nodedist
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"io"
+	"path/filepath"
+	"runtime"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+	"golang.org/x/crypto/openpgp" //nolint:staticcheck // openpgp is the GPG verification primitive; see verify.go.
+)
+
+// Fetcher provisions a verified Node distribution and caches its unpacked
+// tree content-addressed. It ties together the package's units: URL
+// resolution, signature-verified checksums, SHA-256 archive matching,
+// archive unpack, and the shared atomic-rename content-addressed store
+// (cstore.CommitDir).
+//
+// Fetcher reuses cstore.Fetcher for all three downloads so tests can
+// substitute an in-memory fetcher with no network, exactly as the connector
+// install pipeline does.
+type Fetcher struct {
+	// HTTP downloads the archive, SHASUMS256.txt, and SHASUMS256.txt.asc.
+	// Required.
+	HTTP cstore.Fetcher
+
+	// Keyring is the set of trusted Node release public keys the checksums
+	// signature is verified against. Required and must be non-empty;
+	// verification fails closed otherwise.
+	Keyring openpgp.EntityList
+
+	// Root is the cache subtree root for unpacked Node trees. The store lays
+	// out entries as `<Root>/sha256/<verified-hash>/`. Required. Callers
+	// typically pass `filepath.Join(cstore.DefaultRoot(), "node")` so the
+	// Node cache never collides with the connector store's `connectors/`
+	// subtree.
+	Root string
+}
+
+// Request selects which Node distribution to provision.
+type Request struct {
+	// Version is the Node version, with or without a leading "v" (e.g.
+	// "24.2.0" or "v24.2.0"). Required.
+	Version string
+
+	// Target is the platform to fetch for. When zero-valued, the running
+	// host's GOOS/GOARCH is used.
+	Target Target
+}
+
+// NodeDist describes a provisioned (cached) Node distribution.
+type NodeDist struct {
+	// Version is the resolved version (no leading "v").
+	Version string
+
+	// EntryDir is the absolute path to the cached unpacked tree
+	// (`<Root>/sha256/<hash>/`). On Unix the layout has `bin/node`; on
+	// Windows `node.exe` at the root.
+	EntryDir string
+
+	// SHA256 is the verified hex SHA-256 of the source archive — the cache
+	// key. Equal to the entry's SHASUMS256.txt value.
+	SHA256 string
+
+	// NodeBinary is the absolute path to the node executable inside
+	// EntryDir.
+	NodeBinary string
+
+	// FromCache is true when the request was served from the
+	// content-addressed cache without re-downloading the archive.
+	FromCache bool
+}
+
+// Fetch provisions the requested Node distribution and returns the cached
+// entry. The pipeline:
+//
+//  1. Resolve archive/checksums/signature URLs for version+target.
+//  2. Download SHASUMS256.txt and SHASUMS256.txt.asc.
+//  3. Verify the detached signature against the keyring, then parse the
+//     verified checksums. A bad signature aborts here — no archive is
+//     fetched and nothing is committed.
+//  4. Look up the selected archive's verified SHA-256.
+//  5. Cache short-circuit: if a tree for that hash is already stored, return
+//     it WITHOUT downloading the archive.
+//  6. Otherwise download the archive and SHA-256 it; reject on a mismatch
+//     against the signed value (nothing is committed).
+//  7. Unpack into a temp tree (zip-slip guarded) and atomically commit it
+//     under the verified hash via cstore.CommitDir.
+func (f *Fetcher) Fetch(ctx context.Context, req Request) (NodeDist, error) {
+	if f.HTTP == nil {
+		return NodeDist{}, wrapErr(ErrConfig, nil, "Fetcher.HTTP is nil")
+	}
+	if len(f.Keyring) == 0 {
+		return NodeDist{}, wrapErr(ErrConfig, nil, "Fetcher.Keyring is empty")
+	}
+	if f.Root == "" {
+		return NodeDist{}, wrapErr(ErrConfig, nil, "Fetcher.Root is empty")
+	}
+
+	target := req.Target
+	if target == (Target{}) {
+		target = Target{GOOS: runtime.GOOS, GOARCH: runtime.GOARCH}
+	}
+
+	version := normalizeVersion(req.Version)
+	urls, err := ResolveURLs(version, target)
+	if err != nil {
+		return NodeDist{}, err
+	}
+	platform, err := target.resolve()
+	if err != nil {
+		return NodeDist{}, err
+	}
+	archiveName, err := ArchiveName(version, target)
+	if err != nil {
+		return NodeDist{}, err
+	}
+	distroName, err := DistroName(version, target)
+	if err != nil {
+		return NodeDist{}, err
+	}
+
+	// Fetch + signature-verify + parse the checksums.
+	checksumsBytes, err := f.download(ctx, urls.Checksums)
+	if err != nil {
+		return NodeDist{}, err
+	}
+	sigBytes, err := f.download(ctx, urls.Signature)
+	if err != nil {
+		return NodeDist{}, err
+	}
+	sums, err := ChecksumVerifier{Keyring: f.Keyring}.VerifyAndParse(checksumsBytes, sigBytes)
+	if err != nil {
+		return NodeDist{}, err
+	}
+
+	expectedHash, ok := sums[archiveName]
+	if !ok {
+		return NodeDist{}, wrapErr(ErrChecksumParse, nil,
+			"SHASUMS256.txt has no entry for %s", archiveName)
+	}
+
+	// Cache short-circuit: already provisioned at this verified hash.
+	present, err := cstore.HasDirHash(f.Root, expectedHash)
+	if err != nil {
+		return NodeDist{}, wrapErr(ErrStore, err, "probe cache for %s", expectedHash)
+	}
+	if present {
+		entryDir, _ := cstore.DirEntryDir(f.Root, expectedHash)
+		return NodeDist{
+			Version:    version,
+			EntryDir:   entryDir,
+			SHA256:     expectedHash,
+			NodeBinary: nodeBinaryPath(entryDir, target),
+			FromCache:  true,
+		}, nil
+	}
+
+	// Download the archive and SHA-256 it against the signed checksum.
+	archiveBytes, err := f.download(ctx, urls.Archive)
+	if err != nil {
+		return NodeDist{}, err
+	}
+	gotHash := sha256Hex(archiveBytes)
+	if gotHash != expectedHash {
+		return NodeDist{}, wrapErr(ErrChecksumMismatch, nil,
+			"archive %s sha256 %s does not match signed checksum %s",
+			archiveName, gotHash, expectedHash)
+	}
+
+	// Unpack into a temp tree and atomically commit under the verified hash.
+	entryDir, _, cErr := cstore.CommitDir(f.Root, expectedHash, func(dir string) error {
+		return unpackArchive(archiveBytes, platform.ext, distroName, dir)
+	})
+	if cErr != nil {
+		// Surface unpack failures with their own kind; wrap store failures.
+		var ndErr *Error
+		if errors.As(cErr, &ndErr) {
+			return NodeDist{}, cErr
+		}
+		return NodeDist{}, wrapErr(ErrStore, cErr, "commit unpacked Node tree")
+	}
+
+	return NodeDist{
+		Version:    version,
+		EntryDir:   entryDir,
+		SHA256:     expectedHash,
+		NodeBinary: nodeBinaryPath(entryDir, target),
+		FromCache:  false,
+	}, nil
+}
+
+// download fetches url via the configured Fetcher and reads the full body.
+func (f *Fetcher) download(ctx context.Context, url string) ([]byte, error) {
+	body, err := f.HTTP.Fetch(ctx, url)
+	if err != nil {
+		return nil, wrapErr(ErrFetchFailed, err, "fetch %s", url)
+	}
+	defer body.Close()
+	data, err := io.ReadAll(body)
+	if err != nil {
+		return nil, wrapErr(ErrFetchFailed, err, "read %s", url)
+	}
+	return data, nil
+}
+
+// nodeBinaryPath returns the absolute path to the node executable inside an
+// unpacked entry for the given target.
+func nodeBinaryPath(entryDir string, target Target) string {
+	if target.GOOS == "windows" {
+		return filepath.Join(entryDir, "node.exe")
+	}
+	return filepath.Join(entryDir, "bin", "node")
+}
+
+func sha256Hex(b []byte) string {
+	sum := sha256.Sum256(b)
+	return hex.EncodeToString(sum[:])
+}

--- a/internal/sandbox/nodedist/fetch_test.go
+++ b/internal/sandbox/nodedist/fetch_test.go
@@ -1,0 +1,284 @@
+package nodedist_test
+
+import (
+	"context"
+	"crypto/sha256"
+	"encoding/hex"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"sync"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/sandbox/nodedist"
+)
+
+// fakeFetcher is an in-memory cstore.Fetcher: it serves pre-registered URL
+// bodies and records every URL requested so tests can assert the cache
+// short-circuit skipped the archive download.
+type fakeFetcher struct {
+	mu      sync.Mutex
+	bodies  map[string][]byte
+	calls   []string
+	failURL string // when set, a request for this URL returns an error
+}
+
+func newFakeFetcher() *fakeFetcher {
+	return &fakeFetcher{bodies: map[string][]byte{}}
+}
+
+func (f *fakeFetcher) Fetch(_ context.Context, url string) (io.ReadCloser, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	f.calls = append(f.calls, url)
+	if url == f.failURL {
+		return nil, fmt.Errorf("simulated fetch failure for %s", url)
+	}
+	body, ok := f.bodies[url]
+	if !ok {
+		return nil, fmt.Errorf("no body registered for %s", url)
+	}
+	return io.NopCloser(strings.NewReader(string(body))), nil
+}
+
+func (f *fakeFetcher) requested(url string) bool {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	for _, c := range f.calls {
+		if c == url {
+			return true
+		}
+	}
+	return false
+}
+
+// linuxTarget is used across the fetch tests; it produces a tar.gz archive.
+var linuxTarget = nodedist.Target{GOOS: "linux", GOARCH: "amd64"}
+
+const fetchVersion = "24.2.0"
+
+// fixture builds a complete, internally-consistent fixture: a synthetic
+// tar.gz Node archive, a SHASUMS256.txt listing its real sha256, and a valid
+// detached signature, all registered on the returned fetcher. The signed
+// archive hash is returned for assertions.
+func fixture(t *testing.T, signerKeyring func(t *testing.T) (*signer, keyring)) (*fakeFetcher, keyring, string, []byte) {
+	t.Helper()
+	distro, err := nodedist.DistroName(fetchVersion, linuxTarget)
+	if err != nil {
+		t.Fatalf("DistroName: %v", err)
+	}
+	archive := buildTarGz(t, distro, []archiveEntry{
+		{name: distro + "/bin/node", body: []byte("#!/bin/node\n"), mode: 0o755},
+		{name: distro + "/README.md", body: []byte("node readme"), mode: 0o644},
+	})
+	sum := sha256.Sum256(archive)
+	archiveHash := hex.EncodeToString(sum[:])
+
+	archiveName, _ := nodedist.ArchiveName(fetchVersion, linuxTarget)
+	checksums := fmt.Sprintf("%s  %s\n", archiveHash, archiveName)
+
+	sk, kr := signerKeyring(t)
+	sig := sk.armoredDetachedSign(t, []byte(checksums))
+
+	urls, _ := nodedist.ResolveURLs(fetchVersion, linuxTarget)
+	ff := newFakeFetcher()
+	ff.bodies[urls.Archive] = archive
+	ff.bodies[urls.Checksums] = []byte(checksums)
+	ff.bodies[urls.Signature] = sig
+	return ff, kr, archiveHash, archive
+}
+
+func TestFetch_HappyPath(t *testing.T) {
+	ff, kr, archiveHash, _ := fixture(t, matchedSigner)
+	root := filepath.Join(t.TempDir(), "node")
+
+	f := &nodedist.Fetcher{HTTP: ff, Keyring: kr, Root: root}
+	dist, err := f.Fetch(context.Background(), nodedist.Request{Version: fetchVersion, Target: linuxTarget})
+	if err != nil {
+		t.Fatalf("Fetch: %v", err)
+	}
+
+	if dist.SHA256 != archiveHash {
+		t.Errorf("SHA256 = %q, want %q", dist.SHA256, archiveHash)
+	}
+	if dist.Version != fetchVersion {
+		t.Errorf("Version = %q, want %q", dist.Version, fetchVersion)
+	}
+	if dist.FromCache {
+		t.Errorf("FromCache = true on first fetch")
+	}
+	// The unpacked tree has a runnable bin/node layout (prefix stripped).
+	wantBin := filepath.Join(dist.EntryDir, "bin", "node")
+	if dist.NodeBinary != wantBin {
+		t.Errorf("NodeBinary = %q, want %q", dist.NodeBinary, wantBin)
+	}
+	body, err := os.ReadFile(wantBin)
+	if err != nil {
+		t.Fatalf("read bin/node: %v", err)
+	}
+	if string(body) != "#!/bin/node\n" {
+		t.Errorf("bin/node body = %q", body)
+	}
+	// Cache key directory is the verified hash.
+	if filepath.Base(dist.EntryDir) != archiveHash {
+		t.Errorf("entry dir base = %q, want verified hash %q", filepath.Base(dist.EntryDir), archiveHash)
+	}
+}
+
+func TestFetch_ChecksumMismatchRejected(t *testing.T) {
+	ff, kr, archiveHash, _ := fixture(t, matchedSigner)
+	root := filepath.Join(t.TempDir(), "node")
+
+	// Corrupt the archive body so its sha256 no longer matches the signed
+	// checksum, but keep the (validly signed) checksums file intact.
+	urls, _ := nodedist.ResolveURLs(fetchVersion, linuxTarget)
+	ff.bodies[urls.Archive] = append(ff.bodies[urls.Archive], 0xFF)
+
+	f := &nodedist.Fetcher{HTTP: ff, Keyring: kr, Root: root}
+	_, err := f.Fetch(context.Background(), nodedist.Request{Version: fetchVersion, Target: linuxTarget})
+	if err == nil {
+		t.Fatalf("Fetch accepted an archive whose sha256 != signed checksum")
+	}
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrChecksumMismatch {
+		t.Fatalf("error = %v, want ErrChecksumMismatch", err)
+	}
+	// Nothing committed: the verified-hash entry must not exist.
+	if _, statErr := os.Stat(filepath.Join(root, "sha256", archiveHash)); statErr == nil {
+		t.Fatalf("a store entry was committed despite checksum mismatch")
+	}
+}
+
+func TestFetch_BadSignatureRejectedBeforeArchiveFetch(t *testing.T) {
+	// Sign the checksums with a key the fetcher does NOT trust.
+	ff, kr, _, _ := fixture(t, mismatchedSigner)
+	root := filepath.Join(t.TempDir(), "node")
+
+	f := &nodedist.Fetcher{HTTP: ff, Keyring: kr, Root: root}
+	_, err := f.Fetch(context.Background(), nodedist.Request{Version: fetchVersion, Target: linuxTarget})
+	if err == nil {
+		t.Fatalf("Fetch accepted a checksums file signed by an untrusted key")
+	}
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrBadSignature {
+		t.Fatalf("error = %v, want ErrBadSignature", err)
+	}
+	// The archive must NOT have been fetched: signature is checked first.
+	urls, _ := nodedist.ResolveURLs(fetchVersion, linuxTarget)
+	if ff.requested(urls.Archive) {
+		t.Fatalf("archive was fetched despite a bad signature")
+	}
+	// Nothing committed.
+	if entries, _ := os.ReadDir(filepath.Join(root, "sha256")); len(entries) != 0 {
+		t.Fatalf("store has entries despite bad signature")
+	}
+}
+
+func TestFetch_CacheShortCircuitSkipsArchive(t *testing.T) {
+	ff, kr, archiveHash, _ := fixture(t, matchedSigner)
+	root := filepath.Join(t.TempDir(), "node")
+
+	f := &nodedist.Fetcher{HTTP: ff, Keyring: kr, Root: root}
+	ctx := context.Background()
+
+	// First fetch populates the cache.
+	if _, err := f.Fetch(ctx, nodedist.Request{Version: fetchVersion, Target: linuxTarget}); err != nil {
+		t.Fatalf("first Fetch: %v", err)
+	}
+
+	// Second fetch against the SAME store and SAME (trusted) checksums/sig,
+	// but with the archive body removed and the call log reset. A cache hit
+	// must serve the entry without ever requesting the archive URL.
+	urls, _ := nodedist.ResolveURLs(fetchVersion, linuxTarget)
+	delete(ff.bodies, urls.Archive) // archive intentionally unavailable now
+	ff.mu.Lock()
+	ff.calls = nil
+	ff.mu.Unlock()
+
+	dist, err := f.Fetch(ctx, nodedist.Request{Version: fetchVersion, Target: linuxTarget})
+	if err != nil {
+		t.Fatalf("cached Fetch: %v", err)
+	}
+	if !dist.FromCache {
+		t.Errorf("FromCache = false on a cached request")
+	}
+	if dist.SHA256 != archiveHash {
+		t.Errorf("SHA256 = %q, want %q", dist.SHA256, archiveHash)
+	}
+	if ff.requested(urls.Archive) {
+		t.Fatalf("archive URL was requested despite a cache hit")
+	}
+}
+
+func TestFetch_UnsupportedTarget(t *testing.T) {
+	ff, kr, _, _ := fixture(t, matchedSigner)
+	f := &nodedist.Fetcher{HTTP: ff, Keyring: kr, Root: t.TempDir()}
+	_, err := f.Fetch(context.Background(), nodedist.Request{
+		Version: fetchVersion,
+		Target:  nodedist.Target{GOOS: "plan9", GOARCH: "mips"},
+	})
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrUnsupportedTarget {
+		t.Fatalf("error = %v, want ErrUnsupportedTarget", err)
+	}
+}
+
+func TestFetch_ConfigValidation(t *testing.T) {
+	ff := newFakeFetcher()
+	_, kr := matchedSigner(t)
+	cases := []struct {
+		name string
+		f    *nodedist.Fetcher
+	}{
+		{"nil HTTP", &nodedist.Fetcher{Keyring: kr, Root: "/tmp/x"}},
+		{"empty keyring", &nodedist.Fetcher{HTTP: ff, Root: "/tmp/x"}},
+		{"empty root", &nodedist.Fetcher{HTTP: ff, Keyring: kr}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			_, err := tc.f.Fetch(context.Background(), nodedist.Request{Version: fetchVersion, Target: linuxTarget})
+			var ndErr *nodedist.Error
+			if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrConfig {
+				t.Fatalf("error = %v, want ErrConfig", err)
+			}
+		})
+	}
+}
+
+func TestFetch_MissingChecksumEntry(t *testing.T) {
+	// A validly signed checksums file that omits the requested archive.
+	sk, kr := matchedSigner(t)
+	urls, _ := nodedist.ResolveURLs(fetchVersion, linuxTarget)
+	checksums := "1111111111111111111111111111111111111111111111111111111111111111  some-other-file.tar.gz\n"
+	sig := sk.armoredDetachedSign(t, []byte(checksums))
+
+	ff := newFakeFetcher()
+	ff.bodies[urls.Checksums] = []byte(checksums)
+	ff.bodies[urls.Signature] = sig
+
+	f := &nodedist.Fetcher{HTTP: ff, Keyring: kr, Root: filepath.Join(t.TempDir(), "node")}
+	_, err := f.Fetch(context.Background(), nodedist.Request{Version: fetchVersion, Target: linuxTarget})
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrChecksumParse {
+		t.Fatalf("error = %v, want ErrChecksumParse", err)
+	}
+	if ff.requested(urls.Archive) {
+		t.Fatalf("archive fetched despite no checksum entry for it")
+	}
+}
+
+func TestFetch_FetchFailurePropagates(t *testing.T) {
+	ff, kr, _, _ := fixture(t, matchedSigner)
+	urls, _ := nodedist.ResolveURLs(fetchVersion, linuxTarget)
+	ff.failURL = urls.Checksums
+
+	f := &nodedist.Fetcher{HTTP: ff, Keyring: kr, Root: filepath.Join(t.TempDir(), "node")}
+	_, err := f.Fetch(context.Background(), nodedist.Request{Version: fetchVersion, Target: linuxTarget})
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrFetchFailed {
+		t.Fatalf("error = %v, want ErrFetchFailed", err)
+	}
+}

--- a/internal/sandbox/nodedist/fetch_test.go
+++ b/internal/sandbox/nodedist/fetch_test.go
@@ -213,6 +213,37 @@ func TestFetch_CacheShortCircuitSkipsArchive(t *testing.T) {
 	}
 }
 
+func TestFetch_UnpackFailurePropagates(t *testing.T) {
+	// A "valid" download: the bytes are not a real archive, but the signed
+	// checksum matches their sha256, so the flow reaches unpack and fails
+	// there. The error must surface as ErrUnpack (not reclassified as a
+	// store error) and nothing is committed.
+	sk, kr := matchedSigner(t)
+	bogus := []byte("this is not a gzip archive")
+	sum := sha256.Sum256(bogus)
+	bogusHash := hex.EncodeToString(sum[:])
+	archiveName, _ := nodedist.ArchiveName(fetchVersion, linuxTarget)
+	checksums := fmt.Sprintf("%s  %s\n", bogusHash, archiveName)
+	sig := sk.armoredDetachedSign(t, []byte(checksums))
+
+	urls, _ := nodedist.ResolveURLs(fetchVersion, linuxTarget)
+	ff := newFakeFetcher()
+	ff.bodies[urls.Archive] = bogus
+	ff.bodies[urls.Checksums] = []byte(checksums)
+	ff.bodies[urls.Signature] = sig
+
+	root := filepath.Join(t.TempDir(), "node")
+	f := &nodedist.Fetcher{HTTP: ff, Keyring: kr, Root: root}
+	_, err := f.Fetch(context.Background(), nodedist.Request{Version: fetchVersion, Target: linuxTarget})
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrUnpack {
+		t.Fatalf("error = %v, want ErrUnpack", err)
+	}
+	if _, statErr := os.Stat(filepath.Join(root, "sha256", bogusHash)); statErr == nil {
+		t.Fatalf("an entry was committed despite an unpack failure")
+	}
+}
+
 func TestFetch_UnsupportedTarget(t *testing.T) {
 	ff, kr, _, _ := fixture(t, matchedSigner)
 	f := &nodedist.Fetcher{HTTP: ff, Keyring: kr, Root: t.TempDir()}

--- a/internal/sandbox/nodedist/nodedist.go
+++ b/internal/sandbox/nodedist/nodedist.go
@@ -1,0 +1,133 @@
+// Package nodedist fetches a pinned Node.js distribution by version and
+// target platform from nodejs.org, verifies it against Node's GPG-signed
+// SHASUMS256.txt, SHA-256-matches the downloaded archive, unpacks it, and
+// caches the unpacked tree content-addressed under the shared
+// atomic-rename store primitive (cstore.CommitDir).
+//
+// This package is the supply-chain-verified Node provisioning layer for the
+// sandbox toolchain (issue #1525, sub-issue 1). It is self-contained and
+// deliberately not wired into any build path here — the call site lands in a
+// later sub-issue. The pipeline shape mirrors cstore's connector install:
+//
+//	fetch (cstore.Fetcher) → verify (ChecksumVerifier) → hash-match → unpack → cache (cstore.CommitDir)
+//
+// Trust property: the cache key is the archive's SHA-256 as published in
+// Node's signed SHASUMS256.txt. The signature is checked first, then the
+// download is matched against the signed hash, then the unpacked tree is
+// stored under that same supply-chain-verified hash. A request whose
+// verified hash is already cached short-circuits without re-downloading the
+// archive.
+package nodedist
+
+import (
+	"fmt"
+	"strings"
+)
+
+// baseURL is the nodejs.org distribution root. Released artifacts for a
+// version v<ver> live under baseURL + "v<ver>/".
+const baseURL = "https://nodejs.org/dist/"
+
+// Target identifies the platform a Node distribution is built for, using
+// Go's GOOS/GOARCH vocabulary at the boundary. The mapping to Node's own
+// os/arch naming (e.g. linux/amd64 → linux-x64) is internal to this
+// package (see nodePlatform).
+type Target struct {
+	GOOS   string
+	GOARCH string
+}
+
+// nodePlatform is Node's own (os, arch, archiveExt) naming for a Target.
+type nodePlatform struct {
+	os   string
+	arch string
+	ext  string // "tar.gz" on Unix, "zip" on Windows
+}
+
+// supportedTargets is the total, explicit GOOS/GOARCH → Node-platform
+// mapping. Unsupported pairs fail fast (no silent fallback). This is kept
+// minimal on purpose; broader arch resolution is sub-issue 2.
+var supportedTargets = map[Target]nodePlatform{
+	{GOOS: "linux", GOARCH: "amd64"}:   {os: "linux", arch: "x64", ext: "tar.gz"},
+	{GOOS: "linux", GOARCH: "arm64"}:   {os: "linux", arch: "arm64", ext: "tar.gz"},
+	{GOOS: "darwin", GOARCH: "amd64"}:  {os: "darwin", arch: "x64", ext: "tar.gz"},
+	{GOOS: "darwin", GOARCH: "arm64"}:  {os: "darwin", arch: "arm64", ext: "tar.gz"},
+	{GOOS: "windows", GOARCH: "amd64"}: {os: "win", arch: "x64", ext: "zip"},
+	{GOOS: "windows", GOARCH: "arm64"}: {os: "win", arch: "arm64", ext: "zip"},
+}
+
+// resolve maps a Target to its Node platform naming, or returns a typed
+// error for an unsupported pair.
+func (t Target) resolve() (nodePlatform, error) {
+	p, ok := supportedTargets[t]
+	if !ok {
+		return nodePlatform{}, &Error{
+			Kind:    ErrUnsupportedTarget,
+			Message: fmt.Sprintf("no Node distribution mapping for %s/%s", t.GOOS, t.GOARCH),
+		}
+	}
+	return p, nil
+}
+
+// normalizeVersion strips a leading "v" from a version string so callers
+// may pass either "24.2.0" or "v24.2.0". The empty version is rejected by
+// the callers that build URLs.
+func normalizeVersion(version string) string {
+	return strings.TrimPrefix(version, "v")
+}
+
+// DistroName returns the top-level directory name a Node archive unpacks
+// to, e.g. "node-v24.2.0-linux-x64". The unpack step strips this prefix.
+func DistroName(version string, target Target) (string, error) {
+	v := normalizeVersion(version)
+	if v == "" {
+		return "", &Error{Kind: ErrInvalidVersion, Message: "empty Node version"}
+	}
+	p, err := target.resolve()
+	if err != nil {
+		return "", err
+	}
+	return fmt.Sprintf("node-v%s-%s-%s", v, p.os, p.arch), nil
+}
+
+// ArchiveName returns the archive filename for a version+target, e.g.
+// "node-v24.2.0-linux-x64.tar.gz" (Unix) or "node-v24.2.0-win-x64.zip"
+// (Windows). This is the exact key that appears in SHASUMS256.txt.
+func ArchiveName(version string, target Target) (string, error) {
+	distro, err := DistroName(version, target)
+	if err != nil {
+		return "", err
+	}
+	p, _ := target.resolve() // already validated by DistroName
+	return distro + "." + p.ext, nil
+}
+
+// URLs holds the three nodejs.org URLs needed to fetch and verify one
+// distribution.
+type URLs struct {
+	// Archive is the platform-specific distribution archive.
+	Archive string
+	// Checksums is the SHASUMS256.txt covering every artifact for the
+	// version.
+	Checksums string
+	// Signature is the detached PGP signature (SHASUMS256.txt.asc) over
+	// Checksums.
+	Signature string
+}
+
+// ResolveURLs computes the archive, checksums, and signature URLs for a
+// version+target. Returns a typed error for an empty version or an
+// unsupported target.
+func ResolveURLs(version string, target Target) (URLs, error) {
+	archiveName, err := ArchiveName(version, target)
+	if err != nil {
+		return URLs{}, err
+	}
+	v := normalizeVersion(version)
+	verRoot := baseURL + "v" + v + "/"
+	return URLs{
+		Archive:   verRoot + archiveName,
+		Checksums: verRoot + "SHASUMS256.txt",
+		Signature: verRoot + "SHASUMS256.txt.asc",
+	}, nil
+}

--- a/internal/sandbox/nodedist/nodedist_test.go
+++ b/internal/sandbox/nodedist/nodedist_test.go
@@ -1,0 +1,108 @@
+package nodedist_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/sandbox/nodedist"
+)
+
+func TestResolveURLs(t *testing.T) {
+	cases := []struct {
+		name      string
+		version   string
+		target    nodedist.Target
+		archive   string
+		checksums string
+		signature string
+		distro    string
+	}{
+		{
+			name:      "linux amd64 tar.gz",
+			version:   "24.2.0",
+			target:    nodedist.Target{GOOS: "linux", GOARCH: "amd64"},
+			archive:   "https://nodejs.org/dist/v24.2.0/node-v24.2.0-linux-x64.tar.gz",
+			checksums: "https://nodejs.org/dist/v24.2.0/SHASUMS256.txt",
+			signature: "https://nodejs.org/dist/v24.2.0/SHASUMS256.txt.asc",
+			distro:    "node-v24.2.0-linux-x64",
+		},
+		{
+			name:    "darwin arm64 tar.gz",
+			version: "24.2.0",
+			target:  nodedist.Target{GOOS: "darwin", GOARCH: "arm64"},
+			archive: "https://nodejs.org/dist/v24.2.0/node-v24.2.0-darwin-arm64.tar.gz",
+			distro:  "node-v24.2.0-darwin-arm64",
+		},
+		{
+			name:    "windows amd64 zip",
+			version: "24.2.0",
+			target:  nodedist.Target{GOOS: "windows", GOARCH: "amd64"},
+			archive: "https://nodejs.org/dist/v24.2.0/node-v24.2.0-win-x64.zip",
+			distro:  "node-v24.2.0-win-x64",
+		},
+		{
+			name:    "leading v in version is accepted",
+			version: "v20.11.1",
+			target:  nodedist.Target{GOOS: "linux", GOARCH: "arm64"},
+			archive: "https://nodejs.org/dist/v20.11.1/node-v20.11.1-linux-arm64.tar.gz",
+			distro:  "node-v20.11.1-linux-arm64",
+		},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			urls, err := nodedist.ResolveURLs(tc.version, tc.target)
+			if err != nil {
+				t.Fatalf("ResolveURLs: %v", err)
+			}
+			if urls.Archive != tc.archive {
+				t.Errorf("Archive = %q, want %q", urls.Archive, tc.archive)
+			}
+			if tc.checksums != "" && urls.Checksums != tc.checksums {
+				t.Errorf("Checksums = %q, want %q", urls.Checksums, tc.checksums)
+			}
+			if tc.signature != "" && urls.Signature != tc.signature {
+				t.Errorf("Signature = %q, want %q", urls.Signature, tc.signature)
+			}
+
+			distro, err := nodedist.DistroName(tc.version, tc.target)
+			if err != nil {
+				t.Fatalf("DistroName: %v", err)
+			}
+			if distro != tc.distro {
+				t.Errorf("DistroName = %q, want %q", distro, tc.distro)
+			}
+		})
+	}
+}
+
+func TestResolveURLs_UnsupportedTarget(t *testing.T) {
+	_, err := nodedist.ResolveURLs("24.2.0", nodedist.Target{GOOS: "plan9", GOARCH: "mips"})
+	if err == nil {
+		t.Fatalf("ResolveURLs accepted an unsupported target")
+	}
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrUnsupportedTarget {
+		t.Fatalf("error = %v, want ErrUnsupportedTarget", err)
+	}
+}
+
+func TestResolveURLs_EmptyVersion(t *testing.T) {
+	_, err := nodedist.ResolveURLs("", nodedist.Target{GOOS: "linux", GOARCH: "amd64"})
+	if err == nil {
+		t.Fatalf("ResolveURLs accepted an empty version")
+	}
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrInvalidVersion {
+		t.Fatalf("error = %v, want ErrInvalidVersion", err)
+	}
+}
+
+func TestArchiveName_WindowsZip(t *testing.T) {
+	name, err := nodedist.ArchiveName("24.2.0", nodedist.Target{GOOS: "windows", GOARCH: "arm64"})
+	if err != nil {
+		t.Fatalf("ArchiveName: %v", err)
+	}
+	if name != "node-v24.2.0-win-arm64.zip" {
+		t.Fatalf("ArchiveName = %q", name)
+	}
+}

--- a/internal/sandbox/nodedist/testhelpers_test.go
+++ b/internal/sandbox/nodedist/testhelpers_test.go
@@ -1,0 +1,71 @@
+package nodedist_test
+
+import (
+	"bytes"
+	"testing"
+
+	"golang.org/x/crypto/openpgp" //nolint:staticcheck // test signing primitive mirrors the production verify path.
+)
+
+// keyring aliases the openpgp.EntityList used as the trusted Node release key
+// set in tests.
+type keyring = openpgp.EntityList
+
+// signer wraps a PGP entity used to sign test fixtures.
+type signer struct {
+	entity *openpgp.Entity
+}
+
+// armoredDetachedSign returns an armored detached signature over msg, the
+// same shape as SHASUMS256.txt.asc.
+func (s *signer) armoredDetachedSign(t *testing.T, msg []byte) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := openpgp.ArmoredDetachSign(&buf, s.entity, bytes.NewReader(msg), nil); err != nil {
+		t.Fatalf("ArmoredDetachSign: %v", err)
+	}
+	return buf.Bytes()
+}
+
+// newEntity creates a fresh in-memory PGP entity for test signing.
+func newEntity(t *testing.T) *openpgp.Entity {
+	t.Helper()
+	ent, err := openpgp.NewEntity("nodedist test", "", "test@example.com", nil)
+	if err != nil {
+		t.Fatalf("NewEntity: %v", err)
+	}
+	return ent
+}
+
+// matchedSigner returns a signer whose public key IS in the returned
+// keyring, modelling "Node signs a release with a key we trust".
+func matchedSigner(t *testing.T) (*signer, keyring) {
+	t.Helper()
+	ent := newEntity(t)
+	return &signer{entity: ent}, keyring{ent}
+}
+
+// mismatchedSigner returns a signer whose public key is NOT in the returned
+// keyring (the keyring holds a different, unrelated key), modelling a
+// checksums file signed by an untrusted key.
+func mismatchedSigner(t *testing.T) (*signer, keyring) {
+	t.Helper()
+	signerEnt := newEntity(t)
+	trustedEnt := newEntity(t)
+	return &signer{entity: signerEnt}, keyring{trustedEnt}
+}
+
+// newTestSigner returns a fresh entity plus a keyring containing only its
+// public half, for the verify-package unit tests.
+func newTestSigner(t *testing.T) (*openpgp.Entity, openpgp.EntityList) {
+	t.Helper()
+	ent := newEntity(t)
+	return ent, openpgp.EntityList{ent}
+}
+
+// armoredDetachedSign signs msg with ent (free-function form used by the
+// verify unit tests).
+func armoredDetachedSign(t *testing.T, ent *openpgp.Entity, msg []byte) []byte {
+	t.Helper()
+	return (&signer{entity: ent}).armoredDetachedSign(t, msg)
+}

--- a/internal/sandbox/nodedist/unpack.go
+++ b/internal/sandbox/nodedist/unpack.go
@@ -1,0 +1,214 @@
+package nodedist
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"io"
+	"os"
+	"path"
+	"path/filepath"
+	"strings"
+)
+
+// maxUnpackBytes caps the total decompressed size of a Node archive to guard
+// against a decompression bomb. A full Node distribution is well under this.
+const maxUnpackBytes = 1 << 30 // 1 GiB
+
+// unpackArchive extracts a Node archive (raw bytes) into dest, stripping the
+// top-level distroPrefix directory (e.g. "node-v24.2.0-linux-x64") so dest
+// ends up with bin/, lib/, etc. at its root. ext selects the format:
+// "tar.gz" or "zip".
+//
+// dest must already exist and be empty. Every entry is checked against
+// zip-slip path traversal: an entry that resolves outside dest aborts the
+// unpack with an ErrUnpack error before any bytes for it are written.
+// Executable bits are preserved from the archive's recorded mode.
+func unpackArchive(data []byte, ext, distroPrefix, dest string) error {
+	switch ext {
+	case "tar.gz":
+		return unpackTarGz(data, distroPrefix, dest)
+	case "zip":
+		return unpackZip(data, distroPrefix, dest)
+	default:
+		return wrapErr(ErrUnpack, nil, "unsupported archive extension %q", ext)
+	}
+}
+
+func unpackTarGz(data []byte, distroPrefix, dest string) error {
+	gz, err := gzip.NewReader(bytes.NewReader(data))
+	if err != nil {
+		return wrapErr(ErrUnpack, err, "open gzip stream")
+	}
+	defer gz.Close()
+
+	tr := tar.NewReader(gz)
+	var written int64
+	for {
+		hdr, hErr := tr.Next()
+		if errors.Is(hErr, io.EOF) {
+			break
+		}
+		if hErr != nil {
+			return wrapErr(ErrUnpack, hErr, "read tar entry")
+		}
+		rel, ok := stripPrefix(hdr.Name, distroPrefix)
+		if !ok || rel == "" {
+			continue
+		}
+		target, sErr := safeJoin(dest, rel)
+		if sErr != nil {
+			return sErr
+		}
+		switch hdr.Typeflag {
+		case tar.TypeDir:
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return wrapErr(ErrUnpack, err, "mkdir %s", rel)
+			}
+		case tar.TypeReg, tar.TypeRegA:
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return wrapErr(ErrUnpack, err, "mkdir parent of %s", rel)
+			}
+			n, wErr := writeRegular(target, tr, fileMode(hdr.Mode), maxUnpackBytes-written)
+			written += n
+			if wErr != nil {
+				return wErr
+			}
+		case tar.TypeSymlink, tar.TypeLink:
+			// Node Unix archives contain symlinks (e.g. lib/node_modules
+			// internals). Recreate them, but only when the target stays
+			// inside dest.
+			if err := writeSymlink(dest, target, hdr.Linkname); err != nil {
+				return err
+			}
+		default:
+			// Skip devices, fifos, etc. — not present in Node archives.
+			continue
+		}
+	}
+	return nil
+}
+
+func unpackZip(data []byte, distroPrefix, dest string) error {
+	zr, err := zip.NewReader(bytes.NewReader(data), int64(len(data)))
+	if err != nil {
+		return wrapErr(ErrUnpack, err, "open zip archive")
+	}
+	var written int64
+	for _, f := range zr.File {
+		rel, ok := stripPrefix(f.Name, distroPrefix)
+		if !ok || rel == "" {
+			continue
+		}
+		target, sErr := safeJoin(dest, rel)
+		if sErr != nil {
+			return sErr
+		}
+		if f.FileInfo().IsDir() {
+			if err := os.MkdirAll(target, 0o755); err != nil {
+				return wrapErr(ErrUnpack, err, "mkdir %s", rel)
+			}
+			continue
+		}
+		if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+			return wrapErr(ErrUnpack, err, "mkdir parent of %s", rel)
+		}
+		rc, oErr := f.Open()
+		if oErr != nil {
+			return wrapErr(ErrUnpack, oErr, "open zip entry %s", rel)
+		}
+		n, wErr := writeRegular(target, rc, f.Mode(), maxUnpackBytes-written)
+		rc.Close()
+		written += n
+		if wErr != nil {
+			return wErr
+		}
+	}
+	return nil
+}
+
+// stripPrefix removes the leading "<distroPrefix>/" segment from a slash-
+// separated archive entry name. Returns (rel, true) when name was under the
+// prefix; (_, false) otherwise (such entries are skipped). The prefix itself
+// (the bare top-level dir) yields ("", true).
+func stripPrefix(name, distroPrefix string) (string, bool) {
+	clean := path.Clean(strings.TrimPrefix(name, "./"))
+	clean = strings.TrimPrefix(clean, "/")
+	if clean == distroPrefix {
+		return "", true
+	}
+	prefix := distroPrefix + "/"
+	if !strings.HasPrefix(clean, prefix) {
+		return "", false
+	}
+	return strings.TrimPrefix(clean, prefix), true
+}
+
+// safeJoin joins dest and a relative path, rejecting any result that escapes
+// dest (zip-slip / "../" path traversal).
+func safeJoin(dest, rel string) (string, error) {
+	target := filepath.Join(dest, filepath.FromSlash(rel))
+	// filepath.Join cleans the path; verify it is still under dest.
+	cleanDest := filepath.Clean(dest)
+	if target != cleanDest && !strings.HasPrefix(target, cleanDest+string(os.PathSeparator)) {
+		return "", wrapErr(ErrUnpack, nil, "archive entry %q escapes the unpack target", rel)
+	}
+	return target, nil
+}
+
+// writeRegular streams src into a new file at target with mode, capping the
+// number of bytes at remaining to bound decompression. Returns the number of
+// bytes written.
+func writeRegular(target string, src io.Reader, mode os.FileMode, remaining int64) (int64, error) {
+	if remaining <= 0 {
+		return 0, wrapErr(ErrUnpack, nil, "archive exceeds maximum unpacked size")
+	}
+	f, err := os.OpenFile(target, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, mode.Perm())
+	if err != nil {
+		return 0, wrapErr(ErrUnpack, err, "create %s", target)
+	}
+	// +1 so we can detect overflow past the cap.
+	n, cErr := io.Copy(f, io.LimitReader(src, remaining+1))
+	if closeErr := f.Close(); closeErr != nil && cErr == nil {
+		cErr = closeErr
+	}
+	if cErr != nil {
+		return n, wrapErr(ErrUnpack, cErr, "write %s", target)
+	}
+	if n > remaining {
+		return n, wrapErr(ErrUnpack, nil, "archive exceeds maximum unpacked size")
+	}
+	return n, nil
+}
+
+// writeSymlink recreates a symlink at target pointing to linkname, but only
+// when the resolved destination stays within root. A symlink escaping root
+// is rejected as a path-traversal attempt.
+func writeSymlink(root, target, linkname string) error {
+	resolved := linkname
+	if !filepath.IsAbs(linkname) {
+		resolved = filepath.Join(filepath.Dir(target), linkname)
+	}
+	cleanRoot := filepath.Clean(root)
+	if resolved != cleanRoot && !strings.HasPrefix(filepath.Clean(resolved), cleanRoot+string(os.PathSeparator)) {
+		return wrapErr(ErrUnpack, nil, "symlink %q -> %q escapes the unpack target", target, linkname)
+	}
+	if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+		return wrapErr(ErrUnpack, err, "mkdir parent for symlink")
+	}
+	// Replace any existing entry so repeated unpacks into a fresh dir are
+	// deterministic (the dir is always fresh in practice).
+	_ = os.Remove(target)
+	if err := os.Symlink(linkname, target); err != nil {
+		return wrapErr(ErrUnpack, err, "create symlink %s", target)
+	}
+	return nil
+}
+
+// fileMode converts a tar header mode (an int64 of Unix permission bits)
+// into an os.FileMode, preserving the executable bits.
+func fileMode(m int64) os.FileMode {
+	return os.FileMode(m).Perm()
+}

--- a/internal/sandbox/nodedist/unpack_internal_test.go
+++ b/internal/sandbox/nodedist/unpack_internal_test.go
@@ -1,0 +1,345 @@
+package nodedist
+
+import (
+	"archive/tar"
+	"archive/zip"
+	"bytes"
+	"compress/gzip"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+const testDistro = "node-v24.2.0-linux-x64"
+
+func tarGz(t *testing.T, write func(tw *tar.Writer)) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	gz := gzip.NewWriter(&buf)
+	tw := tar.NewWriter(gz)
+	write(tw)
+	if err := tw.Close(); err != nil {
+		t.Fatalf("close tar: %v", err)
+	}
+	if err := gz.Close(); err != nil {
+		t.Fatalf("close gzip: %v", err)
+	}
+	return buf.Bytes()
+}
+
+func TestUnpackTarGz_LayoutAndExecBit(t *testing.T) {
+	data := tarGz(t, func(tw *tar.Writer) {
+		writeTarDir(t, tw, testDistro+"/")
+		writeTarDir(t, tw, testDistro+"/bin/")
+		writeTarFile(t, tw, testDistro+"/bin/node", []byte("#!node"), 0o755)
+		writeTarFile(t, tw, testDistro+"/README.md", []byte("readme"), 0o644)
+	})
+
+	dest := t.TempDir()
+	if err := unpackArchive(data, "tar.gz", testDistro, dest); err != nil {
+		t.Fatalf("unpackArchive: %v", err)
+	}
+
+	// Top-level prefix stripped: bin/node sits directly under dest.
+	nodePath := filepath.Join(dest, "bin", "node")
+	got, err := os.ReadFile(nodePath)
+	if err != nil {
+		t.Fatalf("read bin/node: %v", err)
+	}
+	if string(got) != "#!node" {
+		t.Fatalf("bin/node content = %q", got)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(nodePath)
+		if err != nil {
+			t.Fatalf("stat bin/node: %v", err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Fatalf("bin/node lost its executable bit: %v", info.Mode())
+		}
+	}
+	if _, err := os.Stat(filepath.Join(dest, "README.md")); err != nil {
+		t.Fatalf("README.md not unpacked: %v", err)
+	}
+}
+
+// TestUnpackTarGz_DoesNotEscapeViaTraversal proves the contract: no archive
+// entry, however its name is crafted, can write a file outside the unpack
+// target. Entries whose names traverse out of the distro prefix are dropped;
+// entries whose cleaned path would still escape are rejected. Either way,
+// nothing lands next to dest.
+func TestUnpackTarGz_DoesNotEscapeViaTraversal(t *testing.T) {
+	data := tarGz(t, func(tw *tar.Writer) {
+		writeTarDir(t, tw, testDistro+"/")
+		writeTarFile(t, tw, testDistro+"/../escape.txt", []byte("pwned"), 0o644)
+		writeTarFile(t, tw, testDistro+"/sub/../../escape2.txt", []byte("pwned"), 0o644)
+		writeTarFile(t, tw, testDistro+"/bin/node", []byte("ok"), 0o755)
+	})
+
+	dest := t.TempDir()
+	if err := unpackArchive(data, "tar.gz", testDistro, dest); err != nil {
+		t.Fatalf("unpackArchive: %v", err)
+	}
+	// Legitimate entry still landed.
+	if _, err := os.Stat(filepath.Join(dest, "bin", "node")); err != nil {
+		t.Fatalf("legitimate entry not unpacked: %v", err)
+	}
+	// Nothing escaped to the parent of dest.
+	parent := filepath.Dir(dest)
+	for _, name := range []string{"escape.txt", "escape2.txt"} {
+		if _, err := os.Stat(filepath.Join(parent, name)); err == nil {
+			t.Fatalf("traversal entry %q wrote a file outside the unpack target", name)
+		}
+	}
+}
+
+// TestSafeJoin_RejectsTraversal exercises the path-traversal guard directly:
+// any relative path that resolves outside dest is rejected with ErrUnpack.
+func TestSafeJoin_RejectsTraversal(t *testing.T) {
+	dest := t.TempDir()
+	for _, rel := range []string{"../escape", "a/../../escape", "../../../../etc/passwd"} {
+		_, err := safeJoin(dest, rel)
+		if err == nil {
+			t.Fatalf("safeJoin(%q) accepted an escaping path", rel)
+		}
+		var ndErr *Error
+		if !errors.As(err, &ndErr) || ndErr.Kind != ErrUnpack {
+			t.Fatalf("safeJoin(%q) error = %v, want ErrUnpack", rel, err)
+		}
+	}
+	// A legitimate nested path is accepted.
+	got, err := safeJoin(dest, "bin/node")
+	if err != nil {
+		t.Fatalf("safeJoin legit: %v", err)
+	}
+	if got != filepath.Join(dest, "bin", "node") {
+		t.Fatalf("safeJoin legit = %q", got)
+	}
+}
+
+func TestUnpackTarGz_RejectsSymlinkEscape(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	data := tarGz(t, func(tw *tar.Writer) {
+		writeTarDir(t, tw, testDistro+"/")
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     testDistro + "/evil",
+			Typeflag: tar.TypeSymlink,
+			Linkname: "../../etc/passwd",
+			Mode:     0o777,
+		}); err != nil {
+			t.Fatalf("write symlink header: %v", err)
+		}
+	})
+	dest := t.TempDir()
+	err := unpackArchive(data, "tar.gz", testDistro, dest)
+	if err == nil {
+		t.Fatalf("unpackArchive accepted an escaping symlink")
+	}
+	var ndErr *Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != ErrUnpack {
+		t.Fatalf("error = %v, want ErrUnpack", err)
+	}
+}
+
+func TestUnpackZip_LayoutAndExecBit(t *testing.T) {
+	winDistro := "node-v24.2.0-win-x64"
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	writeZipFile(t, zw, winDistro+"/node.exe", []byte("MZexe"), 0o755)
+	writeZipFile(t, zw, winDistro+"/npm.cmd", []byte("@echo"), 0o644)
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	dest := t.TempDir()
+	if err := unpackArchive(buf.Bytes(), "zip", winDistro, dest); err != nil {
+		t.Fatalf("unpackArchive zip: %v", err)
+	}
+	got, err := os.ReadFile(filepath.Join(dest, "node.exe"))
+	if err != nil {
+		t.Fatalf("read node.exe: %v", err)
+	}
+	if string(got) != "MZexe" {
+		t.Fatalf("node.exe content = %q", got)
+	}
+	if runtime.GOOS != "windows" {
+		info, err := os.Stat(filepath.Join(dest, "node.exe"))
+		if err != nil {
+			t.Fatalf("stat node.exe: %v", err)
+		}
+		if info.Mode().Perm()&0o111 == 0 {
+			t.Fatalf("node.exe lost exec bit: %v", info.Mode())
+		}
+	}
+}
+
+func TestUnpackZip_DoesNotEscapeViaTraversal(t *testing.T) {
+	winDistro := "node-v24.2.0-win-x64"
+	var buf bytes.Buffer
+	zw := zip.NewWriter(&buf)
+	// CreateHeader does not sanitize names; craft traversal entries.
+	for _, name := range []string{winDistro + "/../escape.txt", winDistro + "/a/../../escape2.txt"} {
+		w, err := zw.CreateHeader(&zip.FileHeader{Name: name, Method: zip.Store})
+		if err != nil {
+			t.Fatalf("create header %s: %v", name, err)
+		}
+		if _, err := w.Write([]byte("pwned")); err != nil {
+			t.Fatalf("write %s: %v", name, err)
+		}
+	}
+	// A legitimate entry to confirm the unpack still works.
+	writeZipFile(t, zw, winDistro+"/node.exe", []byte("ok"), 0o755)
+	if err := zw.Close(); err != nil {
+		t.Fatalf("close zip: %v", err)
+	}
+
+	dest := t.TempDir()
+	if err := unpackArchive(buf.Bytes(), "zip", winDistro, dest); err != nil {
+		t.Fatalf("unpackArchive: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(dest, "node.exe")); err != nil {
+		t.Fatalf("legitimate entry not unpacked: %v", err)
+	}
+	parent := filepath.Dir(dest)
+	for _, name := range []string{"escape.txt", "escape2.txt"} {
+		if _, err := os.Stat(filepath.Join(parent, name)); err == nil {
+			t.Fatalf("traversal entry %q escaped the unpack target", name)
+		}
+	}
+}
+
+func TestUnpackTarGz_RecreatesInternalSymlink(t *testing.T) {
+	if runtime.GOOS == "windows" {
+		t.Skip("symlink semantics differ on Windows")
+	}
+	data := tarGz(t, func(tw *tar.Writer) {
+		writeTarDir(t, tw, testDistro+"/")
+		writeTarDir(t, tw, testDistro+"/bin/")
+		writeTarFile(t, tw, testDistro+"/bin/node", []byte("#!node"), 0o755)
+		// A relative symlink that stays inside the tree, as real Node
+		// archives contain (e.g. npx -> ../lib/node_modules/...).
+		if err := tw.WriteHeader(&tar.Header{
+			Name:     testDistro + "/bin/nodealias",
+			Typeflag: tar.TypeSymlink,
+			Linkname: "node",
+			Mode:     0o777,
+		}); err != nil {
+			t.Fatalf("write symlink header: %v", err)
+		}
+	})
+
+	dest := t.TempDir()
+	if err := unpackArchive(data, "tar.gz", testDistro, dest); err != nil {
+		t.Fatalf("unpackArchive: %v", err)
+	}
+	link := filepath.Join(dest, "bin", "nodealias")
+	got, err := os.Readlink(link)
+	if err != nil {
+		t.Fatalf("readlink: %v", err)
+	}
+	if got != "node" {
+		t.Fatalf("symlink target = %q, want %q", got, "node")
+	}
+	// And it resolves to the real file.
+	body, err := os.ReadFile(link)
+	if err != nil {
+		t.Fatalf("read through symlink: %v", err)
+	}
+	if string(body) != "#!node" {
+		t.Fatalf("resolved symlink content = %q", body)
+	}
+}
+
+func TestUnpackArchive_UnsupportedExtension(t *testing.T) {
+	err := unpackArchive([]byte("x"), "rar", testDistro, t.TempDir())
+	if err == nil {
+		t.Fatalf("unpackArchive accepted an unsupported extension")
+	}
+	var ndErr *Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != ErrUnpack {
+		t.Fatalf("error = %v, want ErrUnpack", err)
+	}
+}
+
+func TestNodeBinaryPath_WindowsAndUnix(t *testing.T) {
+	unix := nodeBinaryPath("/cache/abc", Target{GOOS: "linux", GOARCH: "amd64"})
+	if unix != filepath.Join("/cache/abc", "bin", "node") {
+		t.Errorf("unix node binary path = %q", unix)
+	}
+	win := nodeBinaryPath("/cache/abc", Target{GOOS: "windows", GOARCH: "amd64"})
+	if win != filepath.Join("/cache/abc", "node.exe") {
+		t.Errorf("windows node binary path = %q", win)
+	}
+}
+
+func TestWriteRegular_EnforcesRemainingCap(t *testing.T) {
+	dir := t.TempDir()
+
+	// remaining <= 0 is rejected immediately.
+	if _, err := writeRegular(filepath.Join(dir, "a"), bytes.NewReader([]byte("x")), 0o644, 0); err == nil {
+		t.Fatalf("writeRegular accepted remaining=0")
+	}
+
+	// A body larger than remaining is rejected as ErrUnpack.
+	body := bytes.Repeat([]byte("z"), 100)
+	_, err := writeRegular(filepath.Join(dir, "b"), bytes.NewReader(body), 0o644, 10)
+	if err == nil {
+		t.Fatalf("writeRegular accepted a body exceeding the cap")
+	}
+	var ndErr *Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != ErrUnpack {
+		t.Fatalf("error = %v, want ErrUnpack", err)
+	}
+
+	// A body within the cap is written verbatim.
+	n, err := writeRegular(filepath.Join(dir, "c"), bytes.NewReader([]byte("hello")), 0o644, 100)
+	if err != nil {
+		t.Fatalf("writeRegular within cap: %v", err)
+	}
+	if n != 5 {
+		t.Fatalf("writeRegular wrote %d bytes, want 5", n)
+	}
+	got, _ := os.ReadFile(filepath.Join(dir, "c"))
+	if string(got) != "hello" {
+		t.Fatalf("written content = %q", got)
+	}
+}
+
+func writeTarDir(t *testing.T, tw *tar.Writer, name string) {
+	t.Helper()
+	if err := tw.WriteHeader(&tar.Header{Name: name, Typeflag: tar.TypeDir, Mode: 0o755}); err != nil {
+		t.Fatalf("write dir %s: %v", name, err)
+	}
+}
+
+func writeTarFile(t *testing.T, tw *tar.Writer, name string, body []byte, mode int64) {
+	t.Helper()
+	if err := tw.WriteHeader(&tar.Header{
+		Name:     name,
+		Typeflag: tar.TypeReg,
+		Mode:     mode,
+		Size:     int64(len(body)),
+	}); err != nil {
+		t.Fatalf("write header %s: %v", name, err)
+	}
+	if _, err := tw.Write(body); err != nil {
+		t.Fatalf("write body %s: %v", name, err)
+	}
+}
+
+func writeZipFile(t *testing.T, zw *zip.Writer, name string, body []byte, mode int64) {
+	t.Helper()
+	hdr := &zip.FileHeader{Name: name, Method: zip.Deflate}
+	hdr.SetMode(os.FileMode(mode).Perm())
+	w, err := zw.CreateHeader(hdr)
+	if err != nil {
+		t.Fatalf("create zip entry %s: %v", name, err)
+	}
+	if _, err := w.Write(body); err != nil {
+		t.Fatalf("write zip entry %s: %v", name, err)
+	}
+}

--- a/internal/sandbox/nodedist/verify.go
+++ b/internal/sandbox/nodedist/verify.go
@@ -1,0 +1,100 @@
+package nodedist
+
+import (
+	"bytes"
+	"strings"
+
+	"golang.org/x/crypto/openpgp" //nolint:staticcheck // openpgp is the GPG detached-signature primitive Node release verification needs; no maintained in-tree replacement.
+)
+
+// Checksums maps an artifact filename to its lowercase hex SHA-256, as
+// published in a verified SHASUMS256.txt.
+type Checksums map[string]string
+
+// ChecksumVerifier verifies Node's SHASUMS256.txt against its detached PGP
+// signature and exposes the verified filename → sha256hex entries. Its
+// contract: a checksum is only ever returned after the signature over the
+// whole file has been verified against the trusted keyring, so a caller can
+// never act on an unsigned or tampered checksum.
+type ChecksumVerifier struct {
+	// Keyring is the set of trusted Node release public keys. A nil or empty
+	// keyring causes VerifyAndParse to fail closed (every signature is
+	// untrusted).
+	Keyring openpgp.EntityList
+}
+
+// VerifyAndParse checks the detached armored signature sig over the
+// SHASUMS256.txt bytes checksums against the verifier's keyring, and only on
+// success parses and returns the verified filename → sha256hex map.
+//
+// Order matters and is part of the contract: the signature is verified
+// first. On a bad signature (wrong key, tampered body, malformed armor) it
+// returns an ErrBadSignature-kind error and no entries — nothing in the file
+// is trusted. Only after the signature verifies are the lines parsed.
+func (v ChecksumVerifier) VerifyAndParse(checksums, sig []byte) (Checksums, error) {
+	if len(v.Keyring) == 0 {
+		return nil, wrapErr(ErrBadSignature, nil, "no trusted Node release keys configured")
+	}
+	_, err := openpgp.CheckArmoredDetachedSignature(
+		v.Keyring,
+		bytes.NewReader(checksums),
+		bytes.NewReader(sig),
+	)
+	if err != nil {
+		return nil, wrapErr(ErrBadSignature, err, "SHASUMS256.txt signature did not verify")
+	}
+	return parseChecksums(checksums)
+}
+
+// parseChecksums decodes a SHASUMS256.txt body into a filename → sha256hex
+// map. Each non-blank line is "<64-hex>  <filename>" (two-space separator,
+// per coreutils sha256sum). A leading "*" binary marker on the filename is
+// stripped. Blank lines are skipped; a malformed line is an error so a
+// truncated or corrupt file is never silently accepted.
+func parseChecksums(body []byte) (Checksums, error) {
+	out := Checksums{}
+	for i, raw := range strings.Split(string(body), "\n") {
+		line := strings.TrimRight(raw, "\r")
+		if strings.TrimSpace(line) == "" {
+			continue
+		}
+		// Split on the first run of spaces: "<hex>  <name>".
+		fields := strings.SplitN(line, " ", 2)
+		if len(fields) != 2 {
+			return nil, wrapErr(ErrChecksumParse, nil, "malformed checksum line %d: %q", i+1, line)
+		}
+		hexDigest := fields[0]
+		name := strings.TrimLeft(fields[1], " ")
+		name = strings.TrimPrefix(name, "*") // binary-mode marker
+		if !isSHA256Hex(hexDigest) {
+			return nil, wrapErr(ErrChecksumParse, nil, "malformed checksum digest on line %d: %q", i+1, hexDigest)
+		}
+		if name == "" {
+			return nil, wrapErr(ErrChecksumParse, nil, "missing filename on checksum line %d", i+1)
+		}
+		out[name] = strings.ToLower(hexDigest)
+	}
+	if len(out) == 0 {
+		return nil, wrapErr(ErrChecksumParse, nil, "SHASUMS256.txt contained no checksum entries")
+	}
+	return out, nil
+}
+
+// isSHA256Hex reports whether s is exactly 64 lowercase-or-uppercase hex
+// characters.
+func isSHA256Hex(s string) bool {
+	if len(s) != 64 {
+		return false
+	}
+	for i := 0; i < len(s); i++ {
+		c := s[i]
+		switch {
+		case c >= '0' && c <= '9':
+		case c >= 'a' && c <= 'f':
+		case c >= 'A' && c <= 'F':
+		default:
+			return false
+		}
+	}
+	return true
+}

--- a/internal/sandbox/nodedist/verify_test.go
+++ b/internal/sandbox/nodedist/verify_test.go
@@ -1,0 +1,104 @@
+package nodedist_test
+
+import (
+	"errors"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/sandbox/nodedist"
+)
+
+const sampleChecksums = "" +
+	"1111111111111111111111111111111111111111111111111111111111111111  node-v24.2.0-linux-x64.tar.gz\n" +
+	"2222222222222222222222222222222222222222222222222222222222222222  node-v24.2.0-darwin-arm64.tar.gz\n" +
+	"3333333333333333333333333333333333333333333333333333333333333333 *node-v24.2.0-win-x64.zip\n"
+
+func TestVerifyAndParse_HappyPath(t *testing.T) {
+	signer, keyring := newTestSigner(t)
+	body := []byte(sampleChecksums)
+	sig := armoredDetachedSign(t, signer, body)
+
+	v := nodedist.ChecksumVerifier{Keyring: keyring}
+	sums, err := v.VerifyAndParse(body, sig)
+	if err != nil {
+		t.Fatalf("VerifyAndParse: %v", err)
+	}
+	if got := sums["node-v24.2.0-linux-x64.tar.gz"]; got != "1111111111111111111111111111111111111111111111111111111111111111" {
+		t.Errorf("linux hash = %q", got)
+	}
+	// The "*" binary-mode marker must be stripped from the filename.
+	if got, ok := sums["node-v24.2.0-win-x64.zip"]; !ok || got != "3333333333333333333333333333333333333333333333333333333333333333" {
+		t.Errorf("win zip entry = %q ok=%v", got, ok)
+	}
+}
+
+func TestVerifyAndParse_BadSignatureWrongKey(t *testing.T) {
+	signer, _ := newTestSigner(t)
+	_, otherKeyring := newTestSigner(t) // a different key
+	body := []byte(sampleChecksums)
+	sig := armoredDetachedSign(t, signer, body)
+
+	v := nodedist.ChecksumVerifier{Keyring: otherKeyring}
+	sums, err := v.VerifyAndParse(body, sig)
+	if err == nil {
+		t.Fatalf("VerifyAndParse accepted a signature from an untrusted key")
+	}
+	if sums != nil {
+		t.Fatalf("entries returned despite bad signature: %v", sums)
+	}
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrBadSignature {
+		t.Fatalf("error = %v, want ErrBadSignature", err)
+	}
+}
+
+func TestVerifyAndParse_TamperedBody(t *testing.T) {
+	signer, keyring := newTestSigner(t)
+	body := []byte(sampleChecksums)
+	sig := armoredDetachedSign(t, signer, body)
+
+	tampered := append([]byte{}, body...)
+	tampered[0] = '9' // flip a digit in the first hash
+
+	v := nodedist.ChecksumVerifier{Keyring: keyring}
+	_, err := v.VerifyAndParse(tampered, sig)
+	if err == nil {
+		t.Fatalf("VerifyAndParse accepted a tampered checksums body")
+	}
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrBadSignature {
+		t.Fatalf("error = %v, want ErrBadSignature", err)
+	}
+}
+
+func TestVerifyAndParse_EmptyKeyringFailsClosed(t *testing.T) {
+	signer, _ := newTestSigner(t)
+	body := []byte(sampleChecksums)
+	sig := armoredDetachedSign(t, signer, body)
+
+	v := nodedist.ChecksumVerifier{Keyring: nil}
+	_, err := v.VerifyAndParse(body, sig)
+	if err == nil {
+		t.Fatalf("VerifyAndParse accepted with no trusted keys")
+	}
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrBadSignature {
+		t.Fatalf("error = %v, want ErrBadSignature", err)
+	}
+}
+
+func TestVerifyAndParse_MalformedLine(t *testing.T) {
+	signer, keyring := newTestSigner(t)
+	// Valid signature over a body with a malformed line (short digest).
+	body := []byte("deadbeef  node-v24.2.0-linux-x64.tar.gz\n")
+	sig := armoredDetachedSign(t, signer, body)
+
+	v := nodedist.ChecksumVerifier{Keyring: keyring}
+	_, err := v.VerifyAndParse(body, sig)
+	if err == nil {
+		t.Fatalf("VerifyAndParse accepted a malformed checksum line")
+	}
+	var ndErr *nodedist.Error
+	if !errors.As(err, &ndErr) || ndErr.Kind != nodedist.ErrChecksumParse {
+		t.Fatalf("error = %v, want ErrChecksumParse", err)
+	}
+}


### PR DESCRIPTION
## Summary

Part of #1525 (sub-issue 1). Adds `internal/sandbox/nodedist`, a self-contained package that fetches a pinned Node distribution by version + GOOS/GOARCH from nodejs.org and provisions it through a supply-chain-verified pipeline that mirrors the connector install flow: **fetch → verify → hash-match → unpack → content-addressed cache**.

What it does:

- Maps `(version, goos, goarch)` to the nodejs.org archive / `SHASUMS256.txt` / `SHASUMS256.txt.asc` URLs and the `node-v<ver>-<os>-<arch>` archive naming (`.tar.gz` on Unix, `.zip` on Windows). Unsupported pairs fail fast.
- Verifies `SHASUMS256.txt` against its detached GPG signature (`golang.org/x/crypto/openpgp`, already a direct dep) **before** any checksum is trusted, then parses the verified `filename → sha256hex` entries.
- Downloads the selected archive, SHA-256-matches it against the signed checksum (rejects on mismatch, commits nothing), unpacks it (tar.gz + zip, top-level prefix stripped, zip-slip / symlink-escape guarded, decompression-size capped), and caches the unpacked tree content-addressed under the **verified archive hash**.
- Cache short-circuit: a request whose verified hash is already cached returns without re-downloading the archive.

Reuses rather than duplicates:

- `cstore.Fetcher` / `HTTPFetcher` for all three downloads.
- A new exported, content-agnostic atomic-rename directory commit extracted from the connector store's private `commit`: `cstore.CommitDir(root, hashHex, write)` + `HasDirHash` / `DirEntryDir`. The connector `commit` now delegates to it (behavior preserving), so the Node cache reuses the same CAS + race-reconcile discipline. The Node cache lives under `<store>/node/sha256/<hex>/`, disjoint from `connectors/`.

The GPG flow is a focused package-local `ChecksumVerifier`, not a `cstore.Verifier` impl: Node's "detached PGP signature over a checksums file" does not fit `cstore.Verifier`'s `(authority, binary, manifest, signature)` Ed25519 shape, and forcing it through would abuse the interface.

### Scope (explicitly out, per the umbrella)

No wiring into `runtime.go` / `devcontainerCLI` (sub-issue 4), no committed version/checksum lock (sub-issue 3), no arch generalization beyond the minimal total mapping (sub-issue 2), no `@devcontainers/cli` fetch (Node only), no `warm`/offline command (sub-issue 6), no docs (land with the wiring). No OpenAPI surface touched.

## Test plan

Contract-level tests, no network, using an in-memory `cstore.Fetcher` (with a call log) + a self-generated test PGP key + synthesized archives:

- URL/naming/arch mapping per platform incl. Windows `.zip`; unsupported pair and empty version rejected.
- Signature verify: valid signature verifies + parses; **wrong-key and tampered-body rejection** (no entries returned); empty keyring fails closed; malformed checksum line rejected.
- Unpack: tar.gz + zip layouts with exec-bit preservation and prefix-strip; path-traversal entries never escape the target; escaping symlink rejected; internal symlink recreated; decompression-size cap enforced.
- Orchestration acceptance set: **happy path** (verify + sha256-match + unpack → runnable `bin/node`, cache key = verified hash); **checksum-mismatch rejection** (nothing committed); **bad-signature rejection before the archive is fetched** (asserted via the fetcher call log; nothing committed); **cache short-circuit** (archive URL not requested on a cache hit); unpack-failure surfaces as `ErrUnpack` (not reclassified) and commits nothing; config validation; fetch-failure propagation.
- `cstore.CommitDir`: happy commit, benign duplicate/concurrent convergence (race-detector clean), distinct-hash isolation, invalid-hash rejection before the callback runs, verbatim callback-error passthrough.

`go test ./...` from `internal/` is green; `go vet` and `gofmt` clean. Coverage: nodedist 85.9%, cstore 88.8%.

> CodeRabbit CLI was rate-limited (free tier) at review time; a manual self-review pass found and fixed the error-classification flattening through `CommitDir` (now returns callback errors verbatim).

Closes #1526
