### PR TITLE
fix(build): use GO_TEST_PACKAGES single source in lint:go vet target

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -282,7 +282,7 @@ tasks:
   lint:go:
     desc: Vet Go code
     cmds:
-      - go vet ./internal/... ./cmd/aileron/... ./cmd/aileron-mcp/...
+      - go vet {{.GO_TEST_PACKAGES}}
 
   lint:webapp:
     desc: Check the local webapp for type errors


### PR DESCRIPTION
## Summary

`task lint:go` hardcoded its `go vet` package list as
`./internal/... ./cmd/aileron/... ./cmd/aileron-mcp/...`, which drifts from
`GO_TEST_PACKAGES` (Taskfile.yml:7) — the documented single source of truth for
the Go test/vet package set. As a result, packages added to `GO_TEST_PACKAGES`
(`./sdk/go/...`, `./test/system/lib/...`) were never vetted by `task lint:go`.

This points the `lint:go` cmd at `{{.GO_TEST_PACKAGES}}` so vet coverage tracks
the package set automatically, matching the existing `vet:all` target which
already uses the var.

## Test plan

- `task lint:go` resolves to
  `go vet ./internal/... ./cmd/aileron/... ./cmd/aileron-mcp/... ./sdk/go/... ./test/system/lib/...`
  and exits 0 (vet clean over the full set).
- No behavior change beyond widening the vetted package set to match the
  already-tested set; lint:go stays green.

Closes #1607

🤖 Generated with [Claude Code](https://claude.com/claude-code)
