### PR TITLE
feat(flightplan): parse rung-3 declaration and report it build-deferred

### DIFF
--- a/cmd/aileron/skill_freeze.go
+++ b/cmd/aileron/skill_freeze.go
@@ -77,6 +77,12 @@ func runSkillFreeze(args []string, stdout, stderr io.Writer) int {
 	}
 	fmt.Fprintf(stdout, "  ContentHash: %s\n", res.ContentHash)
 	fmt.Fprintf(stdout, "  Stored at:   %s\n", s.FrozenDir(res.Name, id))
+	// Surface any execution-environment rung that was declared but
+	// intentionally not built (today: the reserved rung-3 slot). The operator
+	// is told explicitly rather than left to assume the image set is complete.
+	for _, rung := range res.DeferredRungs {
+		fmt.Fprintf(stdout, "  Rung 3 declared: build-deferred (reserved manifest slot %q, ADR-0027); no image built\n", rung)
+	}
 	return 0
 }
 

--- a/cmd/aileron/skill_freeze_test.go
+++ b/cmd/aileron/skill_freeze_test.go
@@ -270,6 +270,81 @@ aileron:
 	}
 }
 
+func TestRunSkillFreeze_Rung3ReportedDeferred(t *testing.T) {
+	storeDir := withTempStore(t)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+
+	// A skill declaring only the reserved rung-3 slot. Freeze must succeed,
+	// pin no image, and tell the operator the rung is build-deferred.
+	const rung3MD = `---
+name: rung3-skill
+description: Reserved rung-3 declaration.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:x.y
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+    executionEnvironment:
+      rung3PerStepImages:
+        steps:
+          - image: registry.example.com/per-step-tool:1
+  inputs: []
+  outputs: []
+---
+
+# Rung 3
+`
+	dir := filepath.Join(storeDir, "rung3-skill")
+	if err := os.MkdirAll(dir, 0o755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.WriteFile(filepath.Join(dir, "SKILL.md"), []byte(rung3MD), 0o644); err != nil {
+		t.Fatal(err)
+	}
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillFreeze([]string{"--signing-key", key, "rung3-skill"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("a rung-3 freeze must succeed (build-deferred, not an error), exit=%d stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Rung 3 declared: build-deferred") {
+		t.Errorf("operator must be told rung-3 is build-deferred, stdout=%q", out)
+	}
+	if !strings.Contains(out, "ADR-0027") {
+		t.Errorf("the deferred line should cite ADR-0027, stdout=%q", out)
+	}
+
+	// The frozen lockfile pins no image (nothing was built).
+	s := store.New(storeDir)
+	ids, err := s.FrozenVersions("rung3-skill")
+	if err != nil || len(ids) != 1 {
+		t.Fatalf("FrozenVersions = %v, %v", ids, err)
+	}
+	v, err := s.ReadFrozen("rung3-skill", ids[0])
+	if err != nil {
+		t.Fatal(err)
+	}
+	if strings.Contains(string(v.Lockfile), "resolvedImages:") {
+		t.Errorf("a rung-3 freeze must pin no image, lockfile:\n%s", v.Lockfile)
+	}
+	if len(v.Signature) == 0 {
+		t.Error("a rung-3 freeze must still be signed")
+	}
+}
+
 func TestRunSkillFreeze_FromPath(t *testing.T) {
 	withTempStore(t)
 	stubFreezeResolvers(t, fakeFreezeDigest)

--- a/docs/schema/flight-plan-manifest.example.rung1.skill.md
+++ b/docs/schema/flight-plan-manifest.example.rung1.skill.md
@@ -1,0 +1,109 @@
+---
+name: nightly-log-rollup
+description: Read a log window from a logging API and roll it up into a daily summary artifact.
+license: Apache-2.0
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:logs.query_window
+        trustContract:
+          credential:
+            kind: aws-sigv4
+            placement: signing
+            identityLabel: log-reader@example.com
+          hosts:
+            - logs.example.com
+          paths:
+            - /v1/logs/query
+          effect: read
+          idempotency:
+            safeToRetry: true
+            idempotencyKey: false
+          verification:
+            method: GET
+            path: /v1/health
+          audit:
+            fields:
+              - connector-hash
+              - action-manifest-version
+              - credential-binding
+              - identity-label
+              - approved-input
+              - approval-decision
+              - network-target
+              - operation-effect
+              - request-summary
+              - response-summary
+              - result
+            sink: audit/log-reads
+    executionEnvironment:
+      rung1Image:
+        ref: registry.example.com/log-rollup-runner:2.3
+  inputs:
+    - name: window_hours
+      type: number
+      description: How many hours back the log window covers. A literal so one image serves operators with different window sizes.
+      resolution:
+        rule: literal
+        default: 24
+    - name: as_of
+      type: timestamp
+      description: The launch timestamp the window is anchored to. Resolved once at launch so every step sees one clock value.
+      resolution:
+        rule: dynamic
+        value: now
+  outputs:
+    - name: rollup.csv
+      mimeType: text/csv
+      encoding: utf-8
+      publish:
+        target: file
+        path: rollup.csv
+  steps:
+    - id: query_logs
+      kind: action-call
+      actionRef: aileron:logs.query_window
+      args:
+        window_hours: inputs.window_hours
+        as_of: inputs.as_of
+      outputs:
+        - entries
+    - id: render_rollup
+      kind: transform
+      bindings:
+        entries: steps.query_logs.entries
+      outputs:
+        - csv
+      materializesOutput: rollup.csv
+---
+
+# Nightly Log Rollup
+
+This skill reads a recent log window and rolls it up into a compact daily CSV summary.
+
+## What it does
+
+The `aileron.steps` block wires this work as a deterministic step graph.
+
+1. `query_logs` (action-call) reads the log window from the logging API.
+2. `render_rollup` (transform) renders a compact CSV rollup of the entries and materializes it into the `rollup.csv` output.
+
+Each step binds its inputs by name to a resolved input (`inputs.<name>`) or a prior step output (`steps.<stepId>.<output>`). A binding is a reference, never a value.
+
+## Execution environment (rung 1)
+
+This skill declares a rung-1 execution environment: it names a whole prebuilt image (`registry.example.com/log-rollup-runner:2.3`) that the operator owns. Freeze resolves that named image to an `image@sha256:` digest pin and records it in the `lock` section. There are no capability units to compose, so the resolved capability set is empty. The contrast with the rung-2 worked example is the boundary this rung-1 example exists to demonstrate: rung-1 pins a named image; rung-2 composes capability-unit Features onto the Aileron base and pins the built result.
+
+## Inputs
+
+- `window_hours`: how far back to look. Defaults to the last 24 hours.
+- `as_of`: the moment the window is anchored to. Defaults to launch time.
+
+## Outputs
+
+- `rollup.csv`: the rendered rollup, one row per bucket.
+
+## Notes
+
+This skill is not yet a Flight Plan. It carries no `lock` section because it has not been frozen. Freeze resolves the rung-1 `rung1Image.ref` to an image digest, attaches the per-action trust contract above, and signs the result. After freeze the `aileron.lock` section is present and immutable for that version.

--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -83,11 +83,19 @@
     },
     "executionEnvironment": {
       "type": "object",
-      "description": "The execution-environment dependency. Exactly one of rung-1 (a pinned prebuilt image) or rung-2 (composed capability units on the Aileron base) is declared per ADR-0027 execution rungs. Rung-3 per-step sibling-image dispatch is a reserved, build-deferred slot.",
+      "description": "The execution-environment dependency. At most one of rung-1 (a pinned prebuilt image) or rung-2 (composed capability units on the Aileron base) is declared per ADR-0027 execution rungs; rung-1 and rung-2 are mutually exclusive. Rung-3 per-step sibling-image dispatch is a reserved, build-deferred slot: a manifest may declare rung3PerStepImages alone, in which case freeze parses it and reports it as build-deferred rather than building anything.",
       "additionalProperties": false,
       "oneOf": [
         { "required": ["rung1Image"], "not": { "required": ["rung2CapabilityUnits"] } },
-        { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } }
+        { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } },
+        {
+          "not": {
+            "anyOf": [
+              { "required": ["rung1Image"] },
+              { "required": ["rung2CapabilityUnits"] }
+            ]
+          }
+        }
       ],
       "properties": {
         "rung1Image": {
@@ -122,9 +130,9 @@
           }
         },
         "rung3PerStepImages": {
-          "$comment": "RESERVED, BUILD-DEFERRED. Rung three is per-step sealed sibling-image dispatch with mount and run-and-collect I/O. ADR-0027 defines it as a manifest slot only so a later build can fill it without a format change. It is intentionally typed loosely here and MUST NOT be relied on by v1 tooling.",
+          "$comment": "RESERVED, BUILD-DEFERRED. Rung three is per-step sealed sibling-image dispatch with mount and run-and-collect I/O. ADR-0027 defines it as a manifest slot only so a later build can fill it without a format change. It is intentionally typed loosely here and MUST NOT be relied on by v1 tooling. Freeze parses a rung-3 declaration and reports it as build-deferred (empty image set); it never builds a rung-3 image in v1.",
           "type": "object",
-          "description": "RESERVED and build-deferred. Per-step sibling-image dispatch (ADR-0027 rung three). Designed as a manifest slot only; not implemented in v1. Do not author this field expecting runtime support."
+          "description": "RESERVED and build-deferred. Per-step sibling-image dispatch (ADR-0027 rung three). Designed as a manifest slot only; not implemented in v1. A manifest may declare this slot alone: freeze parses it and reports it as build-deferred rather than building anything. Do not author this field expecting runtime support."
         }
       }
     },

