### PR TITLE
docs(skill): note git prerequisite for git-URL skill installs

### DIFF
--- a/docs/src/content/docs/guides/installing-a-skill.md
+++ b/docs/src/content/docs/guides/installing-a-skill.md
@@ -33,6 +33,8 @@ aileron skill install https://github.com/acme/weekly-digest.git
 
 Aileron shallow-clones the repository, reads the `SKILL.md` at its root, and installs it the same way as a local path.
 
+A git-URL install requires the `git` binary on your `PATH`. `aileron skill install` runs host-side, so it is unrestricted by the sandbox egress boundary. If `git` is missing the install fails with the underlying clone error.
+
 > Installing by an [agentskills.io](https://agentskills.io) registry slug is not wired yet. Use a local path or a git URL for now.
 
 ## Action requirements and graceful degrade


### PR DESCRIPTION
## Summary

Adds a one-line prerequisite note to the Installing a Skill guide for git-URL installs, per the operator-authorized decision on the #1508 plan-review residual (#1582).

The guide documented `aileron skill install <git-url>` (shallow-clone) but never named:
- the `git` binary as a host prerequisite on `PATH`,
- that `aileron skill install` runs host-side and is therefore unrestricted by the sandbox egress boundary,
- the failure mode when `git` is absent (the underlying clone error surfaces).

Docs-only change. No code behavior change. The git-absent failure surface is already covered in code by the injectable `gitRunner` seam and `TestInstallGitURLCloneFailureSurfaces` in `internal/flightplan/store/source_test.go`.

## Test plan

- [x] Docs-only; no code paths touched. Verified the existing git-URL install path (`internal/flightplan/store/source.go` `runGit`) shells out to `git` on `PATH`, matching the new note.
- [x] Writing voice respected (no em-dashes, one thought per sentence).

Closes #1582

🤖 Generated with [Claude Code](https://claude.com/claude-code)
