### PR TITLE
docs: use em-dash separator for ai-assisted-authoring index bullet

### DIFF
--- a/docs/src/content/docs/development/index.md
+++ b/docs/src/content/docs/development/index.md
@@ -18,7 +18,7 @@ If you're looking for end-user docs, the [Getting Started](/getting-started/) gu
 - [Sandbox Agent Images](/development/sandbox-agent-images/) — which agent commands are supported by the selected sandbox image and how to check them before launch.
 - [Sandbox Connector Specs](/development/sandbox-connector-specs/) — how installed connector specs drive data-plane operation validation in sandboxed launch sessions.
 - [Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) — the `SKILL.md` frontmatter extension that declares a Flight Plan's `requires` block, per-action trust contract, inputs, outputs, and frozen lock section.
-- [AI-Assisted Authoring UX Spec](/development/ai-assisted-authoring-spec/): the AI-assisted experience that takes an operator from describing an outcome to a signed Flight Plan, with the AI owning composition and the human owning the trust contract.
+- [AI-Assisted Authoring UX Spec](/development/ai-assisted-authoring-spec/) — the AI-assisted experience that takes an operator from describing an outcome to a signed Flight Plan, with the AI owning composition and the human owning the trust contract.
 - [Sandbox Proxy CLI Verification Matrix](/development/sandbox-proxy-cli-matrix/) — verify the v4 HTTPS proxy works with `curl`, `gh`, and `aws`; success and failure cases with expected audit events.
 - [Submitting Changes](/development/submitting-changes/) — branch and PR conventions, commit message format, ADR amendments, what gets reviewed.
 - [Adding an Agent](/development/adding-an-agent/) — how to wire a new AI coding agent into `aileron launch` via the `Agent` SPI.


### PR DESCRIPTION
## Summary

The development index (`docs/src/content/docs/development/index.md`) listed the AI-Assisted Authoring UX Spec bullet with a colon separator (`):  the ...`) while every other bullet in the file — including the immediately adjacent Flight Plan Manifest Spec line — uses the ` — ` em-dash separator. This one-line change aligns the bullet with the file's established pattern.

Closes #1581

## Test plan

- Docs-only prose change; no code or generated files touched, so there is no test suite to extend.
- Verified the diff is a single-character separator change (`:` → ` —`) and that the link target and bullet text are otherwise unchanged.
- Confirmed all sibling bullets in the file use the same ` — ` separator.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
