### PR TITLE
feat(sandbox): add warm/prefetch and offline managed-toolchain build path

### DIFF
--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -21,7 +21,7 @@ import (
 
 func runSandbox(args []string, registry *launch.Registry, stdout, stderr io.Writer) int {
 	if len(args) == 0 {
-		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check|cache>")
+		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check|warm|cache>")
 		return 1
 	}
 	switch args[0] {
@@ -33,11 +33,13 @@ func runSandbox(args []string, registry *launch.Registry, stdout, stderr io.Writ
 		return runSandboxBuild(args[1:], stdout, stderr)
 	case "check":
 		return runSandboxCheck(args[1:], stdout, stderr)
+	case "warm":
+		return runSandboxWarm(args[1:], stdout, stderr)
 	case "cache":
 		return runSandboxCache(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown sandbox command: %q\n", args[0])
-		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check|cache>")
+		fmt.Fprintln(stderr, "usage: aileron sandbox <init|plan|build|check|warm|cache>")
 		return 1
 	}
 }
@@ -217,11 +219,12 @@ func runSandboxBuild(args []string, stdout, stderr io.Writer) int {
 	toolchain := flags.String("toolchain", sandboxcontainer.ToolchainModeAuto, "Features-build toolchain: managed (default) or host-npx")
 	node := flags.String("node", "", "Managed-toolchain escape hatch: path to a Node binary (with --devcontainer-cli)")
 	devcontainerCLI := flags.String("devcontainer-cli", "", "Managed-toolchain escape hatch: path to the @devcontainers/cli entrypoint (with --node)")
+	offline := flags.Bool("offline", false, "Resolve the managed toolchain from the warm cache with no network (run `aileron sandbox warm` first)")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
 	if flags.NArg() != 0 {
-		fmt.Fprintln(stderr, "usage: aileron sandbox build [--runtime=auto|docker] [--tag=<image>] [--toolchain=managed|host-npx] [--node=<path> --devcontainer-cli=<path>]")
+		fmt.Fprintln(stderr, "usage: aileron sandbox build [--runtime=auto|docker] [--tag=<image>] [--toolchain=managed|host-npx] [--offline] [--node=<path> --devcontainer-cli=<path>]")
 		return 1
 	}
 	cwd, err := os.Getwd()
@@ -242,6 +245,7 @@ func runSandboxBuild(args []string, stdout, stderr io.Writer) int {
 		ToolchainMode:             toolchainMode,
 		NodeBinary:                nodeBinary,
 		DevcontainerCLIEntrypoint: cliEntrypoint,
+		Offline:                   *offline,
 	})
 	if errors.Is(err, sandboxcontainer.ErrNoBuildRequired) {
 		fmt.Fprintf(stdout, "tier: %s\n", result.Tier)
@@ -269,11 +273,12 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 	toolchain := flags.String("toolchain", sandboxcontainer.ToolchainModeAuto, "Features-build toolchain: managed (default) or host-npx")
 	node := flags.String("node", "", "Managed-toolchain escape hatch: path to a Node binary (with --devcontainer-cli)")
 	devcontainerCLI := flags.String("devcontainer-cli", "", "Managed-toolchain escape hatch: path to the @devcontainers/cli entrypoint (with --node)")
+	offline := flags.Bool("offline", false, "Resolve the managed toolchain from the warm cache with no network (run `aileron sandbox warm` first)")
 	if err := flags.Parse(args); err != nil {
 		return 1
 	}
 	if flags.NArg() > 1 || (*agent != "" && flags.NArg() != 0) {
-		fmt.Fprintln(stderr, "usage: aileron sandbox check [--runtime=auto|docker] [--build=auto|always|never] [--agent=<command>] [--toolchain=managed|host-npx] [--node=<path> --devcontainer-cli=<path>] [command]")
+		fmt.Fprintln(stderr, "usage: aileron sandbox check [--runtime=auto|docker] [--build=auto|always|never] [--agent=<command>] [--toolchain=managed|host-npx] [--offline] [--node=<path> --devcontainer-cli=<path>] [command]")
 		return 1
 	}
 	command := *agent
@@ -315,6 +320,7 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 		ToolchainMode:             toolchainMode,
 		NodeBinary:                nodeBinary,
 		DevcontainerCLIEntrypoint: cliEntrypoint,
+		Offline:                   *offline,
 	})
 	if err != nil && !errors.Is(err, sandboxcontainer.ErrNoBuildRequired) {
 		fmt.Fprintf(stderr, "error: %s\n", sandboxCheckError(err))
@@ -348,6 +354,47 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
+// runSandboxWarm pre-stages the Aileron-managed toolchain (the pinned Node
+// runtime plus @devcontainers/cli) into the content-addressed cache ahead of the
+// first build, so a later `aileron sandbox build --offline` resolves it with no
+// network. Warm is managed-only by definition: there is nothing to pre-fetch for
+// the host-npx path (it uses the host's npx at build time), so an explicit
+// `--toolchain=host-npx` is rejected with a clear message. Warm is idempotent: a
+// warm cache short-circuits without re-downloading.
+func runSandboxWarm(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("sandbox warm", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	toolchain := flags.String("toolchain", sandboxcontainer.ToolchainModeAuto, "Toolchain to warm: managed (default). host-npx has nothing to pre-fetch.")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 0 {
+		fmt.Fprintln(stderr, "usage: aileron sandbox warm [--toolchain=managed]")
+		return 1
+	}
+	if !sandboxcontainer.IsManagedToolchain(*toolchain) {
+		fmt.Fprintln(stderr, "error: `aileron sandbox warm` only applies to the managed toolchain; host-npx has nothing to pre-fetch")
+		return 1
+	}
+	managed, err := sandboxWarmFn(context.Background())
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	fmt.Fprintf(stdout, "node: %s\n", managed.NodeBinary)
+	fmt.Fprintf(stdout, "devcontainer-cli: %s\n", managed.CLIEntrypoint)
+	fmt.Fprintln(stdout, "warmed: ok")
+	return 0
+}
+
+// sandboxWarmFn provisions the managed toolchain with all production defaults
+// (network on, Offline=false), populating the content-addressed cache.
+// Swappable in tests so a unit test exercises the command surface without
+// network.
+var sandboxWarmFn = func(ctx context.Context) (sandboxcontainer.ManagedToolchain, error) {
+	return sandboxtoolchain.Provision(ctx, sandboxtoolchain.Options{})
+}
+
 // reportBakedMCPVersion surfaces version skew between a baked sandbox image's
 // aileron-mcp and the host CLI. ADR-0024's host-mount lockstep does not hold
 // for baked images (issue #957), so skew is an expected operational state for
@@ -377,7 +424,9 @@ var sandboxBuildFn = func(ctx context.Context, runtimeName string, stdout, stder
 	// Builder consults the provisioner only on the managed branch and only when the
 	// escape hatch is absent.
 	if sandboxcontainer.IsManagedToolchain(opts.ToolchainMode) {
-		builder.Provisioner = sandboxtoolchain.Provisioner{}
+		builder.Provisioner = sandboxtoolchain.Provisioner{
+			Options: sandboxtoolchain.Options{Offline: opts.Offline},
+		}
 	}
 	return builder.Build(ctx, opts)
 }

--- a/cmd/aileron/sandbox_toolchain_test.go
+++ b/cmd/aileron/sandbox_toolchain_test.go
@@ -3,7 +3,9 @@ package main
 import (
 	"bytes"
 	"context"
+	"errors"
 	"io"
+	"strings"
 	"testing"
 
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
@@ -106,6 +108,108 @@ func TestRunSandboxBuildEscapeHatchEnvThreaded(t *testing.T) {
 	}
 	if got.DevcontainerCLIEntrypoint != "/opt/cli/devcontainer.js" {
 		t.Fatalf("DevcontainerCLIEntrypoint = %q, want env value", got.DevcontainerCLIEntrypoint)
+	}
+}
+
+func TestRunSandboxBuildOfflineFlagThreads(t *testing.T) {
+	// --offline must surface on BuildOptions.Offline so the CLI layer constructs
+	// an offline provisioner for a managed build.
+	t.Chdir(t.TempDir())
+	got := captureSandboxBuildOpts(t)
+	var out, errb bytes.Buffer
+	if code := runSandboxBuild([]string{"--offline"}, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if !got.Offline {
+		t.Fatal("BuildOptions.Offline = false, want true with --offline")
+	}
+	if !sandboxcontainer.IsManagedToolchain(got.ToolchainMode) {
+		t.Fatalf("default ToolchainMode = %q, want managed", got.ToolchainMode)
+	}
+}
+
+func TestRunSandboxBuildOfflineDefaultsFalse(t *testing.T) {
+	t.Chdir(t.TempDir())
+	got := captureSandboxBuildOpts(t)
+	var out, errb bytes.Buffer
+	if code := runSandboxBuild(nil, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if got.Offline {
+		t.Fatal("BuildOptions.Offline = true without --offline, want false")
+	}
+}
+
+// captureSandboxWarm swaps sandboxWarmFn so a test exercises the warm command
+// surface without network, returning a pointer to a call counter.
+func captureSandboxWarm(t *testing.T, managed sandboxcontainer.ManagedToolchain, err error) *int {
+	t.Helper()
+	orig := sandboxWarmFn
+	t.Cleanup(func() { sandboxWarmFn = orig })
+	calls := 0
+	sandboxWarmFn = func(_ context.Context) (sandboxcontainer.ManagedToolchain, error) {
+		calls++
+		return managed, err
+	}
+	return &calls
+}
+
+func TestRunSandboxWarmDispatchesAndPrints(t *testing.T) {
+	calls := captureSandboxWarm(t, sandboxcontainer.ManagedToolchain{
+		NodeBinary:    "/cache/node/sha256/abc/bin/node",
+		CLIEntrypoint: "/cache/devcontainer-cli/1.0.0/devcontainer.js",
+	}, nil)
+	var out, errb bytes.Buffer
+	if code := runSandboxWarm(nil, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if *calls != 1 {
+		t.Fatalf("warm provision calls = %d, want 1", *calls)
+	}
+	got := out.String()
+	for _, want := range []string{"node: /cache/node/sha256/abc/bin/node", "devcontainer-cli: /cache/devcontainer-cli/1.0.0/devcontainer.js", "warmed: ok"} {
+		if !strings.Contains(got, want) {
+			t.Fatalf("warm output missing %q:\n%s", want, got)
+		}
+	}
+}
+
+func TestRunSandboxWarmRejectsHostNPX(t *testing.T) {
+	calls := captureSandboxWarm(t, sandboxcontainer.ManagedToolchain{}, nil)
+	var out, errb bytes.Buffer
+	if code := runSandboxWarm([]string{"--toolchain=host-npx"}, &out, &errb); code != 1 {
+		t.Fatalf("exit = %d, want 1 for host-npx warm", code)
+	}
+	if *calls != 0 {
+		t.Fatalf("warm provision ran (%d calls) for host-npx; want 0", *calls)
+	}
+	if !strings.Contains(errb.String(), "host-npx") {
+		t.Fatalf("stderr = %q, want a host-npx rejection message", errb.String())
+	}
+}
+
+func TestRunSandboxWarmRejectsUnknownArgs(t *testing.T) {
+	calls := captureSandboxWarm(t, sandboxcontainer.ManagedToolchain{}, nil)
+	var out, errb bytes.Buffer
+	if code := runSandboxWarm([]string{"extra"}, &out, &errb); code != 1 {
+		t.Fatalf("exit = %d, want 1 for unexpected args", code)
+	}
+	if *calls != 0 {
+		t.Fatalf("warm provision ran (%d calls) with bad args; want 0", *calls)
+	}
+	if !strings.Contains(errb.String(), "usage: aileron sandbox warm") {
+		t.Fatalf("stderr = %q, want usage", errb.String())
+	}
+}
+
+func TestRunSandboxWarmSurfacesProvisionError(t *testing.T) {
+	captureSandboxWarm(t, sandboxcontainer.ManagedToolchain{}, errors.New("warm boom"))
+	var out, errb bytes.Buffer
+	if code := runSandboxWarm(nil, &out, &errb); code != 1 {
+		t.Fatalf("exit = %d, want 1 on provision error", code)
+	}
+	if !strings.Contains(errb.String(), "warm boom") {
+		t.Fatalf("stderr = %q, want the provision error surfaced", errb.String())
 	}
 }
 

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -161,6 +161,27 @@ aileron sandbox build --toolchain=managed \
 
 The escape hatch is also available through `AILERON_SANDBOX_NODE` and `AILERON_DEVCONTAINER_CLI`. Both paths must be supplied together and must exist on disk; a half-configured escape hatch is rejected rather than partially provisioned.
 
+### Prefetch and offline builds
+
+`aileron sandbox warm` pre-stages the managed toolchain ahead of the first build. It fetches and verifies the pinned Node distribution and installs the pinned `@devcontainers/cli` into the content-addressed cache, exactly as a managed build does on a cold cache. Run it once on a host with network access:
+
+```bash
+aileron sandbox warm
+```
+
+Warm is idempotent. A warm cache short-circuits without re-downloading. Warm applies only to the managed toolchain, so `aileron sandbox warm --toolchain=host-npx` is rejected because the host-npx path has nothing to pre-fetch.
+
+Once warmed, `aileron sandbox build --offline` (and `aileron sandbox check --offline`) resolve the managed toolchain from that cache with no network access:
+
+```bash
+aileron sandbox build --offline
+aileron sandbox check --offline --agent=claude
+```
+
+Offline mode computes the Node cache key from the committed `tools.lock.json` pin rather than downloading the signed checksums to learn it, so it never touches the network. The cached Node hash is re-verified against the pin as a tamper guard. On a cold cache the build fails with an actionable error that names `aileron sandbox warm`, so run warm with network access first.
+
+This is distinct from the escape hatch above. The escape hatch points at pre-staged Node and CLI binaries you manage yourself. The `--offline` route resolves the Aileron-managed, pin-verified toolchain from Aileron's own cache.
+
 ## Claude Code Feature
 
 The Claude Code agent Feature installs the `claude` CLI onto `ghcr.io/alrubinger/aileron-sandbox-base`. It is the single source of truth that Aileron CI bakes into the prebuilt Claude image and that you compose for Tier 1. The Feature lives at `images/sandbox-features/claude/` (`devcontainer-feature.json` plus `install.sh`).

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -266,6 +266,14 @@ type BuildOptions struct {
 	// pre-staged Node + CLI rather than fetching. Both must exist on disk.
 	NodeBinary                string
 	DevcontainerCLIEntrypoint string
+	// Offline requests that a managed-toolchain build resolve Node +
+	// @devcontainers/cli from the warm content-addressed cache with no network
+	// access (#1531). The Builder itself never reads this field; the CLI layer
+	// that constructs the toolchain Provisioner carries it into
+	// toolchain.Options.Offline, so a build with --offline fails fast with a
+	// `run aileron sandbox warm` hint on a cold cache instead of fetching. It is
+	// ignored when ToolchainMode is host-npx or when the escape hatch is set.
+	Offline bool
 }
 
 // BuildResult reports the image selected or built for launch.

--- a/internal/sandbox/container/toolslock.go
+++ b/internal/sandbox/container/toolslock.go
@@ -170,6 +170,18 @@ func nodePlatformToken(goos, goarch string) (string, bool) {
 	return os + "-" + arch, true
 }
 
+// PinnedNodeChecksum returns the recorded sha256 for the requested Node version
+// on the given GOOS/GOARCH and whether a pin applies. ok is false when version
+// is not the pinned version, when the GOOS/GOARCH pair is unsupported, or when no
+// checksum is recorded for the resolved platform. It is the exported wrapper the
+// managed-toolchain provisioner's offline path (internal/sandbox/toolchain, #1531)
+// reads to compute the content-addressed cache key from the pin alone, with no
+// network: the pinned sha256 is exactly the cstore cache key for the Node tree.
+// It keeps the committed tools.lock the single source of truth for that mapping.
+func PinnedNodeChecksum(version, goos, goarch string) (string, bool) {
+	return pinnedNodeChecksum(version, goos, goarch)
+}
+
 // pinnedNodeChecksum returns the recorded sha256 for the requested Node version
 // on the given GOOS/GOARCH and whether a pin applies. ok is false when version
 // is not the pinned version, when the GOOS/GOARCH pair is unsupported, or when no

--- a/internal/sandbox/container/toolslock_test.go
+++ b/internal/sandbox/container/toolslock_test.go
@@ -90,6 +90,30 @@ func TestPinnedNodeChecksumLookup(t *testing.T) {
 	})
 }
 
+// PinnedNodeChecksum is the exported wrapper the offline toolchain resolver
+// (#1531) reads to compute the cache key from the pin alone. It must return the
+// same hash the unexported lookup does for a supported platform, and ok=false
+// for an unsupported platform or a non-pinned version, with no logic of its own.
+func TestPinnedNodeChecksumExported(t *testing.T) {
+	sum, ok := PinnedNodeChecksum(pinnedNode.Version, "linux", "amd64")
+	if !ok {
+		t.Fatal("PinnedNodeChecksum(linux/amd64) ok=false, want a pin")
+	}
+	if want := pinnedNode.Checksums["linux-x64"]; sum != want {
+		t.Fatalf("checksum = %q, want %q", sum, want)
+	}
+	// Exported wrapper must agree with the unexported source exactly.
+	if inner, innerOK := pinnedNodeChecksum(pinnedNode.Version, "linux", "amd64"); inner != sum || innerOK != ok {
+		t.Fatalf("PinnedNodeChecksum (%q,%v) disagrees with pinnedNodeChecksum (%q,%v)", sum, ok, inner, innerOK)
+	}
+	if _, ok := PinnedNodeChecksum(pinnedNode.Version, "plan9", "mips"); ok {
+		t.Fatal("an unsupported platform must resolve ok=false")
+	}
+	if _, ok := PinnedNodeChecksum("0.0.0", "linux", "amd64"); ok {
+		t.Fatal("a non-pinned version must resolve ok=false")
+	}
+}
+
 // Checksum-mismatch-vs-lock acceptance / regression guard: VerifyNodeChecksum
 // rejects a distribution whose sha256 disagrees with the lock (naming the
 // platform and both hashes), accepts the recorded sha, and rejects an unpinned

--- a/internal/sandbox/nodedist/fetch.go
+++ b/internal/sandbox/nodedist/fetch.go
@@ -206,6 +206,15 @@ func (f *Fetcher) download(ctx context.Context, url string) ([]byte, error) {
 	return data, nil
 }
 
+// NodeBinaryPath returns the absolute path to the node executable inside an
+// unpacked entry for the given target. It is the exported wrapper the managed
+// toolchain's offline resolver (internal/sandbox/toolchain, #1531) calls so it
+// reuses this package's single rule for the `bin/node` (Unix) vs `node.exe`
+// (Windows) layout rather than re-deriving it.
+func NodeBinaryPath(entryDir string, target Target) string {
+	return nodeBinaryPath(entryDir, target)
+}
+
 // nodeBinaryPath returns the absolute path to the node executable inside an
 // unpacked entry for the given target.
 func nodeBinaryPath(entryDir string, target Target) string {

--- a/internal/sandbox/nodedist/fetch_test.go
+++ b/internal/sandbox/nodedist/fetch_test.go
@@ -91,6 +91,20 @@ func fixture(t *testing.T, signerKeyring func(t *testing.T) (*signer, keyring)) 
 	return ff, kr, archiveHash, archive
 }
 
+// NodeBinaryPath is the exported wrapper the offline toolchain resolver (#1531)
+// calls so it reuses this package's single layout rule rather than re-deriving
+// it. It must return bin/node on unix targets and node.exe on windows.
+func TestNodeBinaryPath(t *testing.T) {
+	entry := filepath.Join("cache", "sha256", "deadbeef")
+	if got, want := nodedist.NodeBinaryPath(entry, linuxTarget), filepath.Join(entry, "bin", "node"); got != want {
+		t.Fatalf("unix NodeBinaryPath = %q, want %q", got, want)
+	}
+	win := nodedist.Target{GOOS: "windows", GOARCH: "amd64"}
+	if got, want := nodedist.NodeBinaryPath(entry, win), filepath.Join(entry, "node.exe"); got != want {
+		t.Fatalf("windows NodeBinaryPath = %q, want %q", got, want)
+	}
+}
+
 func TestFetch_HappyPath(t *testing.T) {
 	ff, kr, archiveHash, _ := fixture(t, matchedSigner)
 	root := filepath.Join(t.TempDir(), "node")

--- a/internal/sandbox/toolchain/offline.go
+++ b/internal/sandbox/toolchain/offline.go
@@ -1,0 +1,123 @@
+package toolchain
+
+import (
+	"fmt"
+	"path/filepath"
+
+	"github.com/ALRubinger/aileron/internal/cstore"
+	"github.com/ALRubinger/aileron/internal/sandbox/container"
+	"github.com/ALRubinger/aileron/internal/sandbox/nodedist"
+)
+
+// provisionOffline resolves the managed toolchain entirely from the warm
+// content-addressed cache, with zero network access. It is the Offline=true
+// branch of Provision: it never constructs the nodedist.Fetcher (which always
+// downloads the signed checksums to learn the expected hash) nor runs the CLI
+// installer. Instead it computes the Node cache key from the committed
+// tools.lock pin, serves the cached Node tree and the cached CLI entrypoint
+// directly, and re-asserts the cached hash against the pin as a cheap tamper
+// guard. A cold cache (Node tree or CLI entrypoint absent) fails with an
+// actionable error naming `aileron sandbox warm`.
+func provisionOffline(resolved resolvedOptions) (container.ManagedToolchain, error) {
+	nodeCacheRoot := filepath.Join(resolved.CacheRoot, "node")
+	node, err := resolveCachedNode(nodeCacheRoot, resolved.NodeVersion, resolved.GOOS, resolved.GOARCH)
+	if err != nil {
+		return container.ManagedToolchain{}, err
+	}
+
+	// Re-verify the cached hash against the committed pin. The hash came from the
+	// pin, so this is a consistency assert (cheap and defensive): it keeps the
+	// offline path's trust anchor identical to the online boundary guard.
+	if err := container.VerifyNodeChecksum(resolved.NodeVersion, resolved.GOOS, resolved.GOARCH, node.SHA256); err != nil {
+		return container.ManagedToolchain{}, err
+	}
+
+	entrypoint := cliEntrypointForCache(resolved.CacheRoot, resolved.CLIVersion)
+	if !fileExists(entrypoint) {
+		return container.ManagedToolchain{}, offlineMissingCLIError(resolved.CLIVersion)
+	}
+
+	return container.ManagedToolchain{
+		NodeBinary:    node.NodeBinary,
+		CLIEntrypoint: entrypoint,
+	}, nil
+}
+
+// cachedNode is a managed Node distribution resolved from the content-addressed
+// cache without any network access. It carries the same fields the online
+// nodedist.Fetcher returns that the offline Provision path needs: the verified
+// sha256 (taken from the pin) and the absolute node binary path.
+type cachedNode struct {
+	// SHA256 is the pinned, content-addressed sha256 of the Node tree — the
+	// cache key. It comes from the committed tools.lock pin, so re-verifying it
+	// against the pin is a cheap consistency assert.
+	SHA256 string
+	// NodeBinary is the absolute path to the node executable inside the cached
+	// entry.
+	NodeBinary string
+}
+
+// resolveCachedNode resolves a managed Node distribution from the warm cache for
+// version on goos/goarch, with zero network access. It computes the cache key
+// from the committed tools.lock pin (the pinned sha256 is exactly the cstore
+// key), probes the content-addressed store for that tree, and returns the cached
+// node binary path. It returns an actionable error naming `aileron sandbox warm`
+// when the tree is absent (a cold cache), and reuses the container package's
+// pin-vs-platform error shape when the platform is unsupported or unpinned.
+//
+// nodeCacheRoot is the Node cache subtree (`<CacheRoot>/node`), matching the
+// Root the online Fetcher uses.
+func resolveCachedNode(nodeCacheRoot, version, goos, goarch string) (cachedNode, error) {
+	hash, ok := container.PinnedNodeChecksum(version, goos, goarch)
+	if !ok {
+		// Reuse the container package's actionable pin/platform error shape so
+		// the offline path reports unsupported/unpinned platforms identically to
+		// the online boundary guard. With no pin, VerifyNodeChecksum reports the
+		// unsupported/unpinned error before it ever compares the actual sha, so
+		// the empty actual is never inspected. Guard against a future change that
+		// returns nil here so the resolver can never report success with no pin.
+		if err := container.VerifyNodeChecksum(version, goos, goarch, ""); err != nil {
+			return cachedNode{}, err
+		}
+		return cachedNode{}, fmt.Errorf("managed Node %s (%s/%s) has no pinned checksum; the offline cache cannot be resolved", version, goos, goarch)
+	}
+
+	present, err := cstore.HasDirHash(nodeCacheRoot, hash)
+	if err != nil {
+		return cachedNode{}, fmt.Errorf("probe offline Node cache for %s: %w", hash, err)
+	}
+	if !present {
+		return cachedNode{}, offlineMissingNodeError(version, goos, goarch)
+	}
+
+	entryDir, err := cstore.DirEntryDir(nodeCacheRoot, hash)
+	if err != nil {
+		return cachedNode{}, fmt.Errorf("resolve offline Node cache entry for %s: %w", hash, err)
+	}
+	return cachedNode{
+		SHA256:     hash,
+		NodeBinary: nodedist.NodeBinaryPath(entryDir, nodedist.Target{GOOS: goos, GOARCH: goarch}),
+	}, nil
+}
+
+// offlineMissingNodeError is the actionable error for a cold Node cache in
+// offline mode: it names the version, the platform, and the `aileron sandbox
+// warm` remedy that populates the cache with network access.
+func offlineMissingNodeError(version, goos, goarch string) error {
+	return fmt.Errorf("managed Node %s (%s/%s) is not in the offline cache; run `aileron sandbox warm` with network access first", version, goos, goarch)
+}
+
+// offlineMissingCLIError is the actionable error for a missing @devcontainers/cli
+// entrypoint in offline mode: the Node tree was cached but the CLI was never
+// installed, so warming is required to populate it.
+func offlineMissingCLIError(cliVersion string) error {
+	return fmt.Errorf("managed @devcontainers/cli@%s is not in the offline cache; run `aileron sandbox warm` with network access first", cliVersion)
+}
+
+// cliEntrypointForCache returns the absolute path the npm installer would place
+// the @devcontainers/cli entrypoint at for cliVersion under cacheRoot. The
+// offline path probes this without running npm; it must match the layout
+// npmCLIInstaller.Install writes (see cli_install.go).
+func cliEntrypointForCache(cacheRoot, cliVersion string) string {
+	return filepath.Join(cacheRoot, "devcontainer-cli", cliVersion, cliEntrypointRelPath)
+}

--- a/internal/sandbox/toolchain/offline_test.go
+++ b/internal/sandbox/toolchain/offline_test.go
@@ -1,0 +1,145 @@
+package toolchain
+
+import (
+	"context"
+	"errors"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// failingFetcher is a cstore.Fetcher that fails the test if its Fetch is ever
+// invoked. The offline path must never touch the network, so any call is a bug.
+type failingFetcher struct{ t *testing.T }
+
+func (f failingFetcher) Fetch(_ context.Context, url string) (io.ReadCloser, error) {
+	f.t.Fatalf("offline Provision attempted a network fetch for %s; offline must use the cache only", url)
+	return nil, errors.New("unreachable")
+}
+
+// failingCLIInstaller fails the test if Install is invoked. Offline must serve
+// the CLI entrypoint from the cache without running the installer.
+type failingCLIInstaller struct{ t *testing.T }
+
+func (f failingCLIInstaller) Install(_ context.Context, _, _, _ string) (string, bool, error) {
+	f.t.Fatal("offline Provision ran the CLI installer; offline must use the cache only")
+	return "", false, errors.New("unreachable")
+}
+
+// stageCLIEntrypoint pre-populates the warm CLI cache for cliVersion under
+// cacheRoot, mirroring what npmCLIInstaller.Install leaves on disk, so the
+// offline path's entrypoint probe finds it.
+func stageCLIEntrypoint(t *testing.T, cacheRoot, cliVersion string) string {
+	t.Helper()
+	entrypoint := cliEntrypointForCache(cacheRoot, cliVersion)
+	if err := os.MkdirAll(filepath.Dir(entrypoint), 0o755); err != nil {
+		t.Fatalf("mkdir CLI prefix: %v", err)
+	}
+	if err := os.WriteFile(entrypoint, []byte("// devcontainer.js\n"), 0o644); err != nil {
+		t.Fatalf("write CLI entrypoint: %v", err)
+	}
+	return entrypoint
+}
+
+func TestProvisionOfflineFromWarmCacheNoNetwork(t *testing.T) {
+	cacheRoot := t.TempDir()
+	hash := pinnedChecksumForLinuxX64(t)
+	stagedNode(t, cacheRoot, hash)
+	cliEntrypoint := stageCLIEntrypoint(t, cacheRoot, container.DevcontainerCLIVersion)
+
+	managed, err := Provision(context.Background(), Options{
+		CacheRoot:    cacheRoot,
+		HTTP:         failingFetcher{t},
+		CLIInstaller: failingCLIInstaller{t},
+		GOOS:         "linux",
+		GOARCH:       "amd64",
+		Offline:      true,
+	})
+	if err != nil {
+		t.Fatalf("offline Provision: %v", err)
+	}
+	wantNode := filepath.Join(cacheRoot, "node", "sha256", hash, "bin", "node")
+	if managed.NodeBinary != wantNode {
+		t.Fatalf("NodeBinary = %q, want %q", managed.NodeBinary, wantNode)
+	}
+	if managed.CLIEntrypoint != cliEntrypoint {
+		t.Fatalf("CLIEntrypoint = %q, want %q", managed.CLIEntrypoint, cliEntrypoint)
+	}
+}
+
+// Regression guard for the named acceptance: offline against a cold cache fails
+// with an actionable message that names `warm` and the missing component, and
+// never attempts a network fetch (the failingFetcher would Fatal if it did).
+func TestProvisionOfflineColdCacheFailsActionably(t *testing.T) {
+	cacheRoot := t.TempDir() // empty: no Node tree, no CLI
+
+	_, err := Provision(context.Background(), Options{
+		CacheRoot:    cacheRoot,
+		HTTP:         failingFetcher{t},
+		CLIInstaller: failingCLIInstaller{t},
+		GOOS:         "linux",
+		GOARCH:       "amd64",
+		Offline:      true,
+	})
+	if err == nil {
+		t.Fatal("offline Provision on a cold cache: want an actionable error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "aileron sandbox warm") {
+		t.Fatalf("error %q does not name `aileron sandbox warm`", msg)
+	}
+	if !strings.Contains(msg, "Node") {
+		t.Fatalf("error %q does not name the missing Node component", msg)
+	}
+}
+
+// Offline with the Node tree cached but the CLI prefix absent must report the
+// CLI as the missing component, also pointing at `warm`.
+func TestProvisionOfflineCLIMissingFailsActionably(t *testing.T) {
+	cacheRoot := t.TempDir()
+	hash := pinnedChecksumForLinuxX64(t)
+	stagedNode(t, cacheRoot, hash) // Node present, CLI deliberately absent
+
+	_, err := Provision(context.Background(), Options{
+		CacheRoot:    cacheRoot,
+		HTTP:         failingFetcher{t},
+		CLIInstaller: failingCLIInstaller{t},
+		GOOS:         "linux",
+		GOARCH:       "amd64",
+		Offline:      true,
+	})
+	if err == nil {
+		t.Fatal("offline Provision with no CLI: want an actionable error, got nil")
+	}
+	msg := err.Error()
+	if !strings.Contains(msg, "aileron sandbox warm") {
+		t.Fatalf("error %q does not name `aileron sandbox warm`", msg)
+	}
+	if !strings.Contains(msg, "@devcontainers/cli") {
+		t.Fatalf("error %q does not name the missing CLI component", msg)
+	}
+}
+
+// Offline on an unsupported/unpinned platform reuses the container package's
+// pin/platform error shape rather than a cache-miss message.
+func TestProvisionOfflineUnsupportedPlatform(t *testing.T) {
+	cacheRoot := t.TempDir()
+	_, err := Provision(context.Background(), Options{
+		CacheRoot:    cacheRoot,
+		HTTP:         failingFetcher{t},
+		CLIInstaller: failingCLIInstaller{t},
+		GOOS:         "plan9",
+		GOARCH:       "mips",
+		Offline:      true,
+	})
+	if err == nil {
+		t.Fatal("offline Provision on an unsupported platform: want an error, got nil")
+	}
+	if !strings.Contains(err.Error(), "unsupported platform") {
+		t.Fatalf("error %q is not the pin/platform error shape", err.Error())
+	}
+}

--- a/internal/sandbox/toolchain/toolchain.go
+++ b/internal/sandbox/toolchain/toolchain.go
@@ -69,6 +69,16 @@ type Options struct {
 
 	// CLIInstaller acquires the pinned CLI. Defaults to the npm-based installer.
 	CLIInstaller cliInstaller
+
+	// Offline resolves the managed toolchain from the warm content-addressed
+	// cache with zero network access (#1531). When true, Provision computes the
+	// Node cache key from the committed tools.lock pin (the pinned sha256 is the
+	// cache key), serves the cached Node tree and the cached CLI entrypoint
+	// directly, and never calls the HTTP fetcher or the CLI installer. A cold
+	// cache (Node tree or CLI entrypoint absent) fails with an actionable error
+	// naming `aileron sandbox warm`. The zero value (false) preserves the
+	// network-backed default exactly.
+	Offline bool
 }
 
 // nodedistKeyring is the keyring type Options.Keyring carries. It is an alias of
@@ -89,6 +99,10 @@ func Provision(ctx context.Context, opts Options) (container.ManagedToolchain, e
 	resolved, err := opts.resolve()
 	if err != nil {
 		return container.ManagedToolchain{}, err
+	}
+
+	if resolved.Offline {
+		return provisionOffline(resolved)
 	}
 
 	keyring, err := resolved.keyring()
@@ -155,6 +169,7 @@ type resolvedOptions struct {
 	GOARCH       string
 	CLIVersion   string
 	CLIInstaller cliInstaller
+	Offline      bool
 }
 
 func (o Options) resolve() (resolvedOptions, error) {
@@ -167,6 +182,7 @@ func (o Options) resolve() (resolvedOptions, error) {
 		GOARCH:       o.GOARCH,
 		CLIVersion:   o.CLIVersion,
 		CLIInstaller: o.CLIInstaller,
+		Offline:      o.Offline,
 	}
 	if r.CacheRoot == "" {
 		r.CacheRoot = filepath.Join(cstore.DefaultRoot(), "toolchain")


### PR DESCRIPTION
## Summary

Part of #1525. This is the last sub-issue: the optional convenience/offline layer on top of the on-demand managed toolchain provisioning that landed in #1526–#1530.

- **`aileron sandbox warm`** pre-stages the pinned Node distribution and `@devcontainers/cli` into the content-addressed cache ahead of the first build. It reuses `toolchain.Provision` (network on) with all production defaults, so there is no new fetch/verify/cache logic. It is idempotent (a warm cache short-circuits) and managed-only (`warm --toolchain=host-npx` is rejected because the host-npx path has nothing to pre-fetch).
- **Offline mode on `toolchain.Provision`** (`Options.Offline`) resolves the managed toolchain from the warm cache with zero network access. It computes the Node cache key from the committed `tools.lock.json` pin (the pinned sha256 is exactly the cstore cache key), serves the cached Node tree and CLI entrypoint directly, re-asserts the cached hash against the pin as a tamper guard, and fails with an actionable `run aileron sandbox warm` error on a cold cache (naming the missing component).
- **`aileron sandbox build --offline` / `check --offline`** thread offline into the provisioner the CLI constructs. The Builder itself is unchanged; offline-ness lives in the provisioner's Options.
- Two thin exported wrappers keep the single source of truth: `container.PinnedNodeChecksum` (over the existing unexported pin lookup) and `nodedist.NodeBinaryPath` (over the existing `bin/node` vs `node.exe` layout rule), so the offline resolver reuses them rather than re-deriving the pin or the layout.

No OpenAPI/spec change, no approval gating, no ADR: `warm` is a local cache-population command, idempotent by construction, not an Aileron API write. No changes to the verified-fetch, signature, or checksum logic. Zero-value `Offline=false` preserves today's behavior exactly.

## Test plan

- `go test ./internal/... ./cmd/aileron/...` — all green.
- New tests against the contract:
  - Offline from a warm cache succeeds with **no network and no installer run** (a fetcher + installer that `t.Fatal` if invoked).
  - **Regression guard**: offline from a cold cache fails with an actionable message naming `aileron sandbox warm` and the missing Node component, with no network attempt.
  - Offline CLI-missing branch (Node cached, CLI absent) names the `@devcontainers/cli` component.
  - Offline on an unsupported platform reuses the pin/platform error shape.
  - `warm` dispatches to the provisioner and prints the resolved paths + `warmed: ok`; `warm host-npx` and unknown args are rejected; a provision error is surfaced.
  - `build --offline` surfaces `BuildOptions.Offline`; defaults to false.
  - Exported wrappers: `container.PinnedNodeChecksum` agrees with the unexported source and returns `ok=false` for unsupported/unpinned; `nodedist.NodeBinaryPath` returns `bin/node` (unix) and `node.exe` (windows).
- `coderabbit review` against `origin/main`: 0 findings.
- Toolchain package coverage 89%.

Closes #1531
