### PR TITLE
test(systest): port assert_test.sh to Go

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -4,7 +4,7 @@ vars:
   COMPOSE_FILE: deploy/docker-compose.yml
   # Single source of truth for Go test/vet package set, shared by local
   # (test:go, vet:go) and CI (test:go:ci) targets.
-  GO_TEST_PACKAGES: ./internal/... ./cmd/aileron/... ./cmd/aileron-mcp/... ./sdk/go/...
+  GO_TEST_PACKAGES: ./internal/... ./cmd/aileron/... ./cmd/aileron-mcp/... ./sdk/go/... ./test/system/lib/...
 
 tasks:
   default:

--- a/go.work
+++ b/go.work
@@ -6,4 +6,5 @@ use (
 	./internal
 	./sdk/go
 	./test/integration
+	./test/system/lib
 )

--- a/test/system/lib/assert.go
+++ b/test/system/lib/assert.go
@@ -1,0 +1,56 @@
+// Package systestlib provides generic assertion + logging helpers for the
+// `aileron launch` system-test scenarios (#1476 codex, #1477 claude), ported
+// from the POSIX-shell assert.sh helper library.
+//
+// The shell helpers signal a violation by returning non-zero and writing an
+// actionable message to stderr; nothing aborts on its own, so a caller decides
+// whether a failed assertion is fatal. The Go port models that contract with
+// the idiomatic error return: nil means the asserted condition holds, and a
+// non-nil error carries the diagnostic message (faithful to the shell stderr
+// text) so callers and tests can inspect it.
+package systestlib
+
+import (
+	"fmt"
+	"strings"
+)
+
+// Fail returns a non-nil error carrying msg, mirroring the shell `fail` helper
+// that always prints `systest: FAIL: <msg>` to stderr and returns 1. Use it for
+// bespoke checks the Assert* helpers below do not cover.
+func Fail(msg string) error {
+	return fmt.Errorf("systest: FAIL: %s", msg)
+}
+
+// AssertEq reports byte-exact string equality between expected and actual.
+// It returns nil when the two are equal and, on mismatch, a non-nil error whose
+// message includes both values so the failure is diagnosable from CI logs alone
+// (mirroring assert_eq's stderr output).
+func AssertEq(expected, actual, what string) error {
+	if expected == actual {
+		return nil
+	}
+	return fmt.Errorf("systest: FAIL: %s\n  expected: %s\n  actual:   %s", what, expected, actual)
+}
+
+// AssertContains reports whether needle is a substring of haystack. It returns
+// nil when haystack contains needle and, otherwise, a non-nil error naming both.
+// strings.Contains is byte-oriented and therefore newline-safe, matching the
+// shell helper's case-glob behavior on multi-line haystacks (env dumps, mount
+// lists).
+func AssertContains(haystack, needle, what string) error {
+	if strings.Contains(haystack, needle) {
+		return nil
+	}
+	return fmt.Errorf("systest: FAIL: %s\n  expected to contain: %s\n  in: %s", what, needle, haystack)
+}
+
+// AssertNotEmpty reports whether value is non-empty. It returns nil for a
+// non-empty value and, for an empty value, the same error Fail would produce
+// for `<what> (value was empty)`, mirroring assert_not_empty.
+func AssertNotEmpty(value, what string) error {
+	if value != "" {
+		return nil
+	}
+	return Fail(fmt.Sprintf("%s (value was empty)", what))
+}

