### PR TITLE
fix(test): make system-test session/workspace vars cross-platform

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -577,13 +577,20 @@ tasks:
       - build:launch
     vars:
       SESSION: smoke-test
-      WORKSPACE:
-        sh: mktemp -d 2>/dev/null || mktemp -d -t aileron-smoke
+      # Pure-template temp path: go-task exposes env vars (TMPDIR/TEMP/TMP) as
+      # template vars, so this resolves a writable dir on Windows (TEMP/TMP set)
+      # and Unix (TMPDIR or /tmp) without `mktemp`, whose bundled-coreutils form
+      # can't resolve /tmp under go-task's embedded shell on Windows. `unixEpoch`
+      # + `randInt` replace `date +%s` and `$$` (no shell binary on PATH needed).
+      WORKSPACE: '{{.TMPDIR | default .TEMP | default .TMP | default "/tmp"}}/aileron-smoke-{{now | unixEpoch}}-{{randInt 10000 99999}}'
     cmds:
       - task: _test:system:precond:docker
         vars:
           TARGET: test:system:smoke
       - defer: { task: _test:system:cleanup, vars: { SESSION: '{{.SESSION}}', WORKSPACE: '{{.WORKSPACE}}' } }
+      # The template no longer creates the dir the way `mktemp -d` did; create it
+      # explicitly (mkdir is bundled in Task's coreutils, works cross-platform).
+      - mkdir -p "{{.WORKSPACE}}"
       - |
         set -u
         # Prove build:launch produced the launch binary.
@@ -631,10 +638,12 @@ tasks:
     deps:
       - build:launch
     vars:
-      SESSION:
-        sh: echo "codex-$(date +%s)-$$"
-      WORKSPACE:
-        sh: mktemp -d 2>/dev/null || mktemp -d -t aileron-codex
+      # Pure-template, no shell binary on PATH needed: `unixEpoch` + `randInt`
+      # replace `date +%s` and `$$` so SESSION/WORKSPACE resolve under go-task's
+      # embedded shell on Windows (no `date`, no usable `mktemp`). go-task exposes
+      # env vars (TMPDIR/TEMP/TMP) as template vars for a writable temp root.
+      SESSION: 'codex-{{now | unixEpoch}}-{{randInt 10000 99999}}'
+      WORKSPACE: '{{.TMPDIR | default .TEMP | default .TMP | default "/tmp"}}/aileron-codex-{{now | unixEpoch}}-{{randInt 10000 99999}}'
     # Task-scoped env: go-task only honors `env:` at the task level, not on an
     # individual `cmds:` entry (a command-level `env:` is silently ignored), so
     # the scenario script must receive AILERON_BIN et al. from here. Keeping it
@@ -647,9 +656,13 @@ tasks:
         sh: echo "${AILERON_STATE_DIR:-$HOME/.aileron}"
     cmds:
       # Register cleanup FIRST so a failed precondition (Docker down or codex
-      # auth absent) still removes the mktemp WORKSPACE created by the dynamic
-      # var above — a `defer` only registers once its line is reached.
+      # auth absent) still removes the WORKSPACE — a `defer` only registers once
+      # its line is reached.
       - defer: { task: _test:system:cleanup, vars: { SESSION: '{{.SESSION}}', WORKSPACE: '{{.WORKSPACE}}' } }
+      # The WORKSPACE template no longer creates the dir the way `mktemp -d` did;
+      # create it explicitly (mkdir is bundled in Task's coreutils, cross-platform)
+      # before the scenario `cd`s into it and writes its sentinel.
+      - mkdir -p "{{.WORKSPACE}}"
       - task: _test:system:precond
         vars:
           AGENT: codex
@@ -671,10 +684,12 @@ tasks:
     deps:
       - build:launch
     vars:
