### PR TITLE
fix(build): append host exe suffix to local build outputs

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,15 +5,6 @@ vars:
   # Single source of truth for Go test/vet package set, shared by local
   # (test:go, vet:go) and CI (test:go:ci) targets.
   GO_TEST_PACKAGES: ./internal/... ./cmd/aileron/... ./cmd/aileron-mcp/... ./sdk/go/...
-  # Host executable suffix from the canonical Go primitive: empty on
-  # Unix/macOS, ".exe" on Windows. The local host-arch build tasks pass an
-  # explicit `-o build/<name>`, so the toolchain writes that exact name and
-  # skips the platform `.exe` append it only performs when `-o` is absent.
-  # Appending {{.HOST_EXE}} keeps the built path matching what consumers
-  # (mcp:setup registration, system-test AILERON_BIN) expect on Windows while
-  # leaving Unix output unchanged by construction.
-  HOST_EXE:
-    sh: go env GOEXE
 
 tasks:
   default:
@@ -113,6 +104,14 @@ tasks:
       VERSION: dev
       COMMIT:
         sh: git rev-parse --short HEAD
+      # Host executable suffix from the canonical Go primitive: empty on
+      # Unix/macOS, ".exe" on Windows. An explicit `-o build/<name>` makes the
+      # toolchain write that exact name and skip the platform `.exe` append it
+      # only performs when `-o` is absent; appending {{.HOST_EXE}} restores it.
+      # Scoped per-task (not global) so Go-free targets like build:docs/webapp
+      # don't eagerly evaluate `go env`, matching build:mcp's HOST_GOOS/GOARCH.
+      HOST_EXE:
+        sh: go env GOEXE
     cmds:
       # Force a pure-Go build (CGO_ENABLED=0) to match .goreleaser.yml. The
       # binaries import no cgo, so an ambient CGO_ENABLED=1 only invites
@@ -132,6 +131,11 @@ tasks:
         sh: go env GOOS
       HOST_GOARCH:
         sh: go env GOARCH
+      # Empty on Unix/macOS, ".exe" on Windows. Appended only to the host-arch
+      # output below; the forced GOOS=linux sandbox sibling stays extensionless
+      # (it is bind-mounted into a Linux container).
+      HOST_EXE:
+        sh: go env GOEXE
     cmds:
       # Force a pure-Go build (CGO_ENABLED=0) to match .goreleaser.yml. The
       # inline assignment is required: go-task's task-level env: does NOT
@@ -153,6 +157,10 @@ tasks:
       VERSION: dev
       COMMIT:
         sh: git rev-parse --short HEAD
+      # Empty on Unix/macOS, ".exe" on Windows. Restores the suffix the toolchain
+      # skips when `-o` is given explicitly (see build:server for the full why).
+      HOST_EXE:
+        sh: go env GOEXE
     cmds:
       # Force a pure-Go build (CGO_ENABLED=0) to match .goreleaser.yml. The
       # inline assignment is required: go-task's task-level env: does NOT
@@ -194,6 +202,11 @@ tasks:
 
   mcp:setup:
     desc: Build and register the Aileron MCP server with Claude Code
+    vars:
+      # Match the path build:mcp wrote: ".exe" on Windows, empty elsewhere, so
+      # the registered MCP binary points at the file that actually exists.
+      HOST_EXE:
+        sh: go env GOEXE
     cmds:
       - task: build:mcp
       - claude mcp add --scope project aileron -e AILERON_URL=http://localhost:8080 -- ./build/aileron-mcp{{.HOST_EXE}}
@@ -617,6 +630,10 @@ tasks:
       # can't resolve /tmp under go-task's embedded shell on Windows. `unixEpoch`
       # + `randInt` replace `date +%s` and `$$` (no shell binary on PATH needed).
       WORKSPACE: '{{.TMPDIR | default .TEMP | default .TMP | default "/tmp"}}/aileron-smoke-{{now | unixEpoch}}-{{randInt 10000 99999}}'
