### PR TITLE
fix(sandbox): build Claude image locally instead of redistributing it

### DIFF
--- a/.github/workflows/sandbox-agents-watch.yml
+++ b/.github/workflows/sandbox-agents-watch.yml
@@ -1,8 +1,11 @@
 name: Sandbox Agent Image Freshness
 
 # Keeps the published per-agent sandbox images
-# (ghcr.io/alrubinger/aileron-sandbox-{claude,codex}) fresh against upstream
-# agent-CLI npm releases by detecting drift and re-triggering sandbox-agents.yml.
+# (ghcr.io/alrubinger/aileron-sandbox-<agent>) fresh against upstream agent-CLI
+# npm releases by detecting drift and re-triggering sandbox-agents.yml. The set
+# of watched agents is the publishable set (composition.PublishedAgents, computed
+# from Go), so a non-publishable agent like Claude Code — which ships no
+# per-agent image — is never watched (#1451).
 #
 # Corrected mechanism (verified against shipped reality):
 #   - The agent Feature install scripts run `npm install -g <pkg>` with NO
@@ -27,13 +30,13 @@ name: Sandbox Agent Image Freshness
 # background job must never clobber it. This is documented in
 # docs/src/content/docs/development/sandbox-agent-images.md.
 #
-# sandbox-agents.yml has a hardcoded [claude, codex] matrix and a bare
-# workflow_dispatch (no inputs). A single `gh workflow run sandbox-agents.yml`
-# rebuilds BOTH agents. This watcher dispatches the whole workflow when *either*
-# agent is stale; rebuilding the non-stale agent is a harmless no-op `edge`
-# republish (same digest, same version). We deliberately do NOT add a
-# workflow_dispatch input to scope dispatch per-agent (keeps sandbox-agents.yml
-# untouched, per the #1088 plan).
+# sandbox-agents.yml derives its build matrix from composition.PublishedAgents
+# and has a bare workflow_dispatch (no inputs). A single `gh workflow run
+# sandbox-agents.yml` rebuilds ALL publishable agents. This watcher dispatches
+# the whole workflow when *any* publishable agent is stale; rebuilding a
+# non-stale agent is a harmless no-op `edge` republish (same digest, same
+# version). We deliberately do NOT add a workflow_dispatch input to scope
+# dispatch per-agent (keeps sandbox-agents.yml untouched, per the #1088 plan).
 #
 # Re-pushing `edge`/`dev-<cli>` to the existing aileron-sandbox-<agent> package
 # preserves its current visibility (visibility is per-package, not per-tag; the
@@ -58,10 +61,14 @@ on:
         default: true
 
 permissions:
+  # contents: read checks out the repo to compute the publishable-agent list
+  # from Go (composition.PublishedAgents), the single source of truth shared with
+  # sandbox-agents.yml (#1451).
   # packages: read enumerates GHCR tags / resolves manifest digests.
   # actions: write dispatches sandbox-agents.yml via `gh workflow run`.
   # No contents: write, no packages: write — the watcher never edits the repo
   # nor pushes images itself.
+  contents: read
   packages: read
   actions: write
 
@@ -74,21 +81,37 @@ jobs:
     name: Detect agent CLI drift
     runs-on: ubuntu-latest
     steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: internal/go.mod
+      - id: agents
+        name: Resolve publishable agents
+        working-directory: internal
+        run: |
+          set -euo pipefail
+          # The agents to watch are exactly the agents sandbox-agents.yml
+          # publishes: composition.PublishedAgents (#1451). A non-publishable
+          # agent (Claude Code) ships no per-agent image, so there is nothing to
+          # watch for drift. Emit a space-separated list for the loop below.
+          list="$(go run ./tools/publishedagents | jq -r '.[]' | paste -sd' ' -)"
+          echo "publishable agents: ${list}"
+          echo "agents=${list}" >> "$GITHUB_OUTPUT"
       - name: Detect drift and conditionally dispatch rebuild
         env:
           GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           # github.event.inputs.dry_run is empty on schedule; treat empty as
           # false so scheduled runs dispatch on drift.
           DRY_RUN: ${{ github.event.inputs.dry_run }}
+          AGENTS: ${{ steps.agents.outputs.agents }}
         run: |
           set -euo pipefail
 
           OWNER="alrubinger"
 
-          # Agent -> npm package. Mirrors the [claude, codex] matrix in
-          # sandbox-agents.yml and NPMPackage in
-          # internal/sandbox/composition/recipes.go (the source of truth for the
-          # package names; kept inline here to avoid a repo checkout). A case
+          # Agent -> npm package. The package names mirror NPMPackage in
+          # internal/sandbox/composition/recipes.go (the source of truth). A case
           # lookup (not an associative array) keeps this portable across bash
           # versions under `set -u`.
           npm_pkg_for() {
@@ -133,7 +156,7 @@ jobs:
               | awk -F': ' 'tolower($1)=="docker-content-digest"{print $2}'
           }
 
-          for agent in claude codex; do
+          for agent in ${AGENTS}; do
             pkg="$(npm_pkg_for "${agent}")"
             repo="${OWNER}/aileron-sandbox-${agent}"
 

--- a/.github/workflows/sandbox-agents-watch.yml
+++ b/.github/workflows/sandbox-agents-watch.yml
@@ -113,7 +113,10 @@ jobs:
           # Agent -> npm package. The package names mirror NPMPackage in
           # internal/sandbox/composition/recipes.go (the source of truth). A case
           # lookup (not an associative array) keeps this portable across bash
-          # versions under `set -u`.
+          # versions under `set -u`. The watched AGENTS list is computed from Go
+          # (composition.PublishedAgents), so a new publishable agent must also be
+          # added here; the `return 1` default fails the step LOUDLY under `set
+          # -e` rather than silently skipping, so the drift never goes unnoticed.
           npm_pkg_for() {
             case "$1" in
               claude) echo "@anthropic-ai/claude-code" ;;

--- a/.github/workflows/sandbox-agents.yml
+++ b/.github/workflows/sandbox-agents.yml
@@ -40,6 +40,7 @@ on:
       - "internal/tools/publishedagents/**"
       - "internal/sandbox/composition/recipes.go"
       - "internal/sandbox/composition/scaffold.go"
+      - "internal/sandbox/composition/composition.go"
   push:
     tags:
       - "v*"

--- a/.github/workflows/sandbox-agents.yml
+++ b/.github/workflows/sandbox-agents.yml
@@ -1,10 +1,17 @@
 name: Sandbox Agent Images
 
 # Builds and publishes the multi-arch per-agent sandbox images
-# (ghcr.io/alrubinger/aileron-sandbox-claude and -codex), each baked from the
+# (ghcr.io/alrubinger/aileron-sandbox-<agent>), each baked from the
 # GHCR-published sandbox base (#1085) plus the agent's devcontainer Feature
-# install script (#1082). One workflow, one matrix leg per agent, so claude and
-# codex stay in lockstep with no file duplication (#1086).
+# install script (#1082). One workflow, one matrix leg per PUBLISHABLE agent,
+# with no file duplication (#1086).
+#
+# The matrix is computed from Go (composition.PublishedAgents, via the `agents`
+# job) rather than hardcoded, so only agents whose CLI license permits
+# redistribution are built/published here. Claude Code is recipe'd but NOT
+# publishable (@anthropic-ai/claude-code is all-rights-reserved); it is excluded
+# from this workflow and instead built LOCALLY on the host from its Feature at
+# launch (#1451). Codex (Apache-2.0) is publishable and stays.
 #
 # Each published image is smoke-tested by the launchability validation in
 # internal/launch/sandbox_agent_image_smoke_test.go: the agent CLI is on PATH
@@ -29,6 +36,10 @@ on:
       - "images/sandbox-agents/**"
       - "images/sandbox-features/**"
       - "internal/launch/sandbox_agent_image_smoke_test.go"
+      # The publishable-agent matrix is computed from these (#1451).
+      - "internal/tools/publishedagents/**"
+      - "internal/sandbox/composition/recipes.go"
+      - "internal/sandbox/composition/scaffold.go"
   push:
     tags:
       - "v*"
@@ -51,8 +62,35 @@ env:
   BASE_IMAGE_NAME: ghcr.io/alrubinger/aileron-sandbox-base
 
 jobs:
+  # Single source of truth for the build matrix: the publishable per-agent
+  # images, computed from Go (composition.PublishedAgents) rather than hardcoded
+  # here. A non-publishable agent (e.g. Claude Code, whose @anthropic-ai/claude-
+  # code license forbids redistribution) is excluded automatically, so CI never
+  # builds or publishes a non-redistributable per-agent image (#1451). A new
+  # publishable agent appears in the matrix by gaining a publishable recipe.
+  agents:
+    name: Resolve publishable agent matrix
+    runs-on: ubuntu-latest
+    outputs:
+      agents: ${{ steps.list.outputs.agents }}
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-go@v6
+        with:
+          go-version: "1.26"
+          cache-dependency-path: internal/go.mod
+      - id: list
+        name: List publishable agents
+        working-directory: internal
+        run: |
+          set -euo pipefail
+          agents="$(go run ./tools/publishedagents)"
+          echo "publishable agents: ${agents}"
+          echo "agents=${agents}" >> "$GITHUB_OUTPUT"
+
   build:
     name: Build sandbox-${{ matrix.agent }}
