### PR TITLE
docs(nav): add Flight Plan Manifest Spec to Development sidebar

### DIFF
--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -94,6 +94,7 @@ export const navigation: NavItem[] = [
       { label: 'Sandbox Composition', href: '/development/sandbox-composition/' },
       { label: 'Sandbox Agent Images', href: '/development/sandbox-agent-images/' },
       { label: 'Sandbox Connector Specs', href: '/development/sandbox-connector-specs/' },
+      { label: 'Flight Plan Manifest Spec', href: '/development/flight-plan-manifest-spec/' },
       { label: 'Submitting Changes', href: '/development/submitting-changes/' }
     ]
   },


### PR DESCRIPTION
## Summary

The Development sidebar is hand-curated in `docs/src/lib/navigation.ts` (consumed by `Sidebar.svelte`; Astro does not autogenerate it). PR #1570 added `development/flight-plan-manifest-spec.md` and listed it in `development/index.md`, but did not add it to `navigation.ts`. As a result the page built as a route yet was absent from the sidebar and effectively unreachable by navigation.

This adds the entry between `Sandbox Connector Specs` and `Submitting Changes` to mirror the `development/index.md` ordering.

Note: three other `index.md` pages (`sandbox-mcp-walkthrough`, `sandbox-proxy-cli-matrix`, `sandbox-agent-auth`) are also missing from `navigation.ts`. That is a pre-existing staleness gap, out of scope for this residual fix, and intentionally not touched here.

## Test plan

- `pnpm install --frozen-lockfile` + `node design/build/generate-tokens.mjs` + `pnpm build` in `docs/`: clean build, 135 pages, `/development/flight-plan-manifest-spec/` route present.
- Verified the rendered sidebar HTML on a sibling Development page now contains the `Flight Plan Manifest Spec` link.
- `pnpm test` in `docs/`: 13 passed, 0 failed.

Closes #1566

🤖 Generated with [Claude Code](https://claude.com/claude-code)
