### PR TITLE
spec(flightplan): manifest + per-action trust-contract field specification

### DIFF
--- a/docs/schema/flight-plan-manifest.example.skill.md
+++ b/docs/schema/flight-plan-manifest.example.skill.md
@@ -147,4 +147,4 @@ This skill reads a recent metrics window, writes a short digest, and files a tra
 
 Binary outputs (for example a rendered chart image) are a deferred follow-up. v1 materializes text artifacts only. When binary outputs land, they will declare `encoding: base64` and ride the mount / run-and-collect boundary.
 
-This skill is not yet a Flight Plan. It carries no `lock` section because it has not been frozen. Freeze (tracked in [#1509](https://github.com/ALRubinger/aileron/issues/1509)) resolves the rung-2 capability-unit Features to image digests, pins the resolved capability set, attaches the per-action trust contract above, and signs the result. After freeze the `aileron.lock` section is present and immutable for that version.
+This skill is not yet a Flight Plan. It carries no `lock` section because it has not been frozen. Freeze (tracked in [#1509](https://github.com/ALRubinger/aileron/issues/1509)) resolves the rung-2 capability-unit `features` to image digests, pins the resolved capability set, attaches the per-action trust contract above, and signs the result. After freeze the `aileron.lock` section is present and immutable for that version.

--- a/docs/schema/flight-plan-manifest.example.skill.md
+++ b/docs/schema/flight-plan-manifest.example.skill.md
@@ -1,0 +1,150 @@
+---
+name: weekly-metrics-digest
+description: Read a metrics window from a metrics API, summarize it, and file a tracking issue with the summary.
+license: Apache-2.0
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: aws-sigv4
+            placement: signing
+            identityLabel: metrics-reader@example.com
+          hosts:
+            - api.example.com
+          paths:
+            - /v2/metrics/query
+          effect: read
+          idempotency:
+            safeToRetry: true
+            idempotencyKey: false
+          redaction:
+            - field: series[].labels.account_id
+              rule: hash
+          verification:
+            method: GET
+            path: /v2/health
+          audit:
+            fields:
+              - connector-hash
+              - action-manifest-version
+              - credential-binding
+              - identity-label
+              - approved-input
+              - approval-decision
+              - network-target
+              - operation-effect
+              - request-summary
+              - response-summary
+              - result
+            sink: audit/metrics-reads
+      - ref: aileron:tracker.create_issue
+        trustContract:
+          credential:
+            kind: oauth2
+            placement: header
+            identityLabel: digest-bot@example.com
+          oauth:
+            scopes:
+              - issues:write
+            endpoints:
+              authorization: https://auth.example.com/oauth/authorize
+              token: https://auth.example.com/oauth/token
+            refresh: refresh-token
+          hosts:
+            - tracker.example.com
+          paths:
+            - /api/v1/issues
+          effect: write
+          idempotency:
+            safeToRetry: false
+            idempotencyKey: true
+          redaction:
+            - field: assignee.email
+              rule: mask
+          verification:
+            method: GET
+            path: /api/v1/me
+          audit:
+            fields:
+              - connector-hash
+              - action-manifest-version
+              - credential-binding
+              - identity-label
+              - approved-input
+              - approval-decision
+              - network-target
+              - operation-effect
+              - request-summary
+              - response-summary
+              - result
+            sink: audit/tracker-writes
+    executionEnvironment:
+      rung2CapabilityUnits:
+        features:
+          - ghcr.io/example/aileron-feature-metrics-cli:1
+          - ghcr.io/example/aileron-feature-tracker-cli:1
+  inputs:
+    - name: window_days
+      type: number
+      description: How many days back the metrics window covers. A literal so one composition serves operators with different window sizes.
+      resolution:
+        rule: literal
+        default: 7
+    - name: as_of
+      type: timestamp
+      description: The launch timestamp the window is anchored to. Resolved once at launch so every step sees one clock value.
+      resolution:
+        rule: dynamic
+        value: now
+    - name: active_metric_set
+      type: array
+      description: The metric set to summarize, read live from the metrics API at launch.
+      resolution:
+        rule: source
+        source:
+          actionRef: aileron:metrics.query_series
+          select: series[].name
+  outputs:
+    - name: digest.csv
+      mimeType: text/csv
+      encoding: utf-8
+      publish:
+        target: file
+        path: digest.csv
+    - name: filed_issue.json
+      mimeType: application/json
+      encoding: utf-8
+      publish:
+        target: file
+        path: filed_issue.json
+---
+
+# Weekly Metrics Digest
+
+This skill reads a recent metrics window, writes a short digest, and files a tracking issue that links to it.
+
+## What it does
+
+1. Query the metrics API for the active metric set over the configured window.
+2. Render a compact CSV digest of the series.
+3. File a tracking issue whose body summarizes the digest.
+
+## Inputs
+
+- `window_days`: how far back to look. Defaults to the last seven days.
+- `as_of`: the moment the window is anchored to. Defaults to launch time.
+- `active_metric_set`: which series to include. Read live at launch.
+
+## Outputs
+
+- `digest.csv`: the rendered digest, one row per series.
+- `filed_issue.json`: the created tracking issue, including its URL.
+
+## Notes
+
+Binary outputs (for example a rendered chart image) are a deferred follow-up. v1 materializes text artifacts only. When binary outputs land, they will declare `encoding: base64` and ride the mount / run-and-collect boundary.
+
+This skill is not yet a Flight Plan. It carries no `lock` section because it has not been frozen. Freeze (tracked in [#1509](https://github.com/ALRubinger/aileron/issues/1509)) resolves the rung-2 capability-unit Features to image digests, pins the resolved capability set, attaches the per-action trust contract above, and signs the result. After freeze the `aileron.lock` section is present and immutable for that version.

--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -1,0 +1,463 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://withaileron.ai/schema/flight-plan-manifest.schema.json",
+  "title": "Aileron Flight Plan Manifest",
+  "description": "JSON Schema for the Aileron-specific block carried in a SKILL.md frontmatter. This block extends the agentskills.io SKILL.md format. It is lossless if stripped: a host without Aileron reads a valid skill and treats this block as inert. Authoritative model: ADR-0027 (Flight Plan = Sealed Installable Skill). This schema validates the `aileron` top-level block only. The skill keys it sits beside (name, description, and so on) are governed by the agentskills.io format and are not constrained here.",
+  "type": "object",
+  "properties": {
+    "aileron": {
+      "$ref": "#/$defs/aileronBlock"
+    }
+  },
+  "$comment": "The `aileron` block is optional at this top level so that a stripped manifest (the block removed) still validates. This encodes the lossless-if-stripped guarantee: the Aileron block is purely additive. An unsatisfied `requires:` is a missing-requirement signal resolved by the runtime, never a schema parse failure.",
+  "$defs": {
+    "aileronBlock": {
+      "type": "object",
+      "description": "The single namespaced top-level key that holds every Aileron-specific field. Namespacing under one key keeps the extension lossless if stripped.",
+      "additionalProperties": false,
+      "required": ["requires", "inputs", "outputs"],
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "description": "The manifest schema version. Optional. When present, identifies the Aileron block contract this manifest was authored against.",
+          "const": "aileron.flightplan.v1"
+        },
+        "requires": {
+          "$ref": "#/$defs/requires"
+        },
+        "inputs": {
+          "type": "array",
+          "description": "Declared inputs (REQUIRED). Every input the Flight Plan depends on is declared here, each with a resolution rule. A value that varies by use case (for example a time window) is a declared input rather than a constant baked into the composition, so one composition serves many operators. See ADR-0027 inputs/resolution and the determinism correction in #1523.",
+          "items": { "$ref": "#/$defs/input" }
+        },
+        "outputs": {
+          "type": "array",
+          "description": "Declared outputs (REQUIRED). The outputs contract names each artifact, its mimeType, its encoding, and its publish target. This is the declared INTERFACE the runtime materializes and distribution publishes. The audit references artifacts by name. The outputs contract is distinct from the file-map transport. See #1519.",
+          "items": { "$ref": "#/$defs/output" }
+        },
+        "lock": {
+          "$ref": "#/$defs/lock"
+        }
+      }
+    },
+    "requires": {
+      "type": "object",
+      "description": "Dependency declaration. Lists both the actions the Flight Plan calls and the execution-environment dependencies it runs in. An unsatisfied entry is a missing-requirement signal the runtime surfaces, never a parse failure.",
+      "additionalProperties": false,
+      "required": ["actions"],
+      "properties": {
+        "actions": {
+          "type": "array",
+          "description": "The actions the Flight Plan calls. Each entry attaches to the action model of ADR-0003 and carries a per-action trust contract.",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/actionRequirement" }
+        },
+        "executionEnvironment": {
+          "$ref": "#/$defs/executionEnvironment"
+        }
+      }
+    },
+    "actionRequirement": {
+      "type": "object",
+      "description": "One required action plus its per-action trust contract. The trust contract is the #925 field set, absorbed here.",
+      "additionalProperties": false,
+      "required": ["ref", "trustContract"],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "description": "The action reference in the form aileron:<connector>.<action> (for example aileron:metrics.query_series).",
+          "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+        },
+        "trustContract": { "$ref": "#/$defs/trustContract" }
+      }
+    },
+    "executionEnvironment": {
+      "type": "object",
+      "description": "The execution-environment dependency. Exactly one of rung-1 (a pinned prebuilt image) or rung-2 (composed capability units on the Aileron base) is declared per ADR-0027 execution rungs. Rung-3 per-step sibling-image dispatch is a reserved, build-deferred slot.",
+      "additionalProperties": false,
+      "properties": {
+        "rung1Image": {
+          "type": "object",
+          "description": "Rung one. The skill names a whole prebuilt image and freeze resolves it to a digest. The operator owns the image.",
+          "additionalProperties": false,
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "An OCI image reference. Pre-freeze this may be a tag (for example registry.example.com/runner:1.4). Freeze resolves it to an image@sha256: digest pin recorded in the lock section.",
+              "minLength": 1
+            }
+          }
+        },
+        "rung2CapabilityUnits": {
+          "type": "object",
+          "description": "Rung two. The skill declares capability units to compose onto a generic Aileron-provided agent-free minimal base image. Freeze composes the operator-owned capability-unit devcontainer Features and pins the result. The capability-unit shape is ADR-0026.",
+          "additionalProperties": false,
+          "required": ["features"],
+          "properties": {
+            "features": {
+              "type": "array",
+              "description": "The capability-unit devcontainer Feature references composed onto the base image.",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "description": "A devcontainer Feature reference for a capability unit (ADR-0026).",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "rung3PerStepImages": {
+          "$comment": "RESERVED, BUILD-DEFERRED. Rung three is per-step sealed sibling-image dispatch with mount and run-and-collect I/O. ADR-0027 defines it as a manifest slot only so a later build can fill it without a format change. It is intentionally typed loosely here and MUST NOT be relied on by v1 tooling.",
+          "type": "object",
+          "description": "RESERVED and build-deferred. Per-step sibling-image dispatch (ADR-0027 rung three). Designed as a manifest slot only; not implemented in v1. Do not author this field expecting runtime support."
+        }
+      }
+    },
+    "trustContract": {
+      "type": "object",
+      "description": "The per-action trust contract. Records the credential kind and placement, OAuth detail where applicable, the expected network reach, the operation effect, idempotency, redaction, a verification probe, and the audit-record structure. Freeze attaches this contract and the detached signature is the human attestation that it is correct (ADR-0027). No field in this contract may carry a credential value; the contract declares credential kind and placement only (ADR-0005, ADR-0019).",
+      "additionalProperties": false,
+      "required": ["credential", "hosts", "effect", "idempotency", "audit"],
+      "properties": {
+        "credential": { "$ref": "#/$defs/credential" },
+        "oauth": { "$ref": "#/$defs/oauth" },
+        "hosts": {
+          "type": "array",
+          "description": "The expected upstream hosts the action reaches. The access-scope declaration IS the security boundary: the runtime grants nothing undeclared. Each entry is a host, with an optional port, and carries no URL scheme or path. Reuses the connector-spec `hosts` vocabulary.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "description": "An allowed upstream host with an optional port, no scheme, no path (for example api.example.com or api.example.com:443).",
+            "pattern": "^[a-zA-Z0-9.-]+(?::[0-9]+)?$"
+          }
+        },
+        "paths": {
+          "type": "array",
+          "description": "The expected request paths the action reaches on the declared hosts. Part of the access-scope declaration. The runtime grants nothing undeclared.",
+          "items": {
+            "type": "string",
+            "description": "A request path, optionally a prefix (for example /v2/metrics or /v2/metrics/*).",
+            "minLength": 1
+          }
+        },
+        "effect": {
+          "type": "string",
+          "description": "The operation effect, aligned to ADR-0003. Drives default approval routing through the out-of-band channel of ADR-0009. `read` observes state; `write` creates or mutates state; `delete` removes state; `spend` commits money; `external-send` sends a message or artifact to a third party.",
+          "enum": ["read", "write", "delete", "spend", "external-send"]
+        },
+        "idempotency": { "$ref": "#/$defs/idempotency" },
+        "redaction": {
+          "type": "array",
+          "description": "Redaction rules applied to the operation's response fields before they reach the agent or author. Each rule names a field path and how it is redacted.",
+          "items": { "$ref": "#/$defs/redactionRule" }
+        },
+        "verification": { "$ref": "#/$defs/verification" },
+        "audit": { "$ref": "#/$defs/auditStructure" }
+      }
+    },
+    "credential": {
+      "type": "object",
+      "description": "The credential KIND and PLACEMENT this action uses. It never holds a credential VALUE. The runtime mediates credential use at the data-plane proxy boundary (ADR-0019) so the composed code never holds a raw credential (ADR-0005).",
+      "additionalProperties": false,
+      "required": ["kind", "placement"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The credential kind. `none` for an unauthenticated call; `api-key` for a static key or token; `oauth2` for an OAuth 2 access token (declare the `oauth` block alongside); `aws-sigv4` for an AWS request-signing credential.",
+          "enum": ["none", "api-key", "oauth2", "aws-sigv4"]
+        },
+        "placement": {
+          "type": "string",
+          "description": "Where the credential is placed on the wire. Maps 1:1 to the closed ADR-0019 injection-scheme set. `header` -> a bearer or templated header (ADR-0019 `bearer` or `header-template`); `query` -> ADR-0019 `query-param`; `body` -> the credential is carried in the request body; `cookie` -> the credential rides as a cookie; `signing` -> AWS SigV4, mapping to ADR-0019 `sigv4-resign` (sealed by #1501); `session` -> the cookie/session-token wire form for a session-authenticated upstream. The exact header or wire shape is per service, not per placement alone.",
+          "enum": ["header", "query", "cookie", "body", "signing", "session"]
+        },
+        "identityLabel": {
+          "type": "string",
+          "description": "A subject or account identity label for multi-tenant binding (for example the workspace or account the credential authenticates as). A non-secret label, never a credential value.",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "$comment": "An oauth2 credential is placed in a header, never via signing/query/cookie/body/session.",
+          "if": { "properties": { "kind": { "const": "oauth2" } } },
+          "then": { "properties": { "placement": { "const": "header" } } }
+        },
+        {
+          "$comment": "An aws-sigv4 credential is always placed via request signing.",
+          "if": { "properties": { "kind": { "const": "aws-sigv4" } } },
+          "then": { "properties": { "placement": { "const": "signing" } } }
+        }
+      ]
+    },
+    "oauth": {
+      "type": "object",
+      "description": "OAuth detail for an oauth2 credential. Records the scopes, endpoints, and refresh behavior. Declared alongside a credential of kind oauth2. Holds no token value.",
+      "additionalProperties": false,
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "description": "The OAuth scopes the action requires.",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "endpoints": {
+          "type": "object",
+          "description": "The OAuth endpoints. Non-secret URLs.",
+          "additionalProperties": false,
+          "properties": {
+            "authorization": { "type": "string", "description": "The authorization endpoint URL.", "format": "uri" },
+            "token": { "type": "string", "description": "The token endpoint URL.", "format": "uri" }
+          }
+        },
+        "refresh": {
+          "type": "string",
+          "description": "The refresh behavior. `refresh-token` uses a stored refresh token; `none` requires re-auth on expiry.",
+          "enum": ["refresh-token", "none"]
+        }
+      }
+    },
+    "idempotency": {
+      "type": "object",
+      "description": "Idempotency declaration, aligned to ADR-0003. Records whether the operation is safe to retry and whether it supports an idempotency key.",
+      "additionalProperties": false,
+      "required": ["safeToRetry"],
+      "properties": {
+        "safeToRetry": {
+          "type": "boolean",
+          "description": "True when re-running the operation with the same inputs produces no additional effect."
+        },
+        "idempotencyKey": {
+          "type": "boolean",
+          "description": "True when the operation accepts a client-supplied idempotency key that the upstream uses to deduplicate retried writes. Defaults to false.",
+          "default": false
+        }
+      }
+    },
+    "redactionRule": {
+      "type": "object",
+      "description": "One redaction rule. Names a response field and how it is redacted before reaching the agent or author.",
+      "additionalProperties": false,
+      "required": ["field", "rule"],
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "The response field path to redact (for example data[].email).",
+          "minLength": 1
+        },
+        "rule": {
+          "type": "string",
+          "description": "How the field is redacted. `drop` removes it; `mask` replaces its value with a fixed mask; `hash` replaces it with a stable hash.",
+          "enum": ["drop", "mask", "hash"]
+        }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "description": "A verification probe. A no-op or read-only call the runtime can issue to confirm the credential still works for this action.",
+      "additionalProperties": false,
+      "required": ["method", "path"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "The HTTP method of the probe. Read-only methods only.",
+          "enum": ["GET", "HEAD"]
+        },
+        "path": {
+          "type": "string",
+          "description": "The probe request path on one of the declared hosts.",
+          "minLength": 1
+        }
+      }
+    },
+    "auditStructure": {
+      "type": "object",
+      "description": "The structure of the audit record this operation emits. The audit records resolved inputs to outputs: scalars by value, data reads by their resolved binding (parameters, query, result or snapshot identifier, summary), never the full dataset inline (ADR-0027 audit boundary, #1523). The sink is customer-owned. The fields below enumerate the record's shape; this block declares which fields the operation's audit record carries.",
+      "additionalProperties": false,
+      "required": ["fields"],
+      "properties": {
+        "fields": {
+          "type": "array",
+          "description": "The audit-record fields this operation emits. Closed enum of the record shape. `connector-hash` the connector content hash; `action-manifest-version` the resolved action version; `credential-binding` the credential binding reference used (never the credential bytes); `identity-label` the subject/account identity; `approved-input` the resolved input that was approved; `approval-decision` the approval outcome; `network-target` the upstream host and path reached; `operation-effect` the recorded effect; `request-summary` a redacted request summary; `response-summary` a redacted response summary; `result` a result or snapshot identifier with a summary.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "connector-hash",
+              "action-manifest-version",
+              "credential-binding",
+              "identity-label",
+              "approved-input",
+              "approval-decision",
+              "network-target",
+              "operation-effect",
+              "request-summary",
+              "response-summary",
+              "result"
+            ]
+          }
+        },
+        "sink": {
+          "type": "string",
+          "description": "A reference to the customer-owned audit sink (for example a log stream or table name). A non-secret reference, never credentials for the sink.",
+          "minLength": 1
+        }
+      }
+    },
+    "input": {
+      "type": "object",
+      "description": "One declared input with its resolution rule. Inputs resolve once, at the launch boundary, into a concrete resolved-input set (ADR-0027, #1523).",
+      "additionalProperties": false,
+      "required": ["name", "type", "resolution"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The input name, unique within the manifest.",
+          "pattern": "^[a-zA-Z0-9_-]+$"
+        },
+        "type": {
+          "type": "string",
+          "description": "The input value type.",
+          "enum": ["string", "number", "boolean", "timestamp", "object", "array"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable semantics of the input."
+        },
+        "resolution": { "$ref": "#/$defs/resolution" }
+      }
+    },
+    "resolution": {
+      "type": "object",
+      "description": "An input resolution rule. Exactly one of three rules: `literal` (a value passed at launch), `dynamic` (a launch-relative value such as now or today), or `source` (a read from a live source). Discriminated by `rule`.",
+      "required": ["rule"],
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["rule"],
+          "properties": {
+            "rule": { "const": "literal", "description": "A literal value passed at launch." },
+            "default": {
+              "description": "An optional default value applied when no value is passed at launch."
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["rule", "value"],
+          "properties": {
+            "rule": { "const": "dynamic", "description": "A launch-relative dynamic value resolved once at launch." },
+            "value": {
+              "type": "string",
+              "description": "The dynamic value to resolve. `now` resolves to the launch timestamp; `today` resolves to the launch date.",
+              "enum": ["now", "today"]
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["rule", "source"],
+          "properties": {
+            "rule": { "const": "source", "description": "A read from a live source resolved once at launch." },
+            "source": {
+              "type": "object",
+              "description": "The live source to read. References a declared action and records the read by its resolved binding in the audit, never the full dataset inline.",
+              "additionalProperties": false,
+              "required": ["actionRef"],
+              "properties": {
+                "actionRef": {
+                  "type": "string",
+                  "description": "The action reference whose result resolves this input, in the form aileron:<connector>.<action>.",
+                  "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+                },
+                "select": {
+                  "type": "string",
+                  "description": "An optional selector identifying which part of the source result resolves this input."
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "output": {
+      "type": "object",
+      "description": "One declared output artifact. Names the artifact, its mimeType, its encoding, and its publish target. This is the declared INTERFACE, distinct from the file-map transport. The transport is a typed JSON file-map of {path, mimeType, encoding, content} entries the runtime materializes into files (#1519); this outputs block is the contract that names what those files are.",
+      "additionalProperties": false,
+      "required": ["name", "mimeType", "encoding", "publish"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The output artifact name, unique within the manifest. The audit references artifacts by this name.",
+          "pattern": "^[a-zA-Z0-9_.-]+$"
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "The artifact media type (for example text/csv or application/json).",
+          "minLength": 1
+        },
+        "encoding": {
+          "type": "string",
+          "description": "The artifact content encoding. `utf-8` is the v1 implementation. `base64` is RESERVED for binary outputs and is a deferred follow-up blocked on a host-ABI binary-body field; the mount / run-and-collect boundary (#1510) is the escape hatch for large or binary artifacts later. The enum value `base64` is present so the declared INTERFACE is binary-ready, but v1 implements `utf-8` only. Text-only is the v1 IMPLEMENTATION, never the declared INTERFACE.",
+          "enum": ["utf-8", "base64"]
+        },
+        "publish": {
+          "type": "object",
+          "description": "The publish target for this artifact. Where the runtime materializes and distribution publishes it.",
+          "additionalProperties": false,
+          "required": ["target"],
+          "properties": {
+            "target": {
+              "type": "string",
+              "description": "The publish target kind. `file` writes the artifact to the run's output file set; `none` retains the artifact in the run record without external publication.",
+              "enum": ["file", "none"]
+            },
+            "path": {
+              "type": "string",
+              "description": "The output file path when target is `file` (for example report.csv)."
+            }
+          }
+        }
+      }
+    },
+    "lock": {
+      "type": "object",
+      "description": "The lock and digest section. Produced by freeze (#1509): pins the resolved image digests and the resolved capability set, and records the manifest content hash plus semver label. ABSENT before freeze; this schema specifies its shape as freeze's target only. When present, every image reference is a content-addressed digest.",
+      "additionalProperties": false,
+      "properties": {
+        "resolvedImages": {
+          "type": "array",
+          "description": "The resolved image digest pins. Each entry pairs the pre-freeze reference with its resolved image@sha256: digest.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ref", "digest"],
+            "properties": {
+              "ref": { "type": "string", "description": "The pre-freeze image reference.", "minLength": 1 },
+              "digest": {
+                "type": "string",
+                "description": "The resolved content-addressed digest.",
+                "pattern": "^sha256:[a-f0-9]{64}$"
+              }
+            }
+          }
+        },
+        "resolvedCapabilitySet": {
+          "type": "array",
+          "description": "The resolved capability set the freeze pinned.",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "contentHash": {
+          "type": "string",
+          "description": "The content hash identifying the exact frozen manifest bytes.",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "version": {
+          "type": "string",
+          "description": "The human-facing semver label for this frozen version.",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -75,6 +75,10 @@
       "type": "object",
       "description": "The execution-environment dependency. Exactly one of rung-1 (a pinned prebuilt image) or rung-2 (composed capability units on the Aileron base) is declared per ADR-0027 execution rungs. Rung-3 per-step sibling-image dispatch is a reserved, build-deferred slot.",
       "additionalProperties": false,
+      "oneOf": [
+        { "required": ["rung1Image"], "not": { "required": ["rung2CapabilityUnits"] } },
+        { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } }
+      ],
       "properties": {
         "rung1Image": {
           "type": "object",
@@ -119,6 +123,13 @@
       "description": "The per-action trust contract. Records the credential kind and placement, OAuth detail where applicable, the expected network reach, the operation effect, idempotency, redaction, a verification probe, and the audit-record structure. Freeze attaches this contract and the detached signature is the human attestation that it is correct (ADR-0027). No field in this contract may carry a credential value; the contract declares credential kind and placement only (ADR-0005, ADR-0019).",
       "additionalProperties": false,
       "required": ["credential", "hosts", "effect", "idempotency", "audit"],
+      "allOf": [
+        {
+          "$comment": "An oauth2 credential MUST declare its oauth block.",
+          "if": { "properties": { "credential": { "properties": { "kind": { "const": "oauth2" } } } } },
+          "then": { "required": ["oauth"] }
+        }
+      ],
       "properties": {
         "credential": { "$ref": "#/$defs/credential" },
         "oauth": { "$ref": "#/$defs/oauth" },
@@ -160,7 +171,7 @@
       "type": "object",
       "description": "The credential KIND and PLACEMENT this action uses. It never holds a credential VALUE. The runtime mediates credential use at the data-plane proxy boundary (ADR-0019) so the composed code never holds a raw credential (ADR-0005).",
       "additionalProperties": false,
-      "required": ["kind", "placement"],
+      "required": ["kind"],
       "properties": {
         "kind": {
           "type": "string",
@@ -179,6 +190,11 @@
         }
       },
       "allOf": [
+        {
+          "$comment": "A placement is required for every credential kind except `none`.",
+          "if": { "properties": { "kind": { "not": { "const": "none" } } } },
+          "then": { "required": ["placement"] }
+        },
         {
           "$comment": "An oauth2 credential is placed in a header, never via signing/query/cookie/body/session.",
           "if": { "properties": { "kind": { "const": "oauth2" } } },
@@ -406,6 +422,13 @@
           "description": "The publish target for this artifact. Where the runtime materializes and distribution publishes it.",
           "additionalProperties": false,
           "required": ["target"],
+          "allOf": [
+            {
+              "$comment": "A file publish target MUST name the output path.",
+              "if": { "properties": { "target": { "const": "file" } } },
+              "then": { "required": ["path"] }
+            }
+          ],
           "properties": {
             "target": {
               "type": "string",

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -1,0 +1,220 @@
+---
+title: "Flight Plan Manifest Spec"
+description: "The SKILL.md frontmatter extension that declares a Flight Plan's requires block, per-action trust contract, inputs, outputs, and frozen lock section."
+order: 9
+---
+
+The Flight Plan manifest is the machine-readable contract that both the authoring tool prompts an operator to fill in and the runtime enforces. A Flight Plan is a sealed Aileron skill ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill)). The skill is the authoring artifact and the Flight Plan is the same artifact after a freeze step seals it. One format spans both states. This page specifies that format field by field.
+
+The manifest is the YAML frontmatter of a `SKILL.md` document in the [agentskills.io](https://agentskills.io) format, extended with a single Aileron-specific block. Every Aileron field lives under one namespaced top-level key so the extension is lossless if stripped. A host without Aileron reads a valid skill and treats the Aileron block as inert.
+
+This page is a spec deliverable. It defines the format. It does not ship a parser, a validator, the freeze step, or runtime enforcement. The Go parser and validator are tracked in [#1508](https://github.com/ALRubinger/aileron/issues/1508). Freeze is tracked in [#1509](https://github.com/ALRubinger/aileron/issues/1509). Runtime enforcement is tracked in [#1511](https://github.com/ALRubinger/aileron/issues/1511). The `lock` section is shaped here as freeze's target, not produced here.
+
+## Schema
+
+The normative schema is JSON Schema draft 2020-12. It lives outside the docs collection so the site never renders it as a page:
+
+```text
+docs/schema/flight-plan-manifest.schema.json
+```
+
+A worked, multi-action example that validates against the schema lives beside it:
+
+```text
+docs/schema/flight-plan-manifest.example.skill.md
+```
+
+A committed Go drift-guard test (`internal/flightplan/spec`) keeps the example and the schema from drifting apart. The Aileron block is the only part the schema constrains. The skill keys it sits beside (`name`, `description`, and so on) are governed by the agentskills.io format. The Aileron block is named `aileron` at the top level of the frontmatter:
+
+```yaml
+---
+name: weekly-metrics-digest
+description: Read a metrics window, summarize it, and file a tracking issue.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions: []          # the actions the plan calls, each with a trust contract
+    executionEnvironment: {}  # the rung-1 or rung-2 execution image
+  inputs: []             # declared inputs with resolution rules
+  outputs: []            # declared output artifacts
+  # lock: produced by freeze, absent before freeze
+---
+```
+
+## Field reference
+
+The tables below give every field's type, required-ness, and semantics. Field names align with [ADR-0003](/adr/0003-action-model) (effect, idempotency, approval routing) and [ADR-0019](/adr/0019-v4-https-data-plane) (the credential-placement scheme set). The `idempotency`, `credential`, `hosts`, and `audit` vocabulary reuses the connector-spec names from the [Sandbox Connector Specs](/development/sandbox-connector-specs/) page rather than inventing parallel ones.
+
+### `aileron` (top-level block)
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `schemaVersion` | string | No | When present, must be `aileron.flightplan.v1`. Identifies the block contract this manifest was authored against. |
+| `requires` | object | Yes | The action and execution-environment dependencies. |
+| `inputs` | array | Yes | The declared inputs, each with a resolution rule. |
+| `outputs` | array | Yes | The declared output artifacts. |
+| `lock` | object | No | The frozen lock and digest section. Absent before freeze. |
+
+### `requires`
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `actions` | array | Yes | The actions the plan calls. At least one entry. Each entry carries a per-action trust contract. |
+| `executionEnvironment` | object | No | The execution image the plan runs in, declared as one rung. |
+
+Each `actions[]` entry:
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `ref` | string | Yes | The action reference in the form `aileron:<connector>.<action>`. Attaches to the action model of [ADR-0003](/adr/0003-action-model). |
+| `trustContract` | object | Yes | The per-action trust contract for this action. |
+
+An unsatisfied `requires:` entry is a missing-requirement signal the runtime surfaces. It is never a parse failure. A manifest that names an action the host has not installed still parses as a valid skill.
+
+### `requires.executionEnvironment`
+
+The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). The MVP ships rung one and rung two.
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `rung1Image` | object | No | Rung one. Names a whole prebuilt operator-owned image. Freeze resolves it to a digest. |
+| `rung1Image.ref` | string | Yes within `rung1Image` | An OCI image reference. Freeze resolves a tag to an `image@sha256:` digest pin. |
+| `rung2CapabilityUnits` | object | No | Rung two. Declares capability units composed onto the Aileron agent-free base image. |
+| `rung2CapabilityUnits.features` | array | Yes within `rung2CapabilityUnits` | The capability-unit devcontainer Feature references ([ADR-0026](/adr/0026-cli-capability-units)). |
+| `rung3PerStepImages` | object | No | RESERVED and build-deferred. The rung-three per-step sibling-image dispatch slot. Designed as a manifest slot only. Not implemented in v1. |
+
+### `requires.actions[].trustContract`
+
+The trust contract is the field set absorbed from #925, quoted here as context rather than depended on. Freeze attaches this contract, and the detached signature is the human attestation that it is correct.
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `credential` | object | Yes | The credential kind and placement. Never a credential value. |
+| `oauth` | object | No | OAuth scopes, endpoints, and refresh behavior. Declared for an `oauth2` credential. |
+| `hosts` | array | Yes | The expected upstream hosts. The access-scope declaration IS the security boundary. The runtime grants nothing undeclared. |
+| `paths` | array | No | The expected request paths on the declared hosts. Part of the access-scope declaration. |
+| `effect` | string | Yes | One of `read`, `write`, `delete`, `spend`, `external-send`. Aligned to [ADR-0003](/adr/0003-action-model). Drives default approval routing through [ADR-0009](/adr/0009-user-channel). |
+| `idempotency` | object | Yes | Whether the operation is safe to retry and whether it supports an idempotency key. |
+| `redaction` | array | No | Rules applied to response fields before they reach the agent or author. |
+| `verification` | object | No | A read-only probe the runtime can call to confirm the credential still works. |
+| `audit` | object | Yes | The structure of the audit record this operation emits. |
+
+The `credential` block:
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `kind` | string | Yes | One of `none`, `api-key`, `oauth2`, `aws-sigv4`. |
+| `placement` | string | Yes | One of `header`, `query`, `cookie`, `body`, `signing`, `session`. Maps 1:1 to the closed [ADR-0019](/adr/0019-v4-https-data-plane) injection-scheme set. |
+| `identityLabel` | string | No | A subject or account identity label for multi-tenant binding. A non-secret label. |
+
+The placement values map to the [ADR-0019](/adr/0019-v4-https-data-plane) wire mechanisms. `header` is a bearer or templated header (`bearer` or `header-template`). `query` is `query-param`. `signing` is AWS SigV4, which maps to `sigv4-resign` and is sealed by [#1501](https://github.com/ALRubinger/aileron/issues/1501). `session` is the cookie or session-token wire form for a session-authenticated upstream. `body` carries the credential in the request body. The exact header or wire shape is per service, not per placement alone.
+
+The `idempotency` block:
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `safeToRetry` | boolean | Yes | True when re-running with the same inputs produces no additional effect. |
+| `idempotencyKey` | boolean | No | True when the operation accepts a client-supplied idempotency key. Defaults to false. |
+
+The `audit` block:
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `fields` | array | Yes | The closed set of audit-record fields this operation emits. |
+| `sink` | string | No | A reference to the customer-owned audit sink. A non-secret reference. |
+
+The closed `audit.fields` set is `connector-hash`, `action-manifest-version`, `credential-binding`, `identity-label`, `approved-input`, `approval-decision`, `network-target`, `operation-effect`, `request-summary`, `response-summary`, and `result`.
+
+### `inputs[]`
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `name` | string | Yes | The input name, unique within the manifest. |
+| `type` | string | Yes | One of `string`, `number`, `boolean`, `timestamp`, `object`, `array`. |
+| `description` | string | No | Human-readable semantics. |
+| `resolution` | object | Yes | The resolution rule. One of `literal`, `dynamic`, or `source`. |
+
+### `outputs[]`
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `name` | string | Yes | The artifact name, unique within the manifest. The audit references artifacts by this name. |
+| `mimeType` | string | Yes | The artifact media type. |
+| `encoding` | string | Yes | One of `utf-8`, `base64`. `base64` is reserved. v1 implements `utf-8` only. |
+| `publish` | object | Yes | The publish target. `target` is `file` or `none`; `path` names the output file when `target` is `file`. |
+
+## Lossless if stripped
+
+The extension is lossless if stripped. A tool that ignores the Aileron fields still reads a valid skill. The schema encodes this guarantee two ways. The `aileron` block is optional at the top level, so a manifest with the block removed is not rejected. Every Aileron-specific field is nested under that one key, so removing it leaves the agentskills.io skill keys untouched.
+
+The same worked example with its Aileron block removed is still a valid skill:
+
+```yaml
+---
+name: weekly-metrics-digest
+description: Read a metrics window, summarize it, and file a tracking issue.
+license: Apache-2.0
+---
+
+# Weekly Metrics Digest
+
+This skill reads a recent metrics window, writes a short digest, and files a
+tracking issue that links to it.
+```
+
+A host without Aileron parses the document above and runs it as an instruction-only skill. An unsatisfied `requires:` is a missing-requirement signal, never a parse failure, so a host that does read the Aileron block but lacks a named action reports a missing requirement rather than refusing to load the document.
+
+## Credential sealing invariant
+
+The manifest declares credential kind and placement. It never declares a credential value. This is load-bearing and follows [ADR-0005](/adr/0005-sandbox-choice) and [ADR-0019](/adr/0019-v4-https-data-plane). The runtime mediates credential use at the data-plane proxy boundary so the composed code never holds a raw credential.
+
+No field in the schema can hold a secret. The `credential` block declares `kind`, `placement`, and a non-secret `identityLabel`. The `oauth` block declares scopes, endpoint URLs, and refresh behavior, never a token. The `audit` structure records a credential binding reference, never the credential bytes. The frozen artifact and the audit records carry bindings and references, never secret material.
+
+## Inputs and resolution
+
+A Flight Plan is a pinned, agent-invariant function over its declared inputs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill), durable record in [#1523](https://github.com/ALRubinger/aileron/issues/1523)). It is deterministic given its resolved inputs. Results legitimately vary as inputs and externally-connected data vary. The crisp line is that an LLM in the runtime loop is forbidden because it injects non-determinism into the logic, while a live or time-relative data read is an allowed input that varies the data, not the logic.
+
+Every input the plan depends on is declared, each with a resolution rule. A value that varies by use case, such as a time window, is a declared input rather than a constant baked into the composition, so one composition serves many operators. Inputs resolve once, at the launch boundary, into a concrete resolved-input set. Two steps that read the same moving value such as the wall clock see one resolved value.
+
+There are three resolution rules, discriminated by the `rule` field.
+
+| `rule` | Required fields | Semantics |
+|---|---|---|
+| `literal` | none beyond `rule` | A value passed at launch. An optional `default` applies when no value is passed. |
+| `dynamic` | `value` | A launch-relative value resolved once at launch. `value` is `now` (the launch timestamp) or `today` (the launch date). |
+| `source` | `source` | A read from a live source. `source.actionRef` names the action whose result resolves the input, with an optional `source.select`. |
+
+## Outputs contract versus file-map transport
+
+The `outputs:` block is the declared interface. The file-map is the transport. They are kept distinct so the transport can change later without changing the declared contract ([#1519](https://github.com/ALRubinger/aileron/issues/1519)).
+
+The `outputs:` block names each artifact, its `mimeType`, its `encoding`, and its publish target. This is the contract the runtime materializes and distribution publishes, and the audit references artifacts by name. The transport is a typed JSON file-map. A step returns an array of `{path, mimeType, encoding, content}` entries that the runtime materializes into files. The file-map generalizes the existing `get-file-content` shape. The `outputs:` block is the contract that names what those files are.
+
+Both the file-entry and the `outputs:` contract carry `mimeType` and `encoding`. The `encoding` enum is `utf-8` and `base64`. v1 implements `utf-8` only. Text-only is the v1 implementation, never the declared interface. Binary outputs are a deferred follow-up blocked on a host-ABI binary-body field, and the mount or run-and-collect boundary ([#1510](https://github.com/ALRubinger/aileron/issues/1510)) is the escape hatch for large or binary artifacts later.
+
+## Audit record structure
+
+The audit records resolved inputs to outputs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) audit boundary, [#1523](https://github.com/ALRubinger/aileron/issues/1523)). A scalar input is recorded by value, so a `current_timestamp` input that resolved to a concrete `as_of` is written down as that timestamp. A data read is recorded by its resolved binding, which is the parameters, the query, and a result or snapshot identifier with a summary, never the full dataset inline. The dataset is the run's recorded output, and the audit references it rather than duplicating it.
+
+Each operation's `audit.fields` declares which of the closed record fields it emits. The closed set is `connector-hash`, `action-manifest-version`, `credential-binding`, `identity-label`, `approved-input`, `approval-decision`, `network-target`, `operation-effect`, `request-summary`, `response-summary`, and `result`. The sink is customer-owned. The recorded binding is what makes a past run explainable without reconstructing it from a moving source.
+
+## Freeze and the lock section
+
+Freeze turns a skill into a Flight Plan ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) freeze boundary). Freeze resolves every image reference to a content-addressed digest, produces a lockfile that pins those digests and the resolved capability set, binds the execution environment, attaches the per-action trust contract, and signs the result. The `lock` section is the record of those pins.
+
+The `lock` section is absent before freeze. This page specifies its shape only, as freeze's target. Freeze itself is tracked in [#1509](https://github.com/ALRubinger/aileron/issues/1509).
+
+| Field | Type | Required | Semantics |
+|---|---|---|---|
+| `resolvedImages` | array | No | The resolved image digest pins. Each entry pairs a pre-freeze `ref` with its resolved `digest`. |
+| `resolvedCapabilitySet` | array | No | The resolved capability set the freeze pinned. |
+| `contentHash` | string | No | The content hash identifying the exact frozen manifest bytes. |
+| `version` | string | No | The human-facing semver label for this frozen version. |
+
+The version is the content hash plus a semver label. The content hash identifies the exact frozen bytes. The semver label is the human-facing version name.
+
+## Execution rungs
+
+A Flight Plan runs on a composed execution image assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). Rung one pins a whole prebuilt operator-owned image, declared as `rung1Image`. Rung two declares capability units that Aileron composes onto a generic agent-free minimal base image, declared as `rung2CapabilityUnits` whose Features follow [ADR-0026](/adr/0026-cli-capability-units).
+
+The MVP ships rung one and rung two. Rung three is a per-step sealed sibling-image dispatch with mount and run-and-collect I/O. Rung three is designed as the `rung3PerStepImages` manifest slot so a later build can fill it without a format change. Rung three is build-deferred and out of scope here. The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -73,7 +73,7 @@ An unsatisfied `requires:` entry is a missing-requirement signal the runtime sur
 
 ### `requires.executionEnvironment`
 
-The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). The MVP ships rung one and rung two.
+The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). The MVP ships rung one and rung two. When `executionEnvironment` is declared it carries exactly one of `rung1Image` or `rung2CapabilityUnits`.
 
 | Field | Type | Required | Semantics |
 |---|---|---|---|
@@ -90,7 +90,7 @@ The trust contract is the field set absorbed from #925, quoted here as context r
 | Field | Type | Required | Semantics |
 |---|---|---|---|
 | `credential` | object | Yes | The credential kind and placement. Never a credential value. |
-| `oauth` | object | No | OAuth scopes, endpoints, and refresh behavior. Declared for an `oauth2` credential. |
+| `oauth` | object | Required when `credential.kind` is `oauth2` | OAuth scopes, endpoints, and refresh behavior. |
 | `hosts` | array | Yes | The expected upstream hosts. The access-scope declaration IS the security boundary. The runtime grants nothing undeclared. |
 | `paths` | array | No | The expected request paths on the declared hosts. Part of the access-scope declaration. |
 | `effect` | string | Yes | One of `read`, `write`, `delete`, `spend`, `external-send`. Aligned to [ADR-0003](/adr/0003-action-model). Drives default approval routing through [ADR-0009](/adr/0009-user-channel). |
@@ -104,8 +104,10 @@ The `credential` block:
 | Field | Type | Required | Semantics |
 |---|---|---|---|
 | `kind` | string | Yes | One of `none`, `api-key`, `oauth2`, `aws-sigv4`. |
-| `placement` | string | Yes | One of `header`, `query`, `cookie`, `body`, `signing`, `session`. Maps 1:1 to the closed [ADR-0019](/adr/0019-v4-https-data-plane) injection-scheme set. |
+| `placement` | string | Yes unless `kind` is `none` | One of `header`, `query`, `cookie`, `body`, `signing`, `session`. Maps 1:1 to the closed [ADR-0019](/adr/0019-v4-https-data-plane) injection-scheme set. A `none` credential has no wire placement. |
 | `identityLabel` | string | No | A subject or account identity label for multi-tenant binding. A non-secret label. |
+
+An `oauth2` credential must declare the `oauth` block. An `aws-sigv4` credential is always placed via `signing`, and an `oauth2` credential is always placed in a `header`.
 
 The placement values map to the [ADR-0019](/adr/0019-v4-https-data-plane) wire mechanisms. `header` is a bearer or templated header (`bearer` or `header-template`). `query` is `query-param`. `signing` is AWS SigV4, which maps to `sigv4-resign` and is sealed by [#1501](https://github.com/ALRubinger/aileron/issues/1501). `session` is the cookie or session-token wire form for a session-authenticated upstream. `body` carries the credential in the request body. The exact header or wire shape is per service, not per placement alone.
 
@@ -141,7 +143,7 @@ The closed `audit.fields` set is `connector-hash`, `action-manifest-version`, `c
 | `name` | string | Yes | The artifact name, unique within the manifest. The audit references artifacts by this name. |
 | `mimeType` | string | Yes | The artifact media type. |
 | `encoding` | string | Yes | One of `utf-8`, `base64`. `base64` is reserved. v1 implements `utf-8` only. |
-| `publish` | object | Yes | The publish target. `target` is `file` or `none`; `path` names the output file when `target` is `file`. |
+| `publish` | object | Yes | The publish target. `target` is `file` or `none`; `path` is required and names the output file when `target` is `file`. |
 
 ## Lossless if stripped
 

--- a/docs/src/content/docs/development/index.md
+++ b/docs/src/content/docs/development/index.md
@@ -17,6 +17,7 @@ If you're looking for end-user docs, the [Getting Started](/getting-started/) gu
 - [Sandbox Composition](/development/sandbox-composition/) — how Aileron uses devcontainer.json, `ghcr.io/alrubinger/aileron-sandbox-base`, and `aileron sandbox` to define the agent container image.
 - [Sandbox Agent Images](/development/sandbox-agent-images/) — which agent commands are supported by the selected sandbox image and how to check them before launch.
 - [Sandbox Connector Specs](/development/sandbox-connector-specs/) — how installed connector specs drive data-plane operation validation in sandboxed launch sessions.
+- [Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) — the `SKILL.md` frontmatter extension that declares a Flight Plan's `requires` block, per-action trust contract, inputs, outputs, and frozen lock section.
 - [Sandbox Proxy CLI Verification Matrix](/development/sandbox-proxy-cli-matrix/) — verify the v4 HTTPS proxy works with `curl`, `gh`, and `aws`; success and failure cases with expected audit events.
 - [Submitting Changes](/development/submitting-changes/) — branch and PR conventions, commit message format, ADR amendments, what gets reviewed.
 - [Adding an Agent](/development/adding-an-agent/) — how to wire a new AI coding agent into `aileron launch` via the `Agent` SPI.

--- a/internal/flightplan/spec/doc.go
+++ b/internal/flightplan/spec/doc.go
@@ -1,0 +1,14 @@
+// Package spec holds the drift-guard test for the Flight Plan manifest
+// specification artifacts that live under docs/.
+//
+// The normative artifacts are the JSON Schema at
+// docs/schema/flight-plan-manifest.schema.json and the worked example at
+// docs/schema/flight-plan-manifest.example.skill.md, both described by the
+// prose specification at
+// docs/src/content/docs/development/flight-plan-manifest-spec.md.
+//
+// This package ships no runtime parser or validator. The Flight Plan parser,
+// validator, freeze, and runtime enforcement are out of scope here and tracked
+// in #1508, #1509, and #1511. The only Go in this package is a test that keeps
+// the schema and the worked example from drifting apart.
+package spec

--- a/internal/flightplan/spec/schema_test.go
+++ b/internal/flightplan/spec/schema_test.go
@@ -96,24 +96,25 @@ func frontmatter(t *testing.T, mdPath string) map[string]any {
 }
 
 // splitFrontmatter splits a Markdown document into its YAML frontmatter block
-// and the remaining body. It expects the document to open with a `---` fence.
+// and the remaining body. It expects the document to open with a `---` fence and
+// closes on the first standalone `---` line, so a body line that merely starts
+// with three dashes (a thematic break, for example) is not mistaken for the
+// closing fence.
 func splitFrontmatter(raw []byte) (front, body []byte, ok bool) {
 	const fence = "---"
-	text := string(raw)
-	// Normalize to avoid CRLF surprises.
-	text = strings.ReplaceAll(text, "\r\n", "\n")
-	if !strings.HasPrefix(text, fence+"\n") {
+	text := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || lines[0] != fence {
 		return nil, nil, false
 	}
-	rest := text[len(fence)+1:]
-	idx := strings.Index(rest, "\n"+fence)
-	if idx < 0 {
-		return nil, nil, false
+	for i := 1; i < len(lines); i++ {
+		if lines[i] == fence {
+			front = []byte(strings.Join(lines[1:i], "\n"))
+			body = []byte(strings.Join(lines[i+1:], "\n"))
+			return front, body, true
+		}
 	}
-	front = []byte(rest[:idx])
-	afterFence := rest[idx+1+len(fence):]
-	afterFence = strings.TrimPrefix(afterFence, "\n")
-	return front, []byte(afterFence), true
+	return nil, nil, false
 }
 
 // jsonifyMap round-trips a YAML-decoded value through JSON so that the schema
@@ -284,5 +285,95 @@ func TestNoSecretValueField(t *testing.T) {
 	cred["value"] = "super-secret-token"
 	if err := sch.Validate(inst); err == nil {
 		t.Fatal("the credential block must reject any secret-bearing field; additionalProperties is closed")
+	}
+}
+
+// TestExecutionEnvironmentRequiresExactlyOneRung: an execution environment that
+// declares both rung1Image and rung2CapabilityUnits, or neither, fails. The
+// prose states exactly one rung is declared (ADR-0027 execution rungs).
+func TestExecutionEnvironmentRequiresExactlyOneRung(t *testing.T) {
+	sch := compileSchema(t)
+
+	bothRungs := func(env map[string]any) {
+		env["rung1Image"] = map[string]any{"ref": "registry.example.com/runner:1.4"}
+		env["rung2CapabilityUnits"] = map[string]any{"features": []any{"ghcr.io/example/feature:1"}}
+	}
+	emptyEnv := func(env map[string]any) {
+		delete(env, "rung1Image")
+		delete(env, "rung2CapabilityUnits")
+	}
+
+	for name, mutate := range map[string]func(map[string]any){
+		"both rungs": bothRungs,
+		"no rung":    emptyEnv,
+	} {
+		t.Run(name, func(t *testing.T) {
+			inst := validExampleInstance(t)
+			blk := aileronBlock(t, inst)
+			requires := blk["requires"].(map[string]any)
+			env := requires["executionEnvironment"].(map[string]any)
+			mutate(env)
+			if err := sch.Validate(inst); err == nil {
+				t.Fatalf("an execution environment with %q must be rejected", name)
+			}
+		})
+	}
+}
+
+// TestOAuthRequiredForOAuth2Credential: an oauth2 credential without its oauth
+// block fails. The prose couples the two.
+func TestOAuthRequiredForOAuth2Credential(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	actions := blk["requires"].(map[string]any)["actions"].([]any)
+	// The second action carries the oauth2 credential in the worked example.
+	var found bool
+	for _, a := range actions {
+		tc := a.(map[string]any)["trustContract"].(map[string]any)
+		cred := tc["credential"].(map[string]any)
+		if cred["kind"] == "oauth2" {
+			delete(tc, "oauth")
+			found = true
+			break
+		}
+	}
+	if !found {
+		t.Fatal("expected the worked example to carry an oauth2 credential")
+	}
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("an oauth2 credential without an oauth block must be rejected")
+	}
+}
+
+// TestFilePublishTargetRequiresPath: a file publish target without a path fails.
+func TestFilePublishTargetRequiresPath(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	outputs := blk["outputs"].([]any)
+	first := outputs[0].(map[string]any)
+	publish := first["publish"].(map[string]any)
+	if publish["target"] != "file" {
+		t.Fatal("expected the first output to publish to a file target")
+	}
+	delete(publish, "path")
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("a file publish target without a path must be rejected")
+	}
+}
+
+// TestNoneCredentialNeedsNoPlacement: a credential of kind none validates without
+// a placement, because an unauthenticated call has no wire placement.
+func TestNoneCredentialNeedsNoPlacement(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	actions := blk["requires"].(map[string]any)["actions"].([]any)
+	tc := actions[0].(map[string]any)["trustContract"].(map[string]any)
+	// Replace the first action's credential with a placement-free `none` kind.
+	tc["credential"] = map[string]any{"kind": "none"}
+	if err := sch.Validate(inst); err != nil {
+		t.Fatalf("a credential of kind none must validate without a placement:\n%v", err)
 	}
 }

--- a/internal/flightplan/spec/schema_test.go
+++ b/internal/flightplan/spec/schema_test.go
@@ -1,0 +1,288 @@
+package spec
+
+import (
+	"bytes"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+// These tests guard the Flight Plan manifest spec artifacts under docs/ against
+// drift. They validate the contract (the JSON Schema), not any implementation
+// internals. The artifacts live outside this Go module, so go:embed cannot
+// reach them; the paths are resolved from the repo root computed via
+// runtime.Caller.
+
+// repoRoot walks up from this source file to the repository root (the directory
+// that contains go.work).
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate the repo root")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.work walking up from %s", filepath.Dir(file))
+		}
+		dir = parent
+	}
+}
+
+func schemaPath(t *testing.T) string {
+	return filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.schema.json")
+}
+
+func examplePath(t *testing.T) string {
+	return filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.skill.md")
+}
+
+// compileSchema compiles the committed Flight Plan manifest schema.
+func compileSchema(t *testing.T) *jsonschema.Schema {
+	t.Helper()
+	f, err := os.Open(schemaPath(t))
+	if err != nil {
+		t.Fatalf("open schema: %v", err)
+	}
+	defer f.Close()
+
+	doc, err := jsonschema.UnmarshalJSON(f)
+	if err != nil {
+		t.Fatalf("parse schema JSON: %v", err)
+	}
+
+	c := jsonschema.NewCompiler()
+	const loc = "https://withaileron.ai/schema/flight-plan-manifest.schema.json"
+	if err := c.AddResource(loc, doc); err != nil {
+		t.Fatalf("add schema resource: %v", err)
+	}
+	sch, err := c.Compile(loc)
+	if err != nil {
+		t.Fatalf("compile schema: %v", err)
+	}
+	return sch
+}
+
+// frontmatter extracts the YAML frontmatter from a SKILL.md document and returns
+// it decoded as a JSON-shaped value the validator can consume, plus the raw
+// frontmatter map.
+func frontmatter(t *testing.T, mdPath string) map[string]any {
+	t.Helper()
+	raw, err := os.ReadFile(mdPath)
+	if err != nil {
+		t.Fatalf("read %s: %v", mdPath, err)
+	}
+	front, _, ok := splitFrontmatter(raw)
+	if !ok {
+		t.Fatalf("no YAML frontmatter found in %s", mdPath)
+	}
+
+	var m map[string]any
+	if err := yaml.Unmarshal(front, &m); err != nil {
+		t.Fatalf("parse frontmatter YAML: %v", err)
+	}
+	return jsonifyMap(t, m)
+}
+
+// splitFrontmatter splits a Markdown document into its YAML frontmatter block
+// and the remaining body. It expects the document to open with a `---` fence.
+func splitFrontmatter(raw []byte) (front, body []byte, ok bool) {
+	const fence = "---"
+	text := string(raw)
+	// Normalize to avoid CRLF surprises.
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	if !strings.HasPrefix(text, fence+"\n") {
+		return nil, nil, false
+	}
+	rest := text[len(fence)+1:]
+	idx := strings.Index(rest, "\n"+fence)
+	if idx < 0 {
+		return nil, nil, false
+	}
+	front = []byte(rest[:idx])
+	afterFence := rest[idx+1+len(fence):]
+	afterFence = strings.TrimPrefix(afterFence, "\n")
+	return front, []byte(afterFence), true
+}
+
+// jsonifyMap round-trips a YAML-decoded value through JSON so that the schema
+// validator sees the same value model it expects (string keys, float64 numbers,
+// []any and map[string]any containers).
+func jsonifyMap(t *testing.T, m map[string]any) map[string]any {
+	t.Helper()
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(m); err != nil {
+		t.Fatalf("re-encode frontmatter to JSON: %v", err)
+	}
+	out, err := jsonschema.UnmarshalJSON(&buf)
+	if err != nil {
+		t.Fatalf("decode frontmatter as JSON: %v", err)
+	}
+	asMap, ok := out.(map[string]any)
+	if !ok {
+		t.Fatalf("frontmatter did not decode to a JSON object, got %T", out)
+	}
+	return asMap
+}
+
+// TestWorkedExampleValidates is the happy path: the committed worked example
+// validates against the committed schema. This is the drift guard.
+func TestWorkedExampleValidates(t *testing.T) {
+	sch := compileSchema(t)
+	inst := frontmatter(t, examplePath(t))
+	if err := sch.Validate(inst); err != nil {
+		t.Fatalf("worked example must validate against the schema:\n%v", err)
+	}
+}
+
+// TestStrippedManifestStillValid asserts the lossless-if-stripped guarantee at
+// the schema level: removing the entire `aileron` block leaves a document that
+// the schema does not reject. A host without Aileron reads a valid skill.
+func TestStrippedManifestStillValid(t *testing.T) {
+	sch := compileSchema(t)
+	inst := frontmatter(t, examplePath(t))
+	delete(inst, "aileron")
+	if err := sch.Validate(inst); err != nil {
+		t.Fatalf("a stripped manifest (no aileron block) must not be rejected by the schema:\n%v", err)
+	}
+}
+
+// TestStrippedBodyRemainsCoherentSkill confirms the worked example's Markdown
+// body remains a self-contained skill with the Aileron frontmatter block
+// removed: it keeps a name and description and a non-empty body.
+func TestStrippedBodyRemainsCoherentSkill(t *testing.T) {
+	raw, err := os.ReadFile(examplePath(t))
+	if err != nil {
+		t.Fatalf("read example: %v", err)
+	}
+	front, body, ok := splitFrontmatter(raw)
+	if !ok {
+		t.Fatal("no frontmatter")
+	}
+	var m map[string]any
+	if err := yaml.Unmarshal(front, &m); err != nil {
+		t.Fatalf("parse frontmatter: %v", err)
+	}
+	if _, hasName := m["name"]; !hasName {
+		t.Error("stripped skill must still carry a name")
+	}
+	if _, hasDesc := m["description"]; !hasDesc {
+		t.Error("stripped skill must still carry a description")
+	}
+	if strings.TrimSpace(string(body)) == "" {
+		t.Error("stripped skill must still carry a non-empty body")
+	}
+}
+
+// mutate returns a deep-ish copy of the worked example's instance with a
+// mutation applied, so each contract-failure case starts from a valid base.
+func validExampleInstance(t *testing.T) map[string]any {
+	return frontmatter(t, examplePath(t))
+}
+
+func aileronBlock(t *testing.T, inst map[string]any) map[string]any {
+	t.Helper()
+	blk, ok := inst["aileron"].(map[string]any)
+	if !ok {
+		t.Fatalf("aileron block missing or not an object, got %T", inst["aileron"])
+	}
+	return blk
+}
+
+// TestMissingInputsRejected: a manifest with no `inputs` block fails, because
+// inputs are REQUIRED (the determinism correction in #1523).
+func TestMissingInputsRejected(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	delete(aileronBlock(t, inst), "inputs")
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("a manifest missing the required inputs block must be rejected")
+	}
+}
+
+// TestMissingOutputsRejected: a manifest with no `outputs` block fails, because
+// outputs are REQUIRED (the output contract correction in #1519).
+func TestMissingOutputsRejected(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	delete(aileronBlock(t, inst), "outputs")
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("a manifest missing the required outputs block must be rejected")
+	}
+}
+
+// TestBadEffectRejected: an out-of-enum operation effect fails. The effect enum
+// is closed and aligned to ADR-0003.
+func TestBadEffectRejected(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	requires := blk["requires"].(map[string]any)
+	actions := requires["actions"].([]any)
+	first := actions[0].(map[string]any)
+	tc := first["trustContract"].(map[string]any)
+	tc["effect"] = "mutate-everything"
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("an out-of-enum effect must be rejected")
+	}
+}
+
+// TestBadEncodingRejected: an unknown output encoding fails. The encoding enum
+// is closed to utf-8 and base64.
+func TestBadEncodingRejected(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	outputs := blk["outputs"].([]any)
+	first := outputs[0].(map[string]any)
+	first["encoding"] = "utf-16"
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("an unknown output encoding must be rejected")
+	}
+}
+
+// TestReservedBase64EncodingAccepted: base64 is reserved in the interface, so
+// the schema must accept it even though v1 implements utf-8 only. The
+// text-only restriction is an implementation property, not the declared
+// contract.
+func TestReservedBase64EncodingAccepted(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	outputs := blk["outputs"].([]any)
+	first := outputs[0].(map[string]any)
+	first["encoding"] = "base64"
+	if err := sch.Validate(inst); err != nil {
+		t.Fatalf("base64 encoding must be accepted as a reserved interface value:\n%v", err)
+	}
+}
+
+// TestNoSecretValueField asserts the load-bearing invariant that no field in the
+// credential contract can hold a secret value. The credential block declares
+// kind and placement only. Adding an obvious secret-bearing key makes the
+// closed object invalid.
+func TestNoSecretValueField(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	requires := blk["requires"].(map[string]any)
+	actions := requires["actions"].([]any)
+	first := actions[0].(map[string]any)
+	tc := first["trustContract"].(map[string]any)
+	cred := tc["credential"].(map[string]any)
+	cred["value"] = "super-secret-token"
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("the credential block must reject any secret-bearing field; additionalProperties is closed")
+	}
+}

--- a/internal/go.mod
+++ b/internal/go.mod
@@ -14,6 +14,7 @@ require (
 	github.com/oapi-codegen/oapi-codegen/v2 v2.7.1
 	github.com/oapi-codegen/runtime v1.4.2
 	github.com/oklog/ulid/v2 v2.1.1
+	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2
 	github.com/testcontainers/testcontainers-go/modules/postgres v0.43.0
 	github.com/tetratelabs/wazero v1.12.0
 	go.opentelemetry.io/otel v1.44.0
@@ -89,7 +90,6 @@ require (
 	github.com/pb33f/ordered-map/v2 v2.3.1 // indirect
 	github.com/pmezard/go-difflib v1.0.1-0.20181226105442-5d4384ee4fb2 // indirect
 	github.com/power-devops/perfstat v0.0.0-20240221224432-82ca36839d55 // indirect
-	github.com/santhosh-tekuri/jsonschema/v6 v6.0.2 // indirect
 	github.com/shirou/gopsutil/v4 v4.26.5 // indirect
 	github.com/sirupsen/logrus v1.9.4 // indirect
 	github.com/speakeasy-api/jsonpath v0.6.3 // indirect


### PR DESCRIPTION
## Summary

Ships the Flight Plan manifest field specification for #1507 as a spec deliverable (no parser, validator, freeze, or runtime enforcement; those stay #1508/#1509/#1511). Absorbs and replaces #925. The authoritative model is [ADR-0027](https://github.com/ALRubinger/aileron/blob/main/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md) plus the two required corrections in the issue body (determinism over resolved inputs #1523; file-artifact outputs contract #1519).

Three artifacts plus a drift guard:

- **JSON Schema** (`docs/schema/flight-plan-manifest.schema.json`, draft 2020-12) defining the namespaced `aileron` block: `requires` (actions + exec-env rungs 1/2, rung-3 reserved+deferred), per-action `trustContract` (credential kind/placement aligned to [ADR-0019](https://github.com/ALRubinger/aileron/blob/main/docs/src/content/docs/adr/0019-v4-https-data-plane.md) injection schemes, oauth, hosts/paths, effect, idempotency, redaction, verification, audit), `inputs[]` (literal | dynamic | source resolution), `outputs[]` (`mimeType` + `encoding` with `base64` reserved), and the freeze-produced `lock` section.
- **Worked example** (`docs/schema/flight-plan-manifest.example.skill.md`): a multi-action Flight Plan (metrics read with `aws-sigv4`/`signing`, tracker write with `oauth2`), generic and customer-free, exercising all three input resolution rules and a text output. Validates against the schema and is lossless if stripped.
- **Prose field spec** (`docs/src/content/docs/development/flight-plan-manifest-spec.md`): field-by-field tables (type, required-ness, semantics), lossless-if-stripped, credential-sealing invariant, inputs/resolution, outputs-vs-transport, audit, freeze/lock, and execution rungs. Every `ADR-NNNN` is a hyperlink.
- **Go drift-guard test** (`internal/flightplan/spec`): the only Go in this issue. Asserts the example validates, required-block omissions and bad enums reject, `base64` is accepted as a reserved interface value, no credential field can hold a secret, and the schema's coupling rules hold.

Wires the new page into the development docs index.

### Key invariants

- **Secrets never appear.** No schema field can hold a credential value; the manifest declares kind + placement only ([ADR-0005](https://github.com/ALRubinger/aileron/blob/main/docs/src/content/docs/adr/0005-sandbox-choice.md), [ADR-0019](https://github.com/ALRubinger/aileron/blob/main/docs/src/content/docs/adr/0019-v4-https-data-plane.md)). A `TestNoSecretValueField` guards it.
- **Lossless if stripped.** The `aileron` block is optional at the top level; removing it leaves a valid skill. Guarded by `TestStrippedManifestStillValid` and `TestStrippedBodyRemainsCoherentSkill`.
- **Binary reserved, text-only v1.** `encoding: base64` is present in the interface; v1 implements `utf-8` only.

## Test plan

- `go test ./flightplan/...` in `internal/` — 13 tests pass (happy path, four contract-failure mutants, stripped-skill, reserved-base64-accepted, no-secret-field, exactly-one-rung, oauth-required, file-publish-path-required, none-credential-no-placement).
- `task build:docs` succeeds; the new page renders at `/development/flight-plan-manifest-spec/`; the JSON schema under `docs/schema/` is not treated as a doc page; all ADR link targets resolve.
- No em-dashes, no "not just X, Y", one-thought-per-sentence (self-review pass).
- `coderabbit review --base main` returns 0 findings after applying the review-round schema tightening.

## Scope boundaries

No Go parser/validator/freeze/runtime (#1508/#1509/#1511). The `lock` section is shaped, not produced. Rung-3 is a reserved deferred slot. Binary outputs reserved, not built. No customer names anywhere.

Closes #1507

🤖 Generated with [Claude Code](https://claude.com/claude-code)
