### PR TITLE
fix(launch): gate uid-remap integration test to linux

### DIFF
--- a/internal/launch/workspace_uid_remap_integration_test.go
+++ b/internal/launch/workspace_uid_remap_integration_test.go
@@ -1,6 +1,16 @@
-//go:build integration_sandbox
+//go:build integration_sandbox && linux
 
 // Workspace uid-remap integration test (#1461).
+//
+// Build constraint: this file is gated to `linux` in addition to
+// `integration_sandbox` because the test reads host-file ownership via
+// `syscall.Stat_t`, which exists only on Unix, and the contract it exercises
+// (the DAC uid mismatch) only reproduces on rootful Linux Docker — the test
+// already skips at runtime unless GOOS == linux (see #1565). Without the
+// `linux` constraint the `syscall.Stat_t` reference fails to compile on
+// Windows and takes the whole package's `integration_sandbox` build down with
+// it, making platform-agnostic siblings like TestSandboxFeaturesManaged
+// unrunnable off-Linux.
 //
 // This test exercises the DAC uid-mismatch contract on the platform where it
 // actually breaks: rootful Docker on Linux. `aileron launch --sandbox=docker`


### PR DESCRIPTION
## Summary

`internal/launch/workspace_uid_remap_integration_test.go` was gated only by `//go:build integration_sandbox` but references `syscall.Stat_t` (lines 154/167), which exists only on Unix. On Windows the file failed to compile and poisoned the entire `internal/launch` `integration_sandbox` build:

```
launch\workspace_uid_remap_integration_test.go:154:39: undefined: syscall.Stat_t
launch\workspace_uid_remap_integration_test.go:167:37: undefined: syscall.Stat_t
FAIL    github.com/ALRubinger/aileron/internal/launch [build failed]
```

So `task test:integration:sandbox-managed` (`go test -tags=integration_sandbox -run TestSandboxFeaturesManaged ./launch/...`) could not even build on Windows, even though `TestSandboxFeaturesManaged` is platform-agnostic.

The uid-remap test already skips at runtime unless `GOOS == linux` — the DAC uid mismatch it exercises only reproduces on rootful Linux Docker — so the whole file is Linux-only by design. The fix changes the build constraint to `//go:build integration_sandbox && linux` so the Unix-only `syscall.Stat_t` reference is never compiled off-Linux, while every other `integration_sandbox` test in the package stays buildable on Windows/macOS.

A scan of the other `integration_sandbox` files in `internal/launch` (`authspec_*`, `sandbox_features_*`, `run_with_proxy_ca_*`, `sandbox_agent_image_smoke_*`) found no other Unix-only `syscall`/`unix`/`/proc` references, so this file was the only latent portability hazard.

Fixes #1565.

## Test plan

- `GOOS=windows GOARCH=amd64 go test -tags=integration_sandbox -run TestSandboxFeaturesManaged -c -o /dev/null ./internal/launch/...` — now builds (was the reported failure).
- `GOOS=darwin GOARCH=arm64 go test -tags=integration_sandbox -c -o /dev/null ./internal/launch/...` — builds.
- `GOOS=linux go vet -tags=integration_sandbox ./internal/launch/...` — clean; the uid-remap test is still compiled on its real target (Linux), so its coverage is unchanged.
- `gofmt -l` clean.

The change is a build-constraint adjustment; behavior on Linux (where the test runs) is unchanged, so no new test logic is added. The "build off-Linux now succeeds" property is itself exercised by the existing Windows/macOS CI matrix building the `integration_sandbox` tag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