+      # ".exe" on Windows, empty elsewhere, so the build:launch artifact check
+      # below tests the actual file the toolchain wrote (build/aileron.exe).
+      HOST_EXE:
+        sh: go env GOEXE
     cmds:
       - task: _test:system:precond:docker
         vars:
@@ -678,6 +695,10 @@ tasks:
       # env vars (TMPDIR/TEMP/TMP) as template vars for a writable temp root.
       SESSION: 'codex-{{now | unixEpoch}}-{{randInt 10000 99999}}'
       WORKSPACE: '{{.TMPDIR | default .TEMP | default .TMP | default "/tmp"}}/aileron-codex-{{now | unixEpoch}}-{{randInt 10000 99999}}'
+      # ".exe" on Windows, empty elsewhere. AILERON_BIN below must point at the
+      # file build:launch wrote; codex.sh invokes "$AILERON_BIN" launch directly.
+      HOST_EXE:
+        sh: go env GOEXE
     # Task-scoped env: go-task only honors `env:` at the task level, not on an
     # individual `cmds:` entry (a command-level `env:` is silently ignored), so
     # the scenario script must receive AILERON_BIN et al. from here. Keeping it
@@ -724,6 +745,10 @@ tasks:
       # env vars (TMPDIR/TEMP/TMP) as template vars for a writable temp root.
       SESSION: 'claude-{{now | unixEpoch}}-{{randInt 10000 99999}}'
       WORKSPACE: '{{.TMPDIR | default .TEMP | default .TMP | default "/tmp"}}/aileron-claude-{{now | unixEpoch}}-{{randInt 10000 99999}}'
+      # ".exe" on Windows, empty elsewhere. AILERON_BIN below must point at the
+      # file build:launch wrote; claude.sh invokes "$AILERON_BIN" launch directly.
+      HOST_EXE:
+        sh: go env GOEXE
     # Task-scoped env: go-task only honors `env:` at the task level, not on an
     # individual `cmds:` entry (a command-level `env:` is silently ignored), so
     # the scenario script must receive AILERON_BIN et al. from here. Keeping it

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -5,6 +5,15 @@ vars:
   # Single source of truth for Go test/vet package set, shared by local
   # (test:go, vet:go) and CI (test:go:ci) targets.
   GO_TEST_PACKAGES: ./internal/... ./cmd/aileron/... ./cmd/aileron-mcp/... ./sdk/go/...
+  # Host executable suffix from the canonical Go primitive: empty on
+  # Unix/macOS, ".exe" on Windows. The local host-arch build tasks pass an
+  # explicit `-o build/<name>`, so the toolchain writes that exact name and
+  # skips the platform `.exe` append it only performs when `-o` is absent.
+  # Appending {{.HOST_EXE}} keeps the built path matching what consumers
+  # (mcp:setup registration, system-test AILERON_BIN) expect on Windows while
+  # leaving Unix output unchanged by construction.
+  HOST_EXE:
+    sh: go env GOEXE
 
 tasks:
   default:
@@ -111,7 +120,7 @@ tasks:
       # Windows). The inline assignment is required: go-task's task-level env:
       # does NOT override a CGO_ENABLED already set in the OS environment, and a
       # cmd-level env: is silently ignored — a shell prefix always wins.
-      - CGO_ENABLED=0 go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron-server ./internal/server
+      - CGO_ENABLED=0 go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron-server{{.HOST_EXE}} ./internal/server
 
   build:mcp:
     desc: Build the Aileron MCP server binary locally (plus a Linux variant on macOS/Windows hosts so `aileron launch --sandbox=docker` can bind-mount it into the container)
@@ -128,7 +137,7 @@ tasks:
       # inline assignment is required: go-task's task-level env: does NOT
       # override a CGO_ENABLED already set in the OS environment, and a cmd-level
       # env: is silently ignored — a shell prefix always wins.
