### PR TITLE
docs(testing): document C-compiler prereq for the -race tasks

### DIFF
--- a/docs/src/content/docs/development/running-tests.md
+++ b/docs/src/content/docs/development/running-tests.md
@@ -46,6 +46,8 @@ go test ./internal/sandbox -race
 
 The sandbox package has the densest concurrency surface (per-invocation state, shared executor, audit emission). Run with `-race` whenever you change any of those paths. CI does the same automatically.
 
+The race detector is a C runtime, so every `-race` task (`test:go:ci`, `test:integration`, `test:integration:coverage`, and the sandbox-integration targets) needs `CGO_ENABLED=1` plus a C compiler on `PATH`. macOS and Linux satisfy this out of the box once you have the Xcode Command Line Tools or your distro's `gcc`. On a stock Windows host Go defaults to `CGO_ENABLED=0` with no compiler present, so `go test -race` aborts with `exit status 2` before any test runs. Install MinGW-w64 (`scoop install mingw` or `choco install mingw`) and set `CGO_ENABLED=1`. CI's Windows runners already ship MinGW-w64 gcc, so this local setup matches CI rather than working around it. See [Building from Source](/development/building-from-source/) for the per-OS install commands.
+
 ## Coverage
 
 The project doesn't pin a hard coverage threshold, but the convention is:

--- a/docs/src/lib/components/ui/build-prereqs.svelte
+++ b/docs/src/lib/components/ui/build-prereqs.svelte
@@ -49,6 +49,30 @@
 		},
 	];
 
+	const ccInstall: PlatformTabItem[] = [
+		{
+			value: "macos",
+			label: "macOS",
+			lang: "sh",
+			note: "Install the Xcode Command Line Tools, which provide clang:",
+			code: "xcode-select --install",
+		},
+		{
+			value: "linux",
+			label: "Linux",
+			lang: "sh",
+			note: "Install your distro's gcc package:",
+			code: "# Debian / Ubuntu\nsudo apt-get install build-essential\n# Fedora\nsudo dnf install gcc",
+		},
+		{
+			value: "windows",
+			label: "Windows",
+			lang: "powershell",
+			note: "Install MinGW-w64 (provides gcc), then make sure CGO_ENABLED=1 is set so the race detector can use it:",
+			code: "scoop install mingw   # or: choco install mingw\n$env:CGO_ENABLED = '1'",
+		},
+	];
+
 	const triggerClass = cn(
 		"flex w-full items-center justify-between py-3 text-left text-sm font-medium",
 		"cursor-pointer hover:bg-muted/60 transition-colors duration-150 px-3 -mx-3 rounded-md focus-visible:outline-1 focus-visible:outline-ring",
@@ -114,6 +138,25 @@
 				then <code>corepack prepare pnpm@11.0.8 --activate</code>.
 			</p>
 			<PlatformTabs items={nodeInstall} />
+		</AccordionPrimitive.Content>
+	</AccordionPrimitive.Item>
+
+	<AccordionPrimitive.Item value="cc" class={itemClass}>
+		<AccordionPrimitive.Header>
+			<AccordionPrimitive.Trigger class={triggerClass}>
+				<span>A C compiler (for the race detector)</span>
+				<ChevronDown size={16} class="shrink-0 transition-transform" />
+			</AccordionPrimitive.Trigger>
+		</AccordionPrimitive.Header>
+		<AccordionPrimitive.Content forceMount class={contentClass}>
+			<p>
+				The Go race detector is a C runtime, so the <code>-race</code> test tasks need cgo enabled
+				(<code>CGO_ENABLED=1</code>) plus a C compiler on <code>PATH</code>. macOS and Linux ship
+				one or install it through the steps above. On a stock Windows host Go defaults to
+				<code>CGO_ENABLED=0</code> with no compiler present, so <code>go test -race</code> aborts
+				before any test runs. Install MinGW-w64 to match what CI's Windows runners already have.
+			</p>
+			<PlatformTabs items={ccInstall} />
 		</AccordionPrimitive.Content>
 	</AccordionPrimitive.Item>
 </AccordionPrimitive.Root>


### PR DESCRIPTION
## Summary

Documents the host prerequisite that the `-race` test tasks already depend on but that the docs never stated.

The race detector is a C runtime, so every `-race` task (`test:go:ci`, `test:integration`, `test:integration:coverage`, and the sandbox-integration targets) needs `CGO_ENABLED=1` plus a C compiler on `PATH`. macOS and Linux ship one out of the box. On a stock Windows host Go defaults to `CGO_ENABLED=0` with no compiler present, so `go test -race` aborts with `exit status 2` before any test runs. CI's `Unit Tests (Windows)` job passes only because GitHub's `windows-latest` runners bundle MinGW-w64 gcc, so documenting the C compiler as a Windows host prereq matches CI rather than being a workaround.

Changes:
- **`docs/src/lib/components/ui/build-prereqs.svelte`** — adds a "A C compiler (for the race detector)" accordion item with per-OS `PlatformTabs` (macOS: Xcode CLT; Linux: distro gcc; Windows: MinGW-w64 via `scoop install mingw` / `choco install mingw` + `CGO_ENABLED=1`).
- **`docs/src/content/docs/development/running-tests.md`** — adds a host-prerequisites paragraph in the Race detector section explaining the cgo/compiler requirement, the Windows failure mode, and that CI's Windows runners already satisfy it.

Out of scope by design (settled in #1569): the Taskfile is not touched and `-race` is not dropped or conditioned out. This documents the existing requirement.

## Test plan

- `task lint:docs` (astro check): 0 errors, 0 warnings, 0 hints.
- `task build:docs`: 135 pages built; verified both rendered pages contain the new content (`A C compiler (for the race detector)`, `MinGW-w64`, `race detector is a C runtime`, `exit status 2`).
- `task test:docs`: 13/13 pass.
- Docs voice: no em-dashes introduced.

No Go, Taskfile, API spec, or generated-file changes. Docs-only.

Closes #1569

🤖 Generated with [Claude Code](https://claude.com/claude-code)
