### PR TITLE
fix(systest): default claude EXPECTED_IMAGE to local non-publishable tag

### DIFF
--- a/test/system/claude.sh
+++ b/test/system/claude.sh
@@ -58,11 +58,18 @@ AUTH_PATH='/home/agent/.claude/.credentials.json'
 WORKSPACE_CONTAINER_PATH='/home/agent/workspace'
 SENTINEL_NAME='.aileron-systest-sentinel'
 
-# Image tag: a dev/empty version build pulls :edge, a release pulls :latest
-# (internal/sandbox/composition/composition.go imageTag). The system test
-# targets dev builds, so :edge is the default; override with EXPECTED_IMAGE
-# to assert a release image or a digest pin.
-EXPECTED_IMAGE="${EXPECTED_IMAGE:-ghcr.io/alrubinger/aileron-sandbox-${IMAGE_SUFFIX}:edge}"
+# Image: claude is recipe'd-but-NOT-publishable (#1451/#1585), so Discover's
+# no-.devcontainer branch resolves a LOCAL Feature build via
+# LocalAgentImageTag(agent, version) = `aileron/sandbox-agent-claude:<tag>`
+# (internal/sandbox/composition/composition.go:188-198, scaffold.go:106-108) —
+# a local-daemon-only repo with no registry host, NOT the GHCR published
+# convention. A dev/empty-version build resolves :edge and a release resolves
+# :latest (both via the shared imageTag()), on that same local repo. claude
+# never has a GHCR-published digest, so the digest-pin path (which applies to
+# publishable agents like codex via PublishedAgentImage) does not apply to it.
+# The system test targets dev builds, so :edge on the local repo is the
+# default; an explicit EXPECTED_IMAGE override still works for a pinned ref.
+EXPECTED_IMAGE="${EXPECTED_IMAGE:-aileron/sandbox-agent-${IMAGE_SUFFIX}:edge}"
 
 : "${AILERON_BIN:?AILERON_BIN must point at the built aileron binary}"
 : "${AILERON_SYSTEST_LIB:?AILERON_SYSTEST_LIB must point at test/system/lib}"

--- a/test/system/lib/probes_test.sh
+++ b/test/system/lib/probes_test.sh
@@ -133,6 +133,45 @@ image_ref_matches 'ghcr.io/alrubinger/aileron-sandbox-codex@sha256:abc' \
 	'ghcr.io/alrubinger/aileron-sandbox-codex@sha256:abc' >/dev/null 2>&1
 check "image_ref_matches accepts an exact digest override" "$?" 0
 
