### PR TITLE
test(systest): port probes_test.sh contract cases to Go

### DIFF
--- a/test/system/lib/probes.go
+++ b/test/system/lib/probes.go
@@ -1,0 +1,171 @@
+// Pure-logic, docker-free ports of the host-verifiable probe helpers in
+// probes.sh. The shell probes inspect a running sandbox container out-of-band
+// (`docker inspect` / `docker exec`) and return non-zero with an actionable
+// message on a violation. The functions here re-express only the *decision*
+// logic that does not need a live container: image-ref arbitration, container
+// discovery count arbitration, the exit-code assertion, and the R8.2 MCP
+// runtime/cmdline decisions once their docker-derived inputs are passed as
+// ordinary Go parameters.
+//
+// The shell contract test (probes_test.sh) stubs `docker` on PATH and feeds
+// those inputs via env (DOCKER_PS_OUTPUT, DOCKER_EXEC_TEST_RC,
+// DOCKER_EXEC_PRINTENV_RC, DOCKER_INSPECT_OUTPUT). The Go port replaces the stub
+// by passing the same inputs as parameters, so the tests run with no docker
+// binary and no stub on PATH.
+//
+// Mirroring assert.go's contract: a nil error means the asserted condition
+// holds; a non-nil error carries the diagnostic (faithful to the shell's stderr
+// wording) so a CI failure reads the same as the shell probe's.
+//
+// The container-bound probes (probe_image, probe_mcp, probe_credentials,
+// probe_daemon_reachable, probe_teardown) are intentionally NOT ported here:
+// they require a live container and are exercised by the by-hand scenario run,
+// exactly as probes_test.sh itself omits them.
+package systestlib
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ImageRepo returns the repository portion of an image ref — everything before
+// the `:tag` or `@sha256:` digest suffix. `:edge`, `:latest`, and `@sha256:abc…`
+// all strip to the same repo; a bare repo (no tag, no digest) returns unchanged.
+// A registry `host:port` with no tag (e.g. localhost:5000/aileron-sandbox-codex)
+// is preserved, because the trailing `:tag` is only stripped when the final path
+// segment (after the last `/`) contains the colon. Pure string logic mirroring
+// the shell image_repo, so it is host-verifiable.
+func ImageRepo(ref string) string {
+	// Strip an `@…` digest suffix first (a digest ref never also carries `:tag`
+	// after the `@`, and the repo's registry `host:port` colon precedes the `@`).
+	if before, _, found := strings.Cut(ref, "@"); found {
+		ref = before
+	}
+	// Strip a trailing `:tag`. Guard against a registry `host:port` with no tag
+	// by only stripping when the final path segment (after the last `/`) carries
+	// the colon.
+	last := ref
+	if i := strings.LastIndex(ref, "/"); i >= 0 {
+		last = ref[i+1:]
+	}
+	if strings.Contains(last, ":") {
+		if i := strings.LastIndex(ref, ":"); i >= 0 {
+			ref = ref[:i]
+		}
+	}
+	return ref
+}
+
+// ImageRefMatches reports R8.1 image equality with digest tolerance, mirroring
+// image_ref_matches. The launcher resolves a floating expected ref (e.g.
+// …-codex:edge) to whatever it pulled: the same floating tag on a dev build, or
+// a `…-codex@sha256:…` digest pin on a reproducible release (#1233). A match
+// requires the SAME repository plus either a floating tag (`:edge`/`:latest`) or
+// an `@sha256:` digest, so a pinned release no longer fails the probe while a
+// wrong repo/agent still does. An explicit expected ref (e.g. a caller-supplied
+// digest or other EXPECTED_IMAGE override) matches exactly. Pure predicate;
+// host-verifiable.
+func ImageRefMatches(expected, actual string) bool {
+	expRepo := ImageRepo(expected)
+	actRepo := ImageRepo(actual)
+	if expRepo != actRepo {
+		return false
+	}
+	// Accept a floating tag or an @sha256: digest on the matched repo.
+	if actual == actRepo+":edge" || actual == actRepo+":latest" {
+		return true
+	}
+	if strings.HasPrefix(actual, actRepo+"@sha256:") {
+		return true
+	}
+	// Exact match against the expected ref (covers a caller-supplied digest or
+	// any other explicit EXPECTED_IMAGE override).
+	return expected == actual
+}
+
+// SplitNames splits a raw, newline/whitespace-delimited block of candidate
+// container names (e.g. the `docker ps --format '{{.Names}}'` output the shell
+// feeds via DOCKER_PS_OUTPUT) into individual names, dropping empty entries.
+// This mirrors the shell `for n in $names` word-splitting so a caller can feed
+// DiscoverContainer either a pre-split []string or the raw block via this
+// helper.
+func SplitNames(raw string) []string {
+	return strings.Fields(raw)
+}
+
+// DiscoverContainer arbitrates the running-container match count exactly as the
+// shell discover_container does over its `docker ps` output. Whitespace-only
+// entries are ignored (mirroring shell word-splitting). Exactly one non-empty
+// name returns that name and a nil error; zero matches returns a non-nil error
+// (never a silent empty string) so a stale container can never be silently
+// probed; more than one match returns a non-nil error rather than guessing.
+// prefix is used only for the diagnostic wording, matching the shell.
+func DiscoverContainer(prefix string, names []string) (string, error) {
+	matches := make([]string, 0, len(names))
+	for _, n := range names {
+		n = strings.TrimSpace(n)
+		if n != "" {
+			matches = append(matches, n)
+		}
+	}
+	switch len(matches) {
+	case 0:
+		return "", fmt.Errorf(
+			"systest: FAIL: no running container named %s* found (is the launch still up?)",
+			prefix)
+	case 1:
+		return matches[0], nil
+	default:
+		return "", fmt.Errorf(
+			"systest: FAIL: %d running containers match %s*; expected exactly one:\n%s",
+			len(matches), prefix, strings.Join(matches, "\n"))
+	}
+}
+
+// ProbeExitCode mirrors probe_exit_code: nil when the actual `aileron launch`
+// exit code equals expected, and a non-nil R8.6 diagnostic (the assert_eq
+// message shape) when they differ. Int parameters are the honest contract for
+// exit codes.
+func ProbeExitCode(actual, expected int) error {
+	return AssertEq(fmt.Sprintf("%d", expected), fmt.Sprintf("%d", actual), "R8.6 aileron launch exit code")
+}
+
+// ProbeMCPRuntime re-expresses the agent-agnostic R8.2 core of
+// probe_mcp_runtime. The shell derives two facts from a live container and feeds
+// them here as parameters: binaryExecutable is whether `test -x
+// /usr/local/bin/aileron-mcp` succeeded, and envVarsAllSet is whether every
+// daemon-wiring env var was present (the shell loops `printenv` over
+// AILERON_URL, AILERON_COMMS_URL, AILERON_SESSION_ID, AILERON_APPROVAL_URL,
+// AILERON_TOKEN, but the stub feeds one rc for all, so the contract under test
+// is "all set / not all set"). The binary check gates before the env check
+// (faithful ordering), so a missing binary yields the binary diagnostic even
+// when env is also unset. Returns nil only when both hold.
+func ProbeMCPRuntime(binaryExecutable, envVarsAllSet bool) error {
+	if !binaryExecutable {
+		return Fail("R8.2 /usr/local/bin/aileron-mcp missing or not executable")
+	}
+	if !envVarsAllSet {
+		return Fail("R8.2 daemon-wiring env var not set")
+	}
+	return nil
+}
+
+// ProbeMCPCmdline re-expresses probe_mcp_cmdline for flag-config agents (e.g.
+// Claude). The agent-agnostic core (ProbeMCPRuntime) gates first, so a runtime
+// failure (missing binary or unset env) fails the whole probe before the
+// cmdline is inspected. Then the inspected container command (cmdline) must
+// contain both flag (e.g. `--mcp-config`) and marker (e.g. the aileron server
+// name), so a stray flag with the wrong payload cannot pass. Diagnostics mirror
+// the shell's R8.2 wording.
+func ProbeMCPCmdline(binaryExecutable, envVarsAllSet bool, cmdline, flag, marker string) error {
+	if err := ProbeMCPRuntime(binaryExecutable, envVarsAllSet); err != nil {
+		return err
+	}
+	if !strings.Contains(cmdline, flag) {
+		return Fail(fmt.Sprintf("R8.2 container command carries %s", flag))
+	}
+	if !strings.Contains(cmdline, marker) {
+		return Fail(fmt.Sprintf("R8.2 %s payload references %s", flag, marker))
+	}
+	return nil
+}

