### PR TITLE
feat(skill): installable skill format + requires resolution + launch projection

### DIFF
--- a/cmd/aileron/auth_test.go
+++ b/cmd/aileron/auth_test.go
@@ -303,6 +303,7 @@ func (f fakeAuthAgent) ConfigureMCP(string, map[string]string, string, launch.Mo
 	return nil, nil, nil
 }
 func (f fakeAuthAgent) AuthSpec() launch.AuthSpec { return f.spec }
+func (f fakeAuthAgent) SkillsPath() string        { return "" }
 
 // TestRunAuth_BindingMissingCapture covers the defensive guard that
 // rejects an agent whose oauth FileBinding declares no Capture

--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -188,6 +188,8 @@ func run(args []string, registry *launch.Registry, stdout, stderr io.Writer) int
 		return runConnector(args[1:], os.Stdin, stdout, stderr)
 	case "action":
 		return runAction(args[1:], os.Stdin, stdout, stderr)
+	case "skill":
+		return runSkill(args[1:], stdout, stderr)
 	case "keyring":
 		return runKeyring(args[1:], stdout, stderr)
 	case "hub":
@@ -240,6 +242,8 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron connector check            Check installed connectors for newer versions")
 	fmt.Fprintln(w, "  aileron action add <FQN>           Install an action template from its FQN")
 	fmt.Fprintln(w, "  aileron action run <NAME>          Invoke an installed action directly")
+	fmt.Fprintln(w, "  aileron skill install <source>     Install a skill (local path or git URL) into ~/.aileron/skills")
+	fmt.Fprintln(w, "  aileron skill list                 List installed skills (mounted read-only at launch)")
 	fmt.Fprintln(w, "  aileron keyring trust <auth> <key> Authorize a publisher's signing key for installs")
 	fmt.Fprintln(w, "  aileron keyring list               List trusted publishers and key fingerprints")
 	fmt.Fprintln(w, "  aileron keyring revoke <auth>      Remove a publisher's keys from the trust list")