--- a/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
+++ b/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
@@ -64,7 +64,7 @@ Rung one pins a whole prebuilt image. The skill names an image, and freeze resol
 
 Rung two declares capability units, and Aileron composes them. The skill declares the units it requires on top of a generic Aileron-provided agent-free minimal base image. Freeze composes the operator-owned capability-unit devcontainer Features onto that base and pins the result. The capability-unit shape is the one defined in [ADR-0026](/adr/0026-cli-capability-units).
 
-The MVP ships rungs one and two. Rung three is a per-step sealed sibling-image dispatch with mount and run-and-collect I/O. Rung three is designed as a manifest slot so a later build can fill it without a format change. Rung three is build-deferred and out of scope here.
+The MVP ships rungs one and two. Rung three is a per-step sealed sibling-image dispatch with mount and run-and-collect I/O. Rung three is designed as a manifest slot so a later build can fill it without a format change. Rung three is build-deferred and out of scope here. A manifest may declare the `rung3PerStepImages` slot alone. Freeze parses that declaration, builds no image, and reports the rung as build-deferred to the operator, so a rung-three-only Flight Plan is a told outcome rather than a parse failure or a silent pass.
 
 The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.
 

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -77,7 +77,7 @@ An unsatisfied `requires:` entry is a missing-requirement signal the runtime sur
 
 ### `requires.executionEnvironment`
 
-The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). The MVP ships rung one and rung two. When `executionEnvironment` is declared it carries exactly one of `rung1Image` or `rung2CapabilityUnits`.
+The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) execution rungs). The MVP ships rung one and rung two. When `executionEnvironment` declares an image rung it carries at most one of `rung1Image` or `rung2CapabilityUnits`; the two are mutually exclusive. The reserved `rung3PerStepImages` slot may be declared alone. Freeze parses a rung-three declaration and reports it as build-deferred (it pins no image), so a rung-three-only manifest is valid and is told to the operator rather than failing.
 
 | Field | Type | Required | Semantics |
 |---|---|---|---|