-      - CGO_ENABLED=0 go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron-mcp ./cmd/aileron-mcp
+      - CGO_ENABLED=0 go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron-mcp{{.HOST_EXE}} ./cmd/aileron-mcp
       # Sandbox launch bind-mounts aileron-mcp into a Linux container. On
       # non-Linux hosts the host-arch Mach-O / PE binary above fails with
       # exec format error; this second build produces a sibling the
@@ -149,7 +158,7 @@ tasks:
       # inline assignment is required: go-task's task-level env: does NOT
       # override a CGO_ENABLED already set in the OS environment, and a cmd-level
       # env: is silently ignored — a shell prefix always wins.
-      - CGO_ENABLED=0 go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron ./cmd/aileron
+      - CGO_ENABLED=0 go build -ldflags "-X github.com/ALRubinger/aileron/internal/version.Version={{.VERSION}} -X github.com/ALRubinger/aileron/internal/version.Commit={{.COMMIT}}" -o build/aileron{{.HOST_EXE}} ./cmd/aileron
 
   build:webapp:
     desc: Install webapp dependencies, build static output, copy into internal/app/webapp_dist for Go embed
@@ -187,7 +196,7 @@ tasks:
     desc: Build and register the Aileron MCP server with Claude Code
     cmds:
       - task: build:mcp
-      - claude mcp add --scope project aileron -e AILERON_URL=http://localhost:8080 -- ./build/aileron-mcp
+      - claude mcp add --scope project aileron -e AILERON_URL=http://localhost:8080 -- ./build/aileron-mcp{{.HOST_EXE}}
 
   up:
     desc: Start all services via Docker Compose
@@ -619,7 +628,7 @@ tasks:
       - |
         set -u
         # Prove build:launch produced the launch binary.
-        test -f build/aileron || { echo "build:launch did not produce build/aileron" >&2; exit 1; }
+        test -f build/aileron{{.HOST_EXE}} || { echo "build:launch did not produce build/aileron{{.HOST_EXE}}" >&2; exit 1; }
         # Seed a sentinel the deferred cleanup must remove.
         touch "{{.WORKSPACE}}/sentinel"
         test -f "{{.WORKSPACE}}/sentinel" || { echo "failed to seed sentinel" >&2; exit 1; }
@@ -674,7 +683,7 @@ tasks:
     # the scenario script must receive AILERON_BIN et al. from here. Keeping it
     # task-scoped also exports the vars to the `defer`/precond cmds uniformly.
     env:
-      AILERON_BIN: '{{.ROOT_DIR}}/build/aileron'
+      AILERON_BIN: '{{.ROOT_DIR}}/build/aileron{{.HOST_EXE}}'
       AILERON_SYSTEST_LIB: '{{.ROOT_DIR}}/test/system/lib'
       WORKSPACE: '{{.WORKSPACE}}'
       AILERON_STATE_DIR:
@@ -720,7 +729,7 @@ tasks:
     # the scenario script must receive AILERON_BIN et al. from here. Keeping it
     # task-scoped also exports the vars to the `defer`/precond cmds uniformly.
     env:
-      AILERON_BIN: '{{.ROOT_DIR}}/build/aileron'
+      AILERON_BIN: '{{.ROOT_DIR}}/build/aileron{{.HOST_EXE}}'
       AILERON_SYSTEST_LIB: '{{.ROOT_DIR}}/test/system/lib'
       WORKSPACE: '{{.WORKSPACE}}'
       AILERON_STATE_DIR:

--- a/test/system/lib/taskenv_test.sh
+++ b/test/system/lib/taskenv_test.sh
@@ -262,25 +262,62 @@ done
 # from the canonical `go env GOEXE` (empty on Unix/macOS, ".exe" on Windows) and
 # appends {{.HOST_EXE}} to the three host-arch outputs and every path that
 # consumes them. This section pins both halves:
-#   E1. structural — HOST_EXE is a global var sourced from `go env GOEXE`; the
-#       host-arch outputs and their consumers append it; the forced GOOS=linux
-#       sandbox sibling stays extensionless (it is bind-mounted into a Linux
-#       container, where a `.exe` suffix would be wrong).
+#   E1. structural — HOST_EXE is sourced from `go env GOEXE`; it is scoped
+#       per-task (NOT a top-level global var, whose eager `sh:` eval would break
+#       Go-free targets like build:docs/webapp); every task that references
+#       {{.HOST_EXE}} also defines it; the host-arch outputs and their consumers
+#       append it; and the forced GOOS=linux sandbox sibling stays extensionless
+#       (it is bind-mounted into a Linux container, where `.exe` would be wrong).
 #   E2. behavioral — with GOEXE=.exe (Windows), AILERON_BIN and the host-arch
 #       build `-o` flags resolve WITH the .exe suffix while the Linux sibling
 #       stays bare; with GOEXE empty (Unix), the outputs are unchanged.
 
-# E1a. HOST_EXE is a top-level var sourced from `go env GOEXE`.
-hostexe_def="$(awk '
+# E1a. Every HOST_EXE definition is sourced from `go env GOEXE`. Each `HOST_EXE:`
+# key in the file must be immediately followed by an `sh: go env GOEXE` child;
+# a literal or any other source would drift from the canonical host primitive.
+hostexe_defs="$(grep -c '^      HOST_EXE:' "$TASKFILE")"
+hostexe_goexe="$(grep -A1 '^      HOST_EXE:' "$TASKFILE" | grep -c 'sh: go env GOEXE')"
+if [ "$hostexe_defs" -ge 1 ] && [ "$hostexe_defs" -eq "$hostexe_goexe" ]; then
+	report "every HOST_EXE definition is sourced from \`go env GOEXE\` ($hostexe_defs found)" 0
+else
+	printf 'HOST_EXE defs=%s, go-env-GOEXE-sourced=%s (must be equal and >=1)\n' "$hostexe_defs" "$hostexe_goexe" >&2
+	report "every HOST_EXE definition is sourced from \`go env GOEXE\`" 1
+fi
+
+# E1a2. HOST_EXE is NOT a top-level (global) var. A global `sh:` var is evaluated
+# eagerly by go-task on EVERY task invocation, so a global `go env GOEXE` would
+# abort Go-free targets (build:docs, build:webapp, up) on a host without `go`.
+# The fix scopes it per-task instead; a 2-space-indented `HOST_EXE:` under the
+# top-level `vars:` block is the regression this guards against.
+global_hostexe="$(awk '
 	/^vars:[[:space:]]*$/ { invars = 1; next }
 	invars && /^[^ ]/ { invars = 0 }
-	invars && /^  HOST_EXE:/ { found = 1; next }
-	found && /^    sh:/ { print; found = 0 }
+	invars && /^  HOST_EXE:/ { print }
 ' "$TASKFILE")"
-case "$hostexe_def" in
-	*"go env GOEXE"*) report "HOST_EXE global var sourced from \`go env GOEXE\`" 0 ;;
-	*) report "HOST_EXE global var sourced from \`go env GOEXE\`" 1 ;;
-esac
+if [ -z "$global_hostexe" ]; then
+	report "HOST_EXE is NOT a top-level global var (no eager go-env on Go-free tasks)" 0
+else
+	report "HOST_EXE is NOT a top-level global var (no eager go-env on Go-free tasks)" 1
+fi
+
+# E1a3. Every task that REFERENCES {{.HOST_EXE}} also DEFINES it in its own vars.
+# A `{{.HOST_EXE}}` reference in a task that lacks a `HOST_EXE:` var resolves to
+# the empty string under go-task (no error), silently reintroducing the bug on
+# Windows. Walk each task block: if it mentions {{.HOST_EXE}}, it must also
+# declare `HOST_EXE:` at the 6-space var indent.
+ref_tasks="$(awk '
+	# A task header is a 2-space-indented name ending in `:` (names may contain
+	# internal colons, e.g. test:system:smoke), so strip only the trailing `:`.
+	/^  [a-zA-Z][a-zA-Z0-9:_-]*:[[:space:]]*$/ { name = $0; sub(/^  /, "", name); sub(/:[[:space:]]*$/, "", name) }
+	/\{\{\.HOST_EXE\}\}/ { if (name != "") print name }
+' "$TASKFILE" | sort -u)"
+for t in $ref_tasks; do
+	if block_for "$t" | grep -q '^      HOST_EXE:'; then
+		report "$t: references {{.HOST_EXE}} and defines it in task vars" 0
+	else
+		report "$t: references {{.HOST_EXE}} and defines it in task vars" 1
+	fi
+done
 
 # E1b. The three host-arch build outputs append {{.HOST_EXE}}. Each `-o` flag for
 # a host binary (server/mcp/cli) must be immediately followed by {{.HOST_EXE}};