--- a/cmd/aileron/skill.go
+++ b/cmd/aileron/skill.go
@@ -1,0 +1,141 @@
+package main
+
+import (
+	"context"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/resolver"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+const skillUsage = `usage:
+  aileron skill install <source>   Install a skill from a local path or git URL into ~/.aileron/skills
+  aileron skill list               List installed skills`
+
+// skillStoreDir is a seam so tests can point the CLI at a temp store
+// instead of the user's real ~/.aileron/skills.
+var skillStoreDir = ""
+
+// newSkillFetcher builds the resolver fetcher that reaches the daemon's
+// GET /v1/actions. It is a package-level seam so tests can inject a fake
+// without a live daemon. A nil return means "no daemon reachable"; the
+// installer then degrades (records refs unsatisfied) rather than failing.
+var newSkillFetcher = func() (resolver.Fetcher, error) {
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return nil, err
+	}
+	return resolver.HTTPFetcher{
+		BaseURL:   base,
+		Client:    &http.Client{Timeout: actionsHTTPClient.Timeout},
+		Authorize: setDaemonAuthorization,
+	}, nil
+}
+
+func runSkill(args []string, stdout, stderr io.Writer) int {
+	if len(args) == 0 {
+		fmt.Fprintln(stderr, skillUsage)
+		return 1
+	}
+	switch args[0] {
+	case "install":
+		return runSkillInstall(args[1:], stdout, stderr)
+	case "list":
+		return runSkillList(args[1:], stdout, stderr)
+	default:
+		fmt.Fprintf(stderr, "unknown skill command: %q\n", args[0])
+		fmt.Fprintln(stderr, skillUsage)
+		return 1
+	}
+}
+
+func runSkillInstall(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("skill install", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 1 {
+		fmt.Fprintln(stderr, skillUsage)
+		return 1
+	}
+	src := flags.Arg(0)
+
+	s := store.New(skillStoreDir)
+
+	// Parse first (cheaply, by installing) — but we only want to consult the
+	// daemon for skills that declare requires. The store's Install handles
+	// the short-circuit: it parses, and reaches the fetcher ONLY when the
+	// skill declares action refs. We pass a lazily-resolved fetcher so an
+	// instruction-only install never even constructs a daemon client.
+	opts := store.InstallOptions{Fetcher: lazyFetcher{stderr: stderr}}
+
+	res, err := s.Install(context.Background(), src, opts)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	if res.Degraded() {
+		fmt.Fprintf(stderr, "warning: skill %q installed, but %d action requirement(s) are not satisfiable here:\n",
+			res.Name, len(res.Unsatisfied))
+		for _, ref := range res.Unsatisfied {
+			fmt.Fprintf(stderr, "  - %s\n", ref)
+		}
+		fmt.Fprintln(stderr, "  Install the connectors/actions these refs name, or launch where they are available.")
+	}
+
+	fmt.Fprintf(stdout, "Installed skill %q to %s\n", res.Name, res.Dir)
+	return 0
+}
+
+func runSkillList(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("skill list", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+
+	s := store.New(skillStoreDir)
+	names, err := s.List()
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+	if len(names) == 0 {
+		fmt.Fprintln(stdout, "No skills installed.")
+		fmt.Fprintln(stdout, "Run `aileron skill install <source>` to install one.")
+		return 0
+	}
+	for _, n := range names {
+		fmt.Fprintln(stdout, n)
+	}
+	return 0
+}
+
+// lazyFetcher defers daemon-client construction until the store actually
+// needs to resolve requires. The store calls FetchActions only for skills
+// that declare action refs, so an instruction-only install never reaches
+// here and never touches the daemon (P2 isolation). If the daemon cannot
+// be reached when resolution IS needed, it warns and returns no actions so
+// the install degrades (warn) rather than failing.
+type lazyFetcher struct {
+	stderr io.Writer
+}
+
+func (l lazyFetcher) FetchActions(ctx context.Context) ([]resolver.Action, error) {
+	f, err := newSkillFetcher()
+	if err != nil {
+		fmt.Fprintf(l.stderr, "warning: could not reach the daemon to resolve action requirements: %v\n", err)
+		return nil, nil
+	}
+	actions, err := f.FetchActions(ctx)
+	if err != nil {
+		fmt.Fprintf(l.stderr, "warning: could not list actions to resolve requirements: %v\n", err)
+		return nil, nil
+	}
+	return actions, nil
+}

--- a/cmd/aileron/skill_test.go
+++ b/cmd/aileron/skill_test.go
@@ -1,0 +1,311 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/resolver"
+)
+
+// repoRootForTest walks up to the directory containing go.work so tests can
+// read the committed worked example as a known-valid credentialed skill.
+func repoRootForTest(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.work from %s", filepath.Dir(file))
+		}
+		dir = parent
+	}
+}
+
+const instructionOnlySkillMd = `---
+name: rubber-duck
+description: Instruction-only skill.
+---
+
+# Rubber Duck
+Explain it out loud.
+`
+
+// withTempStore points the CLI at a temp skill store for the test.
+func withTempStore(t *testing.T) string {
+	t.Helper()
+	dir := t.TempDir()
+	orig := skillStoreDir
+	skillStoreDir = dir
+	t.Cleanup(func() { skillStoreDir = orig })
+	return dir
+}
+
+// writeSkillFile materializes a SKILL.md in a temp dir and returns its
+// directory path (a valid local install source).
+func writeSkillFile(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// stubFetcher swaps newSkillFetcher with one returning the given actions
+// (or error), recording whether it was constructed.
+func stubFetcher(t *testing.T, actions []resolver.Action, fetchErr, ctorErr error) *bool {
+	t.Helper()
+	constructed := false
+	orig := newSkillFetcher
+	newSkillFetcher = func() (resolver.Fetcher, error) {
+		constructed = true
+		if ctorErr != nil {
+			return nil, ctorErr
+		}
+		return resolver.FetcherFunc(func(ctx context.Context) ([]resolver.Action, error) {
+			return actions, fetchErr
+		}), nil
+	}
+	t.Cleanup(func() { newSkillFetcher = orig })
+	return &constructed
+}
+
+func exampleSource(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRootForTest(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatalf("read worked example: %v", err)
+	}
+	return writeSkillFile(t, string(raw))
+}
+
+func TestRunSkillInstall_InstructionOnly_Clean(t *testing.T) {
+	store := withTempStore(t)
+	src := writeSkillFile(t, instructionOnlySkillMd)
+	// A fetcher constructor that fails if touched proves the daemon client
+	// is never even constructed for an instruction-only install.
+	constructed := stubFetcher(t, nil, nil, errors.New("must not be reached"))
+
+	var stdout, stderr bytes.Buffer
+	if code := runSkillInstall([]string{src}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if *constructed {
+		t.Error("daemon fetcher must not be constructed for instruction-only install")
+	}
+	if stderr.Len() != 0 {
+		t.Errorf("instruction-only install must be silent on stderr, got: %s", stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Installed skill \"rubber-duck\"") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+	if _, err := os.Stat(filepath.Join(store, "rubber-duck", "SKILL.md")); err != nil {
+		t.Errorf("skill not written: %v", err)
+	}
+}
+
+func TestRunSkillInstall_CredentialedSatisfiable_NoWarning(t *testing.T) {
+	withTempStore(t)
+	src := exampleSource(t)
+	stubFetcher(t, []resolver.Action{
+		{Name: "query-series", Requires: resolver.Requires{Connectors: []resolver.Connector{{Name: "github://aileron/metrics"}}}},
+		{Name: "create-issue", Requires: resolver.Requires{Connectors: []resolver.Connector{{Name: "github://aileron/tracker"}}}},
+	}, nil, nil)
+
+	var stdout, stderr bytes.Buffer
+	if code := runSkillInstall([]string{src}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	if strings.Contains(stderr.String(), "warning") {
+		t.Errorf("satisfiable install must not warn, stderr=%s", stderr.String())
+	}
+}
+
+func TestRunSkillInstall_Unsatisfiable_WarnsButExits0(t *testing.T) {
+	withTempStore(t)
+	src := exampleSource(t)
+	// No actions installed: both refs are unsatisfiable.
+	stubFetcher(t, nil, nil, nil)
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillInstall([]string{src}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("unsatisfiable install must still exit 0, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "not satisfiable") {
+		t.Errorf("expected a degrade warning on stderr, got: %s", stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "aileron:metrics.query_series") {
+		t.Errorf("warning should name the unsatisfied ref, got: %s", stderr.String())
+	}
+}
+
+func TestRunSkillInstall_DaemonDownInstructionOnly_Clean(t *testing.T) {
+	withTempStore(t)
+	src := writeSkillFile(t, instructionOnlySkillMd)
+	// Daemon-down via a constructor error — must never be reached.
+	stubFetcher(t, nil, nil, errors.New("daemon down"))
+
+	var stdout, stderr bytes.Buffer
+	if code := runSkillInstall([]string{src}, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if strings.Contains(stderr.String(), "daemon") {
+		t.Errorf("instruction-only install must not surface daemon connectivity, got: %s", stderr.String())
+	}
+}
+
+func TestRunSkillInstall_DaemonDownCredentialed_DegradesNotFails(t *testing.T) {
+	withTempStore(t)
+	src := exampleSource(t)
+	// Daemon unreachable when resolution IS needed: degrade (warn), exit 0.
+	stubFetcher(t, nil, nil, errors.New("connection refused"))
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillInstall([]string{src}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("daemon-down credentialed install must degrade not fail, got %d", code)
+	}
+	if !strings.Contains(stderr.String(), "could not reach the daemon") {
+		t.Errorf("expected a daemon-unreachable warning, got: %s", stderr.String())
+	}
+}
+
+func TestRunSkillList(t *testing.T) {
+	store := withTempStore(t)
+	// Pre-populate two skills.
+	for _, name := range []string{"beta", "alpha"} {
+		dir := filepath.Join(store, name)
+		if err := os.MkdirAll(dir, 0o755); err != nil {
+			t.Fatal(err)
+		}
+		if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte("---\nname: "+name+"\n---\nx\n"), 0o644); err != nil {
+			t.Fatal(err)
+		}
+	}
+	var stdout, stderr bytes.Buffer
+	if code := runSkillList(nil, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	// Sorted output.
+	if got := stdout.String(); got != "alpha\nbeta\n" {
+		t.Errorf("list output = %q", got)
+	}
+}
+
+func TestRunSkillList_Empty(t *testing.T) {
+	withTempStore(t)
+	var stdout, stderr bytes.Buffer
+	if code := runSkillList(nil, &stdout, &stderr); code != 0 {
+		t.Fatalf("exit = %d", code)
+	}
+	if !strings.Contains(stdout.String(), "No skills installed") {
+		t.Errorf("empty list = %q", stdout.String())
+	}
+}
+
+func TestRunSkill_UnknownSubcommand(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runSkill([]string{"frobnicate"}, &stdout, &stderr); code != 1 {
+		t.Errorf("unknown subcommand exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "unknown skill command") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunSkillInstall_RequiresExactlyOneSource(t *testing.T) {
+	withTempStore(t)
+	var stdout, stderr bytes.Buffer
+	// No source argument.
+	if code := runSkillInstall(nil, &stdout, &stderr); code != 1 {
+		t.Errorf("no source exit = %d, want 1", code)
+	}
+	// Two sources.
+	if code := runSkillInstall([]string{"a", "b"}, &stdout, &stderr); code != 1 {
+		t.Errorf("two sources exit = %d, want 1", code)
+	}
+}
+
+func TestRunSkillInstall_BadFlag(t *testing.T) {
+	withTempStore(t)
+	var stdout, stderr bytes.Buffer
+	if code := runSkillInstall([]string{"--nope"}, &stdout, &stderr); code != 1 {
+		t.Errorf("bad flag exit = %d, want 1", code)
+	}
+}
+
+func TestRunSkillInstall_BadSourceError(t *testing.T) {
+	withTempStore(t)
+	stubFetcher(t, nil, nil, nil)
+	var stdout, stderr bytes.Buffer
+	// A nonexistent local path that is not a git URL classifies as a slug,
+	// which is not wired, so install surfaces an error and exits 1.
+	if code := runSkillInstall([]string{"definitely/not/installed"}, &stdout, &stderr); code != 1 {
+		t.Errorf("unresolvable source exit = %d, want 1", code)
+	}
+	if !strings.Contains(stderr.String(), "error:") {
+		t.Errorf("expected an error on stderr, got: %s", stderr.String())
+	}
+}
+
+func TestNewSkillFetcher_DaemonUnreachableDegrades(t *testing.T) {
+	// Exercise the real newSkillFetcher (not the stub) so the lazyFetcher
+	// ctor + daemon-unreachable degrade path is covered. Point the daemon
+	// base URL at a dead address; resolution must warn, not fail.
+	withTempStore(t)
+	t.Setenv("AILERON_API_URL", "http://127.0.0.1:1/v1")
+	src := exampleSource(t)
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillInstall([]string{src}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("daemon-unreachable credentialed install must degrade not fail, got %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stderr.String(), "could not") {
+		t.Errorf("expected a daemon-unreachable warning, got: %s", stderr.String())
+	}
+}
+
+func TestRunSkill_NoArgs(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runSkill(nil, &stdout, &stderr); code != 1 {
+		t.Errorf("no-args exit = %d, want 1", code)
+	}
+}
+
+func TestRun_DispatchesSkill(t *testing.T) {
+	withTempStore(t)
+	var stdout, stderr bytes.Buffer
+	// `aileron skill list` on an empty store routes through run() dispatch
+	// and exits 0.
+	if code := run([]string{"skill", "list"}, newTestRegistry(), &stdout, &stderr); code != 0 {
+		t.Fatalf("run skill list exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "No skills installed") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRun_HelpMentionsSkill(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := run([]string{"help"}, newTestRegistry(), &stdout, &stderr); code != 0 {
+		t.Fatalf("help exit = %d", code)
+	}
+	if !strings.Contains(stdout.String(), "aileron skill install") {
+		t.Errorf("help must mention skill install, got: %s", stdout.String())
+	}
+}

--- a/docs/src/content/docs/guides/installing-a-skill.md
+++ b/docs/src/content/docs/guides/installing-a-skill.md
@@ -1,0 +1,64 @@
+---
+title: "Installing a Skill"
+description: "Install a SKILL.md-format skill from a local path or git URL into the canonical store, see its action requirements resolve, and have it projected into every agent you launch."
+---
+
+This guide is for users adding skills to their local Aileron install. It covers `aileron skill install` for a local path or a git URL, `aileron skill list` to see what is installed, how a skill's `requires:` action references are resolved at install time, and how an installed skill becomes visible to every agent you launch through Aileron. By the end you will have one or more skills installed under `~/.aileron/skills/` and understand the install-once, launch-anywhere projection.
+
+A skill is a [SKILL.md-format](https://agentskills.io) document: YAML frontmatter plus a Markdown body. The surrounding skill keys (`name`, `description`, `license`, and so on) follow the agentskills.io format. Aileron adds one optional, namespaced `aileron` frontmatter block that declares the skill's action requirements and trust contract. A skill with no `aileron` block is an instruction-only skill and installs cleanly with nothing to resolve.
+
+## What gets installed
+
+`aileron skill install <source>` fetches the skill, parses its SKILL.md, resolves any declared action requirements against your running daemon, and writes the skill into `~/.aileron/skills/<name>/`. The store is the single host-side writer. An installed skill is read-only after install; editing is an explicit future operation.
+
+The install never touches credential values. A skill's trust contract declares the credential kind and placement only. The resolver matches action references against the actions you already have installed by name; the credential itself is injected at the network boundary at run time, never handed to skill code.
+
+## Installing from a local path
+
+```sh
+aileron skill install ./my-skills/weekly-digest
+```
+
+The source may point at a directory that contains a `SKILL.md`, or directly at a `SKILL.md` file. The CLI parses it, resolves its requirements, copies the whole skill folder (SKILL.md plus any reference files) into the store, and prints where it landed:
+
+```
+Installed skill "weekly-metrics-digest" to /Users/you/.aileron/skills/weekly-metrics-digest
+```
+
+## Installing from a git URL
+
+```sh
+aileron skill install https://github.com/acme/weekly-digest.git
+```
+
+Aileron shallow-clones the repository, reads the `SKILL.md` at its root, and installs it the same way as a local path.
+
+> Installing by an [agentskills.io](https://agentskills.io) registry slug is not wired yet. Use a local path or a git URL for now.
+
+## Action requirements and graceful degrade
+
+When a skill declares `requires:` action references (for example `aileron:metrics.query_series`), the installer asks your running daemon which actions are installed and checks each reference. A reference is satisfied when an installed action matches both the connector and the action name.
+
+Install is degrade-not-block. If a reference does not resolve, the install still succeeds and prints a warning naming the unsatisfied references:
+
+```
+warning: skill "weekly-metrics-digest" installed, but 1 action requirement(s) are not satisfiable here:
+  - aileron:metrics.query_series
+  Install the connectors/actions these refs name, or launch where they are available.
+```
+
+An instruction-only skill (no `aileron` block) skips requirement resolution entirely, so it installs cleanly and silently even when the daemon is not running.
+
+## Listing installed skills
+
+```sh
+aileron skill list
+```
+
+prints the installed skill names, one per line. When the store is empty it tells you so and points at `aileron skill install`.
+
+## Launch-anywhere projection
+
+You install a skill once. At `aileron launch <agent>` in the sandbox, the launcher bind-mounts the canonical skill store read-only at the agent's skills path (for example `/home/agent/.claude/skills` for Claude Code), so the skill is visible to the agent without copying it per agent. The agent's MCP configuration already points at the Aileron MCP server, so a skill's `requires:` action references resolve through Aileron and stay gated by your approval policy.
+
+Per-agent path differences are absorbed by the launcher, not by rewriting the skill. The mount is read-only: editing an installed skill is an explicit operation, not a side effect of launch.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -71,6 +71,7 @@ export const navigation: NavItem[] = [
       { label: 'Discovering Connectors', href: '/guides/discovering-connectors/' },
       { label: 'Installing a Connector', href: '/guides/installing-a-connector/' },
       { label: 'Installing an Action', href: '/guides/installing-an-action/' },
+      { label: 'Installing a Skill', href: '/guides/installing-a-skill/' },
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },
       { label: 'Setting up BlueBubbles for Aileron', href: '/guides/setting-up-bluebubbles/' },
       { label: 'Authoring an Action', href: '/guides/authoring-an-action/' },

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -1,0 +1,599 @@
+{
+  "$schema": "https://json-schema.org/draft/2020-12/schema",
+  "$id": "https://withaileron.ai/schema/flight-plan-manifest.schema.json",
+  "title": "Aileron Flight Plan Manifest",
+  "description": "JSON Schema for the Aileron-specific block carried in a SKILL.md frontmatter. This block extends the agentskills.io SKILL.md format. It is lossless if stripped: a host without Aileron reads a valid skill and treats this block as inert. Authoritative model: ADR-0027 (Flight Plan = Sealed Installable Skill). This schema validates the `aileron` top-level block only. The skill keys it sits beside (name, description, and so on) are governed by the agentskills.io format and are not constrained here.",
+  "type": "object",
+  "properties": {
+    "aileron": {
+      "$ref": "#/$defs/aileronBlock"
+    }
+  },
+  "$comment": "The `aileron` block is optional at this top level so that a stripped manifest (the block removed) still validates. This encodes the lossless-if-stripped guarantee: the Aileron block is purely additive. An unsatisfied `requires:` is a missing-requirement signal resolved by the runtime, never a schema parse failure.",
+  "$defs": {
+    "aileronBlock": {
+      "type": "object",
+      "description": "The single namespaced top-level key that holds every Aileron-specific field. Namespacing under one key keeps the extension lossless if stripped.",
+      "additionalProperties": false,
+      "required": ["requires", "inputs", "outputs"],
+      "properties": {
+        "schemaVersion": {
+          "type": "string",
+          "description": "The manifest schema version. Optional. When present, identifies the Aileron block contract this manifest was authored against.",
+          "const": "aileron.flightplan.v1"
+        },
+        "requires": {
+          "$ref": "#/$defs/requires"
+        },
+        "inputs": {
+          "type": "array",
+          "description": "Declared inputs (REQUIRED). Every input the Flight Plan depends on is declared here, each with a resolution rule. A value that varies by use case (for example a time window) is a declared input rather than a constant baked into the composition, so one composition serves many operators. See ADR-0027 inputs/resolution and the determinism correction in #1523.",
+          "items": { "$ref": "#/$defs/input" }
+        },
+        "outputs": {
+          "type": "array",
+          "description": "Declared outputs (REQUIRED). The outputs contract names each artifact, its mimeType, its encoding, and its publish target. This is the declared INTERFACE the runtime materializes and distribution publishes. The audit references artifacts by name. The outputs contract is distinct from the file-map transport. See #1519.",
+          "items": { "$ref": "#/$defs/output" }
+        },
+        "steps": {
+          "type": "array",
+          "$comment": "OPTIONAL. `steps` is the deterministic no-LLM composition (the step graph). It is optional so a manifest without a composition still validates and stays lossless-if-stripped: the whole `aileron` block remains removable, and within the block a manifest that only declares requires/inputs/outputs is still complete. When present, `steps` wires declared actions and deterministic transforms into a directed acyclic graph. The single ADR-0027-permitted non-deterministic seam is the `llm-seam` kind; no other kind can reach an LLM, which makes the no-LLM guarantee structurally checkable because `kind` is a closed enum. Cross-step references (a binding to a prior step's output) and acyclicity are graph properties a JSON Schema cannot express; the prose states them as invariants, the freeze/lint step (#1509) checks them, and the runtime (#1511) enforces them.",
+          "description": "The deterministic step graph (OPTIONAL). Wires declared actions and deterministic transforms into a directed acyclic graph. Bindings reference resolved inputs and prior step outputs by name, never by value. The only non-deterministic seam is the marked `llm-seam` kind.",
+          "items": { "$ref": "#/$defs/step" }
+        },
+        "lock": {
+          "$ref": "#/$defs/lock"
+        }
+      }
+    },
+    "requires": {
+      "type": "object",
+      "description": "Dependency declaration. Lists both the actions the Flight Plan calls and the execution-environment dependencies it runs in. An unsatisfied entry is a missing-requirement signal the runtime surfaces, never a parse failure.",
+      "additionalProperties": false,
+      "required": ["actions"],
+      "properties": {
+        "actions": {
+          "type": "array",
+          "description": "The actions the Flight Plan calls. Each entry attaches to the action model of ADR-0003 and carries a per-action trust contract.",
+          "minItems": 1,
+          "items": { "$ref": "#/$defs/actionRequirement" }
+        },
+        "executionEnvironment": {
+          "$ref": "#/$defs/executionEnvironment"
+        }
+      }
+    },
+    "actionRequirement": {
+      "type": "object",
+      "description": "One required action plus its per-action trust contract. The trust contract is the #925 field set, absorbed here.",
+      "additionalProperties": false,
+      "required": ["ref", "trustContract"],
+      "properties": {
+        "ref": {
+          "type": "string",
+          "description": "The action reference in the form aileron:<connector>.<action> (for example aileron:metrics.query_series).",
+          "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+        },
+        "trustContract": { "$ref": "#/$defs/trustContract" }
+      }
+    },
+    "executionEnvironment": {
+      "type": "object",
+      "description": "The execution-environment dependency. Exactly one of rung-1 (a pinned prebuilt image) or rung-2 (composed capability units on the Aileron base) is declared per ADR-0027 execution rungs. Rung-3 per-step sibling-image dispatch is a reserved, build-deferred slot.",
+      "additionalProperties": false,
+      "oneOf": [
+        { "required": ["rung1Image"], "not": { "required": ["rung2CapabilityUnits"] } },
+        { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } }
+      ],
+      "properties": {
+        "rung1Image": {
+          "type": "object",
+          "description": "Rung one. The skill names a whole prebuilt image and freeze resolves it to a digest. The operator owns the image.",
+          "additionalProperties": false,
+          "required": ["ref"],
+          "properties": {
+            "ref": {
+              "type": "string",
+              "description": "An OCI image reference. Pre-freeze this may be a tag (for example registry.example.com/runner:1.4). Freeze resolves it to an image@sha256: digest pin recorded in the lock section.",
+              "minLength": 1
+            }
+          }
+        },
+        "rung2CapabilityUnits": {
+          "type": "object",
+          "description": "Rung two. The skill declares capability units to compose onto a generic Aileron-provided agent-free minimal base image. Freeze composes the operator-owned capability-unit devcontainer Features and pins the result. The capability-unit shape is ADR-0026.",
+          "additionalProperties": false,
+          "required": ["features"],
+          "properties": {
+            "features": {
+              "type": "array",
+              "description": "The capability-unit devcontainer Feature references composed onto the base image.",
+              "minItems": 1,
+              "items": {
+                "type": "string",
+                "description": "A devcontainer Feature reference for a capability unit (ADR-0026).",
+                "minLength": 1
+              }
+            }
+          }
+        },
+        "rung3PerStepImages": {
+          "$comment": "RESERVED, BUILD-DEFERRED. Rung three is per-step sealed sibling-image dispatch with mount and run-and-collect I/O. ADR-0027 defines it as a manifest slot only so a later build can fill it without a format change. It is intentionally typed loosely here and MUST NOT be relied on by v1 tooling.",
+          "type": "object",
+          "description": "RESERVED and build-deferred. Per-step sibling-image dispatch (ADR-0027 rung three). Designed as a manifest slot only; not implemented in v1. Do not author this field expecting runtime support."
+        }
+      }
+    },
+    "trustContract": {
+      "type": "object",
+      "description": "The per-action trust contract. Records the credential kind and placement, OAuth detail where applicable, the expected network reach, the operation effect, idempotency, redaction, a verification probe, and the audit-record structure. Freeze attaches this contract and the detached signature is the human attestation that it is correct (ADR-0027). No field in this contract may carry a credential value; the contract declares credential kind and placement only (ADR-0005, ADR-0019).",
+      "additionalProperties": false,
+      "required": ["credential", "hosts", "effect", "idempotency", "audit"],
+      "allOf": [
+        {
+          "$comment": "An oauth2 credential MUST declare its oauth block.",
+          "if": { "properties": { "credential": { "properties": { "kind": { "const": "oauth2" } } } } },
+          "then": { "required": ["oauth"] }
+        }
+      ],
+      "properties": {
+        "credential": { "$ref": "#/$defs/credential" },
+        "oauth": { "$ref": "#/$defs/oauth" },
+        "hosts": {
+          "type": "array",
+          "description": "The expected upstream hosts the action reaches. The access-scope declaration IS the security boundary: the runtime grants nothing undeclared. Each entry is a host, with an optional port, and carries no URL scheme or path. Reuses the connector-spec `hosts` vocabulary.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "description": "An allowed upstream host with an optional port, no scheme, no path (for example api.example.com or api.example.com:443).",
+            "pattern": "^[a-zA-Z0-9.-]+(?::[0-9]+)?$"
+          }
+        },
+        "paths": {
+          "type": "array",
+          "description": "The expected request paths the action reaches on the declared hosts. Part of the access-scope declaration. The runtime grants nothing undeclared.",
+          "items": {
+            "type": "string",
+            "description": "A request path, optionally a prefix (for example /v2/metrics or /v2/metrics/*).",
+            "minLength": 1
+          }
+        },
+        "effect": {
+          "type": "string",
+          "description": "The operation effect, aligned to ADR-0003. Drives default approval routing through the out-of-band channel of ADR-0009. `read` observes state; `write` creates or mutates state; `delete` removes state; `spend` commits money; `external-send` sends a message or artifact to a third party.",
+          "enum": ["read", "write", "delete", "spend", "external-send"]
+        },
+        "idempotency": { "$ref": "#/$defs/idempotency" },
+        "redaction": {
+          "type": "array",
+          "description": "Redaction rules applied to the operation's response fields before they reach the agent or author. Each rule names a field path and how it is redacted.",
+          "items": { "$ref": "#/$defs/redactionRule" }
+        },
+        "verification": { "$ref": "#/$defs/verification" },
+        "audit": { "$ref": "#/$defs/auditStructure" }
+      }
+    },
+    "credential": {
+      "type": "object",
+      "description": "The credential KIND and PLACEMENT this action uses. It never holds a credential VALUE. The runtime mediates credential use at the data-plane proxy boundary (ADR-0019) so the composed code never holds a raw credential (ADR-0005).",
+      "additionalProperties": false,
+      "required": ["kind"],
+      "properties": {
+        "kind": {
+          "type": "string",
+          "description": "The credential kind. `none` for an unauthenticated call; `api-key` for a static key or token; `oauth2` for an OAuth 2 access token (declare the `oauth` block alongside); `aws-sigv4` for an AWS request-signing credential.",
+          "enum": ["none", "api-key", "oauth2", "aws-sigv4"]
+        },
+        "placement": {
+          "type": "string",
+          "description": "Where the credential is placed on the wire. Maps 1:1 to the closed ADR-0019 injection-scheme set. `header` -> a bearer or templated header (ADR-0019 `bearer` or `header-template`); `query` -> ADR-0019 `query-param`; `body` -> the credential is carried in the request body; `cookie` -> the credential rides as a cookie; `signing` -> AWS SigV4, mapping to ADR-0019 `sigv4-resign` (sealed by #1501); `session` -> the cookie/session-token wire form for a session-authenticated upstream. The exact header or wire shape is per service, not per placement alone.",
+          "enum": ["header", "query", "cookie", "body", "signing", "session"]
+        },
+        "identityLabel": {
+          "type": "string",
+          "description": "A subject or account identity label for multi-tenant binding (for example the workspace or account the credential authenticates as). A non-secret label, never a credential value.",
+          "minLength": 1
+        }
+      },
+      "allOf": [
+        {
+          "$comment": "A placement is required for every credential kind except `none`.",
+          "if": { "properties": { "kind": { "not": { "const": "none" } } } },
+          "then": { "required": ["placement"] }
+        },
+        {
+          "$comment": "An oauth2 credential is placed in a header, never via signing/query/cookie/body/session.",
+          "if": { "properties": { "kind": { "const": "oauth2" } } },
+          "then": { "properties": { "placement": { "const": "header" } } }
+        },
+        {
+          "$comment": "An aws-sigv4 credential is always placed via request signing.",
+          "if": { "properties": { "kind": { "const": "aws-sigv4" } } },
+          "then": { "properties": { "placement": { "const": "signing" } } }
+        }
+      ]
+    },
+    "oauth": {
+      "type": "object",
+      "description": "OAuth detail for an oauth2 credential. Records the scopes, endpoints, and refresh behavior. Declared alongside a credential of kind oauth2. Holds no token value.",
+      "additionalProperties": false,
+      "properties": {
+        "scopes": {
+          "type": "array",
+          "description": "The OAuth scopes the action requires.",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "endpoints": {
+          "type": "object",
+          "description": "The OAuth endpoints. Non-secret URLs.",
+          "additionalProperties": false,
+          "properties": {
+            "authorization": { "type": "string", "description": "The authorization endpoint URL.", "format": "uri" },
+            "token": { "type": "string", "description": "The token endpoint URL.", "format": "uri" }
+          }
+        },
+        "refresh": {
+          "type": "string",
+          "description": "The refresh behavior. `refresh-token` uses a stored refresh token; `none` requires re-auth on expiry.",
+          "enum": ["refresh-token", "none"]
+        }
+      }
+    },
+    "idempotency": {
+      "type": "object",
+      "description": "Idempotency declaration, aligned to ADR-0003. Records whether the operation is safe to retry and whether it supports an idempotency key.",
+      "additionalProperties": false,
+      "required": ["safeToRetry"],
+      "properties": {
+        "safeToRetry": {
+          "type": "boolean",
+          "description": "True when re-running the operation with the same inputs produces no additional effect."
+        },
+        "idempotencyKey": {
+          "type": "boolean",
+          "description": "True when the operation accepts a client-supplied idempotency key that the upstream uses to deduplicate retried writes. Defaults to false.",
+          "default": false
+        }
+      }
+    },
+    "redactionRule": {
+      "type": "object",
+      "description": "One redaction rule. Names a response field and how it is redacted before reaching the agent or author.",
+      "additionalProperties": false,
+      "required": ["field", "rule"],
+      "properties": {
+        "field": {
+          "type": "string",
+          "description": "The response field path to redact (for example data[].email).",
+          "minLength": 1
+        },
+        "rule": {
+          "type": "string",
+          "description": "How the field is redacted. `drop` removes it; `mask` replaces its value with a fixed mask; `hash` replaces it with a stable hash.",
+          "enum": ["drop", "mask", "hash"]
+        }
+      }
+    },
+    "verification": {
+      "type": "object",
+      "description": "A verification probe. A no-op or read-only call the runtime can issue to confirm the credential still works for this action.",
+      "additionalProperties": false,
+      "required": ["method", "path"],
+      "properties": {
+        "method": {
+          "type": "string",
+          "description": "The HTTP method of the probe. Read-only methods only.",
+          "enum": ["GET", "HEAD"]
+        },
+        "path": {
+          "type": "string",
+          "description": "The probe request path on one of the declared hosts.",
+          "minLength": 1
+        }
+      }
+    },
+    "auditStructure": {
+      "type": "object",
+      "description": "The structure of the audit record this operation emits. The audit records resolved inputs to outputs: scalars by value, data reads by their resolved binding (parameters, query, result or snapshot identifier, summary), never the full dataset inline (ADR-0027 audit boundary, #1523). The sink is customer-owned. The fields below enumerate the record's shape; this block declares which fields the operation's audit record carries.",
+      "additionalProperties": false,
+      "required": ["fields"],
+      "properties": {
+        "fields": {
+          "type": "array",
+          "description": "The audit-record fields this operation emits. Closed enum of the record shape. `connector-hash` the connector content hash; `action-manifest-version` the resolved action version; `credential-binding` the credential binding reference used (never the credential bytes); `identity-label` the subject/account identity; `approved-input` the resolved input that was approved; `approval-decision` the approval outcome; `network-target` the upstream host and path reached; `operation-effect` the recorded effect; `request-summary` a redacted request summary; `response-summary` a redacted response summary; `result` a result or snapshot identifier with a summary.",
+          "minItems": 1,
+          "items": {
+            "type": "string",
+            "enum": [
+              "connector-hash",
+              "action-manifest-version",
+              "credential-binding",
+              "identity-label",
+              "approved-input",
+              "approval-decision",
+              "network-target",
+              "operation-effect",
+              "request-summary",
+              "response-summary",
+              "result"
+            ]
+          }
+        },
+        "sink": {
+          "type": "string",
+          "description": "A reference to the customer-owned audit sink (for example a log stream or table name). A non-secret reference, never credentials for the sink.",
+          "minLength": 1
+        }
+      }
+    },
+    "input": {
+      "type": "object",
+      "description": "One declared input with its resolution rule. Inputs resolve once, at the launch boundary, into a concrete resolved-input set (ADR-0027, #1523).",
+      "additionalProperties": false,
+      "required": ["name", "type", "resolution"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The input name, unique within the manifest.",
+          "pattern": "^[a-zA-Z0-9_-]+$"
+        },
+        "type": {
+          "type": "string",
+          "description": "The input value type.",
+          "enum": ["string", "number", "boolean", "timestamp", "object", "array"]
+        },
+        "description": {
+          "type": "string",
+          "description": "Human-readable semantics of the input."
+        },
+        "resolution": { "$ref": "#/$defs/resolution" }
+      }
+    },
+    "resolution": {
+      "type": "object",
+      "description": "An input resolution rule. Exactly one of three rules: `literal` (a value passed at launch), `dynamic` (a launch-relative value such as now or today), or `source` (a read from a live source). Discriminated by `rule`.",
+      "required": ["rule"],
+      "oneOf": [
+        {
+          "additionalProperties": false,
+          "required": ["rule"],
+          "properties": {
+            "rule": { "const": "literal", "description": "A literal value passed at launch." },
+            "default": {
+              "description": "An optional default value applied when no value is passed at launch."
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["rule", "value"],
+          "properties": {
+            "rule": { "const": "dynamic", "description": "A launch-relative dynamic value resolved once at launch." },
+            "value": {
+              "type": "string",
+              "description": "The dynamic value to resolve. `now` resolves to the launch timestamp; `today` resolves to the launch date.",
+              "enum": ["now", "today"]
+            }
+          }
+        },
+        {
+          "additionalProperties": false,
+          "required": ["rule", "source"],
+          "properties": {
+            "rule": { "const": "source", "description": "A read from a live source resolved once at launch." },
+            "source": {
+              "type": "object",
+              "description": "The live source to read. References a declared action and records the read by its resolved binding in the audit, never the full dataset inline.",
+              "additionalProperties": false,
+              "required": ["actionRef"],
+              "properties": {
+                "actionRef": {
+                  "type": "string",
+                  "description": "The action reference whose result resolves this input, in the form aileron:<connector>.<action>.",
+                  "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+                },
+                "select": {
+                  "type": "string",
+                  "description": "An optional selector identifying which part of the source result resolves this input."
+                }
+              }
+            }
+          }
+        }
+      ]
+    },
+    "output": {
+      "type": "object",
+      "description": "One declared output artifact. Names the artifact, its mimeType, its encoding, and its publish target. This is the declared INTERFACE, distinct from the file-map transport. The transport is a typed JSON file-map of {path, mimeType, encoding, content} entries the runtime materializes into files (#1519); this outputs block is the contract that names what those files are.",
+      "additionalProperties": false,
+      "required": ["name", "mimeType", "encoding", "publish"],
+      "properties": {
+        "name": {
+          "type": "string",
+          "description": "The output artifact name, unique within the manifest. The audit references artifacts by this name.",
+          "pattern": "^[a-zA-Z0-9_.-]+$"
+        },
+        "mimeType": {
+          "type": "string",
+          "description": "The artifact media type (for example text/csv or application/json).",
+          "minLength": 1
+        },
+        "encoding": {
+          "type": "string",
+          "description": "The artifact content encoding. `utf-8` is the v1 implementation. `base64` is RESERVED for binary outputs and is a deferred follow-up blocked on a host-ABI binary-body field; the mount / run-and-collect boundary (#1510) is the escape hatch for large or binary artifacts later. The enum value `base64` is present so the declared INTERFACE is binary-ready, but v1 implements `utf-8` only. Text-only is the v1 IMPLEMENTATION, never the declared INTERFACE.",
+          "enum": ["utf-8", "base64"]
+        },
+        "publish": {
+          "type": "object",
+          "description": "The publish target for this artifact. Where the runtime materializes and distribution publishes it.",
+          "additionalProperties": false,
+          "required": ["target"],
+          "allOf": [
+            {
+              "$comment": "A file publish target MUST name the output path.",
+              "if": { "properties": { "target": { "const": "file" } } },
+              "then": { "required": ["path"] }
+            }
+          ],
+          "properties": {
+            "target": {
+              "type": "string",
+              "description": "The publish target kind. `file` writes the artifact to the run's output file set; `none` retains the artifact in the run record without external publication.",
+              "enum": ["file", "none"]
+            },
+            "path": {
+              "type": "string",
+              "description": "The output file path when target is `file` (for example report.csv)."
+            }
+          }
+        }
+      }
+    },
+    "binding": {
+      "type": "string",
+      "description": "A data-flow binding. A binding is a REFERENCE, never a value: it names where a step reads its data from. `inputs.<name>` references a declared input resolved at the launch boundary (#1523). `steps.<stepId>.<outputName>` references a named output of a prior step. A binding never carries a literal secret; secret material is mediated at the data-plane proxy boundary (ADR-0005, ADR-0019). The closed reference grammar is the structural guarantee that step args are wiring, not embedded values.",
+      "pattern": "^(inputs\\.[a-zA-Z0-9_-]+|steps\\.[a-zA-Z0-9_-]+\\.[a-zA-Z0-9_-]+)$"
+    },
+    "stepOutputs": {
+      "type": "array",
+      "description": "The named results a step produces. Each name is referenced by a later step as `steps.<thisStepId>.<name>` or wired to a declared output artifact by name. Names are unique within the step.",
+      "minItems": 1,
+      "items": {
+        "type": "string",
+        "description": "A named result this step produces.",
+        "pattern": "^[a-zA-Z0-9_-]+$"
+      }
+    },
+    "materializesOutput": {
+      "type": "string",
+      "description": "OPTIONAL. Names a declared `outputs[].name` artifact that this step's result materializes into. This wires a step result to the declared outputs contract, which the runtime materializes through the typed file-map transport {path, mimeType, encoding, content} (#1519). The schema cannot enforce that the value matches a declared output name (cross-array membership); the prose states it as an invariant and the drift-guard asserts it on the example.",
+      "pattern": "^[a-zA-Z0-9_.-]+$"
+    },
+    "step": {
+      "type": "object",
+      "description": "One step in the deterministic step graph. Discriminated by `kind`. The closed `kind` enum is the structural no-LLM guarantee: an `action-call` invokes a declared action, a `transform` runs deterministic no-LLM logic, and the single `llm-seam` is the only kind that reaches an LLM (ADR-0027). Every step kind is a closed object (additionalProperties:false), so no step field may carry a secret; a step binds references, never values.",
+      "required": ["id", "kind"],
+      "oneOf": [
+        { "$ref": "#/$defs/actionCallStep" },
+        { "$ref": "#/$defs/transformStep" },
+        { "$ref": "#/$defs/llmSeamStep" }
+      ]
+    },
+    "actionCallStep": {
+      "type": "object",
+      "description": "A step that invokes a declared action. Its `actionRef` MUST match a `requires.actions[].ref` (cross-array membership a JSON Schema cannot enforce; stated as a prose invariant, checked by #1509 lint, asserted by the drift-guard). Args bind to resolved inputs or prior step outputs by reference, never by value.",
+      "additionalProperties": false,
+      "required": ["id", "kind", "actionRef"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The step id, unique within the step graph. Prior steps reference this step's outputs as `steps.<id>.<outputName>`.",
+          "pattern": "^[a-zA-Z0-9_-]+$"
+        },
+        "kind": {
+          "const": "action-call",
+          "description": "Invokes a declared action."
+        },
+        "actionRef": {
+          "type": "string",
+          "description": "The action this step invokes, in the form aileron:<connector>.<action>. MUST match a declared requires.actions[].ref.",
+          "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+        },
+        "args": {
+          "type": "object",
+          "description": "The action arguments. Each value is a binding REFERENCE, never a literal value or secret. The argument name is per-action; the value is a binding to a resolved input or a prior step output.",
+          "additionalProperties": { "$ref": "#/$defs/binding" }
+        },
+        "outputs": { "$ref": "#/$defs/stepOutputs" },
+        "materializesOutput": { "$ref": "#/$defs/materializesOutput" }
+      }
+    },
+    "transformStep": {
+      "type": "object",
+      "description": "A step that runs deterministic no-LLM logic. It has no host, network, or credential surface: a transform reshapes data already in the graph. The closed `kind` enum and the closed object guarantee a transform cannot reach an LLM or carry a credential. Bindings reference resolved inputs or prior step outputs by name, never by value.",
+      "additionalProperties": false,
+      "required": ["id", "kind", "outputs"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The step id, unique within the step graph.",
+          "pattern": "^[a-zA-Z0-9_-]+$"
+        },
+        "kind": {
+          "const": "transform",
+          "description": "Deterministic no-LLM logic over data already in the graph."
+        },
+        "bindings": {
+          "type": "object",
+          "description": "The named inputs to the transform. Each value is a binding REFERENCE to a resolved input or a prior step output, never a value.",
+          "additionalProperties": { "$ref": "#/$defs/binding" }
+        },
+        "outputs": { "$ref": "#/$defs/stepOutputs" },
+        "materializesOutput": { "$ref": "#/$defs/materializesOutput" }
+      }
+    },
+    "llmSeamStep": {
+      "type": "object",
+      "description": "The single ADR-0027-permitted non-deterministic seam. The `kind: llm-seam` value is the first-class mark #1509 lint checks; by construction no other step kind reaches an LLM, so the no-LLM guarantee is structurally checkable because `kind` is a closed enum and only this one value reaches an LLM. Bindings reference resolved inputs or prior step outputs by name, never by value; the seam holds no credential and binds no secret.",
+      "additionalProperties": false,
+      "required": ["id", "kind", "outputs"],
+      "properties": {
+        "id": {
+          "type": "string",
+          "description": "The step id, unique within the step graph.",
+          "pattern": "^[a-zA-Z0-9_-]+$"
+        },
+        "kind": {
+          "const": "llm-seam",
+          "description": "The single marked non-deterministic seam. The only kind that reaches an LLM."
+        },
+        "bindings": {
+          "type": "object",
+          "description": "The named inputs to the seam. Each value is a binding REFERENCE to a resolved input or a prior step output, never a value.",
+          "additionalProperties": { "$ref": "#/$defs/binding" }
+        },
+        "outputs": { "$ref": "#/$defs/stepOutputs" },
+        "materializesOutput": { "$ref": "#/$defs/materializesOutput" }
+      }
+    },
+    "lock": {
+      "type": "object",
+      "description": "The lock and digest section. Produced by freeze (#1509): pins the resolved image digests and the resolved capability set, and records the manifest content hash plus semver label. ABSENT before freeze; this schema specifies its shape as freeze's target only. When present, every image reference is a content-addressed digest.",
+      "additionalProperties": false,
+      "properties": {
+        "resolvedImages": {
+          "type": "array",
+          "description": "The resolved image digest pins. Each entry pairs the pre-freeze reference with its resolved image@sha256: digest.",
+          "items": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": ["ref", "digest"],
+            "properties": {
+              "ref": { "type": "string", "description": "The pre-freeze image reference.", "minLength": 1 },
+              "digest": {
+                "type": "string",
+                "description": "The resolved content-addressed digest.",
+                "pattern": "^sha256:[a-f0-9]{64}$"
+              }
+            }
+          }
+        },
+        "resolvedCapabilitySet": {
+          "type": "array",
+          "description": "The resolved capability set the freeze pinned.",
+          "items": { "type": "string", "minLength": 1 }
+        },
+        "contentHash": {
+          "type": "string",
+          "description": "The content hash identifying the exact frozen manifest bytes.",
+          "pattern": "^sha256:[a-f0-9]{64}$"
+        },
+        "version": {
+          "type": "string",
+          "description": "The human-facing semver label for this frozen version.",
+          "minLength": 1
+        }
+      }
+    }
+  }
+}

--- a/internal/flightplan/manifest/manifest.go
+++ b/internal/flightplan/manifest/manifest.go
@@ -1,0 +1,161 @@
+// Package manifest parses an installable Aileron skill (a SKILL.md
+// document: YAML frontmatter plus a Markdown body) and validates the
+// Aileron-specific frontmatter block against the normative Flight Plan
+// manifest schema.
+//
+// The agentskills.io SKILL.md format owns the surrounding skill keys
+// (name, description, license, ...). Aileron's additive extension is the
+// single namespaced top-level `aileron` block, validated here. The block
+// is optional: a SKILL.md with no `aileron` block is an instruction-only
+// skill and is perfectly valid (the lossless-if-stripped guarantee, see
+// ADR-0027). A block that is present but schema-invalid is an error.
+//
+// This package never reads or carries credential values. The trust
+// contract declares the credential kind and placement only (ADR-0005,
+// ADR-0019); the resolver matches on names. No secret ever reaches skill
+// code through this parser.
+package manifest
+
+import (
+	"errors"
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ErrNoFrontmatter is returned by Parse when the document does not open
+// with a YAML frontmatter fence.
+var ErrNoFrontmatter = errors.New("manifest: no YAML frontmatter found")
+
+// Manifest is the parsed result of a SKILL.md document.
+type Manifest struct {
+	// Name is the skill's name from the SKILL.md frontmatter (the
+	// agentskills.io key). May be empty when the document omits it.
+	Name string
+	// Description is the skill's description from the frontmatter.
+	Description string
+	// Body is the Markdown content following the frontmatter fence.
+	Body string
+	// InstructionOnly reports whether the document carries no `aileron`
+	// block. An instruction-only skill has no actions to resolve and the
+	// installer short-circuits the requires-resolver for it.
+	InstructionOnly bool
+	// Aileron is the parsed Aileron block. Zero value when
+	// InstructionOnly is true.
+	Aileron AileronBlock
+}
+
+// AileronBlock is the Aileron-specific frontmatter block.
+type AileronBlock struct {
+	SchemaVersion string         `yaml:"schemaVersion"`
+	Requires      Requires       `yaml:"requires"`
+	Inputs        []any          `yaml:"inputs"`
+	Outputs       []any          `yaml:"outputs"`
+	Steps         []any          `yaml:"steps"`
+	Lock          map[string]any `yaml:"lock"`
+}
+
+// Requires lists the actions the skill calls and its execution-environment
+// dependencies.
+type Requires struct {
+	Actions              []ActionRequirement `yaml:"actions"`
+	ExecutionEnvironment map[string]any      `yaml:"executionEnvironment"`
+}
+
+// ActionRequirement is one required action plus its per-action trust
+// contract. Only the reference and the trust-contract shape are modeled;
+// the trust contract declares credential kind/placement, never a value.
+type ActionRequirement struct {
+	Ref           string         `yaml:"ref"`
+	TrustContract map[string]any `yaml:"trustContract"`
+}
+
+// Refs returns the action references declared in requires.actions, in
+// declaration order. Instruction-only manifests return nil.
+func (m *Manifest) Refs() []string {
+	if m.InstructionOnly {
+		return nil
+	}
+	refs := make([]string, 0, len(m.Aileron.Requires.Actions))
+	for _, a := range m.Aileron.Requires.Actions {
+		refs = append(refs, a.Ref)
+	}
+	return refs
+}
+
+// frontmatterEnvelope decodes only the keys Parse needs from the raw
+// frontmatter: the skill name/description and the namespaced aileron block.
+// Other agentskills.io keys are intentionally ignored here (they are not
+// Aileron's to constrain).
+type frontmatterEnvelope struct {
+	Name        string        `yaml:"name"`
+	Description string        `yaml:"description"`
+	Aileron     *AileronBlock `yaml:"aileron"`
+}
+
+// Parse decodes a SKILL.md document. It splits the YAML frontmatter from
+// the Markdown body, decodes the frontmatter, and — when an `aileron`
+// block is present — validates that block against the embedded schema and
+// returns field-level errors on failure.
+//
+// A document with no `aileron` block parses cleanly as InstructionOnly.
+// A document with a present-but-invalid block returns a validation error.
+func Parse(raw []byte) (*Manifest, error) {
+	front, body, ok := splitFrontmatter(raw)
+	if !ok {
+		return nil, ErrNoFrontmatter
+	}
+
+	var env frontmatterEnvelope
+	if err := yaml.Unmarshal(front, &env); err != nil {
+		return nil, fmt.Errorf("manifest: parse frontmatter YAML: %w", err)
+	}
+
+	m := &Manifest{
+		Name:        env.Name,
+		Description: env.Description,
+		Body:        string(body),
+	}
+
+	if env.Aileron == nil {
+		// No aileron block: instruction-only skill. Lossless-if-stripped:
+		// a valid skill the runtime treats as having no actions to resolve.
+		m.InstructionOnly = true
+		return m, nil
+	}
+
+	// The aileron block is present. Validate the full required set against
+	// the embedded schema (not just the per-ref regex): aileronBlock
+	// requires requires/inputs/outputs; requires requires a non-empty
+	// actions array; each actionRequirement requires ref + trustContract.
+	if err := validateFrontmatter(front); err != nil {
+		return nil, err
+	}
+
+	m.Aileron = *env.Aileron
+	return m, nil
+}
+
+// splitFrontmatter splits a Markdown document into its YAML frontmatter
+// block and the remaining body. It expects the document to open with a
+// `---` fence and closes on the first standalone `---` line, so a body
+// line that merely starts with three dashes (a thematic break, for
+// example) is not mistaken for the closing fence. This mirrors the
+// splitter proven in internal/flightplan/spec.
+func splitFrontmatter(raw []byte) (front, body []byte, ok bool) {
+	const fence = "---"
+	text := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || lines[0] != fence {
+		return nil, nil, false
+	}
+	for i := 1; i < len(lines); i++ {
+		if lines[i] == fence {
+			front = []byte(strings.Join(lines[1:i], "\n"))
+			body = []byte(strings.Join(lines[i+1:], "\n"))
+			return front, body, true
+		}
+	}
+	return nil, nil, false
+}

--- a/internal/flightplan/manifest/manifest_test.go
+++ b/internal/flightplan/manifest/manifest_test.go
@@ -1,0 +1,112 @@
+package manifest
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+)
+
+// exampleSkill loads the committed, schema-valid worked example. Using the
+// canonical example as the valid-path fixture keeps the test honest: it
+// exercises a manifest that the normative schema actually accepts, rather
+// than a hand-rolled minimal block that could drift from the contract.
+func exampleSkill(t *testing.T) []byte {
+	t.Helper()
+	p := filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.skill.md")
+	raw, err := os.ReadFile(p)
+	if err != nil {
+		t.Fatalf("read worked example: %v", err)
+	}
+	return raw
+}
+
+// instructionOnlySkill carries no aileron block. It is a valid skill.
+const instructionOnlySkill = `---
+name: rubber-duck
+description: A skill with only instructions, no Aileron actions.
+---
+
+# Rubber Duck
+
+Explain your problem out loud.
+`
+
+func TestParseInstructionOnly(t *testing.T) {
+	m, err := Parse([]byte(instructionOnlySkill))
+	if err != nil {
+		t.Fatalf("instruction-only skill must parse: %v", err)
+	}
+	if !m.InstructionOnly {
+		t.Error("expected InstructionOnly true for a skill with no aileron block")
+	}
+	if m.Name != "rubber-duck" {
+		t.Errorf("name = %q, want rubber-duck", m.Name)
+	}
+	if len(m.Refs()) != 0 {
+		t.Errorf("instruction-only Refs() = %v, want empty", m.Refs())
+	}
+	if !strings.Contains(m.Body, "Explain your problem out loud") {
+		t.Errorf("body not captured: %q", m.Body)
+	}
+}
+
+func TestParseValidCredentialed(t *testing.T) {
+	m, err := Parse(exampleSkill(t))
+	if err != nil {
+		t.Fatalf("valid credentialed skill must parse: %v", err)
+	}
+	if m.InstructionOnly {
+		t.Error("expected InstructionOnly false for a skill with an aileron block")
+	}
+	if m.Name != "weekly-metrics-digest" {
+		t.Errorf("name = %q", m.Name)
+	}
+	want := []string{"aileron:metrics.query_series", "aileron:tracker.create_issue"}
+	got := m.Refs()
+	if len(got) != len(want) {
+		t.Fatalf("Refs() = %v, want %v", got, want)
+	}
+	for i := range want {
+		if got[i] != want[i] {
+			t.Errorf("Refs()[%d] = %q, want %q", i, got[i], want[i])
+		}
+	}
+	if m.Aileron.SchemaVersion != "aileron.flightplan.v1" {
+		t.Errorf("schemaVersion = %q", m.Aileron.SchemaVersion)
+	}
+	// The trust contract must carry only declarative kind/placement, never
+	// a credential value. Assert no secret-shaped key leaked into the
+	// parsed contract.
+	tc := m.Aileron.Requires.Actions[0].TrustContract
+	cred, ok := tc["credential"].(map[string]any)
+	if !ok {
+		t.Fatalf("trustContract.credential missing or wrong type: %T", tc["credential"])
+	}
+	for _, forbidden := range []string{"value", "secret", "token", "password"} {
+		if _, present := cred[forbidden]; present {
+			t.Errorf("trust contract leaked a credential value under %q", forbidden)
+		}
+	}
+}
+
+func TestParseNoFrontmatter(t *testing.T) {
+	_, err := Parse([]byte("# Just a heading\n\nNo frontmatter here.\n"))
+	if !errors.Is(err, ErrNoFrontmatter) {
+		t.Errorf("expected ErrNoFrontmatter, got %v", err)
+	}
+}
+
+func TestParseThematicBreakNotFence(t *testing.T) {
+	// A body line that is a thematic break (---) inside the markdown must
+	// not be mistaken for the closing frontmatter fence.
+	doc := "---\nname: x\ndescription: y\n---\n\nIntro\n\n---\n\nMore body.\n"
+	m, err := Parse([]byte(doc))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if !strings.Contains(m.Body, "More body.") {
+		t.Errorf("body should include the thematic break and what follows: %q", m.Body)
+	}
+}

--- a/internal/flightplan/manifest/schema.go
+++ b/internal/flightplan/manifest/schema.go
@@ -1,0 +1,20 @@
+package manifest
+
+import _ "embed"
+
+// embeddedSchema is a byte-identical copy of the normative Flight Plan
+// manifest schema at docs/schema/flight-plan-manifest.schema.json.
+//
+// The schema is the source of truth, but it lives outside this Go module
+// (the internal module cannot go:embed across the module boundary into
+// docs/). So the parser embeds a copy and a drift-guard test
+// (schema_drift_test.go) asserts byte-equality with the doc copy. This
+// mirrors the drift-guard discipline already used by
+// internal/flightplan/spec.
+//
+//go:embed flight-plan-manifest.schema.json
+var embeddedSchema []byte
+
+// EmbeddedSchema returns the embedded Flight Plan manifest schema bytes.
+// Exposed so the drift-guard test can compare against the doc copy.
+func EmbeddedSchema() []byte { return embeddedSchema }

--- a/internal/flightplan/manifest/schema_drift_test.go
+++ b/internal/flightplan/manifest/schema_drift_test.go
@@ -1,0 +1,49 @@
+package manifest
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// repoRoot walks up from this source file to the repository root (the
+// directory that contains go.work). The normative schema lives outside
+// this Go module under docs/, so go:embed cannot reach it; the embedded
+// copy must be kept byte-identical and this test is the guard.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed; cannot locate the repo root")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.work walking up from %s", filepath.Dir(file))
+		}
+		dir = parent
+	}
+}
+
+// TestEmbeddedSchemaMatchesDoc is the drift guard: the schema embedded in
+// this package must be byte-identical to the normative copy at
+// docs/schema/flight-plan-manifest.schema.json. If the doc schema changes
+// (for example #1580 hoisting actionRef into $defs), this test fails until
+// the embedded copy is refreshed.
+func TestEmbeddedSchemaMatchesDoc(t *testing.T) {
+	docPath := filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.schema.json")
+	want, err := os.ReadFile(docPath)
+	if err != nil {
+		t.Fatalf("read normative schema: %v", err)
+	}
+	if !bytes.Equal(want, EmbeddedSchema()) {
+		t.Fatalf("embedded schema has drifted from %s; refresh the copy at "+
+			"internal/flightplan/manifest/flight-plan-manifest.schema.json", docPath)
+	}
+}

--- a/internal/flightplan/manifest/validate.go
+++ b/internal/flightplan/manifest/validate.go
@@ -1,0 +1,89 @@
+package manifest
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"sync"
+
+	"github.com/santhosh-tekuri/jsonschema/v6"
+	"gopkg.in/yaml.v3"
+)
+
+// schemaLocation is the $id the embedded schema declares. The compiler
+// keys the resource by this URI.
+const schemaLocation = "https://withaileron.ai/schema/flight-plan-manifest.schema.json"
+
+var (
+	compiledSchema     *jsonschema.Schema
+	compiledSchemaErr  error
+	compiledSchemaOnce sync.Once
+)
+
+// schema compiles the embedded Flight Plan manifest schema once and
+// returns the cached result on subsequent calls.
+func schema() (*jsonschema.Schema, error) {
+	compiledSchemaOnce.Do(func() {
+		doc, err := jsonschema.UnmarshalJSON(bytes.NewReader(embeddedSchema))
+		if err != nil {
+			compiledSchemaErr = fmt.Errorf("manifest: parse embedded schema JSON: %w", err)
+			return
+		}
+		c := jsonschema.NewCompiler()
+		if err := c.AddResource(schemaLocation, doc); err != nil {
+			compiledSchemaErr = fmt.Errorf("manifest: add embedded schema resource: %w", err)
+			return
+		}
+		sch, err := c.Compile(schemaLocation)
+		if err != nil {
+			compiledSchemaErr = fmt.Errorf("manifest: compile embedded schema: %w", err)
+			return
+		}
+		compiledSchema = sch
+	})
+	return compiledSchema, compiledSchemaErr
+}
+
+// validateFrontmatter validates a SKILL.md YAML frontmatter block against
+// the embedded schema. The schema validates the whole top-level object;
+// the `aileron` key is optional at the top level (lossless-if-stripped),
+// so this returns nil for a stripped manifest. When the `aileron` block is
+// present but malformed, it returns a field-level validation error.
+func validateFrontmatter(front []byte) error {
+	sch, err := schema()
+	if err != nil {
+		return err
+	}
+
+	var m map[string]any
+	if err := yaml.Unmarshal(front, &m); err != nil {
+		return fmt.Errorf("manifest: parse frontmatter YAML: %w", err)
+	}
+
+	inst, err := jsonify(m)
+	if err != nil {
+		return err
+	}
+
+	if err := sch.Validate(inst); err != nil {
+		return fmt.Errorf("manifest: aileron block failed schema validation: %w", err)
+	}
+	return nil
+}
+
+// jsonify round-trips a YAML-decoded value through JSON so the validator
+// sees the value model it expects (string keys, float64 numbers, []any and
+// map[string]any containers). YAML decodes maps as map[string]any here
+// because the frontmatter envelope uses string keys, but nested values may
+// still carry YAML-native types, so the round-trip normalizes them.
+func jsonify(m map[string]any) (any, error) {
+	var buf bytes.Buffer
+	if err := json.NewEncoder(&buf).Encode(m); err != nil {
+		return nil, fmt.Errorf("manifest: re-encode frontmatter to JSON: %w", err)
+	}
+	out, err := jsonschema.UnmarshalJSON(&buf)
+	if err != nil {
+		return nil, fmt.Errorf("manifest: decode frontmatter as JSON: %w", err)
+	}
+	return out, nil
+}

--- a/internal/flightplan/manifest/validate_test.go
+++ b/internal/flightplan/manifest/validate_test.go
@@ -1,0 +1,116 @@
+package manifest
+
+import (
+	"strings"
+	"testing"
+)
+
+// invalidCases enumerates the contract's stated failure modes for a
+// present aileron block. Each document has the block present (so the parser
+// must validate it) but violates exactly one required-field rule.
+func TestParseInvalidBlocks(t *testing.T) {
+	cases := map[string]string{
+		"missing requires": `---
+name: s
+description: d
+aileron:
+  inputs: []
+  outputs: []
+---
+body
+`,
+		"missing inputs": `---
+name: s
+description: d
+aileron:
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract: {}
+  outputs: []
+---
+body
+`,
+		"missing outputs": `---
+name: s
+description: d
+aileron:
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract: {}
+  inputs: []
+---
+body
+`,
+		"empty actions array": `---
+name: s
+description: d
+aileron:
+  requires:
+    actions: []
+  inputs: []
+  outputs: []
+---
+body
+`,
+		"action missing ref": `---
+name: s
+description: d
+aileron:
+  requires:
+    actions:
+      - trustContract: {}
+  inputs: []
+  outputs: []
+---
+body
+`,
+		"action missing trustContract": `---
+name: s
+description: d
+aileron:
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+  inputs: []
+  outputs: []
+---
+body
+`,
+		"ref malformed (no connector.action)": `---
+name: s
+description: d
+aileron:
+  requires:
+    actions:
+      - ref: not-a-valid-ref
+        trustContract: {}
+  inputs: []
+  outputs: []
+---
+body
+`,
+	}
+
+	for name, doc := range cases {
+		t.Run(name, func(t *testing.T) {
+			_, err := Parse([]byte(doc))
+			if err == nil {
+				t.Fatalf("expected validation error for %q, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "schema validation") {
+				t.Errorf("error should cite schema validation, got: %v", err)
+			}
+		})
+	}
+}
+
+// TestStrippedTopLevelStillValid confirms the schema does not reject a
+// document with the aileron block absent. This is the lossless-if-stripped
+// guarantee at the parser boundary: an instruction-only skill is valid.
+func TestStrippedTopLevelStillValid(t *testing.T) {
+	if err := validateFrontmatter([]byte("name: s\ndescription: d\n")); err != nil {
+		t.Fatalf("a stripped manifest must validate, got: %v", err)
+	}
+}

--- a/internal/flightplan/resolver/client.go
+++ b/internal/flightplan/resolver/client.go
@@ -1,0 +1,84 @@
+package resolver
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// Fetcher fetches the installed actions the resolver matches refs against.
+// It is the daemon seam: production wires it to GET /v1/actions; tests
+// inject a fake so no live daemon is required (mirroring the syncFetcher /
+// bindingAPIBaseURL seam discipline elsewhere in the codebase).
+type Fetcher interface {
+	FetchActions(ctx context.Context) ([]Action, error)
+}
+
+// FetcherFunc adapts a function to the Fetcher interface.
+type FetcherFunc func(ctx context.Context) ([]Action, error)
+
+// FetchActions calls the underlying function.
+func (f FetcherFunc) FetchActions(ctx context.Context) ([]Action, error) {
+	return f(ctx)
+}
+
+// listActionsResponse mirrors the daemon's GET /v1/actions envelope. Only
+// the items array is decoded, and within each item only the fields the
+// resolver matches on (Action's json tags ignore the rest).
+type listActionsResponse struct {
+	Items []Action `json:"items"`
+}
+
+// HTTPFetcher fetches actions from the daemon over HTTP.
+type HTTPFetcher struct {
+	// BaseURL is the daemon API base including the /v1 suffix.
+	BaseURL string
+	// Client is the HTTP client; nil uses a default with a 30s timeout.
+	Client *http.Client
+	// Authorize, when non-nil, sets the daemon bearer token on the request.
+	Authorize func(*http.Request)
+}
+
+// FetchActions retrieves the installed actions from GET {BaseURL}/actions.
+func (h HTTPFetcher) FetchActions(ctx context.Context) ([]Action, error) {
+	client := h.Client
+	if client == nil {
+		client = &http.Client{Timeout: 30 * time.Second}
+	}
+	req, err := http.NewRequestWithContext(ctx, http.MethodGet, h.BaseURL+"/actions", nil)
+	if err != nil {
+		return nil, fmt.Errorf("resolver: build actions request: %w", err)
+	}
+	if h.Authorize != nil {
+		h.Authorize(req)
+	}
+	resp, err := client.Do(req)
+	if err != nil {
+		return nil, fmt.Errorf("resolver: fetch actions: %w", err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		body, _ := io.ReadAll(resp.Body)
+		return nil, fmt.Errorf("resolver: daemon returned %d: %s", resp.StatusCode, string(body))
+	}
+	var out listActionsResponse
+	if err := json.NewDecoder(resp.Body).Decode(&out); err != nil {
+		return nil, fmt.Errorf("resolver: decode actions response: %w", err)
+	}
+	return out.Items, nil
+}
+
+// ResolveWith fetches the installed actions via the fetcher and resolves
+// the refs against them. A fetch error is returned to the caller (the
+// installer decides whether a daemon-down condition warns or fails; an
+// instruction-only skill never reaches this code).
+func ResolveWith(ctx context.Context, f Fetcher, refs []string) (Resolution, error) {
+	actions, err := f.FetchActions(ctx)
+	if err != nil {
+		return Resolution{}, err
+	}
+	return Resolve(refs, actions), nil
+}

--- a/internal/flightplan/resolver/client_test.go
+++ b/internal/flightplan/resolver/client_test.go
@@ -1,0 +1,53 @@
+package resolver
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+)
+
+func TestHTTPFetcherDecodesActions(t *testing.T) {
+	var sawAuth string
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		sawAuth = r.Header.Get("Authorization")
+		if r.URL.Path != "/actions" {
+			t.Errorf("path = %q, want /actions", r.URL.Path)
+		}
+		w.Header().Set("Content-Type", "application/json")
+		_, _ = w.Write([]byte(`{"items":[{"name":"query-series","requires":{"connectors":[{"name":"github://aileron/metrics"}]}}]}`))
+	}))
+	defer srv.Close()
+
+	f := HTTPFetcher{
+		BaseURL: srv.URL,
+		Authorize: func(req *http.Request) {
+			req.Header.Set("Authorization", "Bearer test-token")
+		},
+	}
+	actions, err := f.FetchActions(context.Background())
+	if err != nil {
+		t.Fatalf("FetchActions: %v", err)
+	}
+	if len(actions) != 1 || actions[0].Name != "query-series" {
+		t.Fatalf("decoded actions = %+v", actions)
+	}
+	if actions[0].Requires.Connectors[0].Name != "github://aileron/metrics" {
+		t.Errorf("connector not decoded: %+v", actions[0].Requires.Connectors)
+	}
+	if sawAuth != "Bearer test-token" {
+		t.Errorf("Authorize hook not applied; saw %q", sawAuth)
+	}
+}
+
+func TestHTTPFetcherNon200(t *testing.T) {
+	srv := httptest.NewServer(http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
+		http.Error(w, "nope", http.StatusInternalServerError)
+	}))
+	defer srv.Close()
+
+	f := HTTPFetcher{BaseURL: srv.URL}
+	if _, err := f.FetchActions(context.Background()); err == nil {
+		t.Error("expected error on non-200 response")
+	}
+}

--- a/internal/flightplan/resolver/resolver.go
+++ b/internal/flightplan/resolver/resolver.go
@@ -1,0 +1,155 @@
+// Package resolver decides whether a Flight Plan skill's declared action
+// references (requires.actions[].ref) are satisfied by the actions the
+// running daemon exposes.
+//
+// This is the #1574 ref-to-action mapping. It is read-only against the
+// existing daemon API (GET /v1/actions): no OpenAPI change, no new
+// endpoint, no generated code. The resolver is a pure function over a
+// decoded []Action plus a thin daemon fetch seam (client.go), so it is
+// independently testable without a live daemon.
+//
+// A ref has the form `aileron:<connector>.<action>`. Per #1574 it is
+// satisfied when some installed action matches on BOTH:
+//
+//   - connector: the ref's connector segment equals the FQN tail of one of
+//     the action's requires.connectors[].name (e.g. ref connector
+//     `slack` matches connector FQN `github://aileron/slack`).
+//   - action: the ref's action segment equals the action's bare local
+//     handle (Action.name), comparing with kebab/underscore normalization
+//     (`query_series` and `query-series` are the same handle).
+//
+// The resolver never touches credential values. It matches names only.
+package resolver
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Action is the subset of the daemon's Action object the resolver matches
+// on. The client seam decodes only these fields from GET /v1/actions.
+type Action struct {
+	// Name is the bare local action handle (e.g. "query-series").
+	Name string `json:"name"`
+	// Requires carries the connector dependency declarations.
+	Requires Requires `json:"requires"`
+}
+
+// Requires mirrors ActionRequires from the daemon API.
+type Requires struct {
+	Connectors []Connector `json:"connectors"`
+}
+
+// Connector mirrors ActionRequiresConnector; only the FQN name is matched.
+type Connector struct {
+	// Name is the connector FQN (e.g. "github://aileron/slack").
+	Name string `json:"name"`
+}
+
+// Ref is a parsed action reference.
+type Ref struct {
+	// Raw is the original ref string as written in the manifest.
+	Raw string
+	// Connector is the connector segment (between `aileron:` and the dot).
+	Connector string
+	// Action is the action segment (after the first dot).
+	Action string
+}
+
+// ParseRef splits an `aileron:<connector>.<action>` reference into its
+// connector and action segments. The action segment may itself contain
+// dots (the schema permits `[a-z0-9_.-]` after the first dot); the split is
+// on the FIRST dot only, so the connector is unambiguous.
+func ParseRef(raw string) (Ref, error) {
+	const prefix = "aileron:"
+	if !strings.HasPrefix(raw, prefix) {
+		return Ref{}, fmt.Errorf("resolver: ref %q missing %q prefix", raw, prefix)
+	}
+	rest := raw[len(prefix):]
+	dot := strings.IndexByte(rest, '.')
+	if dot <= 0 || dot == len(rest)-1 {
+		return Ref{}, fmt.Errorf("resolver: ref %q is not aileron:<connector>.<action>", raw)
+	}
+	return Ref{
+		Raw:       raw,
+		Connector: rest[:dot],
+		Action:    rest[dot+1:],
+	}, nil
+}
+
+// normalize collapses kebab/underscore differences so `query_series` and
+// `query-series` compare equal. The daemon's aileron-mcp toolName() maps
+// `-`→`_`; the manifest author may write either, so we normalize both
+// sides to a single separator before comparing.
+func normalize(s string) string {
+	return strings.ReplaceAll(s, "-", "_")
+}
+
+// fqnTail returns the trailing path segment of a connector FQN. For
+// `github://aileron/slack` it returns `slack`; for a bare `slack` it
+// returns `slack`. The scheme (`github://`) is stripped first so a
+// `://`-bearing FQN does not leak its scheme into the tail.
+func fqnTail(fqn string) string {
+	if i := strings.Index(fqn, "://"); i >= 0 {
+		fqn = fqn[i+len("://"):]
+	}
+	if i := strings.LastIndexByte(fqn, '/'); i >= 0 {
+		return fqn[i+1:]
+	}
+	return fqn
+}
+
+// Satisfies reports whether the given action satisfies the ref: the ref's
+// connector segment equals the FQN tail of one of the action's connectors
+// AND the ref's action segment equals the action's bare name (normalized).
+func Satisfies(ref Ref, a Action) bool {
+	if normalize(a.Name) != normalize(ref.Action) {
+		return false
+	}
+	for _, c := range a.Requires.Connectors {
+		if normalize(fqnTail(c.Name)) == normalize(ref.Connector) {
+			return true
+		}
+	}
+	return false
+}
+
+// Resolution is the outcome of resolving a set of refs against the
+// installed actions.
+type Resolution struct {
+	// Satisfied lists the refs that matched an installed action.
+	Satisfied []string
+	// Unsatisfied lists the refs that matched no installed action. An
+	// unsatisfied ref is a degrade signal, not an install failure.
+	Unsatisfied []string
+}
+
+// AllSatisfied reports whether every ref resolved.
+func (r Resolution) AllSatisfied() bool { return len(r.Unsatisfied) == 0 }
+
+// Resolve partitions refs into satisfied and unsatisfied against the
+// installed actions. A ref that fails to parse is reported as unsatisfied
+// (a malformed ref cannot match any action). Order follows the input refs.
+func Resolve(refs []string, actions []Action) Resolution {
+	var res Resolution
+	for _, raw := range refs {
+		ref, err := ParseRef(raw)
+		if err != nil {
+			res.Unsatisfied = append(res.Unsatisfied, raw)
+			continue
+		}
+		matched := false
+		for _, a := range actions {
+			if Satisfies(ref, a) {
+				matched = true
+				break
+			}
+		}
+		if matched {
+			res.Satisfied = append(res.Satisfied, raw)
+		} else {
+			res.Unsatisfied = append(res.Unsatisfied, raw)
+		}
+	}
+	return res
+}

--- a/internal/flightplan/resolver/resolver_test.go
+++ b/internal/flightplan/resolver/resolver_test.go
@@ -1,0 +1,153 @@
+package resolver
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+func action(name string, connectorFQNs ...string) Action {
+	a := Action{Name: name}
+	for _, fqn := range connectorFQNs {
+		a.Requires.Connectors = append(a.Requires.Connectors, Connector{Name: fqn})
+	}
+	return a
+}
+
+func TestParseRef(t *testing.T) {
+	tests := []struct {
+		raw               string
+		wantConn, wantAct string
+		wantErr           bool
+	}{
+		{"aileron:metrics.query_series", "metrics", "query_series", false},
+		{"aileron:slack.send.message", "slack", "send.message", false},
+		{"metrics.query_series", "", "", true}, // missing prefix
+		{"aileron:metrics", "", "", true},      // missing dot
+		{"aileron:.query", "", "", true},       // empty connector
+		{"aileron:metrics.", "", "", true},     // empty action
+	}
+	for _, tt := range tests {
+		got, err := ParseRef(tt.raw)
+		if tt.wantErr {
+			if err == nil {
+				t.Errorf("ParseRef(%q) expected error, got %+v", tt.raw, got)
+			}
+			continue
+		}
+		if err != nil {
+			t.Errorf("ParseRef(%q): %v", tt.raw, err)
+			continue
+		}
+		if got.Connector != tt.wantConn || got.Action != tt.wantAct {
+			t.Errorf("ParseRef(%q) = {%q, %q}, want {%q, %q}", tt.raw, got.Connector, got.Action, tt.wantConn, tt.wantAct)
+		}
+	}
+}
+
+func TestSatisfies(t *testing.T) {
+	ref, err := ParseRef("aileron:metrics.query_series")
+	if err != nil {
+		t.Fatal(err)
+	}
+	tests := []struct {
+		name string
+		a    Action
+		want bool
+	}{
+		// Satisfiable: action name matches, connector FQN tail matches.
+		{"exact", action("query_series", "github://aileron/metrics"), true},
+		// Kebab/underscore normalization on the action handle.
+		{"kebab action handle", action("query-series", "github://aileron/metrics"), true},
+		// FQN-tail matching: bare connector segment matches the tail.
+		{"bare connector fqn", action("query_series", "metrics"), true},
+		// Wrong connector tail.
+		{"wrong connector", action("query_series", "github://aileron/tracker"), false},
+		// Right connector, wrong action.
+		{"wrong action", action("create_issue", "github://aileron/metrics"), false},
+		// No connectors declared.
+		{"no connectors", action("query_series"), false},
+		// Multiple connectors, one matches.
+		{"one of many", action("query_series", "github://aileron/x", "github://aileron/metrics"), true},
+	}
+	for _, tt := range tests {
+		if got := Satisfies(ref, tt.a); got != tt.want {
+			t.Errorf("%s: Satisfies = %v, want %v", tt.name, got, tt.want)
+		}
+	}
+}
+
+func TestNormalizationBoundary(t *testing.T) {
+	// query_series in the ref must match query-series on the action and
+	// vice versa.
+	refUnderscore, _ := ParseRef("aileron:metrics.query_series")
+	refKebab, _ := ParseRef("aileron:metrics.query-series")
+	a := action("query-series", "github://aileron/metrics")
+	if !Satisfies(refUnderscore, a) {
+		t.Error("underscore ref should match kebab action")
+	}
+	if !Satisfies(refKebab, action("query_series", "github://aileron/metrics")) {
+		t.Error("kebab ref should match underscore action")
+	}
+}
+
+func TestResolve(t *testing.T) {
+	actions := []Action{
+		action("query_series", "github://aileron/metrics"),
+		action("create_issue", "github://aileron/tracker"),
+	}
+	res := Resolve([]string{
+		"aileron:metrics.query_series",  // satisfied
+		"aileron:tracker.create_issue",  // satisfied
+		"aileron:metrics.delete_series", // unsatisfied (no such action)
+		"not-a-ref",                     // unsatisfied (malformed)
+	}, actions)
+
+	if len(res.Satisfied) != 2 {
+		t.Errorf("Satisfied = %v, want 2", res.Satisfied)
+	}
+	if len(res.Unsatisfied) != 2 {
+		t.Errorf("Unsatisfied = %v, want 2", res.Unsatisfied)
+	}
+	if res.AllSatisfied() {
+		t.Error("AllSatisfied should be false with unsatisfied refs")
+	}
+}
+
+func TestResolveEmptyActionList(t *testing.T) {
+	res := Resolve([]string{"aileron:metrics.query_series"}, nil)
+	if len(res.Satisfied) != 0 || len(res.Unsatisfied) != 1 {
+		t.Errorf("empty action list: %+v, want all unsatisfied", res)
+	}
+}
+
+func TestResolveAllSatisfied(t *testing.T) {
+	res := Resolve(nil, nil)
+	if !res.AllSatisfied() {
+		t.Error("no refs should be vacuously all-satisfied")
+	}
+}
+
+func TestResolveWithFetcher(t *testing.T) {
+	fake := FetcherFunc(func(ctx context.Context) ([]Action, error) {
+		return []Action{action("query_series", "github://aileron/metrics")}, nil
+	})
+	res, err := ResolveWith(context.Background(), fake, []string{"aileron:metrics.query_series"})
+	if err != nil {
+		t.Fatalf("ResolveWith: %v", err)
+	}
+	if !res.AllSatisfied() {
+		t.Errorf("expected satisfied, got %+v", res)
+	}
+}
+
+func TestResolveWithFetcherError(t *testing.T) {
+	wantErr := errors.New("daemon down")
+	fake := FetcherFunc(func(ctx context.Context) ([]Action, error) {
+		return nil, wantErr
+	})
+	_, err := ResolveWith(context.Background(), fake, []string{"aileron:metrics.query_series"})
+	if !errors.Is(err, wantErr) {
+		t.Errorf("expected fetch error to propagate, got %v", err)
+	}
+}

--- a/internal/flightplan/store/install.go
+++ b/internal/flightplan/store/install.go
@@ -1,0 +1,135 @@
+package store
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+	"github.com/ALRubinger/aileron/internal/flightplan/resolver"
+)
+
+// InstallResult describes the outcome of an Install.
+type InstallResult struct {
+	// Name is the installed skill's name.
+	Name string
+	// Dir is the on-disk directory the skill was written to.
+	Dir string
+	// InstructionOnly reports whether the skill carried no aileron block.
+	// Instruction-only skills skip requires-resolution entirely.
+	InstructionOnly bool
+	// Unsatisfied lists the action refs that did not resolve against the
+	// running daemon. Non-empty means the install degraded: the skill is
+	// still installed, but its requires are not all satisfiable here.
+	Unsatisfied []string
+	// ResolverConsulted reports whether the requires-resolver (and thus the
+	// daemon) was consulted. It is false for instruction-only skills.
+	ResolverConsulted bool
+}
+
+// Degraded reports whether the install resolved with unsatisfied refs.
+func (r InstallResult) Degraded() bool { return len(r.Unsatisfied) > 0 }
+
+// InstallOptions configures an Install.
+type InstallOptions struct {
+	// Fetcher resolves the skill's action requirements against the running
+	// daemon. It is consulted ONLY for skills that declare an aileron block
+	// with requires. Instruction-only skills never reach it (P2 isolation:
+	// a daemon-down instruction-only install must be clean and silent).
+	// A nil Fetcher means "do not resolve": refs are recorded as
+	// unsatisfied without a daemon call (used when no daemon is reachable
+	// and the caller wants install-anyway behavior).
+	Fetcher resolver.Fetcher
+
+	// git overrides the git runner (seam for tests). Nil uses runGit.
+	git gitRunner
+	// slug overrides the slug resolver (seam for tests). Nil uses the v0
+	// not-wired resolver.
+	slug slugResolver
+}
+
+// Install fetches a skill from src (local path, git URL, or — once wired —
+// an agentskills.io slug), parses and validates it, resolves its action
+// requirements when it declares any, and writes it into the canonical
+// store under its skill name.
+//
+// Degrade, not block: an unsatisfiable requires warns (recorded in
+// InstallResult.Unsatisfied) but still installs. An instruction-only skill
+// (no aileron block) skips the resolver and any daemon call entirely.
+//
+// Re-installing a skill of the same name overwrites it (idempotent), which
+// keeps the #1509 freeze flow simple.
+func (s *Store) Install(ctx context.Context, src string, opts InstallOptions) (InstallResult, error) {
+	git := opts.git
+	if git == nil {
+		git = runGit
+	}
+	slug := opts.slug
+	if slug == nil {
+		slug = notWiredSlugResolver
+	}
+
+	workDir, err := os.MkdirTemp("", "aileron-skill-install-")
+	if err != nil {
+		return InstallResult{}, fmt.Errorf("store: temp dir: %w", err)
+	}
+	defer os.RemoveAll(workDir)
+
+	srcDir, err := fetchToDir(ctx, src, workDir, git, slug)
+	if err != nil {
+		return InstallResult{}, err
+	}
+
+	raw, err := os.ReadFile(filepath.Join(srcDir, "SKILL.md"))
+	if err != nil {
+		return InstallResult{}, fmt.Errorf("store: read SKILL.md: %w", err)
+	}
+	m, err := manifest.Parse(raw)
+	if err != nil {
+		return InstallResult{}, fmt.Errorf("store: parse skill: %w", err)
+	}
+	if m.Name == "" {
+		return InstallResult{}, fmt.Errorf("store: skill has no name in its frontmatter")
+	}
+
+	result := InstallResult{
+		Name:            m.Name,
+		Dir:             s.Dir(m.Name),
+		InstructionOnly: m.InstructionOnly,
+	}
+
+	// Requires-resolution. Instruction-only skills (and skills that declare
+	// no action refs) short-circuit BEFORE any daemon call so a daemon-down
+	// instruction-only install is clean and silent.
+	refs := m.Refs()
+	if len(refs) > 0 {
+		if opts.Fetcher != nil {
+			res, err := resolver.ResolveWith(ctx, opts.Fetcher, refs)
+			if err != nil {
+				return InstallResult{}, fmt.Errorf("store: resolve requires: %w", err)
+			}
+			result.ResolverConsulted = true
+			result.Unsatisfied = res.Unsatisfied
+		} else {
+			// No fetcher: record all refs as unsatisfied without a daemon
+			// call. The caller warns and installs anyway (degrade, not block).
+			result.Unsatisfied = append(result.Unsatisfied, refs...)
+		}
+	}
+
+	// Write into the canonical store. Overwrite any prior install of the
+	// same name (idempotent re-install).
+	dst := s.Dir(m.Name)
+	if err := os.RemoveAll(dst); err != nil {
+		return InstallResult{}, fmt.Errorf("store: clear prior install: %w", err)
+	}
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return InstallResult{}, fmt.Errorf("store: create skill dir: %w", err)
+	}
+	if err := copyTree(srcDir, dst); err != nil {
+		return InstallResult{}, fmt.Errorf("store: write skill content: %w", err)
+	}
+
+	return result, nil
+}

