### PR TITLE
ci: add test/system/lib/go.sum to setup-go cache-dependency-path

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -27,6 +27,7 @@ jobs:
             cmd/aileron-mcp/go.mod
             sdk/go/go.mod
             test/integration/go.mod
+            test/system/lib/go.sum
 
       - name: Verify generated code
         working-directory: internal
@@ -87,6 +88,7 @@ jobs:
             cmd/aileron-mcp/go.mod
             sdk/go/go.mod
             test/integration/go.mod
+            test/system/lib/go.sum
 
       - name: Install Task
         uses: arduino/setup-task@v2


### PR DESCRIPTION
## Summary

Operator-answered `cw-review-residual` decision for #1603 (residual #1610).

The committed root `go.work` lists `./test/system/lib`, and that module's `go.mod` now requires `gopkg.in/yaml.v3` (landed in #1614). Two CI Go jobs exercise the full `GO_TEST_PACKAGES` set — which now includes `./test/system/lib/...`:

- **Lint & Verify** runs `task vet:go` (`go vet {{.GO_TEST_PACKAGES}}`)
- **Unit Tests** runs `task test:go:ci:{sandbox,rest}` (same package set)

Both `setup-go` `cache-dependency-path` blocks listed the other five module `go.mod` paths but omitted `test/system/lib`, so its `yaml.v3` dependency fell outside the cache key. This appends `test/system/lib/go.sum` to both blocks to keep the cache key honest for the dependency actually pulled.

The residual's original recommendation ("leave it out, no CI job loads the module") was correctly overturned by the operator: the committed `go.work` use entry means the module IS exercised in CI.

## Test plan

- YAML validated (parses clean).
- No behavioral change: cache-dependency-path only affects the setup-go module-cache key, not test execution. CI green is the proof.

Closes #1610

🤖 Generated with [Claude Code](https://claude.com/claude-code)
