### PR TITLE
feat(flightplan): deterministic Launch runtime (no-LLM step graph + trust-contract enforcement)

### DIFF
--- a/cmd/aileron/skill.go
+++ b/cmd/aileron/skill.go
@@ -14,7 +14,8 @@ import (
 const skillUsage = `usage:
   aileron skill install <source>   Install a skill from a local path or git URL into ~/.aileron/skills
   aileron skill list               List installed skills
-  aileron skill freeze <name>      Seal an installed skill into a signed, digest-pinned Flight Plan version`
+  aileron skill freeze <name>      Seal an installed skill into a signed, digest-pinned Flight Plan version
+  aileron skill launch <name>      Run a frozen Flight Plan deterministically (no-LLM step graph)`
 
 // skillStoreDir is a seam so tests can point the CLI at a temp store
 // instead of the user's real ~/.aileron/skills.
@@ -48,6 +49,8 @@ func runSkill(args []string, stdout, stderr io.Writer) int {
 		return runSkillList(args[1:], stdout, stderr)
 	case "freeze":
 		return runSkillFreeze(args[1:], stdout, stderr)
+	case "launch":
+		return runSkillLaunch(args[1:], stdout, stderr)
 	default:
 		fmt.Fprintf(stderr, "unknown skill command: %q\n", args[0])
 		fmt.Fprintln(stderr, skillUsage)

--- a/cmd/aileron/skill_launch.go
+++ b/cmd/aileron/skill_launch.go
@@ -1,0 +1,232 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"flag"
+	"fmt"
+	"io"
+	"net/http"
+	"net/url"
+	"strings"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+// The Launch SPIs are wired here from package-level seams so CLI tests
+// exercise the orchestration with fakes and no live daemon, mirroring
+// skill_freeze.go's newDigestResolver/newFeatureComposer discipline. Each seam
+// returns the daemon-backed implementation in production.
+var newLaunchDispatcher = func() runtime.ActionDispatcher { return daemonDispatcher{} }
+var newLaunchApprover = func() runtime.Approver { return daemonApprover{} }
+var newLaunchAuditSink = func() runtime.AuditSink { return stdoutAuditSink{} }
+
+// launchSeamForTest is the LLM seam the launch wires into the runtime. It is
+// nil by default, which is the v1 contract: a plan with an llm-seam step
+// errors unless a provider is configured, so a default launch reaches no LLM.
+// It is a package-level seam so tests can supply a deterministic seam; there
+// is no production LLM seam provider wired in v1.
+var launchSeamForTest runtime.LLMSeam
+
+// inputFlag collects repeated --input name=value launch overrides.
+type inputFlag struct {
+	values map[string]any
+}
+
+func (f *inputFlag) String() string { return "" }
+
+func (f *inputFlag) Set(s string) error {
+	i := strings.IndexByte(s, '=')
+	if i <= 0 {
+		return fmt.Errorf("--input must be name=value, got %q", s)
+	}
+	if f.values == nil {
+		f.values = map[string]any{}
+	}
+	f.values[s[:i]] = s[i+1:]
+	return nil
+}
+
+// runSkillLaunch implements `aileron skill launch <name>`. It loads a frozen
+// version from the store, verifies it, resolves declared inputs, walks the
+// deterministic step graph through the daemon-backed action boundary, and
+// materializes declared artifacts into --out-dir. This is the Flight-Plan
+// Launch runtime (#1511); it is distinct from the top-level `aileron launch`
+// agent-sandbox command (a different subsystem).
+func runSkillLaunch(args []string, stdout, stderr io.Writer) int {
+	flags := flag.NewFlagSet("skill launch", flag.ContinueOnError)
+	flags.SetOutput(stderr)
+	version := flags.String("version", "", "Frozen version id to launch (defaults to the only/most recent version)")
+	outDir := flags.String("out-dir", ".", "Directory file-target artifacts are written to")
+	var inputs inputFlag
+	flags.Var(&inputs, "input", "Launch input override as name=value; repeatable")
+	if err := flags.Parse(args); err != nil {
+		return 1
+	}
+	if flags.NArg() != 1 {
+		fmt.Fprintln(stderr, skillUsage)
+		return 1
+	}
+	name := flags.Arg(0)
+
+	s := store.New(skillStoreDir)
+	id, err := resolveLaunchVersion(s, name, *version)
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	res, err := runtime.Run(context.Background(), runtime.Options{
+		Store:      s,
+		Name:       name,
+		Version:    id,
+		Inputs:     runtime.LaunchArgs(inputs.values),
+		Dispatcher: newLaunchDispatcher(),
+		Approver:   newLaunchApprover(),
+		Audit:      newLaunchAuditSink(),
+		// Seam is nil in v1 production: the LLM seam is unwired, so a plan with
+		// an llm-seam step errors unless a provider is supplied. Tests inject a
+		// deterministic seam through launchSeamForTest.
+		Seam:   launchSeamForTest,
+		OutDir: *outDir,
+	})
+	if err != nil {
+		fmt.Fprintf(stderr, "error: %v\n", err)
+		return 1
+	}
+
+	fmt.Fprintf(stdout, "Launched %q\n", name)
+	fmt.Fprintf(stdout, "  Version:     %s\n", id)
+	fmt.Fprintf(stdout, "  ContentHash: %s\n", res.ContentHash)
+	if len(res.ResolvedInputs) > 0 {
+		fmt.Fprintln(stdout, "  Resolved inputs:")
+		for k, v := range res.ResolvedInputs {
+			fmt.Fprintf(stdout, "    %s = %v\n", k, v)
+		}
+	}
+	if len(res.Artifacts) > 0 {
+		fmt.Fprintln(stdout, "  Artifacts:")
+		for _, a := range res.Artifacts {
+			if a.Written {
+				fmt.Fprintf(stdout, "    %s -> %s\n", a.Name, a.Path)
+			} else {
+				fmt.Fprintf(stdout, "    %s (retained)\n", a.Name)
+			}
+		}
+	}
+	if len(res.AuditIDs) > 0 {
+		fmt.Fprintf(stdout, "  Audit records: %d\n", len(res.AuditIDs))
+	}
+	return 0
+}
+
+// resolveLaunchVersion resolves the version id to launch: the explicit
+// --version when given, otherwise the single frozen version (or the most
+// recent when several exist, since FrozenVersions returns sorted ids).
+func resolveLaunchVersion(s *store.Store, name, version string) (string, error) {
+	if version != "" {
+		return version, nil
+	}
+	ids, err := s.FrozenVersions(name)
+	if err != nil {
+		return "", fmt.Errorf("list frozen versions for %q: %w", name, err)
+	}
+	if len(ids) == 0 {
+		return "", fmt.Errorf("skill %q has no frozen versions; run `aileron skill freeze %s` first", name, name)
+	}
+	return ids[len(ids)-1], nil
+}
+
+// daemonDispatcher dispatches an action through the daemon's
+// POST /v1/actions/{name}/run endpoint. The action ref (aileron:<c>.<a>) maps
+// to the daemon action name; credentials are injected host-side at the
+// boundary, so the dispatcher never sees them. A 202 (approval pending) is
+// surfaced as an error directing the operator to approve, since v1 launch runs
+// unattended and does not poll the approval lifecycle.
+type daemonDispatcher struct{}
+
+func (daemonDispatcher) Dispatch(ctx context.Context, ref string, args map[string]any) (runtime.DispatchResult, error) {
+	base, err := bindingAPIBaseURL()
+	if err != nil {
+		return runtime.DispatchResult{}, err
+	}
+	name := daemonActionName(ref)
+	body, _ := json.Marshal(actionRunRequest{Args: args})
+	req, err := http.NewRequestWithContext(ctx, http.MethodPost, base+"/actions/"+url.PathEscape(name)+"/run", bytes.NewReader(body))
+	if err != nil {
+		return runtime.DispatchResult{}, err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	setDaemonAuthorization(req)
+	resp, err := actionsHTTPClient.Do(req)
+	if err != nil {
+		return runtime.DispatchResult{}, err
+	}
+	defer resp.Body.Close()
+	raw, _ := io.ReadAll(resp.Body)
+
+	switch resp.StatusCode {
+	case http.StatusOK, http.StatusCreated:
+		var out actionRunResponse
+		if err := json.Unmarshal(raw, &out); err != nil {
+			return runtime.DispatchResult{}, fmt.Errorf("decode action result: %w", err)
+		}
+		return runtime.DispatchResult{Output: parseResultPayload(out.Result)}, nil
+	case http.StatusAccepted:
+		return runtime.DispatchResult{}, fmt.Errorf("action %q requires approval; approve it (aileron approval list) and re-launch", ref)
+	default:
+		return runtime.DispatchResult{}, fmt.Errorf("daemon returned %d for %q: %s", resp.StatusCode, ref, strings.TrimSpace(string(raw)))
+	}
+}
+
+// daemonActionName maps a manifest action ref (aileron:<connector>.<action>)
+// to the daemon action name. v1 uses the bare action segment as the daemon
+// name; the connector binding is resolved daemon-side.
+func daemonActionName(ref string) string {
+	r := strings.TrimPrefix(ref, "aileron:")
+	if i := strings.LastIndex(r, "."); i >= 0 {
+		return r[i+1:]
+	}
+	return r
+}
+
+// parseResultPayload decodes the daemon's string result into a JSON map so the
+// runtime can bind downstream steps against it. A non-JSON or empty result
+// surfaces under a "result" key so a downstream binding still resolves.
+func parseResultPayload(result *string) map[string]any {
+	if result == nil || *result == "" {
+		return map[string]any{}
+	}
+	var m map[string]any
+	if err := json.Unmarshal([]byte(*result), &m); err == nil {
+		return m
+	}
+	return map[string]any{"result": *result}
+}
+
+// daemonApprover defers to the daemon's own approval gate at the action
+// boundary: the daemon's POST /run returns 202 when an action needs approval,
+// which the dispatcher surfaces. The runtime-level approver therefore approves
+// here so the routing is decided once, at the daemon boundary, rather than
+// gated twice. A future interactive launch can replace this seam with one that
+// drives the approval lifecycle in-process.
+type daemonApprover struct{}
+
+func (daemonApprover) Approve(_ context.Context, _ runtime.ApprovalRequest) (runtime.Decision, error) {
+	return runtime.Decision{Approved: true}, nil
+}
+
+// stdoutAuditSink is a minimal launch audit sink. The customer-owned audit
+// store is the daemon's configured sink; this CLI-side sink records a local
+// summary id so the launch surfaces an audit count. It is replaced by a
+// daemon-backed recorder when the daemon exposes a launch-audit endpoint.
+type stdoutAuditSink struct{}
+
+func (stdoutAuditSink) Record(_ context.Context, rec runtime.AuditRecord) string {
+	if rec.ActionRef != "" {
+		return "launch-audit-" + rec.ActionRef
+	}
+	return "launch-audit-summary"
+}

--- a/cmd/aileron/skill_launch_test.go
+++ b/cmd/aileron/skill_launch_test.go
@@ -1,0 +1,266 @@
+package main
+
+import (
+	"bytes"
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/runtime"
+)
+
+// fakeLaunchDispatcher returns canned per-ref results so the launch runs
+// end-to-end without a daemon. It records the refs it was asked to dispatch.
+type fakeLaunchDispatcher struct {
+	results map[string]map[string]any
+	refs    []string
+}
+
+func (f *fakeLaunchDispatcher) Dispatch(_ context.Context, ref string, _ map[string]any) (runtime.DispatchResult, error) {
+	f.refs = append(f.refs, ref)
+	return runtime.DispatchResult{Output: f.results[ref]}, nil
+}
+
+// stubLaunchSeams points the CLI launch seams at fakes. The transform that
+// materializes digest.csv is supplied via the runtime default registry, so the
+// fake dispatcher + a file-map-emitting transform drive the worked example.
+func stubLaunchSeams(t *testing.T, disp runtime.ActionDispatcher) {
+	t.Helper()
+	origD, origA, origS := newLaunchDispatcher, newLaunchApprover, newLaunchAuditSink
+	newLaunchDispatcher = func() runtime.ActionDispatcher { return disp }
+	newLaunchApprover = func() runtime.Approver { return daemonApprover{} }
+	newLaunchAuditSink = func() runtime.AuditSink { return stdoutAuditSink{} }
+	t.Cleanup(func() {
+		newLaunchDispatcher, newLaunchApprover, newLaunchAuditSink = origD, origA, origS
+	})
+}
+
+// freezeExampleForLaunch installs + freezes the worked example into the temp
+// store so a launch has a verifiable frozen version to load.
+func freezeExampleForLaunch(t *testing.T, storeDir string) {
+	t.Helper()
+	installExample(t, storeDir)
+	stubFreezeResolvers(t, fakeFreezeDigest)
+	key := writeSigningKey(t)
+	var out, errOut bytes.Buffer
+	if code := runSkillFreeze([]string{"--signing-key", key, "--version", "1.0.0", "weekly-metrics-digest"}, &out, &errOut); code != 0 {
+		t.Fatalf("freeze failed: %s", errOut.String())
+	}
+}
+
+func TestRunSkillLaunch_EndToEnd(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+
+	// The tracker write materializes filed_issue.json; the metrics read feeds
+	// render_csv. The render_csv transform is the default identity, which for
+	// this worked example forwards the series; to materialize a CSV file-map
+	// the worked example's transform must emit one. We rely on the runtime's
+	// action-call materialization for filed_issue.json and skip CSV bytes by
+	// having the metrics read return a file-map-shaped series the transform
+	// forwards. Simpler: assert the launch loads, verifies, dispatches both
+	// actions, and exits 0.
+	disp := &fakeLaunchDispatcher{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {
+			"path": "digest.csv", "mimeType": "text/csv", "encoding": "utf-8", "content": "name\ncpu\n",
+		},
+		"aileron:tracker.create_issue": {
+			"path": "filed_issue.json", "mimeType": "application/json", "encoding": "utf-8", "content": "{}",
+		},
+	}}
+	stubLaunchSeams(t, disp)
+	// Supply a seam so the llm-seam step runs.
+	origRun := launchSeamForTest
+	launchSeamForTest = fakeCLISeam{}
+	t.Cleanup(func() { launchSeamForTest = origRun })
+
+	outDir := t.TempDir()
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", outDir, "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	out := stdout.String()
+	if !strings.Contains(out, "Launched \"weekly-metrics-digest\"") {
+		t.Errorf("stdout = %q", out)
+	}
+	if !strings.Contains(out, "ContentHash: sha256:") {
+		t.Errorf("stdout missing content hash: %q", out)
+	}
+	// The worked example dispatches the metrics read twice (once for the
+	// active_metric_set source input in Phase A, once for the query_metrics
+	// step in Phase B) and the tracker write once.
+	var metrics, tracker int
+	for _, ref := range disp.refs {
+		switch ref {
+		case "aileron:metrics.query_series":
+			metrics++
+		case "aileron:tracker.create_issue":
+			tracker++
+		}
+	}
+	if metrics != 2 || tracker != 1 {
+		t.Errorf("dispatch counts: metrics=%d tracker=%d, want 2/1 (%v)", metrics, tracker, disp.refs)
+	}
+	// filed_issue.json materialized to the out dir.
+	if _, err := os.Stat(filepath.Join(outDir, "filed_issue.json")); err != nil {
+		t.Errorf("filed_issue.json not materialized: %v", err)
+	}
+}
+
+func TestRunSkillLaunch_MissingVersionRefuses(t *testing.T) {
+	withTempStore(t)
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"weekly-metrics-digest"}, &stdout, &stderr)
+	if code == 0 {
+		t.Fatal("launching a skill with no frozen versions must fail")
+	}
+	if !strings.Contains(stderr.String(), "no frozen versions") {
+		t.Errorf("stderr = %q", stderr.String())
+	}
+}
+
+func TestRunSkillLaunch_InputOverride(t *testing.T) {
+	storeDir := withTempStore(t)
+	freezeExampleForLaunch(t, storeDir)
+	disp := &fakeLaunchDispatcher{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"path": "digest.csv", "encoding": "utf-8", "content": "x", "mimeType": "text/csv"},
+		"aileron:tracker.create_issue": {"path": "filed_issue.json", "encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+	stubLaunchSeams(t, disp)
+	origRun := launchSeamForTest
+	launchSeamForTest = fakeCLISeam{}
+	t.Cleanup(func() { launchSeamForTest = origRun })
+
+	var stdout, stderr bytes.Buffer
+	code := runSkillLaunch([]string{"--out-dir", t.TempDir(), "--input", "window_days=30", "weekly-metrics-digest"}, &stdout, &stderr)
+	if code != 0 {
+		t.Fatalf("launch exit = %d, stderr=%s", code, stderr.String())
+	}
+	if !strings.Contains(stdout.String(), "window_days = 30") {
+		t.Errorf("override not reflected in resolved inputs: %q", stdout.String())
+	}
+}
+
+func TestRunSkillLaunch_UnknownSkillErrors(t *testing.T) {
+	withTempStore(t)
+	var stdout, stderr bytes.Buffer
+	if code := runSkillLaunch([]string{"ghost"}, &stdout, &stderr); code == 0 {
+		t.Fatal("an unknown skill must fail")
+	}
+}
+
+func TestRunSkillLaunch_BadInputFlag(t *testing.T) {
+	var stdout, stderr bytes.Buffer
+	if code := runSkillLaunch([]string{"--input", "noequals", "x"}, &stdout, &stderr); code == 0 {
+		t.Fatal("a malformed --input must fail")
+	}
+}
+
+// withDaemon points the CLI's daemon base URL + HTTP client at an httptest
+// server so the daemon-backed dispatcher path runs without a live daemon.
+func withDaemon(t *testing.T, h http.HandlerFunc) {
+	t.Helper()
+	srv := httptest.NewServer(h)
+	origBase := bindingAPIBaseURL
+	origClient := actionsHTTPClient
+	bindingAPIBaseURL = func() (string, error) { return srv.URL + "/v1", nil }
+	actionsHTTPClient = srv.Client()
+	t.Cleanup(func() {
+		srv.Close()
+		bindingAPIBaseURL = origBase
+		actionsHTTPClient = origClient
+	})
+}
+
+func TestDaemonDispatcher_OKResult(t *testing.T) {
+	withDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path != "/v1/actions/query_series/run" {
+			t.Errorf("unexpected path %q", r.URL.Path)
+		}
+		w.WriteHeader(http.StatusOK)
+		_, _ = w.Write([]byte(`{"audit_id":"a1","result":"{\"series\":[1]}"}`))
+	})
+	res, err := daemonDispatcher{}.Dispatch(context.Background(), "aileron:metrics.query_series", map[string]any{"x": 1})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if _, ok := res.Output["series"]; !ok {
+		t.Errorf("result not surfaced: %v", res.Output)
+	}
+}
+
+func TestDaemonDispatcher_PendingApprovalErrors(t *testing.T) {
+	withDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusAccepted)
+		_, _ = w.Write([]byte(`{"status":"pending","approval_id":"ap1"}`))
+	})
+	_, err := daemonDispatcher{}.Dispatch(context.Background(), "aileron:t.create_issue", nil)
+	if err == nil || !strings.Contains(err.Error(), "approval") {
+		t.Fatalf("a 202 pending must surface an approval error, got %v", err)
+	}
+}
+
+func TestDaemonDispatcher_ServerErrorSurfaces(t *testing.T) {
+	withDaemon(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusInternalServerError)
+		_, _ = w.Write([]byte(`boom`))
+	})
+	_, err := daemonDispatcher{}.Dispatch(context.Background(), "aileron:m.read", nil)
+	if err == nil {
+		t.Fatal("a 500 must surface an error")
+	}
+}
+
+func TestDaemonActionName(t *testing.T) {
+	cases := map[string]string{
+		"aileron:metrics.query_series": "query_series",
+		"aileron:tracker.create_issue": "create_issue",
+		"aileron:a.b.c":                "c",
+		"bare":                         "bare",
+	}
+	for ref, want := range cases {
+		if got := daemonActionName(ref); got != want {
+			t.Errorf("daemonActionName(%q) = %q, want %q", ref, got, want)
+		}
+	}
+}
+
+func TestParseResultPayload(t *testing.T) {
+	// A JSON object result decodes into a map the runtime can bind against.
+	s := `{"series":[1,2]}`
+	m := parseResultPayload(&s)
+	if _, ok := m["series"]; !ok {
+		t.Errorf("JSON result must decode into a map, got %v", m)
+	}
+	// A non-JSON result surfaces under "result" so a binding still resolves.
+	plain := "hello"
+	m = parseResultPayload(&plain)
+	if m["result"] != "hello" {
+		t.Errorf("non-JSON result must surface under result, got %v", m)
+	}
+	// Nil and empty results yield an empty map, never nil.
+	if got := parseResultPayload(nil); got == nil || len(got) != 0 {
+		t.Errorf("nil result = %v, want empty map", got)
+	}
+	empty := ""
+	if got := parseResultPayload(&empty); len(got) != 0 {
+		t.Errorf("empty result = %v, want empty map", got)
+	}
+}
+
+// fakeCLISeam is a deterministic seam used by CLI launch tests so the llm-seam
+// step produces its declared output.
+type fakeCLISeam struct{}
+
+func (fakeCLISeam) Run(_ context.Context, req runtime.SeamRequest) (map[string]any, error) {
+	out := map[string]any{}
+	for _, name := range req.Outputs {
+		out[name] = "summary"
+	}
+	return out, nil
+}

--- a/docs/src/content/docs/development/flight-plan-manifest-spec.md
+++ b/docs/src/content/docs/development/flight-plan-manifest-spec.md
@@ -248,7 +248,7 @@ Each operation's `audit.fields` declares which of the closed record fields it em
 
 Freeze turns a skill into a Flight Plan ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill) freeze boundary). Freeze resolves every image reference to a content-addressed digest, produces a lockfile that pins those digests and the resolved capability set, binds the execution environment, attaches the per-action trust contract, and signs the result. The `lock` section is the record of those pins.
 
-The `lock` section is absent before freeze. Freeze populates it and writes an immutable, signed version into the canonical skill store. See the [Freezing a Flight Plan](/guides/freezing-a-flight-plan) guide for the command and the reproducibility and signature-verification guarantees.
+The `lock` section is absent before freeze. Freeze populates it and writes an immutable, signed version into the canonical skill store. See the [Freezing a Flight Plan](/guides/freezing-a-flight-plan) guide for the command and the reproducibility and signature-verification guarantees. See the [Launching a Flight Plan](/guides/launching-a-flight-plan) guide for how the runtime ([#1511](https://github.com/ALRubinger/aileron/issues/1511)) verifies a frozen unit, resolves inputs once at the launch boundary, walks the step graph with no model in the loop, enforces the per-action trust contract, and materializes the declared outputs.
 
 | Field | Type | Required | Semantics |
 |---|---|---|---|

--- a/docs/src/content/docs/guides/launching-a-flight-plan.md
+++ b/docs/src/content/docs/guides/launching-a-flight-plan.md
@@ -1,0 +1,57 @@
+---
+title: "Launching a Flight Plan"
+description: "How aileron skill launch runs a frozen Flight Plan deterministically: a no-LLM step graph with trust-contract enforcement, single-boundary input resolution, and materialized outputs."
+---
+
+Launch is the runtime step that runs a frozen Flight Plan ([ADR-0027](/adr/0027-flight-plan-sealed-installable-skill)). Freeze seals a skill into a signed, digest-pinned version. Launch loads that version, verifies it, and runs its declared step graph deterministically. The runtime walks the steps as plain code. No language model sits in the execution loop by default. This guide explains the command and the guarantees it produces.
+
+The Flight Plan Launch runtime is a `skill` subcommand. It is distinct from the top-level `aileron launch` command, which starts an interactive agent sandbox. The two are different subsystems. This guide covers `aileron skill launch` only.
+
+## Running a launch
+
+Launch a frozen skill by name.
+
+```sh
+aileron skill launch weekly-metrics-digest --out-dir ./run
+```
+
+The runtime loads the most recent frozen version of that skill from the canonical store. Pass `--version` to launch a specific version id. Pass `--input name=value` once per literal input you want to override. File-target outputs are written under `--out-dir`.
+
+```sh
+aileron skill launch weekly-metrics-digest \
+  --version 5f2a9c1e4b7d8a30 \
+  --input window_days=30 \
+  --out-dir ./run
+```
+
+## The verification gate
+
+Launch refuses to run a frozen unit it cannot verify. Before any step runs, the runtime reconstructs the exact canonical bytes freeze signed, recomputes the content hash, and compares it to the recorded hash. It then verifies the detached signature against the stored public key. A flipped manifest byte fails the hash check. A flipped signature byte fails the signature check. A recorded hash that disagrees with the bytes fails the comparison. Any failure aborts the launch before a single step dispatches.
+
+## The no-LLM guarantee
+
+A Flight Plan is a pinned function over its declared inputs. It is deterministic given those resolved inputs. The runtime guarantees this structurally. Every step declares a `kind` from a closed set: `action-call`, `transform`, or `llm-seam`. The executor has exactly three branches, one per kind. The `action-call` and `transform` branches hold no reference to any language-model type. No deterministic step can reach a model by construction.
+
+The single marked seam is the `llm-seam` step. It is the only kind that may reach a model. In v1 the seam is unwired by default. An `llm-seam` step with no configured provider is a hard error. A default launch therefore reaches no model at all, so the no-LLM property holds by default and not only by construction.
+
+## Input resolution at the launch boundary
+
+Every declared input resolves once, at the launch boundary, into a concrete value. The resolution rule decides how. A `literal` input takes its launch override, then its declared default. A required literal with neither is an error. A `dynamic` input reads the launch clock once. `now` resolves to the launch timestamp and `today` resolves to the launch date. The runtime reads the clock a single time and reuses that value for every dynamic input, so two steps that read the same dynamic input always see one value. A `source` input is read live from a declared action through the sealed boundary. The runtime records the read by its resolved binding, the action ref and the selector, never the dataset inline.
+
+A `source` input that reads from the same action a step calls is not a step and not a graph edge. The acyclicity check covers `steps.*` edges only. The source read happens in the resolution phase, before the step graph walks.
+
+## Trust-contract enforcement
+
+Each `action-call` dispatches through the sealed action boundary. The runtime enforces the per-action trust contract on every call. The operation effect routes approval. A `read` runs unattended. A `write`, `delete`, `spend`, or `external-send` raises an approval gate and blocks on the decision. A denied action aborts its step and the launch records the denial. Idempotency governs retries. An action declared not safe to retry is never silently re-issued. An action that declares an idempotency key threads a stable key so the upstream deduplicates a retried write. Redaction runs on the dispatch result before it enters the graph or any audit summary. A `drop` rule removes a field, a `mask` rule replaces its value, and a `hash` rule replaces it with a stable hash. Credentials never appear in step arguments. A binding is a reference, never a value, and the closed binding grammar enforces this at decode time.
+
+## Output materialization
+
+A step that declares `materializesOutput` produces a typed file-map. The runtime materializes the entry into a file at the declared output path. v1 materializes `utf-8` text outputs only. A `base64` or binary output is refused with a clear error that points at the deferred mount and run-and-collect boundary ([#1510](https://github.com/ALRubinger/aileron/issues/1510)). The materialized file's mime type must match the declared output's mime type. Materialization is pure deterministic code. No model interprets the file-map.
+
+## The audit boundary
+
+Launch emits a customer-owned audit record per action and one per launch. Each record carries exactly the audit fields the action declares. Scalars are recorded by value. Data reads are recorded by their resolved binding, a result or snapshot summary, never the full dataset inline. The audit sink is the customer-owned store the runtime is wired to.
+
+## Determinism
+
+Given the same resolved inputs, a launch produces the same output. The topological walk order is deterministic. Ties break by declaration order. The transform vocabulary is pure and closed. The only non-deterministic seam is the marked `llm-seam`, which is unwired by default. This is the behavioral guarantee that makes a Flight Plan a function you can pin, sign, and re-run.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -73,6 +73,7 @@ export const navigation: NavItem[] = [
       { label: 'Installing an Action', href: '/guides/installing-an-action/' },
       { label: 'Installing a Skill', href: '/guides/installing-a-skill/' },
       { label: 'Freezing a Flight Plan', href: '/guides/freezing-a-flight-plan/' },
+      { label: 'Launching a Flight Plan', href: '/guides/launching-a-flight-plan/' },
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },
       { label: 'Setting up BlueBubbles for Aileron', href: '/guides/setting-up-bluebubbles/' },
       { label: 'Authoring an Action', href: '/guides/authoring-an-action/' },

--- a/internal/flightplan/freeze/launch.go
+++ b/internal/flightplan/freeze/launch.go
@@ -50,29 +50,49 @@ func VerifyFrozen(skillMD, lockfile, signature, pubPEM []byte) (VerifiedFrozen, 
 		return VerifiedFrozen{}, fmt.Errorf("freeze: frozen manifest has no lock.contentHash; not a frozen unit")
 	}
 
-	// Parse the standalone lockfile and clear its self-referential hash. The
-	// resulting Lockfile drives BOTH no-hash regions so the reconstruction
-	// reuses the exact freeze-time write primitives (injectLock /
-	// MarshalLockfile) rather than a parallel byte editor that could drift.
-	var lf Lockfile
-	if err := yaml.Unmarshal(lockfile, &lf); err != nil {
+	// Parse the standalone lockfile's lock record.
+	var lockfileRecord Lockfile
+	if err := yaml.Unmarshal(lockfile, &lockfileRecord); err != nil {
 		return VerifiedFrozen{}, fmt.Errorf("freeze: parse frozen lockfile: %w", err)
 	}
-	lockNoHashRecord := lf.withoutContentHash()
+
+	// Parse the manifest's OWN embedded lock block. The reconstruction below
+	// rebuilds each no-hash region from the artifact it belongs to (manifest
+	// region from the manifest's lock, lockfile region from the standalone
+	// lockfile). This is what makes a tampered manifest lock block (for
+	// example a swapped resolvedImages digest) change the recomputed hash and
+	// fail verification: the rebuild faithfully reflects the on-disk manifest
+	// rather than healing it from the lockfile.
+	manifestLock, hasLock, err := lockFromManifest(skillMD)
+	if err != nil {
+		return VerifiedFrozen{}, err
+	}
+	if !hasLock {
+		return VerifiedFrozen{}, fmt.Errorf("freeze: frozen manifest has no lock block; not a frozen unit")
+	}
+
+	// The manifest's embedded lock and the standalone lockfile record the same
+	// frozen unit and must agree on the content hash. A disagreement is a
+	// refusal (the two artifacts are inconsistent).
+	if lockfileRecord.ContentHash != "" && lockfileRecord.ContentHash != recorded {
+		return VerifiedFrozen{}, fmt.Errorf(
+			"freeze: lock hash mismatch: manifest records %s but the lockfile records %s; the frozen unit is inconsistent",
+			recorded, lockfileRecord.ContentHash)
+	}
 
 	// Reconstruct the exact byte sequence Sign signed (see content.go): the
-	// frozen manifest re-emitted with a no-hash lock block, and the
+	// frozen manifest re-emitted with its own no-hash lock block, and the
 	// standalone lockfile re-marshaled without its hash. Reusing injectLock /
 	// MarshalLockfile guarantees byte-for-byte parity with freeze.
 	instructionOnly, err := manifestIsInstructionOnly(skillMD)
 	if err != nil {
 		return VerifiedFrozen{}, err
 	}
-	manifestNoHash, err := injectLockMaybe(skillMD, lockNoHashRecord, instructionOnly)
+	manifestNoHash, err := injectLockMaybe(skillMD, manifestLock.withoutContentHash(), instructionOnly)
 	if err != nil {
 		return VerifiedFrozen{}, fmt.Errorf("freeze: reconstruct frozen manifest: %w", err)
 	}
-	lockNoHash, err := MarshalLockfile(lockNoHashRecord)
+	lockNoHash, err := MarshalLockfile(lockfileRecord.withoutContentHash())
 	if err != nil {
 		return VerifiedFrozen{}, err
 	}
@@ -93,7 +113,40 @@ func VerifyFrozen(skillMD, lockfile, signature, pubPEM []byte) (VerifiedFrozen, 
 		return VerifiedFrozen{}, err
 	}
 
-	return VerifiedFrozen{SkillMD: skillMD, ContentHash: recorded}, nil
+	// Return a defensive copy of the verified manifest bytes so a later mutation
+	// of the caller's slice can never change what was verified.
+	verified := append([]byte(nil), skillMD...)
+	return VerifiedFrozen{SkillMD: verified, ContentHash: recorded}, nil
+}
+
+// lockFromManifest parses the `aileron.lock` block of a frozen SKILL.md into a
+// typed Lockfile. The second return is false when the manifest carries no lock
+// block (an unfrozen or instruction-only manifest).
+func lockFromManifest(skillMD []byte) (Lockfile, bool, error) {
+	front, _, _, ok := splitFrontmatter(skillMD)
+	if !ok {
+		return Lockfile{}, false, fmt.Errorf("freeze: frozen manifest has no YAML frontmatter")
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(front, &doc); err != nil {
+		return Lockfile{}, false, fmt.Errorf("freeze: parse frozen frontmatter: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return Lockfile{}, false, fmt.Errorf("freeze: frozen frontmatter is not a mapping")
+	}
+	aileron := mappingValue(doc.Content[0], "aileron")
+	if aileron == nil {
+		return Lockfile{}, false, nil
+	}
+	lockNode := mappingValue(aileron, "lock")
+	if lockNode == nil {
+		return Lockfile{}, false, nil
+	}
+	var lf Lockfile
+	if err := lockNode.Decode(&lf); err != nil {
+		return Lockfile{}, false, fmt.Errorf("freeze: decode manifest lock block: %w", err)
+	}
+	return lf, true, nil
 }
 
 // contentHashFromManifest reads the `aileron.lock.contentHash` scalar from a

--- a/internal/flightplan/freeze/launch.go
+++ b/internal/flightplan/freeze/launch.go
@@ -1,0 +1,144 @@
+package freeze
+
+import (
+	"fmt"
+
+	"gopkg.in/yaml.v3"
+)
+
+// VerifiedFrozen is the result of a successful frozen-unit verification. It
+// carries the bytes Launch (#1511) re-parses into a typed plan, already
+// proven untampered against the author signature and the recorded content
+// hash.
+type VerifiedFrozen struct {
+	// SkillMD is the frozen SKILL.md bytes exactly as stored (lock block
+	// present, contentHash included). The runtime re-parses these.
+	SkillMD []byte
+	// ContentHash is the verified `sha256:<hex>` content hash. It equals
+	// both the recomputed canonical hash and the value recorded in the
+	// frozen lock block.
+	ContentHash string
+}
+
+// VerifyFrozen is the Launch-time verification gate (ADR-0027, #1509/#1511).
+// A frozen unit refuses to run unless both the author signature verifies and
+// the recorded content hash matches the bytes on disk.
+//
+// It reconstructs the exact canonical byte sequence Sign signed (see
+// content.go): the frozen manifest and the standalone lockfile, each with the
+// self-referential `contentHash` field stripped, joined by the 0x00
+// separator. It then:
+//
+//  1. recomputes the canonical content hash and confirms it matches the
+//     `lock.contentHash` recorded in the frozen manifest (and the lockfile),
+//     so a tampered manifest or lockfile is rejected before any execution;
+//     and
+//  2. verifies the detached ed25519 signature over those same canonical
+//     bytes against the stored public key.
+//
+// Either failure returns a non-nil error and the frozen unit must not run.
+// The function is self-contained: it needs only the four stored artifacts,
+// never the private key or store access.
+func VerifyFrozen(skillMD, lockfile, signature, pubPEM []byte) (VerifiedFrozen, error) {
+	// The recorded hash lives in the lock block of the frozen manifest. Read
+	// it so we can compare the recomputed value against the author's claim.
+	recorded, err := contentHashFromManifest(skillMD)
+	if err != nil {
+		return VerifiedFrozen{}, err
+	}
+	if recorded == "" {
+		return VerifiedFrozen{}, fmt.Errorf("freeze: frozen manifest has no lock.contentHash; not a frozen unit")
+	}
+
+	// Parse the standalone lockfile and clear its self-referential hash. The
+	// resulting Lockfile drives BOTH no-hash regions so the reconstruction
+	// reuses the exact freeze-time write primitives (injectLock /
+	// MarshalLockfile) rather than a parallel byte editor that could drift.
+	var lf Lockfile
+	if err := yaml.Unmarshal(lockfile, &lf); err != nil {
+		return VerifiedFrozen{}, fmt.Errorf("freeze: parse frozen lockfile: %w", err)
+	}
+	lockNoHashRecord := lf.withoutContentHash()
+
+	// Reconstruct the exact byte sequence Sign signed (see content.go): the
+	// frozen manifest re-emitted with a no-hash lock block, and the
+	// standalone lockfile re-marshaled without its hash. Reusing injectLock /
+	// MarshalLockfile guarantees byte-for-byte parity with freeze.
+	instructionOnly, err := manifestIsInstructionOnly(skillMD)
+	if err != nil {
+		return VerifiedFrozen{}, err
+	}
+	manifestNoHash, err := injectLockMaybe(skillMD, lockNoHashRecord, instructionOnly)
+	if err != nil {
+		return VerifiedFrozen{}, fmt.Errorf("freeze: reconstruct frozen manifest: %w", err)
+	}
+	lockNoHash, err := MarshalLockfile(lockNoHashRecord)
+	if err != nil {
+		return VerifiedFrozen{}, err
+	}
+	canonical := canonicalContent(manifestNoHash, lockNoHash)
+
+	// The recomputed hash must match the recorded one (tamper detection on
+	// the manifest or lockfile content).
+	recomputed := contentHash(manifestNoHash, lockNoHash)
+	if recomputed != recorded {
+		return VerifiedFrozen{}, fmt.Errorf(
+			"freeze: content hash mismatch: recorded %s but recomputed %s; the frozen unit was modified after signing",
+			recorded, recomputed)
+	}
+
+	// The signature must verify over the canonical bytes (author attestation
+	// and tamper detection on the signature itself).
+	if err := Verify(canonical, signature, pubPEM); err != nil {
+		return VerifiedFrozen{}, err
+	}
+
+	return VerifiedFrozen{SkillMD: skillMD, ContentHash: recorded}, nil
+}
+
+// contentHashFromManifest reads the `aileron.lock.contentHash` scalar from a
+// frozen SKILL.md, returning "" when the manifest carries no lock block.
+func contentHashFromManifest(skillMD []byte) (string, error) {
+	front, _, _, ok := splitFrontmatter(skillMD)
+	if !ok {
+		return "", fmt.Errorf("freeze: frozen manifest has no YAML frontmatter")
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(front, &doc); err != nil {
+		return "", fmt.Errorf("freeze: parse frozen frontmatter: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return "", fmt.Errorf("freeze: frozen frontmatter is not a mapping")
+	}
+	root := doc.Content[0]
+	aileron := mappingValue(root, "aileron")
+	if aileron == nil {
+		return "", nil
+	}
+	lock := mappingValue(aileron, "lock")
+	if lock == nil {
+		return "", nil
+	}
+	if h := mappingValue(lock, "contentHash"); h != nil {
+		return h.Value, nil
+	}
+	return "", nil
+}
+
+// manifestIsInstructionOnly reports whether a frozen SKILL.md carries no
+// `aileron` block, mirroring manifest.Parse's InstructionOnly determination
+// without importing the manifest package (freeze must not depend on it).
+func manifestIsInstructionOnly(skillMD []byte) (bool, error) {
+	front, _, _, ok := splitFrontmatter(skillMD)
+	if !ok {
+		return false, fmt.Errorf("freeze: frozen manifest has no YAML frontmatter")
+	}
+	var doc yaml.Node
+	if err := yaml.Unmarshal(front, &doc); err != nil {
+		return false, fmt.Errorf("freeze: parse frozen frontmatter: %w", err)
+	}
+	if doc.Kind != yaml.DocumentNode || len(doc.Content) == 0 {
+		return false, fmt.Errorf("freeze: frozen frontmatter is not a mapping")
+	}
+	return mappingValue(doc.Content[0], "aileron") == nil, nil
+}

--- a/internal/flightplan/freeze/launch_test.go
+++ b/internal/flightplan/freeze/launch_test.go
@@ -82,3 +82,37 @@ func TestVerifyFrozen_RejectsMissingLockBlock(t *testing.T) {
 		t.Fatal("VerifyFrozen accepted an unfrozen manifest")
 	}
 }
+
+func TestVerifyFrozen_RejectsTamperedManifestLockBlock(t *testing.T) {
+	res := freezeExample(t)
+	// The worked example is rung-2: its lock pins a resolved image digest.
+	// Swap that digest inside the frozen manifest's lock block while leaving
+	// the standalone lockfile and the recorded contentHash untouched. The
+	// reconstruction rebuilds the manifest region from the manifest's OWN lock,
+	// so the recomputed hash diverges and verification must refuse. A rebuild
+	// that healed the manifest from the lockfile would wrongly accept this.
+	orig := fakeDigest
+	swapped := "sha256:" + strings.Repeat("b", 64)
+	tampered := bytes.Replace(res.FrozenManifest, []byte(orig), []byte(swapped), 1)
+	if bytes.Equal(tampered, res.FrozenManifest) {
+		t.Skip("worked example lock digest not found to tamper")
+	}
+	if _, err := VerifyFrozen(tampered, res.Lockfile, res.Signature, res.PublicKey); err == nil {
+		t.Fatal("a tampered manifest lock block must refuse to verify")
+	}
+}
+
+func TestVerifyFrozen_DefensiveCopyOfSkillMD(t *testing.T) {
+	res := freezeExample(t)
+	v, err := VerifyFrozen(res.FrozenManifest, res.Lockfile, res.Signature, res.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen: %v", err)
+	}
+	// Mutating the caller's slice must not change the verified bytes.
+	if len(res.FrozenManifest) > 0 {
+		res.FrozenManifest[0] ^= 0xFF
+	}
+	if bytes.Equal(v.SkillMD, res.FrozenManifest) {
+		t.Error("VerifiedFrozen.SkillMD must be a defensive copy, not alias the caller's slice")
+	}
+}

--- a/internal/flightplan/freeze/launch_test.go
+++ b/internal/flightplan/freeze/launch_test.go
@@ -116,3 +116,24 @@ func TestVerifyFrozen_DefensiveCopyOfSkillMD(t *testing.T) {
 		t.Error("VerifiedFrozen.SkillMD must be a defensive copy, not alias the caller's slice")
 	}
 }
+
+func TestVerifyFrozen_RejectsInconsistentLockfileHash(t *testing.T) {
+	res := freezeExample(t)
+	// Alter the standalone lockfile's recorded contentHash so it disagrees with
+	// the manifest's recorded hash. The two artifacts are inconsistent and
+	// verification must refuse.
+	bad := "sha256:" + strings.Repeat("c", 64)
+	tampered := bytes.Replace(res.Lockfile, []byte(res.ContentHash), []byte(bad), 1)
+	if bytes.Equal(tampered, res.Lockfile) {
+		t.Fatal("test setup: contentHash not found in the lockfile")
+	}
+	if _, err := VerifyFrozen(res.FrozenManifest, tampered, res.Signature, res.PublicKey); err == nil {
+		t.Fatal("a lockfile whose recorded hash disagrees with the manifest must refuse")
+	}
+}
+
+func TestVerifyFrozen_RejectsNoFrontmatter(t *testing.T) {
+	if _, err := VerifyFrozen([]byte("no frontmatter here\n"), []byte("{}\n"), []byte("s"), []byte("p")); err == nil {
+		t.Fatal("a manifest with no frontmatter must refuse")
+	}
+}

--- a/internal/flightplan/freeze/launch_test.go
+++ b/internal/flightplan/freeze/launch_test.go
@@ -1,0 +1,84 @@
+package freeze
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+)
+
+// freezeExample freezes the committed worked example with a fresh signing key
+// and returns the freeze Result. It is the shared fixture for the
+// Launch-side verification tests: the bytes it produces are exactly what the
+// store persists and what VerifyFrozen must accept.
+func freezeExample(t *testing.T) Result {
+	t.Helper()
+	_, keyPath := genSigningKey(t)
+	res, err := Run(context.Background(), exampleSkillMD(t), Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+		Composer:       fakeComposer(fakeDigest),
+	})
+	if err != nil {
+		t.Fatalf("freeze.Run: %v", err)
+	}
+	return res
+}
+
+func TestVerifyFrozen_AcceptsUntamperedUnit(t *testing.T) {
+	res := freezeExample(t)
+	v, err := VerifyFrozen(res.FrozenManifest, res.Lockfile, res.Signature, res.PublicKey)
+	if err != nil {
+		t.Fatalf("VerifyFrozen rejected an untampered unit: %v", err)
+	}
+	if v.ContentHash != res.ContentHash {
+		t.Errorf("verified contentHash = %q, want %q", v.ContentHash, res.ContentHash)
+	}
+	if !bytes.Equal(v.SkillMD, res.FrozenManifest) {
+		t.Error("verified SkillMD must equal the stored frozen manifest bytes")
+	}
+}
+
+func TestVerifyFrozen_RejectsTamperedManifest(t *testing.T) {
+	res := freezeExample(t)
+	// Flip a byte in the Markdown body (after the frontmatter) so the
+	// manifest no longer matches the signed canonical bytes.
+	tampered := bytes.Replace(res.FrozenManifest,
+		[]byte("Weekly Metrics Digest"), []byte("Weekly Metrics Digesz"), 1)
+	if bytes.Equal(tampered, res.FrozenManifest) {
+		t.Fatal("test setup: expected to alter the manifest body")
+	}
+	if _, err := VerifyFrozen(tampered, res.Lockfile, res.Signature, res.PublicKey); err == nil {
+		t.Fatal("VerifyFrozen accepted a tampered manifest")
+	}
+}
+
+func TestVerifyFrozen_RejectsTamperedSignature(t *testing.T) {
+	res := freezeExample(t)
+	sig := append([]byte(nil), res.Signature...)
+	sig[0] ^= 0xFF
+	if _, err := VerifyFrozen(res.FrozenManifest, res.Lockfile, sig, res.PublicKey); err == nil {
+		t.Fatal("VerifyFrozen accepted a tampered signature")
+	}
+}
+
+func TestVerifyFrozen_RejectsContentHashMismatch(t *testing.T) {
+	res := freezeExample(t)
+	// Rewrite the recorded contentHash in the frozen manifest to a different
+	// (but well-formed) digest. The recomputed hash will no longer match.
+	bad := "sha256:" + strings.Repeat("0", 64)
+	tampered := bytes.Replace(res.FrozenManifest, []byte(res.ContentHash), []byte(bad), 1)
+	if bytes.Equal(tampered, res.FrozenManifest) {
+		t.Fatal("test setup: contentHash not found in frozen manifest")
+	}
+	if _, err := VerifyFrozen(tampered, res.Lockfile, res.Signature, res.PublicKey); err == nil {
+		t.Fatal("VerifyFrozen accepted a manifest whose recorded hash was altered")
+	}
+}
+
+func TestVerifyFrozen_RejectsMissingLockBlock(t *testing.T) {
+	// An unfrozen manifest (no lock block) is not a frozen unit.
+	if _, err := VerifyFrozen(exampleSkillMD(t), []byte("{}\n"), []byte("sig"), []byte("pub")); err == nil {
+		t.Fatal("VerifyFrozen accepted an unfrozen manifest")
+	}
+}

--- a/internal/flightplan/freeze/launch_test.go
+++ b/internal/flightplan/freeze/launch_test.go
@@ -95,7 +95,7 @@ func TestVerifyFrozen_RejectsTamperedManifestLockBlock(t *testing.T) {
 	swapped := "sha256:" + strings.Repeat("b", 64)
 	tampered := bytes.Replace(res.FrozenManifest, []byte(orig), []byte(swapped), 1)
 	if bytes.Equal(tampered, res.FrozenManifest) {
-		t.Skip("worked example lock digest not found to tamper")
+		t.Fatal("test setup: worked example lock digest not found in the frozen manifest to tamper")
 	}
 	if _, err := VerifyFrozen(tampered, res.Lockfile, res.Signature, res.PublicKey); err == nil {
 		t.Fatal("a tampered manifest lock block must refuse to verify")

--- a/internal/flightplan/runtime/approval.go
+++ b/internal/flightplan/runtime/approval.go
@@ -1,0 +1,22 @@
+package runtime
+
+// requiresApproval reports whether an effect routes through the out-of-band
+// approval channel (ADR-0009). A read observes state and runs unattended;
+// write, delete, spend, and external-send all mutate state, money, or reach a
+// third party, so they raise an approval gate and block on the decision.
+//
+// This is the single effect→route decision point. Keeping it one function
+// means the routing rule is stated once and the executor reads it, never
+// re-deriving it per call site.
+func requiresApproval(effect Effect) bool {
+	switch effect {
+	case EffectRead:
+		return false
+	case EffectWrite, EffectDelete, EffectSpend, EffectExternalSend:
+		return true
+	default:
+		// An unknown effect should never reach here (decode validates the
+		// closed enum). Fail safe: require approval rather than run unattended.
+		return true
+	}
+}

--- a/internal/flightplan/runtime/approval_test.go
+++ b/internal/flightplan/runtime/approval_test.go
@@ -1,0 +1,24 @@
+package runtime
+
+import "testing"
+
+func TestRequiresApproval_EffectRouting(t *testing.T) {
+	cases := map[Effect]bool{
+		EffectRead:         false,
+		EffectWrite:        true,
+		EffectDelete:       true,
+		EffectSpend:        true,
+		EffectExternalSend: true,
+	}
+	for eff, want := range cases {
+		if got := requiresApproval(eff); got != want {
+			t.Errorf("requiresApproval(%q) = %v, want %v", eff, got, want)
+		}
+	}
+}
+
+func TestRequiresApproval_UnknownFailsSafe(t *testing.T) {
+	if !requiresApproval(Effect("mystery")) {
+		t.Error("an unknown effect must fail safe (require approval), never run unattended")
+	}
+}

--- a/internal/flightplan/runtime/audit.go
+++ b/internal/flightplan/runtime/audit.go
@@ -1,0 +1,109 @@
+package runtime
+
+import "context"
+
+// auditFieldValue computes the value for one declared audit field from an
+// action dispatch. The closed field set mirrors the schema's auditStructure
+// enum. Data reads are referenced by resolved binding (a result/snapshot
+// summary), never the dataset inline (ADR-0027 audit boundary, #1523). A
+// field the runtime cannot populate from the available context is omitted
+// rather than guessed.
+func auditFieldValue(field string, d actionDispatch) (any, bool) {
+	switch field {
+	case "operation-effect":
+		return string(d.Effect), true
+	case "approval-decision":
+		if !d.ApprovalRequested {
+			return "unattended", true
+		}
+		if d.Approved {
+			return "approved", true
+		}
+		return "denied", true
+	case "result":
+		// A result/snapshot summary, never the full dataset: record the set of
+		// top-level result keys so the audit references the shape, not the data.
+		return resultSummary(d.Result), true
+	case "network-target":
+		return d.ActionRef, true
+	default:
+		// connector-hash, action-manifest-version, credential-binding,
+		// identity-label, approved-input, request-summary, response-summary
+		// are populated by the daemon-backed sink at the action boundary in
+		// production; the runtime core does not synthesize them. Omitted here
+		// so the record carries only fields it can populate truthfully.
+		return nil, false
+	}
+}
+
+// resultSummary returns an audit-safe summary of a dispatch result: the sorted
+// top-level keys, never the values. This is the "result or snapshot identifier
+// with a summary" the audit boundary permits.
+func resultSummary(result map[string]any) map[string]any {
+	keys := make([]string, 0, len(result))
+	for k := range result {
+		keys = append(keys, k)
+	}
+	sortStrings(keys)
+	return map[string]any{"fields": keys, "fieldCount": len(keys)}
+}
+
+// buildActionRecord builds the AuditRecord for one action dispatch from its
+// declared audit fields. Only declared fields are emitted (ADR-0027).
+func buildActionRecord(d actionDispatch) AuditRecord {
+	fields := map[string]any{}
+	for _, f := range d.AuditFields {
+		if v, ok := auditFieldValue(f, d); ok {
+			fields[f] = v
+		}
+	}
+	return AuditRecord{ActionRef: d.ActionRef, Fields: fields, Sink: d.Sink}
+}
+
+// emitAudit records every per-action audit record plus one per-launch summary
+// record through the sink, returning the minted record ids in order. The sink
+// is the customer-owned audit store (wired by the CLI). A nil sink emits
+// nothing and returns no ids.
+func emitAudit(ctx context.Context, sink AuditSink, st execState) []string {
+	if sink == nil {
+		return nil
+	}
+	var ids []string
+	for _, d := range st.dispatches {
+		ids = append(ids, sink.Record(ctx, buildActionRecord(d)))
+	}
+	// Per-launch summary: resolved inputs → materialized artifacts, by
+	// reference. Data inputs are recorded by their source binding, never the
+	// dataset inline.
+	ids = append(ids, sink.Record(ctx, buildLaunchRecord(st)))
+	return ids
+}
+
+// buildLaunchRecord builds the per-launch resolved-inputs→outputs record. It
+// references source-input reads by their resolved binding and lists the
+// materialized artifact names, never inline data.
+func buildLaunchRecord(st execState) AuditRecord {
+	artifacts := make([]string, 0, len(st.artifacts))
+	for _, a := range st.artifacts {
+		artifacts = append(artifacts, a.Name)
+	}
+	sources := map[string]any{}
+	for name, sb := range st.inputs.SourceBindings {
+		sources[name] = map[string]any{"actionRef": sb.ActionRef, "select": sb.Select}
+	}
+	return AuditRecord{
+		Fields: map[string]any{
+			"sourceInputBindings": sources,
+			"materializedOutputs": artifacts,
+		},
+	}
+}
+
+// sortStrings sorts in place without importing sort at every call site.
+func sortStrings(s []string) {
+	for i := 1; i < len(s); i++ {
+		for j := i; j > 0 && s[j-1] > s[j]; j-- {
+			s[j-1], s[j] = s[j], s[j-1]
+		}
+	}
+}

--- a/internal/flightplan/runtime/audit_test.go
+++ b/internal/flightplan/runtime/audit_test.go
@@ -1,0 +1,99 @@
+package runtime
+
+import "testing"
+
+func TestBuildActionRecord_OnlyDeclaredFields(t *testing.T) {
+	d := actionDispatch{
+		ActionRef:         "aileron:m.read",
+		Effect:            EffectRead,
+		ApprovalRequested: false,
+		Approved:          true,
+		Result:            map[string]any{"series": []any{1}, "meta": "x"},
+		AuditFields:       []string{"operation-effect", "result"},
+		Sink:              "audit/reads",
+	}
+	rec := buildActionRecord(d)
+	if rec.Sink != "audit/reads" {
+		t.Errorf("sink = %q", rec.Sink)
+	}
+	// Exactly the declared fields, no more.
+	if len(rec.Fields) != 2 {
+		t.Fatalf("want 2 declared fields, got %d: %v", len(rec.Fields), rec.Fields)
+	}
+	if rec.Fields["operation-effect"] != "read" {
+		t.Errorf("operation-effect = %v", rec.Fields["operation-effect"])
+	}
+	// A field the runtime cannot populate (credential-binding) is omitted, not guessed.
+	if _, present := rec.Fields["credential-binding"]; present {
+		t.Error("an undeclared field must not appear")
+	}
+}
+
+func TestAuditResult_ReferencesShapeNotData(t *testing.T) {
+	d := actionDispatch{
+		Effect:      EffectRead,
+		Result:      map[string]any{"series": []any{map[string]any{"secret": "value"}}},
+		AuditFields: []string{"result"},
+	}
+	rec := buildActionRecord(d)
+	summary, ok := rec.Fields["result"].(map[string]any)
+	if !ok {
+		t.Fatalf("result field = %T", rec.Fields["result"])
+	}
+	// The summary records the field shape (keys), never the dataset values.
+	fields, ok := summary["fields"].([]string)
+	if !ok || len(fields) != 1 || fields[0] != "series" {
+		t.Errorf("result summary must reference top-level keys, got %v", summary)
+	}
+	// The secret value must NOT appear anywhere in the summary.
+	if containsValue(summary, "value") {
+		t.Error("the audit result summary must not carry the dataset inline")
+	}
+}
+
+func TestApprovalDecisionAudit(t *testing.T) {
+	cases := []struct {
+		name      string
+		requested bool
+		approved  bool
+		want      string
+	}{
+		{"unattended read", false, true, "unattended"},
+		{"approved write", true, true, "approved"},
+		{"denied write", true, false, "denied"},
+	}
+	for _, c := range cases {
+		d := actionDispatch{ApprovalRequested: c.requested, Approved: c.approved, AuditFields: []string{"approval-decision"}}
+		rec := buildActionRecord(d)
+		if rec.Fields["approval-decision"] != c.want {
+			t.Errorf("%s: approval-decision = %v, want %q", c.name, rec.Fields["approval-decision"], c.want)
+		}
+	}
+}
+
+// containsValue deep-searches a JSON-shaped value for a string leaf.
+func containsValue(v any, want string) bool {
+	switch t := v.(type) {
+	case string:
+		return t == want
+	case map[string]any:
+		for _, child := range t {
+			if containsValue(child, want) {
+				return true
+			}
+		}
+	case []any:
+		for _, child := range t {
+			if containsValue(child, want) {
+				return true
+			}
+		}
+	case []string:
+		for _, child := range t {
+			if child == want {
+				return true
+			}
+		}
+	}
+	return false
+}

--- a/internal/flightplan/runtime/binding.go
+++ b/internal/flightplan/runtime/binding.go
@@ -1,0 +1,54 @@
+package runtime
+
+import (
+	"fmt"
+	"regexp"
+)
+
+// BindingKind discriminates the two reference forms in the closed binding
+// grammar: a resolved input or a prior step output.
+type BindingKind int
+
+const (
+	// BindInput references a declared input resolved at the launch boundary:
+	// inputs.<name>.
+	BindInput BindingKind = iota
+	// BindStep references a named output of a prior step: steps.<id>.<out>.
+	BindStep
+)
+
+// Binding is a parsed data-flow binding. A binding is a REFERENCE, never a
+// value (schema $defs.binding). The closed grammar is the structural
+// guarantee that step args are wiring, not embedded secrets.
+type Binding struct {
+	Kind BindingKind
+	// Raw is the original binding string, retained for error messages and
+	// audit summaries.
+	Raw string
+	// Name is the input name for BindInput.
+	Name string
+	// StepID and Output identify a prior step output for BindStep.
+	StepID string
+	Output string
+}
+
+// bindingPattern is the closed binding grammar from the schema
+// ($defs.binding): inputs.<name> or steps.<id>.<output>. Names use the
+// schema's [a-zA-Z0-9_-]+ character class. Anchored so a binding may carry
+// nothing outside the grammar.
+var bindingPattern = regexp.MustCompile(
+	`^(?:inputs\.([a-zA-Z0-9_-]+)|steps\.([a-zA-Z0-9_-]+)\.([a-zA-Z0-9_-]+))$`)
+
+// ParseBinding parses a binding string against the closed grammar. A string
+// outside the grammar is a hard decode error: it could smuggle a literal
+// value where only a reference is permitted.
+func ParseBinding(raw string) (Binding, error) {
+	m := bindingPattern.FindStringSubmatch(raw)
+	if m == nil {
+		return Binding{}, fmt.Errorf("binding %q is not a valid reference (want inputs.<name> or steps.<id>.<output>)", raw)
+	}
+	if m[1] != "" {
+		return Binding{Kind: BindInput, Raw: raw, Name: m[1]}, nil
+	}
+	return Binding{Kind: BindStep, Raw: raw, StepID: m[2], Output: m[3]}, nil
+}

--- a/internal/flightplan/runtime/binding_test.go
+++ b/internal/flightplan/runtime/binding_test.go
@@ -1,0 +1,44 @@
+package runtime
+
+import "testing"
+
+func TestParseBinding_Input(t *testing.T) {
+	b, err := ParseBinding("inputs.window_days")
+	if err != nil {
+		t.Fatalf("ParseBinding: %v", err)
+	}
+	if b.Kind != BindInput || b.Name != "window_days" {
+		t.Errorf("got %+v", b)
+	}
+}
+
+func TestParseBinding_Step(t *testing.T) {
+	b, err := ParseBinding("steps.query_metrics.series")
+	if err != nil {
+		t.Fatalf("ParseBinding: %v", err)
+	}
+	if b.Kind != BindStep || b.StepID != "query_metrics" || b.Output != "series" {
+		t.Errorf("got %+v", b)
+	}
+}
+
+func TestParseBinding_Rejects(t *testing.T) {
+	cases := []string{
+		"",
+		"window_days",     // no namespace
+		"inputs.",         // empty name
+		"inputs.a.b",      // input has no sub-output
+		"steps.only",      // step without output
+		"steps.a.b.c",     // too many segments
+		"literal-value",   // a literal masquerading as a binding
+		"inputs.bad name", // space outside the char class
+		"outputs.x",       // not a binding namespace
+		"steps..x",        // empty step id
+		"${secret}",       // an interpolation attempt
+	}
+	for _, c := range cases {
+		if _, err := ParseBinding(c); err == nil {
+			t.Errorf("ParseBinding(%q) accepted an invalid binding", c)
+		}
+	}
+}

--- a/internal/flightplan/runtime/clock.go
+++ b/internal/flightplan/runtime/clock.go
@@ -1,0 +1,25 @@
+package runtime
+
+import "time"
+
+// Clock supplies the single launch-time read for dynamic inputs (now/today).
+// It is injected so the resolution phase is deterministic in tests: the
+// runtime reads the clock ONCE at the launch boundary and reuses that value
+// for every dynamic input, so two steps reading the same dynamic input see
+// one value (#1523 boundary-straddle guarantee).
+type Clock interface {
+	Now() time.Time
+}
+
+// SystemClock reads the wall clock in UTC. Production launches use it.
+type SystemClock struct{}
+
+// Now returns the current UTC time.
+func (SystemClock) Now() time.Time { return time.Now().UTC() }
+
+// FixedClock returns a fixed time. It is the deterministic test clock and the
+// pin point for the determinism property test.
+type FixedClock struct{ T time.Time }
+
+// Now returns the fixed time.
+func (c FixedClock) Now() time.Time { return c.T }

--- a/internal/flightplan/runtime/decode.go
+++ b/internal/flightplan/runtime/decode.go
@@ -1,6 +1,7 @@
 package runtime
 
 import (
+	"bytes"
 	"fmt"
 
 	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
@@ -58,16 +59,22 @@ func Decode(m *manifest.Manifest) (*Plan, error) {
 }
 
 // remarshal round-trips a YAML-decoded `any` (already a map[string]any from
-// the manifest decode) back through YAML into a strict typed struct. The
-// destination structs set yaml tags and the wire DTOs use closed shapes so an
-// unexpected field surfaces as a decode mismatch where the typed model
-// requires it.
+// the manifest decode) back through YAML into a strict typed struct. Decode is
+// strict (KnownFields): the DTOs model the schema's full closed shapes, so an
+// unexpected field is a decode error rather than a silently-dropped typo. This
+// is the runtime's structural defense-in-depth over the loosely-typed manifest
+// []any blocks.
 func remarshal(v any, dst any) error {
 	raw, err := yaml.Marshal(v)
 	if err != nil {
 		return err
 	}
-	return yaml.Unmarshal(raw, dst)
+	dec := yaml.NewDecoder(bytes.NewReader(raw))
+	dec.KnownFields(true)
+	if err := dec.Decode(dst); err != nil {
+		return err
+	}
+	return nil
 }
 
 func decodeActions(m *manifest.Manifest, p *Plan) error {

--- a/internal/flightplan/runtime/decode.go
+++ b/internal/flightplan/runtime/decode.go
@@ -1,0 +1,285 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+	"gopkg.in/yaml.v3"
+)
+
+// DecodeError reports a strict-decode refusal. A decode error means the plan
+// is structurally invalid and the runtime refuses to run any step. The
+// message names the offending element so the author can fix it.
+type DecodeError struct {
+	Reason string
+}
+
+func (e *DecodeError) Error() string { return "flightplan decode: " + e.Reason }
+
+func decodeErrf(format string, args ...any) error {
+	return &DecodeError{Reason: fmt.Sprintf(format, args...)}
+}
+
+// Decode builds a typed, validated Plan from a parsed manifest. It is strict:
+// an unknown step kind, a malformed binding, a duplicate id, a binding that
+// references an undeclared input or absent step, a materializesOutput naming
+// an undeclared output, or a cycle in the steps.* dependency graph is a hard
+// refusal returned as a *DecodeError. No step runs unless Decode succeeds.
+//
+// An instruction-only manifest (no aileron block) has no composition to run
+// and is refused: Launch executes a step graph, and there is none.
+func Decode(m *manifest.Manifest) (*Plan, error) {
+	if m == nil {
+		return nil, decodeErrf("nil manifest")
+	}
+	if m.InstructionOnly {
+		return nil, decodeErrf("manifest is instruction-only; there is no step graph to launch")
+	}
+
+	p := &Plan{
+		Name:    m.Name,
+		Actions: map[string]Action{},
+		Outputs: map[string]Output{},
+	}
+
+	if err := decodeActions(m, p); err != nil {
+		return nil, err
+	}
+	if err := decodeInputs(m, p); err != nil {
+		return nil, err
+	}
+	if err := decodeOutputs(m, p); err != nil {
+		return nil, err
+	}
+	if err := decodeSteps(m, p); err != nil {
+		return nil, err
+	}
+	return p, nil
+}
+
+// remarshal round-trips a YAML-decoded `any` (already a map[string]any from
+// the manifest decode) back through YAML into a strict typed struct. The
+// destination structs set yaml tags and the wire DTOs use closed shapes so an
+// unexpected field surfaces as a decode mismatch where the typed model
+// requires it.
+func remarshal(v any, dst any) error {
+	raw, err := yaml.Marshal(v)
+	if err != nil {
+		return err
+	}
+	return yaml.Unmarshal(raw, dst)
+}
+
+func decodeActions(m *manifest.Manifest, p *Plan) error {
+	for _, ar := range m.Aileron.Requires.Actions {
+		var tc trustContractDTO
+		if err := remarshal(ar.TrustContract, &tc); err != nil {
+			return decodeErrf("action %q: parse trust contract: %v", ar.Ref, err)
+		}
+		act, err := tc.toAction(ar.Ref)
+		if err != nil {
+			return err
+		}
+		if _, dup := p.Actions[ar.Ref]; dup {
+			return decodeErrf("duplicate action ref %q", ar.Ref)
+		}
+		p.Actions[ar.Ref] = act
+	}
+	return nil
+}
+
+func decodeInputs(m *manifest.Manifest, p *Plan) error {
+	seen := map[string]bool{}
+	for i, raw := range m.Aileron.Inputs {
+		var dto inputDTO
+		if err := remarshal(raw, &dto); err != nil {
+			return decodeErrf("input %d: %v", i, err)
+		}
+		in, err := dto.toInput()
+		if err != nil {
+			return err
+		}
+		if seen[in.Name] {
+			return decodeErrf("duplicate input name %q", in.Name)
+		}
+		seen[in.Name] = true
+		p.Inputs = append(p.Inputs, in)
+	}
+	return nil
+}
+
+func decodeOutputs(m *manifest.Manifest, p *Plan) error {
+	for i, raw := range m.Aileron.Outputs {
+		var dto outputDTO
+		if err := remarshal(raw, &dto); err != nil {
+			return decodeErrf("output %d: %v", i, err)
+		}
+		out, err := dto.toOutput()
+		if err != nil {
+			return err
+		}
+		if _, dup := p.Outputs[out.Name]; dup {
+			return decodeErrf("duplicate output name %q", out.Name)
+		}
+		p.Outputs[out.Name] = out
+	}
+	return nil
+}
+
+func decodeSteps(m *manifest.Manifest, p *Plan) error {
+	if len(m.Aileron.Steps) == 0 {
+		return decodeErrf("manifest declares no steps; there is no step graph to launch")
+	}
+	inputNames := map[string]bool{}
+	for _, in := range p.Inputs {
+		inputNames[in.Name] = true
+	}
+
+	stepIndex := map[string]int{}
+	for i, raw := range m.Aileron.Steps {
+		var dto stepDTO
+		if err := remarshal(raw, &dto); err != nil {
+			return decodeErrf("step %d: %v", i, err)
+		}
+		step, err := dto.toStep()
+		if err != nil {
+			return err
+		}
+		if _, dup := stepIndex[step.ID]; dup {
+			return decodeErrf("duplicate step id %q", step.ID)
+		}
+		stepIndex[step.ID] = i
+		p.Steps = append(p.Steps, step)
+	}
+
+	if err := validateReferences(p, inputNames, stepIndex); err != nil {
+		return err
+	}
+	order, err := topoSort(p, stepIndex)
+	if err != nil {
+		return err
+	}
+	p.Order = order
+	return nil
+}
+
+// validateReferences checks every step binding and materializesOutput against
+// the declared inputs, the prior-step outputs, and the declared outputs. A
+// binding to an undeclared input or an absent step/output is a hard refusal.
+// An action-call whose ref is not in requires.actions is refused (the access
+// scope is the boundary).
+func validateReferences(p *Plan, inputNames map[string]bool, stepIndex map[string]int) error {
+	// stepOutputs lets a binding confirm the referenced step declares the
+	// named output. Built across all steps first so a forward reference is
+	// caught as a graph-shape error by topoSort, not mistaken for a missing
+	// output here.
+	stepOutputs := map[string]map[string]bool{}
+	for _, s := range p.Steps {
+		outs := map[string]bool{}
+		for _, o := range s.Outputs {
+			outs[o] = true
+		}
+		stepOutputs[s.ID] = outs
+	}
+
+	for _, s := range p.Steps {
+		if s.Kind == KindActionCall {
+			if _, ok := p.Actions[s.ActionRef]; !ok {
+				return decodeErrf("step %q calls action %q not declared in requires.actions", s.ID, s.ActionRef)
+			}
+		}
+		for argName, b := range s.binds() {
+			switch b.Kind {
+			case BindInput:
+				if !inputNames[b.Name] {
+					return decodeErrf("step %q binding %q references undeclared input %q", s.ID, argName, b.Name)
+				}
+			case BindStep:
+				outs, ok := stepOutputs[b.StepID]
+				if !ok {
+					return decodeErrf("step %q binding %q references unknown step %q", s.ID, argName, b.StepID)
+				}
+				if !outs[b.Output] {
+					return decodeErrf("step %q binding %q references output %q not produced by step %q", s.ID, argName, b.Output, b.StepID)
+				}
+				if b.StepID == s.ID {
+					return decodeErrf("step %q binding %q references its own output", s.ID, argName)
+				}
+			}
+		}
+		if s.MaterializesOutput != "" {
+			if _, ok := p.Outputs[s.MaterializesOutput]; !ok {
+				return decodeErrf("step %q materializes undeclared output %q", s.ID, s.MaterializesOutput)
+			}
+		}
+	}
+	return nil
+}
+
+// topoSort returns a deterministic topological order of step indices using
+// steps.* edges ONLY. Input-source reads are not steps and not graph edges,
+// so a `source` input that calls the same action a step calls never trips the
+// cycle check (#1523 boundary). A cycle is a hard refusal.
+//
+// Determinism: ties are broken by declaration order (the manifest step
+// order), so the same plan always yields the same walk order.
+func topoSort(p *Plan, stepIndex map[string]int) ([]int, error) {
+	n := len(p.Steps)
+	// deps[i] is the set of step indices step i depends on (its steps.*
+	// bindings). indegree counts unresolved deps.
+	deps := make([]map[int]bool, n)
+	indegree := make([]int, n)
+	// dependents[j] lists steps that depend on j, so resolving j decrements
+	// their indegree.
+	dependents := make([][]int, n)
+
+	for i, s := range p.Steps {
+		deps[i] = map[int]bool{}
+		for _, b := range s.binds() {
+			if b.Kind != BindStep {
+				continue
+			}
+			j := stepIndex[b.StepID]
+			if !deps[i][j] {
+				deps[i][j] = true
+				indegree[i]++
+				dependents[j] = append(dependents[j], i)
+			}
+		}
+	}
+
+	// Kahn's algorithm with a declaration-order ready set so the output is
+	// deterministic.
+	order := make([]int, 0, n)
+	resolved := make([]bool, n)
+	for len(order) < n {
+		next := -1
+		for i := 0; i < n; i++ {
+			if !resolved[i] && indegree[i] == 0 {
+				next = i
+				break
+			}
+		}
+		if next == -1 {
+			// No indegree-zero step remains but steps are unresolved: a cycle.
+			return nil, decodeErrf("step graph has a cycle among steps.* edges; %s", cycleMembers(resolved, p))
+		}
+		resolved[next] = true
+		order = append(order, next)
+		for _, d := range dependents[next] {
+			indegree[d]--
+		}
+	}
+	return order, nil
+}
+
+// cycleMembers names the unresolved steps for a cycle error message.
+func cycleMembers(resolved []bool, p *Plan) string {
+	var members []string
+	for i, r := range resolved {
+		if !r {
+			members = append(members, p.Steps[i].ID)
+		}
+	}
+	return fmt.Sprintf("unresolved steps: %v", members)
+}

--- a/internal/flightplan/runtime/decode_test.go
+++ b/internal/flightplan/runtime/decode_test.go
@@ -317,3 +317,41 @@ func TestDecodeError_Type(t *testing.T) {
 		t.Fatalf("error %v is not a *DecodeError", err)
 	}
 }
+
+func TestDecode_ActionCallWithBindingsRefused(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "s1", "kind": "action-call", "actionRef": "aileron:metrics.query_series",
+			"bindings": map[string]any{"v": "inputs.x"},
+			"outputs":  []any{"o"},
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("an action-call carrying bindings must be refused")
+	}
+}
+
+func TestDecode_TransformWithArgsRefused(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "s1", "kind": "transform",
+			"args":    map[string]any{"v": "inputs.x"},
+			"outputs": []any{"o"},
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a transform carrying args must be refused")
+	}
+}
+
+func TestDecode_UnknownStepFieldRefused(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "s1", "kind": "transform", "outputs": []any{"o"},
+			"bogusTypo": true,
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a step with an unknown field must be refused (strict decode)")
+	}
+}

--- a/internal/flightplan/runtime/decode_test.go
+++ b/internal/flightplan/runtime/decode_test.go
@@ -355,3 +355,94 @@ func TestDecode_UnknownStepFieldRefused(t *testing.T) {
 		t.Fatal("a step with an unknown field must be refused (strict decode)")
 	}
 }
+
+func TestDecode_DuplicateOutputRefused(t *testing.T) {
+	out := func() any {
+		return map[string]any{"name": "dup.csv", "mimeType": "text/csv", "encoding": "utf-8",
+			"publish": map[string]any{"target": "none"}}
+	}
+	m := rawManifest(nil, []any{out(), out()},
+		[]any{step(map[string]any{"id": "s", "kind": "transform", "outputs": []any{"x"}})})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a duplicate output name must be refused")
+	}
+}
+
+func TestDecode_UnknownEncodingRefused(t *testing.T) {
+	m := rawManifest(nil, []any{map[string]any{
+		"name": "o", "mimeType": "text/csv", "encoding": "rot13",
+		"publish": map[string]any{"target": "none"},
+	}}, []any{step(map[string]any{"id": "s", "kind": "transform", "outputs": []any{"x"}})})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("an unknown output encoding must be refused")
+	}
+}
+
+func TestDecode_FilePublishNeedsPath(t *testing.T) {
+	m := rawManifest(nil, []any{map[string]any{
+		"name": "o", "mimeType": "text/csv", "encoding": "utf-8",
+		"publish": map[string]any{"target": "file"},
+	}}, []any{step(map[string]any{"id": "s", "kind": "transform", "outputs": []any{"x"}})})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a file publish target without a path must be refused")
+	}
+}
+
+func TestDecode_UnknownInputTypeRefused(t *testing.T) {
+	m := rawManifest([]any{map[string]any{
+		"name": "i", "type": "quaternion", "resolution": map[string]any{"rule": "literal"},
+	}}, nil, []any{step(map[string]any{"id": "s", "kind": "transform", "outputs": []any{"x"}})})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("an unknown input type must be refused")
+	}
+}
+
+func TestDecode_UnknownResolutionRuleRefused(t *testing.T) {
+	m := rawManifest([]any{map[string]any{
+		"name": "i", "type": "string", "resolution": map[string]any{"rule": "telepathy"},
+	}}, nil, []any{step(map[string]any{"id": "s", "kind": "transform", "outputs": []any{"x"}})})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("an unknown resolution rule must be refused")
+	}
+}
+
+func TestDecode_DynamicValueValidated(t *testing.T) {
+	m := rawManifest([]any{map[string]any{
+		"name": "i", "type": "timestamp",
+		"resolution": map[string]any{"rule": "dynamic", "value": "yesterday"},
+	}}, nil, []any{step(map[string]any{"id": "s", "kind": "transform", "outputs": []any{"x"}})})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a dynamic value other than now/today must be refused")
+	}
+}
+
+func TestDecode_SourceWithoutActionRefRefused(t *testing.T) {
+	m := rawManifest([]any{map[string]any{
+		"name": "i", "type": "array",
+		"resolution": map[string]any{"rule": "source", "source": map[string]any{"select": "x"}},
+	}}, nil, []any{step(map[string]any{"id": "s", "kind": "transform", "outputs": []any{"x"}})})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a source resolution without an actionRef must be refused")
+	}
+}
+
+func TestDecode_UnknownEffectRefused(t *testing.T) {
+	ar := readActionReq()
+	ar.TrustContract["effect"] = "teleport"
+	m := &manifest.Manifest{Name: "t", Aileron: manifest.AileronBlock{
+		Requires: manifest.Requires{Actions: []manifest.ActionRequirement{ar}},
+		Steps:    []any{step(map[string]any{"id": "s", "kind": "transform", "outputs": []any{"x"}})},
+	}}
+	if _, err := Decode(m); err == nil {
+		t.Fatal("an unknown trust-contract effect must be refused")
+	}
+}
+
+func TestDecode_DuplicateStepOutputRefused(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{"id": "s", "kind": "transform", "outputs": []any{"x", "x"}}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a step with duplicate output names must be refused")
+	}
+}

--- a/internal/flightplan/runtime/decode_test.go
+++ b/internal/flightplan/runtime/decode_test.go
@@ -1,0 +1,319 @@
+package runtime
+
+import (
+	"errors"
+	"os"
+	"path/filepath"
+	"runtime"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+)
+
+// repoRoot walks up to the directory holding go.work so tests can read the
+// committed worked example.
+func repoRoot(t *testing.T) string {
+	t.Helper()
+	_, file, _, ok := runtime.Caller(0)
+	if !ok {
+		t.Fatal("runtime.Caller failed")
+	}
+	dir := filepath.Dir(file)
+	for {
+		if _, err := os.Stat(filepath.Join(dir, "go.work")); err == nil {
+			return dir
+		}
+		parent := filepath.Dir(dir)
+		if parent == dir {
+			t.Fatalf("could not find go.work from %s", filepath.Dir(file))
+		}
+		dir = parent
+	}
+}
+
+// exampleManifest parses the committed worked-example SKILL.md.
+func exampleManifest(t *testing.T) *manifest.Manifest {
+	t.Helper()
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatalf("read worked example: %v", err)
+	}
+	m, err := manifest.Parse(raw)
+	if err != nil {
+		t.Fatalf("parse worked example: %v", err)
+	}
+	return m
+}
+
+// parseInline parses a SKILL.md literal through the full manifest.Parse path
+// (schema validation included). Use it for cases the schema accepts.
+func parseInline(t *testing.T, md string) *manifest.Manifest {
+	t.Helper()
+	m, err := manifest.Parse([]byte(md))
+	if err != nil {
+		t.Fatalf("parse inline manifest: %v", err)
+	}
+	return m
+}
+
+// readActionReq is the minimal valid read-action requirement every fixture
+// shares, so the runtime decoder always has the action a step can call.
+func readActionReq() manifest.ActionRequirement {
+	return manifest.ActionRequirement{
+		Ref: "aileron:metrics.query_series",
+		TrustContract: map[string]any{
+			"credential":  map[string]any{"kind": "none"},
+			"hosts":       []any{"api.example.com"},
+			"effect":      "read",
+			"idempotency": map[string]any{"safeToRetry": true},
+			"audit":       map[string]any{"fields": []any{"result"}},
+		},
+	}
+}
+
+// rawManifest builds a *manifest.Manifest directly, bypassing schema
+// validation, so the runtime decoder's OWN guards are exercised on inputs the
+// schema would otherwise reject upstream. The runtime must refuse these
+// independently (defense in depth: the manifest carries loosely-typed []any).
+func rawManifest(inputs, outputs, steps []any) *manifest.Manifest {
+	return &manifest.Manifest{
+		Name: "t",
+		Aileron: manifest.AileronBlock{
+			SchemaVersion: "aileron.flightplan.v1",
+			Requires:      manifest.Requires{Actions: []manifest.ActionRequirement{readActionReq()}},
+			Inputs:        inputs,
+			Outputs:       outputs,
+			Steps:         steps,
+		},
+	}
+}
+
+func TestDecode_WorkedExample(t *testing.T) {
+	p, err := Decode(exampleManifest(t))
+	if err != nil {
+		t.Fatalf("Decode worked example: %v", err)
+	}
+	if p.Name != "weekly-metrics-digest" {
+		t.Errorf("name = %q", p.Name)
+	}
+	if len(p.Steps) != 4 {
+		t.Fatalf("got %d steps, want 4", len(p.Steps))
+	}
+	if len(p.Order) != 4 {
+		t.Fatalf("got order len %d, want 4", len(p.Order))
+	}
+	// query_metrics has no step deps, so it must come first in topo order.
+	if p.Steps[p.Order[0]].ID != "query_metrics" {
+		t.Errorf("first step = %q, want query_metrics", p.Steps[p.Order[0]].ID)
+	}
+	// file_issue depends on summarize, which depends on query_metrics +
+	// render_csv, so it must come last.
+	if p.Steps[p.Order[3]].ID != "file_issue" {
+		t.Errorf("last step = %q, want file_issue", p.Steps[p.Order[3]].ID)
+	}
+	// Trust contract decoded: tracker.create_issue is a write.
+	if p.Actions["aileron:tracker.create_issue"].TrustContract.Effect != EffectWrite {
+		t.Error("tracker.create_issue effect must decode to write")
+	}
+	if p.Actions["aileron:metrics.query_series"].TrustContract.Effect != EffectRead {
+		t.Error("metrics.query_series effect must decode to read")
+	}
+}
+
+func TestDecode_TopoOrderDeterministic(t *testing.T) {
+	m := exampleManifest(t)
+	var first []string
+	for i := 0; i < 20; i++ {
+		p, err := Decode(m)
+		if err != nil {
+			t.Fatalf("Decode: %v", err)
+		}
+		var order []string
+		for _, idx := range p.Order {
+			order = append(order, p.Steps[idx].ID)
+		}
+		if i == 0 {
+			first = order
+			continue
+		}
+		if strings.Join(order, ",") != strings.Join(first, ",") {
+			t.Fatalf("topo order not deterministic: %v vs %v", order, first)
+		}
+	}
+}
+
+func TestDecode_InstructionOnlyRefused(t *testing.T) {
+	md := "---\nname: x\ndescription: y\n---\n\n# X\n"
+	m := parseInline(t, md)
+	if _, err := Decode(m); err == nil {
+		t.Fatal("instruction-only manifest must be refused")
+	}
+}
+
+// step builds a raw step map of the shape the manifest carries (map[string]any).
+func step(fields map[string]any) any { return fields }
+
+func litInput(name, typ string, def any) any {
+	res := map[string]any{"rule": "literal"}
+	if def != nil {
+		res["default"] = def
+	}
+	return map[string]any{"name": name, "type": typ, "resolution": res}
+}
+
+func TestDecode_UnknownStepKind(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{"id": "s1", "kind": "psychic", "outputs": []any{"x"}}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("unknown step kind must be refused")
+	} else if !strings.Contains(err.Error(), "unknown kind") {
+		t.Errorf("error = %v, want unknown kind", err)
+	}
+}
+
+func TestDecode_MalformedBinding(t *testing.T) {
+	m := rawManifest(
+		[]any{litInput("w", "number", 7)},
+		nil,
+		[]any{step(map[string]any{
+			"id": "s1", "kind": "transform",
+			"bindings": map[string]any{"v": "not-a-binding"},
+			"outputs":  []any{"x"},
+		})},
+	)
+	if _, err := Decode(m); err == nil {
+		t.Fatal("binding outside the closed grammar must be refused")
+	}
+}
+
+func TestDecode_BindingToUndeclaredInput(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "s1", "kind": "transform",
+			"bindings": map[string]any{"v": "inputs.missing"},
+			"outputs":  []any{"x"},
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("binding to undeclared input must be refused")
+	}
+}
+
+func TestDecode_BindingToAbsentStep(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "s1", "kind": "transform",
+			"bindings": map[string]any{"v": "steps.ghost.out"},
+			"outputs":  []any{"x"},
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("binding to an absent step must be refused")
+	}
+}
+
+func TestDecode_BindingToAbsentStepOutput(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{"id": "a", "kind": "transform", "outputs": []any{"x"}}),
+		step(map[string]any{
+			"id": "b", "kind": "transform",
+			"bindings": map[string]any{"v": "steps.a.nope"},
+			"outputs":  []any{"y"},
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("binding to a non-existent output of a real step must be refused")
+	}
+}
+
+func TestDecode_CyclicStepsRefused(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "a", "kind": "transform",
+			"bindings": map[string]any{"v": "steps.b.y"},
+			"outputs":  []any{"x"},
+		}),
+		step(map[string]any{
+			"id": "b", "kind": "transform",
+			"bindings": map[string]any{"v": "steps.a.x"},
+			"outputs":  []any{"y"},
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("a steps.* cycle must be refused")
+	} else if !strings.Contains(err.Error(), "cycle") {
+		t.Errorf("error = %v, want cycle", err)
+	}
+}
+
+// A source input referencing the same action a step calls is NOT a graph edge
+// and must NOT trip the cycle check (#1523 boundary).
+func TestDecode_SourceInputIsNotAStepEdge(t *testing.T) {
+	m := rawManifest(
+		[]any{map[string]any{
+			"name": "live", "type": "array",
+			"resolution": map[string]any{
+				"rule": "source",
+				"source": map[string]any{
+					"actionRef": "aileron:metrics.query_series",
+					"select":    "series[].name",
+				},
+			},
+		}},
+		nil,
+		[]any{step(map[string]any{
+			"id": "query", "kind": "action-call",
+			"actionRef": "aileron:metrics.query_series",
+			"args":      map[string]any{"metric_set": "inputs.live"},
+			"outputs":   []any{"series"},
+		})},
+	)
+	if _, err := Decode(m); err != nil {
+		t.Fatalf("a source input on the same action a step calls must not trip the cycle check: %v", err)
+	}
+}
+
+func TestDecode_DuplicateStepID(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{"id": "dup", "kind": "transform", "outputs": []any{"x"}}),
+		step(map[string]any{"id": "dup", "kind": "transform", "outputs": []any{"y"}}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("duplicate step id must be refused")
+	}
+}
+
+func TestDecode_MaterializesUndeclaredOutput(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "s1", "kind": "transform", "outputs": []any{"x"},
+			"materializesOutput": "ghost.csv",
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("materializing an undeclared output must be refused")
+	}
+}
+
+func TestDecode_ActionCallToUndeclaredAction(t *testing.T) {
+	m := rawManifest(nil, nil, []any{
+		step(map[string]any{
+			"id": "s1", "kind": "action-call",
+			"actionRef": "aileron:other.thing",
+			"outputs":   []any{"x"},
+		}),
+	})
+	if _, err := Decode(m); err == nil {
+		t.Fatal("action-call to an action not in requires.actions must be refused")
+	}
+}
+
+func TestDecodeError_Type(t *testing.T) {
+	_, err := Decode(parseInline(t, "---\nname: x\ndescription: y\n---\n\n# X\n"))
+	var de *DecodeError
+	if !errors.As(err, &de) {
+		t.Fatalf("error %v is not a *DecodeError", err)
+	}
+}

--- a/internal/flightplan/runtime/decode_test.go
+++ b/internal/flightplan/runtime/decode_test.go
@@ -112,11 +112,21 @@ func TestDecode_WorkedExample(t *testing.T) {
 	if p.Steps[p.Order[3]].ID != "file_issue" {
 		t.Errorf("last step = %q, want file_issue", p.Steps[p.Order[3]].ID)
 	}
-	// Trust contract decoded: tracker.create_issue is a write.
-	if p.Actions["aileron:tracker.create_issue"].TrustContract.Effect != EffectWrite {
+	// Trust contract decoded: assert the action exists before inspecting its
+	// effect, so a missing decode entry fails loudly rather than passing on a
+	// zero-valued Effect.
+	tracker, ok := p.Actions["aileron:tracker.create_issue"]
+	if !ok {
+		t.Fatal("tracker.create_issue must decode into the action set")
+	}
+	if tracker.TrustContract.Effect != EffectWrite {
 		t.Error("tracker.create_issue effect must decode to write")
 	}
-	if p.Actions["aileron:metrics.query_series"].TrustContract.Effect != EffectRead {
+	metrics, ok := p.Actions["aileron:metrics.query_series"]
+	if !ok {
+		t.Fatal("metrics.query_series must decode into the action set")
+	}
+	if metrics.TrustContract.Effect != EffectRead {
 		t.Error("metrics.query_series effect must decode to read")
 	}
 }

--- a/internal/flightplan/runtime/dispatch.go
+++ b/internal/flightplan/runtime/dispatch.go
@@ -41,10 +41,12 @@ type dispatchOutcome struct {
 }
 
 // dispatch runs one action through the enforcement pipeline. action is the
-// decoded trust contract; args are the resolved binding values. attempt is the
-// 1-based call attempt so a retry of a non-idempotent action is refused rather
-// than silently re-issued.
-func (e *enforcer) dispatch(ctx context.Context, action Action, args map[string]any, attempt int) (dispatchOutcome, error) {
+// decoded trust contract; args are the resolved binding values. callID
+// identifies this specific call site (the step id, or a source-input marker)
+// so the idempotency key is stable per call and never collides when the same
+// action ref runs at two call sites. attempt is the 1-based call attempt so a
+// retry of a non-idempotent action is refused rather than silently re-issued.
+func (e *enforcer) dispatch(ctx context.Context, callID string, action Action, args map[string]any, attempt int) (dispatchOutcome, error) {
 	tc := action.TrustContract
 
 	// Idempotency: a retried dispatch of an action declared not safe-to-retry
@@ -81,7 +83,7 @@ func (e *enforcer) dispatch(ctx context.Context, action Action, args map[string]
 	// and never carries a secret.
 	dispatchArgs := args
 	if tc.Idempotency.IdempotencyKey {
-		dispatchArgs = withIdempotencyKey(args, action.Ref)
+		dispatchArgs = withIdempotencyKey(args, callID, action.Ref)
 	}
 
 	res, err := e.dispatcher.Dispatch(ctx, action.Ref, dispatchArgs)
@@ -107,13 +109,14 @@ func approvalArgsSummary(args map[string]any) map[string]any {
 const idempotencyKeyField = "idempotencyKey"
 
 // withIdempotencyKey returns a copy of args with a stable idempotency key
-// added, derived from the action ref. The key lets the upstream deduplicate a
-// retried write. It is deterministic for a given action so a retry threads the
-// same key.
-func withIdempotencyKey(args map[string]any, ref string) map[string]any {
+// added, derived from the call site (callID) and the action ref. The key lets
+// the upstream deduplicate a retried write. It is deterministic for a given
+// call so a retry of that call threads the same key, while two distinct call
+// sites of the same action ref get distinct keys (no cross-call collision).
+func withIdempotencyKey(args map[string]any, callID, ref string) map[string]any {
 	out := deepCopyMap(args)
 	if _, present := out[idempotencyKeyField]; !present {
-		out[idempotencyKeyField] = "aileron-idem-" + ref
+		out[idempotencyKeyField] = "aileron-idem-" + callID + "-" + ref
 	}
 	return out
 }

--- a/internal/flightplan/runtime/dispatch.go
+++ b/internal/flightplan/runtime/dispatch.go
@@ -1,0 +1,119 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+)
+
+// DenyError reports that an effect-gated action was denied at the approval
+// channel. The step aborts and the run fails; the denial is audited.
+type DenyError struct {
+	ActionRef string
+	Reason    string
+}
+
+func (e *DenyError) Error() string {
+	if e.Reason != "" {
+		return fmt.Sprintf("flightplan: action %q denied at approval: %s", e.ActionRef, e.Reason)
+	}
+	return fmt.Sprintf("flightplan: action %q denied at approval", e.ActionRef)
+}
+
+// enforcer wraps the action-dispatch seam with trust-contract enforcement
+// (#1507): effect-routed approval before dispatch, idempotency-aware retry,
+// and redaction of the result before it surfaces. It is the single chokepoint
+// every action-call (and source-input read) passes through, so the
+// trust-contract rules are applied in exactly one place.
+type enforcer struct {
+	dispatcher ActionDispatcher
+	approver   Approver
+}
+
+// dispatchOutcome carries the redacted result plus the approval decision (for
+// the audit record).
+type dispatchOutcome struct {
+	// Result is the redacted dispatch result that surfaces into the graph.
+	Result map[string]any
+	// Approved is the approval decision; true for an unattended read.
+	Approved bool
+	// ApprovalRequested reports whether the action routed through approval.
+	ApprovalRequested bool
+}
+
+// dispatch runs one action through the enforcement pipeline. action is the
+// decoded trust contract; args are the resolved binding values. attempt is the
+// 1-based call attempt so a retry of a non-idempotent action is refused rather
+// than silently re-issued.
+func (e *enforcer) dispatch(ctx context.Context, action Action, args map[string]any, attempt int) (dispatchOutcome, error) {
+	tc := action.TrustContract
+
+	// Idempotency: a retried dispatch of an action declared not safe-to-retry
+	// is refused rather than re-issued, so a write is never silently doubled.
+	if attempt > 1 && !tc.Idempotency.SafeToRetry {
+		return dispatchOutcome{}, fmt.Errorf("flightplan: action %q is not safe to retry (attempt %d); refusing to re-issue", action.Ref, attempt)
+	}
+
+	out := dispatchOutcome{Approved: true}
+
+	// Effect-routed approval (ADR-0009). A read runs unattended; everything
+	// else blocks on the out-of-band decision.
+	if requiresApproval(tc.Effect) {
+		out.ApprovalRequested = true
+		if e.approver == nil {
+			return dispatchOutcome{}, fmt.Errorf("flightplan: action %q has effect %q and needs approval but no approver is configured", action.Ref, tc.Effect)
+		}
+		decision, err := e.approver.Approve(ctx, ApprovalRequest{
+			ActionRef: action.Ref,
+			Effect:    tc.Effect,
+			Args:      approvalArgsSummary(args),
+		})
+		if err != nil {
+			return dispatchOutcome{}, fmt.Errorf("flightplan: approval for %q failed: %w", action.Ref, err)
+		}
+		out.Approved = decision.Approved
+		if !decision.Approved {
+			return dispatchOutcome{Approved: false, ApprovalRequested: true}, &DenyError{ActionRef: action.Ref, Reason: decision.Reason}
+		}
+	}
+
+	// Thread a stable idempotency key when the contract declares one so the
+	// upstream dedups a retried write. The key is derived from the action ref
+	// and never carries a secret.
+	dispatchArgs := args
+	if tc.Idempotency.IdempotencyKey {
+		dispatchArgs = withIdempotencyKey(args, action.Ref)
+	}
+
+	res, err := e.dispatcher.Dispatch(ctx, action.Ref, dispatchArgs)
+	if err != nil {
+		return dispatchOutcome{Approved: out.Approved, ApprovalRequested: out.ApprovalRequested}, fmt.Errorf("flightplan: dispatch %q: %w", action.Ref, err)
+	}
+
+	// Redaction runs on the dispatch result BEFORE it enters the graph or any
+	// audit summary (#1507). The original result is never surfaced unredacted.
+	out.Result = applyRedaction(res.Output, tc.Redaction)
+	return out, nil
+}
+
+// approvalArgsSummary builds the redacted args summary presented to the
+// approver. Args are already resolved binding values (never secrets), but we
+// pass a copy so the approver can never mutate the live args.
+func approvalArgsSummary(args map[string]any) map[string]any {
+	return deepCopyMap(args)
+}
+
+// idempotencyKeyField is the conventional arg key the runtime threads a stable
+// idempotency key through when the contract declares idempotencyKey:true.
+const idempotencyKeyField = "idempotencyKey"
+
+// withIdempotencyKey returns a copy of args with a stable idempotency key
+// added, derived from the action ref. The key lets the upstream deduplicate a
+// retried write. It is deterministic for a given action so a retry threads the
+// same key.
+func withIdempotencyKey(args map[string]any, ref string) map[string]any {
+	out := deepCopyMap(args)
+	if _, present := out[idempotencyKeyField]; !present {
+		out[idempotencyKeyField] = "aileron-idem-" + ref
+	}
+	return out
+}

--- a/internal/flightplan/runtime/dispatch_test.go
+++ b/internal/flightplan/runtime/dispatch_test.go
@@ -1,0 +1,162 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"testing"
+)
+
+// fakeDispatcher records calls and returns a canned result. It is the action
+// boundary stand-in; secrets never reach it because bindings are references.
+type fakeDispatcher struct {
+	calls   []dispatchCall
+	result  map[string]any
+	failErr error
+}
+
+type dispatchCall struct {
+	ref  string
+	args map[string]any
+}
+
+func (f *fakeDispatcher) Dispatch(_ context.Context, ref string, args map[string]any) (DispatchResult, error) {
+	f.calls = append(f.calls, dispatchCall{ref: ref, args: args})
+	if f.failErr != nil {
+		return DispatchResult{}, f.failErr
+	}
+	res := f.result
+	if res == nil {
+		res = map[string]any{"ok": true}
+	}
+	return DispatchResult{Output: res}, nil
+}
+
+// fakeApprover returns a fixed decision and records the requests it saw.
+type fakeApprover struct {
+	decision Decision
+	err      error
+	requests []ApprovalRequest
+}
+
+func (f *fakeApprover) Approve(_ context.Context, req ApprovalRequest) (Decision, error) {
+	f.requests = append(f.requests, req)
+	if f.err != nil {
+		return Decision{}, f.err
+	}
+	return f.decision, nil
+}
+
+func readAction(ref string) Action {
+	return Action{Ref: ref, TrustContract: TrustContract{Effect: EffectRead, Hosts: []string{"h"}}}
+}
+
+func writeAction(ref string, safeToRetry, idemKey bool) Action {
+	return Action{Ref: ref, TrustContract: TrustContract{
+		Effect:      EffectWrite,
+		Hosts:       []string{"h"},
+		Idempotency: Idempotency{SafeToRetry: safeToRetry, IdempotencyKey: idemKey},
+	}}
+}
+
+func TestDispatch_ReadRunsWithoutApproval(t *testing.T) {
+	disp := &fakeDispatcher{}
+	app := &fakeApprover{}
+	e := &enforcer{dispatcher: disp, approver: app}
+	out, err := e.dispatch(context.Background(), readAction("aileron:m.read"), map[string]any{"a": 1}, 1)
+	if err != nil {
+		t.Fatalf("read dispatch: %v", err)
+	}
+	if out.ApprovalRequested {
+		t.Error("a read must not request approval")
+	}
+	if len(app.requests) != 0 {
+		t.Error("approver must not be called for a read")
+	}
+	if len(disp.calls) != 1 {
+		t.Fatalf("want 1 dispatch, got %d", len(disp.calls))
+	}
+}
+
+func TestDispatch_WriteBlocksThenProceedsOnApprove(t *testing.T) {
+	disp := &fakeDispatcher{}
+	app := &fakeApprover{decision: Decision{Approved: true}}
+	e := &enforcer{dispatcher: disp, approver: app}
+	out, err := e.dispatch(context.Background(), writeAction("aileron:t.write", false, false), nil, 1)
+	if err != nil {
+		t.Fatalf("write dispatch: %v", err)
+	}
+	if !out.ApprovalRequested || !out.Approved {
+		t.Error("a write must request approval and proceed on approve")
+	}
+	if len(disp.calls) != 1 {
+		t.Error("an approved write must dispatch")
+	}
+}
+
+func TestDispatch_DeleteAbortsOnDeny(t *testing.T) {
+	disp := &fakeDispatcher{}
+	app := &fakeApprover{decision: Decision{Approved: false, Reason: "no"}}
+	del := Action{Ref: "aileron:t.delete", TrustContract: TrustContract{Effect: EffectDelete, Hosts: []string{"h"}}}
+	e := &enforcer{dispatcher: disp, approver: app}
+	_, err := e.dispatch(context.Background(), del, nil, 1)
+	var de *DenyError
+	if !errors.As(err, &de) {
+		t.Fatalf("a denied delete must return a *DenyError, got %v", err)
+	}
+	if len(disp.calls) != 0 {
+		t.Error("a denied action must NOT dispatch")
+	}
+}
+
+func TestDispatch_NonRetryableNotReissued(t *testing.T) {
+	disp := &fakeDispatcher{}
+	app := &fakeApprover{decision: Decision{Approved: true}}
+	e := &enforcer{dispatcher: disp, approver: app}
+	// attempt 2 of a safeToRetry:false action must be refused.
+	_, err := e.dispatch(context.Background(), writeAction("aileron:t.write", false, false), nil, 2)
+	if err == nil {
+		t.Fatal("retry of a non-idempotent action must be refused")
+	}
+	if len(disp.calls) != 0 {
+		t.Error("a refused retry must not dispatch")
+	}
+}
+
+func TestDispatch_IdempotencyKeyThreaded(t *testing.T) {
+	disp := &fakeDispatcher{}
+	app := &fakeApprover{decision: Decision{Approved: true}}
+	e := &enforcer{dispatcher: disp, approver: app}
+	_, err := e.dispatch(context.Background(), writeAction("aileron:t.write", true, true), map[string]any{"body": "x"}, 1)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	got := disp.calls[0].args[idempotencyKeyField]
+	if got == nil || got == "" {
+		t.Error("an idempotencyKey:true contract must thread a stable key into dispatch args")
+	}
+}
+
+func TestDispatch_NoApproverForWriteErrors(t *testing.T) {
+	e := &enforcer{dispatcher: &fakeDispatcher{}, approver: nil}
+	if _, err := e.dispatch(context.Background(), writeAction("aileron:t.write", true, false), nil, 1); err == nil {
+		t.Fatal("a write with no approver configured must error, not run unattended")
+	}
+}
+
+func TestDispatch_RedactsBeforeSurfacing(t *testing.T) {
+	disp := &fakeDispatcher{result: map[string]any{"email": "a@b.com", "id": 7}}
+	app := &fakeApprover{}
+	act := readAction("aileron:m.read")
+	act.TrustContract.Redaction = []RedactionRule{{Field: "email", Rule: RedactDrop}}
+	e := &enforcer{dispatcher: disp, approver: app}
+	out, err := e.dispatch(context.Background(), act, nil, 1)
+	if err != nil {
+		t.Fatalf("dispatch: %v", err)
+	}
+	if _, present := out.Result["email"]; present {
+		t.Error("redaction must drop the declared field before it surfaces")
+	}
+	if out.Result["id"] != 7 {
+		t.Error("non-redacted fields must survive")
+	}
+}

--- a/internal/flightplan/runtime/dispatch_test.go
+++ b/internal/flightplan/runtime/dispatch_test.go
@@ -178,3 +178,11 @@ func TestDispatch_IdempotencyKeyDistinctPerCallSite(t *testing.T) {
 		t.Error("two call sites of the same action ref must get distinct idempotency keys")
 	}
 }
+
+func TestDispatch_DispatcherErrorSurfaces(t *testing.T) {
+	disp := &fakeDispatcher{failErr: errors.New("boom")}
+	e := &enforcer{dispatcher: disp, approver: &fakeApprover{}}
+	if _, err := e.dispatch(context.Background(), "test", readAction("aileron:m.read"), nil, 1); err == nil {
+		t.Fatal("a dispatcher error must surface")
+	}
+}

--- a/internal/flightplan/runtime/dispatch_test.go
+++ b/internal/flightplan/runtime/dispatch_test.go
@@ -62,7 +62,7 @@ func TestDispatch_ReadRunsWithoutApproval(t *testing.T) {
 	disp := &fakeDispatcher{}
 	app := &fakeApprover{}
 	e := &enforcer{dispatcher: disp, approver: app}
-	out, err := e.dispatch(context.Background(), readAction("aileron:m.read"), map[string]any{"a": 1}, 1)
+	out, err := e.dispatch(context.Background(), "test", readAction("aileron:m.read"), map[string]any{"a": 1}, 1)
 	if err != nil {
 		t.Fatalf("read dispatch: %v", err)
 	}
@@ -81,7 +81,7 @@ func TestDispatch_WriteBlocksThenProceedsOnApprove(t *testing.T) {
 	disp := &fakeDispatcher{}
 	app := &fakeApprover{decision: Decision{Approved: true}}
 	e := &enforcer{dispatcher: disp, approver: app}
-	out, err := e.dispatch(context.Background(), writeAction("aileron:t.write", false, false), nil, 1)
+	out, err := e.dispatch(context.Background(), "test", writeAction("aileron:t.write", false, false), nil, 1)
 	if err != nil {
 		t.Fatalf("write dispatch: %v", err)
 	}
@@ -98,7 +98,7 @@ func TestDispatch_DeleteAbortsOnDeny(t *testing.T) {
 	app := &fakeApprover{decision: Decision{Approved: false, Reason: "no"}}
 	del := Action{Ref: "aileron:t.delete", TrustContract: TrustContract{Effect: EffectDelete, Hosts: []string{"h"}}}
 	e := &enforcer{dispatcher: disp, approver: app}
-	_, err := e.dispatch(context.Background(), del, nil, 1)
+	_, err := e.dispatch(context.Background(), "test", del, nil, 1)
 	var de *DenyError
 	if !errors.As(err, &de) {
 		t.Fatalf("a denied delete must return a *DenyError, got %v", err)
@@ -113,7 +113,7 @@ func TestDispatch_NonRetryableNotReissued(t *testing.T) {
 	app := &fakeApprover{decision: Decision{Approved: true}}
 	e := &enforcer{dispatcher: disp, approver: app}
 	// attempt 2 of a safeToRetry:false action must be refused.
-	_, err := e.dispatch(context.Background(), writeAction("aileron:t.write", false, false), nil, 2)
+	_, err := e.dispatch(context.Background(), "test", writeAction("aileron:t.write", false, false), nil, 2)
 	if err == nil {
 		t.Fatal("retry of a non-idempotent action must be refused")
 	}
@@ -126,7 +126,7 @@ func TestDispatch_IdempotencyKeyThreaded(t *testing.T) {
 	disp := &fakeDispatcher{}
 	app := &fakeApprover{decision: Decision{Approved: true}}
 	e := &enforcer{dispatcher: disp, approver: app}
-	_, err := e.dispatch(context.Background(), writeAction("aileron:t.write", true, true), map[string]any{"body": "x"}, 1)
+	_, err := e.dispatch(context.Background(), "test", writeAction("aileron:t.write", true, true), map[string]any{"body": "x"}, 1)
 	if err != nil {
 		t.Fatalf("dispatch: %v", err)
 	}
@@ -138,7 +138,7 @@ func TestDispatch_IdempotencyKeyThreaded(t *testing.T) {
 
 func TestDispatch_NoApproverForWriteErrors(t *testing.T) {
 	e := &enforcer{dispatcher: &fakeDispatcher{}, approver: nil}
-	if _, err := e.dispatch(context.Background(), writeAction("aileron:t.write", true, false), nil, 1); err == nil {
+	if _, err := e.dispatch(context.Background(), "test", writeAction("aileron:t.write", true, false), nil, 1); err == nil {
 		t.Fatal("a write with no approver configured must error, not run unattended")
 	}
 }
@@ -149,7 +149,7 @@ func TestDispatch_RedactsBeforeSurfacing(t *testing.T) {
 	act := readAction("aileron:m.read")
 	act.TrustContract.Redaction = []RedactionRule{{Field: "email", Rule: RedactDrop}}
 	e := &enforcer{dispatcher: disp, approver: app}
-	out, err := e.dispatch(context.Background(), act, nil, 1)
+	out, err := e.dispatch(context.Background(), "test", act, nil, 1)
 	if err != nil {
 		t.Fatalf("dispatch: %v", err)
 	}
@@ -158,5 +158,23 @@ func TestDispatch_RedactsBeforeSurfacing(t *testing.T) {
 	}
 	if out.Result["id"] != 7 {
 		t.Error("non-redacted fields must survive")
+	}
+}
+
+func TestDispatch_IdempotencyKeyDistinctPerCallSite(t *testing.T) {
+	disp := &fakeDispatcher{}
+	app := &fakeApprover{decision: Decision{Approved: true}}
+	e := &enforcer{dispatcher: disp, approver: app}
+	act := writeAction("aileron:t.write", true, true)
+	if _, err := e.dispatch(context.Background(), "step:a", act, map[string]any{}, 1); err != nil {
+		t.Fatalf("dispatch a: %v", err)
+	}
+	if _, err := e.dispatch(context.Background(), "step:b", act, map[string]any{}, 1); err != nil {
+		t.Fatalf("dispatch b: %v", err)
+	}
+	ka := disp.calls[0].args[idempotencyKeyField]
+	kb := disp.calls[1].args[idempotencyKeyField]
+	if ka == kb {
+		t.Error("two call sites of the same action ref must get distinct idempotency keys")
 	}
 }

--- a/internal/flightplan/runtime/dto.go
+++ b/internal/flightplan/runtime/dto.go
@@ -14,10 +14,17 @@ type trustContractDTO struct {
 		Placement     string `yaml:"placement"`
 		IdentityLabel string `yaml:"identityLabel"`
 	} `yaml:"credential"`
-	Hosts       []string `yaml:"hosts"`
-	Paths       []string `yaml:"paths"`
-	Effect      string   `yaml:"effect"`
-	Idempotency struct {
+	// OAuth and Verification are modeled (but not consumed by the runtime) so
+	// strict decode does not reject a manifest that legitimately declares
+	// them. The schema's full trustContract shape is represented here; the
+	// runtime enforces effect/idempotency/redaction/audit and the access
+	// scope, and the host injects credentials at the boundary.
+	OAuth        map[string]any `yaml:"oauth"`
+	Verification map[string]any `yaml:"verification"`
+	Hosts        []string       `yaml:"hosts"`
+	Paths        []string       `yaml:"paths"`
+	Effect       string         `yaml:"effect"`
+	Idempotency  struct {
 		SafeToRetry    bool `yaml:"safeToRetry"`
 		IdempotencyKey bool `yaml:"idempotencyKey"`
 	} `yaml:"idempotency"`
@@ -206,6 +213,12 @@ func (d stepDTO) toStep() (Step, error) {
 		if d.ActionRef == "" {
 			return Step{}, decodeErrf("step %q: action-call has no actionRef", d.ID)
 		}
+		// An action-call carries args, not bindings: a stray bindings block is
+		// a malformed step (the closed schema forbids it), refused rather than
+		// silently ignored.
+		if len(d.Bindings) != 0 {
+			return Step{}, decodeErrf("step %q: action-call must not declare bindings (use args)", d.ID)
+		}
 		step.ActionRef = d.ActionRef
 		args, err := parseBindings(d.ID, d.Args)
 		if err != nil {
@@ -215,6 +228,11 @@ func (d stepDTO) toStep() (Step, error) {
 	} else {
 		if d.ActionRef != "" {
 			return Step{}, decodeErrf("step %q: kind %q must not declare an actionRef", d.ID, d.Kind)
+		}
+		// A transform / llm-seam carries bindings, not args: a stray args block
+		// is a malformed step, refused rather than silently ignored.
+		if len(d.Args) != 0 {
+			return Step{}, decodeErrf("step %q: kind %q must not declare args (use bindings)", d.ID, d.Kind)
 		}
 		binds, err := parseBindings(d.ID, d.Bindings)
 		if err != nil {

--- a/internal/flightplan/runtime/dto.go
+++ b/internal/flightplan/runtime/dto.go
@@ -1,0 +1,267 @@
+package runtime
+
+// The DTOs in this file mirror the manifest schema wire shapes. They are the
+// strict-decode boundary: the loosely-typed manifest `[]any`/`map[string]any`
+// elements round-trip through these structs (via remarshal) and the toX
+// converters validate closed enums and required fields exactly as the schema
+// declares them, then build the clean typed model the executor reads.
+
+// ---- trust contract ----
+
+type trustContractDTO struct {
+	Credential struct {
+		Kind          string `yaml:"kind"`
+		Placement     string `yaml:"placement"`
+		IdentityLabel string `yaml:"identityLabel"`
+	} `yaml:"credential"`
+	Hosts       []string `yaml:"hosts"`
+	Paths       []string `yaml:"paths"`
+	Effect      string   `yaml:"effect"`
+	Idempotency struct {
+		SafeToRetry    bool `yaml:"safeToRetry"`
+		IdempotencyKey bool `yaml:"idempotencyKey"`
+	} `yaml:"idempotency"`
+	Redaction []struct {
+		Field string `yaml:"field"`
+		Rule  string `yaml:"rule"`
+	} `yaml:"redaction"`
+	Audit struct {
+		Fields []string `yaml:"fields"`
+		Sink   string   `yaml:"sink"`
+	} `yaml:"audit"`
+}
+
+var validEffects = map[string]Effect{
+	"read":          EffectRead,
+	"write":         EffectWrite,
+	"delete":        EffectDelete,
+	"spend":         EffectSpend,
+	"external-send": EffectExternalSend,
+}
+
+var validRedactKinds = map[string]RedactionKind{
+	"drop": RedactDrop,
+	"mask": RedactMask,
+	"hash": RedactHash,
+}
+
+func (d trustContractDTO) toAction(ref string) (Action, error) {
+	eff, ok := validEffects[d.Effect]
+	if !ok {
+		return Action{}, decodeErrf("action %q: unknown effect %q", ref, d.Effect)
+	}
+	if len(d.Hosts) == 0 {
+		return Action{}, decodeErrf("action %q: trust contract declares no hosts (access scope is the boundary)", ref)
+	}
+	tc := TrustContract{
+		CredentialKind: d.Credential.Kind,
+		Hosts:          d.Hosts,
+		Paths:          d.Paths,
+		Effect:         eff,
+		Idempotency:    Idempotency{SafeToRetry: d.Idempotency.SafeToRetry, IdempotencyKey: d.Idempotency.IdempotencyKey},
+		IdentityLabel:  d.Credential.IdentityLabel,
+		Audit:          AuditStructure{Fields: d.Audit.Fields, Sink: d.Audit.Sink},
+	}
+	for _, r := range d.Redaction {
+		rk, ok := validRedactKinds[r.Rule]
+		if !ok {
+			return Action{}, decodeErrf("action %q: unknown redaction rule %q on field %q", ref, r.Rule, r.Field)
+		}
+		tc.Redaction = append(tc.Redaction, RedactionRule{Field: r.Field, Rule: rk})
+	}
+	return Action{Ref: ref, TrustContract: tc}, nil
+}
+
+// ---- input ----
+
+type inputDTO struct {
+	Name        string `yaml:"name"`
+	Type        string `yaml:"type"`
+	Description string `yaml:"description"`
+	Resolution  struct {
+		Rule    string `yaml:"rule"`
+		Default any    `yaml:"default"`
+		Value   string `yaml:"value"`
+		Source  struct {
+			ActionRef string `yaml:"actionRef"`
+			Select    string `yaml:"select"`
+		} `yaml:"source"`
+	} `yaml:"resolution"`
+}
+
+var validInputTypes = map[string]InputType{
+	"string": "string", "number": "number", "boolean": "boolean",
+	"timestamp": "timestamp", "object": "object", "array": "array",
+}
+
+func (d inputDTO) toInput() (Input, error) {
+	if d.Name == "" {
+		return Input{}, decodeErrf("input has no name")
+	}
+	it, ok := validInputTypes[d.Type]
+	if !ok {
+		return Input{}, decodeErrf("input %q: unknown type %q", d.Name, d.Type)
+	}
+	res := Resolution{}
+	switch d.Resolution.Rule {
+	case "literal":
+		res.Rule = ResolutionLiteral
+		if d.Resolution.Default != nil {
+			res.HasDefault = true
+			res.Default = d.Resolution.Default
+		}
+	case "dynamic":
+		res.Rule = ResolutionDynamic
+		if d.Resolution.Value != "now" && d.Resolution.Value != "today" {
+			return Input{}, decodeErrf("input %q: dynamic value must be now or today, got %q", d.Name, d.Resolution.Value)
+		}
+		res.DynamicValue = d.Resolution.Value
+	case "source":
+		res.Rule = ResolutionSource
+		if d.Resolution.Source.ActionRef == "" {
+			return Input{}, decodeErrf("input %q: source resolution needs an actionRef", d.Name)
+		}
+		res.SourceActionRef = d.Resolution.Source.ActionRef
+		res.SourceSelect = d.Resolution.Source.Select
+	default:
+		return Input{}, decodeErrf("input %q: unknown resolution rule %q", d.Name, d.Resolution.Rule)
+	}
+	return Input{Name: d.Name, Type: it, Description: d.Description, Resolution: res}, nil
+}
+
+// ---- output ----
+
+type outputDTO struct {
+	Name     string `yaml:"name"`
+	MimeType string `yaml:"mimeType"`
+	Encoding string `yaml:"encoding"`
+	Publish  struct {
+		Target string `yaml:"target"`
+		Path   string `yaml:"path"`
+	} `yaml:"publish"`
+}
+
+var validEncodings = map[string]Encoding{
+	"utf-8":  EncodingUTF8,
+	"base64": EncodingBase64,
+}
+
+func (d outputDTO) toOutput() (Output, error) {
+	if d.Name == "" {
+		return Output{}, decodeErrf("output has no name")
+	}
+	enc, ok := validEncodings[d.Encoding]
+	if !ok {
+		return Output{}, decodeErrf("output %q: unknown encoding %q", d.Name, d.Encoding)
+	}
+	if d.MimeType == "" {
+		return Output{}, decodeErrf("output %q: missing mimeType", d.Name)
+	}
+	var target PublishTarget
+	switch d.Publish.Target {
+	case "file":
+		target = PublishFile
+		if d.Publish.Path == "" {
+			return Output{}, decodeErrf("output %q: file publish target needs a path", d.Name)
+		}
+	case "none":
+		target = PublishNone
+	default:
+		return Output{}, decodeErrf("output %q: unknown publish target %q", d.Name, d.Publish.Target)
+	}
+	return Output{Name: d.Name, MimeType: d.MimeType, Encoding: enc, Target: target, Path: d.Publish.Path}, nil
+}
+
+// ---- step ----
+
+type stepDTO struct {
+	ID                 string            `yaml:"id"`
+	Kind               string            `yaml:"kind"`
+	ActionRef          string            `yaml:"actionRef"`
+	Args               map[string]string `yaml:"args"`
+	Bindings           map[string]string `yaml:"bindings"`
+	Outputs            []string          `yaml:"outputs"`
+	MaterializesOutput string            `yaml:"materializesOutput"`
+}
+
+func (d stepDTO) toStep() (Step, error) {
+	if d.ID == "" {
+		return Step{}, decodeErrf("step has no id")
+	}
+	var kind StepKind
+	switch d.Kind {
+	case "action-call":
+		kind = KindActionCall
+	case "transform":
+		kind = KindTransform
+	case "llm-seam":
+		kind = KindLLMSeam
+	default:
+		return Step{}, decodeErrf("step %q: unknown kind %q (only action-call, transform, and the marked llm-seam may appear)", d.ID, d.Kind)
+	}
+
+	step := Step{ID: d.ID, Kind: kind, Outputs: d.Outputs, MaterializesOutput: d.MaterializesOutput}
+
+	if kind == KindActionCall {
+		if d.ActionRef == "" {
+			return Step{}, decodeErrf("step %q: action-call has no actionRef", d.ID)
+		}
+		step.ActionRef = d.ActionRef
+		args, err := parseBindings(d.ID, d.Args)
+		if err != nil {
+			return Step{}, err
+		}
+		step.Args = args
+	} else {
+		if d.ActionRef != "" {
+			return Step{}, decodeErrf("step %q: kind %q must not declare an actionRef", d.ID, d.Kind)
+		}
+		binds, err := parseBindings(d.ID, d.Bindings)
+		if err != nil {
+			return Step{}, err
+		}
+		step.Bindings = binds
+	}
+
+	// Every kind requires at least one declared output (schema stepOutputs
+	// minItems:1; action-call's outputs is optional in the schema but the
+	// worked example always declares them, and a step that produces nothing
+	// referenceable is dead). Action-call without outputs is allowed only
+	// when it materializes a declared output (terminal write).
+	if len(step.Outputs) == 0 && step.MaterializesOutput == "" {
+		return Step{}, decodeErrf("step %q: declares no outputs and materializes nothing", d.ID)
+	}
+	if err := uniqueOutputs(d.ID, step.Outputs); err != nil {
+		return Step{}, err
+	}
+	return step, nil
+}
+
+func parseBindings(stepID string, raw map[string]string) (map[string]Binding, error) {
+	if len(raw) == 0 {
+		return nil, nil
+	}
+	out := make(map[string]Binding, len(raw))
+	for name, ref := range raw {
+		b, err := ParseBinding(ref)
+		if err != nil {
+			return nil, decodeErrf("step %q binding %q: %v", stepID, name, err)
+		}
+		out[name] = b
+	}
+	return out, nil
+}
+
+func uniqueOutputs(stepID string, outs []string) error {
+	seen := map[string]bool{}
+	for _, o := range outs {
+		if o == "" {
+			return decodeErrf("step %q: empty output name", stepID)
+		}
+		if seen[o] {
+			return decodeErrf("step %q: duplicate output name %q", stepID, o)
+		}
+		seen[o] = true
+	}
+	return nil
+}

--- a/internal/flightplan/runtime/execute.go
+++ b/internal/flightplan/runtime/execute.go
@@ -102,7 +102,7 @@ func (x *executor) execute(ctx context.Context, inputs ResolvedInputs) (execStat
 // outputs: each declared output name reads from the redacted result by name.
 func (x *executor) runActionCall(ctx context.Context, step Step, args map[string]any, st *execState) (map[string]any, error) {
 	action := x.plan.Actions[step.ActionRef]
-	outcome, err := x.enforcer.dispatch(ctx, action, args, 1)
+	outcome, err := x.enforcer.dispatch(ctx, "step:"+step.ID, action, args, 1)
 	// Record the dispatch even on a deny so the audit reflects the denial.
 	rec := actionDispatch{
 		StepID:            step.ID,
@@ -127,8 +127,15 @@ func (x *executor) runActionCall(ctx context.Context, step Step, args map[string
 		outputs[step.Outputs[0]] = outcome.Result
 		return outputs, nil
 	}
+	// A multi-output action-call reads each declared output from the redacted
+	// result by name. A missing key is a hard error so a nil never slips
+	// through to bypass the downstream presence check.
 	for _, name := range step.Outputs {
-		outputs[name] = outcome.Result[name]
+		v, ok := outcome.Result[name]
+		if !ok {
+			return nil, fmt.Errorf("flightplan: action %q (step %q) result has no declared output %q", step.ActionRef, step.ID, name)
+		}
+		outputs[name] = v
 	}
 	return outputs, nil
 }

--- a/internal/flightplan/runtime/execute.go
+++ b/internal/flightplan/runtime/execute.go
@@ -1,0 +1,168 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+)
+
+// stepResult is the named-output set one step produced, keyed by output name.
+type stepResult map[string]any
+
+// execState carries the accumulating graph state through the walk.
+type execState struct {
+	inputs     ResolvedInputs
+	stepOutput map[string]stepResult // steps.<id> → its outputs
+	// dispatches records the per-action-call outcome (for audit + the run
+	// result), in execution order.
+	dispatches []actionDispatch
+	// artifacts records materialized output artifacts, in execution order.
+	artifacts []Artifact
+}
+
+// actionDispatch records one action-call's enforced outcome for the audit.
+type actionDispatch struct {
+	StepID            string
+	ActionRef         string
+	Effect            Effect
+	ApprovalRequested bool
+	Approved          bool
+	Result            map[string]any
+	AuditFields       []string
+	Sink              string
+}
+
+// executor walks the topologically-ordered step graph. It has EXACTLY three
+// kind branches (action-call, transform, llm-seam). The action-call and
+// transform branches hold no reference to the seam type, so no deterministic
+// step can reach an LLM. Only the llm-seam branch calls runSeam, and that
+// errors by default in v1.
+type executor struct {
+	plan      *Plan
+	enforcer  *enforcer
+	transform *TransformRegistry
+	seam      LLMSeam
+}
+
+// execute runs Phase B: it walks p.Order, executes each step against the
+// resolved inputs and accumulated step outputs, materializes declared
+// artifacts, and returns the final state. A step error aborts the walk (no
+// later step runs) and is returned to the caller.
+func (x *executor) execute(ctx context.Context, inputs ResolvedInputs) (execState, error) {
+	st := execState{
+		inputs:     inputs,
+		stepOutput: map[string]stepResult{},
+	}
+	for _, idx := range x.plan.Order {
+		step := x.plan.Steps[idx]
+		resolved, err := x.resolveBindings(step, st)
+		if err != nil {
+			return st, err
+		}
+
+		var outputs map[string]any
+		switch step.Kind {
+		case KindActionCall:
+			outputs, err = x.runActionCall(ctx, step, resolved, &st)
+		case KindTransform:
+			outputs, err = x.transform.run(step, resolved)
+		case KindLLMSeam:
+			outputs, err = runSeam(ctx, x.seam, step, resolved)
+		default:
+			// Unreachable: decode validated the closed kind enum.
+			err = fmt.Errorf("flightplan: step %q has unhandled kind %q", step.ID, step.Kind)
+		}
+		if err != nil {
+			return st, err
+		}
+
+		// Every declared output must be produced so downstream bindings
+		// resolve. (runSeam already checks this for the seam; action-call and
+		// transform are checked here.)
+		for _, name := range step.Outputs {
+			if _, ok := outputs[name]; !ok {
+				return st, fmt.Errorf("flightplan: step %q did not produce declared output %q", step.ID, name)
+			}
+		}
+		st.stepOutput[step.ID] = stepResult(outputs)
+
+		// Materialize a declared output artifact when the step wires one.
+		if step.MaterializesOutput != "" {
+			art, err := materialize(x.plan, step, outputs)
+			if err != nil {
+				return st, err
+			}
+			st.artifacts = append(st.artifacts, art)
+		}
+	}
+	return st, nil
+}
+
+// runActionCall dispatches an action-call through the enforced boundary and
+// records the dispatch for the audit. The redacted result becomes the step's
+// outputs: each declared output name reads from the redacted result by name.
+func (x *executor) runActionCall(ctx context.Context, step Step, args map[string]any, st *execState) (map[string]any, error) {
+	action := x.plan.Actions[step.ActionRef]
+	outcome, err := x.enforcer.dispatch(ctx, action, args, 1)
+	// Record the dispatch even on a deny so the audit reflects the denial.
+	rec := actionDispatch{
+		StepID:            step.ID,
+		ActionRef:         step.ActionRef,
+		Effect:            action.TrustContract.Effect,
+		ApprovalRequested: outcome.ApprovalRequested,
+		Approved:          outcome.Approved,
+		Result:            outcome.Result,
+		AuditFields:       action.TrustContract.Audit.Fields,
+		Sink:              action.TrustContract.Audit.Sink,
+	}
+	st.dispatches = append(st.dispatches, rec)
+	if err != nil {
+		return nil, err
+	}
+
+	// Map the redacted result to the step's declared outputs. A single
+	// declared output reads the whole redacted result; otherwise each output
+	// reads the same-named field from the result.
+	outputs := make(map[string]any, len(step.Outputs))
+	if len(step.Outputs) == 1 {
+		outputs[step.Outputs[0]] = outcome.Result
+		return outputs, nil
+	}
+	for _, name := range step.Outputs {
+		outputs[name] = outcome.Result[name]
+	}
+	return outputs, nil
+}
+
+// resolveBindings resolves a step's binding map into concrete values against
+// the resolved inputs and accumulated prior step outputs. A binding can only
+// reference an already-resolved input or an already-executed step (guaranteed
+// by the topological order), so a missing value here is an internal invariant
+// violation, not user error.
+func (x *executor) resolveBindings(step Step, st execState) (map[string]any, error) {
+	binds := step.binds()
+	if len(binds) == 0 {
+		return map[string]any{}, nil
+	}
+	out := make(map[string]any, len(binds))
+	for name, b := range binds {
+		switch b.Kind {
+		case BindInput:
+			v, ok := st.inputs.Values[b.Name]
+			if !ok {
+				return nil, fmt.Errorf("flightplan: step %q binding %q: input %q was not resolved", step.ID, name, b.Name)
+			}
+			out[name] = v
+		case BindStep:
+			sr, ok := st.stepOutput[b.StepID]
+			if !ok {
+				return nil, fmt.Errorf("flightplan: step %q binding %q: step %q output not available (walk order invariant)", step.ID, name, b.StepID)
+			}
+			v, ok := sr[b.Output]
+			if !ok {
+				return nil, fmt.Errorf("flightplan: step %q binding %q: step %q has no output %q", step.ID, name, b.StepID, b.Output)
+			}
+			out[name] = v
+		}
+	}
+	return out, nil
+}

--- a/internal/flightplan/runtime/execute_test.go
+++ b/internal/flightplan/runtime/execute_test.go
@@ -1,0 +1,163 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+)
+
+// fixturePlan builds an in-memory plan that mirrors the worked example's
+// shape: a read action-call, a transform that materializes a CSV, an llm-seam,
+// and a write action-call that materializes JSON. It is the integration
+// fixture for execute/run/audit tests, decoupled from on-disk freeze so the
+// executor's behavior can be exercised directly.
+func fixturePlan() *Plan {
+	mb := func(s string) Binding { b, _ := ParseBinding(s); return b }
+	p := &Plan{
+		Name: "weekly-metrics-digest",
+		Actions: map[string]Action{
+			"aileron:metrics.query_series": {
+				Ref: "aileron:metrics.query_series",
+				TrustContract: TrustContract{
+					Effect: EffectRead, Hosts: []string{"api.example.com"},
+					Idempotency: Idempotency{SafeToRetry: true},
+					Audit:       AuditStructure{Fields: []string{"operation-effect", "approval-decision", "result"}, Sink: "audit/reads"},
+				},
+			},
+			"aileron:tracker.create_issue": {
+				Ref: "aileron:tracker.create_issue",
+				TrustContract: TrustContract{
+					Effect: EffectWrite, Hosts: []string{"tracker.example.com"},
+					Idempotency: Idempotency{SafeToRetry: false, IdempotencyKey: true},
+					Audit:       AuditStructure{Fields: []string{"operation-effect", "approval-decision", "result"}, Sink: "audit/writes"},
+				},
+			},
+		},
+		Outputs: map[string]Output{
+			"digest.csv":       {Name: "digest.csv", MimeType: "text/csv", Encoding: EncodingUTF8, Target: PublishFile, Path: "digest.csv"},
+			"filed_issue.json": {Name: "filed_issue.json", MimeType: "application/json", Encoding: EncodingUTF8, Target: PublishFile, Path: "filed_issue.json"},
+		},
+		Inputs: []Input{
+			{Name: "window_days", Type: "number", Resolution: Resolution{Rule: ResolutionLiteral, HasDefault: true, Default: 7}},
+		},
+		Steps: []Step{
+			{ID: "query_metrics", Kind: KindActionCall, ActionRef: "aileron:metrics.query_series",
+				Args: map[string]Binding{"window_days": mb("inputs.window_days")}, Outputs: []string{"series"}},
+			{ID: "render_csv", Kind: KindTransform,
+				Bindings: map[string]Binding{"series": mb("steps.query_metrics.series")},
+				Outputs:  []string{"file"}, MaterializesOutput: "digest.csv"},
+			{ID: "summarize", Kind: KindLLMSeam,
+				Bindings: map[string]Binding{"series": mb("steps.query_metrics.series")}, Outputs: []string{"issue_body"}},
+			{ID: "file_issue", Kind: KindActionCall, ActionRef: "aileron:tracker.create_issue",
+				Args:    map[string]Binding{"body": mb("steps.summarize.issue_body")},
+				Outputs: []string{"file"}, MaterializesOutput: "filed_issue.json"},
+		},
+	}
+	order, err := topoSort(p, map[string]int{"query_metrics": 0, "render_csv": 1, "summarize": 2, "file_issue": 3})
+	if err != nil {
+		panic(err)
+	}
+	p.Order = order
+	return p
+}
+
+// csvTransform emits a file-map for the digest.csv output deterministically.
+func csvTransformRegistry() *TransformRegistry {
+	reg := NewTransformRegistry()
+	return reg
+}
+
+// runFixture wires the fixture plan with fakes that produce the file-maps the
+// materializing steps need. The transform that materializes digest.csv and the
+// action-call that materializes filed_issue.json both emit file-map carriers.
+func runFixture(t *testing.T, opts Options) (RunResult, *dispatchRouter, *recordingSink) {
+	t.Helper()
+	p := fixturePlan()
+
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {
+			"path": "filed_issue.json", "mimeType": "application/json", "encoding": "utf-8",
+			"content": `{"url":"https://tracker.example.com/issues/1"}`,
+		},
+	}}
+	sink := &recordingSink{}
+	reg := csvTransformRegistry()
+	// The render_csv transform forwards its single binding; to materialize a
+	// CSV file-map deterministically, register a transform keyed for the step.
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{
+			"path": "digest.csv", "mimeType": "text/csv", "encoding": "utf-8", "content": "name\ncpu\n",
+		}}, nil
+	})
+
+	o := Options{
+		Dispatcher: disp,
+		Approver:   &fakeApprover{decision: Decision{Approved: true}},
+		Audit:      sink,
+		Seam:       fakeSeam{out: map[string]any{"issue_body": "A short digest."}},
+		Clock:      FixedClock{},
+		Transforms: reg,
+	}
+	if opts.OutDir != "" {
+		o.OutDir = opts.OutDir
+	}
+	if opts.Inputs != nil {
+		o.Inputs = opts.Inputs
+	}
+	if opts.Seam != nil {
+		o.Seam = opts.Seam
+	}
+	res, err := runPlan(context.Background(), p, "sha256:test", o)
+	if err != nil {
+		t.Fatalf("runPlan: %v", err)
+	}
+	return res, disp, sink
+}
+
+// dispatchRouter returns a per-ref canned result, so a multi-action plan gets
+// distinct results per action.
+type dispatchRouter struct {
+	fakeDispatcher
+	results map[string]map[string]any
+}
+
+func (d *dispatchRouter) Dispatch(ctx context.Context, ref string, args map[string]any) (DispatchResult, error) {
+	d.calls = append(d.calls, dispatchCall{ref: ref, args: args})
+	return DispatchResult{Output: d.results[ref]}, nil
+}
+
+// recordingSink records every audit record it receives.
+type recordingSink struct {
+	records []AuditRecord
+}
+
+func (s *recordingSink) Record(_ context.Context, rec AuditRecord) string {
+	s.records = append(s.records, rec)
+	return "audit-" + rec.ActionRef
+}
+
+func TestExecute_WorkedExampleEndToEnd(t *testing.T) {
+	res, disp, _ := runFixture(t, Options{})
+	// Both action-calls dispatched, in topo order.
+	if len(disp.calls) != 2 {
+		t.Fatalf("want 2 dispatches, got %d", len(disp.calls))
+	}
+	if disp.calls[0].ref != "aileron:metrics.query_series" {
+		t.Errorf("first dispatch = %q", disp.calls[0].ref)
+	}
+	if disp.calls[1].ref != "aileron:tracker.create_issue" {
+		t.Errorf("second dispatch = %q", disp.calls[1].ref)
+	}
+	// Two artifacts materialized.
+	if len(res.Artifacts) != 2 {
+		t.Fatalf("want 2 artifacts, got %d", len(res.Artifacts))
+	}
+}
+
+func TestExecute_WriteThreadsIdempotencyKey(t *testing.T) {
+	_, disp, _ := runFixture(t, Options{})
+	writeArgs := disp.calls[1].args
+	if _, ok := writeArgs[idempotencyKeyField]; !ok {
+		t.Error("the write action (idempotencyKey:true) must thread a stable key")
+	}
+}

--- a/internal/flightplan/runtime/execute_test.go
+++ b/internal/flightplan/runtime/execute_test.go
@@ -161,3 +161,39 @@ func TestExecute_WriteThreadsIdempotencyKey(t *testing.T) {
 		t.Error("the write action (idempotencyKey:true) must thread a stable key")
 	}
 }
+
+func TestExecute_MultiOutputActionMissingFieldErrors(t *testing.T) {
+	p := &Plan{
+		Name:    "t",
+		Actions: map[string]Action{"aileron:m.read": readAction("aileron:m.read")},
+		Outputs: map[string]Output{},
+		Steps: []Step{
+			{ID: "s", Kind: KindActionCall, ActionRef: "aileron:m.read", Outputs: []string{"a", "b"}},
+		},
+	}
+	p.Order = []int{0}
+	x := &executor{
+		plan:      p,
+		enforcer:  &enforcer{dispatcher: &fakeDispatcher{result: map[string]any{"a": 1}}, approver: &fakeApprover{}},
+		transform: NewTransformRegistry(),
+	}
+	if _, err := x.execute(context.Background(), ResolvedInputs{Values: map[string]any{}}); err == nil {
+		t.Fatal("a multi-output action result missing a declared output must error")
+	}
+}
+
+func TestExecute_TransformMissingDeclaredOutputErrors(t *testing.T) {
+	p := &Plan{
+		Name: "t", Actions: map[string]Action{}, Outputs: map[string]Output{},
+		Steps: []Step{{ID: "s", Kind: KindTransform, Outputs: []string{"a", "b"}}},
+	}
+	p.Order = []int{0}
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(_ map[string]any, _ []string) (map[string]any, error) {
+		return map[string]any{"a": 1}, nil // omits "b"
+	})
+	x := &executor{plan: p, enforcer: &enforcer{}, transform: reg}
+	if _, err := x.execute(context.Background(), ResolvedInputs{Values: map[string]any{}}); err == nil {
+		t.Fatal("a transform that omits a declared output must error")
+	}
+}

--- a/internal/flightplan/runtime/inputs.go
+++ b/internal/flightplan/runtime/inputs.go
@@ -113,7 +113,7 @@ func resolveSource(ctx context.Context, p *Plan, in Input, e *enforcer) (any, So
 	if !ok {
 		return nil, SourceBinding{}, fmt.Errorf("input %q: source action %q is not declared in requires.actions", in.Name, ref)
 	}
-	out, err := e.dispatch(ctx, action, map[string]any{}, 1)
+	out, err := e.dispatch(ctx, "input:"+in.Name, action, map[string]any{}, 1)
 	if err != nil {
 		return nil, SourceBinding{}, fmt.Errorf("input %q: resolve from source %q: %w", in.Name, ref, err)
 	}

--- a/internal/flightplan/runtime/inputs.go
+++ b/internal/flightplan/runtime/inputs.go
@@ -60,7 +60,10 @@ func resolveInputs(ctx context.Context, p *Plan, args LaunchArgs, clk Clock, e *
 			if err != nil {
 				return ResolvedInputs{}, err
 			}
-			ri.Values[in.Name] = val
+			// Deep-copy so the frozen resolved set never aliases the caller's
+			// launch args or the declared default: a downstream step that
+			// mutates an input value can never reach back into the source.
+			ri.Values[in.Name] = deepCopyValue(val)
 		case ResolutionDynamic:
 			ri.Values[in.Name] = resolveDynamic(in, launchTime)
 		case ResolutionSource:
@@ -68,7 +71,8 @@ func resolveInputs(ctx context.Context, p *Plan, args LaunchArgs, clk Clock, e *
 			if err != nil {
 				return ResolvedInputs{}, err
 			}
-			ri.Values[in.Name] = val
+			// Deep-copy so the resolved set does not alias the dispatch result.
+			ri.Values[in.Name] = deepCopyValue(val)
 			ri.SourceBindings[in.Name] = sb
 		default:
 			return ResolvedInputs{}, fmt.Errorf("input %q: unhandled resolution rule %q", in.Name, in.Resolution.Rule)

--- a/internal/flightplan/runtime/inputs.go
+++ b/internal/flightplan/runtime/inputs.go
@@ -1,0 +1,164 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// ResolvedInputs is the frozen, read-only set of input values produced once at
+// the launch boundary (#1523). Phase B (the DAG walk) consumes it without
+// re-resolving: a dynamic input is read from the clock exactly once, so two
+// steps reading the same input see one value.
+type ResolvedInputs struct {
+	// Values maps input name → resolved value.
+	Values map[string]any
+	// SourceBindings records, per source input, the resolved binding the read
+	// was recorded by (action ref + select), never the dataset inline. This
+	// is what the audit references (ADR-0027 audit boundary).
+	SourceBindings map[string]SourceBinding
+}
+
+// SourceBinding is the audit-safe record of a source input resolution: the
+// action ref and selector that produced it. The resolved dataset is never
+// stored inline here.
+type SourceBinding struct {
+	ActionRef string
+	Select    string
+}
+
+// LaunchArgs are the literal input overrides supplied at launch (the
+// `--input name=value` CLI flags). A literal input takes its launch override,
+// then its declared default; a missing required literal (no override, no
+// default) is an error.
+type LaunchArgs map[string]any
+
+// resolveInputs runs Phase A: it resolves every declared input ONCE into a
+// concrete ResolvedInputs set. literal → launch arg or default; dynamic → a
+// single read of the injected clock (now/today); source → one dispatch through
+// the enforced action boundary, recorded by resolved binding.
+//
+// The clock is read at most once and the value reused for every dynamic input,
+// so the launch-boundary straddle (#1523) cannot give two steps different
+// clock values.
+func resolveInputs(ctx context.Context, p *Plan, args LaunchArgs, clk Clock, e *enforcer) (ResolvedInputs, error) {
+	if args == nil {
+		args = LaunchArgs{}
+	}
+	ri := ResolvedInputs{
+		Values:         map[string]any{},
+		SourceBindings: map[string]SourceBinding{},
+	}
+
+	// Read the clock once at the boundary; reuse for every dynamic input.
+	launchTime := clk.Now()
+
+	for _, in := range p.Inputs {
+		switch in.Resolution.Rule {
+		case ResolutionLiteral:
+			val, err := resolveLiteral(in, args)
+			if err != nil {
+				return ResolvedInputs{}, err
+			}
+			ri.Values[in.Name] = val
+		case ResolutionDynamic:
+			ri.Values[in.Name] = resolveDynamic(in, launchTime)
+		case ResolutionSource:
+			val, sb, err := resolveSource(ctx, p, in, e)
+			if err != nil {
+				return ResolvedInputs{}, err
+			}
+			ri.Values[in.Name] = val
+			ri.SourceBindings[in.Name] = sb
+		default:
+			return ResolvedInputs{}, fmt.Errorf("input %q: unhandled resolution rule %q", in.Name, in.Resolution.Rule)
+		}
+	}
+	return ri, nil
+}
+
+// resolveLiteral resolves a literal input: the launch override wins, then the
+// declared default. A literal with neither is a missing required input.
+func resolveLiteral(in Input, args LaunchArgs) (any, error) {
+	if v, ok := args[in.Name]; ok {
+		return v, nil
+	}
+	if in.Resolution.HasDefault {
+		return in.Resolution.Default, nil
+	}
+	return nil, fmt.Errorf("input %q is required: pass it at launch (it declares no default)", in.Name)
+}
+
+// resolveDynamic reads the single launch-time clock value. `now` resolves to
+// the RFC3339 launch timestamp; `today` resolves to the launch date.
+func resolveDynamic(in Input, launchTime time.Time) any {
+	switch in.Resolution.DynamicValue {
+	case "now":
+		return launchTime.Format(time.RFC3339)
+	case "today":
+		return launchTime.Format("2006-01-02")
+	default:
+		// Decode validated the value; this branch is unreachable.
+		return launchTime.Format(time.RFC3339)
+	}
+}
+
+// resolveSource resolves a source input by ONE dispatch through the enforced
+// action boundary, applying the select and recording the resolved binding.
+// The source read is NOT a step and not a graph edge (#1523): it is resolved
+// in Phase A, before the DAG walk.
+func resolveSource(ctx context.Context, p *Plan, in Input, e *enforcer) (any, SourceBinding, error) {
+	ref := in.Resolution.SourceActionRef
+	action, ok := p.Actions[ref]
+	if !ok {
+		return nil, SourceBinding{}, fmt.Errorf("input %q: source action %q is not declared in requires.actions", in.Name, ref)
+	}
+	out, err := e.dispatch(ctx, action, map[string]any{}, 1)
+	if err != nil {
+		return nil, SourceBinding{}, fmt.Errorf("input %q: resolve from source %q: %w", in.Name, ref, err)
+	}
+	sb := SourceBinding{ActionRef: ref, Select: in.Resolution.SourceSelect}
+	val := applySelect(out.Result, in.Resolution.SourceSelect)
+	return val, sb, nil
+}
+
+// applySelect applies the source selector to a dispatch result. v1 supports a
+// dotted path with the `[]` array-element wildcard (the same grammar redaction
+// uses), returning the selected value. An empty selector returns the whole
+// result. A selector that matches nothing returns nil.
+func applySelect(result map[string]any, sel string) any {
+	if sel == "" {
+		return result
+	}
+	return selectPath(any(result), parsePath(sel))
+}
+
+// selectPath walks a select path, collecting array-wildcard results into a
+// slice so `series[].name` yields every series name.
+func selectPath(node any, segs []pathSeg) any {
+	if len(segs) == 0 {
+		return node
+	}
+	seg := segs[0]
+	m, ok := node.(map[string]any)
+	if !ok {
+		return nil
+	}
+	child, present := m[seg.key]
+	if !present {
+		return nil
+	}
+	if seg.wildcard {
+		arr, ok := child.([]any)
+		if !ok {
+			return nil
+		}
+		rest := segs[1:]
+		out := make([]any, 0, len(arr))
+		for _, el := range arr {
+			out = append(out, selectPath(el, rest))
+		}
+		return out
+	}
+	return selectPath(child, segs[1:])
+}

--- a/internal/flightplan/runtime/inputs_test.go
+++ b/internal/flightplan/runtime/inputs_test.go
@@ -1,0 +1,132 @@
+package runtime
+
+import (
+	"context"
+	"testing"
+	"time"
+)
+
+func planWithInputs(inputs []Input, actions map[string]Action) *Plan {
+	if actions == nil {
+		actions = map[string]Action{}
+	}
+	return &Plan{Name: "t", Inputs: inputs, Actions: actions, Outputs: map[string]Output{}}
+}
+
+func TestResolveInputs_LiteralDefaultAndOverride(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "window", Type: "number", Resolution: Resolution{Rule: ResolutionLiteral, HasDefault: true, Default: 7}},
+	}, nil)
+
+	// Default applies when no override.
+	ri, err := resolveInputs(context.Background(), p, nil, FixedClock{}, &enforcer{})
+	if err != nil {
+		t.Fatalf("resolveInputs: %v", err)
+	}
+	if ri.Values["window"] != 7 {
+		t.Errorf("default not applied: %v", ri.Values["window"])
+	}
+
+	// Override wins.
+	ri, err = resolveInputs(context.Background(), p, LaunchArgs{"window": 30}, FixedClock{}, &enforcer{})
+	if err != nil {
+		t.Fatalf("resolveInputs: %v", err)
+	}
+	if ri.Values["window"] != 30 {
+		t.Errorf("override not applied: %v", ri.Values["window"])
+	}
+}
+
+func TestResolveInputs_MissingRequiredLiteralErrors(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "req", Type: "string", Resolution: Resolution{Rule: ResolutionLiteral}},
+	}, nil)
+	if _, err := resolveInputs(context.Background(), p, nil, FixedClock{}, &enforcer{}); err == nil {
+		t.Fatal("a required literal with no default and no override must error")
+	}
+}
+
+func TestResolveInputs_DynamicResolvedOnce(t *testing.T) {
+	fixed := time.Date(2026, 6, 24, 15, 4, 5, 0, time.UTC)
+	p := planWithInputs([]Input{
+		{Name: "now_ts", Type: "timestamp", Resolution: Resolution{Rule: ResolutionDynamic, DynamicValue: "now"}},
+		{Name: "today", Type: "string", Resolution: Resolution{Rule: ResolutionDynamic, DynamicValue: "today"}},
+	}, nil)
+	ri, err := resolveInputs(context.Background(), p, nil, FixedClock{T: fixed}, &enforcer{})
+	if err != nil {
+		t.Fatalf("resolveInputs: %v", err)
+	}
+	if ri.Values["now_ts"] != "2026-06-24T15:04:05Z" {
+		t.Errorf("now = %v", ri.Values["now_ts"])
+	}
+	if ri.Values["today"] != "2026-06-24" {
+		t.Errorf("today = %v", ri.Values["today"])
+	}
+}
+
+// countingClock counts Now() calls so we can prove the runtime reads the clock
+// once at the launch boundary (#1523), not per-input or per-step.
+type countingClock struct {
+	t     time.Time
+	calls int
+}
+
+func (c *countingClock) Now() time.Time {
+	c.calls++
+	return c.t
+}
+
+func TestResolveInputs_ClockReadOnce(t *testing.T) {
+	clk := &countingClock{t: time.Unix(0, 0).UTC()}
+	p := planWithInputs([]Input{
+		{Name: "a", Type: "timestamp", Resolution: Resolution{Rule: ResolutionDynamic, DynamicValue: "now"}},
+		{Name: "b", Type: "timestamp", Resolution: Resolution{Rule: ResolutionDynamic, DynamicValue: "now"}},
+		{Name: "c", Type: "string", Resolution: Resolution{Rule: ResolutionDynamic, DynamicValue: "today"}},
+	}, nil)
+	if _, err := resolveInputs(context.Background(), p, nil, clk, &enforcer{}); err != nil {
+		t.Fatalf("resolveInputs: %v", err)
+	}
+	if clk.calls != 1 {
+		t.Errorf("clock read %d times, want exactly 1 (launch-boundary single read)", clk.calls)
+	}
+}
+
+func TestResolveInputs_SourceRecordedByBindingNotDataset(t *testing.T) {
+	ref := "aileron:metrics.query_series"
+	actions := map[string]Action{ref: {Ref: ref, TrustContract: TrustContract{Effect: EffectRead, Hosts: []string{"h"}}}}
+	p := planWithInputs([]Input{
+		{Name: "live", Type: "array", Resolution: Resolution{Rule: ResolutionSource, SourceActionRef: ref, SourceSelect: "series[].name"}},
+	}, actions)
+
+	disp := &fakeDispatcher{result: map[string]any{
+		"series": []any{
+			map[string]any{"name": "cpu"},
+			map[string]any{"name": "mem"},
+		},
+	}}
+	enf := &enforcer{dispatcher: disp, approver: &fakeApprover{}}
+	ri, err := resolveInputs(context.Background(), p, nil, FixedClock{}, enf)
+	if err != nil {
+		t.Fatalf("resolveInputs: %v", err)
+	}
+	// The select extracted the series names.
+	got, ok := ri.Values["live"].([]any)
+	if !ok || len(got) != 2 || got[0] != "cpu" || got[1] != "mem" {
+		t.Errorf("select result = %v", ri.Values["live"])
+	}
+	// The audit binding records the action + select, never the dataset.
+	sb, ok := ri.SourceBindings["live"]
+	if !ok || sb.ActionRef != ref || sb.Select != "series[].name" {
+		t.Errorf("source binding = %+v", sb)
+	}
+}
+
+func TestResolveInputs_SourceUndeclaredActionErrors(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "live", Type: "array", Resolution: Resolution{Rule: ResolutionSource, SourceActionRef: "aileron:ghost.read"}},
+	}, nil)
+	enf := &enforcer{dispatcher: &fakeDispatcher{}, approver: &fakeApprover{}}
+	if _, err := resolveInputs(context.Background(), p, nil, FixedClock{}, enf); err == nil {
+		t.Fatal("a source input naming an undeclared action must error")
+	}
+}

--- a/internal/flightplan/runtime/inputs_test.go
+++ b/internal/flightplan/runtime/inputs_test.go
@@ -130,3 +130,20 @@ func TestResolveInputs_SourceUndeclaredActionErrors(t *testing.T) {
 		t.Fatal("a source input naming an undeclared action must error")
 	}
 }
+
+func TestResolveInputs_FrozenFromLaunchArgMutation(t *testing.T) {
+	p := planWithInputs([]Input{
+		{Name: "obj", Type: "object", Resolution: Resolution{Rule: ResolutionLiteral}},
+	}, nil)
+	arg := map[string]any{"k": "v"}
+	ri, err := resolveInputs(context.Background(), p, LaunchArgs{"obj": arg}, FixedClock{}, &enforcer{})
+	if err != nil {
+		t.Fatalf("resolveInputs: %v", err)
+	}
+	// Mutating the launch arg after resolution must not change the frozen set.
+	arg["k"] = "tampered"
+	got := ri.Values["obj"].(map[string]any)
+	if got["k"] != "v" {
+		t.Error("resolved inputs must be frozen against later launch-arg mutation")
+	}
+}

--- a/internal/flightplan/runtime/inputs_test.go
+++ b/internal/flightplan/runtime/inputs_test.go
@@ -147,3 +147,40 @@ func TestResolveInputs_FrozenFromLaunchArgMutation(t *testing.T) {
 		t.Error("resolved inputs must be frozen against later launch-arg mutation")
 	}
 }
+
+func TestApplySelect_EmptyReturnsWholeResult(t *testing.T) {
+	res := map[string]any{"a": 1}
+	got := applySelect(res, "")
+	if m, ok := got.(map[string]any); !ok || m["a"] != 1 {
+		t.Errorf("empty select must return the whole result, got %v", got)
+	}
+}
+
+func TestApplySelect_MissingPathReturnsNil(t *testing.T) {
+	if got := applySelect(map[string]any{"a": 1}, "b.c"); got != nil {
+		t.Errorf("a select that matches nothing must return nil, got %v", got)
+	}
+}
+
+func TestApplySelect_NestedScalar(t *testing.T) {
+	res := map[string]any{"meta": map[string]any{"id": "x"}}
+	if got := applySelect(res, "meta.id"); got != "x" {
+		t.Errorf("nested select = %v, want x", got)
+	}
+}
+
+func TestResolveInputs_SourceSelectMissingYieldsNil(t *testing.T) {
+	ref := "aileron:m.read"
+	actions := map[string]Action{ref: {Ref: ref, TrustContract: TrustContract{Effect: EffectRead, Hosts: []string{"h"}}}}
+	p := planWithInputs([]Input{
+		{Name: "x", Type: "string", Resolution: Resolution{Rule: ResolutionSource, SourceActionRef: ref, SourceSelect: "missing.path"}},
+	}, actions)
+	enf := &enforcer{dispatcher: &fakeDispatcher{result: map[string]any{"present": 1}}, approver: &fakeApprover{}}
+	ri, err := resolveInputs(context.Background(), p, nil, FixedClock{}, enf)
+	if err != nil {
+		t.Fatalf("resolveInputs: %v", err)
+	}
+	if ri.Values["x"] != nil {
+		t.Errorf("a select that matches nothing must resolve to nil, got %v", ri.Values["x"])
+	}
+}

--- a/internal/flightplan/runtime/load.go
+++ b/internal/flightplan/runtime/load.go
@@ -1,0 +1,62 @@
+package runtime
+
+import (
+	"fmt"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/manifest"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+// LoadError reports a load/verify refusal. A frozen unit that fails
+// verification returns a *LoadError and runs zero steps.
+type LoadError struct {
+	Reason string
+}
+
+func (e *LoadError) Error() string { return "flightplan load: " + e.Reason }
+
+// LoadedPlan is a verified, decoded plan ready to run, plus the verified
+// content hash for the audit trail.
+type LoadedPlan struct {
+	Plan        *Plan
+	ContentHash string
+}
+
+// LoadVerified loads a frozen skill version from the store, verifies it
+// (signature + content hash), parses the verified manifest, and decodes it
+// into a typed Plan. Any verification failure or decode refusal returns an
+// error and the runtime runs no step.
+//
+// The verification gate (#1509/#1511) is the security boundary: a tampered
+// manifest, a flipped signature, or a content-hash mismatch all refuse before
+// execution. Verification reuses freeze.VerifyFrozen so the canonical-bytes
+// reconstruction lives in exactly one place.
+func LoadVerified(s *store.Store, name, id string) (LoadedPlan, error) {
+	if s == nil {
+		return LoadedPlan{}, &LoadError{Reason: "nil store"}
+	}
+	fv, err := s.ReadFrozen(name, id)
+	if err != nil {
+		return LoadedPlan{}, &LoadError{Reason: fmt.Sprintf("read frozen version %s/%s: %v", name, id, err)}
+	}
+	return verifyAndDecode(fv)
+}
+
+// verifyAndDecode is the verify→parse→decode core, factored out so tests can
+// drive it from an in-memory FrozenVersion without a store on disk.
+func verifyAndDecode(fv store.FrozenVersion) (LoadedPlan, error) {
+	verified, err := freeze.VerifyFrozen(fv.SkillMD, fv.Lockfile, fv.Signature, fv.PublicKey)
+	if err != nil {
+		return LoadedPlan{}, &LoadError{Reason: err.Error()}
+	}
+	m, err := manifest.Parse(verified.SkillMD)
+	if err != nil {
+		return LoadedPlan{}, &LoadError{Reason: fmt.Sprintf("parse verified manifest: %v", err)}
+	}
+	plan, err := Decode(m)
+	if err != nil {
+		return LoadedPlan{}, err
+	}
+	return LoadedPlan{Plan: plan, ContentHash: verified.ContentHash}, nil
+}

--- a/internal/flightplan/runtime/load_test.go
+++ b/internal/flightplan/runtime/load_test.go
@@ -1,0 +1,132 @@
+package runtime
+
+import (
+	"bytes"
+	"context"
+	"crypto/ed25519"
+	"crypto/rand"
+	"crypto/x509"
+	"encoding/pem"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/freeze"
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+// frozenExample freezes the committed worked example with a fresh signing key
+// and returns the store.FrozenVersion the runtime loads. This is the shared
+// fixture for load + run tests: the bytes are exactly what `skill freeze`
+// would persist.
+func frozenExample(t *testing.T) store.FrozenVersion {
+	t.Helper()
+	_, priv, err := ed25519.GenerateKey(rand.Reader)
+	if err != nil {
+		t.Fatalf("GenerateKey: %v", err)
+	}
+	der, err := x509.MarshalPKCS8PrivateKey(priv)
+	if err != nil {
+		t.Fatalf("MarshalPKCS8PrivateKey: %v", err)
+	}
+	keyPath := filepath.Join(t.TempDir(), "signing-key.pem")
+	if err := os.WriteFile(keyPath, pem.EncodeToMemory(&pem.Block{Type: "PRIVATE KEY", Bytes: der}), 0o600); err != nil {
+		t.Fatalf("write key: %v", err)
+	}
+
+	raw, err := os.ReadFile(filepath.Join(repoRoot(t), "docs", "schema", "flight-plan-manifest.example.skill.md"))
+	if err != nil {
+		t.Fatalf("read worked example: %v", err)
+	}
+	res, err := freeze.Run(context.Background(), raw, freeze.Options{
+		Version:        "1.0.0",
+		SigningKeyPath: keyPath,
+		Composer: freeze.FeatureComposerFunc(func(_ context.Context, _ []string) (string, error) {
+			return "sha256:" + strings.Repeat("a", 64), nil
+		}),
+	})
+	if err != nil {
+		t.Fatalf("freeze.Run: %v", err)
+	}
+	return store.FrozenVersion{
+		ID:        "test",
+		SkillMD:   res.FrozenManifest,
+		Lockfile:  res.Lockfile,
+		Signature: res.Signature,
+		PublicKey: res.PublicKey,
+	}
+}
+
+func TestLoadVerified_UntamperedLoads(t *testing.T) {
+	fv := frozenExample(t)
+	lp, err := verifyAndDecode(fv)
+	if err != nil {
+		t.Fatalf("verifyAndDecode rejected an untampered unit: %v", err)
+	}
+	if lp.Plan == nil || lp.Plan.Name != "weekly-metrics-digest" {
+		t.Fatalf("decoded plan = %+v", lp.Plan)
+	}
+	if !strings.HasPrefix(lp.ContentHash, "sha256:") {
+		t.Errorf("content hash = %q", lp.ContentHash)
+	}
+}
+
+func TestLoadVerified_TamperedManifestRefuses(t *testing.T) {
+	fv := frozenExample(t)
+	fv.SkillMD = bytes.Replace(fv.SkillMD, []byte("Weekly Metrics Digest"), []byte("Weekly Metrics Digesz"), 1)
+	if _, err := verifyAndDecode(fv); err == nil {
+		t.Fatal("a tampered manifest must refuse to load")
+	}
+}
+
+func TestLoadVerified_FlippedSignatureRefuses(t *testing.T) {
+	fv := frozenExample(t)
+	fv.Signature = append([]byte(nil), fv.Signature...)
+	fv.Signature[0] ^= 0xFF
+	if _, err := verifyAndDecode(fv); err == nil {
+		t.Fatal("a flipped signature must refuse to load")
+	}
+}
+
+func TestLoadVerified_ContentHashMismatchRefuses(t *testing.T) {
+	fv := frozenExample(t)
+	// Find and corrupt the recorded contentHash in the lockfile only, leaving
+	// the manifest's recorded hash intact: the recomputed hash will diverge
+	// because the lockfile bytes changed.
+	fv.Lockfile = bytes.Replace(fv.Lockfile, []byte("resolvedCapabilitySet"), []byte("resolvedCapabilityseT"), 1)
+	if _, err := verifyAndDecode(fv); err == nil {
+		t.Fatal("a lockfile content change must refuse to load")
+	}
+}
+
+func TestLoadVerified_MissingPublicKeyRefuses(t *testing.T) {
+	fv := frozenExample(t)
+	fv.PublicKey = []byte("not a pem key")
+	if _, err := verifyAndDecode(fv); err == nil {
+		t.Fatal("a missing/invalid public key must refuse to load")
+	}
+}
+
+func TestLoadVerified_FromStore(t *testing.T) {
+	fv := frozenExample(t)
+	dir := t.TempDir()
+	s := store.New(dir)
+	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+	lp, err := LoadVerified(s, "weekly-metrics-digest", "test")
+	if err != nil {
+		t.Fatalf("LoadVerified: %v", err)
+	}
+	if lp.Plan.Name != "weekly-metrics-digest" {
+		t.Errorf("name = %q", lp.Plan.Name)
+	}
+}
+
+func TestLoadVerified_UnknownVersionRefuses(t *testing.T) {
+	s := store.New(t.TempDir())
+	if _, err := LoadVerified(s, "ghost", "nope"); err == nil {
+		t.Fatal("an unknown version must refuse to load")
+	}
+}

--- a/internal/flightplan/runtime/materialize.go
+++ b/internal/flightplan/runtime/materialize.go
@@ -1,0 +1,130 @@
+package runtime
+
+import (
+	"encoding/json"
+	"fmt"
+)
+
+// Artifact is one materialized output: the declared output's name, the path it
+// was written to, its mime type, and the bytes. The runtime records it in the
+// audit by name; the bytes are written to disk by the run orchestration when
+// the publish target is `file`.
+type Artifact struct {
+	Name     string
+	Path     string
+	MimeType string
+	// Content is the materialized utf-8 bytes. Empty for a target:none
+	// artifact (recorded but not written).
+	Content []byte
+	// Written reports whether the artifact should be written to disk
+	// (publish target `file`) vs retained in the run record only (`none`).
+	Written bool
+}
+
+// fileMapEntry is one entry of the typed JSON file-map transport a
+// materializesOutput step produces: {path, mimeType, encoding, content}
+// (#1519). Materialization is pure deterministic code; no LLM interprets the
+// file-map.
+type fileMapEntry struct {
+	Path     string `json:"path"`
+	MimeType string `json:"mimeType"`
+	Encoding string `json:"encoding"`
+	Content  string `json:"content"`
+}
+
+// materialize parses the typed JSON file-map from a materializesOutput step's
+// result, validates it against the declared output, and returns the artifact.
+// v1 materializes utf-8 only; a base64/binary entry is a hard error citing the
+// deferred mount boundary (#1510). The materialized name must match the
+// declared output and the mime type must match the declared mimeType.
+//
+// The step result for a materializing step is expected to carry the file-map
+// under the step's first declared output (the conventional carrier), shaped as
+// a single file-map entry. A step may produce the entry directly as a map.
+func materialize(p *Plan, step Step, outputs map[string]any) (Artifact, error) {
+	out, ok := p.Outputs[step.MaterializesOutput]
+	if !ok {
+		// Decode already guards this; defensive.
+		return Artifact{}, fmt.Errorf("flightplan: step %q materializes undeclared output %q", step.ID, step.MaterializesOutput)
+	}
+
+	entry, err := fileMapFor(step, outputs)
+	if err != nil {
+		return Artifact{}, fmt.Errorf("flightplan: step %q materialize %q: %w", step.ID, out.Name, err)
+	}
+
+	// Validate the encoding: v1 is utf-8 only.
+	switch entry.Encoding {
+	case "", string(EncodingUTF8):
+		// utf-8 (default) is materialized.
+	case string(EncodingBase64):
+		return Artifact{}, fmt.Errorf(
+			"flightplan: step %q output %q declares base64/binary encoding, which is deferred to the mount / run-and-collect boundary (#1510); v1 materializes utf-8 only",
+			step.ID, out.Name)
+	default:
+		return Artifact{}, fmt.Errorf("flightplan: step %q output %q has unknown file-map encoding %q", step.ID, out.Name, entry.Encoding)
+	}
+
+	// The mime type, when the file-map declares one, must match the declared
+	// output's mimeType so the materialized artifact matches its contract.
+	if entry.MimeType != "" && entry.MimeType != out.MimeType {
+		return Artifact{}, fmt.Errorf(
+			"flightplan: step %q output %q file-map mimeType %q does not match the declared %q",
+			step.ID, out.Name, entry.MimeType, out.MimeType)
+	}
+
+	art := Artifact{
+		Name:     out.Name,
+		MimeType: out.MimeType,
+		Content:  []byte(entry.Content),
+	}
+	if out.Target == PublishFile {
+		// The publish path comes from the declared output, not the file-map,
+		// so the runtime controls where artifacts land (the file-map path is
+		// advisory transport detail).
+		art.Path = out.Path
+		art.Written = true
+	}
+	return art, nil
+}
+
+// fileMapFor extracts the file-map entry from a step's outputs. It accepts the
+// entry under the step's materializing output name (the conventional carrier),
+// or — when the step produced exactly one output — under that single output.
+// The carrier value may be a map[string]any (already decoded) or a JSON string
+// the step emitted; both decode to a fileMapEntry.
+func fileMapFor(step Step, outputs map[string]any) (fileMapEntry, error) {
+	var carrier any
+	// Prefer an output whose name matches the materialized output, else the
+	// step's first declared output.
+	if len(step.Outputs) > 0 {
+		carrier = outputs[step.Outputs[0]]
+	}
+	if carrier == nil {
+		return fileMapEntry{}, fmt.Errorf("step produced no file-map carrier output")
+	}
+	return decodeFileMapEntry(carrier)
+}
+
+// decodeFileMapEntry coerces a carrier value into a fileMapEntry. A decoded
+// map or a JSON string are both accepted; anything else is a typed error.
+func decodeFileMapEntry(carrier any) (fileMapEntry, error) {
+	var raw []byte
+	switch c := carrier.(type) {
+	case map[string]any:
+		b, err := json.Marshal(c)
+		if err != nil {
+			return fileMapEntry{}, err
+		}
+		raw = b
+	case string:
+		raw = []byte(c)
+	default:
+		return fileMapEntry{}, fmt.Errorf("file-map carrier is %T, want a {path,mimeType,encoding,content} object or its JSON", carrier)
+	}
+	var entry fileMapEntry
+	if err := json.Unmarshal(raw, &entry); err != nil {
+		return fileMapEntry{}, fmt.Errorf("decode file-map entry: %w", err)
+	}
+	return entry, nil
+}

--- a/internal/flightplan/runtime/materialize.go
+++ b/internal/flightplan/runtime/materialize.go
@@ -95,9 +95,11 @@ func materialize(p *Plan, step Step, outputs map[string]any) (Artifact, error) {
 // the step emitted; both decode to a fileMapEntry.
 func fileMapFor(step Step, outputs map[string]any) (fileMapEntry, error) {
 	var carrier any
-	// Prefer an output whose name matches the materialized output, else the
-	// step's first declared output.
-	if len(step.Outputs) > 0 {
+	// Prefer an output whose name matches the materialized output, then fall
+	// back to the step's first declared output.
+	if c, ok := outputs[step.MaterializesOutput]; ok {
+		carrier = c
+	} else if len(step.Outputs) > 0 {
 		carrier = outputs[step.Outputs[0]]
 	}
 	if carrier == nil {

--- a/internal/flightplan/runtime/materialize_test.go
+++ b/internal/flightplan/runtime/materialize_test.go
@@ -72,3 +72,43 @@ func TestMaterialize_TargetNoneRecordedNotWritten(t *testing.T) {
 		t.Errorf("artifact name = %q", art.Name)
 	}
 }
+
+func TestMaterialize_CarrierFromJSONString(t *testing.T) {
+	p := planWithOutput(Output{Name: "d.json", MimeType: "application/json", Encoding: EncodingUTF8, Target: PublishFile, Path: "d.json"})
+	step := fileMapStep("d.json")
+	// The carrier is a JSON string the step emitted, not a decoded map.
+	outputs := map[string]any{"file": `{"encoding":"utf-8","content":"{}","mimeType":"application/json"}`}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if string(art.Content) != "{}" {
+		t.Errorf("content = %q", art.Content)
+	}
+}
+
+func TestMaterialize_NonObjectCarrierRefused(t *testing.T) {
+	p := planWithOutput(Output{Name: "d.csv", MimeType: "text/csv", Encoding: EncodingUTF8, Target: PublishNone})
+	step := fileMapStep("d.csv")
+	outputs := map[string]any{"file": 42} // not a map or JSON string
+	if _, err := materialize(p, step, outputs); err == nil {
+		t.Fatal("a non-object, non-JSON-string carrier must be refused")
+	}
+}
+
+func TestMaterialize_NoCarrierRefused(t *testing.T) {
+	p := planWithOutput(Output{Name: "d.csv", MimeType: "text/csv", Encoding: EncodingUTF8, Target: PublishNone})
+	step := Step{ID: "s", Kind: KindTransform, Outputs: nil, MaterializesOutput: "d.csv"}
+	if _, err := materialize(p, step, map[string]any{}); err == nil {
+		t.Fatal("a step with no carrier output must be refused")
+	}
+}
+
+func TestMaterialize_MalformedJSONCarrierRefused(t *testing.T) {
+	p := planWithOutput(Output{Name: "d.csv", MimeType: "text/csv", Encoding: EncodingUTF8, Target: PublishNone})
+	step := fileMapStep("d.csv")
+	outputs := map[string]any{"file": "{not json"}
+	if _, err := materialize(p, step, outputs); err == nil {
+		t.Fatal("a malformed JSON carrier must be refused")
+	}
+}

--- a/internal/flightplan/runtime/materialize_test.go
+++ b/internal/flightplan/runtime/materialize_test.go
@@ -1,0 +1,74 @@
+package runtime
+
+import (
+	"strings"
+	"testing"
+)
+
+func planWithOutput(out Output) *Plan {
+	return &Plan{Outputs: map[string]Output{out.Name: out}}
+}
+
+func fileMapStep(materializes string) Step {
+	return Step{ID: "s", Kind: KindTransform, Outputs: []string{"file"}, MaterializesOutput: materializes}
+}
+
+func TestMaterialize_UTF8ToDeclaredPath(t *testing.T) {
+	p := planWithOutput(Output{Name: "digest.csv", MimeType: "text/csv", Encoding: EncodingUTF8, Target: PublishFile, Path: "digest.csv"})
+	step := fileMapStep("digest.csv")
+	outputs := map[string]any{"file": map[string]any{
+		"path": "digest.csv", "mimeType": "text/csv", "encoding": "utf-8", "content": "a,b\n1,2\n",
+	}}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if string(art.Content) != "a,b\n1,2\n" {
+		t.Errorf("content = %q", art.Content)
+	}
+	if art.Path != "digest.csv" || !art.Written {
+		t.Errorf("artifact = %+v", art)
+	}
+}
+
+func TestMaterialize_Base64Refused(t *testing.T) {
+	p := planWithOutput(Output{Name: "chart.png", MimeType: "image/png", Encoding: EncodingBase64, Target: PublishFile, Path: "chart.png"})
+	step := fileMapStep("chart.png")
+	outputs := map[string]any{"file": map[string]any{
+		"path": "chart.png", "mimeType": "image/png", "encoding": "base64", "content": "AAAA",
+	}}
+	_, err := materialize(p, step, outputs)
+	if err == nil {
+		t.Fatal("base64/binary materialization must be refused in v1")
+	}
+	if !strings.Contains(err.Error(), "#1510") {
+		t.Errorf("error must cite the deferred mount boundary (#1510), got %v", err)
+	}
+}
+
+func TestMaterialize_MimeTypeMismatchRefused(t *testing.T) {
+	p := planWithOutput(Output{Name: "digest.csv", MimeType: "text/csv", Encoding: EncodingUTF8, Target: PublishFile, Path: "digest.csv"})
+	step := fileMapStep("digest.csv")
+	outputs := map[string]any{"file": map[string]any{
+		"mimeType": "application/json", "encoding": "utf-8", "content": "{}",
+	}}
+	if _, err := materialize(p, step, outputs); err == nil {
+		t.Fatal("a file-map mimeType that disagrees with the declared output must be refused")
+	}
+}
+
+func TestMaterialize_TargetNoneRecordedNotWritten(t *testing.T) {
+	p := planWithOutput(Output{Name: "kept.json", MimeType: "application/json", Encoding: EncodingUTF8, Target: PublishNone})
+	step := fileMapStep("kept.json")
+	outputs := map[string]any{"file": map[string]any{"encoding": "utf-8", "content": "{}"}}
+	art, err := materialize(p, step, outputs)
+	if err != nil {
+		t.Fatalf("materialize: %v", err)
+	}
+	if art.Written {
+		t.Error("a target:none artifact must not be written")
+	}
+	if art.Name != "kept.json" {
+		t.Errorf("artifact name = %q", art.Name)
+	}
+}

--- a/internal/flightplan/runtime/plan.go
+++ b/internal/flightplan/runtime/plan.go
@@ -1,0 +1,217 @@
+// Package runtime is the deterministic Launch executor for a frozen Aileron
+// Flight Plan (ADR-0027, issue #1511). It loads a sealed, signed plan from
+// the store, verifies it, resolves declared inputs once at the launch
+// boundary (#1523), and walks the step graph in topological order through the
+// sealed action boundary (#1507), materializing declared file artifacts
+// (#1519) and emitting a customer-owned audit record.
+//
+// The no-LLM guarantee is structural, not a runtime check. The executor has
+// exactly three step-kind branches (action-call, transform, llm-seam) and
+// only the explicitly marked llm-seam branch can reach a language model. The
+// action-call and transform branches hold no reference to any seam type, so
+// no deterministic step can reach an LLM by construction. In v1 the seam is
+// unwired by default: an llm-seam step with no configured provider is a hard
+// error, so a default launch reaches no LLM at all.
+//
+// The runtime depends on the manifest, freeze, and store packages but takes
+// the action boundary, the approval channel, and the audit sink as thin SPI
+// interfaces (ActionDispatcher, Approver, AuditSink, Clock, LLMSeam). The CLI
+// wires those seams to the real daemon-backed implementations; the runtime
+// core stays unit-testable with fakes, mirroring the freeze
+// DigestResolver/FeatureComposer seam discipline.
+//
+// This package never reads or carries a credential value. Step args are
+// binding references only (the closed binding grammar enforces this at
+// decode), and credentials are injected host-side at the action boundary
+// (ADR-0005, ADR-0019). No secret ever reaches plan code through this
+// runtime.
+package runtime
+
+// Plan is the typed, validated model of a frozen plan's `aileron` block that
+// the executor walks. It is produced by Decode from a manifest.Manifest and
+// is the single in-memory shape the runtime reads; the loosely-typed `[]any`
+// fields on the manifest never escape the decode boundary.
+type Plan struct {
+	// Name is the skill name from the manifest frontmatter.
+	Name string
+	// Actions are the declared action requirements indexed by ref. The
+	// trust contract drives approval routing, idempotency, redaction, and
+	// audit for each action-call.
+	Actions map[string]Action
+	// Inputs are the declared inputs in declaration order. Each resolves
+	// once at the launch boundary.
+	Inputs []Input
+	// Outputs are the declared output artifacts indexed by name.
+	Outputs map[string]Output
+	// Steps are the step-graph steps in declaration order. The executor
+	// walks them in a topologically-sorted order (see Order).
+	Steps []Step
+	// Order is the deterministic topological order of step indices the
+	// executor walks, computed from `steps.*` edges only.
+	Order []int
+}
+
+// Action is one declared action requirement plus its decoded trust contract.
+type Action struct {
+	Ref           string
+	TrustContract TrustContract
+}
+
+// Effect is the operation effect that drives approval routing (ADR-0009).
+type Effect string
+
+const (
+	EffectRead         Effect = "read"
+	EffectWrite        Effect = "write"
+	EffectDelete       Effect = "delete"
+	EffectSpend        Effect = "spend"
+	EffectExternalSend Effect = "external-send"
+)
+
+// TrustContract mirrors the manifest trust-contract fields the runtime
+// enforces per action-call: effect routing, idempotency, redaction, audit.
+// Credential/host/path are the declared access scope; the runtime grants
+// nothing undeclared.
+type TrustContract struct {
+	CredentialKind string
+	Hosts          []string
+	Paths          []string
+	Effect         Effect
+	Idempotency    Idempotency
+	Redaction      []RedactionRule
+	IdentityLabel  string
+	Audit          AuditStructure
+}
+
+// Idempotency records whether an action is safe to retry and whether it
+// accepts a client-supplied idempotency key.
+type Idempotency struct {
+	SafeToRetry    bool
+	IdempotencyKey bool
+}
+
+// RedactionRule names a result field path and how it is redacted before the
+// result surfaces into the graph or any audit summary.
+type RedactionRule struct {
+	Field string
+	Rule  RedactionKind
+}
+
+// RedactionKind is the closed set of redaction operations.
+type RedactionKind string
+
+const (
+	RedactDrop RedactionKind = "drop"
+	RedactMask RedactionKind = "mask"
+	RedactHash RedactionKind = "hash"
+)
+
+// AuditStructure declares the closed set of audit fields an action emits and
+// the customer-owned sink reference.
+type AuditStructure struct {
+	Fields []string
+	Sink   string
+}
+
+// InputType is the declared value type of an input.
+type InputType string
+
+// ResolutionRule discriminates how an input resolves at the launch boundary.
+type ResolutionRule string
+
+const (
+	ResolutionLiteral ResolutionRule = "literal"
+	ResolutionDynamic ResolutionRule = "dynamic"
+	ResolutionSource  ResolutionRule = "source"
+)
+
+// Input is one declared input with its resolution rule. Inputs resolve once,
+// at the launch boundary, into a concrete resolved-input set (#1523).
+type Input struct {
+	Name        string
+	Type        InputType
+	Description string
+	Resolution  Resolution
+}
+
+// Resolution is a decoded input resolution rule. Exactly one of the three
+// rule shapes is populated, discriminated by Rule.
+type Resolution struct {
+	Rule ResolutionRule
+	// Literal fields.
+	HasDefault bool
+	Default    any
+	// Dynamic field: "now" or "today".
+	DynamicValue string
+	// Source fields.
+	SourceActionRef string
+	SourceSelect    string
+}
+
+// Encoding is the artifact content encoding. v1 implements utf-8 only;
+// base64 is reserved and refused at materialization.
+type Encoding string
+
+const (
+	EncodingUTF8   Encoding = "utf-8"
+	EncodingBase64 Encoding = "base64"
+)
+
+// PublishTarget is where the runtime materializes an output artifact.
+type PublishTarget string
+
+const (
+	PublishFile PublishTarget = "file"
+	PublishNone PublishTarget = "none"
+)
+
+// Output is one declared output artifact: the declared interface the runtime
+// materializes through the file-map transport (#1519).
+type Output struct {
+	Name     string
+	MimeType string
+	Encoding Encoding
+	Target   PublishTarget
+	Path     string
+}
+
+// StepKind is the closed step-kind enum. The no-LLM guarantee is structural:
+// only KindLLMSeam can reach a language model.
+type StepKind string
+
+const (
+	KindActionCall StepKind = "action-call"
+	KindTransform  StepKind = "transform"
+	KindLLMSeam    StepKind = "llm-seam"
+)
+
+// Step is one step in the deterministic step graph. A single struct carries
+// every kind's fields; Kind selects which are meaningful. ActionRef is set
+// only for action-call; Args is the action-call binding map; Bindings is the
+// transform/llm-seam binding map. Keeping one struct keeps the executor's
+// three-branch switch the single dispatch point.
+type Step struct {
+	ID        string
+	Kind      StepKind
+	ActionRef string
+	// Args binds action-call argument names to binding references.
+	Args map[string]Binding
+	// Bindings binds transform / llm-seam input names to binding references.
+	Bindings map[string]Binding
+	// Outputs are the named results this step produces, referenced by a
+	// later step as steps.<id>.<output>.
+	Outputs []string
+	// MaterializesOutput names a declared output this step's result
+	// materializes into. Empty when the step materializes nothing.
+	MaterializesOutput string
+}
+
+// binds returns the step's binding map regardless of kind (Args for
+// action-call, Bindings otherwise), so dependency extraction and execution
+// read one source.
+func (s Step) binds() map[string]Binding {
+	if s.Kind == KindActionCall {
+		return s.Args
+	}
+	return s.Bindings
+}

--- a/internal/flightplan/runtime/redact.go
+++ b/internal/flightplan/runtime/redact.go
@@ -1,0 +1,175 @@
+package runtime
+
+import (
+	"crypto/sha256"
+	"encoding/hex"
+	"strconv"
+	"strings"
+)
+
+// applyRedaction applies the trust-contract redaction rules to a dispatch
+// result IN PLACE on a deep copy, BEFORE the result surfaces into the graph
+// or any audit summary. Each rule names a field path and how it is redacted:
+// drop removes it, mask replaces it with a fixed mask, hash replaces it with
+// a stable hash (ADR-0027). The original result is never mutated.
+//
+// Field paths use dotted segments with a `[]` element-wildcard for arrays,
+// matching the schema's example shape (for example series[].labels.account_id
+// or assignee.email). A path that matches nothing is a no-op: redaction is a
+// declared safeguard, not a required-field assertion.
+func applyRedaction(result map[string]any, rules []RedactionRule) map[string]any {
+	out := deepCopyMap(result)
+	for _, r := range rules {
+		segs := parsePath(r.Field)
+		redactPath(out, segs, r.Rule)
+	}
+	return out
+}
+
+// pathSeg is one segment of a redaction path. Wildcard marks a `[]` array
+// element traversal.
+type pathSeg struct {
+	key      string
+	wildcard bool
+}
+
+// parsePath splits a dotted field path into segments, treating a `[]` suffix
+// on a segment as an array-element wildcard that applies the remaining path to
+// every element.
+func parsePath(path string) []pathSeg {
+	var segs []pathSeg
+	for _, raw := range strings.Split(path, ".") {
+		if raw == "" {
+			continue
+		}
+		if strings.HasSuffix(raw, "[]") {
+			segs = append(segs, pathSeg{key: strings.TrimSuffix(raw, "[]"), wildcard: true})
+		} else {
+			segs = append(segs, pathSeg{key: raw})
+		}
+	}
+	return segs
+}
+
+// redactPath walks segs into m and applies the rule at the leaf. It recurses
+// through wildcard array elements so a single rule covers every element of a
+// declared array field.
+func redactPath(node any, segs []pathSeg, rule RedactionKind) {
+	if len(segs) == 0 {
+		return
+	}
+	m, ok := node.(map[string]any)
+	if !ok {
+		return
+	}
+	seg := segs[0]
+	last := len(segs) == 1
+
+	if last && !seg.wildcard {
+		applyRule(m, seg.key, rule)
+		return
+	}
+
+	child, present := m[seg.key]
+	if !present {
+		return
+	}
+
+	if seg.wildcard {
+		// child should be an array; apply the remainder to each element. When
+		// the wildcard is the leaf segment, redact each element value
+		// directly under its parent slice.
+		arr, ok := child.([]any)
+		if !ok {
+			return
+		}
+		rest := segs[1:]
+		if last {
+			for i := range arr {
+				arr[i] = redactValue(arr[i], rule)
+			}
+			return
+		}
+		for _, el := range arr {
+			redactPath(el, rest, rule)
+		}
+		return
+	}
+
+	redactPath(child, segs[1:], rule)
+}
+
+// applyRule redacts key in m per rule.
+func applyRule(m map[string]any, key string, rule RedactionKind) {
+	v, present := m[key]
+	if !present {
+		return
+	}
+	switch rule {
+	case RedactDrop:
+		delete(m, key)
+	default:
+		m[key] = redactValue(v, rule)
+	}
+}
+
+// redactValue returns the redacted form of a scalar value. drop is handled by
+// the caller (it removes the key); mask and hash transform the value.
+func redactValue(v any, rule RedactionKind) any {
+	switch rule {
+	case RedactMask:
+		return "***"
+	case RedactHash:
+		sum := sha256.Sum256([]byte(stringify(v)))
+		return "sha256:" + hex.EncodeToString(sum[:])
+	case RedactDrop:
+		// In an array context drop replaces the element with nil since a slice
+		// cannot remove an index by key.
+		return nil
+	default:
+		return v
+	}
+}
+
+// stringify renders a scalar deterministically for hashing.
+func stringify(v any) string {
+	switch t := v.(type) {
+	case string:
+		return t
+	case bool:
+		return strconv.FormatBool(t)
+	case int:
+		return strconv.Itoa(t)
+	case int64:
+		return strconv.FormatInt(t, 10)
+	case float64:
+		return strconv.FormatFloat(t, 'g', -1, 64)
+	default:
+		return ""
+	}
+}
+
+// deepCopyMap returns a deep copy of a JSON-shaped map so redaction never
+// mutates the dispatcher's result.
+func deepCopyMap(m map[string]any) map[string]any {
+	out := make(map[string]any, len(m))
+	for k, v := range m {
+		out[k] = deepCopyValue(v)
+	}
+	return out
+}
+
+func deepCopyValue(v any) any {
+	switch t := v.(type) {
+	case map[string]any:
+		return deepCopyMap(t)
+	case []any:
+		arr := make([]any, len(t))
+		for i, el := range t {
+			arr[i] = deepCopyValue(el)
+		}
+		return arr
+	default:
+		return v
+	}
+}

--- a/internal/flightplan/runtime/redact.go
+++ b/internal/flightplan/runtime/redact.go
@@ -3,7 +3,7 @@ package runtime
 import (
 	"crypto/sha256"
 	"encoding/hex"
-	"strconv"
+	"encoding/json"
 	"strings"
 )
 
@@ -113,14 +113,22 @@ func applyRule(m map[string]any, key string, rule RedactionKind) {
 	}
 }
 
-// redactValue returns the redacted form of a scalar value. drop is handled by
-// the caller (it removes the key); mask and hash transform the value.
+// redactValue returns the redacted form of a value. drop is handled by the
+// caller (it removes the key); mask and hash transform the value.
 func redactValue(v any, rule RedactionKind) any {
 	switch rule {
 	case RedactMask:
 		return "***"
 	case RedactHash:
-		sum := sha256.Sum256([]byte(stringify(v)))
+		// Hash a canonical, type-preserving JSON encoding so distinct inputs
+		// (a number vs the string of that number, or two different objects)
+		// never collide to the same hash. A value that cannot encode falls
+		// back to the mask so a redacted field is never surfaced in the clear.
+		encoded, err := json.Marshal(v)
+		if err != nil {
+			return "***"
+		}
+		sum := sha256.Sum256(encoded)
 		return "sha256:" + hex.EncodeToString(sum[:])
 	case RedactDrop:
 		// In an array context drop replaces the element with nil since a slice
@@ -128,24 +136,6 @@ func redactValue(v any, rule RedactionKind) any {
 		return nil
 	default:
 		return v
-	}
-}
-
-// stringify renders a scalar deterministically for hashing.
-func stringify(v any) string {
-	switch t := v.(type) {
-	case string:
-		return t
-	case bool:
-		return strconv.FormatBool(t)
-	case int:
-		return strconv.Itoa(t)
-	case int64:
-		return strconv.FormatInt(t, 10)
-	case float64:
-		return strconv.FormatFloat(t, 'g', -1, 64)
-	default:
-		return ""
 	}
 }
 

--- a/internal/flightplan/runtime/redact_test.go
+++ b/internal/flightplan/runtime/redact_test.go
@@ -65,3 +65,14 @@ func TestApplyRedaction_MissingFieldIsNoOp(t *testing.T) {
 		t.Errorf("a non-matching path must be a no-op, got %v", out)
 	}
 }
+
+func TestApplyRedaction_HashDistinguishesTypes(t *testing.T) {
+	rules := []RedactionRule{{Field: "v", Rule: RedactHash}}
+	// The number 7 and the string "7" must hash to different values: a
+	// type-collapsing stringify would make them collide.
+	a := applyRedaction(map[string]any{"v": 7}, rules)
+	b := applyRedaction(map[string]any{"v": "7"}, rules)
+	if a["v"] == b["v"] {
+		t.Error("hash must distinguish a number from its string form")
+	}
+}

--- a/internal/flightplan/runtime/redact_test.go
+++ b/internal/flightplan/runtime/redact_test.go
@@ -1,0 +1,67 @@
+package runtime
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestApplyRedaction_Drop(t *testing.T) {
+	in := map[string]any{"keep": "yes", "secret": "drop-me"}
+	out := applyRedaction(in, []RedactionRule{{Field: "secret", Rule: RedactDrop}})
+	if _, present := out["secret"]; present {
+		t.Error("drop must remove the field")
+	}
+	if out["keep"] != "yes" {
+		t.Error("drop must leave other fields")
+	}
+	// Original untouched.
+	if _, present := in["secret"]; !present {
+		t.Error("redaction must not mutate the original result")
+	}
+}
+
+func TestApplyRedaction_Mask(t *testing.T) {
+	out := applyRedaction(map[string]any{"assignee": map[string]any{"email": "a@b.com"}},
+		[]RedactionRule{{Field: "assignee.email", Rule: RedactMask}})
+	email := out["assignee"].(map[string]any)["email"]
+	if email != "***" {
+		t.Errorf("mask = %v, want ***", email)
+	}
+}
+
+func TestApplyRedaction_HashStable(t *testing.T) {
+	rules := []RedactionRule{{Field: "id", Rule: RedactHash}}
+	a := applyRedaction(map[string]any{"id": "abc"}, rules)
+	b := applyRedaction(map[string]any{"id": "abc"}, rules)
+	if a["id"] != b["id"] {
+		t.Error("hash must be stable for the same input")
+	}
+	if a["id"] == "abc" {
+		t.Error("hash must replace the value")
+	}
+}
+
+func TestApplyRedaction_ArrayWildcard(t *testing.T) {
+	in := map[string]any{
+		"series": []any{
+			map[string]any{"labels": map[string]any{"account_id": "111"}},
+			map[string]any{"labels": map[string]any{"account_id": "222"}},
+		},
+	}
+	out := applyRedaction(in, []RedactionRule{{Field: "series[].labels.account_id", Rule: RedactHash}})
+	arr := out["series"].([]any)
+	for _, el := range arr {
+		got := el.(map[string]any)["labels"].(map[string]any)["account_id"]
+		if got == "111" || got == "222" {
+			t.Errorf("array element account_id not redacted: %v", got)
+		}
+	}
+}
+
+func TestApplyRedaction_MissingFieldIsNoOp(t *testing.T) {
+	in := map[string]any{"a": 1}
+	out := applyRedaction(in, []RedactionRule{{Field: "nope.deeper", Rule: RedactDrop}})
+	if !reflect.DeepEqual(out, map[string]any{"a": 1}) {
+		t.Errorf("a non-matching path must be a no-op, got %v", out)
+	}
+}

--- a/internal/flightplan/runtime/run.go
+++ b/internal/flightplan/runtime/run.go
@@ -1,0 +1,189 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+// Options configures a launch. The Store + Name + Version select the frozen
+// unit; the SPI seams wire the runtime to the daemon-backed boundary; the
+// Clock and TransformRegistry default to deterministic, LLM-free
+// implementations.
+type Options struct {
+	// Store is the canonical skill store the frozen unit loads from.
+	Store *store.Store
+	// Name is the frozen skill name.
+	Name string
+	// Version is the frozen version id (the store directory id).
+	Version string
+
+	// Inputs are the literal input overrides supplied at launch.
+	Inputs LaunchArgs
+
+	// Dispatcher is the action boundary seam (required to run any action-call
+	// or source input).
+	Dispatcher ActionDispatcher
+	// Approver routes effect-gated actions (required when any non-read action
+	// runs).
+	Approver Approver
+	// Audit receives the customer-owned audit records. Nil emits no audit.
+	Audit AuditSink
+	// Seam is the single marked LLM seam. Nil (the v1 default) makes any
+	// llm-seam step error, so a default launch reaches no LLM.
+	Seam LLMSeam
+
+	// Clock supplies the single launch-time read for dynamic inputs. Nil uses
+	// SystemClock.
+	Clock Clock
+	// Transforms is the deterministic transform registry. Nil uses the
+	// default registry.
+	Transforms *TransformRegistry
+
+	// OutDir is the directory file-target artifacts are written to. Empty
+	// skips writing (artifacts are still recorded in the result).
+	OutDir string
+}
+
+// RunResult is the outcome of a launch: the resolved inputs, the step outputs,
+// the materialized artifacts, and the emitted audit record ids.
+type RunResult struct {
+	// ContentHash is the verified content hash of the frozen unit that ran.
+	ContentHash string
+	// ResolvedInputs is the frozen resolved-input set (Phase A output).
+	ResolvedInputs map[string]any
+	// StepOutputs maps steps.<id> → its named outputs.
+	StepOutputs map[string]map[string]any
+	// Artifacts are the materialized output artifacts.
+	Artifacts []Artifact
+	// AuditIDs are the audit record ids emitted to the sink.
+	AuditIDs []string
+}
+
+// Run is the deterministic Launch entry point (#1511). It loads and verifies
+// the frozen unit, resolves declared inputs once (#1523), walks the step graph
+// in topological order through the sealed action boundary with trust-contract
+// enforcement (#1507), materializes declared file artifacts (#1519), writes
+// them to OutDir, and emits the customer-owned audit. Any verification failure
+// or step error aborts with zero side effects beyond the audit trail.
+func Run(ctx context.Context, opts Options) (RunResult, error) {
+	lp, err := LoadVerified(opts.Store, opts.Name, opts.Version)
+	if err != nil {
+		return RunResult{}, err
+	}
+	return runPlan(ctx, lp.Plan, lp.ContentHash, opts)
+}
+
+// runPlan executes an already-loaded, verified plan. It is factored out so
+// tests drive the full Phase A/B/materialize/audit pipeline from an in-memory
+// plan without a store on disk, while Run handles the load+verify gate.
+func runPlan(ctx context.Context, plan *Plan, contentHash string, opts Options) (RunResult, error) {
+	clk := opts.Clock
+	if clk == nil {
+		clk = SystemClock{}
+	}
+	reg := opts.Transforms
+	if reg == nil {
+		reg = NewTransformRegistry()
+	}
+	enf := &enforcer{dispatcher: opts.Dispatcher, approver: opts.Approver}
+
+	// Phase A: resolve declared inputs once at the launch boundary.
+	inputs, err := resolveInputs(ctx, plan, opts.Inputs, clk, enf)
+	if err != nil {
+		return RunResult{}, err
+	}
+
+	// Phase B: walk the DAG.
+	x := &executor{plan: plan, enforcer: enf, transform: reg, seam: opts.Seam}
+	st, runErr := x.execute(ctx, inputs)
+
+	// Emit the audit regardless of run outcome so a mid-run denial is recorded
+	// (the audit is an append-only companion, not gated on success).
+	auditIDs := emitAudit(ctx, opts.Audit, st)
+
+	if runErr != nil {
+		return RunResult{}, runErr
+	}
+
+	// Write file-target artifacts to OutDir.
+	if err := writeArtifacts(opts.OutDir, st.artifacts); err != nil {
+		return RunResult{}, err
+	}
+
+	return RunResult{
+		ContentHash:    contentHash,
+		ResolvedInputs: inputs.Values,
+		StepOutputs:    stepOutputsMap(st),
+		Artifacts:      st.artifacts,
+		AuditIDs:       auditIDs,
+	}, nil
+}
+
+// writeArtifacts writes every file-target artifact under outDir at its declared
+// path. An empty outDir skips writing (the artifacts are still in the result).
+// Paths are constrained to stay within outDir so a crafted declared path can
+// never escape the output directory.
+func writeArtifacts(outDir string, artifacts []Artifact) error {
+	if outDir == "" {
+		return nil
+	}
+	for _, a := range artifacts {
+		if !a.Written {
+			continue
+		}
+		dest, err := safeJoin(outDir, a.Path)
+		if err != nil {
+			return fmt.Errorf("flightplan: artifact %q: %w", a.Name, err)
+		}
+		if err := os.MkdirAll(filepath.Dir(dest), 0o755); err != nil {
+			return fmt.Errorf("flightplan: create artifact dir for %q: %w", a.Name, err)
+		}
+		if err := os.WriteFile(dest, a.Content, 0o644); err != nil {
+			return fmt.Errorf("flightplan: write artifact %q: %w", a.Name, err)
+		}
+	}
+	return nil
+}
+
+// safeJoin joins base and a relative path, refusing any path that escapes base
+// (absolute paths or `..` traversal). This is the materialization boundary: a
+// declared output path is operator-authored but still constrained.
+func safeJoin(base, rel string) (string, error) {
+	if filepath.IsAbs(rel) {
+		return "", fmt.Errorf("path %q must be relative to the output directory", rel)
+	}
+	dest := filepath.Join(base, rel)
+	absBase, err := filepath.Abs(base)
+	if err != nil {
+		return "", err
+	}
+	absDest, err := filepath.Abs(dest)
+	if err != nil {
+		return "", err
+	}
+	rel2, err := filepath.Rel(absBase, absDest)
+	if err != nil {
+		return "", err
+	}
+	if rel2 == ".." || filepath.IsAbs(rel2) || hasDotDotPrefix(rel2) {
+		return "", fmt.Errorf("path %q escapes the output directory", rel)
+	}
+	return dest, nil
+}
+
+func hasDotDotPrefix(p string) bool {
+	return len(p) >= 3 && p[0] == '.' && p[1] == '.' && (p[2] == filepath.Separator)
+}
+
+// stepOutputsMap converts the internal step-output map into the public shape.
+func stepOutputsMap(st execState) map[string]map[string]any {
+	out := make(map[string]map[string]any, len(st.stepOutput))
+	for id, sr := range st.stepOutput {
+		out[id] = map[string]any(sr)
+	}
+	return out
+}

--- a/internal/flightplan/runtime/run_extra_test.go
+++ b/internal/flightplan/runtime/run_extra_test.go
@@ -1,0 +1,94 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/ALRubinger/aileron/internal/flightplan/store"
+)
+
+func TestSafeJoin_RefusesEscape(t *testing.T) {
+	base := t.TempDir()
+	cases := []string{"../escape.txt", "/etc/passwd", "a/../../escape.txt"}
+	for _, c := range cases {
+		if _, err := safeJoin(base, c); err == nil {
+			t.Errorf("safeJoin(%q) must refuse an escaping path", c)
+		}
+	}
+	// A nested relative path within base is allowed.
+	if _, err := safeJoin(base, "sub/dir/report.csv"); err != nil {
+		t.Errorf("safeJoin must allow a nested relative path: %v", err)
+	}
+}
+
+func TestWriteArtifacts_RefusesEscapingArtifact(t *testing.T) {
+	err := writeArtifacts(t.TempDir(), []Artifact{
+		{Name: "evil", Path: "../escape.txt", Content: []byte("x"), Written: true},
+	})
+	if err == nil {
+		t.Fatal("an artifact whose declared path escapes the output dir must be refused")
+	}
+}
+
+func TestErrorMessages(t *testing.T) {
+	if got := (&DenyError{ActionRef: "aileron:t.del", Reason: "no"}).Error(); !strings.Contains(got, "denied") {
+		t.Errorf("DenyError = %q", got)
+	}
+	if got := (&DenyError{ActionRef: "aileron:t.del"}).Error(); !strings.Contains(got, "aileron:t.del") {
+		t.Errorf("DenyError without reason = %q", got)
+	}
+	if got := (&LoadError{Reason: "bad"}).Error(); !strings.Contains(got, "bad") {
+		t.Errorf("LoadError = %q", got)
+	}
+	if got := (&DecodeError{Reason: "bad"}).Error(); !strings.Contains(got, "bad") {
+		t.Errorf("DecodeError = %q", got)
+	}
+}
+
+// TestRun_PublicEntryPointThroughStore exercises the public Run from a frozen
+// version on disk: load+verify+resolve+execute+materialize end-to-end.
+func TestRun_PublicEntryPointThroughStore(t *testing.T) {
+	fv := frozenExample(t)
+	s := store.New(t.TempDir())
+	if err := s.WriteFrozen("weekly-metrics-digest", fv); err != nil {
+		t.Fatalf("WriteFrozen: %v", err)
+	}
+
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "name\ncpu\n", "mimeType": "text/csv"}}, nil
+	})
+	disp := &dispatchRouter{results: map[string]map[string]any{
+		"aileron:metrics.query_series": {"series": []any{map[string]any{"name": "cpu"}}},
+		"aileron:tracker.create_issue": {"encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+	}}
+
+	res, err := Run(context.Background(), Options{
+		Store:      s,
+		Name:       "weekly-metrics-digest",
+		Version:    "test",
+		Dispatcher: disp,
+		Approver:   &fakeApprover{decision: Decision{Approved: true}},
+		Seam:       fakeSeam{out: map[string]any{"issue_body": "x"}},
+		Clock:      FixedClock{},
+		Transforms: reg,
+		OutDir:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.ContentHash == "" {
+		t.Error("Run must surface the verified content hash")
+	}
+	if len(res.Artifacts) != 2 {
+		t.Errorf("want 2 artifacts, got %d", len(res.Artifacts))
+	}
+}
+
+func TestRun_LoadFailureSurfaces(t *testing.T) {
+	s := store.New(t.TempDir())
+	if _, err := Run(context.Background(), Options{Store: s, Name: "ghost", Version: "x"}); err == nil {
+		t.Fatal("Run must surface a load/verify failure")
+	}
+}

--- a/internal/flightplan/runtime/run_test.go
+++ b/internal/flightplan/runtime/run_test.go
@@ -1,0 +1,119 @@
+package runtime
+
+import (
+	"context"
+	"errors"
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestRun_WritesArtifactsToOutDir(t *testing.T) {
+	dir := t.TempDir()
+	res, _, _ := runFixture(t, Options{OutDir: dir})
+	if len(res.Artifacts) != 2 {
+		t.Fatalf("want 2 artifacts, got %d", len(res.Artifacts))
+	}
+	csv, err := os.ReadFile(filepath.Join(dir, "digest.csv"))
+	if err != nil {
+		t.Fatalf("read digest.csv: %v", err)
+	}
+	if string(csv) != "name\ncpu\n" {
+		t.Errorf("digest.csv = %q", csv)
+	}
+	issue, err := os.ReadFile(filepath.Join(dir, "filed_issue.json"))
+	if err != nil {
+		t.Fatalf("read filed_issue.json: %v", err)
+	}
+	if string(issue) != `{"url":"https://tracker.example.com/issues/1"}` {
+		t.Errorf("filed_issue.json = %q", issue)
+	}
+}
+
+// TestRun_DeterminismProperty pins the resolved-input fixture and runs the
+// full pipeline twice with a deterministic dispatcher, asserting byte-identical
+// outputs (the behavioral-determinism property: same resolved inputs → same
+// output).
+func TestRun_DeterminismProperty(t *testing.T) {
+	a, _, _ := runFixture(t, Options{Inputs: LaunchArgs{"window_days": 14}})
+	b, _, _ := runFixture(t, Options{Inputs: LaunchArgs{"window_days": 14}})
+
+	if len(a.Artifacts) != len(b.Artifacts) {
+		t.Fatalf("artifact counts differ: %d vs %d", len(a.Artifacts), len(b.Artifacts))
+	}
+	for i := range a.Artifacts {
+		if a.Artifacts[i].Name != b.Artifacts[i].Name {
+			t.Errorf("artifact %d name differs", i)
+		}
+		if string(a.Artifacts[i].Content) != string(b.Artifacts[i].Content) {
+			t.Errorf("artifact %q content not byte-identical across runs", a.Artifacts[i].Name)
+		}
+	}
+	// Resolved inputs identical.
+	if a.ResolvedInputs["window_days"] != b.ResolvedInputs["window_days"] {
+		t.Error("resolved inputs differ across runs with identical launch args")
+	}
+}
+
+// TestRun_StructuralNoLLMGuarantee proves a default launch (no seam provider)
+// reaches no LLM: the llm-seam step errors, so a plan with an llm-seam refuses
+// to run unless a seam is explicitly supplied. The action-call and transform
+// branches never reach the seam.
+func TestRun_StructuralNoLLMGuarantee(t *testing.T) {
+	p := fixturePlan()
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "x", "mimeType": "text/csv"}}, nil
+	})
+	_, err := runPlan(context.Background(), p, "h", Options{
+		Dispatcher: &dispatchRouter{results: map[string]map[string]any{
+			"aileron:metrics.query_series": {"series": []any{}},
+		}},
+		Approver:   &fakeApprover{decision: Decision{Approved: true}},
+		Clock:      FixedClock{},
+		Transforms: reg,
+		// Seam intentionally nil: the v1 default.
+	})
+	if err == nil {
+		t.Fatal("a plan with an llm-seam and no configured provider must refuse (no LLM by default)")
+	}
+}
+
+// TestRun_DeniedApprovalAbortsAndAudits proves a denied write mid-run aborts
+// the run and the audit reflects the denial.
+func TestRun_DeniedApprovalAbortsAndAudits(t *testing.T) {
+	p := fixturePlan()
+	sink := &recordingSink{}
+	reg := NewTransformRegistry()
+	reg.Register("identity", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: map[string]any{"encoding": "utf-8", "content": "x", "mimeType": "text/csv"}}, nil
+	})
+	_, err := runPlan(context.Background(), p, "h", Options{
+		Dispatcher: &dispatchRouter{results: map[string]map[string]any{
+			"aileron:metrics.query_series": {"series": []any{}},
+			"aileron:tracker.create_issue": {"path": "filed_issue.json", "encoding": "utf-8", "content": "{}", "mimeType": "application/json"},
+		}},
+		Approver:   &fakeApprover{decision: Decision{Approved: false, Reason: "operator declined"}},
+		Audit:      sink,
+		Seam:       fakeSeam{out: map[string]any{"issue_body": "x"}},
+		Clock:      FixedClock{},
+		Transforms: reg,
+	})
+	if err == nil {
+		t.Fatal("a denied write must abort the run")
+	}
+	var de *DenyError
+	if !errors.As(err, &de) {
+		t.Fatalf("error = %v, want *DenyError", err)
+	}
+	// The audit must include the denied write's record.
+	found := false
+	for _, rec := range sink.records {
+		if rec.ActionRef == "aileron:tracker.create_issue" && rec.Fields["approval-decision"] == "denied" {
+			found = true
+		}
+	}
+	if !found {
+		t.Error("the audit must record the denied approval decision")
+	}
+}

--- a/internal/flightplan/runtime/seam.go
+++ b/internal/flightplan/runtime/seam.go
@@ -1,0 +1,37 @@
+package runtime
+
+import (
+	"context"
+	"fmt"
+)
+
+// runSeam executes the single marked llm-seam step. It is the ONLY place the
+// runtime reaches the LLMSeam interface. When no seam provider is configured
+// (the v1 default), it errors with a clear "no seam provider configured"
+// message, so a default launch reaches no LLM at all and the no-LLM guarantee
+// holds by default, not merely by construction.
+//
+// Keeping seam invocation in this dedicated function, distinct from the
+// transform and action-call paths, is the structural guarantee: the
+// deterministic branches never call runSeam and never touch the LLMSeam type.
+func runSeam(ctx context.Context, seam LLMSeam, step Step, bindings map[string]any) (map[string]any, error) {
+	if seam == nil {
+		return nil, fmt.Errorf("flightplan: step %q is an llm-seam but no seam provider is configured (v1 leaves the seam unwired by default)", step.ID)
+	}
+	out, err := seam.Run(ctx, SeamRequest{
+		StepID:   step.ID,
+		Bindings: bindings,
+		Outputs:  step.Outputs,
+	})
+	if err != nil {
+		return nil, fmt.Errorf("flightplan: llm-seam step %q failed: %w", step.ID, err)
+	}
+	// The seam must produce every declared output so downstream bindings
+	// resolve. A missing output is a hard error: the graph cannot proceed.
+	for _, name := range step.Outputs {
+		if _, ok := out[name]; !ok {
+			return nil, fmt.Errorf("flightplan: llm-seam step %q did not produce declared output %q", step.ID, name)
+		}
+	}
+	return out, nil
+}

--- a/internal/flightplan/runtime/seam_test.go
+++ b/internal/flightplan/runtime/seam_test.go
@@ -1,0 +1,54 @@
+package runtime
+
+import (
+	"context"
+	"strings"
+	"testing"
+)
+
+func TestRunSeam_NilProviderErrorsByDefault(t *testing.T) {
+	step := Step{ID: "summarize", Kind: KindLLMSeam, Outputs: []string{"issue_body"}}
+	_, err := runSeam(context.Background(), nil, step, map[string]any{"series": "x"})
+	if err == nil {
+		t.Fatal("an llm-seam step with no provider must error (v1 reaches no LLM by default)")
+	}
+	if !strings.Contains(err.Error(), "no seam provider") {
+		t.Errorf("error = %v, want 'no seam provider'", err)
+	}
+}
+
+// fakeSeam is a test LLM seam. It is the ONLY way a test reaches the seam,
+// proving the seam is opt-in.
+type fakeSeam struct {
+	out map[string]any
+}
+
+func (f fakeSeam) Run(_ context.Context, req SeamRequest) (map[string]any, error) {
+	if f.out != nil {
+		return f.out, nil
+	}
+	out := map[string]any{}
+	for _, name := range req.Outputs {
+		out[name] = "seam-" + name
+	}
+	return out, nil
+}
+
+func TestRunSeam_ProducesDeclaredOutputs(t *testing.T) {
+	step := Step{ID: "s", Kind: KindLLMSeam, Outputs: []string{"issue_body"}}
+	out, err := runSeam(context.Background(), fakeSeam{}, step, map[string]any{"series": "x"})
+	if err != nil {
+		t.Fatalf("runSeam: %v", err)
+	}
+	if out["issue_body"] != "seam-issue_body" {
+		t.Errorf("seam output = %v", out["issue_body"])
+	}
+}
+
+func TestRunSeam_MissingOutputErrors(t *testing.T) {
+	step := Step{ID: "s", Kind: KindLLMSeam, Outputs: []string{"a", "b"}}
+	seam := fakeSeam{out: map[string]any{"a": 1}} // missing "b"
+	if _, err := runSeam(context.Background(), seam, step, nil); err == nil {
+		t.Fatal("a seam that omits a declared output must error")
+	}
+}

--- a/internal/flightplan/runtime/spi.go
+++ b/internal/flightplan/runtime/spi.go
@@ -1,0 +1,95 @@
+package runtime
+
+import "context"
+
+// The SPIs in this file are the thin seams the runtime core depends on so it
+// stays unit-testable with fakes. The CLI (cmd/aileron) wires each one to the
+// real daemon-backed implementation: ActionDispatcher → the action boundary
+// (internal/action), Approver → the approval queue (internal/approval),
+// AuditSink → the audit recorder (internal/audit), LLMSeam → an explicit LLM
+// provider (unset by default in v1). The runtime never imports those packages
+// concretely, mirroring the freeze DigestResolver/FeatureComposer discipline.
+
+// DispatchResult is the outcome of one action dispatch through the sealed
+// boundary. Output is the parsed action result the runtime reads downstream;
+// it carries no credential (credentials are injected host-side).
+type DispatchResult struct {
+	// Output is the action's result payload, a JSON-shaped map the runtime
+	// binds downstream steps against and redacts before surfacing.
+	Output map[string]any
+}
+
+// ActionDispatcher dispatches a declared action through the sealed action
+// boundary (ADR-0003/0005/0008). ref is the manifest action ref
+// (aileron:<connector>.<action>); args are resolved binding values, never
+// secrets. The host injects credentials at the boundary; dispatcher code
+// never sees them.
+type ActionDispatcher interface {
+	Dispatch(ctx context.Context, ref string, args map[string]any) (DispatchResult, error)
+}
+
+// ApprovalRequest is the effect-driven gate the runtime raises before a
+// non-read action-call. It mirrors the ActionApproval shape the daemon
+// approval lifecycle consumes (ADR-0009) without taking the dependency.
+type ApprovalRequest struct {
+	// ActionRef is the action awaiting a decision.
+	ActionRef string
+	// Effect is the operation effect that routed this action to approval.
+	Effect Effect
+	// Args is a redacted summary of the resolved args presented to the
+	// approver. Never secrets (bindings are references).
+	Args map[string]any
+}
+
+// Decision is an approval outcome.
+type Decision struct {
+	Approved bool
+	// Reason carries an optional human reason recorded in the audit on deny.
+	Reason string
+}
+
+// Approver routes an effect-gated action through the out-of-band approval
+// channel and blocks until a decision lands (ADR-0009). A read action never
+// reaches the Approver; the runtime calls it only for write/delete/spend/
+// external-send.
+type Approver interface {
+	Approve(ctx context.Context, req ApprovalRequest) (Decision, error)
+}
+
+// AuditRecord is one customer-owned audit entry. Fields holds exactly the
+// declared audit.fields for the action (data reads referenced by resolved
+// binding, never the dataset inline; ADR-0027 audit boundary).
+type AuditRecord struct {
+	// ActionRef is the action the record describes, or "" for a per-launch
+	// summary record.
+	ActionRef string
+	// Fields holds the declared audit field values.
+	Fields map[string]any
+	// Sink is the customer-owned sink reference from the trust contract.
+	Sink string
+}
+
+// AuditSink receives the per-action and per-launch audit records. The CLI
+// wires it to internal/audit.Recorder over the configured store; tests use a
+// recording fake. Record returns a record id the RunResult surfaces.
+type AuditSink interface {
+	Record(ctx context.Context, rec AuditRecord) string
+}
+
+// SeamRequest is the input to the single marked LLM seam (the llm-seam step).
+type SeamRequest struct {
+	StepID   string
+	Bindings map[string]any
+	// Outputs are the named results the seam must produce.
+	Outputs []string
+}
+
+// LLMSeam is the single marked non-deterministic seam (ADR-0027). It is the
+// ONLY interface in the runtime that may reach a language model. In v1 the
+// seam is unset by default, so an llm-seam step errors with "no seam provider
+// configured" and a default launch reaches no LLM at all. The action-call and
+// transform branches hold no reference to this type, so no deterministic step
+// can reach an LLM by construction.
+type LLMSeam interface {
+	Run(ctx context.Context, req SeamRequest) (map[string]any, error)
+}

--- a/internal/flightplan/runtime/transform.go
+++ b/internal/flightplan/runtime/transform.go
@@ -1,0 +1,81 @@
+package runtime
+
+import "fmt"
+
+// Transform is one deterministic, no-LLM transform. It reshapes data already
+// in the graph and has NO host, network, credential, or LLM surface. A
+// Transform receives the step's resolved bindings and the names it must
+// produce, and returns one value per declared output.
+//
+// The signature deliberately holds no reference to any seam or dispatcher
+// type: a transform cannot reach an LLM or the action boundary by
+// construction. This is half of the structural no-LLM guarantee (the other
+// half is that the executor's transform branch only calls into here).
+type Transform func(bindings map[string]any, outputs []string) (map[string]any, error)
+
+// TransformRegistry is the closed set of named deterministic transforms a plan
+// may use. v1 ships a default registry; the seam discipline keeps it a pure,
+// LLM-free unit. A transform step names its transform; an unnamed transform
+// step uses the identity passthrough so the worked example (whose transform
+// reshapes a series into a CSV) runs without a bespoke registry entry in v1.
+type TransformRegistry struct {
+	byName map[string]Transform
+}
+
+// NewTransformRegistry returns the default registry. v1 registers the
+// deterministic transforms the runtime needs; callers may extend it before a
+// run. The registry never contains an LLM-backed transform: that is what the
+// llm-seam kind is for.
+func NewTransformRegistry() *TransformRegistry {
+	r := &TransformRegistry{byName: map[string]Transform{}}
+	r.byName["identity"] = identityTransform
+	r.byName["passthrough"] = identityTransform
+	return r
+}
+
+// Register adds a named transform. It overwrites an existing name so a host
+// can supply its own deterministic transform for a plan.
+func (r *TransformRegistry) Register(name string, t Transform) {
+	r.byName[name] = t
+}
+
+// run executes the transform for a step. v1 transform steps do not name a
+// transform in the manifest schema (the transformStep shape carries no
+// transform name), so the runtime applies the registry's `identity` transform
+// by default: it surfaces each binding under the matching declared output
+// name, and for a single-output step with a single binding it maps that
+// binding to the output. A host may override `identity` (or register named
+// transforms) before a run to supply deterministic reshaping; the registry is
+// the single, LLM-free transform vocabulary. This keeps the worked example
+// deterministic and LLM-free while a richer named-transform vocabulary lands
+// later.
+func (r *TransformRegistry) run(step Step, bindings map[string]any) (map[string]any, error) {
+	t, ok := r.byName["identity"]
+	if !ok {
+		t = identityTransform
+	}
+	return t(bindings, step.Outputs)
+}
+
+// identityTransform is the deterministic default: it produces one value per
+// declared output. With one output and one binding it forwards the binding
+// value; otherwise it groups all bindings under each output name. It is pure
+// and total, so the same bindings always yield the same output.
+func identityTransform(bindings map[string]any, outputs []string) (map[string]any, error) {
+	if len(outputs) == 0 {
+		return nil, fmt.Errorf("transform declares no outputs")
+	}
+	out := make(map[string]any, len(outputs))
+	if len(outputs) == 1 && len(bindings) == 1 {
+		for _, v := range bindings {
+			out[outputs[0]] = v
+		}
+		return out, nil
+	}
+	for _, name := range outputs {
+		// Each output receives a snapshot of the bindings so the transform is
+		// deterministic and the outputs are independent values.
+		out[name] = deepCopyValue(any(bindings))
+	}
+	return out, nil
+}

--- a/internal/flightplan/runtime/transform_test.go
+++ b/internal/flightplan/runtime/transform_test.go
@@ -1,0 +1,51 @@
+package runtime
+
+import (
+	"reflect"
+	"testing"
+)
+
+func TestTransform_Deterministic(t *testing.T) {
+	reg := NewTransformRegistry()
+	step := Step{ID: "s", Kind: KindTransform, Outputs: []string{"out"}}
+	bind := map[string]any{"series": []any{1, 2, 3}}
+	a, err := reg.run(step, bind)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	b, err := reg.run(step, bind)
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if !reflect.DeepEqual(a, b) {
+		t.Errorf("transform not deterministic: %v vs %v", a, b)
+	}
+}
+
+func TestTransform_SingleOutputSingleBindingForwards(t *testing.T) {
+	reg := NewTransformRegistry()
+	step := Step{ID: "s", Kind: KindTransform, Outputs: []string{"csv"}}
+	out, err := reg.run(step, map[string]any{"series": "data"})
+	if err != nil {
+		t.Fatalf("run: %v", err)
+	}
+	if out["csv"] != "data" {
+		t.Errorf("single-output single-binding must forward the value, got %v", out["csv"])
+	}
+}
+
+func TestTransform_NoOutputsErrors(t *testing.T) {
+	if _, err := identityTransform(map[string]any{}, nil); err == nil {
+		t.Fatal("a transform with no declared outputs must error")
+	}
+}
+
+func TestTransform_RegisterCustom(t *testing.T) {
+	reg := NewTransformRegistry()
+	reg.Register("upper", func(b map[string]any, outs []string) (map[string]any, error) {
+		return map[string]any{outs[0]: "X"}, nil
+	})
+	if _, ok := reg.byName["upper"]; !ok {
+		t.Error("Register must add the transform")
+	}
+}


### PR DESCRIPTION
## Summary

Adds the deterministic **Launch runtime** that runs a frozen Aileron Flight Plan with no LLM in the execution loop (#1511). A new `internal/flightplan/runtime` package owns a typed step-graph model and walks it as plain code; the CLI exposes it as `aileron skill launch`.

What lands:

- **Typed step-graph + strict decode** (`plan.go`, `decode.go`, `dto.go`, `binding.go`). The loosely-typed manifest `[]any` blocks decode into a validated `Plan`. An unknown `kind`, a binding outside the closed grammar, a duplicate id, a `steps.*` cycle, a binding to an undeclared input/absent step, an action-call to an undeclared action, or a `materializesOutput` naming an undeclared output is a hard refusal before any step runs. Cycle detection is scoped to `steps.*` edges only, so a `source` input that reads the same action a step calls is not treated as a graph edge (#1523).
- **Load + verify gate** (`load.go` + new `freeze.VerifyFrozen`). A frozen unit refuses to run unless the author signature verifies and the recorded content hash matches the on-disk bytes. `VerifyFrozen` reconstructs the exact canonical bytes freeze signed by reusing the freeze write primitives (`injectLock`/`MarshalLockfile`), so there is no parallel byte editor to drift.
- **Single-boundary input resolution** (`inputs.go`, `clock.go`). Every input resolves once at the launch boundary: `literal` (override → default), `dynamic` (one clock read reused for every dynamic input), `source` (one enforced dispatch, recorded by resolved binding never the dataset).
- **Trust-contract enforcement** (`dispatch.go`, `approval.go`, `redact.go`). Effect-routed approval (read unattended; write/delete/spend/external-send gated and blocking), idempotency-on-retry (a non-`safeToRetry` action is never silently re-issued; an `idempotencyKey` contract threads a stable key), and redaction applied to the result before it surfaces into the graph or audit.
- **Deterministic executor** (`execute.go`, `transform.go`, `seam.go`). Exactly three step-kind branches; `action-call`/`transform` hold no reference to any LLM type. The marked `llm-seam` is the only path to a model and is **unwired by default**, so a default launch reaches no LLM at all.
- **Output materialization** (`materialize.go`). utf-8 file-map entries are written to the declared `publish.path`; `base64`/binary is refused with a message citing the deferred mount boundary (#1510). Artifact write paths are constrained to the out-dir (no `..`/absolute escape).
- **Run orchestration + audit** (`run.go`, `audit.go`). Stitches load→resolve→execute→materialize→audit; emits per-action and per-launch records carrying only the declared `audit.fields`, data reads referenced by binding.
- **CLI** (`cmd/aileron/skill_launch.go`): `aileron skill launch <name> [--version] [--input k=v] [--out-dir]`, wired to the daemon action `/run` boundary via package-level seams. Distinct from the top-level agent-sandbox `aileron launch`.
- **Docs**: new "Launching a Flight Plan" guide + nav entry + a spec cross-reference.

No OpenAPI/HTTP change: Launch loads a local frozen plan and dispatches through the existing action boundary.

## Test plan

- `internal/flightplan/runtime`: decode (worked example + every refusal branch), binding grammar, load/verify (untampered loads; tampered manifest/signature/lockfile/missing key all refuse), input resolution (literal default/override, dynamic-read-once via a counting clock, source-by-binding), dispatch (read unattended, write blocks→proceeds, delete aborts-on-deny, non-retryable not re-issued, idempotency key threaded, redaction-before-surface, no-approver-errors), transform determinism, seam (nil-provider errors by default; produces declared outputs), materialize (utf-8 written, base64 refused citing #1510, mime mismatch refused, target:none retained), run (writes artifacts, **determinism property** same inputs→byte-identical output, **structural no-LLM** default-launch refuses the seam, denied-approval aborts and audits), audit (only declared fields, result summarized by shape not data), and path-traversal refusal. Coverage 83.5%.
- `internal/flightplan/freeze`: `VerifyFrozen` round-trip + tamper cases. Coverage 87.6%.
- `cmd/aileron`: `skill launch` end-to-end against a fake store + fake dispatcher (writes artifacts), missing/unverifiable version refuses, `--input` override, unknown skill errors, malformed `--input`, daemon dispatcher 200/202/500 branches via httptest, ref→name mapping, result-payload decoding.

All affected packages build, vet clean, and pass.

### Known gaps / scope notes
- v1 leaves the LLM seam unwired (the worked example's `llm-seam` step errors unless a provider is supplied); this is the intended no-LLM-by-default contract, not a missing feature.
- The CLI's daemon-backed approver defers to the daemon's own `/run` gate (a 202 surfaces an approve-and-re-launch error) to avoid double-gating; an interactive in-process approval loop is a follow-up.

Closes #1511

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added `aileron skill launch` to run frozen Flight Plans with version selection, input overrides, and output directory support.
  * Launches now verify frozen content before execution and provide a summary of resolved inputs, artifacts, and audit activity.
* **Bug Fixes**
  * Improved enforcement around approvals, retries, output materialization, and safe artifact paths.
  * Added stronger validation for plan loading, bindings, inputs, and execution determinism.
* **Documentation**
  * Added a launch guide and updated manifest docs to explain the new runtime behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->