@@ -85,7 +85,7 @@ The execution image is assembled from rungs ([ADR-0027](/adr/0027-flight-plan-se
 | `rung1Image.ref` | string | Yes within `rung1Image` | An OCI image reference. Freeze resolves a tag to an `image@sha256:` digest pin. |
 | `rung2CapabilityUnits` | object | No | Rung two. Declares capability units composed onto the Aileron agent-free base image. |
 | `rung2CapabilityUnits.features` | array | Yes within `rung2CapabilityUnits` | The capability-unit devcontainer Feature references ([ADR-0026](/adr/0026-cli-capability-units)). |
-| `rung3PerStepImages` | object | No | RESERVED and build-deferred. The rung-three per-step sibling-image dispatch slot. Designed as a manifest slot only. Not implemented in v1. |
+| `rung3PerStepImages` | object | No | RESERVED and build-deferred. The rung-three per-step sibling-image dispatch slot. Designed as a manifest slot only. Not implemented in v1. May be declared alone: freeze parses it and reports it as build-deferred rather than building anything. |
 
 ### `requires.actions[].trustContract`
 

--- a/internal/flightplan/freeze/freeze.go
+++ b/internal/flightplan/freeze/freeze.go
@@ -48,6 +48,14 @@ type Result struct {
 	PublicKey []byte
 	// Lock is the structured lockfile record (contentHash included).
 	Lock Lockfile
+	// DeferredRungs records execution-environment rungs that were declared in
+	// the manifest but intentionally not built by freeze. Today this is the
+	// reserved, build-deferred rung-3 slot (rung3PerStepImages, ADR-0027):
+	// when present it is parsed and reported as deferred rather than failing
+	// or silently passing. Empty for a fully-resolved or instruction-only
+	// skill. This lives in the Result and CLI output only; it is not persisted
+	// to the lockfile (no lockfile schema change).
+	DeferredRungs []string
 }
 
 // Options configures a Run.
@@ -93,7 +101,7 @@ func Run(ctx context.Context, raw []byte, opts Options) (Result, error) {
 		return Result{}, err
 	}
 
-	pins, capSet, err := resolveImages(ctx, m, opts.Resolver, opts.Composer)
+	pins, capSet, deferred, err := resolveImages(ctx, m, opts.Resolver, opts.Composer)
 	if err != nil {
 		return Result{}, err
 	}
@@ -145,5 +153,6 @@ func Run(ctx context.Context, raw []byte, opts Options) (Result, error) {
 		Signature:      sig,
 		PublicKey:      pubPEM,
 		Lock:           lock,
+		DeferredRungs:  deferred,
 	}, nil
 }

--- a/internal/flightplan/freeze/images.go
+++ b/internal/flightplan/freeze/images.go
@@ -56,72 +56,90 @@ func (f FeatureComposerFunc) ComposeDigest(ctx context.Context, features []strin
 	return f(ctx, features)
 }
 
+// rung3Name is the rung label recorded in Result.DeferredRungs when a
+// manifest declares the reserved, build-deferred rung-3 slot.
+const rung3Name = "rung3PerStepImages"
+
 // resolveImages resolves a manifest's execution environment to the pinned
 // image set and resolved capability set, returning the data the lockfile
-// records. The four cases:
+// records plus the rungs that were declared but intentionally not built. The
+// cases:
 //
 //   - instruction-only / no executionEnvironment: empty pins, no error
 //     (the skill still gets a contentHash and signature);
 //   - rung-1 (rung1Image.ref): resolve the named image to a digest pin;
 //   - rung-2 (rung2CapabilityUnits.features): compose the Features and pin
 //     the built image's digest plus the resolved capability set;
-//   - both rungs present, or neither: a malformed manifest the schema
+//   - rung-3 (rung3PerStepImages, no rung-1/rung-2): a reserved,
+//     build-deferred slot (ADR-0027). It parses to an empty image set and is
+//     reported as deferred, never built. This is a first-class outcome, not
+//     an error;
+//   - both rung-1 and rung-2 present, or an executionEnvironment naming
+//     neither an image rung nor rung-3: a malformed manifest the schema
 //     already rejects; guarded here defensively.
 //
 // Every resolved digest is checked against digestPattern: a resolver that
 // yields a tag rather than a digest is rejected (pin by digest, never tag).
-func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver, fc FeatureComposer) (pins []ImagePin, capSet []string, err error) {
+func resolveImages(ctx context.Context, m *manifest.Manifest, dr DigestResolver, fc FeatureComposer) (pins []ImagePin, capSet []string, deferred []string, err error) {
 	if m == nil || m.InstructionOnly {
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 	env := m.Aileron.Requires.ExecutionEnvironment
 	if len(env) == 0 {
 		// No execution environment declared: an instruction/composition-only
 		// skill freezes with an empty resolvedImages set.
-		return nil, nil, nil
+		return nil, nil, nil, nil
 	}
 
 	rung1, hasRung1 := env["rung1Image"]
 	rung2, hasRung2 := env["rung2CapabilityUnits"]
+	_, hasRung3 := env[rung3Name]
 	switch {
 	case hasRung1 && hasRung2:
-		return nil, nil, fmt.Errorf("freeze: executionEnvironment declares both rung1Image and rung2CapabilityUnits; exactly one is permitted")
+		return nil, nil, nil, fmt.Errorf("freeze: executionEnvironment declares both rung1Image and rung2CapabilityUnits; exactly one is permitted")
 	case hasRung1:
 		ref, err := rung1ImageRef(rung1)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if dr == nil {
-			return nil, nil, fmt.Errorf("freeze: rung-1 image %q requires a digest resolver", ref)
+			return nil, nil, nil, fmt.Errorf("freeze: rung-1 image %q requires a digest resolver", ref)
 		}
 		digest, err := dr.ResolveDigest(ctx, ref)
 		if err != nil {
-			return nil, nil, fmt.Errorf("freeze: resolve rung-1 image %q: %w", ref, err)
+			return nil, nil, nil, fmt.Errorf("freeze: resolve rung-1 image %q: %w", ref, err)
 		}
 		if err := requireDigest(ref, digest); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
-		return []ImagePin{{Ref: ref, Digest: digest}}, nil, nil
+		return []ImagePin{{Ref: ref, Digest: digest}}, nil, nil, nil
 	case hasRung2:
 		features, err := rung2Features(rung2)
 		if err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		if fc == nil {
-			return nil, nil, fmt.Errorf("freeze: rung-2 capability units require a feature composer")
+			return nil, nil, nil, fmt.Errorf("freeze: rung-2 capability units require a feature composer")
 		}
 		digest, err := fc.ComposeDigest(ctx, features)
 		if err != nil {
-			return nil, nil, fmt.Errorf("freeze: compose rung-2 capability units: %w", err)
+			return nil, nil, nil, fmt.Errorf("freeze: compose rung-2 capability units: %w", err)
 		}
 		if err := requireDigest("rung2:"+joinFeatures(features), digest); err != nil {
-			return nil, nil, err
+			return nil, nil, nil, err
 		}
 		// The pre-freeze "ref" for a composed image is the feature set; the
 		// resolved capability set is the same features, pinned.
-		return []ImagePin{{Ref: composedRef(features), Digest: digest}}, append([]string(nil), features...), nil
+		return []ImagePin{{Ref: composedRef(features), Digest: digest}}, append([]string(nil), features...), nil, nil
+	case hasRung3:
+		// Rung-3 (per-step sibling-image dispatch) is a reserved,
+		// build-deferred slot (ADR-0027). Freeze parses it and reports it as
+		// deferred: no image is built, the resolved image set is empty, and
+		// the rung is recorded as intentionally not built. This is a normal
+		// freeze outcome, not an error.
+		return nil, nil, []string{rung3Name}, nil
 	default:
-		return nil, nil, fmt.Errorf("freeze: executionEnvironment declares neither rung1Image nor rung2CapabilityUnits")
+		return nil, nil, nil, fmt.Errorf("freeze: executionEnvironment declares neither rung1Image nor rung2CapabilityUnits")
 	}
 }
 

--- a/internal/flightplan/freeze/images_malformed_test.go
+++ b/internal/flightplan/freeze/images_malformed_test.go
@@ -25,49 +25,49 @@ func TestResolveImages_BothRungsRejected(t *testing.T) {
 		"rung1Image":           map[string]any{"ref": "a:1"},
 		"rung2CapabilityUnits": map[string]any{"features": []any{"f"}},
 	})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("declaring both rungs must error")
 	}
 }
 
 func TestResolveImages_Rung1MissingRef(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung1Image": map[string]any{}})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("rung1Image with no ref must error")
 	}
 }
 
 func TestResolveImages_Rung1NotMapping(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung1Image": "scalar"})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("rung1Image that is not a mapping must error")
 	}
 }
 
 func TestResolveImages_Rung2EmptyFeatures(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{}}})