--- a/test/system/lib/probes_test.go
+++ b/test/system/lib/probes_test.go
@@ -1,0 +1,358 @@
+// Contract tests for the pure-logic probe helpers ported from probes.sh,
+// represented one-to-one with the cases in probes_test.sh. Every case is
+// host-verifiable and docker-free: the shell stubbed `docker` on PATH and fed
+// inputs via env (DOCKER_PS_OUTPUT, DOCKER_EXEC_TEST_RC,
+// DOCKER_EXEC_PRINTENV_RC, DOCKER_INSPECT_OUTPUT); here those same inputs are
+// passed as ordinary Go parameters. Tests assert the contract (returned
+// bool/error and, on the failure path, a faithful diagnostic), never
+// implementation internals.
+package systestlib_test
+
+import (
+	"strings"
+	"testing"
+
+	systestlib "github.com/ALRubinger/aileron/test/system/lib"
+)
+
+func TestImageRepo(t *testing.T) {
+	tests := []struct {
+		name string
+		ref  string
+		want string
+	}{
+		{
+			name: "strips :edge floating tag from a GHCR ref",
+			ref:  "ghcr.io/alrubinger/aileron-sandbox-codex:edge",
+			want: "ghcr.io/alrubinger/aileron-sandbox-codex",
+		},
+		{
+			name: "strips @sha256 digest from a GHCR ref",
+			ref:  "ghcr.io/alrubinger/aileron-sandbox-codex@sha256:abc123",
+			want: "ghcr.io/alrubinger/aileron-sandbox-codex",
+		},
+		{
+			name: "keeps a registry host:port with no tag",
+			ref:  "localhost:5000/aileron-sandbox-codex",
+			want: "localhost:5000/aileron-sandbox-codex",
+		},
+		{
+			name: "strips :edge from a host-less local ref",
+			ref:  "aileron/sandbox-agent-claude:edge",
+			want: "aileron/sandbox-agent-claude",
+		},
+		{
+			name: "strips :latest from a host-less local ref",
+			ref:  "aileron/sandbox-agent-claude:latest",
+			want: "aileron/sandbox-agent-claude",
+		},
+		{
+			name: "bare repo with no tag or digest is unchanged",
+			ref:  "aileron/sandbox-agent-claude",
+			want: "aileron/sandbox-agent-claude",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := systestlib.ImageRepo(tc.ref); got != tc.want {
+				t.Errorf("ImageRepo(%q) = %q; want %q", tc.ref, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestImageRefMatches(t *testing.T) {
+	tests := []struct {
+		name             string
+		expected, actual string
+		want             bool
+	}{
+		{
+			name:     "accepts the same floating tag",
+			expected: "ghcr.io/alrubinger/aileron-sandbox-codex:edge",
+			actual:   "ghcr.io/alrubinger/aileron-sandbox-codex:edge",
+			want:     true,
+		},
+		{
+			// #1233 regression: a floating expected ref must match the digest the
+			// launcher actually pulled on a reproducible release.
+			name:     "accepts a digest pin on the same repo (release path)",
+			expected: "ghcr.io/alrubinger/aileron-sandbox-codex:edge",
+			actual:   "ghcr.io/alrubinger/aileron-sandbox-codex@sha256:deadbeef",
+			want:     true,
+		},
+		{
+			name:     "accepts a digest pin against a :latest expectation",
+			expected: "ghcr.io/alrubinger/aileron-sandbox-codex:latest",
+			actual:   "ghcr.io/alrubinger/aileron-sandbox-codex@sha256:deadbeef",
+			want:     true,
+		},
+		{
+			name:     "rejects a digest pin on a different agent repo",
+			expected: "ghcr.io/alrubinger/aileron-sandbox-codex:edge",
+			actual:   "ghcr.io/alrubinger/aileron-sandbox-claude@sha256:deadbeef",
+			want:     false,
+		},
+		{
+			name:     "rejects an unexpected tag on the right repo",
+			expected: "ghcr.io/alrubinger/aileron-sandbox-codex:edge",
+			actual:   "ghcr.io/alrubinger/aileron-sandbox-codex:v0.0.1",
+			want:     false,
+		},
+		{
+			name:     "accepts an exact digest override",
+			expected: "ghcr.io/alrubinger/aileron-sandbox-codex@sha256:abc",
+			actual:   "ghcr.io/alrubinger/aileron-sandbox-codex@sha256:abc",
+			want:     true,
+		},
+		{
+			name:     "accepts the local :edge tag on its own repo",
+			expected: "aileron/sandbox-agent-claude:edge",
+			actual:   "aileron/sandbox-agent-claude:edge",
+			want:     true,
+		},
+		{
+			name:     "accepts the local :latest tag on its own repo",
+			expected: "aileron/sandbox-agent-claude:latest",
+			actual:   "aileron/sandbox-agent-claude:latest",
+			want:     true,
+		},
+		{
+			name:     "rejects a different local agent repo",
+			expected: "aileron/sandbox-agent-claude:edge",
+			actual:   "aileron/sandbox-agent-codex:edge",
+			want:     false,
+		},
+		{
+			name:     "rejects an unexpected tag on the local repo",
+			expected: "aileron/sandbox-agent-claude:edge",
+			actual:   "aileron/sandbox-agent-claude:v0.0.1",
+			want:     false,
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := systestlib.ImageRefMatches(tc.expected, tc.actual); got != tc.want {
+				t.Errorf("ImageRefMatches(%q, %q) = %v; want %v", tc.expected, tc.actual, got, tc.want)
+			}
+		})
+	}
+}
+
+func TestDiscoverContainer(t *testing.T) {
+	const prefix = "aileron-sbx-"
+	tests := []struct {
+		name string
+		// raw is the newline-delimited block (as DOCKER_PS_OUTPUT would feed it);
+		// it is split via the package's whitespace splitter to prove the
+		// docker-free arbitration matches the shell.
+		raw      string
+		wantName string
+		wantErr  bool
+		// errContains are substrings the diagnostic must carry on the failure path.
+		errContains []string
+	}{
+		{
+			name:     "exactly one match returns the name and nil error",
+			raw:      "aileron-sbx-codex-123\n",
+			wantName: "aileron-sbx-codex-123",
+			wantErr:  false,
+		},
+		{
+			name:        "zero matches returns an error, never a silent empty name",
+			raw:         "",
+			wantErr:     true,
+			errContains: []string{"no running container named", prefix},
+		},
+		{
+			name:        "more than one match returns an error rather than guessing",
+			raw:         "aileron-sbx-a\naileron-sbx-b\n",
+			wantErr:     true,
+			errContains: []string{"2 running containers match", prefix},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := systestlib.DiscoverContainer(prefix, systestlib.SplitNames(tc.raw))
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("DiscoverContainer returned nil error; want non-nil")
+				}
+				if got != "" {
+					t.Errorf("DiscoverContainer returned name %q on the error path; want empty", got)
+				}
+				for _, sub := range tc.errContains {
+					if !strings.Contains(err.Error(), sub) {
+						t.Errorf("error %q does not contain %q", err.Error(), sub)
+					}
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DiscoverContainer returned error %q; want nil", err.Error())
+			}
+			if got != tc.wantName {
+				t.Errorf("DiscoverContainer = %q; want %q", got, tc.wantName)
+			}
+		})
+	}
+}
+
+// TestDiscoverContainerSlice drives DiscoverContainer with a pre-split []string
+// (the other input shape the brief calls out) to confirm whitespace-only and
+// empty entries are ignored, matching the shell's word-splitting of the
+// docker ps block.
+func TestDiscoverContainerSlice(t *testing.T) {
+	const prefix = "aileron-sbx-"
+	got, err := systestlib.DiscoverContainer(prefix, []string{"", "   ", "aileron-sbx-only", "\t"})
+	if err != nil {
+		t.Fatalf("DiscoverContainer returned error %q; want nil", err.Error())
+	}
+	if got != "aileron-sbx-only" {
+		t.Errorf("DiscoverContainer = %q; want %q", got, "aileron-sbx-only")
+	}
+}
+
+func TestProbeExitCode(t *testing.T) {
+	tests := []struct {
+		name             string
+		actual, expected int
+		wantErr          bool
+	}{
+		{name: "matching codes return nil", actual: 0, expected: 0, wantErr: false},
+		{name: "differing codes return an error", actual: 1, expected: 0, wantErr: true},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := systestlib.ProbeExitCode(tc.actual, tc.expected)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("ProbeExitCode returned nil error; want non-nil")
+				}
+				if !strings.Contains(err.Error(), "R8.6") {
+					t.Errorf("error %q does not contain %q", err.Error(), "R8.6")
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ProbeExitCode returned error %q; want nil", err.Error())
+			}
+		})
+	}
+}
+
+func TestProbeMCPRuntime(t *testing.T) {
+	tests := []struct {
+		name             string
+		binaryExecutable bool
+		envVarsAllSet    bool
+		wantErr          bool
+		errContains      string
+	}{
+		{
+			name:             "binary present and env all set returns nil",
+			binaryExecutable: true,
+			envVarsAllSet:    true,
+			wantErr:          false,
+		},
+		{
+			// Binary missing gates before env: even with env unset, the diagnostic
+			// is the binary one, proving the faithful ordering.
+			name:             "binary missing returns error and gates before env",
+			binaryExecutable: false,
+			envVarsAllSet:    false,
+			wantErr:          true,
+			errContains:      "aileron-mcp missing or not executable",
+		},
+		{
+			name:             "binary present but a daemon env var unset returns error",
+			binaryExecutable: true,
+			envVarsAllSet:    false,
+			wantErr:          true,
+			errContains:      "env var not set",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := systestlib.ProbeMCPRuntime(tc.binaryExecutable, tc.envVarsAllSet)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("ProbeMCPRuntime returned nil error; want non-nil")
+				}
+				if !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ProbeMCPRuntime returned error %q; want nil", err.Error())
+			}
+		})
+	}
+}
+
+func TestProbeMCPCmdline(t *testing.T) {
+	const (
+		flag   = "--mcp-config"
+		marker = `"aileron"`
+	)
+	tests := []struct {
+		name             string
+		binaryExecutable bool
+		envVarsAllSet    bool
+		cmdline          string
+		wantErr          bool
+		errContains      string
+	}{
+		{
+			name:             "flag and marker both present (core ok) returns nil",
+			binaryExecutable: true,
+			envVarsAllSet:    true,
+			cmdline:          `claude --mcp-config {"mcpServers":{"aileron":{}}} -p hi `,
+			wantErr:          false,
+		},
+		{
+			name:             "flag present but marker absent from payload returns error",
+			binaryExecutable: true,
+			envVarsAllSet:    true,
+			cmdline:          `claude --mcp-config {"mcpServers":{"other":{}}} -p hi `,
+			wantErr:          true,
+			errContains:      "payload references",
+		},
+		{
+			name:             "no --mcp-config flag at all returns error",
+			binaryExecutable: true,
+			envVarsAllSet:    true,
+			cmdline:          `claude -p hi `,
+			wantErr:          true,
+			errContains:      "container command carries",
+		},
+		{
+			// Cmdline is correct, but the runtime core fails first (binary
+			// missing), proving the core gates before the cmdline check.
+			name:             "runtime core failing gates before the cmdline check",
+			binaryExecutable: false,
+			envVarsAllSet:    true,
+			cmdline:          `claude --mcp-config {"mcpServers":{"aileron":{}}} -p hi `,
+			wantErr:          true,
+			errContains:      "aileron-mcp missing or not executable",
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := systestlib.ProbeMCPCmdline(tc.binaryExecutable, tc.envVarsAllSet, tc.cmdline, flag, marker)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatal("ProbeMCPCmdline returned nil error; want non-nil")
+				}
+				if !strings.Contains(err.Error(), tc.errContains) {
+					t.Errorf("error %q does not contain %q", err.Error(), tc.errContains)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("ProbeMCPCmdline returned error %q; want nil", err.Error())
+			}
+		})
+	}
+}


