### PR TITLE
test(systest): port claude scenario body to the shared Go driver

### DIFF
--- a/test/system/README.md
+++ b/test/system/README.md
@@ -17,9 +17,10 @@ test/system/
   codex.sh             the codex scenario body (#1476)
   claude.sh            the claude scenario body (#1477)
   scenario/            shell-free Go scenario driver (#1624), its own module,
-                       run by hand with `go run ./test/system/scenario codex`;
-                       NOT in GO_TEST_PACKAGES, so the live path never runs in CI
-    main.go            agent-name dispatch (codex today; claude in #1625)
+                       run by hand with `go run ./test/system/scenario codex`
+                       (or `claude`); NOT in GO_TEST_PACKAGES, so the live path
+                       never runs in CI
+    main.go            agent-name dispatch (codex and claude)
     scenario.go        the live orchestration (background launch, reap,
                        discovery poll, probes, sentinel read, R10 audit)
     docker.go          thin docker ps/inspect/exec shellouts returning raw facts
@@ -55,7 +56,8 @@ path, excluded from CI).
 | Go scenario driver compile | `go build ./test/system/scenario` | Go toolchain | yes — compiles the driver; its own module, not in GO_TEST_PACKAGES |
 | Live codex scenario (shell) | `task test:system:launch:codex` | Docker + `codex login` + tokens | **no — by hand on a real host** |
 | Live codex scenario (Go) | `go run ./test/system/scenario codex` | Docker + `codex login` + tokens | **no — by hand on a real host** |
-| Live claude scenario | `task test:system:launch:claude` | Docker + Claude login (vault, ADR-0025) + tokens | **no — by hand on a real host** |
+| Live claude scenario (shell) | `task test:system:launch:claude` | Docker + Claude login (vault, ADR-0025) + tokens | **no — by hand on a real host** |
+| Live claude scenario (Go) | `go run ./test/system/scenario claude` | Docker + Claude login (vault, ADR-0025) + tokens | **no — by hand on a real host** |
 
 The headless path validates the **wiring** (the target compiles, the build
 dependency and preconditions resolve, the scenario library passes its Go
@@ -222,6 +224,33 @@ task test:system:launch:claude
 > no Claude vault auth, so the scenario here is statically validated only
 > (`task --dry`, `shellcheck`); a green live run is verified by hand on a
 > claude-authed host.
+
+## Run the claude scenario by hand (shell-free Go)
+
+`go run ./test/system/scenario claude` is the shell-free Go equivalent of
+`claude.sh`. It reuses the same shared runner body as the codex Go path and
+differs only in the claude bindings and the R8.2 MCP probe. It needs the same
+prerequisites as the shell claude scenario above (Docker, a Claude login the
+launcher's AuthSpec resolves, and optionally a running daemon for R10). Build an
+`aileron` first and point the driver at it:
+
+```sh
+task build                                  # produces build/aileron
+AILERON_BIN="$PWD/build/aileron" \
+WORKSPACE="$(mktemp -d)" \
+AILERON_STATE_DIR="$HOME/.aileron" \
+  go run ./test/system/scenario claude
+```
+
+The default `EXPECTED_IMAGE` is the LOCAL `aileron/sandbox-agent-claude:edge` ref
+(no registry host, no digest pin), because the claude sandbox image is built
+locally from the devcontainer Feature rather than published to a registry. An
+explicit `EXPECTED_IMAGE` override is honored the same way the shell scenario does.
+
+The R8.2 MCP probe is the flag-mode probe. The driver asserts the `--mcp-config`
+flag and the `"aileron"` server marker on the running container's command line
+(not a config file), plus the shared agent-agnostic core (`aileron-mcp` present
+and executable, the daemon-wiring env vars set).
 
 ## Editing the shared library
 

--- a/test/system/lib/runner.go
+++ b/test/system/lib/runner.go
@@ -77,6 +77,14 @@ type AgentConfig struct {
 // assert a release :latest or a digest pin.
 const codexDefaultImage = "ghcr.io/alrubinger/aileron-sandbox-codex:edge"
 
+// claudeDefaultImage is the floating dev image ref claude.sh defaults
+// EXPECTED_IMAGE to. Unlike codex's GHCR ref, this is the LOCAL Feature-build
+// repo (`aileron/sandbox-agent-claude`, per #1451/#1585): no registry host and
+// no digest-pin path, because the claude sandbox image is built locally from the
+// devcontainer Feature rather than published to a registry. A dev/empty version
+// build pulls :edge; override with EXPECTED_IMAGE to assert a specific local ref.
+const claudeDefaultImage = "aileron/sandbox-agent-claude:edge"
+
 // ResolveExpectedImage mirrors codex.sh's `EXPECTED_IMAGE="${EXPECTED_IMAGE:-<default>}"`:
 // a non-empty override wins, otherwise the agent default is used. Pure; the
 // override is passed in (read from os.Getenv("EXPECTED_IMAGE") by the live driver)
@@ -100,6 +108,35 @@ func CodexConfig(expectedImageOverride string) AgentConfig {
 		MCPMarker:              "[mcp_servers.aileron]",
 		AuthPath:               "/home/agent/.codex/auth.json",
 		BatchFlags:             []string{"exec", "--skip-git-repo-check"},
+		WorkspaceContainerPath: "/home/agent/workspace",
+		SentinelName:           ".aileron-systest-sentinel",
+	}
+}
+
+// ClaudeConfig returns the claude AgentConfig with bindings confirmed against
+// claude.sh (issue #1477 decision 2). override is the EXPECTED_IMAGE value (empty
+// for the default); the live driver passes os.Getenv("EXPECTED_IMAGE").
+//
+// Claude differs from codex in three ways the driver reads off this config:
+//   - MCP is wired by the `--mcp-config` command-line flag (MCPModeCmdline), not a
+//     config file, so ConfigPath is empty and MCPFlag/MCPMarker drive the R8.2
+//     cmdline probe (ProbeMCPCmdline). MCPMarker is the JSON-key form `"aileron"`,
+//     byte-identical to claude.sh's MCP_MARKER.
+//   - The credential file is /home/agent/.claude/.credentials.json.
+//   - The non-interactive batch flag is `-p`, so BuildExecArgs yields
+//     ["-p", "<prompt>"] forwarded as `aileron launch claude -- -p "<prompt>"`.
+//
+// The default ExpectedImage is the LOCAL aileron/sandbox-agent-claude:edge ref
+// (no registry host, no digest pin); see claudeDefaultImage.
+func ClaudeConfig(expectedImageOverride string) AgentConfig {
+	return AgentConfig{
+		Name:                   "claude",
+		ExpectedImage:          ResolveExpectedImage(expectedImageOverride, claudeDefaultImage),
+		MCPMode:                MCPModeCmdline,
+		MCPFlag:                "--mcp-config",
+		MCPMarker:              `"aileron"`,
+		AuthPath:               "/home/agent/.claude/.credentials.json",
+		BatchFlags:             []string{"-p"},
 		WorkspaceContainerPath: "/home/agent/workspace",
 		SentinelName:           ".aileron-systest-sentinel",
 	}

--- a/test/system/lib/runner_test.go
+++ b/test/system/lib/runner_test.go
@@ -53,6 +53,96 @@ func TestCodexConfigBindings(t *testing.T) {
 	}
 }
 
+func TestClaudeConfigBindings(t *testing.T) {
+	cfg := systestlib.ClaudeConfig("")
+
+	if cfg.Name != "claude" {
+		t.Errorf("Name = %q; want %q", cfg.Name, "claude")
+	}
+	// LOCAL Feature-build ref: no registry host, no digest pin (#1451/#1585).
+	if cfg.ExpectedImage != "aileron/sandbox-agent-claude:edge" {
+		t.Errorf("ExpectedImage = %q; want the claude local :edge default", cfg.ExpectedImage)
+	}
+	if strings.Contains(cfg.ExpectedImage, "ghcr.io") || strings.Contains(cfg.ExpectedImage, "@sha256:") {
+		t.Errorf("ExpectedImage = %q; claude default must be a local ref with no registry host and no digest", cfg.ExpectedImage)
+	}
+	// Claude is cmdline mode: ConfigPath is unused (empty), MCPFlag/MCPMarker drive
+	// the R8.2 ProbeMCPCmdline decision.
+	if cfg.MCPMode != systestlib.MCPModeCmdline {
+		t.Errorf("MCPMode = %v; want MCPModeCmdline", cfg.MCPMode)
+	}
+	if cfg.ConfigPath != "" {
+		t.Errorf("ConfigPath = %q; want empty for cmdline mode", cfg.ConfigPath)
+	}
+	if cfg.MCPFlag != "--mcp-config" {
+		t.Errorf("MCPFlag = %q; want --mcp-config", cfg.MCPFlag)
+	}
+	if cfg.MCPMarker != `"aileron"` {
+		t.Errorf("MCPMarker = %q; want the JSON-key form \"aileron\"", cfg.MCPMarker)
+	}
+	if cfg.AuthPath != "/home/agent/.claude/.credentials.json" {
+		t.Errorf("AuthPath = %q; want the claude .credentials.json path", cfg.AuthPath)
+	}
+	if cfg.WorkspaceContainerPath != "/home/agent/workspace" {
+		t.Errorf("WorkspaceContainerPath = %q; want /home/agent/workspace", cfg.WorkspaceContainerPath)
+	}
+	if cfg.SentinelName != ".aileron-systest-sentinel" {
+		t.Errorf("SentinelName = %q; want .aileron-systest-sentinel", cfg.SentinelName)
+	}
+	wantFlags := []string{"-p"}
+	if len(cfg.BatchFlags) != len(wantFlags) {
+		t.Fatalf("BatchFlags = %v; want %v", cfg.BatchFlags, wantFlags)
+	}
+	for i := range wantFlags {
+		if cfg.BatchFlags[i] != wantFlags[i] {
+			t.Errorf("BatchFlags[%d] = %q; want %q", i, cfg.BatchFlags[i], wantFlags[i])
+		}
+	}
+}
+
+func TestClaudeConfigHonorsExpectedImageOverride(t *testing.T) {
+	override := "aileron/sandbox-agent-claude:latest"
+	cfg := systestlib.ClaudeConfig(override)
+	if cfg.ExpectedImage != override {
+		t.Errorf("ExpectedImage = %q; want the override %q", cfg.ExpectedImage, override)
+	}
+}
+
+// TestBuildExecArgsClaude proves the claude batch flag assembles to
+// `-p "<prompt>"`, the post-`--` token list forwarded to the claude CLI.
+func TestBuildExecArgsClaude(t *testing.T) {
+	cfg := systestlib.ClaudeConfig("")
+	args := systestlib.BuildExecArgs(cfg, "PROMPT")
+	want := []string{"-p", "PROMPT"}
+	if len(args) != len(want) {
+		t.Fatalf("BuildExecArgs = %v; want %v", args, want)
+	}
+	for i := range want {
+		if args[i] != want[i] {
+			t.Errorf("args[%d] = %q; want %q", i, args[i], want[i])
+		}
+	}
+}
+
+// TestBuildPromptClaude proves the shared deterministic prompt builder works with
+// the claude config (same workspace/sentinel bindings, same two side effects).
+func TestBuildPromptClaude(t *testing.T) {
+	cfg := systestlib.ClaudeConfig("")
+	sentinel := systestlib.Sentinel("17-42-abc")
+	prompt := systestlib.BuildPrompt(cfg, sentinel)
+
+	if !strings.Contains(prompt, sentinel) {
+		t.Errorf("prompt missing the sentinel token %q:\n%s", sentinel, prompt)
+	}
+	wantPath := cfg.WorkspaceContainerPath + "/" + cfg.SentinelName
+	if !strings.Contains(prompt, wantPath) {
+		t.Errorf("prompt missing the sentinel file path %q:\n%s", wantPath, prompt)
+	}
+	if !strings.Contains(prompt, "${AILERON_URL}/healthz") {
+		t.Errorf("prompt missing the healthz URL (literal ${AILERON_URL}):\n%s", prompt)
+	}
+}
+
 func TestResolveExpectedImage(t *testing.T) {
 	const def = "ghcr.io/alrubinger/aileron-sandbox-codex:edge"
 	if got := systestlib.ResolveExpectedImage("", def); got != def {

--- a/test/system/scenario/main.go
+++ b/test/system/scenario/main.go
@@ -1,7 +1,9 @@
-// Command scenario is the shell-free Go equivalent of test/system/codex.sh: it
-// drives a live `aileron launch <agent>` against a real Docker sandbox and runs
-// the R7a/R8.1-8.6/R9/R10 assertions, delegating every decision to the pure
-// test/system/lib (systestlib) package.
+// Command scenario is the shell-free Go equivalent of test/system/codex.sh and
+// test/system/claude.sh: it drives a live `aileron launch <agent>` against a real
+// Docker sandbox and runs the R7a/R8.1-8.6/R9/R10 assertions, delegating every
+// decision to the pure test/system/lib (systestlib) package. The supported agents
+// are codex and claude; they share the same runner body and differ only in their
+// AgentConfig and R8.2 MCP probe.
 //
 // It is invoked BY HAND on a real, agent-authed host (it performs a live launch
 // that needs a real agent login and consumes LLM tokens), exactly like the bash
@@ -10,7 +12,7 @@
 //	AILERON_BIN=/abs/path/to/aileron \
 //	WORKSPACE=/tmp/aileron-systest \
 //	AILERON_STATE_DIR=$HOME/.aileron \
-//	  go run ./test/system/scenario codex
+//	  go run ./test/system/scenario codex   # or: claude
 //
 // This package is its own nested Go module OUTSIDE ./test/system/lib/..., so the
 // standard `go test ./test/system/lib/...` coverage/vet CI job never compiles or
@@ -42,12 +44,13 @@ func main() {
 	}
 }
 
-// run dispatches on the agent name argument. Today only codex is wired (#1624);
-// claude lands in #1625 reusing the same runner with its own AgentConfig
-// constructor, so this dispatch grows one case, not a new driver.
+// run dispatches on the agent name argument. Both codex (#1624) and claude
+// (#1625) reuse the same shared runner (runScenario) with their own AgentConfig
+// constructor and R8.2 MCP probe, so each agent is one dispatch case, not a new
+// driver.
 func run(args []string) error {
 	if len(args) != 1 {
-		return fmt.Errorf("usage: scenario <agent>  (supported: codex)")
+		return fmt.Errorf("usage: scenario <agent>  (supported: codex, claude)")
 	}
 	agent := args[0]
 
@@ -59,7 +62,9 @@ func run(args []string) error {
 	switch agent {
 	case "codex":
 		return runCodex(env)
+	case "claude":
+		return runClaude(env)
 	default:
-		return fmt.Errorf("unsupported agent %q (supported: codex)", agent)
+		return fmt.Errorf("unsupported agent %q (supported: codex, claude)", agent)
 	}
 }

--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -54,19 +54,38 @@ func logf(format string, a ...any) {
 // `aileron launch codex -- exec --skip-git-repo-check "<prompt>"` in the
 // background, runs the live-container R8 probes while codex is resident, reaps
 // the launch and asserts its exit code, verifies clean teardown, then performs
-// the host-side R9 sentinel and conditional R10 audit assertions. Every decision
-// delegates to systestlib; this function holds only the impure docker/exec/poll
-// plumbing.
+// the host-side R9 sentinel and conditional R10 audit assertions. It is the
+// codex binding of the shared runScenario body; its R8.2 MCP probe is the
+// config-file wrapper probeMCPConfigFile.
 func runCodex(e env) error {
-	cfg := systestlib.CodexConfig(e.expectedImage)
+	return runScenario(e, systestlib.CodexConfig(e.expectedImage), probeMCPConfigFile)
+}
 
+// runClaude is the faithful Go port of claude.sh's scenario body. It is the
+// claude binding of the shared runScenario body, differing from codex only in the
+// claude AgentConfig (cmdline-mode MCP, `-p` batch flag, the claude credential
+// path, the local sandbox-agent-claude image) and its R8.2 MCP probe, which is
+// the flag-mode wrapper probeMCPCmdline (asserting `--mcp-config` + the
+// `"aileron"` server marker on the container command line).
+func runClaude(e env) error {
+	return runScenario(e, systestlib.ClaudeConfig(e.expectedImage), probeMCPCmdline)
+}
+
+// runScenario is the shared, agent-agnostic live-scenario body both runCodex and
+// runClaude delegate to. cfg carries the per-agent bindings (image, batch flags,
+// credential path, MCP mode); probeMCP is the agent's R8.2 MCP probe wrapper
+// (config-file for codex, cmdline for claude). The launch/reap/discovery-poll and
+// the R8.1/R8.3-8.6/R9/R7a/R10 assertions are identical across agents, so they
+// live here once. Every decision delegates to systestlib; this function holds
+// only the impure docker/exec/poll plumbing.
+func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container string, cfg systestlib.AgentConfig) error) error {
 	// Per-run sentinel (R9): a fresh token so a stale workspace file can't pass.
 	runID := systestlib.NewRunID()
 	sentinel := systestlib.Sentinel(runID)
 	prompt := systestlib.BuildPrompt(cfg, sentinel)
 	execArgs := systestlib.BuildExecArgs(cfg, prompt)
 
-	logf("codex scenario: runid=%s workspace=%s image=%s", runID, e.workspace, cfg.ExpectedImage)
+	logf("%s scenario: runid=%s workspace=%s image=%s", cfg.Name, runID, e.workspace, cfg.ExpectedImage)
 
 	// --- launch in the background (R7a arg forwarding) ---------------------
 	// `-- exec --skip-git-repo-check "<prompt>"` forwards verbatim through
@@ -156,7 +175,7 @@ func runCodex(e env) error {
 		if err := probeImage(container, cfg.ExpectedImage); err != nil {
 			return err
 		}
-		if err := probeMCPConfigFile(container, cfg); err != nil {
+		if err := probeMCP(container, cfg); err != nil {
 			return err
 		}
 		if err := probeCredentials(container, cfg.AuthPath); err != nil {
@@ -199,17 +218,17 @@ func runCodex(e env) error {
 	logf("ok: R9 sentinel content byte-exact")
 
 	// --- R7a forwarding: the agent acted on the forwarded exec instruction --
-	if err := systestlib.AssertNotEmpty(actual, "R7a post-`--` exec args forwarded to codex"); err != nil {
+	if err := systestlib.AssertNotEmpty(actual, "R7a post-`--` exec args forwarded to "+cfg.Name); err != nil {
 		return err
 	}
-	logf("ok: R7a post-`--` exec args forwarded to codex")
+	logf("ok: R7a post-`--` exec args forwarded to %s", cfg.Name)
 
 	// --- R10 round-trip audit (conditional on AILERON_STATE_DIR) -----------
 	if err := assertAuditR10(e.stateDir); err != nil {
 		return err
 	}
 
-	logf("codex scenario: all assertions passed (R7a, R8.1-8.6, R9, R10)")
+	logf("%s scenario: all assertions passed (R7a, R8.1-8.6, R9, R10)", cfg.Name)
 	return nil
 }
 
@@ -276,6 +295,33 @@ func probeMCPConfigFile(container string, cfg systestlib.AgentConfig) error {
 		return err
 	}
 	logf("ok: R8.2 %s contains %s", cfg.ConfigPath, cfg.MCPMarker)
+	return nil
+}
+
+func probeMCPCmdline(container string, cfg systestlib.AgentConfig) error {
+	// Agent-agnostic R8.2 core (same facts probeMCPConfigFile gathers):
+	// aileron-mcp present + executable, daemon-wiring env vars all set.
+	binOK := dockerExecOK(container, "test", "-x", "/usr/local/bin/aileron-mcp")
+	envOK := true
+	for _, v := range []string{"AILERON_URL", "AILERON_COMMS_URL", "AILERON_SESSION_ID", "AILERON_APPROVAL_URL", "AILERON_TOKEN"} {
+		if !dockerExecOK(container, "printenv", v) {
+			envOK = false
+			break
+		}
+	}
+
+	// Cmdline tail: the container command line carries the MCP flag whose payload
+	// references the aileron server marker. Inspect BOTH .Config.Cmd and .Args so
+	// the probe is robust to whichever Docker populates, matching probe_mcp_cmdline
+	// in lib/probes.sh.
+	cmdline, err := dockerInspect(container, "{{range .Config.Cmd}}{{.}} {{end}}{{range .Args}}{{.}} {{end}}")
+	if err != nil {
+		return systestlib.Fail(fmt.Sprintf("R8.2 docker inspect %s failed (probe_mcp_cmdline)", container))
+	}
+	if err := systestlib.ProbeMCPCmdline(binOK, envOK, cmdline, cfg.MCPFlag, cfg.MCPMarker); err != nil {
+		return err
+	}
+	logf("ok: R8.2 container command carries %s and references %s", cfg.MCPFlag, cfg.MCPMarker)
 	return nil
 }
 


### PR DESCRIPTION
## Summary

Adds the `claude` entry point to the shell-free Go `aileron launch` system-test driver, mirroring the codex port from #1628. The cmdline-mode MCP infrastructure (`ProbeMCPCmdline`, `MCPModeCmdline`, `MCPFlag`/`MCPMarker` and their tests) was already merged on `main` from #1624, so this PR reuses it verbatim and adds only the claude-specific wiring.

- `test/system/lib/runner.go` — new `ClaudeConfig` constructor and `claudeDefaultImage` const. Claude wires MCP via the `--mcp-config` CLI flag (`MCPModeCmdline`, marker `"aileron"`), uses the `-p` batch flag, the `/home/agent/.claude/.credentials.json` credential path, and the LOCAL `aileron/sandbox-agent-claude:edge` image (no registry host, no digest pin, per #1451/#1585).
- `test/system/lib/runner_test.go` — contract tests for the claude config wiring (every field, local-image default with no registry-host/digest, override precedence, `-p` exec-arg assembly, shared prompt builder reuse).
- `test/system/scenario/scenario.go` — factored `runCodex`'s body into a shared, agent-agnostic `runScenario(e, cfg, probeMCP)`; added `runClaude` and the flag-mode `probeMCPCmdline` wrapper (asserts `--mcp-config` + the `"aileron"` server marker on the container command line, inspecting both `.Config.Cmd` and `.Args`).
- `test/system/scenario/main.go` — dispatch `claude`; usage and error strings now list `(supported: codex, claude)`.
- `test/system/README.md` — documents the shell-free Go claude path, the local-image default, and the flag-mode MCP probe.

### Scope boundaries

- No Taskfile change: `test:system:launch:claude` still runs `claude.sh`. The Go path is invoked by hand via `go run ./test/system/scenario claude`. `claude.sh` stays on disk and functional; the rewire is the sub-issue 3 retire PR.
- No new probe or `AgentConfig` field (all merged from #1624).
- No digest-pin path for the local claude image; codex's GHCR digest handling is untouched.

## Test plan

- `task test:system:lib` green (covers the new `ClaudeConfig` wiring; the merged `TestProbeMCPCmdline` already covers the flag-mode decision contract).
- `go test -cover ./test/system/lib/...` → 96.8% of statements; the new claude wiring lines are covered.
- `go build ./test/system/scenario` and `go vet ./test/system/scenario` clean.
- `go run ./test/system/scenario` (no arg) and `... badagent` print the updated usage error including `claude`.
- `gofmt -l` clean on all changed Go files.
- The live path (`go run ./test/system/scenario claude`) needs Docker + a Claude login + tokens; it is run BY HAND on an authed host. This headless host validates wiring only. The `scenario` module is its own nested Go module outside `GO_TEST_PACKAGES`, so the live path never executes under plain `go test`.

Closes #1625


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for running system scenarios with both `codex` and `claude`.
  * Introduced a new manual `claude` scenario flow with its own setup and validation steps.

* **Documentation**
  * Clarified how to run system tests locally versus in CI.
  * Added setup and execution instructions for the `claude` scenario, including image and environment requirements.

* **Bug Fixes**
  * Improved scenario handling so agent-specific checks and command-line validation work correctly for both supported agents.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->