-      SESSION:
-        sh: echo "claude-$(date +%s)-$$"
-      WORKSPACE:
-        sh: mktemp -d 2>/dev/null || mktemp -d -t aileron-claude
+      # Pure-template, no shell binary on PATH needed: `unixEpoch` + `randInt`
+      # replace `date +%s` and `$$` so SESSION/WORKSPACE resolve under go-task's
+      # embedded shell on Windows (no `date`, no usable `mktemp`). go-task exposes
+      # env vars (TMPDIR/TEMP/TMP) as template vars for a writable temp root.
+      SESSION: 'claude-{{now | unixEpoch}}-{{randInt 10000 99999}}'
+      WORKSPACE: '{{.TMPDIR | default .TEMP | default .TMP | default "/tmp"}}/aileron-claude-{{now | unixEpoch}}-{{randInt 10000 99999}}'
     # Task-scoped env: go-task only honors `env:` at the task level, not on an
     # individual `cmds:` entry (a command-level `env:` is silently ignored), so
     # the scenario script must receive AILERON_BIN et al. from here. Keeping it
@@ -687,9 +702,13 @@ tasks:
         sh: echo "${AILERON_STATE_DIR:-$HOME/.aileron}"
     cmds:
       # Register cleanup FIRST so a failed precondition (Docker down or claude
-      # auth absent) still removes the mktemp WORKSPACE created by the dynamic
-      # var above — a `defer` only registers once its line is reached.
+      # auth absent) still removes the WORKSPACE — a `defer` only registers once
+      # its line is reached.
       - defer: { task: _test:system:cleanup, vars: { SESSION: '{{.SESSION}}', WORKSPACE: '{{.WORKSPACE}}' } }
+      # The WORKSPACE template no longer creates the dir the way `mktemp -d` did;
+      # create it explicitly (mkdir is bundled in Task's coreutils, cross-platform)
+      # before the scenario `cd`s into it and writes its sentinel.
+      - mkdir -p "{{.WORKSPACE}}"
       - task: _test:system:precond
         vars:
           AGENT: claude