-	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
 		t.Error("rung2 with empty features must error")
 	}
 }
 
 func TestResolveImages_Rung2EmptyFeatureEntry(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": map[string]any{"features": []any{""}}})
-	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
 		t.Error("rung2 with an empty feature entry must error")
 	}
 }
 
 func TestResolveImages_Rung2NotMapping(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"rung2CapabilityUnits": "scalar"})
-	if _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, nil, fakeComposer(fakeDigest)); err == nil {
 		t.Error("rung2CapabilityUnits that is not a mapping must error")
 	}
 }
 
 func TestResolveImages_NeitherRung(t *testing.T) {
 	m := mWithExecEnv(map[string]any{"somethingElse": map[string]any{}})
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("an executionEnvironment with neither rung must error")
 	}
 }

--- a/internal/flightplan/freeze/images_test.go
+++ b/internal/flightplan/freeze/images_test.go
@@ -25,9 +25,12 @@ func TestResolveImages_Rung1ResolvesToDigest(t *testing.T) {
 		gotRef = ref
 		return fakeDigest, nil
 	})
-	pins, capSet, err := resolveImages(context.Background(), m, dr, nil)
+	pins, capSet, deferred, err := resolveImages(context.Background(), m, dr, nil)
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
+	}
+	if len(deferred) != 0 {
+		t.Errorf("rung-1 must defer nothing, got %v", deferred)
 	}
 	if gotRef != "registry.example.com/runner:1.4" {
 		t.Errorf("resolver got ref %q", gotRef)
@@ -47,9 +50,12 @@ func TestResolveImages_Rung2ComposesAndPins(t *testing.T) {
 		gotFeatures = features
 		return fakeDigest, nil
 	})
