### PR TITLE
docs: fix running-tests page mislabeling test:integration as Playwright

### DIFF
--- a/docs/src/content/docs/development/running-tests.md
+++ b/docs/src/content/docs/development/running-tests.md
@@ -12,7 +12,7 @@ Aileron leans heavily on the test suite. Every PR runs the full Go test set on L
 task test
 ```
 
-This is the full local equivalent of what CI runs. It exercises the Go suite, the docs tests, the UI tests, and the Playwright integration tests. Expect ~5–10 minutes on a modern machine.
+This runs the Go suite, the webapp tests, the UI tests, and the docs tests. Expect ~5–10 minutes on a modern machine. It does not bring up the stack, so it excludes both `task test:integration` (the Go HTTP/API suite) and the Playwright E2E suite. CI runs those in dedicated jobs that provision a running stack first.
 
 For a faster inner loop, run individual targets:
 
@@ -22,8 +22,22 @@ task test:go:cover        # Go unit tests with coverage summary
 task test:go:ci           # what CI runs: race + coverage + JUnit
 task test:docs            # docs site unit tests (rehype plugins, etc.)
 task test:ui              # UI unit and component tests
-task test:integration     # Playwright + running services
+task test:integration     # Go HTTP/API integration suite against a running daemon
 task test:e2e:integration # Playwright E2E against a real stack
+```
+
+`task test:integration` needs a daemon already listening on `localhost:8080`. It does not start the stack itself, and `task test` deliberately excludes it. Run it standalone against a cold machine and every HTTP test fails with `dial tcp [::1]:8080: connect: connection refused`. Bring the stack up first. The simplest path is:
+
+```sh
+task test:integration:coverage  # brings the compose stack up --wait, runs the Go suite, then tears it down
+```
+
+Or run the explicit sequence that `task ci` uses:
+
+```sh
+task up -- -d --build --wait
+task test:integration
+task down
 ```
 
 ## Run a single Go package
@@ -97,7 +111,7 @@ If a test passes locally but fails in CI, the usual suspects are:
 
 ## System tests (black-box CLI)
 
-The system-test suite sits above the unit, integration, and sandbox-integration layers. It builds the shipped `aileron` binary and drives the real `aileron launch <agent> -- <agent-flag> "..."` path against a live Docker sandbox, for example `aileron launch codex -- exec "..."` or `aileron launch claude -- -p "..."`, then asserts on the result with shell and `jq`. The lower layers prove that Docker works on the host. The `test:go` unit layer exercises Go functions in isolation. The `task test:integration` layer runs Playwright against running services. The `integration_sandbox` Go tests call `docker run` and the sandbox Go functions directly. The system suite proves that `aileron launch` itself correctly drives Docker on the host. It does not replace any of those layers, and it sits above them.
+The system-test suite sits above the unit, integration, and sandbox-integration layers. It builds the shipped `aileron` binary and drives the real `aileron launch <agent> -- <agent-flag> "..."` path against a live Docker sandbox, for example `aileron launch codex -- exec "..."` or `aileron launch claude -- -p "..."`, then asserts on the result with shell and `jq`. The lower layers prove that Docker works on the host. The `test:go` unit layer exercises Go functions in isolation. The `task test:integration` layer runs the Go HTTP/API integration tests against a running daemon. The `integration_sandbox` Go tests call `docker run` and the sandbox Go functions directly. The system suite proves that `aileron launch` itself correctly drives Docker on the host. It does not replace any of those layers, and it sits above them.
 
 ### Run it
 


### PR DESCRIPTION
## Summary

The Development → "Running Tests" docs page (`docs/src/content/docs/development/running-tests.md`) described `task test:integration` as a Playwright suite. It is not. `task test:integration` runs the **Go** HTTP/API integration suite against a running daemon:

```
go test -tags=integration -race ./test/integration/... ./internal/store/postgres/...
```

Playwright is the separate `task test:e2e:integration`. Following the page led contributors to run `task test:integration` standalone and hit a wall of `dial tcp [::1]:8080: connect: connection refused`, because the task does not start the stack and `task test` deliberately excludes it.

This PR:

1. Fixes the inner-loop comment table (line 25): `test:integration` is now described as the Go HTTP/API suite against a running daemon; `test:e2e:integration` stays the Playwright line.
2. Fixes the System tests prose (line 100): "runs Playwright against running services" → "runs the Go HTTP/API integration tests against a running daemon".
3. Adds the missing prerequisite: a daemon must be listening on `localhost:8080` first. Points readers at `task test:integration:coverage` (brings the compose stack up `--wait`, runs the suite, tears it down) or the explicit `task up -- -d --build --wait` → `test:integration` → `task down` sequence that `task ci` uses.
4. Corrects the "Run everything" blurb that claimed `task test` runs "the Playwright integration tests" — `task test` only runs `test:go`, `test:webapp`, `test:ui`, `test:docs`, and explicitly excludes the stack-requiring suites.

Ground truth verified against `Taskfile.yml` (`test:integration` ≈ L378, `test:e2e:integration` ≈ L728, `test:integration:coverage`, and the `ci` target's up/test/down sequence) and the `test` target deps.

## Test plan

- `task test:docs` passes (13/13).
- Docs-only change; no Go/UI code touched.
- Manual read-through: a reader following the corrected page brings the stack up before `task test:integration`, and is no longer told the suite is Playwright.

Closes #1567

🤖 Generated with [Claude Code](https://claude.com/claude-code)
