### PR TITLE
fix(test): make aileron launch system tests runnable

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -541,6 +541,7 @@ tasks:
     cmds:
       - sh "{{.ROOT_DIR}}/test/system/lib/assert_test.sh"
       - sh "{{.ROOT_DIR}}/test/system/lib/probes_test.sh"
+      - sh "{{.ROOT_DIR}}/test/system/lib/taskenv_test.sh"
 
   test:system:smoke:
     desc: >-
@@ -613,6 +614,16 @@ tasks:
         sh: echo "codex-$(date +%s)-$$"
       WORKSPACE:
         sh: mktemp -d 2>/dev/null || mktemp -d -t aileron-codex
+    # Task-scoped env: go-task only honors `env:` at the task level, not on an
+    # individual `cmds:` entry (a command-level `env:` is silently ignored), so
+    # the scenario script must receive AILERON_BIN et al. from here. Keeping it
+    # task-scoped also exports the vars to the `defer`/precond cmds uniformly.
+    env:
+      AILERON_BIN: '{{.ROOT_DIR}}/build/aileron'
+      AILERON_SYSTEST_LIB: '{{.ROOT_DIR}}/test/system/lib'
+      WORKSPACE: '{{.WORKSPACE}}'
+      AILERON_STATE_DIR:
+        sh: echo "${AILERON_STATE_DIR:-$HOME/.aileron}"
     cmds:
       # Register cleanup FIRST so a failed precondition (Docker down or codex
       # auth absent) still removes the mktemp WORKSPACE created by the dynamic
@@ -622,12 +633,6 @@ tasks:
         vars:
           AGENT: codex
       - cmd: sh "{{.ROOT_DIR}}/test/system/codex.sh"
-        env:
-          AILERON_BIN: '{{.ROOT_DIR}}/build/aileron'
-          AILERON_SYSTEST_LIB: '{{.ROOT_DIR}}/test/system/lib'
-          WORKSPACE: '{{.WORKSPACE}}'
-          AILERON_STATE_DIR:
-            sh: echo "${AILERON_STATE_DIR:-$HOME/.aileron}"
 
   test:system:launch:claude:
     desc: >-
@@ -649,6 +654,16 @@ tasks:
         sh: echo "claude-$(date +%s)-$$"
       WORKSPACE:
         sh: mktemp -d 2>/dev/null || mktemp -d -t aileron-claude
+    # Task-scoped env: go-task only honors `env:` at the task level, not on an
+    # individual `cmds:` entry (a command-level `env:` is silently ignored), so
+    # the scenario script must receive AILERON_BIN et al. from here. Keeping it
+    # task-scoped also exports the vars to the `defer`/precond cmds uniformly.
+    env:
+      AILERON_BIN: '{{.ROOT_DIR}}/build/aileron'
+      AILERON_SYSTEST_LIB: '{{.ROOT_DIR}}/test/system/lib'
+      WORKSPACE: '{{.WORKSPACE}}'
+      AILERON_STATE_DIR:
+        sh: echo "${AILERON_STATE_DIR:-$HOME/.aileron}"
     cmds:
       # Register cleanup FIRST so a failed precondition (Docker down or claude
       # auth absent) still removes the mktemp WORKSPACE created by the dynamic
@@ -658,12 +673,6 @@ tasks:
         vars:
           AGENT: claude
       - cmd: sh "{{.ROOT_DIR}}/test/system/claude.sh"
-        env:
-          AILERON_BIN: '{{.ROOT_DIR}}/build/aileron'
-          AILERON_SYSTEST_LIB: '{{.ROOT_DIR}}/test/system/lib'
-          WORKSPACE: '{{.WORKSPACE}}'
-          AILERON_STATE_DIR:
-            sh: echo "${AILERON_STATE_DIR:-$HOME/.aileron}"
 
   test:e2e:integration:
     desc: Run Playwright E2E tests against running services

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -21,6 +21,8 @@ test/system/
     probes.sh          agent-agnostic R8 wiring-invariant probes (sourced)
     assert_test.sh     contract tests for assert.sh   (CI-safe, no Docker)
     probes_test.sh     contract tests for probes.sh   (CI-safe, stubbed docker)