--- a/test/system/lib/taskenv_test.sh
+++ b/test/system/lib/taskenv_test.sh
@@ -144,6 +144,114 @@ check_target() {
 check_target test:system:launch:codex
 check_target test:system:launch:claude
 
+# --- C. structural: SESSION/WORKSPACE vars are Unix-shell-free (#1547) --------
+# The three run-by-hand system-test targets must not derive SESSION/WORKSPACE via
+# `date +%s`, `$$`, `mktemp`, or a hardcoded `/tmp` LHS — go-task's embedded shell
+# has no `date` and a `mktemp` that can't resolve /tmp on Windows, so those forms
+# fail before any test logic. Portable forms use pure template funcs
+# (`now | unixEpoch`, `randInt`) and env-var-derived temp roots.
+vars_section_for() {
+	# $1 = task name. Isolates the lines under the task-level `vars:` key (its
+	# 6-space children), stopping at the next 4-space task key
+	# (cmds:/deps:/vars:/env:).
+	block_for "$1" | awk '
+		/^    vars:[[:space:]]*$/ { invars = 1; next }
+		invars && /^    [^ ]/ { invars = 0 }
+		invars { print }
+	'
+}
+
+# The default-chain temp root (`/tmp` only as the final `default` fallback) is
+# the one sanctioned literal `/tmp`; flag any OTHER `/tmp` (e.g. a hardcoded
+# `/tmp/aileron-...` LHS). Strip the sanctioned token before scanning.
+var_subblock_for() {
+	# $1 = task name, $2 = var key. Prints the var's definition sub-block: the
+	# `KEY:` line (6-space indent) plus any deeper-indented children (e.g. a
+	# legacy `sh:` line at 8-space indent), stopping at the next 6-space var key
+	# or any comment line. Catches both the inline form (`KEY: '...'`) and the
+	# old multi-line dynamic form (`KEY:` / `  sh: ...`).
+	vars_section_for "$1" | awk -v key="      $2:" '
+		index($0, key) == 1 { invar = 1; print; next }
+		invar && /^      [^ ]/ { invar = 0 }
+		invar && /^      #/ { invar = 0 }
+		invar { print }
+	'
+}
+
+forbidden_in_vars() {
+	# $1 = task name. Prints any offending var definition line, empty if clean.
+	# Scans the SESSION/WORKSPACE definition sub-blocks (inline value and any
+	# `sh:` children), never the explanatory comments around them. The sanctioned
+	# `default "/tmp"` fallback is stripped before scanning.
+	for k in SESSION WORKSPACE; do
+		var_subblock_for "$1" "$k"
+	done \
+		| sed 's#default "/tmp"##g' \
+		| grep -nE 'date \+%s|\$\$|mktemp|/tmp' || true
+}
+
+for t in test:system:smoke test:system:launch:codex test:system:launch:claude; do
+	offending="$(forbidden_in_vars "$t")"
+	if [ -z "$offending" ]; then
+		report "$t: SESSION/WORKSPACE vars use no date/\$\$/mktemp//tmp (portable)" 0
+	else
+		printf 'offending var line(s) in %s:\n%s\n' "$t" "$offending" >&2
+		report "$t: SESSION/WORKSPACE vars use no date/\$\$/mktemp//tmp (portable)" 1
+	fi
+done
+
+# --- D. behavioral: vars resolve with `date`+`mktemp` off PATH (#1547) --------
+# Simulates go-task's Windows embedded-shell condition (no `date`, no usable
+# `mktemp`) by extracting each target's real SESSION/WORKSPACE var lines into a
+# minimal Taskfile and resolving them under a PATH that contains the `task` and
+# `sh` binaries but NOT `date`/`mktemp`. Pure-template vars resolve regardless;
+# the old `sh:` dynamic vars would fail here (this case fails before the fix).
+TASK_BIN="$(command -v task)"
+SH_BIN="$(command -v sh)"
+SANDBOX_PATH="$WORK/nobins"
+mkdir -p "$SANDBOX_PATH"
+ln -s "$TASK_BIN" "$SANDBOX_PATH/task"
+ln -s "$SH_BIN" "$SANDBOX_PATH/sh"
+# Confirm the simulation is real: `date`/`mktemp` must be absent under this PATH.
+if PATH="$SANDBOX_PATH" command -v date >/dev/null 2>&1 ||
+	PATH="$SANDBOX_PATH" command -v mktemp >/dev/null 2>&1; then
+	report "sandbox PATH excludes date/mktemp (Windows embedded-shell sim)" 1
+else
+	report "sandbox PATH excludes date/mktemp (Windows embedded-shell sim)" 0
+fi
+
+resolve_var_under_sandbox() {
+	# $1 = task name, $2 = var key (SESSION|WORKSPACE). Echoes the resolved value.
+	# Pull the exact `KEY: '...'` line from the real Taskfile's vars block so the
+	# behavioral case tracks whatever the structural case pinned.
+	varline="$(vars_section_for "$1" | grep -E "^      $2:" | head -n1 | sed 's/^      //')"
+	[ -n "$varline" ] || { echo ""; return; }
+	gen="$WORK/Taskfile.$2.$(echo "$1" | tr ':' '_').yml"
+	{
+		echo "version: '3'"
+		echo "tasks:"
+		echo "  r:"
+		echo "    vars:"
+		echo "      $varline"
+		echo "    cmds:"
+		echo "      - 'echo RESOLVED=[{{.$2}}]'"
+	} >"$gen"
+	out="$(PATH="$SANDBOX_PATH" "$TASK_BIN" -t "$gen" r 2>/dev/null)"
+	# Extract the value inside RESOLVED=[...].
+	printf '%s\n' "$out" | sed -n 's/.*RESOLVED=\[\(.*\)\].*/\1/p' | head -n1
+}
+
+for t in test:system:smoke test:system:launch:codex test:system:launch:claude; do
+	for key in SESSION WORKSPACE; do
+		val="$(resolve_var_under_sandbox "$t" "$key")"
+		if [ -n "$val" ]; then
+			report "$t: $key resolves non-empty with date/mktemp off PATH" 0
+		else
+			report "$t: $key resolves non-empty with date/mktemp off PATH" 1
+		fi
+	done
+done
+
 if [ "$failures" -ne 0 ]; then
 	printf '\n%s task-env wiring case(s) FAILED\n' "$failures" >&2
 	exit 1


### PR DESCRIPTION
## Summary

The three run-by-hand system-test tasks in `Taskfile.yml` — `test:system:smoke`, `test:system:launch:codex`, `test:system:launch:claude` — derived `SESSION` and `WORKSPACE` from Unix-only `sh:` dynamic vars (`echo "<agent>-$(date +%s)-$$"` and `mktemp -d 2>/dev/null || mktemp -d -t ...`). On Windows, go-task's embedded shell has no `date` on PATH and its bundled coreutils `mktemp` can't resolve `/tmp`, so both vars failed before any test logic ran.

This replaces them with pure go-task template funcs that need no shell binary:

- `{{now | unixEpoch}}` replaces `date +%s`
- `{{randInt 10000 99999}}` replaces the `$$` uniqueness component
- `{{.TMPDIR | default .TEMP | default .TMP | default "/tmp"}}` resolves a writable temp root from auto-exposed env vars (TMPDIR on Unix, TEMP/TMP on Windows, `/tmp` final fallback) — no `mktemp`, no hardcoded `/tmp`

Because the template no longer creates the directory the way `mktemp -d` did, each task gets a `mkdir -p "{{.WORKSPACE}}"` (mkdir is bundled in Task's coreutils and is cross-platform) before the scenario consumes the workspace. The launch tasks keep cleanup registered first (defer), then mkdir, so a failed precondition still removes the workspace. The existing cleanup guard `case "{{.WORKSPACE}}" in ""|/) ;;` already protects empty/root and is unchanged.

Downstream consumers are compatible: `codex.sh`/`claude.sh` only require WORKSPACE to exist (they `cd` in and write a sentinel) and smoke touches `WORKSPACE/sentinel` — all satisfied by `mkdir -p`.

## Test plan

Regression coverage added to `test/system/lib/taskenv_test.sh` (the CI-safe, POSIX, no-Docker lib-tier test already run by `task test:system:lib`):

- **(C) structural** — asserts none of the three tasks' `SESSION`/`WORKSPACE` definitions contain `date +%s`, `$$`, `mktemp`, or a literal `/tmp` (the sanctioned `default "/tmp"` fallback excepted). Catches both the inline and the old multi-line `sh:` form.
- **(D) behavioral** — extracts each task's real `SESSION`/`WORKSPACE` var lines into a minimal Taskfile and resolves them under a PATH that excludes `date` and `mktemp` (simulating go-task's Windows embedded shell), asserting each resolves non-empty.

Verified:

- New cases **fail against pre-fix `Taskfile.yml`** (5 behavioral + 3 structural failures) and **pass against the fix** — true regression test.
- `task test:system:lib` green (all assert/probes/taskenv contract cases pass).
- `task --dry test:system:launch:codex` and `:claude` show `mkdir -p` before the scenario and resolved vars.
- `task test:system:smoke` runs end-to-end (Docker up): mkdir creates the workspace, sentinel seeded, deferred cleanup removes it.
- `shellcheck -x -s sh test/system/lib/taskenv_test.sh` clean.

Out of scope: `test/system/README.md` was left unchanged — its cross-OS note is about the PTY path, not a Unix-only claim about these vars, so the feedback's update-if-claimed condition isn't met.

Closes #1547

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Refactored system test framework configuration to significantly improve portability and reliability across different execution environments
  * Added comprehensive regression test cases to thoroughly validate correct initialization and consistent behavior of system test launch targets
  * Enhanced environment variable verification mechanisms to ensure proper resolution under various operational constraints and runtime execution conditions

<!-- end of auto-generated comment: release notes by coderabbit.ai -->