### PR DESCRIPTION
## Summary

Ports the host-verifiable, docker-free probe helpers from `test/system/lib/probes.sh` to Go in the existing `systestlib` package (created by #1601), mirroring the `assert.go` / `assert_test.go` pattern exactly. Two new files only:

- `test/system/lib/probes.go` (`package systestlib`) — pure-logic helpers:
  - `ImageRepo(ref)` — strip `@…` digest then a trailing `:tag` only when the final path segment carries the colon (preserves a registry `host:port` with no tag).
  - `ImageRefMatches(expected, actual)` — R8.1 digest tolerance (#1233): same repo plus a floating `:edge`/`:latest` tag or an `@sha256:` digest on `actual`, else exact match. Byte-faithful to the shell `image_ref_matches`.
  - `SplitNames(raw)` / `DiscoverContainer(prefix, names)` — count arbitration over candidate names (one → name; zero/many → diagnostic error), ignoring whitespace-only entries to mirror shell word-splitting of the `docker ps` block.
  - `ProbeExitCode(actual, expected)` — R8.6 exit-code assertion.
  - `ProbeMCPRuntime(binaryExecutable, envVarsAllSet)` — R8.2 core; binary check gates before env, faithful ordering.
  - `ProbeMCPCmdline(binaryExecutable, envVarsAllSet, cmdline, flag, marker)` — core gates first, then `cmdline` must contain both `flag` and `marker`.
- `test/system/lib/probes_test.go` (`package systestlib_test`) — table-driven contract tests, one-to-one with every `probes_test.sh` case (happy path + each documented failure).

The shell contract test stubbed `docker` on PATH and fed inputs via env (`DOCKER_PS_OUTPUT`, `DOCKER_EXEC_TEST_RC`, `DOCKER_EXEC_PRINTENV_RC`, `DOCKER_INSPECT_OUTPUT`). The Go port replaces the stub by passing those same inputs as ordinary Go parameters — no docker binary, no stub on PATH.

Out of scope (untouched, per the plan): `probes.sh`, `probes_test.sh` (deletion is #1604's job), `Taskfile.yml` / `GO_TEST_PACKAGES`, `go.mod`, the existing assert files, and the container-bound probes (`probe_image`/`probe_mcp`/`probe_credentials`/`probe_daemon_reachable`/`probe_teardown`).

## Test plan

- `cd test/system/lib && go build ./...` — compiles.
- `go vet ./...` — clean.
- `go test ./...` — passes (no docker daemon required).
- `go test -cover ./...` — **100.0% of statements** on the package.
- `git diff --stat` shows only the two new files added; no other paths touched.

CodeRabbit review surfaced one minor finding suggesting `ImageRefMatches` short-circuit to exact-match when `expected` is itself a pinned digest. Declined: the current behavior is byte-faithful to the shell `image_ref_matches` (probes.sh:86-100), where the `@sha256:` branch keys on `actual` alone, independent of `expected`. probes.sh is the source-of-truth contract this PR ports, and changing it would diverge the Go port from the shipped shell library (out of scope, and a faithfulness regression). In practice the launcher always passes a resolved floating ref as `expected`, so the tolerance on `actual` is exactly the R8.1 behavior #1233 requires.

Closes #1602

🤖 Generated with [Claude Code](https://claude.com/claude-code)