+    taskenv_test.sh    regression: launch targets export AILERON_BIN et al.
+                       at task scope, where go-task honors `env:` (CI-safe)
 ```
 
 ## Static gate (what runs unattended vs. by hand)

--- a/test/system/claude.sh
+++ b/test/system/claude.sh
@@ -105,7 +105,10 @@ LAUNCH_LOG="$WORKSPACE/.launch.log"
 	# --sandbox=docker is the claude default (cmd/aileron/main.go), so we do
 	# not pass an explicit sandbox flag — the run also asserts that default.
 	"$AILERON_BIN" launch "$AGENT" -- -p "$EXEC_PROMPT"
-) >"$LAUNCH_LOG" 2>&1 &
+# stdin from /dev/null (matching codex.sh): the launch is headless, claude -p
+# takes its prompt as an arg, and backgrounding already yields /dev/null stdin
+# by POSIX — making it explicit keeps the two scenarios symmetric.
+) </dev/null >"$LAUNCH_LOG" 2>&1 &
 LAUNCH_PID=$!
 
 # Under `set -e` a failing probe aborts the script before the explicit
@@ -132,7 +135,11 @@ while [ "$i" -lt 120 ]; do
 		log "launch exited before container probe window; continuing to post-run checks"
 		break
 	fi
-	if container="$(discover_container "$AILERON_SBX_PREFIX")"; then
+	# A zero-match is expected while the container is still coming up (image
+	# resolve + create takes a few seconds), so suppress discover_container's
+	# per-poll "no running container" diagnostic here — a genuine timeout is
+	# reported by the explicit `fail` after the loop.
+	if container="$(discover_container "$AILERON_SBX_PREFIX" 2>/dev/null)"; then
 		break
 	fi
 	container=''

--- a/test/system/codex.sh
+++ b/test/system/codex.sh
@@ -70,19 +70,27 @@ EXEC_PROMPT="Do exactly two things and then stop. \
 log "codex scenario: runid=${RUNID} workspace=${WORKSPACE} image=${EXPECTED_IMAGE}"
 
 # --- launch (R7a arg-forwarding asserted: post-\`--\` tokens reach codex) -----
-# `-- exec "<prompt>"` forwards verbatim through LaunchConfig.Args
-# (cmd/aileron/main.go applyTrailingLaunchFlags) ->
+# `-- exec --skip-git-repo-check "<prompt>"` forwards verbatim through
+# LaunchConfig.Args (cmd/aileron/main.go applyTrailingLaunchFlags) ->
 # launcher.go `command = append(command, config.Args...)` ->
 # runtime.go image then opts.Command. We run the launch in the background so
 # the live-container probes can inspect the container while codex is still
 # resident, then reap the exit code.
+#
+# `--skip-git-repo-check` is required: codex exec refuses to run in a directory
+# that is not a trusted/git workspace ("Not inside a trusted directory and
+# --skip-git-repo-check was not specified"), and the mounted workspace
+# (/home/agent/workspace) is a bare temp dir, not a git repo. Without the flag
+# codex exits immediately, the container stops, and the R8.1 .State.Running
+# probe fails. stdin is redirected from /dev/null so codex exec never blocks
+# waiting for piped instructions (the prompt is supplied as an arg).
 LAUNCH_LOG="$WORKSPACE/.launch.log"
 (
 	cd "$WORKSPACE"
 	# --sandbox=docker is the codex default (cmd/aileron/main.go), so we do
 	# not pass an explicit sandbox flag — the run also asserts that default.
-	"$AILERON_BIN" launch "$AGENT" -- exec "$EXEC_PROMPT"
-) >"$LAUNCH_LOG" 2>&1 &
+	"$AILERON_BIN" launch "$AGENT" -- exec --skip-git-repo-check "$EXEC_PROMPT"
+) </dev/null >"$LAUNCH_LOG" 2>&1 &
 LAUNCH_PID=$!
 
 # Under `set -e` a failing probe aborts the script before the explicit
@@ -109,7 +117,11 @@ while [ "$i" -lt 120 ]; do
 		log "launch exited before container probe window; continuing to post-run checks"
 		break
 	fi
-	if container="$(discover_container "$AILERON_SBX_PREFIX")"; then
+	# A zero-match is expected while the container is still coming up (image
+	# resolve + create takes a few seconds), so suppress discover_container's
+	# per-poll "no running container" diagnostic here — a genuine timeout is
+	# reported by the explicit `fail` after the loop.
+	if container="$(discover_container "$AILERON_SBX_PREFIX" 2>/dev/null)"; then
 		break
 	fi
 	container=''

--- a/test/system/lib/taskenv_test.sh
+++ b/test/system/lib/taskenv_test.sh
@@ -1,0 +1,151 @@
+#!/bin/sh
+# test/system/lib/taskenv_test.sh
+#
+# Regression contract for the env wiring of the run-by-hand launch scenarios
+# (test:system:launch:codex / :claude). Pure POSIX shell + the `task` binary
+# the lib tier already runs under, no Docker and no `aileron launch`, so it is
+# CI-safe and unattended.
+#
+# Why this exists (#1485 regression): the scenario scripts require AILERON_BIN,
+# AILERON_SYSTEST_LIB and WORKSPACE in their environment (codex.sh/claude.sh
+# fail-fast with `: "${AILERON_BIN:?...}"`). The original wiring declared those
+# under an individual `cmds:` entry's `env:` — but go-task ONLY honors `env:`
+# at the task level; a command-scoped `env:` is silently dropped. The dry-run
+# wiring check (`task --dry`) cannot observe env, so nothing caught it and every
+# live run aborted at line 1 of the scenario with "AILERON_BIN must point at the
+# built aileron binary". This test pins both halves of the contract:
+#   A. behavioral — task-scoped `env:` reaches the invoked script (and a
+#      command-scoped `env:` does not), proving the shape the fix depends on.
+#   B. structural — the real Taskfile's launch targets keep AILERON_BIN et al.
+#      at task scope, so moving them back under a `cmds:` entry fails here
+#      rather than silently at the next by-hand run.
+#
+# Run: sh test/system/lib/taskenv_test.sh   (exit 0 = all cases pass)
+
+set -u
+
+HERE="$(CDPATH='' cd -- "$(dirname -- "$0")" && pwd)"
+# test/system/lib -> repo root
+ROOT="$(CDPATH='' cd -- "$HERE/../../.." && pwd)"
+TASKFILE="$ROOT/Taskfile.yml"
+
+failures=0
+pass() { printf 'PASS: %s\n' "$1"; }
+report() {
+	# $1 description, $2 ok(0/1)
+	if [ "$2" -eq 0 ]; then pass "$1"; else
+		printf 'FAIL: %s\n' "$1" >&2
+		failures=$((failures + 1))
+	fi
+}
+
+if ! command -v task >/dev/null 2>&1; then
+	# shellcheck disable=SC2016  # the backticks here are literal prose, not a subshell
+	printf 'FAIL: `task` binary not on PATH (required to validate env wiring)\n' >&2
+	exit 1
+fi
+
+WORK="$(mktemp -d 2>/dev/null || mktemp -d -t aileron-taskenv)"
+trap 'rm -rf "$WORK"' EXIT INT TERM
+
+# --- A. behavioral: prove go-task's task- vs command-scope env semantics -----
+# A probe script the generated tasks invoke; it echoes what it received so we
+# can assert from the host side rather than trusting the task echo.
+cat >"$WORK/probe.sh" <<'PROBE'
+#!/bin/sh
+echo "PROBE_BIN=[${AILERON_BIN:-}]"
+PROBE
+
+# task-scoped env MUST reach the script.
+cat >"$WORK/Taskfile.task.yml" <<EOF
+version: '3'
+tasks:
+  t:
+    env:
+      AILERON_BIN: 'task-scope-value'
+    cmds:
+      - cmd: sh "$WORK/probe.sh"
+EOF
+out_task="$(task -t "$WORK/Taskfile.task.yml" t 2>/dev/null)"
+case "$out_task" in
+	*"PROBE_BIN=[task-scope-value]"*) report "task-scoped env reaches the scenario script" 0 ;;
+	*) report "task-scoped env reaches the scenario script" 1 ;;
+esac
+
+# command-scoped env must NOT reach the script — this is the footgun the fix
+# routes around; asserting it documents why the env lives at task scope.
+cat >"$WORK/Taskfile.cmd.yml" <<EOF
+version: '3'
+tasks:
+  t:
+    cmds:
+      - cmd: sh "$WORK/probe.sh"
+        env:
+          AILERON_BIN: 'cmd-scope-value'
+EOF
+out_cmd="$(task -t "$WORK/Taskfile.cmd.yml" t 2>/dev/null)"
+case "$out_cmd" in
+	*"PROBE_BIN=[cmd-scope-value]"*) report "command-scoped env is dropped by go-task (regression footgun)" 1 ;;
+	*) report "command-scoped env is dropped by go-task (regression footgun)" 0 ;;
+esac
+
+# --- B. structural: the real launch targets keep env at task scope -----------
+# For each target block, every required key must appear at the 6-space indent
+# of a task-level `env:` child, and never at the 10-space indent of an `env:`
+# nested under a `- cmd:` list item. awk extracts the block from its header to
+# the next top-level (2-space) task key.
+required_keys='AILERON_BIN AILERON_SYSTEST_LIB WORKSPACE'
+
+block_for() {
+	# $1 = task name (e.g. test:system:launch:codex)
+	awk -v target="  $1:" '
+		$0 == target { inblk = 1; next }
+		inblk && /^  [^ ]/ { inblk = 0 }
+		inblk { print }
+	' "$TASKFILE"
+}
+
+env_section_for() {
+	# $1 = task name. Isolates the lines under the task-level `env:` key (its
+	# 6-space children) so the positive check can't be satisfied by a key of
+	# the same name elsewhere in the block (e.g. WORKSPACE also lives under
+	# `vars:`). Stops at the next 4-space task key (cmds:/deps:/vars:/env:).
+	block_for "$1" | awk '
+		/^    env:[[:space:]]*$/ { inenv = 1; next }
+		inenv && /^    [^ ]/ { inenv = 0 }
+		inenv { print }
+	'
+}
+
+check_target() {
+	# $1 = task name
+	blk="$(block_for "$1")"
+	if [ -z "$blk" ]; then
+		report "$1: target block found in Taskfile.yml" 1
+		return
+	fi
+	env_blk="$(env_section_for "$1")"
+	for key in $required_keys; do
+		# Good: the key is a child of the task-level `env:` block (6-space indent).
+		if printf '%s\n' "$env_blk" | grep -q "^      ${key}:"; then
+			report "$1: ${key} declared under task-level env" 0
+		else
+			report "$1: ${key} declared under task-level env" 1
+		fi
+		# Bad: env nested under a `- cmd:` entry puts the key at 10 spaces.
+		if printf '%s\n' "$blk" | grep -q "^          ${key}:"; then
+			report "$1: ${key} NOT nested under a cmds entry (go-task would drop it)" 1
+		else
+			report "$1: ${key} NOT nested under a cmds entry (go-task would drop it)" 0
+		fi
+	done
+}
+
+check_target test:system:launch:codex
+check_target test:system:launch:claude
+
+if [ "$failures" -ne 0 ]; then
+	printf '\n%s task-env wiring case(s) FAILED\n' "$failures" >&2
+	exit 1
+fi
+printf '\nall task-env wiring contract cases passed\n'


### PR DESCRIPTION
## Summary

The run-by-hand `task test:system:launch:{codex,claude}` scenarios (added in #1485) could never complete a live run. Two real bugs blocked every invocation, plus one misleading-diagnostic cleanup:

1. **Env never reached the scenario script (both targets).** The `AILERON_BIN` / `AILERON_SYSTEST_LIB` / `WORKSPACE` / `AILERON_STATE_DIR` block was declared under a `cmds:` entry's `env:`. **go-task only honors `env:` at task scope — a command-scoped `env:` is silently dropped.** So the scenario aborted immediately at `: "${AILERON_BIN:?AILERON_BIN must point at the built aileron binary}"`. Moved the block to task scope (matching every other `env:` in the Taskfile).

2. **codex refused to run.** Once the env was fixed, `codex exec` bailed with `Not inside a trusted directory and --skip-git-repo-check was not specified` — the mounted workspace (`/home/agent/workspace`) is a bare temp dir, not a git repo. codex exited instantly, the container stopped, and the R8.1 `.State.Running` probe failed. Added `--skip-git-repo-check` to the forwarded `codex exec`, plus explicit `</dev/null` stdin (headless; the prompt is an arg) and mirrored the headless stdin on claude for symmetry.

3. **Misleading "no running container" noise.** `discover_container` logged a `FAIL` on every poll during normal container startup latency (~3-4s), which read as a failure on an otherwise-passing run. Suppressed the per-poll diagnostic; a genuine timeout is still reported by the explicit `fail` after the loop.

### Why CI never caught it

The only headless validation is `task --dry`, which compiles the target but **cannot observe env**. So nothing flagged the dropped env. This PR adds `test/system/lib/taskenv_test.sh` (wired into the CI-safe `task test:system:lib` tier) that pins the contract:

- **behavioral** — task-scoped `env:` reaches an invoked script, command-scoped `env:` does not (proving the shape the fix relies on);
- **structural** — both launch targets keep `AILERON_BIN` et al. at task scope, so re-introducing the `cmds:`-scope bug fails here instead of silently at the next by-hand run.

## Test plan

- `task test:system:lib` — green (incl. the new `taskenv_test.sh`).
- `task --dry test:system:launch:{codex,claude}` — compile clean.
- `shellcheck -x -s sh test/system/lib/*.sh test/system/codex.sh test/system/claude.sh` — clean.
- **Live scenarios run by hand on macOS + Docker Desktop — both green.** `task test:system:launch:codex` and `task test:system:launch:claude` each pass every assertion: R7a arg-forwarding, R8.1–8.6 wiring invariants, R9 sentinel byte-exact (the agent actually wrote the file), and R10 audit round-trip (the `http_request` MCP tool round-tripped through the daemon). `rc=0`.
- Regression test verified to **fail on the old `cmds:`-scope shape** and pass on the fix.

### Known gaps / notes

- claude needs no analogous trust flag: the launcher already injects `--dangerously-skip-permissions` for claude in sandbox mode (`internal/launch/agents/claude.go:91`), which also bypasses the folder-trust dialog — confirmed by the green live run above (R9 sentinel + R10 audit prove the agent ran, wrote the file, and called the MCP tool).
- The behavioral "command-scoped env is dropped" assertion couples to current go-task semantics by design; if a future go-task honors cmd-scope env it will fail as a prompt to revisit.
- CodeRabbit pre-PR review was rate-limited at run time; self-reviewed instead.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

