### PR TITLE
docs(sandbox): correct offline-mode "tamper guard" overclaim

### DIFF
--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -178,7 +178,7 @@ aileron sandbox build --offline
 aileron sandbox check --offline --agent=claude
 ```
 
-Offline mode computes the Node cache key from the committed `tools.lock.json` pin rather than downloading the signed checksums to learn it, so it never touches the network. The cached Node hash is re-verified against the pin as a tamper guard. On a cold cache the build fails with an actionable error that names `aileron sandbox warm`, so run warm with network access first.
+Offline mode computes the Node cache key from the committed `tools.lock.json` pin rather than downloading the signed checksums to learn it, so it never touches the network. The cached Node hash is re-asserted against the pin as a cheap consistency check that guards against a drifted lock pin. It does not re-hash the on-disk cache tree, so offline mode does not detect tampering of an already-warmed cache (the online warm path has the same trust-on-name property). On a cold cache the build fails with an actionable error that names `aileron sandbox warm`, so run warm with network access first.
 
 This is distinct from the escape hatch above. The escape hatch points at pre-staged Node and CLI binaries you manage yourself. The `--offline` route resolves the Aileron-managed, pin-verified toolchain from Aileron's own cache.
 


### PR DESCRIPTION
## Summary

Triage of cw-review-residual #1550 (plan findings for #1531, shipped via #1559) found one actionable item: a docs overclaim.

The offline-build docs said the cached Node hash is "re-verified against the pin as a tamper guard." That overstates the guarantee. The hash is *derived from* the `tools.lock.json` pin, so re-verifying it against the pin is tautological. It only catches a drifted lock pin. It does not re-hash the on-disk cache tree, so it cannot detect tampering of an already-warmed cache (the online warm path has the same trust-on-name property via `cstore.HasDirHash`, which only `os.Stat`s the hash-named dir).

This reword aligns the docs with the accurate framing already present in `internal/sandbox/toolchain/offline.go` comments ("consistency assert (cheap and defensive)", "drifted-lock-pin guard").

## Test plan

Docs-only change; no code paths affected. `offline.go`'s defensive `VerifyNodeChecksum` call is retained unchanged.

Closes #1550

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified offline sandbox build behavior: Node cache key computation from embedded pins without downloading checksums, cache validation process, and explanation that offline mode cannot detect tampering of existing caches. Updated guidance that cold-cache offline builds require the warm command before building.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->