### PR TITLE
spec(flightplan): launch-a-flight distribution surfaces

### DIFF
--- a/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
+++ b/docs/src/content/docs/adr/0027-flight-plan-sealed-installable-skill.md
@@ -88,7 +88,7 @@ The architectural split sits at the freeze step. There are two sub-layers.
 
 The format and install sub-layer holds skills before freeze. This sub-layer covers instruction-only skills and credentialed skills. This sub-layer carries no determinism guarantee. A skill in this sub-layer can be installed and run, and it has no reproducibility or behavioral-determinism promise.
 
-The Flight-Plan-core sub-layer holds skills after freeze. This sub-layer carries the freeze step, the execution-environment binding, the no-LLM-at-runtime rule, and the signing. A unit in this sub-layer is a Flight Plan with all the guarantees recorded above.
+The Flight-Plan-core sub-layer holds skills after freeze. This sub-layer carries the freeze step, the execution-environment binding, the no-LLM-at-runtime rule, and the signing. A unit in this sub-layer is a Flight Plan with all the guarantees recorded above. The distribution surfaces over a frozen Flight Plan are specified in the [Launch-a-Flight Surfaces Spec](/development/launch-surfaces-spec/).
 
 ### Layer boundary
 
@@ -151,6 +151,7 @@ The following are out of scope for this ADR and this layer's MVP.
 - [Issue #1514](https://github.com/ALRubinger/aileron/issues/1514). This ADR's tracking sub-issue
 - [Issue #1519](https://github.com/ALRubinger/aileron/issues/1519). The output-contract reservation that text is the v1 implementation and binary is a deferred follow-up
 - [The Flight Plan manifest specification](/development/flight-plan-manifest-spec). The `outputs:` contract shape and the file-map transport
+- [The Launch-a-Flight Surfaces Spec](/development/launch-surfaces-spec/). The distribution surfaces over a frozen Flight Plan
 - [ADR-0003](/adr/0003-action-model). The action model the per-action trust contract attaches to
 - [ADR-0005](/adr/0005-sandbox-choice). The sandbox and credential mediation a Flight Plan runs inside
 - [ADR-0009](/adr/0009-user-channel). The out-of-band approval channel the per-action effect feeds

--- a/docs/src/content/docs/development/launch-surfaces-spec.md
+++ b/docs/src/content/docs/development/launch-surfaces-spec.md
@@ -1,0 +1,180 @@
+---
+title: "Launch-a-Flight Surfaces Spec"
+description: "The distribution surfaces over a frozen, signed Flight Plan. How anyone in an org Launches a Flight without operating an agent, the per-surface invocation contract, preview and approval routing, and result delivery including file-artifact outputs."
+order: 12
+---
+
+A Launch invokes a frozen, signed Flight Plan version through the deterministic Launch runtime ([Launching a Flight Plan guide](/guides/launching-a-flight-plan/), [ADR-0027](/adr/0027-flight-plan-sealed-installable-skill)). A surface is the front door to that runtime. A surface is not a new runtime. This page specifies the distribution surfaces over a frozen Flight Plan: the four internal surfaces, the four external surfaces, and per surface the invocation contract, the preview and approval routing, and the result delivery.
+
+Anyone in an org can Launch a Flight against a Flight Plan, and no one operates an agent. The Flight Plan is exposed for launching through one or more surfaces. The person who Launches a Flight states an outcome and receives a result. The deterministic Launch runtime does the work, and the org's connectors perform the credentialed calls.
+
+## Scope and non-goals
+
+This spec defines surfaces. It does not redefine the freeze boundary, the Launch runtime, the per-action trust contract, or the [ADR-0009](/adr/0009-user-channel) out-of-band approval. Those are specified elsewhere and reused here.
+
+A surface introduces no new approval mechanism. Approval routing is the effect-driven out-of-band approval already specified by the [Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) trust contract and [ADR-0009](/adr/0009-user-channel). A surface binds to that routing and never replaces it.
+
+File-artifact outputs are in scope for result delivery. Binary materialization stays deferred. v1 materializes `utf-8` artifacts only, and `base64` or binary output is blocked on the host-ABI binary-body field and the rung-three mount or run-and-collect boundary ([#1510](https://github.com/ALRubinger/aileron/issues/1510)).
+
+This spec ships no code. It is a normative format and contract spec in the same register as the [Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) and the [AI-Assisted Authoring UX Spec](/development/ai-assisted-authoring-spec/). The runtime it surfaces is tracked in [#1511](https://github.com/ALRubinger/aileron/issues/1511). The surface set is absorbed and quoted from [#928](https://github.com/ALRubinger/aileron/issues/928), not depended on.
+
+## The common Launch contract
+
+Every surface shares one Launch contract. The per-surface dimensions specialize how a surface gathers a payload and renders a result, never the underlying guarantees.
+
+Every Launch binds a frozen Flight Plan version. The version is the content hash plus the semver label from the manifest `lock` section ([Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) freeze and lock section). A surface invokes the deterministic Launch runtime against a digest-pinned, signed version. A surface never invokes an unfrozen skill.
+
+Every Launch resolves its declared inputs once, at the launch boundary ([#1523](https://github.com/ALRubinger/aileron/issues/1523)). A surface passes literal-input overrides into that single resolution step. A surface never resolves inputs itself and never resolves them more than once.
+
+Every Launch carries an idempotency key. The key identifies one Launch attempt so a retried submission from the same surface does not double-run a Flight. The key is supplied by the surface and recorded with the run.
+
+Every Launch ties to an `identityLabel` for audit. The label is the same non-secret subject or account identity label in the manifest `credential` block ([Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) credential block). The label binds the Launch to an identity for audit ([ADR-0015](/adr/0015-launch-audit-scope/)). The label is never a credential value.
+
+Three per-surface dimensions specialize this contract.
+
+| Dimension | What it specializes |
+|---|---|
+| Invocation contract | The payload shape, the identity binding, and the idempotency key for this surface. |
+| Preview and approval routing | How an effect-driven approval reaches the approver through the out-of-band channel for this surface. |
+| Result delivery | How message-shaped and file-artifact outputs reach the person who Launched. |
+
+Approval routing reuses the effect-driven gate. The trust contract declares an `effect` for each action, one of `read`, `write`, `delete`, `spend`, or `external-send` ([Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) trust contract). A `read` Launch runs unattended. A `write`, `delete`, `spend`, or `external-send` Launch raises an out-of-band approval gate and blocks on the decision ([ADR-0009](/adr/0009-user-channel)). The approval-time preview is fetched at decision time ([ADR-0016](/adr/0016-approval-preview/)). A surface routes the approval to the approver through its channel and surfaces the recorded decision in result delivery. A surface never confirms an effect inline in place of the out-of-band gate.
+
+## Internal surfaces
+
+The internal surfaces expose a Flight Plan to people inside the org. The four internal surfaces are the button in the org's own portal, the form, the Slack command, and integrations into the org's own tools.
+
+### Portal button
+
+The portal button is an embeddable widget the org places in its own portal. The button design is specified in [Embeddable widget designs](#embeddable-widget-designs).
+
+The invocation contract is a button click that emits the embeddable invocation payload. The payload names the Flight Plan, the version, the resolved-input overrides, the idempotency key, and the identity label. The identity binding is the portal session identity carried into the `identityLabel`. The idempotency key is minted per click so a double click does not double-run.
+
+The approval routing is the effect-driven out-of-band gate. A `read` Launch runs on click. A `write`, `delete`, `spend`, or `external-send` Launch raises the [ADR-0009](/adr/0009-user-channel) gate, and the button reflects a pending-approval state until the decision returns.
+
+The result delivery is the result-render contract of [Embeddable widget designs](#embeddable-widget-designs). The widget renders a message-shaped result inline and renders each file artifact through the file-artifact rules in [Result delivery and file artifacts](#result-delivery-and-file-artifacts).
+
+### Form
+
+The form collects literal-input overrides as form fields and Launches on submit.
+
+The invocation contract is a form submission that maps each declared literal input to a form field. The submission emits the same invocation payload as the portal button. The identity binding is the form session identity carried into the `identityLabel`. The idempotency key is minted per submission so a resubmitted form does not double-run.
+
+The approval routing is the effect-driven out-of-band gate, unchanged from the common contract.
+
+The result delivery shows the run outcome on the form's result view. A message-shaped result renders inline. A file artifact renders through the file-artifact rules.
+
+### Slack command
+
+The Slack command is an embeddable command the org installs in its own workspace. The command design is specified in [Embeddable widget designs](#embeddable-widget-designs).
+
+The invocation contract is a slash-command invocation that emits the invocation payload. Command arguments map to declared literal inputs. The identity binding is the Slack user identity carried into the `identityLabel`. The idempotency key is minted per invocation.
+
+The approval routing is the effect-driven out-of-band gate. A gated Launch routes the approval to the approver and posts the recorded decision back into the command's thread.
+
+The result delivery posts the result into the command's Slack thread. A message-shaped result posts inline. A file artifact posts through the file-artifact rules, by reference when the artifact is large or binary.
+
+### Integrations into the org's own tools
+
+This surface lets the org Launch a Flight from its own internal tools through a programmatic trigger.
+
+The invocation contract is a programmatic call that supplies the invocation payload. The identity binding is the calling system's identity carried into the `identityLabel`. The idempotency key is supplied by the calling system so a retried call does not double-run.
+
+The approval routing is the effect-driven out-of-band gate. A gated Launch blocks on the [ADR-0009](/adr/0009-user-channel) decision before the run proceeds.
+
+The result delivery returns the run outcome to the calling system. A message-shaped result returns inline. A file artifact returns through the file-artifact rules, by reference for large or binary artifacts.
+
+## External surfaces
+
+The external surfaces expose a Flight Plan to people outside the org. The four external surfaces are the customer portal button, the self-serve form, the public Slack or email channel, and the email reply parser.
+
+### External auth model
+
+The person Launching never operates an agent and never authenticates beyond the org's own surface. A customer interacts with the org's surface alone. The org's connectors perform the credentialed work behind that surface. Identity binding ties each Launch to an identity label for audit ([ADR-0015](/adr/0015-launch-audit-scope/)). The customer never holds a credential, never sees a credential, and never reaches the connectors directly. The org's frozen Flight Plan and its trust contract are the only thing the customer's request flows through.
+
+### Customer portal button
+
+The customer portal button is the embeddable button placed in a customer-facing portal.
+
+The invocation contract is a button click that emits the invocation payload. The identity binding is the customer identity carried into the `identityLabel`. The idempotency key is minted per click.
+
+The approval routing is the effect-driven out-of-band gate. The approver is in the org, not the customer. A gated Launch routes the approval to the org's approver through the [ADR-0009](/adr/0009-user-channel) channel, and the customer sees a pending state until the decision returns.
+
+The result delivery renders the result in the customer portal. A message-shaped result renders inline. A file artifact renders through the file-artifact rules, including a hosted URL or iframe target for a surface that cannot execute JavaScript.
+
+### Self-serve form
+
+The self-serve form lets a customer Launch a Flight by filling in literal inputs.
+
+The invocation contract is a form submission that maps declared literal inputs to fields and emits the invocation payload. The identity binding is the customer identity carried into the `identityLabel`. The idempotency key is minted per submission.
+
+The approval routing is the effect-driven out-of-band gate, with the org as the approver.
+
+The result delivery shows the outcome on the form's result view. A file artifact renders through the file-artifact rules, by reference for large or binary artifacts.
+
+### Public Slack or email channel
+
+This surface lets a customer Launch a Flight by posting into a public Slack channel or sending to an org email address.
+
+The invocation contract parses the inbound message into the invocation payload. Message content maps to declared literal inputs. The identity binding is the sender identity carried into the `identityLabel`. The idempotency key is derived from the inbound message identity so a redelivered message does not double-run.
+
+The approval routing is the effect-driven out-of-band gate, with the org as the approver.
+
+The result delivery replies in the same channel. A message-shaped result replies inline. A file artifact replies through the file-artifact rules. An email reply that cannot render inline content receives a hosted URL.
+
+### Email reply parser
+
+The email reply parser Launches a Flight from a structured reply to an org email.
+
+The invocation contract parses the reply body into the invocation payload. The reply structure maps to declared literal inputs. The identity binding is the replying sender identity carried into the `identityLabel`. The idempotency key is derived from the reply message identity.
+
+The approval routing is the effect-driven out-of-band gate, with the org as the approver.
+
+The result delivery sends a reply email. A message-shaped result is the reply body. A file artifact is delivered through the file-artifact rules. A large or binary artifact is delivered by reference as a hosted URL rather than an attachment.
+
+## Result delivery and file artifacts
+
+Result delivery covers named file-artifact outputs, not only message-shaped results. The artifacts are the ones declared in the Flight Plan `outputs:` contract ([Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) outputs contract). Three rules govern file-artifact delivery across every surface.
+
+A named file artifact is published to its declared publish target. The `outputs:` contract names each artifact and its publish target. The runtime publishes each artifact to that target, whether an object store, an embedded portal surface, or email. The audit references each published artifact by its declared name, reusing the `outputs:` contract rule that the audit references artifacts by name ([Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) outputs contract).
+
+A surface that cannot execute JavaScript receives a hosted URL or an iframe target rather than inline content. An email reply and a static surface cannot render an interactive result inline. The surface receives a hosted URL or an iframe target that points at the published artifact instead.
+
+A large or binary artifact is published by reference, never inlined. A small text artifact may render inline. A large artifact or a binary artifact is published to its target and delivered as a reference to that target. This is consistent with v1 `utf-8`-only materialization. Binary and `base64` materialization is the deferred follow-up blocked on the host-ABI binary-body field and the rung-three mount or run-and-collect escape hatch ([#1510](https://github.com/ALRubinger/aileron/issues/1510)).
+
+## Embeddable widget designs
+
+The portal button, the form, and the Slack command are embeddable. Each is implementable from one invocation payload shape and one result-render contract.
+
+The invocation payload is the shape a widget emits to Launch a Flight. It names the Flight Plan, the frozen version, the resolved-input overrides, the idempotency key, and the identity label. The payload is a binding of values into the common Launch contract, never a step or a credential.
+
+| Field | Required | Semantics |
+|---|---|---|
+| `flightPlan` | Yes | The Flight Plan name the widget Launches. |
+| `version` | No | The frozen version id, the content hash plus the semver label. Absent selects the most recent frozen version. |
+| `inputs` | No | The resolved-input overrides, one entry per declared literal input the widget collected. |
+| `idempotencyKey` | Yes | The per-invocation idempotency key the widget mints so a repeated submission does not double-run. |
+| `identityLabel` | Yes | The non-secret identity label carried for audit ([ADR-0015](/adr/0015-launch-audit-scope/)). |
+
+The result-render contract is the shape a widget renders after a Launch. It carries the run identity, the approval decision when the Launch was gated, the message-shaped result, and the published file artifacts.
+
+| Field | Required | Semantics |
+|---|---|---|
+| `runId` | Yes | The run identity the audit references. |
+| `approvalDecision` | No | The recorded out-of-band approval decision, present when the Launch was gated ([ADR-0009](/adr/0009-user-channel)). |
+| `message` | No | The message-shaped result rendered inline. |
+| `artifacts` | No | The published file artifacts, each named and referenced by its declared `outputs:` name, delivered by reference when large or binary. |
+
+A widget renders a message-shaped result inline. A widget renders each file artifact through the file-artifact rules in [Result delivery and file artifacts](#result-delivery-and-file-artifacts). A widget on a surface that cannot execute JavaScript renders the hosted URL or iframe target the runtime publishes.
+
+## References
+
+- [ADR-0027](/adr/0027-flight-plan-sealed-installable-skill). The Flight Plan as a sealed installable skill, the freeze boundary, and the layer split this spec distributes over
+- [The Flight Plan manifest specification](/development/flight-plan-manifest-spec/). The trust contract, the `outputs:` contract, and the `credential` block this spec binds to
+- [Launching a Flight Plan](/guides/launching-a-flight-plan/). The deterministic Launch runtime a surface invokes
+- [ADR-0009](/adr/0009-user-channel/). The out-of-band approval channel the per-action effect routes through
+- [ADR-0016](/adr/0016-approval-preview/). The approval-time preview fetch the gated routing surfaces
+- [ADR-0015](/adr/0015-launch-audit-scope/). The launch audit scope the identity label and the artifact names are recorded under
+- [Issue #1511](https://github.com/ALRubinger/aileron/issues/1511). The deterministic Launch runtime a surface invokes
+- [Issue #1519](https://github.com/ALRubinger/aileron/issues/1519). The output-contract scope that brings named file-artifact outputs into result delivery
+- The distribution-surfaces spec ([#928](https://github.com/ALRubinger/aileron/issues/928)) is absorbed and quoted here, not depended on.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -99,6 +99,7 @@ export const navigation: NavItem[] = [
       { label: 'Sandbox Connector Specs', href: '/development/sandbox-connector-specs/' },
       { label: 'Flight Plan Manifest Spec', href: '/development/flight-plan-manifest-spec/' },
       { label: 'AI-Assisted Authoring UX Spec', href: '/development/ai-assisted-authoring-spec/' },
+      { label: 'Launch-a-Flight Surfaces Spec', href: '/development/launch-surfaces-spec/' },
       { label: 'Submitting Changes', href: '/development/submitting-changes/' }
     ]
   },


### PR DESCRIPTION
## Summary

Adds the normative **Launch-a-Flight Surfaces Spec**, the distribution layer over a frozen, signed Flight Plan. A surface is the front door to the deterministic Launch runtime (#1511); it is not a new runtime. The spec defines how anyone in an org Launches a Flight without operating an agent, enumerating the 4 internal and 4 external surfaces (quoted from #928) and, per surface, the invocation contract, the preview/approval routing, and result delivery.

Key decisions, faithful to the plan:

- **No new approval mechanism.** Approval routing reuses the effect-driven out-of-band gate from the manifest trust contract and ADR-0009: a `read` Launch runs unattended; `write`/`delete`/`spend`/`external-send` raise the OOB gate and block on the decision (preview fetched at decision time per ADR-0016).
- **Common Launch contract** shared by all surfaces: every Launch binds a frozen version (content-hash + semver from the `lock` section), resolves inputs once at the launch boundary (#1523), carries an idempotency key, and ties to a non-secret `identityLabel` for audit (ADR-0015).
- **File-artifact outputs are in scope** for result delivery (#1519): publish named artifacts to their declared `outputs:` publish target, audit references each by name, JS-incapable surfaces get a hosted URL/iframe, large/binary published by reference. Binary materialization stays deferred (#1510).
- **External auth model** stated unambiguously: the person Launching never operates an agent and never authenticates beyond the org's own surface; the org's connectors do the work; identity binding ties each Launch to a label for audit.
- **Embeddable widget designs** for portal button, form, and Slack command: one invocation-payload shape and one result-render contract.

Also adds the Development sidebar entry (array-position-driven, immediately after the flightplan triad) and a cross-link plus a References bullet in ADR-0027. No Go, OpenAPI, or schema changes. The launching guide and the manifest spec are cross-linked FROM only, never edited.

## Test plan

- `task lint:docs` — `astro check` green: 0 errors, 0 warnings, 0 hints.
- `task build:docs` — Starlight build green, 145 pages built; the new `/development/launch-surfaces-spec/` page renders.
- Right-reason cross-link check: verified every internal route the new page links (ADR-0027, manifest spec, launching guide, ADR-0009/0015/0016, AI-assisted authoring spec) produced an output `index.html` in `dist/`, and both in-page anchors (`#embeddable-widget-designs`, `#result-delivery-and-file-artifacts`) match the generated heading slugs.
- Voice check: no em-dashes, no "not just X, Y".

Closes #1513
