### PR TITLE
fix(systest): wait for natural launch exit before reading R9 sentinel

### DIFF
--- a/test/system/scenario/scenario.go
+++ b/test/system/scenario/scenario.go
@@ -211,8 +211,17 @@ func runScenario(e env, cfg systestlib.AgentConfig, probeMCP func(container stri
 		return systestlib.Fail(fmt.Sprintf("never observed a running %s* container during the launch", sbxPrefix))
 	}
 
-	// --- reap and assert the launch exit code (R8.6) -----------------------
-	reap()
+	// --- wait for the launch to finish, then assert its exit code (R8.6) ----
+	// Wait for the launch to exit on its own here — do NOT reap()/kill it. The
+	// agent must complete its forwarded exec (write the R9 sentinel into the
+	// mounted workspace and perform the R10 http_request) before we read the
+	// result, exactly as bash did with `wait "$LAUNCH_PID"`. Calling reap()
+	// (which signals/kills the launch) on this normal path interrupts the agent
+	// mid-exec, so the sentinel is never written and R9 fails with "agent did
+	// not write it". The probes above already ran against the live container;
+	// reap() remains the deferred / early-return safety net for the abnormal
+	// path (a mid-probe failure still tears the launch down).
+	<-waitDone
 	if err := systestlib.ProbeExitCode(launchExit(), 0); err != nil {
 		logf("launch log follows:")
 		dumpFile(launchLog)


### PR DESCRIPTION
## Summary

The first by-hand live run of the ported codex scenario (`task test:system:launch:codex`) failed at **R9** with `sentinel file not found ... (agent did not write it)` while R8.1-8.5 all passed. Root cause: the Go scenario driver **reaped (killed) the `aileron launch` process on the normal path**, right after the live-container probes and before reading R9 — interrupting the agent mid-exec so it never wrote the sentinel.

The retired bash scenarios used `wait "$LAUNCH_PID"` at this point: they waited for the launch to exit on its own so the agent could finish its forwarded exec (write the R9 sentinel, perform the R10 http_request) before the result was read. The kill path (`reap_launch`) was only the EXIT/INT/TERM trap. The port used the kill-reap closure on the normal path; the SIGINT reap from #1637 then masked it at R8.6 (the launcher catches SIGINT, `docker stop`s, exits 0).

**Fix:** replace the normal-path `reap()` with `<-waitDone` (block for natural exit), mirroring bash. `reap()` stays the deferred / early-return safety net, so a mid-probe failure still tears the launch down. Fixes both codex and claude (shared `runScenario`).

## Test plan

- `go build`/`go vet ./test/system/scenario/...` and `go test ./test/system/lib/...` (the `GO_TEST_PACKAGES` CI tier) pass.
- **Cross-compiles clean for all three OSes** (`GOOS=darwin|linux|windows go build ./test/system/scenario/...`), so the shell-free driver builds on macOS, Linux, and Windows.
- **No new unit test, deliberately:** the wait-vs-reap sequencing is in the by-hand live-Docker driver (outside `GO_TEST_PACKAGES`, never run in CI by design, #1623). Behavioral verification is a by-hand `task test:system:launch:codex` / `:claude` on a Docker + agent-auth host — the same run that surfaced this bug re-runs to confirm R9 (then R10) passes.

Found via the #1629 by-hand verification. Part of #1623.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
