### PR TITLE
fix(sandbox): reject --offline with --node/--devcontainer-cli escape hatch

### DIFF
--- a/cmd/aileron/sandbox.go
+++ b/cmd/aileron/sandbox.go
@@ -211,6 +211,22 @@ func runSandboxPlan(args []string, stdout, stderr io.Writer) int {
 	return 0
 }
 
+// rejectOfflineWithEscapeHatch fails fast when --offline is combined with the
+// managed-toolchain escape hatch (--node/--devcontainer-cli). The two express
+// conflicting intents: --offline asks to resolve the managed toolchain from the
+// warm cache, while the escape hatch points the build at a pre-staged
+// Node + CLI and skips the provisioner entirely (so Offline would be a silent
+// no-op). Rather than dropping the offline intent, name both flags so the
+// operator picks one. It returns a non-nil error when the combination is
+// present (the message is already written to stderr).
+func rejectOfflineWithEscapeHatch(offline bool, node, devcontainerCLI string, stderr io.Writer) error {
+	if !offline || (node == "" && devcontainerCLI == "") {
+		return nil
+	}
+	fmt.Fprintln(stderr, "error: --offline cannot be combined with the --node/--devcontainer-cli escape hatch; --offline resolves the managed toolchain from the warm cache, while --node/--devcontainer-cli skip the provisioner entirely. Pick one.")
+	return errors.New("offline conflicts with escape hatch")
+}
+
 func runSandboxBuild(args []string, stdout, stderr io.Writer) int {
 	flags := flag.NewFlagSet("sandbox build", flag.ContinueOnError)
 	flags.SetOutput(stderr)
@@ -225,6 +241,9 @@ func runSandboxBuild(args []string, stdout, stderr io.Writer) int {
 	}
 	if flags.NArg() != 0 {
 		fmt.Fprintln(stderr, "usage: aileron sandbox build [--runtime=auto|docker] [--tag=<image>] [--toolchain=managed|host-npx] [--offline] [--node=<path> --devcontainer-cli=<path>]")
+		return 1
+	}
+	if err := rejectOfflineWithEscapeHatch(*offline, *node, *devcontainerCLI, stderr); err != nil {
 		return 1
 	}
 	cwd, err := os.Getwd()
@@ -279,6 +298,9 @@ func runSandboxCheck(args []string, stdout, stderr io.Writer) int {
 	}
 	if flags.NArg() > 1 || (*agent != "" && flags.NArg() != 0) {
 		fmt.Fprintln(stderr, "usage: aileron sandbox check [--runtime=auto|docker] [--build=auto|always|never] [--agent=<command>] [--toolchain=managed|host-npx] [--offline] [--node=<path> --devcontainer-cli=<path>] [command]")
+		return 1
+	}
+	if err := rejectOfflineWithEscapeHatch(*offline, *node, *devcontainerCLI, stderr); err != nil {
 		return 1
 	}
 	command := *agent

--- a/cmd/aileron/sandbox_test.go
+++ b/cmd/aileron/sandbox_test.go
@@ -332,6 +332,53 @@ func TestRunSandboxCheckOfflineDefaultsFalse(t *testing.T) {
 	}
 }
 
