### PR TITLE
fix(flightplan): reject present-but-empty executionEnvironment at schema layer

### DIFF
--- a/docs/schema/flight-plan-manifest.schema.json
+++ b/docs/schema/flight-plan-manifest.schema.json
@@ -89,6 +89,7 @@
         { "required": ["rung1Image"], "not": { "required": ["rung2CapabilityUnits"] } },
         { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } },
         {
+          "required": ["rung3PerStepImages"],
           "not": {
             "anyOf": [
               { "required": ["rung1Image"] },

--- a/internal/flightplan/manifest/flight-plan-manifest.schema.json
+++ b/internal/flightplan/manifest/flight-plan-manifest.schema.json
@@ -89,6 +89,7 @@
         { "required": ["rung1Image"], "not": { "required": ["rung2CapabilityUnits"] } },
         { "required": ["rung2CapabilityUnits"], "not": { "required": ["rung1Image"] } },
         {
+          "required": ["rung3PerStepImages"],
           "not": {
             "anyOf": [
               { "required": ["rung1Image"] },

--- a/internal/flightplan/manifest/validate_test.go
+++ b/internal/flightplan/manifest/validate_test.go
@@ -151,7 +151,9 @@ aileron:
 // rung-3-only declaration is now valid (a reserved, build-deferred slot it is
 // freeze's job to report, not the schema's job to forbid). rung-3 alongside
 // rung-1 is also permitted: rung-3 is a reserved slot and does not weaken the
-// rung-1/rung-2 exclusivity.
+// rung-1/rung-2 exclusivity. A present-but-empty executionEnvironment ({}) is
+// rejected: declaring the key obliges naming at least one rung (key omission,
+// not an empty block, is how a skill says it has no execution environment).
 func TestExecutionEnvironmentRungValidity(t *testing.T) {
 	valid := map[string]string{
 		"rung1 only": `      rung1Image:
@@ -182,6 +184,7 @@ func TestExecutionEnvironmentRungValidity(t *testing.T) {
       rung2CapabilityUnits:
         features:
           - ghcr.io/example/aileron-feature-metrics-cli:1`,
+		"empty executionEnvironment rejected": `      {}`,
 	}
 	for name, env := range invalid {
 		t.Run("invalid/"+name, func(t *testing.T) {


### PR DESCRIPTION
## Summary

The flight-plan manifest schema's third `executionEnvironment` `oneOf` branch
only forbade rung-1/rung-2 presence; it did not require any rung. As a result a
present-but-empty `executionEnvironment: {}` block passed schema validation,
even though declaring the key should oblige naming at least one rung.

This tightens the third branch to `required: ["rung3PerStepImages"]` (keeping
the existing `not anyOf rung1/rung2` exclusivity). The only valid manifest with
neither rung-1 nor rung-2 is now a rung-3-only declaration. Key omission (not an
empty block) remains the way a skill declares it has no execution environment,
so freeze's `len(env) == 0` instruction-only path is unchanged.

Both schema copies — `internal/flightplan/manifest/flight-plan-manifest.schema.json`
and `docs/schema/flight-plan-manifest.schema.json` — are edited identically so
`schema_drift_test` stays green.

## Test plan

- Added invalid case `empty executionEnvironment rejected` (an empty `{}` block)
  to `TestExecutionEnvironmentRungValidity`, asserting a schema validation error.
- Verified the new test FAILS without the schema change (got nil) and PASSES with
  it.
- Existing valid cases (rung1-only, rung2-only, rung3-only, rung3 alongside
  rung1) and the rung1+rung2 rejection case still pass.
- `go test ./internal/flightplan/...` green (including schema_drift); `go build`
  and `go vet` clean for the flightplan packages.

Closes #1613

🤖 Generated with [Claude Code](https://claude.com/claude-code)