-	pins, capSet, err := resolveImages(context.Background(), m, nil, fc)
+	pins, capSet, deferred, err := resolveImages(context.Background(), m, nil, fc)
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
+	}
+	if len(deferred) != 0 {
+		t.Errorf("rung-2 must defer nothing, got %v", deferred)
 	}
 	wantFeatures := []string{
 		"ghcr.io/example/aileron-feature-metrics-cli:1",
@@ -68,7 +74,7 @@ func TestResolveImages_Rung2ComposesAndPins(t *testing.T) {
 
 func TestResolveImages_InstructionOnlyEmpty(t *testing.T) {
 	m := parseM(t, []byte(instructionOnlyMD))
-	pins, capSet, err := resolveImages(context.Background(), m, nil, nil)
+	pins, capSet, _, err := resolveImages(context.Background(), m, nil, nil)
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -79,7 +85,7 @@ func TestResolveImages_InstructionOnlyEmpty(t *testing.T) {
 
 func TestResolveImages_NoExecEnvEmpty(t *testing.T) {
 	m := parseM(t, []byte(noExecEnvMD))
-	pins, _, err := resolveImages(context.Background(), m, nil, nil)
+	pins, _, _, err := resolveImages(context.Background(), m, nil, nil)
 	if err != nil {
 		t.Fatalf("resolveImages: %v", err)
 	}
@@ -93,7 +99,7 @@ func TestResolveImages_RejectsTagNotDigest(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return "registry.example.com/runner:1.4", nil // a tag, not a digest
 	})
-	_, _, err := resolveImages(context.Background(), m, dr, nil)
+	_, _, _, err := resolveImages(context.Background(), m, dr, nil)
 	if err == nil {
 		t.Fatal("a resolver returning a tag must be rejected")
 	}
@@ -107,21 +113,21 @@ func TestResolveImages_ResolverError(t *testing.T) {
 	dr := DigestResolverFunc(func(_ context.Context, _ string) (string, error) {
 		return "", errors.New("image not found")
 	})
-	if _, _, err := resolveImages(context.Background(), m, dr, nil); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, dr, nil); err == nil {
 		t.Error("an unresolvable image must error")
 	}
 }
 
 func TestResolveImages_Rung1NeedsResolver(t *testing.T) {
 	m := parseM(t, []byte(rung1MD))
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("a rung-1 manifest with no resolver must error")
 	}
 }
 
 func TestResolveImages_Rung2NeedsComposer(t *testing.T) {
 	m := parseM(t, exampleSkillMD(t))
-	if _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
+	if _, _, _, err := resolveImages(context.Background(), m, nil, nil); err == nil {
 		t.Error("a rung-2 manifest with no composer must error")
 	}
 }
@@ -134,5 +140,114 @@ func TestRequireDigest(t *testing.T) {
 		if err := requireDigest("ref", bad); err == nil {
 			t.Errorf("bad digest %q accepted", bad)
 		}
+	}
+}
+
+// TestResolveImages_Rung3DeclaredReportedDeferred is the #1510 acceptance
+// proof for rung-3: a manifest declaring only the reserved rung-3 slot is
+// parsed, builds no image (empty pins, empty capability set), and is reported
+// as deferred rather than erroring. A nil resolver and composer are passed to
+// prove rung-3 never touches the build seams.
+func TestResolveImages_Rung3DeclaredReportedDeferred(t *testing.T) {
+	m := parseM(t, []byte(rung3MD))
+	pins, capSet, deferred, err := resolveImages(context.Background(), m, nil, nil)
+	if err != nil {
+		t.Fatalf("a rung-3 declaration must parse and defer, not error: %v", err)
+	}
+	if len(pins) != 0 {
+		t.Errorf("rung-3 must build no image, got pins %+v", pins)
+	}
+	if len(capSet) != 0 {
+		t.Errorf("rung-3 must pin no capability set, got %v", capSet)
+	}
+	if len(deferred) != 1 || deferred[0] != rung3Name {
+		t.Errorf("rung-3 must be reported deferred as %q, got %v", rung3Name, deferred)
+	}
+}
+
+// TestResolveImages_DistinctFeatureSetsDistinctPins is the #1510 acceptance
+// proof for operator-specific composition divergence: two different
+// capability-unit Feature sets must produce two different pinned image
+// digests from the same base. The composer is a fake mapping each distinct
+// feature set to a distinct digest, proving the contract (different inputs →
+// different pins) at the freeze layer without a container runtime.
+func TestResolveImages_DistinctFeatureSetsDistinctPins(t *testing.T) {
+	// A composer that returns a digest deterministically keyed to the feature
+	// set: identical inputs yield identical pins, distinct inputs yield
+	// distinct pins.
+	digestFor := map[string]string{
+		"a": fakeDigest,
+		"b": fakeDigest2,
+	}
+	fc := FeatureComposerFunc(func(_ context.Context, features []string) (string, error) {
+		return digestFor[joinFeatures(features)], nil
+	})
+
+	mWithFeatures := func(features ...string) *manifest.Manifest {
+		list := make([]any, len(features))
+		for i, f := range features {
+			list[i] = f
+		}
+		return &manifest.Manifest{
+			Name: "x",
+			Aileron: manifest.AileronBlock{
+				Requires: manifest.Requires{ExecutionEnvironment: map[string]any{
+					"rung2CapabilityUnits": map[string]any{"features": list},
+				}},
+			},
+		}
+	}
+
+	pinsA, _, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc)
+	if err != nil {
+		t.Fatalf("compose feature set A: %v", err)
+	}
+	pinsB, _, _, err := resolveImages(context.Background(), mWithFeatures("b"), nil, fc)
+	if err != nil {
+		t.Fatalf("compose feature set B: %v", err)
+	}
+	if len(pinsA) != 1 || len(pinsB) != 1 {
+		t.Fatalf("each composition must pin exactly one image, got A=%+v B=%+v", pinsA, pinsB)
+	}
+	if pinsA[0].Digest == pinsB[0].Digest {
+		t.Errorf("distinct Feature sets must produce distinct pinned digests, both pinned %q", pinsA[0].Digest)
+	}
+	// Same feature set must reproduce the same pin (determinism).
+	pinsA2, _, _, err := resolveImages(context.Background(), mWithFeatures("a"), nil, fc)
+	if err != nil {
+		t.Fatalf("recompose feature set A: %v", err)
+	}
+	if pinsA2[0].Digest != pinsA[0].Digest {
+		t.Errorf("the same Feature set must reproduce the same pin: %q vs %q", pinsA2[0].Digest, pinsA[0].Digest)
+	}
+}
+
+// TestFreeze_Rung1WorkedExample is the #1510 rung-1 worked-example acceptance:
+// the committed rung-1 example skill freezes to a single image digest pin
+// (the named image resolved by the fake resolver) and an empty capability
+// set, with nothing deferred. It doubles as an executable check that the
+// worked example stays valid.
+func TestFreeze_Rung1WorkedExample(t *testing.T) {
+	m := parseM(t, exampleRung1SkillMD(t))
+	var gotRef string
+	dr := DigestResolverFunc(func(_ context.Context, ref string) (string, error) {
+		gotRef = ref
+		return fakeDigest, nil
+	})
+	pins, capSet, deferred, err := resolveImages(context.Background(), m, dr, nil)
+	if err != nil {
+		t.Fatalf("freeze rung-1 worked example: %v", err)
+	}
+	if gotRef != "registry.example.com/log-rollup-runner:2.3" {
+		t.Errorf("resolver got ref %q, want the example's rung1Image.ref", gotRef)
+	}
+	if len(pins) != 1 || pins[0].Digest != fakeDigest {
+		t.Errorf("rung-1 example must pin exactly the named image's digest, got %+v", pins)
+	}
+	if len(capSet) != 0 {
+		t.Errorf("rung-1 has no capability set, got %v", capSet)
+	}
+	if len(deferred) != 0 {
+		t.Errorf("rung-1 example must defer nothing, got %v", deferred)
 	}
 }

