### PR TITLE
build(taskfile): add test:integration:local one-command Go integration task

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -749,6 +749,25 @@ tasks:
       AILERON_API_URL: http://localhost:8080
       AILERON_UI_BASE_URL: http://localhost:3000
 
+  test:integration:local:
+    desc: One command for the local Go integration loop — build + start the stack, wait for health, run the integration suite, then tear the stack down (even on failure)
+    cmds:
+      # Register teardown FIRST so the stack comes down even if `up`, the health
+      # poll, or the tests fail — a `defer` only registers once its line runs,
+      # mirroring the test:e2e:scenario cleanup-first pattern in this file.
+      - defer: { task: down, vars: { CLI_ARGS: '-v' } }
+      # Match the `up` task: seed deploy/.env from the example so a fresh clone's
+      # `docker compose up` resolves its env interpolation.
+      - test -f deploy/.env || cp deploy/.env.example deploy/.env
+      - docker compose -f {{.COMPOSE_FILE}} up -d --build --wait
+      # Belt-and-suspenders over compose `--wait`: poll the health endpoint the
+      # same way the CI integration-go job does before running the suite.
+      - for i in $(seq 1 60); do curl -sf http://localhost:8080/v1/health && break; sleep 3; done
+      - go test -tags=integration -race ./test/integration/... ./internal/store/postgres/...
+    env:
+      AILERON_API_URL: http://localhost:8080
+      AILERON_UI_BASE_URL: http://localhost:3000
+
   ci:
     desc: Run the full CI pipeline locally
     cmds:


### PR DESCRIPTION
## Summary

Adds one convenience task, `task test:integration:local`, that wraps the full local Go HTTP integration inner loop into a single command: build + start the Docker Compose stack, wait for health, run the integration suite, then tear the stack down (even on failure).

Before this, the local loop was either three manual commands (`task up -- -d --build --wait` → `task test:integration` → `task down`) or the heavier coverage-instrumented `task test:integration:coverage`. Running `task test:integration` alone is a footgun: it only runs `go test` against `localhost:8080` with nothing listening, producing ~47 `connection refused` failures.

### What the task does
- Registers teardown FIRST via go-task `defer: { task: down, vars: { CLI_ARGS: '-v' } }` so the stack is torn down even if the build, health poll, or tests fail — mirroring the `test:e2e:scenario` cleanup-first pattern already in the file.
- Seeds `deploy/.env` from `.env.example` (matching the `up` task) so a fresh clone's compose env interpolation resolves.
- `docker compose up -d --build --wait` (no coverage overlay).
- Polls `http://localhost:8080/v1/health` (60 × 3s) the same way the CI integration-go job does, as belt-and-suspenders over compose `--wait`.
- Runs `go test -tags=integration -race ./test/integration/... ./internal/store/postgres/...` with `AILERON_API_URL`/`AILERON_UI_BASE_URL` set to match the suite's expectations.

Taskfile-only change. No app/spec change, so the OpenAPI-regen convention does not apply.

## Test plan
- `task test:integration:local --dry` — confirms the command sequence and that the `defer` resolves `down` with `-v`.
- `task test:integration:local` end-to-end on Docker:
  - stack built and came up healthy (postgres/server/ui all Healthy)
  - health endpoint returned `{"status":"ok",...}`
  - both integration packages passed (`ok test/integration`, `ok internal/store/postgres`)
  - defer tore the stack down with `-v` (volume removed); verified no leftover `deploy-*` containers afterward.

Closes #1568
