### PR TITLE
docs(flight-plans): add Flight Plans concept page and authoring guide

### DIFF
--- a/docs/src/content/docs/concepts/flight-plans.md
+++ b/docs/src/content/docs/concepts/flight-plans.md
@@ -1,0 +1,83 @@
+---
+title: "Flight Plans"
+description: "A Flight Plan is a sealed Aileron skill: an authored SKILL.md that a freeze step pins to digests, locks, binds to an execution environment, attaches a per-action trust contract to, and signs into a reproducible, behaviorally deterministic unit."
+order: 7
+---
+
+A **Flight Plan** is a sealed Aileron skill. A skill is the authoring artifact. A Flight Plan is the same artifact after a freeze step seals it. One format spans both states, and the freeze step is the boundary between them.
+
+If [actions](/concepts/actions/) are the atomic unit of agent capability, a Flight Plan is the named composition above them. It calls actions, runs inside the [sandbox](/concepts/deterministic-agentic-execution/), and surfaces its per-action effects through the out-of-band approval channel. A Flight Plan composes those primitives. It does not redefine them.
+
+## A Flight Plan is a sealed skill
+
+"Flight Plan" is the user-facing product noun. "Skill" is the [agentskills.io](https://agentskills.io) `SKILL.md` format, extended with one Aileron-specific block. Every Flight Plan is a skill. Not every skill is a Flight Plan.
+
+A skill becomes a Flight Plan only after it is frozen. Before freeze, the document is an authoring artifact with no determinism guarantee. After freeze, the document is a sealed unit with every guarantee below.
+
+The extension is lossless if stripped. A tool that ignores the Aileron fields still reads a valid skill. That is why the same `SKILL.md` spans authoring and sealing.
+
+## The freeze boundary
+
+Freeze is the step that turns a skill into a Flight Plan. It runs a fixed sequence over one `SKILL.md` document.
+
+- It resolves every image reference to a content-addressed digest.
+- It produces a lockfile that pins those digests and the resolved capability set.
+- It binds the execution environment the Flight Plan runs in.
+- It attaches the per-action trust contract.
+- It signs the result with a detached signature.
+
+Before freeze, none of these are present. After freeze, all of them are present and immutable for that version. The signature is a human attestation that the trust contract is correct, and it is the act that makes the unit trusted. The [Freezing a Flight Plan](/guides/freezing-a-flight-plan/) guide walks through running freeze and the reproducibility it guarantees.
+
+## Two determinisms
+
+A Flight Plan carries two distinct determinism guarantees.
+
+The first is **environmental reproducibility**. Every image reference is pinned to a digest at freeze. The same Flight Plan resolves the same images on every run. The lockfile is the record of those pins.
+
+The second is **behavioral determinism**. No LLM runs at Flight Plan runtime by default. An LLM runs only at a single seam that is explicitly marked in the skill and structurally enforced by the runtime. A freeze-time lint rejects any unmarked LLM call. A skill that reaches an LLM outside the marked seam fails freeze and never becomes a Flight Plan. The marked seam is the one place where non-deterministic reasoning is allowed, and everything outside it is deterministic by construction.
+
+## Inputs, resolution, and the audit boundary
+
+Behavioral determinism is a property of the function, not of the output. A Flight Plan is a pinned function over its declared inputs. Given the same resolved inputs, it produces the same output.
+
+The point of running a Flight Plan again is that its inputs, or the data in the systems it reads, have moved. Results therefore vary across runs, and that variance is expected rather than a determinism violation. The line is between the logic, which is sealed and fixed, and the inputs, which are declared, resolved, and recorded.
+
+Inputs are declared, each with a resolution rule. A resolution rule is a literal value passed at launch, a dynamic value such as the launch time or launch date, or a read from a live source. A value that varies by use case, such as a time window, is a declared input rather than a constant baked into the composition, so one composition serves many operators.
+
+Inputs resolve once, at the launch boundary. The runtime resolves all declared inputs one time into a concrete resolved-input set, and the composition runs against that set. Two steps that read the same moving value such as the wall clock see one resolved value. The resolved-input set is the single recorded binding for the run.
+
+The audit records resolved inputs and outputs. A scalar input is recorded by value, so a launch-time clock input is recorded as the concrete timestamp it resolved to. A data read is recorded by its resolved binding, which is the parameters, the query, and a result or snapshot identifier with a summary, rather than the full dataset inline. The recorded binding is what makes a past run explainable without reconstructing it from a moving source.
+
+## The per-action trust contract
+
+Each action a Flight Plan calls carries a per-action trust contract. The contract is the field set freeze attaches, and the detached signature is the human attestation that it is correct.
+
+The contract records the credential kind and its placement, never a credential value. It records the OAuth scopes, endpoints, and refresh behavior for an OAuth credential. It records the expected network hosts and paths the action reaches. It records the operation effect as one of `read`, `write`, `delete`, `spend`, or `external-send`. It records whether the operation is idempotent. It records the redaction rules for the operation's inputs and outputs. It records a verification probe the runtime can call to confirm the operation's result. It records the structure of the audit record the operation emits.
+
+The operation effect feeds the approval surface. A `read` runs unattended. A `write`, `delete`, `spend`, or `external-send` raises an approval gate and blocks on the decision. The user sees the recorded effect when an approval is requested.
+
+## The execution environment
+
+A Flight Plan runs on a composed execution image, and that image is assembled from rungs.
+
+Rung one pins a whole prebuilt image. The skill names an image, and freeze resolves it to a digest. The operator owns that image.
+
+Rung two declares capability units, and Aileron composes them. The skill declares the units it requires on top of a generic Aileron-provided agent-free minimal base image. Freeze composes the operator-owned capability-unit devcontainer Features onto that base and pins the result.
+
+The MVP ships rungs one and two. Rung three is a per-step sealed sibling-image dispatch, and it is a forward-declared manifest slot only. The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.
+
+## The lifecycle
+
+A Flight Plan moves through three phases.
+
+1. **Author.** You hand-write a `SKILL.md` with the `requires:` block, the deterministic step graph, the `outputs:` contract, and a per-action trust contract for every action it calls. The [Authoring a Flight Plan](/guides/authoring-a-flight-plan/) guide walks through this.
+2. **Freeze.** `aileron skill freeze` seals the skill into a signed, digest-pinned, immutable Flight Plan version. The [Freezing a Flight Plan](/guides/freezing-a-flight-plan/) guide covers the command.
+3. **Launch.** `aileron skill launch` verifies the frozen unit, resolves inputs once at the boundary, walks the step graph with no model in the loop, enforces the trust contract, and materializes the declared outputs. The [Launching a Flight Plan](/guides/launching-a-flight-plan/) guide covers the runtime.
+
+## Where to go next
+
+- [Authoring a Flight Plan](/guides/authoring-a-flight-plan/) — write the `SKILL.md` by hand, then hand it off to freeze.
+- [Freezing a Flight Plan](/guides/freezing-a-flight-plan/) — seal an installed skill into a signed Flight Plan version.
+- [Launching a Flight Plan](/guides/launching-a-flight-plan/) — run a frozen Flight Plan deterministically.
+- [ADR-0027: Flight Plan = Sealed Installable Skill](/adr/0027-flight-plan-sealed-installable-skill/) — the design decision behind everything on this page.
+- [Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) — the normative `SKILL.md` frontmatter format, field by field.

--- a/docs/src/content/docs/guides/authoring-a-flight-plan.md
+++ b/docs/src/content/docs/guides/authoring-a-flight-plan.md
@@ -69,7 +69,7 @@ aileron:
     - id: summarize
       kind: transform
       bindings:
-        rows: steps.read
+        rows: steps.read.messages
       outputs: ["text"]
       materializesOutput: digest
 ---

--- a/docs/src/content/docs/guides/authoring-a-flight-plan.md
+++ b/docs/src/content/docs/guides/authoring-a-flight-plan.md
@@ -1,0 +1,213 @@
+---
+title: "Authoring a Flight Plan"
+description: "Hand-write a Flight Plan SKILL.md: the requires block for actions and execution environments, per-action trust contracts, declared inputs and outputs, the deterministic no-LLM step graph, and the handoff to freeze and sign."
+---
+
+This guide walks you from an empty file to a skill ready to freeze. By the end you will have a single `SKILL.md` document that declares the actions it calls, the environment it runs in, the inputs it resolves, the outputs it produces, and a deterministic step graph that wires them together with no language model in the loop.
+
+If you have not read it yet, start with [Flight Plans](/concepts/flight-plans/) for the model. This guide is the *how*; that page is the *what* and *why*. The normative field reference is the [Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/), and the companion guides downstream are [Freezing a Flight Plan](/guides/freezing-a-flight-plan/) and [Launching a Flight Plan](/guides/launching-a-flight-plan/).
+
+This guide covers authoring by hand. The same manifest is also the form an [AI-assisted authoring flow](/development/ai-assisted-authoring-spec/) prompts an operator to fill in, but the artifact is identical either way.
+
+## What you are building
+
+A Flight Plan is a skill before it is sealed. The skill is one `SKILL.md` document in the [agentskills.io](https://agentskills.io) format, extended with a single Aileron-specific block. You author the skill. A freeze step turns it into a Flight Plan by resolving images to digests, locking, binding the execution environment, attaching the trust contract, and signing.
+
+This shapes how you author. You write the contract; you do not write the seal. The `requires:` block, the inputs, the outputs, the step graph, and the per-action trust contract are yours to write. The lockfile, the digest pins, and the signature are produced by freeze, never hand-written.
+
+The Aileron extension lives under one namespaced `aileron` key in the frontmatter. The extension is lossless if stripped. A tool that ignores the Aileron fields still reads a valid skill, and a host that lacks a named action reports a missing requirement rather than refusing to load the document.
+
+## The skeleton
+
+A complete, valid minimum:
+
+```yaml
+---
+name: weekly-metrics-digest
+description: Read a metrics window, summarize it, and file a tracking issue.
+aileron:
+  schemaVersion: aileron.flightplan.v1
+  requires:
+    actions:
+      - ref: aileron:metrics.read_window
+        trustContract:
+          credential:
+            kind: oauth2
+            placement: header
+          oauth:
+            scopes: ["metrics.read"]
+          hosts: ["metrics.example.com:443"]
+          effect: read
+          idempotency:
+            safeToRetry: true
+          audit:
+            fields: ["network-target", "operation-effect", "response-summary"]
+    executionEnvironment:
+      rung2CapabilityUnits:
+        features:
+          - "ghcr.io/aileron/features/jq:1"
+  inputs:
+    - name: window_days
+      type: number
+      description: How many days of metrics to read.
+      resolution:
+        rule: literal
+        default: 7
+  outputs:
+    - name: digest
+      mimeType: text/markdown
+      encoding: utf-8
+      publish:
+        target: file
+        path: digest.md
+  steps:
+    - id: read
+      kind: action-call
+      actionRef: aileron:metrics.read_window
+      args:
+        days: inputs.window_days
+    - id: summarize
+      kind: transform
+      bindings:
+        rows: steps.read
+      outputs: ["text"]
+      materializesOutput: digest
+---
+
+# Weekly Metrics Digest
+
+This skill reads a recent metrics window, writes a short digest, and files a
+tracking issue that links to it.
+```
+
+Open the frontmatter block at the top; close it; write the body underneath. The `aileron` block is the only Aileron-specific part. The keys it sits beside (`name`, `description`, and the rest) are the agentskills.io skill keys.
+
+## The `requires:` block
+
+The `requires:` block lists the actions the plan calls and the execution environment it runs in. It is the dependency declaration freeze reads when it pins and binds.
+
+### Actions and the per-action trust contract
+
+Each `requires.actions[]` entry names one action by `ref` and carries a per-action `trustContract`. The `ref` is `aileron:<connector>.<action>`, and it attaches to the [action model](/concepts/actions/). An unsatisfied `requires:` entry is a missing-requirement signal the runtime surfaces, never a parse failure.
+
+The trust contract is the security surface for that action. You write it; freeze attaches it; the detached signature is the human attestation that it is correct. Every field below records something the runtime enforces or the user sees.
+
+- `credential` declares the credential `kind` (`none`, `api-key`, `oauth2`, `aws-sigv4`) and its `placement` (`header`, `query`, `cookie`, `body`, `signing`, `session`). It never carries a credential value. An `oauth2` credential is always placed in a `header`; an `aws-sigv4` credential is always placed via `signing`.
+- `oauth` is required when `credential.kind` is `oauth2`. It declares the scopes, endpoints, and refresh behavior, never a token.
+- `hosts` is the closed list of upstream hosts the action reaches, as `host:port` pairs. The declared host set IS the security boundary. The runtime grants nothing undeclared. `paths` optionally narrows the request paths on those hosts.
+- `effect` is one of `read`, `write`, `delete`, `spend`, `external-send`. It drives default approval routing. A `read` runs unattended; the other four raise an approval gate at launch.
+- `idempotency.safeToRetry` declares whether re-running with the same inputs produces no additional effect. `idempotency.idempotencyKey` declares whether the operation accepts a client-supplied key. Read ops are typically safe to retry; writes that mutate the world are not.
+- `redaction` optionally lists rules applied to response fields before they reach the agent or the author. A `drop` rule removes a field, a `mask` rule replaces its value, and a `hash` rule replaces it with a stable hash.
+- `verification` optionally declares a read-only probe the runtime can call to confirm the credential still works.
+- `audit.fields` declares which of the closed audit-record fields this operation emits. The closed set is `connector-hash`, `action-manifest-version`, `credential-binding`, `identity-label`, `approved-input`, `approval-decision`, `network-target`, `operation-effect`, `request-summary`, `response-summary`, and `result`.
+
+Declare the minimum each action needs. The contract is verbose by design. A plan with many actions records many such blocks, and that is the cost of a per-action audit story the user can read.
+
+### The execution environment
+
+`requires.executionEnvironment` declares the image the Flight Plan runs in, as one rung. The MVP ships two rungs, and they are mutually exclusive.
+
+- `rung1Image.ref` names a whole prebuilt operator-owned image. Freeze resolves a tag to an `image@sha256:` digest pin.
+- `rung2CapabilityUnits.features` declares the capability-unit devcontainer Features composed onto the Aileron agent-free base image. Freeze composes them and pins the built image by digest.
+
+The reserved `rung3PerStepImages` slot may be declared alone. Freeze parses it, builds nothing, and reports it as build-deferred, so a rung-three-only manifest is a told outcome rather than a parse failure.
+
+The execution image is agent-free. The base image carries no coding agent. The Flight Plan runs composed steps, not an interactive agent session.
+
+## Inputs
+
+Every input the plan depends on is declared in `inputs[]`, each with a resolution rule. A value that varies by use case, such as a time window, is a declared input rather than a constant baked into the composition, so one composition serves many operators.
+
+- `name` is the input name, unique within the manifest.
+- `type` is one of `string`, `number`, `boolean`, `timestamp`, `object`, `array`.
+- `description` is optional human-readable semantics.
+- `resolution` is the resolution rule, discriminated by its `rule` field.
+
+There are three resolution rules.
+
+- `literal` takes a value passed at launch. An optional `default` applies when no value is passed.
+- `dynamic` resolves a launch-relative value once at launch. Its `value` is `now` (the launch timestamp) or `today` (the launch date).
+- `source` reads from a live source. Its `source.actionRef` names the action whose result resolves the input, with an optional `source.select`.
+
+Inputs resolve once, at the launch boundary, into a concrete resolved-input set. Two steps that read the same dynamic input see one value. A `source` read happens in the resolution phase, before the step graph walks, so it is not a graph edge.
+
+## Outputs
+
+The `outputs[]` block is the declared contract for what the plan produces. It is kept distinct from the transport so the transport can change later without changing the contract.
+
+- `name` is the artifact name, unique within the manifest. The audit references artifacts by this name.
+- `mimeType` is the artifact media type.
+- `encoding` is `utf-8` or `base64`. v1 implements `utf-8` only. `base64` is reserved.
+- `publish.target` is `file` or `none`. When `target` is `file`, `publish.path` names the output file.
+
+A step result reaches a declared output through the step's `materializesOutput` field, which names a declared `outputs[].name`.
+
+## The deterministic step graph
+
+The `steps[]` block is the composition. It wires declared actions and deterministic transforms into a directed acyclic graph. The block is optional. A skill with no `steps` block is instruction-only and still a valid manifest.
+
+Every step carries an `id` unique within the graph and a `kind` from a closed enum. The `kind` is what makes the no-LLM guarantee structurally checkable.
+
+| `kind` | Reaches an LLM | Semantics |
+|---|---|---|
+| `action-call` | No | Invokes a declared action. Its `actionRef` names the action and its `args` bind the action's arguments. |
+| `transform` | No | Runs deterministic no-LLM logic over data already in the graph. It has no host, network, or credential surface. |
+| `llm-seam` | Yes | The single marked non-deterministic seam. The only kind that reaches an LLM. |
+
+Wire steps with bindings, never values. A binding is a reference. An `action-call` step binds its `args`; a `transform` and an `llm-seam` step bind their `bindings`. A binding takes one of two forms.
+
+- `inputs.<name>` references a declared input resolved once at the launch boundary.
+- `steps.<stepId>.<outputName>` references a named output of a prior step.
+
+The references make the wiring a graph. The runtime executes it in deterministic topological order, breaking ties by declaration order.
+
+Three rules a JSON Schema cannot express, that the freeze lint checks and the runtime enforces:
+
+- The graph is acyclic.
+- An `action-call` step's `actionRef` must match a declared `requires.actions[].ref`.
+- An `llm-seam` is the only kind that may reach an LLM.
+
+No step field may hold a secret. Every step kind is a closed object, and the `args` and `bindings` grammar is closed to `inputs.<name>` and `steps.<id>.<output>`, so a literal secret cannot be embedded in the wiring.
+
+### Wiring the no-LLM seam
+
+Behavioral determinism is the whole point. No LLM runs at Flight Plan runtime by default. If your plan needs LLM reasoning at one point, mark exactly one step `kind: llm-seam` and route all of it through that step. Everything else is `action-call` and `transform`, both of which hold no reference to any language-model type.
+
+In v1 the seam is unwired by default. An `llm-seam` step with no configured provider is a hard error at launch, so a default launch reaches no model at all. A skill that reaches an LLM outside the marked seam fails the freeze lint and never becomes a Flight Plan. Keep the seam single. A plan that needs reasoning in more than one place routes all of it through the one marked seam or restructures to fit.
+
+## The Markdown body
+
+Everything after the closing frontmatter is the body. It is the agentskills.io skill body. Write what the skill does, the inputs it expects, and the output it produces. The body is the prose a reader and a skill-aware host consume, and it stays a valid skill even with the Aileron block stripped.
+
+## Handoff to freeze and sign
+
+When the skill validates and behaves the way you want, hand it to freeze. Freeze is the boundary between a skill and a Flight Plan.
+
+```sh
+aileron skill freeze weekly-metrics-digest \
+  --signing-key ~/.aileron/keys/author.pem \
+  --version 1.0.0
+```
+
+Freeze parses and lints the manifest, rejecting any step that could reach an LLM outside the marked `llm-seam`. It resolves the execution environment to image digests. It builds the lockfile. It content-addresses the unit and signs it with a detached ed25519 signature. It writes the frozen version into the store as an immutable directory.
+
+The signing key is a PEM-encoded ed25519 private key, read for signing only and never copied into the artifact. The detached signature is your attestation that the per-action trust contract is correct. See [Freezing a Flight Plan](/guides/freezing-a-flight-plan/) for the full command and the reproducibility and signature-verification guarantees.
+
+After freeze, [launch](/guides/launching-a-flight-plan/) runs the frozen Flight Plan deterministically.
+
+## Common authoring mistakes
+
+- **A literal secret in the wiring.** No step field holds a value. `args` and `bindings` are references (`inputs.<name>` or `steps.<id>.<output>`), and the credential lives in the trust contract as a `kind`/`placement` declaration, never a token.
+- **An unmarked LLM call.** Any reach to a model outside a `kind: llm-seam` step fails the freeze lint. Mark the one seam, or restructure the plan to keep the logic deterministic.
+- **More than one seam.** v1 allows exactly one marked seam. Route all reasoning through it.
+- **An `actionRef` with no matching `requires.actions[].ref`.** A step can only call an action the `requires:` block declares. The freeze lint catches the mismatch.
+- **Hand-writing the lock.** The `lock` section is produced by freeze. It is absent before freeze, and you never author it.
+- **A `base64` output in v1.** The `encoding` field reserves `base64`, but the v1 runtime materializes `utf-8` text only. A binary artifact waits on the deferred rung-three boundary.
+
+## Where to go next
+
+- [Flight Plans](/concepts/flight-plans/) — the model behind everything in this guide.
+- [Flight Plan Manifest Spec](/development/flight-plan-manifest-spec/) — the normative field reference, with the full schema and a worked example.
+- [Freezing a Flight Plan](/guides/freezing-a-flight-plan/) — seal the skill into a signed Flight Plan version.
+- [Launching a Flight Plan](/guides/launching-a-flight-plan/) — run the frozen Flight Plan deterministically.
+- [ADR-0027: Flight Plan = Sealed Installable Skill](/adr/0027-flight-plan-sealed-installable-skill/) — the design constraints behind this layer.

--- a/docs/src/lib/navigation.ts
+++ b/docs/src/lib/navigation.ts
@@ -54,7 +54,8 @@ export const navigation: NavItem[] = [
       { label: 'Connectors', href: '/concepts/connectors/' },
       { label: 'The Vault', href: '/concepts/the-vault/' },
       { label: 'Proof of Control', href: '/concepts/proof-of-control/' },
-      { label: 'The Keyring', href: '/concepts/the-keyring/' }
+      { label: 'The Keyring', href: '/concepts/the-keyring/' },
+      { label: 'Flight Plans', href: '/concepts/flight-plans/' }
     ]
   },
   {
@@ -72,6 +73,7 @@ export const navigation: NavItem[] = [
       { label: 'Installing a Connector', href: '/guides/installing-a-connector/' },
       { label: 'Installing an Action', href: '/guides/installing-an-action/' },
       { label: 'Installing a Skill', href: '/guides/installing-a-skill/' },
+      { label: 'Authoring a Flight Plan', href: '/guides/authoring-a-flight-plan/' },
       { label: 'Freezing a Flight Plan', href: '/guides/freezing-a-flight-plan/' },
       { label: 'Launching a Flight Plan', href: '/guides/launching-a-flight-plan/' },
       { label: 'Authoring a Connector', href: '/guides/authoring-a-connector/' },


### PR DESCRIPTION
## Summary

The Flight Plan layer (umbrella #1506) shipped operating guides (freezing/installing/launching), dev specs (manifest/launch-surfaces/ai-assisted-authoring), and ADR-0027, but had no user-facing Concepts page defining what a Flight Plan *is* and no authoring how-to. The repo had `authoring-a-connector`/`authoring-an-action`/`authoring-an-action-suite` guides but conspicuously lacked `authoring-a-flight-plan`. This PR closes both gaps with two cohesive pages.

- **`concepts/flight-plans.md`** (order 7, after the six existing concept primitives). Distilled from ADR-0027: the sealed-skill construct, the freeze boundary, the two determinisms (environmental reproducibility via pinned digests; behavioral determinism via no-LLM-at-runtime with one marked seam), inputs/resolution/audit, the per-action trust contract, and the execution rungs. Cross-links the operating guides, ADR-0027, and the manifest spec.
- **`guides/authoring-a-flight-plan.md`**. How to hand-write the `SKILL.md`: the `requires:` block (actions + execution environments), the per-action trust-contract fields, declared `inputs:`/`outputs:`, and the deterministic no-LLM step graph (`action-call` / `transform` / `llm-seam` wiring via bindings). Then the handoff to `aileron skill freeze`. Mirrors the `authoring-an-action`/`authoring-a-connector` shape and voice (skeleton → frontmatter field-by-field → body → handoff → common mistakes → where to go next), grounded field-for-field in the Flight Plan Manifest Spec.

Both register in `navigation.ts` (concept under Concepts, guide next to the other Flight Plan guides) and follow the docs writing voice.

## Test plan

- `pnpm run check` (astro check): 0 errors, 0 warnings, 0 hints across 27 files.
- `pnpm run build`: 149 pages built; verified `dist/concepts/flight-plans/index.html` and `dist/guides/authoring-a-flight-plan/index.html` exist.
- `pnpm run test` (docs unit tests): 13/13 pass.
- Verified every internal link target in both pages resolves to a built page (concepts/actions, concepts/deterministic-agentic-execution, the three flight-plan guides, adr/0027, development/flight-plan-manifest-spec, development/ai-assisted-authoring-spec).
- Voice pass: no em-dashes in running prose, no "not just X, Y" constructions. The `—` separators in the "Where to go next" bullet lists match the existing `authoring-an-action`/`authoring-a-connector` convention.

Closes #1641

🤖 Generated with [Claude Code](https://claude.com/claude-code)