--- a/test/system/lib/assert_test.go
+++ b/test/system/lib/assert_test.go
@@ -1,0 +1,105 @@
+// Contract tests for the systestlib assert helpers, ported one-to-one from the
+// POSIX-shell assert_test.sh. Each case states the expected behavior from the
+// helper's contract (nil error on the satisfied condition, a non-nil error
+// carrying a diagnostic on violation) and exercises both the happy path and the
+// documented failure path. The shell test inspected return codes and stderr;
+// here we inspect the returned error and its message.
+package systestlib_test
+
+import (
+	"strings"
+	"testing"
+
+	systestlib "github.com/ALRubinger/aileron/test/system/lib"
+)
+
+func TestAssertEq(t *testing.T) {
+	tests := []struct {
+		name             string
+		expected, actual string
+		wantErr          bool
+		// wantInMsg are substrings the error message must contain on the
+		// failure path (mirroring assert_eq's stderr diagnostic).
+		wantInMsg []string
+	}{
+		{name: "equal returns nil", expected: "a", actual: "a", wantErr: false},
+		{name: "unequal returns error", expected: "a", actual: "b", wantErr: true, wantInMsg: []string{"eq-fail", "a", "b"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := systestlib.AssertEq(tc.expected, tc.actual, "eq-fail")
+			assertErr(t, err, tc.wantErr, tc.wantInMsg)
+		})
+	}
+}
+
+func TestAssertContains(t *testing.T) {
+	// The multi-line haystack is the load-bearing case from the brief: env
+	// dumps / mount lists contain newlines and assert_contains must still match.
+	multiLine := "a\nbind:/home/agent/.codex\nc"
+	tests := []struct {
+		name             string
+		haystack, needle string
+		wantErr          bool
+		wantInMsg        []string
+	}{
+		{name: "substring present returns nil", haystack: "hello world", needle: "lo wo", wantErr: false},
+		{name: "substring absent returns error", haystack: "hello world", needle: "xyz", wantErr: true, wantInMsg: []string{"xyz", "hello world"}},
+		{name: "multi-line haystack matches", haystack: multiLine, needle: "bind:/home/agent/.codex", wantErr: false},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := systestlib.AssertContains(tc.haystack, tc.needle, "contains-what")
+			assertErr(t, err, tc.wantErr, tc.wantInMsg)
+		})
+	}
+}
+
+func TestAssertNotEmpty(t *testing.T) {
+	tests := []struct {
+		name      string
+		value     string
+		wantErr   bool
+		wantInMsg []string
+	}{
+		{name: "non-empty returns nil", value: "x", wantErr: false},
+		{name: "empty returns error", value: "", wantErr: true, wantInMsg: []string{"notempty-fail", "value was empty"}},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := systestlib.AssertNotEmpty(tc.value, "notempty-fail")
+			assertErr(t, err, tc.wantErr, tc.wantInMsg)
+		})
+	}
+}
+
+func TestFail(t *testing.T) {
+	err := systestlib.Fail("boom")
+	if err == nil {
+		t.Fatal("Fail returned nil; want non-nil error")
+	}
+	if !strings.Contains(err.Error(), "boom") {
+		t.Errorf("Fail error %q does not contain %q", err.Error(), "boom")
+	}
+}
+
+// assertErr checks an Assert* return against its contract: nil when wantErr is
+// false, otherwise a non-nil error whose message contains every wantInMsg
+// substring.
+func assertErr(t *testing.T, err error, wantErr bool, wantInMsg []string) {
+	t.Helper()
+	if wantErr {
+		if err == nil {
+			t.Fatal("got nil error; want non-nil")
+		}
+		for _, sub := range wantInMsg {
+			if !strings.Contains(err.Error(), sub) {
+				t.Errorf("error %q does not contain %q", err.Error(), sub)
+			}
+		}
+		return
+	}
+	if err != nil {
+		t.Fatalf("got error %q; want nil", err.Error())
+	}
+}

--- a/test/system/lib/go.mod
+++ b/test/system/lib/go.mod
@@ -1,0 +1,3 @@
+module github.com/ALRubinger/aileron/test/system/lib
+
+go 1.26.0


### PR DESCRIPTION
## Summary

Part of umbrella #1600. This is the package-creating node: it stands up a brand-new zero-dependency Go workspace module under `test/system/lib/` (package `systestlib`) that #1602 and #1603 will extend.

It ports the shipped POSIX-shell `assert.sh` contract to Go as four small functions, each returning an `error` (the idiomatic Go modeling of the shell "return 0 / non-zero with a stderr message" contract — `nil` = satisfied, non-nil carries the diagnostic):

- `AssertEq(expected, actual, what) error`
- `AssertContains(haystack, needle, what) error` (via `strings.Contains`, inherently newline-safe)
- `AssertNotEmpty(value, what) error`
- `Fail(msg) error`

Diagnostic messages stay faithful to the shell stderr text so callers/tests can assert on them.

Wiring is additive only:
- New module `test/system/lib/go.mod` (module `github.com/ALRubinger/aileron/test/system/lib`, `go 1.26.0`, no requires — mirrors `sdk/go`).
- `go.work`: `./test/system/lib` added to `use`.
- `Taskfile.yml`: `./test/system/lib/...` appended to `GO_TEST_PACKAGES` so the package runs under `task test:go`, `task test:go:cover`, and CI's `test:go:ci:rest` shard.

The shell helpers (`assert.sh`, `assert_test.sh`) and the `test:system:lib` Taskfile cmds are untouched; retiring the shell test is #1604. No `go.work.sum` change needed (zero-dep module).

## Test plan

- `go build ./test/system/lib/...` — succeeds within the workspace.
- `go test -cover ./test/system/lib/...` — passes, 100.0% coverage of `assert.go` (well above the 80% bar; not in the coverage strip regex, so it counts).
- `go vet ./test/system/lib/...` — clean. `gofmt -l` — clean.
- `go list ./internal/... ./cmd/aileron/... ./cmd/aileron-mcp/... ./sdk/go/... ./test/system/lib/...` resolves the new package, and the `test:go:ci:rest` `grep -vE '/sandbox'` filter still includes it.
- `assert_test.go` reproduces every `assert_test.sh` case one-to-one, including the load-bearing multi-line haystack (`a\nbind:/home/agent/.codex\nc`) and both happy + documented failure paths.
- `sh test/system/lib/assert_test.sh` still passes — the shell contract is unchanged.

### Collision note
`Taskfile.yml:7` (`GO_TEST_PACKAGES`) and `go.work` are shared edit points with sibling nodes #1602/#1603. This node creates the package, so it must merge first; siblings rebase onto it.

Closes #1601

🤖 Generated with [Claude Code](https://claude.com/claude-code)
