### PR TITLE
refactor(sandbox): use cstore.CredentialKind consts in injectCredential switch

### DIFF
--- a/internal/sandbox/host.go
+++ b/internal/sandbox/host.go
@@ -466,13 +466,13 @@ func injectCredential(ctx context.Context, s *hostState, req *http.Request, requ
 		}
 	}
 	switch cred.Kind {
-	case "oauth2":
+	case cstore.CredentialKindOAuth2:
 		// RFC 6750 fixes OAuth2 access tokens as
 		// `Authorization: Bearer <token>`. The manifest's `header` and
 		// `format` fields are rejected at validation for oauth2 kind,
 		// so we never have to consult them here.
 		req.Header.Set("Authorization", "Bearer "+string(cred.Value))
-	case "api_key":
+	case cstore.CredentialKindAPIKey:
 		header, format := apiKeyInjection(s.credentialHeader, s.credentialFormat)
 		req.Header.Set(header, strings.ReplaceAll(format, "{key}", string(cred.Value)))
 	case cstore.CredentialKindAWSSigV4:


### PR DESCRIPTION
## Summary

Recovers the operator-approved fix for `cw-review-residual` #1522 (sub-issue #1504). The original PR #1544 was auto-closed unmerged when its base branch `integration/sigv4-sealing` was deleted during the umbrella #1501 promotion (PR #1545) — a concurrency casualty, not a rejection. This re-targets the same single fix commit onto `main`.

Makes the `injectCredential` `switch cred.Kind` in `internal/sandbox/host.go` uniform: the `oauth2` and `api_key` arms used string literals while the `aws_sigv4` arm already used `cstore.CredentialKindAWSSigV4`.

- `case "oauth2"` → `case cstore.CredentialKindOAuth2`
- `case "api_key"` → `case cstore.CredentialKindAPIKey`

The constants equal the prior literals (`internal/cstore/manifest.go`), so the change is behavior-preserving.

## Test plan

- `go build ./internal/sandbox/...` — passes.
- `go test ./internal/sandbox/` — passes.
- No new tests: behavior-preserving refactor; the three switch arms are already covered by observable-behavior tests in `host_credential_test.go` (`TestInjectCredential_OAuth2*`, `TestInjectCredential_APIKey*`, `TestInjectCredential_AWSSigV4*`).

Closes #1522

🤖 Generated with [Claude Code](https://claude.com/claude-code)
