### PR TITLE
fix(sandbox): cover check --offline, share CLI cache prefix, soften doc

### DIFF
--- a/cmd/aileron/sandbox_test.go
+++ b/cmd/aileron/sandbox_test.go
@@ -278,6 +278,60 @@ func captureSandboxCheckPlan(t *testing.T) *sandboxcomposition.Plan {
 	return &gotPlan
 }
 
+// captureSandboxCheckBuildOpts swaps the check build/baked/validate seams and
+// returns a pointer to the BuildOptions runSandboxCheck assembles, so a test can
+// assert how check flags thread into the toolchain selection without a real
+// build. It swaps sandboxCheckBuildFn specifically (the check path's seam, a
+// separate value from sandboxBuildFn), so this asserts the check entrypoint
+// threads --offline rather than relying on the build-path test.
+func captureSandboxCheckBuildOpts(t *testing.T) *sandboxcontainer.BuildOptions {
+	t.Helper()
+	origBuild := sandboxCheckBuildFn
+	origBaked := sandboxCheckBakedVersionFn
+	origValidate := sandboxCheckValidateFn
+	t.Cleanup(func() {
+		sandboxCheckBuildFn = origBuild
+		sandboxCheckBakedVersionFn = origBaked
+		sandboxCheckValidateFn = origValidate
+	})
+	var got sandboxcontainer.BuildOptions
+	sandboxCheckBuildFn = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.BuildOptions) (sandboxcontainer.BuildResult, error) {
+		got = opts
+		return sandboxcontainer.BuildResult{Runtime: "docker", Image: opts.Plan.Image, Tier: opts.Plan.Tier}, nil
+	}
+	sandboxCheckBakedVersionFn = func(context.Context, string, string) string { return "" }
+	sandboxCheckValidateFn = func(context.Context, string, string, string, string, bool) error { return nil }
+	return &got
+}
+
+func TestRunSandboxCheckOfflineFlagThreads(t *testing.T) {
+	// --offline must surface on the check path's BuildOptions.Offline so the CLI
+	// layer constructs an offline provisioner. This mirrors
+	// TestRunSandboxBuildOfflineFlagThreads but for runSandboxCheck, whose build
+	// seam (sandboxCheckBuildFn) is a separate value from sandboxBuildFn.
+	t.Chdir(t.TempDir())
+	got := captureSandboxCheckBuildOpts(t)
+	var out, errb bytes.Buffer
+	if code := runSandboxCheck([]string{"--offline", "--agent=claude"}, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if !got.Offline {
+		t.Fatal("BuildOptions.Offline = false, want true with --offline on check")
+	}
+}
+
+func TestRunSandboxCheckOfflineDefaultsFalse(t *testing.T) {
+	t.Chdir(t.TempDir())
+	got := captureSandboxCheckBuildOpts(t)
+	var out, errb bytes.Buffer
+	if code := runSandboxCheck([]string{"--agent=claude"}, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if got.Offline {
+		t.Fatal("BuildOptions.Offline = true without --offline on check, want false")
+	}
+}
+
 func TestRunSandboxCheckPublishedAgentResolvesPerAgentImage(t *testing.T) {
 	t.Chdir(t.TempDir())
 	plan := captureSandboxCheckPlan(t)

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -178,7 +178,7 @@ aileron sandbox build --offline
 aileron sandbox check --offline --agent=claude
 ```
 
-Offline mode computes the Node cache key from the committed `tools.lock.json` pin rather than downloading the signed checksums to learn it, so it never touches the network. The cached Node hash is re-verified against the pin as a tamper guard. On a cold cache the build fails with an actionable error that names `aileron sandbox warm`, so run warm with network access first.
+Offline mode computes the Node cache key from the committed `tools.lock.json` pin rather than downloading the signed checksums to learn it, so it never touches the network. The cache key already comes from that pin, so re-asserting it against the pin is a cheap consistency check rather than a tamper guard: the offline path does not re-hash the cached Node contents. On a cold cache the build fails with an actionable error that names `aileron sandbox warm`, so run warm with network access first.
 
 This is distinct from the escape hatch above. The escape hatch points at pre-staged Node and CLI binaries you manage yourself. The `--offline` route resolves the Aileron-managed, pin-verified toolchain from Aileron's own cache.
 

--- a/internal/sandbox/toolchain/cli_install.go
+++ b/internal/sandbox/toolchain/cli_install.go
@@ -19,6 +19,14 @@ const devcontainerCLIPackage = "@devcontainers/cli"
 // "bin" points at devcontainer.js under its bin/ directory.
 var cliEntrypointRelPath = filepath.Join("lib", "node_modules", "@devcontainers", "cli", "devcontainer.js")
 
+// cliCachePrefix is the version-keyed npm install prefix the CLI installer
+// writes into: <cacheRoot>/devcontainer-cli/<cliVersion>. It is the single
+// source of truth for that layout, reused by the offline resolver (via
+// cliEntrypointForCache) so the offline probe and the installer can never drift.
+func cliCachePrefix(cacheRoot, cliVersion string) string {
+	return filepath.Join(cacheRoot, "devcontainer-cli", cliVersion)
+}
+
 // npmCLIInstaller is the production cliInstaller: it runs the managed node's
 // bundled npm to install the pinned @devcontainers/cli into a version-keyed
 // cache prefix, then resolves the CLI's JS entrypoint. The install is keyed by
@@ -32,7 +40,7 @@ type npmCLIInstaller struct{}
 // otherwise npm installs the pinned package into the prefix and the entrypoint is
 // returned with fromCache=false.
 func (npmCLIInstaller) Install(ctx context.Context, nodeBinary, cliVersion, cacheRoot string) (string, bool, error) {
-	prefix := filepath.Join(cacheRoot, "devcontainer-cli", cliVersion)
+	prefix := cliCachePrefix(cacheRoot, cliVersion)
 	entrypoint := filepath.Join(prefix, cliEntrypointRelPath)
 	if fileExists(entrypoint) {
 		return entrypoint, true, nil

--- a/internal/sandbox/toolchain/offline.go
+++ b/internal/sandbox/toolchain/offline.go
@@ -119,5 +119,5 @@ func offlineMissingCLIError(cliVersion string) error {
 // offline path probes this without running npm; it must match the layout
 // npmCLIInstaller.Install writes (see cli_install.go).
 func cliEntrypointForCache(cacheRoot, cliVersion string) string {
-	return filepath.Join(cacheRoot, "devcontainer-cli", cliVersion, cliEntrypointRelPath)
+	return filepath.Join(cliCachePrefix(cacheRoot, cliVersion), cliEntrypointRelPath)
 }


### PR DESCRIPTION
## Summary

Three small, high-confidence cw-review-residual cleanups triaged from #1531. Each is behavior-preserving except the first, which is a pure additive test.

1. **Test gap (check --offline):** The only offline-flag test, `TestRunSandboxBuildOfflineFlagThreads`, swaps `sandboxBuildFn` — a separate value-copy from `sandboxCheckBuildFn` (the alias the check path dispatches through). Production correctly threads `Offline` for both build and check (`sandbox.go:248,323`), but nothing asserted that `runSandboxCheck --offline` surfaces `BuildOptions.Offline == true`. Added `TestRunSandboxCheckOfflineFlagThreads` (and a `DefaultsFalse` counterpart) that swap `sandboxCheckBuildFn` and assert the threaded value.

2. **Duplicated path construction:** `npmCLIInstaller.Install` and `cliEntrypointForCache` both re-derived `<cacheRoot>/devcontainer-cli/<cliVersion>` inline. Extracted `cliCachePrefix(cacheRoot, cliVersion)` as the single source of truth; both now build on it so the installer's write layout and the offline probe cannot drift.

3. **Doc over-claim:** `sandbox-agent-images.md:181` still called the offline Node-hash re-assert a "tamper guard". The offline path does not re-hash cached contents (it re-asserts the pin-derived hash against the pin), so the code comments already describe it as a cheap consistency check. Softened the doc sentence to match.

## Test plan

- `go build ./internal/sandbox/toolchain/... ./cmd/aileron/...` — clean.
- `go vet` on both packages — clean.
- `go test ./internal/sandbox/toolchain/... ./cmd/aileron/... -count=1` — pass.
- New tests verified: `TestRunSandboxCheckOfflineFlagThreads`, `TestRunSandboxCheckOfflineDefaultsFalse` pass; existing `cli_install_test.go` and `offline_test.go` continue to cover the shared-helper paths.

Relates to #1558

🤖 Generated with [Claude Code](https://claude.com/claude-code)