+func TestRunSandboxCheckOfflineRejectsEscapeHatch(t *testing.T) {
+	// As with build, --offline and the --node/--devcontainer-cli escape hatch
+	// conflict; check must reject the combination before building and name both
+	// flags so the offline intent is not silently dropped.
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"node only", []string{"--offline", "--node=/opt/node/bin/node", "--agent=claude"}},
+		{"cli only", []string{"--offline", "--devcontainer-cli=/opt/cli/devcontainer.js", "--agent=claude"}},
+		{"both", []string{"--offline", "--node=/opt/node/bin/node", "--devcontainer-cli=/opt/cli/devcontainer.js", "--agent=claude"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			calls := 0
+			origBuild := sandboxCheckBuildFn
+			origBaked := sandboxCheckBakedVersionFn
+			origValidate := sandboxCheckValidateFn
+			t.Cleanup(func() {
+				sandboxCheckBuildFn = origBuild
+				sandboxCheckBakedVersionFn = origBaked
+				sandboxCheckValidateFn = origValidate
+			})
+			sandboxCheckBuildFn = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.BuildOptions) (sandboxcontainer.BuildResult, error) {
+				calls++
+				return sandboxcontainer.BuildResult{Runtime: "docker", Image: opts.Plan.Image, Tier: opts.Plan.Tier}, nil
+			}
+			sandboxCheckBakedVersionFn = func(context.Context, string, string) string { return "" }
+			sandboxCheckValidateFn = func(context.Context, string, string, string, string, bool) error { return nil }
+			var out, errb bytes.Buffer
+			if code := runSandboxCheck(tc.args, &out, &errb); code != 1 {
+				t.Fatalf("exit = %d, want 1 for --offline + escape hatch", code)
+			}
+			if calls != 0 {
+				t.Fatalf("check build ran (%d calls) for rejected combination; want 0", calls)
+			}
+			msg := errb.String()
+			for _, want := range []string{"--offline", "--node", "--devcontainer-cli"} {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("stderr = %q, want it to name %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
 func TestRunSandboxCheckPublishedAgentResolvesPerAgentImage(t *testing.T) {
 	t.Chdir(t.TempDir())
 	plan := captureSandboxCheckPlan(t)

--- a/cmd/aileron/sandbox_toolchain_test.go
+++ b/cmd/aileron/sandbox_toolchain_test.go
@@ -140,6 +140,46 @@ func TestRunSandboxBuildOfflineDefaultsFalse(t *testing.T) {
 	}
 }
 
+func TestRunSandboxBuildOfflineRejectsEscapeHatch(t *testing.T) {
+	// --offline and the --node/--devcontainer-cli escape hatch express
+	// conflicting intents; combining them must fail before any build runs, and
+	// the error must name both flags so the operator's offline intent is not
+	// silently dropped.
+	cases := []struct {
+		name string
+		args []string
+	}{
+		{"node only", []string{"--offline", "--node=/opt/node/bin/node"}},
+		{"cli only", []string{"--offline", "--devcontainer-cli=/opt/cli/devcontainer.js"}},
+		{"both", []string{"--offline", "--node=/opt/node/bin/node", "--devcontainer-cli=/opt/cli/devcontainer.js"}},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			t.Chdir(t.TempDir())
+			calls := 0
+			orig := sandboxBuildFn
+			t.Cleanup(func() { sandboxBuildFn = orig })
+			sandboxBuildFn = func(_ context.Context, _ string, _, _ io.Writer, opts sandboxcontainer.BuildOptions) (sandboxcontainer.BuildResult, error) {
+				calls++
+				return sandboxcontainer.BuildResult{Runtime: "docker", Image: opts.Plan.Image, Tier: opts.Plan.Tier}, nil
+			}
+			var out, errb bytes.Buffer
+			if code := runSandboxBuild(tc.args, &out, &errb); code != 1 {
+				t.Fatalf("exit = %d, want 1 for --offline + escape hatch", code)
+			}
+			if calls != 0 {
+				t.Fatalf("build ran (%d calls) for rejected combination; want 0", calls)
+			}
+			msg := errb.String()
+			for _, want := range []string{"--offline", "--node", "--devcontainer-cli"} {
+				if !strings.Contains(msg, want) {
+					t.Fatalf("stderr = %q, want it to name %q", msg, want)
+				}
+			}
+		})
+	}
+}
+
 // captureSandboxWarm swaps sandboxWarmFn so a test exercises the warm command
 // surface without network, returning a pointer to a call counter.
 func captureSandboxWarm(t *testing.T, managed sandboxcontainer.ManagedToolchain, err error) *int {

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -272,7 +272,9 @@ type BuildOptions struct {
 	// that constructs the toolchain Provisioner carries it into
 	// toolchain.Options.Offline, so a build with --offline fails fast with a
 	// `run aileron sandbox warm` hint on a cold cache instead of fetching. It is
-	// ignored when ToolchainMode is host-npx or when the escape hatch is set.
+	// ignored when ToolchainMode is host-npx; the CLI rejects combining --offline
+	// with the --node/--devcontainer-cli escape hatch up front, so the escape
+	// hatch never reaches a build with Offline set.
 	Offline bool
 }
 

--- a/internal/sandbox/toolchain/offline.go
+++ b/internal/sandbox/toolchain/offline.go
@@ -15,9 +15,11 @@ import (
 // downloads the signed checksums to learn the expected hash) nor runs the CLI
 // installer. Instead it computes the Node cache key from the committed
 // tools.lock pin, serves the cached Node tree and the cached CLI entrypoint
-// directly, and re-asserts the cached hash against the pin as a cheap tamper
-// guard. A cold cache (Node tree or CLI entrypoint absent) fails with an
-// actionable error naming `aileron sandbox warm`.
+// directly, and re-asserts the cached hash against the pin as a cheap
+// consistency assert against the committed pin (it does not re-hash cached
+// contents, so it is not a tamper guard). A cold cache (Node tree or CLI
+// entrypoint absent) fails with an actionable error naming `aileron sandbox
+// warm`.
 func provisionOffline(resolved resolvedOptions) (container.ManagedToolchain, error) {
 	nodeCacheRoot := filepath.Join(resolved.CacheRoot, "node")
 	node, err := resolveCachedNode(nodeCacheRoot, resolved.NodeVersion, resolved.GOOS, resolved.GOARCH)


### PR DESCRIPTION
## Summary

Resolves the remaining actionable findings from cw-review-residual #1558 (sub-issue #1531), two small high-confidence cleanups:

1. **`--offline` precedence vs the escape hatch was unspecified.** `--offline` and the managed-toolchain escape hatch (`--node`/`--devcontainer-cli`) express conflicting intents: `--offline` resolves the managed toolchain from the warm cache, while the escape hatch points the build at a pre-staged Node + CLI and skips the provisioner entirely, making `Offline` a silent no-op. Per the operator's parked decision, both `runSandboxBuild` and `runSandboxCheck` now fail fast with an error naming both `--offline` and `--node`/`--devcontainer-cli` and return exit 1, so offline intent is never silently dropped. A shared helper `rejectOfflineWithEscapeHatch` runs after flag parse on both commands.

2. **Two over-claiming doc comments corrected.**
   - `BuildOptions.Offline` (internal/sandbox/container/runtime.go) no longer says `Offline` is silently ignored when the escape hatch is set; the CLI rejects that combination up front.
   - `provisionOffline` (internal/sandbox/toolchain/offline.go) now describes its hash re-check as a consistency assert against the committed pin (it does not re-hash cached contents, so it is not a tamper guard), matching the inline comment and the softened docs from #1562.

## Test plan

- New `TestRunSandboxBuildOfflineRejectsEscapeHatch` and `TestRunSandboxCheckOfflineRejectsEscapeHatch`, each with `node only` / `cli only` / `both` subtests, assert exit 1, that the build seam is never invoked, and that stderr names all three flags.
- Existing offline-flag threading tests (`...OfflineFlagThreads`, `...OfflineDefaultsFalse`) still pass, confirming the rejection only fires on the conflicting combination.
- `go build`, `go vet`, and `go test` pass for `cmd/aileron`, `internal/sandbox/toolchain`, and `internal/sandbox/container`; `gofmt` clean.

Closes #1558

🤖 Generated with [Claude Code](https://claude.com/claude-code)