--- a/test/system/lib/taskenv_test.sh
+++ b/test/system/lib/taskenv_test.sh
@@ -252,6 +252,124 @@ for t in test:system:smoke test:system:launch:codex test:system:launch:claude; d
 	done
 done
 
+# --- E. host-arch build outputs carry the host exe suffix (#1590) ------------
+# The local host-arch build tasks pass an explicit `-o build/<name>`, so the Go
+# toolchain writes that exact name and skips the platform `.exe` append it only
+# performs when `-o` is absent. On Windows that left build/aileron(.exe-less)
+# while mcp:setup registered ./build/aileron-mcp and the launch scenarios pointed
+# AILERON_BIN at build/aileron, none of which matched the file the toolchain
+# actually wrote (build/aileron.exe). The fix introduces a HOST_EXE var sourced
+# from the canonical `go env GOEXE` (empty on Unix/macOS, ".exe" on Windows) and
+# appends {{.HOST_EXE}} to the three host-arch outputs and every path that
+# consumes them. This section pins both halves:
+#   E1. structural — HOST_EXE is a global var sourced from `go env GOEXE`; the
+#       host-arch outputs and their consumers append it; the forced GOOS=linux
+#       sandbox sibling stays extensionless (it is bind-mounted into a Linux
+#       container, where a `.exe` suffix would be wrong).
+#   E2. behavioral — with GOEXE=.exe (Windows), AILERON_BIN and the host-arch
+#       build `-o` flags resolve WITH the .exe suffix while the Linux sibling
+#       stays bare; with GOEXE empty (Unix), the outputs are unchanged.
+
+# E1a. HOST_EXE is a top-level var sourced from `go env GOEXE`.
+hostexe_def="$(awk '
+	/^vars:[[:space:]]*$/ { invars = 1; next }
+	invars && /^[^ ]/ { invars = 0 }
+	invars && /^  HOST_EXE:/ { found = 1; next }
+	found && /^    sh:/ { print; found = 0 }
+' "$TASKFILE")"
+case "$hostexe_def" in
+	*"go env GOEXE"*) report "HOST_EXE global var sourced from \`go env GOEXE\`" 0 ;;
+	*) report "HOST_EXE global var sourced from \`go env GOEXE\`" 1 ;;
+esac
+
+# E1b. The three host-arch build outputs append {{.HOST_EXE}}. Each `-o` flag for
+# a host binary (server/mcp/cli) must be immediately followed by {{.HOST_EXE}};
+# a bare `-o build/aileron ` (no suffix) is the pre-fix regression.
+for spec in 'aileron-server' 'aileron-mcp' 'aileron'; do
+	# Match the host-arch line: `-o build/<name>{{.HOST_EXE}} `. The mcp name is a
+	# prefix of the linux sibling and `aileron` a prefix of both others, so anchor
+	# on the trailing `{{.HOST_EXE}} ` to avoid cross-matching.
+	if grep -qE "\-o build/${spec}\{\{\.HOST_EXE\}\} " "$TASKFILE"; then
+		report "build output build/${spec} appends {{.HOST_EXE}}" 0
+	else
+		report "build output build/${spec} appends {{.HOST_EXE}}" 1
+	fi
+	# Guard the regression directly: no bare `-o build/<name> ` (suffix-less)
+	# survives for a host target.
+	if grep -qE "\-o build/${spec} " "$TASKFILE"; then
+		report "no suffix-less -o build/${spec} remains (Windows regression)" 1
+	else
+		report "no suffix-less -o build/${spec} remains (Windows regression)" 0
+	fi
+done
+
+# E1c. The forced GOOS=linux sandbox sibling MUST stay extensionless — it is
+# bind-mounted into a Linux container.
+if grep -qE "\-o build/aileron-mcp-linux-\{\{\.HOST_GOARCH\}\} " "$TASKFILE"; then
+	report "linux sandbox sibling stays extensionless (no HOST_EXE)" 0
+else
+	report "linux sandbox sibling stays extensionless (no HOST_EXE)" 1
+fi
+
+# E1d. The consumers (mcp:setup registration, both launch scenarios' AILERON_BIN)
+# append {{.HOST_EXE}} so they match the built file on Windows.
+if grep -qE "mcp add .* \./build/aileron-mcp\{\{\.HOST_EXE\}\}" "$TASKFILE"; then
+	report "mcp:setup registers ./build/aileron-mcp{{.HOST_EXE}}" 0
+else
+	report "mcp:setup registers ./build/aileron-mcp{{.HOST_EXE}}" 1
+fi
+ailbin_count="$(grep -cE "AILERON_BIN: '\{\{\.ROOT_DIR\}\}/build/aileron\{\{\.HOST_EXE\}\}'" "$TASKFILE")"
+if [ "$ailbin_count" -eq 2 ]; then
+	report "both launch scenarios point AILERON_BIN at build/aileron{{.HOST_EXE}}" 0
+else
+	printf 'expected 2 AILERON_BIN+HOST_EXE refs, found %s\n' "$ailbin_count" >&2
+	report "both launch scenarios point AILERON_BIN at build/aileron{{.HOST_EXE}}" 1
+fi
+
+# E2. Behavioral: resolve a HOST_EXE-bearing template under a forced GOEXE and
+# confirm the suffix flows through. A tiny Taskfile mirrors the real var shape
+# (HOST_EXE from `go env GOEXE`) and a path that consumes it; we drive `go env
+# GOEXE` deterministically via GOOS so this is hermetic regardless of host OS.
+resolve_hostexe_path() {
+	# $1 = GOOS to force (windows -> .exe, the native value -> usually empty).
+	gen="$WORK/Taskfile.hostexe.yml"
+	{
+		echo "version: '3'"
+		echo "vars:"
+		echo "  HOST_EXE:"
+		echo "    sh: go env GOEXE"
+		echo "tasks:"
+		echo "  r:"
+		echo "    cmds:"
+		echo "      - 'echo RESOLVED=[build/aileron{{.HOST_EXE}}]'"
+	} >"$gen"
+	out="$(GOOS="$1" "$TASK_BIN" -t "$gen" r 2>/dev/null)"
+	printf '%s\n' "$out" | sed -n 's/.*RESOLVED=\[\(.*\)\].*/\1/p' | head -n1
+}
+
+if command -v go >/dev/null 2>&1; then
+	win_path="$(resolve_hostexe_path windows)"
+	if [ "$win_path" = "build/aileron.exe" ]; then
+		report "HOST_EXE resolves to .exe under GOOS=windows (path = build/aileron.exe)" 0
+	else
+		printf 'got Windows path [%s], expected [build/aileron.exe]\n' "$win_path" >&2
+		report "HOST_EXE resolves to .exe under GOOS=windows (path = build/aileron.exe)" 1
+	fi
+	# Native resolution: whatever this host's GOEXE is, the path must be a valid
+	# build/aileron(.exe)? form and, on a non-Windows host, suffix-less.
+	native_goexe="$(go env GOEXE)"
+	native_path="$(resolve_hostexe_path "$(go env GOOS)")"
+	if [ "$native_path" = "build/aileron${native_goexe}" ]; then
+		report "HOST_EXE resolves to host GOEXE natively (path = build/aileron${native_goexe})" 0
+	else
+		printf 'got native path [%s], expected [build/aileron%s]\n' "$native_path" "$native_goexe" >&2
+		report "HOST_EXE resolves to host GOEXE natively (path = build/aileron${native_goexe})" 1
+	fi
+else
+	# `go` is a hard prerequisite for these builds; its absence is a real gap.
+	report "go binary on PATH (required to resolve HOST_EXE behaviorally)" 1
+fi
+
 if [ "$failures" -ne 0 ]; then
 	printf '\n%s task-env wiring case(s) FAILED\n' "$failures" >&2
 	exit 1


