### PR TITLE
feat(systest): port codex.sh scenario body to a shell-free Go driver

### DIFF
--- a/go.work
+++ b/go.work
@@ -7,4 +7,5 @@ use (
 	./sdk/go
 	./test/integration
 	./test/system/lib
+	./test/system/scenario
 )

--- a/test/system/README.md
+++ b/test/system/README.md
@@ -16,13 +16,35 @@ test/system/
   README.md            this file
   codex.sh             the codex scenario body (#1476)
   claude.sh            the claude scenario body (#1477)
+  scenario/            shell-free Go scenario driver (#1624), its own module,
+                       run by hand with `go run ./test/system/scenario codex`;
+                       NOT in GO_TEST_PACKAGES, so the live path never runs in CI
+    main.go            agent-name dispatch (codex today; claude in #1625)
+    scenario.go        the live orchestration (background launch, reap,
+                       discovery poll, probes, sentinel read, R10 audit)
+    docker.go          thin docker ps/inspect/exec shellouts returning raw facts
   lib/
     assert.sh          generic assert/log helpers (sourced)
     probes.sh          agent-agnostic R8 wiring-invariant probes (sourced)
-    *_test.go          Go contract suite for assert.sh and probes.sh plus the
-                       launch-target taskenv wiring regression; needs only the
-                       Go toolchain, no Docker and no shell (CI-safe, Windows)
+    runner.go          AgentConfig + CodexConfig + BuildExecArgs/BuildPrompt
+    sentinel.go        per-run sentinel (R9) generation
+    audit.go           pure R10 audit event-record count + assertion
+    scenario.go        pure R8.1/8.3/8.4/8.5 decision predicates (docker-free)
+    *_test.go          Go contract suite for the shell library and the pure Go
+                       scenario logic plus the launch-target taskenv wiring
+                       regression; needs only the Go toolchain, no Docker and no
+                       shell (CI-safe, Windows)
 ```
+
+The Go driver is the shell-free equivalent of `codex.sh`. Both still exist
+side by side: the Taskfile target `test:system:launch:codex` runs `codex.sh`
+today, and the Go path is added and documented here. `codex.sh` (and
+`claude.sh`/`probes.sh`/`assert.sh`) stay on disk and functional; the Taskfile
+rewire and the shell retirement happen in #1626. The pure decision logic the Go
+driver depends on lives in `lib/` (`systestlib`) and is covered by the standard
+`go test ./test/system/lib/...` CI job; the `scenario/` module holds only the
+impure docker/exec/poll plumbing and has no tests by design (it is the live
+path, excluded from CI).
 
 ## Static gate (what runs unattended vs. by hand)
 
@@ -30,7 +52,9 @@ test/system/
 | --- | --- | --- | --- |
 | Library contract tests | `task test:system:lib` | Go toolchain | yes, runs unattended and on Windows (Go contract suite, no Docker, no shell) |
 | Scenario wiring compile | `task --dry test:system:launch:codex` / `:claude` | nothing | yes — compiles the target, does not launch |
-| Live codex scenario | `task test:system:launch:codex` | Docker + `codex login` + tokens | **no — by hand on a real host** |
+| Go scenario driver compile | `go build ./test/system/scenario` | Go toolchain | yes — compiles the driver; its own module, not in GO_TEST_PACKAGES |
+| Live codex scenario (shell) | `task test:system:launch:codex` | Docker + `codex login` + tokens | **no — by hand on a real host** |
+| Live codex scenario (Go) | `go run ./test/system/scenario codex` | Docker + `codex login` + tokens | **no — by hand on a real host** |
 | Live claude scenario | `task test:system:launch:claude` | Docker + Claude login (vault, ADR-0025) + tokens | **no — by hand on a real host** |
 
 The headless path validates the **wiring** (the target compiles, the build
@@ -57,6 +81,34 @@ The target builds a fresh `aileron` (+ the Linux `aileron-mcp` sibling),
 checks the preconditions, runs `test/system/codex.sh`, and on exit the
 deferred cleanup removes the sandbox container and the temp workspace even if
 an assertion failed.
+
+## Run the codex scenario by hand (shell-free Go)
+
+`test/system/scenario` is the shell-free Go equivalent of `codex.sh`. It runs
+the same R7a/R8.1-8.6/R9/R10 assertions, delegating every decision to the pure
+`lib/` (`systestlib`) package, and holds only the impure docker/exec/poll
+plumbing. It needs the same prerequisites as the shell scenario (Docker, a
+`codex login`, and optionally a running daemon for R10). It reads its inputs
+from the environment, so build an `aileron` first and point the driver at it:
+
+```sh
+task build                                  # produces build/aileron
+AILERON_BIN="$PWD/build/aileron" \
+WORKSPACE="$(mktemp -d)" \
+AILERON_STATE_DIR="$HOME/.aileron" \
+  go run ./test/system/scenario codex
+```
+
+`EXPECTED_IMAGE` overrides the default expected image ref the same way the shell
+scenario does. `AILERON_STATE_DIR` is optional: when unset the R10 audit
+assertion is skipped with a logged note. The driver imports the scenario library
+as a Go package, so the `AILERON_SYSTEST_LIB` variable the shell path needs is
+vestigial for the Go path and is not read.
+
+The driver is its own nested Go module outside `./test/system/lib/...`, so the
+standard `go test ./test/system/lib/...` coverage and vet CI job never compiles
+or executes it and cannot start a real container. Its pure logic is covered by
+the `systestlib` unit tests; the driver itself has no tests by design.
 
 ## What the codex scenario asserts
 

--- a/test/system/lib/audit.go
+++ b/test/system/lib/audit.go
@@ -1,0 +1,76 @@
+// Pure R10 audit-round-trip parsing for the shell-free scenario driver. The bash
+// counts `jq -c 'select(.event != null)'` lines in today's audit JSONL file and
+// asserts the count is greater than zero, proving the agent's http_request tool
+// produced a daemon-side audit record for the run. This file re-expresses that
+// count + assertion as pure Go over the file bytes.
+//
+// The event-line definition is reimplemented locally (not by importing
+// internal/audit) so the nested test/system/lib module stays dependency-free and
+// isolated, consistent with the existing probes.go isolation. The behavior
+// matches internal/audit.readMessageEntriesFromFile: skip empty lines, skip lines
+// that do not JSON-decode, and skip lines whose decoded "event" field is empty;
+// every remaining line is one event record.
+package systestlib
+
+import (
+	"bufio"
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"io"
+)
+
+// CountAuditEventRecords counts the audit "event records" in a JSONL byte stream,
+// matching the bash `jq -c 'select(.event != null)' | wc -l`. A line counts when
+// it JSON-decodes to an object with a non-empty "event" field. Empty lines and
+// non-JSON lines are skipped (mirroring internal/audit). The returned error is
+// non-nil only for an underlying read error; a well-formed stream with zero event
+// records returns (0, nil) so the caller (AssertAuditHasEvents) can render the
+// faithful R10 diagnostic.
+func CountAuditEventRecords(jsonl []byte) (int, error) {
+	return countAuditEventRecords(bytes.NewReader(jsonl))
+}
+
+func countAuditEventRecords(r io.Reader) (int, error) {
+	count := 0
+	scanner := bufio.NewScanner(r)
+	// Audit lines can be long (message bodies); raise the token limit above the
+	// 64KiB default so a large but valid record is not truncated into a parse miss.
+	scanner.Buffer(make([]byte, 0, 64*1024), 4*1024*1024)
+	for scanner.Scan() {
+		line := scanner.Bytes()
+		if len(bytes.TrimSpace(line)) == 0 {
+			continue
+		}
+		var rec struct {
+			Event string `json:"event"`
+		}
+		if err := json.Unmarshal(line, &rec); err != nil {
+			continue
+		}
+		if rec.Event == "" {
+			continue
+		}
+		count++
+	}
+	if err := scanner.Err(); err != nil {
+		return 0, err
+	}
+	return count, nil
+}
+
+// AssertAuditHasEvents is the R10 decision wrapper: it returns nil when the audit
+// JSONL contains at least one event record, and otherwise the faithful R10
+// diagnostic ("R10 no event records in <path> for this run"), mirroring the bash
+// `fail` wording. auditPath is used only for the diagnostic. A read error from
+// CountAuditEventRecords is surfaced as a non-nil error too.
+func AssertAuditHasEvents(jsonl []byte, auditPath string) error {
+	count, err := CountAuditEventRecords(jsonl)
+	if err != nil {
+		return Fail(fmt.Sprintf("R10 could not parse audit file %s: %v", auditPath, err))
+	}
+	if count > 0 {
+		return nil
+	}
+	return Fail(fmt.Sprintf("R10 no event records in %s for this run", auditPath))
+}

--- a/test/system/lib/audit_test.go
+++ b/test/system/lib/audit_test.go
@@ -1,0 +1,80 @@
+// Contract tests for the pure R10 audit parser. They assert the happy path (a
+// file with N event lines counts N), the documented-failure path (no event lines
+// yields the faithful "no event records" diagnostic via the assert wrapper), and
+// the skip rules that match internal/audit: malformed JSON lines and empty lines
+// are skipped, and a line whose "event" field is empty/absent is not an event
+// record.
+package systestlib_test
+
+import (
+	"strings"
+	"testing"
+
+	systestlib "github.com/ALRubinger/aileron/test/system/lib"
+)
+
+func TestCountAuditEventRecordsHappyPath(t *testing.T) {
+	jsonl := []byte(strings.Join([]string{
+		`{"event":"message_received","session_id":"s1"}`,
+		`{"event":"message_sent","session_id":"s1"}`,
+		`{"event":"reply_sent","session_id":"s2"}`,
+	}, "\n") + "\n")
+	got, err := systestlib.CountAuditEventRecords(jsonl)
+	if err != nil {
+		t.Fatalf("CountAuditEventRecords returned error %v; want nil", err)
+	}
+	if got != 3 {
+		t.Errorf("count = %d; want 3", got)
+	}
+}
+
+func TestCountAuditEventRecordsSkipRules(t *testing.T) {
+	jsonl := []byte(strings.Join([]string{
+		`{"event":"message_received"}`, // counts
+		``,                             // empty line: skipped
+		`   `,                          // whitespace-only line: skipped
+		`not json at all`,              // malformed: skipped
+		`{"event":""}`,                 // empty event field: skipped
+		`{"session_id":"s1"}`,          // no event field: skipped
+		`{"event":"reply_sent"}`,       // counts
+	}, "\n") + "\n")
+	got, err := systestlib.CountAuditEventRecords(jsonl)
+	if err != nil {
+		t.Fatalf("CountAuditEventRecords returned error %v; want nil", err)
+	}
+	if got != 2 {
+		t.Errorf("count = %d; want 2 (only the two non-empty event lines)", got)
+	}
+}
+
+func TestCountAuditEventRecordsEmptyStream(t *testing.T) {
+	got, err := systestlib.CountAuditEventRecords([]byte(""))
+	if err != nil {
+		t.Fatalf("CountAuditEventRecords returned error %v; want nil", err)
+	}
+	if got != 0 {
+		t.Errorf("count = %d; want 0 for an empty stream", got)
+	}
+}
+
+func TestAssertAuditHasEventsHappyPath(t *testing.T) {
+	jsonl := []byte(`{"event":"message_sent","session_id":"s1"}` + "\n")
+	if err := systestlib.AssertAuditHasEvents(jsonl, "/state/audit/audit-2026-06-24.jsonl"); err != nil {
+		t.Errorf("AssertAuditHasEvents returned error %v; want nil for a file with an event record", err)
+	}
+}
+
+func TestAssertAuditHasEventsNoRecords(t *testing.T) {
+	// A file with only non-event lines must fail with the faithful R10 diagnostic.
+	jsonl := []byte(`{"session_id":"s1"}` + "\n" + `not json` + "\n")
+	const path = "/state/audit/audit-2026-06-24.jsonl"
+	err := systestlib.AssertAuditHasEvents(jsonl, path)
+	if err == nil {
+		t.Fatal("AssertAuditHasEvents returned nil; want the R10 no-event-records error")
+	}
+	for _, sub := range []string{"R10", "no event records", path} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("error %q does not contain %q", err.Error(), sub)
+		}
+	}
+}

--- a/test/system/lib/runner.go
+++ b/test/system/lib/runner.go
@@ -1,0 +1,132 @@
+// Pure, docker-free scenario configuration and assembly logic for the shell-free
+// Go `aileron launch` system-test driver (#1624). The bash scenario bodies
+// (codex.sh / claude.sh) hard-code their agent bindings inline and assemble the
+// launch command + agent prompt as shell strings. This file re-expresses that
+// agent-config wiring and command/prompt assembly as pure Go: an AgentConfig
+// struct carries the per-agent bindings, and a small set of pure constructors
+// turn it into the post-`--` token list and the deterministic agent prompt.
+//
+// Everything here is pure (no os/exec, no docker, no filesystem): the impure
+// live-Docker plumbing lives in the separate test/system/scenario main module,
+// which imports this package and delegates every decision back to it. Keeping
+// the wiring pure is what lets the standard `go test ./test/system/lib/...` CI
+// job cover the agent-config + assembly contract with no container.
+//
+// The codex bindings are confirmed against codex.sh: IMAGE_SUFFIX=codex,
+// EXPECTED_IMAGE default ghcr.io/alrubinger/aileron-sandbox-codex:edge,
+// CONFIG_PATH=/home/agent/.codex/config.toml, MCP_MARKER=[mcp_servers.aileron],
+// AUTH_PATH=/home/agent/.codex/auth.json, batch flags exec --skip-git-repo-check,
+// workspace container path /home/agent/workspace, sentinel file
+// .aileron-systest-sentinel.
+package systestlib
+
+import "fmt"
+
+// MCPMode distinguishes how an agent is pointed at the aileron MCP server, which
+// in turn selects which R8.2 probe applies. Codex writes a config.toml the host
+// can read inside the container (config-file mode); Claude passes `--mcp-config`
+// on the command line (cmdline mode). The runner needs both shapes so #1625
+// (claude) reuses this struct without a runner change.
+type MCPMode int
+
+const (
+	// MCPModeConfigFile is the codex shape: the agent reads an MCP config file in
+	// the container (ConfigPath) which must contain MCPMarker. Probe via
+	// ProbeMCPRuntime + the config-file read (ProbeMCPConfigContains).
+	MCPModeConfigFile MCPMode = iota
+	// MCPModeCmdline is the claude shape: the agent is wired by a command-line
+	// flag (MCPFlag) whose payload references MCPMarker. Probe via ProbeMCPCmdline.
+	MCPModeCmdline
+)
+
+// AgentConfig carries every per-agent binding the scenario driver needs, so the
+// driver itself is agent-agnostic and a new agent is one constructor. The codex
+// constructor is CodexConfig; the claude constructor lands in #1625 reusing this
+// shape verbatim.
+type AgentConfig struct {
+	// Name is the `aileron launch <Name>` agent argument (e.g. "codex").
+	Name string
+	// ExpectedImage is the already-resolved R8.1 expected image ref (default or
+	// EXPECTED_IMAGE override). Use ResolveExpectedImage to compute it.
+	ExpectedImage string
+	// MCPMode selects the R8.2 probe shape (config-file vs cmdline).
+	MCPMode MCPMode
+	// ConfigPath is the in-container MCP config file path (config-file mode only).
+	ConfigPath string
+	// MCPFlag is the command-line MCP flag (cmdline mode only, e.g. --mcp-config).
+	MCPFlag string
+	// MCPMarker is the substring that proves the aileron MCP block/payload is
+	// present (config-file marker e.g. "[mcp_servers.aileron]", or cmdline server
+	// name marker e.g. `"aileron"`).
+	MCPMarker string
+	// AuthPath is the in-container credential file path (R8.3).
+	AuthPath string
+	// BatchFlags are the agent-specific tokens that precede the prompt in the
+	// post-`--` forwarding (R7a), e.g. ["exec", "--skip-git-repo-check"] for codex
+	// or ["-p"] for claude.
+	BatchFlags []string
+	// WorkspaceContainerPath is the bind-mounted workspace path inside the
+	// container (where the agent writes the sentinel).
+	WorkspaceContainerPath string
+	// SentinelName is the sentinel file basename (R9), e.g. .aileron-systest-sentinel.
+	SentinelName string
+}
+
+// codexDefaultImage is the floating dev image ref codex.sh defaults EXPECTED_IMAGE
+// to. A dev/empty version build pulls :edge; override with EXPECTED_IMAGE to
+// assert a release :latest or a digest pin.
+const codexDefaultImage = "ghcr.io/alrubinger/aileron-sandbox-codex:edge"
+
+// ResolveExpectedImage mirrors codex.sh's `EXPECTED_IMAGE="${EXPECTED_IMAGE:-<default>}"`:
+// a non-empty override wins, otherwise the agent default is used. Pure; the
+// override is passed in (read from os.Getenv("EXPECTED_IMAGE") by the live driver)
+// so this stays host-verifiable.
+func ResolveExpectedImage(override, def string) string {
+	if override != "" {
+		return override
+	}
+	return def
+}
+
+// CodexConfig returns the codex AgentConfig with bindings confirmed against
+// codex.sh. override is the EXPECTED_IMAGE value (empty for the default); the
+// live driver passes os.Getenv("EXPECTED_IMAGE").
+func CodexConfig(expectedImageOverride string) AgentConfig {
+	return AgentConfig{
+		Name:                   "codex",
+		ExpectedImage:          ResolveExpectedImage(expectedImageOverride, codexDefaultImage),
+		MCPMode:                MCPModeConfigFile,
+		ConfigPath:             "/home/agent/.codex/config.toml",
+		MCPMarker:              "[mcp_servers.aileron]",
+		AuthPath:               "/home/agent/.codex/auth.json",
+		BatchFlags:             []string{"exec", "--skip-git-repo-check"},
+		WorkspaceContainerPath: "/home/agent/workspace",
+		SentinelName:           ".aileron-systest-sentinel",
+	}
+}
+
+// BuildExecArgs assembles the post-`--` token list forwarded to the agent CLI,
+// mirroring codex.sh's `-- exec --skip-git-repo-check "<prompt>"` (R7a). The
+// result is BatchFlags followed by the single prompt token. A fresh slice is
+// returned so the caller cannot mutate cfg.BatchFlags through the result.
+func BuildExecArgs(cfg AgentConfig, prompt string) []string {
+	args := make([]string, 0, len(cfg.BatchFlags)+1)
+	args = append(args, cfg.BatchFlags...)
+	args = append(args, prompt)
+	return args
+}
+
+// BuildPrompt assembles the deterministic two-step agent prompt, byte-for-byte
+// faithful to codex.sh's EXEC_PROMPT: (1) write the exact sentinel string (no
+// newline, nothing else) to <WorkspaceContainerPath>/<SentinelName>, and (2)
+// call the aileron http_request tool GET ${AILERON_URL}/healthz so a daemon-side
+// audit record lands for the run (R10). sentinel is the per-run token from
+// Sentinel(runID). The ${AILERON_URL} is left literal so the container's shell/
+// agent expands it inside the sandbox, matching the bash.
+func BuildPrompt(cfg AgentConfig, sentinel string) string {
+	return fmt.Sprintf(
+		"Do exactly two things and then stop. "+
+			"1) Write the exact text %s (no newline, nothing else) to the file %s/%s. "+
+			"2) Call the aileron http_request tool with method GET and url ${AILERON_URL}/healthz.",
+		sentinel, cfg.WorkspaceContainerPath, cfg.SentinelName)
+}

--- a/test/system/lib/runner_test.go
+++ b/test/system/lib/runner_test.go
@@ -1,0 +1,123 @@
+// Contract tests for the pure agent-config + command/prompt assembly logic.
+// They assert the codex bindings exactly (faithful to codex.sh), the
+// EXPECTED_IMAGE override precedence, and that the assembled exec args and prompt
+// match the bash byte-for-byte. No docker, no filesystem.
+package systestlib_test
+
+import (
+	"strings"
+	"testing"
+
+	systestlib "github.com/ALRubinger/aileron/test/system/lib"
+)
+
+func TestCodexConfigBindings(t *testing.T) {
+	cfg := systestlib.CodexConfig("")
+
+	if cfg.Name != "codex" {
+		t.Errorf("Name = %q; want %q", cfg.Name, "codex")
+	}
+	if cfg.ExpectedImage != "ghcr.io/alrubinger/aileron-sandbox-codex:edge" {
+		t.Errorf("ExpectedImage = %q; want the codex :edge default", cfg.ExpectedImage)
+	}
+	if cfg.MCPMode != systestlib.MCPModeConfigFile {
+		t.Errorf("MCPMode = %v; want MCPModeConfigFile", cfg.MCPMode)
+	}
+	if cfg.ConfigPath != "/home/agent/.codex/config.toml" {
+		t.Errorf("ConfigPath = %q; want the codex config.toml path", cfg.ConfigPath)
+	}
+	if cfg.MCPMarker != "[mcp_servers.aileron]" {
+		t.Errorf("MCPMarker = %q; want the codex config-file marker", cfg.MCPMarker)
+	}
+	if cfg.AuthPath != "/home/agent/.codex/auth.json" {
+		t.Errorf("AuthPath = %q; want the codex auth.json path", cfg.AuthPath)
+	}
+	if cfg.WorkspaceContainerPath != "/home/agent/workspace" {
+		t.Errorf("WorkspaceContainerPath = %q; want /home/agent/workspace", cfg.WorkspaceContainerPath)
+	}
+	if cfg.SentinelName != ".aileron-systest-sentinel" {
+		t.Errorf("SentinelName = %q; want .aileron-systest-sentinel", cfg.SentinelName)
+	}
+	wantFlags := []string{"exec", "--skip-git-repo-check"}
+	if len(cfg.BatchFlags) != len(wantFlags) {
+		t.Fatalf("BatchFlags = %v; want %v", cfg.BatchFlags, wantFlags)
+	}
+	for i := range wantFlags {
+		if cfg.BatchFlags[i] != wantFlags[i] {
+			t.Errorf("BatchFlags[%d] = %q; want %q", i, cfg.BatchFlags[i], wantFlags[i])
+		}
+	}
+	// Codex is config-file mode, so MCPFlag is unused (empty).
+	if cfg.MCPFlag != "" {
+		t.Errorf("MCPFlag = %q; want empty for config-file mode", cfg.MCPFlag)
+	}
+}
+
+func TestResolveExpectedImage(t *testing.T) {
+	const def = "ghcr.io/alrubinger/aileron-sandbox-codex:edge"
+	if got := systestlib.ResolveExpectedImage("", def); got != def {
+		t.Errorf("empty override = %q; want default %q", got, def)
+	}
+	override := "ghcr.io/alrubinger/aileron-sandbox-codex@sha256:abc"
+	if got := systestlib.ResolveExpectedImage(override, def); got != override {
+		t.Errorf("override = %q; want %q (override beats default)", got, override)
+	}
+}
+
+func TestCodexConfigHonorsExpectedImageOverride(t *testing.T) {
+	override := "ghcr.io/alrubinger/aileron-sandbox-codex:latest"
+	cfg := systestlib.CodexConfig(override)
+	if cfg.ExpectedImage != override {
+		t.Errorf("ExpectedImage = %q; want the override %q", cfg.ExpectedImage, override)
+	}
+}
+
+func TestBuildExecArgs(t *testing.T) {
+	cfg := systestlib.CodexConfig("")
+	args := systestlib.BuildExecArgs(cfg, "PROMPT")
+	want := []string{"exec", "--skip-git-repo-check", "PROMPT"}
+	if len(args) != len(want) {
+		t.Fatalf("BuildExecArgs = %v; want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q; want %q", i, args[i], want[i])
+		}
+	}
+}
+
+// TestBuildExecArgsDoesNotAliasBatchFlags proves the returned slice is
+// independent, so a caller mutating it cannot corrupt the config's BatchFlags.
+func TestBuildExecArgsDoesNotAliasBatchFlags(t *testing.T) {
+	cfg := systestlib.CodexConfig("")
+	args := systestlib.BuildExecArgs(cfg, "P")
+	args[0] = "MUTATED"
+	if cfg.BatchFlags[0] != "exec" {
+		t.Errorf("mutating the result changed cfg.BatchFlags[0] to %q; want it isolated", cfg.BatchFlags[0])
+	}
+}
+
+func TestBuildPrompt(t *testing.T) {
+	cfg := systestlib.CodexConfig("")
+	sentinel := systestlib.Sentinel("17-42-abc")
+	prompt := systestlib.BuildPrompt(cfg, sentinel)
+
+	// Side effect 1: write the exact sentinel to the workspace sentinel file.
+	if !strings.Contains(prompt, sentinel) {
+		t.Errorf("prompt missing the sentinel token %q:\n%s", sentinel, prompt)
+	}
+	wantPath := cfg.WorkspaceContainerPath + "/" + cfg.SentinelName
+	if !strings.Contains(prompt, wantPath) {
+		t.Errorf("prompt missing the sentinel file path %q:\n%s", wantPath, prompt)
+	}
+	// Side effect 2: call the http_request tool GET ${AILERON_URL}/healthz.
+	if !strings.Contains(prompt, "http_request") {
+		t.Errorf("prompt missing the http_request instruction:\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "${AILERON_URL}/healthz") {
+		t.Errorf("prompt missing the healthz URL (literal ${AILERON_URL}):\n%s", prompt)
+	}
+	if !strings.Contains(prompt, "method GET") {
+		t.Errorf("prompt missing the GET method:\n%s", prompt)
+	}
+}

--- a/test/system/lib/scenario.go
+++ b/test/system/lib/scenario.go
@@ -1,0 +1,102 @@
+// Pure scenario decision predicates for the live-Docker probes whose decision
+// cores were not yet in probes.go: the R8.3 credentials decision (auth file
+// present + mode 0600 + parent dir bind-mounted), the R8.4 daemon-reachable
+// decision (AILERON_URL host is host.docker.internal, plus the Linux-gated
+// host-gateway ExtraHosts check), and the R8.5 teardown decision (no sandbox
+// container survived). Each takes the docker-derived facts the live driver
+// gathers (printenv output, stat mode, the mount list, ExtraHosts, surviving
+// names) as ordinary parameters and returns the pass/fail error, exactly as
+// probes.go does for ProbeMCPRuntime / ProbeExitCode / DiscoverContainer. This
+// keeps the orchestration *decisions* unit-tested with stubbed facts while the
+// impure docker exec/inspect plumbing stays in the scenario main module.
+package systestlib
+
+import (
+	"fmt"
+	"strings"
+)
+
+// ProbeCredentials re-expresses probe_credentials' decision core (R8.3). The live
+// driver supplies: authFileExists (`docker exec test -f <auth_path>` succeeded),
+// mode (`docker exec stat -c %a <auth_path>`, e.g. "600"), authDir
+// (path.Dir(authPath)), and mounts (the `{{.Type}}:{{.Destination}}` block from
+// `docker inspect`, one per line). Returns nil only when the file exists, the
+// mode is exactly "600", and some bind mount's Destination equals authDir.
+// Diagnostics mirror the shell's R8.3 wording so CI logs read the same.
+func ProbeCredentials(authFileExists bool, mode, authPath, authDir, mounts string) error {
+	if !authFileExists {
+		return Fail(fmt.Sprintf("R8.3 auth file %s missing in container", authPath))
+	}
+	if err := AssertEq("600", mode, fmt.Sprintf("R8.3 %s mode is 0600", authPath)); err != nil {
+		return err
+	}
+	// The auth file's parent dir must be a bind mount. The shell matches the
+	// substring `bind:<authDir>` in the mount block; do the same but anchor each
+	// line so a parent-of-parent prefix cannot accidentally satisfy it.
+	want := "bind:" + authDir
+	for _, line := range strings.Split(mounts, "\n") {
+		if strings.TrimSpace(line) == want {
+			return nil
+		}
+	}
+	return fmt.Errorf("systest: FAIL: R8.3 no bind mount for %s; mounts were:\n%s", authDir, mounts)
+}
+
+// ProbeDaemonReachable re-expresses probe_daemon_reachable's decision core
+// (R8.4). url is the container's AILERON_URL (`docker exec printenv AILERON_URL`).
+// It must contain host.docker.internal (the loopback rewrite). isLinuxHost gates
+// the second check: on a Linux Docker host the launcher injects
+// `--add-host host.docker.internal:host-gateway`, which surfaces in extraHosts
+// (the `{{range .HostConfig.ExtraHosts}}` block); on macOS/Windows Docker Desktop
+// the gateway is built in, so the check is skipped. Returns nil when the
+// applicable checks hold.
+func ProbeDaemonReachable(url string, isLinuxHost bool, extraHosts string) error {
+	if err := AssertContains(url, "host.docker.internal", "R8.4 AILERON_URL host is host.docker.internal"); err != nil {
+		return err
+	}
+	if isLinuxHost {
+		return AssertContains(extraHosts, "host.docker.internal:host-gateway",
+			"R8.4 --add-host host.docker.internal:host-gateway present (Linux)")
+	}
+	return nil
+}
+
+// ProbeTeardown re-expresses probe_teardown's decision core (R8.5): no sandbox
+// container survived the launch. survivingNames is the `docker ps -a` names block
+// (filtered by the prefix); after whitespace splitting it must be empty. prefix is
+// used only for the diagnostic. Returns nil when nothing survived.
+func ProbeTeardown(prefix, survivingNames string) error {
+	remaining := strings.Fields(survivingNames)
+	if len(remaining) == 0 {
+		return nil
+	}
+	return fmt.Errorf("systest: FAIL: R8.5 sandbox container(s) survived teardown:\n%s",
+		strings.Join(remaining, "\n"))
+}
+
+// ProbeImageRunning re-expresses probe_image's decision core (R8.1) once its
+// docker-derived facts are gathered: actualImage (`docker inspect -f
+// {{.Config.Image}}`), running (`{{.State.Running}}`, e.g. "true"), and status
+// (`{{.State.Status}}`, e.g. "running"). The image-ref arbitration reuses the
+// existing ImageRefMatches core. Returns nil when the image matches the expected
+// ref (with digest tolerance) and the container is running.
+func ProbeImageRunning(expectedImage, actualImage, running, status string) error {
+	if !ImageRefMatches(expectedImage, actualImage) {
+		return fmt.Errorf(
+			"systest: FAIL: R8.1 container image\n  expected: %s (or its @sha256 digest on the same repo)\n  actual:   %s",
+			expectedImage, actualImage)
+	}
+	if err := AssertEq("true", running, "R8.1 container .State.Running"); err != nil {
+		return err
+	}
+	return AssertEq("running", status, "R8.1 container .State.Status")
+}
+
+// ProbeMCPConfigContains re-expresses the config-file-specific tail of probe_mcp
+// (R8.2 for config-file agents like codex): after the agent-agnostic runtime core
+// holds, the agent's MCP config file content must contain the marker. The live
+// driver passes config (`docker exec cat <config_path>`), the configPath (for the
+// diagnostic), and the marker. Returns nil when the marker is present.
+func ProbeMCPConfigContains(config, configPath, marker string) error {
+	return AssertContains(config, marker, fmt.Sprintf("R8.2 %s contains %s", configPath, marker))
+}

--- a/test/system/lib/scenario_test.go
+++ b/test/system/lib/scenario_test.go
@@ -1,0 +1,203 @@
+// Contract tests for the pure scenario decision predicates (R8.1/R8.3/R8.4/R8.5
+// decision cores plus the config-file MCP tail). Each test feeds the
+// docker-derived facts as parameters (mirroring probes_test.go's parameter-fed
+// pattern) so the decisions are verified with no docker. Tests assert the
+// returned error contract and, on the failure path, a faithful diagnostic.
+package systestlib_test
+
+import (
+	"strings"
+	"testing"
+
+	systestlib "github.com/ALRubinger/aileron/test/system/lib"
+)
+
+func TestProbeImageRunning(t *testing.T) {
+	const expected = "ghcr.io/alrubinger/aileron-sandbox-codex:edge"
+	tests := []struct {
+		name                         string
+		actualImage, running, status string
+		wantErr                      bool
+		errContains                  []string
+	}{
+		{
+			name:        "matching image, running and status ok returns nil",
+			actualImage: "ghcr.io/alrubinger/aileron-sandbox-codex:edge",
+			running:     "true",
+			status:      "running",
+			wantErr:     false,
+		},
+		{
+			name:        "digest pin on the same repo is accepted",
+			actualImage: "ghcr.io/alrubinger/aileron-sandbox-codex@sha256:deadbeef",
+			running:     "true",
+			status:      "running",
+			wantErr:     false,
+		},
+		{
+			name:        "wrong repo fails on the image check",
+			actualImage: "ghcr.io/alrubinger/aileron-sandbox-claude:edge",
+			running:     "true",
+			status:      "running",
+			wantErr:     true,
+			errContains: []string{"R8.1 container image"},
+		},
+		{
+			name:        "right image but not running fails on .State.Running",
+			actualImage: expected,
+			running:     "false",
+			status:      "exited",
+			wantErr:     true,
+			errContains: []string{"R8.1 container .State.Running"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := systestlib.ProbeImageRunning(expected, tc.actualImage, tc.running, tc.status)
+			assertErr(t, err, tc.wantErr, tc.errContains)
+		})
+	}
+}
+
+func TestProbeMCPConfigContains(t *testing.T) {
+	const (
+		path   = "/home/agent/.codex/config.toml"
+		marker = "[mcp_servers.aileron]"
+	)
+	if err := systestlib.ProbeMCPConfigContains("foo\n[mcp_servers.aileron]\nbar", path, marker); err != nil {
+		t.Errorf("present marker returned error %v; want nil", err)
+	}
+	err := systestlib.ProbeMCPConfigContains("[mcp_servers.other]", path, marker)
+	if err == nil {
+		t.Fatal("absent marker returned nil; want error")
+	}
+	if !strings.Contains(err.Error(), marker) {
+		t.Errorf("error %q does not name the marker %q", err.Error(), marker)
+	}
+}
+
+func TestProbeCredentials(t *testing.T) {
+	const (
+		authPath = "/home/agent/.codex/auth.json"
+		authDir  = "/home/agent/.codex"
+	)
+	okMounts := "bind:/home/agent/workspace\nbind:/home/agent/.codex\nvolume:/data"
+	tests := []struct {
+		name           string
+		authFileExists bool
+		mode, mounts   string
+		wantErr        bool
+		errContains    []string
+	}{
+		{
+			name:           "exists, 0600, parent bind-mounted returns nil",
+			authFileExists: true,
+			mode:           "600",
+			mounts:         okMounts,
+			wantErr:        false,
+		},
+		{
+			name:           "missing auth file fails",
+			authFileExists: false,
+			mode:           "600",
+			mounts:         okMounts,
+			wantErr:        true,
+			errContains:    []string{"auth file"},
+		},
+		{
+			name:           "wrong mode fails on the 0600 check",
+			authFileExists: true,
+			mode:           "644",
+			mounts:         okMounts,
+			wantErr:        true,
+			errContains:    []string{"mode is 0600"},
+		},
+		{
+			name:           "no bind mount for the auth dir fails",
+			authFileExists: true,
+			mode:           "600",
+			mounts:         "bind:/home/agent/workspace\nvolume:/data",
+			wantErr:        true,
+			errContains:    []string{"no bind mount"},
+		},
+		{
+			name:           "a bind mount of a parent-of-parent dir does not satisfy the check",
+			authFileExists: true,
+			mode:           "600",
+			mounts:         "bind:/home/agent",
+			wantErr:        true,
+			errContains:    []string{"no bind mount"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := systestlib.ProbeCredentials(tc.authFileExists, tc.mode, authPath, authDir, tc.mounts)
+			assertErr(t, err, tc.wantErr, tc.errContains)
+		})
+	}
+}
+
+func TestProbeDaemonReachable(t *testing.T) {
+	const goodURL = "http://host.docker.internal:8080"
+	tests := []struct {
+		name        string
+		url         string
+		isLinux     bool
+		extraHosts  string
+		wantErr     bool
+		errContains []string
+	}{
+		{
+			name:    "non-linux host needs only the loopback rewrite",
+			url:     goodURL,
+			isLinux: false,
+			wantErr: false,
+		},
+		{
+			name:       "linux host with host-gateway present returns nil",
+			url:        goodURL,
+			isLinux:    true,
+			extraHosts: "host.docker.internal:host-gateway\n",
+			wantErr:    false,
+		},
+		{
+			name:        "url not rewritten to host.docker.internal fails",
+			url:         "http://127.0.0.1:8080",
+			isLinux:     false,
+			wantErr:     true,
+			errContains: []string{"host.docker.internal"},
+		},
+		{
+			name:        "linux host missing the host-gateway extra host fails",
+			url:         goodURL,
+			isLinux:     true,
+			extraHosts:  "",
+			wantErr:     true,
+			errContains: []string{"host-gateway"},
+		},
+	}
+	for _, tc := range tests {
+		t.Run(tc.name, func(t *testing.T) {
+			err := systestlib.ProbeDaemonReachable(tc.url, tc.isLinux, tc.extraHosts)
+			assertErr(t, err, tc.wantErr, tc.errContains)
+		})
+	}
+}
+
+func TestProbeTeardown(t *testing.T) {
+	if err := systestlib.ProbeTeardown("aileron-sbx-", ""); err != nil {
+		t.Errorf("empty surviving block returned error %v; want nil", err)
+	}
+	if err := systestlib.ProbeTeardown("aileron-sbx-", "   \n  \n"); err != nil {
+		t.Errorf("whitespace-only surviving block returned error %v; want nil", err)
+	}
+	err := systestlib.ProbeTeardown("aileron-sbx-", "aileron-sbx-codex-123\n")
+	if err == nil {
+		t.Fatal("a surviving container returned nil; want the R8.5 error")
+	}
+	for _, sub := range []string{"R8.5", "survived teardown", "aileron-sbx-codex-123"} {
+		if !strings.Contains(err.Error(), sub) {
+			t.Errorf("error %q does not contain %q", err.Error(), sub)
+		}
+	}
+}

--- a/test/system/lib/sentinel.go
+++ b/test/system/lib/sentinel.go
@@ -1,0 +1,63 @@
+// Per-run sentinel generation for the R9 deterministic-result assertion. The
+// bash scenario derives a fresh run id from `date +%s`-`$$` and forms the
+// sentinel `AILERON_SYSTEST_OK_<runid>`, so a stale workspace file from a prior
+// run can never pass the byte-exact check. This file re-expresses that as pure
+// Go: NewRunID produces a fresh, filename-safe id from the wall clock, the PID,
+// and a random component (the Go analogues of `date +%s` and `$$`), and Sentinel
+// forms the token. Pure (no filesystem, no docker); the live driver writes
+// nothing here and only reads the host-side file the agent produced.
+package systestlib
+
+import (
+	"fmt"
+	"math/rand"
+	"os"
+	"time"
+)
+
+// sentinelPrefix is the fixed token prefix the agent writes, matching codex.sh's
+// `SENTINEL_EXPECTED="AILERON_SYSTEST_OK_${RUNID}"`.
+const sentinelPrefix = "AILERON_SYSTEST_OK_"
+
+// NewRunID returns a fresh, filename-safe run id unique per call. It mirrors the
+// bash `date +%s`-`$$` (seconds + PID) and adds a random suffix so two calls
+// within the same second and process still differ (the bash relies on the
+// process being fresh per run; the Go driver is one process, so the random
+// component supplies the freshness the PID gave bash). The charset is
+// [0-9a-z-] only, so the id is safe in a filename and in the shell prompt.
+func NewRunID() string {
+	now := time.Now().UnixNano()
+	pid := os.Getpid()
+	// rand.Int63 is seeded from the runtime's global source (auto-seeded since
+	// Go 1.20), which is sufficient for de-duplication; this is not a security
+	// token. Mask to a positive value and format base-36 for a compact charset.
+	suffix := rand.Int63()
+	if suffix < 0 {
+		suffix = -suffix
+	}
+	return fmt.Sprintf("%d-%d-%s", now, pid, strconvBase36(suffix))
+}
+
+// Sentinel forms the per-run sentinel string `AILERON_SYSTEST_OK_<runID>` the
+// agent is instructed to write and the host-side check compares byte-exact.
+func Sentinel(runID string) string {
+	return sentinelPrefix + runID
+}
+
+// strconvBase36 formats a non-negative int64 in base-36 ([0-9a-z]) without
+// importing strconv's FormatInt purely to keep the call site explicit about the
+// filename-safe charset guarantee.
+func strconvBase36(n int64) string {
+	if n == 0 {
+		return "0"
+	}
+	const digits = "0123456789abcdefghijklmnopqrstuvwxyz"
+	var buf [13]byte // enough for max int64 in base 36
+	i := len(buf)
+	for n > 0 {
+		i--
+		buf[i] = digits[n%36]
+		n /= 36
+	}
+	return string(buf[i:])
+}

--- a/test/system/lib/sentinel_test.go
+++ b/test/system/lib/sentinel_test.go
@@ -1,0 +1,61 @@
+// Contract tests for the per-run sentinel (R9): the format
+// AILERON_SYSTEST_OK_<runid>, freshness across calls (a stale workspace file can
+// never pass), and the filename-safe charset.
+package systestlib_test
+
+import (
+	"strings"
+	"testing"
+
+	systestlib "github.com/ALRubinger/aileron/test/system/lib"
+)
+
+func TestSentinelFormat(t *testing.T) {
+	got := systestlib.Sentinel("17-42-abc")
+	want := "AILERON_SYSTEST_OK_17-42-abc"
+	if got != want {
+		t.Errorf("Sentinel = %q; want %q", got, want)
+	}
+	if !strings.HasPrefix(got, "AILERON_SYSTEST_OK_") {
+		t.Errorf("Sentinel %q missing the AILERON_SYSTEST_OK_ prefix", got)
+	}
+}
+
+// TestNewRunIDFreshness proves two calls produce distinct run ids so a stale
+// sentinel file from a prior run cannot satisfy the byte-exact R9 check.
+func TestNewRunIDFreshness(t *testing.T) {
+	seen := make(map[string]bool)
+	for i := 0; i < 1000; i++ {
+		id := systestlib.NewRunID()
+		if id == "" {
+			t.Fatal("NewRunID returned empty")
+		}
+		if seen[id] {
+			t.Fatalf("NewRunID produced a duplicate id %q within %d calls; freshness violated", id, i)
+		}
+		seen[id] = true
+	}
+}
+
+// TestNewRunIDFilenameSafe proves the run id (and thus the sentinel that embeds
+// it) uses only filename-safe characters [0-9a-z-], so writing it as a file is
+// safe and the bash prompt comparison stays byte-exact.
+func TestNewRunIDFilenameSafe(t *testing.T) {
+	for i := 0; i < 100; i++ {
+		id := systestlib.NewRunID()
+		for _, r := range id {
+			ok := (r >= '0' && r <= '9') || (r >= 'a' && r <= 'z') || r == '-'
+			if !ok {
+				t.Fatalf("NewRunID %q contains a non-filename-safe rune %q", id, r)
+			}
+		}
+		// The sentinel that embeds it must also be safe.
+		s := systestlib.Sentinel(id)
+		for _, r := range s {
+			ok := (r >= '0' && r <= '9') || (r >= 'A' && r <= 'Z') || (r >= 'a' && r <= 'z') || r == '_' || r == '-'
+			if !ok {
+				t.Fatalf("Sentinel %q contains an unexpected rune %q", s, r)
+			}
+		}
+	}
+}

--- a/test/system/scenario/docker.go
+++ b/test/system/scenario/docker.go
@@ -1,0 +1,67 @@
+package main
+
+import (
+	"os/exec"
+	"strings"
+)
+
+// docker.go holds the thin `docker ps` / `docker inspect` / `docker exec`
+// shellouts. Each returns the raw fact (trimmed stdout, or a success boolean for
+// the test-style probes) that a systestlib decision predicate consumes. Nothing
+// here makes a pass/fail decision; the decisions live in systestlib so they are
+// unit-tested without Docker.
+
+// dockerPSNames returns the `{{.Names}}` block for running containers whose name
+// matches the prefix filter. Errors are swallowed to "" (matching the shell's
+// `2>/dev/null`): a transient docker error during the discovery poll is
+// indistinguishable from "no container yet", and the explicit timeout after the
+// poll loop is what reports a genuine failure.
+func dockerPSNames(prefix string) string {
+	out, err := exec.Command("docker", "ps",
+		"--filter", "name="+prefix,
+		"--format", "{{.Names}}").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// dockerPSAllNames returns the `{{.Names}}` block for ALL containers (running or
+// not) matching the prefix, used by the R8.5 teardown check.
+func dockerPSAllNames(prefix string) string {
+	out, err := exec.Command("docker", "ps", "-a",
+		"--filter", "name="+prefix,
+		"--format", "{{.Names}}").Output()
+	if err != nil {
+		return ""
+	}
+	return strings.TrimSpace(string(out))
+}
+
+// dockerInspect runs `docker inspect -f <format> <container>` and returns the
+// trimmed stdout plus any error.
+func dockerInspect(container, format string) (string, error) {
+	out, err := exec.Command("docker", "inspect", "-f", format, container).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// dockerExecOutput runs `docker exec <container> <args...>` and returns the
+// trimmed stdout plus any error.
+func dockerExecOutput(container string, args ...string) (string, error) {
+	cmdArgs := append([]string{"exec", container}, args...)
+	out, err := exec.Command("docker", cmdArgs...).Output()
+	if err != nil {
+		return "", err
+	}
+	return strings.TrimSpace(string(out)), nil
+}
+
+// dockerExecOK runs `docker exec <container> <args...>` and reports whether it
+// exited zero, mirroring the shell's `if docker exec … test -x …` boolean probes.
+func dockerExecOK(container string, args ...string) bool {
+	cmdArgs := append([]string{"exec", container}, args...)
+	return exec.Command("docker", cmdArgs...).Run() == nil
+}

--- a/test/system/scenario/go.mod
+++ b/test/system/scenario/go.mod
@@ -1,0 +1,7 @@
+module github.com/ALRubinger/aileron/test/system/scenario
+
+go 1.26.0
+
+require github.com/ALRubinger/aileron/test/system/lib v0.0.0
+
+replace github.com/ALRubinger/aileron/test/system/lib => ../lib

--- a/test/system/scenario/go.sum
+++ b/test/system/scenario/go.sum
@@ -1,0 +1,2 @@
+gopkg.in/yaml.v3 v3.0.1 h1:fxVm/GzAzEWqLHuvctI91KS9hhNmmWOoWu0XTYJS7CA=
+gopkg.in/yaml.v3 v3.0.1/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=

--- a/test/system/scenario/main.go
+++ b/test/system/scenario/main.go
@@ -1,0 +1,65 @@
+// Command scenario is the shell-free Go equivalent of test/system/codex.sh: it
+// drives a live `aileron launch <agent>` against a real Docker sandbox and runs
+// the R7a/R8.1-8.6/R9/R10 assertions, delegating every decision to the pure
+// test/system/lib (systestlib) package.
+//
+// It is invoked BY HAND on a real, agent-authed host (it performs a live launch
+// that needs a real agent login and consumes LLM tokens), exactly like the bash
+// scenario it replaces:
+//
+//	AILERON_BIN=/abs/path/to/aileron \
+//	WORKSPACE=/tmp/aileron-systest \
+//	AILERON_STATE_DIR=$HOME/.aileron \
+//	  go run ./test/system/scenario codex
+//
+// This package is its own nested Go module OUTSIDE ./test/system/lib/..., so the
+// standard `go test ./test/system/lib/...` coverage/vet CI job never compiles or
+// executes it and cannot start a real container. Its pure logic is covered by the
+// systestlib unit tests; this package holds only the impure docker/exec/poll
+// plumbing. There are intentionally no tests here.
+//
+// Required environment (the bash target exported these; the AILERON_SYSTEST_LIB
+// var the bash needed is now vestigial because the lib is an imported package):
+//
+//	AILERON_BIN          absolute path to the freshly built aileron binary
+//	WORKSPACE            temp workspace dir bind-mounted into the container
+//	AILERON_STATE_DIR    daemon state dir for the R10 audit read (optional)
+//	EXPECTED_IMAGE       override the default expected image ref (optional)
+//
+// Exit 0 means every assertion passed; a non-zero exit aborts (and reaps the
+// background launch so its `docker run --rm` container is torn down).
+package main
+
+import (
+	"fmt"
+	"os"
+)
+
+func main() {
+	if err := run(os.Args[1:]); err != nil {
+		fmt.Fprintf(os.Stderr, "systest: FAIL: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+// run dispatches on the agent name argument. Today only codex is wired (#1624);
+// claude lands in #1625 reusing the same runner with its own AgentConfig
+// constructor, so this dispatch grows one case, not a new driver.
+func run(args []string) error {
+	if len(args) != 1 {
+		return fmt.Errorf("usage: scenario <agent>  (supported: codex)")
+	}
+	agent := args[0]
+
+	env, err := loadEnv()
+	if err != nil {
+		return err
+	}
+
+	switch agent {
+	case "codex":
+		return runCodex(env)
+	default:
+		return fmt.Errorf("unsupported agent %q (supported: codex)", agent)
+	}
+}

--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -1,0 +1,355 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"runtime"
+	"time"
+
+	systestlib "github.com/ALRubinger/aileron/test/system/lib"
+)
+
+// sbxPrefix is the stable sandbox container name prefix (launcher.go
+// aileron-sbx-<id>); the session id is derived at runtime, so the harness
+// discovers the container by this prefix rather than predicting the full name.
+const sbxPrefix = "aileron-sbx-"
+
+// env holds the validated environment the scenario reads, mirroring the bash
+// `: "${VAR:?...}"` preconditions. AILERON_SYSTEST_LIB is intentionally absent:
+// the lib is now an imported Go package, so that var is vestigial for this path.
+type env struct {
+	aileronBin    string
+	workspace     string
+	stateDir      string // optional; empty means the R10 audit assertion is skipped
+	expectedImage string // optional EXPECTED_IMAGE override; empty means the agent default
+}
+
+// loadEnv reads + validates the required environment, returning a faithful
+// remediation error for a missing required var (matching the bash `:?` message).
+func loadEnv() (env, error) {
+	e := env{
+		aileronBin:    os.Getenv("AILERON_BIN"),
+		workspace:     os.Getenv("WORKSPACE"),
+		stateDir:      os.Getenv("AILERON_STATE_DIR"),
+		expectedImage: os.Getenv("EXPECTED_IMAGE"),
+	}
+	if e.aileronBin == "" {
+		return env{}, fmt.Errorf("AILERON_BIN must point at the built aileron binary")
+	}
+	if e.workspace == "" {
+		return env{}, fmt.Errorf("WORKSPACE must be a writable temp dir")
+	}
+	return e, nil
+}
+
+// logf writes a systest-prefixed informational line to stderr, mirroring the
+// shell `log` helper so the Go path's output reads the same as the bash path's.
+func logf(format string, a ...any) {
+	fmt.Fprintf(os.Stderr, "systest: "+format+"\n", a...)
+}
+
+// runCodex is the faithful Go port of codex.sh's scenario body. It launches
+// `aileron launch codex -- exec --skip-git-repo-check "<prompt>"` in the
+// background, runs the live-container R8 probes while codex is resident, reaps
+// the launch and asserts its exit code, verifies clean teardown, then performs
+// the host-side R9 sentinel and conditional R10 audit assertions. Every decision
+// delegates to systestlib; this function holds only the impure docker/exec/poll
+// plumbing.
+func runCodex(e env) error {
+	cfg := systestlib.CodexConfig(e.expectedImage)
+
+	// Per-run sentinel (R9): a fresh token so a stale workspace file can't pass.
+	runID := systestlib.NewRunID()
+	sentinel := systestlib.Sentinel(runID)
+	prompt := systestlib.BuildPrompt(cfg, sentinel)
+	execArgs := systestlib.BuildExecArgs(cfg, prompt)
+
+	logf("codex scenario: runid=%s workspace=%s image=%s", runID, e.workspace, cfg.ExpectedImage)
+
+	// --- launch in the background (R7a arg forwarding) ---------------------
+	// `-- exec --skip-git-repo-check "<prompt>"` forwards verbatim through
+	// LaunchConfig.Args into the container command. We run it in the background
+	// so the live-container probes can inspect the container while codex is
+	// resident, then reap the exit code. stdin is /dev/null so codex exec never
+	// blocks waiting for piped input (the prompt is supplied as an arg);
+	// stdout+stderr are captured to <workspace>/.launch.log.
+	launchLog := filepath.Join(e.workspace, ".launch.log")
+	logFile, err := os.Create(launchLog)
+	if err != nil {
+		return fmt.Errorf("creating launch log %s: %w", launchLog, err)
+	}
+	defer logFile.Close()
+
+	devNull, err := os.Open(os.DevNull)
+	if err != nil {
+		return fmt.Errorf("opening %s: %w", os.DevNull, err)
+	}
+	defer devNull.Close()
+
+	launchArgs := append([]string{"launch", cfg.Name, "--"}, execArgs...)
+	cmd := exec.Command(e.aileronBin, launchArgs...)
+	cmd.Dir = e.workspace
+	cmd.Stdin = devNull
+	cmd.Stdout = logFile
+	cmd.Stderr = logFile
+	if err := cmd.Start(); err != nil {
+		return fmt.Errorf("starting aileron launch: %w", err)
+	}
+
+	// A single goroutine owns cmd.Wait (calling Wait twice is undefined), so we
+	// learn the exit code exactly once and never race the runtime's process
+	// reaping. waitDone closes when the launch exits on its own; exitCode then
+	// holds its code.
+	var exitCode int
+	waitDone := make(chan struct{})
+	go func() {
+		exitCode = waitExitCode(cmd)
+		close(waitDone)
+	}()
+
+	// reap tears the launch down. Killing the `aileron launch` process stops its
+	// `docker run --rm` container too. This is the cross-platform analogue of the
+	// bash trap (no `kill -0`, no shell trap): we call it on any early return so a
+	// mid-probe failure tears the launch down, and again on the normal path. It is
+	// idempotent and blocks until the single Wait goroutine has set exitCode, so
+	// launchExit() is valid afterward.
+	reaped := false
+	reap := func() {
+		if reaped {
+			return
+		}
+		reaped = true
+		_ = cmd.Process.Kill()
+		<-waitDone
+	}
+	defer reap()
+	// launchExit returns the reaped exit code; only valid after reap() (or a
+	// natural exit) has closed waitDone.
+	launchExit := func() int { return exitCode }
+
+	// --- discovery poll: wait up to 120s for the container ------------------
+	container := ""
+	for i := 0; i < 120; i++ {
+		// If the launch already exited, stop polling: a short-lived run still
+		// reaches the post-run assertions below (the bash does the same).
+		select {
+		case <-waitDone:
+			logf("launch exited before container probe window; continuing to post-run checks")
+			i = 120
+		default:
+		}
+		if i >= 120 {
+			break
+		}
+		if name, derr := systestlib.DiscoverContainer(sbxPrefix, systestlib.SplitNames(dockerPSNames(sbxPrefix))); derr == nil {
+			container = name
+			break
+		}
+		time.Sleep(1 * time.Second)
+	}
+
+	// --- live-container R8 probes ------------------------------------------
+	if container != "" {
+		logf("probing running container: %s", container)
+		if err := probeImage(container, cfg.ExpectedImage); err != nil {
+			return err
+		}
+		if err := probeMCPConfigFile(container, cfg); err != nil {
+			return err
+		}
+		if err := probeCredentials(container, cfg.AuthPath); err != nil {
+			return err
+		}
+		if err := probeDaemonReachable(container); err != nil {
+			return err
+		}
+	} else {
+		return systestlib.Fail(fmt.Sprintf("never observed a running %s* container during the launch", sbxPrefix))
+	}
+
+	// --- reap and assert the launch exit code (R8.6) -----------------------
+	reap()
+	if err := systestlib.ProbeExitCode(launchExit(), 0); err != nil {
+		logf("launch log follows:")
+		dumpFile(launchLog)
+		return err
+	}
+
+	// --- R8.5 clean teardown: no sandbox container survives ----------------
+	if err := systestlib.ProbeTeardown(sbxPrefix, dockerPSAllNames(sbxPrefix)); err != nil {
+		return err
+	}
+	logf("ok: R8.5 no sandbox container survived (docker run --rm teardown)")
+
+	// --- R9 deterministic result: read the sentinel host-side --------------
+	sentinelHost := filepath.Join(e.workspace, cfg.SentinelName)
+	data, err := os.ReadFile(sentinelHost)
+	if err != nil {
+		return systestlib.Fail(fmt.Sprintf("R9 sentinel file not found at %s (agent did not write it)", sentinelHost))
+	}
+	// Trim a single trailing newline the editor/agent may add, matching the
+	// bash `$(cat …)` (which strips trailing newlines) so the comparison is
+	// robust without accepting arbitrary trailing content.
+	actual := trimOneTrailingNewline(string(data))
+	if err := systestlib.AssertEq(sentinel, actual, "R9 sentinel content byte-exact"); err != nil {
+		return err
+	}
+	logf("ok: R9 sentinel content byte-exact")
+
+	// --- R7a forwarding: the agent acted on the forwarded exec instruction --
+	if err := systestlib.AssertNotEmpty(actual, "R7a post-`--` exec args forwarded to codex"); err != nil {
+		return err
+	}
+	logf("ok: R7a post-`--` exec args forwarded to codex")
+
+	// --- R10 round-trip audit (conditional on AILERON_STATE_DIR) -----------
+	if err := assertAuditR10(e.stateDir); err != nil {
+		return err
+	}
+
+	logf("codex scenario: all assertions passed (R7a, R8.1-8.6, R9, R10)")
+	return nil
+}
+
+// assertAuditR10 performs the conditional R10 audit assertion: when stateDir is
+// set, read today's audit JSONL and assert it has at least one event record;
+// when unset, skip with a logged note (matching the bash). The audit filename is
+// audit-YYYY-MM-DD.jsonl per internal/audit/local.go.
+func assertAuditR10(stateDir string) error {
+	if stateDir == "" {
+		logf("R10 audit assertion skipped: AILERON_STATE_DIR unset (set it to the daemon state dir to enable)")
+		return nil
+	}
+	auditFile := filepath.Join(stateDir, "audit", "audit-"+time.Now().Format("2006-01-02")+".jsonl")
+	data, err := os.ReadFile(auditFile)
+	if err != nil {
+		return systestlib.Fail(fmt.Sprintf("R10 audit file not found: %s", auditFile))
+	}
+	if err := systestlib.AssertAuditHasEvents(data, auditFile); err != nil {
+		return err
+	}
+	count, _ := systestlib.CountAuditEventRecords(data)
+	logf("ok: R10 today's audit JSONL has %d event record(s) (%s)", count, auditFile)
+	return nil
+}
+
+// --- live probe wrappers: gather docker facts, delegate the decision -------
+
+func probeImage(container, expectedImage string) error {
+	actualImage, err := dockerInspect(container, "{{.Config.Image}}")
+	if err != nil {
+		return systestlib.Fail(fmt.Sprintf("docker inspect %s failed (probe_image)", container))
+	}
+	running, _ := dockerInspect(container, "{{.State.Running}}")
+	status, _ := dockerInspect(container, "{{.State.Status}}")
+	if err := systestlib.ProbeImageRunning(expectedImage, actualImage, running, status); err != nil {
+		return err
+	}
+	logf("ok: R8.1 container image matches %s (actual: %s)", expectedImage, actualImage)
+	return nil
+}
+
+func probeMCPConfigFile(container string, cfg systestlib.AgentConfig) error {
+	// Agent-agnostic R8.2 core: aileron-mcp present + executable, daemon-wiring
+	// env vars all set.
+	binOK := dockerExecOK(container, "test", "-x", "/usr/local/bin/aileron-mcp")
+	envOK := true
+	for _, v := range []string{"AILERON_URL", "AILERON_COMMS_URL", "AILERON_SESSION_ID", "AILERON_APPROVAL_URL", "AILERON_TOKEN"} {
+		if !dockerExecOK(container, "printenv", v) {
+			envOK = false
+			break
+		}
+	}
+	if err := systestlib.ProbeMCPRuntime(binOK, envOK); err != nil {
+		return err
+	}
+	logf("ok: R8.2 aileron-mcp present + executable and daemon-wiring env set")
+
+	// Config-file tail: the agent's MCP config contains the aileron block.
+	config, err := dockerExecOutput(container, "cat", cfg.ConfigPath)
+	if err != nil {
+		return systestlib.Fail(fmt.Sprintf("R8.2 could not read %s in %s", cfg.ConfigPath, container))
+	}
+	if err := systestlib.ProbeMCPConfigContains(config, cfg.ConfigPath, cfg.MCPMarker); err != nil {
+		return err
+	}
+	logf("ok: R8.2 %s contains %s", cfg.ConfigPath, cfg.MCPMarker)
+	return nil
+}
+
+func probeCredentials(container, authPath string) error {
+	authFileExists := dockerExecOK(container, "test", "-f", authPath)
+	mode := ""
+	if authFileExists {
+		// `stat -c %a` is GNU coreutils (the Linux sandbox base); octal without a
+		// leading zero, e.g. "600".
+		mode, _ = dockerExecOutput(container, "stat", "-c", "%a", authPath)
+	}
+	mounts, _ := dockerInspect(container, `{{range .Mounts}}{{.Type}}:{{.Destination}}{{"\n"}}{{end}}`)
+	authDir := filepath.Dir(authPath)
+	if err := systestlib.ProbeCredentials(authFileExists, mode, authPath, authDir, mounts); err != nil {
+		return err
+	}
+	logf("ok: R8.3 auth file %s present, mode 0600, %s bind-mounted", authPath, authDir)
+	return nil
+}
+
+func probeDaemonReachable(container string) error {
+	url, err := dockerExecOutput(container, "printenv", "AILERON_URL")
+	if err != nil {
+		return systestlib.Fail(fmt.Sprintf("R8.4 AILERON_URL not set in %s", container))
+	}
+	isLinux := runtime.GOOS == "linux"
+	extraHosts := ""
+	if isLinux {
+		extraHosts, _ = dockerInspect(container, `{{range .HostConfig.ExtraHosts}}{{.}}{{"\n"}}{{end}}`)
+	}
+	if err := systestlib.ProbeDaemonReachable(url, isLinux, extraHosts); err != nil {
+		return err
+	}
+	logf("ok: R8.4 daemon reachable (AILERON_URL host is host.docker.internal)")
+	return nil
+}
+
+// --- small impure helpers --------------------------------------------------
+
+// waitExitCode waits for cmd and returns its exit code, treating a kill-signal
+// termination as the bash `wait` would (the explicit kill in reap is an expected
+// teardown, not a launch failure, so a signal exit is reported as the underlying
+// process exit). An ExitError carries the code; any other wait error maps to a
+// non-zero code so the R8.6 assertion fails loudly rather than silently passing.
+func waitExitCode(cmd *exec.Cmd) int {
+	err := cmd.Wait()
+	if err == nil {
+		return 0
+	}
+	if ee, ok := err.(*exec.ExitError); ok {
+		return ee.ExitCode()
+	}
+	return -1
+}
+
+// trimOneTrailingNewline strips a single trailing "\n" (and a preceding "\r" if
+// present), matching the bash `$(cat …)` trailing-newline trim without accepting
+// arbitrary trailing content.
+func trimOneTrailingNewline(s string) string {
+	if len(s) > 0 && s[len(s)-1] == '\n' {
+		s = s[:len(s)-1]
+	}
+	if len(s) > 0 && s[len(s)-1] == '\r' {
+		s = s[:len(s)-1]
+	}
+	return s
+}
+
+// dumpFile copies a file's contents to stderr, used to surface the launch log on
+// an R8.6 exit-code failure (the bash `cat "$LAUNCH_LOG" >&2`).
+func dumpFile(path string) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return
+	}
+	_, _ = os.Stderr.Write(data)
+}


### PR DESCRIPTION
## Summary

Re-expresses `test/system/codex.sh`'s scenario orchestration as shell-free Go, split into a **pure decision layer** in the existing `systestlib` package and an **impure live-Docker driver** in a new nested module. `codex.sh` stays on disk and functional; no Taskfile target is rewired (retire is #1626). This is the linchpin node: the package layout chosen here is what #1625 (claude) and #1626 (rewire/retire) inherit.

Every R7a / R8.1-8.6 / R9 / R10 assertion is preserved one-for-one, with the bash diagnostic wording mirrored so CI/by-hand logs read the same.

### Package layout (the delegated decision)

- **Pure logic → `test/system/lib` (`systestlib`), already in `GO_TEST_PACKAGES`.** Unit-tested with stubbed docker facts (mirroring `probes_test.go`'s parameter-fed pattern):
  - `runner.go` — `AgentConfig` + `MCPMode` enum (config-file vs cmdline, so #1625 claude reuses the struct verbatim), `CodexConfig` with the confirmed codex bindings, `ResolveExpectedImage` (`EXPECTED_IMAGE` override), `BuildExecArgs` (R7a `exec --skip-git-repo-check <prompt>`), `BuildPrompt` (the deterministic two-step sentinel + `http_request` prompt, byte-faithful to the bash).
  - `sentinel.go` — `NewRunID`/`Sentinel` for the per-run R9 sentinel `AILERON_SYSTEST_OK_<runid>`, fresh per call, filename-safe charset (replaces bash `date +%s`-`$$`).
  - `audit.go` — `CountAuditEventRecords` + `AssertAuditHasEvents`, the pure R10 parser reimplemented locally (no `internal/audit` import, keeping the nested module dependency-free) matching `internal/audit`'s skip rules (empty lines, non-JSON lines, empty `event` field).
  - `scenario.go` — pure R8.1/8.3/8.4/8.5 decision predicates fed inspected docker facts as parameters, reusing the existing `ImageRefMatches`/`ProbeMCPRuntime` cores.
- **Live-Docker driver → new module `test/system/scenario` (`main`), added to `go.work`, NOT in `GO_TEST_PACKAGES`.** Because it is its own module outside `./test/system/lib/...`, `go test ./test/system/lib/...` and the coverage/vet CI job never compile or execute it and it cannot start a real container. Invoked by hand: `go run ./test/system/scenario codex`. Faithful port of `codex.sh` control flow: background launch, cross-platform reap via `Process.Kill` (no `kill -0`/trap; a single goroutine owns `cmd.Wait`), 120s discovery poll, live probes delegating every decision to `systestlib`, exit-code + teardown + host-side byte-exact sentinel + conditional R10.

`AILERON_SYSTEST_LIB` is now vestigial for the Go path (the lib is an imported package); the driver reads `AILERON_BIN`, `WORKSPACE`, `AILERON_STATE_DIR`, `EXPECTED_IMAGE` from env as before.

## Test plan

- `task test:system:lib` — green.
- `go test -cover ./test/system/lib/...` — **96.8%** of statements; every new exported function is at or above 83% (most 100%). Happy path + documented-failure path covered for sentinel (format/freshness/charset), audit parse (N events, skip rules, no-records diagnostic), agent-config (exact codex bindings, override precedence, exec-args, prompt byte-exact), and the decision glue (image match/mismatch, MCP marker present/absent, 0600-vs-other, bind-mount present/absent, daemon host + Linux-gated host-gateway, teardown).
- `go test -race ./test/system/lib/...` — green (covers the goroutine/channel reap path indirectly via the pure logic; the driver's own concurrency is reasoned about, not unit-tested by design).
- `go build ./test/system/scenario` + `go vet ./test/system/scenario` — clean under `go.work`.
- `go vet` over the full `GO_TEST_PACKAGES` set — clean.
- Confirmed `go list ./test/system/lib/...` does **not** include the scenario module, so the live path is excluded from CI.
- Driver dispatch/env-validation/unsupported-agent error paths exercised by hand (usage error, missing `AILERON_BIN`, unknown agent).

### Intentional coverage exclusion

`test/system/scenario` has **no tests by design**: it is the live-Docker path, excluded from CI, holding only impure `os/exec` + docker plumbing. Its pure decision logic is covered by the `systestlib` unit tests. A green live run (Docker + `codex login` + tokens) is verified **by hand** on a real host per the static gate in `test/system/README.md`; this headless authoring host has no codex auth.

### Note on automated review

CodeRabbit was rate-limited at review time (free tier, ~19 min cooldown). A self-review pass found no correctness/security/scope issues; the diff is pure-Go additions plus docs, with no spec/endpoint/approval surface touched.

Closes #1624