--- a/internal/flightplan/freeze/testdata_test.go
+++ b/internal/flightplan/freeze/testdata_test.go
@@ -42,6 +42,19 @@ func exampleSkillMD(t *testing.T) []byte {
 	return raw
 }
 
+// exampleRung1SkillMD reads the committed rung-1 worked example SKILL.md: a
+// skill naming a whole prebuilt image (rung1Image.ref) with no capability
+// units to compose. It is the living-documentation parallel to the rung-2
+// example.
+func exampleRung1SkillMD(t *testing.T) []byte {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.rung1.skill.md"))
+	if err != nil {
+		t.Fatalf("read rung-1 worked example: %v", err)
+	}
+	return raw
+}
+
 // instructionOnlyMD is a SKILL.md with no aileron block.
 const instructionOnlyMD = `---
 name: rubber-duck
@@ -108,6 +121,40 @@ aileron:
 ---
 
 # No Exec Env
+`
+
+// rung3MD declares only the reserved, build-deferred rung-3 slot
+// (rung3PerStepImages) with neither rung-1 nor rung-2. The schema permits a
+// rung-3-only declaration and freeze parses it, builds no image, and reports
+// it as deferred (ADR-0027).
+const rung3MD = `---
+name: rung3-skill
+description: A skill declaring only the reserved rung-3 slot.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+    executionEnvironment:
+      rung3PerStepImages:
+        steps:
+          - image: registry.example.com/per-step-tool:1
+  inputs: []
+  outputs: []
+---
+
+# Rung 3 Skill
 `
 
 // genSigningKey returns a fresh ed25519 private key and writes its PKCS#8

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -83,11 +83,19 @@
     },
     "executionEnvironment": {
       "type": "object",
-      "description": "The execution-environment dependency. Exactly one of rung-1 (a pinned prebuilt image) or rung-2 (composed capability units on the Aileron base) is declared per ADR-0027 execution rungs. Rung-3 per-step sibling-image dispatch is a reserved, build-deferred slot.",
+      "description": "The execution-environment dependency. At most one of rung-1 (a pinned prebuilt image) or rung-2 (composed capability units on the Aileron base) is declared per ADR-0027 execution rungs; rung-1 and rung-2 are mutually exclusive. Rung-3 per-step sibling-image dispatch is a reserved, build-deferred slot: a manifest may declare rung3PerStepImages alone, in which case freeze parses it and reports it as build-deferred rather than building anything.",
       "additionalProperties": false,
       "oneOf": [
         { "required": ["rung1Image"], "not": { "required": ["rung2CapabilityUnits"] } },
-        { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } }
+        { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } },
+        {
+          "not": {
+            "anyOf": [
+              { "required": ["rung1Image"] },
+              { "required": ["rung2CapabilityUnits"] }
+            ]
+          }
+        }
       ],
       "properties": {
         "rung1Image": {
@@ -122,9 +130,9 @@
           }
         },
         "rung3PerStepImages": {
-          "$comment": "RESERVED, BUILD-DEFERRED. Rung three is per-step sealed sibling-image dispatch with mount and run-and-collect I/O. ADR-0027 defines it as a manifest slot only so a later build can fill it without a format change. It is intentionally typed loosely here and MUST NOT be relied on by v1 tooling.",
+          "$comment": "RESERVED, BUILD-DEFERRED. Rung three is per-step sealed sibling-image dispatch with mount and run-and-collect I/O. ADR-0027 defines it as a manifest slot only so a later build can fill it without a format change. It is intentionally typed loosely here and MUST NOT be relied on by v1 tooling. Freeze parses a rung-3 declaration and reports it as build-deferred (empty image set); it never builds a rung-3 image in v1.",
           "type": "object",
-          "description": "RESERVED and build-deferred. Per-step sibling-image dispatch (ADR-0027 rung three). Designed as a manifest slot only; not implemented in v1. Do not author this field expecting runtime support."
+          "description": "RESERVED and build-deferred. Per-step sibling-image dispatch (ADR-0027 rung three). Designed as a manifest slot only; not implemented in v1. A manifest may declare this slot alone: freeze parses it and reports it as build-deferred rather than building anything. Do not author this field expecting runtime support."
         }
       }
     },

--- a/internal/flightplan/manifest/validate_test.go
+++ b/internal/flightplan/manifest/validate_test.go
@@ -114,3 +114,84 @@ func TestStrippedTopLevelStillValid(t *testing.T) {
 		t.Fatalf("a stripped manifest must validate, got: %v", err)
 	}
 }
