### PR TITLE
fix(sandbox): probe Windows npm prefix layout for managed devcontainer CLI

### DIFF
--- a/internal/sandbox/toolchain/cli_install.go
+++ b/internal/sandbox/toolchain/cli_install.go
@@ -13,11 +13,33 @@ import (
 // this package never carries its own copy of the pin.
 const devcontainerCLIPackage = "@devcontainers/cli"
 
-// cliEntrypointRelPath is the path, relative to an npm install prefix, of the
-// devcontainer CLI's JS entrypoint. npm installs a package's files under
-// <prefix>/lib/node_modules/<package>/, and @devcontainers/cli's package.json
-// "bin" points at devcontainer.js under its bin/ directory.
-var cliEntrypointRelPath = filepath.Join("lib", "node_modules", "@devcontainers", "cli", "devcontainer.js")
+// cliEntrypointRelPaths are the candidate paths, relative to an npm install
+// prefix, of the devcontainer CLI's JS entrypoint. `npm install --global
+// --prefix <prefix>` lands the package's files under
+// <prefix>/lib/node_modules/<package>/ on Unix but <prefix>/node_modules/<package>/
+// on Windows (npm omits the lib/ segment there), so both layouts must be probed.
+// @devcontainers/cli's package.json "bin" points at devcontainer.js under its
+// own root. The Unix path is first so it is the canonical one used in error
+// messages (see cliEntrypointForPrefix).
+var cliEntrypointRelPaths = []string{
+	filepath.Join("lib", "node_modules", "@devcontainers", "cli", "devcontainer.js"),
+	filepath.Join("node_modules", "@devcontainers", "cli", "devcontainer.js"),
+}
+
+// cliEntrypointForPrefix returns the @devcontainers/cli JS entrypoint under an
+// npm install prefix. It probes the Unix and Windows install layouts in order
+// and returns the first that exists with found=true. When none exists it returns
+// the canonical Unix path with found=false, so callers get a stable,
+// human-readable path to name in "not found" errors regardless of platform.
+func cliEntrypointForPrefix(prefix string) (string, bool) {
+	for _, rel := range cliEntrypointRelPaths {
+		candidate := filepath.Join(prefix, rel)
+		if fileExists(candidate) {
+			return candidate, true
+		}
+	}
+	return filepath.Join(prefix, cliEntrypointRelPaths[0]), false
+}
 
 // cliCachePrefix is the version-keyed npm install prefix the CLI installer
 // writes into: <cacheRoot>/devcontainer-cli/<cliVersion>. It is the single
@@ -41,8 +63,7 @@ type npmCLIInstaller struct{}
 // returned with fromCache=false.
 func (npmCLIInstaller) Install(ctx context.Context, nodeBinary, cliVersion, cacheRoot string) (string, bool, error) {
 	prefix := cliCachePrefix(cacheRoot, cliVersion)
-	entrypoint := filepath.Join(prefix, cliEntrypointRelPath)
-	if fileExists(entrypoint) {
+	if entrypoint, found := cliEntrypointForPrefix(prefix); found {
 		return entrypoint, true, nil
 	}
 	if err := os.MkdirAll(prefix, 0o755); err != nil {
@@ -54,7 +75,8 @@ func (npmCLIInstaller) Install(ctx context.Context, nodeBinary, cliVersion, cach
 	}
 	// Run the managed node against its bundled npm to install the pinned package
 	// into the version-keyed prefix. `--prefix` makes npm treat the prefix as a
-	// global install root, landing files under <prefix>/lib/node_modules.
+	// global install root, landing files under <prefix>/lib/node_modules on Unix
+	// and <prefix>/node_modules on Windows (cliEntrypointForPrefix probes both).
 	spec := devcontainerCLIPackage + "@" + cliVersion
 	args := []string{npmCLI, "install", "--global", "--prefix", prefix, "--no-audit", "--no-fund", spec}
 	cmd := exec.CommandContext(ctx, nodeBinary, args...)
@@ -63,7 +85,8 @@ func (npmCLIInstaller) Install(ctx context.Context, nodeBinary, cliVersion, cach
 	if err := cmd.Run(); err != nil {
 		return "", false, fmt.Errorf("npm install %s: %w", spec, err)
 	}
-	if !fileExists(entrypoint) {
+	entrypoint, found := cliEntrypointForPrefix(prefix)
+	if !found {
 		return "", false, fmt.Errorf("npm install %s did not produce %s", spec, entrypoint)
 	}
 	return entrypoint, false, nil

--- a/internal/sandbox/toolchain/cli_install_test.go
+++ b/internal/sandbox/toolchain/cli_install_test.go
@@ -15,7 +15,7 @@ func TestNpmInstallerCacheHitSkipsNpm(t *testing.T) {
 	cliVersion := "9.9.9"
 	// Pre-create the entrypoint so the warm-cache probe short-circuits before any
 	// npm subprocess runs (a missing node binary would otherwise fail the exec).
-	entrypoint := filepath.Join(cacheRoot, "devcontainer-cli", cliVersion, cliEntrypointRelPath)
+	entrypoint := filepath.Join(cacheRoot, "devcontainer-cli", cliVersion, cliEntrypointRelPaths[0])
 	if err := os.MkdirAll(filepath.Dir(entrypoint), 0o755); err != nil {
 		t.Fatalf("mkdir: %v", err)
 	}
@@ -32,6 +32,100 @@ func TestNpmInstallerCacheHitSkipsNpm(t *testing.T) {
 	if got != entrypoint {
 		t.Fatalf("entrypoint = %q, want %q", got, entrypoint)
 	}
+}
+
+// TestNpmInstallerFindsWindowsLayoutEntrypoint is the regression for the
+// reported Windows failure: `npm install --global --prefix <prefix>` lands
+// @devcontainers/cli at <prefix>/node_modules/... (no lib/ segment) on Windows,
+// but the warm-cache probe only checked the Unix lib/node_modules/ layout, so it
+// reported "did not produce ...lib\\node_modules..." for a package npm had just
+// installed. With the Windows candidate probed, the staged Windows-layout
+// entrypoint is found and Install short-circuits from cache without running npm.
+func TestNpmInstallerFindsWindowsLayoutEntrypoint(t *testing.T) {
+	cacheRoot := t.TempDir()
+	cliVersion := "9.9.9"
+	// Stage the entrypoint at the Windows layout (<prefix>/node_modules/..., no
+	// lib/ segment), exactly where `npm install --prefix` lands it on Windows.
+	windowsEntrypoint := filepath.Join(
+		cacheRoot, "devcontainer-cli", cliVersion,
+		"node_modules", "@devcontainers", "cli", "devcontainer.js",
+	)
+	if err := os.MkdirAll(filepath.Dir(windowsEntrypoint), 0o755); err != nil {
+		t.Fatalf("mkdir: %v", err)
+	}
+	if err := os.WriteFile(windowsEntrypoint, []byte("// devcontainer cli"), 0o644); err != nil {
+		t.Fatalf("write entrypoint: %v", err)
+	}
+	// A nonexistent node would fail any npm subprocess; the probe must find the
+	// staged file and short-circuit before exec.
+	got, fromCache, err := npmCLIInstaller{}.Install(context.Background(), "/nonexistent/node", cliVersion, cacheRoot)
+	if err != nil {
+		t.Fatalf("Install (warm Windows-layout cache): %v", err)
+	}
+	if !fromCache {
+		t.Fatal("fromCache = false for a staged Windows-layout entrypoint; want true")
+	}
+	if got != windowsEntrypoint {
+		t.Fatalf("entrypoint = %q, want %q", got, windowsEntrypoint)
+	}
+}
+
+// TestCLIEntrypointForPrefixPrefersUnixThenWindows pins the probe's contract:
+// the Unix layout wins when present, the Windows layout is found when only it
+// exists, and a missing entrypoint falls back to the canonical Unix path with
+// found=false so error messages stay stable across platforms.
+func TestCLIEntrypointForPrefixPrefersUnixThenWindows(t *testing.T) {
+	unixRel := filepath.Join("lib", "node_modules", "@devcontainers", "cli", "devcontainer.js")
+	windowsRel := filepath.Join("node_modules", "@devcontainers", "cli", "devcontainer.js")
+
+	t.Run("missing returns canonical Unix path, not found", func(t *testing.T) {
+		prefix := t.TempDir()
+		got, found := cliEntrypointForPrefix(prefix)
+		if found {
+			t.Fatalf("found = true for an empty prefix; want false")
+		}
+		if want := filepath.Join(prefix, unixRel); got != want {
+			t.Fatalf("path = %q, want canonical Unix %q", got, want)
+		}
+	})
+
+	t.Run("windows-only layout is found", func(t *testing.T) {
+		prefix := t.TempDir()
+		win := filepath.Join(prefix, windowsRel)
+		if err := os.MkdirAll(filepath.Dir(win), 0o755); err != nil {
+			t.Fatalf("mkdir: %v", err)
+		}
+		if err := os.WriteFile(win, []byte("//cli"), 0o644); err != nil {
+			t.Fatalf("write: %v", err)
+		}
+		got, found := cliEntrypointForPrefix(prefix)
+		if !found {
+			t.Fatalf("found = false for a staged Windows layout; want true")
+		}
+		if got != win {
+			t.Fatalf("path = %q, want %q", got, win)
+		}
+	})
+
+	t.Run("unix layout wins when both present", func(t *testing.T) {
+		prefix := t.TempDir()
+		for _, rel := range []string{unixRel, windowsRel} {
+			p := filepath.Join(prefix, rel)
+			if err := os.MkdirAll(filepath.Dir(p), 0o755); err != nil {
+				t.Fatalf("mkdir: %v", err)
+			}
+			if err := os.WriteFile(p, []byte("//cli"), 0o644); err != nil {
+				t.Fatalf("write: %v", err)
+			}
+		}
+		got, found := cliEntrypointForPrefix(prefix)
+		if !found {
+			t.Fatalf("found = false when both layouts present; want true")
+		}
+		if want := filepath.Join(prefix, unixRel); got != want {
+			t.Fatalf("path = %q, want Unix %q to win", got, want)
+		}
+	})
 }
 
 func TestNpmEntrypointResolvesUnixLayout(t *testing.T) {

--- a/internal/sandbox/toolchain/offline.go
+++ b/internal/sandbox/toolchain/offline.go
@@ -34,8 +34,8 @@ func provisionOffline(resolved resolvedOptions) (container.ManagedToolchain, err
 		return container.ManagedToolchain{}, err
 	}
 
-	entrypoint := cliEntrypointForCache(resolved.CacheRoot, resolved.CLIVersion)
-	if !fileExists(entrypoint) {
+	entrypoint, found := cliEntrypointForCache(resolved.CacheRoot, resolved.CLIVersion)
+	if !found {
 		return container.ManagedToolchain{}, offlineMissingCLIError(resolved.CLIVersion)
 	}
 
@@ -116,10 +116,12 @@ func offlineMissingCLIError(cliVersion string) error {
 	return fmt.Errorf("managed @devcontainers/cli@%s is not in the offline cache; run `aileron sandbox warm` with network access first", cliVersion)
 }
 
-// cliEntrypointForCache returns the absolute path the npm installer would place
-// the @devcontainers/cli entrypoint at for cliVersion under cacheRoot. The
-// offline path probes this without running npm; it must match the layout
+// cliEntrypointForCache returns the @devcontainers/cli entrypoint the npm
+// installer would place for cliVersion under cacheRoot, probing both the Unix
+// and Windows install layouts. found is true when the entrypoint exists; when it
+// is false the returned path is the canonical Unix path (for error messages).
+// The offline path probes this without running npm; it must match the layout
 // npmCLIInstaller.Install writes (see cli_install.go).
-func cliEntrypointForCache(cacheRoot, cliVersion string) string {
-	return filepath.Join(cliCachePrefix(cacheRoot, cliVersion), cliEntrypointRelPath)
+func cliEntrypointForCache(cacheRoot, cliVersion string) (string, bool) {
+	return cliEntrypointForPrefix(cliCachePrefix(cacheRoot, cliVersion))
 }

--- a/internal/sandbox/toolchain/offline_test.go
+++ b/internal/sandbox/toolchain/offline_test.go
@@ -35,7 +35,7 @@ func (f failingCLIInstaller) Install(_ context.Context, _, _, _ string) (string,
 // offline path's entrypoint probe finds it.
 func stageCLIEntrypoint(t *testing.T, cacheRoot, cliVersion string) string {
 	t.Helper()
-	entrypoint := cliEntrypointForCache(cacheRoot, cliVersion)
+	entrypoint, _ := cliEntrypointForCache(cacheRoot, cliVersion)
 	if err := os.MkdirAll(filepath.Dir(entrypoint), 0o755); err != nil {
 		t.Fatalf("mkdir CLI prefix: %v", err)
 	}


### PR DESCRIPTION
## Summary

The managed-toolchain CLI installer (`internal/sandbox/toolchain/cli_install.go`) hardcoded the devcontainer-CLI entrypoint probe to the Unix `lib/node_modules/@devcontainers/cli/devcontainer.js` layout. On Windows, `npm install --global --prefix <prefix>` lands the package at `<prefix>/node_modules/...` (no `lib/` segment), so the post-install probe never found the file npm had just installed. The zero-config managed toolchain dead-ended with the verbatim `npm install ... did not produce ...lib\node_modules...` error.

This replaces the single Unix path with Unix + Windows candidates and adds `cliEntrypointForPrefix(prefix) (path, found)`, which returns the first existing candidate and falls back to the canonical Unix path for error messages. The warm-cache probe, the post-install probe, and the offline/`aileron sandbox warm` resolver (`offline.go`) all route through the same helper so they cannot drift. This mirrors the two-layout handling already present in the neighboring `npmEntrypoint` helper — the CLI probe was the only place missing the Windows candidate.

## Test plan

- `TestNpmInstallerFindsWindowsLayoutEntrypoint` — regression for the reported failure: stages the entrypoint at the Windows layout (`<prefix>/node_modules/...`) and asserts `Install` finds it from cache. Verified it **fails before** the fix (reproduces the "tries npm / can't find file" dead-end) and **passes after**.
- `TestCLIEntrypointForPrefixPrefersUnixThenWindows` — pins the probe contract: Unix wins when both present, Windows-only is found, missing returns the canonical Unix path with `found=false`.
- Updated stale `cliEntrypointRelPath` references in `cli_install_test.go` and `offline_test.go` to the new candidate slice / two-value helper.
- `go build ./...`, `go vet`, and `go test ./internal/sandbox/toolchain/` all pass; package coverage 88.0%.

Note: the Windows-specific install path (npm runs but lands files in `node_modules/`) is exercised via filesystem-staged tests on all platforms rather than a real Windows npm run, since the probe logic is platform-independent given the staged layout.

Closes #1597