--- a/internal/flightplan/store/install_test.go
+++ b/internal/flightplan/store/install_test.go
@@ -1,0 +1,243 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/resolver"
+)
+
+// repoRoot walks up to the directory containing go.work so tests can read
+// the committed worked example as a known-valid credentialed skill.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.work from %s", filepath.Dir(file))
+		}
+		dir = parent
+	}
+}
+
+// writeSkill writes a SKILL.md into a fresh temp dir and returns the dir.
+func writeSkill(t *testing.T, content string) string {
+	t.Helper()
+	dir := t.TempDir()
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	return dir
+}
+
+// credentialedSkillDir copies the committed worked example into a temp dir
+// so install can resolve its real requires refs.
+func credentialedSkillDir(t *testing.T) string {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatalf("read worked example: %v", err)
+	}
+	return writeSkill(t, string(raw))
+}
+
+const instructionOnly = `---
+name: rubber-duck
+description: Instruction-only skill, no aileron block.
+---
+
+# Rubber Duck
+Explain the problem out loud.
+`
+
+// recordingFetcher records whether FetchActions was called, so tests can
+// assert the resolver/daemon seam is NOT consulted for instruction-only
+// installs.
+type recordingFetcher struct {
+	called  bool
+	actions []resolver.Action
+	err     error
+}
+
+func (r *recordingFetcher) FetchActions(ctx context.Context) ([]resolver.Action, error) {
+	r.called = true
+	return r.actions, r.err
+}
+
+func TestInstallInstructionOnlyClean(t *testing.T) {
+	s := New(t.TempDir())
+	src := writeSkill(t, instructionOnly)
+
+	// A fetcher that fails if touched proves instruction-only installs
+	// never reach the daemon (P2 isolation: daemon-down must be silent).
+	fetcher := &recordingFetcher{err: errors.New("daemon down")}
+
+	res, err := s.Install(context.Background(), src, InstallOptions{Fetcher: fetcher})
+	if err != nil {
+		t.Fatalf("instruction-only install must be clean: %v", err)
+	}
+	if fetcher.called {
+		t.Error("resolver/daemon seam was consulted for an instruction-only skill")
+	}
+	if !res.InstructionOnly {
+		t.Error("result should be marked InstructionOnly")
+	}
+	if res.ResolverConsulted {
+		t.Error("ResolverConsulted should be false for instruction-only")
+	}
+	if res.Degraded() {
+		t.Error("instruction-only install must not degrade")
+	}
+	if res.Name != "rubber-duck" {
+		t.Errorf("name = %q", res.Name)
+	}
+	// Content landed in the store.
+	if _, err := os.Stat(filepath.Join(res.Dir, "SKILL.md")); err != nil {
+		t.Errorf("SKILL.md not written to store: %v", err)
+	}
+	names, _ := s.List()
+	if len(names) != 1 || names[0] != "rubber-duck" {
+		t.Errorf("List after install = %v", names)
+	}
+}
+
+func TestInstallCredentialedSatisfiable(t *testing.T) {
+	s := New(t.TempDir())
+	src := credentialedSkillDir(t)
+
+	// Satisfy both refs the worked example declares.
+	fetcher := &recordingFetcher{actions: []resolver.Action{
+		{Name: "query-series", Requires: resolver.Requires{Connectors: []resolver.Connector{{Name: "github://aileron/metrics"}}}},
+		{Name: "create-issue", Requires: resolver.Requires{Connectors: []resolver.Connector{{Name: "github://aileron/tracker"}}}},
+	}}
+
+	res, err := s.Install(context.Background(), src, InstallOptions{Fetcher: fetcher})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if !fetcher.called || !res.ResolverConsulted {
+		t.Error("credentialed install must consult the resolver")
+	}
+	if res.Degraded() {
+		t.Errorf("expected no degrade, unsatisfied = %v", res.Unsatisfied)
+	}
+}
+
+func TestInstallCredentialedUnsatisfiableStillInstalls(t *testing.T) {
+	s := New(t.TempDir())
+	src := credentialedSkillDir(t)
+
+	// Empty action list: nothing resolves. Degrade, not block.
+	fetcher := &recordingFetcher{}
+
+	res, err := s.Install(context.Background(), src, InstallOptions{Fetcher: fetcher})
+	if err != nil {
+		t.Fatalf("unsatisfiable install must still succeed: %v", err)
+	}
+	if !res.Degraded() {
+		t.Error("expected degrade with unsatisfiable refs")
+	}
+	if len(res.Unsatisfied) != 2 {
+		t.Errorf("unsatisfied = %v, want 2", res.Unsatisfied)
+	}
+	// The skill is installed despite the degrade.
+	if _, err := os.Stat(filepath.Join(res.Dir, "SKILL.md")); err != nil {
+		t.Errorf("skill must be installed despite degrade: %v", err)
+	}
+}
+
+func TestInstallCredentialedNoFetcherDegrades(t *testing.T) {
+	s := New(t.TempDir())
+	src := credentialedSkillDir(t)
+
+	// nil Fetcher: install-anyway, all refs recorded unsatisfied, no panic.
+	res, err := s.Install(context.Background(), src, InstallOptions{})
+	if err != nil {
+		t.Fatalf("install with no fetcher: %v", err)
+	}
+	if res.ResolverConsulted {
+		t.Error("no fetcher means the resolver is not consulted")
+	}
+	if len(res.Unsatisfied) != 2 {
+		t.Errorf("unsatisfied = %v, want all refs", res.Unsatisfied)
+	}
+}
+
+func TestInstallReinstallOverwrites(t *testing.T) {
+	s := New(t.TempDir())
+	src := writeSkill(t, instructionOnly)
+
+	if _, err := s.Install(context.Background(), src, InstallOptions{}); err != nil {
+		t.Fatal(err)
+	}
+	// Re-install of the same name is idempotent (overwrite).
+	if _, err := s.Install(context.Background(), src, InstallOptions{}); err != nil {
+		t.Fatalf("re-install must overwrite: %v", err)
+	}
+	names, _ := s.List()
+	if len(names) != 1 {
+		t.Errorf("re-install should not duplicate, got %v", names)
+	}
+}
+
+func TestInstallCopiesAccompanyingFiles(t *testing.T) {
+	s := New(t.TempDir())
+	// A skill that carries a reference file in a subdirectory: the store
+	// must copy the whole tree, not just SKILL.md.
+	srcDir := writeSkill(t, instructionOnly)
+	if err := os.MkdirAll(filepath.Join(srcDir, "references"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(srcDir, "references", "guide.md"), []byte("# Guide\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	res, err := s.Install(context.Background(), srcDir, InstallOptions{})
+	if err != nil {
+		t.Fatalf("install: %v", err)
+	}
+	if _, err := os.Stat(filepath.Join(res.Dir, "references", "guide.md")); err != nil {
+		t.Errorf("accompanying file not copied into store: %v", err)
+	}
+}
+
+func TestListErrorOnFileRoot(t *testing.T) {
+	// A store root that is a regular file (not a directory) surfaces an
+	// error from List rather than being silently treated as empty.
+	f := filepath.Join(t.TempDir(), "rootfile")
+	if err := os.WriteFile(f, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := New(f).List(); err == nil {
+		t.Error("expected List error when root is a file")
+	}
+}
+
+func TestInstallSlugNotWired(t *testing.T) {
+	s := New(t.TempDir())
+	// A bare owner/name with no matching local path classifies as a slug.
+	_, err := s.Install(context.Background(), "acme/weekly-digest", InstallOptions{})
+	if !errors.Is(err, ErrSlugNotWired) {
+		t.Errorf("expected ErrSlugNotWired, got %v", err)
+	}
+}
+
+func TestInstallSkillWithoutNameRejected(t *testing.T) {
+	s := New(t.TempDir())
+	src := writeSkill(t, "---\ndescription: no name here\n---\nbody\n")
+	if _, err := s.Install(context.Background(), src, InstallOptions{}); err == nil {
+		t.Error("expected error for a skill with no name")
+	}
+}

--- a/internal/flightplan/store/source.go
+++ b/internal/flightplan/store/source.go
@@ -1,0 +1,181 @@
+package store
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"io"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// ErrSlugNotWired is returned when an agentskills.io slug install is
+// attempted. The slug source is a seam in v0: there is no pinned
+// agentskills.io wire contract in the repo yet, so the concrete fetch is
+// deferred to a named follow-up rather than invented here. See issue #1583.
+var ErrSlugNotWired = errors.New(
+	"store: installing by agentskills.io slug is not wired yet; " +
+		"use a local path or a git URL for now (tracked by #1583)")
+
+// SourceKind classifies an install source string.
+type SourceKind int
+
+const (
+	// SourceLocalPath is a filesystem path to a skill directory (a
+	// directory containing SKILL.md) or directly to a SKILL.md file.
+	SourceLocalPath SourceKind = iota
+	// SourceGitURL is a remote git repository URL to clone.
+	SourceGitURL
+	// SourceSlug is an agentskills.io registry slug (owner/name).
+	SourceSlug
+)
+
+// classifySource decides how to interpret an install source string.
+//
+//   - A string with a git URL shape (scheme://… or git@host:…, or a .git
+//     suffix) is a git URL.
+//   - A string that resolves to an existing filesystem path is a local path.
+//   - Anything else with an `owner/name` shape is treated as a registry slug.
+func classifySource(src string) SourceKind {
+	if isGitURL(src) {
+		return SourceGitURL
+	}
+	if _, err := os.Stat(src); err == nil {
+		return SourceLocalPath
+	}
+	return SourceSlug
+}
+
+// isGitURL reports whether src looks like a git remote URL rather than a
+// local path or a bare slug.
+func isGitURL(src string) bool {
+	switch {
+	case strings.HasSuffix(src, ".git"):
+		return true
+	case strings.HasPrefix(src, "git@"):
+		return true
+	case strings.Contains(src, "://"):
+		// Any scheme://… (https://, ssh://, git://, file://) is a URL.
+		return true
+	default:
+		return false
+	}
+}
+
+// gitRunner runs a git command. It is a seam so tests can drive the
+// git-URL path without a network clone; production uses runGit.
+type gitRunner func(ctx context.Context, args ...string) error
+
+// runGit shells out to the git binary.
+func runGit(ctx context.Context, args ...string) error {
+	cmd := exec.CommandContext(ctx, "git", args...)
+	if out, err := cmd.CombinedOutput(); err != nil {
+		return fmt.Errorf("git %s: %w: %s", strings.Join(args, " "), err, strings.TrimSpace(string(out)))
+	}
+	return nil
+}
+
+// slugResolver resolves an agentskills.io slug to fetched skill content on
+// disk, returning the local directory the content was fetched into. It is a
+// seam: v0 returns ErrSlugNotWired. See issue #1583 for the wire contract.
+type slugResolver func(ctx context.Context, slug, destDir string) (string, error)
+
+// notWiredSlugResolver is the v0 slug resolver.
+func notWiredSlugResolver(_ context.Context, _, _ string) (string, error) {
+	return "", ErrSlugNotWired
+}
+
+// fetchToDir materializes the install source into a directory containing a
+// SKILL.md and returns that directory. For a local path it returns the
+// source directory directly (no copy until the store write). For a git URL
+// it clones into workDir. For a slug it calls the slug resolver.
+func fetchToDir(ctx context.Context, src string, workDir string, git gitRunner, slug slugResolver) (string, error) {
+	switch classifySource(src) {
+	case SourceLocalPath:
+		return localSourceDir(src)
+	case SourceGitURL:
+		clone := filepath.Join(workDir, "clone")
+		if err := git(ctx, "clone", "--depth", "1", "--single-branch", src, clone); err != nil {
+			return "", err
+		}
+		return skillDirWithin(clone)
+	case SourceSlug:
+		return slug(ctx, src, workDir)
+	default:
+		return "", fmt.Errorf("store: unrecognized source %q", src)
+	}
+}
+
+// localSourceDir resolves a local install source to the directory that
+// contains its SKILL.md. The source may point at the directory or directly
+// at the SKILL.md file.
+func localSourceDir(src string) (string, error) {
+	info, err := os.Stat(src)
+	if err != nil {
+		return "", fmt.Errorf("store: stat source %q: %w", src, err)
+	}
+	if info.IsDir() {
+		return skillDirWithin(src)
+	}
+	// A file path: it must be a SKILL.md.
+	if filepath.Base(src) != "SKILL.md" {
+		return "", fmt.Errorf("store: source file %q is not a SKILL.md", src)
+	}
+	return filepath.Dir(src), nil
+}
+
+// skillDirWithin verifies dir contains a SKILL.md and returns dir.
+func skillDirWithin(dir string) (string, error) {
+	if _, err := os.Stat(filepath.Join(dir, "SKILL.md")); err != nil {
+		return "", fmt.Errorf("store: no SKILL.md in %q", dir)
+	}
+	return dir, nil
+}
+
+// copyTree recursively copies the regular files and subdirectories under
+// src into dst. Symlinks are skipped (the store holds plain skill content;
+// the codebase avoids symlinks in repos and the store mirrors that). It is
+// the store's write primitive.
+func copyTree(src, dst string) error {
+	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		switch {
+		case info.IsDir():
+			return os.MkdirAll(target, 0o755)
+		case info.Mode().IsRegular():
+			return copyFile(p, target, info.Mode().Perm())
+		default:
+			// Skip non-regular files (symlinks, devices, sockets).
+			return nil
+		}
+	})
+}
+
+func copyFile(src, dst string, perm os.FileMode) error {
+	in, err := os.Open(src)
+	if err != nil {
+		return err
+	}
+	defer in.Close()
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	out, err := os.OpenFile(dst, os.O_WRONLY|os.O_CREATE|os.O_TRUNC, perm)
+	if err != nil {
+		return err
+	}
+	if _, err := io.Copy(out, in); err != nil {
+		out.Close()
+		return err
+	}
+	return out.Close()
+}

--- a/internal/flightplan/store/source.go
+++ b/internal/flightplan/store/source.go
@@ -147,6 +147,13 @@ func copyTree(src, dst string) error {
 		if err != nil {
 			return err
 		}
+		// Skip a .git directory entirely. A git-URL install clones into a
+		// working tree whose root carries .git; the store holds skill
+		// content only, not version-control metadata, so copying it in
+		// would bloat the store with the whole history.
+		if info.IsDir() && info.Name() == ".git" {
+			return filepath.SkipDir
+		}
 		target := filepath.Join(dst, rel)
 		switch {
 		case info.IsDir():

--- a/internal/flightplan/store/source_test.go
+++ b/internal/flightplan/store/source_test.go
@@ -85,6 +85,11 @@ func TestInstallGitURLViaLocalBareRepo(t *testing.T) {
 	if _, err := os.Stat(filepath.Join(res.Dir, "SKILL.md")); err != nil {
 		t.Errorf("git-cloned skill not written: %v", err)
 	}
+	// Regression: the store must hold skill content only, never the clone's
+	// .git directory.
+	if _, err := os.Stat(filepath.Join(res.Dir, ".git")); !os.IsNotExist(err) {
+		t.Errorf("install copied the clone's .git into the store (err=%v)", err)
+	}
 }
 
 func TestInstallGitURLCloneFailureSurfaces(t *testing.T) {

--- a/internal/flightplan/store/source_test.go
+++ b/internal/flightplan/store/source_test.go
@@ -1,0 +1,101 @@
+package store
+
+import (
+	"context"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestClassifySource(t *testing.T) {
+	dir := t.TempDir()
+	tests := []struct {
+		src  string
+		want SourceKind
+	}{
+		{dir, SourceLocalPath},
+		{"https://github.com/acme/skill.git", SourceGitURL},
+		{"git@github.com:acme/skill.git", SourceGitURL},
+		{"ssh://git@host/acme/skill", SourceGitURL},
+		{"acme/weekly-digest", SourceSlug},
+	}
+	for _, tt := range tests {
+		if got := classifySource(tt.src); got != tt.want {
+			t.Errorf("classifySource(%q) = %v, want %v", tt.src, got, tt.want)
+		}
+	}
+}
+
+func TestLocalSourceDirFile(t *testing.T) {
+	dir := writeSkill(t, instructionOnly)
+	// Pointing at the SKILL.md file directly resolves to its directory.
+	got, err := localSourceDir(filepath.Join(dir, "SKILL.md"))
+	if err != nil {
+		t.Fatalf("localSourceDir: %v", err)
+	}
+	if got != dir {
+		t.Errorf("localSourceDir = %q, want %q", got, dir)
+	}
+}
+
+func TestLocalSourceDirRejectsNonSkillFile(t *testing.T) {
+	dir := t.TempDir()
+	other := filepath.Join(dir, "notes.txt")
+	if err := os.WriteFile(other, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := localSourceDir(other); err == nil {
+		t.Error("expected error for a non-SKILL.md file source")
+	}
+}
+
+func TestLocalSourceDirMissingSkillMd(t *testing.T) {
+	dir := t.TempDir() // empty dir, no SKILL.md
+	if _, err := localSourceDir(dir); err == nil {
+		t.Error("expected error for a directory with no SKILL.md")
+	}
+}
+
+// TestInstallGitURLViaLocalBareRepo exercises the git-URL install path
+// against a real local git repository (file:// clone), so no network is
+// required. It proves the clone → parse → store write flow end to end.
+func TestInstallGitURLViaLocalBareRepo(t *testing.T) {
+	if !gitAvailable() {
+		t.Skip("git not available")
+	}
+	repo := t.TempDir()
+	mustGit(t, repo, "init", "-q")
+	mustGit(t, repo, "config", "user.email", "t@example.com")
+	mustGit(t, repo, "config", "user.name", "T")
+	if err := os.WriteFile(filepath.Join(repo, "SKILL.md"), []byte(instructionOnly), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	mustGit(t, repo, "add", "SKILL.md")
+	mustGit(t, repo, "commit", "-q", "-m", "init")
+
+	s := New(t.TempDir())
+	url := "file://" + repo
+	res, err := s.Install(context.Background(), url, InstallOptions{})
+	if err != nil {
+		t.Fatalf("git-URL install: %v", err)
+	}
+	if res.Name != "rubber-duck" {
+		t.Errorf("installed name = %q", res.Name)
+	}
+	if _, err := os.Stat(filepath.Join(res.Dir, "SKILL.md")); err != nil {
+		t.Errorf("git-cloned skill not written: %v", err)
+	}
+}
+
+func TestInstallGitURLCloneFailureSurfaces(t *testing.T) {
+	s := New(t.TempDir())
+	// A git runner seam that fails proves clone errors surface as install
+	// errors rather than being swallowed.
+	failGit := func(ctx context.Context, args ...string) error {
+		return errClone
+	}
+	_, err := s.Install(context.Background(), "https://example.invalid/x.git", InstallOptions{git: failGit})
+	if err == nil {
+		t.Error("expected clone failure to surface")
+	}
+}

--- a/internal/flightplan/store/source_test.go
+++ b/internal/flightplan/store/source_test.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"os"
 	"path/filepath"
+	"strings"
 	"testing"
 )
 
@@ -74,7 +75,14 @@ func TestInstallGitURLViaLocalBareRepo(t *testing.T) {
 	mustGit(t, repo, "commit", "-q", "-m", "init")
 
 	s := New(t.TempDir())
-	url := "file://" + repo
+	// Build a cross-platform file URL. On Windows a temp path is like
+	// C:\...; the valid file URL form is file:///C:/... (forward slashes,
+	// triple slash). filepath.ToSlash + a leading slash normalizes both.
+	slashed := filepath.ToSlash(repo)
+	if !strings.HasPrefix(slashed, "/") {
+		slashed = "/" + slashed
+	}
+	url := "file://" + slashed
 	res, err := s.Install(context.Background(), url, InstallOptions{})
 	if err != nil {
 		t.Fatalf("git-URL install: %v", err)

--- a/internal/flightplan/store/store.go
+++ b/internal/flightplan/store/store.go
@@ -1,0 +1,83 @@
+// Package store is the host-side canonical store for installed Flight Plan
+// skills. It is the single writer of `~/.aileron/skills/<name>/`, mirroring
+// the actions store convention (internal/action/loader.go DefaultDir).
+//
+// The store is designed as the shared canonical location the freeze step
+// (#1509) writes frozen skill versions into. It is not a parser-local
+// artifact: an installed skill is read-only after install (editing is an
+// explicit future op), and `aileron launch` bind-mounts this directory
+// read-only at the agent's skills path (#1508 launch-anywhere projection).
+//
+// The store never reads or carries credential values (ADR-0005, ADR-0019).
+// It writes skill content (SKILL.md plus any accompanying files) only.
+package store
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// DefaultDir returns the user-level skills directory `~/.aileron/skills`.
+// Falls back to `./.aileron/skills` if the user's home directory is not
+// resolvable, matching internal/action/loader.go DefaultDir.
+func DefaultDir() string {
+	const subdir = "skills"
+	if home, err := os.UserHomeDir(); err == nil && home != "" {
+		return filepath.Join(home, ".aileron", subdir)
+	}
+	return filepath.Join(".aileron", subdir)
+}
+
+// Store is a canonical skill store rooted at a directory.
+type Store struct {
+	root string
+}
+
+// New returns a Store rooted at dir. An empty dir uses DefaultDir.
+func New(dir string) *Store {
+	if dir == "" {
+		dir = DefaultDir()
+	}
+	return &Store{root: dir}
+}
+
+// Root returns the store's root directory.
+func (s *Store) Root() string { return s.root }
+
+// Dir returns the on-disk directory for a named skill,
+// `<root>/<name>`. It does not create the directory.
+func (s *Store) Dir(name string) string {
+	return filepath.Join(s.root, name)
+}
+
+// List returns the names of installed skills in sorted order. A skill is
+// any subdirectory of the store root that contains a SKILL.md file. A
+// missing store root is not an error: it lists as empty.
+func (s *Store) List() ([]string, error) {
+	entries, err := os.ReadDir(s.root)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("store: read skills dir: %w", err)
+	}
+	var names []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(s.root, e.Name(), "SKILL.md")); err != nil {
+			continue
+		}
+		names = append(names, e.Name())
+	}
+	sort.Strings(names)
+	return names, nil
+}
+
+// Read returns the raw SKILL.md bytes for an installed skill.
+func (s *Store) Read(name string) ([]byte, error) {
+	return os.ReadFile(filepath.Join(s.Dir(name), "SKILL.md"))
+}

--- a/internal/flightplan/store/store_test.go
+++ b/internal/flightplan/store/store_test.go
@@ -1,0 +1,69 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestDefaultDir(t *testing.T) {
+	d := DefaultDir()
+	if filepath.Base(d) != "skills" {
+		t.Errorf("DefaultDir = %q, want a path ending in skills", d)
+	}
+}
+
+func TestNewDefaultsRootAndExposesIt(t *testing.T) {
+	// An empty dir falls back to DefaultDir.
+	if got := New("").Root(); got != DefaultDir() {
+		t.Errorf("New(\"\").Root() = %q, want %q", got, DefaultDir())
+	}
+	// An explicit dir is exposed verbatim.
+	if got := New("/tmp/x").Root(); got != "/tmp/x" {
+		t.Errorf("Root() = %q, want /tmp/x", got)
+	}
+}
+
+func TestListAndRead(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+
+	// Empty / missing store lists as empty.
+	names, err := s.List()
+	if err != nil {
+		t.Fatalf("List on empty store: %v", err)
+	}
+	if len(names) != 0 {
+		t.Errorf("empty store List = %v, want empty", names)
+	}
+
+	// A directory without SKILL.md is not a skill.
+	if err := os.MkdirAll(filepath.Join(root, "not-a-skill"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	// A directory with SKILL.md is a skill.
+	skillDir := filepath.Join(root, "alpha")
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const content = "---\nname: alpha\n---\nbody\n"
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte(content), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	names, err = s.List()
+	if err != nil {
+		t.Fatalf("List: %v", err)
+	}
+	if len(names) != 1 || names[0] != "alpha" {
+		t.Errorf("List = %v, want [alpha]", names)
+	}
+
+	got, err := s.Read("alpha")
+	if err != nil {
+		t.Fatalf("Read: %v", err)
+	}
+	if string(got) != content {
+		t.Errorf("Read = %q", string(got))
+	}
+}

--- a/internal/flightplan/store/testhelpers_test.go
+++ b/internal/flightplan/store/testhelpers_test.go
@@ -1,0 +1,25 @@
+package store
+
+import (
+	"errors"
+	"os/exec"
+	"testing"
+)
+
+var errClone = errors.New("clone failed")
+
+// gitAvailable reports whether the git binary is resolvable on PATH.
+func gitAvailable() bool {
+	_, err := exec.LookPath("git")
+	return err == nil
+}
+
+// mustGit runs a git command in dir and fails the test on error.
+func mustGit(t *testing.T, dir string, args ...string) {
+	t.Helper()
+	cmd := exec.Command("git", args...)
+	cmd.Dir = dir
+	if out, err := cmd.CombinedOutput(); err != nil {
+		t.Fatalf("git %v: %v: %s", args, err, string(out))
+	}
+}

--- a/internal/launch/agent.go
+++ b/internal/launch/agent.go
@@ -104,6 +104,21 @@ type Agent interface {
 	// Agents that have no vault-backed credentials return the zero
 	// value AuthSpec{}; the launcher treats that as a no-op.
 	AuthSpec() AuthSpec
+	// SkillsPath returns the container-side directory the agent reads
+	// installed Agent Skills from (e.g. "/home/agent/.claude/skills" for
+	// Claude Code). At sandbox launch the launcher bind-mounts the
+	// canonical host-side skill store read-only at this path, so a skill
+	// installed once via `aileron skill install` is visible to the agent
+	// wherever it launches (the install-once / launch-anywhere projection,
+	// #1508). Per-agent path differences are absorbed here, not by
+	// transpiling SKILL.md.
+	//
+	// An agent whose skills directory is not yet grounded returns "", and
+	// the launcher skips the skills mount for it. Projection is a v4
+	// container-model behavior: host launch (--local) lets the agent read
+	// its own native skills directory and the launcher does not mount over
+	// it.
+	SkillsPath() string
 }
 
 // Registry maps agent names to their definitions.

--- a/internal/launch/agent_test.go
+++ b/internal/launch/agent_test.go
@@ -62,3 +62,4 @@ func (a testAgent) ConfigureMCP(string, map[string]string, string, launch.Mode) 
 	return nil, nil, nil
 }
 func (a testAgent) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
+func (a testAgent) SkillsPath() string        { return "" }

--- a/internal/launch/agents/claude.go
+++ b/internal/launch/agents/claude.go
@@ -125,6 +125,12 @@ func (c Claude) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string, 
 	return []string{"--mcp-config", mcpConfig}, nil, nil
 }
 
+// SkillsPath returns Claude Code's container-side Agent Skills directory.
+// Claude Code reads personal skills from ~/.claude/skills, which under the
+// sandbox's /home/agent home is /home/agent/.claude/skills. The launcher
+// bind-mounts the canonical skill store read-only here at sandbox launch.
+func (c Claude) SkillsPath() string { return "/home/agent/.claude/skills" }
+
 // AuthSpec returns Claude's vault-backed credential descriptor per
 // ADR-0025.
 //

--- a/internal/launch/agents/codex.go
+++ b/internal/launch/agents/codex.go
@@ -114,6 +114,14 @@ func (c Codex) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string, m
 // persists the rotated bundle to vault, and hands Render the new
 // secret. AE6 invariant: the rotated bundle is in vault before
 // container start; a failed persist aborts the launch.
+// SkillsPath returns Codex's container-side Agent Skills directory. Codex
+// reads skills from ~/.codex/skills, which under the sandbox's /home/agent
+// home is /home/agent/.codex/skills — consistent with the .codex home
+// convention the rest of this adapter uses (config.toml, auth.json). The
+// launcher bind-mounts the canonical skill store read-only here at sandbox
+// launch.
+func (c Codex) SkillsPath() string { return "/home/agent/.codex/skills" }
+
 func (c Codex) AuthSpec() launch.AuthSpec {
 	return launch.AuthSpec{
 		FileBindings: []launch.FileBinding{{

--- a/internal/launch/agents/goose.go
+++ b/internal/launch/agents/goose.go
@@ -196,6 +196,11 @@ func gooseConfigDir() (string, error) {
 // nothing to snapshot back) and no PreLaunchRefresh (a static API key
 // does not rotate). Required is false so an unseeded vault falls through
 // to Goose's normal provider-key resolution instead of hard-failing.
+// SkillsPath returns "" because Goose's Agent Skills directory under the
+// sandbox is not yet grounded; the launcher skips the skills mount for it.
+// Wiring Goose's skills path is deferred until its layout is confirmed.
+func (g Goose) SkillsPath() string { return "" }
+
 func (g Goose) AuthSpec() launch.AuthSpec {
 	return launch.AuthSpec{
 		EnvBindings: []launch.EnvBinding{{

--- a/internal/launch/agents/opencode.go
+++ b/internal/launch/agents/opencode.go
@@ -93,6 +93,12 @@ func (o OpenCode) ConfigureMCP(mcpBin string, mcpEnv map[string]string, dir stri
 // ConfigureMCP writes a project-local `opencode.json` in the workspace
 // mount, not under the data dir, so no sibling mount needs to coexist
 // with auth.json.
+// SkillsPath returns "" because OpenCode's Agent Skills directory under
+// the sandbox is not yet grounded; the launcher skips the skills mount for
+// it. Wiring OpenCode's skills path is deferred until its layout is
+// confirmed.
+func (o OpenCode) SkillsPath() string { return "" }
+
 func (o OpenCode) AuthSpec() launch.AuthSpec {
 	return launch.AuthSpec{
 		FileBindings: []launch.FileBinding{{

--- a/internal/launch/agents/pi.go
+++ b/internal/launch/agents/pi.go
@@ -56,6 +56,11 @@ func (p Pi) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ string, _ la
 // clean exit. MountAsFile is false (the default): Pi's ConfigureMCP
 // passes MCP config via a CLI flag, not a file mount, so no sibling
 // mount needs to coexist with auth.json.
+// SkillsPath returns "" because Pi's Agent Skills directory under the
+// sandbox is not yet grounded; the launcher skips the skills mount for it.
+// Wiring Pi's skills path is deferred until its layout is confirmed.
+func (p Pi) SkillsPath() string { return "" }
+
 func (p Pi) AuthSpec() launch.AuthSpec {
 	return launch.AuthSpec{
 		FileBindings: []launch.FileBinding{{

--- a/internal/launch/agents/skills_path_test.go
+++ b/internal/launch/agents/skills_path_test.go
@@ -1,0 +1,32 @@
+package agents_test
+
+import (
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/launch/agents"
+)
+
+// TestSkillsPaths pins each agent's container-side Agent Skills directory.
+// Claude and Codex have grounded paths (the launcher bind-mounts the
+// canonical skill store read-only there at sandbox launch); the others
+// return "" until their skills layout is confirmed, which the launcher
+// treats as "skip the skills mount".
+func TestSkillsPaths(t *testing.T) {
+	tests := []struct {
+		name string
+		got  string
+		want string
+	}{
+		{"claude subscription", agents.NewClaude(agents.ClaudeAuthModeSubscription).SkillsPath(), "/home/agent/.claude/skills"},
+		{"claude apikey", agents.NewClaude(agents.ClaudeAuthModeAPIKey).SkillsPath(), "/home/agent/.claude/skills"},
+		{"codex", agents.Codex{}.SkillsPath(), "/home/agent/.codex/skills"},
+		{"goose", agents.Goose{}.SkillsPath(), ""},
+		{"opencode", agents.OpenCode{}.SkillsPath(), ""},
+		{"pi", agents.Pi{}.SkillsPath(), ""},
+	}
+	for _, tt := range tests {
+		if tt.got != tt.want {
+			t.Errorf("%s SkillsPath() = %q, want %q", tt.name, tt.got, tt.want)
+		}
+	}
+}

--- a/internal/launch/claude_auth_banner_test.go
+++ b/internal/launch/claude_auth_banner_test.go
@@ -22,6 +22,7 @@ func (a claudeModeAgent) ConfigureMCP(string, map[string]string, string, Mode) (
 	return nil, nil, nil
 }
 func (a claudeModeAgent) AuthSpec() AuthSpec               { return AuthSpec{} }
+func (a claudeModeAgent) SkillsPath() string               { return "" }
 func (a claudeModeAgent) AuthModeDisplay() AuthModeDisplay { return a.mode }
 
 func TestPrintClaudeAuthBanner_SandboxClaude(t *testing.T) {
@@ -92,3 +93,4 @@ func (emptyClaudeAgent) ConfigureMCP(string, map[string]string, string, Mode) ([
 	return nil, nil, nil
 }
 func (emptyClaudeAgent) AuthSpec() AuthSpec { return AuthSpec{} }
+func (emptyClaudeAgent) SkillsPath() string { return "" }

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -23,6 +23,7 @@ import (
 	"github.com/ALRubinger/aileron/internal/cstore"
 	"github.com/ALRubinger/aileron/internal/daemon/discovery"
 	"github.com/ALRubinger/aileron/internal/daemon/spawn"
+	skillstore "github.com/ALRubinger/aileron/internal/flightplan/store"
 	sandboxcomposition "github.com/ALRubinger/aileron/internal/sandbox/composition"
 	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
 	sandboxtoolchain "github.com/ALRubinger/aileron/internal/sandbox/toolchain"
@@ -1115,6 +1116,95 @@ func enclosingDirMount(mounts []sandboxcontainer.Volume, target string) *sandbox
 	return nil
 }
 
+// skillStoreDir is a package-level seam so tests can point the skills
+// projection at a temp store instead of the user's ~/.aileron/skills.
+var skillStoreDir = skillstore.DefaultDir
+
+// skillsStoreNonEmpty reports whether the canonical skill store at dir
+// holds at least one installed skill. An absent or empty store means
+// nothing to project.
+func skillsStoreNonEmpty(dir string) bool {
+	names, err := skillstore.New(dir).List()
+	return err == nil && len(names) > 0
+}
+
+// appendSkillsMount projects the canonical skill store read-only at the
+// agent's skills path. It is a no-op when the agent declares no skills path
+// (SkillsPath() == "") or the store is empty.
+//
+// When the agent's skills target is NOT nested inside an existing mount,
+// the store is added as a single read-only directory bind mount. When the
+// target nests inside an existing (AuthSpec) directory mount, the store
+// content is copied into that mount's host-side source so no nested bind
+// mount is created — the same hazard avoidance collapseNestedMCPMounts
+// applies for MCP config files (issue #1143: nested binds are rejected by
+// runc on macOS Docker Desktop virtiofs). The copy lands under the relative
+// subpath the target sits at within the parent mount.
+func appendSkillsMount(existing []sandboxcontainer.Volume, agent Agent, storeDir string) ([]sandboxcontainer.Volume, error) {
+	target := agent.SkillsPath()
+	if target == "" {
+		return existing, nil
+	}
+	if !skillsStoreNonEmpty(storeDir) {
+		return existing, nil
+	}
+
+	parent := enclosingDirMount(existing, target)
+	if parent == nil {
+		// No enclosing mount: a plain read-only directory bind is safe.
+		return append(existing, sandboxcontainer.Volume{
+			Source:   storeDir,
+			Target:   target,
+			ReadOnly: true,
+		}), nil
+	}
+
+	// The target nests inside an existing directory mount. Copy the store
+	// content into that mount's host-side source under the relative subpath
+	// rather than creating a nested bind. The agent reads the same files at
+	// the same in-container path; nesting is avoided.
+	rel := strings.TrimPrefix(target, parent.Target)
+	rel = strings.TrimPrefix(rel, "/")
+	dst := filepath.Join(parent.Source, rel)
+	if err := os.MkdirAll(dst, 0o755); err != nil {
+		return nil, fmt.Errorf("create skills dir %s: %w", dst, err)
+	}
+	if err := copySkillTree(storeDir, dst); err != nil {
+		return nil, err
+	}
+	return existing, nil
+}
+
+// copySkillTree recursively copies the regular files and subdirectories
+// under src into dst. Symlinks and other non-regular files are skipped.
+func copySkillTree(src, dst string) error {
+	return filepath.Walk(src, func(p string, info os.FileInfo, err error) error {
+		if err != nil {
+			return err
+		}
+		rel, err := filepath.Rel(src, p)
+		if err != nil {
+			return err
+		}
+		target := filepath.Join(dst, rel)
+		switch {
+		case info.IsDir():
+			return os.MkdirAll(target, 0o755)
+		case info.Mode().IsRegular():
+			data, err := os.ReadFile(p)
+			if err != nil {
+				return err
+			}
+			if err := os.MkdirAll(filepath.Dir(target), 0o755); err != nil {
+				return err
+			}
+			return os.WriteFile(target, data, info.Mode().Perm())
+		default:
+			return nil
+		}
+	})
+}
+
 // chownAuthTree, when non-nil, recursively chowns the AuthSpec transient
 // tree to the resolved in-container agent UID. The launcher invokes it
 // AFTER collapseNestedMCPMounts has placed the agent's MCP config into
@@ -1181,6 +1271,18 @@ func launchSandbox(ctx context.Context, plan SandboxLaunchPlan, config LaunchCon
 		return LaunchResult{}, fmt.Errorf("placing MCP config for %s: %w", config.Agent.Name(), err)
 	}
 	mounts = collapsed
+
+	// Project the canonical skill store read-only at the agent's skills
+	// path (install-once / launch-anywhere, #1508). This runs BEFORE the
+	// chown for the same reason the MCP collapse does: when the skills
+	// target nests inside an AuthSpec directory mount (Claude's writable
+	// /home/agent/.claude/), the store content is copied into that mount's
+	// host-side source and must be in place before the tree is re-owned to
+	// the foreign agent UID.
+	mounts, err = appendSkillsMount(mounts, config.Agent, skillStoreDir())
+	if err != nil {
+		return LaunchResult{}, fmt.Errorf("projecting skills for %s: %w", config.Agent.Name(), err)
+	}
 
 	// Chown the AuthSpec transient tree to the in-container agent UID now
 	// that the MCP config has been placed into it (issue #1488). The chown

--- a/internal/launch/launcher.go
+++ b/internal/launch/launcher.go
@@ -1163,6 +1163,13 @@ func appendSkillsMount(existing []sandboxcontainer.Volume, agent Agent, storeDir
 	// content into that mount's host-side source under the relative subpath
 	// rather than creating a nested bind. The agent reads the same files at
 	// the same in-container path; nesting is avoided.
+	//
+	// Read-only semantics in the nested case: the enclosing AuthSpec mount
+	// may be writable (Claude's /home/agent/.claude/ is, for credential
+	// rotation), so the copied skills are not RO at the mount level. The
+	// canonical store is still protected because this is a per-launch COPY,
+	// not a bind back to ~/.aileron/skills: any in-container edit dies with
+	// the ephemeral container and never reaches the canonical store.
 	rel := strings.TrimPrefix(target, parent.Target)
 	rel = strings.TrimPrefix(rel, "/")
 	dst := filepath.Join(parent.Source, rel)

--- a/internal/launch/launcher_internal_test.go
+++ b/internal/launch/launcher_internal_test.go
@@ -29,6 +29,7 @@ func (emptyBinaryAgent) ConfigureMCP(string, map[string]string, string, Mode) ([
 	return nil, nil, nil
 }
 func (emptyBinaryAgent) AuthSpec() AuthSpec { return AuthSpec{} }
+func (emptyBinaryAgent) SkillsPath() string { return "" }
 
 type namedBinaryAgent struct{ name string }
 
@@ -41,6 +42,7 @@ func (a namedBinaryAgent) ConfigureMCP(string, map[string]string, string, Mode) 
 	return nil, nil, nil
 }
 func (a namedBinaryAgent) AuthSpec() AuthSpec { return AuthSpec{} }
+func (a namedBinaryAgent) SkillsPath() string { return "" }
 
 // publishedNameAgent reports its name as a published agent id (e.g. "claude")
 // so Discover/EnrichValidateError treat it as having a published per-agent
@@ -56,6 +58,7 @@ func (a publishedNameAgent) ConfigureMCP(string, map[string]string, string, Mode
 	return nil, nil, nil
 }
 func (a publishedNameAgent) AuthSpec() AuthSpec { return AuthSpec{} }
+func (a publishedNameAgent) SkillsPath() string { return "" }
 
 func TestFirstAgentBinaryHandlesEmptyAgent(t *testing.T) {
 	if got := firstAgentBinary(emptyBinaryAgent{}); got != "" {

--- a/internal/launch/launcher_test.go
+++ b/internal/launch/launcher_test.go
@@ -134,6 +134,7 @@ func (a scriptAgent) ConfigureMCP(string, map[string]string, string, launch.Mode
 	return a.mcpArgs, nil, nil
 }
 func (a scriptAgent) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
+func (a scriptAgent) SkillsPath() string        { return "" }
 
 func TestLaunch_AgentEnvVarsFlowThrough(t *testing.T) {
 	dir := t.TempDir()
@@ -1624,6 +1625,7 @@ func (claudeTestAgent) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ s
 	return []string{"--mcp-config", `{"mcpServers":{"aileron":{"command":"` + mcpBin + `","env":` + envJSON + `}}}`}, nil, nil
 }
 func (claudeTestAgent) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
+func (claudeTestAgent) SkillsPath() string        { return "" }
 
 type piTestAgent struct{}
 
@@ -1637,6 +1639,7 @@ func (piTestAgent) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ strin
 	return []string{"--mcp-config", `{"mcpServers":{"aileron":{"command":"` + mcpBin + `","env":` + envJSON + `}}}`}, nil, nil
 }
 func (piTestAgent) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
+func (piTestAgent) SkillsPath() string        { return "" }
 
 type gooseTestAgent struct{}
 
@@ -1660,6 +1663,7 @@ func (gooseTestAgent) ConfigureMCP(mcpBin string, mcpEnv map[string]string, _ st
 	return []string{"--with-extension", strings.Join(parts, " ")}, nil, nil
 }
 func (gooseTestAgent) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
+func (gooseTestAgent) SkillsPath() string        { return "" }
 
 type openCodeTestAgent struct{}
 
@@ -1678,6 +1682,7 @@ func (openCodeTestAgent) ConfigureMCP(mcpBin string, mcpEnv map[string]string, d
 	return nil, nil, os.WriteFile(filepath.Join(dir, "opencode.json"), []byte(body), 0o644)
 }
 func (openCodeTestAgent) AuthSpec() launch.AuthSpec { return launch.AuthSpec{} }
+func (openCodeTestAgent) SkillsPath() string        { return "" }
 
 // t1 is a tiny *testing.T-shaped stand-in used by the test stubs above
 // to forward fatal failures. The real agent definitions use t.Fatal

--- a/internal/launch/skills_mount_test.go
+++ b/internal/launch/skills_mount_test.go
@@ -1,0 +1,143 @@
+package launch
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	sandboxcontainer "github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// installSkill writes a minimal SKILL.md under dir/<name>/ so the store's
+// List sees it as an installed skill.
+func installSkill(t *testing.T, storeDir, name string) {
+	t.Helper()
+	skillDir := filepath.Join(storeDir, name)
+	if err := os.MkdirAll(skillDir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(skillDir, "SKILL.md"), []byte("---\nname: "+name+"\n---\nbody\n"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+// skillsAgent is a minimal Agent whose only relevant behavior is its
+// SkillsPath; the appendSkillsMount logic depends on nothing else.
+type skillsAgent struct {
+	name string
+	path string
+}
+
+func (a skillsAgent) Name() string           { return a.name }
+func (a skillsAgent) BinaryNames() []string  { return []string{a.name} }
+func (a skillsAgent) Args(Mode) []string     { return nil }
+func (a skillsAgent) Env() map[string]string { return nil }
+func (a skillsAgent) LLMEndpointEnv() string { return "" }
+func (a skillsAgent) ConfigureMCP(string, map[string]string, string, Mode) ([]string, []MCPMount, error) {
+	return nil, nil, nil
+}
+func (a skillsAgent) AuthSpec() AuthSpec { return AuthSpec{} }
+func (a skillsAgent) SkillsPath() string { return a.path }
+
+func TestSkillsStoreNonEmpty(t *testing.T) {
+	dir := t.TempDir()
+	if skillsStoreNonEmpty(dir) {
+		t.Error("empty store should report not-non-empty")
+	}
+	installSkill(t, dir, "alpha")
+	if !skillsStoreNonEmpty(dir) {
+		t.Error("store with a skill should report non-empty")
+	}
+}
+
+func TestAppendSkillsMount_SkippedWhenNoPath(t *testing.T) {
+	dir := t.TempDir()
+	installSkill(t, dir, "alpha")
+	agent := skillsAgent{name: "noskills", path: ""}
+	mounts, err := appendSkillsMount(nil, agent, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mounts) != 0 {
+		t.Errorf("agent with no skills path must add no mount, got %v", mounts)
+	}
+}
+
+func TestAppendSkillsMount_SkippedWhenStoreEmpty(t *testing.T) {
+	dir := t.TempDir() // no skills installed
+	agent := skillsAgent{name: "claude", path: "/home/agent/.claude/skills"}
+	mounts, err := appendSkillsMount(nil, agent, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mounts) != 0 {
+		t.Errorf("empty store must add no mount, got %v", mounts)
+	}
+}
+
+func TestAppendSkillsMount_ReadOnlyBindWhenNotNested(t *testing.T) {
+	dir := t.TempDir()
+	installSkill(t, dir, "alpha")
+	agent := skillsAgent{name: "codex", path: "/home/agent/.codex/skills"}
+
+	// Existing mounts that do NOT enclose the skills target.
+	existing := []sandboxcontainer.Volume{
+		{Source: "/host/auth.json", Target: "/home/agent/.codex/auth.json", ReadOnly: false},
+	}
+	mounts, err := appendSkillsMount(existing, agent, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mounts) != 2 {
+		t.Fatalf("expected the skills mount appended, got %v", mounts)
+	}
+	got := mounts[1]
+	if got.Target != "/home/agent/.codex/skills" || got.Source != dir || !got.ReadOnly {
+		t.Errorf("skills mount = %+v, want read-only %s -> /home/agent/.codex/skills", got, dir)
+	}
+}
+
+func TestAppendSkillsMount_CopiesIntoEnclosingDirMount(t *testing.T) {
+	dir := t.TempDir()
+	installSkill(t, dir, "alpha")
+	agent := skillsAgent{name: "claude", path: "/home/agent/.claude/skills"}
+
+	// Claude's AuthSpec mounts /home/agent/.claude as a writable directory.
+	// The skills target nests inside it, so the store content must be
+	// copied into the parent's host source rather than added as a nested
+	// bind (issue #1143 hazard avoidance).
+	authHostDir := t.TempDir()
+	existing := []sandboxcontainer.Volume{
+		{Source: authHostDir, Target: "/home/agent/.claude", ReadOnly: false},
+	}
+	mounts, err := appendSkillsMount(existing, agent, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mounts) != 1 {
+		t.Fatalf("nested skills must not add a new mount, got %v", mounts)
+	}
+	// The store content landed under the parent mount's host source at the
+	// relative subpath (skills/).
+	copied := filepath.Join(authHostDir, "skills", "alpha", "SKILL.md")
+	if _, err := os.Stat(copied); err != nil {
+		t.Errorf("skill content not copied into enclosing mount: %v", err)
+	}
+}
+
+func TestAppendSkillsMount_SingleReadOnlyBindForGroundedAgent(t *testing.T) {
+	// With no pre-existing mounts, a grounded agent gets exactly one
+	// read-only skills bind at its skills path. (The host launch path never
+	// calls this helper — projection is a sandbox-mode behavior — so the
+	// agent on the host reads its own native skills dir untouched.)
+	dir := t.TempDir()
+	installSkill(t, dir, "alpha")
+	agent := skillsAgent{name: "claude", path: "/home/agent/.claude/skills"}
+	mounts, err := appendSkillsMount(nil, agent, dir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(mounts) != 1 || mounts[0].Target != "/home/agent/.claude/skills" {
+		t.Errorf("expected a single read-only skills mount, got %v", mounts)
+	}
+}


### PR DESCRIPTION
## Summary

Implements the Flight Plan format/install sub-layer (#1508): a `SKILL.md`-format skill becomes installable and its `requires:[aileron:<connector>.<action>]` references resolvable, for both instruction-only and credentialed skills, with no determinism guarantees (that is the Flight-Plan-core tranche).

New `internal/flightplan` packages (independently testable, per the reuse-over-duplication convention):

- **`manifest`** — parses a SKILL.md (YAML frontmatter + Markdown body), detects instruction-only (no `aileron` block) vs present-but-invalid, and validates a present block against the embedded schema. The schema is a byte-identical copy of `docs/schema/flight-plan-manifest.schema.json` guarded by a drift test (the doc schema cannot be `go:embed`'d across the module boundary).
- **`resolver`** — the #1574 ref→action mapping: split `aileron:<connector>.<action>`, match the connector against the FQN tail of `Action.requires.connectors[].name`, match the action against `Action.name` with kebab/underscore normalization. Read-only over the existing `GET /v1/actions`; no OpenAPI or generated-code change. The daemon fetch is an injectable seam.
- **`store`** — the single host-side writer of `~/.aileron/skills/<name>/`. Install from local path or git URL. Degrade-not-block: unsatisfiable `requires:` warn and still install; instruction-only skills skip the resolver before any daemon call (so a daemon-down instruction-only install is clean and silent). Re-install overwrites (idempotent).

CLI: `aileron skill install <source>` / `aileron skill list`, wired into root dispatch + help.

Launch projection: `Agent.SkillsPath()` plus a read-only skills mount appended in `launchSandbox`. Claude (`/home/agent/.claude/skills`) and Codex (`/home/agent/.codex/skills`) are grounded; the others return `""` and are skipped. When the skills target nests inside an existing AuthSpec directory mount, the store content is copied into that mount's host source rather than added as a nested bind, avoiding the #1143 nested-bind hazard.

Docs: a new **Installing a Skill** guide + nav entry.

### Scope boundaries honored
- No determinism / step-graph / freeze / lock (that is #1509 / #1511). `steps`/`lock` parse if present but are not executed or frozen.
- No OpenAPI / generated-code change — resolver reads existing fields only.
- The agentskills.io slug source ships as a seam returning a clear not-wired error, with the wire contract filed as a named follow-up (#1583).
- Editing installed skills is an explicit future op; mounts are read-only.

### Credential isolation
The store and parser never read credential values; the trust contract declares kind/placement only and the resolver matches names. A parser test asserts no credential value leaks into the parsed trust contract.

## Test plan
- `go test ./internal/flightplan/...` — manifest (instruction-only, each missing-required-field case, valid worked example, schema drift guard), resolver (satisfiable/unsatisfiable/normalization/FQN-tail/empty-list + HTTP fetcher), store (instruction-only clean, satisfiable no-degrade, unsatisfiable still-installs, **instruction-only + daemon-down asserts the resolver seam is NOT called**, git-URL via a local bare repo, slug not-wired, accompanying-file copy).
- `go test ./cmd/aileron/...` — install instruction-only (silent, no daemon client constructed), credentialed satisfiable (no warning), unsatisfiable (warns, exit 0), daemon-down credentialed degrades not fails, `skill list` sorted/empty, dispatch + help.
- `go test ./internal/launch/...` — per-agent `SkillsPath()`, skills-mount appended read-only when store non-empty, skipped when empty or agent has no path, nested-target copy into the enclosing AuthSpec mount.

All suites green locally on macOS.

> CodeRabbit review was rate-limited at PR-open time; a manual self-review pass found no P0s. I will re-run the CLI review once the limit resets.

Closes #1508