+
+// execEnvFrontmatter wraps an executionEnvironment block body into a complete,
+// otherwise-valid aileron frontmatter so a test exercises only the
+// executionEnvironment validity rules. envBlock is the YAML for the
+// executionEnvironment value, indented to sit under requires.
+func execEnvFrontmatter(envBlock string) []byte {
+	return []byte(`name: s
+description: d
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.query_series
+        trustContract:
+          credential:
+            kind: none
+          hosts:
+            - api.example.com
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields:
+              - result
+    executionEnvironment:
+` + envBlock + `
+  inputs: []
+  outputs: []
+`)
+}
+
+// TestExecutionEnvironmentRungValidity locks the rung composition rules at the
+// schema boundary: rung-1-only and rung-2-only are valid, declaring both
+// rung-1 and rung-2 is rejected (the existing exclusivity guarantee), and a
+// rung-3-only declaration is now valid (a reserved, build-deferred slot it is
+// freeze's job to report, not the schema's job to forbid). rung-3 alongside
+// rung-1 is also permitted: rung-3 is a reserved slot and does not weaken the
+// rung-1/rung-2 exclusivity.
+func TestExecutionEnvironmentRungValidity(t *testing.T) {
+	valid := map[string]string{
+		"rung1 only": `      rung1Image:
+        ref: registry.example.com/runner:1.4`,
+		"rung2 only": `      rung2CapabilityUnits:
+        features:
+          - ghcr.io/example/aileron-feature-metrics-cli:1`,
+		"rung3 only (reserved, build-deferred)": `      rung3PerStepImages:
+        steps:
+          - image: registry.example.com/per-step-tool:1`,
+		"rung3 alongside rung1": `      rung1Image:
+        ref: registry.example.com/runner:1.4
+      rung3PerStepImages:
+        steps:
+          - image: registry.example.com/per-step-tool:1`,
+	}
+	for name, env := range valid {
+		t.Run("valid/"+name, func(t *testing.T) {
+			if err := validateFrontmatter(execEnvFrontmatter(env)); err != nil {
+				t.Fatalf("expected valid, got: %v", err)
+			}
+		})
+	}
+
+	invalid := map[string]string{
+		"rung1 and rung2 together rejected": `      rung1Image:
+        ref: registry.example.com/runner:1.4
+      rung2CapabilityUnits:
+        features:
+          - ghcr.io/example/aileron-feature-metrics-cli:1`,
+	}
+	for name, env := range invalid {
+		t.Run("invalid/"+name, func(t *testing.T) {
+			err := validateFrontmatter(execEnvFrontmatter(env))
+			if err == nil {
+				t.Fatalf("expected validation error for %q, got nil", name)
+			}
+			if !strings.Contains(err.Error(), "schema validation") {
+				t.Errorf("error should cite schema validation, got: %v", err)
+			}
+		})
+	}
+}

--- a/internal/flightplan/spec/schema_test.go
+++ b/internal/flightplan/spec/schema_test.go
@@ -48,6 +48,10 @@ func examplePath(t *testing.T) string {
 	return filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.skill.md")
 }
 
+func rung1ExamplePath(t *testing.T) string {
+	return filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.rung1.skill.md")
+}
+
 // compileSchema compiles the committed Flight Plan manifest schema.
 func compileSchema(t *testing.T) *jsonschema.Schema {
 	t.Helper()
@@ -144,6 +148,25 @@ func TestWorkedExampleValidates(t *testing.T) {
 	inst := frontmatter(t, examplePath(t))
 	if err := sch.Validate(inst); err != nil {
 		t.Fatalf("worked example must validate against the schema:\n%v", err)
+	}
+}
+
+// TestRung1WorkedExampleValidates is the rung-1 worked-example drift guard:
+// the committed rung-1 example (a skill naming a whole prebuilt image)
+// validates against the committed schema, paralleling the rung-2 example.
+func TestRung1WorkedExampleValidates(t *testing.T) {
+	sch := compileSchema(t)
+	inst := frontmatter(t, rung1ExamplePath(t))
+	if err := sch.Validate(inst); err != nil {
+		t.Fatalf("rung-1 worked example must validate against the schema:\n%v", err)
+	}
+	// It declares a rung-1 image and no rung-2 capability units.
+	env := inst["aileron"].(map[string]any)["requires"].(map[string]any)["executionEnvironment"].(map[string]any)
+	if _, ok := env["rung1Image"]; !ok {
+		t.Error("rung-1 example must declare rung1Image")
+	}
+	if _, ok := env["rung2CapabilityUnits"]; ok {
+		t.Error("rung-1 example must not declare rung2CapabilityUnits")
 	}
 }
 
@@ -288,35 +311,42 @@ func TestNoSecretValueField(t *testing.T) {
 	}
 }
 