+# --- LOCAL (no registry host) tag: the recipe'd-but-not-publishable agent -----
+# claude (#1451/#1585) resolves LocalAgentImageTag = `aileron/sandbox-agent-
+# claude:<tag>` (composition.go:188-198, scaffold.go:106-108), a local-daemon
+# repo with NO registry host. The shared probe must derive the repo from the
+# actual ref and accept :edge/:latest on it, exactly as it does for the GHCR
+# repo — that is what lets claude reuse probes.sh verbatim. This locks that
+# contract so the R8.1 probe handles a host-less local tag.
+
+# image_repo strips :edge from a no-registry-host local ref.
+out="$(image_repo 'aileron/sandbox-agent-claude:edge')"
+assert_eq "aileron/sandbox-agent-claude" "$out" "image_repo strips :edge from a local ref" >/dev/null 2>&1
+check "image_repo strips the tag from a no-registry-host ref" "$?" 0
+
+# image_repo strips :latest from the same local ref (release-path tag).
+out="$(image_repo 'aileron/sandbox-agent-claude:latest')"
+assert_eq "aileron/sandbox-agent-claude" "$out" "image_repo strips :latest from a local ref" >/dev/null 2>&1
+check "image_repo strips :latest from a no-registry-host ref" "$?" 0
+
+# image_ref_matches accepts the local :edge tag on its own repo (claude default).
+image_ref_matches 'aileron/sandbox-agent-claude:edge' \
+	'aileron/sandbox-agent-claude:edge' >/dev/null 2>&1
+check "image_ref_matches accepts the local :edge tag on its own repo" "$?" 0
+
+# image_ref_matches accepts the local :latest tag on its own repo (release path).
+# claude has no GHCR-published digest, so :latest is the release shape here.
+image_ref_matches 'aileron/sandbox-agent-claude:latest' \
+	'aileron/sandbox-agent-claude:latest' >/dev/null 2>&1
+check "image_ref_matches accepts the local :latest tag on its own repo" "$?" 0
+
+# A wrong repo (codex) must still fail against the local claude expectation.
+image_ref_matches 'aileron/sandbox-agent-claude:edge' \
+	'aileron/sandbox-agent-codex:edge' >/dev/null 2>&1
+check "image_ref_matches rejects a different local agent repo" "$?" 1
+
+# A wrong (non-floating) tag on the right local repo must still fail.
+image_ref_matches 'aileron/sandbox-agent-claude:edge' \
+	'aileron/sandbox-agent-claude:v0.0.1' >/dev/null 2>&1
+check "image_ref_matches rejects an unexpected tag on the local repo" "$?" 1
+
 # --- probe_mcp_runtime: the agent-agnostic R8.2 core (binary + env) ----------
 # All sub-checks green: aileron-mcp present (test -x rc 0) and every daemon env
 # var set (printenv rc 0) -> returns 0.


### PR DESCRIPTION
## Summary

After #1585 (b367ad24), `claude` is recipe'd-but-not-publishable: Discover's no-`.devcontainer` branch resolves its image via `LocalAgentImageTag(agent, version)` = `aileron/sandbox-agent-claude:edge` (`internal/sandbox/composition/composition.go:188-198`, `scaffold.go:106-108`), a **local-daemon-only** tag with no registry host. But `test/system/claude.sh` still defaulted `EXPECTED_IMAGE` to the GHCR published convention `ghcr.io/alrubinger/aileron-sandbox-claude:edge`, and the Taskfile target passes no `EXPECTED_IMAGE` override, so the R8.1 `probe_image` assertion would fail on a real by-hand run.

`codex` stays publishable (`TierPublished` -> `PublishedAgentImage` -> GHCR) and is unaffected.

### Changes
- `test/system/claude.sh`: default `EXPECTED_IMAGE` to `aileron/sandbox-agent-claude:edge`; rewrite the tag comment to describe the non-publishable/local-build reality (dev -> `:edge`, release -> `:latest`, both on the local `aileron/sandbox-agent-claude` repo via the shared `imageTag()`; claude never has a GHCR-published digest, so the digest-pin path does not apply, though an explicit `EXPECTED_IMAGE` override still works).
- `test/system/lib/probes_test.sh`: regression cases proving `image_repo` strips the tag from a no-registry-host ref and `image_ref_matches` accepts `aileron/sandbox-agent-claude:edge` (and `:latest`) on its own repo while still rejecting a wrong repo/tag. Locks the contract that the shared probe handles a host-less local tag.

No probe-code change needed: `image_repo`/`image_ref_matches` already derive the repo from the actual ref and accept `:edge`/`:latest` on the matched repo.

## Test plan
- `sh test/system/lib/probes_test.sh` — green (baseline + 6 new local-tag cases).
- `task --dry test:system:launch:claude` — target compiles; confirms no `EXPECTED_IMAGE` override is injected, so the script default is authoritative.
- `shellcheck -s sh` — no warnings beyond benign SC1091 (sourced-file follow info).
- The live R8.1 `probe_image` assertion is exercised by the by-hand scenario run (STATIC GATE, needs a real Claude login + LLM tokens); it could not be executed headlessly, which is the pre-existing constraint documented in `test/system/README.md`.

Closes #1591

🤖 Generated with [Claude Code](https://claude.com/claude-code)
