### PR TITLE
fix(systest): SIGINT-then-SIGKILL launch reap to preserve R8.5 teardown

### DIFF
--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -16,6 +16,11 @@ import (
 // discovers the container by this prefix rather than predicting the full name.
 const sbxPrefix = "aileron-sbx-"
 
+// reapGracePeriod is how long reap waits for the `aileron launch` process to exit
+// after a graceful SIGINT (so the launcher's `docker stop` handler can tear the
+// sandbox down) before escalating to SIGKILL.
+const reapGracePeriod = 10 * time.Second
+
 // env holds the validated environment the scenario reads, mirroring the bash
 // `: "${VAR:?...}"` preconditions. AILERON_SYSTEST_LIB is intentionally absent:
 // the lib is now an imported Go package, so that var is vestigial for this path.
@@ -140,7 +145,25 @@ func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container stri
 			return
 		}
 		reaped = true
-		_ = cmd.Process.Kill()
+		// Graceful stop first, mirroring the bash trap's `kill` (SIGTERM): the
+		// launcher installs a SIGINT/SIGTERM handler that runs `docker stop` on
+		// the `docker run --rm` sandbox, so a graceful signal is what tears the
+		// container down and lets R8.5 (probe_teardown: no `aileron-sbx-*`
+		// survives) hold on the mid-probe abort path. A bare SIGKILL bypasses
+		// that handler and can leave a stray container. os.Interrupt maps to
+		// SIGINT on Unix; on Windows it cannot be delivered to another process,
+		// so Signal returns an error and we fall straight through to Kill.
+		// Either way we escalate to SIGKILL if the launch has not exited within
+		// the grace window, so reap never blocks indefinitely.
+		if err := cmd.Process.Signal(os.Interrupt); err != nil {
+			_ = cmd.Process.Kill()
+		} else {
+			select {
+			case <-waitDone:
+			case <-time.After(reapGracePeriod):
+				_ = cmd.Process.Kill()
+			}
+		}
 		<-waitDone
 	}
 	defer reap()


### PR DESCRIPTION
## Summary

Resolves the one actionable finding from residual #1627 (the cross-platform systest port umbrella #1623): the Go scenario driver reaped the `aileron launch` process with a bare `cmd.Process.Kill()` (SIGKILL), bypassing the launcher's SIGINT/SIGTERM → `docker stop` handler. On the mid-probe abort path that could leave an `aileron-sbx-*` sandbox alive and flake R8.5 (`probe_teardown`). The retired bash scenarios reaped with `kill` (SIGTERM), which triggered the handler; the Go port silently regressed it.

The fix sends a graceful signal first (`os.Interrupt` → SIGINT on Unix, handled identically to SIGTERM by the launcher) and escalates to SIGKILL only after a 10s grace window. On Windows `os.Interrupt` cannot be delivered to another process, so `Signal` returns an error and we fall through to `Kill`, preserving the cross-platform contract that motivated #1623.

The other four #1627 findings were re-judged against shipped `main` and confirmed already resolved (sentinel trailing-newline trim, scenario `go.mod` require, R10 `Event==""` comment) or covered by #1625 (cmdline-mode AgentConfig) — see the triage comment on #1627. This PR closes it.

## Test plan

- `go build ./test/system/scenario/...` and `go vet ./test/system/scenario/...` pass (via `go.work`).
- `go test ./test/system/lib/...` (the `GO_TEST_PACKAGES` CI tier) stays green.
- **No new unit test, deliberately:** the reap is a closure over a live `*exec.Cmd` in the by-hand live-Docker module, which is outside `GO_TEST_PACKAGES` and never executed in CI by design (#1623). A test would require faking a process and asserting signal ordering — coupling to internals, which the repo testing philosophy forbids. Behavioral acceptance (an aborted run leaves no surviving `aileron-sbx-*`) is verified by-hand on a Docker host, like the rest of this tier.

Closes #1627. Part of #1623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