### PR DESCRIPTION
## Summary

The local host-arch build tasks pass an explicit `-o build/<name>` with no extension, so the Go toolchain writes that exact name and skips the platform `.exe` append it only performs when `-o` is absent. On Windows that left `build/aileron` (no `.exe`) while `mcp:setup` registered `./build/aileron-mcp` and the launch scenarios pointed `AILERON_BIN` at `build/aileron` — none of which matched the file the toolchain actually wrote (`build/aileron.exe`). Released artifacts are unaffected because GoReleaser uses a logical `binary:` name.

This introduces a `HOST_EXE` var sourced from the canonical `go env GOEXE` (empty on Unix/macOS, `.exe` on Windows — verified: `GOOS=windows go env GOEXE` => `.exe`, native macOS => empty) and appends `{{.HOST_EXE}}` to:

- the three host-arch build outputs: `build:server`, `build:mcp`, `build:cli`
- the consumers of those paths: `mcp:setup` registration, the `test:system:smoke` assertion, both launch scenarios' `AILERON_BIN`

The forced `GOOS=linux` sandbox sibling (`build/aileron-mcp-linux-<arch>`) **stays extensionless** — it is bind-mounted into a Linux container where a `.exe` suffix would be wrong. Unix output is unchanged by construction (GOEXE is empty there).