+    needs: agents
     runs-on: ubuntu-latest
     # Skip the cascade leg unless the triggering base run SUCCEEDED on main: a
     # failed or non-main base run must not republish agent edge onto a base that
@@ -72,10 +110,11 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        # The agent name doubles as the Feature subdirectory under
-        # images/sandbox-features/<agent>, the AGENT build-arg, and the agent CLI
-        # command asserted on PATH.
-        agent: [claude, codex]
+        # The publishable agents resolved by the `agents` job from
+        # composition.PublishedAgents (#1451). The agent name doubles as the
+        # Feature subdirectory under images/sandbox-features/<agent>, the AGENT
+        # build-arg, and the agent CLI command asserted on PATH.
+        agent: ${{ fromJSON(needs.agents.outputs.agents) }}
     steps:
       - uses: actions/checkout@v7
 

--- a/cmd/aileron/sandbox_test.go
+++ b/cmd/aileron/sandbox_test.go
@@ -379,19 +379,56 @@ func TestRunSandboxCheckOfflineRejectsEscapeHatch(t *testing.T) {
 	}
 }
 
+// TestRunSandboxCheckPublishedAgentResolvesPerAgentImage pins that a publishable
+// agent (codex, Apache-2.0) resolves the build-free TierPublished default whose
+// image is the prebuilt per-agent image, in parity with launch. Claude is no
+// longer publishable (#1451) and is covered by
+// TestRunSandboxCheckNonPublishableAgentBuildsLocally.
 func TestRunSandboxCheckPublishedAgentResolvesPerAgentImage(t *testing.T) {
+	t.Chdir(t.TempDir())
+	plan := captureSandboxCheckPlan(t)
+	var out, errb bytes.Buffer
+	if code := runSandboxCheck([]string{"--agent=codex"}, &out, &errb); code != 0 {
+		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
+	}
+	if plan.Tier != sandboxcomposition.TierPublished {
+		t.Fatalf("plan.Tier = %s, want %s", plan.Tier, sandboxcomposition.TierPublished)
+	}
+	want := sandboxcomposition.PublishedAgentImage("codex", version.Version)
+	if plan.Image != want {
+		t.Fatalf("plan.Image = %q, want %q (parity with launch)", plan.Image, want)
+	}
+}
+
+// TestRunSandboxCheckNonPublishableAgentBuildsLocally is the #1451 check-side
+// parity with TestLaunch_SandboxNoDevcontainerNonPublishableAgentBuildsLocally:
+// a recipe'd-but-not-publishable agent (claude) must NOT resolve a published
+// per-agent image. With no .devcontainer it resolves a LOCAL Feature build
+// (TierDevcontainer with the agent Feature + a synthesized devcontainer), built
+// on the host rather than pulled, keeping Aileron out of the redistribution
+// chain.
+func TestRunSandboxCheckNonPublishableAgentBuildsLocally(t *testing.T) {
 	t.Chdir(t.TempDir())
 	plan := captureSandboxCheckPlan(t)
 	var out, errb bytes.Buffer
 	if code := runSandboxCheck([]string{"--agent=claude"}, &out, &errb); code != 0 {
 		t.Fatalf("exit = %d, want 0; stderr=%q", code, errb.String())
 	}
-	if plan.Tier != sandboxcomposition.TierPublished {
-		t.Fatalf("plan.Tier = %s, want %s", plan.Tier, sandboxcomposition.TierPublished)
+	if plan.Tier != sandboxcomposition.TierDevcontainer {
+		t.Fatalf("plan.Tier = %s, want %s (local build, not published)", plan.Tier, sandboxcomposition.TierDevcontainer)
 	}
-	want := sandboxcomposition.PublishedAgentImage("claude", version.Version)
+	want := sandboxcomposition.LocalAgentImageTag("claude", version.Version)
 	if plan.Image != want {
-		t.Fatalf("plan.Image = %q, want %q (parity with launch)", plan.Image, want)
+		t.Fatalf("plan.Image = %q, want %q (local agent image tag)", plan.Image, want)
+	}
+	if plan.Image == sandboxcomposition.PublishedAgentImage("claude", version.Version) {
+		t.Fatalf("plan.Image resolved a published claude image; want a local build")
+	}
+	if _, ok := plan.Features[sandboxcomposition.FeatureReference("claude")]; !ok {
+		t.Fatalf("plan.Features missing the claude agent Feature: %v", plan.Features)
+	}
+	if plan.SynthesizedDevcontainer == "" {
+		t.Fatal("plan.SynthesizedDevcontainer is empty; want a synthesized devcontainer for the no-.devcontainer local build")
 	}
 }
 

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -19,8 +19,8 @@ The check uses the same composition plan and minimal launch validation as `ailer
 
 | Agent | Command | Sandbox image support | MCP under `--sandbox=docker` | Notes |
 |---|---|---|---|---|
-| Claude Code | `claude` | Agent Feature | ✓ via `--mcp-config` | First-class Feature below. Use `sandbox check --agent=claude` before launch. |
-| Codex | `codex` | Agent Feature | ✓ via bind-mounted `config.toml` | Feature below. Sandbox launch writes a generated `config.toml` to a host tempdir and bind-mounts it into `/home/agent/.codex/config.toml` ([ADR-0024](/adr/0024-sandbox-mcp-parity/)). Host `~/.codex/config.toml` is never touched. |
+| Claude Code | `claude` | Agent Feature (local build) | ✓ via `--mcp-config` | First-class Feature below. The build-free path builds the image **locally** from the Feature, because `@anthropic-ai/claude-code` is all-rights-reserved and cannot be redistributed as a published image ([#1451](https://github.com/ALRubinger/aileron/issues/1451)). Use `sandbox check --agent=claude` before launch. |
+| Codex | `codex` | Agent Feature (published image) | ✓ via bind-mounted `config.toml` | Feature below. `@openai/codex` is Apache-2.0, so its per-agent image is published and pulled build-free. Sandbox launch writes a generated `config.toml` to a host tempdir and bind-mounts it into `/home/agent/.codex/config.toml` ([ADR-0024](/adr/0024-sandbox-mcp-parity/)). Host `~/.codex/config.toml` is never touched. |
 | Goose | `goose` | Command contract only | ✓ via `--with-extension` | List the agent Feature in Tier 1, or install the CLI in a BYO image; no maintained Feature yet. |
 | OpenCode | `opencode` | Command contract only | ✓ via workspace `opencode.json` | Launcher writes `opencode.json` into the launch directory; the workspace bind-mount makes it readable in-container. |
 | Pi | `pi` | Command contract only | ✓ via `--mcp-config` | Shares Claude's MCP wiring. |
@@ -32,24 +32,29 @@ Docker is the only supported sandbox runtime in v4. Podman is planned but not ye
 
 The harness-free `ghcr.io/alrubinger/aileron-sandbox-base` intentionally does not include agent CLIs ([ADR-0017](/adr/0017-sandbox-composition/)). Each agent install is authored once as a devcontainer Feature, the single source of truth that Aileron CI bakes into prebuilt per-agent images and that customers compose for Tier 1. The prebuilt per-agent image is the zero-build Tier 0 default, owned by [#965](https://github.com/ALRubinger/aileron/issues/965). Use Tier 1 when you want Aileron's base runtime plus an agent plus your own tools, or Tier 2 when your team owns the full image.
 
-## Build-Free Default
+## Default Launch Paths
 
-With no `.devcontainer` in the project, `aileron launch --sandbox=docker <agent>` is build-free for a published agent. The launcher resolves the prebuilt per-agent image `ghcr.io/alrubinger/aileron-sandbox-<agent>` and pulls it. There is no `sandbox init`, no Dockerfile, and no local image build. The published agents today are `claude` and `codex`.
+With no `.devcontainer` in the project, `aileron launch --sandbox=docker <agent>` resolves one of three default paths from the requested agent:
 
-`sandbox check --agent=<agent>` resolves the same image, so a passing check matches what launch will run.
+- **Published agent (build-free):** the launcher resolves the prebuilt per-agent image `ghcr.io/alrubinger/aileron-sandbox-<agent>` and pulls it. There is no `sandbox init`, no Dockerfile, and no local image build. The published agent today is `codex`, whose `@openai/codex` CLI is Apache-2.0 and so redistributable.
+- **Recipe'd-but-not-publishable agent (local build):** the launcher composes the base image with the agent Feature and builds the image **locally** on your host through `@devcontainers/cli`, then launches it. `claude` takes this path: `@anthropic-ai/claude-code` is all-rights-reserved with no redistribution grant, so Aileron never bakes it into a published image ([#1451](https://github.com/ALRubinger/aileron/issues/1451)). The build needs only Docker on the host (the managed toolchain provisions Node and the CLI; see [Managed Toolchain Build](#managed-toolchain-build)). Aileron synthesizes the composed `devcontainer.json` into a managed temp workspace folder for the build, so your working directory is never written to. The resulting image is tagged locally and reused across launches, so only the first launch builds.
+- **Empty or unsupported agent (local base):** `sandbox plan`/`build` (which pass no agent) and agents with no recipe keep the local agent-less base.
 
-The launcher resolves the image for this build-free default in two ways. A release build with a recorded digest pin pulls a fixed image by `@sha256` (see [Reproducible releases](#reproducible-releases-digest-pinning) below). Otherwise it resolves a floating tag: a release build with no recorded pin pulls `latest` (which the image workflows move only on a `v*` tag), and a dev build off `main` pulls `edge` (republished on every merge to `main` that touches the image source, and on `workflow_dispatch`). So `latest` always names the most recent release and a dev run never clobbers it. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so the floating tag is the fallback when no digest is pinned. The freshness policy that keeps `edge` current is owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088).
+`sandbox check --agent=<agent>` resolves the same path, so a passing check matches what launch will run.
 
-When the requested agent has no published image, launch falls back to the customization tier. The image validation then emits the actionable message to install the agent CLI in the sandbox image or launch with `--local`.
+For a **published** agent, the launcher resolves the image in two ways. A release build with a recorded digest pin pulls a fixed image by `@sha256` (see [Reproducible releases](#reproducible-releases-digest-pinning) below). Otherwise it resolves a floating tag: a release build with no recorded pin pulls `latest` (which the image workflows move only on a `v*` tag), and a dev build off `main` pulls `edge` (republished on every merge to `main` that touches the image source, and on `workflow_dispatch`). So `latest` always names the most recent release and a dev run never clobbers it. A version-pinned tag (`<aileron-version>-<agent-cli-version>`) needs the agent CLI version, which the launcher does not know at resolve time, so the floating tag is the fallback when no digest is pinned. The freshness policy that keeps `edge` current is owned by [#1088](https://github.com/ALRubinger/aileron/issues/1088).
+
+Credential sealing is runtime-side and image-provenance-agnostic ([ADR-0025](/adr/0025-vault-backed-agent-auth/)), so a locally-built Claude image launches with credentials sealed exactly as a published image would.
 
 ## Prebuilt Per-Agent Images
 
-Aileron CI publishes one multi-arch image per agent to GHCR. Each image is baked from the GHCR sandbox base plus that agent's devcontainer Feature install script, so the Feature stays the single source of truth.
+Aileron CI publishes one multi-arch image per **publishable** agent to GHCR. Each image is baked from the GHCR sandbox base plus that agent's devcontainer Feature install script, so the Feature stays the single source of truth. The published set is computed from `composition.PublishedAgents` (the publishable agents), so an agent whose CLI license forbids redistribution is never published.
 
 | Agent | Image |
 |---|---|
-| Claude Code | `ghcr.io/alrubinger/aileron-sandbox-claude` |
 | Codex | `ghcr.io/alrubinger/aileron-sandbox-codex` |
+
+Claude Code is **not** published: `@anthropic-ai/claude-code` is all-rights-reserved with no redistribution grant, so its image is built locally from the Feature at launch instead ([#1451](https://github.com/ALRubinger/aileron/issues/1451)). See the [Claude Code Feature](#claude-code-feature) section.
 
 Each image is built for `linux/amd64` and `linux/arm64`, so a `docker pull` resolves the manifest for your platform automatically.
 
@@ -62,21 +67,20 @@ The tag scheme is `<aileron-version>-<agent-cli-version>` plus two floating tags
 Pull the most recent release (`latest`), or the latest dev publish off `main` (`edge`):
 
 ```bash
-docker pull ghcr.io/alrubinger/aileron-sandbox-claude:latest
 docker pull ghcr.io/alrubinger/aileron-sandbox-codex:latest
 # tip of main, republished on every image-affecting merge to main:
-docker pull ghcr.io/alrubinger/aileron-sandbox-claude:edge
+docker pull ghcr.io/alrubinger/aileron-sandbox-codex:edge
 ```
 
-Pull a pinned version, for example Aileron `0.0.1` with the Claude CLI at `2.1.179`:
+Pull a pinned version, for example Aileron `0.0.1` with the Codex CLI at `0.2.0`:
 
 ```bash
-docker pull ghcr.io/alrubinger/aileron-sandbox-claude:0.0.1-2.1.179
+docker pull ghcr.io/alrubinger/aileron-sandbox-codex:0.0.1-0.2.0
 ```
 
 CI smoke-tests every published image for launchability before it ships. The smoke asserts the agent CLI resolves on `PATH` and that the launcher's image validation succeeds.
 
-A daily watcher workflow (`sandbox-agents-watch.yml`) keeps the `edge` images fresh against upstream agent-CLI releases. It polls npm for the latest `@anthropic-ai/claude-code` and `@openai/codex` versions. It compares each against the CLI version baked into the `edge` image, recovered from the `dev-<cli-version>` tag co-located on the `edge` manifest digest. On drift it re-triggers `sandbox-agents.yml`, which rebuilds from the unpinned Feature install scripts and so bakes the latest CLI. The refreshed build publishes `edge` and `dev-<cli-version>`. Dev and main consumers pull `edge`, so they pick up new agent CLIs automatically without a release.
+A daily watcher workflow (`sandbox-agents-watch.yml`) keeps the `edge` images fresh against upstream agent-CLI releases. It watches the publishable agents (computed from `composition.PublishedAgents`, so a non-publishable agent like Claude Code is never watched) by polling npm for each agent's latest CLI version, for example `@openai/codex`. It compares each against the CLI version baked into the `edge` image, recovered from the `dev-<cli-version>` tag co-located on the `edge` manifest digest. On drift it re-triggers `sandbox-agents.yml`, which rebuilds from the unpinned Feature install scripts and so bakes the latest CLI. The refreshed build publishes `edge` and `dev-<cli-version>`. Dev and main consumers pull `edge`, so they pick up new agent CLIs automatically without a release.
 
 `latest` and the release-pinned `<aileron-version>-<agent-cli-version>` tags move on `v*` releases only, by design. A released user on `latest` stays pinned to that release's CLI version until the next release. This is intentional. A release is an immutable point and `latest` names the most-recent release, so a background job must never clobber it. Keeping `latest` fresh between releases is an accepted gap, not a bug.
 
@@ -184,9 +188,11 @@ This is distinct from the escape hatch above. The escape hatch points at pre-sta
 
 ## Claude Code Feature
 
-The Claude Code agent Feature installs the `claude` CLI onto `ghcr.io/alrubinger/aileron-sandbox-base`. It is the single source of truth that Aileron CI bakes into the prebuilt Claude image and that you compose for Tier 1. The Feature lives at `images/sandbox-features/claude/` (`devcontainer-feature.json` plus `install.sh`).
+The Claude Code agent Feature installs the `claude` CLI onto `ghcr.io/alrubinger/aileron-sandbox-base`. It is the single source of truth you compose for Tier 1, and the recipe Aileron builds **locally** on your host for the default launch path. The Feature lives at `images/sandbox-features/claude/` (`devcontainer-feature.json` plus `install.sh`).
 
-For the Tier 0 zero-build path, launch the prebuilt image directly:
+Claude Code is not redistributed as a published image: `@anthropic-ai/claude-code` is all-rights-reserved with no redistribution grant, so Aileron never bakes it into a GHCR image ([#1451](https://github.com/ALRubinger/aileron/issues/1451)). The default launch path therefore builds the image locally from the Feature instead of pulling one. The build needs only Docker on the host; the managed toolchain provisions Node and `@devcontainers/cli` (see [Managed Toolchain Build](#managed-toolchain-build)). The composed `devcontainer.json` is synthesized into a managed temp workspace folder, so your working directory is never written to, and the locally-tagged image is reused across launches so only the first launch builds.
+
+For the default local-build path, launch directly with no `.devcontainer` in your project:
 
 ```bash
 aileron launch --sandbox=docker claude
@@ -204,7 +210,7 @@ Claude Code still owns its own authentication flow. Do not bake Claude, Anthropi
 
 ## Codex Feature
 
-The Codex agent Feature installs the `codex` CLI onto `ghcr.io/alrubinger/aileron-sandbox-base`. The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine base. Like the Claude Feature, it is baked into the prebuilt Codex image and composable for Tier 1. The Feature lives at `images/sandbox-features/codex/` (`devcontainer-feature.json` plus `install.sh`).
+The Codex agent Feature installs the `codex` CLI onto `ghcr.io/alrubinger/aileron-sandbox-base`. The `@openai/codex` npm package ships prebuilt musl binaries, so it installs cleanly on the Alpine base. `@openai/codex` is Apache-2.0, so unlike Claude its image is baked into the prebuilt, published Codex image; it is also composable for Tier 1. The Feature lives at `images/sandbox-features/codex/` (`devcontainer-feature.json` plus `install.sh`).
 
 For the Tier 0 zero-build path:
 

--- a/docs/src/content/docs/development/sandbox-agent-images.md
+++ b/docs/src/content/docs/development/sandbox-agent-images.md
@@ -19,7 +19,7 @@ The check uses the same composition plan and minimal launch validation as `ailer
 
 | Agent | Command | Sandbox image support | MCP under `--sandbox=docker` | Notes |
 |---|---|---|---|---|
-| Claude Code | `claude` | Agent Feature (local build) | ✓ via `--mcp-config` | First-class Feature below. The build-free path builds the image **locally** from the Feature, because `@anthropic-ai/claude-code` is all-rights-reserved and cannot be redistributed as a published image ([#1451](https://github.com/ALRubinger/aileron/issues/1451)). Use `sandbox check --agent=claude` before launch. |
+| Claude Code | `claude` | Agent Feature (local build) | ✓ via `--mcp-config` | First-class Feature below. The default launch path builds the image **locally** from the Feature, because `@anthropic-ai/claude-code` is all-rights-reserved and cannot be redistributed as a published image ([#1451](https://github.com/ALRubinger/aileron/issues/1451)). Use `sandbox check --agent=claude` before launch. |
 | Codex | `codex` | Agent Feature (published image) | ✓ via bind-mounted `config.toml` | Feature below. `@openai/codex` is Apache-2.0, so its per-agent image is published and pulled build-free. Sandbox launch writes a generated `config.toml` to a host tempdir and bind-mounts it into `/home/agent/.codex/config.toml` ([ADR-0024](/adr/0024-sandbox-mcp-parity/)). Host `~/.codex/config.toml` is never touched. |
 | Goose | `goose` | Command contract only | ✓ via `--with-extension` | List the agent Feature in Tier 1, or install the CLI in a BYO image; no maintained Feature yet. |
 | OpenCode | `opencode` | Command contract only | ✓ via workspace `opencode.json` | Launcher writes `opencode.json` into the launch directory; the workspace bind-mount makes it readable in-container. |

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -234,16 +234,19 @@ func TestValidateSandboxEnrichesDevcontainerMismatch(t *testing.T) {
 	orig := validateSandboxImageForLaunch
 	t.Cleanup(func() { validateSandboxImageForLaunch = orig })
 	validateSandboxImageForLaunch = func(_ context.Context, _ SandboxLaunchPlan, _ LaunchConfig, _ map[string]string, _ []sandboxcontainer.Volume, _ string) error {
-		return errors.New("validate sandbox image image:test: agent command not found in sandbox image: claude: exit status 127")
+		return errors.New("validate sandbox image image:test: agent command not found in sandbox image: codex: exit status 127")
 	}
 
+	// codex is publishable, so the enrichment names its published image as the
+	// alternative. Claude is no longer publishable (#1451), so it would not
+	// trigger this hint.
 	workDir := t.TempDir()
 	err := validateSandbox(context.Background(), SandboxLaunchPlan{
 		Runtime: "docker",
 		Image:   "image:test",
 		Tier:    sandboxcomposition.TierDevcontainer,
 	}, LaunchConfig{
-		Agent: publishedNameAgent{name: "claude"},
+		Agent: publishedNameAgent{name: "codex"},
 		Dir:   workDir,
 	}, nil)
 	if err == nil {
@@ -253,7 +256,7 @@ func TestValidateSandboxEnrichesDevcontainerMismatch(t *testing.T) {
 	for _, want := range []string{
 		string(sandboxcomposition.TierDevcontainer),
 		filepath.Join(workDir, sandboxcomposition.DefaultDevcontainerPath),
-		sandboxcomposition.PublishedAgentImage("claude", version.Version),
+		sandboxcomposition.PublishedAgentImage("codex", version.Version),
 	} {
 		if !strings.Contains(msg, want) {
 			t.Errorf("validateSandbox error missing %q: %s", want, msg)

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -1164,10 +1164,12 @@ func TestLaunch_SandboxBuildRunsPreparedImage(t *testing.T) {
 	}
 }
 
-// publishedAgent reports a Name() that has a published per-agent sandbox image
-// (claude/codex), so the no-.devcontainer launch path resolves the build-free
+// publishedAgent reports a Name() that has a publishable per-agent sandbox image
+// (codex), so the no-.devcontainer launch path resolves the build-free
 // TierPublished default and pulls the per-agent image instead of building the
-// local base.
+// local base. Claude is no longer publishable (#1451), so it would take the
+// local-build path instead and is covered by
+// TestLaunch_SandboxNoDevcontainerNonPublishableAgentBuildsLocally.
 type publishedAgent struct {
 	scriptAgent
 	name string
@@ -1193,7 +1195,7 @@ func TestLaunch_SandboxNoDevcontainerPublishedAgentPullsPerAgentImage(t *testing
 	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
 
 	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
-		Agent:              publishedAgent{scriptAgent: scriptAgent{script: "claude"}, name: "claude"},
+		Agent:              publishedAgent{scriptAgent: scriptAgent{script: "codex"}, name: "codex"},
 		Dir:                dir,
 		Args:               []string{"--dangerously-skip-permissions"},
 		SandboxRuntime:     "docker",
@@ -1207,13 +1209,13 @@ func TestLaunch_SandboxNoDevcontainerPublishedAgentPullsPerAgentImage(t *testing
 		t.Fatalf("read docker args: %v", err)
 	}
 	args := string(data)
-	const image = "ghcr.io/alrubinger/aileron-sandbox-claude:edge"
+	const image = "ghcr.io/alrubinger/aileron-sandbox-codex:edge"
 	for _, want := range []string{
 		"pull\n" + image + "\n",
 		"run\n--rm\n-i\n",
 		"--env\nAILERON_SANDBOX_IMAGE=" + image + "\n",
 		"--env\nAILERON_SANDBOX_TIER=published\n",
-		image + "\naileron-run-with-proxy-ca\nclaude\n--dangerously-skip-permissions\n",
+		image + "\naileron-run-with-proxy-ca\ncodex\n--dangerously-skip-permissions\n",
 	} {
 		if !strings.Contains(args, want) {
 			t.Errorf("expected %q in docker args:\n%s", want, args)
@@ -1222,6 +1224,94 @@ func TestLaunch_SandboxNoDevcontainerPublishedAgentPullsPerAgentImage(t *testing
 	// The published path must not build the local base image.
 	if strings.Contains(args, "build\n-t\nghcr.io/alrubinger/aileron-sandbox-base") {
 		t.Errorf("published launch unexpectedly built the local base image:\n%s", args)
+	}
+}
+
+// TestLaunch_SandboxNoDevcontainerNonPublishableAgentBuildsLocally is the #1451
+// launch-level regression: with no .devcontainer and a recipe'd-but-not-
+// publishable agent (claude), launch must NOT pull a published
+// aileron-sandbox-claude image. It must build the agent image LOCALLY via
+// @devcontainers/cli from a synthesized devcontainer materialized into a managed
+// temp workspace folder (never the user's workDir), then run that local image.
+func TestLaunch_SandboxNoDevcontainerNonPublishableAgentBuildsLocally(t *testing.T) {
+	launch.PinWorkspaceUIDRemapForTest(t, false)
+	// Pin host-npx so the build path execs `npx @devcontainers/cli` hermetically;
+	// the managed default would provision a real Node, out of place in a unit
+	// test (the managed build is proven in the integration-sandbox-managed job).
+	t.Setenv(sandboxcontainer.ToolchainModeEnv, sandboxcontainer.ToolchainModeHostNPX)
+
+	dir := t.TempDir() // no .devcontainer, no images/sandbox-base context
+	binDir := t.TempDir()
+	argsFile := filepath.Join(dir, "docker-args.txt")
+	npxArgsFile := filepath.Join(dir, "npx-args.txt")
+	writeStub := func(name, dest string) {
+		script := "#!/bin/sh\nprintf '%s\\n' '---' >> " + dest + "\nprintf '%s\\n' \"$@\" >> " + dest + "\n"
+		if err := os.WriteFile(filepath.Join(binDir, name), []byte(script), 0o755); err != nil {
+			t.Fatal(err)
+		}
+	}
+	writeStub("docker", argsFile)
+	writeStub("npx", npxArgsFile)
+	t.Setenv("PATH", binDir+string(os.PathListSeparator)+os.Getenv("PATH"))
+
+	_, err := launch.Launch(context.Background(), launch.LaunchConfig{
+		Agent:              publishedAgent{scriptAgent: scriptAgent{script: "claude"}, name: "claude"},
+		Dir:                dir,
+		Args:               []string{"--dangerously-skip-permissions"},
+		SandboxRuntime:     "docker",
+		SandboxBuildPolicy: "always",
+	})
+	if err != nil {
+		t.Fatalf("launch: %v", err)
+	}
+
+	// The image is built LOCALLY via @devcontainers/cli, not pulled.
+	npxData, err := os.ReadFile(npxArgsFile)
+	if err != nil {
+		t.Fatalf("read npx args: %v", err)
+	}
+	localTag := sandboxcomposition.LocalAgentImageTag("claude", "dev")
+	for _, want := range []string{
+		"@devcontainers/cli@",
+		"build\n",
+		"--image-name\n" + localTag + "\n",
+	} {
+		if !strings.Contains(string(npxData), want) {
+			t.Fatalf("local devcontainers/cli build call missing %q:\n%s", want, npxData)
+		}
+	}
+	// The build never references a published claude image.
+	if strings.Contains(string(npxData), "aileron-sandbox-claude") {
+		t.Fatalf("local build unexpectedly referenced a published claude image:\n%s", npxData)
+	}
+	// The --workspace-folder is a managed temp dir, NOT the user's workDir.
+	if strings.Contains(string(npxData), "--workspace-folder\n"+dir+"\n") {
+		t.Fatalf("build used the user's workDir as --workspace-folder; want a managed temp folder:\n%s", npxData)
+	}
+	if !strings.Contains(string(npxData), "--workspace-folder\n") {
+		t.Fatalf("build did not pass a --workspace-folder:\n%s", npxData)
+	}
+	// The user's workDir must be left untouched: no .devcontainer written there.
+	if _, statErr := os.Stat(filepath.Join(dir, sandboxcomposition.DefaultDevcontainerPath)); !os.IsNotExist(statErr) {
+		t.Fatalf("user workDir was polluted with a .devcontainer (stat err=%v)", statErr)
+	}
+
+	// docker is used for validate + run, never to pull a published claude image.
+	data, err := os.ReadFile(argsFile)
+	if err != nil {
+		t.Fatalf("read docker args: %v", err)
+	}
+	if strings.Contains(string(data), "pull\nghcr.io/alrubinger/aileron-sandbox-claude") {
+		t.Fatalf("launch pulled a published claude image; want a local build:\n%s", data)
+	}
+	for _, want := range []string{
+		"--env\nAILERON_SANDBOX_IMAGE=" + localTag + "\n",
+		"--env\nAILERON_SANDBOX_TIER=devcontainer\n",
+		localTag + "\naileron-run-with-proxy-ca\nclaude\n--dangerously-skip-permissions\n",
+	} {
+		if !strings.Contains(string(data), want) {
+			t.Fatalf("docker run call missing %q:\n%s", want, data)
+		}
 	}
 }
 

--- a/internal/sandbox/composition/composition.go
+++ b/internal/sandbox/composition/composition.go
@@ -72,6 +72,17 @@ type Plan struct {
 	// rather than raw `docker build`; on a Tier 2 (BYO image) plan it is inert
 	// (carried only for plan inspection).
 	Features map[string]json.RawMessage
+	// SynthesizedDevcontainer carries a devcontainer.json that Discover
+	// composed in memory rather than reading from the user's workDir. It is set
+	// only on the no-.devcontainer local-build branch for a recipe'd-but-not-
+	// publishable agent (e.g. Claude Code): Discover composes BaseImage + the
+	// agent Feature into a TierDevcontainer plan whose Features route the build
+	// through @devcontainers/cli, but with no .devcontainer on disk the builder
+	// must materialize this content into a managed temp workspace folder to feed
+	// `devcontainer build --workspace-folder` without polluting the user's
+	// workDir (#1451). Empty on every other tier and on devcontainer plans read
+	// from disk.
+	SynthesizedDevcontainer string
 }
 
 // Mount is the subset of devcontainer mount configuration Aileron needs to
@@ -134,13 +145,21 @@ type devcontainerCustomizations struct {
 // Discover returns the sandbox image-composition plan for workDir.
 //
 // agent is the launch agent's name (e.g. "claude", "codex"). It only affects
-// the no-.devcontainer branch: when a project authors no .devcontainer and the
-// agent has a published per-agent image (PublishedAgentExists), Discover
-// resolves the build-free Tier 0 default (TierPublished) whose Image is that
-// per-agent image. An empty agent or an agent with no published image keeps the
-// existing local-base behavior (TierBase), so `sandbox plan`/`build` (which pass
-// no agent) and unsupported agents are unchanged. The agent never perturbs Tier
-// 1/Tier 2 resolution when a .devcontainer is present.
+// the no-.devcontainer branch, which resolves one of three ways (#1451):
+//
+//   - A publishable agent (PublishedAgentExists, e.g. "codex"): the build-free
+//     Tier 0 default (TierPublished) whose Image is the prebuilt per-agent
+//     image. Pulled, never built.
+//   - A recipe'd-but-not-publishable agent (has a recipe but no redistributable
+//     published image, e.g. "claude"): a LOCAL Feature build (TierDevcontainer
+//     with the agent Feature and a SynthesizedDevcontainer), built on the host
+//     from the base image + agent Feature via @devcontainers/cli.
+//   - An empty agent or an unsupported agent (no recipe): the local-base default
+//     (TierBase), so `sandbox plan`/`build` (which pass no agent) and unknown
+//     agents are unchanged.
+//
+// The agent never perturbs Tier 1/Tier 2 resolution when a .devcontainer is
+// present.
 func Discover(workDir, version, agent string) (Plan, error) {
 	if workDir == "" {
 		workDir = "."
@@ -156,6 +175,26 @@ func Discover(workDir, version, agent string) (Plan, error) {
 					BaseImage: baseImage,
 					Image:     PublishedAgentImage(agent, version),
 				}, nil
+			}
+			// A recipe'd-but-not-publishable agent (e.g. Claude Code) has a
+			// Feature and a verified install recipe but no redistributable
+			// published image (#1451). Resolve a LOCAL Feature build: compose
+			// the base image with the agent Feature into a TierDevcontainer
+			// plan whose Features route the build through @devcontainers/cli
+			// (runtime.go Features path), materializing the synthesized
+			// devcontainer.json into a managed temp workspace folder so it
+			// builds without a .devcontainer on disk and without touching the
+			// user's workDir.
+			if agent != "" {
+				if _, ok := recipeForAgent(agent); ok {
+					return Plan{
+						Tier:                    TierDevcontainer,
+						BaseImage:               baseImage,
+						Image:                   LocalAgentImageTag(agent, version),
+						Features:                map[string]json.RawMessage{FeatureReference(agent): json.RawMessage("{}")},
+						SynthesizedDevcontainer: synthesizedAgentDevcontainer(agent, version),
+					}, nil
+				}
 			}
 			return Plan{Tier: TierBase, BaseImage: baseImage, Image: baseImage}, nil
 		}

--- a/internal/sandbox/composition/composition_test.go
+++ b/internal/sandbox/composition/composition_test.go
@@ -20,29 +20,70 @@ func TestDiscoverMissingDevcontainerUsesBaseImage(t *testing.T) {
 	}
 }
 
-func TestDiscoverMissingDevcontainerPublishedAgentResolvesPerAgentImage(t *testing.T) {
-	for _, tc := range []struct {
-		agent     string
-		wantImage string
-	}{
-		{"claude", "ghcr.io/alrubinger/aileron-sandbox-claude:latest"},
-		{"codex", "ghcr.io/alrubinger/aileron-sandbox-codex:latest"},
-	} {
-		t.Run(tc.agent, func(t *testing.T) {
-			plan, err := Discover(t.TempDir(), "0.4.0", tc.agent)
-			if err != nil {
-				t.Fatalf("Discover: %v", err)
-			}
-			if plan.Tier != TierPublished {
-				t.Fatalf("Tier = %s, want %s", plan.Tier, TierPublished)
-			}
-			if plan.Image != tc.wantImage {
-				t.Fatalf("Image = %q, want %q", plan.Image, tc.wantImage)
-			}
-			if plan.BaseImage != BaseImage("0.4.0") {
-				t.Fatalf("BaseImage = %q, want %q", plan.BaseImage, BaseImage("0.4.0"))
-			}
-		})
+func TestDiscoverMissingDevcontainerPublishableAgentResolvesPerAgentImage(t *testing.T) {
+	// Codex is publishable (Apache-2.0): no .devcontainer resolves the build-free
+	// published per-agent image.
+	plan, err := Discover(t.TempDir(), "0.4.0", "codex")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if plan.Tier != TierPublished {
+		t.Fatalf("Tier = %s, want %s", plan.Tier, TierPublished)
+	}
+	if plan.Image != "ghcr.io/alrubinger/aileron-sandbox-codex:latest" {
+		t.Fatalf("Image = %q, want %q", plan.Image, "ghcr.io/alrubinger/aileron-sandbox-codex:latest")
+	}
+	if plan.BaseImage != BaseImage("0.4.0") {
+		t.Fatalf("BaseImage = %q, want %q", plan.BaseImage, BaseImage("0.4.0"))
+	}
+	if plan.SynthesizedDevcontainer != "" {
+		t.Fatalf("SynthesizedDevcontainer should be empty for a published agent, got %q", plan.SynthesizedDevcontainer)
+	}
+}
+
+func TestDiscoverMissingDevcontainerNonPublishableAgentResolvesLocalBuild(t *testing.T) {
+	// Claude has a recipe but is NOT publishable (@anthropic-ai/claude-code is
+	// all-rights-reserved, no redistribution grant, #1451). With no .devcontainer
+	// it must resolve a LOCAL Feature build (TierDevcontainer with the agent
+	// Feature and a synthesized devcontainer.json), never a published image pull.
+	plan, err := Discover(t.TempDir(), "0.4.0", "claude")
+	if err != nil {
+		t.Fatalf("Discover: %v", err)
+	}
+	if plan.Tier != TierDevcontainer {
+		t.Fatalf("Tier = %s, want %s", plan.Tier, TierDevcontainer)
+	}
+	if plan.Image != LocalAgentImageTag("claude", "0.4.0") {
+		t.Fatalf("Image = %q, want local tag %q", plan.Image, LocalAgentImageTag("claude", "0.4.0"))
+	}
+	// The plan must NOT name any aileron-sandbox-claude published image: that
+	// would redistribute Claude Code, the exact violation #1451 fixes.
+	if strings.Contains(plan.Image, "aileron-sandbox-claude") {
+		t.Fatalf("Image = %q must not reference a published claude image", plan.Image)
+	}
+	want := FeatureReference("claude")
+	if _, ok := plan.Features[want]; !ok {
+		t.Fatalf("Features = %v, want it to contain the claude Feature %q", plan.Features, want)
+	}
+	if len(plan.Features) != 1 {
+		t.Fatalf("Features = %v, want exactly the claude Feature", plan.Features)
+	}
+	if plan.SynthesizedDevcontainer == "" {
+		t.Fatalf("SynthesizedDevcontainer must be set for a local agent build")
+	}
+	// The synthesized config must compose the base image with the claude Feature
+	// and nothing else (no published claude image baked in).
+	if !strings.Contains(plan.SynthesizedDevcontainer, BaseImage("0.4.0")) {
+		t.Fatalf("SynthesizedDevcontainer %q must FROM the base image", plan.SynthesizedDevcontainer)
+	}
+	if !strings.Contains(plan.SynthesizedDevcontainer, want) {
+		t.Fatalf("SynthesizedDevcontainer %q must reference the claude Feature %q", plan.SynthesizedDevcontainer, want)
+	}
+	if strings.Contains(plan.SynthesizedDevcontainer, "aileron-sandbox-claude") {
+		t.Fatalf("SynthesizedDevcontainer %q must not reference a published claude image", plan.SynthesizedDevcontainer)
+	}
+	if plan.BaseImage != BaseImage("0.4.0") {
+		t.Fatalf("BaseImage = %q, want %q", plan.BaseImage, BaseImage("0.4.0"))
 	}
 }
 
@@ -109,8 +150,10 @@ func TestPublishedAgentImage(t *testing.T) {
 }
 
 func TestPublishedAgentExists(t *testing.T) {
+	// PublishedAgentExists is now publish-eligibility, not recipe-existence:
+	// claude has a recipe but is NOT publishable (#1451), so it is false here.
 	for agent, want := range map[string]bool{
-		"claude": true,
+		"claude": false,
 		"codex":  true,
 		"goose":  false,
 		"":       false,

--- a/internal/sandbox/composition/digests_test.go
+++ b/internal/sandbox/composition/digests_test.go
@@ -161,7 +161,9 @@ func TestPublishedAgentImageDigestPin(t *testing.T) {
 
 func TestPublishedAgents(t *testing.T) {
 	got := PublishedAgents()
-	want := []string{"claude", "codex"}
+	// Only publishable agents are listed. Claude is recipe'd but not publishable
+	// (#1451), so it is excluded; codex (Apache-2.0) remains.
+	want := []string{"codex"}
 	if len(got) != len(want) {
 		t.Fatalf("PublishedAgents() = %v, want %v", got, want)
 	}

--- a/internal/sandbox/composition/recipes.go
+++ b/internal/sandbox/composition/recipes.go
@@ -21,6 +21,15 @@ type agentRecipe struct {
 	// NPMPackage is the global npm package (`npm install -g <pkg>`) that
 	// installs the agent's CLI binary onto PATH.
 	NPMPackage string
+	// Publishable reports whether the agent's CLI license permits Aileron to
+	// bake it into a redistributable, publicly-hosted per-agent image. This is
+	// distinct from having a recipe: an agent always has a Feature and a
+	// local-build path when a recipe exists, but only a publishable agent's
+	// image may be pushed to GHCR and pulled build-free (TierPublished). A
+	// non-publishable agent (e.g. Claude Code, which is all-rights-reserved with
+	// no redistribution grant) keeps its Feature and resolves to a LOCAL Feature
+	// build instead of a published image (#1451).
+	Publishable bool
 }
 
 // agentRecipes maps an agent id to its canonical install recipe. Agents absent
@@ -29,10 +38,18 @@ var agentRecipes = map[string]agentRecipe{
 	"claude": {
 		Prereqs:    []string{"git", "nodejs", "npm", "ripgrep"},
 		NPMPackage: "@anthropic-ai/claude-code",
+		// @anthropic-ai/claude-code is all-rights-reserved with no
+		// redistribution grant, so Aileron may not bake it into a published
+		// image. Claude keeps its Feature (local-build path) but is never
+		// published (#1451).
+		Publishable: false,
 	},
 	"codex": {
 		Prereqs:    []string{"git", "nodejs", "npm", "ripgrep"},
 		NPMPackage: "@openai/codex",
+		// @openai/codex is Apache-2.0, which grants redistribution, so its
+		// per-agent image may be published and pulled build-free.
+		Publishable: true,
 	},
 }
 
@@ -40,4 +57,12 @@ var agentRecipes = map[string]agentRecipe{
 func recipeForAgent(agent string) (agentRecipe, bool) {
 	r, ok := agentRecipes[agent]
 	return r, ok
+}
+
+// agentPublishable reports whether agent has a recipe AND its CLI license
+// permits baking it into a redistributable published image. It is the predicate
+// that separates publish-eligibility from recipe-existence (#1451).
+func agentPublishable(agent string) bool {
+	r, ok := agentRecipes[agent]
+	return ok && r.Publishable
 }

--- a/internal/sandbox/composition/scaffold.go
+++ b/internal/sandbox/composition/scaffold.go
@@ -97,28 +97,66 @@ func PublishedAgentImage(agent, version string) string {
 	return DefaultPublishedImageRepository + "-" + agent + ":" + imageTag(version)
 }
 
-// PublishedAgents returns the agents that ship a prebuilt per-agent image,
-// sorted for determinism. It is the single source of truth for "which images
-// exist" consumed by the digest-pin generator (internal/tools/agentdigests), so
-// a new agent gaining a recipe is automatically pinned at the next release prep.
+// LocalAgentImageTag returns the local-only image tag for a recipe'd-but-not-
+// publishable agent built from a synthesized devcontainer (#1451). The name is
+// deterministic per (agent, image tag) so the `auto` build policy can skip a
+// rebuild when the image already exists locally. It is never pushed to a
+// registry — the "aileron/" prefix (no registry host) keeps it a local-daemon
+// tag, mirroring ProjectImageTag's convention.
+func LocalAgentImageTag(agent, version string) string {
+	return "aileron/sandbox-agent-" + agent + ":" + imageTag(version)
+}
+
+// PublishedAgents returns the agents whose per-agent image is publishable, i.e.
+// whose CLI license permits Aileron to bake it into a redistributable image and
+// host it on GHCR (see agentPublishable). It is the single source of truth for
+// "which images exist to publish" consumed by the digest-pin generator
+// (internal/tools/agentdigests) and the sandbox-agents CI matrix, so a
+// publishable agent is automatically pinned at release prep and a
+// non-publishable one (e.g. Claude Code) is auto-excluded from publishing
+// without further wiring (#1451). The list is sorted for determinism.
 func PublishedAgents() []string {
 	agents := make([]string, 0, len(agentRecipes))
-	for agent := range agentRecipes {
-		agents = append(agents, agent)
+	for agent, recipe := range agentRecipes {
+		if recipe.Publishable {
+			agents = append(agents, agent)
+		}
 	}
 	sort.Strings(agents)
 	return agents
 }
 
-// PublishedAgentExists reports whether agent has a prebuilt per-agent image to
-// pull for the build-free default. It reuses the agentRecipes set, which is the
-// single source of truth for "this agent has a verified recipe and ships a
-// published Feature/image" (see recipes.go). Discover and `sandbox check` share
-// this predicate so both resolve the same image (the launch/check parity
-// requirement). New agents that gain a recipe automatically gain auto-resolve.
+// PublishedAgentExists reports whether agent ships a prebuilt, publishable
+// per-agent image to pull for the build-free default. It is the publish-eligible
+// subset of recipe-existence: an agent must both have a verified recipe AND have
+// a redistributable CLI license (see agentPublishable). Discover and `sandbox
+// check` share this predicate so both resolve the same published image (the
+// launch/check parity requirement). A recipe'd-but-not-publishable agent (e.g.
+// Claude Code) is false here and resolves to a LOCAL Feature build instead of a
+// published image pull (#1451).
 func PublishedAgentExists(agent string) bool {
-	_, ok := recipeForAgent(agent)
-	return ok
+	return agentPublishable(agent)
+}
+
+// synthesizedAgentDevcontainer returns the devcontainer.json that composes the
+// Aileron base image with a single agent Feature, used by Discover's
+// no-.devcontainer local-build branch for a recipe'd-but-not-publishable agent
+// (e.g. Claude Code). It carries no commented customer-tooling slot and no
+// customizations block: it is a build-only artifact materialized into a managed
+// temp workspace folder by the container builder, never written into the user's
+// workDir (#1451). The Aileron customizations the launcher needs (mediation,
+// approval surface, credential sealing) are applied runtime-side regardless of
+// image provenance, so this minimal config is sufficient to build a launchable
+// agent image.
+func synthesizedAgentDevcontainer(agent, version string) string {
+	return fmt.Sprintf(`{
+  "name": "Aileron sandbox",
+  "image": %q,
+  "features": {
+    %q: {}
+  }
+}
+`, BaseImage(version), FeatureReference(agent))
 }
 
 // starterDevcontainer emits the Feature-composing devcontainer.json recorded in

--- a/internal/sandbox/composition/validatehint_test.go
+++ b/internal/sandbox/composition/validatehint_test.go
@@ -20,7 +20,10 @@ func agentNotFoundErr(agent string) error {
 // names none of those) and passes after.
 func TestEnrichValidateErrorDevcontainerMismatch(t *testing.T) {
 	const (
-		agent   = "claude"
+		// codex is publishable (Apache-2.0), so the devcontainer-mismatch hint
+		// names its published image as the alternative. Claude is no longer
+		// publishable (#1451), so it would not trigger this hint.
+		agent   = "codex"
 		version = "1.2.3"
 		workDir = "/home/dev/project"
 	)
@@ -283,8 +286,10 @@ func TestEnrichValidateErrorNilUnchanged(t *testing.T) {
 }
 
 func TestEnrichValidateErrorEmptyWorkDirDefaultsToCwd(t *testing.T) {
-	base := agentNotFoundErr("claude")
-	got := EnrichValidateError(base, TierDevcontainer, "claude", "1.2.3", "", "linux", false)
+	// codex is publishable, so the devcontainer-mismatch hint fires and names
+	// the devcontainer path (claude is no longer publishable, #1451).
+	base := agentNotFoundErr("codex")
+	got := EnrichValidateError(base, TierDevcontainer, "codex", "1.2.3", "", "linux", false)
 	// filepath.Join(".", path) cleans to the bare relative path.
 	wantPath := DefaultDevcontainerPath
 	if !strings.Contains(got.Error(), wantPath) {

--- a/internal/sandbox/container/runtime.go
+++ b/internal/sandbox/container/runtime.go
@@ -420,8 +420,18 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 			return BuildResult{}, err
 		}
 		result.Runtime = runtimeName
+		// A synthesized-devcontainer plan (Discover's no-.devcontainer local
+		// agent build, #1451) carries its own deterministic local image tag in
+		// Plan.Image and is NOT keyed off workDir: the build reads a managed
+		// temp workspace folder, not workDir, so ProjectImageTag(workDir) would
+		// be the wrong (and non-deterministic across launches) name. Honor
+		// Plan.Image for that case; otherwise the project-local image tag.
 		if opts.Tag == "" {
-			result.Image = ProjectImageTag(workDir)
+			if opts.Plan.SynthesizedDevcontainer != "" {
+				result.Image = opts.Plan.Image
+			} else {
+				result.Image = ProjectImageTag(workDir)
+			}
 		}
 		shouldBuild, err := b.shouldBuild(ctx, runner, runtimeName, result.Image, policy)
 		if err != nil {
@@ -440,7 +450,21 @@ func (b Builder) Build(ctx context.Context, opts BuildOptions) (BuildResult, err
 			if err != nil {
 				return BuildResult{}, err
 			}
-			name, args, err := devcontainerCLIBuildArgs(prefix, workDir, opts.Plan, result.Image)
+			// For a synthesized-devcontainer plan there is no .devcontainer on
+			// disk under workDir; materialize the composed config into a
+			// managed temp workspace folder and build from there so the user's
+			// workDir is never written to (#1451). The run path still mounts
+			// the real workDir; only the build reads the temp folder.
+			buildWorkDir := workDir
+			if opts.Plan.SynthesizedDevcontainer != "" {
+				tmp, cleanup, err := materializeSynthesizedWorkspace(opts.Plan.SynthesizedDevcontainer)
+				if err != nil {
+					return BuildResult{}, err
+				}
+				defer cleanup()
+				buildWorkDir = tmp
+			}
+			name, args, err := devcontainerCLIBuildArgs(prefix, buildWorkDir, opts.Plan, result.Image)
 			if err != nil {
 				return BuildResult{}, err
 			}
@@ -1267,6 +1291,32 @@ func statExisting(path, label string) error {
 // <image>` plus deterministic (sorted) `--build-arg k=v` tokens mirroring
 // devcontainerBuildArgs. The argv tail (everything after the prefix) is
 // byte-identical between the host-npx and managed branches.
+// materializeSynthesizedWorkspace writes a Discover-synthesized devcontainer.json
+// (the no-.devcontainer local agent build, #1451) into a fresh temp directory
+// laid out as <tmp>/.devcontainer/devcontainer.json, so devcontainerCLIBuildArgs
+// can pass <tmp> as the `--workspace-folder` exactly as it would a real project
+// directory. The returned cleanup removes the temp tree; callers defer it. The
+// user's actual workDir is never touched — only the build reads this folder, and
+// the run path mounts the real workDir.
+func materializeSynthesizedWorkspace(content string) (string, func(), error) {
+	tmp, err := os.MkdirTemp("", "aileron-sandbox-build-")
+	if err != nil {
+		return "", func() {}, fmt.Errorf("create synthesized devcontainer workspace: %w", err)
+	}
+	cleanup := func() { _ = os.RemoveAll(tmp) }
+	dir := filepath.Join(tmp, filepath.Dir(composition.DefaultDevcontainerPath))
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("create synthesized devcontainer dir: %w", err)
+	}
+	path := filepath.Join(tmp, composition.DefaultDevcontainerPath)
+	if err := os.WriteFile(path, []byte(content), 0o644); err != nil {
+		cleanup()
+		return "", func() {}, fmt.Errorf("write synthesized devcontainer %s: %w", path, err)
+	}
+	return tmp, cleanup, nil
+}
+
 func devcontainerCLIBuildArgs(prefix []string, workDir string, plan composition.Plan, image string) (string, []string, error) {
 	devcontainerPath := filepath.Join(workDir, composition.DefaultDevcontainerPath)
 	if _, err := os.Stat(devcontainerPath); err != nil {

--- a/internal/sandbox/container/runtime_test.go
+++ b/internal/sandbox/container/runtime_test.go
@@ -280,6 +280,98 @@ func TestBuildDevcontainerWithoutFeaturesUsesDockerBuild(t *testing.T) {
 	}
 }
 
+// synthesizedReadingRunner records the build args and, when a --workspace-folder
+// is present, reads the devcontainer.json under it AT RUN TIME so the test can
+// prove the synthesized config was materialized before the build dispatched (and
+// is therefore gone after, once the deferred cleanup fires).
+type synthesizedReadingRunner struct {
+	name           string
+	args           []string
+	workspaceFlag  string
+	devcontainerOK bool
+	devcontainer   string
+}
+
+func (r *synthesizedReadingRunner) Run(_ context.Context, name string, args []string, _, _ io.Writer) error {
+	r.name = name
+	r.args = append([]string(nil), args...)
+	for i := 0; i+1 < len(args); i++ {
+		if args[i] == "--workspace-folder" {
+			r.workspaceFlag = args[i+1]
+			b, err := os.ReadFile(filepath.Join(args[i+1], composition.DefaultDevcontainerPath))
+			if err == nil {
+				r.devcontainerOK = true
+				r.devcontainer = string(b)
+			}
+		}
+	}
+	return nil
+}
+
+// TestBuildSynthesizedDevcontainerLocalAgentBuild is the #1451 regression: a
+// Discover-synthesized plan (no .devcontainer on disk, a recipe'd-but-not-
+// publishable agent like claude) must build LOCALLY via @devcontainers/cli from
+// a materialized temp workspace folder — never the user's workDir — using the
+// plan's deterministic local image tag rather than ProjectImageTag(workDir), and
+// must leave the user's workDir untouched.
+func TestBuildSynthesizedDevcontainerLocalAgentBuild(t *testing.T) {
+	workDir := t.TempDir()
+	const localTag = "aileron/sandbox-agent-claude:edge"
+	synth := `{"name":"Aileron sandbox","image":"ghcr.io/alrubinger/aileron-sandbox-base:edge","features":{"ghcr.io/alrubinger/aileron-features/claude:0":{}}}`
+	runner := &synthesizedReadingRunner{}
+	result, err := Builder{Runtime: "docker", Runner: runner}.Build(context.Background(), BuildOptions{
+		WorkDir:       workDir,
+		ToolchainMode: ToolchainModeHostNPX,
+		Plan: composition.Plan{
+			Tier:                    composition.TierDevcontainer,
+			Image:                   localTag,
+			Features:                map[string]json.RawMessage{"ghcr.io/alrubinger/aileron-features/claude:0": json.RawMessage("{}")},
+			SynthesizedDevcontainer: synth,
+		},
+	})
+	if err != nil {
+		t.Fatalf("Build: %v", err)
+	}
+	// Built locally via the CLI, not pulled.
+	if !result.Built {
+		t.Fatalf("result.Built = false, want true (a local Feature build)")
+	}
+	if runner.name != devcontainerCLI[0] {
+		t.Fatalf("runner.name = %q, want the devcontainer CLI %q", runner.name, devcontainerCLI[0])
+	}
+	// Image is the deterministic local tag, NOT ProjectImageTag(workDir).
+	if result.Image != localTag {
+		t.Fatalf("result.Image = %q, want the plan's local tag %q", result.Image, localTag)
+	}
+	if result.Image == ProjectImageTag(workDir) {
+		t.Fatalf("result.Image must not be the workDir-keyed project tag")
+	}
+	if strings.Contains(result.Image, "aileron-sandbox-claude") {
+		t.Fatalf("result.Image = %q must not reference a published claude image", result.Image)
+	}
+	// The build read a temp workspace folder, never the user's workDir.
+	if runner.workspaceFlag == "" {
+		t.Fatalf("no --workspace-folder passed to the CLI build")
+	}
+	if runner.workspaceFlag == workDir {
+		t.Fatalf("--workspace-folder = workDir %q, want a managed temp folder", workDir)
+	}
+	if !runner.devcontainerOK {
+		t.Fatalf("synthesized devcontainer.json was not materialized under the build workspace folder")
+	}
+	if runner.devcontainer != synth {
+		t.Fatalf("materialized devcontainer = %q, want %q", runner.devcontainer, synth)
+	}
+	// The user's workDir must be untouched: no .devcontainer written there.
+	if _, err := os.Stat(filepath.Join(workDir, composition.DefaultDevcontainerPath)); !os.IsNotExist(err) {
+		t.Fatalf("user workDir was polluted with a .devcontainer (stat err=%v)", err)
+	}
+	// The temp workspace folder is cleaned up after Build returns.
+	if _, err := os.Stat(runner.workspaceFlag); !os.IsNotExist(err) {
+		t.Fatalf("temp build workspace %q was not cleaned up (stat err=%v)", runner.workspaceFlag, err)
+	}
+}
+
 func TestBuildBYOImageWithFeaturesNoBuild(t *testing.T) {
 	// Features on a BYO (Tier 2) image are inert; the build still short-circuits
 	// to ErrNoBuildRequired with no CLI invocation.

--- a/internal/tools/publishedagents/main.go
+++ b/internal/tools/publishedagents/main.go
@@ -1,0 +1,38 @@
+// Command publishedagents prints the agents whose per-agent sandbox image is
+// publishable (composition.PublishedAgents) as a JSON array, one source of truth
+// for the sandbox-agents.yml CI build matrix.
+//
+// PublishedAgents excludes agents whose CLI license forbids redistribution (e.g.
+// Claude Code, @anthropic-ai/claude-code, all-rights-reserved), so driving the
+// matrix off this command guarantees CI never builds or publishes a
+// non-redistributable per-agent image (#1451). A new publishable agent is added
+// to the matrix automatically by gaining a publishable recipe; nothing in the
+// workflow YAML hardcodes the agent list.
+//
+// Usage:
+//
+//	go run ./tools/publishedagents
+//
+// prints e.g. ["codex"] to stdout.
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+
+	"github.com/ALRubinger/aileron/internal/sandbox/composition"
+)
+
+func main() {
+	agents := composition.PublishedAgents()
+	if agents == nil {
+		agents = []string{}
+	}
+	data, err := json.Marshal(agents)
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "marshal published agents: %v\n", err)
+		os.Exit(1)
+	}
+	fmt.Println(string(data))
+}


### PR DESCRIPTION
## Summary

Claude Code (`@anthropic-ai/claude-code`) is all-rights-reserved with no redistribution grant, so baking it into a published per-agent image (`ghcr.io/alrubinger/aileron-sandbox-claude`) is a licensing violation. The root cause: `composition.Discover`'s no-`.devcontainer` branch resolved `TierPublished` and pulled that image whenever `PublishedAgentExists(agent)` was true, but that predicate conflated two distinct facts through the single `agentRecipes` table — "has a verified install recipe" (claude AND codex) and "ships a redistributable published image" (should be codex only).

This is the residual core of #1451 and lands as one indivisible change (any intermediate state either still redistributes Claude or breaks launch). The keystone substrate #1454 (managed devcontainer-CLI toolchain, default `ToolchainModeManaged`) has already landed, so a local Feature build needs only Docker on the host.

### What changed

1. **Split publish-eligibility from recipe-existence.** `agentRecipe` gains a `Publishable` flag (claude `false`, codex `true`) and a new `agentPublishable` predicate. `PublishedAgents`/`PublishedAgentExists` now mean publish-eligible. Claude keeps its recipe (and therefore its Feature and a local-build path) but is no longer publish-eligible.
2. **Local build for non-publishable agents.** In `Discover`'s no-`.devcontainer` branch, a recipe'd-but-not-publishable agent (claude) resolves to a `TierDevcontainer` plan that composes `BaseImage` + the agent Feature, carrying a synthesized `devcontainer.json` and a deterministic local image tag (`LocalAgentImageTag`). A publishable agent (codex) keeps `TierPublished`; empty/unsupported agents keep `TierBase`.
3. **Materialize without polluting workDir.** `devcontainerCLIBuildArgs` requires a `.devcontainer/devcontainer.json` under `--workspace-folder`. The builder now materializes the synthesized config into a managed temp workspace folder (cleaned up after the build) and uses the plan's local image tag rather than `ProjectImageTag(workDir)`, so the user's working directory is never written to and the run path still mounts the real workDir.
4. **CI driven off the publishable set.** `sandbox-agents.yml` and `sandbox-agents-watch.yml` compute their agent list from `composition.PublishedAgents` (via a new `internal/tools/publishedagents` helper) instead of a hardcoded `[claude, codex]`, so claude is dropped from building/publishing and the watcher automatically.
5. **Digest set + docs.** `PublishedAgents()` feeds `internal/tools/agentdigests`, so claude auto-excludes from `agent-images.lock.json` (currently `{}`, no churn). `docs/.../sandbox-agent-images.md` updated to describe the three default launch paths and that Claude builds locally.

Credential sealing is runtime-side and image-provenance-agnostic ([ADR-0025](https://github.com/ALRubinger/aileron/blob/main/docs/src/content/docs/adr/0025-vault-backed-agent-auth.md)), so a locally-built Claude image launches with creds sealed exactly as a published image would. Per the issue's scope guard, this flattens only the AGENT install; capability-unit Features like `gh` (#1319) are untouched. Follow-ons #1456/#1457 stay out of scope.

## Test plan

- `go test ./...` (internal module) — green.
- New regression tests:
  - `TestDiscoverMissingDevcontainerNonPublishableAgentResolvesLocalBuild` — claude resolves a `TierDevcontainer` local-build plan that references no published claude image.
  - `TestDiscoverMissingDevcontainerPublishableAgentResolvesPerAgentImage` — codex keeps `TierPublished`.
  - `TestBuildSynthesizedDevcontainerLocalAgentBuild` (container) — synthesized plan builds via the CLI from a managed temp workspace folder, uses the local tag (not `ProjectImageTag`), leaves the user's workDir untouched, cleans up the temp folder.
  - `TestLaunch_SandboxNoDevcontainerNonPublishableAgentBuildsLocally` (launch) — end-to-end, claude builds locally via `@devcontainers/cli` and is never pulled as a published image.
  - `TestPublishedAgents`/`TestPublishedAgentExists` updated to the publish-eligible contract.
- Coverage: `sandbox/composition` 93.9%, `sandbox/container` 92.1%. New functions 100% covered; the only sub-80% spot is `materializeSynthesizedWorkspace`'s defensive `os.*` error branches (64%), which are honest error paths not worth fault-injecting.
- `go vet ./...` clean; `actionlint` clean on both workflows.

Closes #1451

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Sandbox agent image handling now automatically distinguishes publishable agents from locally built ones, improving launch behavior for supported agents.
  * Launches without a devcontainer can now build non-publishable agent images locally when needed.

* **Bug Fixes**
  * Fixed image selection so published agents use the correct prebuilt image, while non-publishable agents no longer try to pull unavailable images.
  * Improved launch error messages and build isolation to avoid modifying your project workspace.

* **Documentation**
  * Updated sandbox image docs to clarify default launch paths and which agent images are published versus built locally.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->