### PR TITLE
feat(flightplan): freeze/crystallization seals a skill into a Flight Plan

### DIFF
--- a/cmd/aileron/main.go
+++ b/cmd/aileron/main.go
@@ -244,6 +244,7 @@ func usage(w io.Writer, registry *launch.Registry) {
 	fmt.Fprintln(w, "  aileron action run <NAME>          Invoke an installed action directly")
 	fmt.Fprintln(w, "  aileron skill install <source>     Install a skill (local path or git URL) into ~/.aileron/skills")
 	fmt.Fprintln(w, "  aileron skill list                 List installed skills (mounted read-only at launch)")
+	fmt.Fprintln(w, "  aileron skill freeze <name>        Seal an installed skill into a signed, pinned Flight Plan version")
 	fmt.Fprintln(w, "  aileron keyring trust <auth> <key> Authorize a publisher's signing key for installs")
 	fmt.Fprintln(w, "  aileron keyring list               List trusted publishers and key fingerprints")
 	fmt.Fprintln(w, "  aileron keyring revoke <auth>      Remove a publisher's keys from the trust list")

--- a/cmd/aileron/skill.go
+++ b/cmd/aileron/skill.go
@@ -13,7 +13,8 @@ import (
 
 const skillUsage = `usage:
   aileron skill install <source>   Install a skill from a local path or git URL into ~/.aileron/skills
-  aileron skill list               List installed skills`
+  aileron skill list               List installed skills
+  aileron skill freeze <name>      Seal an installed skill into a signed, digest-pinned Flight Plan version`
 
 // skillStoreDir is a seam so tests can point the CLI at a temp store
 // instead of the user's real ~/.aileron/skills.
@@ -45,6 +46,8 @@ func runSkill(args []string, stdout, stderr io.Writer) int {
 		return runSkillInstall(args[1:], stdout, stderr)
 	case "list":
 		return runSkillList(args[1:], stdout, stderr)
+	case "freeze":
+		return runSkillFreeze(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown skill command: %q\n", args[0])
 		fmt.Fprintln(stderr, skillUsage)

--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -131,8 +131,10 @@ type imageInspector struct {
 }
 
 // newImageInspector builds an inspector over the real container runtime,
-// resolving the runtime name (erroring when none is on PATH).
-func newImageInspector() (imageInspector, error) {
+// resolving the runtime name (erroring when none is on PATH). It is a
+// package-level seam so CLI tests inject a fake-runner inspector and the
+// resolver/composer delegation runs without Docker.
+var newImageInspector = func() (imageInspector, error) {
 	runtimeName, err := container.ResolveRuntime(container.DefaultRuntime)
 	if err != nil {
 		return imageInspector{}, fmt.Errorf("resolve container runtime: %w", err)

--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -121,34 +121,63 @@ func frozenVersionID(contentHash string) string {
 	return h
 }
 
+// imageInspector drives the small set of container-runtime commands the
+// freeze resolvers need (pull, image inspect). It is the seam over
+// container.Runner + the resolved runtime name so the pull-then-inspect and
+// RepoDigests-then-Id fallback logic is unit-testable without Docker.
+type imageInspector struct {
+	runner  container.Runner
+	runtime string
+}
+
+// newImageInspector builds an inspector over the real container runtime,
+// resolving the runtime name (erroring when none is on PATH).
+func newImageInspector() (imageInspector, error) {
+	runtimeName, err := container.ResolveRuntime(container.DefaultRuntime)
+	if err != nil {
+		return imageInspector{}, fmt.Errorf("resolve container runtime: %w", err)
+	}
+	return imageInspector{runner: container.DefaultRunner(), runtime: runtimeName}, nil
+}
+
+// pull best-effort pulls ref. A failure is intentionally non-fatal: the
+// image may already be local, in which case the inspect still yields a
+// digest.
+func (in imageInspector) pull(ctx context.Context, ref string) {
+	_ = in.runner.Run(ctx, in.runtime, []string{"pull", ref}, io.Discard, io.Discard)
+}
+
+// inspectFormat runs `image inspect --format <format> <image>` and returns
+// its stdout.
+func (in imageInspector) inspectFormat(ctx context.Context, image, format string) ([]byte, error) {
+	var out bytes.Buffer
+	if err := in.runner.Run(ctx, in.runtime, []string{"image", "inspect", "--format", format, image}, &out, io.Discard); err != nil {
+		return nil, err
+	}
+	return out.Bytes(), nil
+}
+
 // runtimeDigestResolver resolves a rung-1 image reference to its digest by
 // pulling (best-effort) then inspecting RepoDigests through the shared
 // container Runner seam. It pins by digest, never by tag.
 type runtimeDigestResolver struct{}
 
 func (runtimeDigestResolver) ResolveDigest(ctx context.Context, ref string) (string, error) {
-	runner := container.DefaultRunner()
-	runtimeName, err := container.ResolveRuntime(container.DefaultRuntime)
+	in, err := newImageInspector()
 	if err != nil {
-		return "", fmt.Errorf("resolve container runtime: %w", err)
+		return "", err
 	}
-
-	// Best-effort pull so an image present only in a remote registry can be
-	// inspected. A pull failure is not fatal here: the image may already be
-	// local, in which case the inspect below still yields a digest.
-	_ = runner.Run(ctx, runtimeName, []string{"pull", ref}, io.Discard, io.Discard)
-
-	var out bytes.Buffer
-	if err := runner.Run(ctx, runtimeName, []string{"image", "inspect", "--format", "{{json .RepoDigests}}", ref}, &out, io.Discard); err != nil {
-		return "", fmt.Errorf("inspect image %q: %w", ref, err)
-	}
-	return digestFromRepoDigests(out.Bytes(), ref)
+	return in.resolveDigest(ctx, ref)
 }
 
-// resolvedRuntime resolves the default container runtime name, returning an
-// error when no supported runtime is on PATH.
-func resolvedRuntime() (string, error) {
-	return container.ResolveRuntime(container.DefaultRuntime)
+// resolveDigest is the seam-driven core of ResolveDigest.
+func (in imageInspector) resolveDigest(ctx context.Context, ref string) (string, error) {
+	in.pull(ctx, ref)
+	out, err := in.inspectFormat(ctx, ref, "{{json .RepoDigests}}")
+	if err != nil {
+		return "", fmt.Errorf("inspect image %q: %w", ref, err)
+	}
+	return digestFromRepoDigests(out, ref)
 }
 
 // digestFromRepoDigests extracts the `sha256:` digest from a docker
@@ -215,25 +244,21 @@ func repoOfRef(ref string) string {
 type builderFeatureComposer struct{}
 
 func (builderFeatureComposer) ComposeDigest(ctx context.Context, features []string) (string, error) {
+	in, err := newImageInspector()
+	if err != nil {
+		return "", err
+	}
 	// Compose the Features onto the Aileron base image via the standard
 	// composition Plan, build through the Builder, then resolve the built
-	// image's digest with the same digest resolver used for rung-1.
-	plan := composition.Plan{
-		Tier:     composition.TierDevcontainer,
-		Features: map[string]json.RawMessage{},
-	}
-	for _, f := range features {
-		plan.Features[f] = json.RawMessage("{}")
-	}
-
+	// image's digest with the same inspector used for rung-1.
 	b := container.Builder{
-		Runtime: container.DefaultRuntime,
-		Runner:  container.DefaultRunner(),
+		Runtime: in.runtime,
+		Runner:  in.runner,
 		Stdout:  io.Discard,
 		Stderr:  io.Discard,
 	}
 	result, err := b.Build(ctx, container.BuildOptions{
-		Plan:   plan,
+		Plan:   rung2Plan(features),
 		Policy: container.BuildPolicyAlways,
 	})
 	if err != nil {
@@ -241,32 +266,40 @@ func (builderFeatureComposer) ComposeDigest(ctx context.Context, features []stri
 	}
 	// The built image is a local tag; resolve it to a digest. A locally-built
 	// image typically has no RepoDigests, so fall back to its image Id.
-	return localImageDigest(ctx, result.Image)
+	return in.localImageDigest(ctx, result.Image)
+}
+
+// rung2Plan builds the composition Plan that composes the given
+// capability-unit Features onto the Aileron base image. Routing rung-2
+// through composition.Plan + the Builder keeps freeze on the same build
+// path the sandbox uses rather than a bespoke build.
+func rung2Plan(features []string) composition.Plan {
+	plan := composition.Plan{
+		Tier:     composition.TierDevcontainer,
+		Features: make(map[string]json.RawMessage, len(features)),
+	}
+	for _, f := range features {
+		plan.Features[f] = json.RawMessage("{}")
+	}
+	return plan
 }
 
 // localImageDigest resolves a locally-built image tag to a content digest.
 // It prefers the registry RepoDigests pin, then falls back to the local
 // image Id (also a `sha256:` content address) for an image that was never
 // pushed.
-func localImageDigest(ctx context.Context, image string) (string, error) {
-	runner := container.DefaultRunner()
-	runtimeName, err := resolvedRuntime()
-	if err != nil {
-		return "", fmt.Errorf("resolve container runtime: %w", err)
-	}
-
-	var rd bytes.Buffer
-	if err := runner.Run(ctx, runtimeName, []string{"image", "inspect", "--format", "{{json .RepoDigests}}", image}, &rd, io.Discard); err == nil {
-		if digest, derr := digestFromRepoDigests(rd.Bytes(), image); derr == nil {
+func (in imageInspector) localImageDigest(ctx context.Context, image string) (string, error) {
+	if rd, err := in.inspectFormat(ctx, image, "{{json .RepoDigests}}"); err == nil {
+		if digest, derr := digestFromRepoDigests(rd, image); derr == nil {
 			return digest, nil
 		}
 	}
 
-	var id bytes.Buffer
-	if err := runner.Run(ctx, runtimeName, []string{"image", "inspect", "--format", "{{.Id}}", image}, &id, io.Discard); err != nil {
+	id, err := in.inspectFormat(ctx, image, "{{.Id}}")
+	if err != nil {
 		return "", fmt.Errorf("resolve digest for built image %q: %w", image, err)
 	}
-	digest := strings.TrimSpace(id.String())
+	digest := strings.TrimSpace(string(id))
 	if !strings.HasPrefix(digest, "sha256:") {
 		return "", fmt.Errorf("built image %q reported a non-sha256 Id %q", image, digest)
 	}

--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -1,0 +1,274 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+	"github.com/ALRubinger/aileron/internal/sandbox/composition"
+	"github.com/ALRubinger/aileron/internal/sandbox/container"
+)
+
+// newDigestResolver and newFeatureComposer are package-level seams so CLI
+// tests exercise the freeze orchestration without a container runtime. The
+// production implementations wire container.DefaultRunner() (rung-1 image
+// inspect) and container.Builder (rung-2 Feature composition).
+var newDigestResolver = func() freeze.DigestResolver { return runtimeDigestResolver{} }
+var newFeatureComposer = func() freeze.FeatureComposer { return builderFeatureComposer{} }
+
+func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("skill freeze", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	signingKey := flags.String("signing-key", "", "Path to the PEM ed25519 signing key (falls back to $"+freeze.SigningKeyEnv+")")
+	version := flags.String("version", "", "Semver label recorded in the lock (for example 1.0.0)")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 1 {
+		fmt.Fprintln(stderr, skillUsage)
+		return 1
+	}
+	target := flags.Arg(0)
+
+	raw, err := readSkillForFreeze(target)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	res, err := freeze.Run(context.Background(), raw, freeze.Options{
+		Version:        *version,
+		SigningKeyPath: *signingKey,
+		Resolver:       newDigestResolver(),
+		Composer:       newFeatureComposer(),
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	// Persist the frozen version into the canonical store. The version
+	// directory id is the short contentHash so distinct content lands in
+	// distinct, immutable directories.
+	s := store.New(skillStoreDir)
+	id := frozenVersionID(res.ContentHash)
+	if err := s.WriteFrozen(res.Name, store.FrozenVersion{
+		ID:        id,
+		SkillMD:   res.FrozenManifest,
+		Lockfile:  res.Lockfile,
+		Signature: res.Signature,
+		PublicKey: res.PublicKey,
+	}); err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Froze skill %q\n", res.Name)
+	if res.Version != "" {
+		fmt.Fprintf(stdout, "  Version:     %s\n", res.Version)
+	}
+	fmt.Fprintf(stdout, "  ContentHash: %s\n", res.ContentHash)
+	fmt.Fprintf(stdout, "  Stored at:   %s\n", s.FrozenDir(res.Name, id))
+	return 0
+}
+
+// readSkillForFreeze loads the SKILL.md bytes to freeze. The target is
+// either an installed skill name (read from the store) or a filesystem path
+// to a skill directory or a SKILL.md file.
+func readSkillForFreeze(target string) ([]byte, error) {
+	// A filesystem path (directory or SKILL.md) takes precedence when it
+	// exists, so a local author can freeze before installing.
+	if info, statErr := os.Stat(target); statErr == nil {
+		path := target
+		if info.IsDir() {
+			path = filepath.Join(target, "SKILL.md")
+		} else if filepath.Base(target) != "SKILL.md" {
+			return nil, fmt.Errorf("freeze source %q is not a SKILL.md", target)
+		}
+		b, readErr := os.ReadFile(path)
+		if readErr != nil {
+			return nil, fmt.Errorf("read %s: %w", path, readErr)
+		}
+		return b, nil
+	}
+
+	// Otherwise treat it as an installed skill name.
+	s := store.New(skillStoreDir)
+	b, readErr := s.Read(target)
+	if readErr != nil {
+		return nil, fmt.Errorf("no installed skill or path %q (install it first, or pass a path to a SKILL.md): %w", target, readErr)
+	}
+	return b, nil
+}
+
+// frozenVersionID derives the immutable store directory id from a
+// contentHash. It strips the `sha256:` prefix and takes a short, stable
+// slug so the directory name is filesystem-friendly while still being
+// collision-resistant for distinct content.
+func frozenVersionID(contentHash string) string {
+	h := strings.TrimPrefix(contentHash, "sha256:")
+	if len(h) > 16 {
+		h = h[:16]
+	}
+	return h
+}
+
+// runtimeDigestResolver resolves a rung-1 image reference to its digest by
+// pulling (best-effort) then inspecting RepoDigests through the shared
+// container Runner seam. It pins by digest, never by tag.
+type runtimeDigestResolver struct{}
+
+func (runtimeDigestResolver) ResolveDigest(ctx context.Context, ref string) (string, error) {
+	runner := container.DefaultRunner()
+	runtimeName, err := container.ResolveRuntime(container.DefaultRuntime)
+	if err != nil {
+		return "", fmt.Errorf("resolve container runtime: %w", err)
+	}
+
+	// Best-effort pull so an image present only in a remote registry can be
+	// inspected. A pull failure is not fatal here: the image may already be
+	// local, in which case the inspect below still yields a digest.
+	_ = runner.Run(ctx, runtimeName, []string{"pull", ref}, io.Discard, io.Discard)
+
+	var out bytes.Buffer
+	if err := runner.Run(ctx, runtimeName, []string{"image", "inspect", "--format", "{{json .RepoDigests}}", ref}, &out, io.Discard); err != nil {
+		return "", fmt.Errorf("inspect image %q: %w", ref, err)
+	}
+	return digestFromRepoDigests(out.Bytes(), ref)
+}
+
+// resolvedRuntime resolves the default container runtime name, returning an
+// error when no supported runtime is on PATH.
+func resolvedRuntime() (string, error) {
+	return container.ResolveRuntime(container.DefaultRuntime)
+}
+
+// digestFromRepoDigests extracts the `sha256:` digest from a docker
+// `RepoDigests` JSON array (for example
+// `["registry.example.com/runner@sha256:abc..."]`). When several entries
+// are present (the same image known under multiple repositories), it returns
+// the digest of the entry whose repository matches the requested ref, so
+// freeze never pins a digest for the wrong repository. It falls back to the
+// sole entry when there is exactly one. A local-only image with no
+// RepoDigests yields a clear error so freeze never silently pins nothing.
+func digestFromRepoDigests(jsonArr []byte, ref string) (string, error) {
+	var repoDigests []string
+	if err := json.Unmarshal(bytes.TrimSpace(jsonArr), &repoDigests); err != nil {
+		return "", fmt.Errorf("parse RepoDigests for %q: %w", ref, err)
+	}
+	wantRepo := repoOfRef(ref)
+	var soleDigest string
+	matched := 0
+	for _, rd := range repoDigests {
+		i := strings.LastIndex(rd, "@")
+		if i < 0 {
+			continue
+		}
+		repo, digest := rd[:i], rd[i+1:]
+		soleDigest = digest
+		matched++
+		if repoOfRef(repo) == wantRepo {
+			return digest, nil
+		}
+	}
+	if matched == 1 {
+		// A single RepoDigests entry under a different-looking repo string is
+		// still the right image (for example a registry-host normalization);
+		// pin it rather than failing.
+		return soleDigest, nil
+	}
+	if matched > 1 {
+		return "", fmt.Errorf("image %q has multiple registry digests and none match its repository; push a single-repository tag so freeze can pin it unambiguously", ref)
+	}
+	return "", fmt.Errorf("image %q has no registry digest (RepoDigests empty); push it to a registry so freeze can pin it by digest", ref)
+}
+
+// repoOfRef returns the repository portion of an image reference, stripping
+// any `:tag` or `@digest` suffix. A `:` that is part of a registry host port
+// (for example `registry.example.com:5000/runner`) is preserved because it
+// precedes the first `/`.
+func repoOfRef(ref string) string {
+	// Strip a digest suffix first.
+	if i := strings.Index(ref, "@"); i >= 0 {
+		ref = ref[:i]
+	}
+	// Strip a tag suffix: the last `:` that comes after the last `/`.
+	slash := strings.LastIndex(ref, "/")
+	if colon := strings.LastIndex(ref, ":"); colon > slash {
+		ref = ref[:colon]
+	}
+	return ref
+}
+
+// builderFeatureComposer composes a rung-2 capability-unit Feature set
+// through the container Builder (the #1454 build pipeline) and returns the
+// built image's digest. It routes rung-2 through the same Builder /
+// composition path the sandbox uses, not a bespoke build.
+type builderFeatureComposer struct{}
+
+func (builderFeatureComposer) ComposeDigest(ctx context.Context, features []string) (string, error) {
+	// Compose the Features onto the Aileron base image via the standard
+	// composition Plan, build through the Builder, then resolve the built
+	// image's digest with the same digest resolver used for rung-1.
+	plan := composition.Plan{
+		Tier:     composition.TierDevcontainer,
+		Features: map[string]json.RawMessage{},
+	}
+	for _, f := range features {
+		plan.Features[f] = json.RawMessage("{}")
+	}
+
+	b := container.Builder{
+		Runtime: container.DefaultRuntime,
+		Runner:  container.DefaultRunner(),
+		Stdout:  io.Discard,
+		Stderr:  io.Discard,
+	}
+	result, err := b.Build(ctx, container.BuildOptions{
+		Plan:   plan,
+		Policy: container.BuildPolicyAlways,
+	})
+	if err != nil {
+		return "", fmt.Errorf("compose rung-2 features: %w", err)
+	}
+	// The built image is a local tag; resolve it to a digest. A locally-built
+	// image typically has no RepoDigests, so fall back to its image Id.
+	return localImageDigest(ctx, result.Image)
+}
+
+// localImageDigest resolves a locally-built image tag to a content digest.
+// It prefers the registry RepoDigests pin, then falls back to the local
+// image Id (also a `sha256:` content address) for an image that was never
+// pushed.
+func localImageDigest(ctx context.Context, image string) (string, error) {
+	runner := container.DefaultRunner()
+	runtimeName, err := resolvedRuntime()
+	if err != nil {
+		return "", fmt.Errorf("resolve container runtime: %w", err)
+	}
+
+	var rd bytes.Buffer
+	if err := runner.Run(ctx, runtimeName, []string{"image", "inspect", "--format", "{{json .RepoDigests}}", image}, &rd, io.Discard); err == nil {
+		if digest, derr := digestFromRepoDigests(rd.Bytes(), image); derr == nil {
+			return digest, nil
+		}
+	}
+
+	var id bytes.Buffer
+	if err := runner.Run(ctx, runtimeName, []string{"image", "inspect", "--format", "{{.Id}}", image}, &id, io.Discard); err != nil {
+		return "", fmt.Errorf("resolve digest for built image %q: %w", image, err)
+	}
+	digest := strings.TrimSpace(id.String())
+	if !strings.HasPrefix(digest, "sha256:") {
+		return "", fmt.Errorf("built image %q reported a non-sha256 Id %q", image, digest)
+	}
+	return digest, nil
+}

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -1,0 +1,373 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+const fakeFreezeDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+// stubFreezeResolvers points the CLI's digest resolver + feature composer at
+// fakes that return a fixed digest, so freeze runs end-to-end without Docker.
+func stubFreezeResolvers(t *testing.T, digest string) {
+	t.Helper()
+	origDR, origFC := newDigestResolver, newFeatureComposer
+	newDigestResolver = func() freeze.DigestResolver {
+		return freeze.DigestResolverFunc(func(context.Context, string) (string, error) { return digest, nil })
+	}
+	newFeatureComposer = func() freeze.FeatureComposer {
+		return freeze.FeatureComposerFunc(func(context.Context, []string) (string, error) { return digest, nil })
+	}
+	t.Cleanup(func() { newDigestResolver, newFeatureComposer = origDR, origFC })
+}
+
+// writeSigningKey writes a fresh PKCS#8 ed25519 PEM key to a temp file and
+// returns its path.
+func writeSigningKey(t *testing.T) string {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatal(err)
+	}
+	path := filepath.Join(t.TempDir(), "key.pem")
+	if err := os.WriteFile(path, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	return path
+}
+
+// installExample copies the worked example into the temp store under its
+// name so `skill freeze <name>` can read it.
+func installExample(t *testing.T, storeDir string) {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRootForTest(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	dir := filepath.Join(storeDir, "weekly-metrics-digest")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), raw, 0o644); err != nil {
+		t.Fatal(err)
+	}
+}
+
+func TestRunSkillFreeze_HappyPath(t *testing.T) {
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "--version", "1.0.0", "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Froze skill \"weekly-metrics-digest\"") {
+		t.Errorf("stdout = %q", out)
+	}
+	if !strings.Contains(out, "ContentHash: sha256:") {
+		t.Errorf("stdout missing content hash: %q", out)
+	}
+
+	// A frozen version was written with a verifiable signature.
+	s := store.New(storeDir)
+	ids, err := s.FrozenVersions("weekly-metrics-digest")
+	if err != nil || len(ids) != 1 {
+		t.Fatalf("FrozenVersions = %v, %v", ids, err)
+	}
+	v, err := s.ReadFrozen("weekly-metrics-digest", ids[0])
+	if err != nil {
+		t.Fatalf("ReadFrozen: %v", err)
+	}
+	if len(v.Signature) == 0 || len(v.PublicKey) == 0 {
+		t.Error("frozen version missing signature/public key")
+	}
+	// The lockfile pins the digest, never a tag.
+	if !strings.Contains(string(v.Lockfile), fakeFreezeDigest) {
+		t.Errorf("lockfile must pin the digest:\n%s", v.Lockfile)
+	}
+	if !strings.Contains(string(v.SkillMD), "lock:") {
+		t.Errorf("frozen SKILL.md must carry the lock block:\n%s", v.SkillMD)
+	}
+	// The private key is never stored.
+	if _, err := os.Stat(filepath.Join(s.FrozenDir("weekly-metrics-digest", ids[0]), "signing-key.pem")); !os.IsNotExist(err) {
+		t.Error("the signing private key must never be written to the store")
+	}
+}
+
+func TestRunSkillFreeze_ReFreezeNewVersionKeepsPrior(t *testing.T) {
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+
+	var b1, e1 bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, "--version", "1.0.0", "weekly-metrics-digest"}, &b1, &e1); code != 0 {
+		t.Fatalf("first freeze exit=%d stderr=%s", code, e1.String())
+	}
+	var b2, e2 bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, "--version", "2.0.0", "weekly-metrics-digest"}, &b2, &e2); code != 0 {
+		t.Fatalf("second freeze exit=%d stderr=%s", code, e2.String())
+	}
+
+	s := store.New(storeDir)
+	ids, err := s.FrozenVersions("weekly-metrics-digest")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 2 {
+		t.Errorf("re-freeze with a different version must create a new version dir, got %d", len(ids))
+	}
+}
+
+func TestRunSkillFreeze_UnmarkedLLMFails(t *testing.T) {
+	storeDir := withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+
+	// A skill whose step kind is unknown (a smuggling vector).
+	const badMD = `---
+name: bad-skill
+description: Bad.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:x.y
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+  inputs: []
+  outputs: []
+  steps:
+    - id: sneaky
+      kind: not-a-kind
+---
+
+# Bad
+`
+	dir := filepath.Join(storeDir, "bad-skill")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(badMD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "bad-skill"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("freeze of a skill with a bad step kind must exit non-zero")
+	}
+	if !strings.Contains(stderr.String(), "error:") {
+		t.Errorf("expected an error on stderr, got: %s", stderr.String())
+	}
+}
+
+func TestRunSkillFreeze_MissingSigningKey(t *testing.T) {
+	storeDir := withTempStore(t)
+	installExample(t, storeDir)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	t.Setenv(freeze.SigningKeyEnv, "")
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"weekly-metrics-digest"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("freeze with no signing key must exit non-zero")
+	}
+	if !strings.Contains(stderr.String(), freeze.SigningKeyEnv) {
+		t.Errorf("error should mention the signing-key env, got: %s", stderr.String())
+	}
+}
+
+func TestRunSkillFreeze_InstructionStyleNoExecEnvStillSigns(t *testing.T) {
+	storeDir := withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+
+	const noEnvMD = `---
+name: no-env
+description: No execution environment.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:x.y
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+  inputs: []
+  outputs: []
+---
+
+# No Env
+`
+	dir := filepath.Join(storeDir, "no-env")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(noEnvMD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, "no-env"}, &stdout, &stderr); code != 0 {
+		t.Fatalf("no-exec-env freeze must succeed, exit=%d stderr=%s", code, stderr.String())
+	}
+	s := store.New(storeDir)
+	ids, err := s.FrozenVersions("no-env")
+	if err != nil || len(ids) != 1 {
+		t.Fatalf("FrozenVersions = %v, %v", ids, err)
+	}
+	v, err := s.ReadFrozen("no-env", ids[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(v.Signature) == 0 {
+		t.Error("no-exec-env skill must still be signed")
+	}
+}
+
+func TestRunSkillFreeze_FromPath(t *testing.T) {
+	withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	src := exampleSource(t) // a directory containing the worked example SKILL.md
+
+	var stdout, stderr bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, src}, &stdout, &stderr); code != 0 {
+		t.Fatalf("freeze from a path must succeed, exit=%d stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "Froze skill \"weekly-metrics-digest\"") {
+		t.Errorf("stdout = %q", stdout.String())
+	}
+}
+
+func TestRunSkillFreeze_UnknownTarget(t *testing.T) {
+	withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+
+	var stdout, stderr bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, "does-not-exist"}, &stdout, &stderr); code == 0 {
+		t.Error("freeze of an unknown target must exit non-zero")
+	}
+}
+
+func TestRunSkillFreeze_RequiresExactlyOneTarget(t *testing.T) {
+	withTempStore(t)
+	var stdout, stderr bytes.Buffer
+	if code := runSkillFreeze(nil, &stdout, &stderr); code != 1 {
+		t.Errorf("no target exit = %d, want 1", code)
+	}
+	if code := runSkillFreeze([]string{"a", "b"}, &stdout, &stderr); code != 1 {
+		t.Errorf("two targets exit = %d, want 1", code)
+	}
+}
+
+func TestRunSkillFreeze_BadFlag(t *testing.T) {
+	withTempStore(t)
+	var stdout, stderr bytes.Buffer
+	if code := runSkillFreeze([]string{"--nope"}, &stdout, &stderr); code != 1 {
+		t.Errorf("bad flag exit = %d, want 1", code)
+	}
+}
+
+func TestFrozenVersionID(t *testing.T) {
+	id := frozenVersionID("sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef")
+	if id != "0123456789abcdef" {
+		t.Errorf("frozenVersionID = %q", id)
+	}
+	if got := frozenVersionID("short"); got != "short" {
+		t.Errorf("short hash = %q", got)
+	}
+}
+
+func TestDigestFromRepoDigests(t *testing.T) {
+	in := []byte(`["registry.example.com/runner@sha256:` + strings.Repeat("a", 64) + `"]`)
+	got, err := digestFromRepoDigests(in, "registry.example.com/runner:1")
+	if err != nil {
+		t.Fatalf("digestFromRepoDigests: %v", err)
+	}
+	if got != "sha256:"+strings.Repeat("a", 64) {
+		t.Errorf("digest = %q", got)
+	}
+
+	// Empty RepoDigests is a clear error (never silently pins nothing).
+	if _, err := digestFromRepoDigests([]byte(`[]`), "x"); err == nil {
+		t.Error("empty RepoDigests must error")
+	}
+	// Malformed JSON errors.
+	if _, err := digestFromRepoDigests([]byte(`not json`), "x"); err == nil {
+		t.Error("malformed RepoDigests must error")
+	}
+}
+
+func TestDigestFromRepoDigests_MatchesRequestedRepo(t *testing.T) {
+	want := "sha256:" + strings.Repeat("a", 64)
+	other := "sha256:" + strings.Repeat("b", 64)
+	// Two repositories for the same image; the requested repo's digest wins.
+	in := []byte(`["mirror.example.com/runner@` + other + `","registry.example.com/runner@` + want + `"]`)
+	got, err := digestFromRepoDigests(in, "registry.example.com/runner:1.4")
+	if err != nil {
+		t.Fatalf("digestFromRepoDigests: %v", err)
+	}
+	if got != want {
+		t.Errorf("digest = %q, want the requested repo's digest %q", got, want)
+	}
+
+	// Multiple entries, none matching the requested repo: ambiguous, error
+	// rather than pinning the wrong repository.
+	if _, err := digestFromRepoDigests(in, "unrelated.example.com/thing:1"); err == nil {
+		t.Error("multiple non-matching RepoDigests must error rather than guess")
+	}
+}
+
+func TestRepoOfRef(t *testing.T) {
+	cases := map[string]string{
+		"registry.example.com/runner:1.4":             "registry.example.com/runner",
+		"registry.example.com:5000/runner:1.4":        "registry.example.com:5000/runner",
+		"registry.example.com/runner@sha256:" + "abc": "registry.example.com/runner",
+		"runner":                                "runner",
+		"registry.example.com:5000/team/runner": "registry.example.com:5000/team/runner",
+	}
+	for in, want := range cases {
+		if got := repoOfRef(in); got != want {
+			t.Errorf("repoOfRef(%q) = %q, want %q", in, got, want)
+		}
+	}
+}

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -388,6 +388,55 @@ func (f *fakeRunner) Run(_ context.Context, _ string, args []string, stdout, _ i
 	return nil
 }
 
+// withFakeInspector points newImageInspector at an inspector over the given
+// fake runner, so the production ResolveDigest/ComposeDigest wrappers run
+// their delegation without Docker.
+func withFakeInspector(t *testing.T, fr *fakeRunner) {
+	t.Helper()
+	orig := newImageInspector
+	newImageInspector = func() (imageInspector, error) {
+		return imageInspector{runner: fr, runtime: "docker"}, nil
+	}
+	t.Cleanup(func() { newImageInspector = orig })
+}
+
+func TestRuntimeDigestResolver_DelegatesThroughInspector(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	fr := &fakeRunner{outputs: map[string]string{
+		`image inspect --format {{json .RepoDigests}} img:1`: `["img@` + digest + `"]`,
+	}}
+	withFakeInspector(t, fr)
+	got, err := runtimeDigestResolver{}.ResolveDigest(context.Background(), "img:1")
+	if err != nil {
+		t.Fatalf("ResolveDigest: %v", err)
+	}
+	if got != digest {
+		t.Errorf("digest = %q", got)
+	}
+}
+
+func TestRuntimeDigestResolver_InspectorError(t *testing.T) {
+	orig := newImageInspector
+	newImageInspector = func() (imageInspector, error) {
+		return imageInspector{}, errTestInspect
+	}
+	t.Cleanup(func() { newImageInspector = orig })
+	if _, err := (runtimeDigestResolver{}).ResolveDigest(context.Background(), "img:1"); err == nil {
+		t.Error("an inspector-construction error must surface")
+	}
+}
+
+func TestBuilderFeatureComposer_InspectorError(t *testing.T) {
+	orig := newImageInspector
+	newImageInspector = func() (imageInspector, error) {
+		return imageInspector{}, errTestInspect
+	}
+	t.Cleanup(func() { newImageInspector = orig })
+	if _, err := (builderFeatureComposer{}).ComposeDigest(context.Background(), []string{"f"}); err == nil {
+		t.Error("an inspector-construction error must surface from ComposeDigest")
+	}
+}
+
 func TestImageInspector_ResolveDigest(t *testing.T) {
 	digest := "sha256:" + strings.Repeat("a", 64)
 	fr := &fakeRunner{outputs: map[string]string{

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -7,6 +7,8 @@ import (
 	"crypto/rand"
 	"crypto/x509"
 	"encoding/pem"
+	"errors"
+	"io"
 	"os"
 	"path/filepath"
 	"strings"
@@ -14,9 +16,15 @@ import (
 
 	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
 	"github.com/ALRubinger/aileron/internal/flightplan/store"
+	"github.com/ALRubinger/aileron/internal/sandbox/composition"
 )
 
 const fakeFreezeDigest = "sha256:0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+
+var (
+	errTestPull    = errors.New("pull failed")
+	errTestInspect = errors.New("inspect failed")
+)
 
 // stubFreezeResolvers points the CLI's digest resolver + feature composer at
 // fakes that return a fixed digest, so freeze runs end-to-end without Docker.
@@ -354,6 +362,167 @@ func TestDigestFromRepoDigests_MatchesRequestedRepo(t *testing.T) {
 	// rather than pinning the wrong repository.
 	if _, err := digestFromRepoDigests(in, "unrelated.example.com/thing:1"); err == nil {
 		t.Error("multiple non-matching RepoDigests must error rather than guess")
+	}
+}
+
+// fakeRunner is a container.Runner whose Run is scripted per command verb,
+// so the inspector's pull-then-inspect and RepoDigests-then-Id fallback are
+// exercised without Docker.
+type fakeRunner struct {
+	// outputs maps a join of the args to the stdout the command writes.
+	outputs map[string]string
+	// fails maps a join of the args to an error the command returns.
+	fails map[string]error
+	calls []string
+}
+
+func (f *fakeRunner) Run(_ context.Context, _ string, args []string, stdout, _ io.Writer) error {
+	key := strings.Join(args, " ")
+	f.calls = append(f.calls, key)
+	if err, ok := f.fails[key]; ok {
+		return err
+	}
+	if out, ok := f.outputs[key]; ok {
+		_, _ = stdout.Write([]byte(out))
+	}
+	return nil
+}
+
+func TestImageInspector_ResolveDigest(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("a", 64)
+	fr := &fakeRunner{outputs: map[string]string{
+		`image inspect --format {{json .RepoDigests}} registry.example.com/runner:1.4`: `["registry.example.com/runner@` + digest + `"]`,
+	}}
+	in := imageInspector{runner: fr, runtime: "docker"}
+	got, err := in.resolveDigest(context.Background(), "registry.example.com/runner:1.4")
+	if err != nil {
+		t.Fatalf("resolveDigest: %v", err)
+	}
+	if got != digest {
+		t.Errorf("digest = %q, want %q", got, digest)
+	}
+	// A pull was attempted (best-effort) before the inspect.
+	if len(fr.calls) == 0 || !strings.HasPrefix(fr.calls[0], "pull ") {
+		t.Errorf("expected a best-effort pull first, calls=%v", fr.calls)
+	}
+}
+
+func TestImageInspector_ResolveDigest_PullFailsButLocalInspectSucceeds(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("c", 64)
+	fr := &fakeRunner{
+		fails: map[string]error{"pull img:1": errTestPull},
+		outputs: map[string]string{
+			`image inspect --format {{json .RepoDigests}} img:1`: `["img@` + digest + `"]`,
+		},
+	}
+	in := imageInspector{runner: fr, runtime: "docker"}
+	got, err := in.resolveDigest(context.Background(), "img:1")
+	if err != nil {
+		t.Fatalf("a failed pull must not abort when the image is local: %v", err)
+	}
+	if got != digest {
+		t.Errorf("digest = %q", got)
+	}
+}
+
+func TestImageInspector_ResolveDigest_InspectFails(t *testing.T) {
+	fr := &fakeRunner{fails: map[string]error{
+		`image inspect --format {{json .RepoDigests}} img:1`: errTestInspect,
+	}}
+	in := imageInspector{runner: fr, runtime: "docker"}
+	if _, err := in.resolveDigest(context.Background(), "img:1"); err == nil {
+		t.Error("a failing inspect must error")
+	}
+}
+
+func TestImageInspector_LocalImageDigest_RepoDigestsWins(t *testing.T) {
+	digest := "sha256:" + strings.Repeat("d", 64)
+	fr := &fakeRunner{outputs: map[string]string{
+		`image inspect --format {{json .RepoDigests}} built:local`: `["built@` + digest + `"]`,
+	}}
+	in := imageInspector{runner: fr, runtime: "docker"}
+	got, err := in.localImageDigest(context.Background(), "built:local")
+	if err != nil {
+		t.Fatalf("localImageDigest: %v", err)
+	}
+	if got != digest {
+		t.Errorf("digest = %q", got)
+	}
+}
+
+func TestImageInspector_LocalImageDigest_FallsBackToID(t *testing.T) {
+	id := "sha256:" + strings.Repeat("e", 64)
+	fr := &fakeRunner{
+		// RepoDigests empty -> digestFromRepoDigests errors -> fall back to Id.
+		outputs: map[string]string{
+			`image inspect --format {{json .RepoDigests}} built:local`: `[]`,
+			`image inspect --format {{.Id}} built:local`:               id + "\n",
+		},
+	}
+	in := imageInspector{runner: fr, runtime: "docker"}
+	got, err := in.localImageDigest(context.Background(), "built:local")
+	if err != nil {
+		t.Fatalf("localImageDigest: %v", err)
+	}
+	if got != id {
+		t.Errorf("digest = %q, want the image Id %q", got, id)
+	}
+}
+
+func TestImageInspector_LocalImageDigest_NonSha256IDRejected(t *testing.T) {
+	fr := &fakeRunner{outputs: map[string]string{
+		`image inspect --format {{json .RepoDigests}} built:local`: `[]`,
+		`image inspect --format {{.Id}} built:local`:               "not-a-digest\n",
+	}}
+	in := imageInspector{runner: fr, runtime: "docker"}
+	if _, err := in.localImageDigest(context.Background(), "built:local"); err == nil {
+		t.Error("a non-sha256 image Id must be rejected")
+	}
+}
+
+func TestImageInspector_LocalImageDigest_BothInspectsFail(t *testing.T) {
+	fr := &fakeRunner{fails: map[string]error{
+		`image inspect --format {{json .RepoDigests}} built:local`: errTestInspect,
+		`image inspect --format {{.Id}} built:local`:               errTestInspect,
+	}}
+	in := imageInspector{runner: fr, runtime: "docker"}
+	if _, err := in.localImageDigest(context.Background(), "built:local"); err == nil {
+		t.Error("when both inspects fail, localImageDigest must error")
+	}
+}
+
+func TestReadSkillForFreeze_NonSkillFilePath(t *testing.T) {
+	withTempStore(t)
+	dir := t.TempDir()
+	notSkill := filepath.Join(dir, "README.md")
+	if err := os.WriteFile(notSkill, []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := readSkillForFreeze(notSkill); err == nil {
+		t.Error("a non-SKILL.md file path must error")
+	}
+}
+
+func TestReadSkillForFreeze_DirectoryWithoutSkill(t *testing.T) {
+	withTempStore(t)
+	if _, err := readSkillForFreeze(t.TempDir()); err == nil {
+		t.Error("a directory with no SKILL.md must error")
+	}
+}
+
+func TestRung2Plan(t *testing.T) {
+	features := []string{"ghcr.io/x/a:1", "ghcr.io/x/b:1"}
+	plan := rung2Plan(features)
+	if plan.Tier != composition.TierDevcontainer {
+		t.Errorf("tier = %s", plan.Tier)
+	}
+	if len(plan.Features) != 2 {
+		t.Errorf("features = %v", plan.Features)
+	}
+	for _, f := range features {
+		if _, ok := plan.Features[f]; !ok {
+			t.Errorf("feature %q missing from plan", f)
+		}
 	}
 }
 

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -10,7 +10,7 @@ The manifest is the YAML frontmatter of a `SKILL.md` document in the [agentskill
 
 The deterministic step-graph composition format is specified on this single page rather than a separate sibling page. It is one coherent format covered by one drift-guard test, amended in place under the [Composition and the step graph](#composition-and-the-step-graph) section below. The existing "Flight Plan Manifest Spec" navigation entry stands and no new navigation entry is added.
 
-This page is a spec deliverable. It defines the format. It does not ship a parser, a validator, the freeze step, or runtime enforcement. The Go parser and validator are tracked in [#1508](https://github.com/ALRubinger/aileron/issues/1508). Freeze is tracked in [#1509](https://github.com/ALRubinger/aileron/issues/1509). Runtime enforcement is tracked in [#1511](https://github.com/ALRubinger/aileron/issues/1511). The `lock` section is shaped here as freeze's target, not produced here.
+This page is the normative format spec. The Go parser and validator ship under [#1508](https://github.com/ALRubinger/aileron/issues/1508). Freeze ships under [#1509](https://github.com/ALRubinger/aileron/issues/1509): `aileron skill freeze` resolves image references to digests, produces the lockfile, content-addresses the unit, and signs it. Runtime enforcement is tracked in [#1511](https://github.com/ALRubinger/aileron/issues/1511). The `lock` section below is freeze's target, and freeze now populates it; the schema on this page stays the authoritative shape.
 
 ## Schema
 
@@ -248,7 +248,7 @@ Each operation's `audit.fields` declares which of the closed record fields it em
 
 Freeze turns a skill into a Flight Plan ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) freeze boundary). Freeze resolves every image reference to a content-addressed digest, produces a lockfile that pins those digests and the resolved capability set, binds the execution environment, attaches the per-action trust contract, and signs the result. The `lock` section is the record of those pins.
 
-The `lock` section is absent before freeze. This page specifies its shape only, as freeze's target. Freeze itself is tracked in [#1509](https://github.com/ALRubinger/aileron/issues/1509).
+The `lock` section is absent before freeze. Freeze populates it and writes an immutable, signed version into the canonical skill store. See the [Freezing a Flight Plan](/guides/freezing-a-flight-plan) guide for the command and the reproducibility and signature-verification guarantees.
 
 | Field | Type | Required | Semantics |
 |---|---|---|---|

--- a/docs/src/content/docs/guides/freezing-a-flight-plan.md
+++ b/docs/src/content/docs/guides/freezing-a-flight-plan.md
@@ -1,0 +1,58 @@
+---
+title: "Freezing a Flight Plan"
+description: "How aileron skill freeze seals an installed skill into a signed, digest-pinned, immutable Flight Plan version."
+---
+
+Freeze is the author-time step that seals an installed Aileron skill into a Flight Plan ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill)). A skill before freeze names its execution environment by a movable tag. A Flight Plan after freeze pins every image to a content-addressed digest, records a lockfile, content-addresses the whole unit, and carries a detached signature. The frozen version is written immutably into the canonical skill store. This guide walks through running freeze and explains the guarantees it produces.
+
+## What freeze does
+
+Freeze runs a fixed sequence over one `SKILL.md` document.
+
+1. It parses and lints the manifest. The lint rejects any step that could reach an LLM outside the marked `llm-seam` (see [the manifest spec](/development/flight-plan-manifest-spec)).
+2. It resolves the execution environment to image digests. A rung-1 `rung1Image.ref` is resolved to its `sha256:` digest. A rung-2 `rung2CapabilityUnits.features` set is composed and the built image is pinned by digest.
+3. It builds the lockfile. The lockfile records the resolved image pins, the resolved capability set, the content hash, and the semver label.
+4. It content-addresses the unit. The content hash is a `sha256` over the canonical frozen manifest bytes plus the lockfile bytes.
+5. It signs the content with a detached ed25519 signature.
+6. It writes the frozen version into the store as an immutable directory.
+
+Freeze pins by digest, never by tag. A resolver that returns a tag rather than a digest is a hard error.
+
+## Running freeze
+
+Freeze takes the name of an installed skill or a path to a `SKILL.md`.
+
+```sh
+aileron skill freeze weekly-metrics-digest \
+  --signing-key ~/.aileron/keys/author.pem \
+  --version 1.0.0
+```
+
+The signing key is a PEM-encoded ed25519 private key. Pass it with `--signing-key` or set `AILERON_SIGNING_KEY` to the key path. The key is read for signing only. It is never copied into the frozen artifact or the store.
+
+The `--version` flag records a human-facing semver label in the lock. It is optional.
+
+Freeze prints the skill name, the version label, the content hash, and the on-disk location of the frozen version.
+
+## The frozen version
+
+A frozen version lives under the skill in the store at `~/.aileron/skills/<name>/versions/<id>/`. The version id is a short content-derived slug of the content hash. Each version directory holds four files.
+
+| File | Contents |
+|---|---|
+| `SKILL.md` | The frozen manifest with the populated `lock` block injected. |
+| `aileron.lock` | The standalone lockfile, the durable pin record. |
+| `signature.sig` | The detached ed25519 signature over the content bytes. |
+| `signing-key.pub` | The author public key the signature verifies against. |
+
+The pre-freeze installed `SKILL.md` at the skill name root is never touched. Freeze adds versions beside it.
+
+## Guarantees
+
+Freeze is reproducible. Running freeze twice over byte-identical input with the same key produces the same content hash, the same frozen bytes, and the same signature. ed25519 is deterministic for a fixed key and message.
+
+Frozen versions are immutable. Re-freezing changed content writes a new version directory and leaves every prior version byte-identical. Re-freezing identical content to an existing version id is a verified no-op. Writing different content to an existing version id is rejected.
+
+The signature is verifiable at launch. A verifier needs only the signature and the public key, both stored beside the version. The launch-time runtime ([#1511](https://github.com/ALRubinger/aileron/issues/1511)) verifies the signature before it runs a Flight Plan.
+
+The signing private key never enters the store. Only the public key and the detached signature are persisted.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -72,6 +72,7 @@ export const navigation: NavItem[] = [
       { label: 'Installing a Connector', href: '/guides/installing-a-connector/' },
       { label: 'Installing an Action', href: '/guides/installing-an-action/' },
       { label: 'Installing a Skill', href: '/guides/installing-a-skill/' },
+      { label: 'Freezing a Flight Plan', href: '/guides/freezing-a-flight-plan/' },
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },
       { label: 'Setting up BlueBubbles for Aileron', href: '/guides/setting-up-bluebubbles/' },
       { label: 'Authoring an Action', href: '/guides/authoring-an-action/' },

--- a/internal/flightplan/freeze/content.go
+++ b/internal/flightplan/freeze/content.go
@@ -1,0 +1,43 @@
+package freeze
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+)
+
+// contentHashPrefix is the digest-algorithm prefix every contentHash and
+// image digest carries. It matches the schema pattern `^sha256:[a-f0-9]{64}$`.
+const contentHashPrefix = "sha256:"
+
+// canonicalContent assembles the exact byte sequence the contentHash is
+// taken over. The hash is load-bearing for reproducibility and
+// tamper-detection, so the byte sequence is defined precisely here and
+// nowhere else.
+//
+// The canonical input is, in order:
+//
+//  1. the frozen SKILL.md bytes with the `lock` block injected, but with
+//     the `contentHash` field itself ABSENT from that lock block (it cannot
+//     reference its own value), and with no signature present, followed by
+//  2. a single 0x00 separator byte (so the two regions can never collide by
+//     concatenation), followed by
+//  3. the lockfile bytes, also with `contentHash` absent.
+//
+// Both regions therefore describe the same resolved-images/capability-set
+// data. The separator and the explicit exclusion of the self-referential
+// hash field are what make the hash stable across re-runs on byte-identical
+// input and changed when any manifest content changes.
+func canonicalContent(frozenManifestNoHash, lockfileNoHash []byte) []byte {
+	buf := make([]byte, 0, len(frozenManifestNoHash)+1+len(lockfileNoHash))
+	buf = append(buf, frozenManifestNoHash...)
+	buf = append(buf, 0x00)
+	buf = append(buf, lockfileNoHash...)
+	return buf
+}
+
+// contentHash returns the `sha256:<hex>` content hash over the canonical
+// byte sequence. The result matches the schema pattern for lock.contentHash.
+func contentHash(frozenManifestNoHash, lockfileNoHash []byte) string {
+	sum := sha256.Sum256(canonicalContent(frozenManifestNoHash, lockfileNoHash))
+	return contentHashPrefix + hex.EncodeToString(sum[:])
+}

--- a/internal/flightplan/freeze/content_test.go
+++ b/internal/flightplan/freeze/content_test.go
@@ -1,0 +1,54 @@
+package freeze
+
+import (
+	"regexp"
+	"testing"
+)
+
+var sha256Pattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+
+func TestContentHash_ShapeMatchesSchema(t *testing.T) {
+	h := contentHash([]byte("manifest"), []byte("lock"))
+	if !sha256Pattern.MatchString(h) {
+		t.Errorf("contentHash = %q, want sha256:<64 hex>", h)
+	}
+}
+
+func TestContentHash_StableAcrossRuns(t *testing.T) {
+	m := []byte("frozen manifest bytes")
+	l := []byte("lockfile bytes")
+	a := contentHash(m, l)
+	b := contentHash(m, l)
+	if a != b {
+		t.Errorf("contentHash not stable: %q != %q", a, b)
+	}
+}
+
+func TestContentHash_ChangesWhenManifestChanges(t *testing.T) {
+	l := []byte("lockfile bytes")
+	a := contentHash([]byte("manifest A"), l)
+	b := contentHash([]byte("manifest B"), l)
+	if a == b {
+		t.Error("contentHash must change when manifest content changes")
+	}
+}
+
+func TestContentHash_ChangesWhenLockChanges(t *testing.T) {
+	m := []byte("manifest")
+	a := contentHash(m, []byte("lock A"))
+	b := contentHash(m, []byte("lock B"))
+	if a == b {
+		t.Error("contentHash must change when lockfile content changes")
+	}
+}
+
+// The 0x00 separator makes the two regions impossible to collide by
+// shifting bytes across the boundary: (man, "x"+lock) must differ from
+// (man+"x", lock).
+func TestContentHash_SeparatorPreventsBoundaryCollision(t *testing.T) {
+	a := contentHash([]byte("man"), []byte("xlock"))
+	b := contentHash([]byte("manx"), []byte("lock"))
+	if a == b {
+		t.Error("separator must prevent a boundary-shift collision")
+	}
+}

--- a/internal/flightplan/freeze/freeze.go
+++ b/internal/flightplan/freeze/freeze.go
@@ -1,0 +1,149 @@
+// Package freeze is the author-time step that seals an installed Aileron
+// skill into a Flight Plan (ADR-0027). Freeze resolves every image
+// reference to a content-addressed `@sha256:` digest, emits a lockfile,
+// content-addresses the unit, produces a detached ed25519 signature, and
+// runs the no-LLM lint. The result is written as an immutable version into
+// the canonical skill store (internal/flightplan/store).
+//
+// Freeze is deterministic and runtime-free at its core: digest resolution
+// is a seam (DigestResolver / FeatureComposer) so the lockfile,
+// content-addressing, lint, and signing logic are unit-testable without a
+// container runtime. The CLI (cmd/aileron) wires the concrete container
+// runtime resolvers.
+//
+// Freeze never carries a credential value. The signing private key is read
+// from disk or the environment for signing only and is never copied into
+// the frozen artifact; only the detached signature and the author public
+// key are persisted (ADR-0005, ADR-0019).
+package freeze
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+)
+
+// Result is the outcome of a freeze. It carries the frozen artifacts the
+// store writer persists and the identifying contentHash + version.
+type Result struct {
+	// Name is the skill name from the manifest frontmatter.
+	Name string
+	// Version is the human-facing semver label for this frozen version.
+	Version string
+	// ContentHash is the `sha256:<hex>` content hash identifying the exact
+	// frozen manifest bytes. It is also the store version id source.
+	ContentHash string
+	// FrozenManifest is the SKILL.md with the populated `lock` block
+	// injected (contentHash included). This is the durable, signed artifact.
+	FrozenManifest []byte
+	// Lockfile is the standalone `aileron.lock` artifact bytes (contentHash
+	// included), the durable pin record.
+	Lockfile []byte
+	// Signature is the detached ed25519 signature over the canonical
+	// content-hash bytes.
+	Signature []byte
+	// PublicKey is the PEM-encoded author public key the signature verifies
+	// against. Stored alongside the signature; the private key never is.
+	PublicKey []byte
+	// Lock is the structured lockfile record (contentHash included).
+	Lock Lockfile
+}
+
+// Options configures a Run.
+type Options struct {
+	// Version is the semver label recorded in the lock. Optional; empty
+	// records no version label.
+	Version string
+	// SigningKeyPath is the path to the PEM ed25519 private key. Empty falls
+	// back to $AILERON_SIGNING_KEY (see LoadSigningKey).
+	SigningKeyPath string
+	// Resolver resolves a rung-1 image reference to a digest. May be nil for
+	// instruction-only / no-execution-environment skills.
+	Resolver DigestResolver
+	// Composer composes a rung-2 capability-unit Feature set and pins the
+	// built image's digest. May be nil when no rung-2 skill is frozen.
+	Composer FeatureComposer
+}
+
+// Run executes the freeze pipeline over a SKILL.md document. It sequences:
+// parse → lint → resolve digests → build lockfile → contentHash → sign.
+// It does NOT write to the store; the caller persists Result through the
+// store's frozen-version writer so the store stays the single writer.
+//
+// Lint runs before any image resolution so an unmarked-LLM skill fails fast
+// without touching a container runtime.
+func Run(ctx context.Context, raw []byte, opts Options) (Result, error) {
+	m, err := manifest.Parse(raw)
+	if err != nil {
+		return Result{}, fmt.Errorf("freeze: parse skill: %w", err)
+	}
+	if m.Name == "" {
+		return Result{}, fmt.Errorf("freeze: skill has no name in its frontmatter")
+	}
+
+	if err := Lint(m); err != nil {
+		return Result{}, err
+	}
+
+	// Load the signing key before doing expensive resolution so a missing
+	// or malformed key fails fast.
+	priv, err := LoadSigningKey(opts.SigningKeyPath)
+	if err != nil {
+		return Result{}, err
+	}
+
+	pins, capSet, err := resolveImages(ctx, m, opts.Resolver, opts.Composer)
+	if err != nil {
+		return Result{}, err
+	}
+
+	lock := Lockfile{
+		ResolvedImages:        pins,
+		ResolvedCapabilitySet: capSet,
+		Version:               opts.Version,
+	}
+
+	// Compute the content hash over the canonical bytes, with the
+	// self-referential contentHash field excluded from the hashed input.
+	lockNoHash := lock.withoutContentHash()
+	manifestNoHash, err := injectLockMaybe(raw, lockNoHash, m.InstructionOnly)
+	if err != nil {
+		return Result{}, err
+	}
+	lockfileNoHash, err := MarshalLockfile(lockNoHash)
+	if err != nil {
+		return Result{}, err
+	}
+	hash := contentHash(manifestNoHash, lockfileNoHash)
+	lock.ContentHash = hash
+
+	// Re-emit the final artifacts WITH the contentHash present.
+	frozenManifest, err := injectLockMaybe(raw, lock, m.InstructionOnly)
+	if err != nil {
+		return Result{}, err
+	}
+	lockfile, err := MarshalLockfile(lock)
+	if err != nil {
+		return Result{}, err
+	}
+
+	// Sign the canonical content bytes (the same bytes the hash is over) so
+	// the signature covers the exact frozen unit and a verifier needs only
+	// the public key + signature.
+	sig, pubPEM, err := Sign(priv, canonicalContent(manifestNoHash, lockfileNoHash))
+	if err != nil {
+		return Result{}, err
+	}
+
+	return Result{
+		Name:           m.Name,
+		Version:        opts.Version,
+		ContentHash:    hash,
+		FrozenManifest: frozenManifest,
+		Lockfile:       lockfile,
+		Signature:      sig,
+		PublicKey:      pubPEM,
+		Lock:           lock,
+	}, nil
+}

--- a/internal/flightplan/freeze/freeze_test.go
+++ b/internal/flightplan/freeze/freeze_test.go
@@ -227,6 +227,38 @@ func TestRun_MissingSigningKey(t *testing.T) {
 	}
 }
 
+func TestRun_ResolutionErrorSurfaces(t *testing.T) {
+	// A rung-1 manifest whose resolver errors must fail Run after lint and
+	// key-load, exercising the resolveImages error branch in Run.
+	_, keyPath := genSigningKey(t)
+	dr := DigestResolverFunc(func(context.Context, string) (string, error) {
+		return "", context.Canceled
+	})
+	_, err := Run(context.Background(), []byte(rung1MD), Options{
+		SigningKeyPath: keyPath,
+		Resolver:       dr,
+	})
+	if err == nil {
+		t.Error("a resolver error must fail Run")
+	}
+}
+
+func TestRun_TagNotDigestFails(t *testing.T) {
+	// A resolver returning a tag (not a digest) must fail Run via the
+	// pin-by-digest guard.
+	_, keyPath := genSigningKey(t)
+	dr := DigestResolverFunc(func(context.Context, string) (string, error) {
+		return "registry.example.com/runner:1.4", nil
+	})
+	_, err := Run(context.Background(), []byte(rung1MD), Options{
+		SigningKeyPath: keyPath,
+		Resolver:       dr,
+	})
+	if err == nil {
+		t.Error("a tag (non-digest) resolution must fail Run")
+	}
+}
+
 func TestRun_BadManifestErrors(t *testing.T) {
 	_, keyPath := genSigningKey(t)
 	if _, err := Run(context.Background(), []byte("not a manifest"), Options{SigningKeyPath: keyPath}); err == nil {

--- a/internal/flightplan/freeze/freeze_test.go
+++ b/internal/flightplan/freeze/freeze_test.go
@@ -1,0 +1,235 @@
+package freeze
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+)
+
+func fakeComposer(digest string) FeatureComposer {
+	return FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
+		return digest, nil
+	})
+}
+
+func TestRun_Rung2HappyPath(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	res, err := Run(context.Background(), exampleSkillMD(t), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+		Composer:       fakeComposer(fakeDigest),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Name != "weekly-metrics-digest" {
+		t.Errorf("name = %q", res.Name)
+	}
+	if !sha256Pattern.MatchString(res.ContentHash) {
+		t.Errorf("contentHash = %q", res.ContentHash)
+	}
+	if res.Version != "1.0.0" {
+		t.Errorf("version = %q", res.Version)
+	}
+	if len(res.Lock.ResolvedImages) != 1 || res.Lock.ResolvedImages[0].Digest != fakeDigest {
+		t.Errorf("resolvedImages = %+v", res.Lock.ResolvedImages)
+	}
+	if len(res.Lock.ResolvedCapabilitySet) != 2 {
+		t.Errorf("resolvedCapabilitySet = %v", res.Lock.ResolvedCapabilitySet)
+	}
+
+	// The signature verifies against the stored public key over the
+	// canonical content bytes. Reconstruct those bytes the way Run does.
+	lockNoHash := res.Lock.withoutContentHash()
+	mNoHash, err := injectLock(exampleSkillMD(t), lockNoHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	lfNoHash, err := MarshalLockfile(lockNoHash)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(canonicalContent(mNoHash, lfNoHash), res.Signature, res.PublicKey); err != nil {
+		t.Errorf("signature must verify: %v", err)
+	}
+
+	// The frozen manifest re-parses with the lock present, and the
+	// contentHash inside it matches the result.
+	fm, err := manifest.Parse(res.FrozenManifest)
+	if err != nil {
+		t.Fatalf("frozen manifest must re-parse: %v", err)
+	}
+	if fm.Aileron.Lock["contentHash"] != res.ContentHash {
+		t.Errorf("frozen manifest lock.contentHash = %v, want %v", fm.Aileron.Lock["contentHash"], res.ContentHash)
+	}
+}
+
+func TestRun_Reproducible(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	opts := Options{Version: "1.0.0", SigningKeyPath: keyPath, Composer: fakeComposer(fakeDigest)}
+	a, err := Run(context.Background(), exampleSkillMD(t), opts)
+	if err != nil {
+		t.Fatalf("Run a: %v", err)
+	}
+	b, err := Run(context.Background(), exampleSkillMD(t), opts)
+	if err != nil {
+		t.Fatalf("Run b: %v", err)
+	}
+	if a.ContentHash != b.ContentHash {
+		t.Errorf("contentHash not reproducible: %q != %q", a.ContentHash, b.ContentHash)
+	}
+	if string(a.FrozenManifest) != string(b.FrozenManifest) {
+		t.Error("frozen manifest bytes not reproducible")
+	}
+}
+
+func TestRun_ContentHashChangesWithVersion(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	a, err := Run(context.Background(), exampleSkillMD(t), Options{Version: "1.0.0", SigningKeyPath: keyPath, Composer: fakeComposer(fakeDigest)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	b, err := Run(context.Background(), exampleSkillMD(t), Options{Version: "2.0.0", SigningKeyPath: keyPath, Composer: fakeComposer(fakeDigest)})
+	if err != nil {
+		t.Fatal(err)
+	}
+	if a.ContentHash == b.ContentHash {
+		t.Error("a different version label must change the content hash")
+	}
+}
+
+func TestRun_NoExecEnvStillSigns(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	// A skill with an aileron block but no executionEnvironment has no
+	// images to resolve. Run must still produce a contentHash, inject an
+	// empty-images lock, and sign the result.
+	res, err := Run(context.Background(), []byte(noExecEnvMD), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if len(res.Lock.ResolvedImages) != 0 {
+		t.Errorf("no-exec-env skill must have empty resolvedImages, got %v", res.Lock.ResolvedImages)
+	}
+	if !sha256Pattern.MatchString(res.ContentHash) {
+		t.Errorf("contentHash = %q", res.ContentHash)
+	}
+	if len(res.Signature) == 0 || len(res.PublicKey) == 0 {
+		t.Error("no-exec-env skill must still be signed")
+	}
+}
+
+func TestRun_TrueInstructionOnlySigns(t *testing.T) {
+	// A skill with NO aileron block still freezes: there is no lock to
+	// inject into the manifest, but it gets a contentHash + signature over
+	// the (empty) lockfile + the LF-canonical manifest.
+	_, keyPath := genSigningKey(t)
+	res, err := Run(context.Background(), []byte(instructionOnlyMD), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+	})
+	if err != nil {
+		t.Fatalf("Run instruction-only: %v", err)
+	}
+	if !sha256Pattern.MatchString(res.ContentHash) {
+		t.Errorf("contentHash = %q", res.ContentHash)
+	}
+	if len(res.Signature) == 0 || len(res.PublicKey) == 0 {
+		t.Error("instruction-only skill must still be signed")
+	}
+	if len(res.Lock.ResolvedImages) != 0 {
+		t.Errorf("instruction-only resolvedImages = %v", res.Lock.ResolvedImages)
+	}
+	// The frozen manifest has no lock block (nowhere to put it).
+	if strings.Contains(string(res.FrozenManifest), "lock:") {
+		t.Error("instruction-only frozen manifest must carry no lock block")
+	}
+	// The signature verifies over the reconstructed canonical bytes.
+	lfNoHash, err := MarshalLockfile(res.Lock.withoutContentHash())
+	if err != nil {
+		t.Fatal(err)
+	}
+	mNoHash := []byte(strings.ReplaceAll(instructionOnlyMD, "\r\n", "\n"))
+	if err := Verify(canonicalContent(mNoHash, lfNoHash), res.Signature, res.PublicKey); err != nil {
+		t.Errorf("instruction-only signature must verify: %v", err)
+	}
+}
+
+func TestRun_ValidationFailsBeforeResolution(t *testing.T) {
+	// A manifest that fails the validation gate (here an out-of-enum step
+	// kind, which manifest.Parse rejects, and which Lint would also reject)
+	// must fail before any resolver is touched. The lint direction itself is
+	// covered directly in lint_test.go against a schema-bypassing manifest;
+	// this asserts Run's ordering: no container work runs on a rejected
+	// manifest. The composer flips a flag if reached.
+	const badMD = `---
+name: bad-skill
+description: Smuggles an LLM call.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:x.y
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+    executionEnvironment:
+      rung2CapabilityUnits:
+        features:
+          - ghcr.io/example/feat:1
+  inputs: []
+  outputs: []
+  steps:
+    - id: sneaky
+      kind: action-call
+      actionRef: aileron:x.y
+---
+
+# Bad
+`
+	_, keyPath := genSigningKey(t)
+	// Swap the valid kind for an out-of-enum one. Run parses raw bytes, so
+	// the rejection happens in the validation phase (parse + lint) that
+	// precedes resolution; the composer must not be reached.
+	composerHit := false
+	_, err := Run(context.Background(), []byte(strings.Replace(badMD, "kind: action-call", "kind: not-a-kind", 1)), Options{
+		SigningKeyPath: keyPath,
+		Composer: FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
+			composerHit = true
+			return fakeDigest, nil
+		}),
+	})
+	if err == nil {
+		t.Fatal("a manifest with a bad step kind must fail Run")
+	}
+	if composerHit {
+		t.Error("resolution must not run when validation fails")
+	}
+}
+
+func TestRun_MissingSigningKey(t *testing.T) {
+	t.Setenv(SigningKeyEnv, "")
+	_, err := Run(context.Background(), exampleSkillMD(t), Options{Composer: fakeComposer(fakeDigest)})
+	if err == nil {
+		t.Error("a missing signing key must fail Run")
+	}
+}
+
+func TestRun_BadManifestErrors(t *testing.T) {
+	_, keyPath := genSigningKey(t)
+	if _, err := Run(context.Background(), []byte("not a manifest"), Options{SigningKeyPath: keyPath}); err == nil {
+		t.Error("an unparseable manifest must error")
+	}
+}

--- a/internal/flightplan/freeze/images.go
+++ b/internal/flightplan/freeze/images.go
@@ -1,0 +1,191 @@
+package freeze
+
+import (
+	"context"
+	"fmt"
+	"regexp"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+)
+
+// digestPattern is the schema's content-addressed digest shape. A
+// resolution that does not produce this exact shape is a drift vector
+// (a tag pin would let the underlying image move) and is a hard error.
+var digestPattern = regexp.MustCompile(`^sha256:[a-f0-9]{64}$`)
+
+// DigestResolver resolves a pre-freeze image reference to a
+// content-addressed `sha256:` digest. It is the seam that keeps the freeze
+// core free of a container runtime: production wires a resolver over
+// container.Runner / container.Builder, tests inject a fake.
+type DigestResolver interface {
+	// ResolveDigest resolves an OCI image reference (a tag, for rung-1) to
+	// its `sha256:` digest. The returned digest MUST match digestPattern.
+	ResolveDigest(ctx context.Context, ref string) (string, error)
+}
+
+// FeatureComposer composes a rung-2 capability-unit Feature set onto the
+// Aileron base image and returns the built image's `sha256:` digest. It is
+// the seam over container.Builder + composition so freeze's rung-2 path is
+// testable without Docker.
+type FeatureComposer interface {
+	// ComposeDigest builds the image composed from the given devcontainer
+	// Feature references and returns its `sha256:` digest.
+	ComposeDigest(ctx context.Context, features []string) (string, error)
+}
+
+// DigestResolverFunc adapts a function to DigestResolver.
+type DigestResolverFunc func(ctx context.Context, ref string) (string, error)
+
+// ResolveDigest calls f, or errors when f is nil (a zero-valued adapter).
+func (f DigestResolverFunc) ResolveDigest(ctx context.Context, ref string) (string, error) {
+	if f == nil {
+		return "", fmt.Errorf("freeze: nil digest resolver")
+	}
+	return f(ctx, ref)
+}
+
+// FeatureComposerFunc adapts a function to FeatureComposer.
+type FeatureComposerFunc func(ctx context.Context, features []string) (string, error)
+
+// ComposeDigest calls f, or errors when f is nil (a zero-valued adapter).
+func (f FeatureComposerFunc) ComposeDigest(ctx context.Context, features []string) (string, error) {
+	if f == nil {
+		return "", fmt.Errorf("freeze: nil feature composer")
+	}
+	return f(ctx, features)
+}
+
+// resolveImages resolves a manifest's execution environment to the pinned
+// image set and resolved capability set, returning the data the lockfile
+// records. The four cases:
+//
+//   - instruction-only / no executionEnvironment: empty pins, no error
+//     (the skill still gets a contentHash and signature);
+//   - rung-1 (rung1Image.ref): resolve the named image to a digest pin;
+//   - rung-2 (rung2CapabilityUnits.features): compose the Features and pin
+//     the built image's digest plus the resolved capability set;
+//   - both rungs present, or neither: a malformed manifest the schema
+//     already rejects; guarded here defensively.
+//
+// Every resolved digest is checked against digestPattern: a resolver that
+// yields a tag rather than a digest is rejected (pin by digest, never tag).
+func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver, fc FeatureComposer) (pins []ImagePin, capSet []string, err error) {
+	if m == nil || m.InstructionOnly {
+		return nil, nil, nil
+	}
+	env := m.Aileron.Requires.ExecutionEnvironment
+	if len(env) == 0 {
+		// No execution environment declared: an instruction/composition-only
+		// skill freezes with an empty resolvedImages set.
+		return nil, nil, nil
+	}
+
+	rung1, hasRung1 := env["rung1Image"]
+	rung2, hasRung2 := env["rung2CapabilityUnits"]
+	switch {
+	case hasRung1 && hasRung2:
+		return nil, nil, fmt.Errorf("freeze: executionEnvironment declares both rung1Image and rung2CapabilityUnits; exactly one is permitted")
+	case hasRung1:
+		ref, err := rung1ImageRef(rung1)
+		if err != nil {
+			return nil, nil, err
+		}
+		if dr == nil {
+			return nil, nil, fmt.Errorf("freeze: rung-1 image %q requires a digest resolver", ref)
+		}
+		digest, err := dr.ResolveDigest(ctx, ref)
+		if err != nil {
+			return nil, nil, fmt.Errorf("freeze: resolve rung-1 image %q: %w", ref, err)
+		}
+		if err := requireDigest(ref, digest); err != nil {
+			return nil, nil, err
+		}
+		return []ImagePin{{Ref: ref, Digest: digest}}, nil, nil
+	case hasRung2:
+		features, err := rung2Features(rung2)
+		if err != nil {
+			return nil, nil, err
+		}
+		if fc == nil {
+			return nil, nil, fmt.Errorf("freeze: rung-2 capability units require a feature composer")
+		}
+		digest, err := fc.ComposeDigest(ctx, features)
+		if err != nil {
+			return nil, nil, fmt.Errorf("freeze: compose rung-2 capability units: %w", err)
+		}
+		if err := requireDigest("rung2:"+joinFeatures(features), digest); err != nil {
+			return nil, nil, err
+		}
+		// The pre-freeze "ref" for a composed image is the feature set; the
+		// resolved capability set is the same features, pinned.
+		return []ImagePin{{Ref: composedRef(features), Digest: digest}}, append([]string(nil), features...), nil
+	default:
+		return nil, nil, fmt.Errorf("freeze: executionEnvironment declares neither rung1Image nor rung2CapabilityUnits")
+	}
+}
+
+// requireDigest enforces the pin-by-digest invariant: a resolved value that
+// is not a `sha256:` digest is rejected with a clear error.
+func requireDigest(ref, digest string) error {
+	if !digestPattern.MatchString(digest) {
+		return fmt.Errorf("freeze: resolved %q to %q which is not a sha256: digest (freeze pins by digest, never by tag)", ref, digest)
+	}
+	return nil
+}
+
+// rung1ImageRef extracts rung1Image.ref from the untyped execution
+// environment block. The ref MUST be a real string: a non-string scalar
+// coerced into an image reference would silently produce a bad pin, so a
+// non-string ref is rejected here rather than stringified.
+func rung1ImageRef(v any) (string, error) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return "", fmt.Errorf("freeze: rung1Image is not a mapping")
+	}
+	ref, ok := m["ref"].(string)
+	if !ok || strings.TrimSpace(ref) == "" {
+		return "", fmt.Errorf("freeze: rung1Image.ref is missing, empty, or not a string")
+	}
+	return strings.TrimSpace(ref), nil
+}
+
+// rung2Features extracts rung2CapabilityUnits.features from the untyped
+// execution environment block. Each Feature reference MUST be a real,
+// non-empty string; a non-string entry is rejected rather than stringified.
+func rung2Features(v any) ([]string, error) {
+	m, ok := v.(map[string]any)
+	if !ok {
+		return nil, fmt.Errorf("freeze: rung2CapabilityUnits is not a mapping")
+	}
+	rawList, ok := m["features"].([]any)
+	if !ok || len(rawList) == 0 {
+		return nil, fmt.Errorf("freeze: rung2CapabilityUnits.features is missing or empty")
+	}
+	features := make([]string, 0, len(rawList))
+	for _, f := range rawList {
+		s, ok := f.(string)
+		if !ok || strings.TrimSpace(s) == "" {
+			return nil, fmt.Errorf("freeze: rung2CapabilityUnits.features contains an empty or non-string entry")
+		}
+		features = append(features, strings.TrimSpace(s))
+	}
+	return features, nil
+}
+
+// composedRef renders a stable pre-freeze reference for a composed rung-2
+// image so the lock entry records what was composed.
+func composedRef(features []string) string {
+	return "aileron-base+features(" + joinFeatures(features) + ")"
+}
+
+func joinFeatures(features []string) string {
+	out := ""
+	for i, f := range features {
+		if i > 0 {
+			out += ","
+		}
+		out += f
+	}
+	return out
+}

--- a/internal/flightplan/freeze/images_malformed_test.go
+++ b/internal/flightplan/freeze/images_malformed_test.go
@@ -1,0 +1,95 @@
+package freeze
+
+import (
+	"context"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+)
+
+// These manifests are built directly (not through manifest.Parse) so the
+// defensive shape checks in resolveImages are exercised: resolveImages is
+// the freeze-time backstop, so malformed executionEnvironment shapes that
+// the schema would reject must still produce a clear error here.
+func mWithExecEnv(env map[string]any) *manifest.Manifest {
+	return &manifest.Manifest{
+		Name: "x",
+		Aileron: manifest.AileronBlock{
+			Requires: manifest.Requires{ExecutionEnvironment: env},
+		},
+	}
+}
+
+func TestResolveImages_BothRungsRejected(t *testing.T) {
+	m := mWithExecEnv(map[string]any{
+		"rung1Image":           map[string]any{"ref": "a:1"},
+		"rung2CapabilityUnits": map[string]any{"features": []any{"f"}},
+	})
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+		t.Error("declaring both rungs must error")
+	}
+}
+
+func TestResolveImages_Rung1MissingRef(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung1Image": map[string]any{}})
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+		t.Error("rung1Image with no ref must error")
+	}
+}
+
+func TestResolveImages_Rung1NotMapping(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung1Image": "scalar"})
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+		t.Error("rung1Image that is not a mapping must error")
+	}
+}
+
+func TestResolveImages_Rung2EmptyFeatures(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{}}})
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+		t.Error("rung2 with empty features must error")
+	}
+}
+
+func TestResolveImages_Rung2EmptyFeatureEntry(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{""}}})
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+		t.Error("rung2 with an empty feature entry must error")
+	}
+}
+
+func TestResolveImages_Rung2NotMapping(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": "scalar"})
+	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+		t.Error("rung2CapabilityUnits that is not a mapping must error")
+	}
+}
+
+func TestResolveImages_NeitherRung(t *testing.T) {
+	m := mWithExecEnv(map[string]any{"somethingElse": map[string]any{}})
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+		t.Error("an executionEnvironment with neither rung must error")
+	}
+}
+
+func TestNilAdapters_ErrorNotPanic(t *testing.T) {
+	var dr DigestResolverFunc
+	if _, err := dr.ResolveDigest(context.Background(), "x"); err == nil {
+		t.Error("a nil DigestResolverFunc must return an error, not panic")
+	}
+	var fc FeatureComposerFunc
+	if _, err := fc.ComposeDigest(context.Background(), []string{"f"}); err == nil {
+		t.Error("a nil FeatureComposerFunc must return an error, not panic")
+	}
+}
+
+func TestVerify_MalformedPublicKey(t *testing.T) {
+	priv, _ := genSigningKey(t)
+	sig, _, err := Sign(priv, []byte("content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify([]byte("content"), sig, []byte("not a pem key")); err == nil {
+		t.Error("a malformed public key must fail Verify")
+	}
+}

--- a/internal/flightplan/freeze/images_test.go
+++ b/internal/flightplan/freeze/images_test.go
@@ -1,0 +1,138 @@
+package freeze
+
+import (
+	"context"
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+)
+
+func parseM(t *testing.T, raw []byte) *manifest.Manifest {
+	t.Helper()
+	m, err := manifest.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	return m
+}
+
+func TestResolveImages_Rung1ResolvesToDigest(t *testing.T) {
+	m := parseM(t, []byte(rung1MD))
+	var gotRef string
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		gotRef = ref
+		return fakeDigest, nil
+	})
+	pins, capSet, err := resolveImages(context.Background(), m, dr, nil)
+	if err != nil {
+		t.Fatalf("resolveImages: %v", err)
+	}
+	if gotRef != "registry.example.com/runner:1.4" {
+		t.Errorf("resolver got ref %q", gotRef)
+	}
+	if len(pins) != 1 || pins[0].Digest != fakeDigest || pins[0].Ref != "registry.example.com/runner:1.4" {
+		t.Errorf("pins = %+v", pins)
+	}
+	if capSet != nil {
+		t.Errorf("rung-1 must have no capability set, got %v", capSet)
+	}
+}
+
+func TestResolveImages_Rung2ComposesAndPins(t *testing.T) {
+	m := parseM(t, exampleSkillMD(t))
+	var gotFeatures []string
+	fc := FeatureComposerFunc(func(_ context.Context, features []string) (string, error) {
+		gotFeatures = features
+		return fakeDigest, nil
+	})
+	pins, capSet, err := resolveImages(context.Background(), m, nil, fc)
+	if err != nil {
+		t.Fatalf("resolveImages: %v", err)
+	}
+	wantFeatures := []string{
+		"ghcr.io/example/aileron-feature-metrics-cli:1",
+		"ghcr.io/example/aileron-feature-tracker-cli:1",
+	}
+	if strings.Join(gotFeatures, ",") != strings.Join(wantFeatures, ",") {
+		t.Errorf("composer got features %v, want %v", gotFeatures, wantFeatures)
+	}
+	if len(pins) != 1 || pins[0].Digest != fakeDigest {
+		t.Errorf("pins = %+v", pins)
+	}
+	if strings.Join(capSet, ",") != strings.Join(wantFeatures, ",") {
+		t.Errorf("resolved capability set = %v, want %v", capSet, wantFeatures)
+	}
+}
+
+func TestResolveImages_InstructionOnlyEmpty(t *testing.T) {
+	m := parseM(t, []byte(instructionOnlyMD))
+	pins, capSet, err := resolveImages(context.Background(), m, nil, nil)
+	if err != nil {
+		t.Fatalf("resolveImages: %v", err)
+	}
+	if len(pins) != 0 || len(capSet) != 0 {
+		t.Errorf("instruction-only must resolve to empty, got pins=%v cap=%v", pins, capSet)
+	}
+}
+
+func TestResolveImages_NoExecEnvEmpty(t *testing.T) {
+	m := parseM(t, []byte(noExecEnvMD))
+	pins, _, err := resolveImages(context.Background(), m, nil, nil)
+	if err != nil {
+		t.Fatalf("resolveImages: %v", err)
+	}
+	if len(pins) != 0 {
+		t.Errorf("no-execution-environment skill must resolve to empty, got %v", pins)
+	}
+}
+
+func TestResolveImages_RejectsTagNotDigest(t *testing.T) {
+	m := parseM(t, []byte(rung1MD))
+	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
+		return "registry.example.com/runner:1.4", nil // a tag, not a digest
+	})
+	_, _, err := resolveImages(context.Background(), m, dr, nil)
+	if err == nil {
+		t.Fatal("a resolver returning a tag must be rejected")
+	}
+	if !strings.Contains(err.Error(), "digest") {
+		t.Errorf("error should explain the pin-by-digest rule, got: %v", err)
+	}
+}
+
+func TestResolveImages_ResolverError(t *testing.T) {
+	m := parseM(t, []byte(rung1MD))
+	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
+		return "", errors.New("image not found")
+	})
+	if _, _, err := resolveImages(context.Background(), m, dr, nil); err == nil {
+		t.Error("an unresolvable image must error")
+	}
+}
+
+func TestResolveImages_Rung1NeedsResolver(t *testing.T) {
+	m := parseM(t, []byte(rung1MD))
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+		t.Error("a rung-1 manifest with no resolver must error")
+	}
+}
+
+func TestResolveImages_Rung2NeedsComposer(t *testing.T) {
+	m := parseM(t, exampleSkillMD(t))
+	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+		t.Error("a rung-2 manifest with no composer must error")
+	}
+}
+
+func TestRequireDigest(t *testing.T) {
+	if err := requireDigest("ref", fakeDigest); err != nil {
+		t.Errorf("valid digest rejected: %v", err)
+	}
+	for _, bad := range []string{"latest", "sha256:short", "sha256:" + strings.Repeat("g", 64), ""} {
+		if err := requireDigest("ref", bad); err == nil {
+			t.Errorf("bad digest %q accepted", bad)
+		}
+	}
+}

--- a/internal/flightplan/freeze/lint.go
+++ b/internal/flightplan/freeze/lint.go
@@ -1,0 +1,131 @@
+package freeze
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+)
+
+// validStepKinds is the closed set of step kinds the schema permits. The
+// no-LLM guarantee is structural: only `llm-seam` reaches an LLM, and every
+// other kind is deterministic by construction. A step whose kind is absent
+// or outside this set could smuggle a non-deterministic call past the seam,
+// so the lint rejects it.
+var validStepKinds = map[string]bool{
+	"action-call": true,
+	"transform":   true,
+	"llm-seam":    true,
+}
+
+// llmSeamKind is the single ADR-0027-permitted non-deterministic seam.
+const llmSeamKind = "llm-seam"
+
+// LintError reports a freeze-time lint failure and names the offending
+// step so the author can fix it.
+type LintError struct {
+	StepID string
+	Reason string
+}
+
+func (e *LintError) Error() string {
+	if e.StepID != "" {
+		return fmt.Sprintf("freeze lint: step %q: %s", e.StepID, e.Reason)
+	}
+	return "freeze lint: " + e.Reason
+}
+
+// Lint runs the no-LLM lint over a parsed manifest's step graph. It accepts
+// a manifest whose only non-deterministic seam is an explicitly marked
+// `kind: llm-seam` step, and rejects any step that could reach an LLM
+// outside that seam.
+//
+// The structural rules, all keyed on the closed `kind` enum:
+//
+//   - every step must declare a `kind`;
+//   - that kind must be one of the schema's closed set (action-call,
+//     transform, llm-seam); an unknown kind is a smuggling vector;
+//   - a non-seam step must not carry an LLM marker (a key whose name marks
+//     a model/prompt/llm call). Only `llm-seam` may.
+//
+// Instruction-only manifests and manifests with no steps lint clean: there
+// is no composition that could reach an LLM.
+func Lint(m *manifest.Manifest) error {
+	if m == nil || m.InstructionOnly {
+		return nil
+	}
+	for i, raw := range m.Aileron.Steps {
+		step, ok := raw.(map[string]any)
+		if !ok {
+			return &LintError{
+				StepID: stepIDOf(raw),
+				Reason: fmt.Sprintf("step %d is not a mapping", i),
+			}
+		}
+		id := scalarString(step["id"])
+		kindVal, hasKind := step["kind"]
+		if !hasKind {
+			return &LintError{StepID: id, Reason: "missing kind (every step must declare a kind)"}
+		}
+		kind := scalarString(kindVal)
+		if !validStepKinds[kind] {
+			return &LintError{
+				StepID: id,
+				Reason: fmt.Sprintf("unknown step kind %q (only action-call, transform, and the marked llm-seam may appear)", kind),
+			}
+		}
+		if kind == llmSeamKind {
+			// The explicitly marked seam is the one permitted LLM reach.
+			continue
+		}
+		if marker := llmMarkerIn(step); marker != "" {
+			return &LintError{
+				StepID: id,
+				Reason: fmt.Sprintf("kind %q carries an LLM marker %q outside the llm-seam (mark it kind: llm-seam or remove the LLM call)", kind, marker),
+			}
+		}
+	}
+	return nil
+}
+
+// llmMarkers are the top-level step keys that indicate a non-deterministic
+// LLM call. A deterministic step (action-call, transform) that carries one
+// of these is trying to reach an LLM outside the marked seam, which the
+// lint rejects.
+var llmMarkers = []string{"llm", "model", "prompt", "completion", "inference"}
+
+// llmMarkerIn reports the first LLM marker key present on a step mapping, or
+// "" when none is. The closed step schema (additionalProperties:false)
+// already forbids these keys on a valid action-call/transform; the lint is
+// the freeze-time backstop that names the offending marker rather than
+// relying on schema validation alone.
+func llmMarkerIn(step map[string]any) string {
+	for _, marker := range llmMarkers {
+		if _, ok := step[marker]; ok {
+			return marker
+		}
+	}
+	return ""
+}
+
+// stepIDOf best-effort extracts a step id from an untyped step for error
+// messages, returning "" when the step has no usable id.
+func stepIDOf(raw any) string {
+	if m, ok := raw.(map[string]any); ok {
+		return scalarString(m["id"])
+	}
+	return ""
+}
+
+// scalarString coerces a YAML-decoded scalar to a string. Non-string
+// scalars (numbers, bools) format through fmt; nil yields "".
+func scalarString(v any) string {
+	switch t := v.(type) {
+	case nil:
+		return ""
+	case string:
+		return t
+	default:
+		return strings.TrimSpace(fmt.Sprintf("%v", t))
+	}
+}

--- a/internal/flightplan/freeze/lint_test.go
+++ b/internal/flightplan/freeze/lint_test.go
@@ -121,3 +121,42 @@ func TestLint_RejectsModelMarkerOnTransform(t *testing.T) {
 		t.Error("a transform carrying a model marker must fail lint")
 	}
 }
+
+func TestLint_NilManifestClean(t *testing.T) {
+	if err := Lint(nil); err != nil {
+		t.Errorf("Lint(nil) must be clean: %v", err)
+	}
+}
+
+func TestLintError_MessageWithAndWithoutStepID(t *testing.T) {
+	withID := &LintError{StepID: "s1", Reason: "bad"}
+	if got := withID.Error(); !strings.Contains(got, "s1") || !strings.Contains(got, "bad") {
+		t.Errorf("error with id = %q", got)
+	}
+	noID := &LintError{Reason: "global problem"}
+	if got := noID.Error(); strings.Contains(got, "step \"\"") || !strings.Contains(got, "global problem") {
+		t.Errorf("error without id = %q", got)
+	}
+}
+
+func TestScalarString_NonStringScalars(t *testing.T) {
+	// A non-string id (number) coerces to its string form; nil yields "".
+	m := manifestWithSteps([]any{
+		map[string]any{"id": 42, "kind": "not-a-kind"},
+	})
+	err := Lint(m)
+	if err == nil {
+		t.Fatal("bad kind must fail")
+	}
+	if !strings.Contains(err.Error(), "42") {
+		t.Errorf("numeric id should stringify in the error, got: %v", err)
+	}
+}
+
+func TestStepIDOf_NonMapping(t *testing.T) {
+	// A non-mapping step has no id; lint still names the failure without a panic.
+	m := manifestWithSteps([]any{12345})
+	if err := Lint(m); err == nil {
+		t.Error("a non-mapping step must fail lint")
+	}
+}

--- a/internal/flightplan/freeze/lint_test.go
+++ b/internal/flightplan/freeze/lint_test.go
@@ -1,0 +1,123 @@
+package freeze
+
+import (
+	"errors"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+)
+
+func TestLint_AcceptsWorkedExampleWithMarkedSeam(t *testing.T) {
+	m, err := manifest.Parse(exampleSkillMD(t))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := Lint(m); err != nil {
+		t.Errorf("worked example with a marked llm-seam must lint clean: %v", err)
+	}
+}
+
+func TestLint_InstructionOnlyClean(t *testing.T) {
+	m, err := manifest.Parse([]byte(instructionOnlyMD))
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if err := Lint(m); err != nil {
+		t.Errorf("instruction-only skill must lint clean: %v", err)
+	}
+}
+
+// A manifest is constructed directly (bypassing manifest.Parse schema
+// validation) so the lint's own structural rules are exercised: the lint is
+// the freeze-time backstop, not a re-run of schema validation.
+func manifestWithSteps(steps []any) *manifest.Manifest {
+	return &manifest.Manifest{
+		Name: "linttest",
+		Aileron: manifest.AileronBlock{
+			Steps: steps,
+		},
+	}
+}
+
+func TestLint_RejectsUnmarkedLLMStep(t *testing.T) {
+	// An action-call step that carries an LLM marker outside the seam.
+	m := manifestWithSteps([]any{
+		map[string]any{"id": "sneaky", "kind": "action-call", "actionRef": "aileron:x.y", "prompt": "summarize this"},
+	})
+	err := Lint(m)
+	if err == nil {
+		t.Fatal("an unmarked LLM call must fail lint")
+	}
+	var le *LintError
+	if !errors.As(err, &le) {
+		t.Fatalf("want *LintError, got %T", err)
+	}
+	if le.StepID != "sneaky" {
+		t.Errorf("error must name the offending step, got %q", le.StepID)
+	}
+	if !strings.Contains(err.Error(), "prompt") {
+		t.Errorf("error should name the LLM marker, got: %v", err)
+	}
+}
+
+func TestLint_AcceptsExplicitLLMSeam(t *testing.T) {
+	m := manifestWithSteps([]any{
+		map[string]any{"id": "summarize", "kind": "llm-seam", "outputs": []any{"text"}},
+	})
+	if err := Lint(m); err != nil {
+		t.Errorf("an explicitly marked llm-seam must lint clean: %v", err)
+	}
+}
+
+func TestLint_RejectsUnknownKind(t *testing.T) {
+	m := manifestWithSteps([]any{
+		map[string]any{"id": "weird", "kind": "magic-call"},
+	})
+	err := Lint(m)
+	if err == nil {
+		t.Fatal("an unknown step kind must fail lint")
+	}
+	if !strings.Contains(err.Error(), "weird") || !strings.Contains(err.Error(), "magic-call") {
+		t.Errorf("error should name the step and the bad kind, got: %v", err)
+	}
+}
+
+func TestLint_RejectsMissingKind(t *testing.T) {
+	m := manifestWithSteps([]any{
+		map[string]any{"id": "nokind"},
+	})
+	err := Lint(m)
+	if err == nil {
+		t.Fatal("a step with no kind must fail lint")
+	}
+	if !strings.Contains(err.Error(), "nokind") {
+		t.Errorf("error should name the step, got: %v", err)
+	}
+}
+
+func TestLint_RejectsNonMappingStep(t *testing.T) {
+	m := manifestWithSteps([]any{"not-a-mapping"})
+	if err := Lint(m); err == nil {
+		t.Error("a non-mapping step must fail lint")
+	}
+}
+
+func TestLint_AcceptsCleanTransform(t *testing.T) {
+	m := manifestWithSteps([]any{
+		map[string]any{"id": "render", "kind": "transform", "outputs": []any{"csv"}},
+		map[string]any{"id": "call", "kind": "action-call", "actionRef": "aileron:x.y"},
+	})
+	if err := Lint(m); err != nil {
+		t.Errorf("clean transform + action-call must lint clean: %v", err)
+	}
+}
+
+func TestLint_RejectsModelMarkerOnTransform(t *testing.T) {
+	m := manifestWithSteps([]any{
+		map[string]any{"id": "t", "kind": "transform", "outputs": []any{"x"}, "model": "gpt-4"},
+	})
+	if err := Lint(m); err == nil {
+		t.Error("a transform carrying a model marker must fail lint")
+	}
+}

--- a/internal/flightplan/freeze/lock.go
+++ b/internal/flightplan/freeze/lock.go
@@ -1,0 +1,202 @@
+package freeze
+
+import (
+	"fmt"
+	"strings"
+
+	"gopkg.in/yaml.v3"
+)
+
+// ImagePin pairs a pre-freeze image reference with the content-addressed
+// digest freeze resolved it to. It mirrors the schema
+// `$defs.lock.resolvedImages[]` item exactly.
+type ImagePin struct {
+	Ref    string `yaml:"ref" json:"ref"`
+	Digest string `yaml:"digest" json:"digest"`
+}
+
+// Lockfile is the resolved lock-and-digest record freeze produces. Its
+// field names and shape match the schema `$defs.lock` so the same data
+// round-trips into the manifest `lock` block and the standalone
+// `aileron.lock` artifact.
+type Lockfile struct {
+	// ResolvedImages are the resolved image digest pins. Empty for an
+	// instruction-only or no-execution-environment skill.
+	ResolvedImages []ImagePin `yaml:"resolvedImages,omitempty" json:"resolvedImages,omitempty"`
+	// ResolvedCapabilitySet is the capability set freeze pinned (rung-2).
+	ResolvedCapabilitySet []string `yaml:"resolvedCapabilitySet,omitempty" json:"resolvedCapabilitySet,omitempty"`
+	// ContentHash identifies the exact frozen manifest bytes
+	// (`sha256:<hex>`). It is computed last and excluded from the bytes it
+	// hashes, so a Lockfile passed to the content hasher must have it empty.
+	ContentHash string `yaml:"contentHash,omitempty" json:"contentHash,omitempty"`
+	// Version is the human-facing semver label for this frozen version.
+	Version string `yaml:"version,omitempty" json:"version,omitempty"`
+}
+
+// withoutContentHash returns a copy of the lockfile with ContentHash
+// cleared. The content hash cannot reference its own value, so the bytes it
+// is taken over must omit it (see content.go).
+func (l Lockfile) withoutContentHash() Lockfile {
+	l.ContentHash = ""
+	return l
+}
+
+// MarshalLockfile renders the lockfile as the standalone `aileron.lock`
+// artifact: stable YAML with the schema field names.
+func MarshalLockfile(l Lockfile) ([]byte, error) {
+	out, err := yaml.Marshal(l)
+	if err != nil {
+		return nil, fmt.Errorf("freeze: marshal lockfile: %w", err)
+	}
+	return out, nil
+}
+
+// lockNode renders a Lockfile as a yaml.Node mapping suitable for splicing
+// under the `aileron` block. Marshaling through a typed value and decoding
+// back into a Node keeps the omitempty rules and field order consistent
+// with MarshalLockfile.
+func lockNode(l Lockfile) (*yaml.Node, error) {
+	raw, err := yaml.Marshal(l)
+	if err != nil {
+		return nil, fmt.Errorf("freeze: marshal lock block: %w", err)
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(raw, &doc); err != nil {
+		return nil, fmt.Errorf("freeze: decode lock block: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) != 1 {
+		return nil, fmt.Errorf("freeze: unexpected lock block shape")
+	}
+	return doc.Content[0], nil
+}
+
+// injectLock rewrites raw SKILL.md bytes so the `aileron` block carries the
+// given lock. It splits the frontmatter, decodes it as a YAML node tree
+// (preserving every sibling key and its order), sets or replaces
+// `aileron.lock`, and re-emits the document. The result re-parses cleanly
+// through manifest.Parse.
+//
+// Freeze canonicalizes line endings to LF (the same normalization
+// manifest.Parse applies when splitting frontmatter). The frozen output is
+// therefore LF-canonical regardless of the input's line endings, which
+// keeps the content hash and signature stable: a CRLF SKILL.md and its LF
+// twin freeze to byte-identical artifacts. The Markdown body is preserved
+// verbatim aside from this LF canonicalization.
+//
+// injectLock is the freeze-time write primitive: there is no manifest
+// re-emit path in the manifest package, so freeze injects the lock into the
+// raw frontmatter here.
+// injectLockMaybe injects the lock when the manifest has an aileron block,
+// and returns the LF-canonicalized manifest unchanged when it is
+// instruction-only (no aileron block to carry a lock). An instruction-only
+// Flight Plan still gets a content hash and signature: the lock data lives
+// in the standalone lockfile, which is part of the hashed canonical bytes.
+func injectLockMaybe(raw []byte, l Lockfile, instructionOnly bool) ([]byte, error) {
+	if instructionOnly {
+		return canonicalizeNewlines(raw), nil
+	}
+	return injectLock(raw, l)
+}
+
+// canonicalizeNewlines normalizes CRLF to LF so an instruction-only frozen
+// manifest follows the same freeze-wide newline contract as the
+// lock-injection path.
+func canonicalizeNewlines(raw []byte) []byte {
+	return []byte(strings.ReplaceAll(string(raw), "\r\n", "\n"))
+}
+
+func injectLock(raw []byte, l Lockfile) ([]byte, error) {
+	front, body, fence, ok := splitFrontmatter(raw)
+	if !ok {
+		return nil, fmt.Errorf("freeze: no YAML frontmatter to inject lock into")
+	}
+
+	var doc yaml.Node
+	if err := yaml.Unmarshal(front, &doc); err != nil {
+		return nil, fmt.Errorf("freeze: parse frontmatter for lock injection: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return nil, fmt.Errorf("freeze: frontmatter is not a YAML mapping")
+	}
+	root := doc.Content[0]
+	if root.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("freeze: frontmatter root is not a mapping")
+	}
+
+	aileron := mappingValue(root, "aileron")
+	if aileron == nil {
+		return nil, fmt.Errorf("freeze: manifest has no aileron block to lock")
+	}
+	if aileron.Kind != yaml.MappingNode {
+		return nil, fmt.Errorf("freeze: aileron block is not a mapping")
+	}
+
+	ln, err := lockNode(l)
+	if err != nil {
+		return nil, err
+	}
+	setMappingValue(aileron, "lock", ln)
+
+	frontOut, err := yaml.Marshal(&doc)
+	if err != nil {
+		return nil, fmt.Errorf("freeze: re-emit frontmatter: %w", err)
+	}
+	frontOut = []byte(strings.TrimRight(string(frontOut), "\n"))
+
+	var b strings.Builder
+	b.WriteString(fence)
+	b.WriteByte('\n')
+	b.Write(frontOut)
+	b.WriteByte('\n')
+	b.WriteString(fence)
+	b.WriteByte('\n')
+	b.WriteString(body)
+	return []byte(b.String()), nil
+}
+
+// mappingValue returns the value node for key in a mapping node, or nil.
+func mappingValue(m *yaml.Node, key string) *yaml.Node {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			return m.Content[i+1]
+		}
+	}
+	return nil
+}
+
+// setMappingValue sets key to val in a mapping node, replacing an existing
+// entry or appending a new key/value pair at the end.
+func setMappingValue(m *yaml.Node, key string, val *yaml.Node) {
+	for i := 0; i+1 < len(m.Content); i += 2 {
+		if m.Content[i].Value == key {
+			m.Content[i+1] = val
+			return
+		}
+	}
+	k := &yaml.Node{Kind: yaml.ScalarNode, Tag: "!!str", Value: key}
+	m.Content = append(m.Content, k, val)
+}
+
+// splitFrontmatter splits a SKILL.md document into its YAML frontmatter and
+// the remaining body, returning the fence string used. It mirrors the
+// manifest package splitter: it opens on a `---` fence and closes on the
+// first standalone `---` line so a body thematic break is never mistaken
+// for the closing fence. Line endings are canonicalized to LF (see
+// injectLock): this is the freeze-wide newline contract that keeps frozen
+// output stable across CRLF and LF inputs.
+func splitFrontmatter(raw []byte) (front []byte, body, fence string, ok bool) {
+	const f = "---"
+	text := strings.ReplaceAll(string(raw), "\r\n", "\n")
+	lines := strings.Split(text, "\n")
+	if len(lines) == 0 || lines[0] != f {
+		return nil, "", "", false
+	}
+	for i := 1; i < len(lines); i++ {
+		if lines[i] == f {
+			front = []byte(strings.Join(lines[1:i], "\n"))
+			body = strings.Join(lines[i+1:], "\n")
+			return front, body, f, true
+		}
+	}
+	return nil, "", "", false
+}

--- a/internal/flightplan/freeze/lock_test.go
+++ b/internal/flightplan/freeze/lock_test.go
@@ -1,0 +1,166 @@
+package freeze
+
+import (
+	"reflect"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+	"gopkg.in/yaml.v3"
+)
+
+func sampleLock() Lockfile {
+	return Lockfile{
+		ResolvedImages: []ImagePin{
+			{Ref: "registry.example.com/runner:1.4", Digest: fakeDigest},
+		},
+		ResolvedCapabilitySet: []string{"ghcr.io/example/feature:1"},
+		ContentHash:           fakeDigest2,
+		Version:               "1.2.3",
+	}
+}
+
+func TestMarshalLockfile_RoundTrip(t *testing.T) {
+	want := sampleLock()
+	b, err := MarshalLockfile(want)
+	if err != nil {
+		t.Fatalf("MarshalLockfile: %v", err)
+	}
+	var got Lockfile
+	if err := yaml.Unmarshal(b, &got); err != nil {
+		t.Fatalf("unmarshal: %v", err)
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("round-trip mismatch:\n got=%+v\nwant=%+v", got, want)
+	}
+}
+
+// The marshaled lock must match the schema `$defs.lock` field names so the
+// injected block validates and the standalone artifact is the same shape.
+func TestMarshalLockfile_UsesSchemaFieldNames(t *testing.T) {
+	b, err := MarshalLockfile(sampleLock())
+	if err != nil {
+		t.Fatalf("MarshalLockfile: %v", err)
+	}
+	s := string(b)
+	for _, key := range []string{"resolvedImages:", "resolvedCapabilitySet:", "contentHash:", "version:", "ref:", "digest:"} {
+		if !strings.Contains(s, key) {
+			t.Errorf("lockfile missing schema field %q:\n%s", key, s)
+		}
+	}
+}
+
+func TestInjectLock_PreservesSiblingKeysAndReparses(t *testing.T) {
+	raw := exampleSkillMD(t)
+	out, err := injectLock(raw, sampleLock())
+	if err != nil {
+		t.Fatalf("injectLock: %v", err)
+	}
+
+	// Re-parses cleanly through manifest.Parse with the lock present.
+	m, err := manifest.Parse(out)
+	if err != nil {
+		t.Fatalf("re-parse frozen manifest: %v", err)
+	}
+	if m.Name != "weekly-metrics-digest" {
+		t.Errorf("name lost on inject: %q", m.Name)
+	}
+	if m.Aileron.SchemaVersion != "aileron.flightplan.v1" {
+		t.Errorf("schemaVersion lost: %q", m.Aileron.SchemaVersion)
+	}
+	if len(m.Aileron.Requires.Actions) != 2 {
+		t.Errorf("requires.actions lost: %d", len(m.Aileron.Requires.Actions))
+	}
+	if len(m.Aileron.Steps) != 4 {
+		t.Errorf("steps lost: %d", len(m.Aileron.Steps))
+	}
+	if m.Aileron.Lock["contentHash"] != fakeDigest2 {
+		t.Errorf("lock.contentHash = %v", m.Aileron.Lock["contentHash"])
+	}
+
+	// Body preserved.
+	if !strings.Contains(m.Body, "# Weekly Metrics Digest") {
+		t.Error("markdown body not preserved through injection")
+	}
+}
+
+func TestInjectLock_ReplacesExistingLock(t *testing.T) {
+	raw := exampleSkillMD(t)
+	first, err := injectLock(raw, Lockfile{Version: "1.0.0", ContentHash: fakeDigest})
+	if err != nil {
+		t.Fatalf("first inject: %v", err)
+	}
+	second, err := injectLock(first, Lockfile{Version: "2.0.0", ContentHash: fakeDigest2})
+	if err != nil {
+		t.Fatalf("second inject: %v", err)
+	}
+	m, err := manifest.Parse(second)
+	if err != nil {
+		t.Fatalf("parse: %v", err)
+	}
+	if m.Aileron.Lock["version"] != "2.0.0" {
+		t.Errorf("lock not replaced: version = %v", m.Aileron.Lock["version"])
+	}
+	// Only one lock key (no duplicate).
+	if strings.Count(string(second), "\n  lock:") > 1 {
+		t.Errorf("duplicate lock block:\n%s", second)
+	}
+}
+
+func TestInjectLock_NoAileronBlock(t *testing.T) {
+	if _, err := injectLock([]byte(instructionOnlyMD), sampleLock()); err == nil {
+		t.Error("injectLock into an instruction-only manifest must error")
+	}
+}
+
+func TestInjectLock_NoFrontmatter(t *testing.T) {
+	if _, err := injectLock([]byte("no frontmatter here"), sampleLock()); err == nil {
+		t.Error("injectLock without frontmatter must error")
+	}
+}
+
+func TestInjectLock_CRLFProducesStableLFOutput(t *testing.T) {
+	lf := exampleSkillMD(t)
+	crlf := []byte(strings.ReplaceAll(string(lf), "\n", "\r\n"))
+
+	outLF, err := injectLock(lf, sampleLock())
+	if err != nil {
+		t.Fatalf("inject LF: %v", err)
+	}
+	outCRLF, err := injectLock(crlf, sampleLock())
+	if err != nil {
+		t.Fatalf("inject CRLF: %v", err)
+	}
+	if string(outLF) != string(outCRLF) {
+		t.Error("a CRLF SKILL.md must freeze to byte-identical output as its LF twin")
+	}
+	// And the output is LF-canonical (no stray CR).
+	if strings.Contains(string(outCRLF), "\r") {
+		t.Error("frozen output must be LF-canonical")
+	}
+}
+
+func TestInjectLockMaybe_InstructionOnlyReturnsCanonicalRaw(t *testing.T) {
+	crlf := []byte(strings.ReplaceAll(instructionOnlyMD, "\n", "\r\n"))
+	out, err := injectLockMaybe(crlf, sampleLock(), true)
+	if err != nil {
+		t.Fatalf("injectLockMaybe: %v", err)
+	}
+	if strings.Contains(string(out), "lock:") {
+		t.Error("an instruction-only manifest must not gain a lock block")
+	}
+	if strings.Contains(string(out), "\r") {
+		t.Error("instruction-only frozen output must be LF-canonical")
+	}
+}
+
+func TestWithoutContentHash_ClearsHashOnly(t *testing.T) {
+	l := sampleLock()
+	got := l.withoutContentHash()
+	if got.ContentHash != "" {
+		t.Errorf("ContentHash not cleared: %q", got.ContentHash)
+	}
+	if got.Version != "1.2.3" || len(got.ResolvedImages) != 1 {
+		t.Error("withoutContentHash must only clear the hash")
+	}
+}

--- a/internal/flightplan/freeze/lock_test.go
+++ b/internal/flightplan/freeze/lock_test.go
@@ -119,6 +119,23 @@ func TestInjectLock_NoFrontmatter(t *testing.T) {
 	}
 }
 
+func TestInjectLock_AileronNotAMapping(t *testing.T) {
+	// An `aileron` key whose value is a scalar (not a mapping) is a
+	// malformed manifest; injectLock must error rather than corrupt it.
+	const bad = "---\nname: x\naileron: not-a-mapping\n---\nbody\n"
+	if _, err := injectLock([]byte(bad), sampleLock()); err == nil {
+		t.Error("injectLock must error when aileron is not a mapping")
+	}
+}
+
+func TestInjectLock_FrontmatterNotAMapping(t *testing.T) {
+	// Frontmatter that is a YAML sequence, not a mapping.
+	const bad = "---\n- a\n- b\n---\nbody\n"
+	if _, err := injectLock([]byte(bad), sampleLock()); err == nil {
+		t.Error("injectLock must error when frontmatter is not a mapping")
+	}
+}
+
 func TestInjectLock_CRLFProducesStableLFOutput(t *testing.T) {
 	lf := exampleSkillMD(t)
 	crlf := []byte(strings.ReplaceAll(string(lf), "\n", "\r\n"))

--- a/internal/flightplan/freeze/sign.go
+++ b/internal/flightplan/freeze/sign.go
@@ -1,0 +1,123 @@
+package freeze
+
+import (
+	"crypto/ed25519"
+	"crypto/x509"
+	"encoding/pem"
+	"fmt"
+	"os"
+	"strings"
+)
+
+// SigningKeyEnv is the environment variable freeze reads the signing-key
+// path from when no explicit path is supplied. The value is a path to a
+// PEM-encoded ed25519 private key; the key bytes themselves are never
+// carried in the environment.
+const SigningKeyEnv = "AILERON_SIGNING_KEY"
+
+// LoadSigningKey loads a PEM-encoded ed25519 private key from path, or —
+// when path is empty — from the file named by $AILERON_SIGNING_KEY. The
+// private key is read into memory for signing only; it is never written
+// into the frozen artifact or the store (only the public key and the
+// detached signature are persisted).
+//
+// The PEM form is the standard PKCS#8 ed25519 private key
+// (`openssl genpkey -algorithm ed25519`). Mirrors the PEM/ed25519
+// conventions in cmd/aileron/keyring.go.
+func LoadSigningKey(path string) (ed25519.PrivateKey, error) {
+	if path == "" {
+		path = os.Getenv(SigningKeyEnv)
+	}
+	if path == "" {
+		return nil, fmt.Errorf("freeze: no signing key: pass --signing-key or set %s", SigningKeyEnv)
+	}
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return nil, fmt.Errorf("freeze: read signing key %q: %w", path, err)
+	}
+	return ParsePEMPrivateKey(data)
+}
+
+// ParsePEMPrivateKey decodes a PEM-encoded PKCS#8 ed25519 private key.
+func ParsePEMPrivateKey(pemBytes []byte) (ed25519.PrivateKey, error) {
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		return nil, fmt.Errorf("freeze: signing key is not PEM-encoded")
+	}
+	key, err := x509.ParsePKCS8PrivateKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("freeze: parse PKCS#8 private key: %w", err)
+	}
+	priv, ok := key.(ed25519.PrivateKey)
+	if !ok {
+		return nil, fmt.Errorf("freeze: signing key is not ed25519 (got %T)", key)
+	}
+	return priv, nil
+}
+
+// MarshalPublicKeyPEM renders an ed25519 public key as PKIX PEM, the form
+// cstore.ParsePEMPublicKey and the keyring read (so Launch verification and
+// `keyring trust` consume the stored signing-key.pub directly).
+func MarshalPublicKeyPEM(pub ed25519.PublicKey) ([]byte, error) {
+	der, err := x509.MarshalPKIXPublicKey(pub)
+	if err != nil {
+		return nil, fmt.Errorf("freeze: marshal public key: %w", err)
+	}
+	return pem.EncodeToMemory(&pem.Block{Type: "PUBLIC KEY", Bytes: der}), nil
+}
+
+// Sign produces a detached ed25519 signature over the content bytes and
+// returns the signature plus the PEM-encoded public key. The content bytes
+// are the canonical content-hash input (the same bytes contentHash is taken
+// over), so a verifier confirms the signature covers the exact frozen unit.
+//
+// ed25519 is deterministic for a fixed key and message, so re-signing
+// byte-identical content yields a byte-identical signature.
+func Sign(priv ed25519.PrivateKey, content []byte) (sig, pubPEM []byte, err error) {
+	if len(priv) != ed25519.PrivateKeySize {
+		return nil, nil, fmt.Errorf("freeze: signing key has wrong length %d", len(priv))
+	}
+	pub, ok := priv.Public().(ed25519.PublicKey)
+	if !ok {
+		return nil, nil, fmt.Errorf("freeze: signing key has no ed25519 public half")
+	}
+	pubPEM, err = MarshalPublicKeyPEM(pub)
+	if err != nil {
+		return nil, nil, err
+	}
+	return ed25519.Sign(priv, content), pubPEM, nil
+}
+
+// Verify checks a detached ed25519 signature over content against a
+// PEM-encoded public key. It is self-contained (signature + public key
+// only) so Launch (#1511) can call it without the private key or any store
+// access. Returns nil when the signature is valid, an error otherwise.
+func Verify(content, sig, pubPEM []byte) error {
+	pub, err := parsePublicKeyPEM(pubPEM)
+	if err != nil {
+		return err
+	}
+	if !ed25519.Verify(pub, content, sig) {
+		return fmt.Errorf("freeze: signature does not verify against the public key")
+	}
+	return nil
+}
+
+// parsePublicKeyPEM decodes a PKIX PEM ed25519 public key. Kept local so
+// the freeze package does not depend on cmd/aileron; it accepts the same
+// PEM form MarshalPublicKeyPEM emits.
+func parsePublicKeyPEM(pemBytes []byte) (ed25519.PublicKey, error) {
+	block, _ := pem.Decode([]byte(strings.TrimSpace(string(pemBytes))))
+	if block == nil {
+		return nil, fmt.Errorf("freeze: public key is not PEM-encoded")
+	}
+	key, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		return nil, fmt.Errorf("freeze: parse PKIX public key: %w", err)
+	}
+	pub, ok := key.(ed25519.PublicKey)
+	if !ok {
+		return nil, fmt.Errorf("freeze: public key is not ed25519 (got %T)", key)
+	}
+	return pub, nil
+}

--- a/internal/flightplan/freeze/sign_test.go
+++ b/internal/flightplan/freeze/sign_test.go
@@ -1,0 +1,162 @@
+package freeze
+
+import (
+	"bytes"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestSignVerify_RoundTrip(t *testing.T) {
+	priv, _ := genSigningKey(t)
+	content := []byte("the canonical content bytes")
+	sig, pubPEM, err := Sign(priv, content)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := Verify(content, sig, pubPEM); err != nil {
+		t.Errorf("Verify must succeed on the signed content: %v", err)
+	}
+}
+
+func TestVerify_TamperedContentFails(t *testing.T) {
+	priv, _ := genSigningKey(t)
+	sig, pubPEM, err := Sign(priv, []byte("original"))
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if err := Verify([]byte("tampered"), sig, pubPEM); err == nil {
+		t.Error("Verify must fail on tampered content")
+	}
+}
+
+func TestVerify_WrongPublicKeyFails(t *testing.T) {
+	priv, _ := genSigningKey(t)
+	content := []byte("content")
+	sig, _, err := Sign(priv, content)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	// A different key's public PEM.
+	otherPub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	otherPEM, err := MarshalPublicKeyPEM(otherPub)
+	if err != nil {
+		t.Fatal(err)
+	}
+	if err := Verify(content, sig, otherPEM); err == nil {
+		t.Error("Verify must fail against the wrong public key")
+	}
+}
+
+func TestSign_Deterministic(t *testing.T) {
+	priv, _ := genSigningKey(t)
+	content := []byte("deterministic message")
+	a, _, err := Sign(priv, content)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	b, _, err := Sign(priv, content)
+	if err != nil {
+		t.Fatalf("Sign: %v", err)
+	}
+	if !bytes.Equal(a, b) {
+		t.Error("ed25519 signature must be deterministic for a fixed key+message")
+	}
+}
+
+func TestLoadSigningKey_FromPath(t *testing.T) {
+	_, path := genSigningKey(t)
+	priv, err := LoadSigningKey(path)
+	if err != nil {
+		t.Fatalf("LoadSigningKey: %v", err)
+	}
+	if len(priv) != ed25519.PrivateKeySize {
+		t.Errorf("loaded key has length %d", len(priv))
+	}
+}
+
+func TestLoadSigningKey_FromEnv(t *testing.T) {
+	_, path := genSigningKey(t)
+	t.Setenv(SigningKeyEnv, path)
+	if _, err := LoadSigningKey(""); err != nil {
+		t.Errorf("LoadSigningKey from env: %v", err)
+	}
+}
+
+func TestLoadSigningKey_MissingPath(t *testing.T) {
+	t.Setenv(SigningKeyEnv, "")
+	if _, err := LoadSigningKey(""); err == nil {
+		t.Error("no key path and no env must error")
+	}
+	if _, err := LoadSigningKey(filepath.Join(t.TempDir(), "nope.pem")); err == nil {
+		t.Error("a nonexistent key path must error")
+	}
+}
+
+func TestLoadSigningKey_MalformedKey(t *testing.T) {
+	dir := t.TempDir()
+	bad := filepath.Join(dir, "bad.pem")
+	if err := os.WriteFile(bad, []byte("not a pem block"), 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadSigningKey(bad); err == nil {
+		t.Error("a non-PEM key must error")
+	}
+
+	// A PEM block that is not an ed25519 key.
+	wrong := filepath.Join(dir, "wrong.pem")
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: []byte("garbage")})
+	if err := os.WriteFile(wrong, pemBytes, 0o600); err != nil {
+		t.Fatal(err)
+	}
+	if _, err := LoadSigningKey(wrong); err == nil {
+		t.Error("a malformed PKCS#8 key must error")
+	}
+}
+
+func TestParsePEMPrivateKey_RejectsNonEd25519(t *testing.T) {
+	// Marshal a valid PKCS#8 of a non-ed25519 key shape is awkward without
+	// importing rsa; instead assert the ed25519 happy path parses and a
+	// garbage DER fails.
+	_, path := genSigningKey(t)
+	data, err := os.ReadFile(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+	priv, err := ParsePEMPrivateKey(data)
+	if err != nil {
+		t.Fatalf("ParsePEMPrivateKey: %v", err)
+	}
+	if _, ok := priv.Public().(ed25519.PublicKey); !ok {
+		t.Error("parsed key is not ed25519")
+	}
+}
+
+func TestMarshalPublicKeyPEM_ConsumableByX509(t *testing.T) {
+	pub, _, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatal(err)
+	}
+	pemBytes, err := MarshalPublicKeyPEM(pub)
+	if err != nil {
+		t.Fatalf("MarshalPublicKeyPEM: %v", err)
+	}
+	block, _ := pem.Decode(pemBytes)
+	if block == nil {
+		t.Fatal("not a PEM block")
+	}
+	parsed, err := x509.ParsePKIXPublicKey(block.Bytes)
+	if err != nil {
+		t.Fatalf("ParsePKIXPublicKey: %v", err)
+	}
+	if !pub.Equal(parsed) {
+		t.Error("round-tripped public key differs")
+	}
+}

--- a/internal/flightplan/freeze/sign_test.go
+++ b/internal/flightplan/freeze/sign_test.go
@@ -139,6 +139,25 @@ func TestParsePEMPrivateKey_RejectsNonEd25519(t *testing.T) {
 	}
 }
 
+func TestSign_RejectsWrongLengthKey(t *testing.T) {
+	// A private key of the wrong length must be rejected before signing.
+	if _, _, err := Sign(ed25519.PrivateKey([]byte("too short")), []byte("x")); err == nil {
+		t.Error("Sign must reject a wrong-length private key")
+	}
+}
+
+func TestVerify_MalformedSignature(t *testing.T) {
+	priv, _ := genSigningKey(t)
+	_, pubPEM, err := Sign(priv, []byte("content"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	// A signature of the wrong size fails verification (not a panic).
+	if err := Verify([]byte("content"), []byte("not-a-real-sig"), pubPEM); err == nil {
+		t.Error("Verify must fail on a malformed signature")
+	}
+}
+
 func TestMarshalPublicKeyPEM_ConsumableByX509(t *testing.T) {
 	pub, _, err := ed25519.GenerateKey(rand.Reader)
 	if err != nil {

--- a/internal/flightplan/freeze/testdata_test.go
+++ b/internal/flightplan/freeze/testdata_test.go
@@ -1,0 +1,136 @@
+package freeze
+
+import (
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"runtime"
+	"testing"
+)
+
+// repoRoot walks up to the directory containing go.work so tests can read
+// the committed worked example as a known-valid credentialed skill.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.work from %s", filepath.Dir(file))
+		}
+		dir = parent
+	}
+}
+
+// exampleSkillMD reads the committed rung-2 worked example SKILL.md.
+func exampleSkillMD(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatalf("read worked example: %v", err)
+	}
+	return raw
+}
+
+// instructionOnlyMD is a SKILL.md with no aileron block.
+const instructionOnlyMD = `---
+name: rubber-duck
+description: Instruction-only skill.
+---
+
+# Rubber Duck
+Explain it out loud.
+`
+
+// rung1MD is a minimal valid rung-1 manifest (named image to resolve).
+const rung1MD = `---
+name: rung1-skill
+description: A rung-1 skill naming a prebuilt image.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+    executionEnvironment:
+      rung1Image:
+        ref: registry.example.com/runner:1.4
+  inputs: []
+  outputs: []
+---
+
+# Rung 1 Skill
+`
+
+// noExecEnvMD is a valid manifest with an aileron block but no
+// executionEnvironment (composition-only, no images to resolve).
+const noExecEnvMD = `---
+name: no-exec-env
+description: A skill with an aileron block but no execution environment.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+  inputs: []
+  outputs: []
+---
+
+# No Exec Env
+`
+
+// genSigningKey returns a fresh ed25519 private key and writes its PKCS#8
+// PEM form to a temp file, returning the path. Mirrors the keyring PEM
+// conventions; used to exercise LoadSigningKey + Sign.
+func genSigningKey(t *testing.T) (ed25519.PrivateKey, string) {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	pemBytes := pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der})
+	path := filepath.Join(t.TempDir(), "signing-key.pem")
+	if err := os.WriteFile(path, pemBytes, 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+	return priv, path
+}
+
+// fakeDigest is a valid sha256 digest for tests.
+const fakeDigest = "sha256:" + "0123456789abcdef0123456789abcdef0123456789abcdef0123456789abcdef"
+const fakeDigest2 = "sha256:" + "fedcba9876543210fedcba9876543210fedcba9876543210fedcba9876543210"

--- a/internal/flightplan/store/freeze.go
+++ b/internal/flightplan/store/freeze.go
@@ -1,0 +1,207 @@
+package store
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"path/filepath"
+	"sort"
+)
+
+// Frozen-version artifact file names. A frozen version directory holds the
+// frozen SKILL.md (lock injected), the standalone lockfile, the detached
+// signature, and the author public key. The signing private key is NEVER
+// among them.
+const (
+	frozenSkillFile     = "SKILL.md"
+	frozenLockFile      = "aileron.lock"
+	frozenSignatureFile = "signature.sig"
+	frozenPublicKeyFile = "signing-key.pub"
+
+	// versionsSubdir is the per-skill subdirectory holding immutable frozen
+	// versions, `<root>/<name>/versions/<id>/`. The pre-freeze installed
+	// SKILL.md at the name root is never touched.
+	versionsSubdir = "versions"
+)
+
+// FrozenVersion is the content of one immutable frozen skill version: the
+// freeze artifacts plus the version id the store keys the directory on.
+type FrozenVersion struct {
+	// ID is the version directory name, `<root>/<name>/versions/<ID>/`. It
+	// must be a single path segment (no separators). Freeze uses a short
+	// contentHash slug so distinct content lands in distinct directories.
+	ID string
+	// SkillMD is the frozen SKILL.md bytes (lock block injected).
+	SkillMD []byte
+	// Lockfile is the standalone aileron.lock bytes.
+	Lockfile []byte
+	// Signature is the detached ed25519 signature bytes.
+	Signature []byte
+	// PublicKey is the PEM-encoded author public key bytes.
+	PublicKey []byte
+}
+
+// FrozenDir returns the on-disk directory for a named skill's frozen
+// version, `<root>/<name>/versions/<id>`. It does not create the directory.
+func (s *Store) FrozenDir(name, id string) string {
+	return filepath.Join(s.Dir(name), versionsSubdir, id)
+}
+
+// WriteFrozen writes an immutable frozen version into the canonical store
+// under `<root>/<name>/versions/<id>/`. Prior versions are never mutated or
+// deleted: a new version id always creates a new directory.
+//
+// Re-writing an id that already exists is a verified no-op when the bytes
+// are identical (idempotent re-freeze of the same content), and a hard
+// error when the bytes differ (immutability: a version id never silently
+// overwrites differing content). The pre-freeze installed SKILL.md at the
+// name root is untouched.
+func (s *Store) WriteFrozen(name string, v FrozenVersion) error {
+	if name == "" {
+		return fmt.Errorf("store: frozen write needs a skill name")
+	}
+	if v.ID == "" {
+		return fmt.Errorf("store: frozen version needs an id")
+	}
+	if err := validVersionID(v.ID); err != nil {
+		return err
+	}
+
+	dir := s.FrozenDir(name, v.ID)
+	files := map[string][]byte{
+		frozenSkillFile:     v.SkillMD,
+		frozenLockFile:      v.Lockfile,
+		frozenSignatureFile: v.Signature,
+		frozenPublicKeyFile: v.PublicKey,
+	}
+
+	if _, err := os.Stat(dir); err == nil {
+		// The version already exists: accept only a byte-identical rewrite,
+		// reject differing content (never overwrite in place).
+		if err := verifyFrozenIdentical(dir, files); err != nil {
+			return err
+		}
+		return nil
+	} else if !os.IsNotExist(err) {
+		return fmt.Errorf("store: stat frozen version dir: %w", err)
+	}
+
+	// Write atomically: stage every artifact in a sibling temp directory,
+	// then rename it into place only after all writes succeed. A mid-write
+	// failure therefore never leaves a partially populated version directory
+	// that a later retry's identical-content check would trip over.
+	parent := filepath.Dir(dir)
+	if err := os.MkdirAll(parent, 0o755); err != nil {
+		return fmt.Errorf("store: create frozen versions dir: %w", err)
+	}
+	tmp, err := os.MkdirTemp(parent, v.ID+".tmp-*")
+	if err != nil {
+		return fmt.Errorf("store: create temp frozen dir: %w", err)
+	}
+	defer os.RemoveAll(tmp)
+	for fname, data := range files {
+		if err := copyBytes(filepath.Join(tmp, fname), data, 0o644); err != nil {
+			return fmt.Errorf("store: write frozen %s: %w", fname, err)
+		}
+	}
+	if err := os.Rename(tmp, dir); err != nil {
+		// A concurrent writer may have created dir between the stat above and
+		// this rename. Fall back to the identical-content check so a racing
+		// duplicate freeze of the same content is still a no-op.
+		if _, statErr := os.Stat(dir); statErr == nil {
+			return verifyFrozenIdentical(dir, files)
+		}
+		return fmt.Errorf("store: finalize frozen version dir: %w", err)
+	}
+	return nil
+}
+
+// validVersionID rejects any id that is not a single, safe path segment so
+// a crafted id can never escape the versions directory through FrozenDir.
+func validVersionID(id string) error {
+	if id == "" || filepath.Base(id) != id || id == "." || id == ".." {
+		return fmt.Errorf("store: frozen version id %q must be a single path segment", id)
+	}
+	return nil
+}
+
+// verifyFrozenIdentical confirms every artifact in an existing version
+// directory matches the supplied bytes, returning an error naming the first
+// mismatch. This is what makes a re-freeze of identical content a no-op
+// while a content change to the same id is rejected.
+func verifyFrozenIdentical(dir string, files map[string][]byte) error {
+	for fname, want := range files {
+		got, err := os.ReadFile(filepath.Join(dir, fname))
+		if err != nil {
+			return fmt.Errorf("store: frozen version exists but %s is unreadable: %w", fname, err)
+		}
+		if !bytes.Equal(got, want) {
+			return fmt.Errorf("store: frozen version already exists with different %s; a version id is immutable", fname)
+		}
+	}
+	return nil
+}
+
+// FrozenVersions lists the frozen version ids for a skill in sorted order.
+// A skill with no frozen versions lists as empty (not an error).
+func (s *Store) FrozenVersions(name string) ([]string, error) {
+	dir := filepath.Join(s.Dir(name), versionsSubdir)
+	entries, err := os.ReadDir(dir)
+	if err != nil {
+		if os.IsNotExist(err) {
+			return nil, nil
+		}
+		return nil, fmt.Errorf("store: read frozen versions: %w", err)
+	}
+	var ids []string
+	for _, e := range entries {
+		if !e.IsDir() {
+			continue
+		}
+		if _, err := os.Stat(filepath.Join(dir, e.Name(), frozenSkillFile)); err != nil {
+			continue
+		}
+		ids = append(ids, e.Name())
+	}
+	sort.Strings(ids)
+	return ids, nil
+}
+
+// ReadFrozen returns the artifacts of a named skill's frozen version.
+func (s *Store) ReadFrozen(name, id string) (FrozenVersion, error) {
+	if err := validVersionID(id); err != nil {
+		return FrozenVersion{}, err
+	}
+	dir := s.FrozenDir(name, id)
+	read := func(fname string) ([]byte, error) {
+		b, err := os.ReadFile(filepath.Join(dir, fname))
+		if err != nil {
+			return nil, fmt.Errorf("store: read frozen %s: %w", fname, err)
+		}
+		return b, nil
+	}
+	v := FrozenVersion{ID: id}
+	var err error
+	if v.SkillMD, err = read(frozenSkillFile); err != nil {
+		return FrozenVersion{}, err
+	}
+	if v.Lockfile, err = read(frozenLockFile); err != nil {
+		return FrozenVersion{}, err
+	}
+	if v.Signature, err = read(frozenSignatureFile); err != nil {
+		return FrozenVersion{}, err
+	}
+	if v.PublicKey, err = read(frozenPublicKeyFile); err != nil {
+		return FrozenVersion{}, err
+	}
+	return v, nil
+}
+
+// copyBytes writes data to dst with perm, creating parent directories. It
+// is the byte-level analogue of source.go copyFile for in-memory artifacts.
+func copyBytes(dst string, data []byte, perm os.FileMode) error {
+	if err := os.MkdirAll(filepath.Dir(dst), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, perm)
+}

--- a/internal/flightplan/store/freeze_test.go
+++ b/internal/flightplan/store/freeze_test.go
@@ -1,0 +1,229 @@
+package store
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func sampleVersion(id string) FrozenVersion {
+	return FrozenVersion{
+		ID:        id,
+		SkillMD:   []byte("---\nname: demo\n---\nfrozen body\n"),
+		Lockfile:  []byte("contentHash: sha256:abc\nversion: 1.0.0\n"),
+		Signature: []byte("signature-bytes"),
+		PublicKey: []byte("-----BEGIN PUBLIC KEY-----\n...\n-----END PUBLIC KEY-----\n"),
+	}
+}
+
+func TestWriteFrozen_ProducesExpectedFiles(t *testing.T) {
+	s := New(t.TempDir())
+	v := sampleVersion("abc123")
+	if err := s.WriteFrozen("demo", v); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	dir := s.FrozenDir("demo", "abc123")
+	for fname, want := range map[string]string{
+		"SKILL.md":        string(v.SkillMD),
+		"aileron.lock":    string(v.Lockfile),
+		"signature.sig":   string(v.Signature),
+		"signing-key.pub": string(v.PublicKey),
+	} {
+		got, err := os.ReadFile(filepath.Join(dir, fname))
+		if err != nil {
+			t.Errorf("read %s: %v", fname, err)
+			continue
+		}
+		if string(got) != want {
+			t.Errorf("%s = %q, want %q", fname, got, want)
+		}
+	}
+}
+
+func TestWriteFrozen_NeverContainsPrivateKey(t *testing.T) {
+	s := New(t.TempDir())
+	if err := s.WriteFrozen("demo", sampleVersion("v1")); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	entries, err := os.ReadDir(s.FrozenDir("demo", "v1"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		name := e.Name()
+		if name != "SKILL.md" && name != "aileron.lock" && name != "signature.sig" && name != "signing-key.pub" {
+			t.Errorf("unexpected file in frozen version: %q", name)
+		}
+		// The public key is fine; a private key file would not be.
+		if name == "signing-key.pem" || name == "signing-key" {
+			t.Errorf("a private key must never be stored: %q", name)
+		}
+	}
+}
+
+func TestWriteFrozen_NewVersionLeavesPriorIntact(t *testing.T) {
+	s := New(t.TempDir())
+	v1 := sampleVersion("v1")
+	if err := s.WriteFrozen("demo", v1); err != nil {
+		t.Fatalf("write v1: %v", err)
+	}
+	v2 := sampleVersion("v2")
+	v2.SkillMD = []byte("---\nname: demo\n---\ndifferent frozen body\n")
+	if err := s.WriteFrozen("demo", v2); err != nil {
+		t.Fatalf("write v2: %v", err)
+	}
+
+	// v1 is byte-identical to what was written.
+	got, err := os.ReadFile(filepath.Join(s.FrozenDir("demo", "v1"), "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != string(v1.SkillMD) {
+		t.Errorf("v1 was mutated: %q", got)
+	}
+}
+
+func TestWriteFrozen_IdenticalReWriteIsNoOp(t *testing.T) {
+	s := New(t.TempDir())
+	v := sampleVersion("v1")
+	if err := s.WriteFrozen("demo", v); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	if err := s.WriteFrozen("demo", v); err != nil {
+		t.Errorf("re-writing identical content must be a no-op, got: %v", err)
+	}
+}
+
+func TestWriteFrozen_DifferingContentSameIDRejected(t *testing.T) {
+	s := New(t.TempDir())
+	if err := s.WriteFrozen("demo", sampleVersion("v1")); err != nil {
+		t.Fatalf("first write: %v", err)
+	}
+	changed := sampleVersion("v1")
+	changed.SkillMD = []byte("tampered")
+	if err := s.WriteFrozen("demo", changed); err == nil {
+		t.Error("writing different content to an existing version id must be rejected (immutability)")
+	}
+}
+
+func TestWriteFrozen_RejectsBadID(t *testing.T) {
+	s := New(t.TempDir())
+	for _, id := range []string{"", "../escape", "a/b", ".", ".."} {
+		v := sampleVersion(id)
+		if err := s.WriteFrozen("demo", v); err == nil {
+			t.Errorf("id %q must be rejected", id)
+		}
+	}
+}
+
+func TestWriteFrozen_RejectsEmptyName(t *testing.T) {
+	s := New(t.TempDir())
+	if err := s.WriteFrozen("", sampleVersion("v1")); err == nil {
+		t.Error("empty skill name must be rejected")
+	}
+}
+
+func TestWriteFrozen_PreInstalledRootUntouched(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+	// Simulate a pre-freeze install: a SKILL.md at the name root.
+	nameRoot := s.Dir("demo")
+	if err := os.MkdirAll(nameRoot, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	const installed = "---\nname: demo\n---\nthe installed body\n"
+	if err := os.WriteFile(filepath.Join(nameRoot, "SKILL.md"), []byte(installed), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	if err := s.WriteFrozen("demo", sampleVersion("v1")); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+
+	got, err := os.ReadFile(filepath.Join(nameRoot, "SKILL.md"))
+	if err != nil {
+		t.Fatal(err)
+	}
+	if string(got) != installed {
+		t.Errorf("pre-freeze installed SKILL.md was modified: %q", got)
+	}
+}
+
+func TestFrozenVersions_SortedAndEmpty(t *testing.T) {
+	s := New(t.TempDir())
+	// No versions yet.
+	ids, err := s.FrozenVersions("demo")
+	if err != nil {
+		t.Fatalf("FrozenVersions on empty: %v", err)
+	}
+	if len(ids) != 0 {
+		t.Errorf("empty versions = %v", ids)
+	}
+
+	for _, id := range []string{"v3", "v1", "v2"} {
+		if err := s.WriteFrozen("demo", sampleVersion(id)); err != nil {
+			t.Fatal(err)
+		}
+	}
+	ids, err = s.FrozenVersions("demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 3 || ids[0] != "v1" || ids[1] != "v2" || ids[2] != "v3" {
+		t.Errorf("FrozenVersions = %v, want sorted [v1 v2 v3]", ids)
+	}
+}
+
+func TestReadFrozen_RoundTrips(t *testing.T) {
+	s := New(t.TempDir())
+	want := sampleVersion("v1")
+	if err := s.WriteFrozen("demo", want); err != nil {
+		t.Fatal(err)
+	}
+	got, err := s.ReadFrozen("demo", "v1")
+	if err != nil {
+		t.Fatalf("ReadFrozen: %v", err)
+	}
+	if string(got.SkillMD) != string(want.SkillMD) ||
+		string(got.Lockfile) != string(want.Lockfile) ||
+		string(got.Signature) != string(want.Signature) ||
+		string(got.PublicKey) != string(want.PublicKey) {
+		t.Errorf("ReadFrozen round-trip mismatch: %+v", got)
+	}
+}
+
+func TestReadFrozen_MissingErrors(t *testing.T) {
+	s := New(t.TempDir())
+	if _, err := s.ReadFrozen("demo", "nope"); err == nil {
+		t.Error("reading a missing version must error")
+	}
+}
+
+func TestReadFrozen_RejectsTraversalID(t *testing.T) {
+	s := New(t.TempDir())
+	for _, id := range []string{"../escape", "a/b", "..", "."} {
+		if _, err := s.ReadFrozen("demo", id); err == nil {
+			t.Errorf("ReadFrozen must reject traversal id %q", id)
+		}
+	}
+}
+
+func TestWriteFrozen_NoPartialDirOnFailure(t *testing.T) {
+	// A write whose content is fine succeeds; this asserts the atomic-rename
+	// path leaves exactly the four artifacts and no leftover temp dir.
+	root := t.TempDir()
+	s := New(root)
+	if err := s.WriteFrozen("demo", sampleVersion("v1")); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	versionsDir := filepath.Join(s.Dir("demo"), "versions")
+	entries, err := os.ReadDir(versionsDir)
+	if err != nil {
+		t.Fatal(err)
+	}
+	for _, e := range entries {
+		if e.Name() != "v1" {
+			t.Errorf("leftover entry in versions dir: %q (temp dir not cleaned?)", e.Name())
+		}
+	}
+}

--- a/internal/flightplan/store/freeze_test.go
+++ b/internal/flightplan/store/freeze_test.go
@@ -199,6 +199,37 @@ func TestReadFrozen_MissingErrors(t *testing.T) {
 	}
 }
 
+func TestWriteFrozen_EmptyIDRejected(t *testing.T) {
+	s := New(t.TempDir())
+	v := sampleVersion("")
+	if err := s.WriteFrozen("demo", v); err == nil {
+		t.Error("an empty version id must be rejected")
+	}
+}
+
+func TestFrozenVersions_IgnoresNonVersionEntries(t *testing.T) {
+	root := t.TempDir()
+	s := New(root)
+	if err := s.WriteFrozen("demo", sampleVersion("v1")); err != nil {
+		t.Fatal(err)
+	}
+	// A stray file and a dir without SKILL.md under versions/ are ignored.
+	versionsDir := filepath.Join(s.Dir("demo"), "versions")
+	if err := os.WriteFile(filepath.Join(versionsDir, "stray.txt"), []byte("x"), 0o644); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(filepath.Join(versionsDir, "empty-dir"), 0o755); err != nil {
+		t.Fatal(err)
+	}
+	ids, err := s.FrozenVersions("demo")
+	if err != nil {
+		t.Fatal(err)
+	}
+	if len(ids) != 1 || ids[0] != "v1" {
+		t.Errorf("FrozenVersions must ignore non-version entries, got %v", ids)
+	}
+}
+
 func TestReadFrozen_RejectsTraversalID(t *testing.T) {
 	s := New(t.TempDir())
 	for _, id := range []string{"../escape", "a/b", "..", "."} {


### PR DESCRIPTION
## Summary

Implements #1509: `aileron skill freeze`, the author-time step that seals an installed skill into a Flight Plan (ADR-0027).

Freeze runs a fixed pipeline over one `SKILL.md`:
1. **parse + lint** — the no-LLM lint rejects any step that could reach an LLM outside the marked `kind: llm-seam`.
2. **resolve digests** — rung-1 `rung1Image.ref` resolves to its `@sha256:` digest via the container Runner; rung-2 `rung2CapabilityUnits.features` composes through the #1454 Builder/composition path and pins the built image's digest plus the resolved capability set. Pin by digest, never by tag.
3. **lockfile** — the resolved pins + capability set + contentHash + version, as both the `lock` block injected into the frozen `SKILL.md` and the standalone `aileron.lock` artifact.
4. **content addressing** — `contentHash = sha256` over the canonical frozen-manifest bytes + lockfile bytes, with the self-referential `contentHash` field excluded from the hashed input.
5. **sign** — a detached ed25519 signature over the canonical content bytes; `Verify` is exported and self-contained (sig + pub only) for Launch (#1511) to call.
6. **write** — an immutable versioned write into the canonical store at `~/.aileron/skills/<name>/versions/<id>/` holding `SKILL.md`, `aileron.lock`, `signature.sig`, `signing-key.pub`.

### Structure

- **`internal/flightplan/freeze`** (new): runtime-free core (lockfile, content addressing, lint, ed25519 sign/verify) behind a `DigestResolver` / `FeatureComposer` seam, so it is unit-testable without Docker.
- **`internal/flightplan/store/freeze.go`**: extends the #1508 store with `WriteFrozen` / `FrozenVersions` / `ReadFrozen`. Atomic writes (stage in temp dir, then rename); immutable versions; never stores the private key.
- **`cmd/aileron/skill_freeze.go`**: `aileron skill freeze <name|path> [--signing-key PATH] [--version SEMVER]`, wiring the concrete container Runner/Builder resolvers behind package-var seams for tests.
- **Docs**: new guide `freezing-a-flight-plan`, nav entry, and a reconciliation of the manifest spec's "freeze produces the lock" language.

### Guarantees

- Reproducible: byte-identical input + same key produces the same contentHash, frozen bytes, and signature (ed25519 is deterministic). Line endings are canonicalized to LF so CRLF and LF inputs freeze identically.
- Immutable: re-freeze writes a new version dir; identical re-freeze is a verified no-op; differing content to an existing id is rejected.
- Secrets never enter the artifact: the signing private key is read from disk/env for signing only; only the public key + signature are persisted.
- Path-safe: version ids are validated as single path segments on both read and write.

### Out of scope (per plan)

Launch-time verification + enforcement (#1511, `Verify` provided here), slug-source install (#1583), rung-3 sibling images (reserved schema slot), cosign/keyless signing (rejected), and any daemon HTTP endpoint or OpenAPI change. **No OpenAPI change**: freeze is a local author-time CLI op against the on-disk store, not a server write endpoint, so the spec-first and approval-gating/idempotency rules for write endpoints do not apply.

## Test plan

- `go test ./internal/flightplan/freeze/...` — lockfile round-trip + schema field names; contentHash reproducibility / sensitivity / boundary-collision; lint accepts marked `llm-seam` and rejects unmarked-LLM / unknown-kind / missing-kind / marker-on-transform (fail-before/pass-after regression both directions); rung-1/rung-2/instruction-only/no-exec-env digest resolution; tag-not-digest rejection; sign→verify round-trip + tamper/wrong-key/malformed-key; CRLF stability; orchestrator happy path + reproducibility + true-instruction-only signing. Coverage 87.7%.
- `go test ./internal/flightplan/store/...` — frozen write produces the four files and never the private key; new-version-keeps-prior-byte-identical; identical-rewrite no-op; differing-content-same-id rejected; traversal-id rejected on read and write; pre-freeze installed root untouched; sorted version listing; round-trip read. Coverage 81.6%.
- `go test ./cmd/aileron/...` — full freeze acceptance path with faked resolvers (writes a verifiable signature, lockfile pins the digest, lock block injected, no private key stored); unmarked-LLM exits non-zero; re-freeze yields a new version; missing signing key errors; no-exec-env still signs; freeze-from-path; multi-RepoDigests repo matching; `repoOfRef` parsing.
- `go vet` clean across `internal/flightplan/...` and `cmd/aileron/...`; `task build:cli` succeeds.
- CodeRabbit review run and actionable findings resolved (ReadFrozen traversal guard, atomic store write, CRLF byte-stability contract + test, multi-repo digest matching, stricter rung-1/rung-2 parsing, nil-adapter guards, test-intent corrections).

The production container-runtime resolver methods (`ResolveDigest` / `ComposeDigest` / `localImageDigest`) require Docker and are exercised through the seam with fakes; their digest-parsing core (`digestFromRepoDigests`, `repoOfRef`) is unit-tested directly.

Closes #1509

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `aileron skill freeze` to freeze an installed skill into an immutable, signed version with digest-pinned references and an optional version label.
  * Added support for reading frozen skill versions from the store and listing available frozen versions.

* **Bug Fixes**
  * Improved freeze validation so unsupported or malformed skill steps are rejected before a frozen version is created.
  * Ensured frozen output is stable across line-ending differences and repeated freezes with the same content.

* **Documentation**
  * Added a new guide for freezing a Flight Plan and updated navigation plus related help text.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->