### Why per-task, not a global var

`HOST_EXE` is scoped **per-task** on the seven tasks that consume it, not as a top-level global var. A global `vars:` entry with `sh: go env GOEXE` is evaluated **eagerly** by go-task on every task invocation, so it would abort Go-free targets (`build:docs`, `build:webapp`, `up`, `setup`) on a host without `go` on PATH with a cryptic `go: executable file not found`. Per-task scoping matches the existing precedent in `build:mcp`, which already sources `HOST_GOOS`/`HOST_GOARCH` from `go env` at task scope for exactly this reason. Verified: with `go` off PATH, `task build:docs` resolves (exit 0) where a global `HOST_EXE` aborts it.

## Test plan

- `task test:system:lib` (runs `test/system/lib/taskenv_test.sh`) — green. The suite gains a regression section (E) that:
  - asserts every `HOST_EXE` definition is sourced from `go env GOEXE` (7 found)
  - asserts `HOST_EXE` is **not** a top-level global var (no eager `go env` on Go-free tasks)
  - asserts every task referencing `{{.HOST_EXE}}` also defines it (an undefined reference resolves to empty under go-task, silently reintroducing the bug)
  - asserts each host output and consumer appends `{{.HOST_EXE}}` while the Linux sibling does not
  - behaviorally resolves the path under `GOOS=windows` (=> `build/aileron.exe`) and natively (=> host GOEXE)
- **Regression proof**: the new section fails on the pre-fix Taskfile (`origin/main`, no HOST_EXE) with 9 failing cases and exit 1; passes after the fix (exit 0).
- `task test:system:smoke` — passes.
- `task build:server build:mcp build:cli` on macOS — produces `build/aileron`, `build/aileron-mcp`, `build/aileron-server` (no `.exe`) and `build/aileron-mcp-linux-arm64` (Linux sibling preserved).
- Windows resolution verified via `GOOS=windows task --dry ...` => `-o build/aileron.exe`, `-o build/aileron-mcp.exe`, `mcp:setup` registers `./build/aileron-mcp.exe`, and the Linux sibling remains `-o build/aileron-mcp-linux-arm64`.

Closes #1590

🤖 Generated with [Claude Code](https://claude.com/claude-code)
