### PR TITLE
fix(flightplan): dedupe actionRef pattern and record amend-in-place nav decision

### DIFF
--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -11,6 +11,11 @@
   },
   "$comment": "The `aileron` block is optional at this top level so that a stripped manifest (the block removed) still validates. This encodes the lossless-if-stripped guarantee: the Aileron block is purely additive. An unsatisfied `requires:` is a missing-requirement signal resolved by the runtime, never a schema parse failure.",
   "$defs": {
+    "actionRef": {
+      "type": "string",
+      "description": "An action reference in the form aileron:<connector>.<action> (for example aileron:metrics.query_series). Per-site descriptions override this default.",
+      "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+    },
     "aileronBlock": {
       "type": "object",
       "description": "The single namespaced top-level key that holds every Aileron-specific field. Namespacing under one key keeps the extension lossless if stripped.",
@@ -70,9 +75,8 @@
       "required": ["ref", "trustContract"],
       "properties": {
         "ref": {
-          "type": "string",
-          "description": "The action reference in the form aileron:<connector>.<action> (for example aileron:metrics.query_series).",
-          "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+          "$ref": "#/$defs/actionRef",
+          "description": "The action reference in the form aileron:<connector>.<action> (for example aileron:metrics.query_series)."
         },
         "trustContract": { "$ref": "#/$defs/trustContract" }
       }
@@ -388,9 +392,8 @@
               "required": ["actionRef"],
               "properties": {
                 "actionRef": {
-                  "type": "string",
-                  "description": "The action reference whose result resolves this input, in the form aileron:<connector>.<action>.",
-                  "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+                  "$ref": "#/$defs/actionRef",
+                  "description": "The action reference whose result resolves this input, in the form aileron:<connector>.<action>."
                 },
                 "select": {
                   "type": "string",
@@ -495,9 +498,8 @@
           "description": "Invokes a declared action."
         },
         "actionRef": {
-          "type": "string",
-          "description": "The action this step invokes, in the form aileron:<connector>.<action>. MUST match a declared requires.actions[].ref.",
-          "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+          "$ref": "#/$defs/actionRef",
+          "description": "The action this step invokes, in the form aileron:<connector>.<action>. MUST match a declared requires.actions[].ref."
         },
         "args": {
           "type": "object",

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -8,6 +8,8 @@ The Flight Plan manifest is the machine-readable contract that both the authorin
 
 The manifest is the YAML frontmatter of a `SKILL.md` document in the [agentskills.io](https://agentskills.io) format, extended with a single Aileron-specific block. Every Aileron field lives under one namespaced top-level key so the extension is lossless if stripped. A host without Aileron reads a valid skill and treats the Aileron block as inert.
 
+The deterministic step-graph composition format is specified on this single page rather than a separate sibling page. It is one coherent format covered by one drift-guard test, amended in place under the [Composition and the step graph](#composition-and-the-step-graph) section below. The existing "Flight Plan Manifest Spec" navigation entry stands and no new navigation entry is added.
+
 This page is a spec deliverable. It defines the format. It does not ship a parser, a validator, the freeze step, or runtime enforcement. The Go parser and validator are tracked in [#1508](https://github.com/ALRubinger/aileron/issues/1508). Freeze is tracked in [#1509](https://github.com/ALRubinger/aileron/issues/1509). Runtime enforcement is tracked in [#1511](https://github.com/ALRubinger/aileron/issues/1511). The `lock` section is shaped here as freeze's target, not produced here.
 
 ## Schema

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -11,6 +11,11 @@
   },
   "$comment": "The `aileron` block is optional at this top level so that a stripped manifest (the block removed) still validates. This encodes the lossless-if-stripped guarantee: the Aileron block is purely additive. An unsatisfied `requires:` is a missing-requirement signal resolved by the runtime, never a schema parse failure.",
   "$defs": {
+    "actionRef": {
+      "type": "string",
+      "description": "An action reference in the form aileron:<connector>.<action> (for example aileron:metrics.query_series). Per-site descriptions override this default.",
+      "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+    },
     "aileronBlock": {
       "type": "object",
       "description": "The single namespaced top-level key that holds every Aileron-specific field. Namespacing under one key keeps the extension lossless if stripped.",
@@ -70,9 +75,8 @@
       "required": ["ref", "trustContract"],
       "properties": {
         "ref": {
-          "type": "string",
-          "description": "The action reference in the form aileron:<connector>.<action> (for example aileron:metrics.query_series).",
-          "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+          "$ref": "#/$defs/actionRef",
+          "description": "The action reference in the form aileron:<connector>.<action> (for example aileron:metrics.query_series)."
         },
         "trustContract": { "$ref": "#/$defs/trustContract" }
       }
@@ -388,9 +392,8 @@
               "required": ["actionRef"],
               "properties": {
                 "actionRef": {
-                  "type": "string",
-                  "description": "The action reference whose result resolves this input, in the form aileron:<connector>.<action>.",
-                  "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+                  "$ref": "#/$defs/actionRef",
+                  "description": "The action reference whose result resolves this input, in the form aileron:<connector>.<action>."
                 },
                 "select": {
                   "type": "string",
@@ -495,9 +498,8 @@
           "description": "Invokes a declared action."
         },
         "actionRef": {
-          "type": "string",
-          "description": "The action this step invokes, in the form aileron:<connector>.<action>. MUST match a declared requires.actions[].ref.",
-          "pattern": "^aileron:[a-z0-9][a-z0-9_-]*\\.[a-z0-9][a-z0-9_.-]*$"
+          "$ref": "#/$defs/actionRef",
+          "description": "The action this step invokes, in the form aileron:<connector>.<action>. MUST match a declared requires.actions[].ref."
         },
         "args": {
           "type": "object",

--- a/internal/flightplan/spec/schema_test.go
+++ b/internal/flightplan/spec/schema_test.go
@@ -649,6 +649,9 @@ func TestMalformedActionRefRejected(t *testing.T) {
 			if !ok {
 				continue
 			}
+			if _, has := src["actionRef"]; !has {
+				continue
+			}
 			src["actionRef"] = bad
 			return
 		}

--- a/internal/flightplan/spec/schema_test.go
+++ b/internal/flightplan/spec/schema_test.go
@@ -616,6 +616,60 @@ func TestStepActionRefsDeclared(t *testing.T) {
 	}
 }
 
+// TestMalformedActionRefRejected: an action reference that violates the
+// aileron:<connector>.<action> pattern is rejected at every site that carries
+// it. The three sites (requires.actions[].ref, an input resolution
+// source.actionRef, and an action-call step's actionRef) share one
+// $defs.actionRef definition, so this exercises the shared pattern at each
+// place it is referenced.
+func TestMalformedActionRefRejected(t *testing.T) {
+	sch := compileSchema(t)
+	const bad = "metrics.query_series" // missing the required aileron: prefix
+
+	atActionRequirement := func(inst map[string]any) {
+		actions := aileronBlock(t, inst)["requires"].(map[string]any)["actions"].([]any)
+		actions[0].(map[string]any)["ref"] = bad
+	}
+	atActionCallStep := func(inst map[string]any) {
+		for _, s := range steps(t, inst) {
+			if s["kind"] == "action-call" {
+				s["actionRef"] = bad
+				return
+			}
+		}
+		t.Fatal("expected the worked example to carry at least one action-call step")
+	}
+	atResolutionSource := func(inst map[string]any) {
+		for _, in := range aileronBlock(t, inst)["inputs"].([]any) {
+			res, ok := in.(map[string]any)["resolution"].(map[string]any)
+			if !ok {
+				continue
+			}
+			src, ok := res["source"].(map[string]any)
+			if !ok {
+				continue
+			}
+			src["actionRef"] = bad
+			return
+		}
+		t.Skip("worked example carries no source-resolved input to mutate")
+	}
+
+	for name, mutate := range map[string]func(map[string]any){
+		"requires.actions[].ref":      atActionRequirement,
+		"action-call step actionRef":  atActionCallStep,
+		"resolution source actionRef": atResolutionSource,
+	} {
+		t.Run(name, func(t *testing.T) {
+			inst := validExampleInstance(t)
+			mutate(inst)
+			if err := sch.Validate(inst); err == nil {
+				t.Fatalf("a malformed actionRef %q at %s must be rejected by the shared pattern", bad, name)
+			}
+		})
+	}
+}
+
 // TestStrippedManifestDropsSteps: removing the aileron block drops the step
 // graph with it, so the lossless-if-stripped guarantee covers the composition.
 // TestStrippedManifestStillValid already deletes the whole block; this sharpens


### PR DESCRIPTION
## Summary

Resolves the two remaining actionable findings from cw-review-residual #1573 (sub-issue #1572).

- **Schema dedupe (P2).** `docs/schema/flight-plan-manifest.schema.json` carried three literal copies of the action-reference pattern `^aileron:[a-z0-9][a-z0-9_-]*\.[a-z0-9][a-z0-9_.-]*$`. Extracted into a single `$defs.actionRef` string definition and `$ref`'d it from all three sites: `requires.actions[].ref`, `resolution.source.actionRef`, and the action-call step's `actionRef`. Each site keeps its own `description` (draft 2020-12 honors sibling keywords alongside `$ref`), overriding the shared default.
- **Nav decision recorded (P1).** Added one sentence to the Flight Plan Manifest Spec prose stating the step-graph composition format is amended in place on this single page (one coherent format, one drift-guard test), not a separate sibling page, and that the existing `navigation.ts` "Flight Plan Manifest Spec" entry stands with no new entry added.

## Test plan

- Added `TestMalformedActionRefRejected` to `internal/flightplan/spec/schema_test.go`: a malformed actionRef is rejected at all three `$ref` sites, exercising the shared `$defs.actionRef` pattern at each place it is referenced.
- `go test ./internal/flightplan/spec/` passes (drift-guard validates the worked example against the deduped schema; existing happy-path and negative tests unchanged).
- `go build ./internal/...` and `go vet ./internal/flightplan/spec/` clean.

Closes #1573

🤖 Generated with [Claude Code](https://claude.com/claude-code)
