### PR TITLE
refactor(sandbox): use cstore.CredentialKind consts in injectCredential switch

### DIFF
--- a/internal/sandbox/host.go
+++ b/internal/sandbox/host.go
@@ -466,13 +466,13 @@ func injectCredential(ctx context.Context, s *hostState, req *http.Request, requ
 		}
 	}
 	switch cred.Kind {
-	case "oauth2":
+	case cstore.CredentialKindOAuth2:
 		// RFC 6750 fixes OAuth2 access tokens as
 		// `Authorization: Bearer <token>`. The manifest's `header` and
 		// `format` fields are rejected at validation for oauth2 kind,
 		// so we never have to consult them here.
 		req.Header.Set("Authorization", "Bearer "+string(cred.Value))
-	case "api_key":
+	case cstore.CredentialKindAPIKey:
 		header, format := apiKeyInjection(s.credentialHeader, s.credentialFormat)
 		req.Header.Set(header, strings.ReplaceAll(format, "{key}", string(cred.Value)))
 	case cstore.CredentialKindAWSSigV4:


### PR DESCRIPTION
## Summary

Resolves the sole remaining actionable finding from cw-review-residual #1522 (sub-issue #1504, shipped via PR #1532 into the `integration/sigv4-sealing` umbrella branch).

The `injectCredential` switch on `cred.Kind` in `internal/sandbox/host.go` was mixed: the `oauth2` and `api_key` arms used string literals while the `aws_sigv4` arm already referenced `cstore.CredentialKindAWSSigV4`. The operator answered the parked decision to make the switch uniform. This converts the two remaining arms:

- `case "oauth2"` -> `case cstore.CredentialKindOAuth2`
- `case "api_key"` -> `case cstore.CredentialKindAPIKey`

The `cstore` import was already present. The constant values are identical to the prior literals (`CredentialKindOAuth2 = "oauth2"`, `CredentialKindAPIKey = "api_key"` in `internal/cstore/manifest.go`), so the change is behavior-preserving.

## Test plan

- `go build ./internal/sandbox/...` — passes.
- `go test ./internal/sandbox/` — passes.
- No new tests added: this is a behavior-preserving refactor whose contract behavior is already fully exercised by `internal/sandbox/host_credential_test.go`, which covers all three switch arms via observable behavior (header set / Bearer format), not the literal labels — `TestInjectCredential_OAuth2InjectsBearerHeader`, the five `TestInjectCredential_APIKey*` tests, and the `TestInjectCredential_AWSSigV4*` tests. These are the regression guard for this change and they pass.

Closes #1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)