-// TestExecutionEnvironmentRequiresExactlyOneRung: an execution environment that
-// declares both rung1Image and rung2CapabilityUnits, or neither, fails. The
-// prose states exactly one rung is declared (ADR-0027 execution rungs).
-func TestExecutionEnvironmentRequiresExactlyOneRung(t *testing.T) {
+// TestExecutionEnvironmentRung1AndRung2MutuallyExclusive: declaring both
+// rung1Image and rung2CapabilityUnits fails. The two image rungs are mutually
+// exclusive (ADR-0027 execution rungs). This is the load-bearing guarantee the
+// rung-3 relaxation must not weaken.
+func TestExecutionEnvironmentRung1AndRung2MutuallyExclusive(t *testing.T) {
 	sch := compileSchema(t)
-
-	bothRungs := func(env map[string]any) {
-		env["rung1Image"] = map[string]any{"ref": "registry.example.com/runner:1.4"}
-		env["rung2CapabilityUnits"] = map[string]any{"features": []any{"ghcr.io/example/feature:1"}}
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	requires := blk["requires"].(map[string]any)
+	env := requires["executionEnvironment"].(map[string]any)
+	env["rung1Image"] = map[string]any{"ref": "registry.example.com/runner:1.4"}
+	env["rung2CapabilityUnits"] = map[string]any{"features": []any{"ghcr.io/example/feature:1"}}
+	if err := sch.Validate(inst); err == nil {
+		t.Fatal("declaring both rung1Image and rung2CapabilityUnits must be rejected")
 	}
-	emptyEnv := func(env map[string]any) {
-		delete(env, "rung1Image")
-		delete(env, "rung2CapabilityUnits")
-	}
+}
 
-	for name, mutate := range map[string]func(map[string]any){
-		"both rungs": bothRungs,
-		"no rung":    emptyEnv,
-	} {
-		t.Run(name, func(t *testing.T) {
-			inst := validExampleInstance(t)
-			blk := aileronBlock(t, inst)
-			requires := blk["requires"].(map[string]any)
-			env := requires["executionEnvironment"].(map[string]any)
-			mutate(env)
-			if err := sch.Validate(inst); err == nil {
-				t.Fatalf("an execution environment with %q must be rejected", name)
-			}
-		})
+// TestExecutionEnvironmentRung3OnlyAccepted: an execution environment that
+// declares only the reserved rung3PerStepImages slot (neither rung1Image nor
+// rung2CapabilityUnits) is valid. The schema permits the reserved slot;
+// freeze parses it and reports it as build-deferred rather than building
+// anything (#1510, ADR-0027). An execution environment with no image rung is
+// no longer a schema rejection.
+func TestExecutionEnvironmentRung3OnlyAccepted(t *testing.T) {
+	sch := compileSchema(t)
+	inst := validExampleInstance(t)
+	blk := aileronBlock(t, inst)
+	requires := blk["requires"].(map[string]any)
+	env := requires["executionEnvironment"].(map[string]any)
+	delete(env, "rung1Image")
+	delete(env, "rung2CapabilityUnits")
+	env["rung3PerStepImages"] = map[string]any{
+		"steps": []any{map[string]any{"image": "registry.example.com/per-step-tool:1"}},
+	}
+	if err := sch.Validate(inst); err != nil {
+		t.Fatalf("a rung-3-only execution environment must validate:\n%v", err)
 	}
 }
 


### PR DESCRIPTION
## Summary

Rungs 1 and 2 of the execution-environment model (rung-1 image pin resolution, rung-2 capability-unit Feature composition through the `composition.Plan` + `container.Builder` pipeline) already landed via the freeze/crystallization work (#1596). This PR closes the honest remaining delta for #1510: the reserved rung-3 slot and the two outstanding acceptance proofs.

- **Schema (source of truth first):** relax `$defs.executionEnvironment.oneOf` so a manifest may declare `rung3PerStepImages` alone (a reserved, build-deferred slot) while still forbidding `rung1Image` + `rung2CapabilityUnits` together. The rung-1/rung-2 mutual exclusivity is preserved. Edited in `docs/schema/flight-plan-manifest.schema.json` and mirrored byte-identically into the internal copy; the drift guard (`TestEmbeddedSchemaMatchesDoc`) stays green.
- **Freeze:** `resolveImages` gains an explicit rung-3 branch *before* the `default` case. A rung-3 declaration resolves to an empty image set and an empty capability set, and surfaces a structured deferred signal (`Result.DeferredRungs`) instead of the misleading "declares neither rung1Image nor rung2CapabilityUnits" error. Nothing is built for rung-3. The deferral lives in the freeze `Result` and CLI output only; the lockfile schema is unchanged.
- **CLI:** `aileron skill freeze` on a rung-3 manifest prints an explicit `Rung 3 declared: build-deferred (...ADR-0027)...` line and exits 0 (freeze succeeds, no image pinned).
- **Acceptance proofs:** a composition-divergence test (two distinct Feature sets produce two distinct pinned digests via the `FeatureComposer` seam, no Docker) and a committed rung-1 worked-example skill (`docs/schema/flight-plan-manifest.example.rung1.skill.md`) with freeze + schema-validation tests, paralleling the existing rung-2 example.
- **Docs:** ADR-0027 and the manifest spec page note that a rung-3-only manifest parses and is reported deferred at freeze rather than failing.

## Test plan

- `go test ./internal/flightplan/... ./cmd/aileron/` — all green.
- New tests:
  - `internal/flightplan/manifest`: `TestExecutionEnvironmentRungValidity` (rung1-only / rung2-only / rung3-only valid; rung1+rung2 rejected — regression for the existing exclusivity guarantee).
  - `internal/flightplan/spec`: `TestExecutionEnvironmentRung1AndRung2MutuallyExclusive` (replaces the old "exactly one / neither rejected" test, which asserted the now-relaxed contract), `TestExecutionEnvironmentRung3OnlyAccepted`, `TestRung1WorkedExampleValidates`.
  - `internal/flightplan/freeze`: `TestResolveImages_Rung3DeclaredReportedDeferred`, `TestResolveImages_DistinctFeatureSetsDistinctPins`, `TestFreeze_Rung1WorkedExample`. Existing tests updated to the 4-value `resolveImages` arity.
  - `cmd/aileron`: `TestRunSkillFreeze_Rung3ReportedDeferred` (rung-3 freeze exits 0, prints the build-deferred line, pins no image, still signs).
- Schema validity verified across the full rung matrix (empty, each single rung, rung1+rung2 rejected, rung1/2/3 combinations) with a real JSON-Schema validator.
- `freeze` package coverage 90.1%; `resolveImages` 94.1%.

### Notes / known gaps
- A rung-1 + rung-3 manifest is schema-valid; freeze resolves the rung-1 image and the reserved rung-3 slot is a no-op (image rung takes precedence). Not reported as deferred in that combined case, since the meaningful action — building the named image — still happens. Out of scope: launch-time consumption of the frozen lockfile image and the actual rung-3 build (both explicitly deferred per the plan).
- CodeRabbit CLI was rate-limited (free plan, ~38 min) at review time; a manual self-review of the schema `oneOf` correctness and the freeze deferred path was performed instead. No P0 findings.

Closes #1510

🤖 Generated with [Claude Code](https://claude.com/claude-code)
